### PR TITLE
fix: fetch tags after bump step so GoReleaser can validate locally

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -17,6 +17,8 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ github.token }}
+      - name: Fetch new tag
+        run: git fetch --tags
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod


### PR DESCRIPTION
## Summary

- `mathieudutour/github-tag-action` pushes the new tag to the remote via the GitHub API, but the local git checkout in the Actions runner does not have it
- GoReleaser validates that the tag exists locally and points to HEAD — this check was failing because the tag was remote-only
- Added `git fetch --tags` between the bump step and GoReleaser to make the newly created tag available locally before GoReleaser runs

Fixes the failure in https://github.com/yuta-yoshinaga/go_trumpcards/actions/runs/22944928421/job/66594841086

## Test plan

- [ ] Merge to `develop` → merge to `master` → verify the "Bump version" workflow completes successfully end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)