### PR TITLE
refactor(entities): replace hardcoded deck initialization with loop-based approach

### DIFF
--- a/entities/TrumpCards.go
+++ b/entities/TrumpCards.go
@@ -20,31 +20,28 @@ func NewTrumpCards(jokerCnt int) *TrumpCards {
 
 // cardsInit カード初期化
 func (t *TrumpCards) cardsInit() {
-	t.deck = make([]*Card, 0)
-	for i := 0; i < t.deckCnt; i++ {
-		var design, value int
-		if 0 <= i && i <= 12 {
-			// スペード
-			design = CardDesignSpade
-			value = i + 1
-		} else if 13 <= i && i <= 25 {
-			// クローバー
-			design = CardDesignClover
-			value = (i - 13) + 1
-		} else if 26 <= i && i <= 38 {
-			// ハート
-			design = CardDesignHeart
-			value = (i - 26) + 1
-		} else if 39 <= i && i <= 51 {
-			// ダイアモンド
-			design = CardDesignDiamond
-			value = (i - 39) + 1
-		} else {
-			// ジョーカー
-			design = CardValueJoker
-			value = (i - 52) + 1
+	t.deck = make([]*Card, 0, t.deckCnt)
+
+	// デザインのリスト
+	designs := []int{
+		CardDesignSpade,
+		CardDesignClover,
+		CardDesignHeart,
+		CardDesignDiamond,
+	}
+
+	// 通常カード (各スート 1-13)
+	for _, design := range designs {
+		for val := 1; val <= CardValueMax; val++ {
+			card := NewCard(design, val, false)
+			t.deck = append(t.deck, card)
 		}
-		card := NewCard(design, value, false)
+	}
+
+	// ジョーカー (残り枚数分)
+	jokerCount := t.deckCnt - CardCnt
+	for i := 1; i <= jokerCount; i++ {
+		card := NewCard(CardDesignJoker, i, false)
 		t.deck = append(t.deck, card)
 	}
 }

--- a/entities/TrumpCards_test.go
+++ b/entities/TrumpCards_test.go
@@ -1,7 +1,6 @@
 package entities_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/entities"
@@ -15,6 +14,106 @@ func TestTrumpCards_Method(t *testing.T) {
 	t.Run("success DrawCard", func(t *testing.T) {
 		tc := entities.NewTrumpCards(2)
 		card := tc.DrawCard()
-		fmt.Println(card)
+		if card == nil {
+			t.Fatal("expected a card but got nil")
+		}
+	})
+}
+
+func TestTrumpCards_cardsInit(t *testing.T) {
+	t.Run("deck size with 0 jokers", func(t *testing.T) {
+		tc := entities.NewTrumpCards(0)
+		// Draw all 52 cards
+		for i := 0; i < 52; i++ {
+			card := tc.DrawCard()
+			if card == nil {
+				t.Fatalf("expected card at index %d but got nil", i)
+			}
+		}
+		// 53rd draw should return nil
+		if card := tc.DrawCard(); card != nil {
+			t.Fatal("expected nil after drawing all cards")
+		}
+	})
+
+	t.Run("deck size with 2 jokers", func(t *testing.T) {
+		tc := entities.NewTrumpCards(2)
+		// Draw all 54 cards
+		for i := 0; i < 54; i++ {
+			card := tc.DrawCard()
+			if card == nil {
+				t.Fatalf("expected card at index %d but got nil", i)
+			}
+		}
+		// 55th draw should return nil
+		if card := tc.DrawCard(); card != nil {
+			t.Fatal("expected nil after drawing all cards")
+		}
+	})
+
+	t.Run("suit and value correctness", func(t *testing.T) {
+		tc := entities.NewTrumpCards(2)
+
+		// Expected suits in order: Spade, Clover, Heart, Diamond
+		expectedDesigns := []int{
+			entities.CardDesignSpade,
+			entities.CardDesignClover,
+			entities.CardDesignHeart,
+			entities.CardDesignDiamond,
+		}
+
+		// Verify 4 suits x 13 cards
+		for _, expectedDesign := range expectedDesigns {
+			for val := 1; val <= entities.CardValueMax; val++ {
+				card := tc.DrawCard()
+				if card == nil {
+					t.Fatalf("expected card with design=%d value=%d but got nil", expectedDesign, val)
+				}
+				if card.GetDesign() != expectedDesign {
+					t.Errorf("expected design %d but got %d", expectedDesign, card.GetDesign())
+				}
+				if card.GetValue() != val {
+					t.Errorf("expected value %d but got %d", val, card.GetValue())
+				}
+			}
+		}
+
+		// Verify 2 jokers
+		for i := 1; i <= 2; i++ {
+			card := tc.DrawCard()
+			if card == nil {
+				t.Fatalf("expected joker %d but got nil", i)
+			}
+			if card.GetDesign() != entities.CardDesignJoker {
+				t.Errorf("expected joker design %d but got %d", entities.CardDesignJoker, card.GetDesign())
+			}
+			if card.GetValue() != i {
+				t.Errorf("expected joker value %d but got %d", i, card.GetValue())
+			}
+		}
+	})
+}
+
+func TestTrumpCards_DrawCard(t *testing.T) {
+	t.Run("returns nil when deck is exhausted", func(t *testing.T) {
+		tc := entities.NewTrumpCards(0)
+		for i := 0; i < 52; i++ {
+			tc.DrawCard()
+		}
+		card := tc.DrawCard()
+		if card != nil {
+			t.Fatal("expected nil when deck is exhausted")
+		}
+	})
+
+	t.Run("drawn card has draw flag set", func(t *testing.T) {
+		tc := entities.NewTrumpCards(0)
+		card := tc.DrawCard()
+		if card == nil {
+			t.Fatal("expected a card but got nil")
+		}
+		if !card.GetDraw() {
+			t.Error("expected draw flag to be true")
+		}
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/yuta-yoshinaga/go_trumpcards
 
 go 1.26.0
 
-toolchain go1.26.0
-
 require (
 	github.com/ant0ine/go-json-rest v3.3.3-0.20170913041208-ebb33769ae01+incompatible
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
## Summary
- Replace hardcoded index-based if/else chain in `cardsInit()` with nested loops over suit constants and rank values
- Fix `CardValueJoker` → `CardDesignJoker` for joker design (semantically correct constant)
- Pre-allocate slice capacity with `make([]*Card, 0, t.deckCnt)`
- Add comprehensive tests for deck initialization, suit/value correctness, and `DrawCard` behavior

Closes #110

## Test plan
- [x] `go test ./entities/ -run TestTrumpCards -v` — all new and existing tests pass
- [x] `go test ./...` — full test suite passes
- [ ] Verify CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)