### PR TITLE
fix(sevens): add missing jokerreclaim flag to CUI reset parser

### DIFF
--- a/internal/adapter/controller/SevensCuiController.go
+++ b/internal/adapter/controller/SevensCuiController.go
@@ -45,6 +45,8 @@ func (c *SevensCuiController) Exec(command string) string {
 						cfg.CpuStrategy = true
 					case f == "nojokerfinish":
 						cfg.NoJokerFinish = true
+					case f == "jokerreclaim":
+						cfg.JokerReclaimEnabled = true
 					case f == "endstop":
 						cfg.EndStopEnabled = true
 					case f == "jokerconsban":

--- a/internal/adapter/controller/SevensCuiController_test.go
+++ b/internal/adapter/controller/SevensCuiController_test.go
@@ -165,6 +165,14 @@ func TestSevensCuiController_Exec(t *testing.T) {
 		m.AssertCalled(t, "ResetWithConfig", domain.SevensConfig{MaxPasses: 5, NoJokerFinish: true})
 	})
 
+	t.Run("reset with jokerreclaim flag", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewSevensCuiController(m)
+		result := c.Exec("r jokerreclaim")
+		assert.Equal(t, mockOutput, result)
+		m.AssertCalled(t, "ResetWithConfig", domain.SevensConfig{MaxPasses: 5, JokerReclaimEnabled: true})
+	})
+
 	t.Run("reset with endstop flag", func(t *testing.T) {
 		m := newMock()
 		c := controller.NewSevensCuiController(m)


### PR DESCRIPTION
## Summary
- Add missing `jokerreclaim` case to `SevensCuiController` reset argument parser so `r jokerreclaim` correctly enables `JokerReclaimEnabled`
- Add test for the new flag

Closes #443

## Test plan
- [x] New test `"reset with jokerreclaim flag"` verifies config is passed correctly
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)