### PR TITLE
refactor(main): rename blackjack cli command from cui to blackjack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This repository contains a Go implementation of trump card game algorithms. The 
 
 **Run the application:**
 ```sh
-go run main.go cui      # BlackJack CLI
+go run main.go blackjack  # BlackJack CLI
 go run main.go poker    # 5-card Draw Poker CLI
 go run main.go oldmaid  # Old Maid CLI
 go run main.go web      # Start REST API + web GUI server

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Run the application:**
 ```sh
-go run main.go cui      # BlackJack CLI
+go run main.go blackjack  # BlackJack CLI
 go run main.go poker    # 5-card Draw Poker CLI
 go run main.go oldmaid  # Old Maid CLI
 go run main.go web      # Start REST API + web GUI server

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cd go_trumpcards
 
 ### Run
 ```sh
-go run main.go cui      # ブラックジャック CLI
+go run main.go blackjack  # ブラックジャック CLI
 go run main.go poker    # 5枚ドローポーカー CLI
 go run main.go oldmaid  # ババ抜き CLI
 go run main.go web      # REST API + Web GUI サーバー起動

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 func main() {
 	flag.Parse()
 	switch strings.ToLower(flag.Arg(0)) {
-	case "cui":
+	case "blackjack":
 		cui := ui.NewBlackJackCui()
 		cui.Exec()
 	case "poker":


### PR DESCRIPTION
the cui command name was too generic with multiple game types available.
renaming to blackjack makes it consistent with poker and oldmaid commands.

closes #30

https://claude.ai/code/session_01Kdouauye4Pq1zsFReYaBE2