### PR TITLE
fix: improve CLI UX and frontend accessibility (#1064-#1071)

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -165,7 +165,7 @@ ENVIRONMENT VARIABLES:
 		"threecard":   func() int { ui.NewThreeCardCui().Exec(); return 0 },
 		"ohhell":      func() int { ui.NewOhHellCui().Exec(); return 0 },
 		"update": func() int {
-			updater := update.NewUpdater(version, os.Stdin, os.Stdout, os.Stderr)
+			updater := update.NewUpdater(version, os.Stdin, os.Stderr, os.Stderr)
 			if err := updater.Exec(); err != nil {
 				return 1
 			}
@@ -201,7 +201,7 @@ ENVIRONMENT VARIABLES:
 	}
 
 	// No argument: start interactive multi-game mode (defaults to blackjack).
-	fmt.Printf("trumpcards %s - Interactive Mode\n", version)
+	fmt.Println(i18n.Tf("cliStartupBanner", "version", version))
 	manager := ui.NewGameManager("blackjack")
 	ui.RunInteractiveCuiLoop(manager)
 	return 0

--- a/frontend/src/components/ConfirmDialog.test.tsx
+++ b/frontend/src/components/ConfirmDialog.test.tsx
@@ -63,17 +63,17 @@ describe('ConfirmDialog', () => {
     expect(onCancel).not.toHaveBeenCalled();
   });
 
-  it('calls onCancel when Escape key is pressed on dialog', () => {
+  it('calls onCancel when Escape key is pressed at document level', () => {
     const onCancel = vi.fn();
     render(<ConfirmDialog {...defaultProps({ onCancel })} />);
-    fireEvent.keyDown(screen.getByRole('alertdialog'), { key: 'Escape' });
+    fireEvent.keyDown(document, { key: 'Escape' });
     expect(onCancel).toHaveBeenCalledOnce();
   });
 
-  it('does not call onCancel for non-Escape key on dialog', () => {
+  it('does not call onCancel for non-Escape key at document level', () => {
     const onCancel = vi.fn();
     render(<ConfirmDialog {...defaultProps({ onCancel })} />);
-    fireEvent.keyDown(screen.getByRole('alertdialog'), { key: 'Enter' });
+    fireEvent.keyDown(document, { key: 'Enter' });
     expect(onCancel).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -35,6 +35,10 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
     first.focus();
 
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        props.onCancel();
+        return;
+      }
       if (e.key !== 'Tab') return;
       if (e.shiftKey) {
         if (document.activeElement === first) {
@@ -49,14 +53,14 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
       }
     };
 
-    dialog.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('keydown', handleKeyDown);
     return () => {
-      dialog.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('keydown', handleKeyDown);
       if (triggerRef.current instanceof HTMLElement) {
         triggerRef.current.focus();
       }
     };
-  }, [props.open]);
+  }, [props.open, props.onCancel]);
 
   if (!props.open) return null;
 
@@ -67,6 +71,7 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
       onClick={props.onCancel}
       role="presentation"
     >
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: keyboard events handled at document level via useEffect */}
       <div
         ref={dialogRef}
         role="alertdialog"
@@ -74,9 +79,6 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
         aria-labelledby="confirm-dialog-title"
         className="glass-panel rounded-lg shadow-xl p-6 max-w-sm mx-4"
         onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => {
-          if (e.key === 'Escape') props.onCancel();
-        }}
       >
         <h2 id="confirm-dialog-title" className="text-lg font-bold text-white mb-2">
           {props.title}

--- a/frontend/src/components/LandscapeBanner.test.tsx
+++ b/frontend/src/components/LandscapeBanner.test.tsx
@@ -22,9 +22,9 @@ describe('LandscapeBanner', () => {
     expect(banner?.className).toContain('sm:hidden');
   });
 
-  it('has animate-pulse class on icon for attention', () => {
+  it('has animate-pulse-once class on icon for limited attention', () => {
     const { container } = render(<LandscapeBanner message="Test" />);
     const icon = container.querySelector('svg');
-    expect(icon?.getAttribute('class')).toContain('animate-pulse');
+    expect(icon?.getAttribute('class')).toContain('animate-pulse-once');
   });
 });

