### PR TITLE
fix(doubt): reject duplicate card indices in PlayerPlay

### DIFF
--- a/internal/domain/Doubt.go
+++ b/internal/domain/Doubt.go
@@ -141,6 +141,14 @@ func (d *Doubt) PlayerPlay(cardIndices []int, claimedValue int) error {
 	if len(cardIndices) == 0 {
 		return NewDomainError(ErrInvalidPlay, "1枚以上のカードを指定してください")
 	}
+	// 重複チェック
+	seen := make(map[int]bool, len(cardIndices))
+	for _, idx := range cardIndices {
+		if seen[idx] {
+			return NewDomainError(ErrInvalidCard, "カードインデックスが重複しています")
+		}
+		seen[idx] = true
+	}
 
 	player := d.players[d.currentTurn]
 	for _, idx := range cardIndices {

--- a/internal/domain/Doubt_test.go
+++ b/internal/domain/Doubt_test.go
@@ -169,6 +169,14 @@ func TestDoubt_PlayerPlay_Errors(t *testing.T) {
 		assert.ErrorIs(t, err, domain.ErrInvalidPlay)
 	})
 
+	t.Run("duplicate card index", func(t *testing.T) {
+		game, players := makeDoubtGame()
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 1, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
+		err := game.PlayerPlay([]int{0, 0}, 1)
+		assert.ErrorIs(t, err, domain.ErrInvalidCard)
+	})
+
 	t.Run("out of range card index", func(t *testing.T) {
 		game, players := makeDoubtGame()
 		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 1, false))


### PR DESCRIPTION
## Summary
- `Doubt.PlayerPlay()` now validates that `cardIndices` contains no duplicates before processing, returning `ErrInvalidCard` if a duplicate is found
- Prevents silent deduplication from causing a mismatch between the caller's intended card count and the actual `CardCount` stored in the game action
- Added test case for duplicate card index error

Closes #201

## Test plan
- [x] `go test ./internal/domain/ -run TestDoubt_PlayerPlay` passes
- [x] `go test ./...` all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)