### PR TITLE
feat(doubt): add api-layer validation for claimedValue in DoubtWebController

### DIFF
--- a/internal/adapter/controller/DoubtWebController.go
+++ b/internal/adapter/controller/DoubtWebController.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 
 	"github.com/ant0ine/go-json-rest/rest"
@@ -86,12 +87,6 @@ func NewDoubtWebController(factory func() usecase.DoubtInteractorIF) *DoubtWebCo
 // MaxCardIndices カードインデックスの最大数 (52枚デッキ)
 const MaxCardIndices = 52
 
-// MinClaimedValue claimed value の最小値 (A)
-const MinClaimedValue = 1
-
-// MaxClaimedValue claimed value の最大値 (K)
-const MaxClaimedValue = 13
-
 // Exec ゲーム実行
 func (dwc *DoubtWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 	var param DoubtWebInput
@@ -125,9 +120,9 @@ func (dwc *DoubtWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 	case "r", "reset":
 		dwc.writePresenterResponse(w, dgi.Reset(), errOutput)
 	case "p", "play":
-		if param.ClaimedValue < MinClaimedValue || param.ClaimedValue > MaxClaimedValue {
+		if param.ClaimedValue < domain.MinClaimedValue || param.ClaimedValue > domain.MaxClaimedValue {
 			w.WriteHeader(http.StatusBadRequest)
-			if err := w.WriteJson(dwc.newDefaultOutput(fmt.Sprintf("param error: claimedValue must be between %d and %d.", MinClaimedValue, MaxClaimedValue))); err != nil {
+			if err := w.WriteJson(dwc.newDefaultOutput(fmt.Sprintf("param error: claimedValue must be between %d and %d.", domain.MinClaimedValue, domain.MaxClaimedValue))); err != nil {
 				log.Printf("WriteJson error: %v", err)
 			}
 			return

--- a/internal/adapter/controller/DoubtWebController_test.go
+++ b/internal/adapter/controller/DoubtWebController_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/usecase"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	uc "github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 
 	"github.com/ant0ine/go-json-rest/rest"
@@ -25,7 +26,10 @@ func mustDoubtOutputJSON(msg string) string {
 		WinnerIdx:   -1,
 		Message:     msg,
 	}
-	b, _ := json.Marshal(out)
+	b, err := json.Marshal(out)
+	if err != nil {
+		panic(fmt.Sprintf("mustDoubtOutputJSON: %v", err))
+	}
 	return string(b)
 }
 
@@ -199,7 +203,7 @@ func TestDoubtWebController_Method(t *testing.T) {
 
 	claimedValueErrBody := mustDoubtOutputJSON(fmt.Sprintf(
 		"param error: claimedValue must be between %d and %d.",
-		controller.MinClaimedValue, controller.MaxClaimedValue,
+		domain.MinClaimedValue, domain.MaxClaimedValue,
 	))
 	claimedValueTests := []struct {
 		name         string

--- a/internal/domain/Doubt.go
+++ b/internal/domain/Doubt.go
@@ -5,6 +5,12 @@ import "math/rand"
 // DoubtPlayerCnt ダウトプレイヤー数
 const DoubtPlayerCnt = 4
 
+// MinClaimedValue claimed value の最小値 (A)
+const MinClaimedValue = 1
+
+// MaxClaimedValue claimed value の最大値 (K)
+const MaxClaimedValue = 13
+
 // DoubtPhase ゲームフェーズ
 type DoubtPhase int
 
@@ -113,7 +119,7 @@ func (d *Doubt) PlayerPlay(cardIndices []int, claimedValue int) error {
 	if !d.players[d.currentTurn].GetIsHuman() {
 		return ErrNotHumanTurn
 	}
-	if claimedValue < 1 || claimedValue > 13 {
+	if claimedValue < MinClaimedValue || claimedValue > MaxClaimedValue {
 		return NewDomainError(ErrInvalidPlay, "宣言する値は1から13の範囲で指定してください")
 	}
 	if len(cardIndices) == 0 {


### PR DESCRIPTION
Add MinClaimedValue (1) and MaxClaimedValue (13) constants and validate
the ClaimedValue parameter in the play command, returning a 400 param error
for values outside the valid range (A=1 through K=13).

Closes #179