### PR TITLE
docs: fix PigsTail phase type drift in UML diagrams

### DIFF
--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -798,13 +798,12 @@ classDiagram
     class PigsTail {
         -trumpCards *TrumpCards
         -players []*PigsTailPlayer
-        -circlePile []*Card
-        -centerPile []*Card
-        -phase PigsTailPhase
+        -center []*Card
         -currentTurn int
+        -gameEndFlag bool
         +Reset()
         +Draw() error
-        +Phase() PigsTailPhase
+        +GetGameEndFlag() bool
         +ActionLog() []*ActionLogEntry
     }
 
@@ -2079,8 +2078,8 @@ stateDiagram-v2
     Play --> GameEnd : 山札が空
     GameEnd --> [*]
 
-    note right of Play : PigsTailPhasePlay = 0
-    note right of GameEnd : PigsTailPhaseGameEnd = 1
+    note right of Play : gameEndFlag = false
+    note right of GameEnd : gameEndFlag = true
 ```
 
 ### 3.27 SevenCardStud フェーズ遷移

--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -468,8 +468,8 @@ classDiagram
 
     class PigsTailPhase {
         <<enumeration>>
-        PLAY = 0
-        GAME_END = 1
+        PIGTAIL_PHASE_PLAY = 0
+        PIGTAIL_PHASE_END = 1
     }
 
     class CribbagePhase {

--- a/frontend/src/types/phases.ts
+++ b/frontend/src/types/phases.ts
@@ -29,7 +29,7 @@
  *   - VideoPoker:  internal/domain/VideoPoker.go  (VideoPokerPhaseBet, VideoPokerPhaseDraw, VideoPokerPhaseResult)
  *   - Pinochle:    internal/domain/Pinochle.go    (PinochlePhaseBid, PinochlePhaseTrump, PinochlePhaseMeld, PinochlePhasePlay, PinochlePhaseTrickEnd, PinochlePhaseRoundEnd, PinochlePhaseGameEnd)
  *   - Golf:        internal/domain/Golf.go        (GolfPhasePlaying, GolfPhaseGameClear, GolfPhaseGameOver)
- *   - PigsTail:    internal/domain/PigsTail.go    (PigsTailPhasePlaying, PigsTailPhaseGameOver)
+ *   - PigsTail:    internal/domain/PigsTail.go    (gameEndFlag bool; local constants PIGTAIL_PHASE_PLAY/END in PigsTailPage.tsx)
  *   - SevenCardStud: internal/domain/SevenCardStud.go (SevenCardStudPhaseInit, SevenCardStudPhaseThirdStreet, ..., SevenCardStudPhaseEnd, SevenCardStudPhaseRebuy)
  *   - ClockSolitaire: internal/domain/ClockSolitaire.go (ClockSolitairePhasePlaying, ClockSolitairePhaseGameClear, ClockSolitairePhaseGameOver)
  */


### PR DESCRIPTION
## Summary
- Fix PigsTail class diagram in `docs/design/backend.md` to use `gameEndFlag bool` + `GetGameEndFlag()` instead of non-existent `PigsTailPhase` type
- Fix state machine notes in `docs/design/backend.md` to reference `gameEndFlag` instead of `PigsTailPhasePlay`/`PigsTailPhaseGameEnd`
- Fix frontend phase enum in `docs/design/frontend.md` to use actual constant names (`PIGTAIL_PHASE_PLAY`/`PIGTAIL_PHASE_END`)
- Fix comment in `frontend/src/types/phases.ts` to accurately describe PigsTail's phase mechanism

Closes #1240

## Test plan
- [ ] Verify Mermaid diagrams render correctly in GitHub
- [ ] Confirm no other references to `PigsTailPhase` remain in docs