### PR TITLE
refactor(domain): extract ChipHolder embedded struct

### DIFF
--- a/internal/domain/BlackJackPlayer.go
+++ b/internal/domain/BlackJackPlayer.go
@@ -3,7 +3,7 @@ package domain
 // BlackJackPlayer ブラックジャックプレイヤークラス
 type BlackJackPlayer struct {
 	Player     // 親クラス
-	chips  int // チップ
+	ChipHolder // チップ管理
 }
 
 // NewBlackJackPlayer コンストラクタ
@@ -12,7 +12,6 @@ func NewBlackJackPlayer() *BlackJackPlayer {
 		Player: Player{
 			cards: make([]*Card, 0),
 		},
-		chips: 0,
 	}
 }
 
@@ -24,30 +23,6 @@ func (bp *BlackJackPlayer) AddCard(card *Card) {
 // GetScore 手札から現在のスコア計算
 func (bp *BlackJackPlayer) GetScore() int {
 	return CalculateBlackJackScore(bp.cards)
-}
-
-// GetChips チップ取得
-func (bp *BlackJackPlayer) GetChips() int {
-	return bp.chips
-}
-
-// SetChips チップ設定
-func (bp *BlackJackPlayer) SetChips(chips int) {
-	bp.chips = chips
-}
-
-// AddChips チップ追加
-func (bp *BlackJackPlayer) AddChips(amount int) {
-	bp.chips += amount
-}
-
-// SubtractChips チップ減算 (不足時はfalseを返す)
-func (bp *BlackJackPlayer) SubtractChips(amount int) bool {
-	if bp.chips < amount {
-		return false
-	}
-	bp.chips -= amount
-	return true
 }
 
 // IsSoft ソフトハンド（11として有効なエースを含む）かどうか判定

--- a/internal/domain/BlackJackPlayer_test.go
+++ b/internal/domain/BlackJackPlayer_test.go
@@ -49,28 +49,3 @@ func TestBlackJackPlayer_Method(t *testing.T) {
 		assert.Equal(t, 23, tbp.GetScore())
 	})
 }
-
-func TestBlackJackPlayer_Chips(t *testing.T) {
-	tbp := domain.NewBlackJackPlayer()
-	t.Run("initial chips is 0", func(t *testing.T) {
-		assert.Equal(t, 0, tbp.GetChips())
-	})
-	t.Run("SetChips", func(t *testing.T) {
-		tbp.SetChips(1000)
-		assert.Equal(t, 1000, tbp.GetChips())
-	})
-	t.Run("AddChips", func(t *testing.T) {
-		tbp.AddChips(500)
-		assert.Equal(t, 1500, tbp.GetChips())
-	})
-	t.Run("SubtractChips success", func(t *testing.T) {
-		ok := tbp.SubtractChips(300)
-		assert.True(t, ok)
-		assert.Equal(t, 1200, tbp.GetChips())
-	})
-	t.Run("SubtractChips insufficient", func(t *testing.T) {
-		ok := tbp.SubtractChips(2000)
-		assert.False(t, ok)
-		assert.Equal(t, 1200, tbp.GetChips())
-	})
-}

--- a/internal/domain/ChipHolder.go
+++ b/internal/domain/ChipHolder.go
@@ -1,0 +1,30 @@
+package domain
+
+// ChipHolder チップ管理の共通構造体
+type ChipHolder struct {
+	chips int
+}
+
+// GetChips チップ取得
+func (ch *ChipHolder) GetChips() int {
+	return ch.chips
+}
+
+// SetChips チップ設定
+func (ch *ChipHolder) SetChips(chips int) {
+	ch.chips = chips
+}
+
+// AddChips チップ追加
+func (ch *ChipHolder) AddChips(amount int) {
+	ch.chips += amount
+}
+
+// SubtractChips チップ減算 (不足時はfalseを返す)
+func (ch *ChipHolder) SubtractChips(amount int) bool {
+	if ch.chips < amount {
+		return false
+	}
+	ch.chips -= amount
+	return true
+}

