### PR TITLE
refactor(controller): extract generic GameWebController to eliminate boilerplate

### DIFF
--- a/internal/adapter/controller/BlackJackWebController.go
+++ b/internal/adapter/controller/BlackJackWebController.go
@@ -86,111 +86,14 @@ type BlackJackWebOutput struct {
 }
 
 // BlackJackWebController ブラックジャックWebコントローラークラス
-type BlackJackWebController struct {
-	baseController
-	factory func() usecase.BlackJackInteractorIF
-	store   *SessionStore[usecase.BlackJackInteractorIF]
-}
+type BlackJackWebController = GameWebController[usecase.BlackJackInteractorIF, BlackJackWebInput, *BlackJackWebOutput]
 
 // NewBlackJackWebController コンストラクタ
 func NewBlackJackWebController(factory func() usecase.BlackJackInteractorIF) *BlackJackWebController {
-	return &BlackJackWebController{
-		factory: factory,
-		store:   NewSessionStore[usecase.BlackJackInteractorIF](),
-	}
+	return NewGameWebController(factory, newBlackJackDefaultOutput, nil, blackJackDispatch)
 }
 
-// Exec ゲーム実行
-func (bwc *BlackJackWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
-	execWithSession(&bwc.baseController, w, r, bwc.store, bwc.factory,
-		func(msg string) any { return bwc.newDefaultOutput(msg) },
-		nil,
-		func(w rest.ResponseWriter, bji usecase.BlackJackInteractorIF, param BlackJackWebInput) bool {
-			switch param.Command {
-			case "r", "reset":
-				if param.DealerHitsSoft17 != nil || param.CpuPlayerCount != nil || param.CountingEnabled != nil || param.DoubleAfterSplit != nil || param.CountingSystem != nil || param.DeckPenetration != nil {
-					h17 := false
-					if param.DealerHitsSoft17 != nil {
-						h17 = *param.DealerHitsSoft17
-					}
-					cpuCount := 0
-					if param.CpuPlayerCount != nil {
-						cpuCount = *param.CpuPlayerCount
-					}
-					counting := false
-					if param.CountingEnabled != nil {
-						counting = *param.CountingEnabled
-					}
-					das := true
-					if param.DoubleAfterSplit != nil {
-						das = *param.DoubleAfterSplit
-					}
-					cs := 0
-					if param.CountingSystem != nil {
-						cs = *param.CountingSystem
-					}
-					dp := 0
-					if param.DeckPenetration != nil {
-						dp = *param.DeckPenetration
-					}
-					bwc.writePresenterResponse(w, bji.ResetWithConfig(h17, cpuCount, counting, das, cs, dp))
-				} else {
-					bwc.writePresenterResponse(w, bji.Reset())
-				}
-			case "h", "hit":
-				bwc.writePresenterResponse(w, bji.Hit())
-			case "s", "stand":
-				bwc.writePresenterResponse(w, bji.Stand())
-			case "b", "bet":
-				ppBet := 0
-				if param.PerfectPairsBet != nil {
-					ppBet = *param.PerfectPairsBet
-				}
-				t3Bet := 0
-				if param.TwentyOnePlus3Bet != nil {
-					t3Bet = *param.TwentyOnePlus3Bet
-				}
-				bwc.writePresenterResponse(w, bji.Bet(param.Amount, ppBet, t3Bet))
-			case "d", "doubledown":
-				bwc.writePresenterResponse(w, bji.DoubleDown())
-			case "sp", "split":
-				bwc.writePresenterResponse(w, bji.Split())
-			case "i", "insurance":
-				bwc.writePresenterResponse(w, bji.Insurance())
-			case "di", "declineinsurance":
-				bwc.writePresenterResponse(w, bji.DeclineInsurance())
-			case "sur", "surrender":
-				bwc.writePresenterResponse(w, bji.Surrender())
-			case "togglehint":
-				bwc.writePresenterResponse(w, bji.ToggleHint())
-			case "sd", "setdeckcount":
-				bwc.writePresenterResponse(w, bji.SetDeckCount(param.Amount))
-			case "togglesoft17":
-				bwc.writePresenterResponse(w, bji.ToggleSoft17())
-			case "togglecounting":
-				bwc.writePresenterResponse(w, bji.ToggleCounting())
-			case "toggledas":
-				bwc.writePresenterResponse(w, bji.ToggleDAS())
-			case "scs", "setcountingsystem":
-				bwc.writePresenterResponse(w, bji.SetCountingSystem(param.Amount))
-			case "pen", "setpenetration":
-				bwc.writePresenterResponse(w, bji.SetDeckPenetration(param.Amount))
-			case "scc", "setcpucount":
-				bwc.writePresenterResponse(w, bji.SetCpuPlayerCount(param.Amount))
-			default:
-				return false
-			}
-			return true
-		})
-}
-
-// Stop stops the background cleanup goroutine of the session store.
-func (bwc *BlackJackWebController) Stop() {
-	bwc.store.Stop()
-}
-
-// newDefaultOutput エラー・定型応答用のデフォルト出力を返す
-func (bwc *BlackJackWebController) newDefaultOutput(msg string) *BlackJackWebOutput {
+func newBlackJackDefaultOutput(msg string) *BlackJackWebOutput {
 	return &BlackJackWebOutput{
 		Dealer:          &BlackJackWebOutputPlayer{},
 		Player:          &BlackJackWebOutputPlayer{},
@@ -198,4 +101,82 @@ func (bwc *BlackJackWebController) newDefaultOutput(msg string) *BlackJackWebOut
 		DeckCount:       1,
 		DeckPenetration: 75,
 	}
+}
+
+func blackJackDispatch(bc *baseController, w rest.ResponseWriter, bji usecase.BlackJackInteractorIF, param BlackJackWebInput, _ func(string) *BlackJackWebOutput) bool {
+	switch param.Command {
+	case "r", "reset":
+		if param.DealerHitsSoft17 != nil || param.CpuPlayerCount != nil || param.CountingEnabled != nil || param.DoubleAfterSplit != nil || param.CountingSystem != nil || param.DeckPenetration != nil {
+			h17 := false
+			if param.DealerHitsSoft17 != nil {
+				h17 = *param.DealerHitsSoft17
+			}
+			cpuCount := 0
+			if param.CpuPlayerCount != nil {
+				cpuCount = *param.CpuPlayerCount
+			}
+			counting := false
+			if param.CountingEnabled != nil {
+				counting = *param.CountingEnabled
+			}
+			das := true
+			if param.DoubleAfterSplit != nil {
+				das = *param.DoubleAfterSplit
+			}
+			cs := 0
+			if param.CountingSystem != nil {
+				cs = *param.CountingSystem
+			}
+			dp := 0
+			if param.DeckPenetration != nil {
+				dp = *param.DeckPenetration
+			}
+			bc.writePresenterResponse(w, bji.ResetWithConfig(h17, cpuCount, counting, das, cs, dp))
+		} else {
+			bc.writePresenterResponse(w, bji.Reset())
+		}
+	case "h", "hit":
+		bc.writePresenterResponse(w, bji.Hit())
+	case "s", "stand":
+		bc.writePresenterResponse(w, bji.Stand())
+	case "b", "bet":
+		ppBet := 0
+		if param.PerfectPairsBet != nil {
+			ppBet = *param.PerfectPairsBet
+		}
+		t3Bet := 0
+		if param.TwentyOnePlus3Bet != nil {
+			t3Bet = *param.TwentyOnePlus3Bet
+		}
+		bc.writePresenterResponse(w, bji.Bet(param.Amount, ppBet, t3Bet))
+	case "d", "doubledown":
+		bc.writePresenterResponse(w, bji.DoubleDown())
+	case "sp", "split":
+		bc.writePresenterResponse(w, bji.Split())
+	case "i", "insurance":
+		bc.writePresenterResponse(w, bji.Insurance())
+	case "di", "declineinsurance":
+		bc.writePresenterResponse(w, bji.DeclineInsurance())
+	case "sur", "surrender":
+		bc.writePresenterResponse(w, bji.Surrender())
+	case "togglehint":
+		bc.writePresenterResponse(w, bji.ToggleHint())
+	case "sd", "setdeckcount":
+		bc.writePresenterResponse(w, bji.SetDeckCount(param.Amount))
+	case "togglesoft17":
+		bc.writePresenterResponse(w, bji.ToggleSoft17())
+	case "togglecounting":
+		bc.writePresenterResponse(w, bji.ToggleCounting())
+	case "toggledas":
+		bc.writePresenterResponse(w, bji.ToggleDAS())
+	case "scs", "setcountingsystem":
+		bc.writePresenterResponse(w, bji.SetCountingSystem(param.Amount))
+	case "pen", "setpenetration":
+		bc.writePresenterResponse(w, bji.SetDeckPenetration(param.Amount))
+	case "scc", "setcpucount":
+		bc.writePresenterResponse(w, bji.SetCpuPlayerCount(param.Amount))
+	default:
+		return false
+	}
+	return true
 }

--- a/internal/adapter/controller/DaifugoWebController.go
+++ b/internal/adapter/controller/DaifugoWebController.go
@@ -89,53 +89,52 @@ type DaifugoWebOutput struct {
 }
 
 // DaifugoWebController 大富豪Webコントローラークラス
-type DaifugoWebController struct {
-	baseController
-	factory func() usecase.DaifugoInteractorIF
-	store   *SessionStore[usecase.DaifugoInteractorIF]
-}
+type DaifugoWebController = GameWebController[usecase.DaifugoInteractorIF, DaifugoWebInput, *DaifugoWebOutput]
 
 // NewDaifugoWebController コンストラクタ
 func NewDaifugoWebController(factory func() usecase.DaifugoInteractorIF) *DaifugoWebController {
-	return &DaifugoWebController{
-		factory: factory,
-		store:   NewSessionStore[usecase.DaifugoInteractorIF](),
+	return NewGameWebController(factory, newDaifugoDefaultOutput, nil, daifugoDispatch)
+}
+
+func newDaifugoDefaultOutput(msg string) *DaifugoWebOutput {
+	return &DaifugoWebOutput{
+		Players:             make([]*DaifugoWebOutputPlayer, 0),
+		TableCards:          make([]*WebOutputCard, 0),
+		CpuActions:          make([]*DaifugoWebOutputAction, 0),
+		ExchangeActions:     make([]*DaifugoWebOutputExchangeAction, 0),
+		Message:             msg,
+		PendingAction:       "none",
+		PendingActionTarget: -1,
 	}
 }
 
-// Exec ゲーム実行
-func (dwc *DaifugoWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
-	execWithSession(&dwc.baseController, w, r, dwc.store, dwc.factory,
-		func(msg string) any { return dwc.newDefaultOutput(msg) },
-		nil,
-		func(w rest.ResponseWriter, dgi usecase.DaifugoInteractorIF, param DaifugoWebInput) bool {
-			switch param.Command {
-			case "r", "reset":
-				if param.Config != nil {
-					dgConfig := convertWebConfig(*param.Config)
-					dwc.writePresenterResponse(w, dgi.ResetWithConfig(dgConfig))
-				} else {
-					dwc.writePresenterResponse(w, dgi.Reset())
-				}
-			case "p", "play":
-				indices := param.Indices
-				if indices == nil {
-					indices = []int{}
-				}
-				dwc.writePresenterResponse(w, dgi.Play(indices))
-			case "sort":
-				mode := domain.DaifugoSortByStrength
-				if param.SortMode != nil {
-					if m := *param.SortMode; m >= int(domain.DaifugoSortByStrength) && m <= int(domain.DaifugoSortByNumber) {
-						mode = domain.DaifugoSortMode(m)
-					}
-				}
-				dwc.writePresenterResponse(w, dgi.Sort(mode))
-			default:
-				return false
+func daifugoDispatch(bc *baseController, w rest.ResponseWriter, dgi usecase.DaifugoInteractorIF, param DaifugoWebInput, _ func(string) *DaifugoWebOutput) bool {
+	switch param.Command {
+	case "r", "reset":
+		if param.Config != nil {
+			dgConfig := convertWebConfig(*param.Config)
+			bc.writePresenterResponse(w, dgi.ResetWithConfig(dgConfig))
+		} else {
+			bc.writePresenterResponse(w, dgi.Reset())
+		}
+	case "p", "play":
+		indices := param.Indices
+		if indices == nil {
+			indices = []int{}
+		}
+		bc.writePresenterResponse(w, dgi.Play(indices))
+	case "sort":
+		mode := domain.DaifugoSortByStrength
+		if param.SortMode != nil {
+			if m := *param.SortMode; m >= int(domain.DaifugoSortByStrength) && m <= int(domain.DaifugoSortByNumber) {
+				mode = domain.DaifugoSortMode(m)
 			}
-			return true
-		})
+		}
+		bc.writePresenterResponse(w, dgi.Sort(mode))
+	default:
+		return false
+	}
+	return true
 }
 
 // convertWebConfig DaifugoWebConfig を domain.DaifugoConfig に変換
@@ -160,23 +159,5 @@ func convertWebConfig(c DaifugoWebConfig) domain.DaifugoConfig {
 		SequenceRevolutionEnabled: c.SequenceRevolutionEnabled,
 		IllegalFinishEnabled:      c.IllegalFinishEnabled,
 		CpuDifficulty:             domain.DaifugoCpuDifficulty(c.CpuDifficulty),
-	}
-}
-
-// Stop stops the background cleanup goroutine of the session store.
-func (dwc *DaifugoWebController) Stop() {
-	dwc.store.Stop()
-}
-
-// newDefaultOutput エラー・定型応答用のデフォルト出力を返す
-func (dwc *DaifugoWebController) newDefaultOutput(msg string) *DaifugoWebOutput {
-	return &DaifugoWebOutput{
-		Players:             make([]*DaifugoWebOutputPlayer, 0),
-		TableCards:          make([]*WebOutputCard, 0),
-		CpuActions:          make([]*DaifugoWebOutputAction, 0),
-		ExchangeActions:     make([]*DaifugoWebOutputExchangeAction, 0),
-		Message:             msg,
-		PendingAction:       "none",
-		PendingActionTarget: -1,
 	}
 }

--- a/internal/adapter/controller/DoubtWebController.go
+++ b/internal/adapter/controller/DoubtWebController.go
@@ -72,19 +72,7 @@ type DoubtWebOutput struct {
 }
 
 // DoubtWebController ダウトWebコントローラークラス
-type DoubtWebController struct {
-	baseController
-	factory func() usecase.DoubtInteractorIF
-	store   *SessionStore[usecase.DoubtInteractorIF]
-}
-
-// NewDoubtWebController コンストラクタ
-func NewDoubtWebController(factory func() usecase.DoubtInteractorIF) *DoubtWebController {
-	return &DoubtWebController{
-		factory: factory,
-		store:   NewSessionStore[usecase.DoubtInteractorIF](),
-	}
-}
+type DoubtWebController = GameWebController[usecase.DoubtInteractorIF, DoubtWebInput, *DoubtWebOutput]
 
 // MaxCardIndices カードインデックスの最大数 (52枚デッキ)
 const MaxCardIndices = 52
@@ -92,76 +80,12 @@ const MaxCardIndices = 52
 // errCardIndicesOverflow is returned by the Doubt validate callback when CardIndices exceeds the limit.
 var errCardIndicesOverflow = errors.New("card indices overflow")
 
-// Exec ゲーム実行
-func (dwc *DoubtWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
-	execWithSession(&dwc.baseController, w, r, dwc.store, dwc.factory,
-		func(msg string) any { return dwc.newDefaultOutput(msg) },
-		func(param DoubtWebInput) error {
-			if len(param.CardIndices) > MaxCardIndices {
-				return errCardIndicesOverflow
-			}
-			return nil
-		},
-		func(w rest.ResponseWriter, dgi usecase.DoubtInteractorIF, param DoubtWebInput) bool {
-			switch param.Command {
-			case "r", "reset":
-				cfg := domain.DefaultDoubtConfig()
-				if param.DoubtWindowSec != nil && *param.DoubtWindowSec >= 1 {
-					cfg.DoubtWindowSec = *param.DoubtWindowSec
-				}
-				if param.CpuMemoryLevel != nil {
-					level := *param.CpuMemoryLevel
-					if level >= int(domain.DoubtMemoryLevelEasy) && level <= int(domain.DoubtMemoryLevelHard) {
-						cfg.CpuMemoryLevel = domain.DoubtMemoryLevel(level)
-					}
-				}
-				if param.PenaltyDrawLimit != nil && *param.PenaltyDrawLimit >= 0 {
-					cfg.PenaltyDrawLimit = *param.PenaltyDrawLimit
-				}
-				dwc.writePresenterResponse(w, dgi.ResetWithConfig(cfg))
-			case "p", "play":
-				if param.ClaimedValue < domain.MinClaimedValue || param.ClaimedValue > domain.MaxClaimedValue {
-					dwc.writeJsonResponse(w, http.StatusBadRequest, dwc.newDefaultOutput(fmt.Sprintf("param error: claimedValue must be between %d and %d.", domain.MinClaimedValue, domain.MaxClaimedValue)))
-					return true
-				}
-				dwc.writePresenterResponse(w, dgi.Play(param.CardIndices, param.ClaimedValue))
-			case "d", "doubt":
-				cpuDoubters := dgi.GetCpuDoubters()
-				humanDoubts := false
-				for _, idx := range param.DoubterIndices {
-					if idx == 0 {
-						humanDoubts = true
-						break
-					}
-				}
-				var doubters []int
-				if humanDoubts {
-					doubters = append([]int{0}, cpuDoubters...)
-				} else {
-					doubters = cpuDoubters
-				}
-				dwc.writePresenterResponse(w, dgi.ResolveDoubt(doubters))
-			case "s", "skip":
-				cpuDoubters := dgi.GetCpuDoubters()
-				if len(cpuDoubters) > 0 {
-					dwc.writePresenterResponse(w, dgi.ResolveDoubt(cpuDoubters))
-				} else {
-					dwc.writePresenterResponse(w, dgi.SkipDoubt())
-				}
-			default:
-				return false
-			}
-			return true
-		})
+// NewDoubtWebController コンストラクタ
+func NewDoubtWebController(factory func() usecase.DoubtInteractorIF) *DoubtWebController {
+	return NewGameWebController(factory, newDoubtDefaultOutput, doubtValidate, doubtDispatch)
 }
 
-// Stop stops the background cleanup goroutine of the session store.
-func (dwc *DoubtWebController) Stop() {
-	dwc.store.Stop()
-}
-
-// newDefaultOutput エラー・定型応答用のデフォルト出力を返す
-func (dwc *DoubtWebController) newDefaultOutput(msg string) *DoubtWebOutput {
+func newDoubtDefaultOutput(msg string) *DoubtWebOutput {
 	return &DoubtWebOutput{
 		Players:     make([]*DoubtWebOutputPlayer, 0),
 		CpuDoubters: make([]int, 0),
@@ -169,4 +93,63 @@ func (dwc *DoubtWebController) newDefaultOutput(msg string) *DoubtWebOutput {
 		WinnerIdx:   -1,
 		Message:     msg,
 	}
+}
+
+func doubtValidate(param DoubtWebInput) error {
+	if len(param.CardIndices) > MaxCardIndices {
+		return errCardIndicesOverflow
+	}
+	return nil
+}
+
+func doubtDispatch(bc *baseController, w rest.ResponseWriter, dgi usecase.DoubtInteractorIF, param DoubtWebInput, newDefault func(string) *DoubtWebOutput) bool {
+	switch param.Command {
+	case "r", "reset":
+		cfg := domain.DefaultDoubtConfig()
+		if param.DoubtWindowSec != nil && *param.DoubtWindowSec >= 1 {
+			cfg.DoubtWindowSec = *param.DoubtWindowSec
+		}
+		if param.CpuMemoryLevel != nil {
+			level := *param.CpuMemoryLevel
+			if level >= int(domain.DoubtMemoryLevelEasy) && level <= int(domain.DoubtMemoryLevelHard) {
+				cfg.CpuMemoryLevel = domain.DoubtMemoryLevel(level)
+			}
+		}
+		if param.PenaltyDrawLimit != nil && *param.PenaltyDrawLimit >= 0 {
+			cfg.PenaltyDrawLimit = *param.PenaltyDrawLimit
+		}
+		bc.writePresenterResponse(w, dgi.ResetWithConfig(cfg))
+	case "p", "play":
+		if param.ClaimedValue < domain.MinClaimedValue || param.ClaimedValue > domain.MaxClaimedValue {
+			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault(fmt.Sprintf("param error: claimedValue must be between %d and %d.", domain.MinClaimedValue, domain.MaxClaimedValue)))
+			return true
+		}
+		bc.writePresenterResponse(w, dgi.Play(param.CardIndices, param.ClaimedValue))
+	case "d", "doubt":
+		cpuDoubters := dgi.GetCpuDoubters()
+		humanDoubts := false
+		for _, idx := range param.DoubterIndices {
+			if idx == 0 {
+				humanDoubts = true
+				break
+			}
+		}
+		var doubters []int
+		if humanDoubts {
+			doubters = append([]int{0}, cpuDoubters...)
+		} else {
+			doubters = cpuDoubters
+		}
+		bc.writePresenterResponse(w, dgi.ResolveDoubt(doubters))
+	case "s", "skip":
+		cpuDoubters := dgi.GetCpuDoubters()
+		if len(cpuDoubters) > 0 {
+			bc.writePresenterResponse(w, dgi.ResolveDoubt(cpuDoubters))
+		} else {
+			bc.writePresenterResponse(w, dgi.SkipDoubt())
+		}
+	default:
+		return false
+	}
+	return true
 }

--- a/internal/adapter/controller/HoldemWebController.go
+++ b/internal/adapter/controller/HoldemWebController.go
@@ -93,99 +93,14 @@ type HoldemWebOutput struct {
 }
 
 // HoldemWebController テキサスホールデムWebコントローラークラス
-type HoldemWebController struct {
-	baseController
-	factory func() usecase.HoldemInteractorIF
-	store   *SessionStore[usecase.HoldemInteractorIF]
-}
+type HoldemWebController = GameWebController[usecase.HoldemInteractorIF, HoldemWebInput, *HoldemWebOutput]
 
 // NewHoldemWebController コンストラクタ
 func NewHoldemWebController(factory func() usecase.HoldemInteractorIF) *HoldemWebController {
-	return &HoldemWebController{
-		factory: factory,
-		store:   NewSessionStore[usecase.HoldemInteractorIF](),
-	}
+	return NewGameWebController(factory, newHoldemDefaultOutput, nil, holdemDispatch)
 }
 
-// Exec ゲーム実行
-func (hwc *HoldemWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
-	execWithSession(&hwc.baseController, w, r, hwc.store, hwc.factory,
-		func(msg string) any { return hwc.newDefaultOutput(msg) },
-		nil,
-		func(w rest.ResponseWriter, hgi usecase.HoldemInteractorIF, param HoldemWebInput) bool {
-			switch param.Command {
-			case "r", "reset":
-				cfg := domain.DefaultHoldemConfig()
-				sb, bb := cfg.SmallBlind, cfg.BigBlind
-				sbProvided := param.SmallBlind != nil && *param.SmallBlind >= 1
-				bbProvided := param.BigBlind != nil && *param.BigBlind >= 1
-				if sbProvided {
-					sb = *param.SmallBlind
-				}
-				if bbProvided {
-					bb = *param.BigBlind
-				}
-				// 片方のみ指定された場合、もう片方を自動調整
-				if sbProvided && !bbProvided && sb >= cfg.BigBlind {
-					bb = sb * 2
-				} else if bbProvided && !sbProvided && bb > 1 {
-					sb = bb / 2
-					if sb < 1 {
-						sb = 1
-					}
-				}
-				if sb >= bb {
-					hwc.writeJsonResponse(w, http.StatusBadRequest, hwc.newDefaultOutput("param error: smallBlind must be less than bigBlind."))
-					return true
-				}
-				cfg.SmallBlind = sb
-				cfg.BigBlind = bb
-				// トーナメントモード設定
-				if param.TournamentMode != nil {
-					cfg.TournamentMode = *param.TournamentMode
-				}
-				if param.BlindLevelHands != nil && *param.BlindLevelHands >= 1 {
-					cfg.BlindLevelHands = *param.BlindLevelHands
-				}
-				if param.BlindMultiplier != nil && *param.BlindMultiplier >= 101 {
-					cfg.BlindMultiplier = *param.BlindMultiplier
-				}
-				if param.BettingLimit != nil {
-					bl := *param.BettingLimit
-					if bl < 0 {
-						bl = 0
-					} else if bl > 2 {
-						bl = 2
-					}
-					cfg.BettingLimit = domain.BettingLimitType(bl)
-				}
-				hwc.writePresenterResponse(w, hgi.ResetWithConfig(cfg))
-			case "f", "fold":
-				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionFold, 0))
-			case "ck", "check":
-				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionCheck, 0))
-			case "c", "call":
-				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionCall, 0))
-			case "b", "bet":
-				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionBet, param.Amount))
-			case "ra", "raise":
-				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionRaise, param.Amount))
-			case "a", "allin":
-				hwc.writePresenterResponse(w, hgi.Action(domain.HoldemActionAllIn, 0))
-			default:
-				return false
-			}
-			return true
-		})
-}
-
-// Stop stops the background cleanup goroutine of the session store.
-func (hwc *HoldemWebController) Stop() {
-	hwc.store.Stop()
-}
-
-// newDefaultOutput エラー・定型応答用のデフォルト出力を返す
-func (hwc *HoldemWebController) newDefaultOutput(msg string) *HoldemWebOutput {
+func newHoldemDefaultOutput(msg string) *HoldemWebOutput {
 	return &HoldemWebOutput{
 		Players:        make([]*HoldemWebOutputPlayer, 0),
 		CommunityCards: make([]*WebOutputCard, 0),
@@ -194,4 +109,70 @@ func (hwc *HoldemWebController) newDefaultOutput(msg string) *HoldemWebOutput {
 		CpuActions:     make([]*HoldemWebOutputCpuAction, 0),
 		Message:        msg,
 	}
+}
+
+func holdemDispatch(bc *baseController, w rest.ResponseWriter, hgi usecase.HoldemInteractorIF, param HoldemWebInput, newDefault func(string) *HoldemWebOutput) bool {
+	switch param.Command {
+	case "r", "reset":
+		cfg := domain.DefaultHoldemConfig()
+		sb, bb := cfg.SmallBlind, cfg.BigBlind
+		sbProvided := param.SmallBlind != nil && *param.SmallBlind >= 1
+		bbProvided := param.BigBlind != nil && *param.BigBlind >= 1
+		if sbProvided {
+			sb = *param.SmallBlind
+		}
+		if bbProvided {
+			bb = *param.BigBlind
+		}
+		// 片方のみ指定された場合、もう片方を自動調整
+		if sbProvided && !bbProvided && sb >= cfg.BigBlind {
+			bb = sb * 2
+		} else if bbProvided && !sbProvided && bb > 1 {
+			sb = bb / 2
+			if sb < 1 {
+				sb = 1
+			}
+		}
+		if sb >= bb {
+			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: smallBlind must be less than bigBlind."))
+			return true
+		}
+		cfg.SmallBlind = sb
+		cfg.BigBlind = bb
+		// トーナメントモード設定
+		if param.TournamentMode != nil {
+			cfg.TournamentMode = *param.TournamentMode
+		}
+		if param.BlindLevelHands != nil && *param.BlindLevelHands >= 1 {
+			cfg.BlindLevelHands = *param.BlindLevelHands
+		}
+		if param.BlindMultiplier != nil && *param.BlindMultiplier >= 101 {
+			cfg.BlindMultiplier = *param.BlindMultiplier
+		}
+		if param.BettingLimit != nil {
+			bl := *param.BettingLimit
+			if bl < 0 {
+				bl = 0
+			} else if bl > 2 {
+				bl = 2
+			}
+			cfg.BettingLimit = domain.BettingLimitType(bl)
+		}
+		bc.writePresenterResponse(w, hgi.ResetWithConfig(cfg))
+	case "f", "fold":
+		bc.writePresenterResponse(w, hgi.Action(domain.HoldemActionFold, 0))
+	case "ck", "check":
+		bc.writePresenterResponse(w, hgi.Action(domain.HoldemActionCheck, 0))
+	case "c", "call":
+		bc.writePresenterResponse(w, hgi.Action(domain.HoldemActionCall, 0))
+	case "b", "bet":
+		bc.writePresenterResponse(w, hgi.Action(domain.HoldemActionBet, param.Amount))
+	case "ra", "raise":
+		bc.writePresenterResponse(w, hgi.Action(domain.HoldemActionRaise, param.Amount))
+	case "a", "allin":
+		bc.writePresenterResponse(w, hgi.Action(domain.HoldemActionAllIn, 0))
+	default:
+		return false
+	}
+	return true
 }

--- a/internal/adapter/controller/OldMaidWebController.go
+++ b/internal/adapter/controller/OldMaidWebController.go
@@ -71,66 +71,14 @@ type OldMaidWebOutput struct {
 }
 
 // OldMaidWebController ババ抜きWebコントローラークラス
-type OldMaidWebController struct {
-	baseController
-	factory func() usecase.OldMaidInteractorIF
-	store   *SessionStore[usecase.OldMaidInteractorIF]
-}
+type OldMaidWebController = GameWebController[usecase.OldMaidInteractorIF, OldMaidWebInput, *OldMaidWebOutput]
 
 // NewOldMaidWebController コンストラクタ
 func NewOldMaidWebController(factory func() usecase.OldMaidInteractorIF) *OldMaidWebController {
-	return &OldMaidWebController{
-		factory: factory,
-		store:   NewSessionStore[usecase.OldMaidInteractorIF](),
-	}
+	return NewGameWebController(factory, newOldMaidDefaultOutput, nil, oldMaidDispatch)
 }
 
-// Exec ゲーム実行
-func (owc *OldMaidWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
-	execWithSession(&owc.baseController, w, r, owc.store, owc.factory,
-		func(msg string) any { return owc.newDefaultOutput(msg) },
-		nil,
-		func(w rest.ResponseWriter, omi usecase.OldMaidInteractorIF, param OldMaidWebInput) bool {
-			switch param.Command {
-			case "r", "reset":
-				if param.Mode < 0 || param.Mode > int(domain.OldMaidModeJijiNuki) {
-					owc.writeJsonResponse(w, http.StatusBadRequest, owc.newDefaultOutput("param error: mode must be between 0 and 1."))
-					return true
-				}
-				cfg := domain.OldMaidConfig{
-					Mode:                 domain.OldMaidMode(param.Mode),
-					CpuPlacementStrategy: param.CpuPlacementStrategy,
-					CpuMemoryAI:          param.CpuMemoryAI,
-				}
-				owc.writePresenterResponse(w, omi.Reset(cfg))
-			case "d", "draw":
-				drawIdx := -1
-				if param.DrawIdx != nil {
-					drawIdx = *param.DrawIdx
-				}
-				owc.writePresenterResponse(w, omi.Draw(drawIdx))
-			case "s", "shuffle":
-				owc.writePresenterResponse(w, omi.Shuffle())
-			case "reorder":
-				if param.ReorderIndices == nil {
-					owc.writeJsonResponse(w, http.StatusBadRequest, owc.newDefaultOutput("param error: reorderIndices is required."))
-					return true
-				}
-				owc.writePresenterResponse(w, omi.Reorder(param.ReorderIndices))
-			default:
-				return false
-			}
-			return true
-		})
-}
-
-// Stop stops the background cleanup goroutine of the session store.
-func (owc *OldMaidWebController) Stop() {
-	owc.store.Stop()
-}
-
-// newDefaultOutput エラー・定型応答用のデフォルト出力を返す
-func (owc *OldMaidWebController) newDefaultOutput(msg string) *OldMaidWebOutput {
+func newOldMaidDefaultOutput(msg string) *OldMaidWebOutput {
 	return &OldMaidWebOutput{
 		Players:               make([]*OldMaidWebOutputPlayer, 0),
 		CpuActions:            make([]*OldMaidWebOutputCpuAction, 0),
@@ -138,4 +86,37 @@ func (owc *OldMaidWebController) newDefaultOutput(msg string) *OldMaidWebOutput 
 		CpuHighlightedCardIdx: -1,
 		Message:               msg,
 	}
+}
+
+func oldMaidDispatch(bc *baseController, w rest.ResponseWriter, omi usecase.OldMaidInteractorIF, param OldMaidWebInput, newDefault func(string) *OldMaidWebOutput) bool {
+	switch param.Command {
+	case "r", "reset":
+		if param.Mode < 0 || param.Mode > int(domain.OldMaidModeJijiNuki) {
+			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: mode must be between 0 and 1."))
+			return true
+		}
+		cfg := domain.OldMaidConfig{
+			Mode:                 domain.OldMaidMode(param.Mode),
+			CpuPlacementStrategy: param.CpuPlacementStrategy,
+			CpuMemoryAI:          param.CpuMemoryAI,
+		}
+		bc.writePresenterResponse(w, omi.Reset(cfg))
+	case "d", "draw":
+		drawIdx := -1
+		if param.DrawIdx != nil {
+			drawIdx = *param.DrawIdx
+		}
+		bc.writePresenterResponse(w, omi.Draw(drawIdx))
+	case "s", "shuffle":
+		bc.writePresenterResponse(w, omi.Shuffle())
+	case "reorder":
+		if param.ReorderIndices == nil {
+			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: reorderIndices is required."))
+			return true
+		}
+		bc.writePresenterResponse(w, omi.Reorder(param.ReorderIndices))
+	default:
+		return false
+	}
+	return true
 }

--- a/internal/adapter/controller/PokerWebController.go
+++ b/internal/adapter/controller/PokerWebController.go
@@ -95,97 +95,14 @@ type PokerWebOutput struct {
 }
 
 // PokerWebController ポーカーWebコントローラークラス
-type PokerWebController struct {
-	baseController
-	factory func() usecase.PokerInteractorIF
-	store   *SessionStore[usecase.PokerInteractorIF]
-}
+type PokerWebController = GameWebController[usecase.PokerInteractorIF, PokerWebInput, *PokerWebOutput]
 
 // NewPokerWebController コンストラクタ
 func NewPokerWebController(factory func() usecase.PokerInteractorIF) *PokerWebController {
-	return &PokerWebController{
-		factory: factory,
-		store:   NewSessionStore[usecase.PokerInteractorIF](),
-	}
+	return NewGameWebController(factory, newPokerDefaultOutput, nil, pokerDispatch)
 }
 
-// Exec ゲーム実行
-func (pwc *PokerWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
-	execWithSession(&pwc.baseController, w, r, pwc.store, pwc.factory,
-		func(msg string) any { return pwc.newDefaultOutput(msg) },
-		nil,
-		func(w rest.ResponseWriter, pi usecase.PokerInteractorIF, param PokerWebInput) bool {
-			switch param.Command {
-			case "r", "reset":
-				cfg := domain.DefaultPokerConfig()
-				if param.CpuCount != nil {
-					cc := *param.CpuCount
-					if cc < 1 {
-						cc = 1
-					} else if cc > 3 {
-						cc = 3
-					}
-					cfg.CpuCount = cc
-				}
-				if param.JokerCount != nil {
-					jc := *param.JokerCount
-					if jc < 0 {
-						jc = 0
-					} else if jc > 2 {
-						jc = 2
-					}
-					cfg.JokerCount = jc
-				}
-				if param.BettingLimit != nil {
-					bl := *param.BettingLimit
-					if bl < 0 {
-						bl = 0
-					} else if bl > 2 {
-						bl = 2
-					}
-					cfg.BettingLimit = domain.BettingLimitType(bl)
-				}
-				pwc.writePresenterResponse(w, pi.ResetWithConfig(cfg))
-			case "e", "exchange":
-				indices := param.Indices
-				if indices == nil {
-					indices = []int{}
-				}
-				pwc.writePresenterResponse(w, pi.Exchange(indices))
-			case "s", "stand":
-				pwc.writePresenterResponse(w, pi.Stand())
-			case "f", "fold":
-				pwc.writePresenterResponse(w, pi.Action(domain.PokerActionFold, 0))
-			case "ck", "check":
-				pwc.writePresenterResponse(w, pi.Action(domain.PokerActionCheck, 0))
-			case "c", "call":
-				pwc.writePresenterResponse(w, pi.Action(domain.PokerActionCall, 0))
-			case "b", "bet":
-				pwc.writePresenterResponse(w, pi.Action(domain.PokerActionBet, param.Amount))
-			case "ra", "raise":
-				pwc.writePresenterResponse(w, pi.Action(domain.PokerActionRaise, param.Amount))
-			case "a", "allin":
-				pwc.writePresenterResponse(w, pi.Action(domain.PokerActionAllIn, 0))
-			case "o", "odds":
-				indices := param.Indices
-				if indices == nil {
-					indices = []int{}
-				}
-				pwc.writePresenterResponse(w, pi.Odds(indices))
-			default:
-				return false
-			}
-			return true
-		})
-}
-
-// Stop stops the background cleanup goroutine of the session store.
-func (pwc *PokerWebController) Stop() {
-	pwc.store.Stop()
-}
-
-// newDefaultOutput エラー・定型応答用のデフォルト出力を返す
-func (pwc *PokerWebController) newDefaultOutput(msg string) *PokerWebOutput {
+func newPokerDefaultOutput(msg string) *PokerWebOutput {
 	return &PokerWebOutput{
 		Players:      make([]*PokerWebOutputPlayer, 0),
 		SidePots:     make([]*PokerWebOutputSidePot, 0),
@@ -194,4 +111,68 @@ func (pwc *PokerWebController) newDefaultOutput(msg string) *PokerWebOutput {
 		CpuExchanges: make([]*PokerWebOutputCpuExchange, 0),
 		Message:      msg,
 	}
+}
+
+func pokerDispatch(bc *baseController, w rest.ResponseWriter, pi usecase.PokerInteractorIF, param PokerWebInput, _ func(string) *PokerWebOutput) bool {
+	switch param.Command {
+	case "r", "reset":
+		cfg := domain.DefaultPokerConfig()
+		if param.CpuCount != nil {
+			cc := *param.CpuCount
+			if cc < 1 {
+				cc = 1
+			} else if cc > 3 {
+				cc = 3
+			}
+			cfg.CpuCount = cc
+		}
+		if param.JokerCount != nil {
+			jc := *param.JokerCount
+			if jc < 0 {
+				jc = 0
+			} else if jc > 2 {
+				jc = 2
+			}
+			cfg.JokerCount = jc
+		}
+		if param.BettingLimit != nil {
+			bl := *param.BettingLimit
+			if bl < 0 {
+				bl = 0
+			} else if bl > 2 {
+				bl = 2
+			}
+			cfg.BettingLimit = domain.BettingLimitType(bl)
+		}
+		bc.writePresenterResponse(w, pi.ResetWithConfig(cfg))
+	case "e", "exchange":
+		indices := param.Indices
+		if indices == nil {
+			indices = []int{}
+		}
+		bc.writePresenterResponse(w, pi.Exchange(indices))
+	case "s", "stand":
+		bc.writePresenterResponse(w, pi.Stand())
+	case "f", "fold":
+		bc.writePresenterResponse(w, pi.Action(domain.PokerActionFold, 0))
+	case "ck", "check":
+		bc.writePresenterResponse(w, pi.Action(domain.PokerActionCheck, 0))
+	case "c", "call":
+		bc.writePresenterResponse(w, pi.Action(domain.PokerActionCall, 0))
+	case "b", "bet":
+		bc.writePresenterResponse(w, pi.Action(domain.PokerActionBet, param.Amount))
+	case "ra", "raise":
+		bc.writePresenterResponse(w, pi.Action(domain.PokerActionRaise, param.Amount))
+	case "a", "allin":
+		bc.writePresenterResponse(w, pi.Action(domain.PokerActionAllIn, 0))
+	case "o", "odds":
+		indices := param.Indices
+		if indices == nil {
+			indices = []int{}
+		}
+		bc.writePresenterResponse(w, pi.Odds(indices))
+	default:
+		return false
+	}
+	return true
 }

--- a/internal/adapter/controller/SevensWebController.go
+++ b/internal/adapter/controller/SevensWebController.go
@@ -74,52 +74,47 @@ type SevensWebOutput struct {
 }
 
 // SevensWebController 7並べWebコントローラークラス
-type SevensWebController struct {
-	baseController
-	factory func() usecase.SevensInteractorIF
-	store   *SessionStore[usecase.SevensInteractorIF]
-}
+type SevensWebController = GameWebController[usecase.SevensInteractorIF, SevensWebInput, *SevensWebOutput]
 
 // NewSevensWebController コンストラクタ
 func NewSevensWebController(factory func() usecase.SevensInteractorIF) *SevensWebController {
-	return &SevensWebController{
-		factory: factory,
-		store:   NewSessionStore[usecase.SevensInteractorIF](),
+	return NewGameWebController(factory, newSevensDefaultOutput, nil, sevensDispatch)
+}
+
+func newSevensDefaultOutput(msg string) *SevensWebOutput {
+	return &SevensWebOutput{
+		Players:    make([]*SevensWebOutputPlayer, 0),
+		CpuActions: make([]*SevensWebOutputAction, 0),
+		Message:    msg,
 	}
 }
 
-// Exec ゲーム実行
-func (swc *SevensWebController) Exec(w rest.ResponseWriter, r *rest.Request) {
-	execWithSession(&swc.baseController, w, r, swc.store, swc.factory,
-		func(msg string) any { return swc.newDefaultOutput(msg) },
-		nil,
-		func(w rest.ResponseWriter, sgi usecase.SevensInteractorIF, param SevensWebInput) bool {
-			switch param.Command {
-			case "r", "reset":
-				if param.TunnelEnabled != nil || param.JokerCount != nil || param.CpuStrategy != nil || param.MaxPasses != nil || param.NoJokerFinish != nil || param.JokerReclaim != nil || param.EndStop != nil || param.JokerConsecutiveBanned != nil {
-					cfg := domain.SevensConfig{
-						TunnelEnabled:          derefBool(param.TunnelEnabled),
-						JokerCount:             derefInt(param.JokerCount),
-						CpuStrategy:            derefBool(param.CpuStrategy),
-						MaxPasses:              derefIntDefault(param.MaxPasses, domain.SevensMaxPasses),
-						NoJokerFinish:          derefBool(param.NoJokerFinish),
-						JokerReclaimEnabled:    derefBool(param.JokerReclaim),
-						EndStopEnabled:         derefBool(param.EndStop),
-						JokerConsecutiveBanned: derefBool(param.JokerConsecutiveBanned),
-					}
-					swc.writePresenterResponse(w, sgi.ResetWithConfig(cfg))
-				} else {
-					swc.writePresenterResponse(w, sgi.Reset())
-				}
-			case "p", "play":
-				swc.writePresenterResponse(w, sgi.Play(param.Index))
-			case "j", "joker":
-				swc.writePresenterResponse(w, sgi.PlayJoker(param.Index, param.JokerTargetSuit, param.JokerTargetValue))
-			default:
-				return false
+func sevensDispatch(bc *baseController, w rest.ResponseWriter, sgi usecase.SevensInteractorIF, param SevensWebInput, _ func(string) *SevensWebOutput) bool {
+	switch param.Command {
+	case "r", "reset":
+		if param.TunnelEnabled != nil || param.JokerCount != nil || param.CpuStrategy != nil || param.MaxPasses != nil || param.NoJokerFinish != nil || param.JokerReclaim != nil || param.EndStop != nil || param.JokerConsecutiveBanned != nil {
+			cfg := domain.SevensConfig{
+				TunnelEnabled:          derefBool(param.TunnelEnabled),
+				JokerCount:             derefInt(param.JokerCount),
+				CpuStrategy:            derefBool(param.CpuStrategy),
+				MaxPasses:              derefIntDefault(param.MaxPasses, domain.SevensMaxPasses),
+				NoJokerFinish:          derefBool(param.NoJokerFinish),
+				JokerReclaimEnabled:    derefBool(param.JokerReclaim),
+				EndStopEnabled:         derefBool(param.EndStop),
+				JokerConsecutiveBanned: derefBool(param.JokerConsecutiveBanned),
 			}
-			return true
-		})
+			bc.writePresenterResponse(w, sgi.ResetWithConfig(cfg))
+		} else {
+			bc.writePresenterResponse(w, sgi.Reset())
+		}
+	case "p", "play":
+		bc.writePresenterResponse(w, sgi.Play(param.Index))
+	case "j", "joker":
+		bc.writePresenterResponse(w, sgi.PlayJoker(param.Index, param.JokerTargetSuit, param.JokerTargetValue))
+	default:
+		return false
+	}
+	return true
 }
 
 func derefBool(p *bool) bool {
@@ -141,18 +136,4 @@ func derefIntDefault(p *int, defaultVal int) int {
 		return defaultVal
 	}
 	return *p
-}
-
-// Stop stops the background cleanup goroutine of the session store.
-func (swc *SevensWebController) Stop() {
-	swc.store.Stop()
-}
-
-// newDefaultOutput エラー・定型応答用のデフォルト出力を返す
-func (swc *SevensWebController) newDefaultOutput(msg string) *SevensWebOutput {
-	return &SevensWebOutput{
-		Players:    make([]*SevensWebOutputPlayer, 0),
-		CpuActions: make([]*SevensWebOutputAction, 0),
-		Message:    msg,
-	}
 }

--- a/internal/adapter/controller/game_web_controller.go
+++ b/internal/adapter/controller/game_web_controller.go
@@ -1,0 +1,48 @@
+package controller
+
+import (
+	"github.com/ant0ine/go-json-rest/rest"
+)
+
+// GameWebController is a generic web controller that eliminates boilerplate
+// shared across all game-specific web controllers. Each game provides its own
+// factory, default-output builder, optional validator, and command dispatcher.
+type GameWebController[I any, P WebInput, O any] struct {
+	baseController
+	factory    func() I
+	store      *SessionStore[I]
+	newDefault func(string) O
+	validate   func(P) error
+	dispatch   func(bc *baseController, w rest.ResponseWriter, interactor I, param P, newDefault func(string) O) bool
+}
+
+// NewGameWebController creates a GameWebController. validate may be nil.
+func NewGameWebController[I any, P WebInput, O any](
+	factory func() I,
+	newDefault func(string) O,
+	validate func(P) error,
+	dispatch func(bc *baseController, w rest.ResponseWriter, interactor I, param P, newDefault func(string) O) bool,
+) *GameWebController[I, P, O] {
+	return &GameWebController[I, P, O]{
+		factory:    factory,
+		store:      NewSessionStore[I](),
+		newDefault: newDefault,
+		validate:   validate,
+		dispatch:   dispatch,
+	}
+}
+
+// Exec handles an incoming game request.
+func (gwc *GameWebController[I, P, O]) Exec(w rest.ResponseWriter, r *rest.Request) {
+	execWithSession(&gwc.baseController, w, r, gwc.store, gwc.factory,
+		func(msg string) any { return gwc.newDefault(msg) },
+		gwc.validate,
+		func(w rest.ResponseWriter, interactor I, param P) bool {
+			return gwc.dispatch(&gwc.baseController, w, interactor, param, gwc.newDefault)
+		})
+}
+
+// Stop stops the background cleanup goroutine of the session store.
+func (gwc *GameWebController[I, P, O]) Stop() {
+	gwc.store.Stop()
+}


### PR DESCRIPTION
## Summary

- Add `GameWebController[I, P, O]` generic struct that extracts shared boilerplate (struct fields, constructor, `Exec`, `Stop`) from all 7 game web controllers
- Refactor all controllers (`BlackJack`, `Poker`, `OldMaid`, `Daifugo`, `Sevens`, `Doubt`, `Holdem`) to use type aliases over the generic base, keeping only game-specific input/output types and command dispatch functions
- Net reduction of ~83 lines with zero changes to tests or infrastructure layer

Closes #399

## Test plan

- [x] All existing controller tests pass unchanged
- [x] `game_web_controller.go` has 100% statement coverage via existing tests
- [x] Full `go test -tags test ./...` passes
- [x] `go vet -tags test ./internal/adapter/controller/` passes
- [x] Infrastructure layer (`TrumpCardsWeb.go`) requires no changes thanks to type aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)