### PR TITLE
fix: use correct i18n key for pigtail action log button

### DIFF
--- a/frontend/src/pages/PigsTailPage.tsx
+++ b/frontend/src/pages/PigsTailPage.tsx
@@ -241,7 +241,7 @@ function PigsTailPageContent() {
                 className="px-4 py-2 rounded-lg bg-gray-600 hover:bg-gray-500 text-white text-sm transition-colors"
                 onClick={showActionLog}
               >
-                {tc('button.log')}
+                {tc('actionLog.view')}
               </button>
             </div>
           </GameFooter>


### PR DESCRIPTION
## Summary
- Replace non-existent `button.log` i18n key with `actionLog.view` in PigsTailPage
- The button label was showing raw key text "button.log" instead of "棋譜を見る" / "View Action Log"
- Uses the same `actionLog.view` key that all other game pages use for this button

Closes #1235

## Test plan
- [x] PigsTail unit tests pass (11/11)
- [x] Biome lint/format check passes
- [ ] Verify on mobile (375x667) that the button now shows "棋譜を見る"