### PR TITLE
fix(web): add aria-pressed to klondike card selection buttons

### DIFF
--- a/frontend/src/pages/KlondikePage.test.tsx
+++ b/frontend/src/pages/KlondikePage.test.tsx
@@ -239,6 +239,37 @@ describe('KlondikePage', () => {
     await waitFor(() => expect(wasteButton.className).toContain('ring-2'));
   });
 
+  it('waste card button has aria-pressed false initially', async () => {
+    renderWithProviders(<KlondikePage />);
+    await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
+
+    const wasteImg = screen.getByAltText('♣ 3');
+    const wasteButton = wasteImg.closest('button') as HTMLButtonElement;
+    expect(wasteButton).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('waste card button has aria-pressed true when selected', async () => {
+    renderWithProviders(<KlondikePage />);
+    await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
+
+    const wasteImg = screen.getByAltText('♣ 3');
+    const wasteButton = wasteImg.closest('button') as HTMLButtonElement;
+    fireEvent.click(wasteButton);
+    await waitFor(() => expect(wasteButton).toHaveAttribute('aria-pressed', 'true'));
+  });
+
+  it('tableau face-up card button has aria-pressed false initially and true when selected', async () => {
+    renderWithProviders(<KlondikePage />);
+    await waitFor(() => expect(screen.getByText('0')).toBeInTheDocument());
+
+    const cardImg = screen.getByAltText('♠ K');
+    const cardButton = cardImg.closest('button') as HTMLButtonElement;
+    expect(cardButton).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(cardButton);
+    await waitFor(() => expect(cardButton).toHaveAttribute('aria-pressed', 'true'));
+  });
+
   it('clicking waste card when source already selected does nothing', async () => {
     renderWithProviders(<KlondikePage />);
     await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());

--- a/frontend/src/pages/KlondikePage.tsx
+++ b/frontend/src/pages/KlondikePage.tsx
@@ -83,6 +83,7 @@ export function KlondikePage() {
                   handleSelectSource({ zone: 'waste' });
                 }}
                 disabled={!isPlaying || loading}
+                aria-pressed={isSourceSelected('waste')}
                 className={`p-0 border-0 bg-transparent cursor-pointer ${isSourceSelected('waste') ? 'ring-2 ring-yellow-400 rounded' : ''}`}
               >
                 <CardImage card={state.waste[state.waste.length - 1]} width={60} />
@@ -161,6 +162,7 @@ export function KlondikePage() {
                             }
                           }}
                           disabled={!isPlaying || loading}
+                          aria-pressed={isSourceSelected('tableau', colIdx, cardIdx)}
                           className={`p-0 border-0 bg-transparent cursor-pointer w-full ${isSourceSelected('tableau', colIdx, cardIdx) ? 'ring-2 ring-yellow-400 rounded' : ''}`}
                         >
                           <CardImage card={tc.card} width={60} style={{ width: '100%' }} />


### PR DESCRIPTION
## Summary

- Add `aria-pressed` attribute to the waste card button in `KlondikePage` to expose selection state to assistive technologies
- Add `aria-pressed` attribute to tableau face-up card buttons for the same reason
- Add 3 test cases verifying initial `false` and toggled `true` states for both buttons

The 2-step click mechanism (source → target selection) was already implemented using `<button>` elements (Tab+Enter/Space already worked). The missing piece was `aria-pressed` to communicate selected state to screen readers, satisfying WCAG 2.1 SC 2.1.1 (Keyboard).

Closes #498

## Test plan

- [ ] `waste card button has aria-pressed false initially` — verifies default unselected state
- [ ] `waste card button has aria-pressed true when selected` — verifies state after click
- [ ] `tableau face-up card button has aria-pressed false initially and true when selected` — verifies both branches
- [ ] All 1224 frontend tests pass: `cd frontend && npm test`
- [ ] Build passes: `cd frontend && npm run build`
- [ ] Lint passes: `cd frontend && npm run check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)