### PR TITLE
fix: reduce text overflow on mobile screens

### DIFF
--- a/frontend/src/i18n/locales/ja/spades.json
+++ b/frontend/src/i18n/locales/ja/spades.json
@@ -36,7 +36,7 @@
   "playButton": "出す",
   "nextTrick": "次のトリック",
   "nextRound": "次のラウンド",
-  "bidPhase": "ビッドを宣言してください (0=ニル, 1-13)",
+  "bidPhase": "ビッド宣言 (0=ニル, 1-13)",
   "playPhase": {
     "lead": "リードしてください",
     "follow": "カードを出してください"

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -113,7 +113,7 @@ function StatTooltip({ id, label, tooltipText }: { id: string; label: string; to
 function HudStats({ vpip, pfr, threeBet, af }: { vpip: number; pfr: number; threeBet: number; af: string }) {
   const { t } = useTranslation('holdem');
   return (
-    <span className="ml-2 text-cyan-300 text-[0.8em]" data-testid="hud-stats">
+    <span className="ml-2 text-cyan-300 text-[0.8em] hidden sm:inline" data-testid="hud-stats">
       <StatTooltip id="tooltip-vpip" label={t('stats.vpip')} tooltipText={t('stats.vpipTooltip')} />:{vpip}%{' '}
       <StatTooltip id="tooltip-pfr" label={t('stats.pfr')} tooltipText={t('stats.pfrTooltip')} />:{pfr}%{' '}
       <StatTooltip id="tooltip-3bet" label={t('stats.threeBet')} tooltipText={t('stats.threeBetTooltip')} />:{threeBet}%{' '}

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -113,7 +113,7 @@ function StatTooltip({ id, label, tooltipText }: { id: string; label: string; to
 function HudStats({ vpip, pfr, threeBet, af }: { vpip: number; pfr: number; threeBet: number; af: string }) {
   const { t } = useTranslation('omaha');
   return (
-    <span className="ml-2 text-cyan-300 text-[0.8em]" data-testid="hud-stats">
+    <span className="ml-2 text-cyan-300 text-[0.8em] hidden sm:inline" data-testid="hud-stats">
       <StatTooltip id="tooltip-vpip" label={t('stats.vpip')} tooltipText={t('stats.vpipTooltip')} />:{vpip}%{' '}
       <StatTooltip id="tooltip-pfr" label={t('stats.pfr')} tooltipText={t('stats.pfrTooltip')} />:{pfr}%{' '}
       <StatTooltip id="tooltip-3bet" label={t('stats.threeBet')} tooltipText={t('stats.threeBetTooltip')} />:{threeBet}%{' '}

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -113,7 +113,7 @@ function StatTooltip({ id, label, tooltipText }: { id: string; label: string; to
 function HudStats({ vpip, pfr, threeBet, af }: { vpip: number; pfr: number; threeBet: number; af: string }) {
   const { t } = useTranslation('shortdeck');
   return (
-    <span className="ml-2 text-cyan-300 text-[0.8em]" data-testid="hud-stats">
+    <span className="ml-2 text-cyan-300 text-[0.8em] hidden sm:inline" data-testid="hud-stats">
       <StatTooltip id="tooltip-vpip" label={t('stats.vpip')} tooltipText={t('stats.vpipTooltip')} />:{vpip}%{' '}
       <StatTooltip id="tooltip-pfr" label={t('stats.pfr')} tooltipText={t('stats.pfrTooltip')} />:{pfr}%{' '}
       <StatTooltip id="tooltip-3bet" label={t('stats.threeBet')} tooltipText={t('stats.threeBetTooltip')} />:{threeBet}%{' '}

--- a/frontend/src/pages/SpadesPage.test.tsx
+++ b/frontend/src/pages/SpadesPage.test.tsx
@@ -173,11 +173,7 @@ describe('SpadesPage', () => {
     mockExec.mockResolvedValue(bidPhaseState);
     renderWithProviders(<SpadesPage />);
     await waitFor(() => {
-      expect(
-        screen.getByText(
-          '\u30d3\u30c3\u30c9\u3092\u5ba3\u8a00\u3057\u3066\u304f\u3060\u3055\u3044 (0=\u30cb\u30eb, 1-13)',
-        ),
-      ).toBeInTheDocument();
+      expect(screen.getByText('\u30d3\u30c3\u30c9\u5ba3\u8a00 (0=\u30cb\u30eb, 1-13)')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- Hide HUD stats (VPIP/PFR/3Bet/AF) on mobile for Hold'em, Omaha, and Short Deck — stats remain visible on desktop (sm+ breakpoint)
- Shorten Spades bid prompt text from "ビッドを宣言してください" to "ビッド宣言" to prevent overflow on narrow (375px) screens

## Test plan
- [x] Build passes
- [x] Biome check passes
- [x] HoldemPage tests pass
- [x] OmahaPage tests pass
- [x] ShortDeckPage tests pass
- [x] SpadesPage tests pass (59/59)

Closes #920