### PR TITLE
fix: prevent layout shift on mobile hamburger menu navigation

### DIFF
--- a/frontend/src/components/NavBar.test.tsx
+++ b/frontend/src/components/NavBar.test.tsx
@@ -306,13 +306,56 @@ describe('NavBar', () => {
       expect(pokerDetails).not.toHaveAttribute('open');
     });
 
+    it('does not close other categories on mousedown inside a category on mobile', () => {
+      const original = window.innerWidth;
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+      window.dispatchEvent(new Event('resize'));
+      renderNavBar('/');
+      fireEvent.click(screen.getByRole('button', { name: i18n.t('nav.openMenu') }));
+
+      const tableDetails = screen.getByText(labelFor('nav.category.table')).closest('details') as HTMLDetailsElement;
+      const pokerDetails = screen.getByText(labelFor('nav.category.poker')).closest('details') as HTMLDetailsElement;
+      expect(tableDetails).toHaveAttribute('open');
+      expect(pokerDetails).toHaveAttribute('open');
+
+      // mousedown on a Poker link — Table category must stay open to prevent layout shift
+      const pokerLink = pokerDetails.querySelector('a') as HTMLElement;
+      fireEvent.mouseDown(pokerLink);
+
+      expect(tableDetails).toHaveAttribute('open');
+      expect(pokerDetails).toHaveAttribute('open');
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: original });
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    it('does not close other categories on mousedown inside a category on medium desktop', () => {
+      const original = window.innerWidth;
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 800 });
+      window.dispatchEvent(new Event('resize'));
+      renderNavBar('/');
+
+      const tableDetails = screen.getByText(labelFor('nav.category.table')).closest('details') as HTMLDetailsElement;
+      const pokerDetails = screen.getByText(labelFor('nav.category.poker')).closest('details') as HTMLDetailsElement;
+      // Force both open to simulate tablet state
+      tableDetails.open = true;
+      pokerDetails.open = true;
+
+      const pokerLink = pokerDetails.querySelector('a') as HTMLElement;
+      fireEvent.mouseDown(pokerLink);
+
+      expect(tableDetails).toHaveAttribute('open');
+      expect(pokerDetails).toHaveAttribute('open');
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: original });
+      window.dispatchEvent(new Event('resize'));
+    });
+
     it('does not close dropdown when clicking inside it', () => {
       renderNavBar('/poker');
       const pokerDetails = screen.getByText(labelFor('nav.category.poker')).closest('details') as HTMLDetailsElement;
       expect(pokerDetails).toHaveAttribute('open');
 
       // Click inside the open dropdown — should stay open
-      const pokerLink = screen.getByRole('link', { name: labelFor('nav.poker') });
+      const pokerLink = pokerDetails.querySelector('a') as HTMLElement;
       fireEvent.mouseDown(pokerLink);
 
       expect(pokerDetails).toHaveAttribute('open');

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -118,9 +118,13 @@ export function NavBar({ soundMuted, onSoundToggle }: NavBarProps = {}) {
     wasOpen.current = isOpen;
   }, [isOpen]);
 
-  // Close nav dropdown on outside click (large desktop only)
+  // Close nav dropdown on outside click (large desktop only).
+  // On mobile/tablet, categories are always-open so this must be skipped
+  // to prevent a layout shift between mousedown and mouseup that causes
+  // clicks to land on the wrong game link.
   useEffect(() => {
     const handleOutsideClick = (e: MouseEvent) => {
+      if (isMobile || isMediumDesktop) return;
       if (!navRef.current) return;
       const openDetails = navRef.current.querySelectorAll('details[open]');
       for (const details of openDetails) {
@@ -131,7 +135,7 @@ export function NavBar({ soundMuted, onSoundToggle }: NavBarProps = {}) {
     };
     document.addEventListener('mousedown', handleOutsideClick);
     return () => document.removeEventListener('mousedown', handleOutsideClick);
-  }, []);
+  }, [isMobile, isMediumDesktop]);
 
   const closeMenu = useCallback(() => {
     setIsOpen(false);


### PR DESCRIPTION
## Summary

- モバイル/タブレットのハンバーガーメニューでゲームリンクをタップすると、ナビゲーションが発火しないバグを修正
- `handleOutsideClick`の`mousedown`リスナーが全画面サイズで動作し、モバイルで常に開いている`<details>`カテゴリを閉じてレイアウトシフトを引き起こしていた
- `mousedown`と`mouseup`の間にレイアウトがシフトし、クリックが別のゲームリンクまたは親DIVに着地してReact Routerのナビゲーションが発火しなかった

## Changes

- `NavBar.tsx`: `handleOutsideClick`にモバイル/タブレットのガードを追加（コメント通り「large desktop only」に修正）
- `NavBar.test.tsx`: モバイル・タブレットでmousedownしても他カテゴリが閉じないことを検証するテスト2件を追加

## Test plan

- [x] NavBar全103テスト通過
- [x] Biome lint/format通過
- [x] Frontend build通過
- [x] Playwrightで全25ゲームのナビゲーション成功を確認（修正前は失敗）