### PR TITLE
refactor: extract buildBase and buildTrickCards in Web Presenters

### DIFF
--- a/internal/adapter/presenter/BridgeWebPresenter.go
+++ b/internal/adapter/presenter/BridgeWebPresenter.go
@@ -13,6 +13,13 @@ type BridgeWebPresenter struct{}
 
 // Output ゲーム状態をJSON出力
 func (p *BridgeWebPresenter) Output(b interfaces.BridgeGame, lastErr error) string {
+	resObj := p.buildBase(b)
+	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(b, b.GetCurrentTrick(), lastErr)
+	return marshalOrError(resObj)
+}
+
+// buildBase 共通フィールドを構築
+func (p *BridgeWebPresenter) buildBase(b interfaces.BridgeGame) *controller.BridgeWebOutput {
 	resObj := new(controller.BridgeWebOutput)
 	resObj.Phase = int(b.GetPhase())
 	resObj.RoundNumber = b.GetRoundNumber()
@@ -45,12 +52,9 @@ func (p *BridgeWebPresenter) Output(b interfaces.BridgeGame, lastErr error) stri
 	}
 
 	resObj.BidHistory = p.buildBidHistoryOutput(b.GetBidHistory())
-	trick := b.GetCurrentTrick()
-	resObj.CurrentTrick = p.buildTrickOutput(trick)
+	resObj.CurrentTrick = p.buildTrickOutput(b.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(b)
-	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(b, trick, lastErr)
-
-	return marshalOrError(resObj)
+	return resObj
 }
 
 // buildBidHistoryOutput ビッド履歴を構築
