### PR TITLE
feat(frontend): add aria-busy and live region notifications for loading states

### DIFF
--- a/frontend/src/components/ErrorAlert.test.tsx
+++ b/frontend/src/components/ErrorAlert.test.tsx
@@ -11,5 +11,6 @@ describe('ErrorAlert', () => {
   it('renders the message when provided', () => {
     render(<ErrorAlert message="通信エラーが発生しました。もう一度お試しください。" />);
     expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/ErrorAlert.tsx
+++ b/frontend/src/components/ErrorAlert.tsx
@@ -5,7 +5,10 @@ interface ErrorAlertProps {
 export function ErrorAlert({ message }: ErrorAlertProps) {
   if (!message) return null;
   return (
-    <div className="bg-red-700/90 text-white text-center px-4 py-2 text-[0.95em] font-bold mb-2 rounded-lg">
+    <div
+      role="alert"
+      className="bg-red-700/90 text-white text-center px-4 py-2 text-[0.95em] font-bold mb-2 rounded-lg"
+    >
       {message}
     </div>
   );

--- a/frontend/src/pages/BlackJackPage.test.tsx
+++ b/frontend/src/pages/BlackJackPage.test.tsx
@@ -591,4 +591,29 @@ describe('BlackJackPage', () => {
     render(<BlackJackPage />);
     await waitFor(() => expect(screen.getByText('デッキ: 6デッキ')).toBeInTheDocument());
   });
+
+  it('sets aria-busy and sr-only loading text while loading', async () => {
+    render(<BlackJackPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).not.toBeDisabled());
+
+    const container = screen.getByRole('button', { name: 'ベット' }).closest('[aria-live]') as HTMLElement;
+    expect(container).toHaveAttribute('aria-busy', 'false');
+    expect(screen.queryByText('処理中...')).not.toBeInTheDocument();
+
+    let resolve!: (value: BlackJackResponse) => void;
+    const slowPromise = new Promise<BlackJackResponse>((res) => {
+      resolve = res;
+    });
+    mockExec.mockReturnValueOnce(slowPromise);
+    fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
+
+    expect(container).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByText('処理中...')).toBeInTheDocument();
+
+    resolve(betPhaseState);
+    await waitFor(() => {
+      expect(container).toHaveAttribute('aria-busy', 'false');
+      expect(screen.queryByText('処理中...')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -53,7 +53,8 @@ export function BlackJackPage() {
   const suggestedAction = state?.suggestedAction ?? BJ_SUGGEST_NONE;
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-[#008000]">
+    <div className="flex-1 flex flex-col min-h-0 bg-[#008000]" aria-busy={loading} aria-live="polite">
+      {loading && <span className="sr-only">処理中...</span>}
       {/* Chip info bar */}
       {state && (
         <div className="shrink-0 bg-black/40 text-white text-sm px-4 py-1.5 flex justify-between">

--- a/frontend/src/pages/DaifugoPage.test.tsx
+++ b/frontend/src/pages/DaifugoPage.test.tsx
@@ -615,6 +615,31 @@ describe('DaifugoPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', [0, 1]));
   });
 
+  it('sets aria-busy and sr-only loading text while loading', async () => {
+    render(<DaifugoPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'パス' })).not.toBeDisabled());
+
+    const container = screen.getByRole('button', { name: 'パス' }).closest('[aria-live]') as HTMLElement;
+    expect(container).toHaveAttribute('aria-busy', 'false');
+    expect(screen.queryByText('処理中...')).not.toBeInTheDocument();
+
+    let resolve!: (value: DaifugoResponse) => void;
+    const slowPromise = new Promise<DaifugoResponse>((res) => {
+      resolve = res;
+    });
+    mockExec.mockReturnValueOnce(slowPromise);
+    fireEvent.click(screen.getByRole('button', { name: 'パス' }));
+
+    expect(container).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByText('処理中...')).toBeInTheDocument();
+
+    resolve(humanTurnState);
+    await waitFor(() => {
+      expect(container).toHaveAttribute('aria-busy', 'false');
+      expect(screen.queryByText('処理中...')).not.toBeInTheDocument();
+    });
+  });
+
   it('drop with invalid dataTransfer data is ignored (NaN guard)', async () => {
     render(<DaifugoPage />);
     await waitFor(() => expect(screen.getByAltText('SPADE 3')).toBeInTheDocument());

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -348,7 +348,8 @@ export function DaifugoPage() {
   }
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-[#1a5c1a]">
+    <div className="flex-1 flex flex-col min-h-0 bg-[#1a5c1a]" aria-busy={loading} aria-live="polite">
+      {loading && <span className="sr-only">処理中...</span>}
       {/* Scrollable: CPU rows + table cards + action logs + result */}
       <div className="flex-1 overflow-y-auto pt-3 px-4">
         {/* CPU row */}

--- a/frontend/src/pages/DoubtPage.test.tsx
+++ b/frontend/src/pages/DoubtPage.test.tsx
@@ -291,6 +291,31 @@ describe('DoubtPage', () => {
     );
   });
 
+  it('sets aria-busy and sr-only loading text while loading', async () => {
+    render(<DoubtPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).not.toBeDisabled());
+
+    const container = screen.getByRole('button', { name: 'リセット' }).closest('[aria-live]') as HTMLElement;
+    expect(container).toHaveAttribute('aria-busy', 'false');
+    expect(screen.queryByText('処理中...')).not.toBeInTheDocument();
+
+    let resolve!: (value: DoubtResponse) => void;
+    const slowPromise = new Promise<DoubtResponse>((res) => {
+      resolve = res;
+    });
+    mockExec.mockReturnValueOnce(slowPromise);
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+
+    expect(container).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByText('処理中...')).toBeInTheDocument();
+
+    resolve(humanTurnState);
+    await waitFor(() => {
+      expect(container).toHaveAttribute('aria-busy', 'false');
+      expect(screen.queryByText('処理中...')).not.toBeInTheDocument();
+    });
+  });
+
   // ── Table area ────────────────────────────────────────────────────────────
 
   it('shows lastAction in table area', async () => {

--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -237,7 +237,8 @@ export function DoubtPage() {
   };
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-[#1a2c5c]">
+    <div className="flex-1 flex flex-col min-h-0 bg-[#1a2c5c]" aria-busy={loading} aria-live="polite">
+      {loading && <span className="sr-only">処理中...</span>}
       {/* Settings panel */}
       <details className="px-4 pt-2">
         <summary className="text-white/70 text-xs cursor-pointer select-none">設定</summary>

--- a/frontend/src/pages/HoldemPage.test.tsx
+++ b/frontend/src/pages/HoldemPage.test.tsx
@@ -758,4 +758,30 @@ describe('HoldemPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bet', 60));
   });
+
+  it('sets aria-busy and sr-only loading text while loading', async () => {
+    mockExec.mockResolvedValue(preFlopState);
+    render(<HoldemPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).not.toBeDisabled());
+
+    const container = screen.getByRole('button', { name: 'ベット' }).closest('[aria-live]') as HTMLElement;
+    expect(container).toHaveAttribute('aria-busy', 'false');
+    expect(screen.queryByText('処理中...')).not.toBeInTheDocument();
+
+    let resolve!: (value: HoldemResponse) => void;
+    const slowPromise = new Promise<HoldemResponse>((res) => {
+      resolve = res;
+    });
+    mockExec.mockReturnValueOnce(slowPromise);
+    fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
+
+    expect(container).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByText('処理中...')).toBeInTheDocument();
+
+    resolve(preFlopState);
+    await waitFor(() => {
+      expect(container).toHaveAttribute('aria-busy', 'false');
+      expect(screen.queryByText('処理中...')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -52,7 +52,8 @@ export function HoldemPage() {
   const minRaise = state?.minRaise ?? 0;
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-[#1a6b1a]">
+    <div className="flex-1 flex flex-col min-h-0 bg-[#1a6b1a]" aria-busy={loading} aria-live="polite">
+      {loading && <span className="sr-only">処理中...</span>}
       {/* Info bar */}
       <div className="shrink-0 bg-black/40 text-white text-sm px-5 py-2 flex flex-wrap gap-x-6 gap-y-1">
         <span>

--- a/frontend/src/pages/OldMaidPage.test.tsx
+++ b/frontend/src/pages/OldMaidPage.test.tsx
@@ -696,6 +696,36 @@ describe('OldMaidPage', () => {
     });
   }, 10000);
 
+  it('setup screen has aria-busy attribute', () => {
+    render(<OldMaidPage />);
+    const setupContainer = screen.getByText('Old Maid 設定').closest('[aria-busy]') as HTMLElement;
+    expect(setupContainer).toHaveAttribute('aria-busy', 'false');
+  });
+
+  it('sets aria-busy and sr-only loading text on game screen while loading', async () => {
+    await startGame();
+
+    const container = screen.getByRole('button', { name: 'リセット' }).closest('[aria-live]') as HTMLElement;
+    expect(container).toHaveAttribute('aria-busy', 'false');
+    expect(screen.queryByText('処理中...')).not.toBeInTheDocument();
+
+    let resolve!: (value: OldMaidResponse) => void;
+    const slowPromise = new Promise<OldMaidResponse>((res) => {
+      resolve = res;
+    });
+    mockExec.mockReturnValueOnce(slowPromise);
+    fireEvent.click(screen.getByRole('button', { name: 'ランダムに引く' }));
+
+    expect(container).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByText('処理中...')).toBeInTheDocument();
+
+    resolve(humanTurnState);
+    await waitFor(() => {
+      expect(container).toHaveAttribute('aria-busy', 'false');
+      expect(screen.queryByText('処理中...')).not.toBeInTheDocument();
+    });
+  });
+
   it('goes directly to CPU replay when humanAction is null', async () => {
     const directCpuState: OldMaidResponse = {
       ...humanTurnState,

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -267,7 +267,7 @@ function SetupScreen({
   loading,
 }: SetupScreenProps) {
   return (
-    <div className="flex-1 flex flex-col items-center justify-center bg-[#1a5c1a] p-6 gap-4">
+    <div className="flex-1 flex flex-col items-center justify-center bg-[#1a5c1a] p-6 gap-4" aria-busy={loading}>
       <div className="text-white text-2xl font-bold mb-2">Old Maid 設定</div>
       <div className="bg-black/40 rounded-xl p-4 w-full max-w-sm flex flex-col gap-3">
         <div className="text-white font-bold mb-1">モード選択</div>
@@ -399,7 +399,8 @@ export function OldMaidPage() {
   }
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-[#1a5c1a]">
+    <div className="flex-1 flex flex-col min-h-0 bg-[#1a5c1a]" aria-busy={loading} aria-live="polite">
+      {loading && <span className="sr-only">処理中...</span>}
       {/* Scrollable: CPU rows + discard + status + logs + result */}
       <div className="flex-1 overflow-y-auto pt-3 px-4">
         {/* Mode badge */}

--- a/frontend/src/pages/PokerPage.test.tsx
+++ b/frontend/src/pages/PokerPage.test.tsx
@@ -419,4 +419,30 @@ describe('PokerPage', () => {
 
     expect((betInput as HTMLInputElement).value).toBe('20');
   });
+
+  it('sets aria-busy and sr-only loading text while loading', async () => {
+    mockExec.mockResolvedValue(phase1State);
+    render(<PokerPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).not.toBeDisabled());
+
+    const container = screen.getByRole('button', { name: 'ベット' }).closest('[aria-live]') as HTMLElement;
+    expect(container).toHaveAttribute('aria-busy', 'false');
+    expect(screen.queryByText('処理中...')).not.toBeInTheDocument();
+
+    let resolve!: (value: PokerResponse) => void;
+    const slowPromise = new Promise<PokerResponse>((res) => {
+      resolve = res;
+    });
+    mockExec.mockReturnValueOnce(slowPromise);
+    fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
+
+    expect(container).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByText('処理中...')).toBeInTheDocument();
+
+    resolve(phase1State);
+    await waitFor(() => {
+      expect(container).toHaveAttribute('aria-busy', 'false');
+      expect(screen.queryByText('処理中...')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -44,7 +44,8 @@ export function PokerPage() {
   };
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-[#1a6b1a]">
+    <div className="flex-1 flex flex-col min-h-0 bg-[#1a6b1a]" aria-busy={loading} aria-live="polite">
+      {loading && <span className="sr-only">処理中...</span>}
       {/* Chip/Pot info bar */}
       <div className="shrink-0 bg-black/40 text-white text-sm px-5 py-2 flex flex-wrap gap-x-6 gap-y-1">
         <span>

--- a/frontend/src/pages/SevensPage.test.tsx
+++ b/frontend/src/pages/SevensPage.test.tsx
@@ -725,6 +725,31 @@ describe('SevensPage', () => {
     await waitFor(() => expect(screen.getByTestId('cpu-action-0')).toBeInTheDocument());
   });
 
+  it('sets aria-busy and sr-only loading text while loading', async () => {
+    render(<SevensPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'パス' })).not.toBeDisabled());
+
+    const container = screen.getByRole('button', { name: 'パス' }).closest('[aria-live]') as HTMLElement;
+    expect(container).toHaveAttribute('aria-busy', 'false');
+    expect(screen.queryByText('処理中...')).not.toBeInTheDocument();
+
+    let resolve!: (value: SevensResponse) => void;
+    const slowPromise = new Promise<SevensResponse>((res) => {
+      resolve = res;
+    });
+    mockExec.mockReturnValueOnce(slowPromise);
+    fireEvent.click(screen.getByRole('button', { name: 'パス' }));
+
+    expect(container).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByText('処理中...')).toBeInTheDocument();
+
+    resolve(humanTurnState);
+    await waitFor(() => {
+      expect(container).toHaveAttribute('aria-busy', 'false');
+      expect(screen.queryByText('処理中...')).not.toBeInTheDocument();
+    });
+  });
+
   it('shows joker played without target info when targetSuit is 0', async () => {
     const jokerNoTargetState: SevensResponse = {
       ...humanTurnState,

--- a/frontend/src/pages/SevensPage.tsx
+++ b/frontend/src/pages/SevensPage.tsx
@@ -318,7 +318,8 @@ export function SevensPage() {
   };
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-[#1a5c1a]">
+    <div className="flex-1 flex flex-col min-h-0 bg-[#1a5c1a]" aria-busy={loading} aria-live="polite">
+      {loading && <span className="sr-only">処理中...</span>}
       {/* Scrollable: CPU rows + board + action logs + result */}
       <div className="flex-1 overflow-y-auto pt-3 px-4">
         {/* Config rules */}


### PR DESCRIPTION
## Summary
- Add `role="alert"` to `ErrorAlert` component for immediate screen reader announcements on errors
- Add `aria-busy={loading}` and `aria-live="polite"` to the main game container on all 7 game pages (BlackJack, Poker, OldMaid, Daifugo, Sevens, Doubt, Holdem)
- Add sr-only `処理中...` loading text inside each live region during API calls
- Add `aria-busy={loading}` to OldMaidPage's setup screen container

Closes #217

## Test plan
- [x] `npm run build` passes
- [x] `npm run check` (Biome lint + format) passes
- [x] `npm test` — 478 tests pass across 14 test files
- [x] Each page test verifies `aria-busy="true"` and sr-only text appear during loading, and clear after loading completes
- [x] ErrorAlert test verifies `role="alert"` is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)