### PR TITLE
refactor: unify deref helpers into generic deref/derefDefault

### DIFF
--- a/internal/adapter/controller/BaccaratWebController.go
+++ b/internal/adapter/controller/BaccaratWebController.go
@@ -51,7 +51,7 @@ func baccaratDispatch(bc *baseController, w rest.ResponseWriter, bi usecase.Bacc
 	case "r", "reset":
 		bc.writePresenterResponse(w, bi.Reset())
 	case "b", "bet":
-		bt := derefInt(param.BetType)
+		bt := deref(param.BetType)
 		bc.writePresenterResponse(w, bi.Bet(param.Amount, bt))
 	case "log", "l":
 		bc.writePresenterResponse(w, bi.ActionLog())

--- a/internal/adapter/controller/BlackJackWebController.go
+++ b/internal/adapter/controller/BlackJackWebController.go
@@ -112,13 +112,13 @@ func blackJackDispatch(bc *baseController, w rest.ResponseWriter, bji usecase.Bl
 	switch param.Command {
 	case "r", "reset":
 		if param.DealerHitsSoft17 != nil || param.CpuPlayerCount != nil || param.CountingEnabled != nil || param.DoubleAfterSplit != nil || param.CountingSystem != nil || param.DeckPenetration != nil || param.SurrenderRule != nil {
-			h17 := derefBool(param.DealerHitsSoft17)
-			cpuCount := derefInt(param.CpuPlayerCount)
-			counting := derefBool(param.CountingEnabled)
-			das := derefBoolDefault(param.DoubleAfterSplit, true)
-			cs := derefInt(param.CountingSystem)
-			dp := derefInt(param.DeckPenetration)
-			sr := derefInt(param.SurrenderRule)
+			h17 := deref(param.DealerHitsSoft17)
+			cpuCount := deref(param.CpuPlayerCount)
+			counting := deref(param.CountingEnabled)
+			das := derefDefault(param.DoubleAfterSplit, true)
+			cs := deref(param.CountingSystem)
+			dp := deref(param.DeckPenetration)
+			sr := deref(param.SurrenderRule)
 			bc.writePresenterResponse(w, bji.ResetWithConfig(h17, cpuCount, counting, das, cs, dp, sr))
 		} else {
 			bc.writePresenterResponse(w, bji.Reset())
@@ -128,9 +128,9 @@ func blackJackDispatch(bc *baseController, w rest.ResponseWriter, bji usecase.Bl
 	case "s", "stand":
 		bc.writePresenterResponse(w, bji.Stand())
 	case "b", "bet":
-		ppBet := derefInt(param.PerfectPairsBet)
-		t3Bet := derefInt(param.TwentyOnePlus3Bet)
-		hc := derefInt(param.HandCount)
+		ppBet := deref(param.PerfectPairsBet)
+		t3Bet := deref(param.TwentyOnePlus3Bet)
+		hc := deref(param.HandCount)
 		bc.writePresenterResponse(w, bji.Bet(param.Amount, ppBet, t3Bet, hc))
 	case "d", "doubledown":
 		bc.writePresenterResponse(w, bji.DoubleDown())

--- a/internal/adapter/controller/OldMaidWebController.go
+++ b/internal/adapter/controller/OldMaidWebController.go
@@ -117,7 +117,7 @@ func oldMaidDispatch(bc *baseController, w rest.ResponseWriter, omi usecase.OldM
 	case "rp", "reset-profile":
 		bc.writePresenterResponse(w, omi.ResetProfile())
 	case "d", "draw":
-		drawIdx := derefIntDefault(param.DrawIdx, -1)
+		drawIdx := derefDefault(param.DrawIdx, -1)
 		bc.writePresenterResponse(w, omi.Draw(drawIdx))
 	case "s", "shuffle":
 		bc.writePresenterResponse(w, omi.Shuffle())

--- a/internal/adapter/controller/SevensWebController.go
+++ b/internal/adapter/controller/SevensWebController.go
@@ -96,15 +96,15 @@ func sevensDispatch(bc *baseController, w rest.ResponseWriter, sgi usecase.Seven
 	case "r", "reset":
 		if param.TunnelEnabled != nil || param.TunnelSkipWidth != nil || param.JokerCount != nil || param.CpuStrategy != nil || param.MaxPasses != nil || param.NoJokerFinish != nil || param.JokerReclaim != nil || param.EndStop != nil || param.JokerConsecutiveBanned != nil {
 			cfg := domain.SevensConfig{
-				TunnelEnabled:          derefBool(param.TunnelEnabled),
-				TunnelSkipWidth:        derefInt(param.TunnelSkipWidth),
-				JokerCount:             derefInt(param.JokerCount),
-				CpuStrategy:            derefInt(param.CpuStrategy),
-				MaxPasses:              derefIntDefault(param.MaxPasses, domain.SevensMaxPasses),
-				NoJokerFinish:          derefBool(param.NoJokerFinish),
-				JokerReclaimEnabled:    derefBool(param.JokerReclaim),
-				EndStopEnabled:         derefBool(param.EndStop),
-				JokerConsecutiveBanned: derefBool(param.JokerConsecutiveBanned),
+				TunnelEnabled:          deref(param.TunnelEnabled),
+				TunnelSkipWidth:        deref(param.TunnelSkipWidth),
+				JokerCount:             deref(param.JokerCount),
+				CpuStrategy:            deref(param.CpuStrategy),
+				MaxPasses:              derefDefault(param.MaxPasses, domain.SevensMaxPasses),
+				NoJokerFinish:          deref(param.NoJokerFinish),
+				JokerReclaimEnabled:    deref(param.JokerReclaim),
+				EndStopEnabled:         deref(param.EndStop),
+				JokerConsecutiveBanned: deref(param.JokerConsecutiveBanned),
 			}
 			bc.writePresenterResponse(w, sgi.ResetWithConfig(cfg))
 		} else {

--- a/internal/adapter/controller/base_controller.go
+++ b/internal/adapter/controller/base_controller.go
@@ -29,28 +29,15 @@ func (b BaseWebInput) GetSessionID() string { return b.SessionID }
 // baseController 各WebController共通のレスポンス書き込みロジック
 type baseController struct{}
 
-func derefBool(p *bool) bool {
+func deref[T any](p *T) T {
+	var zero T
 	if p == nil {
-		return false
+		return zero
 	}
 	return *p
 }
 
-func derefBoolDefault(p *bool, defaultVal bool) bool {
-	if p == nil {
-		return defaultVal
-	}
-	return *p
-}
-
-func derefInt(p *int) int {
-	if p == nil {
-		return 0
-	}
-	return *p
-}
-
-func derefIntDefault(p *int, defaultVal int) int {
+func derefDefault[T any](p *T, defaultVal T) T {
 	if p == nil {
 		return defaultVal
 	}

--- a/internal/adapter/controller/base_controller_internal_test.go
+++ b/internal/adapter/controller/base_controller_internal_test.go
@@ -13,46 +13,40 @@ import (
 
 // --- deref helper tests ---
 
-func TestDerefBool(t *testing.T) {
-	t.Run("nil returns false", func(t *testing.T) {
-		assert.False(t, derefBool(nil))
+func TestDeref(t *testing.T) {
+	t.Run("bool nil returns zero", func(t *testing.T) {
+		assert.False(t, deref[bool](nil))
 	})
-	t.Run("non-nil returns value", func(t *testing.T) {
+	t.Run("bool non-nil returns value", func(t *testing.T) {
 		v := true
-		assert.True(t, derefBool(&v))
+		assert.True(t, deref(&v))
 	})
-}
-
-func TestDerefBoolDefault(t *testing.T) {
-	t.Run("nil returns default true", func(t *testing.T) {
-		assert.True(t, derefBoolDefault(nil, true))
+	t.Run("int nil returns zero", func(t *testing.T) {
+		assert.Equal(t, 0, deref[int](nil))
 	})
-	t.Run("nil returns default false", func(t *testing.T) {
-		assert.False(t, derefBoolDefault(nil, false))
-	})
-	t.Run("non-nil returns value", func(t *testing.T) {
-		v := false
-		assert.False(t, derefBoolDefault(&v, true))
-	})
-}
-
-func TestDerefInt(t *testing.T) {
-	t.Run("nil returns 0", func(t *testing.T) {
-		assert.Equal(t, 0, derefInt(nil))
-	})
-	t.Run("non-nil returns value", func(t *testing.T) {
+	t.Run("int non-nil returns value", func(t *testing.T) {
 		v := 42
-		assert.Equal(t, 42, derefInt(&v))
+		assert.Equal(t, 42, deref(&v))
 	})
 }
 
-func TestDerefIntDefault(t *testing.T) {
-	t.Run("nil returns default", func(t *testing.T) {
-		assert.Equal(t, 99, derefIntDefault(nil, 99))
+func TestDerefDefault(t *testing.T) {
+	t.Run("bool nil returns default true", func(t *testing.T) {
+		assert.True(t, derefDefault[bool](nil, true))
 	})
-	t.Run("non-nil returns value", func(t *testing.T) {
+	t.Run("bool nil returns default false", func(t *testing.T) {
+		assert.False(t, derefDefault[bool](nil, false))
+	})
+	t.Run("bool non-nil returns value", func(t *testing.T) {
+		v := false
+		assert.False(t, derefDefault(&v, true))
+	})
+	t.Run("int nil returns default", func(t *testing.T) {
+		assert.Equal(t, 99, derefDefault[int](nil, 99))
+	})
+	t.Run("int non-nil returns value", func(t *testing.T) {
 		v := 7
-		assert.Equal(t, 7, derefIntDefault(&v, 99))
+		assert.Equal(t, 7, derefDefault(&v, 99))
 	})
 }
 


### PR DESCRIPTION
## Summary

- Replace `derefBool`, `derefBoolDefault`, `derefInt`, `derefIntDefault` (4 typed functions) with two generic functions `deref[T any]` and `derefDefault[T any]`
- Update all callers: `BlackJackWebController`, `SevensWebController`, `OldMaidWebController`, `BaccaratWebController`
- Consolidate 4 test functions into 2, each covering both `bool` and `int` cases

Closes #485

## Test plan

- [ ] `go test -tags test ./internal/adapter/controller/...` passes
- [ ] `go test -tags test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)