### PR TITLE
docs: sync UML design documents with 26-game codebase

### DIFF
--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -1132,7 +1132,7 @@ stateDiagram-v2
     [*] --> Playing : Reset()
     Playing --> Playing : Move / Draw / Deal / Remove / Undo
     Playing --> GameClear : 全カードをFoundation/Pyramid除去完了
-    Playing --> GameClear : Autocomplete成功
+    Playing --> GameClear : Autocomplete成功 (Klondike/FreeCell/Spider のみ)
     Playing --> GameOver : GiveUp
     GameClear --> [*]
     GameOver --> [*]
@@ -1143,6 +1143,8 @@ stateDiagram-v2
 ```
 
 Pyramid 固有のアクション: `Draw` / `RemovePair` / `RemoveKing` / `RemoveWithWaste` / `RemoveWasteKing` / `Undo`。クリア条件はピラミッドの28枚全除去。
+
+各ゲームのフェーズ定数名: `KlondikePhasePlaying` / `FreeCellPhasePlaying` / `SpiderPhasePlaying` / `PyramidPhasePlaying` = 0、`…GameClear` = 1、`…GameOver` = 2。
 
 ### 3.9 CrazyEights フェーズ遷移
 

--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -299,7 +299,7 @@ classDiagram
         GAME_END = 5
     }
 
-    note for KlondikePhase "KlondikePhase, FreeCellPhase, SpiderPhase,\nPyramidPhase は同一の値を持つ別定数"
+    note for KlondikePhase "KlondikePhase, FreeCellPhase, SpiderPhase, PyramidPhase は、\nそれぞれ同一の値を持つ別定数です"
 ```
 
 ### 1.2 API クライアント層


### PR DESCRIPTION
## Summary

Closes #988

- Update game count 24→26 in `docs/design/backend.md` headings, TOC, and controller/presenter notes (48→52)
- Add note explaining DeucesWild/JokerPoker as VideoPoker variant configs (no separate domain classes)
- Consolidate duplicate Pyramid state machine (§3.16) into §3.8, renumber subsequent sections
- Add explicit `FreeCellPhase` and `SpiderPhase` class entries in `docs/design/frontend.md`

## Test plan

- [ ] Verify Mermaid diagrams render correctly in GitHub markdown preview
- [ ] Confirm no remaining "24ゲーム" or "48 Controller" references in design docs
- [ ] Verify TOC anchor links match section headings after renumbering

🤖 Generated with [Claude Code](https://claude.com/claude-code)