### PR TITLE
fix: add border and shadow to card backs for visibility on green backgrounds

### DIFF
--- a/frontend/src/components/CardImage.tsx
+++ b/frontend/src/components/CardImage.tsx
@@ -81,7 +81,15 @@ export function CardBack({ width, style, className, onClick, ariaLabel }: CardBa
       width={CARD_NATURAL_WIDTH}
       height={CARD_NATURAL_HEIGHT}
       loading="lazy"
-      style={{ width: w, maxWidth: '100%', borderRadius: 6, display: 'block', ...style }}
+      style={{
+        width: w,
+        maxWidth: '100%',
+        borderRadius: 6,
+        display: 'block',
+        border: '1px solid rgba(255,255,255,0.4)',
+        boxShadow: '0 1px 4px rgba(0,0,0,0.5)',
+        ...style,
+      }}
       className={className}
     />
   );

--- a/frontend/src/components/CpuPlayerCard.tsx
+++ b/frontend/src/components/CpuPlayerCard.tsx
@@ -26,7 +26,7 @@ export function CpuPlayerCard({ player, showCards, faceDownCount, showHandName, 
   const { t } = useTranslation('common');
   const { cpuCardWidth } = useCardDimensions();
   return (
-    <div className="mb-3">
+    <div className="mb-3 rounded-lg p-2 bg-black/20 border border-white/10">
       <div className="text-white text-sm mb-1">
         {t('player.cpu', { id: player.id })} <span className="text-gray-300 text-xs">({player.playStyleName})</span>
         <span className="ml-2 text-xs">


### PR DESCRIPTION
## Summary
- Add white border (`1px solid rgba(255,255,255,0.4)`) and drop shadow to `CardBack` component so face-down cards are visible against green game backgrounds on mobile
- Add semi-transparent background and border to `CpuPlayerCard` areas for clearer player section separation in Hold'em games

## Test plan
- [x] Build passes
- [x] Biome check passes
- [x] CardImage tests pass (all 42)
- [x] CpuPlayerCard tests pass

Closes #916