### PR TITLE
fix(adapter): add error handling for json.Marshal and WriteJson

### DIFF
--- a/internal/adapter/controller/BlackJackWebController.go
+++ b/internal/adapter/controller/BlackJackWebController.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
@@ -73,18 +74,24 @@ func (bwc *BlackJackWebController) Exec(w rest.ResponseWriter, r *rest.Request) 
 	err := r.DecodeJsonPayload(&param)
 	if err != nil || param.Command == "" || param.SessionId == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		_ = w.WriteJson(bwc.newDefaultOutput("param error."))
+		if err := w.WriteJson(bwc.newDefaultOutput("param error.")); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 		return
 	}
 	if param.Command == "q" || param.Command == "quit" {
 		w.WriteHeader(http.StatusOK)
-		_ = w.WriteJson(bwc.newDefaultOutput("bye."))
+		if err := w.WriteJson(bwc.newDefaultOutput("bye.")); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 		return
 	}
 	bji, mu, ok := bwc.store.GetWithLock(param.SessionId, bwc.factory)
 	if !ok {
 		w.WriteHeader(http.StatusBadRequest)
-		_ = w.WriteJson(bwc.newDefaultOutput("param error."))
+		if err := w.WriteJson(bwc.newDefaultOutput("param error.")); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 		return
 	}
 	mu.Lock()
@@ -109,7 +116,9 @@ func (bwc *BlackJackWebController) Exec(w rest.ResponseWriter, r *rest.Request) 
 		bwc.writePresenterResponse(w, bji.DeclineInsurance(), errOutput)
 	default:
 		w.WriteHeader(http.StatusOK)
-		_ = w.WriteJson(bwc.newDefaultOutput("Unsupported command."))
+		if err := w.WriteJson(bwc.newDefaultOutput("Unsupported command.")); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 	}
 }
 

--- a/internal/adapter/controller/DaifugoWebController.go
+++ b/internal/adapter/controller/DaifugoWebController.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
@@ -94,18 +95,24 @@ func (dwc *DaifugoWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 	err := r.DecodeJsonPayload(&param)
 	if err != nil || param.Command == "" || param.SessionId == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		_ = w.WriteJson(dwc.newDefaultOutput("param error."))
+		if err := w.WriteJson(dwc.newDefaultOutput("param error.")); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 		return
 	}
 	if param.Command == "q" || param.Command == "quit" {
 		w.WriteHeader(http.StatusOK)
-		_ = w.WriteJson(dwc.newDefaultOutput("bye."))
+		if err := w.WriteJson(dwc.newDefaultOutput("bye.")); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 		return
 	}
 	dgi, mu, ok := dwc.store.GetWithLock(param.SessionId, dwc.factory)
 	if !ok {
 		w.WriteHeader(http.StatusBadRequest)
-		_ = w.WriteJson(dwc.newDefaultOutput("param error."))
+		if err := w.WriteJson(dwc.newDefaultOutput("param error.")); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 		return
 	}
 	mu.Lock()
@@ -122,7 +129,9 @@ func (dwc *DaifugoWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 		dwc.writePresenterResponse(w, dgi.Play(indices), errOutput)
 	default:
 		w.WriteHeader(http.StatusOK)
-		_ = w.WriteJson(dwc.newDefaultOutput("Unsupported command."))
+		if err := w.WriteJson(dwc.newDefaultOutput("Unsupported command.")); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 	}
 }
 

--- a/internal/adapter/controller/OldMaidWebController.go
+++ b/internal/adapter/controller/OldMaidWebController.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
@@ -78,18 +79,24 @@ func (owc *OldMaidWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 	err := r.DecodeJsonPayload(&param)
 	if err != nil || param.Command == "" || param.SessionId == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		_ = w.WriteJson(owc.newDefaultOutput("param error."))
+		if err := w.WriteJson(owc.newDefaultOutput("param error.")); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 		return
 	}
 	if param.Command == "q" || param.Command == "quit" {
 		w.WriteHeader(http.StatusOK)
-		_ = w.WriteJson(owc.newDefaultOutput("bye."))
+		if err := w.WriteJson(owc.newDefaultOutput("bye.")); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 		return
 	}
 	omi, mu, ok := owc.store.GetWithLock(param.SessionId, owc.factory)
 	if !ok {
 		w.WriteHeader(http.StatusBadRequest)
-		_ = w.WriteJson(owc.newDefaultOutput("param error."))
+		if err := w.WriteJson(owc.newDefaultOutput("param error.")); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 		return
 	}
 	drawIdx := -1
