### PR TITLE
refactor(usecase): add nil validation guards to interactor constructors

### DIFF
--- a/internal/usecase/BlackJackInteractor.go
+++ b/internal/usecase/BlackJackInteractor.go
@@ -25,6 +25,12 @@ type BlackJackInteractor struct {
 
 // NewBlackJackInteractor コンストラクタ
 func NewBlackJackInteractor(bj *domain.BlackJack, bjp presenter.BlackJackPresenter) *BlackJackInteractor {
+	if bj == nil {
+		panic("BlackJackInteractor: bj must not be nil")
+	}
+	if bjp == nil {
+		panic("BlackJackInteractor: bjp must not be nil")
+	}
 	return &BlackJackInteractor{
 		bj:  bj,
 		bjp: bjp,

--- a/internal/usecase/BlackJackInteractor_test.go
+++ b/internal/usecase/BlackJackInteractor_test.go
@@ -11,6 +11,20 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+func TestNewBlackJackInteractor_NilGuards(t *testing.T) {
+	bjpMock := new(presenter.MockBlackJackPresenter)
+	t.Run("panics when bj is nil", func(t *testing.T) {
+		assert.PanicsWithValue(t, "BlackJackInteractor: bj must not be nil", func() {
+			usecase.NewBlackJackInteractor(nil, bjpMock)
+		})
+	})
+	t.Run("panics when bjp is nil", func(t *testing.T) {
+		assert.PanicsWithValue(t, "BlackJackInteractor: bjp must not be nil", func() {
+			usecase.NewBlackJackInteractor(domain.NewDefaultBlackJack(), nil)
+		})
+	})
+}
+
 func TestBlackJackInteractor_Method(t *testing.T) {
 	bjpMock := new(presenter.MockBlackJackPresenter)
 	bjpMock.On("Output", mock.Anything, mock.Anything).Return("----------\ndealer score \nCLOVER 2,\n----------\nplayer score 22\nSPADE 2,SPADE 10,SPADE 11\n----------\n")

--- a/internal/usecase/DaifugoInteractor.go
+++ b/internal/usecase/DaifugoInteractor.go
@@ -19,6 +19,9 @@ type DaifugoInteractor struct {
 
 // NewDaifugoInteractor コンストラクタ
 func NewDaifugoInteractor(dgp presenter.DaifugoPresenter) *DaifugoInteractor {
+	if dgp == nil {
+		panic("DaifugoInteractor: dgp must not be nil")
+	}
 	config := domain.DefaultDaifugoConfig()
 	players := []*domain.DaifugoPlayer{
 		domain.NewDaifugoPlayer(true),  // player 0: 人間

--- a/internal/usecase/DaifugoInteractor_test.go
+++ b/internal/usecase/DaifugoInteractor_test.go
@@ -10,6 +10,14 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+func TestNewDaifugoInteractor_NilGuards(t *testing.T) {
+	t.Run("panics when dgp is nil", func(t *testing.T) {
+		assert.PanicsWithValue(t, "DaifugoInteractor: dgp must not be nil", func() {
+			usecase.NewDaifugoInteractor(nil)
+		})
+	})
+}
+
 func TestDaifugoInteractor_Method(t *testing.T) {
 	mockOutput := `{"players":[],"currentTurn":0,"tableCards":[],"lastPlayPlayerIdx":-1,"gameEndFlag":false,"cpuActions":[],"humanAction":null,"message":""}`
 	dgpMock := new(presenter.MockDaifugoPresenter)

--- a/internal/usecase/OldMaidInteractor.go
+++ b/internal/usecase/OldMaidInteractor.go
@@ -19,6 +19,9 @@ type OldMaidInteractor struct {
 
 // NewOldMaidInteractor コンストラクタ
 func NewOldMaidInteractor(omp presenter.OldMaidPresenter) *OldMaidInteractor {
+	if omp == nil {
+		panic("OldMaidInteractor: omp must not be nil")
+	}
 	players := []*domain.OldMaidPlayer{
 		domain.NewOldMaidPlayer(true),  // player 0: 人間
 		domain.NewOldMaidPlayer(false), // player 1: CPU

--- a/internal/usecase/OldMaidInteractor_test.go
+++ b/internal/usecase/OldMaidInteractor_test.go
@@ -10,6 +10,14 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+func TestNewOldMaidInteractor_NilGuards(t *testing.T) {
+	t.Run("panics when omp is nil", func(t *testing.T) {
+		assert.PanicsWithValue(t, "OldMaidInteractor: omp must not be nil", func() {
+			usecase.NewOldMaidInteractor(nil)
+		})
+	})
+}
+
 func TestOldMaidInteractor_Method(t *testing.T) {
 	mockOutput := `{"players":[],"currentTurn":0,"nextDrawTargetIdx":1,"gameEndFlag":false,"loserIdx":-1,"lastDrawPlayerIdx":-1,"lastDrawFromIdx":-1,"lastDiscardedPairs":0,"hasDrawn":false,"message":""}`
 	ompMock := new(presenter.MockOldMaidPresenter)

--- a/internal/usecase/PokerInteractor.go
+++ b/internal/usecase/PokerInteractor.go
@@ -25,6 +25,9 @@ type PokerInteractor struct {
 
 // NewPokerInteractor コンストラクタ
 func NewPokerInteractor(pp presenter.PokerPresenter) *PokerInteractor {
+	if pp == nil {
+		panic("PokerInteractor: pp must not be nil")
+	}
 	return &PokerInteractor{
 		p:  domain.NewPoker(domain.NewTrumpCards(0), domain.NewPokerPlayer(), domain.NewPokerPlayer()),
 		pp: pp,

--- a/internal/usecase/PokerInteractor_test.go
+++ b/internal/usecase/PokerInteractor_test.go
@@ -10,6 +10,14 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+func TestNewPokerInteractor_NilGuards(t *testing.T) {
+	t.Run("panics when pp is nil", func(t *testing.T) {
+		assert.PanicsWithValue(t, "PokerInteractor: pp must not be nil", func() {
+			usecase.NewPokerInteractor(nil)
+		})
+	})
+}
+
 func TestPokerInteractor_Method(t *testing.T) {
 	mockOutput := `{"dealer":{"handRank":0,"handName":"High Card","cards":[]},"player":{"handRank":0,"handName":"High Card","cards":[]},"phase":1,"message":"","pot":20,"ante":10}`
 	ppMock := new(presenter.MockPokerPresenter)

--- a/internal/usecase/SevensInteractor.go
+++ b/internal/usecase/SevensInteractor.go
@@ -21,6 +21,9 @@ type SevensInteractor struct {
 
 // NewSevensInteractor コンストラクタ
 func NewSevensInteractor(sp presenter.SevensPresenter) *SevensInteractor {
+	if sp == nil {
+		panic("SevensInteractor: sp must not be nil")
+	}
 	config := domain.DefaultSevensConfig()
 	players := []*domain.SevensPlayer{
 		domain.NewSevensPlayer(true),  // player 0: 人間

--- a/internal/usecase/SevensInteractor_test.go
+++ b/internal/usecase/SevensInteractor_test.go
@@ -10,6 +10,14 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+func TestNewSevensInteractor_NilGuards(t *testing.T) {
+	t.Run("panics when sp is nil", func(t *testing.T) {
+		assert.PanicsWithValue(t, "SevensInteractor: sp must not be nil", func() {
+			usecase.NewSevensInteractor(nil)
+		})
+	})
+}
+
 func TestSevensInteractor_Method(t *testing.T) {
 	mockOutput := `{"players":[],"currentTurn":0,"tableMinVals":[0,7,7,7,7],"tableMaxVals":[0,7,7,7,7],"gameEndFlag":false,"cpuActions":[],"humanAction":null,"message":""}`
 	spMock := new(presenter.MockSevensPresenter)


### PR DESCRIPTION
Add panic-on-nil guards to all five interactor constructors
(BlackJack, Poker, OldMaid, Daifugo, Sevens) so that programming
errors are caught immediately at construction time rather than at
the first method call. Corresponding tests are added to verify
the panic message for each nil guard.

Closes #140

https://claude.ai/code/session_01TuDkapSL3cfCEudDVS9Goz