### PR TITLE
docs: convert backtick file references to clickable markdown links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,11 @@
 # Agent Instructions
 
-All project-specific rules, architecture, testing policies, and workflows are defined in `CLAUDE.md` and its referenced files. Follow `CLAUDE.md` as the single source of truth.
+All project-specific rules, architecture, testing policies, and workflows are defined in [`CLAUDE.md`](CLAUDE.md) and its referenced files. Follow [`CLAUDE.md`](CLAUDE.md) as the single source of truth.
 
 Key references:
-- `CLAUDE.md` -- Root project rules and commands
-- `docs/` -- Detailed context (architecture, testing, games, workflow)
-- `.ai/skills/` -- Reusable skill definitions (TDD flow)
-- `.ai/hooks/` -- Pre-commit verification commands
-- `internal/CLAUDE.md` -- Go backend-specific rules
-- `frontend/CLAUDE.md` -- Frontend-specific rules
+- [`CLAUDE.md`](CLAUDE.md) -- Root project rules and commands
+- [`docs/`](docs/) -- Detailed context (architecture, testing, games, workflow)
+- [`.ai/skills/`](.ai/skills/) -- Reusable skill definitions (TDD flow)
+- [`.ai/hooks/`](.ai/hooks/) -- Pre-commit verification commands
+- [`internal/CLAUDE.md`](internal/CLAUDE.md) -- Go backend-specific rules
+- [`frontend/CLAUDE.md`](frontend/CLAUDE.md) -- Frontend-specific rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,20 +49,20 @@ docker run --rm -d -p 8080:8080 go_trumpcards
 
 ## Architecture
 
-Clean Architecture: `infrastructure` -> `adapter` -> `usecase` -> `domain`. See `docs/architecture.md` for full details.
+Clean Architecture: `infrastructure` -> `adapter` -> `usecase` -> `domain`. See [`docs/architecture.md`](docs/architecture.md) for full details.
 
 ## Testing
 
 TDD (Red-Green-Refactor) is mandatory. 100% branch coverage (C1) required. See:
-- `docs/testing.md` -- Full testing policy (Go + frontend + E2E + i18n)
-- `.ai/skills/tdd-flow.md` -- TDD cycle workflow
-- `.ai/hooks/README.md` -- Pre-commit verification commands
-- `internal/CLAUDE.md` -- Go-specific testing rules
-- `frontend/CLAUDE.md` -- Frontend-specific testing rules
+- [`docs/testing.md`](docs/testing.md) -- Full testing policy (Go + frontend + E2E + i18n)
+- [`.ai/skills/tdd-flow.md`](.ai/skills/tdd-flow.md) -- TDD cycle workflow
+- [`.ai/hooks/README.md`](.ai/hooks/README.md) -- Pre-commit verification commands
+- [`internal/CLAUDE.md`](internal/CLAUDE.md) -- Go-specific testing rules
+- [`frontend/CLAUDE.md`](frontend/CLAUDE.md) -- Frontend-specific testing rules
 
 ## Documentation Maintenance
 
-See `docs/documentation-maintenance.md` for the update matrix.
+See [`docs/documentation-maintenance.md`](docs/documentation-maintenance.md) for the update matrix.
 
 ## Git Workflow
 
