### PR TITLE
refactor(controller): remove redundant JSON validation from writePresenterResponse

### DIFF
--- a/internal/adapter/controller/BlackJackWebController.go
+++ b/internal/adapter/controller/BlackJackWebController.go
@@ -75,30 +75,30 @@ func (bwc *BlackJackWebController) Exec(w rest.ResponseWriter, r *rest.Request) 
 	execWithSession(&bwc.baseController, w, r, bwc.store, bwc.factory,
 		func(msg string) any { return bwc.newDefaultOutput(msg) },
 		nil,
-		func(w rest.ResponseWriter, bji usecase.BlackJackInteractorIF, param BlackJackWebInput, errOutput any) bool {
+		func(w rest.ResponseWriter, bji usecase.BlackJackInteractorIF, param BlackJackWebInput) bool {
 			switch param.Command {
 			case "r", "reset":
-				bwc.writePresenterResponse(w, bji.Reset(), errOutput)
+				bwc.writePresenterResponse(w, bji.Reset())
 			case "h", "hit":
-				bwc.writePresenterResponse(w, bji.Hit(), errOutput)
+				bwc.writePresenterResponse(w, bji.Hit())
 			case "s", "stand":
-				bwc.writePresenterResponse(w, bji.Stand(), errOutput)
+				bwc.writePresenterResponse(w, bji.Stand())
 			case "b", "bet":
-				bwc.writePresenterResponse(w, bji.Bet(param.Amount), errOutput)
+				bwc.writePresenterResponse(w, bji.Bet(param.Amount))
 			case "d", "doubledown":
-				bwc.writePresenterResponse(w, bji.DoubleDown(), errOutput)
+				bwc.writePresenterResponse(w, bji.DoubleDown())
 			case "sp", "split":
-				bwc.writePresenterResponse(w, bji.Split(), errOutput)
+				bwc.writePresenterResponse(w, bji.Split())
 			case "i", "insurance":
-				bwc.writePresenterResponse(w, bji.Insurance(), errOutput)
+				bwc.writePresenterResponse(w, bji.Insurance())
 			case "di", "declineinsurance":
-				bwc.writePresenterResponse(w, bji.DeclineInsurance(), errOutput)
+				bwc.writePresenterResponse(w, bji.DeclineInsurance())
 			case "sur", "surrender":
-				bwc.writePresenterResponse(w, bji.Surrender(), errOutput)
+				bwc.writePresenterResponse(w, bji.Surrender())
 			case "togglehint":
-				bwc.writePresenterResponse(w, bji.ToggleHint(), errOutput)
+				bwc.writePresenterResponse(w, bji.ToggleHint())
 			case "sd", "setdeckcount":
-				bwc.writePresenterResponse(w, bji.SetDeckCount(param.Amount), errOutput)
+				bwc.writePresenterResponse(w, bji.SetDeckCount(param.Amount))
 			default:
 				return false
 			}

--- a/internal/adapter/controller/BlackJackWebController_test.go
+++ b/internal/adapter/controller/BlackJackWebController_test.go
@@ -174,15 +174,6 @@ func TestBlackJackWebController_Method(t *testing.T) {
 		recorded.CodeIs(http.StatusBadRequest)
 		recorded.ContentTypeIsJson()
 	})
-	t.Run("failed Exec response empty", func(t *testing.T) {
-		bjiMock.On("Reset").Return(``)
-		_ = json.Unmarshal([]byte(`{"command": "r", "sessionId": "test-session-1"}`), &jsonCase1)
-		req := test.MakeSimpleRequest("POST", "http://1.2.3.4/blackjack/exec", &jsonCase1)
-		req.Header.Set("Content-Type", "application/json;charset=UTF-8")
-		recorded := test.RunRequest(t, api.MakeHandler(), req)
-		recorded.CodeIs(http.StatusBadRequest)
-		recorded.ContentTypeIsJson()
-	})
 }
 
 func TestBlackJackWebController_SessionIsolation(t *testing.T) {

--- a/internal/adapter/controller/DaifugoWebController.go
+++ b/internal/adapter/controller/DaifugoWebController.go
@@ -115,21 +115,21 @@ func (dwc *DaifugoWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 	execWithSession(&dwc.baseController, w, r, dwc.store, dwc.factory,
 		func(msg string) any { return dwc.newDefaultOutput(msg) },
 		nil,
-		func(w rest.ResponseWriter, dgi usecase.DaifugoInteractorIF, param DaifugoWebInput, errOutput any) bool {
+		func(w rest.ResponseWriter, dgi usecase.DaifugoInteractorIF, param DaifugoWebInput) bool {
 			switch param.Command {
 			case "r", "reset":
 				if param.Config != nil {
 					dgConfig := convertWebInputConfig(*param.Config)
-					dwc.writePresenterResponse(w, dgi.ResetWithConfig(dgConfig), errOutput)
+					dwc.writePresenterResponse(w, dgi.ResetWithConfig(dgConfig))
 				} else {
-					dwc.writePresenterResponse(w, dgi.Reset(), errOutput)
+					dwc.writePresenterResponse(w, dgi.Reset())
 				}
 			case "p", "play":
 				indices := param.Indices
 				if indices == nil {
 					indices = []int{}
 				}
-				dwc.writePresenterResponse(w, dgi.Play(indices), errOutput)
+				dwc.writePresenterResponse(w, dgi.Play(indices))
 			default:
 				return false
 			}

--- a/internal/adapter/controller/DaifugoWebController_test.go
+++ b/internal/adapter/controller/DaifugoWebController_test.go
@@ -146,16 +146,6 @@ func TestDaifugoWebController_Method(t *testing.T) {
 		recorded.BodyIs(`{"players":[],"currentTurn":0,"tableCards":[],"lastPlayPlayerIdx":0,"gameEndFlag":false,"revolutionActive":false,"elevenBackActive":false,"suitLocked":false,"lockedSuit":"","tableIsSequence":false,"config":{"jokerCount":0,"eightCutEnabled":false,"suitLockEnabled":false,"elevenBackEnabled":false,"sequenceEnabled":false,"cardExchangeEnabled":false,"fiveSkipEnabled":false,"sevenPassEnabled":false,"tenDiscardEnabled":false,"spadeThreeEnabled":false,"capitalFallEnabled":false},"exchangeActions":[],"cpuActions":[],"humanAction":null,"message":"param error.","pendingAction":"none","pendingActionTarget":-1}`)
 	})
 
-	t.Run("failed Exec response empty", func(t *testing.T) {
-		dgiMock.On("Reset").Return(``)
-		_ = json.Unmarshal([]byte(`{"command": "r", "sessionId": "test-session-1"}`), &jsonInput)
-		req := test.MakeSimpleRequest("POST", "http://1.2.3.4/daifugo/exec", &jsonInput)
-		req.Header.Set("Content-Type", "application/json;charset=UTF-8")
-		recorded := test.RunRequest(t, api.MakeHandler(), req)
-		recorded.CodeIs(http.StatusBadRequest)
-		recorded.ContentTypeIsJson()
-		recorded.BodyIs(`{"players":[],"currentTurn":0,"tableCards":[],"lastPlayPlayerIdx":0,"gameEndFlag":false,"revolutionActive":false,"elevenBackActive":false,"suitLocked":false,"lockedSuit":"","tableIsSequence":false,"config":{"jokerCount":0,"eightCutEnabled":false,"suitLockEnabled":false,"elevenBackEnabled":false,"sequenceEnabled":false,"cardExchangeEnabled":false,"fiveSkipEnabled":false,"sevenPassEnabled":false,"tenDiscardEnabled":false,"spadeThreeEnabled":false,"capitalFallEnabled":false},"exchangeActions":[],"cpuActions":[],"humanAction":null,"message":"error.","pendingAction":"none","pendingActionTarget":-1}`)
-	})
 }
 
 func TestDaifugoWebController_SessionIsolation(t *testing.T) {

--- a/internal/adapter/controller/DoubtWebController.go
+++ b/internal/adapter/controller/DoubtWebController.go
@@ -103,7 +103,7 @@ func (dwc *DoubtWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 			}
 			return nil
 		},
-		func(w rest.ResponseWriter, dgi usecase.DoubtInteractorIF, param DoubtWebInput, errOutput any) bool {
+		func(w rest.ResponseWriter, dgi usecase.DoubtInteractorIF, param DoubtWebInput) bool {
 			switch param.Command {
 			case "r", "reset":
 				cfg := domain.DefaultDoubtConfig()
@@ -116,13 +116,13 @@ func (dwc *DoubtWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 						cfg.CpuMemoryLevel = domain.DoubtMemoryLevel(level)
 					}
 				}
-				dwc.writePresenterResponse(w, dgi.ResetWithConfig(cfg), errOutput)
+				dwc.writePresenterResponse(w, dgi.ResetWithConfig(cfg))
 			case "p", "play":
 				if param.ClaimedValue < domain.MinClaimedValue || param.ClaimedValue > domain.MaxClaimedValue {
 					dwc.writeJsonResponse(w, http.StatusBadRequest, dwc.newDefaultOutput(fmt.Sprintf("param error: claimedValue must be between %d and %d.", domain.MinClaimedValue, domain.MaxClaimedValue)))
 					return true
 				}
-				dwc.writePresenterResponse(w, dgi.Play(param.CardIndices, param.ClaimedValue), errOutput)
+				dwc.writePresenterResponse(w, dgi.Play(param.CardIndices, param.ClaimedValue))
 			case "d", "doubt":
 				cpuDoubters := dgi.GetCpuDoubters()
 				humanDoubts := false
@@ -138,13 +138,13 @@ func (dwc *DoubtWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 				} else {
 					doubters = cpuDoubters
 				}
-				dwc.writePresenterResponse(w, dgi.ResolveDoubt(doubters), errOutput)
+				dwc.writePresenterResponse(w, dgi.ResolveDoubt(doubters))
 			case "s", "skip":
 				cpuDoubters := dgi.GetCpuDoubters()
 				if len(cpuDoubters) > 0 {
-					dwc.writePresenterResponse(w, dgi.ResolveDoubt(cpuDoubters), errOutput)
+					dwc.writePresenterResponse(w, dgi.ResolveDoubt(cpuDoubters))
 				} else {
-					dwc.writePresenterResponse(w, dgi.SkipDoubt(), errOutput)
+					dwc.writePresenterResponse(w, dgi.SkipDoubt())
 				}
 			default:
 				return false

--- a/internal/adapter/controller/DoubtWebController_test.go
+++ b/internal/adapter/controller/DoubtWebController_test.go
@@ -252,29 +252,6 @@ func TestDoubtWebController_Method(t *testing.T) {
 	})
 }
 
-func TestDoubtWebController_ResetEmptyResponse(t *testing.T) {
-	dgiMock := new(usecase.MockDoubtInteractor)
-	dgiMock.On("ResetWithConfig", domain.DefaultDoubtConfig()).Return(``)
-
-	factory := func() uc.DoubtInteractorIF { return dgiMock }
-	tdwc := controller.NewDoubtWebController(factory)
-	defer tdwc.Stop()
-	api := rest.NewApi()
-	router, _ := rest.MakeRouter(rest.Post("/doubt/exec", tdwc.Exec))
-	api.SetApp(router)
-
-	t.Run("failed Exec response empty returns error output", func(t *testing.T) {
-		var jsonInput controller.DoubtWebInput
-		_ = json.Unmarshal([]byte(`{"command": "r", "sessionId": "reset-empty-session"}`), &jsonInput)
-		req := test.MakeSimpleRequest("POST", "http://1.2.3.4/doubt/exec", &jsonInput)
-		req.Header.Set("Content-Type", "application/json;charset=UTF-8")
-		recorded := test.RunRequest(t, api.MakeHandler(), req)
-		recorded.CodeIs(http.StatusBadRequest)
-		recorded.ContentTypeIsJson()
-		recorded.BodyIs(mustDoubtOutputJSON("error."))
-	})
-}
-
 func TestDoubtWebController_SkipWithCpuDoubters(t *testing.T) {
 	mockOutput := `{"players":[],"currentTurn":0,"phase":0,"tableCardCount":0,"lastAction":null,"cpuDoubters":[],"cpuActions":[],"humanAction":null,"lastDoubtResult":null,"gameEndFlag":false,"winnerIdx":-1,"message":""}`
 

--- a/internal/adapter/controller/HoldemWebController.go
+++ b/internal/adapter/controller/HoldemWebController.go
@@ -98,7 +98,7 @@ func (hwc *HoldemWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 	execWithSession(&hwc.baseController, w, r, hwc.store, hwc.factory,
 		func(msg string) any { return hwc.newDefaultOutput(msg) },
 		nil,
-		func(w rest.ResponseWriter, hgi usecase.HoldemInteractorIF, param HoldemWebInput, errOutput any) bool {
+		func(w rest.ResponseWriter, hgi usecase.HoldemInteractorIF, param HoldemWebInput) bool {
 			switch param.Command {
 			case "r", "reset":
 				cfg := domain.DefaultHoldemConfig()
@@ -126,19 +126,19 @@ func (hwc *HoldemWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 				}
 				cfg.SmallBlind = sb
 				cfg.BigBlind = bb
-				hwc.writePresenterResponse(w, hgi.ResetWithConfig(cfg), errOutput)
+				hwc.writePresenterResponse(w, hgi.ResetWithConfig(cfg))
 			case "f", "fold":
-				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionFold, 0), errOutput)
+				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionFold, 0))
 			case "ck", "check":
-				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionCheck, 0), errOutput)
+				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionCheck, 0))
 			case "c", "call":
-				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionCall, 0), errOutput)
+				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionCall, 0))
 			case "b", "bet":
