### PR TITLE
fix(cli): output human-readable error to stderr for unknown game names

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log/slog"
 	"os"
 	"strings"
 
@@ -115,7 +114,7 @@ OPTIONS:
 		w.Exec()
 	default:
 		if flag.Arg(0) != "" {
-			slog.Error("unknown command", "arg", flag.Arg(0))
+			fmt.Fprintf(os.Stderr, "Error: unknown game %q\n\n", flag.Arg(0))
 			flag.Usage()
 			os.Exit(1)
 		}


### PR DESCRIPTION
Replace slog.Error with fmt.Fprintf(os.Stderr, ...) so that passing an
unknown game name (e.g. `trumpcards invalid`) prints a clear message
"Error: unknown game \"invalid\"" followed by usage, instead of a
structured JSON log line. Also corrects the wording from "unknown
command" to "unknown game" and removes the now-unused log/slog import.

Closes #534

https://claude.ai/code/session_01Vu7fDDqFT7EPEjavKBYWdQ