### PR TITLE
refactor(web): rename BlackJackWeb to TrumpCardsWeb

### DIFF
--- a/frameworks_drivers/web/TrumpCardsWeb.go
+++ b/frameworks_drivers/web/TrumpCardsWeb.go
@@ -12,16 +12,16 @@ import (
 	"github.com/ant0ine/go-json-rest/rest"
 )
 
-// BlackJackWeb ブラックジャックWebクラス
-type BlackJackWeb struct {
+// TrumpCardsWeb トランプカードゲームWebクラス
+type TrumpCardsWeb struct {
 	bjc *controllers.BlackJackWebController
 	pkc *controllers.PokerWebController
 	omc *controllers.OldMaidWebController
 }
 
-// NewBlackJackWeb コンストラクタ
-func NewBlackJackWeb() *BlackJackWeb {
-	return &BlackJackWeb{
+// NewTrumpCardsWeb コンストラクタ
+func NewTrumpCardsWeb() *TrumpCardsWeb {
+	return &TrumpCardsWeb{
 		bjc: controllers.NewBlackJackWebController(usecases.NewBlackJackInteractor(presenters.NewBlackJackWebPresenter())),
 		pkc: controllers.NewPokerWebController(usecases.NewPokerInteractor(presenters.NewPokerWebPresenter())),
 		omc: controllers.NewOldMaidWebController(usecases.NewOldMaidInteractor(presenters.NewOldMaidWebPresenter())),
@@ -29,7 +29,7 @@ func NewBlackJackWeb() *BlackJackWeb {
 }
 
 // Exec ゲーム実行
-func (web *BlackJackWeb) Exec() {
+func (web *TrumpCardsWeb) Exec() {
 	api := rest.NewApi()
 	api.Use(rest.DefaultDevStack...)
 	router, err := rest.MakeRouter(

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 		oldmaid := ui.NewOldMaidCui()
 		oldmaid.Exec()
 	case "web":
-		web := web.NewBlackJackWeb()
+		web := web.NewTrumpCardsWeb()
 		web.Exec()
 	default:
 		log.Fatal(fmt.Errorf("Error: param not found %s", flag.Arg(0)))


### PR DESCRIPTION
The BlackJackWeb struct handled all three card games (BlackJack, Poker,
and Old Maid), making its name misleading. Rename it to TrumpCardsWeb
to reflect its actual generalized responsibility.

- Rename BlackJackWeb.go to TrumpCardsWeb.go
- Rename struct BlackJackWeb → TrumpCardsWeb
- Rename constructor NewBlackJackWeb → NewTrumpCardsWeb
- Update main.go to call NewTrumpCardsWeb

Closes #25

https://claude.ai/code/session_01RWPGBLjRW5d68FDskAfQqK