### PR TITLE
fix: mobile hand card horizontal scroll for trick-taking games

### DIFF
--- a/frontend/src/pages/EuchrePage.test.tsx
+++ b/frontend/src/pages/EuchrePage.test.tsx
@@ -792,4 +792,34 @@ describe('EuchrePage', () => {
     renderWithProviders(<EuchrePage />);
     await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
   });
+
+  it('renders mobile viewport with horizontal scroll hand', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      renderWithProviders(<EuchrePage />);
+      await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+      const hand = document.querySelector('[data-tutorial="eu-player-hand"]');
+      expect(hand?.className).toContain('overflow-x-auto');
+      expect(hand?.className).not.toContain('flex-wrap');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
+
+  it('renders desktop viewport with wrapping hand', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 800 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      renderWithProviders(<EuchrePage />);
+      await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+      const hand = document.querySelector('[data-tutorial="eu-player-hand"]');
+      expect(hand?.className).toContain('flex-wrap');
+      expect(hand?.className).not.toContain('overflow-x-auto');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
 });

--- a/frontend/src/pages/EuchrePage.tsx
+++ b/frontend/src/pages/EuchrePage.tsx
@@ -130,7 +130,7 @@ function EuchrePageContent() {
     hintLoading,
     handleHint,
   } = useEuchreGame();
-  const { cardWidth } = useCardDimensions();
+  const { cardWidth, isMobile, solitaireMinColWidth } = useCardDimensions();
   const [goAlone, setGoAlone] = useState(false);
 
   const isPlayPhaseForKbd = state?.phase === EuchrePhase.PLAY;
