### PR TITLE
refactor: replace switch/struct boilerplate with registry maps (#1308-#1311)

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -92,13 +92,12 @@ func run() int {
 	commands := buildGameCommands()
 	commands["games"] = func() int {
 		var short bool
-		fs, code, ok := parseSubFlags("games", func(f *flag.FlagSet) {
+		_, code, ok := parseSubFlags("games", func(f *flag.FlagSet) {
 			f.BoolVar(&short, "short", false, "Print game names only")
 		})
 		if !ok {
 			return code
 		}
-		_ = fs
 		// Build reverse alias map: canonical name -> sorted list of aliases.
 		reverseAliases := make(map[string][]string)
 		for alias, canonical := range ui.GameAliases {

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -91,17 +91,14 @@ func run() int {
 	// Build game commands from the registry (single source of truth).
 	commands := buildGameCommands()
 	commands["games"] = func() int {
-		gamesFlags := flag.NewFlagSet("games", flag.ContinueOnError)
-		short := gamesFlags.Bool("short", false, "Print game names only")
-		if err := gamesFlags.Parse(flag.Args()[1:]); err != nil {
-			if errors.Is(err, flag.ErrHelp) {
-				return 0
-			}
-			return 1
+		var short bool
+		fs, code, ok := parseSubFlags("games", func(f *flag.FlagSet) {
+			f.BoolVar(&short, "short", false, "Print game names only")
+		})
+		if !ok {
+			return code
 		}
-		if gamesFlags.NArg() > 0 {
-			fmt.Fprintln(os.Stderr, i18n.Tf("cliExtraArgsWarning", "args", strings.Join(gamesFlags.Args(), " ")))
-		}
+		_ = fs
 		// Build reverse alias map: canonical name -> sorted list of aliases.
 		reverseAliases := make(map[string][]string)
 		for alias, canonical := range ui.GameAliases {
@@ -112,7 +109,7 @@ func run() int {
 		}
 		descs := ui.GameDescriptions()
 		for _, name := range ui.GameNames() {
-			if *short {
+			if short {
 				fmt.Println(name)
 			} else {
 				line := fmt.Sprintf("  %-16s %s", name, descs[name])
@@ -131,41 +128,36 @@ func run() int {
 		return runHelpCommand(flag.Args()[1:], helpText, os.Stdout, os.Stderr)
 	}
 	commands["update"] = func() int {
-		updateFlags := flag.NewFlagSet("update", flag.ContinueOnError)
-		yes := updateFlags.Bool("yes", false, "Skip confirmation prompt")
-		updateFlags.BoolVar(yes, "y", false, "Skip confirmation prompt (shorthand)")
-		if err := updateFlags.Parse(flag.Args()[1:]); err != nil {
-			if errors.Is(err, flag.ErrHelp) {
-				return 0
-			}
-			return 1
+		var yes bool
+		_, code, ok := parseSubFlags("update", func(f *flag.FlagSet) {
+			f.BoolVar(&yes, "yes", false, "Skip confirmation prompt")
+			f.BoolVar(&yes, "y", false, "Skip confirmation prompt (shorthand)")
+		})
+		if !ok {
+			return code
 		}
 		updater := update.NewUpdater(version, os.Stdin, os.Stderr, os.Stderr)
-		updater.SetAutoConfirm(*yes)
+		updater.SetAutoConfirm(yes)
 		if err := updater.Exec(); err != nil {
 			return 1
 		}
 		return 0
 	}
 	commands["web"] = func() int {
-		webFlags := flag.NewFlagSet("web", flag.ContinueOnError)
-		port := webFlags.Int("port", 0, "Port number for the web server (default: 8080)")
-		webFlags.IntVar(port, "p", 0, "Port number for the web server (shorthand)")
-		if err := webFlags.Parse(flag.Args()[1:]); err != nil {
-			if errors.Is(err, flag.ErrHelp) {
-				return 0
-			}
-			return 1
+		var port int
+		_, code, ok := parseSubFlags("web", func(f *flag.FlagSet) {
+			f.IntVar(&port, "port", 0, "Port number for the web server (default: 8080)")
+			f.IntVar(&port, "p", 0, "Port number for the web server (shorthand)")
+		})
+		if !ok {
+			return code
 		}
-		if webFlags.NArg() > 0 {
-			fmt.Fprintln(os.Stderr, i18n.Tf("cliExtraArgsWarning", "args", strings.Join(webFlags.Args(), " ")))
-		}
-		if *port != 0 {
-			if *port < 1 || *port > 65535 {
-				fmt.Fprintln(os.Stderr, i18n.Tf("cliInvalidPort", "port", strconv.Itoa(*port)))
+		if port != 0 {
+			if port < 1 || port > 65535 {
+				fmt.Fprintln(os.Stderr, i18n.Tf("cliInvalidPort", "port", strconv.Itoa(port)))
 				return 1
 			}
-			_ = os.Setenv("PORT", strconv.Itoa(*port))
+			_ = os.Setenv("PORT", strconv.Itoa(port))
 		}
 		infrastructure.InitLogger()
 		w := web.NewTrumpCardsWeb()
@@ -180,6 +172,7 @@ func run() int {
 	}
 
 	// Commands that parse their own sub-flags; skip the extra-args warning for these.
+	// parseSubFlags-based commands handle extra-args warnings internally.
 	subFlagCommands := map[string]bool{"web": true, "completion": true, "games": true, "update": true, "help": true}
 
 	arg := strings.ToLower(flag.Arg(0))
@@ -252,6 +245,24 @@ func runHelpCommand(args []string, helpText string, stdout, stderr io.Writer) in
 		_, _ = fmt.Fprintf(stderr, "  %s\n", i18n.Tf("didYouMean", "name", suggestion))
 	}
 	return 1
+}
+
+// parseSubFlags creates a FlagSet, applies setup, parses subcommand args, and
+// warns about extra positional arguments. Returns (fs, exitCode, ok). If ok is
+// false, the caller should return exitCode immediately.
+func parseSubFlags(name string, setup func(*flag.FlagSet)) (*flag.FlagSet, int, bool) {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	setup(fs)
+	if err := fs.Parse(flag.Args()[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil, 0, false
+		}
+		return nil, 1, false
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(os.Stderr, i18n.Tf("cliExtraArgsWarning", "args", strings.Join(fs.Args(), " ")))
+	}
+	return fs, 0, true
 }
 
 func mapKeys(m map[string]func() int) []string {

--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -76,48 +76,55 @@ import { getTwoTenJackHint } from '../utils/hints/twotenjackHint';
 import { getVideoPokerHint } from '../utils/hints/videopokerHint';
 import { useLocalStorageToggle } from './useLocalStorageToggle';
 
-/** Supported game names for the hint system. */
-type HintGameName =
-  | 'baccarat'
-  | 'blackjack'
-  | 'poker'
-  | 'hearts'
-  | 'spades'
-  | 'holdem'
-  | 'omaha'
-  | 'shortdeck'
-  | 'pineapple'
-  | 'videopoker'
-  | 'deuceswild'
-  | 'jokerpoker'
-  | 'indianpoker'
-  | 'threecard'
-  | 'euchre'
-  | 'napoleon'
-  | 'ohhell'
-  | 'oldmaid'
-  | 'doubt'
-  | 'daifugo'
-  | 'sevens'
-  | 'crazyeights'
-  | 'speed'
-  | 'ginrummy'
-  | 'cribbage'
-  | 'klondike'
-  | 'freecell'
-  | 'spider'
-  | 'pyramid'
-  | 'tripeaks'
-  | 'memory'
-  | 'sevencardstud'
-  | 'fortythieves'
-  | 'paigow'
-  | 'gofish'
-  | 'caribbeanstud'
-  | 'durak'
-  | 'canasta'
-  | 'pinochle'
-  | 'twotenjack';
+/** Hint function that takes game state and returns a hint result or null. */
+type HintFn = (state: unknown) => HintResult | null;
+
+/** Registry mapping game names to their hint functions. */
+const hintFactories = {
+  baccarat: (s) => getBaccaratHint(s as BaccaratResponse),
+  blackjack: (s) => getBlackjackHint(s as BlackJackResponse),
+  poker: (s) => getPokerHint(s as PokerResponse),
+  hearts: (s) => getHeartsHint(s as HeartsResponse),
+  spades: (s) => getSpadesHint(s as SpadesResponse),
+  holdem: (s) => getHoldemHint(s as HoldemResponse),
+  omaha: (s) => getOmahaHint(s as OmahaResponse),
+  shortdeck: (s) => getShortDeckHint(s as ShortDeckResponse),
+  pineapple: (s) => getPineappleHint(s as PineappleResponse),
+  videopoker: (s) => getVideoPokerHint(s as VideoPokerResponse),
+  deuceswild: (s) => getDeucesWildHint(s as VideoPokerResponse),
+  jokerpoker: (s) => getJokerPokerHint(s as VideoPokerResponse),
+  indianpoker: (s) => getIndianPokerHint(s as IndianPokerResponse),
+  threecard: (s) => getThreeCardHint(s as ThreeCardResponse),
+  euchre: (s) => getEuchreHint(s as EuchreResponse),
+  napoleon: (s) => getNapoleonHint(s as NapoleonResponse),
+  ohhell: (s) => getOhHellHint(s as OhHellResponse),
+  oldmaid: (s) => getOldMaidHint(s as OldMaidResponse),
+  doubt: (s) => getDoubtHint(s as DoubtResponse),
+  daifugo: (s) => getDaifugoHint(s as DaifugoResponse),
+  sevens: (s) => getSevensHint(s as SevensResponse),
+  crazyeights: (s) => getCrazyEightsHint(s as CrazyEightsResponse),
+  speed: (s) => getSpeedHint(s as SpeedResponse),
+  klondike: (s) => getKlondikeHint(s as KlondikeResponse),
+  freecell: (s) => getFreeCellHint(s as FreeCellResponse),
+  spider: (s) => getSpiderHint(s as SpiderResponse),
+  pyramid: (s) => getPyramidHint(s as PyramidResponse),
+  tripeaks: (s) => getTriPeaksHint(s as TriPeaksResponse),
+  memory: (s) => getMemoryHint(s as MemoryResponse),
+  ginrummy: (s) => getGinRummyHint(s as GinRummyResponse),
+  cribbage: (s) => getCribbageHint(s as CribbageResponse),
+  gofish: (s) => getGoFishHint(s as GoFishResponse),
+  caribbeanstud: (s) => getCaribbeanStudHint(s as CaribbeanStudResponse),
+  durak: (s) => getDurakHint(s as DurakResponse),
+  canasta: (s) => getCanastaHint(s as CanastaResponse),
+  pinochle: (s) => getPinochleHint(s as PinochleResponse),
+  twotenjack: (s) => getTwoTenJackHint(s as TwoTenJackResponse),
+  sevencardstud: () => null,
+  fortythieves: () => null,
+  paigow: () => null,
+} satisfies Record<string, HintFn>;
+
+/** Supported game names for the hint system, derived from the registry. */
+export type HintGameName = keyof typeof hintFactories;
 
 /** Return type of the useGameHint hook. */
 export interface UseGameHintReturn {
@@ -135,84 +142,7 @@ export function useGameHint(gameName: HintGameName, state: unknown): UseGameHint
 
   const hint = useMemo(() => {
     if (!hintEnabled || !state) return null;
-    switch (gameName) {
-      case 'baccarat':
-        return getBaccaratHint(state as BaccaratResponse);
-      case 'blackjack':
-        return getBlackjackHint(state as BlackJackResponse);
-      case 'poker':
-        return getPokerHint(state as PokerResponse);
-      case 'hearts':
-        return getHeartsHint(state as HeartsResponse);
-      case 'spades':
-        return getSpadesHint(state as SpadesResponse);
-      case 'holdem':
-        return getHoldemHint(state as HoldemResponse);
-      case 'omaha':
-        return getOmahaHint(state as OmahaResponse);
-      case 'shortdeck':
-        return getShortDeckHint(state as ShortDeckResponse);
-      case 'pineapple':
-        return getPineappleHint(state as PineappleResponse);
-      case 'videopoker':
-        return getVideoPokerHint(state as VideoPokerResponse);
-      case 'deuceswild':
-        return getDeucesWildHint(state as VideoPokerResponse);
-      case 'jokerpoker':
-        return getJokerPokerHint(state as VideoPokerResponse);
-      case 'indianpoker':
-        return getIndianPokerHint(state as IndianPokerResponse);
-      case 'threecard':
-        return getThreeCardHint(state as ThreeCardResponse);
-      case 'euchre':
-        return getEuchreHint(state as EuchreResponse);
-      case 'napoleon':
-        return getNapoleonHint(state as NapoleonResponse);
-      case 'ohhell':
-        return getOhHellHint(state as OhHellResponse);
-      case 'oldmaid':
-        return getOldMaidHint(state as OldMaidResponse);
-      case 'doubt':
-        return getDoubtHint(state as DoubtResponse);
-      case 'daifugo':
-        return getDaifugoHint(state as DaifugoResponse);
-      case 'sevens':
-        return getSevensHint(state as SevensResponse);
-      case 'crazyeights':
-        return getCrazyEightsHint(state as CrazyEightsResponse);
-      case 'speed':
-        return getSpeedHint(state as SpeedResponse);
-      case 'klondike':
-        return getKlondikeHint(state as KlondikeResponse);
-      case 'freecell':
-        return getFreeCellHint(state as FreeCellResponse);
-      case 'spider':
-        return getSpiderHint(state as SpiderResponse);
-      case 'pyramid':
-        return getPyramidHint(state as PyramidResponse);
-      case 'tripeaks':
-        return getTriPeaksHint(state as TriPeaksResponse);
-      case 'memory':
-        return getMemoryHint(state as MemoryResponse);
-      case 'ginrummy':
-        return getGinRummyHint(state as GinRummyResponse);
-      case 'cribbage':
-        return getCribbageHint(state as CribbageResponse);
-      case 'gofish':
-        return getGoFishHint(state as GoFishResponse);
-      case 'caribbeanstud':
-        return getCaribbeanStudHint(state as CaribbeanStudResponse);
-      case 'durak':
-        return getDurakHint(state as DurakResponse);
-      case 'canasta':
-        return getCanastaHint(state as CanastaResponse);
-      case 'pinochle':
-        return getPinochleHint(state as PinochleResponse);
-      case 'twotenjack':
-        return getTwoTenJackHint(state as TwoTenJackResponse);
-      default:
-        return null;
-    }
+    return hintFactories[gameName]?.(state) ?? null;
   }, [gameName, hintEnabled, state]);
 
   return { hintEnabled, setHintEnabled, hint };

--- a/internal/adapter/presenter/BlackJackWebPresenter.go
+++ b/internal/adapter/presenter/BlackJackWebPresenter.go
@@ -46,7 +46,7 @@ func (bjp *BlackJackWebPresenter) Output(bj interfaces.BlackJackGame, lastErr er
 	resObj.PerfectPairsBet = bj.GetPerfectPairsBet()
 	resObj.TwentyOnePlus3Bet = bj.Get21Plus3Bet()
 
-	resObj.Message, resObj.MessageCode = bjp.buildMessage(bj, lastErr)
+	resObj.Message, resObj.MessageCode, resObj.MessageParams = bjp.buildMessage(bj, lastErr)
 
 	return marshalOrError(resObj)
 }
@@ -138,21 +138,21 @@ func (bjp *BlackJackWebPresenter) buildSideBetsOutput(bj interfaces.BlackJackGam
 }
 
 // buildMessage ゲーム結果メッセージを構築
-func (bjp *BlackJackWebPresenter) buildMessage(bj interfaces.BlackJackGame, lastErr error) (string, string) {
+func (bjp *BlackJackWebPresenter) buildMessage(bj interfaces.BlackJackGame, lastErr error) (string, string, map[string]string) {
 	if lastErr != nil {
-		return lastErr.Error(), ""
+		return lastErr.Error(), "", nil
 	}
 	if bj.GetGameEndFlag() {
 		switch bj.GameJudgment() {
 		case domain.GameResultDraw:
-			return "It is a draw.", "blackjack.result.draw"
+			return "It is a draw.", "blackjack.result.draw", nil
 		case domain.GameResultWin:
-			return "You are the winner.", "blackjack.result.win"
+			return "You are the winner.", "blackjack.result.win", nil
 		case domain.GameResultLose:
-			return "It is your loss.", "blackjack.result.lose"
+			return "It is your loss.", "blackjack.result.lose", nil
 		}
 	}
-	return "", ""
+	return "", "", nil
 }
 
 // ActionLogOutput 棋譜をJSON出力

--- a/internal/adapter/presenter/HoldemWebPresenter.go
+++ b/internal/adapter/presenter/HoldemWebPresenter.go
@@ -75,7 +75,7 @@ func (hwp *HoldemWebPresenter) buildOutput(h interfaces.HoldemGame, lastErr erro
 		resObj.PotOdds = &potOdds
 	}
 
-	resObj.Message, resObj.MessageCode = hwp.buildMessage(h, lastErr)
+	resObj.Message, resObj.MessageCode, resObj.MessageParams = hwp.buildMessage(h, lastErr)
 
 	// メタAI情報
 	if profile := h.GetHumanProfile(); profile != nil {
@@ -182,17 +182,18 @@ func (hwp *HoldemWebPresenter) buildRoundResultsOutput(h interfaces.HoldemGame) 
 }
 
 // buildMessage ゲーム結果メッセージを構築
-func (hwp *HoldemWebPresenter) buildMessage(h interfaces.HoldemGame, lastErr error) (string, string) {
+func (hwp *HoldemWebPresenter) buildMessage(h interfaces.HoldemGame, lastErr error) (string, string, map[string]string) {
 	if lastErr != nil {
-		return lastErr.Error(), ""
+		return lastErr.Error(), "", nil
 	}
 	if h.IsMuckAvailable() {
-		return "Muck or show your hand.", "holdem.muck.prompt"
+		return "Muck or show your hand.", "holdem.muck.prompt", nil
 	}
 	if h.GetGameEndFlag() {
-		return hwp.buildResultMessage(h)
+		msg, code := hwp.buildResultMessage(h)
+		return msg, code, nil
 	}
-	return "", ""
+	return "", "", nil
 }
 
 // buildResultMessage builds the end-of-round message and its i18n code

--- a/internal/adapter/presenter/IndianPokerWebPresenter.go
+++ b/internal/adapter/presenter/IndianPokerWebPresenter.go
@@ -38,7 +38,7 @@ func (iwp *IndianPokerWebPresenter) buildOutput(ip interfaces.IndianPokerGame, l
 	resObj.CpuActions = iwp.buildCpuActionsOutput(ip)
 	resObj.RoundResults = iwp.buildRoundResultsOutput(ip)
 
-	resObj.Message, resObj.MessageCode = iwp.buildMessage(ip, lastErr)
+	resObj.Message, resObj.MessageCode, resObj.MessageParams = iwp.buildMessage(ip, lastErr)
 
 	// メタAI情報
 	if profile := ip.GetHumanProfile(); profile != nil {
@@ -134,14 +134,15 @@ func (iwp *IndianPokerWebPresenter) buildRoundResultsOutput(ip interfaces.Indian
 }
 
 // buildMessage ゲーム結果メッセージを構築
-func (iwp *IndianPokerWebPresenter) buildMessage(ip interfaces.IndianPokerGame, lastErr error) (string, string) {
+func (iwp *IndianPokerWebPresenter) buildMessage(ip interfaces.IndianPokerGame, lastErr error) (string, string, map[string]string) {
 	if lastErr != nil {
-		return lastErr.Error(), ""
+		return lastErr.Error(), "", nil
 	}
 	if ip.GetGameEndFlag() {
-		return iwp.buildResultMessage(ip)
+		msg, code := iwp.buildResultMessage(ip)
+		return msg, code, nil
 	}
-	return "", ""
+	return "", "", nil
 }
 
 // buildResultMessage builds the end-of-round message and its i18n code

--- a/internal/adapter/presenter/OmahaWebPresenter.go
+++ b/internal/adapter/presenter/OmahaWebPresenter.go
@@ -74,7 +74,7 @@ func (owp *OmahaWebPresenter) buildOutput(o interfaces.OmahaGame, lastErr error)
 		resObj.PotOdds = &potOdds
 	}
 
-	resObj.Message, resObj.MessageCode = owp.buildMessage(o, lastErr)
+	resObj.Message, resObj.MessageCode, resObj.MessageParams = owp.buildMessage(o, lastErr)
 
 	// メタAI情報
 	if profile := o.GetHumanProfile(); profile != nil {
@@ -174,17 +174,18 @@ func (owp *OmahaWebPresenter) buildRoundResultsOutput(o interfaces.OmahaGame) []
 	return out
 }
 
-func (owp *OmahaWebPresenter) buildMessage(o interfaces.OmahaGame, lastErr error) (string, string) {
+func (owp *OmahaWebPresenter) buildMessage(o interfaces.OmahaGame, lastErr error) (string, string, map[string]string) {
 	if lastErr != nil {
-		return lastErr.Error(), ""
+		return lastErr.Error(), "", nil
 	}
 	if o.IsMuckAvailable() {
-		return "Muck or show your hand.", "omaha.muck.prompt"
+		return "Muck or show your hand.", "omaha.muck.prompt", nil
 	}
 	if o.GetGameEndFlag() {
-		return owp.buildResultMessage(o)
+		msg, code := owp.buildResultMessage(o)
+		return msg, code, nil
 	}
-	return "", ""
+	return "", "", nil
 }
 
 func (owp *OmahaWebPresenter) buildResultMessage(o interfaces.OmahaGame) (string, string) {

--- a/internal/adapter/presenter/PineappleWebPresenter.go
+++ b/internal/adapter/presenter/PineappleWebPresenter.go
@@ -77,7 +77,7 @@ func (pp *PineappleWebPresenter) buildOutput(p interfaces.PineappleGame, lastErr
 		resObj.PotOdds = &potOdds
 	}
 
-	resObj.Message, resObj.MessageCode = pp.buildMessage(p, lastErr)
+	resObj.Message, resObj.MessageCode, resObj.MessageParams = pp.buildMessage(p, lastErr)
 
 	// メタAI情報
 	if profile := p.GetHumanProfile(); profile != nil {
@@ -184,20 +184,21 @@ func (pp *PineappleWebPresenter) buildRoundResultsOutput(p interfaces.PineappleG
 }
 
 // buildMessage ゲーム結果メッセージを構築
-func (pp *PineappleWebPresenter) buildMessage(p interfaces.PineappleGame, lastErr error) (string, string) {
+func (pp *PineappleWebPresenter) buildMessage(p interfaces.PineappleGame, lastErr error) (string, string, map[string]string) {
 	if lastErr != nil {
-		return lastErr.Error(), ""
+		return lastErr.Error(), "", nil
 	}
 	if p.IsDiscardPhase() {
-		return "Select a card to discard.", "pineapple.discard.prompt"
+		return "Select a card to discard.", "pineapple.discard.prompt", nil
 	}
 	if p.IsMuckAvailable() {
-		return "Muck or show your hand.", "pineapple.muck.prompt"
+		return "Muck or show your hand.", "pineapple.muck.prompt", nil
 	}
 	if p.GetGameEndFlag() {
-		return pp.buildResultMessage(p)
+		msg, code := pp.buildResultMessage(p)
+		return msg, code, nil
 	}
-	return "", ""
+	return "", "", nil
 }
 
 // buildResultMessage builds the end-of-round message and its i18n code

--- a/internal/adapter/presenter/PineappleWebPresenter_test.go
+++ b/internal/adapter/presenter/PineappleWebPresenter_test.go
@@ -1,0 +1,102 @@
+//go:build test
+
+package presenter_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+)
+
+func TestPineappleWebPresenter_Output(t *testing.T) {
+	p := new(presenter.PineappleWebPresenter)
+
+	setup := func() (*domain.Pineapple, []*domain.PineapplePlayer) {
+		tc := domain.NewTrumpCards(0)
+		cfg := domain.DefaultPineappleConfig()
+		players := domain.NewPineapplePlayersForTable(cfg.TableSize)
+		game := domain.NewPineapple(tc, players, cfg)
+		return game, players
+	}
+
+	t.Run("initial state", func(t *testing.T) {
+		game, _ := setup()
+		game.SetPhase(domain.PineapplePhasePreFlop)
+
+		result := p.Output(game, nil)
+		var out controller.PineappleWebOutput
+		err := json.Unmarshal([]byte(result), &out)
+		assert.NoError(t, err)
+		assert.Equal(t, domain.PineapplePhasePreFlop, out.Phase)
+		assert.False(t, out.GameEndFlag)
+		assert.Equal(t, "", out.Message)
+		assert.Equal(t, "", out.MessageCode)
+		assert.False(t, out.IsDiscardPhase)
+		assert.False(t, out.MuckAvailable)
+	})
+
+	t.Run("error message", func(t *testing.T) {
+		game, _ := setup()
+		game.SetPhase(domain.PineapplePhasePreFlop)
+
+		result := p.Output(game, errors.New("invalid action"))
+		var out controller.PineappleWebOutput
+		_ = json.Unmarshal([]byte(result), &out)
+
+		assert.Equal(t, "invalid action", out.Message)
+		assert.Equal(t, "", out.MessageCode)
+	})
+
+	t.Run("discard phase message", func(t *testing.T) {
+		game, _ := setup()
+		game.SetPhase(domain.PineapplePhaseDiscard)
+
+		result := p.Output(game, nil)
+		var out controller.PineappleWebOutput
+		_ = json.Unmarshal([]byte(result), &out)
+
+		assert.Equal(t, "Select a card to discard.", out.Message)
+		assert.Equal(t, "pineapple.discard.prompt", out.MessageCode)
+		assert.True(t, out.IsDiscardPhase)
+	})
+
+	t.Run("muck available message", func(t *testing.T) {
+		game, players := setup()
+		game.SetPhase(domain.PineapplePhaseShowdown)
+		// IsMuckAvailable returns true when phase==Showdown and human has WonAmount==0
+		game.SetRoundResults([]domain.PineappleResult{
+			{PlayerIdx: 0, WonAmount: 0},
+		})
+		_ = players // players[0] is human (IsHuman=true)
+
+		result := p.Output(game, nil)
+		var out controller.PineappleWebOutput
+		_ = json.Unmarshal([]byte(result), &out)
+
+		assert.Equal(t, "Muck or show your hand.", out.Message)
+		assert.Equal(t, "pineapple.muck.prompt", out.MessageCode)
+		assert.True(t, out.MuckAvailable)
+	})
+
+	t.Run("game end message - human wins", func(t *testing.T) {
+		game, _ := setup()
+		game.SetPhase(domain.PineapplePhaseEnd)
+		game.SetGameEndFlag(true)
+		game.SetRoundResults([]domain.PineappleResult{
+			{PlayerIdx: 0, WonAmount: 100},
+		})
+
+		result := p.Output(game, nil)
+		var out controller.PineappleWebOutput
+		_ = json.Unmarshal([]byte(result), &out)
+
+		assert.Contains(t, out.Message, "You are the winner.")
+		assert.Equal(t, "pineapple.result.win", out.MessageCode)
+	})
+}

--- a/internal/adapter/presenter/PokerWebPresenter.go
+++ b/internal/adapter/presenter/PokerWebPresenter.go
@@ -60,7 +60,7 @@ func (pwp *PokerWebPresenter) buildOutput(p interfaces.PokerGame, lastErr error)
 	resObj.CpuActions = pwp.buildCpuActionsOutput(p)
 	resObj.CpuExchanges = pwp.buildCpuExchangesOutput(p)
 	resObj.RoundResults = pwp.buildRoundResultsOutput(p)
-	resObj.Message, resObj.MessageCode = pwp.buildMessage(p, lastErr)
+	resObj.Message, resObj.MessageCode, resObj.MessageParams = pwp.buildMessage(p, lastErr)
 
 	// メタAI情報
 	if profile := p.GetHumanProfile(); profile != nil {
@@ -79,14 +79,15 @@ func (pwp *PokerWebPresenter) buildOutput(p interfaces.PokerGame, lastErr error)
 }
 
 // buildMessage ゲーム結果メッセージを構築
-func (pwp *PokerWebPresenter) buildMessage(p interfaces.PokerGame, lastErr error) (string, string) {
+func (pwp *PokerWebPresenter) buildMessage(p interfaces.PokerGame, lastErr error) (string, string, map[string]string) {
 	if lastErr != nil {
-		return lastErr.Error(), ""
+		return lastErr.Error(), "", nil
 	}
 	if p.GetGameEndFlag() {
-		return pwp.buildResultMessage(p)
+		msg, code := pwp.buildResultMessage(p)
+		return msg, code, nil
 	}
-	return "", ""
+	return "", "", nil
 }
 
 // buildSidePotsOutput サイドポット情報を構築

--- a/internal/adapter/presenter/SevenCardStudWebPresenter.go
+++ b/internal/adapter/presenter/SevenCardStudWebPresenter.go
@@ -59,7 +59,7 @@ func (p *SevenCardStudWebPresenter) buildOutput(s interfaces.SevenCardStudGame, 
 	resObj.CpuActions = p.buildCpuActionsOutput(s)
 	resObj.RoundResults = p.buildRoundResultsOutput(s)
 
-	resObj.Message, resObj.MessageCode = p.buildMessage(s, lastErr)
+	resObj.Message, resObj.MessageCode, resObj.MessageParams = p.buildMessage(s, lastErr)
 
 	// メタAI情報
 	if profile := s.GetHumanProfile(); profile != nil {
@@ -174,17 +174,18 @@ func (p *SevenCardStudWebPresenter) buildRoundResultsOutput(s interfaces.SevenCa
 }
 
 // buildMessage ゲーム結果メッセージを構築
-func (p *SevenCardStudWebPresenter) buildMessage(s interfaces.SevenCardStudGame, lastErr error) (string, string) {
+func (p *SevenCardStudWebPresenter) buildMessage(s interfaces.SevenCardStudGame, lastErr error) (string, string, map[string]string) {
 	if lastErr != nil {
-		return lastErr.Error(), ""
+		return lastErr.Error(), "", nil
 	}
 	if s.IsMuckAvailable() {
-		return "Muck or show your hand.", "sevencardstud.muck.prompt"
+		return "Muck or show your hand.", "sevencardstud.muck.prompt", nil
 	}
 	if s.GetGameEndFlag() {
-		return p.buildResultMessage(s)
+		msg, code := p.buildResultMessage(s)
+		return msg, code, nil
 	}
-	return "", ""
+	return "", "", nil
 }
 
 // buildResultMessage builds the end-of-round message and its i18n code

--- a/internal/adapter/presenter/ShortDeckWebPresenter.go
+++ b/internal/adapter/presenter/ShortDeckWebPresenter.go
@@ -74,7 +74,7 @@ func (owp *ShortDeckWebPresenter) buildOutput(o interfaces.ShortDeckGame, lastEr
 		resObj.PotOdds = &potOdds
 	}
 
-	resObj.Message, resObj.MessageCode = owp.buildMessage(o, lastErr)
+	resObj.Message, resObj.MessageCode, resObj.MessageParams = owp.buildMessage(o, lastErr)
 
 	// メタAI情報
 	if profile := o.GetHumanProfile(); profile != nil {
@@ -174,17 +174,18 @@ func (owp *ShortDeckWebPresenter) buildRoundResultsOutput(o interfaces.ShortDeck
 	return out
 }
 
-func (owp *ShortDeckWebPresenter) buildMessage(o interfaces.ShortDeckGame, lastErr error) (string, string) {
+func (owp *ShortDeckWebPresenter) buildMessage(o interfaces.ShortDeckGame, lastErr error) (string, string, map[string]string) {
 	if lastErr != nil {
-		return lastErr.Error(), ""
+		return lastErr.Error(), "", nil
 	}
 	if o.IsMuckAvailable() {
-		return "Muck or show your hand.", "shortdeck.muck.prompt"
+		return "Muck or show your hand.", "shortdeck.muck.prompt", nil
 	}
 	if o.GetGameEndFlag() {
-		return owp.buildResultMessage(o)
+		msg, code := owp.buildResultMessage(o)
+		return msg, code, nil
 	}
-	return "", ""
+	return "", "", nil
 }
 
 func (owp *ShortDeckWebPresenter) buildResultMessage(o interfaces.ShortDeckGame) (string, string) {

--- a/internal/domain/Pineapple_testhelpers.go
+++ b/internal/domain/Pineapple_testhelpers.go
@@ -1,0 +1,58 @@
+//go:build test
+
+package domain
+
+// This file contains test helper methods for Pineapple.
+// They exist solely for cross-package test setup (e.g. presenter tests)
+// and are not part of the production game logic.
+
+// SetPhase フェーズ設定（テスト用）
+func (p *Pineapple) SetPhase(phase int) { p.phase = phase }
+
+// SetCurrentTurn 現在のターン設定（テスト用）
+func (p *Pineapple) SetCurrentTurn(turn int) { p.currentTurn = turn }
+
+// SetCommunityCards コミュニティカード設定（テスト用）
+func (p *Pineapple) SetCommunityCards(cards []*Card) { p.communityCards = cards }
+
+// SetPot ポット設定（テスト用）
+func (p *Pineapple) SetPot(pot int) { p.pot = pot }
+
+// SetDealerIdx ディーラーインデックス設定（テスト用）
+func (p *Pineapple) SetDealerIdx(idx int) { p.dealerIdx = idx }
+
+// SetGameEndFlag ゲーム終了フラグ設定（テスト用）
+func (p *Pineapple) SetGameEndFlag(flag bool) { p.gameEndFlag = flag }
+
+// SetLastBet 最後のベット設定（テスト用）
+func (p *Pineapple) SetLastBet(bet int) { p.lastBet = bet }
+
+// SetMinRaise 最小レイズ額設定（テスト用）
+func (p *Pineapple) SetMinRaise(raise int) { p.minRaise = raise }
+
+// SetRoundResults ラウンド結果設定（テスト用）
+func (p *Pineapple) SetRoundResults(results []PineappleResult) { p.roundResults = results }
+
+// SetCpuActions CPU行動記録設定（テスト用）
+func (p *Pineapple) SetCpuActions(actions []PineappleCpuAction) { p.cpuActions = actions }
+
+// SetSidePots サイドポット設定（テスト用）
+func (p *Pineapple) SetSidePots(pots []PineappleSidePot) { p.sidePots = pots }
+
+// SetHandCount ハンド数設定（テスト用）
+func (p *Pineapple) SetHandCount(count int) { p.handCount = count }
+
+// SetRebuyCounts リバイ回数設定（テスト用）
+func (p *Pineapple) SetRebuyCounts(counts []int) { p.rebuyCounts = counts }
+
+// SetAddonUsed アドオン使用フラグ設定（テスト用）
+func (p *Pineapple) SetAddonUsed(used []bool) { p.addonUsed = used }
+
+// SetRebuyPhaseType リバイフェーズ種別設定（テスト用）
+func (p *Pineapple) SetRebuyPhaseType(t int) { p.rebuyPhaseType = t }
+
+// SetHumanProfile メタAIプロファイル設定（テスト用）
+func (p *Pineapple) SetHumanProfile(profile *BettingHumanProfile) { p.humanProfile = profile }
+
+// GetLastHumanPlayMs 最後の人間プレイ時間取得（テスト用）
+func (p *Pineapple) GetLastHumanPlayMs() int { return p.lastHumanPlayMs }

--- a/internal/infrastructure/web/TrumpCardsWeb.go
+++ b/internal/infrastructure/web/TrumpCardsWeb.go
@@ -21,470 +21,395 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
+// webController is the common interface for all game web controllers.
+type webController interface {
+	Exec(http.ResponseWriter, *http.Request)
+	Stop()
+}
+
+// gameEntry pairs a route name with its controller constructor.
+type gameEntry struct {
+	name       string
+	controller webController
+}
+
 // TrumpCardsWeb トランプカードゲームWebクラス
 type TrumpCardsWeb struct {
-	bjc  *controller.BlackJackWebController
-	pkc  *controller.PokerWebController
-	omc  *controller.OldMaidWebController
-	dgc  *controller.DaifugoWebController
-	sgc  *controller.SevensWebController
-	dwc  *controller.DoubtWebController
-	hmc  *controller.HoldemWebController
-	ohc  *controller.OmahaWebController
-	skc  *controller.ShortDeckWebController
-	htc  *controller.HeartsWebController
-	myc  *controller.MemoryWebController
-	klc  *controller.KlondikeWebController
-	fcc  *controller.FreeCellWebController
-	bcc  *controller.BaccaratWebController
-	spc  *controller.SpadesWebController
-	cec  *controller.CrazyEightsWebController
-	grc  *controller.GinRummyWebController
-	sdc  *controller.SpiderWebController
-	npc  *controller.NapoleonWebController
-	ipc  *controller.IndianPokerWebController
-	vpc  *controller.VideoPokerWebController
-	dwwc *controller.VideoPokerWebController
-	jpwc *controller.VideoPokerWebController
-	euc  *controller.EuchreWebController
-	pyc  *controller.PyramidWebController
-	cbc  *controller.CribbageWebController
-	tpc  *controller.TriPeaksWebController
-	tcc  *controller.ThreeCardWebController
-	ohlc *controller.OhHellWebController
-	brc  *controller.BridgeWebController
-	pnc  *controller.PineappleWebController
-	spdc *controller.SpeedWebController
-	gfc  *controller.GoFishWebController
-	cnc  *controller.CanastaWebController
-	pinc *controller.PinochleWebController
-	glfc *controller.GolfWebController
-	ptc  *controller.PigsTailWebController
-	scsc *controller.SevenCardStudWebController
-	csc  *controller.ClockSolitaireWebController
-	drc  *controller.DurakWebController
-	ftc  *controller.FortyThievesWebController
-	pgc  *controller.PaiGowWebController
-	ttjc *controller.TwoTenJackWebController
-	cspc *controller.CaribbeanStudWebController
-	warc *controller.WarWebController
-	cfc  *controller.CanfieldWebController
+	games []gameEntry
 }
 
 // NewTrumpCardsWeb コンストラクタ
 func NewTrumpCardsWeb() *TrumpCardsWeb {
-	return &TrumpCardsWeb{
-		bjc: controller.NewBlackJackWebController(func() usecase.BlackJackInteractorIF {
-			return usecase.NewBlackJackInteractor(
-				domain.NewDefaultBlackJack(),
-				new(presenter.BlackJackWebPresenter),
-			)
-		}),
-		pkc: controller.NewPokerWebController(func() usecase.PokerInteractorIF {
-			config := domain.DefaultPokerConfig()
-			players := []*domain.PokerPlayer{
-				domain.NewPokerPlayer(true, domain.PokerStyleBalanced),
-				domain.NewPokerPlayer(false, domain.PokerStyleConservative),
-				domain.NewPokerPlayer(false, domain.PokerStyleAggressive),
-				domain.NewPokerPlayer(false, domain.PokerStyleBluffer),
-			}
-			poker := domain.NewPoker(domain.NewTrumpCards(config.JokerCount), players, config)
-			return usecase.NewPokerInteractor(poker, new(presenter.PokerWebPresenter))
-		}),
-		omc: controller.NewOldMaidWebController(func() usecase.OldMaidInteractorIF {
-			players := []*domain.OldMaidPlayer{
-				domain.NewOldMaidPlayer(true),
-				domain.NewOldMaidPlayer(false),
-				domain.NewOldMaidPlayer(false),
-				domain.NewOldMaidPlayer(false),
-			}
-			oldMaid := domain.NewOldMaid(domain.NewTrumpCards(1), players)
-			return usecase.NewOldMaidInteractor(oldMaid, new(presenter.OldMaidWebPresenter))
-		}),
-		dgc: controller.NewDaifugoWebController(func() usecase.DaifugoInteractorIF {
-			config := domain.DefaultDaifugoConfig()
-			players := []*domain.DaifugoPlayer{
-				domain.NewDaifugoPlayer(true),
-				domain.NewDaifugoPlayer(false),
-				domain.NewDaifugoPlayer(false),
-				domain.NewDaifugoPlayer(false),
-			}
-			daifugo := domain.NewDaifugo(domain.NewTrumpCards(config.JokerCount), players, config)
-			return usecase.NewDaifugoInteractor(daifugo, new(presenter.DaifugoWebPresenter))
-		}),
-		sgc: controller.NewSevensWebController(func() usecase.SevensInteractorIF {
-			config := domain.DefaultSevensConfig()
-			players := []*domain.SevensPlayer{
-				domain.NewSevensPlayer(true),
-				domain.NewSevensPlayer(false),
-				domain.NewSevensPlayer(false),
-				domain.NewSevensPlayer(false),
-			}
-			sevens := domain.NewSevens(domain.NewTrumpCards(config.JokerCount), players, config)
-			return usecase.NewSevensInteractor(sevens, new(presenter.SevensWebPresenter))
-		}),
-		dwc: controller.NewDoubtWebController(func() usecase.DoubtInteractorIF {
-			players := []*domain.DoubtPlayer{
-				domain.NewDoubtPlayer(true),
-				domain.NewDoubtPlayer(false),
-				domain.NewDoubtPlayer(false),
-				domain.NewDoubtPlayer(false),
-			}
-			doubt := domain.NewDoubt(domain.NewTrumpCards(0), players)
-			return usecase.NewDoubtInteractor(doubt, new(presenter.DoubtWebPresenter))
-		}),
-		hmc: controller.NewHoldemWebController(func() usecase.HoldemInteractorIF {
-			cfg := domain.DefaultHoldemConfig()
-			holdem := domain.NewHoldem(domain.NewTrumpCards(0), domain.NewPlayersForTable(cfg.TableSize), cfg)
-			return usecase.NewHoldemInteractor(holdem, new(presenter.HoldemWebPresenter))
-		}),
-		ohc: controller.NewOmahaWebController(func() usecase.OmahaInteractorIF {
-			cfg := domain.DefaultOmahaConfig()
-			omaha := domain.NewOmaha(domain.NewTrumpCards(0), domain.NewOmahaPlayersForTable(cfg.TableSize), cfg)
-			return usecase.NewOmahaInteractor(omaha, new(presenter.OmahaWebPresenter))
-		}),
-		skc: controller.NewShortDeckWebController(func() usecase.ShortDeckInteractorIF {
-			cfg := domain.DefaultShortDeckConfig()
-			sd := domain.NewShortDeck(domain.NewTrumpCardsShortDeck(), domain.NewShortDeckPlayersForTable(cfg.TableSize), cfg)
-			return usecase.NewShortDeckInteractor(sd, new(presenter.ShortDeckWebPresenter))
-		}),
-		htc: controller.NewHeartsWebController(func() usecase.HeartsInteractorIF {
-			config := domain.DefaultHeartsConfig()
-			players := []*domain.HeartsPlayer{
-				domain.NewHeartsPlayer(true),
-				domain.NewHeartsPlayer(false),
-				domain.NewHeartsPlayer(false),
-				domain.NewHeartsPlayer(false),
-			}
-			hearts := domain.NewHearts(domain.NewTrumpCards(0), players, config)
-			return usecase.NewHeartsInteractor(hearts, new(presenter.HeartsWebPresenter))
-		}),
-		myc: controller.NewMemoryWebController(func() usecase.MemoryInteractorIF {
-			config := domain.DefaultMemoryConfig()
-			players := []*domain.MemoryPlayer{
-				domain.NewMemoryPlayer(true),
-				domain.NewMemoryPlayer(false),
-				domain.NewMemoryPlayer(false),
-				domain.NewMemoryPlayer(false),
-			}
-			memory := domain.NewMemory(domain.NewTrumpCards(0), players, config)
-			return usecase.NewMemoryInteractor(memory, new(presenter.MemoryWebPresenter))
-		}),
-		klc: controller.NewKlondikeWebController(func() usecase.KlondikeInteractorIF {
-			klondike := domain.NewKlondike(domain.NewTrumpCards(0))
-			return usecase.NewKlondikeInteractor(klondike, new(presenter.KlondikeWebPresenter))
-		}),
-		fcc: controller.NewFreeCellWebController(func() usecase.FreeCellInteractorIF {
-			freeCell := domain.NewFreeCell(domain.NewTrumpCards(0))
-			return usecase.NewFreeCellInteractor(freeCell, new(presenter.FreeCellWebPresenter))
-		}),
-		bcc: controller.NewBaccaratWebController(func() usecase.BaccaratInteractorIF {
-			baccarat := domain.NewDefaultBaccarat()
-			return usecase.NewBaccaratInteractor(baccarat, new(presenter.BaccaratWebPresenter))
-		}),
-		spc: controller.NewSpadesWebController(func() usecase.SpadesInteractorIF {
-			config := domain.DefaultSpadesConfig()
-			players := []*domain.SpadesPlayer{
-				domain.NewSpadesPlayer(true),
-				domain.NewSpadesPlayer(false),
-				domain.NewSpadesPlayer(false),
-				domain.NewSpadesPlayer(false),
-			}
-			spades := domain.NewSpades(domain.NewTrumpCards(0), players, config)
-			return usecase.NewSpadesInteractor(spades, new(presenter.SpadesWebPresenter))
-		}),
-		cec: controller.NewCrazyEightsWebController(func() usecase.CrazyEightsInteractorIF {
-			config := domain.DefaultCrazyEightsConfig()
-			players := []*domain.CrazyEightsPlayer{
-				domain.NewCrazyEightsPlayer(true),
-				domain.NewCrazyEightsPlayer(false),
-				domain.NewCrazyEightsPlayer(false),
-				domain.NewCrazyEightsPlayer(false),
-			}
-			ce := domain.NewCrazyEights(domain.NewTrumpCards(0), players, config)
-			return usecase.NewCrazyEightsInteractor(ce, new(presenter.CrazyEightsWebPresenter))
-		}),
-		grc: controller.NewGinRummyWebController(func() usecase.GinRummyInteractorIF {
-			config := domain.DefaultGinRummyConfig()
-			players := []*domain.GinRummyPlayer{
-				domain.NewGinRummyPlayer(true),
-				domain.NewGinRummyPlayer(false),
-			}
-			gr := domain.NewGinRummy(domain.NewTrumpCards(0), players, config)
-			return usecase.NewGinRummyInteractor(gr, new(presenter.GinRummyWebPresenter))
-		}),
-		sdc: controller.NewSpiderWebController(func() usecase.SpiderInteractorIF {
-			spider := domain.NewSpider(domain.NewTrumpCardsWithSuits(domain.SpiderTotalCards, []int{domain.CardDesignSpade}))
-			return usecase.NewSpiderInteractor(spider, new(presenter.SpiderWebPresenter))
-		}),
-		npc: controller.NewNapoleonWebController(func() usecase.NapoleonInteractorIF {
-			config := domain.DefaultNapoleonConfig()
-			players := []*domain.NapoleonPlayer{
-				domain.NewNapoleonPlayer(true),
-				domain.NewNapoleonPlayer(false),
-				domain.NewNapoleonPlayer(false),
-				domain.NewNapoleonPlayer(false),
-			}
-			napoleon := domain.NewNapoleon(domain.NewTrumpCards(1), players, config)
-			return usecase.NewNapoleonInteractor(napoleon, new(presenter.NapoleonWebPresenter))
-		}),
-		ipc: controller.NewIndianPokerWebController(func() usecase.IndianPokerInteractorIF {
-			cfg := domain.DefaultIndianPokerConfig()
-			ip := domain.NewIndianPoker(domain.NewTrumpCards(0), domain.NewIndianPokerPlayers(), cfg)
-			return usecase.NewIndianPokerInteractor(ip, new(presenter.IndianPokerWebPresenter))
-		}),
-		vpc: controller.NewVideoPokerWebController(func() usecase.VideoPokerInteractorIF {
-			return usecase.NewVideoPokerInteractor(
-				domain.NewDefaultVideoPoker(),
-				new(presenter.VideoPokerWebPresenter),
-			)
-		}),
-		dwwc: controller.NewVideoPokerWebController(func() usecase.VideoPokerInteractorIF {
-			return usecase.NewVideoPokerInteractor(
-				domain.NewDeucesWildVideoPoker(),
-				new(presenter.VideoPokerWebPresenter),
-			)
-		}),
-		jpwc: controller.NewVideoPokerWebController(func() usecase.VideoPokerInteractorIF {
-			return usecase.NewVideoPokerInteractor(
-				domain.NewJokerPokerVideoPoker(),
-				new(presenter.VideoPokerWebPresenter),
-			)
-		}),
-		euc: controller.NewEuchreWebController(func() usecase.EuchreInteractorIF {
-			config := domain.DefaultEuchreConfig()
-			players := []*domain.EuchrePlayer{
-				domain.NewEuchrePlayer(true, 0),
-				domain.NewEuchrePlayer(false, 1),
-				domain.NewEuchrePlayer(false, 0),
-				domain.NewEuchrePlayer(false, 1),
-			}
-			euchre := domain.NewEuchre(domain.NewTrumpCardsEuchre(), players, config)
-			return usecase.NewEuchreInteractor(euchre, new(presenter.EuchreWebPresenter))
-		}),
-		pyc: controller.NewPyramidWebController(func() usecase.PyramidInteractorIF {
-			pyramid := domain.NewPyramid(domain.NewTrumpCards(0))
-			return usecase.NewPyramidInteractor(pyramid, new(presenter.PyramidWebPresenter))
-		}),
-		tpc: controller.NewTriPeaksWebController(func() usecase.TriPeaksInteractorIF {
-			triPeaks := domain.NewTriPeaks(domain.NewTrumpCards(0))
-			return usecase.NewTriPeaksInteractor(triPeaks, new(presenter.TriPeaksWebPresenter))
-		}),
-		cbc: controller.NewCribbageWebController(func() usecase.CribbageInteractorIF {
-			config := domain.DefaultCribbageConfig()
-			players := []*domain.CribbagePlayer{
-				domain.NewCribbagePlayer(true),
-				domain.NewCribbagePlayer(false),
-			}
-			cribbage := domain.NewCribbage(domain.NewTrumpCards(0), players, config)
-			return usecase.NewCribbageInteractor(cribbage, new(presenter.CribbageWebPresenter))
-		}),
-		tcc: controller.NewThreeCardWebController(func() usecase.ThreeCardInteractorIF {
-			return usecase.NewThreeCardInteractor(
-				domain.NewDefaultThreeCard(),
-				new(presenter.ThreeCardWebPresenter),
-			)
-		}),
-		ohlc: controller.NewOhHellWebController(func() usecase.OhHellInteractorIF {
-			config := domain.DefaultOhHellConfig()
-			players := []*domain.OhHellPlayer{
-				domain.NewOhHellPlayer(true),
-				domain.NewOhHellPlayer(false),
-				domain.NewOhHellPlayer(false),
-				domain.NewOhHellPlayer(false),
-			}
-			ohHell := domain.NewOhHell(domain.NewTrumpCards(0), players, config)
-			return usecase.NewOhHellInteractor(ohHell, new(presenter.OhHellWebPresenter))
-		}),
-		brc: controller.NewBridgeWebController(func() usecase.BridgeInteractorIF {
-			config := domain.DefaultBridgeConfig()
-			players := []*domain.BridgePlayer{
-				domain.NewBridgePlayer(true, 0),
-				domain.NewBridgePlayer(false, 1),
-				domain.NewBridgePlayer(false, 0),
-				domain.NewBridgePlayer(false, 1),
-			}
-			bridge := domain.NewBridge(domain.NewTrumpCards(0), players, config)
-			return usecase.NewBridgeInteractor(bridge, new(presenter.BridgeWebPresenter))
-		}),
-		pnc: controller.NewPineappleWebController(func() usecase.PineappleInteractorIF {
-			cfg := domain.DefaultPineappleConfig()
-			pineapple := domain.NewPineapple(domain.NewTrumpCards(0), domain.NewPineapplePlayersForTable(cfg.TableSize), cfg)
-			return usecase.NewPineappleInteractor(pineapple, new(presenter.PineappleWebPresenter))
-		}),
-		spdc: controller.NewSpeedWebController(func() usecase.SpeedInteractorIF {
-			config := domain.DefaultSpeedConfig()
-			players := []*domain.SpeedPlayer{
-				domain.NewSpeedPlayer(true),
-				domain.NewSpeedPlayer(false),
-			}
-			speed := domain.NewSpeed(domain.NewTrumpCards(0), players, config)
-			return usecase.NewSpeedInteractor(speed, new(presenter.SpeedWebPresenter))
-		}),
-		gfc: controller.NewGoFishWebController(func() usecase.GoFishInteractorIF {
-			players := []*domain.GoFishPlayer{
-				domain.NewGoFishPlayer(true),
-				domain.NewGoFishPlayer(false),
-				domain.NewGoFishPlayer(false),
-				domain.NewGoFishPlayer(false),
-			}
-			goFish := domain.NewGoFish(domain.NewTrumpCards(0), players)
-			return usecase.NewGoFishInteractor(goFish, new(presenter.GoFishWebPresenter))
-		}),
-		cnc: controller.NewCanastaWebController(func() usecase.CanastaInteractorIF {
-			config := domain.DefaultCanastaConfig()
-			players := []*domain.CanastaPlayer{
-				domain.NewCanastaPlayer(true),
-				domain.NewCanastaPlayer(false),
-			}
-			canasta := domain.NewCanasta(domain.NewTrumpCardsWithDecks(2, 4), players, config)
-			return usecase.NewCanastaInteractor(canasta, new(presenter.CanastaWebPresenter))
-		}),
-		pinc: controller.NewPinochleWebController(func() usecase.PinochleInteractorIF {
-			config := domain.DefaultPinochleConfig()
-			players := []*domain.PinochlePlayer{
-				domain.NewPinochlePlayer(true, 0),
-				domain.NewPinochlePlayer(false, 1),
-				domain.NewPinochlePlayer(false, 0),
-				domain.NewPinochlePlayer(false, 1),
-			}
-			pinochle := domain.NewPinochle(domain.NewTrumpCardsPinochle(), players, config)
-			return usecase.NewPinochleInteractor(pinochle, new(presenter.PinochleWebPresenter))
-		}),
-		glfc: controller.NewGolfWebController(func() usecase.GolfInteractorIF {
-			golf := domain.NewGolf(domain.NewTrumpCards(0))
-			return usecase.NewGolfInteractor(golf, new(presenter.GolfWebPresenter))
-		}),
-		ptc: controller.NewPigsTailWebController(func() usecase.PigsTailInteractorIF {
-			players := []*domain.PigsTailPlayer{
-				domain.NewPigsTailPlayer(true),
-				domain.NewPigsTailPlayer(false),
-				domain.NewPigsTailPlayer(false),
-				domain.NewPigsTailPlayer(false),
-			}
-			pigsTail := domain.NewPigsTail(domain.NewTrumpCards(0), players)
-			return usecase.NewPigsTailInteractor(pigsTail, new(presenter.PigsTailWebPresenter))
-		}),
-		scsc: controller.NewSevenCardStudWebController(func() usecase.SevenCardStudInteractorIF {
-			cfg := domain.DefaultSevenCardStudConfig()
-			scs := domain.NewSevenCardStud(domain.NewTrumpCards(0), domain.NewSevenCardStudPlayersForTable(cfg.TableSize), cfg)
-			return usecase.NewSevenCardStudInteractor(scs, new(presenter.SevenCardStudWebPresenter))
-		}),
-		csc: controller.NewClockSolitaireWebController(func() usecase.ClockSolitaireInteractorIF {
-			cs := domain.NewClockSolitaire(domain.NewTrumpCards(0))
-			return usecase.NewClockSolitaireInteractor(cs, new(presenter.ClockSolitaireWebPresenter))
-		}),
-		drc: controller.NewDurakWebController(func() usecase.DurakInteractorIF {
-			players := []*domain.DurakPlayer{
-				domain.NewDurakPlayer(true),
-				domain.NewDurakPlayer(false),
-				domain.NewDurakPlayer(false),
-				domain.NewDurakPlayer(false),
-			}
-			d := domain.NewDurak(domain.NewTrumpCardsShortDeck(), players)
-			return usecase.NewDurakInteractor(d, new(presenter.DurakWebPresenter))
-		}),
-		ftc: controller.NewFortyThievesWebController(func() usecase.FortyThievesInteractorIF {
-			ft := domain.NewFortyThieves(domain.NewTrumpCardsWithDecks(2, 0))
-			return usecase.NewFortyThievesInteractor(ft, new(presenter.FortyThievesWebPresenter))
-		}),
-		pgc: controller.NewPaiGowWebController(func() usecase.PaiGowInteractorIF {
-			return usecase.NewPaiGowInteractor(
-				domain.NewDefaultPaiGow(),
-				new(presenter.PaiGowWebPresenter),
-			)
-		}),
-		ttjc: controller.NewTwoTenJackWebController(func() usecase.TwoTenJackInteractorIF {
-			config := domain.DefaultTwoTenJackConfig()
-			players := []*domain.TwoTenJackPlayer{
-				domain.NewTwoTenJackPlayer(true),
-				domain.NewTwoTenJackPlayer(false),
-				domain.NewTwoTenJackPlayer(false),
-				domain.NewTwoTenJackPlayer(false),
-			}
-			ttj := domain.NewTwoTenJack(domain.NewTrumpCards(0), players, config)
-			return usecase.NewTwoTenJackInteractor(ttj, new(presenter.TwoTenJackWebPresenter))
-		}),
-		cspc: controller.NewCaribbeanStudWebController(func() usecase.CaribbeanStudInteractorIF {
-			return usecase.NewCaribbeanStudInteractor(
-				domain.NewDefaultCaribbeanStud(),
-				new(presenter.CaribbeanStudWebPresenter),
-			)
-		}),
-		warc: controller.NewWarWebController(func() usecase.WarInteractorIF {
-			config := domain.DefaultWarConfig()
-			players := []*domain.WarPlayer{
-				domain.NewWarPlayer(true),
-				domain.NewWarPlayer(false),
-			}
-			war := domain.NewWar(domain.NewTrumpCards(0), players, config)
-			return usecase.NewWarInteractor(war, new(presenter.WarWebPresenter))
-		}),
-		cfc: controller.NewCanfieldWebController(func() usecase.CanfieldInteractorIF {
-			canfield := domain.NewCanfield(domain.NewTrumpCards(0))
-			return usecase.NewCanfieldInteractor(canfield, new(presenter.CanfieldWebPresenter))
-		}),
-	}
+	web := &TrumpCardsWeb{}
+	web.registerAll()
+	return web
+}
+
+// register adds a game controller to the registry.
+func (web *TrumpCardsWeb) register(name string, c webController) {
+	web.games = append(web.games, gameEntry{name: name, controller: c})
+}
+
+// registerAll registers all game controllers.
+func (web *TrumpCardsWeb) registerAll() {
+	web.register("blackjack", controller.NewBlackJackWebController(func() usecase.BlackJackInteractorIF {
+		return usecase.NewBlackJackInteractor(
+			domain.NewDefaultBlackJack(),
+			new(presenter.BlackJackWebPresenter),
+		)
+	}))
+	web.register("poker", controller.NewPokerWebController(func() usecase.PokerInteractorIF {
+		config := domain.DefaultPokerConfig()
+		players := []*domain.PokerPlayer{
+			domain.NewPokerPlayer(true, domain.PokerStyleBalanced),
+			domain.NewPokerPlayer(false, domain.PokerStyleConservative),
+			domain.NewPokerPlayer(false, domain.PokerStyleAggressive),
+			domain.NewPokerPlayer(false, domain.PokerStyleBluffer),
+		}
+		poker := domain.NewPoker(domain.NewTrumpCards(config.JokerCount), players, config)
+		return usecase.NewPokerInteractor(poker, new(presenter.PokerWebPresenter))
+	}))
+	web.register("oldmaid", controller.NewOldMaidWebController(func() usecase.OldMaidInteractorIF {
+		players := []*domain.OldMaidPlayer{
+			domain.NewOldMaidPlayer(true),
+			domain.NewOldMaidPlayer(false),
+			domain.NewOldMaidPlayer(false),
+			domain.NewOldMaidPlayer(false),
+		}
+		oldMaid := domain.NewOldMaid(domain.NewTrumpCards(1), players)
+		return usecase.NewOldMaidInteractor(oldMaid, new(presenter.OldMaidWebPresenter))
+	}))
+	web.register("daifugo", controller.NewDaifugoWebController(func() usecase.DaifugoInteractorIF {
+		config := domain.DefaultDaifugoConfig()
+		players := []*domain.DaifugoPlayer{
+			domain.NewDaifugoPlayer(true),
+			domain.NewDaifugoPlayer(false),
+			domain.NewDaifugoPlayer(false),
+			domain.NewDaifugoPlayer(false),
+		}
+		daifugo := domain.NewDaifugo(domain.NewTrumpCards(config.JokerCount), players, config)
+		return usecase.NewDaifugoInteractor(daifugo, new(presenter.DaifugoWebPresenter))
+	}))
+	web.register("sevens", controller.NewSevensWebController(func() usecase.SevensInteractorIF {
+		config := domain.DefaultSevensConfig()
+		players := []*domain.SevensPlayer{
+			domain.NewSevensPlayer(true),
+			domain.NewSevensPlayer(false),
+			domain.NewSevensPlayer(false),
+			domain.NewSevensPlayer(false),
+		}
+		sevens := domain.NewSevens(domain.NewTrumpCards(config.JokerCount), players, config)
+		return usecase.NewSevensInteractor(sevens, new(presenter.SevensWebPresenter))
+	}))
+	web.register("doubt", controller.NewDoubtWebController(func() usecase.DoubtInteractorIF {
+		players := []*domain.DoubtPlayer{
+			domain.NewDoubtPlayer(true),
+			domain.NewDoubtPlayer(false),
+			domain.NewDoubtPlayer(false),
+			domain.NewDoubtPlayer(false),
+		}
+		doubt := domain.NewDoubt(domain.NewTrumpCards(0), players)
+		return usecase.NewDoubtInteractor(doubt, new(presenter.DoubtWebPresenter))
+	}))
+	web.register("holdem", controller.NewHoldemWebController(func() usecase.HoldemInteractorIF {
+		cfg := domain.DefaultHoldemConfig()
+		holdem := domain.NewHoldem(domain.NewTrumpCards(0), domain.NewPlayersForTable(cfg.TableSize), cfg)
+		return usecase.NewHoldemInteractor(holdem, new(presenter.HoldemWebPresenter))
+	}))
+	web.register("omaha", controller.NewOmahaWebController(func() usecase.OmahaInteractorIF {
+		cfg := domain.DefaultOmahaConfig()
+		omaha := domain.NewOmaha(domain.NewTrumpCards(0), domain.NewOmahaPlayersForTable(cfg.TableSize), cfg)
+		return usecase.NewOmahaInteractor(omaha, new(presenter.OmahaWebPresenter))
+	}))
+	web.register("shortdeck", controller.NewShortDeckWebController(func() usecase.ShortDeckInteractorIF {
+		cfg := domain.DefaultShortDeckConfig()
+		sd := domain.NewShortDeck(domain.NewTrumpCardsShortDeck(), domain.NewShortDeckPlayersForTable(cfg.TableSize), cfg)
+		return usecase.NewShortDeckInteractor(sd, new(presenter.ShortDeckWebPresenter))
+	}))
+	web.register("hearts", controller.NewHeartsWebController(func() usecase.HeartsInteractorIF {
+		config := domain.DefaultHeartsConfig()
+		players := []*domain.HeartsPlayer{
+			domain.NewHeartsPlayer(true),
+			domain.NewHeartsPlayer(false),
+			domain.NewHeartsPlayer(false),
+			domain.NewHeartsPlayer(false),
+		}
+		hearts := domain.NewHearts(domain.NewTrumpCards(0), players, config)
+		return usecase.NewHeartsInteractor(hearts, new(presenter.HeartsWebPresenter))
+	}))
+	web.register("memory", controller.NewMemoryWebController(func() usecase.MemoryInteractorIF {
+		config := domain.DefaultMemoryConfig()
+		players := []*domain.MemoryPlayer{
+			domain.NewMemoryPlayer(true),
+			domain.NewMemoryPlayer(false),
+			domain.NewMemoryPlayer(false),
+			domain.NewMemoryPlayer(false),
+		}
+		memory := domain.NewMemory(domain.NewTrumpCards(0), players, config)
+		return usecase.NewMemoryInteractor(memory, new(presenter.MemoryWebPresenter))
+	}))
+	web.register("klondike", controller.NewKlondikeWebController(func() usecase.KlondikeInteractorIF {
+		klondike := domain.NewKlondike(domain.NewTrumpCards(0))
+		return usecase.NewKlondikeInteractor(klondike, new(presenter.KlondikeWebPresenter))
+	}))
+	web.register("freecell", controller.NewFreeCellWebController(func() usecase.FreeCellInteractorIF {
+		freeCell := domain.NewFreeCell(domain.NewTrumpCards(0))
+		return usecase.NewFreeCellInteractor(freeCell, new(presenter.FreeCellWebPresenter))
+	}))
+	web.register("baccarat", controller.NewBaccaratWebController(func() usecase.BaccaratInteractorIF {
+		baccarat := domain.NewDefaultBaccarat()
+		return usecase.NewBaccaratInteractor(baccarat, new(presenter.BaccaratWebPresenter))
+	}))
+	web.register("spades", controller.NewSpadesWebController(func() usecase.SpadesInteractorIF {
+		config := domain.DefaultSpadesConfig()
+		players := []*domain.SpadesPlayer{
+			domain.NewSpadesPlayer(true),
+			domain.NewSpadesPlayer(false),
+			domain.NewSpadesPlayer(false),
+			domain.NewSpadesPlayer(false),
+		}
+		spades := domain.NewSpades(domain.NewTrumpCards(0), players, config)
+		return usecase.NewSpadesInteractor(spades, new(presenter.SpadesWebPresenter))
+	}))
+	web.register("crazyeights", controller.NewCrazyEightsWebController(func() usecase.CrazyEightsInteractorIF {
+		config := domain.DefaultCrazyEightsConfig()
+		players := []*domain.CrazyEightsPlayer{
+			domain.NewCrazyEightsPlayer(true),
+			domain.NewCrazyEightsPlayer(false),
+			domain.NewCrazyEightsPlayer(false),
+			domain.NewCrazyEightsPlayer(false),
+		}
+		ce := domain.NewCrazyEights(domain.NewTrumpCards(0), players, config)
+		return usecase.NewCrazyEightsInteractor(ce, new(presenter.CrazyEightsWebPresenter))
+	}))
+	web.register("ginrummy", controller.NewGinRummyWebController(func() usecase.GinRummyInteractorIF {
+		config := domain.DefaultGinRummyConfig()
+		players := []*domain.GinRummyPlayer{
+			domain.NewGinRummyPlayer(true),
+			domain.NewGinRummyPlayer(false),
+		}
+		gr := domain.NewGinRummy(domain.NewTrumpCards(0), players, config)
+		return usecase.NewGinRummyInteractor(gr, new(presenter.GinRummyWebPresenter))
+	}))
+	web.register("spider", controller.NewSpiderWebController(func() usecase.SpiderInteractorIF {
+		spider := domain.NewSpider(domain.NewTrumpCardsWithSuits(domain.SpiderTotalCards, []int{domain.CardDesignSpade}))
+		return usecase.NewSpiderInteractor(spider, new(presenter.SpiderWebPresenter))
+	}))
+	web.register("napoleon", controller.NewNapoleonWebController(func() usecase.NapoleonInteractorIF {
+		config := domain.DefaultNapoleonConfig()
+		players := []*domain.NapoleonPlayer{
+			domain.NewNapoleonPlayer(true),
+			domain.NewNapoleonPlayer(false),
+			domain.NewNapoleonPlayer(false),
+			domain.NewNapoleonPlayer(false),
+		}
+		napoleon := domain.NewNapoleon(domain.NewTrumpCards(1), players, config)
+		return usecase.NewNapoleonInteractor(napoleon, new(presenter.NapoleonWebPresenter))
+	}))
+	web.register("indianpoker", controller.NewIndianPokerWebController(func() usecase.IndianPokerInteractorIF {
+		cfg := domain.DefaultIndianPokerConfig()
+		ip := domain.NewIndianPoker(domain.NewTrumpCards(0), domain.NewIndianPokerPlayers(), cfg)
+		return usecase.NewIndianPokerInteractor(ip, new(presenter.IndianPokerWebPresenter))
+	}))
+	web.register("videopoker", controller.NewVideoPokerWebController(func() usecase.VideoPokerInteractorIF {
+		return usecase.NewVideoPokerInteractor(
+			domain.NewDefaultVideoPoker(),
+			new(presenter.VideoPokerWebPresenter),
+		)
+	}))
+	web.register("deuceswild", controller.NewVideoPokerWebController(func() usecase.VideoPokerInteractorIF {
+		return usecase.NewVideoPokerInteractor(
+			domain.NewDeucesWildVideoPoker(),
+			new(presenter.VideoPokerWebPresenter),
+		)
+	}))
+	web.register("jokerpoker", controller.NewVideoPokerWebController(func() usecase.VideoPokerInteractorIF {
+		return usecase.NewVideoPokerInteractor(
+			domain.NewJokerPokerVideoPoker(),
+			new(presenter.VideoPokerWebPresenter),
+		)
+	}))
+	web.register("euchre", controller.NewEuchreWebController(func() usecase.EuchreInteractorIF {
+		config := domain.DefaultEuchreConfig()
+		players := []*domain.EuchrePlayer{
+			domain.NewEuchrePlayer(true, 0),
+			domain.NewEuchrePlayer(false, 1),
+			domain.NewEuchrePlayer(false, 0),
+			domain.NewEuchrePlayer(false, 1),
+		}
+		euchre := domain.NewEuchre(domain.NewTrumpCardsEuchre(), players, config)
+		return usecase.NewEuchreInteractor(euchre, new(presenter.EuchreWebPresenter))
+	}))
+	web.register("pyramid", controller.NewPyramidWebController(func() usecase.PyramidInteractorIF {
+		pyramid := domain.NewPyramid(domain.NewTrumpCards(0))
+		return usecase.NewPyramidInteractor(pyramid, new(presenter.PyramidWebPresenter))
+	}))
+	web.register("tripeaks", controller.NewTriPeaksWebController(func() usecase.TriPeaksInteractorIF {
+		triPeaks := domain.NewTriPeaks(domain.NewTrumpCards(0))
+		return usecase.NewTriPeaksInteractor(triPeaks, new(presenter.TriPeaksWebPresenter))
+	}))
+	web.register("cribbage", controller.NewCribbageWebController(func() usecase.CribbageInteractorIF {
+		config := domain.DefaultCribbageConfig()
+		players := []*domain.CribbagePlayer{
+			domain.NewCribbagePlayer(true),
+			domain.NewCribbagePlayer(false),
+		}
+		cribbage := domain.NewCribbage(domain.NewTrumpCards(0), players, config)
+		return usecase.NewCribbageInteractor(cribbage, new(presenter.CribbageWebPresenter))
+	}))
+	web.register("threecard", controller.NewThreeCardWebController(func() usecase.ThreeCardInteractorIF {
+		return usecase.NewThreeCardInteractor(
+			domain.NewDefaultThreeCard(),
+			new(presenter.ThreeCardWebPresenter),
+		)
+	}))
+	web.register("ohhell", controller.NewOhHellWebController(func() usecase.OhHellInteractorIF {
+		config := domain.DefaultOhHellConfig()
+		players := []*domain.OhHellPlayer{
+			domain.NewOhHellPlayer(true),
+			domain.NewOhHellPlayer(false),
+			domain.NewOhHellPlayer(false),
+			domain.NewOhHellPlayer(false),
+		}
+		ohHell := domain.NewOhHell(domain.NewTrumpCards(0), players, config)
+		return usecase.NewOhHellInteractor(ohHell, new(presenter.OhHellWebPresenter))
+	}))
+	web.register("bridge", controller.NewBridgeWebController(func() usecase.BridgeInteractorIF {
+		config := domain.DefaultBridgeConfig()
+		players := []*domain.BridgePlayer{
+			domain.NewBridgePlayer(true, 0),
+			domain.NewBridgePlayer(false, 1),
+			domain.NewBridgePlayer(false, 0),
+			domain.NewBridgePlayer(false, 1),
+		}
+		bridge := domain.NewBridge(domain.NewTrumpCards(0), players, config)
+		return usecase.NewBridgeInteractor(bridge, new(presenter.BridgeWebPresenter))
+	}))
+	web.register("pineapple", controller.NewPineappleWebController(func() usecase.PineappleInteractorIF {
+		cfg := domain.DefaultPineappleConfig()
+		pineapple := domain.NewPineapple(domain.NewTrumpCards(0), domain.NewPineapplePlayersForTable(cfg.TableSize), cfg)
+		return usecase.NewPineappleInteractor(pineapple, new(presenter.PineappleWebPresenter))
+	}))
+	web.register("speed", controller.NewSpeedWebController(func() usecase.SpeedInteractorIF {
+		config := domain.DefaultSpeedConfig()
+		players := []*domain.SpeedPlayer{
+			domain.NewSpeedPlayer(true),
+			domain.NewSpeedPlayer(false),
+		}
+		speed := domain.NewSpeed(domain.NewTrumpCards(0), players, config)
+		return usecase.NewSpeedInteractor(speed, new(presenter.SpeedWebPresenter))
+	}))
+	web.register("gofish", controller.NewGoFishWebController(func() usecase.GoFishInteractorIF {
+		players := []*domain.GoFishPlayer{
+			domain.NewGoFishPlayer(true),
+			domain.NewGoFishPlayer(false),
+			domain.NewGoFishPlayer(false),
+			domain.NewGoFishPlayer(false),
+		}
+		goFish := domain.NewGoFish(domain.NewTrumpCards(0), players)
+		return usecase.NewGoFishInteractor(goFish, new(presenter.GoFishWebPresenter))
+	}))
+	web.register("canasta", controller.NewCanastaWebController(func() usecase.CanastaInteractorIF {
+		config := domain.DefaultCanastaConfig()
+		players := []*domain.CanastaPlayer{
+			domain.NewCanastaPlayer(true),
+			domain.NewCanastaPlayer(false),
+		}
+		canasta := domain.NewCanasta(domain.NewTrumpCardsWithDecks(2, 4), players, config)
+		return usecase.NewCanastaInteractor(canasta, new(presenter.CanastaWebPresenter))
+	}))
+	web.register("pinochle", controller.NewPinochleWebController(func() usecase.PinochleInteractorIF {
+		config := domain.DefaultPinochleConfig()
+		players := []*domain.PinochlePlayer{
+			domain.NewPinochlePlayer(true, 0),
+			domain.NewPinochlePlayer(false, 1),
+			domain.NewPinochlePlayer(false, 0),
+			domain.NewPinochlePlayer(false, 1),
+		}
+		pinochle := domain.NewPinochle(domain.NewTrumpCardsPinochle(), players, config)
+		return usecase.NewPinochleInteractor(pinochle, new(presenter.PinochleWebPresenter))
+	}))
+	web.register("golf", controller.NewGolfWebController(func() usecase.GolfInteractorIF {
+		golf := domain.NewGolf(domain.NewTrumpCards(0))
+		return usecase.NewGolfInteractor(golf, new(presenter.GolfWebPresenter))
+	}))
+	web.register("pigtail", controller.NewPigsTailWebController(func() usecase.PigsTailInteractorIF {
+		players := []*domain.PigsTailPlayer{
+			domain.NewPigsTailPlayer(true),
+			domain.NewPigsTailPlayer(false),
+			domain.NewPigsTailPlayer(false),
+			domain.NewPigsTailPlayer(false),
+		}
+		pigsTail := domain.NewPigsTail(domain.NewTrumpCards(0), players)
+		return usecase.NewPigsTailInteractor(pigsTail, new(presenter.PigsTailWebPresenter))
+	}))
+	web.register("sevencardstud", controller.NewSevenCardStudWebController(func() usecase.SevenCardStudInteractorIF {
+		cfg := domain.DefaultSevenCardStudConfig()
+		scs := domain.NewSevenCardStud(domain.NewTrumpCards(0), domain.NewSevenCardStudPlayersForTable(cfg.TableSize), cfg)
+		return usecase.NewSevenCardStudInteractor(scs, new(presenter.SevenCardStudWebPresenter))
+	}))
+	web.register("clocksolitaire", controller.NewClockSolitaireWebController(func() usecase.ClockSolitaireInteractorIF {
+		cs := domain.NewClockSolitaire(domain.NewTrumpCards(0))
+		return usecase.NewClockSolitaireInteractor(cs, new(presenter.ClockSolitaireWebPresenter))
+	}))
+	web.register("durak", controller.NewDurakWebController(func() usecase.DurakInteractorIF {
+		players := []*domain.DurakPlayer{
+			domain.NewDurakPlayer(true),
+			domain.NewDurakPlayer(false),
+			domain.NewDurakPlayer(false),
+			domain.NewDurakPlayer(false),
+		}
+		d := domain.NewDurak(domain.NewTrumpCardsShortDeck(), players)
+		return usecase.NewDurakInteractor(d, new(presenter.DurakWebPresenter))
+	}))
+	web.register("fortythieves", controller.NewFortyThievesWebController(func() usecase.FortyThievesInteractorIF {
+		ft := domain.NewFortyThieves(domain.NewTrumpCardsWithDecks(2, 0))
+		return usecase.NewFortyThievesInteractor(ft, new(presenter.FortyThievesWebPresenter))
+	}))
+	web.register("paigow", controller.NewPaiGowWebController(func() usecase.PaiGowInteractorIF {
+		return usecase.NewPaiGowInteractor(
+			domain.NewDefaultPaiGow(),
+			new(presenter.PaiGowWebPresenter),
+		)
+	}))
+	web.register("twotenjack", controller.NewTwoTenJackWebController(func() usecase.TwoTenJackInteractorIF {
+		config := domain.DefaultTwoTenJackConfig()
+		players := []*domain.TwoTenJackPlayer{
+			domain.NewTwoTenJackPlayer(true),
+			domain.NewTwoTenJackPlayer(false),
+			domain.NewTwoTenJackPlayer(false),
+			domain.NewTwoTenJackPlayer(false),
+		}
+		ttj := domain.NewTwoTenJack(domain.NewTrumpCards(0), players, config)
+		return usecase.NewTwoTenJackInteractor(ttj, new(presenter.TwoTenJackWebPresenter))
+	}))
+	web.register("caribbeanstud", controller.NewCaribbeanStudWebController(func() usecase.CaribbeanStudInteractorIF {
+		return usecase.NewCaribbeanStudInteractor(
+			domain.NewDefaultCaribbeanStud(),
+			new(presenter.CaribbeanStudWebPresenter),
+		)
+	}))
+	web.register("war", controller.NewWarWebController(func() usecase.WarInteractorIF {
+		config := domain.DefaultWarConfig()
+		players := []*domain.WarPlayer{
+			domain.NewWarPlayer(true),
+			domain.NewWarPlayer(false),
+		}
+		war := domain.NewWar(domain.NewTrumpCards(0), players, config)
+		return usecase.NewWarInteractor(war, new(presenter.WarWebPresenter))
+	}))
+	web.register("canfield", controller.NewCanfieldWebController(func() usecase.CanfieldInteractorIF {
+		canfield := domain.NewCanfield(domain.NewTrumpCards(0))
+		return usecase.NewCanfieldInteractor(canfield, new(presenter.CanfieldWebPresenter))
+	}))
 }
 
 // Exec ゲーム実行
 func (web *TrumpCardsWeb) Exec() error {
 	mux := http.NewServeMux()
 
-	type apiRoute struct {
-		path    string
-		handler http.HandlerFunc
-	}
-	routes := []apiRoute{
-		{"/blackjack/exec", web.bjc.Exec},
-		{"/poker/exec", web.pkc.Exec},
-		{"/oldmaid/exec", web.omc.Exec},
-		{"/daifugo/exec", web.dgc.Exec},
-		{"/sevens/exec", web.sgc.Exec},
-		{"/doubt/exec", web.dwc.Exec},
-		{"/holdem/exec", web.hmc.Exec},
-		{"/omaha/exec", web.ohc.Exec},
-		{"/shortdeck/exec", web.skc.Exec},
-		{"/hearts/exec", web.htc.Exec},
-		{"/memory/exec", web.myc.Exec},
-		{"/klondike/exec", web.klc.Exec},
-		{"/freecell/exec", web.fcc.Exec},
-		{"/baccarat/exec", web.bcc.Exec},
-		{"/spades/exec", web.spc.Exec},
-		{"/crazyeights/exec", web.cec.Exec},
-		{"/ginrummy/exec", web.grc.Exec},
-		{"/spider/exec", web.sdc.Exec},
-		{"/napoleon/exec", web.npc.Exec},
-		{"/indianpoker/exec", web.ipc.Exec},
-		{"/videopoker/exec", web.vpc.Exec},
-		{"/deuceswild/exec", web.dwwc.Exec},
-		{"/jokerpoker/exec", web.jpwc.Exec},
-		{"/euchre/exec", web.euc.Exec},
-		{"/pyramid/exec", web.pyc.Exec},
-		{"/tripeaks/exec", web.tpc.Exec},
-		{"/cribbage/exec", web.cbc.Exec},
-		{"/threecard/exec", web.tcc.Exec},
-		{"/ohhell/exec", web.ohlc.Exec},
-		{"/bridge/exec", web.brc.Exec},
-		{"/pineapple/exec", web.pnc.Exec},
-		{"/speed/exec", web.spdc.Exec},
-		{"/gofish/exec", web.gfc.Exec},
-		{"/canasta/exec", web.cnc.Exec},
-		{"/pinochle/exec", web.pinc.Exec},
-		{"/golf/exec", web.glfc.Exec},
-		{"/pigtail/exec", web.ptc.Exec},
-		{"/sevencardstud/exec", web.scsc.Exec},
-		{"/clocksolitaire/exec", web.csc.Exec},
-		{"/durak/exec", web.drc.Exec},
-		{"/fortythieves/exec", web.ftc.Exec},
-		{"/paigow/exec", web.pgc.Exec},
-		{"/twotenjack/exec", web.ttjc.Exec},
-		{"/caribbeanstud/exec", web.cspc.Exec},
-		{"/war/exec", web.warc.Exec},
-		{"/canfield/exec", web.cfc.Exec},
-	}
-	for _, r := range routes {
-		mux.HandleFunc("POST "+r.path, r.handler)
+	for _, g := range web.games {
+		mux.HandleFunc("POST /"+g.name+"/exec", g.controller.Exec)
 	}
 	RegisterSwaggerRoutes(mux)
 	mux.Handle("/", http.FileServer(http.Dir("public")))
@@ -544,48 +469,9 @@ func (web *TrumpCardsWeb) Exec() error {
 		}
 	}
 
-	web.bjc.Stop()
-	web.pkc.Stop()
-	web.omc.Stop()
-	web.dgc.Stop()
-	web.sgc.Stop()
-	web.dwc.Stop()
-	web.hmc.Stop()
-	web.ohc.Stop()
-	web.skc.Stop()
-	web.htc.Stop()
-	web.myc.Stop()
-	web.klc.Stop()
-	web.fcc.Stop()
-	web.bcc.Stop()
-	web.spc.Stop()
-	web.cec.Stop()
-	web.grc.Stop()
-	web.sdc.Stop()
-	web.npc.Stop()
-	web.ipc.Stop()
-	web.vpc.Stop()
-	web.dwwc.Stop()
-	web.jpwc.Stop()
-	web.euc.Stop()
-	web.pyc.Stop()
-	web.cbc.Stop()
-	web.tpc.Stop()
-	web.tcc.Stop()
-	web.ohlc.Stop()
-	web.brc.Stop()
-	web.cnc.Stop()
-	web.pnc.Stop()
-	web.spdc.Stop()
-	web.gfc.Stop()
-	web.pinc.Stop()
-	web.glfc.Stop()
-	web.ptc.Stop()
-	web.scsc.Stop()
-	web.csc.Stop()
-	web.drc.Stop()
-	web.ftc.Stop()
-	web.cspc.Stop()
+	for _, g := range web.games {
+		g.controller.Stop()
+	}
 	fmt.Println(i18n.T("webServerStopped"))
 	slog.Info("server stopped")
 	return runErr


### PR DESCRIPTION
## Summary

- **#1308 useGameHint**: Replaced 37-case switch with `hintFactories` registry map; derived `HintGameName` type from `keyof typeof hintFactories` for type-safe single-source-of-truth
- **#1309 CLI parseSubFlags**: Extracted `parseSubFlags()` helper to consolidate FlagSet creation, parse, ErrHelp check, and extra-args warning across `games`/`update`/`web` subcommands
- **#1310 buildMessage signature**: Unified all 8 poker-family Web Presenters from `(string, string)` to `(string, string, map[string]string)` return, matching the pattern already used by trick-taking games
- **#1311 TrumpCardsWeb registry**: Replaced 46 struct fields + manual route list + manual Stop() list with `[]gameEntry` registry; route registration and shutdown are now simple loops. **Also fixed a bug: 4 controllers (paigow, twotenjack, war, canfield) were never Stop()-ed on shutdown**

Net: **-166 lines** (531 added, 697 removed)

Closes #1308, Closes #1309, Closes #1310, Closes #1311

## Test plan

- [x] `go test -tags test ./internal/...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `bun run test` (frontend) — 307/308 files pass, 4959/4975 tests pass (1 worker OOM crash on low-RAM CI, not a test failure)
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run check` — biome lint clean
- [x] CLI smoke test: `go run ./cmd/trumpcards games --short`, `go run ./cmd/trumpcards web --help`