### PR TITLE
test(controller): achieve 100% statement coverage

### DIFF
--- a/internal/adapter/controller/OldMaidWebController_test.go
+++ b/internal/adapter/controller/OldMaidWebController_test.go
@@ -19,6 +19,7 @@ func TestOldMaidWebController_Method(t *testing.T) {
 	omiMock := new(usecase.MockOldMaidInteractor)
 	omiMock.On("Reset").Return(mockOutput).Times(2)
 	omiMock.On("Draw", -1).Return(mockOutput)
+	omiMock.On("Draw", 2).Return(mockOutput)
 
 	factory := func() uc.OldMaidInteractorIF { return omiMock }
 	towc := controller.NewOldMaidWebController(factory)
@@ -81,6 +82,20 @@ func TestOldMaidWebController_Method(t *testing.T) {
 	t.Run("success Exec draw", func(t *testing.T) {
 		_ = json.Unmarshal([]byte(`{"command": "draw", "sessionId": "test-session-1"}`), &jsonInput)
 		req := test.MakeSimpleRequest("POST", "http://1.2.3.4/oldmaid/exec", &jsonInput)
+		req.Header.Set("Content-Type", "application/json;charset=UTF-8")
+		recorded := test.RunRequest(t, api.MakeHandler(), req)
+		recorded.CodeIs(http.StatusOK)
+		recorded.ContentTypeIsJson()
+		recorded.BodyIs(mockOutput)
+	})
+	t.Run("success Exec draw with drawIdx", func(t *testing.T) {
+		drawIdx := 2
+		input := controller.OldMaidWebInput{
+			Command:   "d",
+			DrawIdx:   &drawIdx,
+			SessionId: "test-session-1",
+		}
+		req := test.MakeSimpleRequest("POST", "http://1.2.3.4/oldmaid/exec", &input)
 		req.Header.Set("Content-Type", "application/json;charset=UTF-8")
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
 		recorded.CodeIs(http.StatusOK)

--- a/internal/adapter/controller/PokerWebController_test.go
+++ b/internal/adapter/controller/PokerWebController_test.go
@@ -85,8 +85,8 @@ func TestPokerWebController_Method(t *testing.T) {
 		recorded.BodyIs(mockOutput)
 	})
 	t.Run("success Exec exchange no indices", func(t *testing.T) {
-		_ = json.Unmarshal([]byte(`{"command": "exchange", "sessionId": "test-session-1"}`), &jsonInput)
-		req := test.MakeSimpleRequest("POST", "http://1.2.3.4/poker/exec", &jsonInput)
+		input := controller.PokerWebInput{Command: "exchange", SessionId: "test-session-1"}
+		req := test.MakeSimpleRequest("POST", "http://1.2.3.4/poker/exec", &input)
 		req.Header.Set("Content-Type", "application/json;charset=UTF-8")
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
 		recorded.CodeIs(http.StatusOK)

--- a/internal/adapter/controller/base_controller_internal_test.go
+++ b/internal/adapter/controller/base_controller_internal_test.go
@@ -1,0 +1,44 @@
+package controller
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// failWriter is a minimal rest.ResponseWriter implementation where WriteJson always fails.
+type failWriter struct {
+	header     http.Header
+	headerCode int
+}
+
+func newFailWriter() *failWriter {
+	return &failWriter{header: http.Header{}}
+}
+
+func (fw *failWriter) Header() http.Header   { return fw.header }
+func (fw *failWriter) WriteHeader(code int)  { fw.headerCode = code }
+func (fw *failWriter) WriteJson(_ any) error { return errors.New("write failed") }
+func (fw *failWriter) EncodeJson(v any) ([]byte, error) {
+	return nil, errors.New("encode failed")
+}
+
+func TestWritePresenterResponse_WriteJsonError_Success(t *testing.T) {
+	bc := &baseController{}
+	fw := newFailWriter()
+
+	// Valid JSON response string — triggers the success WriteJson path (line 24).
+	bc.writePresenterResponse(fw, `{"ok":true}`, "fallback")
+	assert.Equal(t, http.StatusOK, fw.headerCode)
+}
+
+func TestWritePresenterResponse_WriteJsonError_Error(t *testing.T) {
+	bc := &baseController{}
+	fw := newFailWriter()
+
+	// Empty response string — triggers the error WriteJson path (line 18).
+	bc.writePresenterResponse(fw, "", "fallback")
+	assert.Equal(t, http.StatusBadRequest, fw.headerCode)
+}

--- a/internal/adapter/controller/session_store.go
+++ b/internal/adapter/controller/session_store.go
@@ -12,9 +12,11 @@ const (
 	SessionMaxCount = 10000
 	// SessionTTL is the inactivity duration after which a session is evicted.
 	SessionTTL = 1 * time.Hour
-	// sessionCleanupInterval is how often the background goroutine runs eviction.
-	sessionCleanupInterval = 10 * time.Minute
 )
+
+// sessionCleanupInterval is how often the background goroutine runs eviction.
+// It is a var (not const) so that internal tests can shorten the interval.
+var sessionCleanupInterval = 10 * time.Minute
 
 type sessionEntry[T any] struct {
 	value    T

--- a/internal/adapter/controller/session_store_internal_test.go
+++ b/internal/adapter/controller/session_store_internal_test.go
@@ -1,0 +1,168 @@
+package controller
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGet_DoubleCheck_ExistingEntry exercises the branch at line 69-71 where,
+// after releasing the global lock to run factory(), another goroutine has
+// already inserted an entry for the same ID.
+func TestGet_DoubleCheck_ExistingEntry(t *testing.T) {
+	s := &SessionStore[int]{
+		entries: make(map[string]*sessionEntry[int]),
+		stopCh:  make(chan struct{}),
+	}
+	defer s.Stop()
+
+	// The factory simulates a race: while it runs (lock is released), another
+	// goroutine inserts an entry for the same key.
+	factory := func() int {
+		s.mu.Lock()
+		s.entries["race"] = &sessionEntry[int]{value: 42, mu: &sync.Mutex{}, lastUsed: time.Now()}
+		s.mu.Unlock()
+		return 99
+	}
+
+	val, ok := s.Get("race", factory)
+	assert.True(t, ok)
+	// Should return the value inserted by the "other goroutine" (42), not factory's 99.
+	assert.Equal(t, 42, val)
+}
+
+// TestGet_DoubleCheck_AtCapacity exercises the branch at line 73-74 where,
+// after releasing the global lock to run factory(), other goroutines fill the
+// store to capacity.
+func TestGet_DoubleCheck_AtCapacity(t *testing.T) {
+	s := &SessionStore[int]{
+		entries: make(map[string]*sessionEntry[int]),
+		stopCh:  make(chan struct{}),
+	}
+	defer s.Stop()
+
+	// Start with SessionMaxCount-1 entries so the first capacity check passes.
+	for i := 0; i < SessionMaxCount-1; i++ {
+		s.entries[fmt.Sprintf("x%d", i)] = &sessionEntry[int]{value: i, mu: &sync.Mutex{}, lastUsed: time.Now()}
+	}
+
+	// factory fills the last slot, so when Get re-acquires the lock for the
+	// double-check, the store is at capacity.
+	factory := func() int {
+		s.mu.Lock()
+		s.entries["blocker"] = &sessionEntry[int]{value: -1, mu: &sync.Mutex{}, lastUsed: time.Now()}
+		s.mu.Unlock()
+		return 999
+	}
+
+	val, ok := s.Get("new-key", factory)
+	assert.False(t, ok)
+	assert.Equal(t, 0, val)
+}
+
+// TestGetWithLock_DoubleCheck_ExistingEntry exercises the branch at line 106-108.
+func TestGetWithLock_DoubleCheck_ExistingEntry(t *testing.T) {
+	s := &SessionStore[int]{
+		entries: make(map[string]*sessionEntry[int]),
+		stopCh:  make(chan struct{}),
+	}
+	defer s.Stop()
+
+	existingMu := &sync.Mutex{}
+	factory := func() int {
+		s.mu.Lock()
+		s.entries["race"] = &sessionEntry[int]{value: 42, mu: existingMu, lastUsed: time.Now()}
+		s.mu.Unlock()
+		return 99
+	}
+
+	val, mu, ok := s.GetWithLock("race", factory)
+	assert.True(t, ok)
+	assert.Equal(t, 42, val)
+	assert.Equal(t, existingMu, mu)
+}
+
+// TestGetWithLock_DoubleCheck_AtCapacity exercises the branch at line 110-111.
+func TestGetWithLock_DoubleCheck_AtCapacity(t *testing.T) {
+	s := &SessionStore[int]{
+		entries: make(map[string]*sessionEntry[int]),
+		stopCh:  make(chan struct{}),
+	}
+	defer s.Stop()
+
+	for i := 0; i < SessionMaxCount-1; i++ {
+		s.entries[fmt.Sprintf("x%d", i)] = &sessionEntry[int]{value: i, mu: &sync.Mutex{}, lastUsed: time.Now()}
+	}
+
+	// factory fills the last slot while lock is released
+	factory := func() int {
+		s.mu.Lock()
+		s.entries["blocker"] = &sessionEntry[int]{value: -1, mu: &sync.Mutex{}, lastUsed: time.Now()}
+		s.mu.Unlock()
+		return 999
+	}
+
+	val, mu, ok := s.GetWithLock("new-key", factory)
+	assert.False(t, ok)
+	assert.Equal(t, 0, val)
+	assert.Nil(t, mu)
+}
+
+func TestEvictExpired_RemovesStaleSession(t *testing.T) {
+	s := &SessionStore[int]{
+		entries: make(map[string]*sessionEntry[int]),
+		stopCh:  make(chan struct{}),
+	}
+	defer s.Stop()
+
+	s.entries["stale"] = &sessionEntry[int]{
+		value:    1,
+		mu:       &sync.Mutex{},
+		lastUsed: time.Now().Add(-SessionTTL - time.Second),
+	}
+	s.entries["fresh"] = &sessionEntry[int]{
+		value:    2,
+		mu:       &sync.Mutex{},
+		lastUsed: time.Now(),
+	}
+
+	s.EvictExpired()
+
+	assert.Equal(t, 1, len(s.entries))
+	_, ok := s.entries["stale"]
+	assert.False(t, ok)
+	_, ok = s.entries["fresh"]
+	assert.True(t, ok)
+}
+
+func TestCleanupLoop_EvictsOnTick(t *testing.T) {
+	// Temporarily shorten the cleanup interval so the ticker fires quickly.
+	orig := sessionCleanupInterval
+	sessionCleanupInterval = 10 * time.Millisecond
+	defer func() { sessionCleanupInterval = orig }()
+
+	s := &SessionStore[int]{
+		entries: make(map[string]*sessionEntry[int]),
+		stopCh:  make(chan struct{}),
+	}
+
+	s.entries["stale"] = &sessionEntry[int]{
+		value:    1,
+		mu:       &sync.Mutex{},
+		lastUsed: time.Now().Add(-SessionTTL - time.Second),
+	}
+
+	go s.cleanupLoop()
+
+	// Wait for the ticker to fire and evict the stale session.
+	assert.Eventually(t, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return len(s.entries) == 0
+	}, 1*time.Second, 5*time.Millisecond)
+
+	s.Stop()
+}

--- a/internal/adapter/controller/web_controller_writejson_internal_test.go
+++ b/internal/adapter/controller/web_controller_writejson_internal_test.go
@@ -1,0 +1,270 @@
+package controller
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
+
+	"github.com/ant0ine/go-json-rest/rest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// makeRestRequest creates a rest.Request with the given JSON body.
+func makeRestRequest(body string) *rest.Request {
+	httpReq, _ := http.NewRequest("POST", "http://localhost/test", io.NopCloser(bytes.NewBufferString(body)))
+	httpReq.Header.Set("Content-Type", "application/json")
+	return &rest.Request{Request: httpReq}
+}
+
+// --- BlackJack WriteJson error tests ---
+
+type mockBlackJackIF struct{ mock.Mock }
+
+func (m *mockBlackJackIF) Reset() string            { return m.Called().String(0) }
+func (m *mockBlackJackIF) Hit() string              { return m.Called().String(0) }
+func (m *mockBlackJackIF) Stand() string            { return m.Called().String(0) }
+func (m *mockBlackJackIF) Bet(a int) string         { return m.Called(a).String(0) }
+func (m *mockBlackJackIF) DoubleDown() string       { return m.Called().String(0) }
+func (m *mockBlackJackIF) Split() string            { return m.Called().String(0) }
+func (m *mockBlackJackIF) Insurance() string        { return m.Called().String(0) }
+func (m *mockBlackJackIF) DeclineInsurance() string { return m.Called().String(0) }
+
+func TestBlackJackWebController_WriteJsonErrors(t *testing.T) {
+	bjMock := &mockBlackJackIF{}
+	factory := func() usecase.BlackJackInteractorIF { return bjMock }
+	ctrl := NewBlackJackWebController(factory)
+	defer ctrl.store.Stop()
+
+	t.Run("param error WriteJson fails", func(t *testing.T) {
+		fw := newFailWriter()
+		req := makeRestRequest(`{"command": "", "sessionId": "s1"}`)
+		ctrl.Exec(fw, req)
+		assert.Equal(t, http.StatusBadRequest, fw.headerCode)
+	})
+
+	t.Run("quit WriteJson fails", func(t *testing.T) {
+		fw := newFailWriter()
+		req := makeRestRequest(`{"command": "q", "sessionId": "s1"}`)
+		ctrl.Exec(fw, req)
+		assert.Equal(t, http.StatusOK, fw.headerCode)
+	})
+
+	t.Run("session error WriteJson fails", func(t *testing.T) {
+		fw := newFailWriter()
+		req := makeRestRequest(`{"command": "r", "sessionId": "` + strings.Repeat("a", SessionMaxIDLen+1) + `"}`)
+		ctrl.Exec(fw, req)
+		assert.Equal(t, http.StatusBadRequest, fw.headerCode)
+	})
+
+	t.Run("unsupported command WriteJson fails", func(t *testing.T) {
+		bjMock2 := &mockBlackJackIF{}
+		factory2 := func() usecase.BlackJackInteractorIF { return bjMock2 }
+		ctrl2 := NewBlackJackWebController(factory2)
+		defer ctrl2.store.Stop()
+		fw := newFailWriter()
+		req := makeRestRequest(`{"command": "xyz", "sessionId": "s-bj-unsupported"}`)
+		ctrl2.Exec(fw, req)
+		assert.Equal(t, http.StatusOK, fw.headerCode)
+	})
+}
+
+// --- Poker WriteJson error tests ---
+
+type mockPokerIF struct{ mock.Mock }
+
+func (m *mockPokerIF) Reset() string           { return m.Called().String(0) }
+func (m *mockPokerIF) Exchange(i []int) string { return m.Called(i).String(0) }
+func (m *mockPokerIF) Stand() string           { return m.Called().String(0) }
+func (m *mockPokerIF) Bet(a int) string        { return m.Called(a).String(0) }
+func (m *mockPokerIF) Call() string            { return m.Called().String(0) }
+func (m *mockPokerIF) Raise(a int) string      { return m.Called(a).String(0) }
+func (m *mockPokerIF) Fold() string            { return m.Called().String(0) }
+func (m *mockPokerIF) Check() string           { return m.Called().String(0) }
+
+func TestPokerWebController_WriteJsonErrors(t *testing.T) {
+	pkMock := &mockPokerIF{}
+	factory := func() usecase.PokerInteractorIF { return pkMock }
+	ctrl := NewPokerWebController(factory)
+	defer ctrl.store.Stop()
+
+	t.Run("param error WriteJson fails", func(t *testing.T) {
+		fw := newFailWriter()
+		req := makeRestRequest(`{"command": "", "sessionId": "s1"}`)
+		ctrl.Exec(fw, req)
+		assert.Equal(t, http.StatusBadRequest, fw.headerCode)
+	})
+
+	t.Run("quit WriteJson fails", func(t *testing.T) {
+		fw := newFailWriter()
+		req := makeRestRequest(`{"command": "q", "sessionId": "s1"}`)
+		ctrl.Exec(fw, req)
+		assert.Equal(t, http.StatusOK, fw.headerCode)
+	})
+
+	t.Run("session error WriteJson fails", func(t *testing.T) {
+		fw := newFailWriter()
+		req := makeRestRequest(`{"command": "r", "sessionId": "` + strings.Repeat("a", SessionMaxIDLen+1) + `"}`)
+		ctrl.Exec(fw, req)
+		assert.Equal(t, http.StatusBadRequest, fw.headerCode)
+	})
+
+	t.Run("unsupported command WriteJson fails", func(t *testing.T) {
+		pkMock2 := &mockPokerIF{}
+		factory2 := func() usecase.PokerInteractorIF { return pkMock2 }
+		ctrl2 := NewPokerWebController(factory2)
+		defer ctrl2.store.Stop()
+		fw := newFailWriter()
+		req := makeRestRequest(`{"command": "xyz", "sessionId": "s-pk-unsupported"}`)
+		ctrl2.Exec(fw, req)
+		assert.Equal(t, http.StatusOK, fw.headerCode)
+	})
+}
+
+// --- OldMaid WriteJson error tests ---
+
+type mockOldMaidIF struct{ mock.Mock }
+
+func (m *mockOldMaidIF) Reset() string       { return m.Called().String(0) }
+func (m *mockOldMaidIF) Draw(idx int) string { return m.Called(idx).String(0) }
+
+func TestOldMaidWebController_WriteJsonErrors(t *testing.T) {
+	omMock := &mockOldMaidIF{}
+	factory := func() usecase.OldMaidInteractorIF { return omMock }
+	ctrl := NewOldMaidWebController(factory)
+	defer ctrl.store.Stop()
+
+	t.Run("param error WriteJson fails", func(t *testing.T) {
+		fw := newFailWriter()
+		req := makeRestRequest(`{"command": "", "sessionId": "s1"}`)
+		ctrl.Exec(fw, req)
+		assert.Equal(t, http.StatusBadRequest, fw.headerCode)
+	})
+
+	t.Run("quit WriteJson fails", func(t *testing.T) {
+		fw := newFailWriter()
+		req := makeRestRequest(`{"command": "q", "sessionId": "s1"}`)
+		ctrl.Exec(fw, req)
+		assert.Equal(t, http.StatusOK, fw.headerCode)
+	})
+
+	t.Run("session error WriteJson fails", func(t *testing.T) {
+		fw := newFailWriter()
+		req := makeRestRequest(`{"command": "r", "sessionId": "` + strings.Repeat("a", SessionMaxIDLen+1) + `"}`)
+		ctrl.Exec(fw, req)
+		assert.Equal(t, http.StatusBadRequest, fw.headerCode)
+	})
+
+	t.Run("unsupported command WriteJson fails", func(t *testing.T) {
+		omMock2 := &mockOldMaidIF{}
+		factory2 := func() usecase.OldMaidInteractorIF { return omMock2 }
+		ctrl2 := NewOldMaidWebController(factory2)
+		defer ctrl2.store.Stop()
+		fw := newFailWriter()
+		req := makeRestRequest(`{"command": "xyz", "sessionId": "s-om-unsupported"}`)
+		ctrl2.Exec(fw, req)
+		assert.Equal(t, http.StatusOK, fw.headerCode)
+	})
+}
+
+// --- Daifugo WriteJson error tests ---
+
+type mockDaifugoIF struct{ mock.Mock }
+
+func (m *mockDaifugoIF) Reset() string       { return m.Called().String(0) }
+func (m *mockDaifugoIF) Play(i []int) string { return m.Called(i).String(0) }
+
+func TestDaifugoWebController_WriteJsonErrors(t *testing.T) {
+	dgMock := &mockDaifugoIF{}
+	factory := func() usecase.DaifugoInteractorIF { return dgMock }
+	ctrl := NewDaifugoWebController(factory)
+	defer ctrl.store.Stop()
+
+	t.Run("param error WriteJson fails", func(t *testing.T) {
+		fw := newFailWriter()
+		req := makeRestRequest(`{"command": "", "sessionId": "s1"}`)
+		ctrl.Exec(fw, req)
+		assert.Equal(t, http.StatusBadRequest, fw.headerCode)
+	})
+
+	t.Run("quit WriteJson fails", func(t *testing.T) {
+		fw := newFailWriter()
+		req := makeRestRequest(`{"command": "q", "sessionId": "s1"}`)
+		ctrl.Exec(fw, req)
+		assert.Equal(t, http.StatusOK, fw.headerCode)
+	})
+
+	t.Run("session error WriteJson fails", func(t *testing.T) {
+		fw := newFailWriter()
+		req := makeRestRequest(`{"command": "r", "sessionId": "` + strings.Repeat("a", SessionMaxIDLen+1) + `"}`)
+		ctrl.Exec(fw, req)
+		assert.Equal(t, http.StatusBadRequest, fw.headerCode)
+	})
+
+	t.Run("unsupported command WriteJson fails", func(t *testing.T) {
+		dgMock2 := &mockDaifugoIF{}
+		factory2 := func() usecase.DaifugoInteractorIF { return dgMock2 }
+		ctrl2 := NewDaifugoWebController(factory2)
+		defer ctrl2.store.Stop()
+		fw := newFailWriter()
+		req := makeRestRequest(`{"command": "xyz", "sessionId": "s-dg-unsupported"}`)
+		ctrl2.Exec(fw, req)
+		assert.Equal(t, http.StatusOK, fw.headerCode)
+	})
+}
+
+// --- Sevens WriteJson error tests ---
+
+type mockSevensIF struct{ mock.Mock }
+
+func (m *mockSevensIF) Reset() string { return m.Called().String(0) }
+func (m *mockSevensIF) ResetWithConfig(t bool, j int, c bool) string {
+	return m.Called(t, j, c).String(0)
+}
+func (m *mockSevensIF) Play(idx int) string { return m.Called(idx).String(0) }
+func (m *mockSevensIF) PlayJoker(idx, suit, val int) string {
+	return m.Called(idx, suit, val).String(0)
+}
+
+func TestSevensWebController_WriteJsonErrors(t *testing.T) {
+	svMock := &mockSevensIF{}
+	factory := func() usecase.SevensInteractorIF { return svMock }
+	ctrl := NewSevensWebController(factory)
+	defer ctrl.store.Stop()
+
+	t.Run("param error WriteJson fails", func(t *testing.T) {
+		fw := newFailWriter()
+		req := makeRestRequest(`{"command": "", "sessionId": "s1"}`)
+		ctrl.Exec(fw, req)
+		assert.Equal(t, http.StatusBadRequest, fw.headerCode)
+	})
+
+	t.Run("quit WriteJson fails", func(t *testing.T) {
+		fw := newFailWriter()
+		req := makeRestRequest(`{"command": "q", "sessionId": "s1"}`)
+		ctrl.Exec(fw, req)
+		assert.Equal(t, http.StatusOK, fw.headerCode)
+	})
+
+	t.Run("session error WriteJson fails", func(t *testing.T) {
+		fw := newFailWriter()
+		req := makeRestRequest(`{"command": "r", "sessionId": "` + strings.Repeat("a", SessionMaxIDLen+1) + `"}`)
+		ctrl.Exec(fw, req)
+		assert.Equal(t, http.StatusBadRequest, fw.headerCode)
+	})
+
+	t.Run("unsupported command WriteJson fails", func(t *testing.T) {
+		svMock2 := &mockSevensIF{}
+		factory2 := func() usecase.SevensInteractorIF { return svMock2 }
+		ctrl2 := NewSevensWebController(factory2)
+		defer ctrl2.store.Stop()
+		fw := newFailWriter()
+		req := makeRestRequest(`{"command": "xyz", "sessionId": "s-sv-unsupported"}`)
+		ctrl2.Exec(fw, req)
+		assert.Equal(t, http.StatusOK, fw.headerCode)
+	})
+}


### PR DESCRIPTION
## Summary
- Achieve 100% C1 (branch) statement coverage for `internal/adapter/controller` (up from 91.2%)
- Cover session_store double-check-locking race paths, eviction, and cleanup loop ticker
- Cover OldMaid `DrawIdx != nil` branch and Poker `indices == nil` branch
- Cover all `WriteJson` error branches across 5 web controllers and `base_controller` via `failWriter` mock

Closes #155

## Test plan
- [x] `go test -coverprofile=coverage.out -covermode=atomic ./internal/adapter/controller/` reports 100.0%
- [x] `go tool cover -func=coverage.out` shows every function at 100.0%
- [x] `go test ./...` passes (full suite)
- [ ] CI passes and Codecov confirms 100% on the package

🤖 Generated with [Claude Code](https://claude.com/claude-code)