### PR TITLE
refactor: extract gameExec helper to deduplicate game API calls

### DIFF
--- a/frontend/src/api/gameApi.test.ts
+++ b/frontend/src/api/gameApi.test.ts
@@ -282,10 +282,10 @@ describe('gameApi', () => {
           body: JSON.stringify({
             command: 'reset',
             amount: undefined,
-            sessionId,
             dealerHitsSoft17: true,
             cpuPlayerCount: 2,
             countingEnabled: true,
+            sessionId,
           }),
         }),
       );
@@ -312,9 +312,9 @@ describe('gameApi', () => {
           body: JSON.stringify({
             command: 'bet',
             amount: 100,
-            sessionId,
             perfectPairsBet: 10,
             twentyOnePlus3Bet: 20,
+            sessionId,
           }),
         }),
       );
@@ -469,8 +469,8 @@ describe('gameApi', () => {
           body: JSON.stringify({
             command: 'reset',
             amount: undefined,
-            sessionId,
             surrenderRule: 1,
+            sessionId,
           }),
         }),
       );
@@ -1043,12 +1043,12 @@ describe('gameApi', () => {
         expect.objectContaining({
           body: JSON.stringify({
             command: 'reset',
-            sessionId,
             doubtWindowSec: 3,
             cpuMemoryLevel: 2,
             penaltyDrawLimit: 5,
             cpuHesitationEnabled: true,
             cpuMetaAI: false,
+            sessionId,
           }),
         }),
       );
@@ -1211,11 +1211,11 @@ describe('gameApi', () => {
           index: -1,
           jokerTargetSuit: 0,
           jokerTargetValue: 0,
-          sessionId,
           tunnelEnabled: true,
           jokerCount: 2,
           cpuStrategy: 1,
           noJokerFinish: true,
+          sessionId,
         }),
       });
     });
@@ -1244,11 +1244,11 @@ describe('gameApi', () => {
           index: -1,
           jokerTargetSuit: 0,
           jokerTargetValue: 0,
-          sessionId,
           tunnelEnabled: true,
           jokerCount: 2,
           cpuStrategy: 1,
           maxPasses: 3,
+          sessionId,
         }),
       });
     });
@@ -1284,9 +1284,9 @@ describe('gameApi', () => {
           index: -1,
           jokerTargetSuit: 0,
           jokerTargetValue: 0,
-          sessionId,
           jokerCount: 1,
           jokerConsecutiveBanned: true,
+          sessionId,
         }),
       });
     });
@@ -1393,9 +1393,9 @@ describe('gameApi', () => {
           body: JSON.stringify({
             command: 'reset',
             amount: undefined,
-            sessionId,
             smallBlind: 10,
             bigBlind: 20,
+            sessionId,
           }),
         }),
       );
@@ -1414,10 +1414,10 @@ describe('gameApi', () => {
           body: JSON.stringify({
             command: 'reset',
             amount: undefined,
-            sessionId,
             tournamentMode: true,
             blindLevelHands: 5,
             blindMultiplier: 200,
+            sessionId,
           }),
         }),
       );
@@ -1432,8 +1432,8 @@ describe('gameApi', () => {
           body: JSON.stringify({
             command: 'reset',
             amount: undefined,
-            sessionId,
             bettingLimit: 2,
+            sessionId,
           }),
         }),
       );
@@ -1448,8 +1448,8 @@ describe('gameApi', () => {
           body: JSON.stringify({
             command: 'reset',
             amount: undefined,
-            sessionId,
             tableSize: 6,
+            sessionId,
           }),
         }),
       );
@@ -1494,10 +1494,10 @@ describe('gameApi', () => {
           body: JSON.stringify({
             command: 'reset',
             amount: undefined,
-            sessionId,
             rebuyEnabled: true,
             addonEnabled: true,
             rebuyMaxCount: 5,
+            sessionId,
           }),
         }),
       );
