### PR TITLE
fix: change web server default port from 80 to 8080

### DIFF
--- a/internal/infrastructure/web/TrumpCardsWeb.go
+++ b/internal/infrastructure/web/TrumpCardsWeb.go
@@ -264,5 +264,5 @@ func getListenPort() string {
 	if port != "" {
 		return ":" + port
 	}
-	return ":80"
+	return ":8080"
 }


### PR DESCRIPTION
Resolves permission denied errors on Linux/macOS where ports below 1024
require root privileges. Port 8080 is the industry standard for local
development and aligns with the existing Docker configuration.

Closes #536

https://claude.ai/code/session_017mQ4H3B4SoztMdbRs3rTue