### PR TITLE
refactor(domain): extract duplicate betting getter/setters into bettingPlayerBase

### DIFF
--- a/internal/domain/HoldemPlayer.go
+++ b/internal/domain/HoldemPlayer.go
@@ -4,18 +4,15 @@ import "sort"
 
 // HoldemPlayer テキサスホールデムプレイヤークラス
 type HoldemPlayer struct {
-	Player                     // 親クラス
-	ChipHolder                 // チップ管理
-	isHuman    bool            // 人間フラグ
-	handRank   int             // ベストハンドランク
-	bestHand   []*Card         // ベスト5枚
-	folded     bool            // フォールド済
-	allIn      bool            // オールイン済
-	currentBet int             // 現ラウンドベット額
-	playStyle  HoldemPlayStyle // CPUプレイスタイル
-	totalHands int             // 総ハンド数 (セッション通算)
-	vpipCount  int             // VPIP対象ハンド数
-	pfrCount   int             // PFR対象ハンド数
+	Player                            // 親クラス
+	ChipHolder                        // チップ管理
+	bettingPlayerBase                 // ベッティング共通状態
+	isHuman           bool            // 人間フラグ
+	bestHand          []*Card         // ベスト5枚
+	playStyle         HoldemPlayStyle // CPUプレイスタイル
+	totalHands        int             // 総ハンド数 (セッション通算)
+	vpipCount         int             // VPIP対象ハンド数
+	pfrCount          int             // PFR対象ハンド数
 }
 
 // NewHoldemPlayer コンストラクタ
