### PR TITLE
feat: add batch undo escape button for solitaire stalemates

### DIFF
--- a/frontend/src/api/gameApi.test.ts
+++ b/frontend/src/api/gameApi.test.ts
@@ -7,6 +7,7 @@ import {
   daifugoApi,
   doubtApi,
   ginrummyApi,
+  golfApi,
   heartsApi,
   holdemApi,
   indianpokerApi,
@@ -15,10 +16,12 @@ import {
   oldmaidApi,
   omahaApi,
   pokerApi,
+  pyramidApi,
   sessionId,
   sevensApi,
   spadesApi,
   spiderApi,
+  tripeaksApi,
 } from './gameApi';
 
 describe('gameApi', () => {
@@ -2795,6 +2798,111 @@ describe('gameApi', () => {
           sessionId,
         }),
       });
+    });
+  });
+
+  describe('pyramidApi.exec', () => {
+    const payload = {
+      pyramid: [],
+      stockCount: 20,
+      waste: [],
+      phase: 0,
+      moveCount: 0,
+      canUndo: false,
+      isStalemate: false,
+      message: '',
+    };
+
+    it('calls with reset command', async () => {
+      mockFetch.mockReturnValue(makeResponse(payload));
+      const result = await pyramidApi.exec('reset');
+      expect(mockFetch).toHaveBeenCalledWith('/pyramid/exec', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: 'reset', card1: undefined, card2: undefined, n: undefined, sessionId }),
+      });
+      expect(result).toEqual(payload);
+    });
+
+    it('calls with undo_n command and n value', async () => {
+      mockFetch.mockReturnValue(makeResponse(payload));
+      await pyramidApi.exec('undo_n', undefined, undefined, 3);
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/pyramid/exec',
+        expect.objectContaining({
+          body: JSON.stringify({ command: 'undo_n', card1: undefined, card2: undefined, n: 3, sessionId }),
+        }),
+      );
+    });
+  });
+
+  describe('tripeaksApi.exec', () => {
+    const payload = {
+      layout: [],
+      stockCount: 20,
+      waste: [],
+      phase: 0,
+      moveCount: 0,
+      canUndo: false,
+      isStalemate: false,
+      message: '',
+    };
+
+    it('calls with reset command', async () => {
+      mockFetch.mockReturnValue(makeResponse(payload));
+      const result = await tripeaksApi.exec('reset');
+      expect(mockFetch).toHaveBeenCalledWith('/tripeaks/exec', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: 'reset', row: undefined, col: undefined, n: undefined, sessionId }),
+      });
+      expect(result).toEqual(payload);
+    });
+
+    it('calls with undo_n command and n value', async () => {
+      mockFetch.mockReturnValue(makeResponse(payload));
+      await tripeaksApi.exec('undo_n', undefined, undefined, 5);
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/tripeaks/exec',
+        expect.objectContaining({
+          body: JSON.stringify({ command: 'undo_n', row: undefined, col: undefined, n: 5, sessionId }),
+        }),
+      );
+    });
+  });
+
+  describe('golfApi.exec', () => {
+    const payload = {
+      layout: [],
+      stockCount: 20,
+      waste: [],
+      phase: 0,
+      moveCount: 0,
+      canUndo: false,
+      isStalemate: false,
+      message: '',
+    };
+
+    it('calls with reset command', async () => {
+      mockFetch.mockReturnValue(makeResponse(payload));
+      const result = await golfApi.exec('reset');
+      expect(mockFetch).toHaveBeenCalledWith('/golf/exec', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: 'reset', col: undefined, n: undefined, sessionId }),
+      });
+      expect(result).toEqual(payload);
+    });
+
+    it('calls with undo_n command and n value', async () => {
+      mockFetch.mockReturnValue(makeResponse(payload));
+      await golfApi.exec('undo_n', undefined, 4);
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/golf/exec',
+        expect.objectContaining({
+          body: JSON.stringify({ command: 'undo_n', col: undefined, n: 4, sessionId }),
+        }),
+      );
     });
   });
 });

