### PR TITLE
refactor(frontend): use useGameApi hook in OldMaidPage

### DIFF
--- a/frontend/src/hooks/useGameApi.test.ts
+++ b/frontend/src/hooks/useGameApi.test.ts
@@ -174,6 +174,30 @@ describe('useGameApi', () => {
     expect(result.current.state).toEqual({ v: 2 });
   });
 
+  it('keeps loading true until async onSuccess resolves', async () => {
+    let resolveCallback!: () => void;
+    const apiFn = vi.fn().mockResolvedValue({ v: 1 });
+    const onSuccess = vi.fn().mockReturnValue(
+      new Promise<void>((r) => {
+        resolveCallback = r;
+      }),
+    );
+    const { result } = renderHook(() => useGameApi(apiFn, { onSuccess }));
+
+    act(() => {
+      result.current.exec();
+    });
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      resolveCallback();
+    });
+
+    expect(result.current.loading).toBe(false);
+  });
+
   it('uses latest onSuccess via ref', async () => {
     const apiFn = vi.fn().mockResolvedValue({ v: 1 });
     const onSuccess1 = vi.fn();

--- a/frontend/src/hooks/useGameApi.ts
+++ b/frontend/src/hooks/useGameApi.ts
@@ -2,7 +2,7 @@ import { useCallback, useRef, useState } from 'react';
 
 export function useGameApi<TState, TArgs extends unknown[]>(
   apiFn: (...args: TArgs) => Promise<TState>,
-  options?: { onSuccess?: (res: TState) => void },
+  options?: { onSuccess?: (res: TState) => void | Promise<void> },
 ): {
   state: TState | null;
   setState: React.Dispatch<React.SetStateAction<TState | null>>;
@@ -24,7 +24,7 @@ export function useGameApi<TState, TArgs extends unknown[]>(
       setError(null);
       const res = await apiFnRef.current(...args);
       setState(res);
-      onSuccessRef.current?.(res);
+      await onSuccessRef.current?.(res);
     } catch {
       setError('通信エラーが発生しました。もう一度お試しください。');
     } finally {

--- a/frontend/src/pages/OldMaidPage.test.tsx
+++ b/frontend/src/pages/OldMaidPage.test.tsx
@@ -246,7 +246,7 @@ describe('OldMaidPage', () => {
     mockExec.mockClear();
     mockExec.mockResolvedValue(cpuTurnState);
     fireEvent.click(screen.getByText('ランダムに引く'));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw', undefined, undefined, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw'));
   });
 
   it('shows status message when hasDrawn is true', async () => {
@@ -288,8 +288,10 @@ describe('OldMaidPage', () => {
     };
     mockExec.mockResolvedValue(stateWithCpuActions);
     await startGame();
-    expect(screen.getByText(/\[CPUの行動\]/)).toBeInTheDocument();
-    expect(screen.getByText(/CPU 1がCPU 2から1枚引きました/)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/\[CPUの行動\]/)).toBeInTheDocument();
+      expect(screen.getByText(/CPU 1がCPU 2から1枚引きました/)).toBeInTheDocument();
+    });
   });
 
   it('does not show drawn card in CPU actions log', async () => {
@@ -320,7 +322,7 @@ describe('OldMaidPage', () => {
     // CPU 1 is target player: click its first card back
     const btn = screen.getByRole('button', { name: 'カード 1 枚目を引く' });
     fireEvent.click(btn);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw', 0, undefined, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw', 0));
   });
 
   it('shows stacked discarded cards when lastDiscardedCards has a pair', async () => {
@@ -386,7 +388,7 @@ describe('OldMaidPage', () => {
 
     // Trigger draw
     fireEvent.click(screen.getByText('ランダムに引く'));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw', undefined, undefined, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw'));
 
     // After all replay delays, final state CPU log should be visible
     // Each delay is 800ms; humanAction + 1 cpuAction = 2 delays = 1600ms max
@@ -454,7 +456,7 @@ describe('OldMaidPage', () => {
     await waitFor(() => expect(screen.getByText('ランダムに引く')).not.toBeDisabled());
 
     fireEvent.click(screen.getByText('ランダムに引く'));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw', undefined, undefined, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw'));
 
     // After all replay delays, the final state (currentTurn=0) must be applied
     // so the button is re-enabled for the human's next turn
@@ -549,7 +551,9 @@ describe('OldMaidPage', () => {
     };
     mockExec.mockResolvedValue(stateWithDiscardedPairs);
     await startGame();
-    expect(screen.getByText(/CPU 1がCPU 2から1枚引きました。2組捨てました/)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/CPU 1がCPU 2から1枚引きました。2組捨てました/)).toBeInTheDocument();
+    });
   });
 
   it('replays two CPU actions covering non-last-action branches', async () => {
@@ -589,7 +593,7 @@ describe('OldMaidPage', () => {
     await waitFor(() => expect(screen.getByText('ランダムに引く')).not.toBeDisabled());
 
     fireEvent.click(screen.getByText('ランダムに引く'));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw', undefined, undefined, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw'));
 
     // After CPU replay with 2 actions, the CPU action log should appear
     await waitFor(() => expect(screen.getByText(/\[CPUの行動\]/)).toBeInTheDocument(), {
@@ -637,7 +641,7 @@ describe('OldMaidPage', () => {
     await waitFor(() => expect(screen.getByText('ランダムに引く')).not.toBeDisabled());
 
     fireEvent.click(screen.getByText('ランダムに引く'));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw', undefined, undefined, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw'));
 
     await waitFor(() => expect(screen.getByText(/\[CPUの行動\]/)).toBeInTheDocument(), {
       timeout: 4000,
@@ -689,7 +693,7 @@ describe('OldMaidPage', () => {
     await waitFor(() => expect(screen.getByText('ランダムに引く')).not.toBeDisabled());
 
     fireEvent.click(screen.getByText('ランダムに引く'));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw', undefined, undefined, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw'));
 
     // Should show the game end message without crashing
     await waitFor(() => expect(screen.getByText(humanActionNoCpuState.message)).toBeInTheDocument(), {
@@ -917,7 +921,7 @@ describe('OldMaidPage', () => {
     await waitFor(() => expect(screen.getByText('ランダムに引く')).not.toBeDisabled());
 
     fireEvent.click(screen.getByText('ランダムに引く'));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw', undefined, undefined, undefined));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw'));
 
     // After CPU replay, the CPU action log should appear
     await waitFor(() => expect(screen.getByText(/\[CPUの行動\]/)).toBeInTheDocument(), {

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -3,6 +3,7 @@ import { oldmaidApi } from '../api/gameApi';
 import { CardBack, CardImage } from '../components/CardImage';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { StatusBadge } from '../components/StatusBadge';
+import { useGameApi } from '../hooks/useGameApi';
 import { btnPrimary, btnSecondary, btnWarning } from '../styles/buttonStyles';
 import { playerAreaBase } from '../styles/gameStyles';
 import type { Card, CpuAction, OldMaidPlayerData, OldMaidResponse } from '../types/card';
@@ -303,52 +304,29 @@ function SetupScreen({
 
 export function OldMaidPage() {
   const [displayState, setDisplayState] = useState<OldMaidResponse | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [setupMode, setSetupMode] = useState<number>(OldMaidMode.Normal);
   const [setupStrategy, setSetupStrategy] = useState(false);
   const [gameSettings, setGameSettings] = useState<{ mode: number; cpuPlacementStrategy: boolean } | null>(null);
 
-  const exec = useCallback(
-    async (command: 'reset' | 'draw', drawIdx?: number, execMode?: number, execStrategy?: boolean) => {
-      setLoading(true);
-      try {
-        setError(null);
-        const res = await oldmaidApi.exec(command, drawIdx, execMode, execStrategy);
+  const onSuccess = useCallback(async (res: OldMaidResponse) => {
+    const humanDrawState = buildHumanDrawState(res);
+    if (humanDrawState) {
+      setDisplayState(humanDrawState);
+      await delay(REPLAY_DELAY_MS);
+    }
+    const replayStates = buildReplayStates(res);
+    if (replayStates.length === 0) {
+      setDisplayState(res);
+      return;
+    }
+    for (const step of replayStates) {
+      setDisplayState(step);
+      await delay(REPLAY_DELAY_MS);
+    }
+    setDisplayState(res);
+  }, []);
 
-        if (command === 'reset') {
-          setDisplayState(res);
-          return;
-        }
-
-        // Show human's draw result first (if humanAction is available)
-        const humanDrawState = buildHumanDrawState(res);
-        if (humanDrawState) {
-          setDisplayState(humanDrawState);
-          await delay(REPLAY_DELAY_MS);
-        }
-
-        if (res.cpuActions.length === 0) {
-          setDisplayState(res);
-          return;
-        }
-
-        // Replay each CPU action step by step
-        const replayStates = buildReplayStates(res);
-        for (const state of replayStates) {
-          setDisplayState(state);
-          await delay(REPLAY_DELAY_MS);
-        }
-        // Restore the actual final state so currentTurn reflects the server response
-        setDisplayState(res);
-      } catch {
-        setError('通信エラーが発生しました。もう一度お試しください。');
-      } finally {
-        setLoading(false);
-      }
-    },
-    [],
-  );
+  const { loading, error, exec } = useGameApi(oldmaidApi.exec, { onSuccess });
 
   const handleStart = useCallback(() => {
     const settings = { mode: setupMode, cpuPlacementStrategy: setupStrategy };
@@ -362,31 +340,12 @@ export function OldMaidPage() {
     }
   }, [exec, gameSettings]);
 
-  const handleShuffle = useCallback(async () => {
-    setLoading(true);
-    try {
-      setError(null);
-      const res = await oldmaidApi.exec('shuffle');
-      setDisplayState(res);
-    } catch {
-      setError('通信エラーが発生しました。もう一度お試しください。');
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  const handleReorder = useCallback(async (indices: number[]) => {
-    setLoading(true);
-    try {
-      setError(null);
-      const res = await oldmaidApi.exec('reorder', undefined, undefined, undefined, indices);
-      setDisplayState(res);
-    } catch {
-      setError('通信エラーが発生しました。もう一度お試しください。');
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const handleReorder = useCallback(
+    (indices: number[]) => {
+      exec('reorder', undefined, undefined, undefined, indices);
+    },
+    [exec],
+  );
 
   if (!gameSettings) {
     return (
@@ -537,7 +496,7 @@ export function OldMaidPage() {
             type="button"
             className={`${btnSecondary} min-w-[110px]`}
             disabled={loading || state.gameEndFlag}
-            onClick={handleShuffle}
+            onClick={() => exec('shuffle')}
           >
             シャッフル
           </button>


### PR DESCRIPTION
## Summary
- Extend `useGameApi` hook to support async `onSuccess` callbacks (`await` the callback so `loading` stays true until it resolves)
- Refactor `OldMaidPage` to use `useGameApi`, removing ~30 lines of duplicated try-catch/loading/error boilerplate (`handleShuffle`, `handleReorder`, and the manual `exec` wrapper)
- Add test for async `onSuccess` behavior in `useGameApi.test.ts`

Closes #310

## Test plan
- [x] `npm test` — all 706 frontend tests pass
- [x] `npm run check` — Biome lint/format clean
- [x] `npm run build` — production build succeeds
- [x] `go test ./...` — all Go tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)