@@ -69,14 +73,9 @@ func (p *BridgeWebPresenter) buildBidHistoryOutput(history []*domain.BridgeBidEn
 
 // buildTrickOutput 現在のトリック情報を構築
 func (p *BridgeWebPresenter) buildTrickOutput(trick []*domain.BridgeTrickCard) []*controller.BridgeWebOutputTrickCard {
-	out := make([]*controller.BridgeWebOutputTrickCard, 0)
-	for _, tc := range trick {
-		out = append(out, &controller.BridgeWebOutputTrickCard{
-			PlayerIdx: tc.PlayerIdx,
-			Card:      cardToOutput(tc.Card),
-		})
-	}
-	return out
+	return buildTrickCards(trick, func(tc *domain.BridgeTrickCard) *controller.BridgeWebOutputTrickCard {
+		return &controller.BridgeWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
+	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -128,37 +127,7 @@ func (p *BridgeWebPresenter) buildMessage(b interfaces.BridgeGame, trick []*doma
 // HintOutput ヒント情報をJSON出力する
 func (p *BridgeWebPresenter) HintOutput(b interfaces.BridgeGame) string {
 	hint := b.GetHint()
-	resObj := new(controller.BridgeWebOutput)
-	resObj.Phase = int(b.GetPhase())
-	resObj.RoundNumber = b.GetRoundNumber()
-	resObj.TrickNumber = b.GetTrickNumber()
-	resObj.CurrentPlayerIdx = b.GetCurrentPlayerIdx()
-	resObj.BidPlayerIdx = b.GetBidPlayerIdx()
-	resObj.DealerIdx = b.GetDealerIdx()
-	resObj.TrumpSuit = trumpSuitForAPI(b.GetTrumpSuit(), b.GetContractSuit())
-	resObj.ContractLevel = b.GetContractLevel()
-	resObj.ContractSuit = b.GetContractSuit()
-	resObj.Doubled = b.GetDoubled()
-	resObj.DeclarerIdx = b.GetDeclarerIdx()
-	resObj.DummyIdx = b.GetDummyIdx()
-	resObj.Vulnerability = [2]bool{b.GetVulnerability(0), b.GetVulnerability(1)}
-	resObj.TeamScores = [2]int{b.GetTeamScore(0), b.GetTeamScore(1)}
-	resObj.GamesWon = [2]int{b.GetGamesWon(0), b.GetGamesWon(1)}
-	resObj.BelowLine = [2]int{b.GetBelowLine(0), b.GetBelowLine(1)}
-	resObj.GameEndFlag = b.GetGameEndFlag()
-	resObj.WinnerTeam = b.GetWinnerTeam()
-	resObj.LeadPlayerIdx = b.GetLeadPlayerIdx()
-	resObj.OpeningLeadDone = b.IsOpeningLeadDone()
-	resObj.DummyHand = cardsToOutputOrEmpty(b.GetDummyHand())
-	cfg := b.GetConfig()
-	resObj.Config = controller.BridgeWebOutputConfig{
-		CpuDifficulty: int(cfg.CpuDifficulty),
-	}
-	resObj.BidHistory = p.buildBidHistoryOutput(b.GetBidHistory())
-	trick := b.GetCurrentTrick()
-	resObj.CurrentTrick = p.buildTrickOutput(trick)
-	resObj.Players = p.buildPlayersOutput(b)
-
+	resObj := p.buildBase(b)
 	if hint != nil {
 		resObj.Hint = &controller.BridgeWebOutputHint{
 			CardIndex: hint.CardIndex,

--- a/internal/adapter/presenter/EuchreWebPresenter.go
+++ b/internal/adapter/presenter/EuchreWebPresenter.go
@@ -13,6 +13,13 @@ type EuchreWebPresenter struct{}
 
 // Output ゲーム状態をJSON出力
 func (p *EuchreWebPresenter) Output(e interfaces.EuchreGame, lastErr error) string {
+	resObj := p.buildBase(e)
+	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(e, e.GetCurrentTrick(), lastErr)
+	return marshalOrError(resObj)
+}
+
+// buildBase 共通フィールドを構築
+func (p *EuchreWebPresenter) buildBase(e interfaces.EuchreGame) *controller.EuchreWebOutput {
 	resObj := new(controller.EuchreWebOutput)
 	resObj.Phase = int(e.GetPhase())
 	resObj.RoundNumber = e.GetRoundNumber()
@@ -37,24 +44,16 @@ func (p *EuchreWebPresenter) Output(e interfaces.EuchreGame, lastErr error) stri
 		PointLimit:    cfg.PointLimit,
 	}
 
-	trick := e.GetCurrentTrick()
-	resObj.CurrentTrick = p.buildTrickOutput(trick)
+	resObj.CurrentTrick = p.buildTrickOutput(e.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(e)
-	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(e, trick, lastErr)
-
-	return marshalOrError(resObj)
+	return resObj
 }
 
 // buildTrickOutput 現在のトリック情報を構築
 func (p *EuchreWebPresenter) buildTrickOutput(trick []*domain.EuchreTrickCard) []*controller.EuchreWebOutputTrickCard {
-	out := make([]*controller.EuchreWebOutputTrickCard, 0)
-	for _, tc := range trick {
-		out = append(out, &controller.EuchreWebOutputTrickCard{
-			PlayerIdx: tc.PlayerIdx,
-			Card:      cardToOutput(tc.Card),
-		})
-	}
-	return out
+	return buildTrickCards(trick, func(tc *domain.EuchreTrickCard) *controller.EuchreWebOutputTrickCard {
+		return &controller.EuchreWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
+	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -110,31 +109,7 @@ func (p *EuchreWebPresenter) buildMessage(e interfaces.EuchreGame, trick []*doma
 // HintOutput ヒント情報をJSON出力する
 func (p *EuchreWebPresenter) HintOutput(e interfaces.EuchreGame) string {
 	hint := e.GetHint()
-	resObj := new(controller.EuchreWebOutput)
-	resObj.Phase = int(e.GetPhase())
-	resObj.RoundNumber = e.GetRoundNumber()
-	resObj.TrickNumber = e.GetTrickNumber()
-	resObj.CurrentPlayerIdx = e.GetCurrentPlayerIdx()
-	resObj.BidPlayerIdx = e.GetBidPlayerIdx()
-	resObj.DealerIdx = e.GetDealerIdx()
-	resObj.TrumpSuit = e.GetTrumpSuit()
-	resObj.FaceUpCard = cardToOutput(e.GetFaceUpCard())
-	resObj.MakerTeam = e.GetMakerTeam()
-	resObj.GoingAlone = e.GetGoingAlone()
-	resObj.GoingAlonePlayerIdx = e.GetGoingAlonePlayerIdx()
-	resObj.TeamScores = [2]int{e.GetTeamScore(0), e.GetTeamScore(1)}
-	resObj.GameEndFlag = e.GetGameEndFlag()
-	resObj.WinnerTeam = e.GetWinnerTeam()
-	resObj.LeadPlayerIdx = e.GetLeadPlayerIdx()
-	cfg := e.GetConfig()
-	resObj.Config = controller.EuchreWebOutputConfig{
-		CpuDifficulty: int(cfg.CpuDifficulty),
-		PointLimit:    cfg.PointLimit,
-	}
-	trick := e.GetCurrentTrick()
-	resObj.CurrentTrick = p.buildTrickOutput(trick)
-	resObj.Players = p.buildPlayersOutput(e)
-
+	resObj := p.buildBase(e)
 	if hint != nil {
 		resObj.Hint = &controller.EuchreWebOutputHint{
 			CardIndex: hint.CardIndex,

--- a/internal/adapter/presenter/HeartsWebPresenter.go
+++ b/internal/adapter/presenter/HeartsWebPresenter.go
@@ -11,6 +11,13 @@ type HeartsWebPresenter struct{}
 
 // Output ゲーム状態をJSON出力
 func (p *HeartsWebPresenter) Output(h interfaces.HeartsGame, lastErr error) string {
+	resObj := p.buildBase(h)
+	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(h, h.GetCurrentTrick(), lastErr)
+	return marshalOrError(resObj)
+}
+
+// buildBase 共通フィールドを構築
+func (p *HeartsWebPresenter) buildBase(h interfaces.HeartsGame) *controller.HeartsWebOutput {
 	resObj := new(controller.HeartsWebOutput)
 	resObj.Phase = int(h.GetPhase())
 	resObj.RoundNumber = h.GetRoundNumber()
@@ -30,24 +37,16 @@ func (p *HeartsWebPresenter) Output(h interfaces.HeartsGame, lastErr error) stri
 		OmnibusJD:     cfg.OmnibusJD,
 	}
 
-	trick := h.GetCurrentTrick()
-	resObj.CurrentTrick = p.buildTrickOutput(trick)
+	resObj.CurrentTrick = p.buildTrickOutput(h.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(h)
-	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(h, trick, lastErr)
-
-	return marshalOrError(resObj)
+	return resObj
 }
 
 // buildTrickOutput 現在のトリック情報を構築
 func (p *HeartsWebPresenter) buildTrickOutput(trick []*domain.HeartsTrickCard) []*controller.HeartsWebOutputTrickCard {
-	out := make([]*controller.HeartsWebOutputTrickCard, 0)
-	for _, tc := range trick {
-		out = append(out, &controller.HeartsWebOutputTrickCard{
-			PlayerIdx: tc.PlayerIdx,
-			Card:      cardToOutput(tc.Card),
-		})
-	}
-	return out
+	return buildTrickCards(trick, func(tc *domain.HeartsTrickCard) *controller.HeartsWebOutputTrickCard {
+		return &controller.HeartsWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
+	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -99,26 +98,7 @@ func (p *HeartsWebPresenter) buildMessage(h interfaces.HeartsGame, trick []*doma
 // HintOutput ヒント情報をJSON出力する
 func (p *HeartsWebPresenter) HintOutput(h interfaces.HeartsGame) string {
 	hint := h.GetHint()
-	resObj := new(controller.HeartsWebOutput)
-	resObj.Phase = int(h.GetPhase())
-	resObj.RoundNumber = h.GetRoundNumber()
-	resObj.TrickNumber = h.GetTrickNumber()
-	resObj.CurrentPlayerIdx = h.GetCurrentPlayerIdx()
-	resObj.HeartsBroken = h.GetHeartsBroken()
-	resObj.PassDirection = int(h.GetPassDirection())
-	resObj.GameEndFlag = h.GetGameEndFlag()
-	resObj.WinnerIdx = h.GetWinnerIdx()
-	resObj.LeadPlayerIdx = h.GetLeadPlayerIdx()
-	cfg := h.GetConfig()
-	resObj.Config = controller.HeartsWebOutputConfig{
-		CpuDifficulty: int(cfg.CpuDifficulty),
-		PointLimit:    cfg.PointLimit,
-		OmnibusJD:     cfg.OmnibusJD,
-	}
-	trick := h.GetCurrentTrick()
-	resObj.CurrentTrick = p.buildTrickOutput(trick)
-	resObj.Players = p.buildPlayersOutput(h)
-
+	resObj := p.buildBase(h)
 	if hint != nil {
 		resObj.Hint = &controller.HeartsWebOutputHint{
 			CardIndices: hint.CardIndices,

--- a/internal/adapter/presenter/NapoleonWebPresenter.go
+++ b/internal/adapter/presenter/NapoleonWebPresenter.go
@@ -68,14 +68,9 @@ func (p *NapoleonWebPresenter) buildBaseOutput(n interfaces.NapoleonGame) *contr
 
 // buildTrickOutput 現在のトリック情報を構築
 func (p *NapoleonWebPresenter) buildTrickOutput(trick []*domain.NapoleonTrickCard) []*controller.NapoleonWebOutputTrickCard {
-	out := make([]*controller.NapoleonWebOutputTrickCard, 0)
-	for _, tc := range trick {
-		out = append(out, &controller.NapoleonWebOutputTrickCard{
-			PlayerIdx: tc.PlayerIdx,
-			Card:      cardToOutput(tc.Card),
-		})
-	}
-	return out
+	return buildTrickCards(trick, func(tc *domain.NapoleonTrickCard) *controller.NapoleonWebOutputTrickCard {
+		return &controller.NapoleonWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
+	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/OhHellWebPresenter.go
+++ b/internal/adapter/presenter/OhHellWebPresenter.go
@@ -69,14 +69,9 @@ func (p *OhHellWebPresenter) buildBase(o interfaces.OhHellGame) *controller.OhHe
 
 // buildTrickOutput 現在のトリック情報を構築
 func (p *OhHellWebPresenter) buildTrickOutput(trick []*domain.OhHellTrickCard) []*controller.OhHellWebOutputTrickCard {
-	out := make([]*controller.OhHellWebOutputTrickCard, 0)
-	for _, tc := range trick {
-		out = append(out, &controller.OhHellWebOutputTrickCard{
-			PlayerIdx: tc.PlayerIdx,
-			Card:      cardToOutput(tc.Card),
-		})
-	}
-	return out
+	return buildTrickCards(trick, func(tc *domain.OhHellTrickCard) *controller.OhHellWebOutputTrickCard {
+		return &controller.OhHellWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
+	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/PinochleWebPresenter.go
+++ b/internal/adapter/presenter/PinochleWebPresenter.go
@@ -75,14 +75,9 @@ func (p *PinochleWebPresenter) ActionLogOutput(g interfaces.PinochleGame) string
 
 // buildTrickOutput 現在のトリック情報を構築
 func (p *PinochleWebPresenter) buildTrickOutput(trick []*domain.PinochleTrickCard) []*controller.PinochleWebOutputTrickCard {
-	out := make([]*controller.PinochleWebOutputTrickCard, 0)
-	for _, tc := range trick {
-		out = append(out, &controller.PinochleWebOutputTrickCard{
-			PlayerIdx: tc.PlayerIdx,
-			Card:      cardToOutput(tc.Card),
-		})
-	}
-	return out
+	return buildTrickCards(trick, func(tc *domain.PinochleTrickCard) *controller.PinochleWebOutputTrickCard {
+		return &controller.PinochleWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
+	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築

--- a/internal/adapter/presenter/SpadesWebPresenter.go
+++ b/internal/adapter/presenter/SpadesWebPresenter.go
@@ -11,6 +11,13 @@ type SpadesWebPresenter struct{}
 
 // Output ゲーム状態をJSON出力
 func (p *SpadesWebPresenter) Output(s interfaces.SpadesGame, lastErr error) string {
+	resObj := p.buildBase(s)
+	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(s, s.GetCurrentTrick(), lastErr)
+	return marshalOrError(resObj)
+}
+
+// buildBase 共通フィールドを構築
+func (p *SpadesWebPresenter) buildBase(s interfaces.SpadesGame) *controller.SpadesWebOutput {
 	resObj := new(controller.SpadesWebOutput)
 	resObj.Phase = int(s.GetPhase())
 	resObj.RoundNumber = s.GetRoundNumber()
@@ -31,24 +38,16 @@ func (p *SpadesWebPresenter) Output(s interfaces.SpadesGame, lastErr error) stri
 		BagPenaltyThreshold: cfg.BagPenaltyThreshold,
 	}
 
-	trick := s.GetCurrentTrick()
-	resObj.CurrentTrick = p.buildTrickOutput(trick)
+	resObj.CurrentTrick = p.buildTrickOutput(s.GetCurrentTrick())
 	resObj.Players = p.buildPlayersOutput(s)
-	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(s, trick, lastErr)
-
-	return marshalOrError(resObj)
+	return resObj
 }
 
 // buildTrickOutput 現在のトリック情報を構築
 func (p *SpadesWebPresenter) buildTrickOutput(trick []*domain.SpadesTrickCard) []*controller.SpadesWebOutputTrickCard {
-	out := make([]*controller.SpadesWebOutputTrickCard, 0)
-	for _, tc := range trick {
-		out = append(out, &controller.SpadesWebOutputTrickCard{
-			PlayerIdx: tc.PlayerIdx,
-			Card:      cardToOutput(tc.Card),
-		})
-	}
-	return out
+	return buildTrickCards(trick, func(tc *domain.SpadesTrickCard) *controller.SpadesWebOutputTrickCard {
+		return &controller.SpadesWebOutputTrickCard{PlayerIdx: tc.PlayerIdx, Card: cardToOutput(tc.Card)}
+	})
 }
 
 // buildPlayersOutput プレイヤー情報を構築
@@ -102,27 +101,7 @@ func (p *SpadesWebPresenter) buildMessage(s interfaces.SpadesGame, trick []*doma
 // HintOutput ヒント情報をJSON出力する
 func (p *SpadesWebPresenter) HintOutput(s interfaces.SpadesGame) string {
 	hint := s.GetHint()
-	resObj := new(controller.SpadesWebOutput)
-	resObj.Phase = int(s.GetPhase())
-	resObj.RoundNumber = s.GetRoundNumber()
-	resObj.TrickNumber = s.GetTrickNumber()
-	resObj.CurrentPlayerIdx = s.GetCurrentPlayerIdx()
-	resObj.BidPlayerIdx = s.GetBidPlayerIdx()
-	resObj.SpadesBroken = s.GetSpadesBroken()
-	resObj.GameEndFlag = s.GetGameEndFlag()
-	resObj.WinnerIdx = s.GetWinnerIdx()
-	resObj.LeadPlayerIdx = s.GetLeadPlayerIdx()
-	cfg := s.GetConfig()
-	resObj.Config = controller.SpadesWebOutputConfig{
-		CpuDifficulty:       int(cfg.CpuDifficulty),
-		PointLimit:          cfg.PointLimit,
-		NilBonus:            cfg.NilBonus,
-		BagPenaltyThreshold: cfg.BagPenaltyThreshold,
-	}
-	trick := s.GetCurrentTrick()
-	resObj.CurrentTrick = p.buildTrickOutput(trick)
-	resObj.Players = p.buildPlayersOutput(s)
-
+	resObj := p.buildBase(s)
 	if hint != nil {
 		resObj.Hint = &controller.SpadesWebOutputHint{
 			CardIndex: hint.CardIndex,

--- a/internal/adapter/presenter/card_output_helper.go
+++ b/internal/adapter/presenter/card_output_helper.go
@@ -47,6 +47,15 @@ func cardsToOutput(cards []*domain.Card) []*controller.WebOutputCard {
 	return result
 }
 
+// buildTrickCards はトリックカードスライスをマッパー関数で変換する汎用ヘルパー
+func buildTrickCards[TC any, OUT any](trick []TC, mapper func(TC) OUT) []OUT {
+	out := make([]OUT, 0, len(trick))
+	for _, tc := range trick {
+		out = append(out, mapper(tc))
+	}
+	return out
+}
+
 // cardsToOutputOrEmpty カードスライスを共通WebOutputCardスライスに変換 (nil → 空スライス)
 func cardsToOutputOrEmpty(cards []*domain.Card) []*controller.WebOutputCard {
 	if cards == nil {

--- a/internal/adapter/presenter/card_output_helper_test.go
+++ b/internal/adapter/presenter/card_output_helper_test.go
@@ -108,6 +108,40 @@ func TestCardsToOutput(t *testing.T) {
 	})
 }
 
+func TestBuildTrickCards(t *testing.T) {
+	type fakeTrick struct {
+		idx  int
+		card *domain.Card
+	}
+	mapper := func(tc fakeTrick) struct {
+		PlayerIdx int
+		Design    string
+	} {
+		return struct {
+			PlayerIdx int
+			Design    string
+		}{PlayerIdx: tc.idx, Design: cardDesignToString(tc.card.GetDesign())}
+	}
+
+	t.Run("empty slice", func(t *testing.T) {
+		result := buildTrickCards([]fakeTrick{}, mapper)
+		assert.NotNil(t, result)
+		assert.Equal(t, 0, len(result))
+	})
+	t.Run("multiple elements", func(t *testing.T) {
+		tricks := []fakeTrick{
+			{idx: 0, card: domain.NewCard(domain.CardDesignSpade, 1, false)},
+			{idx: 2, card: domain.NewCard(domain.CardDesignHeart, 5, false)},
+		}
+		result := buildTrickCards(tricks, mapper)
+		assert.Equal(t, 2, len(result))
+		assert.Equal(t, 0, result[0].PlayerIdx)
+		assert.Equal(t, "SPADE", result[0].Design)
+		assert.Equal(t, 2, result[1].PlayerIdx)
+		assert.Equal(t, "HEART", result[1].Design)
+	})
+}
+
 func TestCardsToOutputOrEmpty(t *testing.T) {
 	t.Run("nil slice returns empty", func(t *testing.T) {
 		result := cardsToOutputOrEmpty(nil)


### PR DESCRIPTION
## Summary
- Extract `buildBase` method in Hearts, Spades, Euchre, and Bridge Web Presenters to eliminate Output/HintOutput body duplication (following the existing OhHell/Napoleon pattern)
- Add generic `buildTrickCards[TC, OUT]` helper to `card_output_helper.go` to reduce `buildTrickOutput` loop boilerplate across all 7 trick-taking Web Presenters
- Net reduction: 69 lines removed

Closes #1142
Closes #1150

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/` passes
- [x] `golangci-lint run ./internal/adapter/presenter/...` — 0 issues
- [x] All files formatted with `goimports -w`