### PR TITLE
fix(controller): prevent duplicate factory execution in GetWithLock

### DIFF
--- a/internal/adapter/controller/session_store.go
+++ b/internal/adapter/controller/session_store.go
@@ -55,21 +55,8 @@ func (s *SessionStore[T]) GetWithLock(id string, factory func() T) (T, *sync.Mut
 		return zero, nil, false
 	}
 	s.mu.Lock()
-	if entry, ok := s.entries[id]; ok {
-		entry.lastUsed = time.Now()
-		s.mu.Unlock()
-		return entry.value, entry.mu, true
-	}
-	if len(s.entries) >= SessionMaxCount {
-		s.mu.Unlock()
-		return zero, nil, false
-	}
-	s.mu.Unlock()
-	// factory() をグローバルmutex外で実行（遅延時のブロッキングを防ぐ）
-	val := factory()
-	s.mu.Lock()
 	defer s.mu.Unlock()
-	// ダブルチェック: 他のゴルーチンが同じIDで作成していないか
+
 	if entry, ok := s.entries[id]; ok {
 		entry.lastUsed = time.Now()
 		return entry.value, entry.mu, true
@@ -77,6 +64,8 @@ func (s *SessionStore[T]) GetWithLock(id string, factory func() T) (T, *sync.Mut
 	if len(s.entries) >= SessionMaxCount {
 		return zero, nil, false
 	}
+
+	val := factory()
 	entry := &sessionEntry[T]{value: val, mu: &sync.Mutex{}, lastUsed: time.Now()}
 	s.entries[id] = entry
 	return entry.value, entry.mu, true

--- a/internal/adapter/controller/session_store_internal_test.go
+++ b/internal/adapter/controller/session_store_internal_test.go
@@ -1,65 +1,12 @@
 package controller
 
 import (
-	"fmt"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
-
-// TestGetWithLock_DoubleCheck_ExistingEntry exercises the branch at line 73-75 where,
-// after releasing the global lock to run factory(), another goroutine has
-// already inserted an entry for the same ID.
-func TestGetWithLock_DoubleCheck_ExistingEntry(t *testing.T) {
-	s := &SessionStore[int]{
-		entries: make(map[string]*sessionEntry[int]),
-		stopCh:  make(chan struct{}),
-	}
-	defer s.Stop()
-
-	existingMu := &sync.Mutex{}
-	factory := func() int {
-		s.mu.Lock()
-		s.entries["race"] = &sessionEntry[int]{value: 42, mu: existingMu, lastUsed: time.Now()}
-		s.mu.Unlock()
-		return 99
-	}
-
-	val, mu, ok := s.GetWithLock("race", factory)
-	assert.True(t, ok)
-	assert.Equal(t, 42, val)
-	assert.Equal(t, existingMu, mu)
-}
-
-// TestGetWithLock_DoubleCheck_AtCapacity exercises the branch at line 77-79 where,
-// after releasing the global lock to run factory(), other goroutines fill the
-// store to capacity.
-func TestGetWithLock_DoubleCheck_AtCapacity(t *testing.T) {
-	s := &SessionStore[int]{
-		entries: make(map[string]*sessionEntry[int]),
-		stopCh:  make(chan struct{}),
-	}
-	defer s.Stop()
-
-	for i := 0; i < SessionMaxCount-1; i++ {
-		s.entries[fmt.Sprintf("x%d", i)] = &sessionEntry[int]{value: i, mu: &sync.Mutex{}, lastUsed: time.Now()}
-	}
-
-	// factory fills the last slot while lock is released
-	factory := func() int {
-		s.mu.Lock()
-		s.entries["blocker"] = &sessionEntry[int]{value: -1, mu: &sync.Mutex{}, lastUsed: time.Now()}
-		s.mu.Unlock()
-		return 999
-	}
-
-	val, mu, ok := s.GetWithLock("new-key", factory)
-	assert.False(t, ok)
-	assert.Equal(t, 0, val)
-	assert.Nil(t, mu)
-}
 
 func TestEvictExpired_RemovesStaleSession(t *testing.T) {
 	s := &SessionStore[int]{


### PR DESCRIPTION
## Summary
- Move `factory()` call inside the global mutex in `SessionStore.GetWithLock` to eliminate the race window where multiple goroutines could concurrently execute `factory()` for the same new session ID
- Replace double-check locking pattern with a single `Lock`/`defer Unlock` flow, removing 67 lines of unnecessary complexity
- Remove two obsolete double-check tests that would deadlock under the new implementation

Closes #246

## Test plan
- [x] `go test ./internal/adapter/controller/...` passes
- [x] `go test ./...` full suite passes
- [x] 100% coverage on all `session_store.go` functions confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)