### PR TITLE
feat: consolidate color system and improve a11y for search, messages, and logs

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -79,6 +79,16 @@
 | `--error-hover` | `#B54949` | Error button hover |
 | `--surface-elevated-hover` | `#2A3A4F` | Elevated surface hover |
 
+### Game-specific palette (poker action buttons)
+| Token | Hex | Usage |
+|-------|-----|-------|
+| `emerald-600` | `#059669` | Call / Check — positive action |
+| `sky-500` | `#0ea5e9` | Raise / Bet — escalation |
+| `amber-500` | `#f59e0b` | All-in — high-stakes |
+| `gray-500` | `#6b7280` | Fold — passive/exit |
+
+These use Tailwind built-in colors directly for game UX color-coding. They are scoped to poker-family button styles (`btnPoker*` in `buttonStyles.ts`) and should not be used elsewhere.
+
 ### Light mode (planned, not yet implemented)
 | Token | Hex |
 |-------|-----|

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -82,12 +82,12 @@
 ### Game-specific palette (poker action buttons)
 | Token | Hex | Usage |
 |-------|-----|-------|
-| `emerald-600` | `#059669` | Call / Check — positive action |
-| `sky-500` | `#0ea5e9` | Raise / Bet — escalation |
-| `amber-500` | `#f59e0b` | All-in — high-stakes |
-| `gray-500` | `#6b7280` | Fold — passive/exit |
+| `--poker-call` | `#059669` | Call / Check — positive action |
+| `--poker-raise` | `#0ea5e9` | Raise / Bet — escalation |
+| `--poker-allin` | `#f59e0b` | All-in — high-stakes |
+| `--poker-fold` | `#6b7280` | Fold — passive/exit |
 
-These use Tailwind built-in colors directly for game UX color-coding. They are scoped to poker-family button styles (`btnPoker*` in `buttonStyles.ts`) and should not be used elsewhere.
+These use design system tokens for game UX color-coding. They are scoped to poker-family button styles (`btnPoker*` in `buttonStyles.ts`) and are defined in `index.css`.
 
 ### Light mode (planned, not yet implemented)
 | Token | Hex |

