### PR TITLE
fix(freecell): allow any card on empty tableau column

### DIFF
--- a/internal/adapter/presenter/FreeCellCuiPresenter_test.go
+++ b/internal/adapter/presenter/FreeCellCuiPresenter_test.go
@@ -175,11 +175,16 @@ func TestFreeCellCuiPresenterHintToFreeCell(t *testing.T) {
 	f.Reset()
 	f.SetPhase(domain.FreeCellPhasePlaying)
 
-	// Set up tableau with cards that can't go to foundation or other tableau, only freecell
+	// Set up tableau with cards that can't go to foundation or other tableau,
+	// with all columns filled so there are no empty columns to use as fallback.
+	// Only the freecell is a valid destination.
 	var tableau [domain.FreeCellTableauCnt][]*domain.Card
 	tableau[0] = []*domain.Card{
 		domain.NewCard(domain.CardDesignSpade, 10, false),
 		domain.NewCard(domain.CardDesignSpade, 9, false),
+	}
+	for i := 1; i < domain.FreeCellTableauCnt; i++ {
+		tableau[i] = []*domain.Card{domain.NewCard(domain.CardDesignSpade, 2, false)}
 	}
 	f.SetTableau(tableau)
 	var cells [domain.FreeCellCellCnt]*domain.Card

--- a/internal/domain/FreeCell.go
+++ b/internal/domain/FreeCell.go
@@ -333,7 +333,8 @@ func (f *FreeCell) GetHint() *FreeCellHint {
 			if toCol == fromCol {
 				continue
 			}
-			// 空列へKing以外のシーケンスを移動しても意味がない（キングのみ移動意味あり）
+			// 優先度3ではKingの空列移動だけを評価する。King以外の空列移動は
+			// 有効な手ではあるが優先度が低いので、後段のフォールバックに委ねる。
 			if len(f.tableau[toCol]) == 0 && card.GetValue() != CardValueMax {
 				continue
 			}
@@ -359,6 +360,8 @@ func (f *FreeCell) GetHint() *FreeCellHint {
 		}
 		card := f.freeCells[cell]
 		for toCol := 0; toCol < FreeCellTableauCnt; toCol++ {
+			// 優先度4ではKingの空列移動だけを評価する。King以外の空列移動は
+			// 有効な手ではあるが優先度が低いので、後段のフォールバックに委ねる。
 			if len(f.tableau[toCol]) == 0 && card.GetValue() != CardValueMax {
 				continue
 			}
@@ -373,7 +376,14 @@ func (f *FreeCell) GetHint() *FreeCellHint {
 			}
 		}
 	}
-	// 優先度5: タブローからフリーセルへ
+	// 優先度5: 空列への非Kingの移動（フォールバック）
+	// フリーセルやタブローの非Kingカードを空列に移すことでタブロー奥のカードを
+	// 露出させる手。フリーセルでは空列に任意のカードを置けるため、有効な手として
+	// 候補に含める。ただし無意味な空列交換を避けるためタブロー列全体の移動は除外する。
+	if hint := f.getHintToEmptyColumn(); hint != nil {
+		return hint
+	}
+	// 優先度6: タブローからフリーセルへ
 	for col := 0; col < FreeCellTableauCnt; col++ {
 		if len(f.tableau[col]) == 0 {
 			continue
@@ -390,6 +400,80 @@ func (f *FreeCell) GetHint() *FreeCellHint {
 			}
 		}
 		break // 最初の非空列について一つのフリーセルを見つければ十分
+	}
+	return nil
+}
+
+// getHintToEmptyColumn は非Kingカードを空列に移動するフォールバックヒントを返す。
+// フリーセルから空列への移動を優先し、次にタブロー列のシーケンスを空列に移動する。
+// 列全体の移動（seqStart == 0）は意味がないため除外する。
+func (f *FreeCell) getHintToEmptyColumn() *FreeCellHint {
+	// 空列の先頭インデックスを探す
+	emptyCol := -1
+	for col := 0; col < FreeCellTableauCnt; col++ {
+		if len(f.tableau[col]) == 0 {
+			emptyCol = col
+			break
+		}
+	}
+	if emptyCol < 0 {
+		return nil
+	}
+	// フリーセル→空列（非King）
+	for cell := 0; cell < FreeCellCellCnt; cell++ {
+		card := f.freeCells[cell]
+		if card == nil || card.GetValue() == CardValueMax {
+			continue
+		}
+		return &FreeCellHint{
+			FromZone:  "freecell",
+			FromCol:   cell,
+			CardIndex: -1,
+			ToZone:    "tableau",
+			ToCol:     emptyCol,
+		}
+	}
+	// タブロー→空列（非King、列全体の移動を除く）
+	for fromCol := 0; fromCol < FreeCellTableauCnt; fromCol++ {
+		fromCards := f.tableau[fromCol]
+		if len(fromCards) == 0 {
+			continue
+		}
+		seqStart := len(fromCards) - 1
+		for seqStart > 0 {
+			if !f.isAlternateColor(fromCards[seqStart], fromCards[seqStart-1]) ||
+				fromCards[seqStart].GetValue() != fromCards[seqStart-1].GetValue()-1 {
+				break
+			}
+			seqStart--
+		}
+		// 列全体を空列に動かすのは無意味な空列交換
+		if seqStart == 0 {
+			continue
+		}
+		card := fromCards[seqStart]
+		if card.GetValue() == CardValueMax {
+			// Kingの空列移動は優先度3で処理済み
+			continue
+		}
+		movingCards := fromCards[seqStart:]
+		// 別の空列を移動先に選ぶ（fromColが空になる場合でも、maxMovableCardsは
+		// toColを除外して計算するため問題ない）
+		for toCol := 0; toCol < FreeCellTableauCnt; toCol++ {
+			if toCol == fromCol || len(f.tableau[toCol]) != 0 {
+				continue
+			}
+			if len(movingCards) > f.maxMovableCards(toCol) {
+				continue
+			}
+			return &FreeCellHint{
+				FromZone:  "tableau",
+				FromCol:   fromCol,
+				CardIndex: seqStart,
+				ToZone:    "tableau",
+				ToCol:     toCol,
+			}
+		}
 	}
 	return nil
 }