@@ -1566,8 +1566,8 @@ describe('gameApi', () => {
           command: 'reset',
           cardIndices: undefined,
           cardIndex: undefined,
-          sessionId,
           config: undefined,
+          sessionId,
         }),
       });
       expect(result).toEqual(payload);
@@ -1583,8 +1583,8 @@ describe('gameApi', () => {
             command: 'play',
             cardIndices: undefined,
             cardIndex: 3,
-            sessionId,
             config: undefined,
+            sessionId,
           }),
         }),
       );
@@ -1600,8 +1600,8 @@ describe('gameApi', () => {
             command: 'pass',
             cardIndices: [0, 1, 2],
             cardIndex: undefined,
-            sessionId,
             config: undefined,
+            sessionId,
           }),
         }),
       );
@@ -1617,8 +1617,8 @@ describe('gameApi', () => {
             command: 'reset',
             cardIndices: undefined,
             cardIndex: undefined,
-            sessionId,
             config: { cpuDifficulty: 2, pointLimit: 50 },
+            sessionId,
           }),
         }),
       );
@@ -1655,8 +1655,8 @@ describe('gameApi', () => {
         body: JSON.stringify({
           command: 'reset',
           position: undefined,
-          sessionId,
           config: undefined,
+          sessionId,
         }),
       });
       expect(result).toEqual(payload);
@@ -1671,8 +1671,8 @@ describe('gameApi', () => {
           body: JSON.stringify({
             command: 'flip',
             position: 5,
-            sessionId,
             config: undefined,
+            sessionId,
           }),
         }),
       );
@@ -1687,8 +1687,8 @@ describe('gameApi', () => {
           body: JSON.stringify({
             command: 'reset',
             position: undefined,
-            sessionId,
             config: { cpuDifficulty: 2 },
+            sessionId,
           }),
         }),
       );

--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -27,6 +27,10 @@ async function postJson<T>(url: string, body: unknown): Promise<T> {
   return res.json() as Promise<T>;
 }
 
