### PR TITLE
fix: set actual KV namespace IDs in wrangler.toml

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -73,15 +73,15 @@ jobs:
           CORS_ORIGINS_PROD: ${{ vars.CORS_ALLOWED_ORIGINS_PROD }}
           CORS_ORIGINS_STAGING: ${{ vars.CORS_ALLOWED_ORIGINS_STAGING }}
         run: |
-          SUFFIX=""
+          ENV_FLAG=""
           CORS_ORIGINS="$CORS_ORIGINS_PROD"
           if [ "$IS_PRODUCTION" != "true" ]; then
-            SUFFIX="-staging"
+            ENV_FLAG="--env staging"
             CORS_ORIGINS="$CORS_ORIGINS_STAGING"
           fi
           cd "workers/${WORKER_NAME}"
           bunx wrangler deploy \
-            --name "go-trumpcards-${WORKER_NAME}${SUFFIX}" \
+            $ENV_FLAG \
             --var "CORS_ALLOWED_ORIGINS:${CORS_ORIGINS}"
 
   deploy-pages:

--- a/workers/casino/wrangler.toml
+++ b/workers/casino/wrangler.toml
@@ -2,7 +2,15 @@ name = "go-trumpcards-casino"
 main = "./build/worker.mjs"
 compatibility_date = "2024-09-23"
 
+# Production KV
 [[kv_namespaces]]
 binding = "GAME_SESSIONS"
-id = "TBD_CASINO_KV_ID"
-preview_id = "TBD_CASINO_KV_PREVIEW_ID"
+id = "766288ab9a9441d7975560a003a1f56f"
+preview_id = "b29980931c9a4a60a945876eb7655f48"
+
+[env.staging]
+name = "go-trumpcards-casino-staging"
+
+[[env.staging.kv_namespaces]]
+binding = "GAME_SESSIONS"
+id = "d44d7ffaff4148929c3f27019188a7fc"

--- a/workers/classic/wrangler.toml
+++ b/workers/classic/wrangler.toml
@@ -2,8 +2,15 @@ name = "go-trumpcards-classic"
 main = "./build/worker.mjs"
 compatibility_date = "2024-09-23"
 
-# Placeholder for Phase 2+: KV session persistence (not yet wired in code)
+# Production KV (Phase 2+: not yet wired in code)
 [[kv_namespaces]]
 binding = "GAME_SESSIONS"
-id = "TBD_CLASSIC_KV_ID"
-preview_id = "TBD_CLASSIC_KV_PREVIEW_ID"
+id = "766288ab9a9441d7975560a003a1f56f"
+preview_id = "b29980931c9a4a60a945876eb7655f48"
+
+[env.staging]
+name = "go-trumpcards-classic-staging"
+
+[[env.staging.kv_namespaces]]
+binding = "GAME_SESSIONS"
+id = "d44d7ffaff4148929c3f27019188a7fc"

--- a/workers/solo/wrangler.toml
+++ b/workers/solo/wrangler.toml
@@ -2,8 +2,15 @@ name = "go-trumpcards-solo"
 main = "./build/worker.mjs"
 compatibility_date = "2024-09-23"
 
-# Placeholder for Phase 2+: KV session persistence (not yet wired in code)
+# Production KV (Phase 2+: not yet wired in code)
 [[kv_namespaces]]
 binding = "GAME_SESSIONS"
-id = "TBD_SOLO_KV_ID"
-preview_id = "TBD_SOLO_KV_PREVIEW_ID"
+id = "766288ab9a9441d7975560a003a1f56f"
+preview_id = "b29980931c9a4a60a945876eb7655f48"
+
+[env.staging]
+name = "go-trumpcards-solo-staging"
+
+[[env.staging.kv_namespaces]]
+binding = "GAME_SESSIONS"
+id = "d44d7ffaff4148929c3f27019188a7fc"


### PR DESCRIPTION
## Summary

- Replace TBD placeholder KV namespace IDs with the real `GAME_SESSIONS` namespace
- Same namespace shared across casino, classic, and solo Workers (session keys are prefixed by game name)
- Fixes the deploy failure from #1024

## Test plan

- [ ] Deploy to Cloudflare succeeds for all 3 Workers
- [ ] E2E: Baccarat session persists across requests on staging