### PR TITLE
refactor: unify logging initialization across CLI and server entrypoints

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/ui"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/web"
 )
@@ -35,6 +36,7 @@ func main() {
 		holdem := ui.NewHoldemCui()
 		holdem.Exec()
 	case "web":
+		infrastructure.InitLogger()
 		w := web.NewTrumpCardsWeb()
 		w.Exec()
 	default:

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,14 +1,12 @@
 package main
 
 import (
-	"log/slog"
-	"os"
-
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/web"
 )
 
 func main() {
-	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
+	infrastructure.InitLogger()
 	w := web.NewTrumpCardsWeb()
 	w.Exec()
 }

--- a/internal/infrastructure/logging.go
+++ b/internal/infrastructure/logging.go
@@ -1,0 +1,11 @@
+package infrastructure
+
+import (
+	"log/slog"
+	"os"
+)
+
+// InitLogger sets up the default structured JSON logger on stderr.
+func InitLogger() {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
+}


### PR DESCRIPTION
## Summary
- Extract shared `InitLogger()` into `internal/infrastructure/logging.go`
- Replace inline `slog.SetDefault(...)` in `cmd/server/main.go` with `infrastructure.InitLogger()`
- Add `infrastructure.InitLogger()` to `cmd/cli/main.go` web subcommand for consistent JSON structured logging

Closes #341

## Test plan
- [x] `go build ./cmd/cli && go build ./cmd/server` — both compile
- [x] `go test -tags test ./...` — all tests pass
- [ ] Start web server via `go run ./cmd/cli web` and verify stderr outputs JSON logs
- [ ] Start web server via `go run ./cmd/server` and verify stderr outputs identical JSON logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)