### PR TITLE
fix: run wrangler from repo root to resolve Wasm paths

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -75,8 +75,9 @@ jobs:
           if [ "$IS_PRODUCTION" != "true" ]; then
             SUFFIX="-staging"
           fi
-          cd "workers/${WORKER_NAME}"
-          bunx wrangler deploy --name "go-trumpcards-${WORKER_NAME}${SUFFIX}"
+          bunx wrangler deploy \
+            --config "workers/${WORKER_NAME}/wrangler.toml" \
+            --name "go-trumpcards-${WORKER_NAME}${SUFFIX}"
 
   deploy-pages:
     name: Deploy Frontend (Pages)

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,6 @@ clean-workers:
 	rm -rf build/casino build/classic build/solo
 
 deploy-workers: build-workers
-	cd workers/casino && bunx wrangler deploy
-	cd workers/classic && bunx wrangler deploy
-	cd workers/solo && bunx wrangler deploy
+	bunx wrangler deploy --config workers/casino/wrangler.toml
+	bunx wrangler deploy --config workers/classic/wrangler.toml
+	bunx wrangler deploy --config workers/solo/wrangler.toml

--- a/workers/casino/wrangler.toml
+++ b/workers/casino/wrangler.toml
@@ -1,5 +1,5 @@
 name = "go-trumpcards-casino"
-main = "../../build/casino/worker.mjs"
+main = "build/casino/worker.mjs"
 compatibility_date = "2024-09-23"
 
 [vars]
@@ -8,4 +8,4 @@ CORS_ALLOWED_ORIGINS = ""
 
 [[rules]]
 type = "CompiledWasm"
-globs = ["../../build/casino/*.wasm"]
+globs = ["build/casino/*.wasm"]

--- a/workers/classic/wrangler.toml
+++ b/workers/classic/wrangler.toml
@@ -1,5 +1,5 @@
 name = "go-trumpcards-classic"
-main = "../../build/classic/worker.mjs"
+main = "build/classic/worker.mjs"
 compatibility_date = "2024-09-23"
 
 [vars]
@@ -8,4 +8,4 @@ CORS_ALLOWED_ORIGINS = ""
 
 [[rules]]
 type = "CompiledWasm"
-globs = ["../../build/classic/*.wasm"]
+globs = ["build/classic/*.wasm"]

--- a/workers/solo/wrangler.toml
+++ b/workers/solo/wrangler.toml
@@ -1,5 +1,5 @@
 name = "go-trumpcards-solo"
-main = "../../build/solo/worker.mjs"
+main = "build/solo/worker.mjs"
 compatibility_date = "2024-09-23"
 
 [vars]
@@ -8,4 +8,4 @@ CORS_ALLOWED_ORIGINS = ""
 
 [[rules]]
 type = "CompiledWasm"
-globs = ["../../build/solo/*.wasm"]
+globs = ["build/solo/*.wasm"]


### PR DESCRIPTION
## Summary
- Fix Cloudflare Workers deploy failure: wrangler couldn't resolve `./app.wasm` import when running from `workers/<name>/` with relative `../../build` paths
- Run `wrangler deploy --config workers/<name>/wrangler.toml` from repo root instead
- Update all wrangler.toml paths from `../../build/<name>/` to `build/<name>/`
- Update Makefile deploy targets to match

Fixes the deploy failure from #1013.

## Test plan
- [ ] CI deploy workflow succeeds on merge to develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)