### PR TITLE
feat(frontend): add pot-size preset buttons to poker betting UI

### DIFF
--- a/frontend/src/components/BettingControls.test.tsx
+++ b/frontend/src/components/BettingControls.test.tsx
@@ -209,6 +209,8 @@ describe('BettingControls', () => {
     it('does not render preset buttons when potSize is undefined', () => {
       render(<BettingControls {...makeProps()} />);
       expect(screen.queryByRole('button', { name: '1/2 Pot' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Pot' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Max' })).not.toBeInTheDocument();
     });
 
     it('renders 1/2 Pot and Pot preset buttons when potSize is positive', () => {
@@ -260,6 +262,26 @@ describe('BettingControls', () => {
       render(<BettingControls {...makeProps({ potSize: 1000, minRaise: 10, maxBetAmount: 300, onBetAmountChange })} />);
       fireEvent.click(screen.getByRole('button', { name: 'Pot' }));
       expect(onBetAmountChange).toHaveBeenCalledWith(300);
+    });
+
+    it('falls back to minRaise when preset computation yields NaN', () => {
+      const onBetAmountChange = vi.fn();
+      render(
+        <BettingControls
+          {...makeProps({ potSize: Number.NaN, minRaise: 10, maxBetAmount: 1000, onBetAmountChange })}
+        />,
+      );
+      // potSize NaN should not render preset buttons (showPresets = pot > 0 is false for NaN)
+      expect(screen.queryByRole('button', { name: '1/2 Pot' })).not.toBeInTheDocument();
+    });
+
+    it('floors Max preset when maxBetAmount has a fractional value', () => {
+      const onBetAmountChange = vi.fn();
+      render(
+        <BettingControls {...makeProps({ potSize: 100, minRaise: 10, maxBetAmount: 350.7, onBetAmountChange })} />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Max' }));
+      expect(onBetAmountChange).toHaveBeenCalledWith(350);
     });
 
     it('disables preset buttons when loading', () => {

--- a/frontend/src/components/BettingControls.test.tsx
+++ b/frontend/src/components/BettingControls.test.tsx
@@ -197,4 +197,76 @@ describe('BettingControls', () => {
     expect(screen.getByRole('button', { name: 'フォールド' })).not.toBeDisabled();
     expect(screen.getByRole('button', { name: 'オールイン' })).not.toBeDisabled();
   });
+
+  describe('preset buttons', () => {
+    it('does not render preset buttons when potSize is 0', () => {
+      render(<BettingControls {...makeProps({ potSize: 0 })} />);
+      expect(screen.queryByRole('button', { name: '1/2 Pot' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Pot' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Max' })).not.toBeInTheDocument();
+    });
+
+    it('does not render preset buttons when potSize is undefined', () => {
+      render(<BettingControls {...makeProps()} />);
+      expect(screen.queryByRole('button', { name: '1/2 Pot' })).not.toBeInTheDocument();
+    });
+
+    it('renders 1/2 Pot and Pot preset buttons when potSize is positive', () => {
+      render(<BettingControls {...makeProps({ potSize: 100 })} />);
+      expect(screen.getByRole('button', { name: '1/2 Pot' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Pot' })).toBeInTheDocument();
+    });
+
+    it('renders Max preset button when maxBetAmount is positive', () => {
+      render(<BettingControls {...makeProps({ potSize: 100, maxBetAmount: 500 })} />);
+      expect(screen.getByRole('button', { name: 'Max' })).toBeInTheDocument();
+    });
+
+    it('does not render Max preset when maxBetAmount is missing', () => {
+      render(<BettingControls {...makeProps({ potSize: 100 })} />);
+      expect(screen.queryByRole('button', { name: 'Max' })).not.toBeInTheDocument();
+    });
+
+    it('sets bet amount to half of pot when 1/2 Pot clicked', () => {
+      const onBetAmountChange = vi.fn();
+      render(<BettingControls {...makeProps({ potSize: 200, minRaise: 10, maxBetAmount: 1000, onBetAmountChange })} />);
+      fireEvent.click(screen.getByRole('button', { name: '1/2 Pot' }));
+      expect(onBetAmountChange).toHaveBeenCalledWith(100);
+    });
+
+    it('sets bet amount to pot when Pot clicked', () => {
+      const onBetAmountChange = vi.fn();
+      render(<BettingControls {...makeProps({ potSize: 200, minRaise: 10, maxBetAmount: 1000, onBetAmountChange })} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Pot' }));
+      expect(onBetAmountChange).toHaveBeenCalledWith(200);
+    });
+
+    it('sets bet amount to maxBetAmount when Max clicked', () => {
+      const onBetAmountChange = vi.fn();
+      render(<BettingControls {...makeProps({ potSize: 200, minRaise: 10, maxBetAmount: 350, onBetAmountChange })} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Max' }));
+      expect(onBetAmountChange).toHaveBeenCalledWith(350);
+    });
+
+    it('clamps 1/2 Pot preset to minRaise when half-pot is below minRaise', () => {
+      const onBetAmountChange = vi.fn();
+      render(<BettingControls {...makeProps({ potSize: 10, minRaise: 20, maxBetAmount: 1000, onBetAmountChange })} />);
+      fireEvent.click(screen.getByRole('button', { name: '1/2 Pot' }));
+      expect(onBetAmountChange).toHaveBeenCalledWith(20);
+    });
+
+    it('clamps Pot preset to maxBetAmount when pot exceeds max', () => {
+      const onBetAmountChange = vi.fn();
+      render(<BettingControls {...makeProps({ potSize: 1000, minRaise: 10, maxBetAmount: 300, onBetAmountChange })} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Pot' }));
+      expect(onBetAmountChange).toHaveBeenCalledWith(300);
+    });
+
+    it('disables preset buttons when loading', () => {
+      render(<BettingControls {...makeProps({ potSize: 100, maxBetAmount: 500, loading: true })} />);
+      expect(screen.getByRole('button', { name: '1/2 Pot' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Pot' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Max' })).toBeDisabled();
+    });
+  });
 });

--- a/frontend/src/components/BettingControls.tsx
+++ b/frontend/src/components/BettingControls.tsx
@@ -7,7 +7,7 @@ interface BettingControlsProps {
   onBetAmountChange: (v: number) => void;
   minRaise: number;
   maxBetAmount?: number;
-  /** Current pot size; when positive, preset quick-amount buttons (1/2 Pot, Pot, Max) are rendered. */
+  /** Current pot size; when positive, 1/2 Pot and Pot preset buttons are rendered. Max additionally requires a positive maxBetAmount. */
   potSize?: number;
   hasOutstandingBet: boolean;
   loading: boolean;
@@ -44,9 +44,9 @@ export function BettingControls({
   const pot = potSize ?? 0;
   const showPresets = pot > 0;
   const clampAmount = (v: number) => {
-    let clamped = Math.floor(v);
+    let clamped = Number.isNaN(v) ? minRaise : Math.floor(v);
     if (clamped < minRaise) clamped = minRaise;
-    if (hasMax && clamped > max) clamped = max;
+    if (hasMax && clamped > max) clamped = Math.floor(max);
     return clamped;
   };
 
@@ -104,7 +104,7 @@ export function BettingControls({
                 type="button"
                 className={`${btnPokerMuted} min-w-[70px] text-xs`}
                 disabled={loading}
-                onClick={() => onBetAmountChange(max)}
+                onClick={() => onBetAmountChange(Math.floor(max))}
               >
                 {t('betting.preset.max')}
               </button>

--- a/frontend/src/components/BettingControls.tsx
+++ b/frontend/src/components/BettingControls.tsx
@@ -7,6 +7,8 @@ interface BettingControlsProps {
   onBetAmountChange: (v: number) => void;
   minRaise: number;
   maxBetAmount?: number;
+  /** Current pot size; when positive, preset quick-amount buttons (1/2 Pot, Pot, Max) are rendered. */
+  potSize?: number;
   hasOutstandingBet: boolean;
   loading: boolean;
   onCall: () => void;
@@ -24,6 +26,7 @@ export function BettingControls({
   onBetAmountChange,
   minRaise,
   maxBetAmount,
+  potSize,
   hasOutstandingBet,
   loading,
   onCall,
@@ -38,6 +41,14 @@ export function BettingControls({
   const hasMax = max > 0;
   const isOutOfRange = Number.isNaN(betAmount) || betAmount < minRaise || (hasMax && betAmount > max);
   const canBet = !loading && !isOutOfRange;
+  const pot = potSize ?? 0;
+  const showPresets = pot > 0;
+  const clampAmount = (v: number) => {
+    let clamped = Math.floor(v);
+    if (clamped < minRaise) clamped = minRaise;
+    if (hasMax && clamped > max) clamped = max;
+    return clamped;
+  };
 
   return (
     <div className="text-center mb-2">
@@ -69,6 +80,36 @@ export function BettingControls({
           <p id={`${inputId}-range`} className="text-ds-error text-xs" role="alert">
             {t('betting.rangeHint', { min: minRaise, max: hasMax ? max : '∞' })}
           </p>
+        )}
+        {showPresets && (
+          <div className="flex items-center justify-center gap-2">
+            <button
+              type="button"
+              className={`${btnPokerMuted} min-w-[70px] text-xs`}
+              disabled={loading}
+              onClick={() => onBetAmountChange(clampAmount(pot / 2))}
+            >
+              {t('betting.preset.halfPot')}
+            </button>
+            <button
+              type="button"
+              className={`${btnPokerMuted} min-w-[70px] text-xs`}
+              disabled={loading}
+              onClick={() => onBetAmountChange(clampAmount(pot))}
+            >
+              {t('betting.preset.pot')}
+            </button>
+            {hasMax && (
+              <button
+                type="button"
+                className={`${btnPokerMuted} min-w-[70px] text-xs`}
+                disabled={loading}
+                onClick={() => onBetAmountChange(max)}
+              >
+                {t('betting.preset.max')}
+              </button>
+            )}
+          </div>
         )}
       </div>
       {hasOutstandingBet ? (

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -91,7 +91,12 @@
     "fixed": "Fixed",
     "potLimit": "Pot Limit",
     "noLimit": "No Limit",
-    "rangeHint": "Enter a value between {{min}} and {{max}}"
+    "rangeHint": "Enter a value between {{min}} and {{max}}",
+    "preset": {
+      "halfPot": "1/2 Pot",
+      "pot": "Pot",
+      "max": "Max"
+    }
   },
   "button": {
     "reset": "Reset",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -91,7 +91,12 @@
     "fixed": "Fixed",
     "potLimit": "Pot Limit",
     "noLimit": "No Limit",
-    "rangeHint": "{{min}} 〜 {{max}} の範囲で入力してください"
+    "rangeHint": "{{min}} 〜 {{max}} の範囲で入力してください",
+    "preset": {
+      "halfPot": "1/2 Pot",
+      "pot": "Pot",
+      "max": "Max"
+    }
   },
   "button": {
     "reset": "リセット",

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -514,6 +514,7 @@ function HoldemPageContent() {
                   onBetAmountChange={setBetAmount}
                   minRaise={minRaise}
                   maxBetAmount={state?.maxBetAmount}
+                  potSize={state?.pot}
                   hasOutstandingBet={hasOutstandingBet}
                   loading={loading}
                   onCall={() => exec('call', undefined, undefined, getElapsed())}

--- a/frontend/src/pages/IndianPokerPage.tsx
+++ b/frontend/src/pages/IndianPokerPage.tsx
@@ -311,6 +311,7 @@ function IndianPokerPageContent() {
                   onBetAmountChange={setBetAmount}
                   minRaise={minRaise}
                   maxBetAmount={state.maxBetAmount}
+                  potSize={state.pot}
                   hasOutstandingBet={hasOutstandingBet}
                   loading={loading}
                   onCall={() => execApi('call', undefined, undefined, getElapsed())}

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -508,6 +508,7 @@ function OmahaPageContent() {
                   onBetAmountChange={setBetAmount}
                   minRaise={minRaise}
                   maxBetAmount={state?.maxBetAmount}
+                  potSize={state?.pot}
                   hasOutstandingBet={hasOutstandingBet}
                   loading={loading}
                   onCall={() => execApi('call', undefined, undefined, getElapsed())}

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -560,6 +560,7 @@ function PineapplePageContent() {
                   onBetAmountChange={setBetAmount}
                   minRaise={minRaise}
                   maxBetAmount={state?.maxBetAmount}
+                  potSize={state?.pot}
                   hasOutstandingBet={hasOutstandingBet}
                   loading={loading}
                   onCall={() => apiExec('call', undefined, undefined, getElapsed())}

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -329,6 +329,7 @@ function PokerPageContent() {
                   onBetAmountChange={setBetAmount}
                   minRaise={minRaise}
                   maxBetAmount={state?.maxBetAmount}
+                  potSize={state?.pot}
                   hasOutstandingBet={hasOutstandingBet}
                   loading={loading}
                   onCall={() => exec('call', undefined, undefined, undefined, getElapsed())}

--- a/frontend/src/pages/SevenCardStudPage.tsx
+++ b/frontend/src/pages/SevenCardStudPage.tsx
@@ -517,6 +517,7 @@ function SevenCardStudPageContent() {
                   onBetAmountChange={setBetAmount}
                   minRaise={minRaise}
                   maxBetAmount={state?.maxBetAmount}
+                  potSize={state?.pot}
                   hasOutstandingBet={hasOutstandingBet}
                   loading={loading}
                   onCall={() => execApi('call', undefined, undefined, getElapsed())}

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -511,6 +511,7 @@ function ShortDeckPageContent() {
                   onBetAmountChange={setBetAmount}
                   minRaise={minRaise}
                   maxBetAmount={state?.maxBetAmount}
+                  potSize={state?.pot}
                   hasOutstandingBet={hasOutstandingBet}
                   loading={loading}
                   onCall={() => execApi('call', undefined, undefined, getElapsed())}


### PR DESCRIPTION
## Summary
- Add `1/2 Pot`, `Pot`, and `Max` quick-amount preset buttons to `BettingControls` so players (especially on mobile) no longer have to manually type bet/raise amounts
- Presets clamp the chosen value to `[minRaise, maxBetAmount]` and only render when `potSize > 0`
- Wired through all seven poker pages: Holdem, Omaha, ShortDeck, Pineapple, Poker, SevenCardStud, IndianPoker
- New i18n keys `betting.preset.{halfPot,pot,max}` added to ja/en `common.json`

Note: chose `Max` rather than `All-in` for the third preset to avoid duplicating the existing All-in action button (which executes the action directly rather than just filling the input).

Closes #1276

## Test plan
- [x] `bun run test -- --run BettingControls.test.tsx` (38/38 pass, including 11 new preset cases)
- [x] `bun run test` for the seven poker page test files (575/575 pass)
- [x] `NODE_OPTIONS=--max-old-space-size=3072 bun run build` (production build succeeds)
- [x] `bun run check` (no new biome warnings; 2 pre-existing warnings unrelated)
- [ ] Manual QA: visit Holdem/Omaha betting phase, click each preset, verify input updates and clamps correctly at min/max boundaries