### PR TITLE
feat: configure Gemini CLI to use AGENTS.md

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,16 @@
+# Gemini CLI Configuration
+
+This repository provides detailed guidance for AI coding agents in the `AGENTS.md` file.
+
+## Core Mandate
+
+Gemini CLI **MUST** read and strictly adhere to the instructions, architectures, and workflows defined in `AGENTS.md` for all tasks within this project.
+
+## Key Instructions
+
+- **Documentation Overlord:** `AGENTS.md` takes precedence for all project-specific rules, including testing policies, commit formats, and architectural boundaries.
+- **Workflow:** Follow the "Workflow Orchestration" and "Task Management" sections in `AGENTS.md`.
+- **Testing:** Adhere to the "Testing Policy" which requires tests for all layers (Entities, Use cases, Presenters, Controllers).
+- **Commits:** Use the "Conventional Commits" format as specified in `AGENTS.md`.
+
+Refer to `AGENTS.md` for the full context.


### PR DESCRIPTION
This PR adds GEMINI.md to the root directory, which instructs Gemini CLI to read and follow the guidelines in AGENTS.md.