### PR TITLE
fix: use tinygo -target wasm for Cloudflare Workers runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ define build_worker
 	@echo "Building worker: $(1)"
 	@mkdir -p workers/$(1)/build
 	$(ASSETS_GEN) -mode=tinygo -o workers/$(1)/build
-	$(TINYGO) build -o workers/$(1)/build/app.wasm -target wasi -no-debug -opt=z ./cmd/workers/$(1)
+	$(TINYGO) build -o workers/$(1)/build/app.wasm -target wasm -no-debug -opt=z ./cmd/workers/$(1)
 	$(WASM_OPT) --enable-bulk-memory --enable-nontrapping-float-to-int --enable-sign-ext -Oz workers/$(1)/build/app.wasm -o workers/$(1)/build/app.wasm
 	@RAW=$$(stat -c%s workers/$(1)/build/app.wasm); GZIP=$$(gzip -c workers/$(1)/build/app.wasm | wc -c); \
 	echo "  $(1): $$RAW bytes raw, $$GZIP bytes gzip"


### PR DESCRIPTION
## Summary
Change TinyGo build target from `-target wasi` to `-target wasm`. Cloudflare Workers uses a JS-based runtime, not WASI. The `wasi` target requires `wasi_snapshot_preview1` imports (like `poll_oneoff`) that don't exist in the Workers environment, causing a `LinkError` at runtime.

The `wasm` target (GOOS=js GOARCH=wasm) matches the `syumai/workers` template's expected build mode.

## Test plan
- [ ] CI Workers build passes
- [ ] Deploy to staging succeeds
- [ ] `curl -X POST .../blackjack/exec` returns game response

🤖 Generated with [Claude Code](https://claude.com/claude-code)