### PR TITLE
fix: replace hardcoded Tailwind colors with design system tokens

### DIFF
--- a/frontend/src/components/BettingControls.test.tsx
+++ b/frontend/src/components/BettingControls.test.tsx
@@ -172,7 +172,7 @@ describe('BettingControls', () => {
   it('applies error styling to input when out of range', () => {
     render(<BettingControls {...makeProps({ betAmount: 80, maxBetAmount: 50 })} />);
     const input = screen.getByLabelText('ベット額:');
-    expect(input.className).toContain('bg-red-100');
+    expect(input.className).toContain('bg-red-900/40');
   });
 
   it('disables bet/raise button when value is out of range', () => {

--- a/frontend/src/components/BettingControls.tsx
+++ b/frontend/src/components/BettingControls.tsx
@@ -58,13 +58,15 @@ export function BettingControls({
             onChange={(e) => {
               onBetAmountChange(Number(e.target.value));
             }}
-            className={`w-20 px-2 py-1 text-sm rounded ${
-              isOutOfRange ? 'bg-red-100 border-red-400 border' : 'bg-white/90'
-            } text-gray-900`}
+            className={`w-20 px-2 py-1 text-sm rounded border ${
+              isOutOfRange
+                ? 'bg-red-900/40 border-ds-error text-ds-error'
+                : 'bg-white/90 border-transparent text-gray-900'
+            }`}
           />
         </div>
         {isOutOfRange && (
-          <p id={`${inputId}-range`} className="text-red-300 text-xs" role="alert">
+          <p id={`${inputId}-range`} className="text-ds-error text-xs" role="alert">
             {t('betting.rangeHint', { min: minRaise, max: hasMax ? max : '∞' })}
           </p>
         )}

--- a/frontend/src/components/CpuPlayerCard.tsx
+++ b/frontend/src/components/CpuPlayerCard.tsx
@@ -73,8 +73,8 @@ export function CpuPlayerCard({
             {t('betting.currentBet')} {player.currentBet}
           </span>
         )}
-        {player.folded && <span className="ml-2 text-red-300 text-xs">[{t('status.folded')}]</span>}
-        {player.allIn && <span className="ml-2 text-yellow-300 text-xs">[{t('status.allIn')}]</span>}
+        {player.folded && <span className="ml-2 text-ds-error text-xs">[{t('status.folded')}]</span>}
+        {player.allIn && <span className="ml-2 text-ds-warning text-xs">[{t('status.allIn')}]</span>}
         {showHandName && !player.folded && player.handName && (
           <span className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}>
             {player.handName}

--- a/frontend/src/components/EquityDisplay.tsx
+++ b/frontend/src/components/EquityDisplay.tsx
@@ -46,7 +46,7 @@ export function EquityDisplay({ equity, potOdds }: EquityDisplayProps) {
 
       <button
         type="button"
-        className="text-xs text-cyan-300 underline cursor-pointer"
+        className="text-xs text-ds-info underline cursor-pointer"
         onClick={() => setShowHandOdds(!showHandOdds)}
         data-testid="toggle-hand-odds"
       >

--- a/frontend/src/components/MetaAiIndicator.test.tsx
+++ b/frontend/src/components/MetaAiIndicator.test.tsx
@@ -18,14 +18,14 @@ describe('MetaAiIndicator', () => {
       render(<MetaAiIndicator adaptationLevel="adapting" strategyStyle="balanced" />);
       const el = screen.getByTestId('meta-ai-indicator');
       expect(el).toHaveTextContent('AI: 適応中');
-      expect(el.className).toContain('text-yellow-300');
+      expect(el.className).toContain('text-ds-warning');
     });
 
     it('renders adapted state in green', () => {
       render(<MetaAiIndicator adaptationLevel="adapted" strategyStyle="balanced" />);
       const el = screen.getByTestId('meta-ai-indicator');
       expect(el).toHaveTextContent('AI: 適応済');
-      expect(el.className).toContain('text-green-300');
+      expect(el.className).toContain('text-ds-success');
     });
   });
 

--- a/frontend/src/components/MetaAiIndicator.tsx
+++ b/frontend/src/components/MetaAiIndicator.tsx
@@ -11,8 +11,8 @@ export interface MetaAiIndicatorProps {
 
 const levelColorClass: Record<AdaptationLevel, string> = {
   learning: 'text-gray-400',
-  adapting: 'text-yellow-300',
-  adapted: 'text-green-300',
+  adapting: 'text-ds-warning',
+  adapted: 'text-ds-success',
 };
 
 /** Renders a small inline indicator showing CPU meta-AI adaptation level and strategy style. */

--- a/frontend/src/components/RoundResults.tsx
+++ b/frontend/src/components/RoundResults.tsx
@@ -26,7 +26,7 @@ export function RoundResults({ results, players }: RoundResultsProps) {
           {r.mucked ? `: ${t('label.mucked')}` : r.handName && `: ${r.handName}`}
           {!r.mucked && r.kickers && ` (${t('label.kicker', { kickers: r.kickers })})`}
           {r.wonAmount > 0 && (
-            <span className="text-yellow-300 ml-1"> {t('label.chipsWon', { amount: r.wonAmount })}</span>
+            <span className="text-ds-warning ml-1"> {t('label.chipsWon', { amount: r.wonAmount })}</span>
           )}
         </div>
       ))}

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -53,7 +53,7 @@ export interface VideoPokerGameContentProps {
 function PayoutTable({ t, rows }: { t: (key: string) => string; rows: string[] }) {
   return (
     <details className="mb-3 text-center">
-      <summary className="text-yellow-300 text-sm cursor-pointer lg:text-base">{t('payoutTable.title')}</summary>
+      <summary className="text-ds-warning text-sm cursor-pointer lg:text-base">{t('payoutTable.title')}</summary>
       <ul className="text-gray-300 text-xs mt-1 space-y-0.5 lg:text-sm lg:space-y-1">
         {rows.map((row) => (
           <li key={row}>{t(`payoutTable.${row}`)}</li>

--- a/frontend/src/components/blackjack/BjBetPhaseControls.tsx
+++ b/frontend/src/components/blackjack/BjBetPhaseControls.tsx
@@ -91,7 +91,7 @@ export function BjBetPhaseControls(props: BjBetPhaseControlsProps) {
 
       {/* Advanced settings: collapsible */}
       <details className="mb-2 text-white text-sm" open={props.autoExpandAdvanced || undefined}>
-        <summary className="cursor-pointer select-none text-center text-yellow-300 hover:text-yellow-200 py-1">
+        <summary className="cursor-pointer select-none text-center text-ds-warning hover:text-ds-warning-hover py-1">
           {t('advancedSettings')}
           {(props.perfectPairsBet > 0 || props.twentyOnePlus3Bet > 0) && (
             <span className="ml-2 inline-block bg-yellow-500 text-black text-xs font-bold px-1.5 py-0.5 rounded-full">

--- a/frontend/src/components/common/SettingsPanel.tsx
+++ b/frontend/src/components/common/SettingsPanel.tsx
@@ -113,7 +113,7 @@ export function SettingsPanel({ title, groups }: SettingsPanelProps) {
           if (group.title) {
             return (
               <fieldset key={group.id ?? `group-${gi.toString()}`} className={gi > 0 ? 'mt-2' : ''}>
-                <legend className="text-yellow-300 font-bold text-xs mb-1">{group.title}</legend>
+                <legend className="text-ds-warning font-bold text-xs mb-1">{group.title}</legend>
                 {content}
               </fieldset>
             );

--- a/frontend/src/components/tutorial/TutorialProgressPanel.tsx
+++ b/frontend/src/components/tutorial/TutorialProgressPanel.tsx
@@ -34,7 +34,7 @@ export function TutorialProgressPanel() {
             <Link
               key={game.gameName}
               to={game.path}
-              className={`flex items-center justify-center px-1.5 py-1 rounded hover:bg-ds-surface-elevated-hover ${game.completed ? 'text-green-400' : 'text-ds-text-muted'}`}
+              className={`flex items-center justify-center px-1.5 py-1 rounded hover:bg-ds-surface-elevated-hover ${game.completed ? 'text-ds-success' : 'text-ds-text-muted'}`}
               title={tc(game.labelKey)}
             >
               {game.completed ? '✓' : '○'}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -131,6 +131,12 @@ input[type="search"] {
   border: 1px solid var(--color-ds-border-subtle);
 }
 
+/* Accent color for checkboxes and radios on dark theme */
+input[type="checkbox"],
+input[type="radio"] {
+  accent-color: var(--color-ds-accent);
+}
+
 input[type="number"]:focus-visible,
 input[type="text"]:focus-visible,
 input[type="search"]:focus-visible {

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -143,7 +143,7 @@ function BigRoadGrid({ history }: { history: number[] }) {
                       className={`w-5 h-5 rounded-full inline-block ${cell.result === ROAD_PLAYER ? 'bg-blue-500' : 'bg-red-500'}`}
                     />
                     {cell.tie && (
-                      <span className="absolute inset-0 flex items-center justify-center text-green-400 font-bold text-xs">
+                      <span className="absolute inset-0 flex items-center justify-center text-ds-success font-bold text-xs">
                         /
                       </span>
                     )}
@@ -296,7 +296,7 @@ function BaccaratPageContent() {
             {/* Player Hand */}
             {state.playerHand.length > 0 && (
               <div className="mb-4" data-tutorial="bac-player-hand">
-                <div className="text-yellow-300 font-bold text-center mb-1">
+                <div className="text-ds-warning font-bold text-center mb-1">
                   <span aria-hidden="true">🟡</span> {t('player')} {t('label.value', { value: state.playerHandValue })}
                 </div>
                 <div className="flex justify-center gap-2">
@@ -315,7 +315,7 @@ function BaccaratPageContent() {
             {/* Banker Hand */}
             {state.bankerHand.length > 0 && (
               <div className="mb-4" data-tutorial="bac-banker-hand">
-                <div className="text-red-300 font-bold text-center mb-1">
+                <div className="text-ds-error font-bold text-center mb-1">
                   <span aria-hidden="true">🔴</span> {t('banker')} {t('label.value', { value: state.bankerHandValue })}
                 </div>
                 <div className="flex justify-center gap-2">

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -333,7 +333,7 @@ function BlackJackPageContent() {
               <div className="mt-4">
                 {cpuPlayers.map((cpu, cpuIdx) => (
                   <div key={cpuIdx} className="mb-3">
-                    <h2 className="text-yellow-200 mt-0 mb-1">
+                    <h2 className="text-ds-accent mt-0 mb-1">
                       {tc('player.cpu', { id: cpuIdx + 1 })} ({cpu.chips} chips)
                       {cpu.insuranceBet > 0 && (
                         <span className="text-yellow-400 text-sm ml-2">
@@ -410,7 +410,7 @@ function BlackJackPageContent() {
 
             {/* Insurance info */}
             {state.insuranceBet > 0 && (
-              <div className="text-yellow-300 text-sm mb-1">
+              <div className="text-ds-warning text-sm mb-1">
                 {t('insurance')} {state.insuranceBet}
               </div>
             )}

--- a/frontend/src/pages/BridgePage.tsx
+++ b/frontend/src/pages/BridgePage.tsx
@@ -270,7 +270,7 @@ function BridgePageContent() {
               <div>
                 {/* Declarer/Dummy info */}
                 {state.declarerIdx >= 0 && (
-                  <div className="text-yellow-300 text-center mb-2">
+                  <div className="text-ds-warning text-center mb-2">
                     <span className="mr-4">
                       {t('declarer')}:{' '}
                       {playerName(
@@ -291,7 +291,7 @@ function BridgePageContent() {
                 )}
 
                 {/* Bid phase instruction */}
-                {isHumanBidTurn && <div className="text-yellow-300 text-center mb-2">{t('bidPhase')}</div>}
+                {isHumanBidTurn && <div className="text-ds-warning text-center mb-2">{t('bidPhase')}</div>}
 
                 {/* Bid History */}
                 {state.bidHistory.length > 0 && (
@@ -406,7 +406,7 @@ function BridgePageContent() {
                     </thead>
                     <tbody>
                       {state.teamScores.map((score, idx) => (
-                        <tr key={idx} className={idx === humanTeam ? 'text-yellow-300' : ''}>
+                        <tr key={idx} className={idx === humanTeam ? 'text-ds-accent' : ''}>
                           <td>{idx === humanTeam ? t('teamYou', { n: idx }) : t('team', { n: idx })}</td>
                           <td className="text-center">{score}</td>
                           <td className="text-center">{state.gamesWon[idx]}</td>
@@ -473,7 +473,7 @@ function BridgePageContent() {
             <ErrorAlert message={error ?? hintError} onRetry={retry} />
 
             {hint && (
-              <div className="text-yellow-300 text-sm mb-2">
+              <div className="text-ds-warning text-sm mb-2">
                 {hint.cardIndex != null
                   ? `${t('hintPlay')}: [${hint.cardIndex}] (${t(`hintReason.${hint.reason}`)})`
                   : `(${t(`hintReason.${hint.reason}`)})`}

--- a/frontend/src/pages/CanastaPage.tsx
+++ b/frontend/src/pages/CanastaPage.tsx
@@ -238,7 +238,7 @@ function CanastaPageContent() {
                       ))}
                       {p.red3s.length > 0 && (
                         <div className="flex flex-wrap gap-1 mt-1">
-                          <span className="text-xs text-red-300 self-center mr-1">{t('red3s')}</span>
+                          <span className="text-xs text-ds-error self-center mr-1">{t('red3s')}</span>
                           {p.red3s.map((card, ri) => (
                             <AnimatedCard
                               key={`red3-${pi}-${ri}`}
@@ -270,7 +270,7 @@ function CanastaPageContent() {
                     </thead>
                     <tbody>
                       {state.players.map((p) => (
-                        <tr key={p.id} className={p.isHuman ? 'text-yellow-300' : ''}>
+                        <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
                           <td>{playerName(p.id, p.isHuman)}</td>
                           <td className="text-center">{p.roundScore}</td>
                           <td className="text-center">{p.cumulativeScore}</td>

--- a/frontend/src/pages/CrazyEightsPage.tsx
+++ b/frontend/src/pages/CrazyEightsPage.tsx
@@ -234,7 +234,7 @@ function CrazyEightsPageContent() {
                     <div className="text-white/70 text-sm">
                       <div>{t('discardTop')}</div>
                       {state.chosenSuit > 0 && (
-                        <div className="text-yellow-300">
+                        <div className="text-ds-warning">
                           {t('chosenSuit')}: {SUIT_SYMBOLS[state.chosenSuit] ?? '?'}
                         </div>
                       )}
@@ -286,7 +286,7 @@ function CrazyEightsPageContent() {
                     </thead>
                     <tbody>
                       {state.players.map((p) => (
-                        <tr key={p.id} className={p.isHuman ? 'text-yellow-300' : ''}>
+                        <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
                           <td>{playerName(p.id, p.isHuman)}</td>
                           <td className="text-center">{p.roundScore}</td>
                           <td className="text-center">{p.cumulativeScore}</td>

--- a/frontend/src/pages/CribbagePage.tsx
+++ b/frontend/src/pages/CribbagePage.tsx
@@ -405,7 +405,7 @@ function CribbagePageContent() {
                     </thead>
                     <tbody>
                       {state.players.map((p) => (
-                        <tr key={p.id} className={p.isHuman ? 'text-yellow-300' : ''}>
+                        <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
                           <td>{playerName(p.id, p.isHuman)}</td>
                           <td className="text-center">{p.roundScore}</td>
                           <td className="text-center">{p.cumulativeScore}</td>

--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -270,7 +270,7 @@ function DoubtPageContent() {
                   <div className="text-white font-bold mb-1">{t('table')}</div>
                   <div className="text-game-text-muted text-sm">{t('tableCards', { count: state.tableCardCount })}</div>
                   {state.lastAction && (
-                    <div className="text-yellow-300 text-xs mt-1">{actionDesc(state.lastAction, state.players, t)}</div>
+                    <div className="text-ds-warning text-xs mt-1">{actionDesc(state.lastAction, state.players, t)}</div>
                   )}
                 </div>
 
@@ -307,7 +307,7 @@ function DoubtPageContent() {
                       <>
                         <div className="text-white font-bold mb-2">{t('cpuJudging')}</div>
                         {state.cpuDoubters.length > 0 && (
-                          <div className="text-red-300 text-sm mb-2">
+                          <div className="text-ds-error text-sm mb-2">
                             {t('cpuDoubtExclaim', {
                               names: state.cpuDoubters.map((idx) => playerName(idx, false)).join(', '),
                             })}
@@ -325,7 +325,7 @@ function DoubtPageContent() {
                 {state.lastDoubtResult && (
                   <div className="bg-black/40 rounded-lg py-2 px-3.5 my-2 text-xs">
                     <div className="text-white font-bold mb-1">{t('doubtResult.title')}</div>
-                    <div className={state.lastDoubtResult.wasLying ? 'text-red-300' : 'text-green-300'}>
+                    <div className={state.lastDoubtResult.wasLying ? 'text-ds-error' : 'text-ds-success'}>
                       {state.lastDoubtResult.wasLying ? t('doubtResult.wasLying') : t('doubtResult.wasTruth')}
                     </div>
                     <div className="text-game-text-muted">
@@ -338,7 +338,7 @@ function DoubtPageContent() {
                       })}
                     </div>
                     {state.lastDoubtResult.discardedCount > 0 && (
-                      <div className="text-yellow-300">
+                      <div className="text-ds-warning">
                         {t('doubtResult.discarded', { count: state.lastDoubtResult.discardedCount })}
                       </div>
                     )}
@@ -433,7 +433,7 @@ function DoubtPageContent() {
                 <div className="text-white font-bold text-sm mb-1">
                   {t('yourCards', { count: humanPlayer.cardCount })}
                   {isHumanTurn && state.phase === 0 && (
-                    <span className="text-green-400 text-xs ml-2">{t('selectPrompt')}</span>
+                    <span className="text-ds-success text-xs ml-2">{t('selectPrompt')}</span>
                   )}
                 </div>
                 {/* Human cards */}

--- a/frontend/src/pages/DurakPage.tsx
+++ b/frontend/src/pages/DurakPage.tsx
@@ -347,7 +347,7 @@ function DurakPageContent() {
                   {humanPlayer.cardCount}
                   {isAttacker && <span className="text-red-400 text-xs ml-2">({t('attacker')})</span>}
                   {isDefender && <span className="text-blue-400 text-xs ml-2">({t('defender')})</span>}
-                  {isHumanTurn && <span className="text-green-400 text-xs ml-2">{t('selectCard')}</span>}
+                  {isHumanTurn && <span className="text-ds-success text-xs ml-2">{t('selectCard')}</span>}
                 </div>
                 <div className="flex flex-wrap gap-1">
                   {humanPlayer.cards.map((card, i) => (

--- a/frontend/src/pages/EuchrePage.tsx
+++ b/frontend/src/pages/EuchrePage.tsx
@@ -267,7 +267,7 @@ function EuchrePageContent() {
               <div>
                 {/* Maker / Going alone info */}
                 {state.makerTeam >= 0 && (
-                  <div className="text-yellow-300 text-center mb-2">
+                  <div className="text-ds-warning text-center mb-2">
                     <span className="mr-4">{t('maker', { team: state.makerTeam })}</span>
                     {state.goingAlone && <span>{t('goingAlone')}</span>}
                   </div>
@@ -275,18 +275,18 @@ function EuchrePageContent() {
 
                 {/* Pick-up phase instruction */}
                 {isHumanBidTurn && isPickUpPhase && (
-                  <div className="text-yellow-300 text-center mb-2" data-tutorial="eu-pickup-controls">
+                  <div className="text-ds-warning text-center mb-2" data-tutorial="eu-pickup-controls">
                     {t('pickUpPhase')}
                   </div>
                 )}
 
                 {/* Call trump phase instruction */}
                 {isHumanBidTurn && isCallTrumpPhase && (
-                  <div className="text-yellow-300 text-center mb-2">{t('callTrumpPhase')}</div>
+                  <div className="text-ds-warning text-center mb-2">{t('callTrumpPhase')}</div>
                 )}
 
                 {/* Discard phase instruction */}
-                {isHumanDiscard && <div className="text-yellow-300 text-center mb-2">{t('discardPhase')}</div>}
+                {isHumanDiscard && <div className="text-ds-warning text-center mb-2">{t('discardPhase')}</div>}
 
                 {/* Face-up card */}
                 {state.faceUpCard && (isPickUpPhase || isCallTrumpPhase) && (
@@ -369,7 +369,7 @@ function EuchrePageContent() {
                     </thead>
                     <tbody>
                       {state.teamScores.map((score, idx) => (
-                        <tr key={idx} className={idx === humanTeam ? 'text-yellow-300' : ''}>
+                        <tr key={idx} className={idx === humanTeam ? 'text-ds-accent' : ''}>
                           <td>{idx === humanTeam ? t('teamYou', { n: idx }) : t('team', { n: idx })}</td>
                           <td className="text-center">{score}</td>
                         </tr>
@@ -434,7 +434,7 @@ function EuchrePageContent() {
             <ErrorAlert message={error ?? hintError} onRetry={retry} />
 
             {hint && (
-              <div className="text-yellow-300 text-sm mb-2">
+              <div className="text-ds-warning text-sm mb-2">
                 {hint.cardIndex != null
                   ? `${t('hintPlay')}: [${hint.cardIndex}] (${t(`hintReason.${hint.reason}`)})`
                   : `(${t(`hintReason.${hint.reason}`)})`}

--- a/frontend/src/pages/FortyThievesPage.tsx
+++ b/frontend/src/pages/FortyThievesPage.tsx
@@ -358,7 +358,7 @@ function FortyThievesPageContent() {
             {/* Hint display */}
             <div data-tutorial="ft-hint-display">
               {hint && (
-                <div className="text-yellow-300 text-sm mb-2">
+                <div className="text-ds-warning text-sm mb-2">
                   {t('hintAvailable')}: {formatHintZone(t, hint.fromZone, hint.fromCol)} →{' '}
                   {formatHintZone(t, hint.toZone, hint.toCol)}
                 </div>

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -325,7 +325,7 @@ function FreeCellPageContent() {
 
             {/* Hint display */}
             {hint && (
-              <div className="text-yellow-300 text-sm mb-2">
+              <div className="text-ds-warning text-sm mb-2">
                 {t('hintAvailable')}: {hint.fromZone}
                 {hint.fromCol >= 0 ? ` ${hint.fromCol}` : ''} → {hint.toZone}
                 {hint.toCol >= 0 ? ` ${hint.toCol}` : ''}

--- a/frontend/src/pages/GinRummyPage.tsx
+++ b/frontend/src/pages/GinRummyPage.tsx
@@ -304,7 +304,7 @@ function GinRummyPageContent() {
                     </thead>
                     <tbody>
                       {state.players.map((p) => (
-                        <tr key={p.id} className={p.isHuman ? 'text-yellow-300' : ''}>
+                        <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
                           <td>{playerName(p.id, p.isHuman)}</td>
                           <td className="text-center">{p.roundScore}</td>
                           <td className="text-center">{p.cumulativeScore}</td>

--- a/frontend/src/pages/GolfPage.tsx
+++ b/frontend/src/pages/GolfPage.tsx
@@ -266,7 +266,7 @@ function GolfPageContent() {
             {/* Hint display */}
             <div data-tutorial="golf-hint-display">
               {hint && (
-                <div className="text-yellow-300 text-sm mb-2 text-center">
+                <div className="text-ds-warning text-sm mb-2 text-center">
                   {t('hintAvailable')}: {t(`hintType.${hint.type}`)}
                 </div>
               )}

--- a/frontend/src/pages/HeartsPage.tsx
+++ b/frontend/src/pages/HeartsPage.tsx
@@ -254,7 +254,7 @@ function HeartsPageContent() {
               <div>
                 {/* Pass direction (pass phase) */}
                 {isPassPhase && (
-                  <div className="text-yellow-300 text-center mb-2" data-tutorial="ht-pass-area">
+                  <div className="text-ds-warning text-center mb-2" data-tutorial="ht-pass-area">
                     {t(`passDirection.${passDirectionKeys[state.passDirection]}`)}
                   </div>
                 )}
@@ -315,7 +315,7 @@ function HeartsPageContent() {
                     </thead>
                     <tbody>
                       {state.players.map((p) => (
-                        <tr key={p.id} className={p.isHuman ? 'text-yellow-300' : ''}>
+                        <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
                           <td>{playerName(p.id, p.isHuman)}</td>
                           <td className="text-center">{p.roundScore}</td>
                           <td className="text-center">{p.cumulativeScore}</td>
@@ -363,7 +363,7 @@ function HeartsPageContent() {
             <ErrorAlert message={error ?? hintError} onRetry={retry} />
 
             {hint && (
-              <div className="text-yellow-300 text-sm mb-2">
+              <div className="text-ds-warning text-sm mb-2">
                 {t('hintAvailable')}: {hint.cardIndices.map((i) => `[${i}]`).join(', ')} (
                 {t(`hintReason.${hint.reason}`)})
               </div>

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -124,7 +124,7 @@ function StatTooltip({ id, label, tooltipText }: { id: string; label: string; to
 function HudStats({ vpip, pfr, threeBet, af }: { vpip: number; pfr: number; threeBet: number; af: string }) {
   const { t } = useTranslation('holdem');
   return (
-    <span className="ml-2 text-cyan-300 text-[0.8em] hidden sm:inline" data-testid="hud-stats">
+    <span className="ml-2 text-ds-info text-[0.8em] hidden sm:inline" data-testid="hud-stats">
       <StatTooltip id="tooltip-vpip" label={t('stats.vpip')} tooltipText={t('stats.vpipTooltip')} />:{vpip}%{' '}
       <StatTooltip id="tooltip-pfr" label={t('stats.pfr')} tooltipText={t('stats.pfrTooltip')} />:{pfr}%{' '}
       <StatTooltip id="tooltip-3bet" label={t('stats.threeBet')} tooltipText={t('stats.threeBetTooltip')} />:{threeBet}%{' '}
@@ -390,8 +390,8 @@ function HoldemPageContent() {
                       {tc('betting.currentBet')} {humanPlayer.currentBet}
                     </span>
                   )}
-                  {humanPlayer.folded && <span className="ml-2 text-red-300 text-xs">[{tc('status.folded')}]</span>}
-                  {humanPlayer.allIn && <span className="ml-2 text-yellow-300 text-xs">[{tc('status.allIn')}]</span>}
+                  {humanPlayer.folded && <span className="ml-2 text-ds-error text-xs">[{tc('status.folded')}]</span>}
+                  {humanPlayer.allIn && <span className="ml-2 text-ds-warning text-xs">[{tc('status.allIn')}]</span>}
                   {isShowdown && !humanPlayer.folded && humanPlayer.handName && (
                     <span className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}>
                       {humanPlayer.handName}

--- a/frontend/src/pages/IndianPokerPage.tsx
+++ b/frontend/src/pages/IndianPokerPage.tsx
@@ -222,8 +222,8 @@ function IndianPokerPageContent() {
                           {tc('betting.currentBet')} {p.currentBet}
                         </span>
                       )}
-                      {p.folded && <span className="ml-1 text-red-300 text-xs">[{tc('status.folded')}]</span>}
-                      {p.allIn && <span className="ml-1 text-yellow-300 text-xs">[{tc('status.allIn')}]</span>}
+                      {p.folded && <span className="ml-1 text-ds-error text-xs">[{tc('status.folded')}]</span>}
+                      {p.allIn && <span className="ml-1 text-ds-warning text-xs">[{tc('status.allIn')}]</span>}
                     </div>
                     <div className={isMobile ? 'flex justify-center' : 'flex flex-wrap gap-1'}>
                       {p.card ? (
@@ -271,8 +271,8 @@ function IndianPokerPageContent() {
                       {tc('betting.currentBet')} {humanPlayer.currentBet}
                     </span>
                   )}
-                  {humanPlayer.folded && <span className="ml-2 text-red-300 text-xs">[{tc('status.folded')}]</span>}
-                  {humanPlayer.allIn && <span className="ml-2 text-yellow-300 text-xs">[{tc('status.allIn')}]</span>}
+                  {humanPlayer.folded && <span className="ml-2 text-ds-error text-xs">[{tc('status.folded')}]</span>}
+                  {humanPlayer.allIn && <span className="ml-2 text-ds-warning text-xs">[{tc('status.allIn')}]</span>}
                 </div>
                 <div className="flex flex-wrap gap-1.5 mb-2">
                   {isShowdown && humanPlayer.card ? (

--- a/frontend/src/pages/KlondikePage.tsx
+++ b/frontend/src/pages/KlondikePage.tsx
@@ -418,7 +418,7 @@ function KlondikePageContent() {
             {/* Hint display */}
             <div data-tutorial="kl-hint-display">
               {hint && (
-                <div className="text-yellow-300 text-sm mb-2">
+                <div className="text-ds-warning text-sm mb-2">
                   {t('hintAvailable')}: {hint.fromZone}
                   {hint.fromCol >= 0 ? ` ${t('tableau')} ${hint.fromCol}` : ` ${t('waste')}`} → {hint.toZone}
                   {hint.toCol >= 0 ? ` ${hint.toCol}` : ''}
@@ -433,7 +433,7 @@ function KlondikePageContent() {
 
             {/* Score display on game clear */}
             {isGameClear && isVegas && (
-              <div className="text-yellow-300 text-lg mb-2">
+              <div className="text-ds-warning text-lg mb-2">
                 {t('totalScore')}: {state.score + timeBonus(elapsedSeconds)}
               </div>
             )}

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -185,7 +185,7 @@ function MemoryPageContent() {
               aria-label={t('scores')}
             >
               {state.players.map((p, idx) => (
-                <span key={p.id} className={p.isHuman ? 'text-yellow-300' : ''}>
+                <span key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
                   {idx > 0 && (
                     <span className="text-white/40 mr-3" aria-hidden="true">
                       |

--- a/frontend/src/pages/NapoleonPage.tsx
+++ b/frontend/src/pages/NapoleonPage.tsx
@@ -312,20 +312,20 @@ function NapoleonPageContent() {
 
                 {/* Bid phase instruction */}
                 {isHumanBidTurn && (
-                  <div className="text-yellow-300 text-center mb-2" data-tutorial="np-bid-controls">
+                  <div className="text-ds-warning text-center mb-2" data-tutorial="np-bid-controls">
                     {t('bidPhase', { min: napoleonConfig.minBid })}
                   </div>
                 )}
 
                 {/* Trump declaration instruction */}
                 {isHumanNapoleon && (
-                  <div className="text-yellow-300 text-center mb-2" data-tutorial="np-trump-declaration">
+                  <div className="text-ds-warning text-center mb-2" data-tutorial="np-trump-declaration">
                     {t('trumpDeclarationPhase')}
                   </div>
                 )}
 
                 {/* Kitty exchange instruction */}
-                {isHumanExchange && <div className="text-yellow-300 text-center mb-2">{t('kittyExchangePhase')}</div>}
+                {isHumanExchange && <div className="text-ds-warning text-center mb-2">{t('kittyExchangePhase')}</div>}
 
                 {/* Kitty cards (during exchange phase) */}
                 {isKittyExchange && state.kitty.length > 0 && (
@@ -390,7 +390,7 @@ function NapoleonPageContent() {
                 {/* Score table */}
                 <div className="my-3 p-2 rounded bg-black/30 relative" data-tutorial="np-score-table">
                   <div className="text-white/70 text-sm mb-1">{t('scores')}</div>
-                  <div className="overflow-x-auto">
+                  <div className="overflow-x-auto -mx-2 px-2">
                     <table className="w-full text-sm text-white/70 min-w-[420px]">
                       <thead>
                         <tr>
@@ -407,7 +407,7 @@ function NapoleonPageContent() {
                       </thead>
                       <tbody>
                         {state.players.map((p) => (
-                          <tr key={p.id} className={p.isHuman ? 'text-yellow-300' : ''}>
+                          <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
                             <td>{playerName(p.id, p.isHuman)}</td>
                             <td className="text-center">
                               {p.isNapoleon
@@ -490,7 +490,7 @@ function NapoleonPageContent() {
             <ErrorAlert message={error ?? hintError} onRetry={retry} />
 
             {hint && (
-              <div className="text-yellow-300 text-sm mb-2">
+              <div className="text-ds-warning text-sm mb-2">
                 {hint.bid != null
                   ? `${t('hintBid')}: ${hint.bid} (${t(`hintReason.${hint.reason}`)})`
                   : hint.trumpSuit != null

--- a/frontend/src/pages/OhHellPage.tsx
+++ b/frontend/src/pages/OhHellPage.tsx
@@ -274,7 +274,7 @@ function OhHellPageContent() {
               <div>
                 {/* Bid phase instruction */}
                 {isHumanBidTurn && (
-                  <div className="text-yellow-300 text-center mb-2" data-tutorial="oh-bid-controls">
+                  <div className="text-ds-warning text-center mb-2" data-tutorial="oh-bid-controls">
                     <div>{t('bidPhase', { max: state.handSize })}</div>
                     {state.restrictedBid >= 0 && (
                       <div className="text-orange-300 text-sm">{t('restrictedBid', { n: state.restrictedBid })}</div>
@@ -339,7 +339,7 @@ function OhHellPageContent() {
                 {/* Score table */}
                 <div className="my-3 p-2 rounded bg-black/30 relative" data-tutorial="oh-score-table">
                   <div className="text-white/70 text-sm mb-1">{t('scores')}</div>
-                  <div className="overflow-x-auto">
+                  <div className="overflow-x-auto -mx-2 px-2">
                     <table className="w-full text-sm text-white/70 min-w-[360px]">
                       <thead>
                         <tr>
@@ -354,7 +354,7 @@ function OhHellPageContent() {
                       </thead>
                       <tbody>
                         {state.players.map((p) => (
-                          <tr key={p.id} className={p.isHuman ? 'text-yellow-300' : ''}>
+                          <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
                             <td>{playerName(p.id, p.isHuman)}</td>
                             <td className="text-center">{p.bid >= 0 ? p.bid : '-'}</td>
                             <td className="text-center">{p.trickCount}</td>
@@ -431,7 +431,7 @@ function OhHellPageContent() {
             <ErrorAlert message={error ?? hintError} onRetry={retry} />
 
             {hint && (
-              <div className="text-yellow-300 text-sm mb-2">
+              <div className="text-ds-warning text-sm mb-2">
                 {hint.bid != null
                   ? `${t('hintBid')}: ${hint.bid} (${t(`hintReason.${hint.reason}`)})`
                   : `${t('hintPlay')}: [${hint.cardIndex}] (${t(`hintReason.${hint.reason}`)})`}

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -124,7 +124,7 @@ function StatTooltip({ id, label, tooltipText }: { id: string; label: string; to
 function HudStats({ vpip, pfr, threeBet, af }: { vpip: number; pfr: number; threeBet: number; af: string }) {
   const { t } = useTranslation('omaha');
   return (
-    <span className="ml-2 text-cyan-300 text-[0.8em] hidden sm:inline" data-testid="hud-stats">
+    <span className="ml-2 text-ds-info text-[0.8em] hidden sm:inline" data-testid="hud-stats">
       <StatTooltip id="tooltip-vpip" label={t('stats.vpip')} tooltipText={t('stats.vpipTooltip')} />:{vpip}%{' '}
       <StatTooltip id="tooltip-pfr" label={t('stats.pfr')} tooltipText={t('stats.pfrTooltip')} />:{pfr}%{' '}
       <StatTooltip id="tooltip-3bet" label={t('stats.threeBet')} tooltipText={t('stats.threeBetTooltip')} />:{threeBet}%{' '}
@@ -385,8 +385,8 @@ function OmahaPageContent() {
                       {tc('betting.currentBet')} {humanPlayer.currentBet}
                     </span>
                   )}
-                  {humanPlayer.folded && <span className="ml-2 text-red-300 text-xs">[{tc('status.folded')}]</span>}
-                  {humanPlayer.allIn && <span className="ml-2 text-yellow-300 text-xs">[{tc('status.allIn')}]</span>}
+                  {humanPlayer.folded && <span className="ml-2 text-ds-error text-xs">[{tc('status.folded')}]</span>}
+                  {humanPlayer.allIn && <span className="ml-2 text-ds-warning text-xs">[{tc('status.allIn')}]</span>}
                   {isShowdown && !humanPlayer.folded && humanPlayer.handName && (
                     <span className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}>
                       {humanPlayer.handName}

--- a/frontend/src/pages/PaiGowPage.tsx
+++ b/frontend/src/pages/PaiGowPage.tsx
@@ -219,7 +219,7 @@ function PaiGowPageContent() {
             {/* Player Cards with selection during SET_HANDS phase */}
             {isSetHandsPhase && state.playerCards.length > 0 && (
               <div className="mb-4" data-tutorial="pg-set-hands">
-                <div className="text-yellow-300 font-bold text-center mb-1">
+                <div className="text-ds-warning font-bold text-center mb-1">
                   <span aria-hidden="true">🟡</span> {t('player')}
                 </div>
                 <p className="text-white/70 text-center text-sm mb-2">
@@ -251,7 +251,7 @@ function PaiGowPageContent() {
               <div data-tutorial="pg-results">
                 {state.playerHighHand.length > 0 && (
                   <div className="mb-4">
-                    <div className="text-yellow-300 font-bold text-center mb-1">
+                    <div className="text-ds-warning font-bold text-center mb-1">
                       <span aria-hidden="true">🟡</span> {t('label.highHand')}
                       {state.playerHighRank >= 0 && (
                         <span className="ml-2 text-sm">({t(HIGH_HAND_RANK_KEYS[state.playerHighRank])})</span>
@@ -271,7 +271,7 @@ function PaiGowPageContent() {
                 )}
                 {state.playerLowHand.length > 0 && (
                   <div className="mb-4">
-                    <div className="text-yellow-300 font-bold text-center mb-1">
+                    <div className="text-ds-warning font-bold text-center mb-1">
                       <span aria-hidden="true">🟡</span> {t('label.lowHand')}
                       {state.playerLowRank >= 0 && (
                         <span className="ml-2 text-sm">({t(LOW_HAND_RANK_KEYS[state.playerLowRank])})</span>
@@ -293,7 +293,7 @@ function PaiGowPageContent() {
                 {/* Dealer High Hand and Low Hand */}
                 {state.dealerHighHand.length > 0 && (
                   <div className="mb-4">
-                    <div className="text-red-300 font-bold text-center mb-1">
+                    <div className="text-ds-error font-bold text-center mb-1">
                       <span aria-hidden="true">🔴</span> {t('label.highHand')}
                       {state.dealerHighRank >= 0 && (
                         <span className="ml-2 text-sm">({t(HIGH_HAND_RANK_KEYS[state.dealerHighRank])})</span>
@@ -313,7 +313,7 @@ function PaiGowPageContent() {
                 )}
                 {state.dealerLowHand.length > 0 && (
                   <div className="mb-4">
-                    <div className="text-red-300 font-bold text-center mb-1">
+                    <div className="text-ds-error font-bold text-center mb-1">
                       <span aria-hidden="true">🔴</span> {t('label.lowHand')}
                       {state.dealerLowRank >= 0 && (
                         <span className="ml-2 text-sm">({t(LOW_HAND_RANK_KEYS[state.dealerLowRank])})</span>

--- a/frontend/src/pages/PigsTailPage.tsx
+++ b/frontend/src/pages/PigsTailPage.tsx
@@ -163,7 +163,7 @@ function PigsTailPageContent() {
             {/* Last action indicator */}
             {state.lastDrawCard && (
               <div
-                className={`text-center text-sm font-medium ${state.lastPenalty ? 'text-red-300' : 'text-green-300'}`}
+                className={`text-center text-sm font-medium ${state.lastPenalty ? 'text-ds-error' : 'text-ds-success'}`}
               >
                 {state.lastPenalty ? t('label.penalty') : t('label.safe')}
               </div>

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -131,7 +131,7 @@ function StatTooltip({ id, label, tooltipText }: { id: string; label: string; to
 function HudStats({ vpip, pfr, threeBet, af }: { vpip: number; pfr: number; threeBet: number; af: string }) {
   const { t } = useTranslation('pineapple');
   return (
-    <span className="ml-2 text-cyan-300 text-[0.8em] hidden sm:inline" data-testid="hud-stats">
+    <span className="ml-2 text-ds-info text-[0.8em] hidden sm:inline" data-testid="hud-stats">
       <StatTooltip id="tooltip-vpip" label={t('stats.vpip')} tooltipText={t('stats.vpipTooltip')} />:{vpip}%{' '}
       <StatTooltip id="tooltip-pfr" label={t('stats.pfr')} tooltipText={t('stats.pfrTooltip')} />:{pfr}%{' '}
       <StatTooltip id="tooltip-3bet" label={t('stats.threeBet')} tooltipText={t('stats.threeBetTooltip')} />:{threeBet}%{' '}
@@ -406,8 +406,8 @@ function PineapplePageContent() {
                       {tc('betting.currentBet')} {humanPlayer.currentBet}
                     </span>
                   )}
-                  {humanPlayer.folded && <span className="ml-2 text-red-300 text-xs">[{tc('status.folded')}]</span>}
-                  {humanPlayer.allIn && <span className="ml-2 text-yellow-300 text-xs">[{tc('status.allIn')}]</span>}
+                  {humanPlayer.folded && <span className="ml-2 text-ds-error text-xs">[{tc('status.folded')}]</span>}
+                  {humanPlayer.allIn && <span className="ml-2 text-ds-warning text-xs">[{tc('status.allIn')}]</span>}
                   {isShowdown && !humanPlayer.folded && humanPlayer.handName && (
                     <span className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}>
                       {humanPlayer.handName}

--- a/frontend/src/pages/PinochlePage.tsx
+++ b/frontend/src/pages/PinochlePage.tsx
@@ -174,7 +174,7 @@ function PinochlePageContent() {
               {state.players?.map((p) => (
                 <div
                   key={p.id}
-                  className={`rounded p-2 text-sm ${p.isHuman ? 'bg-yellow-500/20 text-yellow-200' : 'bg-black/30 text-white/70'}`}
+                  className={`rounded p-2 text-sm ${p.isHuman ? 'bg-ds-accent/20 text-ds-accent' : 'bg-black/30 text-white/70'}`}
                 >
                   <div className="font-bold">{playerName(p.id, p.isHuman)}</div>
                   <div>

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -255,8 +255,8 @@ function PokerPageContent() {
                       {tc('betting.currentBet')} {humanPlayer.currentBet}
                     </span>
                   )}
-                  {humanPlayer.folded && <span className="ml-2 text-red-300 text-xs">[{tc('status.folded')}]</span>}
-                  {humanPlayer.allIn && <span className="ml-2 text-yellow-300 text-xs">[{tc('status.allIn')}]</span>}
+                  {humanPlayer.folded && <span className="ml-2 text-ds-error text-xs">[{tc('status.folded')}]</span>}
+                  {humanPlayer.allIn && <span className="ml-2 text-ds-warning text-xs">[{tc('status.allIn')}]</span>}
                   {isEnd && !humanPlayer.folded && humanPlayer.handName && (
                     <span className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}>
                       {humanPlayer.handName}

--- a/frontend/src/pages/PyramidPage.tsx
+++ b/frontend/src/pages/PyramidPage.tsx
@@ -304,7 +304,7 @@ function PyramidPageContent() {
             {/* Hint display */}
             <div data-tutorial="py-hint-display">
               {hint && (
-                <div className="text-yellow-300 text-sm mb-2 text-center">
+                <div className="text-ds-warning text-sm mb-2 text-center">
                   {t('hintAvailable')}: {t(`hintType.${hint.type}`)}
                 </div>
               )}

--- a/frontend/src/pages/SevenCardStudPage.tsx
+++ b/frontend/src/pages/SevenCardStudPage.tsx
@@ -294,8 +294,8 @@ function SevenCardStudPageContent() {
                         {tc('betting.currentBet')} {p.currentBet}
                       </span>
                     )}
-                    {p.folded && <span className="ml-2 text-red-300 text-xs">[{tc('status.folded')}]</span>}
-                    {p.allIn && <span className="ml-2 text-yellow-300 text-xs">[{tc('status.allIn')}]</span>}
+                    {p.folded && <span className="ml-2 text-ds-error text-xs">[{tc('status.folded')}]</span>}
+                    {p.allIn && <span className="ml-2 text-ds-warning text-xs">[{tc('status.allIn')}]</span>}
                     {isShowdown && !p.folded && p.handName && (
                       <span className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}>
                         {p.handName}
@@ -374,8 +374,8 @@ function SevenCardStudPageContent() {
                       {tc('betting.currentBet')} {humanPlayer.currentBet}
                     </span>
                   )}
-                  {humanPlayer.folded && <span className="ml-2 text-red-300 text-xs">[{tc('status.folded')}]</span>}
-                  {humanPlayer.allIn && <span className="ml-2 text-yellow-300 text-xs">[{tc('status.allIn')}]</span>}
+                  {humanPlayer.folded && <span className="ml-2 text-ds-error text-xs">[{tc('status.folded')}]</span>}
+                  {humanPlayer.allIn && <span className="ml-2 text-ds-warning text-xs">[{tc('status.allIn')}]</span>}
                   {isShowdown && !humanPlayer.folded && humanPlayer.handName && (
                     <span className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}>
                       {humanPlayer.handName}

--- a/frontend/src/pages/SevensPage.tsx
+++ b/frontend/src/pages/SevensPage.tsx
@@ -280,7 +280,7 @@ function SevensPageContent() {
                 state.config.jokerReclaimEnabled ||
                 state.config.endStopEnabled ||
                 state.config.jokerConsecutiveBanned) && (
-                <div className="bg-black/30 rounded-lg text-yellow-300 py-1.5 px-3 mb-2 text-xs">
+                <div className="bg-black/30 rounded-lg text-ds-warning py-1.5 px-3 mb-2 text-xs">
                   {t('rules.title')}
                   {state.config.tunnelEnabled && ` ${t('rules.tunnelTag')}`}
                   {state.config.tunnelSkipWidth >= 2 &&

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -124,7 +124,7 @@ function StatTooltip({ id, label, tooltipText }: { id: string; label: string; to
 function HudStats({ vpip, pfr, threeBet, af }: { vpip: number; pfr: number; threeBet: number; af: string }) {
   const { t } = useTranslation('shortdeck');
   return (
-    <span className="ml-2 text-cyan-300 text-[0.8em] hidden sm:inline" data-testid="hud-stats">
+    <span className="ml-2 text-ds-info text-[0.8em] hidden sm:inline" data-testid="hud-stats">
       <StatTooltip id="tooltip-vpip" label={t('stats.vpip')} tooltipText={t('stats.vpipTooltip')} />:{vpip}%{' '}
       <StatTooltip id="tooltip-pfr" label={t('stats.pfr')} tooltipText={t('stats.pfrTooltip')} />:{pfr}%{' '}
       <StatTooltip id="tooltip-3bet" label={t('stats.threeBet')} tooltipText={t('stats.threeBetTooltip')} />:{threeBet}%{' '}
@@ -388,8 +388,8 @@ function ShortDeckPageContent() {
                       {tc('betting.currentBet')} {humanPlayer.currentBet}
                     </span>
                   )}
-                  {humanPlayer.folded && <span className="ml-2 text-red-300 text-xs">[{tc('status.folded')}]</span>}
-                  {humanPlayer.allIn && <span className="ml-2 text-yellow-300 text-xs">[{tc('status.allIn')}]</span>}
+                  {humanPlayer.folded && <span className="ml-2 text-ds-error text-xs">[{tc('status.folded')}]</span>}
+                  {humanPlayer.allIn && <span className="ml-2 text-ds-warning text-xs">[{tc('status.allIn')}]</span>}
                   {isShowdown && !humanPlayer.folded && humanPlayer.handName && (
                     <span className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}>
                       {humanPlayer.handName}

--- a/frontend/src/pages/SpadesPage.tsx
+++ b/frontend/src/pages/SpadesPage.tsx
@@ -240,7 +240,7 @@ function SpadesPageContent() {
               <div>
                 {/* Bid phase instruction */}
                 {isHumanBidTurn && (
-                  <div className="text-yellow-300 text-center mb-2" data-tutorial="sp-bid-controls">
+                  <div className="text-ds-warning text-center mb-2" data-tutorial="sp-bid-controls">
                     {t('bidPhase')}
                   </div>
                 )}
@@ -289,7 +289,7 @@ function SpadesPageContent() {
                 {/* Score table */}
                 <div className="my-3 p-2 rounded bg-black/30 relative" data-tutorial="sp-score-table">
                   <div className="text-white/70 text-sm mb-1">{t('scores')}</div>
-                  <div className="overflow-x-auto">
+                  <div className="overflow-x-auto -mx-2 px-2">
                     <table className="w-full text-sm text-white/70 min-w-[360px]">
                       <thead>
                         <tr>
@@ -305,7 +305,7 @@ function SpadesPageContent() {
                       </thead>
                       <tbody>
                         {state.players.map((p) => (
-                          <tr key={p.id} className={p.isHuman ? 'text-yellow-300' : ''}>
+                          <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
                             <td>{playerName(p.id, p.isHuman)}</td>
                             <td className="text-center">{p.bid >= 0 ? p.bid : '-'}</td>
                             <td className="text-center">{p.trickCount}</td>
@@ -357,7 +357,7 @@ function SpadesPageContent() {
             <ErrorAlert message={error ?? hintError} onRetry={retry} />
 
             {hint && (
-              <div className="text-yellow-300 text-sm mb-2">
+              <div className="text-ds-warning text-sm mb-2">
                 {hint.bid != null
                   ? `${t('hintBid')}: ${hint.bid} (${t(`hintReason.${hint.reason}`)})`
                   : `${t('hintPlay')}: [${hint.cardIndex}] (${t(`hintReason.${hint.reason}`)})`}

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -296,7 +296,7 @@ function SpiderPageContent() {
 
             {/* Hint display */}
             {hint && (
-              <div className="text-yellow-300 text-sm mb-2">
+              <div className="text-ds-warning text-sm mb-2">
                 {t('hintAvailable')}: {t('tableau')} {hint.fromCol} [{hint.cardIndex}] → {t('tableau')} {hint.toCol}
               </div>
             )}

--- a/frontend/src/pages/ThreeCardPage.tsx
+++ b/frontend/src/pages/ThreeCardPage.tsx
@@ -220,7 +220,7 @@ function ThreeCardPageContent() {
             {/* Player Hand */}
             {state.playerHand.length > 0 && (
               <div className="mb-4" data-tutorial="tc-results">
-                <div className="text-yellow-300 font-bold text-center mb-1">
+                <div className="text-ds-warning font-bold text-center mb-1">
                   <span aria-hidden="true">🟡</span> {t('player')}
                   {isEndPhase && state.playerHandRank > 0 && (
                     <span className="ml-2 text-sm">({t(HAND_RANK_KEYS[state.playerHandRank])})</span>
@@ -242,7 +242,7 @@ function ThreeCardPageContent() {
             {/* Dealer Hand */}
             {state.dealerHand.length > 0 && (
               <div className="mb-4">
-                <div className="text-red-300 font-bold text-center mb-1">
+                <div className="text-ds-error font-bold text-center mb-1">
                   <span aria-hidden="true">🔴</span> {t('dealer')}
                   {isEndPhase && state.dealerHandRank > 0 && (
                     <span className="ml-2 text-sm">({t(HAND_RANK_KEYS[state.dealerHandRank])})</span>

--- a/frontend/src/pages/TriPeaksPage.tsx
+++ b/frontend/src/pages/TriPeaksPage.tsx
@@ -287,7 +287,7 @@ function TriPeaksPageContent() {
             {/* Hint display */}
             <div data-tutorial="tp-hint-display">
               {hint && (
-                <div className="text-yellow-300 text-sm mb-2 text-center">
+                <div className="text-ds-warning text-sm mb-2 text-center">
                   {t('hintAvailable')}: {t(`hintType.${hint.type}`)}
                 </div>
               )}


### PR DESCRIPTION
## Summary

- **#1263**: Replace 90+ hardcoded Tailwind color classes (`text-yellow-300`, `text-red-300`, `text-cyan-300`, `text-green-400/300`) with design system tokens (`text-ds-warning`, `text-ds-error`, `text-ds-info`, `text-ds-success`, `text-ds-accent`) across 43 page/component files, enabling CSS Custom Property-based theme switching
- **#1264**: Add `accent-color: var(--color-ds-accent)` for `input[type="checkbox"]` and `input[type="radio"]` in `index.css` so all 50+ checkboxes match the gold design system palette on dark backgrounds
- **#1265**: Add `-mx-2 px-2` scroll padding to `overflow-x-auto` score table wrappers in OhHellPage, NapoleonPage, and SpadesPage for better mobile edge-scroll UX
- **#1266**: Replace `bg-red-100 border-red-400` with `bg-red-900/40 border-ds-error text-ds-error` in BettingControls error state for proper dark-theme contrast

Closes #1263, Closes #1264, Closes #1265, Closes #1266

## Test plan

- [x] Frontend build passes (`bun run build`)
- [x] Biome lint passes (`bun run check`)
- [x] All 4723 Vitest tests pass (`bun run test`)
- [x] MetaAiIndicator test updated for new DS token class names
- [x] BettingControls test updated for new error state class names
- [ ] Visual verification: spot-check HoldemPage HUD stats (info), folded/allIn badges (error/warning), score table highlights (accent)
- [ ] Visual verification: checkboxes in SettingsPanel render with gold accent color
- [ ] Visual verification: BettingControls error state visible on dark background
- [ ] Mobile verification: score tables in OhHell/Napoleon/Spades scroll within container without page-level horizontal scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)