### PR TITLE
fix(frontend): improve tutorial dialog visibility with darker overlay and scroll lock

### DIFF
--- a/frontend/src/components/tutorial/TutorialOverlay.test.tsx
+++ b/frontend/src/components/tutorial/TutorialOverlay.test.tsx
@@ -185,6 +185,20 @@ describe('TutorialOverlay', () => {
     expect(document.activeElement).toBe(buttons[0]);
   });
 
+  it('locks body scroll on mount and restores on unmount', () => {
+    document.body.style.overflow = 'auto';
+    const { unmount } = render(<TutorialOverlay {...defaultProps} />);
+    expect(document.body.style.overflow).toBe('hidden');
+    unmount();
+    expect(document.body.style.overflow).toBe('auto');
+  });
+
+  it('uses darker overlay opacity (0.75)', () => {
+    const { container } = render(<TutorialOverlay {...defaultProps} />);
+    const overlayRect = container.querySelector('svg > rect[mask]');
+    expect(overlayRect).toHaveAttribute('fill', 'rgba(0,0,0,0.75)');
+  });
+
   it('restores focus on unmount', () => {
     const triggerButton = document.createElement('button');
     document.body.appendChild(triggerButton);

--- a/frontend/src/components/tutorial/TutorialOverlay.tsx
+++ b/frontend/src/components/tutorial/TutorialOverlay.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
 import type { TutorialStep } from '../../types/tutorial';
 import { getFocusableElements } from '../ConfirmDialog';
 import { TutorialTooltip } from './TutorialTooltip';
@@ -67,6 +67,15 @@ export function TutorialOverlay({ step, stepIndex, totalSteps, onNext, onSkip, r
   const dialogRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<Element | null>(null);
   const [spotlightRect, setSpotlightRect] = useState<SpotlightRect | null>(null);
+
+  // Lock background scroll while overlay is visible
+  useLayoutEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, []);
 
   // Find and observe the target element
   useEffect(() => {
@@ -174,7 +183,7 @@ export function TutorialOverlay({ step, stepIndex, totalSteps, onNext, onSkip, r
             )}
           </mask>
         </defs>
-        <rect width="100%" height="100%" fill="rgba(0,0,0,0.6)" mask={`url(#tutorial-mask-${maskId})`} />
+        <rect width="100%" height="100%" fill="rgba(0,0,0,0.75)" mask={`url(#tutorial-mask-${maskId})`} />
       </svg>
 
       {/* Tooltip positioned relative to spotlight */}

--- a/frontend/src/components/tutorial/TutorialSuggestDialog.test.tsx
+++ b/frontend/src/components/tutorial/TutorialSuggestDialog.test.tsx
@@ -99,6 +99,20 @@ describe('TutorialSuggestDialog', () => {
     expect(document.activeElement).toBe(focusable[focusable.length - 1]);
   });
 
+  it('locks body scroll when open and restores on close', () => {
+    document.body.style.overflow = 'auto';
+    const { unmount } = render(<TutorialSuggestDialog {...defaultProps} />);
+    expect(document.body.style.overflow).toBe('hidden');
+    unmount();
+    expect(document.body.style.overflow).toBe('auto');
+  });
+
+  it('does not lock body scroll when not open', () => {
+    document.body.style.overflow = 'auto';
+    render(<TutorialSuggestDialog {...defaultProps} open={false} />);
+    expect(document.body.style.overflow).toBe('auto');
+  });
+
   it('has aria-describedby pointing to message paragraph', () => {
     render(<TutorialSuggestDialog {...defaultProps} />);
     const dialog = screen.getByRole('alertdialog');

--- a/frontend/src/components/tutorial/TutorialSuggestDialog.tsx
+++ b/frontend/src/components/tutorial/TutorialSuggestDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { btnPrimary, btnSecondary } from '../../styles/buttonStyles';
 import { getFocusableElements } from '../../utils/dom';
@@ -28,6 +28,16 @@ export function TutorialSuggestDialog({
   const { t } = useTranslation('tutorial');
   const dialogRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<Element | null>(null);
+
+  // Lock background scroll while dialog is visible
+  useLayoutEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;


### PR DESCRIPTION
## Summary
- Increased `TutorialOverlay` background opacity from 0.6 to 0.75 for better contrast against game UI elements
- Added `body.style.overflow = 'hidden'` scroll lock to both `TutorialOverlay` and `TutorialSuggestDialog`, restoring original value on unmount
- Added unit tests for scroll lock behavior and overlay opacity

Closes #964

## Test plan
- [x] `bun run build` passes
- [x] `bun run check` passes (Biome lint + format)
- [x] `bun run test` passes (3030/3030 tests, including 4 new tests)
- [ ] Visual verification on mobile (375x667) that tutorial dialog is readable over Poker/Hold'em/Baccarat game elements