### PR TITLE
fix(frontend): add accordion categories to desktop sidebar

### DIFF
--- a/frontend/src/components/DesktopSidebar.test.tsx
+++ b/frontend/src/components/DesktopSidebar.test.tsx
@@ -194,38 +194,47 @@ describe('DesktopSidebar', () => {
   describe('accordion categories', () => {
     it('renders categories as details elements', () => {
       renderSidebar();
-      const details = document.querySelectorAll('details.sidebar-category');
-      expect(details.length).toBe(gameCategories.length);
+      for (const { labelKey } of gameCategories) {
+        const summary = screen.getByText(labelFor(labelKey));
+        expect(summary.closest('details')).toBeInTheDocument();
+      }
     });
 
     it('expands category containing the active game', () => {
       renderSidebar('/poker');
-      const details = document.querySelectorAll('details.sidebar-category');
-      // Poker is in the second category (index 1)
-      expect(details[1]).toHaveAttribute('open');
+      const pokerCategory = screen.getByText(labelFor('nav.category.poker'));
+      expect(pokerCategory.closest('details')).toHaveAttribute('open');
     });
 
     it('collapses categories without the active game', () => {
       renderSidebar('/poker');
-      const details = document.querySelectorAll('details.sidebar-category');
-      // Table games (index 0) should be collapsed
-      expect(details[0]).not.toHaveAttribute('open');
-      // Solitaire (index 4) should be collapsed
-      expect(details[4]).not.toHaveAttribute('open');
+      const tableCategory = screen.getByText(labelFor('nav.category.table'));
+      expect(tableCategory.closest('details')).not.toHaveAttribute('open');
+      const solitaireCategory = screen.getByText(labelFor('nav.category.solitaire'));
+      expect(solitaireCategory.closest('details')).not.toHaveAttribute('open');
     });
 
     it('expands table category by default when on home page', () => {
       renderSidebar('/');
-      const details = document.querySelectorAll('details.sidebar-category');
-      // BlackJack is at "/" in the table category (index 0)
-      expect(details[0]).toHaveAttribute('open');
+      const tableCategory = screen.getByText(labelFor('nav.category.table'));
+      expect(tableCategory.closest('details')).toHaveAttribute('open');
+    });
+
+    it('toggles category open/closed on click', () => {
+      renderSidebar('/poker');
+      const tableCategory = screen.getByText(labelFor('nav.category.table'));
+      expect(tableCategory.closest('details')).not.toHaveAttribute('open');
+      fireEvent.click(tableCategory);
+      expect(tableCategory.closest('details')).toHaveAttribute('open');
+      fireEvent.click(tableCategory);
+      expect(tableCategory.closest('details')).not.toHaveAttribute('open');
     });
   });
 
   describe('search icon', () => {
     it('renders a search icon in the search area', () => {
       renderSidebar();
-      expect(document.querySelector('[data-testid="search-icon"]')).toBeInTheDocument();
+      expect(screen.getByTestId('search-icon')).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/DesktopSidebar.tsx
+++ b/frontend/src/components/DesktopSidebar.tsx
@@ -164,10 +164,10 @@ export function DesktopSidebar({ soundMuted, onSoundToggle }: DesktopSidebarProp
           gameCategories.map(({ labelKey, icon: catIcon, routes }) => {
             const hasActivePage = routes.some(({ path }) => path === pathname);
             return (
-              <details key={labelKey} className="sidebar-category mb-1" open={hasActivePage || undefined}>
+              <details key={labelKey} className="sidebar-category mb-1" open={hasActivePage}>
                 <summary className="text-gray-400 text-[10px] uppercase tracking-wider px-1 py-1 font-semibold flex items-center gap-1 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
                   <span aria-hidden="true">{catIcon}</span> {t(labelKey)}
-                  <span className="ml-auto text-[8px] text-gray-500" aria-hidden="true">
+                  <span className="ml-auto text-[8px] text-gray-500 sidebar-category-chevron" aria-hidden="true">
                     ▶
                   </span>
                 </summary>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -164,11 +164,11 @@ input[type="text"] {
 }
 
 /* Rotate chevron when sidebar category is open */
-.sidebar-category[open] > summary span[aria-hidden="true"]:last-child {
+.sidebar-category[open] .sidebar-category-chevron {
   transform: rotate(90deg);
 }
 
-.sidebar-category > summary span[aria-hidden="true"]:last-child {
+.sidebar-category-chevron {
   transition: transform 150ms ease;
 }
 


### PR DESCRIPTION
## Summary
- Convert desktop sidebar game categories from always-expanded lists to collapsible `<details>/<summary>` accordion elements
- Only the category containing the active game auto-expands, so Solitaire and Rummy categories are visible without scrolling on 800px-height screens
- Add a magnifying glass search icon to improve search box discoverability
- Add chevron indicator (▶/▼) with CSS rotation animation for open/closed state

## Test plan
- [ ] Verify on 1280x800 desktop: only the active category is expanded
- [ ] Verify clicking a category header toggles its open/closed state
- [ ] Verify navigating to a game in a collapsed category auto-expands it
- [ ] Verify search still filters games correctly across all categories
- [ ] Verify favorites section still appears at the top
- [ ] `bun run build && bun run check && bun run test` all pass (3121 tests)

Closes #1001