### PR TITLE
feat: replace freecell solver DFS with A* search

### DIFF
--- a/internal/domain/freecell_solver.go
+++ b/internal/domain/freecell_solver.go
@@ -234,7 +234,7 @@ func (s *freeCellSolver) generateSuccessors(st *freeCellState) []*freeCellState 
 }
 
 // copyState creates a deep copy of a freeCellState.
-// The caller is responsible for setting g and h on the returned state.
+// NOTE: g and h are left at 0 in the copy; the caller must set them before pushing to the priority queue.
 func copyState(st *freeCellState) *freeCellState {
 	next := &freeCellState{}
 	for i := range FreeCellTableauCnt {

--- a/internal/domain/freecell_solver_internal_test.go
+++ b/internal/domain/freecell_solver_internal_test.go
@@ -167,7 +167,7 @@ func TestFreeCellSolver_FreeCellToFoundation(t *testing.T) {
 	assert.True(t, solver.isSolvable())
 }
 
-func TestFreeCellSolver_FreeCellToTableau(t *testing.T) {
+func TestFreeCellSolver_FreeCellKingToFoundation(t *testing.T) {
 	f := NewFreeCell(NewTrumpCards(0))
 	f.Reset()
 


### PR DESCRIPTION
## Summary
- Replaces recursive DFS with A* search using `container/heap` priority queue
- Heuristic: `h = 52 - foundationCardCount` (admissible, never overestimates)
- Each state is an explicit board copy (no backtracking needed)
- Same iteration budget (100k), same public API, same semantics
- A* explores states in priority order (lowest f=g+h first), finding solutions faster

Closes #863

## Test plan
- [x] All existing solver tests pass (same behavior)
- [x] New tests: heuristic correctness, solvable board efficiency (< 1000 iterations), priority queue ordering
- [ ] CI: `go test -tags test ./...`
- [ ] CI: `golangci-lint run ./...`