@@ -106,7 +113,9 @@ func (owc *OldMaidWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 		owc.writePresenterResponse(w, omi.Draw(drawIdx), errOutput)
 	default:
 		w.WriteHeader(http.StatusOK)
-		_ = w.WriteJson(owc.newDefaultOutput("Unsupported command."))
+		if err := w.WriteJson(owc.newDefaultOutput("Unsupported command.")); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 	}
 }
 

--- a/internal/adapter/controller/PokerWebController.go
+++ b/internal/adapter/controller/PokerWebController.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
@@ -62,18 +63,24 @@ func (pwc *PokerWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 	err := r.DecodeJsonPayload(&param)
 	if err != nil || param.Command == "" || param.SessionId == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		_ = w.WriteJson(pwc.newDefaultOutput("param error."))
+		if err := w.WriteJson(pwc.newDefaultOutput("param error.")); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 		return
 	}
 	if param.Command == "q" || param.Command == "quit" {
 		w.WriteHeader(http.StatusOK)
-		_ = w.WriteJson(pwc.newDefaultOutput("bye."))
+		if err := w.WriteJson(pwc.newDefaultOutput("bye.")); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 		return
 	}
 	pi, mu, ok := pwc.store.GetWithLock(param.SessionId, pwc.factory)
 	if !ok {
 		w.WriteHeader(http.StatusBadRequest)
-		_ = w.WriteJson(pwc.newDefaultOutput("param error."))
+		if err := w.WriteJson(pwc.newDefaultOutput("param error.")); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 		return
 	}
 	mu.Lock()
@@ -102,7 +109,9 @@ func (pwc *PokerWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 		pwc.writePresenterResponse(w, pi.Check(), errOutput)
 	default:
 		w.WriteHeader(http.StatusOK)
-		_ = w.WriteJson(pwc.newDefaultOutput("Unsupported command."))
+		if err := w.WriteJson(pwc.newDefaultOutput("Unsupported command.")); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 	}
 }
 

--- a/internal/adapter/controller/SevensWebController.go
+++ b/internal/adapter/controller/SevensWebController.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
@@ -88,18 +89,24 @@ func (swc *SevensWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 	err := r.DecodeJsonPayload(&param)
 	if err != nil || param.Command == "" || param.SessionId == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		_ = w.WriteJson(swc.newDefaultOutput("param error."))
+		if err := w.WriteJson(swc.newDefaultOutput("param error.")); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 		return
 	}
 	if param.Command == "q" || param.Command == "quit" {
 		w.WriteHeader(http.StatusOK)
-		_ = w.WriteJson(swc.newDefaultOutput("bye."))
+		if err := w.WriteJson(swc.newDefaultOutput("bye.")); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 		return
 	}
 	sgi, mu, ok := swc.store.GetWithLock(param.SessionId, swc.factory)
 	if !ok {
 		w.WriteHeader(http.StatusBadRequest)
-		_ = w.WriteJson(swc.newDefaultOutput("param error."))
+		if err := w.WriteJson(swc.newDefaultOutput("param error.")); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 		return
 	}
 	mu.Lock()
@@ -118,7 +125,9 @@ func (swc *SevensWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 		swc.writePresenterResponse(w, sgi.PlayJoker(param.Index, param.JokerTargetSuit, param.JokerTargetValue), errOutput)
 	default:
 		w.WriteHeader(http.StatusOK)
-		_ = w.WriteJson(swc.newDefaultOutput("Unsupported command."))
+		if err := w.WriteJson(swc.newDefaultOutput("Unsupported command.")); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 	}
 }
 

--- a/internal/adapter/controller/base_controller.go
+++ b/internal/adapter/controller/base_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 
 	"github.com/ant0ine/go-json-rest/rest"
