### PR TITLE
chore: reduce repomix output size for NotebookLM import

### DIFF
--- a/.github/workflows/deploy-repomix.yml
+++ b/.github/workflows/deploy-repomix.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Run repomix
         # .repomixignore is picked up automatically by repomix
-        run: npx --yes repomix --output repomix-output.txt --style xml
+        run: npx --yes repomix --output repomix-output.txt --style xml --compress --remove-empty-lines
 
       - name: Prepare pages directory
         run: |

--- a/.repomixignore
+++ b/.repomixignore
@@ -29,6 +29,17 @@ public/assets/
 *.so
 go_trumpcards
 *.log
+*.html
+
+# Lock files (large, not useful for code reading)
+go.sum
+frontend/package-lock.json
+
+# Test files (large, reduce noise for reading)
+*_test.go
+*.test.ts
+*.test.tsx
+frontend/e2e/
 
 # Dependencies
 node_modules/


### PR DESCRIPTION
## Summary

- `.repomixignore` にテストファイル・ロックファイル・HTMLを追加除外し、出力サイズを削減
- `deploy-repomix.yml` に `--compress --remove-empty-lines` オプションを追加

## Changes

| 対象 | 内容 |
|------|------|
| `*_test.go`, `*.test.ts`, `*.test.tsx`, `frontend/e2e/` | テストファイル除外（6万行超） |
| `go.sum`, `frontend/package-lock.json` | ロックファイル除外（7000行超） |
| `*.html` | HTMLファイル除外 |
| `--compress --remove-empty-lines` | repomix側でさらに圧縮 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)