### PR TITLE
fix: correct BridgeBidEntry field names to match API response

### DIFF
--- a/frontend/src/pages/BridgePage.test.tsx
+++ b/frontend/src/pages/BridgePage.test.tsx
@@ -116,9 +116,9 @@ const gameEndByFlagState: BridgeResponse = {
 const bidHistoryState: BridgeResponse = {
   ...bidPhaseState,
   bidHistory: [
-    { playerIdx: 0, bidType: 1, bidLevel: 1, bidSuit: 5 },
-    { playerIdx: 1, bidType: 0, bidLevel: 0, bidSuit: 0 },
-    { playerIdx: 2, bidType: 2, bidLevel: 0, bidSuit: 0 },
+    { playerIdx: 0, bidType: 1, level: 1, suit: 5 },
+    { playerIdx: 1, bidType: 0, level: 0, suit: 0 },
+    { playerIdx: 2, bidType: 2, level: 0, suit: 0 },
   ],
 };
 

--- a/frontend/src/pages/BridgePage.tsx
+++ b/frontend/src/pages/BridgePage.tsx
@@ -215,7 +215,7 @@ export function BridgePage() {
                           ? t('doubleButton')
                           : entry.bidType === 3
                             ? t('redoubleButton')
-                            : `${entry.bidLevel}${suitLabel(entry.bidSuit)}`}
+                            : `${entry.level}${suitLabel(entry.suit)}`}
                     </span>
                   ))}
                 </div>

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -1216,8 +1216,8 @@ export interface BridgeTrickCard {
 export interface BridgeBidEntry {
   playerIdx: number;
   bidType: number;
-  bidLevel: number;
-  bidSuit: number;
+  level: number;
+  suit: number;
 }
 
 /** Bridge game configuration. */


### PR DESCRIPTION
## Summary

- Fix JSON field name mismatch in `BridgeBidEntry` type: `bidLevel`/`bidSuit` → `level`/`suit` to match the Go backend's `json:"level"` / `json:"suit"` tags
- This caused "undefined" to appear in the Bridge bid history for normal bids (bidType=1)

Closes #1094

## Test plan

- [x] `bun run build` passes
- [x] `bun run check` passes
- [x] All 27 BridgePage unit tests pass
- [ ] Manual verification: play Bridge, make bids, verify bid history shows correct level and suit