### PR TITLE
docs: update CLAUDE.md files with missing context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ E2E tests should not assert on specific card values (randomness). Instead, verif
 The Web GUI supports Japanese (ja) and English (en) via **react-i18next** with **i18next-browser-languagedetector**.
 
 - **Config**: `frontend/src/i18n/index.ts`
-- **Translation files**: `frontend/src/i18n/locales/{ja,en}/{common,blackjack,poker,oldmaid,daifugo,sevens,doubt,holdem,hearts,memory,klondike}.json`
+- **Translation files**: `frontend/src/i18n/locales/{ja,en}/{common,blackjack,poker,oldmaid,daifugo,sevens,doubt,holdem,hearts,memory,klondike,baccarat}.json`
 - **In components**: use the `useTranslation()` hook
 - **In non-component files** (e.g., `playerUtils.ts`, `messages.ts`, `gameConstants.ts`): import the `i18n` instance directly
 - **Tests**: i18n is initialized in `frontend/src/test/setup.ts` with ja translations loaded

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -45,7 +45,7 @@ E2E tests should not assert on specific card values (randomness). Instead, verif
 The Web GUI supports Japanese (ja) and English (en) via **react-i18next** with **i18next-browser-languagedetector**.
 
 - **Config**: `src/i18n/index.ts`
-- **Translation files**: `src/i18n/locales/{ja,en}/{common,blackjack,poker,oldmaid,daifugo,sevens,doubt,holdem,hearts}.json`
+- **Translation files**: `src/i18n/locales/{ja,en}/{common,blackjack,poker,oldmaid,daifugo,sevens,doubt,holdem,hearts,memory,klondike,baccarat}.json`
 - **In components**: use the `useTranslation()` hook
 - **In non-component files** (e.g., `playerUtils.ts`, `messages.ts`, `gameConstants.ts`): import the `i18n` instance directly
 - **Tests**: i18n is initialized in `src/test/setup.ts` with ja translations loaded

--- a/internal/CLAUDE.md
+++ b/internal/CLAUDE.md
@@ -50,6 +50,10 @@ Card games involve shuffling, so tests must not depend on random outcomes:
 
 **After editing any Go source file, always run `goimports -w` on the modified files before committing.** Use `goimports`, not `gofmt`.
 
+## Lint
+
+**Before committing, run `golangci-lint run ./...` and ensure no warnings or errors.**
+
 ## Run tests
 
 ```sh


### PR DESCRIPTION
## Summary

- Add `baccarat` to i18n translation file list in `CLAUDE.md` and `frontend/CLAUDE.md` (was missing after baccarat game was added)
- Add `memory` and `klondike` to i18n translation file list in `frontend/CLAUDE.md` (was 3 games behind)
- Add `golangci-lint run ./...` pre-commit step to `internal/CLAUDE.md` (was documented in `.claude/rules/go.md` but missing here)

## Test plan

- [ ] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)