### PR TITLE
fix(web): add explicit id/htmlFor association to form labels

### DIFF
--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -64,9 +64,10 @@ export function DoubtPage() {
       <details className="px-4 pt-2">
         <summary className="text-white/70 text-xs cursor-pointer select-none">{t('settings.title')}</summary>
         <div className="bg-black/30 rounded-lg p-3 mt-1 flex flex-wrap gap-4 text-sm text-white">
-          <label className="flex items-center gap-2">
+          <label htmlFor="doubtWindowSec" className="flex items-center gap-2">
             {t('settings.doubtTime')}
             <select
+              id="doubtWindowSec"
               className="bg-black/50 text-white rounded px-2 py-1 border border-white/30"
               value={doubtConfig.doubtWindowSec}
               onChange={(e) => handleConfigChange('doubtWindowSec', e.target.value)}
@@ -78,9 +79,10 @@ export function DoubtPage() {
               ))}
             </select>
           </label>
-          <label className="flex items-center gap-2">
+          <label htmlFor="cpuMemoryLevel" className="flex items-center gap-2">
             {t('settings.cpuMemory')}
             <select
+              id="cpuMemoryLevel"
               className="bg-black/50 text-white rounded px-2 py-1 border border-white/30"
               value={doubtConfig.cpuMemoryLevel}
               onChange={(e) => handleConfigChange('cpuMemoryLevel', e.target.value)}
@@ -92,9 +94,10 @@ export function DoubtPage() {
               ))}
             </select>
           </label>
-          <label className="flex items-center gap-2">
+          <label htmlFor="penaltyDrawLimit" className="flex items-center gap-2">
             {t('settings.penaltyDrawLimit')}
             <select
