### PR TITLE
fix: install repomix via npm to resolve missing fast-xml-builder dependency

### DIFF
--- a/.github/workflows/deploy-repomix.yml
+++ b/.github/workflows/deploy-repomix.yml
@@ -25,9 +25,12 @@ jobs:
         with:
           node-version: '24'
 
+      - name: Install repomix
+        run: npm install -g repomix
+
       - name: Run repomix
         # .repomixignore is picked up automatically by repomix
-        run: npx --yes repomix --output repomix-output.txt --style xml --compress --remove-empty-lines
+        run: repomix --output repomix-output.txt --style xml --compress --remove-empty-lines
 
       - name: Prepare pages directory
         run: |


### PR DESCRIPTION
## Summary

- Replace `npx --yes repomix` with `npm install -g repomix` + `repomix` invocation in the deploy workflow
- Fixes CI failure caused by `fast-xml-builder` not being resolved when running repomix via npx

## Root Cause

The `fast-xml-parser` package (a transitive dependency of repomix) was split into a separate `fast-xml-builder` package in newer versions. When invoked via `npx`, this peer dependency was not installed, resulting in `ERR_MODULE_NOT_FOUND`. Installing repomix explicitly via `npm install -g` ensures all dependencies are resolved correctly.

## Test plan

- [ ] Verify the `Build Repomix Output` CI job passes after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)