### PR TITLE
refactor: remove dead code (NewPlayer, CountActiveBettingPlayers, BJ_SIDE_BET_21_PLUS_3, HoldemAction)

### DIFF
--- a/frontend/src/components/blackjack/bjConstants.ts
+++ b/frontend/src/components/blackjack/bjConstants.ts
@@ -1,6 +1,5 @@
 // Side bet type constants (must match domain BJSideBet constants)
 export const BJ_SIDE_BET_PERFECT_PAIRS = 1;
-export const BJ_SIDE_BET_21_PLUS_3 = 2;
 
 // suggestedAction constants (must match domain BJSuggestedAction)
 export const BJ_SUGGEST_NONE = 0;

--- a/frontend/src/styles/gameConstants.ts
+++ b/frontend/src/styles/gameConstants.ts
@@ -2,7 +2,7 @@ import { PokerAction } from '../types/phases';
 
 /**
  * Betting action display names shared by Poker and Holdem.
- * PokerAction and HoldemAction have the same numeric values (0-5),
+ * Both games use the same numeric action values (0-5),
  * so a single map is sufficient. Separate aliases are exported
  * for semantic clarity at call sites.
  */

--- a/frontend/src/types/phases.ts
+++ b/frontend/src/types/phases.ts
@@ -44,13 +44,3 @@ export const HoldemPhase = {
   SHOWDOWN: 5,
   END: 6,
 } as const;
-
-// Texas Hold'em action constants (sync: internal/domain/Holdem.go)
-export const HoldemAction = {
-  FOLD: 0,
-  CHECK: 1,
-  CALL: 2,
-  BET: 3,
-  RAISE: 4,
-  ALL_IN: 5,
-} as const;

--- a/internal/domain/Player.go
+++ b/internal/domain/Player.go
@@ -10,13 +10,6 @@ type Player struct {
 	cards []*Card // プレイヤーカード
 }
 
