### PR TITLE
refactor(controller): extract common web controller boilerplate

### DIFF
--- a/internal/adapter/controller/BlackJackWebController.go
+++ b/internal/adapter/controller/BlackJackWebController.go
@@ -1,9 +1,6 @@
 package controller
 
 import (
-	"log"
-	"net/http"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 
 	"github.com/ant0ine/go-json-rest/rest"
@@ -15,6 +12,12 @@ type BlackJackWebInput struct {
 	Amount    int    `json:"amount,omitempty"`
 	SessionId string `json:"sessionId"`
 }
+
+// GetCommand returns the command string.
+func (i BlackJackWebInput) GetCommand() string { return i.Command }
+
+// GetSessionID returns the session ID string.
+func (i BlackJackWebInput) GetSessionID() string { return i.SessionId }
 
 // BlackJackWebOutputHand ブラックジャックWebアウトプットハンド
 type BlackJackWebOutputHand struct {
@@ -69,62 +72,38 @@ func NewBlackJackWebController(factory func() usecase.BlackJackInteractorIF) *Bl
 
 // Exec ゲーム実行
 func (bwc *BlackJackWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
-	var param BlackJackWebInput
-	err := r.DecodeJsonPayload(&param)
-	if err != nil || param.Command == "" || param.SessionId == "" {
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(bwc.newDefaultOutput("param error.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	if param.Command == "q" || param.Command == "quit" {
-		w.WriteHeader(http.StatusOK)
-		if err := w.WriteJson(bwc.newDefaultOutput("bye.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	bji, mu, ok := bwc.store.GetWithLock(param.SessionId, bwc.factory)
-	if !ok {
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(bwc.newDefaultOutput("param error.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	mu.Lock()
-	defer mu.Unlock()
-	errOutput := bwc.newDefaultOutput("error.")
-	switch param.Command {
-	case "r", "reset":
-		bwc.writePresenterResponse(w, bji.Reset(), errOutput)
-	case "h", "hit":
-		bwc.writePresenterResponse(w, bji.Hit(), errOutput)
-	case "s", "stand":
-		bwc.writePresenterResponse(w, bji.Stand(), errOutput)
-	case "b", "bet":
-		bwc.writePresenterResponse(w, bji.Bet(param.Amount), errOutput)
-	case "d", "doubledown":
-		bwc.writePresenterResponse(w, bji.DoubleDown(), errOutput)
-	case "sp", "split":
-		bwc.writePresenterResponse(w, bji.Split(), errOutput)
-	case "i", "insurance":
-		bwc.writePresenterResponse(w, bji.Insurance(), errOutput)
-	case "di", "declineinsurance":
-		bwc.writePresenterResponse(w, bji.DeclineInsurance(), errOutput)
-	case "sur", "surrender":
-		bwc.writePresenterResponse(w, bji.Surrender(), errOutput)
-	case "togglehint":
-		bwc.writePresenterResponse(w, bji.ToggleHint(), errOutput)
-	case "sd", "setdeckcount":
-		bwc.writePresenterResponse(w, bji.SetDeckCount(param.Amount), errOutput)
-	default:
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(bwc.newDefaultOutput("Unsupported command.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-	}
+	execWithSession(&bwc.baseController, w, r, bwc.store, bwc.factory,
+		func(msg string) any { return bwc.newDefaultOutput(msg) },
+		nil,
+		func(w rest.ResponseWriter, bji usecase.BlackJackInteractorIF, param BlackJackWebInput, errOutput any) bool {
+			switch param.Command {
+			case "r", "reset":
+				bwc.writePresenterResponse(w, bji.Reset(), errOutput)
+			case "h", "hit":
+				bwc.writePresenterResponse(w, bji.Hit(), errOutput)
+			case "s", "stand":
+				bwc.writePresenterResponse(w, bji.Stand(), errOutput)
+			case "b", "bet":
+				bwc.writePresenterResponse(w, bji.Bet(param.Amount), errOutput)
+			case "d", "doubledown":
+				bwc.writePresenterResponse(w, bji.DoubleDown(), errOutput)
+			case "sp", "split":
+				bwc.writePresenterResponse(w, bji.Split(), errOutput)
+			case "i", "insurance":
+				bwc.writePresenterResponse(w, bji.Insurance(), errOutput)
+			case "di", "declineinsurance":
+				bwc.writePresenterResponse(w, bji.DeclineInsurance(), errOutput)
+			case "sur", "surrender":
+				bwc.writePresenterResponse(w, bji.Surrender(), errOutput)
+			case "togglehint":
+				bwc.writePresenterResponse(w, bji.ToggleHint(), errOutput)
+			case "sd", "setdeckcount":
+				bwc.writePresenterResponse(w, bji.SetDeckCount(param.Amount), errOutput)
+			default:
+				return false
+			}
+			return true
+		})
 }
 
 // Stop stops the background cleanup goroutine of the session store.

--- a/internal/adapter/controller/DaifugoWebController.go
+++ b/internal/adapter/controller/DaifugoWebController.go
@@ -1,9 +1,6 @@
 package controller
 
 import (
-	"log"
-	"net/http"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 
@@ -32,6 +29,12 @@ type DaifugoWebInput struct {
 	SessionId string                 `json:"sessionId"`
 	Config    *DaifugoWebInputConfig `json:"config"` // リセット時のローカルルール設定 (省略可)
 }
+
+// GetCommand returns the command string.
+func (i DaifugoWebInput) GetCommand() string { return i.Command }
+
+// GetSessionID returns the session ID string.
+func (i DaifugoWebInput) GetSessionID() string { return i.SessionId }
 
 // DaifugoWebOutputPlayer 大富豪Webアウトプットプレイヤー
 type DaifugoWebOutputPlayer struct {
@@ -109,53 +112,29 @@ func NewDaifugoWebController(factory func() usecase.DaifugoInteractorIF) *Daifug
 
 // Exec ゲーム実行
 func (dwc *DaifugoWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
-	var param DaifugoWebInput
-	err := r.DecodeJsonPayload(&param)
-	if err != nil || param.Command == "" || param.SessionId == "" {
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(dwc.newDefaultOutput("param error.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	if param.Command == "q" || param.Command == "quit" {
-		w.WriteHeader(http.StatusOK)
-		if err := w.WriteJson(dwc.newDefaultOutput("bye.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	dgi, mu, ok := dwc.store.GetWithLock(param.SessionId, dwc.factory)
-	if !ok {
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(dwc.newDefaultOutput("param error.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	mu.Lock()
-	defer mu.Unlock()
-	errOutput := dwc.newDefaultOutput("error.")
-	switch param.Command {
-	case "r", "reset":
-		if param.Config != nil {
-			dgConfig := convertWebInputConfig(*param.Config)
-			dwc.writePresenterResponse(w, dgi.ResetWithConfig(dgConfig), errOutput)
-		} else {
-			dwc.writePresenterResponse(w, dgi.Reset(), errOutput)
-		}
-	case "p", "play":
-		indices := param.Indices
-		if indices == nil {
-			indices = []int{}
-		}
-		dwc.writePresenterResponse(w, dgi.Play(indices), errOutput)
-	default:
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(dwc.newDefaultOutput("Unsupported command.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-	}
+	execWithSession(&dwc.baseController, w, r, dwc.store, dwc.factory,
+		func(msg string) any { return dwc.newDefaultOutput(msg) },
+		nil,
+		func(w rest.ResponseWriter, dgi usecase.DaifugoInteractorIF, param DaifugoWebInput, errOutput any) bool {
+			switch param.Command {
+			case "r", "reset":
+				if param.Config != nil {
+					dgConfig := convertWebInputConfig(*param.Config)
+					dwc.writePresenterResponse(w, dgi.ResetWithConfig(dgConfig), errOutput)
+				} else {
+					dwc.writePresenterResponse(w, dgi.Reset(), errOutput)
+				}
+			case "p", "play":
+				indices := param.Indices
+				if indices == nil {
+					indices = []int{}
+				}
+				dwc.writePresenterResponse(w, dgi.Play(indices), errOutput)
+			default:
+				return false
+			}
+			return true
+		})
 }
 
 // convertWebInputConfig DaifugoWebInputConfig を domain.DaifugoConfig に変換

--- a/internal/adapter/controller/DoubtWebController.go
+++ b/internal/adapter/controller/DoubtWebController.go
@@ -1,8 +1,8 @@
 package controller
 
 import (
+	"errors"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -21,6 +21,12 @@ type DoubtWebInput struct {
 	DoubtWindowSec *int   `json:"doubtWindowSec,omitempty"`
 	CpuMemoryLevel *int   `json:"cpuMemoryLevel,omitempty"`
 }
+
+// GetCommand returns the command string.
+func (i DoubtWebInput) GetCommand() string { return i.Command }
+
+// GetSessionID returns the session ID string.
+func (i DoubtWebInput) GetSessionID() string { return i.SessionId }
 
 // DoubtWebOutputPlayer ダウトWebアウトプットプレイヤー
 type DoubtWebOutputPlayer struct {
@@ -84,86 +90,67 @@ func NewDoubtWebController(factory func() usecase.DoubtInteractorIF) *DoubtWebCo
 // MaxCardIndices カードインデックスの最大数 (52枚デッキ)
 const MaxCardIndices = 52
 
+// errCardIndicesOverflow is returned by the Doubt validate callback when CardIndices exceeds the limit.
+var errCardIndicesOverflow = errors.New("card indices overflow")
+
 // Exec ゲーム実行
 func (dwc *DoubtWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
-	var param DoubtWebInput
-	err := r.DecodeJsonPayload(&param)
-	if err != nil || param.Command == "" || param.SessionId == "" || len(param.CardIndices) > MaxCardIndices {
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(dwc.newDefaultOutput("param error.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	if param.Command == "q" || param.Command == "quit" {
-		w.WriteHeader(http.StatusOK)
-		if err := w.WriteJson(dwc.newDefaultOutput("bye.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	dgi, mu, ok := dwc.store.GetWithLock(param.SessionId, dwc.factory)
-	if !ok {
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(dwc.newDefaultOutput("param error.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	mu.Lock()
-	defer mu.Unlock()
-	errOutput := dwc.newDefaultOutput("error.")
-	switch param.Command {
-	case "r", "reset":
-		cfg := domain.DefaultDoubtConfig()
-		if param.DoubtWindowSec != nil && *param.DoubtWindowSec >= 1 {
-			cfg.DoubtWindowSec = *param.DoubtWindowSec
-		}
-		if param.CpuMemoryLevel != nil {
-			level := *param.CpuMemoryLevel
-			if level >= int(domain.DoubtMemoryLevelEasy) && level <= int(domain.DoubtMemoryLevelHard) {
-				cfg.CpuMemoryLevel = domain.DoubtMemoryLevel(level)
+	execWithSession(&dwc.baseController, w, r, dwc.store, dwc.factory,
+		func(msg string) any { return dwc.newDefaultOutput(msg) },
+		func(param DoubtWebInput) error {
+			if len(param.CardIndices) > MaxCardIndices {
+				return errCardIndicesOverflow
 			}
-		}
-		dwc.writePresenterResponse(w, dgi.ResetWithConfig(cfg), errOutput)
-	case "p", "play":
-		if param.ClaimedValue < domain.MinClaimedValue || param.ClaimedValue > domain.MaxClaimedValue {
-			w.WriteHeader(http.StatusBadRequest)
-			if err := w.WriteJson(dwc.newDefaultOutput(fmt.Sprintf("param error: claimedValue must be between %d and %d.", domain.MinClaimedValue, domain.MaxClaimedValue))); err != nil {
-				log.Printf("WriteJson error: %v", err)
+			return nil
+		},
+		func(w rest.ResponseWriter, dgi usecase.DoubtInteractorIF, param DoubtWebInput, errOutput any) bool {
+			switch param.Command {
+			case "r", "reset":
+				cfg := domain.DefaultDoubtConfig()
+				if param.DoubtWindowSec != nil && *param.DoubtWindowSec >= 1 {
+					cfg.DoubtWindowSec = *param.DoubtWindowSec
+				}
+				if param.CpuMemoryLevel != nil {
+					level := *param.CpuMemoryLevel
+					if level >= int(domain.DoubtMemoryLevelEasy) && level <= int(domain.DoubtMemoryLevelHard) {
+						cfg.CpuMemoryLevel = domain.DoubtMemoryLevel(level)
+					}
+				}
+				dwc.writePresenterResponse(w, dgi.ResetWithConfig(cfg), errOutput)
+			case "p", "play":
+				if param.ClaimedValue < domain.MinClaimedValue || param.ClaimedValue > domain.MaxClaimedValue {
+					dwc.writeJsonResponse(w, http.StatusBadRequest, dwc.newDefaultOutput(fmt.Sprintf("param error: claimedValue must be between %d and %d.", domain.MinClaimedValue, domain.MaxClaimedValue)))
+					return true
+				}
+				dwc.writePresenterResponse(w, dgi.Play(param.CardIndices, param.ClaimedValue), errOutput)
+			case "d", "doubt":
+				cpuDoubters := dgi.GetCpuDoubters()
+				humanDoubts := false
+				for _, idx := range param.DoubterIndices {
+					if idx == 0 {
+						humanDoubts = true
+						break
+					}
+				}
+				var doubters []int
+				if humanDoubts {
+					doubters = append([]int{0}, cpuDoubters...)
+				} else {
+					doubters = cpuDoubters
+				}
+				dwc.writePresenterResponse(w, dgi.ResolveDoubt(doubters), errOutput)
+			case "s", "skip":
+				cpuDoubters := dgi.GetCpuDoubters()
+				if len(cpuDoubters) > 0 {
+					dwc.writePresenterResponse(w, dgi.ResolveDoubt(cpuDoubters), errOutput)
+				} else {
+					dwc.writePresenterResponse(w, dgi.SkipDoubt(), errOutput)
+				}
+			default:
+				return false
 			}
-			return
-		}
-		dwc.writePresenterResponse(w, dgi.Play(param.CardIndices, param.ClaimedValue), errOutput)
-	case "d", "doubt":
-		cpuDoubters := dgi.GetCpuDoubters()
-		humanDoubts := false
-		for _, idx := range param.DoubterIndices {
-			if idx == 0 {
-				humanDoubts = true
-				break
-			}
-		}
-		var doubters []int
-		if humanDoubts {
-			doubters = append([]int{0}, cpuDoubters...)
-		} else {
-			doubters = cpuDoubters
-		}
-		dwc.writePresenterResponse(w, dgi.ResolveDoubt(doubters), errOutput)
-	case "s", "skip":
-		cpuDoubters := dgi.GetCpuDoubters()
-		if len(cpuDoubters) > 0 {
-			dwc.writePresenterResponse(w, dgi.ResolveDoubt(cpuDoubters), errOutput)
-		} else {
-			dwc.writePresenterResponse(w, dgi.SkipDoubt(), errOutput)
-		}
-	default:
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(dwc.newDefaultOutput("Unsupported command.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-	}
+			return true
+		})
 }
 
 // Stop stops the background cleanup goroutine of the session store.

--- a/internal/adapter/controller/HoldemWebController.go
+++ b/internal/adapter/controller/HoldemWebController.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -18,6 +17,12 @@ type HoldemWebInput struct {
 	SmallBlind *int   `json:"smallBlind,omitempty"`
 	BigBlind   *int   `json:"bigBlind,omitempty"`
 }
+
+// GetCommand returns the command string.
+func (i HoldemWebInput) GetCommand() string { return i.Command }
+
+// GetSessionID returns the session ID string.
+func (i HoldemWebInput) GetSessionID() string { return i.SessionId }
 
 // HoldemWebOutputPlayer テキサスホールデムWebアウトプットプレイヤー
 type HoldemWebOutputPlayer struct {
@@ -90,82 +95,55 @@ func NewHoldemWebController(factory func() usecase.HoldemInteractorIF) *HoldemWe
 
 // Exec ゲーム実行
 func (hwc *HoldemWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
-	var param HoldemWebInput
-	err := r.DecodeJsonPayload(&param)
-	if err != nil || param.Command == "" || param.SessionId == "" {
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(hwc.newDefaultOutput("param error.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	if param.Command == "q" || param.Command == "quit" {
-		w.WriteHeader(http.StatusOK)
-		if err := w.WriteJson(hwc.newDefaultOutput("bye.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	hgi, mu, ok := hwc.store.GetWithLock(param.SessionId, hwc.factory)
-	if !ok {
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(hwc.newDefaultOutput("param error.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	mu.Lock()
-	defer mu.Unlock()
-	errOutput := hwc.newDefaultOutput("error.")
-	switch param.Command {
-	case "r", "reset":
-		cfg := domain.DefaultHoldemConfig()
-		sb, bb := cfg.SmallBlind, cfg.BigBlind
-		sbProvided := param.SmallBlind != nil && *param.SmallBlind >= 1
-		bbProvided := param.BigBlind != nil && *param.BigBlind >= 1
-		if sbProvided {
-			sb = *param.SmallBlind
-		}
-		if bbProvided {
-			bb = *param.BigBlind
-		}
-		// 片方のみ指定された場合、もう片方を自動調整
-		if sbProvided && !bbProvided && sb >= cfg.BigBlind {
-			bb = sb * 2
-		} else if bbProvided && !sbProvided && bb > 1 {
-			sb = bb / 2
-			if sb < 1 {
-				sb = 1
+	execWithSession(&hwc.baseController, w, r, hwc.store, hwc.factory,
+		func(msg string) any { return hwc.newDefaultOutput(msg) },
+		nil,
+		func(w rest.ResponseWriter, hgi usecase.HoldemInteractorIF, param HoldemWebInput, errOutput any) bool {
+			switch param.Command {
+			case "r", "reset":
+				cfg := domain.DefaultHoldemConfig()
+				sb, bb := cfg.SmallBlind, cfg.BigBlind
+				sbProvided := param.SmallBlind != nil && *param.SmallBlind >= 1
+				bbProvided := param.BigBlind != nil && *param.BigBlind >= 1
+				if sbProvided {
+					sb = *param.SmallBlind
+				}
+				if bbProvided {
+					bb = *param.BigBlind
+				}
+				// 片方のみ指定された場合、もう片方を自動調整
+				if sbProvided && !bbProvided && sb >= cfg.BigBlind {
+					bb = sb * 2
+				} else if bbProvided && !sbProvided && bb > 1 {
+					sb = bb / 2
+					if sb < 1 {
+						sb = 1
+					}
+				}
+				if sb >= bb {
+					hwc.writeJsonResponse(w, http.StatusBadRequest, hwc.newDefaultOutput("param error: smallBlind must be less than bigBlind."))
+					return true
+				}
+				cfg.SmallBlind = sb
+				cfg.BigBlind = bb
+				hwc.writePresenterResponse(w, hgi.ResetWithConfig(cfg), errOutput)
+			case "f", "fold":
+				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionFold, 0), errOutput)
+			case "ck", "check":
+				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionCheck, 0), errOutput)
+			case "c", "call":
+				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionCall, 0), errOutput)
+			case "b", "bet":
+				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionBet, param.Amount), errOutput)
+			case "ra", "raise":
+				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionRaise, param.Amount), errOutput)
+			case "a", "allin":
+				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionAllIn, 0), errOutput)
+			default:
+				return false
 			}
-		}
-		if sb >= bb {
-			w.WriteHeader(http.StatusBadRequest)
-			if err := w.WriteJson(hwc.newDefaultOutput("param error: smallBlind must be less than bigBlind.")); err != nil {
-				log.Printf("WriteJson error: %v", err)
-			}
-			return
-		}
-		cfg.SmallBlind = sb
-		cfg.BigBlind = bb
-		hwc.writePresenterResponse(w, hgi.ResetWithConfig(cfg), errOutput)
-	case "f", "fold":
-		hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionFold, 0), errOutput)
-	case "ck", "check":
-		hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionCheck, 0), errOutput)
-	case "c", "call":
-		hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionCall, 0), errOutput)
-	case "b", "bet":
-		hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionBet, param.Amount), errOutput)
-	case "ra", "raise":
-		hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionRaise, param.Amount), errOutput)
-	case "a", "allin":
-		hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionAllIn, 0), errOutput)
-	default:
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(hwc.newDefaultOutput("Unsupported command.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-	}
+			return true
+		})
 }
 
 // Stop stops the background cleanup goroutine of the session store.

--- a/internal/adapter/controller/OldMaidWebController.go
+++ b/internal/adapter/controller/OldMaidWebController.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -18,6 +17,12 @@ type OldMaidWebInput struct {
 	Mode                 int    `json:"mode"`
 	CpuPlacementStrategy bool   `json:"cpuPlacementStrategy"`
 }
+
+// GetCommand returns the command string.
+func (i OldMaidWebInput) GetCommand() string { return i.Command }
+
+// GetSessionID returns the session ID string.
+func (i OldMaidWebInput) GetSessionID() string { return i.SessionId }
 
 // OldMaidWebOutputPlayer ババ抜きWebアウトプットプレイヤー
 type OldMaidWebOutputPlayer struct {
@@ -75,59 +80,32 @@ func NewOldMaidWebController(factory func() usecase.OldMaidInteractorIF) *OldMai
 
 // Exec ゲーム実行
 func (owc *OldMaidWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
-	var param OldMaidWebInput
-	err := r.DecodeJsonPayload(&param)
-	if err != nil || param.Command == "" || param.SessionId == "" {
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(owc.newDefaultOutput("param error.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	if param.Command == "q" || param.Command == "quit" {
-		w.WriteHeader(http.StatusOK)
-		if err := w.WriteJson(owc.newDefaultOutput("bye.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	omi, mu, ok := owc.store.GetWithLock(param.SessionId, owc.factory)
-	if !ok {
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(owc.newDefaultOutput("param error.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	drawIdx := -1
-	if param.DrawIdx != nil {
-		drawIdx = *param.DrawIdx
-	}
-	mu.Lock()
-	defer mu.Unlock()
-	errOutput := owc.newDefaultOutput("error.")
-	switch param.Command {
-	case "r", "reset":
-		if param.Mode < 0 || param.Mode > int(domain.OldMaidModeJijiNuki) {
-			w.WriteHeader(http.StatusBadRequest)
-			if err := w.WriteJson(owc.newDefaultOutput("param error: mode must be between 0 and 1.")); err != nil {
-				log.Printf("WriteJson error: %v", err)
+	execWithSession(&owc.baseController, w, r, owc.store, owc.factory,
+		func(msg string) any { return owc.newDefaultOutput(msg) },
+		nil,
+		func(w rest.ResponseWriter, omi usecase.OldMaidInteractorIF, param OldMaidWebInput, errOutput any) bool {
+			switch param.Command {
+			case "r", "reset":
+				if param.Mode < 0 || param.Mode > int(domain.OldMaidModeJijiNuki) {
+					owc.writeJsonResponse(w, http.StatusBadRequest, owc.newDefaultOutput("param error: mode must be between 0 and 1."))
+					return true
+				}
+				cfg := domain.OldMaidConfig{
+					Mode:                 domain.OldMaidMode(param.Mode),
+					CpuPlacementStrategy: param.CpuPlacementStrategy,
+				}
+				owc.writePresenterResponse(w, omi.Reset(cfg), errOutput)
+			case "d", "draw":
+				drawIdx := -1
+				if param.DrawIdx != nil {
+					drawIdx = *param.DrawIdx
+				}
+				owc.writePresenterResponse(w, omi.Draw(drawIdx), errOutput)
+			default:
+				return false
 			}
-			return
-		}
-		cfg := domain.OldMaidConfig{
-			Mode:                 domain.OldMaidMode(param.Mode),
-			CpuPlacementStrategy: param.CpuPlacementStrategy,
-		}
-		owc.writePresenterResponse(w, omi.Reset(cfg), errOutput)
-	case "d", "draw":
-		owc.writePresenterResponse(w, omi.Draw(drawIdx), errOutput)
-	default:
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(owc.newDefaultOutput("Unsupported command.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-	}
+			return true
+		})
 }
 
 // Stop stops the background cleanup goroutine of the session store.

--- a/internal/adapter/controller/PokerWebController.go
+++ b/internal/adapter/controller/PokerWebController.go
@@ -1,9 +1,6 @@
 package controller
 
 import (
-	"log"
-	"net/http"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 
 	"github.com/ant0ine/go-json-rest/rest"
@@ -16,6 +13,12 @@ type PokerWebInput struct {
 	Amount    int    `json:"amount,omitempty"`
 	SessionId string `json:"sessionId"`
 }
+
+// GetCommand returns the command string.
+func (i PokerWebInput) GetCommand() string { return i.Command }
+
+// GetSessionID returns the session ID string.
+func (i PokerWebInput) GetSessionID() string { return i.SessionId }
 
 // PokerWebOutputPlayer ポーカーWebアウトプットプレイヤー
 type PokerWebOutputPlayer struct {
@@ -53,60 +56,36 @@ func NewPokerWebController(factory func() usecase.PokerInteractorIF) *PokerWebCo
 
 // Exec ゲーム実行
 func (pwc *PokerWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
-	var param PokerWebInput
-	err := r.DecodeJsonPayload(&param)
-	if err != nil || param.Command == "" || param.SessionId == "" {
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(pwc.newDefaultOutput("param error.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	if param.Command == "q" || param.Command == "quit" {
-		w.WriteHeader(http.StatusOK)
-		if err := w.WriteJson(pwc.newDefaultOutput("bye.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	pi, mu, ok := pwc.store.GetWithLock(param.SessionId, pwc.factory)
-	if !ok {
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(pwc.newDefaultOutput("param error.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	mu.Lock()
-	defer mu.Unlock()
-	errOutput := pwc.newDefaultOutput("error.")
-	switch param.Command {
-	case "r", "reset":
-		pwc.writePresenterResponse(w, pi.Reset(), errOutput)
-	case "e", "exchange":
-		indices := param.Indices
-		if indices == nil {
-			indices = []int{}
-		}
-		pwc.writePresenterResponse(w, pi.Exchange(indices), errOutput)
-	case "s", "stand":
-		pwc.writePresenterResponse(w, pi.Stand(), errOutput)
-	case "b", "bet":
-		pwc.writePresenterResponse(w, pi.Bet(param.Amount), errOutput)
-	case "c", "call":
-		pwc.writePresenterResponse(w, pi.Call(), errOutput)
-	case "ra", "raise":
-		pwc.writePresenterResponse(w, pi.Raise(param.Amount), errOutput)
-	case "f", "fold":
-		pwc.writePresenterResponse(w, pi.Fold(), errOutput)
-	case "ck", "check":
-		pwc.writePresenterResponse(w, pi.Check(), errOutput)
-	default:
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(pwc.newDefaultOutput("Unsupported command.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-	}
+	execWithSession(&pwc.baseController, w, r, pwc.store, pwc.factory,
+		func(msg string) any { return pwc.newDefaultOutput(msg) },
+		nil,
+		func(w rest.ResponseWriter, pi usecase.PokerInteractorIF, param PokerWebInput, errOutput any) bool {
+			switch param.Command {
+			case "r", "reset":
+				pwc.writePresenterResponse(w, pi.Reset(), errOutput)
+			case "e", "exchange":
+				indices := param.Indices
+				if indices == nil {
+					indices = []int{}
+				}
+				pwc.writePresenterResponse(w, pi.Exchange(indices), errOutput)
+			case "s", "stand":
+				pwc.writePresenterResponse(w, pi.Stand(), errOutput)
+			case "b", "bet":
+				pwc.writePresenterResponse(w, pi.Bet(param.Amount), errOutput)
+			case "c", "call":
+				pwc.writePresenterResponse(w, pi.Call(), errOutput)
+			case "ra", "raise":
+				pwc.writePresenterResponse(w, pi.Raise(param.Amount), errOutput)
+			case "f", "fold":
+				pwc.writePresenterResponse(w, pi.Fold(), errOutput)
+			case "ck", "check":
+				pwc.writePresenterResponse(w, pi.Check(), errOutput)
+			default:
+				return false
+			}
+			return true
+		})
 }
 
 // Stop stops the background cleanup goroutine of the session store.

--- a/internal/adapter/controller/SevensWebController.go
+++ b/internal/adapter/controller/SevensWebController.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -22,6 +21,12 @@ type SevensWebInput struct {
 	MaxPasses        *int   `json:"maxPasses,omitempty"`     // 最大パス回数 (reset時のみ, 0=無制限)
 	SessionId        string `json:"sessionId"`
 }
+
+// GetCommand returns the command string.
+func (i SevensWebInput) GetCommand() string { return i.Command }
+
+// GetSessionID returns the session ID string.
+func (i SevensWebInput) GetSessionID() string { return i.SessionId }
 
 // SevensWebOutputPlayer 7並べWebアウトプットプレイヤー
 type SevensWebOutputPlayer struct {
@@ -83,58 +88,31 @@ func NewSevensWebController(factory func() usecase.SevensInteractorIF) *SevensWe
 
 // Exec ゲーム実行
 func (swc *SevensWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
-	var param SevensWebInput
-	err := r.DecodeJsonPayload(&param)
-	if err != nil || param.Command == "" || param.SessionId == "" {
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(swc.newDefaultOutput("param error.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	if param.Command == "q" || param.Command == "quit" {
-		w.WriteHeader(http.StatusOK)
-		if err := w.WriteJson(swc.newDefaultOutput("bye.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	sgi, mu, ok := swc.store.GetWithLock(param.SessionId, swc.factory)
-	if !ok {
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(swc.newDefaultOutput("param error.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
-	mu.Lock()
-	defer mu.Unlock()
-	errOutput := swc.newDefaultOutput("error.")
-	switch param.Command {
-	case "r", "reset":
-		if param.TunnelEnabled != nil || param.JokerCount != nil || param.CpuStrategy != nil || param.MaxPasses != nil {
-			jokerCount := derefInt(param.JokerCount)
-			if jokerCount < 0 || jokerCount > domain.SevensMaxJokerCount {
-				w.WriteHeader(http.StatusBadRequest)
-				if err := w.WriteJson(swc.newDefaultOutput("param error: jokerCount must be between 0 and 2.")); err != nil {
-					log.Printf("WriteJson error: %v", err)
+	execWithSession(&swc.baseController, w, r, swc.store, swc.factory,
+		func(msg string) any { return swc.newDefaultOutput(msg) },
+		nil,
+		func(w rest.ResponseWriter, sgi usecase.SevensInteractorIF, param SevensWebInput, errOutput any) bool {
+			switch param.Command {
+			case "r", "reset":
+				if param.TunnelEnabled != nil || param.JokerCount != nil || param.CpuStrategy != nil || param.MaxPasses != nil {
+					jokerCount := derefInt(param.JokerCount)
+					if jokerCount < 0 || jokerCount > domain.SevensMaxJokerCount {
+						swc.writeJsonResponse(w, http.StatusBadRequest, swc.newDefaultOutput("param error: jokerCount must be between 0 and 2."))
+						return true
+					}
+					swc.writePresenterResponse(w, sgi.ResetWithConfig(derefBool(param.TunnelEnabled), jokerCount, derefBool(param.CpuStrategy), derefIntDefault(param.MaxPasses, domain.SevensMaxPasses)), errOutput)
+				} else {
+					swc.writePresenterResponse(w, sgi.Reset(), errOutput)
 				}
-				return
+			case "p", "play":
+				swc.writePresenterResponse(w, sgi.Play(param.Index), errOutput)
+			case "j", "joker":
+				swc.writePresenterResponse(w, sgi.PlayJoker(param.Index, param.JokerTargetSuit, param.JokerTargetValue), errOutput)
+			default:
+				return false
 			}
-			swc.writePresenterResponse(w, sgi.ResetWithConfig(derefBool(param.TunnelEnabled), jokerCount, derefBool(param.CpuStrategy), derefIntDefault(param.MaxPasses, domain.SevensMaxPasses)), errOutput)
-		} else {
-			swc.writePresenterResponse(w, sgi.Reset(), errOutput)
-		}
-	case "p", "play":
-		swc.writePresenterResponse(w, sgi.Play(param.Index), errOutput)
-	case "j", "joker":
-		swc.writePresenterResponse(w, sgi.PlayJoker(param.Index, param.JokerTargetSuit, param.JokerTargetValue), errOutput)
-	default:
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(swc.newDefaultOutput("Unsupported command.")); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-	}
+			return true
+		})
 }
 
 func derefBool(p *bool) bool {

--- a/internal/adapter/controller/base_controller.go
+++ b/internal/adapter/controller/base_controller.go
@@ -8,6 +8,12 @@ import (
 	"github.com/ant0ine/go-json-rest/rest"
 )
 
+// WebInput is the interface that all web controller input structs must implement.
+type WebInput interface {
+	GetCommand() string
+	GetSessionID() string
+}
+
 // baseController 各WebController共通のレスポンス書き込みロジック
 type baseController struct{}
 
@@ -23,5 +29,53 @@ func (bc *baseController) writePresenterResponse(w rest.ResponseWriter, response
 	w.WriteHeader(http.StatusOK)
 	if err := w.WriteJson(json.RawMessage(responseStr)); err != nil {
 		log.Printf("WriteJson error: %v", err)
+	}
+}
+
+// writeJsonResponse writes a JSON response with the given HTTP status code.
+func (bc *baseController) writeJsonResponse(w rest.ResponseWriter, status int, body any) {
+	w.WriteHeader(status)
+	if err := w.WriteJson(body); err != nil {
+		log.Printf("WriteJson error: %v", err)
+	}
+}
+
+// execWithSession handles common web controller boilerplate.
+// handler returns true if command was recognized, false for unsupported.
+func execWithSession[P WebInput, T any](
+	bc *baseController,
+	w rest.ResponseWriter,
+	r *rest.Request,
+	store *SessionStore[T],
+	factory func() T,
+	newDefault func(string) any,
+	validate func(P) error,
+	handler func(w rest.ResponseWriter, interactor T, param P, errOutput any) bool,
+) {
+	var param P
+	if err := r.DecodeJsonPayload(&param); err != nil || param.GetCommand() == "" || param.GetSessionID() == "" {
+		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error."))
+		return
+	}
+	if validate != nil {
+		if err := validate(param); err != nil {
+			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error."))
+			return
+		}
+	}
+	if cmd := param.GetCommand(); cmd == "q" || cmd == "quit" {
+		bc.writeJsonResponse(w, http.StatusOK, newDefault("bye."))
+		return
+	}
+	interactor, mu, ok := store.GetWithLock(param.GetSessionID(), factory)
+	if !ok {
+		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error."))
+		return
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	errOutput := newDefault("error.")
+	if !handler(w, interactor, param, errOutput) {
+		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("Unsupported command."))
 	}
 }

--- a/internal/adapter/controller/base_controller_internal_test.go
+++ b/internal/adapter/controller/base_controller_internal_test.go
@@ -1,10 +1,13 @@
 package controller
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/ant0ine/go-json-rest/rest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,6 +28,25 @@ func (fw *failWriter) EncodeJson(v any) ([]byte, error) {
 	return nil, errors.New("encode failed")
 }
 
+// successWriter is a minimal rest.ResponseWriter that records the status code and JSON body.
+type successWriter struct {
+	header     http.Header
+	headerCode int
+	body       any
+}
+
+func newSuccessWriter() *successWriter {
+	return &successWriter{header: http.Header{}}
+}
+
+func (sw *successWriter) Header() http.Header  { return sw.header }
+func (sw *successWriter) WriteHeader(code int) { sw.headerCode = code }
+func (sw *successWriter) WriteJson(v any) error {
+	sw.body = v
+	return nil
+}
+func (sw *successWriter) EncodeJson(v any) ([]byte, error) { return json.Marshal(v) }
+
 func TestWritePresenterResponse_WriteJsonError_Success(t *testing.T) {
 	bc := &baseController{}
 	fw := newFailWriter()
@@ -41,4 +63,205 @@ func TestWritePresenterResponse_WriteJsonError_Error(t *testing.T) {
 	// Empty response string — triggers the error WriteJson path (line 18).
 	bc.writePresenterResponse(fw, "", "fallback")
 	assert.Equal(t, http.StatusBadRequest, fw.headerCode)
+}
+
+// --- writeJsonResponse tests ---
+
+func TestWriteJsonResponse_Success(t *testing.T) {
+	bc := &baseController{}
+	sw := newSuccessWriter()
+
+	bc.writeJsonResponse(sw, http.StatusOK, map[string]string{"msg": "ok"})
+	assert.Equal(t, http.StatusOK, sw.headerCode)
+	assert.Equal(t, map[string]string{"msg": "ok"}, sw.body)
+}
+
+func TestWriteJsonResponse_WriteJsonError(t *testing.T) {
+	bc := &baseController{}
+	fw := newFailWriter()
+
+	// WriteJson fails — should log but not panic.
+	bc.writeJsonResponse(fw, http.StatusBadRequest, "error body")
+	assert.Equal(t, http.StatusBadRequest, fw.headerCode)
+}
+
+// --- execWithSession tests ---
+
+// testInput is a minimal WebInput implementation for testing.
+type testInput struct {
+	Command   string `json:"command"`
+	SessionId string `json:"sessionId"`
+}
+
+func (i testInput) GetCommand() string   { return i.Command }
+func (i testInput) GetSessionID() string { return i.SessionId }
+
+// testInteractor is a trivial interactor for testing.
+type testInteractor struct{}
+
+func TestExecWithSession_DecodeError(t *testing.T) {
+	bc := &baseController{}
+	store := NewSessionStore[*testInteractor]()
+	defer store.Stop()
+	sw := newSuccessWriter()
+	req := makeRestRequest(`{invalid json}`)
+
+	execWithSession(bc, sw, req, store,
+		func() *testInteractor { return &testInteractor{} },
+		func(msg string) any { return map[string]string{"message": msg} },
+		nil,
+		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput, _ any) bool { return true },
+	)
+	assert.Equal(t, http.StatusBadRequest, sw.headerCode)
+	assert.Equal(t, map[string]string{"message": "param error."}, sw.body)
+}
+
+func TestExecWithSession_EmptyCommand(t *testing.T) {
+	bc := &baseController{}
+	store := NewSessionStore[*testInteractor]()
+	defer store.Stop()
+	sw := newSuccessWriter()
+	req := makeRestRequest(`{"command":"","sessionId":"s1"}`)
+
+	execWithSession(bc, sw, req, store,
+		func() *testInteractor { return &testInteractor{} },
+		func(msg string) any { return map[string]string{"message": msg} },
+		nil,
+		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput, _ any) bool { return true },
+	)
+	assert.Equal(t, http.StatusBadRequest, sw.headerCode)
+	assert.Equal(t, map[string]string{"message": "param error."}, sw.body)
+}
+
+func TestExecWithSession_EmptySessionId(t *testing.T) {
+	bc := &baseController{}
+	store := NewSessionStore[*testInteractor]()
+	defer store.Stop()
+	sw := newSuccessWriter()
+	req := makeRestRequest(`{"command":"r","sessionId":""}`)
+
+	execWithSession(bc, sw, req, store,
+		func() *testInteractor { return &testInteractor{} },
+		func(msg string) any { return map[string]string{"message": msg} },
+		nil,
+		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput, _ any) bool { return true },
+	)
+	assert.Equal(t, http.StatusBadRequest, sw.headerCode)
+	assert.Equal(t, map[string]string{"message": "param error."}, sw.body)
+}
+
+func TestExecWithSession_ValidateReturnsError(t *testing.T) {
+	bc := &baseController{}
+	store := NewSessionStore[*testInteractor]()
+	defer store.Stop()
+	sw := newSuccessWriter()
+	req := makeRestRequest(`{"command":"r","sessionId":"s1"}`)
+
+	execWithSession(bc, sw, req, store,
+		func() *testInteractor { return &testInteractor{} },
+		func(msg string) any { return map[string]string{"message": msg} },
+		func(_ testInput) error { return errors.New("invalid") },
+		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput, _ any) bool { return true },
+	)
+	assert.Equal(t, http.StatusBadRequest, sw.headerCode)
+	assert.Equal(t, map[string]string{"message": "param error."}, sw.body)
+}
+
+func TestExecWithSession_ValidateNilSkipped(t *testing.T) {
+	bc := &baseController{}
+	store := NewSessionStore[*testInteractor]()
+	defer store.Stop()
+	sw := newSuccessWriter()
+	req := makeRestRequest(`{"command":"r","sessionId":"s1"}`)
+	handlerCalled := false
+
+	execWithSession(bc, sw, req, store,
+		func() *testInteractor { return &testInteractor{} },
+		func(msg string) any { return map[string]string{"message": msg} },
+		nil,
+		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput, _ any) bool {
+			handlerCalled = true
+			return true
+		},
+	)
+	assert.True(t, handlerCalled)
+}
+
+func TestExecWithSession_QuitCommand(t *testing.T) {
+	for _, cmd := range []string{"q", "quit"} {
+		t.Run(cmd, func(t *testing.T) {
+			bc := &baseController{}
+			store := NewSessionStore[*testInteractor]()
+			defer store.Stop()
+			sw := newSuccessWriter()
+			req := makeRestRequest(`{"command":"` + cmd + `","sessionId":"s1"}`)
+
+			execWithSession(bc, sw, req, store,
+				func() *testInteractor { return &testInteractor{} },
+				func(msg string) any { return map[string]string{"message": msg} },
+				nil,
+				func(_ rest.ResponseWriter, _ *testInteractor, _ testInput, _ any) bool { return true },
+			)
+			assert.Equal(t, http.StatusOK, sw.headerCode)
+			assert.Equal(t, map[string]string{"message": "bye."}, sw.body)
+		})
+	}
+}
+
+func TestExecWithSession_SessionRetrievalFailure(t *testing.T) {
+	bc := &baseController{}
+	store := NewSessionStore[*testInteractor]()
+	defer store.Stop()
+	sw := newSuccessWriter()
+	// Session ID exceeding max length triggers GetWithLock failure.
+	longID := strings.Repeat("x", SessionMaxIDLen+1)
+	req := makeRestRequest(`{"command":"r","sessionId":"` + longID + `"}`)
+
+	execWithSession(bc, sw, req, store,
+		func() *testInteractor { return &testInteractor{} },
+		func(msg string) any { return map[string]string{"message": msg} },
+		nil,
+		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput, _ any) bool { return true },
+	)
+	assert.Equal(t, http.StatusBadRequest, sw.headerCode)
+	assert.Equal(t, map[string]string{"message": "param error."}, sw.body)
+}
+
+func TestExecWithSession_HandlerReturnsTrue(t *testing.T) {
+	bc := &baseController{}
+	store := NewSessionStore[*testInteractor]()
+	defer store.Stop()
+	sw := newSuccessWriter()
+	req := makeRestRequest(`{"command":"r","sessionId":"s1"}`)
+
+	execWithSession(bc, sw, req, store,
+		func() *testInteractor { return &testInteractor{} },
+		func(msg string) any { return map[string]string{"message": msg} },
+		nil,
+		func(w rest.ResponseWriter, _ *testInteractor, _ testInput, _ any) bool {
+			bc.writeJsonResponse(w, http.StatusOK, map[string]string{"message": "handled"})
+			return true
+		},
+	)
+	assert.Equal(t, http.StatusOK, sw.headerCode)
+	assert.Equal(t, map[string]string{"message": "handled"}, sw.body)
+}
+
+func TestExecWithSession_HandlerReturnsFalse(t *testing.T) {
+	bc := &baseController{}
+	store := NewSessionStore[*testInteractor]()
+	defer store.Stop()
+	sw := newSuccessWriter()
+	req := makeRestRequest(`{"command":"xyz","sessionId":"s1"}`)
+
+	execWithSession(bc, sw, req, store,
+		func() *testInteractor { return &testInteractor{} },
+		func(msg string) any { return map[string]string{"message": msg} },
+		nil,
+		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput, _ any) bool {
+			return false
+		},
+	)
+	assert.Equal(t, http.StatusBadRequest, sw.headerCode)
+	assert.Equal(t, map[string]string{"message": "Unsupported command."}, sw.body)
 }


### PR DESCRIPTION
## Summary
- Add `WebInput` interface, `writeJsonResponse` helper, and generic `execWithSession` function to `base_controller.go`, extracting ~20 lines of duplicated decode/validate/quit/session/lock/dispatch boilerplate per controller
- Refactor all 7 web controllers (`BlackJack`, `Poker`, `OldMaid`, `Daifugo`, `Sevens`, `Doubt`, `Holdem`) to delegate their `Exec()` methods to `execWithSession`, passing only a game-specific handler callback
- Add comprehensive tests for `writeJsonResponse` and `execWithSession` covering all branches (decode error, empty command/sessionId, validate error, quit, session failure, handler true/false)

Closes #247

## Test plan
- [x] `go test ./internal/adapter/controller/...` — all existing + new tests pass
- [x] `go test ./...` — full suite green
- [x] `go vet ./...` — clean
- [x] Controller coverage 99.8% maintained (pre-existing 0.2% gap in Holdem `sb < 1` branch)
- [x] New functions `writeJsonResponse` and `execWithSession` at 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)