### PR TITLE
fix: CLI UX improvements for shell completion, aliases, and update --yes

### DIFF
--- a/cmd/trumpcards/completion.go
+++ b/cmd/trumpcards/completion.go
@@ -8,13 +8,15 @@ import (
 
 // completionSubcommands is the list of all subcommands for shell completion.
 var completionSubcommands = []string{
-	"baccarat", "blackjack", "bridge", "canasta", "clocksolitaire", "completion",
-	"crazyeights", "cribbage", "daifugo", "deuceswild", "doubt", "euchre",
-	"freecell", "games", "ginrummy", "gofish", "golf", "hearts", "holdem",
-	"indianpoker", "jokerpoker", "klondike", "memory", "napoleon", "ohhell",
-	"oldmaid", "omaha", "pigtail", "pineapple", "pinochle", "poker", "pyramid",
-	"sevencardstud", "sevens", "shortdeck", "spades", "speed", "spider",
-	"threecard", "tripeaks", "update", "videopoker", "web",
+	"3card", "40t", "6plus", "7cs", "7stud",
+	"baccarat", "blackjack", "bridge", "canasta", "clock", "clocksolitaire", "completion",
+	"crazy8", "crazyeights", "cribbage", "daifugo", "deuces", "deuceswild", "doubt", "durak",
+	"euchre", "fortythieves", "freecell", "games", "gin", "ginrummy", "gofish", "golf",
+	"hearts", "holdem", "indian", "indianpoker", "joker", "jokerpoker", "klondike",
+	"memory", "napoleon", "ohhell", "oldmaid", "omaha", "paigow", "pgp", "pigtail",
+	"pineapple", "pinochle", "poker", "pyramid", "sevencardstud", "sevens", "short",
+	"shortdeck", "spades", "speed", "spider", "threecard", "tripeaks", "update",
+	"video", "videopoker", "web",
 }
 
 // runCompletion outputs a shell completion script for the given shell name.
@@ -93,6 +95,10 @@ func writeBashCompletion(w io.Writer) error {
             COMPREPLY=( $(compgen -W "bash zsh fish" -- "$cur") )
             return
             ;;
+        update)
+            COMPREPLY=( $(compgen -W "--yes -y" -- "$cur") )
+            return
+            ;;
         --port|-p)
             return
             ;;
@@ -103,7 +109,7 @@ func writeBashCompletion(w io.Writer) error {
         return
     fi
 
-    local commands="baccarat blackjack bridge canasta clocksolitaire completion crazyeights cribbage daifugo deuceswild doubt euchre freecell games ginrummy gofish golf hearts holdem indianpoker jokerpoker klondike memory napoleon ohhell oldmaid omaha pigtail pineapple pinochle poker pyramid sevencardstud sevens shortdeck spades speed spider threecard tripeaks update videopoker web"
+    local commands="3card 40t 6plus 7cs 7stud baccarat blackjack bridge canasta clock clocksolitaire completion crazy8 crazyeights cribbage daifugo deuces deuceswild doubt durak euchre fortythieves freecell games gin ginrummy gofish golf hearts holdem indian indianpoker joker jokerpoker klondike memory napoleon ohhell oldmaid omaha paigow pgp pigtail pineapple pinochle poker pyramid sevencardstud sevens short shortdeck spades speed spider threecard tripeaks update video videopoker web"
     COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
 }
 complete -F _trumpcards trumpcards
