### PR TITLE
fix(frontend): add phase/status bar to Daifugo page

### DIFF
--- a/frontend/src/i18n/locales/en/daifugo.json
+++ b/frontend/src/i18n/locales/en/daifugo.json
@@ -45,6 +45,10 @@
     "suit": "By Suit",
     "number": "By Number"
   },
+  "phase": {
+    "play": "Play",
+    "end": "End"
+  },
   "resultPrefix": "Game Over!",
   "resultEntry": "{{name}}: {{rank}}",
   "settings": {

--- a/frontend/src/i18n/locales/ja/daifugo.json
+++ b/frontend/src/i18n/locales/ja/daifugo.json
@@ -45,6 +45,10 @@
     "suit": "スート順",
     "number": "数字順"
   },
+  "phase": {
+    "play": "プレイ",
+    "end": "終了"
+  },
   "resultPrefix": "ゲーム終了！",
   "resultEntry": "{{name}}:{{rank}}",
   "settings": {

--- a/frontend/src/pages/DaifugoPage.test.tsx
+++ b/frontend/src/pages/DaifugoPage.test.tsx
@@ -119,6 +119,30 @@ describe('DaifugoPage', () => {
     expect(screen.getByTestId('skeleton')).toBeInTheDocument();
   });
 
+  it('shows phase indicator with プレイ during gameplay', async () => {
+    renderWithProviders(<DaifugoPage />);
+    await waitFor(() => {
+      const indicator = screen.getByTestId('phase-indicator');
+      expect(indicator).toHaveTextContent('プレイ');
+    });
+  });
+
+  it('shows あなたのターン when it is human turn', async () => {
+    renderWithProviders(<DaifugoPage />);
+    await waitFor(() => {
+      expect(screen.getByText('あなたのターン')).toBeInTheDocument();
+    });
+  });
+
+  it('shows 終了 phase when game ends', async () => {
+    mockExec.mockResolvedValue(gameEndState);
+    renderWithProviders(<DaifugoPage />);
+    await waitFor(() => {
+      const indicator = screen.getByTestId('phase-indicator');
+      expect(indicator).toHaveTextContent('終了');
+    });
+  });
+
   it('calls reset command on mount', async () => {
     renderWithProviders(<DaifugoPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
@@ -802,9 +826,8 @@ describe('DaifugoPage', () => {
     renderWithProviders(<DaifugoPage />);
     await waitFor(() => {
       const badges = screen.getAllByText('数縛り');
-      // Badge button + settings checkbox label
       expect(badges.length).toBeGreaterThanOrEqual(1);
-      expect(badges[0].tagName).toBe('BUTTON');
+      expect(badges.some((el) => el.tagName === 'BUTTON')).toBe(true);
     });
   });
 
@@ -1123,7 +1146,7 @@ describe('DaifugoPage', () => {
     await waitFor(() => {
       const badges = screen.getAllByText('階段縛り');
       expect(badges.length).toBeGreaterThanOrEqual(1);
-      expect(badges[0].tagName).toBe('BUTTON');
+      expect(badges.some((el) => el.tagName === 'BUTTON')).toBe(true);
     });
   });
 

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -13,6 +13,7 @@ import { GamePageHeading } from '../components/GamePageHeading';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { WinCelebration } from '../components/motion/WinCelebration';
+import { PhaseIndicator } from '../components/PhaseIndicator';
 import { DaifugoSkeleton } from '../components/skeleton/DaifugoSkeleton';
 import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -165,10 +166,11 @@ function DaifugoPageContent() {
   return (
     <div className="flex-1 flex flex-col min-h-0 bg-game-bg-green" aria-busy={loading} aria-live="polite">
       <GamePageHeading title={tc('nav.daifugo')} />
-      <div className="flex items-center justify-end px-4 pt-2">
+      <PhaseIndicator phaseName={state.gameEndFlag ? t('phase.end') : t('phase.play')} isHumanTurn={isHumanTurn}>
         <TutorialButton />
-      </div>
+      </PhaseIndicator>
       <div className="flex-1 overflow-y-auto pt-3 px-4 lg:px-8">
+        <DaifugoSettingsPanel config={configInput} onChange={handleConfigChange} />
         <div className="flex gap-2.5 flex-wrap mb-2.5">
           {cpuPlayers.map((player) => (
             <DaifugoCpuArea key={player.id} player={player} isCurrentTurn={state.currentTurn === player.id} />
@@ -262,8 +264,6 @@ function DaifugoPageContent() {
       </div>
 
       <GameFooter className="bg-game-bg-green-dark border-white/20 px-4 py-2.5">
-        <DaifugoSettingsPanel config={configInput} onChange={handleConfigChange} />
-
         <div className="text-center mb-1" data-tutorial="df-sort-buttons">
           {sortModes.map(({ mode, label }) => (
             <button


### PR DESCRIPTION
## Summary
- Add `PhaseIndicator` component to Daifugo page (shows "プレイ"/"Play" during gameplay, "終了"/"End" when game ends, plus turn indicator)
- Move `TutorialButton` inside `PhaseIndicator` for consistency with other game pages
- Move `DaifugoSettingsPanel` from sticky footer to scrollable content area (already collapsible via `<details>`)
- Add i18n keys for phase names (`phase.play`, `phase.end`) in ja/en

Closes #959

## Test plan
- [x] 3 new tests for PhaseIndicator (play phase, human turn indicator, end phase)
- [x] Fixed 2 existing badge tests that broke due to DOM order change (settings panel labels now appear before badges)
- [x] All 3014 frontend tests pass
- [x] Build and lint clean