### PR TITLE
docs: fix mermaid state diagram parse error in frontend.md

### DIFF
--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -695,8 +695,8 @@ stateDiagram-v2
     Selected --> Empty : clear()
     Selected --> Empty : confirm() → アクション実行後クリア
 
-    note right of Selected : selected: number[]\n選択中のカードインデックス配列
-    note right of Empty : selected: []\n何も選択されていない
+    note right of Selected : selected = number[]\n選択中のカードインデックス配列
+    note right of Empty : selected = []\n何も選択されていない
 ```
 
 ### 3.3 確認ダイアログ状態 (useConfirmDialog)


### PR DESCRIPTION
## Summary
- フロントエンド設計ドキュメント (`docs/design/frontend.md`) のMermaidステートマシン図でGitHub上のレンダリングエラーを修正
- セクション3.2のnote内のコロン(`:`)がMermaidパーサーの区切り文字と競合していたため、`=` に置換

## Test plan
- [ ] GitHub上で `docs/design/frontend.md` のMermaidダイアグラムが正常にレンダリングされることを確認

https://claude.ai/code/session_01Wyx3RaoyW2RzTZXC1JdeZN