### PR TITLE
docs(blackjack): add scc command to CUI help text and manual

### DIFF
--- a/docs/manual/cui/blackjack.md
+++ b/docs/manual/cui/blackjack.md
@@ -80,6 +80,7 @@ flowchart TD
 | `setcountingsystem N` | `scs N` | カウンティングシステムを設定（0=Hi-Lo / 1=KO / 2=Zen Count / 3=Omega II） |
 | `toggledas` | `das` | スプリット後のダブルダウン（DAS）許可のON/OFFを切り替える |
 | `setpenetration N` | `pen N` | デッキペネトレーション率を設定（有効値: 50 / 75）。BETフェーズのみ有効 |
+| `setcpucount N` | `scc N` | CPUプレイヤー数を設定（0〜3）。BETフェーズのみ有効 |
 | `quit` | `q` | ゲーム終了 |
 
 ## 特殊ルール
@@ -137,7 +138,7 @@ KOシステムはアンバランス型のため、トゥルーカウント（TC�
 
 ### マルチプレイヤーCPU席
 
-0〜3名のCPUプレイヤーを追加できます。CPUプレイヤーはベーシックストラテジーに基づいて自動的にプレイします。
+`setcpucount N`（短縮形: `scc N`）で0〜3名のCPUプレイヤーを追加できます。BETフェーズ中に設定を変更すると、次の `reset` 時に反映されます。CPUプレイヤーはベーシックストラテジーに基づいて自動的にプレイします。
 
 ### サイドベット
 

--- a/internal/infrastructure/ui/BlackJackCui.go
+++ b/internal/infrastructure/ui/BlackJackCui.go
@@ -35,5 +35,6 @@ func (cui *BlackJackCui) Exec() {
 		"sp・・・split",
 		"i・・・insurance",
 		"di・・・decline insurance",
+		"scc N・・・set CPU player count (0-3)",
 	})
 }


### PR DESCRIPTION
## Summary
- `scc N`（`setcpucount N`）コマンドをCUIヘルプテキストに追加
- マニュアルのコマンド一覧表にCPU人数設定コマンドを追加
- マルチプレイヤーCPU席セクションにコマンドの使い方を記載

Closes #439

## Test plan
- [x] `go test -tags test ./internal/adapter/controller/` passes
- [x] No code changes — documentation/help text only

🤖 Generated with [Claude Code](https://claude.com/claude-code)