### PR TITLE
docs: fix UML diagram drift for VideoPoker and Napoleon phases

### DIFF
--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -1205,9 +1205,9 @@ stateDiagram-v2
     Result --> Bet : 次ラウンド (Reset)
     Result --> [*] : チップ0 (ゲーム終了)
 
-    note right of Bet : VideoPokerPhaseBet = 0
-    note right of Draw : VideoPokerPhaseDraw = 1
-    note right of Result : VideoPokerPhaseResult = 2
+    note right of Bet : VideoPokerPhaseBet = 1
+    note right of Draw : VideoPokerPhaseDraw = 2
+    note right of Result : VideoPokerPhaseResult = 3
 ```
 
 ### 3.15 Euchre フェーズ遷移

--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -233,8 +233,8 @@ classDiagram
     class NapoleonPhase {
         <<enumeration>>
         BID = 0
-        TRUMP = 1
-        EXCHANGE = 2
+        TRUMP_DECLARATION = 1
+        KITTY_EXCHANGE = 2
         PLAY = 3
         TRICK_END = 4
         ROUND_END = 5
@@ -252,9 +252,9 @@ classDiagram
 
     class VideoPokerPhase {
         <<enumeration>>
-        BET = 0
-        DRAW = 1
-        RESULT = 2
+        BET = 1
+        DRAW = 2
+        RESULT = 3
     }
 
     class EuchrePhase {


### PR DESCRIPTION
## Summary
- Fix VideoPoker phase values in backend.md state diagram (0/1/2 → 1/2/3)
- Fix VideoPokerPhase values in frontend.md class diagram (0/1/2 → 1/2/3)
- Fix NapoleonPhase field names in frontend.md class diagram (`TRUMP`/`EXCHANGE` → `TRUMP_DECLARATION`/`KITTY_EXCHANGE`)

Closes #887

## Test plan
- [ ] Verify Mermaid diagrams render correctly on GitHub
- [ ] Confirm values match `internal/domain/VideoPoker.go` and `frontend/src/types/phases.ts`