### PR TITLE
refactor(daifugo): extract shared card group search helper

### DIFF
--- a/internal/domain/Daifugo.go
+++ b/internal/domain/Daifugo.go
@@ -1007,7 +1007,7 @@ func (d *Daifugo) shouldStrategicPass(player *DaifugoPlayer, indices []int) bool
 	return false
 }
 
-// calcTableStrength 場のカードの強さを計算する
+// calcTableStrength 場のカードの強さを計算する (d.tableCards が非nil前提)
 func (d *Daifugo) calcTableStrength() int {
 	tableBase := getBaseValue(d.tableCards)
 	if tableBase < 0 {
@@ -1023,6 +1023,8 @@ type cardSearchOpts struct {
 }
 
 // searchCardGroup 手札からカードグループを検索する共通ヘルパー
+// 手札は強さ順 (弱→強) でソート済みなので、selectStrongest=true の場合は
+// 後に見つかるグループほど強いため、上書きし続けて最後の結果を返す。
 func (d *Daifugo) searchCardGroup(player *DaifugoPlayer, needed int, tableStrength int, opts cardSearchOpts) []int {
 	jokerIndices := d.findJokerIndices(player)
 	var bestIndices []int


### PR DESCRIPTION
## Summary

- Extract `calcTableStrength()` and `searchCardGroup()` helper methods to eliminate ~200 lines of duplicated card group search logic across `findBestPlayNormal()`, `findBestPlayEasy()`, and `findBestPlayHard()`
- Introduce `cardSearchOpts` struct with `skipRevolution` and `selectStrongest` flags to parameterize difficulty-specific behavior without code duplication
- Net reduction: 94 lines (97 insertions, 191 deletions)

Closes #397

## Test plan

- [x] All existing tests pass (`go test -tags test ./...`)
- [x] Coverage unchanged or improved (99.0% → 99.1%)
- [x] New helper methods (`calcTableStrength`, `searchCardGroup`) have 100% statement coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)