### PR TITLE
fix(web): display shutdown messages in human-readable format to stdout

### DIFF
--- a/internal/infrastructure/web/TrumpCardsWeb.go
+++ b/internal/infrastructure/web/TrumpCardsWeb.go
@@ -237,6 +237,7 @@ func (web *TrumpCardsWeb) Exec() {
 			os.Exit(1)
 		}
 	case <-ctx.Done():
+		fmt.Println("\nShutting down server...")
 		slog.Info("shutting down server")
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
@@ -256,6 +257,7 @@ func (web *TrumpCardsWeb) Exec() {
 	web.myc.Stop()
 	web.klc.Stop()
 	web.bcc.Stop()
+	fmt.Println("Server stopped.")
 	slog.Info("server stopped")
 }
 


### PR DESCRIPTION
Supplement structured slog logging with fmt.Println() calls so terminal
users see plain-text feedback when the web server shuts down:
- "\nShutting down server..." on Ctrl+C
- "Server stopped." after graceful shutdown completes

Closes #538