### PR TITLE
feat(web): display server URL to stdout when launching web command

### DIFF
--- a/internal/infrastructure/web/TrumpCardsWeb.go
+++ b/internal/infrastructure/web/TrumpCardsWeb.go
@@ -3,7 +3,9 @@ package web
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -214,8 +216,17 @@ func (web *TrumpCardsWeb) Exec() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	ln, err := net.Listen("tcp", srv.Addr)
+	if err != nil {
+		slog.Error("server listen error", "error", err)
+		os.Exit(1)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	fmt.Printf("Server is running at http://localhost:%d\n", port)
+	fmt.Println("Press Ctrl+C to stop")
+
 	errCh := make(chan error, 1)
-	go func() { errCh <- srv.ListenAndServe() }()
+	go func() { errCh <- srv.Serve(ln) }()
 
 	select {
 	case err := <-errCh:


### PR DESCRIPTION
Print human-readable startup messages to stdout after the server starts
listening, so users can immediately see the access URL and know the
server is ready.

- Use net.Listen to acquire the port before printing so the URL is
  accurate even when PORT is dynamically assigned
- Switch from srv.ListenAndServe to srv.Serve(ln) to reuse the listener
- Print "Server is running at http://localhost:<port>" and
  "Press Ctrl+C to stop" to stdout

Closes #533

https://claude.ai/code/session_011MJiYiLevJHxSAtbG9tgHF