### PR TITLE
refactor: extract genericCuiGame to eliminate CUI boilerplate

### DIFF
--- a/internal/infrastructure/ui/BaccaratCui.go
+++ b/internal/infrastructure/ui/BaccaratCui.go
@@ -8,27 +8,13 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// BaccaratCui バカラCUIクラス
-type BaccaratCui struct {
-	bc *controller.BaccaratCuiController
-}
-
 // NewBaccaratCui コンストラクタ
-func NewBaccaratCui() *BaccaratCui {
-	return &BaccaratCui{
-		bc: controller.NewBaccaratCuiController(usecase.NewBaccaratInteractor(
-			domain.NewDefaultBaccarat(),
-			new(presenter.BaccaratCuiPresenter),
-		)),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *BaccaratCui) Controller() CuiExecer { return cui.bc }
-
-// HelpLines returns the game's help lines.
-func (cui *BaccaratCui) HelpLines() []string {
-	return []string{
+func NewBaccaratCui() *genericCuiGame {
+	bc := controller.NewBaccaratCuiController(usecase.NewBaccaratInteractor(
+		domain.NewDefaultBaccarat(),
+		new(presenter.BaccaratCuiPresenter),
+	))
+	return newCuiGame(bc, []string{
 		i18n.T("baccarat.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -40,10 +26,5 @@ func (cui *BaccaratCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *BaccaratCui) Exec() {
-	RunCuiLoop(cui.bc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/BlackJackCui.go
+++ b/internal/infrastructure/ui/BlackJackCui.go
@@ -8,27 +8,13 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// BlackJackCui ブラックジャックCUIクラス
-type BlackJackCui struct {
-	bjc *controller.BlackJackCuiController
-}
-
 // NewBlackJackCui コンストラクタ
-func NewBlackJackCui() *BlackJackCui {
-	return &BlackJackCui{
-		bjc: controller.NewBlackJackCuiController(usecase.NewBlackJackInteractor(
-			domain.NewDefaultBlackJack(),
-			new(presenter.BlackJackCuiPresenter),
-		)),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *BlackJackCui) Controller() CuiExecer { return cui.bjc }
-
-// HelpLines returns the game's help lines.
-func (cui *BlackJackCui) HelpLines() []string {
-	return []string{
+func NewBlackJackCui() *genericCuiGame {
+	bjc := controller.NewBlackJackCuiController(usecase.NewBlackJackInteractor(
+		domain.NewDefaultBlackJack(),
+		new(presenter.BlackJackCuiPresenter),
+	))
+	return newCuiGame(bjc, []string{
 		i18n.T("blackjack.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -47,10 +33,5 @@ func (cui *BlackJackCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *BlackJackCui) Exec() {
-	RunCuiLoop(cui.bjc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/BridgeCui.go
+++ b/internal/infrastructure/ui/BridgeCui.go
@@ -7,13 +7,8 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// BridgeCui ブリッジCUIクラス
-type BridgeCui struct {
-	bc *controller.BridgeCuiController
-}
-
 // NewBridgeCui コンストラクタ
-func NewBridgeCui() *BridgeCui {
+func NewBridgeCui() *genericCuiGame {
 	config := domain.DefaultBridgeConfig()
 	players := []*domain.BridgePlayer{
 		domain.NewBridgePlayer(true, 0),  // North (human, team 0)
@@ -22,17 +17,8 @@ func NewBridgeCui() *BridgeCui {
 		domain.NewBridgePlayer(false, 1), // West (CPU, team 1)
 	}
 	bridge := domain.NewBridge(domain.NewTrumpCards(0), players, config)
-	return &BridgeCui{
-		bc: controller.NewBridgeCuiController(usecase.NewBridgeInteractor(bridge, new(presenter.BridgeCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *BridgeCui) Controller() CuiExecer { return cui.bc }
-
-// HelpLines returns the game's help lines.
-func (cui *BridgeCui) HelpLines() []string {
-	return []string{
+	bc := controller.NewBridgeCuiController(usecase.NewBridgeInteractor(bridge, new(presenter.BridgeCuiPresenter)))
+	return newCuiGame(bc, []string{
 		"=== Contract Bridge ===",
 		"",
 		"Game Commands:",
@@ -50,10 +36,5 @@ func (cui *BridgeCui) HelpLines() []string {
 		"  r                        reset game",
 		"  q                        quit",
 		"  help                     show this help",
-	}
-}
-
-// Exec ゲーム実行
-func (cui *BridgeCui) Exec() {
-	RunCuiLoop(cui.bc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/CanastaCui.go
+++ b/internal/infrastructure/ui/CanastaCui.go
@@ -7,30 +7,16 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// CanastaCui カナスタCUIクラス
-type CanastaCui struct {
-	cc *controller.CanastaCuiController
-}
-
 // NewCanastaCui コンストラクタ
-func NewCanastaCui() *CanastaCui {
+func NewCanastaCui() *genericCuiGame {
 	config := domain.DefaultCanastaConfig()
 	players := []*domain.CanastaPlayer{
 		domain.NewCanastaPlayer(true),
 		domain.NewCanastaPlayer(false),
 	}
 	canasta := domain.NewCanasta(domain.NewTrumpCardsWithDecks(2, 4), players, config)
-	return &CanastaCui{
-		cc: controller.NewCanastaCuiController(usecase.NewCanastaInteractor(canasta, new(presenter.CanastaCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *CanastaCui) Controller() CuiExecer { return cui.cc }
-
-// HelpLines returns the game's help lines.
-func (cui *CanastaCui) HelpLines() []string {
-	return []string{
+	cc := controller.NewCanastaCuiController(usecase.NewCanastaInteractor(canasta, new(presenter.CanastaCuiPresenter)))
+	return newCuiGame(cc, []string{
 		"Canasta (カナスタ) Help",
 		"",
 		"Game Commands:",
@@ -51,10 +37,5 @@ func (cui *CanastaCui) HelpLines() []string {
 		"  r / reset            reset game",
 		"  q / quit             quit",
 		"  ? / help             show help",
-	}
-}
-
-// Exec ゲーム実行
-func (cui *CanastaCui) Exec() {
-	RunCuiLoop(cui.cc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/CrazyEightsCui.go
+++ b/internal/infrastructure/ui/CrazyEightsCui.go
@@ -8,13 +8,8 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// CrazyEightsCui クレイジーエイトCUIクラス
-type CrazyEightsCui struct {
-	cc *controller.CrazyEightsCuiController
-}
-
 // NewCrazyEightsCui コンストラクタ
-func NewCrazyEightsCui() *CrazyEightsCui {
+func NewCrazyEightsCui() *genericCuiGame {
 	config := domain.DefaultCrazyEightsConfig()
 	players := []*domain.CrazyEightsPlayer{
 		domain.NewCrazyEightsPlayer(true),
@@ -23,17 +18,8 @@ func NewCrazyEightsCui() *CrazyEightsCui {
 		domain.NewCrazyEightsPlayer(false),
 	}
 	ce := domain.NewCrazyEights(domain.NewTrumpCards(0), players, config)
-	return &CrazyEightsCui{
-		cc: controller.NewCrazyEightsCuiController(usecase.NewCrazyEightsInteractor(ce, new(presenter.CrazyEightsCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *CrazyEightsCui) Controller() CuiExecer { return cui.cc }
-
-// HelpLines returns the game's help lines.
-func (cui *CrazyEightsCui) HelpLines() []string {
-	return []string{
+	cc := controller.NewCrazyEightsCuiController(usecase.NewCrazyEightsInteractor(ce, new(presenter.CrazyEightsCuiPresenter)))
+	return newCuiGame(cc, []string{
 		i18n.T("crazyeights.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -51,10 +37,5 @@ func (cui *CrazyEightsCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *CrazyEightsCui) Exec() {
-	RunCuiLoop(cui.cc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/CribbageCui.go
+++ b/internal/infrastructure/ui/CribbageCui.go
@@ -8,30 +8,16 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// CribbageCui クリベッジCUIクラス
-type CribbageCui struct {
-	cc *controller.CribbageCuiController
-}
-
 // NewCribbageCui コンストラクタ
-func NewCribbageCui() *CribbageCui {
+func NewCribbageCui() *genericCuiGame {
 	config := domain.DefaultCribbageConfig()
 	players := []*domain.CribbagePlayer{
 		domain.NewCribbagePlayer(true),
 		domain.NewCribbagePlayer(false),
 	}
 	g := domain.NewCribbage(domain.NewTrumpCards(0), players, config)
-	return &CribbageCui{
-		cc: controller.NewCribbageCuiController(usecase.NewCribbageInteractor(g, new(presenter.CribbageCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *CribbageCui) Controller() CuiExecer { return cui.cc }
-
-// HelpLines returns the game's help lines.
-func (cui *CribbageCui) HelpLines() []string {
-	return []string{
+	cc := controller.NewCribbageCuiController(usecase.NewCribbageInteractor(g, new(presenter.CribbageCuiPresenter)))
+	return newCuiGame(cc, []string{
 		i18n.T("cribbage.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -50,10 +36,5 @@ func (cui *CribbageCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *CribbageCui) Exec() {
-	RunCuiLoop(cui.cc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/DaifugoCui.go
+++ b/internal/infrastructure/ui/DaifugoCui.go
@@ -8,13 +8,8 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// DaifugoCui 大富豪CUIクラス
-type DaifugoCui struct {
-	dgc *controller.DaifugoCuiController
-}
-
 // NewDaifugoCui コンストラクタ
-func NewDaifugoCui() *DaifugoCui {
+func NewDaifugoCui() *genericCuiGame {
 	config := domain.DefaultDaifugoConfig()
 	players := []*domain.DaifugoPlayer{
 		domain.NewDaifugoPlayer(true),
@@ -23,19 +18,10 @@ func NewDaifugoCui() *DaifugoCui {
 		domain.NewDaifugoPlayer(false),
 	}
 	daifugo := domain.NewDaifugo(domain.NewTrumpCards(config.JokerCount), players, config)
-	return &DaifugoCui{
-		dgc: controller.NewDaifugoCuiController(
-			usecase.NewDaifugoInteractor(daifugo, new(presenter.DaifugoCuiPresenter)),
-		),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *DaifugoCui) Controller() CuiExecer { return cui.dgc }
-
-// HelpLines returns the game's help lines.
-func (cui *DaifugoCui) HelpLines() []string {
-	return []string{
+	dgc := controller.NewDaifugoCuiController(
+		usecase.NewDaifugoInteractor(daifugo, new(presenter.DaifugoCuiPresenter)),
+	)
+	return newCuiGame(dgc, []string{
 		i18n.T("daifugo.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -51,10 +37,5 @@ func (cui *DaifugoCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *DaifugoCui) Exec() {
-	RunCuiLoop(cui.dgc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/DeucesWildCui.go
+++ b/internal/infrastructure/ui/DeucesWildCui.go
@@ -8,27 +8,13 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// DeucesWildCui Deuces Wild CUIクラス
-type DeucesWildCui struct {
-	vc *controller.VideoPokerCuiController
-}
-
 // NewDeucesWildCui コンストラクタ
-func NewDeucesWildCui() *DeucesWildCui {
-	return &DeucesWildCui{
-		vc: controller.NewVideoPokerCuiController(usecase.NewVideoPokerInteractor(
-			domain.NewDeucesWildVideoPoker(),
-			new(presenter.VideoPokerCuiPresenter),
-		)),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *DeucesWildCui) Controller() CuiExecer { return cui.vc }
-
-// HelpLines returns the game's help lines.
-func (cui *DeucesWildCui) HelpLines() []string {
-	return []string{
+func NewDeucesWildCui() *genericCuiGame {
+	vc := controller.NewVideoPokerCuiController(usecase.NewVideoPokerInteractor(
+		domain.NewDeucesWildVideoPoker(),
+		new(presenter.VideoPokerCuiPresenter),
+	))
+	return newCuiGame(vc, []string{
 		i18n.T("deuceswild.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -40,10 +26,5 @@ func (cui *DeucesWildCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *DeucesWildCui) Exec() {
-	RunCuiLoop(cui.vc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/EuchreCui.go
+++ b/internal/infrastructure/ui/EuchreCui.go
@@ -8,13 +8,8 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// EuchreCui ユーカーCUIクラス
-type EuchreCui struct {
-	ec *controller.EuchreCuiController
-}
-
 // NewEuchreCui コンストラクタ
-func NewEuchreCui() *EuchreCui {
+func NewEuchreCui() *genericCuiGame {
 	config := domain.DefaultEuchreConfig()
 	players := []*domain.EuchrePlayer{
 		domain.NewEuchrePlayer(true, 0),
@@ -23,17 +18,8 @@ func NewEuchreCui() *EuchreCui {
 		domain.NewEuchrePlayer(false, 1),
 	}
 	euchre := domain.NewEuchre(domain.NewTrumpCardsEuchre(), players, config)
-	return &EuchreCui{
-		ec: controller.NewEuchreCuiController(usecase.NewEuchreInteractor(euchre, new(presenter.EuchreCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *EuchreCui) Controller() CuiExecer { return cui.ec }
-
-// HelpLines returns the game's help lines.
-func (cui *EuchreCui) HelpLines() []string {
-	return []string{
+	ec := controller.NewEuchreCuiController(usecase.NewEuchreInteractor(euchre, new(presenter.EuchreCuiPresenter)))
+	return newCuiGame(ec, []string{
 		i18n.T("euchre.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -56,10 +42,5 @@ func (cui *EuchreCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *EuchreCui) Exec() {
-	RunCuiLoop(cui.ec, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/FreeCellCui.go
+++ b/internal/infrastructure/ui/FreeCellCui.go
@@ -8,25 +8,11 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// FreeCellCui フリーセルCUIクラス
-type FreeCellCui struct {
-	fc *controller.FreeCellCuiController
-}
-
 // NewFreeCellCui コンストラクタ
-func NewFreeCellCui() *FreeCellCui {
+func NewFreeCellCui() *genericCuiGame {
 	freeCell := domain.NewFreeCell(domain.NewTrumpCards(0))
-	return &FreeCellCui{
-		fc: controller.NewFreeCellCuiController(usecase.NewFreeCellInteractor(freeCell, new(presenter.FreeCellCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *FreeCellCui) Controller() CuiExecer { return cui.fc }
-
-// HelpLines returns the game's help lines.
-func (cui *FreeCellCui) HelpLines() []string {
-	return []string{
+	fc := controller.NewFreeCellCuiController(usecase.NewFreeCellInteractor(freeCell, new(presenter.FreeCellCuiPresenter)))
+	return newCuiGame(fc, []string{
 		i18n.T("freecell.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -45,10 +31,5 @@ func (cui *FreeCellCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *FreeCellCui) Exec() {
-	RunCuiLoop(cui.fc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/GinRummyCui.go
+++ b/internal/infrastructure/ui/GinRummyCui.go
@@ -8,30 +8,16 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// GinRummyCui ジンラミーCUIクラス
-type GinRummyCui struct {
-	cc *controller.GinRummyCuiController
-}
-
 // NewGinRummyCui コンストラクタ
-func NewGinRummyCui() *GinRummyCui {
+func NewGinRummyCui() *genericCuiGame {
 	config := domain.DefaultGinRummyConfig()
 	players := []*domain.GinRummyPlayer{
 		domain.NewGinRummyPlayer(true),
 		domain.NewGinRummyPlayer(false),
 	}
 	gr := domain.NewGinRummy(domain.NewTrumpCards(0), players, config)
-	return &GinRummyCui{
-		cc: controller.NewGinRummyCuiController(usecase.NewGinRummyInteractor(gr, new(presenter.GinRummyCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *GinRummyCui) Controller() CuiExecer { return cui.cc }
-
-// HelpLines returns the game's help lines.
-func (cui *GinRummyCui) HelpLines() []string {
-	return []string{
+	cc := controller.NewGinRummyCuiController(usecase.NewGinRummyInteractor(gr, new(presenter.GinRummyCuiPresenter)))
+	return newCuiGame(cc, []string{
 		i18n.T("ginrummy.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -51,10 +37,5 @@ func (cui *GinRummyCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *GinRummyCui) Exec() {
-	RunCuiLoop(cui.cc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/GoFishCui.go
+++ b/internal/infrastructure/ui/GoFishCui.go
@@ -8,13 +8,8 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// GoFishCui Go FishCUIクラス
-type GoFishCui struct {
-	gfc *controller.GoFishCuiController
-}
-
 // NewGoFishCui コンストラクタ
-func NewGoFishCui() *GoFishCui {
+func NewGoFishCui() *genericCuiGame {
 	players := []*domain.GoFishPlayer{
 		domain.NewGoFishPlayer(true),
 		domain.NewGoFishPlayer(false),
@@ -22,19 +17,10 @@ func NewGoFishCui() *GoFishCui {
 		domain.NewGoFishPlayer(false),
 	}
 	goFish := domain.NewGoFish(domain.NewTrumpCards(0), players)
-	return &GoFishCui{
-		gfc: controller.NewGoFishCuiController(
-			usecase.NewGoFishInteractor(goFish, new(presenter.GoFishCuiPresenter)),
-		),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *GoFishCui) Controller() CuiExecer { return cui.gfc }
-
-// HelpLines returns the game's help lines.
-func (cui *GoFishCui) HelpLines() []string {
-	return []string{
+	gfc := controller.NewGoFishCuiController(
+		usecase.NewGoFishInteractor(goFish, new(presenter.GoFishCuiPresenter)),
+	)
+	return newCuiGame(gfc, []string{
 		i18n.T("gofish.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -47,10 +33,5 @@ func (cui *GoFishCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *GoFishCui) Exec() {
-	RunCuiLoop(cui.gfc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/GolfCui.go
+++ b/internal/infrastructure/ui/GolfCui.go
@@ -8,25 +8,11 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// GolfCui ゴルフソリティアCUIクラス
-type GolfCui struct {
-	gc *controller.GolfCuiController
-}
-
 // NewGolfCui コンストラクタ
-func NewGolfCui() *GolfCui {
+func NewGolfCui() *genericCuiGame {
 	golf := domain.NewGolf(domain.NewTrumpCards(0))
-	return &GolfCui{
-		gc: controller.NewGolfCuiController(usecase.NewGolfInteractor(golf, new(presenter.GolfCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *GolfCui) Controller() CuiExecer { return cui.gc }
-
-// HelpLines returns the game's help lines.
-func (cui *GolfCui) HelpLines() []string {
-	return []string{
+	gc := controller.NewGolfCuiController(usecase.NewGolfInteractor(golf, new(presenter.GolfCuiPresenter)))
+	return newCuiGame(gc, []string{
 		i18n.T("golf.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -40,10 +26,5 @@ func (cui *GolfCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *GolfCui) Exec() {
-	RunCuiLoop(cui.gc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/HeartsCui.go
+++ b/internal/infrastructure/ui/HeartsCui.go
@@ -8,13 +8,8 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// HeartsCui ハーツCUIクラス
-type HeartsCui struct {
-	hc *controller.HeartsCuiController
-}
-
 // NewHeartsCui コンストラクタ
-func NewHeartsCui() *HeartsCui {
+func NewHeartsCui() *genericCuiGame {
 	config := domain.DefaultHeartsConfig()
 	players := []*domain.HeartsPlayer{
 		domain.NewHeartsPlayer(true),
@@ -23,17 +18,8 @@ func NewHeartsCui() *HeartsCui {
 		domain.NewHeartsPlayer(false),
 	}
 	hearts := domain.NewHearts(domain.NewTrumpCards(0), players, config)
-	return &HeartsCui{
-		hc: controller.NewHeartsCuiController(usecase.NewHeartsInteractor(hearts, new(presenter.HeartsCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *HeartsCui) Controller() CuiExecer { return cui.hc }
-
-// HelpLines returns the game's help lines.
-func (cui *HeartsCui) HelpLines() []string {
-	return []string{
+	hc := controller.NewHeartsCuiController(usecase.NewHeartsInteractor(hearts, new(presenter.HeartsCuiPresenter)))
+	return newCuiGame(hc, []string{
 		i18n.T("hearts.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -51,10 +37,5 @@ func (cui *HeartsCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *HeartsCui) Exec() {
-	RunCuiLoop(cui.hc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/HoldemCui.go
+++ b/internal/infrastructure/ui/HoldemCui.go
@@ -8,26 +8,12 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// HoldemCui テキサスホールデムCUIクラス
-type HoldemCui struct {
-	hc *controller.HoldemCuiController
-}
-
 // NewHoldemCui コンストラクタ
-func NewHoldemCui() *HoldemCui {
+func NewHoldemCui() *genericCuiGame {
 	cfg := domain.DefaultHoldemConfig()
 	holdem := domain.NewHoldem(domain.NewTrumpCards(0), domain.NewPlayersForTable(cfg.TableSize), cfg)
-	return &HoldemCui{
-		hc: controller.NewHoldemCuiController(usecase.NewHoldemInteractor(holdem, new(presenter.HoldemCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *HoldemCui) Controller() CuiExecer { return cui.hc }
-
-// HelpLines returns the game's help lines.
-func (cui *HoldemCui) HelpLines() []string {
-	return []string{
+	hc := controller.NewHoldemCuiController(usecase.NewHoldemInteractor(holdem, new(presenter.HoldemCuiPresenter)))
+	return newCuiGame(hc, []string{
 		i18n.T("holdem.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -54,10 +40,5 @@ func (cui *HoldemCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *HoldemCui) Exec() {
-	RunCuiLoop(cui.hc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/IndianPokerCui.go
+++ b/internal/infrastructure/ui/IndianPokerCui.go
@@ -8,26 +8,12 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// IndianPokerCui インディアンポーカーCUIクラス
-type IndianPokerCui struct {
-	ipc *controller.IndianPokerCuiController
-}
-
 // NewIndianPokerCui コンストラクタ
-func NewIndianPokerCui() *IndianPokerCui {
+func NewIndianPokerCui() *genericCuiGame {
 	cfg := domain.DefaultIndianPokerConfig()
 	ip := domain.NewIndianPoker(domain.NewTrumpCards(0), domain.NewIndianPokerPlayers(), cfg)
-	return &IndianPokerCui{
-		ipc: controller.NewIndianPokerCuiController(usecase.NewIndianPokerInteractor(ip, new(presenter.IndianPokerCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *IndianPokerCui) Controller() CuiExecer { return cui.ipc }
-
-// HelpLines returns the game's help lines.
-func (cui *IndianPokerCui) HelpLines() []string {
-	return []string{
+	ipc := controller.NewIndianPokerCuiController(usecase.NewIndianPokerInteractor(ip, new(presenter.IndianPokerCuiPresenter)))
+	return newCuiGame(ipc, []string{
 		i18n.T("indianpoker.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -47,10 +33,5 @@ func (cui *IndianPokerCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *IndianPokerCui) Exec() {
-	RunCuiLoop(cui.ipc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/JokerPokerCui.go
+++ b/internal/infrastructure/ui/JokerPokerCui.go
@@ -8,27 +8,13 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// JokerPokerCui Joker Poker CUIクラス
-type JokerPokerCui struct {
-	vc *controller.VideoPokerCuiController
-}
-
 // NewJokerPokerCui コンストラクタ
-func NewJokerPokerCui() *JokerPokerCui {
-	return &JokerPokerCui{
-		vc: controller.NewVideoPokerCuiController(usecase.NewVideoPokerInteractor(
-			domain.NewJokerPokerVideoPoker(),
-			new(presenter.VideoPokerCuiPresenter),
-		)),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *JokerPokerCui) Controller() CuiExecer { return cui.vc }
-
-// HelpLines returns the game's help lines.
-func (cui *JokerPokerCui) HelpLines() []string {
-	return []string{
+func NewJokerPokerCui() *genericCuiGame {
+	vc := controller.NewVideoPokerCuiController(usecase.NewVideoPokerInteractor(
+		domain.NewJokerPokerVideoPoker(),
+		new(presenter.VideoPokerCuiPresenter),
+	))
+	return newCuiGame(vc, []string{
 		i18n.T("jokerpoker.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -40,10 +26,5 @@ func (cui *JokerPokerCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *JokerPokerCui) Exec() {
-	RunCuiLoop(cui.vc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/KlondikeCui.go
+++ b/internal/infrastructure/ui/KlondikeCui.go
@@ -8,25 +8,11 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// KlondikeCui クロンダイクCUIクラス
-type KlondikeCui struct {
-	kc *controller.KlondikeCuiController
-}
-
 // NewKlondikeCui コンストラクタ
-func NewKlondikeCui() *KlondikeCui {
+func NewKlondikeCui() *genericCuiGame {
 	klondike := domain.NewKlondike(domain.NewTrumpCards(0))
-	return &KlondikeCui{
-		kc: controller.NewKlondikeCuiController(usecase.NewKlondikeInteractor(klondike, new(presenter.KlondikeCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *KlondikeCui) Controller() CuiExecer { return cui.kc }
-
-// HelpLines returns the game's help lines.
-func (cui *KlondikeCui) HelpLines() []string {
-	return []string{
+	kc := controller.NewKlondikeCuiController(usecase.NewKlondikeInteractor(klondike, new(presenter.KlondikeCuiPresenter)))
+	return newCuiGame(kc, []string{
 		i18n.T("klondike.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -44,10 +30,5 @@ func (cui *KlondikeCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *KlondikeCui) Exec() {
-	RunCuiLoop(cui.kc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/MemoryCui.go
+++ b/internal/infrastructure/ui/MemoryCui.go
@@ -8,13 +8,8 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// MemoryCui 神経衰弱CUIクラス
-type MemoryCui struct {
-	mc *controller.MemoryCuiController
-}
-
 // NewMemoryCui コンストラクタ
-func NewMemoryCui() *MemoryCui {
+func NewMemoryCui() *genericCuiGame {
 	config := domain.DefaultMemoryConfig()
 	players := []*domain.MemoryPlayer{
 		domain.NewMemoryPlayer(true),
@@ -23,17 +18,8 @@ func NewMemoryCui() *MemoryCui {
 		domain.NewMemoryPlayer(false),
 	}
 	memory := domain.NewMemory(domain.NewTrumpCards(0), players, config)
-	return &MemoryCui{
-		mc: controller.NewMemoryCuiController(usecase.NewMemoryInteractor(memory, new(presenter.MemoryCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *MemoryCui) Controller() CuiExecer { return cui.mc }
-
-// HelpLines returns the game's help lines.
-func (cui *MemoryCui) HelpLines() []string {
-	return []string{
+	mc := controller.NewMemoryCuiController(usecase.NewMemoryInteractor(memory, new(presenter.MemoryCuiPresenter)))
+	return newCuiGame(mc, []string{
 		i18n.T("memory.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -48,10 +34,5 @@ func (cui *MemoryCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *MemoryCui) Exec() {
-	RunCuiLoop(cui.mc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/NapoleonCui.go
+++ b/internal/infrastructure/ui/NapoleonCui.go
@@ -8,13 +8,8 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// NapoleonCui ナポレオンCUIクラス
-type NapoleonCui struct {
-	nc *controller.NapoleonCuiController
-}
-
 // NewNapoleonCui コンストラクタ
-func NewNapoleonCui() *NapoleonCui {
+func NewNapoleonCui() *genericCuiGame {
 	config := domain.DefaultNapoleonConfig()
 	players := []*domain.NapoleonPlayer{
 		domain.NewNapoleonPlayer(true),
@@ -23,17 +18,8 @@ func NewNapoleonCui() *NapoleonCui {
 		domain.NewNapoleonPlayer(false),
 	}
 	napoleon := domain.NewNapoleon(domain.NewTrumpCards(1), players, config)
-	return &NapoleonCui{
-		nc: controller.NewNapoleonCuiController(usecase.NewNapoleonInteractor(napoleon, new(presenter.NapoleonCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *NapoleonCui) Controller() CuiExecer { return cui.nc }
-
-// HelpLines returns the game's help lines.
-func (cui *NapoleonCui) HelpLines() []string {
-	return []string{
+	nc := controller.NewNapoleonCuiController(usecase.NewNapoleonInteractor(napoleon, new(presenter.NapoleonCuiPresenter)))
+	return newCuiGame(nc, []string{
 		i18n.T("napoleon.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -54,10 +40,5 @@ func (cui *NapoleonCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *NapoleonCui) Exec() {
-	RunCuiLoop(cui.nc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/OhHellCui.go
+++ b/internal/infrastructure/ui/OhHellCui.go
@@ -8,13 +8,8 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// OhHellCui オー・ヘルCUIクラス
-type OhHellCui struct {
-	oc *controller.OhHellCuiController
-}
-
 // NewOhHellCui コンストラクタ
-func NewOhHellCui() *OhHellCui {
+func NewOhHellCui() *genericCuiGame {
 	config := domain.DefaultOhHellConfig()
 	players := []*domain.OhHellPlayer{
 		domain.NewOhHellPlayer(true),
@@ -23,17 +18,8 @@ func NewOhHellCui() *OhHellCui {
 		domain.NewOhHellPlayer(false),
 	}
 	ohHell := domain.NewOhHell(domain.NewTrumpCards(0), players, config)
-	return &OhHellCui{
-		oc: controller.NewOhHellCuiController(usecase.NewOhHellInteractor(ohHell, new(presenter.OhHellCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *OhHellCui) Controller() CuiExecer { return cui.oc }
-
-// HelpLines returns the game's help lines.
-func (cui *OhHellCui) HelpLines() []string {
-	return []string{
+	oc := controller.NewOhHellCuiController(usecase.NewOhHellInteractor(ohHell, new(presenter.OhHellCuiPresenter)))
+	return newCuiGame(oc, []string{
 		i18n.T("ohhell.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -51,10 +37,5 @@ func (cui *OhHellCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *OhHellCui) Exec() {
-	RunCuiLoop(cui.oc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/OldMaidCui.go
+++ b/internal/infrastructure/ui/OldMaidCui.go
@@ -8,13 +8,8 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// OldMaidCui ババ抜きCUIクラス
-type OldMaidCui struct {
-	omc *controller.OldMaidCuiController
-}
-
 // NewOldMaidCui コンストラクタ
-func NewOldMaidCui() *OldMaidCui {
+func NewOldMaidCui() *genericCuiGame {
 	players := []*domain.OldMaidPlayer{
 		domain.NewOldMaidPlayer(true),
 		domain.NewOldMaidPlayer(false),
@@ -22,19 +17,10 @@ func NewOldMaidCui() *OldMaidCui {
 		domain.NewOldMaidPlayer(false),
 	}
 	oldMaid := domain.NewOldMaid(domain.NewTrumpCards(1), players)
-	return &OldMaidCui{
-		omc: controller.NewOldMaidCuiController(
-			usecase.NewOldMaidInteractor(oldMaid, new(presenter.OldMaidCuiPresenter)),
-		),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *OldMaidCui) Controller() CuiExecer { return cui.omc }
-
-// HelpLines returns the game's help lines.
-func (cui *OldMaidCui) HelpLines() []string {
-	return []string{
+	omc := controller.NewOldMaidCuiController(
+		usecase.NewOldMaidInteractor(oldMaid, new(presenter.OldMaidCuiPresenter)),
+	)
+	return newCuiGame(omc, []string{
 		i18n.T("oldmaid.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -51,10 +37,5 @@ func (cui *OldMaidCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *OldMaidCui) Exec() {
-	RunCuiLoop(cui.omc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/OmahaCui.go
+++ b/internal/infrastructure/ui/OmahaCui.go
@@ -8,26 +8,12 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// OmahaCui オマハホールデムCUIクラス
-type OmahaCui struct {
-	oc *controller.OmahaCuiController
-}
-
 // NewOmahaCui コンストラクタ
-func NewOmahaCui() *OmahaCui {
+func NewOmahaCui() *genericCuiGame {
 	cfg := domain.DefaultOmahaConfig()
 	omaha := domain.NewOmaha(domain.NewTrumpCards(0), domain.NewOmahaPlayersForTable(cfg.TableSize), cfg)
-	return &OmahaCui{
-		oc: controller.NewOmahaCuiController(usecase.NewOmahaInteractor(omaha, new(presenter.OmahaCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *OmahaCui) Controller() CuiExecer { return cui.oc }
-
-// HelpLines returns the game's help lines.
-func (cui *OmahaCui) HelpLines() []string {
-	return []string{
+	oc := controller.NewOmahaCuiController(usecase.NewOmahaInteractor(omaha, new(presenter.OmahaCuiPresenter)))
+	return newCuiGame(oc, []string{
 		i18n.T("omaha.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -54,10 +40,5 @@ func (cui *OmahaCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *OmahaCui) Exec() {
-	RunCuiLoop(cui.oc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/PineappleCui.go
+++ b/internal/infrastructure/ui/PineappleCui.go
@@ -8,26 +8,12 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// PineappleCui パイナップルポーカーCUIクラス
-type PineappleCui struct {
-	pc *controller.PineappleCuiController
-}
-
 // NewPineappleCui コンストラクタ
-func NewPineappleCui() *PineappleCui {
+func NewPineappleCui() *genericCuiGame {
 	cfg := domain.DefaultPineappleConfig()
 	pineapple := domain.NewPineapple(domain.NewTrumpCards(0), domain.NewPineapplePlayersForTable(cfg.TableSize), cfg)
-	return &PineappleCui{
-		pc: controller.NewPineappleCuiController(usecase.NewPineappleInteractor(pineapple, new(presenter.PineappleCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *PineappleCui) Controller() CuiExecer { return cui.pc }
-
-// HelpLines returns the game's help lines.
-func (cui *PineappleCui) HelpLines() []string {
-	return []string{
+	pc := controller.NewPineappleCuiController(usecase.NewPineappleInteractor(pineapple, new(presenter.PineappleCuiPresenter)))
+	return newCuiGame(pc, []string{
 		i18n.T("pineapple.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -55,10 +41,5 @@ func (cui *PineappleCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *PineappleCui) Exec() {
-	RunCuiLoop(cui.pc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/PinochleCui.go
+++ b/internal/infrastructure/ui/PinochleCui.go
@@ -8,13 +8,8 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// PinochleCui ピノクルCUIクラス
-type PinochleCui struct {
-	pc *controller.PinochleCuiController
-}
-
 // NewPinochleCui コンストラクタ
-func NewPinochleCui() *PinochleCui {
+func NewPinochleCui() *genericCuiGame {
 	config := domain.DefaultPinochleConfig()
 	players := []*domain.PinochlePlayer{
 		domain.NewPinochlePlayer(true, 0),
@@ -23,17 +18,8 @@ func NewPinochleCui() *PinochleCui {
 		domain.NewPinochlePlayer(false, 1),
 	}
 	pinochle := domain.NewPinochle(domain.NewTrumpCardsPinochle(), players, config)
-	return &PinochleCui{
-		pc: controller.NewPinochleCuiController(usecase.NewPinochleInteractor(pinochle, new(presenter.PinochleCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *PinochleCui) Controller() CuiExecer { return cui.pc }
-
-// HelpLines returns the game's help lines.
-func (cui *PinochleCui) HelpLines() []string {
-	return []string{
+	pc := controller.NewPinochleCuiController(usecase.NewPinochleInteractor(pinochle, new(presenter.PinochleCuiPresenter)))
+	return newCuiGame(pc, []string{
 		i18n.T("pinochle.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -54,10 +40,5 @@ func (cui *PinochleCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *PinochleCui) Exec() {
-	RunCuiLoop(cui.pc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/PokerCui.go
+++ b/internal/infrastructure/ui/PokerCui.go
@@ -8,13 +8,8 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// PokerCui ポーカーCUIクラス
-type PokerCui struct {
-	pc *controller.PokerCuiController
-}
-
 // NewPokerCui コンストラクタ
-func NewPokerCui() *PokerCui {
+func NewPokerCui() *genericCuiGame {
 	config := domain.DefaultPokerConfig()
 	players := []*domain.PokerPlayer{
 		domain.NewPokerPlayer(true, domain.PokerStyleBalanced),
@@ -23,17 +18,8 @@ func NewPokerCui() *PokerCui {
 		domain.NewPokerPlayer(false, domain.PokerStyleBluffer),
 	}
 	poker := domain.NewPoker(domain.NewTrumpCards(config.JokerCount), players, config)
-	return &PokerCui{
-		pc: controller.NewPokerCuiController(usecase.NewPokerInteractor(poker, new(presenter.PokerCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *PokerCui) Controller() CuiExecer { return cui.pc }
-
-// HelpLines returns the game's help lines.
-func (cui *PokerCui) HelpLines() []string {
-	return []string{
+	pc := controller.NewPokerCuiController(usecase.NewPokerInteractor(poker, new(presenter.PokerCuiPresenter)))
+	return newCuiGame(pc, []string{
 		i18n.T("poker.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -54,10 +40,5 @@ func (cui *PokerCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *PokerCui) Exec() {
-	RunCuiLoop(cui.pc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/PyramidCui.go
+++ b/internal/infrastructure/ui/PyramidCui.go
@@ -8,25 +8,11 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// PyramidCui ピラミッドCUIクラス
-type PyramidCui struct {
-	pc *controller.PyramidCuiController
-}
-
 // NewPyramidCui コンストラクタ
-func NewPyramidCui() *PyramidCui {
+func NewPyramidCui() *genericCuiGame {
 	pyramid := domain.NewPyramid(domain.NewTrumpCards(0))
-	return &PyramidCui{
-		pc: controller.NewPyramidCuiController(usecase.NewPyramidInteractor(pyramid, new(presenter.PyramidCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *PyramidCui) Controller() CuiExecer { return cui.pc }
-
-// HelpLines returns the game's help lines.
-func (cui *PyramidCui) HelpLines() []string {
-	return []string{
+	pc := controller.NewPyramidCuiController(usecase.NewPyramidInteractor(pyramid, new(presenter.PyramidCuiPresenter)))
+	return newCuiGame(pc, []string{
 		i18n.T("pyramid.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -43,10 +29,5 @@ func (cui *PyramidCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *PyramidCui) Exec() {
-	RunCuiLoop(cui.pc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/SevensCui.go
+++ b/internal/infrastructure/ui/SevensCui.go
@@ -8,13 +8,8 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// SevensCui 7並べCUIクラス
-type SevensCui struct {
-	sgc *controller.SevensCuiController
-}
-
 // NewSevensCui コンストラクタ
-func NewSevensCui() *SevensCui {
+func NewSevensCui() *genericCuiGame {
 	config := domain.DefaultSevensConfig()
 	players := []*domain.SevensPlayer{
 		domain.NewSevensPlayer(true),
@@ -23,19 +18,10 @@ func NewSevensCui() *SevensCui {
 		domain.NewSevensPlayer(false),
 	}
 	sevens := domain.NewSevens(domain.NewTrumpCards(config.JokerCount), players, config)
-	return &SevensCui{
-		sgc: controller.NewSevensCuiController(
-			usecase.NewSevensInteractor(sevens, new(presenter.SevensCuiPresenter)),
-		),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *SevensCui) Controller() CuiExecer { return cui.sgc }
-
-// HelpLines returns the game's help lines.
-func (cui *SevensCui) HelpLines() []string {
-	return []string{
+	sgc := controller.NewSevensCuiController(
+		usecase.NewSevensInteractor(sevens, new(presenter.SevensCuiPresenter)),
+	)
+	return newCuiGame(sgc, []string{
 		i18n.T("sevens.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -45,10 +31,5 @@ func (cui *SevensCui) HelpLines() []string {
 		"  r [tunnel] [joker=N] [strategy] [passes=N]  reset with options",
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *SevensCui) Exec() {
-	RunCuiLoop(cui.sgc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/ShortDeckCui.go
+++ b/internal/infrastructure/ui/ShortDeckCui.go
@@ -8,26 +8,12 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// ShortDeckCui ショートデックCUIクラス
-type ShortDeckCui struct {
-	sc *controller.ShortDeckCuiController
-}
-
 // NewShortDeckCui コンストラクタ
-func NewShortDeckCui() *ShortDeckCui {
+func NewShortDeckCui() *genericCuiGame {
 	cfg := domain.DefaultShortDeckConfig()
 	sd := domain.NewShortDeck(domain.NewTrumpCardsShortDeck(), domain.NewShortDeckPlayersForTable(cfg.TableSize), cfg)
-	return &ShortDeckCui{
-		sc: controller.NewShortDeckCuiController(usecase.NewShortDeckInteractor(sd, new(presenter.ShortDeckCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *ShortDeckCui) Controller() CuiExecer { return cui.sc }
-
-// HelpLines returns the game's help lines.
-func (cui *ShortDeckCui) HelpLines() []string {
-	return []string{
+	sc := controller.NewShortDeckCuiController(usecase.NewShortDeckInteractor(sd, new(presenter.ShortDeckCuiPresenter)))
+	return newCuiGame(sc, []string{
 		i18n.T("shortdeck.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -54,10 +40,5 @@ func (cui *ShortDeckCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *ShortDeckCui) Exec() {
-	RunCuiLoop(cui.sc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/SpadesCui.go
+++ b/internal/infrastructure/ui/SpadesCui.go
@@ -8,13 +8,8 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// SpadesCui スペードCUIクラス
-type SpadesCui struct {
-	sc *controller.SpadesCuiController
-}
-
 // NewSpadesCui コンストラクタ
-func NewSpadesCui() *SpadesCui {
+func NewSpadesCui() *genericCuiGame {
 	config := domain.DefaultSpadesConfig()
 	players := []*domain.SpadesPlayer{
 		domain.NewSpadesPlayer(true),
@@ -23,17 +18,8 @@ func NewSpadesCui() *SpadesCui {
 		domain.NewSpadesPlayer(false),
 	}
 	spades := domain.NewSpades(domain.NewTrumpCards(0), players, config)
-	return &SpadesCui{
-		sc: controller.NewSpadesCuiController(usecase.NewSpadesInteractor(spades, new(presenter.SpadesCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *SpadesCui) Controller() CuiExecer { return cui.sc }
-
-// HelpLines returns the game's help lines.
-func (cui *SpadesCui) HelpLines() []string {
-	return []string{
+	sc := controller.NewSpadesCuiController(usecase.NewSpadesInteractor(spades, new(presenter.SpadesCuiPresenter)))
+	return newCuiGame(sc, []string{
 		i18n.T("spades.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -51,10 +37,5 @@ func (cui *SpadesCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *SpadesCui) Exec() {
-	RunCuiLoop(cui.sc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/SpeedCui.go
+++ b/internal/infrastructure/ui/SpeedCui.go
@@ -8,13 +8,8 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// SpeedCui スピードCUIクラス
-type SpeedCui struct {
-	sc *controller.SpeedCuiController
-}
-
 // NewSpeedCui コンストラクタ
-func NewSpeedCui() *SpeedCui {
+func NewSpeedCui() *genericCuiGame {
 	players := []*domain.SpeedPlayer{
 		domain.NewSpeedPlayer(true),
 		domain.NewSpeedPlayer(false),
@@ -24,15 +19,7 @@ func NewSpeedCui() *SpeedCui {
 	sc := controller.NewSpeedCuiController(
 		usecase.NewSpeedInteractor(game, new(presenter.SpeedCuiPresenter)),
 	)
-	return &SpeedCui{sc: sc}
-}
-
-// Controller returns the game controller.
-func (cui *SpeedCui) Controller() CuiExecer { return cui.sc }
-
-// HelpLines returns the game's help lines.
-func (cui *SpeedCui) HelpLines() []string {
-	return []string{
+	return newCuiGame(sc, []string{
 		i18n.T("speed.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -47,10 +34,5 @@ func (cui *SpeedCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲームメインループ
-func (cui *SpeedCui) Exec() {
-	RunCuiLoop(cui.sc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/SpiderCui.go
+++ b/internal/infrastructure/ui/SpiderCui.go
@@ -8,25 +8,11 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// SpiderCui スパイダーソリティアCUIクラス
-type SpiderCui struct {
-	sc *controller.SpiderCuiController
-}
-
 // NewSpiderCui コンストラクタ
-func NewSpiderCui() *SpiderCui {
+func NewSpiderCui() *genericCuiGame {
 	spider := domain.NewSpider(domain.NewTrumpCardsWithSuits(domain.SpiderTotalCards, []int{domain.CardDesignSpade}))
-	return &SpiderCui{
-		sc: controller.NewSpiderCuiController(usecase.NewSpiderInteractor(spider, new(presenter.SpiderCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *SpiderCui) Controller() CuiExecer { return cui.sc }
-
-// HelpLines returns the game's help lines.
-func (cui *SpiderCui) HelpLines() []string {
-	return []string{
+	sc := controller.NewSpiderCuiController(usecase.NewSpiderInteractor(spider, new(presenter.SpiderCuiPresenter)))
+	return newCuiGame(sc, []string{
 		i18n.T("spider.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -41,10 +27,5 @@ func (cui *SpiderCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *SpiderCui) Exec() {
-	RunCuiLoop(cui.sc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/ThreeCardCui.go
+++ b/internal/infrastructure/ui/ThreeCardCui.go
@@ -8,27 +8,13 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// ThreeCardCui スリーカードポーカーCUIクラス
-type ThreeCardCui struct {
-	tc *controller.ThreeCardCuiController
-}
-
 // NewThreeCardCui コンストラクタ
-func NewThreeCardCui() *ThreeCardCui {
-	return &ThreeCardCui{
-		tc: controller.NewThreeCardCuiController(usecase.NewThreeCardInteractor(
-			domain.NewDefaultThreeCard(),
-			new(presenter.ThreeCardCuiPresenter),
-		)),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *ThreeCardCui) Controller() CuiExecer { return cui.tc }
-
-// HelpLines returns the game's help lines.
-func (cui *ThreeCardCui) HelpLines() []string {
-	return []string{
+func NewThreeCardCui() *genericCuiGame {
+	tc := controller.NewThreeCardCuiController(usecase.NewThreeCardInteractor(
+		domain.NewDefaultThreeCard(),
+		new(presenter.ThreeCardCuiPresenter),
+	))
+	return newCuiGame(tc, []string{
 		i18n.T("threecard.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -41,10 +27,5 @@ func (cui *ThreeCardCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *ThreeCardCui) Exec() {
-	RunCuiLoop(cui.tc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/TriPeaksCui.go
+++ b/internal/infrastructure/ui/TriPeaksCui.go
@@ -8,25 +8,11 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// TriPeaksCui トリピークスCUIクラス
-type TriPeaksCui struct {
-	tc *controller.TriPeaksCuiController
-}
-
 // NewTriPeaksCui コンストラクタ
-func NewTriPeaksCui() *TriPeaksCui {
+func NewTriPeaksCui() *genericCuiGame {
 	triPeaks := domain.NewTriPeaks(domain.NewTrumpCards(0))
-	return &TriPeaksCui{
-		tc: controller.NewTriPeaksCuiController(usecase.NewTriPeaksInteractor(triPeaks, new(presenter.TriPeaksCuiPresenter))),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *TriPeaksCui) Controller() CuiExecer { return cui.tc }
-
-// HelpLines returns the game's help lines.
-func (cui *TriPeaksCui) HelpLines() []string {
-	return []string{
+	tc := controller.NewTriPeaksCuiController(usecase.NewTriPeaksInteractor(triPeaks, new(presenter.TriPeaksCuiPresenter)))
+	return newCuiGame(tc, []string{
 		i18n.T("tripeaks.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -40,10 +26,5 @@ func (cui *TriPeaksCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *TriPeaksCui) Exec() {
-	RunCuiLoop(cui.tc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/VideoPokerCui.go
+++ b/internal/infrastructure/ui/VideoPokerCui.go
@@ -8,27 +8,13 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
-// VideoPokerCui ビデオポーカーCUIクラス
-type VideoPokerCui struct {
-	vc *controller.VideoPokerCuiController
-}
-
 // NewVideoPokerCui コンストラクタ
-func NewVideoPokerCui() *VideoPokerCui {
-	return &VideoPokerCui{
-		vc: controller.NewVideoPokerCuiController(usecase.NewVideoPokerInteractor(
-			domain.NewDefaultVideoPoker(),
-			new(presenter.VideoPokerCuiPresenter),
-		)),
-	}
-}
-
-// Controller returns the game controller.
-func (cui *VideoPokerCui) Controller() CuiExecer { return cui.vc }
-
-// HelpLines returns the game's help lines.
-func (cui *VideoPokerCui) HelpLines() []string {
-	return []string{
+func NewVideoPokerCui() *genericCuiGame {
+	vc := controller.NewVideoPokerCuiController(usecase.NewVideoPokerInteractor(
+		domain.NewDefaultVideoPoker(),
+		new(presenter.VideoPokerCuiPresenter),
+	))
+	return newCuiGame(vc, []string{
 		i18n.T("videopoker.helpTitle"),
 		"",
 		i18n.T("gameCommands"),
@@ -40,10 +26,5 @@ func (cui *VideoPokerCui) HelpLines() []string {
 		i18n.T("resetEntry"),
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
-	}
-}
-
-// Exec ゲーム実行
-func (cui *VideoPokerCui) Exec() {
-	RunCuiLoop(cui.vc, cui.HelpLines())
+	})
 }

--- a/internal/infrastructure/ui/generic_cui_game.go
+++ b/internal/infrastructure/ui/generic_cui_game.go
@@ -1,0 +1,22 @@
+package ui
+
+// genericCuiGame eliminates per-game struct boilerplate by implementing
+// cuiGame with a controller and help lines provided at construction time.
+type genericCuiGame struct {
+	controller CuiExecer
+	helpLines  []string
+}
+
+// newCuiGame creates a genericCuiGame from a controller and help lines.
+func newCuiGame(controller CuiExecer, helpLines []string) *genericCuiGame {
+	return &genericCuiGame{controller: controller, helpLines: helpLines}
+}
+
+// Controller returns the game controller.
+func (g *genericCuiGame) Controller() CuiExecer { return g.controller }
+
+// HelpLines returns the game's help lines.
+func (g *genericCuiGame) HelpLines() []string { return g.helpLines }
+
+// Exec runs the CUI game loop.
+func (g *genericCuiGame) Exec() { RunCuiLoop(g.controller, g.helpLines) }


### PR DESCRIPTION
## Summary
- Introduced `genericCuiGame` struct in `generic_cui_game.go` that implements `cuiGame` interface (`Controller`, `HelpLines`) and provides `Exec`
- Converted 35 per-game `*Cui.go` files from individual structs with identical method implementations to single constructor functions returning `*genericCuiGame`
- `DoubtCui` retains its custom struct due to its unique game loop with doubt window handling
- **Net reduction: 829 deletions, 187 insertions (~640 lines eliminated)**

## Test plan
- [x] `go build ./...` passes
- [x] `go test -tags test ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `goimports -w` run on all modified files

Closes #1195