### PR TITLE
fix: wait for game render before taking UX review screenshots

### DIFF
--- a/.claude/commands/desktop-ux-review.md
+++ b/.claude/commands/desktop-ux-review.md
@@ -40,6 +40,7 @@ for game in $GAMES; do
   [ "$game" = "$ROOT_GAME" ] && path="/"
   PLAYWRIGHT_BROWSERS_PATH=~/.cache/ms-playwright bunx playwright screenshot \
     --browser chromium --viewport-size "1280,800" --full-page \
+    --wait-for-selector '[aria-live="polite"]' \
     "http://localhost:8080$path" "/tmp/desktop-screenshots/${game}.png" 2>&1
 done
 ```
@@ -82,8 +83,10 @@ const { chromium } = require('playwright');
 
   for (const { name, path } of games) {
     await page.goto(`http://localhost:8080${path}`);
+    // Wait for game content to render (skeleton disappears, real content with aria-live appears)
+    await page.waitForSelector('[aria-live="polite"]', { timeout: 10000 });
     await dismissTutorial(page);
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(300);
     await page.screenshot({ path: `/tmp/desktop-screenshots/${name}-play.png`, fullPage: true });
   }
 
@@ -104,6 +107,8 @@ const { chromium } = require('playwright');
   const browser = await chromium.launch({ headless: true });
   const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
   await page.goto('http://localhost:8080/');
+  // Wait for game content to render
+  await page.waitForSelector('[aria-live="polite"]', { timeout: 10000 });
   const skipBtn = page.getByRole('button', { name: 'スキップ' });
   if (await skipBtn.isVisible({ timeout: 1500 }).catch(() => false)) {
     await skipBtn.click();

--- a/.claude/commands/mobile-ux-review.md
+++ b/.claude/commands/mobile-ux-review.md
@@ -40,6 +40,7 @@ for game in $GAMES; do
   [ "$game" = "$ROOT_GAME" ] && path="/"
   PLAYWRIGHT_BROWSERS_PATH=~/.cache/ms-playwright bunx playwright screenshot \
     --browser chromium --viewport-size "375,667" --full-page \
+    --wait-for-selector '[aria-live="polite"]' \
     "http://localhost:8080$path" "/tmp/mobile-screenshots/${game}.png" 2>&1
 done
 ```
@@ -82,8 +83,10 @@ const { chromium } = require('playwright');
 
   for (const { name, path } of games) {
     await page.goto(`http://localhost:8080${path}`);
+    // Wait for game content to render (skeleton disappears, real content with aria-live appears)
+    await page.waitForSelector('[aria-live="polite"]', { timeout: 10000 });
     await dismissTutorial(page);
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(300);
     await page.screenshot({ path: `/tmp/mobile-screenshots/${name}-play.png`, fullPage: true });
   }
 
@@ -102,6 +105,8 @@ const { chromium } = require('playwright');
   const browser = await chromium.launch({ headless: true });
   const page = await browser.newPage({ viewport: { width: 375, height: 667 } });
   await page.goto('http://localhost:8080/');
+  // Wait for game content to render
+  await page.waitForSelector('[aria-live="polite"]', { timeout: 10000 });
   const skipBtn = page.getByRole('button', { name: 'スキップ' });
   if (await skipBtn.isVisible({ timeout: 1500 }).catch(() => false)) {
     await skipBtn.click();


### PR DESCRIPTION
## Summary
- UX reviewコマンド（mobile/desktop）のスクリーンショット撮影で、ゲームの初期描画完了を待たずにSkeleton状態を撮影していた問題を修正
- 全3撮影ステップ（2a CLI, 2b Playwrightスクリプト, 2c ナビスクリプト）に `--wait-for-selector '[aria-live="polite"]'` を追加
- Hold'em/Omaha/ShortDeckで「カード裏面が背景と同化」と報告されていた Issue #945 は、実際にはSkeleton撮影が原因だったことが判明

## Test plan
- [x] Hold'emページで `--wait-for-selector '[aria-live="polite"]'` 付きスクリーンショットを撮影し、カード裏面が正しく描画されることを確認済み
- [ ] `/mobile-ux-review holdem` で修正後の撮影を確認
- [ ] `/desktop-ux-review holdem` で修正後の撮影を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)