### PR TITLE
docs: sync doc drift for 46-game lineup (#1293)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Go trump card game algorithms -- Baccarat, BlackJack, Canasta, Clock Solitaire, Contract Bridge, Crazy Eights, Cribbage, Daifugo, Deuces Wild, Doubt, Durak, Euchre, Forty Thieves, FreeCell, Gin Rummy, Go Fish, Golf, Hearts, Indian Poker, Joker Poker, Klondike, Memory, Napoleon, Oh Hell, Old Maid, Omaha Hold'em, Pai Gow Poker, Pig's Tail, Pineapple Poker, Pinochle, Poker, Pyramid, Seven Card Stud, Sevens, Short Deck Hold'em, Spades, Speed, Spider Solitaire, Texas Hold'em, Three Card Poker, TriPeaks, Video Poker. Clean Architecture with CLI and Web GUI (React + Go REST API).
+Go trump card game algorithms -- Baccarat, BlackJack, Canasta, Canfield, Caribbean Stud Poker, Clock Solitaire, Contract Bridge, Crazy Eights, Cribbage, Daifugo, Deuces Wild, Doubt, Durak, Euchre, Forty Thieves, FreeCell, Gin Rummy, Go Fish, Golf, Hearts, Indian Poker, Joker Poker, Klondike, Memory, Napoleon, Oh Hell, Old Maid, Omaha Hold'em, Pai Gow Poker, Pig's Tail, Pineapple Poker, Pinochle, Poker, Pyramid, Seven Card Stud, Sevens, Short Deck Hold'em, Spades, Speed, Spider Solitaire, Texas Hold'em, Three Card Poker, TriPeaks, Two Ten Jack, Video Poker, War. Clean Architecture with CLI and Web GUI (React + Go REST API).
 
 ## Requirements
 

--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -6,7 +6,7 @@
 
 - [1. クラス図](#1-クラス図)
   - [1.1 コアドメイン (カード・プレイヤー)](#11-コアドメイン-カードプレイヤー)
-  - [1.2 ゲームドメイン (全43ゲーム)](#12-ゲームドメイン-全43ゲーム)
+  - [1.2 ゲームドメイン (全46ゲーム)](#12-ゲームドメイン-全46ゲーム)
   - [1.3 ユースケース層 (Interactor・Presenter)](#13-ユースケース層-interactorpresenter)
   - [1.4 アダプタ層 (Controller・Presenter実装)](#14-アダプタ層-controllerpresenter実装)
   - [1.5 インフラストラクチャ層](#15-インフラストラクチャ層)
@@ -125,7 +125,7 @@ classDiagram
     GamePlayer *-- ChipHolder : mixin
 ```
 
-### 1.2 ゲームドメイン (全43ゲーム)
+### 1.2 ゲームドメイン (全46ゲーム)
 
 #### ベッティング系ゲーム
 
@@ -1248,7 +1248,7 @@ classDiagram
     note for GamePresenter "各ゲームの Presenter は\nGamePresenter[G] の型エイリアス\nまたは拡張インターフェース"
 ```
 
-**Interactor パターン (全41ゲーム共通)**
+**Interactor パターン (全46ゲーム共通)**
 
 ```mermaid
 classDiagram
@@ -1388,8 +1388,8 @@ classDiagram
         +Exec(input string) string
     }
 
-    TrumpCardsWeb --> "*" GameWebController : holds 40 controllers
-    GameManager --> "*" CuiExecer : holds 40 games
+    TrumpCardsWeb --> "*" GameWebController : holds 46 controllers
+    GameManager --> "*" CuiExecer : holds 46 games
     GameCui ..|> CuiExecer : implements
     GameCui --> GameCuiController : delegates
 ```

--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -348,7 +348,7 @@ classDiagram
         +object messageParams
     }
 
-    note for BlackJackResponse "各ゲームが固有のResponse型を持つ\n(全39ゲーム分存在)\n共通フィールド: message, messageCode, messageParams"
+    note for BlackJackResponse "各ゲームが固有のResponse型を持つ\n(全46ゲーム分存在)\n共通フィールド: message, messageCode, messageParams"
 ```
 
 **フェーズ定数 (全ゲーム)**
@@ -631,7 +631,40 @@ classDiagram
         REBUY = 8
     }
 
-    note for KlondikePhase "KlondikePhase, FreeCellPhase, SpiderPhase, PyramidPhase, TriPeaksPhase, GolfPhase, ClockSolitairePhase, FortyThievesPhase は、\nそれぞれ同一の値を持つ別定数です"
+    class CanfieldPhase {
+        <<enumeration>>
+        PLAYING = 0
+        GAME_CLEAR = 1
+        GAME_OVER = 2
+    }
+
+    class TwoTenJackPhase {
+        <<enumeration>>
+        DECLARE = 0
+        PLAY = 1
+        TRICK_END = 2
+        ROUND_END = 3
+        GAME_END = 4
+    }
+
+    class CaribbeanStudPhase {
+        <<enumeration>>
+        BET = 1
+        ACTION = 2
+        END = 3
+    }
+
+    class WarPhase {
+        <<enumeration>>
+        REVEAL = 0
+        RESOLVED = 1
+        WAR_BURY = 2
+        GAME_END = 3
+    }
+
+    note for KlondikePhase "KlondikePhase, FreeCellPhase, SpiderPhase, PyramidPhase, TriPeaksPhase, GolfPhase, ClockSolitairePhase, FortyThievesPhase, CanfieldPhase は、\nそれぞれ同一の値を持つ別定数です"
+
+    note for DurakPhase "DurakPhase の定数は src/pages/DurakPage.tsx 内にローカル定義 (PHASE_ATTACK/DEFEND/BOUT_END)。\nPigsTailPhase の定数は src/pages/PigsTailPage.tsx 内にローカル定義 (PIGTAIL_PHASE_PLAY/END)。\nDaifugoPage は数値 Phase を持たず gameEndFlag と t('phase.play'/'phase.end') を使用する"
 ```
 
 ### 1.2 API クライアント層
@@ -739,7 +772,7 @@ classDiagram
 
     PaiGowApi --> gameApi : uses postJson/gameExec
 
-    note for BlackJackApi "全44ゲーム分のAPI Objectが存在\n(blackjack, poker, oldmaid, daifugo,\nsevens, doubt, holdem, omaha, shortdeck,\npineapple, hearts, memory, klondike, freecell,\nbaccarat, spades, twotenjack, crazyeights, ginrummy, canasta,\nspider, napoleon, indianpoker, videopoker,\ndeuceswild, jokerpoker, euchre, pyramid, tripeaks,\ncribbage, threecard, caribbeanstud, ohhell, bridge, speed,\ngofish, pinochle, golf, pigtail,\nsevencardstud, clocksolitaire, durak,\nfortythieves, paigow)"
+    note for BlackJackApi "全46ゲーム分のAPI Objectが存在\n(blackjack, poker, oldmaid, daifugo,\nsevens, doubt, holdem, omaha, shortdeck,\npineapple, hearts, memory, klondike, freecell,\nbaccarat, spades, twotenjack, crazyeights, ginrummy, canasta,\nspider, napoleon, indianpoker, videopoker,\ndeuceswild, jokerpoker, euchre, pyramid, tripeaks,\ncribbage, threecard, caribbeanstud, ohhell, bridge, speed,\ngofish, pinochle, golf, pigtail,\nsevencardstud, clocksolitaire, durak,\nfortythieves, paigow, war, canfield)"
 ```
 
 ### 1.3 Hook 層 (共通Hook)


### PR DESCRIPTION
## Summary

Fix documentation drift found by `/doc-drift-check` (tracked in #1293). The actual lineup is **46 games** (verified via `frontend/src/i18n/locales/ja/`, `docs/manual/cui/`, and `/exec` endpoints in `TrumpCardsWeb.go`), but several docs still reflected earlier counts (43, 41, 40, 39, 44) and were missing the newer Canfield, Caribbean Stud Poker, Two Ten Jack, and War entries.

### Changes

- **CLAUDE.md** header game list — add Canfield, Caribbean Stud Poker, Two Ten Jack, War
- **docs/design/backend.md** — update counts in the section 1.2 heading/TOC, the Interactor pattern note, and the GameManager class diagram (43/41/40 → 46)
- **docs/design/frontend.md**:
  - Update Response note (39 → 46) and API Object note (44 → 46; include war/canfield)
  - Add class diagrams for the missing `CanfieldPhase`, `TwoTenJackPhase`, `CaribbeanStudPhase`, `WarPhase`
  - Extend the Klondike phase-equivalence note with `CanfieldPhase`
  - Add a clarifying note that `DurakPhase`/`PigsTailPhase` constants live locally in `DurakPage.tsx` / `PigsTailPage.tsx` (not centralized in `types/phases.ts`), and that `DaifugoPage` uses `gameEndFlag` + i18n strings instead of a numeric enum

No code files touched — docs-only sync.

Closes #1293

## Test plan

- [ ] CI `golangci-lint` / CodeQL pass (no source changes, should be clean)
- [ ] Visual diff review of `docs/design/backend.md` and `docs/design/frontend.md` mermaid blocks