### PR TITLE
refactor: extract shared components and consolidate duplicated code

### DIFF
--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -149,7 +149,9 @@ classDiagram
         -trumpCards *TrumpCards
         -players []*PokerPlayer
         -config PokerConfig
-        -phase int
+        -dealerIdx int
+        -humanProfile *BettingHumanProfile
+        -round pokerRoundState
         +Reset()
         +PlayerExchange(indices []int) error
         +PlayerFold() error
@@ -246,12 +248,7 @@ classDiagram
         -trumpCards *TrumpCards
         -players []*NapoleonPlayer
         -config NapoleonConfig
-        -phase NapoleonPhase
-        -trickCards []*NapoleonTrickCard
-        -kitty []*Card
-        -napoleonIdx int
-        -adjutantCard *Card
-        -trumpSuit int
+        -round napoleonRoundState
         +Reset()
         +Bid(amount int) error
         +DeclareTrump(suit int) error
@@ -463,8 +460,8 @@ classDiagram
         -trumpCards *TrumpCards
         -players []*DaifugoPlayer
         -config DaifugoConfig
-        -currentTurn int
-        -tableCards []*Card
+        -sortMode DaifugoSortMode
+        -round daifugoRoundState
         +Reset()
         +Play(indices []int) error
         +Pass() error

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -101,6 +101,7 @@ Interactive step-by-step tutorial system for guiding new players through game me
 
 | Component | Location | Purpose |
 |-----------|----------|---------|
+| `TutorialButton` | `src/components/tutorial/TutorialButton.tsx` | Shared tutorial start button (imported by all 24 game pages) |
 | `TutorialProvider` | `src/providers/TutorialProvider.tsx` | Context provider; wraps game page, renders overlay when active |
 | `TutorialOverlay` | `src/components/tutorial/TutorialOverlay.tsx` | Full-screen overlay with SVG mask spotlight and focus trap |
 | `TutorialTooltip` | `src/components/tutorial/TutorialTooltip.tsx` | Glass-panel tooltip with step indicator and nav buttons |
@@ -122,7 +123,7 @@ Interactive step-by-step tutorial system for guiding new players through game me
 1. Define `TutorialStep[]` array with `target` (CSS selector using `data-tutorial` attributes), `messageKey`, `placement`, and `advanceOn`
 2. Add `data-tutorial="<step-name>"` attributes to the game page's key UI elements
 3. Add tutorial step text to `src/i18n/locales/{ja,en}/<game>.json` under a `tutorial` key
-4. Wrap the page content with `<TutorialProvider config={config} translateMessage={t}>` and add a `TutorialButton` component
+4. Wrap the page content with `<TutorialProvider config={config} translateMessage={t}>` and import `TutorialButton` from `../components/tutorial/TutorialButton`
 
 ### Phase 3 features
 

