### PR TITLE
fix: use semantic footer element in GameFooter

### DIFF
--- a/frontend/src/components/GameFooter.test.tsx
+++ b/frontend/src/components/GameFooter.test.tsx
@@ -12,48 +12,57 @@ describe('GameFooter', () => {
     expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument();
   });
 
-  it('applies safe-area paddingBottom style', () => {
-    const { container } = render(
-      <GameFooter className="bg-green-800">
-        <span>content</span>
-      </GameFooter>,
-    );
-    const div = container.firstChild as HTMLElement;
-    expect(div.style.paddingBottom).toContain('env(safe-area-inset-bottom)');
-  });
-
-  it('includes shrink-0 and border-t base classes', () => {
-    const { container } = render(
-      <GameFooter className="bg-green-800">
-        <span>content</span>
-      </GameFooter>,
-    );
-    const div = container.firstChild as HTMLElement;
-    expect(div.className).toContain('shrink-0');
-    expect(div.className).toContain('border-t');
-  });
-
-  it('renders without className prop', () => {
-    const { container } = render(
+  it('renders as a semantic footer element', () => {
+    render(
       <GameFooter>
         <span>content</span>
       </GameFooter>,
     );
-    const div = container.firstChild as HTMLElement;
-    expect(div.className).toContain('shrink-0');
-    expect(div.className).toContain('border-t');
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+  });
+
+  it('applies safe-area paddingBottom style', () => {
+    render(
+      <GameFooter className="bg-green-800">
+        <span>content</span>
+      </GameFooter>,
+    );
+    const footer = screen.getByRole('contentinfo');
+    expect(footer.style.paddingBottom).toContain('env(safe-area-inset-bottom)');
+  });
+
+  it('includes shrink-0 and border-t base classes', () => {
+    render(
+      <GameFooter className="bg-green-800">
+        <span>content</span>
+      </GameFooter>,
+    );
+    const footer = screen.getByRole('contentinfo');
+    expect(footer.className).toContain('shrink-0');
+    expect(footer.className).toContain('border-t');
+  });
+
+  it('renders without className prop', () => {
+    render(
+      <GameFooter>
+        <span>content</span>
+      </GameFooter>,
+    );
+    const footer = screen.getByRole('contentinfo');
+    expect(footer.className).toContain('shrink-0');
+    expect(footer.className).toContain('border-t');
   });
 
   it('merges provided className', () => {
-    const { container } = render(
+    render(
       <GameFooter className="bg-game-bg-green-bright-dark border-white/15 px-4 py-3">
         <span>content</span>
       </GameFooter>,
     );
-    const div = container.firstChild as HTMLElement;
-    expect(div.className).toContain('bg-game-bg-green-bright-dark');
-    expect(div.className).toContain('border-white/15');
-    expect(div.className).toContain('px-4');
-    expect(div.className).toContain('py-3');
+    const footer = screen.getByRole('contentinfo');
+    expect(footer.className).toContain('bg-game-bg-green-bright-dark');
+    expect(footer.className).toContain('border-white/15');
+    expect(footer.className).toContain('px-4');
+    expect(footer.className).toContain('py-3');
   });
 });

--- a/frontend/src/components/GameFooter.tsx
+++ b/frontend/src/components/GameFooter.tsx
@@ -6,11 +6,11 @@ interface GameFooterProps {
 /** Renders a sticky footer area for game action buttons with safe-area padding. */
 export function GameFooter({ className, children }: GameFooterProps) {
   return (
-    <div
+    <footer
       className={`shrink-0 border-t ${className ?? ''}`}
       style={{ paddingBottom: 'calc(env(safe-area-inset-bottom) + 12px)' }}
     >
       {children}
-    </div>
+    </footer>
   );
 }


### PR DESCRIPTION
## Summary
- Replace `<div>` with `<footer>` in `GameFooter.tsx` so screen readers can navigate to the game action area via landmark navigation
- Update tests to assert on the `contentinfo` ARIA role instead of generic container queries

Closes #761

## Test plan
- [x] `bun run test` — GameFooter tests pass (6/6)
- [x] `bun run build` — builds successfully
- [x] `bun run check` — Biome lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)