@@ -87,18 +87,18 @@ All commit messages must follow [Conventional Commits](https://www.conventionalc
 
 ## Workflow & Principles
 
-See `docs/workflow.md` for workflow orchestration, task management, and core principles.
+See [`docs/workflow.md`](docs/workflow.md) for workflow orchestration, task management, and core principles.
 
 ## Detailed Context
 
 | Topic | File |
 |-------|------|
-| Architecture & key patterns | `docs/architecture.md` |
-| Testing policy (all layers) | `docs/testing.md` |
-| Game descriptions & entities | `docs/games.md` |
-| Documentation update matrix | `docs/documentation-maintenance.md` |
-| Workflow & principles | `docs/workflow.md` |
-| TDD skill | `.ai/skills/tdd-flow.md` |
-| Pre-commit hooks | `.ai/hooks/README.md` |
-| Go backend rules | `internal/CLAUDE.md` |
-| Frontend rules | `frontend/CLAUDE.md` |
+| Architecture & key patterns | [`docs/architecture.md`](docs/architecture.md) |
+| Testing policy (all layers) | [`docs/testing.md`](docs/testing.md) |
+| Game descriptions & entities | [`docs/games.md`](docs/games.md) |
+| Documentation update matrix | [`docs/documentation-maintenance.md`](docs/documentation-maintenance.md) |
+| Workflow & principles | [`docs/workflow.md`](docs/workflow.md) |
+| TDD skill | [`.ai/skills/tdd-flow.md`](.ai/skills/tdd-flow.md) |
+| Pre-commit hooks | [`.ai/hooks/README.md`](.ai/hooks/README.md) |
+| Go backend rules | [`internal/CLAUDE.md`](internal/CLAUDE.md) |
+| Frontend rules | [`frontend/CLAUDE.md`](frontend/CLAUDE.md) |

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,11 +1,11 @@
 # Gemini CLI Configuration
 
-All project-specific rules, architecture, testing policies, and workflows are defined in `CLAUDE.md` and its referenced files. Follow `CLAUDE.md` as the single source of truth.
+All project-specific rules, architecture, testing policies, and workflows are defined in [`CLAUDE.md`](CLAUDE.md) and its referenced files. Follow [`CLAUDE.md`](CLAUDE.md) as the single source of truth.
 
 Key references:
-- `CLAUDE.md` -- Root project rules and commands
-- `docs/` -- Detailed context (architecture, testing, games, workflow)
-- `.ai/skills/` -- Reusable skill definitions (TDD flow)
-- `.ai/hooks/` -- Pre-commit verification commands
-- `internal/CLAUDE.md` -- Go backend-specific rules
-- `frontend/CLAUDE.md` -- Frontend-specific rules
+- [`CLAUDE.md`](CLAUDE.md) -- Root project rules and commands
+- [`docs/`](docs/) -- Detailed context (architecture, testing, games, workflow)
+- [`.ai/skills/`](.ai/skills/) -- Reusable skill definitions (TDD flow)
+- [`.ai/hooks/`](.ai/hooks/) -- Pre-commit verification commands
+- [`internal/CLAUDE.md`](internal/CLAUDE.md) -- Go backend-specific rules
+- [`frontend/CLAUDE.md`](frontend/CLAUDE.md) -- Frontend-specific rules

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,5 +38,5 @@ public/                        # Built frontend assets served by Go web server
 ## Key patterns
 
 - **Presenter pattern**: `internal/usecase/presenter/` defines output interfaces (e.g., `BlackJackPresenter`). `internal/adapter/presenter/` provides concrete implementations (CUI vs Web). Presenters are injected into interactors.
-- **Mock presenters**: `*_mock.go` files in `internal/adapter/presenter/` and `internal/usecase/presenter/` are used in tests to avoid I/O.
+- **Mock presenters**: `*_mock.go` files in `internal/usecase/presenter/` are used in tests to avoid I/O.
 - **Web API**: Seven endpoints -- `POST /blackjack/exec` (BlackJack), `POST /poker/exec` (Poker), `POST /oldmaid/exec` (Old Maid), `POST /daifugo/exec` (Daifugo), `POST /sevens/exec` (Sevens), `POST /doubt/exec` (Doubt), and `POST /holdem/exec` (Texas Hold'em) -- accept JSON with a `Cmd` field and game state.

--- a/docs/documentation-maintenance.md
+++ b/docs/documentation-maintenance.md
@@ -4,16 +4,16 @@
 
 | Change type | Documents to update |
 |-------------|---------------------|
-| Add/remove a game | `README.md` (Description, Run section), `CLAUDE.md` (Commands), `docs/games.md` |
-| Add/remove a CLI command (`cmd/cli/main.go`) | `README.md` (Run section), `CLAUDE.md` (Commands) |
-| Add/remove a Web API endpoint | `docs/architecture.md` (Web API in Key patterns), `api/openapi.yaml` |
-| Change request/response schema of a Web API endpoint | `api/openapi.yaml` |
-| Change architecture or layer structure | `README.md` (Architecture), `CLAUDE.md` (Architecture), `docs/architecture.md` |
-| Change Git workflow or CI/CD | `CLAUDE.md` (Git Workflow) |
+| Add/remove a game | [`README.md`](../README.md) (Description, Run section), [`CLAUDE.md`](../CLAUDE.md) (Commands), [`docs/games.md`](games.md) |
+| Add/remove a CLI command (`cmd/cli/main.go`) | [`README.md`](../README.md) (Run section), [`CLAUDE.md`](../CLAUDE.md) (Commands) |
+| Add/remove a Web API endpoint | [`docs/architecture.md`](architecture.md) (Web API in Key patterns), [`api/openapi.yaml`](../api/openapi.yaml) |
+| Change request/response schema of a Web API endpoint | [`api/openapi.yaml`](../api/openapi.yaml) |
+| Change architecture or layer structure | [`README.md`](../README.md) (Architecture), [`CLAUDE.md`](../CLAUDE.md) (Architecture), [`docs/architecture.md`](architecture.md) |
+| Change Git workflow or CI/CD | [`CLAUDE.md`](../CLAUDE.md) (Git Workflow) |
 | Modify anything under `frontend/` | Run `cd frontend && npm run build`, `cd frontend && npm run check`, and `cd frontend && npm test` and ensure all three pass before committing |
-| Add/remove frontend source files or change testing approach | Update `docs/testing.md` (Frontend testing) and `frontend/CLAUDE.md` |
-| Change frontend tooling or scripts | `frontend/README.md` (Scripts, Tooling) |
+| Add/remove frontend source files or change testing approach | Update [`docs/testing.md`](testing.md) (Frontend testing) and [`frontend/CLAUDE.md`](../frontend/CLAUDE.md) |
+| Change frontend tooling or scripts | [`frontend/README.md`](../frontend/README.md) (Scripts, Tooling) |
 | Change game rules or game flow logic | `docs/manual/cui/<game>.md` and `docs/manual/web/<game>.md` for the affected game |
-| Change Go testing policy or mock patterns | Update `docs/testing.md` and `internal/CLAUDE.md` |
+| Change Go testing policy or mock patterns | Update [`docs/testing.md`](testing.md) and [`internal/CLAUDE.md`](../internal/CLAUDE.md) |
 
 Use commit type `docs` (or include doc changes in the same commit as the code change) following the Conventional Commits format.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,7 +4,7 @@
 
 ## TDD (Test-Driven Development)
 
-**All code changes must follow the TDD cycle (Red-Green-Refactor).** See `.ai/skills/tdd-flow.md` for the detailed workflow.
+**All code changes must follow the TDD cycle (Red-Green-Refactor).** See [`.ai/skills/tdd-flow.md`](../.ai/skills/tdd-flow.md) for the detailed workflow.
 
 ## Coverage standard
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,3 +1,3 @@
 # Agent Instructions
 
-All project-specific rules are defined in `CLAUDE.md` (this directory) and the root `CLAUDE.md`. Follow those files for testing, i18n, and workflow guidance.
+All project-specific rules are defined in [`CLAUDE.md`](CLAUDE.md) (this directory) and the root [`CLAUDE.md`](../CLAUDE.md). Follow those files for testing, i18n, and workflow guidance.

--- a/frontend/GEMINI.md
+++ b/frontend/GEMINI.md
@@ -1,3 +1,3 @@
 # Gemini CLI Instructions
 
-All project-specific rules are defined in `CLAUDE.md` (this directory) and the root `CLAUDE.md`. Follow those files for testing, i18n, and workflow guidance.
+All project-specific rules are defined in [`CLAUDE.md`](CLAUDE.md) (this directory) and the root [`CLAUDE.md`](../CLAUDE.md). Follow those files for testing, i18n, and workflow guidance.

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -1,3 +1,3 @@
 # Agent Instructions
 
-All project-specific rules are defined in `CLAUDE.md` (this directory) and the root `CLAUDE.md`. Follow those files for architecture, testing, and workflow guidance.
+All project-specific rules are defined in [`CLAUDE.md`](CLAUDE.md) (this directory) and the root [`CLAUDE.md`](../CLAUDE.md). Follow those files for architecture, testing, and workflow guidance.

--- a/internal/CLAUDE.md
+++ b/internal/CLAUDE.md
@@ -15,7 +15,7 @@ This directory contains all Go backend code following Clean Architecture.
 
 ## Testing
 
-Follow TDD (Red-Green-Refactor). See `../.ai/skills/tdd-flow.md` for the full workflow.
+Follow TDD (Red-Green-Refactor). See [`../.ai/skills/tdd-flow.md`](../.ai/skills/tdd-flow.md) for the full workflow.
 
 **Branch coverage (C1) must be 100%** for all packages in this directory except `infrastructure/` (the top-level `cmd/` directory is also excluded project-wide).
 

--- a/internal/GEMINI.md
+++ b/internal/GEMINI.md
@@ -1,3 +1,3 @@
 # Gemini CLI Instructions
 
-All project-specific rules are defined in `CLAUDE.md` (this directory) and the root `CLAUDE.md`. Follow those files for architecture, testing, and workflow guidance.
+All project-specific rules are defined in [`CLAUDE.md`](CLAUDE.md) (this directory) and the root [`CLAUDE.md`](../CLAUDE.md). Follow those files for architecture, testing, and workflow guidance.


### PR DESCRIPTION
## Summary
- mdファイル内の内部ドキュメント参照をバッククォート形式から正しいmarkdownリンクシンタックスに変換し、GitHub上でクリック可能にした
- `docs/architecture.md` の誤ったモックファイルパス参照（`internal/adapter/presenter/`）を修正

## Changed files
`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `docs/architecture.md`, `docs/documentation-maintenance.md`, `docs/testing.md`, `internal/CLAUDE.md`, `internal/AGENTS.md`, `internal/GEMINI.md`, `frontend/AGENTS.md`, `frontend/GEMINI.md`

## Test plan
- [ ] GitHub上で各mdファイルのリンクがクリック可能で正しいファイルに遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)