### PR TITLE
refactor: extract resetPlayers generic helper

### DIFF
--- a/internal/domain/Daifugo.go
+++ b/internal/domain/Daifugo.go
@@ -209,11 +209,7 @@ func (d *Daifugo) Reset() {
 	d.trumpCards.Shuffle()
 
 	// 全プレイヤーのカードリセット
-	for _, p := range d.players {
-		p.Reset()
-		p.SetIsFinished(false)
-		p.SetRank(-1)
-	}
+	resetPlayers(d.players, func(p *DaifugoPlayer) { p.SetRank(-1) })
 
 	// プレイ順をランダムにする
 	rand.Shuffle(len(d.players), func(i, j int) {

--- a/internal/domain/Doubt.go
+++ b/internal/domain/Doubt.go
@@ -132,11 +132,7 @@ func (d *Doubt) Reset() {
 	d.winnerIdx = -1
 	d.turnCounter = 0
 
-	for _, p := range d.players {
-		p.Reset()
-		p.SetIsFinished(false)
-		p.ResetMemory()
-	}
+	resetPlayers(d.players, func(p *DoubtPlayer) { p.ResetMemory() })
 
 	d.trumpCards.Shuffle()
 	dealAllCards(d.trumpCards, d.players)

--- a/internal/domain/OldMaid.go
+++ b/internal/domain/OldMaid.go
@@ -97,10 +97,7 @@ func (o *OldMaid) Reset() {
 	o.cpuHighlightedCardIdx = -1
 
 	// 全プレイヤーのカードリセット
-	for _, p := range o.players {
-		p.Reset()
-		p.SetIsFinished(false)
-	}
+	resetPlayers(o.players, nil)
 
 	// プレイ順をランダムにする
 	rand.Shuffle(len(o.players), func(i, j int) {

--- a/internal/domain/Sevens.go
+++ b/internal/domain/Sevens.go
@@ -68,14 +68,12 @@ func (s *Sevens) Reset() {
 	s.jokerCards = nil
 
 	// 全プレイヤーのリセット
-	for _, p := range s.players {
-		p.Reset()
-		p.SetIsFinished(false)
+	resetPlayers(s.players, func(p *SevensPlayer) {
 		p.SetIsEliminated(false)
 		p.SetRank(-1)
 		p.ResetPasses()
 		p.SetMaxPasses(s.config.MaxPasses)
-	}
+	})
 
 	// プレイ順をランダムにする
 	rand.Shuffle(len(s.players), func(i, j int) {

--- a/internal/domain/player_helpers.go
+++ b/internal/domain/player_helpers.go
@@ -20,6 +20,25 @@ func nextActivePlayer[T finishable](players []T, from, direction int) int {
 	return -1
 }
 
+// resettable is satisfied by player types whose hands can be cleared
+// and whose finish flag can be toggled (OldMaidPlayer, DaifugoPlayer, etc.).
+type resettable interface {
+	Reset()
+	SetIsFinished(bool)
+}
+
+// resetPlayers resets all players' hands and clears their finish flags.
+// If extra is non-nil it is called per player for game-specific cleanup.
+func resetPlayers[T resettable](players []T, extra func(T)) {
+	for _, p := range players {
+		p.Reset()
+		p.SetIsFinished(false)
+		if extra != nil {
+			extra(p)
+		}
+	}
+}
+
 // countPlayers counts players matching a predicate.
 func countPlayers[T any](players []T, pred func(T) bool) int {
 	cnt := 0


### PR DESCRIPTION
## Summary
- Extract `resetPlayers[T resettable]` generic helper into `internal/domain/player_helpers.go` to deduplicate identical player-reset loops across four games
- Replace manual loops in OldMaid, Daifugo, Sevens, and Doubt `Reset()` methods with calls to `resetPlayers`, using an optional `extra` callback for game-specific cleanup
- No behavioral changes; all existing tests pass as-is

Closes #333

## Test plan
- [x] `go test -tags test ./...` passes with no failures
- [x] Verified `resetPlayers` with `nil` extra (OldMaid) and non-nil extra (Daifugo, Sevens, Doubt) both exercised by existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)