### PR TITLE
refactor: extract runCpuBidsLoop for shared bidding patterns

### DIFF
--- a/internal/usecase/BridgeInteractor.go
+++ b/internal/usecase/BridgeInteractor.go
@@ -122,16 +122,7 @@ func (bi *BridgeInteractor) ActionLog() string {
 
 // runCpuBids ビッドフェーズでCPUを自動実行する
 func (bi *BridgeInteractor) runCpuBids() {
-	for !bi.b.GetGameEndFlag() {
-		phase := bi.b.GetPhase()
-		if phase != domain.BridgePhaseBid {
-			break
-		}
-		if bi.b.IsHumanBidTurn() {
-			break
-		}
-		bi.b.CpuBid()
-	}
+	runCpuBidsLoop(bi.b, domain.BridgePhaseBid)
 }
 
 // runCpuTurns プレイフェーズでCPUターンを自動実行する

--- a/internal/usecase/NapoleonInteractor.go
+++ b/internal/usecase/NapoleonInteractor.go
@@ -166,15 +166,7 @@ func (ni *NapoleonInteractor) ActionLog() string {
 
 // runCpuBids CPUビッドを実行
 func (ni *NapoleonInteractor) runCpuBids() {
-	for !ni.n.GetGameEndFlag() {
-		if ni.n.GetPhase() != domain.NapoleonPhaseBid {
-			break
-		}
-		if ni.n.IsHumanBidTurn() {
-			break
-		}
-		ni.n.CpuBid()
-	}
+	runCpuBidsLoop(ni.n, domain.NapoleonPhaseBid)
 }
 
 // runCpuDeclareAndExchange CPUの切り札宣言と場札交換を自動処理

--- a/internal/usecase/OhHellInteractor.go
+++ b/internal/usecase/OhHellInteractor.go
@@ -128,15 +128,7 @@ func (oi *OhHellInteractor) ActionLog() string {
 
 // runCpuBids ゲームが終わるかヒューマンのビッド番またはビッドフェーズが終了するまでCPUビッドを実行
 func (oi *OhHellInteractor) runCpuBids() {
-	for !oi.o.GetGameEndFlag() {
-		if oi.o.GetPhase() != domain.OhHellPhaseBid {
-			break
-		}
-		if oi.o.IsHumanBidTurn() {
-			break
-		}
-		oi.o.CpuBid()
-	}
+	runCpuBidsLoop(oi.o, domain.OhHellPhaseBid)
 }
 
 // runCpuTurns ゲームが終わるか人間の手番またはトリック/ラウンド終了になるまでCPUターンを実行

--- a/internal/usecase/SpadesInteractor.go
+++ b/internal/usecase/SpadesInteractor.go
@@ -121,15 +121,7 @@ func (si *SpadesInteractor) ActionLog() string {
 
 // runCpuBids ゲームが終わるかヒューマンのビッド番またはビッドフェーズが終了するまでCPUビッドを実行
 func (si *SpadesInteractor) runCpuBids() {
-	for !si.s.GetGameEndFlag() {
-		if si.s.GetPhase() != domain.SpadesPhaseBid {
-			break
-		}
-		if si.s.IsHumanBidTurn() {
-			break
-		}
-		si.s.CpuBid()
-	}
+	runCpuBidsLoop(si.s, domain.SpadesPhaseBid)
 }
 
 // runCpuTurns ゲームが終わるか人間の手番またはトリック/ラウンド終了になるまでCPUターンを実行

--- a/internal/usecase/interactor_trick.go
+++ b/internal/usecase/interactor_trick.go
@@ -18,6 +18,28 @@ type trickPhases[P comparable] struct {
 	gameEnd  P
 }
 
+// bidGame ビッドフェーズを持つゲーム共通インタフェース
+type bidGame[P comparable] interface {
+	GetGameEndFlag() bool
+	GetPhase() P
+	IsHumanBidTurn() bool
+	CpuBid()
+}
+
+// runCpuBidsLoop ビッドフェーズでCPUのビッドを自動実行するループ。
+// bidPhase に該当するフェーズの間、人間の手番になるまでCPUにビッドさせる。
+func runCpuBidsLoop[P comparable](g bidGame[P], bidPhase P) {
+	for !g.GetGameEndFlag() {
+		if g.GetPhase() != bidPhase {
+			break
+		}
+		if g.IsHumanBidTurn() {
+			break
+		}
+		g.CpuBid()
+	}
+}
+
 // runCpuTurnsLoop トリックテイキングゲーム共通のCPUターン実行ループ
 func runCpuTurnsLoop[P comparable](g trickGame[P], p trickPhases[P]) {
 	for !g.GetGameEndFlag() {


### PR DESCRIPTION
## Summary
- Add generic `runCpuBidsLoop[P]` helper to `interactor_trick.go` for the common CPU bidding loop pattern
- Apply to Bridge, Spades, OhHell, and Napoleon Interactors which had identical implementations
- Euchre and Pinochle have multi-phase bidding loops (PickUp+CallTrump, Bid+Trump) that remain game-specific

Closes #1146

## Test plan
- [x] `go test -tags test ./internal/usecase/` passes
- [x] `golangci-lint run ./internal/usecase/...` — 0 issues
- [x] All files formatted with `goimports -w`