### PR TITLE
fix(i18n): wrap hardcoded CPU/Player labels with t() translation function

### DIFF
--- a/frontend/src/components/CpuActionLog.tsx
+++ b/frontend/src/components/CpuActionLog.tsx
@@ -13,7 +13,7 @@ export function CpuActionLog({ actions }: CpuActionLogProps) {
       <div className="font-bold mb-1">{t('label.cpuAction')}</div>
       {actions.map((a, i) => (
         <div key={`${i}-${a.playerIdx}-${a.action}`}>
-          Player {a.playerIdx}: {bettingActionName(a.action)}
+          {t('player.player', { idx: a.playerIdx })}: {bettingActionName(a.action)}
           {a.amount > 0 && ` (${a.amount})`}
         </div>
       ))}

--- a/frontend/src/components/CpuPlayerCard.tsx
+++ b/frontend/src/components/CpuPlayerCard.tsx
@@ -25,7 +25,8 @@ export function CpuPlayerCard({ player, showCards, faceDownCount, showHandName, 
   return (
     <div className="mb-3">
       <div className="text-white text-[0.95em] mb-1">
-        CPU {player.id} <span className="text-gray-300 text-[0.85em]">({player.playStyleName})</span>
+        {t('player.cpu', { id: player.id })}{' '}
+        <span className="text-gray-300 text-[0.85em]">({player.playStyleName})</span>
         <span className="ml-2 text-[0.85em]">
           {t('betting.chips')} {player.chips}
         </span>

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -173,7 +173,7 @@ export function BlackJackPage() {
               // biome-ignore lint/suspicious/noArrayIndexKey: CPU seats have fixed order
               <div key={cpuIdx} className="mb-3">
                 <h3 className="text-yellow-200 mt-0 mb-1">
-                  CPU {cpuIdx + 1} ({cpu.chips} chips)
+                  {tc('player.cpu', { id: cpuIdx + 1 })} ({cpu.chips} chips)
                   {cpu.insuranceBet > 0 && (
                     <span className="text-yellow-400 text-sm ml-2">
                       [{t('insurance')} {cpu.insuranceBet}]


### PR DESCRIPTION
Replace hardcoded "CPU {id}" and "Player {idx}" strings in
CpuPlayerCard.tsx, CpuActionLog.tsx, and BlackJackPage.tsx with
t('player.cpu') and t('player.player') calls using the existing
common locale keys, ensuring consistent localization across ja/en.

Closes #551