### PR TITLE
docs: ban direct node invocation in favor of bun

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Go trump card game algorithms -- BlackJack, Poker, Old Maid, Daifugo, Sevens, Do
 
 ## Package Manager Rule
 
-**Always use `bun` instead of `npm`, and `bunx` instead of `npx`.** This project uses Bun as the sole JavaScript package manager and script runner.
+**Always use `bun` instead of `npm`/`node`, and `bunx` instead of `npx`.** This project uses Bun as the sole JavaScript runtime, package manager, and script runner. Never invoke `node ./node_modules/...` directly — use `bun` or `bunx` instead, as Node.js consumes significantly more memory.
 
 ## Commands
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -4,7 +4,7 @@ This directory contains the React frontend (Vite + React + TypeScript).
 
 ## Package Manager Rule
 
-**Always use `bun` instead of `npm`, and `bunx` instead of `npx`.** This project uses Bun as the sole JavaScript package manager and script runner.
+**Always use `bun` instead of `npm`/`node`, and `bunx` instead of `npx`.** This project uses Bun as the sole JavaScript runtime, package manager, and script runner. Never invoke `node ./node_modules/...` directly — use `bun` or `bunx` instead.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- Update Package Manager Rule in root `CLAUDE.md` and `frontend/CLAUDE.md` to explicitly ban `node ./node_modules/...` direct invocation
- `node` process consumes significantly more memory than `bun` on this RAM-constrained WSL2 environment

## Test plan
- [x] Documentation-only changes — no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)