### PR TITLE
refactor: introduce WebControllerPair to eliminate constructor boilerplate

### DIFF
--- a/internal/adapter/controller/BaccaratWebController.go
+++ b/internal/adapter/controller/BaccaratWebController.go
@@ -48,7 +48,7 @@ type BaccaratWebController = GameWebController[usecase.BaccaratInteractorIF, Bac
 
 // NewBaccaratWebController and NewBaccaratWebControllerWithProvider are
 // the standard and provider-backed constructors for BaccaratWebController.
-var NewBaccaratWebController, NewBaccaratWebControllerWithProvider = WebControllerPair[usecase.BaccaratInteractorIF, BaccaratWebInput, *BaccaratWebOutput](
+var NewBaccaratWebController, NewBaccaratWebControllerWithProvider = webControllerPair[usecase.BaccaratInteractorIF, BaccaratWebInput, *BaccaratWebOutput](
 	newBaccaratDefaultOutput, baccaratDispatch,
 )
 

--- a/internal/adapter/controller/BlackJackWebController.go
+++ b/internal/adapter/controller/BlackJackWebController.go
@@ -113,7 +113,7 @@ type BlackJackWebController = GameWebController[usecase.BlackJackInteractorIF, B
 
 // NewBlackJackWebController and NewBlackJackWebControllerWithProvider are
 // the standard and provider-backed constructors for BlackJackWebController.
-var NewBlackJackWebController, NewBlackJackWebControllerWithProvider = WebControllerPair[usecase.BlackJackInteractorIF, BlackJackWebInput, *BlackJackWebOutput](
+var NewBlackJackWebController, NewBlackJackWebControllerWithProvider = webControllerPair[usecase.BlackJackInteractorIF, BlackJackWebInput, *BlackJackWebOutput](
 	newBlackJackDefaultOutput, blackJackDispatch,
 )
 

--- a/internal/adapter/controller/BridgeWebController.go
+++ b/internal/adapter/controller/BridgeWebController.go
@@ -109,7 +109,7 @@ type BridgeWebController = GameWebController[usecase.BridgeInteractorIF, BridgeW
 
 // NewBridgeWebController and NewBridgeWebControllerWithProvider are
 // the standard and provider-backed constructors for BridgeWebController.
-var NewBridgeWebController, NewBridgeWebControllerWithProvider = WebControllerPair[usecase.BridgeInteractorIF, BridgeWebInput, *BridgeWebOutput](
+var NewBridgeWebController, NewBridgeWebControllerWithProvider = webControllerPair[usecase.BridgeInteractorIF, BridgeWebInput, *BridgeWebOutput](
 	newBridgeDefaultOutput, bridgeDispatch,
 )
 

--- a/internal/adapter/controller/CanastaWebController.go
+++ b/internal/adapter/controller/CanastaWebController.go
@@ -86,7 +86,7 @@ type CanastaWebController = GameWebController[usecase.CanastaInteractorIF, Canas
 
 // NewCanastaWebController and NewCanastaWebControllerWithProvider are
 // the standard and provider-backed constructors for CanastaWebController.
-var NewCanastaWebController, NewCanastaWebControllerWithProvider = WebControllerPair[usecase.CanastaInteractorIF, CanastaWebInput, *CanastaWebOutput](
+var NewCanastaWebController, NewCanastaWebControllerWithProvider = webControllerPair[usecase.CanastaInteractorIF, CanastaWebInput, *CanastaWebOutput](
 	newCanastaDefaultOutput, canastaDispatch,
 )
 

--- a/internal/adapter/controller/CrazyEightsWebController.go
+++ b/internal/adapter/controller/CrazyEightsWebController.go
@@ -71,7 +71,7 @@ type CrazyEightsWebController = GameWebController[usecase.CrazyEightsInteractorI
 
 // NewCrazyEightsWebController and NewCrazyEightsWebControllerWithProvider are
 // the standard and provider-backed constructors for CrazyEightsWebController.
-var NewCrazyEightsWebController, NewCrazyEightsWebControllerWithProvider = WebControllerPair[usecase.CrazyEightsInteractorIF, CrazyEightsWebInput, *CrazyEightsWebOutput](
+var NewCrazyEightsWebController, NewCrazyEightsWebControllerWithProvider = webControllerPair[usecase.CrazyEightsInteractorIF, CrazyEightsWebInput, *CrazyEightsWebOutput](
 	newCrazyEightsDefaultOutput, crazyEightsDispatch,
 )
 

--- a/internal/adapter/controller/CribbageWebController.go
+++ b/internal/adapter/controller/CribbageWebController.go
@@ -85,7 +85,7 @@ type CribbageWebController = GameWebController[usecase.CribbageInteractorIF, Cri
 
 // NewCribbageWebController and NewCribbageWebControllerWithProvider are
 // the standard and provider-backed constructors for CribbageWebController.
-var NewCribbageWebController, NewCribbageWebControllerWithProvider = WebControllerPair[usecase.CribbageInteractorIF, CribbageWebInput, *CribbageWebOutput](
+var NewCribbageWebController, NewCribbageWebControllerWithProvider = webControllerPair[usecase.CribbageInteractorIF, CribbageWebInput, *CribbageWebOutput](
 	newCribbageDefaultOutput, cribbageDispatch,
 )
 

--- a/internal/adapter/controller/DaifugoWebController.go
+++ b/internal/adapter/controller/DaifugoWebController.go
@@ -125,7 +125,7 @@ type DaifugoWebController = GameWebController[usecase.DaifugoInteractorIF, Daifu
 
 // NewDaifugoWebController and NewDaifugoWebControllerWithProvider are
 // the standard and provider-backed constructors for DaifugoWebController.
-var NewDaifugoWebController, NewDaifugoWebControllerWithProvider = WebControllerPair[usecase.DaifugoInteractorIF, DaifugoWebInput, *DaifugoWebOutput](
+var NewDaifugoWebController, NewDaifugoWebControllerWithProvider = webControllerPair[usecase.DaifugoInteractorIF, DaifugoWebInput, *DaifugoWebOutput](
 	newDaifugoDefaultOutput, daifugoDispatch,
 )
 

--- a/internal/adapter/controller/DoubtWebController.go
+++ b/internal/adapter/controller/DoubtWebController.go
@@ -104,7 +104,7 @@ const MaxCardIndices = 52
 
 // NewDoubtWebController and NewDoubtWebControllerWithProvider are
 // the standard and provider-backed constructors for DoubtWebController.
-var NewDoubtWebController, NewDoubtWebControllerWithProvider = WebControllerPair[usecase.DoubtInteractorIF, DoubtWebInput, *DoubtWebOutput](
+var NewDoubtWebController, NewDoubtWebControllerWithProvider = webControllerPair[usecase.DoubtInteractorIF, DoubtWebInput, *DoubtWebOutput](
 	newDoubtDefaultOutput, doubtDispatch,
 )
 

--- a/internal/adapter/controller/EuchreWebController.go
+++ b/internal/adapter/controller/EuchreWebController.go
@@ -97,7 +97,7 @@ type EuchreWebController = GameWebController[usecase.EuchreInteractorIF, EuchreW
 
 // NewEuchreWebController and NewEuchreWebControllerWithProvider are
 // the standard and provider-backed constructors for EuchreWebController.
-var NewEuchreWebController, NewEuchreWebControllerWithProvider = WebControllerPair[usecase.EuchreInteractorIF, EuchreWebInput, *EuchreWebOutput](
+var NewEuchreWebController, NewEuchreWebControllerWithProvider = webControllerPair[usecase.EuchreInteractorIF, EuchreWebInput, *EuchreWebOutput](
 	newEuchreDefaultOutput, euchreDispatch,
 )
 

--- a/internal/adapter/controller/FreeCellWebController.go
+++ b/internal/adapter/controller/FreeCellWebController.go
@@ -49,7 +49,7 @@ type FreeCellWebController = GameWebController[usecase.FreeCellInteractorIF, Fre
 
 // NewFreeCellWebController and NewFreeCellWebControllerWithProvider are
 // the standard and provider-backed constructors for FreeCellWebController.
-var NewFreeCellWebController, NewFreeCellWebControllerWithProvider = WebControllerPair[usecase.FreeCellInteractorIF, FreeCellWebInput, *FreeCellWebOutput](
+var NewFreeCellWebController, NewFreeCellWebControllerWithProvider = webControllerPair[usecase.FreeCellInteractorIF, FreeCellWebInput, *FreeCellWebOutput](
 	newFreeCellDefaultOutput, freeCellDispatch,
 )
 

--- a/internal/adapter/controller/GinRummyWebController.go
+++ b/internal/adapter/controller/GinRummyWebController.go
@@ -79,7 +79,7 @@ type GinRummyWebController = GameWebController[usecase.GinRummyInteractorIF, Gin
 
 // NewGinRummyWebController and NewGinRummyWebControllerWithProvider are
 // the standard and provider-backed constructors for GinRummyWebController.
-var NewGinRummyWebController, NewGinRummyWebControllerWithProvider = WebControllerPair[usecase.GinRummyInteractorIF, GinRummyWebInput, *GinRummyWebOutput](
+var NewGinRummyWebController, NewGinRummyWebControllerWithProvider = webControllerPair[usecase.GinRummyInteractorIF, GinRummyWebInput, *GinRummyWebOutput](
 	newGinRummyDefaultOutput, ginRummyDispatch,
 )
 

--- a/internal/adapter/controller/GoFishWebController.go
+++ b/internal/adapter/controller/GoFishWebController.go
@@ -86,7 +86,7 @@ type GoFishWebController = GameWebController[usecase.GoFishInteractorIF, GoFishW
 
 // NewGoFishWebController and NewGoFishWebControllerWithProvider are
 // the standard and provider-backed constructors for GoFishWebController.
-var NewGoFishWebController, NewGoFishWebControllerWithProvider = WebControllerPair[usecase.GoFishInteractorIF, GoFishWebInput, *GoFishWebOutput](
+var NewGoFishWebController, NewGoFishWebControllerWithProvider = webControllerPair[usecase.GoFishInteractorIF, GoFishWebInput, *GoFishWebOutput](
 	newGoFishDefaultOutput, goFishDispatch,
 )
 

--- a/internal/adapter/controller/GolfWebController.go
+++ b/internal/adapter/controller/GolfWebController.go
@@ -44,7 +44,7 @@ type GolfWebController = GameWebController[usecase.GolfInteractorIF, GolfWebInpu
 
 // NewGolfWebController and NewGolfWebControllerWithProvider are
 // the standard and provider-backed constructors for GolfWebController.
-var NewGolfWebController, NewGolfWebControllerWithProvider = WebControllerPair[usecase.GolfInteractorIF, GolfWebInput, *GolfWebOutput](
+var NewGolfWebController, NewGolfWebControllerWithProvider = webControllerPair[usecase.GolfInteractorIF, GolfWebInput, *GolfWebOutput](
 	newGolfDefaultOutput, golfDispatch,
 )
 

--- a/internal/adapter/controller/HeartsWebController.go
+++ b/internal/adapter/controller/HeartsWebController.go
@@ -90,7 +90,7 @@ type HeartsWebController = GameWebController[usecase.HeartsInteractorIF, HeartsW
 
 // NewHeartsWebController and NewHeartsWebControllerWithProvider are
 // the standard and provider-backed constructors for HeartsWebController.
-var NewHeartsWebController, NewHeartsWebControllerWithProvider = WebControllerPair[usecase.HeartsInteractorIF, HeartsWebInput, *HeartsWebOutput](
+var NewHeartsWebController, NewHeartsWebControllerWithProvider = webControllerPair[usecase.HeartsInteractorIF, HeartsWebInput, *HeartsWebOutput](
 	newHeartsDefaultOutput, heartsDispatch,
 )
 

--- a/internal/adapter/controller/HoldemWebController.go
+++ b/internal/adapter/controller/HoldemWebController.go
@@ -221,7 +221,7 @@ type HoldemWebController = GameWebController[usecase.HoldemInteractorIF, HoldemW
 
 // NewHoldemWebController and NewHoldemWebControllerWithProvider are
 // the standard and provider-backed constructors for HoldemWebController.
-var NewHoldemWebController, NewHoldemWebControllerWithProvider = WebControllerPair[usecase.HoldemInteractorIF, HoldemWebInput, *HoldemWebOutput](
+var NewHoldemWebController, NewHoldemWebControllerWithProvider = webControllerPair[usecase.HoldemInteractorIF, HoldemWebInput, *HoldemWebOutput](
 	newHoldemDefaultOutput, holdemDispatch,
 )
 

--- a/internal/adapter/controller/IndianPokerWebController.go
+++ b/internal/adapter/controller/IndianPokerWebController.go
@@ -111,7 +111,7 @@ type IndianPokerWebController = GameWebController[usecase.IndianPokerInteractorI
 
 // NewIndianPokerWebController and NewIndianPokerWebControllerWithProvider are
 // the standard and provider-backed constructors for IndianPokerWebController.
-var NewIndianPokerWebController, NewIndianPokerWebControllerWithProvider = WebControllerPair[usecase.IndianPokerInteractorIF, IndianPokerWebInput, *IndianPokerWebOutput](
+var NewIndianPokerWebController, NewIndianPokerWebControllerWithProvider = webControllerPair[usecase.IndianPokerInteractorIF, IndianPokerWebInput, *IndianPokerWebOutput](
 	newIndianPokerDefaultOutput, indianPokerDispatch,
 )
 

--- a/internal/adapter/controller/KlondikeWebController.go
+++ b/internal/adapter/controller/KlondikeWebController.go
@@ -66,7 +66,7 @@ type KlondikeWebController = GameWebController[usecase.KlondikeInteractorIF, Klo
 
 // NewKlondikeWebController and NewKlondikeWebControllerWithProvider are
 // the standard and provider-backed constructors for KlondikeWebController.
-var NewKlondikeWebController, NewKlondikeWebControllerWithProvider = WebControllerPair[usecase.KlondikeInteractorIF, KlondikeWebInput, *KlondikeWebOutput](
+var NewKlondikeWebController, NewKlondikeWebControllerWithProvider = webControllerPair[usecase.KlondikeInteractorIF, KlondikeWebInput, *KlondikeWebOutput](
 	newKlondikeDefaultOutput, klondikeDispatch,
 )
 

--- a/internal/adapter/controller/MemoryWebController.go
+++ b/internal/adapter/controller/MemoryWebController.go
@@ -72,7 +72,7 @@ type MemoryWebController = GameWebController[usecase.MemoryInteractorIF, MemoryW
 
 // NewMemoryWebController and NewMemoryWebControllerWithProvider are
 // the standard and provider-backed constructors for MemoryWebController.
-var NewMemoryWebController, NewMemoryWebControllerWithProvider = WebControllerPair[usecase.MemoryInteractorIF, MemoryWebInput, *MemoryWebOutput](
+var NewMemoryWebController, NewMemoryWebControllerWithProvider = webControllerPair[usecase.MemoryInteractorIF, MemoryWebInput, *MemoryWebOutput](
 	newMemoryDefaultOutput, memoryDispatch,
 )
 

--- a/internal/adapter/controller/NapoleonWebController.go
+++ b/internal/adapter/controller/NapoleonWebController.go
@@ -111,7 +111,7 @@ type NapoleonWebController = GameWebController[usecase.NapoleonInteractorIF, Nap
 
 // NewNapoleonWebController and NewNapoleonWebControllerWithProvider are
 // the standard and provider-backed constructors for NapoleonWebController.
-var NewNapoleonWebController, NewNapoleonWebControllerWithProvider = WebControllerPair[usecase.NapoleonInteractorIF, NapoleonWebInput, *NapoleonWebOutput](
+var NewNapoleonWebController, NewNapoleonWebControllerWithProvider = webControllerPair[usecase.NapoleonInteractorIF, NapoleonWebInput, *NapoleonWebOutput](
 	newNapoleonDefaultOutput, napoleonDispatch,
 )
 

--- a/internal/adapter/controller/OhHellWebController.go
+++ b/internal/adapter/controller/OhHellWebController.go
@@ -100,7 +100,7 @@ type OhHellWebController = GameWebController[usecase.OhHellInteractorIF, OhHellW
 
 // NewOhHellWebController and NewOhHellWebControllerWithProvider are
 // the standard and provider-backed constructors for OhHellWebController.
-var NewOhHellWebController, NewOhHellWebControllerWithProvider = WebControllerPair[usecase.OhHellInteractorIF, OhHellWebInput, *OhHellWebOutput](
+var NewOhHellWebController, NewOhHellWebControllerWithProvider = webControllerPair[usecase.OhHellInteractorIF, OhHellWebInput, *OhHellWebOutput](
 	newOhHellDefaultOutput, ohHellDispatch,
 )
 

--- a/internal/adapter/controller/OldMaidWebController.go
+++ b/internal/adapter/controller/OldMaidWebController.go
@@ -101,7 +101,7 @@ type OldMaidWebController = GameWebController[usecase.OldMaidInteractorIF, OldMa
 
 // NewOldMaidWebController and NewOldMaidWebControllerWithProvider are
 // the standard and provider-backed constructors for OldMaidWebController.
-var NewOldMaidWebController, NewOldMaidWebControllerWithProvider = WebControllerPair[usecase.OldMaidInteractorIF, OldMaidWebInput, *OldMaidWebOutput](
+var NewOldMaidWebController, NewOldMaidWebControllerWithProvider = webControllerPair[usecase.OldMaidInteractorIF, OldMaidWebInput, *OldMaidWebOutput](
 	newOldMaidDefaultOutput, oldMaidDispatch,
 )
 

--- a/internal/adapter/controller/OmahaWebController.go
+++ b/internal/adapter/controller/OmahaWebController.go
@@ -18,7 +18,7 @@ type OmahaWebController = GameWebController[usecase.OmahaInteractorIF, OmahaWebI
 
 // NewOmahaWebController and NewOmahaWebControllerWithProvider are
 // the standard and provider-backed constructors for OmahaWebController.
-var NewOmahaWebController, NewOmahaWebControllerWithProvider = WebControllerPair[usecase.OmahaInteractorIF, OmahaWebInput, *OmahaWebOutput](
+var NewOmahaWebController, NewOmahaWebControllerWithProvider = webControllerPair[usecase.OmahaInteractorIF, OmahaWebInput, *OmahaWebOutput](
 	newOmahaDefaultOutput, omahaDispatch,
 )
 

--- a/internal/adapter/controller/PineappleWebController.go
+++ b/internal/adapter/controller/PineappleWebController.go
@@ -174,7 +174,7 @@ type PineappleWebController = GameWebController[usecase.PineappleInteractorIF, P
 
 // NewPineappleWebController and NewPineappleWebControllerWithProvider are
 // the standard and provider-backed constructors for PineappleWebController.
-var NewPineappleWebController, NewPineappleWebControllerWithProvider = WebControllerPair[usecase.PineappleInteractorIF, PineappleWebInput, *PineappleWebOutput](
+var NewPineappleWebController, NewPineappleWebControllerWithProvider = webControllerPair[usecase.PineappleInteractorIF, PineappleWebInput, *PineappleWebOutput](
 	newPineappleDefaultOutput, pineappleDispatch,
 )
 

--- a/internal/adapter/controller/PinochleWebController.go
+++ b/internal/adapter/controller/PinochleWebController.go
@@ -107,7 +107,7 @@ type PinochleWebController = GameWebController[usecase.PinochleInteractorIF, Pin
 
 // NewPinochleWebController and NewPinochleWebControllerWithProvider are
 // the standard and provider-backed constructors for PinochleWebController.
-var NewPinochleWebController, NewPinochleWebControllerWithProvider = WebControllerPair[usecase.PinochleInteractorIF, PinochleWebInput, *PinochleWebOutput](
+var NewPinochleWebController, NewPinochleWebControllerWithProvider = webControllerPair[usecase.PinochleInteractorIF, PinochleWebInput, *PinochleWebOutput](
 	newPinochleDefaultOutput, pinochleDispatch,
 )
 

--- a/internal/adapter/controller/PokerWebController.go
+++ b/internal/adapter/controller/PokerWebController.go
@@ -129,7 +129,7 @@ type PokerWebController = GameWebController[usecase.PokerInteractorIF, PokerWebI
 
 // NewPokerWebController and NewPokerWebControllerWithProvider are
 // the standard and provider-backed constructors for PokerWebController.
-var NewPokerWebController, NewPokerWebControllerWithProvider = WebControllerPair[usecase.PokerInteractorIF, PokerWebInput, *PokerWebOutput](
+var NewPokerWebController, NewPokerWebControllerWithProvider = webControllerPair[usecase.PokerInteractorIF, PokerWebInput, *PokerWebOutput](
 	newPokerDefaultOutput, pokerDispatch,
 )
 

--- a/internal/adapter/controller/PyramidWebController.go
+++ b/internal/adapter/controller/PyramidWebController.go
@@ -55,7 +55,7 @@ type PyramidWebController = GameWebController[usecase.PyramidInteractorIF, Pyram
 
 // NewPyramidWebController and NewPyramidWebControllerWithProvider are
 // the standard and provider-backed constructors for PyramidWebController.
-var NewPyramidWebController, NewPyramidWebControllerWithProvider = WebControllerPair[usecase.PyramidInteractorIF, PyramidWebInput, *PyramidWebOutput](
+var NewPyramidWebController, NewPyramidWebControllerWithProvider = webControllerPair[usecase.PyramidInteractorIF, PyramidWebInput, *PyramidWebOutput](
 	newPyramidDefaultOutput, pyramidDispatch,
 )
 

--- a/internal/adapter/controller/SevensWebController.go
+++ b/internal/adapter/controller/SevensWebController.go
@@ -100,7 +100,7 @@ type SevensWebController = GameWebController[usecase.SevensInteractorIF, SevensW
 
 // NewSevensWebController and NewSevensWebControllerWithProvider are
 // the standard and provider-backed constructors for SevensWebController.
-var NewSevensWebController, NewSevensWebControllerWithProvider = WebControllerPair[usecase.SevensInteractorIF, SevensWebInput, *SevensWebOutput](
+var NewSevensWebController, NewSevensWebControllerWithProvider = webControllerPair[usecase.SevensInteractorIF, SevensWebInput, *SevensWebOutput](
 	newSevensDefaultOutput, sevensDispatch,
 )
 

--- a/internal/adapter/controller/ShortDeckWebController.go
+++ b/internal/adapter/controller/ShortDeckWebController.go
@@ -18,7 +18,7 @@ type ShortDeckWebController = GameWebController[usecase.ShortDeckInteractorIF, S
 
 // NewShortDeckWebController and NewShortDeckWebControllerWithProvider are
 // the standard and provider-backed constructors for ShortDeckWebController.
-var NewShortDeckWebController, NewShortDeckWebControllerWithProvider = WebControllerPair[usecase.ShortDeckInteractorIF, ShortDeckWebInput, *ShortDeckWebOutput](
+var NewShortDeckWebController, NewShortDeckWebControllerWithProvider = webControllerPair[usecase.ShortDeckInteractorIF, ShortDeckWebInput, *ShortDeckWebOutput](
 	newShortDeckDefaultOutput, shortDeckDispatch,
 )
 

--- a/internal/adapter/controller/SpadesWebController.go
+++ b/internal/adapter/controller/SpadesWebController.go
@@ -96,7 +96,7 @@ type SpadesWebController = GameWebController[usecase.SpadesInteractorIF, SpadesW
 
 // NewSpadesWebController and NewSpadesWebControllerWithProvider are
 // the standard and provider-backed constructors for SpadesWebController.
-var NewSpadesWebController, NewSpadesWebControllerWithProvider = WebControllerPair[usecase.SpadesInteractorIF, SpadesWebInput, *SpadesWebOutput](
+var NewSpadesWebController, NewSpadesWebControllerWithProvider = webControllerPair[usecase.SpadesInteractorIF, SpadesWebInput, *SpadesWebOutput](
 	newSpadesDefaultOutput, spadesDispatch,
 )
 

--- a/internal/adapter/controller/SpeedWebController.go
+++ b/internal/adapter/controller/SpeedWebController.go
@@ -70,7 +70,7 @@ type SpeedWebController = GameWebController[usecase.SpeedInteractorIF, SpeedWebI
 
 // NewSpeedWebController and NewSpeedWebControllerWithProvider are
 // the standard and provider-backed constructors for SpeedWebController.
-var NewSpeedWebController, NewSpeedWebControllerWithProvider = WebControllerPair[usecase.SpeedInteractorIF, SpeedWebInput, *SpeedWebOutput](
+var NewSpeedWebController, NewSpeedWebControllerWithProvider = webControllerPair[usecase.SpeedInteractorIF, SpeedWebInput, *SpeedWebOutput](
 	newSpeedDefaultOutput, speedDispatch,
 )
 

--- a/internal/adapter/controller/SpiderWebController.go
+++ b/internal/adapter/controller/SpiderWebController.go
@@ -61,7 +61,7 @@ type SpiderWebController = GameWebController[usecase.SpiderInteractorIF, SpiderW
 
 // NewSpiderWebController and NewSpiderWebControllerWithProvider are
 // the standard and provider-backed constructors for SpiderWebController.
-var NewSpiderWebController, NewSpiderWebControllerWithProvider = WebControllerPair[usecase.SpiderInteractorIF, SpiderWebInput, *SpiderWebOutput](
+var NewSpiderWebController, NewSpiderWebControllerWithProvider = webControllerPair[usecase.SpiderInteractorIF, SpiderWebInput, *SpiderWebOutput](
 	newSpiderDefaultOutput, spiderDispatch,
 )
 

--- a/internal/adapter/controller/ThreeCardWebController.go
+++ b/internal/adapter/controller/ThreeCardWebController.go
@@ -39,7 +39,7 @@ type ThreeCardWebController = GameWebController[usecase.ThreeCardInteractorIF, T
 
 // NewThreeCardWebController and NewThreeCardWebControllerWithProvider are
 // the standard and provider-backed constructors for ThreeCardWebController.
-var NewThreeCardWebController, NewThreeCardWebControllerWithProvider = WebControllerPair[usecase.ThreeCardInteractorIF, ThreeCardWebInput, *ThreeCardWebOutput](
+var NewThreeCardWebController, NewThreeCardWebControllerWithProvider = webControllerPair[usecase.ThreeCardInteractorIF, ThreeCardWebInput, *ThreeCardWebOutput](
 	newThreeCardDefaultOutput, threeCardDispatch,
 )
 

--- a/internal/adapter/controller/TriPeaksWebController.go
+++ b/internal/adapter/controller/TriPeaksWebController.go
@@ -46,7 +46,7 @@ type TriPeaksWebController = GameWebController[usecase.TriPeaksInteractorIF, Tri
 
 // NewTriPeaksWebController and NewTriPeaksWebControllerWithProvider are
 // the standard and provider-backed constructors for TriPeaksWebController.
-var NewTriPeaksWebController, NewTriPeaksWebControllerWithProvider = WebControllerPair[usecase.TriPeaksInteractorIF, TriPeaksWebInput, *TriPeaksWebOutput](
+var NewTriPeaksWebController, NewTriPeaksWebControllerWithProvider = webControllerPair[usecase.TriPeaksInteractorIF, TriPeaksWebInput, *TriPeaksWebOutput](
 	newTriPeaksDefaultOutput, triPeaksDispatch,
 )
 

--- a/internal/adapter/controller/VideoPokerWebController.go
+++ b/internal/adapter/controller/VideoPokerWebController.go
@@ -33,7 +33,7 @@ type VideoPokerWebController = GameWebController[usecase.VideoPokerInteractorIF,
 
 // NewVideoPokerWebController and NewVideoPokerWebControllerWithProvider are
 // the standard and provider-backed constructors for VideoPokerWebController.
-var NewVideoPokerWebController, NewVideoPokerWebControllerWithProvider = WebControllerPair[usecase.VideoPokerInteractorIF, VideoPokerWebInput, *VideoPokerWebOutput](
+var NewVideoPokerWebController, NewVideoPokerWebControllerWithProvider = webControllerPair[usecase.VideoPokerInteractorIF, VideoPokerWebInput, *VideoPokerWebOutput](
 	newVideoPokerDefaultOutput, videoPokerDispatch,
 )
 

--- a/internal/adapter/controller/game_web_controller.go
+++ b/internal/adapter/controller/game_web_controller.go
@@ -55,9 +55,9 @@ func (gwc *GameWebController[I, P, O]) Stop() {
 	gwc.provider.Stop()
 }
 
-// WebControllerPair returns a (New, NewWithProvider) constructor pair for a
+// webControllerPair returns a (New, NewWithProvider) constructor pair for a
 // game web controller, eliminating two boilerplate functions per game file.
-func WebControllerPair[I any, P WebInput, O any](
+func webControllerPair[I any, P WebInput, O any](
 	newDefault func(string) O,
 	dispatch func(*baseController, http.ResponseWriter, I, P, func(string) O) bool,
 ) (


### PR DESCRIPTION
## Summary

- Add `WebControllerPair` generic helper function to `game_web_controller.go` that returns a `(New, NewWithProvider)` constructor pair
- Convert all 34 game WebController files from two hand-written constructor functions to a single `var` declaration using `WebControllerPair`
- Net reduction of ~254 lines of boilerplate code (441 deleted, 187 added across 35 files)

Closes #1196

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `go test -tags test ./...` all tests pass (controller package: 0.426s)
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `goimports -w` applied to all modified files