### PR TITLE
fix: reduce equity Monte Carlo simulations to prevent CPU timeout

### DIFF
--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -20,10 +20,10 @@ import { CPU_DIFFICULTY_OPTIONS, useMemoryGame } from '../hooks/useMemoryGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { TutorialProvider } from '../providers/TutorialProvider';
 import { btnOutline, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
-import { cardAlt } from '../utils/cardAlt';
 import { gameTheme } from '../styles/gameTheme';
 import { MemoryPhase } from '../types/phases';
 import type { TutorialConfig, TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import { playerName } from '../utils/playerUtils';
 
 /** Memory tutorial step definitions. */

--- a/internal/domain/HoldemEquity.go
+++ b/internal/domain/HoldemEquity.go
@@ -7,9 +7,6 @@ import (
 	"time"
 )
 
-// holdemEquitySimulations デフォルトのモンテカルロシミュレーション回数
-const holdemEquitySimulations = 50000
-
 // HoldemEquityResult エクイティ計算結果
 type HoldemEquityResult struct {
 	Equity   float64          // 勝率 (0.0 - 1.0)

--- a/internal/domain/OmahaEquity.go
+++ b/internal/domain/OmahaEquity.go
@@ -4,9 +4,6 @@ import (
 	"math/rand"
 )
 
-// omahaEquitySimulations デフォルトのモンテカルロシミュレーション回数
-const omahaEquitySimulations = 50000
-
 // CalcOmahaEquity モンテカルロシミュレーションによるオマハエクイティ計算
 // humanCards: 人間の手札(4枚), communityCards: コミュニティカード,
 // activePlayers: アクティブ相手プレイヤー数, simulations: シミュレーション回数,

--- a/internal/domain/ShortDeckEquity.go
+++ b/internal/domain/ShortDeckEquity.go
@@ -4,9 +4,6 @@ import (
 	"math/rand"
 )
 
-// shortDeckEquitySimulations デフォルトのモンテカルロシミュレーション回数
-const shortDeckEquitySimulations = 50000
-
 // CalcShortDeckEquity モンテカルロシミュレーションによるショートデックエクイティ計算
 // humanCards: 人間の手札(2枚), communityCards: コミュニティカード,
 // activePlayers: アクティブ相手プレイヤー数, simulations: シミュレーション回数,

--- a/internal/domain/equity_simulations.go
+++ b/internal/domain/equity_simulations.go
@@ -1,0 +1,12 @@
+//go:build !js
+
+package domain
+
+// エクイティ計算のモンテカルロシミュレーション回数 (ネイティブビルド)。
+// 50000回では Free tier サーバー (Render等) でリクエストタイムアウトが発生するため
+// 2000回に削減。精度は±3%程度でゲームプレイには十分。
+const (
+	holdemEquitySimulations    = 2000
+	omahaEquitySimulations     = 2000
+	shortDeckEquitySimulations = 2000
+)

--- a/internal/domain/equity_simulations_wasm.go
+++ b/internal/domain/equity_simulations_wasm.go
@@ -1,0 +1,12 @@
+//go:build js && wasm
+
+package domain
+
+// エクイティ計算のモンテカルロシミュレーション回数 (Cloudflare Workers / TinyGo WASM)。
+// ネイティブビルドでは2000回だが、Workers の CPU 時間制限 (10-30ms) では
+// 重いモンテカルロシミュレーションがタイムアウトするため200回に抑える。
+const (
+	holdemEquitySimulations    = 200
+	omahaEquitySimulations     = 200
+	shortDeckEquitySimulations = 200
+)


### PR DESCRIPTION
## Summary
- Holdem/Omaha/ShortDeck games were returning 503 on Cloudflare Workers (error 1102 = CPU time exceeded) and timing out on Render free tier due to **50,000 Monte Carlo equity simulations** per API response
- Split simulation count constants into build-tagged files:
  - Native (`!js`): 2,000 simulations (~1s on free tier servers)
  - WASM (`js && wasm`): 200 simulations (fits within Workers CPU limits)
- Fix biome import ordering in MemoryPage.tsx

## Test plan
- [x] All Go tests pass (`go test -tags test ./...`)
- [x] Native and WASM builds compile
- [x] `golangci-lint run ./...` clean
- [x] `bun run check` passes
- [ ] Verify holdem/omaha/shortdeck return 200 on Cloudflare after deploy
- [ ] Verify holdem/omaha/shortdeck return 200 on Render after deploy