### PR TITLE
fix(frontend): collapse payout table by default in Video Poker variants

### DIFF
--- a/frontend/src/components/VideoPokerGameContent.test.tsx
+++ b/frontend/src/components/VideoPokerGameContent.test.tsx
@@ -171,10 +171,13 @@ describe('VideoPokerGameContent', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bet', 5));
   });
 
-  it('renders payout table', async () => {
+  it('renders payout table collapsed by default', async () => {
     mockExec.mockResolvedValue(betPhaseState);
     renderContent();
     await waitFor(() => expect(screen.getByText(/配当表/)).toBeInTheDocument());
+    // Payout table should be collapsed (details element should not have open attribute)
+    const details = screen.getByText(/配当表/).closest('details');
+    expect(details).not.toHaveAttribute('open');
   });
 
   it('clicking card in result phase does not toggle hold', async () => {

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -34,10 +34,10 @@ export interface VideoPokerGameContentProps {
   payoutTableRows: string[];
 }
 
-/** Payout table display component. */
-function PayoutTable({ t, rows, expanded }: { t: (key: string) => string; rows: string[]; expanded?: boolean }) {
+/** Payout table display component (collapsed by default, user can expand on tap). */
+function PayoutTable({ t, rows }: { t: (key: string) => string; rows: string[] }) {
   return (
-    <details className="mb-3 text-center" open={expanded}>
+    <details className="mb-3 text-center">
       <summary className="text-yellow-300 text-sm cursor-pointer lg:text-base">{t('payoutTable.title')}</summary>
       <ul className="text-gray-300 text-xs mt-1 space-y-0.5 lg:text-sm lg:space-y-1">
         {rows.map((row) => (
@@ -168,7 +168,7 @@ export function VideoPokerGameContent({
           <div className="text-white text-center font-bold mb-2">{t('label.payout', { payout: state.payout })}</div>
         )}
 
-        <PayoutTable t={tNs} rows={payoutTableRows} expanded={isBetPhase} />
+        <PayoutTable t={tNs} rows={payoutTableRows} />
 
         {actionLog && <ActionLogPanel entries={actionLog} onClose={hideActionLog} />}
       </div>


### PR DESCRIPTION
## Summary
- Collapse the payout table (`<details>`) by default in all Video Poker variants (Video Poker, Deuces Wild, Joker Poker)
- Previously, the payout table was forced open during the bet phase, occupying ~60% of the mobile viewport and pushing the "Deal" button below the fold
- Users can still expand the table on tap via the `<details>/<summary>` toggle

Closes #961

## Test plan
- [x] Updated test to assert payout table is collapsed by default
- [x] All 3015 frontend tests pass
- [x] `bun run build` passes
- [x] `bun run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)