### PR TITLE
feat: add focus management to mobile hamburger menu

### DIFF
--- a/frontend/src/components/NavBar.test.tsx
+++ b/frontend/src/components/NavBar.test.tsx
@@ -171,5 +171,42 @@ describe('NavBar', () => {
       const jaBtns = screen.getAllByRole('button', { name: i18n.t('nav.switchToJa') });
       expect(jaBtns.length).toBeGreaterThanOrEqual(2);
     });
+
+    it('moves focus to first game link when menu opens', () => {
+      renderNavBar();
+      const btn = screen.getByRole('button', { name: i18n.t('nav.openMenu') });
+      fireEvent.click(btn);
+      const nav = screen.getByRole('navigation');
+      const firstLink = nav.querySelector('a');
+      expect(document.activeElement).toBe(firstLink);
+    });
+
+    it('returns focus to hamburger button when menu closes', () => {
+      renderNavBar();
+      const btn = screen.getByRole('button', { name: i18n.t('nav.openMenu') });
+      fireEvent.click(btn);
+      const closeBtn = screen.getByRole('button', { name: i18n.t('nav.closeMenu') });
+      fireEvent.click(closeBtn);
+      expect(document.activeElement).toBe(closeBtn);
+    });
+
+    it('closes menu and returns focus to hamburger button on Escape key', () => {
+      renderNavBar();
+      const btn = screen.getByRole('button', { name: i18n.t('nav.openMenu') });
+      fireEvent.click(btn);
+      const nav = screen.getByRole('navigation');
+      fireEvent.keyDown(nav, { key: 'Escape' });
+      expect(nav).toHaveClass('hidden');
+      expect(document.activeElement).toBe(btn);
+    });
+
+    it('does not close menu on non-Escape key', () => {
+      renderNavBar();
+      const btn = screen.getByRole('button', { name: i18n.t('nav.openMenu') });
+      fireEvent.click(btn);
+      const nav = screen.getByRole('navigation');
+      fireEvent.keyDown(nav, { key: 'Tab' });
+      expect(nav).not.toHaveClass('hidden');
+    });
   });
 });

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useLocation } from 'react-router-dom';
 import { gameCategories } from '../constants/gameRoutes';
@@ -36,6 +36,26 @@ export function NavBar() {
   const { t, i18n } = useTranslation('common');
   const currentLang = i18n.language;
   const [isOpen, setIsOpen] = useState(false);
+  const navRef = useRef<HTMLElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+  const wasOpen = useRef(false);
+
+  useEffect(() => {
+    if (isOpen && navRef.current) {
+      const firstLink = navRef.current.querySelector<HTMLElement>('a');
+      firstLink?.focus();
+    }
+    if (!isOpen && wasOpen.current && toggleRef.current) {
+      toggleRef.current.focus();
+    }
+    wasOpen.current = isOpen;
+  }, [isOpen]);
+
+  const handleNavKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      setIsOpen(false);
+    }
+  };
 
   return (
     <div className="bg-gray-800">
@@ -50,6 +70,7 @@ export function NavBar() {
         <div className="flex items-center gap-2">
           {langToggle(currentLang, i18n, t)}
           <button
+            ref={toggleRef}
             type="button"
             onClick={() => setIsOpen(!isOpen)}
             aria-expanded={isOpen}
@@ -63,7 +84,9 @@ export function NavBar() {
       </div>
 
       <nav
+        ref={navRef}
         id="main-nav"
+        onKeyDown={handleNavKeyDown}
         className={`${isOpen ? 'flex' : 'hidden'} flex-col gap-2 mx-2.5 mb-2 sm:flex sm:flex-row sm:flex-wrap sm:items-start sm:justify-end sm:my-2`}
       >
         <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:flex-1 sm:justify-end sm:gap-3">


### PR DESCRIPTION
## Summary
- Move focus to the first game link when the hamburger menu opens
- Return focus to the hamburger button when the menu closes
- Close the menu on Escape key press
- Added 4 new tests covering all focus management branches

Closes #763

## Test plan
- [x] `bun run build` passes
- [x] `bun run check` passes
- [x] `bun run test` passes (2098 tests, 105 files)
- [x] 100% branch coverage for NavBar component

🤖 Generated with [Claude Code](https://claude.com/claude-code)