@@ -338,7 +338,10 @@ function EuchrePageContent() {
       <GameFooter className="bg-game-bg-blue-dark border-white/20 px-4 py-2.5">
         {/* Human cards */}
         {humanPlayer && (
-          <div className="flex flex-wrap gap-1 mb-2" data-tutorial="eu-player-hand">
+          <div
+            className={isMobile ? 'flex gap-1 overflow-x-auto mb-2' : 'flex flex-wrap gap-1 mb-2'}
+            data-tutorial="eu-player-hand"
+          >
             {humanPlayer.cards.map((card, idx) => (
               <button
                 type="button"
@@ -353,6 +356,7 @@ function EuchrePageContent() {
                   borderRadius: 8,
                   ...selectedCardStyle(selectedCardIndices.includes(idx)),
                   boxSizing: 'border-box',
+                  ...(isMobile ? { minWidth: solitaireMinColWidth, flexShrink: 0 } : {}),
                 }}
               >
                 <AnimatedCard card={card} width={cardWidth} />

--- a/frontend/src/pages/HeartsPage.test.tsx
+++ b/frontend/src/pages/HeartsPage.test.tsx
@@ -786,4 +786,34 @@ describe('HeartsPage', () => {
     renderWithProviders(<HeartsPage />);
     await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
   });
+
+  it('renders mobile viewport with horizontal scroll hand', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      renderWithProviders(<HeartsPage />);
+      await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+      const hand = document.querySelector('[data-tutorial="ht-player-hand"]');
+      expect(hand?.className).toContain('overflow-x-auto');
+      expect(hand?.className).not.toContain('flex-wrap');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
+
+  it('renders desktop viewport with wrapping hand', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 800 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      renderWithProviders(<HeartsPage />);
+      await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+      const hand = document.querySelector('[data-tutorial="ht-player-hand"]');
+      expect(hand?.className).toContain('flex-wrap');
+      expect(hand?.className).not.toContain('overflow-x-auto');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
 });

--- a/frontend/src/pages/HeartsPage.tsx
+++ b/frontend/src/pages/HeartsPage.tsx
@@ -128,7 +128,7 @@ function HeartsPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('hearts', state);
-  const { cardWidth } = useCardDimensions();
+  const { cardWidth, isMobile, solitaireMinColWidth } = useCardDimensions();
 
   const isPassPhaseForKbd = state?.phase === HeartsPhase.PASS;
   const isPlayPhaseForKbd = state?.phase === HeartsPhase.PLAY;
@@ -308,7 +308,10 @@ function HeartsPageContent() {
       <GameFooter className="bg-game-bg-blue-dark border-white/20 px-4 py-2.5">
         {/* Human cards */}
         {humanPlayer && (
-          <div className="flex flex-wrap gap-1 mb-2" data-tutorial="ht-player-hand">
+          <div
+            className={isMobile ? 'flex gap-1 overflow-x-auto mb-2' : 'flex flex-wrap gap-1 mb-2'}
+            data-tutorial="ht-player-hand"
+          >
             {humanPlayer.cards.map((card, idx) => (
               <button
                 type="button"
@@ -323,6 +326,7 @@ function HeartsPageContent() {
                   borderRadius: 8,
                   ...selectedCardStyle(selectedCardIndices.includes(idx)),
                   boxSizing: 'border-box',
+                  ...(isMobile ? { minWidth: solitaireMinColWidth, flexShrink: 0 } : {}),
                 }}
               >
                 <AnimatedCard card={card} width={cardWidth} />

--- a/frontend/src/pages/NapoleonPage.test.tsx
+++ b/frontend/src/pages/NapoleonPage.test.tsx
@@ -1041,4 +1041,34 @@ describe('NapoleonPage', () => {
     renderWithProviders(<NapoleonPage />);
     await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
   });
+
+  it('renders mobile viewport with horizontal scroll hand', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      renderWithProviders(<NapoleonPage />);
+      await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+      const hand = document.querySelector('[data-tutorial="np-player-hand"]');
+      expect(hand?.className).toContain('overflow-x-auto');
+      expect(hand?.className).not.toContain('flex-wrap');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
+
+  it('renders desktop viewport with wrapping hand', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 800 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      renderWithProviders(<NapoleonPage />);
+      await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+      const hand = document.querySelector('[data-tutorial="np-player-hand"]');
+      expect(hand?.className).toContain('flex-wrap');
+      expect(hand?.className).not.toContain('overflow-x-auto');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
 });

--- a/frontend/src/pages/NapoleonPage.tsx
+++ b/frontend/src/pages/NapoleonPage.tsx
@@ -137,7 +137,7 @@ function NapoleonPageContent() {
     hintLoading,
     handleHint,
   } = useNapoleonGame();
-  const { cardWidth } = useCardDimensions();
+  const { cardWidth, isMobile, solitaireMinColWidth } = useCardDimensions();
 
   const [bidValue, setBidValue] = useState(12);
   const [trumpSuitValue, setTrumpSuitValue] = useState(1);
@@ -377,7 +377,10 @@ function NapoleonPageContent() {
       <GameFooter className="bg-game-bg-blue-dark border-white/20 px-4 py-2.5">
         {/* Human cards */}
         {humanPlayer && (
-          <div className="flex flex-wrap gap-1 mb-2" data-tutorial="np-player-hand">
+          <div
+            className={isMobile ? 'flex gap-1 overflow-x-auto mb-2' : 'flex flex-wrap gap-1 mb-2'}
+            data-tutorial="np-player-hand"
+          >
             {humanPlayer.cards.map((card, idx) => (
               <button
                 type="button"
@@ -392,6 +395,7 @@ function NapoleonPageContent() {
                   borderRadius: 8,
                   ...selectedCardStyle(selectedCardIndices.includes(idx)),
                   boxSizing: 'border-box',
+                  ...(isMobile ? { minWidth: solitaireMinColWidth, flexShrink: 0 } : {}),
                 }}
               >
                 <AnimatedCard card={card} width={cardWidth} />

--- a/frontend/src/pages/SpadesPage.test.tsx
+++ b/frontend/src/pages/SpadesPage.test.tsx
@@ -753,4 +753,34 @@ describe('SpadesPage', () => {
     renderWithProviders(<SpadesPage />);
     await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
   });
+
+  it('renders mobile viewport with horizontal scroll hand', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      renderWithProviders(<SpadesPage />);
+      await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+      const hand = document.querySelector('[data-tutorial="sp-player-hand"]');
+      expect(hand?.className).toContain('overflow-x-auto');
+      expect(hand?.className).not.toContain('flex-wrap');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
+
+  it('renders desktop viewport with wrapping hand', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 800 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      renderWithProviders(<SpadesPage />);
+      await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+      const hand = document.querySelector('[data-tutorial="sp-player-hand"]');
+      expect(hand?.className).toContain('flex-wrap');
+      expect(hand?.className).not.toContain('overflow-x-auto');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
 });

--- a/frontend/src/pages/SpadesPage.tsx
+++ b/frontend/src/pages/SpadesPage.tsx
@@ -125,7 +125,7 @@ function SpadesPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('spades', state);
-  const { cardWidth } = useCardDimensions();
+  const { cardWidth, isMobile, solitaireMinColWidth } = useCardDimensions();
   const [bidValue, setBidValue] = useState(1);
 
   const isPlayPhaseForKbd = state?.phase === SpadesPhase.PLAY;
@@ -300,7 +300,10 @@ function SpadesPageContent() {
       <GameFooter className="bg-game-bg-blue-dark border-white/20 px-4 py-2.5">
         {/* Human cards */}
         {humanPlayer && (
-          <div className="flex flex-wrap gap-1 mb-2" data-tutorial="sp-player-hand">
+          <div
+            className={isMobile ? 'flex gap-1 overflow-x-auto mb-2' : 'flex flex-wrap gap-1 mb-2'}
+            data-tutorial="sp-player-hand"
+          >
             {humanPlayer.cards.map((card, idx) => (
               <button
                 type="button"
@@ -315,6 +318,7 @@ function SpadesPageContent() {
                   borderRadius: 8,
                   ...selectedCardStyle(selectedCardIndices.includes(idx)),
                   boxSizing: 'border-box',
+                  ...(isMobile ? { minWidth: solitaireMinColWidth, flexShrink: 0 } : {}),
                 }}
               >
                 <AnimatedCard card={card} width={cardWidth} />


### PR DESCRIPTION
## Summary
- Hearts, Spades, Napoleon, Euchre hand card containers switch from `flex-wrap` to `overflow-x-auto` horizontal scroll on mobile (< 640px)
- Each card button gets `minWidth: 48px` and `flexShrink: 0` on mobile for touch target compliance
- Desktop layout unchanged (flex-wrap)

## Test plan
- [x] Build passes (`bun run build`)
- [x] Biome check passes (`bun run check`)
- [x] All 2963 tests pass (`bun run test`)
- [x] 8 new tests: mobile viewport (375px) verifies `overflow-x-auto`, desktop viewport (800px) verifies `flex-wrap`
- [ ] Manual test on mobile device / DevTools (375px): verify hand cards scroll horizontally

Closes #956