### PR TITLE
fix: add missing Stop() calls and fix documentation drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Go trump card game algorithms -- Baccarat, BlackJack, Canasta, Contract Bridge, Crazy Eights, Cribbage, Daifugo, Deuces Wild, Doubt, Euchre, FreeCell, Gin Rummy, Go Fish, Hearts, Indian Poker, Joker Poker, Klondike, Memory, Napoleon, Oh Hell, Old Maid, Omaha Hold'em, Pineapple Poker, Poker, Pyramid, Sevens, Short Deck Hold'em, Spades, Speed, Spider Solitaire, Texas Hold'em, Three Card Poker, TriPeaks, Video Poker. Clean Architecture with CLI and Web GUI (React + Go REST API).
+Go trump card game algorithms -- Baccarat, BlackJack, Canasta, Contract Bridge, Crazy Eights, Cribbage, Daifugo, Deuces Wild, Doubt, Euchre, FreeCell, Gin Rummy, Go Fish, Golf, Hearts, Indian Poker, Joker Poker, Klondike, Memory, Napoleon, Oh Hell, Old Maid, Omaha Hold'em, Pineapple Poker, Pinochle, Poker, Pyramid, Sevens, Short Deck Hold'em, Spades, Speed, Spider Solitaire, Texas Hold'em, Three Card Poker, TriPeaks, Video Poker. Clean Architecture with CLI and Web GUI (React + Go REST API).
 
 ## Requirements
 

--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -1164,8 +1164,8 @@ classDiagram
         +Exec(input string) string
     }
 
-    TrumpCardsWeb --> "*" GameWebController : holds 30 controllers
-    GameManager --> "*" CuiExecer : holds 29 games
+    TrumpCardsWeb --> "*" GameWebController : holds 36 controllers
+    GameManager --> "*" CuiExecer : holds 36 games
     GameCui ..|> CuiExecer : implements
     GameCui --> GameCuiController : delegates
 ```

--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -548,7 +548,7 @@ classDiagram
     CanastaApi --> gameApi : uses postJson/gameExec
 
     note for gameApi "全APIリクエストにsessionIdを自動付与\n各ゲームAPIは cmd ベースの統一形式"
-    note for BlackJackApi "全36ゲーム分のAPI Objectが存在\n(blackjack, poker, oldmaid, daifugo,\nsevens, doubt, holdem, omaha, shortdeck,\nhearts, memory, klondike, freecell, baccarat,\nspades, crazyeights, ginrummy, canasta, spider,\nnapoleon, indianpoker, videopoker, deuceswild,\njokerpoker, euchre, pyramid, tripeaks, cribbage,\nthreecard, ohhell, bridge, speed, gofish,\npinochle, golf)"
+    note for BlackJackApi "全36ゲーム分のAPI Objectが存在\n(blackjack, poker, oldmaid, daifugo,\nsevens, doubt, holdem, omaha, shortdeck,\npineapple, hearts, memory, klondike, freecell,\nbaccarat, spades, crazyeights, ginrummy, canasta,\nspider, napoleon, indianpoker, videopoker,\ndeuceswild, jokerpoker, euchre, pyramid, tripeaks,\ncribbage, threecard, ohhell, bridge, speed,\ngofish, pinochle, golf)"
 ```
 
 ### 1.3 Hook 層 (共通Hook)

--- a/internal/infrastructure/web/TrumpCardsWeb.go
+++ b/internal/infrastructure/web/TrumpCardsWeb.go
@@ -484,6 +484,11 @@ func (web *TrumpCardsWeb) Exec() error {
 	web.ohlc.Stop()
 	web.brc.Stop()
 	web.cnc.Stop()
+	web.pnc.Stop()
+	web.spdc.Stop()
+	web.gfc.Stop()
+	web.pinc.Stop()
+	web.glfc.Stop()
 	fmt.Println("Server stopped.")
 	slog.Info("server stopped")
 	return runErr


### PR DESCRIPTION
## Summary
- Add missing `Stop()` calls for 5 controllers (Pineapple, Speed, GoFish, Pinochle, Golf) that were not stopped on server shutdown, causing goroutine leaks
- Add Golf and Pinochle to `CLAUDE.md` project description (was 34 games, now 36)
- Update stale UML counts: "30 controllers" → "36", "29 games" → "36" in `docs/design/backend.md`
- Add missing `pineapple` to API note game list in `docs/design/frontend.md`

Closes #1185

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test -tags test ./...` passes
- [ ] Verify all 36 controllers have matching `Stop()` calls in `TrumpCardsWeb.go`