### PR TITLE
fix: unify card selection visual feedback in PokerPage

### DIFF
--- a/frontend/src/pages/PokerPage.test.tsx
+++ b/frontend/src/pages/PokerPage.test.tsx
@@ -631,6 +631,23 @@ describe('PokerPage', () => {
     expect(cardBtn).toHaveAttribute('aria-label', '♠ A');
   });
 
+  it('applies unified selectedCardStyle to card button when selected', async () => {
+    mockExec.mockResolvedValue(exchangeState);
+    renderWithProviders(<PokerPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'スタンド' })).toBeInTheDocument());
+
+    const cardBtn = screen.getByAltText('♠ A').closest('button') as HTMLButtonElement;
+    // Before selection: transparent border, no transform
+    expect(cardBtn.style.border).toBe('3px solid transparent');
+    expect(cardBtn.style.transform).toBe('none');
+
+    fireEvent.click(cardBtn);
+    // After selection: selectedCardStyle applied to button (border + transform + shadow)
+    expect(cardBtn.style.border).toContain('3px solid');
+    expect(cardBtn.style.border).not.toBe('3px solid transparent');
+    expect(cardBtn.style.transform).toBe('translateY(-8px)');
+  });
+
   it('does not select card when not in exchange phase', async () => {
     mockExec.mockResolvedValue(dealState);
     renderWithProviders(<PokerPage />);

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -32,15 +32,6 @@ function usePhaseNames(t: (key: string) => string): Record<number, string> {
   };
 }
 
-const cardWrapBase: React.CSSProperties = {
-  position: 'relative',
-  cursor: 'pointer',
-  transition: 'transform 0.15s',
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'center',
-};
-
 export function PokerPage() {
   const { t } = useTranslation('poker');
   const { t: tc } = useTranslation('common');
@@ -178,23 +169,14 @@ export function PokerPage() {
                     className={`${focusRingBlue} rounded`}
                     style={{
                       background: 'none',
-                      border: 'none',
                       padding: 0,
-                      ...cardWrapBase,
                       cursor: canExchange ? 'pointer' : 'default',
+                      borderRadius: 8,
+                      ...selectedCardStyle(isSelected),
+                      boxSizing: 'border-box',
                     }}
                   >
-                    <CardImage card={card} width={60} style={selectedCardStyle(isSelected)} />
-                    <div
-                      style={{
-                        color: 'var(--color-game-card-selected)',
-                        fontSize: '0.75em',
-                        fontWeight: 'bold',
-                        visibility: isSelected ? 'visible' : 'hidden',
-                      }}
-                    >
-                      {t('exchangeLabel')}
-                    </div>
+                    <CardImage card={card} width={60} />
                   </button>
                 );
               })}


### PR DESCRIPTION
## Summary
- Moved `selectedCardStyle` from `CardImage` to the wrapping `<button>` in PokerPage, matching the unified pattern used by Daifugo, Hearts, and Doubt (border + translateY + shadow)
- Removed the text label ("交換") `<div>` below selected cards — selection is now indicated visually via border, lift, and shadow only
- Removed the unused `cardWrapBase` constant

Closes #658

## Test plan
- [x] Added test `applies unified selectedCardStyle to card button when selected` verifying border/transform on button
- [x] All 1526 frontend tests pass
- [x] `bun run build` passes
- [x] `bun run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)