### PR TITLE
refactor: extract shared ActionLogOutput helpers to eliminate duplication

### DIFF
--- a/internal/adapter/presenter/BaccaratCuiPresenter.go
+++ b/internal/adapter/presenter/BaccaratCuiPresenter.go
@@ -81,10 +81,7 @@ func (bp *BaccaratCuiPresenter) Output(b interfaces.BaccaratGame, lastErr error)
 
 // ActionLogOutput 棋譜をテキスト出力
 func (bp *BaccaratCuiPresenter) ActionLogOutput(b interfaces.BaccaratGame) string {
-	if !b.GetGameEndFlag() {
-		return actionLogToText(nil)
-	}
-	return actionLogToText(b.GetActionLog())
+	return actionLogOutputText(b)
 }
 
 // phaseStr フェーズ文字列

--- a/internal/adapter/presenter/BaccaratWebPresenter.go
+++ b/internal/adapter/presenter/BaccaratWebPresenter.go
@@ -62,8 +62,5 @@ func (bp *BaccaratWebPresenter) Output(b interfaces.BaccaratGame, lastErr error)
 
 // ActionLogOutput 棋譜をJSON出力
 func (bp *BaccaratWebPresenter) ActionLogOutput(b interfaces.BaccaratGame) string {
-	if !b.GetGameEndFlag() {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(b.GetActionLog())
+	return actionLogOutputJSON(b)
 }

--- a/internal/adapter/presenter/BlackJackCuiPresenter.go
+++ b/internal/adapter/presenter/BlackJackCuiPresenter.go
@@ -220,10 +220,7 @@ func (bjp *BlackJackCuiPresenter) Output(bj interfaces.BlackJackGame, lastErr er
 
 // ActionLogOutput 棋譜をテキスト出力
 func (bjp *BlackJackCuiPresenter) ActionLogOutput(bj interfaces.BlackJackGame) string {
-	if !bj.GetGameEndFlag() {
-		return actionLogToText(nil)
-	}
-	return actionLogToText(bj.GetActionLog())
+	return actionLogOutputText(bj)
 }
 
 // phaseStr フェーズ文字列

--- a/internal/adapter/presenter/BlackJackWebPresenter.go
+++ b/internal/adapter/presenter/BlackJackWebPresenter.go
@@ -147,8 +147,5 @@ func (bjp *BlackJackWebPresenter) Output(bj interfaces.BlackJackGame, lastErr er
 
 // ActionLogOutput 棋譜をJSON出力
 func (bjp *BlackJackWebPresenter) ActionLogOutput(bj interfaces.BlackJackGame) string {
-	if !bj.GetGameEndFlag() {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(bj.GetActionLog())
+	return actionLogOutputJSON(bj)
 }

--- a/internal/adapter/presenter/DaifugoCuiPresenter.go
+++ b/internal/adapter/presenter/DaifugoCuiPresenter.go
@@ -171,10 +171,7 @@ func (p *DaifugoCuiPresenter) Output(dg interfaces.DaifugoGame, lastErr error) s
 
 // ActionLogOutput 棋譜をテキスト出力
 func (p *DaifugoCuiPresenter) ActionLogOutput(dg interfaces.DaifugoGame) string {
-	if !dg.GetGameEndFlag() {
-		return actionLogToText(nil)
-	}
-	return actionLogToText(dg.GetActionLog())
+	return actionLogOutputText(dg)
 }
 
 // rankName ランク名取得

--- a/internal/adapter/presenter/DaifugoWebPresenter.go
+++ b/internal/adapter/presenter/DaifugoWebPresenter.go
@@ -168,10 +168,7 @@ func (dwp *DaifugoWebPresenter) buildResultMessage(dg interfaces.DaifugoGame) st
 
 // ActionLogOutput 棋譜をJSON出力
 func (dwp *DaifugoWebPresenter) ActionLogOutput(dg interfaces.DaifugoGame) string {
-	if !dg.GetGameEndFlag() {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(dg.GetActionLog())
+	return actionLogOutputJSON(dg)
 }
 
 // getSuitName スート名取得 (スート縛り用: 4スートのみ変換し、それ以外は空文字)

--- a/internal/adapter/presenter/DoubtCuiPresenter.go
+++ b/internal/adapter/presenter/DoubtCuiPresenter.go
@@ -152,8 +152,5 @@ func (p *DoubtCuiPresenter) Output(d interfaces.DoubtGame, lastErr error) string
 
 // ActionLogOutput 棋譜をテキスト出力
 func (p *DoubtCuiPresenter) ActionLogOutput(d interfaces.DoubtGame) string {
-	if !d.GetGameEndFlag() {
-		return actionLogToText(nil)
-	}
-	return actionLogToText(d.GetActionLog())
+	return actionLogOutputText(d)
 }

--- a/internal/adapter/presenter/DoubtWebPresenter.go
+++ b/internal/adapter/presenter/DoubtWebPresenter.go
@@ -133,10 +133,7 @@ func (dwp *DoubtWebPresenter) buildResultMessage(d interfaces.DoubtGame) string 
 
 // ActionLogOutput 棋譜をJSON出力
 func (dwp *DoubtWebPresenter) ActionLogOutput(d interfaces.DoubtGame) string {
-	if !d.GetGameEndFlag() {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(d.GetActionLog())
+	return actionLogOutputJSON(d)
 }
 
 // actionToOutput DoubtCpuAction を DoubtWebOutputAction に変換

--- a/internal/adapter/presenter/HeartsCuiPresenter.go
+++ b/internal/adapter/presenter/HeartsCuiPresenter.go
@@ -109,10 +109,7 @@ func (p *HeartsCuiPresenter) Output(h interfaces.HeartsGame, lastErr error) stri
 
 // ActionLogOutput 棋譜をテキスト出力
 func (p *HeartsCuiPresenter) ActionLogOutput(h interfaces.HeartsGame) string {
-	if !h.GetGameEndFlag() {
-		return actionLogToText(nil)
-	}
-	return actionLogToText(h.GetActionLog())
+	return actionLogOutputText(h)
 }
 
 // cuiPassDirectionStr パス方向の日本語表示

--- a/internal/adapter/presenter/HeartsWebPresenter.go
+++ b/internal/adapter/presenter/HeartsWebPresenter.go
@@ -119,8 +119,5 @@ func (p *HeartsWebPresenter) buildResultMessage(h interfaces.HeartsGame) string 
 
 // ActionLogOutput 棋譜をJSON出力
 func (p *HeartsWebPresenter) ActionLogOutput(h interfaces.HeartsGame) string {
-	if !h.GetGameEndFlag() {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(h.GetActionLog())
+	return actionLogOutputJSON(h)
 }

--- a/internal/adapter/presenter/HoldemCuiPresenter.go
+++ b/internal/adapter/presenter/HoldemCuiPresenter.go
@@ -18,10 +18,7 @@ func NewHoldemCuiPresenter() *HoldemCuiPresenter {
 
 // ActionLogOutput 棋譜をテキスト出力
 func (p *HoldemCuiPresenter) ActionLogOutput(h interfaces.HoldemGame) string {
-	if !h.GetGameEndFlag() {
-		return actionLogToText(nil)
-	}
-	return actionLogToText(h.GetActionLog())
+	return actionLogOutputText(h)
 }
 
 // Output ゲーム状態を文字列出力

--- a/internal/adapter/presenter/HoldemWebPresenter.go
+++ b/internal/adapter/presenter/HoldemWebPresenter.go
@@ -188,10 +188,7 @@ func (hwp *HoldemWebPresenter) buildResultMessage(h interfaces.HoldemGame) (stri
 
 // ActionLogOutput 棋譜をJSON出力
 func (hwp *HoldemWebPresenter) ActionLogOutput(h interfaces.HoldemGame) string {
-	if !h.GetGameEndFlag() {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(h.GetActionLog())
+	return actionLogOutputJSON(h)
 }
 
 // getHandName ハンドランクから名前を返す

--- a/internal/adapter/presenter/MemoryCuiPresenter.go
+++ b/internal/adapter/presenter/MemoryCuiPresenter.go
@@ -93,8 +93,5 @@ func (p *MemoryCuiPresenter) Output(m interfaces.MemoryGame, lastErr error) stri
 
 // ActionLogOutput 棋譜をテキスト出力
 func (p *MemoryCuiPresenter) ActionLogOutput(m interfaces.MemoryGame) string {
-	if !m.GetGameEndFlag() {
-		return actionLogToText(nil)
-	}
-	return actionLogToText(m.GetActionLog())
+	return actionLogOutputText(m)
 }

--- a/internal/adapter/presenter/MemoryWebPresenter.go
+++ b/internal/adapter/presenter/MemoryWebPresenter.go
@@ -111,8 +111,5 @@ func (p *MemoryWebPresenter) buildResultMessage(m interfaces.MemoryGame) string 
 
 // ActionLogOutput 棋譜をJSON出力
 func (p *MemoryWebPresenter) ActionLogOutput(m interfaces.MemoryGame) string {
-	if !m.GetGameEndFlag() {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(m.GetActionLog())
+	return actionLogOutputJSON(m)
 }

--- a/internal/adapter/presenter/OldMaidCuiPresenter.go
+++ b/internal/adapter/presenter/OldMaidCuiPresenter.go
@@ -150,8 +150,5 @@ func (p *OldMaidCuiPresenter) Output(om interfaces.OldMaidGame, lastErr error) s
 
 // ActionLogOutput 棋譜をテキスト出力
 func (p *OldMaidCuiPresenter) ActionLogOutput(om interfaces.OldMaidGame) string {
-	if !om.GetGameEndFlag() {
-		return actionLogToText(nil)
-	}
-	return actionLogToText(om.GetActionLog())
+	return actionLogOutputText(om)
 }

--- a/internal/adapter/presenter/OldMaidWebPresenter.go
+++ b/internal/adapter/presenter/OldMaidWebPresenter.go
@@ -140,8 +140,5 @@ func (owp *OldMaidWebPresenter) Output(om interfaces.OldMaidGame, lastErr error)
 
 // ActionLogOutput 棋譜をJSON出力
 func (owp *OldMaidWebPresenter) ActionLogOutput(om interfaces.OldMaidGame) string {
-	if !om.GetGameEndFlag() {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(om.GetActionLog())
+	return actionLogOutputJSON(om)
 }

--- a/internal/adapter/presenter/PokerCuiPresenter.go
+++ b/internal/adapter/presenter/PokerCuiPresenter.go
@@ -166,10 +166,7 @@ func (pcp *PokerCuiPresenter) Output(p interfaces.PokerGame, lastErr error) stri
 
 // ActionLogOutput 棋譜をテキスト出力
 func (pcp *PokerCuiPresenter) ActionLogOutput(p interfaces.PokerGame) string {
-	if !p.GetGameEndFlag() {
-		return actionLogToText(nil)
-	}
-	return actionLogToText(p.GetActionLog())
+	return actionLogOutputText(p)
 }
 
 // OutputWithOdds ゲーム状態 + オッズ出力

--- a/internal/adapter/presenter/PokerWebPresenter.go
+++ b/internal/adapter/presenter/PokerWebPresenter.go
@@ -40,10 +40,7 @@ func (pwp *PokerWebPresenter) OutputWithOdds(p interfaces.PokerGame, lastErr err
 
 // ActionLogOutput 棋譜をJSON出力
 func (pwp *PokerWebPresenter) ActionLogOutput(p interfaces.PokerGame) string {
-	if !p.GetGameEndFlag() {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(p.GetActionLog())
+	return actionLogOutputJSON(p)
 }
 
 // buildOutput ゲーム状態をPokerWebOutputに変換

--- a/internal/adapter/presenter/SevensCuiPresenter.go
+++ b/internal/adapter/presenter/SevensCuiPresenter.go
@@ -18,10 +18,7 @@ func NewSevensCuiPresenter() *SevensCuiPresenter {
 
 // ActionLogOutput 棋譜をテキスト出力
 func (p *SevensCuiPresenter) ActionLogOutput(s interfaces.SevensGame) string {
-	if !s.GetGameEndFlag() {
-		return actionLogToText(nil)
-	}
-	return actionLogToText(s.GetActionLog())
+	return actionLogOutputText(s)
 }
 
 // Output ゲーム状態を文字列出力

--- a/internal/adapter/presenter/SevensWebPresenter.go
+++ b/internal/adapter/presenter/SevensWebPresenter.go
@@ -107,10 +107,7 @@ func (swp *SevensWebPresenter) Output(s interfaces.SevensGame, lastErr error) st
 
 // ActionLogOutput 棋譜をJSON出力
 func (swp *SevensWebPresenter) ActionLogOutput(s interfaces.SevensGame) string {
-	if !s.GetGameEndFlag() {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(s.GetActionLog())
+	return actionLogOutputJSON(s)
 }
 
 // buildResultMessage ゲーム終了メッセージを生成

--- a/internal/adapter/presenter/action_log_helper.go
+++ b/internal/adapter/presenter/action_log_helper.go
@@ -8,6 +8,28 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 )
 
+// gameEndLogger is a minimal interface satisfied by all game types that support action logs.
+type gameEndLogger interface {
+	GetGameEndFlag() bool
+	GetActionLog() []*domain.ActionLogEntry
+}
+
+// actionLogOutputText returns the action log as plain text, or an empty log if the game is not finished.
+func actionLogOutputText(game gameEndLogger) string {
+	if !game.GetGameEndFlag() {
+		return actionLogToText(nil)
+	}
+	return actionLogToText(game.GetActionLog())
+}
+
+// actionLogOutputJSON returns the action log as JSON, or an empty log if the game is not finished.
+func actionLogOutputJSON(game gameEndLogger) string {
+	if !game.GetGameEndFlag() {
+		return actionLogToJSON(nil)
+	}
+	return actionLogToJSON(game.GetActionLog())
+}
+
 // actionLogToJSON 棋譜をJSON文字列に変換する
 func actionLogToJSON(entries []*domain.ActionLogEntry) string {
 	out := &controller.ActionLogWebOutput{

--- a/internal/adapter/presenter/action_log_helper_test.go
+++ b/internal/adapter/presenter/action_log_helper_test.go
@@ -11,6 +11,55 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 )
 
+// stubGameEndLogger is a test double for gameEndLogger.
+type stubGameEndLogger struct {
+	ended     bool
+	actionLog []*domain.ActionLogEntry
+}
+
+func (s *stubGameEndLogger) GetGameEndFlag() bool                   { return s.ended }
+func (s *stubGameEndLogger) GetActionLog() []*domain.ActionLogEntry { return s.actionLog }
+
+func TestActionLogOutputText(t *testing.T) {
+	t.Run("game not ended returns empty log", func(t *testing.T) {
+		g := &stubGameEndLogger{ended: false}
+		result := actionLogOutputText(g)
+		assert.Equal(t, "棋譜はありません。\n", result)
+	})
+
+	t.Run("game ended returns log", func(t *testing.T) {
+		g := &stubGameEndLogger{
+			ended: true,
+			actionLog: []*domain.ActionLogEntry{
+				{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "test"},
+			},
+		}
+		result := actionLogOutputText(g)
+		assert.Contains(t, result, "T1")
+		assert.Contains(t, result, "Player 0")
+	})
+}
+
+func TestActionLogOutputJSON(t *testing.T) {
+	t.Run("game not ended returns empty log", func(t *testing.T) {
+		g := &stubGameEndLogger{ended: false}
+		result := actionLogOutputJSON(g)
+		assert.Contains(t, result, `"entries":[]`)
+	})
+
+	t.Run("game ended returns log", func(t *testing.T) {
+		g := &stubGameEndLogger{
+			ended: true,
+			actionLog: []*domain.ActionLogEntry{
+				{TurnNumber: 2, PlayerIdx: 1, ActionType: "draw", Detail: "drew a card"},
+			},
+		}
+		result := actionLogOutputJSON(g)
+		assert.Contains(t, result, `"turnNumber":2`)
+		assert.Contains(t, result, `"playerIdx":1`)
+	})
+}
+
 func TestActionLogToJSON(t *testing.T) {
 	t.Run("empty entries", func(t *testing.T) {
 		result := actionLogToJSON([]*domain.ActionLogEntry{})


### PR DESCRIPTION
## Summary

- Add `gameEndLogger` minimal interface and `actionLogOutputText`/`actionLogOutputJSON` helper functions in `action_log_helper.go`
- Refactor 20 CUI/Web presenter `ActionLogOutput` methods to delegate to the shared helpers instead of repeating the same 5-line pattern
- `KlondikeCuiPresenter` and `KlondikeWebPresenter` are intentionally excluded as they use a phase-based check rather than `GetGameEndFlag`
- Add tests for the two new helpers covering both branches (game ended / not ended)

## Test plan

- [x] `go test -tags test ./internal/adapter/presenter/...` passes
- [x] `go test -tags test ./...` passes
- [x] `goimports -w` applied to all modified files

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)