### PR TITLE
feat(oldmaid): improve UX with card selection, draw feedback, and CPU action log

### DIFF
--- a/entities/OldMaid.go
+++ b/entities/OldMaid.go
@@ -5,31 +5,43 @@ import "math/rand"
 // OldMaidPlayerCnt ババ抜きプレイヤー数
 const OldMaidPlayerCnt = 4
 
+// OldMaidCpuAction CPUの1ターン分の行動記録
+type OldMaidCpuAction struct {
+	DrawPlayerIdx  int   // 引いたプレイヤーインデックス
+	DrawFromIdx    int   // 引かれた相手のインデックス
+	DrawnCard      *Card // 引いたカード
+	DiscardedPairs int   // 捨てたペア数
+}
+
 // OldMaid ババ抜きゲームクラス
 type OldMaid struct {
 	trumpCards         *TrumpCards
 	players            []*OldMaidPlayer
-	currentTurn        int  // 現在の手番プレイヤーインデックス
-	gameEndFlag        bool // ゲーム終了フラグ
-	loserIdx           int  // 負けたプレイヤーインデックス
-	lastDrawPlayerIdx  int  // 最後に引いたプレイヤーのインデックス (-1=まだなし)
-	lastDrawFromIdx    int  // 最後に引いた相手のインデックス (-1=まだなし)
-	lastDiscardedPairs int  // 最後に捨てたペア数
-	hasDrawn           bool // 引きが発生したか
+	currentTurn        int                // 現在の手番プレイヤーインデックス
+	gameEndFlag        bool               // ゲーム終了フラグ
+	loserIdx           int                // 負けたプレイヤーインデックス
+	lastDrawPlayerIdx  int                // 最後に引いたプレイヤーのインデックス (-1=まだなし)
+	lastDrawFromIdx    int                // 最後に引いた相手のインデックス (-1=まだなし)
+	lastDrawCard       *Card              // 最後に引いたカード
+	lastDiscardedPairs int                // 最後に捨てたペア数
+	hasDrawn           bool               // 引きが発生したか
+	cpuActions         []*OldMaidCpuAction // CPUターンの行動履歴 (人間のターン後にリセット)
 }
 
 // NewOldMaid コンストラクタ
 func NewOldMaid(trumpCards *TrumpCards, players []*OldMaidPlayer) *OldMaid {
 	return &OldMaid{
-		trumpCards:        trumpCards,
-		players:           players,
-		currentTurn:       0,
-		gameEndFlag:       false,
-		loserIdx:          -1,
-		lastDrawPlayerIdx: -1,
-		lastDrawFromIdx:   -1,
+		trumpCards:         trumpCards,
+		players:            players,
+		currentTurn:        0,
+		gameEndFlag:        false,
+		loserIdx:           -1,
+		lastDrawPlayerIdx:  -1,
+		lastDrawFromIdx:    -1,
+		lastDrawCard:       nil,
 		lastDiscardedPairs: 0,
-		hasDrawn:          false,
+		hasDrawn:           false,
+		cpuActions:         nil,
 	}
 }
 
