### PR TITLE
refactor: consolidate game registry and extract poker helpers

### DIFF
--- a/cmd/trumpcards/completion.go
+++ b/cmd/trumpcards/completion.go
@@ -13,8 +13,8 @@ import (
 // completionSubcommands returns the sorted list of all subcommands for shell completion,
 // derived from the game registry and aliases.
 func completionSubcommands() []string {
-	names := make([]string, 0, len(ui.GameNames)+len(ui.GameAliases)+4)
-	names = append(names, ui.GameNames...)
+	names := make([]string, 0, len(ui.GameNames())+len(ui.GameAliases)+4)
+	names = append(names, ui.GameNames()...)
 	for alias := range ui.GameAliases {
 		names = append(names, alias)
 	}
@@ -215,7 +215,7 @@ type completionEntry struct {
 // buildCompletionEntries builds a sorted list of all commands with descriptions
 // for shell completion, derived from the game registry and aliases.
 func buildCompletionEntries() []completionEntry {
-	descs := ui.GameDescriptions
+	descs := ui.GameDescriptions()
 	// Strip Japanese text in parentheses for cleaner completion descriptions.
 	stripJa := func(s string) string {
 		if idx := strings.Index(s, " ("); idx >= 0 {
@@ -224,8 +224,8 @@ func buildCompletionEntries() []completionEntry {
 		return s
 	}
 
-	entries := make([]completionEntry, 0, len(ui.GameNames)+len(ui.GameAliases)+4)
-	for _, name := range ui.GameNames {
+	entries := make([]completionEntry, 0, len(ui.GameNames())+len(ui.GameAliases)+4)
+	for _, name := range ui.GameNames() {
 		entries = append(entries, completionEntry{name, stripJa(descs[name])})
 	}
 	for alias, canonical := range ui.GameAliases {

--- a/cmd/trumpcards/completion.go
+++ b/cmd/trumpcards/completion.go
@@ -4,19 +4,23 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
+	"strings"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/ui"
 )
 
-// completionSubcommands is the list of all subcommands for shell completion.
-var completionSubcommands = []string{
-	"3card", "40t", "6plus", "7cs", "7stud",
-	"baccarat", "blackjack", "bridge", "canasta", "clock", "clocksolitaire", "completion",
-	"crazy8", "crazyeights", "cribbage", "daifugo", "deuces", "deuceswild", "doubt", "durak",
-	"euchre", "fortythieves", "freecell", "games", "gin", "ginrummy", "gofish", "golf",
-	"hearts", "holdem", "indian", "indianpoker", "joker", "jokerpoker", "klondike",
-	"memory", "napoleon", "ohhell", "oldmaid", "omaha", "paigow", "pgp", "pigtail",
-	"pineapple", "pinochle", "poker", "pyramid", "sevencardstud", "sevens", "short",
-	"shortdeck", "spades", "speed", "spider", "threecard", "tripeaks", "update",
-	"video", "videopoker", "web",
+// completionSubcommands returns the sorted list of all subcommands for shell completion,
+// derived from the game registry and aliases.
+func completionSubcommands() []string {
+	names := make([]string, 0, len(ui.GameNames)+len(ui.GameAliases)+4)
+	names = append(names, ui.GameNames...)
+	for alias := range ui.GameAliases {
+		names = append(names, alias)
+	}
+	names = append(names, "completion", "games", "update", "web")
+	sort.Strings(names)
+	return names
 }
 
 // runCompletion outputs a shell completion script for the given shell name.
@@ -82,7 +86,8 @@ func writeInstallHint(w io.Writer, shell string) {
 }
 
 func writeBashCompletion(w io.Writer) error {
-	script := `_trumpcards() {
+	cmds := strings.Join(completionSubcommands(), " ")
+	script := fmt.Sprintf(`_trumpcards() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
@@ -109,82 +114,29 @@ func writeBashCompletion(w io.Writer) error {
         return
     fi
 
-    local commands="3card 40t 6plus 7cs 7stud baccarat blackjack bridge canasta clock clocksolitaire completion crazy8 crazyeights cribbage daifugo deuces deuceswild doubt durak euchre fortythieves freecell games gin ginrummy gofish golf hearts holdem indian indianpoker joker jokerpoker klondike memory napoleon ohhell oldmaid omaha paigow pgp pigtail pineapple pinochle poker pyramid sevencardstud sevens short shortdeck spades speed spider threecard tripeaks update video videopoker web"
+    local commands="%s"
     COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
 }
 complete -F _trumpcards trumpcards
-`
+`, cmds)
 	_, err := fmt.Fprint(w, script)
 	return err
 }
 
 func writeZshCompletion(w io.Writer) error {
-	script := `#compdef trumpcards
+	entries := buildCompletionEntries()
+	var sb strings.Builder
+	for _, e := range entries {
+		// Escape single quotes for zsh: ' -> '\''
+		desc := strings.ReplaceAll(e.desc, "'", `'\''`)
+		fmt.Fprintf(&sb, "        '%s:%s'\n", e.name, desc)
+	}
+	script := fmt.Sprintf(`#compdef trumpcards
 
 _trumpcards() {
     local -a commands
     commands=(
-        '3card:Three Card Poker (alias)'
-        '40t:Forty Thieves (alias)'
-        '6plus:Short Deck Hold'\''em (alias)'
-        '7cs:Seven Card Stud (alias)'
-        '7stud:Seven Card Stud (alias)'
-        'baccarat:Baccarat'
-        'blackjack:BlackJack'
-        'bridge:Contract Bridge'
-        'canasta:Canasta'
-        'clock:Clock Solitaire (alias)'
-        'clocksolitaire:Clock Solitaire'
-        'completion:Generate shell completion script'
-        'crazy8:Crazy Eights (alias)'
-        'crazyeights:Crazy Eights'
-        'cribbage:Cribbage'
-        'daifugo:Daifugo'
-        'deuces:Deuces Wild (alias)'
-        'deuceswild:Deuces Wild'
-        'doubt:Doubt'
-        'durak:Durak'
-        'euchre:Euchre'
-        'fortythieves:Forty Thieves'
-        'freecell:FreeCell'
-        'games:List available games'
-        'gin:Gin Rummy (alias)'
-        'ginrummy:Gin Rummy'
-        'gofish:Go Fish'
-        'golf:Golf Solitaire'
-        'hearts:Hearts'
-        'holdem:Texas Hold'\''em'
-        'indian:Indian Poker (alias)'
-        'indianpoker:Indian Poker'
-        'joker:Joker Poker (alias)'
-        'jokerpoker:Joker Poker'
-        'klondike:Klondike Solitaire'
-        'memory:Memory'
-        'napoleon:Napoleon'
-        'ohhell:Oh Hell'
-        'oldmaid:Old Maid'
-        'omaha:Omaha Hold'\''em'
-        'paigow:Pai Gow Poker'
-        'pgp:Pai Gow Poker (alias)'
-        'pigtail:Pig'\''s Tail'
-        'pineapple:Pineapple Poker'
-        'pinochle:Pinochle'
-        'poker:5-card Draw Poker'
-        'pyramid:Pyramid'
-        'sevencardstud:Seven Card Stud'
-        'sevens:Sevens'
-        'short:Short Deck Hold'\''em (alias)'
-        'shortdeck:Short Deck Hold'\''em'
-        'spades:Spades'
-        'speed:Speed'
-        'spider:Spider Solitaire'
-        'threecard:Three Card Poker'
-        'tripeaks:TriPeaks'
-        'update:Self-update to the latest version'
-        'video:Video Poker (alias)'
-        'videopoker:Video Poker'
-        'web:Start REST API + web GUI server'
-    )
+%s    )
 
     _arguments \
         '(-h --help)'{-h,--help}'[Show help message]' \
@@ -217,13 +169,20 @@ _trumpcards() {
 }
 
 _trumpcards "$@"
-`
+`, sb.String())
 	_, err := fmt.Fprint(w, script)
 	return err
 }
 
 func writeFishCompletion(w io.Writer) error {
-	script := `# Fish completion for trumpcards
+	entries := buildCompletionEntries()
+	var sb strings.Builder
+	for _, e := range entries {
+		// Escape single quotes for fish: ' -> \'
+		desc := strings.ReplaceAll(e.desc, "'", `\'`)
+		fmt.Fprintf(&sb, "complete -c trumpcards -n __fish_use_subcommand -a %s -d '%s'\n", e.name, desc)
+	}
+	script := fmt.Sprintf(`# Fish completion for trumpcards
 complete -c trumpcards -f
 
 # Global options
@@ -233,67 +192,7 @@ complete -c trumpcards -l lang -x -a 'ja en' -d 'Language'
 complete -c trumpcards -l no-color -d 'Disable color output'
 
 # Subcommands
-complete -c trumpcards -n __fish_use_subcommand -a 3card -d 'Three Card Poker (alias)'
-complete -c trumpcards -n __fish_use_subcommand -a 40t -d 'Forty Thieves (alias)'
-complete -c trumpcards -n __fish_use_subcommand -a 6plus -d 'Short Deck Hold'\''em (alias)'
-complete -c trumpcards -n __fish_use_subcommand -a 7cs -d 'Seven Card Stud (alias)'
-complete -c trumpcards -n __fish_use_subcommand -a 7stud -d 'Seven Card Stud (alias)'
-complete -c trumpcards -n __fish_use_subcommand -a baccarat -d 'Baccarat'
-complete -c trumpcards -n __fish_use_subcommand -a blackjack -d 'BlackJack'
-complete -c trumpcards -n __fish_use_subcommand -a bridge -d 'Contract Bridge'
-complete -c trumpcards -n __fish_use_subcommand -a canasta -d 'Canasta'
-complete -c trumpcards -n __fish_use_subcommand -a clock -d 'Clock Solitaire (alias)'
-complete -c trumpcards -n __fish_use_subcommand -a clocksolitaire -d 'Clock Solitaire'
-complete -c trumpcards -n __fish_use_subcommand -a completion -d 'Generate shell completion script'
-complete -c trumpcards -n __fish_use_subcommand -a crazy8 -d 'Crazy Eights (alias)'
-complete -c trumpcards -n __fish_use_subcommand -a crazyeights -d 'Crazy Eights'
-complete -c trumpcards -n __fish_use_subcommand -a cribbage -d 'Cribbage'
-complete -c trumpcards -n __fish_use_subcommand -a daifugo -d 'Daifugo'
-complete -c trumpcards -n __fish_use_subcommand -a deuces -d 'Deuces Wild (alias)'
-complete -c trumpcards -n __fish_use_subcommand -a deuceswild -d 'Deuces Wild'
-complete -c trumpcards -n __fish_use_subcommand -a doubt -d 'Doubt'
-complete -c trumpcards -n __fish_use_subcommand -a durak -d 'Durak'
-complete -c trumpcards -n __fish_use_subcommand -a euchre -d 'Euchre'
-complete -c trumpcards -n __fish_use_subcommand -a fortythieves -d 'Forty Thieves'
-complete -c trumpcards -n __fish_use_subcommand -a freecell -d 'FreeCell'
-complete -c trumpcards -n __fish_use_subcommand -a games -d 'List available games'
-complete -c trumpcards -n __fish_use_subcommand -a gin -d 'Gin Rummy (alias)'
-complete -c trumpcards -n __fish_use_subcommand -a ginrummy -d 'Gin Rummy'
-complete -c trumpcards -n __fish_use_subcommand -a gofish -d 'Go Fish'
-complete -c trumpcards -n __fish_use_subcommand -a golf -d 'Golf Solitaire'
-complete -c trumpcards -n __fish_use_subcommand -a hearts -d 'Hearts'
-complete -c trumpcards -n __fish_use_subcommand -a holdem -d 'Texas Hold'\''em'
-complete -c trumpcards -n __fish_use_subcommand -a indian -d 'Indian Poker (alias)'
-complete -c trumpcards -n __fish_use_subcommand -a indianpoker -d 'Indian Poker'
-complete -c trumpcards -n __fish_use_subcommand -a joker -d 'Joker Poker (alias)'
-complete -c trumpcards -n __fish_use_subcommand -a jokerpoker -d 'Joker Poker'
-complete -c trumpcards -n __fish_use_subcommand -a klondike -d 'Klondike Solitaire'
-complete -c trumpcards -n __fish_use_subcommand -a memory -d 'Memory'
-complete -c trumpcards -n __fish_use_subcommand -a napoleon -d 'Napoleon'
-complete -c trumpcards -n __fish_use_subcommand -a ohhell -d 'Oh Hell'
-complete -c trumpcards -n __fish_use_subcommand -a oldmaid -d 'Old Maid'
-complete -c trumpcards -n __fish_use_subcommand -a omaha -d 'Omaha Hold'\''em'
-complete -c trumpcards -n __fish_use_subcommand -a paigow -d 'Pai Gow Poker'
-complete -c trumpcards -n __fish_use_subcommand -a pgp -d 'Pai Gow Poker (alias)'
-complete -c trumpcards -n __fish_use_subcommand -a pigtail -d 'Pig'\''s Tail'
-complete -c trumpcards -n __fish_use_subcommand -a pineapple -d 'Pineapple Poker'
-complete -c trumpcards -n __fish_use_subcommand -a pinochle -d 'Pinochle'
-complete -c trumpcards -n __fish_use_subcommand -a poker -d '5-card Draw Poker'
-complete -c trumpcards -n __fish_use_subcommand -a pyramid -d 'Pyramid'
-complete -c trumpcards -n __fish_use_subcommand -a sevencardstud -d 'Seven Card Stud'
-complete -c trumpcards -n __fish_use_subcommand -a sevens -d 'Sevens'
-complete -c trumpcards -n __fish_use_subcommand -a short -d 'Short Deck Hold'\''em (alias)'
-complete -c trumpcards -n __fish_use_subcommand -a shortdeck -d 'Short Deck Hold'\''em'
-complete -c trumpcards -n __fish_use_subcommand -a spades -d 'Spades'
-complete -c trumpcards -n __fish_use_subcommand -a speed -d 'Speed'
-complete -c trumpcards -n __fish_use_subcommand -a spider -d 'Spider Solitaire'
-complete -c trumpcards -n __fish_use_subcommand -a threecard -d 'Three Card Poker'
-complete -c trumpcards -n __fish_use_subcommand -a tripeaks -d 'TriPeaks'
-complete -c trumpcards -n __fish_use_subcommand -a update -d 'Self-update to the latest version'
-complete -c trumpcards -n __fish_use_subcommand -a video -d 'Video Poker (alias)'
-complete -c trumpcards -n __fish_use_subcommand -a videopoker -d 'Video Poker'
-complete -c trumpcards -n __fish_use_subcommand -a web -d 'Start REST API + web GUI server'
-
+%s
 # completion subcommand
 complete -c trumpcards -n '__fish_seen_subcommand_from completion' -a 'bash zsh fish'
 
@@ -302,7 +201,42 @@ complete -c trumpcards -n '__fish_seen_subcommand_from update' -l yes -s y -d 'S
 
 # web subcommand
 complete -c trumpcards -n '__fish_seen_subcommand_from web' -l port -s p -d 'Port number' -x
-`
+`, sb.String())
 	_, err := fmt.Fprint(w, script)
 	return err
+}
+
+// completionEntry holds a command name and its short description for shell completion.
+type completionEntry struct {
+	name string
+	desc string
+}
+
+// buildCompletionEntries builds a sorted list of all commands with descriptions
+// for shell completion, derived from the game registry and aliases.
+func buildCompletionEntries() []completionEntry {
+	descs := ui.GameDescriptions
+	// Strip Japanese text in parentheses for cleaner completion descriptions.
+	stripJa := func(s string) string {
+		if idx := strings.Index(s, " ("); idx >= 0 {
+			return s[:idx]
+		}
+		return s
+	}
+
+	entries := make([]completionEntry, 0, len(ui.GameNames)+len(ui.GameAliases)+4)
+	for _, name := range ui.GameNames {
+		entries = append(entries, completionEntry{name, stripJa(descs[name])})
+	}
+	for alias, canonical := range ui.GameAliases {
+		entries = append(entries, completionEntry{alias, stripJa(descs[canonical]) + " (alias)"})
+	}
+	entries = append(entries,
+		completionEntry{"completion", "Generate shell completion script"},
+		completionEntry{"games", "List available games"},
+		completionEntry{"update", "Self-update to the latest version"},
+		completionEntry{"web", "Start REST API + web GUI server"},
+	)
+	sort.Slice(entries, func(i, j int) bool { return entries[i].name < entries[j].name })
+	return entries
 }

--- a/cmd/trumpcards/completion_test.go
+++ b/cmd/trumpcards/completion_test.go
@@ -20,7 +20,7 @@ func TestWriteBashCompletion(t *testing.T) {
 	assert.Contains(t, script, "--lang")
 	assert.Contains(t, script, "--port")
 	// Every subcommand in the canonical list must appear in the bash script.
-	for _, cmd := range completionSubcommands {
+	for _, cmd := range completionSubcommands() {
 		assert.Contains(t, script, cmd, "bash completion missing subcommand %q", cmd)
 	}
 }
@@ -33,7 +33,7 @@ func TestWriteZshCompletion(t *testing.T) {
 	assert.Contains(t, script, "#compdef trumpcards")
 	assert.Contains(t, script, "--port")
 	// Every subcommand in the canonical list must appear in the zsh script.
-	for _, cmd := range completionSubcommands {
+	for _, cmd := range completionSubcommands() {
 		assert.Contains(t, script, "'"+cmd+":", "zsh completion missing subcommand %q", cmd)
 	}
 }
@@ -47,7 +47,7 @@ func TestWriteFishCompletion(t *testing.T) {
 	assert.Contains(t, script, "__fish_seen_subcommand_from completion")
 	assert.Contains(t, script, "-l port")
 	// Every subcommand in the canonical list must appear in the fish script.
-	for _, cmd := range completionSubcommands {
+	for _, cmd := range completionSubcommands() {
 		assert.Contains(t, script, "-a "+cmd, "fish completion missing subcommand %q", cmd)
 	}
 }
@@ -105,30 +105,30 @@ func TestRunCompletion_ValidShells(t *testing.T) {
 
 func TestCompletionSubcommands_ContainsAllGames(t *testing.T) {
 	// Verify the list is sorted
-	for i := 1; i < len(completionSubcommands); i++ {
-		assert.True(t, completionSubcommands[i-1] < completionSubcommands[i],
-			"completionSubcommands not sorted: %q >= %q", completionSubcommands[i-1], completionSubcommands[i])
+	for i := 1; i < len(completionSubcommands()); i++ {
+		assert.True(t, completionSubcommands()[i-1] < completionSubcommands()[i],
+			"completionSubcommands() not sorted: %q >= %q", completionSubcommands()[i-1], completionSubcommands()[i])
 	}
 
 	// Verify key games are present
 	expected := []string{"blackjack", "poker", "web", "update", "completion", "golf"}
-	joined := strings.Join(completionSubcommands, " ")
+	joined := strings.Join(completionSubcommands(), " ")
 	for _, e := range expected {
 		assert.Contains(t, joined, e)
 	}
 }
 
 func TestCompletionSubcommands_SyncWithGameNames(t *testing.T) {
-	subSet := make(map[string]bool, len(completionSubcommands))
-	for _, s := range completionSubcommands {
+	subSet := make(map[string]bool, len(completionSubcommands()))
+	for _, s := range completionSubcommands() {
 		subSet[s] = true
 	}
-	// Every game in ui.GameNames must appear in completionSubcommands.
+	// Every game in ui.GameNames must appear in completionSubcommands().
 	for _, name := range ui.GameNames {
-		assert.True(t, subSet[name], "completionSubcommands missing game %q from ui.GameNames", name)
+		assert.True(t, subSet[name], "completionSubcommands() missing game %q from ui.GameNames", name)
 	}
-	// Every alias in ui.GameAliases must appear in completionSubcommands.
+	// Every alias in ui.GameAliases must appear in completionSubcommands().
 	for alias := range ui.GameAliases {
-		assert.True(t, subSet[alias], "completionSubcommands missing alias %q from ui.GameAliases", alias)
+		assert.True(t, subSet[alias], "completionSubcommands() missing alias %q from ui.GameAliases", alias)
 	}
 }

--- a/cmd/trumpcards/completion_test.go
+++ b/cmd/trumpcards/completion_test.go
@@ -124,8 +124,8 @@ func TestCompletionSubcommands_SyncWithGameNames(t *testing.T) {
 		subSet[s] = true
 	}
 	// Every game in ui.GameNames must appear in completionSubcommands().
-	for _, name := range ui.GameNames {
-		assert.True(t, subSet[name], "completionSubcommands() missing game %q from ui.GameNames", name)
+	for _, name := range ui.GameNames() {
+		assert.True(t, subSet[name], "completionSubcommands() missing game %q from ui.GameNames()", name)
 	}
 	// Every alias in ui.GameAliases must appear in completionSubcommands().
 	for alias := range ui.GameAliases {

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -32,87 +32,7 @@ func main() {
 }
 
 func run() int {
-	helpText := `USAGE:
-  trumpcards [--lang ja|en] [game]
-  trumpcards --help
-
-GAMES:
-  blackjack    BlackJack (ブラックジャック)
-  poker        5-card Draw Poker (ポーカー)
-  oldmaid      Old Maid (ババ抜き)
-  daifugo      Daifugo / Great Fool (大富豪)
-  sevens       Sevens (7並べ)
-  doubt        Doubt (ダウト)
-  durak        Durak / Fool (ドゥラーク)
-  holdem       Texas Hold'em (テキサスホールデム)
-  omaha        Omaha Hold'em (オマハホールデム)
-  shortdeck    Short Deck (6+ Hold'em) (ショートデック)
-  hearts       Hearts (ハーツ)
-  memory       Memory / Concentration (神経衰弱)
-  klondike     Klondike Solitaire (ソリティア)
-  fortythieves Forty Thieves (フォーティシーブス)
-  freecell     FreeCell (フリーセル)
-  baccarat     Baccarat (バカラ)
-  spades       Spades (スペード)
-  crazyeights  Crazy Eights (クレイジーエイト)
-  ginrummy     Gin Rummy (ジンラミー)
-  canasta      Canasta (カナスタ)
-  spider       Spider Solitaire (スパイダーソリティア)
-  napoleon     Napoleon (ナポレオン)
-  indianpoker  Indian Poker (インディアンポーカー)
-  videopoker   Video Poker Jacks or Better (ビデオポーカー)
-  deuceswild   Deuces Wild (デューシーズワイルド)
-  jokerpoker   Joker Poker (ジョーカーポーカー)
-  euchre       Euchre (ユーカー)
-  pyramid      Pyramid (ピラミッド)
-  tripeaks     TriPeaks (トリピークス)
-  cribbage     Cribbage (クリベッジ)
-  threecard    Three Card Poker (スリーカードポーカー)
-  ohhell       Oh Hell (オー・ヘル)
-  bridge       Contract Bridge (コントラクトブリッジ)
-  pineapple    Pineapple Poker (パイナップルポーカー)
-  speed        Speed (スピード)
-  gofish       Go Fish (ゴーフィッシュ)
-  paigow       Pai Gow Poker (パイガオポーカー)
-  pinochle     Pinochle (ピノクル)
-  pigtail      Pig's Tail (ブタのしっぽ)
-  sevencardstud Seven Card Stud (セブンカードスタッド)
-  golf         Golf Solitaire (ゴルフ)
-  clocksolitaire Clock Solitaire (クロックソリティア)
-
-COMMANDS:
-  games        List all available games (--short for names only)
-  completion   Generate shell completion script (bash, zsh, fish)
-  update       Self-update to the latest version
-  web          Start REST API + web GUI server
-
-  (no argument) Interactive mode with game switching
-
-OPTIONS:
-  -h, --help        Show this help message
-  --lang ja|en      Language (default: ja)
-  --no-color        Disable color output
-  -V, --version     Show version information
-
-EXAMPLES:
-  trumpcards                     Start interactive mode (switch games with 'switch <game>')
-  trumpcards blackjack           Play BlackJack
-  trumpcards --lang en poker     Play Poker in English
-  trumpcards games               List all available games
-  trumpcards games --short       List game names only (for scripting)
-  trumpcards update              Self-update to the latest version
-  trumpcards update --yes        Update without confirmation prompt
-  NO_COLOR=1 trumpcards hearts   Play Hearts without color output
-  trumpcards web                 Start the web GUI server
-  trumpcards web --port 3000     Start the web GUI on port 3000
-  source <(trumpcards completion bash)   Enable bash completion
-
-ENVIRONMENT VARIABLES:
-  NO_COLOR          Disable color output when set (see https://no-color.org/)
-                    Example: NO_COLOR=1 trumpcards blackjack
-  PORT              Port number for the web server (default: 8080)
-                    Example: PORT=3000 trumpcards web
-`
+	helpText := buildHelpText()
 
 	lang := flag.String("lang", "", "language (ja or en)")
 	showVersion := flag.Bool("version", false, "Show version information")
@@ -159,176 +79,88 @@ ENVIRONMENT VARIABLES:
 	if i18n.Lang() != detectedLang && detectedLang != "" {
 		fmt.Fprintln(os.Stderr, i18n.Tf("cliUnsupportedLang", "lang", detectedLang))
 	}
-	// gameDescriptions maps canonical game names to display descriptions.
-	gameDescriptions := map[string]string{
-		"blackjack":      "BlackJack (ブラックジャック)",
-		"poker":          "5-card Draw Poker (ポーカー)",
-		"oldmaid":        "Old Maid (ババ抜き)",
-		"daifugo":        "Daifugo / Great Fool (大富豪)",
-		"sevens":         "Sevens (7並べ)",
-		"doubt":          "Doubt (ダウト)",
-		"holdem":         "Texas Hold'em (テキサスホールデム)",
-		"omaha":          "Omaha Hold'em (オマハホールデム)",
-		"shortdeck":      "Short Deck (6+ Hold'em) (ショートデック)",
-		"pineapple":      "Pineapple Poker (パイナップルポーカー)",
-		"hearts":         "Hearts (ハーツ)",
-		"memory":         "Memory / Concentration (神経衰弱)",
-		"klondike":       "Klondike Solitaire (ソリティア)",
-		"freecell":       "FreeCell (フリーセル)",
-		"baccarat":       "Baccarat (バカラ)",
-		"spades":         "Spades (スペード)",
-		"crazyeights":    "Crazy Eights (クレイジーエイト)",
-		"ginrummy":       "Gin Rummy (ジンラミー)",
-		"canasta":        "Canasta (カナスタ)",
-		"spider":         "Spider Solitaire (スパイダーソリティア)",
-		"napoleon":       "Napoleon (ナポレオン)",
-		"indianpoker":    "Indian Poker (インディアンポーカー)",
-		"videopoker":     "Video Poker Jacks or Better (ビデオポーカー)",
-		"deuceswild":     "Deuces Wild (デューシーズワイルド)",
-		"jokerpoker":     "Joker Poker (ジョーカーポーカー)",
-		"euchre":         "Euchre (ユーカー)",
-		"pyramid":        "Pyramid (ピラミッド)",
-		"tripeaks":       "TriPeaks (トリピークス)",
-		"cribbage":       "Cribbage (クリベッジ)",
-		"threecard":      "Three Card Poker (スリーカードポーカー)",
-		"ohhell":         "Oh Hell (オー・ヘル)",
-		"bridge":         "Contract Bridge (コントラクトブリッジ)",
-		"speed":          "Speed (スピード)",
-		"gofish":         "Go Fish (ゴーフィッシュ)",
-		"pinochle":       "Pinochle (ピノクル)",
-		"golf":           "Golf Solitaire (ゴルフ)",
-		"pigtail":        "Pig's Tail (ブタのしっぽ)",
-		"sevencardstud":  "Seven Card Stud (セブンカードスタッド)",
-		"clocksolitaire": "Clock Solitaire (クロックソリティア)",
-		"durak":          "Durak / Fool (ドゥラーク)",
-		"fortythieves":   "Forty Thieves (フォーティシーブス)",
-		"paigow":         "Pai Gow Poker (パイガオポーカー)",
+	// Build game commands from the registry (single source of truth).
+	commands := buildGameCommands()
+	commands["games"] = func() int {
+		gamesFlags := flag.NewFlagSet("games", flag.ContinueOnError)
+		short := gamesFlags.Bool("short", false, "Print game names only")
+		if err := gamesFlags.Parse(flag.Args()[1:]); err != nil {
+			if errors.Is(err, flag.ErrHelp) {
+				return 0
+			}
+			return 1
+		}
+		if gamesFlags.NArg() > 0 {
+			fmt.Fprintln(os.Stderr, i18n.Tf("cliExtraArgsWarning", "args", strings.Join(gamesFlags.Args(), " ")))
+		}
+		// Build reverse alias map: canonical name -> sorted list of aliases.
+		reverseAliases := make(map[string][]string)
+		for alias, canonical := range ui.GameAliases {
+			reverseAliases[canonical] = append(reverseAliases[canonical], alias)
+		}
+		for k := range reverseAliases {
+			sort.Strings(reverseAliases[k])
+		}
+		for _, name := range ui.GameNames {
+			if *short {
+				fmt.Println(name)
+			} else {
+				line := fmt.Sprintf("  %-16s %s", name, ui.GameDescriptions[name])
+				if aliases := reverseAliases[name]; len(aliases) > 0 {
+					line += fmt.Sprintf("  [aliases: %s]", strings.Join(aliases, ", "))
+				}
+				fmt.Println(line)
+			}
+		}
+		return 0
 	}
-
-	commands := map[string]func() int{
-		"blackjack":      func() int { ui.NewBlackJackCui().Exec(); return 0 },
-		"poker":          func() int { ui.NewPokerCui().Exec(); return 0 },
-		"oldmaid":        func() int { ui.NewOldMaidCui().Exec(); return 0 },
-		"daifugo":        func() int { ui.NewDaifugoCui().Exec(); return 0 },
-		"sevens":         func() int { ui.NewSevensCui().Exec(); return 0 },
-		"doubt":          func() int { ui.NewDoubtCui().Exec(); return 0 },
-		"holdem":         func() int { ui.NewHoldemCui().Exec(); return 0 },
-		"omaha":          func() int { ui.NewOmahaCui().Exec(); return 0 },
-		"shortdeck":      func() int { ui.NewShortDeckCui().Exec(); return 0 },
-		"hearts":         func() int { ui.NewHeartsCui().Exec(); return 0 },
-		"memory":         func() int { ui.NewMemoryCui().Exec(); return 0 },
-		"klondike":       func() int { ui.NewKlondikeCui().Exec(); return 0 },
-		"freecell":       func() int { ui.NewFreeCellCui().Exec(); return 0 },
-		"baccarat":       func() int { ui.NewBaccaratCui().Exec(); return 0 },
-		"spades":         func() int { ui.NewSpadesCui().Exec(); return 0 },
-		"crazyeights":    func() int { ui.NewCrazyEightsCui().Exec(); return 0 },
-		"ginrummy":       func() int { ui.NewGinRummyCui().Exec(); return 0 },
-		"canasta":        func() int { ui.NewCanastaCui().Exec(); return 0 },
-		"spider":         func() int { ui.NewSpiderCui().Exec(); return 0 },
-		"napoleon":       func() int { ui.NewNapoleonCui().Exec(); return 0 },
-		"indianpoker":    func() int { ui.NewIndianPokerCui().Exec(); return 0 },
-		"videopoker":     func() int { ui.NewVideoPokerCui().Exec(); return 0 },
-		"deuceswild":     func() int { ui.NewDeucesWildCui().Exec(); return 0 },
-		"jokerpoker":     func() int { ui.NewJokerPokerCui().Exec(); return 0 },
-		"euchre":         func() int { ui.NewEuchreCui().Exec(); return 0 },
-		"pyramid":        func() int { ui.NewPyramidCui().Exec(); return 0 },
-		"tripeaks":       func() int { ui.NewTriPeaksCui().Exec(); return 0 },
-		"cribbage":       func() int { ui.NewCribbageCui().Exec(); return 0 },
-		"threecard":      func() int { ui.NewThreeCardCui().Exec(); return 0 },
-		"ohhell":         func() int { ui.NewOhHellCui().Exec(); return 0 },
-		"bridge":         func() int { ui.NewBridgeCui().Exec(); return 0 },
-		"pineapple":      func() int { ui.NewPineappleCui().Exec(); return 0 },
-		"speed":          func() int { ui.NewSpeedCui().Exec(); return 0 },
-		"gofish":         func() int { ui.NewGoFishCui().Exec(); return 0 },
-		"pinochle":       func() int { ui.NewPinochleCui().Exec(); return 0 },
-		"golf":           func() int { ui.NewGolfCui().Exec(); return 0 },
-		"pigtail":        func() int { ui.NewPigsTailCui().Exec(); return 0 },
-		"sevencardstud":  func() int { ui.NewSevenCardStudCui().Exec(); return 0 },
-		"clocksolitaire": func() int { ui.NewClockSolitaireCui().Exec(); return 0 },
-		"durak":          func() int { ui.NewDurakCui().Exec(); return 0 },
-		"fortythieves":   func() int { ui.NewFortyThievesCui().Exec(); return 0 },
-		"paigow":         func() int { ui.NewPaiGowCui().Exec(); return 0 },
-		"games": func() int {
-			gamesFlags := flag.NewFlagSet("games", flag.ContinueOnError)
-			short := gamesFlags.Bool("short", false, "Print game names only")
-			if err := gamesFlags.Parse(flag.Args()[1:]); err != nil {
-				if errors.Is(err, flag.ErrHelp) {
-					return 0
-				}
+	commands["completion"] = func() int {
+		return runCompletion(flag.Args()[1:])
+	}
+	commands["update"] = func() int {
+		updateFlags := flag.NewFlagSet("update", flag.ContinueOnError)
+		yes := updateFlags.Bool("yes", false, "Skip confirmation prompt")
+		updateFlags.BoolVar(yes, "y", false, "Skip confirmation prompt (shorthand)")
+		if err := updateFlags.Parse(flag.Args()[1:]); err != nil {
+			if errors.Is(err, flag.ErrHelp) {
+				return 0
+			}
+			return 1
+		}
+		updater := update.NewUpdater(version, os.Stdin, os.Stderr, os.Stderr)
+		updater.SetAutoConfirm(*yes)
+		if err := updater.Exec(); err != nil {
+			return 1
+		}
+		return 0
+	}
+	commands["web"] = func() int {
+		webFlags := flag.NewFlagSet("web", flag.ContinueOnError)
+		port := webFlags.Int("port", 0, "Port number for the web server (default: 8080)")
+		webFlags.IntVar(port, "p", 0, "Port number for the web server (shorthand)")
+		if err := webFlags.Parse(flag.Args()[1:]); err != nil {
+			if errors.Is(err, flag.ErrHelp) {
+				return 0
+			}
+			return 1
+		}
+		if webFlags.NArg() > 0 {
+			fmt.Fprintln(os.Stderr, i18n.Tf("cliExtraArgsWarning", "args", strings.Join(webFlags.Args(), " ")))
+		}
+		if *port != 0 {
+			if *port < 1 || *port > 65535 {
+				fmt.Fprintln(os.Stderr, i18n.Tf("cliInvalidPort", "port", strconv.Itoa(*port)))
 				return 1
 			}
-			if gamesFlags.NArg() > 0 {
-				fmt.Fprintln(os.Stderr, i18n.Tf("cliExtraArgsWarning", "args", strings.Join(gamesFlags.Args(), " ")))
-			}
-			// Build reverse alias map: canonical name -> sorted list of aliases.
-			reverseAliases := make(map[string][]string)
-			for alias, canonical := range ui.GameAliases {
-				reverseAliases[canonical] = append(reverseAliases[canonical], alias)
-			}
-			for k := range reverseAliases {
-				sort.Strings(reverseAliases[k])
-			}
-			for _, name := range ui.GameNames {
-				if *short {
-					fmt.Println(name)
-				} else {
-					line := fmt.Sprintf("  %-16s %s", name, gameDescriptions[name])
-					if aliases := reverseAliases[name]; len(aliases) > 0 {
-						line += fmt.Sprintf("  [aliases: %s]", strings.Join(aliases, ", "))
-					}
-					fmt.Println(line)
-				}
-			}
-			return 0
-		},
-		"completion": func() int {
-			return runCompletion(flag.Args()[1:])
-		},
-		"update": func() int {
-			updateFlags := flag.NewFlagSet("update", flag.ContinueOnError)
-			yes := updateFlags.Bool("yes", false, "Skip confirmation prompt")
-			updateFlags.BoolVar(yes, "y", false, "Skip confirmation prompt (shorthand)")
-			if err := updateFlags.Parse(flag.Args()[1:]); err != nil {
-				if errors.Is(err, flag.ErrHelp) {
-					return 0
-				}
-				return 1
-			}
-			updater := update.NewUpdater(version, os.Stdin, os.Stderr, os.Stderr)
-			updater.SetAutoConfirm(*yes)
-			if err := updater.Exec(); err != nil {
-				return 1
-			}
-			return 0
-		},
-		"web": func() int {
-			webFlags := flag.NewFlagSet("web", flag.ContinueOnError)
-			port := webFlags.Int("port", 0, "Port number for the web server (default: 8080)")
-			webFlags.IntVar(port, "p", 0, "Port number for the web server (shorthand)")
-			if err := webFlags.Parse(flag.Args()[1:]); err != nil {
-				if errors.Is(err, flag.ErrHelp) {
-					return 0
-				}
-				return 1
-			}
-			if webFlags.NArg() > 0 {
-				fmt.Fprintln(os.Stderr, i18n.Tf("cliExtraArgsWarning", "args", strings.Join(webFlags.Args(), " ")))
-			}
-			if *port != 0 {
-				if *port < 1 || *port > 65535 {
-					fmt.Fprintln(os.Stderr, i18n.Tf("cliInvalidPort", "port", strconv.Itoa(*port)))
-					return 1
-				}
-				_ = os.Setenv("PORT", strconv.Itoa(*port))
-			}
-			infrastructure.InitLogger()
-			w := web.NewTrumpCardsWeb()
-			if err := w.Exec(); err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				return 1
-			}
-			return 0
-		},
+			_ = os.Setenv("PORT", strconv.Itoa(*port))
+		}
+		infrastructure.InitLogger()
+		w := web.NewTrumpCardsWeb()
+		if err := w.Exec(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
+		}
+		return 0
 	}
 
 	// Commands that parse their own sub-flags; skip the extra-args warning for these.
@@ -369,4 +201,68 @@ func mapKeys(m map[string]func() int) []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+// buildHelpText generates the CLI help text with the games section derived from the registry.
+func buildHelpText() string {
+	var sb strings.Builder
+	sb.WriteString(`USAGE:
+  trumpcards [--lang ja|en] [game]
+  trumpcards --help
+
+GAMES:
+`)
+	for _, entry := range ui.GameRegistry() {
+		fmt.Fprintf(&sb, "  %-16s %s\n", entry.Name, entry.Description)
+	}
+	sb.WriteString(`
+COMMANDS:
+  games        List all available games (--short for names only)
+  completion   Generate shell completion script (bash, zsh, fish)
+  update       Self-update to the latest version
+  web          Start REST API + web GUI server
+
+  (no argument) Interactive mode with game switching
+
+OPTIONS:
+  -h, --help        Show this help message
+  --lang ja|en      Language (default: ja)
+  --no-color        Disable color output
+  -V, --version     Show version information
+
+EXAMPLES:
+  trumpcards                     Start interactive mode (switch games with 'switch <game>')
+  trumpcards blackjack           Play BlackJack
+  trumpcards --lang en poker     Play Poker in English
+  trumpcards games               List all available games
+  trumpcards games --short       List game names only (for scripting)
+  trumpcards update              Self-update to the latest version
+  trumpcards update --yes        Update without confirmation prompt
+  NO_COLOR=1 trumpcards hearts   Play Hearts without color output
+  trumpcards web                 Start the web GUI server
+  trumpcards web --port 3000     Start the web GUI on port 3000
+  source <(trumpcards completion bash)   Enable bash completion
+
+ENVIRONMENT VARIABLES:
+  NO_COLOR          Disable color output when set (see https://no-color.org/)
+                    Example: NO_COLOR=1 trumpcards blackjack
+  PORT              Port number for the web server (default: 8080)
+                    Example: PORT=3000 trumpcards web
+`)
+	return sb.String()
+}
+
+// buildGameCommands generates command handlers for all games from the registry.
+func buildGameCommands() map[string]func() int {
+	registry := ui.GameRegistry()
+	commands := make(map[string]func() int, len(registry)+4)
+	for _, entry := range registry {
+		e := entry // capture loop variable
+		commands[e.Name] = func() int {
+			g := e.NewCui()
+			ui.RunCuiLoop(g.Controller(), g.HelpLines())
+			return 0
+		}
+	}
+	return commands
 }

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -101,11 +101,12 @@ func run() int {
 		for k := range reverseAliases {
 			sort.Strings(reverseAliases[k])
 		}
-		for _, name := range ui.GameNames {
+		descs := ui.GameDescriptions()
+		for _, name := range ui.GameNames() {
 			if *short {
 				fmt.Println(name)
 			} else {
-				line := fmt.Sprintf("  %-16s %s", name, ui.GameDescriptions[name])
+				line := fmt.Sprintf("  %-16s %s", name, descs[name])
 				if aliases := reverseAliases[name]; len(aliases) > 0 {
 					line += fmt.Sprintf("  [aliases: %s]", strings.Join(aliases, ", "))
 				}

--- a/internal/adapter/controller/HoldemWebController.go
+++ b/internal/adapter/controller/HoldemWebController.go
@@ -146,44 +146,13 @@ type HoldemWebOutput struct {
 // Returns an error if the blind configuration is invalid or tableSize is invalid.
 func (p HoldemWebInput) ToConfig() (domain.HoldemConfig, error) {
 	cfg := domain.DefaultHoldemConfig()
-	sb, bb := cfg.SmallBlind, cfg.BigBlind
-	sbProvided := p.SmallBlind != nil && *p.SmallBlind >= 1
-	bbProvided := p.BigBlind != nil && *p.BigBlind >= 1
-	if sbProvided {
-		sb = *p.SmallBlind
+	if err := validateAndApplyBlinds(&cfg.SmallBlind, &cfg.BigBlind, p.SmallBlind, p.BigBlind, cfg.BigBlind); err != nil {
+		return domain.HoldemConfig{}, err
 	}
-	if bbProvided {
-		bb = *p.BigBlind
-	}
-	// 片方のみ指定された場合、もう片方を自動調整
-	if sbProvided && !bbProvided && sb >= cfg.BigBlind {
-		bb = sb * 2
-	} else if bbProvided && !sbProvided && bb > 1 {
-		sb = bb / 2
-	}
-	if sb >= bb {
-		return domain.HoldemConfig{}, errors.New("param error: smallBlind must be less than bigBlind")
-	}
-	cfg.SmallBlind = sb
-	cfg.BigBlind = bb
-	if p.TournamentMode != nil {
-		cfg.TournamentMode = *p.TournamentMode
-	}
-	if p.BlindLevelHands != nil && *p.BlindLevelHands >= 1 {
-		cfg.BlindLevelHands = *p.BlindLevelHands
-	}
-	if p.BlindMultiplier != nil && *p.BlindMultiplier >= 101 {
-		cfg.BlindMultiplier = *p.BlindMultiplier
-	}
-	if p.BettingLimit != nil {
-		bl := *p.BettingLimit
-		if bl < 0 {
-			bl = 0
-		} else if bl > 2 {
-			bl = 2
-		}
-		cfg.BettingLimit = domain.BettingLimitType(bl)
-	}
+	applyBool(&cfg.TournamentMode, p.TournamentMode)
+	applyIntIfGte(&cfg.BlindLevelHands, p.BlindLevelHands, 1)
+	applyIntIfGte(&cfg.BlindMultiplier, p.BlindMultiplier, 101)
+	applyBettingLimit(&cfg.BettingLimit, p.BettingLimit)
 	if p.TableSize != nil {
 		ts := *p.TableSize
 		if !domain.IsValidHoldemTableSize(ts) {
@@ -191,27 +160,10 @@ func (p HoldemWebInput) ToConfig() (domain.HoldemConfig, error) {
 		}
 		cfg.TableSize = ts
 	}
-	if p.RebuyEnabled != nil {
-		cfg.RebuyEnabled = *p.RebuyEnabled
-	}
-	if p.RebuyMaxCount != nil && *p.RebuyMaxCount >= 1 {
-		cfg.RebuyMaxCount = *p.RebuyMaxCount
-	}
-	if p.RebuyChips != nil && *p.RebuyChips >= 1 {
-		cfg.RebuyChips = *p.RebuyChips
-	}
-	if p.RebuyPeriodHands != nil && *p.RebuyPeriodHands >= 1 {
-		cfg.RebuyPeriodHands = *p.RebuyPeriodHands
-	}
-	if p.AddonEnabled != nil {
-		cfg.AddonEnabled = *p.AddonEnabled
-	}
-	if p.AddonChips != nil && *p.AddonChips >= 1 {
-		cfg.AddonChips = *p.AddonChips
-	}
-	if p.AddonAfterHand != nil && *p.AddonAfterHand >= 1 {
-		cfg.AddonAfterHand = *p.AddonAfterHand
-	}
+	applyRebuyConfig(&cfg.RebuyEnabled, &cfg.RebuyMaxCount, &cfg.RebuyChips, &cfg.RebuyPeriodHands,
+		p.RebuyEnabled, p.RebuyMaxCount, p.RebuyChips, p.RebuyPeriodHands)
+	applyAddonConfig(&cfg.AddonEnabled, &cfg.AddonChips, &cfg.AddonAfterHand,
+		p.AddonEnabled, p.AddonChips, p.AddonAfterHand)
 	cfg.CpuMetaAI = p.CpuMetaAI
 	return cfg, nil
 }
@@ -237,6 +189,9 @@ func newHoldemDefaultOutput(msg string) *HoldemWebOutput {
 }
 
 func holdemDispatch(bc *baseController, w http.ResponseWriter, hgi usecase.HoldemInteractorIF, param HoldemWebInput, newDefault func(string) *HoldemWebOutput) bool {
+	if dispatchPokerAction(bc, w, hgi, param.Command, param.Amount, param.HumanPlayMs) {
+		return true
+	}
 	switch param.Command {
 	case "r", "reset":
 		cfg, err := param.ToConfig()
@@ -245,30 +200,6 @@ func holdemDispatch(bc *baseController, w http.ResponseWriter, hgi usecase.Holde
 			return true
 		}
 		bc.writePresenterResponse(w, hgi.ResetWithConfig(cfg, param.Profile))
-	case "f", "fold":
-		bc.writePresenterResponse(w, hgi.Action(domain.HoldemActionFold, 0, param.HumanPlayMs))
-	case "ck", "check":
-		bc.writePresenterResponse(w, hgi.Action(domain.HoldemActionCheck, 0, param.HumanPlayMs))
-	case "c", "call":
-		bc.writePresenterResponse(w, hgi.Action(domain.HoldemActionCall, 0, param.HumanPlayMs))
-	case "b", "bet":
-		bc.writePresenterResponse(w, hgi.Action(domain.HoldemActionBet, param.Amount, param.HumanPlayMs))
-	case "ra", "raise":
-		bc.writePresenterResponse(w, hgi.Action(domain.HoldemActionRaise, param.Amount, param.HumanPlayMs))
-	case "a", "allin":
-		bc.writePresenterResponse(w, hgi.Action(domain.HoldemActionAllIn, 0, param.HumanPlayMs))
-	case "rb", "rebuy":
-		bc.writePresenterResponse(w, hgi.Rebuy())
-	case "sr", "skiprebuy":
-		bc.writePresenterResponse(w, hgi.SkipRebuy())
-	case "ad", "addon":
-		bc.writePresenterResponse(w, hgi.Addon())
-	case "sa", "skipaddon":
-		bc.writePresenterResponse(w, hgi.SkipAddon())
-	case "m", "muck":
-		bc.writePresenterResponse(w, hgi.Muck())
-	case "sh", "show":
-		bc.writePresenterResponse(w, hgi.ShowHand())
 	default:
 		return dispatchLog(param.Command, bc, w, hgi.ActionLog)
 	}

--- a/internal/adapter/controller/OmahaWebController.go
+++ b/internal/adapter/controller/OmahaWebController.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 
 	"net/http"
@@ -34,38 +33,17 @@ func newOmahaDefaultOutput(msg string) *OmahaWebOutput {
 }
 
 func omahaDispatch(bc *baseController, w http.ResponseWriter, ogi usecase.OmahaInteractorIF, param OmahaWebInput, newDefault func(string) *OmahaWebOutput) bool {
+	if dispatchPokerAction(bc, w, ogi, param.Command, param.Amount, param.HumanPlayMs) {
+		return true
+	}
 	switch param.Command {
 	case "r", "reset":
 		cfg, err := param.ToConfig()
 		if err != nil {
-			bc.writeJsonResponse(w, 400, newDefault(err.Error()))
+			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault(err.Error()))
 			return true
 		}
 		bc.writePresenterResponse(w, ogi.ResetWithConfig(cfg, param.Profile))
-	case "f", "fold":
-		bc.writePresenterResponse(w, ogi.Action(domain.OmahaActionFold, 0, param.HumanPlayMs))
-	case "ck", "check":
-		bc.writePresenterResponse(w, ogi.Action(domain.OmahaActionCheck, 0, param.HumanPlayMs))
-	case "c", "call":
-		bc.writePresenterResponse(w, ogi.Action(domain.OmahaActionCall, 0, param.HumanPlayMs))
-	case "b", "bet":
-		bc.writePresenterResponse(w, ogi.Action(domain.OmahaActionBet, param.Amount, param.HumanPlayMs))
-	case "ra", "raise":
-		bc.writePresenterResponse(w, ogi.Action(domain.OmahaActionRaise, param.Amount, param.HumanPlayMs))
-	case "a", "allin":
-		bc.writePresenterResponse(w, ogi.Action(domain.OmahaActionAllIn, 0, param.HumanPlayMs))
-	case "rb", "rebuy":
-		bc.writePresenterResponse(w, ogi.Rebuy())
-	case "sr", "skiprebuy":
-		bc.writePresenterResponse(w, ogi.SkipRebuy())
-	case "ad", "addon":
-		bc.writePresenterResponse(w, ogi.Addon())
-	case "sa", "skipaddon":
-		bc.writePresenterResponse(w, ogi.SkipAddon())
-	case "m", "muck":
-		bc.writePresenterResponse(w, ogi.Muck())
-	case "sh", "show":
-		bc.writePresenterResponse(w, ogi.ShowHand())
 	default:
 		return dispatchLog(param.Command, bc, w, ogi.ActionLog)
 	}

--- a/internal/adapter/controller/OmahaWebController.go
+++ b/internal/adapter/controller/OmahaWebController.go
@@ -1,9 +1,9 @@
 package controller
 
 import (
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
-
 	"net/http"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
 // OmahaWebInput オマハホールデムWebインプット (HoldemWebInputと同一構造)

--- a/internal/adapter/controller/PineappleWebController.go
+++ b/internal/adapter/controller/PineappleWebController.go
@@ -100,43 +100,13 @@ type PineappleWebOutput struct {
 // ToConfig builds a PineappleConfig from the web input.
 func (p PineappleWebInput) ToConfig() (domain.PineappleConfig, error) {
 	cfg := domain.DefaultPineappleConfig()
-	sb, bb := cfg.SmallBlind, cfg.BigBlind
-	sbProvided := p.SmallBlind != nil && *p.SmallBlind >= 1
-	bbProvided := p.BigBlind != nil && *p.BigBlind >= 1
-	if sbProvided {
-		sb = *p.SmallBlind
+	if err := validateAndApplyBlinds(&cfg.SmallBlind, &cfg.BigBlind, p.SmallBlind, p.BigBlind, cfg.BigBlind); err != nil {
+		return domain.PineappleConfig{}, err
 	}
-	if bbProvided {
-		bb = *p.BigBlind
-	}
-	if sbProvided && !bbProvided && sb >= cfg.BigBlind {
-		bb = sb * 2
-	} else if bbProvided && !sbProvided && bb > 1 {
-		sb = bb / 2
-	}
-	if sb >= bb {
-		return domain.PineappleConfig{}, errors.New("param error: smallBlind must be less than bigBlind")
-	}
-	cfg.SmallBlind = sb
-	cfg.BigBlind = bb
-	if p.TournamentMode != nil {
-		cfg.TournamentMode = *p.TournamentMode
-	}
-	if p.BlindLevelHands != nil && *p.BlindLevelHands >= 1 {
-		cfg.BlindLevelHands = *p.BlindLevelHands
-	}
-	if p.BlindMultiplier != nil && *p.BlindMultiplier >= 101 {
-		cfg.BlindMultiplier = *p.BlindMultiplier
-	}
-	if p.BettingLimit != nil {
-		bl := *p.BettingLimit
-		if bl < 0 {
-			bl = 0
-		} else if bl > 2 {
-			bl = 2
-		}
-		cfg.BettingLimit = domain.BettingLimitType(bl)
-	}
+	applyBool(&cfg.TournamentMode, p.TournamentMode)
+	applyIntIfGte(&cfg.BlindLevelHands, p.BlindLevelHands, 1)
+	applyIntIfGte(&cfg.BlindMultiplier, p.BlindMultiplier, 101)
+	applyBettingLimit(&cfg.BettingLimit, p.BettingLimit)
 	if p.TableSize != nil {
 		ts := *p.TableSize
 		if !domain.IsValidHoldemTableSize(ts) {
@@ -144,27 +114,10 @@ func (p PineappleWebInput) ToConfig() (domain.PineappleConfig, error) {
 		}
 		cfg.TableSize = ts
 	}
-	if p.RebuyEnabled != nil {
-		cfg.RebuyEnabled = *p.RebuyEnabled
-	}
-	if p.RebuyMaxCount != nil && *p.RebuyMaxCount >= 1 {
-		cfg.RebuyMaxCount = *p.RebuyMaxCount
-	}
-	if p.RebuyChips != nil && *p.RebuyChips >= 1 {
-		cfg.RebuyChips = *p.RebuyChips
-	}
-	if p.RebuyPeriodHands != nil && *p.RebuyPeriodHands >= 1 {
-		cfg.RebuyPeriodHands = *p.RebuyPeriodHands
-	}
-	if p.AddonEnabled != nil {
-		cfg.AddonEnabled = *p.AddonEnabled
-	}
-	if p.AddonChips != nil && *p.AddonChips >= 1 {
-		cfg.AddonChips = *p.AddonChips
-	}
-	if p.AddonAfterHand != nil && *p.AddonAfterHand >= 1 {
-		cfg.AddonAfterHand = *p.AddonAfterHand
-	}
+	applyRebuyConfig(&cfg.RebuyEnabled, &cfg.RebuyMaxCount, &cfg.RebuyChips, &cfg.RebuyPeriodHands,
+		p.RebuyEnabled, p.RebuyMaxCount, p.RebuyChips, p.RebuyPeriodHands)
+	applyAddonConfig(&cfg.AddonEnabled, &cfg.AddonChips, &cfg.AddonAfterHand,
+		p.AddonEnabled, p.AddonChips, p.AddonAfterHand)
 	cfg.CpuMetaAI = p.CpuMetaAI
 	return cfg, nil
 }
@@ -190,6 +143,9 @@ func newPineappleDefaultOutput(msg string) *PineappleWebOutput {
 }
 
 func pineappleDispatch(bc *baseController, w http.ResponseWriter, pgi usecase.PineappleInteractorIF, param PineappleWebInput, newDefault func(string) *PineappleWebOutput) bool {
+	if dispatchPokerAction(bc, w, pgi, param.Command, param.Amount, param.HumanPlayMs) {
+		return true
+	}
 	switch param.Command {
 	case "r", "reset":
 		cfg, err := param.ToConfig()
@@ -198,36 +154,12 @@ func pineappleDispatch(bc *baseController, w http.ResponseWriter, pgi usecase.Pi
 			return true
 		}
 		bc.writePresenterResponse(w, pgi.ResetWithConfig(cfg, param.Profile))
-	case "f", "fold":
-		bc.writePresenterResponse(w, pgi.Action(domain.PineappleActionFold, 0, param.HumanPlayMs))
-	case "ck", "check":
-		bc.writePresenterResponse(w, pgi.Action(domain.PineappleActionCheck, 0, param.HumanPlayMs))
-	case "c", "call":
-		bc.writePresenterResponse(w, pgi.Action(domain.PineappleActionCall, 0, param.HumanPlayMs))
-	case "b", "bet":
-		bc.writePresenterResponse(w, pgi.Action(domain.PineappleActionBet, param.Amount, param.HumanPlayMs))
-	case "ra", "raise":
-		bc.writePresenterResponse(w, pgi.Action(domain.PineappleActionRaise, param.Amount, param.HumanPlayMs))
-	case "a", "allin":
-		bc.writePresenterResponse(w, pgi.Action(domain.PineappleActionAllIn, 0, param.HumanPlayMs))
 	case "d", "discard":
 		if param.CardIdx == nil {
 			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIdx is required for discard"))
 			return true
 		}
 		bc.writePresenterResponse(w, pgi.Discard(*param.CardIdx))
-	case "rb", "rebuy":
-		bc.writePresenterResponse(w, pgi.Rebuy())
-	case "sr", "skiprebuy":
-		bc.writePresenterResponse(w, pgi.SkipRebuy())
-	case "ad", "addon":
-		bc.writePresenterResponse(w, pgi.Addon())
-	case "sa", "skipaddon":
-		bc.writePresenterResponse(w, pgi.SkipAddon())
-	case "m", "muck":
-		bc.writePresenterResponse(w, pgi.Muck())
-	case "sh", "show":
-		bc.writePresenterResponse(w, pgi.ShowHand())
 	default:
 		return dispatchLog(param.Command, bc, w, pgi.ActionLog)
 	}

--- a/internal/adapter/controller/PineappleWebController_test.go
+++ b/internal/adapter/controller/PineappleWebController_test.go
@@ -1,0 +1,454 @@
+//go:build test
+
+package controller_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
+	mockUsecase "github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/usecase"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
+)
+
+func newPineappleTestController(mi *mockUsecase.MockPineappleInteractor) *controller.PineappleWebController {
+	pwc := controller.NewPineappleWebController(func() usecase.PineappleInteractorIF {
+		return mi
+	})
+	return pwc
+}
+
+func TestPineappleWebController_Reset(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+
+	cfg := domain.DefaultPineappleConfig()
+	mi.On("ResetWithConfig", cfg, mock.Anything).Return(`{"phase":1,"message":""}`)
+
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{
+		"command":   "reset",
+		"sessionId": "test-session",
+	})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_Reset_WithConfig(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+
+	sb := 10
+	bb := 20
+	cfg := domain.DefaultPineappleConfig()
+	cfg.SmallBlind = sb
+	cfg.BigBlind = bb
+	mi.On("ResetWithConfig", cfg, mock.Anything).Return(`{"phase":1,"message":""}`)
+
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{
+		"command":    "reset",
+		"sessionId":  "test-session",
+		"smallBlind": sb,
+		"bigBlind":   bb,
+	})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_Fold(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+
+	mi.On("Action", domain.PineappleActionFold, 0, 0).Return(`{"phase":1}`)
+
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{
+		"command":   "fold",
+		"sessionId": "test-session",
+	})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_Check(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	mi.On("Action", domain.PineappleActionCheck, 0, 0).Return(`{"phase":1}`)
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "check", "sessionId": "s1"})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_Call(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	mi.On("Action", domain.PineappleActionCall, 0, 0).Return(`{"phase":1}`)
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "call", "sessionId": "s1"})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_Bet(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	mi.On("Action", domain.PineappleActionBet, 50, 0).Return(`{"phase":1}`)
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "bet", "sessionId": "s1", "amount": 50})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_Raise(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	mi.On("Action", domain.PineappleActionRaise, 30, 0).Return(`{"phase":1}`)
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "raise", "sessionId": "s1", "amount": 30})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_AllIn(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	mi.On("Action", domain.PineappleActionAllIn, 0, 0).Return(`{"phase":1}`)
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "allin", "sessionId": "s1"})
+	recorded.CodeIs(200)
+}
+
+// --- discard (Pineapple-specific) ---
+
+func TestPineappleWebController_Discard_ValidCardIdx(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+
+	cardIdx := 2
+	mi.On("Discard", cardIdx).Return(`{"phase":2}`)
+
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{
+		"command":   "discard",
+		"sessionId": "s1",
+		"cardIdx":   cardIdx,
+	})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_Discard_ShortCommand(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+
+	cardIdx := 0
+	mi.On("Discard", cardIdx).Return(`{"phase":2}`)
+
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{
+		"command":   "d",
+		"sessionId": "s1",
+		"cardIdx":   cardIdx,
+	})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_Discard_NilCardIdx(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+
+	// cardIdx is omitted → nil in parsed input → should return 400
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{
+		"command":   "discard",
+		"sessionId": "s1",
+	})
+	recorded.CodeIs(400)
+}
+
+func TestPineappleWebController_Quit(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "quit", "sessionId": "s1"})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_QuitShort(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "q", "sessionId": "s1"})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_Unknown(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	// Must have a session first
+	cfg := domain.DefaultPineappleConfig()
+	mi.On("ResetWithConfig", cfg, mock.Anything).Return(`{"phase":1}`)
+	execRequest(t, pwc.Exec,
+		map[string]interface{}{"command": "reset", "sessionId": "s1"})
+
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "xyz", "sessionId": "s1"})
+	recorded.CodeIs(400)
+}
+
+func TestPineappleWebController_BadRequest_EmptyBody(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	recorded := execRequest(t, pwc.Exec, nil)
+	recorded.CodeIs(400)
+}
+
+func TestPineappleWebController_BadRequest_NoCommand(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"sessionId": "s1"})
+	recorded.CodeIs(400)
+}
+
+func TestPineappleWebController_BadRequest_NoSession(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "reset"})
+	recorded.CodeIs(400)
+}
+
+func TestPineappleWebController_ShortCommands(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+
+	cfg := domain.DefaultPineappleConfig()
+	mi.On("ResetWithConfig", cfg, mock.Anything).Return(`{"phase":1}`)
+	mi.On("Action", domain.PineappleActionFold, 0, 0).Return(`{"phase":1}`)
+	mi.On("Action", domain.PineappleActionCheck, 0, 0).Return(`{"phase":1}`)
+	mi.On("Action", domain.PineappleActionCall, 0, 0).Return(`{"phase":1}`)
+	mi.On("Action", domain.PineappleActionBet, 0, 0).Return(`{"phase":1}`)
+	mi.On("Action", domain.PineappleActionRaise, 0, 0).Return(`{"phase":1}`)
+	mi.On("Action", domain.PineappleActionAllIn, 0, 0).Return(`{"phase":1}`)
+
+	commands := []string{"r", "f", "ck", "c", "b", "ra", "a"}
+	for _, cmd := range commands {
+		recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": cmd, "sessionId": "s-short"})
+		recorded.CodeIs(200)
+	}
+}
+
+func TestPineappleWebController_LongSessionId(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	recorded := execRequest(t, pwc.Exec,
+		map[string]interface{}{
+			"command":   "reset",
+			"sessionId": strings.Repeat("a", controller.SessionMaxIDLen+1),
+		})
+	recorded.CodeIs(400)
+}
+
+func TestPineappleWebController_Stop(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	c := controller.NewPineappleWebController(func() usecase.PineappleInteractorIF {
+		return mi
+	})
+	c.Stop()
+	c.Stop()
+}
+
+// --- rebuy / addon commands ---
+
+func TestPineappleWebController_Rebuy(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	mi.On("Rebuy").Return(`{"phase":1}`)
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "rebuy", "sessionId": "s1"})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_RebuyShort(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	mi.On("Rebuy").Return(`{"phase":1}`)
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "rb", "sessionId": "s1"})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_SkipRebuy(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	mi.On("SkipRebuy").Return(`{"phase":1}`)
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "skiprebuy", "sessionId": "s1"})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_SkipRebuyShort(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	mi.On("SkipRebuy").Return(`{"phase":1}`)
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "sr", "sessionId": "s1"})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_Addon(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	mi.On("Addon").Return(`{"phase":1}`)
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "addon", "sessionId": "s1"})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_AddonShort(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	mi.On("Addon").Return(`{"phase":1}`)
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "ad", "sessionId": "s1"})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_SkipAddon(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	mi.On("SkipAddon").Return(`{"phase":1}`)
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "skipaddon", "sessionId": "s1"})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_SkipAddonShort(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	mi.On("SkipAddon").Return(`{"phase":1}`)
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "sa", "sessionId": "s1"})
+	recorded.CodeIs(200)
+}
+
+// --- muck / show commands ---
+
+func TestPineappleWebController_Muck(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	mi.On("Muck").Return(`{"phase":1}`)
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "muck", "sessionId": "s1"})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_MuckShort(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	mi.On("Muck").Return(`{"phase":1}`)
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "m", "sessionId": "s1"})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_ShowHand(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	mi.On("ShowHand").Return(`{"phase":1}`)
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "show", "sessionId": "s1"})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_ShowHandShort(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+	mi.On("ShowHand").Return(`{"phase":1}`)
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{"command": "sh", "sessionId": "s1"})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_Log(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+
+	mockLogOutput := `{"entries":[]}`
+	mi.On("ActionLog").Return(mockLogOutput)
+
+	t.Run("log command", func(t *testing.T) {
+		recorded := execRequest(t, pwc.Exec, map[string]interface{}{
+			"command":   "log",
+			"sessionId": "pi-log-1",
+		})
+		recorded.CodeIs(200)
+		recorded.ContentTypeIsJson()
+		mi.AssertCalled(t, "ActionLog")
+	})
+
+	t.Run("l shorthand", func(t *testing.T) {
+		recorded := execRequest(t, pwc.Exec, map[string]interface{}{
+			"command":   "l",
+			"sessionId": "pi-log-1",
+		})
+		recorded.CodeIs(200)
+		recorded.ContentTypeIsJson()
+		mi.AssertCalled(t, "ActionLog")
+	})
+}
+
+// --- reset with blind/tournament config ---
+
+func TestPineappleWebController_Reset_SmallBlindGeBigBlind(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{
+		"command":    "reset",
+		"sessionId":  "s-ge",
+		"smallBlind": 20,
+		"bigBlind":   10,
+	})
+	recorded.CodeIs(400)
+}
+
+func TestPineappleWebController_Reset_TournamentMode(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+
+	tm := true
+	blh := 5
+	blm := 200
+	cfg := domain.DefaultPineappleConfig()
+	cfg.TournamentMode = true
+	cfg.BlindLevelHands = 5
+	cfg.BlindMultiplier = 200
+	mi.On("ResetWithConfig", cfg, mock.Anything).Return(`{"phase":1}`)
+
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{
+		"command":         "reset",
+		"sessionId":       "s-tm",
+		"tournamentMode":  tm,
+		"blindLevelHands": blh,
+		"blindMultiplier": blm,
+	})
+	recorded.CodeIs(200)
+}
+
+func TestPineappleWebController_Reset_WithTableSize_Invalid(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{
+		"command":   "reset",
+		"sessionId": "s1",
+		"tableSize": 5,
+	})
+	recorded.CodeIs(400)
+}

--- a/internal/adapter/controller/SevenCardStudWebController.go
+++ b/internal/adapter/controller/SevenCardStudWebController.go
@@ -137,36 +137,14 @@ type SevenCardStudWebOutput struct {
 // Returns an error if the table size is invalid.
 func (p SevenCardStudWebInput) ToConfig() (domain.SevenCardStudConfig, error) {
 	cfg := domain.DefaultSevenCardStudConfig()
-	if p.Ante != nil && *p.Ante >= 1 {
-		cfg.Ante = *p.Ante
-	}
-	if p.BringIn != nil && *p.BringIn >= 1 {
-		cfg.BringIn = *p.BringIn
-	}
-	if p.SmallBet != nil && *p.SmallBet >= 1 {
-		cfg.SmallBet = *p.SmallBet
-	}
-	if p.BigBet != nil && *p.BigBet >= 1 {
-		cfg.BigBet = *p.BigBet
-	}
-	if p.TournamentMode != nil {
-		cfg.TournamentMode = *p.TournamentMode
-	}
-	if p.AnteLevelHands != nil && *p.AnteLevelHands >= 1 {
-		cfg.AnteLevelHands = *p.AnteLevelHands
-	}
-	if p.AnteMultiplier != nil && *p.AnteMultiplier >= 101 {
-		cfg.AnteMultiplier = *p.AnteMultiplier
-	}
-	if p.BettingLimit != nil {
-		bl := *p.BettingLimit
-		if bl < 0 {
-			bl = 0
-		} else if bl > 2 {
-			bl = 2
-		}
-		cfg.BettingLimit = domain.BettingLimitType(bl)
-	}
+	applyIntIfGte(&cfg.Ante, p.Ante, 1)
+	applyIntIfGte(&cfg.BringIn, p.BringIn, 1)
+	applyIntIfGte(&cfg.SmallBet, p.SmallBet, 1)
+	applyIntIfGte(&cfg.BigBet, p.BigBet, 1)
+	applyBool(&cfg.TournamentMode, p.TournamentMode)
+	applyIntIfGte(&cfg.AnteLevelHands, p.AnteLevelHands, 1)
+	applyIntIfGte(&cfg.AnteMultiplier, p.AnteMultiplier, 101)
+	applyBettingLimit(&cfg.BettingLimit, p.BettingLimit)
 	if p.TableSize != nil {
 		ts := *p.TableSize
 		if !domain.IsValidSevenCardStudTableSize(ts) {
@@ -174,27 +152,10 @@ func (p SevenCardStudWebInput) ToConfig() (domain.SevenCardStudConfig, error) {
 		}
 		cfg.TableSize = ts
 	}
-	if p.RebuyEnabled != nil {
-		cfg.RebuyEnabled = *p.RebuyEnabled
-	}
-	if p.RebuyMaxCount != nil && *p.RebuyMaxCount >= 1 {
-		cfg.RebuyMaxCount = *p.RebuyMaxCount
-	}
-	if p.RebuyChips != nil && *p.RebuyChips >= 1 {
-		cfg.RebuyChips = *p.RebuyChips
-	}
-	if p.RebuyPeriodHands != nil && *p.RebuyPeriodHands >= 1 {
-		cfg.RebuyPeriodHands = *p.RebuyPeriodHands
-	}
-	if p.AddonEnabled != nil {
-		cfg.AddonEnabled = *p.AddonEnabled
-	}
-	if p.AddonChips != nil && *p.AddonChips >= 1 {
-		cfg.AddonChips = *p.AddonChips
-	}
-	if p.AddonAfterHand != nil && *p.AddonAfterHand >= 1 {
-		cfg.AddonAfterHand = *p.AddonAfterHand
-	}
+	applyRebuyConfig(&cfg.RebuyEnabled, &cfg.RebuyMaxCount, &cfg.RebuyChips, &cfg.RebuyPeriodHands,
+		p.RebuyEnabled, p.RebuyMaxCount, p.RebuyChips, p.RebuyPeriodHands)
+	applyAddonConfig(&cfg.AddonEnabled, &cfg.AddonChips, &cfg.AddonAfterHand,
+		p.AddonEnabled, p.AddonChips, p.AddonAfterHand)
 	cfg.CpuMetaAI = p.CpuMetaAI
 	return cfg, nil
 }
@@ -219,6 +180,9 @@ func newSevenCardStudDefaultOutput(msg string) *SevenCardStudWebOutput {
 }
 
 func sevenCardStudDispatch(bc *baseController, w http.ResponseWriter, sgi usecase.SevenCardStudInteractorIF, param SevenCardStudWebInput, newDefault func(string) *SevenCardStudWebOutput) bool {
+	if dispatchPokerAction(bc, w, sgi, param.Command, param.Amount, param.HumanPlayMs) {
+		return true
+	}
 	switch param.Command {
 	case "r", "reset":
 		cfg, err := param.ToConfig()
@@ -227,30 +191,6 @@ func sevenCardStudDispatch(bc *baseController, w http.ResponseWriter, sgi usecas
 			return true
 		}
 		bc.writePresenterResponse(w, sgi.ResetWithConfig(cfg, param.Profile))
-	case "f", "fold":
-		bc.writePresenterResponse(w, sgi.Action(domain.SevenCardStudActionFold, 0, param.HumanPlayMs))
-	case "ck", "check":
-		bc.writePresenterResponse(w, sgi.Action(domain.SevenCardStudActionCheck, 0, param.HumanPlayMs))
-	case "c", "call":
-		bc.writePresenterResponse(w, sgi.Action(domain.SevenCardStudActionCall, 0, param.HumanPlayMs))
-	case "b", "bet":
-		bc.writePresenterResponse(w, sgi.Action(domain.SevenCardStudActionBet, param.Amount, param.HumanPlayMs))
-	case "ra", "raise":
-		bc.writePresenterResponse(w, sgi.Action(domain.SevenCardStudActionRaise, param.Amount, param.HumanPlayMs))
-	case "a", "allin":
-		bc.writePresenterResponse(w, sgi.Action(domain.SevenCardStudActionAllIn, 0, param.HumanPlayMs))
-	case "rb", "rebuy":
-		bc.writePresenterResponse(w, sgi.Rebuy())
-	case "sr", "skiprebuy":
-		bc.writePresenterResponse(w, sgi.SkipRebuy())
-	case "ad", "addon":
-		bc.writePresenterResponse(w, sgi.Addon())
-	case "sa", "skipaddon":
-		bc.writePresenterResponse(w, sgi.SkipAddon())
-	case "m", "muck":
-		bc.writePresenterResponse(w, sgi.Muck())
-	case "sh", "show":
-		bc.writePresenterResponse(w, sgi.ShowHand())
 	default:
 		return dispatchLog(param.Command, bc, w, sgi.ActionLog)
 	}

--- a/internal/adapter/controller/ShortDeckWebController.go
+++ b/internal/adapter/controller/ShortDeckWebController.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 
 	"net/http"
@@ -34,38 +33,17 @@ func newShortDeckDefaultOutput(msg string) *ShortDeckWebOutput {
 }
 
 func shortDeckDispatch(bc *baseController, w http.ResponseWriter, ogi usecase.ShortDeckInteractorIF, param ShortDeckWebInput, newDefault func(string) *ShortDeckWebOutput) bool {
+	if dispatchPokerAction(bc, w, ogi, param.Command, param.Amount, param.HumanPlayMs) {
+		return true
+	}
 	switch param.Command {
 	case "r", "reset":
 		cfg, err := param.ToConfig()
 		if err != nil {
-			bc.writeJsonResponse(w, 400, newDefault(err.Error()))
+			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault(err.Error()))
 			return true
 		}
 		bc.writePresenterResponse(w, ogi.ResetWithConfig(cfg, param.Profile))
-	case "f", "fold":
-		bc.writePresenterResponse(w, ogi.Action(domain.ShortDeckActionFold, 0, param.HumanPlayMs))
-	case "ck", "check":
-		bc.writePresenterResponse(w, ogi.Action(domain.ShortDeckActionCheck, 0, param.HumanPlayMs))
-	case "c", "call":
-		bc.writePresenterResponse(w, ogi.Action(domain.ShortDeckActionCall, 0, param.HumanPlayMs))
-	case "b", "bet":
-		bc.writePresenterResponse(w, ogi.Action(domain.ShortDeckActionBet, param.Amount, param.HumanPlayMs))
-	case "ra", "raise":
-		bc.writePresenterResponse(w, ogi.Action(domain.ShortDeckActionRaise, param.Amount, param.HumanPlayMs))
-	case "a", "allin":
-		bc.writePresenterResponse(w, ogi.Action(domain.ShortDeckActionAllIn, 0, param.HumanPlayMs))
-	case "rb", "rebuy":
-		bc.writePresenterResponse(w, ogi.Rebuy())
-	case "sr", "skiprebuy":
-		bc.writePresenterResponse(w, ogi.SkipRebuy())
-	case "ad", "addon":
-		bc.writePresenterResponse(w, ogi.Addon())
-	case "sa", "skipaddon":
-		bc.writePresenterResponse(w, ogi.SkipAddon())
-	case "m", "muck":
-		bc.writePresenterResponse(w, ogi.Muck())
-	case "sh", "show":
-		bc.writePresenterResponse(w, ogi.ShowHand())
 	default:
 		return dispatchLog(param.Command, bc, w, ogi.ActionLog)
 	}

--- a/internal/adapter/controller/ShortDeckWebController.go
+++ b/internal/adapter/controller/ShortDeckWebController.go
@@ -1,9 +1,9 @@
 package controller
 
 import (
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
-
 	"net/http"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
 // ShortDeckWebInput ショートデックホールデムWebインプット (HoldemWebInputと同一構造)

--- a/internal/adapter/controller/config_helpers.go
+++ b/internal/adapter/controller/config_helpers.go
@@ -20,14 +20,15 @@ func applyBool(dst *bool, src *bool) {
 	}
 }
 
-// applyBettingLimit validates and applies the betting limit.
+// applyBettingLimit validates and applies the betting limit,
+// clamping the value to the valid range [BettingLimitFixed, BettingLimitNoLimit].
 func applyBettingLimit(dst *domain.BettingLimitType, src *int) {
 	if src != nil {
 		bl := *src
-		if bl < 0 {
-			bl = 0
-		} else if bl > 2 {
-			bl = 2
+		if bl < int(domain.BettingLimitFixed) {
+			bl = int(domain.BettingLimitFixed)
+		} else if bl > int(domain.BettingLimitNoLimit) {
+			bl = int(domain.BettingLimitNoLimit)
 		}
 		*dst = domain.BettingLimitType(bl)
 	}

--- a/internal/adapter/controller/config_helpers.go
+++ b/internal/adapter/controller/config_helpers.go
@@ -1,0 +1,73 @@
+package controller
+
+import (
+	"errors"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+)
+
+// applyIntIfGte sets *dst to *src if src is non-nil and *src >= minVal.
+func applyIntIfGte(dst *int, src *int, minVal int) {
+	if src != nil && *src >= minVal {
+		*dst = *src
+	}
+}
+
+// applyBool sets *dst to *src if src is non-nil.
+func applyBool(dst *bool, src *bool) {
+	if src != nil {
+		*dst = *src
+	}
+}
+
+// applyBettingLimit validates and applies the betting limit.
+func applyBettingLimit(dst *domain.BettingLimitType, src *int) {
+	if src != nil {
+		bl := *src
+		if bl < 0 {
+			bl = 0
+		} else if bl > 2 {
+			bl = 2
+		}
+		*dst = domain.BettingLimitType(bl)
+	}
+}
+
+// applyRebuyConfig applies rebuy-related config fields.
+func applyRebuyConfig(rebuyEnabled *bool, rebuyMaxCount, rebuyChips, rebuyPeriodHands *int,
+	srcEnabled *bool, srcMaxCount, srcChips, srcPeriodHands *int) {
+	applyBool(rebuyEnabled, srcEnabled)
+	applyIntIfGte(rebuyMaxCount, srcMaxCount, 1)
+	applyIntIfGte(rebuyChips, srcChips, 1)
+	applyIntIfGte(rebuyPeriodHands, srcPeriodHands, 1)
+}
+
+// applyAddonConfig applies addon-related config fields.
+func applyAddonConfig(addonEnabled *bool, addonChips, addonAfterHand *int,
+	srcEnabled *bool, srcChips, srcAfterHand *int) {
+	applyBool(addonEnabled, srcEnabled)
+	applyIntIfGte(addonChips, srcChips, 1)
+	applyIntIfGte(addonAfterHand, srcAfterHand, 1)
+}
+
+// validateAndApplyBlinds validates small/big blind values and applies them to dst pointers.
+// If only one blind is provided, the other is auto-adjusted.
+func validateAndApplyBlinds(sb, bb *int, sbPtr, bbPtr *int, defaultBB int) error {
+	sbProvided := sbPtr != nil && *sbPtr >= 1
+	bbProvided := bbPtr != nil && *bbPtr >= 1
+	if sbProvided {
+		*sb = *sbPtr
+	}
+	if bbProvided {
+		*bb = *bbPtr
+	}
+	if sbProvided && !bbProvided && *sb >= defaultBB {
+		*bb = *sb * 2
+	} else if bbProvided && !sbProvided && *bb > 1 {
+		*sb = *bb / 2
+	}
+	if *sb >= *bb {
+		return errors.New("param error: smallBlind must be less than bigBlind")
+	}
+	return nil
+}

--- a/internal/adapter/controller/config_helpers_test.go
+++ b/internal/adapter/controller/config_helpers_test.go
@@ -1,0 +1,128 @@
+//go:build test
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+)
+
+func intPtr(v int) *int    { return &v }
+func boolPtr(v bool) *bool { return &v }
+
+func TestApplyIntIfGte(t *testing.T) {
+	tests := []struct {
+		name     string
+		dst      int
+		src      *int
+		minVal   int
+		expected int
+	}{
+		{"nil src unchanged", 10, nil, 1, 10},
+		{"below min unchanged", 10, intPtr(0), 1, 10},
+		{"at min applied", 10, intPtr(1), 1, 1},
+		{"above min applied", 10, intPtr(50), 1, 50},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst := tt.dst
+			applyIntIfGte(&dst, tt.src, tt.minVal)
+			assert.Equal(t, tt.expected, dst)
+		})
+	}
+}
+
+func TestApplyBool(t *testing.T) {
+	tests := []struct {
+		name     string
+		dst      bool
+		src      *bool
+		expected bool
+	}{
+		{"nil src unchanged", false, nil, false},
+		{"set true", false, boolPtr(true), true},
+		{"set false", true, boolPtr(false), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst := tt.dst
+			applyBool(&dst, tt.src)
+			assert.Equal(t, tt.expected, dst)
+		})
+	}
+}
+
+func TestApplyBettingLimit(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      *int
+		expected domain.BettingLimitType
+	}{
+		{"nil unchanged", nil, domain.BettingLimitFixed},
+		{"clamp negative to 0", intPtr(-1), domain.BettingLimitFixed},
+		{"valid 1", intPtr(1), domain.BettingLimitPotLimit},
+		{"clamp above 2 to 2", intPtr(5), domain.BettingLimitNoLimit},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst := domain.BettingLimitFixed
+			applyBettingLimit(&dst, tt.src)
+			assert.Equal(t, tt.expected, dst)
+		})
+	}
+}
+
+func TestApplyRebuyConfig(t *testing.T) {
+	enabled, maxCount, chips, period := false, 0, 0, 0
+	applyRebuyConfig(&enabled, &maxCount, &chips, &period,
+		boolPtr(true), intPtr(5), intPtr(1000), intPtr(20))
+	assert.True(t, enabled)
+	assert.Equal(t, 5, maxCount)
+	assert.Equal(t, 1000, chips)
+	assert.Equal(t, 20, period)
+}
+
+func TestApplyAddonConfig(t *testing.T) {
+	enabled, chips, afterHand := false, 0, 0
+	applyAddonConfig(&enabled, &chips, &afterHand,
+		boolPtr(true), intPtr(1500), intPtr(25))
+	assert.True(t, enabled)
+	assert.Equal(t, 1500, chips)
+	assert.Equal(t, 25, afterHand)
+}
+
+func TestValidateAndApplyBlinds(t *testing.T) {
+	tests := []struct {
+		name      string
+		sbPtr     *int
+		bbPtr     *int
+		defaultBB int
+		wantSB    int
+		wantBB    int
+		wantErr   bool
+	}{
+		{"both nil unchanged", nil, nil, 10, 5, 10, false},
+		{"sb only below default bb", intPtr(3), nil, 10, 3, 10, false},
+		{"sb only at default bb auto-adjusts bb", intPtr(10), nil, 10, 10, 20, false},
+		{"bb only auto-adjusts sb", nil, intPtr(20), 10, 10, 20, false},
+		{"both provided valid", intPtr(5), intPtr(20), 10, 5, 20, false},
+		{"sb >= bb error", intPtr(10), intPtr(10), 10, 0, 0, true},
+		{"sb > bb error", intPtr(20), intPtr(10), 10, 0, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sb, bb := 5, 10
+			err := validateAndApplyBlinds(&sb, &bb, tt.sbPtr, tt.bbPtr, tt.defaultBB)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantSB, sb)
+				assert.Equal(t, tt.wantBB, bb)
+			}
+		})
+	}
+}

--- a/internal/adapter/controller/poker_dispatch.go
+++ b/internal/adapter/controller/poker_dispatch.go
@@ -1,0 +1,78 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+)
+
+// pokerActionInteractor is the common interface for poker-family game interactors.
+// All five poker games (Holdem, Omaha, ShortDeck, Pineapple, SevenCardStud) satisfy this.
+type pokerActionInteractor interface {
+	Action(action int, amount int, humanPlayMs int) string
+	Rebuy() string
+	SkipRebuy() string
+	Addon() string
+	SkipAddon() string
+	Muck() string
+	ShowHand() string
+	ActionLog() string
+}
+
+// pokerAction describes a command-to-action mapping.
+type pokerAction struct {
+	actionType int
+	usesAmount bool
+}
+
+// pokerActionMap maps command strings to action types for all poker-family games.
+// All games share the same int values for fold/check/call/bet/raise/allin.
+var pokerActionMap = map[string]pokerAction{
+	"f":     {domain.HoldemActionFold, false},
+	"fold":  {domain.HoldemActionFold, false},
+	"ck":    {domain.HoldemActionCheck, false},
+	"check": {domain.HoldemActionCheck, false},
+	"c":     {domain.HoldemActionCall, false},
+	"call":  {domain.HoldemActionCall, false},
+	"a":     {domain.HoldemActionAllIn, false},
+	"allin": {domain.HoldemActionAllIn, false},
+	"b":     {domain.HoldemActionBet, true},
+	"bet":   {domain.HoldemActionBet, true},
+	"ra":    {domain.HoldemActionRaise, true},
+	"raise": {domain.HoldemActionRaise, true},
+}
+
+// pokerTournamentMap maps tournament-related commands to methods.
+var pokerTournamentMap = map[string]func(pokerActionInteractor) string{
+	"rb":        func(i pokerActionInteractor) string { return i.Rebuy() },
+	"rebuy":     func(i pokerActionInteractor) string { return i.Rebuy() },
+	"sr":        func(i pokerActionInteractor) string { return i.SkipRebuy() },
+	"skiprebuy": func(i pokerActionInteractor) string { return i.SkipRebuy() },
+	"ad":        func(i pokerActionInteractor) string { return i.Addon() },
+	"addon":     func(i pokerActionInteractor) string { return i.Addon() },
+	"sa":        func(i pokerActionInteractor) string { return i.SkipAddon() },
+	"skipaddon": func(i pokerActionInteractor) string { return i.SkipAddon() },
+	"m":         func(i pokerActionInteractor) string { return i.Muck() },
+	"muck":      func(i pokerActionInteractor) string { return i.Muck() },
+	"sh":        func(i pokerActionInteractor) string { return i.ShowHand() },
+	"show":      func(i pokerActionInteractor) string { return i.ShowHand() },
+}
+
+// dispatchPokerAction handles commands common to all poker-family games:
+// action commands (fold/check/call/bet/raise/allin) and tournament commands
+// (rebuy/addon/muck/show). Returns true if the command was handled.
+func dispatchPokerAction(bc *baseController, w http.ResponseWriter, interactor pokerActionInteractor, command string, amount int, humanPlayMs int) bool {
+	if pa, ok := pokerActionMap[command]; ok {
+		amt := 0
+		if pa.usesAmount {
+			amt = amount
+		}
+		bc.writePresenterResponse(w, interactor.Action(pa.actionType, amt, humanPlayMs))
+		return true
+	}
+	if fn, ok := pokerTournamentMap[command]; ok {
+		bc.writePresenterResponse(w, fn(interactor))
+		return true
+	}
+	return false
+}

--- a/internal/adapter/controller/poker_dispatch.go
+++ b/internal/adapter/controller/poker_dispatch.go
@@ -26,20 +26,15 @@ type pokerAction struct {
 }
 
 // pokerActionMap maps command strings to action types for all poker-family games.
-// All games share the same int values for fold/check/call/bet/raise/allin.
+// Uses PokerAction* constants which are the canonical aliases shared by all variants
+// (HoldemActionFold, OmahaActionFold, etc. are all equal to PokerActionFold).
 var pokerActionMap = map[string]pokerAction{
-	"f":     {domain.HoldemActionFold, false},
-	"fold":  {domain.HoldemActionFold, false},
-	"ck":    {domain.HoldemActionCheck, false},
-	"check": {domain.HoldemActionCheck, false},
-	"c":     {domain.HoldemActionCall, false},
-	"call":  {domain.HoldemActionCall, false},
-	"a":     {domain.HoldemActionAllIn, false},
-	"allin": {domain.HoldemActionAllIn, false},
-	"b":     {domain.HoldemActionBet, true},
-	"bet":   {domain.HoldemActionBet, true},
-	"ra":    {domain.HoldemActionRaise, true},
-	"raise": {domain.HoldemActionRaise, true},
+	"f": {domain.PokerActionFold, false}, "fold": {domain.PokerActionFold, false},
+	"ck": {domain.PokerActionCheck, false}, "check": {domain.PokerActionCheck, false},
+	"c": {domain.PokerActionCall, false}, "call": {domain.PokerActionCall, false},
+	"a": {domain.PokerActionAllIn, false}, "allin": {domain.PokerActionAllIn, false},
+	"b": {domain.PokerActionBet, true}, "bet": {domain.PokerActionBet, true},
+	"ra": {domain.PokerActionRaise, true}, "raise": {domain.PokerActionRaise, true},
 }
 
 // pokerTournamentMap maps tournament-related commands to methods.

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -69,25 +69,25 @@ func GameRegistry() []GameRegistryEntry {
 	return cp
 }
 
-// GameNames is the canonical ordered list of available game names,
-// derived from gameRegistry.
-var GameNames = func() []string {
+// GameNames returns the canonical ordered list of available game names,
+// derived from gameRegistry. Returns a fresh copy on each call.
+func GameNames() []string {
 	names := make([]string, len(gameRegistry))
 	for i, e := range gameRegistry {
 		names[i] = e.Name
 	}
 	return names
-}()
+}
 
-// GameDescriptions maps game names to their display descriptions,
-// derived from gameRegistry.
-var GameDescriptions = func() map[string]string {
+// GameDescriptions returns a map of game names to their display descriptions,
+// derived from gameRegistry. Returns a fresh copy on each call.
+func GameDescriptions() map[string]string {
 	m := make(map[string]string, len(gameRegistry))
 	for _, e := range gameRegistry {
 		m[e.Name] = e.Description
 	}
 	return m
-}()
+}
 
 // GameAliases maps short alias names to their canonical game names.
 // Aliases are not shown in help or game lists.
@@ -136,7 +136,7 @@ func NewGameManager(startGame string) *GameManager {
 		helpLines:   helpLines,
 		initialized: make(map[string]bool),
 		currentGame: startGame,
-		gameOrder:   GameNames,
+		gameOrder:   GameNames(),
 	}
 }
 

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -8,18 +8,86 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
-// GameNames is the canonical ordered list of available game names.
-var GameNames = []string{
-	"blackjack", "poker", "oldmaid", "daifugo", "sevens",
-	"doubt", "holdem", "omaha", "shortdeck", "pineapple",
-	"hearts", "memory", "klondike", "freecell", "baccarat",
-	"spades", "crazyeights", "ginrummy", "canasta", "spider",
-	"napoleon", "indianpoker", "videopoker", "deuceswild", "jokerpoker",
-	"euchre", "pyramid", "tripeaks", "cribbage", "threecard",
-	"ohhell", "bridge", "speed", "gofish", "pinochle", "golf",
-	"pigtail", "sevencardstud", "clocksolitaire", "durak",
-	"fortythieves", "paigow",
+// GameRegistryEntry holds a game's name, description, and CUI constructor.
+type GameRegistryEntry struct {
+	Name        string
+	Description string
+	NewCui      func() cuiGame
 }
+
+// gameRegistry is the single source of truth for all games.
+// Order determines display order in help, games list, and completion.
+var gameRegistry = []GameRegistryEntry{
+	{"blackjack", "BlackJack (ブラックジャック)", func() cuiGame { return NewBlackJackCui() }},
+	{"poker", "5-card Draw Poker (ポーカー)", func() cuiGame { return NewPokerCui() }},
+	{"oldmaid", "Old Maid (ババ抜き)", func() cuiGame { return NewOldMaidCui() }},
+	{"daifugo", "Daifugo / Great Fool (大富豪)", func() cuiGame { return NewDaifugoCui() }},
+	{"sevens", "Sevens (7並べ)", func() cuiGame { return NewSevensCui() }},
+	{"doubt", "Doubt (ダウト)", func() cuiGame { return NewDoubtCui() }},
+	{"holdem", "Texas Hold'em (テキサスホールデム)", func() cuiGame { return NewHoldemCui() }},
+	{"omaha", "Omaha Hold'em (オマハホールデム)", func() cuiGame { return NewOmahaCui() }},
+	{"shortdeck", "Short Deck (6+ Hold'em) (ショートデック)", func() cuiGame { return NewShortDeckCui() }},
+	{"pineapple", "Pineapple Poker (パイナップルポーカー)", func() cuiGame { return NewPineappleCui() }},
+	{"hearts", "Hearts (ハーツ)", func() cuiGame { return NewHeartsCui() }},
+	{"memory", "Memory / Concentration (神経衰弱)", func() cuiGame { return NewMemoryCui() }},
+	{"klondike", "Klondike Solitaire (ソリティア)", func() cuiGame { return NewKlondikeCui() }},
+	{"freecell", "FreeCell (フリーセル)", func() cuiGame { return NewFreeCellCui() }},
+	{"baccarat", "Baccarat (バカラ)", func() cuiGame { return NewBaccaratCui() }},
+	{"spades", "Spades (スペード)", func() cuiGame { return NewSpadesCui() }},
+	{"crazyeights", "Crazy Eights (クレイジーエイト)", func() cuiGame { return NewCrazyEightsCui() }},
+	{"ginrummy", "Gin Rummy (ジンラミー)", func() cuiGame { return NewGinRummyCui() }},
+	{"canasta", "Canasta (カナスタ)", func() cuiGame { return NewCanastaCui() }},
+	{"spider", "Spider Solitaire (スパイダーソリティア)", func() cuiGame { return NewSpiderCui() }},
+	{"napoleon", "Napoleon (ナポレオン)", func() cuiGame { return NewNapoleonCui() }},
+	{"indianpoker", "Indian Poker (インディアンポーカー)", func() cuiGame { return NewIndianPokerCui() }},
+	{"videopoker", "Video Poker Jacks or Better (ビデオポーカー)", func() cuiGame { return NewVideoPokerCui() }},
+	{"deuceswild", "Deuces Wild (デューシーズワイルド)", func() cuiGame { return NewDeucesWildCui() }},
+	{"jokerpoker", "Joker Poker (ジョーカーポーカー)", func() cuiGame { return NewJokerPokerCui() }},
+	{"euchre", "Euchre (ユーカー)", func() cuiGame { return NewEuchreCui() }},
+	{"pyramid", "Pyramid (ピラミッド)", func() cuiGame { return NewPyramidCui() }},
+	{"tripeaks", "TriPeaks (トリピークス)", func() cuiGame { return NewTriPeaksCui() }},
+	{"cribbage", "Cribbage (クリベッジ)", func() cuiGame { return NewCribbageCui() }},
+	{"threecard", "Three Card Poker (スリーカードポーカー)", func() cuiGame { return NewThreeCardCui() }},
+	{"ohhell", "Oh Hell (オー・ヘル)", func() cuiGame { return NewOhHellCui() }},
+	{"bridge", "Contract Bridge (コントラクトブリッジ)", func() cuiGame { return NewBridgeCui() }},
+	{"speed", "Speed (スピード)", func() cuiGame { return NewSpeedCui() }},
+	{"gofish", "Go Fish (ゴーフィッシュ)", func() cuiGame { return NewGoFishCui() }},
+	{"pinochle", "Pinochle (ピノクル)", func() cuiGame { return NewPinochleCui() }},
+	{"golf", "Golf Solitaire (ゴルフ)", func() cuiGame { return NewGolfCui() }},
+	{"pigtail", "Pig's Tail (ブタのしっぽ)", func() cuiGame { return NewPigsTailCui() }},
+	{"sevencardstud", "Seven Card Stud (セブンカードスタッド)", func() cuiGame { return NewSevenCardStudCui() }},
+	{"clocksolitaire", "Clock Solitaire (クロックソリティア)", func() cuiGame { return NewClockSolitaireCui() }},
+	{"durak", "Durak / Fool (ドゥラーク)", func() cuiGame { return NewDurakCui() }},
+	{"fortythieves", "Forty Thieves (フォーティシーブス)", func() cuiGame { return NewFortyThievesCui() }},
+	{"paigow", "Pai Gow Poker (パイガオポーカー)", func() cuiGame { return NewPaiGowCui() }},
+}
+
+// GameRegistry returns a copy of the game registry for external use.
+func GameRegistry() []GameRegistryEntry {
+	cp := make([]GameRegistryEntry, len(gameRegistry))
+	copy(cp, gameRegistry)
+	return cp
+}
+
+// GameNames is the canonical ordered list of available game names,
+// derived from gameRegistry.
+var GameNames = func() []string {
+	names := make([]string, len(gameRegistry))
+	for i, e := range gameRegistry {
+		names[i] = e.Name
+	}
+	return names
+}()
+
+// GameDescriptions maps game names to their display descriptions,
+// derived from gameRegistry.
+var GameDescriptions = func() map[string]string {
+	m := make(map[string]string, len(gameRegistry))
+	for _, e := range gameRegistry {
+		m[e.Name] = e.Description
+	}
+	return m
+}()
 
 // GameAliases maps short alias names to their canonical game names.
 // Aliases are not shown in help or game lists.
@@ -165,55 +233,12 @@ func (m *GameManager) listGames() string {
 }
 
 func buildGameEntries() (map[string]CuiExecer, map[string][]string) {
-	entries := map[string]cuiGame{
-		"blackjack":      NewBlackJackCui(),
-		"poker":          NewPokerCui(),
-		"oldmaid":        NewOldMaidCui(),
-		"daifugo":        NewDaifugoCui(),
-		"sevens":         NewSevensCui(),
-		"doubt":          NewDoubtCui(),
-		"holdem":         NewHoldemCui(),
-		"omaha":          NewOmahaCui(),
-		"shortdeck":      NewShortDeckCui(),
-		"pineapple":      NewPineappleCui(),
-		"hearts":         NewHeartsCui(),
-		"memory":         NewMemoryCui(),
-		"klondike":       NewKlondikeCui(),
-		"freecell":       NewFreeCellCui(),
-		"baccarat":       NewBaccaratCui(),
-		"spades":         NewSpadesCui(),
-		"crazyeights":    NewCrazyEightsCui(),
-		"ginrummy":       NewGinRummyCui(),
-		"canasta":        NewCanastaCui(),
-		"spider":         NewSpiderCui(),
-		"napoleon":       NewNapoleonCui(),
-		"indianpoker":    NewIndianPokerCui(),
-		"videopoker":     NewVideoPokerCui(),
-		"deuceswild":     NewDeucesWildCui(),
-		"jokerpoker":     NewJokerPokerCui(),
-		"euchre":         NewEuchreCui(),
-		"pyramid":        NewPyramidCui(),
-		"tripeaks":       NewTriPeaksCui(),
-		"cribbage":       NewCribbageCui(),
-		"threecard":      NewThreeCardCui(),
-		"ohhell":         NewOhHellCui(),
-		"bridge":         NewBridgeCui(),
-		"speed":          NewSpeedCui(),
-		"gofish":         NewGoFishCui(),
-		"pinochle":       NewPinochleCui(),
-		"golf":           NewGolfCui(),
-		"pigtail":        NewPigsTailCui(),
-		"sevencardstud":  NewSevenCardStudCui(),
-		"clocksolitaire": NewClockSolitaireCui(),
-		"durak":          NewDurakCui(),
-		"fortythieves":   NewFortyThievesCui(),
-		"paigow":         NewPaiGowCui(),
-	}
-	controllers := make(map[string]CuiExecer, len(entries))
-	helpLines := make(map[string][]string, len(entries))
-	for name, g := range entries {
-		controllers[name] = g.Controller()
-		helpLines[name] = g.HelpLines()
+	controllers := make(map[string]CuiExecer, len(gameRegistry))
+	helpLines := make(map[string][]string, len(gameRegistry))
+	for _, entry := range gameRegistry {
+		g := entry.NewCui()
+		controllers[entry.Name] = g.Controller()
+		helpLines[entry.Name] = g.HelpLines()
 	}
 	return controllers, helpLines
 }

--- a/internal/infrastructure/ui/GameManager_test.go
+++ b/internal/infrastructure/ui/GameManager_test.go
@@ -235,11 +235,11 @@ func TestGameManager_NewGameManager_Smoke(t *testing.T) {
 
 func TestGameManager_NewGameManager_AllGamesRegistered(t *testing.T) {
 	mgr := NewGameManager("blackjack")
-	// Verify that all 42 games are registered.
+	// Verify that recently-added games are registered.
 	for _, name := range []string{"canasta", "bridge", "pineapple", "gofish", "pinochle", "pigtail", "sevencardstud", "clocksolitaire", "durak", "fortythieves", "paigow"} {
 		assert.Contains(t, mgr.games, name, "game %q should be registered", name)
 	}
-	assert.Equal(t, 42, len(mgr.games))
+	assert.Equal(t, len(GameNames()), len(mgr.games))
 }
 
 func TestGameManager_NewGameManager_PanicsOnInvalidGame(t *testing.T) {

--- a/internal/infrastructure/ui/GameManager_test.go
+++ b/internal/infrastructure/ui/GameManager_test.go
@@ -230,7 +230,7 @@ func TestGameManager_NewGameManager_Smoke(t *testing.T) {
 	mgr := NewGameManager("blackjack")
 	assert.Equal(t, "blackjack", mgr.CurrentGame())
 	assert.NotNil(t, mgr.games["blackjack"])
-	assert.Len(t, mgr.games, len(GameNames))
+	assert.Len(t, mgr.games, len(GameNames()))
 }
 
 func TestGameManager_NewGameManager_AllGamesRegistered(t *testing.T) {
@@ -290,8 +290,8 @@ func TestGameManager_SwitchAliasMultiple(t *testing.T) {
 }
 
 func TestGameAliases_AllPointToValidGames(t *testing.T) {
-	gameSet := make(map[string]bool, len(GameNames))
-	for _, name := range GameNames {
+	gameSet := make(map[string]bool, len(GameNames()))
+	for _, name := range GameNames() {
 		gameSet[name] = true
 	}
 	for alias, canonical := range GameAliases {
@@ -301,15 +301,16 @@ func TestGameAliases_AllPointToValidGames(t *testing.T) {
 
 func TestGameRegistry_NamesMatchGameNames(t *testing.T) {
 	registry := GameRegistry()
-	assert.Equal(t, len(GameNames), len(registry), "registry and GameNames must have same length")
+	assert.Equal(t, len(GameNames()), len(registry), "registry and GameNames() must have same length")
 	for i, entry := range registry {
-		assert.Equal(t, GameNames[i], entry.Name, "registry[%d].Name must match GameNames[%d]", i, i)
+		assert.Equal(t, GameNames()[i], entry.Name, "registry[%d].Name must match GameNames()[%d]", i, i)
 	}
 }
 
 func TestGameRegistry_DescriptionsMatchGameDescriptions(t *testing.T) {
+	descs := GameDescriptions()
 	for _, entry := range GameRegistry() {
-		desc, ok := GameDescriptions[entry.Name]
+		desc, ok := descs[entry.Name]
 		assert.True(t, ok, "GameDescriptions must contain %q", entry.Name)
 		assert.Equal(t, entry.Description, desc)
 	}

--- a/internal/infrastructure/ui/GameManager_test.go
+++ b/internal/infrastructure/ui/GameManager_test.go
@@ -298,3 +298,33 @@ func TestGameAliases_AllPointToValidGames(t *testing.T) {
 		assert.True(t, gameSet[canonical], "alias %q points to unknown game %q", alias, canonical)
 	}
 }
+
+func TestGameRegistry_NamesMatchGameNames(t *testing.T) {
+	registry := GameRegistry()
+	assert.Equal(t, len(GameNames), len(registry), "registry and GameNames must have same length")
+	for i, entry := range registry {
+		assert.Equal(t, GameNames[i], entry.Name, "registry[%d].Name must match GameNames[%d]", i, i)
+	}
+}
+
+func TestGameRegistry_DescriptionsMatchGameDescriptions(t *testing.T) {
+	for _, entry := range GameRegistry() {
+		desc, ok := GameDescriptions[entry.Name]
+		assert.True(t, ok, "GameDescriptions must contain %q", entry.Name)
+		assert.Equal(t, entry.Description, desc)
+	}
+}
+
+func TestGameRegistry_NoDuplicateNames(t *testing.T) {
+	seen := make(map[string]bool, len(gameRegistry))
+	for _, entry := range gameRegistry {
+		assert.False(t, seen[entry.Name], "duplicate game name in registry: %q", entry.Name)
+		seen[entry.Name] = true
+	}
+}
+
+func TestGameRegistry_AllConstructorsNonNil(t *testing.T) {
+	for _, entry := range gameRegistry {
+		assert.NotNil(t, entry.NewCui, "NewCui must not be nil for %q", entry.Name)
+	}
+}


### PR DESCRIPTION
## Summary

- **Single game registry** (`gameRegistry` in `GameManager.go`) as the source of truth for all game names, descriptions, and CUI constructors — eliminates 5 duplicate game lists across `main.go`, `GameManager.go`, and `completion.go`
- **Shared config validation helpers** (`config_helpers.go`) — extracts common blind validation, `applyIntIfGte`, `applyBool`, `applyBettingLimit`, `applyRebuyConfig`, `applyAddonConfig` from 3 poker `ToConfig()` methods (~350→75 lines)
- **Table-driven poker dispatch** (`poker_dispatch.go`) — replaces 5 identical 30+ line switch statements with a shared `dispatchPokerAction()` using action/tournament command maps
- **Bug fix**: Omaha and ShortDeck dispatch now use `http.StatusBadRequest` instead of hardcoded `400`

Closes #1267, closes #1268, closes #1269, closes #1270

## Test plan

- [x] All Go tests pass: `go test -tags test ./...`
- [x] Go lint passes: `golangci-lint run ./...` (0 issues)
- [x] New tests for config helpers (`config_helpers_test.go`)
- [x] New tests for registry consistency (`TestGameRegistry_*`)
- [x] Existing completion tests pass with dynamic generation
- [x] Existing poker controller tests pass with refactored dispatch