### PR TITLE
fix(web): return HTTP 400 for unsupported commands

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -187,7 +187,7 @@ paths:
                     insuranceAvailable: false
                     message: bye.
         '400':
-          description: Bad request (missing/invalid parameters or session error)
+          description: Bad request (unsupported command, missing/invalid parameters, or session error)
           content:
             application/json:
               schema:
@@ -348,7 +348,7 @@ paths:
                     pot: 0
                     ante: 10
         '400':
-          description: Bad request (missing/invalid parameters or session error)
+          description: Bad request (unsupported command, missing/invalid parameters, or session error)
           content:
             application/json:
               schema:
@@ -420,7 +420,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/OldMaidResponse'
         '400':
-          description: Bad request (missing/invalid parameters or session error)
+          description: Bad request (unsupported command, missing/invalid parameters, or session error)
           content:
             application/json:
               schema:
@@ -491,7 +491,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/DaifugoResponse'
         '400':
-          description: Bad request (missing/invalid parameters or session error)
+          description: Bad request (unsupported command, missing/invalid parameters, or session error)
           content:
             application/json:
               schema:
@@ -562,7 +562,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/SevensResponse'
         '400':
-          description: Bad request (missing/invalid parameters or session error)
+          description: Bad request (unsupported command, missing/invalid parameters, or session error)
           content:
             application/json:
               schema:
@@ -639,7 +639,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/DoubtResponse'
         '400':
-          description: Bad request (missing/invalid parameters or session error)
+          description: Bad request (unsupported command, missing/invalid parameters, or session error)
           content:
             application/json:
               schema:
@@ -747,7 +747,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/HoldemResponse'
         '400':
-          description: Bad request (missing/invalid parameters or session error)
+          description: Bad request (unsupported command, missing/invalid parameters, or session error)
           content:
             application/json:
               schema:

--- a/internal/adapter/controller/BlackJackWebController.go
+++ b/internal/adapter/controller/BlackJackWebController.go
@@ -126,7 +126,7 @@ func (bwc *BlackJackWebController) Exec(w rest.ResponseWriter, r *rest.Request) 
 	case "sd", "setdeckcount":
 		bwc.writePresenterResponse(w, bji.SetDeckCount(param.Amount), errOutput)
 	default:
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusBadRequest)
 		if err := w.WriteJson(bwc.newDefaultOutput("Unsupported command.")); err != nil {
 			log.Printf("WriteJson error: %v", err)
 		}

--- a/internal/adapter/controller/BlackJackWebController_test.go
+++ b/internal/adapter/controller/BlackJackWebController_test.go
@@ -143,7 +143,7 @@ func TestBlackJackWebController_Method(t *testing.T) {
 		req := test.MakeSimpleRequest("POST", "http://1.2.3.4/blackjack/exec", &jsonCase1)
 		req.Header.Set("Content-Type", "application/json;charset=UTF-8")
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
-		recorded.CodeIs(http.StatusOK)
+		recorded.CodeIs(http.StatusBadRequest)
 		recorded.ContentTypeIsJson()
 	})
 	t.Run("failed Exec command empty", func(t *testing.T) {

--- a/internal/adapter/controller/DaifugoWebController.go
+++ b/internal/adapter/controller/DaifugoWebController.go
@@ -157,7 +157,7 @@ func (dwc *DaifugoWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 		}
 		dwc.writePresenterResponse(w, dgi.Play(indices), errOutput)
 	default:
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusBadRequest)
 		if err := w.WriteJson(dwc.newDefaultOutput("Unsupported command.")); err != nil {
 			log.Printf("WriteJson error: %v", err)
 		}

--- a/internal/adapter/controller/DaifugoWebController_test.go
+++ b/internal/adapter/controller/DaifugoWebController_test.go
@@ -108,7 +108,7 @@ func TestDaifugoWebController_Method(t *testing.T) {
 		req := test.MakeSimpleRequest("POST", "http://1.2.3.4/daifugo/exec", &jsonInput)
 		req.Header.Set("Content-Type", "application/json;charset=UTF-8")
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
-		recorded.CodeIs(http.StatusOK)
+		recorded.CodeIs(http.StatusBadRequest)
 		recorded.ContentTypeIsJson()
 		recorded.BodyIs(`{"players":[],"currentTurn":0,"tableCards":[],"lastPlayPlayerIdx":0,"gameEndFlag":false,"revolutionActive":false,"elevenBackActive":false,"suitLocked":false,"lockedSuit":"","tableIsSequence":false,"config":{"jokerCount":0,"eightCutEnabled":false,"suitLockEnabled":false,"elevenBackEnabled":false,"sequenceEnabled":false,"cardExchangeEnabled":false,"fiveSkipEnabled":false,"sevenPassEnabled":false,"tenDiscardEnabled":false,"spadeThreeEnabled":false,"capitalFallEnabled":false},"exchangeActions":[],"cpuActions":[],"humanAction":null,"message":"Unsupported command.","pendingAction":"none","pendingActionTarget":-1}`)
 	})

