### PR TITLE
feat(frontend): auto-flip in Speed stuck phase

### DIFF
--- a/frontend/src/hooks/useSpeedGame.ts
+++ b/frontend/src/hooks/useSpeedGame.ts
@@ -1,6 +1,7 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { speedApi } from '../api/gameApi';
 import type { SpeedConfig } from '../types/card';
+import { SpeedPhase } from '../types/phases';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
@@ -8,7 +9,11 @@ import { useGameConfig } from './useGameConfig';
 /** Default Speed game configuration. */
 export const DEFAULT_SPEED_CONFIG: SpeedConfig = {
   cpuDifficulty: 1,
+  autoFlip: true,
 };
+
+/** Delay in milliseconds before an automatic flip fires while stuck. */
+export const AUTO_FLIP_DELAY_MS = 2500;
 
 /** CPU difficulty options for Speed settings. */
 export const CPU_DIFFICULTY_OPTIONS = [
@@ -20,7 +25,7 @@ export const CPU_DIFFICULTY_OPTIONS = [
 /** Hook that manages Speed game state and player actions. */
 export function useSpeedGame() {
   const { selected: selectedCardIndices, toggle: toggleCard, clear: clearSelection } = useCardSelection();
-  const { config: speedConfig, handleConfigChange } = useGameConfig<SpeedConfig>(DEFAULT_SPEED_CONFIG);
+  const { config: speedConfig, handleConfigChange, handleToggle } = useGameConfig<SpeedConfig>(DEFAULT_SPEED_CONFIG);
 
   const onSuccess = useCallback(() => {
     clearSelection();
@@ -49,6 +54,24 @@ export function useSpeedGame() {
     gameExec('hint');
   }, [gameExec]);
 
+  // Auto-flip: when stuck and enabled, schedule a flip after a short delay
+  // so players don't have to manually press the button. Cleared on phase
+  // change, unmount, or when the toggle flips off.
+  const autoFlipEnabled = speedConfig.autoFlip;
+  const phase = state?.phase;
+  const handleFlipRef = useRef(handleFlip);
+  useEffect(() => {
+    handleFlipRef.current = handleFlip;
+  }, [handleFlip]);
+  useEffect(() => {
+    if (!autoFlipEnabled) return;
+    if (phase !== SpeedPhase.STUCK) return;
+    const timerId = setTimeout(() => {
+      handleFlipRef.current();
+    }, AUTO_FLIP_DELAY_MS);
+    return () => clearTimeout(timerId);
+  }, [autoFlipEnabled, phase]);
+
   return {
     state,
     loading,
@@ -59,6 +82,7 @@ export function useSpeedGame() {
     toggleCard,
     clearSelection,
     handleConfigChange,
+    handleToggle,
     handlePlay,
     handleFlip,
     handleHint,

--- a/frontend/src/hooks/useSpeedGame.ts
+++ b/frontend/src/hooks/useSpeedGame.ts
@@ -64,13 +64,12 @@ export function useSpeedGame() {
     handleFlipRef.current = handleFlip;
   }, [handleFlip]);
   useEffect(() => {
-    if (!autoFlipEnabled) return;
-    if (phase !== SpeedPhase.STUCK) return;
+    if (!autoFlipEnabled || phase !== SpeedPhase.STUCK || loading) return;
     const timerId = setTimeout(() => {
       handleFlipRef.current();
     }, AUTO_FLIP_DELAY_MS);
     return () => clearTimeout(timerId);
-  }, [autoFlipEnabled, phase]);
+  }, [autoFlipEnabled, phase, loading]);
 
   return {
     state,

--- a/frontend/src/i18n/locales/en/speed.json
+++ b/frontend/src/i18n/locales/en/speed.json
@@ -19,7 +19,8 @@
     "cpuDifficulty": "CPU Difficulty",
     "easy": "Easy",
     "normal": "Normal",
-    "hard": "Hard"
+    "hard": "Hard",
+    "autoFlip": "Auto-flip when stuck"
   },
   "hint": {
     "play": "Play card {{cardIndex}} to pile {{pileIndex}}",

--- a/frontend/src/i18n/locales/ja/speed.json
+++ b/frontend/src/i18n/locales/ja/speed.json
@@ -19,7 +19,8 @@
     "cpuDifficulty": "CPU難易度",
     "easy": "イージー",
     "normal": "ノーマル",
-    "hard": "ハード"
+    "hard": "ハード",
+    "autoFlip": "膠着時に自動でめくる"
   },
   "hint": {
     "play": "カード{{cardIndex}}を台札{{pileIndex}}に出せます",

--- a/frontend/src/pages/SpeedPage.test.tsx
+++ b/frontend/src/pages/SpeedPage.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { speedApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { SpeedResponse } from '../types/card';
@@ -35,7 +35,7 @@ const playState: SpeedResponse = {
   phase: 0,
   gameEndFlag: false,
   winnerIdx: -1,
-  config: { cpuDifficulty: 1 },
+  config: { cpuDifficulty: 1, autoFlip: true },
   message: '',
 };
 
@@ -78,7 +78,7 @@ describe('SpeedPage', () => {
   it('calls reset on mount', async () => {
     renderWithProviders(<SpeedPage />);
     await waitFor(() => {
-      expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined, { cpuDifficulty: 1 });
+      expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined, { cpuDifficulty: 1, autoFlip: true });
     });
   });
 
@@ -239,5 +239,57 @@ describe('SpeedPage', () => {
     const flipPileBtns = screen.getAllByRole('button', { name: 'めくる' });
     // Center pile buttons (first two) should have animate-pulse
     expect(flipPileBtns[0]).toHaveClass('animate-pulse');
+  });
+
+  it('renders the auto-flip settings toggle', async () => {
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
+    expect(screen.getByLabelText('膠着時に自動でめくる')).toBeInTheDocument();
+  });
+});
+
+describe('SpeedPage auto-flip timer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockExec.mockResolvedValue(stuckState);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('automatically calls flip after the delay when stuck and auto-flip enabled', async () => {
+    renderWithProviders(<SpeedPage />);
+    // Wait until the stuck state is rendered
+    await waitFor(() => expect(screen.getByTestId('flip-button')).toBeInTheDocument());
+    mockExec.mockClear();
+    // Advance past the 2.5s auto-flip delay
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2600);
+    });
+    expect(mockExec).toHaveBeenCalledWith('flip');
+  });
+
+  it('does not auto-flip before the delay elapses', async () => {
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByTestId('flip-button')).toBeInTheDocument());
+    mockExec.mockClear();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(mockExec).not.toHaveBeenCalledWith('flip');
+  });
+
+  it('does not auto-flip when disabled via the settings toggle', async () => {
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByTestId('flip-button')).toBeInTheDocument());
+    // Turn auto-flip off before the timer fires
+    fireEvent.click(screen.getByLabelText('膠着時に自動でめくる'));
+    mockExec.mockClear();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(mockExec).not.toHaveBeenCalledWith('flip');
   });
 });

