### PR TITLE
fix: remove POST method prefix from worker routes for TinyGo

### DIFF
--- a/cmd/workers/casino/main.go
+++ b/cmd/workers/casino/main.go
@@ -23,7 +23,7 @@ func main() {
 			new(presenter.BlackJackWebPresenter),
 		)
 	})
-	mux.HandleFunc("POST /blackjack/exec", bjc.Exec)
+	mux.HandleFunc("/blackjack/exec", bjc.Exec)
 
 	// Baccarat
 	bcc := controller.NewBaccaratWebController(func() usecase.BaccaratInteractorIF {
@@ -32,7 +32,7 @@ func main() {
 			new(presenter.BaccaratWebPresenter),
 		)
 	})
-	mux.HandleFunc("POST /baccarat/exec", bcc.Exec)
+	mux.HandleFunc("/baccarat/exec", bcc.Exec)
 
 	// Poker
 	pkc := controller.NewPokerWebController(func() usecase.PokerInteractorIF {
@@ -46,7 +46,7 @@ func main() {
 		poker := domain.NewPoker(domain.NewTrumpCards(config.JokerCount), players, config)
 		return usecase.NewPokerInteractor(poker, new(presenter.PokerWebPresenter))
 	})
-	mux.HandleFunc("POST /poker/exec", pkc.Exec)
+	mux.HandleFunc("/poker/exec", pkc.Exec)
 
 	// Texas Hold'em
 	hmc := controller.NewHoldemWebController(func() usecase.HoldemInteractorIF {
@@ -54,7 +54,7 @@ func main() {
 		holdem := domain.NewHoldem(domain.NewTrumpCards(0), domain.NewPlayersForTable(cfg.TableSize), cfg)
 		return usecase.NewHoldemInteractor(holdem, new(presenter.HoldemWebPresenter))
 	})
-	mux.HandleFunc("POST /holdem/exec", hmc.Exec)
+	mux.HandleFunc("/holdem/exec", hmc.Exec)
 
 	// Omaha
 	ohc := controller.NewOmahaWebController(func() usecase.OmahaInteractorIF {
@@ -62,7 +62,7 @@ func main() {
 		omaha := domain.NewOmaha(domain.NewTrumpCards(0), domain.NewOmahaPlayersForTable(cfg.TableSize), cfg)
 		return usecase.NewOmahaInteractor(omaha, new(presenter.OmahaWebPresenter))
 	})
-	mux.HandleFunc("POST /omaha/exec", ohc.Exec)
+	mux.HandleFunc("/omaha/exec", ohc.Exec)
 
 	// Short Deck
 	skc := controller.NewShortDeckWebController(func() usecase.ShortDeckInteractorIF {
@@ -70,7 +70,7 @@ func main() {
 		sd := domain.NewShortDeck(domain.NewTrumpCardsShortDeck(), domain.NewShortDeckPlayersForTable(cfg.TableSize), cfg)
 		return usecase.NewShortDeckInteractor(sd, new(presenter.ShortDeckWebPresenter))
 	})
-	mux.HandleFunc("POST /shortdeck/exec", skc.Exec)
+	mux.HandleFunc("/shortdeck/exec", skc.Exec)
 
 	// Indian Poker
 	ipc := controller.NewIndianPokerWebController(func() usecase.IndianPokerInteractorIF {
@@ -78,7 +78,7 @@ func main() {
 		ip := domain.NewIndianPoker(domain.NewTrumpCards(0), domain.NewIndianPokerPlayers(), cfg)
 		return usecase.NewIndianPokerInteractor(ip, new(presenter.IndianPokerWebPresenter))
 	})
-	mux.HandleFunc("POST /indianpoker/exec", ipc.Exec)
+	mux.HandleFunc("/indianpoker/exec", ipc.Exec)
 
 	// Video Poker
 	vpc := controller.NewVideoPokerWebController(func() usecase.VideoPokerInteractorIF {
@@ -87,7 +87,7 @@ func main() {
 			new(presenter.VideoPokerWebPresenter),
 		)
 	})
-	mux.HandleFunc("POST /videopoker/exec", vpc.Exec)
+	mux.HandleFunc("/videopoker/exec", vpc.Exec)
 
 	// Deuces Wild
 	dwc := controller.NewVideoPokerWebController(func() usecase.VideoPokerInteractorIF {
@@ -96,7 +96,7 @@ func main() {
 			new(presenter.VideoPokerWebPresenter),
 		)
 	})
-	mux.HandleFunc("POST /deuceswild/exec", dwc.Exec)
+	mux.HandleFunc("/deuceswild/exec", dwc.Exec)
 
 	// Joker Poker
 	jpc := controller.NewVideoPokerWebController(func() usecase.VideoPokerInteractorIF {
@@ -105,7 +105,7 @@ func main() {
 			new(presenter.VideoPokerWebPresenter),
 		)
 	})
-	mux.HandleFunc("POST /jokerpoker/exec", jpc.Exec)
+	mux.HandleFunc("/jokerpoker/exec", jpc.Exec)
 
 	var handler http.Handler = mux
 	if origins := corsmw.ParseOrigins(os.Getenv("CORS_ALLOWED_ORIGINS")); origins != nil {

--- a/cmd/workers/classic/main.go
+++ b/cmd/workers/classic/main.go
@@ -28,7 +28,7 @@ func main() {
 		hearts := domain.NewHearts(domain.NewTrumpCards(0), players, config)
 		return usecase.NewHeartsInteractor(hearts, new(presenter.HeartsWebPresenter))
 	})
-	mux.HandleFunc("POST /hearts/exec", htc.Exec)
+	mux.HandleFunc("/hearts/exec", htc.Exec)
 
 	// Spades
 	spc := controller.NewSpadesWebController(func() usecase.SpadesInteractorIF {
@@ -42,7 +42,7 @@ func main() {
 		spades := domain.NewSpades(domain.NewTrumpCards(0), players, config)
 		return usecase.NewSpadesInteractor(spades, new(presenter.SpadesWebPresenter))
 	})
-	mux.HandleFunc("POST /spades/exec", spc.Exec)
+	mux.HandleFunc("/spades/exec", spc.Exec)
 
 	// Euchre
 	euc := controller.NewEuchreWebController(func() usecase.EuchreInteractorIF {
@@ -56,7 +56,7 @@ func main() {
 		euchre := domain.NewEuchre(domain.NewTrumpCardsEuchre(), players, config)
 		return usecase.NewEuchreInteractor(euchre, new(presenter.EuchreWebPresenter))
 	})
-	mux.HandleFunc("POST /euchre/exec", euc.Exec)
+	mux.HandleFunc("/euchre/exec", euc.Exec)
 
 	// Napoleon
 	npc := controller.NewNapoleonWebController(func() usecase.NapoleonInteractorIF {
@@ -70,7 +70,7 @@ func main() {
 		napoleon := domain.NewNapoleon(domain.NewTrumpCards(1), players, config)
 		return usecase.NewNapoleonInteractor(napoleon, new(presenter.NapoleonWebPresenter))
 	})
-	mux.HandleFunc("POST /napoleon/exec", npc.Exec)
+	mux.HandleFunc("/napoleon/exec", npc.Exec)
 
 	// Old Maid
 	omc := controller.NewOldMaidWebController(func() usecase.OldMaidInteractorIF {
@@ -83,7 +83,7 @@ func main() {
 		oldMaid := domain.NewOldMaid(domain.NewTrumpCards(1), players)
 		return usecase.NewOldMaidInteractor(oldMaid, new(presenter.OldMaidWebPresenter))
 	})
-	mux.HandleFunc("POST /oldmaid/exec", omc.Exec)
+	mux.HandleFunc("/oldmaid/exec", omc.Exec)
 
 	// Doubt
 	dwc := controller.NewDoubtWebController(func() usecase.DoubtInteractorIF {
@@ -96,7 +96,7 @@ func main() {
 		doubt := domain.NewDoubt(domain.NewTrumpCards(0), players)
 		return usecase.NewDoubtInteractor(doubt, new(presenter.DoubtWebPresenter))
 	})
-	mux.HandleFunc("POST /doubt/exec", dwc.Exec)
+	mux.HandleFunc("/doubt/exec", dwc.Exec)
 
 	// Daifugo
 	dgc := controller.NewDaifugoWebController(func() usecase.DaifugoInteractorIF {
@@ -110,7 +110,7 @@ func main() {
 		daifugo := domain.NewDaifugo(domain.NewTrumpCards(config.JokerCount), players, config)
 		return usecase.NewDaifugoInteractor(daifugo, new(presenter.DaifugoWebPresenter))
 	})
-	mux.HandleFunc("POST /daifugo/exec", dgc.Exec)
+	mux.HandleFunc("/daifugo/exec", dgc.Exec)
 
 	// Sevens
 	sgc := controller.NewSevensWebController(func() usecase.SevensInteractorIF {
@@ -124,7 +124,7 @@ func main() {
 		sevens := domain.NewSevens(domain.NewTrumpCards(config.JokerCount), players, config)
 		return usecase.NewSevensInteractor(sevens, new(presenter.SevensWebPresenter))
 	})
-	mux.HandleFunc("POST /sevens/exec", sgc.Exec)
+	mux.HandleFunc("/sevens/exec", sgc.Exec)
 
 	// Crazy Eights
 	cec := controller.NewCrazyEightsWebController(func() usecase.CrazyEightsInteractorIF {
@@ -138,7 +138,7 @@ func main() {
 		ce := domain.NewCrazyEights(domain.NewTrumpCards(0), players, config)
 		return usecase.NewCrazyEightsInteractor(ce, new(presenter.CrazyEightsWebPresenter))
 	})
-	mux.HandleFunc("POST /crazyeights/exec", cec.Exec)
+	mux.HandleFunc("/crazyeights/exec", cec.Exec)
 
 	var handler http.Handler = mux
 	if origins := corsmw.ParseOrigins(os.Getenv("CORS_ALLOWED_ORIGINS")); origins != nil {

--- a/cmd/workers/solo/main.go
+++ b/cmd/workers/solo/main.go
@@ -21,28 +21,28 @@ func main() {
 		klondike := domain.NewKlondike(domain.NewTrumpCards(0))
 		return usecase.NewKlondikeInteractor(klondike, new(presenter.KlondikeWebPresenter))
 	})
-	mux.HandleFunc("POST /klondike/exec", klc.Exec)
+	mux.HandleFunc("/klondike/exec", klc.Exec)
 
 	// FreeCell
 	fcc := controller.NewFreeCellWebController(func() usecase.FreeCellInteractorIF {
 		freeCell := domain.NewFreeCell(domain.NewTrumpCards(0))
 		return usecase.NewFreeCellInteractor(freeCell, new(presenter.FreeCellWebPresenter))
 	})
-	mux.HandleFunc("POST /freecell/exec", fcc.Exec)
+	mux.HandleFunc("/freecell/exec", fcc.Exec)
 
 	// Spider
 	sdc := controller.NewSpiderWebController(func() usecase.SpiderInteractorIF {
 		spider := domain.NewSpider(domain.NewTrumpCardsWithSuits(domain.SpiderTotalCards, []int{domain.CardDesignSpade}))
 		return usecase.NewSpiderInteractor(spider, new(presenter.SpiderWebPresenter))
 	})
-	mux.HandleFunc("POST /spider/exec", sdc.Exec)
+	mux.HandleFunc("/spider/exec", sdc.Exec)
 
 	// Pyramid
 	pyc := controller.NewPyramidWebController(func() usecase.PyramidInteractorIF {
 		pyramid := domain.NewPyramid(domain.NewTrumpCards(0))
 		return usecase.NewPyramidInteractor(pyramid, new(presenter.PyramidWebPresenter))
 	})
-	mux.HandleFunc("POST /pyramid/exec", pyc.Exec)
+	mux.HandleFunc("/pyramid/exec", pyc.Exec)
 
 	// Memory
 	myc := controller.NewMemoryWebController(func() usecase.MemoryInteractorIF {
@@ -56,7 +56,7 @@ func main() {
 		memory := domain.NewMemory(domain.NewTrumpCards(0), players, config)
 		return usecase.NewMemoryInteractor(memory, new(presenter.MemoryWebPresenter))
 	})
-	mux.HandleFunc("POST /memory/exec", myc.Exec)
+	mux.HandleFunc("/memory/exec", myc.Exec)
 
 	// Gin Rummy
 	grc := controller.NewGinRummyWebController(func() usecase.GinRummyInteractorIF {
@@ -68,7 +68,7 @@ func main() {
 		gr := domain.NewGinRummy(domain.NewTrumpCards(0), players, config)
 		return usecase.NewGinRummyInteractor(gr, new(presenter.GinRummyWebPresenter))
 	})
-	mux.HandleFunc("POST /ginrummy/exec", grc.Exec)
+	mux.HandleFunc("/ginrummy/exec", grc.Exec)
 
 	// Cribbage
 	cbc := controller.NewCribbageWebController(func() usecase.CribbageInteractorIF {
@@ -80,7 +80,7 @@ func main() {
 		cribbage := domain.NewCribbage(domain.NewTrumpCards(0), players, config)
 		return usecase.NewCribbageInteractor(cribbage, new(presenter.CribbageWebPresenter))
 	})
-	mux.HandleFunc("POST /cribbage/exec", cbc.Exec)
+	mux.HandleFunc("/cribbage/exec", cbc.Exec)
 
 	var handler http.Handler = mux
 	if origins := corsmw.ParseOrigins(os.Getenv("CORS_ALLOWED_ORIGINS")); origins != nil {


### PR DESCRIPTION
## Summary
TinyGo's net/http implementation does not support Go 1.22's method-prefixed routing pattern (`"POST /path"`). Change all worker routes from `mux.HandleFunc("POST /game/exec", ...)` to `mux.HandleFunc("/game/exec", ...)`.

The Docker server (`TrumpCardsWeb.go`) continues to use `"POST /path"` since it runs with standard Go.

## Test plan
- [ ] Deploy to staging succeeds
- [ ] `curl -X POST .../blackjack/exec` returns game response (not 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)