+function gameExec<T>(game: string, body: Record<string, unknown>): Promise<T> {
+  return postJson<T>(`/${game}/exec`, { ...body, sessionId });
+}
+
 export interface BlackJackConfigInput {
   dealerHitsSoft17?: boolean;
   cpuPlayerCount?: number;
@@ -69,7 +73,7 @@ export const blackjackApi = {
     amount?: number,
     config?: BlackJackConfigInput,
     betOptions?: BlackJackBetOptions,
-  ) => postJson<BlackJackResponse>('/blackjack/exec', { command, amount, sessionId, ...config, ...betOptions }),
+  ) => gameExec<BlackJackResponse>('blackjack', { command, amount, ...config, ...betOptions }),
 };
 
 export interface PokerConfigInput {
@@ -85,7 +89,7 @@ export const pokerApi = {
     indices?: number[],
     amount?: number,
     config?: PokerConfigInput,
-  ) => postJson<PokerResponse>('/poker/exec', { command, indices, amount, ...config, sessionId }),
+  ) => gameExec<PokerResponse>('poker', { command, indices, amount, ...config }),
 };
 
 export const oldmaidApi = {
@@ -99,7 +103,7 @@ export const oldmaidApi = {
     cpuHesitationEnabled?: boolean,
     cpuMetaAI?: boolean,
   ) =>
-    postJson<OldMaidResponse>('/oldmaid/exec', {
+    gameExec<OldMaidResponse>('oldmaid', {
       command,
       drawIdx,
       mode,
@@ -108,13 +112,12 @@ export const oldmaidApi = {
       cpuMemoryAI,
       cpuHesitationEnabled,
       cpuMetaAI,
-      sessionId,
     }),
 };
 
 export const daifugoApi = {
   exec: (command: 'reset' | 'play' | 'sort', indices?: number[], config?: DaifugoConfigInput, sortMode?: number) =>
-    postJson<DaifugoResponse>('/daifugo/exec', { command, indices, config, sortMode, sessionId }),
+    gameExec<DaifugoResponse>('daifugo', { command, indices, config, sortMode }),
 };
 
 export const doubtApi = {
@@ -125,12 +128,11 @@ export const doubtApi = {
     doubterIndices?: number[],
     config?: DoubtConfig,
   ) =>
-    postJson<DoubtResponse>('/doubt/exec', {
+    gameExec<DoubtResponse>('doubt', {
       command,
       cardIndices,
       claimedValue,
       doubterIndices,
-      sessionId,
       doubtWindowSec: config?.doubtWindowSec,
       cpuMemoryLevel: config?.cpuMemoryLevel,
       penaltyDrawLimit: config?.penaltyDrawLimit,
@@ -159,12 +161,11 @@ export const sevensApi = {
     jokerTargetValue = 0,
     config?: SevensConfigInput,
   ) =>
-    postJson<SevensResponse>('/sevens/exec', {
+    gameExec<SevensResponse>('sevens', {
       command,
       index,
       jokerTargetSuit,
       jokerTargetValue,
-      sessionId,
       ...config,
     }),
 };
@@ -205,10 +206,9 @@ export const holdemApi = {
     amount?: number,
     config?: HoldemConfigInput,
   ) =>
-    postJson<HoldemResponse>('/holdem/exec', {
+    gameExec<HoldemResponse>('holdem', {
       command,
       amount,
-      sessionId,
       ...config,
     }),
 };
@@ -225,11 +225,10 @@ export const heartsApi = {
     cardIndex?: number,
     config?: HeartsConfigInput,
   ) =>
-    postJson<HeartsResponse>('/hearts/exec', {
+    gameExec<HeartsResponse>('hearts', {
       command,
       cardIndices,
       cardIndex,
-      sessionId,
       config,
     }),
 };
@@ -240,10 +239,9 @@ export interface MemoryConfigInput {
 
 export const memoryApi = {
   exec: (command: 'reset' | 'flip' | 'next' | 'log', position?: number, config?: MemoryConfigInput) =>
-    postJson<MemoryResponse>('/memory/exec', {
+    gameExec<MemoryResponse>('memory', {
       command,
       position,
-      sessionId,
       config,
     }),
 };
@@ -260,22 +258,17 @@ export const klondikeApi = {
     from?: KlondikeMoveZone,
     to?: KlondikeMoveZone,
   ) =>
-    postJson<KlondikeResponse>('/klondike/exec', {
+    gameExec<KlondikeResponse>('klondike', {
       command,
       from,
       to,
-      sessionId,
     }),
 };
 
 export const baccaratApi = {
   exec: (command: 'reset' | 'bet' | 'log', amount?: number, betType?: number) =>
-    postJson<BaccaratResponse>('/baccarat/exec', { command, amount, betType, sessionId }),
+    gameExec<BaccaratResponse>('baccarat', { command, amount, betType }),
 };
-
-function fetchLog(url: string): Promise<ActionLogResponse> {
-  return postJson<ActionLogResponse>(url, { command: 'log', sessionId });
-}
 
 const games = [
   'blackjack',
@@ -294,7 +287,7 @@ type Game = (typeof games)[number];
 
 export const actionLogApi: { [K in Game]: () => Promise<ActionLogResponse> } = games.reduce(
   (acc, game) => {
-    acc[game] = () => fetchLog(`/${game}/exec`);
+    acc[game] = () => gameExec<ActionLogResponse>(game, { command: 'log' });
     return acc;
   },
   {} as { [K in Game]: () => Promise<ActionLogResponse> },


### PR DESCRIPTION
## Summary
- Added `gameExec<T>(game, body)` helper in `gameApi.ts` that encapsulates the `postJson` call pattern with URL construction (`/${game}/exec`) and `sessionId` injection
- Updated all 11 game APIs and `actionLogApi` to delegate to `gameExec`, removing duplicated `sessionId` and URL pattern across the file
- Removed the now-unnecessary `fetchLog` helper

Closes #670

## Test plan
- [x] `bun run test` — all 1604 tests pass
- [x] `bun run check` — lint/format pass
- [x] `bun run build` — build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)