### PR TITLE
feat: add port validation, games subcommand, and game name aliases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ go run ./cmd/trumpcards --lang en <game>   # Run in English
 # crazyeights, ginrummy, spider, napoleon, indianpoker, videopoker, deuceswild,
 # jokerpoker, euchre, pyramid, tripeaks, cribbage, threecard, ohhell, bridge, speed,
 # gofish, canasta, pinochle, golf, pigtail, sevencardstud, clocksolitaire
+go run ./cmd/trumpcards games      # List all available games
+go run ./cmd/trumpcards games --short  # List game names only (for scripting)
 go run ./cmd/trumpcards update     # Self-update to the latest version
 go run ./cmd/trumpcards web        # Start REST API + web GUI server (via CLI)
 go run ./cmd/trumpcards web --port 3000  # Start web server on custom port

--- a/cmd/trumpcards/completion.go
+++ b/cmd/trumpcards/completion.go
@@ -8,13 +8,13 @@ import (
 
 // completionSubcommands is the list of all subcommands for shell completion.
 var completionSubcommands = []string{
-	"baccarat", "blackjack", "bridge", "canasta", "completion", "crazyeights",
-	"cribbage", "daifugo", "deuceswild", "doubt", "euchre", "freecell",
-	"ginrummy", "gofish", "golf", "hearts", "holdem", "indianpoker",
-	"jokerpoker", "klondike", "memory", "napoleon", "ohhell", "oldmaid",
-	"omaha", "pineapple", "pinochle", "poker", "pyramid", "sevens",
-	"shortdeck", "spades", "speed", "spider", "threecard", "tripeaks",
-	"update", "videopoker", "web",
+	"baccarat", "blackjack", "bridge", "canasta", "clocksolitaire", "completion",
+	"crazyeights", "cribbage", "daifugo", "deuceswild", "doubt", "euchre",
+	"freecell", "games", "ginrummy", "gofish", "golf", "hearts", "holdem",
+	"indianpoker", "jokerpoker", "klondike", "memory", "napoleon", "ohhell",
+	"oldmaid", "omaha", "pigtail", "pineapple", "pinochle", "poker", "pyramid",
+	"sevencardstud", "sevens", "shortdeck", "spades", "speed", "spider",
+	"threecard", "tripeaks", "update", "videopoker", "web",
 }
 
 // runCompletion outputs a shell completion script for the given shell name.
@@ -103,7 +103,7 @@ func writeBashCompletion(w io.Writer) error {
         return
     fi
 
-    local commands="baccarat blackjack bridge canasta completion crazyeights cribbage daifugo deuceswild doubt euchre freecell ginrummy gofish golf hearts holdem indianpoker jokerpoker klondike memory napoleon ohhell oldmaid omaha pineapple pinochle poker pyramid sevens shortdeck spades speed spider threecard tripeaks update videopoker web"
+    local commands="baccarat blackjack bridge canasta clocksolitaire completion crazyeights cribbage daifugo deuceswild doubt euchre freecell games ginrummy gofish golf hearts holdem indianpoker jokerpoker klondike memory napoleon ohhell oldmaid omaha pigtail pineapple pinochle poker pyramid sevencardstud sevens shortdeck spades speed spider threecard tripeaks update videopoker web"
     COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
 }
 complete -F _trumpcards trumpcards
@@ -122,6 +122,7 @@ _trumpcards() {
         'blackjack:BlackJack'
         'bridge:Contract Bridge'
         'canasta:Canasta'
+        'clocksolitaire:Clock Solitaire'
         'completion:Generate shell completion script'
         'crazyeights:Crazy Eights'
         'cribbage:Cribbage'
@@ -130,6 +131,7 @@ _trumpcards() {
         'doubt:Doubt'
         'euchre:Euchre'
         'freecell:FreeCell'
+        'games:List available games'
         'ginrummy:Gin Rummy'
         'gofish:Go Fish'
         'golf:Golf Solitaire'
@@ -143,10 +145,12 @@ _trumpcards() {
         'ohhell:Oh Hell'
         'oldmaid:Old Maid'
         'omaha:Omaha Hold'\''em'
+        'pigtail:Pig'\''s Tail'
         'pineapple:Pineapple Poker'
         'pinochle:Pinochle'
         'poker:5-card Draw Poker'
         'pyramid:Pyramid'
+        'sevencardstud:Seven Card Stud'
         'sevens:Sevens'
         'shortdeck:Short Deck Hold'\''em'
         'spades:Spades'
@@ -206,6 +210,7 @@ complete -c trumpcards -n __fish_use_subcommand -a baccarat -d 'Baccarat'
 complete -c trumpcards -n __fish_use_subcommand -a blackjack -d 'BlackJack'
 complete -c trumpcards -n __fish_use_subcommand -a bridge -d 'Contract Bridge'
 complete -c trumpcards -n __fish_use_subcommand -a canasta -d 'Canasta'
+complete -c trumpcards -n __fish_use_subcommand -a clocksolitaire -d 'Clock Solitaire'
 complete -c trumpcards -n __fish_use_subcommand -a completion -d 'Generate shell completion script'
 complete -c trumpcards -n __fish_use_subcommand -a crazyeights -d 'Crazy Eights'
 complete -c trumpcards -n __fish_use_subcommand -a cribbage -d 'Cribbage'
@@ -214,6 +219,7 @@ complete -c trumpcards -n __fish_use_subcommand -a deuceswild -d 'Deuces Wild'
 complete -c trumpcards -n __fish_use_subcommand -a doubt -d 'Doubt'
 complete -c trumpcards -n __fish_use_subcommand -a euchre -d 'Euchre'
 complete -c trumpcards -n __fish_use_subcommand -a freecell -d 'FreeCell'
+complete -c trumpcards -n __fish_use_subcommand -a games -d 'List available games'
 complete -c trumpcards -n __fish_use_subcommand -a ginrummy -d 'Gin Rummy'
 complete -c trumpcards -n __fish_use_subcommand -a gofish -d 'Go Fish'
 complete -c trumpcards -n __fish_use_subcommand -a golf -d 'Golf Solitaire'
@@ -227,10 +233,12 @@ complete -c trumpcards -n __fish_use_subcommand -a napoleon -d 'Napoleon'
 complete -c trumpcards -n __fish_use_subcommand -a ohhell -d 'Oh Hell'
 complete -c trumpcards -n __fish_use_subcommand -a oldmaid -d 'Old Maid'
 complete -c trumpcards -n __fish_use_subcommand -a omaha -d 'Omaha Hold'\''em'
+complete -c trumpcards -n __fish_use_subcommand -a pigtail -d 'Pig'\''s Tail'
 complete -c trumpcards -n __fish_use_subcommand -a pineapple -d 'Pineapple Poker'
 complete -c trumpcards -n __fish_use_subcommand -a pinochle -d 'Pinochle'
 complete -c trumpcards -n __fish_use_subcommand -a poker -d '5-card Draw Poker'
 complete -c trumpcards -n __fish_use_subcommand -a pyramid -d 'Pyramid'
+complete -c trumpcards -n __fish_use_subcommand -a sevencardstud -d 'Seven Card Stud'
 complete -c trumpcards -n __fish_use_subcommand -a sevens -d 'Sevens'
 complete -c trumpcards -n __fish_use_subcommand -a shortdeck -d 'Short Deck Hold'\''em'
 complete -c trumpcards -n __fish_use_subcommand -a spades -d 'Spades'

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -74,6 +74,9 @@ GAMES:
   sevencardstud Seven Card Stud (セブンカードスタッド)
   golf         Golf Solitaire (ゴルフ)
   clocksolitaire Clock Solitaire (クロックソリティア)
+
+COMMANDS:
+  games        List all available games (--short for names only)
   completion   Generate shell completion script (bash, zsh, fish)
   update       Self-update to the latest version
   web          Start REST API + web GUI server
@@ -90,6 +93,8 @@ EXAMPLES:
   trumpcards                     Start interactive mode (switch games with 'switch <game>')
   trumpcards blackjack           Play BlackJack
   trumpcards --lang en poker     Play Poker in English
+  trumpcards games               List all available games
+  trumpcards games --short       List game names only (for scripting)
   trumpcards update              Self-update to the latest version
   NO_COLOR=1 trumpcards hearts   Play Hearts without color output
   trumpcards web                 Start the web GUI server
@@ -148,6 +153,49 @@ ENVIRONMENT VARIABLES:
 	if i18n.Lang() != detectedLang && detectedLang != "" {
 		fmt.Fprintln(os.Stderr, i18n.Tf("cliUnsupportedLang", "lang", detectedLang))
 	}
+	// gameDescriptions maps canonical game names to display descriptions.
+	gameDescriptions := map[string]string{
+		"blackjack":      "BlackJack (ブラックジャック)",
+		"poker":          "5-card Draw Poker (ポーカー)",
+		"oldmaid":        "Old Maid (ババ抜き)",
+		"daifugo":        "Daifugo / Great Fool (大富豪)",
+		"sevens":         "Sevens (7並べ)",
+		"doubt":          "Doubt (ダウト)",
+		"holdem":         "Texas Hold'em (テキサスホールデム)",
+		"omaha":          "Omaha Hold'em (オマハホールデム)",
+		"shortdeck":      "Short Deck (6+ Hold'em) (ショートデック)",
+		"pineapple":      "Pineapple Poker (パイナップルポーカー)",
+		"hearts":         "Hearts (ハーツ)",
+		"memory":         "Memory / Concentration (神経衰弱)",
+		"klondike":       "Klondike Solitaire (ソリティア)",
+		"freecell":       "FreeCell (フリーセル)",
+		"baccarat":       "Baccarat (バカラ)",
+		"spades":         "Spades (スペード)",
+		"crazyeights":    "Crazy Eights (クレイジーエイト)",
+		"ginrummy":       "Gin Rummy (ジンラミー)",
+		"canasta":        "Canasta (カナスタ)",
+		"spider":         "Spider Solitaire (スパイダーソリティア)",
+		"napoleon":       "Napoleon (ナポレオン)",
+		"indianpoker":    "Indian Poker (インディアンポーカー)",
+		"videopoker":     "Video Poker Jacks or Better (ビデオポーカー)",
+		"deuceswild":     "Deuces Wild (デューシーズワイルド)",
+		"jokerpoker":     "Joker Poker (ジョーカーポーカー)",
+		"euchre":         "Euchre (ユーカー)",
+		"pyramid":        "Pyramid (ピラミッド)",
+		"tripeaks":       "TriPeaks (トリピークス)",
+		"cribbage":       "Cribbage (クリベッジ)",
+		"threecard":      "Three Card Poker (スリーカードポーカー)",
+		"ohhell":         "Oh Hell (オー・ヘル)",
+		"bridge":         "Contract Bridge (コントラクトブリッジ)",
+		"speed":          "Speed (スピード)",
+		"gofish":         "Go Fish (ゴーフィッシュ)",
+		"pinochle":       "Pinochle (ピノクル)",
+		"golf":           "Golf Solitaire (ゴルフ)",
+		"pigtail":        "Pig's Tail (ブタのしっぽ)",
+		"sevencardstud":  "Seven Card Stud (セブンカードスタッド)",
+		"clocksolitaire": "Clock Solitaire (クロックソリティア)",
+	}
+
 	commands := map[string]func() int{
 		"blackjack":      func() int { ui.NewBlackJackCui().Exec(); return 0 },
 		"poker":          func() int { ui.NewPokerCui().Exec(); return 0 },
@@ -188,6 +236,21 @@ ENVIRONMENT VARIABLES:
 		"pigtail":        func() int { ui.NewPigsTailCui().Exec(); return 0 },
 		"sevencardstud":  func() int { ui.NewSevenCardStudCui().Exec(); return 0 },
 		"clocksolitaire": func() int { ui.NewClockSolitaireCui().Exec(); return 0 },
+		"games": func() int {
+			gamesFlags := flag.NewFlagSet("games", flag.ContinueOnError)
+			short := gamesFlags.Bool("short", false, "Print game names only")
+			if err := gamesFlags.Parse(flag.Args()[1:]); err != nil {
+				return 1
+			}
+			for _, name := range ui.GameNames {
+				if *short {
+					fmt.Println(name)
+				} else {
+					fmt.Printf("  %-16s %s\n", name, gameDescriptions[name])
+				}
+			}
+			return 0
+		},
 		"completion": func() int {
 			return runCompletion(flag.Args()[1:])
 		},
@@ -208,7 +271,11 @@ ENVIRONMENT VARIABLES:
 			if webFlags.NArg() > 0 {
 				fmt.Fprintln(os.Stderr, i18n.Tf("cliExtraArgsWarning", "args", strings.Join(webFlags.Args(), " ")))
 			}
-			if *port > 0 {
+			if *port != 0 {
+				if *port < 1 || *port > 65535 {
+					fmt.Fprintln(os.Stderr, i18n.Tf("cliInvalidPort", "port", strconv.Itoa(*port)))
+					return 1
+				}
 				_ = os.Setenv("PORT", strconv.Itoa(*port))
 			}
 			infrastructure.InitLogger()
@@ -222,9 +289,13 @@ ENVIRONMENT VARIABLES:
 	}
 
 	// Commands that parse their own sub-flags; skip the extra-args warning for these.
-	subFlagCommands := map[string]bool{"web": true, "completion": true}
+	subFlagCommands := map[string]bool{"web": true, "completion": true, "games": true}
 
 	arg := strings.ToLower(flag.Arg(0))
+	// Resolve game name aliases (e.g., "gin" -> "ginrummy", "7stud" -> "sevencardstud").
+	if canonical, ok := ui.GameAliases[arg]; ok {
+		arg = canonical
+	}
 	if handler, ok := commands[arg]; ok {
 		if flag.NArg() > 1 && !subFlagCommands[arg] {
 			fmt.Fprintln(os.Stderr, i18n.Tf("cliExtraArgsWarning", "args", strings.Join(flag.Args()[1:], " ")))

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -240,7 +241,13 @@ ENVIRONMENT VARIABLES:
 			gamesFlags := flag.NewFlagSet("games", flag.ContinueOnError)
 			short := gamesFlags.Bool("short", false, "Print game names only")
 			if err := gamesFlags.Parse(flag.Args()[1:]); err != nil {
+				if errors.Is(err, flag.ErrHelp) {
+					return 0
+				}
 				return 1
+			}
+			if gamesFlags.NArg() > 0 {
+				fmt.Fprintln(os.Stderr, i18n.Tf("cliExtraArgsWarning", "args", strings.Join(gamesFlags.Args(), " ")))
 			}
 			for _, name := range ui.GameNames {
 				if *short {
@@ -266,6 +273,9 @@ ENVIRONMENT VARIABLES:
 			port := webFlags.Int("port", 0, "Port number for the web server (default: 8080)")
 			webFlags.IntVar(port, "p", 0, "Port number for the web server (shorthand)")
 			if err := webFlags.Parse(flag.Args()[1:]); err != nil {
+				if errors.Is(err, flag.ErrHelp) {
+					return 0
+				}
 				return 1
 			}
 			if webFlags.NArg() > 0 {

--- a/frontend/src/pages/PigsTailPage.test.tsx
+++ b/frontend/src/pages/PigsTailPage.test.tsx
@@ -1,11 +1,10 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { pigtailApi } from '../api/gameApi';
+import { useCliMode } from '../hooks/useCliMode';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { PigsTailResponse } from '../types/card';
 import { PigsTailPage } from './PigsTailPage';
-
-import { useCliMode } from '../hooks/useCliMode';
 
 vi.mock('../hooks/useCliMode', () => ({
   useCliMode: vi.fn(() => ({

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -34,6 +34,7 @@
   "cliUnsupportedLang": "Warning: unsupported language \"{{lang}}\", defaulting to ja",
   "emptyInputHint": "Type 'help' for available commands.",
   "cliStartupBanner": "trumpcards {{version}} - Interactive Mode",
+  "cliInvalidPort": "Error: invalid port number {{port}} (must be 1-65535)",
   "cliExtraArgsWarning": "Warning: extra arguments ignored: {{args}}",
   "metaAIRequired": "Meta-AI setting is required (0=off, 1=on).",
   "invalidMetaAI": "Invalid value: {{val}}. Please enter 0 or 1.",

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -34,6 +34,7 @@
   "cliUnsupportedLang": "警告: サポートされていない言語「{{lang}}」です。ja をデフォルトとして使用します",
   "emptyInputHint": "'help' でコマンド一覧を表示します。",
   "cliStartupBanner": "trumpcards {{version}} - インタラクティブモード",
+  "cliInvalidPort": "エラー: 無効なポート番号 {{port}} です (1-65535 の範囲で指定してください)",
   "cliExtraArgsWarning": "警告: 余分な引数は無視されました: {{args}}",
   "metaAIRequired": "メタAI設定が必要です (0=オフ, 1=オン)。",
   "invalidMetaAI": "無効な値です: {{val}}。0 または 1 を入力してください。",

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -8,8 +8,8 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
-// gameNames is the canonical ordered list of available game names.
-var gameNames = []string{
+// GameNames is the canonical ordered list of available game names.
+var GameNames = []string{
 	"blackjack", "poker", "oldmaid", "daifugo", "sevens",
 	"doubt", "holdem", "omaha", "shortdeck", "pineapple",
 	"hearts", "memory", "klondike", "freecell", "baccarat",
@@ -18,6 +18,23 @@ var gameNames = []string{
 	"euchre", "pyramid", "tripeaks", "cribbage", "threecard",
 	"ohhell", "bridge", "speed", "gofish", "pinochle", "golf",
 	"pigtail", "sevencardstud", "clocksolitaire",
+}
+
+// GameAliases maps short alias names to their canonical game names.
+// Aliases are not shown in help or game lists.
+var GameAliases = map[string]string{
+	"7stud":  "sevencardstud",
+	"7cs":    "sevencardstud",
+	"clock":  "clocksolitaire",
+	"crazy8": "crazyeights",
+	"indian": "indianpoker",
+	"video":  "videopoker",
+	"deuces": "deuceswild",
+	"joker":  "jokerpoker",
+	"short":  "shortdeck",
+	"6plus":  "shortdeck",
+	"gin":    "ginrummy",
+	"3card":  "threecard",
 }
 
 // cuiGame is implemented by each *Cui struct to expose its controller and help lines.
@@ -48,7 +65,7 @@ func NewGameManager(startGame string) *GameManager {
 		helpLines:   helpLines,
 		initialized: make(map[string]bool),
 		currentGame: startGame,
-		gameOrder:   gameNames,
+		gameOrder:   GameNames,
 	}
 }
 
@@ -108,6 +125,9 @@ func (m *GameManager) initGame(name string) string {
 
 func (m *GameManager) switchGame(name string) string {
 	name = strings.ToLower(name)
+	if canonical, ok := GameAliases[name]; ok {
+		name = canonical
+	}
 	if _, ok := m.games[name]; !ok {
 		msg := i18n.Tf("unknownGame", "name", name)
 		if suggestion := cuiutil.SuggestCommand(name, m.gameOrder, 2); suggestion != "" {

--- a/internal/infrastructure/ui/GameManager_test.go
+++ b/internal/infrastructure/ui/GameManager_test.go
@@ -230,7 +230,7 @@ func TestGameManager_NewGameManager_Smoke(t *testing.T) {
 	mgr := NewGameManager("blackjack")
 	assert.Equal(t, "blackjack", mgr.CurrentGame())
 	assert.NotNil(t, mgr.games["blackjack"])
-	assert.Len(t, mgr.games, len(gameNames))
+	assert.Len(t, mgr.games, len(GameNames))
 }
 
 func TestGameManager_NewGameManager_AllGamesRegistered(t *testing.T) {
@@ -246,4 +246,54 @@ func TestGameManager_NewGameManager_PanicsOnInvalidGame(t *testing.T) {
 	assert.Panics(t, func() {
 		NewGameManager("chess")
 	})
+}
+
+func TestGameManager_SwitchAlias(t *testing.T) {
+	mgr := NewGameManager("blackjack")
+	mgr.InitCurrentGame()
+
+	// "gin" is an alias for "ginrummy"
+	result := mgr.Exec("switch gin")
+	assert.Contains(t, result, "ginrummy")
+	assert.Equal(t, "ginrummy", mgr.CurrentGame())
+}
+
+func TestGameManager_SwitchAliasMultiple(t *testing.T) {
+	mgr := NewGameManager("blackjack")
+	mgr.InitCurrentGame()
+
+	tests := []struct {
+		alias     string
+		canonical string
+	}{
+		{"7stud", "sevencardstud"},
+		{"clock", "clocksolitaire"},
+		{"crazy8", "crazyeights"},
+		{"indian", "indianpoker"},
+		{"video", "videopoker"},
+		{"deuces", "deuceswild"},
+		{"joker", "jokerpoker"},
+		{"short", "shortdeck"},
+		{"6plus", "shortdeck"},
+		{"3card", "threecard"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.alias, func(t *testing.T) {
+			// Reset to blackjack so we can switch
+			mgr.currentGame = "blackjack"
+			result := mgr.Exec("switch " + tt.alias)
+			assert.Contains(t, result, tt.canonical)
+			assert.Equal(t, tt.canonical, mgr.CurrentGame())
+		})
+	}
+}
+
+func TestGameAliases_AllPointToValidGames(t *testing.T) {
+	gameSet := make(map[string]bool, len(GameNames))
+	for _, name := range GameNames {
+		gameSet[name] = true
+	}
+	for alias, canonical := range GameAliases {
+		assert.True(t, gameSet[canonical], "alias %q points to unknown game %q", alias, canonical)
+	}
 }

--- a/internal/infrastructure/ui/GameManager_test.go
+++ b/internal/infrastructure/ui/GameManager_test.go
@@ -267,6 +267,7 @@ func TestGameManager_SwitchAliasMultiple(t *testing.T) {
 		canonical string
 	}{
 		{"7stud", "sevencardstud"},
+		{"7cs", "sevencardstud"},
 		{"clock", "clocksolitaire"},
 		{"crazy8", "crazyeights"},
 		{"indian", "indianpoker"},


### PR DESCRIPTION
## Summary
- **#1217**: Validate `web --port` range (1-65535) with localized error messages instead of opaque OS errors
- **#1218**: Add `games` subcommand to list available games (`--short` flag for scripting/piping)
- **#1219**: Add 12 short aliases for long game names (e.g., `gin`→`ginrummy`, `7stud`→`sevencardstud`, `clock`→`clocksolitaire`) in both CLI and interactive mode
- Fix missing `clocksolitaire`, `pigtail`, `sevencardstud` in shell completion scripts (bash/zsh/fish)

Closes #1217, Closes #1218, Closes #1219

## Test plan
- [x] `trumpcards web --port 99999` → clear error message with valid range
- [x] `trumpcards web --port -1` → clear error message
- [x] `trumpcards games` → formatted game list with descriptions
- [x] `trumpcards games --short` → one game name per line
- [x] `trumpcards gin` → launches Gin Rummy (alias resolution)
- [x] `switch 7stud` in interactive mode → switches to Seven Card Stud
- [x] All existing tests pass (`go test -tags test ./...`)
- [x] `golangci-lint run ./...` clean