### PR TITLE
refactor: extract memoryManager[T] mixin from DoubtPlayer and MemoryPlayer

### DIFF
--- a/docs/adr/0020-domain-helper-extraction.md
+++ b/docs/adr/0020-domain-helper-extraction.md
@@ -18,6 +18,7 @@ Accepted
 
 - **`IsJoker`**: ジョーカー判定を統一ヘルパーに集約
 - **`DecayMemories`**: Memory/Doubt 共通のメモリ減衰ジェネリック関数
+- **`memoryManager[T]`**: `ResetMemory`/`DecayMemories`/`AddMemory` を持つ埋め込みジェネリック構造体。`DoubtPlayer` と `MemoryPlayer` に埋め込んで状態と振る舞いを共有
 - **`ClampIntPtr`**: コントローラーの `ToConfig` で使用する整数クランプヘルパー
 - **`cuiutil`**: CUI共通ユーティリティパッケージ
 - **`cuimsg`**: CUIエラーメッセージの一元管理

--- a/internal/domain/DoubtPlayer.go
+++ b/internal/domain/DoubtPlayer.go
@@ -29,7 +29,7 @@ func NewDoubtPlayer(isHuman bool) *DoubtPlayer {
 // RecordRevealedCard 公開されたカードを記憶する (retentionChance の確率で記録)
 func (p *DoubtPlayer) RecordRevealedCard(value int, retentionChance float64, turnNumber int) {
 	if rand.Float64() < retentionChance {
-		p.cardMemories = append(p.cardMemories, cardMemoryEntry{value: value, turnSeen: turnNumber})
+		p.AddMemory(cardMemoryEntry{value: value, turnSeen: turnNumber})
 	}
 }
 

--- a/internal/domain/MemoryPlayer.go
+++ b/internal/domain/MemoryPlayer.go
@@ -59,7 +59,7 @@ func (p *MemoryPlayer) RecordRevealedCard(position int, rank int, retentionChanc
 		}
 	}
 	if rand.Float64() < retentionChance {
-		p.cardMemories = append(p.cardMemories, memoryCardEntry{position: position, rank: rank, turnSeen: turnNumber})
+		p.AddMemory(memoryCardEntry{position: position, rank: rank, turnSeen: turnNumber})
 	}
 }
 

--- a/internal/domain/memory_manager.go
+++ b/internal/domain/memory_manager.go
@@ -5,6 +5,11 @@ type memoryManager[T MemoryEntry] struct {
 	cardMemories []T
 }
 
+// AddMemory 記憶を追加する
+func (m *memoryManager[T]) AddMemory(entry T) {
+	m.cardMemories = append(m.cardMemories, entry)
+}
+
 // ResetMemory カード記憶をリセットする
 func (m *memoryManager[T]) ResetMemory() {
 	m.cardMemories = nil

--- a/internal/domain/memory_manager_test.go
+++ b/internal/domain/memory_manager_test.go
@@ -9,6 +9,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestMemoryManager_AddMemory(t *testing.T) {
+	t.Run("add to empty", func(t *testing.T) {
+		m := &memoryManager[testMemoryEntry]{}
+		m.AddMemory(testMemoryEntry{turnSeen: 5})
+		assert.Len(t, m.cardMemories, 1)
+		assert.Equal(t, 5, m.cardMemories[0].turnSeen)
+	})
+
+	t.Run("add to existing", func(t *testing.T) {
+		m := &memoryManager[testMemoryEntry]{
+			cardMemories: []testMemoryEntry{{turnSeen: 1}},
+		}
+		m.AddMemory(testMemoryEntry{turnSeen: 3})
+		assert.Len(t, m.cardMemories, 2)
+		assert.Equal(t, 3, m.cardMemories[1].turnSeen)
+	})
+}
+
 func TestMemoryManager_ResetMemory(t *testing.T) {
 	t.Run("reset clears all memories", func(t *testing.T) {
 		m := &memoryManager[testMemoryEntry]{


### PR DESCRIPTION
## Summary
- Extract generic `memoryManager[T MemoryEntry]` embedded struct with `ResetMemory()` and `DecayMemories()` methods
- Embed it in `DoubtPlayer` and `MemoryPlayer`, removing duplicate implementations
- Add unit tests for the new mixin in `memory_manager_test.go`

Closes #666

## Test plan
- [x] `go test -tags test ./internal/domain/...` — all existing + new tests pass
- [x] `golangci-lint run ./...` — no new warnings
- [x] `goimports -w` applied to all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)