### PR TITLE
fix: replace low-opacity white text with text-game-text-muted for WCAG AA

### DIFF
--- a/frontend/src/components/PhaseIndicator.test.tsx
+++ b/frontend/src/components/PhaseIndicator.test.tsx
@@ -19,7 +19,7 @@ describe('PhaseIndicator', () => {
     render(<PhaseIndicator phaseName="アクション" isHumanTurn={false} />);
     expect(screen.getByText('待機中')).toBeInTheDocument();
     const turnSpan = screen.getByText('待機中');
-    expect(turnSpan).toHaveClass('text-white/50');
+    expect(turnSpan).toHaveClass('text-game-text-muted');
   });
 
   it('does not render turn indicator when isHumanTurn is undefined', () => {

--- a/frontend/src/components/PhaseIndicator.tsx
+++ b/frontend/src/components/PhaseIndicator.tsx
@@ -21,7 +21,7 @@ export function PhaseIndicator({ phaseName, isHumanTurn, children }: PhaseIndica
         <strong>{phaseName}</strong>
       </span>
       {isHumanTurn !== undefined && (
-        <span className={isHumanTurn ? 'text-green-400 animate-pulse' : 'text-white/50'}>
+        <span className={isHumanTurn ? 'text-green-400 animate-pulse' : 'text-game-text-muted'}>
           {isHumanTurn ? t('turnIndicator.yourTurn') : t('turnIndicator.waiting')}
         </span>
       )}

--- a/frontend/src/components/oldmaid/OldMaidDiscardedArea.tsx
+++ b/frontend/src/components/oldmaid/OldMaidDiscardedArea.tsx
@@ -9,7 +9,7 @@ export function OldMaidDiscardedArea({ cards }: { cards: Card[] | undefined }) {
   const { cardWidth, cardHeight } = useCardDimensions();
   if (!cards || cards.length === 0) {
     return (
-      <div className="h-[90px] flex items-center justify-center border-2 border-dashed border-white/15 rounded-[10px] my-2 text-white/30 text-sm">
+      <div className="h-[90px] flex items-center justify-center border-2 border-dashed border-white/15 rounded-[10px] my-2 text-game-text-muted text-sm">
         {t('discardArea')}
       </div>
     );

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -86,7 +86,7 @@ export function FreeCellPage() {
           {/* Free cells */}
           {state.freeCells.map((card: Card | null, idx: number) => (
             <div key={`fc-${idx.toString()}`} className="text-center">
-              <div className="text-white/60 text-xs mb-1">
+              <div className="text-game-text-muted text-xs mb-1">
                 {t('freecell')} {idx}
               </div>
               {card ? (
@@ -107,7 +107,7 @@ export function FreeCellPage() {
                   disabled={!isPlaying || loading || !selectedSource}
                   aria-label={t('emptyFreecellAriaLabel', { idx: String(idx) })}
                   style={{ width: cardWidth, height: cardHeight }}
-                  className={`rounded border-2 border-dashed border-white/30 text-white/30 text-xs flex items-center justify-center ${focusRingWhite}`}
+                  className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}`}
                 >
                   {t('empty')}
                 </button>
@@ -120,7 +120,7 @@ export function FreeCellPage() {
           {/* Foundation piles */}
           {state.foundation.map((pile: Card[], idx: number) => (
             <div key={`f-${idx.toString()}`} className="text-center">
-              <div className="text-white/60 text-xs mb-1">{FOUNDATION_SUITS[idx]}</div>
+              <div className="text-game-text-muted text-xs mb-1">{FOUNDATION_SUITS[idx]}</div>
               {pile.length > 0 ? (
                 <button
                   type="button"
@@ -138,7 +138,7 @@ export function FreeCellPage() {
                   disabled={!isPlaying || loading || !selectedSource}
                   aria-label={t('emptyFoundationAriaLabel', { suit: FOUNDATION_SUITS[idx] })}
                   style={{ width: cardWidth, height: cardHeight }}
-                  className={`rounded border-2 border-dashed border-white/30 text-white/30 text-xs flex items-center justify-center ${focusRingWhite}`}
+                  className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}`}
                 >
                   A
                 </button>
@@ -151,7 +151,7 @@ export function FreeCellPage() {
         <div className="flex gap-2 mb-3">
           {state.tableau.map((col: (Card | null)[], colIdx: number) => (
             <div key={`col-${colIdx.toString()}`} className="flex-1 min-w-0">
-              <div className="text-white/40 text-xs text-center mb-1">{colIdx}</div>
+              <div className="text-game-text-muted text-xs text-center mb-1">{colIdx}</div>
               <div className="relative" style={{ minHeight: cardHeight }}>
                 {col.length === 0 ? (
                   <button
@@ -159,7 +159,7 @@ export function FreeCellPage() {
                     onClick={() => handleSelectTarget({ zone: 'tableau', col: colIdx })}
                     disabled={!isPlaying || loading || !selectedSource}
                     style={{ height: cardHeight }}
-                    className={`w-full rounded border-2 border-dashed border-white/20 text-white/20 text-xs flex items-center justify-center ${focusRingWhite}`}
+                    className={`w-full rounded border-2 border-dashed border-white/20 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}`}
                   >
                     K
                   </button>

--- a/frontend/src/pages/HeartsPage.tsx
+++ b/frontend/src/pages/HeartsPage.tsx
@@ -162,7 +162,7 @@ export function HeartsPage() {
               {state.currentTrick.map((trickCard) => (
                 <div key={`trick-${trickCard.playerIdx}`} className="text-center">
                   <CardImage card={trickCard.card} width={cardWidth} />
-                  <div className="text-white/50 text-xs mt-1">
+                  <div className="text-game-text-muted text-xs mt-1">
                     {playerName(
                       state.players[trickCard.playerIdx]?.id ?? trickCard.playerIdx,
                       state.players[trickCard.playerIdx]?.isHuman ?? false,

--- a/frontend/src/pages/KlondikePage.tsx
+++ b/frontend/src/pages/KlondikePage.tsx
@@ -116,7 +116,7 @@ export function KlondikePage() {
         <div className="flex gap-2 mb-3 items-start flex-wrap">
           {/* Stock */}
           <div className="text-center">
-            <div className="text-white/60 text-xs mb-1">
+            <div className="text-game-text-muted text-xs mb-1">
               {t('stock')} ({state.stockCount})
             </div>
             {state.stockCount > 0 ? (
@@ -127,7 +127,7 @@ export function KlondikePage() {
                 onClick={handleDraw}
                 disabled={!isPlaying || loading}
                 style={{ width: cardWidth, height: cardHeight }}
-                className={`rounded border-2 border-dashed border-white/30 text-white/40 text-xs flex items-center justify-center ${focusRingWhite}`}
+                className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}`}
               >
                 {t('draw')}
               </button>
@@ -136,7 +136,7 @@ export function KlondikePage() {
 
           {/* Waste */}
           <div className="text-center">
-            <div className="text-white/60 text-xs mb-1">{t('waste')}</div>
+            <div className="text-game-text-muted text-xs mb-1">{t('waste')}</div>
             {wasteDisplay.length > 0 ? (
               <div className="relative" style={{ width: cardWidth + (wasteDisplay.length - 1) * 15 }}>
                 {wasteDisplay.map((card, idx) => {
@@ -168,7 +168,7 @@ export function KlondikePage() {
             ) : (
               <div
                 style={{ width: cardWidth, height: cardHeight }}
-                className="rounded border border-white/20 flex items-center justify-center text-white/30 text-xs"
+                className="rounded border border-white/20 flex items-center justify-center text-game-text-muted text-xs"
               >
                 {t('empty')}
               </div>
@@ -180,7 +180,7 @@ export function KlondikePage() {
           {/* Foundation piles */}
           {state.foundation.map((pile, idx) => (
             <div key={`f-${idx.toString()}`} className="text-center">
-              <div className="text-white/60 text-xs mb-1">{FOUNDATION_SUITS[idx]}</div>
+              <div className="text-game-text-muted text-xs mb-1">{FOUNDATION_SUITS[idx]}</div>
               {pile.length > 0 ? (
                 <button
                   type="button"
@@ -198,7 +198,7 @@ export function KlondikePage() {
                   disabled={!isPlaying || loading || !selectedSource}
                   aria-label={t('emptyFoundationAriaLabel', { suit: FOUNDATION_SUITS[idx] })}
                   style={{ width: cardWidth, height: cardHeight }}
-                  className={`rounded border-2 border-dashed border-white/30 text-white/30 text-xs flex items-center justify-center ${focusRingWhite}`}
+                  className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}`}
                 >
                   A
                 </button>
@@ -211,7 +211,7 @@ export function KlondikePage() {
         <div className="flex gap-2 mb-3">
           {state.tableau.map((col, colIdx) => (
             <div key={`col-${colIdx.toString()}`} className="flex-1 min-w-0">
-              <div className="text-white/40 text-xs text-center mb-1">{colIdx}</div>
+              <div className="text-game-text-muted text-xs text-center mb-1">{colIdx}</div>
               <div className="relative" style={{ minHeight: cardHeight }}>
                 {col.length === 0 ? (
                   <button
@@ -219,7 +219,7 @@ export function KlondikePage() {
                     onClick={() => handleSelectTarget({ zone: 'tableau', col: colIdx })}
                     disabled={!isPlaying || loading || !selectedSource}
                     style={{ height: cardHeight }}
-                    className={`w-full rounded border-2 border-dashed border-white/20 text-white/20 text-xs flex items-center justify-center ${focusRingWhite}`}
+                    className={`w-full rounded border-2 border-dashed border-white/20 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}`}
                   >
                     K
                   </button>

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -130,7 +130,7 @@ export function MemoryPage() {
                 } transition-all`}
               >
                 {bc.faceUp && bc.card && <CardImage card={bc.card} width={cardWidth} />}
-                {!bc.taken && !bc.faceUp && <span className="text-white/40 text-xs">{idx}</span>}
+                {!bc.taken && !bc.faceUp && <span className="text-game-text-muted text-xs">{idx}</span>}
               </button>
             ))}
           </div>

--- a/frontend/src/pages/SpadesPage.tsx
+++ b/frontend/src/pages/SpadesPage.tsx
@@ -146,7 +146,7 @@ export function SpadesPage() {
               {state.currentTrick.map((trickCard) => (
                 <div key={`trick-${trickCard.playerIdx}`} className="text-center">
                   <CardImage card={trickCard.card} width={cardWidth} />
-                  <div className="text-white/50 text-xs mt-1">
+                  <div className="text-game-text-muted text-xs mt-1">
                     {playerName(
                       state.players[trickCard.playerIdx]?.id ?? trickCard.playerIdx,
                       state.players[trickCard.playerIdx]?.isHuman ?? false,


### PR DESCRIPTION
## Summary
- Replace `text-white/20` through `text-white/60` classes with `text-game-text-muted` (#e5e5e5) across 7 frontend files to meet WCAG 2.1 Level AA contrast ratio (4.5:1) on dark backgrounds
- Affected pages: MemoryPage, SpadesPage, HeartsPage, KlondikePage, FreeCellPage, PhaseIndicator, OldMaidDiscardedArea
- Border opacity classes (`border-white/*`) are left unchanged as they are non-text decorative elements

Closes #760

## Test plan
- [x] All 268 tests for affected files pass (`bun run test`)
- [x] `bun run build` passes
- [x] `bun run check` (Biome lint + format) passes
- [ ] Visual verification that muted text is readable on game backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)