--- a/internal/adapter/controller/DoubtWebController.go
+++ b/internal/adapter/controller/DoubtWebController.go
@@ -165,7 +165,7 @@ func (dwc *DoubtWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 			dwc.writePresenterResponse(w, dgi.SkipDoubt(), errOutput)
 		}
 	default:
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusBadRequest)
 		if err := w.WriteJson(dwc.newDefaultOutput("Unsupported command.")); err != nil {
 			log.Printf("WriteJson error: %v", err)
 		}

--- a/internal/adapter/controller/DoubtWebController_test.go
+++ b/internal/adapter/controller/DoubtWebController_test.go
@@ -149,7 +149,7 @@ func TestDoubtWebController_Method(t *testing.T) {
 		req := test.MakeSimpleRequest("POST", "http://1.2.3.4/doubt/exec", &jsonInput)
 		req.Header.Set("Content-Type", "application/json;charset=UTF-8")
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
-		recorded.CodeIs(http.StatusOK)
+		recorded.CodeIs(http.StatusBadRequest)
 		recorded.ContentTypeIsJson()
 		recorded.BodyIs(mustDoubtOutputJSON("Unsupported command."))
 	})

--- a/internal/adapter/controller/HoldemWebController.go
+++ b/internal/adapter/controller/HoldemWebController.go
@@ -167,7 +167,7 @@ func (hwc *HoldemWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 	case "a", "allin":
 		hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionAllIn, 0), errOutput)
 	default:
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusBadRequest)
 		if err := w.WriteJson(hwc.newDefaultOutput("Unsupported command.")); err != nil {
 			log.Printf("WriteJson error: %v", err)
 		}

--- a/internal/adapter/controller/HoldemWebController_test.go
+++ b/internal/adapter/controller/HoldemWebController_test.go
@@ -158,7 +158,7 @@ func TestHoldemWebController_Unknown(t *testing.T) {
 	recorded := test.RunRequest(t, api.MakeHandler(),
 		test.MakeSimpleRequest("POST", "http://localhost/holdem/exec",
 			map[string]interface{}{"command": "xyz", "sessionId": "s1"}))
-	recorded.CodeIs(200)
+	recorded.CodeIs(400)
 }
 
 func TestHoldemWebController_BadRequest_EmptyBody(t *testing.T) {

--- a/internal/adapter/controller/OldMaidWebController.go
+++ b/internal/adapter/controller/OldMaidWebController.go
@@ -122,7 +122,7 @@ func (owc *OldMaidWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 	case "d", "draw":
 		owc.writePresenterResponse(w, omi.Draw(drawIdx), errOutput)
 	default:
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusBadRequest)
 		if err := w.WriteJson(owc.newDefaultOutput("Unsupported command.")); err != nil {
 			log.Printf("WriteJson error: %v", err)
 		}

--- a/internal/adapter/controller/OldMaidWebController_test.go
+++ b/internal/adapter/controller/OldMaidWebController_test.go
@@ -121,7 +121,7 @@ func TestOldMaidWebController_Method(t *testing.T) {
 		req := test.MakeSimpleRequest("POST", "http://1.2.3.4/oldmaid/exec", &jsonInput)
 		req.Header.Set("Content-Type", "application/json;charset=UTF-8")
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
-		recorded.CodeIs(http.StatusOK)
+		recorded.CodeIs(http.StatusBadRequest)
 		recorded.ContentTypeIsJson()
 		recorded.BodyIs(`{"players":[],"currentTurn":0,"nextDrawTargetIdx":0,"gameEndFlag":false,"loserIdx":0,"lastDrawPlayerIdx":0,"lastDrawFromIdx":0,"lastDrawCard":null,"lastDiscardedPairs":0,"lastDiscardedCards":null,"hasDrawn":false,"cpuActions":[],"humanAction":null,"cpuHighlightedCardIdx":-1,"removedCard":null,"mode":0,"message":"Unsupported command."}`)
 	})

