### PR TITLE
refactor(ui): extract common CUI game loop into RunCuiLoop

### DIFF
--- a/internal/infrastructure/ui/BlackJackCui.go
+++ b/internal/infrastructure/ui/BlackJackCui.go
@@ -1,10 +1,6 @@
 package ui
 
 import (
-	"bufio"
-	"fmt"
-	"os"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -28,27 +24,16 @@ func NewBlackJackCui() *BlackJackCui {
 
 // Exec ゲーム実行
 func (cui *BlackJackCui) Exec() {
-	fmt.Println(cui.bjc.Exec("r"))
-	scanner := bufio.NewScanner(os.Stdin)
-	for {
-		fmt.Println("Please enter a command.")
-		fmt.Println("q・・・quit")
-		fmt.Println("r・・・reset")
-		fmt.Println("b N・・・bet (e.g. b 100)")
-		fmt.Println("h・・・hit")
-		fmt.Println("s・・・stand")
-		fmt.Println("d・・・doubledown")
-		fmt.Println("sp・・・split")
-		fmt.Println("i・・・insurance")
-		fmt.Println("di・・・decline insurance")
-		input, exit := readInput(scanner)
-		if exit {
-			break
-		}
-		res := cui.bjc.Exec(input)
-		fmt.Println(res)
-		if res == "bye." {
-			break
-		}
-	}
+	RunCuiLoop(cui.bjc, []string{
+		"Please enter a command.",
+		"q・・・quit",
+		"r・・・reset",
+		"b N・・・bet (e.g. b 100)",
+		"h・・・hit",
+		"s・・・stand",
+		"d・・・doubledown",
+		"sp・・・split",
+		"i・・・insurance",
+		"di・・・decline insurance",
+	})
 }

--- a/internal/infrastructure/ui/DaifugoCui.go
+++ b/internal/infrastructure/ui/DaifugoCui.go
@@ -1,10 +1,6 @@
 package ui
 
 import (
-	"bufio"
-	"fmt"
-	"os"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -35,21 +31,10 @@ func NewDaifugoCui() *DaifugoCui {
 
 // Exec ゲーム実行
 func (cui *DaifugoCui) Exec() {
-	fmt.Println(cui.dgc.Exec("r"))
-	scanner := bufio.NewScanner(os.Stdin)
-	for {
-		fmt.Println("コマンドを入力してください。")
-		fmt.Println("q・・・quit")
-		fmt.Println("r・・・reset")
-		fmt.Println("p [インデックス...]・・・カードを出す (インデックスなしでパス)")
-		input, exit := readInput(scanner)
-		if exit {
-			break
-		}
-		res := cui.dgc.Exec(input)
-		fmt.Println(res)
-		if res == "bye." {
-			break
-		}
-	}
+	RunCuiLoop(cui.dgc, []string{
+		"コマンドを入力してください。",
+		"q・・・quit",
+		"r・・・reset",
+		"p [インデックス...]・・・カードを出す (インデックスなしでパス)",
+	})
 }

--- a/internal/infrastructure/ui/OldMaidCui.go
+++ b/internal/infrastructure/ui/OldMaidCui.go
@@ -1,10 +1,6 @@
 package ui
 
 import (
-	"bufio"
-	"fmt"
-	"os"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -34,21 +30,10 @@ func NewOldMaidCui() *OldMaidCui {
 
 // Exec ゲーム実行
 func (cui *OldMaidCui) Exec() {
-	fmt.Println(cui.omc.Exec("r"))
-	scanner := bufio.NewScanner(os.Stdin)
-	for {
-		fmt.Println("コマンドを入力してください。")
-		fmt.Println("q・・・quit")
-		fmt.Println("r・・・reset")
-		fmt.Println("d・・・draw (カードを引く)")
-		input, exit := readInput(scanner)
-		if exit {
-			break
-		}
-		res := cui.omc.Exec(input)
-		fmt.Println(res)
-		if res == "bye." {
-			break
-		}
-	}
+	RunCuiLoop(cui.omc, []string{
+		"コマンドを入力してください。",
+		"q・・・quit",
+		"r・・・reset",
+		"d・・・draw (カードを引く)",
+	})
 }

--- a/internal/infrastructure/ui/PokerCui.go
+++ b/internal/infrastructure/ui/PokerCui.go
@@ -1,10 +1,6 @@
 package ui
 
 import (
-	"bufio"
-	"fmt"
-	"os"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -33,29 +29,18 @@ func NewPokerCui() *PokerCui {
 
 // Exec ゲーム実行
 func (cui *PokerCui) Exec() {
-	fmt.Println(cui.pc.Exec("r"))
-	scanner := bufio.NewScanner(os.Stdin)
-	for {
-		fmt.Println("Please enter a command.")
-		fmt.Println("q・・・quit")
-		fmt.Println("r・・・reset")
-		fmt.Println("b [amount]・・・bet (e.g. 'b 20')")
-		fmt.Println("c・・・call")
-		fmt.Println("ra [amount]・・・raise (e.g. 'ra 30')")
-		fmt.Println("ck・・・check")
-		fmt.Println("f・・・fold")
-		fmt.Println("a・・・all-in")
-		fmt.Println("e [0-4]・・・exchange (e.g. 'e 0 2 4' to exchange cards at index 0, 2, 4)")
-		fmt.Println("s・・・stand (no exchange)")
-		fmt.Println("bl [0-2]・・・betting limit (0=Fixed, 1=PotLimit, 2=NoLimit)")
-		input, exit := readInput(scanner)
-		if exit {
-			break
-		}
-		res := cui.pc.Exec(input)
-		fmt.Println(res)
-		if res == "bye." {
-			break
-		}
-	}
+	RunCuiLoop(cui.pc, []string{
+		"Please enter a command.",
+		"q・・・quit",
+		"r・・・reset",
+		"b [amount]・・・bet (e.g. 'b 20')",
+		"c・・・call",
+		"ra [amount]・・・raise (e.g. 'ra 30')",
+		"ck・・・check",
+		"f・・・fold",
+		"a・・・all-in",
+		"e [0-4]・・・exchange (e.g. 'e 0 2 4' to exchange cards at index 0, 2, 4)",
+		"s・・・stand (no exchange)",
+		"bl [0-2]・・・betting limit (0=Fixed, 1=PotLimit, 2=NoLimit)",
+	})
 }

--- a/internal/infrastructure/ui/SevensCui.go
+++ b/internal/infrastructure/ui/SevensCui.go
@@ -1,10 +1,6 @@
 package ui
 
 import (
-	"bufio"
-	"fmt"
-	"os"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -35,21 +31,10 @@ func NewSevensCui() *SevensCui {
 
 // Exec ゲーム実行
 func (cui *SevensCui) Exec() {
-	fmt.Println(cui.sgc.Exec("r"))
-	scanner := bufio.NewScanner(os.Stdin)
-	for {
-		fmt.Println("コマンドを入力してください。")
-		fmt.Println("q・・・quit")
-		fmt.Println("r [tunnel] [joker=N] [strategy] [passes=N]・・・reset (オプションルール設定)")
-		fmt.Println("p [インデックス]・・・カードを出す (インデックスなしでパス)")
-		input, exit := readInput(scanner)
-		if exit {
-			break
-		}
-		res := cui.sgc.Exec(input)
-		fmt.Println(res)
-		if res == "bye." {
-			break
-		}
-	}
+	RunCuiLoop(cui.sgc, []string{
+		"コマンドを入力してください。",
+		"q・・・quit",
+		"r [tunnel] [joker=N] [strategy] [passes=N]・・・reset (オプションルール設定)",
+		"p [インデックス]・・・カードを出す (インデックスなしでパス)",
+	})
 }

--- a/internal/infrastructure/ui/cui_runner.go
+++ b/internal/infrastructure/ui/cui_runner.go
@@ -1,0 +1,33 @@
+package ui
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// CuiExecer CUIコントローラの共通インタフェース
+type CuiExecer interface {
+	Exec(command string) string
+}
+
+// RunCuiLoop 標準CUIゲームループを実行する
+// helpLines は毎回入力前に表示されるヘルプメッセージ
+func RunCuiLoop(controller CuiExecer, helpLines []string) {
+	fmt.Println(controller.Exec("r"))
+	scanner := bufio.NewScanner(os.Stdin)
+	for {
+		for _, line := range helpLines {
+			fmt.Println(line)
+		}
+		input, exit := readInput(scanner)
+		if exit {
+			break
+		}
+		res := controller.Exec(input)
+		fmt.Println(res)
+		if res == "bye." {
+			break
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `CuiExecer` interface and `RunCuiLoop` helper in `cui_runner.go` to consolidate the duplicated CUI game loop (reset → scanner → help → readInput → exec → bye check)
- Simplify `Exec()` in 5 CUI structs (BlackJack, Poker, OldMaid, Daifugo, Sevens) to one-liner `RunCuiLoop` calls
- Doubt and Holdem retain custom loops due to fundamentally different input handling (goroutine-based doubt window / one-time help display)

Closes #400

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `go test -tags test ./...` all tests pass
- [x] `goimports -w` applied to all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)