### PR TITLE
refactor(frontend): extract duplicated valueName into shared cardUtils utility

### DIFF
--- a/frontend/src/pages/DoubtPage.test.tsx
+++ b/frontend/src/pages/DoubtPage.test.tsx
@@ -296,48 +296,6 @@ describe('DoubtPage', () => {
     expect(screen.queryByText(/枚出しました/)).not.toBeInTheDocument();
   });
 
-  // ── valueName branches ───────────────────────────────────────────────────
-
-  it('valueName shows A for claimedValue 1', async () => {
-    const s: DoubtResponse = {
-      ...humanTurnState,
-      lastAction: { playerIdx: 1, claimedValue: 1, cardCount: 1, isBluff: false },
-    };
-    mockExec.mockResolvedValue(s);
-    render(<DoubtPage />);
-    await waitFor(() => expect(screen.getByText(/宣言: A/)).toBeInTheDocument());
-  });
-
-  it('valueName shows J for claimedValue 11', async () => {
-    const s: DoubtResponse = {
-      ...humanTurnState,
-      lastAction: { playerIdx: 1, claimedValue: 11, cardCount: 1, isBluff: false },
-    };
-    mockExec.mockResolvedValue(s);
-    render(<DoubtPage />);
-    await waitFor(() => expect(screen.getByText(/宣言: J/)).toBeInTheDocument());
-  });
-
-  it('valueName shows Q for claimedValue 12', async () => {
-    const s: DoubtResponse = {
-      ...humanTurnState,
-      lastAction: { playerIdx: 1, claimedValue: 12, cardCount: 1, isBluff: false },
-    };
-    mockExec.mockResolvedValue(s);
-    render(<DoubtPage />);
-    await waitFor(() => expect(screen.getByText(/宣言: Q/)).toBeInTheDocument());
-  });
-
-  it('valueName shows K for claimedValue 13', async () => {
-    const s: DoubtResponse = {
-      ...humanTurnState,
-      lastAction: { playerIdx: 1, claimedValue: 13, cardCount: 1, isBluff: false },
-    };
-    mockExec.mockResolvedValue(s);
-    render(<DoubtPage />);
-    await waitFor(() => expect(screen.getByText(/宣言: K/)).toBeInTheDocument());
-  });
-
   // ── actionDesc branches ───────────────────────────────────────────────────
 
   it('actionDesc uses Player index when player not found', async () => {

--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -5,15 +5,8 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { useGameApi } from '../hooks/useGameApi';
 import { btnDanger, btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import type { Card, DoubtConfig, DoubtCpuAction, DoubtPlayerData } from '../types/card';
+import { valueName } from '../utils/cardUtils';
 import { playerName } from '../utils/playerUtils';
-
-function valueName(v: number): string {
-  if (v === 1) return 'A';
-  if (v === 11) return 'J';
-  if (v === 12) return 'Q';
-  if (v === 13) return 'K';
-  return String(v);
-}
 
 // ── CPU player area ──────────────────────────────────────────────────────────
 

--- a/frontend/src/pages/SevensPage.tsx
+++ b/frontend/src/pages/SevensPage.tsx
@@ -5,6 +5,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { useGameApi } from '../hooks/useGameApi';
 import { btnPrimary, btnWarning } from '../styles/buttonStyles';
 import type { Card, CardDesign, SevensAction, SevensPlayerData, SevensResponse } from '../types/card';
+import { valueName } from '../utils/cardUtils';
 import { findPlayerName, playerName } from '../utils/playerUtils';
 
 // Design → suit index (matches Go backend: 1=SPADE, 2=CLOVER, 3=HEART, 4=DIAMOND)
@@ -24,14 +25,6 @@ const SUITS = [
   { idx: 3, name: 'HEART', label: '♥', color: '#f87171' },
   { idx: 4, name: 'DIAMOND', label: '♦', color: '#f87171' },
 ];
-
-function valueName(v: number): string {
-  if (v === 1) return 'A';
-  if (v === 11) return 'J';
-  if (v === 12) return 'Q';
-  if (v === 13) return 'K';
-  return String(v);
-}
 
 function isPositionPlaced(tablePlaced: number[], suit: number, value: number): boolean {
   return (tablePlaced[suit] & (1 << value)) !== 0;

--- a/frontend/src/utils/cardUtils.test.ts
+++ b/frontend/src/utils/cardUtils.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { valueName } from './cardUtils';
+
+describe('valueName', () => {
+  it('returns A for value 1', () => {
+    expect(valueName(1)).toBe('A');
+  });
+
+  it('returns J for value 11', () => {
+    expect(valueName(11)).toBe('J');
+  });
+
+  it('returns Q for value 12', () => {
+    expect(valueName(12)).toBe('Q');
+  });
+
+  it('returns K for value 13', () => {
+    expect(valueName(13)).toBe('K');
+  });
+
+  it('returns string representation for other values', () => {
+    expect(valueName(5)).toBe('5');
+    expect(valueName(10)).toBe('10');
+  });
+});

--- a/frontend/src/utils/cardUtils.ts
+++ b/frontend/src/utils/cardUtils.ts
@@ -1,0 +1,8 @@
+/** Return display name for a card value (1→'A', 11→'J', 12→'Q', 13→'K', else string). */
+export function valueName(v: number): string {
+  if (v === 1) return 'A';
+  if (v === 11) return 'J';
+  if (v === 12) return 'Q';
+  if (v === 13) return 'K';
+  return String(v);
+}


### PR DESCRIPTION
## Summary
- Extracted duplicated `valueName` function from `SevensPage.tsx` and `DoubtPage.tsx` into a shared `frontend/src/utils/cardUtils.ts` utility
- Added dedicated unit tests in `cardUtils.test.ts` with 100% branch coverage
- Removed redundant `valueName` branch tests from `DoubtPage.test.tsx`

Closes #214

## Test plan
- [x] `npm test` — all 460 tests pass
- [x] `npm run check` — Biome lint/format clean
- [x] `npm run build` — builds successfully
- [x] `npm run test:coverage` — 100% branch coverage on `utils/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)