### PR TITLE
fix(ui): add background color to NavBar for mobile visibility

### DIFF
--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -37,7 +37,7 @@ export function NavBar() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <div>
+    <div className="bg-gray-800">
       <div className="flex items-center justify-between sm:hidden my-2 mx-2.5">
         <Link to="/" className="text-white font-bold" onClick={() => setIsOpen(false)}>
           Trump Cards


### PR DESCRIPTION
## Summary
- Add `bg-gray-800` to the NavBar outer `<div>` so the hamburger menu (☰) and brand text ("Trump Cards") are visible on mobile
- Previously, white text on the default white body background made the mobile header invisible

Closes #687

## Test plan
- [x] `npm run build` passes
- [x] `npm run check` passes
- [x] `npm test` passes (1410 tests)
- [ ] Verify hamburger menu visibility on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)