### PR TITLE
refactor: remove empty onSuccess callback from BaccaratPage

### DIFF
--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { baccaratApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
 import { CardImage } from '../components/CardImage';
@@ -13,7 +13,6 @@ import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
-import type { BaccaratResponse } from '../types/card';
 import { BaccaratBetType, BaccaratPhase } from '../types/phases';
 
 const BET_TYPE_LABELS: Record<number, string> = {
@@ -29,10 +28,8 @@ export function BaccaratPage() {
   const [betAmount, setBetAmount] = useState(100);
   const [betType, setBetType] = useState<number>(BaccaratBetType.PLAYER);
 
-  const onSuccess = useCallback((_res: BaccaratResponse) => {}, []);
-
   const { cardWidth } = useCardDimensions();
-  const { state, loading, error, exec } = useGameApi(baccaratApi.exec, { onSuccess });
+  const { state, loading, error, exec } = useGameApi(baccaratApi.exec);
 
   useEffect(() => {
     exec('reset');


### PR DESCRIPTION
## Summary
- Remove the empty `onSuccess` callback and its `useCallback`/`BaccaratResponse` imports from `BaccaratPage.tsx`
- `useGameApi` already supports optional `onSuccess`, so no hook changes needed

Closes #674

## Test plan
- [x] `bun run build` passes
- [x] `bun run check` passes
- [x] All 18 BaccaratPage tests pass
- [x] No other pages affected (only BaccaratPage had the empty callback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)