### PR TITLE
feat(frontend): display API error messages to users

### DIFF
--- a/frontend/src/components/ErrorAlert.test.tsx
+++ b/frontend/src/components/ErrorAlert.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ErrorAlert } from './ErrorAlert';
+
+describe('ErrorAlert', () => {
+  it('renders nothing when message is null', () => {
+    const { container } = render(<ErrorAlert message={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the message when provided', () => {
+    render(<ErrorAlert message="通信エラーが発生しました。もう一度お試しください。" />);
+    expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ErrorAlert.tsx
+++ b/frontend/src/components/ErrorAlert.tsx
@@ -1,0 +1,12 @@
+interface ErrorAlertProps {
+  message: string | null;
+}
+
+export function ErrorAlert({ message }: ErrorAlertProps) {
+  if (!message) return null;
+  return (
+    <div className="bg-red-700/90 text-white text-center px-4 py-2 text-[0.95em] font-bold mb-2 rounded-lg">
+      {message}
+    </div>
+  );
+}

--- a/frontend/src/pages/BlackJackPage.test.tsx
+++ b/frontend/src/pages/BlackJackPage.test.tsx
@@ -309,4 +309,32 @@ describe('BlackJackPage', () => {
     resolve(actionPhaseState);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ヒット' })).not.toBeDisabled());
   });
+
+  it('shows error message when API call fails', async () => {
+    render(<BlackJackPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined));
+
+    mockExec.mockRejectedValueOnce(new Error('network error'));
+    fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
+    await waitFor(() =>
+      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
+    );
+  });
+
+  it('clears error message on successful API call after failure', async () => {
+    render(<BlackJackPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined));
+
+    mockExec.mockRejectedValueOnce(new Error('network error'));
+    fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
+    await waitFor(() =>
+      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
+    );
+
+    mockExec.mockResolvedValueOnce(actionPhaseState);
+    fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
+    await waitFor(() =>
+      expect(screen.queryByText('通信エラーが発生しました。もう一度お試しください。')).not.toBeInTheDocument(),
+    );
+  });
 });

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { blackjackApi } from '../api/gameApi';
 import { CardBack, CardImage } from '../components/CardImage';
+import { ErrorAlert } from '../components/ErrorAlert';
 import { btnDanger, btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import type { BlackJackResponse } from '../types/card';
 import { BjPhase } from '../types/phases';
@@ -10,6 +11,7 @@ export function BlackJackPage() {
   const [message, setMessage] = useState('');
   const [betAmount, setBetAmount] = useState(10);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const exec = useCallback(
     async (
@@ -18,11 +20,12 @@ export function BlackJackPage() {
     ) => {
       setLoading(true);
       try {
+        setError(null);
         const res = await blackjackApi.exec(command, amount);
         setState(res);
         setMessage(res.message ?? '');
       } catch {
-        console.error('blackjack request failed');
+        setError('通信エラーが発生しました。もう一度お試しください。');
       } finally {
         setLoading(false);
       }
@@ -107,6 +110,8 @@ export function BlackJackPage() {
             {message}
           </div>
         )}
+
+        <ErrorAlert message={error} />
 
         {/* Phase-based buttons */}
         <div className="text-center">

--- a/frontend/src/pages/DaifugoPage.test.tsx
+++ b/frontend/src/pages/DaifugoPage.test.tsx
@@ -317,4 +317,35 @@ describe('DaifugoPage', () => {
     resolve(humanTurnState);
     await waitFor(() => expect(screen.getByRole('button', { name: 'パス' })).not.toBeDisabled());
   });
+
+  it('shows error message when API call fails', async () => {
+    render(<DaifugoPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'パス' })).not.toBeDisabled());
+
+    mockExec.mockReset();
+    mockExec.mockRejectedValue(new Error('network error'));
+    fireEvent.click(screen.getByRole('button', { name: 'パス' }));
+    await waitFor(() =>
+      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
+    );
+  }, 10000);
+
+  it('clears error message on successful API call after failure', async () => {
+    render(<DaifugoPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'パス' })).not.toBeDisabled());
+
+    mockExec.mockReset();
+    mockExec.mockRejectedValue(new Error('network error'));
+    fireEvent.click(screen.getByRole('button', { name: 'パス' }));
+    await waitFor(() =>
+      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
+    );
+
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(humanTurnState);
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    await waitFor(() =>
+      expect(screen.queryByText('通信エラーが発生しました。もう一度お試しください。')).not.toBeInTheDocument(),
+    );
+  }, 10000);
 });

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { daifugoApi } from '../api/gameApi';
 import { CardImage } from '../components/CardImage';
