### PR TITLE
feat(doubt): add mixed bluff for CPU multi-card plays

### DIFF
--- a/internal/domain/Doubt.go
+++ b/internal/domain/Doubt.go
@@ -543,8 +543,8 @@ func selectMixedCards(player *DoubtPlayer, claimedValue int, numCards int) []*Ca
 		}
 	}
 
-	// 不一致カードがない場合はフォールバック
-	if len(nonMatching) == 0 {
+	// 一致または不一致カードがない場合はフォールバック
+	if len(matching) == 0 || len(nonMatching) == 0 {
 		indices := make([]int, numCards)
 		for i := range indices {
 			indices[i] = i

--- a/internal/domain/Doubt_test.go
+++ b/internal/domain/Doubt_test.go
@@ -344,7 +344,7 @@ func TestDoubt_CpuPlay_MixedBluff(t *testing.T) {
 		for attempt := 0; attempt < 1000; attempt++ {
 			game, players := makeDoubtGame()
 			advanceToCpuTurn(game)
-			// Give CPU 1 cards with different values to enable mixed bluff
+			// Give CPU 1 five cards with different values to enable mixed bluff
 			for i := 1; i <= 5; i++ {
 				players[1].AddCard(domain.NewCard(domain.CardDesignSpade, i, false))
 			}

--- a/internal/domain/doubt_internal_test.go
+++ b/internal/domain/doubt_internal_test.go
@@ -170,6 +170,16 @@ func TestSelectMixedCards(t *testing.T) {
 		}
 	})
 
+	t.Run("fallback - no cards match claimed value", func(t *testing.T) {
+		player := NewDoubtPlayer(false)
+		player.AddCard(NewCard(CardDesignSpade, 3, false))
+		player.AddCard(NewCard(CardDesignHeart, 7, false))
+		player.AddCard(NewCard(CardDesignClover, 9, false))
+
+		played := selectMixedCards(player, 5, 2)
+		assert.Len(t, played, 2)
+	})
+
 	t.Run("guard - numCards < 2 returns single card", func(t *testing.T) {
 		player := NewDoubtPlayer(false)
 		player.AddCard(NewCard(CardDesignSpade, 5, false))


### PR DESCRIPTION
## Summary
- Add mixed bluff (混合ブラフ) mode for Doubt CPU: when playing multiple cards without intentional bluff, 30% chance to mix genuine + unrelated cards
- Add `selectMixedCards` helper that splits hand into matching/non-matching groups and picks at least 1 from each
- Restructure `CpuPlay` to move bluff decision before card selection, preserving identical bluff probability via pre-computed post-removal values

Closes #357

## Test plan
- [x] `TestMixedBluffChance` — verifies constant value (0.3)
- [x] `TestSelectMixedCards` — 4 subtests: normal mixed, fallback (all match), fallback (no match), edge (1 non-matching)
- [x] `TestDoubt_CpuPlay_MixedBluff` — retry loop confirming mixed bluff pattern is reachable in CpuPlay
- [x] Full test suite passes (`go test -tags test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)