### PR TITLE
chore: update Go version to 1.24.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yuta-yoshinaga/go_trumpcards
 
-go 1.20
+go 1.24.7
 
 require (
 	github.com/ant0ine/go-json-rest v3.3.3-0.20170913041208-ebb33769ae01+incompatible


### PR DESCRIPTION
Update go.mod from Go 1.20 to Go 1.24.7, the latest stable version.

Closes #35