### PR TITLE
refactor(domain): extract shared BlackJack judge/payout logic

### DIFF
--- a/internal/domain/BlackJack.go
+++ b/internal/domain/BlackJack.go
@@ -447,7 +447,7 @@ func (b *BlackJack) endGame() {
 
 // judgeHandCore 共通ハンド勝敗判定ロジック
 // handCount はスプリットBJ抑制用: handCount==1 の場合のみプレイヤーBJとして判定
-func (b *BlackJack) judgeHandCore(hand *BlackJackHand, handCount int) GameResult {
+func (b *BlackJack) judgeHandCore(hand *BlackJackHand, handCount int /* 1=single hand, >1=split */) GameResult {
 	playerScore := hand.GetScore()
 	dealerScore := b.dealer.GetScore()
 
@@ -480,7 +480,7 @@ func (b *BlackJack) judgeHandCore(hand *BlackJackHand, handCount int) GameResult
 
 // payoutHand 共通ハンド精算ロジック
 // handCount はBJ 3:2配当判定用: handCount==1 かつ BJ の場合のみ 3:2 配当
-func (b *BlackJack) payoutHand(player *BlackJackPlayer, hand *BlackJackHand, handCount int, result GameResult) {
+func payoutHand(player *BlackJackPlayer, hand *BlackJackHand, handCount int /* 1=single hand, >1=split */, result GameResult) {
 	bet := hand.GetBet()
 	switch result {
 	case GameResultWin:
@@ -556,7 +556,7 @@ func (b *BlackJack) resolvePayouts() {
 			continue
 		}
 		result := b.judgeHand(hand)
-		b.payoutHand(b.player, hand, len(b.playerHands), result)
+		payoutHand(b.player, hand, len(b.playerHands), result)
 	}
 }
 
@@ -983,7 +983,7 @@ func (b *BlackJack) resolvePayoutsCpu() {
 				continue
 			}
 			result := b.judgeCpuHand(hand)
-			b.payoutHand(cpu.GetPlayer(), hand, len(cpu.GetHands()), result)
+			payoutHand(cpu.GetPlayer(), hand, len(cpu.GetHands()), result)
 		}
 	}
 }

--- a/internal/domain/blackjack_internal_test.go
+++ b/internal/domain/blackjack_internal_test.go
@@ -404,7 +404,6 @@ func TestJudgeHandCore(t *testing.T) {
 
 func TestPayoutHand(t *testing.T) {
 	t.Run("win with BJ and handCount=1 gets 3:2 payout", func(t *testing.T) {
-		bj, _, _ := setupInternalTestBJ(1000, 1000)
 		player := NewBlackJackPlayer()
 		player.SetChips(900)
 
@@ -413,12 +412,11 @@ func TestPayoutHand(t *testing.T) {
 		hand.AddCard(NewCard(CardDesignDiamond, 13, false)) // BJ
 		hand.SetBet(100)
 
-		bj.payoutHand(player, hand, 1, GameResultWin)
+		payoutHand(player, hand, 1, GameResultWin)
 		assert.Equal(t, 900+250, player.GetChips()) // 100 + 150 = 250
 	})
 
 	t.Run("win with BJ but handCount>1 gets 2x payout", func(t *testing.T) {
-		bj, _, _ := setupInternalTestBJ(1000, 1000)
 		player := NewBlackJackPlayer()
 		player.SetChips(900)
 
@@ -427,12 +425,11 @@ func TestPayoutHand(t *testing.T) {
 		hand.AddCard(NewCard(CardDesignDiamond, 13, false)) // BJ
 		hand.SetBet(100)
 
-		bj.payoutHand(player, hand, 2, GameResultWin)
+		payoutHand(player, hand, 2, GameResultWin)
 		assert.Equal(t, 900+200, player.GetChips()) // normal 2x
 	})
 
 	t.Run("win without BJ gets 2x payout", func(t *testing.T) {
-		bj, _, _ := setupInternalTestBJ(1000, 1000)
 		player := NewBlackJackPlayer()
 		player.SetChips(900)
 
@@ -441,12 +438,11 @@ func TestPayoutHand(t *testing.T) {
 		hand.AddCard(NewCard(CardDesignDiamond, 9, false)) // 19, not BJ
 		hand.SetBet(100)
 
-		bj.payoutHand(player, hand, 1, GameResultWin)
+		payoutHand(player, hand, 1, GameResultWin)
 		assert.Equal(t, 900+200, player.GetChips())
 	})
 
 	t.Run("draw returns bet", func(t *testing.T) {
-		bj, _, _ := setupInternalTestBJ(1000, 1000)
 		player := NewBlackJackPlayer()
 		player.SetChips(900)
 
@@ -455,12 +451,11 @@ func TestPayoutHand(t *testing.T) {
 		hand.AddCard(NewCard(CardDesignDiamond, 8, false))
 		hand.SetBet(100)
 
-		bj.payoutHand(player, hand, 1, GameResultDraw)
+		payoutHand(player, hand, 1, GameResultDraw)
 		assert.Equal(t, 900+100, player.GetChips())
 	})
 
 	t.Run("lose adds nothing", func(t *testing.T) {
-		bj, _, _ := setupInternalTestBJ(1000, 1000)
 		player := NewBlackJackPlayer()
 		player.SetChips(900)
 
@@ -469,7 +464,7 @@ func TestPayoutHand(t *testing.T) {
 		hand.AddCard(NewCard(CardDesignDiamond, 7, false))
 		hand.SetBet(100)
 
-		bj.payoutHand(player, hand, 1, GameResultLose)
+		payoutHand(player, hand, 1, GameResultLose)
 		assert.Equal(t, 900, player.GetChips())
 	})
 }


### PR DESCRIPTION
## Summary
- Add `judgeHandCore(hand, handCount)` and `payoutHand(player, hand, handCount, result)` shared methods to eliminate ~90 lines of duplicated score comparison and payout switch logic between human and CPU paths
- Simplify `judgeHand`, `judgeCpuHand`, `resolvePayouts`, and `resolvePayoutsCpu` to thin wrappers over the shared core
- Add 15 new test sub-tests (`TestJudgeHandCore` x10, `TestPayoutHand` x5) with 100% branch coverage on all modified functions

Closes #283

## Test plan
- [x] All new tests pass (`TestJudgeHandCore`, `TestPayoutHand`)
- [x] All existing tests pass unchanged (`TestJudgeCpuHand`, `TestResolvePayoutsCpuInternal`, `TestBlackJack_JudgeHand_*`)
- [x] Full test suite passes (`go test ./...`)
- [x] 100% coverage on `judgeHandCore`, `payoutHand`, `judgeHand`, `judgeCpuHand`, `resolvePayouts`, `resolvePayoutsCpu`

🤖 Generated with [Claude Code](https://claude.com/claude-code)