### PR TITLE
fix: prevent manual modal close button from overflowing viewport

### DIFF
--- a/frontend/src/components/ManualModal.tsx
+++ b/frontend/src/components/ManualModal.tsx
@@ -103,15 +103,15 @@ export function ManualModal({ open, onClose, gamePath }: ManualModalProps) {
         role="dialog"
         aria-modal="true"
         aria-label={t('manual.ariaLabel')}
-        className="rounded-lg shadow-xl p-6 mx-4 max-w-4xl w-full max-h-[calc(100vh-4rem)] flex flex-col bg-ds-surface border border-ds-border-subtle"
+        className="rounded-lg shadow-xl p-6 mx-4 max-w-4xl w-full h-[calc(100vh-4rem)] overflow-hidden flex flex-col bg-ds-surface border border-ds-border-subtle"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex justify-end mb-2">
+        <div className="flex justify-end mb-2 flex-shrink-0">
           <button type="button" className={btnSecondary} onClick={onClose} aria-label={t('manual.close')}>
             &times;
           </button>
         </div>
-        <div className="overflow-y-auto flex-1 prose prose-invert max-w-none">
+        <div className="overflow-y-auto flex-1 min-h-0 prose prose-invert max-w-none">
           <Markdown remarkPlugins={remarkPlugins} components={markdownComponents}>
             {markdown}
           </Markdown>


### PR DESCRIPTION
## Summary
- Fix manual modal close button overflowing above the viewport when content is long
- Add `overflow-hidden` to dialog, `flex-shrink-0` to close button area, `min-h-0` to scrollable content to fix flexbox `min-height: auto` issue
- Restore fixed height (`h-`) instead of `max-h` to maintain near-fullscreen modal size (avoid regression from commit 229e533)

## Test plan
- [ ] Open a game manual with long content — close button stays visible at top-right
- [ ] Open a game manual with short content — modal remains near-fullscreen size
- [ ] Click the close button — modal closes
- [ ] Press Escape — modal closes
- [ ] Vitest ManualModal tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)