@@ -530,8 +614,8 @@ func (f *FreeCell) SetFoundation(foundation [FreeCellFoundationCnt][]*Card) {
 func (f *FreeCell) canPlaceOnTableau(card *Card, col int) bool {
 	colCards := f.tableau[col]
 	if len(colCards) == 0 {
-		// 空の列にはKのみ置ける
-		return card.GetValue() == CardValueMax
+		// フリーセルでは空列には任意のカードを置ける
+		return true
 	}
 	topCard := colCards[len(colCards)-1]
 	return f.isAlternateColor(card, topCard) && card.GetValue() == topCard.GetValue()-1

--- a/internal/domain/FreeCell.go
+++ b/internal/domain/FreeCell.go
@@ -457,21 +457,14 @@ func (f *FreeCell) getHintToEmptyColumn() *FreeCellHint {
 			continue
 		}
 		movingCards := fromCards[seqStart:]
-		// 別の空列を移動先に選ぶ（fromColが空になる場合でも、maxMovableCardsは
-		// toColを除外して計算するため問題ない）
-		for toCol := 0; toCol < FreeCellTableauCnt; toCol++ {
-			if toCol == fromCol || len(f.tableau[toCol]) != 0 {
-				continue
-			}
-			if len(movingCards) > f.maxMovableCards(toCol) {
-				continue
-			}
+		// emptyColはfromColと異なる（fromCardsが非空のため）
+		if len(movingCards) <= f.maxMovableCards(emptyCol) {
 			return &FreeCellHint{
 				FromZone:  "tableau",
 				FromCol:   fromCol,
 				CardIndex: seqStart,
 				ToZone:    "tableau",
-				ToCol:     toCol,
+				ToCol:     emptyCol,
 			}
 		}
 	}

--- a/internal/domain/FreeCell_test.go
+++ b/internal/domain/FreeCell_test.go
@@ -241,12 +241,15 @@ func TestFreeCellMoveTableauToTableauErrors(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("non-king to empty", func(t *testing.T) {
+	t.Run("non-king to empty succeeds", func(t *testing.T) {
+		// フリーセルでは空列に任意のカードを置けるため、非Kingの移動も成立する
 		f := setupPlayingFreeCell()
 		clearTableauFC(f)
 		f.tableau[0] = []*Card{makeCard(CardDesignSpade, 5)}
 		err := f.MoveTableauToTableau(0, 0, 1)
-		assert.Error(t, err)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(f.tableau[0]))
+		assert.Equal(t, 1, len(f.tableau[1]))
 	})
 }
 
@@ -690,6 +693,70 @@ func TestFreeCellGetHintEmptyTableauColumns(t *testing.T) {
 	assert.Equal(t, 0, hint.ToCol) // move to col 0 (non-empty)
 }
 
+func TestFreeCellGetHintFreeCellNonKingToEmptyColumn(t *testing.T) {
+	// フリーセルにしか置き場所がなく、かつ非Kingカードであっても空列へのヒントを返す
+	// （Issue #1283: FreeCellでは空列に任意のカードを置ける）。
+	f := setupPlayingFreeCell()
+	clearTableauFC(f)
+
+	// フリーセルの5♥はタブロー上の6♥（同色）には置けない。他の列は空。
+	f.tableau[0] = []*Card{makeCard(CardDesignHeart, 6)}
+	f.freeCells[0] = makeCard(CardDesignHeart, 5)
+
+	hint := f.GetHint()
+	assert.NotNil(t, hint)
+	assert.Equal(t, "freecell", hint.FromZone)
+	assert.Equal(t, 0, hint.FromCol)
+	assert.Equal(t, "tableau", hint.ToZone)
+	// col 0以外の最初の空列（col 1）
+	assert.Equal(t, 1, hint.ToCol)
+}
+
+func TestFreeCellGetHintTableauNonKingSequenceToEmptyColumn(t *testing.T) {
+	// タブロー奥のカードを露出させる目的で、非Kingのシーケンスを空列に移動する
+	// ヒントを返す（Issue #1283）。
+	f := setupPlayingFreeCell()
+	clearTableauFC(f)
+
+	// col 0: 隠したい9♥の上に非Kingの有効シーケンス（4♠, 3♥）が乗っている
+	f.tableau[0] = []*Card{
+		makeCard(CardDesignHeart, 9),
+		makeCard(CardDesignSpade, 4),
+		makeCard(CardDesignHeart, 3),
+	}
+	// col 1: 他のタブロー間移動を成立させないための同色カード
+	f.tableau[1] = []*Card{makeCard(CardDesignSpade, 10)}
+	// col 2-7は空。フリーセルは空のまま。
+
+	hint := f.GetHint()
+	assert.NotNil(t, hint)
+	assert.Equal(t, "tableau", hint.FromZone)
+	assert.Equal(t, 0, hint.FromCol)
+	assert.Equal(t, 1, hint.CardIndex) // 4♠の位置
+	assert.Equal(t, "tableau", hint.ToZone)
+	// col 2が最初の空列
+	assert.Equal(t, 2, hint.ToCol)
+}
+
+func TestFreeCellGetHintSkipsWholeColumnMoveToEmpty(t *testing.T) {
+	// 列全体を空列に移動するのは無意味な空列交換なので、空列への
+	// フォールバックヒントには含めない。その場合はタブロー→フリーセルに
+	// フォールバックする。
+	f := setupPlayingFreeCell()
+	clearTableauFC(f)
+
+	// col 0には単独カード（これを空列に動かしても空列交換にしかならない）
+	f.tableau[0] = []*Card{makeCard(CardDesignSpade, 5)}
+	// col 1-7は空、フリーセルは空
+
+	hint := f.GetHint()
+	assert.NotNil(t, hint)
+	// 空列交換を避けて、タブロー→フリーセルが選ばれる
+	assert.Equal(t, "tableau", hint.FromZone)
+	assert.Equal(t, 0, hint.FromCol)
+	assert.Equal(t, "freecell", hint.ToZone)
+}
+
 // --- AutoComplete tests ---
 
 func TestFreeCellAutoComplete(t *testing.T) {
@@ -986,7 +1053,8 @@ func TestFreeCellCanPlaceOnTableau(t *testing.T) {
 	})
 
 	t.Run("non-king on empty", func(t *testing.T) {
-		assert.False(t, f.canPlaceOnTableau(makeCard(CardDesignSpade, 5), 0))
+		// フリーセルでは空列に任意のカードを置ける（クロンダイクと異なる）
+		assert.True(t, f.canPlaceOnTableau(makeCard(CardDesignSpade, 5), 0))
 	})
 
 	t.Run("alternate color descending", func(t *testing.T) {

--- a/internal/domain/freecell_solver.go
+++ b/internal/domain/freecell_solver.go
@@ -258,7 +258,8 @@ func isSolvedState(st *freeCellState) bool {
 func canPlaceOnTableau(card *Card, col int, tableau [FreeCellTableauCnt][]*Card) bool {
 	colCards := tableau[col]
 	if len(colCards) == 0 {
-		return card.GetValue() == CardValueMax
+		// フリーセルでは空列には任意のカードを置ける
+		return true
 	}
 	topCard := colCards[len(colCards)-1]
 	return isAlternateColor(card, topCard) && card.GetValue() == topCard.GetValue()-1

--- a/internal/domain/freecell_solver_internal_test.go
+++ b/internal/domain/freecell_solver_internal_test.go
@@ -403,3 +403,30 @@ func TestFreeCellSolver_AStarPriorityQueueOrder(t *testing.T) {
 	third := heap.Pop(pq).(*freeCellState)
 	assert.Equal(t, 15, third.g+third.h)
 }
+
+func TestCanPlaceOnTableau_SolverAllowsNonKingOnEmpty(t *testing.T) {
+	var tableau [FreeCellTableauCnt][]*Card
+
+	t.Run("non-King on empty column", func(t *testing.T) {
+		// FreeCell rule: any card can go on an empty column
+		heart5 := NewCard(CardDesignHeart, 5, false)
+		assert.True(t, canPlaceOnTableau(heart5, 0, tableau))
+	})
+
+	t.Run("King on empty column", func(t *testing.T) {
+		king := NewCard(CardDesignSpade, CardValueMax, false)
+		assert.True(t, canPlaceOnTableau(king, 0, tableau))
+	})
+
+	t.Run("valid alternating-color descending on non-empty", func(t *testing.T) {
+		tableau[1] = []*Card{NewCard(CardDesignSpade, 6, false)}
+		heart5 := NewCard(CardDesignHeart, 5, false)
+		assert.True(t, canPlaceOnTableau(heart5, 1, tableau))
+	})
+
+	t.Run("invalid same-color on non-empty", func(t *testing.T) {
+		tableau[2] = []*Card{NewCard(CardDesignSpade, 6, false)}
+		clover5 := NewCard(CardDesignClover, 5, false)
+		assert.False(t, canPlaceOnTableau(clover5, 2, tableau))
+	})
+}


### PR DESCRIPTION
## Summary
- Fix FreeCell's `canPlaceOnTableau` and `GetHint()` which were applying the Klondike "King only on empty column" rule, breaking a core FreeCell technique of emptying/filling columns to expose buried cards.
- `GetHint()` now keeps the King-to-empty preference in priorities 3/4 and adds a new priority 5 fallback that suggests non-King sequences or free cell cards to empty columns when no stronger move exists (whole-column moves are skipped to avoid pointless empty-column swaps).

## Test plan
- [x] `go test -tags test ./...`
- [x] `golangci-lint run ./...`
- [x] `goimports -w` on modified files
- [x] Added unit tests covering: non-King on empty column in `canPlaceOnTableau`, `MoveTableauToTableau` non-King to empty succeeds, new GetHint fallback paths (freecell→empty, tableau sequence→empty, whole-column-move skipped), and updated the CUI presenter hint test to preserve its tableau→freecell intent.

Closes #1283