--- a/frontend/src/components/LandscapeBanner.tsx
+++ b/frontend/src/components/LandscapeBanner.tsx
@@ -19,7 +19,7 @@ export function LandscapeBanner({ message }: LandscapeBannerProps) {
         strokeLinecap="round"
         strokeLinejoin="round"
         aria-hidden="true"
-        className="flex-shrink-0 animate-pulse"
+        className="flex-shrink-0 animate-pulse-once"
       >
         <rect x="4" y="2" width="16" height="20" rx="2" ry="2" />
         <line x1="12" y1="18" x2="12.01" y2="18" />

--- a/frontend/src/components/ScrollFadeHint.test.tsx
+++ b/frontend/src/components/ScrollFadeHint.test.tsx
@@ -18,4 +18,14 @@ describe('ScrollFadeHint', () => {
     const { container } = render(<ScrollFadeHint />);
     expect(container.firstElementChild?.className).toContain('pointer-events-none');
   });
+
+  it('uses from-black/50 gradient for dark background visibility', () => {
+    const { container } = render(<ScrollFadeHint />);
+    expect(container.firstElementChild?.className).toContain('from-black/50');
+  });
+
+  it('has w-8 width for sufficient gradient visibility', () => {
+    const { container } = render(<ScrollFadeHint />);
+    expect(container.firstElementChild?.className).toContain('w-8');
+  });
 });

