### PR TITLE
docs: update ADR-0025 tutorial phases to completed status

### DIFF
--- a/docs/adr/0025-tutorial-system.md
+++ b/docs/adr/0025-tutorial-system.md
@@ -51,8 +51,8 @@ Accepted
 ### 段階的展開
 
 - Phase 1: 基盤コンポーネント + BlackJack（本ADR）
-- Phase 2: 全ゲームへの展開（Issue #860）
-- Phase 3: ヒント表示・自動提案・進捗管理（Issue #861）
+- Phase 2: 全ゲームへの展開（完了済）
+- Phase 3: ヒント表示・自動提案・進捗管理（完了済）
 
 ## Consequences
 


### PR DESCRIPTION
## Summary
- ADR-0025の「段階的展開」セクションで、Phase 2（全ゲームへの展開）とPhase 3（ヒント・自動提案・進捗管理）のステータスを「Issue #860/861」から「完了済」に更新

Closes #902

## Test plan
- [ ] ADR-0025の記述が正しく更新されていること