### PR TITLE
feat: make OldMaidDiscardedArea card sizes responsive

### DIFF
--- a/frontend/src/components/oldmaid/OldMaidDiscardedArea.test.tsx
+++ b/frontend/src/components/oldmaid/OldMaidDiscardedArea.test.tsx
@@ -49,8 +49,9 @@ describe('OldMaidDiscardedArea', () => {
     const cards = [makeCard('SPADE', 1), makeCard('HEART', 1)];
     const { container } = render(<OldMaidDiscardedArea cards={cards} />);
     const pairContainer = container.querySelector('div[style*="position: relative"]') as HTMLElement;
-    expect(pairContainer.style.width).toBe('60px');
-    expect(pairContainer.style.height).toBe('84px');
+    // desktop: cardWidth=60, cardHeight=84, overlapLeft=11, overlapTop=7
+    expect(pairContainer.style.width).toBe('71px');
+    expect(pairContainer.style.height).toBe('91px');
   });
 
   it('uses mobile card dimensions on narrow viewport', () => {
@@ -58,8 +59,9 @@ describe('OldMaidDiscardedArea', () => {
     const cards = [makeCard('SPADE', 1), makeCard('HEART', 1)];
     const { container } = render(<OldMaidDiscardedArea cards={cards} />);
     const pairContainer = container.querySelector('div[style*="position: relative"]') as HTMLElement;
-    expect(pairContainer.style.width).toBe('40px');
-    expect(pairContainer.style.height).toBe('60px');
+    // mobile: cardWidth=40, cardHeight=60, overlapLeft=7, overlapTop=4
+    expect(pairContainer.style.width).toBe('47px');
+    expect(pairContainer.style.height).toBe('64px');
   });
 
   it('scales overlap offsets proportionally on desktop', () => {

--- a/frontend/src/components/oldmaid/OldMaidDiscardedArea.tsx
+++ b/frontend/src/components/oldmaid/OldMaidDiscardedArea.tsx
@@ -22,15 +22,20 @@ export function OldMaidDiscardedArea({ cards }: { cards: Card[] | undefined }) {
   // If odd number of cards, show the last one alone
   const remainder = cards.length % 2 === 1 ? cards[cards.length - 1] : null;
 
-  const overlapLeft = Math.round(cardWidth * 0.18);
-  const overlapTop = Math.round(cardWidth * 0.11);
+  const HORIZONTAL_OVERLAP_RATIO = 0.18;
+  const VERTICAL_OVERLAP_RATIO = 0.11;
+  const overlapLeft = Math.round(cardWidth * HORIZONTAL_OVERLAP_RATIO);
+  const overlapTop = Math.round(cardWidth * VERTICAL_OVERLAP_RATIO);
 
   return (
     <div className="my-2 p-2 bg-black/20 rounded-[10px] text-center min-h-[90px]">
       <div className="text-game-text-muted text-xs mb-1.5">{t('lastDiscarded')}</div>
       <div className="flex justify-center gap-5 items-end">
         {pairs.map(([c1, c2]) => (
-          <div key={`${c1.design}-${c1.value}`} style={{ position: 'relative', width: cardWidth, height: cardHeight }}>
+          <div
+            key={`${c1.design}-${c1.value}`}
+            style={{ position: 'relative', width: cardWidth + overlapLeft, height: cardHeight + overlapTop }}
+          >
             <CardImage card={c1} width={cardWidth} style={{ position: 'absolute', left: 0, top: 0 }} />
             <CardImage
               card={c2}


### PR DESCRIPTION
## Summary
- Replace hardcoded card dimensions (`width: 65, height: 82`, `width={55}`) in `OldMaidDiscardedArea` with `useCardDimensions` hook for responsive sizing (40px mobile, 60px desktop)
- Scale overlap offsets proportionally using `Math.round(cardWidth * 0.18)` and `Math.round(cardWidth * 0.11)`
- Add unit tests with 100% branch coverage (empty/undefined, pairs, remainder, desktop/mobile dimensions, overlap offsets)

Closes #661

## Test plan
- [x] `bun run test -- --run OldMaidDiscardedArea` — 8 tests pass
- [x] `bun run build` — builds successfully
- [x] `bun run check` — no new errors
- [x] `bun run test` — all 1554 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)