### PR TITLE
fix(blackjack): call Reset before SetConfig in ResetWithConfig to avoid phase error

### DIFF
--- a/internal/usecase/BlackJackInteractor.go
+++ b/internal/usecase/BlackJackInteractor.go
@@ -128,6 +128,7 @@ func (bi *BlackJackInteractor) ToggleCounting() string {
 
 // ResetWithConfig 設定付きリセット
 func (bi *BlackJackInteractor) ResetWithConfig(dealerHitsSoft17 bool, cpuPlayerCount int, countingEnabled bool) string {
+	bi.bj.Reset()
 	err := bi.bj.SetConfig(domain.BlackJackConfig{
 		DealerHitsSoft17: dealerHitsSoft17,
 		CpuPlayerCount:   cpuPlayerCount,

--- a/internal/usecase/BlackJackInteractor_test.go
+++ b/internal/usecase/BlackJackInteractor_test.go
@@ -139,7 +139,7 @@ func TestResetWithConfig(t *testing.T) {
 	result := tbj.ResetWithConfig(true, 2, true)
 	assert.Equal(t, "reset done", result)
 	bjMock.AssertCalled(t, "SetConfig", domain.BlackJackConfig{DealerHitsSoft17: true, CpuPlayerCount: 2, CountingEnabled: true})
-	bjMock.AssertCalled(t, "Reset")
+	bjMock.AssertNumberOfCalls(t, "Reset", 2)
 }
 
 func TestResetWithConfig_Error(t *testing.T) {
@@ -148,9 +148,10 @@ func TestResetWithConfig_Error(t *testing.T) {
 
 	bjMock := new(interfaces.MockBlackJackGame)
 	bjMock.On("SetConfig", domain.BlackJackConfig{DealerHitsSoft17: true, CpuPlayerCount: 5, CountingEnabled: false}).Return(errors.New("invalid cpu count"))
+	bjMock.On("Reset").Return()
 
 	tbj := usecase.NewBlackJackInteractor(bjMock, bjpMock)
 	result := tbj.ResetWithConfig(true, 5, false)
 	assert.Equal(t, "config error output", result)
-	bjMock.AssertNotCalled(t, "Reset")
+	bjMock.AssertNumberOfCalls(t, "Reset", 1)
 }


### PR DESCRIPTION
## Summary
- Fix `ResetWithConfig` calling `SetConfig` before `Reset`, which failed when the game was in End phase because `SetConfig` requires `BJPhaseBet`
- Now calls `Reset()` first to return to bet phase, then `SetConfig()`, then `Reset()` again to re-initialize with the new config (CPU count, etc.)
- Updated tests to verify `Reset` is called twice on success and once on config error

Closes #375

## Test plan
- [x] `go test -tags test ./internal/usecase/ -run TestResetWithConfig` passes
- [x] `go test -tags test ./...` full suite passes
- [ ] Manual: start BlackJack web GUI, play a round to End phase, press Reset with config changes — game resets correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)