### PR TITLE
refactor(entities): compute BlackJackPlayer score on-demand

### DIFF
--- a/entities/BlackJackPlayer.go
+++ b/entities/BlackJackPlayer.go
@@ -2,8 +2,7 @@ package entities
 
 // BlackJackPlayer ブラックジャックプレイヤークラス
 type BlackJackPlayer struct {
-	Player     // 親クラス
-	score  int // スコア
+	Player // 親クラス
 }
 
 // NewBlackJackPlayer コンストラクタ
@@ -12,32 +11,30 @@ func NewBlackJackPlayer() *BlackJackPlayer {
 		Player: Player{
 			cards: make([]*Card, 0),
 		},
-		score: 0,
 	}
 }
 
 // AddCard カード追加
 func (bp *BlackJackPlayer) AddCard(card *Card) {
 	bp.cards = append(bp.cards, card)
-	bp.CalcScore()
 }
 
-// CalcScore 手札から現在のスコア計算
-func (bp *BlackJackPlayer) CalcScore() {
+// GetScore 手札から現在のスコア計算
+func (bp *BlackJackPlayer) GetScore() int {
 	aceFlag := false
-	bp.score = 0
-	for i := 0; i < len(bp.cards); i++ {
-		value := bp.cards[i].GetValue()
+	score := 0
+	for _, card := range bp.cards {
+		value := card.GetValue()
 		if 2 <= value && value <= 10 {
 			// 2～10
-			bp.score += value
+			score += value
 		} else if 11 <= value && value <= 13 {
 			// 11～13
-			bp.score += 10
+			score += 10
 		} else {
 			if aceFlag {
 				// 2枚目のエースは強制的に1で換算する
-				bp.score++
+				score++
 			} else {
 				// エースは後ほど計算する
 				aceFlag = true
@@ -46,22 +43,11 @@ func (bp *BlackJackPlayer) CalcScore() {
 	}
 	if aceFlag {
 		// エース計算
-		tmpScore1 := bp.score + 1
-		tmpScore2 := bp.score + 11
-		if 22 <= tmpScore1 && 22 <= tmpScore2 {
-			// どちらもバーストしているならエースを1
-			bp.score = tmpScore1
-		} else if tmpScore1 <= 21 && 22 <= tmpScore2 {
-			// エースが11でバーストしているならエースを1
-			bp.score = tmpScore1
+		if score+11 <= 21 {
+			score += 11
 		} else {
-			// どちらもバーストしていないならエースを11
-			bp.score = tmpScore2
+			score++
 		}
 	}
-}
-
-// GetScore スコア取得
-func (bp *BlackJackPlayer) GetScore() int {
-	return bp.score
+	return score
 }

--- a/entities/BlackJackPlayer_test.go
+++ b/entities/BlackJackPlayer_test.go
@@ -10,48 +10,42 @@ import (
 
 func TestBlackJackPlayer_Method(t *testing.T) {
 	tbp := entities.NewBlackJackPlayer()
-	t.Run("success CalcScore 0", func(t *testing.T) {
+	t.Run("success GetScore 0", func(t *testing.T) {
 		tbp.Reset()
-		tbp.CalcScore()
 		assert.Equal(t, 0, tbp.GetScore())
 	})
-	t.Run("success CalcScore 11", func(t *testing.T) {
+	t.Run("success GetScore 11", func(t *testing.T) {
 		tbp.Reset()
 		tbp.AddCard(entities.NewCard(entities.CardDesignSpade, 1, false))
-		tbp.CalcScore()
 		assert.Equal(t, 11, tbp.GetScore())
 	})
-	t.Run("success CalcScore 13", func(t *testing.T) {
+	t.Run("success GetScore 13", func(t *testing.T) {
 		tbp.Reset()
 		tbp.AddCard(entities.NewCard(entities.CardDesignSpade, 1, false))
 		tbp.AddCard(entities.NewCard(entities.CardDesignSpade, 2, false))
-		tbp.CalcScore()
 		assert.Equal(t, 13, tbp.GetScore())
 	})
-	t.Run("success CalcScore 13", func(t *testing.T) {
+	t.Run("success GetScore 13", func(t *testing.T) {
 		tbp.Reset()
 		tbp.AddCard(entities.NewCard(entities.CardDesignSpade, 1, false))
 		tbp.AddCard(entities.NewCard(entities.CardDesignSpade, 2, false))
 		tbp.AddCard(entities.NewCard(entities.CardDesignSpade, 11, false))
-		tbp.CalcScore()
 		assert.Equal(t, 13, tbp.GetScore())
 	})
-	t.Run("success CalcScore 14", func(t *testing.T) {
+	t.Run("success GetScore 14", func(t *testing.T) {
 		tbp.Reset()
 		tbp.AddCard(entities.NewCard(entities.CardDesignSpade, 1, false))
 		tbp.AddCard(entities.NewCard(entities.CardDesignSpade, 2, false))
 		tbp.AddCard(entities.NewCard(entities.CardDesignSpade, 11, false))
 		tbp.AddCard(entities.NewCard(entities.CardDesignClover, 1, false))
-		tbp.CalcScore()
 		assert.Equal(t, 14, tbp.GetScore())
 	})
-	t.Run("success CalcScore 23", func(t *testing.T) {
+	t.Run("success GetScore 23", func(t *testing.T) {
 		tbp.Reset()
 		tbp.AddCard(entities.NewCard(entities.CardDesignSpade, 1, false))
 		tbp.AddCard(entities.NewCard(entities.CardDesignSpade, 2, false))
 		tbp.AddCard(entities.NewCard(entities.CardDesignSpade, 11, false))
 		tbp.AddCard(entities.NewCard(entities.CardDesignClover, 11, false))
-		tbp.CalcScore()
 		assert.Equal(t, 23, tbp.GetScore())
 	})
 }


### PR DESCRIPTION
## Summary
- Removed mutable `score` field and `CalcScore()` method from `BlackJackPlayer`
- `GetScore()` now computes the score on-demand from the current hand, making `cards` the single source of truth
- Simplified `AddCard()` to only append the card with no side effects

Closes #113

## Test plan
- [x] All existing tests pass with identical expected values (`go test ./...`)
- [ ] Verify no regressions in BlackJack game behavior via CLI or web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)