### PR TITLE
fix(a11y): add focus ring to DoubtPage card count input for keyboard accessibility

### DIFF
--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -16,7 +16,7 @@ import {
   PENALTY_DRAW_LIMIT_OPTIONS,
   useDoubtGame,
 } from '../hooks/useDoubtGame';
-import { btnDanger, btnPrimary, btnSecondary, btnSuccess, btnWarning } from '../styles/buttonStyles';
+import { btnDanger, btnPrimary, btnSecondary, btnSuccess, btnWarning, focusRing } from '../styles/buttonStyles';
 import type { DoubtCpuAction } from '../types/card';
 import { valueName } from '../utils/cardUtils';
 import { playerName } from '../utils/playerUtils';
@@ -299,7 +299,7 @@ export function DoubtPage() {
                     const num = Number(e.target.value);
                     setClaimedValue(Math.max(1, Math.min(13, num)));
                   }}
-                  className="bg-black/50 text-white rounded px-2 py-1 w-16 text-sm border border-white/30"
+                  className={`bg-black/50 text-white rounded px-2 py-1 w-16 text-sm border border-white/30 ${focusRing}`}
                 />
                 <span className="text-game-text-muted text-xs">({valueName(claimedValue)})</span>
               </div>

--- a/frontend/src/styles/buttonStyles.test.ts
+++ b/frontend/src/styles/buttonStyles.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { btnDanger, btnPrimary, btnSecondary, btnSuccess, btnWarning, focusRing } from './buttonStyles';
+
+describe('buttonStyles', () => {
+  it('btnPrimary includes blue background', () => {
+    expect(btnPrimary).toContain('bg-blue-600');
+  });
+
+  it('btnWarning includes yellow background', () => {
+    expect(btnWarning).toContain('bg-yellow-400');
+  });
+
+  it('btnSuccess includes green background', () => {
+    expect(btnSuccess).toContain('bg-green-600');
+  });
+
+  it('btnDanger includes red background', () => {
+    expect(btnDanger).toContain('bg-red-600');
+  });
+
+  it('btnSecondary includes gray background', () => {
+    expect(btnSecondary).toContain('bg-gray-600');
+  });
+
+  it('focusRing includes focus:ring-2 and focus:outline-none', () => {
+    expect(focusRing).toContain('focus:outline-none');
+    expect(focusRing).toContain('focus:ring-2');
+    expect(focusRing).toContain('focus:ring-white/70');
+  });
+});

--- a/frontend/src/styles/buttonStyles.ts
+++ b/frontend/src/styles/buttonStyles.ts
@@ -5,3 +5,6 @@ export const btnWarning = `${base} text-gray-900 bg-yellow-400 hover:bg-yellow-5
 export const btnSuccess = `${base} text-white bg-green-600 hover:bg-green-700`;
 export const btnDanger = `${base} text-white bg-red-600 hover:bg-red-700`;
 export const btnSecondary = `${base} text-white bg-gray-600 hover:bg-gray-500`;
+
+export const focusRing =
+  'focus:outline-none focus:ring-2 focus:ring-white/70 focus:ring-offset-1 focus:ring-offset-black/50';


### PR DESCRIPTION
Add `focusRing` utility constant to buttonStyles.ts and apply it to the
claimed-value input in DoubtPage.tsx, making focus state visible for
keyboard users and satisfying WCAG 2.1 2.4.7 (Focus Visible, Level AA).

Closes #550

https://claude.ai/code/session_019F1eCkNubaUaL4rrV8Xy6A