--- a/internal/domain/ChipHolder_test.go
+++ b/internal/domain/ChipHolder_test.go
@@ -1,0 +1,57 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChipHolder_GetChips(t *testing.T) {
+	t.Run("initial value is 0", func(t *testing.T) {
+		ch := ChipHolder{}
+		assert.Equal(t, 0, ch.GetChips())
+	})
+}
+
+func TestChipHolder_SetChips(t *testing.T) {
+	t.Run("sets chips to given value", func(t *testing.T) {
+		ch := ChipHolder{}
+		ch.SetChips(1000)
+		assert.Equal(t, 1000, ch.GetChips())
+	})
+}
+
+func TestChipHolder_AddChips(t *testing.T) {
+	t.Run("adds amount to current chips", func(t *testing.T) {
+		ch := ChipHolder{}
+		ch.SetChips(500)
+		ch.AddChips(300)
+		assert.Equal(t, 800, ch.GetChips())
+	})
+}
+
+func TestChipHolder_SubtractChips(t *testing.T) {
+	t.Run("sufficient chips returns true and subtracts", func(t *testing.T) {
+		ch := ChipHolder{}
+		ch.SetChips(1000)
+		ok := ch.SubtractChips(300)
+		assert.True(t, ok)
+		assert.Equal(t, 700, ch.GetChips())
+	})
+
+	t.Run("exact chips returns true and zeroes out", func(t *testing.T) {
+		ch := ChipHolder{}
+		ch.SetChips(500)
+		ok := ch.SubtractChips(500)
+		assert.True(t, ok)
+		assert.Equal(t, 0, ch.GetChips())
+	})
+
+	t.Run("insufficient chips returns false and unchanged", func(t *testing.T) {
+		ch := ChipHolder{}
+		ch.SetChips(100)
+		ok := ch.SubtractChips(200)
+		assert.False(t, ok)
+		assert.Equal(t, 100, ch.GetChips())
+	})
+}

