### PR TITLE
feat(frontend): switch manual modal to CUI version in CLI mode

### DIFF
--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -1322,9 +1322,10 @@ classDiagram
         +string gamePath
         +react-markdown レンダリング
         +remark-gfm テーブル対応
-        +bg-gray-900 不透明背景
+        +bg-ds-surface 不透明背景
         +フォーカストラップ
         +Escape キー対応
+        +isCliModeEnabled() CUI/Web切り替え
     }
 
     class MermaidBlock {
@@ -1334,8 +1335,19 @@ classDiagram
         +エラー時フォールバック表示
     }
 
+    class cuiManualTexts {
+        +Record~string,string~ CUI版マニュアルマップ
+        +isCliModeEnabled(gamePath) boolean
+    }
+
+    class manualTexts {
+        +Record~string,string~ Web版マニュアルマップ
+    }
+
     ManualButton --> ManualModal : renders
     ManualModal --> MermaidBlock : renders mermaid code blocks
+    ManualModal --> cuiManualTexts : CLIモード判定・CUIテキスト取得
+    ManualModal --> manualTexts : Webテキスト取得
 ```
 
 ### 1.6 ページコンポーネント層

--- a/frontend/src/components/ManualModal.test.tsx
+++ b/frontend/src/components/ManualModal.test.tsx
@@ -31,6 +31,7 @@ vi.mock('../constants/cuiManualTexts', async () => {
 
 afterEach(() => {
   localStorage.clear();
+  vi.restoreAllMocks();
 });
 
 describe('ManualModal', () => {
@@ -83,7 +84,6 @@ describe('ManualModal', () => {
     render(<ManualModal open={true} onClose={vi.fn()} gamePath="/" />);
     expect(screen.getByText('BlackJack')).toBeInTheDocument();
     expect(screen.queryByText('BlackJack CUI')).not.toBeInTheDocument();
-    vi.restoreAllMocks();
   });
 
   it('renders empty content for unknown gamePath', () => {

--- a/frontend/src/components/ManualModal.test.tsx
+++ b/frontend/src/components/ManualModal.test.tsx
@@ -76,6 +76,16 @@ describe('ManualModal', () => {
     expect(screen.getByText('Poker CUI')).toBeInTheDocument();
   });
 
+  it('renders web manual when localStorage.getItem throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('localStorage unavailable');
+    });
+    render(<ManualModal open={true} onClose={vi.fn()} gamePath="/" />);
+    expect(screen.getByText('BlackJack')).toBeInTheDocument();
+    expect(screen.queryByText('BlackJack CUI')).not.toBeInTheDocument();
+    vi.restoreAllMocks();
+  });
+
   it('renders empty content for unknown gamePath', () => {
     render(<ManualModal open={true} onClose={vi.fn()} gamePath="/unknown" />);
     const dialog = screen.getByRole('dialog');

--- a/frontend/src/components/ManualModal.test.tsx
+++ b/frontend/src/components/ManualModal.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ManualModal } from './ManualModal';
 
 vi.mock('mermaid', () => ({
@@ -17,6 +17,21 @@ vi.mock('../constants/manualTexts', () => ({
     '/code': '# Code\n\n```js\nconsole.log("hello");\n```',
   },
 }));
+
+vi.mock('../constants/cuiManualTexts', async () => {
+  const actual = await vi.importActual<typeof import('../constants/cuiManualTexts')>('../constants/cuiManualTexts');
+  return {
+    ...actual,
+    cuiManualTexts: {
+      '/': '# BlackJack CUI\n\nCUI manual text',
+      '/poker': '# Poker CUI\n\nCUI poker manual',
+    },
+  };
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
 
 describe('ManualModal', () => {
   it('renders nothing when closed', () => {
@@ -39,6 +54,26 @@ describe('ManualModal', () => {
   it('renders different manual for different gamePath', () => {
     render(<ManualModal open={true} onClose={vi.fn()} gamePath="/poker" />);
     expect(screen.getByText('Poker')).toBeInTheDocument();
+  });
+
+  it('renders CUI manual when CLI mode is enabled for the game', () => {
+    localStorage.setItem('cli-mode-blackjack', 'true');
+    render(<ManualModal open={true} onClose={vi.fn()} gamePath="/" />);
+    expect(screen.getByText('BlackJack CUI')).toBeInTheDocument();
+    expect(screen.queryByText('BlackJack')).not.toBeInTheDocument();
+  });
+
+  it('renders web manual when CLI mode is disabled', () => {
+    localStorage.setItem('cli-mode-blackjack', 'false');
+    render(<ManualModal open={true} onClose={vi.fn()} gamePath="/" />);
+    expect(screen.getByText('BlackJack')).toBeInTheDocument();
+    expect(screen.queryByText('BlackJack CUI')).not.toBeInTheDocument();
+  });
+
+  it('renders CUI manual for /poker when CLI mode is enabled for poker', () => {
+    localStorage.setItem('cli-mode-poker', 'true');
+    render(<ManualModal open={true} onClose={vi.fn()} gamePath="/poker" />);
+    expect(screen.getByText('Poker CUI')).toBeInTheDocument();
   });
 
   it('renders empty content for unknown gamePath', () => {

--- a/frontend/src/components/ManualModal.tsx
+++ b/frontend/src/components/ManualModal.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import type { Components } from 'react-markdown';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { cuiManualTexts, isCliModeEnabled } from '../constants/cuiManualTexts';
 import { manualTexts } from '../constants/manualTexts';
 import { btnSecondary } from '../styles/buttonStyles';
 import { getFocusableElements } from '../utils/dom';
@@ -89,7 +90,8 @@ export function ManualModal({ open, onClose, gamePath }: ManualModalProps) {
 
   if (!open) return null;
 
-  const markdown = manualTexts[gamePath] ?? '';
+  const cliMode = isCliModeEnabled(gamePath);
+  const markdown = (cliMode ? cuiManualTexts[gamePath] : manualTexts[gamePath]) ?? '';
 
   return createPortal(
     // biome-ignore lint/a11y/noStaticElementInteractions: overlay backdrop dismisses modal on click

--- a/frontend/src/constants/cuiManualTexts.ts
+++ b/frontend/src/constants/cuiManualTexts.ts
@@ -1,0 +1,165 @@
+/**
+ * Build-time imports of game manual Markdown files (Japanese, CUI version).
+ * Keyed by game route path for direct lookup from the current URL.
+ * Used when the page has CLI mode enabled so the manual matches the terminal UI.
+ */
+import baccarat from '../../../docs/manual/cui/baccarat.md?raw';
+import blackjack from '../../../docs/manual/cui/blackjack.md?raw';
+import bridge from '../../../docs/manual/cui/bridge.md?raw';
+import canasta from '../../../docs/manual/cui/canasta.md?raw';
+import canfield from '../../../docs/manual/cui/canfield.md?raw';
+import caribbeanstud from '../../../docs/manual/cui/caribbeanstud.md?raw';
+import clocksolitaire from '../../../docs/manual/cui/clocksolitaire.md?raw';
+import crazyeights from '../../../docs/manual/cui/crazyeights.md?raw';
+import cribbage from '../../../docs/manual/cui/cribbage.md?raw';
+import daifugo from '../../../docs/manual/cui/daifugo.md?raw';
+import deuceswild from '../../../docs/manual/cui/deuceswild.md?raw';
+import doubt from '../../../docs/manual/cui/doubt.md?raw';
+import durak from '../../../docs/manual/cui/durak.md?raw';
+import euchre from '../../../docs/manual/cui/euchre.md?raw';
+import fortythieves from '../../../docs/manual/cui/fortythieves.md?raw';
+import freecell from '../../../docs/manual/cui/freecell.md?raw';
+import ginrummy from '../../../docs/manual/cui/ginrummy.md?raw';
+import gofish from '../../../docs/manual/cui/gofish.md?raw';
+import golf from '../../../docs/manual/cui/golf.md?raw';
+import hearts from '../../../docs/manual/cui/hearts.md?raw';
+import holdem from '../../../docs/manual/cui/holdem.md?raw';
+import indianpoker from '../../../docs/manual/cui/indianpoker.md?raw';
+import jokerpoker from '../../../docs/manual/cui/jokerpoker.md?raw';
+import klondike from '../../../docs/manual/cui/klondike.md?raw';
+import memory from '../../../docs/manual/cui/memory.md?raw';
+import napoleon from '../../../docs/manual/cui/napoleon.md?raw';
+import ohhell from '../../../docs/manual/cui/ohhell.md?raw';
+import oldmaid from '../../../docs/manual/cui/oldmaid.md?raw';
+import omaha from '../../../docs/manual/cui/omaha.md?raw';
+import paigow from '../../../docs/manual/cui/paigow.md?raw';
+import pigtail from '../../../docs/manual/cui/pigtail.md?raw';
+import pineapple from '../../../docs/manual/cui/pineapple.md?raw';
+import pinochle from '../../../docs/manual/cui/pinochle.md?raw';
+import poker from '../../../docs/manual/cui/poker.md?raw';
+import pyramid from '../../../docs/manual/cui/pyramid.md?raw';
+import sevencardstud from '../../../docs/manual/cui/sevencardstud.md?raw';
+import sevens from '../../../docs/manual/cui/sevens.md?raw';
+import shortdeck from '../../../docs/manual/cui/shortdeck.md?raw';
+import spades from '../../../docs/manual/cui/spades.md?raw';
+import speed from '../../../docs/manual/cui/speed.md?raw';
+import spider from '../../../docs/manual/cui/spider.md?raw';
+import threecard from '../../../docs/manual/cui/threecard.md?raw';
+import tripeaks from '../../../docs/manual/cui/tripeaks.md?raw';
+import twotenjack from '../../../docs/manual/cui/twotenjack.md?raw';
+import videopoker from '../../../docs/manual/cui/videopoker.md?raw';
+import war from '../../../docs/manual/cui/war.md?raw';
+
+/** Map from game route path to raw CUI Markdown manual text. */
+export const cuiManualTexts: Readonly<Record<string, string>> = {
+  '/': blackjack,
+  '/baccarat': baccarat,
+  '/bridge': bridge,
+  '/canasta': canasta,
+  '/canfield': canfield,
+  '/caribbeanstud': caribbeanstud,
+  '/clocksolitaire': clocksolitaire,
+  '/crazyeights': crazyeights,
+  '/cribbage': cribbage,
+  '/daifugo': daifugo,
+  '/deuceswild': deuceswild,
+  '/doubt': doubt,
+  '/durak': durak,
+  '/fortythieves': fortythieves,
+  '/euchre': euchre,
+  '/freecell': freecell,
+  '/ginrummy': ginrummy,
+  '/gofish': gofish,
+  '/golf': golf,
+  '/hearts': hearts,
+  '/holdem': holdem,
+  '/indianpoker': indianpoker,
+  '/jokerpoker': jokerpoker,
+  '/klondike': klondike,
+  '/memory': memory,
+  '/napoleon': napoleon,
+  '/ohhell': ohhell,
+  '/oldmaid': oldmaid,
+  '/omaha': omaha,
+  '/paigow': paigow,
+  '/pineapple': pineapple,
+  '/pigtail': pigtail,
+  '/pinochle': pinochle,
+  '/poker': poker,
+  '/pyramid': pyramid,
+  '/sevencardstud': sevencardstud,
+  '/sevens': sevens,
+  '/shortdeck': shortdeck,
+  '/spades': spades,
+  '/speed': speed,
+  '/spider': spider,
+  '/threecard': threecard,
+  '/tripeaks': tripeaks,
+  '/twotenjack': twotenjack,
+  '/videopoker': videopoker,
+  '/war': war,
+};
+
+/**
+ * Map from game route path to the CLI-mode localStorage key game name used by useCliMode.
+ * Kept alongside cuiManualTexts so the manual modal can decide which variant to show.
+ */
+export const gamePathToCliName: Readonly<Record<string, string>> = {
+  '/': 'blackjack',
+  '/baccarat': 'baccarat',
+  '/bridge': 'bridge',
+  '/canasta': 'canasta',
+  '/canfield': 'canfield',
+  '/caribbeanstud': 'caribbeanstud',
+  '/clocksolitaire': 'clocksolitaire',
+  '/crazyeights': 'crazyeights',
+  '/cribbage': 'cribbage',
+  '/daifugo': 'daifugo',
+  '/deuceswild': 'deuceswild',
+  '/doubt': 'doubt',
+  '/durak': 'durak',
+  '/fortythieves': 'fortythieves',
+  '/euchre': 'euchre',
+  '/freecell': 'freecell',
+  '/ginrummy': 'ginrummy',
+  '/gofish': 'gofish',
+  '/golf': 'golf',
+  '/hearts': 'hearts',
+  '/holdem': 'holdem',
+  '/indianpoker': 'indianpoker',
+  '/jokerpoker': 'jokerpoker',
+  '/klondike': 'klondike',
+  '/memory': 'memory',
+  '/napoleon': 'napoleon',
+  '/ohhell': 'ohhell',
+  '/oldmaid': 'oldmaid',
+  '/omaha': 'omaha',
+  '/paigow': 'paigow',
+  '/pineapple': 'pineapple',
+  '/pigtail': 'pigtail',
+  '/pinochle': 'pinochle',
+  '/poker': 'poker',
+  '/pyramid': 'pyramid',
+  '/sevencardstud': 'sevencardstud',
+  '/sevens': 'sevens',
+  '/shortdeck': 'shortdeck',
+  '/spades': 'spades',
+  '/speed': 'speed',
+  '/spider': 'spider',
+  '/threecard': 'threecard',
+  '/tripeaks': 'tripeaks',
+  '/twotenjack': 'twotenjack',
+  '/videopoker': 'videopoker',
+  '/war': 'war',
+};
+
+/** Returns true when CLI mode is enabled for the game at the given path. */
+export function isCliModeEnabled(gamePath: string): boolean {
+  const gameName = gamePathToCliName[gamePath];
+  if (!gameName) return false;
+  try {
+    return localStorage.getItem(`cli-mode-${gameName}`) === 'true';
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/constants/cuiManualTexts.ts
+++ b/frontend/src/constants/cuiManualTexts.ts
@@ -100,63 +100,9 @@ export const cuiManualTexts: Readonly<Record<string, string>> = {
   '/war': war,
 };
 
-/**
- * Map from game route path to the CLI-mode localStorage key game name used by useCliMode.
- * Kept alongside cuiManualTexts so the manual modal can decide which variant to show.
- */
-export const gamePathToCliName: Readonly<Record<string, string>> = {
-  '/': 'blackjack',
-  '/baccarat': 'baccarat',
-  '/bridge': 'bridge',
-  '/canasta': 'canasta',
-  '/canfield': 'canfield',
-  '/caribbeanstud': 'caribbeanstud',
-  '/clocksolitaire': 'clocksolitaire',
-  '/crazyeights': 'crazyeights',
-  '/cribbage': 'cribbage',
-  '/daifugo': 'daifugo',
-  '/deuceswild': 'deuceswild',
-  '/doubt': 'doubt',
-  '/durak': 'durak',
-  '/fortythieves': 'fortythieves',
-  '/euchre': 'euchre',
-  '/freecell': 'freecell',
-  '/ginrummy': 'ginrummy',
-  '/gofish': 'gofish',
-  '/golf': 'golf',
-  '/hearts': 'hearts',
-  '/holdem': 'holdem',
-  '/indianpoker': 'indianpoker',
-  '/jokerpoker': 'jokerpoker',
-  '/klondike': 'klondike',
-  '/memory': 'memory',
-  '/napoleon': 'napoleon',
-  '/ohhell': 'ohhell',
-  '/oldmaid': 'oldmaid',
-  '/omaha': 'omaha',
-  '/paigow': 'paigow',
-  '/pineapple': 'pineapple',
-  '/pigtail': 'pigtail',
-  '/pinochle': 'pinochle',
-  '/poker': 'poker',
-  '/pyramid': 'pyramid',
-  '/sevencardstud': 'sevencardstud',
-  '/sevens': 'sevens',
-  '/shortdeck': 'shortdeck',
-  '/spades': 'spades',
-  '/speed': 'speed',
-  '/spider': 'spider',
-  '/threecard': 'threecard',
-  '/tripeaks': 'tripeaks',
-  '/twotenjack': 'twotenjack',
-  '/videopoker': 'videopoker',
-  '/war': 'war',
-};
-
 /** Returns true when CLI mode is enabled for the game at the given path. */
 export function isCliModeEnabled(gamePath: string): boolean {
-  const gameName = gamePathToCliName[gamePath];
-  if (!gameName) return false;
+  const gameName = gamePath === '/' ? 'blackjack' : gamePath.slice(1);
   try {
     return localStorage.getItem(`cli-mode-${gameName}`) === 'true';
   } catch {


### PR DESCRIPTION
## Summary

- CLI モード（`cli-mode-<game>` が localStorage で `true`）になっているゲームで、マニュアルモーダルを開いた際に Web 版マニュアルではなく CUI 版マニュアル（`docs/manual/cui/*.md`）を表示するようにした
- CLI モード時に端末で使っているコマンドやキー入力と、画面上のヘルプが一致するようにするのが目的
- `frontend/src/constants/cuiManualTexts.ts` を新規追加し、既存の `manualTexts.ts` と同じキーで CUI マニュアルをバンドル
- `ManualModal` は `isCliModeEnabled(gamePath)` の結果で CUI / Web を切り替えるだけなので、40+ ページ側を触らずに済む

### 変更ファイル

- `frontend/src/constants/cuiManualTexts.ts`（新規）
- `frontend/src/components/ManualModal.tsx`
- `frontend/src/components/ManualModal.test.tsx`

## Test plan

- [x] `bun run test -- --run ManualModal` が全 20 件 passed（CLI モード ON/OFF 切り替えの新テストを含む）
- [x] `bun run build` passed
- [x] `bun run check` は対象ファイルで警告なし（pre-existing warning のみ）
- [ ] ブラウザで任意のゲーム（例: `/canfield`）を開き、CLI モードを ON → マニュアルを開くと CUI 版が、OFF に戻すと Web 版が表示されることを目視確認