### PR TITLE
test(frontend): add vitest unit tests for all frontend modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ go mod tidy
 **Build frontend (React):**
 ```sh
 cd frontend && npm install && npm run build  # Build React app to public/
+cd frontend && npm test                      # Run frontend unit tests (Vitest)
 ```
 
 > **Important:** The built assets in `public/assets/` and `public/index.html` are committed to the
@@ -118,6 +119,29 @@ Always run the full test suite before committing and ensure it passes:
 go test ./...
 ```
 
+### Frontend testing
+
+Frontend unit tests are also mandatory. The test stack is **Vitest + React Testing Library + jest-dom**.
+
+| Layer | Location | What to test |
+|-------|----------|--------------|
+| API client | `frontend/src/api/*.test.ts` | Correct URL, request body, and error handling for every API method |
+| Components | `frontend/src/components/*.test.tsx` | Rendered output, props, event handlers |
+| Pages | `frontend/src/pages/*.test.tsx` | On-mount API calls, rendering for each game phase/state, button interactions |
+
+**Patterns:**
+
+- **Mock the API module**: use `vi.mock('../api/gameApi', ...)` inside page test files; access the typed mock with `vi.mocked(api.exec)`
+- **Wrap router-dependent components**: render `NavBar` (and any component using `useLocation`) inside `<MemoryRouter initialEntries={['/path']}>`
+- **Wait for async effects**: use `waitFor(() => expect(...))` after render when the component fires an API call in `useEffect`
+- **Query buttons by role**: when a text string appears in multiple elements, use `screen.getByRole('button', { name: '...' })` instead of `getByText`
+
+**Run frontend tests before committing:**
+
+```sh
+cd frontend && npm test
+```
+
 ## Documentation Maintenance
 
 **When making code changes, always update the following documentation in the same commit:**
@@ -130,6 +154,7 @@ go test ./...
 | Change architecture or layer structure | `README.md` (Architecture), `CLAUDE.md` (Architecture), `AGENTS.md` (Architecture) |
 | Change Git workflow or CI/CD | `CLAUDE.md` (Git Workflow), `AGENTS.md` (Git Workflow & CI/CD) |
 | Modify anything under `frontend/` | Run `npm run build` and commit updated `public/assets/` and `public/index.html` in the same commit |
+| Add/remove frontend source files or change testing approach | Update `CLAUDE.md` (Frontend testing) and `AGENTS.md` (Frontend testing) |
 
 Use commit type `docs` (or include doc changes in the same commit as the code change) following the Conventional Commits format.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ cd frontend
 npm install        # Install Node.js dependencies
 npm run build      # Build React app to public/ (run before starting the web server)
 npm run dev        # Start Vite dev server (proxies API to localhost:80)
+npm test           # Run frontend unit tests (Vitest)
+npm run test:watch # Run frontend tests in watch mode
 ```
 
 > **Important:** The built assets in `public/assets/` and `public/index.html` are committed to the
@@ -114,6 +116,29 @@ Always run the full test suite before committing and ensure it passes:
 go test ./...
 ```
 
+### Frontend testing
+
+Frontend unit tests are also mandatory. The test stack is **Vitest + React Testing Library + jest-dom**.
+
+| Layer | Location | What to test |
+|-------|----------|--------------|
+| API client | `frontend/src/api/*.test.ts` | Correct URL, request body, and error handling for every API method |
+| Components | `frontend/src/components/*.test.tsx` | Rendered output, props, event handlers |
+| Pages | `frontend/src/pages/*.test.tsx` | On-mount API calls, rendering for each game phase/state, button interactions |
+
+**Patterns:**
+
+- **Mock the API module**: use `vi.mock('../api/gameApi', ...)` inside page test files; access the typed mock with `vi.mocked(api.exec)`
+- **Wrap router-dependent components**: render `NavBar` (and any component using `useLocation`) inside `<MemoryRouter initialEntries={['/path']}>`
+- **Wait for async effects**: use `waitFor(() => expect(...))` after render when the component fires an API call in `useEffect`
+- **Query buttons by role**: when a text string appears in multiple elements (e.g., "交換" appears on both cards and a button), use `screen.getByRole('button', { name: '交換' })` instead of `getByText`
+
+**Run frontend tests before committing:**
+
+```sh
+cd frontend && npm test
+```
+
 ## Documentation Maintenance
 
 **When making code changes, always update the following documentation in the same commit:**
@@ -126,6 +151,7 @@ go test ./...
 | Change architecture or layer structure | `README.md` (Architecture), `CLAUDE.md` (Architecture), `AGENTS.md` (Architecture) |
 | Change Git workflow or CI/CD | `CLAUDE.md` (Git Workflow), `AGENTS.md` (Git Workflow & CI/CD) |
 | Modify anything under `frontend/` | Run `npm run build` and commit updated `public/assets/` and `public/index.html` in the same commit |
+| Add/remove frontend source files or change testing approach | Update `CLAUDE.md` (Frontend testing) and `AGENTS.md` (Frontend testing) |
 
 Use commit type `docs` (or include doc changes in the same commit as the code change) following the Conventional Commits format.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
@@ -22,10 +24,81 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "jsdom": "^28.1.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
-        "vite": "^7.3.1"
+        "vite": "^7.3.1",
+        "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -261,6 +334,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -307,6 +390,151 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
+      "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
+      "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.1",
+        "@csstools/css-calc": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.27.tgz",
+      "integrity": "sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -908,6 +1136,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.1.tgz",
+      "integrity": "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1367,6 +1613,97 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1411,6 +1748,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1759,6 +2114,117 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1782,6 +2248,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1797,6 +2273,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -1822,6 +2309,26 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1837,6 +2344,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -1914,6 +2431,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1994,12 +2521,73 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.0.1.tgz",
+      "integrity": "sha512-IoJs7La+oFp/AB033wBStxNOJt4+9hHMxsXUPANcoXL2b3W4DZKghlJ2cI/eyeRZIQ9ysvYEorVhjrcYctWbog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.26",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2019,6 +2607,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2026,12 +2621,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -2272,6 +2905,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2280,6 +2923,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2450,6 +3103,47 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2487,6 +3181,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2509,6 +3213,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2535,6 +3246,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -2641,6 +3393,44 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2692,6 +3482,17 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -2757,6 +3558,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2776,6 +3590,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2836,6 +3657,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2866,6 +3717,14 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -2913,6 +3772,30 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -2970,6 +3853,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3015,6 +3911,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3023,6 +3926,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3051,6 +3981,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3066,6 +4020,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
+      "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.23"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
+      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3130,6 +4140,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -3255,6 +4275,132 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3271,6 +4417,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -3280,6 +4443,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "react": "^19.2.0",
@@ -16,6 +18,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
@@ -24,8 +28,10 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "jsdom": "^28.1.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^4.0.18"
   }
 }

--- a/frontend/src/api/gameApi.test.ts
+++ b/frontend/src/api/gameApi.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { blackjackApi, pokerApi, oldmaidApi } from './gameApi'
+
+describe('gameApi', () => {
+  const mockFetch = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  function makeResponse(data: unknown, ok = true, status = 200) {
+    return Promise.resolve({
+      ok,
+      status,
+      json: () => Promise.resolve(data),
+    })
+  }
+
+  describe('blackjackApi.exec', () => {
+    it('calls the correct URL with reset command', async () => {
+      const payload = {
+        dealer: { score: 17, cards: [] },
+        player: { score: 15, cards: [] },
+        message: '',
+      }
+      mockFetch.mockReturnValue(makeResponse(payload))
+
+      const result = await blackjackApi.exec('reset')
+
+      expect(mockFetch).toHaveBeenCalledWith('/blackjac/exec', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: 'reset' }),
+      })
+      expect(result).toEqual(payload)
+    })
+
+    it('calls with hit command', async () => {
+      mockFetch.mockReturnValue(makeResponse({ dealer: { score: 0, cards: [] }, player: { score: 20, cards: [] }, message: '' }))
+      await blackjackApi.exec('hit')
+      expect(mockFetch).toHaveBeenCalledWith('/blackjac/exec', expect.objectContaining({
+        body: JSON.stringify({ command: 'hit' }),
+      }))
+    })
+
+    it('calls with stand command', async () => {
+      mockFetch.mockReturnValue(makeResponse({ dealer: { score: 18, cards: [] }, player: { score: 19, cards: [] }, message: 'win' }))
+      await blackjackApi.exec('stand')
+      expect(mockFetch).toHaveBeenCalledWith('/blackjac/exec', expect.objectContaining({
+        body: JSON.stringify({ command: 'stand' }),
+      }))
+    })
+
+    it('throws on HTTP error', async () => {
+      mockFetch.mockReturnValue(makeResponse(null, false, 500))
+      await expect(blackjackApi.exec('reset')).rejects.toThrow('HTTP error: 500')
+    })
+  })
+
+  describe('pokerApi.exec', () => {
+    it('calls the correct URL with reset command', async () => {
+      const payload = {
+        phase: 0,
+        player: { cards: [], handName: '' },
+        dealer: { cards: [], handName: '' },
+        message: '',
+      }
+      mockFetch.mockReturnValue(makeResponse(payload))
+
+      const result = await pokerApi.exec('reset')
+
+      expect(mockFetch).toHaveBeenCalledWith('/poker/exec', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: 'reset', indices: undefined }),
+      })
+      expect(result).toEqual(payload)
+    })
+
+    it('calls with exchange command and indices', async () => {
+      mockFetch.mockReturnValue(makeResponse({
+        phase: 2,
+        player: { cards: [], handName: 'Pair' },
+        dealer: { cards: [], handName: 'High Card' },
+        message: 'win',
+      }))
+      await pokerApi.exec('exchange', [0, 2, 4])
+      expect(mockFetch).toHaveBeenCalledWith('/poker/exec', expect.objectContaining({
+        body: JSON.stringify({ command: 'exchange', indices: [0, 2, 4] }),
+      }))
+    })
+
+    it('throws on HTTP error', async () => {
+      mockFetch.mockReturnValue(makeResponse(null, false, 503))
+      await expect(pokerApi.exec('reset')).rejects.toThrow('HTTP error: 503')
+    })
+  })
+
+  describe('oldmaidApi.exec', () => {
+    it('calls the correct URL with reset command', async () => {
+      const payload = {
+        players: [],
+        currentTurn: 0,
+        nextDrawTargetIdx: 1,
+        gameEndFlag: false,
+        hasDrawn: false,
+        lastDrawPlayerIdx: 0,
+        lastDrawFromIdx: 0,
+        lastDrawCard: null,
+        lastDiscardedPairs: 0,
+        cpuActions: [],
+        message: '',
+      }
+      mockFetch.mockReturnValue(makeResponse(payload))
+
+      const result = await oldmaidApi.exec('reset')
+
+      expect(mockFetch).toHaveBeenCalledWith('/oldmaid/exec', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: 'reset', drawIdx: undefined }),
+      })
+      expect(result).toEqual(payload)
+    })
+
+    it('calls with draw command and drawIdx', async () => {
+      mockFetch.mockReturnValue(makeResponse({
+        players: [],
+        currentTurn: 1,
+        nextDrawTargetIdx: 0,
+        gameEndFlag: false,
+        hasDrawn: true,
+        lastDrawPlayerIdx: 1,
+        lastDrawFromIdx: 0,
+        lastDrawCard: { design: 'SPADE', value: 3 },
+        lastDiscardedPairs: 0,
+        cpuActions: [],
+        message: '',
+      }))
+      await oldmaidApi.exec('draw', 2)
+      expect(mockFetch).toHaveBeenCalledWith('/oldmaid/exec', expect.objectContaining({
+        body: JSON.stringify({ command: 'draw', drawIdx: 2 }),
+      }))
+    })
+
+    it('throws on HTTP error', async () => {
+      mockFetch.mockReturnValue(makeResponse(null, false, 404))
+      await expect(oldmaidApi.exec('reset')).rejects.toThrow('HTTP error: 404')
+    })
+  })
+})

--- a/frontend/src/components/CardImage.test.tsx
+++ b/frontend/src/components/CardImage.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CardImage, CardBack } from './CardImage'
+import type { Card, CardDesign } from '../types/card'
+
+describe('CardImage', () => {
+  it.each<[CardDesign, string]>([
+    ['SPADE', 's'],
+    ['CLOVER', 'c'],
+    ['HEART', 'h'],
+    ['DIAMOND', 'd'],
+    ['JOKER', 'x'],
+  ])('renders correct image src for %s', (design, prefix) => {
+    const card: Card = { design, value: 1 }
+    render(<CardImage card={card} />)
+    expect(screen.getByRole('img')).toHaveAttribute('src', `/images/${prefix}01.png`)
+  })
+
+  it('zero-pads single-digit card values', () => {
+    const card: Card = { design: 'HEART', value: 5 }
+    render(<CardImage card={card} />)
+    expect(screen.getByRole('img')).toHaveAttribute('src', '/images/h05.png')
+  })
+
+  it('does not pad two-digit card values', () => {
+    const card: Card = { design: 'SPADE', value: 13 }
+    render(<CardImage card={card} />)
+    expect(screen.getByRole('img')).toHaveAttribute('src', '/images/s13.png')
+  })
+
+  it('renders alt text with design and value', () => {
+    const card: Card = { design: 'DIAMOND', value: 7 }
+    render(<CardImage card={card} />)
+    expect(screen.getByRole('img')).toHaveAttribute('alt', 'DIAMOND 7')
+  })
+
+  it('applies custom className', () => {
+    const card: Card = { design: 'SPADE', value: 1 }
+    render(<CardImage card={card} className="my-class" />)
+    expect(screen.getByRole('img')).toHaveClass('my-class')
+  })
+
+  it('applies custom style', () => {
+    const card: Card = { design: 'SPADE', value: 1 }
+    render(<CardImage card={card} style={{ opacity: 0.5 }} />)
+    const img = screen.getByRole('img')
+    expect(img).toHaveStyle({ opacity: '0.5' })
+  })
+})
+
+describe('CardBack', () => {
+  it('renders the card back image', () => {
+    render(<CardBack />)
+    const img = screen.getByRole('img')
+    expect(img).toHaveAttribute('src', '/images/z01.png')
+    expect(img).toHaveAttribute('alt', 'card back')
+  })
+
+  it('applies custom className', () => {
+    render(<CardBack className="back-class" />)
+    expect(screen.getByRole('img')).toHaveClass('back-class')
+  })
+
+  it('calls onClick when clicked', async () => {
+    const onClick = vi.fn()
+    render(<CardBack onClick={onClick} />)
+    screen.getByRole('img').click()
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows pointer cursor when onClick is provided', () => {
+    render(<CardBack onClick={() => undefined} />)
+    const img = screen.getByRole('img')
+    expect(img).toHaveStyle({ cursor: 'pointer' })
+  })
+
+  it('has no pointer cursor when onClick is absent', () => {
+    render(<CardBack />)
+    const img = screen.getByRole('img')
+    expect(img.style.cursor).toBe('')
+  })
+})

--- a/frontend/src/components/NavBar.test.tsx
+++ b/frontend/src/components/NavBar.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { NavBar } from './NavBar'
+
+function renderNavBar(initialPath = '/') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <NavBar />
+    </MemoryRouter>
+  )
+}
+
+describe('NavBar', () => {
+  it('renders three navigation links', () => {
+    renderNavBar()
+    const links = screen.getAllByRole('link')
+    expect(links).toHaveLength(3)
+  })
+
+  it('renders BlackJack link', () => {
+    renderNavBar()
+    expect(screen.getByText('ブラックジャック')).toBeInTheDocument()
+  })
+
+  it('renders Poker link', () => {
+    renderNavBar()
+    expect(screen.getByText('ポーカー')).toBeInTheDocument()
+  })
+
+  it('renders OldMaid link', () => {
+    renderNavBar()
+    expect(screen.getByText('ババ抜き')).toBeInTheDocument()
+  })
+
+  it('marks BlackJack link as active when on root path', () => {
+    renderNavBar('/')
+    const blackjackLink = screen.getByText('ブラックジャック')
+    expect(blackjackLink).toHaveClass('active')
+    expect(screen.getByText('ポーカー')).not.toHaveClass('active')
+    expect(screen.getByText('ババ抜き')).not.toHaveClass('active')
+  })
+
+  it('marks Poker link as active when on /poker path', () => {
+    renderNavBar('/poker')
+    expect(screen.getByText('ポーカー')).toHaveClass('active')
+    expect(screen.getByText('ブラックジャック')).not.toHaveClass('active')
+    expect(screen.getByText('ババ抜き')).not.toHaveClass('active')
+  })
+
+  it('marks OldMaid link as active when on /oldmaid path', () => {
+    renderNavBar('/oldmaid')
+    expect(screen.getByText('ババ抜き')).toHaveClass('active')
+    expect(screen.getByText('ブラックジャック')).not.toHaveClass('active')
+    expect(screen.getByText('ポーカー')).not.toHaveClass('active')
+  })
+
+  it('links point to correct hrefs', () => {
+    renderNavBar()
+    const links = screen.getAllByRole('link')
+    expect(links[0]).toHaveAttribute('href', '/')
+    expect(links[1]).toHaveAttribute('href', '/poker')
+    expect(links[2]).toHaveAttribute('href', '/oldmaid')
+  })
+})

--- a/frontend/src/pages/BlackJackPage.test.tsx
+++ b/frontend/src/pages/BlackJackPage.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { BlackJackPage } from './BlackJackPage'
+import { blackjackApi } from '../api/gameApi'
+import type { BlackJackResponse } from '../types/card'
+
+vi.mock('../api/gameApi', () => ({
+  blackjackApi: { exec: vi.fn() },
+}))
+
+const mockExec = vi.mocked(blackjackApi.exec)
+
+const defaultState: BlackJackResponse = {
+  dealer: { score: 17, cards: [{ design: 'SPADE', value: 1 }] },
+  player: { score: 15, cards: [{ design: 'HEART', value: 5 }, { design: 'DIAMOND', value: 10 }] },
+  message: '',
+}
+
+beforeEach(() => {
+  mockExec.mockResolvedValue(defaultState)
+})
+
+describe('BlackJackPage', () => {
+  it('calls reset command on mount', async () => {
+    render(<BlackJackPage />)
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'))
+  })
+
+  it('renders dealer and player section headings', async () => {
+    render(<BlackJackPage />)
+    await waitFor(() => expect(screen.getByText('ディーラー手札')).toBeInTheDocument())
+    expect(screen.getByText('プレイヤー手札')).toBeInTheDocument()
+  })
+
+  it('displays dealer score when non-zero', async () => {
+    render(<BlackJackPage />)
+    await waitFor(() => expect(screen.getByText(/スコア 17/)).toBeInTheDocument())
+  })
+
+  it('hides dealer score when zero (face-down)', async () => {
+    mockExec.mockResolvedValue({
+      ...defaultState,
+      dealer: { score: 0, cards: [{ design: 'SPADE', value: 1 }] },
+    })
+    render(<BlackJackPage />)
+    await waitFor(() => expect(screen.getByText('ディーラー手札')).toBeInTheDocument())
+    // Score 0 should not appear in the dealer score heading
+    const headings = screen.getAllByText(/スコア/)
+    expect(headings[0].textContent).toBe('スコア ')
+  })
+
+  it('shows card back image when dealer score is zero', async () => {
+    mockExec.mockResolvedValue({
+      ...defaultState,
+      dealer: { score: 0, cards: [{ design: 'SPADE', value: 1 }] },
+    })
+    render(<BlackJackPage />)
+    await waitFor(() => {
+      const imgs = screen.getAllByRole('img')
+      const cardBackImg = imgs.find(img => img.getAttribute('src') === '/images/z01.png')
+      expect(cardBackImg).toBeInTheDocument()
+    })
+  })
+
+  it('displays player score', async () => {
+    render(<BlackJackPage />)
+    await waitFor(() => expect(screen.getByText(/スコア 15/)).toBeInTheDocument())
+  })
+
+  it('renders Hit button', async () => {
+    render(<BlackJackPage />)
+    expect(screen.getByText('ヒット')).toBeInTheDocument()
+  })
+
+  it('renders Stand button', async () => {
+    render(<BlackJackPage />)
+    expect(screen.getByText('スタンド')).toBeInTheDocument()
+  })
+
+  it('renders Reset button', async () => {
+    render(<BlackJackPage />)
+    expect(screen.getByText('リセット')).toBeInTheDocument()
+  })
+
+  it('calls hit command when Hit button is clicked', async () => {
+    render(<BlackJackPage />)
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'))
+    mockExec.mockClear()
+    mockExec.mockResolvedValue({ ...defaultState, player: { score: 20, cards: defaultState.player.cards } })
+    fireEvent.click(screen.getByText('ヒット'))
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hit'))
+  })
+
+  it('calls stand command when Stand button is clicked', async () => {
+    render(<BlackJackPage />)
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'))
+    mockExec.mockClear()
+    mockExec.mockResolvedValue({ ...defaultState, message: 'win' })
+    fireEvent.click(screen.getByText('スタンド'))
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('stand'))
+  })
+
+  it('calls reset command when Reset button is clicked', async () => {
+    render(<BlackJackPage />)
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'))
+    mockExec.mockClear()
+    mockExec.mockResolvedValue(defaultState)
+    fireEvent.click(screen.getByText('リセット'))
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'))
+  })
+
+  it('shows message overlay when message is non-empty', async () => {
+    mockExec.mockResolvedValue({ ...defaultState, message: 'あなたの勝ち！' })
+    render(<BlackJackPage />)
+    await waitFor(() => expect(screen.getByText('あなたの勝ち！')).toBeInTheDocument())
+  })
+
+  it('does not show message overlay when message is empty', async () => {
+    mockExec.mockResolvedValue({ ...defaultState, message: '' })
+    render(<BlackJackPage />)
+    await waitFor(() => expect(screen.getByText('ディーラー手札')).toBeInTheDocument())
+    expect(screen.queryByText('あなたの勝ち！')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/OldMaidPage.test.tsx
+++ b/frontend/src/pages/OldMaidPage.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { OldMaidPage } from './OldMaidPage'
+import { oldmaidApi } from '../api/gameApi'
+import type { OldMaidResponse } from '../types/card'
+
+vi.mock('../api/gameApi', () => ({
+  oldmaidApi: { exec: vi.fn() },
+}))
+
+const mockExec = vi.mocked(oldmaidApi.exec)
+
+const humanTurnState: OldMaidResponse = {
+  players: [
+    { id: 0, isHuman: true, isFinished: false, cardCount: 3, cards: [
+      { design: 'SPADE', value: 1 },
+      { design: 'HEART', value: 2 },
+      { design: 'JOKER', value: 0 },
+    ]},
+    { id: 1, isHuman: false, isFinished: false, cardCount: 4, cards: [] },
+    { id: 2, isHuman: false, isFinished: false, cardCount: 2, cards: [] },
+  ],
+  currentTurn: 0,
+  nextDrawTargetIdx: 1,
+  gameEndFlag: false,
+  hasDrawn: false,
+  lastDrawPlayerIdx: 0,
+  lastDrawFromIdx: 0,
+  lastDrawCard: null,
+  lastDiscardedPairs: 0,
+  cpuActions: [],
+  message: '',
+}
+
+const cpuTurnState: OldMaidResponse = {
+  ...humanTurnState,
+  currentTurn: 1,
+  nextDrawTargetIdx: 0,
+  hasDrawn: true,
+  lastDrawPlayerIdx: 1,
+  lastDrawFromIdx: 2,
+  lastDrawCard: { design: 'HEART', value: 5 },
+  lastDiscardedPairs: 1,
+}
+
+const gameEndState: OldMaidResponse = {
+  ...humanTurnState,
+  gameEndFlag: true,
+  message: 'あなたが負けました',
+}
+
+beforeEach(() => {
+  mockExec.mockResolvedValue(humanTurnState)
+})
+
+describe('OldMaidPage', () => {
+  it('renders nothing before first API response', () => {
+    // Simulate pending promise that never resolves during this check
+    mockExec.mockReturnValue(new Promise(() => undefined))
+    const { container } = render(<OldMaidPage />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('calls reset command on mount', async () => {
+    render(<OldMaidPage />)
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined))
+  })
+
+  it('renders human player area labeled あなた', async () => {
+    render(<OldMaidPage />)
+    await waitFor(() => expect(screen.getByText('あなた')).toBeInTheDocument())
+  })
+
+  it('renders CPU player areas with correct labels', async () => {
+    render(<OldMaidPage />)
+    await waitFor(() => {
+      expect(screen.getByText('CPU 1')).toBeInTheDocument()
+      expect(screen.getByText('CPU 2')).toBeInTheDocument()
+    })
+  })
+
+  it('shows human player cards', async () => {
+    render(<OldMaidPage />)
+    await waitFor(() => {
+      // Human player cards: SPADE 1, HEART 2, JOKER 0
+      expect(screen.getByAltText('SPADE 1')).toBeInTheDocument()
+      expect(screen.getByAltText('HEART 2')).toBeInTheDocument()
+      expect(screen.getByAltText('JOKER 0')).toBeInTheDocument()
+    })
+  })
+
+  it('shows card counts for CPU players', async () => {
+    render(<OldMaidPage />)
+    await waitFor(() => {
+      expect(screen.getByText('4枚')).toBeInTheDocument()
+      expect(screen.getByText('2枚')).toBeInTheDocument()
+    })
+  })
+
+  it('shows target player badge (← 引く相手) on human turn', async () => {
+    render(<OldMaidPage />)
+    await waitFor(() => expect(screen.getByText('← 引く相手')).toBeInTheDocument())
+  })
+
+  it('shows instruction to click target player on human turn', async () => {
+    render(<OldMaidPage />)
+    await waitFor(() => expect(screen.getByText(/あなたの番！/)).toBeInTheDocument())
+  })
+
+  it('random draw button is enabled on human turn', async () => {
+    render(<OldMaidPage />)
+    await waitFor(() => expect(screen.getByText('ランダムに引く')).not.toBeDisabled())
+  })
+
+  it('random draw button is disabled on CPU turn', async () => {
+    mockExec.mockResolvedValue(cpuTurnState)
+    render(<OldMaidPage />)
+    await waitFor(() => expect(screen.getByText('ランダムに引く')).toBeDisabled())
+  })
+
+  it('random draw button is disabled when game has ended', async () => {
+    mockExec.mockResolvedValue(gameEndState)
+    render(<OldMaidPage />)
+    await waitFor(() => expect(screen.getByText('ランダムに引く')).toBeDisabled())
+  })
+
+  it('calls reset when reset button is clicked', async () => {
+    render(<OldMaidPage />)
+    await waitFor(() => expect(screen.getByText('リセット')).toBeInTheDocument())
+    mockExec.mockClear()
+    mockExec.mockResolvedValue(humanTurnState)
+    fireEvent.click(screen.getByText('リセット'))
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined))
+  })
+
+  it('calls draw when random draw button is clicked', async () => {
+    render(<OldMaidPage />)
+    await waitFor(() => expect(screen.getByText('ランダムに引く')).not.toBeDisabled())
+    mockExec.mockClear()
+    mockExec.mockResolvedValue(cpuTurnState)
+    fireEvent.click(screen.getByText('ランダムに引く'))
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw', undefined))
+  })
+
+  it('shows status message when hasDrawn is true', async () => {
+    mockExec.mockResolvedValue(cpuTurnState)
+    render(<OldMaidPage />)
+    await waitFor(() => expect(screen.getByText(/CPU 1がCPU 2から1枚引きました/)).toBeInTheDocument())
+  })
+
+  it('shows discarded pairs in status message', async () => {
+    mockExec.mockResolvedValue(cpuTurnState)
+    render(<OldMaidPage />)
+    await waitFor(() => expect(screen.getByText(/1組捨てました/)).toBeInTheDocument())
+  })
+
+  it('shows finished badge for completed players', async () => {
+    const stateWithFinished: OldMaidResponse = {
+      ...humanTurnState,
+      players: [
+        { ...humanTurnState.players[0] },
+        { id: 1, isHuman: false, isFinished: true, cardCount: 0, cards: [] },
+        { ...humanTurnState.players[2] },
+      ],
+    }
+    mockExec.mockResolvedValue(stateWithFinished)
+    render(<OldMaidPage />)
+    await waitFor(() => expect(screen.getByText('上がり')).toBeInTheDocument())
+  })
+
+  it('shows game result message when game ends', async () => {
+    mockExec.mockResolvedValue(gameEndState)
+    render(<OldMaidPage />)
+    await waitFor(() => expect(screen.getByText('あなたが負けました')).toBeInTheDocument())
+  })
+
+  it('shows CPU actions log when cpuActions is non-empty', async () => {
+    const stateWithCpuActions: OldMaidResponse = {
+      ...humanTurnState,
+      cpuActions: [
+        { drawPlayerIdx: 1, drawFromIdx: 2, drawnCard: { design: 'SPADE', value: 3 }, discardedPairs: 0 },
+      ],
+    }
+    mockExec.mockResolvedValue(stateWithCpuActions)
+    render(<OldMaidPage />)
+    await waitFor(() => expect(screen.getByText(/\[CPUの行動\]/)).toBeInTheDocument())
+    expect(screen.getByText(/CPU 1がCPU 2から1枚引きました/)).toBeInTheDocument()
+  })
+
+  it('calls draw with drawIdx when a target player card back is clicked', async () => {
+    render(<OldMaidPage />)
+    await waitFor(() => expect(screen.getByText('← 引く相手')).toBeInTheDocument())
+
+    mockExec.mockClear()
+    mockExec.mockResolvedValue(cpuTurnState)
+    // CPU 1 is target player: click its first card back
+    const cardBacks = screen.getAllByAltText('card back')
+    fireEvent.click(cardBacks[0])
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw', 0))
+  })
+})

--- a/frontend/src/pages/PokerPage.test.tsx
+++ b/frontend/src/pages/PokerPage.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { PokerPage } from './PokerPage'
+import { pokerApi } from '../api/gameApi'
+import type { PokerResponse } from '../types/card'
+
+vi.mock('../api/gameApi', () => ({
+  pokerApi: { exec: vi.fn() },
+}))
+
+const mockExec = vi.mocked(pokerApi.exec)
+
+const phase0State: PokerResponse = {
+  phase: 0,
+  player: { cards: [], handName: '' },
+  dealer: { cards: [], handName: '' },
+  message: 'リセットしました',
+}
+
+const phase1State: PokerResponse = {
+  phase: 1,
+  player: {
+    cards: [
+      { design: 'SPADE', value: 1 },
+      { design: 'HEART', value: 5 },
+      { design: 'DIAMOND', value: 10 },
+      { design: 'CLOVER', value: 3 },
+      { design: 'SPADE', value: 7 },
+    ],
+    handName: '',
+  },
+  dealer: { cards: [], handName: '' },
+  message: '',
+}
+
+const phase2State: PokerResponse = {
+  phase: 2,
+  player: {
+    cards: [
+      { design: 'SPADE', value: 1 },
+      { design: 'HEART', value: 5 },
+      { design: 'DIAMOND', value: 10 },
+      { design: 'CLOVER', value: 3 },
+      { design: 'SPADE', value: 7 },
+    ],
+    handName: 'High Card',
+  },
+  dealer: {
+    cards: [
+      { design: 'HEART', value: 2 },
+      { design: 'DIAMOND', value: 4 },
+      { design: 'CLOVER', value: 6 },
+      { design: 'SPADE', value: 8 },
+      { design: 'HEART', value: 10 },
+    ],
+    handName: 'Pair',
+  },
+  message: 'あなたの負け',
+}
+
+beforeEach(() => {
+  mockExec.mockResolvedValue(phase0State)
+})
+
+describe('PokerPage', () => {
+  it('calls reset command on mount', async () => {
+    render(<PokerPage />)
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined))
+  })
+
+  it('renders dealer and player section labels', async () => {
+    render(<PokerPage />)
+    await waitFor(() => expect(screen.getByText(/ディーラー手札/)).toBeInTheDocument())
+    expect(screen.getByText(/プレイヤー手札/)).toBeInTheDocument()
+  })
+
+  it('shows 5 card backs for dealer in phase 0', async () => {
+    render(<PokerPage />)
+    await waitFor(() => expect(screen.getByText(/ディーラー手札/)).toBeInTheDocument())
+    const cardBacks = screen.getAllByAltText('card back')
+    expect(cardBacks.length).toBeGreaterThanOrEqual(5)
+  })
+
+  it('exchange button is disabled in phase 0', async () => {
+    render(<PokerPage />)
+    await waitFor(() => expect(screen.getByText(/ディーラー手札/)).toBeInTheDocument())
+    expect(screen.getByText('交換')).toBeDisabled()
+  })
+
+  it('stand button is disabled in phase 0', async () => {
+    render(<PokerPage />)
+    await waitFor(() => expect(screen.getByText(/ディーラー手札/)).toBeInTheDocument())
+    expect(screen.getByText('スタンド')).toBeDisabled()
+  })
+
+  it('exchange button is enabled in phase 1', async () => {
+    mockExec.mockResolvedValue(phase1State)
+    render(<PokerPage />)
+    await waitFor(() => expect(screen.getByRole('button', { name: '交換' })).not.toBeDisabled())
+  })
+
+  it('stand button is enabled in phase 1', async () => {
+    mockExec.mockResolvedValue(phase1State)
+    render(<PokerPage />)
+    await waitFor(() => expect(screen.getByText('スタンド')).not.toBeDisabled())
+  })
+
+  it('shows player hand name in phase 2', async () => {
+    mockExec.mockResolvedValue(phase2State)
+    render(<PokerPage />)
+    await waitFor(() => expect(screen.getByText('High Card')).toBeInTheDocument())
+  })
+
+  it('shows dealer hand name in phase 2', async () => {
+    mockExec.mockResolvedValue(phase2State)
+    render(<PokerPage />)
+    await waitFor(() => expect(screen.getByText('Pair')).toBeInTheDocument())
+  })
+
+  it('shows dealer cards (not card backs) in phase 2', async () => {
+    mockExec.mockResolvedValue(phase2State)
+    render(<PokerPage />)
+    await waitFor(() => expect(screen.getByText('High Card')).toBeInTheDocument())
+    // In phase 2, dealer cards are shown as real cards not card backs
+    const cardBacks = screen.queryAllByAltText('card back')
+    expect(cardBacks).toHaveLength(0)
+  })
+
+  it('shows result message', async () => {
+    mockExec.mockResolvedValue(phase2State)
+    render(<PokerPage />)
+    await waitFor(() => expect(screen.getByText('あなたの負け')).toBeInTheDocument())
+  })
+
+  it('calls exchange with selected indices when exchange button clicked', async () => {
+    mockExec.mockResolvedValue(phase1State)
+    render(<PokerPage />)
+    await waitFor(() => expect(screen.getByRole('button', { name: '交換' })).not.toBeDisabled())
+
+    // Click first two player card images to select them
+    const playerCardImgs = screen.getAllByAltText(/SPADE 1|HEART 5/)
+    fireEvent.click(playerCardImgs[0])
+    fireEvent.click(playerCardImgs[1])
+
+    mockExec.mockClear()
+    mockExec.mockResolvedValue({ ...phase1State, phase: 2 })
+    fireEvent.click(screen.getByRole('button', { name: '交換' }))
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('exchange', expect.arrayContaining([0, 1])))
+  })
+
+  it('calls stand command when stand button is clicked in phase 1', async () => {
+    mockExec.mockResolvedValue(phase1State)
+    render(<PokerPage />)
+    await waitFor(() => expect(screen.getByText('スタンド')).not.toBeDisabled())
+
+    mockExec.mockClear()
+    mockExec.mockResolvedValue(phase2State)
+    fireEvent.click(screen.getByText('スタンド'))
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('stand', undefined))
+  })
+
+  it('calls reset command when reset button is clicked', async () => {
+    render(<PokerPage />)
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined))
+    mockExec.mockClear()
+    mockExec.mockResolvedValue(phase0State)
+    fireEvent.click(screen.getByText('リセット'))
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined))
+  })
+
+  it('shows instruction text in phase 1', async () => {
+    mockExec.mockResolvedValue(phase1State)
+    render(<PokerPage />)
+    await waitFor(() => expect(screen.getByText(/交換したいカードをクリックして選択/)).toBeInTheDocument())
+  })
+})

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,7 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup } from '@testing-library/react'
+import { afterEach } from 'vitest'
+
+afterEach(() => {
+  cleanup()
+})

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
@@ -7,5 +7,9 @@ export default defineConfig({
   build: {
     outDir: '../public',
     emptyOutDir: false,
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
   },
 })


### PR DESCRIPTION
- set up Vitest + @testing-library/react + jest-dom as test stack
- add explicit afterEach cleanup to src/test/setup.ts to prevent DOM accumulation across tests
- add tests for API client (gameApi.ts): URL, request body, and error handling
- add tests for CardImage and CardBack components: image src per design, alt text, onClick, cursor style
- add tests for NavBar: link rendering, active-class behaviour per route
- add tests for BlackJackPage: on-mount reset, card/score display, Hit/Stand/Reset buttons, message overlay
- add tests for PokerPage: phase-based button states, card selection, exchange/stand commands
- add tests for OldMaidPage: player rendering, turn logic, draw/reset buttons, CPU action log
- update CLAUDE.md and AGENTS.md with frontend testing policy and commands

Closes #41

https://claude.ai/code/session_01XDREPCg44Edc9EDWuEfZr2