### PR TITLE
fix: use 4-column grid on mobile for Memory tap targets

### DIFF
--- a/frontend/src/pages/MemoryPage.test.tsx
+++ b/frontend/src/pages/MemoryPage.test.tsx
@@ -448,11 +448,18 @@ describe('MemoryPage', () => {
     expect(faceUpBtn).toHaveAttribute('aria-label', '♠ 3');
   });
 
-  it('board grid uses 6-column layout on mobile', async () => {
+  it('board grid uses 4-column layout on mobile for adequate tap targets', async () => {
     renderWithProviders(<MemoryPage />);
     await waitFor(() => expect(screen.getByText(/あなた: 0/)).toBeInTheDocument());
     const boardGrid = screen.getByTestId('board-0').parentElement;
-    expect(boardGrid).toHaveClass('grid-cols-6');
+    expect(boardGrid).toHaveClass('grid-cols-4');
+  });
+
+  it('card buttons have min-h-[44px] for WCAG tap target compliance', async () => {
+    renderWithProviders(<MemoryPage />);
+    await waitFor(() => expect(screen.getByText(/あなた: 0/)).toBeInTheDocument());
+    const cardBtn = screen.getByTestId('board-0');
+    expect(cardBtn.className).toContain('min-h-[44px]');
   });
 
   it('face-down cards have subtle border instead of thick blue border', async () => {

--- a/frontend/src/pages/MemoryPage.test.tsx
+++ b/frontend/src/pages/MemoryPage.test.tsx
@@ -455,11 +455,12 @@ describe('MemoryPage', () => {
     expect(boardGrid).toHaveClass('grid-cols-4');
   });
 
-  it('card buttons have min-h-[44px] for WCAG tap target compliance', async () => {
+  it('card buttons have min-h-[44px] and min-w-[44px] for WCAG tap target compliance', async () => {
     renderWithProviders(<MemoryPage />);
     await waitFor(() => expect(screen.getByText(/あなた: 0/)).toBeInTheDocument());
     const cardBtn = screen.getByTestId('board-0');
     expect(cardBtn.className).toContain('min-h-[44px]');
+    expect(cardBtn.className).toContain('min-w-[44px]');
   });
 
   it('face-down cards have subtle border instead of thick blue border', async () => {

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -201,7 +201,7 @@ function MemoryPageContent() {
               className="my-3 lg:my-1 p-2 lg:p-1 rounded bg-black/40 lg:flex-1 lg:min-h-0 lg:overflow-hidden"
               data-tutorial="mem-board"
             >
-              <div className="grid grid-cols-6 md:grid-cols-8 lg:grid-cols-13 gap-0.5 md:gap-1 lg:grid-rows-4 lg:h-full">
+              <div className="grid grid-cols-4 gap-1 sm:grid-cols-6 sm:gap-0.5 md:grid-cols-8 md:gap-1 lg:grid-cols-13 lg:grid-rows-4 lg:h-full">
                 {state.board.map((bc, idx) => (
                   <button
                     type="button"
@@ -210,7 +210,7 @@ function MemoryPageContent() {
                     aria-label={bc.faceUp && bc.card ? cardAlt(bc.card) : t('cardFaceDown', { position: idx + 1 })}
                     disabled={loading || !isHumanTurn || bc.taken || bc.faceUp}
                     onClick={() => handleFlip(idx)}
-                    className={`memory-card relative aspect-[2/3] lg:aspect-auto rounded ${focusRingWhite} ${
+                    className={`memory-card relative aspect-[2/3] min-h-[44px] lg:aspect-auto rounded ${focusRingWhite} ${
                       bc.taken
                         ? 'hidden'
                         : bc.faceUp

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -201,7 +201,7 @@ function MemoryPageContent() {
               className="my-3 lg:my-1 p-2 lg:p-1 rounded bg-black/40 lg:flex-1 lg:min-h-0 lg:overflow-hidden"
               data-tutorial="mem-board"
             >
-              <div className="grid grid-cols-4 gap-1 sm:grid-cols-6 sm:gap-0.5 md:grid-cols-8 md:gap-1 lg:grid-cols-13 lg:grid-rows-4 lg:h-full">
+              <div className="grid grid-cols-4 gap-1 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-13 lg:grid-rows-4 lg:h-full">
                 {state.board.map((bc, idx) => (
                   <button
                     type="button"
@@ -210,7 +210,7 @@ function MemoryPageContent() {
                     aria-label={bc.faceUp && bc.card ? cardAlt(bc.card) : t('cardFaceDown', { position: idx + 1 })}
                     disabled={loading || !isHumanTurn || bc.taken || bc.faceUp}
                     onClick={() => handleFlip(idx)}
-                    className={`memory-card relative aspect-[2/3] min-h-[44px] lg:aspect-auto rounded ${focusRingWhite} ${
+                    className={`memory-card relative aspect-[2/3] min-h-[44px] min-w-[44px] lg:aspect-auto rounded ${focusRingWhite} ${
                       bc.taken
                         ? 'hidden'
                         : bc.faceUp


### PR DESCRIPTION
## Summary
- On mobile viewports (<640px), reduce Memory board grid from 6 to 4 columns for larger, easier-to-tap cards
- Add `min-h-[44px]` to card buttons to guarantee WCAG tap target compliance (44x44px)
- Increase mobile gap from `gap-0.5` to `gap-1` for better card separation

Closes #1246

## Test plan
- [x] Unit tests updated (grid class assertion, min-height assertion)
- [ ] Manual test on 375x667 viewport: cards are large enough to tap accurately
- [ ] Verify no layout regression on tablet (640px+) and desktop (1024px+)