### PR TITLE
refactor: extract marshalOrError helper for web presenters

### DIFF
--- a/internal/adapter/presenter/BlackJackWebPresenter.go
+++ b/internal/adapter/presenter/BlackJackWebPresenter.go
@@ -133,9 +133,5 @@ func (bjp *BlackJackWebPresenter) Output(bj interfaces.BlackJackGame, lastErr er
 			resObj.Message = "It is your loss."
 		}
 	}
-	res, err := jsonMarshal(resObj)
-	if err != nil {
-		return internalServerErrorJSON()
-	}
-	return string(res)
+	return marshalOrError(resObj)
 }

--- a/internal/adapter/presenter/DaifugoWebPresenter.go
+++ b/internal/adapter/presenter/DaifugoWebPresenter.go
@@ -129,11 +129,7 @@ func (dwp *DaifugoWebPresenter) Output(dg interfaces.DaifugoGame, lastErr error)
 		resObj.Message = dwp.buildResultMessage(dg)
 	}
 
-	res, err := jsonMarshal(resObj)
-	if err != nil {
-		return internalServerErrorJSON()
-	}
-	return string(res)
+	return marshalOrError(resObj)
 }
 
 // buildResultMessage ゲーム終了メッセージを生成

--- a/internal/adapter/presenter/DoubtWebPresenter.go
+++ b/internal/adapter/presenter/DoubtWebPresenter.go
@@ -92,11 +92,7 @@ func (dwp *DoubtWebPresenter) Output(d interfaces.DoubtGame, lastErr error) stri
 		resObj.Message = dwp.buildResultMessage(d)
 	}
 
-	res, err := jsonMarshal(resObj)
-	if err != nil {
-		return internalServerErrorJSON()
-	}
-	return string(res)
+	return marshalOrError(resObj)
 }
 
 // buildResultMessage ゲーム終了メッセージを生成

--- a/internal/adapter/presenter/HoldemWebPresenter.go
+++ b/internal/adapter/presenter/HoldemWebPresenter.go
@@ -119,11 +119,7 @@ func (hwp *HoldemWebPresenter) Output(h interfaces.HoldemGame, lastErr error) st
 		resObj.Message = hwp.buildResultMessage(h)
 	}
 
-	res, err := jsonMarshal(resObj)
-	if err != nil {
-		return internalServerErrorJSON()
-	}
-	return string(res)
+	return marshalOrError(resObj)
 }
 
 // buildResultMessage builds the end-of-round message

--- a/internal/adapter/presenter/OldMaidWebPresenter.go
+++ b/internal/adapter/presenter/OldMaidWebPresenter.go
@@ -110,9 +110,5 @@ func (owp *OldMaidWebPresenter) Output(om interfaces.OldMaidGame, lastErr error)
 		}
 	}
 
-	res, err := jsonMarshal(resObj)
-	if err != nil {
-		return internalServerErrorJSON()
-	}
-	return string(res)
+	return marshalOrError(resObj)
 }

--- a/internal/adapter/presenter/PokerWebPresenter.go
+++ b/internal/adapter/presenter/PokerWebPresenter.go
@@ -17,11 +17,7 @@ func NewPokerWebPresenter() *PokerWebPresenter {
 // Output ゲーム状態をJSON出力
 func (pwp *PokerWebPresenter) Output(p interfaces.PokerGame, lastErr error) string {
 	resObj := pwp.buildOutput(p, lastErr)
-	res, err := jsonMarshal(resObj)
-	if err != nil {
-		return internalServerErrorJSON()
-	}
-	return string(res)
+	return marshalOrError(resObj)
 }
 
 // OutputWithOdds ゲーム状態 + ドローオッズをJSON出力
@@ -39,11 +35,7 @@ func (pwp *PokerWebPresenter) OutputWithOdds(p interfaces.PokerGame, lastErr err
 			}
 		}
 	}
-	res, err := jsonMarshal(resObj)
-	if err != nil {
-		return internalServerErrorJSON()
-	}
-	return string(res)
+	return marshalOrError(resObj)
 }
 
 // buildOutput ゲーム状態をPokerWebOutputに変換

--- a/internal/adapter/presenter/SevensWebPresenter.go
+++ b/internal/adapter/presenter/SevensWebPresenter.go
@@ -96,11 +96,7 @@ func (swp *SevensWebPresenter) Output(s interfaces.SevensGame, lastErr error) st
 		resObj.Message = swp.buildResultMessage(s)
 	}
 
-	res, err := jsonMarshal(resObj)
-	if err != nil {
-		return internalServerErrorJSON()
-	}
-	return string(res)
+	return marshalOrError(resObj)
 }
 
 // buildResultMessage ゲーム終了メッセージを生成

--- a/internal/adapter/presenter/json_marshal.go
+++ b/internal/adapter/presenter/json_marshal.go
@@ -4,3 +4,12 @@ import "encoding/json"
 
 // jsonMarshal is a variable wrapping json.Marshal to allow replacement in tests.
 var jsonMarshal = json.Marshal
+
+// marshalOrError marshals v to JSON, returning internalServerErrorJSON on failure.
+func marshalOrError(v any) string {
+	res, err := jsonMarshal(v)
+	if err != nil {
+		return internalServerErrorJSON()
+	}
+	return string(res)
+}


### PR DESCRIPTION
## Summary
- Extract `marshalOrError` helper into `json_marshal.go` to deduplicate the 4-line JSON marshal + error handling pattern repeated across all 7 web presenters (8 occurrences)
- Replace boilerplate in `BlackJackWebPresenter`, `PokerWebPresenter` (2 methods), `OldMaidWebPresenter`, `DaifugoWebPresenter`, `SevensWebPresenter`, `DoubtWebPresenter`, and `HoldemWebPresenter`

Closes #334

## Test plan
- [x] Existing `WebPresenter_marshal_internal_test.go` covers all 8 marshal error paths
- [x] `go test -tags test ./internal/adapter/presenter/...` passes
- [x] `go test -tags test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)