+import { ErrorAlert } from '../components/ErrorAlert';
 import { btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import type { Card, DaifugoAction, DaifugoExchangeAction, DaifugoPlayerData, DaifugoResponse } from '../types/card';
 import { findPlayerName, playerName } from '../utils/playerUtils';
@@ -209,15 +210,17 @@ export function DaifugoPage() {
   const [state, setState] = useState<DaifugoResponse | null>(null);
   const [selectedIndices, setSelectedIndices] = useState<number[]>([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const exec = useCallback(async (command: 'reset' | 'play', indices?: number[]) => {
     setLoading(true);
     try {
+      setError(null);
       const res = await daifugoApi.exec(command, indices);
       setState(res);
       setSelectedIndices([]);
     } catch {
-      console.error('daifugo request failed');
+      setError('通信エラーが発生しました。もう一度お試しください。');
     } finally {
       setLoading(false);
     }
@@ -306,6 +309,8 @@ export function DaifugoPage() {
             />
           </div>
         )}
+
+        <ErrorAlert message={error} />
 
         {/* Buttons */}
         <div className="text-center">

--- a/frontend/src/pages/OldMaidPage.test.tsx
+++ b/frontend/src/pages/OldMaidPage.test.tsx
@@ -352,4 +352,35 @@ describe('OldMaidPage', () => {
     // so the button is re-enabled for the human's next turn
     await waitFor(() => expect(screen.getByText('ランダムに引く')).not.toBeDisabled(), { timeout: 4000 });
   }, 10000);
+
+  it('shows error message when API call fails', async () => {
+    render(<OldMaidPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).not.toBeDisabled());
+
+    mockExec.mockReset();
+    mockExec.mockRejectedValue(new Error('network error'));
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    await waitFor(() =>
+      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
+    );
+  }, 10000);
+
+  it('clears error message on successful API call after failure', async () => {
+    render(<OldMaidPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).not.toBeDisabled());
+
+    mockExec.mockReset();
+    mockExec.mockRejectedValue(new Error('network error'));
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    await waitFor(() =>
+      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
+    );
+
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(humanTurnState);
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    await waitFor(() =>
+      expect(screen.queryByText('通信エラーが発生しました。もう一度お試しください。')).not.toBeInTheDocument(),
+    );
+  }, 10000);
 });

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { oldmaidApi } from '../api/gameApi';
 import { CardBack, CardImage } from '../components/CardImage';
+import { ErrorAlert } from '../components/ErrorAlert';
 import { btnPrimary, btnWarning } from '../styles/buttonStyles';
 import type { Card, CpuAction, OldMaidPlayerData, OldMaidResponse } from '../types/card';
 import { findPlayerName, playerName } from '../utils/playerUtils';
@@ -226,12 +227,14 @@ function DiscardedArea({ cards }: { cards: Card[] | undefined }) {
 export function OldMaidPage() {
   const [displayState, setDisplayState] = useState<OldMaidResponse | null>(null);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const replayGenRef = useRef(0);
 
   const exec = useCallback(async (command: 'reset' | 'draw', drawIdx?: number) => {
     const myGen = ++replayGenRef.current;
     setLoading(true);
     try {
+      setError(null);
       const res = await oldmaidApi.exec(command, drawIdx);
       if (myGen !== replayGenRef.current) return;
 
@@ -258,7 +261,7 @@ export function OldMaidPage() {
       // Restore the actual final state so currentTurn reflects the server response
       setDisplayState(res);
     } catch {
-      console.error('oldmaid request failed');
+      setError('通信エラーが発生しました。もう一度お試しください。');
     } finally {
       setLoading(false);
     }
@@ -358,6 +361,8 @@ export function OldMaidPage() {
             />
           </div>
         )}
+
+        <ErrorAlert message={error} />
 
         {/* Buttons */}
         <div className="text-center">

--- a/frontend/src/pages/PokerPage.test.tsx
+++ b/frontend/src/pages/PokerPage.test.tsx
@@ -317,4 +317,32 @@ describe('PokerPage', () => {
     resolve(phase1State);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).not.toBeDisabled());
   });
+
+  it('shows error message when API call fails', async () => {
+    render(<PokerPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined));
+
+    mockExec.mockRejectedValueOnce(new Error('network error'));
+    fireEvent.click(screen.getByText('リセット'));
+    await waitFor(() =>
+      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
+    );
+  });
+
+  it('clears error message on successful API call after failure', async () => {
+    render(<PokerPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined));
+
+    mockExec.mockRejectedValueOnce(new Error('network error'));
+    fireEvent.click(screen.getByText('リセット'));
+    await waitFor(() =>
+      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
+    );
+
+    mockExec.mockResolvedValueOnce(phase0State);
+    fireEvent.click(screen.getByText('リセット'));
+    await waitFor(() =>
+      expect(screen.queryByText('通信エラーが発生しました。もう一度お試しください。')).not.toBeInTheDocument(),
+    );
+  });
 });

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { pokerApi } from '../api/gameApi';
 import { CardBack, CardImage } from '../components/CardImage';