--- a/internal/domain/HoldemPlayer.go
+++ b/internal/domain/HoldemPlayer.go
@@ -5,8 +5,8 @@ import "sort"
 // HoldemPlayer テキサスホールデムプレイヤークラス
 type HoldemPlayer struct {
 	Player                     // 親クラス
+	ChipHolder                 // チップ管理
 	isHuman    bool            // 人間フラグ
-	chips      int             // チップ
 	handRank   int             // ベストハンドランク
 	bestHand   []*Card         // ベスト5枚
 	folded     bool            // フォールド済
@@ -29,24 +29,6 @@ func NewHoldemPlayer(isHuman bool, style HoldemPlayStyle) *HoldemPlayer {
 
 // GetIsHuman 人間フラグ取得
 func (hp *HoldemPlayer) GetIsHuman() bool { return hp.isHuman }
-
-// GetChips チップ取得
-func (hp *HoldemPlayer) GetChips() int { return hp.chips }
-
-// SetChips チップ設定
-func (hp *HoldemPlayer) SetChips(chips int) { hp.chips = chips }
-
-// AddChips チップ追加
-func (hp *HoldemPlayer) AddChips(amount int) { hp.chips += amount }
-
-// SubtractChips チップ減算 (不足時はfalseを返す)
-func (hp *HoldemPlayer) SubtractChips(amount int) bool {
-	if hp.chips < amount {
-		return false
-	}
-	hp.chips -= amount
-	return true
-}
 
 // GetHandRank ハンドランク取得
 func (hp *HoldemPlayer) GetHandRank() int { return hp.handRank }

--- a/internal/domain/HoldemPlayer_test.go
+++ b/internal/domain/HoldemPlayer_test.go
@@ -17,24 +17,6 @@ func TestNewHoldemPlayer(t *testing.T) {
 	assert.Equal(t, 0, p.GetCardsSize())
 }
 
-func TestHoldemPlayer_ChipOperations(t *testing.T) {
-	p := NewHoldemPlayer(false, HoldemStyleLAP)
-
-	p.SetChips(1000)
-	assert.Equal(t, 1000, p.GetChips())
-
-	p.AddChips(500)
-	assert.Equal(t, 1500, p.GetChips())
-
-	ok := p.SubtractChips(200)
-	assert.True(t, ok)
-	assert.Equal(t, 1300, p.GetChips())
-
-	ok = p.SubtractChips(2000)
-	assert.False(t, ok)
-	assert.Equal(t, 1300, p.GetChips())
-}
-
 func TestHoldemPlayer_SettersGetters(t *testing.T) {
 	p := NewHoldemPlayer(true, HoldemStyleTAG)
 
@@ -474,7 +456,7 @@ func TestHoldemPlayer_HUDStats(t *testing.T) {
 		assert.Equal(t, 4, p.GetTotalHands())
 		assert.Equal(t, 3, p.GetVPIPCount())
 		assert.Equal(t, 1, p.GetPFRCount())
-		assert.Equal(t, 75, p.GetVPIP())  // 3*100/4=75
-		assert.Equal(t, 25, p.GetPFR())   // 1*100/4=25
+		assert.Equal(t, 75, p.GetVPIP()) // 3*100/4=75
+		assert.Equal(t, 25, p.GetPFR())  // 1*100/4=25
 	})
 }

--- a/internal/domain/PokerPlayer.go
+++ b/internal/domain/PokerPlayer.go
@@ -33,8 +33,8 @@ var PokerHandNames = []string{
 // PokerPlayer ポーカープレイヤークラス
 type PokerPlayer struct {
 	Player                       // 親クラス
+	ChipHolder                   // チップ管理
 	handRank      int            // ハンドランク
-	chips         int            // チップ
 	isHuman       bool           // 人間フラグ
 	folded        bool           // フォールド済
 	allIn         bool           // オールイン済
@@ -83,30 +83,6 @@ func (pp *PokerPlayer) GetHandName() string {
 		return PokerHandNames[pp.handRank]
 	}
 	return "Unknown"
-}
-
-// GetChips チップ取得
-func (pp *PokerPlayer) GetChips() int {
-	return pp.chips
-}
-
-// SetChips チップ設定
-func (pp *PokerPlayer) SetChips(chips int) {
-	pp.chips = chips
-}
-
-// AddChips チップ追加
-func (pp *PokerPlayer) AddChips(amount int) {
-	pp.chips += amount
-}
-
-// SubtractChips チップ減算 (不足時はfalseを返す)
-func (pp *PokerPlayer) SubtractChips(amount int) bool {
-	if pp.chips < amount {
-		return false
-	}
-	pp.chips -= amount
-	return true
 }
 
 // GetIsHuman 人間フラグ取得

--- a/internal/domain/PokerPlayer_test.go
+++ b/internal/domain/PokerPlayer_test.go
@@ -171,51 +171,6 @@ func TestPokerPlayer_GetHandName(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// GetChips / SetChips / AddChips
-// ---------------------------------------------------------------------------
-
-func TestPokerPlayer_Chips(t *testing.T) {
-	p := NewPokerPlayer(true, PokerStyleBalanced)
-	assert.Equal(t, 0, p.GetChips())
-
-	p.SetChips(500)
-	assert.Equal(t, 500, p.GetChips())
-
-	p.AddChips(200)
-	assert.Equal(t, 700, p.GetChips())
-}
-
-// ---------------------------------------------------------------------------
-// SubtractChips
-// ---------------------------------------------------------------------------
-
-func TestPokerPlayer_SubtractChips(t *testing.T) {
-	t.Run("sufficient chips returns true", func(t *testing.T) {
-		p := NewPokerPlayer(true, PokerStyleBalanced)
-		p.SetChips(100)
-		ok := p.SubtractChips(60)
-		assert.True(t, ok)
-		assert.Equal(t, 40, p.GetChips())
-	})
-
-	t.Run("exact chips returns true", func(t *testing.T) {
-		p := NewPokerPlayer(true, PokerStyleBalanced)
-		p.SetChips(100)
-		ok := p.SubtractChips(100)
-		assert.True(t, ok)
-		assert.Equal(t, 0, p.GetChips())
-	})
-
-	t.Run("insufficient chips returns false and chips unchanged", func(t *testing.T) {
-		p := NewPokerPlayer(true, PokerStyleBalanced)
-		p.SetChips(10)
-		ok := p.SubtractChips(50)
-		assert.False(t, ok)
-		assert.Equal(t, 10, p.GetChips())
-	})
-}
-
-// ---------------------------------------------------------------------------
 // GetIsHuman / GetFolded / SetFolded / GetAllIn / SetAllIn
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Extracted a shared `ChipHolder` struct (`GetChips`, `SetChips`, `AddChips`, `SubtractChips`) and embedded it in `BlackJackPlayer`, `PokerPlayer`, and `HoldemPlayer`, eliminating ~60 lines of duplicated chip methods
- Added `ChipHolder_test.go` with 100% branch coverage; removed redundant chip tests from the three player test files
- All existing tests pass; `BettingPlayer` interface satisfaction is preserved via promoted methods

Closes #284

## Test plan
- [x] `go test ./...` passes
- [x] `ChipHolder_test.go` covers all 4 methods including insufficient-chips branch
- [x] Verified `BlackJackPlayer`, `PokerPlayer`, `HoldemPlayer` still satisfy `BettingPlayer` interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)