-// NewPlayer コンストラクタ
-func NewPlayer() *Player {
-	return &Player{
-		cards: make([]*Card, 0),
-	}
-}
-
 // GetCardsSize プレイヤーカードの枚数取得
 func (p *Player) GetCardsSize() int {
 	return len(p.cards)

--- a/internal/domain/Player_test.go
+++ b/internal/domain/Player_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestPlayer_Method(t *testing.T) {
-	tp := domain.NewPlayer()
+	tp := new(domain.Player)
 	t.Run("success AddCard", func(t *testing.T) {
 		tp.AddCard(domain.NewCard(domain.CardDesignJoker, domain.CardValueJoker, false))
 		assert.Equal(t, 1, tp.GetCardsSize())
@@ -33,7 +33,7 @@ func TestPlayer_Method(t *testing.T) {
 		assert.Equal(t, 0, tp.GetCardsSize())
 	})
 	t.Run("success ShuffleCards does not change size", func(t *testing.T) {
-		p := domain.NewPlayer()
+		p := new(domain.Player)
 		p.AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
 		p.AddCard(domain.NewCard(domain.CardDesignClover, 5, false))
 		p.AddCard(domain.NewCard(domain.CardDesignHeart, 7, false))
@@ -41,7 +41,7 @@ func TestPlayer_Method(t *testing.T) {
 		assert.Equal(t, 3, p.GetCardsSize())
 	})
 	t.Run("success ShuffleCards randomizes order", func(t *testing.T) {
-		p := domain.NewPlayer()
+		p := new(domain.Player)
 		for i := 2; i <= 10; i++ {
 			p.AddCard(domain.NewCard(domain.CardDesignSpade, i, false))
 		}
@@ -52,7 +52,7 @@ func TestPlayer_Method(t *testing.T) {
 		// 多数回シャッフルして順番が変わることを確認
 		changed := false
 		for attempt := 0; attempt < 100; attempt++ {
-			p2 := domain.NewPlayer()
+			p2 := new(domain.Player)
 			for _, v := range original {
 				p2.AddCard(domain.NewCard(domain.CardDesignSpade, v, false))
 			}
@@ -70,12 +70,12 @@ func TestPlayer_Method(t *testing.T) {
 		assert.True(t, changed, "ShuffleCards should change card order")
 	})
 	t.Run("success ShuffleCards on empty hand", func(t *testing.T) {
-		p := domain.NewPlayer()
+		p := new(domain.Player)
 		p.ShuffleCards()
 		assert.Equal(t, 0, p.GetCardsSize())
 	})
 	t.Run("success ShuffleCards on single card hand", func(t *testing.T) {
-		p := domain.NewPlayer()
+		p := new(domain.Player)
 		p.AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
 		p.ShuffleCards()
 		assert.Equal(t, 1, p.GetCardsSize())
@@ -85,7 +85,7 @@ func TestPlayer_Method(t *testing.T) {
 
 func TestPlayer_ReorderCards(t *testing.T) {
 	t.Run("success valid permutation", func(t *testing.T) {
-		p := domain.NewPlayer()
+		p := new(domain.Player)
 		p.AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
 		p.AddCard(domain.NewCard(domain.CardDesignClover, 5, false))
 		p.AddCard(domain.NewCard(domain.CardDesignHeart, 7, false))
@@ -96,7 +96,7 @@ func TestPlayer_ReorderCards(t *testing.T) {
 		assert.Equal(t, 5, p.GetCard(2).GetValue())
 	})
 	t.Run("success identity permutation", func(t *testing.T) {
-		p := domain.NewPlayer()
+		p := new(domain.Player)
 		p.AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
 		p.AddCard(domain.NewCard(domain.CardDesignClover, 5, false))
 		err := p.ReorderCards([]int{0, 1})
@@ -105,33 +105,33 @@ func TestPlayer_ReorderCards(t *testing.T) {
 		assert.Equal(t, 5, p.GetCard(1).GetValue())
 	})
 	t.Run("success empty hand", func(t *testing.T) {
-		p := domain.NewPlayer()
+		p := new(domain.Player)
 		err := p.ReorderCards([]int{})
 		assert.NoError(t, err)
 	})
 	t.Run("error length mismatch", func(t *testing.T) {
-		p := domain.NewPlayer()
+		p := new(domain.Player)
 		p.AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
 		p.AddCard(domain.NewCard(domain.CardDesignClover, 5, false))
 		err := p.ReorderCards([]int{0})
 		assert.ErrorIs(t, err, domain.ErrInvalidIndices)
 	})
 	t.Run("error duplicate indices", func(t *testing.T) {
-		p := domain.NewPlayer()
+		p := new(domain.Player)
 		p.AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
 		p.AddCard(domain.NewCard(domain.CardDesignClover, 5, false))
 		err := p.ReorderCards([]int{0, 0})
 		assert.ErrorIs(t, err, domain.ErrInvalidIndices)
 	})
 	t.Run("error out of range positive", func(t *testing.T) {
-		p := domain.NewPlayer()
+		p := new(domain.Player)
 		p.AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
 		p.AddCard(domain.NewCard(domain.CardDesignClover, 5, false))
 		err := p.ReorderCards([]int{0, 5})
 		assert.ErrorIs(t, err, domain.ErrInvalidIndices)
 	})
 	t.Run("error out of range negative", func(t *testing.T) {
-		p := domain.NewPlayer()
+		p := new(domain.Player)
 		p.AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
 		p.AddCard(domain.NewCard(domain.CardDesignClover, 5, false))
 		err := p.ReorderCards([]int{-1, 0})
@@ -141,7 +141,7 @@ func TestPlayer_ReorderCards(t *testing.T) {
 
 func TestPlayer_RemoveCard(t *testing.T) {
 	t.Run("valid first index", func(t *testing.T) {
-		p := domain.NewPlayer()
+		p := new(domain.Player)
 		p.AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
 		p.AddCard(domain.NewCard(domain.CardDesignClover, 5, false))
 		p.AddCard(domain.NewCard(domain.CardDesignHeart, 7, false))
@@ -153,7 +153,7 @@ func TestPlayer_RemoveCard(t *testing.T) {
 	})
 
 	t.Run("valid middle index", func(t *testing.T) {
-		p := domain.NewPlayer()
+		p := new(domain.Player)
 		p.AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
 		p.AddCard(domain.NewCard(domain.CardDesignClover, 5, false))
 		p.AddCard(domain.NewCard(domain.CardDesignHeart, 7, false))
@@ -164,7 +164,7 @@ func TestPlayer_RemoveCard(t *testing.T) {
 	})
 
 	t.Run("valid last index", func(t *testing.T) {
-		p := domain.NewPlayer()
+		p := new(domain.Player)
 		p.AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
 		p.AddCard(domain.NewCard(domain.CardDesignClover, 5, false))
 		card := p.RemoveCard(1)
@@ -174,7 +174,7 @@ func TestPlayer_RemoveCard(t *testing.T) {
 	})
 
 	t.Run("negative index returns nil", func(t *testing.T) {
-		p := domain.NewPlayer()
+		p := new(domain.Player)
 		p.AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
 		card := p.RemoveCard(-1)
 		assert.Nil(t, card)
@@ -182,7 +182,7 @@ func TestPlayer_RemoveCard(t *testing.T) {
 	})
 
 	t.Run("out-of-bounds index returns nil", func(t *testing.T) {
-		p := domain.NewPlayer()
+		p := new(domain.Player)
 		p.AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
 		card := p.RemoveCard(5)
 		assert.Nil(t, card)
@@ -190,7 +190,7 @@ func TestPlayer_RemoveCard(t *testing.T) {
 	})
 
 	t.Run("empty hand returns nil", func(t *testing.T) {
-		p := domain.NewPlayer()
+		p := new(domain.Player)
 		card := p.RemoveCard(0)
 		assert.Nil(t, card)
 		assert.Equal(t, 0, p.GetCardsSize())
@@ -199,7 +199,7 @@ func TestPlayer_RemoveCard(t *testing.T) {
 
 func TestPlayer_RemoveCards(t *testing.T) {
 	makePlayer := func() *domain.Player {
-		p := domain.NewPlayer()
+		p := new(domain.Player)
 		p.AddCard(domain.NewCard(domain.CardDesignSpade, 1, false)) // 0
 		p.AddCard(domain.NewCard(domain.CardDesignSpade, 2, false)) // 1
 		p.AddCard(domain.NewCard(domain.CardDesignSpade, 3, false)) // 2
@@ -277,7 +277,7 @@ func TestPlayer_RemoveCards(t *testing.T) {
 }
 
 func TestPlayer_PrependCard(t *testing.T) {
-	p := domain.NewPlayer()
+	p := new(domain.Player)
 	p.AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
 	p.AddCard(domain.NewCard(domain.CardDesignClover, 3, false))
 	front := domain.NewCard(domain.CardDesignHeart, 1, false)

--- a/internal/domain/betting.go
+++ b/internal/domain/betting.go
@@ -326,17 +326,6 @@ func DistributePots(players []BettingPlayer, sidePots []SidePot) map[int]int {
 	return wonAmounts
 }
 
-// CountActiveBettingPlayers フォールドしていないプレイヤー数を返す
-func CountActiveBettingPlayers(players []BettingPlayer) int {
-	cnt := 0
-	for _, pl := range players {
-		if !pl.GetFolded() {
-			cnt++
-		}
-	}
-	return cnt
-}
-
 // CpuFoldOrCheck コール額がある場合はフォールド、なければチェック
 func CpuFoldOrCheck(callAmount int) (int, int) {
 	if callAmount > 0 {

--- a/internal/domain/betting_test.go
+++ b/internal/domain/betting_test.go
@@ -716,20 +716,6 @@ func TestDistributePots_EmptyWinners(t *testing.T) {
 	assert.Equal(t, 0, won[0])
 }
 
-// --- CountActiveBettingPlayers tests ---
-
-func TestCountActiveBettingPlayers_AllActive(t *testing.T) {
-	players := []BettingPlayer{newMockPlayer(100), newMockPlayer(100), newMockPlayer(100)}
-	assert.Equal(t, 3, CountActiveBettingPlayers(players))
-}
-
-func TestCountActiveBettingPlayers_SomeFolded(t *testing.T) {
-	p0 := newMockPlayer(100)
-	p0.folded = true
-	players := []BettingPlayer{p0, newMockPlayer(100), newMockPlayer(100)}
-	assert.Equal(t, 2, CountActiveBettingPlayers(players))
-}
-
 // --- CPU helper tests ---
 
 func TestCpuFoldOrCheck(t *testing.T) {


### PR DESCRIPTION
## Summary
- Remove `NewPlayer()` from `internal/domain/Player.go` (only used in tests; replaced with `new(domain.Player)`)
- Remove `CountActiveBettingPlayers()` from `internal/domain/betting.go` and its tests (only used in tests, never in production)
- Remove `BJ_SIDE_BET_21_PLUS_3` from `frontend/src/components/blackjack/bjConstants.ts` (exported but never imported)
- Remove `HoldemAction` from `frontend/src/types/phases.ts` (duplicates `PokerAction` values; never imported)

Closes #342

## Test plan
- [x] All Go tests pass (`go test ./...`)
- [x] Frontend build succeeds (`npm run build`)
- [x] Biome lint/format check passes (`npm run check`)
- [x] All 764 frontend unit tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)