### PR TITLE
feat(ui/ux): a11y improvements — round score announcements, CPU toast dismiss, safe-area

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Trump Card Games</title>
     <link rel="apple-touch-icon" href="/images/favicon.ico" />
     <link rel="shortcut icon" href="/images/favicon.ico" />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -109,7 +109,7 @@ export default function App() {
   return (
     <HashRouter>
       <ErrorBoundary>
-        <div className="flex flex-col h-full lg:flex-row">
+        <div className="flex flex-col h-full pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pl-[env(safe-area-inset-left)] lg:flex-row">
           <SkipNavLink targetId="main-content" label={t('nav.skipToContent')} />
           <DesktopSidebar />
           <div className="flex flex-col flex-1 min-w-0">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -109,7 +109,7 @@ export default function App() {
   return (
     <HashRouter>
       <ErrorBoundary>
-        <div className="flex flex-col h-full pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pl-[env(safe-area-inset-left)] lg:flex-row">
+        <div className="flex flex-col h-full lg:flex-row">
           <SkipNavLink targetId="main-content" label={t('nav.skipToContent')} />
           <DesktopSidebar />
           <div className="flex flex-col flex-1 min-w-0">

--- a/frontend/src/components/CpuActionToast.test.tsx
+++ b/frontend/src/components/CpuActionToast.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CpuActionToast } from './CpuActionToast';
 
@@ -8,10 +8,16 @@ vi.mock('react-i18next', async () => ({
   useTranslation: () => ({ t: mockT }),
 }));
 
+const mockReduced = vi.fn(() => false);
+vi.mock('../hooks/useReducedMotion', () => ({
+  useReducedMotion: () => mockReduced(),
+}));
+
 describe('CpuActionToast', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     mockT.mockClear();
+    mockReduced.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -35,15 +41,19 @@ describe('CpuActionToast', () => {
     expect(mockT).toHaveBeenCalledWith('player.player', { idx: 1 });
   });
 
-  it('auto-dismisses after 3 seconds', () => {
+  it('auto-dismisses after 5 seconds', () => {
     const actions = [{ playerIdx: 1, action: 2, amount: 0 }];
     render(<CpuActionToast actions={actions} />);
     expect(screen.getByRole('status')).toBeInTheDocument();
 
     act(() => {
-      vi.advanceTimersByTime(3000);
+      vi.advanceTimersByTime(4999);
     });
+    expect(screen.getByRole('status')).toBeInTheDocument();
 
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
     expect(screen.queryByRole('status')).toBeNull();
   });
 
@@ -52,9 +62,8 @@ describe('CpuActionToast', () => {
     const { rerender } = render(<CpuActionToast actions={actions1} />);
     expect(screen.getByRole('status')).toBeInTheDocument();
 
-    // Advance 2s, then new actions arrive
     act(() => {
-      vi.advanceTimersByTime(2000);
+      vi.advanceTimersByTime(3000);
     });
 
     const actions2 = [
@@ -63,15 +72,15 @@ describe('CpuActionToast', () => {
     ];
     rerender(<CpuActionToast actions={actions2} />);
 
-    // After another 2s (total 4s), toast should still be visible because timer reset
+    // 4 more seconds (7s total) — still visible because timer reset
     act(() => {
-      vi.advanceTimersByTime(2000);
+      vi.advanceTimersByTime(4000);
     });
     expect(screen.getByRole('status')).toBeInTheDocument();
 
-    // After 3s from last update, toast disappears
+    // Past the 5s window since last update
     act(() => {
-      vi.advanceTimersByTime(1000);
+      vi.advanceTimersByTime(1001);
     });
     expect(screen.queryByRole('status')).toBeNull();
   });
@@ -86,5 +95,35 @@ describe('CpuActionToast', () => {
     const actions = [{ playerIdx: 1, action: 2, amount: 0 }];
     render(<CpuActionToast actions={actions} />);
     expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('dismisses when the close button is clicked', () => {
+    const actions = [{ playerIdx: 1, action: 2, amount: 0 }];
+    render(<CpuActionToast actions={actions} />);
+    fireEvent.click(screen.getByRole('button', { name: 'button.dismiss' }));
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('dismisses when Escape is pressed', () => {
+    const actions = [{ playerIdx: 1, action: 2, amount: 0 }];
+    render(<CpuActionToast actions={actions} />);
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Escape' });
+    });
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('omits the slide-down animation when prefers-reduced-motion is set', () => {
+    mockReduced.mockReturnValue(true);
+    const actions = [{ playerIdx: 1, action: 2, amount: 0 }];
+    render(<CpuActionToast actions={actions} />);
+    expect(screen.getByRole('status').className).not.toContain('slideDown');
+  });
+
+  it('applies the slide-down animation when reduced motion is off', () => {
+    mockReduced.mockReturnValue(false);
+    const actions = [{ playerIdx: 1, action: 2, amount: 0 }];
+    render(<CpuActionToast actions={actions} />);
+    expect(screen.getByRole('status').className).toContain('slideDown');
   });
 });

--- a/frontend/src/components/CpuActionToast.tsx
+++ b/frontend/src/components/CpuActionToast.tsx
@@ -1,16 +1,22 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useReducedMotion } from '../hooks/useReducedMotion';
 import { bettingActionName } from '../styles/gameConstants';
 
 interface CpuActionToastProps {
   actions: { playerIdx: number; action: number; amount: number }[] | undefined;
 }
 
-const DISMISS_MS = 3000;
+const DISMISS_MS = 5000;
 
-/** Toast notification for CPU betting actions. Auto-dismisses after 3 seconds. */
+/**
+ * Toast notification for CPU betting actions. Auto-dismisses after 5 seconds,
+ * but can be dismissed early via the close button or the Escape key. Respects
+ * the user's `prefers-reduced-motion` setting.
+ */
 export function CpuActionToast({ actions }: CpuActionToastProps) {
   const { t } = useTranslation('common');
+  const reduced = useReducedMotion();
   const [visible, setVisible] = useState(false);
   const prevLenRef = useRef(0);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -27,13 +33,24 @@ export function CpuActionToast({ actions }: CpuActionToastProps) {
     return () => clearTimeout(timerRef.current);
   }, [len]);
 
+  useEffect(() => {
+    if (!visible) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setVisible(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [visible]);
+
   if (!visible || !actions || actions.length === 0) return null;
+
+  const animation = reduced ? '' : 'animate-[slideDown_0.3s_ease-out] ';
 
   return (
     <div
       role="status"
       aria-live="polite"
-      className="absolute top-0 left-0 right-0 z-20 mx-4 mt-1 animate-[slideDown_0.3s_ease-out] rounded bg-black/70 px-3 py-1.5 text-white text-xs shadow-lg"
+      className={`absolute top-0 left-0 right-0 z-20 mx-4 mt-1 ${animation}rounded bg-black/70 px-3 py-1.5 pr-8 text-white text-xs shadow-lg`}
     >
       {actions.map((a, i) => (
         <div key={`${i}-${a.playerIdx}-${a.action}`}>
@@ -41,6 +58,14 @@ export function CpuActionToast({ actions }: CpuActionToastProps) {
           {a.amount > 0 && ` (${a.amount})`}
         </div>
       ))}
+      <button
+        type="button"
+        onClick={() => setVisible(false)}
+        aria-label={t('button.dismiss')}
+        className="absolute top-0 right-1 px-2 py-0.5 text-white/70 hover:text-white focus:outline-none focus:ring-2 focus:ring-ds-accent"
+      >
+        ×
+      </button>
     </div>
   );
 }

--- a/frontend/src/components/DesktopSidebar.tsx
+++ b/frontend/src/components/DesktopSidebar.tsx
@@ -41,7 +41,7 @@ export function DesktopSidebar() {
 
   return (
     <aside
-      className="hidden lg:flex lg:flex-col lg:w-60 lg:shrink-0 glass-panel--dark overflow-y-auto"
+      className="hidden lg:flex lg:flex-col lg:w-60 lg:shrink-0 glass-panel--dark overflow-y-auto pt-[env(safe-area-inset-top)] pl-[env(safe-area-inset-left)]"
       aria-label={t('nav.sidebar', { defaultValue: 'Game navigation' })}
     >
       {/* Site name */}

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -163,7 +163,7 @@ export function NavBar() {
   }, [searchTerm, searchableRoutes]);
 
   return (
-    <div className="glass-panel--dark lg:hidden relative z-30">
+    <div className="glass-panel--dark lg:hidden relative z-30 pt-[env(safe-area-inset-top)] pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)]">
       <div className="flex items-center justify-between sm:hidden my-2 mx-2.5">
         <Link
           to="/"

--- a/frontend/src/components/RoundScoreAnnouncement.test.tsx
+++ b/frontend/src/components/RoundScoreAnnouncement.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { RoundScoreAnnouncement } from './RoundScoreAnnouncement';
+
+describe('RoundScoreAnnouncement', () => {
+  const entries = [
+    { name: 'You', roundScore: 13, cumulativeScore: 26 },
+    { name: 'CPU 1', roundScore: 0, cumulativeScore: 7 },
+  ];
+
+  it('renders an sr-only live region', () => {
+    render(<RoundScoreAnnouncement active={false} entries={entries} />);
+    const status = screen.getByRole('status');
+    expect(status).toHaveClass('sr-only');
+    expect(status).toHaveAttribute('aria-live', 'polite');
+    expect(status).toHaveAttribute('aria-atomic', 'true');
+  });
+
+  it('is empty when inactive', () => {
+    render(<RoundScoreAnnouncement active={false} entries={entries} />);
+    expect(screen.getByRole('status').textContent).toBe('');
+  });
+
+  it('announces round deltas when active', () => {
+    render(<RoundScoreAnnouncement active={true} entries={entries} />);
+    const text = screen.getByRole('status').textContent ?? '';
+    expect(text.length).toBeGreaterThan(0);
+    expect(text).toContain('You');
+    expect(text).toContain('13');
+    expect(text).toContain('26');
+    expect(text).toContain('CPU 1');
+  });
+
+  it('handles an empty entries list', () => {
+    render(<RoundScoreAnnouncement active={true} entries={[]} />);
+    expect(screen.getByRole('status').textContent).not.toBe('');
+  });
+});

--- a/frontend/src/components/RoundScoreAnnouncement.tsx
+++ b/frontend/src/components/RoundScoreAnnouncement.tsx
@@ -1,0 +1,36 @@
+import { useTranslation } from 'react-i18next';
+
+/** One player's round summary entry. */
+export interface RoundScoreEntry {
+  name: string;
+  roundScore: number;
+  cumulativeScore: number;
+}
+
+interface RoundScoreAnnouncementProps {
+  active: boolean;
+  entries: RoundScoreEntry[];
+}
+
+/**
+ * Screen-reader-only live region that announces round score deltas when a
+ * round ends. The visible score table remains unchanged; this component is
+ * the announcement channel for assistive tech.
+ */
+export function RoundScoreAnnouncement({ active, entries }: RoundScoreAnnouncementProps) {
+  const { t } = useTranslation('common');
+  const details = entries
+    .map((e) =>
+      t('roundScoreAnnouncement.entry', {
+        name: e.name,
+        round: e.roundScore,
+        total: e.cumulativeScore,
+      }),
+    )
+    .join(', ');
+  return (
+    <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+      {active ? t('roundScoreAnnouncement.message', { details }) : ''}
+    </div>
+  );
+}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -110,7 +110,12 @@
     "confirmResetMessage": "Are you sure you want to reset the game?",
     "confirm": "Confirm",
     "hint": "Hint",
-    "retry": "Retry"
+    "retry": "Retry",
+    "dismiss": "Dismiss"
+  },
+  "roundScoreAnnouncement": {
+    "message": "Round complete. {{details}}",
+    "entry": "{{name}}: +{{round}} (total {{total}})"
   },
   "stalemateEscape": "Escape (undo {{count}} moves)",
   "status": {

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -110,7 +110,12 @@
     "confirmResetMessage": "本当にゲームをリセットしますか？",
     "confirm": "確認",
     "hint": "ヒント",
-    "retry": "再試行"
+    "retry": "再試行",
+    "dismiss": "閉じる"
+  },
+  "roundScoreAnnouncement": {
+    "message": "ラウンド終了。{{details}}",
+    "entry": "{{name}}: +{{round}} (合計 {{total}})"
   },
   "stalemateEscape": "脱出する ({{count}}手戻る)",
   "status": {

--- a/frontend/src/pages/HeartsPage.tsx
+++ b/frontend/src/pages/HeartsPage.tsx
@@ -11,6 +11,7 @@ import { GamePageShell } from '../components/GamePageShell';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { PlayerHandSection } from '../components/PlayerHandSection';
+import { RoundScoreAnnouncement } from '../components/RoundScoreAnnouncement';
 import { HeartsSkeleton } from '../components/skeleton/HeartsSkeleton';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -325,6 +326,14 @@ function HeartsPageContent() {
                     </tbody>
                   </table>
                 </div>
+                <RoundScoreAnnouncement
+                  active={isRoundEnd || isGameEnd}
+                  entries={state.players.map((p) => ({
+                    name: playerName(p.id, p.isHuman),
+                    roundScore: p.roundScore,
+                    cumulativeScore: p.cumulativeScore,
+                  }))}
+                />
               </div>
             </div>
 

--- a/frontend/src/pages/NapoleonPage.tsx
+++ b/frontend/src/pages/NapoleonPage.tsx
@@ -15,6 +15,7 @@ import { MobileHandGrid } from '../components/MobileHandGrid';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
+import { RoundScoreAnnouncement } from '../components/RoundScoreAnnouncement';
 import { ScrollFadeHint } from '../components/ScrollFadeHint';
 import { NapoleonSkeleton } from '../components/skeleton/NapoleonSkeleton';
 import { TutorialButton } from '../components/tutorial/TutorialButton';
@@ -428,6 +429,14 @@ function NapoleonPageContent() {
                   </div>
                   {isMobile && <ScrollFadeHint />}
                 </div>
+                <RoundScoreAnnouncement
+                  active={isRoundEnd || isGameEnd}
+                  entries={state.players.map((p) => ({
+                    name: playerName(p.id, p.isHuman),
+                    roundScore: p.roundScore,
+                    cumulativeScore: p.cumulativeScore,
+                  }))}
+                />
               </div>
             </div>
 

--- a/frontend/src/pages/OhHellPage.tsx
+++ b/frontend/src/pages/OhHellPage.tsx
@@ -15,6 +15,7 @@ import { MobileHandGrid } from '../components/MobileHandGrid';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
+import { RoundScoreAnnouncement } from '../components/RoundScoreAnnouncement';
 import { ScrollFadeHint } from '../components/ScrollFadeHint';
 import { OhHellSkeleton } from '../components/skeleton/OhHellSkeleton';
 import { TutorialButton } from '../components/tutorial/TutorialButton';
@@ -367,6 +368,14 @@ function OhHellPageContent() {
                   </div>
                   {isMobile && <ScrollFadeHint />}
                 </div>
+                <RoundScoreAnnouncement
+                  active={isRoundEnd || isGameEnd}
+                  entries={state.players.map((p) => ({
+                    name: playerName(p.id, p.isHuman),
+                    roundScore: p.roundScore,
+                    cumulativeScore: p.cumulativeScore,
+                  }))}
+                />
               </div>
             </div>
 

--- a/frontend/src/pages/SpadesPage.tsx
+++ b/frontend/src/pages/SpadesPage.tsx
@@ -11,6 +11,7 @@ import { GamePageShell } from '../components/GamePageShell';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { PlayerHandSection } from '../components/PlayerHandSection';
+import { RoundScoreAnnouncement } from '../components/RoundScoreAnnouncement';
 import { ScrollFadeHint } from '../components/ScrollFadeHint';
 import { SpadesSkeleton } from '../components/skeleton/SpadesSkeleton';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
@@ -319,6 +320,14 @@ function SpadesPageContent() {
                   </div>
                   {isMobile && <ScrollFadeHint />}
                 </div>
+                <RoundScoreAnnouncement
+                  active={isRoundEnd || isGameEnd}
+                  entries={state.players.map((p) => ({
+                    name: playerName(p.id, p.isHuman),
+                    roundScore: p.roundScore,
+                    cumulativeScore: p.cumulativeScore,
+                  }))}
+                />
               </div>
             </div>
 

--- a/frontend/src/pages/TwoTenJackPage.tsx
+++ b/frontend/src/pages/TwoTenJackPage.tsx
@@ -11,6 +11,7 @@ import { GamePageShell } from '../components/GamePageShell';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { PlayerHandSection } from '../components/PlayerHandSection';
+import { RoundScoreAnnouncement } from '../components/RoundScoreAnnouncement';
 import { ScrollFadeHint } from '../components/ScrollFadeHint';
 import { TwoTenJackSkeleton } from '../components/skeleton/TwoTenJackSkeleton';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
@@ -312,6 +313,13 @@ function TwoTenJackPageContent() {
                   </div>
                   {isMobile && <ScrollFadeHint />}
                 </div>
+                <RoundScoreAnnouncement
+                  active={isRoundEnd || isGameEnd}
+                  entries={[
+                    { name: t('team0'), roundScore: team0Captured, cumulativeScore: team0Total },
+                    { name: t('team1'), roundScore: team1Captured, cumulativeScore: team1Total },
+                  ]}
+                />
               </div>
             </div>
 


### PR DESCRIPTION
## Summary

- **#1305** — Add an sr-only `RoundScoreAnnouncement` live region (`role="status"`, `aria-live="polite"`, `aria-atomic="true"`) to the trick-taking pages. When a round ends, screen readers hear the per-player (or per-team) round delta and cumulative total without the visible score table itself becoming a live region. Applied to Hearts, Spades, Napoleon, OhHell, and TwoTenJack. Euchre and Bridge use team-only score shapes and were left out of this PR to keep scope focused — they can follow with their own PRs.
- **#1306** — `CpuActionToast` now:
  - respects `prefers-reduced-motion` (drops the `slideDown` animation when set), matching the existing `useReducedMotion` pattern used by `WinCelebration` and `AnimatedCard`;
  - extends auto-dismiss from 3s → 5s so slower readers / screen-reader users can finish reading;
  - adds a close (×) button with an accessible label (`button.dismiss`) and an Escape-key shortcut so the toast can be dismissed early.
- **#1307** — Add `viewport-fit=cover` to the viewport meta tag and apply `env(safe-area-inset-*)` padding at the App root (`pt`/`pl`/`pr`) so iPhone notch / Dynamic Island safe areas are respected. `GameFooter`'s existing `safe-area-inset-bottom` handling is preserved.

## Test plan

- [x] `bun run test` — all 4975 frontend tests pass (including new `RoundScoreAnnouncement` tests and updated `CpuActionToast` tests covering Escape/click dismiss, 5s timing, reduced-motion branches)
- [x] `bun run check` — biome clean
- [x] `bun run build` — production build succeeds
- [ ] Manual: verify toast close button and Escape key work on a long poker round
- [ ] Manual: enable `prefers-reduced-motion` and confirm the toast no longer slides
- [ ] Manual: inspect a Hearts round-end with VoiceOver / NVDA and confirm the announcement is heard
- [ ] Manual: load on an iPhone-like viewport with a simulated notch and confirm NavBar is not clipped

Closes #1305
Closes #1306
Closes #1307