### PR TITLE
refactor(docker): switch final stage to distroless image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o go_trumpcards ./cmd/se
 
 # Stage 3: Final production image
 # Pinned to a specific digest for reproducible builds
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Replace `alpine:3.21` with `gcr.io/distroless/static-debian12:nonroot` as the final Docker stage
- Remove `addgroup`/`adduser`/`apk` RUN block (distroless has no shell; `:nonroot` tag provides UID 65532)
- Update `COPY --chown` to `nonroot:nonroot` and `CMD` to absolute path `/app/go_trumpcards`

Closes #362

## Test plan
- [ ] `docker build -t go_trumpcards .` succeeds
- [ ] `docker run --rm -d -p 8080:8080 go_trumpcards` starts without errors
- [ ] App loads at http://localhost:8080
- [ ] Container runs as non-root (`docker exec <id> id` is not available — verify via `docker inspect --format '{{.Config.User}}'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)