### PR TITLE
fix(i18n): use i18n for input read error message

### DIFF
--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -27,5 +27,6 @@
   "updateSuccess": "Successfully updated to {{version}}",
   "updateFetchError": "Failed to fetch latest release info: {{error}}",
   "updateNoAsset": "No binary found for your platform ({{os}}/{{arch}})",
-  "updateApplyError": "Failed to apply update: {{error}}"
+  "updateApplyError": "Failed to apply update: {{error}}",
+  "inputReadError": "Error reading input: {{error}}"
 }

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -27,5 +27,6 @@
   "updateSuccess": "{{version}} にアップデートしました",
   "updateFetchError": "最新リリース情報の取得に失敗しました: {{error}}",
   "updateNoAsset": "お使いの環境({{os}}/{{arch}})に対応するバイナリが見つかりませんでした",
-  "updateApplyError": "アップデートの適用に失敗しました: {{error}}"
+  "updateApplyError": "アップデートの適用に失敗しました: {{error}}",
+  "inputReadError": "入力の読み取り中にエラーが発生しました: {{error}}"
 }

--- a/internal/infrastructure/ui/input.go
+++ b/internal/infrastructure/ui/input.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 // readInput はスキャナから1行を読み込み、EOFとエラーを処理します。
@@ -12,7 +14,7 @@ func readInput(scanner *bufio.Scanner) (text string, exit bool) {
 	fmt.Print("> ")
 	if !scanner.Scan() {
 		if err := scanner.Err(); err != nil {
-			fmt.Fprintf(os.Stderr, "入力の読み取り中にエラーが発生しました: %v\n", err)
+			fmt.Fprintln(os.Stderr, i18n.Tf("inputReadError", "error", err.Error()))
 		}
 		return "", true
 	}


### PR DESCRIPTION
## Summary
- Add `inputReadError` translation key to ja/en `common.json` locale files
- Replace hardcoded Japanese error string in `input.go` with `i18n.Tf("inputReadError", ...)`
- Input read errors now respect the `--lang` flag, consistent with all other CLI messages

Closes #649

## Test plan
- [x] `go test -tags test ./...` passes
- [ ] Run `go run ./cmd/trumpcards --lang en blackjack` and trigger an input error to verify English message
- [ ] Run `go run ./cmd/trumpcards blackjack` and trigger an input error to verify Japanese message

🤖 Generated with [Claude Code](https://claude.com/claude-code)