### PR TITLE
fix: render ManualModal via portal to escape stacking context

### DIFF
--- a/frontend/src/components/ManualModal.test.tsx
+++ b/frontend/src/components/ManualModal.test.tsx
@@ -20,8 +20,8 @@ vi.mock('../constants/manualTexts', () => ({
 
 describe('ManualModal', () => {
   it('renders nothing when closed', () => {
-    const { container } = render(<ManualModal open={false} onClose={vi.fn()} gamePath="/" />);
-    expect(container.innerHTML).toBe('');
+    render(<ManualModal open={false} onClose={vi.fn()} gamePath="/" />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
   it('renders markdown content when open', () => {
@@ -48,9 +48,10 @@ describe('ManualModal', () => {
   });
 
   it('renders mermaid diagram', async () => {
-    const { container } = render(<ManualModal open={true} onClose={vi.fn()} gamePath="/mermaid" />);
+    render(<ManualModal open={true} onClose={vi.fn()} gamePath="/mermaid" />);
     await waitFor(() => {
-      expect(container.querySelector('svg')).toBeTruthy();
+      const dialog = screen.getByRole('dialog');
+      expect(dialog.querySelector('svg')).toBeTruthy();
     });
   });
 
@@ -123,9 +124,10 @@ describe('ManualModal', () => {
   });
 
   it('renders regular code block inside pre without unwrapping', () => {
-    const { container } = render(<ManualModal open={true} onClose={vi.fn()} gamePath="/code" />);
-    expect(container.querySelector('pre')).toBeInTheDocument();
-    expect(container.querySelector('code')).toBeInTheDocument();
+    render(<ManualModal open={true} onClose={vi.fn()} gamePath="/code" />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.querySelector('pre')).toBeInTheDocument();
+    expect(dialog.querySelector('code')).toBeInTheDocument();
   });
 
   it('ignores non-Tab/non-Escape keydown events', () => {

--- a/frontend/src/components/ManualModal.tsx
+++ b/frontend/src/components/ManualModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import type { Components } from 'react-markdown';
 import Markdown from 'react-markdown';
@@ -90,7 +91,7 @@ export function ManualModal({ open, onClose, gamePath }: ManualModalProps) {
 
   const markdown = manualTexts[gamePath] ?? '';
 
-  return (
+  return createPortal(
     // biome-ignore lint/a11y/noStaticElementInteractions: overlay backdrop dismisses modal on click
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
@@ -117,6 +118,7 @@ export function ManualModal({ open, onClose, gamePath }: ManualModalProps) {
           </Markdown>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }


### PR DESCRIPTION
## Summary
- ManualModal was hidden behind NavBar and game UI due to `backdrop-filter` on ancestor elements (e.g., `PhaseIndicator`'s `glass-panel` class) creating a new stacking context that trapped the modal's `fixed` + `z-50`
- Use `createPortal(…, document.body)` to render the modal at the document root, ensuring it always appears on top
- Updated tests to query portal-rendered elements via `screen` / `dialog` instead of `container`

## Test plan
- [x] `bun run test -- --run ManualModal` — 17/17 pass
- [x] `bun run check` — no lint errors
- [x] `bun run build` — builds successfully
- [ ] Open Klondike and click the manual button — modal should appear above all UI elements
- [ ] Verify on mobile viewport — close button and overlay visible and functional