### PR TITLE
refactor: consolidate DRY violations (#1224-#1227)

### DIFF
--- a/cmd/workers/casino/main.go
+++ b/cmd/workers/casino/main.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/syumai/workers"
@@ -13,42 +12,15 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	corsmw "github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/cors"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/worker"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
-
-// registerKV creates a KV-backed session provider for a game and registers the
-// controller on the given mux. It eliminates the repeated boilerplate of
-// creating a provider, building a controller, and wiring up the route.
-func registerKV[I any](
-	mux *http.ServeMux,
-	path string,
-	kvPrefix string,
-	factory func() I,
-	restore func([]byte) (I, error),
-	newCtrl func(controller.SessionProvider[I], func() I) interface {
-		Exec(http.ResponseWriter, *http.Request)
-		Stop()
-	},
-) {
-	kvProvider, err := controller.NewKVSessionProvider[I](
-		"GAME_SESSIONS", kvPrefix,
-		func(i I) ([]byte, error) {
-			return any(i).(interface{ Snapshot() ([]byte, error) }).Snapshot()
-		},
-		restore,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
-	ctrl := newCtrl(kvProvider, factory)
-	mux.HandleFunc(path, ctrl.Exec)
-}
 
 func main() {
 	mux := http.NewServeMux()
 
 	// BlackJack
-	registerKV(mux, "/blackjack/exec", "blackjack:",
+	worker.RegisterKV(mux, "/blackjack/exec", "blackjack:",
 		func() usecase.BlackJackInteractorIF {
 			return usecase.NewBlackJackInteractor(
 				domain.NewDefaultBlackJack(),
@@ -58,16 +30,11 @@ func main() {
 		func(data []byte) (usecase.BlackJackInteractorIF, error) {
 			return usecase.RestoreBlackJackInteractor(data, new(presenter.BlackJackWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.BlackJackInteractorIF], f func() usecase.BlackJackInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewBlackJackWebControllerWithProvider(p, f)
-		},
+		controller.NewBlackJackWebControllerWithProvider,
 	)
 
 	// Baccarat
-	registerKV(mux, "/baccarat/exec", "baccarat:",
+	worker.RegisterKV(mux, "/baccarat/exec", "baccarat:",
 		func() usecase.BaccaratInteractorIF {
 			return usecase.NewBaccaratInteractor(
 				domain.NewDefaultBaccarat(),
@@ -77,16 +44,11 @@ func main() {
 		func(data []byte) (usecase.BaccaratInteractorIF, error) {
 			return usecase.RestoreBaccaratInteractor(data, new(presenter.BaccaratWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.BaccaratInteractorIF], f func() usecase.BaccaratInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewBaccaratWebControllerWithProvider(p, f)
-		},
+		controller.NewBaccaratWebControllerWithProvider,
 	)
 
 	// Poker
-	registerKV(mux, "/poker/exec", "poker:",
+	worker.RegisterKV(mux, "/poker/exec", "poker:",
 		func() usecase.PokerInteractorIF {
 			config := domain.DefaultPokerConfig()
 			players := []*domain.PokerPlayer{
@@ -101,16 +63,11 @@ func main() {
 		func(data []byte) (usecase.PokerInteractorIF, error) {
 			return usecase.RestorePokerInteractor(data, new(presenter.PokerWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.PokerInteractorIF], f func() usecase.PokerInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewPokerWebControllerWithProvider(p, f)
-		},
+		controller.NewPokerWebControllerWithProvider,
 	)
 
 	// Texas Hold'em
-	registerKV(mux, "/holdem/exec", "holdem:",
+	worker.RegisterKV(mux, "/holdem/exec", "holdem:",
 		func() usecase.HoldemInteractorIF {
 			cfg := domain.DefaultHoldemConfig()
 			holdem := domain.NewHoldem(domain.NewTrumpCards(0), domain.NewPlayersForTable(cfg.TableSize), cfg)
@@ -119,16 +76,11 @@ func main() {
 		func(data []byte) (usecase.HoldemInteractorIF, error) {
 			return usecase.RestoreHoldemInteractor(data, new(presenter.HoldemWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.HoldemInteractorIF], f func() usecase.HoldemInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewHoldemWebControllerWithProvider(p, f)
-		},
+		controller.NewHoldemWebControllerWithProvider,
 	)
 
 	// Omaha
-	registerKV(mux, "/omaha/exec", "omaha:",
+	worker.RegisterKV(mux, "/omaha/exec", "omaha:",
 		func() usecase.OmahaInteractorIF {
 			cfg := domain.DefaultOmahaConfig()
 			omaha := domain.NewOmaha(domain.NewTrumpCards(0), domain.NewOmahaPlayersForTable(cfg.TableSize), cfg)
@@ -137,16 +89,11 @@ func main() {
 		func(data []byte) (usecase.OmahaInteractorIF, error) {
 			return usecase.RestoreOmahaInteractor(data, new(presenter.OmahaWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.OmahaInteractorIF], f func() usecase.OmahaInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewOmahaWebControllerWithProvider(p, f)
-		},
+		controller.NewOmahaWebControllerWithProvider,
 	)
 
 	// Short Deck
-	registerKV(mux, "/shortdeck/exec", "shortdeck:",
+	worker.RegisterKV(mux, "/shortdeck/exec", "shortdeck:",
 		func() usecase.ShortDeckInteractorIF {
 			cfg := domain.DefaultShortDeckConfig()
 			sd := domain.NewShortDeck(domain.NewTrumpCardsShortDeck(), domain.NewShortDeckPlayersForTable(cfg.TableSize), cfg)
@@ -155,16 +102,11 @@ func main() {
 		func(data []byte) (usecase.ShortDeckInteractorIF, error) {
 			return usecase.RestoreShortDeckInteractor(data, new(presenter.ShortDeckWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.ShortDeckInteractorIF], f func() usecase.ShortDeckInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewShortDeckWebControllerWithProvider(p, f)
-		},
+		controller.NewShortDeckWebControllerWithProvider,
 	)
 
 	// Indian Poker
-	registerKV(mux, "/indianpoker/exec", "indianpoker:",
+	worker.RegisterKV(mux, "/indianpoker/exec", "indianpoker:",
 		func() usecase.IndianPokerInteractorIF {
 			cfg := domain.DefaultIndianPokerConfig()
 			ip := domain.NewIndianPoker(domain.NewTrumpCards(0), domain.NewIndianPokerPlayers(), cfg)
@@ -173,16 +115,11 @@ func main() {
 		func(data []byte) (usecase.IndianPokerInteractorIF, error) {
 			return usecase.RestoreIndianPokerInteractor(data, new(presenter.IndianPokerWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.IndianPokerInteractorIF], f func() usecase.IndianPokerInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewIndianPokerWebControllerWithProvider(p, f)
-		},
+		controller.NewIndianPokerWebControllerWithProvider,
 	)
 
 	// Video Poker
-	registerKV(mux, "/videopoker/exec", "videopoker:",
+	worker.RegisterKV(mux, "/videopoker/exec", "videopoker:",
 		func() usecase.VideoPokerInteractorIF {
 			return usecase.NewVideoPokerInteractor(
 				domain.NewDefaultVideoPoker(),
@@ -192,16 +129,11 @@ func main() {
 		func(data []byte) (usecase.VideoPokerInteractorIF, error) {
 			return usecase.RestoreVideoPokerInteractor(data, new(presenter.VideoPokerWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.VideoPokerInteractorIF], f func() usecase.VideoPokerInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewVideoPokerWebControllerWithProvider(p, f)
-		},
+		controller.NewVideoPokerWebControllerWithProvider,
 	)
 
 	// Deuces Wild
-	registerKV(mux, "/deuceswild/exec", "deuceswild:",
+	worker.RegisterKV(mux, "/deuceswild/exec", "deuceswild:",
 		func() usecase.VideoPokerInteractorIF {
 			return usecase.NewVideoPokerInteractor(
 				domain.NewDeucesWildVideoPoker(),
@@ -211,16 +143,11 @@ func main() {
 		func(data []byte) (usecase.VideoPokerInteractorIF, error) {
 			return usecase.RestoreVideoPokerInteractor(data, new(presenter.VideoPokerWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.VideoPokerInteractorIF], f func() usecase.VideoPokerInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewVideoPokerWebControllerWithProvider(p, f)
-		},
+		controller.NewVideoPokerWebControllerWithProvider,
 	)
 
 	// Joker Poker
-	registerKV(mux, "/jokerpoker/exec", "jokerpoker:",
+	worker.RegisterKV(mux, "/jokerpoker/exec", "jokerpoker:",
 		func() usecase.VideoPokerInteractorIF {
 			return usecase.NewVideoPokerInteractor(
 				domain.NewJokerPokerVideoPoker(),
@@ -230,16 +157,11 @@ func main() {
 		func(data []byte) (usecase.VideoPokerInteractorIF, error) {
 			return usecase.RestoreVideoPokerInteractor(data, new(presenter.VideoPokerWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.VideoPokerInteractorIF], f func() usecase.VideoPokerInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewVideoPokerWebControllerWithProvider(p, f)
-		},
+		controller.NewVideoPokerWebControllerWithProvider,
 	)
 
 	// Three Card Poker
-	registerKV(mux, "/threecard/exec", "threecard:",
+	worker.RegisterKV(mux, "/threecard/exec", "threecard:",
 		func() usecase.ThreeCardInteractorIF {
 			return usecase.NewThreeCardInteractor(
 				domain.NewDefaultThreeCard(),
@@ -249,16 +171,11 @@ func main() {
 		func(data []byte) (usecase.ThreeCardInteractorIF, error) {
 			return usecase.RestoreThreeCardInteractor(data, new(presenter.ThreeCardWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.ThreeCardInteractorIF], f func() usecase.ThreeCardInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewThreeCardWebControllerWithProvider(p, f)
-		},
+		controller.NewThreeCardWebControllerWithProvider,
 	)
 
 	// Pineapple Poker
-	registerKV(mux, "/pineapple/exec", "pineapple:",
+	worker.RegisterKV(mux, "/pineapple/exec", "pineapple:",
 		func() usecase.PineappleInteractorIF {
 			cfg := domain.DefaultPineappleConfig()
 			pineapple := domain.NewPineapple(domain.NewTrumpCards(0), domain.NewPineapplePlayersForTable(cfg.TableSize), cfg)
@@ -267,16 +184,11 @@ func main() {
 		func(data []byte) (usecase.PineappleInteractorIF, error) {
 			return usecase.RestorePineappleInteractor(data, new(presenter.PineappleWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.PineappleInteractorIF], f func() usecase.PineappleInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewPineappleWebControllerWithProvider(p, f)
-		},
+		controller.NewPineappleWebControllerWithProvider,
 	)
 
 	// Seven Card Stud
-	registerKV(mux, "/sevencardstud/exec", "sevencardstud:",
+	worker.RegisterKV(mux, "/sevencardstud/exec", "sevencardstud:",
 		func() usecase.SevenCardStudInteractorIF {
 			cfg := domain.DefaultSevenCardStudConfig()
 			scs := domain.NewSevenCardStud(domain.NewTrumpCards(0), domain.NewSevenCardStudPlayersForTable(cfg.TableSize), cfg)
@@ -285,12 +197,7 @@ func main() {
 		func(data []byte) (usecase.SevenCardStudInteractorIF, error) {
 			return usecase.RestoreSevenCardStudInteractor(data, new(presenter.SevenCardStudWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.SevenCardStudInteractorIF], f func() usecase.SevenCardStudInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewSevenCardStudWebControllerWithProvider(p, f)
-		},
+		controller.NewSevenCardStudWebControllerWithProvider,
 	)
 
 	var handler http.Handler = mux

--- a/cmd/workers/casino/main.go
+++ b/cmd/workers/casino/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/syumai/workers"
@@ -20,7 +21,7 @@ func main() {
 	mux := http.NewServeMux()
 
 	// BlackJack
-	worker.RegisterKV(mux, "/blackjack/exec", "blackjack:",
+	if err := worker.RegisterKV(mux, "/blackjack/exec", "blackjack:",
 		func() usecase.BlackJackInteractorIF {
 			return usecase.NewBlackJackInteractor(
 				domain.NewDefaultBlackJack(),
@@ -31,10 +32,12 @@ func main() {
 			return usecase.RestoreBlackJackInteractor(data, new(presenter.BlackJackWebPresenter))
 		},
 		controller.NewBlackJackWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Baccarat
-	worker.RegisterKV(mux, "/baccarat/exec", "baccarat:",
+	if err := worker.RegisterKV(mux, "/baccarat/exec", "baccarat:",
 		func() usecase.BaccaratInteractorIF {
 			return usecase.NewBaccaratInteractor(
 				domain.NewDefaultBaccarat(),
@@ -45,10 +48,12 @@ func main() {
 			return usecase.RestoreBaccaratInteractor(data, new(presenter.BaccaratWebPresenter))
 		},
 		controller.NewBaccaratWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Poker
-	worker.RegisterKV(mux, "/poker/exec", "poker:",
+	if err := worker.RegisterKV(mux, "/poker/exec", "poker:",
 		func() usecase.PokerInteractorIF {
 			config := domain.DefaultPokerConfig()
 			players := []*domain.PokerPlayer{
@@ -64,10 +69,12 @@ func main() {
 			return usecase.RestorePokerInteractor(data, new(presenter.PokerWebPresenter))
 		},
 		controller.NewPokerWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Texas Hold'em
-	worker.RegisterKV(mux, "/holdem/exec", "holdem:",
+	if err := worker.RegisterKV(mux, "/holdem/exec", "holdem:",
 		func() usecase.HoldemInteractorIF {
 			cfg := domain.DefaultHoldemConfig()
 			holdem := domain.NewHoldem(domain.NewTrumpCards(0), domain.NewPlayersForTable(cfg.TableSize), cfg)
@@ -77,10 +84,12 @@ func main() {
 			return usecase.RestoreHoldemInteractor(data, new(presenter.HoldemWebPresenter))
 		},
 		controller.NewHoldemWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Omaha
-	worker.RegisterKV(mux, "/omaha/exec", "omaha:",
+	if err := worker.RegisterKV(mux, "/omaha/exec", "omaha:",
 		func() usecase.OmahaInteractorIF {
 			cfg := domain.DefaultOmahaConfig()
 			omaha := domain.NewOmaha(domain.NewTrumpCards(0), domain.NewOmahaPlayersForTable(cfg.TableSize), cfg)
@@ -90,10 +99,12 @@ func main() {
 			return usecase.RestoreOmahaInteractor(data, new(presenter.OmahaWebPresenter))
 		},
 		controller.NewOmahaWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Short Deck
-	worker.RegisterKV(mux, "/shortdeck/exec", "shortdeck:",
+	if err := worker.RegisterKV(mux, "/shortdeck/exec", "shortdeck:",
 		func() usecase.ShortDeckInteractorIF {
 			cfg := domain.DefaultShortDeckConfig()
 			sd := domain.NewShortDeck(domain.NewTrumpCardsShortDeck(), domain.NewShortDeckPlayersForTable(cfg.TableSize), cfg)
@@ -103,10 +114,12 @@ func main() {
 			return usecase.RestoreShortDeckInteractor(data, new(presenter.ShortDeckWebPresenter))
 		},
 		controller.NewShortDeckWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Indian Poker
-	worker.RegisterKV(mux, "/indianpoker/exec", "indianpoker:",
+	if err := worker.RegisterKV(mux, "/indianpoker/exec", "indianpoker:",
 		func() usecase.IndianPokerInteractorIF {
 			cfg := domain.DefaultIndianPokerConfig()
 			ip := domain.NewIndianPoker(domain.NewTrumpCards(0), domain.NewIndianPokerPlayers(), cfg)
@@ -116,10 +129,12 @@ func main() {
 			return usecase.RestoreIndianPokerInteractor(data, new(presenter.IndianPokerWebPresenter))
 		},
 		controller.NewIndianPokerWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Video Poker
-	worker.RegisterKV(mux, "/videopoker/exec", "videopoker:",
+	if err := worker.RegisterKV(mux, "/videopoker/exec", "videopoker:",
 		func() usecase.VideoPokerInteractorIF {
 			return usecase.NewVideoPokerInteractor(
 				domain.NewDefaultVideoPoker(),
@@ -130,10 +145,12 @@ func main() {
 			return usecase.RestoreVideoPokerInteractor(data, new(presenter.VideoPokerWebPresenter))
 		},
 		controller.NewVideoPokerWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Deuces Wild
-	worker.RegisterKV(mux, "/deuceswild/exec", "deuceswild:",
+	if err := worker.RegisterKV(mux, "/deuceswild/exec", "deuceswild:",
 		func() usecase.VideoPokerInteractorIF {
 			return usecase.NewVideoPokerInteractor(
 				domain.NewDeucesWildVideoPoker(),
@@ -144,10 +161,12 @@ func main() {
 			return usecase.RestoreVideoPokerInteractor(data, new(presenter.VideoPokerWebPresenter))
 		},
 		controller.NewVideoPokerWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Joker Poker
-	worker.RegisterKV(mux, "/jokerpoker/exec", "jokerpoker:",
+	if err := worker.RegisterKV(mux, "/jokerpoker/exec", "jokerpoker:",
 		func() usecase.VideoPokerInteractorIF {
 			return usecase.NewVideoPokerInteractor(
 				domain.NewJokerPokerVideoPoker(),
@@ -158,10 +177,12 @@ func main() {
 			return usecase.RestoreVideoPokerInteractor(data, new(presenter.VideoPokerWebPresenter))
 		},
 		controller.NewVideoPokerWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Three Card Poker
-	worker.RegisterKV(mux, "/threecard/exec", "threecard:",
+	if err := worker.RegisterKV(mux, "/threecard/exec", "threecard:",
 		func() usecase.ThreeCardInteractorIF {
 			return usecase.NewThreeCardInteractor(
 				domain.NewDefaultThreeCard(),
@@ -172,10 +193,12 @@ func main() {
 			return usecase.RestoreThreeCardInteractor(data, new(presenter.ThreeCardWebPresenter))
 		},
 		controller.NewThreeCardWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Pineapple Poker
-	worker.RegisterKV(mux, "/pineapple/exec", "pineapple:",
+	if err := worker.RegisterKV(mux, "/pineapple/exec", "pineapple:",
 		func() usecase.PineappleInteractorIF {
 			cfg := domain.DefaultPineappleConfig()
 			pineapple := domain.NewPineapple(domain.NewTrumpCards(0), domain.NewPineapplePlayersForTable(cfg.TableSize), cfg)
@@ -185,10 +208,12 @@ func main() {
 			return usecase.RestorePineappleInteractor(data, new(presenter.PineappleWebPresenter))
 		},
 		controller.NewPineappleWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Seven Card Stud
-	worker.RegisterKV(mux, "/sevencardstud/exec", "sevencardstud:",
+	if err := worker.RegisterKV(mux, "/sevencardstud/exec", "sevencardstud:",
 		func() usecase.SevenCardStudInteractorIF {
 			cfg := domain.DefaultSevenCardStudConfig()
 			scs := domain.NewSevenCardStud(domain.NewTrumpCards(0), domain.NewSevenCardStudPlayersForTable(cfg.TableSize), cfg)
@@ -198,7 +223,9 @@ func main() {
 			return usecase.RestoreSevenCardStudInteractor(data, new(presenter.SevenCardStudWebPresenter))
 		},
 		controller.NewSevenCardStudWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	var handler http.Handler = mux
 	if origins := corsmw.ParseOrigins(cloudflare.Getenv("CORS_ALLOWED_ORIGINS")); origins != nil {

--- a/cmd/workers/classic/main.go
+++ b/cmd/workers/classic/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/syumai/workers"
@@ -20,7 +21,7 @@ func main() {
 	mux := http.NewServeMux()
 
 	// Hearts
-	worker.RegisterKV(mux, "/hearts/exec", "hearts:",
+	if err := worker.RegisterKV(mux, "/hearts/exec", "hearts:",
 		func() usecase.HeartsInteractorIF {
 			config := domain.DefaultHeartsConfig()
 			players := []*domain.HeartsPlayer{
@@ -36,10 +37,12 @@ func main() {
 			return usecase.RestoreHeartsInteractor(data, new(presenter.HeartsWebPresenter))
 		},
 		controller.NewHeartsWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Spades
-	worker.RegisterKV(mux, "/spades/exec", "spades:",
+	if err := worker.RegisterKV(mux, "/spades/exec", "spades:",
 		func() usecase.SpadesInteractorIF {
 			config := domain.DefaultSpadesConfig()
 			players := []*domain.SpadesPlayer{
@@ -55,10 +58,12 @@ func main() {
 			return usecase.RestoreSpadesInteractor(data, new(presenter.SpadesWebPresenter))
 		},
 		controller.NewSpadesWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Euchre
-	worker.RegisterKV(mux, "/euchre/exec", "euchre:",
+	if err := worker.RegisterKV(mux, "/euchre/exec", "euchre:",
 		func() usecase.EuchreInteractorIF {
 			config := domain.DefaultEuchreConfig()
 			players := []*domain.EuchrePlayer{
@@ -74,10 +79,12 @@ func main() {
 			return usecase.RestoreEuchreInteractor(data, new(presenter.EuchreWebPresenter))
 		},
 		controller.NewEuchreWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Napoleon
-	worker.RegisterKV(mux, "/napoleon/exec", "napoleon:",
+	if err := worker.RegisterKV(mux, "/napoleon/exec", "napoleon:",
 		func() usecase.NapoleonInteractorIF {
 			config := domain.DefaultNapoleonConfig()
 			players := []*domain.NapoleonPlayer{
@@ -93,10 +100,12 @@ func main() {
 			return usecase.RestoreNapoleonInteractor(data, new(presenter.NapoleonWebPresenter))
 		},
 		controller.NewNapoleonWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Old Maid
-	worker.RegisterKV(mux, "/oldmaid/exec", "oldmaid:",
+	if err := worker.RegisterKV(mux, "/oldmaid/exec", "oldmaid:",
 		func() usecase.OldMaidInteractorIF {
 			players := []*domain.OldMaidPlayer{
 				domain.NewOldMaidPlayer(true),
@@ -111,10 +120,12 @@ func main() {
 			return usecase.RestoreOldMaidInteractor(data, new(presenter.OldMaidWebPresenter))
 		},
 		controller.NewOldMaidWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Doubt
-	worker.RegisterKV(mux, "/doubt/exec", "doubt:",
+	if err := worker.RegisterKV(mux, "/doubt/exec", "doubt:",
 		func() usecase.DoubtInteractorIF {
 			players := []*domain.DoubtPlayer{
 				domain.NewDoubtPlayer(true),
@@ -129,10 +140,12 @@ func main() {
 			return usecase.RestoreDoubtInteractor(data, new(presenter.DoubtWebPresenter))
 		},
 		controller.NewDoubtWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Daifugo
-	worker.RegisterKV(mux, "/daifugo/exec", "daifugo:",
+	if err := worker.RegisterKV(mux, "/daifugo/exec", "daifugo:",
 		func() usecase.DaifugoInteractorIF {
 			config := domain.DefaultDaifugoConfig()
 			players := []*domain.DaifugoPlayer{
@@ -148,10 +161,12 @@ func main() {
 			return usecase.RestoreDaifugoInteractor(data, new(presenter.DaifugoWebPresenter))
 		},
 		controller.NewDaifugoWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Sevens
-	worker.RegisterKV(mux, "/sevens/exec", "sevens:",
+	if err := worker.RegisterKV(mux, "/sevens/exec", "sevens:",
 		func() usecase.SevensInteractorIF {
 			config := domain.DefaultSevensConfig()
 			players := []*domain.SevensPlayer{
@@ -167,10 +182,12 @@ func main() {
 			return usecase.RestoreSevensInteractor(data, new(presenter.SevensWebPresenter))
 		},
 		controller.NewSevensWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Crazy Eights
-	worker.RegisterKV(mux, "/crazyeights/exec", "crazyeights:",
+	if err := worker.RegisterKV(mux, "/crazyeights/exec", "crazyeights:",
 		func() usecase.CrazyEightsInteractorIF {
 			config := domain.DefaultCrazyEightsConfig()
 			players := []*domain.CrazyEightsPlayer{
@@ -186,10 +203,12 @@ func main() {
 			return usecase.RestoreCrazyEightsInteractor(data, new(presenter.CrazyEightsWebPresenter))
 		},
 		controller.NewCrazyEightsWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Oh Hell
-	worker.RegisterKV(mux, "/ohhell/exec", "ohhell:",
+	if err := worker.RegisterKV(mux, "/ohhell/exec", "ohhell:",
 		func() usecase.OhHellInteractorIF {
 			config := domain.DefaultOhHellConfig()
 			players := []*domain.OhHellPlayer{
@@ -205,10 +224,12 @@ func main() {
 			return usecase.RestoreOhHellInteractor(data, new(presenter.OhHellWebPresenter))
 		},
 		controller.NewOhHellWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Contract Bridge
-	worker.RegisterKV(mux, "/bridge/exec", "bridge:",
+	if err := worker.RegisterKV(mux, "/bridge/exec", "bridge:",
 		func() usecase.BridgeInteractorIF {
 			config := domain.DefaultBridgeConfig()
 			players := []*domain.BridgePlayer{
@@ -224,10 +245,12 @@ func main() {
 			return usecase.RestoreBridgeInteractor(data, new(presenter.BridgeWebPresenter))
 		},
 		controller.NewBridgeWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Speed
-	worker.RegisterKV(mux, "/speed/exec", "speed:",
+	if err := worker.RegisterKV(mux, "/speed/exec", "speed:",
 		func() usecase.SpeedInteractorIF {
 			config := domain.DefaultSpeedConfig()
 			players := []*domain.SpeedPlayer{
@@ -241,10 +264,12 @@ func main() {
 			return usecase.RestoreSpeedInteractor(data, new(presenter.SpeedWebPresenter))
 		},
 		controller.NewSpeedWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Go Fish
-	worker.RegisterKV(mux, "/gofish/exec", "gofish:",
+	if err := worker.RegisterKV(mux, "/gofish/exec", "gofish:",
 		func() usecase.GoFishInteractorIF {
 			players := []*domain.GoFishPlayer{
 				domain.NewGoFishPlayer(true),
@@ -259,10 +284,12 @@ func main() {
 			return usecase.RestoreGoFishInteractor(data, new(presenter.GoFishWebPresenter))
 		},
 		controller.NewGoFishWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Pinochle
-	worker.RegisterKV(mux, "/pinochle/exec", "pinochle:",
+	if err := worker.RegisterKV(mux, "/pinochle/exec", "pinochle:",
 		func() usecase.PinochleInteractorIF {
 			config := domain.DefaultPinochleConfig()
 			players := []*domain.PinochlePlayer{
@@ -278,10 +305,12 @@ func main() {
 			return usecase.RestorePinochleInteractor(data, new(presenter.PinochleWebPresenter))
 		},
 		controller.NewPinochleWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Pig's Tail
-	worker.RegisterKV(mux, "/pigtail/exec", "pigtail:",
+	if err := worker.RegisterKV(mux, "/pigtail/exec", "pigtail:",
 		func() usecase.PigsTailInteractorIF {
 			players := []*domain.PigsTailPlayer{
 				domain.NewPigsTailPlayer(true),
@@ -296,7 +325,9 @@ func main() {
 			return usecase.RestorePigsTailInteractor(data, new(presenter.PigsTailWebPresenter))
 		},
 		controller.NewPigsTailWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	var handler http.Handler = mux
 	if origins := corsmw.ParseOrigins(cloudflare.Getenv("CORS_ALLOWED_ORIGINS")); origins != nil {

--- a/cmd/workers/classic/main.go
+++ b/cmd/workers/classic/main.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/syumai/workers"
@@ -13,42 +12,15 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	corsmw "github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/cors"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/worker"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
-
-// registerKV creates a KV-backed session provider for a game and registers the
-// controller on the given mux. It eliminates the repeated boilerplate of
-// creating a provider, building a controller, and wiring up the route.
-func registerKV[I any](
-	mux *http.ServeMux,
-	path string,
-	kvPrefix string,
-	factory func() I,
-	restore func([]byte) (I, error),
-	newCtrl func(controller.SessionProvider[I], func() I) interface {
-		Exec(http.ResponseWriter, *http.Request)
-		Stop()
-	},
-) {
-	kvProvider, err := controller.NewKVSessionProvider[I](
-		"GAME_SESSIONS", kvPrefix,
-		func(i I) ([]byte, error) {
-			return any(i).(interface{ Snapshot() ([]byte, error) }).Snapshot()
-		},
-		restore,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
-	ctrl := newCtrl(kvProvider, factory)
-	mux.HandleFunc(path, ctrl.Exec)
-}
 
 func main() {
 	mux := http.NewServeMux()
 
 	// Hearts
-	registerKV(mux, "/hearts/exec", "hearts:",
+	worker.RegisterKV(mux, "/hearts/exec", "hearts:",
 		func() usecase.HeartsInteractorIF {
 			config := domain.DefaultHeartsConfig()
 			players := []*domain.HeartsPlayer{
@@ -63,16 +35,11 @@ func main() {
 		func(data []byte) (usecase.HeartsInteractorIF, error) {
 			return usecase.RestoreHeartsInteractor(data, new(presenter.HeartsWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.HeartsInteractorIF], f func() usecase.HeartsInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewHeartsWebControllerWithProvider(p, f)
-		},
+		controller.NewHeartsWebControllerWithProvider,
 	)
 
 	// Spades
-	registerKV(mux, "/spades/exec", "spades:",
+	worker.RegisterKV(mux, "/spades/exec", "spades:",
 		func() usecase.SpadesInteractorIF {
 			config := domain.DefaultSpadesConfig()
 			players := []*domain.SpadesPlayer{
@@ -87,16 +54,11 @@ func main() {
 		func(data []byte) (usecase.SpadesInteractorIF, error) {
 			return usecase.RestoreSpadesInteractor(data, new(presenter.SpadesWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.SpadesInteractorIF], f func() usecase.SpadesInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewSpadesWebControllerWithProvider(p, f)
-		},
+		controller.NewSpadesWebControllerWithProvider,
 	)
 
 	// Euchre
-	registerKV(mux, "/euchre/exec", "euchre:",
+	worker.RegisterKV(mux, "/euchre/exec", "euchre:",
 		func() usecase.EuchreInteractorIF {
 			config := domain.DefaultEuchreConfig()
 			players := []*domain.EuchrePlayer{
@@ -111,16 +73,11 @@ func main() {
 		func(data []byte) (usecase.EuchreInteractorIF, error) {
 			return usecase.RestoreEuchreInteractor(data, new(presenter.EuchreWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.EuchreInteractorIF], f func() usecase.EuchreInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewEuchreWebControllerWithProvider(p, f)
-		},
+		controller.NewEuchreWebControllerWithProvider,
 	)
 
 	// Napoleon
-	registerKV(mux, "/napoleon/exec", "napoleon:",
+	worker.RegisterKV(mux, "/napoleon/exec", "napoleon:",
 		func() usecase.NapoleonInteractorIF {
 			config := domain.DefaultNapoleonConfig()
 			players := []*domain.NapoleonPlayer{
@@ -135,16 +92,11 @@ func main() {
 		func(data []byte) (usecase.NapoleonInteractorIF, error) {
 			return usecase.RestoreNapoleonInteractor(data, new(presenter.NapoleonWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.NapoleonInteractorIF], f func() usecase.NapoleonInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewNapoleonWebControllerWithProvider(p, f)
-		},
+		controller.NewNapoleonWebControllerWithProvider,
 	)
 
 	// Old Maid
-	registerKV(mux, "/oldmaid/exec", "oldmaid:",
+	worker.RegisterKV(mux, "/oldmaid/exec", "oldmaid:",
 		func() usecase.OldMaidInteractorIF {
 			players := []*domain.OldMaidPlayer{
 				domain.NewOldMaidPlayer(true),
@@ -158,16 +110,11 @@ func main() {
 		func(data []byte) (usecase.OldMaidInteractorIF, error) {
 			return usecase.RestoreOldMaidInteractor(data, new(presenter.OldMaidWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.OldMaidInteractorIF], f func() usecase.OldMaidInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewOldMaidWebControllerWithProvider(p, f)
-		},
+		controller.NewOldMaidWebControllerWithProvider,
 	)
 
 	// Doubt
-	registerKV(mux, "/doubt/exec", "doubt:",
+	worker.RegisterKV(mux, "/doubt/exec", "doubt:",
 		func() usecase.DoubtInteractorIF {
 			players := []*domain.DoubtPlayer{
 				domain.NewDoubtPlayer(true),
@@ -181,16 +128,11 @@ func main() {
 		func(data []byte) (usecase.DoubtInteractorIF, error) {
 			return usecase.RestoreDoubtInteractor(data, new(presenter.DoubtWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.DoubtInteractorIF], f func() usecase.DoubtInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewDoubtWebControllerWithProvider(p, f)
-		},
+		controller.NewDoubtWebControllerWithProvider,
 	)
 
 	// Daifugo
-	registerKV(mux, "/daifugo/exec", "daifugo:",
+	worker.RegisterKV(mux, "/daifugo/exec", "daifugo:",
 		func() usecase.DaifugoInteractorIF {
 			config := domain.DefaultDaifugoConfig()
 			players := []*domain.DaifugoPlayer{
@@ -205,16 +147,11 @@ func main() {
 		func(data []byte) (usecase.DaifugoInteractorIF, error) {
 			return usecase.RestoreDaifugoInteractor(data, new(presenter.DaifugoWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.DaifugoInteractorIF], f func() usecase.DaifugoInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewDaifugoWebControllerWithProvider(p, f)
-		},
+		controller.NewDaifugoWebControllerWithProvider,
 	)
 
 	// Sevens
-	registerKV(mux, "/sevens/exec", "sevens:",
+	worker.RegisterKV(mux, "/sevens/exec", "sevens:",
 		func() usecase.SevensInteractorIF {
 			config := domain.DefaultSevensConfig()
 			players := []*domain.SevensPlayer{
@@ -229,16 +166,11 @@ func main() {
 		func(data []byte) (usecase.SevensInteractorIF, error) {
 			return usecase.RestoreSevensInteractor(data, new(presenter.SevensWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.SevensInteractorIF], f func() usecase.SevensInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewSevensWebControllerWithProvider(p, f)
-		},
+		controller.NewSevensWebControllerWithProvider,
 	)
 
 	// Crazy Eights
-	registerKV(mux, "/crazyeights/exec", "crazyeights:",
+	worker.RegisterKV(mux, "/crazyeights/exec", "crazyeights:",
 		func() usecase.CrazyEightsInteractorIF {
 			config := domain.DefaultCrazyEightsConfig()
 			players := []*domain.CrazyEightsPlayer{
@@ -253,16 +185,11 @@ func main() {
 		func(data []byte) (usecase.CrazyEightsInteractorIF, error) {
 			return usecase.RestoreCrazyEightsInteractor(data, new(presenter.CrazyEightsWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.CrazyEightsInteractorIF], f func() usecase.CrazyEightsInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewCrazyEightsWebControllerWithProvider(p, f)
-		},
+		controller.NewCrazyEightsWebControllerWithProvider,
 	)
 
 	// Oh Hell
-	registerKV(mux, "/ohhell/exec", "ohhell:",
+	worker.RegisterKV(mux, "/ohhell/exec", "ohhell:",
 		func() usecase.OhHellInteractorIF {
 			config := domain.DefaultOhHellConfig()
 			players := []*domain.OhHellPlayer{
@@ -277,16 +204,11 @@ func main() {
 		func(data []byte) (usecase.OhHellInteractorIF, error) {
 			return usecase.RestoreOhHellInteractor(data, new(presenter.OhHellWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.OhHellInteractorIF], f func() usecase.OhHellInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewOhHellWebControllerWithProvider(p, f)
-		},
+		controller.NewOhHellWebControllerWithProvider,
 	)
 
 	// Contract Bridge
-	registerKV(mux, "/bridge/exec", "bridge:",
+	worker.RegisterKV(mux, "/bridge/exec", "bridge:",
 		func() usecase.BridgeInteractorIF {
 			config := domain.DefaultBridgeConfig()
 			players := []*domain.BridgePlayer{
@@ -301,16 +223,11 @@ func main() {
 		func(data []byte) (usecase.BridgeInteractorIF, error) {
 			return usecase.RestoreBridgeInteractor(data, new(presenter.BridgeWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.BridgeInteractorIF], f func() usecase.BridgeInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewBridgeWebControllerWithProvider(p, f)
-		},
+		controller.NewBridgeWebControllerWithProvider,
 	)
 
 	// Speed
-	registerKV(mux, "/speed/exec", "speed:",
+	worker.RegisterKV(mux, "/speed/exec", "speed:",
 		func() usecase.SpeedInteractorIF {
 			config := domain.DefaultSpeedConfig()
 			players := []*domain.SpeedPlayer{
@@ -323,16 +240,11 @@ func main() {
 		func(data []byte) (usecase.SpeedInteractorIF, error) {
 			return usecase.RestoreSpeedInteractor(data, new(presenter.SpeedWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.SpeedInteractorIF], f func() usecase.SpeedInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewSpeedWebControllerWithProvider(p, f)
-		},
+		controller.NewSpeedWebControllerWithProvider,
 	)
 
 	// Go Fish
-	registerKV(mux, "/gofish/exec", "gofish:",
+	worker.RegisterKV(mux, "/gofish/exec", "gofish:",
 		func() usecase.GoFishInteractorIF {
 			players := []*domain.GoFishPlayer{
 				domain.NewGoFishPlayer(true),
@@ -346,15 +258,11 @@ func main() {
 		func(data []byte) (usecase.GoFishInteractorIF, error) {
 			return usecase.RestoreGoFishInteractor(data, new(presenter.GoFishWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.GoFishInteractorIF], f func() usecase.GoFishInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewGoFishWebControllerWithProvider(p, f)
-		},
+		controller.NewGoFishWebControllerWithProvider,
 	)
 
-	registerKV(mux, "/pinochle/exec", "pinochle:",
+	// Pinochle
+	worker.RegisterKV(mux, "/pinochle/exec", "pinochle:",
 		func() usecase.PinochleInteractorIF {
 			config := domain.DefaultPinochleConfig()
 			players := []*domain.PinochlePlayer{
@@ -369,16 +277,11 @@ func main() {
 		func(data []byte) (usecase.PinochleInteractorIF, error) {
 			return usecase.RestorePinochleInteractor(data, new(presenter.PinochleWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.PinochleInteractorIF], f func() usecase.PinochleInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewPinochleWebControllerWithProvider(p, f)
-		},
+		controller.NewPinochleWebControllerWithProvider,
 	)
 
 	// Pig's Tail
-	registerKV(mux, "/pigtail/exec", "pigtail:",
+	worker.RegisterKV(mux, "/pigtail/exec", "pigtail:",
 		func() usecase.PigsTailInteractorIF {
 			players := []*domain.PigsTailPlayer{
 				domain.NewPigsTailPlayer(true),
@@ -392,12 +295,7 @@ func main() {
 		func(data []byte) (usecase.PigsTailInteractorIF, error) {
 			return usecase.RestorePigsTailInteractor(data, new(presenter.PigsTailWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.PigsTailInteractorIF], f func() usecase.PigsTailInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewPigsTailWebControllerWithProvider(p, f)
-		},
+		controller.NewPigsTailWebControllerWithProvider,
 	)
 
 	var handler http.Handler = mux

--- a/cmd/workers/solo/main.go
+++ b/cmd/workers/solo/main.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/syumai/workers"
@@ -13,42 +12,15 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	corsmw "github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/cors"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/worker"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
-
-// registerKV creates a KV-backed session provider for a game and registers the
-// controller on the given mux. It eliminates the repeated boilerplate of
-// creating a provider, building a controller, and wiring up the route.
-func registerKV[I any](
-	mux *http.ServeMux,
-	path string,
-	kvPrefix string,
-	factory func() I,
-	restore func([]byte) (I, error),
-	newCtrl func(controller.SessionProvider[I], func() I) interface {
-		Exec(http.ResponseWriter, *http.Request)
-		Stop()
-	},
-) {
-	kvProvider, err := controller.NewKVSessionProvider[I](
-		"GAME_SESSIONS", kvPrefix,
-		func(i I) ([]byte, error) {
-			return any(i).(interface{ Snapshot() ([]byte, error) }).Snapshot()
-		},
-		restore,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
-	ctrl := newCtrl(kvProvider, factory)
-	mux.HandleFunc(path, ctrl.Exec)
-}
 
 func main() {
 	mux := http.NewServeMux()
 
 	// Klondike
-	registerKV(mux, "/klondike/exec", "klondike:",
+	worker.RegisterKV(mux, "/klondike/exec", "klondike:",
 		func() usecase.KlondikeInteractorIF {
 			klondike := domain.NewKlondike(domain.NewTrumpCards(0))
 			return usecase.NewKlondikeInteractor(klondike, new(presenter.KlondikeWebPresenter))
@@ -56,16 +28,11 @@ func main() {
 		func(data []byte) (usecase.KlondikeInteractorIF, error) {
 			return usecase.RestoreKlondikeInteractor(data, new(presenter.KlondikeWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.KlondikeInteractorIF], f func() usecase.KlondikeInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewKlondikeWebControllerWithProvider(p, f)
-		},
+		controller.NewKlondikeWebControllerWithProvider,
 	)
 
 	// FreeCell
-	registerKV(mux, "/freecell/exec", "freecell:",
+	worker.RegisterKV(mux, "/freecell/exec", "freecell:",
 		func() usecase.FreeCellInteractorIF {
 			freeCell := domain.NewFreeCell(domain.NewTrumpCards(0))
 			return usecase.NewFreeCellInteractor(freeCell, new(presenter.FreeCellWebPresenter))
@@ -73,16 +40,11 @@ func main() {
 		func(data []byte) (usecase.FreeCellInteractorIF, error) {
 			return usecase.RestoreFreeCellInteractor(data, new(presenter.FreeCellWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.FreeCellInteractorIF], f func() usecase.FreeCellInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewFreeCellWebControllerWithProvider(p, f)
-		},
+		controller.NewFreeCellWebControllerWithProvider,
 	)
 
 	// Spider
-	registerKV(mux, "/spider/exec", "spider:",
+	worker.RegisterKV(mux, "/spider/exec", "spider:",
 		func() usecase.SpiderInteractorIF {
 			spider := domain.NewSpider(domain.NewTrumpCardsWithSuits(domain.SpiderTotalCards, []int{domain.CardDesignSpade}))
 			return usecase.NewSpiderInteractor(spider, new(presenter.SpiderWebPresenter))
@@ -90,16 +52,11 @@ func main() {
 		func(data []byte) (usecase.SpiderInteractorIF, error) {
 			return usecase.RestoreSpiderInteractor(data, new(presenter.SpiderWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.SpiderInteractorIF], f func() usecase.SpiderInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewSpiderWebControllerWithProvider(p, f)
-		},
+		controller.NewSpiderWebControllerWithProvider,
 	)
 
 	// Pyramid
-	registerKV(mux, "/pyramid/exec", "pyramid:",
+	worker.RegisterKV(mux, "/pyramid/exec", "pyramid:",
 		func() usecase.PyramidInteractorIF {
 			pyramid := domain.NewPyramid(domain.NewTrumpCards(0))
 			return usecase.NewPyramidInteractor(pyramid, new(presenter.PyramidWebPresenter))
@@ -107,16 +64,11 @@ func main() {
 		func(data []byte) (usecase.PyramidInteractorIF, error) {
 			return usecase.RestorePyramidInteractor(data, new(presenter.PyramidWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.PyramidInteractorIF], f func() usecase.PyramidInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewPyramidWebControllerWithProvider(p, f)
-		},
+		controller.NewPyramidWebControllerWithProvider,
 	)
 
 	// TriPeaks
-	registerKV(mux, "/tripeaks/exec", "tripeaks:",
+	worker.RegisterKV(mux, "/tripeaks/exec", "tripeaks:",
 		func() usecase.TriPeaksInteractorIF {
 			triPeaks := domain.NewTriPeaks(domain.NewTrumpCards(0))
 			return usecase.NewTriPeaksInteractor(triPeaks, new(presenter.TriPeaksWebPresenter))
@@ -124,16 +76,11 @@ func main() {
 		func(data []byte) (usecase.TriPeaksInteractorIF, error) {
 			return usecase.RestoreTriPeaksInteractor(data, new(presenter.TriPeaksWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.TriPeaksInteractorIF], f func() usecase.TriPeaksInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewTriPeaksWebControllerWithProvider(p, f)
-		},
+		controller.NewTriPeaksWebControllerWithProvider,
 	)
 
 	// Memory
-	registerKV(mux, "/memory/exec", "memory:",
+	worker.RegisterKV(mux, "/memory/exec", "memory:",
 		func() usecase.MemoryInteractorIF {
 			config := domain.DefaultMemoryConfig()
 			players := []*domain.MemoryPlayer{
@@ -148,16 +95,11 @@ func main() {
 		func(data []byte) (usecase.MemoryInteractorIF, error) {
 			return usecase.RestoreMemoryInteractor(data, new(presenter.MemoryWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.MemoryInteractorIF], f func() usecase.MemoryInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewMemoryWebControllerWithProvider(p, f)
-		},
+		controller.NewMemoryWebControllerWithProvider,
 	)
 
 	// Gin Rummy
-	registerKV(mux, "/ginrummy/exec", "ginrummy:",
+	worker.RegisterKV(mux, "/ginrummy/exec", "ginrummy:",
 		func() usecase.GinRummyInteractorIF {
 			config := domain.DefaultGinRummyConfig()
 			players := []*domain.GinRummyPlayer{
@@ -170,16 +112,11 @@ func main() {
 		func(data []byte) (usecase.GinRummyInteractorIF, error) {
 			return usecase.RestoreGinRummyInteractor(data, new(presenter.GinRummyWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.GinRummyInteractorIF], f func() usecase.GinRummyInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewGinRummyWebControllerWithProvider(p, f)
-		},
+		controller.NewGinRummyWebControllerWithProvider,
 	)
 
 	// Cribbage
-	registerKV(mux, "/cribbage/exec", "cribbage:",
+	worker.RegisterKV(mux, "/cribbage/exec", "cribbage:",
 		func() usecase.CribbageInteractorIF {
 			config := domain.DefaultCribbageConfig()
 			players := []*domain.CribbagePlayer{
@@ -192,16 +129,11 @@ func main() {
 		func(data []byte) (usecase.CribbageInteractorIF, error) {
 			return usecase.RestoreCribbageInteractor(data, new(presenter.CribbageWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.CribbageInteractorIF], f func() usecase.CribbageInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewCribbageWebControllerWithProvider(p, f)
-		},
+		controller.NewCribbageWebControllerWithProvider,
 	)
 
 	// Canasta
-	registerKV(mux, "/canasta/exec", "canasta:",
+	worker.RegisterKV(mux, "/canasta/exec", "canasta:",
 		func() usecase.CanastaInteractorIF {
 			config := domain.DefaultCanastaConfig()
 			players := []*domain.CanastaPlayer{
@@ -214,16 +146,11 @@ func main() {
 		func(data []byte) (usecase.CanastaInteractorIF, error) {
 			return usecase.RestoreCanastaInteractor(data, new(presenter.CanastaWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.CanastaInteractorIF], f func() usecase.CanastaInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewCanastaWebControllerWithProvider(p, f)
-		},
+		controller.NewCanastaWebControllerWithProvider,
 	)
 
 	// Golf
-	registerKV(mux, "/golf/exec", "golf:",
+	worker.RegisterKV(mux, "/golf/exec", "golf:",
 		func() usecase.GolfInteractorIF {
 			golf := domain.NewGolf(domain.NewTrumpCards(0))
 			return usecase.NewGolfInteractor(golf, new(presenter.GolfWebPresenter))
@@ -231,16 +158,11 @@ func main() {
 		func(data []byte) (usecase.GolfInteractorIF, error) {
 			return usecase.RestoreGolfInteractor(data, new(presenter.GolfWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.GolfInteractorIF], f func() usecase.GolfInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewGolfWebControllerWithProvider(p, f)
-		},
+		controller.NewGolfWebControllerWithProvider,
 	)
 
 	// Clock Solitaire
-	registerKV(mux, "/clocksolitaire/exec", "clocksolitaire:",
+	worker.RegisterKV(mux, "/clocksolitaire/exec", "clocksolitaire:",
 		func() usecase.ClockSolitaireInteractorIF {
 			cs := domain.NewClockSolitaire(domain.NewTrumpCards(0))
 			return usecase.NewClockSolitaireInteractor(cs, new(presenter.ClockSolitaireWebPresenter))
@@ -248,12 +170,7 @@ func main() {
 		func(data []byte) (usecase.ClockSolitaireInteractorIF, error) {
 			return usecase.RestoreClockSolitaireInteractor(data, new(presenter.ClockSolitaireWebPresenter))
 		},
-		func(p controller.SessionProvider[usecase.ClockSolitaireInteractorIF], f func() usecase.ClockSolitaireInteractorIF) interface {
-			Exec(http.ResponseWriter, *http.Request)
-			Stop()
-		} {
-			return controller.NewClockSolitaireWebControllerWithProvider(p, f)
-		},
+		controller.NewClockSolitaireWebControllerWithProvider,
 	)
 
 	var handler http.Handler = mux

--- a/cmd/workers/solo/main.go
+++ b/cmd/workers/solo/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/syumai/workers"
@@ -20,7 +21,7 @@ func main() {
 	mux := http.NewServeMux()
 
 	// Klondike
-	worker.RegisterKV(mux, "/klondike/exec", "klondike:",
+	if err := worker.RegisterKV(mux, "/klondike/exec", "klondike:",
 		func() usecase.KlondikeInteractorIF {
 			klondike := domain.NewKlondike(domain.NewTrumpCards(0))
 			return usecase.NewKlondikeInteractor(klondike, new(presenter.KlondikeWebPresenter))
@@ -29,10 +30,12 @@ func main() {
 			return usecase.RestoreKlondikeInteractor(data, new(presenter.KlondikeWebPresenter))
 		},
 		controller.NewKlondikeWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// FreeCell
-	worker.RegisterKV(mux, "/freecell/exec", "freecell:",
+	if err := worker.RegisterKV(mux, "/freecell/exec", "freecell:",
 		func() usecase.FreeCellInteractorIF {
 			freeCell := domain.NewFreeCell(domain.NewTrumpCards(0))
 			return usecase.NewFreeCellInteractor(freeCell, new(presenter.FreeCellWebPresenter))
@@ -41,10 +44,12 @@ func main() {
 			return usecase.RestoreFreeCellInteractor(data, new(presenter.FreeCellWebPresenter))
 		},
 		controller.NewFreeCellWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Spider
-	worker.RegisterKV(mux, "/spider/exec", "spider:",
+	if err := worker.RegisterKV(mux, "/spider/exec", "spider:",
 		func() usecase.SpiderInteractorIF {
 			spider := domain.NewSpider(domain.NewTrumpCardsWithSuits(domain.SpiderTotalCards, []int{domain.CardDesignSpade}))
 			return usecase.NewSpiderInteractor(spider, new(presenter.SpiderWebPresenter))
@@ -53,10 +58,12 @@ func main() {
 			return usecase.RestoreSpiderInteractor(data, new(presenter.SpiderWebPresenter))
 		},
 		controller.NewSpiderWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Pyramid
-	worker.RegisterKV(mux, "/pyramid/exec", "pyramid:",
+	if err := worker.RegisterKV(mux, "/pyramid/exec", "pyramid:",
 		func() usecase.PyramidInteractorIF {
 			pyramid := domain.NewPyramid(domain.NewTrumpCards(0))
 			return usecase.NewPyramidInteractor(pyramid, new(presenter.PyramidWebPresenter))
@@ -65,10 +72,12 @@ func main() {
 			return usecase.RestorePyramidInteractor(data, new(presenter.PyramidWebPresenter))
 		},
 		controller.NewPyramidWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// TriPeaks
-	worker.RegisterKV(mux, "/tripeaks/exec", "tripeaks:",
+	if err := worker.RegisterKV(mux, "/tripeaks/exec", "tripeaks:",
 		func() usecase.TriPeaksInteractorIF {
 			triPeaks := domain.NewTriPeaks(domain.NewTrumpCards(0))
 			return usecase.NewTriPeaksInteractor(triPeaks, new(presenter.TriPeaksWebPresenter))
@@ -77,10 +86,12 @@ func main() {
 			return usecase.RestoreTriPeaksInteractor(data, new(presenter.TriPeaksWebPresenter))
 		},
 		controller.NewTriPeaksWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Memory
-	worker.RegisterKV(mux, "/memory/exec", "memory:",
+	if err := worker.RegisterKV(mux, "/memory/exec", "memory:",
 		func() usecase.MemoryInteractorIF {
 			config := domain.DefaultMemoryConfig()
 			players := []*domain.MemoryPlayer{
@@ -96,10 +107,12 @@ func main() {
 			return usecase.RestoreMemoryInteractor(data, new(presenter.MemoryWebPresenter))
 		},
 		controller.NewMemoryWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Gin Rummy
-	worker.RegisterKV(mux, "/ginrummy/exec", "ginrummy:",
+	if err := worker.RegisterKV(mux, "/ginrummy/exec", "ginrummy:",
 		func() usecase.GinRummyInteractorIF {
 			config := domain.DefaultGinRummyConfig()
 			players := []*domain.GinRummyPlayer{
@@ -113,10 +126,12 @@ func main() {
 			return usecase.RestoreGinRummyInteractor(data, new(presenter.GinRummyWebPresenter))
 		},
 		controller.NewGinRummyWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Cribbage
-	worker.RegisterKV(mux, "/cribbage/exec", "cribbage:",
+	if err := worker.RegisterKV(mux, "/cribbage/exec", "cribbage:",
 		func() usecase.CribbageInteractorIF {
 			config := domain.DefaultCribbageConfig()
 			players := []*domain.CribbagePlayer{
@@ -130,10 +145,12 @@ func main() {
 			return usecase.RestoreCribbageInteractor(data, new(presenter.CribbageWebPresenter))
 		},
 		controller.NewCribbageWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Canasta
-	worker.RegisterKV(mux, "/canasta/exec", "canasta:",
+	if err := worker.RegisterKV(mux, "/canasta/exec", "canasta:",
 		func() usecase.CanastaInteractorIF {
 			config := domain.DefaultCanastaConfig()
 			players := []*domain.CanastaPlayer{
@@ -147,10 +164,12 @@ func main() {
 			return usecase.RestoreCanastaInteractor(data, new(presenter.CanastaWebPresenter))
 		},
 		controller.NewCanastaWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Golf
-	worker.RegisterKV(mux, "/golf/exec", "golf:",
+	if err := worker.RegisterKV(mux, "/golf/exec", "golf:",
 		func() usecase.GolfInteractorIF {
 			golf := domain.NewGolf(domain.NewTrumpCards(0))
 			return usecase.NewGolfInteractor(golf, new(presenter.GolfWebPresenter))
@@ -159,10 +178,12 @@ func main() {
 			return usecase.RestoreGolfInteractor(data, new(presenter.GolfWebPresenter))
 		},
 		controller.NewGolfWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	// Clock Solitaire
-	worker.RegisterKV(mux, "/clocksolitaire/exec", "clocksolitaire:",
+	if err := worker.RegisterKV(mux, "/clocksolitaire/exec", "clocksolitaire:",
 		func() usecase.ClockSolitaireInteractorIF {
 			cs := domain.NewClockSolitaire(domain.NewTrumpCards(0))
 			return usecase.NewClockSolitaireInteractor(cs, new(presenter.ClockSolitaireWebPresenter))
@@ -171,7 +192,9 @@ func main() {
 			return usecase.RestoreClockSolitaireInteractor(data, new(presenter.ClockSolitaireWebPresenter))
 		},
 		controller.NewClockSolitaireWebControllerWithProvider,
-	)
+	); err != nil {
+		log.Fatal(err)
+	}
 
 	var handler http.Handler = mux
 	if origins := corsmw.ParseOrigins(cloudflare.Getenv("CORS_ALLOWED_ORIGINS")); origins != nil {

--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -285,88 +285,38 @@ export interface HoldemConfigInput {
   cpuMetaAI?: boolean;
 }
 
-/** API client for the Texas Hold'em /holdem/exec endpoint. */
-export const holdemApi = {
-  exec: (
-    command:
-      | 'reset'
-      | 'fold'
-      | 'check'
-      | 'call'
-      | 'bet'
-      | 'raise'
-      | 'allin'
-      | 'rebuy'
-      | 'skiprebuy'
-      | 'addon'
-      | 'skipaddon'
-      | 'muck'
-      | 'show',
-    amount?: number,
-    config?: HoldemConfigInput,
-    humanPlayMs?: number,
-    profile?: unknown,
-  ) =>
-    gameExec<HoldemResponse>('holdem', {
-      command,
-      amount,
-      humanPlayMs,
-      profile,
-      ...config,
-    }),
-};
+/** Command set shared by Hold'em-family games. */
+type HoldemLikeCommand =
+  | 'reset'
+  | 'fold'
+  | 'check'
+  | 'call'
+  | 'bet'
+  | 'raise'
+  | 'allin'
+  | 'rebuy'
+  | 'skiprebuy'
+  | 'addon'
+  | 'skipaddon'
+  | 'muck'
+  | 'show';
 
-/** Configuration options for Pineapple Poker (extends Hold'em with cardIdx for discard). */
-export interface PineappleConfigInput extends HoldemConfigInput {
-  cardIdx?: number;
+/** Factory for Hold'em-family APIs that share the same exec pattern. */
+function createHoldemLikeApi<T, C = HoldemConfigInput>(game: string) {
+  return {
+    exec: (command: HoldemLikeCommand, amount?: number, config?: C, humanPlayMs?: number, profile?: unknown) =>
+      gameExec<T>(game, { command, amount, humanPlayMs, profile, ...(config as Record<string, unknown>) }),
+  };
 }
 
-/** API client for the Pineapple Poker /pineapple/exec endpoint. */
-export const pineappleApi = {
-  exec: (
-    command:
-      | 'reset'
-      | 'fold'
-      | 'check'
-      | 'call'
-      | 'bet'
-      | 'raise'
-      | 'allin'
-      | 'rebuy'
-      | 'skiprebuy'
-      | 'addon'
-      | 'skipaddon'
-      | 'muck'
-      | 'show'
-      | 'discard',
-    amount?: number,
-    config?: PineappleConfigInput,
-    humanPlayMs?: number,
-    profile?: unknown,
-  ) =>
-    gameExec<PineappleResponse>('pineapple', {
-      command,
-      amount,
-      humanPlayMs,
-      profile,
-      cardIdx: config?.cardIdx,
-      smallBlind: config?.smallBlind,
-      bigBlind: config?.bigBlind,
-      tournamentMode: config?.tournamentMode,
-      blindLevelHands: config?.blindLevelHands,
-      blindMultiplier: config?.blindMultiplier,
-      bettingLimit: config?.bettingLimit,
-      tableSize: config?.tableSize,
-      rebuyEnabled: config?.rebuyEnabled,
-      rebuyMaxCount: config?.rebuyMaxCount,
-      rebuyChips: config?.rebuyChips,
-      rebuyPeriodHands: config?.rebuyPeriodHands,
-      addonEnabled: config?.addonEnabled,
-      addonChips: config?.addonChips,
-      addonAfterHand: config?.addonAfterHand,
-      cpuMetaAI: config?.cpuMetaAI,
-    }),
-};
+/** API client for the Texas Hold'em /holdem/exec endpoint. */
+export const holdemApi = createHoldemLikeApi<HoldemResponse>('holdem');
+
+/** API client for the Omaha Hold'em /omaha/exec endpoint. */
+export const omahaApi = createHoldemLikeApi<OmahaResponse>('omaha');
+
+/** API client for the Short Deck Hold'em /shortdeck/exec endpoint. */
+export const shortdeckApi = createHoldemLikeApi<ShortDeckResponse>('shortdeck');
 
 /** Configuration options for Seven Card Stud game settings. */
 export interface SevenCardStudConfigInput {
@@ -390,96 +340,23 @@ export interface SevenCardStudConfigInput {
 }
 
 /** API client for the Seven Card Stud /sevencardstud/exec endpoint. */
-export const sevenCardStudApi = {
+export const sevenCardStudApi = createHoldemLikeApi<SevenCardStudResponse, SevenCardStudConfigInput>('sevencardstud');
+
+/** Configuration options for Pineapple Poker (extends Hold'em with cardIdx for discard). */
+export interface PineappleConfigInput extends HoldemConfigInput {
+  cardIdx?: number;
+}
+
+/** API client for the Pineapple Poker /pineapple/exec endpoint. */
+export const pineappleApi = {
   exec: (
-    command:
-      | 'reset'
-      | 'fold'
-      | 'check'
-      | 'call'
-      | 'bet'
-      | 'raise'
-      | 'allin'
-      | 'rebuy'
-      | 'skiprebuy'
-      | 'addon'
-      | 'skipaddon'
-      | 'muck'
-      | 'show',
+    command: HoldemLikeCommand | 'discard',
     amount?: number,
-    config?: SevenCardStudConfigInput,
+    config?: PineappleConfigInput,
     humanPlayMs?: number,
     profile?: unknown,
   ) =>
-    gameExec<SevenCardStudResponse>('sevencardstud', {
-      command,
-      amount,
-      humanPlayMs,
-      profile,
-      ...config,
-    }),
-};
-
-/** Configuration options for Omaha Hold'em (same as Hold'em). */
-export type OmahaConfigInput = HoldemConfigInput;
-
-/** API client for the Omaha Hold'em /omaha/exec endpoint. */
-export const omahaApi = {
-  exec: (
-    command:
-      | 'reset'
-      | 'fold'
-      | 'check'
-      | 'call'
-      | 'bet'
-      | 'raise'
-      | 'allin'
-      | 'rebuy'
-      | 'skiprebuy'
-      | 'addon'
-      | 'skipaddon'
-      | 'muck'
-      | 'show',
-    amount?: number,
-    config?: OmahaConfigInput,
-    humanPlayMs?: number,
-    profile?: unknown,
-  ) =>
-    gameExec<OmahaResponse>('omaha', {
-      command,
-      amount,
-      humanPlayMs,
-      profile,
-      ...config,
-    }),
-};
-
-/** Configuration options for Short Deck Hold'em (same as Hold'em). */
-export type ShortDeckConfigInput = HoldemConfigInput;
-
-/** API client for the Short Deck Hold'em /shortdeck/exec endpoint. */
-export const shortdeckApi = {
-  exec: (
-    command:
-      | 'reset'
-      | 'fold'
-      | 'check'
-      | 'call'
-      | 'bet'
-      | 'raise'
-      | 'allin'
-      | 'rebuy'
-      | 'skiprebuy'
-      | 'addon'
-      | 'skipaddon'
-      | 'muck'
-      | 'show',
-    amount?: number,
-    config?: ShortDeckConfigInput,
-    humanPlayMs?: number,
-    profile?: unknown,
-  ) =>
-    gameExec<ShortDeckResponse>('shortdeck', {
+    gameExec<PineappleResponse>('pineapple', {
       command,
       amount,
       humanPlayMs,
@@ -519,21 +396,20 @@ export interface SpadesConfigInput {
   bagPenaltyThreshold?: number;
 }
 
+/** Factory for bid-play trick-taking APIs that share the same exec pattern. */
+function createBidPlayApi<T, C>(game: string) {
+  return {
+    exec: (
+      command: 'reset' | 'bid' | 'play' | 'next' | 'nextround' | 'hint',
+      bid?: number,
+      cardIndex?: number,
+      config?: C,
+    ) => gameExec<T>(game, { command, bid, cardIndex, config }),
+  };
+}
+
 /** API client for the Spades /spades/exec endpoint. */
-export const spadesApi = {
-  exec: (
-    command: 'reset' | 'bid' | 'play' | 'next' | 'nextround' | 'hint',
-    bid?: number,
-    cardIndex?: number,
-    config?: SpadesConfigInput,
-  ) =>
-    gameExec<SpadesResponse>('spades', {
-      command,
-      bid,
-      cardIndex,
-      config,
-    }),
-};
+export const spadesApi = createBidPlayApi<SpadesResponse, SpadesConfigInput>('spades');
 
 /** Configuration options for Oh Hell game settings. */
 export interface OhHellConfigInput {
@@ -544,20 +420,7 @@ export interface OhHellConfigInput {
 }
 
 /** API client for the Oh Hell /ohhell/exec endpoint. */
-export const ohHellApi = {
-  exec: (
-    command: 'reset' | 'bid' | 'play' | 'next' | 'nextround' | 'hint',
-    bid?: number,
-    cardIndex?: number,
-    config?: OhHellConfigInput,
-  ) =>
-    gameExec<OhHellResponse>('ohhell', {
-      command,
-      bid,
-      cardIndex,
-      config,
-    }),
-};
+export const ohHellApi = createBidPlayApi<OhHellResponse, OhHellConfigInput>('ohhell');
 
 /** Configuration options for Memory game settings. */
 export interface MemoryConfigInput {
@@ -923,23 +786,22 @@ export const tripeaksApi = {
     gameExec<TriPeaksResponse>('tripeaks', { command, row, col }),
 };
 
+/** Factory for video poker variant APIs that share the same exec pattern. */
+function createVideoPokerApi(game: string) {
+  return {
+    exec: (command: 'reset' | 'bet' | 'hold' | 'log', amount?: number, indices?: number[]) =>
+      gameExec<VideoPokerResponse>(game, { command, amount, indices }),
+  };
+}
+
 /** API client for the Video Poker /videopoker/exec endpoint. */
-export const videopokerApi = {
-  exec: (command: 'reset' | 'bet' | 'hold' | 'log', amount?: number, indices?: number[]) =>
-    gameExec<VideoPokerResponse>('videopoker', { command, amount, indices }),
-};
+export const videopokerApi = createVideoPokerApi('videopoker');
 
 /** API client for the Deuces Wild /deuceswild/exec endpoint. */
-export const deuceswildApi = {
-  exec: (command: 'reset' | 'bet' | 'hold' | 'log', amount?: number, indices?: number[]) =>
-    gameExec<VideoPokerResponse>('deuceswild', { command, amount, indices }),
-};
+export const deuceswildApi = createVideoPokerApi('deuceswild');
 
 /** API client for the Joker Poker /jokerpoker/exec endpoint. */
-export const jokerpokerApi = {
-  exec: (command: 'reset' | 'bet' | 'hold' | 'log', amount?: number, indices?: number[]) =>
-    gameExec<VideoPokerResponse>('jokerpoker', { command, amount, indices }),
-};
+export const jokerpokerApi = createVideoPokerApi('jokerpoker');
 
 /** API client for the Speed /speed/exec endpoint. */
 export const speedApi = {

--- a/frontend/src/i18n/buildResources.ts
+++ b/frontend/src/i18n/buildResources.ts
@@ -1,0 +1,11 @@
+/** Extract namespace name from glob path (e.g. './locales/ja/blackjack.json' → 'blackjack'). */
+export function buildResources(
+  modules: Record<string, Record<string, string>>,
+): Record<string, Record<string, string>> {
+  const resources: Record<string, Record<string, string>> = {};
+  for (const [path, mod] of Object.entries(modules)) {
+    const name = path.split('/').pop()?.replace('.json', '');
+    if (name) resources[name] = mod;
+  }
+  return resources;
+}

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,6 +1,7 @@
 import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
+import { buildResources } from './buildResources';
 
 /** Eagerly import all locale JSON files via Vite glob. */
 const jaModules = import.meta.glob('./locales/ja/*.json', {
@@ -12,16 +13,6 @@ const enModules = import.meta.glob('./locales/en/*.json', {
   eager: true,
   import: 'default',
 }) as Record<string, Record<string, string>>;
-
-/** Extract namespace name from glob path (e.g. './locales/ja/blackjack.json' → 'blackjack'). */
-function buildResources(modules: Record<string, Record<string, string>>): Record<string, Record<string, string>> {
-  const resources: Record<string, Record<string, string>> = {};
-  for (const [path, mod] of Object.entries(modules)) {
-    const name = path.split('/').pop()?.replace('.json', '');
-    if (name) resources[name] = mod;
-  }
-  return resources;
-}
 
 const jaResources = buildResources(jaModules);
 const enResources = buildResources(enModules);

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -2,226 +2,41 @@ import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 
-import enBaccarat from './locales/en/baccarat.json';
-import enBlackjack from './locales/en/blackjack.json';
-import enBridge from './locales/en/bridge.json';
-import enCanasta from './locales/en/canasta.json';
-import enClocksolitaire from './locales/en/clocksolitaire.json';
-import enCommon from './locales/en/common.json';
-import enCrazyeights from './locales/en/crazyeights.json';
-import enCribbage from './locales/en/cribbage.json';
-import enDaifugo from './locales/en/daifugo.json';
-import enDeuceswild from './locales/en/deuceswild.json';
-import enDoubt from './locales/en/doubt.json';
-import enEuchre from './locales/en/euchre.json';
-import enFreecell from './locales/en/freecell.json';
-import enGinrummy from './locales/en/ginrummy.json';
-import enGofish from './locales/en/gofish.json';
-import enGolf from './locales/en/golf.json';
-import enHearts from './locales/en/hearts.json';
-import enHoldem from './locales/en/holdem.json';
-import enIndianpoker from './locales/en/indianpoker.json';
-import enJokerpoker from './locales/en/jokerpoker.json';
-import enKlondike from './locales/en/klondike.json';
-import enMemory from './locales/en/memory.json';
-import enNapoleon from './locales/en/napoleon.json';
-import enOhhell from './locales/en/ohhell.json';
-import enOldmaid from './locales/en/oldmaid.json';
-import enOmaha from './locales/en/omaha.json';
-import enPigtail from './locales/en/pigtail.json';
-import enPineapple from './locales/en/pineapple.json';
-import enPinochle from './locales/en/pinochle.json';
-import enPoker from './locales/en/poker.json';
-import enPyramid from './locales/en/pyramid.json';
-import enSevencardstud from './locales/en/sevencardstud.json';
-import enSevens from './locales/en/sevens.json';
-import enShortdeck from './locales/en/shortdeck.json';
-import enSpades from './locales/en/spades.json';
-import enSpeed from './locales/en/speed.json';
-import enSpider from './locales/en/spider.json';
-import enThreecard from './locales/en/threecard.json';
-import enTripeaks from './locales/en/tripeaks.json';
-import enTutorial from './locales/en/tutorial.json';
-import enVideopoker from './locales/en/videopoker.json';
-import jaBaccarat from './locales/ja/baccarat.json';
-import jaBlackjack from './locales/ja/blackjack.json';
-import jaBridge from './locales/ja/bridge.json';
-import jaCanasta from './locales/ja/canasta.json';
-import jaClocksolitaire from './locales/ja/clocksolitaire.json';
-import jaCommon from './locales/ja/common.json';
-import jaCrazyeights from './locales/ja/crazyeights.json';
-import jaCribbage from './locales/ja/cribbage.json';
-import jaDaifugo from './locales/ja/daifugo.json';
-import jaDeuceswild from './locales/ja/deuceswild.json';
-import jaDoubt from './locales/ja/doubt.json';
-import jaEuchre from './locales/ja/euchre.json';
-import jaFreecell from './locales/ja/freecell.json';
-import jaGinrummy from './locales/ja/ginrummy.json';
-import jaGofish from './locales/ja/gofish.json';
-import jaGolf from './locales/ja/golf.json';
-import jaHearts from './locales/ja/hearts.json';
-import jaHoldem from './locales/ja/holdem.json';
-import jaIndianpoker from './locales/ja/indianpoker.json';
-import jaJokerpoker from './locales/ja/jokerpoker.json';
-import jaKlondike from './locales/ja/klondike.json';
-import jaMemory from './locales/ja/memory.json';
-import jaNapoleon from './locales/ja/napoleon.json';
-import jaOhhell from './locales/ja/ohhell.json';
-import jaOldmaid from './locales/ja/oldmaid.json';
-import jaOmaha from './locales/ja/omaha.json';
-import jaPigtail from './locales/ja/pigtail.json';
-import jaPineapple from './locales/ja/pineapple.json';
-import jaPinochle from './locales/ja/pinochle.json';
-import jaPoker from './locales/ja/poker.json';
-import jaPyramid from './locales/ja/pyramid.json';
-import jaSevencardstud from './locales/ja/sevencardstud.json';
-import jaSevens from './locales/ja/sevens.json';
-import jaShortdeck from './locales/ja/shortdeck.json';
-import jaSpades from './locales/ja/spades.json';
-import jaSpeed from './locales/ja/speed.json';
-import jaSpider from './locales/ja/spider.json';
-import jaThreecard from './locales/ja/threecard.json';
-import jaTripeaks from './locales/ja/tripeaks.json';
-import jaTutorial from './locales/ja/tutorial.json';
-import jaVideopoker from './locales/ja/videopoker.json';
+/** Eagerly import all locale JSON files via Vite glob. */
+const jaModules = import.meta.glob('./locales/ja/*.json', {
+  eager: true,
+  import: 'default',
+}) as Record<string, Record<string, string>>;
+
+const enModules = import.meta.glob('./locales/en/*.json', {
+  eager: true,
+  import: 'default',
+}) as Record<string, Record<string, string>>;
+
+/** Extract namespace name from glob path (e.g. './locales/ja/blackjack.json' → 'blackjack'). */
+function buildResources(modules: Record<string, Record<string, string>>): Record<string, Record<string, string>> {
+  const resources: Record<string, Record<string, string>> = {};
+  for (const [path, mod] of Object.entries(modules)) {
+    const name = path.split('/').pop()?.replace('.json', '');
+    if (name) resources[name] = mod;
+  }
+  return resources;
+}
+
+const jaResources = buildResources(jaModules);
+const enResources = buildResources(enModules);
 
 i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
     resources: {
-      ja: {
-        common: jaCommon,
-        blackjack: jaBlackjack,
-        poker: jaPoker,
-        oldmaid: jaOldmaid,
-        daifugo: jaDaifugo,
-        sevens: jaSevens,
-        doubt: jaDoubt,
-        euchre: jaEuchre,
-        bridge: jaBridge,
-        holdem: jaHoldem,
-        omaha: jaOmaha,
-        pineapple: jaPineapple,
-        pinochle: jaPinochle,
-        shortdeck: jaShortdeck,
-        hearts: jaHearts,
-        spades: jaSpades,
-        napoleon: jaNapoleon,
-        ohhell: jaOhhell,
-        memory: jaMemory,
-        klondike: jaKlondike,
-        freecell: jaFreecell,
-        baccarat: jaBaccarat,
-        crazyeights: jaCrazyeights,
-        ginrummy: jaGinrummy,
-        canasta: jaCanasta,
-        cribbage: jaCribbage,
-        spider: jaSpider,
-        indianpoker: jaIndianpoker,
-        pyramid: jaPyramid,
-        threecard: jaThreecard,
-        tripeaks: jaTripeaks,
-        videopoker: jaVideopoker,
-        deuceswild: jaDeuceswild,
-        jokerpoker: jaJokerpoker,
-        speed: jaSpeed,
-        gofish: jaGofish,
-        golf: jaGolf,
-        pigtail: jaPigtail,
-        sevencardstud: jaSevencardstud,
-        clocksolitaire: jaClocksolitaire,
-        tutorial: jaTutorial,
-      },
-      en: {
-        common: enCommon,
-        blackjack: enBlackjack,
-        poker: enPoker,
-        oldmaid: enOldmaid,
-        daifugo: enDaifugo,
-        sevens: enSevens,
-        doubt: enDoubt,
-        euchre: enEuchre,
-        bridge: enBridge,
-        holdem: enHoldem,
-        omaha: enOmaha,
-        pineapple: enPineapple,
-        pinochle: enPinochle,
-        shortdeck: enShortdeck,
-        hearts: enHearts,
-        spades: enSpades,
-        napoleon: enNapoleon,
-        ohhell: enOhhell,
-        memory: enMemory,
-        klondike: enKlondike,
-        freecell: enFreecell,
-        baccarat: enBaccarat,
-        crazyeights: enCrazyeights,
-        ginrummy: enGinrummy,
-        canasta: enCanasta,
-        cribbage: enCribbage,
-        spider: enSpider,
-        indianpoker: enIndianpoker,
-        pyramid: enPyramid,
-        threecard: enThreecard,
-        tripeaks: enTripeaks,
-        videopoker: enVideopoker,
-        deuceswild: enDeuceswild,
-        jokerpoker: enJokerpoker,
-        speed: enSpeed,
-        gofish: enGofish,
-        golf: enGolf,
-        pigtail: enPigtail,
-        sevencardstud: enSevencardstud,
-        clocksolitaire: enClocksolitaire,
-        tutorial: enTutorial,
-      },
+      ja: jaResources,
+      en: enResources,
     },
     fallbackLng: 'ja',
     defaultNS: 'common',
-    ns: [
-      'common',
-      'blackjack',
-      'poker',
-      'oldmaid',
-      'daifugo',
-      'sevens',
-      'doubt',
-      'euchre',
-      'bridge',
-      'holdem',
-      'omaha',
-      'pineapple',
-      'pinochle',
-      'shortdeck',
-      'hearts',
-      'spades',
-      'napoleon',
-      'ohhell',
-      'memory',
-      'klondike',
-      'freecell',
-      'baccarat',
-      'crazyeights',
-      'ginrummy',
-      'canasta',
-      'cribbage',
-      'spider',
-      'indianpoker',
-      'pyramid',
-      'threecard',
-      'tripeaks',
-      'videopoker',
-      'deuceswild',
-      'jokerpoker',
-      'speed',
-      'gofish',
-      'golf',
-      'pigtail',
-      'sevencardstud',
-      'clocksolitaire',
-      'tutorial',
-    ],
+    ns: Object.keys(jaResources),
     detection: {
       order: ['localStorage'],
       lookupLocalStorage: 'i18n_lang',

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -58,95 +58,37 @@ vi.mock('framer-motion', async () => {
   return { motion: createMotionProxy(), AnimatePresence };
 });
 
-import enCommon from '../i18n/locales/en/common.json';
-import jaBaccarat from '../i18n/locales/ja/baccarat.json';
-import jaBlackjack from '../i18n/locales/ja/blackjack.json';
-import jaCommon from '../i18n/locales/ja/common.json';
-import jaCrazyeights from '../i18n/locales/ja/crazyeights.json';
-import jaDaifugo from '../i18n/locales/ja/daifugo.json';
-import jaDoubt from '../i18n/locales/ja/doubt.json';
-import jaFreecell from '../i18n/locales/ja/freecell.json';
-import jaGinrummy from '../i18n/locales/ja/ginrummy.json';
-import jaGofish from '../i18n/locales/ja/gofish.json';
-import jaHearts from '../i18n/locales/ja/hearts.json';
-import jaHoldem from '../i18n/locales/ja/holdem.json';
-import jaIndianpoker from '../i18n/locales/ja/indianpoker.json';
-import jaKlondike from '../i18n/locales/ja/klondike.json';
-import jaMemory from '../i18n/locales/ja/memory.json';
-import jaNapoleon from '../i18n/locales/ja/napoleon.json';
-import jaOldmaid from '../i18n/locales/ja/oldmaid.json';
-import jaOmaha from '../i18n/locales/ja/omaha.json';
-import jaPoker from '../i18n/locales/ja/poker.json';
-import jaSevencardstud from '../i18n/locales/ja/sevencardstud.json';
-import jaSevens from '../i18n/locales/ja/sevens.json';
-import jaSpades from '../i18n/locales/ja/spades.json';
-import jaSpeed from '../i18n/locales/ja/speed.json';
-import jaSpider from '../i18n/locales/ja/spider.json';
-import jaThreecard from '../i18n/locales/ja/threecard.json';
-import jaTutorial from '../i18n/locales/ja/tutorial.json';
+// Eagerly import all locale JSON files via Vite glob
+const jaModules = import.meta.glob('../i18n/locales/ja/*.json', {
+  eager: true,
+  import: 'default',
+}) as Record<string, Record<string, string>>;
+
+const enModules = import.meta.glob('../i18n/locales/en/*.json', {
+  eager: true,
+  import: 'default',
+}) as Record<string, Record<string, string>>;
+
+function buildResources(modules: Record<string, Record<string, string>>): Record<string, Record<string, string>> {
+  const resources: Record<string, Record<string, string>> = {};
+  for (const [path, mod] of Object.entries(modules)) {
+    const name = path.split('/').pop()?.replace('.json', '');
+    if (name) resources[name] = mod;
+  }
+  return resources;
+}
+
+const jaResources = buildResources(jaModules);
+const enResources = buildResources(enModules);
 
 i18n.use(initReactI18next).init({
   lng: 'ja',
   fallbackLng: 'ja',
   defaultNS: 'common',
-  ns: [
-    'common',
-    'blackjack',
-    'poker',
-    'oldmaid',
-    'daifugo',
-    'sevens',
-    'doubt',
-    'holdem',
-    'omaha',
-    'hearts',
-    'spades',
-    'memory',
-    'baccarat',
-    'crazyeights',
-    'klondike',
-    'freecell',
-    'ginrummy',
-    'napoleon',
-    'spider',
-    'indianpoker',
-    'threecard',
-    'speed',
-    'gofish',
-    'sevencardstud',
-    'tutorial',
-  ],
+  ns: Object.keys(jaResources),
   resources: {
-    ja: {
-      common: jaCommon,
-      blackjack: jaBlackjack,
-      poker: jaPoker,
-      oldmaid: jaOldmaid,
-      daifugo: jaDaifugo,
-      sevens: jaSevens,
-      doubt: jaDoubt,
-      holdem: jaHoldem,
-      omaha: jaOmaha,
-      hearts: jaHearts,
-      spades: jaSpades,
-      memory: jaMemory,
-      baccarat: jaBaccarat,
-      crazyeights: jaCrazyeights,
-      klondike: jaKlondike,
-      freecell: jaFreecell,
-      ginrummy: jaGinrummy,
-      napoleon: jaNapoleon,
-      spider: jaSpider,
-      indianpoker: jaIndianpoker,
-      threecard: jaThreecard,
-      speed: jaSpeed,
-      gofish: jaGofish,
-      sevencardstud: jaSevencardstud,
-      tutorial: jaTutorial,
-    },
-    en: {
-      common: enCommon,
-    },
+    ja: jaResources,
+    en: enResources,
   },
   interpolation: { escapeValue: false },
 });

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -58,6 +58,8 @@ vi.mock('framer-motion', async () => {
   return { motion: createMotionProxy(), AnimatePresence };
 });
 
+import { buildResources } from '../i18n/buildResources';
+
 // Eagerly import all locale JSON files via Vite glob
 const jaModules = import.meta.glob('../i18n/locales/ja/*.json', {
   eager: true,
@@ -68,15 +70,6 @@ const enModules = import.meta.glob('../i18n/locales/en/*.json', {
   eager: true,
   import: 'default',
 }) as Record<string, Record<string, string>>;
-
-function buildResources(modules: Record<string, Record<string, string>>): Record<string, Record<string, string>> {
-  const resources: Record<string, Record<string, string>> = {};
-  for (const [path, mod] of Object.entries(modules)) {
-    const name = path.split('/').pop()?.replace('.json', '');
-    if (name) resources[name] = mod;
-  }
-  return resources;
-}
 
 const jaResources = buildResources(jaModules);
 const enResources = buildResources(enModules);

--- a/internal/adapter/controller/usecase/BaccaratInteractor_mock.go
+++ b/internal/adapter/controller/usecase/BaccaratInteractor_mock.go
@@ -28,3 +28,9 @@ func (m *MockBaccaratInteractor) ActionLog() string {
 	args := m.Called()
 	return args.String(0)
 }
+
+// Snapshot モック
+func (m *MockBaccaratInteractor) Snapshot() ([]byte, error) {
+	ret := m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/BlackJackInteractor_mock.go
+++ b/internal/adapter/controller/usecase/BlackJackInteractor_mock.go
@@ -144,3 +144,9 @@ func (_m *MockBlackJackInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockBlackJackInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/BridgeInteractor_mock.go
+++ b/internal/adapter/controller/usecase/BridgeInteractor_mock.go
@@ -66,3 +66,9 @@ func (_m *MockBridgeInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockBridgeInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/CanastaInteractor_mock.go
+++ b/internal/adapter/controller/usecase/CanastaInteractor_mock.go
@@ -56,3 +56,9 @@ func (_m *MockCanastaInteractor) GetConfig() domain.CanastaConfig {
 func (_m *MockCanastaInteractor) ActionLog() string {
 	return _m.Called().String(0)
 }
+
+// Snapshot モック
+func (_m *MockCanastaInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/ClockSolitaireInteractor_mock.go
+++ b/internal/adapter/controller/usecase/ClockSolitaireInteractor_mock.go
@@ -28,3 +28,9 @@ func (_m *MockClockSolitaireInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockClockSolitaireInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/CrazyEightsInteractor_mock.go
+++ b/internal/adapter/controller/usecase/CrazyEightsInteractor_mock.go
@@ -44,3 +44,9 @@ func (_m *MockCrazyEightsInteractor) GetConfig() domain.CrazyEightsConfig {
 func (_m *MockCrazyEightsInteractor) ActionLog() string {
 	return _m.Called().String(0)
 }
+
+// Snapshot モック
+func (_m *MockCrazyEightsInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/CribbageInteractor_mock.go
+++ b/internal/adapter/controller/usecase/CribbageInteractor_mock.go
@@ -48,3 +48,9 @@ func (_m *MockCribbageInteractor) GetConfig() domain.CribbageConfig {
 func (_m *MockCribbageInteractor) ActionLog() string {
 	return _m.Called().String(0)
 }
+
+// Snapshot モック
+func (_m *MockCribbageInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/DaifugoInteractor_mock.go
+++ b/internal/adapter/controller/usecase/DaifugoInteractor_mock.go
@@ -48,3 +48,9 @@ func (_m *MockDaifugoInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockDaifugoInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/DoubtInteractor_mock.go
+++ b/internal/adapter/controller/usecase/DoubtInteractor_mock.go
@@ -69,3 +69,9 @@ func (_m *MockDoubtInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockDoubtInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/EuchreInteractor_mock.go
+++ b/internal/adapter/controller/usecase/EuchreInteractor_mock.go
@@ -90,3 +90,9 @@ func (_m *MockEuchreInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockEuchreInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/FreeCellInteractor_mock.go
+++ b/internal/adapter/controller/usecase/FreeCellInteractor_mock.go
@@ -70,3 +70,9 @@ func (_m *MockFreeCellInteractor) UndoN(n int) string {
 	ret := _m.Called(n)
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockFreeCellInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/GinRummyInteractor_mock.go
+++ b/internal/adapter/controller/usecase/GinRummyInteractor_mock.go
@@ -52,3 +52,9 @@ func (_m *MockGinRummyInteractor) GetConfig() domain.GinRummyConfig {
 func (_m *MockGinRummyInteractor) ActionLog() string {
 	return _m.Called().String(0)
 }
+
+// Snapshot モック
+func (_m *MockGinRummyInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/GoFishInteractor_mock.go
+++ b/internal/adapter/controller/usecase/GoFishInteractor_mock.go
@@ -36,3 +36,9 @@ func (_m *MockGoFishInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockGoFishInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/GolfInteractor_mock.go
+++ b/internal/adapter/controller/usecase/GolfInteractor_mock.go
@@ -48,3 +48,9 @@ func (_m *MockGolfInteractor) UndoN(n int) string {
 	ret := _m.Called(n)
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockGolfInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/HeartsInteractor_mock.go
+++ b/internal/adapter/controller/usecase/HeartsInteractor_mock.go
@@ -66,3 +66,9 @@ func (_m *MockHeartsInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockHeartsInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/HoldemInteractor_mock.go
+++ b/internal/adapter/controller/usecase/HoldemInteractor_mock.go
@@ -78,3 +78,9 @@ func (_m *MockHoldemInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockHoldemInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/IndianPokerInteractor_mock.go
+++ b/internal/adapter/controller/usecase/IndianPokerInteractor_mock.go
@@ -42,3 +42,9 @@ func (_m *MockIndianPokerInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockIndianPokerInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/KlondikeInteractor_mock.go
+++ b/internal/adapter/controller/usecase/KlondikeInteractor_mock.go
@@ -77,3 +77,9 @@ func (_m *MockKlondikeInteractor) UndoN(n int) string {
 	ret := _m.Called(n)
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockKlondikeInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/MemoryInteractor_mock.go
+++ b/internal/adapter/controller/usecase/MemoryInteractor_mock.go
@@ -48,3 +48,9 @@ func (_m *MockMemoryInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockMemoryInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/NapoleonInteractor_mock.go
+++ b/internal/adapter/controller/usecase/NapoleonInteractor_mock.go
@@ -78,3 +78,9 @@ func (_m *MockNapoleonInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockNapoleonInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/OhHellInteractor_mock.go
+++ b/internal/adapter/controller/usecase/OhHellInteractor_mock.go
@@ -66,3 +66,9 @@ func (_m *MockOhHellInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockOhHellInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/OldMaidInteractor_mock.go
+++ b/internal/adapter/controller/usecase/OldMaidInteractor_mock.go
@@ -54,3 +54,9 @@ func (_m *MockOldMaidInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockOldMaidInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/OmahaInteractor_mock.go
+++ b/internal/adapter/controller/usecase/OmahaInteractor_mock.go
@@ -78,3 +78,9 @@ func (_m *MockOmahaInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockOmahaInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/PigsTailInteractor_mock.go
+++ b/internal/adapter/controller/usecase/PigsTailInteractor_mock.go
@@ -36,3 +36,9 @@ func (_m *MockPigsTailInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockPigsTailInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/PineappleInteractor_mock.go
+++ b/internal/adapter/controller/usecase/PineappleInteractor_mock.go
@@ -84,3 +84,9 @@ func (_m *MockPineappleInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockPineappleInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/PinochleInteractor_mock.go
+++ b/internal/adapter/controller/usecase/PinochleInteractor_mock.go
@@ -84,3 +84,9 @@ func (_m *MockPinochleInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockPinochleInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/PokerInteractor_mock.go
+++ b/internal/adapter/controller/usecase/PokerInteractor_mock.go
@@ -60,3 +60,9 @@ func (_m *MockPokerInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockPokerInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/PyramidInteractor_mock.go
+++ b/internal/adapter/controller/usecase/PyramidInteractor_mock.go
@@ -63,3 +63,9 @@ func (_m *MockPyramidInteractor) UndoN(n int) string {
 	ret := _m.Called(n)
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockPyramidInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/SevenCardStudInteractor_mock.go
+++ b/internal/adapter/controller/usecase/SevenCardStudInteractor_mock.go
@@ -78,3 +78,9 @@ func (_m *MockSevenCardStudInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockSevenCardStudInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/SevensInteractor_mock.go
+++ b/internal/adapter/controller/usecase/SevensInteractor_mock.go
@@ -42,3 +42,9 @@ func (_m *MockSevensInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockSevensInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/ShortDeckInteractor_mock.go
+++ b/internal/adapter/controller/usecase/ShortDeckInteractor_mock.go
@@ -78,3 +78,9 @@ func (_m *MockShortDeckInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockShortDeckInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/SpadesInteractor_mock.go
+++ b/internal/adapter/controller/usecase/SpadesInteractor_mock.go
@@ -66,3 +66,9 @@ func (_m *MockSpadesInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockSpadesInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/SpeedInteractor_mock.go
+++ b/internal/adapter/controller/usecase/SpeedInteractor_mock.go
@@ -54,3 +54,9 @@ func (_m *MockSpeedInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockSpeedInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/SpiderInteractor_mock.go
+++ b/internal/adapter/controller/usecase/SpiderInteractor_mock.go
@@ -62,3 +62,9 @@ func (_m *MockSpiderInteractor) UndoN(n int) string {
 	ret := _m.Called(n)
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockSpiderInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/ThreeCardInteractor_mock.go
+++ b/internal/adapter/controller/usecase/ThreeCardInteractor_mock.go
@@ -33,3 +33,9 @@ func (m *MockThreeCardInteractor) ActionLog() string {
 	args := m.Called()
 	return args.String(0)
 }
+
+// Snapshot モック
+func (m *MockThreeCardInteractor) Snapshot() ([]byte, error) {
+	ret := m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/TriPeaksInteractor_mock.go
+++ b/internal/adapter/controller/usecase/TriPeaksInteractor_mock.go
@@ -48,3 +48,9 @@ func (_m *MockTriPeaksInteractor) UndoN(n int) string {
 	ret := _m.Called(n)
 	return ret.Get(0).(string)
 }
+
+// Snapshot モック
+func (_m *MockTriPeaksInteractor) Snapshot() ([]byte, error) {
+	ret := _m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/adapter/controller/usecase/VideoPokerInteractor_mock.go
+++ b/internal/adapter/controller/usecase/VideoPokerInteractor_mock.go
@@ -28,3 +28,9 @@ func (m *MockVideoPokerInteractor) ActionLog() string {
 	args := m.Called()
 	return args.String(0)
 }
+
+// Snapshot モック
+func (m *MockVideoPokerInteractor) Snapshot() ([]byte, error) {
+	ret := m.Called()
+	return ret.Get(0).([]byte), ret.Error(1)
+}

--- a/internal/infrastructure/worker/register.go
+++ b/internal/infrastructure/worker/register.go
@@ -4,14 +4,13 @@
 package worker
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 )
 
-// snapshotIF is the interface expected on all interactors for KV persistence.
-type snapshotIF interface {
+// SnapshotIF is the interface required on all interactors for KV persistence.
+type SnapshotIF interface {
 	Snapshot() ([]byte, error)
 }
 
@@ -19,10 +18,11 @@ type snapshotIF interface {
 // controller on the given mux. Returns an error if the KV namespace cannot be
 // initialised; callers should handle it (typically with log.Fatal in main).
 //
+// I must implement SnapshotIF; this is enforced at compile time.
 // newCtrl is a controller constructor such as controller.NewBlackJackWebControllerWithProvider.
 // Passing the constructor directly avoids the 4-line closure wrapper that was
 // previously required at every call site.
-func RegisterKV[I any, P controller.WebInput, O any](
+func RegisterKV[I SnapshotIF, P controller.WebInput, O any](
 	mux *http.ServeMux,
 	path string,
 	kvPrefix string,
@@ -32,13 +32,7 @@ func RegisterKV[I any, P controller.WebInput, O any](
 ) error {
 	kvProvider, err := controller.NewKVSessionProvider[I](
 		"GAME_SESSIONS", kvPrefix,
-		func(i I) ([]byte, error) {
-			s, ok := any(i).(snapshotIF)
-			if !ok {
-				return nil, fmt.Errorf("interactor %T does not implement Snapshot()", i)
-			}
-			return s.Snapshot()
-		},
+		func(i I) ([]byte, error) { return i.Snapshot() },
 		restore,
 	)
 	if err != nil {

--- a/internal/infrastructure/worker/register.go
+++ b/internal/infrastructure/worker/register.go
@@ -1,0 +1,40 @@
+//go:build js && wasm
+
+// Package worker provides shared helpers for Cloudflare Worker entry points.
+package worker
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
+)
+
+// RegisterKV creates a KV-backed session provider for a game and registers the
+// controller on the given mux. It eliminates the repeated boilerplate of
+// creating a provider, building a controller, and wiring up the route.
+//
+// newCtrl is a controller constructor such as controller.NewBlackJackWebControllerWithProvider.
+// Passing the constructor directly avoids the 4-line closure wrapper that was
+// previously required at every call site.
+func RegisterKV[I any, P controller.WebInput, O any](
+	mux *http.ServeMux,
+	path string,
+	kvPrefix string,
+	factory func() I,
+	restore func([]byte) (I, error),
+	newCtrl func(controller.SessionProvider[I], func() I) *controller.GameWebController[I, P, O],
+) {
+	kvProvider, err := controller.NewKVSessionProvider[I](
+		"GAME_SESSIONS", kvPrefix,
+		func(i I) ([]byte, error) {
+			return any(i).(interface{ Snapshot() ([]byte, error) }).Snapshot()
+		},
+		restore,
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctrl := newCtrl(kvProvider, factory)
+	mux.HandleFunc(path, ctrl.Exec)
+}

--- a/internal/infrastructure/worker/register.go
+++ b/internal/infrastructure/worker/register.go
@@ -4,15 +4,20 @@
 package worker
 
 import (
-	"log"
+	"fmt"
 	"net/http"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 )
 
+// snapshotIF is the interface expected on all interactors for KV persistence.
+type snapshotIF interface {
+	Snapshot() ([]byte, error)
+}
+
 // RegisterKV creates a KV-backed session provider for a game and registers the
-// controller on the given mux. It eliminates the repeated boilerplate of
-// creating a provider, building a controller, and wiring up the route.
+// controller on the given mux. Returns an error if the KV namespace cannot be
+// initialised; callers should handle it (typically with log.Fatal in main).
 //
 // newCtrl is a controller constructor such as controller.NewBlackJackWebControllerWithProvider.
 // Passing the constructor directly avoids the 4-line closure wrapper that was
@@ -24,17 +29,22 @@ func RegisterKV[I any, P controller.WebInput, O any](
 	factory func() I,
 	restore func([]byte) (I, error),
 	newCtrl func(controller.SessionProvider[I], func() I) *controller.GameWebController[I, P, O],
-) {
+) error {
 	kvProvider, err := controller.NewKVSessionProvider[I](
 		"GAME_SESSIONS", kvPrefix,
 		func(i I) ([]byte, error) {
-			return any(i).(interface{ Snapshot() ([]byte, error) }).Snapshot()
+			s, ok := any(i).(snapshotIF)
+			if !ok {
+				return nil, fmt.Errorf("interactor %T does not implement Snapshot()", i)
+			}
+			return s.Snapshot()
 		},
 		restore,
 	)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	ctrl := newCtrl(kvProvider, factory)
 	mux.HandleFunc(path, ctrl.Exec)
+	return nil
 }

--- a/internal/usecase/BaccaratInteractor.go
+++ b/internal/usecase/BaccaratInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -22,7 +20,7 @@ type BaccaratInteractorIF interface {
 
 // BaccaratInteractor バカラインタラクタークラス
 type BaccaratInteractor struct {
-	b  interfaces.BaccaratGame
+	GameBase[interfaces.BaccaratGame]
 	bp presenter.BaccaratPresenter
 }
 
@@ -30,41 +28,34 @@ type BaccaratInteractor struct {
 func NewBaccaratInteractor(b interfaces.BaccaratGame, bp presenter.BaccaratPresenter) *BaccaratInteractor {
 	mustNotNil("BaccaratInteractor", map[string]any{"b": b, "bp": bp})
 	return &BaccaratInteractor{
-		b:  b,
-		bp: bp,
+		GameBase: GameBase[interfaces.BaccaratGame]{Game: b},
+		bp:       bp,
 	}
 }
 
 // Reset ゲーム初期化
 func (bi *BaccaratInteractor) Reset() string {
-	return runAndPresent(bi.b, bi.bp, bi.b.Reset)
+	return runAndPresent(bi.Game, bi.bp, bi.Game.Reset)
 }
 
 // Bet ベット
 func (bi *BaccaratInteractor) Bet(amount, betType, ppBet, bpBet int) string {
-	return execAndPresent(bi.b, bi.bp, func() error { return bi.b.Bet(amount, betType, ppBet, bpBet) })
+	return execAndPresent(bi.Game, bi.bp, func() error { return bi.Game.Bet(amount, betType, ppBet, bpBet) })
 }
 
 // ClearHistory 罫線履歴クリア
 func (bi *BaccaratInteractor) ClearHistory() string {
-	return runAndPresent(bi.b, bi.bp, bi.b.ClearHistory)
+	return runAndPresent(bi.Game, bi.bp, bi.Game.ClearHistory)
 }
 
 // ActionLog 棋譜を出力する
 func (bi *BaccaratInteractor) ActionLog() string {
-	return bi.bp.ActionLogOutput(bi.b)
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (bi *BaccaratInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(bi.b)
+	return bi.bp.ActionLogOutput(bi.Game)
 }
 
 // RestoreBaccaratInteractor deserialises JSON into a BaccaratInteractor.
 func RestoreBaccaratInteractor(data []byte, bp presenter.BaccaratPresenter) (*BaccaratInteractor, error) {
-	bac, err := restoreGame[domain.Baccarat](data)
-	if err != nil {
-		return nil, err
-	}
-	return &BaccaratInteractor{b: bac, bp: bp}, nil
+	return restoreAndBuild[domain.Baccarat](data, func(g *domain.Baccarat) *BaccaratInteractor {
+		return &BaccaratInteractor{GameBase: GameBase[interfaces.BaccaratGame]{Game: g}, bp: bp}
+	})
 }

--- a/internal/usecase/BaccaratInteractor.go
+++ b/internal/usecase/BaccaratInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // BaccaratInteractorIF バカラインタラクターインタフェース
 type BaccaratInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// Bet ベット

--- a/internal/usecase/BlackJackInteractor.go
+++ b/internal/usecase/BlackJackInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // BlackJackInteractorIF ブラックジャックインタラクターインタフェース
 type BlackJackInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// Hit ヒット

--- a/internal/usecase/BlackJackInteractor.go
+++ b/internal/usecase/BlackJackInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -58,7 +56,7 @@ type BlackJackInteractorIF interface {
 
 // BlackJackInteractor ブラックジャックインタラクタークラス
 type BlackJackInteractor struct {
-	bj  interfaces.BlackJackGame
+	GameBase[interfaces.BlackJackGame]
 	bjp presenter.BlackJackPresenter
 }
 
@@ -66,82 +64,82 @@ type BlackJackInteractor struct {
 func NewBlackJackInteractor(bj interfaces.BlackJackGame, bjp presenter.BlackJackPresenter) *BlackJackInteractor {
 	mustNotNil("BlackJackInteractor", map[string]any{"bj": bj, "bjp": bjp})
 	return &BlackJackInteractor{
-		bj:  bj,
-		bjp: bjp,
+		GameBase: GameBase[interfaces.BlackJackGame]{Game: bj},
+		bjp:      bjp,
 	}
 }
 
 // Reset ゲーム初期化
 func (bi *BlackJackInteractor) Reset() string {
-	return runAndPresent(bi.bj, bi.bjp, bi.bj.Reset)
+	return runAndPresent(bi.Game, bi.bjp, bi.Game.Reset)
 }
 
 // Hit ヒット
 func (bi *BlackJackInteractor) Hit() string {
-	return execAndPresent(bi.bj, bi.bjp, bi.bj.PlayerHit)
+	return execAndPresent(bi.Game, bi.bjp, bi.Game.PlayerHit)
 }
 
 // Stand スタンド
 func (bi *BlackJackInteractor) Stand() string {
-	return execAndPresent(bi.bj, bi.bjp, bi.bj.PlayerStand)
+	return execAndPresent(bi.Game, bi.bjp, bi.Game.PlayerStand)
 }
 
 // Bet ベット
 func (bi *BlackJackInteractor) Bet(amount, ppBet, t3Bet, handCount int) string {
-	return execAndPresent(bi.bj, bi.bjp, func() error { return bi.bj.PlayerBet(amount, ppBet, t3Bet, handCount) })
+	return execAndPresent(bi.Game, bi.bjp, func() error { return bi.Game.PlayerBet(amount, ppBet, t3Bet, handCount) })
 }
 
 // DoubleDown ダブルダウン
 func (bi *BlackJackInteractor) DoubleDown() string {
-	return execAndPresent(bi.bj, bi.bjp, bi.bj.PlayerDoubleDown)
+	return execAndPresent(bi.Game, bi.bjp, bi.Game.PlayerDoubleDown)
 }
 
 // Split スプリット
 func (bi *BlackJackInteractor) Split() string {
-	return execAndPresent(bi.bj, bi.bjp, bi.bj.PlayerSplit)
+	return execAndPresent(bi.Game, bi.bjp, bi.Game.PlayerSplit)
 }
 
 // Insurance インシュランス
 func (bi *BlackJackInteractor) Insurance() string {
-	return execAndPresent(bi.bj, bi.bjp, bi.bj.PlayerInsurance)
+	return execAndPresent(bi.Game, bi.bjp, bi.Game.PlayerInsurance)
 }
 
 // DeclineInsurance インシュランス辞退
 func (bi *BlackJackInteractor) DeclineInsurance() string {
-	return execAndPresent(bi.bj, bi.bjp, bi.bj.PlayerDeclineInsurance)
+	return execAndPresent(bi.Game, bi.bjp, bi.Game.PlayerDeclineInsurance)
 }
 
 // Surrender サレンダー
 func (bi *BlackJackInteractor) Surrender() string {
-	return execAndPresent(bi.bj, bi.bjp, bi.bj.PlayerSurrender)
+	return execAndPresent(bi.Game, bi.bjp, bi.Game.PlayerSurrender)
 }
 
 // EarlySurrender アーリーサレンダー
 func (bi *BlackJackInteractor) EarlySurrender() string {
-	return execAndPresent(bi.bj, bi.bjp, bi.bj.PlayerEarlySurrender)
+	return execAndPresent(bi.Game, bi.bjp, bi.Game.PlayerEarlySurrender)
 }
 
 // DeclineEarlySurrender アーリーサレンダー辞退
 func (bi *BlackJackInteractor) DeclineEarlySurrender() string {
-	return execAndPresent(bi.bj, bi.bjp, bi.bj.PlayerDeclineEarlySurrender)
+	return execAndPresent(bi.Game, bi.bjp, bi.Game.PlayerDeclineEarlySurrender)
 }
 
 // SetDeckCount デッキ数設定
 func (bi *BlackJackInteractor) SetDeckCount(count int) string {
-	return execAndPresent(bi.bj, bi.bjp, func() error { return bi.bj.SetDeckCount(count) })
+	return execAndPresent(bi.Game, bi.bjp, func() error { return bi.Game.SetDeckCount(count) })
 }
 
 // ToggleHint ヒント表示切り替え
 func (bi *BlackJackInteractor) ToggleHint() string {
-	return runAndPresent(bi.bj, bi.bjp, bi.bj.ToggleHint)
+	return runAndPresent(bi.Game, bi.bjp, bi.Game.ToggleHint)
 }
 
 // applyConfig は設定の取得・変更・保存・表示を行う共通ヘルパー
 func (bi *BlackJackInteractor) applyConfig(modify func(*domain.BlackJackConfig)) string {
-	config := bi.bj.GetConfig()
+	config := bi.Game.GetConfig()
 	modify(&config)
-	err := bi.bj.SetConfig(config)
-	return bi.bjp.Output(bi.bj, err)
+	err := bi.Game.SetConfig(config)
+	return bi.bjp.Output(bi.Game, err)
 }
 
 // ToggleSoft17 ソフト17ルール切り替え
@@ -181,30 +179,23 @@ func (bi *BlackJackInteractor) SetSurrenderRule(rule int) string {
 
 // ResetWithConfig 設定付きリセット
 func (bi *BlackJackInteractor) ResetWithConfig(cfg domain.BlackJackConfig) string {
-	bi.bj.Reset()
-	err := bi.bj.SetConfig(cfg)
+	bi.Game.Reset()
+	err := bi.Game.SetConfig(cfg)
 	if err != nil {
-		return bi.bjp.Output(bi.bj, err)
+		return bi.bjp.Output(bi.Game, err)
 	}
-	bi.bj.Reset()
-	return bi.bjp.Output(bi.bj, nil)
+	bi.Game.Reset()
+	return bi.bjp.Output(bi.Game, nil)
 }
 
 // ActionLog 棋譜を出力する
 func (bi *BlackJackInteractor) ActionLog() string {
-	return bi.bjp.ActionLogOutput(bi.bj)
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (bi *BlackJackInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(bi.bj)
+	return bi.bjp.ActionLogOutput(bi.Game)
 }
 
 // RestoreBlackJackInteractor deserialises JSON into a BlackJackInteractor.
 func RestoreBlackJackInteractor(data []byte, bjp presenter.BlackJackPresenter) (*BlackJackInteractor, error) {
-	bj, err := restoreGame[domain.BlackJack](data)
-	if err != nil {
-		return nil, err
-	}
-	return &BlackJackInteractor{bj: bj, bjp: bjp}, nil
+	return restoreAndBuild[domain.BlackJack](data, func(g *domain.BlackJack) *BlackJackInteractor {
+		return &BlackJackInteractor{GameBase: GameBase[interfaces.BlackJackGame]{Game: g}, bjp: bjp}
+	})
 }

--- a/internal/usecase/BridgeInteractor.go
+++ b/internal/usecase/BridgeInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // BridgeInteractorIF ブリッジインタラクターインタフェース
 type BridgeInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// ResetWithConfig 設定を変更してゲーム初期化

--- a/internal/usecase/BridgeInteractor.go
+++ b/internal/usecase/BridgeInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -32,102 +30,102 @@ type BridgeInteractorIF interface {
 
 // BridgeInteractor ブリッジインタラクタークラス
 type BridgeInteractor struct {
-	b  interfaces.BridgeGame
+	GameBase[interfaces.BridgeGame]
 	bp presenter.BridgePresenter
 }
 
 // NewBridgeInteractor コンストラクタ
 func NewBridgeInteractor(b interfaces.BridgeGame, bp presenter.BridgePresenter) *BridgeInteractor {
 	mustNotNil("BridgeInteractor", map[string]any{"b": b, "bp": bp})
-	return &BridgeInteractor{b: b, bp: bp}
+	return &BridgeInteractor{GameBase: GameBase[interfaces.BridgeGame]{Game: b}, bp: bp}
 }
 
 // Reset ゲーム初期化
 func (bi *BridgeInteractor) Reset() string {
-	bi.b.Reset()
+	bi.Game.Reset()
 	bi.runCpuBids()
 	bi.runCpuTurns()
-	return bi.bp.Output(bi.b, nil)
+	return bi.bp.Output(bi.Game, nil)
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (bi *BridgeInteractor) ResetWithConfig(cfg domain.BridgeConfig) string {
-	return resetWithValidatedConfig(bi.b, bi.bp, cfg, bi.b.SetConfig, bi.Reset)
+	return resetWithValidatedConfig(bi.Game, bi.bp, cfg, bi.Game.SetConfig, bi.Reset)
 }
 
 // Bid ビッドする
 func (bi *BridgeInteractor) Bid(bidType int, level int, suit int) string {
-	if out, blocked := guardGameEnd(bi.b, bi.bp); blocked {
+	if out, blocked := guardGameEnd(bi.Game, bi.bp); blocked {
 		return out
 	}
-	err := bi.b.PlayerBid(bidType, level, suit)
+	err := bi.Game.PlayerBid(bidType, level, suit)
 	if err != nil {
-		return bi.bp.Output(bi.b, err)
+		return bi.bp.Output(bi.Game, err)
 	}
 	bi.runCpuBids()
 	bi.runCpuTurns()
-	return bi.bp.Output(bi.b, nil)
+	return bi.bp.Output(bi.Game, nil)
 }
 
 // Play カードをプレイ
 func (bi *BridgeInteractor) Play(cardIndex int) string {
-	if out, blocked := guardNotPlayable(bi.b, bi.bp); blocked {
+	if out, blocked := guardNotPlayable(bi.Game, bi.bp); blocked {
 		return out
 	}
-	err := bi.b.PlayerPlay(cardIndex)
+	err := bi.Game.PlayerPlay(cardIndex)
 	if err != nil {
-		return bi.bp.Output(bi.b, err)
+		return bi.bp.Output(bi.Game, err)
 	}
 	bi.runCpuTurns()
-	return bi.bp.Output(bi.b, nil)
+	return bi.bp.Output(bi.Game, nil)
 }
 
 // NextTrick トリックを解決して次のトリックへ進む
 func (bi *BridgeInteractor) NextTrick() string {
-	bi.b.ResolveTrick()
-	if out, blocked := guardGameEnd(bi.b, bi.bp); blocked {
+	bi.Game.ResolveTrick()
+	if out, blocked := guardGameEnd(bi.Game, bi.bp); blocked {
 		return out
 	}
-	bi.b.NextTrick()
+	bi.Game.NextTrick()
 	bi.runCpuTurns()
-	return bi.bp.Output(bi.b, nil)
+	return bi.bp.Output(bi.Game, nil)
 }
 
 // NextRound ラウンドをスコアリングして次のラウンドへ進む
 func (bi *BridgeInteractor) NextRound() string {
-	bi.b.ScoreRound()
-	if out, blocked := guardGameEnd(bi.b, bi.bp); blocked {
+	bi.Game.ScoreRound()
+	if out, blocked := guardGameEnd(bi.Game, bi.bp); blocked {
 		return out
 	}
-	bi.b.NextRound()
+	bi.Game.NextRound()
 	bi.runCpuBids()
 	bi.runCpuTurns()
-	return bi.bp.Output(bi.b, nil)
+	return bi.bp.Output(bi.Game, nil)
 }
 
 // GetConfig 現在の設定を取得
 func (bi *BridgeInteractor) GetConfig() domain.BridgeConfig {
-	return bi.b.GetConfig()
+	return bi.Game.GetConfig()
 }
 
 // Hint ヒント取得
 func (bi *BridgeInteractor) Hint() string {
-	return bi.bp.HintOutput(bi.b)
+	return bi.bp.HintOutput(bi.Game)
 }
 
 // ActionLog 棋譜を出力する
 func (bi *BridgeInteractor) ActionLog() string {
-	return bi.bp.ActionLogOutput(bi.b)
+	return bi.bp.ActionLogOutput(bi.Game)
 }
 
 // runCpuBids ビッドフェーズでCPUを自動実行する
 func (bi *BridgeInteractor) runCpuBids() {
-	runCpuBidsLoop(bi.b, domain.BridgePhaseBid)
+	runCpuBidsLoop(bi.Game, domain.BridgePhaseBid)
 }
 
 // runCpuTurns プレイフェーズでCPUターンを自動実行する
 func (bi *BridgeInteractor) runCpuTurns() {
-	runCpuTurnsLoop(bi.b, trickPhases[domain.BridgePhase]{
+	runCpuTurnsLoop(bi.Game, trickPhases[domain.BridgePhase]{
 		play:     domain.BridgePhasePlay,
 		trickEnd: domain.BridgePhaseTrickEnd,
 		roundEnd: domain.BridgePhaseRoundEnd,
@@ -135,16 +133,9 @@ func (bi *BridgeInteractor) runCpuTurns() {
 	})
 }
 
-// Snapshot serialises the game state to JSON for KV persistence.
-func (bi *BridgeInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(bi.b)
-}
-
 // RestoreBridgeInteractor deserialises JSON into a BridgeInteractor.
 func RestoreBridgeInteractor(data []byte, bp presenter.BridgePresenter) (*BridgeInteractor, error) {
-	b, err := restoreGame[domain.Bridge](data)
-	if err != nil {
-		return nil, err
-	}
-	return &BridgeInteractor{b: b, bp: bp}, nil
+	return restoreAndBuild[domain.Bridge](data, func(g *domain.Bridge) *BridgeInteractor {
+		return &BridgeInteractor{GameBase: GameBase[interfaces.BridgeGame]{Game: g}, bp: bp}
+	})
 }

--- a/internal/usecase/BridgeInteractor_test.go
+++ b/internal/usecase/BridgeInteractor_test.go
@@ -176,3 +176,66 @@ func TestBridgeInteractor_ActionLog(t *testing.T) {
 	result := bi.ActionLog()
 	assert.Contains(t, result, "log")
 }
+
+func TestBridgeInteractor_Play_NotHumanTurn(t *testing.T) {
+	bpMock := new(presenter.MockBridgePresenter)
+	bpMock.On("Output", mock.Anything, mock.Anything).Return(`{"notHuman":true}`)
+	gameMock := new(interfaces.MockBridgeGame)
+	gameMock.On("GetGameEndFlag").Return(false)
+	gameMock.On("IsHumanTurn").Return(false)
+
+	bi := usecase.NewBridgeInteractor(gameMock, bpMock)
+	result := bi.Play(0)
+	assert.Contains(t, result, "notHuman")
+}
+
+func TestBridgeInteractor_NextTrick_GameEnd(t *testing.T) {
+	bpMock := new(presenter.MockBridgePresenter)
+	bpMock.On("Output", mock.Anything, mock.Anything).Return(`{"gameEnd":true}`)
+	gameMock := new(interfaces.MockBridgeGame)
+	gameMock.On("ResolveTrick").Return()
+	gameMock.On("GetGameEndFlag").Return(true)
+
+	bi := usecase.NewBridgeInteractor(gameMock, bpMock)
+	result := bi.NextTrick()
+	assert.Contains(t, result, "gameEnd")
+	gameMock.AssertCalled(t, "ResolveTrick")
+}
+
+func TestBridgeInteractor_NextRound_GameEnd(t *testing.T) {
+	bpMock := new(presenter.MockBridgePresenter)
+	bpMock.On("Output", mock.Anything, mock.Anything).Return(`{"gameEnd":true}`)
+	gameMock := new(interfaces.MockBridgeGame)
+	gameMock.On("ScoreRound").Return()
+	gameMock.On("GetGameEndFlag").Return(true)
+
+	bi := usecase.NewBridgeInteractor(gameMock, bpMock)
+	result := bi.NextRound()
+	assert.Contains(t, result, "gameEnd")
+	gameMock.AssertCalled(t, "ScoreRound")
+}
+
+func TestRestoreBridgeInteractor(t *testing.T) {
+	players := []*domain.BridgePlayer{
+		domain.NewBridgePlayer(true, 0),
+		domain.NewBridgePlayer(false, 1),
+		domain.NewBridgePlayer(false, 0),
+		domain.NewBridgePlayer(false, 1),
+	}
+	b := domain.NewBridge(domain.NewTrumpCards(0), players, domain.DefaultBridgeConfig())
+	bpMock := new(presenter.MockBridgePresenter)
+	bi := usecase.NewBridgeInteractor(b, bpMock)
+
+	data, err := bi.Snapshot()
+	assert.NoError(t, err)
+
+	restored, err := usecase.RestoreBridgeInteractor(data, bpMock)
+	assert.NoError(t, err)
+	assert.NotNil(t, restored)
+}
+
+func TestRestoreBridgeInteractor_InvalidJSON(t *testing.T) {
+	bpMock := new(presenter.MockBridgePresenter)
+	_, err := usecase.RestoreBridgeInteractor([]byte("invalid"), bpMock)
+	assert.Error(t, err)
+}

--- a/internal/usecase/CanastaInteractor.go
+++ b/internal/usecase/CanastaInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // CanastaInteractorIF カナスタインタラクターインタフェース
 type CanastaInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// ResetWithConfig 設定を変更してゲーム初期化

--- a/internal/usecase/CanastaInteractor.go
+++ b/internal/usecase/CanastaInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -36,150 +34,143 @@ type CanastaInteractorIF interface {
 
 // CanastaInteractor カナスタインタラクタークラス
 type CanastaInteractor struct {
-	g  interfaces.CanastaGame
+	GameBase[interfaces.CanastaGame]
 	gp presenter.CanastaPresenter
 }
 
 // NewCanastaInteractor コンストラクタ
 func NewCanastaInteractor(g interfaces.CanastaGame, gp presenter.CanastaPresenter) *CanastaInteractor {
 	mustNotNil("CanastaInteractor", map[string]any{"g": g, "gp": gp})
-	return &CanastaInteractor{g: g, gp: gp}
+	return &CanastaInteractor{GameBase: GameBase[interfaces.CanastaGame]{Game: g}, gp: gp}
 }
 
 // Reset ゲーム初期化
 func (ci *CanastaInteractor) Reset() string {
-	ci.g.Reset()
+	ci.Game.Reset()
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (ci *CanastaInteractor) ResetWithConfig(cfg domain.CanastaConfig) string {
-	return resetWithValidatedConfig(ci.g, ci.gp, cfg, ci.g.SetConfig, ci.Reset)
+	return resetWithValidatedConfig(ci.Game, ci.gp, cfg, ci.Game.SetConfig, ci.Reset)
 }
 
 // DrawFromStock 山札からカードを引く
 func (ci *CanastaInteractor) DrawFromStock() string {
-	if out, blocked := guardNotPlayable(ci.g, ci.gp); blocked {
+	if out, blocked := guardNotPlayable(ci.Game, ci.gp); blocked {
 		return out
 	}
-	err := ci.g.PlayerDrawFromStock()
+	err := ci.Game.PlayerDrawFromStock()
 	if err != nil {
-		return ci.gp.Output(ci.g, err)
+		return ci.gp.Output(ci.Game, err)
 	}
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // DrawFromDiscard 捨て札の山を取る
 func (ci *CanastaInteractor) DrawFromDiscard(naturalPairIndices []int) string {
-	if out, blocked := guardNotPlayable(ci.g, ci.gp); blocked {
+	if out, blocked := guardNotPlayable(ci.Game, ci.gp); blocked {
 		return out
 	}
-	err := ci.g.PlayerDrawFromDiscard(naturalPairIndices)
+	err := ci.Game.PlayerDrawFromDiscard(naturalPairIndices)
 	if err != nil {
-		return ci.gp.Output(ci.g, err)
+		return ci.gp.Output(ci.Game, err)
 	}
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // Meld メルドを出す
 func (ci *CanastaInteractor) Meld(meldGroups [][]int) string {
-	if out, blocked := guardNotPlayable(ci.g, ci.gp); blocked {
+	if out, blocked := guardNotPlayable(ci.Game, ci.gp); blocked {
 		return out
 	}
-	err := ci.g.PlayerMeld(meldGroups)
+	err := ci.Game.PlayerMeld(meldGroups)
 	if err != nil {
-		return ci.gp.Output(ci.g, err)
+		return ci.gp.Output(ci.Game, err)
 	}
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // SkipMeld メルドフェーズをスキップ
 func (ci *CanastaInteractor) SkipMeld() string {
-	if out, blocked := guardNotPlayable(ci.g, ci.gp); blocked {
+	if out, blocked := guardNotPlayable(ci.Game, ci.gp); blocked {
 		return out
 	}
-	err := ci.g.PlayerSkipMeld()
+	err := ci.Game.PlayerSkipMeld()
 	if err != nil {
-		return ci.gp.Output(ci.g, err)
+		return ci.gp.Output(ci.Game, err)
 	}
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // Discard カードを捨てる
 func (ci *CanastaInteractor) Discard(cardIndex int) string {
-	if out, blocked := guardNotPlayable(ci.g, ci.gp); blocked {
+	if out, blocked := guardNotPlayable(ci.Game, ci.gp); blocked {
 		return out
 	}
-	err := ci.g.PlayerDiscard(cardIndex)
+	err := ci.Game.PlayerDiscard(cardIndex)
 	if err != nil {
-		return ci.gp.Output(ci.g, err)
+		return ci.gp.Output(ci.Game, err)
 	}
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // GoOut 上がる
 func (ci *CanastaInteractor) GoOut() string {
-	if out, blocked := guardNotPlayable(ci.g, ci.gp); blocked {
+	if out, blocked := guardNotPlayable(ci.Game, ci.gp); blocked {
 		return out
 	}
-	err := ci.g.PlayerGoOut()
+	err := ci.Game.PlayerGoOut()
 	if err != nil {
-		return ci.gp.Output(ci.g, err)
+		return ci.gp.Output(ci.Game, err)
 	}
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // NextRound 次のラウンドへ進む
 func (ci *CanastaInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.g, ci.gp); blocked {
+	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
 		return out
 	}
-	ci.g.NextRound()
+	ci.Game.NextRound()
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // GetConfig 現在の設定を取得
 func (ci *CanastaInteractor) GetConfig() domain.CanastaConfig {
-	return ci.g.GetConfig()
+	return ci.Game.GetConfig()
 }
 
 // ActionLog 棋譜を出力する
 func (ci *CanastaInteractor) ActionLog() string {
-	return ci.gp.ActionLogOutput(ci.g)
+	return ci.gp.ActionLogOutput(ci.Game)
 }
 
 // runCpuTurns CPUターンを実行
 func (ci *CanastaInteractor) runCpuTurns() {
-	for !ci.g.GetGameEndFlag() {
-		phase := ci.g.GetPhase()
+	for !ci.Game.GetGameEndFlag() {
+		phase := ci.Game.GetPhase()
 		if phase == domain.CanastaPhaseRoundEnd || phase == domain.CanastaPhaseGameEnd {
 			break
 		}
-		if ci.g.IsHumanTurn() {
+		if ci.Game.IsHumanTurn() {
 			break
 		}
-		ci.g.CpuPlay()
+		ci.Game.CpuPlay()
 	}
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (ci *CanastaInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(ci.g)
 }
 
 // RestoreCanastaInteractor deserialises JSON into a CanastaInteractor.
 func RestoreCanastaInteractor(data []byte, gp presenter.CanastaPresenter) (*CanastaInteractor, error) {
-	g, err := restoreGame[domain.Canasta](data)
-	if err != nil {
-		return nil, err
-	}
-	return &CanastaInteractor{g: g, gp: gp}, nil
+	return restoreAndBuild[domain.Canasta](data, func(g *domain.Canasta) *CanastaInteractor {
+		return &CanastaInteractor{GameBase: GameBase[interfaces.CanastaGame]{Game: g}, gp: gp}
+	})
 }

--- a/internal/usecase/ClockSolitaireInteractor.go
+++ b/internal/usecase/ClockSolitaireInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -22,46 +20,39 @@ type ClockSolitaireInteractorIF interface {
 
 // ClockSolitaireInteractor クロックソリティアインタラクタークラス
 type ClockSolitaireInteractor struct {
-	g interfaces.ClockSolitaireGame
+	GameBase[interfaces.ClockSolitaireGame]
 	p presenter.ClockSolitairePresenter
 }
 
 // NewClockSolitaireInteractor コンストラクタ
 func NewClockSolitaireInteractor(g interfaces.ClockSolitaireGame, p presenter.ClockSolitairePresenter) *ClockSolitaireInteractor {
 	mustNotNil("ClockSolitaireInteractor", map[string]any{"g": g, "p": p})
-	return &ClockSolitaireInteractor{g: g, p: p}
+	return &ClockSolitaireInteractor{GameBase: GameBase[interfaces.ClockSolitaireGame]{Game: g}, p: p}
 }
 
 // Reset ゲーム初期化
 func (ci *ClockSolitaireInteractor) Reset() string {
-	return runAndPresent(ci.g, ci.p, ci.g.Reset)
+	return runAndPresent(ci.Game, ci.p, ci.Game.Reset)
 }
 
 // Step 1ステップ実行
 func (ci *ClockSolitaireInteractor) Step() string {
-	return execAndPresent(ci.g, ci.p, ci.g.Step)
+	return execAndPresent(ci.Game, ci.p, ci.Game.Step)
 }
 
 // AutoPlay 自動プレイ
 func (ci *ClockSolitaireInteractor) AutoPlay() string {
-	return execAndPresent(ci.g, ci.p, ci.g.AutoPlay)
+	return execAndPresent(ci.Game, ci.p, ci.Game.AutoPlay)
 }
 
 // ActionLog 棋譜を出力する
 func (ci *ClockSolitaireInteractor) ActionLog() string {
-	return ci.p.ActionLogOutput(ci.g)
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (ci *ClockSolitaireInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(ci.g)
+	return ci.p.ActionLogOutput(ci.Game)
 }
 
 // RestoreClockSolitaireInteractor deserialises JSON into a ClockSolitaireInteractor.
 func RestoreClockSolitaireInteractor(data []byte, p presenter.ClockSolitairePresenter) (*ClockSolitaireInteractor, error) {
-	cs, err := restoreGame[domain.ClockSolitaire](data)
-	if err != nil {
-		return nil, err
-	}
-	return &ClockSolitaireInteractor{g: cs, p: p}, nil
+	return restoreAndBuild[domain.ClockSolitaire](data, func(g *domain.ClockSolitaire) *ClockSolitaireInteractor {
+		return &ClockSolitaireInteractor{GameBase: GameBase[interfaces.ClockSolitaireGame]{Game: g}, p: p}
+	})
 }

--- a/internal/usecase/ClockSolitaireInteractor.go
+++ b/internal/usecase/ClockSolitaireInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // ClockSolitaireInteractorIF クロックソリティアインタラクターインタフェース
 type ClockSolitaireInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// Step 1ステップ実行

--- a/internal/usecase/CrazyEightsInteractor.go
+++ b/internal/usecase/CrazyEightsInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -30,109 +28,109 @@ type CrazyEightsInteractorIF interface {
 
 // CrazyEightsInteractor クレイジーエイトインタラクタークラス
 type CrazyEightsInteractor struct {
-	g  interfaces.CrazyEightsGame
+	GameBase[interfaces.CrazyEightsGame]
 	gp presenter.CrazyEightsPresenter
 }
 
 // NewCrazyEightsInteractor コンストラクタ
 func NewCrazyEightsInteractor(g interfaces.CrazyEightsGame, gp presenter.CrazyEightsPresenter) *CrazyEightsInteractor {
 	mustNotNil("CrazyEightsInteractor", map[string]any{"g": g, "gp": gp})
-	return &CrazyEightsInteractor{g: g, gp: gp}
+	return &CrazyEightsInteractor{GameBase: GameBase[interfaces.CrazyEightsGame]{Game: g}, gp: gp}
 }
 
 // Reset ゲーム初期化
 func (ci *CrazyEightsInteractor) Reset() string {
-	ci.g.Reset()
+	ci.Game.Reset()
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (ci *CrazyEightsInteractor) ResetWithConfig(cfg domain.CrazyEightsConfig) string {
-	return resetWithValidatedConfig(ci.g, ci.gp, cfg, ci.g.SetConfig, ci.Reset)
+	return resetWithValidatedConfig(ci.Game, ci.gp, cfg, ci.Game.SetConfig, ci.Reset)
 }
 
 // Play カードをプレイ
 func (ci *CrazyEightsInteractor) Play(cardIndex int) string {
-	if out, blocked := guardNotPlayable(ci.g, ci.gp); blocked {
+	if out, blocked := guardNotPlayable(ci.Game, ci.gp); blocked {
 		return out
 	}
-	err := ci.g.PlayerPlay(cardIndex)
+	err := ci.Game.PlayerPlay(cardIndex)
 	if err != nil {
-		return ci.gp.Output(ci.g, err)
+		return ci.gp.Output(ci.Game, err)
 	}
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // ChooseSuit スートを選択 (8を出した後)
 func (ci *CrazyEightsInteractor) ChooseSuit(suit int) string {
-	if out, blocked := guardGameEnd(ci.g, ci.gp); blocked {
+	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
 		return out
 	}
-	err := ci.g.PlayerChooseSuit(suit)
+	err := ci.Game.PlayerChooseSuit(suit)
 	if err != nil {
-		return ci.gp.Output(ci.g, err)
+		return ci.gp.Output(ci.Game, err)
 	}
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // Draw カードを引く
 func (ci *CrazyEightsInteractor) Draw() string {
-	if out, blocked := guardNotPlayable(ci.g, ci.gp); blocked {
+	if out, blocked := guardNotPlayable(ci.Game, ci.gp); blocked {
 		return out
 	}
-	err := ci.g.PlayerDraw()
+	err := ci.Game.PlayerDraw()
 	if err != nil {
-		return ci.gp.Output(ci.g, err)
+		return ci.gp.Output(ci.Game, err)
 	}
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // NextRound ラウンドをスコアリングして次のラウンドへ進む
 func (ci *CrazyEightsInteractor) NextRound() string {
-	ci.g.ScoreRound()
-	if out, blocked := guardGameEnd(ci.g, ci.gp); blocked {
+	ci.Game.ScoreRound()
+	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
 		return out
 	}
-	ci.g.NextRound()
+	ci.Game.NextRound()
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // GetConfig 現在の設定を取得
 func (ci *CrazyEightsInteractor) GetConfig() domain.CrazyEightsConfig {
-	return ci.g.GetConfig()
+	return ci.Game.GetConfig()
 }
 
 // ActionLog 棋譜を出力する
 func (ci *CrazyEightsInteractor) ActionLog() string {
-	return ci.gp.ActionLogOutput(ci.g)
+	return ci.gp.ActionLogOutput(ci.Game)
 }
 
 // runCpuTurns ゲームが終わるか人間の手番またはラウンド/ゲーム終了になるまでCPUターンを実行
 func (ci *CrazyEightsInteractor) runCpuTurns() {
-	for !ci.g.GetGameEndFlag() {
-		phase := ci.g.GetPhase()
+	for !ci.Game.GetGameEndFlag() {
+		phase := ci.Game.GetPhase()
 		if phase == CrazyEightsPhaseRoundEnd || phase == CrazyEightsPhaseGameEnd {
 			break
 		}
 		if phase == domain.CrazyEightsPhaseChooseSuit {
-			if ci.g.IsHumanTurn() {
+			if ci.Game.IsHumanTurn() {
 				break
 			}
-			ci.g.CpuChooseSuit()
+			ci.Game.CpuChooseSuit()
 			continue
 		}
 		if phase != domain.CrazyEightsPhasePlay {
 			break
 		}
-		if ci.g.IsHumanTurn() {
+		if ci.Game.IsHumanTurn() {
 			break
 		}
-		ci.g.CpuPlay()
+		ci.Game.CpuPlay()
 	}
 }
 
@@ -143,16 +141,9 @@ const (
 	CrazyEightsPhaseGameEnd = domain.CrazyEightsPhaseGameEnd
 )
 
-// Snapshot serialises the game state to JSON for KV persistence.
-func (ci *CrazyEightsInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(ci.g)
-}
-
 // RestoreCrazyEightsInteractor deserialises JSON into a CrazyEightsInteractor.
 func RestoreCrazyEightsInteractor(data []byte, gp presenter.CrazyEightsPresenter) (*CrazyEightsInteractor, error) {
-	g, err := restoreGame[domain.CrazyEights](data)
-	if err != nil {
-		return nil, err
-	}
-	return &CrazyEightsInteractor{g: g, gp: gp}, nil
+	return restoreAndBuild[domain.CrazyEights](data, func(g *domain.CrazyEights) *CrazyEightsInteractor {
+		return &CrazyEightsInteractor{GameBase: GameBase[interfaces.CrazyEightsGame]{Game: g}, gp: gp}
+	})
 }

--- a/internal/usecase/CrazyEightsInteractor.go
+++ b/internal/usecase/CrazyEightsInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // CrazyEightsInteractorIF クレイジーエイトインタラクターインタフェース
 type CrazyEightsInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// ResetWithConfig 設定を変更してゲーム初期化

--- a/internal/usecase/CribbageInteractor.go
+++ b/internal/usecase/CribbageInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -32,124 +30,117 @@ type CribbageInteractorIF interface {
 
 // CribbageInteractor クリベッジインタラクタークラス
 type CribbageInteractor struct {
-	g  interfaces.CribbageGame
+	GameBase[interfaces.CribbageGame]
 	gp presenter.CribbagePresenter
 }
 
 // NewCribbageInteractor コンストラクタ
 func NewCribbageInteractor(g interfaces.CribbageGame, gp presenter.CribbagePresenter) *CribbageInteractor {
 	mustNotNil("CribbageInteractor", map[string]any{"g": g, "gp": gp})
-	return &CribbageInteractor{g: g, gp: gp}
+	return &CribbageInteractor{GameBase: GameBase[interfaces.CribbageGame]{Game: g}, gp: gp}
 }
 
 // Reset ゲーム初期化
 func (ci *CribbageInteractor) Reset() string {
-	ci.g.Reset()
+	ci.Game.Reset()
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (ci *CribbageInteractor) ResetWithConfig(cfg domain.CribbageConfig) string {
-	return resetWithValidatedConfig(ci.g, ci.gp, cfg, ci.g.SetConfig, ci.Reset)
+	return resetWithValidatedConfig(ci.Game, ci.gp, cfg, ci.Game.SetConfig, ci.Reset)
 }
 
 // Discard クリブに2枚捨てる
 func (ci *CribbageInteractor) Discard(cardIndices []int) string {
-	if out, blocked := guardNotPlayable(ci.g, ci.gp); blocked {
+	if out, blocked := guardNotPlayable(ci.Game, ci.gp); blocked {
 		return out
 	}
-	err := ci.g.PlayerDiscard(cardIndices)
+	err := ci.Game.PlayerDiscard(cardIndices)
 	if err != nil {
-		return ci.gp.Output(ci.g, err)
+		return ci.gp.Output(ci.Game, err)
 	}
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // Peg ペギングでカードを出す
 func (ci *CribbageInteractor) Peg(cardIndex int) string {
-	if out, blocked := guardNotPlayable(ci.g, ci.gp); blocked {
+	if out, blocked := guardNotPlayable(ci.Game, ci.gp); blocked {
 		return out
 	}
-	err := ci.g.PlayerPeg(cardIndex)
+	err := ci.Game.PlayerPeg(cardIndex)
 	if err != nil {
-		return ci.gp.Output(ci.g, err)
+		return ci.gp.Output(ci.Game, err)
 	}
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // Go Goを宣言する
 func (ci *CribbageInteractor) Go() string {
-	if out, blocked := guardNotPlayable(ci.g, ci.gp); blocked {
+	if out, blocked := guardNotPlayable(ci.Game, ci.gp); blocked {
 		return out
 	}
-	err := ci.g.PlayerGo()
+	err := ci.Game.PlayerGo()
 	if err != nil {
-		return ci.gp.Output(ci.g, err)
+		return ci.gp.Output(ci.Game, err)
 	}
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // ShowNext ショーフェーズの次のスコア計算
 func (ci *CribbageInteractor) ShowNext() string {
-	if out, blocked := guardGameEnd(ci.g, ci.gp); blocked {
+	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
 		return out
 	}
-	err := ci.g.ShowNext()
+	err := ci.Game.ShowNext()
 	if err != nil {
-		return ci.gp.Output(ci.g, err)
+		return ci.gp.Output(ci.Game, err)
 	}
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // NextRound 次のラウンドへ進む
 func (ci *CribbageInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.g, ci.gp); blocked {
+	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
 		return out
 	}
-	ci.g.NextRound()
+	ci.Game.NextRound()
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // GetConfig 現在の設定を取得
 func (ci *CribbageInteractor) GetConfig() domain.CribbageConfig {
-	return ci.g.GetConfig()
+	return ci.Game.GetConfig()
 }
 
 // ActionLog 棋譜を出力する
 func (ci *CribbageInteractor) ActionLog() string {
-	return ci.gp.ActionLogOutput(ci.g)
+	return ci.gp.ActionLogOutput(ci.Game)
 }
 
 // runCpuTurns CPUターンを実行
 func (ci *CribbageInteractor) runCpuTurns() {
-	for !ci.g.GetGameEndFlag() {
-		phase := ci.g.GetPhase()
+	for !ci.Game.GetGameEndFlag() {
+		phase := ci.Game.GetPhase()
 		if phase == domain.CribbagePhaseRoundEnd || phase == domain.CribbagePhaseGameEnd ||
 			phase == domain.CribbagePhaseShow {
 			break
 		}
-		if ci.g.IsHumanTurn() {
+		if ci.Game.IsHumanTurn() {
 			break
 		}
-		ci.g.CpuPlay()
+		ci.Game.CpuPlay()
 	}
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (ci *CribbageInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(ci.g)
 }
 
 // RestoreCribbageInteractor deserialises JSON into a CribbageInteractor.
 func RestoreCribbageInteractor(data []byte, gp presenter.CribbagePresenter) (*CribbageInteractor, error) {
-	g, err := restoreGame[domain.Cribbage](data)
-	if err != nil {
-		return nil, err
-	}
-	return &CribbageInteractor{g: g, gp: gp}, nil
+	return restoreAndBuild[domain.Cribbage](data, func(g *domain.Cribbage) *CribbageInteractor {
+		return &CribbageInteractor{GameBase: GameBase[interfaces.CribbageGame]{Game: g}, gp: gp}
+	})
 }

--- a/internal/usecase/CribbageInteractor.go
+++ b/internal/usecase/CribbageInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // CribbageInteractorIF クリベッジインタラクターインタフェース
 type CribbageInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// ResetWithConfig 設定を変更してゲーム初期化

--- a/internal/usecase/DaifugoInteractor.go
+++ b/internal/usecase/DaifugoInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // DaifugoInteractorIF 大富豪インタラクターインタフェース
 type DaifugoInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// Play 人間プレイヤーがカードを出す (または パスする)

--- a/internal/usecase/DaifugoInteractor.go
+++ b/internal/usecase/DaifugoInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -26,7 +24,7 @@ type DaifugoInteractorIF interface {
 
 // DaifugoInteractor 大富豪インタラクタークラス
 type DaifugoInteractor struct {
-	dg  interfaces.DaifugoGame
+	GameBase[interfaces.DaifugoGame]
 	dgp presenter.DaifugoPresenter
 }
 
@@ -34,68 +32,61 @@ type DaifugoInteractor struct {
 func NewDaifugoInteractor(dg interfaces.DaifugoGame, dgp presenter.DaifugoPresenter) *DaifugoInteractor {
 	mustNotNil("DaifugoInteractor", map[string]any{"dg": dg, "dgp": dgp})
 	return &DaifugoInteractor{
-		dg:  dg,
-		dgp: dgp,
+		GameBase: GameBase[interfaces.DaifugoGame]{Game: dg},
+		dgp:      dgp,
 	}
 }
 
 // Reset ゲーム初期化
 func (di *DaifugoInteractor) Reset() string {
-	di.dg.Reset()
+	di.Game.Reset()
 	di.runCpuTurns()
-	return di.dgp.Output(di.dg, nil)
+	return di.dgp.Output(di.Game, nil)
 }
 
 // Play 人間プレイヤーがカードを出す (または パスする)
 // indices: 出すカードのインデックス。空の場合はパス。
 func (di *DaifugoInteractor) Play(indices []int) string {
-	if out, blocked := guardNotPlayable(di.dg, di.dgp); blocked {
+	if out, blocked := guardNotPlayable(di.Game, di.dgp); blocked {
 		return out
 	}
-	err := di.dg.PlayerPlay(indices)
-	if err == nil && !di.dg.GetGameEndFlag() && !di.dg.HasPendingAction() {
+	err := di.Game.PlayerPlay(indices)
+	if err == nil && !di.Game.GetGameEndFlag() && !di.Game.HasPendingAction() {
 		di.runCpuTurns()
 	}
-	return di.dgp.Output(di.dg, err)
+	return di.dgp.Output(di.Game, err)
 }
 
 // GetConfig 現在の設定を返す
 func (di *DaifugoInteractor) GetConfig() domain.DaifugoConfig {
-	return di.dg.GetConfig()
+	return di.Game.GetConfig()
 }
 
 // ResetWithConfig 設定を変更してゲームを初期化
 func (di *DaifugoInteractor) ResetWithConfig(config domain.DaifugoConfig) string {
-	return resetWithValidatedConfig(di.dg, di.dgp, config, di.dg.SetConfig, di.Reset)
+	return resetWithValidatedConfig(di.Game, di.dgp, config, di.Game.SetConfig, di.Reset)
 }
 
 // Sort 手札ソートモードを変更
 func (di *DaifugoInteractor) Sort(mode domain.DaifugoSortMode) string {
-	return execAndPresent(di.dg, di.dgp, func() error { return di.dg.SortHumanHand(mode) })
+	return execAndPresent(di.Game, di.dgp, func() error { return di.Game.SortHumanHand(mode) })
 }
 
 // ActionLog 棋譜を出力する
 func (di *DaifugoInteractor) ActionLog() string {
-	return di.dgp.ActionLogOutput(di.dg)
+	return di.dgp.ActionLogOutput(di.Game)
 }
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 func (di *DaifugoInteractor) runCpuTurns() {
-	for !di.dg.GetGameEndFlag() && !di.dg.IsHumanTurn() {
-		di.dg.CpuPlay()
+	for !di.Game.GetGameEndFlag() && !di.Game.IsHumanTurn() {
+		di.Game.CpuPlay()
 	}
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (di *DaifugoInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(di.dg)
 }
 
 // RestoreDaifugoInteractor deserialises JSON into a DaifugoInteractor.
 func RestoreDaifugoInteractor(data []byte, dgp presenter.DaifugoPresenter) (*DaifugoInteractor, error) {
-	dg, err := restoreGame[domain.Daifugo](data)
-	if err != nil {
-		return nil, err
-	}
-	return &DaifugoInteractor{dg: dg, dgp: dgp}, nil
+	return restoreAndBuild[domain.Daifugo](data, func(g *domain.Daifugo) *DaifugoInteractor {
+		return &DaifugoInteractor{GameBase: GameBase[interfaces.DaifugoGame]{Game: g}, dgp: dgp}
+	})
 }

--- a/internal/usecase/DaifugoInteractor_internal_test.go
+++ b/internal/usecase/DaifugoInteractor_internal_test.go
@@ -61,11 +61,11 @@ func TestDaifugoInteractor_Play_GameEndFlag(t *testing.T) {
 	dgpMock := new(presenter.MockDaifugoPresenter)
 	dgpMock.On("Output", mock.Anything, mock.Anything).Return(mockOutput)
 	di := NewDaifugoInteractor(newInternalTestDaifugo(), dgpMock)
-	di.dg = buildDaifugoEndedGame()
+	di.Game = buildDaifugoEndedGame()
 
 	// Play the card at index 0 → human finishes → checkGameEnd → gameEndFlag = true.
 	di.Play([]int{0})
-	assert.True(t, di.dg.GetGameEndFlag())
+	assert.True(t, di.Game.GetGameEndFlag())
 
 	// Now call Play again with gameEndFlag == true → early return.
 	result := di.Play([]int{})
@@ -77,10 +77,10 @@ func TestDaifugoInteractor_Play_NotHumanTurn(t *testing.T) {
 	dgpMock := new(presenter.MockDaifugoPresenter)
 	dgpMock.On("Output", mock.Anything, mock.Anything).Return(mockOutput)
 	di := NewDaifugoInteractor(newInternalTestDaifugo(), dgpMock)
-	di.dg = buildDaifugoCpuTurnGame()
+	di.Game = buildDaifugoCpuTurnGame()
 
 	// currentTurn = 0, player 0 is CPU → !IsHumanTurn() is true.
-	assert.False(t, di.dg.IsHumanTurn())
+	assert.False(t, di.Game.IsHumanTurn())
 	result := di.Play([]int{})
 	assert.Equal(t, mockOutput, result)
 }

--- a/internal/usecase/DoubtInteractor.go
+++ b/internal/usecase/DoubtInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // DoubtInteractorIF ダウトインタラクターインタフェース
 type DoubtInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// ResetWithConfig 設定を変更してゲーム初期化 (profileData: JSONプロファイル、nilなら無視)

--- a/internal/usecase/DoubtInteractor.go
+++ b/internal/usecase/DoubtInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -32,97 +30,90 @@ type DoubtInteractorIF interface {
 
 // DoubtInteractor ダウトインタラクタークラス
 type DoubtInteractor struct {
-	d  interfaces.DoubtGame
+	GameBase[interfaces.DoubtGame]
 	dp presenter.DoubtPresenter
 }
 
 // NewDoubtInteractor コンストラクタ
 func NewDoubtInteractor(d interfaces.DoubtGame, dp presenter.DoubtPresenter) *DoubtInteractor {
 	mustNotNil("DoubtInteractor", map[string]any{"d": d, "dp": dp})
-	return &DoubtInteractor{d: d, dp: dp}
+	return &DoubtInteractor{GameBase: GameBase[interfaces.DoubtGame]{Game: d}, dp: dp}
 }
 
 // Reset ゲーム初期化
 func (di *DoubtInteractor) Reset() string {
-	return runAndPresent(di.d, di.dp, di.d.Reset)
+	return runAndPresent(di.Game, di.dp, di.Game.Reset)
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (di *DoubtInteractor) ResetWithConfig(cfg domain.DoubtConfig, profileData []byte) string {
-	di.d.SetConfig(cfg)
-	di.d.Reset()
+	di.Game.SetConfig(cfg)
+	di.Game.Reset()
 	if len(profileData) > 0 {
-		_ = di.d.ImportProfile(profileData)
+		_ = di.Game.ImportProfile(profileData)
 	}
-	return di.dp.Output(di.d, nil)
+	return di.dp.Output(di.Game, nil)
 }
 
 // Play 人間プレイヤーがカードを出す
 func (di *DoubtInteractor) Play(cardIndices []int, claimedValue int, humanPlayMs int) string {
-	if out, blocked := guardNotPlayable(di.d, di.dp); blocked {
+	if out, blocked := guardNotPlayable(di.Game, di.dp); blocked {
 		return out
 	}
-	err := di.d.PlayerPlay(cardIndices, claimedValue, humanPlayMs)
-	return di.dp.Output(di.d, err)
+	err := di.Game.PlayerPlay(cardIndices, claimedValue, humanPlayMs)
+	return di.dp.Output(di.Game, err)
 }
 
 // ResolveDoubt ダウト解決 (ダウトした人が正しかったか判定)
 func (di *DoubtInteractor) ResolveDoubt(doubterIndices []int) string {
-	di.d.ResolveDoubt(doubterIndices)
+	di.Game.ResolveDoubt(doubterIndices)
 	di.runCpuTurns()
-	return di.dp.Output(di.d, nil)
+	return di.dp.Output(di.Game, nil)
 }
 
 // SkipDoubt ダウトをスキップ (誰もダウトしなかった)
 func (di *DoubtInteractor) SkipDoubt() string {
-	di.d.SkipDoubt()
+	di.Game.SkipDoubt()
 	di.runCpuTurns()
-	return di.dp.Output(di.d, nil)
+	return di.dp.Output(di.Game, nil)
 }
 
 // GetCpuDoubters CPUダウターインデックスリスト取得
 func (di *DoubtInteractor) GetCpuDoubters() []int {
-	return di.d.GetCpuDoubters()
+	return di.Game.GetCpuDoubters()
 }
 
 // GetConfig 現在の設定を取得
 func (di *DoubtInteractor) GetConfig() domain.DoubtConfig {
-	return di.d.GetConfig()
+	return di.Game.GetConfig()
 }
 
 // ResetProfile メタAIプロファイルをリセット
 func (di *DoubtInteractor) ResetProfile() string {
-	return runAndPresent(di.d, di.dp, di.d.ResetProfile)
+	return runAndPresent(di.Game, di.dp, di.Game.ResetProfile)
 }
 
 // ActionLog 棋譜を出力する
 func (di *DoubtInteractor) ActionLog() string {
-	return di.dp.ActionLogOutput(di.d)
+	return di.dp.ActionLogOutput(di.Game)
 }
 
 // runCpuTurns ゲームが終わるか人間の手番またはダウトフェーズになるまでCPUターンを実行
 func (di *DoubtInteractor) runCpuTurns() {
-	for !di.d.GetGameEndFlag() {
-		if di.d.GetPhase() == domain.DoubtPhaseDoubt {
+	for !di.Game.GetGameEndFlag() {
+		if di.Game.GetPhase() == domain.DoubtPhaseDoubt {
 			break
 		}
-		if di.d.IsHumanTurn() {
+		if di.Game.IsHumanTurn() {
 			break
 		}
-		di.d.CpuPlay()
+		di.Game.CpuPlay()
 	}
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (di *DoubtInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(di.d)
 }
 
 // RestoreDoubtInteractor deserialises JSON into a DoubtInteractor.
 func RestoreDoubtInteractor(data []byte, dp presenter.DoubtPresenter) (*DoubtInteractor, error) {
-	d, err := restoreGame[domain.Doubt](data)
-	if err != nil {
-		return nil, err
-	}
-	return &DoubtInteractor{d: d, dp: dp}, nil
+	return restoreAndBuild[domain.Doubt](data, func(g *domain.Doubt) *DoubtInteractor {
+		return &DoubtInteractor{GameBase: GameBase[interfaces.DoubtGame]{Game: g}, dp: dp}
+	})
 }

--- a/internal/usecase/EuchreInteractor.go
+++ b/internal/usecase/EuchreInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -40,168 +38,168 @@ type EuchreInteractorIF interface {
 
 // EuchreInteractor ユーカーインタラクタークラス
 type EuchreInteractor struct {
-	e  interfaces.EuchreGame
+	GameBase[interfaces.EuchreGame]
 	ep presenter.EuchrePresenter
 }
 
 // NewEuchreInteractor コンストラクタ
 func NewEuchreInteractor(e interfaces.EuchreGame, ep presenter.EuchrePresenter) *EuchreInteractor {
 	mustNotNil("EuchreInteractor", map[string]any{"e": e, "ep": ep})
-	return &EuchreInteractor{e: e, ep: ep}
+	return &EuchreInteractor{GameBase: GameBase[interfaces.EuchreGame]{Game: e}, ep: ep}
 }
 
 // Reset ゲーム初期化
 func (ei *EuchreInteractor) Reset() string {
-	ei.e.Reset()
+	ei.Game.Reset()
 	ei.runCpuBids()
 	ei.runCpuDiscard()
 	ei.runCpuTurns()
-	return ei.ep.Output(ei.e, nil)
+	return ei.ep.Output(ei.Game, nil)
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (ei *EuchreInteractor) ResetWithConfig(cfg domain.EuchreConfig) string {
-	return resetWithValidatedConfig(ei.e, ei.ep, cfg, ei.e.SetConfig, ei.Reset)
+	return resetWithValidatedConfig(ei.Game, ei.ep, cfg, ei.Game.SetConfig, ei.Reset)
 }
 
 // PickUp ピックアップ判断
 func (ei *EuchreInteractor) PickUp(orderUp bool, goAlone bool) string {
-	if out, blocked := guardGameEnd(ei.e, ei.ep); blocked {
+	if out, blocked := guardGameEnd(ei.Game, ei.ep); blocked {
 		return out
 	}
-	err := ei.e.PlayerPickUp(orderUp, goAlone)
+	err := ei.Game.PlayerPickUp(orderUp, goAlone)
 	if err != nil {
-		return ei.ep.Output(ei.e, err)
+		return ei.ep.Output(ei.Game, err)
 	}
 	ei.runCpuBids()
 	ei.runCpuDiscard()
 	ei.runCpuTurns()
-	return ei.ep.Output(ei.e, nil)
+	return ei.ep.Output(ei.Game, nil)
 }
 
 // CallTrump スートを指名する
 func (ei *EuchreInteractor) CallTrump(suit int, goAlone bool) string {
-	if out, blocked := guardGameEnd(ei.e, ei.ep); blocked {
+	if out, blocked := guardGameEnd(ei.Game, ei.ep); blocked {
 		return out
 	}
-	err := ei.e.PlayerCallTrump(suit, goAlone)
+	err := ei.Game.PlayerCallTrump(suit, goAlone)
 	if err != nil {
-		return ei.ep.Output(ei.e, err)
+		return ei.ep.Output(ei.Game, err)
 	}
 	ei.runCpuTurns()
-	return ei.ep.Output(ei.e, nil)
+	return ei.ep.Output(ei.Game, nil)
 }
 
 // Pass 現在のフェーズに応じてパスする (PickUp → PickUp(false,false), CallTrump → PassCall)
 func (ei *EuchreInteractor) Pass() string {
-	if out, blocked := guardGameEnd(ei.e, ei.ep); blocked {
+	if out, blocked := guardGameEnd(ei.Game, ei.ep); blocked {
 		return out
 	}
-	phase := ei.e.GetPhase()
+	phase := ei.Game.GetPhase()
 	switch phase {
 	case domain.EuchrePhasePickUp:
 		return ei.PickUp(false, false)
 	case domain.EuchrePhaseCallTrump:
 		return ei.PassCall()
 	default:
-		return ei.ep.Output(ei.e, domain.ErrWrongPhase)
+		return ei.ep.Output(ei.Game, domain.ErrWrongPhase)
 	}
 }
 
 // PassCall コールフェーズでパスする
 func (ei *EuchreInteractor) PassCall() string {
-	if out, blocked := guardGameEnd(ei.e, ei.ep); blocked {
+	if out, blocked := guardGameEnd(ei.Game, ei.ep); blocked {
 		return out
 	}
-	err := ei.e.PlayerPassCall()
+	err := ei.Game.PlayerPassCall()
 	if err != nil {
-		return ei.ep.Output(ei.e, err)
+		return ei.ep.Output(ei.Game, err)
 	}
 	ei.runCpuBids()
 	ei.runCpuDiscard()
 	ei.runCpuTurns()
-	return ei.ep.Output(ei.e, nil)
+	return ei.ep.Output(ei.Game, nil)
 }
 
 // Discard カードを捨てる
 func (ei *EuchreInteractor) Discard(cardIndex int) string {
-	if out, blocked := guardGameEnd(ei.e, ei.ep); blocked {
+	if out, blocked := guardGameEnd(ei.Game, ei.ep); blocked {
 		return out
 	}
-	err := ei.e.PlayerDiscard(cardIndex)
+	err := ei.Game.PlayerDiscard(cardIndex)
 	if err != nil {
-		return ei.ep.Output(ei.e, err)
+		return ei.ep.Output(ei.Game, err)
 	}
 	ei.runCpuTurns()
-	return ei.ep.Output(ei.e, nil)
+	return ei.ep.Output(ei.Game, nil)
 }
 
 // Play カードをプレイ
 func (ei *EuchreInteractor) Play(cardIndex int) string {
-	if out, blocked := guardNotPlayable(ei.e, ei.ep); blocked {
+	if out, blocked := guardNotPlayable(ei.Game, ei.ep); blocked {
 		return out
 	}
-	err := ei.e.PlayerPlay(cardIndex)
+	err := ei.Game.PlayerPlay(cardIndex)
 	if err != nil {
-		return ei.ep.Output(ei.e, err)
+		return ei.ep.Output(ei.Game, err)
 	}
 	ei.runCpuTurns()
-	return ei.ep.Output(ei.e, nil)
+	return ei.ep.Output(ei.Game, nil)
 }
 
 // NextTrick トリックを解決して次のトリックへ進む
 func (ei *EuchreInteractor) NextTrick() string {
-	ei.e.ResolveTrick()
-	if out, blocked := guardGameEnd(ei.e, ei.ep); blocked {
+	ei.Game.ResolveTrick()
+	if out, blocked := guardGameEnd(ei.Game, ei.ep); blocked {
 		return out
 	}
-	ei.e.NextTrick()
+	ei.Game.NextTrick()
 	ei.runCpuTurns()
-	return ei.ep.Output(ei.e, nil)
+	return ei.ep.Output(ei.Game, nil)
 }
 
 // NextRound ラウンドをスコアリングして次のラウンドへ進む
 func (ei *EuchreInteractor) NextRound() string {
-	ei.e.ScoreRound()
-	if out, blocked := guardGameEnd(ei.e, ei.ep); blocked {
+	ei.Game.ScoreRound()
+	if out, blocked := guardGameEnd(ei.Game, ei.ep); blocked {
 		return out
 	}
-	ei.e.NextRound()
+	ei.Game.NextRound()
 	ei.runCpuBids()
 	ei.runCpuDiscard()
 	ei.runCpuTurns()
-	return ei.ep.Output(ei.e, nil)
+	return ei.ep.Output(ei.Game, nil)
 }
 
 // GetConfig 現在の設定を取得
 func (ei *EuchreInteractor) GetConfig() domain.EuchreConfig {
-	return ei.e.GetConfig()
+	return ei.Game.GetConfig()
 }
 
 // Hint ヒント取得
 func (ei *EuchreInteractor) Hint() string {
-	return ei.ep.HintOutput(ei.e)
+	return ei.ep.HintOutput(ei.Game)
 }
 
 // ActionLog 棋譜を出力する
 func (ei *EuchreInteractor) ActionLog() string {
-	return ei.ep.ActionLogOutput(ei.e)
+	return ei.ep.ActionLogOutput(ei.Game)
 }
 
 // runCpuBids PickUpとCallTrumpフェーズでCPUを自動実行する
 func (ei *EuchreInteractor) runCpuBids() {
-	for !ei.e.GetGameEndFlag() {
-		phase := ei.e.GetPhase()
+	for !ei.Game.GetGameEndFlag() {
+		phase := ei.Game.GetPhase()
 		if phase == domain.EuchrePhasePickUp {
-			if ei.e.IsHumanBidTurn() {
+			if ei.Game.IsHumanBidTurn() {
 				break
 			}
-			ei.e.CpuPickUp()
+			ei.Game.CpuPickUp()
 		} else if phase == domain.EuchrePhaseCallTrump {
-			if ei.e.IsHumanBidTurn() {
+			if ei.Game.IsHumanBidTurn() {
 				break
 			}
-			ei.e.CpuCallTrump()
+			ei.Game.CpuCallTrump()
 		} else {
 			break
 		}
@@ -210,29 +208,24 @@ func (ei *EuchreInteractor) runCpuBids() {
 
 // runCpuDiscard DiscardフェーズでCPUディーラーを自動実行する
 func (ei *EuchreInteractor) runCpuDiscard() {
-	if ei.e.GetGameEndFlag() {
+	if ei.Game.GetGameEndFlag() {
 		return
 	}
-	if ei.e.GetPhase() == domain.EuchrePhaseDiscard {
-		if !ei.e.IsHumanTurn() {
-			ei.e.CpuDiscard()
+	if ei.Game.GetPhase() == domain.EuchrePhaseDiscard {
+		if !ei.Game.IsHumanTurn() {
+			ei.Game.CpuDiscard()
 		}
 	}
 }
 
 // runCpuTurns プレイフェーズでCPUターンを自動実行する
 func (ei *EuchreInteractor) runCpuTurns() {
-	runCpuTurnsLoop(ei.e, trickPhases[domain.EuchrePhase]{
+	runCpuTurnsLoop(ei.Game, trickPhases[domain.EuchrePhase]{
 		play:     domain.EuchrePhasePlay,
 		trickEnd: domain.EuchrePhaseTrickEnd,
 		roundEnd: domain.EuchrePhaseRoundEnd,
 		gameEnd:  domain.EuchrePhaseGameEnd,
 	})
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (ei *EuchreInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(ei.e)
 }
 
 // RestoreEuchreInteractor deserialises JSON into an EuchreInteractor.
@@ -241,5 +234,5 @@ func RestoreEuchreInteractor(data []byte, ep presenter.EuchrePresenter) (*Euchre
 	if err != nil {
 		return nil, err
 	}
-	return &EuchreInteractor{e: e, ep: ep}, nil
+	return &EuchreInteractor{GameBase: GameBase[interfaces.EuchreGame]{Game: e}, ep: ep}, nil
 }

--- a/internal/usecase/EuchreInteractor.go
+++ b/internal/usecase/EuchreInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // EuchreInteractorIF ユーカーインタラクターインタフェース
 type EuchreInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// ResetWithConfig 設定を変更してゲーム初期化

--- a/internal/usecase/EuchreInteractor_test.go
+++ b/internal/usecase/EuchreInteractor_test.go
@@ -251,3 +251,99 @@ func TestEuchreInteractor_ActionLog(t *testing.T) {
 	result := ei.ActionLog()
 	assert.Contains(t, result, "action")
 }
+
+func TestEuchreInteractor_PassCall_GameEnd(t *testing.T) {
+	epMock := new(presenter.MockEuchrePresenter)
+	epMock.On("Output", mock.Anything, mock.Anything).Return(`{"gameEnd":true}`)
+	gameMock := new(interfaces.MockEuchreGame)
+	gameMock.On("GetGameEndFlag").Return(true)
+
+	ei := usecase.NewEuchreInteractor(gameMock, epMock)
+	result := ei.PassCall()
+	assert.Contains(t, result, "gameEnd")
+}
+
+func TestEuchreInteractor_Discard_GameEnd(t *testing.T) {
+	epMock := new(presenter.MockEuchrePresenter)
+	epMock.On("Output", mock.Anything, mock.Anything).Return(`{"gameEnd":true}`)
+	gameMock := new(interfaces.MockEuchreGame)
+	gameMock.On("GetGameEndFlag").Return(true)
+
+	ei := usecase.NewEuchreInteractor(gameMock, epMock)
+	result := ei.Discard(0)
+	assert.Contains(t, result, "gameEnd")
+}
+
+func TestEuchreInteractor_Discard_Error(t *testing.T) {
+	gameMock, epMock := setupEuchreInteractorMocks(domain.EuchrePhaseDiscard)
+	gameMock.On("PlayerDiscard", 99).Return(errors.New("invalid card"))
+
+	ei := usecase.NewEuchreInteractor(gameMock, epMock)
+	result := ei.Discard(99)
+	assert.Contains(t, result, "phase")
+}
+
+func TestEuchreInteractor_Play_NotHumanTurn(t *testing.T) {
+	epMock := new(presenter.MockEuchrePresenter)
+	epMock.On("Output", mock.Anything, mock.Anything).Return(`{"notHuman":true}`)
+	gameMock := new(interfaces.MockEuchreGame)
+	gameMock.On("GetGameEndFlag").Return(false)
+	gameMock.On("IsHumanTurn").Return(false)
+
+	ei := usecase.NewEuchreInteractor(gameMock, epMock)
+	result := ei.Play(0)
+	assert.Contains(t, result, "notHuman")
+}
+
+func TestEuchreInteractor_NextTrick_GameEnd(t *testing.T) {
+	epMock := new(presenter.MockEuchrePresenter)
+	epMock.On("Output", mock.Anything, mock.Anything).Return(`{"gameEnd":true}`)
+	gameMock := new(interfaces.MockEuchreGame)
+	// After ResolveTrick, game is ended
+	gameMock.On("ResolveTrick").Return()
+	gameMock.On("GetGameEndFlag").Return(true)
+
+	ei := usecase.NewEuchreInteractor(gameMock, epMock)
+	result := ei.NextTrick()
+	assert.Contains(t, result, "gameEnd")
+	gameMock.AssertCalled(t, "ResolveTrick")
+}
+
+func TestEuchreInteractor_NextRound_GameEnd(t *testing.T) {
+	epMock := new(presenter.MockEuchrePresenter)
+	epMock.On("Output", mock.Anything, mock.Anything).Return(`{"gameEnd":true}`)
+	gameMock := new(interfaces.MockEuchreGame)
+	// After ScoreRound, game is ended
+	gameMock.On("ScoreRound").Return()
+	gameMock.On("GetGameEndFlag").Return(true)
+
+	ei := usecase.NewEuchreInteractor(gameMock, epMock)
+	result := ei.NextRound()
+	assert.Contains(t, result, "gameEnd")
+	gameMock.AssertCalled(t, "ScoreRound")
+}
+
+func TestRestoreEuchreInteractor(t *testing.T) {
+	players := []*domain.EuchrePlayer{
+		domain.NewEuchrePlayer(true, 0),
+		domain.NewEuchrePlayer(false, 1),
+		domain.NewEuchrePlayer(false, 0),
+		domain.NewEuchrePlayer(false, 1),
+	}
+	e := domain.NewEuchre(domain.NewTrumpCardsEuchre(), players, domain.DefaultEuchreConfig())
+	epMock := new(presenter.MockEuchrePresenter)
+	ei := usecase.NewEuchreInteractor(e, epMock)
+
+	data, err := ei.Snapshot()
+	assert.NoError(t, err)
+
+	restored, err := usecase.RestoreEuchreInteractor(data, epMock)
+	assert.NoError(t, err)
+	assert.NotNil(t, restored)
+}
+
+func TestRestoreEuchreInteractor_InvalidJSON(t *testing.T) {
+	epMock := new(presenter.MockEuchrePresenter)
+	_, err := usecase.RestoreEuchreInteractor([]byte("invalid"), epMock)
+	assert.Error(t, err)
+}

--- a/internal/usecase/FreeCellInteractor.go
+++ b/internal/usecase/FreeCellInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // FreeCellInteractorIF フリーセルインタラクターインタフェース
 type FreeCellInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// MoveTableauToTableau タブローからタブローにカードを移動

--- a/internal/usecase/FreeCellInteractor.go
+++ b/internal/usecase/FreeCellInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -38,86 +36,79 @@ type FreeCellInteractorIF interface {
 
 // FreeCellInteractor フリーセルインタラクタークラス
 type FreeCellInteractor struct {
-	f  interfaces.FreeCellGame
+	GameBase[interfaces.FreeCellGame]
 	fp presenter.FreeCellPresenter
 }
 
 // NewFreeCellInteractor コンストラクタ
 func NewFreeCellInteractor(f interfaces.FreeCellGame, fp presenter.FreeCellPresenter) *FreeCellInteractor {
 	mustNotNil("FreeCellInteractor", map[string]any{"f": f, "fp": fp})
-	return &FreeCellInteractor{f: f, fp: fp}
+	return &FreeCellInteractor{GameBase: GameBase[interfaces.FreeCellGame]{Game: f}, fp: fp}
 }
 
 // Reset ゲーム初期化
 func (fi *FreeCellInteractor) Reset() string {
-	return runAndPresent(fi.f, fi.fp, fi.f.Reset)
+	return runAndPresent(fi.Game, fi.fp, fi.Game.Reset)
 }
 
 // MoveTableauToTableau タブローからタブローにカードを移動
 func (fi *FreeCellInteractor) MoveTableauToTableau(fromCol, cardIndex, toCol int) string {
-	return execAndPresent(fi.f, fi.fp, func() error { return fi.f.MoveTableauToTableau(fromCol, cardIndex, toCol) })
+	return execAndPresent(fi.Game, fi.fp, func() error { return fi.Game.MoveTableauToTableau(fromCol, cardIndex, toCol) })
 }
 
 // MoveTableauToFoundation タブローからファンデーションにカードを移動
 func (fi *FreeCellInteractor) MoveTableauToFoundation(col int) string {
-	return execAndPresent(fi.f, fi.fp, func() error { return fi.f.MoveTableauToFoundation(col) })
+	return execAndPresent(fi.Game, fi.fp, func() error { return fi.Game.MoveTableauToFoundation(col) })
 }
 
 // MoveTableauToFreeCell タブローからフリーセルにカードを移動
 func (fi *FreeCellInteractor) MoveTableauToFreeCell(col, cell int) string {
-	return execAndPresent(fi.f, fi.fp, func() error { return fi.f.MoveTableauToFreeCell(col, cell) })
+	return execAndPresent(fi.Game, fi.fp, func() error { return fi.Game.MoveTableauToFreeCell(col, cell) })
 }
 
 // MoveFreeCellToTableau フリーセルからタブローにカードを移動
 func (fi *FreeCellInteractor) MoveFreeCellToTableau(cell, col int) string {
-	return execAndPresent(fi.f, fi.fp, func() error { return fi.f.MoveFreeCellToTableau(cell, col) })
+	return execAndPresent(fi.Game, fi.fp, func() error { return fi.Game.MoveFreeCellToTableau(cell, col) })
 }
 
 // MoveFreeCellToFoundation フリーセルからファンデーションにカードを移動
 func (fi *FreeCellInteractor) MoveFreeCellToFoundation(cell int) string {
-	return execAndPresent(fi.f, fi.fp, func() error { return fi.f.MoveFreeCellToFoundation(cell) })
+	return execAndPresent(fi.Game, fi.fp, func() error { return fi.Game.MoveFreeCellToFoundation(cell) })
 }
 
 // GiveUp ギブアップ
 func (fi *FreeCellInteractor) GiveUp() string {
-	return runAndPresent(fi.f, fi.fp, fi.f.GiveUp)
+	return runAndPresent(fi.Game, fi.fp, fi.Game.GiveUp)
 }
 
 // Hint ヒント取得
 func (fi *FreeCellInteractor) Hint() string {
-	return fi.fp.HintOutput(fi.f)
+	return fi.fp.HintOutput(fi.Game)
 }
 
 // AutoComplete オートコンプリート
 func (fi *FreeCellInteractor) AutoComplete() string {
-	return execAndPresent(fi.f, fi.fp, fi.f.AutoComplete)
+	return execAndPresent(fi.Game, fi.fp, fi.Game.AutoComplete)
 }
 
 // ActionLog 棋譜を出力する
 func (fi *FreeCellInteractor) ActionLog() string {
-	return fi.fp.ActionLogOutput(fi.f)
+	return fi.fp.ActionLogOutput(fi.Game)
 }
 
 // Undo アンドゥ
 func (fi *FreeCellInteractor) Undo() string {
-	return execAndPresent(fi.f, fi.fp, fi.f.Undo)
+	return execAndPresent(fi.Game, fi.fp, fi.Game.Undo)
 }
 
 // UndoN n回連続アンドゥ
 func (fi *FreeCellInteractor) UndoN(n int) string {
-	return execAndPresent(fi.f, fi.fp, func() error { return fi.f.UndoN(n) })
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (fi *FreeCellInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(fi.f)
+	return execAndPresent(fi.Game, fi.fp, func() error { return fi.Game.UndoN(n) })
 }
 
 // RestoreFreeCellInteractor deserialises JSON into a FreeCellInteractor.
 func RestoreFreeCellInteractor(data []byte, fp presenter.FreeCellPresenter) (*FreeCellInteractor, error) {
-	fc, err := restoreGame[domain.FreeCell](data)
-	if err != nil {
-		return nil, err
-	}
-	return &FreeCellInteractor{f: fc, fp: fp}, nil
+	return restoreAndBuild[domain.FreeCell](data, func(g *domain.FreeCell) *FreeCellInteractor {
+		return &FreeCellInteractor{GameBase: GameBase[interfaces.FreeCellGame]{Game: g}, fp: fp}
+	})
 }

--- a/internal/usecase/GinRummyInteractor.go
+++ b/internal/usecase/GinRummyInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -34,137 +32,130 @@ type GinRummyInteractorIF interface {
 
 // GinRummyInteractor ジンラミーインタラクタークラス
 type GinRummyInteractor struct {
-	g  interfaces.GinRummyGame
+	GameBase[interfaces.GinRummyGame]
 	gp presenter.GinRummyPresenter
 }
 
 // NewGinRummyInteractor コンストラクタ
 func NewGinRummyInteractor(g interfaces.GinRummyGame, gp presenter.GinRummyPresenter) *GinRummyInteractor {
 	mustNotNil("GinRummyInteractor", map[string]any{"g": g, "gp": gp})
-	return &GinRummyInteractor{g: g, gp: gp}
+	return &GinRummyInteractor{GameBase: GameBase[interfaces.GinRummyGame]{Game: g}, gp: gp}
 }
 
 // Reset ゲーム初期化
 func (ci *GinRummyInteractor) Reset() string {
-	ci.g.Reset()
+	ci.Game.Reset()
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (ci *GinRummyInteractor) ResetWithConfig(cfg domain.GinRummyConfig) string {
-	return resetWithValidatedConfig(ci.g, ci.gp, cfg, ci.g.SetConfig, ci.Reset)
+	return resetWithValidatedConfig(ci.Game, ci.gp, cfg, ci.Game.SetConfig, ci.Reset)
 }
 
 // DrawFromStock 山札からカードを引く
 func (ci *GinRummyInteractor) DrawFromStock() string {
-	if out, blocked := guardNotPlayable(ci.g, ci.gp); blocked {
+	if out, blocked := guardNotPlayable(ci.Game, ci.gp); blocked {
 		return out
 	}
-	err := ci.g.PlayerDrawFromStock()
+	err := ci.Game.PlayerDrawFromStock()
 	if err != nil {
-		return ci.gp.Output(ci.g, err)
+		return ci.gp.Output(ci.Game, err)
 	}
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // DrawFromDiscard 捨て札からカードを引く
 func (ci *GinRummyInteractor) DrawFromDiscard() string {
-	if out, blocked := guardNotPlayable(ci.g, ci.gp); blocked {
+	if out, blocked := guardNotPlayable(ci.Game, ci.gp); blocked {
 		return out
 	}
-	err := ci.g.PlayerDrawFromDiscard()
+	err := ci.Game.PlayerDrawFromDiscard()
 	if err != nil {
-		return ci.gp.Output(ci.g, err)
+		return ci.gp.Output(ci.Game, err)
 	}
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // Discard カードを捨てる
 func (ci *GinRummyInteractor) Discard(cardIndex int) string {
-	if out, blocked := guardNotPlayable(ci.g, ci.gp); blocked {
+	if out, blocked := guardNotPlayable(ci.Game, ci.gp); blocked {
 		return out
 	}
-	err := ci.g.PlayerDiscard(cardIndex)
+	err := ci.Game.PlayerDiscard(cardIndex)
 	if err != nil {
-		return ci.gp.Output(ci.g, err)
+		return ci.gp.Output(ci.Game, err)
 	}
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // Knock ノックする
 func (ci *GinRummyInteractor) Knock(cardIndex int) string {
-	if out, blocked := guardNotPlayable(ci.g, ci.gp); blocked {
+	if out, blocked := guardNotPlayable(ci.Game, ci.gp); blocked {
 		return out
 	}
-	err := ci.g.PlayerKnock(cardIndex)
+	err := ci.Game.PlayerKnock(cardIndex)
 	if err != nil {
-		return ci.gp.Output(ci.g, err)
+		return ci.gp.Output(ci.Game, err)
 	}
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // Layoff レイオフする
 func (ci *GinRummyInteractor) Layoff(cardIndices []int) string {
-	if out, blocked := guardGameEnd(ci.g, ci.gp); blocked {
+	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
 		return out
 	}
-	err := ci.g.PlayerLayoff(cardIndices)
+	err := ci.Game.PlayerLayoff(cardIndices)
 	if err != nil {
-		return ci.gp.Output(ci.g, err)
+		return ci.gp.Output(ci.Game, err)
 	}
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // NextRound 次のラウンドへ進む
 func (ci *GinRummyInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(ci.g, ci.gp); blocked {
+	if out, blocked := guardGameEnd(ci.Game, ci.gp); blocked {
 		return out
 	}
-	ci.g.NextRound()
+	ci.Game.NextRound()
 	ci.runCpuTurns()
-	return ci.gp.Output(ci.g, nil)
+	return ci.gp.Output(ci.Game, nil)
 }
 
 // GetConfig 現在の設定を取得
 func (ci *GinRummyInteractor) GetConfig() domain.GinRummyConfig {
-	return ci.g.GetConfig()
+	return ci.Game.GetConfig()
 }
 
 // ActionLog 棋譜を出力する
 func (ci *GinRummyInteractor) ActionLog() string {
-	return ci.gp.ActionLogOutput(ci.g)
+	return ci.gp.ActionLogOutput(ci.Game)
 }
 
 // runCpuTurns CPUターンを実行
 func (ci *GinRummyInteractor) runCpuTurns() {
-	for !ci.g.GetGameEndFlag() {
-		phase := ci.g.GetPhase()
+	for !ci.Game.GetGameEndFlag() {
+		phase := ci.Game.GetPhase()
 		if phase == domain.GinRummyPhaseRoundEnd || phase == domain.GinRummyPhaseGameEnd {
 			break
 		}
-		if ci.g.IsHumanTurn() {
+		if ci.Game.IsHumanTurn() {
 			break
 		}
-		ci.g.CpuPlay()
+		ci.Game.CpuPlay()
 	}
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (ci *GinRummyInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(ci.g)
 }
 
 // RestoreGinRummyInteractor deserialises JSON into a GinRummyInteractor.
 func RestoreGinRummyInteractor(data []byte, gp presenter.GinRummyPresenter) (*GinRummyInteractor, error) {
-	g, err := restoreGame[domain.GinRummy](data)
-	if err != nil {
-		return nil, err
-	}
-	return &GinRummyInteractor{g: g, gp: gp}, nil
+	return restoreAndBuild[domain.GinRummy](data, func(g *domain.GinRummy) *GinRummyInteractor {
+		return &GinRummyInteractor{GameBase: GameBase[interfaces.GinRummyGame]{Game: g}, gp: gp}
+	})
 }

--- a/internal/usecase/GinRummyInteractor.go
+++ b/internal/usecase/GinRummyInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // GinRummyInteractorIF ジンラミーインタラクターインタフェース
 type GinRummyInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// ResetWithConfig 設定を変更してゲーム初期化

--- a/internal/usecase/GoFishInteractor.go
+++ b/internal/usecase/GoFishInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // GoFishInteractorIF Go Fishインタラクターインタフェース
 type GoFishInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset(config domain.GoFishConfig) string
 	// GetConfig 現在の設定を返す

--- a/internal/usecase/GoFishInteractor.go
+++ b/internal/usecase/GoFishInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -22,66 +20,59 @@ type GoFishInteractorIF interface {
 
 // GoFishInteractor Go Fishインタラクタークラス
 type GoFishInteractor struct {
-	gf  interfaces.GoFishGame
+	GameBase[interfaces.GoFishGame]
 	gfp presenter.GoFishPresenter
 }
 
 // NewGoFishInteractor コンストラクタ
 func NewGoFishInteractor(gf interfaces.GoFishGame, gfp presenter.GoFishPresenter) *GoFishInteractor {
 	mustNotNil("GoFishInteractor", map[string]any{"gf": gf, "gfp": gfp})
-	return &GoFishInteractor{gf: gf, gfp: gfp}
+	return &GoFishInteractor{GameBase: GameBase[interfaces.GoFishGame]{Game: gf}, gfp: gfp}
 }
 
 // GetConfig 現在の設定を返す
 func (gi *GoFishInteractor) GetConfig() domain.GoFishConfig {
-	return gi.gf.GetConfig()
+	return gi.Game.GetConfig()
 }
 
 // Reset ゲーム初期化
 func (gi *GoFishInteractor) Reset(config domain.GoFishConfig) string {
 	if err := config.Validate(); err != nil {
-		return gi.gfp.Output(gi.gf, err)
+		return gi.gfp.Output(gi.Game, err)
 	}
-	gi.gf.SetConfig(config)
-	gi.gf.Reset()
+	gi.Game.SetConfig(config)
+	gi.Game.Reset()
 	gi.runCpuTurns()
-	return gi.gfp.Output(gi.gf, nil)
+	return gi.gfp.Output(gi.Game, nil)
 }
 
 // Ask 人間プレイヤーが相手にランクを要求する
 func (gi *GoFishInteractor) Ask(targetIdx, rank int) string {
-	if out, blocked := guardNotPlayable(gi.gf, gi.gfp); blocked {
+	if out, blocked := guardNotPlayable(gi.Game, gi.gfp); blocked {
 		return out
 	}
-	err := gi.gf.PlayerAsk(targetIdx, rank)
-	if err == nil && !gi.gf.GetGameEndFlag() {
+	err := gi.Game.PlayerAsk(targetIdx, rank)
+	if err == nil && !gi.Game.GetGameEndFlag() {
 		gi.runCpuTurns()
 	}
-	return gi.gfp.Output(gi.gf, err)
+	return gi.gfp.Output(gi.Game, err)
 }
 
 // ActionLog 棋譜を出力する
 func (gi *GoFishInteractor) ActionLog() string {
-	return gi.gfp.ActionLogOutput(gi.gf)
+	return gi.gfp.ActionLogOutput(gi.Game)
 }
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 func (gi *GoFishInteractor) runCpuTurns() {
-	for !gi.gf.GetGameEndFlag() && !gi.gf.IsHumanTurn() {
-		_ = gi.gf.CpuAsk()
+	for !gi.Game.GetGameEndFlag() && !gi.Game.IsHumanTurn() {
+		_ = gi.Game.CpuAsk()
 	}
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (gi *GoFishInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(gi.gf)
 }
 
 // RestoreGoFishInteractor deserialises JSON into a GoFishInteractor.
 func RestoreGoFishInteractor(data []byte, gfp presenter.GoFishPresenter) (*GoFishInteractor, error) {
-	gf, err := restoreGame[domain.GoFish](data)
-	if err != nil {
-		return nil, err
-	}
-	return &GoFishInteractor{gf: gf, gfp: gfp}, nil
+	return restoreAndBuild[domain.GoFish](data, func(g *domain.GoFish) *GoFishInteractor {
+		return &GoFishInteractor{GameBase: GameBase[interfaces.GoFishGame]{Game: g}, gfp: gfp}
+	})
 }

--- a/internal/usecase/GolfInteractor.go
+++ b/internal/usecase/GolfInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // GolfInteractorIF ゴルフソリティアインタラクターインタフェース
 type GolfInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// Draw ストックからウェイストにカードを引く

--- a/internal/usecase/GolfInteractor.go
+++ b/internal/usecase/GolfInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -30,66 +28,59 @@ type GolfInteractorIF interface {
 
 // GolfInteractor ゴルフソリティアインタラクタークラス
 type GolfInteractor struct {
-	g  interfaces.GolfGame
+	GameBase[interfaces.GolfGame]
 	gp presenter.GolfPresenter
 }
 
 // NewGolfInteractor コンストラクタ
 func NewGolfInteractor(g interfaces.GolfGame, gp presenter.GolfPresenter) *GolfInteractor {
 	mustNotNil("GolfInteractor", map[string]any{"g": g, "gp": gp})
-	return &GolfInteractor{g: g, gp: gp}
+	return &GolfInteractor{GameBase: GameBase[interfaces.GolfGame]{Game: g}, gp: gp}
 }
 
 // Reset ゲーム初期化
 func (gi *GolfInteractor) Reset() string {
-	return runAndPresent(gi.g, gi.gp, gi.g.Reset)
+	return runAndPresent(gi.Game, gi.gp, gi.Game.Reset)
 }
 
 // Draw ストックからウェイストにカードを引く
 func (gi *GolfInteractor) Draw() string {
-	return execAndPresent(gi.g, gi.gp, gi.g.Draw)
+	return execAndPresent(gi.Game, gi.gp, gi.Game.Draw)
 }
 
 // Remove タブローのカードを除去
 func (gi *GolfInteractor) Remove(col int) string {
-	return execAndPresent(gi.g, gi.gp, func() error { return gi.g.Remove(col) })
+	return execAndPresent(gi.Game, gi.gp, func() error { return gi.Game.Remove(col) })
 }
 
 // GiveUp ギブアップ
 func (gi *GolfInteractor) GiveUp() string {
-	return runAndPresent(gi.g, gi.gp, gi.g.GiveUp)
+	return runAndPresent(gi.Game, gi.gp, gi.Game.GiveUp)
 }
 
 // Hint ヒント取得
 func (gi *GolfInteractor) Hint() string {
-	return gi.gp.HintOutput(gi.g)
+	return gi.gp.HintOutput(gi.Game)
 }
 
 // ActionLog 棋譜を出力する
 func (gi *GolfInteractor) ActionLog() string {
-	return gi.gp.ActionLogOutput(gi.g)
+	return gi.gp.ActionLogOutput(gi.Game)
 }
 
 // Undo アンドゥ
 func (gi *GolfInteractor) Undo() string {
-	return execAndPresent(gi.g, gi.gp, gi.g.Undo)
+	return execAndPresent(gi.Game, gi.gp, gi.Game.Undo)
 }
 
 // UndoN n回連続アンドゥ
 func (gi *GolfInteractor) UndoN(n int) string {
-	return execAndPresent(gi.g, gi.gp, func() error { return gi.g.UndoN(n) })
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (gi *GolfInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(gi.g)
+	return execAndPresent(gi.Game, gi.gp, func() error { return gi.Game.UndoN(n) })
 }
 
 // RestoreGolfInteractor deserialises JSON into a GolfInteractor.
 func RestoreGolfInteractor(data []byte, gp presenter.GolfPresenter) (*GolfInteractor, error) {
-	golf, err := restoreGame[domain.Golf](data)
-	if err != nil {
-		return nil, err
-	}
-	return &GolfInteractor{g: golf, gp: gp}, nil
+	return restoreAndBuild[domain.Golf](data, func(g *domain.Golf) *GolfInteractor {
+		return &GolfInteractor{GameBase: GameBase[interfaces.GolfGame]{Game: g}, gp: gp}
+	})
 }

--- a/internal/usecase/HeartsInteractor.go
+++ b/internal/usecase/HeartsInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -32,93 +30,93 @@ type HeartsInteractorIF interface {
 
 // HeartsInteractor ハーツインタラクタークラス
 type HeartsInteractor struct {
-	h  interfaces.HeartsGame
+	GameBase[interfaces.HeartsGame]
 	hp presenter.HeartsPresenter
 }
 
 // NewHeartsInteractor コンストラクタ
 func NewHeartsInteractor(h interfaces.HeartsGame, hp presenter.HeartsPresenter) *HeartsInteractor {
 	mustNotNil("HeartsInteractor", map[string]any{"h": h, "hp": hp})
-	return &HeartsInteractor{h: h, hp: hp}
+	return &HeartsInteractor{GameBase: GameBase[interfaces.HeartsGame]{Game: h}, hp: hp}
 }
 
 // Reset ゲーム初期化
 func (hi *HeartsInteractor) Reset() string {
-	hi.h.Reset()
-	if hi.h.GetPassDirection() == domain.HeartsPassNone {
+	hi.Game.Reset()
+	if hi.Game.GetPassDirection() == domain.HeartsPassNone {
 		hi.runCpuTurns()
 	}
-	return hi.hp.Output(hi.h, nil)
+	return hi.hp.Output(hi.Game, nil)
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (hi *HeartsInteractor) ResetWithConfig(cfg domain.HeartsConfig) string {
-	return resetWithValidatedConfig(hi.h, hi.hp, cfg, hi.h.SetConfig, hi.Reset)
+	return resetWithValidatedConfig(hi.Game, hi.hp, cfg, hi.Game.SetConfig, hi.Reset)
 }
 
 // Pass カード交換
 func (hi *HeartsInteractor) Pass(cardIndices []int) string {
-	if out, blocked := guardGameEnd(hi.h, hi.hp); blocked {
+	if out, blocked := guardGameEnd(hi.Game, hi.hp); blocked {
 		return out
 	}
-	err := hi.h.PlayerPass(cardIndices)
+	err := hi.Game.PlayerPass(cardIndices)
 	if err != nil {
-		return hi.hp.Output(hi.h, err)
+		return hi.hp.Output(hi.Game, err)
 	}
-	hi.h.CpuPass()
-	hi.h.ExecutePass()
+	hi.Game.CpuPass()
+	hi.Game.ExecutePass()
 	hi.runCpuTurns()
-	return hi.hp.Output(hi.h, nil)
+	return hi.hp.Output(hi.Game, nil)
 }
 
 // Play カードをプレイ
 func (hi *HeartsInteractor) Play(cardIndex int) string {
-	if out, blocked := guardNotPlayable(hi.h, hi.hp); blocked {
+	if out, blocked := guardNotPlayable(hi.Game, hi.hp); blocked {
 		return out
 	}
-	err := hi.h.PlayerPlay(cardIndex)
+	err := hi.Game.PlayerPlay(cardIndex)
 	if err != nil {
-		return hi.hp.Output(hi.h, err)
+		return hi.hp.Output(hi.Game, err)
 	}
 	hi.runCpuTurns()
-	return hi.hp.Output(hi.h, nil)
+	return hi.hp.Output(hi.Game, nil)
 }
 
 // NextTrick 次のトリックへ進む
 func (hi *HeartsInteractor) NextTrick() string {
-	hi.h.NextTrick()
+	hi.Game.NextTrick()
 	hi.runCpuTurns()
-	return hi.hp.Output(hi.h, nil)
+	return hi.hp.Output(hi.Game, nil)
 }
 
 // NextRound ラウンドをスコアリングして次のラウンドへ進む
 func (hi *HeartsInteractor) NextRound() string {
-	hi.h.ScoreRound()
-	if out, blocked := guardGameEnd(hi.h, hi.hp); blocked {
+	hi.Game.ScoreRound()
+	if out, blocked := guardGameEnd(hi.Game, hi.hp); blocked {
 		return out
 	}
-	hi.h.NextRound()
-	return hi.hp.Output(hi.h, nil)
+	hi.Game.NextRound()
+	return hi.hp.Output(hi.Game, nil)
 }
 
 // GetConfig 現在の設定を取得
 func (hi *HeartsInteractor) GetConfig() domain.HeartsConfig {
-	return hi.h.GetConfig()
+	return hi.Game.GetConfig()
 }
 
 // Hint ヒント取得
 func (hi *HeartsInteractor) Hint() string {
-	return hi.hp.HintOutput(hi.h)
+	return hi.hp.HintOutput(hi.Game)
 }
 
 // ActionLog 棋譜を出力する
 func (hi *HeartsInteractor) ActionLog() string {
-	return hi.hp.ActionLogOutput(hi.h)
+	return hi.hp.ActionLogOutput(hi.Game)
 }
 
 // runCpuTurns ゲームが終わるか人間の手番またはトリック/ラウンド終了になるまでCPUターンを実行
 func (hi *HeartsInteractor) runCpuTurns() {
-	runCpuTurnsLoop(hi.h, trickPhases[domain.HeartsPhase]{
+	runCpuTurnsLoop(hi.Game, trickPhases[domain.HeartsPhase]{
 		play:     domain.HeartsPhasePlay,
 		trickEnd: domain.HeartsPhaseTrickEnd,
 		roundEnd: domain.HeartsPhaseRoundEnd,
@@ -126,16 +124,9 @@ func (hi *HeartsInteractor) runCpuTurns() {
 	})
 }
 
-// Snapshot serialises the game state to JSON for KV persistence.
-func (hi *HeartsInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(hi.h)
-}
-
 // RestoreHeartsInteractor deserialises JSON into a HeartsInteractor.
 func RestoreHeartsInteractor(data []byte, hp presenter.HeartsPresenter) (*HeartsInteractor, error) {
-	h, err := restoreGame[domain.Hearts](data)
-	if err != nil {
-		return nil, err
-	}
-	return &HeartsInteractor{h: h, hp: hp}, nil
+	return restoreAndBuild[domain.Hearts](data, func(g *domain.Hearts) *HeartsInteractor {
+		return &HeartsInteractor{GameBase: GameBase[interfaces.HeartsGame]{Game: g}, hp: hp}
+	})
 }

--- a/internal/usecase/HeartsInteractor.go
+++ b/internal/usecase/HeartsInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // HeartsInteractorIF ハーツインタラクターインタフェース
 type HeartsInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// ResetWithConfig 設定を変更してゲーム初期化

--- a/internal/usecase/HoldemInteractor.go
+++ b/internal/usecase/HoldemInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // HoldemInteractorIF テキサスホールデムインタラクターインタフェース
 type HoldemInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	TournamentInteractorIF
 	// Reset ゲーム初期化
 	Reset() string

--- a/internal/usecase/HoldemInteractor.go
+++ b/internal/usecase/HoldemInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -25,7 +23,7 @@ type HoldemInteractorIF interface {
 
 // HoldemInteractor テキサスホールデムインタラクタークラス
 type HoldemInteractor struct {
-	h  interfaces.HoldemGame
+	GameBase[interfaces.HoldemGame]
 	hp presenter.HoldemPresenter
 	tournamentActions[interfaces.HoldemGame]
 }
@@ -34,7 +32,7 @@ type HoldemInteractor struct {
 func NewHoldemInteractor(h interfaces.HoldemGame, hp presenter.HoldemPresenter) *HoldemInteractor {
 	mustNotNil("HoldemInteractor", map[string]any{"h": h, "hp": hp})
 	return &HoldemInteractor{
-		h:                 h,
+		GameBase:          GameBase[interfaces.HoldemGame]{Game: h},
 		hp:                hp,
 		tournamentActions: newTournamentActions[interfaces.HoldemGame](h, hp),
 	}
@@ -42,51 +40,44 @@ func NewHoldemInteractor(h interfaces.HoldemGame, hp presenter.HoldemPresenter) 
 
 // Reset ゲーム初期化
 func (hi *HoldemInteractor) Reset() string {
-	return execAndPresent(hi.h, hi.hp, hi.h.Reset)
+	return execAndPresent(hi.Game, hi.hp, hi.Game.Reset)
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (hi *HoldemInteractor) ResetWithConfig(cfg domain.HoldemConfig, profileData []byte) string {
 	if err := cfg.Validate(); err != nil {
-		return hi.hp.Output(hi.h, err)
+		return hi.hp.Output(hi.Game, err)
 	}
 	// テーブルサイズ変更時はプレイヤーを再構築
-	if cfg.TableSize > 0 && cfg.TableSize != hi.h.GetPlayerCnt() {
-		hi.h.Resize(domain.NewPlayersForTable(cfg.TableSize))
+	if cfg.TableSize > 0 && cfg.TableSize != hi.Game.GetPlayerCnt() {
+		hi.Game.Resize(domain.NewPlayersForTable(cfg.TableSize))
 	}
-	hi.h.SetConfig(cfg)
-	err := hi.h.Reset()
+	hi.Game.SetConfig(cfg)
+	err := hi.Game.Reset()
 	if len(profileData) > 0 {
-		_ = hi.h.ImportProfile(profileData)
+		_ = hi.Game.ImportProfile(profileData)
 	}
-	return hi.hp.Output(hi.h, err)
+	return hi.hp.Output(hi.Game, err)
 }
 
 // Action プレイヤーアクション実行
 func (hi *HoldemInteractor) Action(action int, amount int, humanPlayMs int) string {
-	return execAndPresent(hi.h, hi.hp, func() error { return hi.h.PlayerAction(action, amount, humanPlayMs) })
+	return execAndPresent(hi.Game, hi.hp, func() error { return hi.Game.PlayerAction(action, amount, humanPlayMs) })
 }
 
 // GetConfig 現在の設定を取得
 func (hi *HoldemInteractor) GetConfig() domain.HoldemConfig {
-	return hi.h.GetConfig()
+	return hi.Game.GetConfig()
 }
 
 // ActionLog 棋譜を出力する
 func (hi *HoldemInteractor) ActionLog() string {
-	return hi.hp.ActionLogOutput(hi.h)
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (hi *HoldemInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(hi.h)
+	return hi.hp.ActionLogOutput(hi.Game)
 }
 
 // RestoreHoldemInteractor deserialises JSON into a HoldemInteractor.
 func RestoreHoldemInteractor(data []byte, hp presenter.HoldemPresenter) (*HoldemInteractor, error) {
-	h, err := restoreGame[domain.Holdem](data)
-	if err != nil {
-		return nil, err
-	}
-	return &HoldemInteractor{h: h, hp: hp, tournamentActions: newTournamentActions[interfaces.HoldemGame](h, hp)}, nil
+	return restoreAndBuild[domain.Holdem](data, func(g *domain.Holdem) *HoldemInteractor {
+		return &HoldemInteractor{GameBase: GameBase[interfaces.HoldemGame]{Game: g}, hp: hp}
+	})
 }

--- a/internal/usecase/IndianPokerInteractor.go
+++ b/internal/usecase/IndianPokerInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -24,52 +22,47 @@ type IndianPokerInteractorIF interface {
 
 // IndianPokerInteractor インディアンポーカーインタラクタークラス
 type IndianPokerInteractor struct {
-	ip  interfaces.IndianPokerGame
+	GameBase[interfaces.IndianPokerGame]
 	ipp presenter.IndianPokerPresenter
 }
 
 // NewIndianPokerInteractor コンストラクタ
 func NewIndianPokerInteractor(ip interfaces.IndianPokerGame, ipp presenter.IndianPokerPresenter) *IndianPokerInteractor {
 	mustNotNil("IndianPokerInteractor", map[string]any{"ip": ip, "ipp": ipp})
-	return &IndianPokerInteractor{ip: ip, ipp: ipp}
+	return &IndianPokerInteractor{GameBase: GameBase[interfaces.IndianPokerGame]{Game: ip}, ipp: ipp}
 }
 
 // Reset ゲーム初期化
 func (ipi *IndianPokerInteractor) Reset() string {
-	return execAndPresent(ipi.ip, ipi.ipp, ipi.ip.Reset)
+	return execAndPresent(ipi.Game, ipi.ipp, ipi.Game.Reset)
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (ipi *IndianPokerInteractor) ResetWithConfig(cfg domain.IndianPokerConfig, profileData []byte) string {
 	if err := cfg.Validate(); err != nil {
-		return ipi.ipp.Output(ipi.ip, err)
+		return ipi.ipp.Output(ipi.Game, err)
 	}
-	ipi.ip.SetConfig(cfg)
-	err := ipi.ip.Reset()
+	ipi.Game.SetConfig(cfg)
+	err := ipi.Game.Reset()
 	if len(profileData) > 0 {
-		_ = ipi.ip.ImportProfile(profileData)
+		_ = ipi.Game.ImportProfile(profileData)
 	}
-	return ipi.ipp.Output(ipi.ip, err)
+	return ipi.ipp.Output(ipi.Game, err)
 }
 
 // Action プレイヤーアクション実行
 func (ipi *IndianPokerInteractor) Action(action int, amount int, humanPlayMs int) string {
-	return execAndPresent(ipi.ip, ipi.ipp, func() error { return ipi.ip.PlayerAction(action, amount, humanPlayMs) })
+	return execAndPresent(ipi.Game, ipi.ipp, func() error { return ipi.Game.PlayerAction(action, amount, humanPlayMs) })
 }
 
 // GetConfig 現在の設定を取得
 func (ipi *IndianPokerInteractor) GetConfig() domain.IndianPokerConfig {
-	return ipi.ip.GetConfig()
+	return ipi.Game.GetConfig()
 }
 
 // ActionLog 棋譜を出力する
 func (ipi *IndianPokerInteractor) ActionLog() string {
-	return ipi.ipp.ActionLogOutput(ipi.ip)
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (ipi *IndianPokerInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(ipi.ip)
+	return ipi.ipp.ActionLogOutput(ipi.Game)
 }
 
 // RestoreIndianPokerInteractor deserialises JSON into an IndianPokerInteractor.
@@ -78,5 +71,5 @@ func RestoreIndianPokerInteractor(data []byte, ipp presenter.IndianPokerPresente
 	if err != nil {
 		return nil, err
 	}
-	return &IndianPokerInteractor{ip: ip, ipp: ipp}, nil
+	return &IndianPokerInteractor{GameBase: GameBase[interfaces.IndianPokerGame]{Game: ip}, ipp: ipp}, nil
 }

--- a/internal/usecase/IndianPokerInteractor.go
+++ b/internal/usecase/IndianPokerInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // IndianPokerInteractorIF インディアンポーカーインタラクターインタフェース
 type IndianPokerInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// ResetWithConfig 設定を変更してゲーム初期化 (profileData: JSONプロファイル、nilなら無視)

--- a/internal/usecase/KlondikeInteractor.go
+++ b/internal/usecase/KlondikeInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -40,91 +38,84 @@ type KlondikeInteractorIF interface {
 
 // KlondikeInteractor クロンダイクインタラクタークラス
 type KlondikeInteractor struct {
-	k  interfaces.KlondikeGame
+	GameBase[interfaces.KlondikeGame]
 	kp presenter.KlondikePresenter
 }
 
 // NewKlondikeInteractor コンストラクタ
 func NewKlondikeInteractor(k interfaces.KlondikeGame, kp presenter.KlondikePresenter) *KlondikeInteractor {
 	mustNotNil("KlondikeInteractor", map[string]any{"k": k, "kp": kp})
-	return &KlondikeInteractor{k: k, kp: kp}
+	return &KlondikeInteractor{GameBase: GameBase[interfaces.KlondikeGame]{Game: k}, kp: kp}
 }
 
 // Reset ゲーム初期化
 func (ki *KlondikeInteractor) Reset() string {
-	return runAndPresent(ki.k, ki.kp, ki.k.Reset)
+	return runAndPresent(ki.Game, ki.kp, ki.Game.Reset)
 }
 
 // ResetWithConfig 設定付きリセット
 func (ki *KlondikeInteractor) ResetWithConfig(cfg domain.KlondikeConfig) string {
-	return runAndPresent(ki.k, ki.kp, func() { ki.k.ResetWithConfig(cfg) })
+	return runAndPresent(ki.Game, ki.kp, func() { ki.Game.ResetWithConfig(cfg) })
 }
 
 // Draw ストックからウェイストにカードを引く
 func (ki *KlondikeInteractor) Draw() string {
-	return execAndPresent(ki.k, ki.kp, ki.k.Draw)
+	return execAndPresent(ki.Game, ki.kp, ki.Game.Draw)
 }
 
 // MoveWasteToTableau ウェイストからタブローにカードを移動
 func (ki *KlondikeInteractor) MoveWasteToTableau(col int) string {
-	return execAndPresent(ki.k, ki.kp, func() error { return ki.k.MoveWasteToTableau(col) })
+	return execAndPresent(ki.Game, ki.kp, func() error { return ki.Game.MoveWasteToTableau(col) })
 }
 
 // MoveWasteToFoundation ウェイストからファンデーションにカードを移動
 func (ki *KlondikeInteractor) MoveWasteToFoundation() string {
-	return execAndPresent(ki.k, ki.kp, ki.k.MoveWasteToFoundation)
+	return execAndPresent(ki.Game, ki.kp, ki.Game.MoveWasteToFoundation)
 }
 
 // MoveTableauToTableau タブローからタブローにカードを移動
 func (ki *KlondikeInteractor) MoveTableauToTableau(fromCol, cardIndex, toCol int) string {
-	return execAndPresent(ki.k, ki.kp, func() error { return ki.k.MoveTableauToTableau(fromCol, cardIndex, toCol) })
+	return execAndPresent(ki.Game, ki.kp, func() error { return ki.Game.MoveTableauToTableau(fromCol, cardIndex, toCol) })
 }
 
 // MoveTableauToFoundation タブローからファンデーションにカードを移動
 func (ki *KlondikeInteractor) MoveTableauToFoundation(col int) string {
-	return execAndPresent(ki.k, ki.kp, func() error { return ki.k.MoveTableauToFoundation(col) })
+	return execAndPresent(ki.Game, ki.kp, func() error { return ki.Game.MoveTableauToFoundation(col) })
 }
 
 // GiveUp ギブアップ
 func (ki *KlondikeInteractor) GiveUp() string {
-	return runAndPresent(ki.k, ki.kp, ki.k.GiveUp)
+	return runAndPresent(ki.Game, ki.kp, ki.Game.GiveUp)
 }
 
 // Hint ヒント取得
 func (ki *KlondikeInteractor) Hint() string {
-	return ki.kp.HintOutput(ki.k)
+	return ki.kp.HintOutput(ki.Game)
 }
 
 // AutoComplete オートコンプリート
 func (ki *KlondikeInteractor) AutoComplete() string {
-	return execAndPresent(ki.k, ki.kp, ki.k.AutoComplete)
+	return execAndPresent(ki.Game, ki.kp, ki.Game.AutoComplete)
 }
 
 // ActionLog 棋譜を出力する
 func (ki *KlondikeInteractor) ActionLog() string {
-	return ki.kp.ActionLogOutput(ki.k)
+	return ki.kp.ActionLogOutput(ki.Game)
 }
 
 // Undo アンドゥ
 func (ki *KlondikeInteractor) Undo() string {
-	return execAndPresent(ki.k, ki.kp, ki.k.Undo)
+	return execAndPresent(ki.Game, ki.kp, ki.Game.Undo)
 }
 
 // UndoN n回連続アンドゥ
 func (ki *KlondikeInteractor) UndoN(n int) string {
-	return execAndPresent(ki.k, ki.kp, func() error { return ki.k.UndoN(n) })
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (ki *KlondikeInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(ki.k)
+	return execAndPresent(ki.Game, ki.kp, func() error { return ki.Game.UndoN(n) })
 }
 
 // RestoreKlondikeInteractor deserialises JSON into a KlondikeInteractor.
 func RestoreKlondikeInteractor(data []byte, kp presenter.KlondikePresenter) (*KlondikeInteractor, error) {
-	kl, err := restoreGame[domain.Klondike](data)
-	if err != nil {
-		return nil, err
-	}
-	return &KlondikeInteractor{k: kl, kp: kp}, nil
+	return restoreAndBuild[domain.Klondike](data, func(g *domain.Klondike) *KlondikeInteractor {
+		return &KlondikeInteractor{GameBase: GameBase[interfaces.KlondikeGame]{Game: g}, kp: kp}
+	})
 }

--- a/internal/usecase/KlondikeInteractor.go
+++ b/internal/usecase/KlondikeInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // KlondikeInteractorIF クロンダイクインタラクターインタフェース
 type KlondikeInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// ResetWithConfig 設定付きリセット

--- a/internal/usecase/MemoryInteractor.go
+++ b/internal/usecase/MemoryInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -26,83 +24,76 @@ type MemoryInteractorIF interface {
 
 // MemoryInteractor 神経衰弱インタラクタークラス
 type MemoryInteractor struct {
-	m  interfaces.MemoryGame
+	GameBase[interfaces.MemoryGame]
 	mp presenter.MemoryPresenter
 }
 
 // NewMemoryInteractor コンストラクタ
 func NewMemoryInteractor(m interfaces.MemoryGame, mp presenter.MemoryPresenter) *MemoryInteractor {
 	mustNotNil("MemoryInteractor", map[string]any{"m": m, "mp": mp})
-	return &MemoryInteractor{m: m, mp: mp}
+	return &MemoryInteractor{GameBase: GameBase[interfaces.MemoryGame]{Game: m}, mp: mp}
 }
 
 // Reset ゲーム初期化
 func (mi *MemoryInteractor) Reset() string {
-	return runAndPresent(mi.m, mi.mp, mi.m.Reset)
+	return runAndPresent(mi.Game, mi.mp, mi.Game.Reset)
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (mi *MemoryInteractor) ResetWithConfig(cfg domain.MemoryConfig) string {
-	mi.m.SetConfig(cfg)
+	mi.Game.SetConfig(cfg)
 	return mi.Reset()
 }
 
 // Flip カードをめくる
 func (mi *MemoryInteractor) Flip(pos int) string {
-	if out, blocked := guardNotPlayable(mi.m, mi.mp); blocked {
+	if out, blocked := guardNotPlayable(mi.Game, mi.mp); blocked {
 		return out
 	}
-	err := mi.m.PlayerFlip(pos)
+	err := mi.Game.PlayerFlip(pos)
 	if err != nil {
-		return mi.mp.Output(mi.m, err)
+		return mi.mp.Output(mi.Game, err)
 	}
-	return mi.mp.Output(mi.m, nil)
+	return mi.mp.Output(mi.Game, nil)
 }
 
 // Next 結果を解決し、CPU ターンを実行する
 func (mi *MemoryInteractor) Next() string {
-	if out, blocked := guardGameEnd(mi.m, mi.mp); blocked {
+	if out, blocked := guardGameEnd(mi.Game, mi.mp); blocked {
 		return out
 	}
-	mi.m.ResolveFlip()
+	mi.Game.ResolveFlip()
 	mi.runCpuTurns()
-	return mi.mp.Output(mi.m, nil)
+	return mi.mp.Output(mi.Game, nil)
 }
 
 // GetConfig 現在の設定を取得
 func (mi *MemoryInteractor) GetConfig() domain.MemoryConfig {
-	return mi.m.GetConfig()
+	return mi.Game.GetConfig()
 }
 
 // ActionLog 棋譜を出力する
 func (mi *MemoryInteractor) ActionLog() string {
-	return mi.mp.ActionLogOutput(mi.m)
+	return mi.mp.ActionLogOutput(mi.Game)
 }
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 func (mi *MemoryInteractor) runCpuTurns() {
-	for !mi.m.GetGameEndFlag() {
-		if mi.m.GetPhase() != domain.MemoryPhaseFlip1 {
+	for !mi.Game.GetGameEndFlag() {
+		if mi.Game.GetPhase() != domain.MemoryPhaseFlip1 {
 			break
 		}
-		if mi.m.IsHumanTurn() {
+		if mi.Game.IsHumanTurn() {
 			break
 		}
-		mi.m.CpuFlip()
-		mi.m.ResolveFlip()
+		mi.Game.CpuFlip()
+		mi.Game.ResolveFlip()
 	}
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (mi *MemoryInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(mi.m)
 }
 
 // RestoreMemoryInteractor deserialises JSON into a MemoryInteractor.
 func RestoreMemoryInteractor(data []byte, mp presenter.MemoryPresenter) (*MemoryInteractor, error) {
-	mem, err := restoreGame[domain.Memory](data)
-	if err != nil {
-		return nil, err
-	}
-	return &MemoryInteractor{m: mem, mp: mp}, nil
+	return restoreAndBuild[domain.Memory](data, func(g *domain.Memory) *MemoryInteractor {
+		return &MemoryInteractor{GameBase: GameBase[interfaces.MemoryGame]{Game: g}, mp: mp}
+	})
 }

--- a/internal/usecase/MemoryInteractor.go
+++ b/internal/usecase/MemoryInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // MemoryInteractorIF 神経衰弱インタラクターインタフェース
 type MemoryInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// ResetWithConfig 設定を変更してゲーム初期化

--- a/internal/usecase/NapoleonInteractor.go
+++ b/internal/usecase/NapoleonInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // NapoleonInteractorIF ナポレオンインタラクターインタフェース
 type NapoleonInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// ResetWithConfig 設定を変更してゲーム初期化

--- a/internal/usecase/NapoleonInteractor.go
+++ b/internal/usecase/NapoleonInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -36,152 +34,152 @@ type NapoleonInteractorIF interface {
 
 // NapoleonInteractor ナポレオンインタラクタークラス
 type NapoleonInteractor struct {
-	n  interfaces.NapoleonGame
+	GameBase[interfaces.NapoleonGame]
 	np presenter.NapoleonPresenter
 }
 
 // NewNapoleonInteractor コンストラクタ
 func NewNapoleonInteractor(n interfaces.NapoleonGame, np presenter.NapoleonPresenter) *NapoleonInteractor {
 	mustNotNil("NapoleonInteractor", map[string]any{"n": n, "np": np})
-	return &NapoleonInteractor{n: n, np: np}
+	return &NapoleonInteractor{GameBase: GameBase[interfaces.NapoleonGame]{Game: n}, np: np}
 }
 
 // Reset ゲーム初期化
 func (ni *NapoleonInteractor) Reset() string {
-	ni.n.Reset()
+	ni.Game.Reset()
 	ni.runCpuBids()
 	ni.runCpuDeclareAndExchange()
-	if ni.n.GetPhase() == domain.NapoleonPhasePlay {
+	if ni.Game.GetPhase() == domain.NapoleonPhasePlay {
 		ni.runCpuTurns()
 	}
-	return ni.np.Output(ni.n, nil)
+	return ni.np.Output(ni.Game, nil)
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (ni *NapoleonInteractor) ResetWithConfig(cfg domain.NapoleonConfig) string {
-	return resetWithValidatedConfig(ni.n, ni.np, cfg, ni.n.SetConfig, ni.Reset)
+	return resetWithValidatedConfig(ni.Game, ni.np, cfg, ni.Game.SetConfig, ni.Reset)
 }
 
 // Bid ビッドを宣言
 func (ni *NapoleonInteractor) Bid(bid int) string {
-	if out, blocked := guardGameEnd(ni.n, ni.np); blocked {
+	if out, blocked := guardGameEnd(ni.Game, ni.np); blocked {
 		return out
 	}
-	err := ni.n.PlayerBid(bid)
+	err := ni.Game.PlayerBid(bid)
 	if err != nil {
-		return ni.np.Output(ni.n, err)
+		return ni.np.Output(ni.Game, err)
 	}
 	ni.runCpuBids()
 	ni.runCpuDeclareAndExchange()
-	if ni.n.GetPhase() == domain.NapoleonPhasePlay {
+	if ni.Game.GetPhase() == domain.NapoleonPhasePlay {
 		ni.runCpuTurns()
 	}
-	return ni.np.Output(ni.n, nil)
+	return ni.np.Output(ni.Game, nil)
 }
 
 // DeclareTrump 切り札と副官を宣言
 func (ni *NapoleonInteractor) DeclareTrump(suit int, adjSuit int, adjVal int) string {
-	if out, blocked := guardGameEnd(ni.n, ni.np); blocked {
+	if out, blocked := guardGameEnd(ni.Game, ni.np); blocked {
 		return out
 	}
-	err := ni.n.PlayerDeclareTrump(suit, adjSuit, adjVal)
+	err := ni.Game.PlayerDeclareTrump(suit, adjSuit, adjVal)
 	if err != nil {
-		return ni.np.Output(ni.n, err)
+		return ni.np.Output(ni.Game, err)
 	}
 	// 場札交換フェーズに移行。CPU napoelonの場合は自動処理
 	ni.runCpuDeclareAndExchange()
-	if ni.n.GetPhase() == domain.NapoleonPhasePlay {
+	if ni.Game.GetPhase() == domain.NapoleonPhasePlay {
 		ni.runCpuTurns()
 	}
-	return ni.np.Output(ni.n, nil)
+	return ni.np.Output(ni.Game, nil)
 }
 
 // ExchangeKitty 場札を交換
 func (ni *NapoleonInteractor) ExchangeKitty(discardIndex int) string {
-	if out, blocked := guardGameEnd(ni.n, ni.np); blocked {
+	if out, blocked := guardGameEnd(ni.Game, ni.np); blocked {
 		return out
 	}
-	err := ni.n.PlayerExchangeKitty(discardIndex)
+	err := ni.Game.PlayerExchangeKitty(discardIndex)
 	if err != nil {
-		return ni.np.Output(ni.n, err)
+		return ni.np.Output(ni.Game, err)
 	}
-	if ni.n.GetPhase() == domain.NapoleonPhasePlay {
+	if ni.Game.GetPhase() == domain.NapoleonPhasePlay {
 		ni.runCpuTurns()
 	}
-	return ni.np.Output(ni.n, nil)
+	return ni.np.Output(ni.Game, nil)
 }
 
 // Play カードをプレイ
 func (ni *NapoleonInteractor) Play(cardIndex int) string {
-	if out, blocked := guardNotPlayable(ni.n, ni.np); blocked {
+	if out, blocked := guardNotPlayable(ni.Game, ni.np); blocked {
 		return out
 	}
-	err := ni.n.PlayerPlay(cardIndex)
+	err := ni.Game.PlayerPlay(cardIndex)
 	if err != nil {
-		return ni.np.Output(ni.n, err)
+		return ni.np.Output(ni.Game, err)
 	}
 	ni.runCpuTurns()
-	return ni.np.Output(ni.n, nil)
+	return ni.np.Output(ni.Game, nil)
 }
 
 // NextTrick 次のトリックへ進む
 func (ni *NapoleonInteractor) NextTrick() string {
-	if out, blocked := guardGameEnd(ni.n, ni.np); blocked {
+	if out, blocked := guardGameEnd(ni.Game, ni.np); blocked {
 		return out
 	}
-	ni.n.NextTrick()
+	ni.Game.NextTrick()
 	ni.runCpuTurns()
-	return ni.np.Output(ni.n, nil)
+	return ni.np.Output(ni.Game, nil)
 }
 
 // NextRound ラウンドをスコアリングして次のラウンドへ進む
 func (ni *NapoleonInteractor) NextRound() string {
-	ni.n.ScoreRound()
-	if out, blocked := guardGameEnd(ni.n, ni.np); blocked {
+	ni.Game.ScoreRound()
+	if out, blocked := guardGameEnd(ni.Game, ni.np); blocked {
 		return out
 	}
-	ni.n.NextRound()
+	ni.Game.NextRound()
 	ni.runCpuBids()
 	ni.runCpuDeclareAndExchange()
-	if ni.n.GetPhase() == domain.NapoleonPhasePlay {
+	if ni.Game.GetPhase() == domain.NapoleonPhasePlay {
 		ni.runCpuTurns()
 	}
-	return ni.np.Output(ni.n, nil)
+	return ni.np.Output(ni.Game, nil)
 }
 
 // GetConfig 現在の設定を取得
 func (ni *NapoleonInteractor) GetConfig() domain.NapoleonConfig {
-	return ni.n.GetConfig()
+	return ni.Game.GetConfig()
 }
 
 // Hint ヒント取得
 func (ni *NapoleonInteractor) Hint() string {
-	return ni.np.HintOutput(ni.n)
+	return ni.np.HintOutput(ni.Game)
 }
 
 // ActionLog 棋譜を出力する
 func (ni *NapoleonInteractor) ActionLog() string {
-	return ni.np.ActionLogOutput(ni.n)
+	return ni.np.ActionLogOutput(ni.Game)
 }
 
 // runCpuBids CPUビッドを実行
 func (ni *NapoleonInteractor) runCpuBids() {
-	runCpuBidsLoop(ni.n, domain.NapoleonPhaseBid)
+	runCpuBidsLoop(ni.Game, domain.NapoleonPhaseBid)
 }
 
 // runCpuDeclareAndExchange CPUの切り札宣言と場札交換を自動処理
 func (ni *NapoleonInteractor) runCpuDeclareAndExchange() {
-	if ni.n.GetPhase() == domain.NapoleonPhaseTrumpDeclaration && !ni.n.IsHumanDeclareTurn() {
-		ni.n.CpuDeclareTrump()
+	if ni.Game.GetPhase() == domain.NapoleonPhaseTrumpDeclaration && !ni.Game.IsHumanDeclareTurn() {
+		ni.Game.CpuDeclareTrump()
 	}
-	if ni.n.GetPhase() == domain.NapoleonPhaseKittyExchange && !ni.n.IsHumanExchangeTurn() {
-		ni.n.CpuExchangeKitty()
+	if ni.Game.GetPhase() == domain.NapoleonPhaseKittyExchange && !ni.Game.IsHumanExchangeTurn() {
+		ni.Game.CpuExchangeKitty()
 	}
 }
 
 // runCpuTurns CPUターンを実行
 func (ni *NapoleonInteractor) runCpuTurns() {
-	runCpuTurnsLoop(ni.n, trickPhases[domain.NapoleonPhase]{
+	runCpuTurnsLoop(ni.Game, trickPhases[domain.NapoleonPhase]{
 		play:     domain.NapoleonPhasePlay,
 		trickEnd: domain.NapoleonPhaseTrickEnd,
 		roundEnd: domain.NapoleonPhaseRoundEnd,
@@ -189,16 +187,9 @@ func (ni *NapoleonInteractor) runCpuTurns() {
 	})
 }
 
-// Snapshot serialises the game state to JSON for KV persistence.
-func (ni *NapoleonInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(ni.n)
-}
-
 // RestoreNapoleonInteractor deserialises JSON into a NapoleonInteractor.
 func RestoreNapoleonInteractor(data []byte, np presenter.NapoleonPresenter) (*NapoleonInteractor, error) {
-	n, err := restoreGame[domain.Napoleon](data)
-	if err != nil {
-		return nil, err
-	}
-	return &NapoleonInteractor{n: n, np: np}, nil
+	return restoreAndBuild[domain.Napoleon](data, func(g *domain.Napoleon) *NapoleonInteractor {
+		return &NapoleonInteractor{GameBase: GameBase[interfaces.NapoleonGame]{Game: g}, np: np}
+	})
 }

--- a/internal/usecase/OhHellInteractor.go
+++ b/internal/usecase/OhHellInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // OhHellInteractorIF オー・ヘルインタラクターインタフェース
 type OhHellInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// ResetWithConfig 設定を変更してゲーム初期化

--- a/internal/usecase/OhHellInteractor.go
+++ b/internal/usecase/OhHellInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -32,118 +30,113 @@ type OhHellInteractorIF interface {
 
 // OhHellInteractor オー・ヘルインタラクタークラス
 type OhHellInteractor struct {
-	o  interfaces.OhHellGame
+	GameBase[interfaces.OhHellGame]
 	op presenter.OhHellPresenter
 }
 
 // NewOhHellInteractor コンストラクタ
 func NewOhHellInteractor(o interfaces.OhHellGame, op presenter.OhHellPresenter) *OhHellInteractor {
 	mustNotNil("OhHellInteractor", map[string]any{"o": o, "op": op})
-	return &OhHellInteractor{o: o, op: op}
+	return &OhHellInteractor{GameBase: GameBase[interfaces.OhHellGame]{Game: o}, op: op}
 }
 
 // Reset ゲーム初期化
 func (oi *OhHellInteractor) Reset() string {
-	oi.o.Reset()
+	oi.Game.Reset()
 	oi.runCpuBids()
-	if oi.o.GetPhase() == domain.OhHellPhasePlay {
+	if oi.Game.GetPhase() == domain.OhHellPhasePlay {
 		oi.runCpuTurns()
 	}
-	return oi.op.Output(oi.o, nil)
+	return oi.op.Output(oi.Game, nil)
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (oi *OhHellInteractor) ResetWithConfig(cfg domain.OhHellConfig) string {
-	return resetWithValidatedConfig(oi.o, oi.op, cfg, oi.o.SetConfig, oi.Reset)
+	return resetWithValidatedConfig(oi.Game, oi.op, cfg, oi.Game.SetConfig, oi.Reset)
 }
 
 // Bid ビッドを宣言
 func (oi *OhHellInteractor) Bid(bid int) string {
-	if out, blocked := guardGameEnd(oi.o, oi.op); blocked {
+	if out, blocked := guardGameEnd(oi.Game, oi.op); blocked {
 		return out
 	}
-	err := oi.o.PlayerBid(bid)
+	err := oi.Game.PlayerBid(bid)
 	if err != nil {
-		return oi.op.Output(oi.o, err)
+		return oi.op.Output(oi.Game, err)
 	}
 	oi.runCpuBids()
-	if oi.o.GetPhase() == domain.OhHellPhasePlay {
+	if oi.Game.GetPhase() == domain.OhHellPhasePlay {
 		oi.runCpuTurns()
 	}
-	return oi.op.Output(oi.o, nil)
+	return oi.op.Output(oi.Game, nil)
 }
 
 // Play カードをプレイ
 func (oi *OhHellInteractor) Play(cardIndex int) string {
-	if out, blocked := guardNotPlayable(oi.o, oi.op); blocked {
+	if out, blocked := guardNotPlayable(oi.Game, oi.op); blocked {
 		return out
 	}
-	err := oi.o.PlayerPlay(cardIndex)
+	err := oi.Game.PlayerPlay(cardIndex)
 	if err != nil {
-		return oi.op.Output(oi.o, err)
+		return oi.op.Output(oi.Game, err)
 	}
 	// 人間が最後のカードを出してトリック完了した場合、即座に解決
-	if oi.o.GetPhase() == domain.OhHellPhaseTrickEnd {
-		oi.o.ResolveTrick()
+	if oi.Game.GetPhase() == domain.OhHellPhaseTrickEnd {
+		oi.Game.ResolveTrick()
 	}
 	oi.runCpuTurns()
-	return oi.op.Output(oi.o, nil)
+	return oi.op.Output(oi.Game, nil)
 }
 
 // NextTrick 次のトリックへ進む
 func (oi *OhHellInteractor) NextTrick() string {
-	oi.o.NextTrick()
+	oi.Game.NextTrick()
 	oi.runCpuTurns()
-	return oi.op.Output(oi.o, nil)
+	return oi.op.Output(oi.Game, nil)
 }
 
 // NextRound ラウンドをスコアリングして次のラウンドへ進む
 func (oi *OhHellInteractor) NextRound() string {
-	oi.o.ScoreRound()
-	if out, blocked := guardGameEnd(oi.o, oi.op); blocked {
+	oi.Game.ScoreRound()
+	if out, blocked := guardGameEnd(oi.Game, oi.op); blocked {
 		return out
 	}
-	oi.o.NextRound()
+	oi.Game.NextRound()
 	oi.runCpuBids()
-	if oi.o.GetPhase() == domain.OhHellPhasePlay {
+	if oi.Game.GetPhase() == domain.OhHellPhasePlay {
 		oi.runCpuTurns()
 	}
-	return oi.op.Output(oi.o, nil)
+	return oi.op.Output(oi.Game, nil)
 }
 
 // GetConfig 現在の設定を取得
 func (oi *OhHellInteractor) GetConfig() domain.OhHellConfig {
-	return oi.o.GetConfig()
+	return oi.Game.GetConfig()
 }
 
 // Hint ヒント取得
 func (oi *OhHellInteractor) Hint() string {
-	return oi.op.HintOutput(oi.o)
+	return oi.op.HintOutput(oi.Game)
 }
 
 // ActionLog 棋譜を出力する
 func (oi *OhHellInteractor) ActionLog() string {
-	return oi.op.ActionLogOutput(oi.o)
+	return oi.op.ActionLogOutput(oi.Game)
 }
 
 // runCpuBids ゲームが終わるかヒューマンのビッド番またはビッドフェーズが終了するまでCPUビッドを実行
 func (oi *OhHellInteractor) runCpuBids() {
-	runCpuBidsLoop(oi.o, domain.OhHellPhaseBid)
+	runCpuBidsLoop(oi.Game, domain.OhHellPhaseBid)
 }
 
 // runCpuTurns ゲームが終わるか人間の手番またはトリック/ラウンド終了になるまでCPUターンを実行
 func (oi *OhHellInteractor) runCpuTurns() {
-	runCpuTurnsLoop(oi.o, trickPhases[domain.OhHellPhase]{
+	runCpuTurnsLoop(oi.Game, trickPhases[domain.OhHellPhase]{
 		play:     domain.OhHellPhasePlay,
 		trickEnd: domain.OhHellPhaseTrickEnd,
 		roundEnd: domain.OhHellPhaseRoundEnd,
 		gameEnd:  domain.OhHellPhaseGameEnd,
 	})
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (oi *OhHellInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(oi.o)
 }
 
 // RestoreOhHellInteractor deserialises JSON into an OhHellInteractor.
@@ -152,5 +145,5 @@ func RestoreOhHellInteractor(data []byte, op presenter.OhHellPresenter) (*OhHell
 	if err != nil {
 		return nil, err
 	}
-	return &OhHellInteractor{o: o, op: op}, nil
+	return &OhHellInteractor{GameBase: GameBase[interfaces.OhHellGame]{Game: o}, op: op}, nil
 }

--- a/internal/usecase/OldMaidInteractor.go
+++ b/internal/usecase/OldMaidInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -28,7 +26,7 @@ type OldMaidInteractorIF interface {
 
 // OldMaidInteractor ババ抜きインタラクタークラス
 type OldMaidInteractor struct {
-	om  interfaces.OldMaidGame
+	GameBase[interfaces.OldMaidGame]
 	omp presenter.OldMaidPresenter
 }
 
@@ -36,75 +34,70 @@ type OldMaidInteractor struct {
 func NewOldMaidInteractor(om interfaces.OldMaidGame, omp presenter.OldMaidPresenter) *OldMaidInteractor {
 	mustNotNil("OldMaidInteractor", map[string]any{"om": om, "omp": omp})
 	return &OldMaidInteractor{
-		om:  om,
-		omp: omp,
+		GameBase: GameBase[interfaces.OldMaidGame]{Game: om},
+		omp:      omp,
 	}
 }
 
 // GetConfig 現在の設定を返す
 func (oi *OldMaidInteractor) GetConfig() domain.OldMaidConfig {
-	return oi.om.GetConfig()
+	return oi.Game.GetConfig()
 }
 
 // Reset ゲーム初期化
 func (oi *OldMaidInteractor) Reset(config domain.OldMaidConfig, profileData []byte) string {
 	if err := config.Validate(); err != nil {
-		return oi.omp.Output(oi.om, err)
+		return oi.omp.Output(oi.Game, err)
 	}
-	oi.om.SetConfig(config)
-	oi.om.Reset()
+	oi.Game.SetConfig(config)
+	oi.Game.Reset()
 	if len(profileData) > 0 {
-		_ = oi.om.ImportProfile(profileData)
+		_ = oi.Game.ImportProfile(profileData)
 	}
 	oi.runCpuTurns()
-	oi.om.ArrangeTargetForHumanDraw()
-	return oi.omp.Output(oi.om, nil)
+	oi.Game.ArrangeTargetForHumanDraw()
+	return oi.omp.Output(oi.Game, nil)
 }
 
 // Draw 人間プレイヤーがカードを引く
 // cardIdx: 引くカードのインデックス。-1 の場合はランダム選択。
 func (oi *OldMaidInteractor) Draw(cardIdx int) string {
-	if out, blocked := guardNotPlayable(oi.om, oi.omp); blocked {
+	if out, blocked := guardNotPlayable(oi.Game, oi.omp); blocked {
 		return out
 	}
-	err := oi.om.PlayerDraw(cardIdx)
-	if err == nil && !oi.om.GetGameEndFlag() {
+	err := oi.Game.PlayerDraw(cardIdx)
+	if err == nil && !oi.Game.GetGameEndFlag() {
 		oi.runCpuTurns()
-		oi.om.ArrangeTargetForHumanDraw()
+		oi.Game.ArrangeTargetForHumanDraw()
 	}
-	return oi.omp.Output(oi.om, err)
+	return oi.omp.Output(oi.Game, err)
 }
 
 // Shuffle 人間プレイヤーの手札をシャッフルする
 func (oi *OldMaidInteractor) Shuffle() string {
-	return execAndPresent(oi.om, oi.omp, oi.om.ShuffleHumanHand)
+	return execAndPresent(oi.Game, oi.omp, oi.Game.ShuffleHumanHand)
 }
 
 // Reorder 人間プレイヤーの手札を並び替える
 func (oi *OldMaidInteractor) Reorder(indices []int) string {
-	return execAndPresent(oi.om, oi.omp, func() error { return oi.om.ReorderHumanHand(indices) })
+	return execAndPresent(oi.Game, oi.omp, func() error { return oi.Game.ReorderHumanHand(indices) })
 }
 
 // ResetProfile メタAIプロファイルをリセット
 func (oi *OldMaidInteractor) ResetProfile() string {
-	return runAndPresent(oi.om, oi.omp, oi.om.ResetProfile)
+	return runAndPresent(oi.Game, oi.omp, oi.Game.ResetProfile)
 }
 
 // ActionLog 棋譜を出力する
 func (oi *OldMaidInteractor) ActionLog() string {
-	return oi.omp.ActionLogOutput(oi.om)
+	return oi.omp.ActionLogOutput(oi.Game)
 }
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 func (oi *OldMaidInteractor) runCpuTurns() {
-	for !oi.om.GetGameEndFlag() && !oi.om.IsHumanTurn() {
-		_ = oi.om.CpuDraw()
+	for !oi.Game.GetGameEndFlag() && !oi.Game.IsHumanTurn() {
+		_ = oi.Game.CpuDraw()
 	}
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (oi *OldMaidInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(oi.om)
 }
 
 // RestoreOldMaidInteractor deserialises JSON into an OldMaidInteractor.
@@ -113,5 +106,5 @@ func RestoreOldMaidInteractor(data []byte, omp presenter.OldMaidPresenter) (*Old
 	if err != nil {
 		return nil, err
 	}
-	return &OldMaidInteractor{om: om, omp: omp}, nil
+	return &OldMaidInteractor{GameBase: GameBase[interfaces.OldMaidGame]{Game: om}, omp: omp}, nil
 }

--- a/internal/usecase/OldMaidInteractor.go
+++ b/internal/usecase/OldMaidInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // OldMaidInteractorIF ババ抜きインタラクターインタフェース
 type OldMaidInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化 (profileData: JSONプロファイル、nilなら無視)
 	Reset(config domain.OldMaidConfig, profileData []byte) string
 	// GetConfig 現在の設定を返す

--- a/internal/usecase/OldMaidInteractor_internal_test.go
+++ b/internal/usecase/OldMaidInteractor_internal_test.go
@@ -59,11 +59,11 @@ func TestOldMaidInteractor_Draw_GameEndFlag(t *testing.T) {
 	ompMock := new(presenter.MockOldMaidPresenter)
 	ompMock.On("Output", mock.Anything, mock.Anything).Return(mockOutput)
 	oi := NewOldMaidInteractor(newInternalTestOldMaid(), ompMock)
-	oi.om = buildOldMaidEndedGame()
+	oi.Game = buildOldMaidEndedGame()
 
 	// Human draws from CPU1 (card index 0) → pair discarded → game ends.
 	oi.Draw(0)
-	assert.True(t, oi.om.GetGameEndFlag())
+	assert.True(t, oi.Game.GetGameEndFlag())
 
 	// Now call Draw with gameEndFlag == true → early return.
 	result := oi.Draw(0)
@@ -75,10 +75,10 @@ func TestOldMaidInteractor_Draw_NotHumanTurn(t *testing.T) {
 	ompMock := new(presenter.MockOldMaidPresenter)
 	ompMock.On("Output", mock.Anything, mock.Anything).Return(mockOutput)
 	oi := NewOldMaidInteractor(newInternalTestOldMaid(), ompMock)
-	oi.om = buildOldMaidCpuTurnGame()
+	oi.Game = buildOldMaidCpuTurnGame()
 
 	// currentTurn = 0, player 0 is CPU → !IsHumanTurn() is true.
-	assert.False(t, oi.om.IsHumanTurn())
+	assert.False(t, oi.Game.IsHumanTurn())
 	result := oi.Draw(0)
 	assert.Equal(t, mockOutput, result)
 }

--- a/internal/usecase/OmahaInteractor.go
+++ b/internal/usecase/OmahaInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -25,7 +23,7 @@ type OmahaInteractorIF interface {
 
 // OmahaInteractor オマハホールデムインタラクタークラス
 type OmahaInteractor struct {
-	o  interfaces.OmahaGame
+	GameBase[interfaces.OmahaGame]
 	op presenter.OmahaPresenter
 	tournamentActions[interfaces.OmahaGame]
 }
@@ -34,7 +32,7 @@ type OmahaInteractor struct {
 func NewOmahaInteractor(o interfaces.OmahaGame, op presenter.OmahaPresenter) *OmahaInteractor {
 	mustNotNil("OmahaInteractor", map[string]any{"o": o, "op": op})
 	return &OmahaInteractor{
-		o:                 o,
+		GameBase:          GameBase[interfaces.OmahaGame]{Game: o},
 		op:                op,
 		tournamentActions: newTournamentActions[interfaces.OmahaGame](o, op),
 	}
@@ -42,43 +40,38 @@ func NewOmahaInteractor(o interfaces.OmahaGame, op presenter.OmahaPresenter) *Om
 
 // Reset ゲーム初期化
 func (oi *OmahaInteractor) Reset() string {
-	return execAndPresent(oi.o, oi.op, oi.o.Reset)
+	return execAndPresent(oi.Game, oi.op, oi.Game.Reset)
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (oi *OmahaInteractor) ResetWithConfig(cfg domain.OmahaConfig, profileData []byte) string {
 	if err := cfg.Validate(); err != nil {
-		return oi.op.Output(oi.o, err)
+		return oi.op.Output(oi.Game, err)
 	}
-	if cfg.TableSize > 0 && cfg.TableSize != oi.o.GetPlayerCnt() {
-		oi.o.Resize(domain.NewOmahaPlayersForTable(cfg.TableSize))
+	if cfg.TableSize > 0 && cfg.TableSize != oi.Game.GetPlayerCnt() {
+		oi.Game.Resize(domain.NewOmahaPlayersForTable(cfg.TableSize))
 	}
-	oi.o.SetConfig(cfg)
-	err := oi.o.Reset()
+	oi.Game.SetConfig(cfg)
+	err := oi.Game.Reset()
 	if len(profileData) > 0 {
-		_ = oi.o.ImportProfile(profileData)
+		_ = oi.Game.ImportProfile(profileData)
 	}
-	return oi.op.Output(oi.o, err)
+	return oi.op.Output(oi.Game, err)
 }
 
 // Action プレイヤーアクション実行
 func (oi *OmahaInteractor) Action(action int, amount int, humanPlayMs int) string {
-	return execAndPresent(oi.o, oi.op, func() error { return oi.o.PlayerAction(action, amount, humanPlayMs) })
+	return execAndPresent(oi.Game, oi.op, func() error { return oi.Game.PlayerAction(action, amount, humanPlayMs) })
 }
 
 // GetConfig 現在の設定を取得
 func (oi *OmahaInteractor) GetConfig() domain.OmahaConfig {
-	return oi.o.GetConfig()
+	return oi.Game.GetConfig()
 }
 
 // ActionLog 棋譜を出力する
 func (oi *OmahaInteractor) ActionLog() string {
-	return oi.op.ActionLogOutput(oi.o)
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (oi *OmahaInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(oi.o)
+	return oi.op.ActionLogOutput(oi.Game)
 }
 
 // RestoreOmahaInteractor deserialises JSON into an OmahaInteractor.
@@ -87,5 +80,5 @@ func RestoreOmahaInteractor(data []byte, op presenter.OmahaPresenter) (*OmahaInt
 	if err != nil {
 		return nil, err
 	}
-	return &OmahaInteractor{o: o, op: op, tournamentActions: newTournamentActions[interfaces.OmahaGame](o, op)}, nil
+	return &OmahaInteractor{GameBase: GameBase[interfaces.OmahaGame]{Game: o}, op: op, tournamentActions: newTournamentActions[interfaces.OmahaGame](o, op)}, nil
 }

--- a/internal/usecase/OmahaInteractor.go
+++ b/internal/usecase/OmahaInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // OmahaInteractorIF オマハホールデムインタラクターインタフェース
 type OmahaInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	TournamentInteractorIF
 	// Reset ゲーム初期化
 	Reset() string

--- a/internal/usecase/PigsTailInteractor.go
+++ b/internal/usecase/PigsTailInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // PigsTailInteractorIF ぶたのしっぽインタラクターインタフェース
 type PigsTailInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset(config domain.PigsTailConfig) string
 	// GetConfig 現在の設定を返す

--- a/internal/usecase/PigsTailInteractor.go
+++ b/internal/usecase/PigsTailInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -22,7 +20,7 @@ type PigsTailInteractorIF interface {
 
 // PigsTailInteractor ぶたのしっぽインタラクタークラス
 type PigsTailInteractor struct {
-	pt  interfaces.PigsTailGame
+	GameBase[interfaces.PigsTailGame]
 	ptp presenter.PigsTailPresenter
 }
 
@@ -30,61 +28,54 @@ type PigsTailInteractor struct {
 func NewPigsTailInteractor(pt interfaces.PigsTailGame, ptp presenter.PigsTailPresenter) *PigsTailInteractor {
 	mustNotNil("PigsTailInteractor", map[string]any{"pt": pt, "ptp": ptp})
 	return &PigsTailInteractor{
-		pt:  pt,
-		ptp: ptp,
+		GameBase: GameBase[interfaces.PigsTailGame]{Game: pt},
+		ptp:      ptp,
 	}
 }
 
 // GetConfig 現在の設定を返す
 func (pi *PigsTailInteractor) GetConfig() domain.PigsTailConfig {
-	return pi.pt.GetConfig()
+	return pi.Game.GetConfig()
 }
 
 // Reset ゲーム初期化
 func (pi *PigsTailInteractor) Reset(config domain.PigsTailConfig) string {
 	if err := config.Validate(); err != nil {
-		return pi.ptp.Output(pi.pt, err)
+		return pi.ptp.Output(pi.Game, err)
 	}
-	pi.pt.SetConfig(config)
-	pi.pt.Reset()
+	pi.Game.SetConfig(config)
+	pi.Game.Reset()
 	pi.runCpuTurns()
-	return pi.ptp.Output(pi.pt, nil)
+	return pi.ptp.Output(pi.Game, nil)
 }
 
 // Action 人間プレイヤーのアクション (山札から1枚引く)
 func (pi *PigsTailInteractor) Action(actionIdx int) string {
-	if out, blocked := guardNotPlayable(pi.pt, pi.ptp); blocked {
+	if out, blocked := guardNotPlayable(pi.Game, pi.ptp); blocked {
 		return out
 	}
-	err := pi.pt.PlayerAction(actionIdx)
-	if err == nil && !pi.pt.GetGameEndFlag() {
+	err := pi.Game.PlayerAction(actionIdx)
+	if err == nil && !pi.Game.GetGameEndFlag() {
 		pi.runCpuTurns()
 	}
-	return pi.ptp.Output(pi.pt, err)
+	return pi.ptp.Output(pi.Game, err)
 }
 
 // ActionLog 棋譜を出力する
 func (pi *PigsTailInteractor) ActionLog() string {
-	return pi.ptp.ActionLogOutput(pi.pt)
+	return pi.ptp.ActionLogOutput(pi.Game)
 }
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 func (pi *PigsTailInteractor) runCpuTurns() {
-	for !pi.pt.GetGameEndFlag() && !pi.pt.IsHumanTurn() {
-		_ = pi.pt.CpuAction()
+	for !pi.Game.GetGameEndFlag() && !pi.Game.IsHumanTurn() {
+		_ = pi.Game.CpuAction()
 	}
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (pi *PigsTailInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(pi.pt)
 }
 
 // RestorePigsTailInteractor deserialises JSON into a PigsTailInteractor.
 func RestorePigsTailInteractor(data []byte, ptp presenter.PigsTailPresenter) (*PigsTailInteractor, error) {
-	pt, err := restoreGame[domain.PigsTail](data)
-	if err != nil {
-		return nil, err
-	}
-	return &PigsTailInteractor{pt: pt, ptp: ptp}, nil
+	return restoreAndBuild[domain.PigsTail](data, func(g *domain.PigsTail) *PigsTailInteractor {
+		return &PigsTailInteractor{GameBase: GameBase[interfaces.PigsTailGame]{Game: g}, ptp: ptp}
+	})
 }

--- a/internal/usecase/PineappleInteractor.go
+++ b/internal/usecase/PineappleInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // PineappleInteractorIF パイナップルポーカーインタラクターインタフェース
 type PineappleInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	TournamentInteractorIF
 	// Reset ゲーム初期化
 	Reset() string

--- a/internal/usecase/PineappleInteractor.go
+++ b/internal/usecase/PineappleInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -27,7 +25,7 @@ type PineappleInteractorIF interface {
 
 // PineappleInteractor パイナップルポーカーインタラクタークラス
 type PineappleInteractor struct {
-	p  interfaces.PineappleGame
+	GameBase[interfaces.PineappleGame]
 	pp presenter.PineapplePresenter
 	tournamentActions[interfaces.PineappleGame]
 }
@@ -36,7 +34,7 @@ type PineappleInteractor struct {
 func NewPineappleInteractor(p interfaces.PineappleGame, pp presenter.PineapplePresenter) *PineappleInteractor {
 	mustNotNil("PineappleInteractor", map[string]any{"p": p, "pp": pp})
 	return &PineappleInteractor{
-		p:                 p,
+		GameBase:          GameBase[interfaces.PineappleGame]{Game: p},
 		pp:                pp,
 		tournamentActions: newTournamentActions[interfaces.PineappleGame](p, pp),
 	}
@@ -44,56 +42,49 @@ func NewPineappleInteractor(p interfaces.PineappleGame, pp presenter.PineapplePr
 
 // Reset ゲーム初期化
 func (pi *PineappleInteractor) Reset() string {
-	return execAndPresent(pi.p, pi.pp, pi.p.Reset)
+	return execAndPresent(pi.Game, pi.pp, pi.Game.Reset)
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (pi *PineappleInteractor) ResetWithConfig(cfg domain.PineappleConfig, profileData []byte) string {
 	if err := cfg.Validate(); err != nil {
-		return pi.pp.Output(pi.p, err)
+		return pi.pp.Output(pi.Game, err)
 	}
 	// テーブルサイズ変更時はプレイヤーを再構築
-	if cfg.TableSize > 0 && cfg.TableSize != pi.p.GetPlayerCnt() {
-		pi.p.Resize(domain.NewPineapplePlayersForTable(cfg.TableSize))
+	if cfg.TableSize > 0 && cfg.TableSize != pi.Game.GetPlayerCnt() {
+		pi.Game.Resize(domain.NewPineapplePlayersForTable(cfg.TableSize))
 	}
-	pi.p.SetConfig(cfg)
-	err := pi.p.Reset()
+	pi.Game.SetConfig(cfg)
+	err := pi.Game.Reset()
 	if len(profileData) > 0 {
-		_ = pi.p.ImportProfile(profileData)
+		_ = pi.Game.ImportProfile(profileData)
 	}
-	return pi.pp.Output(pi.p, err)
+	return pi.pp.Output(pi.Game, err)
 }
 
 // Action プレイヤーアクション実行
 func (pi *PineappleInteractor) Action(action int, amount int, humanPlayMs int) string {
-	return execAndPresent(pi.p, pi.pp, func() error { return pi.p.PlayerAction(action, amount, humanPlayMs) })
+	return execAndPresent(pi.Game, pi.pp, func() error { return pi.Game.PlayerAction(action, amount, humanPlayMs) })
 }
 
 // Discard ディスカード実行
 func (pi *PineappleInteractor) Discard(cardIdx int) string {
-	return execAndPresent(pi.p, pi.pp, func() error { return pi.p.DiscardCard(cardIdx) })
+	return execAndPresent(pi.Game, pi.pp, func() error { return pi.Game.DiscardCard(cardIdx) })
 }
 
 // GetConfig 現在の設定を取得
 func (pi *PineappleInteractor) GetConfig() domain.PineappleConfig {
-	return pi.p.GetConfig()
+	return pi.Game.GetConfig()
 }
 
 // ActionLog 棋譜を出力する
 func (pi *PineappleInteractor) ActionLog() string {
-	return pi.pp.ActionLogOutput(pi.p)
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (pi *PineappleInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(pi.p)
+	return pi.pp.ActionLogOutput(pi.Game)
 }
 
 // RestorePineappleInteractor deserialises JSON into a PineappleInteractor.
 func RestorePineappleInteractor(data []byte, pp presenter.PineapplePresenter) (*PineappleInteractor, error) {
-	p, err := restoreGame[domain.Pineapple](data)
-	if err != nil {
-		return nil, err
-	}
-	return &PineappleInteractor{p: p, pp: pp, tournamentActions: newTournamentActions[interfaces.PineappleGame](p, pp)}, nil
+	return restoreAndBuild[domain.Pineapple](data, func(g *domain.Pineapple) *PineappleInteractor {
+		return &PineappleInteractor{GameBase: GameBase[interfaces.PineappleGame]{Game: g}, pp: pp}
+	})
 }

--- a/internal/usecase/PinochleInteractor.go
+++ b/internal/usecase/PinochleInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // PinochleInteractorIF ピノクルインタラクターインタフェース
 type PinochleInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// ResetWithConfig 設定を変更してゲーム初期化

--- a/internal/usecase/PinochleInteractor.go
+++ b/internal/usecase/PinochleInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -38,139 +36,139 @@ type PinochleInteractorIF interface {
 
 // PinochleInteractor ピノクルインタラクタークラス
 type PinochleInteractor struct {
-	p  interfaces.PinochleGame
+	GameBase[interfaces.PinochleGame]
 	pp presenter.PinochlePresenter
 }
 
 // NewPinochleInteractor コンストラクタ
 func NewPinochleInteractor(p interfaces.PinochleGame, pp presenter.PinochlePresenter) *PinochleInteractor {
 	mustNotNil("PinochleInteractor", map[string]any{"p": p, "pp": pp})
-	return &PinochleInteractor{p: p, pp: pp}
+	return &PinochleInteractor{GameBase: GameBase[interfaces.PinochleGame]{Game: p}, pp: pp}
 }
 
 // Reset ゲーム初期化
 func (pi *PinochleInteractor) Reset() string {
-	pi.p.Reset()
+	pi.Game.Reset()
 	pi.runCpuBids()
-	return pi.pp.Output(pi.p, nil)
+	return pi.pp.Output(pi.Game, nil)
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (pi *PinochleInteractor) ResetWithConfig(cfg domain.PinochleConfig) string {
-	return resetWithValidatedConfig(pi.p, pi.pp, cfg, pi.p.SetConfig, pi.Reset)
+	return resetWithValidatedConfig(pi.Game, pi.pp, cfg, pi.Game.SetConfig, pi.Reset)
 }
 
 // Bid ビッドする
 func (pi *PinochleInteractor) Bid(amount int) string {
-	if out, blocked := guardGameEnd(pi.p, pi.pp); blocked {
+	if out, blocked := guardGameEnd(pi.Game, pi.pp); blocked {
 		return out
 	}
-	err := pi.p.PlayerBid(amount)
+	err := pi.Game.PlayerBid(amount)
 	if err != nil {
-		return pi.pp.Output(pi.p, err)
+		return pi.pp.Output(pi.Game, err)
 	}
 	pi.runCpuBids()
-	return pi.pp.Output(pi.p, nil)
+	return pi.pp.Output(pi.Game, nil)
 }
 
 // Pass パスする
 func (pi *PinochleInteractor) Pass() string {
-	if out, blocked := guardGameEnd(pi.p, pi.pp); blocked {
+	if out, blocked := guardGameEnd(pi.Game, pi.pp); blocked {
 		return out
 	}
-	err := pi.p.PlayerPass()
+	err := pi.Game.PlayerPass()
 	if err != nil {
-		return pi.pp.Output(pi.p, err)
+		return pi.pp.Output(pi.Game, err)
 	}
 	pi.runCpuBids()
-	return pi.pp.Output(pi.p, nil)
+	return pi.pp.Output(pi.Game, nil)
 }
 
 // CallTrump トランプスートを宣言する
 func (pi *PinochleInteractor) CallTrump(suit int) string {
-	if out, blocked := guardGameEnd(pi.p, pi.pp); blocked {
+	if out, blocked := guardGameEnd(pi.Game, pi.pp); blocked {
 		return out
 	}
-	err := pi.p.PlayerCallTrump(suit)
+	err := pi.Game.PlayerCallTrump(suit)
 	if err != nil {
-		return pi.pp.Output(pi.p, err)
+		return pi.pp.Output(pi.Game, err)
 	}
-	return pi.pp.Output(pi.p, nil)
+	return pi.pp.Output(pi.Game, nil)
 }
 
 // ConfirmMelds メルドを確認してプレイフェーズに進む
 func (pi *PinochleInteractor) ConfirmMelds() string {
-	if out, blocked := guardGameEnd(pi.p, pi.pp); blocked {
+	if out, blocked := guardGameEnd(pi.Game, pi.pp); blocked {
 		return out
 	}
-	pi.p.ConfirmMelds()
+	pi.Game.ConfirmMelds()
 	pi.runCpuTurns()
-	return pi.pp.Output(pi.p, nil)
+	return pi.pp.Output(pi.Game, nil)
 }
 
 // Play カードをプレイ
 func (pi *PinochleInteractor) Play(cardIndex int) string {
-	if out, blocked := guardNotPlayable(pi.p, pi.pp); blocked {
+	if out, blocked := guardNotPlayable(pi.Game, pi.pp); blocked {
 		return out
 	}
-	err := pi.p.PlayerPlay(cardIndex)
+	err := pi.Game.PlayerPlay(cardIndex)
 	if err != nil {
-		return pi.pp.Output(pi.p, err)
+		return pi.pp.Output(pi.Game, err)
 	}
 	pi.runCpuTurns()
-	return pi.pp.Output(pi.p, nil)
+	return pi.pp.Output(pi.Game, nil)
 }
 
 // NextTrick 次のトリックへ進む
 func (pi *PinochleInteractor) NextTrick() string {
-	pi.p.ResolveTrick()
-	if out, blocked := guardGameEnd(pi.p, pi.pp); blocked {
+	pi.Game.ResolveTrick()
+	if out, blocked := guardGameEnd(pi.Game, pi.pp); blocked {
 		return out
 	}
-	pi.p.NextTrick()
+	pi.Game.NextTrick()
 	pi.runCpuTurns()
-	return pi.pp.Output(pi.p, nil)
+	return pi.pp.Output(pi.Game, nil)
 }
 
 // NextRound 次のラウンドへ進む
 func (pi *PinochleInteractor) NextRound() string {
-	if out, blocked := guardGameEnd(pi.p, pi.pp); blocked {
+	if out, blocked := guardGameEnd(pi.Game, pi.pp); blocked {
 		return out
 	}
-	pi.p.NextRound()
+	pi.Game.NextRound()
 	pi.runCpuBids()
-	return pi.pp.Output(pi.p, nil)
+	return pi.pp.Output(pi.Game, nil)
 }
 
 // GetConfig 現在の設定を取得
 func (pi *PinochleInteractor) GetConfig() domain.PinochleConfig {
-	return pi.p.GetConfig()
+	return pi.Game.GetConfig()
 }
 
 // Hint ヒント取得
 func (pi *PinochleInteractor) Hint() string {
-	return pi.pp.HintOutput(pi.p)
+	return pi.pp.HintOutput(pi.Game)
 }
 
 // ActionLog 棋譜を出力する
 func (pi *PinochleInteractor) ActionLog() string {
-	return pi.pp.ActionLogOutput(pi.p)
+	return pi.pp.ActionLogOutput(pi.Game)
 }
 
 // runCpuBids ビッドおよびトランプ宣言フェーズでCPUを自動実行する
 func (pi *PinochleInteractor) runCpuBids() {
-	for !pi.p.GetGameEndFlag() {
-		phase := pi.p.GetPhase()
+	for !pi.Game.GetGameEndFlag() {
+		phase := pi.Game.GetPhase()
 		if phase == domain.PinochlePhaseBid {
-			if pi.p.IsHumanBidTurn() {
+			if pi.Game.IsHumanBidTurn() {
 				break
 			}
-			pi.p.CpuBid()
+			pi.Game.CpuBid()
 		} else if phase == domain.PinochlePhaseTrump {
-			if pi.p.IsHumanTurn() {
+			if pi.Game.IsHumanTurn() {
 				break
 			}
-			pi.p.CpuCallTrump()
+			pi.Game.CpuCallTrump()
 		} else {
 			break
 		}
@@ -179,7 +177,7 @@ func (pi *PinochleInteractor) runCpuBids() {
 
 // runCpuTurns プレイフェーズでCPUターンを自動実行する
 func (pi *PinochleInteractor) runCpuTurns() {
-	runCpuTurnsLoop(pi.p, trickPhases[domain.PinochlePhase]{
+	runCpuTurnsLoop(pi.Game, trickPhases[domain.PinochlePhase]{
 		play:     domain.PinochlePhasePlay,
 		trickEnd: domain.PinochlePhaseTrickEnd,
 		roundEnd: domain.PinochlePhaseRoundEnd,
@@ -187,16 +185,9 @@ func (pi *PinochleInteractor) runCpuTurns() {
 	})
 }
 
-// Snapshot serialises the game state to JSON for KV persistence.
-func (pi *PinochleInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(pi.p)
-}
-
 // RestorePinochleInteractor deserialises JSON into a PinochleInteractor.
 func RestorePinochleInteractor(data []byte, pp presenter.PinochlePresenter) (*PinochleInteractor, error) {
-	p, err := restoreGame[domain.Pinochle](data)
-	if err != nil {
-		return nil, err
-	}
-	return &PinochleInteractor{p: p, pp: pp}, nil
+	return restoreAndBuild[domain.Pinochle](data, func(g *domain.Pinochle) *PinochleInteractor {
+		return &PinochleInteractor{GameBase: GameBase[interfaces.PinochleGame]{Game: g}, pp: pp}
+	})
 }

--- a/internal/usecase/PinochleInteractor_test.go
+++ b/internal/usecase/PinochleInteractor_test.go
@@ -198,3 +198,62 @@ func TestPinochleInteractor_GameEndGuard(t *testing.T) {
 	assert.Contains(t, pi.NextRound(), "gameEndFlag")
 	assert.Contains(t, pi.ConfirmMelds(), "gameEndFlag")
 }
+
+func TestPinochleInteractor_Play_Error(t *testing.T) {
+	gameMock, ppMock := setupPinochleInteractorMocks(domain.PinochlePhasePlay)
+	gameMock.On("PlayerPlay", 99).Return(domain.NewDomainError(domain.ErrInvalidCard, "invalid"))
+
+	pi := usecase.NewPinochleInteractor(gameMock, ppMock)
+	result := pi.Play(99)
+	assert.Contains(t, result, "phase")
+}
+
+func TestPinochleInteractor_Play_NotHumanTurn(t *testing.T) {
+	ppMock := new(presenter.MockPinochlePresenter)
+	ppMock.On("Output", mock.Anything, mock.Anything).Return(`{"notHuman":true}`)
+	gameMock := new(interfaces.MockPinochleGame)
+	gameMock.On("GetGameEndFlag").Return(false)
+	gameMock.On("IsHumanTurn").Return(false)
+
+	pi := usecase.NewPinochleInteractor(gameMock, ppMock)
+	result := pi.Play(0)
+	assert.Contains(t, result, "notHuman")
+}
+
+func TestPinochleInteractor_NextTrick_GameEnd(t *testing.T) {
+	ppMock := new(presenter.MockPinochlePresenter)
+	ppMock.On("Output", mock.Anything, mock.Anything).Return(`{"gameEnd":true}`)
+	gameMock := new(interfaces.MockPinochleGame)
+	gameMock.On("ResolveTrick").Return()
+	gameMock.On("GetGameEndFlag").Return(true)
+
+	pi := usecase.NewPinochleInteractor(gameMock, ppMock)
+	result := pi.NextTrick()
+	assert.Contains(t, result, "gameEnd")
+	gameMock.AssertCalled(t, "ResolveTrick")
+}
+
+func TestRestorePinochleInteractor(t *testing.T) {
+	players := []*domain.PinochlePlayer{
+		domain.NewPinochlePlayer(true, 0),
+		domain.NewPinochlePlayer(false, 1),
+		domain.NewPinochlePlayer(false, 0),
+		domain.NewPinochlePlayer(false, 1),
+	}
+	p := domain.NewPinochle(domain.NewTrumpCardsPinochle(), players, domain.DefaultPinochleConfig())
+	ppMock := new(presenter.MockPinochlePresenter)
+	pi := usecase.NewPinochleInteractor(p, ppMock)
+
+	data, err := pi.Snapshot()
+	assert.NoError(t, err)
+
+	restored, err := usecase.RestorePinochleInteractor(data, ppMock)
+	assert.NoError(t, err)
+	assert.NotNil(t, restored)
+}
+
+func TestRestorePinochleInteractor_InvalidJSON(t *testing.T) {
+	ppMock := new(presenter.MockPinochlePresenter)
+	_, err := usecase.RestorePinochleInteractor([]byte("invalid"), ppMock)
+	assert.Error(t, err)
+}

--- a/internal/usecase/PokerInteractor.go
+++ b/internal/usecase/PokerInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // PokerInteractorIF ポーカーインタラクターインタフェース
 type PokerInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// ResetWithConfig 設定を変更してゲーム初期化 (profileData: JSONプロファイル、nilなら無視)

--- a/internal/usecase/PokerInteractor.go
+++ b/internal/usecase/PokerInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -30,7 +28,7 @@ type PokerInteractorIF interface {
 
 // PokerInteractor ポーカーインタラクタークラス
 type PokerInteractor struct {
-	p  interfaces.PokerGame
+	GameBase[interfaces.PokerGame]
 	pp presenter.PokerPresenter
 }
 
@@ -38,73 +36,66 @@ type PokerInteractor struct {
 func NewPokerInteractor(p interfaces.PokerGame, pp presenter.PokerPresenter) *PokerInteractor {
 	mustNotNil("PokerInteractor", map[string]any{"p": p, "pp": pp})
 	return &PokerInteractor{
-		p:  p,
-		pp: pp,
+		GameBase: GameBase[interfaces.PokerGame]{Game: p},
+		pp:       pp,
 	}
 }
 
 // Reset ゲーム初期化
 func (pi *PokerInteractor) Reset() string {
-	return execAndPresent(pi.p, pi.pp, pi.p.Reset)
+	return execAndPresent(pi.Game, pi.pp, pi.Game.Reset)
 }
 
 // GetConfig 現在の設定を取得
 func (pi *PokerInteractor) GetConfig() domain.PokerConfig {
-	return pi.p.GetConfig()
+	return pi.Game.GetConfig()
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (pi *PokerInteractor) ResetWithConfig(cfg domain.PokerConfig, profileData []byte) string {
 	if err := cfg.Validate(); err != nil {
-		return pi.pp.Output(pi.p, err)
+		return pi.pp.Output(pi.Game, err)
 	}
-	pi.p.SetConfig(cfg)
-	err := pi.p.Reset()
+	pi.Game.SetConfig(cfg)
+	err := pi.Game.Reset()
 	if len(profileData) > 0 {
-		_ = pi.p.ImportProfile(profileData)
+		_ = pi.Game.ImportProfile(profileData)
 	}
-	return pi.pp.Output(pi.p, err)
+	return pi.pp.Output(pi.Game, err)
 }
 
 // Action プレイヤーアクション実行
 func (pi *PokerInteractor) Action(action int, amount int, humanPlayMs int) string {
-	return execAndPresent(pi.p, pi.pp, func() error { return pi.p.PlayerAction(action, amount, humanPlayMs) })
+	return execAndPresent(pi.Game, pi.pp, func() error { return pi.Game.PlayerAction(action, amount, humanPlayMs) })
 }
 
 // Exchange カード交換
 func (pi *PokerInteractor) Exchange(indices []int) string {
-	return execAndPresent(pi.p, pi.pp, func() error { return pi.p.PlayerExchange(indices) })
+	return execAndPresent(pi.Game, pi.pp, func() error { return pi.Game.PlayerExchange(indices) })
 }
 
 // Stand カード交換なし
 func (pi *PokerInteractor) Stand() string {
-	return execAndPresent(pi.p, pi.pp, pi.p.PlayerStand)
+	return execAndPresent(pi.Game, pi.pp, pi.Game.PlayerStand)
 }
 
 // ActionLog 棋譜を出力する
 func (pi *PokerInteractor) ActionLog() string {
-	return pi.pp.ActionLogOutput(pi.p)
+	return pi.pp.ActionLogOutput(pi.Game)
 }
 
 // Odds ドローオッズ計算
 func (pi *PokerInteractor) Odds(indices []int) string {
-	odds, err := pi.p.CalcDrawOdds(indices)
+	odds, err := pi.Game.CalcDrawOdds(indices)
 	if err != nil {
-		return pi.pp.Output(pi.p, err)
+		return pi.pp.Output(pi.Game, err)
 	}
-	return pi.pp.OutputWithOdds(pi.p, nil, odds)
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (pi *PokerInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(pi.p)
+	return pi.pp.OutputWithOdds(pi.Game, nil, odds)
 }
 
 // RestorePokerInteractor deserialises JSON into a PokerInteractor.
 func RestorePokerInteractor(data []byte, pp presenter.PokerPresenter) (*PokerInteractor, error) {
-	p, err := restoreGame[domain.Poker](data)
-	if err != nil {
-		return nil, err
-	}
-	return &PokerInteractor{p: p, pp: pp}, nil
+	return restoreAndBuild[domain.Poker](data, func(g *domain.Poker) *PokerInteractor {
+		return &PokerInteractor{GameBase: GameBase[interfaces.PokerGame]{Game: g}, pp: pp}
+	})
 }

--- a/internal/usecase/PyramidInteractor.go
+++ b/internal/usecase/PyramidInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // PyramidInteractorIF ピラミッドインタラクターインタフェース
 type PyramidInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// Draw ストックからウェイストにカードを引く

--- a/internal/usecase/PyramidInteractor.go
+++ b/internal/usecase/PyramidInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -36,81 +34,74 @@ type PyramidInteractorIF interface {
 
 // PyramidInteractor ピラミッドインタラクタークラス
 type PyramidInteractor struct {
-	p  interfaces.PyramidGame
+	GameBase[interfaces.PyramidGame]
 	pp presenter.PyramidPresenter
 }
 
 // NewPyramidInteractor コンストラクタ
 func NewPyramidInteractor(p interfaces.PyramidGame, pp presenter.PyramidPresenter) *PyramidInteractor {
 	mustNotNil("PyramidInteractor", map[string]any{"p": p, "pp": pp})
-	return &PyramidInteractor{p: p, pp: pp}
+	return &PyramidInteractor{GameBase: GameBase[interfaces.PyramidGame]{Game: p}, pp: pp}
 }
 
 // Reset ゲーム初期化
 func (pi *PyramidInteractor) Reset() string {
-	return runAndPresent(pi.p, pi.pp, pi.p.Reset)
+	return runAndPresent(pi.Game, pi.pp, pi.Game.Reset)
 }
 
 // Draw ストックからウェイストにカードを引く
 func (pi *PyramidInteractor) Draw() string {
-	return execAndPresent(pi.p, pi.pp, pi.p.Draw)
+	return execAndPresent(pi.Game, pi.pp, pi.Game.Draw)
 }
 
 // RemovePair ピラミッド上の2枚を合計13で除去
 func (pi *PyramidInteractor) RemovePair(row1, col1, row2, col2 int) string {
-	return execAndPresent(pi.p, pi.pp, func() error { return pi.p.RemovePair(row1, col1, row2, col2) })
+	return execAndPresent(pi.Game, pi.pp, func() error { return pi.Game.RemovePair(row1, col1, row2, col2) })
 }
 
 // RemoveKing ピラミッド上のKを単独除去
 func (pi *PyramidInteractor) RemoveKing(row, col int) string {
-	return execAndPresent(pi.p, pi.pp, func() error { return pi.p.RemoveKing(row, col) })
+	return execAndPresent(pi.Game, pi.pp, func() error { return pi.Game.RemoveKing(row, col) })
 }
 
 // RemoveWithWaste ウェイストとピラミッドのペア除去
 func (pi *PyramidInteractor) RemoveWithWaste(row, col int) string {
-	return execAndPresent(pi.p, pi.pp, func() error { return pi.p.RemoveWithWaste(row, col) })
+	return execAndPresent(pi.Game, pi.pp, func() error { return pi.Game.RemoveWithWaste(row, col) })
 }
 
 // RemoveWasteKing ウェイストのK除去
 func (pi *PyramidInteractor) RemoveWasteKing() string {
-	return execAndPresent(pi.p, pi.pp, pi.p.RemoveWasteKing)
+	return execAndPresent(pi.Game, pi.pp, pi.Game.RemoveWasteKing)
 }
 
 // GiveUp ギブアップ
 func (pi *PyramidInteractor) GiveUp() string {
-	return runAndPresent(pi.p, pi.pp, pi.p.GiveUp)
+	return runAndPresent(pi.Game, pi.pp, pi.Game.GiveUp)
 }
 
 // Hint ヒント取得
 func (pi *PyramidInteractor) Hint() string {
-	return pi.pp.HintOutput(pi.p)
+	return pi.pp.HintOutput(pi.Game)
 }
 
 // ActionLog 棋譜を出力する
 func (pi *PyramidInteractor) ActionLog() string {
-	return pi.pp.ActionLogOutput(pi.p)
+	return pi.pp.ActionLogOutput(pi.Game)
 }
 
 // Undo アンドゥ
 func (pi *PyramidInteractor) Undo() string {
-	return execAndPresent(pi.p, pi.pp, pi.p.Undo)
+	return execAndPresent(pi.Game, pi.pp, pi.Game.Undo)
 }
 
 // UndoN n回連続アンドゥ
 func (pi *PyramidInteractor) UndoN(n int) string {
-	return execAndPresent(pi.p, pi.pp, func() error { return pi.p.UndoN(n) })
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (pi *PyramidInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(pi.p)
+	return execAndPresent(pi.Game, pi.pp, func() error { return pi.Game.UndoN(n) })
 }
 
 // RestorePyramidInteractor deserialises JSON into a PyramidInteractor.
 func RestorePyramidInteractor(data []byte, pp presenter.PyramidPresenter) (*PyramidInteractor, error) {
-	pyr, err := restoreGame[domain.Pyramid](data)
-	if err != nil {
-		return nil, err
-	}
-	return &PyramidInteractor{p: pyr, pp: pp}, nil
+	return restoreAndBuild[domain.Pyramid](data, func(g *domain.Pyramid) *PyramidInteractor {
+		return &PyramidInteractor{GameBase: GameBase[interfaces.PyramidGame]{Game: g}, pp: pp}
+	})
 }

--- a/internal/usecase/SevenCardStudInteractor.go
+++ b/internal/usecase/SevenCardStudInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // SevenCardStudInteractorIF セブンカードスタッドインタラクターインタフェース
 type SevenCardStudInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	TournamentInteractorIF
 	// Reset ゲーム初期化
 	Reset() string

--- a/internal/usecase/SevenCardStudInteractor.go
+++ b/internal/usecase/SevenCardStudInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -25,7 +23,7 @@ type SevenCardStudInteractorIF interface {
 
 // SevenCardStudInteractor セブンカードスタッドインタラクタークラス
 type SevenCardStudInteractor struct {
-	s  interfaces.SevenCardStudGame
+	GameBase[interfaces.SevenCardStudGame]
 	sp presenter.SevenCardStudPresenter
 	tournamentActions[interfaces.SevenCardStudGame]
 }
@@ -34,7 +32,7 @@ type SevenCardStudInteractor struct {
 func NewSevenCardStudInteractor(s interfaces.SevenCardStudGame, sp presenter.SevenCardStudPresenter) *SevenCardStudInteractor {
 	mustNotNil("SevenCardStudInteractor", map[string]any{"s": s, "sp": sp})
 	return &SevenCardStudInteractor{
-		s:                 s,
+		GameBase:          GameBase[interfaces.SevenCardStudGame]{Game: s},
 		sp:                sp,
 		tournamentActions: newTournamentActions[interfaces.SevenCardStudGame](s, sp),
 	}
@@ -42,50 +40,43 @@ func NewSevenCardStudInteractor(s interfaces.SevenCardStudGame, sp presenter.Sev
 
 // Reset ゲーム初期化
 func (si *SevenCardStudInteractor) Reset() string {
-	return execAndPresent(si.s, si.sp, si.s.Reset)
+	return execAndPresent(si.Game, si.sp, si.Game.Reset)
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (si *SevenCardStudInteractor) ResetWithConfig(cfg domain.SevenCardStudConfig, profileData []byte) string {
 	if err := cfg.Validate(); err != nil {
-		return si.sp.Output(si.s, err)
+		return si.sp.Output(si.Game, err)
 	}
-	if cfg.TableSize > 0 && cfg.TableSize != si.s.GetPlayerCnt() {
-		si.s.Resize(domain.NewSevenCardStudPlayersForTable(cfg.TableSize))
+	if cfg.TableSize > 0 && cfg.TableSize != si.Game.GetPlayerCnt() {
+		si.Game.Resize(domain.NewSevenCardStudPlayersForTable(cfg.TableSize))
 	}
-	si.s.SetConfig(cfg)
-	err := si.s.Reset()
+	si.Game.SetConfig(cfg)
+	err := si.Game.Reset()
 	if len(profileData) > 0 {
-		_ = si.s.ImportProfile(profileData)
+		_ = si.Game.ImportProfile(profileData)
 	}
-	return si.sp.Output(si.s, err)
+	return si.sp.Output(si.Game, err)
 }
 
 // Action プレイヤーアクション実行
 func (si *SevenCardStudInteractor) Action(action int, amount int, humanPlayMs int) string {
-	return execAndPresent(si.s, si.sp, func() error { return si.s.PlayerAction(action, amount, humanPlayMs) })
+	return execAndPresent(si.Game, si.sp, func() error { return si.Game.PlayerAction(action, amount, humanPlayMs) })
 }
 
 // GetConfig 現在の設定を取得
 func (si *SevenCardStudInteractor) GetConfig() domain.SevenCardStudConfig {
-	return si.s.GetConfig()
+	return si.Game.GetConfig()
 }
 
 // ActionLog 棋譜を出力する
 func (si *SevenCardStudInteractor) ActionLog() string {
-	return si.sp.ActionLogOutput(si.s)
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (si *SevenCardStudInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(si.s)
+	return si.sp.ActionLogOutput(si.Game)
 }
 
 // RestoreSevenCardStudInteractor deserialises JSON into a SevenCardStudInteractor.
 func RestoreSevenCardStudInteractor(data []byte, sp presenter.SevenCardStudPresenter) (*SevenCardStudInteractor, error) {
-	s, err := restoreGame[domain.SevenCardStud](data)
-	if err != nil {
-		return nil, err
-	}
-	return &SevenCardStudInteractor{s: s, sp: sp, tournamentActions: newTournamentActions[interfaces.SevenCardStudGame](s, sp)}, nil
+	return restoreAndBuild[domain.SevenCardStud](data, func(g *domain.SevenCardStud) *SevenCardStudInteractor {
+		return &SevenCardStudInteractor{GameBase: GameBase[interfaces.SevenCardStudGame]{Game: g}, sp: sp}
+	})
 }

--- a/internal/usecase/SevensInteractor.go
+++ b/internal/usecase/SevensInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // SevensInteractorIF 7並べインタラクターインタフェース
 type SevensInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// ResetWithConfig 設定付きゲーム初期化

--- a/internal/usecase/SevensInteractor.go
+++ b/internal/usecase/SevensInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -24,7 +22,7 @@ type SevensInteractorIF interface {
 
 // SevensInteractor 7並べインタラクタークラス
 type SevensInteractor struct {
-	s  interfaces.SevensGame
+	GameBase[interfaces.SevensGame]
 	sp presenter.SevensPresenter
 }
 
@@ -32,83 +30,76 @@ type SevensInteractor struct {
 func NewSevensInteractor(s interfaces.SevensGame, sp presenter.SevensPresenter) *SevensInteractor {
 	mustNotNil("SevensInteractor", map[string]any{"s": s, "sp": sp})
 	return &SevensInteractor{
-		s:  s,
-		sp: sp,
+		GameBase: GameBase[interfaces.SevensGame]{Game: s},
+		sp:       sp,
 	}
 }
 
 // ResetWithConfig 設定付きゲーム初期化
 func (si *SevensInteractor) ResetWithConfig(cfg domain.SevensConfig) string {
-	si.s.SetConfig(cfg)
-	si.s.Reset()
+	si.Game.SetConfig(cfg)
+	si.Game.Reset()
 	si.runCpuTurns()
-	return si.sp.Output(si.s, nil)
+	return si.sp.Output(si.Game, nil)
 }
 
 // Reset ゲーム初期化
 func (si *SevensInteractor) Reset() string {
-	si.s.Reset()
+	si.Game.Reset()
 	si.runCpuTurns()
-	return si.sp.Output(si.s, nil)
+	return si.sp.Output(si.Game, nil)
 }
 
 // Play 人間プレイヤーがカードを出す (または パスする)
 // idx: 出すカードのインデックス。-1 の場合はパス。
 func (si *SevensInteractor) Play(idx int) string {
-	if out, blocked := guardNotPlayable(si.s, si.sp); blocked {
+	if out, blocked := guardNotPlayable(si.Game, si.sp); blocked {
 		return out
 	}
-	err := si.s.PlayerPlay(idx)
-	if err == nil && !si.s.GetGameEndFlag() {
+	err := si.Game.PlayerPlay(idx)
+	if err == nil && !si.Game.GetGameEndFlag() {
 		si.runCpuTurns()
 	}
-	return si.sp.Output(si.s, err)
+	return si.sp.Output(si.Game, err)
 }
 
 // PlayJoker 人間プレイヤーがジョーカーを指定ポジションに出す
 func (si *SevensInteractor) PlayJoker(cardIdx, targetSuit, targetValue int) string {
-	if out, blocked := guardNotPlayable(si.s, si.sp); blocked {
+	if out, blocked := guardNotPlayable(si.Game, si.sp); blocked {
 		return out
 	}
-	err := si.s.PlayerPlayJoker(cardIdx, targetSuit, targetValue)
-	if err == nil && !si.s.GetGameEndFlag() {
+	err := si.Game.PlayerPlayJoker(cardIdx, targetSuit, targetValue)
+	if err == nil && !si.Game.GetGameEndFlag() {
 		si.runCpuTurns()
 	}
-	return si.sp.Output(si.s, err)
+	return si.sp.Output(si.Game, err)
 }
 
 // ActionLog 棋譜を出力する
 func (si *SevensInteractor) ActionLog() string {
-	return si.sp.ActionLogOutput(si.s)
+	return si.sp.ActionLogOutput(si.Game)
 }
 
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 // 人間の手番になった場合でも選択肢がなければ自動処理する
 func (si *SevensInteractor) runCpuTurns() {
-	for !si.s.GetGameEndFlag() {
-		if si.s.IsHumanTurn() {
+	for !si.Game.GetGameEndFlag() {
+		if si.Game.IsHumanTurn() {
 			// 人間に選択肢がなければ自動処理 (失格)
-			if !si.s.HasAnyOption(si.s.GetCurrentTurn()) {
-				si.s.AutoHandleNoOption()
+			if !si.Game.HasAnyOption(si.Game.GetCurrentTurn()) {
+				si.Game.AutoHandleNoOption()
 			} else {
 				break
 			}
 		} else {
-			si.s.CpuPlay()
+			si.Game.CpuPlay()
 		}
 	}
 }
 
-// Snapshot serialises the game state to JSON for KV persistence.
-func (si *SevensInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(si.s)
-}
-
 // RestoreSevensInteractor deserialises JSON into a SevensInteractor.
 func RestoreSevensInteractor(data []byte, sp presenter.SevensPresenter) (*SevensInteractor, error) {
-	s, err := restoreGame[domain.Sevens](data)
-	if err != nil {
-		return nil, err
-	}
-	return &SevensInteractor{s: s, sp: sp}, nil
+	return restoreAndBuild[domain.Sevens](data, func(g *domain.Sevens) *SevensInteractor {
+		return &SevensInteractor{GameBase: GameBase[interfaces.SevensGame]{Game: g}, sp: sp}
+	})
 }

--- a/internal/usecase/SevensInteractor_internal_test.go
+++ b/internal/usecase/SevensInteractor_internal_test.go
@@ -80,11 +80,11 @@ func TestSevensInteractor_Play_GameEndFlag(t *testing.T) {
 	si := NewSevensInteractor(newInternalTestSevens(), spMock)
 
 	s := buildSevensEndedGame()
-	si.s = s
+	si.Game = s
 
 	// Human plays card at index 0 → finishes → checkGameEnd → gameEndFlag = true.
 	si.Play(0)
-	assert.True(t, si.s.GetGameEndFlag())
+	assert.True(t, si.Game.GetGameEndFlag())
 
 	// Now call Play with gameEndFlag == true → early return.
 	result := si.Play(0)
@@ -97,9 +97,9 @@ func TestSevensInteractor_Play_NotHumanTurn(t *testing.T) {
 	spMock.On("Output", mock.Anything, mock.Anything).Return(mockOutput)
 	si := NewSevensInteractor(newInternalTestSevens(), spMock)
 
-	si.s = buildSevensCpuTurnGame()
+	si.Game = buildSevensCpuTurnGame()
 
-	assert.False(t, si.s.IsHumanTurn())
+	assert.False(t, si.Game.IsHumanTurn())
 	result := si.Play(0)
 	assert.Equal(t, mockOutput, result)
 }
@@ -129,11 +129,11 @@ func TestSevensInteractor_PlayJoker_GameEndFlag(t *testing.T) {
 	}
 	// Give human a joker.
 	players[0].AddCard(domain.NewCard(domain.CardDesignJoker, 0, false))
-	si.s = s
+	si.Game = s
 
 	// Play joker at a valid position (spade 6, adjacent to 7).
 	si.PlayJoker(0, domain.CardDesignSpade, 6)
-	assert.True(t, si.s.GetGameEndFlag())
+	assert.True(t, si.Game.GetGameEndFlag())
 
 	// Now call PlayJoker with gameEndFlag == true → early return.
 	result := si.PlayJoker(0, domain.CardDesignSpade, 5)
@@ -170,12 +170,12 @@ func TestSevensInteractor_PlayJoker_SuccessRunCpuTurns(t *testing.T) {
 	players[2].AddCard(domain.NewCard(domain.CardDesignSpade, 8, false))
 	players[3].AddCard(domain.NewCard(domain.CardDesignHeart, 6, false))
 
-	si.s = s
+	si.Game = s
 
 	// Human plays joker at spade 6 (adjacent to 7) → success → runCpuTurns.
 	result := si.PlayJoker(0, domain.CardDesignSpade, 6)
 	assert.Equal(t, mockOutput, result)
-	assert.False(t, si.s.GetGameEndFlag())
+	assert.False(t, si.Game.GetGameEndFlag())
 }
 
 func TestSevensInteractor_PlayJoker_NotHumanTurn(t *testing.T) {
@@ -184,9 +184,9 @@ func TestSevensInteractor_PlayJoker_NotHumanTurn(t *testing.T) {
 	spMock.On("Output", mock.Anything, mock.Anything).Return(mockOutput)
 	si := NewSevensInteractor(newInternalTestSevens(), spMock)
 
-	si.s = buildSevensCpuTurnGame()
+	si.Game = buildSevensCpuTurnGame()
 
-	assert.False(t, si.s.IsHumanTurn())
+	assert.False(t, si.Game.IsHumanTurn())
 	result := si.PlayJoker(0, domain.CardDesignSpade, 6)
 	assert.Equal(t, mockOutput, result)
 }
@@ -229,7 +229,7 @@ func TestSevensInteractor_runCpuTurns_HumanAutoHandleNoOption(t *testing.T) {
 	// CPU3 gets heart 6 (playable, adjacent to 7).
 	players[3].AddCard(domain.NewCard(domain.CardDesignHeart, 6, false))
 
-	si.s = s
+	si.Game = s
 
 	// runCpuTurns is called: human is turn 0, has no option → AutoHandleNoOption
 	// → human is eliminated → turn advances to CPU → CPUs play → eventually
@@ -237,13 +237,13 @@ func TestSevensInteractor_runCpuTurns_HumanAutoHandleNoOption(t *testing.T) {
 	si.runCpuTurns()
 
 	// Verify human was eliminated (AutoHandleNoOption path was taken).
-	assert.True(t, si.s.GetPlayer(0).GetIsEliminated())
-	assert.True(t, si.s.GetPlayer(0).GetIsFinished())
+	assert.True(t, si.Game.GetPlayer(0).GetIsEliminated())
+	assert.True(t, si.Game.GetPlayer(0).GetIsFinished())
 
 	// Verify subsequent CPU turns ran and the game ended.
 	// The last remaining player is auto-finished by checkGameEnd (may still hold cards).
-	assert.True(t, si.s.GetGameEndFlag())
-	for i := 1; i < si.s.GetPlayerCnt(); i++ {
-		assert.True(t, si.s.GetPlayer(i).GetIsFinished(), "player %d should be finished", i)
+	assert.True(t, si.Game.GetGameEndFlag())
+	for i := 1; i < si.Game.GetPlayerCnt(); i++ {
+		assert.True(t, si.Game.GetPlayer(i).GetIsFinished(), "player %d should be finished", i)
 	}
 }

--- a/internal/usecase/ShortDeckInteractor.go
+++ b/internal/usecase/ShortDeckInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -25,7 +23,7 @@ type ShortDeckInteractorIF interface {
 
 // ShortDeckInteractor ショートデックホールデムインタラクタークラス
 type ShortDeckInteractor struct {
-	o  interfaces.ShortDeckGame
+	GameBase[interfaces.ShortDeckGame]
 	op presenter.ShortDeckPresenter
 	tournamentActions[interfaces.ShortDeckGame]
 }
@@ -34,7 +32,7 @@ type ShortDeckInteractor struct {
 func NewShortDeckInteractor(o interfaces.ShortDeckGame, op presenter.ShortDeckPresenter) *ShortDeckInteractor {
 	mustNotNil("ShortDeckInteractor", map[string]any{"o": o, "op": op})
 	return &ShortDeckInteractor{
-		o:                 o,
+		GameBase:          GameBase[interfaces.ShortDeckGame]{Game: o},
 		op:                op,
 		tournamentActions: newTournamentActions[interfaces.ShortDeckGame](o, op),
 	}
@@ -42,50 +40,43 @@ func NewShortDeckInteractor(o interfaces.ShortDeckGame, op presenter.ShortDeckPr
 
 // Reset ゲーム初期化
 func (oi *ShortDeckInteractor) Reset() string {
-	return execAndPresent(oi.o, oi.op, oi.o.Reset)
+	return execAndPresent(oi.Game, oi.op, oi.Game.Reset)
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (oi *ShortDeckInteractor) ResetWithConfig(cfg domain.ShortDeckConfig, profileData []byte) string {
 	if err := cfg.Validate(); err != nil {
-		return oi.op.Output(oi.o, err)
+		return oi.op.Output(oi.Game, err)
 	}
-	if cfg.TableSize > 0 && cfg.TableSize != oi.o.GetPlayerCnt() {
-		oi.o.Resize(domain.NewShortDeckPlayersForTable(cfg.TableSize))
+	if cfg.TableSize > 0 && cfg.TableSize != oi.Game.GetPlayerCnt() {
+		oi.Game.Resize(domain.NewShortDeckPlayersForTable(cfg.TableSize))
 	}
-	oi.o.SetConfig(cfg)
-	err := oi.o.Reset()
+	oi.Game.SetConfig(cfg)
+	err := oi.Game.Reset()
 	if len(profileData) > 0 {
-		_ = oi.o.ImportProfile(profileData)
+		_ = oi.Game.ImportProfile(profileData)
 	}
-	return oi.op.Output(oi.o, err)
+	return oi.op.Output(oi.Game, err)
 }
 
 // Action プレイヤーアクション実行
 func (oi *ShortDeckInteractor) Action(action int, amount int, humanPlayMs int) string {
-	return execAndPresent(oi.o, oi.op, func() error { return oi.o.PlayerAction(action, amount, humanPlayMs) })
+	return execAndPresent(oi.Game, oi.op, func() error { return oi.Game.PlayerAction(action, amount, humanPlayMs) })
 }
 
 // GetConfig 現在の設定を取得
 func (oi *ShortDeckInteractor) GetConfig() domain.ShortDeckConfig {
-	return oi.o.GetConfig()
+	return oi.Game.GetConfig()
 }
 
 // ActionLog 棋譜を出力する
 func (oi *ShortDeckInteractor) ActionLog() string {
-	return oi.op.ActionLogOutput(oi.o)
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (oi *ShortDeckInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(oi.o)
+	return oi.op.ActionLogOutput(oi.Game)
 }
 
 // RestoreShortDeckInteractor deserialises JSON into a ShortDeckInteractor.
 func RestoreShortDeckInteractor(data []byte, op presenter.ShortDeckPresenter) (*ShortDeckInteractor, error) {
-	sd, err := restoreGame[domain.ShortDeck](data)
-	if err != nil {
-		return nil, err
-	}
-	return &ShortDeckInteractor{o: sd, op: op, tournamentActions: newTournamentActions[interfaces.ShortDeckGame](sd, op)}, nil
+	return restoreAndBuild[domain.ShortDeck](data, func(g *domain.ShortDeck) *ShortDeckInteractor {
+		return &ShortDeckInteractor{GameBase: GameBase[interfaces.ShortDeckGame]{Game: g}, op: op}
+	})
 }

--- a/internal/usecase/ShortDeckInteractor.go
+++ b/internal/usecase/ShortDeckInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // ShortDeckInteractorIF ショートデックホールデムインタラクターインタフェース
 type ShortDeckInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	TournamentInteractorIF
 	// Reset ゲーム初期化
 	Reset() string

--- a/internal/usecase/SpadesInteractor.go
+++ b/internal/usecase/SpadesInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // SpadesInteractorIF スペードインタラクターインタフェース
 type SpadesInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// ResetWithConfig 設定を変更してゲーム初期化

--- a/internal/usecase/SpadesInteractor.go
+++ b/internal/usecase/SpadesInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -32,101 +30,101 @@ type SpadesInteractorIF interface {
 
 // SpadesInteractor スペードインタラクタークラス
 type SpadesInteractor struct {
-	s  interfaces.SpadesGame
+	GameBase[interfaces.SpadesGame]
 	sp presenter.SpadesPresenter
 }
 
 // NewSpadesInteractor コンストラクタ
 func NewSpadesInteractor(s interfaces.SpadesGame, sp presenter.SpadesPresenter) *SpadesInteractor {
 	mustNotNil("SpadesInteractor", map[string]any{"s": s, "sp": sp})
-	return &SpadesInteractor{s: s, sp: sp}
+	return &SpadesInteractor{GameBase: GameBase[interfaces.SpadesGame]{Game: s}, sp: sp}
 }
 
 // Reset ゲーム初期化
 func (si *SpadesInteractor) Reset() string {
-	si.s.Reset()
+	si.Game.Reset()
 	si.runCpuBids()
-	if si.s.GetPhase() == domain.SpadesPhasePlay {
+	if si.Game.GetPhase() == domain.SpadesPhasePlay {
 		si.runCpuTurns()
 	}
-	return si.sp.Output(si.s, nil)
+	return si.sp.Output(si.Game, nil)
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (si *SpadesInteractor) ResetWithConfig(cfg domain.SpadesConfig) string {
-	return resetWithValidatedConfig(si.s, si.sp, cfg, si.s.SetConfig, si.Reset)
+	return resetWithValidatedConfig(si.Game, si.sp, cfg, si.Game.SetConfig, si.Reset)
 }
 
 // Bid ビッドを宣言
 func (si *SpadesInteractor) Bid(bid int) string {
-	if out, blocked := guardGameEnd(si.s, si.sp); blocked {
+	if out, blocked := guardGameEnd(si.Game, si.sp); blocked {
 		return out
 	}
-	err := si.s.PlayerBid(bid)
+	err := si.Game.PlayerBid(bid)
 	if err != nil {
-		return si.sp.Output(si.s, err)
+		return si.sp.Output(si.Game, err)
 	}
 	si.runCpuBids()
-	if si.s.GetPhase() == domain.SpadesPhasePlay {
+	if si.Game.GetPhase() == domain.SpadesPhasePlay {
 		si.runCpuTurns()
 	}
-	return si.sp.Output(si.s, nil)
+	return si.sp.Output(si.Game, nil)
 }
 
 // Play カードをプレイ
 func (si *SpadesInteractor) Play(cardIndex int) string {
-	if out, blocked := guardNotPlayable(si.s, si.sp); blocked {
+	if out, blocked := guardNotPlayable(si.Game, si.sp); blocked {
 		return out
 	}
-	err := si.s.PlayerPlay(cardIndex)
+	err := si.Game.PlayerPlay(cardIndex)
 	if err != nil {
-		return si.sp.Output(si.s, err)
+		return si.sp.Output(si.Game, err)
 	}
 	si.runCpuTurns()
-	return si.sp.Output(si.s, nil)
+	return si.sp.Output(si.Game, nil)
 }
 
 // NextTrick 次のトリックへ進む
 func (si *SpadesInteractor) NextTrick() string {
-	si.s.NextTrick()
+	si.Game.NextTrick()
 	si.runCpuTurns()
-	return si.sp.Output(si.s, nil)
+	return si.sp.Output(si.Game, nil)
 }
 
 // NextRound ラウンドをスコアリングして次のラウンドへ進む
 func (si *SpadesInteractor) NextRound() string {
-	si.s.ScoreRound()
-	if out, blocked := guardGameEnd(si.s, si.sp); blocked {
+	si.Game.ScoreRound()
+	if out, blocked := guardGameEnd(si.Game, si.sp); blocked {
 		return out
 	}
-	si.s.NextRound()
+	si.Game.NextRound()
 	si.runCpuBids()
-	return si.sp.Output(si.s, nil)
+	return si.sp.Output(si.Game, nil)
 }
 
 // GetConfig 現在の設定を取得
 func (si *SpadesInteractor) GetConfig() domain.SpadesConfig {
-	return si.s.GetConfig()
+	return si.Game.GetConfig()
 }
 
 // Hint ヒント取得
 func (si *SpadesInteractor) Hint() string {
-	return si.sp.HintOutput(si.s)
+	return si.sp.HintOutput(si.Game)
 }
 
 // ActionLog 棋譜を出力する
 func (si *SpadesInteractor) ActionLog() string {
-	return si.sp.ActionLogOutput(si.s)
+	return si.sp.ActionLogOutput(si.Game)
 }
 
 // runCpuBids ゲームが終わるかヒューマンのビッド番またはビッドフェーズが終了するまでCPUビッドを実行
 func (si *SpadesInteractor) runCpuBids() {
-	runCpuBidsLoop(si.s, domain.SpadesPhaseBid)
+	runCpuBidsLoop(si.Game, domain.SpadesPhaseBid)
 }
 
 // runCpuTurns ゲームが終わるか人間の手番またはトリック/ラウンド終了になるまでCPUターンを実行
 func (si *SpadesInteractor) runCpuTurns() {
-	runCpuTurnsLoop(si.s, trickPhases[domain.SpadesPhase]{
+	runCpuTurnsLoop(si.Game, trickPhases[domain.SpadesPhase]{
 		play:     domain.SpadesPhasePlay,
 		trickEnd: domain.SpadesPhaseTrickEnd,
 		roundEnd: domain.SpadesPhaseRoundEnd,
@@ -134,16 +132,9 @@ func (si *SpadesInteractor) runCpuTurns() {
 	})
 }
 
-// Snapshot serialises the game state to JSON for KV persistence.
-func (si *SpadesInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(si.s)
-}
-
 // RestoreSpadesInteractor deserialises JSON into a SpadesInteractor.
 func RestoreSpadesInteractor(data []byte, sp presenter.SpadesPresenter) (*SpadesInteractor, error) {
-	s, err := restoreGame[domain.Spades](data)
-	if err != nil {
-		return nil, err
-	}
-	return &SpadesInteractor{s: s, sp: sp}, nil
+	return restoreAndBuild[domain.Spades](data, func(g *domain.Spades) *SpadesInteractor {
+		return &SpadesInteractor{GameBase: GameBase[interfaces.SpadesGame]{Game: g}, sp: sp}
+	})
 }

--- a/internal/usecase/SpeedInteractor.go
+++ b/internal/usecase/SpeedInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -28,86 +26,79 @@ type SpeedInteractorIF interface {
 
 // SpeedInteractor スピードインタラクタークラス
 type SpeedInteractor struct {
-	s  interfaces.SpeedGame
+	GameBase[interfaces.SpeedGame]
 	sp presenter.SpeedPresenter
 }
 
 // NewSpeedInteractor コンストラクタ
 func NewSpeedInteractor(s interfaces.SpeedGame, sp presenter.SpeedPresenter) *SpeedInteractor {
 	mustNotNil("SpeedInteractor", map[string]any{"s": s, "sp": sp})
-	return &SpeedInteractor{s: s, sp: sp}
+	return &SpeedInteractor{GameBase: GameBase[interfaces.SpeedGame]{Game: s}, sp: sp}
 }
 
 // Reset ゲーム初期化
 func (si *SpeedInteractor) Reset() string {
-	return runAndPresent(si.s, si.sp, si.s.Reset)
+	return runAndPresent(si.Game, si.sp, si.Game.Reset)
 }
 
 // ResetWithConfig 設定を変更してゲーム初期化
 func (si *SpeedInteractor) ResetWithConfig(cfg domain.SpeedConfig) string {
-	return resetWithValidatedConfig(si.s, si.sp, cfg, si.s.SetConfig, si.Reset)
+	return resetWithValidatedConfig(si.Game, si.sp, cfg, si.Game.SetConfig, si.Reset)
 }
 
 // Play 人間プレイヤーがカードを出す、その後CPUが自動応答する
 func (si *SpeedInteractor) Play(cardIndex, pileIndex int) string {
-	if out, blocked := guardGameEnd(si.s, si.sp); blocked {
+	if out, blocked := guardGameEnd(si.Game, si.sp); blocked {
 		return out
 	}
-	err := si.s.PlayerPlay(cardIndex, pileIndex)
+	err := si.Game.PlayerPlay(cardIndex, pileIndex)
 	if err != nil {
-		return si.sp.Output(si.s, err)
+		return si.sp.Output(si.Game, err)
 	}
 	// CPU自動応答ループ
-	if !si.s.GetGameEndFlag() {
-		si.s.CpuPlay()
+	if !si.Game.GetGameEndFlag() {
+		si.Game.CpuPlay()
 	}
 	// フェーズ更新 (膠着判定)
-	si.s.UpdatePhase()
-	return si.sp.Output(si.s, nil)
+	si.Game.UpdatePhase()
+	return si.sp.Output(si.Game, nil)
 }
 
 // Flip 膠着時に台札をめくる
 func (si *SpeedInteractor) Flip() string {
-	if out, blocked := guardGameEnd(si.s, si.sp); blocked {
+	if out, blocked := guardGameEnd(si.Game, si.sp); blocked {
 		return out
 	}
-	err := si.s.Flip()
+	err := si.Game.Flip()
 	if err != nil {
-		return si.sp.Output(si.s, err)
+		return si.sp.Output(si.Game, err)
 	}
 	// フリップ後にCPU自動応答
-	if !si.s.GetGameEndFlag() {
-		si.s.CpuPlay()
-		si.s.UpdatePhase()
+	if !si.Game.GetGameEndFlag() {
+		si.Game.CpuPlay()
+		si.Game.UpdatePhase()
 	}
-	return si.sp.Output(si.s, nil)
+	return si.sp.Output(si.Game, nil)
 }
 
 // Hint ヒントを取得する
 func (si *SpeedInteractor) Hint() string {
-	return si.sp.Output(si.s, nil)
+	return si.sp.Output(si.Game, nil)
 }
 
 // GetConfig 現在の設定を取得
 func (si *SpeedInteractor) GetConfig() domain.SpeedConfig {
-	return si.s.GetConfig()
+	return si.Game.GetConfig()
 }
 
 // ActionLog 棋譜を出力する
 func (si *SpeedInteractor) ActionLog() string {
-	return si.sp.ActionLogOutput(si.s)
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (si *SpeedInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(si.s)
+	return si.sp.ActionLogOutput(si.Game)
 }
 
 // RestoreSpeedInteractor deserialises JSON into a SpeedInteractor.
 func RestoreSpeedInteractor(data []byte, sp presenter.SpeedPresenter) (*SpeedInteractor, error) {
-	s, err := restoreGame[domain.Speed](data)
-	if err != nil {
-		return nil, err
-	}
-	return &SpeedInteractor{s: s, sp: sp}, nil
+	return restoreAndBuild[domain.Speed](data, func(g *domain.Speed) *SpeedInteractor {
+		return &SpeedInteractor{GameBase: GameBase[interfaces.SpeedGame]{Game: g}, sp: sp}
+	})
 }

--- a/internal/usecase/SpeedInteractor.go
+++ b/internal/usecase/SpeedInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // SpeedInteractorIF スピードインタラクターインタフェース
 type SpeedInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// ResetWithConfig 設定を変更してゲーム初期化

--- a/internal/usecase/SpiderInteractor.go
+++ b/internal/usecase/SpiderInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // SpiderInteractorIF スパイダーソリティアインタラクターインタフェース
 type SpiderInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// ResetWithConfig 設定付きリセット

--- a/internal/usecase/SpiderInteractor.go
+++ b/internal/usecase/SpiderInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -34,76 +32,69 @@ type SpiderInteractorIF interface {
 
 // SpiderInteractor スパイダーソリティアインタラクタークラス
 type SpiderInteractor struct {
-	s  interfaces.SpiderGame
+	GameBase[interfaces.SpiderGame]
 	sp presenter.SpiderPresenter
 }
 
 // NewSpiderInteractor コンストラクタ
 func NewSpiderInteractor(s interfaces.SpiderGame, sp presenter.SpiderPresenter) *SpiderInteractor {
 	mustNotNil("SpiderInteractor", map[string]any{"s": s, "sp": sp})
-	return &SpiderInteractor{s: s, sp: sp}
+	return &SpiderInteractor{GameBase: GameBase[interfaces.SpiderGame]{Game: s}, sp: sp}
 }
 
 // Reset ゲーム初期化
 func (si *SpiderInteractor) Reset() string {
-	return runAndPresent(si.s, si.sp, si.s.Reset)
+	return runAndPresent(si.Game, si.sp, si.Game.Reset)
 }
 
 // ResetWithConfig 設定付きリセット
 func (si *SpiderInteractor) ResetWithConfig(cfg domain.SpiderConfig) string {
-	return runAndPresent(si.s, si.sp, func() { si.s.ResetWithConfig(cfg) })
+	return runAndPresent(si.Game, si.sp, func() { si.Game.ResetWithConfig(cfg) })
 }
 
 // Deal ストックからタブローに配る
 func (si *SpiderInteractor) Deal() string {
-	return execAndPresent(si.s, si.sp, si.s.Deal)
+	return execAndPresent(si.Game, si.sp, si.Game.Deal)
 }
 
 // MoveTableauToTableau タブロー間でカードを移動
 func (si *SpiderInteractor) MoveTableauToTableau(fromCol, cardIndex, toCol int) string {
-	return execAndPresent(si.s, si.sp, func() error { return si.s.MoveTableauToTableau(fromCol, cardIndex, toCol) })
+	return execAndPresent(si.Game, si.sp, func() error { return si.Game.MoveTableauToTableau(fromCol, cardIndex, toCol) })
 }
 
 // GiveUp ギブアップ
 func (si *SpiderInteractor) GiveUp() string {
-	return runAndPresent(si.s, si.sp, si.s.GiveUp)
+	return runAndPresent(si.Game, si.sp, si.Game.GiveUp)
 }
 
 // Hint ヒント取得
 func (si *SpiderInteractor) Hint() string {
-	return si.sp.HintOutput(si.s)
+	return si.sp.HintOutput(si.Game)
 }
 
 // AutoComplete オートコンプリート
 func (si *SpiderInteractor) AutoComplete() string {
-	return execAndPresent(si.s, si.sp, si.s.AutoComplete)
+	return execAndPresent(si.Game, si.sp, si.Game.AutoComplete)
 }
 
 // ActionLog 棋譜を出力する
 func (si *SpiderInteractor) ActionLog() string {
-	return si.sp.ActionLogOutput(si.s)
+	return si.sp.ActionLogOutput(si.Game)
 }
 
 // Undo アンドゥ
 func (si *SpiderInteractor) Undo() string {
-	return execAndPresent(si.s, si.sp, si.s.Undo)
+	return execAndPresent(si.Game, si.sp, si.Game.Undo)
 }
 
 // UndoN n回連続アンドゥ
 func (si *SpiderInteractor) UndoN(n int) string {
-	return execAndPresent(si.s, si.sp, func() error { return si.s.UndoN(n) })
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (si *SpiderInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(si.s)
+	return execAndPresent(si.Game, si.sp, func() error { return si.Game.UndoN(n) })
 }
 
 // RestoreSpiderInteractor deserialises JSON into a SpiderInteractor.
 func RestoreSpiderInteractor(data []byte, sp presenter.SpiderPresenter) (*SpiderInteractor, error) {
-	spi, err := restoreGame[domain.Spider](data)
-	if err != nil {
-		return nil, err
-	}
-	return &SpiderInteractor{s: spi, sp: sp}, nil
+	return restoreAndBuild[domain.Spider](data, func(g *domain.Spider) *SpiderInteractor {
+		return &SpiderInteractor{GameBase: GameBase[interfaces.SpiderGame]{Game: g}, sp: sp}
+	})
 }

--- a/internal/usecase/ThreeCardInteractor.go
+++ b/internal/usecase/ThreeCardInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -24,7 +22,7 @@ type ThreeCardInteractorIF interface {
 
 // ThreeCardInteractor スリーカードポーカーインタラクタークラス
 type ThreeCardInteractor struct {
-	tc interfaces.ThreeCardGame
+	GameBase[interfaces.ThreeCardGame]
 	tp presenter.ThreeCardPresenter
 }
 
@@ -32,46 +30,39 @@ type ThreeCardInteractor struct {
 func NewThreeCardInteractor(tc interfaces.ThreeCardGame, tp presenter.ThreeCardPresenter) *ThreeCardInteractor {
 	mustNotNil("ThreeCardInteractor", map[string]any{"tc": tc, "tp": tp})
 	return &ThreeCardInteractor{
-		tc: tc,
-		tp: tp,
+		GameBase: GameBase[interfaces.ThreeCardGame]{Game: tc},
+		tp:       tp,
 	}
 }
 
 // Reset ゲーム初期化
 func (ti *ThreeCardInteractor) Reset() string {
-	return runAndPresent(ti.tc, ti.tp, ti.tc.Reset)
+	return runAndPresent(ti.Game, ti.tp, ti.Game.Reset)
 }
 
 // Bet アンテベット
 func (ti *ThreeCardInteractor) Bet(ante, pairPlus int) string {
-	return execAndPresent(ti.tc, ti.tp, func() error { return ti.tc.Bet(ante, pairPlus) })
+	return execAndPresent(ti.Game, ti.tp, func() error { return ti.Game.Bet(ante, pairPlus) })
 }
 
 // Play プレイ
 func (ti *ThreeCardInteractor) Play() string {
-	return execAndPresent(ti.tc, ti.tp, ti.tc.Play)
+	return execAndPresent(ti.Game, ti.tp, ti.Game.Play)
 }
 
 // Fold フォールド
 func (ti *ThreeCardInteractor) Fold() string {
-	return execAndPresent(ti.tc, ti.tp, ti.tc.Fold)
+	return execAndPresent(ti.Game, ti.tp, ti.Game.Fold)
 }
 
 // ActionLog 棋譜を出力する
 func (ti *ThreeCardInteractor) ActionLog() string {
-	return ti.tp.ActionLogOutput(ti.tc)
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (ti *ThreeCardInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(ti.tc)
+	return ti.tp.ActionLogOutput(ti.Game)
 }
 
 // RestoreThreeCardInteractor deserialises JSON into a ThreeCardInteractor.
 func RestoreThreeCardInteractor(data []byte, tp presenter.ThreeCardPresenter) (*ThreeCardInteractor, error) {
-	tc, err := restoreGame[domain.ThreeCard](data)
-	if err != nil {
-		return nil, err
-	}
-	return &ThreeCardInteractor{tc: tc, tp: tp}, nil
+	return restoreAndBuild[domain.ThreeCard](data, func(g *domain.ThreeCard) *ThreeCardInteractor {
+		return &ThreeCardInteractor{GameBase: GameBase[interfaces.ThreeCardGame]{Game: g}, tp: tp}
+	})
 }

--- a/internal/usecase/ThreeCardInteractor.go
+++ b/internal/usecase/ThreeCardInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // ThreeCardInteractorIF スリーカードポーカーインタラクターインタフェース
 type ThreeCardInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// Bet アンテベット

--- a/internal/usecase/TriPeaksInteractor.go
+++ b/internal/usecase/TriPeaksInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // TriPeaksInteractorIF トリピークスインタラクターインタフェース
 type TriPeaksInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// Draw ストックからウェイストにカードを引く

--- a/internal/usecase/TriPeaksInteractor.go
+++ b/internal/usecase/TriPeaksInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -30,66 +28,59 @@ type TriPeaksInteractorIF interface {
 
 // TriPeaksInteractor トリピークスインタラクタークラス
 type TriPeaksInteractor struct {
-	t  interfaces.TriPeaksGame
+	GameBase[interfaces.TriPeaksGame]
 	tp presenter.TriPeaksPresenter
 }
 
 // NewTriPeaksInteractor コンストラクタ
 func NewTriPeaksInteractor(t interfaces.TriPeaksGame, tp presenter.TriPeaksPresenter) *TriPeaksInteractor {
 	mustNotNil("TriPeaksInteractor", map[string]any{"t": t, "tp": tp})
-	return &TriPeaksInteractor{t: t, tp: tp}
+	return &TriPeaksInteractor{GameBase: GameBase[interfaces.TriPeaksGame]{Game: t}, tp: tp}
 }
 
 // Reset ゲーム初期化
 func (ti *TriPeaksInteractor) Reset() string {
-	return runAndPresent(ti.t, ti.tp, ti.t.Reset)
+	return runAndPresent(ti.Game, ti.tp, ti.Game.Reset)
 }
 
 // Draw ストックからウェイストにカードを引く
 func (ti *TriPeaksInteractor) Draw() string {
-	return execAndPresent(ti.t, ti.tp, ti.t.Draw)
+	return execAndPresent(ti.Game, ti.tp, ti.Game.Draw)
 }
 
 // Remove タブローのカードを除去
 func (ti *TriPeaksInteractor) Remove(row, col int) string {
-	return execAndPresent(ti.t, ti.tp, func() error { return ti.t.Remove(row, col) })
+	return execAndPresent(ti.Game, ti.tp, func() error { return ti.Game.Remove(row, col) })
 }
 
 // GiveUp ギブアップ
 func (ti *TriPeaksInteractor) GiveUp() string {
-	return runAndPresent(ti.t, ti.tp, ti.t.GiveUp)
+	return runAndPresent(ti.Game, ti.tp, ti.Game.GiveUp)
 }
 
 // Hint ヒント取得
 func (ti *TriPeaksInteractor) Hint() string {
-	return ti.tp.HintOutput(ti.t)
+	return ti.tp.HintOutput(ti.Game)
 }
 
 // ActionLog 棋譜を出力する
 func (ti *TriPeaksInteractor) ActionLog() string {
-	return ti.tp.ActionLogOutput(ti.t)
+	return ti.tp.ActionLogOutput(ti.Game)
 }
 
 // Undo アンドゥ
 func (ti *TriPeaksInteractor) Undo() string {
-	return execAndPresent(ti.t, ti.tp, ti.t.Undo)
+	return execAndPresent(ti.Game, ti.tp, ti.Game.Undo)
 }
 
 // UndoN n回連続アンドゥ
 func (ti *TriPeaksInteractor) UndoN(n int) string {
-	return execAndPresent(ti.t, ti.tp, func() error { return ti.t.UndoN(n) })
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (ti *TriPeaksInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(ti.t)
+	return execAndPresent(ti.Game, ti.tp, func() error { return ti.Game.UndoN(n) })
 }
 
 // RestoreTriPeaksInteractor deserialises JSON into a TriPeaksInteractor.
 func RestoreTriPeaksInteractor(data []byte, tp presenter.TriPeaksPresenter) (*TriPeaksInteractor, error) {
-	tripeaks, err := restoreGame[domain.TriPeaks](data)
-	if err != nil {
-		return nil, err
-	}
-	return &TriPeaksInteractor{t: tripeaks, tp: tp}, nil
+	return restoreAndBuild[domain.TriPeaks](data, func(g *domain.TriPeaks) *TriPeaksInteractor {
+		return &TriPeaksInteractor{GameBase: GameBase[interfaces.TriPeaksGame]{Game: g}, tp: tp}
+	})
 }

--- a/internal/usecase/VideoPokerInteractor.go
+++ b/internal/usecase/VideoPokerInteractor.go
@@ -8,6 +8,8 @@ import (
 
 // VideoPokerInteractorIF ビデオポーカーインタラクターインタフェース
 type VideoPokerInteractorIF interface {
+	// Snapshot serialises game state for KV persistence.
+	Snapshot() ([]byte, error)
 	// Reset ゲーム初期化
 	Reset() string
 	// Bet ベット

--- a/internal/usecase/VideoPokerInteractor.go
+++ b/internal/usecase/VideoPokerInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"encoding/json"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -22,7 +20,7 @@ type VideoPokerInteractorIF interface {
 
 // VideoPokerInteractor ビデオポーカーインタラクタークラス
 type VideoPokerInteractor struct {
-	vp  interfaces.VideoPokerGame
+	GameBase[interfaces.VideoPokerGame]
 	vpp presenter.VideoPokerPresenter
 }
 
@@ -30,41 +28,34 @@ type VideoPokerInteractor struct {
 func NewVideoPokerInteractor(vp interfaces.VideoPokerGame, vpp presenter.VideoPokerPresenter) *VideoPokerInteractor {
 	mustNotNil("VideoPokerInteractor", map[string]any{"vp": vp, "vpp": vpp})
 	return &VideoPokerInteractor{
-		vp:  vp,
-		vpp: vpp,
+		GameBase: GameBase[interfaces.VideoPokerGame]{Game: vp},
+		vpp:      vpp,
 	}
 }
 
 // Reset ゲーム初期化
 func (vi *VideoPokerInteractor) Reset() string {
-	return runAndPresent(vi.vp, vi.vpp, vi.vp.Reset)
+	return runAndPresent(vi.Game, vi.vpp, vi.Game.Reset)
 }
 
 // Bet ベット
 func (vi *VideoPokerInteractor) Bet(amount int) string {
-	return execAndPresent(vi.vp, vi.vpp, func() error { return vi.vp.Bet(amount) })
+	return execAndPresent(vi.Game, vi.vpp, func() error { return vi.Game.Bet(amount) })
 }
 
 // Hold ホールド＆ドロー
 func (vi *VideoPokerInteractor) Hold(indices []int) string {
-	return execAndPresent(vi.vp, vi.vpp, func() error { return vi.vp.Hold(indices) })
+	return execAndPresent(vi.Game, vi.vpp, func() error { return vi.Game.Hold(indices) })
 }
 
 // ActionLog 棋譜を出力する
 func (vi *VideoPokerInteractor) ActionLog() string {
-	return vi.vpp.ActionLogOutput(vi.vp)
-}
-
-// Snapshot serialises the game state to JSON for KV persistence.
-func (vi *VideoPokerInteractor) Snapshot() ([]byte, error) {
-	return json.Marshal(vi.vp)
+	return vi.vpp.ActionLogOutput(vi.Game)
 }
 
 // RestoreVideoPokerInteractor deserialises JSON into a VideoPokerInteractor.
 func RestoreVideoPokerInteractor(data []byte, vpp presenter.VideoPokerPresenter) (*VideoPokerInteractor, error) {
-	vp, err := restoreGame[domain.VideoPoker](data)
-	if err != nil {
-		return nil, err
-	}
-	return &VideoPokerInteractor{vp: vp, vpp: vpp}, nil
+	return restoreAndBuild[domain.VideoPoker](data, func(g *domain.VideoPoker) *VideoPokerInteractor {
+		return &VideoPokerInteractor{GameBase: GameBase[interfaces.VideoPokerGame]{Game: g}, vpp: vpp}
+	})
 }

--- a/internal/usecase/interactor_base.go
+++ b/internal/usecase/interactor_base.go
@@ -1,0 +1,24 @@
+package usecase
+
+import "encoding/json"
+
+// GameBase provides common functionality for all game interactors.
+// Embed this struct to inherit the Snapshot method.
+type GameBase[G any] struct {
+	Game G
+}
+
+// Snapshot serialises the game state to JSON for KV persistence.
+func (b *GameBase[G]) Snapshot() ([]byte, error) {
+	return json.Marshal(b.Game)
+}
+
+// restoreAndBuild deserialises JSON into a domain struct and passes it to a
+// builder function that constructs the interactor.
+func restoreAndBuild[D any, I any](data []byte, build func(*D) *I) (*I, error) {
+	g, err := restoreGame[D](data)
+	if err != nil {
+		return nil, err
+	}
+	return build(g), nil
+}


### PR DESCRIPTION
## Summary

- **#1224 Worker registration**: Extract shared `RegisterKV` to `internal/infrastructure/worker/` package, eliminating 3× duplicated `registerKV` function and 35+ `newCtrl` closure wrappers by accepting controller constructors directly via generics
- **#1225 Interactor generics**: Create `GameBase[G]` with embedded `Snapshot()` and `restoreAndBuild` helper, reducing 37 Interactor files by removing identical Snapshot methods, json imports, and Restore boilerplate
- **#1226 gameApi.ts factories**: Create `createHoldemLikeApi`, `createBidPlayApi`, `createVideoPokerApi` factory functions to consolidate games with identical exec signatures; remove redundant type aliases
- **#1227 i18n auto-import**: Replace 86 manual locale imports with Vite `import.meta.glob` in both `i18n/index.ts` and `test/setup.ts` for automatic namespace discovery

**Net reduction: ~920 lines** (2044 deletions, 1126 insertions across 48 files)

Closes #1224, closes #1225, closes #1226, closes #1227

## Test plan

- [x] `go build ./...` passes
- [x] `go test -tags test ./...` passes (all Go tests)
- [x] `GOOS=js GOARCH=wasm go build` passes for all 3 workers (casino, classic, solo)
- [x] `golangci-lint run` passes with 0 issues
- [x] `bun run build` passes (frontend)
- [x] `bun run check` passes (biome lint)
- [x] `bun run test` passes (4552/4561 tests pass; 9 timeouts are pre-existing flaky tests on 2GB RAM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)