--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -453,16 +453,18 @@ export interface KlondikeConfigInput {
 /** API client for the Klondike /klondike/exec endpoint. */
 export const klondikeApi = {
   exec: (
-    command: 'reset' | 'draw' | 'move' | 'giveup' | 'hint' | 'autocomplete' | 'log' | 'undo',
+    command: 'reset' | 'draw' | 'move' | 'giveup' | 'hint' | 'autocomplete' | 'log' | 'undo' | 'undo_n',
     from?: KlondikeMoveZone,
     to?: KlondikeMoveZone,
     config?: KlondikeConfigInput,
+    n?: number,
   ) =>
     gameExec<KlondikeResponse>('klondike', {
       command,
       from,
       to,
       config,
+      n,
     }),
 };
 
@@ -477,14 +479,16 @@ export interface FreeCellMoveZone {
 /** API client for the FreeCell /freecell/exec endpoint. */
 export const freecellApi = {
   exec: (
-    command: 'reset' | 'move' | 'giveup' | 'hint' | 'autocomplete' | 'log' | 'undo',
+    command: 'reset' | 'move' | 'giveup' | 'hint' | 'autocomplete' | 'log' | 'undo' | 'undo_n',
     from?: FreeCellMoveZone,
     to?: FreeCellMoveZone,
+    n?: number,
   ) =>
     gameExec<FreeCellResponse>('freecell', {
       command,
       from,
       to,
+      n,
     }),
 };
 
@@ -634,16 +638,18 @@ export interface SpiderConfigInput {
 /** API client for the Spider /spider/exec endpoint. */
 export const spiderApi = {
   exec: (
-    command: 'reset' | 'deal' | 'move' | 'giveup' | 'hint' | 'autocomplete' | 'log' | 'undo',
+    command: 'reset' | 'deal' | 'move' | 'giveup' | 'hint' | 'autocomplete' | 'log' | 'undo' | 'undo_n',
     from?: SpiderMoveZone,
     to?: SpiderMoveZone,
     config?: SpiderConfigInput,
+    n?: number,
   ) =>
     gameExec<SpiderResponse>('spider', {
       command,
       from,
       to,
       config,
+      n,
     }),
 };
 
@@ -774,16 +780,21 @@ export interface PyramidRemoveCard {
 /** API client for the Pyramid /pyramid/exec endpoint. */
 export const pyramidApi = {
   exec: (
-    command: 'reset' | 'draw' | 'remove' | 'giveup' | 'hint' | 'log' | 'undo',
+    command: 'reset' | 'draw' | 'remove' | 'giveup' | 'hint' | 'log' | 'undo' | 'undo_n',
     card1?: PyramidRemoveCard,
     card2?: PyramidRemoveCard,
-  ) => gameExec<PyramidResponse>('pyramid', { command, card1, card2 }),
+    n?: number,
+  ) => gameExec<PyramidResponse>('pyramid', { command, card1, card2, n }),
 };
 
 /** API client for the TriPeaks /tripeaks/exec endpoint. */
 export const tripeaksApi = {
-  exec: (command: 'reset' | 'draw' | 'remove' | 'giveup' | 'hint' | 'log' | 'undo', row?: number, col?: number) =>
-    gameExec<TriPeaksResponse>('tripeaks', { command, row, col }),
+  exec: (
+    command: 'reset' | 'draw' | 'remove' | 'giveup' | 'hint' | 'log' | 'undo' | 'undo_n',
+    row?: number,
+    col?: number,
+    n?: number,
+  ) => gameExec<TriPeaksResponse>('tripeaks', { command, row, col, n }),
 };
 
 /** Factory for video poker variant APIs that share the same exec pattern. */
@@ -826,8 +837,11 @@ export const goFishApi = {
 
 /** API client for the Golf Solitaire /golf/exec endpoint. */
 export const golfApi = {
-  exec: (command: 'reset' | 'draw' | 'remove' | 'giveup' | 'hint' | 'log' | 'undo', col?: number) =>
-    gameExec<GolfResponse>('golf', { command, col }),
+  exec: (
+    command: 'reset' | 'draw' | 'remove' | 'giveup' | 'hint' | 'log' | 'undo' | 'undo_n',
+    col?: number,
+    n?: number,
+  ) => gameExec<GolfResponse>('golf', { command, col, n }),
 };
 
 /** Pig's Tail game API client. */

--- a/frontend/src/components/StalemateEscapeButton.test.tsx
+++ b/frontend/src/components/StalemateEscapeButton.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { StalemateEscapeButton } from './StalemateEscapeButton';
+
+describe('StalemateEscapeButton', () => {
+  it('renders nothing when undoToEscape is 0', () => {
+    const { container } = render(<StalemateEscapeButton undoToEscape={0} onEscape={vi.fn()} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders button with undo count when undoToEscape > 0', () => {
+    render(<StalemateEscapeButton undoToEscape={5} onEscape={vi.fn()} />);
+    expect(screen.getByTestId('stalemate-escape-button')).toHaveTextContent('脱出する (5手戻る)');
+  });
+
+  it('calls onEscape with undoToEscape count on click', () => {
+    const onEscape = vi.fn();
+    render(<StalemateEscapeButton undoToEscape={3} onEscape={onEscape} />);
+    fireEvent.click(screen.getByTestId('stalemate-escape-button'));
+    expect(onEscape).toHaveBeenCalledWith(3);
+  });
+
+  it('button is disabled when disabled prop is true', () => {
+    render(<StalemateEscapeButton undoToEscape={5} onEscape={vi.fn()} disabled />);
+    expect(screen.getByTestId('stalemate-escape-button')).toBeDisabled();
+  });
+
+  it('button has animate-pulse class', () => {
+    render(<StalemateEscapeButton undoToEscape={5} onEscape={vi.fn()} />);
+    expect(screen.getByTestId('stalemate-escape-button')).toHaveClass('animate-pulse');
+  });
+});

--- a/frontend/src/components/StalemateEscapeButton.test.tsx
+++ b/frontend/src/components/StalemateEscapeButton.test.tsx
@@ -10,7 +10,7 @@ describe('StalemateEscapeButton', () => {
 
   it('renders button with undo count when undoToEscape > 0', () => {
     render(<StalemateEscapeButton undoToEscape={5} onEscape={vi.fn()} />);
-    expect(screen.getByTestId('stalemate-escape-button')).toHaveTextContent('脱出する (5手戻る)');
+    expect(screen.getByTestId('stalemate-escape-button')).toHaveTextContent('5');
   });
 
   it('calls onEscape with undoToEscape count on click', () => {

--- a/frontend/src/components/StalemateEscapeButton.tsx
+++ b/frontend/src/components/StalemateEscapeButton.tsx
@@ -12,6 +12,9 @@ export interface StalemateEscapeButtonProps {
 export function StalemateEscapeButton({ undoToEscape, onEscape, disabled }: StalemateEscapeButtonProps) {
   const { t } = useTranslation('common');
 
+  // Guard: callers gate on state.isStalemate, but undoToEscape may be 0 or
+  // undefined (coerced via ?? 0) if the server omits it. Render nothing in
+  // that case rather than showing a broken button.
   if (undoToEscape <= 0) return null;
 
   return (

--- a/frontend/src/components/StalemateEscapeButton.tsx
+++ b/frontend/src/components/StalemateEscapeButton.tsx
@@ -1,0 +1,28 @@
+import { useTranslation } from 'react-i18next';
+import { btnWarning } from '../styles/buttonStyles';
+
+/** Props for the StalemateEscapeButton component. */
+export interface StalemateEscapeButtonProps {
+  undoToEscape: number;
+  onEscape: (n: number) => void;
+  disabled?: boolean;
+}
+
+/** Renders a button to batch-undo moves and escape a stalemate in solitaire games. */
+export function StalemateEscapeButton({ undoToEscape, onEscape, disabled }: StalemateEscapeButtonProps) {
+  const { t } = useTranslation('common');
+
+  if (undoToEscape <= 0) return null;
+
+  return (
+    <button
+      type="button"
+      className={`${btnWarning} animate-pulse`}
+      onClick={() => onEscape(undoToEscape)}
+      disabled={disabled}
+      data-testid="stalemate-escape-button"
+    >
+      {t('stalemateEscape', { count: undoToEscape })}
+    </button>
+  );
+}

--- a/frontend/src/hooks/useFreeCellGame.test.ts
+++ b/frontend/src/hooks/useFreeCellGame.test.ts
@@ -224,6 +224,19 @@ describe('useFreeCellGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo'));
   });
 
+  it('handleUndoEscape dispatches undo_n with count', async () => {
+    const { result } = renderHook(() => useFreeCellGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(defaultState);
+    act(() => {
+      result.current.handleUndoEscape(4);
+    });
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo_n', undefined, undefined, 4));
+  });
+
   it('handleSelectSource sets selectedSource', async () => {
     const { result } = renderHook(() => useFreeCellGame(), { wrapper: createWrapper() });
     await waitFor(() => expect(result.current.state).not.toBeNull());

--- a/frontend/src/hooks/useFreeCellGame.ts
+++ b/frontend/src/hooks/useFreeCellGame.ts
@@ -54,6 +54,16 @@ export function useFreeCellGame() {
     callExec('undo');
   }, [callExec]);
 
+  /** Undo N moves at once to escape a stalemate. */
+  const handleUndoEscape = useCallback(
+    (n: number) => {
+      setSelectedSource(null);
+      setHint(null);
+      callExec('undo_n', undefined, undefined, n);
+    },
+    [callExec],
+  );
+
   const handleSelectSource = useCallback((zone: FreeCellMoveZone) => {
     setSelectedSource((prev) => {
       if (
@@ -92,6 +102,7 @@ export function useFreeCellGame() {
     handleHint,
     handleAutoComplete,
     handleUndo,
+    handleUndoEscape,
     handleSelectSource,
     handleSelectTarget,
     isAutoCompleting,

--- a/frontend/src/hooks/useGolfGame.test.ts
+++ b/frontend/src/hooks/useGolfGame.test.ts
@@ -97,6 +97,19 @@ describe('useGolfGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo'));
   });
 
+  it('handleUndoEscape dispatches undo_n with count', async () => {
+    const { result } = renderHook(() => useGolfGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(defaultState);
+    act(() => {
+      result.current.handleUndoEscape(6);
+    });
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo_n', undefined, 6));
+  });
+
   it('handleSelectCard dispatches remove command with col', async () => {
     const { result } = renderHook(() => useGolfGame(), { wrapper: createWrapper() });
     await waitFor(() => expect(result.current.state).not.toBeNull());

--- a/frontend/src/hooks/useGolfGame.ts
+++ b/frontend/src/hooks/useGolfGame.ts
@@ -44,6 +44,15 @@ export function useGolfGame() {
     exec('undo');
   }, [exec]);
 
+  /** Batch undo to escape stalemate. */
+  const handleUndoEscape = useCallback(
+    (n: number) => {
+      setHint(null);
+      exec('undo_n', undefined, n);
+    },
+    [exec],
+  );
+
   const handleSelectCard = useCallback(
     (col: number) => {
       setHint(null);
@@ -64,6 +73,7 @@ export function useGolfGame() {
     handleGiveUp,
     handleHint,
     handleUndo,
+    handleUndoEscape,
     handleSelectCard,
     retry,
   };

--- a/frontend/src/hooks/useKlondikeGame.test.ts
+++ b/frontend/src/hooks/useKlondikeGame.test.ts
@@ -265,6 +265,19 @@ describe('useKlondikeGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo'));
   });
 
+  it('handleUndoEscape dispatches undo_n with count', async () => {
+    const { result } = renderHook(() => useKlondikeGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(defaultState);
+    act(() => {
+      result.current.handleUndoEscape(5);
+    });
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo_n', undefined, undefined, undefined, 5));
+  });
+
   it('handleResetWithConfig dispatches reset with config', async () => {
     const { result } = renderHook(() => useKlondikeGame(), { wrapper: createWrapper() });
     await waitFor(() => expect(result.current.state).not.toBeNull());

--- a/frontend/src/hooks/useKlondikeGame.ts
+++ b/frontend/src/hooks/useKlondikeGame.ts
@@ -69,6 +69,16 @@ export function useKlondikeGame() {
     exec('undo');
   }, [exec]);
 
+  /** Undo N moves at once to escape a stalemate. */
+  const handleUndoEscape = useCallback(
+    (n: number) => {
+      setSelectedSource(null);
+      setHint(null);
+      exec('undo_n', undefined, undefined, undefined, n);
+    },
+    [exec],
+  );
+
   const handleSelectSource = useCallback((zone: KlondikeMoveZone) => {
     setSelectedSource((prev) => {
       if (prev && prev.zone === zone.zone && prev.col === zone.col && prev.cardIndex === zone.cardIndex) {
@@ -103,6 +113,7 @@ export function useKlondikeGame() {
     handleHint,
     handleAutoComplete,
     handleUndo,
+    handleUndoEscape,
     handleSelectSource,
     handleSelectTarget,
     isAutoCompleting,

--- a/frontend/src/hooks/usePyramidGame.test.ts
+++ b/frontend/src/hooks/usePyramidGame.test.ts
@@ -1,0 +1,156 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { pyramidApi } from '../api/gameApi';
+import type { PyramidResponse } from '../types/card';
+import { usePyramidGame } from './usePyramidGame';
+
+vi.mock('../api/gameApi', () => ({
+  pyramidApi: { exec: vi.fn() },
+}));
+
+const mockExec = vi.mocked(pyramidApi.exec);
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+const defaultState: PyramidResponse = {
+  pyramid: [[{ card: null, removed: false, exposed: false }]],
+  stockCount: 20,
+  waste: [],
+  phase: 0,
+  moveCount: 0,
+  canUndo: false,
+  isStalemate: false,
+  message: '',
+};
+
+beforeEach(() => {
+  mockExec.mockResolvedValue(defaultState);
+});
+
+describe('usePyramidGame', () => {
+  it('calls reset on mount', async () => {
+    renderHook(() => usePyramidGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+  });
+
+  it('returns initial state after mount', async () => {
+    const { result } = renderHook(() => usePyramidGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).toEqual(defaultState));
+  });
+
+  it('handleDraw dispatches draw and clears hint', async () => {
+    const { result } = renderHook(() => usePyramidGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(defaultState);
+    act(() => {
+      result.current.handleDraw();
+    });
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw'));
+    expect(result.current.hint).toBeNull();
+  });
+
+  it('handleReset dispatches reset and clears hint', async () => {
+    const { result } = renderHook(() => usePyramidGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(defaultState);
+    act(() => {
+      result.current.handleReset();
+    });
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(result.current.hint).toBeNull();
+  });
+
+  it('handleGiveUp dispatches giveup', async () => {
+    const { result } = renderHook(() => usePyramidGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(defaultState);
+    act(() => {
+      result.current.handleGiveUp();
+    });
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
+  });
+
+  it('handleUndo dispatches undo', async () => {
+    const { result } = renderHook(() => usePyramidGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(defaultState);
+    act(() => {
+      result.current.handleUndo();
+    });
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo'));
+  });
+
+  it('handleUndoEscape dispatches undo_n with count and clears hint', async () => {
+    const { result } = renderHook(() => usePyramidGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(defaultState);
+    act(() => {
+      result.current.handleUndoEscape(5);
+    });
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo_n', undefined, undefined, 5));
+    expect(result.current.hint).toBeNull();
+  });
+
+  it('handleHint calls exec with hint and sets hint state', async () => {
+    const hintResponse: PyramidResponse = {
+      ...defaultState,
+      hint: { type: 'pair', row1: 2, col1: 0, row2: 2, col2: 1 },
+    };
+    const { result } = renderHook(() => usePyramidGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockResolvedValue(hintResponse);
+    await act(async () => {
+      await result.current.handleHint();
+    });
+
+    expect(result.current.hint).toEqual(hintResponse.hint);
+  });
+
+  it('handleHint sets hint to null when no hint returned', async () => {
+    const { result } = renderHook(() => usePyramidGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockResolvedValue({ ...defaultState, hint: undefined });
+    await act(async () => {
+      await result.current.handleHint();
+    });
+
+    expect(result.current.hint).toBeNull();
+  });
+
+  it('handleHint sets hintError on failure', async () => {
+    const { result } = renderHook(() => usePyramidGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockRejectedValue(new Error('Network error'));
+    await act(async () => {
+      await result.current.handleHint();
+    });
+
+    expect(result.current.hintError).toBeTruthy();
+    expect(result.current.hint).toBeNull();
+  });
+});

--- a/frontend/src/hooks/usePyramidGame.ts
+++ b/frontend/src/hooks/usePyramidGame.ts
@@ -56,6 +56,16 @@ export function usePyramidGame() {
     exec('undo');
   }, [exec]);
 
+  /** Batch undo N moves to escape a stalemate. */
+  const handleUndoEscape = useCallback(
+    (n: number) => {
+      setSelectedCard(null);
+      setHint(null);
+      exec('undo_n', undefined, undefined, n);
+    },
+    [exec],
+  );
+
   const selectionToRemoveCard = useCallback((sel: PyramidSelection): PyramidRemoveCard => {
     return { zone: sel.zone, row: sel.row, col: sel.col };
   }, []);
@@ -103,6 +113,7 @@ export function usePyramidGame() {
     handleGiveUp,
     handleHint,
     handleUndo,
+    handleUndoEscape,
     handleSelectCard,
     retry,
   };

--- a/frontend/src/hooks/useSpiderGame.test.ts
+++ b/frontend/src/hooks/useSpiderGame.test.ts
@@ -175,6 +175,19 @@ describe('useSpiderGame', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo'));
   });
 
+  it('handleUndoEscape dispatches undo_n with count', async () => {
+    const { result } = renderHook(() => useSpiderGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(defaultState);
+    act(() => {
+      result.current.handleUndoEscape(3);
+    });
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo_n', undefined, undefined, undefined, 3));
+  });
+
   it('handleSelectSource sets selectedSource', async () => {
     const { result } = renderHook(() => useSpiderGame(), { wrapper: createWrapper() });
     await waitFor(() => expect(result.current.state).not.toBeNull());

--- a/frontend/src/hooks/useSpiderGame.ts
+++ b/frontend/src/hooks/useSpiderGame.ts
@@ -69,6 +69,16 @@ export function useSpiderGame() {
     apiExec('undo');
   }, [apiExec]);
 
+  /** Undo N moves at once to escape a stalemate. */
+  const handleUndoEscape = useCallback(
+    (n: number) => {
+      setSelectedSource(null);
+      setHint(null);
+      apiExec('undo_n', undefined, undefined, undefined, n);
+    },
+    [apiExec],
+  );
+
   const handleSelectSource = useCallback((zone: SpiderMoveZone) => {
     setSelectedSource((prev) => {
       if (prev && prev.zone === zone.zone && prev.col === zone.col && prev.cardIndex === zone.cardIndex) {
@@ -103,6 +113,7 @@ export function useSpiderGame() {
     handleHint,
     handleAutoComplete,
     handleUndo,
+    handleUndoEscape,
     handleSelectSource,
     handleSelectTarget,
     isAutoCompleting,

--- a/frontend/src/hooks/useTriPeaksGame.test.ts
+++ b/frontend/src/hooks/useTriPeaksGame.test.ts
@@ -1,0 +1,156 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { tripeaksApi } from '../api/gameApi';
+import type { TriPeaksResponse } from '../types/card';
+import { useTriPeaksGame } from './useTriPeaksGame';
+
+vi.mock('../api/gameApi', () => ({
+  tripeaksApi: { exec: vi.fn() },
+}));
+
+const mockExec = vi.mocked(tripeaksApi.exec);
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+const defaultState: TriPeaksResponse = {
+  layout: [[{ card: null, removed: true, exposed: false }]],
+  stockCount: 20,
+  waste: [],
+  phase: 0,
+  moveCount: 0,
+  canUndo: false,
+  isStalemate: false,
+  message: '',
+};
+
+beforeEach(() => {
+  mockExec.mockResolvedValue(defaultState);
+});
+
+describe('useTriPeaksGame', () => {
+  it('calls reset on mount', async () => {
+    renderHook(() => useTriPeaksGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+  });
+
+  it('returns initial state after mount', async () => {
+    const { result } = renderHook(() => useTriPeaksGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).toEqual(defaultState));
+  });
+
+  it('handleDraw dispatches draw and clears hint', async () => {
+    const { result } = renderHook(() => useTriPeaksGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(defaultState);
+    act(() => {
+      result.current.handleDraw();
+    });
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw'));
+    expect(result.current.hint).toBeNull();
+  });
+
+  it('handleReset dispatches reset and clears hint', async () => {
+    const { result } = renderHook(() => useTriPeaksGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(defaultState);
+    act(() => {
+      result.current.handleReset();
+    });
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(result.current.hint).toBeNull();
+  });
+
+  it('handleGiveUp dispatches giveup', async () => {
+    const { result } = renderHook(() => useTriPeaksGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(defaultState);
+    act(() => {
+      result.current.handleGiveUp();
+    });
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
+  });
+
+  it('handleUndo dispatches undo', async () => {
+    const { result } = renderHook(() => useTriPeaksGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(defaultState);
+    act(() => {
+      result.current.handleUndo();
+    });
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo'));
+  });
+
+  it('handleUndoEscape dispatches undo_n with count and clears hint', async () => {
+    const { result } = renderHook(() => useTriPeaksGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(defaultState);
+    act(() => {
+      result.current.handleUndoEscape(5);
+    });
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo_n', undefined, undefined, 5));
+    expect(result.current.hint).toBeNull();
+  });
+
+  it('handleHint calls exec with hint and sets hint state', async () => {
+    const hintResponse: TriPeaksResponse = {
+      ...defaultState,
+      hint: { type: 'remove', row: 3, col: 0 },
+    };
+    const { result } = renderHook(() => useTriPeaksGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockResolvedValue(hintResponse);
+    await act(async () => {
+      await result.current.handleHint();
+    });
+
+    expect(result.current.hint).toEqual(hintResponse.hint);
+  });
+
+  it('handleHint sets hint to null when no hint returned', async () => {
+    const { result } = renderHook(() => useTriPeaksGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockResolvedValue({ ...defaultState, hint: undefined });
+    await act(async () => {
+      await result.current.handleHint();
+    });
+
+    expect(result.current.hint).toBeNull();
+  });
+
+  it('handleHint sets hintError on failure', async () => {
+    const { result } = renderHook(() => useTriPeaksGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.state).not.toBeNull());
+
+    mockExec.mockRejectedValue(new Error('Network error'));
+    await act(async () => {
+      await result.current.handleHint();
+    });
+
+    expect(result.current.hintError).toBeTruthy();
+    expect(result.current.hint).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useTriPeaksGame.ts
+++ b/frontend/src/hooks/useTriPeaksGame.ts
@@ -44,6 +44,15 @@ export function useTriPeaksGame() {
     exec('undo');
   }, [exec]);
 
+  /** Batch undo to escape stalemate. */
+  const handleUndoEscape = useCallback(
+    (n: number) => {
+      setHint(null);
+      exec('undo_n', undefined, undefined, n);
+    },
+    [exec],
+  );
+
   const handleSelectCard = useCallback(
     (row: number, col: number) => {
       setHint(null);
@@ -64,6 +73,7 @@ export function useTriPeaksGame() {
     handleGiveUp,
     handleHint,
     handleUndo,
+    handleUndoEscape,
     handleSelectCard,
     retry,
   };

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -100,6 +100,7 @@
     "hint": "Hint",
     "retry": "Retry"
   },
+  "stalemateEscape": "Escape (undo {{count}} moves)",
   "status": {
     "folded": "Folded",
     "allIn": "All-in",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -304,9 +304,5 @@
     "unknownCommandWithSuggestion": "Unknown command: {{cmd}}. Did you mean: {{suggestion}}",
     "emptyInput": "Please enter a command. Type 'help' for help.",
     "helpCommon": "Common commands: r/reset (reset), help/? (help), clear (clear log)"
-  },
-  "solitaire": {
-    "undoToEscape": "Undo {{n}} steps to escape",
-    "noEscape": "No escapable state found. Please reset."
   }
 }

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -100,6 +100,7 @@
     "hint": "ヒント",
     "retry": "再試行"
   },
+  "stalemateEscape": "脱出する ({{count}}手戻る)",
   "status": {
     "folded": "フォールド",
     "allIn": "オールイン",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -304,9 +304,5 @@
     "unknownCommandWithSuggestion": "不明なコマンド: {{cmd}}。もしかして: {{suggestion}}",
     "emptyInput": "コマンドを入力してください。'help' でヘルプを表示",
     "helpCommon": "共通コマンド: r/reset (リセット), help/? (ヘルプ), clear (ログクリア)"
-  },
-  "solitaire": {
-    "undoToEscape": "{{n}}手前に戻る",
-    "noEscape": "戻れる手がありません。リセットしてください。"
   }
 }

--- a/frontend/src/pages/FreeCellPage.test.tsx
+++ b/frontend/src/pages/FreeCellPage.test.tsx
@@ -653,4 +653,27 @@ describe('FreeCellPage', () => {
     renderWithProviders(<FreeCellPage />);
     await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
   });
+
+  it('does not show stalemate escape button when not stalemate', async () => {
+    renderWithProviders(<FreeCellPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('stalemate-escape-button')).not.toBeInTheDocument();
+  });
+
+  it('shows stalemate escape button when isStalemate is true', async () => {
+    mockExec.mockResolvedValue({ ...playingState, isStalemate: true, undoToEscape: 5 });
+    renderWithProviders(<FreeCellPage />);
+    await waitFor(() => expect(screen.getByTestId('stalemate-escape-button')).toBeInTheDocument());
+    expect(screen.getByTestId('stalemate-escape-button')).toHaveTextContent('5');
+  });
+
+  it('clicking stalemate escape button dispatches undo_n', async () => {
+    mockExec.mockResolvedValue({ ...playingState, isStalemate: true, undoToEscape: 3 });
+    renderWithProviders(<FreeCellPage />);
+    await waitFor(() => expect(screen.getByTestId('stalemate-escape-button')).toBeInTheDocument());
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(playingState);
+    fireEvent.click(screen.getByTestId('stalemate-escape-button'));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo_n', undefined, undefined, 3));
+  });
 });

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -15,6 +15,7 @@ import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
+import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { FreeCellSkeleton } from '../components/skeleton/FreeCellSkeleton';
 import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
@@ -100,6 +101,7 @@ function FreeCellPageContent() {
     handleHint,
     handleAutoComplete,
     handleUndo,
+    handleUndoEscape,
     handleSelectSource,
     handleSelectTarget,
     isAutoCompleting,
@@ -380,6 +382,13 @@ function FreeCellPageContent() {
                   >
                     {t('undo')}
                   </button>
+                  {state.isStalemate && (
+                    <StalemateEscapeButton
+                      undoToEscape={state.undoToEscape ?? 0}
+                      onEscape={handleUndoEscape}
+                      disabled={loading || isAutoCompleting}
+                    />
+                  )}
                   <button
                     type="button"
                     className={btnSuccess}

--- a/frontend/src/pages/GolfPage.tsx
+++ b/frontend/src/pages/GolfPage.tsx
@@ -15,6 +15,7 @@ import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
+import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { GolfSkeleton } from '../components/skeleton/GolfSkeleton';
 import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
@@ -96,6 +97,7 @@ function GolfPageContent() {
     handleGiveUp,
     handleHint,
     handleUndo,
+    handleUndoEscape,
     handleSelectCard,
   } = useGolfGame();
   const { cardHeight, cardWidth, isMobile } = useCardDimensions();
@@ -303,6 +305,13 @@ function GolfPageContent() {
                   >
                     {t('undo')}
                   </button>
+                  {state.isStalemate && (
+                    <StalemateEscapeButton
+                      undoToEscape={state.undoToEscape ?? 0}
+                      onEscape={handleUndoEscape}
+                      disabled={loading}
+                    />
+                  )}
                   <button type="button" className={btnSuccess} onClick={handleHint} disabled={loading}>
                     {t('hint')}
                   </button>

--- a/frontend/src/pages/KlondikePage.test.tsx
+++ b/frontend/src/pages/KlondikePage.test.tsx
@@ -844,4 +844,27 @@ describe('KlondikePage', () => {
     renderWithProviders(<KlondikePage />);
     await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
   });
+
+  it('does not show stalemate escape button when not stalemate', async () => {
+    renderWithProviders(<KlondikePage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('stalemate-escape-button')).not.toBeInTheDocument();
+  });
+
+  it('shows stalemate escape button when isStalemate is true', async () => {
+    mockExec.mockResolvedValue({ ...playingState, isStalemate: true, undoToEscape: 3, canUndo: true });
+    renderWithProviders(<KlondikePage />);
+    await waitFor(() => expect(screen.getByTestId('stalemate-escape-button')).toBeInTheDocument());
+    expect(screen.getByTestId('stalemate-escape-button')).toHaveTextContent('3');
+  });
+
+  it('clicking stalemate escape button dispatches undo_n', async () => {
+    mockExec.mockResolvedValue({ ...playingState, isStalemate: true, undoToEscape: 4, canUndo: true });
+    renderWithProviders(<KlondikePage />);
+    await waitFor(() => expect(screen.getByTestId('stalemate-escape-button')).toBeInTheDocument());
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(playingState);
+    fireEvent.click(screen.getByTestId('stalemate-escape-button'));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo_n', undefined, undefined, undefined, 4));
+  });
 });

--- a/frontend/src/pages/KlondikePage.tsx
+++ b/frontend/src/pages/KlondikePage.tsx
@@ -16,6 +16,7 @@ import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
+import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { KlondikeSkeleton } from '../components/skeleton/KlondikeSkeleton';
 import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
@@ -110,6 +111,7 @@ function KlondikePageContent() {
     handleHint,
     handleAutoComplete,
     handleUndo,
+    handleUndoEscape,
     handleSelectSource,
     handleSelectTarget,
     isAutoCompleting,
@@ -492,6 +494,13 @@ function KlondikePageContent() {
                   >
                     {t('undo')}
                   </button>
+                  {state.isStalemate && (
+                    <StalemateEscapeButton
+                      undoToEscape={state.undoToEscape ?? 0}
+                      onEscape={handleUndoEscape}
+                      disabled={loading || isAutoCompleting}
+                    />
+                  )}
                   <button
                     type="button"
                     className={btnSuccess}

--- a/frontend/src/pages/PyramidPage.test.tsx
+++ b/frontend/src/pages/PyramidPage.test.tsx
@@ -482,4 +482,27 @@ describe('PyramidPage', () => {
     renderWithProviders(<PyramidPage />);
     await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
   });
+
+  it('does not show stalemate escape button when not stalemate', async () => {
+    renderWithProviders(<PyramidPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('stalemate-escape-button')).not.toBeInTheDocument();
+  });
+
+  it('shows stalemate escape button when isStalemate is true', async () => {
+    mockExec.mockResolvedValue({ ...playingState, isStalemate: true, undoToEscape: 3, canUndo: true });
+    renderWithProviders(<PyramidPage />);
+    await waitFor(() => expect(screen.getByTestId('stalemate-escape-button')).toBeInTheDocument());
+    expect(screen.getByTestId('stalemate-escape-button')).toHaveTextContent('3');
+  });
+
+  it('clicking stalemate escape button dispatches undo_n', async () => {
+    mockExec.mockResolvedValue({ ...playingState, isStalemate: true, undoToEscape: 4, canUndo: true });
+    renderWithProviders(<PyramidPage />);
+    await waitFor(() => expect(screen.getByTestId('stalemate-escape-button')).toBeInTheDocument());
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(playingState);
+    fireEvent.click(screen.getByTestId('stalemate-escape-button'));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo_n', undefined, undefined, 4));
+  });
 });

--- a/frontend/src/pages/PyramidPage.tsx
+++ b/frontend/src/pages/PyramidPage.tsx
@@ -16,6 +16,7 @@ import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
+import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { PyramidSkeleton } from '../components/skeleton/PyramidSkeleton';
 import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
@@ -99,6 +100,7 @@ function PyramidPageContent() {
     handleGiveUp,
     handleHint,
     handleUndo,
+    handleUndoEscape,
     handleSelectCard,
   } = usePyramidGame();
   const {
@@ -364,6 +366,13 @@ function PyramidPageContent() {
                   >
                     {t('undo')}
                   </button>
+                  {state.isStalemate && (
+                    <StalemateEscapeButton
+                      undoToEscape={state.undoToEscape ?? 0}
+                      onEscape={handleUndoEscape}
+                      disabled={loading}
+                    />
+                  )}
                   <button type="button" className={btnSuccess} onClick={handleHint} disabled={loading}>
                     {t('hint')}
                   </button>

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -201,7 +201,7 @@ function SpeedPageContent() {
                   type="button"
                   onClick={handleFlip}
                   disabled={loading}
-                  className={"px-4 py-2 bg-amber-500 text-white rounded hover:bg-amber-600 disabled:opacity-50 ring-2 ring-amber-300" + (!loading ? " animate-pulse" : "")}
+                  className={`px-4 py-2 bg-amber-500 text-white rounded hover:bg-amber-600 disabled:opacity-50 ring-2 ring-amber-300${!loading ? ' animate-pulse' : ''}`}
                   data-testid="flip-button"
                 >
                   {t('flipButton')}

--- a/frontend/src/pages/SpiderPage.test.tsx
+++ b/frontend/src/pages/SpiderPage.test.tsx
@@ -531,4 +531,16 @@ describe('SpiderPage', () => {
     renderWithProviders(<SpiderPage />);
     await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
   });
+
+  it('does not show stalemate escape button when not stalemate', async () => {
+    renderWithProviders(<SpiderPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('stalemate-escape-button')).not.toBeInTheDocument();
+  });
+
+  it('shows stalemate escape button when isStalemate is true', async () => {
+    mockExec.mockResolvedValue({ ...playingState, isStalemate: true, undoToEscape: 7, canUndo: true });
+    renderWithProviders(<SpiderPage />);
+    await waitFor(() => expect(screen.getByTestId('stalemate-escape-button')).toBeInTheDocument());
+  });
 });

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -16,6 +16,7 @@ import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
+import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { SpiderSkeleton } from '../components/skeleton/SpiderSkeleton';
 import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
@@ -107,6 +108,7 @@ function SpiderPageContent() {
     handleHint,
     handleAutoComplete,
     handleUndo,
+    handleUndoEscape,
     handleSelectSource,
     handleSelectTarget,
     isAutoCompleting,
@@ -360,6 +362,13 @@ function SpiderPageContent() {
                   >
                     {t('undo')}
                   </button>
+                  {state.isStalemate && (
+                    <StalemateEscapeButton
+                      undoToEscape={state.undoToEscape ?? 0}
+                      onEscape={handleUndoEscape}
+                      disabled={loading || isAutoCompleting}
+                    />
+                  )}
                   <button
                     type="button"
                     className={btnSuccess}

--- a/frontend/src/pages/TriPeaksPage.test.tsx
+++ b/frontend/src/pages/TriPeaksPage.test.tsx
@@ -217,4 +217,27 @@ describe('TriPeaksPage', () => {
       Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
     }
   });
+
+  it('does not show stalemate escape button when not stalemate', async () => {
+    renderWithProviders(<TriPeaksPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('stalemate-escape-button')).not.toBeInTheDocument();
+  });
+
+  it('shows stalemate escape button when isStalemate is true', async () => {
+    mockExec.mockResolvedValue({ ...playingState, isStalemate: true, undoToEscape: 3, canUndo: true });
+    renderWithProviders(<TriPeaksPage />);
+    await waitFor(() => expect(screen.getByTestId('stalemate-escape-button')).toBeInTheDocument());
+    expect(screen.getByTestId('stalemate-escape-button')).toHaveTextContent('3');
+  });
+
+  it('clicking stalemate escape button dispatches undo_n', async () => {
+    mockExec.mockResolvedValue({ ...playingState, isStalemate: true, undoToEscape: 4, canUndo: true });
+    renderWithProviders(<TriPeaksPage />);
+    await waitFor(() => expect(screen.getByTestId('stalemate-escape-button')).toBeInTheDocument());
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(playingState);
+    fireEvent.click(screen.getByTestId('stalemate-escape-button'));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo_n', undefined, undefined, 4));
+  });
 });

--- a/frontend/src/pages/TriPeaksPage.tsx
+++ b/frontend/src/pages/TriPeaksPage.tsx
@@ -16,6 +16,7 @@ import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
+import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { TriPeaksSkeleton } from '../components/skeleton/TriPeaksSkeleton';
 import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
@@ -106,6 +107,7 @@ function TriPeaksPageContent() {
     handleGiveUp,
     handleHint,
     handleUndo,
+    handleUndoEscape,
     handleSelectCard,
   } = useTriPeaksGame();
   const {
@@ -344,6 +346,13 @@ function TriPeaksPageContent() {
                   >
                     {t('undo')}
                   </button>
+                  {state.isStalemate && (
+                    <StalemateEscapeButton
+                      undoToEscape={state.undoToEscape ?? 0}
+                      onEscape={handleUndoEscape}
+                      disabled={loading}
+                    />
+                  )}
                   <button type="button" className={btnSuccess} onClick={handleHint} disabled={loading}>
                     {t('hint')}
                   </button>


### PR DESCRIPTION
## Summary
- Add shared `StalemateEscapeButton` component with pulse animation
- Wire `undo_n` API command to all 6 solitaire game APIs (Klondike, FreeCell, Spider, Pyramid, TriPeaks, Golf)
- Add `handleUndoEscape(n)` to each solitaire hook
- Show escape button next to undo button when `isStalemate` is true, calling `undo_n(undoToEscape)`
- Add i18n keys for ja/en ("脱出する (N手戻る)" / "Escape (undo N moves)")

Closes #1245

## Test plan
- [x] 5 unit tests for StalemateEscapeButton component
- [x] 312 existing solitaire tests still pass
- [x] TypeScript type check passes
- [ ] Manual test: trigger stalemate in Klondike, verify escape button appears and works
- [ ] Verify button disappears after escape succeeds