### PR TITLE
feat: add sequence play support to daifugo endgame solver

### DIFF
--- a/internal/domain/daifugo_solver.go
+++ b/internal/domain/daifugo_solver.go
@@ -419,20 +419,36 @@ func (s *daifugoSolver) canFormSequenceFromStrengths(strengths []int, si int, jo
 }
 
 // sequenceMinStrength returns the minimum card strength in a sequence play.
+// Jokers may represent cards below the minimum real card, so the true minimum
+// is computed by deducting leftover jokers (after filling interior gaps) from
+// the minimum real card strength.
 func (s *daifugoSolver) sequenceMinStrength(cards []*Card) int {
-	minStr := DaifugoJokerStrength + 1
+	var realStrengths []int
+	jokerCount := 0
 	for _, c := range cards {
-		var str int
 		if IsJoker(c) {
-			str = DaifugoJokerStrength
+			jokerCount++
 		} else {
-			str = s.cardStrength(c.GetValue())
-		}
-		if str < minStr {
-			minStr = str
+			realStrengths = append(realStrengths, s.cardStrength(c.GetValue()))
 		}
 	}
-	return minStr
+	if len(realStrengths) == 0 {
+		return DaifugoJokerStrength
+	}
+	sort.Ints(realStrengths)
+	minReal := realStrengths[0]
+	maxReal := realStrengths[len(realStrengths)-1]
+	// Interior gaps that jokers fill between real cards
+	interiorGaps := (maxReal - minReal + 1) - len(realStrengths)
+	if interiorGaps < 0 {
+		interiorGaps = 0
+	}
+	// Remaining jokers extend the sequence below the minimum real card
+	extendBelow := jokerCount - interiorGaps
+	if extendBelow < 0 {
+		extendBelow = 0
+	}
+	return minReal - extendBelow
 }
 
 // generateSequencePlays generates all valid sequence plays (3+ cards, same suit, consecutive)
@@ -486,9 +502,10 @@ func (s *daifugoSolver) generateSequenceResponsePlays(hand []*Card, needed int, 
 		sort.Slice(cards, func(i, j int) bool {
 			return s.cardStrength(cards[i].GetValue()) < s.cardStrength(cards[j].GetValue())
 		})
-		seqs := s.findAllSequences(cards, jokers, needed)
-		for _, seq := range seqs {
-			if len(seq) == needed && s.sequenceMinStrength(seq) > tableMinStr {
+		// Build exact-length sequences directly (no need for findAllSequences)
+		for si := range cards {
+			seq := s.tryBuildSolverSequence(cards, si, jokers, needed)
+			if seq != nil && s.sequenceMinStrength(seq) > tableMinStr {
 				moves = append(moves, solverPlay{cards: seq, isSequence: true})
 			}
 		}

--- a/internal/domain/daifugo_solver_internal_test.go
+++ b/internal/domain/daifugo_solver_internal_test.go
@@ -1116,14 +1116,26 @@ func TestDaifugoSolver_helpers(t *testing.T) {
 		assert.Equal(t, 5, solver.sequenceMinStrength(cards))
 	})
 
-	t.Run("sequenceMinStrength with joker", func(t *testing.T) {
+	t.Run("sequenceMinStrength with joker in middle", func(t *testing.T) {
 		solver := &daifugoSolver{config: DaifugoConfig{}}
+		// [5♠, Joker(fills 6), 7♠] → min strength = 5
 		cards := []*Card{
-			NewCard(CardDesignSpade, 5, false), // strength 5
-			NewCard(CardDesignJoker, 0, false), // strength 16
-			NewCard(CardDesignSpade, 7, false), // strength 7
+			NewCard(CardDesignSpade, 5, false),
+			NewCard(CardDesignJoker, 0, false),
+			NewCard(CardDesignSpade, 7, false),
 		}
 		assert.Equal(t, 5, solver.sequenceMinStrength(cards))
+	})
+
+	t.Run("sequenceMinStrength with joker at start", func(t *testing.T) {
+		solver := &daifugoSolver{config: DaifugoConfig{}}
+		// [Joker(represents 4), 5♠, 6♠] → min strength = 4
+		cards := []*Card{
+			NewCard(CardDesignJoker, 0, false),
+			NewCard(CardDesignSpade, 5, false),
+			NewCard(CardDesignSpade, 6, false),
+		}
+		assert.Equal(t, 4, solver.sequenceMinStrength(cards))
 	})
 
 	t.Run("generateSequencePlays finds valid sequences", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Extends the endgame solver (`daifugo_solver.go`) to explore sequence (階段) plays in the DFS tree
- Removes the early return when `tableIsSequence` is true in `trySolveEndgame()`
- Adds sequence play generation for both opening and response moves
- Implements joker gap-filling, unbeatability checks, and 8-cut marking for sequence responses
- Adds comprehensive tests for all new solver paths

Closes #862

## Test plan
- [x] All existing solver tests pass
- [x] New tests: sequence as opening, joker gap-filling, sequence-only winning path, sequence response, beatable sequence
- [ ] CI: `go test -tags test ./...`
- [ ] CI: `golangci-lint run ./...`