### PR TITLE
refactor(frontend): extract error message string to constant

### DIFF
--- a/frontend/src/components/ErrorAlert.test.tsx
+++ b/frontend/src/components/ErrorAlert.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
+import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import { ErrorAlert } from './ErrorAlert';
 
 describe('ErrorAlert', () => {
@@ -9,8 +10,8 @@ describe('ErrorAlert', () => {
   });
 
   it('renders the message when provided', () => {
-    render(<ErrorAlert message="通信エラーが発生しました。もう一度お試しください。" />);
-    expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument();
+    render(<ErrorAlert message={NETWORK_ERROR_MESSAGE} />);
+    expect(screen.getByText(NETWORK_ERROR_MESSAGE)).toBeInTheDocument();
     expect(screen.getByRole('alert')).toBeInTheDocument();
   });
 });

--- a/frontend/src/constants/messages.test.ts
+++ b/frontend/src/constants/messages.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { NETWORK_ERROR_MESSAGE } from './messages';
+
+describe('NETWORK_ERROR_MESSAGE', () => {
+  it('has the expected value', () => {
+    expect(NETWORK_ERROR_MESSAGE).toBe('通信エラーが発生しました。もう一度お試しください。');
+  });
+});

--- a/frontend/src/constants/messages.ts
+++ b/frontend/src/constants/messages.ts
@@ -1,0 +1,1 @@
+export const NETWORK_ERROR_MESSAGE = '通信エラーが発生しました。もう一度お試しください。';

--- a/frontend/src/hooks/useGameApi.test.ts
+++ b/frontend/src/hooks/useGameApi.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import { useGameApi } from './useGameApi';
 
 describe('useGameApi', () => {
@@ -55,7 +56,7 @@ describe('useGameApi', () => {
       await result.current.exec();
     });
 
-    expect(result.current.error).toBe('通信エラーが発生しました。もう一度お試しください。');
+    expect(result.current.error).toBe(NETWORK_ERROR_MESSAGE);
     expect(result.current.state).toBeNull();
     expect(result.current.loading).toBe(false);
   });

