### PR TITLE
fix: improve Speed stuck state UX with pulse animation

### DIFF
--- a/frontend/src/pages/SpeedPage.test.tsx
+++ b/frontend/src/pages/SpeedPage.test.tsx
@@ -108,11 +108,11 @@ describe('SpeedPage', () => {
     await waitFor(() => expect(screen.getByText('めくる')).toBeInTheDocument());
   });
 
-  it('calls flip on button click', async () => {
+  it('calls flip on flip button click', async () => {
     mockExec.mockResolvedValue(stuckState);
     renderWithProviders(<SpeedPage />);
-    await waitFor(() => expect(screen.getByText('めくる')).toBeInTheDocument());
-    fireEvent.click(screen.getByRole('button', { name: 'めくる' }));
+    await waitFor(() => expect(screen.getByTestId('flip-button')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('flip-button'));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('flip'));
   });
 
@@ -209,5 +209,35 @@ describe('SpeedPage', () => {
     mockExec.mockResolvedValue(stuckState);
     renderWithProviders(<SpeedPage />);
     await waitFor(() => expect(screen.getByText('膠着')).toBeInTheDocument());
+  });
+
+  it('flip button has pulse animation when stuck', async () => {
+    mockExec.mockResolvedValue(stuckState);
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByTestId('flip-button')).toBeInTheDocument());
+    expect(screen.getByTestId('flip-button')).toHaveClass('animate-pulse');
+  });
+
+  it('center piles trigger flip when stuck', async () => {
+    mockExec.mockResolvedValue(stuckState);
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByText('めくる')).toBeInTheDocument());
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(playState);
+    // Center pile buttons should have flip aria-label when stuck
+    const flipPileBtns = screen.getAllByRole('button', { name: 'めくる' });
+    // There should be center piles + the flip button = 3 buttons with 'めくる' label
+    expect(flipPileBtns.length).toBeGreaterThanOrEqual(2);
+    fireEvent.click(flipPileBtns[0]);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('flip'));
+  });
+
+  it('center piles have pulse animation when stuck', async () => {
+    mockExec.mockResolvedValue(stuckState);
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByText('めくる')).toBeInTheDocument());
+    const flipPileBtns = screen.getAllByRole('button', { name: 'めくる' });
+    // Center pile buttons (first two) should have animate-pulse
+    expect(flipPileBtns[0]).toHaveClass('animate-pulse');
   });
 });

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -149,7 +149,7 @@ function SpeedPageContent() {
                   key={pi}
                   onClick={isStuck ? handleFlip : () => handlePlay(pi)}
                   disabled={isStuck ? loading : !isPlayPhase || selectedCardIndices.length !== 1 || loading}
-                  className={`transition-transform hover:scale-105 disabled:opacity-50 ${focusRingCard}${isStuck ? ' animate-pulse cursor-pointer' : ''}`}
+                  className={`transition-transform hover:scale-105 disabled:opacity-50 ${focusRingCard}${isStuck && !loading ? ' animate-pulse cursor-pointer' : ''}`}
                   aria-label={isStuck ? t('flipButton') : `${t('centerPile')} ${pi}`}
                 >
                   {card && (
@@ -201,7 +201,7 @@ function SpeedPageContent() {
                   type="button"
                   onClick={handleFlip}
                   disabled={loading}
-                  className="px-4 py-2 bg-amber-500 text-white rounded hover:bg-amber-600 disabled:opacity-50 animate-pulse ring-2 ring-amber-300"
+                  className={"px-4 py-2 bg-amber-500 text-white rounded hover:bg-amber-600 disabled:opacity-50 ring-2 ring-amber-300" + (!loading ? " animate-pulse" : "")}
                   data-testid="flip-button"
                 >
                   {t('flipButton')}

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -141,16 +141,16 @@ function SpeedPageContent() {
               </span>
             </div>
 
-            {/* Center piles */}
+            {/* Center piles — clickable for play (normal) or flip (stuck) */}
             <div className="flex items-center justify-center gap-6" data-tutorial="sp-center-piles">
               {state.centerPiles.map((card, pi) => (
                 <button
                   type="button"
                   key={pi}
-                  onClick={() => handlePlay(pi)}
-                  disabled={!isPlayPhase || selectedCardIndices.length !== 1 || loading}
-                  className={`transition-transform hover:scale-105 disabled:opacity-50 ${focusRingCard}`}
-                  aria-label={`${t('centerPile')} ${pi}`}
+                  onClick={isStuck ? handleFlip : () => handlePlay(pi)}
+                  disabled={isStuck ? loading : !isPlayPhase || selectedCardIndices.length !== 1 || loading}
+                  className={`transition-transform hover:scale-105 disabled:opacity-50 ${focusRingCard}${isStuck ? ' animate-pulse cursor-pointer' : ''}`}
+                  aria-label={isStuck ? t('flipButton') : `${t('centerPile')} ${pi}`}
                 >
                   {card && (
                     <AnimatedCard
@@ -201,7 +201,8 @@ function SpeedPageContent() {
                   type="button"
                   onClick={handleFlip}
                   disabled={loading}
-                  className="px-4 py-2 bg-amber-500 text-white rounded hover:bg-amber-600 disabled:opacity-50"
+                  className="px-4 py-2 bg-amber-500 text-white rounded hover:bg-amber-600 disabled:opacity-50 animate-pulse ring-2 ring-amber-300"
+                  data-testid="flip-button"
                 >
                   {t('flipButton')}
                 </button>


### PR DESCRIPTION
## Summary
- Add `animate-pulse` and ring highlight to the flip button when stuck phase is active
- Make center pile cards clickable during stuck state to trigger flip (reduces cognitive load)
- Center piles show pulse animation and update aria-label to "めくる" when stuck

Closes #1244

## Test plan
- [x] 22 unit tests pass (18 existing + 4 new stuck UX tests)
- [ ] Manual test: verify flip button pulses when stuck
- [ ] Manual test: verify clicking center piles triggers flip when stuck
- [ ] Verify play phase is unaffected (center piles still accept card plays)