### PR TITLE
refactor(controller): unify CUI controller error messages

### DIFF
--- a/internal/adapter/controller/BlackJackCuiController.go
+++ b/internal/adapter/controller/BlackJackCuiController.go
@@ -25,7 +25,7 @@ func (bcc *BlackJackCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return bcc.bji.Reset() },
-		func(_ string) string { return "Unsupported command." },
+		unknownCommandMessage,
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "h", "hit":

--- a/internal/adapter/controller/BlackJackCuiController_test.go
+++ b/internal/adapter/controller/BlackJackCuiController_test.go
@@ -88,10 +88,10 @@ func TestBlackJackCuiController_Method(t *testing.T) {
 		assert.Equal(t, mockOutput, tbc.Exec("declineinsurance"))
 	})
 	t.Run("success Exec other", func(t *testing.T) {
-		assert.Equal(t, "Unsupported command.", tbc.Exec("other"))
+		assert.Equal(t, "コマンドが不明です: other", tbc.Exec("other"))
 	})
 	t.Run("success Exec empty", func(t *testing.T) {
-		assert.Equal(t, "Unsupported command.", tbc.Exec(""))
+		assert.Equal(t, "コマンドが不明です: ", tbc.Exec(""))
 	})
 }
 

--- a/internal/adapter/controller/DaifugoCuiController.go
+++ b/internal/adapter/controller/DaifugoCuiController.go
@@ -24,7 +24,7 @@ func (c *DaifugoCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return c.dgi.Reset() },
-		func(command string) string { return "コマンドが不明です: " + command },
+		unknownCommandMessage,
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":

--- a/internal/adapter/controller/DoubtCuiController.go
+++ b/internal/adapter/controller/DoubtCuiController.go
@@ -30,7 +30,7 @@ func (c *DoubtCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return c.di.Reset() },
-		func(command string) string { return "コマンドが不明です: " + command },
+		unknownCommandMessage,
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":

--- a/internal/adapter/controller/HoldemCuiController.go
+++ b/internal/adapter/controller/HoldemCuiController.go
@@ -23,7 +23,7 @@ func (c *HoldemCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return c.hi.Reset() },
-		func(command string) string { return "コマンドが不明です: " + command },
+		unknownCommandMessage,
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "f", "fold":

--- a/internal/adapter/controller/OldMaidCuiController.go
+++ b/internal/adapter/controller/OldMaidCuiController.go
@@ -24,7 +24,7 @@ func (c *OldMaidCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return c.omi.Reset(domain.DefaultOldMaidConfig()) },
-		func(command string) string { return "コマンドが不明です: " + command },
+		unknownCommandMessage,
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "d", "draw":

--- a/internal/adapter/controller/PokerCuiController.go
+++ b/internal/adapter/controller/PokerCuiController.go
@@ -26,7 +26,7 @@ func (pcc *PokerCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return pcc.pi.Reset() },
-		func(_ string) string { return "Unsupported command." },
+		unknownCommandMessage,
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "e", "exchange":

--- a/internal/adapter/controller/PokerCuiController_test.go
+++ b/internal/adapter/controller/PokerCuiController_test.go
@@ -218,13 +218,13 @@ func TestPokerCuiController_AllIn(t *testing.T) {
 func TestPokerCuiController_Empty(t *testing.T) {
 	mi := new(mockUsecase.MockPokerInteractor)
 	c := NewPokerCuiController(mi)
-	assert.Equal(t, "Unsupported command.", c.Exec(""))
+	assert.Equal(t, "コマンドが不明です: ", c.Exec(""))
 }
 
 func TestPokerCuiController_Unknown(t *testing.T) {
 	mi := new(mockUsecase.MockPokerInteractor)
 	c := NewPokerCuiController(mi)
-	assert.Equal(t, "Unsupported command.", c.Exec("xyz"))
+	assert.Equal(t, "コマンドが不明です: xyz", c.Exec("xyz"))
 }
 
 // --- betting limit ---

--- a/internal/adapter/controller/SevensCuiController.go
+++ b/internal/adapter/controller/SevensCuiController.go
@@ -55,7 +55,7 @@ func (c *SevensCuiController) Exec(command string) string {
 			}
 			return c.sgi.Reset()
 		},
-		func(command string) string { return "コマンドが不明です: " + command },
+		unknownCommandMessage,
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":

--- a/internal/adapter/controller/cui_controller_helper.go
+++ b/internal/adapter/controller/cui_controller_helper.go
@@ -2,6 +2,11 @@ package controller
 
 import "strings"
 
+// unknownCommandMessage は不明なコマンドに対する統一エラーメッセージを返す。
+func unknownCommandMessage(command string) string {
+	return "コマンドが不明です: " + command
+}
+
 // execCuiCommand は全CUIコントローラーで共通のコマンド解析を行うヘルパー関数。
 // command を strings.Fields で分割し、空入力・q/quit・r/reset を共通処理する。
 // ゲーム固有コマンドは gameHandler で処理し、未知コマンドは unknownMsg で応答する。

--- a/internal/adapter/controller/cui_controller_helper_test.go
+++ b/internal/adapter/controller/cui_controller_helper_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestUnknownCommandMessage(t *testing.T) {
+	assert.Equal(t, "コマンドが不明です: foo", unknownCommandMessage("foo"))
+	assert.Equal(t, "コマンドが不明です: ", unknownCommandMessage(""))
+}
+
 func TestExecCuiCommand(t *testing.T) {
 	resetFn := func(args []string) string {
 		if len(args) > 0 {


### PR DESCRIPTION
## Summary
- Extract `unknownCommandMessage` helper into `cui_controller_helper.go` to provide a single unified error message for unknown commands
- Replace inline lambdas in all 7 CUI controllers (BlackJack, Poker, OldMaid, Daifugo, Sevens, Doubt, Holdem) with the shared helper
- Unify language from mixed English/Japanese to consistent Japanese (`コマンドが不明です: <command>`)

Closes #405

## Test plan
- [x] All existing controller tests pass with updated expected messages
- [x] New `TestUnknownCommandMessage` covers the helper function
- [x] 100% branch coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)