### PR TITLE
fix: increase tutorial dialog overlay opacity for better readability

### DIFF
--- a/frontend/src/components/tutorial/TutorialSuggestDialog.tsx
+++ b/frontend/src/components/tutorial/TutorialSuggestDialog.tsx
@@ -70,7 +70,7 @@ export function TutorialSuggestDialog({
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: overlay backdrop dismisses dialog on click
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
       onClick={onSkip}
       role="presentation"
     >


### PR DESCRIPTION
## Summary
- Increase `TutorialSuggestDialog` backdrop opacity from `bg-black/50` to `bg-black/80` so background game elements (cards, scores, text) don't bleed through and interfere with dialog readability

## Test plan
- [x] Build passes
- [x] Biome check passes
- [x] TutorialSuggestDialog unit tests pass (13/13)

Closes #915