@@ -14,9 +15,13 @@ type baseController struct{}
 func (bc *baseController) writePresenterResponse(w rest.ResponseWriter, responseStr string, errorOutput any) {
 	if responseStr == "" || !json.Valid([]byte(responseStr)) {
 		w.WriteHeader(http.StatusBadRequest)
-		_ = w.WriteJson(errorOutput)
+		if err := w.WriteJson(errorOutput); err != nil {
+			log.Printf("WriteJson error: %v", err)
+		}
 		return
 	}
 	w.WriteHeader(http.StatusOK)
-	_ = w.WriteJson(json.RawMessage(responseStr))
+	if err := w.WriteJson(json.RawMessage(responseStr)); err != nil {
+		log.Printf("WriteJson error: %v", err)
+	}
 }

--- a/internal/adapter/presenter/BlackJackWebPresenter.go
+++ b/internal/adapter/presenter/BlackJackWebPresenter.go
@@ -75,7 +75,10 @@ func (bjp *BlackJackWebPresenter) Output(bj *domain.BlackJack) string {
 			resObj.Message = "It is your loss."
 		}
 	}
-	res, _ := json.Marshal(resObj)
+	res, err := json.Marshal(resObj)
+	if err != nil {
+		return `{"error":"internal server error"}`
+	}
 	return string(res)
 }
 

--- a/internal/adapter/presenter/DaifugoWebPresenter.go
+++ b/internal/adapter/presenter/DaifugoWebPresenter.go
@@ -99,7 +99,10 @@ func (dwp *DaifugoWebPresenter) Output(dg *domain.Daifugo) string {
 		resObj.Message = dwp.buildResultMessage(dg)
 	}
 
-	res, _ := json.Marshal(resObj)
+	res, err := json.Marshal(resObj)
+	if err != nil {
+		return `{"error":"internal server error"}`
+	}
 	return string(res)
 }
 

--- a/internal/adapter/presenter/OldMaidWebPresenter.go
+++ b/internal/adapter/presenter/OldMaidWebPresenter.go
@@ -98,7 +98,10 @@ func (owp *OldMaidWebPresenter) Output(om *domain.OldMaid) string {
 		}
 	}
 
-	res, _ := json.Marshal(resObj)
+	res, err := json.Marshal(resObj)
+	if err != nil {
+		return `{"error":"internal server error"}`
+	}
 	return string(res)
 }
 

--- a/internal/adapter/presenter/PokerWebPresenter.go
+++ b/internal/adapter/presenter/PokerWebPresenter.go
@@ -63,7 +63,10 @@ func (pwp *PokerWebPresenter) Output(p *domain.Poker) string {
 		}
 	}
 
-	res, _ := json.Marshal(resObj)
+	res, err := json.Marshal(resObj)
+	if err != nil {
+		return `{"error":"internal server error"}`
+	}
 	return string(res)
 }
 

--- a/internal/adapter/presenter/SevensWebPresenter.go
+++ b/internal/adapter/presenter/SevensWebPresenter.go
@@ -87,7 +87,10 @@ func (swp *SevensWebPresenter) Output(s *domain.Sevens) string {
 		resObj.Message = swp.buildResultMessage(s)
 	}
 
-	res, _ := json.Marshal(resObj)
+	res, err := json.Marshal(resObj)
+	if err != nil {
+		return `{"error":"internal server error"}`
+	}
 	return string(res)
 }
 


### PR DESCRIPTION
## Summary
- WebPresenter `Output()` methods now check `json.Marshal` errors and return `{"error":"internal server error"}` instead of silently returning empty strings
- WebController `Exec()` methods and `base_controller.writePresenterResponse()` now log `WriteJson` errors via `log.Printf` instead of discarding them
- All 5 games (BlackJack, Poker, OldMaid, Daifugo, Sevens) are covered

Closes #133

## Test plan
- [x] `go test ./...` passes with all existing tests
- [x] No remaining `_ = w.WriteJson` patterns in the codebase
- [x] No remaining `res, _ := json.Marshal` patterns in WebPresenter files

🤖 Generated with [Claude Code](https://claude.com/claude-code)