--- a/frontend/src/components/BettingControls.test.tsx
+++ b/frontend/src/components/BettingControls.test.tsx
@@ -45,16 +45,16 @@ describe('BettingControls', () => {
 
   it('applies poker-themed styles to action buttons', () => {
     render(<BettingControls {...makeProps({ hasOutstandingBet: true })} />);
-    expect(screen.getByRole('button', { name: 'コール' }).className).toContain('bg-emerald-600');
-    expect(screen.getByRole('button', { name: 'レイズ' }).className).toContain('bg-sky-500');
-    expect(screen.getByRole('button', { name: 'フォールド' }).className).toContain('bg-gray-500');
-    expect(screen.getByRole('button', { name: 'オールイン' }).className).toContain('bg-amber-500');
+    expect(screen.getByRole('button', { name: 'コール' }).className).toContain('bg-poker-call');
+    expect(screen.getByRole('button', { name: 'レイズ' }).className).toContain('bg-poker-raise');
+    expect(screen.getByRole('button', { name: 'フォールド' }).className).toContain('bg-poker-fold');
+    expect(screen.getByRole('button', { name: 'オールイン' }).className).toContain('bg-poker-allin');
   });
 
   it('applies poker-themed styles to bet/check buttons', () => {
     render(<BettingControls {...makeProps()} />);
-    expect(screen.getByRole('button', { name: 'ベット' }).className).toContain('bg-sky-500');
-    expect(screen.getByRole('button', { name: 'チェック' }).className).toContain('bg-emerald-600');
+    expect(screen.getByRole('button', { name: 'ベット' }).className).toContain('bg-poker-raise');
+    expect(screen.getByRole('button', { name: 'チェック' }).className).toContain('bg-poker-call');
   });
 
   it('disables buttons when loading', () => {

--- a/frontend/src/components/CpuActionLog.test.tsx
+++ b/frontend/src/components/CpuActionLog.test.tsx
@@ -24,6 +24,15 @@ describe('CpuActionLog', () => {
     expect(screen.getByText('Player 2: フォールド')).toBeInTheDocument();
   });
 
+  it('has role="log" and aria-live="polite" for screen readers', () => {
+    const actions = [{ playerIdx: 1, action: 0, amount: 0 }];
+    render(<CpuActionLog actions={actions} />);
+    const el = screen.getByRole('log');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveAttribute('aria-live', 'polite');
+    expect(el).toHaveAttribute('aria-label', 'CPUプレイヤーの行動ログ');
+  });
+
   it('renders unknown action as 不明', () => {
     const actions = [{ playerIdx: 1, action: 99, amount: 0 }];
     render(<CpuActionLog actions={actions} />);

--- a/frontend/src/components/CpuActionLog.tsx
+++ b/frontend/src/components/CpuActionLog.tsx
@@ -10,7 +10,12 @@ export function CpuActionLog({ actions }: CpuActionLogProps) {
   const { t } = useTranslation('common');
   if (!actions || actions.length === 0) return null;
   return (
-    <div className="bg-black/30 rounded p-2 mb-3 text-white text-xs">
+    <div
+      role="log"
+      aria-live="polite"
+      aria-label={t('label.cpuActionLog')}
+      className="bg-black/30 rounded p-2 mb-3 text-white text-xs"
+    >
       <div className="font-bold mb-1">{t('label.cpuAction')}</div>
       {actions.map((a, i) => (
         <div key={`${i}-${a.playerIdx}-${a.action}`}>

--- a/frontend/src/components/DesktopSidebar.test.tsx
+++ b/frontend/src/components/DesktopSidebar.test.tsx
@@ -95,7 +95,8 @@ describe('DesktopSidebar', () => {
       renderSidebar();
       const input = screen.getByPlaceholderText(i18n.t('nav.searchPlaceholder'));
       fireEvent.change(input, { target: { value: 'xyznonexistent' } });
-      expect(screen.getByText(i18n.t('nav.noResults'))).toBeInTheDocument();
+      const noResultsElements = screen.getAllByText(i18n.t('nav.noResults'));
+      expect(noResultsElements.length).toBeGreaterThanOrEqual(1);
     });
 
     it('hides categories during search and restores on clear', () => {

--- a/frontend/src/components/DesktopSidebar.tsx
+++ b/frontend/src/components/DesktopSidebar.tsx
@@ -126,6 +126,12 @@ export function DesktopSidebar() {
           </div>
         )}
 
+        <div aria-live="polite" className="sr-only">
+          {searchTerm &&
+            (filteredPaths && filteredPaths.size > 0
+              ? t('nav.searchResultCount', { count: filteredPaths.size })
+              : t('nav.searchNoResults'))}
+        </div>
         {/* Search results or category list */}
         {filteredPaths ? (
           <div className="flex flex-col gap-0.5">

--- a/frontend/src/components/DesktopSidebar.tsx
+++ b/frontend/src/components/DesktopSidebar.tsx
@@ -130,7 +130,7 @@ export function DesktopSidebar() {
           {searchTerm &&
             (filteredPaths && filteredPaths.size > 0
               ? t('nav.searchResultCount', { count: filteredPaths.size })
-              : t('nav.searchNoResults'))}
+              : t('nav.noResults'))}
         </div>
         {/* Search results or category list */}
         {filteredPaths ? (

--- a/frontend/src/components/ErrorAlert.tsx
+++ b/frontend/src/components/ErrorAlert.tsx
@@ -12,7 +12,7 @@ export function ErrorAlert({ message, onRetry }: ErrorAlertProps) {
   return (
     <div
       role="alert"
-      className="bg-red-700/90 text-white text-center px-4 py-2 text-sm font-bold mb-2 rounded-lg flex items-center justify-center gap-2"
+      className="bg-ds-error/90 text-white text-center px-4 py-2 text-sm font-bold mb-2 rounded-lg flex items-center justify-center gap-2"
     >
       <span>{message}</span>
       {onRetry && (

--- a/frontend/src/components/GameMessageBox.test.tsx
+++ b/frontend/src/components/GameMessageBox.test.tsx
@@ -18,11 +18,18 @@ describe('GameMessageBox', () => {
     expect(screen.getByText('テスト結果')).toBeInTheDocument();
   });
 
-  it('has role="status" and aria-live="polite" for screen reader announcements', () => {
+  it('has role="status" and aria-live="polite" by default', () => {
     render(<GameMessageBox message="勝ちました" />);
     const el = screen.getByRole('status');
     expect(el).toBeInTheDocument();
     expect(el).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('has role="alert" and aria-live="assertive" when severity is alert', () => {
+    render(<GameMessageBox message="バスト！" severity="alert" />);
+    const el = screen.getByRole('alert');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveAttribute('aria-live', 'assertive');
   });
 
   it('renders empty div when message is undefined and alwaysVisible is true', () => {

--- a/frontend/src/components/GameMessageBox.tsx
+++ b/frontend/src/components/GameMessageBox.tsx
@@ -5,10 +5,18 @@ interface GameMessageBoxProps {
   messageCode?: string;
   messageParams?: Record<string, string>;
   alwaysVisible?: boolean;
+  /** "info" (default): polite announcement, "alert": assertive announcement for game results. */
+  severity?: 'info' | 'alert';
 }
 
 /** Renders a game message box with i18n translation support via messageCode. */
-export function GameMessageBox({ message, messageCode, messageParams, alwaysVisible = false }: GameMessageBoxProps) {
+export function GameMessageBox({
+  message,
+  messageCode,
+  messageParams,
+  alwaysVisible = false,
+  severity = 'info',
+}: GameMessageBoxProps) {
   const { t } = useTranslation('common');
   let displayMessage = message ?? '';
   if (messageCode) {
@@ -18,10 +26,12 @@ export function GameMessageBox({ message, messageCode, messageParams, alwaysVisi
     }
   }
   if (!alwaysVisible && !displayMessage) return null;
+  const role = severity === 'alert' ? 'alert' : 'status';
+  const live = severity === 'alert' ? 'assertive' : 'polite';
   return (
     <div
-      role="status"
-      aria-live="polite"
+      role={role}
+      aria-live={live}
       className="glass-panel rounded-lg text-white text-center px-4 py-2 text-lg font-bold mb-2"
     >
       {displayMessage}

--- a/frontend/src/components/NavBar.test.tsx
+++ b/frontend/src/components/NavBar.test.tsx
@@ -609,7 +609,8 @@ describe('NavBar', () => {
       fireEvent.click(screen.getByRole('button', { name: i18n.t('nav.openMenu') }));
       const input = screen.getByPlaceholderText(i18n.t('nav.searchPlaceholder'));
       fireEvent.change(input, { target: { value: 'xyznonexistent' } });
-      expect(screen.getByText(i18n.t('nav.noResults'))).toBeInTheDocument();
+      const noResultsElements = screen.getAllByText(i18n.t('nav.noResults'));
+      expect(noResultsElements.length).toBeGreaterThanOrEqual(1);
       Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: original });
       window.dispatchEvent(new Event('resize'));
     });

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -274,7 +274,7 @@ export function NavBar() {
             {searchTerm &&
               (filteredRoutes && filteredRoutes.length > 0
                 ? t('nav.searchResultCount', { count: filteredRoutes.length })
-                : t('nav.searchNoResults'))}
+                : t('nav.noResults'))}
           </div>
         )}
         {filteredRoutes ? (

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -269,6 +269,14 @@ export function NavBar() {
             })}
           </div>
         )}
+        {isMobile && (
+          <div aria-live="polite" className="sr-only">
+            {searchTerm &&
+              (filteredRoutes && filteredRoutes.length > 0
+                ? t('nav.searchResultCount', { count: filteredRoutes.length })
+                : t('nav.searchNoResults'))}
+          </div>
+        )}
         {filteredRoutes ? (
           <div className="flex flex-col gap-1">
             {filteredRoutes.length === 0 ? (

--- a/frontend/src/components/hint/HintTooltip.test.tsx
+++ b/frontend/src/components/hint/HintTooltip.test.tsx
@@ -16,7 +16,7 @@ describe('HintTooltip', () => {
   it('uses solid border for strong confidence', () => {
     render(<HintTooltip reason="test" confidence="strong" />);
     const el = screen.getByTestId('hint-tooltip');
-    expect(el).toHaveClass('border-yellow-400');
+    expect(el).toHaveClass('border-ds-accent');
     expect(el).not.toHaveClass('border-dashed');
   });
 

--- a/frontend/src/components/hint/HintTooltip.tsx
+++ b/frontend/src/components/hint/HintTooltip.tsx
@@ -10,11 +10,11 @@ export interface HintTooltipProps {
 
 /** Displays a tooltip with the hint reasoning and confidence indicator. */
 export function HintTooltip({ reason, confidence }: HintTooltipProps) {
-  const borderClass = confidence === 'strong' ? 'border-yellow-400' : 'border-yellow-400/50 border-dashed';
+  const borderClass = confidence === 'strong' ? 'border-ds-accent' : 'border-ds-accent/50 border-dashed';
 
   return (
     <div
-      className={`text-sm text-yellow-200 bg-gray-800/90 border ${borderClass} rounded px-3 py-1.5 mt-1`}
+      className={`text-sm text-ds-accent bg-gray-800/90 border ${borderClass} rounded px-3 py-1.5 mt-1`}
       role="status"
       aria-live="polite"
       data-testid="hint-tooltip"

--- a/frontend/src/components/hint/HintTooltip.tsx
+++ b/frontend/src/components/hint/HintTooltip.tsx
@@ -14,7 +14,7 @@ export function HintTooltip({ reason, confidence }: HintTooltipProps) {
 
   return (
     <div
-      className={`text-sm text-ds-accent bg-gray-800/90 border ${borderClass} rounded px-3 py-1.5 mt-1`}
+      className={`text-sm text-ds-accent bg-ds-surface/90 border ${borderClass} rounded px-3 py-1.5 mt-1`}
       role="status"
       aria-live="polite"
       data-testid="hint-tooltip"

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -8,6 +8,8 @@
     "searchPlaceholder": "Search games...",
     "searchClear": "Clear search",
     "noResults": "No games found",
+    "searchResultCount": "{{count}} games found",
+    "searchNoResults": "No matching games",
     "recentGames": "Recently Played",
     "favoriteGames": "Favorites",
     "addFavorite": "Add to favorites",
@@ -127,6 +129,7 @@
   "label": {
     "result": "Result:",
     "cpuAction": "CPU Actions:",
+    "cpuActionLog": "CPU player action log",
     "cpuActions": "[CPU Actions]",
     "cpuOpponents": "CPU Opponents ({{count}})",
     "pot": "Pot:",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -9,7 +9,6 @@
     "searchClear": "Clear search",
     "noResults": "No games found",
     "searchResultCount": "{{count}} games found",
-    "searchNoResults": "No matching games",
     "recentGames": "Recently Played",
     "favoriteGames": "Favorites",
     "addFavorite": "Add to favorites",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -9,7 +9,6 @@
     "searchClear": "検索をクリア",
     "noResults": "該当するゲームがありません",
     "searchResultCount": "{{count}}件のゲームが見つかりました",
-    "searchNoResults": "該当するゲームはありません",
     "recentGames": "最近プレイしたゲーム",
     "favoriteGames": "お気に入り",
     "addFavorite": "お気に入りに追加",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -8,6 +8,8 @@
     "searchPlaceholder": "ゲームを検索...",
     "searchClear": "検索をクリア",
     "noResults": "該当するゲームがありません",
+    "searchResultCount": "{{count}}件のゲームが見つかりました",
+    "searchNoResults": "該当するゲームはありません",
     "recentGames": "最近プレイしたゲーム",
     "favoriteGames": "お気に入り",
     "addFavorite": "お気に入りに追加",
@@ -127,6 +129,7 @@
   "label": {
     "result": "結果:",
     "cpuAction": "CPU行動:",
+    "cpuActionLog": "CPUプレイヤーの行動ログ",
     "cpuActions": "[CPUの行動]",
     "cpuOpponents": "CPU対戦相手 ({{count}})",
     "pot": "ポット:",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -56,6 +56,15 @@
   --color-ds-info: #5b8fb9;
   --color-ds-border: rgba(212, 168, 83, 0.15);
   --color-ds-border-subtle: rgba(139, 154, 175, 0.12);
+  /* Poker action button colors (from DESIGN.md game-specific palette) */
+  --color-poker-call: #059669;
+  --color-poker-call-hover: #047857;
+  --color-poker-raise: #0ea5e9;
+  --color-poker-raise-hover: #0284c7;
+  --color-poker-allin: #f59e0b;
+  --color-poker-allin-hover: #d97706;
+  --color-poker-fold: #6b7280;
+  --color-poker-fold-hover: #4b5563;
   /* Typography */
   --font-display: "Fraunces", "Noto Sans JP", serif;
   --font-body: "DM Sans", "Noto Sans JP", system-ui, sans-serif;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,9 +1,9 @@
 @import "tailwindcss";
 
 @theme {
-  --color-game-status-active: #5cb85c;
-  --color-game-status-waiting: #f0ad4e;
-  --color-game-status-out: #dc3545;
+  --color-game-status-active: var(--color-ds-success);
+  --color-game-status-waiting: var(--color-ds-warning);
+  --color-game-status-out: var(--color-ds-error);
   --color-game-text-muted: #f0f0f0;
   --color-game-text-highlight: #ccffcc;
   --color-game-text-strong: #222222;

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -444,7 +444,12 @@ function BlackJackPageContent() {
 
             {/* Result message */}
             <div data-tutorial="bj-result-message">
-              <GameMessageBox message={message} messageCode={state?.messageCode} messageParams={state?.messageParams} />
+              <GameMessageBox
+                message={message}
+                messageCode={state?.messageCode}
+                messageParams={state?.messageParams}
+                severity={phase === BjPhase.END ? 'alert' : 'info'}
+              />
             </div>
 
             {/* Action log */}

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -423,6 +423,7 @@ function HoldemPageContent() {
               messageCode={state?.messageCode}
               messageParams={state?.messageParams}
               alwaysVisible
+              severity={phase === HoldemPhase.END || phase === HoldemPhase.SHOWDOWN ? 'alert' : 'info'}
             />
 
             <ErrorAlert message={error} onRetry={retry} />

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -303,6 +303,7 @@ function PokerPageContent() {
                 messageCode={state?.messageCode}
                 messageParams={state?.messageParams}
                 alwaysVisible
+                severity={phase === PokerPhase.END ? 'alert' : 'info'}
               />
             </div>
 

--- a/frontend/src/styles/buttonStyles.ts
+++ b/frontend/src/styles/buttonStyles.ts
@@ -13,13 +13,13 @@ export const btnDanger = `${base} text-white bg-ds-error hover:bg-ds-error-hover
 export const btnSecondary = `${base} text-ds-text-primary bg-ds-surface-elevated hover:bg-ds-surface-elevated-hover`;
 
 /** Poker primary (emerald) — call/check action. */
-export const btnPokerPrimary = `${base} text-white bg-emerald-600 hover:bg-emerald-700`;
+export const btnPokerPrimary = `${base} text-white bg-poker-call hover:bg-poker-call-hover`;
 /** Poker accent (sky) — raise/bet action. */
-export const btnPokerAccent = `${base} text-white bg-sky-500 hover:bg-sky-600`;
+export const btnPokerAccent = `${base} text-white bg-poker-raise hover:bg-poker-raise-hover`;
 /** Poker all-in (amber) — high-stakes action. */
-export const btnPokerAllIn = `${base} text-white bg-amber-500 hover:bg-amber-600`;
+export const btnPokerAllIn = `${base} text-white bg-poker-allin hover:bg-poker-allin-hover`;
 /** Poker muted (gray) — fold action. */
-export const btnPokerMuted = `${base} text-white bg-gray-500 hover:bg-gray-600`;
+export const btnPokerMuted = `${base} text-white bg-poker-fold hover:bg-poker-fold-hover`;
 /** Outline button — minimal visual weight for reset etc. */
 export const btnOutline = `${base} text-ds-text-muted border border-ds-border-subtle bg-transparent hover:bg-ds-surface-elevated`;
 


### PR DESCRIPTION
## Summary
- **#1220**: Map legacy `game-status-*` CSS variables to design system tokens (`--color-ds-success/warning/error`), replace hardcoded Tailwind colors in `ErrorAlert` (`bg-red-700` → `bg-ds-error`) and `HintTooltip` (`text-yellow-200` → `text-ds-accent`), document poker game-specific palette in `DESIGN.md`
- **#1221**: Add `aria-live="polite"` search result count announcements (sr-only) in `NavBar` and `DesktopSidebar` for screen reader users
- **#1222**: Add `severity` prop to `GameMessageBox` — `"alert"` uses `role="alert"` + `aria-live="assertive"` for game results; applied to BlackJack, Poker, and Holdem end phases
- **#1223**: Add `role="log"` and `aria-live="polite"` to `CpuActionLog` so screen readers announce new CPU actions

Closes #1220, Closes #1221, Closes #1222, Closes #1223

## Test plan
- [x] All existing component tests pass (GameMessageBox, CpuActionLog, StatusBadge, ErrorAlert, HintTooltip)
- [x] New tests for `severity="alert"` in GameMessageBox and `role="log"` in CpuActionLog
- [x] NavBar and DesktopSidebar tests pass (159 tests)
- [x] BlackJack, Poker, Holdem page tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Biome check passes
- [x] Vite build succeeds