@@ -40,8 +52,10 @@ func (o *OldMaid) Reset() {
 	o.currentTurn = 0
 	o.lastDrawPlayerIdx = -1
 	o.lastDrawFromIdx = -1
+	o.lastDrawCard = nil
 	o.lastDiscardedPairs = 0
 	o.hasDrawn = false
+	o.cpuActions = nil
 
 	// シャッフル
 	for i := 0; i < 10; i++ {
@@ -127,32 +141,37 @@ func (o *OldMaid) checkGameEnd() bool {
 }
 
 // drawCard playerIdxがカードを引く (内部処理)
-func (o *OldMaid) drawCard(playerIdx int) {
+// cardIdx: 引くカードのインデックス。-1 の場合はランダム選択。
+func (o *OldMaid) drawCard(playerIdx int, cardIdx int) *Card {
 	if o.gameEndFlag {
-		return
+		return nil
 	}
 	player := o.players[playerIdx]
 	if player.GetIsFinished() {
-		return
+		return nil
 	}
 
 	targetIdx := o.getNextActivePlayer(playerIdx)
 	if targetIdx < 0 {
-		return
+		return nil
 	}
 	target := o.players[targetIdx]
 	if target.GetCardsSize() == 0 {
-		return
+		return nil
 	}
 
-	// ランダムにカードを選ぶ
-	randomIdx := rand.Intn(target.GetCardsSize())
-	card := target.RemoveCard(randomIdx)
+	// カードインデックスの決定
+	idx := cardIdx
+	if idx < 0 || idx >= target.GetCardsSize() {
+		idx = rand.Intn(target.GetCardsSize())
+	}
+	card := target.RemoveCard(idx)
 	player.AddCard(card)
 
 	// 最後の引き情報を更新
 	o.lastDrawPlayerIdx = playerIdx
 	o.lastDrawFromIdx = targetIdx
+	o.lastDrawCard = card
 	o.hasDrawn = true
 
 	// ペアを捨てる
@@ -169,6 +188,8 @@ func (o *OldMaid) drawCard(playerIdx int) {
 
 	// ゲーム終了チェック
 	o.checkGameEnd()
+
+	return card
 }
 
 // advanceTurn 手番を次のアクティブなプレイヤーへ進める
@@ -183,11 +204,14 @@ func (o *OldMaid) advanceTurn() {
 }
 
 // PlayerDraw 人間プレイヤーがカードを引く
-func (o *OldMaid) PlayerDraw() {
+// cardIdx: 引くカードのインデックス。-1 の場合はランダム選択。
+func (o *OldMaid) PlayerDraw(cardIdx int) {
 	if o.gameEndFlag || !o.players[o.currentTurn].GetIsHuman() {
 		return
 	}
-	o.drawCard(o.currentTurn)
+	// 人間のターン開始時にCPU行動履歴をリセット
+	o.cpuActions = nil
+	o.drawCard(o.currentTurn, cardIdx)
 	if !o.gameEndFlag {
 		o.advanceTurn()
 	}
@@ -198,7 +222,15 @@ func (o *OldMaid) CpuDraw() {
 	if o.gameEndFlag || o.players[o.currentTurn].GetIsHuman() {
 		return
 	}
-	o.drawCard(o.currentTurn)
+	playerIdx := o.currentTurn
+	card := o.drawCard(playerIdx, -1)
+	action := &OldMaidCpuAction{
+		DrawPlayerIdx:  playerIdx,
+		DrawFromIdx:    o.lastDrawFromIdx,
+		DrawnCard:      card,
+		DiscardedPairs: o.lastDiscardedPairs,
+	}
+	o.cpuActions = append(o.cpuActions, action)
 	if !o.gameEndFlag {
 		o.advanceTurn()
 	}
@@ -252,6 +284,11 @@ func (o *OldMaid) GetLastDrawFromIdx() int {
 	return o.lastDrawFromIdx
 }
 
+// GetLastDrawCard 最後に引いたカード
+func (o *OldMaid) GetLastDrawCard() *Card {
+	return o.lastDrawCard
+}
+
 // GetLastDiscardedPairs 最後に捨てたペア数
 func (o *OldMaid) GetLastDiscardedPairs() int {
 	return o.lastDiscardedPairs
@@ -260,4 +297,9 @@ func (o *OldMaid) GetLastDiscardedPairs() int {
 // GetHasDrawn 引きが発生したかどうか
 func (o *OldMaid) GetHasDrawn() bool {
 	return o.hasDrawn
+}
+
+// GetCpuActions CPUターンの行動履歴取得
+func (o *OldMaid) GetCpuActions() []*OldMaidCpuAction {
+	return o.cpuActions
 }

--- a/entities/OldMaid_test.go
+++ b/entities/OldMaid_test.go
@@ -143,7 +143,7 @@ func TestOldMaid_Method(t *testing.T) {
 		om.Reset()
 		if !om.IsHumanTurn() {
 			prevHasDrawn := om.GetHasDrawn()
-			om.PlayerDraw()
+			om.PlayerDraw(0)
 			assert.Equal(t, prevHasDrawn, om.GetHasDrawn())
 		}
 	})

--- a/interface_adapters/controllers/OldMaidCuiController.go
+++ b/interface_adapters/controllers/OldMaidCuiController.go
@@ -1,6 +1,11 @@
 package controllers
 
-import "github.com/yuta-yoshinaga/go_trumpcards/usecases"
+import (
+	"strconv"
+	"strings"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/usecases"
+)
 
 // OldMaidCuiController ババ抜きCUIコントローラークラス
 type OldMaidCuiController struct {
@@ -13,14 +18,26 @@ func NewOldMaidCuiController(omi usecases.OldMaidInteractorIF) *OldMaidCuiContro
 }
 
 // Exec コマンド実行
+// draw コマンドは "d N" または "draw N" の形式でカードインデックスを指定可能。
+// 例: "d 2" → インデックス2のカードを引く / "d" → ランダムに引く
 func (c *OldMaidCuiController) Exec(command string) string {
-	switch command {
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return "コマンドが不明です: " + command
+	}
+	switch fields[0] {
 	case "q", "quit":
 		return "bye."
 	case "r", "reset":
 		return c.omi.Reset()
 	case "d", "draw":
-		return c.omi.Draw()
+		cardIdx := -1
+		if len(fields) >= 2 {
+			if idx, err := strconv.Atoi(fields[1]); err == nil {
+				cardIdx = idx
+			}
+		}
+		return c.omi.Draw(cardIdx)
 	default:
 		return "コマンドが不明です: " + command
 	}

--- a/interface_adapters/controllers/OldMaidCuiController_test.go
+++ b/interface_adapters/controllers/OldMaidCuiController_test.go
@@ -13,7 +13,9 @@ func TestOldMaidCuiController_Method(t *testing.T) {
 	mockOutput := "==========\nOld Maid (ババ抜き)\n==========\n[You]: 0枚\n\nCPU 1: 0枚\nCPU 2: 0枚\nCPU 3: 0枚\n----------\n手番: あなた\n==========\n"
 	omiMock := new(usecases.MockOldMaidInteractor)
 	omiMock.On("Reset").Return(mockOutput)
-	omiMock.On("Draw").Return(mockOutput)
+	omiMock.On("Draw", -1).Return(mockOutput)
+	omiMock.On("Draw", 0).Return(mockOutput)
+	omiMock.On("Draw", 2).Return(mockOutput)
 
 	tomc := controllers.NewOldMaidCuiController(omiMock)
 
@@ -34,6 +36,12 @@ func TestOldMaidCuiController_Method(t *testing.T) {
 	})
 	t.Run("success Exec draw", func(t *testing.T) {
 		assert.Equal(t, mockOutput, tomc.Exec("draw"))
+	})
+	t.Run("success Exec d 0", func(t *testing.T) {
+		assert.Equal(t, mockOutput, tomc.Exec("d 0"))
+	})
+	t.Run("success Exec draw 2", func(t *testing.T) {
+		assert.Equal(t, mockOutput, tomc.Exec("draw 2"))
 	})
 	t.Run("success Exec other", func(t *testing.T) {
 		assert.Equal(t, "コマンドが不明です: other", tomc.Exec("other"))

--- a/interface_adapters/controllers/OldMaidWebController.go
+++ b/interface_adapters/controllers/OldMaidWebController.go
@@ -12,6 +12,7 @@ import (
 // OldMaidWebInput ババ抜きWebインプット
 type OldMaidWebInput struct {
 	Command string `json:"command"`
+	DrawIdx *int   `json:"drawIdx"` // 引くカードのインデックス。nil の場合はランダム選択。
 }
 
 // OldMaidWebOutputCard ババ抜きWebアウトプットカード
@@ -29,18 +30,28 @@ type OldMaidWebOutputPlayer struct {
 	Cards      []*OldMaidWebOutputCard `json:"cards"`
 }
 
+// OldMaidWebOutputCpuAction CPUターンの行動記録
+type OldMaidWebOutputCpuAction struct {
+	DrawPlayerIdx  int                   `json:"drawPlayerIdx"`
+	DrawFromIdx    int                   `json:"drawFromIdx"`
+	DrawnCard      *OldMaidWebOutputCard `json:"drawnCard"`
+	DiscardedPairs int                   `json:"discardedPairs"`
+}
+
 // OldMaidWebOutput ババ抜きWebアウトプット
 type OldMaidWebOutput struct {
-	Players           []*OldMaidWebOutputPlayer `json:"players"`
-	CurrentTurn       int                       `json:"currentTurn"`
-	NextDrawTargetIdx int                       `json:"nextDrawTargetIdx"`
-	GameEndFlag       bool                      `json:"gameEndFlag"`
-	LoserIdx          int                       `json:"loserIdx"`
-	LastDrawPlayerIdx int                       `json:"lastDrawPlayerIdx"`
-	LastDrawFromIdx   int                       `json:"lastDrawFromIdx"`
-	LastDiscardedPairs int                      `json:"lastDiscardedPairs"`
-	HasDrawn          bool                      `json:"hasDrawn"`
-	Message           string                    `json:"message"`
+	Players            []*OldMaidWebOutputPlayer    `json:"players"`
+	CurrentTurn        int                          `json:"currentTurn"`
+	NextDrawTargetIdx  int                          `json:"nextDrawTargetIdx"`
+	GameEndFlag        bool                         `json:"gameEndFlag"`
+	LoserIdx           int                          `json:"loserIdx"`
+	LastDrawPlayerIdx  int                          `json:"lastDrawPlayerIdx"`
+	LastDrawFromIdx    int                          `json:"lastDrawFromIdx"`
+	LastDrawCard       *OldMaidWebOutputCard        `json:"lastDrawCard"`
+	LastDiscardedPairs int                          `json:"lastDiscardedPairs"`
+	HasDrawn           bool                         `json:"hasDrawn"`
+	CpuActions         []*OldMaidWebOutputCpuAction `json:"cpuActions"`
+	Message            string                       `json:"message"`
 }
 
 // OldMaidWebController ババ抜きWebコントローラークラス
@@ -63,19 +74,24 @@ func (owc *OldMaidWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 		status = http.StatusBadRequest
 		responseStr = `{"message":"param error."}`
 	} else {
+		drawIdx := -1
+		if param.DrawIdx != nil {
+			drawIdx = *param.DrawIdx
+		}
 		switch param.Command {
 		case "q", "quit":
 			responseStr = `{"message":"bye."}`
 		case "r", "reset":
 			responseStr = owc.omi.Reset()
 		case "d", "draw":
-			responseStr = owc.omi.Draw()
+			responseStr = owc.omi.Draw(drawIdx)
 		default:
 			responseStr = `{"message":"Unsupported command."}`
 		}
 	}
 	response := new(OldMaidWebOutput)
 	response.Players = make([]*OldMaidWebOutputPlayer, 0)
+	response.CpuActions = make([]*OldMaidWebOutputCpuAction, 0)
 	err = json.Unmarshal([]byte(responseStr), &response)
 	if err != nil || responseStr == "" {
 		status = http.StatusBadRequest

--- a/interface_adapters/controllers/OldMaidWebController_test.go
+++ b/interface_adapters/controllers/OldMaidWebController_test.go
@@ -14,9 +14,11 @@ import (
 
 func TestOldMaidWebController_Method(t *testing.T) {
 	mockOutput := `{"players":[],"currentTurn":0,"nextDrawTargetIdx":1,"gameEndFlag":false,"loserIdx":-1,"lastDrawPlayerIdx":-1,"lastDrawFromIdx":-1,"lastDiscardedPairs":0,"hasDrawn":false,"message":""}`
+	// After controller unmarshal+remarshal, new fields are included
+	expectedBody := `{"players":[],"currentTurn":0,"nextDrawTargetIdx":1,"gameEndFlag":false,"loserIdx":-1,"lastDrawPlayerIdx":-1,"lastDrawFromIdx":-1,"lastDrawCard":null,"lastDiscardedPairs":0,"hasDrawn":false,"cpuActions":[],"message":""}`
 	omiMock := new(usecases.MockOldMaidInteractor)
 	omiMock.On("Reset").Return(mockOutput).Times(2)
-	omiMock.On("Draw").Return(mockOutput)
+	omiMock.On("Draw", -1).Return(mockOutput)
 
 	towc := controllers.NewOldMaidWebController(omiMock)
 
@@ -28,7 +30,7 @@ func TestOldMaidWebController_Method(t *testing.T) {
 
 	var jsonInput controllers.OldMaidWebInput
 	// When "q" / "quit": responseStr = {"message":"bye."} → all other fields default to zero
-	qBody := `{"players":[],"currentTurn":0,"nextDrawTargetIdx":0,"gameEndFlag":false,"loserIdx":0,"lastDrawPlayerIdx":0,"lastDrawFromIdx":0,"lastDiscardedPairs":0,"hasDrawn":false,"message":"bye."}`
+	qBody := `{"players":[],"currentTurn":0,"nextDrawTargetIdx":0,"gameEndFlag":false,"loserIdx":0,"lastDrawPlayerIdx":0,"lastDrawFromIdx":0,"lastDrawCard":null,"lastDiscardedPairs":0,"hasDrawn":false,"cpuActions":[],"message":"bye."}`
 
 	t.Run("success Exec q", func(t *testing.T) {
 		_ = json.Unmarshal([]byte(`{"command": "q"}`), &jsonInput)
@@ -55,7 +57,7 @@ func TestOldMaidWebController_Method(t *testing.T) {
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
 		recorded.CodeIs(http.StatusOK)
 		recorded.ContentTypeIsJson()
-		recorded.BodyIs(mockOutput)
+		recorded.BodyIs(expectedBody)
 	})
 	t.Run("success Exec reset", func(t *testing.T) {
 		_ = json.Unmarshal([]byte(`{"command": "reset"}`), &jsonInput)
@@ -64,7 +66,7 @@ func TestOldMaidWebController_Method(t *testing.T) {
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
 		recorded.CodeIs(http.StatusOK)
 		recorded.ContentTypeIsJson()
-		recorded.BodyIs(mockOutput)
+		recorded.BodyIs(expectedBody)
 	})
 	t.Run("success Exec d", func(t *testing.T) {
 		_ = json.Unmarshal([]byte(`{"command": "d"}`), &jsonInput)
@@ -73,7 +75,7 @@ func TestOldMaidWebController_Method(t *testing.T) {
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
 		recorded.CodeIs(http.StatusOK)
 		recorded.ContentTypeIsJson()
-		recorded.BodyIs(mockOutput)
+		recorded.BodyIs(expectedBody)
 	})
 	t.Run("success Exec draw", func(t *testing.T) {
 		_ = json.Unmarshal([]byte(`{"command": "draw"}`), &jsonInput)
@@ -82,7 +84,7 @@ func TestOldMaidWebController_Method(t *testing.T) {
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
 		recorded.CodeIs(http.StatusOK)
 		recorded.ContentTypeIsJson()
-		recorded.BodyIs(mockOutput)
+		recorded.BodyIs(expectedBody)
 	})
 	t.Run("failed Exec other", func(t *testing.T) {
 		_ = json.Unmarshal([]byte(`{"command": "other"}`), &jsonInput)
@@ -91,7 +93,7 @@ func TestOldMaidWebController_Method(t *testing.T) {
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
 		recorded.CodeIs(http.StatusOK)
 		recorded.ContentTypeIsJson()
-		recorded.BodyIs(`{"players":[],"currentTurn":0,"nextDrawTargetIdx":0,"gameEndFlag":false,"loserIdx":0,"lastDrawPlayerIdx":0,"lastDrawFromIdx":0,"lastDiscardedPairs":0,"hasDrawn":false,"message":"Unsupported command."}`)
+		recorded.BodyIs(`{"players":[],"currentTurn":0,"nextDrawTargetIdx":0,"gameEndFlag":false,"loserIdx":0,"lastDrawPlayerIdx":0,"lastDrawFromIdx":0,"lastDrawCard":null,"lastDiscardedPairs":0,"hasDrawn":false,"cpuActions":[],"message":"Unsupported command."}`)
 	})
 	t.Run("failed Exec command empty", func(t *testing.T) {
 		_ = json.Unmarshal([]byte(`{"command": ""}`), &jsonInput)
@@ -100,7 +102,7 @@ func TestOldMaidWebController_Method(t *testing.T) {
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
 		recorded.CodeIs(http.StatusBadRequest)
 		recorded.ContentTypeIsJson()
-		recorded.BodyIs(`{"players":[],"currentTurn":0,"nextDrawTargetIdx":0,"gameEndFlag":false,"loserIdx":0,"lastDrawPlayerIdx":0,"lastDrawFromIdx":0,"lastDiscardedPairs":0,"hasDrawn":false,"message":"param error."}`)
+		recorded.BodyIs(`{"players":[],"currentTurn":0,"nextDrawTargetIdx":0,"gameEndFlag":false,"loserIdx":0,"lastDrawPlayerIdx":0,"lastDrawFromIdx":0,"lastDrawCard":null,"lastDiscardedPairs":0,"hasDrawn":false,"cpuActions":[],"message":"param error."}`)
 	})
 	t.Run("failed Exec response empty", func(t *testing.T) {
 		omiMock.On("Reset").Return(``)
@@ -110,6 +112,6 @@ func TestOldMaidWebController_Method(t *testing.T) {
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
 		recorded.CodeIs(http.StatusBadRequest)
 		recorded.ContentTypeIsJson()
-		recorded.BodyIs(`{"players":[],"currentTurn":0,"nextDrawTargetIdx":0,"gameEndFlag":false,"loserIdx":0,"lastDrawPlayerIdx":0,"lastDrawFromIdx":0,"lastDiscardedPairs":0,"hasDrawn":false,"message":"error."}`)
+		recorded.BodyIs(`{"players":[],"currentTurn":0,"nextDrawTargetIdx":0,"gameEndFlag":false,"loserIdx":0,"lastDrawPlayerIdx":0,"lastDrawFromIdx":0,"lastDrawCard":null,"lastDiscardedPairs":0,"hasDrawn":false,"cpuActions":[],"message":"error."}`)
 	})
 }

--- a/interface_adapters/controllers/usecases/OldMaidInteractor_mock.go
+++ b/interface_adapters/controllers/usecases/OldMaidInteractor_mock.go
@@ -14,7 +14,7 @@ func (_m *MockOldMaidInteractor) Reset() string {
 }
 
 // Draw モック
-func (_m *MockOldMaidInteractor) Draw() string {
-	ret := _m.Called()
+func (_m *MockOldMaidInteractor) Draw(cardIdx int) string {
+	ret := _m.Called(cardIdx)
 	return ret.Get(0).(string)
 }

--- a/interface_adapters/presenters/OldMaidCuiPresenter.go
+++ b/interface_adapters/presenters/OldMaidCuiPresenter.go
@@ -52,11 +52,33 @@ func (p *OldMaidCuiPresenter) Output(om *entities.OldMaid) string {
 		discarded := om.GetLastDiscardedPairs()
 		drawPlayerName := p.getPlayerName(om, drawPlayerIdx)
 		drawFromName := p.getPlayerName(om, drawFromIdx)
+		drawnCard := om.GetLastDrawCard()
 		res += fmt.Sprintf("%sが%sから1枚引きました", drawPlayerName, drawFromName)
+		if drawnCard != nil {
+			res += fmt.Sprintf(" (%s)", p.getCardStr(drawnCard))
+		}
 		if discarded > 0 {
 			res += fmt.Sprintf("。%d組捨てました", discarded)
 		}
 		res += "\n"
+	}
+
+	// CPUの行動履歴を表示
+	cpuActions := om.GetCpuActions()
+	if len(cpuActions) > 0 {
+		res += "[CPUの行動]\n"
+		for _, action := range cpuActions {
+			actPlayerName := p.getPlayerName(om, action.DrawPlayerIdx)
+			actFromName := p.getPlayerName(om, action.DrawFromIdx)
+			res += fmt.Sprintf("%sが%sから1枚引きました", actPlayerName, actFromName)
+			if action.DrawnCard != nil {
+				res += fmt.Sprintf(" (%s)", p.getCardStr(action.DrawnCard))
+			}
+			if action.DiscardedPairs > 0 {
+				res += fmt.Sprintf("。%d組捨てました", action.DiscardedPairs)
+			}
+			res += "\n"
+		}
 	}
 
 	if om.GetGameEndFlag() {

--- a/interface_adapters/presenters/OldMaidCuiPresenter_test.go
+++ b/interface_adapters/presenters/OldMaidCuiPresenter_test.go
@@ -47,7 +47,7 @@ func TestOldMaidCuiPresenter_Method(t *testing.T) {
 		players := makePlayers()
 		om := entities.NewOldMaid(tc, players)
 		// Setup: player 0 (human, turn=0) has JOKER + SPADE 5 + CLOVER 5
-		// player 1 (CPU 1) has HEART 7 — exactly 1 card (deterministic draw)
+		// player 1 (CPU 1) has HEART 7 — exactly 1 card (deterministic draw at index 0)
 		// players 2,3 finished
 		players[0].AddCard(entities.NewCard(entities.CardDesignJoker, entities.CardValueJoker, false))
 		players[0].AddCard(entities.NewCard(entities.CardDesignSpade, 5, false))
@@ -55,19 +55,19 @@ func TestOldMaidCuiPresenter_Method(t *testing.T) {
 		players[1].AddCard(entities.NewCard(entities.CardDesignHeart, 7, false))
 		players[2].SetIsFinished(true)
 		players[3].SetIsFinished(true)
-		// PlayerDraw: player 0 draws from player 1 (1 card → index always 0, deterministic)
+		// PlayerDraw(0): draws card at index 0 from player 1 (HEART 7)
 		// player 0 gains HEART 7 → hand: JOKER, SPADE 5, CLOVER 5, HEART 7
 		// DiscardPairs: SPADE 5 + CLOVER 5 pair → discarded → player 0: JOKER, HEART 7
 		// player 1 has 0 cards → finished
 		// checkGameEnd: active = {0} → gameEndFlag=true, loserIdx=0
-		om.PlayerDraw()
+		om.PlayerDraw(0)
 		expected := "==========\nOld Maid (ババ抜き)\n==========\n" +
 			"[You]: 2枚\n[0]JOKER  [1]HEART 7\n" +
 			"CPU 1: 上がり\n" +
 			"CPU 2: 上がり\n" +
 			"CPU 3: 上がり\n" +
 			"----------\n" +
-			"あなたがCPU 1から1枚引きました。1組捨てました\n" +
+			"あなたがCPU 1から1枚引きました (HEART 7)。1組捨てました\n" +
 			"ゲーム終了！ あなたの負け！\n" +
 			"==========\n"
 		assert.Equal(t, expected, top.Output(om))
@@ -81,20 +81,20 @@ func TestOldMaidCuiPresenter_Method(t *testing.T) {
 		// player 1 (CPU 1): CLOVER 3 (1 card, next active) → deterministic draw (index always 0)
 		// player 2 (CPU 2): JOKER (1 card) → will be the loser
 		// player 3: finished
-		// PlayerDraw: player 0 draws CLOVER 3, forms pair with SPADE 3 → both players 0 and 1 finish
+		// PlayerDraw(0): player 0 draws CLOVER 3, forms pair with SPADE 3 → both players 0 and 1 finish
 		// active = {2} → gameEndFlag=true, loserIdx=2
 		players[0].AddCard(entities.NewCard(entities.CardDesignSpade, 3, false))
 		players[1].AddCard(entities.NewCard(entities.CardDesignClover, 3, false))
 		players[2].AddCard(entities.NewCard(entities.CardDesignJoker, entities.CardValueJoker, false))
 		players[3].SetIsFinished(true)
-		om.PlayerDraw()
+		om.PlayerDraw(0)
 		expected := "==========\nOld Maid (ババ抜き)\n==========\n" +
 			"[You]: 上がり\n" +
 			"CPU 1: 上がり\n" +
 			"CPU 2: 1枚\n" +
 			"CPU 3: 上がり\n" +
 			"----------\n" +
-			"あなたがCPU 1から1枚引きました。1組捨てました\n" +
+			"あなたがCPU 1から1枚引きました (CLOVER 3)。1組捨てました\n" +
 			"ゲーム終了！ CPU 2の負け！\n" +
 			"==========\n"
 		assert.Equal(t, expected, top.Output(om))

--- a/interface_adapters/presenters/OldMaidWebPresenter.go
+++ b/interface_adapters/presenters/OldMaidWebPresenter.go
@@ -26,8 +26,21 @@ func (owp *OldMaidWebPresenter) Output(om *entities.OldMaid) string {
 	resObj.LoserIdx = om.GetLoserIdx()
 	resObj.LastDrawPlayerIdx = om.GetLastDrawPlayerIdx()
 	resObj.LastDrawFromIdx = om.GetLastDrawFromIdx()
+	resObj.LastDrawCard = owp.getCardObj(om.GetLastDrawCard())
 	resObj.LastDiscardedPairs = om.GetLastDiscardedPairs()
 	resObj.HasDrawn = om.GetHasDrawn()
+
+	// CPU行動履歴
+	resObj.CpuActions = make([]*controllers.OldMaidWebOutputCpuAction, 0)
+	for _, action := range om.GetCpuActions() {
+		a := &controllers.OldMaidWebOutputCpuAction{
+			DrawPlayerIdx:  action.DrawPlayerIdx,
+			DrawFromIdx:    action.DrawFromIdx,
+			DrawnCard:      owp.getCardObj(action.DrawnCard),
+			DiscardedPairs: action.DiscardedPairs,
+		}
+		resObj.CpuActions = append(resObj.CpuActions, a)
+	}
 
 	for i := 0; i < om.GetPlayerCnt(); i++ {
 		player := om.GetPlayer(i)
@@ -58,8 +71,11 @@ func (owp *OldMaidWebPresenter) Output(om *entities.OldMaid) string {
 	return string(res)
 }
 
-// getCardObj カード情報オブジェクト取得
+// getCardObj カード情報オブジェクト取得 (nil の場合は nil を返す)
 func (owp *OldMaidWebPresenter) getCardObj(card *entities.Card) *controllers.OldMaidWebOutputCard {
+	if card == nil {
+		return nil
+	}
 	res := new(controllers.OldMaidWebOutputCard)
 	switch card.GetDesign() {
 	case entities.CardDesignSpade:

--- a/interface_adapters/presenters/OldMaidWebPresenter_test.go
+++ b/interface_adapters/presenters/OldMaidWebPresenter_test.go
@@ -30,7 +30,7 @@ func TestOldMaidWebPresenter_Method(t *testing.T) {
 		players[1].AddCard(entities.NewCard(entities.CardDesignHeart, 3, false))
 		players[2].SetIsFinished(true)
 		players[3].AddCard(entities.NewCard(entities.CardDesignDiamond, 4, false))
-		expected := `{"players":[{"id":0,"isHuman":true,"isFinished":false,"cardCount":2,"cards":[{"design":"SPADE","value":1},{"design":"CLOVER","value":2}]},{"id":1,"isHuman":false,"isFinished":false,"cardCount":1,"cards":[]},{"id":2,"isHuman":false,"isFinished":true,"cardCount":0,"cards":[]},{"id":3,"isHuman":false,"isFinished":false,"cardCount":1,"cards":[]}],"currentTurn":0,"nextDrawTargetIdx":1,"gameEndFlag":false,"loserIdx":-1,"lastDrawPlayerIdx":-1,"lastDrawFromIdx":-1,"lastDiscardedPairs":0,"hasDrawn":false,"message":""}`
+		expected := `{"players":[{"id":0,"isHuman":true,"isFinished":false,"cardCount":2,"cards":[{"design":"SPADE","value":1},{"design":"CLOVER","value":2}]},{"id":1,"isHuman":false,"isFinished":false,"cardCount":1,"cards":[]},{"id":2,"isHuman":false,"isFinished":true,"cardCount":0,"cards":[]},{"id":3,"isHuman":false,"isFinished":false,"cardCount":1,"cards":[]}],"currentTurn":0,"nextDrawTargetIdx":1,"gameEndFlag":false,"loserIdx":-1,"lastDrawPlayerIdx":-1,"lastDrawFromIdx":-1,"lastDrawCard":null,"lastDiscardedPairs":0,"hasDrawn":false,"cpuActions":[],"message":""}`
 		assert.Equal(t, expected, towp.Output(om))
 	})
 
@@ -39,7 +39,7 @@ func TestOldMaidWebPresenter_Method(t *testing.T) {
 		players := makePlayers()
 		om := entities.NewOldMaid(tc, players)
 		// player 0 (human, turn=0): JOKER, SPADE 5, CLOVER 5
-		// player 1 (CPU 1): HEART 7 — exactly 1 card (deterministic draw)
+		// player 1 (CPU 1): HEART 7 — exactly 1 card (deterministic draw at index 0)
 		// players 2,3 finished
 		players[0].AddCard(entities.NewCard(entities.CardDesignJoker, entities.CardValueJoker, false))
 		players[0].AddCard(entities.NewCard(entities.CardDesignSpade, 5, false))
@@ -47,11 +47,10 @@ func TestOldMaidWebPresenter_Method(t *testing.T) {
 		players[1].AddCard(entities.NewCard(entities.CardDesignHeart, 7, false))
 		players[2].SetIsFinished(true)
 		players[3].SetIsFinished(true)
-		// PlayerDraw: draws HEART 7 (only card), discards SPADE5+CLOVER5 pair (1 pair)
+		// PlayerDraw(0): draws HEART 7 (only card), discards SPADE5+CLOVER5 pair (1 pair)
 		// player 0 left: JOKER, HEART 7; player 1 finished; game ends; loserIdx=0
-		om.PlayerDraw()
-		// getNextActivePlayer(0): only player 0 is active, so it returns 0 (itself)
-		expected := `{"players":[{"id":0,"isHuman":true,"isFinished":false,"cardCount":2,"cards":[{"design":"JOKER","value":0},{"design":"HEART","value":7}]},{"id":1,"isHuman":false,"isFinished":true,"cardCount":0,"cards":[]},{"id":2,"isHuman":false,"isFinished":true,"cardCount":0,"cards":[]},{"id":3,"isHuman":false,"isFinished":true,"cardCount":0,"cards":[]}],"currentTurn":0,"nextDrawTargetIdx":0,"gameEndFlag":true,"loserIdx":0,"lastDrawPlayerIdx":0,"lastDrawFromIdx":1,"lastDiscardedPairs":1,"hasDrawn":true,"message":"ゲーム終了！ あなたの負け！"}`
+		om.PlayerDraw(0)
+		expected := `{"players":[{"id":0,"isHuman":true,"isFinished":false,"cardCount":2,"cards":[{"design":"JOKER","value":0},{"design":"HEART","value":7}]},{"id":1,"isHuman":false,"isFinished":true,"cardCount":0,"cards":[]},{"id":2,"isHuman":false,"isFinished":true,"cardCount":0,"cards":[]},{"id":3,"isHuman":false,"isFinished":true,"cardCount":0,"cards":[]}],"currentTurn":0,"nextDrawTargetIdx":0,"gameEndFlag":true,"loserIdx":0,"lastDrawPlayerIdx":0,"lastDrawFromIdx":1,"lastDrawCard":{"design":"HEART","value":7},"lastDiscardedPairs":1,"hasDrawn":true,"cpuActions":[],"message":"ゲーム終了！ あなたの負け！"}`
 		assert.Equal(t, expected, towp.Output(om))
 	})
 
@@ -60,71 +59,40 @@ func TestOldMaidWebPresenter_Method(t *testing.T) {
 		players := makePlayers()
 		om := entities.NewOldMaid(tc, players)
 		// player 0 (human, turn=0): SPADE 5 (1 card)
-		// player 1 (CPU 1): CLOVER 7, DIAMOND 8 (2 cards) — non-deterministic draw, skip
-		// Instead: player 1 has exactly 1 card CLOVER 7 (no pair with SPADE 5)
+		// player 1 (CPU 1): CLOVER 7 (1 card) — deterministic draw at index 0
 		// player 2: HEART 9 (1 card, active)
 		// player 3: finished
-		// PlayerDraw: player 0 draws from player 1 (1 card → index 0, deterministic)
-		//   player 0 gets CLOVER 7 → SPADE 5, CLOVER 7 → no pair → 0 discarded
-		//   player 1 has 0 cards → finished
-		//   checkGameEnd: active = {0, 2} → 2 active → game not ended
-		//   advanceTurn: nextActivePlayer(0) = 2 (player 1 is finished, player 2 is active)
 		players[0].AddCard(entities.NewCard(entities.CardDesignSpade, 5, false))
 		players[1].AddCard(entities.NewCard(entities.CardDesignClover, 7, false))
 		players[2].AddCard(entities.NewCard(entities.CardDesignHeart, 9, false))
 		players[3].SetIsFinished(true)
-		om.PlayerDraw()
-		// After draw: player 0 has SPADE 5, CLOVER 7; player 1 finished; player 2 has HEART 9
-		// currentTurn = 2 (advanced past finished player 1)
-		// hasDrawn=true, lastDrawPlayerIdx=0, lastDrawFromIdx=1, lastDiscardedPairs=0
+		om.PlayerDraw(0)
 		result := towp.Output(om)
 		assert.Contains(t, result, `"hasDrawn":true`)
 		assert.Contains(t, result, `"lastDrawPlayerIdx":0`)
 		assert.Contains(t, result, `"lastDrawFromIdx":1`)
 		assert.Contains(t, result, `"lastDiscardedPairs":0`)
 		assert.Contains(t, result, `"gameEndFlag":false`)
+		assert.Contains(t, result, `"lastDrawCard":{"design":"CLOVER","value":7}`)
+		assert.Contains(t, result, `"cpuActions":[]`)
 	})
 
 	t.Run("success Output game ended cpu loses", func(t *testing.T) {
 		tc := entities.NewTrumpCards(1)
 		players := makePlayers()
 		om := entities.NewOldMaid(tc, players)
-		// Setup for CPU 2 losing:
 		// player 0 (human, turn=0): SPADE 3 (1 card)
-		// player 1 (CPU 1): finished
-		// player 2 (CPU 2): JOKER, CLOVER 3 (2 cards)  → nextActive from 0 is 2
-		// player 3: finished
-		// PlayerDraw: player 0 draws from player 2 (next active after 0, skipping finished 1)
-		//   player 2 has 2 cards → non-deterministic!
-		// Use 1 card for player 2: JOKER (1 card, deterministic)
-		// player 0 draws JOKER → SPADE 3, JOKER → no pair → 0 discarded
-		// player 2 has 0 cards → finished
-		// checkGameEnd: active = {0} (players 1,2,3 all finished) → gameEndFlag=true, loserIdx=0
-		// This again gives human as loser. Let's try differently.
-		//
-		// The only way to get CPU losing deterministically via public API starting from turn=0:
-		// player 0 draws, then finishes, then CPU with joker is last → but that requires player 0 to
-		// finish after drawing (pair is created). Then only CPU with joker remains → CPU loses.
-		//
-		// Setup:
-		// player 0 (human, turn=0): SPADE 3, CLOVER 3 (pair available after drawing matching card?)
-		// No - the pair in player 0's hand would be discarded by DiscardPairs call.
-		// player 0 needs to GAIN a card that pairs with something in hand.
-		// player 0: SPADE 3 (1 card) - will pair with what they draw
-		// player 1 (CPU 1): CLOVER 3 (1 card, next active after 0) - exactly 1 card (deterministic)
+		// player 1 (CPU 1): CLOVER 3 (1 card, next active) → deterministic
 		// player 2 (CPU 2): JOKER (1 card)
 		// player 3: finished
-		// PlayerDraw: player 0 draws CLOVER 3 from player 1 (1 card → deterministic)
-		//   player 0 now has SPADE 3, CLOVER 3 → DiscardPairs: 1 pair → player 0 has 0 cards → finished
-		//   player 1 has 0 cards → finished
-		//   checkGameEnd: active = {2} → gameEndFlag=true, loserIdx=2
+		// PlayerDraw(0): player 0 draws CLOVER 3, forms pair → players 0,1 finish
+		// active = {2} → gameEndFlag=true, loserIdx=2
 		players[0].AddCard(entities.NewCard(entities.CardDesignSpade, 3, false))
 		players[1].AddCard(entities.NewCard(entities.CardDesignClover, 3, false))
 		players[2].AddCard(entities.NewCard(entities.CardDesignJoker, entities.CardValueJoker, false))
 		players[3].SetIsFinished(true)
-		om.PlayerDraw()
-		// getNextActivePlayer(0): player 0 finished, player 1 finished, player 2 not finished → returns 2
-		expected := `{"players":[{"id":0,"isHuman":true,"isFinished":true,"cardCount":0,"cards":[]},{"id":1,"isHuman":false,"isFinished":true,"cardCount":0,"cards":[]},{"id":2,"isHuman":false,"isFinished":false,"cardCount":1,"cards":[]},{"id":3,"isHuman":false,"isFinished":true,"cardCount":0,"cards":[]}],"currentTurn":0,"nextDrawTargetIdx":2,"gameEndFlag":true,"loserIdx":2,"lastDrawPlayerIdx":0,"lastDrawFromIdx":1,"lastDiscardedPairs":1,"hasDrawn":true,"message":"ゲーム終了！ CPU 2の負け！"}`
+		om.PlayerDraw(0)
+		expected := `{"players":[{"id":0,"isHuman":true,"isFinished":true,"cardCount":0,"cards":[]},{"id":1,"isHuman":false,"isFinished":true,"cardCount":0,"cards":[]},{"id":2,"isHuman":false,"isFinished":false,"cardCount":1,"cards":[]},{"id":3,"isHuman":false,"isFinished":true,"cardCount":0,"cards":[]}],"currentTurn":0,"nextDrawTargetIdx":2,"gameEndFlag":true,"loserIdx":2,"lastDrawPlayerIdx":0,"lastDrawFromIdx":1,"lastDrawCard":{"design":"CLOVER","value":3},"lastDiscardedPairs":1,"hasDrawn":true,"cpuActions":[],"message":"ゲーム終了！ CPU 2の負け！"}`
 		assert.Equal(t, expected, towp.Output(om))
 	})
 }

--- a/public/js/oldmaid.js
+++ b/public/js/oldmaid.js
@@ -7,6 +7,7 @@ $(document).ready(function () {
     });
 
     $('#btn-draw').on('click', function () {
+        // ランダムに引く (drawIdx 未指定 = サーバー側でランダム選択)
         oldmaidRequest({ command: 'draw' });
     });
 
@@ -31,27 +32,31 @@ $(document).ready(function () {
     function updateUi(response) {
         if (!response || !response.players) return;
 
+        var isHumanTurn = !response.gameEndFlag && response.currentTurn === 0;
+
         response.players.forEach(function (player) {
-            updatePlayerArea(player, response);
+            updatePlayerArea(player, response, isHumanTurn);
         });
 
         updateStatus(response);
+        updateCpuLog(response);
         updateResult(response);
-        updateButtons(response);
+        updateButtons(response, isHumanTurn);
     }
 
-    function updatePlayerArea(player, response) {
+    function updatePlayerArea(player, response, isHumanTurn) {
         var id = player.id;
         var $area = $('#player-area-' + id);
         var $label = $('#label-' + id);
         var $count = $('#count-' + id);
         var $cards = $('#cards-' + id);
+        var isTarget = !response.gameEndFlag && response.nextDrawTargetIdx === id;
 
         // Finished / draw-target styling
         $area.removeClass('draw-target finished-area');
         if (player.isFinished) {
             $area.addClass('finished-area');
-        } else if (!response.gameEndFlag && response.nextDrawTargetIdx === id) {
+        } else if (isTarget) {
             $area.addClass('draw-target');
         }
 
@@ -59,7 +64,7 @@ $(document).ready(function () {
         $label.find('.finished-badge, .draw-target-badge').remove();
         if (player.isFinished) {
             $label.append('<span class="finished-badge">上がり</span>');
-        } else if (!response.gameEndFlag && response.nextDrawTargetIdx === id && !player.isHuman) {
+        } else if (isTarget && !player.isHuman) {
             $label.append('<span class="draw-target-badge">← 引く相手</span>');
         }
 
@@ -68,6 +73,14 @@ $(document).ready(function () {
             $count.text('');
         } else {
             $count.text(player.cardCount + '枚');
+        }
+
+        // Select hint for CPU target
+        if (!player.isHuman) {
+            var $hint = $('#select-hint-' + id);
+            if ($hint.length) {
+                $hint.toggle(isHumanTurn && isTarget && !player.isFinished);
+            }
         }
 
         // Render cards
@@ -85,8 +98,25 @@ $(document).ready(function () {
                     $cards.append($wrap);
                 });
             }
+        } else if (isHumanTurn && isTarget) {
+            // Show selectable (clickable) card backs so player can choose which to draw
+            var showCount = Math.min(player.cardCount, 10);
+            for (var i = 0; i < showCount; i++) {
+                var $img = $('<img>').attr('src', './images/z01.png').attr('alt', 'card');
+                var $wrap = $('<div class="card-wrap selectable"></div>').append($img);
+                // Capture index in closure
+                $wrap.on('click', (function (idx) {
+                    return function () {
+                        oldmaidRequest({ command: 'draw', drawIdx: idx });
+                    };
+                })(i));
+                $cards.append($wrap);
+            }
+            if (player.cardCount > 10) {
+                $cards.append('<span class="card-count-extra">+' + (player.cardCount - 10) + '</span>');
+            }
         } else {
-            // Show card backs (max 10 visible)
+            // Show non-clickable card backs (max 10 visible)
             var showCount = Math.min(player.cardCount, 10);
             for (var i = 0; i < showCount; i++) {
                 var $img = $('<img>').attr('src', './images/z01.png').attr('alt', 'card');
@@ -105,22 +135,45 @@ $(document).ready(function () {
             $status.text('');
             return;
         }
-        var msg = '';
+        var lines = [];
         if (response.hasDrawn) {
             var drawName = playerName(response.lastDrawPlayerIdx);
             var fromName = playerName(response.lastDrawFromIdx);
-            msg = drawName + 'が' + fromName + 'から1枚引きました';
+            var msg = drawName + 'が' + fromName + 'から1枚引きました';
+            if (response.lastDrawCard) {
+                msg += ' (' + cardLabel(response.lastDrawCard) + ')';
+            }
             if (response.lastDiscardedPairs > 0) {
                 msg += '。' + response.lastDiscardedPairs + '組捨てました';
             }
-            msg += '\n';
+            lines.push(msg);
         }
         // Turn hint
         if (response.currentTurn === 0) {
             var targetName = playerName(response.nextDrawTargetIdx);
-            msg += 'あなたの番！ ' + targetName + 'から引いてください。';
+            lines.push('あなたの番！ ' + targetName + 'のカードをクリックして引いてください。');
         }
-        $status.text(msg);
+        $status.text(lines.join('\n'));
+    }
+
+    function updateCpuLog(response) {
+        var $log = $('#cpu-log-box');
+        if (!response.cpuActions || response.cpuActions.length === 0) {
+            $log.hide().text('');
+            return;
+        }
+        var lines = ['[CPUの行動]'];
+        response.cpuActions.forEach(function (action) {
+            var msg = playerName(action.drawPlayerIdx) + 'が' + playerName(action.drawFromIdx) + 'から1枚引きました';
+            if (action.drawnCard) {
+                msg += ' (' + cardLabel(action.drawnCard) + ')';
+            }
+            if (action.discardedPairs > 0) {
+                msg += '。' + action.discardedPairs + '組捨てました';
+            }
+            lines.push(msg);
+        });
+        $log.text(lines.join('\n')).show();
     }
 
     function updateResult(response) {
@@ -132,12 +185,11 @@ $(document).ready(function () {
         }
     }
 
-    function updateButtons(response) {
+    function updateButtons(response, isHumanTurn) {
         if (response.gameEndFlag) {
             $('#btn-draw').prop('disabled', true);
             $('#btn-reset').prop('disabled', false);
         } else {
-            var isHumanTurn = (response.currentTurn === 0);
             $('#btn-draw').prop('disabled', !isHumanTurn);
             $('#btn-reset').prop('disabled', false);
         }
@@ -151,6 +203,7 @@ $(document).ready(function () {
     }
 
     function cardLabel(card) {
+        if (!card) return '';
         if (card.design === 'JOKER') return 'JOKER';
         return card.design + ' ' + card.value;
     }

--- a/public/oldmaid.html
+++ b/public/oldmaid.html
@@ -99,6 +99,32 @@
             align-self: center;
         }
 
+        /* Selectable card back: shown when human can choose which card to draw */
+        .card-wrap.selectable {
+            cursor: pointer;
+            border-radius: 6px;
+            border: 2px solid transparent;
+            transition: border-color 0.15s, box-shadow 0.15s, transform 0.1s;
+        }
+
+        .card-wrap.selectable:hover {
+            border-color: #fff176;
+            box-shadow: 0 0 8px rgba(255, 241, 118, 0.85);
+            transform: translateY(-4px);
+        }
+
+        .card-wrap.selectable img {
+            display: block;
+        }
+
+        /* Hint label shown above selectable cards */
+        .select-hint {
+            color: #fff176;
+            font-size: 0.82em;
+            margin-bottom: 4px;
+            font-style: italic;
+        }
+
         /* Human area: full width at the bottom */
         .human-area {
             margin-top: 12px;
@@ -122,6 +148,18 @@
             font-size: 0.95em;
             margin: 10px 0 4px;
             min-height: 36px;
+            white-space: pre-line;
+        }
+
+        .cpu-log-box {
+            background: rgba(0, 0, 0, 0.3);
+            border-radius: 8px;
+            color: #aad4ff;
+            padding: 8px 14px;
+            font-size: 0.88em;
+            margin: 4px 0;
+            white-space: pre-line;
+            display: none;
         }
 
         .result-box {
@@ -166,16 +204,19 @@
             <div class="player-area" id="player-area-1">
                 <div class="player-label" id="label-1">CPU 1</div>
                 <div class="card-count-label" id="count-1"></div>
+                <div id="select-hint-1" class="select-hint" style="display:none;">クリックして引く</div>
                 <div class="cards-row" id="cards-1"></div>
             </div>
             <div class="player-area" id="player-area-2">
                 <div class="player-label" id="label-2">CPU 2</div>
                 <div class="card-count-label" id="count-2"></div>
+                <div id="select-hint-2" class="select-hint" style="display:none;">クリックして引く</div>
                 <div class="cards-row" id="cards-2"></div>
             </div>
             <div class="player-area" id="player-area-3">
                 <div class="player-label" id="label-3">CPU 3</div>
                 <div class="card-count-label" id="count-3"></div>
+                <div id="select-hint-3" class="select-hint" style="display:none;">クリックして引く</div>
                 <div class="cards-row" id="cards-3"></div>
             </div>
         </div>
@@ -189,14 +230,15 @@
             <div class="cards-row" id="cards-0"></div>
         </div>
 
-        <!-- Status & Result -->
+        <!-- Status & CPU log & Result -->
         <div class="status-box" id="status-box"></div>
+        <div class="cpu-log-box" id="cpu-log-box"></div>
         <div class="result-box" id="result-box"></div>
 
         <!-- Buttons -->
         <div class="btn_field">
             <button type="button" class="btn btn-primary btn-sm" id="btn-reset">リセット</button>
-            <button type="button" class="btn btn-warning btn-sm" id="btn-draw" disabled>引く</button>
+            <button type="button" class="btn btn-warning btn-sm" id="btn-draw" disabled>ランダムに引く</button>
         </div>
     </div>
 

--- a/usecases/OldMaidInteractor.go
+++ b/usecases/OldMaidInteractor.go
@@ -8,7 +8,7 @@ import (
 // OldMaidInteractorIF ババ抜きインタラクターインタフェース
 type OldMaidInteractorIF interface {
 	Reset() string
-	Draw() string
+	Draw(cardIdx int) string
 }
 
 // OldMaidInteractor ババ抜きインタラクタークラス
@@ -39,14 +39,15 @@ func (oi *OldMaidInteractor) Reset() string {
 }
 
 // Draw 人間プレイヤーがカードを引く
-func (oi *OldMaidInteractor) Draw() string {
+// cardIdx: 引くカードのインデックス。-1 の場合はランダム選択。
+func (oi *OldMaidInteractor) Draw(cardIdx int) string {
 	if oi.om.GetGameEndFlag() {
 		return oi.omp.Output(oi.om)
 	}
 	if !oi.om.IsHumanTurn() {
 		return oi.omp.Output(oi.om)
 	}
-	oi.om.PlayerDraw()
+	oi.om.PlayerDraw(cardIdx)
 	if !oi.om.GetGameEndFlag() {
 		oi.runCpuTurns()
 	}

--- a/usecases/OldMaidInteractor_test.go
+++ b/usecases/OldMaidInteractor_test.go
@@ -20,6 +20,6 @@ func TestOldMaidInteractor_Method(t *testing.T) {
 		assert.Equal(t, mockOutput, toi.Reset())
 	})
 	t.Run("success Draw", func(t *testing.T) {
-		assert.Equal(t, mockOutput, toi.Draw())
+		assert.Equal(t, mockOutput, toi.Draw(-1))
 	})
 }


### PR DESCRIPTION
- allow the human player to select which specific card to draw by
  clicking on the target CPU's face-down cards (web GUI); the CLI also
  accepts "d N" / "draw N" to pick card at index N
- expose the drawn card in the game state (lastDrawCard) so both the
  CUI and web presenters can report exactly which card was drawn
- record CPU turn actions (cpuActions) and display them as a
  scrollable log after each CPU phase, making the game progress
  fully visible to the player
- add lastDrawCard and cpuActions fields to the JSON API response;
  update OldMaidWebInput with optional drawIdx field
- update all tests and mocks to match the new signatures and
  expected output

Closes #32

https://claude.ai/code/session_01UVmEHXEmT8PE5fPvozq3bB