-				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionBet, param.Amount), errOutput)
+				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionBet, param.Amount))
 			case "ra", "raise":
-				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionRaise, param.Amount), errOutput)
+				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionRaise, param.Amount))
 			case "a", "allin":
-				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionAllIn, 0), errOutput)
+				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionAllIn, 0))
 			default:
 				return false
 			}

--- a/internal/adapter/controller/HoldemWebController_test.go
+++ b/internal/adapter/controller/HoldemWebController_test.go
@@ -224,17 +224,6 @@ func TestHoldemWebController_ShortCommands(t *testing.T) {
 	}
 }
 
-func TestHoldemWebController_ErrorResponse(t *testing.T) {
-	mi := new(mockUsecase.MockHoldemInteractor)
-	api, hwc := newHoldemTestHandler(mi)
-	defer hwc.Stop()
-	mi.On("Action", domain.HoldemActionFold, 0).Return("invalid json")
-	recorded := test.RunRequest(t, api.MakeHandler(),
-		test.MakeSimpleRequest("POST", "http://localhost/holdem/exec",
-			map[string]interface{}{"command": "fold", "sessionId": "s-err"}))
-	recorded.CodeIs(400)
-}
-
 func TestHoldemWebController_LongSessionId(t *testing.T) {
 	mi := new(mockUsecase.MockHoldemInteractor)
 	api, hwc := newHoldemTestHandler(mi)

--- a/internal/adapter/controller/OldMaidWebController.go
+++ b/internal/adapter/controller/OldMaidWebController.go
@@ -83,7 +83,7 @@ func (owc *OldMaidWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 	execWithSession(&owc.baseController, w, r, owc.store, owc.factory,
 		func(msg string) any { return owc.newDefaultOutput(msg) },
 		nil,
-		func(w rest.ResponseWriter, omi usecase.OldMaidInteractorIF, param OldMaidWebInput, errOutput any) bool {
+		func(w rest.ResponseWriter, omi usecase.OldMaidInteractorIF, param OldMaidWebInput) bool {
 			switch param.Command {
 			case "r", "reset":
 				if param.Mode < 0 || param.Mode > int(domain.OldMaidModeJijiNuki) {
@@ -94,13 +94,13 @@ func (owc *OldMaidWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 					Mode:                 domain.OldMaidMode(param.Mode),
 					CpuPlacementStrategy: param.CpuPlacementStrategy,
 				}
-				owc.writePresenterResponse(w, omi.Reset(cfg), errOutput)
+				owc.writePresenterResponse(w, omi.Reset(cfg))
 			case "d", "draw":
 				drawIdx := -1
 				if param.DrawIdx != nil {
 					drawIdx = *param.DrawIdx
 				}
-				owc.writePresenterResponse(w, omi.Draw(drawIdx), errOutput)
+				owc.writePresenterResponse(w, omi.Draw(drawIdx))
 			default:
 				return false
 			}

--- a/internal/adapter/controller/OldMaidWebController_test.go
+++ b/internal/adapter/controller/OldMaidWebController_test.go
@@ -182,16 +182,6 @@ func TestOldMaidWebController_Method(t *testing.T) {
 		recorded.ContentTypeIsJson()
 		recorded.BodyIs(`{"players":[],"currentTurn":0,"nextDrawTargetIdx":0,"gameEndFlag":false,"loserIdx":0,"lastDrawPlayerIdx":0,"lastDrawFromIdx":0,"lastDrawCard":null,"lastDiscardedPairs":0,"lastDiscardedCards":null,"hasDrawn":false,"cpuActions":[],"humanAction":null,"cpuHighlightedCardIdx":-1,"removedCard":null,"mode":0,"message":"param error."}`)
 	})
-	t.Run("failed Exec response empty", func(t *testing.T) {
-		omiMock.On("Reset", mock.Anything).Return(``)
-		_ = json.Unmarshal([]byte(`{"command": "r", "sessionId": "test-session-1"}`), &jsonInput)
-		req := test.MakeSimpleRequest("POST", "http://1.2.3.4/oldmaid/exec", &jsonInput)
-		req.Header.Set("Content-Type", "application/json;charset=UTF-8")
-		recorded := test.RunRequest(t, api.MakeHandler(), req)
-		recorded.CodeIs(http.StatusBadRequest)
-		recorded.ContentTypeIsJson()
-		recorded.BodyIs(`{"players":[],"currentTurn":0,"nextDrawTargetIdx":0,"gameEndFlag":false,"loserIdx":0,"lastDrawPlayerIdx":0,"lastDrawFromIdx":0,"lastDrawCard":null,"lastDiscardedPairs":0,"lastDiscardedCards":null,"hasDrawn":false,"cpuActions":[],"humanAction":null,"cpuHighlightedCardIdx":-1,"removedCard":null,"mode":0,"message":"error."}`)
-	})
 }
 
 func TestOldMaidWebController_SessionIsolation(t *testing.T) {

--- a/internal/adapter/controller/PokerWebController.go
+++ b/internal/adapter/controller/PokerWebController.go
@@ -59,28 +59,28 @@ func (pwc *PokerWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 	execWithSession(&pwc.baseController, w, r, pwc.store, pwc.factory,
 		func(msg string) any { return pwc.newDefaultOutput(msg) },
 		nil,
-		func(w rest.ResponseWriter, pi usecase.PokerInteractorIF, param PokerWebInput, errOutput any) bool {
+		func(w rest.ResponseWriter, pi usecase.PokerInteractorIF, param PokerWebInput) bool {
 			switch param.Command {
 			case "r", "reset":
-				pwc.writePresenterResponse(w, pi.Reset(), errOutput)
+				pwc.writePresenterResponse(w, pi.Reset())
 			case "e", "exchange":
 				indices := param.Indices
 				if indices == nil {
 					indices = []int{}
 				}
-				pwc.writePresenterResponse(w, pi.Exchange(indices), errOutput)
+				pwc.writePresenterResponse(w, pi.Exchange(indices))
 			case "s", "stand":
-				pwc.writePresenterResponse(w, pi.Stand(), errOutput)
+				pwc.writePresenterResponse(w, pi.Stand())
 			case "b", "bet":
-				pwc.writePresenterResponse(w, pi.Bet(param.Amount), errOutput)
+				pwc.writePresenterResponse(w, pi.Bet(param.Amount))
 			case "c", "call":
-				pwc.writePresenterResponse(w, pi.Call(), errOutput)
+				pwc.writePresenterResponse(w, pi.Call())
 			case "ra", "raise":
-				pwc.writePresenterResponse(w, pi.Raise(param.Amount), errOutput)
+				pwc.writePresenterResponse(w, pi.Raise(param.Amount))
 			case "f", "fold":
-				pwc.writePresenterResponse(w, pi.Fold(), errOutput)
+				pwc.writePresenterResponse(w, pi.Fold())
 			case "ck", "check":
-				pwc.writePresenterResponse(w, pi.Check(), errOutput)
+				pwc.writePresenterResponse(w, pi.Check())
 			default:
 				return false
 			}

--- a/internal/adapter/controller/PokerWebController_test.go
+++ b/internal/adapter/controller/PokerWebController_test.go
@@ -241,16 +241,6 @@ func TestPokerWebController_Method(t *testing.T) {
 		recorded.ContentTypeIsJson()
 		recorded.BodyIs(`{"dealer":{"handRank":0,"handName":"","cards":null,"chips":0,"bet":0},"player":{"handRank":0,"handName":"","cards":null,"chips":0,"bet":0},"phase":0,"message":"param error.","pot":0,"ante":0}`)
 	})
-	t.Run("failed Exec response empty", func(t *testing.T) {
-		piMock.On("Reset").Return(``)
-		_ = json.Unmarshal([]byte(`{"command": "r", "sessionId": "test-session-1"}`), &jsonInput)
-		req := test.MakeSimpleRequest("POST", "http://1.2.3.4/poker/exec", &jsonInput)
-		req.Header.Set("Content-Type", "application/json;charset=UTF-8")
-		recorded := test.RunRequest(t, api.MakeHandler(), req)
-		recorded.CodeIs(http.StatusBadRequest)
-		recorded.ContentTypeIsJson()
-		recorded.BodyIs(`{"dealer":{"handRank":0,"handName":"","cards":null,"chips":0,"bet":0},"player":{"handRank":0,"handName":"","cards":null,"chips":0,"bet":0},"phase":0,"message":"error.","pot":0,"ante":0}`)
-	})
 }
 
 func TestPokerWebController_SessionIsolation(t *testing.T) {

--- a/internal/adapter/controller/SevensWebController.go
+++ b/internal/adapter/controller/SevensWebController.go
@@ -91,7 +91,7 @@ func (swc *SevensWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 	execWithSession(&swc.baseController, w, r, swc.store, swc.factory,
 		func(msg string) any { return swc.newDefaultOutput(msg) },
 		nil,
-		func(w rest.ResponseWriter, sgi usecase.SevensInteractorIF, param SevensWebInput, errOutput any) bool {
+		func(w rest.ResponseWriter, sgi usecase.SevensInteractorIF, param SevensWebInput) bool {
 			switch param.Command {
 			case "r", "reset":
 				if param.TunnelEnabled != nil || param.JokerCount != nil || param.CpuStrategy != nil || param.MaxPasses != nil {
@@ -100,14 +100,14 @@ func (swc *SevensWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
 						swc.writeJsonResponse(w, http.StatusBadRequest, swc.newDefaultOutput("param error: jokerCount must be between 0 and 2."))
 						return true
 					}
-					swc.writePresenterResponse(w, sgi.ResetWithConfig(derefBool(param.TunnelEnabled), jokerCount, derefBool(param.CpuStrategy), derefIntDefault(param.MaxPasses, domain.SevensMaxPasses)), errOutput)
+					swc.writePresenterResponse(w, sgi.ResetWithConfig(derefBool(param.TunnelEnabled), jokerCount, derefBool(param.CpuStrategy), derefIntDefault(param.MaxPasses, domain.SevensMaxPasses)))
 				} else {
-					swc.writePresenterResponse(w, sgi.Reset(), errOutput)
+					swc.writePresenterResponse(w, sgi.Reset())
 				}
 			case "p", "play":
-				swc.writePresenterResponse(w, sgi.Play(param.Index), errOutput)
+				swc.writePresenterResponse(w, sgi.Play(param.Index))
 			case "j", "joker":
-				swc.writePresenterResponse(w, sgi.PlayJoker(param.Index, param.JokerTargetSuit, param.JokerTargetValue), errOutput)
+				swc.writePresenterResponse(w, sgi.PlayJoker(param.Index, param.JokerTargetSuit, param.JokerTargetValue))
 			default:
 				return false
 			}

--- a/internal/adapter/controller/SevensWebController_test.go
+++ b/internal/adapter/controller/SevensWebController_test.go
@@ -149,16 +149,6 @@ func TestSevensWebController_Method(t *testing.T) {
 		recorded.BodyIs(`{"players":[],"currentTurn":0,"tableMinVals":[0,0,0,0,0],"tableMaxVals":[0,0,0,0,0],"tablePlaced":[0,0,0,0,0],"config":{"tunnelEnabled":false,"jokerCount":0,"cpuStrategy":false,"maxPasses":0},"gameEndFlag":false,"cpuActions":[],"humanAction":null,"message":"param error."}`)
 	})
 
-	t.Run("failed Exec response empty", func(t *testing.T) {
-		sgiMock.On("Reset").Return(``)
-		_ = json.Unmarshal([]byte(`{"command": "r", "sessionId": "test-session-1"}`), &jsonInput)
-		req := test.MakeSimpleRequest("POST", "http://1.2.3.4/sevens/exec", &jsonInput)
-		req.Header.Set("Content-Type", "application/json;charset=UTF-8")
-		recorded := test.RunRequest(t, api.MakeHandler(), req)
-		recorded.CodeIs(http.StatusBadRequest)
-		recorded.ContentTypeIsJson()
-		recorded.BodyIs(`{"players":[],"currentTurn":0,"tableMinVals":[0,0,0,0,0],"tableMaxVals":[0,0,0,0,0],"tablePlaced":[0,0,0,0,0],"config":{"tunnelEnabled":false,"jokerCount":0,"cpuStrategy":false,"maxPasses":0},"gameEndFlag":false,"cpuActions":[],"humanAction":null,"message":"error."}`)
-	})
 }
 
 func TestSevensWebController_ResetWithConfig(t *testing.T) {

--- a/internal/adapter/controller/base_controller.go
+++ b/internal/adapter/controller/base_controller.go
@@ -18,14 +18,7 @@ type WebInput interface {
 type baseController struct{}
 
 // writePresenterResponse プレゼンターの出力を再エンコードせず直接書き込む
-func (bc *baseController) writePresenterResponse(w rest.ResponseWriter, responseStr string, errorOutput any) {
-	if responseStr == "" || !json.Valid([]byte(responseStr)) {
-		w.WriteHeader(http.StatusBadRequest)
-		if err := w.WriteJson(errorOutput); err != nil {
-			log.Printf("WriteJson error: %v", err)
-		}
-		return
-	}
+func (bc *baseController) writePresenterResponse(w rest.ResponseWriter, responseStr string) {
 	w.WriteHeader(http.StatusOK)
 	if err := w.WriteJson(json.RawMessage(responseStr)); err != nil {
 		log.Printf("WriteJson error: %v", err)
@@ -50,7 +43,7 @@ func execWithSession[P WebInput, T any](
 	factory func() T,
 	newDefault func(string) any,
 	validate func(P) error,
-	handler func(w rest.ResponseWriter, interactor T, param P, errOutput any) bool,
+	handler func(w rest.ResponseWriter, interactor T, param P) bool,
 ) {
 	var param P
 	if err := r.DecodeJsonPayload(&param); err != nil || param.GetCommand() == "" || param.GetSessionID() == "" {
@@ -74,8 +67,7 @@ func execWithSession[P WebInput, T any](
 	}
 	mu.Lock()
 	defer mu.Unlock()
-	errOutput := newDefault("error.")
-	if !handler(w, interactor, param, errOutput) {
+	if !handler(w, interactor, param) {
 		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("Unsupported command."))
 	}
 }

--- a/internal/adapter/controller/base_controller_internal_test.go
+++ b/internal/adapter/controller/base_controller_internal_test.go
@@ -47,22 +47,13 @@ func (sw *successWriter) WriteJson(v any) error {
 }
 func (sw *successWriter) EncodeJson(v any) ([]byte, error) { return json.Marshal(v) }
 
-func TestWritePresenterResponse_WriteJsonError_Success(t *testing.T) {
+func TestWritePresenterResponse_WriteJsonError(t *testing.T) {
 	bc := &baseController{}
 	fw := newFailWriter()
 
-	// Valid JSON response string — triggers the success WriteJson path (line 24).
-	bc.writePresenterResponse(fw, `{"ok":true}`, "fallback")
+	// Valid JSON response string — triggers the WriteJson error path.
+	bc.writePresenterResponse(fw, `{"ok":true}`)
 	assert.Equal(t, http.StatusOK, fw.headerCode)
-}
-
-func TestWritePresenterResponse_WriteJsonError_Error(t *testing.T) {
-	bc := &baseController{}
-	fw := newFailWriter()
-
-	// Empty response string — triggers the error WriteJson path (line 18).
-	bc.writePresenterResponse(fw, "", "fallback")
-	assert.Equal(t, http.StatusBadRequest, fw.headerCode)
 }
 
 // --- writeJsonResponse tests ---
@@ -110,7 +101,7 @@ func TestExecWithSession_DecodeError(t *testing.T) {
 		func() *testInteractor { return &testInteractor{} },
 		func(msg string) any { return map[string]string{"message": msg} },
 		nil,
-		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput, _ any) bool { return true },
+		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput) bool { return true },
 	)
 	assert.Equal(t, http.StatusBadRequest, sw.headerCode)
 	assert.Equal(t, map[string]string{"message": "param error."}, sw.body)
@@ -127,7 +118,7 @@ func TestExecWithSession_EmptyCommand(t *testing.T) {
 		func() *testInteractor { return &testInteractor{} },
 		func(msg string) any { return map[string]string{"message": msg} },
 		nil,
-		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput, _ any) bool { return true },
+		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput) bool { return true },
 	)
 	assert.Equal(t, http.StatusBadRequest, sw.headerCode)
 	assert.Equal(t, map[string]string{"message": "param error."}, sw.body)
@@ -144,7 +135,7 @@ func TestExecWithSession_EmptySessionId(t *testing.T) {
 		func() *testInteractor { return &testInteractor{} },
 		func(msg string) any { return map[string]string{"message": msg} },
 		nil,
-		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput, _ any) bool { return true },
+		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput) bool { return true },
 	)
 	assert.Equal(t, http.StatusBadRequest, sw.headerCode)
 	assert.Equal(t, map[string]string{"message": "param error."}, sw.body)
@@ -161,7 +152,7 @@ func TestExecWithSession_ValidateReturnsError(t *testing.T) {
 		func() *testInteractor { return &testInteractor{} },
 		func(msg string) any { return map[string]string{"message": msg} },
 		func(_ testInput) error { return errors.New("invalid") },
-		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput, _ any) bool { return true },
+		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput) bool { return true },
 	)
 	assert.Equal(t, http.StatusBadRequest, sw.headerCode)
 	assert.Equal(t, map[string]string{"message": "param error."}, sw.body)
@@ -179,7 +170,7 @@ func TestExecWithSession_ValidateNilSkipped(t *testing.T) {
 		func() *testInteractor { return &testInteractor{} },
 		func(msg string) any { return map[string]string{"message": msg} },
 		nil,
-		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput, _ any) bool {
+		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput) bool {
 			handlerCalled = true
 			return true
 		},
@@ -200,7 +191,7 @@ func TestExecWithSession_QuitCommand(t *testing.T) {
 				func() *testInteractor { return &testInteractor{} },
 				func(msg string) any { return map[string]string{"message": msg} },
 				nil,
-				func(_ rest.ResponseWriter, _ *testInteractor, _ testInput, _ any) bool { return true },
+				func(_ rest.ResponseWriter, _ *testInteractor, _ testInput) bool { return true },
 			)
 			assert.Equal(t, http.StatusOK, sw.headerCode)
 			assert.Equal(t, map[string]string{"message": "bye."}, sw.body)
@@ -221,7 +212,7 @@ func TestExecWithSession_SessionRetrievalFailure(t *testing.T) {
 		func() *testInteractor { return &testInteractor{} },
 		func(msg string) any { return map[string]string{"message": msg} },
 		nil,
-		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput, _ any) bool { return true },
+		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput) bool { return true },
 	)
 	assert.Equal(t, http.StatusBadRequest, sw.headerCode)
 	assert.Equal(t, map[string]string{"message": "param error."}, sw.body)
@@ -238,7 +229,7 @@ func TestExecWithSession_HandlerReturnsTrue(t *testing.T) {
 		func() *testInteractor { return &testInteractor{} },
 		func(msg string) any { return map[string]string{"message": msg} },
 		nil,
-		func(w rest.ResponseWriter, _ *testInteractor, _ testInput, _ any) bool {
+		func(w rest.ResponseWriter, _ *testInteractor, _ testInput) bool {
 			bc.writeJsonResponse(w, http.StatusOK, map[string]string{"message": "handled"})
 			return true
 		},
@@ -258,7 +249,7 @@ func TestExecWithSession_HandlerReturnsFalse(t *testing.T) {
 		func() *testInteractor { return &testInteractor{} },
 		func(msg string) any { return map[string]string{"message": msg} },
 		nil,
-		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput, _ any) bool {
+		func(_ rest.ResponseWriter, _ *testInteractor, _ testInput) bool {
 			return false
 		},
 	)


### PR DESCRIPTION
## Summary
- Remove `errorOutput` parameter and `json.Valid()` check from `writePresenterResponse` since all presenters produce JSON via `json.Marshal()`, which guarantees validity
- Remove `errOutput` plumbing through `execWithSession` handler signatures across all 7 web controllers
- Remove now-dead "empty response" test cases from all controller test files

Closes #251

## Test plan
- [x] `go test ./...` — all pass
- [x] `cd frontend && npm run build` — success
- [x] `cd frontend && npm run check` — clean
- [x] `cd frontend && npm test` — all 490 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)