--- a/internal/adapter/controller/PokerWebController.go
+++ b/internal/adapter/controller/PokerWebController.go
@@ -108,7 +108,7 @@ func (pwc *PokerWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 	case "ck", "check":
 		pwc.writePresenterResponse(w, pi.Check(), errOutput)
 	default:
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusBadRequest)
 		if err := w.WriteJson(pwc.newDefaultOutput("Unsupported command.")); err != nil {
 			log.Printf("WriteJson error: %v", err)
 		}

--- a/internal/adapter/controller/PokerWebController_test.go
+++ b/internal/adapter/controller/PokerWebController_test.go
@@ -206,7 +206,7 @@ func TestPokerWebController_Method(t *testing.T) {
 		req := test.MakeSimpleRequest("POST", "http://1.2.3.4/poker/exec", &jsonInput)
 		req.Header.Set("Content-Type", "application/json;charset=UTF-8")
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
-		recorded.CodeIs(http.StatusOK)
+		recorded.CodeIs(http.StatusBadRequest)
 		recorded.ContentTypeIsJson()
 		recorded.BodyIs(`{"dealer":{"handRank":0,"handName":"","cards":null,"chips":0,"bet":0},"player":{"handRank":0,"handName":"","cards":null,"chips":0,"bet":0},"phase":0,"message":"Unsupported command.","pot":0,"ante":0}`)
 	})

--- a/internal/adapter/controller/SevensWebController.go
+++ b/internal/adapter/controller/SevensWebController.go
@@ -128,7 +128,7 @@ func (swc *SevensWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 	case "j", "joker":
 		swc.writePresenterResponse(w, sgi.PlayJoker(param.Index, param.JokerTargetSuit, param.JokerTargetValue), errOutput)
 	default:
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusBadRequest)
 		if err := w.WriteJson(swc.newDefaultOutput("Unsupported command.")); err != nil {
 			log.Printf("WriteJson error: %v", err)
 		}

--- a/internal/adapter/controller/SevensWebController_test.go
+++ b/internal/adapter/controller/SevensWebController_test.go
@@ -111,7 +111,7 @@ func TestSevensWebController_Method(t *testing.T) {
 		req := test.MakeSimpleRequest("POST", "http://1.2.3.4/sevens/exec", &jsonInput)
 		req.Header.Set("Content-Type", "application/json;charset=UTF-8")
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
-		recorded.CodeIs(http.StatusOK)
+		recorded.CodeIs(http.StatusBadRequest)
 		recorded.ContentTypeIsJson()
 		recorded.BodyIs(`{"players":[],"currentTurn":0,"tableMinVals":[0,0,0,0,0],"tableMaxVals":[0,0,0,0,0],"tablePlaced":[0,0,0,0,0],"config":{"tunnelEnabled":false,"jokerCount":0,"cpuStrategy":false,"maxPasses":0},"gameEndFlag":false,"cpuActions":[],"humanAction":null,"message":"Unsupported command."}`)
 	})

