### PR TITLE
fix(a11y): add scope="col" to memory scoreboard table headers

### DIFF
--- a/frontend/src/pages/MemoryPage.test.tsx
+++ b/frontend/src/pages/MemoryPage.test.tsx
@@ -106,6 +106,15 @@ describe('MemoryPage', () => {
     expect(screen.getByText('CPU 3')).toBeInTheDocument();
   });
 
+  it('score table headers have scope="col" for accessibility', async () => {
+    const { container } = renderWithProviders(<MemoryPage />);
+    await waitFor(() => expect(screen.getByText('あなた')).toBeInTheDocument());
+    const ths = container.querySelectorAll('th');
+    ths.forEach((th) => {
+      expect(th).toHaveAttribute('scope', 'col');
+    });
+  });
+
   it('renders board with 52 buttons', async () => {
     renderWithProviders(<MemoryPage />);
     await waitFor(() => expect(screen.getByText('スコア')).toBeInTheDocument());

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -59,8 +59,10 @@ export function MemoryPage() {
           <table className="w-full">
             <thead>
               <tr>
-                <th className="text-left">{t('scoresPlayer')}</th>
-                <th>{t('scoresPairs')}</th>
+                <th scope="col" className="text-left">
+                  {t('scoresPlayer')}
+                </th>
+                <th scope="col">{t('scoresPairs')}</th>
               </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
Add scope="col" attribute to all <th> elements in MemoryPage scoreboard
table to enable screen readers to properly associate cells with headers,
addressing WCAG 2.1 criterion 1.3.1 Info and Relationships (Level A).

Closes #546