### PR TITLE
refactor(presenter): extract shared getPlayerName into generic cuiPlayerName

### DIFF
--- a/internal/adapter/presenter/DaifugoCuiPresenter.go
+++ b/internal/adapter/presenter/DaifugoCuiPresenter.go
@@ -79,8 +79,8 @@ func (p *DaifugoCuiPresenter) Output(dg interfaces.DaifugoGame, lastErr error) s
 				cardStrs[i] = cuiCardStr(c)
 			}
 			fmt.Fprintf(&b, "%s → %s: %s\n",
-				p.getPlayerName(dg, ex.FromPlayerIdx),
-				p.getPlayerName(dg, ex.ToPlayerIdx),
+				cuiPlayerName(dg.GetPlayer(ex.FromPlayerIdx), ex.FromPlayerIdx),
+				cuiPlayerName(dg.GetPlayer(ex.ToPlayerIdx), ex.ToPlayerIdx),
 				strings.Join(cardStrs, ", "))
 		}
 	}
@@ -92,9 +92,10 @@ func (p *DaifugoCuiPresenter) Output(dg interfaces.DaifugoGame, lastErr error) s
 		for i, c := range tableCards {
 			cardStrs[i] = cuiCardStr(c)
 		}
+		lastPlayIdx := dg.GetLastPlayPlayerIdx()
 		fmt.Fprintf(&b, "場: %s (出したプレイヤー: %s)\n",
 			strings.Join(cardStrs, ", "),
-			p.getPlayerName(dg, dg.GetLastPlayPlayerIdx()))
+			cuiPlayerName(dg.GetPlayer(lastPlayIdx), lastPlayIdx))
 	} else {
 		b.WriteString("場: なし (誰でも出せます)\n")
 	}
@@ -103,14 +104,14 @@ func (p *DaifugoCuiPresenter) Output(dg interfaces.DaifugoGame, lastErr error) s
 	humanAction := dg.GetHumanAction()
 	if humanAction != nil {
 		if len(humanAction.PlayedCards) == 0 {
-			fmt.Fprintf(&b, "%sがパスしました\n", p.getPlayerName(dg, humanAction.PlayerIdx))
+			fmt.Fprintf(&b, "%sがパスしました\n", cuiPlayerName(dg.GetPlayer(humanAction.PlayerIdx), humanAction.PlayerIdx))
 		} else {
 			cardStrs := make([]string, len(humanAction.PlayedCards))
 			for i, c := range humanAction.PlayedCards {
 				cardStrs[i] = cuiCardStr(c)
 			}
 			fmt.Fprintf(&b, "%sが %s を出しました\n",
-				p.getPlayerName(dg, humanAction.PlayerIdx),
+				cuiPlayerName(dg.GetPlayer(humanAction.PlayerIdx), humanAction.PlayerIdx),
 				strings.Join(cardStrs, ", "))
 		}
 	}
