### PR TITLE
fix(frontend): fix BlackJackPage card key collision in multi-deck

### DIFF
--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -96,8 +96,8 @@ export function BlackJackPage() {
             <h3 className="text-white">ディーラー手札{dealerHitsSoft17 ? ' (H17)' : ' (S17)'}</h3>
             <h3 className="text-white">スコア {state.dealer.score ? state.dealer.score : ''}</h3>
             <div className="flex flex-wrap gap-2">
-              {state.dealer.cards?.map((card) => (
-                <CardImage key={`${card.design}-${card.value}`} card={card} width={60} />
+              {state.dealer.cards?.map((card, idx) => (
+                <CardImage key={`dealer-${idx}-${card.design}-${card.value}`} card={card} width={60} />
               ))}
               {!state.dealer.score && <CardBack width={60} />}
             </div>
@@ -125,9 +125,9 @@ export function BlackJackPage() {
                       {hand.surrendered && ' [SUR]'}
                     </div>
                     <div className="flex flex-wrap gap-1">
-                      {hand.cards.map((card) => (
+                      {hand.cards.map((card, cardIdx) => (
                         <CardImage
-                          key={`cpu${cpuIdx}-${card.design}-${card.value}-${handIdx}`}
+                          key={`cpu${cpuIdx}-hand${handIdx}-${cardIdx}-${card.design}-${card.value}`}
                           card={card}
                           width={50}
                         />
@@ -150,7 +150,8 @@ export function BlackJackPage() {
         {state && phase !== BjPhase.BET && hands.length > 0 && (
           <div className="mb-2">
             {hands.map((hand, handIndex) => (
-              <div key={`hand-${hand.score}-${hand.bet}-${hand.cards.length}`} className="mb-2">
+              // biome-ignore lint/suspicious/noArrayIndexKey: player hands have fixed order per round
+              <div key={`hand-${handIndex}`} className="mb-2">
                 <h3 className="text-white mt-0 mb-0.5">
                   {hands.length > 1 ? `ハンド ${handIndex + 1}` : 'プレイヤー手札'}
                   {handIndex === currentHandIdx && phase === BjPhase.ACTION && ' (*)'}
@@ -165,8 +166,12 @@ export function BlackJackPage() {
                   スコア {hand.score} / ベット {hand.bet}
                 </h3>
                 <div className="flex flex-wrap gap-1.5">
-                  {hand.cards.map((card) => (
-                    <CardImage key={`${card.design}-${card.value}-${handIndex}`} card={card} width={60} />
+                  {hand.cards.map((card, cardIdx) => (
+                    <CardImage
+                      key={`hand-${handIndex}-${cardIdx}-${card.design}-${card.value}`}
+                      card={card}
+                      width={60}
+                    />
                   ))}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Added array index to React `key` props for dealer cards, CPU player cards, and player hand cards in `BlackJackPage.tsx` to prevent key collisions when using multi-deck shoes (up to 8 decks)
- Also fixed the player hand wrapper `<div>` key which used `score-bet-cardCount` (could collide on split hands with identical state) to use `handIndex` instead

Closes #288

## Test plan
- [x] All 75 BlackJackPage tests pass with no key collision warnings
- [x] All 654 frontend tests pass
- [x] Biome lint + format check passes
- [x] Frontend build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)