+              id="penaltyDrawLimit"
               className="bg-black/50 text-white rounded px-2 py-1 border border-white/30"
               value={doubtConfig.penaltyDrawLimit}
               onChange={(e) => handleConfigChange('penaltyDrawLimit', e.target.value)}

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -32,9 +32,10 @@ export function MemoryPage() {
       <details className="px-4 pt-2">
         <summary className="text-white/70 text-sm cursor-pointer">{t('settings.title')}</summary>
         <div className="mt-2 flex flex-wrap gap-4 text-sm text-white/70">
-          <label>
+          <label htmlFor="cpuDifficulty">
             {t('settings.cpuDifficulty')}
             <select
+              id="cpuDifficulty"
               value={memoryConfig.cpuDifficulty}
               onChange={(e) => handleConfigChange('cpuDifficulty', e.target.value)}
               className="ml-1 bg-gray-700 text-white rounded px-1"

--- a/frontend/src/pages/SevensPage.tsx
+++ b/frontend/src/pages/SevensPage.tsx
@@ -176,13 +176,19 @@ export function SevensPage() {
 
         <div className="bg-black/30 rounded-lg py-1.5 px-3 mb-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[0.85em] text-white/80">
           <span className="text-yellow-300 font-bold">{t('config.title')}</span>
-          <label className="flex items-center gap-1 cursor-pointer">
-            <input type="checkbox" checked={cfgTunnel} onChange={(e) => setCfgTunnel(e.target.checked)} />
+          <label htmlFor="cfgTunnel" className="flex items-center gap-1 cursor-pointer">
+            <input
+              id="cfgTunnel"
+              type="checkbox"
+              checked={cfgTunnel}
+              onChange={(e) => setCfgTunnel(e.target.checked)}
+            />
             {t('config.tunnel')}
           </label>
-          <label className="flex items-center gap-1 cursor-pointer">
+          <label htmlFor="cfgTunnelSkipWidth" className="flex items-center gap-1 cursor-pointer">
             {t('config.tunnelSkip')}
             <select
+              id="cfgTunnelSkipWidth"
               value={cfgTunnelSkipWidth}
               onChange={(e) => setCfgTunnelSkipWidth(Number(e.target.value))}
               className="bg-black/50 text-white rounded px-1 py-0.5"
@@ -195,9 +201,10 @@ export function SevensPage() {
               <option value={6}>6</option>
             </select>
           </label>
-          <label className="flex items-center gap-1 cursor-pointer">
+          <label htmlFor="cfgJokerCount" className="flex items-center gap-1 cursor-pointer">
             {t('config.joker')}
             <select
+              id="cfgJokerCount"
               value={cfgJokerCount}
               onChange={(e) => setCfgJokerCount(Number(e.target.value))}
               className="bg-black/50 text-white rounded px-1 py-0.5"
@@ -207,9 +214,10 @@ export function SevensPage() {
               <option value={2}>2</option>
             </select>
           </label>
-          <label className="flex items-center gap-1 cursor-pointer">
+          <label htmlFor="cfgCpuStrategy" className="flex items-center gap-1 cursor-pointer">
             {t('config.cpuStrategy')}
             <select
+              id="cfgCpuStrategy"
               value={cfgCpuStrategy}
               onChange={(e) => setCfgCpuStrategy(Number(e.target.value))}
               className="bg-black/50 text-white rounded px-1 py-0.5"
@@ -219,9 +227,10 @@ export function SevensPage() {
               <option value={2}>{t('config.cpuStrategyHarassment')}</option>
             </select>
           </label>
-          <label className="flex items-center gap-1 cursor-pointer">
+          <label htmlFor="cfgMaxPasses" className="flex items-center gap-1 cursor-pointer">
             {t('config.passCount')}
             <select
+              id="cfgMaxPasses"
               value={cfgMaxPasses}
               onChange={(e) => setCfgMaxPasses(Number(e.target.value))}
               className="bg-black/50 text-white rounded px-1 py-0.5"
@@ -232,20 +241,40 @@ export function SevensPage() {
               <option value={0}>{t('config.passUnlimited')}</option>
             </select>
           </label>
-          <label className="flex items-center gap-1 cursor-pointer">
-            <input type="checkbox" checked={cfgNoJokerFinish} onChange={(e) => setCfgNoJokerFinish(e.target.checked)} />
+          <label htmlFor="cfgNoJokerFinish" className="flex items-center gap-1 cursor-pointer">
+            <input
+              id="cfgNoJokerFinish"
+              type="checkbox"
+              checked={cfgNoJokerFinish}
+              onChange={(e) => setCfgNoJokerFinish(e.target.checked)}
+            />
             {t('config.noJokerFinish')}
           </label>
-          <label className="flex items-center gap-1 cursor-pointer">
-            <input type="checkbox" checked={cfgJokerReclaim} onChange={(e) => setCfgJokerReclaim(e.target.checked)} />
+          <label htmlFor="cfgJokerReclaim" className="flex items-center gap-1 cursor-pointer">
+            <input
+              id="cfgJokerReclaim"
+              type="checkbox"
+              checked={cfgJokerReclaim}
+              onChange={(e) => setCfgJokerReclaim(e.target.checked)}
+            />
             {t('config.jokerReclaim')}
           </label>
-          <label className="flex items-center gap-1 cursor-pointer">
-            <input type="checkbox" checked={cfgEndStop} onChange={(e) => setCfgEndStop(e.target.checked)} />
+          <label htmlFor="cfgEndStop" className="flex items-center gap-1 cursor-pointer">
+            <input
+              id="cfgEndStop"
+              type="checkbox"
+              checked={cfgEndStop}
+              onChange={(e) => setCfgEndStop(e.target.checked)}
+            />
             {t('config.endStop')}
           </label>
-          <label className="flex items-center gap-1 cursor-pointer">
-            <input type="checkbox" checked={cfgJokerConsBan} onChange={(e) => setCfgJokerConsBan(e.target.checked)} />
+          <label htmlFor="cfgJokerConsBan" className="flex items-center gap-1 cursor-pointer">
+            <input
+              id="cfgJokerConsBan"
+              type="checkbox"
+              checked={cfgJokerConsBan}
+              onChange={(e) => setCfgJokerConsBan(e.target.checked)}
+            />
             {t('config.jokerConsecutiveBanned')}
           </label>
         </div>


### PR DESCRIPTION
## Summary

- Add `id` attributes to `<select>` and `<input>` elements in DoubtPage, SevensPage, and MemoryPage settings forms
- Add `htmlFor` attributes to their corresponding `<label>` elements
- Provides explicit label–control association per WCAG 2.1 SC 1.3.1, enabling screen readers (NVDA/VoiceOver) to correctly announce settings controls

## Test plan

- [x] All 1219 frontend unit tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Biome lint/format check passes (`npm run check`)

Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)