### PR TITLE
feat(ui): add scope="col" to HeartsPage score table headers

### DIFF
--- a/frontend/src/pages/HeartsPage.test.tsx
+++ b/frontend/src/pages/HeartsPage.test.tsx
@@ -305,6 +305,15 @@ describe('HeartsPage', () => {
     });
   });
 
+  it('score table headers have scope="col" for accessibility', async () => {
+    const { container } = renderWithProviders(<HeartsPage />);
+    await waitFor(() => expect(screen.getByText('あなた')).toBeInTheDocument());
+    const ths = container.querySelectorAll('th');
+    ths.forEach((th) => {
+      expect(th).toHaveAttribute('scope', 'col');
+    });
+  });
+
   it('shows hearts broken text', async () => {
     mockExec.mockResolvedValue(heartsBrokenState);
     renderWithProviders(<HeartsPage />);

--- a/frontend/src/pages/HeartsPage.tsx
+++ b/frontend/src/pages/HeartsPage.tsx
@@ -175,10 +175,12 @@ export function HeartsPage() {
           <table className="w-full text-sm text-white/70">
             <thead>
               <tr>
-                <th className="text-left">{t('scoresPlayer')}</th>
-                <th>{t('scoresRound')}</th>
-                <th>{t('scoresTotal')}</th>
-                <th>{t('scoresTricks')}</th>
+                <th scope="col" className="text-left">
+                  {t('scoresPlayer')}
+                </th>
+                <th scope="col">{t('scoresRound')}</th>
+                <th scope="col">{t('scoresTotal')}</th>
+                <th scope="col">{t('scoresTricks')}</th>
               </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
## Summary
- Add `scope="col"` attribute to all `<th>` elements in the HeartsPage score table for screen reader accessibility (WCAG 2.1 Level A §1.3.1)
- Add unit test verifying all table headers have the `scope="col"` attribute

Closes #654

## Test plan
- [x] New test `score table headers have scope="col" for accessibility` passes
- [x] All 58 HeartsPage tests pass
- [x] `npm run build` succeeds
- [x] `npm run check` passes (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)