### PR TITLE
fix: remove wrangler rules to fix wasm module resolution

### DIFF
--- a/workers/casino/wrangler.toml
+++ b/workers/casino/wrangler.toml
@@ -5,7 +5,3 @@ compatibility_date = "2024-09-23"
 [vars]
 # Set to your Cloudflare Pages URL, e.g. "https://go-trumpcards.pages.dev"
 CORS_ALLOWED_ORIGINS = ""
-
-[[rules]]
-type = "CompiledWasm"
-globs = ["./build/*.wasm"]

--- a/workers/classic/wrangler.toml
+++ b/workers/classic/wrangler.toml
@@ -5,7 +5,3 @@ compatibility_date = "2024-09-23"
 [vars]
 # Set to your Cloudflare Pages URL, e.g. "https://go-trumpcards.pages.dev"
 CORS_ALLOWED_ORIGINS = ""
-
-[[rules]]
-type = "CompiledWasm"
-globs = ["./build/*.wasm"]

--- a/workers/solo/wrangler.toml
+++ b/workers/solo/wrangler.toml
@@ -5,7 +5,3 @@ compatibility_date = "2024-09-23"
 [vars]
 # Set to your Cloudflare Pages URL, e.g. "https://go-trumpcards.pages.dev"
 CORS_ALLOWED_ORIGINS = ""
-
-[[rules]]
-type = "CompiledWasm"
-globs = ["./build/*.wasm"]


### PR DESCRIPTION
## Summary
Remove custom `[[rules]]` section from wrangler.toml configs. The custom glob `./build/*.wasm` conflicted with wrangler's default `**/*.wasm` rule, causing a build error. The default rule handles wasm imports correctly.

## Test plan
- [ ] CI deploy workflow succeeds on merge to develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)