### PR TITLE
refactor(domain): unify joker checks to use IsJoker helper

### DIFF
--- a/internal/domain/DaifugoPlayer.go
+++ b/internal/domain/DaifugoPlayer.go
@@ -40,7 +40,7 @@ func (p *DaifugoPlayer) SortCardsByStrength(strengthFn func(*Card) int) {
 // SortCards カードを大富豪の通常ルールに従った強さ順 (弱い順) にソート
 func (p *DaifugoPlayer) SortCards() {
 	p.SortCardsByStrength(func(c *Card) int {
-		if c.GetDesign() == CardDesignJoker {
+		if IsJoker(c) {
 			return DaifugoJokerStrength
 		}
 		return DaifugoCardStrength(c.GetValue())

--- a/internal/domain/OldMaidPlayer.go
+++ b/internal/domain/OldMaidPlayer.go
@@ -41,12 +41,12 @@ func (p *OldMaidPlayer) DiscardPairs() ([]*Card, int) {
 		found := false
 		for i := 0; i < len(p.cards); i++ {
 			c1 := p.cards[i]
-			if c1.GetDesign() == CardDesignJoker {
+			if IsJoker(c1) {
 				continue
 			}
 			for j := i + 1; j < len(p.cards); j++ {
 				c2 := p.cards[j]
-				if c2.GetDesign() == CardDesignJoker {
+				if IsJoker(c2) {
 					continue
 				}
 				if c1.GetValue() == c2.GetValue() {

--- a/internal/domain/PokerPlayer.go
+++ b/internal/domain/PokerPlayer.go
@@ -107,7 +107,7 @@ func evalFiveCardHandWithJokers(cards []*Card) int {
 	// ジョーカーの位置を探す
 	jokerIndices := make([]int, 0)
 	for i, c := range cards {
-		if c.GetDesign() == CardDesignJoker {
+		if IsJoker(c) {
 			jokerIndices = append(jokerIndices, i)
 		}
 	}


### PR DESCRIPTION
## Summary
- Replace direct `c.GetDesign() == CardDesignJoker` comparisons with `IsJoker(c)` in `DaifugoPlayer.go`, `OldMaidPlayer.go`, and `PokerPlayer.go`
- Ensures consistent joker detection across domain layer, making future changes to joker logic a single-point update

Closes #618

## Test plan
- [x] All existing Go tests pass (`go test -tags test ./...`)
- [x] No behavioral changes — `IsJoker(c)` is equivalent to `c.GetDesign() == CardDesignJoker`

🤖 Generated with [Claude Code](https://claude.com/claude-code)