### PR TITLE
refactor(domain): remove redundant AddCard overrides

### DIFF
--- a/internal/domain/BlackJackPlayer.go
+++ b/internal/domain/BlackJackPlayer.go
@@ -15,11 +15,6 @@ func NewBlackJackPlayer() *BlackJackPlayer {
 	}
 }
 
-// AddCard カード追加
-func (bp *BlackJackPlayer) AddCard(card *Card) {
-	bp.cards = append(bp.cards, card)
-}
-
 // GetScore 手札から現在のスコア計算
 func (bp *BlackJackPlayer) GetScore() int {
 	return CalculateBlackJackScore(bp.cards)

--- a/internal/domain/PokerPlayer.go
+++ b/internal/domain/PokerPlayer.go
@@ -54,11 +54,6 @@ func NewPokerPlayer(isHuman bool, style PokerPlayStyle) *PokerPlayer {
 	}
 }
 
-// AddCard カード追加
-func (pp *PokerPlayer) AddCard(card *Card) {
-	pp.cards = append(pp.cards, card)
-}
-
 // ExchangeCard 指定インデックスのカードを交換
 func (pp *PokerPlayer) ExchangeCard(idx int, card *Card) {
 	if 0 <= idx && idx < len(pp.cards) {


### PR DESCRIPTION
## Summary
- Remove `BlackJackPlayer.AddCard()` override (identical to base `Player.AddCard()`)
- Remove `PokerPlayer.AddCard()` override (identical to base `Player.AddCard()`)
- Go's embedding makes these unnecessary; all other Player types already rely on the base implementation

Closes #307

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] No behavioral change — base `Player.AddCard()` via embedding is functionally identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)