### PR TITLE
fix(cli): add prompt character to indicate input waiting state

### DIFF
--- a/internal/infrastructure/ui/input.go
+++ b/internal/infrastructure/ui/input.go
@@ -9,6 +9,7 @@ import (
 // readInput はスキャナから1行を読み込み、EOFとエラーを処理します。
 // 入力テキストと、プログラムを終了すべきかを示すブール値を返します。
 func readInput(scanner *bufio.Scanner) (text string, exit bool) {
+	fmt.Print("> ")
 	if !scanner.Scan() {
 		if err := scanner.Err(); err != nil {
 			fmt.Fprintf(os.Stderr, "入力の読み取り中にエラーが発生しました: %v\n", err)


### PR DESCRIPTION
## Summary
- Add `> ` prompt character in `readInput` before `scanner.Scan()` so users can tell when the CLI is waiting for input

Closes #600

## Test plan
- [x] All Go tests pass (`go test -tags test ./...`)
- [ ] Manually run a CLI game and verify `> ` prompt appears before each input

🤖 Generated with [Claude Code](https://claude.com/claude-code)