### PR TITLE
docs: add rule to close associated issues in PR summary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ Use commit type `docs` (or include doc changes in the same commit as the code ch
 
 - **`develop`**: Default branch; target for all PRs. CodeQL analysis runs on push/PR.
 - **`master`**: Triggers automatic version bump, git tag, and GitHub Release.
-- **PR Summary**: When creating a PR, if there is an associated issue, the PR summary comment must explicitly close the issue (e.g., `Closes #123`).
+- **PR Summary**: When creating a PR, if there is an associated issue, the PR description must explicitly close the issue (e.g., `Closes #123`).
 
 ## Commit Message Format
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ Use commit type `docs` (or include doc changes in the same commit as the code ch
 
 - **`develop`**: Default branch; target for all PRs. CodeQL analysis runs on push/PR.
 - **`master`**: Triggers automatic version bump, git tag, and GitHub Release.
-- **PR Summary**: When creating a PR, if there is an associated issue, the PR summary comment must explicitly close the issue (e.g., `Closes #123`).
+- **PR Summary**: When creating a PR, if there is an associated issue, the PR description must explicitly close the issue (e.g., `Closes #123`).
 
 ## Commit Message Format
 


### PR DESCRIPTION
This PR adds a rule to AGENTS.md and CLAUDE.md requiring coding agents to close associated issues in PR summaries.

Closes #73