### PR TITLE
refactor(infrastructure): add graceful shutdown to web server

### DIFF
--- a/internal/adapter/controller/BlackJackWebController.go
+++ b/internal/adapter/controller/BlackJackWebController.go
@@ -127,6 +127,11 @@ func (bwc *BlackJackWebController) Exec(w rest.ResponseWriter, r *rest.Request) 
 	}
 }
 
+// Stop stops the background cleanup goroutine of the session store.
+func (bwc *BlackJackWebController) Stop() {
+	bwc.store.Stop()
+}
+
 // newDefaultOutput エラー・定型応答用のデフォルト出力を返す
 func (bwc *BlackJackWebController) newDefaultOutput(msg string) *BlackJackWebOutput {
 	return &BlackJackWebOutput{

--- a/internal/adapter/controller/BlackJackWebController_test.go
+++ b/internal/adapter/controller/BlackJackWebController_test.go
@@ -27,6 +27,7 @@ func TestBlackJackWebController_Method(t *testing.T) {
 	bjiMock.On("DeclineInsurance").Return(mockOutput)
 	factory := func() uc.BlackJackInteractorIF { return bjiMock }
 	tbc := controller.NewBlackJackWebController(factory)
+	defer tbc.Stop()
 
 	api := rest.NewApi()
 	router, _ := rest.MakeRouter(
@@ -199,6 +200,7 @@ func TestBlackJackWebController_SessionIsolation(t *testing.T) {
 		}
 		return mockB
 	})
+	defer isoController.Stop()
 
 	api := rest.NewApi()
 	router, _ := rest.MakeRouter(
@@ -249,6 +251,7 @@ func TestBlackJackWebController_NewCommands(t *testing.T) {
 	bjiMock.On("SetDeckCount", 6).Return(mockOutput)
 	factory := func() uc.BlackJackInteractorIF { return bjiMock }
 	tbc := controller.NewBlackJackWebController(factory)
+	defer tbc.Stop()
 
 	api := rest.NewApi()
 	router, _ := rest.MakeRouter(rest.Post("/blackjack/exec", tbc.Exec))
@@ -294,4 +297,13 @@ func TestBlackJackWebController_NewCommands(t *testing.T) {
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
 		recorded.CodeIs(http.StatusOK)
 	})
+}
+
+func TestBlackJackWebController_Stop(t *testing.T) {
+	bjiMock := new(usecase.MockBlackJackInteractor)
+	factory := func() uc.BlackJackInteractorIF { return bjiMock }
+	c := controller.NewBlackJackWebController(factory)
+	// Stop should be idempotent and not panic when called multiple times.
+	c.Stop()
+	c.Stop()
 }

--- a/internal/adapter/controller/DaifugoWebController.go
+++ b/internal/adapter/controller/DaifugoWebController.go
@@ -175,6 +175,11 @@ func convertWebInputConfig(c DaifugoWebInputConfig) domain.DaifugoConfig {
 	}
 }
 
+// Stop stops the background cleanup goroutine of the session store.
+func (dwc *DaifugoWebController) Stop() {
+	dwc.store.Stop()
+}
+
 // newDefaultOutput エラー・定型応答用のデフォルト出力を返す
 func (dwc *DaifugoWebController) newDefaultOutput(msg string) *DaifugoWebOutput {
 	return &DaifugoWebOutput{

--- a/internal/adapter/controller/DaifugoWebController_test.go
+++ b/internal/adapter/controller/DaifugoWebController_test.go
@@ -24,6 +24,7 @@ func TestDaifugoWebController_Method(t *testing.T) {
 
 	factory := func() uc.DaifugoInteractorIF { return dgiMock }
 	tdwc := controller.NewDaifugoWebController(factory)
+	defer tdwc.Stop()
 
 	api := rest.NewApi()
 	router, _ := rest.MakeRouter(
@@ -172,6 +173,7 @@ func TestDaifugoWebController_SessionIsolation(t *testing.T) {
 		}
 		return mockB
 	})
+	defer isoController.Stop()
 
 	api := rest.NewApi()
 	router, _ := rest.MakeRouter(
@@ -211,4 +213,12 @@ func TestDaifugoWebController_SessionIsolation(t *testing.T) {
 			t.Errorf("expected factory to be called 2 times, got %d", callCount)
 		}
 	})
+}
+
+func TestDaifugoWebController_Stop(t *testing.T) {
+	dgiMock := new(usecase.MockDaifugoInteractor)
+	factory := func() uc.DaifugoInteractorIF { return dgiMock }
+	c := controller.NewDaifugoWebController(factory)
+	c.Stop()
+	c.Stop()
 }

--- a/internal/adapter/controller/DoubtWebController.go
+++ b/internal/adapter/controller/DoubtWebController.go
@@ -166,6 +166,11 @@ func (dwc *DoubtWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 	}
 }
 
