### PR TITLE
docs: add TDD (Red-Green-Refactor) rules to CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ public/                        # Built frontend assets served by Go web server
 Before writing any production code, create or modify a test file (`*_test.go`) that captures the expected behavior. Run the test and confirm it fails:
 
 ```sh
-go test -tags test ./internal/domain/ -run TestNewFeature  # Confirm the test fails (Red)
+go test -tags test ./path/to/package -run TestNewFeature  # Confirm the test fails (Red)
 ```
 
 Write tests in the corresponding location for each Clean Architecture layer:
@@ -160,7 +160,7 @@ Write tests in the corresponding location for each Clean Architecture layer:
 Implement only the code necessary to make the failing test pass. Do not add extra functionality beyond what the test requires:
 
 ```sh
-go test -tags test ./internal/domain/ -run TestNewFeature  # Confirm the test passes (Green)
+go test -tags test ./path/to/package -run TestNewFeature  # Confirm the test passes (Green)
 ```
 
 #### 3. Refactor — Clean up while keeping tests green

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ public/                        # Built frontend assets served by Go web server
 Before writing any production code, create or modify a test file (`*_test.go`) that captures the expected behavior. Run the test and confirm it fails:
 
 ```sh
-go test -tags test ./internal/domain/ -run TestNewFeature  # Confirm the test fails (Red)
+go test -tags test ./path/to/package -run TestNewFeature  # Confirm the test fails (Red)
 ```
 
 Write tests in the corresponding location for each Clean Architecture layer:
@@ -157,7 +157,7 @@ Write tests in the corresponding location for each Clean Architecture layer:
 Implement only the code necessary to make the failing test pass. Do not add extra functionality beyond what the test requires:
 
 ```sh
-go test -tags test ./internal/domain/ -run TestNewFeature  # Confirm the test passes (Green)
+go test -tags test ./path/to/package -run TestNewFeature  # Confirm the test passes (Green)
 ```
 
 #### 3. Refactor — Clean up while keeping tests green


### PR DESCRIPTION
## Summary
- Add TDD (Red-Green-Refactor) cycle rules to both `CLAUDE.md` and `AGENTS.md` under the Testing Policy section
- Both files contain identical TDD content covering: Red (write failing test first), Green (write minimum code to pass), Refactor (clean up while tests stay green)
- Includes Go-specific `go test` commands at each stage and Clean Architecture layer-aware test location table

Closes #388

## Test plan
- [x] Verify `CLAUDE.md` contains the TDD section with Red-Green-Refactor rules
- [x] Verify `AGENTS.md` contains the identical TDD section
- [x] Verify Go-specific `go test` commands are included at each stage
- [x] Verify Clean Architecture layer test locations are referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)