### PR TITLE
fix: unify ErrorAlert placement inside GameFooter for all game pages

### DIFF
--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -77,8 +77,6 @@ export function BaccaratPage() {
       </PhaseIndicator>
 
       <div className="flex-1 overflow-y-auto pt-3 px-4">
-        <ErrorAlert message={error} />
-
         <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
 
         {/* Player Hand */}
@@ -120,6 +118,7 @@ export function BaccaratPage() {
 
       {/* Footer */}
       <GameFooter className="bg-gray-800 px-4 pt-3">
+        <ErrorAlert message={error} />
         {isBetPhase && (
           <div className="flex flex-col items-center gap-2 pb-2">
             <div className="flex items-center gap-2">

--- a/frontend/src/pages/HeartsPage.tsx
+++ b/frontend/src/pages/HeartsPage.tsx
@@ -199,9 +199,6 @@ export function HeartsPage() {
         {/* Message */}
         <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
 
-        {/* Error */}
-        <ErrorAlert message={error} />
-
         {/* Action log */}
         <ActionLogSection
           isEndPhase={isGameEnd}
@@ -237,6 +234,8 @@ export function HeartsPage() {
             ))}
           </div>
         )}
+
+        <ErrorAlert message={error} />
 
         <div className="flex gap-2 items-center">
           {isPassPhase && (

--- a/frontend/src/pages/KlondikePage.tsx
+++ b/frontend/src/pages/KlondikePage.tsx
@@ -234,9 +234,6 @@ export function KlondikePage() {
         {/* Message */}
         <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
 
-        {/* Error */}
-        <ErrorAlert message={error ?? hintError} />
-
         {/* Action log */}
         <ActionLogSection
           isEndPhase={isEnded}
@@ -248,6 +245,7 @@ export function KlondikePage() {
 
       {/* Footer */}
       <GameFooter className="bg-game-bg-casino-dark border-white/20 px-4 py-2.5">
+        <ErrorAlert message={error ?? hintError} />
         <div className="flex gap-2 items-center flex-wrap">
           {isPlaying && (
             <>

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -139,9 +139,6 @@ export function MemoryPage() {
         {/* Message */}
         <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
 
-        {/* Error */}
-        <ErrorAlert message={error} />
-
         {/* Action log */}
         <ActionLogSection
           isEndPhase={isGameEnd}
@@ -153,6 +150,7 @@ export function MemoryPage() {
 
       {/* Footer */}
       <GameFooter className="bg-game-bg-blue-dark border-white/20 px-4 py-2.5">
+        <ErrorAlert message={error} />
         <div className="flex gap-2 items-center">
           {isResult && (
             <button type="button" className={btnSuccess} onClick={handleNext} disabled={loading}>


### PR DESCRIPTION
## Summary
- Move `<ErrorAlert>` from scrollable content area into `<GameFooter>` for HeartsPage, MemoryPage, KlondikePage, and BaccaratPage
- Matches the pattern already used by the other 7 game pages, ensuring errors are always visible regardless of scroll position

Closes #659

## Test plan
- [x] `bun run build` passes
- [x] `bun run check` passes
- [x] `bun run test` passes (68 files, 1526 tests)
- [ ] Manual verification: trigger an API error on Hearts, Memory, Klondike, and Baccarat pages and confirm the error message appears in the footer area

🤖 Generated with [Claude Code](https://claude.com/claude-code)