--- a/internal/adapter/controller/web_controller_writejson_internal_test.go
+++ b/internal/adapter/controller/web_controller_writejson_internal_test.go
@@ -73,7 +73,7 @@ func TestBlackJackWebController_WriteJsonErrors(t *testing.T) {
 		fw := newFailWriter()
 		req := makeRestRequest(`{"command": "xyz", "sessionId": "s-bj-unsupported"}`)
 		ctrl2.Exec(fw, req)
-		assert.Equal(t, http.StatusOK, fw.headerCode)
+		assert.Equal(t, http.StatusBadRequest, fw.headerCode)
 	})
 }
 
@@ -125,7 +125,7 @@ func TestPokerWebController_WriteJsonErrors(t *testing.T) {
 		fw := newFailWriter()
 		req := makeRestRequest(`{"command": "xyz", "sessionId": "s-pk-unsupported"}`)
 		ctrl2.Exec(fw, req)
-		assert.Equal(t, http.StatusOK, fw.headerCode)
+		assert.Equal(t, http.StatusBadRequest, fw.headerCode)
 	})
 }
 
@@ -171,7 +171,7 @@ func TestOldMaidWebController_WriteJsonErrors(t *testing.T) {
 		fw := newFailWriter()
 		req := makeRestRequest(`{"command": "xyz", "sessionId": "s-om-unsupported"}`)
 		ctrl2.Exec(fw, req)
-		assert.Equal(t, http.StatusOK, fw.headerCode)
+		assert.Equal(t, http.StatusBadRequest, fw.headerCode)
 	})
 }
 
@@ -222,7 +222,7 @@ func TestDaifugoWebController_WriteJsonErrors(t *testing.T) {
 		fw := newFailWriter()
 		req := makeRestRequest(`{"command": "xyz", "sessionId": "s-dg-unsupported"}`)
 		ctrl2.Exec(fw, req)
-		assert.Equal(t, http.StatusOK, fw.headerCode)
+		assert.Equal(t, http.StatusBadRequest, fw.headerCode)
 	})
 }
 
@@ -274,7 +274,7 @@ func TestSevensWebController_WriteJsonErrors(t *testing.T) {
 		fw := newFailWriter()
 		req := makeRestRequest(`{"command": "xyz", "sessionId": "s-sv-unsupported"}`)
 		ctrl2.Exec(fw, req)
-		assert.Equal(t, http.StatusOK, fw.headerCode)
+		assert.Equal(t, http.StatusBadRequest, fw.headerCode)
 	})
 }
 
@@ -330,7 +330,7 @@ func TestDoubtWebController_WriteJsonErrors(t *testing.T) {
 		fw := newFailWriter()
 		req := makeRestRequest(`{"command": "xyz", "sessionId": "s-dw-unsupported"}`)
 		ctrl2.Exec(fw, req)
-		assert.Equal(t, http.StatusOK, fw.headerCode)
+		assert.Equal(t, http.StatusBadRequest, fw.headerCode)
 	})
 }
 
@@ -381,6 +381,6 @@ func TestHoldemWebController_WriteJsonErrors(t *testing.T) {
 		fw := newFailWriter()
 		req := makeRestRequest(`{"command": "xyz", "sessionId": "s-hm-unsupported"}`)
 		ctrl2.Exec(fw, req)
-		assert.Equal(t, http.StatusOK, fw.headerCode)
+		assert.Equal(t, http.StatusBadRequest, fw.headerCode)
 	})
 }


### PR DESCRIPTION
## Summary
- Change all 7 WebController `default` branches from HTTP 200 to HTTP 400 for unsupported commands
- Update all corresponding tests (external + internal WriteJson error tests) to expect 400
- Update OpenAPI spec 400 response descriptions to include "unsupported command"

Closes #207

## Test plan
- [x] `go test ./internal/adapter/controller/...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)