### PR TITLE
feat: unify game background themes by category

### DIFF
--- a/frontend/src/components/skeleton/CrazyEightsSkeleton.tsx
+++ b/frontend/src/components/skeleton/CrazyEightsSkeleton.tsx
@@ -1,4 +1,5 @@
 import { useCardDimensions } from '../../hooks/useCardDimensions';
+import { gameTheme } from '../../styles/gameTheme';
 import { GameSkeleton } from './GameSkeleton';
 import { SkeletonHand } from './SkeletonHand';
 
@@ -7,8 +8,8 @@ export function CrazyEightsSkeleton() {
   const { cardWidth, cardHeight } = useCardDimensions();
   return (
     <GameSkeleton
-      bgClass="bg-game-bg-green"
-      footerClassName="bg-game-bg-green-dark border-white/20 px-4 py-2.5"
+      bgClass={gameTheme.crazyeights.bg}
+      footerClassName={`${gameTheme.crazyeights.footer} px-4 py-2.5`}
       footer={
         <>
           <SkeletonHand cardWidth={cardWidth} cardHeight={cardHeight} count={5} className="mb-2" />

--- a/frontend/src/components/skeleton/DoubtSkeleton.tsx
+++ b/frontend/src/components/skeleton/DoubtSkeleton.tsx
@@ -1,4 +1,5 @@
 import { useCardDimensions } from '../../hooks/useCardDimensions';
+import { gameTheme } from '../../styles/gameTheme';
 import { GameSkeleton } from './GameSkeleton';
 import { SkeletonHand } from './SkeletonHand';
 
@@ -7,8 +8,8 @@ export function DoubtSkeleton() {
   const { cardWidth, cardHeight } = useCardDimensions();
   return (
     <GameSkeleton
-      bgClass="bg-game-bg-green"
-      footerClassName="bg-game-bg-green-dark border-white/20 px-4 py-2.5"
+      bgClass={gameTheme.doubt.bg}
+      footerClassName={`${gameTheme.doubt.footer} px-4 py-2.5`}
       footer={
         <>
           <div className="mb-2">

--- a/frontend/src/components/skeleton/MemorySkeleton.tsx
+++ b/frontend/src/components/skeleton/MemorySkeleton.tsx
@@ -1,3 +1,4 @@
+import { gameTheme } from '../../styles/gameTheme';
 import { GameSkeleton } from './GameSkeleton';
 import { SkeletonGrid } from './SkeletonGrid';
 
@@ -5,8 +6,8 @@ import { SkeletonGrid } from './SkeletonGrid';
 export function MemorySkeleton() {
   return (
     <GameSkeleton
-      bgClass="bg-game-bg-casino"
-      footerClassName="bg-game-bg-casino-dark border-white/20 px-4 py-2.5"
+      bgClass={gameTheme.memory.bg}
+      footerClassName={`${gameTheme.memory.footer} px-4 py-2.5`}
       footer={<div className="h-8 w-24 rounded bg-white/10 animate-pulse" />}
     >
       <div className="my-2 p-2 rounded bg-black/30">

--- a/frontend/src/pages/CrazyEightsPage.tsx
+++ b/frontend/src/pages/CrazyEightsPage.tsx
@@ -20,6 +20,7 @@ import { usePhaseNames } from '../hooks/usePhaseNames';
 import { TutorialProvider } from '../providers/TutorialProvider';
 import { btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
+import { gameTheme } from '../styles/gameTheme';
 import { CrazyEightsPhase, CrazyEightsSuit } from '../types/phases';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
@@ -140,7 +141,7 @@ function CrazyEightsPageContent() {
   const isHumanTurn = isPlayPhase && state.players[state.currentPlayerIdx]?.isHuman === true;
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-game-bg-green" aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.crazyeights.bg}`} aria-busy={loading} aria-live="polite">
       <GamePageHeading title={tc('nav.crazyeights')} />
       <PhaseIndicator phaseName={phaseNames[state.phase]} isHumanTurn={isHumanTurn || isChooseSuit}>
         <TutorialButton />
@@ -243,7 +244,7 @@ function CrazyEightsPageContent() {
         />
       </div>
 
-      <GameFooter className="bg-game-bg-green-dark border-white/20 px-4 py-2.5">
+      <GameFooter className={`${gameTheme.crazyeights.footer} px-4 py-2.5`}>
         {humanPlayer && (
           <div className="flex flex-wrap gap-1 mb-2" data-tutorial="ce-player-hand">
             {humanPlayer.cards.map((card, idx) => (

--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -26,6 +26,7 @@ import {
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { TutorialProvider } from '../providers/TutorialProvider';
 import { btnDanger, btnPrimary, btnSuccess, btnWarning, focusRingBlue } from '../styles/buttonStyles';
+import { gameTheme } from '../styles/gameTheme';
 import type { DoubtCpuAction } from '../types/card';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
 import { valueName } from '../utils/cardUtils';
@@ -158,7 +159,7 @@ function DoubtPageContent() {
   );
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-game-bg-green" aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.doubt.bg}`} aria-busy={loading} aria-live="polite">
       <GamePageHeading title={tc('nav.doubt')} />
       {/* Phase indicator */}
       <PhaseIndicator
@@ -358,7 +359,7 @@ function DoubtPageContent() {
       </div>
 
       {/* Sticky footer: human player hand + action buttons */}
-      <GameFooter className="bg-game-bg-green-dark border-white/20 px-4 py-2.5">
+      <GameFooter className={`${gameTheme.doubt.footer} px-4 py-2.5`}>
         {/* Human player info */}
         {humanPlayer && (
           <div className="mb-2" data-tutorial="dt-player-hand">

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -19,6 +19,7 @@ import { CPU_DIFFICULTY_OPTIONS, useMemoryGame } from '../hooks/useMemoryGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { TutorialProvider } from '../providers/TutorialProvider';
 import { btnSuccess, btnWarning, focusRingWhite } from '../styles/buttonStyles';
+import { gameTheme } from '../styles/gameTheme';
 import { MemoryPhase } from '../types/phases';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
 import { playerName } from '../utils/playerUtils';
@@ -104,7 +105,7 @@ function MemoryPageContent() {
   const isHumanTurn = (isFlip1 || isFlip2) && state.players[state.currentPlayerIdx]?.isHuman === true;
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-game-bg-casino" aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.memory.bg}`} aria-busy={loading} aria-live="polite">
       <GamePageHeading title={tc('nav.memory')} />
       {/* Phase indicator */}
       <PhaseIndicator phaseName={phaseNames[state.phase]} isHumanTurn={isHumanTurn}>
@@ -202,7 +203,7 @@ function MemoryPageContent() {
       </div>
 
       {/* Footer */}
-      <GameFooter className="bg-game-bg-casino-dark border-white/20 px-4 py-2.5">
+      <GameFooter className={`${gameTheme.memory.footer} px-4 py-2.5`}>
         <ErrorAlert message={error} />
         <div className="flex gap-2 items-center">
           {isResult && (

--- a/frontend/src/styles/gameTheme.test.ts
+++ b/frontend/src/styles/gameTheme.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { gameTheme } from './gameTheme';
+
+describe('gameTheme', () => {
+  it('table games use green-bright theme', () => {
+    expect(gameTheme.blackjack.bg).toContain('green-bright');
+  });
+
+  it('poker games use green-poker theme', () => {
+    expect(gameTheme.holdem.bg).toContain('green-poker');
+    expect(gameTheme.omaha.bg).toContain('green-poker');
+  });
+
+  it('trick-taking games use blue theme', () => {
+    expect(gameTheme.hearts.bg).toContain('blue');
+    expect(gameTheme.spades.bg).toContain('blue');
+  });
+
+  it('matching/pass games use green theme', () => {
+    expect(gameTheme.doubt.bg).toContain('green');
+    expect(gameTheme.crazyeights.bg).toContain('green');
+  });
+
+  it('solitaire games use casino theme', () => {
+    expect(gameTheme.klondike.bg).toContain('casino');
+    expect(gameTheme.memory.bg).toContain('casino');
+  });
+
+  it('counting/rummy games use blue theme', () => {
+    expect(gameTheme.ginrummy.bg).toContain('blue');
+    expect(gameTheme.cribbage.bg).toContain('blue');
+  });
+
+  it('every entry has bg and footer fields', () => {
+    for (const [key, value] of Object.entries(gameTheme)) {
+      expect(value.bg, `${key}.bg`).toBeTruthy();
+      expect(value.footer, `${key}.footer`).toBeTruthy();
+    }
+  });
+});

--- a/frontend/src/styles/gameTheme.ts
+++ b/frontend/src/styles/gameTheme.ts
@@ -29,7 +29,7 @@ export const gameTheme: Record<string, { bg: string; footer: string }> = {
   spider: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
   pyramid: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
   memory: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
-  // Rummy — unified to blue
+  // Counting/Rummy — unified to blue
   ginrummy: { bg: 'bg-game-bg-blue', footer: 'bg-game-bg-blue-dark border-white/20' },
   cribbage: { bg: 'bg-game-bg-blue', footer: 'bg-game-bg-blue-dark border-white/20' },
-} as const;
+};


### PR DESCRIPTION
## Summary
- Standardize background colors by game category:
  - Matching/Pass games (Doubt, Crazy Eights): blue → green (matches OldMaid, Daifugo, Sevens)
  - Solitaire games (Memory): blue → casino (matches Klondike, FreeCell, Spider, Pyramid)
- Add `gameTheme.ts` reference mapping documenting category-based theme assignments
- Update skeleton loading components to match new theme colors

## Test plan
- [x] Build passes
- [x] Biome check passes
- [x] DoubtPage tests pass
- [x] CrazyEightsPage tests pass
- [x] MemoryPage tests pass
- [x] GameSkeleton tests pass

Closes #922