### PR TITLE
fix(blackjack): return ErrDeckExhausted from PlayerDoubleDown and PlayerSplit

### DIFF
--- a/internal/domain/BlackJack.go
+++ b/internal/domain/BlackJack.go
@@ -243,9 +243,15 @@ func (b *BlackJack) PlayerDoubleDown() error {
 	hand.SetBet(bet * 2)
 	hand.SetDoubled(true)
 	// ダブルダウンは1枚だけ引いてスタンド
-	if card := b.drawCard(); card != nil {
-		hand.AddCard(card)
+	card := b.drawCard()
+	if card == nil {
+		// デッキ枯渇: ベットと状態を元に戻す
+		b.player.AddChips(bet)
+		hand.SetBet(bet)
+		hand.SetDoubled(false)
+		return ErrDeckExhausted
 	}
+	hand.AddCard(card)
 	if hand.GetScore() >= 22 {
 		hand.SetBusted(true)
 	} else {
@@ -288,17 +294,30 @@ func (b *BlackJack) PlayerSplit() error {
 	newHand.SetBet(bet)
 	newHand.AddCard(secondCard)
 
-	// 各ハンドに1枚ずつ配る（山札枯渇時は自動スタンド）
-	if card := b.drawCard(); card != nil {
-		hand.AddCard(card)
-	} else {
-		hand.SetStood(true)
+	// 各ハンドに1枚ずつ配る
+	card1 := b.drawCard()
+	if card1 == nil {
+		// デッキ枯渇: 元のハンドを復元してベットを返却
+		hand.Reset()
+		hand.SetBet(bet)
+		hand.AddCard(firstCard)
+		hand.AddCard(secondCard)
+		b.player.AddChips(bet)
+		return ErrDeckExhausted
 	}
-	if card := b.drawCard(); card != nil {
-		newHand.AddCard(card)
-	} else {
-		newHand.SetStood(true)
+	hand.AddCard(card1)
+
+	card2 := b.drawCard()
+	if card2 == nil {
+		// デッキ枯渇: 部分的なドローを元に戻し、元のハンドを復元してベットを返却
+		hand.Reset()
+		hand.SetBet(bet)
+		hand.AddCard(firstCard)
+		hand.AddCard(secondCard)
+		b.player.AddChips(bet)
+		return ErrDeckExhausted
 	}
+	newHand.AddCard(card2)
 
 	// 新しいハンドを挿入
 	b.playerHands = append(b.playerHands[:b.currentHandIdx+1], append([]*BlackJackHand{newHand}, b.playerHands[b.currentHandIdx+1:]...)...)

--- a/internal/domain/BlackJack_test.go
+++ b/internal/domain/BlackJack_test.go
@@ -1095,7 +1095,7 @@ func TestBlackJack_DoubleDown_NoBust(t *testing.T) {
 }
 
 func TestBlackJack_PlayerSplit_DeckExhausted(t *testing.T) {
-	// After split, deck is exhausted so both new hands get stood automatically.
+	// Deck exhausted before first draw → error returned and state reverted.
 	tc := domain.NewTrumpCards(0)
 	player := domain.NewBlackJackPlayer()
 	dealer := domain.NewBlackJackPlayer()
@@ -1112,6 +1112,8 @@ func TestBlackJack_PlayerSplit_DeckExhausted(t *testing.T) {
 	dealer.AddCard(domain.NewCard(domain.CardDesignDiamond, 7, false))
 	bj.SetPhase(domain.BJPhaseAction)
 
+	chipsBefore := player.GetChips()
+
 	// Drain the deck completely (Reset rebuilds deck so use GetTrumpCards)
 	deck := bj.GetTrumpCards()
 	for i := 0; i < 52; i++ {
@@ -1119,16 +1121,87 @@ func TestBlackJack_PlayerSplit_DeckExhausted(t *testing.T) {
 	}
 
 	err := bj.PlayerSplit()
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(bj.GetPlayerHands()))
-	// Both hands should be stood because no cards could be drawn
-	assert.True(t, bj.GetPlayerHands()[0].IsStood(), "first hand should be auto-stood")
-	assert.True(t, bj.GetPlayerHands()[1].IsStood(), "second hand should be auto-stood")
-	// Each hand should have only 1 card (the original split card, no new card drawn)
-	assert.Equal(t, 1, bj.GetPlayerHands()[0].GetCardsSize())
-	assert.Equal(t, 1, bj.GetPlayerHands()[1].GetCardsSize())
-	// All hands finished → game should end
-	assert.True(t, bj.GetGameEndFlag())
+	assert.ErrorIs(t, err, domain.ErrDeckExhausted)
+	// State should be reverted: 1 hand with 2 original cards, chips refunded
+	assert.Equal(t, 1, len(bj.GetPlayerHands()))
+	assert.Equal(t, 2, bj.GetPlayerHands()[0].GetCardsSize())
+	assert.Equal(t, 100, bj.GetPlayerHands()[0].GetBet())
+	assert.Equal(t, chipsBefore, player.GetChips(), "split bet should be refunded")
+	assert.False(t, bj.GetGameEndFlag())
+}
+
+func TestBlackJack_PlayerSplit_DeckExhaustedAfterFirstDraw(t *testing.T) {
+	// First draw succeeds but second draw fails → error returned and state fully reverted.
+	tc := domain.NewTrumpCards(0)
+	player := domain.NewBlackJackPlayer()
+	dealer := domain.NewBlackJackPlayer()
+	player.SetChips(1000)
+	dealer.SetChips(1000)
+	bj := domain.NewBlackJack(tc, player, dealer)
+	bj.Reset()
+
+	hand := bj.GetPlayerHands()[0]
+	hand.SetBet(100)
+	hand.AddCard(domain.NewCard(domain.CardDesignSpade, 8, false))
+	hand.AddCard(domain.NewCard(domain.CardDesignHeart, 8, false))
+	dealer.AddCard(domain.NewCard(domain.CardDesignClover, 10, false))
+	dealer.AddCard(domain.NewCard(domain.CardDesignDiamond, 7, false))
+	bj.SetPhase(domain.BJPhaseAction)
+
+	chipsBefore := player.GetChips()
+
+	// Drain the deck to leave exactly 1 card
+	deck := bj.GetTrumpCards()
+	for i := 0; i < 51; i++ {
+		deck.DrawCard()
+	}
+
+	err := bj.PlayerSplit()
+	assert.ErrorIs(t, err, domain.ErrDeckExhausted)
+	// State should be reverted: 1 hand with 2 original cards, chips refunded
+	assert.Equal(t, 1, len(bj.GetPlayerHands()))
+	assert.Equal(t, 2, bj.GetPlayerHands()[0].GetCardsSize())
+	assert.Equal(t, 100, bj.GetPlayerHands()[0].GetBet())
+	assert.Equal(t, chipsBefore, player.GetChips(), "split bet should be refunded")
+	assert.False(t, bj.GetGameEndFlag())
+}
+
+func TestBlackJack_PlayerDoubleDown_DeckExhausted(t *testing.T) {
+	// Deck exhausted during double down → error returned and state reverted.
+	tc := domain.NewTrumpCards(0)
+	player := domain.NewBlackJackPlayer()
+	dealer := domain.NewBlackJackPlayer()
+	player.SetChips(1000)
+	dealer.SetChips(1000)
+	bj := domain.NewBlackJack(tc, player, dealer)
+	bj.Reset()
+
+	hand := bj.GetPlayerHands()[0]
+	hand.SetBet(100)
+	hand.AddCard(domain.NewCard(domain.CardDesignSpade, 5, false))
+	hand.AddCard(domain.NewCard(domain.CardDesignHeart, 6, false))
+	dealer.AddCard(domain.NewCard(domain.CardDesignClover, 10, false))
+	dealer.AddCard(domain.NewCard(domain.CardDesignDiamond, 7, false))
+	bj.SetPhase(domain.BJPhaseAction)
+
+	chipsBefore := player.GetChips()
+
+	// Drain the deck completely
+	deck := bj.GetTrumpCards()
+	for i := 0; i < 52; i++ {
+		deck.DrawCard()
+	}
+
+	err := bj.PlayerDoubleDown()
+	assert.ErrorIs(t, err, domain.ErrDeckExhausted)
+	// State should be reverted: bet not doubled, chips not reduced, hand unchanged
+	assert.Equal(t, chipsBefore, player.GetChips(), "extra bet should be refunded")
+	assert.Equal(t, 100, hand.GetBet(), "bet should not be doubled")
+	assert.Equal(t, 2, hand.GetCardsSize(), "no card should be added")
+	assert.False(t, hand.IsDoubled(), "doubled flag should be reverted")
+	assert.False(t, hand.IsStood(), "hand should not be stood")
+	assert.False(t, hand.IsBusted(), "hand should not be busted")
+	assert.False(t, bj.GetGameEndFlag())
 }
 
 func TestBlackJack_PlayerInsurance_InsufficientChips(t *testing.T) {


### PR DESCRIPTION
## Summary
- `PlayerDoubleDown()` now returns `ErrDeckExhausted` (with state revert: refund chips, restore bet, clear doubled flag) instead of silently continuing with no card dealt
- `PlayerSplit()` now returns `ErrDeckExhausted` (with full state revert: restore original 2-card hand, refund split bet) instead of auto-standing hands with missing cards
- Updated existing split exhaustion test and added tests for double-down exhaustion and partial-split exhaustion

Closes #244

## Test plan
- [x] `TestBlackJack_PlayerDoubleDown_DeckExhausted` — verifies error, chip refund, bet revert, doubled flag cleared
- [x] `TestBlackJack_PlayerSplit_DeckExhausted` — verifies error and full state revert when both draws fail
- [x] `TestBlackJack_PlayerSplit_DeckExhaustedAfterFirstDraw` — verifies error and revert when first draw succeeds but second fails
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)