### PR TITLE
style(frontend): replace arbitrary em font sizes with Tailwind standard classes

### DIFF
--- a/frontend/src/components/CpuActionLog.tsx
+++ b/frontend/src/components/CpuActionLog.tsx
@@ -9,7 +9,7 @@ export function CpuActionLog({ actions }: CpuActionLogProps) {
   const { t } = useTranslation('common');
   if (!actions || actions.length === 0) return null;
   return (
-    <div className="bg-black/30 rounded p-2 mb-3 text-white text-[0.85em]">
+    <div className="bg-black/30 rounded p-2 mb-3 text-white text-xs">
       <div className="font-bold mb-1">{t('label.cpuAction')}</div>
       {actions.map((a, i) => (
         <div key={`${i}-${a.playerIdx}-${a.action}`}>

--- a/frontend/src/components/CpuPlayerCard.tsx
+++ b/frontend/src/components/CpuPlayerCard.tsx
@@ -24,22 +24,21 @@ export function CpuPlayerCard({ player, showCards, faceDownCount, showHandName, 
   const { t } = useTranslation('common');
   return (
     <div className="mb-3">
-      <div className="text-white text-[0.95em] mb-1">
-        {t('player.cpu', { id: player.id })}{' '}
-        <span className="text-gray-300 text-[0.85em]">({player.playStyleName})</span>
-        <span className="ml-2 text-[0.85em]">
+      <div className="text-white text-sm mb-1">
+        {t('player.cpu', { id: player.id })} <span className="text-gray-300 text-xs">({player.playStyleName})</span>
+        <span className="ml-2 text-xs">
           {t('betting.chips')} {player.chips}
         </span>
         {extraInfo}
         {player.currentBet > 0 && (
-          <span className="ml-2 text-[0.85em]">
+          <span className="ml-2 text-xs">
             {t('betting.currentBet')} {player.currentBet}
           </span>
         )}
-        {player.folded && <span className="ml-2 text-red-300 text-[0.85em]">[{t('status.folded')}]</span>}
-        {player.allIn && <span className="ml-2 text-yellow-300 text-[0.85em]">[{t('status.allIn')}]</span>}
+        {player.folded && <span className="ml-2 text-red-300 text-xs">[{t('status.folded')}]</span>}
+        {player.allIn && <span className="ml-2 text-yellow-300 text-xs">[{t('status.allIn')}]</span>}
         {showHandName && !player.folded && player.handName && (
-          <span className={`inline-block ml-2 text-[0.85em] font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}>
+          <span className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}>
             {player.handName}
           </span>
         )}

--- a/frontend/src/components/ErrorAlert.tsx
+++ b/frontend/src/components/ErrorAlert.tsx
@@ -5,10 +5,7 @@ interface ErrorAlertProps {
 export function ErrorAlert({ message }: ErrorAlertProps) {
   if (!message) return null;
   return (
-    <div
-      role="alert"
-      className="bg-red-700/90 text-white text-center px-4 py-2 text-[0.95em] font-bold mb-2 rounded-lg"
-    >
+    <div role="alert" className="bg-red-700/90 text-white text-center px-4 py-2 text-sm font-bold mb-2 rounded-lg">
       {message}
     </div>
   );

--- a/frontend/src/components/GameMessageBox.tsx
+++ b/frontend/src/components/GameMessageBox.tsx
@@ -18,7 +18,7 @@ export function GameMessageBox({ message, messageCode, messageParams, alwaysVisi
   }
   if (!alwaysVisible && !displayMessage) return null;
   return (
-    <div className="bg-black/55 rounded-lg text-white text-center px-4 py-2 text-[1.1em] font-bold mb-2">
+    <div className="bg-black/55 rounded-lg text-white text-center px-4 py-2 text-lg font-bold mb-2">
       {displayMessage}
     </div>
   );

--- a/frontend/src/components/RoundResults.tsx
+++ b/frontend/src/components/RoundResults.tsx
@@ -17,7 +17,7 @@ export function RoundResults({ results, players }: RoundResultsProps) {
   const { t } = useTranslation('common');
   if (!results || results.length === 0) return null;
   return (
-    <div className="bg-black/30 rounded p-2 mb-3 text-white text-[0.85em]">
+    <div className="bg-black/30 rounded p-2 mb-3 text-white text-xs">
       <div className="font-bold mb-1">{t('label.result')}</div>
       {results.map((r) => (
         <div key={r.playerIdx}>

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -1,9 +1,9 @@
 export type StatusBadgeVariant = 'success' | 'warning' | 'danger';
 
 const variantClasses: Record<StatusBadgeVariant, string> = {
-  success: 'bg-game-status-active text-white rounded-[6px] px-2 py-[1px] ml-1.5 text-[0.8em]',
-  warning: 'bg-game-status-waiting text-game-text-strong rounded-[6px] px-2 py-[1px] ml-1.5 text-[0.8em] font-bold',
-  danger: 'bg-game-status-out text-white rounded-[6px] px-2 py-[1px] ml-1.5 text-[0.8em] font-bold',
+  success: 'bg-game-status-active text-white rounded-[6px] px-2 py-[1px] ml-1.5 text-xs',
+  warning: 'bg-game-status-waiting text-game-text-strong rounded-[6px] px-2 py-[1px] ml-1.5 text-xs font-bold',
+  danger: 'bg-game-status-out text-white rounded-[6px] px-2 py-[1px] ml-1.5 text-xs font-bold',
 };
 
 export function StatusBadge({ variant, children }: { variant: StatusBadgeVariant; children: React.ReactNode }) {

--- a/frontend/src/components/__snapshots__/StatusBadge.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/StatusBadge.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`StatusBadge > renders danger variant 1`] = `
 <span
-  class="bg-game-status-out text-white rounded-[6px] px-2 py-[1px] ml-1.5 text-[0.8em] font-bold"
+  class="bg-game-status-out text-white rounded-[6px] px-2 py-[1px] ml-1.5 text-xs font-bold"
 >
   容疑者
 </span>
@@ -10,7 +10,7 @@ exports[`StatusBadge > renders danger variant 1`] = `
 
 exports[`StatusBadge > renders success variant 1`] = `
 <span
-  class="bg-game-status-active text-white rounded-[6px] px-2 py-[1px] ml-1.5 text-[0.8em]"
+  class="bg-game-status-active text-white rounded-[6px] px-2 py-[1px] ml-1.5 text-xs"
 >
   上がり
 </span>
@@ -18,7 +18,7 @@ exports[`StatusBadge > renders success variant 1`] = `
 
 exports[`StatusBadge > renders warning variant 1`] = `
 <span
-  class="bg-game-status-waiting text-game-text-strong rounded-[6px] px-2 py-[1px] ml-1.5 text-[0.8em] font-bold"
+  class="bg-game-status-waiting text-game-text-strong rounded-[6px] px-2 py-[1px] ml-1.5 text-xs font-bold"
 >
   考え中...
 </span>

--- a/frontend/src/components/daifugo/DaifugoCpuArea.tsx
+++ b/frontend/src/components/daifugo/DaifugoCpuArea.tsx
@@ -20,7 +20,7 @@ export function DaifugoCpuArea({ player, isCurrentTurn }: { player: DaifugoPlaye
       className={playerAreaClass}
     >
       {!player.isFinished && (
-        <div className="text-game-text-muted text-[0.85em]">{t('cardCount', { count: player.cardCount })}</div>
+        <div className="text-game-text-muted text-xs">{t('cardCount', { count: player.cardCount })}</div>
       )}
       {player.illegalFinishPenalty && <StatusBadge variant="danger">{t('badge.illegalFinishPenalty')}</StatusBadge>}
     </CpuTurnArea>

--- a/frontend/src/components/daifugo/DaifugoExchangeLog.tsx
+++ b/frontend/src/components/daifugo/DaifugoExchangeLog.tsx
@@ -12,7 +12,7 @@ export function DaifugoExchangeLog({
 }) {
   const { t } = useTranslation('daifugo');
   return (
-    <div className="bg-black/40 rounded-lg text-[#ffd] py-2 px-3.5 my-2 whitespace-pre-line text-[0.85em]">
+    <div className="bg-black/40 rounded-lg text-[#ffd] py-2 px-3.5 my-2 whitespace-pre-line text-xs">
       {[
         t('exchange.title'),
         ...actions.map((a) => {

--- a/frontend/src/components/daifugo/DaifugoHumanArea.tsx
+++ b/frontend/src/components/daifugo/DaifugoHumanArea.tsx
@@ -39,7 +39,7 @@ export function DaifugoHumanArea({
         {player.illegalFinishPenalty && <StatusBadge variant="danger">{t('badge.illegalFinishPenalty')}</StatusBadge>}
       </div>
       {!player.isFinished && (
-        <div className="text-game-text-muted text-[0.85em] mb-1">
+        <div className="text-game-text-muted text-xs mb-1">
           {t('cardCount', { count: player.cardCount })}
           {isCurrentTurn && <span className="ml-2 text-game-text-highlight">{t('selectToPlay')}</span>}
         </div>

--- a/frontend/src/components/daifugo/DaifugoSettingsPanel.tsx
+++ b/frontend/src/components/daifugo/DaifugoSettingsPanel.tsx
@@ -29,8 +29,8 @@ export function DaifugoSettingsPanel({ config, onChange }: SettingsPanelProps) {
   ];
   return (
     <details className="mb-2">
-      <summary className="cursor-pointer text-game-text-muted text-[0.85em] select-none">{t('settings.title')}</summary>
-      <div className="bg-black/40 rounded-lg p-2 mt-1 text-[0.82em] text-white">
+      <summary className="cursor-pointer text-game-text-muted text-xs select-none">{t('settings.title')}</summary>
+      <div className="bg-black/40 rounded-lg p-2 mt-1 text-xs text-white">
         <div className="mb-1 flex flex-wrap gap-x-4 gap-y-1">
           <span>
             <label htmlFor="joker-count" className="mr-2">

--- a/frontend/src/components/doubt/DoubtCpuArea.tsx
+++ b/frontend/src/components/doubt/DoubtCpuArea.tsx
@@ -27,7 +27,7 @@ export function DoubtCpuArea({
       className={playerAreaClass}
       nameClassName="text-sm"
     >
-      <div className="text-game-text-muted text-[0.85em]">{t('cardCount', { count: player.cardCount })}</div>
+      <div className="text-game-text-muted text-xs">{t('cardCount', { count: player.cardCount })}</div>
       {hasTell && (
         <span className="animate-sweat-drop text-lg" role="img" aria-label={t('tell')}>
           💧

--- a/frontend/src/components/oldmaid/OldMaidDiscardedArea.tsx
+++ b/frontend/src/components/oldmaid/OldMaidDiscardedArea.tsx
@@ -6,7 +6,7 @@ export function OldMaidDiscardedArea({ cards }: { cards: Card[] | undefined }) {
   const { t } = useTranslation('oldmaid');
   if (!cards || cards.length === 0) {
     return (
-      <div className="h-[90px] flex items-center justify-center border-2 border-dashed border-white/15 rounded-[10px] my-2 text-white/30 text-[0.9em]">
+      <div className="h-[90px] flex items-center justify-center border-2 border-dashed border-white/15 rounded-[10px] my-2 text-white/30 text-sm">
         {t('discardArea')}
       </div>
     );
@@ -22,7 +22,7 @@ export function OldMaidDiscardedArea({ cards }: { cards: Card[] | undefined }) {
 
   return (
     <div className="my-2 p-2 bg-black/20 rounded-[10px] text-center min-h-[90px]">
-      <div className="text-game-text-muted text-[0.8em] mb-1.5">{t('lastDiscarded')}</div>
+      <div className="text-game-text-muted text-xs mb-1.5">{t('lastDiscarded')}</div>
       <div className="flex justify-center gap-5 items-end">
         {pairs.map(([c1, c2]) => (
           <div key={`${c1.design}-${c1.value}`} style={{ position: 'relative', width: 65, height: 82 }}>

--- a/frontend/src/components/oldmaid/OldMaidDrawHistory.tsx
+++ b/frontend/src/components/oldmaid/OldMaidDrawHistory.tsx
@@ -23,8 +23,8 @@ export function OldMaidDrawHistory({
 
   return (
     <div className="bg-black/50 rounded-lg my-2 p-2" data-testid="draw-history-timeline">
-      <div className="text-white font-bold text-[0.8em] mb-1">{t('history.title')}</div>
-      <div ref={scrollRef} className="max-h-[120px] overflow-y-auto text-[0.75em] text-game-text-muted">
+      <div className="text-white font-bold text-xs mb-1">{t('history.title')}</div>
+      <div ref={scrollRef} className="max-h-[120px] overflow-y-auto text-xs text-game-text-muted">
         {entries.map((entry, i) => {
           const from = findPlayerName(players, entry.drawPlayerIdx);
           const target = findPlayerName(players, entry.drawFromIdx);

--- a/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
+++ b/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
@@ -50,7 +50,7 @@ export function OldMaidPlayerArea({
       id={`player-area-${player.id}`}
       className={`${playerAreaClass}${conditionalClass ? ` ${conditionalClass}` : ''}`}
     >
-      <div className="text-white font-bold mb-1 text-[0.9em]">
+      <div className="text-white font-bold mb-1 text-sm">
         {playerName(player.id, player.isHuman)}
         {player.isFinished && <StatusBadge variant="success">{tc('status.finished')}</StatusBadge>}
         {isTarget && !player.isHuman && !player.isFinished && !gameEndFlag && (
@@ -60,7 +60,7 @@ export function OldMaidPlayerArea({
         {onToggleSuspect && !player.isFinished && !gameEndFlag && (
           <button
             type="button"
-            className="ml-1 px-1.5 py-0.5 text-[0.65em] rounded bg-red-700/60 hover:bg-red-700 text-white"
+            className="ml-1 px-1.5 py-0.5 text-xs rounded bg-red-700/60 hover:bg-red-700 text-white"
             onClick={onToggleSuspect}
           >
             {isSuspect ? t('suspect.unpin') : t('suspect.pin')}
@@ -68,11 +68,9 @@ export function OldMaidPlayerArea({
         )}
       </div>
       {!player.isFinished && (
-        <div className="text-game-text-muted text-[0.8em] mb-1">{t('cardCount', { count: player.cardCount })}</div>
+        <div className="text-game-text-muted text-xs mb-1">{t('cardCount', { count: player.cardCount })}</div>
       )}
-      {showSelectable && !player.isFinished && (
-        <div className="text-game-text-highlight text-[0.75em] mb-1">{t('draw')}</div>
-      )}
+      {showSelectable && !player.isFinished && <div className="text-game-text-highlight text-xs mb-1">{t('draw')}</div>}
       <div className="flex flex-wrap gap-0.5 justify-center">
         {player.isFinished ? null : player.isHuman ? (
           player.cards?.map((card, i) => (
@@ -120,7 +118,7 @@ export function OldMaidPlayerArea({
               );
             })}
             {player.cardCount > 10 && (
-              <span className="text-white self-center ml-0.5 text-[0.8em]">+{player.cardCount - 10}</span>
+              <span className="text-white self-center ml-0.5 text-xs">+{player.cardCount - 10}</span>
             )}
           </>
         ) : (
@@ -130,7 +128,7 @@ export function OldMaidPlayerArea({
               <CardBack key={i} width={40} />
             ))}
             {player.cardCount > 10 && (
-              <span className="text-white self-center ml-0.5 text-[0.8em]">+{player.cardCount - 10}</span>
+              <span className="text-white self-center ml-0.5 text-xs">+{player.cardCount - 10}</span>
             )}
           </>
         )}

--- a/frontend/src/components/sevens/SevensBoard.tsx
+++ b/frontend/src/components/sevens/SevensBoard.tsx
@@ -83,7 +83,7 @@ function Board({
                 );
               })}
               {tunnelEnabled && (
-                <span role="img" className="text-yellow-400 text-[0.65em] ml-0.5" aria-label={t('tunnelConnection')}>
+                <span role="img" className="text-yellow-400 text-xs ml-0.5" aria-label={t('tunnelConnection')}>
                   ↔
                 </span>
               )}

--- a/frontend/src/components/sevens/SevensCpuArea.tsx
+++ b/frontend/src/components/sevens/SevensCpuArea.tsx
@@ -15,7 +15,7 @@ function SevCpuArea({ player, isCurrentTurn }: { player: SevensPlayerData; isCur
       className={playerAreaClass}
     >
       {!player.isFinished && (
-        <div className="text-game-text-muted text-[0.85em]">
+        <div className="text-game-text-muted text-xs">
           {t('cardCount', { count: player.cardCount })}
           {'　'}
           {t('passCount', {

--- a/frontend/src/components/sevens/SevensHumanArea.tsx
+++ b/frontend/src/components/sevens/SevensHumanArea.tsx
@@ -44,7 +44,7 @@ function HumanArea({
         {player.isFinished && <StatusBadge variant="success">{t('rankLabel', { rank: player.rank })}</StatusBadge>}
       </div>
       {!player.isFinished && (
-        <div className="text-game-text-muted text-[0.85em] mb-1">
+        <div className="text-game-text-muted text-xs mb-1">
           {t('cardCount', { count: player.cardCount })}
           {'　'}
           {t('passCount', {

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -96,7 +96,7 @@ export function DaifugoPage() {
         </div>
 
         {pendingBanner && (
-          <div className="bg-yellow-700/80 rounded-[10px] text-white text-center py-2 px-4 text-[0.95em] font-bold my-2">
+          <div className="bg-yellow-700/80 rounded-[10px] text-white text-center py-2 px-4 text-sm font-bold my-2">
             {pendingBanner}
             {pendingAction === 'queenBomber' && isHumanTurn && (
               <div className="flex flex-wrap justify-center gap-1 mt-2">
@@ -123,13 +123,13 @@ export function DaifugoPage() {
         )}
 
         {state.humanAction && (
-          <div className="bg-black/40 rounded-lg text-green-200 py-2 px-3.5 my-2 text-[0.85em]">
+          <div className="bg-black/40 rounded-lg text-green-200 py-2 px-3.5 my-2 text-xs">
             {actionDescription(state.players, state.humanAction)}
           </div>
         )}
 
         {state.cpuActions && state.cpuActions.length > 0 && (
-          <div className="bg-black/40 rounded-lg text-white py-2 px-3.5 my-2 whitespace-pre-line text-[0.85em]">
+          <div className="bg-black/40 rounded-lg text-white py-2 px-3.5 my-2 whitespace-pre-line text-xs">
             {[tc('label.cpuActions'), ...state.cpuActions.map((a) => actionDescription(state.players, a))].join('\n')}
           </div>
         )}

--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -157,9 +157,9 @@ export function DoubtPage() {
         {/* Table area */}
         <div className="bg-black/30 rounded-[10px] py-2.5 px-3.5 my-2">
           <div className="text-white font-bold mb-1">{t('table')}</div>
-          <div className="text-game-text-muted text-[0.9em]">{t('tableCards', { count: state.tableCardCount })}</div>
+          <div className="text-game-text-muted text-sm">{t('tableCards', { count: state.tableCardCount })}</div>
           {state.lastAction && (
-            <div className="text-yellow-300 text-[0.85em] mt-1">{actionDesc(state.lastAction, state.players, t)}</div>
+            <div className="text-yellow-300 text-xs mt-1">{actionDesc(state.lastAction, state.players, t)}</div>
           )}
         </div>
 
@@ -173,7 +173,7 @@ export function DoubtPage() {
                   <div className="text-yellow-300 text-lg font-bold mb-2">{t('countdown', { sec: countdown })}</div>
                 )}
                 {state.cpuDoubters.length > 0 && (
-                  <div className="text-game-text-muted text-[0.85em] mb-2">
+                  <div className="text-game-text-muted text-xs mb-2">
                     {t('cpuDoubters', { names: state.cpuDoubters.map((idx) => playerName(idx, false)).join(', ') })}
                   </div>
                 )}
@@ -190,7 +190,7 @@ export function DoubtPage() {
               <>
                 <div className="text-white font-bold mb-2">{t('cpuJudging')}</div>
                 {state.cpuDoubters.length > 0 && (
-                  <div className="text-red-300 text-[0.9em] mb-2">
+                  <div className="text-red-300 text-sm mb-2">
                     {t('cpuDoubtExclaim', { names: state.cpuDoubters.map((idx) => playerName(idx, false)).join(', ') })}
                   </div>
                 )}
@@ -204,7 +204,7 @@ export function DoubtPage() {
 
         {/* Last doubt result */}
         {state.lastDoubtResult && (
-          <div className="bg-black/40 rounded-lg py-2 px-3.5 my-2 text-[0.85em]">
+          <div className="bg-black/40 rounded-lg py-2 px-3.5 my-2 text-xs">
             <div className="text-white font-bold mb-1">{t('doubtResult.title')}</div>
             <div className={state.lastDoubtResult.wasLying ? 'text-red-300' : 'text-green-300'}>
               {state.lastDoubtResult.wasLying ? t('doubtResult.wasLying') : t('doubtResult.wasTruth')}
@@ -235,12 +235,12 @@ export function DoubtPage() {
 
         {/* Human/CPU action logs */}
         {state.humanAction && !isDoubtPhase && (
-          <div className="bg-black/40 rounded-lg text-game-text-highlight py-2 px-3.5 my-2 text-[0.85em]">
+          <div className="bg-black/40 rounded-lg text-game-text-highlight py-2 px-3.5 my-2 text-xs">
             {actionDesc(state.humanAction, state.players, t)}
           </div>
         )}
         {state.cpuActions && state.cpuActions.length > 0 && (
-          <div className="bg-black/40 rounded-lg text-game-text-muted py-2 px-3.5 my-2 whitespace-pre-line text-[0.85em]">
+          <div className="bg-black/40 rounded-lg text-game-text-muted py-2 px-3.5 my-2 whitespace-pre-line text-xs">
             {[tc('label.cpuActions'), ...state.cpuActions.map((a) => actionDesc(a, state.players, t))].join('\n')}
           </div>
         )}

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -121,7 +121,7 @@ export function HoldemPage() {
       <div className="flex-1 overflow-y-auto pt-4 px-5">
         {/* Community cards */}
         <div className="mb-4">
-          <div className="text-white text-[1.1em] mb-1.5">{t('communityCards')}</div>
+          <div className="text-white text-lg mb-1.5">{t('communityCards')}</div>
           <div className="flex flex-wrap gap-2">
             {state?.communityCards?.length
               ? state.communityCards.map((card) => (
@@ -177,9 +177,9 @@ export function HoldemPage() {
         {/* Human player */}
         {humanPlayer && (
           <div className="mb-2">
-            <div className="text-white text-[1.1em] mb-1">
+            <div className="text-white text-lg mb-1">
               {t('yourHand')}
-              <span className="ml-3 text-[0.85em]">
+              <span className="ml-3 text-xs">
                 {tc('betting.chips')} {humanPlayer.chips}
               </span>
               {humanPlayer.totalHands > 0 && (
@@ -191,14 +191,14 @@ export function HoldemPage() {
                 />
               )}
               {humanPlayer.currentBet > 0 && (
-                <span className="ml-2 text-[0.85em]">
+                <span className="ml-2 text-xs">
                   {tc('betting.currentBet')} {humanPlayer.currentBet}
                 </span>
               )}
-              {humanPlayer.folded && <span className="ml-2 text-red-300 text-[0.85em]">[{tc('status.folded')}]</span>}
-              {humanPlayer.allIn && <span className="ml-2 text-yellow-300 text-[0.85em]">[{tc('status.allIn')}]</span>}
+              {humanPlayer.folded && <span className="ml-2 text-red-300 text-xs">[{tc('status.folded')}]</span>}
+              {humanPlayer.allIn && <span className="ml-2 text-yellow-300 text-xs">[{tc('status.allIn')}]</span>}
               {isShowdown && !humanPlayer.folded && humanPlayer.handName && (
-                <span className={`inline-block ml-2 text-[0.85em] font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}>
+                <span className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}>
                   {humanPlayer.handName}
                 </span>
               )}

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -152,14 +152,14 @@ export function OldMaidPage() {
 
         {/* Status */}
         {statusLines.length > 0 && (
-          <div className="bg-black/50 rounded-lg text-white py-2 px-3 my-2 whitespace-pre-line text-[0.9em]">
+          <div className="bg-black/50 rounded-lg text-white py-2 px-3 my-2 whitespace-pre-line text-sm">
             {statusLines.join('\n')}
           </div>
         )}
 
         {/* CPU log */}
         {state.cpuActions && state.cpuActions.length > 0 && (
-          <div className="bg-black/40 rounded-lg text-game-text-muted py-1.5 px-2.5 my-1.5 whitespace-pre-line text-[0.8em] max-h-[120px] overflow-y-auto">
+          <div className="bg-black/40 rounded-lg text-game-text-muted py-1.5 px-2.5 my-1.5 whitespace-pre-line text-xs max-h-[120px] overflow-y-auto">
             {[
               tc('label.cpuActions'),
               ...state.cpuActions.map((action: CpuAction) => {
@@ -182,7 +182,7 @@ export function OldMaidPage() {
 
         {/* JijiNuki: show removed card at game end */}
         {state.gameEndFlag && state.removedCard && (
-          <div className="text-center my-2 text-white text-[0.9em]">
+          <div className="text-center my-2 text-white text-sm">
             {t('removedCard', { card: cardLabel(state.removedCard) })}
           </div>
         )}

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -136,7 +136,7 @@ export function PokerPage() {
               showHandName={isEnd}
               extraInfo={
                 (phase === PokerPhase.SECOND_BET || isEnd) && p.exchangeCount > 0 && !p.folded ? (
-                  <span className="ml-2 text-[0.85em]">{t('exchangeCount', { count: p.exchangeCount })}</span>
+                  <span className="ml-2 text-xs">{t('exchangeCount', { count: p.exchangeCount })}</span>
                 ) : undefined
               }
             />
@@ -147,7 +147,7 @@ export function PokerPage() {
 
         {/* CPU exchanges log */}
         {state?.cpuExchanges && state.cpuExchanges.length > 0 && (
-          <div className="bg-black/30 rounded p-2 mb-3 text-white text-[0.85em]">
+          <div className="bg-black/30 rounded p-2 mb-3 text-white text-xs">
             <div className="font-bold mb-1">{t('cpuExchange')}</div>
             {state.cpuExchanges.map((ex, i) => (
               <div key={`${i}-${ex.playerIdx}`}>
@@ -166,27 +166,25 @@ export function PokerPage() {
         {/* Human player */}
         {humanPlayer && (
           <div className="mb-2">
-            <div className="text-white text-[1.1em] mb-1">
+            <div className="text-white text-lg mb-1">
               {t('yourHand')}
-              <span className="ml-3 text-[0.85em]">
+              <span className="ml-3 text-xs">
                 {tc('betting.chips')} {humanPlayer.chips}
               </span>
               {humanPlayer.currentBet > 0 && (
-                <span className="ml-2 text-[0.85em]">
+                <span className="ml-2 text-xs">
                   {tc('betting.currentBet')} {humanPlayer.currentBet}
                 </span>
               )}
-              {humanPlayer.folded && <span className="ml-2 text-red-300 text-[0.85em]">[{tc('status.folded')}]</span>}
-              {humanPlayer.allIn && <span className="ml-2 text-yellow-300 text-[0.85em]">[{tc('status.allIn')}]</span>}
+              {humanPlayer.folded && <span className="ml-2 text-red-300 text-xs">[{tc('status.folded')}]</span>}
+              {humanPlayer.allIn && <span className="ml-2 text-yellow-300 text-xs">[{tc('status.allIn')}]</span>}
               {isEnd && !humanPlayer.folded && humanPlayer.handName && (
-                <span className={`inline-block ml-2 text-[0.85em] font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}>
+                <span className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}>
                   {humanPlayer.handName}
                 </span>
               )}
             </div>
-            {canExchange && (
-              <div className="text-game-text-highlight text-[0.85em] mb-1">{t('exchangeInstruction')}</div>
-            )}
+            {canExchange && <div className="text-game-text-highlight text-xs mb-1">{t('exchangeInstruction')}</div>}
             <div className="flex flex-wrap gap-1.5 mb-2">
               {humanPlayer.cards?.map((card, i) => {
                 const isSelected = selected.includes(i);
@@ -272,7 +270,7 @@ export function PokerPage() {
 
         {/* Draw odds panel */}
         {canExchange && odds && odds.some((o) => o.probability > 0) && (
-          <div className="bg-black/40 rounded-lg px-4 py-2 mb-2 text-white text-[0.85em]" data-testid="odds-panel">
+          <div className="bg-black/40 rounded-lg px-4 py-2 mb-2 text-white text-xs" data-testid="odds-panel">
             <div className="font-bold mb-1">{t('drawOdds')}</div>
             {odds
               .filter((o) => o.probability > 0)

--- a/frontend/src/pages/SevensPage.tsx
+++ b/frontend/src/pages/SevensPage.tsx
@@ -73,7 +73,7 @@ export function SevensPage() {
             state.config.jokerReclaimEnabled ||
             state.config.endStopEnabled ||
             state.config.jokerConsecutiveBanned) && (
-            <div className="bg-black/30 rounded-lg text-yellow-300 py-1.5 px-3 mb-2 text-[0.85em]">
+            <div className="bg-black/30 rounded-lg text-yellow-300 py-1.5 px-3 mb-2 text-xs">
               {t('rules.title')}
               {state.config.tunnelEnabled && ` ${t('rules.tunnelTag')}`}
               {state.config.tunnelSkipWidth >= 2 &&
@@ -110,14 +110,14 @@ export function SevensPage() {
         {state.humanAction && (
           <div
             data-testid={state.humanAction.forcedPass ? 'human-action-forced-pass' : 'human-action'}
-            className={`rounded-lg py-2 px-3.5 my-2 text-[0.85em] ${state.humanAction.forcedPass ? 'bg-red-900/50 text-orange-200 border border-red-500/50' : 'bg-black/40 text-green-200'}`}
+            className={`rounded-lg py-2 px-3.5 my-2 text-xs ${state.humanAction.forcedPass ? 'bg-red-900/50 text-orange-200 border border-red-500/50' : 'bg-black/40 text-green-200'}`}
           >
             {actionDesc(state.players, state.humanAction, t)}
           </div>
         )}
 
         {state.cpuActions && state.cpuActions.length > 0 && (
-          <div className="bg-black/40 rounded-lg py-2 px-3.5 my-2 text-[0.85em]">
+          <div className="bg-black/40 rounded-lg py-2 px-3.5 my-2 text-xs">
             <span className="text-white">{tc('label.cpuActions')}</span>
             {state.cpuActions.map((a, i) => (
               <div
@@ -175,7 +175,7 @@ export function SevensPage() {
           </div>
         )}
 
-        <div className="bg-black/30 rounded-lg py-1.5 px-3 mb-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[0.85em] text-white">
+        <div className="bg-black/30 rounded-lg py-1.5 px-3 mb-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-white">
           <span className="text-yellow-300 font-bold">{t('config.title')}</span>
           <label htmlFor="cfgTunnel" className="flex items-center gap-1 cursor-pointer">
             <input


### PR DESCRIPTION
Replace all `text-[*em]` arbitrary values with standard Tailwind typography
classes across the entire frontend codebase:
- text-[0.65em], text-[0.75em], text-[0.8em], text-[0.82em], text-[0.85em] → text-xs
- text-[0.9em], text-[0.95em] → text-sm
- text-[1.1em] → text-lg

This ensures design system consistency, enables batch design updates via
standard classes, and prevents layout issues from relative em sizing.

Closes #554