### PR TITLE
refactor(web): extract exec boilerplate into useGameApi custom hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,7 @@ frontend/                      # React frontend source (Vite + React + TypeScrip
   src/
     api/                       # API client functions (fetch wrappers)
     components/                # Shared React components (NavBar, CardImage, CardBack)
+    hooks/                     # Custom React hooks (useGameApi)
     pages/                     # Game page components (BlackJackPage, PokerPage, OldMaidPage, DaifugoPage)
     types/                     # TypeScript type definitions for card/game data
 public/                        # Built frontend assets served by Go web server

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ frontend/                      # React frontend source (Vite + React + TypeScrip
   src/
     api/                       # API client functions (fetch wrappers for game endpoints)
     components/                # Shared React components (NavBar, CardImage, CardBack)
+    hooks/                     # Custom React hooks (useGameApi)
     pages/                     # Game page components (BlackJackPage, PokerPage, OldMaidPage)
     types/                     # TypeScript type definitions for card/game data
 public/                        # Built frontend assets served by Go web server

--- a/frontend/src/hooks/useGameApi.test.ts
+++ b/frontend/src/hooks/useGameApi.test.ts
@@ -1,0 +1,197 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useGameApi } from './useGameApi';
+
+describe('useGameApi', () => {
+  it('has correct initial state', () => {
+    const apiFn = vi.fn();
+    const { result } = renderHook(() => useGameApi(apiFn));
+    expect(result.current.state).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets state on success', async () => {
+    const apiFn = vi.fn().mockResolvedValue({ value: 42 });
+    const { result } = renderHook(() => useGameApi(apiFn));
+
+    await act(async () => {
+      await result.current.exec('arg1', 'arg2');
+    });
+
+    expect(apiFn).toHaveBeenCalledWith('arg1', 'arg2');
+    expect(result.current.state).toEqual({ value: 42 });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets loading during exec', async () => {
+    let resolve!: (v: unknown) => void;
+    const apiFn = vi.fn().mockReturnValue(
+      new Promise((r) => {
+        resolve = r;
+      }),
+    );
+    const { result } = renderHook(() => useGameApi(apiFn));
+
+    act(() => {
+      result.current.exec();
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    await act(async () => {
+      resolve({ done: true });
+    });
+
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('sets error on failure', async () => {
+    const apiFn = vi.fn().mockRejectedValue(new Error('network'));
+    const { result } = renderHook(() => useGameApi(apiFn));
+
+    await act(async () => {
+      await result.current.exec();
+    });
+
+    expect(result.current.error).toBe('通信エラーが発生しました。もう一度お試しください。');
+    expect(result.current.state).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('clears error on successful retry', async () => {
+    const apiFn = vi.fn().mockRejectedValueOnce(new Error('fail')).mockResolvedValueOnce({ ok: true });
+    const { result } = renderHook(() => useGameApi(apiFn));
+
+    await act(async () => {
+      await result.current.exec();
+    });
+    expect(result.current.error).not.toBeNull();
+
+    await act(async () => {
+      await result.current.exec();
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.state).toEqual({ ok: true });
+  });
+
+  it('calls onSuccess with response', async () => {
+    const apiFn = vi.fn().mockResolvedValue({ data: 'hello' });
+    const onSuccess = vi.fn();
+    const { result } = renderHook(() => useGameApi(apiFn, { onSuccess }));
+
+    await act(async () => {
+      await result.current.exec();
+    });
+
+    expect(onSuccess).toHaveBeenCalledWith({ data: 'hello' });
+  });
+
+  it('works without onSuccess option', async () => {
+    const apiFn = vi.fn().mockResolvedValue({ v: 1 });
+    const { result } = renderHook(() => useGameApi(apiFn));
+
+    await act(async () => {
+      await result.current.exec();
+    });
+
+    expect(result.current.state).toEqual({ v: 1 });
+  });
+
+  it('does not call onSuccess on error', async () => {
+    const apiFn = vi.fn().mockRejectedValue(new Error('err'));
+    const onSuccess = vi.fn();
+    const { result } = renderHook(() => useGameApi(apiFn, { onSuccess }));
+
+    await act(async () => {
+      await result.current.exec();
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('allows direct setState usage', async () => {
+    const apiFn = vi.fn().mockResolvedValue({ init: true });
+    const { result } = renderHook(() => useGameApi(apiFn));
+
+    await act(async () => {
+      await result.current.exec();
+    });
+    expect(result.current.state).toEqual({ init: true });
+
+    act(() => {
+      result.current.setState({ manual: true });
+    });
+    expect(result.current.state).toEqual({ manual: true });
+  });
+
+  it('passes all arguments through to the api function', async () => {
+    const apiFn = vi.fn().mockResolvedValue(null);
+    const { result } = renderHook(() => useGameApi(apiFn));
+
+    await act(async () => {
+      await result.current.exec('cmd', [1, 2], 99);
+    });
+
+    expect(apiFn).toHaveBeenCalledWith('cmd', [1, 2], 99);
+  });
+
+  it('preserves state on error', async () => {
+    const apiFn = vi.fn().mockResolvedValueOnce({ initial: true }).mockRejectedValueOnce(new Error('fail'));
+    const { result } = renderHook(() => useGameApi(apiFn));
+
+    await act(async () => {
+      await result.current.exec();
+    });
+    expect(result.current.state).toEqual({ initial: true });
+
+    await act(async () => {
+      await result.current.exec();
+    });
+    expect(result.current.state).toEqual({ initial: true });
+    expect(result.current.error).not.toBeNull();
+  });
+
+  it('uses latest apiFn via ref', async () => {
+    const apiFn1 = vi.fn().mockResolvedValue({ v: 1 });
+    const apiFn2 = vi.fn().mockResolvedValue({ v: 2 });
+    const { result, rerender } = renderHook(({ fn }) => useGameApi(fn), {
+      initialProps: { fn: apiFn1 },
+    });
+
+    await act(async () => {
+      await result.current.exec();
+    });
+    expect(result.current.state).toEqual({ v: 1 });
+
+    rerender({ fn: apiFn2 });
+
+    await act(async () => {
+      await result.current.exec();
+    });
+    expect(apiFn2).toHaveBeenCalled();
+    expect(result.current.state).toEqual({ v: 2 });
+  });
+
+  it('uses latest onSuccess via ref', async () => {
+    const apiFn = vi.fn().mockResolvedValue({ v: 1 });
+    const onSuccess1 = vi.fn();
+    const onSuccess2 = vi.fn();
+    const { result, rerender } = renderHook(({ cb }) => useGameApi(apiFn, { onSuccess: cb }), {
+      initialProps: { cb: onSuccess1 },
+    });
+
+    await act(async () => {
+      await result.current.exec();
+    });
+    expect(onSuccess1).toHaveBeenCalled();
+
+    rerender({ cb: onSuccess2 });
+
+    await act(async () => {
+      await result.current.exec();
+    });
+    expect(onSuccess2).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useGameApi.ts
+++ b/frontend/src/hooks/useGameApi.ts
@@ -1,0 +1,36 @@
+import { useCallback, useRef, useState } from 'react';
+
+export function useGameApi<TState, TArgs extends unknown[]>(
+  apiFn: (...args: TArgs) => Promise<TState>,
+  options?: { onSuccess?: (res: TState) => void },
+): {
+  state: TState | null;
+  setState: React.Dispatch<React.SetStateAction<TState | null>>;
+  loading: boolean;
+  error: string | null;
+  exec: (...args: TArgs) => Promise<void>;
+} {
+  const [state, setState] = useState<TState | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const apiFnRef = useRef(apiFn);
+  apiFnRef.current = apiFn;
+  const onSuccessRef = useRef(options?.onSuccess);
+  onSuccessRef.current = options?.onSuccess;
+
+  const exec = useCallback(async (...args: TArgs) => {
+    setLoading(true);
+    try {
+      setError(null);
+      const res = await apiFnRef.current(...args);
+      setState(res);
+      onSuccessRef.current?.(res);
+    } catch {
+      setError('通信エラーが発生しました。もう一度お試しください。');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { state, setState, loading, error, exec };
+}

--- a/frontend/src/pages/BlackJackPage.test.tsx
+++ b/frontend/src/pages/BlackJackPage.test.tsx
@@ -111,7 +111,7 @@ beforeEach(() => {
 describe('BlackJackPage', () => {
   it('calls reset command on mount', async () => {
     render(<BlackJackPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
   it('shows chip info bar', async () => {
@@ -132,7 +132,7 @@ describe('BlackJackPage', () => {
 
   it('calls bet command when bet button is clicked', async () => {
     render(<BlackJackPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     mockExec.mockResolvedValue(actionPhaseState);
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
@@ -179,21 +179,21 @@ describe('BlackJackPage', () => {
   it('calls insurance command when insurance button is clicked', async () => {
     mockExec.mockResolvedValue(insurancePhaseState);
     render(<BlackJackPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     mockExec.mockResolvedValue(actionPhaseState);
     fireEvent.click(screen.getByRole('button', { name: 'インシュランス' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('insurance', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('insurance'));
   });
 
   it('calls declineinsurance command when decline button is clicked', async () => {
     mockExec.mockResolvedValue(insurancePhaseState);
     render(<BlackJackPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     mockExec.mockResolvedValue(actionPhaseState);
     fireEvent.click(screen.getByRole('button', { name: '辞退' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('declineinsurance', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('declineinsurance'));
   });
 
   it('shows reset button in end phase', async () => {
@@ -218,21 +218,21 @@ describe('BlackJackPage', () => {
   it('calls hit command when Hit button is clicked', async () => {
     mockExec.mockResolvedValue(actionPhaseState);
     render(<BlackJackPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     mockExec.mockResolvedValue(actionPhaseState);
     fireEvent.click(screen.getByRole('button', { name: 'ヒット' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hit', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hit'));
   });
 
   it('calls stand command when Stand button is clicked', async () => {
     mockExec.mockResolvedValue(actionPhaseState);
     render(<BlackJackPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     mockExec.mockResolvedValue(endPhaseState);
     fireEvent.click(screen.getByRole('button', { name: 'スタンド' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('stand', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('stand'));
   });
 
   it('displays player score and bet', async () => {
@@ -308,7 +308,7 @@ describe('BlackJackPage', () => {
 
   it('shows error message when API call fails', async () => {
     render(<BlackJackPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
 
     mockExec.mockRejectedValueOnce(new Error('network error'));
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
@@ -319,7 +319,7 @@ describe('BlackJackPage', () => {
 
   it('clears error message on successful API call after failure', async () => {
     render(<BlackJackPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
 
     mockExec.mockRejectedValueOnce(new Error('network error'));
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
@@ -438,7 +438,7 @@ describe('BlackJackPage', () => {
 
   it('calls setdeckcount when deck count is changed', async () => {
     render(<BlackJackPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     mockExec.mockResolvedValue(betPhaseState);
     fireEvent.change(screen.getByLabelText('デッキ数:'), { target: { value: '6' } });
@@ -452,11 +452,11 @@ describe('BlackJackPage', () => {
 
   it('calls togglehint when hint toggle button is clicked', async () => {
     render(<BlackJackPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     mockExec.mockResolvedValue(betPhaseState);
     fireEvent.click(screen.getByRole('button', { name: 'ヒント OFF' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('togglehint', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('togglehint'));
   });
 
   it('shows hint button as ON when hintEnabled is true', async () => {
@@ -487,11 +487,11 @@ describe('BlackJackPage', () => {
       hands: [{ ...baseHand, canSurrender: true }],
     });
     render(<BlackJackPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     mockExec.mockResolvedValue(endPhaseState);
     fireEvent.click(screen.getByRole('button', { name: 'サレンダー' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('surrender', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('surrender'));
   });
 
   it('shows hint banner when hint is enabled and action is suggested', async () => {

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { blackjackApi } from '../api/gameApi';
 import { CardBack, CardImage } from '../components/CardImage';
 import { ErrorAlert } from '../components/ErrorAlert';
+import { useGameApi } from '../hooks/useGameApi';
 import { btnDanger, btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import type { BlackJackResponse } from '../types/card';
 import { BjPhase } from '../types/phases';
@@ -31,42 +32,13 @@ function highlightClass(base: string, isHighlighted: boolean): string {
 }
 
 export function BlackJackPage() {
-  const [state, setState] = useState<BlackJackResponse | null>(null);
   const [message, setMessage] = useState('');
   const [betAmount, setBetAmount] = useState(10);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
-  const exec = useCallback(
-    async (
-      command:
-        | 'reset'
-        | 'hit'
-        | 'stand'
-        | 'bet'
-        | 'doubledown'
-        | 'split'
-        | 'insurance'
-        | 'declineinsurance'
-        | 'surrender'
-        | 'togglehint'
-        | 'setdeckcount',
-      amount?: number,
-    ) => {
-      setLoading(true);
-      try {
-        setError(null);
-        const res = await blackjackApi.exec(command, amount);
-        setState(res);
-        setMessage(res.message);
-      } catch {
-        setError('通信エラーが発生しました。もう一度お試しください。');
-      } finally {
-        setLoading(false);
-      }
-    },
-    [],
-  );
+  const onSuccess = useCallback((res: BlackJackResponse) => {
+    setMessage(res.message);
+  }, []);
+  const { state, loading, error, exec } = useGameApi(blackjackApi.exec, { onSuccess });
 
   useEffect(() => {
     exec('reset');

--- a/frontend/src/pages/DaifugoPage.test.tsx
+++ b/frontend/src/pages/DaifugoPage.test.tsx
@@ -96,7 +96,7 @@ describe('DaifugoPage', () => {
 
   it('calls reset command on mount', async () => {
     render(<DaifugoPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
   it('renders human player area labeled あなた', async () => {
@@ -180,7 +180,7 @@ describe('DaifugoPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(cpuTurnState);
     fireEvent.click(screen.getByRole('button', { name: 'パス' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', [], undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', []));
   });
 
   it('selects a card on click and enables play button', async () => {
@@ -198,7 +198,7 @@ describe('DaifugoPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(cpuTurnState);
     fireEvent.click(screen.getByRole('button', { name: '選択して出す' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', [0], undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', [0]));
   });
 
   it('shows human action log after play', async () => {
@@ -576,7 +576,7 @@ describe('DaifugoPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(cpuTurnState);
     fireEvent(dropZone, dropEvent);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', [0], undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', [0]));
   });
 
   it('drop on table plays selected cards when dragged card is in selection', async () => {
@@ -598,7 +598,7 @@ describe('DaifugoPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(cpuTurnState);
     fireEvent(dropZone, dropEvent);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', [0, 1], undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', [0, 1]));
   });
 
   it('drop with invalid dataTransfer data is ignored (NaN guard)', async () => {

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { daifugoApi } from '../api/gameApi';
 import { CardImage } from '../components/CardImage';
 import { ErrorAlert } from '../components/ErrorAlert';
+import { useGameApi } from '../hooks/useGameApi';
 import { btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import type {
   Card,
@@ -288,25 +289,13 @@ const defaultConfigInput: DaifugoConfigInput = {
 };
 
 export function DaifugoPage() {
-  const [state, setState] = useState<DaifugoResponse | null>(null);
   const [selectedIndices, setSelectedIndices] = useState<number[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [configInput, setConfigInput] = useState<DaifugoConfigInput>(defaultConfigInput);
 
-  const exec = useCallback(async (command: 'reset' | 'play', indices?: number[], config?: DaifugoConfigInput) => {
-    setLoading(true);
-    try {
-      setError(null);
-      const res = await daifugoApi.exec(command, indices, config);
-      setState(res);
-      setSelectedIndices([]);
-    } catch {
-      setError('通信エラーが発生しました。もう一度お試しください。');
-    } finally {
-      setLoading(false);
-    }
+  const onSuccess = useCallback(() => {
+    setSelectedIndices([]);
   }, []);
+  const { state, loading, error, exec } = useGameApi(daifugoApi.exec, { onSuccess });
 
   useEffect(() => {
     exec('reset');

--- a/frontend/src/pages/DoubtPage.test.tsx
+++ b/frontend/src/pages/DoubtPage.test.tsx
@@ -212,7 +212,7 @@ describe('DoubtPage', () => {
     mockExec.mockResolvedValue(cpuTurnState);
     fireEvent.click(screen.getByRole('button', { name: '出す' }));
 
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', [0], 1, undefined, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', [0], 1));
   });
 
   it('calls reset when reset button is clicked', async () => {
@@ -385,7 +385,7 @@ describe('DoubtPage', () => {
     mockExec.mockResolvedValue(humanTurnState);
     fireEvent.click(screen.getByRole('button', { name: 'ダウト！' }));
 
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('doubt', undefined, undefined, [0], undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('doubt', undefined, undefined, [0]));
   });
 
   it('calls skip with [] when スルー clicked (no cpu doubters)', async () => {
@@ -397,7 +397,7 @@ describe('DoubtPage', () => {
     mockExec.mockResolvedValue(humanTurnState);
     fireEvent.click(screen.getByRole('button', { name: 'スルー' }));
 
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('skip', undefined, undefined, [], undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('skip', undefined, undefined, []));
   });
 
   it('calls doubt with [0, ...cpuDoubters] when ダウト！ clicked with cpu doubters', async () => {
@@ -410,7 +410,7 @@ describe('DoubtPage', () => {
     mockExec.mockResolvedValue(humanTurnState);
     fireEvent.click(screen.getByRole('button', { name: 'ダウト！' }));
 
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('doubt', undefined, undefined, [0, 2, 3], undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('doubt', undefined, undefined, [0, 2, 3]));
   });
 
   // ── Doubt phase: human played ─────────────────────────────────────────────
@@ -447,7 +447,7 @@ describe('DoubtPage', () => {
     mockExec.mockResolvedValue(humanTurnState);
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
 
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('doubt', undefined, undefined, [1, 2], undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('doubt', undefined, undefined, [1, 2]));
   });
 
   // ── Doubt phase suppressed when gameEndFlag ───────────────────────────────
@@ -506,7 +506,7 @@ describe('DoubtPage', () => {
 
       // Auto-skip is called with the correct doubters
       await waitFor(() => {
-        expect(mockExec).toHaveBeenCalledWith('skip', undefined, undefined, [], undefined);
+        expect(mockExec).toHaveBeenCalledWith('skip', undefined, undefined, []);
       });
     });
 

--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -2,8 +2,9 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { doubtApi } from '../api/gameApi';
 import { CardImage } from '../components/CardImage';
 import { ErrorAlert } from '../components/ErrorAlert';
+import { useGameApi } from '../hooks/useGameApi';
 import { btnDanger, btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
-import type { Card, DoubtConfig, DoubtCpuAction, DoubtPlayerData, DoubtResponse } from '../types/card';
+import type { Card, DoubtConfig, DoubtCpuAction, DoubtPlayerData } from '../types/card';
 import { playerName } from '../utils/playerUtils';
 
 function valueName(v: number): string {
@@ -125,16 +126,19 @@ const CPU_MEMORY_OPTIONS = [
 ] as const;
 
 export function DoubtPage() {
-  const [state, setState] = useState<DoubtResponse | null>(null);
   const [selectedCardIndices, setSelectedCardIndices] = useState<number[]>([]);
   const [claimedValue, setClaimedValue] = useState(1);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [countdown, setCountdown] = useState<number | null>(null);
   const [doubtConfig, setDoubtConfig] = useState<DoubtConfig>(DEFAULT_DOUBT_CONFIG);
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const autoSkipRef = useRef(false);
   const cpuDoubtersRef = useRef<number[]>([]);
+
+  const onSuccess = useCallback(() => {
+    setSelectedCardIndices([]);
+    setClaimedValue(1);
+  }, []);
+  const { state, loading, error, exec: rawExec } = useGameApi(doubtApi.exec, { onSuccess });
 
   // Keep cpuDoubters ref current so the auto-skip effect avoids stale state
   useEffect(() => {
@@ -171,28 +175,11 @@ export function DoubtPage() {
   );
 
   const exec = useCallback(
-    async (
-      command: 'reset' | 'play' | 'doubt' | 'skip',
-      cardIndices?: number[],
-      cv?: number,
-      doubterIndices?: number[],
-      config?: DoubtConfig,
-    ) => {
-      setLoading(true);
+    (...args: Parameters<typeof rawExec>) => {
       stopCountdown();
-      try {
-        setError(null);
-        const res = await doubtApi.exec(command, cardIndices, cv, doubterIndices, config);
-        setState(res);
-        setSelectedCardIndices([]);
-        setClaimedValue(1);
-      } catch {
-        setError('通信エラーが発生しました。もう一度お試しください。');
-      } finally {
-        setLoading(false);
-      }
+      return rawExec(...args);
     },
-    [stopCountdown],
+    [rawExec, stopCountdown],
   );
 
   const handleConfigChange = useCallback((key: keyof DoubtConfig, value: string) => {

--- a/frontend/src/pages/HoldemPage.test.tsx
+++ b/frontend/src/pages/HoldemPage.test.tsx
@@ -152,7 +152,7 @@ describe('HoldemPage', () => {
   // ---- mount & reset ----
   it('calls reset on mount', async () => {
     render(<HoldemPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
   // ---- phase name display ----
@@ -598,7 +598,7 @@ describe('HoldemPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(preFlopState);
     fireEvent.click(screen.getByRole('button', { name: 'チェック' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('check', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('check'));
   });
 
   it('calls fold command', async () => {
@@ -609,7 +609,7 @@ describe('HoldemPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(preFlopState);
     fireEvent.click(screen.getByRole('button', { name: 'フォールド' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('fold', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('fold'));
   });
 
   it('calls allin command', async () => {
@@ -620,7 +620,7 @@ describe('HoldemPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(preFlopState);
     fireEvent.click(screen.getByRole('button', { name: 'オールイン' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('allin', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('allin'));
   });
 
   it('calls call command when has outstanding bet', async () => {
@@ -631,7 +631,7 @@ describe('HoldemPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(preFlopState);
     fireEvent.click(screen.getByRole('button', { name: 'コール' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('call', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('call'));
   });
 
   it('calls raise command with betAmount when has outstanding bet', async () => {
@@ -647,12 +647,12 @@ describe('HoldemPage', () => {
 
   it('calls reset command when reset button is clicked', async () => {
     render(<HoldemPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
 
     mockExec.mockClear();
     mockExec.mockResolvedValue(initState);
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
   // ---- loading / disabled state ----
@@ -681,7 +681,7 @@ describe('HoldemPage', () => {
   // ---- error handling ----
   it('shows error message when API call fails', async () => {
     render(<HoldemPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
 
     mockExec.mockRejectedValueOnce(new Error('network error'));
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
@@ -692,7 +692,7 @@ describe('HoldemPage', () => {
 
   it('clears error on successful call after failure', async () => {
     render(<HoldemPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
 
     mockExec.mockRejectedValueOnce(new Error('network error'));
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { holdemApi } from '../api/gameApi';
 import { CardBack, CardImage } from '../components/CardImage';
 import { ErrorAlert } from '../components/ErrorAlert';
+import { useGameApi } from '../hooks/useGameApi';
 import { btnDanger, btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
-import type { HoldemResponse } from '../types/card';
+
 import { HoldemAction, HoldemPhase } from '../types/phases';
 
 const ACTION_NAMES: Record<number, string> = {
@@ -25,26 +26,8 @@ const PHASE_NAMES: Record<number, string> = {
 };
 
 export function HoldemPage() {
-  const [state, setState] = useState<HoldemResponse | null>(null);
+  const { state, loading, error, exec } = useGameApi(holdemApi.exec);
   const [betAmount, setBetAmount] = useState(20);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const exec = useCallback(
-    async (command: 'reset' | 'fold' | 'check' | 'call' | 'bet' | 'raise' | 'allin', amount?: number) => {
-      setLoading(true);
-      try {
-        setError(null);
-        const res = await holdemApi.exec(command, amount);
-        setState(res);
-      } catch {
-        setError('通信エラーが発生しました。もう一度お試しください。');
-      } finally {
-        setLoading(false);
-      }
-    },
-    [],
-  );
 
   useEffect(() => {
     exec('reset');

--- a/frontend/src/pages/PokerPage.test.tsx
+++ b/frontend/src/pages/PokerPage.test.tsx
@@ -122,7 +122,7 @@ beforeEach(() => {
 describe('PokerPage', () => {
   it('calls reset command on mount', async () => {
     render(<PokerPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
   it('renders dealer and player section labels', async () => {
@@ -207,7 +207,7 @@ describe('PokerPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue({ ...phase2State, phase: 3 });
     fireEvent.click(screen.getByRole('button', { name: '交換' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('exchange', expect.arrayContaining([0, 1]), undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('exchange', expect.arrayContaining([0, 1])));
   });
 
   it('calls stand command when stand button is clicked in phase 2', async () => {
@@ -218,16 +218,16 @@ describe('PokerPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(phase4State);
     fireEvent.click(screen.getByRole('button', { name: 'スタンド' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('stand', undefined, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('stand'));
   });
 
   it('calls reset command when reset button is clicked', async () => {
     render(<PokerPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
     mockExec.mockResolvedValue(phase0State);
     fireEvent.click(screen.getByText('リセット'));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
   it('shows instruction text in phase 2', async () => {
@@ -255,7 +255,7 @@ describe('PokerPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(phase2State);
     fireEvent.click(screen.getByRole('button', { name: 'チェック' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('check', undefined, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('check'));
   });
 
   it('calls fold command', async () => {
@@ -266,7 +266,7 @@ describe('PokerPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(phase4State);
     fireEvent.click(screen.getByRole('button', { name: 'フォールド' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('fold', undefined, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('fold'));
   });
 
   it('calls call command when dealer has bet', async () => {
@@ -277,7 +277,7 @@ describe('PokerPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(phase2State);
     fireEvent.click(screen.getByRole('button', { name: 'コール' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('call', undefined, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('call'));
   });
 
   it('calls raise command with amount when dealer has bet', async () => {
@@ -320,7 +320,7 @@ describe('PokerPage', () => {
 
   it('shows error message when API call fails', async () => {
     render(<PokerPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
 
     mockExec.mockRejectedValueOnce(new Error('network error'));
     fireEvent.click(screen.getByText('リセット'));
@@ -331,7 +331,7 @@ describe('PokerPage', () => {
 
   it('clears error message on successful API call after failure', async () => {
     render(<PokerPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
 
     mockExec.mockRejectedValueOnce(new Error('network error'));
     fireEvent.click(screen.getByText('リセット'));

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -2,8 +2,9 @@ import { useCallback, useEffect, useState } from 'react';
 import { pokerApi } from '../api/gameApi';
 import { CardBack, CardImage } from '../components/CardImage';
 import { ErrorAlert } from '../components/ErrorAlert';
+import { useGameApi } from '../hooks/useGameApi';
 import { btnDanger, btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
-import type { PokerResponse } from '../types/card';
+
 import { PokerPhase } from '../types/phases';
 
 const cardWrapBase: React.CSSProperties = {
@@ -16,32 +17,13 @@ const cardWrapBase: React.CSSProperties = {
 };
 
 export function PokerPage() {
-  const [state, setState] = useState<PokerResponse | null>(null);
   const [selected, setSelected] = useState<number[]>([]);
   const [betAmount, setBetAmount] = useState(10);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
-  const exec = useCallback(
-    async (
-      command: 'reset' | 'exchange' | 'stand' | 'bet' | 'call' | 'raise' | 'fold' | 'check',
-      indices?: number[],
-      amount?: number,
-    ) => {
-      setLoading(true);
-      try {
-        setError(null);
-        const res = await pokerApi.exec(command, indices, amount);
-        setState(res);
-        setSelected([]);
-      } catch {
-        setError('通信エラーが発生しました。もう一度お試しください。');
-      } finally {
-        setLoading(false);
-      }
-    },
-    [],
-  );
+  const onSuccess = useCallback(() => {
+    setSelected([]);
+  }, []);
+  const { state, loading, error, exec } = useGameApi(pokerApi.exec, { onSuccess });
 
   useEffect(() => {
     exec('reset');

--- a/frontend/src/pages/SevensPage.test.tsx
+++ b/frontend/src/pages/SevensPage.test.tsx
@@ -86,7 +86,7 @@ describe('SevensPage', () => {
 
   it('calls reset command on mount', async () => {
     render(<SevensPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', -1, 0, 0, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
   it('renders human player area labeled あなた', async () => {
@@ -146,7 +146,7 @@ describe('SevensPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(cpuTurnState);
     fireEvent.click(screen.getByRole('button', { name: 'パス' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', -1, 0, 0, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', -1));
   });
 
   it('calls play with card index when a playable card is clicked', async () => {
@@ -155,7 +155,7 @@ describe('SevensPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(cpuTurnState);
     fireEvent.click(screen.getByAltText('SPADE 6'));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', 0, 0, 0, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', 0));
   });
 
   it('does not call play when a non-playable card is clicked', async () => {
@@ -549,8 +549,8 @@ describe('SevensPage', () => {
     mockExec.mockResolvedValue(humanTurnState);
     fireEvent.click(boardButtons6[0]);
 
-    // exec is called as: sevensApi.exec('joker', 0, suit, 6, undefined)
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('joker', 0, expect.any(Number), 6, undefined));
+    // exec is called as: sevensApi.exec('joker', 0, suit, 6)
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('joker', 0, expect.any(Number), 6));
   }, 10000);
 
   it('shows rank badge when human player finishes', async () => {

--- a/frontend/src/pages/SevensPage.tsx
+++ b/frontend/src/pages/SevensPage.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
-import type { SevensConfigInput } from '../api/gameApi';
 import { sevensApi } from '../api/gameApi';
 import { CardImage } from '../components/CardImage';
 import { ErrorAlert } from '../components/ErrorAlert';
+import { useGameApi } from '../hooks/useGameApi';
 import { btnPrimary, btnWarning } from '../styles/buttonStyles';
 import type { Card, CardDesign, SevensAction, SevensPlayerData, SevensResponse } from '../types/card';
 import { findPlayerName, playerName } from '../utils/playerUtils';
@@ -281,35 +281,20 @@ function HumanArea({ player, isCurrentTurn, tablePlaced, tunnelEnabled, loading,
 // ── Main page ────────────────────────────────────────────────────────────────
 
 export function SevensPage() {
-  const [state, setState] = useState<SevensResponse | null>(null);
   const [jokerCardIdx, setJokerCardIdx] = useState<number | null>(null);
   const [cfgTunnel, setCfgTunnel] = useState(false);
   const [cfgJokerCount, setCfgJokerCount] = useState(0);
   const [cfgCpuStrategy, setCfgCpuStrategy] = useState(false);
   const [cfgMaxPasses, setCfgMaxPasses] = useState(5);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
-  const exec = useCallback(
-    async (command: 'reset' | 'play' | 'joker', index = -1, suit = 0, value = 0, config?: SevensConfigInput) => {
-      setLoading(true);
-      try {
-        setError(null);
-        const res = await sevensApi.exec(command, index, suit, value, config);
-        setState(res);
-        setJokerCardIdx(null);
-        setCfgTunnel(res.config.tunnelEnabled);
-        setCfgJokerCount(res.config.jokerCount);
-        setCfgCpuStrategy(res.config.cpuStrategy);
-        setCfgMaxPasses(res.config.maxPasses);
-      } catch {
-        setError('通信エラーが発生しました。もう一度お試しください。');
-      } finally {
-        setLoading(false);
-      }
-    },
-    [],
-  );
+  const onSuccess = useCallback((res: SevensResponse) => {
+    setJokerCardIdx(null);
+    setCfgTunnel(res.config.tunnelEnabled);
+    setCfgJokerCount(res.config.jokerCount);
+    setCfgCpuStrategy(res.config.cpuStrategy);
+    setCfgMaxPasses(res.config.maxPasses);
+  }, []);
+  const { state, loading, error, exec } = useGameApi(sevensApi.exec, { onSuccess });
 
   useEffect(() => {
     exec('reset');


### PR DESCRIPTION
## Summary
- Extract shared `state`/`loading`/`error`/`exec` management from 6 game pages into a reusable `useGameApi` custom hook (`frontend/src/hooks/useGameApi.ts`)
- Refactor BlackJackPage, PokerPage, DaifugoPage, SevensPage, DoubtPage, and HoldemPage to use the hook, reducing ~100 lines of duplicated boilerplate
- OldMaidPage excluded — its exec uses async animation replay with multiple `setDisplayState` calls and `await delay()`, making it structurally incompatible with the shared hook pattern
- Update CLAUDE.md and AGENTS.md to document the new `hooks/` directory

Closes #213

## Test plan
- [x] `npm run build` passes
- [x] `npm run check` passes (Biome lint + format)
- [x] `npm test` — all 459 tests pass
- [x] `npm run test:coverage` — `hooks/useGameApi.ts` has 100% branch coverage
- [x] All 6 refactored page test suites pass without changes to observable behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)