+// Stop stops the background cleanup goroutine of the session store.
+func (dwc *DoubtWebController) Stop() {
+	dwc.store.Stop()
+}
+
 // newDefaultOutput エラー・定型応答用のデフォルト出力を返す
 func (dwc *DoubtWebController) newDefaultOutput(msg string) *DoubtWebOutput {
 	return &DoubtWebOutput{

--- a/internal/adapter/controller/DoubtWebController_test.go
+++ b/internal/adapter/controller/DoubtWebController_test.go
@@ -48,6 +48,7 @@ func TestDoubtWebController_Method(t *testing.T) {
 
 	factory := func() uc.DoubtInteractorIF { return dgiMock }
 	tdwc := controller.NewDoubtWebController(factory)
+	defer tdwc.Stop()
 
 	api := rest.NewApi()
 	router, _ := rest.MakeRouter(
@@ -189,7 +190,6 @@ func TestDoubtWebController_Method(t *testing.T) {
 		recorded.BodyIs(mustDoubtOutputJSON("param error."))
 	})
 
-
 	claimedValueErrBody := mustDoubtOutputJSON(fmt.Sprintf(
 		"param error: claimedValue must be between %d and %d.",
 		domain.MinClaimedValue, domain.MaxClaimedValue,
@@ -258,6 +258,7 @@ func TestDoubtWebController_ResetEmptyResponse(t *testing.T) {
 
 	factory := func() uc.DoubtInteractorIF { return dgiMock }
 	tdwc := controller.NewDoubtWebController(factory)
+	defer tdwc.Stop()
 	api := rest.NewApi()
 	router, _ := rest.MakeRouter(rest.Post("/doubt/exec", tdwc.Exec))
 	api.SetApp(router)
@@ -283,6 +284,7 @@ func TestDoubtWebController_SkipWithCpuDoubters(t *testing.T) {
 
 	factory := func() uc.DoubtInteractorIF { return dgiMock }
 	tdwc := controller.NewDoubtWebController(factory)
+	defer tdwc.Stop()
 
 	api := rest.NewApi()
 	router, _ := rest.MakeRouter(
@@ -319,6 +321,7 @@ func TestDoubtWebController_SessionIsolation(t *testing.T) {
 		}
 		return mockB
 	})
+	defer isoController.Stop()
 
 	api := rest.NewApi()
 	router, _ := rest.MakeRouter(
@@ -372,6 +375,7 @@ func TestDoubtWebController_ResetWithConfig(t *testing.T) {
 
 		factory := func() uc.DoubtInteractorIF { return dgiMock }
 		ctrl := controller.NewDoubtWebController(factory)
+		defer ctrl.Stop()
 		api := rest.NewApi()
 		router, _ := rest.MakeRouter(rest.Post("/doubt/exec", ctrl.Exec))
 		api.SetApp(router)
@@ -398,6 +402,7 @@ func TestDoubtWebController_ResetWithConfig(t *testing.T) {
 
 		factory := func() uc.DoubtInteractorIF { return dgiMock }
 		ctrl := controller.NewDoubtWebController(factory)
+		defer ctrl.Stop()
 		api := rest.NewApi()
 		router, _ := rest.MakeRouter(rest.Post("/doubt/exec", ctrl.Exec))
 		api.SetApp(router)
@@ -424,6 +429,7 @@ func TestDoubtWebController_ResetWithConfig(t *testing.T) {
 
 		factory := func() uc.DoubtInteractorIF { return dgiMock }
 		ctrl := controller.NewDoubtWebController(factory)
+		defer ctrl.Stop()
 		api := rest.NewApi()
 		router, _ := rest.MakeRouter(rest.Post("/doubt/exec", ctrl.Exec))
 		api.SetApp(router)
@@ -450,6 +456,7 @@ func TestDoubtWebController_ResetWithConfig(t *testing.T) {
 
 		factory := func() uc.DoubtInteractorIF { return dgiMock }
 		ctrl := controller.NewDoubtWebController(factory)
+		defer ctrl.Stop()
 		api := rest.NewApi()
 		router, _ := rest.MakeRouter(rest.Post("/doubt/exec", ctrl.Exec))
 		api.SetApp(router)
@@ -466,4 +473,12 @@ func TestDoubtWebController_ResetWithConfig(t *testing.T) {
 		recorded.CodeIs(http.StatusOK)
 		dgiMock.AssertCalled(t, "ResetWithConfig", expected)
 	})
+}
+
+func TestDoubtWebController_Stop(t *testing.T) {
+	dgiMock := new(usecase.MockDoubtInteractor)
+	factory := func() uc.DoubtInteractorIF { return dgiMock }
+	c := controller.NewDoubtWebController(factory)
+	c.Stop()
+	c.Stop()
 }

--- a/internal/adapter/controller/HoldemWebController.go
+++ b/internal/adapter/controller/HoldemWebController.go
@@ -168,6 +168,11 @@ func (hwc *HoldemWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 	}
 }
 
+// Stop stops the background cleanup goroutine of the session store.
+func (hwc *HoldemWebController) Stop() {
+	hwc.store.Stop()
+}
+
 // newDefaultOutput エラー・定型応答用のデフォルト出力を返す
 func (hwc *HoldemWebController) newDefaultOutput(msg string) *HoldemWebOutput {
 	return &HoldemWebOutput{

--- a/internal/adapter/controller/HoldemWebController_test.go
+++ b/internal/adapter/controller/HoldemWebController_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-func newHoldemTestHandler(mi *mockUsecase.MockHoldemInteractor) *rest.Api {
+func newHoldemTestHandler(mi *mockUsecase.MockHoldemInteractor) (*rest.Api, *HoldemWebController) {
 	api := rest.NewApi()
 	api.Use(rest.DefaultDevStack...)
 	hwc := NewHoldemWebController(func() usecase.HoldemInteractorIF {
@@ -21,12 +21,13 @@ func newHoldemTestHandler(mi *mockUsecase.MockHoldemInteractor) *rest.Api {
 		rest.Post("/holdem/exec", hwc.Exec),
 	)
 	api.SetApp(router)
-	return api
+	return api, hwc
 }
 
 func TestHoldemWebController_Reset(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 
 	cfg := domain.DefaultHoldemConfig()
 	mi.On("ResetWithConfig", cfg).Return(`{"phase":1,"message":""}`)
@@ -42,7 +43,8 @@ func TestHoldemWebController_Reset(t *testing.T) {
 
 func TestHoldemWebController_Reset_WithConfig(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 
 	sb := 10
 	bb := 20
@@ -64,7 +66,8 @@ func TestHoldemWebController_Reset_WithConfig(t *testing.T) {
 
 func TestHoldemWebController_Fold(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 
 	mi.On("Action", domain.HoldemActionFold, 0).Return(`{"phase":1}`)
 
@@ -79,7 +82,8 @@ func TestHoldemWebController_Fold(t *testing.T) {
 
 func TestHoldemWebController_Check(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 	mi.On("Action", domain.HoldemActionCheck, 0).Return(`{"phase":1}`)
 	recorded := test.RunRequest(t, api.MakeHandler(),
 		test.MakeSimpleRequest("POST", "http://localhost/holdem/exec",
@@ -89,7 +93,8 @@ func TestHoldemWebController_Check(t *testing.T) {
 
 func TestHoldemWebController_Call(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 	mi.On("Action", domain.HoldemActionCall, 0).Return(`{"phase":1}`)
 	recorded := test.RunRequest(t, api.MakeHandler(),
 		test.MakeSimpleRequest("POST", "http://localhost/holdem/exec",
@@ -99,7 +104,8 @@ func TestHoldemWebController_Call(t *testing.T) {
 
 func TestHoldemWebController_Bet(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 	mi.On("Action", domain.HoldemActionBet, 50).Return(`{"phase":1}`)
 	recorded := test.RunRequest(t, api.MakeHandler(),
 		test.MakeSimpleRequest("POST", "http://localhost/holdem/exec",
@@ -109,7 +115,8 @@ func TestHoldemWebController_Bet(t *testing.T) {
 
 func TestHoldemWebController_Raise(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 	mi.On("Action", domain.HoldemActionRaise, 30).Return(`{"phase":1}`)
 	recorded := test.RunRequest(t, api.MakeHandler(),
 		test.MakeSimpleRequest("POST", "http://localhost/holdem/exec",
@@ -119,7 +126,8 @@ func TestHoldemWebController_Raise(t *testing.T) {
 
 func TestHoldemWebController_AllIn(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 	mi.On("Action", domain.HoldemActionAllIn, 0).Return(`{"phase":1}`)
 	recorded := test.RunRequest(t, api.MakeHandler(),
 		test.MakeSimpleRequest("POST", "http://localhost/holdem/exec",
@@ -129,7 +137,8 @@ func TestHoldemWebController_AllIn(t *testing.T) {
 
 func TestHoldemWebController_Quit(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 	recorded := test.RunRequest(t, api.MakeHandler(),
 		test.MakeSimpleRequest("POST", "http://localhost/holdem/exec",
 			map[string]interface{}{"command": "quit", "sessionId": "s1"}))
@@ -138,7 +147,8 @@ func TestHoldemWebController_Quit(t *testing.T) {
 
 func TestHoldemWebController_QuitShort(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 	recorded := test.RunRequest(t, api.MakeHandler(),
 		test.MakeSimpleRequest("POST", "http://localhost/holdem/exec",
 			map[string]interface{}{"command": "q", "sessionId": "s1"}))
@@ -147,7 +157,8 @@ func TestHoldemWebController_QuitShort(t *testing.T) {
 
 func TestHoldemWebController_Unknown(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 	// Must have a session first
 	cfg := domain.DefaultHoldemConfig()
 	mi.On("ResetWithConfig", cfg).Return(`{"phase":1}`)
@@ -163,7 +174,8 @@ func TestHoldemWebController_Unknown(t *testing.T) {
 
 func TestHoldemWebController_BadRequest_EmptyBody(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 	recorded := test.RunRequest(t, api.MakeHandler(),
 		test.MakeSimpleRequest("POST", "http://localhost/holdem/exec", nil))
 	recorded.CodeIs(400)
@@ -171,7 +183,8 @@ func TestHoldemWebController_BadRequest_EmptyBody(t *testing.T) {
 
 func TestHoldemWebController_BadRequest_NoCommand(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 	recorded := test.RunRequest(t, api.MakeHandler(),
 		test.MakeSimpleRequest("POST", "http://localhost/holdem/exec",
 			map[string]interface{}{"sessionId": "s1"}))
@@ -180,7 +193,8 @@ func TestHoldemWebController_BadRequest_NoCommand(t *testing.T) {
 
 func TestHoldemWebController_BadRequest_NoSession(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 	recorded := test.RunRequest(t, api.MakeHandler(),
 		test.MakeSimpleRequest("POST", "http://localhost/holdem/exec",
 			map[string]interface{}{"command": "reset"}))
@@ -189,7 +203,8 @@ func TestHoldemWebController_BadRequest_NoSession(t *testing.T) {
 
 func TestHoldemWebController_ShortCommands(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 
 	cfg := domain.DefaultHoldemConfig()
 	mi.On("ResetWithConfig", cfg).Return(`{"phase":1}`)
@@ -211,7 +226,8 @@ func TestHoldemWebController_ShortCommands(t *testing.T) {
 
 func TestHoldemWebController_ErrorResponse(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 	mi.On("Action", domain.HoldemActionFold, 0).Return("invalid json")
 	recorded := test.RunRequest(t, api.MakeHandler(),
 		test.MakeSimpleRequest("POST", "http://localhost/holdem/exec",
@@ -221,7 +237,8 @@ func TestHoldemWebController_ErrorResponse(t *testing.T) {
 
 func TestHoldemWebController_LongSessionId(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 	recorded := test.RunRequest(t, api.MakeHandler(),
 		test.MakeSimpleRequest("POST", "http://localhost/holdem/exec",
 			map[string]interface{}{
@@ -233,7 +250,8 @@ func TestHoldemWebController_LongSessionId(t *testing.T) {
 
 func TestHoldemWebController_Reset_SmallBlindOnly(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 
 	sb := 3
 	cfg := domain.DefaultHoldemConfig()
@@ -252,7 +270,8 @@ func TestHoldemWebController_Reset_SmallBlindOnly(t *testing.T) {
 
 func TestHoldemWebController_Reset_BigBlindOnly(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 
 	bb := 30
 	cfg := domain.DefaultHoldemConfig()
@@ -271,7 +290,8 @@ func TestHoldemWebController_Reset_BigBlindOnly(t *testing.T) {
 
 func TestHoldemWebController_Reset_SmallBlindOnly_AutoAdjust(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 
 	// smallBlind=20のみ指定: bigBlindがデフォルト(10)より大きいので自動調整 bb=40
 	sb := 20
@@ -292,7 +312,8 @@ func TestHoldemWebController_Reset_SmallBlindOnly_AutoAdjust(t *testing.T) {
 
 func TestHoldemWebController_Reset_BigBlindOnly_AutoAdjust(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 
 	// bigBlind=4のみ指定: smallBlindがデフォルト(5)より大きいので自動調整 sb=2
 	bb := 4
@@ -313,7 +334,8 @@ func TestHoldemWebController_Reset_BigBlindOnly_AutoAdjust(t *testing.T) {
 
 func TestHoldemWebController_Reset_SmallBlindGeBigBlind(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 
 	// smallBlind >= bigBlind は不正
 	recorded := test.RunRequest(t, api.MakeHandler(),
@@ -340,7 +362,8 @@ func TestHoldemWebController_Reset_SmallBlindGeBigBlind(t *testing.T) {
 
 func TestHoldemWebController_Reset_InvalidBlinds(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
-	api := newHoldemTestHandler(mi)
+	api, hwc := newHoldemTestHandler(mi)
+	defer hwc.Stop()
 
 	cfg := domain.DefaultHoldemConfig() // defaults unchanged when values < 1
 	mi.On("ResetWithConfig", cfg).Return(`{"phase":1}`)
@@ -354,4 +377,13 @@ func TestHoldemWebController_Reset_InvalidBlinds(t *testing.T) {
 				"bigBlind":   0,
 			}))
 	recorded.CodeIs(200)
+}
+
+func TestHoldemWebController_Stop(t *testing.T) {
+	mi := new(mockUsecase.MockHoldemInteractor)
+	c := NewHoldemWebController(func() usecase.HoldemInteractorIF {
+		return mi
+	})
+	c.Stop()
+	c.Stop()
 }

--- a/internal/adapter/controller/OldMaidWebController.go
+++ b/internal/adapter/controller/OldMaidWebController.go
@@ -130,6 +130,11 @@ func (owc *OldMaidWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 	}
 }
 
+// Stop stops the background cleanup goroutine of the session store.
+func (owc *OldMaidWebController) Stop() {
+	owc.store.Stop()
+}
+
 // newDefaultOutput エラー・定型応答用のデフォルト出力を返す
 func (owc *OldMaidWebController) newDefaultOutput(msg string) *OldMaidWebOutput {
 	return &OldMaidWebOutput{

--- a/internal/adapter/controller/OldMaidWebController_test.go
+++ b/internal/adapter/controller/OldMaidWebController_test.go
@@ -24,6 +24,7 @@ func TestOldMaidWebController_Method(t *testing.T) {
 
 	factory := func() uc.OldMaidInteractorIF { return omiMock }
 	towc := controller.NewOldMaidWebController(factory)
+	defer towc.Stop()
 
 	api := rest.NewApi()
 	router, _ := rest.MakeRouter(
@@ -208,6 +209,7 @@ func TestOldMaidWebController_SessionIsolation(t *testing.T) {
 		}
 		return mockB
 	})
+	defer isoController.Stop()
 
 	api := rest.NewApi()
 	router, _ := rest.MakeRouter(
@@ -247,4 +249,12 @@ func TestOldMaidWebController_SessionIsolation(t *testing.T) {
 			t.Errorf("expected factory to be called 2 times, got %d", callCount)
 		}
 	})
+}
+
+func TestOldMaidWebController_Stop(t *testing.T) {
+	omiMock := new(usecase.MockOldMaidInteractor)
+	factory := func() uc.OldMaidInteractorIF { return omiMock }
+	c := controller.NewOldMaidWebController(factory)
+	c.Stop()
+	c.Stop()
 }

--- a/internal/adapter/controller/PokerWebController.go
+++ b/internal/adapter/controller/PokerWebController.go
@@ -109,6 +109,11 @@ func (pwc *PokerWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 	}
 }
 
+// Stop stops the background cleanup goroutine of the session store.
+func (pwc *PokerWebController) Stop() {
+	pwc.store.Stop()
+}
+
 // newDefaultOutput エラー・定型応答用のデフォルト出力を返す
 func (pwc *PokerWebController) newDefaultOutput(msg string) *PokerWebOutput {
 	return &PokerWebOutput{

--- a/internal/adapter/controller/PokerWebController_test.go
+++ b/internal/adapter/controller/PokerWebController_test.go
@@ -29,6 +29,7 @@ func TestPokerWebController_Method(t *testing.T) {
 
 	factory := func() uc.PokerInteractorIF { return piMock }
 	tpc := controller.NewPokerWebController(factory)
+	defer tpc.Stop()
 
 	api := rest.NewApi()
 	router, _ := rest.MakeRouter(
@@ -267,6 +268,7 @@ func TestPokerWebController_SessionIsolation(t *testing.T) {
 		}
 		return mockB
 	})
+	defer isoController.Stop()
 
 	api := rest.NewApi()
 	router, _ := rest.MakeRouter(
@@ -306,4 +308,12 @@ func TestPokerWebController_SessionIsolation(t *testing.T) {
 			t.Errorf("expected factory to be called 2 times, got %d", callCount)
 		}
 	})
+}
+
+func TestPokerWebController_Stop(t *testing.T) {
+	piMock := new(usecase.MockPokerInteractor)
+	factory := func() uc.PokerInteractorIF { return piMock }
+	c := controller.NewPokerWebController(factory)
+	c.Stop()
+	c.Stop()
 }

--- a/internal/adapter/controller/SevensWebController.go
+++ b/internal/adapter/controller/SevensWebController.go
@@ -158,6 +158,11 @@ func derefIntDefault(p *int, defaultVal int) int {
 	return *p
 }
 
+// Stop stops the background cleanup goroutine of the session store.
+func (swc *SevensWebController) Stop() {
+	swc.store.Stop()
+}
+
 // newDefaultOutput エラー・定型応答用のデフォルト出力を返す
 func (swc *SevensWebController) newDefaultOutput(msg string) *SevensWebOutput {
 	return &SevensWebOutput{

--- a/internal/adapter/controller/SevensWebController_test.go
+++ b/internal/adapter/controller/SevensWebController_test.go
@@ -25,6 +25,7 @@ func TestSevensWebController_Method(t *testing.T) {
 
 	factory := func() uc.SevensInteractorIF { return sgiMock }
 	tswc := controller.NewSevensWebController(factory)
+	defer tswc.Stop()
 
 	api := rest.NewApi()
 	router, _ := rest.MakeRouter(
@@ -168,6 +169,7 @@ func TestSevensWebController_ResetWithConfig(t *testing.T) {
 		sgiMock.On("ResetWithConfig", true, 2, true, 5).Return(mockOutput)
 		factory := func() uc.SevensInteractorIF { return sgiMock }
 		tswc := controller.NewSevensWebController(factory)
+		defer tswc.Stop()
 		api := rest.NewApi()
 		router, _ := rest.MakeRouter(rest.Post("/sevens/exec", tswc.Exec))
 		api.SetApp(router)
@@ -190,6 +192,7 @@ func TestSevensWebController_ResetWithConfig(t *testing.T) {
 		sgiMock.On("Reset").Return(defaultOutput)
 		factory := func() uc.SevensInteractorIF { return sgiMock }
 		tswc := controller.NewSevensWebController(factory)
+		defer tswc.Stop()
 		api := rest.NewApi()
 		router, _ := rest.MakeRouter(rest.Post("/sevens/exec", tswc.Exec))
 		api.SetApp(router)
@@ -212,6 +215,7 @@ func TestSevensWebController_ResetWithConfig(t *testing.T) {
 		sgiMock.On("ResetWithConfig", true, 0, false, 5).Return(partialOutput)
 		factory := func() uc.SevensInteractorIF { return sgiMock }
 		tswc := controller.NewSevensWebController(factory)
+		defer tswc.Stop()
 		api := rest.NewApi()
 		router, _ := rest.MakeRouter(rest.Post("/sevens/exec", tswc.Exec))
 		api.SetApp(router)
@@ -233,6 +237,7 @@ func TestSevensWebController_ResetWithConfig(t *testing.T) {
 		sgiMock.On("ResetWithConfig", false, 0, false, 3).Return(passesOutput)
 		factory := func() uc.SevensInteractorIF { return sgiMock }
 		tswc := controller.NewSevensWebController(factory)
+		defer tswc.Stop()
 		api := rest.NewApi()
 		router, _ := rest.MakeRouter(rest.Post("/sevens/exec", tswc.Exec))
 		api.SetApp(router)
@@ -253,6 +258,7 @@ func TestSevensWebController_ResetWithConfig(t *testing.T) {
 		sgiMock := new(usecase.MockSevensInteractor)
 		factory := func() uc.SevensInteractorIF { return sgiMock }
 		tswc := controller.NewSevensWebController(factory)
+		defer tswc.Stop()
 		api := rest.NewApi()
 		router, _ := rest.MakeRouter(rest.Post("/sevens/exec", tswc.Exec))
 		api.SetApp(router)
@@ -277,6 +283,7 @@ func TestSevensWebController_ResetWithConfig(t *testing.T) {
 		sgiMock := new(usecase.MockSevensInteractor)
 		factory := func() uc.SevensInteractorIF { return sgiMock }
 		tswc := controller.NewSevensWebController(factory)
+		defer tswc.Stop()
 		api := rest.NewApi()
 		router, _ := rest.MakeRouter(rest.Post("/sevens/exec", tswc.Exec))
 		api.SetApp(router)
@@ -303,6 +310,7 @@ func TestSevensWebController_ResetWithConfig(t *testing.T) {
 		sgiMock.On("ResetWithConfig", false, 0, false, 0).Return(passesOutput)
 		factory := func() uc.SevensInteractorIF { return sgiMock }
 		tswc := controller.NewSevensWebController(factory)
+		defer tswc.Stop()
 		api := rest.NewApi()
 		router, _ := rest.MakeRouter(rest.Post("/sevens/exec", tswc.Exec))
 		api.SetApp(router)
@@ -335,6 +343,7 @@ func TestSevensWebController_SessionIsolation(t *testing.T) {
 		}
 		return mockB
 	})
+	defer isoController.Stop()
 
 	api := rest.NewApi()
 	router, _ := rest.MakeRouter(
@@ -374,4 +383,12 @@ func TestSevensWebController_SessionIsolation(t *testing.T) {
 			t.Errorf("expected factory to be called 2 times, got %d", callCount)
 		}
 	})
+}
+
+func TestSevensWebController_Stop(t *testing.T) {
+	sgiMock := new(usecase.MockSevensInteractor)
+	factory := func() uc.SevensInteractorIF { return sgiMock }
+	c := controller.NewSevensWebController(factory)
+	c.Stop()
+	c.Stop()
 }

--- a/internal/infrastructure/web/TrumpCardsWeb.go
+++ b/internal/infrastructure/web/TrumpCardsWeb.go
@@ -1,10 +1,14 @@
 package web
 
 import (
+	"context"
+	"errors"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
@@ -153,9 +157,10 @@ func (web *TrumpCardsWeb) Exec() {
 	}
 	mux.Handle("/", http.FileServer(http.Dir("public")))
 	const (
-		readTimeout  = 10 * time.Second
-		writeTimeout = 30 * time.Second
-		idleTimeout  = 60 * time.Second
+		readTimeout     = 10 * time.Second
+		writeTimeout    = 30 * time.Second
+		idleTimeout     = 60 * time.Second
+		shutdownTimeout = 30 * time.Second
 	)
 	srv := &http.Server{
 		Addr:         getListenPort(),
@@ -164,7 +169,35 @@ func (web *TrumpCardsWeb) Exec() {
 		WriteTimeout: writeTimeout,
 		IdleTimeout:  idleTimeout,
 	}
-	log.Fatal(srv.ListenAndServe())
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.ListenAndServe() }()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, http.ErrServerClosed) {
+			log.Fatal(err)
+		}
+	case <-ctx.Done():
+		log.Println("shutting down server...")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			log.Printf("server shutdown error: %v", err)
+		}
+	}
+
+	web.bjc.Stop()
+	web.pkc.Stop()
+	web.omc.Stop()
+	web.dgc.Stop()
+	web.sgc.Stop()
+	web.dwc.Stop()
+	web.hmc.Stop()
+	log.Println("server stopped")
 }
 
 func getListenPort() string {


### PR DESCRIPTION
## Summary
- Replace `log.Fatal(srv.ListenAndServe())` with `signal.NotifyContext` + `http.Server.Shutdown` for graceful shutdown on SIGINT/SIGTERM
- Add `Stop()` method to all 7 web controllers to cleanly terminate `SessionStore` background cleanup goroutines
- Add `defer Stop()` calls to existing controller tests to prevent goroutine leaks
- Add `Stop()` idempotency tests for all 7 controllers

Closes #209

## Test plan
- [x] `go test ./...` — all pass
- [x] `go vet ./...` — no issues
- [x] `goimports -w` applied to all modified files
- [ ] Manual: `go run ./cmd/server`, then Ctrl+C → confirm "shutting down server..." / "server stopped" logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)