--- a/frontend/src/pages/SpeedPage.test.tsx
+++ b/frontend/src/pages/SpeedPage.test.tsx
@@ -281,6 +281,25 @@ describe('SpeedPage auto-flip timer', () => {
     expect(mockExec).not.toHaveBeenCalledWith('flip');
   });
 
+  it('does not auto-flip while a manual flip request is in flight', async () => {
+    // First render resolves to stuckState; subsequent calls hang so loading stays true
+    mockExec.mockResolvedValueOnce(stuckState).mockReturnValue(new Promise(() => {}));
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByTestId('flip-button')).toBeInTheDocument());
+    // Manual click sets loading=true for the pending mutation; wait for the
+    // loading state (disabled button) to propagate through react-query before
+    // advancing fake timers, otherwise the pre-click timer can still fire.
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('flip-button'));
+    });
+    await waitFor(() => expect(screen.getByTestId('flip-button')).toBeDisabled());
+    mockExec.mockClear();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(mockExec).not.toHaveBeenCalledWith('flip');
+  });
+
   it('does not auto-flip when disabled via the settings toggle', async () => {
     renderWithProviders(<SpeedPage />);
     await waitFor(() => expect(screen.getByTestId('flip-button')).toBeInTheDocument());

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -74,6 +74,7 @@ function SpeedPageContent() {
     handleFlip,
     handleHint,
     handleConfigChange,
+    handleToggle,
   } = useSpeedGame();
   const {
     hint: frontendHint,
@@ -238,6 +239,13 @@ function SpeedPageContent() {
                       label: t(`settings.${o.label}`),
                     })),
                     onSelect: (v: string) => handleConfigChange('cpuDifficulty', v),
+                  },
+                  {
+                    type: 'checkbox' as const,
+                    id: 'autoFlip',
+                    label: t('settings.autoFlip'),
+                    checked: speedConfig.autoFlip,
+                    onToggle: (v: boolean) => handleToggle('autoFlip', v),
                   },
                   {
                     type: 'checkbox' as const,

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -1539,6 +1539,7 @@ export interface SpeedHint {
 /** Speed game configuration. */
 export interface SpeedConfig {
   cpuDifficulty: number;
+  autoFlip: boolean;
 }
 
 /** Full Speed game state returned from the API. */

--- a/frontend/src/utils/hints/speedHint.test.ts
+++ b/frontend/src/utils/hints/speedHint.test.ts
@@ -21,7 +21,7 @@ function makeState(overrides: Partial<SpeedResponse> = {}): SpeedResponse {
     phase: SpeedPhase.PLAY,
     gameEndFlag: false,
     winnerIdx: -1,
-    config: { cpuDifficulty: 0 },
+    config: { cpuDifficulty: 0, autoFlip: true },
     message: '',
     ...overrides,
   };


### PR DESCRIPTION
## Summary
- Adds an auto-flip feature so Speed automatically fires `Flip` ~2.5s after entering the stuck (膠着) phase, restoring the game's natural tempo.
- New `autoFlip` toggle in the Speed settings panel (default on) lets players opt out and fall back to manual flipping.
- Implementation is pure frontend: a `setTimeout` inside `useSpeedGame` that is cleared on phase change, unmount, or when the toggle flips off.

## Changes
- `frontend/src/types/card.ts`: extend `SpeedConfig` with `autoFlip: boolean`
- `frontend/src/hooks/useSpeedGame.ts`: new `AUTO_FLIP_DELAY_MS` constant, phase-scoped `useEffect` that schedules the flip, and exposes `handleToggle`
- `frontend/src/pages/SpeedPage.tsx`: checkbox in the settings panel bound to the new toggle
- i18n: new `settings.autoFlip` key for ja/en
- Tests: updated existing reset-config expectations and added a dedicated `auto-flip timer` suite using fake timers to cover fire/early-cancel/disabled paths

## Test plan
- [x] `cd frontend && bun run test -- --run src/pages/SpeedPage.test.tsx` (26/26 passing)
- [x] `cd frontend && NODE_OPTIONS='--max-old-space-size=4096' bun run build` (type check + vite build green)
- [x] `cd frontend && bun run check` (no new biome warnings in touched files)

Closes #1277