@@ -118,26 +124,39 @@ func writeZshCompletion(w io.Writer) error {
 _trumpcards() {
     local -a commands
     commands=(
+        '3card:Three Card Poker (alias)'
+        '40t:Forty Thieves (alias)'
+        '6plus:Short Deck Hold'\''em (alias)'
+        '7cs:Seven Card Stud (alias)'
+        '7stud:Seven Card Stud (alias)'
         'baccarat:Baccarat'
         'blackjack:BlackJack'
         'bridge:Contract Bridge'
         'canasta:Canasta'
+        'clock:Clock Solitaire (alias)'
         'clocksolitaire:Clock Solitaire'
         'completion:Generate shell completion script'
+        'crazy8:Crazy Eights (alias)'
         'crazyeights:Crazy Eights'
         'cribbage:Cribbage'
         'daifugo:Daifugo'
+        'deuces:Deuces Wild (alias)'
         'deuceswild:Deuces Wild'
         'doubt:Doubt'
+        'durak:Durak'
         'euchre:Euchre'
+        'fortythieves:Forty Thieves'
         'freecell:FreeCell'
         'games:List available games'
+        'gin:Gin Rummy (alias)'
         'ginrummy:Gin Rummy'
         'gofish:Go Fish'
         'golf:Golf Solitaire'
         'hearts:Hearts'
         'holdem:Texas Hold'\''em'
+        'indian:Indian Poker (alias)'
         'indianpoker:Indian Poker'
+        'joker:Joker Poker (alias)'
         'jokerpoker:Joker Poker'
         'klondike:Klondike Solitaire'
         'memory:Memory'
@@ -145,6 +164,8 @@ _trumpcards() {
         'ohhell:Oh Hell'
         'oldmaid:Old Maid'
         'omaha:Omaha Hold'\''em'
+        'paigow:Pai Gow Poker'
+        'pgp:Pai Gow Poker (alias)'
         'pigtail:Pig'\''s Tail'
         'pineapple:Pineapple Poker'
         'pinochle:Pinochle'
@@ -152,6 +173,7 @@ _trumpcards() {
         'pyramid:Pyramid'
         'sevencardstud:Seven Card Stud'
         'sevens:Sevens'
+        'short:Short Deck Hold'\''em (alias)'
         'shortdeck:Short Deck Hold'\''em'
         'spades:Spades'
         'speed:Speed'
@@ -159,6 +181,7 @@ _trumpcards() {
         'threecard:Three Card Poker'
         'tripeaks:TriPeaks'
         'update:Self-update to the latest version'
+        'video:Video Poker (alias)'
         'videopoker:Video Poker'
         'web:Start REST API + web GUI server'
     )
@@ -179,6 +202,10 @@ _trumpcards() {
             case "${words[1]}" in
                 completion)
                     _values 'shell' bash zsh fish
+                    ;;
+                update)
+                    _arguments \
+                        '(-y --yes)'{-y,--yes}'[Skip confirmation prompt]'
                     ;;
                 web)
                     _arguments \
@@ -206,26 +233,39 @@ complete -c trumpcards -l lang -x -a 'ja en' -d 'Language'
 complete -c trumpcards -l no-color -d 'Disable color output'
 
 # Subcommands
+complete -c trumpcards -n __fish_use_subcommand -a 3card -d 'Three Card Poker (alias)'
+complete -c trumpcards -n __fish_use_subcommand -a 40t -d 'Forty Thieves (alias)'
+complete -c trumpcards -n __fish_use_subcommand -a 6plus -d 'Short Deck Hold'\''em (alias)'
+complete -c trumpcards -n __fish_use_subcommand -a 7cs -d 'Seven Card Stud (alias)'
+complete -c trumpcards -n __fish_use_subcommand -a 7stud -d 'Seven Card Stud (alias)'
 complete -c trumpcards -n __fish_use_subcommand -a baccarat -d 'Baccarat'
 complete -c trumpcards -n __fish_use_subcommand -a blackjack -d 'BlackJack'
 complete -c trumpcards -n __fish_use_subcommand -a bridge -d 'Contract Bridge'
 complete -c trumpcards -n __fish_use_subcommand -a canasta -d 'Canasta'
+complete -c trumpcards -n __fish_use_subcommand -a clock -d 'Clock Solitaire (alias)'
 complete -c trumpcards -n __fish_use_subcommand -a clocksolitaire -d 'Clock Solitaire'
 complete -c trumpcards -n __fish_use_subcommand -a completion -d 'Generate shell completion script'
+complete -c trumpcards -n __fish_use_subcommand -a crazy8 -d 'Crazy Eights (alias)'
 complete -c trumpcards -n __fish_use_subcommand -a crazyeights -d 'Crazy Eights'
 complete -c trumpcards -n __fish_use_subcommand -a cribbage -d 'Cribbage'
 complete -c trumpcards -n __fish_use_subcommand -a daifugo -d 'Daifugo'
+complete -c trumpcards -n __fish_use_subcommand -a deuces -d 'Deuces Wild (alias)'
 complete -c trumpcards -n __fish_use_subcommand -a deuceswild -d 'Deuces Wild'
 complete -c trumpcards -n __fish_use_subcommand -a doubt -d 'Doubt'
+complete -c trumpcards -n __fish_use_subcommand -a durak -d 'Durak'
 complete -c trumpcards -n __fish_use_subcommand -a euchre -d 'Euchre'
+complete -c trumpcards -n __fish_use_subcommand -a fortythieves -d 'Forty Thieves'
 complete -c trumpcards -n __fish_use_subcommand -a freecell -d 'FreeCell'
 complete -c trumpcards -n __fish_use_subcommand -a games -d 'List available games'
+complete -c trumpcards -n __fish_use_subcommand -a gin -d 'Gin Rummy (alias)'
 complete -c trumpcards -n __fish_use_subcommand -a ginrummy -d 'Gin Rummy'
 complete -c trumpcards -n __fish_use_subcommand -a gofish -d 'Go Fish'
 complete -c trumpcards -n __fish_use_subcommand -a golf -d 'Golf Solitaire'
 complete -c trumpcards -n __fish_use_subcommand -a hearts -d 'Hearts'
 complete -c trumpcards -n __fish_use_subcommand -a holdem -d 'Texas Hold'\''em'
+complete -c trumpcards -n __fish_use_subcommand -a indian -d 'Indian Poker (alias)'
 complete -c trumpcards -n __fish_use_subcommand -a indianpoker -d 'Indian Poker'
+complete -c trumpcards -n __fish_use_subcommand -a joker -d 'Joker Poker (alias)'
 complete -c trumpcards -n __fish_use_subcommand -a jokerpoker -d 'Joker Poker'
 complete -c trumpcards -n __fish_use_subcommand -a klondike -d 'Klondike Solitaire'
 complete -c trumpcards -n __fish_use_subcommand -a memory -d 'Memory'
@@ -233,6 +273,8 @@ complete -c trumpcards -n __fish_use_subcommand -a napoleon -d 'Napoleon'
 complete -c trumpcards -n __fish_use_subcommand -a ohhell -d 'Oh Hell'
 complete -c trumpcards -n __fish_use_subcommand -a oldmaid -d 'Old Maid'
 complete -c trumpcards -n __fish_use_subcommand -a omaha -d 'Omaha Hold'\''em'
+complete -c trumpcards -n __fish_use_subcommand -a paigow -d 'Pai Gow Poker'
+complete -c trumpcards -n __fish_use_subcommand -a pgp -d 'Pai Gow Poker (alias)'
 complete -c trumpcards -n __fish_use_subcommand -a pigtail -d 'Pig'\''s Tail'
 complete -c trumpcards -n __fish_use_subcommand -a pineapple -d 'Pineapple Poker'
 complete -c trumpcards -n __fish_use_subcommand -a pinochle -d 'Pinochle'
@@ -240,6 +282,7 @@ complete -c trumpcards -n __fish_use_subcommand -a poker -d '5-card Draw Poker'
 complete -c trumpcards -n __fish_use_subcommand -a pyramid -d 'Pyramid'
 complete -c trumpcards -n __fish_use_subcommand -a sevencardstud -d 'Seven Card Stud'
 complete -c trumpcards -n __fish_use_subcommand -a sevens -d 'Sevens'
+complete -c trumpcards -n __fish_use_subcommand -a short -d 'Short Deck Hold'\''em (alias)'
 complete -c trumpcards -n __fish_use_subcommand -a shortdeck -d 'Short Deck Hold'\''em'
 complete -c trumpcards -n __fish_use_subcommand -a spades -d 'Spades'
 complete -c trumpcards -n __fish_use_subcommand -a speed -d 'Speed'
@@ -247,11 +290,15 @@ complete -c trumpcards -n __fish_use_subcommand -a spider -d 'Spider Solitaire'
 complete -c trumpcards -n __fish_use_subcommand -a threecard -d 'Three Card Poker'
 complete -c trumpcards -n __fish_use_subcommand -a tripeaks -d 'TriPeaks'
 complete -c trumpcards -n __fish_use_subcommand -a update -d 'Self-update to the latest version'
+complete -c trumpcards -n __fish_use_subcommand -a video -d 'Video Poker (alias)'
 complete -c trumpcards -n __fish_use_subcommand -a videopoker -d 'Video Poker'
 complete -c trumpcards -n __fish_use_subcommand -a web -d 'Start REST API + web GUI server'
 
 # completion subcommand
 complete -c trumpcards -n '__fish_seen_subcommand_from completion' -a 'bash zsh fish'
+
+# update subcommand
+complete -c trumpcards -n '__fish_seen_subcommand_from update' -l yes -s y -d 'Skip confirmation prompt'
 
 # web subcommand
 complete -c trumpcards -n '__fish_seen_subcommand_from web' -l port -s p -d 'Port number' -x

--- a/cmd/trumpcards/completion_test.go
+++ b/cmd/trumpcards/completion_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/ui"
 )
 

--- a/cmd/trumpcards/completion_test.go
+++ b/cmd/trumpcards/completion_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/ui"
 )
 
 func TestWriteBashCompletion(t *testing.T) {
@@ -113,5 +114,20 @@ func TestCompletionSubcommands_ContainsAllGames(t *testing.T) {
 	joined := strings.Join(completionSubcommands, " ")
 	for _, e := range expected {
 		assert.Contains(t, joined, e)
+	}
+}
+
+func TestCompletionSubcommands_SyncWithGameNames(t *testing.T) {
+	subSet := make(map[string]bool, len(completionSubcommands))
+	for _, s := range completionSubcommands {
+		subSet[s] = true
+	}
+	// Every game in ui.GameNames must appear in completionSubcommands.
+	for _, name := range ui.GameNames {
+		assert.True(t, subSet[name], "completionSubcommands missing game %q from ui.GameNames", name)
+	}
+	// Every alias in ui.GameAliases must appear in completionSubcommands.
+	for alias := range ui.GameAliases {
+		assert.True(t, subSet[alias], "completionSubcommands missing alias %q from ui.GameAliases", alias)
 	}
 }

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -100,6 +101,7 @@ EXAMPLES:
   trumpcards games               List all available games
   trumpcards games --short       List game names only (for scripting)
   trumpcards update              Self-update to the latest version
+  trumpcards update --yes        Update without confirmation prompt
   NO_COLOR=1 trumpcards hearts   Play Hearts without color output
   trumpcards web                 Start the web GUI server
   trumpcards web --port 3000     Start the web GUI on port 3000
@@ -258,11 +260,23 @@ ENVIRONMENT VARIABLES:
 			if gamesFlags.NArg() > 0 {
 				fmt.Fprintln(os.Stderr, i18n.Tf("cliExtraArgsWarning", "args", strings.Join(gamesFlags.Args(), " ")))
 			}
+			// Build reverse alias map: canonical name -> sorted list of aliases.
+			reverseAliases := make(map[string][]string)
+			for alias, canonical := range ui.GameAliases {
+				reverseAliases[canonical] = append(reverseAliases[canonical], alias)
+			}
+			for k := range reverseAliases {
+				sort.Strings(reverseAliases[k])
+			}
 			for _, name := range ui.GameNames {
 				if *short {
 					fmt.Println(name)
 				} else {
-					fmt.Printf("  %-16s %s\n", name, gameDescriptions[name])
+					line := fmt.Sprintf("  %-16s %s", name, gameDescriptions[name])
+					if aliases := reverseAliases[name]; len(aliases) > 0 {
+						line += fmt.Sprintf("  [aliases: %s]", strings.Join(aliases, ", "))
+					}
+					fmt.Println(line)
 				}
 			}
 			return 0
@@ -271,7 +285,17 @@ ENVIRONMENT VARIABLES:
 			return runCompletion(flag.Args()[1:])
 		},
 		"update": func() int {
+			updateFlags := flag.NewFlagSet("update", flag.ContinueOnError)
+			yes := updateFlags.Bool("yes", false, "Skip confirmation prompt")
+			updateFlags.BoolVar(yes, "y", false, "Skip confirmation prompt (shorthand)")
+			if err := updateFlags.Parse(flag.Args()[1:]); err != nil {
+				if errors.Is(err, flag.ErrHelp) {
+					return 0
+				}
+				return 1
+			}
 			updater := update.NewUpdater(version, os.Stdin, os.Stderr, os.Stderr)
+			updater.SetAutoConfirm(*yes)
 			if err := updater.Exec(); err != nil {
 				return 1
 			}
@@ -308,7 +332,7 @@ ENVIRONMENT VARIABLES:
 	}
 
 	// Commands that parse their own sub-flags; skip the extra-args warning for these.
-	subFlagCommands := map[string]bool{"web": true, "completion": true, "games": true}
+	subFlagCommands := map[string]bool{"web": true, "completion": true, "games": true, "update": true}
 
 	arg := strings.ToLower(flag.Arg(0))
 	// Resolve game name aliases (e.g., "gin" -> "ginrummy", "7stud" -> "sevencardstud").

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -22,6 +22,7 @@
   "skippedWarning": "Warning: invalid values {{values}} were ignored",
   "updateAlreadyLatest": "Already on the latest version ({{version}})",
   "updateAvailable": "A new version ({{version}}) is available. Update now? [y/N]",
+  "updateAutoConfirm": "Updating to {{version}} (auto-confirmed)...",
   "updateCancelled": "Update cancelled",
   "updateDownloading": "Downloading {{version}}...",
   "updateSuccess": "Successfully updated to {{version}}",

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -22,6 +22,7 @@
   "skippedWarning": "警告: 無効な値 {{values}} は無視されました",
   "updateAlreadyLatest": "既に最新バージョン({{version}})です",
   "updateAvailable": "最新版({{version}})があります。アップデートしますか？ [y/N]",
+  "updateAutoConfirm": "{{version}} にアップデートします (自動確認)...",
   "updateCancelled": "アップデートをキャンセルしました",
   "updateDownloading": "{{version}} をダウンロード中...",
   "updateSuccess": "{{version}} にアップデートしました",

--- a/internal/infrastructure/update/Updater.go
+++ b/internal/infrastructure/update/Updater.go
@@ -28,6 +28,13 @@ type Updater struct {
 	writer         io.Writer
 	errWriter      io.Writer
 	httpClient     *http.Client
+	autoConfirm    bool
+}
+
+// SetAutoConfirm enables or disables the automatic confirmation of updates,
+// skipping the interactive prompt. Useful for CI/CD and scripted environments.
+func (u *Updater) SetAutoConfirm(v bool) {
+	u.autoConfirm = v
 }
 
 // NewUpdater creates a new Updater.
@@ -84,14 +91,18 @@ func (u *Updater) Exec() error {
 		return nil
 	}
 
-	// Prompt for confirmation.
-	_, _ = fmt.Fprint(u.writer, i18n.Tf("updateAvailable", "version", release.TagName)+" ")
-	var answer string
-	_, _ = fmt.Fscanln(u.reader, &answer)
-	ans := strings.ToLower(strings.TrimSpace(answer))
-	if ans != "y" && ans != "yes" {
-		_, _ = fmt.Fprintln(u.writer, i18n.T("updateCancelled"))
-		return nil
+	// Prompt for confirmation (skipped with --yes).
+	if u.autoConfirm {
+		_, _ = fmt.Fprintln(u.writer, i18n.Tf("updateAutoConfirm", "version", release.TagName))
+	} else {
+		_, _ = fmt.Fprint(u.writer, i18n.Tf("updateAvailable", "version", release.TagName)+" ")
+		var answer string
+		_, _ = fmt.Fscanln(u.reader, &answer)
+		ans := strings.ToLower(strings.TrimSpace(answer))
+		if ans != "y" && ans != "yes" {
+			_, _ = fmt.Fprintln(u.writer, i18n.T("updateCancelled"))
+			return nil
+		}
 	}
 
 	// Find matching asset.

--- a/internal/infrastructure/update/Updater_test.go
+++ b/internal/infrastructure/update/Updater_test.go
@@ -1,0 +1,193 @@
+package update
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetAutoConfirm(t *testing.T) {
+	u := NewUpdater("1.0.0", nil, &bytes.Buffer{}, &bytes.Buffer{})
+	assert.False(t, u.autoConfirm)
+	u.SetAutoConfirm(true)
+	assert.True(t, u.autoConfirm)
+	u.SetAutoConfirm(false)
+	assert.False(t, u.autoConfirm)
+}
+
+func TestExec_AlreadyLatest(t *testing.T) {
+	release := ghRelease{TagName: "v1.2.3"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(release)
+	}))
+	defer srv.Close()
+
+	out := &bytes.Buffer{}
+	u := &Updater{
+		currentVersion: "1.2.3",
+		repoOwner:      "test",
+		repoName:       "test",
+		reader:         strings.NewReader(""),
+		writer:         out,
+		errWriter:      &bytes.Buffer{},
+		httpClient:     srv.Client(),
+	}
+	// Override the URL by replacing the httpClient transport.
+	u.httpClient = &http.Client{Transport: &rewriteTransport{base: srv.Client().Transport, url: srv.URL}}
+
+	err := u.Exec()
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "v1.2.3")
+}
+
+func TestExec_UserCancels(t *testing.T) {
+	release := ghRelease{TagName: "v2.0.0"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(release)
+	}))
+	defer srv.Close()
+
+	out := &bytes.Buffer{}
+	u := &Updater{
+		currentVersion: "1.0.0",
+		repoOwner:      "test",
+		repoName:       "test",
+		reader:         strings.NewReader("n\n"),
+		writer:         out,
+		errWriter:      &bytes.Buffer{},
+		httpClient:     &http.Client{Transport: &rewriteTransport{base: srv.Client().Transport, url: srv.URL}},
+	}
+
+	err := u.Exec()
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "v2.0.0")
+}
+
+func TestExec_AutoConfirmSkipsPrompt(t *testing.T) {
+	release := ghRelease{TagName: "v2.0.0", Assets: []ghAsset{}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(release)
+	}))
+	defer srv.Close()
+
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	u := &Updater{
+		currentVersion: "1.0.0",
+		repoOwner:      "test",
+		repoName:       "test",
+		reader:         strings.NewReader(""), // no input — would hang without autoConfirm
+		writer:         out,
+		errWriter:      errOut,
+		httpClient:     &http.Client{Transport: &rewriteTransport{base: srv.Client().Transport, url: srv.URL}},
+		autoConfirm:    true,
+	}
+
+	// Exec will proceed past the prompt but fail at findAsset (no matching asset).
+	// That's expected — we're testing that it skips the prompt.
+	err := u.Exec()
+	require.Error(t, err) // no asset for current platform
+	// The output should NOT contain the "[y/N]" prompt.
+	assert.NotContains(t, out.String(), "[y/N]")
+	// The output should contain the auto-confirm message.
+	assert.Contains(t, out.String(), "v2.0.0")
+}
+
+func TestExec_FetchError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	errOut := &bytes.Buffer{}
+	u := &Updater{
+		currentVersion: "1.0.0",
+		repoOwner:      "test",
+		repoName:       "test",
+		reader:         strings.NewReader(""),
+		writer:         &bytes.Buffer{},
+		errWriter:      errOut,
+		httpClient:     &http.Client{Transport: &rewriteTransport{base: srv.Client().Transport, url: srv.URL}},
+	}
+
+	err := u.Exec()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestFindAsset(t *testing.T) {
+	u := NewUpdater("1.0.0", nil, &bytes.Buffer{}, &bytes.Buffer{})
+
+	tests := []struct {
+		name      string
+		assets    []ghAsset
+		wantEmpty bool
+	}{
+		{
+			name:      "empty assets",
+			assets:    nil,
+			wantEmpty: true,
+		},
+		{
+			name: "no matching asset",
+			assets: []ghAsset{
+				{Name: "trumpcards_1.0.0_freebsd_riscv.tar.gz", BrowserDownloadURL: "https://example.com/a"},
+			},
+			wantEmpty: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, url := u.findAsset(tt.assets)
+			if tt.wantEmpty {
+				assert.Empty(t, name)
+				assert.Empty(t, url)
+			} else {
+				assert.NotEmpty(t, name)
+				assert.NotEmpty(t, url)
+			}
+		})
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		input    int64
+		expected string
+	}{
+		{500, "500 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{1073741824, "1.0 GB"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, formatBytes(tt.input))
+		})
+	}
+}
+
+// rewriteTransport rewrites all request URLs to the test server.
+type rewriteTransport struct {
+	base http.RoundTripper
+	url  string
+}
+
+func (t *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "http"
+	req.URL.Host = strings.TrimPrefix(t.url, "http://")
+	if t.base != nil {
+		return t.base.RoundTrip(req)
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}

--- a/internal/infrastructure/update/Updater_test.go
+++ b/internal/infrastructure/update/Updater_test.go
@@ -37,10 +37,8 @@ func TestExec_AlreadyLatest(t *testing.T) {
 		reader:         strings.NewReader(""),
 		writer:         out,
 		errWriter:      &bytes.Buffer{},
-		httpClient:     srv.Client(),
+		httpClient:     &http.Client{Transport: &rewriteTransport{base: srv.Client().Transport, url: srv.URL}},
 	}
-	// Override the URL by replacing the httpClient transport.
-	u.httpClient = &http.Client{Transport: &rewriteTransport{base: srv.Client().Transport, url: srv.URL}}
 
 	err := u.Exec()
 	require.NoError(t, err)
@@ -69,6 +67,32 @@ func TestExec_UserCancels(t *testing.T) {
 	err := u.Exec()
 	require.NoError(t, err)
 	assert.Contains(t, out.String(), "v2.0.0")
+}
+
+func TestExec_UserAccepts(t *testing.T) {
+	release := ghRelease{TagName: "v2.0.0", Assets: []ghAsset{}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(release)
+	}))
+	defer srv.Close()
+
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	u := &Updater{
+		currentVersion: "1.0.0",
+		repoOwner:      "test",
+		repoName:       "test",
+		reader:         strings.NewReader("y\n"),
+		writer:         out,
+		errWriter:      errOut,
+		httpClient:     &http.Client{Transport: &rewriteTransport{base: srv.Client().Transport, url: srv.URL}},
+	}
+
+	// Exec proceeds past the prompt but fails at findAsset (no matching asset).
+	err := u.Exec()
+	require.Error(t, err)
+	assert.Contains(t, out.String(), "[y/N]")
 }
 
 func TestExec_AutoConfirmSkipsPrompt(t *testing.T) {


### PR DESCRIPTION
## Summary
- **#1260**: Add `durak`, `fortythieves`, `paigow` to bash/zsh/fish shell completion scripts and add a cross-check test that keeps `completionSubcommands` in sync with `GameNames`/`GameAliases`
- **#1261**: Show `[aliases: ...]` in `games` command output and add all 14 game aliases to shell completion with `(alias)` descriptions
- **#1262**: Add `--yes`/`-y` flag to `update` command to skip the confirmation prompt for CI/CD and scripted environments; add i18n messages and `Updater_test.go`

Closes #1260, closes #1261, closes #1262

## Test plan
- [x] `go test -tags test ./...` — all pass
- [x] `golangci-lint run ./...` — clean
- [ ] Run `trumpcards games` and verify aliases appear (e.g., `[aliases: 7cs, 7stud]`)
- [ ] Run `trumpcards completion bash | grep durak` to confirm missing games are present
- [ ] Run `trumpcards completion bash | grep 7stud` to confirm aliases are in completion
- [ ] Run `trumpcards update --yes` to confirm flag is accepted (skips prompt)