### PR TITLE
fix(blackjack): apply CPU player count change immediately

### DIFF
--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -54,7 +54,8 @@ export const blackjackApi = {
       | 'togglecounting'
       | 'toggledas'
       | 'setcountingsystem'
-      | 'setpenetration',
+      | 'setpenetration'
+      | 'setcpucount',
     amount?: number,
     config?: BlackJackConfigInput,
     sideBets?: BlackJackSideBetInput,

--- a/frontend/src/pages/BlackJackPage.test.tsx
+++ b/frontend/src/pages/BlackJackPage.test.tsx
@@ -918,11 +918,13 @@ describe('BlackJackPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bet', 50, undefined, {}));
   });
 
-  it('updates CPU count when selector value is changed', async () => {
+  it('calls setcpucount when CPU count selector value is changed', async () => {
     renderWithProviders(<BlackJackPage />);
     await waitFor(() => expect(screen.getByLabelText('CPU人数:')).toBeInTheDocument());
+    mockExec.mockClear();
+    mockExec.mockResolvedValue({ ...betPhaseState, cpuPlayerCount: 2 });
     fireEvent.change(screen.getByLabelText('CPU人数:'), { target: { value: '2' } });
-    expect(screen.getByLabelText('CPU人数:')).toHaveValue('2');
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('setcpucount', 2));
   });
 
   it('calls doubledown command when double down button is clicked', async () => {

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -263,7 +263,7 @@ export function BlackJackPage() {
                 deckCount={state?.deckCount ?? 1}
                 onDeckCountChange={(v) => exec('setdeckcount', v)}
                 cpuPlayerCount={cpuPlayerCount}
-                onCpuPlayerCountChange={setCpuPlayerCount}
+                onCpuPlayerCountChange={(v) => exec('setcpucount', v)}
                 hintEnabled={hintEnabled}
                 onToggleHint={() => exec('togglehint')}
                 dealerHitsSoft17={dealerHitsSoft17}

--- a/internal/adapter/controller/BlackJackCuiController.go
+++ b/internal/adapter/controller/BlackJackCuiController.go
@@ -80,6 +80,15 @@ func (bcc *BlackJackCuiController) Exec(command string) string {
 					return "Invalid deck count. Please enter a number.", true
 				}
 				return bcc.bji.SetDeckCount(count), true
+			case "scc", "setcpucount":
+				if len(args) < 1 {
+					return "CPU player count is required.", true
+				}
+				count, err := strconv.Atoi(args[0])
+				if err != nil || count < 0 || count > domain.BJMaxCpuPlayers {
+					return "Invalid CPU player count. Please enter a number (0-3).", true
+				}
+				return bcc.bji.SetCpuPlayerCount(count), true
 			case "scs", "setcountingsystem":
 				if len(args) < 1 {
 					return "Counting system is required.", true

--- a/internal/adapter/controller/BlackJackCuiController_test.go
+++ b/internal/adapter/controller/BlackJackCuiController_test.go
@@ -211,6 +211,36 @@ func TestBlackJackCuiController_Soft17AndCountingCommands(t *testing.T) {
 	})
 }
 
+func TestBlackJackCuiController_SetCpuPlayerCount(t *testing.T) {
+	mockOutput := "----------\n"
+	bjiMock := new(usecase.MockBlackJackInteractor)
+	bjiMock.On("SetCpuPlayerCount", 2).Return(mockOutput)
+	tbc := controller.NewBlackJackCuiController(bjiMock)
+
+	t.Run("scc with valid count", func(t *testing.T) {
+		assert.Equal(t, mockOutput, tbc.Exec("scc 2"))
+	})
+	t.Run("setcpucount with valid count", func(t *testing.T) {
+		assert.Equal(t, mockOutput, tbc.Exec("setcpucount 2"))
+	})
+	t.Run("scc without arg", func(t *testing.T) {
+		assert.Equal(t, "CPU player count is required.", tbc.Exec("scc"))
+	})
+	t.Run("scc with invalid arg", func(t *testing.T) {
+		assert.Equal(t, "Invalid CPU player count. Please enter a number (0-3).", tbc.Exec("scc abc"))
+	})
+	t.Run("scc with negative arg", func(t *testing.T) {
+		assert.Equal(t, "Invalid CPU player count. Please enter a number (0-3).", tbc.Exec("scc -1"))
+	})
+	t.Run("scc with out-of-range arg", func(t *testing.T) {
+		assert.Equal(t, "Invalid CPU player count. Please enter a number (0-3).", tbc.Exec("scc 4"))
+	})
+	t.Run("scc with zero (valid)", func(t *testing.T) {
+		bjiMock.On("SetCpuPlayerCount", 0).Return(mockOutput)
+		assert.Equal(t, mockOutput, tbc.Exec("scc 0"))
+	})
+}
+
 func TestBlackJackCuiController_SetPenetration_Valid(t *testing.T) {
 	mockOutput := "----------\n"
 	bjiMock := new(usecase.MockBlackJackInteractor)

--- a/internal/adapter/controller/BlackJackWebController.go
+++ b/internal/adapter/controller/BlackJackWebController.go
@@ -175,6 +175,8 @@ func (bwc *BlackJackWebController) Exec(w rest.ResponseWriter, r *rest.Request) 
 				bwc.writePresenterResponse(w, bji.SetCountingSystem(param.Amount))
 			case "pen", "setpenetration":
 				bwc.writePresenterResponse(w, bji.SetDeckPenetration(param.Amount))
+			case "scc", "setcpucount":
+				bwc.writePresenterResponse(w, bji.SetCpuPlayerCount(param.Amount))
 			default:
 				return false
 			}

--- a/internal/adapter/controller/BlackJackWebController_test.go
+++ b/internal/adapter/controller/BlackJackWebController_test.go
@@ -530,6 +530,38 @@ func TestBlackJackWebController_SetPenetration(t *testing.T) {
 	})
 }
 
+func TestBlackJackWebController_SetCpuPlayerCount(t *testing.T) {
+	mockOutput := `{"dealer":{"score":0,"cards":null,"chips":1000},"player":{"score":0,"cards":null,"chips":1000},"message":"","cpuPlayerCount":2}`
+	bjiMock := new(usecase.MockBlackJackInteractor)
+	bjiMock.On("SetCpuPlayerCount", 2).Return(mockOutput)
+	factory := func() uc.BlackJackInteractorIF { return bjiMock }
+	tbc := controller.NewBlackJackWebController(factory)
+	defer tbc.Stop()
+
+	api := rest.NewApi()
+	router, _ := rest.MakeRouter(rest.Post("/blackjack/exec", tbc.Exec))
+	api.SetApp(router)
+
+	t.Run("setcpucount with amount", func(t *testing.T) {
+		var input controller.BlackJackWebInput
+		_ = json.Unmarshal([]byte(`{"command":"setcpucount","amount":2,"sessionId":"bj-scc-1"}`), &input)
+		req := test.MakeSimpleRequest("POST", "http://1.2.3.4/blackjack/exec", &input)
+		req.Header.Set("Content-Type", "application/json;charset=UTF-8")
+		recorded := test.RunRequest(t, api.MakeHandler(), req)
+		recorded.CodeIs(http.StatusOK)
+		recorded.ContentTypeIsJson()
+	})
+
+	t.Run("scc shorthand", func(t *testing.T) {
+		var input controller.BlackJackWebInput
+		_ = json.Unmarshal([]byte(`{"command":"scc","amount":2,"sessionId":"bj-scc-1"}`), &input)
+		req := test.MakeSimpleRequest("POST", "http://1.2.3.4/blackjack/exec", &input)
+		req.Header.Set("Content-Type", "application/json;charset=UTF-8")
+		recorded := test.RunRequest(t, api.MakeHandler(), req)
+		recorded.CodeIs(http.StatusOK)
+	})
+}
+
 func TestBlackJackWebController_ResetWithPenetration(t *testing.T) {
 	mockOutput := `{"dealer":{"score":0,"cards":null,"chips":1000},"player":{"score":0,"cards":null,"chips":1000},"message":"","deckPenetration":50}`
 	bjiMock := new(usecase.MockBlackJackInteractor)

--- a/internal/adapter/controller/usecase/BlackJackInteractor_mock.go
+++ b/internal/adapter/controller/usecase/BlackJackInteractor_mock.go
@@ -103,6 +103,12 @@ func (_m *MockBlackJackInteractor) SetDeckPenetration(penetration int) string {
 	return ret.Get(0).(string)
 }
 
+// SetCpuPlayerCount モック
+func (_m *MockBlackJackInteractor) SetCpuPlayerCount(count int) string {
+	ret := _m.Called(count)
+	return ret.Get(0).(string)
+}
+
 // ResetWithConfig モック
 func (_m *MockBlackJackInteractor) ResetWithConfig(dealerHitsSoft17 bool, cpuPlayerCount int, countingEnabled bool, doubleAfterSplit bool, countingSystem int, deckPenetration int) string {
 	ret := _m.Called(dealerHitsSoft17, cpuPlayerCount, countingEnabled, doubleAfterSplit, countingSystem, deckPenetration)

--- a/internal/adapter/controller/web_controller_writejson_internal_test.go
+++ b/internal/adapter/controller/web_controller_writejson_internal_test.go
@@ -44,6 +44,7 @@ func (m *mockBlackJackIF) ToggleCounting() string                    { return ""
 func (m *mockBlackJackIF) ToggleDAS() string                         { return "" }
 func (m *mockBlackJackIF) SetCountingSystem(system int) string       { return "" }
 func (m *mockBlackJackIF) SetDeckPenetration(penetration int) string { return "" }
+func (m *mockBlackJackIF) SetCpuPlayerCount(count int) string        { return "" }
 func (m *mockBlackJackIF) ResetWithConfig(dealerHitsSoft17 bool, cpuPlayerCount int, countingEnabled bool, doubleAfterSplit bool, countingSystem int, deckPenetration int) string {
 	return ""
 }

--- a/internal/usecase/BlackJackInteractor.go
+++ b/internal/usecase/BlackJackInteractor.go
@@ -24,6 +24,7 @@ type BlackJackInteractorIF interface {
 	ToggleDAS() string
 	SetCountingSystem(system int) string
 	SetDeckPenetration(penetration int) string
+	SetCpuPlayerCount(count int) string
 	ResetWithConfig(dealerHitsSoft17 bool, cpuPlayerCount int, countingEnabled bool, doubleAfterSplit bool, countingSystem int, deckPenetration int) string
 }
 
@@ -149,6 +150,14 @@ func (bi *BlackJackInteractor) SetCountingSystem(system int) string {
 func (bi *BlackJackInteractor) SetDeckPenetration(penetration int) string {
 	config := bi.bj.GetConfig()
 	config.DeckPenetration = penetration
+	err := bi.bj.SetConfig(config)
+	return bi.bjp.Output(bi.bj, err)
+}
+
+// SetCpuPlayerCount CPUプレイヤー数変更
+func (bi *BlackJackInteractor) SetCpuPlayerCount(count int) string {
+	config := bi.bj.GetConfig()
+	config.CpuPlayerCount = count
 	err := bi.bj.SetConfig(config)
 	return bi.bjp.Output(bi.bj, err)
 }

--- a/internal/usecase/BlackJackInteractor_test.go
+++ b/internal/usecase/BlackJackInteractor_test.go
@@ -237,6 +237,33 @@ func TestSetDeckPenetration_Error(t *testing.T) {
 	assert.Equal(t, "error output", result)
 }
 
+func TestSetCpuPlayerCount(t *testing.T) {
+	bjpMock := new(presenter.MockBlackJackPresenter)
+	bjpMock.On("Output", mock.Anything, mock.Anything).Return("cpu count changed")
+
+	bjMock := new(interfaces.MockBlackJackGame)
+	bjMock.On("GetConfig").Return(domain.BlackJackConfig{DealerHitsSoft17: false, CpuPlayerCount: 0, CountingEnabled: false, DoubleAfterSplit: true})
+	bjMock.On("SetConfig", domain.BlackJackConfig{DealerHitsSoft17: false, CpuPlayerCount: 2, CountingEnabled: false, DoubleAfterSplit: true}).Return(nil)
+
+	tbj := usecase.NewBlackJackInteractor(bjMock, bjpMock)
+	result := tbj.SetCpuPlayerCount(2)
+	assert.Equal(t, "cpu count changed", result)
+	bjMock.AssertCalled(t, "SetConfig", domain.BlackJackConfig{DealerHitsSoft17: false, CpuPlayerCount: 2, CountingEnabled: false, DoubleAfterSplit: true})
+}
+
+func TestSetCpuPlayerCount_Error(t *testing.T) {
+	bjpMock := new(presenter.MockBlackJackPresenter)
+	bjpMock.On("Output", mock.Anything, mock.Anything).Return("error output")
+
+	bjMock := new(interfaces.MockBlackJackGame)
+	bjMock.On("GetConfig").Return(domain.BlackJackConfig{DealerHitsSoft17: false, CpuPlayerCount: 0, CountingEnabled: false, DoubleAfterSplit: true})
+	bjMock.On("SetConfig", domain.BlackJackConfig{DealerHitsSoft17: false, CpuPlayerCount: 5, CountingEnabled: false, DoubleAfterSplit: true}).Return(errors.New("invalid cpu count"))
+
+	tbj := usecase.NewBlackJackInteractor(bjMock, bjpMock)
+	result := tbj.SetCpuPlayerCount(5)
+	assert.Equal(t, "error output", result)
+}
+
 func TestResetWithConfig_WithPenetration(t *testing.T) {
 	bjpMock := new(presenter.MockBlackJackPresenter)
 	bjpMock.On("Output", mock.Anything, mock.Anything).Return("reset done")


### PR DESCRIPTION
## Summary
- CPU人数変更が即座にバックエンドに反映されないバグを修正
- `SetCpuPlayerCount` コマンドを全層（Interactor / CUI Controller / Web Controller / Frontend）に追加
- フロントエンドのCPU人数ドロップダウン変更時に `exec('setcpucount', v)` でAPIコールするよう修正

Closes #407

## Test plan
- [x] Go全テスト通過 (`go test -tags test ./...`)
- [x] フロントエンド全874テスト通過 (`npm test`)
- [x] usecase / controller カバレッジ 100%
- [x] CUI: `scc` / `setcpucount` コマンド（正常系・エラー系7ケース）
- [x] Web: `setcpucount` / `scc` コマンド（2ケース）
- [x] BlackJackPage: CPU人数変更でAPIコールが発生することを検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)