### PR TITLE
feat(cli): add EXAMPLES section to help message

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -60,6 +60,14 @@ OPTIONS:
   --no-color        Disable color output
   -V, --version     Show version information
 
+EXAMPLES:
+  trumpcards                     Start interactive mode (switch games with 'switch <game>')
+  trumpcards blackjack           Play BlackJack
+  trumpcards --lang en poker     Play Poker in English
+  trumpcards update              Self-update to the latest version
+  NO_COLOR=1 trumpcards hearts   Play Hearts without color output
+  trumpcards web                 Start the web GUI server
+
 ENVIRONMENT VARIABLES:
   NO_COLOR          Disable color output when set (see https://no-color.org/)
                     Example: NO_COLOR=1 trumpcards blackjack


### PR DESCRIPTION
## Summary
- Add an `EXAMPLES` section to the CLI help message (`--help`) between OPTIONS and ENVIRONMENT VARIABLES
- Includes examples for interactive mode, direct game launch, language flag, self-update, NO_COLOR, and web server

Closes #648

## Test plan
- [ ] Run `go run ./cmd/trumpcards --help` and verify the EXAMPLES section appears between OPTIONS and ENVIRONMENT VARIABLES
- [ ] Verify all 6 example commands are displayed with correct alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)