--- a/frontend/src/hooks/useGameApi.ts
+++ b/frontend/src/hooks/useGameApi.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from 'react';
+import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 
 export function useGameApi<TState, TArgs extends unknown[]>(
   apiFn: (...args: TArgs) => Promise<TState>,
@@ -26,7 +27,7 @@ export function useGameApi<TState, TArgs extends unknown[]>(
       setState(res);
       await onSuccessRef.current?.(res);
     } catch {
-      setError('通信エラーが発生しました。もう一度お試しください。');
+      setError(NETWORK_ERROR_MESSAGE);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/BlackJackPage.test.tsx
+++ b/frontend/src/pages/BlackJackPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { blackjackApi } from '../api/gameApi';
+import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { BlackJackCpuSeat, BlackJackHand, BlackJackResponse } from '../types/card';
 import { BlackJackPage } from './BlackJackPage';
 
@@ -332,9 +333,7 @@ describe('BlackJackPage', () => {
 
     mockExec.mockRejectedValueOnce(new Error('network error'));
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
-    await waitFor(() =>
-      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(NETWORK_ERROR_MESSAGE)).toBeInTheDocument());
   });
 
   it('clears error message on successful API call after failure', async () => {
@@ -343,15 +342,11 @@ describe('BlackJackPage', () => {
 
     mockExec.mockRejectedValueOnce(new Error('network error'));
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
-    await waitFor(() =>
-      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(NETWORK_ERROR_MESSAGE)).toBeInTheDocument());
 
     mockExec.mockResolvedValueOnce(actionPhaseState);
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
-    await waitFor(() =>
-      expect(screen.queryByText('通信エラーが発生しました。もう一度お試しください。')).not.toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.queryByText(NETWORK_ERROR_MESSAGE)).not.toBeInTheDocument());
   });
 
   it('shows [BUST] flag for busted hand', async () => {

--- a/frontend/src/pages/DaifugoPage.test.tsx
+++ b/frontend/src/pages/DaifugoPage.test.tsx
@@ -1,6 +1,7 @@
 import { createEvent, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { daifugoApi } from '../api/gameApi';
+import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { DaifugoResponse } from '../types/card';
 import { DaifugoPage } from './DaifugoPage';
 
@@ -341,9 +342,7 @@ describe('DaifugoPage', () => {
     mockExec.mockReset();
     mockExec.mockRejectedValue(new Error('network error'));
     fireEvent.click(screen.getByRole('button', { name: 'パス' }));
-    await waitFor(() =>
-      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(NETWORK_ERROR_MESSAGE)).toBeInTheDocument());
   }, 10000);
 
   it('clears error message on successful API call after failure', async () => {
@@ -353,16 +352,12 @@ describe('DaifugoPage', () => {
     mockExec.mockReset();
     mockExec.mockRejectedValue(new Error('network error'));
     fireEvent.click(screen.getByRole('button', { name: 'パス' }));
-    await waitFor(() =>
-      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(NETWORK_ERROR_MESSAGE)).toBeInTheDocument());
 
     mockExec.mockReset();
     mockExec.mockResolvedValue(humanTurnState);
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    await waitFor(() =>
-      expect(screen.queryByText('通信エラーが発生しました。もう一度お試しください。')).not.toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.queryByText(NETWORK_ERROR_MESSAGE)).not.toBeInTheDocument());
   }, 10000);
 
   it('shows pass message for empty playedCards array', async () => {

--- a/frontend/src/pages/DoubtPage.test.tsx
+++ b/frontend/src/pages/DoubtPage.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { doubtApi } from '../api/gameApi';
+import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { DoubtConfig, DoubtResponse } from '../types/card';
 import { DoubtPage } from './DoubtPage';
 
@@ -265,9 +266,7 @@ describe('DoubtPage', () => {
     mockExec.mockRejectedValue(new Error('network error'));
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
 
-    await waitFor(() =>
-      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(NETWORK_ERROR_MESSAGE)).toBeInTheDocument());
   });
 
   it('clears error message on successful API call after failure', async () => {
@@ -278,17 +277,13 @@ describe('DoubtPage', () => {
     mockExec.mockRejectedValue(new Error('network error'));
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
 
-    await waitFor(() =>
-      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(NETWORK_ERROR_MESSAGE)).toBeInTheDocument());
 
     mockExec.mockReset();
     mockExec.mockResolvedValue(humanTurnState);
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
 
-    await waitFor(() =>
-      expect(screen.queryByText('通信エラーが発生しました。もう一度お試しください。')).not.toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.queryByText(NETWORK_ERROR_MESSAGE)).not.toBeInTheDocument());
   });
 
   it('sets aria-busy and sr-only loading text while loading', async () => {

--- a/frontend/src/pages/HoldemPage.test.tsx
+++ b/frontend/src/pages/HoldemPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { holdemApi } from '../api/gameApi';
+import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { HoldemResponse } from '../types/card';
 import { HoldemPage } from './HoldemPage';
 
@@ -710,9 +711,7 @@ describe('HoldemPage', () => {
 
     mockExec.mockRejectedValueOnce(new Error('network error'));
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    await waitFor(() =>
-      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(NETWORK_ERROR_MESSAGE)).toBeInTheDocument());
   });
 
   it('clears error on successful call after failure', async () => {
@@ -721,15 +720,11 @@ describe('HoldemPage', () => {
 
     mockExec.mockRejectedValueOnce(new Error('network error'));
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    await waitFor(() =>
-      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(NETWORK_ERROR_MESSAGE)).toBeInTheDocument());
 
     mockExec.mockResolvedValueOnce(initState);
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    await waitFor(() =>
-      expect(screen.queryByText('通信エラーが発生しました。もう一度お試しください。')).not.toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.queryByText(NETWORK_ERROR_MESSAGE)).not.toBeInTheDocument());
   });
 
   // ---- END phase (also isShowdown) ----

--- a/frontend/src/pages/OldMaidPage.test.tsx
+++ b/frontend/src/pages/OldMaidPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { oldmaidApi } from '../api/gameApi';
+import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { OldMaidResponse } from '../types/card';
 import { OldMaidPage } from './OldMaidPage';
 
@@ -472,9 +473,7 @@ describe('OldMaidPage', () => {
     mockExec.mockReset();
     mockExec.mockRejectedValue(new Error('network error'));
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    await waitFor(() =>
-      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(NETWORK_ERROR_MESSAGE)).toBeInTheDocument());
   }, 10000);
 
   it('clears error message on successful API call after failure', async () => {
@@ -484,16 +483,12 @@ describe('OldMaidPage', () => {
     mockExec.mockReset();
     mockExec.mockRejectedValue(new Error('network error'));
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    await waitFor(() =>
-      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(NETWORK_ERROR_MESSAGE)).toBeInTheDocument());
 
     mockExec.mockReset();
     mockExec.mockResolvedValue(humanTurnState);
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    await waitFor(() =>
-      expect(screen.queryByText('通信エラーが発生しました。もう一度お試しください。')).not.toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.queryByText(NETWORK_ERROR_MESSAGE)).not.toBeInTheDocument());
   }, 10000);
 
   it('shows JOKER label in status when lastDrawCard is JOKER', async () => {
@@ -788,9 +783,7 @@ describe('OldMaidPage', () => {
     mockExec.mockReset();
     mockExec.mockRejectedValue(new Error('network error'));
     fireEvent.click(screen.getByRole('button', { name: 'シャッフル' }));
-    await waitFor(() =>
-      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(NETWORK_ERROR_MESSAGE)).toBeInTheDocument());
   });
 
   it('human cards are draggable when game is active', async () => {
@@ -882,9 +875,7 @@ describe('OldMaidPage', () => {
       dataTransfer: { getData: () => '0' },
     });
 
-    await waitFor(() =>
-      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(NETWORK_ERROR_MESSAGE)).toBeInTheDocument());
   });
 
   it('goes directly to CPU replay when humanAction is null', async () => {

--- a/frontend/src/pages/PokerPage.test.tsx
+++ b/frontend/src/pages/PokerPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { pokerApi } from '../api/gameApi';
+import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { PokerResponse } from '../types/card';
 import { PokerPage } from './PokerPage';
 
@@ -847,9 +848,7 @@ describe('PokerPage', () => {
 
     mockExec.mockRejectedValueOnce(new Error('network error'));
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    await waitFor(() =>
-      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(NETWORK_ERROR_MESSAGE)).toBeInTheDocument());
   });
 
   it('clears error on successful call after failure', async () => {
@@ -858,15 +857,11 @@ describe('PokerPage', () => {
 
     mockExec.mockRejectedValueOnce(new Error('network error'));
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    await waitFor(() =>
-      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(NETWORK_ERROR_MESSAGE)).toBeInTheDocument());
 
     mockExec.mockResolvedValueOnce(initState);
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    await waitFor(() =>
-      expect(screen.queryByText('通信エラーが発生しました。もう一度お試しください。')).not.toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.queryByText(NETWORK_ERROR_MESSAGE)).not.toBeInTheDocument());
   });
 
   // ---- message ----

--- a/frontend/src/pages/SevensPage.test.tsx
+++ b/frontend/src/pages/SevensPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { sevensApi } from '../api/gameApi';
+import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import type { SevensResponse } from '../types/card';
 import { SevensPage } from './SevensPage';
 
@@ -398,9 +399,7 @@ describe('SevensPage', () => {
     mockExec.mockReset();
     mockExec.mockRejectedValue(new Error('network error'));
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    await waitFor(() =>
-      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(NETWORK_ERROR_MESSAGE)).toBeInTheDocument());
   }, 10000);
 
   it('clears error message on successful API call after failure', async () => {
@@ -410,16 +409,12 @@ describe('SevensPage', () => {
     mockExec.mockReset();
     mockExec.mockRejectedValue(new Error('network error'));
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    await waitFor(() =>
-      expect(screen.getByText('通信エラーが発生しました。もう一度お試しください。')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(NETWORK_ERROR_MESSAGE)).toBeInTheDocument());
 
     mockExec.mockReset();
     mockExec.mockResolvedValue(humanTurnState);
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    await waitFor(() =>
-      expect(screen.queryByText('通信エラーが発生しました。もう一度お試しください。')).not.toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.queryByText(NETWORK_ERROR_MESSAGE)).not.toBeInTheDocument());
   }, 10000);
 
   it('A is playable via tunnel when K is placed', async () => {


### PR DESCRIPTION
## Summary
- Created `frontend/src/constants/messages.ts` with `NETWORK_ERROR_MESSAGE` constant to replace the hardcoded error string `'通信エラーが発生しました。もう一度お試しください。'`
- Updated 1 production file (`useGameApi.ts`) and 9 test files (26 occurrences) to use the constant
- Added unit test for the new constant in `messages.test.ts`

Closes #313

## Test plan
- [x] `npm run build` passes
- [x] `npm run check` (Biome lint/format) passes
- [x] `npm test` — all 710 tests pass
- [x] `grep` confirms the raw string only exists in `constants/messages.ts` and its test

🤖 Generated with [Claude Code](https://claude.com/claude-code)