### PR TITLE
fix(e2e): fix flaky doubt E2E test

### DIFF
--- a/frontend/e2e/doubt.spec.ts
+++ b/frontend/e2e/doubt.spec.ts
@@ -11,59 +11,47 @@ test.describe('Doubt E2E', () => {
     await resetButton.click();
     await waitForLoaded(page);
 
-    // Game loop
-    let gameEnded = false;
-    for (let turn = 0; turn < 200; turn++) {
-      // Check if game ended
-      const gameEnd = page.locator('text=ゲーム終了');
-      if (await gameEnd.isVisible({ timeout: 1_000 }).catch(() => false)) {
-        gameEnded = true;
-        break;
-      }
+    const MAX_TURNS = 300;
+    const gameEnd = page.locator('text=ゲーム終了');
+    const skipButton = page.getByRole('button', { name: 'スルー' });
+    const confirmButton = page.getByRole('button', { name: '確認' });
+    const playButton = page.getByRole('button', { name: '出す' });
+    const handCards = page.locator('[data-testid="hand-card"]');
 
-      // Doubt phase: skip doubt or confirm
-      const skipButton = page.getByRole('button', { name: 'スルー' });
-      const confirmButton = page.getByRole('button', { name: '確認' });
+    for (let turn = 0; turn < MAX_TURNS; turn++) {
+      // Wait for any actionable element or game end to appear
+      await expect(gameEnd.or(skipButton).or(confirmButton).or(playButton)).toBeVisible({ timeout: 10_000 });
 
-      if (await skipButton.isVisible({ timeout: 1_000 }).catch(() => false)) {
+      // Check if game ended (instant, no timeout)
+      if (await gameEnd.isVisible()) break;
+
+      // Doubt phase: skip doubt or confirm CPU doubt
+      if (await skipButton.isVisible()) {
         await skipButton.click();
         await waitForLoaded(page);
         continue;
       }
 
-      if (await confirmButton.isVisible({ timeout: 1_000 }).catch(() => false)) {
+      if (await confirmButton.isVisible()) {
         await confirmButton.click();
         await waitForLoaded(page);
         continue;
       }
 
       // Play phase: select first card and play
-      const playButton = page.getByRole('button', { name: '出す' });
-      if (await playButton.isVisible({ timeout: 2_000 }).catch(() => false)) {
-        // Select the first card in hand
-        const handCards = page
-          .locator('[aria-busy="false"] button[class*="border"]')
-          .or(page.locator('img[alt]').first());
-        if (
-          await handCards
-            .first()
-            .isVisible()
-            .catch(() => false)
-        ) {
+      if (await playButton.isVisible()) {
+        if ((await handCards.count()) > 0) {
           await handCards.first().click();
         }
-
-        // Click 出す if enabled
         if (await playButton.isEnabled()) {
           await playButton.click();
           await waitForLoaded(page);
         }
       }
-
-      await waitForLoaded(page);
     }
 
-    expect(gameEnded).toBe(true);
+    // Assert game ended (Playwright auto-retry)
+    await expect(gameEnd).toBeVisible({ timeout: 5_000 });
 
     // Reset
     await resetButton.click();

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -2,7 +2,7 @@ import type { Page } from '@playwright/test';
 
 /** Wait for the page to finish loading (aria-busy becomes "false"). */
 export async function waitForLoaded(page: Page) {
-  await page.waitForSelector('[aria-busy="false"]', { timeout: 15_000 });
+  await page.waitForSelector('[aria-busy="false"]', { timeout: 30_000 });
 }
 
 /** Navigate to a hash-routed page and wait for it to load. */

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
-  timeout: 60_000,
+  timeout: 90_000,
   use: {
     baseURL: 'http://localhost:8080',
     trace: 'on-first-retry',

--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -58,6 +58,7 @@ function HandCard({ card, index, selected, selectable, onToggle }: HandCardProps
   return (
     <button
       type="button"
+      data-testid="hand-card"
       aria-pressed={selected}
       disabled={!selectable}
       onClick={() => onToggle(index)}


### PR DESCRIPTION
## Summary
- Replace per-check `isVisible({ timeout })` calls with a single `expect(...).toBeVisible({ timeout: 10_000 })` wait, then instant `isVisible()` checks — eliminates cumulative timeout that caused 200 × 4s = 800s > 60s test timeout
- Add `data-testid="hand-card"` to `HandCard` button, replacing fragile `button[class*="border"]` CSS selector in E2E test
- Increase Playwright test timeout from 60s → 90s and `waitForLoaded` helper from 15s → 30s for slow CI

Closes #343

## Test plan
- [x] `npm run build` — build passes
- [x] `npm run check` — Biome lint/format passes
- [x] `npm test` — 764 unit tests pass
- [x] `go test ./...` — Go tests unaffected
- [ ] CI E2E tests pass reliably (verify in CI run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)