### PR TITLE
fix: write human-readable server error message to stderr

### DIFF
--- a/internal/infrastructure/web/TrumpCardsWeb.go
+++ b/internal/infrastructure/web/TrumpCardsWeb.go
@@ -219,6 +219,7 @@ func (web *TrumpCardsWeb) Exec() {
 	ln, err := net.Listen("tcp", srv.Addr)
 	if err != nil {
 		slog.Error("server listen error", "error", err)
+		fmt.Fprintf(os.Stderr, "Error: failed to start server: %v\n", err)
 		os.Exit(1)
 	}
 	port := ln.Addr().(*net.TCPAddr).Port
@@ -232,6 +233,7 @@ func (web *TrumpCardsWeb) Exec() {
 	case err := <-errCh:
 		if !errors.Is(err, http.ErrServerClosed) {
 			slog.Error("server error", "error", err)
+			fmt.Fprintf(os.Stderr, "Error: failed to start server: %v\n", err)
 			os.Exit(1)
 		}
 	case <-ctx.Done():


### PR DESCRIPTION
When the web server fails to start (e.g., port conflict or insufficient
permissions), print a human-readable error to stderr in addition to the
existing structured slog entry.

Closes #535