### PR TITLE
feat(frontend): swipe-to-bulk-select cards in Daifugo and Doubt

### DIFF
--- a/frontend/src/components/daifugo/DaifugoHumanArea.tsx
+++ b/frontend/src/components/daifugo/DaifugoHumanArea.tsx
@@ -59,7 +59,7 @@ export function DaifugoHumanArea({
             aria-pressed={selectedIndices.includes(i)}
             disabled={!isCurrentTurn}
             draggable={isCurrentTurn}
-            className={focusRingCard}
+            className={`${focusRingCard} touch-none`}
             onClick={() => onToggle(i)}
             onPointerDown={isCurrentTurn && onSwipeStart ? () => onSwipeStart(i) : undefined}
             onDragStart={(e) => {

--- a/frontend/src/components/daifugo/DaifugoHumanArea.tsx
+++ b/frontend/src/components/daifugo/DaifugoHumanArea.tsx
@@ -13,6 +13,7 @@ interface HumanPlayerAreaProps {
   onToggle: (idx: number) => void;
   isCurrentTurn: boolean;
   onDragCard: (idx: number) => void;
+  onSwipeStart?: (idx: number) => void;
 }
 
 /** Renders the human player's hand area for Daifugo with card selection and drag support. */
@@ -22,6 +23,7 @@ export function DaifugoHumanArea({
   onToggle,
   isCurrentTurn,
   onDragCard,
+  onSwipeStart,
 }: HumanPlayerAreaProps) {
   const { t } = useTranslation('daifugo');
   const { cardWidth } = useCardDimensions();
@@ -53,11 +55,13 @@ export function DaifugoHumanArea({
           <button
             key={`${card.design}-${card.value}`}
             type="button"
+            data-card-index={i}
             aria-pressed={selectedIndices.includes(i)}
             disabled={!isCurrentTurn}
             draggable={isCurrentTurn}
             className={focusRingCard}
             onClick={() => onToggle(i)}
+            onPointerDown={isCurrentTurn && onSwipeStart ? () => onSwipeStart(i) : undefined}
             onDragStart={(e) => {
               e.dataTransfer.setData('cardIndex', String(i));
               onDragCard(i);

--- a/frontend/src/components/doubt/DoubtHandCard.test.tsx
+++ b/frontend/src/components/doubt/DoubtHandCard.test.tsx
@@ -69,4 +69,41 @@ describe('DoubtHandCard', () => {
     fireEvent.click(screen.getByTestId('hand-card'));
     expect(onToggle).toHaveBeenCalledWith(3);
   });
+
+  it('exposes data-card-index for swipe selection lookup', () => {
+    render(<DoubtHandCard card={card} index={4} selected={false} selectable={true} onToggle={vi.fn()} />);
+    expect(screen.getByTestId('hand-card')).toHaveAttribute('data-card-index', '4');
+  });
+
+  it('calls onSwipeStart with index on pointerdown when selectable', () => {
+    const onSwipeStart = vi.fn();
+    render(
+      <DoubtHandCard
+        card={card}
+        index={2}
+        selected={false}
+        selectable={true}
+        onToggle={vi.fn()}
+        onSwipeStart={onSwipeStart}
+      />,
+    );
+    fireEvent.pointerDown(screen.getByTestId('hand-card'));
+    expect(onSwipeStart).toHaveBeenCalledWith(2);
+  });
+
+  it('does not call onSwipeStart on pointerdown when not selectable', () => {
+    const onSwipeStart = vi.fn();
+    render(
+      <DoubtHandCard
+        card={card}
+        index={2}
+        selected={false}
+        selectable={false}
+        onToggle={vi.fn()}
+        onSwipeStart={onSwipeStart}
+      />,
+    );
+    fireEvent.pointerDown(screen.getByTestId('hand-card'));
+    expect(onSwipeStart).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/components/doubt/DoubtHandCard.tsx
+++ b/frontend/src/components/doubt/DoubtHandCard.tsx
@@ -22,7 +22,7 @@ export function DoubtHandCard({ card, index, selected, selectable, onToggle, onS
       data-card-index={index}
       aria-pressed={selected}
       disabled={!selectable}
-      className={focusRingCard}
+      className={`${focusRingCard} touch-none`}
       onClick={() => onToggle(index)}
       onPointerDown={selectable && onSwipeStart ? () => onSwipeStart(index) : undefined}
       style={{

--- a/frontend/src/components/doubt/DoubtHandCard.tsx
+++ b/frontend/src/components/doubt/DoubtHandCard.tsx
@@ -9,19 +9,22 @@ interface HandCardProps {
   selected: boolean;
   selectable: boolean;
   onToggle: (idx: number) => void;
+  onSwipeStart?: (idx: number) => void;
 }
 
 /** Renders a selectable hand card for Doubt with selection highlight. */
-export function DoubtHandCard({ card, index, selected, selectable, onToggle }: HandCardProps) {
+export function DoubtHandCard({ card, index, selected, selectable, onToggle, onSwipeStart }: HandCardProps) {
   const { cardWidth } = useCardDimensions();
   return (
     <button
       type="button"
       data-testid="hand-card"
+      data-card-index={index}
       aria-pressed={selected}
       disabled={!selectable}
       className={focusRingCard}
       onClick={() => onToggle(index)}
+      onPointerDown={selectable && onSwipeStart ? () => onSwipeStart(index) : undefined}
       style={{
         background: 'none',
         padding: 0,

--- a/frontend/src/hooks/useCardSwipeSelection.test.ts
+++ b/frontend/src/hooks/useCardSwipeSelection.test.ts
@@ -1,0 +1,168 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCardSwipeSelection } from './useCardSwipeSelection';
+
+/**
+ * Tests for the swipe/drag bulk card selection hook. We stub
+ * `document.elementFromPoint` so each x-coordinate (10 px wide) resolves to a
+ * synthetic card element whose `data-card-index` the hook can read.
+ */
+describe('useCardSwipeSelection', () => {
+  let cardElements: Map<number, HTMLElement>;
+
+  beforeEach(() => {
+    cardElements = new Map();
+    for (let i = 0; i < 5; i++) {
+      const el = document.createElement('button');
+      el.setAttribute('data-card-index', String(i));
+      document.body.appendChild(el);
+      cardElements.set(i, el);
+    }
+    vi.spyOn(document, 'elementFromPoint').mockImplementation((x: number) => {
+      const idx = Math.floor(x / 10);
+      return cardElements.get(idx) ?? null;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cardElements.forEach((el) => {
+      el.remove();
+    });
+    cardElements.clear();
+  });
+
+  const firePointer = (type: 'pointermove' | 'pointerup' | 'pointercancel', x: number, y = 0) => {
+    const ev = new Event(type, { bubbles: true });
+    Object.defineProperty(ev, 'clientX', { value: x });
+    Object.defineProperty(ev, 'clientY', { value: y });
+    window.dispatchEvent(ev);
+  };
+
+  it('does not toggle on a plain tap (no pointer movement)', () => {
+    const toggle = vi.fn();
+    const { result } = renderHook(() => useCardSwipeSelection({ selected: [], toggle }));
+    act(() => {
+      result.current.onPointerDown(0);
+      firePointer('pointerup', 0);
+    });
+    expect(toggle).not.toHaveBeenCalled();
+  });
+
+  it('bulk-selects cards traversed when starting from an unselected card', () => {
+    const toggle = vi.fn();
+    const { result } = renderHook(() => useCardSwipeSelection({ selected: [], toggle }));
+    act(() => {
+      result.current.onPointerDown(0);
+      firePointer('pointermove', 15);
+      firePointer('pointermove', 25);
+      firePointer('pointerup', 25);
+    });
+    expect(toggle).toHaveBeenCalledWith(0);
+    expect(toggle).toHaveBeenCalledWith(1);
+    expect(toggle).toHaveBeenCalledWith(2);
+    expect(toggle).toHaveBeenCalledTimes(3);
+  });
+
+  it('bulk-deselects cards traversed when starting from a selected card', () => {
+    const toggle = vi.fn();
+    const { result } = renderHook(() => useCardSwipeSelection({ selected: [0, 1, 2], toggle }));
+    act(() => {
+      result.current.onPointerDown(0);
+      firePointer('pointermove', 15);
+      firePointer('pointermove', 25);
+      firePointer('pointerup', 25);
+    });
+    expect(toggle).toHaveBeenCalledWith(0);
+    expect(toggle).toHaveBeenCalledWith(1);
+    expect(toggle).toHaveBeenCalledWith(2);
+    expect(toggle).toHaveBeenCalledTimes(3);
+  });
+
+  it('leaves cards alone that already match the swipe mode', () => {
+    const toggle = vi.fn();
+    // Start on card 0 (unselected) → mode = select. Card 1 is already selected
+    // so it should be skipped. Card 2 is unselected so it gets toggled.
+    const { result } = renderHook(() => useCardSwipeSelection({ selected: [1], toggle }));
+    act(() => {
+      result.current.onPointerDown(0);
+      firePointer('pointermove', 15);
+      firePointer('pointermove', 25);
+      firePointer('pointerup', 25);
+    });
+    expect(toggle).toHaveBeenCalledWith(0);
+    expect(toggle).not.toHaveBeenCalledWith(1);
+    expect(toggle).toHaveBeenCalledWith(2);
+    expect(toggle).toHaveBeenCalledTimes(2);
+  });
+
+  it('toggles each card only once, even if the pointer re-enters it', () => {
+    const toggle = vi.fn();
+    const { result } = renderHook(() => useCardSwipeSelection({ selected: [], toggle }));
+    act(() => {
+      result.current.onPointerDown(0);
+      firePointer('pointermove', 15);
+      firePointer('pointermove', 25);
+      firePointer('pointermove', 15); // back to card 1
+      firePointer('pointermove', 5); // back to card 0
+      firePointer('pointerup', 5);
+    });
+    expect(toggle).toHaveBeenCalledTimes(3);
+  });
+
+  it('suppresses the trailing click after a real swipe', () => {
+    const toggle = vi.fn();
+    const clickHandler = vi.fn();
+    const card1 = cardElements.get(1);
+    if (!card1) throw new Error('card1 missing');
+    card1.addEventListener('click', clickHandler);
+    const { result } = renderHook(() => useCardSwipeSelection({ selected: [], toggle }));
+    act(() => {
+      result.current.onPointerDown(0);
+      firePointer('pointermove', 15);
+      firePointer('pointerup', 15);
+      card1.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+    expect(clickHandler).not.toHaveBeenCalled();
+    card1.removeEventListener('click', clickHandler);
+  });
+
+  it('does not suppress clicks after a plain tap', () => {
+    const toggle = vi.fn();
+    const clickHandler = vi.fn();
+    const card0 = cardElements.get(0);
+    if (!card0) throw new Error('card0 missing');
+    card0.addEventListener('click', clickHandler);
+    const { result } = renderHook(() => useCardSwipeSelection({ selected: [], toggle }));
+    act(() => {
+      result.current.onPointerDown(0);
+      firePointer('pointerup', 0);
+      card0.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+    expect(clickHandler).toHaveBeenCalledTimes(1);
+    card0.removeEventListener('click', clickHandler);
+  });
+
+  it('cancels an in-progress swipe when a native drag starts', () => {
+    const toggle = vi.fn();
+    const { result } = renderHook(() => useCardSwipeSelection({ selected: [], toggle }));
+    act(() => {
+      result.current.onPointerDown(0);
+      window.dispatchEvent(new Event('dragstart'));
+      firePointer('pointermove', 15);
+      firePointer('pointerup', 15);
+    });
+    expect(toggle).not.toHaveBeenCalled();
+  });
+
+  it('is inert when disabled', () => {
+    const toggle = vi.fn();
+    const { result } = renderHook(() => useCardSwipeSelection({ selected: [], toggle, enabled: false }));
+    act(() => {
+      result.current.onPointerDown(0);
+      firePointer('pointermove', 15);
+      firePointer('pointerup', 15);
+    });
+    expect(toggle).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useCardSwipeSelection.test.ts
+++ b/frontend/src/hooks/useCardSwipeSelection.test.ts
@@ -110,6 +110,46 @@ describe('useCardSwipeSelection', () => {
     expect(toggle).toHaveBeenCalledTimes(3);
   });
 
+  it('treats pointercancel the same as pointerup and suppresses the trailing click', () => {
+    const toggle = vi.fn();
+    const clickHandler = vi.fn();
+    const card1 = cardElements.get(1);
+    if (!card1) throw new Error('card1 missing');
+    card1.addEventListener('click', clickHandler);
+    const { result } = renderHook(() => useCardSwipeSelection({ selected: [], toggle }));
+    act(() => {
+      result.current.onPointerDown(0);
+      firePointer('pointermove', 15);
+      firePointer('pointercancel', 15);
+      card1.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+    // Both cards 0 and 1 should have been toggled before cancel fired.
+    expect(toggle).toHaveBeenCalledWith(0);
+    expect(toggle).toHaveBeenCalledWith(1);
+    // And the trailing click on the released card must be swallowed.
+    expect(clickHandler).not.toHaveBeenCalled();
+    card1.removeEventListener('click', clickHandler);
+  });
+
+  it('does not swallow clicks on non-card elements after a swipe', () => {
+    const toggle = vi.fn();
+    const nonCard = document.createElement('button');
+    document.body.appendChild(nonCard);
+    const clickHandler = vi.fn();
+    nonCard.addEventListener('click', clickHandler);
+    const { result } = renderHook(() => useCardSwipeSelection({ selected: [], toggle }));
+    act(() => {
+      result.current.onPointerDown(0);
+      firePointer('pointermove', 15);
+      firePointer('pointerup', 15);
+      // An unrelated button click in the same task must still fire.
+      nonCard.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+    expect(clickHandler).toHaveBeenCalledTimes(1);
+    nonCard.removeEventListener('click', clickHandler);
+    nonCard.remove();
+  });
+
   it('suppresses the trailing click after a real swipe', () => {
     const toggle = vi.fn();
     const clickHandler = vi.fn();

--- a/frontend/src/hooks/useCardSwipeSelection.ts
+++ b/frontend/src/hooks/useCardSwipeSelection.ts
@@ -22,12 +22,15 @@ interface SwipeState {
  *
  * Each card button must render with a `data-card-index="<index>"` attribute so
  * the hook can resolve which card is under the pointer via
- * `document.elementFromPoint`. The hook decides the swipe mode from the first
- * card's current selection state: if it's unselected, the swipe selects every
- * card the pointer traverses; if it's already selected, the swipe deselects
- * them. Single taps are left untouched so the existing click handler still
- * toggles one card at a time; the trailing click after an actual swipe is
- * suppressed to avoid double-toggling the card the pointer was released on.
+ * `document.elementFromPoint`. Card buttons should also carry
+ * `touch-action: none` (e.g. Tailwind's `touch-none`); otherwise mobile
+ * browsers hijack the swipe as a scroll gesture and `pointermove` events
+ * stop firing. The hook decides the swipe mode from the first card's current
+ * selection state: if it's unselected, the swipe selects every card the
+ * pointer traverses; if it's already selected, the swipe deselects them.
+ * Single taps are left untouched so the existing click handler still toggles
+ * one card at a time; the trailing click after an actual swipe is suppressed
+ * to avoid double-toggling the card the pointer was released on.
  */
 export function useCardSwipeSelection({ selected, toggle, enabled = true }: UseCardSwipeSelectionParams) {
   const stateRef = useRef<SwipeState | null>(null);
@@ -80,12 +83,20 @@ export function useCardSwipeSelection({ selected, toggle, enabled = true }: UseC
 
     const suppressNextClick = () => {
       const suppress = (clickEvent: MouseEvent) => {
-        clickEvent.stopPropagation();
-        clickEvent.preventDefault();
+        // Only eat the click if it lands on a card; an unrelated click on a
+        // nearby action button during the same task must still fire.
+        const target = clickEvent.target as Element | null;
+        if (target?.closest('[data-card-index]')) {
+          clickEvent.stopPropagation();
+          clickEvent.preventDefault();
+        }
         window.removeEventListener('click', suppress, true);
       };
       window.addEventListener('click', suppress, true);
-      // Clean up in case no click ever fires (e.g. pointerup outside any card).
+      // Fall through to the next task so the trusted click queued by the
+      // browser's pointer sequence has already fired before we unregister;
+      // this also cleans up when pointerup landed outside any card and no
+      // click follows at all.
       setTimeout(() => window.removeEventListener('click', suppress, true), 0);
     };
 

--- a/frontend/src/hooks/useCardSwipeSelection.ts
+++ b/frontend/src/hooks/useCardSwipeSelection.ts
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/** Parameters for {@link useCardSwipeSelection}. */
+export interface UseCardSwipeSelectionParams {
+  /** Current selected card indices, used to decide swipe mode (select vs deselect). */
+  selected: number[];
+  /** Toggle a single card index in the existing selection. */
+  toggle: (idx: number) => void;
+  /** When false, pointer handlers are inert. */
+  enabled?: boolean;
+}
+
+interface SwipeState {
+  startIdx: number;
+  mode: 'select' | 'deselect' | null;
+  visited: Set<number>;
+  moved: boolean;
+}
+
+/**
+ * Enables swipe (drag) across card buttons to bulk select or deselect.
+ *
+ * Each card button must render with a `data-card-index="<index>"` attribute so
+ * the hook can resolve which card is under the pointer via
+ * `document.elementFromPoint`. The hook decides the swipe mode from the first
+ * card's current selection state: if it's unselected, the swipe selects every
+ * card the pointer traverses; if it's already selected, the swipe deselects
+ * them. Single taps are left untouched so the existing click handler still
+ * toggles one card at a time; the trailing click after an actual swipe is
+ * suppressed to avoid double-toggling the card the pointer was released on.
+ */
+export function useCardSwipeSelection({ selected, toggle, enabled = true }: UseCardSwipeSelectionParams) {
+  const stateRef = useRef<SwipeState | null>(null);
+  const selectedRef = useRef(selected);
+  const toggleRef = useRef(toggle);
+  selectedRef.current = selected;
+  toggleRef.current = toggle;
+
+  const applyToIndex = useCallback((idx: number) => {
+    const state = stateRef.current;
+    if (!state || state.mode === null) return;
+    if (state.visited.has(idx)) return;
+    state.visited.add(idx);
+    const has = selectedRef.current.includes(idx);
+    if ((state.mode === 'select' && !has) || (state.mode === 'deselect' && has)) {
+      toggleRef.current(idx);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const findIndexAt = (clientX: number, clientY: number): number | null => {
+      const el = document.elementFromPoint(clientX, clientY);
+      if (!el) return null;
+      const cardEl = (el as Element).closest('[data-card-index]');
+      if (!cardEl) return null;
+      const raw = cardEl.getAttribute('data-card-index');
+      if (raw === null) return null;
+      const n = Number(raw);
+      return Number.isFinite(n) ? n : null;
+    };
+
+    const handleMove = (e: PointerEvent) => {
+      const state = stateRef.current;
+      if (!state) return;
+      const idx = findIndexAt(e.clientX, e.clientY);
+      if (idx === null) return;
+      if (!state.moved) {
+        if (idx === state.startIdx) return;
+        // First move off the start card: fix the swipe mode based on the
+        // start card's current selection state, then apply to both cards.
+        const startSelected = selectedRef.current.includes(state.startIdx);
+        state.mode = startSelected ? 'deselect' : 'select';
+        state.moved = true;
+        applyToIndex(state.startIdx);
+      }
+      applyToIndex(idx);
+    };
+
+    const suppressNextClick = () => {
+      const suppress = (clickEvent: MouseEvent) => {
+        clickEvent.stopPropagation();
+        clickEvent.preventDefault();
+        window.removeEventListener('click', suppress, true);
+      };
+      window.addEventListener('click', suppress, true);
+      // Clean up in case no click ever fires (e.g. pointerup outside any card).
+      setTimeout(() => window.removeEventListener('click', suppress, true), 0);
+    };
+
+    const handleUp = () => {
+      const state = stateRef.current;
+      if (!state) return;
+      const wasSwipe = state.moved;
+      stateRef.current = null;
+      if (wasSwipe) suppressNextClick();
+    };
+
+    const handleDragStart = () => {
+      // Native HTML5 drag took over (e.g. Daifugo's drag-to-play): abandon
+      // the swipe so we don't double-dispatch when the drag ends.
+      stateRef.current = null;
+    };
+
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', handleUp);
+    window.addEventListener('pointercancel', handleUp);
+    window.addEventListener('dragstart', handleDragStart);
+    return () => {
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', handleUp);
+      window.removeEventListener('pointercancel', handleUp);
+      window.removeEventListener('dragstart', handleDragStart);
+    };
+  }, [enabled, applyToIndex]);
+
+  const onPointerDown = useCallback(
+    (idx: number) => {
+      if (!enabled) return;
+      stateRef.current = {
+        startIdx: idx,
+        mode: null,
+        visited: new Set<number>(),
+        moved: false,
+      };
+    },
+    [enabled],
+  );
+
+  return { onPointerDown } as const;
+}

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -24,6 +24,7 @@ import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
+import { useCardSwipeSelection } from '../hooks/useCardSwipeSelection';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useDaifugoGame } from '../hooks/useDaifugoGame';
@@ -154,6 +155,12 @@ function DaifugoPageContent() {
     onToggle: toggleCardSelection,
     onConfirm: kbdConfirm,
     onClear: clearSelection,
+    enabled: isHumanTurnForKbd && !loading,
+  });
+
+  const { onPointerDown: handleDaifugoSwipeStart } = useCardSwipeSelection({
+    selected: selectedIndices,
+    toggle: toggleCardSelection,
     enabled: isHumanTurnForKbd && !loading,
   });
 
@@ -343,6 +350,7 @@ function DaifugoPageContent() {
                   onToggle={toggleCardSelection}
                   isCurrentTurn={isHumanTurn}
                   onDragCard={handleDragCard}
+                  onSwipeStart={handleDaifugoSwipeStart}
                 />
               </div>
             )}

--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -22,6 +22,7 @@ import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
+import { useCardSwipeSelection } from '../hooks/useCardSwipeSelection';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import {
@@ -169,6 +170,12 @@ function DoubtPageContent() {
     onToggle: toggleCard,
     onConfirm: handlePlay,
     onClear: clearSelection,
+    enabled: isHumanPlayTurn && !loading,
+  });
+
+  const { onPointerDown: handleCardSwipeStart } = useCardSwipeSelection({
+    selected: selectedCardIndices,
+    toggle: toggleCard,
     enabled: isHumanPlayTurn && !loading,
   });
 
@@ -446,6 +453,7 @@ function DoubtPageContent() {
                       selected={selectedCardIndices.includes(i)}
                       selectable={isHumanTurn && state.phase === 0 && !loading}
                       onToggle={toggleCard}
+                      onSwipeStart={handleCardSwipeStart}
                     />
                   ))}
                 </div>


### PR DESCRIPTION
## Summary
- New `useCardSwipeSelection` hook lets players drag/swipe across card buttons to bulk select or deselect in one gesture. Swipe mode is locked from the start card (unselected → select-all-traversed; selected → deselect-all-traversed), each card is toggled at most once, and the trailing click after a real swipe is suppressed so the release card is not double-toggled.
- Wired into Daifugo (`DaifugoHumanArea` / `DaifugoPage`) and Doubt (`DoubtHandCard` / `DoubtPage`). Plain taps still fall through to the existing `onClick`, and Daifugo's native HTML5 drag-to-play is preserved — a `dragstart` cancels any in-flight swipe.
- GoFish already selects all cards of one rank in a single tap and OldMaid has no selection state, so neither needs the new hook.

Closes #1278

## Test plan
- [x] `bun run check`
- [x] `bun run build`
- [x] `bun run test` (4783 pass; the only error is a pre-existing vitest worker-teardown flake on `NavBar.test.tsx` — all 131 tests inside it pass and it's unrelated to this change)
- [x] New unit tests:
  - `useCardSwipeSelection` — 9 tests (tap no-op, bulk-select, bulk-deselect, mode gating, re-entry idempotence, click suppression, dragstart cancellation, `enabled: false`)
  - `DoubtHandCard` — 4 new tests for `data-card-index` and `onSwipeStart` wiring
- [ ] Manual QA on mobile (touch swipe) and desktop (mouse drag) in Daifugo and Doubt