+import { ErrorAlert } from '../components/ErrorAlert';
 import { btnDanger, btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import type { PokerResponse } from '../types/card';
 import { PokerPhase } from '../types/phases';
@@ -19,6 +20,7 @@ export function PokerPage() {
   const [selected, setSelected] = useState<number[]>([]);
   const [betAmount, setBetAmount] = useState(10);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const exec = useCallback(
     async (
@@ -28,11 +30,12 @@ export function PokerPage() {
     ) => {
       setLoading(true);
       try {
+        setError(null);
         const res = await pokerApi.exec(command, indices, amount);
         setState(res);
         setSelected([]);
       } catch {
-        console.error('poker request failed');
+        setError('通信エラーが発生しました。もう一度お試しください。');
       } finally {
         setLoading(false);
       }
@@ -189,6 +192,8 @@ export function PokerPage() {
         <div className="bg-black/55 rounded-lg text-white text-center px-4 py-2 text-[1.1em] font-bold mb-2 min-h-[36px]">
           {state?.message ?? ''}
         </div>
+
+        <ErrorAlert message={error} />
 
         {/* Betting controls */}
         {isBettingPhase && (

--- a/frontend/src/pages/SevensPage.test.tsx
+++ b/frontend/src/pages/SevensPage.test.tsx
@@ -377,4 +377,35 @@ describe('SevensPage', () => {
     resolve(humanTurnState);
     await waitFor(() => expect(screen.getByRole('button', { name: 'パス' })).not.toBeDisabled());
   });
+
+  it('shows error message when API call fails', async () => {
+    render(<SevensPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).not.toBeDisabled());
+
+    mockExec.mockReset();
+    mockExec.mockRejectedValue(new Error('network error'));
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    await waitFor(() =>
+      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
+    );
+  }, 10000);
+
+  it('clears error message on successful API call after failure', async () => {
+    render(<SevensPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).not.toBeDisabled());
+
+    mockExec.mockReset();
+    mockExec.mockRejectedValue(new Error('network error'));
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    await waitFor(() =>
+      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
+    );
+
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(humanTurnState);
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    await waitFor(() =>
+      expect(screen.queryByText('通信エラーが発生しました。もう一度お試しください。')).not.toBeInTheDocument(),
+    );
+  }, 10000);
 });

--- a/frontend/src/pages/SevensPage.tsx
+++ b/frontend/src/pages/SevensPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import type { SevensConfigInput } from '../api/gameApi';
 import { sevensApi } from '../api/gameApi';
 import { CardImage } from '../components/CardImage';
+import { ErrorAlert } from '../components/ErrorAlert';
 import { btnPrimary, btnWarning } from '../styles/buttonStyles';
 import type { Card, CardDesign, SevensAction, SevensPlayerData, SevensResponse } from '../types/card';
 import { findPlayerName, playerName } from '../utils/playerUtils';
@@ -285,11 +286,13 @@ export function SevensPage() {
   const [cfgJokerCount, setCfgJokerCount] = useState(0);
   const [cfgCpuStrategy, setCfgCpuStrategy] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const exec = useCallback(
     async (command: 'reset' | 'play' | 'joker', index = -1, suit = 0, value = 0, config?: SevensConfigInput) => {
       setLoading(true);
       try {
+        setError(null);
         const res = await sevensApi.exec(command, index, suit, value, config);
         setState(res);
         setJokerCardIdx(null);
@@ -299,7 +302,7 @@ export function SevensPage() {
           setCfgCpuStrategy(res.config.cpuStrategy);
         }
       } catch {
-        console.error('sevens request failed');
+        setError('通信エラーが発生しました。もう一度お試しください。');
       } finally {
         setLoading(false);
       }
@@ -429,6 +432,8 @@ export function SevensPage() {
             CPU戦略
           </label>
         </div>
+
+        <ErrorAlert message={error} />
 
         {/* Buttons */}
         <div className="text-center">


### PR DESCRIPTION
## Summary
- Add shared `ErrorAlert` component for consistent error display across all game pages
- Add `error` state to all 5 game pages (BlackJack, Poker, OldMaid, Daifugo, Sevens) that shows a Japanese error message when API calls fail
- Error automatically clears on the next successful request

Closes #135

## Test plan
- [x] `ErrorAlert` component tests (null renders nothing, string renders message)
- [x] Each page: error message appears when API call fails
- [x] Each page: error message clears on subsequent successful API call
- [x] `npm run check` passes
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)