### PR TITLE
refactor(daifugo): split CPU AI play methods to reduce complexity

### DIFF
--- a/internal/domain/Daifugo.go
+++ b/internal/domain/Daifugo.go
@@ -1132,14 +1132,12 @@ func tryBuildSequence(suitCards []suitCardEntry, si int, jokerIndices []int, nee
 	for len(indices) < needed {
 		targetStr := lastStr + 1
 		found := false
-		for sci < len(suitCards) {
-			if suitCards[sci].strength == targetStr {
-				indices = append(indices, suitCards[sci].idx)
-				lastStr = targetStr
-				sci++
-				found = true
-			}
-			break
+		// suitCards は強さ昇順なので、sci 位置が targetStr と一致するかだけ確認すればよい
+		if sci < len(suitCards) && suitCards[sci].strength == targetStr {
+			indices = append(indices, suitCards[sci].idx)
+			lastStr = targetStr
+			sci++
+			found = true
 		}
 		if !found {
 			if jokersUsed < len(jokerIndices) {

--- a/internal/domain/Daifugo_test.go
+++ b/internal/domain/Daifugo_test.go
@@ -6336,3 +6336,68 @@ func TestDaifugo_CpuDifficulty(t *testing.T) {
 		assert.Equal(t, 6, players[1].GetCardsSize(), "Hard passes when no valid play available")
 	})
 }
+
+func TestDaifugoHardNonUrgentOpeningPlay(t *testing.T) {
+	tc := domain.NewTrumpCards(0)
+	players := makeDaifugoPlayers()
+	cfg := noRulesConfig()
+	cfg.CpuDifficulty = domain.DaifugoDifficultyHard
+	dg := domain.NewDaifugo(tc, players, cfg)
+
+	// Human passes on empty table
+	players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 3, false))
+	players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 4, false))
+	players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 5, false))
+	players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 6, false))
+	players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 7, false))
+	// CPU 1: normal cards, no emperor combo
+	players[1].AddCard(domain.NewCard(domain.CardDesignHeart, 4, false))
+	players[1].AddCard(domain.NewCard(domain.CardDesignHeart, 5, false))
+	players[1].AddCard(domain.NewCard(domain.CardDesignHeart, 6, false))
+	// Not urgent: opponents have many cards
+	players[2].AddCard(domain.NewCard(domain.CardDesignClover, 3, false))
+	players[2].AddCard(domain.NewCard(domain.CardDesignClover, 4, false))
+	players[2].AddCard(domain.NewCard(domain.CardDesignClover, 5, false))
+	players[2].AddCard(domain.NewCard(domain.CardDesignClover, 6, false))
+	players[2].AddCard(domain.NewCard(domain.CardDesignClover, 7, false))
+	players[3].AddCard(domain.NewCard(domain.CardDesignDiamond, 3, false))
+	players[3].AddCard(domain.NewCard(domain.CardDesignDiamond, 4, false))
+	players[3].AddCard(domain.NewCard(domain.CardDesignDiamond, 5, false))
+	players[3].AddCard(domain.NewCard(domain.CardDesignDiamond, 6, false))
+	players[3].AddCard(domain.NewCard(domain.CardDesignDiamond, 7, false))
+
+	err := dg.PlayerPlay([]int{})
+	assert.NoError(t, err)
+	dg.CpuPlay()
+
+	// Hard non-urgent should play weakest card (4) like Normal AI
+	assert.Equal(t, 2, players[1].GetCardsSize(), "Hard non-urgent should play opening card")
+}
+
+func TestIllegalFinish_OpeningSingleCardFallback(t *testing.T) {
+	tc := domain.NewTrumpCards(0)
+	players := makeDaifugoPlayers()
+	config := domain.DaifugoConfig{
+		EightCutEnabled:      true,
+		IllegalFinishEnabled: true,
+	}
+	dg := domain.NewDaifugo(tc, players, config)
+
+	// CPU 1 has only an 8 → only filter match is illegal finish → fallback used
+	players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 3, false))
+	players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 4, false))
+	players[1].AddCard(domain.NewCard(domain.CardDesignHeart, 8, false))
+	players[2].AddCard(domain.NewCard(domain.CardDesignClover, 6, false))
+	players[2].AddCard(domain.NewCard(domain.CardDesignClover, 7, false))
+	players[3].AddCard(domain.NewCard(domain.CardDesignDiamond, 9, false))
+	players[3].AddCard(domain.NewCard(domain.CardDesignDiamond, 10, false))
+
+	err := dg.PlayerPlay([]int{})
+	assert.NoError(t, err)
+	dg.CpuPlay()
+
+	// CPU must play the 8 (only card) and accept penalty
+	assert.Equal(t, 0, players[1].GetCardsSize(), "CPU should play only card")
+	assert.True(t, players[1].GetIsFinished())
+	assert.True(t, players[1].GetIllegalFinishPenalty(), "CPU should accept illegal finish penalty")
+}


### PR DESCRIPTION
## Summary

- Extract shared helpers (`collectSuitCards`, `tryBuildSequence`, `findOpeningSingleCard`, `findJokerSinglePlay`) to eliminate duplication across CPU AI play methods
- Split `findBestPlayNormal` into `findNormalOpeningPlay` / `findNormalResponsePlay` (~20 lines each)
- Split `findBestPlayHard` into `findHardOpeningPlay` / `findHardResponsePlay` (~20 lines each)
- Unify `findBestSequencePlay` / `findBestSequencePlayHard` via `findSequencePlay` with `selectStrongest` parameter
- Net reduction of ~96 lines; each method now fits in 10-20 lines
- Coverage improved from 98.9% to 99.2% by consolidating duplicate code paths

Closes #398

## Test plan

- [x] All existing Daifugo tests pass (`go test -tags test ./internal/domain/`)
- [x] Full test suite passes (`go test -tags test ./...`)
- [x] Coverage verified: 99.2% (improved from 98.9%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)