### PR TITLE
fix: output interactive prompt to stderr instead of stdout

### DIFF
--- a/internal/infrastructure/ui/input.go
+++ b/internal/infrastructure/ui/input.go
@@ -11,7 +11,7 @@ import (
 // readInput はスキャナから1行を読み込み、EOFとエラーを処理します。
 // 入力テキストと、プログラムを終了すべきかを示すブール値を返します。
 func readInput(scanner *bufio.Scanner) (text string, exit bool) {
-	fmt.Print("> ")
+	fmt.Fprint(os.Stderr, "> ")
 	if !scanner.Scan() {
 		if err := scanner.Err(); err != nil {
 			fmt.Fprintln(os.Stderr, i18n.Tf("inputReadError", "error", err.Error()))


### PR DESCRIPTION
## Summary
- Change `readInput` prompt `"> "` output from `fmt.Print` (stdout) to `fmt.Fprint(os.Stderr, ...)` (stderr)
- Prevents prompt characters from polluting stdout when redirecting or piping game output
- Follows POSIX convention: stdout for data, stderr for interactive/diagnostic messages

Closes #754

## Test plan
- [ ] `go test -tags test ./...` passes
- [ ] `golangci-lint run ./...` reports 0 issues
- [ ] Manual: `go run ./cmd/trumpcards blackjack > /dev/null` still shows `"> "` prompt on terminal
- [ ] Manual: `go run ./cmd/trumpcards blackjack > game.log` — log file contains no `"> "` strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)