### PR TITLE
fix(frontend): replace traffic-light button colors with poker-themed palette

### DIFF
--- a/frontend/src/components/BettingControls.test.tsx
+++ b/frontend/src/components/BettingControls.test.tsx
@@ -43,6 +43,20 @@ describe('BettingControls', () => {
     expect(screen.getByRole('button', { name: 'オールイン' })).toBeInTheDocument();
   });
 
+  it('applies poker-themed styles to action buttons', () => {
+    render(<BettingControls {...makeProps({ hasOutstandingBet: true })} />);
+    expect(screen.getByRole('button', { name: 'コール' }).className).toContain('bg-emerald-600');
+    expect(screen.getByRole('button', { name: 'レイズ' }).className).toContain('bg-sky-500');
+    expect(screen.getByRole('button', { name: 'フォールド' }).className).toContain('bg-gray-500');
+    expect(screen.getByRole('button', { name: 'オールイン' }).className).toContain('bg-amber-500');
+  });
+
+  it('applies poker-themed styles to bet/check buttons', () => {
+    render(<BettingControls {...makeProps()} />);
+    expect(screen.getByRole('button', { name: 'ベット' }).className).toContain('bg-sky-500');
+    expect(screen.getByRole('button', { name: 'チェック' }).className).toContain('bg-emerald-600');
+  });
+
   it('disables buttons when loading', () => {
     render(<BettingControls {...makeProps({ loading: true })} />);
     for (const btn of screen.getAllByRole('button')) {

--- a/frontend/src/components/BettingControls.tsx
+++ b/frontend/src/components/BettingControls.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { btnDanger, btnSuccess, btnWarning } from '../styles/buttonStyles';
+import { btnPokerAccent, btnPokerAllIn, btnPokerMuted, btnPokerPrimary } from '../styles/buttonStyles';
 
 interface BettingControlsProps {
   inputId: string;
@@ -58,27 +58,27 @@ export function BettingControls({
       </div>
       {hasOutstandingBet ? (
         <>
-          <button type="button" className={`${btnSuccess} min-w-[80px]`} disabled={loading} onClick={onCall}>
+          <button type="button" className={`${btnPokerPrimary} min-w-[80px]`} disabled={loading} onClick={onCall}>
             {t('action.call')}
           </button>
-          <button type="button" className={`${btnWarning} min-w-[80px]`} disabled={loading} onClick={onRaise}>
+          <button type="button" className={`${btnPokerAccent} min-w-[80px]`} disabled={loading} onClick={onRaise}>
             {t('action.raise')}
           </button>
         </>
       ) : (
         <>
-          <button type="button" className={`${btnWarning} min-w-[80px]`} disabled={loading} onClick={onBet}>
+          <button type="button" className={`${btnPokerAccent} min-w-[80px]`} disabled={loading} onClick={onBet}>
             {t('action.bet')}
           </button>
-          <button type="button" className={`${btnSuccess} min-w-[80px]`} disabled={loading} onClick={onCheck}>
+          <button type="button" className={`${btnPokerPrimary} min-w-[80px]`} disabled={loading} onClick={onCheck}>
             {t('action.check')}
           </button>
         </>
       )}
-      <button type="button" className={`${btnDanger} min-w-[80px]`} disabled={loading} onClick={onFold}>
+      <button type="button" className={`${btnPokerMuted} min-w-[80px]`} disabled={loading} onClick={onFold}>
         {t('action.fold')}
       </button>
-      <button type="button" className={`${btnWarning} min-w-[80px]`} disabled={loading} onClick={onAllIn}>
+      <button type="button" className={`${btnPokerAllIn} min-w-[80px]`} disabled={loading} onClick={onAllIn}>
         {t('action.allIn')}
       </button>
     </div>

--- a/frontend/src/pages/HoldemPage.test.tsx
+++ b/frontend/src/pages/HoldemPage.test.tsx
@@ -745,6 +745,14 @@ describe('HoldemPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, { cpuMetaAI: false }));
   });
 
+  it('uses outline style for reset button', async () => {
+    renderWithProviders(<HoldemPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    const resetBtn = screen.getByRole('button', { name: 'リセット' });
+    expect(resetBtn.className).toContain('bg-transparent');
+    expect(resetBtn.className).toContain('border');
+  });
+
   // ---- loading / disabled state ----
   it('disables buttons while loading', async () => {
     mockExec.mockResolvedValue(preFlopState);

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -24,7 +24,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { TutorialProvider } from '../providers/TutorialProvider';
-import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { btnOutline, btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { HoldemPhase, HoldemRebuyPhaseType } from '../types/phases';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
@@ -465,7 +465,7 @@ function HoldemPageContent() {
           </label>
           <button
             type="button"
-            className={`${btnPrimary} min-w-[90px]`}
+            className={`${btnOutline} min-w-[90px]`}
             disabled={loading}
             onClick={() =>
               requestConfirm(() => {

--- a/frontend/src/pages/OmahaPage.test.tsx
+++ b/frontend/src/pages/OmahaPage.test.tsx
@@ -759,6 +759,14 @@ describe('OmahaPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, { cpuMetaAI: false }));
   });
 
+  it('uses outline style for reset button', async () => {
+    renderWithProviders(<OmahaPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    const resetBtn = screen.getByRole('button', { name: 'リセット' });
+    expect(resetBtn.className).toContain('bg-transparent');
+    expect(resetBtn.className).toContain('border');
+  });
+
   // ---- loading / disabled state ----
   it('disables buttons while loading', async () => {
     mockExec.mockResolvedValue(preFlopState);

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -24,7 +24,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { TutorialProvider } from '../providers/TutorialProvider';
-import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { btnOutline, btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { OmahaPhase, OmahaRebuyPhaseType } from '../types/phases';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
@@ -461,7 +461,7 @@ function OmahaPageContent() {
           </label>
           <button
             type="button"
-            className={`${btnPrimary} min-w-[90px]`}
+            className={`${btnOutline} min-w-[90px]`}
             disabled={loading}
             onClick={() =>
               requestConfirm(() => {

--- a/frontend/src/pages/ShortDeckPage.test.tsx
+++ b/frontend/src/pages/ShortDeckPage.test.tsx
@@ -581,6 +581,14 @@ describe('ShortDeckPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, { cpuMetaAI: false }));
   });
 
+  it('uses outline style for reset button', async () => {
+    renderWithProviders(<ShortDeckPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    const resetBtn = screen.getByRole('button', { name: 'リセット' });
+    expect(resetBtn.className).toContain('bg-transparent');
+    expect(resetBtn.className).toContain('border');
+  });
+
   // ---- loading / disabled state ----
   it('disables buttons while loading', async () => {
     mockExec.mockResolvedValue(preFlopState);

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -24,7 +24,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { TutorialProvider } from '../providers/TutorialProvider';
-import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { btnOutline, btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { HoldemPhase, HoldemRebuyPhaseType } from '../types/phases';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
@@ -465,7 +465,7 @@ function ShortDeckPageContent() {
           </label>
           <button
             type="button"
-            className={`${btnPrimary} min-w-[90px]`}
+            className={`${btnOutline} min-w-[90px]`}
             disabled={loading}
             onClick={() =>
               requestConfirm(() => {

--- a/frontend/src/styles/buttonStyles.ts
+++ b/frontend/src/styles/buttonStyles.ts
@@ -12,6 +12,17 @@ export const btnDanger = `${base} text-white bg-red-600 hover:bg-red-700`;
 /** Secondary (gray) button style. */
 export const btnSecondary = `${base} text-white bg-gray-600 hover:bg-gray-500`;
 
+/** Poker primary (emerald) — call/check action. */
+export const btnPokerPrimary = `${base} text-white bg-emerald-600 hover:bg-emerald-700`;
+/** Poker accent (sky) — raise/bet action. */
+export const btnPokerAccent = `${base} text-white bg-sky-500 hover:bg-sky-600`;
+/** Poker all-in (amber) — high-stakes action. */
+export const btnPokerAllIn = `${base} text-white bg-amber-500 hover:bg-amber-600`;
+/** Poker muted (gray) — fold action. */
+export const btnPokerMuted = `${base} text-white bg-gray-500 hover:bg-gray-600`;
+/** Outline button — minimal visual weight for reset etc. */
+export const btnOutline = `${base} text-gray-300 border border-gray-500 bg-transparent hover:bg-gray-700`;
+
 /** White focus ring style for keyboard navigation. */
 export const focusRingWhite = 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80';
 


### PR DESCRIPTION
## Summary
- Replace green/yellow/red/yellow "traffic light" button colors in Hold'em action buttons with a calmer poker-themed palette: emerald (call/check), sky-blue (raise/bet), amber (all-in), muted gray (fold)
- Convert reset button from solid blue (`btnPrimary`) to transparent outline (`btnOutline`) to reduce visual weight
- Add poker-specific button styles (`btnPokerPrimary`, `btnPokerAccent`, `btnPokerAllIn`, `btnPokerMuted`, `btnOutline`) to `buttonStyles.ts`

Closes #962

## Test plan
- [x] `bun run build` passes
- [x] `bun run check` passes (Biome lint + format)
- [x] `bun run test` passes (3020 tests, including new style assertions)
- [ ] Visual verification on mobile viewport (375x667) for Texas Hold'em, Omaha, Short Deck

🤖 Generated with [Claude Code](https://claude.com/claude-code)