### PR TITLE
feat(frontend): add aria-pressed to card selection toggle buttons

### DIFF
--- a/frontend/src/pages/DaifugoPage.test.tsx
+++ b/frontend/src/pages/DaifugoPage.test.tsx
@@ -436,6 +436,20 @@ describe('DaifugoPage', () => {
     await waitFor(() => expect(screen.getByText(/上がり \(大貧民\)/)).toBeInTheDocument());
   });
 
+  it('toggles aria-pressed on card button click', async () => {
+    render(<DaifugoPage />);
+    await waitFor(() => expect(screen.getByAltText('SPADE 3')).toBeInTheDocument());
+
+    const cardBtn = screen.getByAltText('SPADE 3').closest('button') as HTMLButtonElement;
+    expect(cardBtn).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(cardBtn);
+    expect(cardBtn).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(cardBtn);
+    expect(cardBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+
   it('deselects a card by clicking it again', async () => {
     render(<DaifugoPage />);
     await waitFor(() => expect(screen.getByAltText('SPADE 3')).toBeInTheDocument());

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -139,6 +139,7 @@ function HumanPlayerArea({ player, selectedIndices, onToggle, isCurrentTurn, onD
           <button
             key={`${card.design}-${card.value}`}
             type="button"
+            aria-pressed={selectedIndices.includes(i)}
             disabled={!isCurrentTurn}
             draggable={isCurrentTurn}
             onClick={() => onToggle(i)}

--- a/frontend/src/pages/DoubtPage.test.tsx
+++ b/frontend/src/pages/DoubtPage.test.tsx
@@ -144,6 +144,20 @@ describe('DoubtPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: '出す' })).toBeDisabled());
   });
 
+  it('toggles aria-pressed on HandCard button click', async () => {
+    render(<DoubtPage />);
+    await waitFor(() => expect(screen.getByAltText('SPADE 1')).toBeInTheDocument());
+
+    const cardBtn = screen.getByAltText('SPADE 1').closest('button') as HTMLButtonElement;
+    expect(cardBtn).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(cardBtn);
+    expect(cardBtn).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(cardBtn);
+    expect(cardBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+
   it('toggles card selection on click and enables 出す button', async () => {
     render(<DoubtPage />);
     await waitFor(() => expect(screen.getByAltText('SPADE 1')).toBeInTheDocument());

--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -75,6 +75,7 @@ function HandCard({ card, index, selected, selectable, onToggle }: HandCardProps
   return (
     <button
       type="button"
+      aria-pressed={selected}
       disabled={!selectable}
       onClick={() => onToggle(index)}
       style={{

--- a/frontend/src/pages/PokerPage.test.tsx
+++ b/frontend/src/pages/PokerPage.test.tsx
@@ -394,6 +394,21 @@ describe('PokerPage', () => {
     expect(screen.queryByText('High Card')).not.toBeInTheDocument();
   });
 
+  it('toggles aria-pressed on card button click in exchange phase', async () => {
+    mockExec.mockResolvedValue(phase2State);
+    render(<PokerPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'スタンド' })).toBeInTheDocument());
+
+    const cardBtn = screen.getByAltText('SPADE 1').closest('button') as HTMLButtonElement;
+    expect(cardBtn).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(cardBtn);
+    expect(cardBtn).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(cardBtn);
+    expect(cardBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+
   it('updates bet amount when changing the bet input', async () => {
     mockExec.mockResolvedValue(phase1State);
     render(<PokerPage />);

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -138,6 +138,7 @@ export function PokerPage() {
                 <button
                   key={`${card.design}-${card.value}`}
                   type="button"
+                  aria-pressed={isSelected}
                   onClick={() => toggleSelect(i)}
                   style={{
                     background: 'none',


### PR DESCRIPTION
## Summary
- Add `aria-pressed` attribute to card toggle buttons in `PokerPage`, `DaifugoPage`, and `DoubtPage` so screen readers can convey selected/unselected state per WAI-ARIA button pattern
- Add tests verifying `aria-pressed` toggles between `"false"` and `"true"` on click for all three pages

## Test plan
- [x] `npm run build` passes
- [x] `npm run check` (Biome lint + format) passes
- [x] `npm test` — all 470 tests pass, including 3 new aria-pressed toggle tests

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)