### PR TITLE
fix: resolve remaining Node.js 20 and Cloudflare deploy warnings

### DIFF
--- a/.github/workflows/cloudflare-workers-build.yml
+++ b/.github/workflows/cloudflare-workers-build.yml
@@ -17,6 +17,9 @@ on:
       - 'Makefile'
       - 'internal/**'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   tinygo-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -25,6 +25,9 @@ concurrency:
   group: deploy-cloudflare-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy-workers:
     name: Deploy Workers (${{ matrix.worker }})
@@ -115,4 +118,4 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           PAGES_PROJECT: ${{ github.ref == 'refs/heads/master' && 'go-trumpcards' || 'go-trumpcards-staging' }}
-        run: bunx wrangler pages deploy public --project-name "$PAGES_PROJECT"
+        run: bunx wrangler pages deploy public --project-name "$PAGES_PROJECT" --commit-dirty=true


### PR DESCRIPTION
## Summary
- Force `acifani/setup-tinygo@v2` to run on Node.js 24 via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env var (upstream has not released a node24-native version yet)
- Suppress "uncommitted changes" warning in `wrangler pages deploy` with `--commit-dirty=true`

Resolves warnings from https://github.com/yuta-yoshinaga/go_trumpcards/actions/runs/23976204483

## Test plan
- [ ] Verify Deploy Workers jobs no longer show Node.js 20 deprecation warning
- [ ] Verify Deploy Frontend (Pages) job no longer shows uncommitted changes warning
- [ ] Verify all deployments still succeed