### PR TITLE
style(navbar): replace inline style with tailwind classes

### DIFF
--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -8,7 +8,7 @@ export function NavBar() {
   const currentLang = i18n.language;
 
   return (
-    <nav style={{ textAlign: 'right', margin: '8px 10px' }} className="flex items-center justify-end gap-2 flex-wrap">
+    <nav className="flex items-center justify-end gap-2 flex-wrap my-2 mx-2.5">
       <div className="flex flex-wrap gap-1 flex-1 justify-end">
         {gameRoutes.map(({ path, labelKey }) => (
           <Link


### PR DESCRIPTION
Closes #556

Replace `style={{ textAlign: 'right', margin: '8px 10px' }}` with
equivalent Tailwind classes `my-2 mx-2.5` on the NavBar nav element,
consistent with the rest of the codebase.