--- a/frontend/src/components/tutorial/TutorialButton.test.tsx
+++ b/frontend/src/components/tutorial/TutorialButton.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TutorialButton } from './TutorialButton';
+
+const mockStart = vi.fn();
+vi.mock('../../providers/TutorialProvider', () => ({
+  useTutorialContext: () => ({ start: mockStart }),
+}));
+
+vi.mock('../../styles/buttonStyles', () => ({
+  btnSecondary: 'btn-secondary',
+}));
+
+describe('TutorialButton', () => {
+  it('renders a button with ? text', () => {
+    render(<TutorialButton />);
+    const btn = screen.getByRole('button', { name: 'チュートリアル' });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveTextContent('?');
+  });
+
+  it('calls start on click', () => {
+    render(<TutorialButton />);
+    fireEvent.click(screen.getByRole('button', { name: 'チュートリアル' }));
+    expect(mockStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('has correct className', () => {
+    render(<TutorialButton />);
+    const btn = screen.getByRole('button', { name: 'チュートリアル' });
+    expect(btn.className).toContain('btn-secondary');
+    expect(btn.className).toContain('text-xs');
+  });
+});

--- a/frontend/src/components/tutorial/TutorialButton.tsx
+++ b/frontend/src/components/tutorial/TutorialButton.tsx
@@ -1,0 +1,20 @@
+import { useTranslation } from 'react-i18next';
+import { useTutorialContext } from '../../providers/TutorialProvider';
+import { btnSecondary } from '../../styles/buttonStyles';
+
+/** Tutorial button that starts the game tutorial. */
+export function TutorialButton() {
+  const { t } = useTranslation('tutorial');
+  const { start } = useTutorialContext();
+  return (
+    <button
+      type="button"
+      className={`${btnSecondary} text-xs`}
+      onClick={start}
+      aria-label={t('tutorialButton')}
+      title={t('tutorialButton')}
+    >
+      ?
+    </button>
+  );
+}

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -10,11 +10,12 @@ import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { BaccaratSkeleton } from '../components/skeleton/BaccaratSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
+import { TutorialProvider } from '../providers/TutorialProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import type { BaccaratSideBetResult } from '../types/card';
 import { BaccaratBetType, BaccaratPhase } from '../types/phases';
@@ -59,23 +60,6 @@ const BAC_TUTORIAL_CONFIG: TutorialConfig = {
   gameName: 'baccarat',
   steps: BAC_TUTORIAL_STEPS,
 };
-
-/** Tutorial button that starts the Baccarat tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 const ROAD_PLAYER = 0;
 const ROAD_BANKER = 1;

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -31,13 +31,13 @@ import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { BlackJackSkeleton } from '../components/skeleton/BlackJackSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
-import { btnSecondary } from '../styles/buttonStyles';
+import { TutorialProvider } from '../providers/TutorialProvider';
 import type { BlackJackResponse } from '../types/card';
 import { BjPhase } from '../types/phases';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
@@ -104,23 +104,6 @@ const BJ_TUTORIAL_STEPS: TutorialStep[] = [
     advanceOn: 'next',
   },
 ];
-
-/** Tutorial button that starts the BlackJack tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** BlackJack tutorial configuration. */
 const BJ_TUTORIAL_CONFIG: TutorialConfig = {

--- a/frontend/src/pages/CrazyEightsPage.tsx
+++ b/frontend/src/pages/CrazyEightsPage.tsx
@@ -10,13 +10,14 @@ import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { CrazyEightsSkeleton } from '../components/skeleton/CrazyEightsSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useCrazyEightsGame } from '../hooks/useCrazyEightsGame';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
-import { btnPrimary, btnSecondary, btnSuccess, btnWarning } from '../styles/buttonStyles';
+import { TutorialProvider } from '../providers/TutorialProvider';
+import { btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { CrazyEightsPhase, CrazyEightsSuit } from '../types/phases';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
@@ -78,23 +79,6 @@ const CE_TUTORIAL_CONFIG: TutorialConfig = {
   gameName: 'crazyeights',
   steps: CE_TUTORIAL_STEPS,
 };
-
-/** Tutorial button that starts the Crazy Eights tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** Renders the Crazy Eights game page with card play and suit selection. */
 export function CrazyEightsPage() {

--- a/frontend/src/pages/CribbagePage.tsx
+++ b/frontend/src/pages/CribbagePage.tsx
@@ -10,13 +10,14 @@ import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { CribbageSkeleton } from '../components/skeleton/CribbageSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useCribbageGame } from '../hooks/useCribbageGame';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
-import { btnPrimary, btnSecondary, btnSuccess, btnWarning } from '../styles/buttonStyles';
+import { TutorialProvider } from '../providers/TutorialProvider';
+import { btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { CribbagePhase } from '../types/phases';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
@@ -71,23 +72,6 @@ const CB_TUTORIAL_CONFIG: TutorialConfig = {
   gameName: 'cribbage',
   steps: CB_TUTORIAL_STEPS,
 };
-
-/** Tutorial button that starts the Cribbage tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** Renders the Cribbage game page with discard, pegging, show, and round phases. */
 export function CribbagePage() {

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -13,11 +13,12 @@ import { GameResetDialog } from '../components/GameResetDialog';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { DaifugoSkeleton } from '../components/skeleton/DaifugoSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useDaifugoGame } from '../hooks/useDaifugoGame';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
+import { TutorialProvider } from '../providers/TutorialProvider';
 import { btnPrimary, btnSecondary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import type { DaifugoAction } from '../types/card';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
@@ -69,23 +70,6 @@ const DF_TUTORIAL_STEPS: TutorialStep[] = [
     advanceOn: 'next',
   },
 ];
-
-/** Tutorial button that starts the Daifugo tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** Daifugo tutorial configuration. */
 const DF_TUTORIAL_CONFIG: TutorialConfig = {

--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -12,6 +12,7 @@ import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { DoubtSkeleton } from '../components/skeleton/DoubtSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import {
@@ -22,8 +23,8 @@ import {
   useDoubtGame,
 } from '../hooks/useDoubtGame';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
-import { btnDanger, btnPrimary, btnSecondary, btnSuccess, btnWarning, focusRingBlue } from '../styles/buttonStyles';
+import { TutorialProvider } from '../providers/TutorialProvider';
+import { btnDanger, btnPrimary, btnSuccess, btnWarning, focusRingBlue } from '../styles/buttonStyles';
 import type { DoubtCpuAction } from '../types/card';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
 import { valueName } from '../utils/cardUtils';
@@ -74,23 +75,6 @@ const DT_TUTORIAL_CONFIG: TutorialConfig = {
   gameName: 'doubt',
   steps: DT_TUTORIAL_STEPS,
 };
-
-/** Tutorial button that starts the Doubt tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** Renders the Doubt game page with card play, doubt window countdown, and config. */
 export function DoubtPage() {

--- a/frontend/src/pages/EuchrePage.tsx
+++ b/frontend/src/pages/EuchrePage.tsx
@@ -10,12 +10,13 @@ import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { EuchreSkeleton } from '../components/skeleton/EuchreSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useEuchreGame } from '../hooks/useEuchreGame';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
+import { TutorialProvider } from '../providers/TutorialProvider';
 import { btnPrimary, btnSecondary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { EuchrePhase } from '../types/phases';
@@ -75,23 +76,6 @@ const EU_TUTORIAL_STEPS: TutorialStep[] = [
     advanceOn: 'next',
   },
 ];
-
-/** Tutorial button that starts the Euchre tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** Euchre tutorial configuration. */
 const EU_TUTORIAL_CONFIG: TutorialConfig = {

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -9,12 +9,13 @@ import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { FreeCellSkeleton } from '../components/skeleton/FreeCellSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useFreeCellGame } from '../hooks/useFreeCellGame';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
-import { btnDanger, btnPrimary, btnSecondary, btnSuccess, btnWarning, focusRingWhite } from '../styles/buttonStyles';
+import { TutorialProvider } from '../providers/TutorialProvider';
+import { btnDanger, btnPrimary, btnSuccess, btnWarning, focusRingWhite } from '../styles/buttonStyles';
 import type { Card } from '../types/card';
 import { FreeCellPhase } from '../types/phases';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
@@ -61,23 +62,6 @@ const FC_TUTORIAL_CONFIG: TutorialConfig = {
   gameName: 'freecell',
   steps: FC_TUTORIAL_STEPS,
 };
-
-/** Tutorial button that starts the FreeCell tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** Renders the FreeCell solitaire game page with tableau, free cells, and foundation. */
 export function FreeCellPage() {

--- a/frontend/src/pages/GinRummyPage.tsx
+++ b/frontend/src/pages/GinRummyPage.tsx
@@ -10,13 +10,14 @@ import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { GinRummySkeleton } from '../components/skeleton/GinRummySkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useGinRummyGame } from '../hooks/useGinRummyGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
-import { btnPrimary, btnSecondary, btnSuccess, btnWarning } from '../styles/buttonStyles';
+import { TutorialProvider } from '../providers/TutorialProvider';
+import { btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { GinRummyPhase } from '../types/phases';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
@@ -71,23 +72,6 @@ const GR_TUTORIAL_CONFIG: TutorialConfig = {
   gameName: 'ginrummy',
   steps: GR_TUTORIAL_STEPS,
 };
-
-/** Tutorial button that starts the Gin Rummy tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** Renders the Gin Rummy game page with draw, discard, knock, and layoff phases. */
 export function GinRummyPage() {

--- a/frontend/src/pages/HeartsPage.tsx
+++ b/frontend/src/pages/HeartsPage.tsx
@@ -11,14 +11,15 @@ import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { HeartsSkeleton } from '../components/skeleton/HeartsSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useHeartsGame } from '../hooks/useHeartsGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
-import { btnPrimary, btnSecondary, btnSuccess, btnWarning } from '../styles/buttonStyles';
+import { TutorialProvider } from '../providers/TutorialProvider';
+import { btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { HeartsPhase } from '../types/phases';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
@@ -70,23 +71,6 @@ const HT_TUTORIAL_STEPS: TutorialStep[] = [
     advanceOn: 'next',
   },
 ];
-
-/** Tutorial button that starts the Hearts tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** Hearts tutorial configuration. */
 const HT_TUTORIAL_CONFIG: TutorialConfig = {

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -16,12 +16,13 @@ import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { RoundResults } from '../components/RoundResults';
 import { HoldemSkeleton } from '../components/skeleton/HoldemSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
+import { TutorialProvider } from '../providers/TutorialProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { HoldemPhase, HoldemRebuyPhaseType } from '../types/phases';
@@ -72,23 +73,6 @@ const HE_TUTORIAL_STEPS: TutorialStep[] = [
     advanceOn: 'next',
   },
 ];
-
-/** Tutorial button that starts the Texas Hold'em tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** Texas Hold'em tutorial configuration. */
 const HE_TUTORIAL_CONFIG: TutorialConfig = {

--- a/frontend/src/pages/IndianPokerPage.tsx
+++ b/frontend/src/pages/IndianPokerPage.tsx
@@ -15,13 +15,14 @@ import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { RoundResults } from '../components/RoundResults';
 import { HoldemSkeleton } from '../components/skeleton/HoldemSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
-import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { TutorialProvider } from '../providers/TutorialProvider';
+import { btnPrimary } from '../styles/buttonStyles';
 import { IndianPokerPhase } from '../types/phases';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
 
@@ -58,23 +59,6 @@ const IP_TUTORIAL_CONFIG: TutorialConfig = {
   gameName: 'indianpoker',
   steps: IP_TUTORIAL_STEPS,
 };
-
-/** Tutorial button that starts the Indian Poker tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 const INDIAN_POKER_PHASE_KEYS: Readonly<Record<number, string>> = {
   [IndianPokerPhase.INIT]: 'init',

--- a/frontend/src/pages/KlondikePage.tsx
+++ b/frontend/src/pages/KlondikePage.tsx
@@ -10,13 +10,14 @@ import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { KlondikeSkeleton } from '../components/skeleton/KlondikeSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useKlondikeGame } from '../hooks/useKlondikeGame';
 import { useKlondikeTimer } from '../hooks/useKlondikeTimer';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
-import { btnDanger, btnPrimary, btnSecondary, btnSuccess, btnWarning, focusRingWhite } from '../styles/buttonStyles';
+import { TutorialProvider } from '../providers/TutorialProvider';
+import { btnDanger, btnPrimary, btnSuccess, btnWarning, focusRingWhite } from '../styles/buttonStyles';
 import { KlondikePhase, KlondikeScoringMode } from '../types/phases';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
@@ -68,23 +69,6 @@ const KL_TUTORIAL_CONFIG: TutorialConfig = {
   gameName: 'klondike',
   steps: KL_TUTORIAL_STEPS,
 };
-
-/** Tutorial button that starts the Klondike tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** Renders the Klondike solitaire game page with tableau, stock/waste, and foundation. */
 export function KlondikePage() {

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -10,13 +10,14 @@ import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { MemorySkeleton } from '../components/skeleton/MemorySkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { CPU_DIFFICULTY_OPTIONS, useMemoryGame } from '../hooks/useMemoryGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
-import { btnSecondary, btnSuccess, btnWarning, focusRingWhite } from '../styles/buttonStyles';
+import { TutorialProvider } from '../providers/TutorialProvider';
+import { btnSuccess, btnWarning, focusRingWhite } from '../styles/buttonStyles';
 import { MemoryPhase } from '../types/phases';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
 import { playerName } from '../utils/playerUtils';
@@ -54,23 +55,6 @@ const MEM_TUTORIAL_CONFIG: TutorialConfig = {
   gameName: 'memory',
   steps: MEM_TUTORIAL_STEPS,
 };
-
-/** Tutorial button that starts the Memory tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 const MEMORY_PHASE_KEYS: Readonly<Record<number, string>> = {
   [MemoryPhase.FLIP1]: 'flip1',

--- a/frontend/src/pages/NapoleonPage.tsx
+++ b/frontend/src/pages/NapoleonPage.tsx
@@ -10,6 +10,7 @@ import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { NapoleonSkeleton } from '../components/skeleton/NapoleonSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
@@ -20,8 +21,8 @@ import {
   useNapoleonGame,
 } from '../hooks/useNapoleonGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
-import { btnPrimary, btnSecondary, btnSuccess, btnWarning } from '../styles/buttonStyles';
+import { TutorialProvider } from '../providers/TutorialProvider';
+import { btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { NapoleonPhase } from '../types/phases';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
@@ -80,23 +81,6 @@ const NP_TUTORIAL_STEPS: TutorialStep[] = [
     advanceOn: 'next',
   },
 ];
-
-/** Tutorial button that starts the Napoleon tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** Napoleon tutorial configuration. */
 const NP_TUTORIAL_CONFIG: TutorialConfig = {

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -13,11 +13,12 @@ import { OldMaidDrawHistory } from '../components/oldmaid/OldMaidDrawHistory';
 import { OldMaidPlayerArea } from '../components/oldmaid/OldMaidPlayerArea';
 import { OldMaidSetupScreen } from '../components/oldmaid/OldMaidSetupScreen';
 import { OldMaidSkeleton } from '../components/skeleton/OldMaidSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { OldMaidMode, useOldMaidGame } from '../hooks/useOldMaidGame';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
+import { TutorialProvider } from '../providers/TutorialProvider';
 import { btnPrimary, btnSecondary, btnWarning } from '../styles/buttonStyles';
 import type { CpuAction } from '../types/card';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
@@ -57,23 +58,6 @@ const OM_TUTORIAL_CONFIG: TutorialConfig = {
   gameName: 'oldmaid',
   steps: OM_TUTORIAL_STEPS,
 };
-
-/** Tutorial button that starts the Old Maid tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** Renders the Old Maid game page with setup screen, player areas, and draw history. */
 export function OldMaidPage() {

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -16,12 +16,13 @@ import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { RoundResults } from '../components/RoundResults';
 import { OmahaSkeleton } from '../components/skeleton/OmahaSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
+import { TutorialProvider } from '../providers/TutorialProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { OmahaPhase, OmahaRebuyPhaseType } from '../types/phases';
@@ -72,23 +73,6 @@ const OH_TUTORIAL_STEPS: TutorialStep[] = [
     advanceOn: 'next',
   },
 ];
-
-/** Tutorial button that starts the Omaha Hold'em tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** Omaha Hold'em tutorial configuration. */
 const OH_TUTORIAL_CONFIG: TutorialConfig = {

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -14,14 +14,15 @@ import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { RoundResults } from '../components/RoundResults';
 import { PokerSkeleton } from '../components/skeleton/PokerSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { usePokerGame } from '../hooks/usePokerGame';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
-import { btnPrimary, btnSecondary, btnSuccess, btnWarning, focusRingBlue } from '../styles/buttonStyles';
+import { TutorialProvider } from '../providers/TutorialProvider';
+import { btnPrimary, btnSuccess, btnWarning, focusRingBlue } from '../styles/buttonStyles';
 import { selectedCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { PokerPhase } from '../types/phases';
@@ -75,23 +76,6 @@ const PK_TUTORIAL_CONFIG: TutorialConfig = {
   gameName: 'poker',
   steps: PK_TUTORIAL_STEPS,
 };
-
-/** Tutorial button that starts the Poker tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** Renders the 5-card Draw Poker game page with betting and card exchange. */
 export function PokerPage() {

--- a/frontend/src/pages/PyramidPage.tsx
+++ b/frontend/src/pages/PyramidPage.tsx
@@ -10,12 +10,13 @@ import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { PyramidSkeleton } from '../components/skeleton/PyramidSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePyramidGame } from '../hooks/usePyramidGame';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
-import { btnDanger, btnPrimary, btnSecondary, btnSuccess, btnWarning, focusRingWhite } from '../styles/buttonStyles';
+import { TutorialProvider } from '../providers/TutorialProvider';
+import { btnDanger, btnPrimary, btnSuccess, btnWarning, focusRingWhite } from '../styles/buttonStyles';
 import { PyramidPhase } from '../types/phases';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
@@ -59,23 +60,6 @@ const PY_TUTORIAL_CONFIG: TutorialConfig = {
   gameName: 'pyramid',
   steps: PY_TUTORIAL_STEPS,
 };
-
-/** Tutorial button that starts the Pyramid tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** Renders the Pyramid Solitaire game page with pyramid, stock/waste, and controls. */
 export function PyramidPage() {

--- a/frontend/src/pages/SevensPage.tsx
+++ b/frontend/src/pages/SevensPage.tsx
@@ -12,11 +12,12 @@ import { SevensBoard } from '../components/sevens/SevensBoard';
 import { SevensCpuArea } from '../components/sevens/SevensCpuArea';
 import { SevensHumanArea } from '../components/sevens/SevensHumanArea';
 import { SevensSkeleton } from '../components/skeleton/SevensSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSevensGame } from '../hooks/useSevensGame';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
-import { btnPrimary, btnSecondary, btnWarning } from '../styles/buttonStyles';
+import { TutorialProvider } from '../providers/TutorialProvider';
+import { btnPrimary, btnWarning } from '../styles/buttonStyles';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
 import { playerName } from '../utils/playerUtils';
 import { actionDesc } from '../utils/sevensUtils';
@@ -45,23 +46,6 @@ const SV_TUTORIAL_CONFIG: TutorialConfig = {
   gameName: 'sevens',
   steps: SV_TUTORIAL_STEPS,
 };
-
-/** Tutorial button that starts the Sevens tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** Renders the Sevens game page with board, player areas, and joker placement. */
 export function SevensPage() {

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -16,12 +16,13 @@ import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { RoundResults } from '../components/RoundResults';
 import { ShortDeckSkeleton } from '../components/skeleton/ShortDeckSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
+import { TutorialProvider } from '../providers/TutorialProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { HoldemPhase, HoldemRebuyPhaseType } from '../types/phases';
@@ -72,23 +73,6 @@ const SD_TUTORIAL_STEPS: TutorialStep[] = [
     advanceOn: 'next',
   },
 ];
-
-/** Tutorial button that starts the Short Deck Hold'em tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** Short Deck Hold'em tutorial configuration. */
 const SD_TUTORIAL_CONFIG: TutorialConfig = {

--- a/frontend/src/pages/SpadesPage.tsx
+++ b/frontend/src/pages/SpadesPage.tsx
@@ -11,14 +11,15 @@ import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { SpadesSkeleton } from '../components/skeleton/SpadesSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useSpadesGame } from '../hooks/useSpadesGame';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
-import { btnPrimary, btnSecondary, btnSuccess, btnWarning } from '../styles/buttonStyles';
+import { TutorialProvider } from '../providers/TutorialProvider';
+import { btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { SpadesPhase } from '../types/phases';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
@@ -70,23 +71,6 @@ const SP_TUTORIAL_STEPS: TutorialStep[] = [
     advanceOn: 'next',
   },
 ];
-
-/** Tutorial button that starts the Spades tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** Spades tutorial configuration. */
 const SP_TUTORIAL_CONFIG: TutorialConfig = {

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -10,12 +10,13 @@ import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { SpiderSkeleton } from '../components/skeleton/SpiderSkeleton';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSpiderGame } from '../hooks/useSpiderGame';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
-import { btnDanger, btnPrimary, btnSecondary, btnSuccess, btnWarning, focusRingWhite } from '../styles/buttonStyles';
+import { TutorialProvider } from '../providers/TutorialProvider';
+import { btnDanger, btnPrimary, btnSuccess, btnWarning, focusRingWhite } from '../styles/buttonStyles';
 import { SpiderPhase } from '../types/phases';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
@@ -65,23 +66,6 @@ const SPD_TUTORIAL_CONFIG: TutorialConfig = {
   gameName: 'spider',
   steps: SPD_TUTORIAL_STEPS,
 };
-
-/** Tutorial button that starts the Spider Solitaire tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** Renders the Spider Solitaire game page with 10 tableau columns and stock. */
 export function SpiderPage() {

--- a/frontend/src/pages/VideoPokerPage.tsx
+++ b/frontend/src/pages/VideoPokerPage.tsx
@@ -9,11 +9,12 @@ import { GameResetDialog } from '../components/GameResetDialog';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
+import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { TutorialProvider, useTutorialContext } from '../providers/TutorialProvider';
+import { TutorialProvider } from '../providers/TutorialProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { VideoPokerPhase } from '../types/phases';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
@@ -51,23 +52,6 @@ const VP_TUTORIAL_CONFIG: TutorialConfig = {
   gameName: 'videopoker',
   steps: VP_TUTORIAL_STEPS,
 };
-
-/** Tutorial button that starts the Video Poker tutorial. */
-function TutorialButton() {
-  const { t } = useTranslation('tutorial');
-  const { start } = useTutorialContext();
-  return (
-    <button
-      type="button"
-      className={`${btnSecondary} text-xs`}
-      onClick={start}
-      aria-label={t('tutorialButton')}
-      title={t('tutorialButton')}
-    >
-      ?
-    </button>
-  );
-}
 
 /** Payout table display component. */
 function PayoutTable({ t }: { t: (key: string) => string }) {

--- a/internal/adapter/presenter/cui_card_helper.go
+++ b/internal/adapter/presenter/cui_card_helper.go
@@ -14,19 +14,41 @@ func isRedSuit(design int) bool {
 	return design == domain.CardDesignHeart || design == domain.CardDesignDiamond
 }
 
-// cuiCardList is the minimal type constraint required by cuiCardListStr.
+// cuiCardList is the minimal type constraint required by formatCardList.
 type cuiCardList interface {
 	GetCardsSize() int
 	GetCard(idx int) *domain.Card
 }
 
-// cuiCardListStr returns a comma-separated card string for all cards in hand.
-func cuiCardListStr(hand cuiCardList) string {
+// cardFormatter formats a single card into a string.
+type cardFormatter func(card *domain.Card) string
+
+// formatCardList formats all cards in a cuiCardList using the given formatter and separator.
+// When indexed is true, each card is prefixed with "[N]".
+func formatCardList(hand cuiCardList, fmtCard cardFormatter, sep string, indexed bool) string {
 	parts := make([]string, hand.GetCardsSize())
 	for i := range parts {
-		parts[i] = cuiCardStr(hand.GetCard(i))
+		s := fmtCard(hand.GetCard(i))
+		if indexed {
+			s = fmt.Sprintf("[%d]%s", i, s)
+		}
+		parts[i] = s
 	}
-	return strings.Join(parts, ",")
+	return strings.Join(parts, sep)
+}
+
+// formatCardSlice formats a card slice using the given formatter and separator.
+func formatCardSlice(cards []*domain.Card, fmtCard cardFormatter, sep string) string {
+	parts := make([]string, len(cards))
+	for i, c := range cards {
+		parts[i] = fmtCard(c)
+	}
+	return strings.Join(parts, sep)
+}
+
+// cuiCardListStr returns a comma-separated card string for all cards in hand.
+func cuiCardListStr(hand cuiCardList) string {
+	return formatCardList(hand, cuiCardStr, ",", false)
 }
 
 // cuiPlayer is the minimal type constraint required by cuiPlayerName.
@@ -139,49 +161,29 @@ func cuiBettingActionName(action int) string {
 // cuiIndexedCardListStr returns a double-space separated indexed card string.
 // e.g. "[0]SPADE 5  [1]HEART 3"
 func cuiIndexedCardListStr(hand cuiCardList) string {
-	parts := make([]string, hand.GetCardsSize())
-	for i := range parts {
-		parts[i] = fmt.Sprintf("[%d]%s", i, cuiCardStr(hand.GetCard(i)))
-	}
-	return strings.Join(parts, "  ")
+	return formatCardList(hand, cuiCardStr, "  ", true)
 }
 
 // cuiCardListStrEmoji returns a double-space separated emoji card string (no index).
 // e.g. "♠5  ♥3"
 func cuiCardListStrEmoji(hand cuiCardList) string {
-	parts := make([]string, hand.GetCardsSize())
-	for i := range parts {
-		parts[i] = cuiCardStrEmoji(hand.GetCard(i))
-	}
-	return strings.Join(parts, "  ")
+	return formatCardList(hand, cuiCardStrEmoji, "  ", false)
 }
 
 // cuiIndexedCardListStrEmoji returns a double-space separated indexed emoji card string.
 // e.g. "[0]♠5  [1]♥3"
 func cuiIndexedCardListStrEmoji(hand cuiCardList) string {
-	parts := make([]string, hand.GetCardsSize())
-	for i := range parts {
-		parts[i] = fmt.Sprintf("[%d]%s", i, cuiCardStrEmoji(hand.GetCard(i)))
-	}
-	return strings.Join(parts, "  ")
+	return formatCardList(hand, cuiCardStrEmoji, "  ", true)
 }
 
 // cuiCardSliceStr returns a comma-space separated card string from a card slice.
 // e.g. "SPADE 5, HEART 3"
 func cuiCardSliceStr(cards []*domain.Card) string {
-	parts := make([]string, len(cards))
-	for i, c := range cards {
-		parts[i] = cuiCardStr(c)
-	}
-	return strings.Join(parts, ", ")
+	return formatCardSlice(cards, cuiCardStr, ", ")
 }
 
 // cuiCardSliceStrEmoji returns a double-space separated emoji card string from a card slice.
 // e.g. "♠5  ♥3"
 func cuiCardSliceStrEmoji(cards []*domain.Card) string {
-	parts := make([]string, len(cards))
-	for i, c := range cards {
-		parts[i] = cuiCardStrEmoji(c)
-	}
-	return strings.Join(parts, "  ")
+	return formatCardSlice(cards, cuiCardStrEmoji, "  ")
 }

--- a/internal/adapter/presenter/cui_card_helper_test.go
+++ b/internal/adapter/presenter/cui_card_helper_test.go
@@ -286,6 +286,70 @@ func TestCuiCardSliceStrEmoji(t *testing.T) {
 	}
 }
 
+func TestFormatCardList(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+
+	hand := &mockCardList{cards: []*domain.Card{
+		domain.NewCard(domain.CardDesignSpade, 1, false),
+		domain.NewCard(domain.CardDesignHeart, 5, false),
+	}}
+
+	tests := []struct {
+		name     string
+		fmtCard  cardFormatter
+		sep      string
+		indexed  bool
+		expected string
+	}{
+		{"text no-index comma", cuiCardStr, ",", false, "SPADE 1,HEART 5"},
+		{"text indexed double-space", cuiCardStr, "  ", true, "[0]SPADE 1  [1]HEART 5"},
+		{"emoji no-index", cuiCardStrEmoji, "  ", false, "♠1  ♥5"},
+		{"emoji indexed", cuiCardStrEmoji, "  ", true, "[0]♠1  [1]♥5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, formatCardList(hand, tt.fmtCard, tt.sep, tt.indexed))
+		})
+	}
+}
+
+func TestFormatCardList_Empty(t *testing.T) {
+	hand := &mockCardList{cards: []*domain.Card{}}
+	assert.Equal(t, "", formatCardList(hand, cuiCardStr, ",", false))
+}
+
+func TestFormatCardSlice(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+
+	cards := []*domain.Card{
+		domain.NewCard(domain.CardDesignSpade, 1, false),
+		domain.NewCard(domain.CardDesignHeart, 5, false),
+	}
+
+	tests := []struct {
+		name     string
+		fmtCard  cardFormatter
+		sep      string
+		expected string
+	}{
+		{"text comma-space", cuiCardStr, ", ", "SPADE 1, HEART 5"},
+		{"emoji double-space", cuiCardStrEmoji, "  ", "♠1  ♥5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, formatCardSlice(cards, tt.fmtCard, tt.sep))
+		})
+	}
+}
+
+func TestFormatCardSlice_Empty(t *testing.T) {
+	assert.Equal(t, "", formatCardSlice([]*domain.Card{}, cuiCardStr, ", "))
+}
+
 func TestCuiBettingActionName(t *testing.T) {
 	origNoColor := color.NoColor()
 	color.SetNoColor(true)

--- a/internal/domain/Daifugo.go
+++ b/internal/domain/Daifugo.go
@@ -96,10 +96,8 @@ type DaifugoExchangeAction struct {
 	Cards         []*Card // 交換されたカード
 }
 
-// Daifugo 大富豪ゲームクラス
-type Daifugo struct {
-	trumpCards          *TrumpCards
-	players             []*DaifugoPlayer
+// daifugoRoundState ラウンドごとにリセットされる状態
+type daifugoRoundState struct {
 	currentTurn         int                      // 現在の手番プレイヤーインデックス
 	tableCards          []*Card                  // 場に出されているカード (nil = 場はクリア)
 	lastPlayPlayerIdx   int                      // 最後にカードを出したプレイヤーインデックス (-1 = なし)
@@ -108,7 +106,6 @@ type Daifugo struct {
 	cpuActions          []*DaifugoCpuAction      // 人間ターン後のCPUの行動履歴
 	humanAction         *DaifugoCpuAction        // 人間の最後の行動
 	revolutionActive    bool                     // 革命フラグ (true = 革命中)
-	config              DaifugoConfig            // ローカルルール設定
 	suitLocked          bool                     // スート縛り発動中
 	lockedSuit          int                      // 縛られているスート (CardDesignSpade等)
 	elevenBackActive    bool                     // 11バック発動中
@@ -119,31 +116,28 @@ type Daifugo struct {
 	reverseDirection    bool                     // 9リバース: ターン方向が逆か
 	numberLocked        bool                     // 激シバ: 連番縛り発動中
 	sequenceLocked      bool                     // 階段縛り: 階段のみ出せる
-	sortMode            DaifugoSortMode          // 手札ソートモード
 	actionLog           []*ActionLogEntry        // 棋譜
+}
+
+// Daifugo 大富豪ゲームクラス
+type Daifugo struct {
+	trumpCards *TrumpCards
+	players    []*DaifugoPlayer
+	config     DaifugoConfig   // ローカルルール設定
+	sortMode   DaifugoSortMode // 手札ソートモード (ラウンド間で維持)
+	round      daifugoRoundState
 }
 
 // NewDaifugo コンストラクタ
 func NewDaifugo(trumpCards *TrumpCards, players []*DaifugoPlayer, config DaifugoConfig) *Daifugo {
 	return &Daifugo{
-		trumpCards:          trumpCards,
-		players:             players,
-		currentTurn:         0,
-		tableCards:          nil,
-		lastPlayPlayerIdx:   -1,
-		gameEndFlag:         false,
-		passCount:           0,
-		cpuActions:          nil,
-		humanAction:         nil,
-		revolutionActive:    false,
-		config:              config,
-		suitLocked:          false,
-		lockedSuit:          0,
-		elevenBackActive:    false,
-		tableIsSequence:     false,
-		exchangeActions:     nil,
-		pendingActionType:   DaifugoPendingNone,
-		pendingActionTarget: -1,
+		trumpCards: trumpCards,
+		players:    players,
+		config:     config,
+		round: daifugoRoundState{
+			lastPlayPlayerIdx:   -1,
+			pendingActionTarget: -1,
+		},
 	}
 }
 
@@ -161,25 +155,10 @@ func (d *Daifugo) Reset() {
 		}
 	}
 
-	d.gameEndFlag = false
-	d.currentTurn = 0
-	d.tableCards = nil
-	d.lastPlayPlayerIdx = -1
-	d.passCount = 0
-	d.cpuActions = nil
-	d.humanAction = nil
-	d.revolutionActive = false
-	d.suitLocked = false
-	d.lockedSuit = 0
-	d.elevenBackActive = false
-	d.tableIsSequence = false
-	d.exchangeActions = nil
-	d.pendingActionType = DaifugoPendingNone
-	d.pendingActionTarget = -1
-	d.reverseDirection = false
-	d.numberLocked = false
-	d.sequenceLocked = false
-	d.actionLog = nil
+	d.round = daifugoRoundState{
+		lastPlayPlayerIdx:   -1,
+		pendingActionTarget: -1,
+	}
 	// sortMode は意図的にリセットしない: ユーザーの好みをラウンド間で維持する
 
 	// シャッフル
@@ -211,26 +190,26 @@ func (d *Daifugo) Reset() {
 // PlayerPlay 人間プレイヤーがカードを出す (または パスする)
 // indices: 出すカードのインデックス。空の場合はパス。
 func (d *Daifugo) PlayerPlay(indices []int) error {
-	if d.gameEndFlag {
+	if d.round.gameEndFlag {
 		return ErrGameEnded
 	}
-	if !d.players[d.currentTurn].GetIsHuman() {
+	if !d.players[d.round.currentTurn].GetIsHuman() {
 		return ErrNotHumanTurn
 	}
 
 	// ペンディングアクションがある場合はそちらを先に解決
-	if d.pendingActionType != DaifugoPendingNone {
+	if d.round.pendingActionType != DaifugoPendingNone {
 		return d.resolvePendingAction(indices)
 	}
 
 	// 人間のターン開始時にCPU行動履歴をリセット
-	d.cpuActions = nil
+	d.round.cpuActions = nil
 
 	if len(indices) == 0 {
 		// パス
-		d.passCount++
-		d.humanAction = &DaifugoCpuAction{PlayerIdx: d.currentTurn, PlayedCards: nil}
-		d.appendLog(d.currentTurn, "pass", "pass", nil)
+		d.round.passCount++
+		d.round.humanAction = &DaifugoCpuAction{PlayerIdx: d.round.currentTurn, PlayedCards: nil}
+		d.appendLog(d.round.currentTurn, "pass", "pass", nil)
 		d.advanceTurn()
 		d.checkPassClear()
 		return nil
@@ -251,7 +230,7 @@ func (d *Daifugo) PlayerPlay(indices []int) error {
 	}
 
 	// 指定カードを収集
-	player := d.players[d.currentTurn]
+	player := d.players[d.round.currentTurn]
 	selectedCards := make([]*Card, len(indices))
 	for i, idx := range indices {
 		card := player.GetCard(idx)
@@ -275,19 +254,19 @@ func (d *Daifugo) PlayerPlay(indices []int) error {
 
 	// カードを出す
 	cards := player.RemoveCards(indices)
-	d.humanAction = &DaifugoCpuAction{PlayerIdx: d.currentTurn, PlayedCards: cards}
-	d.appendLog(d.currentTurn, "play", fmt.Sprintf("played %d card(s)", len(cards)), cards)
-	d.playCards(d.currentTurn, cards, isSeq, spadeThree)
+	d.round.humanAction = &DaifugoCpuAction{PlayerIdx: d.round.currentTurn, PlayedCards: cards}
+	d.appendLog(d.round.currentTurn, "play", fmt.Sprintf("played %d card(s)", len(cards)), cards)
+	d.playCards(d.round.currentTurn, cards, isSeq, spadeThree)
 	return nil
 }
 
 // playCards はカードプレイ後の共通処理を実行する
 func (d *Daifugo) playCards(playerIdx int, cards []*Card, isSeq bool, spadeThree bool) {
 	d.updateSequenceLock(isSeq)
-	d.tableCards = cards
-	d.lastPlayPlayerIdx = playerIdx
-	d.passCount = 0
-	d.tableIsSequence = isSeq
+	d.round.tableCards = cards
+	d.round.lastPlayPlayerIdx = playerIdx
+	d.round.passCount = 0
+	d.round.tableIsSequence = isSeq
 
 	emperor := d.triggerEmperor(cards)
 	if !emperor {
@@ -312,14 +291,14 @@ func (d *Daifugo) playCards(playerIdx int, cards []*Card, isSeq bool, spadeThree
 	d.triggerTenDiscardIfNeeded(cards, isSeq)
 	d.triggerQueenBomberIfNeeded(cards, isSeq)
 
-	if d.pendingActionType != DaifugoPendingNone {
+	if d.round.pendingActionType != DaifugoPendingNone {
 		return
 	}
 
 	if !d.checkGameEnd() {
 		if (!eightCut && !sandstorm && !emperor && !spadeThree) || d.players[playerIdx].GetIsFinished() {
 			d.advanceTurn()
-			for i := 0; i < fiveSkipCount && !d.gameEndFlag; i++ {
+			for i := 0; i < fiveSkipCount && !d.round.gameEndFlag; i++ {
 				d.advanceTurn()
 			}
 			d.checkPassClear()
@@ -329,17 +308,17 @@ func (d *Daifugo) playCards(playerIdx int, cards []*Card, isSeq bool, spadeThree
 
 // CpuPlay 現在の手番がCPUの場合に1ターン実行
 func (d *Daifugo) CpuPlay() {
-	if d.gameEndFlag || d.players[d.currentTurn].GetIsHuman() {
+	if d.round.gameEndFlag || d.players[d.round.currentTurn].GetIsHuman() {
 		return
 	}
 
 	// ペンディングアクションがある場合はCPUが自動解決
-	if d.pendingActionType != DaifugoPendingNone {
+	if d.round.pendingActionType != DaifugoPendingNone {
 		d.cpuResolvePendingAction()
 		return
 	}
 
-	playerIdx := d.currentTurn
+	playerIdx := d.round.currentTurn
 	player := d.players[playerIdx]
 
 	// 出せる最弱のカードセットを探す
@@ -347,9 +326,9 @@ func (d *Daifugo) CpuPlay() {
 
 	if len(playIndices) == 0 {
 		// パス
-		d.passCount++
+		d.round.passCount++
 		action := &DaifugoCpuAction{PlayerIdx: playerIdx, PlayedCards: nil}
-		d.cpuActions = append(d.cpuActions, action)
+		d.round.cpuActions = append(d.round.cpuActions, action)
 		d.appendLog(playerIdx, "pass", "pass", nil)
 		d.advanceTurn()
 		d.checkPassClear()
@@ -371,7 +350,7 @@ func (d *Daifugo) CpuPlay() {
 
 		cards := player.RemoveCards(playIndices)
 		action := &DaifugoCpuAction{PlayerIdx: playerIdx, PlayedCards: cards}
-		d.cpuActions = append(d.cpuActions, action)
+		d.round.cpuActions = append(d.round.cpuActions, action)
 		d.appendLog(playerIdx, "play", fmt.Sprintf("played %d card(s)", len(cards)), cards)
 		d.playCards(playerIdx, cards, isSeq, spadeThree)
 	}
@@ -379,54 +358,54 @@ func (d *Daifugo) CpuPlay() {
 
 // advanceTurn 手番を次のアクティブなプレイヤーへ進める
 func (d *Daifugo) advanceTurn() {
-	if d.gameEndFlag {
+	if d.round.gameEndFlag {
 		return
 	}
-	next := d.getNextActivePlayer(d.currentTurn)
+	next := d.getNextActivePlayer(d.round.currentTurn)
 	if next >= 0 {
-		d.currentTurn = next
+		d.round.currentTurn = next
 	}
 }
 
 // checkPassClear 全員パスしたら場をクリアする
 func (d *Daifugo) checkPassClear() {
-	if d.tableCards == nil || d.lastPlayPlayerIdx < 0 {
+	if d.round.tableCards == nil || d.round.lastPlayPlayerIdx < 0 {
 		return
 	}
 	// 手番が最後に出したプレイヤーに戻ってきたら全員パス
-	if d.currentTurn == d.lastPlayPlayerIdx {
+	if d.round.currentTurn == d.round.lastPlayPlayerIdx {
 		d.clearTableState()
 	}
 }
 
 // clearTableState 場の状態をクリア (8切り、上がり時等に使用)
 func (d *Daifugo) clearTableState() {
-	d.tableCards = nil
-	d.lastPlayPlayerIdx = -1
-	d.passCount = 0
-	d.suitLocked = false
-	d.lockedSuit = 0
-	d.elevenBackActive = false
-	d.tableIsSequence = false
-	d.numberLocked = false
+	d.round.tableCards = nil
+	d.round.lastPlayPlayerIdx = -1
+	d.round.passCount = 0
+	d.round.suitLocked = false
+	d.round.lockedSuit = 0
+	d.round.elevenBackActive = false
+	d.round.tableIsSequence = false
+	d.round.numberLocked = false
 }
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (d *Daifugo) IsHumanTurn() bool {
-	return d.players[d.currentTurn].GetIsHuman()
+	return d.players[d.round.currentTurn].GetIsHuman()
 }
 
 // GetCurrentTurn 現在の手番プレイヤーインデックス取得
-func (d *Daifugo) GetCurrentTurn() int { return d.currentTurn }
+func (d *Daifugo) GetCurrentTurn() int { return d.round.currentTurn }
 
 // GetGameEndFlag ゲーム終了フラグ取得
-func (d *Daifugo) GetGameEndFlag() bool { return d.gameEndFlag }
+func (d *Daifugo) GetGameEndFlag() bool { return d.round.gameEndFlag }
 
 // GetTableCards 場のカード取得 (nil = クリア)
-func (d *Daifugo) GetTableCards() []*Card { return d.tableCards }
+func (d *Daifugo) GetTableCards() []*Card { return d.round.tableCards }
 
 // GetLastPlayPlayerIdx 最後にカードを出したプレイヤーインデックス取得 (-1 = なし)
-func (d *Daifugo) GetLastPlayPlayerIdx() int { return d.lastPlayPlayerIdx }
+func (d *Daifugo) GetLastPlayPlayerIdx() int { return d.round.lastPlayPlayerIdx }
 
 // GetPlayer プレイヤー取得
 func (d *Daifugo) GetPlayer(idx int) *DaifugoPlayer {
@@ -440,66 +419,66 @@ func (d *Daifugo) GetPlayer(idx int) *DaifugoPlayer {
 func (d *Daifugo) GetPlayerCnt() int { return len(d.players) }
 
 // GetCpuActions CPUターンの行動履歴取得
-func (d *Daifugo) GetCpuActions() []*DaifugoCpuAction { return d.cpuActions }
+func (d *Daifugo) GetCpuActions() []*DaifugoCpuAction { return d.round.cpuActions }
 
 // GetHumanAction 人間の最後の行動取得
-func (d *Daifugo) GetHumanAction() *DaifugoCpuAction { return d.humanAction }
+func (d *Daifugo) GetHumanAction() *DaifugoCpuAction { return d.round.humanAction }
 
 // GetPassCount 現在のパスカウント取得
-func (d *Daifugo) GetPassCount() int { return d.passCount }
+func (d *Daifugo) GetPassCount() int { return d.round.passCount }
 
 // GetRevolutionActive 革命フラグ取得
-func (d *Daifugo) GetRevolutionActive() bool { return d.revolutionActive }
+func (d *Daifugo) GetRevolutionActive() bool { return d.round.revolutionActive }
 
 // GetConfig ローカルルール設定取得
 func (d *Daifugo) GetConfig() DaifugoConfig { return d.config }
 
 // GetSuitLocked スート縛り発動中か取得
-func (d *Daifugo) GetSuitLocked() bool { return d.suitLocked }
+func (d *Daifugo) GetSuitLocked() bool { return d.round.suitLocked }
 
 // GetLockedSuit 縛られているスート取得
-func (d *Daifugo) GetLockedSuit() int { return d.lockedSuit }
+func (d *Daifugo) GetLockedSuit() int { return d.round.lockedSuit }
 
 // GetElevenBackActive 11バック発動中か取得
-func (d *Daifugo) GetElevenBackActive() bool { return d.elevenBackActive }
+func (d *Daifugo) GetElevenBackActive() bool { return d.round.elevenBackActive }
 
 // GetTableIsSequence 場が階段プレイか取得
-func (d *Daifugo) GetTableIsSequence() bool { return d.tableIsSequence }
+func (d *Daifugo) GetTableIsSequence() bool { return d.round.tableIsSequence }
 
 // GetExchangeActions カード交換記録取得
-func (d *Daifugo) GetExchangeActions() []*DaifugoExchangeAction { return d.exchangeActions }
+func (d *Daifugo) GetExchangeActions() []*DaifugoExchangeAction { return d.round.exchangeActions }
 
 // GetPendingActionType ペンディングアクションの種類取得
-func (d *Daifugo) GetPendingActionType() DaifugoPendingAction { return d.pendingActionType }
+func (d *Daifugo) GetPendingActionType() DaifugoPendingAction { return d.round.pendingActionType }
 
 // GetPendingActionTarget ペンディングアクションの対象プレイヤーインデックス取得
-func (d *Daifugo) GetPendingActionTarget() int { return d.pendingActionTarget }
+func (d *Daifugo) GetPendingActionTarget() int { return d.round.pendingActionTarget }
 
 // HasPendingAction ペンディングアクションがあるか取得
-func (d *Daifugo) HasPendingAction() bool { return d.pendingActionType != DaifugoPendingNone }
+func (d *Daifugo) HasPendingAction() bool { return d.round.pendingActionType != DaifugoPendingNone }
 
 // SetConfig ローカルルール設定を変更（ResetWithConfig用）
 func (d *Daifugo) SetConfig(config DaifugoConfig) { d.config = config }
 
 // GetReverseDirection 9リバースの方向取得
-func (d *Daifugo) GetReverseDirection() bool { return d.reverseDirection }
+func (d *Daifugo) GetReverseDirection() bool { return d.round.reverseDirection }
 
 // GetNumberLocked 連番縛り発動中か取得
-func (d *Daifugo) GetNumberLocked() bool { return d.numberLocked }
+func (d *Daifugo) GetNumberLocked() bool { return d.round.numberLocked }
 
 // GetSequenceLocked 階段縛り発動中か取得
-func (d *Daifugo) GetSequenceLocked() bool { return d.sequenceLocked }
+func (d *Daifugo) GetSequenceLocked() bool { return d.round.sequenceLocked }
 
 // GetSortMode 手札ソートモード取得
 func (d *Daifugo) GetSortMode() DaifugoSortMode { return d.sortMode }
 
 // GetActionLog 棋譜を取得する
-func (d *Daifugo) GetActionLog() []*ActionLogEntry { return d.actionLog }
+func (d *Daifugo) GetActionLog() []*ActionLogEntry { return d.round.actionLog }
 
 // appendLog 棋譜にエントリを追加する
 func (d *Daifugo) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	d.actionLog = append(d.actionLog, &ActionLogEntry{
-		TurnNumber: len(d.actionLog) + 1,
+	d.round.actionLog = append(d.round.actionLog, &ActionLogEntry{
+		TurnNumber: len(d.round.actionLog) + 1,
 		PlayerIdx:  playerIdx,
 		ActionType: actionType,
 		Detail:     detail,

--- a/internal/domain/DaifugoCPU.go
+++ b/internal/domain/DaifugoCPU.go
@@ -54,7 +54,7 @@ func (d *Daifugo) shouldStrategicPass(player *DaifugoPlayer, indices []int) bool
 	if player.GetCardsSize() <= 5 {
 		return false
 	}
-	tableBase := getBaseValue(d.tableCards)
+	tableBase := getBaseValue(d.round.tableCards)
 	var tableStrength int
 	if tableBase < 0 {
 		tableStrength = DaifugoJokerStrength
@@ -77,9 +77,9 @@ func (d *Daifugo) shouldStrategicPass(player *DaifugoPlayer, indices []int) bool
 	return false
 }
 
-// calcTableStrength 場のカードの強さを計算する (d.tableCards が非nil前提)
+// calcTableStrength 場のカードの強さを計算する (d.round.tableCards が非nil前提)
 func (d *Daifugo) calcTableStrength() int {
-	tableBase := getBaseValue(d.tableCards)
+	tableBase := getBaseValue(d.round.tableCards)
 	if tableBase < 0 {
 		return DaifugoJokerStrength
 	}
@@ -91,11 +91,11 @@ func (d *Daifugo) calcTableStrength() int {
 // 片縛り: グループ内に少なくとも1枚ロックスートと一致するカードがあればOK
 func (d *Daifugo) searchCardGroupSuitCheck(player *DaifugoPlayer, start, end int) bool {
 	if d.config.SuitLockMode == DaifugoSuitLockFull {
-		return player.GetCard(start).GetDesign() == d.lockedSuit
+		return player.GetCard(start).GetDesign() == d.round.lockedSuit
 	}
 	// 片縛り
 	for k := start; k < end; k++ {
-		if player.GetCard(k).GetDesign() == d.lockedSuit {
+		if player.GetCard(k).GetDesign() == d.round.lockedSuit {
 			return true
 		}
 	}
@@ -123,12 +123,12 @@ func (d *Daifugo) searchCardGroup(player *DaifugoPlayer, needed int, tableStreng
 		count := j - i
 		if count >= needed && d.cardStrength(v) > tableStrength {
 			// 革命防止: 4枚以上かつ革命未発動かつ出した後も手札が残る場合はスキップ
-			if opts.skipRevolution && count >= 4 && !d.revolutionActive && player.GetCardsSize() > count {
+			if opts.skipRevolution && count >= 4 && !d.round.revolutionActive && player.GetCardsSize() > count {
 				i = j
 				continue
 			}
 			// スート縛りチェック
-			if d.suitLocked && d.config.SuitLockMode != DaifugoSuitLockNone {
+			if d.round.suitLocked && d.config.SuitLockMode != DaifugoSuitLockNone {
 				if !d.searchCardGroupSuitCheck(player, i, j) {
 					i = j
 					continue
@@ -147,7 +147,7 @@ func (d *Daifugo) searchCardGroup(player *DaifugoPlayer, needed int, tableStreng
 		if count < needed && count > 0 && d.cardStrength(v) > tableStrength {
 			if count+len(jokerIndices) >= needed {
 				// スート縛りチェック
-				if d.suitLocked && d.config.SuitLockMode != DaifugoSuitLockNone {
+				if d.round.suitLocked && d.config.SuitLockMode != DaifugoSuitLockNone {
 					if !d.searchCardGroupSuitCheck(player, i, j) {
 						i = j
 						continue
@@ -273,7 +273,7 @@ func (d *Daifugo) findJokerSinglePlay(player *DaifugoPlayer, tableStrength int) 
 
 // findBestPlayNormal 通常難易度: 既存ロジック (最弱のカードを出す、8/ジョーカー温存)
 func (d *Daifugo) findBestPlayNormal(player *DaifugoPlayer) []int {
-	if d.tableCards == nil {
+	if d.round.tableCards == nil {
 		return d.findNormalOpeningPlay(player)
 	}
 	return d.findNormalResponsePlay(player)
@@ -286,7 +286,7 @@ func (d *Daifugo) findNormalOpeningPlay(player *DaifugoPlayer) []int {
 			return emperorIndices
 		}
 	}
-	if d.sequenceLocked {
+	if d.round.sequenceLocked {
 		return d.findOpeningSequencePlay(player)
 	}
 	return d.findOpeningSingleCard(player, []func(*Card) bool{
@@ -297,11 +297,11 @@ func (d *Daifugo) findNormalOpeningPlay(player *DaifugoPlayer) []int {
 
 // findNormalResponsePlay Normal AIの応手プレイ: 階段 → 最弱グループ → ジョーカー単体
 func (d *Daifugo) findNormalResponsePlay(player *DaifugoPlayer) []int {
-	if d.tableIsSequence && d.config.SequenceEnabled {
+	if d.round.tableIsSequence && d.config.SequenceEnabled {
 		return d.findBestSequencePlay(player)
 	}
 
-	needed := len(d.tableCards)
+	needed := len(d.round.tableCards)
 	tableStrength := d.calcTableStrength()
 
 	if indices := d.searchCardGroup(player, needed, tableStrength, cardSearchOpts{skipRevolution: true}); indices != nil {
@@ -320,9 +320,9 @@ func (d *Daifugo) findNormalResponsePlay(player *DaifugoPlayer) []int {
 
 // findBestPlayEasy 簡単難易度: 単純に出せる最弱のカードを出す (8/ジョーカー温存なし、エンペラー探索なし、革命防止なし)
 func (d *Daifugo) findBestPlayEasy(player *DaifugoPlayer) []int {
-	if d.tableCards == nil {
+	if d.round.tableCards == nil {
 		// 階段縛り中は階段を探す
-		if d.sequenceLocked {
+		if d.round.sequenceLocked {
 			return d.findOpeningSequencePlay(player)
 		}
 		// 場がクリアなら最弱の1枚を出す (温存戦略なし、反則上がりチェックなし: Easy AIは戦略なしで失敗もする)
@@ -333,11 +333,11 @@ func (d *Daifugo) findBestPlayEasy(player *DaifugoPlayer) []int {
 	}
 
 	// 場が階段の場合
-	if d.tableIsSequence && d.config.SequenceEnabled {
+	if d.round.tableIsSequence && d.config.SequenceEnabled {
 		return d.findBestSequencePlay(player)
 	}
 
-	needed := len(d.tableCards)
+	needed := len(d.round.tableCards)
 	tableStrength := d.calcTableStrength()
 
 	// 最弱のグループを探す (革命防止なし、ジョーカー温存なし)
@@ -360,7 +360,7 @@ func (d *Daifugo) findBestPlayHard(player *DaifugoPlayer) []int {
 	if indices := d.trySolveEndgame(player); indices != nil {
 		return indices
 	}
-	if d.tableCards == nil {
+	if d.round.tableCards == nil {
 		return d.findHardOpeningPlay(player)
 	}
 	return d.findHardResponsePlay(player)
@@ -373,7 +373,7 @@ func (d *Daifugo) findHardOpeningPlay(player *DaifugoPlayer) []int {
 			return emperorIndices
 		}
 	}
-	if d.sequenceLocked {
+	if d.round.sequenceLocked {
 		return d.findOpeningSequencePlay(player)
 	}
 	if d.isUrgent(player) {
@@ -386,11 +386,11 @@ func (d *Daifugo) findHardOpeningPlay(player *DaifugoPlayer) []int {
 
 // findHardResponsePlay Hard AIの応手プレイ: 緊急時は最強グループ / 非緊急時はNormal+戦略的パス
 func (d *Daifugo) findHardResponsePlay(player *DaifugoPlayer) []int {
-	if d.tableIsSequence && d.config.SequenceEnabled {
+	if d.round.tableIsSequence && d.config.SequenceEnabled {
 		return d.findBestSequencePlayHard(player)
 	}
 
-	needed := len(d.tableCards)
+	needed := len(d.round.tableCards)
 	tableStrength := d.calcTableStrength()
 
 	if d.isUrgent(player) {
@@ -436,8 +436,8 @@ func (d *Daifugo) findBestSequencePlay(player *DaifugoPlayer) []int {
 
 // findSequencePlay 階段モードで出せる階段を探す (selectStrongest=true で最強、false で最弱)
 func (d *Daifugo) findSequencePlay(player *DaifugoPlayer, selectStrongest bool) []int {
-	needed := len(d.tableCards)
-	tableMinStr := d.getSequenceMinStrength(d.tableCards)
+	needed := len(d.round.tableCards)
+	tableMinStr := d.getSequenceMinStrength(d.round.tableCards)
 	jokerIndices := d.findJokerIndices(player)
 
 	var bestIndices []int
@@ -505,7 +505,7 @@ func (d *Daifugo) findOpeningSequencePlay(player *DaifugoPlayer) []int {
 
 // findEmperorPlay エンペラーの組み合わせを探す (場がクリアの時のみ)
 func (d *Daifugo) findEmperorPlay(player *DaifugoPlayer) []int {
-	if !d.config.EmperorEnabled || d.tableCards != nil {
+	if !d.config.EmperorEnabled || d.round.tableCards != nil {
 		return nil
 	}
 	n := player.GetCardsSize()
@@ -555,36 +555,36 @@ func (d *Daifugo) findWeakestNonJokerIndex(player *DaifugoPlayer) int {
 
 // cpuResolvePendingAction CPUがペンディングアクションを自動解決する
 func (d *Daifugo) cpuResolvePendingAction() {
-	player := d.players[d.currentTurn]
+	player := d.players[d.round.currentTurn]
 
 	var idx int
-	switch d.pendingActionType {
+	switch d.round.pendingActionType {
 	case DaifugoPendingSevenPass:
 		// 7渡し: 最強の非ジョーカーカードを渡す
 		idx = d.findStrongestNonJokerIndex(player)
 		removed := player.RemoveCards([]int{idx})
-		target := d.players[d.pendingActionTarget]
+		target := d.players[d.round.pendingActionTarget]
 		target.AddCard(removed[0])
 		target.SortCardsByStrength(d.cardStrengthForCard)
-		action := &DaifugoCpuAction{PlayerIdx: d.currentTurn, PlayedCards: removed}
-		d.cpuActions = append(d.cpuActions, action)
+		action := &DaifugoCpuAction{PlayerIdx: d.round.currentTurn, PlayedCards: removed}
+		d.round.cpuActions = append(d.round.cpuActions, action)
 	case DaifugoPendingTenDiscard:
 		// 10捨て: 最弱の非ジョーカーカードを捨てる
 		idx = d.findWeakestNonJokerIndex(player)
 		removed := player.RemoveCards([]int{idx})
-		action := &DaifugoCpuAction{PlayerIdx: d.currentTurn, PlayedCards: removed}
-		d.cpuActions = append(d.cpuActions, action)
+		action := &DaifugoCpuAction{PlayerIdx: d.round.currentTurn, PlayedCards: removed}
+		d.round.cpuActions = append(d.round.cpuActions, action)
 	case DaifugoPendingQueenBomber:
 		// 12ボンバー: 対戦相手から最も多くカードを除去できる値を選ぶ
 		bestValue := d.cpuChooseQueenBomberValue(player)
 		d.resolveQueenBomber(bestValue)
 		d.finishEmptyPlayers()
-		action := &DaifugoCpuAction{PlayerIdx: d.currentTurn, PlayedCards: nil}
-		d.cpuActions = append(d.cpuActions, action)
+		action := &DaifugoCpuAction{PlayerIdx: d.round.currentTurn, PlayedCards: nil}
+		d.round.cpuActions = append(d.round.cpuActions, action)
 	}
 
-	d.pendingActionType = DaifugoPendingNone
-	d.pendingActionTarget = -1
+	d.round.pendingActionType = DaifugoPendingNone
+	d.round.pendingActionTarget = -1
 
 	if d.checkGameEnd() {
 		return

--- a/internal/domain/DaifugoEval.go
+++ b/internal/domain/DaifugoEval.go
@@ -31,7 +31,7 @@ func IsJoker(card *Card) bool {
 // cardStrength 現在の革命・11バック状態に応じたカード値の強さを返す
 func (d *Daifugo) cardStrength(v int) int {
 	// 革命と11バックのXOR: 両方有効なら打ち消し合う
-	reversed := d.revolutionActive != d.elevenBackActive
+	reversed := d.round.revolutionActive != d.round.elevenBackActive
 	if reversed {
 		return DaifugoCardStrengthRevolution(v)
 	}
@@ -148,9 +148,9 @@ func (d *Daifugo) isPlayable(cards []*Card) bool {
 		return false
 	}
 
-	if d.tableCards == nil {
+	if d.round.tableCards == nil {
 		// 階段縛り中は階段またはエンペラーのみ
-		if d.sequenceLocked {
+		if d.round.sequenceLocked {
 			return validSeq || validEmperor
 		}
 		// 場がクリアなら何でも出せる
@@ -158,16 +158,16 @@ func (d *Daifugo) isPlayable(cards []*Card) bool {
 	}
 
 	// 枚数が一致しているか
-	if len(cards) != len(d.tableCards) {
+	if len(cards) != len(d.round.tableCards) {
 		return false
 	}
 
 	// 場が階段の場合
-	if d.tableIsSequence {
+	if d.round.tableIsSequence {
 		if !validSeq {
 			return false
 		}
-		tableMin := d.getSequenceMinStrength(d.tableCards)
+		tableMin := d.getSequenceMinStrength(d.round.tableCards)
 		playMin := d.getSequenceMinStrength(cards)
 		return playMin > tableMin
 	}
@@ -178,23 +178,23 @@ func (d *Daifugo) isPlayable(cards []*Card) bool {
 	}
 
 	// スート縛りチェック
-	if d.suitLocked && d.config.SuitLockMode != DaifugoSuitLockNone {
+	if d.round.suitLocked && d.config.SuitLockMode != DaifugoSuitLockNone {
 		if d.config.SuitLockMode == DaifugoSuitLockFull {
 			// 両縛り: 全てのカードがロックされたスートに一致する必要がある
 			newSuit := d.getNonJokerSuit(cards)
-			if newSuit > 0 && newSuit != d.lockedSuit {
+			if newSuit > 0 && newSuit != d.round.lockedSuit {
 				return false
 			}
 		} else {
 			// 片縛り: 少なくとも1枚がロックされたスートに一致する必要がある
-			if !d.hasMatchingSuit(cards, d.lockedSuit) {
+			if !d.hasMatchingSuit(cards, d.round.lockedSuit) {
 				return false
 			}
 		}
 	}
 
 	// 強さ比較
-	tableBase := getBaseValue(d.tableCards)
+	tableBase := getBaseValue(d.round.tableCards)
 	playBase := getBaseValue(cards)
 
 	var tableStrength, playStrength int
@@ -211,7 +211,7 @@ func (d *Daifugo) isPlayable(cards []*Card) bool {
 
 	// 数縛り: 連番縛り発動中は強さの差が1でなければ出せない
 	// ジョーカーは連番縛りをバイパスし、通常の強さ比較のみ適用
-	if d.numberLocked && d.config.NumberLockEnabled {
+	if d.round.numberLocked && d.config.NumberLockEnabled {
 		if playBase > 0 && tableBase > 0 {
 			return playStrength-tableStrength == 1
 		}

--- a/internal/domain/DaifugoRules.go
+++ b/internal/domain/DaifugoRules.go
@@ -15,7 +15,7 @@ func (d *Daifugo) triggerRevolutionIfNeeded(cards []*Card, isSeq bool) {
 	if isSeq && !d.config.SequenceRevolutionEnabled {
 		return
 	}
-	d.revolutionActive = !d.revolutionActive
+	d.round.revolutionActive = !d.round.revolutionActive
 	d.appendLog(-1, "revolution", "revolution!", nil)
 	d.sortAllActiveHands()
 }
@@ -53,7 +53,7 @@ func (d *Daifugo) triggerSandstorm(cards []*Card) bool {
 
 // isValidEmperor エンペラー判定: 4枚の連番カード(全スート異なる)を場がクリアの時に出す
 func (d *Daifugo) isValidEmperor(cards []*Card) bool {
-	if !d.config.EmperorEnabled || len(cards) != 4 || d.tableCards != nil {
+	if !d.config.EmperorEnabled || len(cards) != 4 || d.round.tableCards != nil {
 		return false
 	}
 	return d.isEmperorCards(cards)
@@ -110,7 +110,7 @@ func (d *Daifugo) triggerEmperor(cards []*Card) bool {
 	if !d.isEmperorCards(cards) {
 		return false
 	}
-	d.revolutionActive = !d.revolutionActive
+	d.round.revolutionActive = !d.round.revolutionActive
 	d.appendLog(-1, "revolution", "revolution!", nil)
 	d.sortAllActiveHands()
 	d.clearTableState()
@@ -124,7 +124,7 @@ func (d *Daifugo) triggerElevenBack(cards []*Card) {
 	}
 	for _, c := range cards {
 		if !IsJoker(c) && c.GetValue() == 11 {
-			d.elevenBackActive = !d.elevenBackActive
+			d.round.elevenBackActive = !d.round.elevenBackActive
 			d.sortAllActiveHands()
 			return
 		}
@@ -138,7 +138,7 @@ func (d *Daifugo) triggerNineReverseIfNeeded(cards []*Card, isSeq bool) {
 	}
 	for _, c := range cards {
 		if !IsJoker(c) && c.GetValue() == 9 {
-			d.reverseDirection = !d.reverseDirection
+			d.round.reverseDirection = !d.round.reverseDirection
 			return
 		}
 	}
@@ -157,7 +157,7 @@ func (d *Daifugo) triggerCoupDetatIfNeeded(cards []*Card) {
 			return
 		}
 	}
-	d.revolutionActive = !d.revolutionActive
+	d.round.revolutionActive = !d.round.revolutionActive
 	d.appendLog(-1, "revolution", "revolution!", nil)
 	d.sortAllActiveHands()
 }
@@ -169,19 +169,19 @@ func (d *Daifugo) updateSuitLock(cards []*Card) {
 		d.updateNumberLock(cards)
 		return
 	}
-	if len(d.tableCards) == 0 {
+	if len(d.round.tableCards) == 0 {
 		// 場がクリアだった → 縛りなし、今出したカードのスートを記録のみ
-		d.suitLocked = false
-		d.lockedSuit = 0
+		d.round.suitLocked = false
+		d.round.lockedSuit = 0
 		return
 	}
 	// 前の場のカードと今出したカードのスートが一致するか確認 (ジョーカー除く)
-	prevSuit := d.getNonJokerSuit(d.tableCards)
+	prevSuit := d.getNonJokerSuit(d.round.tableCards)
 	newSuit := d.getNonJokerSuit(cards)
 	if prevSuit > 0 && newSuit > 0 && prevSuit == newSuit {
-		if !d.suitLocked {
-			d.suitLocked = true
-			d.lockedSuit = prevSuit
+		if !d.round.suitLocked {
+			d.round.suitLocked = true
+			d.round.lockedSuit = prevSuit
 			d.updateNumberLock(cards)
 		}
 	}
@@ -192,8 +192,8 @@ func (d *Daifugo) updateSequenceLock(isSeq bool) {
 	if !d.config.SequenceLockEnabled {
 		return
 	}
-	if d.tableIsSequence && isSeq {
-		d.sequenceLocked = true
+	if d.round.tableIsSequence && isSeq {
+		d.round.sequenceLocked = true
 	}
 }
 
@@ -202,16 +202,16 @@ func (d *Daifugo) updateNumberLock(cards []*Card) {
 	if !d.config.NumberLockEnabled {
 		return
 	}
-	if len(d.tableCards) == 0 {
+	if len(d.round.tableCards) == 0 {
 		return
 	}
-	prevBase := getBaseValue(d.tableCards)
+	prevBase := getBaseValue(d.round.tableCards)
 	newBase := getBaseValue(cards)
 	if prevBase > 0 && newBase > 0 {
 		prevStr := d.cardStrength(prevBase)
 		newStr := d.cardStrength(newBase)
 		if newStr-prevStr == 1 {
-			d.numberLocked = true
+			d.round.numberLocked = true
 		}
 	}
 }
@@ -252,7 +252,7 @@ func (d *Daifugo) triggerSevenPassIfNeeded(cards []*Card, isSeq bool) {
 	if !d.config.SevenPassEnabled || isSeq {
 		return
 	}
-	player := d.players[d.currentTurn]
+	player := d.players[d.round.currentTurn]
 	// 出した後に手札が残っている場合のみ
 	if player.GetCardsSize() == 0 {
 		return
@@ -260,10 +260,10 @@ func (d *Daifugo) triggerSevenPassIfNeeded(cards []*Card, isSeq bool) {
 	for _, c := range cards {
 		if !IsJoker(c) && c.GetValue() == 7 {
 			// 渡す対象: 次のアクティブなプレイヤー (自分以外)
-			target := d.getNextActivePlayer(d.currentTurn)
-			if target >= 0 && target != d.currentTurn {
-				d.pendingActionType = DaifugoPendingSevenPass
-				d.pendingActionTarget = target
+			target := d.getNextActivePlayer(d.round.currentTurn)
+			if target >= 0 && target != d.round.currentTurn {
+				d.round.pendingActionType = DaifugoPendingSevenPass
+				d.round.pendingActionTarget = target
 			}
 			return
 		}
@@ -275,15 +275,15 @@ func (d *Daifugo) triggerTenDiscardIfNeeded(cards []*Card, isSeq bool) {
 	if !d.config.TenDiscardEnabled || isSeq {
 		return
 	}
-	player := d.players[d.currentTurn]
+	player := d.players[d.round.currentTurn]
 	// 出した後に手札が残っている場合のみ
 	if player.GetCardsSize() == 0 {
 		return
 	}
 	for _, c := range cards {
 		if !IsJoker(c) && c.GetValue() == 10 {
-			d.pendingActionType = DaifugoPendingTenDiscard
-			d.pendingActionTarget = -1
+			d.round.pendingActionType = DaifugoPendingTenDiscard
+			d.round.pendingActionTarget = -1
 			return
 		}
 	}
@@ -294,15 +294,15 @@ func (d *Daifugo) triggerQueenBomberIfNeeded(cards []*Card, isSeq bool) {
 	if !d.config.QueenBomberEnabled || isSeq {
 		return
 	}
-	player := d.players[d.currentTurn]
+	player := d.players[d.round.currentTurn]
 	// 出した後に手札が残っている場合のみ
 	if player.GetCardsSize() == 0 {
 		return
 	}
 	for _, c := range cards {
 		if !IsJoker(c) && c.GetValue() == 12 {
-			d.pendingActionType = DaifugoPendingQueenBomber
-			d.pendingActionTarget = -1
+			d.round.pendingActionType = DaifugoPendingQueenBomber
+			d.round.pendingActionTarget = -1
 			return
 		}
 	}
@@ -314,7 +314,7 @@ func (d *Daifugo) isSpadeThreeCounter(cards []*Card) bool {
 		return false
 	}
 	// 場がジョーカー1枚のみ
-	if len(d.tableCards) != 1 || !IsJoker(d.tableCards[0]) {
+	if len(d.round.tableCards) != 1 || !IsJoker(d.round.tableCards[0]) {
 		return false
 	}
 	// 出すカードがスペードの3を1枚のみ
@@ -328,7 +328,7 @@ func (d *Daifugo) isSpadeThreeCounter(cards []*Card) bool {
 // resolvePendingAction ペンディングアクションを解決する
 func (d *Daifugo) resolvePendingAction(indices []int) error {
 	// 12ボンバーは indices[0] をカード値 (1-13) として解釈する
-	if d.pendingActionType == DaifugoPendingQueenBomber {
+	if d.round.pendingActionType == DaifugoPendingQueenBomber {
 		if len(indices) != 1 {
 			return NewDomainError(ErrInvalidPlay, "queen bomber requires exactly 1 card value")
 		}
@@ -338,10 +338,10 @@ func (d *Daifugo) resolvePendingAction(indices []int) error {
 		}
 		d.resolveQueenBomber(v)
 		d.finishEmptyPlayers()
-		d.humanAction = &DaifugoCpuAction{PlayerIdx: d.currentTurn, PlayedCards: nil}
+		d.round.humanAction = &DaifugoCpuAction{PlayerIdx: d.round.currentTurn, PlayedCards: nil}
 
-		d.pendingActionType = DaifugoPendingNone
-		d.pendingActionTarget = -1
+		d.round.pendingActionType = DaifugoPendingNone
+		d.round.pendingActionTarget = -1
 
 		if !d.checkGameEnd() {
 			d.advanceTurn()
@@ -353,28 +353,28 @@ func (d *Daifugo) resolvePendingAction(indices []int) error {
 	if len(indices) != 1 {
 		return NewDomainError(ErrInvalidPlay, "pending action requires exactly 1 card index")
 	}
-	player := d.players[d.currentTurn]
+	player := d.players[d.round.currentTurn]
 	card := player.GetCard(indices[0])
 	if card == nil {
 		return NewDomainError(ErrInvalidCard, fmt.Sprintf("card index %d out of range", indices[0]))
 	}
 
-	switch d.pendingActionType {
+	switch d.round.pendingActionType {
 	case DaifugoPendingSevenPass:
 		// 7渡し: カードを対象プレイヤーに渡す
 		removed := player.RemoveCards([]int{indices[0]})
-		target := d.players[d.pendingActionTarget]
+		target := d.players[d.round.pendingActionTarget]
 		target.AddCard(removed[0])
 		target.SortCardsByStrength(d.cardStrengthForCard)
-		d.humanAction = &DaifugoCpuAction{PlayerIdx: d.currentTurn, PlayedCards: removed}
+		d.round.humanAction = &DaifugoCpuAction{PlayerIdx: d.round.currentTurn, PlayedCards: removed}
 	case DaifugoPendingTenDiscard:
 		// 10捨て: カードを捨てる
 		removed := player.RemoveCards([]int{indices[0]})
-		d.humanAction = &DaifugoCpuAction{PlayerIdx: d.currentTurn, PlayedCards: removed}
+		d.round.humanAction = &DaifugoCpuAction{PlayerIdx: d.round.currentTurn, PlayedCards: removed}
 	}
 
-	d.pendingActionType = DaifugoPendingNone
-	d.pendingActionTarget = -1
+	d.round.pendingActionType = DaifugoPendingNone
+	d.round.pendingActionTarget = -1
 
 	d.advanceTurn()
 	d.checkPassClear()
@@ -510,7 +510,7 @@ func (d *Daifugo) applyCapitalFall() {
 
 // performCardExchange 前回のランクに基づいてカード交換を行う
 func (d *Daifugo) performCardExchange() {
-	d.exchangeActions = make([]*DaifugoExchangeAction, 0)
+	d.round.exchangeActions = make([]*DaifugoExchangeAction, 0)
 
 	// 前回のランクからプレイヤーインデックスのマッピングを作成
 	rankToPlayer := make(map[int]int) // rank → current player index
@@ -535,7 +535,7 @@ func (d *Daifugo) performCardExchange() {
 	}
 
 	// 交換記録を棋譜に追加
-	for _, ex := range d.exchangeActions {
+	for _, ex := range d.round.exchangeActions {
 		d.appendLog(ex.FromPlayerIdx, "exchange", fmt.Sprintf("exchanged %d card(s) with player %d", len(ex.Cards), ex.ToPlayerIdx), ex.Cards)
 	}
 
@@ -584,12 +584,12 @@ func (d *Daifugo) exchangeCardsBetween(upperIdx, lowerIdx, count int) {
 	}
 
 	// 交換記録
-	d.exchangeActions = append(d.exchangeActions, &DaifugoExchangeAction{
+	d.round.exchangeActions = append(d.round.exchangeActions, &DaifugoExchangeAction{
 		FromPlayerIdx: lowerIdx,
 		ToPlayerIdx:   upperIdx,
 		Cards:         lowerBestCards,
 	})
-	d.exchangeActions = append(d.exchangeActions, &DaifugoExchangeAction{
+	d.round.exchangeActions = append(d.round.exchangeActions, &DaifugoExchangeAction{
 		FromPlayerIdx: upperIdx,
 		ToPlayerIdx:   lowerIdx,
 		Cards:         upperWorstCards,
@@ -609,7 +609,7 @@ func (d *Daifugo) getActivePlayerCnt() int {
 // getNextActivePlayer fromの次のアクティブなプレイヤーインデックスを取得
 func (d *Daifugo) getNextActivePlayer(from int) int {
 	direction := 1
-	if d.reverseDirection {
+	if d.round.reverseDirection {
 		direction = -1
 	}
 	return nextActivePlayer(d.players, from, direction)
@@ -625,7 +625,7 @@ func (d *Daifugo) checkGameEnd() bool {
 				break
 			}
 		}
-		d.gameEndFlag = true
+		d.round.gameEndFlag = true
 		d.applyCapitalFall()
 		d.applyIllegalFinishPenalty()
 		return true
@@ -641,7 +641,7 @@ func (d *Daifugo) finishPlayer(idx int) {
 	d.players[idx].SetRank(rank)
 	d.appendLog(idx, "finish", fmt.Sprintf("player %d finished (rank %d)", idx, rank), nil)
 	// 上がったプレイヤーが最後に出したプレイヤーなら場をクリア
-	if d.lastPlayPlayerIdx == idx {
+	if d.round.lastPlayPlayerIdx == idx {
 		d.clearTableState()
 	}
 }
@@ -657,7 +657,7 @@ func (d *Daifugo) finishEmptyPlayers() {
 
 // SortHumanHand 人間プレイヤーの手札を指定モードでソートする
 func (d *Daifugo) SortHumanHand(mode DaifugoSortMode) error {
-	if d.gameEndFlag {
+	if d.round.gameEndFlag {
 		return ErrGameEnded
 	}
 	d.sortMode = mode

--- a/internal/domain/Daifugo_testhelpers.go
+++ b/internal/domain/Daifugo_testhelpers.go
@@ -7,45 +7,45 @@ package domain
 // and are not part of the production game logic.
 
 // SetElevenBackActive 11バック設定（テスト用）
-func (d *Daifugo) SetElevenBackActive(active bool) { d.elevenBackActive = active }
+func (d *Daifugo) SetElevenBackActive(active bool) { d.round.elevenBackActive = active }
 
 // SetSuitLocked スート縛り設定（テスト用）
 func (d *Daifugo) SetSuitLocked(locked bool, suit int) {
-	d.suitLocked = locked
-	d.lockedSuit = suit
+	d.round.suitLocked = locked
+	d.round.lockedSuit = suit
 }
 
 // SetTableIsSequence 階段フラグ設定（テスト用）
-func (d *Daifugo) SetTableIsSequence(seq bool) { d.tableIsSequence = seq }
+func (d *Daifugo) SetTableIsSequence(seq bool) { d.round.tableIsSequence = seq }
 
 // SetExchangeActions カード交換記録設定（テスト用）
 func (d *Daifugo) SetExchangeActions(actions []*DaifugoExchangeAction) {
-	d.exchangeActions = actions
+	d.round.exchangeActions = actions
 }
 
 // SetHumanAction 人間の行動設定（テスト用）
-func (d *Daifugo) SetHumanAction(action *DaifugoCpuAction) { d.humanAction = action }
+func (d *Daifugo) SetHumanAction(action *DaifugoCpuAction) { d.round.humanAction = action }
 
 // SetReverseDirection 9リバースの方向設定（テスト用）
-func (d *Daifugo) SetReverseDirection(v bool) { d.reverseDirection = v }
+func (d *Daifugo) SetReverseDirection(v bool) { d.round.reverseDirection = v }
 
 // SetNumberLocked 連番縛り設定（テスト用）
-func (d *Daifugo) SetNumberLocked(v bool) { d.numberLocked = v }
+func (d *Daifugo) SetNumberLocked(v bool) { d.round.numberLocked = v }
 
 // SetSortMode 手札ソートモード設定（テスト用）
 func (d *Daifugo) SetSortMode(mode DaifugoSortMode) { d.sortMode = mode }
 
 // SetTableCards 場札設定（テスト用）
-func (d *Daifugo) SetTableCards(cards []*Card) { d.tableCards = cards }
+func (d *Daifugo) SetTableCards(cards []*Card) { d.round.tableCards = cards }
 
 // SetCurrentTurn ターン設定（テスト用）
-func (d *Daifugo) SetCurrentTurn(turn int) { d.currentTurn = turn }
+func (d *Daifugo) SetCurrentTurn(turn int) { d.round.currentTurn = turn }
 
 // SetLastPlayPlayerIdx 最後にカードを出したプレイヤー設定（テスト用）
-func (d *Daifugo) SetLastPlayPlayerIdx(idx int) { d.lastPlayPlayerIdx = idx }
+func (d *Daifugo) SetLastPlayPlayerIdx(idx int) { d.round.lastPlayPlayerIdx = idx }
 
 // SetRevolutionActive 革命フラグ設定（テスト用）
-func (d *Daifugo) SetRevolutionActive(v bool) { d.revolutionActive = v }
+func (d *Daifugo) SetRevolutionActive(v bool) { d.round.revolutionActive = v }
 
 // SetSequenceLocked 階段縛り設定（テスト用）
-func (d *Daifugo) SetSequenceLocked(v bool) { d.sequenceLocked = v }
+func (d *Daifugo) SetSequenceLocked(v bool) { d.round.sequenceLocked = v }

--- a/internal/domain/Napoleon.go
+++ b/internal/domain/Napoleon.go
@@ -66,11 +66,8 @@ type NapoleonTrickCard struct {
 	Card      *Card
 }
 
-// Napoleon ナポレオンゲームクラス
-type Napoleon struct {
-	trumpCards       *TrumpCards
-	players          []*NapoleonPlayer
-	config           NapoleonConfig
+// napoleonRoundState ラウンドごとにリセットされる状態
+type napoleonRoundState struct {
 	phase            NapoleonPhase
 	roundNumber      int
 	trickNumber      int
@@ -92,40 +89,40 @@ type Napoleon struct {
 	actionLog        []*ActionLogEntry
 }
 
+// Napoleon ナポレオンゲームクラス
+type Napoleon struct {
+	trumpCards *TrumpCards
+	players    []*NapoleonPlayer
+	config     NapoleonConfig
+	round      napoleonRoundState
+}
+
 // NewNapoleon コンストラクタ
 func NewNapoleon(trumpCards *TrumpCards, players []*NapoleonPlayer, config NapoleonConfig) *Napoleon {
 	return &Napoleon{
-		trumpCards:    trumpCards,
-		players:       players,
-		config:        config,
-		winnerTeam:    NapoleonWinnerUndecided,
-		napoleonIdx:   -1,
-		adjutantIdx:   -1,
-		highestBidder: -1,
-		roundNumber:   0,
+		trumpCards: trumpCards,
+		players:    players,
+		config:     config,
+		round: napoleonRoundState{
+			winnerTeam:    NapoleonWinnerUndecided,
+			napoleonIdx:   -1,
+			adjutantIdx:   -1,
+			highestBidder: -1,
+		},
 	}
 }
 
 // Reset ゲーム初期化
 func (n *Napoleon) Reset() {
-	n.gameEndFlag = false
-	n.winnerTeam = NapoleonWinnerUndecided
-	n.roundNumber = 1
-	n.trickNumber = 0
-	n.currentTrick = nil
-	n.leadPlayerIdx = -1
-	n.currentPlayerIdx = -1
-	n.bidPlayerIdx = 0
-	n.trumpSuit = 0
-	n.adjutantCard = nil
-	n.napoleonIdx = -1
-	n.adjutantIdx = -1
-	n.adjutantRevealed = false
-	n.kitty = nil
-	n.highestBid = 0
-	n.highestBidder = -1
-	n.passCount = 0
-	n.actionLog = nil
+	n.round = napoleonRoundState{
+		roundNumber:      1,
+		leadPlayerIdx:    -1,
+		currentPlayerIdx: -1,
+		napoleonIdx:      -1,
+		adjutantIdx:      -1,
+		highestBidder:    -1,
+		winnerTeam:       NapoleonWinnerUndecided,
+	}
 
 	for _, p := range n.players {
 		p.bid = -1
@@ -143,30 +140,25 @@ func (n *Napoleon) Reset() {
 	n.dealCards()
 	n.sortAllHands()
 
-	n.phase = NapoleonPhaseBid
+	n.round.phase = NapoleonPhaseBid
 }
 
 // NextRound 次のラウンドを開始する
 func (n *Napoleon) NextRound() {
-	if n.phase != NapoleonPhaseRoundEnd {
+	if n.round.phase != NapoleonPhaseRoundEnd {
 		return
 	}
 
-	n.roundNumber++
-	n.trickNumber = 0
-	n.currentTrick = nil
-	n.leadPlayerIdx = -1
-	n.currentPlayerIdx = -1
-	n.bidPlayerIdx = 0
-	n.trumpSuit = 0
-	n.adjutantCard = nil
-	n.napoleonIdx = -1
-	n.adjutantIdx = -1
-	n.adjutantRevealed = false
-	n.kitty = nil
-	n.highestBid = 0
-	n.highestBidder = -1
-	n.passCount = 0
+	prevRound := n.round.roundNumber
+	n.round = napoleonRoundState{
+		roundNumber:      prevRound + 1,
+		leadPlayerIdx:    -1,
+		currentPlayerIdx: -1,
+		napoleonIdx:      -1,
+		adjutantIdx:      -1,
+		highestBidder:    -1,
+		winnerTeam:       NapoleonWinnerUndecided,
+	}
 
 	for _, p := range n.players {
 		p.ResetRound()
@@ -175,20 +167,20 @@ func (n *Napoleon) NextRound() {
 	n.dealCards()
 	n.sortAllHands()
 
-	n.phase = NapoleonPhaseBid
+	n.round.phase = NapoleonPhaseBid
 }
 
 // PlayerBid 人間プレイヤーがビッドする (0 = パス)
 func (n *Napoleon) PlayerBid(bid int) error {
-	if n.gameEndFlag {
+	if n.round.gameEndFlag {
 		return ErrGameEnded
 	}
-	if n.phase != NapoleonPhaseBid {
+	if n.round.phase != NapoleonPhaseBid {
 		return ErrWrongPhase
 	}
 
 	humanIdx := n.findHumanIdx()
-	if humanIdx < 0 || n.bidPlayerIdx != humanIdx {
+	if humanIdx < 0 || n.round.bidPlayerIdx != humanIdx {
 		return ErrNotHumanTurn
 	}
 
@@ -196,8 +188,8 @@ func (n *Napoleon) PlayerBid(bid int) error {
 		if bid < n.config.MinBid || bid > NapoleonMaxPictureCards {
 			return NewDomainError(ErrInvalidPlay, fmt.Sprintf("ビッドは%d〜%dで指定してください（0でパス）", n.config.MinBid, NapoleonMaxPictureCards))
 		}
-		if bid <= n.highestBid {
-			return NewDomainError(ErrInvalidPlay, fmt.Sprintf("現在の最高ビッド%dより高い値を指定してください", n.highestBid))
+		if bid <= n.round.highestBid {
+			return NewDomainError(ErrInvalidPlay, fmt.Sprintf("現在の最高ビッド%dより高い値を指定してください", n.round.highestBid))
 		}
 	}
 
@@ -207,29 +199,29 @@ func (n *Napoleon) PlayerBid(bid int) error {
 
 // CpuBid 現在のビッドプレイヤーがCPUの場合にビッドする
 func (n *Napoleon) CpuBid() {
-	if n.gameEndFlag || n.phase != NapoleonPhaseBid {
+	if n.round.gameEndFlag || n.round.phase != NapoleonPhaseBid {
 		return
 	}
-	if n.bidPlayerIdx >= NapoleonPlayerCnt {
+	if n.round.bidPlayerIdx >= NapoleonPlayerCnt {
 		return
 	}
-	if n.players[n.bidPlayerIdx].GetIsHuman() {
+	if n.players[n.round.bidPlayerIdx].GetIsHuman() {
 		return
 	}
 
-	bid := n.cpuSelectBid(n.bidPlayerIdx)
-	n.applyBid(n.bidPlayerIdx, bid)
+	bid := n.cpuSelectBid(n.round.bidPlayerIdx)
+	n.applyBid(n.round.bidPlayerIdx, bid)
 }
 
 // PlayerDeclareTrump 人間プレイヤーが切り札と副官を宣言する
 func (n *Napoleon) PlayerDeclareTrump(suit int, adjSuit int, adjVal int) error {
-	if n.gameEndFlag {
+	if n.round.gameEndFlag {
 		return ErrGameEnded
 	}
-	if n.phase != NapoleonPhaseTrumpDeclaration {
+	if n.round.phase != NapoleonPhaseTrumpDeclaration {
 		return ErrWrongPhase
 	}
-	if n.napoleonIdx < 0 || !n.players[n.napoleonIdx].GetIsHuman() {
+	if n.round.napoleonIdx < 0 || !n.players[n.round.napoleonIdx].GetIsHuman() {
 		return ErrNotHumanTurn
 	}
 
@@ -256,30 +248,30 @@ func (n *Napoleon) PlayerDeclareTrump(suit int, adjSuit int, adjVal int) error {
 
 // CpuDeclareTrump CPUナポレオンが切り札と副官を宣言する
 func (n *Napoleon) CpuDeclareTrump() {
-	if n.gameEndFlag || n.phase != NapoleonPhaseTrumpDeclaration {
+	if n.round.gameEndFlag || n.round.phase != NapoleonPhaseTrumpDeclaration {
 		return
 	}
-	if n.napoleonIdx < 0 || n.players[n.napoleonIdx].GetIsHuman() {
+	if n.round.napoleonIdx < 0 || n.players[n.round.napoleonIdx].GetIsHuman() {
 		return
 	}
 
-	suit, adjSuit, adjVal := n.cpuSelectTrump(n.napoleonIdx)
+	suit, adjSuit, adjVal := n.cpuSelectTrump(n.round.napoleonIdx)
 	n.applyDeclareTrump(suit, adjSuit, adjVal)
 }
 
 // PlayerExchangeKitty 人間ナポレオンが場札を交換する (捨てるカードのインデックス指定)
 func (n *Napoleon) PlayerExchangeKitty(discardIndex int) error {
-	if n.gameEndFlag {
+	if n.round.gameEndFlag {
 		return ErrGameEnded
 	}
-	if n.phase != NapoleonPhaseKittyExchange {
+	if n.round.phase != NapoleonPhaseKittyExchange {
 		return ErrWrongPhase
 	}
-	if n.napoleonIdx < 0 || !n.players[n.napoleonIdx].GetIsHuman() {
+	if n.round.napoleonIdx < 0 || !n.players[n.round.napoleonIdx].GetIsHuman() {
 		return ErrNotHumanTurn
 	}
 
-	player := n.players[n.napoleonIdx]
+	player := n.players[n.round.napoleonIdx]
 	// 場札はすでに手札に追加されている (14枚)
 	if discardIndex < 0 || discardIndex >= player.GetCardsSize() {
 		return NewDomainError(ErrInvalidCard, "カードインデックスが範囲外です")
@@ -291,68 +283,68 @@ func (n *Napoleon) PlayerExchangeKitty(discardIndex int) error {
 
 // CpuExchangeKitty CPUナポレオンが場札を交換する
 func (n *Napoleon) CpuExchangeKitty() {
-	if n.gameEndFlag || n.phase != NapoleonPhaseKittyExchange {
+	if n.round.gameEndFlag || n.round.phase != NapoleonPhaseKittyExchange {
 		return
 	}
-	if n.napoleonIdx < 0 || n.players[n.napoleonIdx].GetIsHuman() {
+	if n.round.napoleonIdx < 0 || n.players[n.round.napoleonIdx].GetIsHuman() {
 		return
 	}
 
-	discardIdx := n.cpuSelectDiscard(n.napoleonIdx)
+	discardIdx := n.cpuSelectDiscard(n.round.napoleonIdx)
 	n.applyExchangeKitty(discardIdx)
 }
 
 // PlayerPlay 人間プレイヤーがカードをプレイする
 func (n *Napoleon) PlayerPlay(cardIndex int) error {
-	if n.gameEndFlag {
+	if n.round.gameEndFlag {
 		return ErrGameEnded
 	}
-	if n.phase != NapoleonPhasePlay {
+	if n.round.phase != NapoleonPhasePlay {
 		return ErrWrongPhase
 	}
-	if !n.players[n.currentPlayerIdx].GetIsHuman() {
+	if !n.players[n.round.currentPlayerIdx].GetIsHuman() {
 		return ErrNotHumanTurn
 	}
 
-	player := n.players[n.currentPlayerIdx]
+	player := n.players[n.round.currentPlayerIdx]
 	if cardIndex < 0 || cardIndex >= player.GetCardsSize() {
 		return NewDomainError(ErrInvalidCard, "カードインデックスが範囲外です")
 	}
 
 	card := player.GetCard(cardIndex)
-	if err := n.validatePlay(n.currentPlayerIdx, card); err != nil {
+	if err := n.validatePlay(n.round.currentPlayerIdx, card); err != nil {
 		return err
 	}
 
 	played := player.RemoveCard(cardIndex)
-	n.playCard(n.currentPlayerIdx, played)
+	n.playCard(n.round.currentPlayerIdx, played)
 	return nil
 }
 
 // CpuPlay 現在の手番がCPUの場合に1ターン実行
 func (n *Napoleon) CpuPlay() {
-	if n.gameEndFlag || n.phase != NapoleonPhasePlay {
+	if n.round.gameEndFlag || n.round.phase != NapoleonPhasePlay {
 		return
 	}
-	if n.players[n.currentPlayerIdx].GetIsHuman() {
+	if n.players[n.round.currentPlayerIdx].GetIsHuman() {
 		return
 	}
 
-	player := n.players[n.currentPlayerIdx]
-	cardIdx := n.cpuSelectPlayCard(n.currentPlayerIdx)
+	player := n.players[n.round.currentPlayerIdx]
+	cardIdx := n.cpuSelectPlayCard(n.round.currentPlayerIdx)
 	played := player.RemoveCard(cardIdx)
-	n.playCard(n.currentPlayerIdx, played)
+	n.playCard(n.round.currentPlayerIdx, played)
 }
 
 // ResolveTrick トリックを解決して勝者を決定する
 func (n *Napoleon) ResolveTrick() {
-	if n.phase != NapoleonPhaseTrickEnd || len(n.currentTrick) != NapoleonPlayerCnt {
+	if n.round.phase != NapoleonPhaseTrickEnd || len(n.round.currentTrick) != NapoleonPlayerCnt {
 		return
 	}
 
 	winnerIdx := n.trickWinner()
-	trickCards := make([]*Card, len(n.currentTrick))
-	for i, tc := range n.currentTrick {
+	trickCards := make([]*Card, len(n.round.currentTrick))
+	for i, tc := range n.round.currentTrick {
 		trickCards[i] = tc.Card
 	}
 
@@ -363,35 +355,35 @@ func (n *Napoleon) ResolveTrick() {
 	n.players[winnerIdx].pictureCards += picCount
 
 	winnerName := n.playerName(winnerIdx)
-	s := fmt.Sprintf("%s wins trick %d", winnerName, n.trickNumber)
+	s := fmt.Sprintf("%s wins trick %d", winnerName, n.round.trickNumber)
 	if picCount > 0 {
 		s += fmt.Sprintf(" (+%d picture cards)", picCount)
 	}
 	n.appendLog(winnerIdx, "trick_win", s, trickCards)
 
-	n.leadPlayerIdx = winnerIdx
+	n.round.leadPlayerIdx = winnerIdx
 
-	if n.trickNumber >= NapoleonHandSize {
-		n.phase = NapoleonPhaseRoundEnd
+	if n.round.trickNumber >= NapoleonHandSize {
+		n.round.phase = NapoleonPhaseRoundEnd
 	} else {
-		n.phase = NapoleonPhaseTrickEnd
+		n.round.phase = NapoleonPhaseTrickEnd
 	}
 }
 
 // NextTrick 次のトリックを開始する
 func (n *Napoleon) NextTrick() {
-	if n.phase != NapoleonPhaseTrickEnd {
+	if n.round.phase != NapoleonPhaseTrickEnd {
 		return
 	}
-	n.currentTrick = nil
-	n.currentPlayerIdx = n.leadPlayerIdx
-	n.trickNumber++
-	n.phase = NapoleonPhasePlay
+	n.round.currentTrick = nil
+	n.round.currentPlayerIdx = n.round.leadPlayerIdx
+	n.round.trickNumber++
+	n.round.phase = NapoleonPhasePlay
 }
 
 // ScoreRound ラウンドのスコアを確定し、ゲーム終了判定を行う
 func (n *Napoleon) ScoreRound() {
-	if n.phase != NapoleonPhaseRoundEnd {
+	if n.round.phase != NapoleonPhaseRoundEnd {
 		return
 	}
 
@@ -403,14 +395,14 @@ func (n *Napoleon) ScoreRound() {
 		}
 	}
 
-	bid := n.highestBid
+	bid := n.round.highestBid
 	napoleonWon := napoleonTeamPictures >= bid
 
 	if napoleonWon {
-		n.winnerTeam = NapoleonWinnerNapoleon
+		n.round.winnerTeam = NapoleonWinnerNapoleon
 		n.appendLog(-1, "round_result", fmt.Sprintf("Napoleon's team wins! (%d/%d picture cards)", napoleonTeamPictures, bid), nil)
 	} else {
-		n.winnerTeam = NapoleonWinnerAllied
+		n.round.winnerTeam = NapoleonWinnerAllied
 		n.appendLog(-1, "round_result", fmt.Sprintf("Allied forces win! (%d/%d picture cards)", napoleonTeamPictures, bid), nil)
 	}
 
@@ -456,73 +448,73 @@ func (n *Napoleon) ScoreRound() {
 // --- State getters ---
 
 // GetPhase 現在のフェーズ取得
-func (n *Napoleon) GetPhase() NapoleonPhase { return n.phase }
+func (n *Napoleon) GetPhase() NapoleonPhase { return n.round.phase }
 
 // SetPhase フェーズ設定 (テスト用)
-func (n *Napoleon) SetPhase(phase NapoleonPhase) { n.phase = phase }
+func (n *Napoleon) SetPhase(phase NapoleonPhase) { n.round.phase = phase }
 
 // GetRoundNumber 現在のラウンド番号取得
-func (n *Napoleon) GetRoundNumber() int { return n.roundNumber }
+func (n *Napoleon) GetRoundNumber() int { return n.round.roundNumber }
 
 // SetRoundNumber ラウンド番号設定 (テスト用)
-func (n *Napoleon) SetRoundNumber(n2 int) { n.roundNumber = n2 }
+func (n *Napoleon) SetRoundNumber(n2 int) { n.round.roundNumber = n2 }
 
 // GetTrickNumber 現在のトリック番号取得
-func (n *Napoleon) GetTrickNumber() int { return n.trickNumber }
+func (n *Napoleon) GetTrickNumber() int { return n.round.trickNumber }
 
 // SetTrickNumber トリック番号設定 (テスト用)
-func (n *Napoleon) SetTrickNumber(t int) { n.trickNumber = t }
+func (n *Napoleon) SetTrickNumber(t int) { n.round.trickNumber = t }
 
 // GetCurrentPlayerIdx 現在のプレイヤーインデックス取得
-func (n *Napoleon) GetCurrentPlayerIdx() int { return n.currentPlayerIdx }
+func (n *Napoleon) GetCurrentPlayerIdx() int { return n.round.currentPlayerIdx }
 
 // SetCurrentPlayerIdx プレイヤーインデックス設定 (テスト用)
-func (n *Napoleon) SetCurrentPlayerIdx(idx int) { n.currentPlayerIdx = idx }
+func (n *Napoleon) SetCurrentPlayerIdx(idx int) { n.round.currentPlayerIdx = idx }
 
 // GetCurrentTrick 現在のトリック取得
-func (n *Napoleon) GetCurrentTrick() []*NapoleonTrickCard { return n.currentTrick }
+func (n *Napoleon) GetCurrentTrick() []*NapoleonTrickCard { return n.round.currentTrick }
 
 // SetCurrentTrick トリック設定 (テスト用)
-func (n *Napoleon) SetCurrentTrick(trick []*NapoleonTrickCard) { n.currentTrick = trick }
+func (n *Napoleon) SetCurrentTrick(trick []*NapoleonTrickCard) { n.round.currentTrick = trick }
 
 // GetTrumpSuit 切り札スート取得
-func (n *Napoleon) GetTrumpSuit() int { return n.trumpSuit }
+func (n *Napoleon) GetTrumpSuit() int { return n.round.trumpSuit }
 
 // SetTrumpSuit 切り札スート設定 (テスト用)
-func (n *Napoleon) SetTrumpSuit(suit int) { n.trumpSuit = suit }
+func (n *Napoleon) SetTrumpSuit(suit int) { n.round.trumpSuit = suit }
 
 // GetAdjutantCard 副官カード取得
-func (n *Napoleon) GetAdjutantCard() *Card { return n.adjutantCard }
+func (n *Napoleon) GetAdjutantCard() *Card { return n.round.adjutantCard }
 
 // SetAdjutantCard 副官カード設定 (テスト用)
-func (n *Napoleon) SetAdjutantCard(card *Card) { n.adjutantCard = card }
+func (n *Napoleon) SetAdjutantCard(card *Card) { n.round.adjutantCard = card }
 
 // GetNapoleonIdx ナポレオンインデックス取得
-func (n *Napoleon) GetNapoleonIdx() int { return n.napoleonIdx }
+func (n *Napoleon) GetNapoleonIdx() int { return n.round.napoleonIdx }
 
 // SetNapoleonIdx ナポレオンインデックス設定 (テスト用)
-func (n *Napoleon) SetNapoleonIdx(idx int) { n.napoleonIdx = idx }
+func (n *Napoleon) SetNapoleonIdx(idx int) { n.round.napoleonIdx = idx }
 
 // GetAdjutantIdx 副官インデックス取得
-func (n *Napoleon) GetAdjutantIdx() int { return n.adjutantIdx }
+func (n *Napoleon) GetAdjutantIdx() int { return n.round.adjutantIdx }
 
 // SetAdjutantIdx 副官インデックス設定 (テスト用)
-func (n *Napoleon) SetAdjutantIdx(idx int) { n.adjutantIdx = idx }
+func (n *Napoleon) SetAdjutantIdx(idx int) { n.round.adjutantIdx = idx }
 
 // GetAdjutantRevealed 副官公開状態取得
-func (n *Napoleon) GetAdjutantRevealed() bool { return n.adjutantRevealed }
+func (n *Napoleon) GetAdjutantRevealed() bool { return n.round.adjutantRevealed }
 
 // SetAdjutantRevealed 副官公開状態設定 (テスト用)
-func (n *Napoleon) SetAdjutantRevealed(v bool) { n.adjutantRevealed = v }
+func (n *Napoleon) SetAdjutantRevealed(v bool) { n.round.adjutantRevealed = v }
 
 // GetGameEndFlag ゲーム終了フラグ取得
-func (n *Napoleon) GetGameEndFlag() bool { return n.gameEndFlag }
+func (n *Napoleon) GetGameEndFlag() bool { return n.round.gameEndFlag }
 
 // SetGameEndFlag ゲーム終了フラグ設定 (テスト用)
-func (n *Napoleon) SetGameEndFlag(flag bool) { n.gameEndFlag = flag }
+func (n *Napoleon) SetGameEndFlag(flag bool) { n.round.gameEndFlag = flag }
 
 // GetWinnerTeam 勝利チーム取得 (-1 = 未確定)
-func (n *Napoleon) GetWinnerTeam() int { return n.winnerTeam }
+func (n *Napoleon) GetWinnerTeam() int { return n.round.winnerTeam }
 
 // GetPlayerCnt プレイヤー数取得
 func (n *Napoleon) GetPlayerCnt() int { return len(n.players) }
@@ -536,71 +528,71 @@ func (n *Napoleon) GetPlayer(i int) *NapoleonPlayer {
 }
 
 // GetLeadPlayerIdx リードプレイヤーインデックス取得
-func (n *Napoleon) GetLeadPlayerIdx() int { return n.leadPlayerIdx }
+func (n *Napoleon) GetLeadPlayerIdx() int { return n.round.leadPlayerIdx }
 
 // SetLeadPlayerIdx リードプレイヤーインデックス設定 (テスト用)
-func (n *Napoleon) SetLeadPlayerIdx(idx int) { n.leadPlayerIdx = idx }
+func (n *Napoleon) SetLeadPlayerIdx(idx int) { n.round.leadPlayerIdx = idx }
 
 // GetBidPlayerIdx ビッドプレイヤーインデックス取得
-func (n *Napoleon) GetBidPlayerIdx() int { return n.bidPlayerIdx }
+func (n *Napoleon) GetBidPlayerIdx() int { return n.round.bidPlayerIdx }
 
 // SetBidPlayerIdx ビッドプレイヤーインデックス設定 (テスト用)
-func (n *Napoleon) SetBidPlayerIdx(idx int) { n.bidPlayerIdx = idx }
+func (n *Napoleon) SetBidPlayerIdx(idx int) { n.round.bidPlayerIdx = idx }
 
 // GetKitty 場札取得
-func (n *Napoleon) GetKitty() []*Card { return n.kitty }
+func (n *Napoleon) GetKitty() []*Card { return n.round.kitty }
 
 // SetKitty 場札設定 (テスト用)
-func (n *Napoleon) SetKitty(kitty []*Card) { n.kitty = kitty }
+func (n *Napoleon) SetKitty(kitty []*Card) { n.round.kitty = kitty }
 
 // GetHighestBid 現在の最高ビッド取得
-func (n *Napoleon) GetHighestBid() int { return n.highestBid }
+func (n *Napoleon) GetHighestBid() int { return n.round.highestBid }
 
 // SetHighestBid 最高ビッド設定 (テスト用)
-func (n *Napoleon) SetHighestBid(bid int) { n.highestBid = bid }
+func (n *Napoleon) SetHighestBid(bid int) { n.round.highestBid = bid }
 
 // GetHighestBidder 最高ビッドプレイヤー取得
-func (n *Napoleon) GetHighestBidder() int { return n.highestBidder }
+func (n *Napoleon) GetHighestBidder() int { return n.round.highestBidder }
 
 // SetHighestBidder 最高ビッドプレイヤー設定 (テスト用)
-func (n *Napoleon) SetHighestBidder(idx int) { n.highestBidder = idx }
+func (n *Napoleon) SetHighestBidder(idx int) { n.round.highestBidder = idx }
 
 // GetPassCount パス数取得
-func (n *Napoleon) GetPassCount() int { return n.passCount }
+func (n *Napoleon) GetPassCount() int { return n.round.passCount }
 
 // SetPassCount パス数設定 (テスト用)
-func (n *Napoleon) SetPassCount(cnt int) { n.passCount = cnt }
+func (n *Napoleon) SetPassCount(cnt int) { n.round.passCount = cnt }
 
 // IsHumanTurn 現在の手番が人間かどうか
 func (n *Napoleon) IsHumanTurn() bool {
-	if n.currentPlayerIdx < 0 || n.currentPlayerIdx >= len(n.players) {
+	if n.round.currentPlayerIdx < 0 || n.round.currentPlayerIdx >= len(n.players) {
 		return false
 	}
-	return n.players[n.currentPlayerIdx].GetIsHuman()
+	return n.players[n.round.currentPlayerIdx].GetIsHuman()
 }
 
 // IsHumanBidTurn 現在のビッド手番が人間かどうか
 func (n *Napoleon) IsHumanBidTurn() bool {
-	if n.bidPlayerIdx < 0 || n.bidPlayerIdx >= len(n.players) {
+	if n.round.bidPlayerIdx < 0 || n.round.bidPlayerIdx >= len(n.players) {
 		return false
 	}
-	return n.players[n.bidPlayerIdx].GetIsHuman()
+	return n.players[n.round.bidPlayerIdx].GetIsHuman()
 }
 
 // IsHumanDeclareTurn 切り札宣言が人間の番かどうか
 func (n *Napoleon) IsHumanDeclareTurn() bool {
-	if n.napoleonIdx < 0 || n.napoleonIdx >= len(n.players) {
+	if n.round.napoleonIdx < 0 || n.round.napoleonIdx >= len(n.players) {
 		return false
 	}
-	return n.players[n.napoleonIdx].GetIsHuman()
+	return n.players[n.round.napoleonIdx].GetIsHuman()
 }
 
 // IsHumanExchangeTurn 場札交換が人間の番かどうか
 func (n *Napoleon) IsHumanExchangeTurn() bool {
-	if n.napoleonIdx < 0 || n.napoleonIdx >= len(n.players) {
+	if n.round.napoleonIdx < 0 || n.round.napoleonIdx >= len(n.players) {
 		return false
 	}
-	return n.players[n.napoleonIdx].GetIsHuman()
+	return n.players[n.round.napoleonIdx].GetIsHuman()
 }
 
 // GetConfig 設定取得
@@ -610,7 +602,7 @@ func (n *Napoleon) GetConfig() NapoleonConfig { return n.config }
 func (n *Napoleon) SetConfig(cfg NapoleonConfig) { n.config = cfg }
 
 // GetActionLog 棋譜取得
-func (n *Napoleon) GetActionLog() []*ActionLogEntry { return n.actionLog }
+func (n *Napoleon) GetActionLog() []*ActionLogEntry { return n.round.actionLog }
 
 // GetValidPlayIndices プレイ可能なカードのインデックスリストを返す (Web用)
 func (n *Napoleon) GetValidPlayIndices(playerIdx int) []int {
@@ -624,30 +616,30 @@ func (n *Napoleon) GetHint() *NapoleonHint {
 		return nil
 	}
 
-	switch n.phase {
+	switch n.round.phase {
 	case NapoleonPhaseBid:
-		if n.bidPlayerIdx != humanIdx {
+		if n.round.bidPlayerIdx != humanIdx {
 			return nil
 		}
 		bid := n.cpuBidHard(humanIdx)
 		return &NapoleonHint{Bid: &bid, Reason: "strategic_bid"}
 
 	case NapoleonPhaseTrumpDeclaration:
-		if n.napoleonIdx != humanIdx {
+		if n.round.napoleonIdx != humanIdx {
 			return nil
 		}
 		suit, adjSuit, adjVal := n.cpuSelectTrumpHard(humanIdx)
 		return &NapoleonHint{TrumpSuit: &suit, AdjutantSuit: &adjSuit, AdjutantValue: &adjVal, Reason: "strategic_declare"}
 
 	case NapoleonPhaseKittyExchange:
-		if n.napoleonIdx != humanIdx {
+		if n.round.napoleonIdx != humanIdx {
 			return nil
 		}
 		discardIdx := n.cpuSelectDiscardHard(humanIdx)
 		return &NapoleonHint{DiscardIndex: &discardIdx, Reason: "strategic_discard"}
 
 	case NapoleonPhasePlay:
-		if n.currentPlayerIdx != humanIdx {
+		if n.round.currentPlayerIdx != humanIdx {
 			return nil
 		}
 		validIndices := n.getValidPlayIndices(humanIdx)
@@ -688,7 +680,7 @@ func (n *Napoleon) dealCards() {
 	// 残り1枚を場札に
 	kittyCard := n.trumpCards.DrawCard()
 	if kittyCard != nil {
-		n.kitty = []*Card{kittyCard}
+		n.round.kitty = []*Card{kittyCard}
 	}
 }
 
@@ -698,80 +690,80 @@ func (n *Napoleon) applyBid(playerIdx int, bid int) {
 
 	if bid == 0 {
 		n.appendLog(playerIdx, "bid", fmt.Sprintf("%s passes", n.playerName(playerIdx)), nil)
-		n.passCount++
+		n.round.passCount++
 	} else {
 		n.appendLog(playerIdx, "bid", fmt.Sprintf("%s bids %d", n.playerName(playerIdx), bid), nil)
-		n.highestBid = bid
-		n.highestBidder = playerIdx
+		n.round.highestBid = bid
+		n.round.highestBidder = playerIdx
 	}
 
-	n.bidPlayerIdx++
+	n.round.bidPlayerIdx++
 	n.checkBidComplete()
 }
 
 // checkBidComplete 全員がビッドしたかチェック
 func (n *Napoleon) checkBidComplete() {
-	if n.bidPlayerIdx < NapoleonPlayerCnt {
+	if n.round.bidPlayerIdx < NapoleonPlayerCnt {
 		return
 	}
 
-	if n.highestBidder < 0 {
+	if n.round.highestBidder < 0 {
 		// 全員パス: 最初のプレイヤーが最低ビッドで強制ナポレオン
-		n.highestBid = n.config.MinBid
-		n.highestBidder = 0
+		n.round.highestBid = n.config.MinBid
+		n.round.highestBidder = 0
 		n.players[0].SetBid(n.config.MinBid)
 		n.appendLog(0, "forced_bid", fmt.Sprintf("%s is forced to bid %d (all pass)", n.playerName(0), n.config.MinBid), nil)
 	}
 
-	n.napoleonIdx = n.highestBidder
-	n.players[n.napoleonIdx].SetIsNapoleon(true)
-	n.appendLog(n.napoleonIdx, "napoleon", fmt.Sprintf("%s becomes Napoleon (bid %d)", n.playerName(n.napoleonIdx), n.highestBid), nil)
+	n.round.napoleonIdx = n.round.highestBidder
+	n.players[n.round.napoleonIdx].SetIsNapoleon(true)
+	n.appendLog(n.round.napoleonIdx, "napoleon", fmt.Sprintf("%s becomes Napoleon (bid %d)", n.playerName(n.round.napoleonIdx), n.round.highestBid), nil)
 
-	n.phase = NapoleonPhaseTrumpDeclaration
+	n.round.phase = NapoleonPhaseTrumpDeclaration
 }
 
 // applyDeclareTrump 切り札宣言を適用する
 func (n *Napoleon) applyDeclareTrump(suit int, adjSuit int, adjVal int) {
-	n.trumpSuit = suit
-	n.adjutantCard = NewCard(adjSuit, adjVal, false)
+	n.round.trumpSuit = suit
+	n.round.adjutantCard = NewCard(adjSuit, adjVal, false)
 
 	suitNames := map[int]string{
 		CardDesignSpade: "Spade", CardDesignClover: "Club",
 		CardDesignHeart: "Heart", CardDesignDiamond: "Diamond",
 		CardDesignJoker: "Joker",
 	}
-	n.appendLog(n.napoleonIdx, "declare_trump",
-		fmt.Sprintf("%s declares %s as trump", n.playerName(n.napoleonIdx), suitNames[suit]), nil)
-	n.appendLog(n.napoleonIdx, "declare_adjutant",
-		fmt.Sprintf("%s names %s as adjutant card", n.playerName(n.napoleonIdx), napoleonCardStr(n.adjutantCard)), nil)
+	n.appendLog(n.round.napoleonIdx, "declare_trump",
+		fmt.Sprintf("%s declares %s as trump", n.playerName(n.round.napoleonIdx), suitNames[suit]), nil)
+	n.appendLog(n.round.napoleonIdx, "declare_adjutant",
+		fmt.Sprintf("%s names %s as adjutant card", n.playerName(n.round.napoleonIdx), napoleonCardStr(n.round.adjutantCard)), nil)
 
 	// 副官を特定
-	n.adjutantIdx = n.findAdjutantHolder()
-	if n.adjutantIdx >= 0 {
-		n.players[n.adjutantIdx].SetIsAdjutant(true)
+	n.round.adjutantIdx = n.findAdjutantHolder()
+	if n.round.adjutantIdx >= 0 {
+		n.players[n.round.adjutantIdx].SetIsAdjutant(true)
 		// 自分自身を指名した場合
-		if n.adjutantIdx == n.napoleonIdx {
-			n.adjutantRevealed = true
-			n.players[n.adjutantIdx].SetAdjutantRevealed(true)
+		if n.round.adjutantIdx == n.round.napoleonIdx {
+			n.round.adjutantRevealed = true
+			n.players[n.round.adjutantIdx].SetAdjutantRevealed(true)
 		}
 	}
 
 	// 場札をナポレオンの手札に追加
-	for _, c := range n.kitty {
-		n.players[n.napoleonIdx].AddCard(c)
+	for _, c := range n.round.kitty {
+		n.players[n.round.napoleonIdx].AddCard(c)
 	}
-	n.sortHand(n.players[n.napoleonIdx])
+	n.sortHand(n.players[n.round.napoleonIdx])
 
-	n.phase = NapoleonPhaseKittyExchange
+	n.round.phase = NapoleonPhaseKittyExchange
 }
 
 // applyExchangeKitty 場札交換を適用する
 func (n *Napoleon) applyExchangeKitty(discardIndex int) {
-	player := n.players[n.napoleonIdx]
+	player := n.players[n.round.napoleonIdx]
 	discarded := player.RemoveCard(discardIndex)
-	n.kitty = []*Card{discarded}
+	n.round.kitty = []*Card{discarded}
 
-	n.appendLog(n.napoleonIdx, "exchange", fmt.Sprintf("%s exchanges kitty card", n.playerName(n.napoleonIdx)), nil)
+	n.appendLog(n.round.napoleonIdx, "exchange", fmt.Sprintf("%s exchanges kitty card", n.playerName(n.round.napoleonIdx)), nil)
 
 	n.sortHand(player)
 	n.startPlayPhase()
@@ -779,16 +771,16 @@ func (n *Napoleon) applyExchangeKitty(discardIndex int) {
 
 // startPlayPhase プレイフェーズ開始: ナポレオンがリード
 func (n *Napoleon) startPlayPhase() {
-	n.leadPlayerIdx = n.napoleonIdx
-	n.currentPlayerIdx = n.napoleonIdx
-	n.trickNumber = 1
-	n.currentTrick = nil
-	n.phase = NapoleonPhasePlay
+	n.round.leadPlayerIdx = n.round.napoleonIdx
+	n.round.currentPlayerIdx = n.round.napoleonIdx
+	n.round.trickNumber = 1
+	n.round.currentTrick = nil
+	n.round.phase = NapoleonPhasePlay
 }
 
 // playCard カードをプレイする共通処理
 func (n *Napoleon) playCard(playerIdx int, card *Card) {
-	n.currentTrick = append(n.currentTrick, &NapoleonTrickCard{
+	n.round.currentTrick = append(n.round.currentTrick, &NapoleonTrickCard{
 		PlayerIdx: playerIdx,
 		Card:      card,
 	})
@@ -798,21 +790,21 @@ func (n *Napoleon) playCard(playerIdx int, card *Card) {
 	// 副官カードが出されたら公開
 	n.checkAdjutantReveal(playerIdx, card)
 
-	if len(n.currentTrick) == NapoleonPlayerCnt {
-		n.phase = NapoleonPhaseTrickEnd
+	if len(n.round.currentTrick) == NapoleonPlayerCnt {
+		n.round.phase = NapoleonPhaseTrickEnd
 	} else {
-		n.currentPlayerIdx = (n.currentPlayerIdx + 1) % NapoleonPlayerCnt
+		n.round.currentPlayerIdx = (n.round.currentPlayerIdx + 1) % NapoleonPlayerCnt
 	}
 }
 
 // validatePlay カードのプレイが有効か検証する
 func (n *Napoleon) validatePlay(playerIdx int, card *Card) error {
-	if len(n.currentTrick) == 0 {
+	if len(n.round.currentTrick) == 0 {
 		// リード: 制限なし
 		return nil
 	}
 
-	leadCard := n.currentTrick[0].Card
+	leadCard := n.round.currentTrick[0].Card
 	// ジョーカーがリードされた場合、何でも出せる
 	if leadCard.GetDesign() == CardDesignJoker {
 		return nil
@@ -837,14 +829,14 @@ func (n *Napoleon) validatePlay(playerIdx int, card *Card) error {
 
 // trickWinner トリックの勝者を決定する
 func (n *Napoleon) trickWinner() int {
-	if len(n.currentTrick) == 0 {
+	if len(n.round.currentTrick) == 0 {
 		return 0
 	}
 
 	// ジョーカーとスペード3の特殊判定
 	jokerIdx := -1
 	spade3Idx := -1
-	for _, tc := range n.currentTrick {
+	for _, tc := range n.round.currentTrick {
 		if tc.Card.GetDesign() == CardDesignJoker {
 			jokerIdx = tc.PlayerIdx
 		}
@@ -863,14 +855,14 @@ func (n *Napoleon) trickWinner() int {
 	}
 
 	// リードスートを特定
-	leadSuit := n.currentTrick[0].Card.GetDesign()
+	leadSuit := n.round.currentTrick[0].Card.GetDesign()
 
-	winnerIdx := n.currentTrick[0].PlayerIdx
-	winnerValue := n.cardStrength(n.currentTrick[0].Card)
-	winnerIsTrump := n.currentTrick[0].Card.GetDesign() == n.trumpSuit
+	winnerIdx := n.round.currentTrick[0].PlayerIdx
+	winnerValue := n.cardStrength(n.round.currentTrick[0].Card)
+	winnerIsTrump := n.round.currentTrick[0].Card.GetDesign() == n.round.trumpSuit
 
-	for _, tc := range n.currentTrick[1:] {
-		isTrump := tc.Card.GetDesign() == n.trumpSuit
+	for _, tc := range n.round.currentTrick[1:] {
+		isTrump := tc.Card.GetDesign() == n.round.trumpSuit
 		value := n.cardStrength(tc.Card)
 
 		if isTrump && !winnerIsTrump {
@@ -923,20 +915,20 @@ func (n *Napoleon) countPictureCards(cards []*Card) int {
 
 // findAdjutantHolder 副官カードの所有者を探す
 func (n *Napoleon) findAdjutantHolder() int {
-	if n.adjutantCard == nil {
+	if n.round.adjutantCard == nil {
 		return -1
 	}
 	for i, p := range n.players {
 		for j := 0; j < p.GetCardsSize(); j++ {
 			c := p.GetCard(j)
-			if c.GetDesign() == n.adjutantCard.GetDesign() && c.GetValue() == n.adjutantCard.GetValue() {
+			if c.GetDesign() == n.round.adjutantCard.GetDesign() && c.GetValue() == n.round.adjutantCard.GetValue() {
 				return i
 			}
 		}
 	}
 	// 場札にあるかもしれない (まだ配られていない)
-	for _, c := range n.kitty {
-		if c.GetDesign() == n.adjutantCard.GetDesign() && c.GetValue() == n.adjutantCard.GetValue() {
+	for _, c := range n.round.kitty {
+		if c.GetDesign() == n.round.adjutantCard.GetDesign() && c.GetValue() == n.round.adjutantCard.GetValue() {
 			// 場札にある場合、ナポレオンが場札交換時に取得する
 			return -1
 		}
@@ -946,11 +938,11 @@ func (n *Napoleon) findAdjutantHolder() int {
 
 // checkAdjutantReveal 副官カードが出されたか確認
 func (n *Napoleon) checkAdjutantReveal(playerIdx int, card *Card) {
-	if n.adjutantRevealed || n.adjutantCard == nil {
+	if n.round.adjutantRevealed || n.round.adjutantCard == nil {
 		return
 	}
-	if card.GetDesign() == n.adjutantCard.GetDesign() && card.GetValue() == n.adjutantCard.GetValue() {
-		n.adjutantRevealed = true
+	if card.GetDesign() == n.round.adjutantCard.GetDesign() && card.GetValue() == n.round.adjutantCard.GetValue() {
+		n.round.adjutantRevealed = true
 		n.players[playerIdx].SetAdjutantRevealed(true)
 		// 副官が場札交換で入れ替わった可能性があるので再設定
 		if !n.players[playerIdx].isAdjutant {
@@ -958,7 +950,7 @@ func (n *Napoleon) checkAdjutantReveal(playerIdx int, card *Card) {
 			for _, p := range n.players {
 				p.isAdjutant = false
 			}
-			n.adjutantIdx = playerIdx
+			n.round.adjutantIdx = playerIdx
 			n.players[playerIdx].SetIsAdjutant(true)
 		}
 		n.appendLog(playerIdx, "adjutant_reveal", fmt.Sprintf("%s is revealed as the adjutant!", n.playerName(playerIdx)), []*Card{card})
@@ -999,8 +991,8 @@ func (n *Napoleon) checkGameEnd() {
 		return
 	}
 
-	n.gameEndFlag = true
-	n.phase = NapoleonPhaseGameEnd
+	n.round.gameEndFlag = true
+	n.round.phase = NapoleonPhaseGameEnd
 
 	// 最高スコアのプレイヤーが勝者
 	maxScore := n.players[0].cumulativeScore
@@ -1053,8 +1045,8 @@ func (n *Napoleon) playerName(idx int) string {
 
 // appendLog 棋譜にエントリを追加する
 func (n *Napoleon) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	n.actionLog = append(n.actionLog, &ActionLogEntry{
-		TurnNumber: len(n.actionLog) + 1,
+	n.round.actionLog = append(n.round.actionLog, &ActionLogEntry{
+		TurnNumber: len(n.round.actionLog) + 1,
 		PlayerIdx:  playerIdx,
 		ActionType: actionType,
 		Detail:     detail,
@@ -1075,18 +1067,18 @@ func (n *Napoleon) playHintReason(chosenIdx int) string {
 	player := n.players[n.findHumanIdx()]
 	card := player.GetCard(chosenIdx)
 
-	if len(n.currentTrick) == 0 {
+	if len(n.round.currentTrick) == 0 {
 		if n.isPictureCard(card) {
 			return "lead_strong"
 		}
 		return "lead_low"
 	}
 
-	leadCard := n.currentTrick[0].Card
+	leadCard := n.round.currentTrick[0].Card
 	if leadCard.GetDesign() != CardDesignJoker && card.GetDesign() == leadCard.GetDesign() {
 		return "follow_suit"
 	}
-	if card.GetDesign() == n.trumpSuit {
+	if card.GetDesign() == n.round.trumpSuit {
 		return "trump_cut"
 	}
 	if card.GetDesign() == CardDesignJoker {
@@ -1130,7 +1122,7 @@ func (n *Napoleon) cpuBidEasy(_ int) int {
 	}
 	// MinBid〜MinBid+2のランダムビッド
 	bid := n.config.MinBid + rand.Intn(3)
-	if bid <= n.highestBid {
+	if bid <= n.round.highestBid {
 		return 0 // 最高ビッドを超えられなければパス
 	}
 	if bid > NapoleonMaxPictureCards {
@@ -1159,7 +1151,7 @@ func (n *Napoleon) cpuBidNormal(playerIdx int) int {
 	if bid < n.config.MinBid {
 		return 0 // 弱ければパス
 	}
-	if bid <= n.highestBid {
+	if bid <= n.round.highestBid {
 		return 0
 	}
 	if bid > NapoleonMaxPictureCards {
@@ -1212,10 +1204,10 @@ func (n *Napoleon) cpuBidHard(playerIdx int) int {
 	if bid < n.config.MinBid {
 		return 0
 	}
-	if bid <= n.highestBid {
+	if bid <= n.round.highestBid {
 		// 半分の確率でもう1上げる
-		if n.highestBid+1 <= NapoleonMaxPictureCards && rand.Intn(2) == 0 && strength >= 6 {
-			return n.highestBid + 1
+		if n.round.highestBid+1 <= NapoleonMaxPictureCards && rand.Intn(2) == 0 && strength >= 6 {
+			return n.round.highestBid + 1
 		}
 		return 0
 	}
@@ -1386,7 +1378,7 @@ func (n *Napoleon) cpuSelectDiscardNormal(playerIdx int) int {
 			score += 50
 		}
 		// 切り札は捨てたくない
-		if card.GetDesign() == n.trumpSuit {
+		if card.GetDesign() == n.round.trumpSuit {
 			score += 30
 		}
 		// ジョーカーは絶対捨てない
@@ -1415,14 +1407,14 @@ func (n *Napoleon) cpuSelectDiscardHard(playerIdx int) int {
 		if n.isPictureCard(card) {
 			score += 50
 		}
-		if card.GetDesign() == n.trumpSuit {
+		if card.GetDesign() == n.round.trumpSuit {
 			score += 30
 		}
 		if card.GetDesign() == CardDesignJoker {
 			score += 100
 		}
 		// 副官カードは絶対捨てない
-		if n.adjutantCard != nil && card.GetDesign() == n.adjutantCard.GetDesign() && card.GetValue() == n.adjutantCard.GetValue() {
+		if n.round.adjutantCard != nil && card.GetDesign() == n.round.adjutantCard.GetDesign() && card.GetValue() == n.round.adjutantCard.GetValue() {
 			score += 200
 		}
 
@@ -1464,7 +1456,7 @@ func (n *Napoleon) cpuPlayNormal(playerIdx int, validIndices []int) int {
 	player := n.players[playerIdx]
 	isNapoleonTeam := n.players[playerIdx].isNapoleon || n.players[playerIdx].isAdjutant
 
-	if len(n.currentTrick) == 0 {
+	if len(n.round.currentTrick) == 0 {
 		// リード
 		if isNapoleonTeam {
 			// ナポレオン軍: 高いカード/絵札でリード
@@ -1476,7 +1468,7 @@ func (n *Napoleon) cpuPlayNormal(playerIdx int, validIndices []int) int {
 				if n.isPictureCard(card) {
 					score += 20
 				}
-				if card.GetDesign() == n.trumpSuit {
+				if card.GetDesign() == n.round.trumpSuit {
 					score += 10
 				}
 				if score > bestScore {
@@ -1500,7 +1492,7 @@ func (n *Napoleon) cpuPlayNormal(playerIdx int, validIndices []int) int {
 	}
 
 	// フォロー
-	leadCard := n.currentTrick[0].Card
+	leadCard := n.round.currentTrick[0].Card
 	leadSuit := leadCard.GetDesign()
 	if leadSuit == CardDesignJoker {
 		// ジョーカーリード: 低いカードを出す
@@ -1518,7 +1510,7 @@ func (n *Napoleon) cpuPlayNormal(playerIdx int, validIndices []int) int {
 
 	// トリック内の絵札があるかチェック
 	hasPictureInTrick := false
-	for _, tc := range n.currentTrick {
+	for _, tc := range n.round.currentTrick {
 		if n.isPictureCard(tc.Card) {
 			hasPictureInTrick = true
 			break
@@ -1553,7 +1545,7 @@ func (n *Napoleon) cpuPlayHard(playerIdx int, validIndices []int) int {
 	player := n.players[playerIdx]
 	isNapoleonTeam := n.players[playerIdx].isNapoleon || n.players[playerIdx].isAdjutant
 
-	if len(n.currentTrick) == 0 {
+	if len(n.round.currentTrick) == 0 {
 		// リード
 		if isNapoleonTeam {
 			// 切り札でリードして絵札を回収
@@ -1562,7 +1554,7 @@ func (n *Napoleon) cpuPlayHard(playerIdx int, validIndices []int) int {
 			for _, idx := range validIndices {
 				card := player.GetCard(idx)
 				score := n.cardStrength(card)
-				if card.GetDesign() == n.trumpSuit {
+				if card.GetDesign() == n.round.trumpSuit {
 					score += 100
 				}
 				if card.GetDesign() == CardDesignJoker {
@@ -1581,7 +1573,7 @@ func (n *Napoleon) cpuPlayHard(playerIdx int, validIndices []int) int {
 		for _, idx := range validIndices {
 			card := player.GetCard(idx)
 			score := n.cardStrength(card)
-			if card.GetDesign() == n.trumpSuit {
+			if card.GetDesign() == n.round.trumpSuit {
 				score += 100
 			}
 			if card.GetDesign() == CardDesignJoker {
@@ -1597,7 +1589,7 @@ func (n *Napoleon) cpuPlayHard(playerIdx int, validIndices []int) int {
 
 	// フォロー (絵札のあるトリックを制する戦略)
 	hasPictureInTrick := false
-	for _, tc := range n.currentTrick {
+	for _, tc := range n.round.currentTrick {
 		if n.isPictureCard(tc.Card) {
 			hasPictureInTrick = true
 			break
@@ -1617,7 +1609,7 @@ func (n *Napoleon) cpuPlayHard(playerIdx int, validIndices []int) int {
 		if n.isPictureCard(card) {
 			score += 50
 		}
-		if card.GetDesign() == n.trumpSuit {
+		if card.GetDesign() == n.round.trumpSuit {
 			score += 30
 		}
 		if card.GetDesign() == CardDesignJoker {
@@ -1636,7 +1628,7 @@ func (n *Napoleon) cpuTryWinTrick(playerIdx int, validIndices []int) int {
 	player := n.players[playerIdx]
 
 	// 現在のトリック勝者を判定するために仮のトリックを見る
-	leadCard := n.currentTrick[0].Card
+	leadCard := n.round.currentTrick[0].Card
 	leadSuit := leadCard.GetDesign()
 	if leadSuit == CardDesignJoker {
 		// ジョーカーリード: 低いカードを出す（勝てない）
@@ -1695,7 +1687,7 @@ func (n *Napoleon) cpuTryWinTrick(playerIdx int, validIndices []int) int {
 func (n *Napoleon) wouldWinTrick(card *Card) bool {
 	if card.GetDesign() == CardDesignJoker {
 		// ジョーカーは勝てるが、スペ3がすでに出ている場合は負ける
-		for _, tc := range n.currentTrick {
+		for _, tc := range n.round.currentTrick {
 			if tc.Card.GetDesign() == CardDesignSpade && tc.Card.GetValue() == 3 {
 				return false
 			}
@@ -1705,14 +1697,14 @@ func (n *Napoleon) wouldWinTrick(card *Card) bool {
 
 	// スペ3でジョーカーに勝てるか
 	if card.GetDesign() == CardDesignSpade && card.GetValue() == 3 {
-		for _, tc := range n.currentTrick {
+		for _, tc := range n.round.currentTrick {
 			if tc.Card.GetDesign() == CardDesignJoker {
 				return true
 			}
 		}
 	}
 
-	leadSuit := n.currentTrick[0].Card.GetDesign()
+	leadSuit := n.round.currentTrick[0].Card.GetDesign()
 	if leadSuit == CardDesignJoker {
 		return false // ジョーカーリードには勝てない
 	}
@@ -1720,11 +1712,11 @@ func (n *Napoleon) wouldWinTrick(card *Card) bool {
 	// 現在の最強カードを特定
 	currentWinnerIsTrump := false
 	currentWinnerValue := 0
-	for _, tc := range n.currentTrick {
+	for _, tc := range n.round.currentTrick {
 		if tc.Card.GetDesign() == CardDesignJoker {
 			return false // ジョーカーがいれば勝てない
 		}
-		isTrump := tc.Card.GetDesign() == n.trumpSuit
+		isTrump := tc.Card.GetDesign() == n.round.trumpSuit
 		val := n.cardStrength(tc.Card)
 		if isTrump && !currentWinnerIsTrump {
 			currentWinnerIsTrump = true
@@ -1736,7 +1728,7 @@ func (n *Napoleon) wouldWinTrick(card *Card) bool {
 		}
 	}
 
-	isTrump := card.GetDesign() == n.trumpSuit
+	isTrump := card.GetDesign() == n.round.trumpSuit
 	val := n.cardStrength(card)
 
 	if isTrump && !currentWinnerIsTrump {

--- a/internal/domain/Poker.go
+++ b/internal/domain/Poker.go
@@ -86,14 +86,10 @@ func findOpenEndedDraw(cards []straightDrawCardInfo, check func(remaining []int)
 	return -1
 }
 
-// Poker ポーカークラス (5枚ドローポーカー・マルチプレイヤー)
-type Poker struct {
-	trumpCards      *TrumpCards
-	players         []*PokerPlayer
-	config          PokerConfig
+// pokerRoundState ラウンドごとにリセットされる状態
+type pokerRoundState struct {
 	phase           int
 	pot             int
-	dealerIdx       int
 	currentTurn     int
 	lastBet         int
 	minRaise        int
@@ -107,41 +103,49 @@ type Poker struct {
 	actionLog       []*ActionLogEntry
 	gameEndFlag     bool
 	lastCpuError    error // CPU行動エラーの最後のフォールバック記録 (テスト検出用)
-	humanProfile    *BettingHumanProfile
 	lastHumanPlayMs int
+}
+
+// Poker ポーカークラス (5枚ドローポーカー・マルチプレイヤー)
+type Poker struct {
+	trumpCards   *TrumpCards
+	players      []*PokerPlayer
+	config       PokerConfig
+	dealerIdx    int
+	humanProfile *BettingHumanProfile
+	round        pokerRoundState
 }
 
 // NewPoker コンストラクタ
 func NewPoker(trumpCards *TrumpCards, players []*PokerPlayer, config PokerConfig) *Poker {
 	return &Poker{
-		trumpCards:    trumpCards,
-		players:       players,
-		config:        config,
-		phase:         PokerPhaseInit,
-		sidePots:      make([]PokerSidePot, 0),
-		actedFlags:    make([]bool, len(players)),
-		roundResults:  make([]PokerResult, 0),
-		cpuActions:    make([]PokerCpuAction, 0),
-		cpuExchanges:  make([]PokerCpuExchange, 0),
-		startingChips: make([]int, len(players)),
+		trumpCards: trumpCards,
+		players:    players,
+		config:     config,
+		round: pokerRoundState{
+			phase:         PokerPhaseInit,
+			sidePots:      make([]PokerSidePot, 0),
+			actedFlags:    make([]bool, len(players)),
+			roundResults:  make([]PokerResult, 0),
+			cpuActions:    make([]PokerCpuAction, 0),
+			cpuExchanges:  make([]PokerCpuExchange, 0),
+			startingChips: make([]int, len(players)),
+		},
 	}
 }
 
 // Reset ゲーム初期化
 func (p *Poker) Reset() error {
-	p.phase = PokerPhaseInit
-	p.pot = 0
-	p.sidePots = make([]PokerSidePot, 0)
-	p.gameEndFlag = false
-	p.lastBet = 0
-	p.minRaise = p.config.MinBet
-	p.raiseCount = 0
-	p.actedFlags = make([]bool, len(p.players))
-	p.roundResults = make([]PokerResult, 0)
-	p.cpuActions = make([]PokerCpuAction, 0)
-	p.cpuExchanges = make([]PokerCpuExchange, 0)
-	p.actionLog = nil
-	p.lastHumanPlayMs = 0
+	p.round = pokerRoundState{
+		phase:         PokerPhaseInit,
+		minRaise:      p.config.MinBet,
+		sidePots:      make([]PokerSidePot, 0),
+		actedFlags:    make([]bool, len(p.players)),
+		roundResults:  make([]PokerResult, 0),
+		cpuActions:    make([]PokerCpuAction, 0),
+		cpuExchanges:  make([]PokerCpuExchange, 0),
+		startingChips: make([]int, len(p.players)),
+	}
 
 	// メタAI: プロファイル初期化
 	if p.config.CpuMetaAI {
@@ -187,9 +191,8 @@ func (p *Poker) Reset() error {
 	}
 
 	// ハンド開始時のチップを記録 (サイドポット計算用)
-	p.startingChips = make([]int, len(p.players))
 	for i, pl := range p.players {
-		p.startingChips[i] = pl.GetChips()
+		p.round.startingChips[i] = pl.GetChips()
 	}
 
 	// アンティ徴収
@@ -209,9 +212,9 @@ func (p *Poker) Reset() error {
 		}
 	}
 
-	p.phase = PokerPhaseDeal
+	p.round.phase = PokerPhaseDeal
 	// ディーラーの左からアクティブプレイヤーを開始
-	p.currentTurn = p.findNextActive(p.dealerIdx)
+	p.round.currentTurn = p.findNextActive(p.dealerIdx)
 
 	// CPU第1ベットアクション実行
 	p.runCpuActions()
@@ -229,7 +232,7 @@ func (p *Poker) collectAntes() {
 			ante = pl.GetChips()
 		}
 		pl.SubtractChips(ante)
-		p.pot += ante
+		p.round.pot += ante
 		p.appendLog(i, "ante", fmt.Sprintf("ante %d chips", ante), nil)
 	}
 }
@@ -237,30 +240,30 @@ func (p *Poker) collectAntes() {
 // PlayerAction 人間プレイヤーのアクション実行
 // humanPlayMs: 迷い時間(ms, 0=計測なし)
 func (p *Poker) PlayerAction(action, amount, humanPlayMs int) error {
-	if p.gameEndFlag {
+	if p.round.gameEndFlag {
 		return NewDomainError(ErrGameEnded, "Game has already ended.")
 	}
-	if p.phase != PokerPhaseDeal && p.phase != PokerPhaseSecondBet {
+	if p.round.phase != PokerPhaseDeal && p.round.phase != PokerPhaseSecondBet {
 		return NewDomainError(ErrWrongPhase, "Action is not allowed now.")
 	}
-	if !p.players[p.currentTurn].GetIsHuman() {
+	if !p.players[p.round.currentTurn].GetIsHuman() {
 		return NewDomainError(ErrNotHumanTurn, "It is not your turn.")
 	}
 
 	// メタAI: 人間アクション記録
-	p.lastHumanPlayMs = humanPlayMs
+	p.round.lastHumanPlayMs = humanPlayMs
 	if p.config.CpuMetaAI && p.humanProfile != nil {
-		pl := p.players[p.currentTurn]
+		pl := p.players[p.round.currentTurn]
 		pl.EvalHand()
 		handRank := pl.GetHandRank()
 		p.humanProfile.RecordAction(handRank, action)
 		p.humanProfile.RecordHesitation(humanPlayMs)
-		if p.lastBet > pl.GetCurrentBet() {
+		if p.round.lastBet > pl.GetCurrentBet() {
 			p.humanProfile.RecordFoldToBet(action == PokerActionFold)
 		}
 	}
 
-	err := p.executeAction(p.currentTurn, action, amount)
+	err := p.executeAction(p.round.currentTurn, action, amount)
 	if err != nil {
 		return err
 	}
@@ -272,10 +275,10 @@ func (p *Poker) PlayerAction(action, amount, humanPlayMs int) error {
 
 // PlayerExchange プレイヤーカード交換
 func (p *Poker) PlayerExchange(indices []int) error {
-	if p.phase != PokerPhaseExchange {
+	if p.round.phase != PokerPhaseExchange {
 		return NewDomainError(ErrWrongPhase, "Exchange is not allowed now.")
 	}
-	if !p.players[p.currentTurn].GetIsHuman() {
+	if !p.players[p.round.currentTurn].GetIsHuman() {
 		return NewDomainError(ErrNotHumanTurn, "It is not your turn.")
 	}
 
@@ -283,12 +286,12 @@ func (p *Poker) PlayerExchange(indices []int) error {
 	for _, idx := range indices {
 		newCard := p.trumpCards.DrawCard()
 		if newCard != nil {
-			p.players[p.currentTurn].ExchangeCard(idx, newCard)
+			p.players[p.round.currentTurn].ExchangeCard(idx, newCard)
 		}
 	}
-	p.players[p.currentTurn].SetExchangeCount(len(indices))
-	p.appendLog(p.currentTurn, "exchange", fmt.Sprintf("exchange %d card(s)", len(indices)), nil)
-	p.actedFlags[p.currentTurn] = true
+	p.players[p.round.currentTurn].SetExchangeCount(len(indices))
+	p.appendLog(p.round.currentTurn, "exchange", fmt.Sprintf("exchange %d card(s)", len(indices)), nil)
+	p.round.actedFlags[p.round.currentTurn] = true
 
 	// 残りのCPU交換を実行
 	p.advanceTurn()
@@ -304,16 +307,16 @@ func (p *Poker) PlayerExchange(indices []int) error {
 
 // PlayerStand カード交換なし
 func (p *Poker) PlayerStand() error {
-	if p.phase != PokerPhaseExchange {
+	if p.round.phase != PokerPhaseExchange {
 		return NewDomainError(ErrWrongPhase, "Stand is not allowed now.")
 	}
-	if !p.players[p.currentTurn].GetIsHuman() {
+	if !p.players[p.round.currentTurn].GetIsHuman() {
 		return NewDomainError(ErrNotHumanTurn, "It is not your turn.")
 	}
 
-	p.players[p.currentTurn].SetExchangeCount(0)
-	p.appendLog(p.currentTurn, "exchange", "exchange 0 card(s)", nil)
-	p.actedFlags[p.currentTurn] = true
+	p.players[p.round.currentTurn].SetExchangeCount(0)
+	p.appendLog(p.round.currentTurn, "exchange", "exchange 0 card(s)", nil)
+	p.round.actedFlags[p.round.currentTurn] = true
 
 	// 残りのCPU交換を実行
 	p.advanceTurn()
@@ -339,17 +342,17 @@ func (p *Poker) bettingPlayers() []BettingPlayer {
 // executeAction 指定プレイヤーのアクション実行
 func (p *Poker) executeAction(playerIdx, action, amount int) error {
 	bp := p.bettingPlayers()
-	// ActedFlags はスライス参照を共有: ExecuteBettingAction 内の変更が p.actedFlags に直接反映される
+	// ActedFlags はスライス参照を共有: ExecuteBettingAction 内の変更が p.round.actedFlags に直接反映される
 	state := &BettingState{
-		Pot: p.pot, LastBet: p.lastBet, MinRaise: p.minRaise,
-		RaiseCount: p.raiseCount, ActedFlags: p.actedFlags,
+		Pot: p.round.pot, LastBet: p.round.lastBet, MinRaise: p.round.minRaise,
+		RaiseCount: p.round.raiseCount, ActedFlags: p.round.actedFlags,
 	}
 	maxRaises, maxBetAmount := p.bettingLimits()
 	err := ExecuteBettingAction(bp, state, playerIdx, action, amount, p.config.MinBet, maxRaises, maxBetAmount)
-	p.pot = state.Pot
-	p.lastBet = state.LastBet
-	p.minRaise = state.MinRaise
-	p.raiseCount = state.RaiseCount
+	p.round.pot = state.Pot
+	p.round.lastBet = state.LastBet
+	p.round.minRaise = state.MinRaise
+	p.round.raiseCount = state.RaiseCount
 	if err != nil {
 		return err
 	}
@@ -366,12 +369,12 @@ func (p *Poker) executeAction(playerIdx, action, amount int) error {
 
 // advanceTurn 次のプレイヤーに進める
 func (p *Poker) advanceTurn() {
-	if p.gameEndFlag {
+	if p.round.gameEndFlag {
 		return
 	}
 
 	// ベッティングラウンド終了チェック
-	if p.phase == PokerPhaseDeal || p.phase == PokerPhaseSecondBet {
+	if p.round.phase == PokerPhaseDeal || p.round.phase == PokerPhaseSecondBet {
 		if p.isBettingRoundComplete() {
 			p.advancePhase()
 			return
@@ -379,7 +382,7 @@ func (p *Poker) advanceTurn() {
 	}
 
 	// 交換フェーズでの終了チェック
-	if p.phase == PokerPhaseExchange {
+	if p.round.phase == PokerPhaseExchange {
 		if p.isExchangeComplete() {
 			return
 		}
@@ -387,9 +390,9 @@ func (p *Poker) advanceTurn() {
 
 	// 次のアクティブプレイヤーを探す
 	for i := 1; i <= len(p.players); i++ {
-		next := (p.currentTurn + i) % len(p.players)
-		if !p.players[next].GetFolded() && !p.players[next].GetAllIn() && !p.actedFlags[next] {
-			p.currentTurn = next
+		next := (p.round.currentTurn + i) % len(p.players)
+		if !p.players[next].GetFolded() && !p.players[next].GetAllIn() && !p.round.actedFlags[next] {
+			p.round.currentTurn = next
 			return
 		}
 	}
@@ -401,7 +404,7 @@ func (p *Poker) isRoundComplete() bool {
 		if pl.GetFolded() || pl.GetAllIn() {
 			continue
 		}
-		if !p.actedFlags[i] {
+		if !p.round.actedFlags[i] {
 			return false
 		}
 	}
@@ -420,25 +423,25 @@ func (p *Poker) isExchangeComplete() bool {
 
 // advancePhase 次のフェーズに進める
 func (p *Poker) advancePhase() {
-	switch p.phase {
+	switch p.round.phase {
 	case PokerPhaseDeal:
 		// ベッティングラウンド1完了 → 交換フェーズへ
-		p.phase = PokerPhaseExchange
+		p.round.phase = PokerPhaseExchange
 		// ラウンドベットリセット
 		for _, pl := range p.players {
 			pl.SetCurrentBet(0)
 		}
-		p.lastBet = 0
-		p.minRaise = p.config.MinBet
-		p.raiseCount = 0
-		p.actedFlags = make([]bool, len(p.players))
+		p.round.lastBet = 0
+		p.round.minRaise = p.config.MinBet
+		p.round.raiseCount = 0
+		p.round.actedFlags = make([]bool, len(p.players))
 		for i, pl := range p.players {
 			if pl.GetFolded() || pl.GetAllIn() {
-				p.actedFlags[i] = true
+				p.round.actedFlags[i] = true
 			}
 		}
 		// ディーラーの左から開始
-		p.currentTurn = p.findNextActive(p.dealerIdx)
+		p.round.currentTurn = p.findNextActive(p.dealerIdx)
 
 	case PokerPhaseSecondBet:
 		// ベッティングラウンド2完了 → ショーダウン
@@ -448,18 +451,18 @@ func (p *Poker) advancePhase() {
 
 // startSecondBettingRound 第2ベッティングラウンド開始
 func (p *Poker) startSecondBettingRound() {
-	p.phase = PokerPhaseSecondBet
+	p.round.phase = PokerPhaseSecondBet
 	// ラウンドベットリセット
 	for _, pl := range p.players {
 		pl.SetCurrentBet(0)
 	}
-	p.lastBet = 0
-	p.minRaise = p.config.MinBet
-	p.raiseCount = 0
-	p.actedFlags = make([]bool, len(p.players))
+	p.round.lastBet = 0
+	p.round.minRaise = p.config.MinBet
+	p.round.raiseCount = 0
+	p.round.actedFlags = make([]bool, len(p.players))
 	for i, pl := range p.players {
 		if pl.GetFolded() || pl.GetAllIn() {
-			p.actedFlags[i] = true
+			p.round.actedFlags[i] = true
 		}
 	}
 
@@ -476,7 +479,7 @@ func (p *Poker) startSecondBettingRound() {
 	}
 
 	// ディーラーの左から開始
-	p.currentTurn = p.findNextActive(p.dealerIdx)
+	p.round.currentTurn = p.findNextActive(p.dealerIdx)
 
 	// CPU第2ベットアクション実行
 	p.runCpuActions()
@@ -508,17 +511,17 @@ func (p *Poker) countActivePlayers() int {
 func (p *Poker) resolveLastPlayer() {
 	for i, pl := range p.players {
 		if !pl.GetFolded() {
-			pl.AddChips(p.pot)
-			p.roundResults = []PokerResult{{
+			pl.AddChips(p.round.pot)
+			p.round.roundResults = []PokerResult{{
 				PlayerIdx: i,
-				WonAmount: p.pot,
+				WonAmount: p.round.pot,
 			}}
-			p.pot = 0
+			p.round.pot = 0
 			break
 		}
 	}
-	p.phase = PokerPhaseEnd
-	p.gameEndFlag = true
+	p.round.phase = PokerPhaseEnd
+	p.round.gameEndFlag = true
 	p.dealerIdx = (p.dealerIdx + 1) % len(p.players)
 }
 
@@ -538,16 +541,16 @@ func (p *Poker) resolveShowdown() {
 
 	// サイドポット計算・配分
 	bp := p.bettingPlayers()
-	p.sidePots = CalculateSidePots(bp, p.pot, p.startingChips)
+	p.round.sidePots = CalculateSidePots(bp, p.round.pot, p.round.startingChips)
 	var wonAmounts map[int]int
 	if p.config.IsLowball {
-		wonAmounts = DistributePotsWithWinnerFunc(bp, p.sidePots, FindPotWinnersLowball)
+		wonAmounts = DistributePotsWithWinnerFunc(bp, p.round.sidePots, FindPotWinnersLowball)
 	} else {
-		wonAmounts = DistributePots(bp, p.sidePots)
+		wonAmounts = DistributePots(bp, p.round.sidePots)
 	}
 
 	// 結果を構築
-	p.roundResults = make([]PokerResult, 0)
+	p.round.roundResults = make([]PokerResult, 0)
 	for i, pl := range p.players {
 		if pl.GetFolded() {
 			continue
@@ -559,44 +562,44 @@ func (p *Poker) resolveShowdown() {
 			Kickers:   ExtractKickers(pl.GetComparisonCards(), pl.GetHandRank()),
 			WonAmount: wonAmounts[i],
 		}
-		p.roundResults = append(p.roundResults, result)
+		p.round.roundResults = append(p.round.roundResults, result)
 	}
 
-	p.phase = PokerPhaseEnd
-	p.gameEndFlag = true
+	p.round.phase = PokerPhaseEnd
+	p.round.gameEndFlag = true
 	p.dealerIdx = (p.dealerIdx + 1) % len(p.players)
 }
 
 // runCpuActions CPUプレイヤーのアクションを実行
 func (p *Poker) runCpuActions() {
-	if p.gameEndFlag {
+	if p.round.gameEndFlag {
 		return
 	}
-	for !p.gameEndFlag && (p.phase == PokerPhaseDeal || p.phase == PokerPhaseSecondBet) {
-		if p.players[p.currentTurn].GetIsHuman() {
+	for !p.round.gameEndFlag && (p.round.phase == PokerPhaseDeal || p.round.phase == PokerPhaseSecondBet) {
+		if p.players[p.round.currentTurn].GetIsHuman() {
 			return
 		}
-		if p.players[p.currentTurn].GetFolded() || p.players[p.currentTurn].GetAllIn() {
+		if p.players[p.round.currentTurn].GetFolded() || p.players[p.round.currentTurn].GetAllIn() {
 			p.advanceTurn()
 			continue
 		}
-		action, amount := p.cpuDecide(p.currentTurn)
-		p.cpuActions = append(p.cpuActions, PokerCpuAction{
-			PlayerIdx: p.currentTurn,
+		action, amount := p.cpuDecide(p.round.currentTurn)
+		p.round.cpuActions = append(p.round.cpuActions, PokerCpuAction{
+			PlayerIdx: p.round.currentTurn,
 			Action:    action,
 			Amount:    amount,
 		})
-		err := p.executeAction(p.currentTurn, action, amount)
+		err := p.executeAction(p.round.currentTurn, action, amount)
 		if err != nil {
-			p.lastCpuError = fmt.Errorf("CPU player %d action %d failed: %w", p.currentTurn, action, err)
-			callAmt := p.lastBet - p.players[p.currentTurn].GetCurrentBet()
+			p.round.lastCpuError = fmt.Errorf("CPU player %d action %d failed: %w", p.round.currentTurn, action, err)
+			callAmt := p.round.lastBet - p.players[p.round.currentTurn].GetCurrentBet()
 			if callAmt > 0 {
-				_ = p.executeAction(p.currentTurn, PokerActionFold, 0)
+				_ = p.executeAction(p.round.currentTurn, PokerActionFold, 0)
 			} else {
-				_ = p.executeAction(p.currentTurn, PokerActionCheck, 0)
+				_ = p.executeAction(p.round.currentTurn, PokerActionCheck, 0)
 			}
 		}
-		if p.gameEndFlag {
+		if p.round.gameEndFlag {
 			return
 		}
 		p.advanceTurn()
@@ -605,18 +608,18 @@ func (p *Poker) runCpuActions() {
 
 // runCpuExchanges CPUプレイヤーのカード交換を実行
 func (p *Poker) runCpuExchanges() {
-	if p.gameEndFlag {
+	if p.round.gameEndFlag {
 		return
 	}
-	for p.phase == PokerPhaseExchange {
+	for p.round.phase == PokerPhaseExchange {
 		if p.isExchangeComplete() {
 			return
 		}
-		if p.players[p.currentTurn].GetIsHuman() {
+		if p.players[p.round.currentTurn].GetIsHuman() {
 			return
 		}
-		if p.players[p.currentTurn].GetFolded() || p.players[p.currentTurn].GetAllIn() {
-			p.actedFlags[p.currentTurn] = true
+		if p.players[p.round.currentTurn].GetFolded() || p.players[p.round.currentTurn].GetAllIn() {
+			p.round.actedFlags[p.round.currentTurn] = true
 			p.advanceTurn()
 			continue
 		}
@@ -624,37 +627,37 @@ func (p *Poker) runCpuExchanges() {
 		// CPU交換AI
 		var indices []int
 		if p.config.IsLowball {
-			indices = p.cpuDecideExchangeLowball(p.currentTurn)
+			indices = p.cpuDecideExchangeLowball(p.round.currentTurn)
 		} else {
-			indices = p.cpuDecideExchange(p.currentTurn)
+			indices = p.cpuDecideExchange(p.round.currentTurn)
 		}
 		for _, idx := range indices {
 			newCard := p.trumpCards.DrawCard()
 			if newCard != nil {
-				p.players[p.currentTurn].ExchangeCard(idx, newCard)
+				p.players[p.round.currentTurn].ExchangeCard(idx, newCard)
 			}
 		}
-		p.players[p.currentTurn].SetExchangeCount(len(indices))
-		p.appendLog(p.currentTurn, "exchange", fmt.Sprintf("exchange %d card(s)", len(indices)), nil)
-		p.cpuExchanges = append(p.cpuExchanges, PokerCpuExchange{
-			PlayerIdx:     p.currentTurn,
+		p.players[p.round.currentTurn].SetExchangeCount(len(indices))
+		p.appendLog(p.round.currentTurn, "exchange", fmt.Sprintf("exchange %d card(s)", len(indices)), nil)
+		p.round.cpuExchanges = append(p.round.cpuExchanges, PokerCpuExchange{
+			PlayerIdx:     p.round.currentTurn,
 			ExchangeCount: len(indices),
 		})
-		p.actedFlags[p.currentTurn] = true
+		p.round.actedFlags[p.round.currentTurn] = true
 		p.advanceTurn()
 	}
 }
 
 // bettingLimits ベッティングリミット設定からmaxRaisesとmaxBetAmountを計算
 func (p *Poker) bettingLimits() (maxRaises, maxBetAmount int) {
-	return CalculateBettingLimits(p.config.BettingLimit, p.pot, p.lastBet)
+	return CalculateBettingLimits(p.config.BettingLimit, p.round.pot, p.round.lastBet)
 }
 
 // cpuDecide CPUプレイヤーの意思決定
 func (p *Poker) cpuDecide(idx int) (int, int) {
 	pl := p.players[idx]
 	style := pl.GetPlayStyle()
-	callAmount := p.lastBet - pl.GetCurrentBet()
+	callAmount := p.round.lastBet - pl.GetCurrentBet()
 
 	params, ok := pokerStyleParamsMap[style]
 	if !ok {
@@ -679,17 +682,17 @@ func (p *Poker) cpuDecide(idx int) (int, int) {
 	exchangeWarning := p.calcExchangeWarning(idx, params.exchangeReadWeight)
 
 	var action, amount int
-	if p.phase == PokerPhaseDeal {
+	if p.round.phase == PokerPhaseDeal {
 		action, amount = p.cpuDecideFirstBet(idx, params, callAmount, handRank)
 	} else {
 		action, amount = p.cpuDecideSecondBet(idx, params, callAmount, handRank, exchangeWarning)
 	}
 
 	// メタAI: 人間のベット/レイズに対してコール確率を調整
-	if p.config.CpuMetaAI && p.humanProfile != nil && p.lastHumanPlayMs > 0 {
+	if p.config.CpuMetaAI && p.humanProfile != nil && p.round.lastHumanPlayMs > 0 {
 		if action == PokerActionFold && callAmount > 0 {
 			bracket := bettingHandBracket(handRank)
-			adjustedCall := p.humanProfile.AdjustedCallChance(0.0, bracket, p.lastHumanPlayMs)
+			adjustedCall := p.humanProfile.AdjustedCallChance(0.0, bracket, p.round.lastHumanPlayMs)
 			if adjustedCall > 0 && rand.Float64() < adjustedCall {
 				action = PokerActionCall
 				amount = 0
@@ -705,7 +708,7 @@ func (p *Poker) cpuDecide(idx int) (int, int) {
 	}
 
 	// レイズ上限に達したら変更
-	if maxRaises > 0 && p.raiseCount >= maxRaises {
+	if maxRaises > 0 && p.round.raiseCount >= maxRaises {
 		if action == PokerActionRaise || action == PokerActionBet {
 			if callAmount > 0 {
 				return PokerActionCall, 0
@@ -718,7 +721,7 @@ func (p *Poker) cpuDecide(idx int) (int, int) {
 
 // calcExchangeWarning 他プレイヤーの交換枚数から警戒度を計算 (0-100)
 func (p *Poker) calcExchangeWarning(idx, weight int) int {
-	if p.phase != PokerPhaseSecondBet {
+	if p.round.phase != PokerPhaseSecondBet {
 		return 0
 	}
 	minExchange := 5
@@ -1012,46 +1015,46 @@ func (p *Poker) findStraightDrawDiscard(playerIdx int) int {
 // --- ゲッター ---
 
 // GetPhase フェーズ取得
-func (p *Poker) GetPhase() int { return p.phase }
+func (p *Poker) GetPhase() int { return p.round.phase }
 
 // GetPlayers プレイヤー一覧取得
 func (p *Poker) GetPlayers() []*PokerPlayer { return p.players }
 
 // GetPot ポット取得
-func (p *Poker) GetPot() int { return p.pot }
+func (p *Poker) GetPot() int { return p.round.pot }
 
 // GetSidePots サイドポット取得
-func (p *Poker) GetSidePots() []PokerSidePot { return p.sidePots }
+func (p *Poker) GetSidePots() []PokerSidePot { return p.round.sidePots }
 
 // GetDealerIdx ディーラーインデックス取得
 func (p *Poker) GetDealerIdx() int { return p.dealerIdx }
 
 // GetCurrentTurn 現在のターン取得
-func (p *Poker) GetCurrentTurn() int { return p.currentTurn }
+func (p *Poker) GetCurrentTurn() int { return p.round.currentTurn }
 
 // GetGameEndFlag ゲーム終了フラグ取得
-func (p *Poker) GetGameEndFlag() bool { return p.gameEndFlag }
+func (p *Poker) GetGameEndFlag() bool { return p.round.gameEndFlag }
 
 // GetLastBet 最後のベット取得
-func (p *Poker) GetLastBet() int { return p.lastBet }
+func (p *Poker) GetLastBet() int { return p.round.lastBet }
 
 // GetMinRaise 最小レイズ額取得
-func (p *Poker) GetMinRaise() int { return p.minRaise }
+func (p *Poker) GetMinRaise() int { return p.round.minRaise }
 
 // GetRaiseCount 現在のレイズ回数取得
-func (p *Poker) GetRaiseCount() int { return p.raiseCount }
+func (p *Poker) GetRaiseCount() int { return p.round.raiseCount }
 
 // GetAnte アンティ取得
 func (p *Poker) GetAnte() int { return p.config.Ante }
 
 // GetRoundResults ラウンド結果取得
-func (p *Poker) GetRoundResults() []PokerResult { return p.roundResults }
+func (p *Poker) GetRoundResults() []PokerResult { return p.round.roundResults }
 
 // GetCpuActions CPU行動記録取得
-func (p *Poker) GetCpuActions() []PokerCpuAction { return p.cpuActions }
+func (p *Poker) GetCpuActions() []PokerCpuAction { return p.round.cpuActions }
 
 // GetCpuExchanges CPU交換記録取得
-func (p *Poker) GetCpuExchanges() []PokerCpuExchange { return p.cpuExchanges }
+func (p *Poker) GetCpuExchanges() []PokerCpuExchange { return p.round.cpuExchanges }
 
 // GetConfig 設定取得
 func (p *Poker) GetConfig() PokerConfig { return p.config }
@@ -1060,7 +1063,7 @@ func (p *Poker) GetConfig() PokerConfig { return p.config }
 func (p *Poker) SetConfig(cfg PokerConfig) { p.config = cfg }
 
 // GetLastCpuError 最後のCPUアクションエラー取得 (テスト・デバッグ用)
-func (p *Poker) GetLastCpuError() error { return p.lastCpuError }
+func (p *Poker) GetLastCpuError() error { return p.round.lastCpuError }
 
 // GetHumanProfile メタAIプロファイル取得
 func (p *Poker) GetHumanProfile() *BettingHumanProfile { return p.humanProfile }
@@ -1092,12 +1095,12 @@ func (p *Poker) ImportProfile(data []byte) error {
 }
 
 // GetActionLog 棋譜を取得する
-func (p *Poker) GetActionLog() []*ActionLogEntry { return p.actionLog }
+func (p *Poker) GetActionLog() []*ActionLogEntry { return p.round.actionLog }
 
 // appendLog 棋譜にエントリを追加する
 func (p *Poker) appendLog(playerIdx int, actionType, detail string, cards []*Card) {
-	p.actionLog = append(p.actionLog, &ActionLogEntry{
-		TurnNumber: len(p.actionLog) + 1,
+	p.round.actionLog = append(p.round.actionLog, &ActionLogEntry{
+		TurnNumber: len(p.round.actionLog) + 1,
 		PlayerIdx:  playerIdx,
 		ActionType: actionType,
 		Detail:     detail,

--- a/internal/domain/PokerOdds.go
+++ b/internal/domain/PokerOdds.go
@@ -12,17 +12,17 @@ type PokerDrawOdds struct {
 // CalcDrawOdds 交換候補のカードインデックスに基づくドローオッズを計算する
 // indices: 交換するカードのインデックス (0-4)
 func (p *Poker) CalcDrawOdds(indices []int) ([]PokerDrawOdds, error) {
-	if p.phase != PokerPhaseExchange {
+	if p.round.phase != PokerPhaseExchange {
 		return nil, NewDomainError(ErrWrongPhase, "Odds calculation is only available during exchange phase.")
 	}
-	if !p.players[p.currentTurn].GetIsHuman() {
+	if !p.players[p.round.currentTurn].GetIsHuman() {
 		return nil, NewDomainError(ErrNotHumanTurn, "It is not your turn.")
 	}
 
 	// インデックスバリデーション
 	seen := make(map[int]bool)
 	for _, idx := range indices {
-		if idx < 0 || idx >= p.players[p.currentTurn].GetCardsSize() {
+		if idx < 0 || idx >= p.players[p.round.currentTurn].GetCardsSize() {
 			return nil, NewDomainError(ErrInvalidIndices, "Card index out of range.")
 		}
 		if seen[idx] {
@@ -31,7 +31,7 @@ func (p *Poker) CalcDrawOdds(indices []int) ([]PokerDrawOdds, error) {
 		seen[idx] = true
 	}
 
-	human := p.players[p.currentTurn]
+	human := p.players[p.round.currentTurn]
 	hand := make([]*Card, human.GetCardsSize())
 	for i := 0; i < human.GetCardsSize(); i++ {
 		hand[i] = human.GetCard(i)

--- a/internal/domain/Poker_test.go
+++ b/internal/domain/Poker_test.go
@@ -1850,7 +1850,7 @@ func TestPoker_GettersSetters(t *testing.T) {
 	pk.SetConfig(cfg)
 	assert.Equal(t, 20, pk.GetConfig().Ante)
 
-	pk.lastCpuError = nil
+	pk.round.lastCpuError = nil
 	assert.Nil(t, pk.GetLastCpuError())
 }
 

--- a/internal/domain/Poker_testhelpers.go
+++ b/internal/domain/Poker_testhelpers.go
@@ -7,40 +7,40 @@ package domain
 // and are not part of the production game logic.
 
 // SetPhase フェーズ設定（テスト用）
-func (p *Poker) SetPhase(phase int) { p.phase = phase }
+func (p *Poker) SetPhase(phase int) { p.round.phase = phase }
 
 // SetCurrentTurn 現在のターン設定（テスト用）
-func (p *Poker) SetCurrentTurn(turn int) { p.currentTurn = turn }
+func (p *Poker) SetCurrentTurn(turn int) { p.round.currentTurn = turn }
 
 // SetPot ポット設定（テスト用）
-func (p *Poker) SetPot(pot int) { p.pot = pot }
+func (p *Poker) SetPot(pot int) { p.round.pot = pot }
 
 // SetDealerIdx ディーラーインデックス設定（テスト用）
 func (p *Poker) SetDealerIdx(idx int) { p.dealerIdx = idx }
 
 // SetGameEndFlag ゲーム終了フラグ設定（テスト用）
-func (p *Poker) SetGameEndFlag(flag bool) { p.gameEndFlag = flag }
+func (p *Poker) SetGameEndFlag(flag bool) { p.round.gameEndFlag = flag }
 
 // SetLastBet 最後のベット設定（テスト用）
-func (p *Poker) SetLastBet(bet int) { p.lastBet = bet }
+func (p *Poker) SetLastBet(bet int) { p.round.lastBet = bet }
 
 // SetMinRaise 最小レイズ額設定（テスト用）
-func (p *Poker) SetMinRaise(raise int) { p.minRaise = raise }
+func (p *Poker) SetMinRaise(raise int) { p.round.minRaise = raise }
 
 // SetRoundResults ラウンド結果設定（テスト用）
-func (p *Poker) SetRoundResults(results []PokerResult) { p.roundResults = results }
+func (p *Poker) SetRoundResults(results []PokerResult) { p.round.roundResults = results }
 
 // SetCpuActions CPU行動記録設定（テスト用）
-func (p *Poker) SetCpuActions(actions []PokerCpuAction) { p.cpuActions = actions }
+func (p *Poker) SetCpuActions(actions []PokerCpuAction) { p.round.cpuActions = actions }
 
 // SetCpuExchanges CPU交換記録設定（テスト用）
-func (p *Poker) SetCpuExchanges(exchanges []PokerCpuExchange) { p.cpuExchanges = exchanges }
+func (p *Poker) SetCpuExchanges(exchanges []PokerCpuExchange) { p.round.cpuExchanges = exchanges }
 
 // SetSidePots サイドポット設定（テスト用）
-func (p *Poker) SetSidePots(pots []PokerSidePot) { p.sidePots = pots }
+func (p *Poker) SetSidePots(pots []PokerSidePot) { p.round.sidePots = pots }
 
 // SetHumanProfile メタAIプロファイル設定（テスト用）
 func (p *Poker) SetHumanProfile(profile *BettingHumanProfile) { p.humanProfile = profile }
 
 // GetLastHumanPlayMs 最後の人間プレイ時間取得（テスト用）
-func (p *Poker) GetLastHumanPlayMs() int { return p.lastHumanPlayMs }
+func (p *Poker) GetLastHumanPlayMs() int { return p.round.lastHumanPlayMs }

--- a/internal/domain/daifugo_internal_test.go
+++ b/internal/domain/daifugo_internal_test.go
@@ -67,10 +67,10 @@ func TestDaifugo_advanceTurn_GameEndFlag(t *testing.T) {
 	config := DaifugoConfig{}
 	d := NewDaifugo(tc, players, config)
 
-	d.gameEndFlag = true
-	originalTurn := d.currentTurn
+	d.round.gameEndFlag = true
+	originalTurn := d.round.currentTurn
 	d.advanceTurn()
-	assert.Equal(t, originalTurn, d.currentTurn)
+	assert.Equal(t, originalTurn, d.round.currentTurn)
 }
 
 // TestDaifugo_isPlayable_EmptyCards covers lines 547-549:
@@ -109,12 +109,12 @@ func TestDaifugo_findBestSequencePlay_StrengthSkip(t *testing.T) {
 	d := NewDaifugo(tc, players, config)
 
 	// Set up a table with a 3-card sequence
-	d.tableCards = []*Card{
+	d.round.tableCards = []*Card{
 		NewCard(CardDesignHeart, 3, false),
 		NewCard(CardDesignHeart, 4, false),
 		NewCard(CardDesignHeart, 5, false),
 	}
-	d.tableIsSequence = true
+	d.round.tableIsSequence = true
 
 	// Craft a hand with same-suit cards in NON-ascending order.
 	// Place a higher-strength card BEFORE a lower-strength same-suit card.
@@ -153,12 +153,12 @@ func TestDaifugo_findBestSequencePlay_SciIncrement(t *testing.T) {
 	d := NewDaifugo(tc, players, config)
 
 	// Table: 3-card sequence of Hearts 3-4-5
-	d.tableCards = []*Card{
+	d.round.tableCards = []*Card{
 		NewCard(CardDesignHeart, 3, false),
 		NewCard(CardDesignHeart, 4, false),
 		NewCard(CardDesignHeart, 5, false),
 	}
-	d.tableIsSequence = true
+	d.round.tableIsSequence = true
 
 	// Craft a hand that, for a given startIdx, builds suitCards with a gap that requires
 	// sci++ advancement. The key is:
@@ -347,7 +347,7 @@ func TestDaifugo_findBestPlay_EightOnly(t *testing.T) {
 
 	// Player 1 has only an 8 (skipped by first loop, picked by second loop)
 	players[1].AddCard(NewCard(CardDesignSpade, 8, false))
-	d.tableCards = nil
+	d.round.tableCards = nil
 
 	result := d.findBestPlay(players[1])
 	assert.Equal(t, []int{0}, result)
@@ -377,13 +377,13 @@ func TestDaifugo_applyCapitalFall_FormerDaifugoIsLast(t *testing.T) {
 	players[3].SetRank(3)
 	// Player 1 is last active, give them 1 card
 	players[1].AddCard(NewCard(CardDesignSpade, 3, false))
-	d.currentTurn = 1 // set turn to CPU player 1
+	d.round.currentTurn = 1 // set turn to CPU player 1
 
 	// CpuPlay: player 1 plays last card → finishPlayer(1) rank=4 → applyCapitalFall
 	d.CpuPlay()
 
 	// lowestIdx == prevDaifugoIdx (both = 1) → no swap
-	assert.True(t, d.gameEndFlag)
+	assert.True(t, d.round.gameEndFlag)
 	assert.Equal(t, 4, players[1].GetRank()) // still last
 	assert.Equal(t, 1, players[0].GetRank()) // unchanged
 }
@@ -401,7 +401,7 @@ func TestDaifugo_findBestPlayEasy_FollowWithJokerSkip(t *testing.T) {
 	d := NewDaifugo(tc, players, cfg)
 
 	// Table has a single card
-	d.tableCards = []*Card{NewCard(CardDesignSpade, 3, false)}
+	d.round.tableCards = []*Card{NewCard(CardDesignSpade, 3, false)}
 	// CPU has joker first, then a normal card
 	players[1].AddCard(NewCard(CardDesignJoker, 0, false))
 	players[1].AddCard(NewCard(CardDesignHeart, 5, false))
@@ -424,7 +424,7 @@ func TestDaifugo_findBestPlayHard_UrgentFollowAllJokerTable(t *testing.T) {
 	d := NewDaifugo(tc, players, cfg)
 
 	// All-joker table (tableBase < 0 → strength = JokerStrength)
-	d.tableCards = []*Card{NewCard(CardDesignJoker, 0, false)}
+	d.round.tableCards = []*Card{NewCard(CardDesignJoker, 0, false)}
 	// CPU 1 has only weak cards → can't beat joker → passes
 	players[1].AddCard(NewCard(CardDesignHeart, 3, false))
 	// Urgent
@@ -447,7 +447,7 @@ func TestDaifugo_findBestPlayEasy_AllJokerTable(t *testing.T) {
 	cfg := DaifugoConfig{CpuDifficulty: DaifugoDifficultyEasy}
 	d := NewDaifugo(tc, players, cfg)
 
-	d.tableCards = []*Card{NewCard(CardDesignJoker, 0, false)}
+	d.round.tableCards = []*Card{NewCard(CardDesignJoker, 0, false)}
 	players[1].AddCard(NewCard(CardDesignHeart, 3, false))
 
 	result := d.findBestPlayEasy(players[1])
@@ -466,7 +466,7 @@ func TestDaifugo_shouldStrategicPass_AllJokerTable(t *testing.T) {
 	cfg := DaifugoConfig{CpuDifficulty: DaifugoDifficultyHard}
 	d := NewDaifugo(tc, players, cfg)
 
-	d.tableCards = []*Card{NewCard(CardDesignJoker, 0, false)}
+	d.round.tableCards = []*Card{NewCard(CardDesignJoker, 0, false)}
 	// 6+ cards in hand
 	for i := 3; i <= 8; i++ {
 		players[1].AddCard(NewCard(CardDesignHeart, i, false))
@@ -490,10 +490,10 @@ func TestDaifugo_shouldStrategicPass_Revolution(t *testing.T) {
 	}
 	cfg := DaifugoConfig{CpuDifficulty: DaifugoDifficultyHard}
 	d := NewDaifugo(tc, players, cfg)
-	d.revolutionActive = true
+	d.round.revolutionActive = true
 
 	// Table: 3 (revolution strength = 15, which is > 10 → returns false early)
-	d.tableCards = []*Card{NewCard(CardDesignSpade, 3, false)}
+	d.round.tableCards = []*Card{NewCard(CardDesignSpade, 3, false)}
 	// 6+ cards in hand
 	for i := 4; i <= 10; i++ {
 		players[1].AddCard(NewCard(CardDesignHeart, i, false))
@@ -504,7 +504,7 @@ func TestDaifugo_shouldStrategicPass_Revolution(t *testing.T) {
 
 	// Table: Ace (revolution strength = 18-14 = 4, which is ≤ 10)
 	// Hand has a 10 (revolution strength = 18-10 = 8, which is < DaifugoCardStrength(1)=14)
-	d.tableCards = []*Card{NewCard(CardDesignSpade, 1, false)}
+	d.round.tableCards = []*Card{NewCard(CardDesignSpade, 1, false)}
 	result = d.shouldStrategicPass(players[1], []int{0})
 	// Card 4 has revolution strength 18-4=14 which equals DaifugoCardStrength(1)=14 → pass
 	assert.True(t, result, "revolution: card strength 14 >= threshold 14 → should pass")
@@ -577,7 +577,7 @@ func TestDaifugo_findBestPlayHard_UrgentFollowOverflowBreak(t *testing.T) {
 	d := NewDaifugo(tc, players, cfg)
 
 	// Table has pair
-	d.tableCards = []*Card{
+	d.round.tableCards = []*Card{
 		NewCard(CardDesignSpade, 3, false),
 		NewCard(CardDesignHeart, 3, false),
 	}
@@ -612,12 +612,12 @@ func TestDaifugo_findBestSequencePlayHard_UrgentJokerFill(t *testing.T) {
 	d := NewDaifugo(tc, players, cfg)
 
 	// Table: 3-card sequence
-	d.tableCards = []*Card{
+	d.round.tableCards = []*Card{
 		NewCard(CardDesignHeart, 3, false),
 		NewCard(CardDesignHeart, 4, false),
 		NewCard(CardDesignHeart, 5, false),
 	}
-	d.tableIsSequence = true
+	d.round.tableIsSequence = true
 
 	// CPU 1: has joker + cards with gap → joker fills the gap
 	// Spade 7, Spade 9 (gap at 8) + Joker
@@ -647,12 +647,12 @@ func TestDaifugo_findBestSequencePlayHard_UrgentNoJokerFill(t *testing.T) {
 	cfg := DaifugoConfig{CpuDifficulty: DaifugoDifficultyHard, SequenceEnabled: true}
 	d := NewDaifugo(tc, players, cfg)
 
-	d.tableCards = []*Card{
+	d.round.tableCards = []*Card{
 		NewCard(CardDesignHeart, 3, false),
 		NewCard(CardDesignHeart, 4, false),
 		NewCard(CardDesignHeart, 5, false),
 	}
-	d.tableIsSequence = true
+	d.round.tableIsSequence = true
 
 	// CPU 1: gap with no joker
 	players[1].AddCard(NewCard(CardDesignSpade, 7, false))
@@ -708,7 +708,7 @@ func TestDaifugo_searchCardGroupSuitCheck(t *testing.T) {
 	t.Run("full lock: first card matches → true", func(t *testing.T) {
 		cfg := DaifugoConfig{SuitLockMode: DaifugoSuitLockFull}
 		d := NewDaifugo(tc, players, cfg)
-		d.lockedSuit = CardDesignSpade
+		d.round.lockedSuit = CardDesignSpade
 
 		players[0].Reset()
 		players[0].AddCard(NewCard(CardDesignSpade, 6, false))
@@ -720,7 +720,7 @@ func TestDaifugo_searchCardGroupSuitCheck(t *testing.T) {
 	t.Run("full lock: first card doesn't match → false", func(t *testing.T) {
 		cfg := DaifugoConfig{SuitLockMode: DaifugoSuitLockFull}
 		d := NewDaifugo(tc, players, cfg)
-		d.lockedSuit = CardDesignSpade
+		d.round.lockedSuit = CardDesignSpade
 
 		players[0].Reset()
 		players[0].AddCard(NewCard(CardDesignHeart, 6, false))
@@ -732,7 +732,7 @@ func TestDaifugo_searchCardGroupSuitCheck(t *testing.T) {
 	t.Run("partial lock: second card matches → true", func(t *testing.T) {
 		cfg := DaifugoConfig{SuitLockMode: DaifugoSuitLockPartial}
 		d := NewDaifugo(tc, players, cfg)
-		d.lockedSuit = CardDesignSpade
+		d.round.lockedSuit = CardDesignSpade
 
 		players[0].Reset()
 		players[0].AddCard(NewCard(CardDesignHeart, 6, false))
@@ -744,7 +744,7 @@ func TestDaifugo_searchCardGroupSuitCheck(t *testing.T) {
 	t.Run("partial lock: no card matches → false", func(t *testing.T) {
 		cfg := DaifugoConfig{SuitLockMode: DaifugoSuitLockPartial}
 		d := NewDaifugo(tc, players, cfg)
-		d.lockedSuit = CardDesignSpade
+		d.round.lockedSuit = CardDesignSpade
 
 		players[0].Reset()
 		players[0].AddCard(NewCard(CardDesignHeart, 6, false))
@@ -789,7 +789,7 @@ func TestDaifugo_shouldStrategicPass_JokerInHand(t *testing.T) {
 	d := NewDaifugo(tc, players, cfg)
 
 	// Table strength <= 10 (card 4, strength = 4)
-	d.tableCards = []*Card{NewCard(CardDesignSpade, 4, false)}
+	d.round.tableCards = []*Card{NewCard(CardDesignSpade, 4, false)}
 	// 6+ cards in hand, with a joker at index 0
 	players[1].AddCard(NewCard(CardDesignJoker, 0, false)) // index 0 = joker
 	for i := 5; i <= 10; i++ {
@@ -822,7 +822,7 @@ func TestDaifugo_searchCardGroup_JokerComplementSelectStrongest(t *testing.T) {
 	players[1].AddCard(NewCard(CardDesignHeart, 10, false)) // idx 1
 	players[1].AddCard(NewCard(CardDesignJoker, 0, false))  // idx 2
 
-	d.tableCards = []*Card{NewCard(CardDesignSpade, 5, false), NewCard(CardDesignClover, 5, false)}
+	d.round.tableCards = []*Card{NewCard(CardDesignSpade, 5, false), NewCard(CardDesignClover, 5, false)}
 
 	result := d.searchCardGroup(players[1], 2, 5, cardSearchOpts{selectStrongest: true})
 	assert.NotNil(t, result)
@@ -846,7 +846,7 @@ func TestDaifugo_findOpeningSequencePlay_SkipsJokerStartIdx(t *testing.T) {
 		SequenceLockEnabled: true,
 	}
 	d := NewDaifugo(tc, players, cfg)
-	d.sequenceLocked = true
+	d.round.sequenceLocked = true
 
 	// Cards sorted by strength: 3(str3), joker(str16 → placed at end after sort)
 	// But we need the joker to appear at a startIdx that the loop reaches.
@@ -890,7 +890,7 @@ func TestDaifugo_findOpeningSequencePlay_IllegalFinishFallback(t *testing.T) {
 		SequenceRevolutionEnabled: true,
 	}
 	d := NewDaifugo(tc, players, cfg)
-	d.sequenceLocked = true
+	d.round.sequenceLocked = true
 
 	// Player has exactly 3 cards that form a valid sequence including an 8 → illegal finish
 	// Hearts 7, 8, 9 → valid sequence, but playing all 3 = finish with 8 = illegal

--- a/internal/domain/daifugo_solver.go
+++ b/internal/domain/daifugo_solver.go
@@ -21,9 +21,9 @@ type daifugoSolver struct {
 func newDaifugoSolver(d *Daifugo, oppHands [][]*Card) *daifugoSolver {
 	return &daifugoSolver{
 		oppHands:       oppHands,
-		revolution:     d.revolutionActive,
-		elevenBack:     d.elevenBackActive,
-		sequenceLocked: d.sequenceLocked,
+		revolution:     d.round.revolutionActive,
+		elevenBack:     d.round.elevenBackActive,
+		sequenceLocked: d.round.sequenceLocked,
 		config:         d.config,
 	}
 }
@@ -751,8 +751,8 @@ func (d *Daifugo) trySolveEndgame(player *DaifugoPlayer) []int {
 	}
 
 	solver := newDaifugoSolver(d, oppHands)
-	result := solver.solve(cpuHand, d.tableCards, d.tableIsSequence,
-		d.suitLocked, d.lockedSuit, d.numberLocked)
+	result := solver.solve(cpuHand, d.round.tableCards, d.round.tableIsSequence,
+		d.round.suitLocked, d.round.lockedSuit, d.round.numberLocked)
 	if result == nil {
 		return nil
 	}

--- a/internal/domain/poker_internal_test.go
+++ b/internal/domain/poker_internal_test.go
@@ -1,20 +1,20 @@
 package domain
 
 // setActedFlags actedフラグ設定（テスト用）
-func (p *Poker) setActedFlags(flags []bool) { p.actedFlags = flags }
+func (p *Poker) setActedFlags(flags []bool) { p.round.actedFlags = flags }
 
 // setRaiseCount レイズ回数設定（テスト用）
-func (p *Poker) setRaiseCount(count int) { p.raiseCount = count }
+func (p *Poker) setRaiseCount(count int) { p.round.raiseCount = count }
 
 // setStartingChips ハンド開始時チップ設定（テスト用）
-func (p *Poker) setStartingChips(chips []int) { p.startingChips = chips }
+func (p *Poker) setStartingChips(chips []int) { p.round.startingChips = chips }
 
 // getStartingChips ハンド開始時チップ取得（テスト用）
-func (p *Poker) getStartingChips() []int { return p.startingChips }
+func (p *Poker) getStartingChips() []int { return p.round.startingChips }
 
 // getActedFlags actedフラグ取得（テスト用）
 func (p *Poker) getActedFlags() []bool {
-	result := make([]bool, len(p.actedFlags))
-	copy(result, p.actedFlags)
+	result := make([]bool, len(p.round.actedFlags))
+	copy(result, p.round.actedFlags)
 	return result
 }


### PR DESCRIPTION
## Summary
- **#898**: Extract `TutorialButton` into `frontend/src/components/tutorial/TutorialButton.tsx`, removing 24 identical local definitions from game pages (~340 lines removed)
- **#899**: Consolidate 6 CUI card formatter functions into 2 generic functions (`formatCardList`, `formatCardSlice`) with thin wrappers for backward compatibility
- **#900**: Extract round-state sub-structs (`daifugoRoundState`, `pokerRoundState`, `napoleonRoundState`) for the 3 largest domain types, simplifying `Reset()` methods and preventing field-reset omission bugs

Closes #898, closes #899, closes #900

## Test plan
- [x] All Go tests pass (`go test -tags test -p 2 ./...`)
- [x] `golangci-lint run ./...` — 0 issues
- [x] Frontend build passes (`bun run build`)
- [x] Biome check passes (`bun run check`)
- [x] All 2867 frontend tests pass (`bun run test`)
- [x] New `TutorialButton.test.tsx` covers render, click, and className
- [x] New `formatCardList`/`formatCardSlice` tests cover all formatter×separator×indexed combinations
- [x] Existing wrapper function tests still pass (behavioral equivalence)
- [x] UML diagrams updated in `docs/design/backend.md`
- [x] Tutorial docs updated in `frontend/CLAUDE.md`