### PR TITLE
fix: output --help to stdout with exit code 0

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -29,12 +29,7 @@ func main() {
 }
 
 func run() int {
-	lang := flag.String("lang", "", "language (ja or en)")
-	showVersion := flag.Bool("version", false, "Show version information")
-	flag.BoolVar(showVersion, "V", false, "Show version information (shorthand)")
-	noColorFlag := flag.Bool("no-color", false, "Disable color output")
-	flag.Usage = func() {
-		fmt.Fprint(os.Stderr, `USAGE:
+	helpText := `USAGE:
   trumpcards [--lang ja|en] [game]
   trumpcards --help
 
@@ -79,9 +74,23 @@ ENVIRONMENT VARIABLES:
                     Example: NO_COLOR=1 trumpcards blackjack
   PORT              Port number for the web server (default: 8080)
                     Example: PORT=3000 trumpcards web
-`)
+`
+
+	lang := flag.String("lang", "", "language (ja or en)")
+	showVersion := flag.Bool("version", false, "Show version information")
+	flag.BoolVar(showVersion, "V", false, "Show version information (shorthand)")
+	noColorFlag := flag.Bool("no-color", false, "Disable color output")
+	showHelp := flag.Bool("help", false, "Show this help message")
+	flag.BoolVar(showHelp, "h", false, "Show this help message (shorthand)")
+	flag.Usage = func() {
+		fmt.Fprint(os.Stderr, helpText)
 	}
 	flag.Parse()
+
+	if *showHelp {
+		_, _ = fmt.Fprint(os.Stdout, helpText)
+		return 0
+	}
 
 	// Color control: NO_COLOR env var (https://no-color.org/), --no-color flag,
 	// or non-TTY stdout (pipe/redirect auto-detection).


### PR DESCRIPTION
## Summary
- Separate `--help`/`-h` output to stdout (exit 0) from error-triggered usage on stderr, per GNU coding standards
- Extract help text into a shared variable to avoid duplication
- Explicitly define `-help`/`-h` flags to override Go's default `flag.ErrHelp` behavior (which calls `flag.Usage()` + `os.Exit(2)`)

Closes #753

## Test plan
- [ ] `go run ./cmd/trumpcards --help` prints to stdout (verify with `go run ./cmd/trumpcards --help | cat`)
- [ ] `go run ./cmd/trumpcards --help | grep poker` finds the line
- [ ] `go run ./cmd/trumpcards -h` works the same as `--help`
- [ ] `go run ./cmd/trumpcards unknowngame` prints usage to stderr (exit 2)
- [ ] `golangci-lint run ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)