### PR TITLE
refactor: extract buildCuiOutput helper to eliminate header/footer boilerplate in CUI presenters

### DIFF
--- a/internal/adapter/presenter/DaifugoCuiPresenter.go
+++ b/internal/adapter/presenter/DaifugoCuiPresenter.go
@@ -18,155 +18,148 @@ func NewDaifugoCuiPresenter() *DaifugoCuiPresenter {
 
 // Output ゲーム状態を文字列出力
 func (p *DaifugoCuiPresenter) Output(dg interfaces.DaifugoGame, lastErr error) string {
-	var b strings.Builder
-
-	b.WriteString("==========\n")
-	b.WriteString("Daifugo (大富豪)\n")
-	b.WriteString("==========\n")
-
-	for i := 0; i < dg.GetPlayerCnt(); i++ {
-		player := dg.GetPlayer(i)
-		if player.GetIsHuman() {
-			b.WriteString("[You]")
-		} else {
-			fmt.Fprintf(&b, "CPU %d", i)
-		}
-		if player.GetIsFinished() {
-			fmt.Fprintf(&b, ": 上がり (ランク: %s)\n", p.rankName(player.GetRank()))
-		} else {
-			fmt.Fprintf(&b, ": %d枚\n", player.GetCardsSize())
-			if player.GetIsHuman() {
-				for j := 0; j < player.GetCardsSize(); j++ {
-					if j != 0 {
-						b.WriteString("  ")
-					}
-					fmt.Fprintf(&b, "[%d]%s", j, cuiCardStr(player.GetCard(j)))
-				}
-				b.WriteString("\n")
-			}
-		}
-	}
-
-	b.WriteString("----------\n")
-
-	// ローカルルール状態
-	if dg.GetRevolutionActive() {
-		b.WriteString("【革命中】2が最弱、3が最強\n")
-	}
-	if dg.GetElevenBackActive() {
-		b.WriteString("【11バック】強さが逆転中\n")
-	}
-	if dg.GetSuitLocked() {
-		fmt.Fprintf(&b, "【スート縛り】%s\n", cuiSuitName(dg.GetLockedSuit()))
-	}
-	if dg.GetTableIsSequence() {
-		b.WriteString("【階段】\n")
-	}
-	if dg.GetReverseDirection() {
-		b.WriteString("【9リバース】\n")
-	}
-	if dg.GetNumberLocked() {
-		b.WriteString("【連番縛り】\n")
-	}
-
-	// カード交換記録
-	exchangeActions := dg.GetExchangeActions()
-	if len(exchangeActions) > 0 {
-		b.WriteString("[カード交換]\n")
-		for _, ex := range exchangeActions {
-			cardStrs := make([]string, len(ex.Cards))
-			for i, c := range ex.Cards {
-				cardStrs[i] = cuiCardStr(c)
-			}
-			fmt.Fprintf(&b, "%s → %s: %s\n",
-				cuiPlayerName(dg.GetPlayer(ex.FromPlayerIdx), ex.FromPlayerIdx),
-				cuiPlayerName(dg.GetPlayer(ex.ToPlayerIdx), ex.ToPlayerIdx),
-				strings.Join(cardStrs, ", "))
-		}
-	}
-
-	// 場のカード
-	tableCards := dg.GetTableCards()
-	if len(tableCards) > 0 {
-		cardStrs := make([]string, len(tableCards))
-		for i, c := range tableCards {
-			cardStrs[i] = cuiCardStr(c)
-		}
-		lastPlayIdx := dg.GetLastPlayPlayerIdx()
-		fmt.Fprintf(&b, "場: %s (出したプレイヤー: %s)\n",
-			strings.Join(cardStrs, ", "),
-			cuiPlayerName(dg.GetPlayer(lastPlayIdx), lastPlayIdx))
-	} else {
-		b.WriteString("場: なし (誰でも出せます)\n")
-	}
-
-	// 人間の前の行動
-	humanAction := dg.GetHumanAction()
-	if humanAction != nil {
-		if len(humanAction.PlayedCards) == 0 {
-			fmt.Fprintf(&b, "%sがパスしました\n", cuiPlayerName(dg.GetPlayer(humanAction.PlayerIdx), humanAction.PlayerIdx))
-		} else {
-			cardStrs := make([]string, len(humanAction.PlayedCards))
-			for i, c := range humanAction.PlayedCards {
-				cardStrs[i] = cuiCardStr(c)
-			}
-			fmt.Fprintf(&b, "%sが %s を出しました\n",
-				cuiPlayerName(dg.GetPlayer(humanAction.PlayerIdx), humanAction.PlayerIdx),
-				strings.Join(cardStrs, ", "))
-		}
-	}
-
-	// CPUの行動履歴を表示
-	cpuActions := dg.GetCpuActions()
-	if len(cpuActions) > 0 {
-		b.WriteString("[CPUの行動]\n")
-		for _, action := range cpuActions {
-			actPlayerName := cuiPlayerName(dg.GetPlayer(action.PlayerIdx), action.PlayerIdx)
-			if len(action.PlayedCards) == 0 {
-				fmt.Fprintf(&b, "%sがパスしました\n", actPlayerName)
-			} else {
-				cardStrs := make([]string, len(action.PlayedCards))
-				for i, c := range action.PlayedCards {
-					cardStrs[i] = cuiCardStr(c)
-				}
-				fmt.Fprintf(&b, "%sが %s を出しました\n", actPlayerName, strings.Join(cardStrs, ", "))
-			}
-		}
-	}
-
-	// エラーメッセージ
-	if lastErr != nil {
-		fmt.Fprintf(&b, "%s\n", lastErr.Error())
-	}
-
-	if dg.GetGameEndFlag() {
-		b.WriteString("ゲーム終了！\n")
+	return buildCuiOutput("Daifugo (大富豪)", func(b *strings.Builder) {
 		for i := 0; i < dg.GetPlayerCnt(); i++ {
 			player := dg.GetPlayer(i)
-			penalty := ""
-			if player.GetIllegalFinishPenalty() {
-				penalty = " [反則上がり]"
+			if player.GetIsHuman() {
+				b.WriteString("[You]")
+			} else {
+				fmt.Fprintf(b, "CPU %d", i)
 			}
-			fmt.Fprintf(&b, "  %s: %s%s\n", cuiPlayerName(dg.GetPlayer(i), i), p.rankName(player.GetRank()), penalty)
+			if player.GetIsFinished() {
+				fmt.Fprintf(b, ": 上がり (ランク: %s)\n", p.rankName(player.GetRank()))
+			} else {
+				fmt.Fprintf(b, ": %d枚\n", player.GetCardsSize())
+				if player.GetIsHuman() {
+					for j := 0; j < player.GetCardsSize(); j++ {
+						if j != 0 {
+							b.WriteString("  ")
+						}
+						fmt.Fprintf(b, "[%d]%s", j, cuiCardStr(player.GetCard(j)))
+					}
+					b.WriteString("\n")
+				}
+			}
 		}
-	} else {
-		currentTurn := dg.GetCurrentTurn()
-		currentName := cuiPlayerName(dg.GetPlayer(currentTurn), currentTurn)
-		fmt.Fprintf(&b, "手番: %s\n", currentName)
-		switch dg.GetPendingActionType() {
-		case domain.DaifugoPendingSevenPass:
-			b.WriteString("【7渡し】渡すカードを選択してください (p [インデックス])\n")
-		case domain.DaifugoPendingTenDiscard:
-			b.WriteString("【10捨て】捨てるカードを選択してください (p [インデックス])\n")
-		case domain.DaifugoPendingQueenBomber:
-			b.WriteString("【12ボンバー】除去するカードの数字を入力してください (p [1-13])\n")
-		default:
-			b.WriteString("p [インデックス...] でカードを出す / p でパス\n")
-		}
-	}
 
-	b.WriteString("==========\n")
-	return b.String()
+		b.WriteString("----------\n")
+
+		// ローカルルール状態
+		if dg.GetRevolutionActive() {
+			b.WriteString("【革命中】2が最弱、3が最強\n")
+		}
+		if dg.GetElevenBackActive() {
+			b.WriteString("【11バック】強さが逆転中\n")
+		}
+		if dg.GetSuitLocked() {
+			fmt.Fprintf(b, "【スート縛り】%s\n", cuiSuitName(dg.GetLockedSuit()))
+		}
+		if dg.GetTableIsSequence() {
+			b.WriteString("【階段】\n")
+		}
+		if dg.GetReverseDirection() {
+			b.WriteString("【9リバース】\n")
+		}
+		if dg.GetNumberLocked() {
+			b.WriteString("【連番縛り】\n")
+		}
+
+		// カード交換記録
+		exchangeActions := dg.GetExchangeActions()
+		if len(exchangeActions) > 0 {
+			b.WriteString("[カード交換]\n")
+			for _, ex := range exchangeActions {
+				cardStrs := make([]string, len(ex.Cards))
+				for i, c := range ex.Cards {
+					cardStrs[i] = cuiCardStr(c)
+				}
+				fmt.Fprintf(b, "%s → %s: %s\n",
+					cuiPlayerName(dg.GetPlayer(ex.FromPlayerIdx), ex.FromPlayerIdx),
+					cuiPlayerName(dg.GetPlayer(ex.ToPlayerIdx), ex.ToPlayerIdx),
+					strings.Join(cardStrs, ", "))
+			}
+		}
+
+		// 場のカード
+		tableCards := dg.GetTableCards()
+		if len(tableCards) > 0 {
+			cardStrs := make([]string, len(tableCards))
+			for i, c := range tableCards {
+				cardStrs[i] = cuiCardStr(c)
+			}
+			lastPlayIdx := dg.GetLastPlayPlayerIdx()
+			fmt.Fprintf(b, "場: %s (出したプレイヤー: %s)\n",
+				strings.Join(cardStrs, ", "),
+				cuiPlayerName(dg.GetPlayer(lastPlayIdx), lastPlayIdx))
+		} else {
+			b.WriteString("場: なし (誰でも出せます)\n")
+		}
+
+		// 人間の前の行動
+		humanAction := dg.GetHumanAction()
+		if humanAction != nil {
+			if len(humanAction.PlayedCards) == 0 {
+				fmt.Fprintf(b, "%sがパスしました\n", cuiPlayerName(dg.GetPlayer(humanAction.PlayerIdx), humanAction.PlayerIdx))
+			} else {
+				cardStrs := make([]string, len(humanAction.PlayedCards))
+				for i, c := range humanAction.PlayedCards {
+					cardStrs[i] = cuiCardStr(c)
+				}
+				fmt.Fprintf(b, "%sが %s を出しました\n",
+					cuiPlayerName(dg.GetPlayer(humanAction.PlayerIdx), humanAction.PlayerIdx),
+					strings.Join(cardStrs, ", "))
+			}
+		}
+
+		// CPUの行動履歴を表示
+		cpuActions := dg.GetCpuActions()
+		if len(cpuActions) > 0 {
+			b.WriteString("[CPUの行動]\n")
+			for _, action := range cpuActions {
+				actPlayerName := cuiPlayerName(dg.GetPlayer(action.PlayerIdx), action.PlayerIdx)
+				if len(action.PlayedCards) == 0 {
+					fmt.Fprintf(b, "%sがパスしました\n", actPlayerName)
+				} else {
+					cardStrs := make([]string, len(action.PlayedCards))
+					for i, c := range action.PlayedCards {
+						cardStrs[i] = cuiCardStr(c)
+					}
+					fmt.Fprintf(b, "%sが %s を出しました\n", actPlayerName, strings.Join(cardStrs, ", "))
+				}
+			}
+		}
+
+		// エラーメッセージ
+		if lastErr != nil {
+			fmt.Fprintf(b, "%s\n", lastErr.Error())
+		}
+
+		if dg.GetGameEndFlag() {
+			b.WriteString("ゲーム終了！\n")
+			for i := 0; i < dg.GetPlayerCnt(); i++ {
+				player := dg.GetPlayer(i)
+				penalty := ""
+				if player.GetIllegalFinishPenalty() {
+					penalty = " [反則上がり]"
+				}
+				fmt.Fprintf(b, "  %s: %s%s\n", cuiPlayerName(dg.GetPlayer(i), i), p.rankName(player.GetRank()), penalty)
+			}
+		} else {
+			currentTurn := dg.GetCurrentTurn()
+			currentName := cuiPlayerName(dg.GetPlayer(currentTurn), currentTurn)
+			fmt.Fprintf(b, "手番: %s\n", currentName)
+			switch dg.GetPendingActionType() {
+			case domain.DaifugoPendingSevenPass:
+				b.WriteString("【7渡し】渡すカードを選択してください (p [インデックス])\n")
+			case domain.DaifugoPendingTenDiscard:
+				b.WriteString("【10捨て】捨てるカードを選択してください (p [インデックス])\n")
+			case domain.DaifugoPendingQueenBomber:
+				b.WriteString("【12ボンバー】除去するカードの数字を入力してください (p [1-13])\n")
+			default:
+				b.WriteString("p [インデックス...] でカードを出す / p でパス\n")
+			}
+		}
+	})
 }
 
 // ActionLogOutput 棋譜をテキスト出力

--- a/internal/adapter/presenter/DoubtCuiPresenter.go
+++ b/internal/adapter/presenter/DoubtCuiPresenter.go
@@ -18,136 +18,129 @@ func NewDoubtCuiPresenter() *DoubtCuiPresenter {
 
 // Output ゲーム状態を文字列出力
 func (p *DoubtCuiPresenter) Output(d interfaces.DoubtGame, lastErr error) string {
-	var b strings.Builder
-
-	b.WriteString("==========\n")
-	b.WriteString("Doubt (ダウト)\n")
-	b.WriteString("==========\n")
-
-	// プレイヤー情報
-	for i := 0; i < d.GetPlayerCnt(); i++ {
-		player := d.GetPlayer(i)
-		if player.GetIsHuman() {
-			b.WriteString("[You]")
-		} else {
-			fmt.Fprintf(&b, "CPU %d", i)
-		}
-		if player.GetIsFinished() {
-			b.WriteString(": 上がり\n")
-		} else {
-			fmt.Fprintf(&b, ": %d枚\n", player.GetCardsSize())
+	return buildCuiOutput("Doubt (ダウト)", func(b *strings.Builder) {
+		// プレイヤー情報
+		for i := 0; i < d.GetPlayerCnt(); i++ {
+			player := d.GetPlayer(i)
 			if player.GetIsHuman() {
-				for j := 0; j < player.GetCardsSize(); j++ {
-					if j != 0 {
-						b.WriteString("  ")
+				b.WriteString("[You]")
+			} else {
+				fmt.Fprintf(b, "CPU %d", i)
+			}
+			if player.GetIsFinished() {
+				b.WriteString(": 上がり\n")
+			} else {
+				fmt.Fprintf(b, ": %d枚\n", player.GetCardsSize())
+				if player.GetIsHuman() {
+					for j := 0; j < player.GetCardsSize(); j++ {
+						if j != 0 {
+							b.WriteString("  ")
+						}
+						fmt.Fprintf(b, "[%d]%s", j, cuiCardStr(player.GetCard(j)))
 					}
-					fmt.Fprintf(&b, "[%d]%s", j, cuiCardStr(player.GetCard(j)))
+					b.WriteString("\n")
+				}
+			}
+		}
+
+		b.WriteString("----------\n")
+		fmt.Fprintf(b, "テーブル: %d枚\n", d.GetTableCardCount())
+
+		// 最後のプレイ情報
+		lastAction := d.GetLastAction()
+		if lastAction != nil {
+			fmt.Fprintf(b, "[最後のプレイ] %sが「%d」を%d枚出しました\n",
+				cuiPlayerName(d.GetPlayer(lastAction.PlayerIdx), lastAction.PlayerIdx),
+				lastAction.ClaimedValue,
+				lastAction.CardCount,
+			)
+		}
+
+		// ダウト結果
+		lastResult := d.GetLastDoubtResult()
+		if lastResult != nil {
+			doubterName := cuiPlayerName(d.GetPlayer(lastResult.DoubterIdx), lastResult.DoubterIdx)
+			cardPlayerName := cuiPlayerName(d.GetPlayer(lastResult.CardPlayerIdx), lastResult.CardPlayerIdx)
+			loserName := cuiPlayerName(d.GetPlayer(lastResult.LoserIdx), lastResult.LoserIdx)
+			if lastResult.WasLying {
+				fmt.Fprintf(b, "[ダウト] %sが%sをダウト → 嘘つき！ %sが%d枚引き取りました\n",
+					doubterName, cardPlayerName, loserName, lastResult.CardCount)
+			} else {
+				fmt.Fprintf(b, "[ダウト] %sが%sをダウト → 正直者！ %sが%d枚引き取りました\n",
+					doubterName, cardPlayerName, loserName, lastResult.CardCount)
+			}
+			if lastResult.DiscardedCount > 0 {
+				fmt.Fprintf(b, "  (%d枚がゲームから除外されました)\n", lastResult.DiscardedCount)
+			}
+			// 公開されたカード
+			if len(lastResult.RevealedCards) > 0 {
+				b.WriteString("  公開カード: ")
+				for i, card := range lastResult.RevealedCards {
+					if i != 0 {
+						b.WriteString(", ")
+					}
+					b.WriteString(cuiCardStr(card))
 				}
 				b.WriteString("\n")
 			}
 		}
-	}
 
-	b.WriteString("----------\n")
-	fmt.Fprintf(&b, "テーブル: %d枚\n", d.GetTableCardCount())
-
-	// 最後のプレイ情報
-	lastAction := d.GetLastAction()
-	if lastAction != nil {
-		fmt.Fprintf(&b, "[最後のプレイ] %sが「%d」を%d枚出しました\n",
-			cuiPlayerName(d.GetPlayer(lastAction.PlayerIdx), lastAction.PlayerIdx),
-			lastAction.ClaimedValue,
-			lastAction.CardCount,
-		)
-	}
-
-	// ダウト結果
-	lastResult := d.GetLastDoubtResult()
-	if lastResult != nil {
-		doubterName := cuiPlayerName(d.GetPlayer(lastResult.DoubterIdx), lastResult.DoubterIdx)
-		cardPlayerName := cuiPlayerName(d.GetPlayer(lastResult.CardPlayerIdx), lastResult.CardPlayerIdx)
-		loserName := cuiPlayerName(d.GetPlayer(lastResult.LoserIdx), lastResult.LoserIdx)
-		if lastResult.WasLying {
-			fmt.Fprintf(&b, "[ダウト] %sが%sをダウト → 嘘つき！ %sが%d枚引き取りました\n",
-				doubterName, cardPlayerName, loserName, lastResult.CardCount)
-		} else {
-			fmt.Fprintf(&b, "[ダウト] %sが%sをダウト → 正直者！ %sが%d枚引き取りました\n",
-				doubterName, cardPlayerName, loserName, lastResult.CardCount)
+		// 人間の行動履歴
+		humanAction := d.GetHumanAction()
+		if humanAction != nil {
+			fmt.Fprintf(b, "[あなたの行動] 「%d」を%d枚出しました\n",
+				humanAction.ClaimedValue, humanAction.CardCount)
 		}
-		if lastResult.DiscardedCount > 0 {
-			fmt.Fprintf(&b, "  (%d枚がゲームから除外されました)\n", lastResult.DiscardedCount)
-		}
-		// 公開されたカード
-		if len(lastResult.RevealedCards) > 0 {
-			b.WriteString("  公開カード: ")
-			for i, card := range lastResult.RevealedCards {
-				if i != 0 {
-					b.WriteString(", ")
-				}
-				b.WriteString(cuiCardStr(card))
+
+		// CPUの行動履歴
+		cpuActions := d.GetCpuActions()
+		if len(cpuActions) > 0 {
+			b.WriteString("[CPUの行動]\n")
+			for _, action := range cpuActions {
+				fmt.Fprintf(b, "%sが「%d」を%d枚出しました\n",
+					cuiPlayerName(d.GetPlayer(action.PlayerIdx), action.PlayerIdx),
+					action.ClaimedValue,
+					action.CardCount,
+				)
 			}
-			b.WriteString("\n")
 		}
-	}
 
-	// 人間の行動履歴
-	humanAction := d.GetHumanAction()
-	if humanAction != nil {
-		fmt.Fprintf(&b, "[あなたの行動] 「%d」を%d枚出しました\n",
-			humanAction.ClaimedValue, humanAction.CardCount)
-	}
-
-	// CPUの行動履歴
-	cpuActions := d.GetCpuActions()
-	if len(cpuActions) > 0 {
-		b.WriteString("[CPUの行動]\n")
-		for _, action := range cpuActions {
-			fmt.Fprintf(&b, "%sが「%d」を%d枚出しました\n",
-				cuiPlayerName(d.GetPlayer(action.PlayerIdx), action.PlayerIdx),
-				action.ClaimedValue,
-				action.CardCount,
+		// メタAI状態
+		if profile := d.GetHumanProfile(); profile != nil {
+			fmt.Fprintf(b, "[メタAI] 適応中 (ゲーム数: %d, ブラフ率: %.0f%%, ダウト正解率: %.0f%%)\n",
+				profile.GamesPlayed,
+				profile.BluffRate(1)*100,
+				profile.DoubtAccuracy()*100,
 			)
 		}
-	}
 
-	// メタAI状態
-	if profile := d.GetHumanProfile(); profile != nil {
-		fmt.Fprintf(&b, "[メタAI] 適応中 (ゲーム数: %d, ブラフ率: %.0f%%, ダウト正解率: %.0f%%)\n",
-			profile.GamesPlayed,
-			profile.BluffRate(1)*100,
-			profile.DoubtAccuracy()*100,
-		)
-	}
-
-	// エラーメッセージ
-	if lastErr != nil {
-		fmt.Fprintf(&b, "%s\n", lastErr.Error())
-	}
-
-	// ゲーム状態
-	if d.GetGameEndFlag() {
-		winnerIdx := d.GetWinnerIdx()
-		fmt.Fprintf(&b, "ゲーム終了！ %sの勝利です！\n", cuiPlayerName(d.GetPlayer(winnerIdx), winnerIdx))
-	} else {
-		currentTurn := d.GetCurrentTurn()
-		phase := d.GetPhase()
-		if phase == domain.DoubtPhaseDoubt {
-			lastAct := d.GetLastAction()
-			if lastAct != nil {
-				fmt.Fprintf(&b, "ダウトフェーズ: %sのプレイにダウトしますか？\n",
-					cuiPlayerName(d.GetPlayer(lastAct.PlayerIdx), lastAct.PlayerIdx))
-			} else {
-				b.WriteString("ダウトフェーズ\n")
-			}
-			b.WriteString("d <idx...>・・・ダウト / s・・・スキップ\n")
-		} else {
-			fmt.Fprintf(&b, "手番: %s\n", cuiPlayerName(d.GetPlayer(currentTurn), currentTurn))
-			b.WriteString("p <値> <idx...>・・・カードを出す\n")
+		// エラーメッセージ
+		if lastErr != nil {
+			fmt.Fprintf(b, "%s\n", lastErr.Error())
 		}
-	}
 
-	b.WriteString("==========\n")
-	return b.String()
+		// ゲーム状態
+		if d.GetGameEndFlag() {
+			winnerIdx := d.GetWinnerIdx()
+			fmt.Fprintf(b, "ゲーム終了！ %sの勝利です！\n", cuiPlayerName(d.GetPlayer(winnerIdx), winnerIdx))
+		} else {
+			currentTurn := d.GetCurrentTurn()
+			phase := d.GetPhase()
+			if phase == domain.DoubtPhaseDoubt {
+				lastAct := d.GetLastAction()
+				if lastAct != nil {
+					fmt.Fprintf(b, "ダウトフェーズ: %sのプレイにダウトしますか？\n",
+						cuiPlayerName(d.GetPlayer(lastAct.PlayerIdx), lastAct.PlayerIdx))
+				} else {
+					b.WriteString("ダウトフェーズ\n")
+				}
+				b.WriteString("d <idx...>・・・ダウト / s・・・スキップ\n")
+			} else {
+				fmt.Fprintf(b, "手番: %s\n", cuiPlayerName(d.GetPlayer(currentTurn), currentTurn))
+				b.WriteString("p <値> <idx...>・・・カードを出す\n")
+			}
+		}
+	})
 }
 
 // ActionLogOutput 棋譜をテキスト出力

--- a/internal/adapter/presenter/HeartsCuiPresenter.go
+++ b/internal/adapter/presenter/HeartsCuiPresenter.go
@@ -18,93 +18,86 @@ func NewHeartsCuiPresenter() *HeartsCuiPresenter {
 
 // Output ゲーム状態を文字列出力
 func (p *HeartsCuiPresenter) Output(h interfaces.HeartsGame, lastErr error) string {
-	var b strings.Builder
+	return buildCuiOutput("Hearts (ハーツ)", func(b *strings.Builder) {
+		fmt.Fprintf(b, "ラウンド: %d  トリック: %d\n", h.GetRoundNumber(), h.GetTrickNumber())
 
-	b.WriteString("==========\n")
-	b.WriteString("Hearts (ハーツ)\n")
-	b.WriteString("==========\n")
+		if h.GetHeartsBroken() {
+			b.WriteString("ハートブレイク: あり\n")
+		} else {
+			b.WriteString("ハートブレイク: なし\n")
+		}
 
-	fmt.Fprintf(&b, "ラウンド: %d  トリック: %d\n", h.GetRoundNumber(), h.GetTrickNumber())
-
-	if h.GetHeartsBroken() {
-		b.WriteString("ハートブレイク: あり\n")
-	} else {
-		b.WriteString("ハートブレイク: なし\n")
-	}
-
-	// プレイヤー情報
-	for i := 0; i < h.GetPlayerCnt(); i++ {
-		player := h.GetPlayer(i)
-		name := cuiPlayerName(player, i)
-		fmt.Fprintf(&b, "%s: 累積%d点 ラウンド%d点 %d枚 %dトリック\n",
-			name,
-			player.GetCumulativeScore(),
-			player.GetRoundScore(),
-			player.GetCardsSize(),
-			player.GetTrickCount(),
-		)
-		if player.GetIsHuman() {
-			for j := 0; j < player.GetCardsSize(); j++ {
-				if j != 0 {
-					b.WriteString("  ")
+		// プレイヤー情報
+		for i := 0; i < h.GetPlayerCnt(); i++ {
+			player := h.GetPlayer(i)
+			name := cuiPlayerName(player, i)
+			fmt.Fprintf(b, "%s: 累積%d点 ラウンド%d点 %d枚 %dトリック\n",
+				name,
+				player.GetCumulativeScore(),
+				player.GetRoundScore(),
+				player.GetCardsSize(),
+				player.GetTrickCount(),
+			)
+			if player.GetIsHuman() {
+				for j := 0; j < player.GetCardsSize(); j++ {
+					if j != 0 {
+						b.WriteString("  ")
+					}
+					fmt.Fprintf(b, "[%d]%s", j, cuiCardStr(player.GetCard(j)))
 				}
-				fmt.Fprintf(&b, "[%d]%s", j, cuiCardStr(player.GetCard(j)))
-			}
-			if player.GetCardsSize() > 0 {
-				b.WriteString("\n")
+				if player.GetCardsSize() > 0 {
+					b.WriteString("\n")
+				}
 			}
 		}
-	}
 
-	b.WriteString("----------\n")
+		b.WriteString("----------\n")
 
-	// 現在のトリック
-	trick := h.GetCurrentTrick()
-	if len(trick) > 0 {
-		b.WriteString("トリック: ")
-		for i, tc := range trick {
-			if i != 0 {
-				b.WriteString(", ")
+		// 現在のトリック
+		trick := h.GetCurrentTrick()
+		if len(trick) > 0 {
+			b.WriteString("トリック: ")
+			for i, tc := range trick {
+				if i != 0 {
+					b.WriteString(", ")
+				}
+				player := h.GetPlayer(tc.PlayerIdx)
+				fmt.Fprintf(b, "%s=%s", cuiPlayerName(player, tc.PlayerIdx), cuiCardStr(tc.Card))
 			}
-			player := h.GetPlayer(tc.PlayerIdx)
-			fmt.Fprintf(&b, "%s=%s", cuiPlayerName(player, tc.PlayerIdx), cuiCardStr(tc.Card))
+			b.WriteString("\n")
 		}
-		b.WriteString("\n")
-	}
 
-	// エラーメッセージ
-	if lastErr != nil {
-		fmt.Fprintf(&b, "%s\n", lastErr.Error())
-	}
-
-	// ゲーム状態
-	if h.GetGameEndFlag() {
-		winnerIdx := h.GetWinnerIdx()
-		player := h.GetPlayer(winnerIdx)
-		fmt.Fprintf(&b, "ゲーム終了！ %sの勝利です！\n", cuiPlayerName(player, winnerIdx))
-	} else {
-		phase := h.GetPhase()
-		switch phase {
-		case domain.HeartsPhasePass:
-			dir := h.GetPassDirection()
-			fmt.Fprintf(&b, "パスフェーズ: %s\n", cuiPassDirectionStr(dir))
-			b.WriteString("pass <idx> <idx> <idx>・・・3枚のカードを選択\n")
-		case domain.HeartsPhasePlay:
-			currentIdx := h.GetCurrentPlayerIdx()
-			player := h.GetPlayer(currentIdx)
-			fmt.Fprintf(&b, "手番: %s\n", cuiPlayerName(player, currentIdx))
-			b.WriteString("play <idx>・・・カードを出す\n")
-		case domain.HeartsPhaseTrickEnd:
-			b.WriteString("トリック終了\n")
-			b.WriteString("next・・・次のトリックへ\n")
-		case domain.HeartsPhaseRoundEnd:
-			b.WriteString("ラウンド終了\n")
-			b.WriteString("next・・・次のラウンドへ\n")
+		// エラーメッセージ
+		if lastErr != nil {
+			fmt.Fprintf(b, "%s\n", lastErr.Error())
 		}
-	}
 
-	b.WriteString("==========\n")
-	return b.String()
+		// ゲーム状態
+		if h.GetGameEndFlag() {
+			winnerIdx := h.GetWinnerIdx()
+			player := h.GetPlayer(winnerIdx)
+			fmt.Fprintf(b, "ゲーム終了！ %sの勝利です！\n", cuiPlayerName(player, winnerIdx))
+		} else {
+			phase := h.GetPhase()
+			switch phase {
+			case domain.HeartsPhasePass:
+				dir := h.GetPassDirection()
+				fmt.Fprintf(b, "パスフェーズ: %s\n", cuiPassDirectionStr(dir))
+				b.WriteString("pass <idx> <idx> <idx>・・・3枚のカードを選択\n")
+			case domain.HeartsPhasePlay:
+				currentIdx := h.GetCurrentPlayerIdx()
+				player := h.GetPlayer(currentIdx)
+				fmt.Fprintf(b, "手番: %s\n", cuiPlayerName(player, currentIdx))
+				b.WriteString("play <idx>・・・カードを出す\n")
+			case domain.HeartsPhaseTrickEnd:
+				b.WriteString("トリック終了\n")
+				b.WriteString("next・・・次のトリックへ\n")
+			case domain.HeartsPhaseRoundEnd:
+				b.WriteString("ラウンド終了\n")
+				b.WriteString("next・・・次のラウンドへ\n")
+			}
+		}
+	})
 }
 
 // ActionLogOutput 棋譜をテキスト出力

--- a/internal/adapter/presenter/KlondikeCuiPresenter.go
+++ b/internal/adapter/presenter/KlondikeCuiPresenter.go
@@ -18,83 +18,76 @@ func NewKlondikeCuiPresenter() *KlondikeCuiPresenter {
 
 // Output ゲーム状態を文字列出力
 func (p *KlondikeCuiPresenter) Output(k interfaces.KlondikeGame, lastErr error) string {
-	var b strings.Builder
-
-	b.WriteString("==========\n")
-	b.WriteString("Klondike (ソリティア)\n")
-	b.WriteString("==========\n")
-
-	// ファンデーション
-	b.WriteString("Foundation: ")
-	foundation := k.GetFoundation()
-	for i := 0; i < domain.KlondikeFoundationCnt; i++ {
-		if i != 0 {
-			b.WriteString(" | ")
-		}
-		pile := foundation[i]
-		if len(pile) == 0 {
-			b.WriteString("[空]")
-		} else {
-			topCard := pile[len(pile)-1]
-			b.WriteString(cuiCardStr(topCard))
-		}
-	}
-	b.WriteString("\n")
-
-	// ストックとウェイスト
-	fmt.Fprintf(&b, "Stock: %d枚", k.GetStockCount())
-	waste := k.GetWaste()
-	if len(waste) > 0 {
-		fmt.Fprintf(&b, " | Waste: %s", cuiCardStr(waste[len(waste)-1]))
-	} else {
-		b.WriteString(" | Waste: [空]")
-	}
-	b.WriteString("\n")
-
-	b.WriteString("----------\n")
-
-	// タブロー
-	tableau := k.GetTableau()
-	for col := 0; col < domain.KlondikeTableauCnt; col++ {
-		fmt.Fprintf(&b, "列%d:", col)
-		colCards := tableau[col]
-		if len(colCards) == 0 {
-			b.WriteString(" [空]")
-		} else {
-			for j, tc := range colCards {
-				if j != 0 {
-					b.WriteString(" ")
-				}
-				if tc.FaceUp {
-					fmt.Fprintf(&b, " [%d]%s", j, cuiCardStr(tc.Card))
-				} else {
-					fmt.Fprintf(&b, " [%d]??", j)
-				}
+	return buildCuiOutput("Klondike (ソリティア)", func(b *strings.Builder) {
+		// ファンデーション
+		b.WriteString("Foundation: ")
+		foundation := k.GetFoundation()
+		for i := 0; i < domain.KlondikeFoundationCnt; i++ {
+			if i != 0 {
+				b.WriteString(" | ")
+			}
+			pile := foundation[i]
+			if len(pile) == 0 {
+				b.WriteString("[空]")
+			} else {
+				topCard := pile[len(pile)-1]
+				b.WriteString(cuiCardStr(topCard))
 			}
 		}
 		b.WriteString("\n")
-	}
 
-	b.WriteString("----------\n")
+		// ストックとウェイスト
+		fmt.Fprintf(b, "Stock: %d枚", k.GetStockCount())
+		waste := k.GetWaste()
+		if len(waste) > 0 {
+			fmt.Fprintf(b, " | Waste: %s", cuiCardStr(waste[len(waste)-1]))
+		} else {
+			b.WriteString(" | Waste: [空]")
+		}
+		b.WriteString("\n")
 
-	// エラーメッセージ
-	if lastErr != nil {
-		fmt.Fprintf(&b, "%s\n", lastErr.Error())
-	}
+		b.WriteString("----------\n")
 
-	// ゲーム状態
-	phase := k.GetPhase()
-	switch phase {
-	case domain.KlondikePhasePlaying:
-		fmt.Fprintf(&b, "手数: %d\n", k.GetMoveCount())
-	case domain.KlondikePhaseGameClear:
-		fmt.Fprintf(&b, "ゲームクリア！ 手数: %d\n", k.GetMoveCount())
-	case domain.KlondikePhaseGameOver:
-		b.WriteString("ゲームオーバー\n")
-	}
+		// タブロー
+		tableau := k.GetTableau()
+		for col := 0; col < domain.KlondikeTableauCnt; col++ {
+			fmt.Fprintf(b, "列%d:", col)
+			colCards := tableau[col]
+			if len(colCards) == 0 {
+				b.WriteString(" [空]")
+			} else {
+				for j, tc := range colCards {
+					if j != 0 {
+						b.WriteString(" ")
+					}
+					if tc.FaceUp {
+						fmt.Fprintf(b, " [%d]%s", j, cuiCardStr(tc.Card))
+					} else {
+						fmt.Fprintf(b, " [%d]??", j)
+					}
+				}
+			}
+			b.WriteString("\n")
+		}
 
-	b.WriteString("==========\n")
-	return b.String()
+		b.WriteString("----------\n")
+
+		// エラーメッセージ
+		if lastErr != nil {
+			fmt.Fprintf(b, "%s\n", lastErr.Error())
+		}
+
+		// ゲーム状態
+		phase := k.GetPhase()
+		switch phase {
+		case domain.KlondikePhasePlaying:
+			fmt.Fprintf(b, "手数: %d\n", k.GetMoveCount())
+		case domain.KlondikePhaseGameClear:
+			fmt.Fprintf(b, "ゲームクリア！ 手数: %d\n", k.GetMoveCount())
+		case domain.KlondikePhaseGameOver:
+			b.WriteString("ゲームオーバー\n")
+		}
+	})
 }
 
 // HintOutput ヒントを文字列出力

--- a/internal/adapter/presenter/MemoryCuiPresenter.go
+++ b/internal/adapter/presenter/MemoryCuiPresenter.go
@@ -18,77 +18,70 @@ func NewMemoryCuiPresenter() *MemoryCuiPresenter {
 
 // Output ゲーム状態を文字列出力
 func (p *MemoryCuiPresenter) Output(m interfaces.MemoryGame, lastErr error) string {
-	var b strings.Builder
+	return buildCuiOutput("Memory (神経衰弱)", func(b *strings.Builder) {
+		// プレイヤー情報
+		for i := 0; i < m.GetPlayerCnt(); i++ {
+			player := m.GetPlayer(i)
+			name := cuiPlayerName(player, i)
+			fmt.Fprintf(b, "%s: %dペア\n", name, player.GetPairCount())
+		}
 
-	b.WriteString("==========\n")
-	b.WriteString("Memory (神経衰弱)\n")
-	b.WriteString("==========\n")
+		b.WriteString("----------\n")
 
-	// プレイヤー情報
-	for i := 0; i < m.GetPlayerCnt(); i++ {
-		player := m.GetPlayer(i)
-		name := cuiPlayerName(player, i)
-		fmt.Fprintf(&b, "%s: %dペア\n", name, player.GetPairCount())
-	}
-
-	b.WriteString("----------\n")
-
-	// ボードを4×13グリッドで表示
-	board := m.GetBoard()
-	for row := 0; row < 4; row++ {
-		for col := 0; col < 13; col++ {
-			pos := row*13 + col
-			if col != 0 {
-				b.WriteString(" ")
+		// ボードを4×13グリッドで表示
+		board := m.GetBoard()
+		for row := 0; row < 4; row++ {
+			for col := 0; col < 13; col++ {
+				pos := row*13 + col
+				if col != 0 {
+					b.WriteString(" ")
+				}
+				bc := board[pos]
+				if bc.Taken {
+					fmt.Fprintf(b, "[%2d]%-10s", pos, "")
+				} else if bc.FaceUp {
+					fmt.Fprintf(b, "[%2d]%-10s", pos, cuiCardStr(bc.Card))
+				} else {
+					fmt.Fprintf(b, "[%2d]%-10s", pos, "??")
+				}
 			}
-			bc := board[pos]
-			if bc.Taken {
-				fmt.Fprintf(&b, "[%2d]%-10s", pos, "")
-			} else if bc.FaceUp {
-				fmt.Fprintf(&b, "[%2d]%-10s", pos, cuiCardStr(bc.Card))
-			} else {
-				fmt.Fprintf(&b, "[%2d]%-10s", pos, "??")
+			b.WriteString("\n")
+		}
+
+		b.WriteString("----------\n")
+
+		// エラーメッセージ
+		if lastErr != nil {
+			fmt.Fprintf(b, "%s\n", lastErr.Error())
+		}
+
+		// ゲーム状態
+		if m.GetGameEndFlag() {
+			winnerIdx := m.GetWinnerIdx()
+			player := m.GetPlayer(winnerIdx)
+			fmt.Fprintf(b, "ゲーム終了！ %sの勝利です！\n", cuiPlayerName(player, winnerIdx))
+		} else {
+			phase := m.GetPhase()
+			currentIdx := m.GetCurrentPlayerIdx()
+			player := m.GetPlayer(currentIdx)
+			playerStr := cuiPlayerName(player, currentIdx)
+			switch phase {
+			case domain.MemoryPhaseFlip1:
+				fmt.Fprintf(b, "手番: %s — 1枚目を選んでください\n", playerStr)
+				b.WriteString("f <pos>・・・カードをめくる\n")
+			case domain.MemoryPhaseFlip2:
+				fmt.Fprintf(b, "手番: %s — 2枚目を選んでください\n", playerStr)
+				b.WriteString("f <pos>・・・カードをめくる\n")
+			case domain.MemoryPhaseResult:
+				if m.GetLastMatchResult() {
+					b.WriteString("ペアが揃いました！\n")
+				} else {
+					b.WriteString("残念、不一致です。\n")
+				}
+				b.WriteString("n・・・次へ\n")
 			}
 		}
-		b.WriteString("\n")
-	}
-
-	b.WriteString("----------\n")
-
-	// エラーメッセージ
-	if lastErr != nil {
-		fmt.Fprintf(&b, "%s\n", lastErr.Error())
-	}
-
-	// ゲーム状態
-	if m.GetGameEndFlag() {
-		winnerIdx := m.GetWinnerIdx()
-		player := m.GetPlayer(winnerIdx)
-		fmt.Fprintf(&b, "ゲーム終了！ %sの勝利です！\n", cuiPlayerName(player, winnerIdx))
-	} else {
-		phase := m.GetPhase()
-		currentIdx := m.GetCurrentPlayerIdx()
-		player := m.GetPlayer(currentIdx)
-		playerStr := cuiPlayerName(player, currentIdx)
-		switch phase {
-		case domain.MemoryPhaseFlip1:
-			fmt.Fprintf(&b, "手番: %s — 1枚目を選んでください\n", playerStr)
-			b.WriteString("f <pos>・・・カードをめくる\n")
-		case domain.MemoryPhaseFlip2:
-			fmt.Fprintf(&b, "手番: %s — 2枚目を選んでください\n", playerStr)
-			b.WriteString("f <pos>・・・カードをめくる\n")
-		case domain.MemoryPhaseResult:
-			if m.GetLastMatchResult() {
-				b.WriteString("ペアが揃いました！\n")
-			} else {
-				b.WriteString("残念、不一致です。\n")
-			}
-			b.WriteString("n・・・次へ\n")
-		}
-	}
-
-	b.WriteString("==========\n")
-	return b.String()
+	})
 }
 
 // ActionLogOutput 棋譜をテキスト出力

--- a/internal/adapter/presenter/OldMaidCuiPresenter.go
+++ b/internal/adapter/presenter/OldMaidCuiPresenter.go
@@ -18,134 +18,127 @@ func NewOldMaidCuiPresenter() *OldMaidCuiPresenter {
 
 // Output ゲーム状態を文字列出力
 func (p *OldMaidCuiPresenter) Output(om interfaces.OldMaidGame, lastErr error) string {
-	var b strings.Builder
-
-	b.WriteString("==========\n")
+	title := "Old Maid (ババ抜き)"
 	if om.GetConfig().Mode == domain.OldMaidModeJijiNuki {
-		b.WriteString("Old Maid (ジジ抜き)\n")
-	} else {
-		b.WriteString("Old Maid (ババ抜き)\n")
+		title = "Old Maid (ジジ抜き)"
 	}
-	b.WriteString("==========\n")
-
-	for i := 0; i < om.GetPlayerCnt(); i++ {
-		player := om.GetPlayer(i)
-		if player.GetIsHuman() {
-			b.WriteString("[You]")
-		} else {
-			fmt.Fprintf(&b, "CPU %d", i)
-		}
-		if player.GetIsFinished() {
-			b.WriteString(": 上がり\n")
-		} else {
-			fmt.Fprintf(&b, ": %d枚\n", player.GetCardsSize())
+	return buildCuiOutput(title, func(b *strings.Builder) {
+		for i := 0; i < om.GetPlayerCnt(); i++ {
+			player := om.GetPlayer(i)
 			if player.GetIsHuman() {
-				for j := 0; j < player.GetCardsSize(); j++ {
-					if j != 0 {
-						b.WriteString("  ")
+				b.WriteString("[You]")
+			} else {
+				fmt.Fprintf(b, "CPU %d", i)
+			}
+			if player.GetIsFinished() {
+				b.WriteString(": 上がり\n")
+			} else {
+				fmt.Fprintf(b, ": %d枚\n", player.GetCardsSize())
+				if player.GetIsHuman() {
+					for j := 0; j < player.GetCardsSize(); j++ {
+						if j != 0 {
+							b.WriteString("  ")
+						}
+						fmt.Fprintf(b, "[%d]%s", j, cuiCardStr(player.GetCard(j)))
 					}
-					fmt.Fprintf(&b, "[%d]%s", j, cuiCardStr(player.GetCard(j)))
+					b.WriteString("\n")
+				}
+			}
+		}
+
+		b.WriteString("----------\n")
+
+		if om.GetHasDrawn() {
+			drawPlayerIdx := om.GetLastDrawPlayerIdx()
+			drawFromIdx := om.GetLastDrawFromIdx()
+			discarded := om.GetLastDiscardedPairs()
+			drawPlayerName := cuiPlayerName(om.GetPlayer(drawPlayerIdx), drawPlayerIdx)
+			drawFromName := cuiPlayerName(om.GetPlayer(drawFromIdx), drawFromIdx)
+			drawnCard := om.GetLastDrawCard()
+			drawPlayer := om.GetPlayer(drawPlayerIdx)
+			fmt.Fprintf(b, "%sが%sから1枚引きました", drawPlayerName, drawFromName)
+			// Only reveal drawn card for human players to preserve CPU game fairness
+			if drawnCard != nil && drawPlayer != nil && drawPlayer.GetIsHuman() {
+				fmt.Fprintf(b, " (%s)", cuiCardStr(drawnCard))
+			}
+			if discarded > 0 {
+				fmt.Fprintf(b, "。%d組捨てました", discarded)
+			}
+			b.WriteString("\n")
+		}
+
+		// CPUの行動履歴を表示
+		cpuActions := om.GetCpuActions()
+		if len(cpuActions) > 0 {
+			b.WriteString("[CPUの行動]\n")
+			for _, action := range cpuActions {
+				actPlayerName := cuiPlayerName(om.GetPlayer(action.DrawPlayerIdx), action.DrawPlayerIdx)
+				actFromName := cuiPlayerName(om.GetPlayer(action.DrawFromIdx), action.DrawFromIdx)
+				fmt.Fprintf(b, "%sが%sから1枚引きました", actPlayerName, actFromName)
+				// CPU drawn card is intentionally hidden to preserve game fairness
+				if action.DiscardedPairs > 0 {
+					fmt.Fprintf(b, "。%d組捨てました", action.DiscardedPairs)
 				}
 				b.WriteString("\n")
 			}
 		}
-	}
 
-	b.WriteString("----------\n")
-
-	if om.GetHasDrawn() {
-		drawPlayerIdx := om.GetLastDrawPlayerIdx()
-		drawFromIdx := om.GetLastDrawFromIdx()
-		discarded := om.GetLastDiscardedPairs()
-		drawPlayerName := cuiPlayerName(om.GetPlayer(drawPlayerIdx), drawPlayerIdx)
-		drawFromName := cuiPlayerName(om.GetPlayer(drawFromIdx), drawFromIdx)
-		drawnCard := om.GetLastDrawCard()
-		drawPlayer := om.GetPlayer(drawPlayerIdx)
-		fmt.Fprintf(&b, "%sが%sから1枚引きました", drawPlayerName, drawFromName)
-		// Only reveal drawn card for human players to preserve CPU game fairness
-		if drawnCard != nil && drawPlayer != nil && drawPlayer.GetIsHuman() {
-			fmt.Fprintf(&b, " (%s)", cuiCardStr(drawnCard))
-		}
-		if discarded > 0 {
-			fmt.Fprintf(&b, "。%d組捨てました", discarded)
-		}
-		b.WriteString("\n")
-	}
-
-	// CPUの行動履歴を表示
-	cpuActions := om.GetCpuActions()
-	if len(cpuActions) > 0 {
-		b.WriteString("[CPUの行動]\n")
-		for _, action := range cpuActions {
-			actPlayerName := cuiPlayerName(om.GetPlayer(action.DrawPlayerIdx), action.DrawPlayerIdx)
-			actFromName := cuiPlayerName(om.GetPlayer(action.DrawFromIdx), action.DrawFromIdx)
-			fmt.Fprintf(&b, "%sが%sから1枚引きました", actPlayerName, actFromName)
-			// CPU drawn card is intentionally hidden to preserve game fairness
-			if action.DiscardedPairs > 0 {
-				fmt.Fprintf(&b, "。%d組捨てました", action.DiscardedPairs)
+		// 引き履歴
+		drawHistory := om.GetDrawHistory()
+		if len(drawHistory) > 0 {
+			b.WriteString("[引き履歴]\n")
+			for i, entry := range drawHistory {
+				drawerName := cuiPlayerName(om.GetPlayer(entry.DrawPlayerIdx), entry.DrawPlayerIdx)
+				fromName := cuiPlayerName(om.GetPlayer(entry.DrawFromIdx), entry.DrawFromIdx)
+				fmt.Fprintf(b, "%d. %sが%sから引いた", i+1, drawerName, fromName)
+				if entry.DiscardedPairs > 0 {
+					fmt.Fprintf(b, " (%d組捨て)", entry.DiscardedPairs)
+				}
+				if entry.DrawerFinished {
+					fmt.Fprintf(b, " [%s上がり]", drawerName)
+				}
+				if entry.TargetFinished {
+					fmt.Fprintf(b, " [%s上がり]", fromName)
+				}
+				b.WriteString("\n")
 			}
-			b.WriteString("\n")
 		}
-	}
 
-	// 引き履歴
-	drawHistory := om.GetDrawHistory()
-	if len(drawHistory) > 0 {
-		b.WriteString("[引き履歴]\n")
-		for i, entry := range drawHistory {
-			drawerName := cuiPlayerName(om.GetPlayer(entry.DrawPlayerIdx), entry.DrawPlayerIdx)
-			fromName := cuiPlayerName(om.GetPlayer(entry.DrawFromIdx), entry.DrawFromIdx)
-			fmt.Fprintf(&b, "%d. %sが%sから引いた", i+1, drawerName, fromName)
-			if entry.DiscardedPairs > 0 {
-				fmt.Fprintf(&b, " (%d組捨て)", entry.DiscardedPairs)
-			}
-			if entry.DrawerFinished {
-				fmt.Fprintf(&b, " [%s上がり]", drawerName)
-			}
-			if entry.TargetFinished {
-				fmt.Fprintf(&b, " [%s上がり]", fromName)
-			}
-			b.WriteString("\n")
+		// メタAI状態
+		if profile := om.GetHumanProfile(); profile != nil {
+			fmt.Fprintf(b, "[メタAI] 適応中 (ゲーム数: %d, 端ピック率: %.0f%%)\n",
+				profile.GamesPlayed,
+				(profile.PickRate(0)+profile.PickRate(2))*100,
+			)
 		}
-	}
 
-	// メタAI状態
-	if profile := om.GetHumanProfile(); profile != nil {
-		fmt.Fprintf(&b, "[メタAI] 適応中 (ゲーム数: %d, 端ピック率: %.0f%%)\n",
-			profile.GamesPlayed,
-			(profile.PickRate(0)+profile.PickRate(2))*100,
-		)
-	}
-
-	// エラーメッセージ
-	if lastErr != nil {
-		fmt.Fprintf(&b, "%s\n", lastErr.Error())
-	}
-
-	if om.GetGameEndFlag() {
-		loserIdx := om.GetLoserIdx()
-		if loserIdx >= 0 {
-			loserName := cuiPlayerName(om.GetPlayer(loserIdx), loserIdx)
-			gameEndLine := fmt.Sprintf("ゲーム終了！ %sの負け！", loserName)
-			if om.GetConfig().Mode == domain.OldMaidModeJijiNuki && om.GetRemovedCard() != nil {
-				gameEndLine += fmt.Sprintf("（除外カード: %s）", cuiCardStr(om.GetRemovedCard()))
-			}
-			fmt.Fprintf(&b, "%s\n", gameEndLine)
+		// エラーメッセージ
+		if lastErr != nil {
+			fmt.Fprintf(b, "%s\n", lastErr.Error())
 		}
-	} else {
-		currentTurn := om.GetCurrentTurn()
-		currentName := cuiPlayerName(om.GetPlayer(currentTurn), currentTurn)
-		targetIdx := om.GetNextDrawTargetIdx()
-		if targetIdx >= 0 {
-			targetName := cuiPlayerName(om.GetPlayer(targetIdx), targetIdx)
-			fmt.Fprintf(&b, "手番: %s → %sから引きます\n", currentName, targetName)
+
+		if om.GetGameEndFlag() {
+			loserIdx := om.GetLoserIdx()
+			if loserIdx >= 0 {
+				loserName := cuiPlayerName(om.GetPlayer(loserIdx), loserIdx)
+				gameEndLine := fmt.Sprintf("ゲーム終了！ %sの負け！", loserName)
+				if om.GetConfig().Mode == domain.OldMaidModeJijiNuki && om.GetRemovedCard() != nil {
+					gameEndLine += fmt.Sprintf("（除外カード: %s）", cuiCardStr(om.GetRemovedCard()))
+				}
+				fmt.Fprintf(b, "%s\n", gameEndLine)
+			}
 		} else {
-			fmt.Fprintf(&b, "手番: %s\n", currentName)
+			currentTurn := om.GetCurrentTurn()
+			currentName := cuiPlayerName(om.GetPlayer(currentTurn), currentTurn)
+			targetIdx := om.GetNextDrawTargetIdx()
+			if targetIdx >= 0 {
+				targetName := cuiPlayerName(om.GetPlayer(targetIdx), targetIdx)
+				fmt.Fprintf(b, "手番: %s → %sから引きます\n", currentName, targetName)
+			} else {
+				fmt.Fprintf(b, "手番: %s\n", currentName)
+			}
 		}
-	}
-
-	b.WriteString("==========\n")
-	return b.String()
+	})
 }
 
 // ActionLogOutput 棋譜をテキスト出力

--- a/internal/adapter/presenter/cui_output_helper.go
+++ b/internal/adapter/presenter/cui_output_helper.go
@@ -1,0 +1,21 @@
+package presenter
+
+import "strings"
+
+// buildCuiOutput constructs a CUI output string with a standard "==========" header block and footer.
+// The output format is:
+//
+//	==========
+//	<title>
+//	==========
+//	<content from buildContent>
+//	==========
+func buildCuiOutput(title string, buildContent func(b *strings.Builder)) string {
+	var b strings.Builder
+	b.WriteString("==========\n")
+	b.WriteString(title + "\n")
+	b.WriteString("==========\n")
+	buildContent(&b)
+	b.WriteString("==========\n")
+	return b.String()
+}

--- a/internal/adapter/presenter/cui_output_helper_test.go
+++ b/internal/adapter/presenter/cui_output_helper_test.go
@@ -1,0 +1,25 @@
+//go:build test
+// +build test
+
+package presenter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildCuiOutput(t *testing.T) {
+	t.Run("wraps content with header and footer", func(t *testing.T) {
+		result := buildCuiOutput("Test Game", func(b *strings.Builder) {
+			b.WriteString("some content\n")
+		})
+		assert.Equal(t, "==========\nTest Game\n==========\nsome content\n==========\n", result)
+	})
+
+	t.Run("empty content", func(t *testing.T) {
+		result := buildCuiOutput("Empty", func(b *strings.Builder) {})
+		assert.Equal(t, "==========\nEmpty\n==========\n==========\n", result)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `buildCuiOutput(title string, buildContent func(b *strings.Builder)) string` helper in `cui_output_helper.go`
- Refactors 6 CUI presenters (Daifugo, Doubt, Hearts, Memory, Klondike, OldMaid) to use the helper, eliminating the repeated 3-line `==========` header block and footer line from each `Output` method
- OldMaid uses a dynamically computed title based on game mode
- The remaining 5 presenters (Sevens, Poker, Holdem, BlackJack, Baccarat) have structurally different patterns (complex conditional headers, no footer, or `----------` dividers) and are not refactored

## Test plan

- [x] `buildCuiOutput` is tested directly in `cui_output_helper_test.go`
- [x] All existing presenter tests continue to pass (`go test -tags test ./...`)
- [x] Branch coverage (C1) maintained at 100% for the presenter package

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)