@@ -30,29 +27,8 @@ func NewHoldemPlayer(isHuman bool, style HoldemPlayStyle) *HoldemPlayer {
 // GetIsHuman 人間フラグ取得
 func (hp *HoldemPlayer) GetIsHuman() bool { return hp.isHuman }
 
-// GetHandRank ハンドランク取得
-func (hp *HoldemPlayer) GetHandRank() int { return hp.handRank }
-
 // GetBestHand ベストハンド取得
 func (hp *HoldemPlayer) GetBestHand() []*Card { return hp.bestHand }
-
-// GetFolded フォールド状態取得
-func (hp *HoldemPlayer) GetFolded() bool { return hp.folded }
-
-// SetFolded フォールド状態設定
-func (hp *HoldemPlayer) SetFolded(folded bool) { hp.folded = folded }
-
-// GetAllIn オールイン状態取得
-func (hp *HoldemPlayer) GetAllIn() bool { return hp.allIn }
-
-// SetAllIn オールイン状態設定
-func (hp *HoldemPlayer) SetAllIn(allIn bool) { hp.allIn = allIn }
-
-// GetCurrentBet 現ラウンドベット取得
-func (hp *HoldemPlayer) GetCurrentBet() int { return hp.currentBet }
-
-// SetCurrentBet 現ラウンドベット設定
-func (hp *HoldemPlayer) SetCurrentBet(bet int) { hp.currentBet = bet }
 
 // GetPlayStyle プレイスタイル取得
 func (hp *HoldemPlayer) GetPlayStyle() HoldemPlayStyle { return hp.playStyle }
@@ -105,9 +81,6 @@ func (hp *HoldemPlayer) GetComparisonCards() []*Card {
 	copy(cards, hp.bestHand)
 	return cards
 }
-
-// SetHandRank ハンドランク設定（テスト用）
-func (hp *HoldemPlayer) SetHandRank(rank int) { hp.handRank = rank }
 
 // SetBestHand ベストハンド設定（テスト用）
 func (hp *HoldemPlayer) SetBestHand(hand []*Card) { hp.bestHand = hand }

--- a/internal/domain/HoldemPlayer_test.go
+++ b/internal/domain/HoldemPlayer_test.go
@@ -17,19 +17,6 @@ func TestNewHoldemPlayer(t *testing.T) {
 	assert.Equal(t, 0, p.GetCardsSize())
 }
 
-func TestHoldemPlayer_SettersGetters(t *testing.T) {
-	p := NewHoldemPlayer(true, HoldemStyleTAG)
-
-	p.SetFolded(true)
-	assert.True(t, p.GetFolded())
-
-	p.SetAllIn(true)
-	assert.True(t, p.GetAllIn())
-
-	p.SetCurrentBet(100)
-	assert.Equal(t, 100, p.GetCurrentBet())
-}
-
 func TestHoldemPlayer_GetPlayStyleName(t *testing.T) {
 	tests := []struct {
 		style HoldemPlayStyle

--- a/internal/domain/PokerPlayer.go
+++ b/internal/domain/PokerPlayer.go
@@ -32,15 +32,12 @@ var PokerHandNames = []string{
 
 // PokerPlayer ポーカープレイヤークラス
 type PokerPlayer struct {
-	Player                       // 親クラス
-	ChipHolder                   // チップ管理
-	handRank      int            // ハンドランク
-	isHuman       bool           // 人間フラグ
-	folded        bool           // フォールド済
-	allIn         bool           // オールイン済
-	currentBet    int            // 現ラウンドベット額
-	playStyle     PokerPlayStyle // CPUプレイスタイル
-	exchangeCount int            // カード交換枚数
+	Player                           // 親クラス
+	ChipHolder                       // チップ管理
+	bettingPlayerBase                // ベッティング共通状態
+	isHuman           bool           // 人間フラグ
+	playStyle         PokerPlayStyle // CPUプレイスタイル
+	exchangeCount     int            // カード交換枚数
 }
 
 // NewPokerPlayer コンストラクタ
@@ -67,11 +64,6 @@ func (pp *PokerPlayer) EvalHand() int {
 	return pp.handRank
 }
 
-// GetHandRank ハンドランク取得
-func (pp *PokerPlayer) GetHandRank() int {
-	return pp.handRank
-}
-
 // GetHandName ハンド名取得
 func (pp *PokerPlayer) GetHandName() string {
 	if 0 <= pp.handRank && pp.handRank < len(PokerHandNames) {
@@ -82,24 +74,6 @@ func (pp *PokerPlayer) GetHandName() string {
 
 // GetIsHuman 人間フラグ取得
 func (pp *PokerPlayer) GetIsHuman() bool { return pp.isHuman }
-
-// GetFolded フォールド状態取得
-func (pp *PokerPlayer) GetFolded() bool { return pp.folded }
-
-// SetFolded フォールド状態設定
-func (pp *PokerPlayer) SetFolded(folded bool) { pp.folded = folded }
-
-// GetAllIn オールイン状態取得
-func (pp *PokerPlayer) GetAllIn() bool { return pp.allIn }
-
-// SetAllIn オールイン状態設定
-func (pp *PokerPlayer) SetAllIn(allIn bool) { pp.allIn = allIn }
-
-// GetCurrentBet 現ラウンドベット取得
-func (pp *PokerPlayer) GetCurrentBet() int { return pp.currentBet }
-
-// SetCurrentBet 現ラウンドベット設定
-func (pp *PokerPlayer) SetCurrentBet(bet int) { pp.currentBet = bet }
 
 // GetPlayStyle プレイスタイル取得
 func (pp *PokerPlayer) GetPlayStyle() PokerPlayStyle { return pp.playStyle }
@@ -124,9 +98,6 @@ func (pp *PokerPlayer) GetComparisonCards() []*Card {
 	copy(cards, pp.cards)
 	return cards
 }
-
-// SetHandRank ハンドランク設定（テスト用）
-func (pp *PokerPlayer) SetHandRank(rank int) { pp.handRank = rank }
 
 // evalFiveCardHandWithJokers ジョーカー対応の5枚ハンド評価
 // ジョーカーがない場合は通常のevalFiveCardHandを呼ぶ

--- a/internal/domain/PokerPlayer_test.go
+++ b/internal/domain/PokerPlayer_test.go
@@ -112,18 +112,6 @@ func TestPokerPlayer_EvalHand(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// GetHandRank / SetHandRank
-// ---------------------------------------------------------------------------
-
-func TestPokerPlayer_HandRank(t *testing.T) {
-	p := NewPokerPlayer(true, PokerStyleBalanced)
-	assert.Equal(t, PokerHandHighCard, p.GetHandRank())
-
-	p.SetHandRank(PokerHandRoyalFlush)
-	assert.Equal(t, PokerHandRoyalFlush, p.GetHandRank())
-}
-
-// ---------------------------------------------------------------------------
 // GetHandName
 // ---------------------------------------------------------------------------
 
@@ -168,40 +156,6 @@ func TestPokerPlayer_GetHandName(t *testing.T) {
 		p.SetHandRank(999)
 		assert.Equal(t, "Unknown", p.GetHandName())
 	})
-}
-
-// ---------------------------------------------------------------------------
-// GetIsHuman / GetFolded / SetFolded / GetAllIn / SetAllIn
-// ---------------------------------------------------------------------------
-
-func TestPokerPlayer_BoolFlags(t *testing.T) {
-	p := NewPokerPlayer(false, PokerStyleAggressive)
-
-	assert.False(t, p.GetIsHuman())
-	assert.False(t, p.GetFolded())
-	assert.False(t, p.GetAllIn())
-
-	p.SetFolded(true)
-	assert.True(t, p.GetFolded())
-	p.SetFolded(false)
-	assert.False(t, p.GetFolded())
-
-	p.SetAllIn(true)
-	assert.True(t, p.GetAllIn())
-	p.SetAllIn(false)
-	assert.False(t, p.GetAllIn())
-}
-
-// ---------------------------------------------------------------------------
-// GetCurrentBet / SetCurrentBet
-// ---------------------------------------------------------------------------
-
-func TestPokerPlayer_CurrentBet(t *testing.T) {
-	p := NewPokerPlayer(true, PokerStyleBalanced)
-	assert.Equal(t, 0, p.GetCurrentBet())
-
-	p.SetCurrentBet(50)
-	assert.Equal(t, 50, p.GetCurrentBet())
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/domain/betting_player_base.go
+++ b/internal/domain/betting_player_base.go
@@ -1,0 +1,34 @@
+package domain
+
+// bettingPlayerBase ベッティング系ゲームの共通プレイヤー状態
+// PokerPlayer と HoldemPlayer で共有する。
+type bettingPlayerBase struct {
+	handRank   int  // ハンドランク
+	folded     bool // フォールド済
+	allIn      bool // オールイン済
+	currentBet int  // 現ラウンドベット額
+}
+
+// GetHandRank ハンドランク取得
+func (b *bettingPlayerBase) GetHandRank() int { return b.handRank }
+
+// SetHandRank ハンドランク設定
+func (b *bettingPlayerBase) SetHandRank(rank int) { b.handRank = rank }
+
+// GetFolded フォールド状態取得
+func (b *bettingPlayerBase) GetFolded() bool { return b.folded }
+
+// SetFolded フォールド状態設定
+func (b *bettingPlayerBase) SetFolded(folded bool) { b.folded = folded }
+
+// GetAllIn オールイン状態取得
+func (b *bettingPlayerBase) GetAllIn() bool { return b.allIn }
+
+// SetAllIn オールイン状態設定
+func (b *bettingPlayerBase) SetAllIn(allIn bool) { b.allIn = allIn }
+
+// GetCurrentBet 現ラウンドベット取得
+func (b *bettingPlayerBase) GetCurrentBet() int { return b.currentBet }
+
+// SetCurrentBet 現ラウンドベット設定
+func (b *bettingPlayerBase) SetCurrentBet(bet int) { b.currentBet = bet }

--- a/internal/domain/betting_player_base_test.go
+++ b/internal/domain/betting_player_base_test.go
@@ -1,0 +1,45 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBettingPlayerBase_HandRank(t *testing.T) {
+	b := &bettingPlayerBase{}
+	assert.Equal(t, 0, b.GetHandRank())
+
+	b.SetHandRank(PokerHandRoyalFlush)
+	assert.Equal(t, PokerHandRoyalFlush, b.GetHandRank())
+}
+
+func TestBettingPlayerBase_Folded(t *testing.T) {
+	b := &bettingPlayerBase{}
+	assert.False(t, b.GetFolded())
+
+	b.SetFolded(true)
+	assert.True(t, b.GetFolded())
+
+	b.SetFolded(false)
+	assert.False(t, b.GetFolded())
+}
+
+func TestBettingPlayerBase_AllIn(t *testing.T) {
+	b := &bettingPlayerBase{}
+	assert.False(t, b.GetAllIn())
+
+	b.SetAllIn(true)
+	assert.True(t, b.GetAllIn())
+
+	b.SetAllIn(false)
+	assert.False(t, b.GetAllIn())
+}
+
+func TestBettingPlayerBase_CurrentBet(t *testing.T) {
+	b := &bettingPlayerBase{}
+	assert.Equal(t, 0, b.GetCurrentBet())
+
+	b.SetCurrentBet(100)
+	assert.Equal(t, 100, b.GetCurrentBet())
+}


### PR DESCRIPTION
## Summary
- Extract 8 identical getter/setter methods (`GetHandRank`, `SetHandRank`, `GetFolded`, `SetFolded`, `GetAllIn`, `SetAllIn`, `GetCurrentBet`, `SetCurrentBet`) from `PokerPlayer` and `HoldemPlayer` into a shared `bettingPlayerBase` embedded struct
- Follows the existing `ChipHolder` embedding pattern
- Add dedicated tests for the new base struct

Closes #309

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] New `betting_player_base_test.go` covers all 8 getter/setter methods
- [x] Go struct embedding promotes methods transparently — no caller changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)