### PR TITLE
fix(web): make Memory board grid responsive

### DIFF
--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -75,7 +75,7 @@ export function MemoryPage() {
 
         {/* Board: 4×13 grid */}
         <div className="my-3 p-2 rounded bg-black/40">
-          <div className="grid grid-cols-13 gap-1">
+          <div className="grid grid-cols-4 sm:grid-cols-7 md:grid-cols-13 gap-1">
             {state.board.map((bc, idx) => (
               <button
                 type="button"


### PR DESCRIPTION
## Summary

- Replace fixed `grid-cols-13` with `grid-cols-4 sm:grid-cols-7 md:grid-cols-13` in `MemoryPage.tsx`
- Mobile (< 640px): 4 columns; tablet (640–767px): 7 columns; desktop (≥ 768px): 13 columns
- All 1230 frontend tests pass; build and Biome check clean

## Test plan

- [ ] Verify Memory board renders correctly at 375px (mobile), 768px (tablet), and 1024px+ (desktop)
- [ ] Verify all existing unit tests still pass: `cd frontend && npm test`

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)