@@ -120,7 +121,7 @@ func (p *DaifugoCuiPresenter) Output(dg interfaces.DaifugoGame, lastErr error) s
 	if len(cpuActions) > 0 {
 		b.WriteString("[CPUの行動]\n")
 		for _, action := range cpuActions {
-			actPlayerName := p.getPlayerName(dg, action.PlayerIdx)
+			actPlayerName := cuiPlayerName(dg.GetPlayer(action.PlayerIdx), action.PlayerIdx)
 			if len(action.PlayedCards) == 0 {
 				fmt.Fprintf(&b, "%sがパスしました\n", actPlayerName)
 			} else {
@@ -142,11 +143,11 @@ func (p *DaifugoCuiPresenter) Output(dg interfaces.DaifugoGame, lastErr error) s
 		b.WriteString("ゲーム終了！\n")
 		for i := 0; i < dg.GetPlayerCnt(); i++ {
 			player := dg.GetPlayer(i)
-			fmt.Fprintf(&b, "  %s: %s\n", p.getPlayerName(dg, i), p.rankName(player.GetRank()))
+			fmt.Fprintf(&b, "  %s: %s\n", cuiPlayerName(dg.GetPlayer(i), i), p.rankName(player.GetRank()))
 		}
 	} else {
 		currentTurn := dg.GetCurrentTurn()
-		currentName := p.getPlayerName(dg, currentTurn)
+		currentName := cuiPlayerName(dg.GetPlayer(currentTurn), currentTurn)
 		fmt.Fprintf(&b, "手番: %s\n", currentName)
 		switch dg.GetPendingActionType() {
 		case domain.DaifugoPendingSevenPass:
@@ -160,15 +161,6 @@ func (p *DaifugoCuiPresenter) Output(dg interfaces.DaifugoGame, lastErr error) s
 
 	b.WriteString("==========\n")
 	return b.String()
-}
-
-// getPlayerName プレイヤー名取得
-func (p *DaifugoCuiPresenter) getPlayerName(dg interfaces.DaifugoGame, idx int) string {
-	player := dg.GetPlayer(idx)
-	if player == nil {
-		return "UNKNOWN"
-	}
-	return cuiPlayerName(player, idx)
 }
 
 // rankName ランク名取得

--- a/internal/adapter/presenter/DoubtCuiPresenter.go
+++ b/internal/adapter/presenter/DoubtCuiPresenter.go
@@ -55,7 +55,7 @@ func (p *DoubtCuiPresenter) Output(d interfaces.DoubtGame, lastErr error) string
 	lastAction := d.GetLastAction()
 	if lastAction != nil {
 		fmt.Fprintf(&b, "[最後のプレイ] %sが「%d」を%d枚出しました\n",
-			p.getPlayerName(d, lastAction.PlayerIdx),
+			cuiPlayerName(d.GetPlayer(lastAction.PlayerIdx), lastAction.PlayerIdx),
 			lastAction.ClaimedValue,
 			lastAction.CardCount,
 		)
@@ -64,9 +64,9 @@ func (p *DoubtCuiPresenter) Output(d interfaces.DoubtGame, lastErr error) string
 	// ダウト結果
 	lastResult := d.GetLastDoubtResult()
 	if lastResult != nil {
-		doubterName := p.getPlayerName(d, lastResult.DoubterIdx)
-		cardPlayerName := p.getPlayerName(d, lastResult.CardPlayerIdx)
-		loserName := p.getPlayerName(d, lastResult.LoserIdx)
+		doubterName := cuiPlayerName(d.GetPlayer(lastResult.DoubterIdx), lastResult.DoubterIdx)
+		cardPlayerName := cuiPlayerName(d.GetPlayer(lastResult.CardPlayerIdx), lastResult.CardPlayerIdx)
+		loserName := cuiPlayerName(d.GetPlayer(lastResult.LoserIdx), lastResult.LoserIdx)
 		if lastResult.WasLying {
 			fmt.Fprintf(&b, "[ダウト] %sが%sをダウト → 嘘つき！ %sが%d枚引き取りました\n",
 				doubterName, cardPlayerName, loserName, lastResult.CardCount)
@@ -100,7 +100,7 @@ func (p *DoubtCuiPresenter) Output(d interfaces.DoubtGame, lastErr error) string
 		b.WriteString("[CPUの行動]\n")
 		for _, action := range cpuActions {
 			fmt.Fprintf(&b, "%sが「%d」を%d枚出しました\n",
-				p.getPlayerName(d, action.PlayerIdx),
+				cuiPlayerName(d.GetPlayer(action.PlayerIdx), action.PlayerIdx),
 				action.ClaimedValue,
 				action.CardCount,
 			)
@@ -115,7 +115,7 @@ func (p *DoubtCuiPresenter) Output(d interfaces.DoubtGame, lastErr error) string
 	// ゲーム状態
 	if d.GetGameEndFlag() {
 		winnerIdx := d.GetWinnerIdx()
-		fmt.Fprintf(&b, "ゲーム終了！ %sの勝利です！\n", p.getPlayerName(d, winnerIdx))
+		fmt.Fprintf(&b, "ゲーム終了！ %sの勝利です！\n", cuiPlayerName(d.GetPlayer(winnerIdx), winnerIdx))
 	} else {
 		currentTurn := d.GetCurrentTurn()
 		phase := d.GetPhase()
@@ -123,26 +123,17 @@ func (p *DoubtCuiPresenter) Output(d interfaces.DoubtGame, lastErr error) string
 			lastAct := d.GetLastAction()
 			if lastAct != nil {
 				fmt.Fprintf(&b, "ダウトフェーズ: %sのプレイにダウトしますか？\n",
-					p.getPlayerName(d, lastAct.PlayerIdx))
+					cuiPlayerName(d.GetPlayer(lastAct.PlayerIdx), lastAct.PlayerIdx))
 			} else {
 				b.WriteString("ダウトフェーズ\n")
 			}
 			b.WriteString("d <idx...>・・・ダウト / s・・・スキップ\n")
 		} else {
-			fmt.Fprintf(&b, "手番: %s\n", p.getPlayerName(d, currentTurn))
+			fmt.Fprintf(&b, "手番: %s\n", cuiPlayerName(d.GetPlayer(currentTurn), currentTurn))
 			b.WriteString("p <値> <idx...>・・・カードを出す\n")
 		}
 	}
 
 	b.WriteString("==========\n")
 	return b.String()
-}
-
-// getPlayerName プレイヤー名取得
-func (p *DoubtCuiPresenter) getPlayerName(d interfaces.DoubtGame, idx int) string {
-	player := d.GetPlayer(idx)
-	if player == nil {
-		return "UNKNOWN"
-	}
-	return cuiPlayerName(player, idx)
 }

--- a/internal/adapter/presenter/OldMaidCuiPresenter.go
+++ b/internal/adapter/presenter/OldMaidCuiPresenter.go
@@ -57,8 +57,8 @@ func (p *OldMaidCuiPresenter) Output(om interfaces.OldMaidGame, lastErr error) s
 		drawPlayerIdx := om.GetLastDrawPlayerIdx()
 		drawFromIdx := om.GetLastDrawFromIdx()
 		discarded := om.GetLastDiscardedPairs()
-		drawPlayerName := p.getPlayerName(om, drawPlayerIdx)
-		drawFromName := p.getPlayerName(om, drawFromIdx)
+		drawPlayerName := cuiPlayerName(om.GetPlayer(drawPlayerIdx), drawPlayerIdx)
+		drawFromName := cuiPlayerName(om.GetPlayer(drawFromIdx), drawFromIdx)
 		drawnCard := om.GetLastDrawCard()
 		drawPlayer := om.GetPlayer(drawPlayerIdx)
 		fmt.Fprintf(&b, "%sが%sから1枚引きました", drawPlayerName, drawFromName)
@@ -77,8 +77,8 @@ func (p *OldMaidCuiPresenter) Output(om interfaces.OldMaidGame, lastErr error) s
 	if len(cpuActions) > 0 {
 		b.WriteString("[CPUの行動]\n")
 		for _, action := range cpuActions {
-			actPlayerName := p.getPlayerName(om, action.DrawPlayerIdx)
-			actFromName := p.getPlayerName(om, action.DrawFromIdx)
+			actPlayerName := cuiPlayerName(om.GetPlayer(action.DrawPlayerIdx), action.DrawPlayerIdx)
+			actFromName := cuiPlayerName(om.GetPlayer(action.DrawFromIdx), action.DrawFromIdx)
 			fmt.Fprintf(&b, "%sが%sから1枚引きました", actPlayerName, actFromName)
 			// CPU drawn card is intentionally hidden to preserve game fairness
 			if action.DiscardedPairs > 0 {
@@ -96,7 +96,7 @@ func (p *OldMaidCuiPresenter) Output(om interfaces.OldMaidGame, lastErr error) s
 	if om.GetGameEndFlag() {
 		loserIdx := om.GetLoserIdx()
 		if loserIdx >= 0 {
-			loserName := p.getPlayerName(om, loserIdx)
+			loserName := cuiPlayerName(om.GetPlayer(loserIdx), loserIdx)
 			gameEndLine := fmt.Sprintf("ゲーム終了！ %sの負け！", loserName)
 			if om.GetConfig().Mode == domain.OldMaidModeJijiNuki && om.GetRemovedCard() != nil {
 				gameEndLine += fmt.Sprintf("（除外カード: %s）", cuiCardStr(om.GetRemovedCard()))
@@ -105,10 +105,10 @@ func (p *OldMaidCuiPresenter) Output(om interfaces.OldMaidGame, lastErr error) s
 		}
 	} else {
 		currentTurn := om.GetCurrentTurn()
-		currentName := p.getPlayerName(om, currentTurn)
+		currentName := cuiPlayerName(om.GetPlayer(currentTurn), currentTurn)
 		targetIdx := om.GetNextDrawTargetIdx()
 		if targetIdx >= 0 {
-			targetName := p.getPlayerName(om, targetIdx)
+			targetName := cuiPlayerName(om.GetPlayer(targetIdx), targetIdx)
 			fmt.Fprintf(&b, "手番: %s → %sから引きます\n", currentName, targetName)
 		} else {
 			fmt.Fprintf(&b, "手番: %s\n", currentName)
@@ -117,13 +117,4 @@ func (p *OldMaidCuiPresenter) Output(om interfaces.OldMaidGame, lastErr error) s
 
 	b.WriteString("==========\n")
 	return b.String()
-}
-
-// getPlayerName プレイヤー名取得
-func (p *OldMaidCuiPresenter) getPlayerName(om interfaces.OldMaidGame, idx int) string {
-	player := om.GetPlayer(idx)
-	if player == nil {
-		return "UNKNOWN"
-	}
-	return cuiPlayerName(player, idx)
 }

--- a/internal/adapter/presenter/SevensCuiPresenter.go
+++ b/internal/adapter/presenter/SevensCuiPresenter.go
@@ -92,18 +92,18 @@ func (p *SevensCuiPresenter) Output(s interfaces.SevensGame, lastErr error) stri
 	if humanAction != nil {
 		if humanAction.PlayedCard == nil {
 			if humanAction.ForcedPass {
-				fmt.Fprintf(&b, "%sがパスしました (出せるカードなし)\n", p.getPlayerName(s, humanAction.PlayerIdx))
+				fmt.Fprintf(&b, "%sがパスしました (出せるカードなし)\n", cuiPlayerName(s.GetPlayer(humanAction.PlayerIdx), humanAction.PlayerIdx))
 			} else {
-				fmt.Fprintf(&b, "%sがパスしました\n", p.getPlayerName(s, humanAction.PlayerIdx))
+				fmt.Fprintf(&b, "%sがパスしました\n", cuiPlayerName(s.GetPlayer(humanAction.PlayerIdx), humanAction.PlayerIdx))
 			}
 		} else {
 			if humanAction.PlayedCard.GetDesign() == domain.CardDesignJoker && humanAction.TargetSuit > 0 {
 				fmt.Fprintf(&b, "%sが %s → %s %d を出しました\n",
-					p.getPlayerName(s, humanAction.PlayerIdx), cuiCardStr(humanAction.PlayedCard),
+					cuiPlayerName(s.GetPlayer(humanAction.PlayerIdx), humanAction.PlayerIdx), cuiCardStr(humanAction.PlayedCard),
 					cuiSuitName(humanAction.TargetSuit), humanAction.TargetValue)
 			} else {
 				fmt.Fprintf(&b, "%sが %s を出しました\n",
-					p.getPlayerName(s, humanAction.PlayerIdx), cuiCardStr(humanAction.PlayedCard))
+					cuiPlayerName(s.GetPlayer(humanAction.PlayerIdx), humanAction.PlayerIdx), cuiCardStr(humanAction.PlayedCard))
 			}
 		}
 	}
@@ -113,7 +113,7 @@ func (p *SevensCuiPresenter) Output(s interfaces.SevensGame, lastErr error) stri
 	if len(cpuActions) > 0 {
 		b.WriteString("[CPUの行動]\n")
 		for _, action := range cpuActions {
-			actPlayerName := p.getPlayerName(s, action.PlayerIdx)
+			actPlayerName := cuiPlayerName(s.GetPlayer(action.PlayerIdx), action.PlayerIdx)
 			if action.PlayedCard == nil {
 				if action.ForcedPass {
 					fmt.Fprintf(&b, "%sがパスしました (出せるカードなし)\n", actPlayerName)
@@ -141,11 +141,11 @@ func (p *SevensCuiPresenter) Output(s interfaces.SevensGame, lastErr error) stri
 		b.WriteString("ゲーム終了！\n")
 		for i := 0; i < s.GetPlayerCnt(); i++ {
 			player := s.GetPlayer(i)
-			fmt.Fprintf(&b, "  %s: %d位\n", p.getPlayerName(s, i), player.GetRank())
+			fmt.Fprintf(&b, "  %s: %d位\n", cuiPlayerName(s.GetPlayer(i), i), player.GetRank())
 		}
 	} else {
 		currentTurn := s.GetCurrentTurn()
-		currentName := p.getPlayerName(s, currentTurn)
+		currentName := cuiPlayerName(s.GetPlayer(currentTurn), currentTurn)
 		fmt.Fprintf(&b, "手番: %s\n", currentName)
 		b.WriteString("p [インデックス] でカードを出す / p でパス\n")
 		if config.JokerCount > 0 {
@@ -155,13 +155,4 @@ func (p *SevensCuiPresenter) Output(s interfaces.SevensGame, lastErr error) stri
 
 	b.WriteString("==========\n")
 	return b.String()
-}
-
-// getPlayerName プレイヤー名取得
-func (p *SevensCuiPresenter) getPlayerName(s interfaces.SevensGame, idx int) string {
-	player := s.GetPlayer(idx)
-	if player == nil {
-		return "UNKNOWN"
-	}
-	return cuiPlayerName(player, idx)
 }

--- a/internal/adapter/presenter/cui_card_helper.go
+++ b/internal/adapter/presenter/cui_card_helper.go
@@ -7,8 +7,9 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 )
 
-// cuiPlayer is the minimal interface required by cuiPlayerName.
+// cuiPlayer is the minimal type constraint required by cuiPlayerName.
 type cuiPlayer interface {
+	comparable
 	GetIsHuman() bool
 }
 
@@ -65,9 +66,14 @@ func cuiSuitName(suit int) string {
 	return "UNKNOWN"
 }
 
-// cuiPlayerName returns "あなた" for human players, "CPU N" for CPU players.
+// cuiPlayerName returns "あなた" for human players, "CPU N" for CPU players,
+// or "UNKNOWN" if the player is nil/zero.
 // Used by OldMaid, Daifugo, Sevens, and Doubt CUI presenters.
-func cuiPlayerName(player cuiPlayer, idx int) string {
+func cuiPlayerName[P cuiPlayer](player P, idx int) string {
+	var zero P
+	if player == zero {
+		return "UNKNOWN"
+	}
 	if player.GetIsHuman() {
 		return "あなた"
 	}

--- a/internal/adapter/presenter/cui_card_helper_test.go
+++ b/internal/adapter/presenter/cui_card_helper_test.go
@@ -81,10 +81,11 @@ func (m *mockCuiPlayer) GetIsHuman() bool {
 func TestCuiPlayerName(t *testing.T) {
 	tests := []struct {
 		name     string
-		player   cuiPlayer
+		player   *mockCuiPlayer
 		idx      int
 		expected string
 	}{
+		{"nil player", nil, 0, "UNKNOWN"},
 		{"human player", &mockCuiPlayer{isHuman: true}, 0, "あなた"},
 		{"cpu player idx 1", &mockCuiPlayer{isHuman: false}, 1, "CPU 1"},
 		{"cpu player idx 3", &mockCuiPlayer{isHuman: false}, 3, "CPU 3"},


### PR DESCRIPTION
## Summary
- Converted `cuiPlayerName` into a generic function with `comparable` constraint and zero-value check to handle nil players directly
- Removed 4 duplicate `getPlayerName` wrapper methods from OldMaid, Daifugo, Sevens, and Doubt CUI presenters
- Added nil-pointer test case to `cui_card_helper_test.go`

Closes #285

## Test plan
- [x] All existing presenter tests pass (`go test ./internal/adapter/presenter/...`)
- [x] Full test suite passes (`go test ./...`)
- [x] 100% statement coverage on all modified files
- [x] Nil-player behavior preserved (tested via out-of-bounds index in each presenter's Output tests)
- [x] `goimports` run on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)