--- a/frontend/src/components/ScrollFadeHint.tsx
+++ b/frontend/src/components/ScrollFadeHint.tsx
@@ -2,7 +2,7 @@
 export function ScrollFadeHint() {
   return (
     <div
-      className="pointer-events-none absolute right-0 top-0 bottom-0 w-6 bg-gradient-to-l from-black/30 to-transparent sm:hidden"
+      className="pointer-events-none absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-black/50 to-transparent sm:hidden"
       aria-hidden="true"
     />
   );

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -107,7 +107,8 @@
     "waiting": "Waiting"
   },
   "card": {
-    "back": "Card back"
+    "back": "Card back",
+    "joker": "Joker"
   },
   "label": {
     "result": "Result:",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -107,7 +107,8 @@
     "waiting": "待機中"
   },
   "card": {
-    "back": "カード裏面"
+    "back": "カード裏面",
+    "joker": "ジョーカー"
   },
   "label": {
     "result": "結果:",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -224,9 +224,23 @@ input[type="text"] {
   transform: rotateY(180deg);
 }
 
+@keyframes pulse-once {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+.animate-pulse-once {
+  animation: pulse-once 1s ease-in-out 2;
+}
+
 /* Respect reduced motion preferences */
 @media (prefers-reduced-motion: reduce) {
   .animate-pulse,
+  .animate-pulse-once,
   .animate-shake,
   .animate-flipIn,
   .animate-sweat-drop {

--- a/frontend/src/utils/cardAlt.test.ts
+++ b/frontend/src/utils/cardAlt.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest';
+import i18n from '../i18n';
 import type { CardDesign } from '../types/card';
 import { cardAlt } from './cardAlt';
 
 describe('cardAlt', () => {
-  it('returns ジョーカー for JOKER', () => {
-    expect(cardAlt({ design: 'JOKER', value: 0 })).toBe('ジョーカー');
+  it('returns localized joker text for JOKER', () => {
+    expect(cardAlt({ design: 'JOKER', value: 0 })).toBe(i18n.t('common:card.joker'));
   });
 
   it.each<[CardDesign, string]>([

--- a/frontend/src/utils/cardAlt.ts
+++ b/frontend/src/utils/cardAlt.ts
@@ -1,3 +1,4 @@
+import i18n from '../i18n';
 import type { Card } from '../types/card';
 import { valueName } from './cardUtils';
 
@@ -8,9 +9,9 @@ const DESIGN_SYMBOLS: Record<string, string> = {
   CLOVER: '♣',
 };
 
-/** Return accessible alt text for a card: "ジョーカー" for jokers, "♠ A" style for normal cards. */
+/** Return accessible alt text for a card: localized "Joker" for jokers, "♠ A" style for normal cards. */
 export function cardAlt(card: Card): string {
-  if (card.design === 'JOKER') return 'ジョーカー';
+  if (card.design === 'JOKER') return i18n.t('common:card.joker');
   const symbol = DESIGN_SYMBOLS[card.design] ?? card.design;
   return `${symbol} ${valueName(card.value)}`;
 }

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -33,6 +33,7 @@
   "didYouMean": "Did you mean \"{{name}}\"?",
   "cliUnsupportedLang": "Warning: unsupported language \"{{lang}}\", defaulting to ja",
   "emptyInputHint": "Type 'help' for available commands.",
+  "cliStartupBanner": "trumpcards {{version}} - Interactive Mode",
   "cliExtraArgsWarning": "Warning: extra arguments ignored: {{args}}",
   "metaAIRequired": "Meta-AI setting is required (0=off, 1=on).",
   "invalidMetaAI": "Invalid value: {{val}}. Please enter 0 or 1."

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -33,6 +33,7 @@
   "didYouMean": "もしかして「{{name}}」ですか？",
   "cliUnsupportedLang": "警告: サポートされていない言語「{{lang}}」です。ja をデフォルトとして使用します",
   "emptyInputHint": "'help' でコマンド一覧を表示します。",
+  "cliStartupBanner": "trumpcards {{version}} - インタラクティブモード",
   "cliExtraArgsWarning": "警告: 余分な引数は無視されました: {{args}}",
   "metaAIRequired": "メタAI設定が必要です (0=オフ, 1=オン)。",
   "invalidMetaAI": "無効な値です: {{val}}。0 または 1 を入力してください。"

--- a/internal/infrastructure/ui/cui_runner.go
+++ b/internal/infrastructure/ui/cui_runner.go
@@ -22,10 +22,15 @@ func setupSignalHandler() {
 		sigCh := make(chan os.Signal, 1)
 		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 		go func() {
-			<-sigCh
+			sig := <-sigCh
 			signal.Stop(sigCh)
 			fmt.Println("\n" + i18n.T("bye"))
-			os.Exit(0)
+			// POSIX convention: exit code = 128 + signal number
+			exitCode := 128
+			if sigNum, ok := sig.(syscall.Signal); ok {
+				exitCode += int(sigNum)
+			}
+			os.Exit(exitCode)
 		}()
 	})
 }


### PR DESCRIPTION
## Summary

- **#1064**: SIGINT exit code changed from `os.Exit(0)` to POSIX-compliant `128 + signal number` (130 for SIGINT)
- **#1065**: Interactive mode startup banner (`trumpcards <version> - Interactive Mode`) now uses `i18n.Tf("cliStartupBanner", ...)` with ja/en translations
- **#1066**: Update command's `Updater` writer changed from `os.Stdout` to `os.Stderr` so progress/prompts don't pollute stdout
- **#1068**: `cardAlt()` joker text changed from hardcoded `'ジョーカー'` to `i18n.t('common:card.joker')` with ja/en translations
- **#1069**: `ConfirmDialog` Escape key handler moved from inline `onKeyDown` on dialog div to `document.addEventListener` in `useEffect`, ensuring Escape works even if focus escapes the dialog
- **#1070**: `LandscapeBanner` icon animation changed from infinite `animate-pulse` to `animate-pulse-once` (2 cycles then stops), with `prefers-reduced-motion` support
- **#1071**: `ScrollFadeHint` gradient increased from `from-black/30 w-6` to `from-black/50 w-8` for better visibility on dark game backgrounds

Closes #1064, Closes #1065, Closes #1066, Closes #1068, Closes #1069, Closes #1070, Closes #1071

## Test plan

- [x] `go build ./...` passes
- [x] `go test -tags test ./internal/i18n/...` passes
- [x] `golangci-lint run` passes (0 issues)
- [x] `bun run build` passes
- [x] `bun run check` passes (Biome lint clean)
- [x] `bun run test` passes (3244 tests, 165 test files)
- [ ] Manual: run `go run ./cmd/trumpcards` and verify Japanese startup banner with `--lang ja`
- [ ] Manual: run `go run ./cmd/trumpcards --lang en` and verify English startup banner
- [ ] Manual: Ctrl+C in CLI and verify `echo $?` returns 130
- [ ] Manual: verify LandscapeBanner icon pulses twice then stops on mobile portrait
- [ ] Manual: verify ScrollFadeHint gradient is visible on dark game backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)