### PR TITLE
feat(solitaire): CLI move shorthand + Canfield drag-and-drop

### DIFF
--- a/frontend/src/pages/CanfieldPage.test.tsx
+++ b/frontend/src/pages/CanfieldPage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { canfieldApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -180,5 +180,97 @@ describe('CanfieldPage', () => {
         { zone: 'tableau', col: 1 },
       ),
     );
+  });
+
+  describe('drag and drop', () => {
+    function buildDataTransfer() {
+      const store: Record<string, string> = {};
+      return {
+        setData: (type: string, val: string) => {
+          store[type] = val;
+        },
+        getData: (type: string) => store[type] ?? '',
+        effectAllowed: '',
+        dropEffect: '',
+      };
+    }
+
+    it('waste card is draggable when playing', async () => {
+      renderWithProviders(<CanfieldPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+      const wasteImg = screen.getByAltText('♥ 4');
+      const wasteButton = wasteImg.closest('button') as HTMLButtonElement;
+      expect(wasteButton).toHaveAttribute('draggable', 'true');
+    });
+
+    it('reserve card is draggable when playing', async () => {
+      renderWithProviders(<CanfieldPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+      const reserveImg = screen.getByAltText('♠ 3');
+      const reserveButton = reserveImg.closest('button') as HTMLButtonElement;
+      expect(reserveButton).toHaveAttribute('draggable', 'true');
+    });
+
+    it('tableau card is draggable when playing', async () => {
+      renderWithProviders(<CanfieldPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+      const cardImg = screen.getByAltText('♠ 7');
+      const cardButton = cardImg.closest('button') as HTMLButtonElement;
+      expect(cardButton).toHaveAttribute('draggable', 'true');
+    });
+
+    it('dragging waste card to tableau dispatches move', async () => {
+      renderWithProviders(<CanfieldPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+      const wasteImg = screen.getByAltText('♥ 4');
+      const wasteButton = wasteImg.closest('button') as HTMLButtonElement;
+      const dataTransfer = buildDataTransfer();
+
+      fireEvent.dragStart(wasteButton, { dataTransfer });
+
+      // Drop on a tableau column DropZone (use the column header text to find it)
+      const colHeaders = screen.getAllByText(/^#\d$/);
+      const dropZone = colHeaders[1].closest('.flex.flex-col')?.querySelector('[role="presentation"]');
+      mockExec.mockClear();
+      mockExec.mockResolvedValue(playingState);
+      fireEvent.dragOver(dropZone as HTMLElement, { dataTransfer });
+      fireEvent.drop(dropZone as HTMLElement, { dataTransfer });
+
+      await waitFor(() =>
+        expect(mockExec).toHaveBeenCalledWith(
+          'move',
+          expect.objectContaining({ zone: 'waste' }),
+          expect.objectContaining({ zone: 'tableau' }),
+        ),
+      );
+    });
+
+    it('dragging reserve card to foundation dispatches move', async () => {
+      renderWithProviders(<CanfieldPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+      const reserveImg = screen.getByAltText('♠ 3');
+      const reserveButton = reserveImg.closest('button') as HTMLButtonElement;
+      const dataTransfer = buildDataTransfer();
+
+      fireEvent.dragStart(reserveButton, { dataTransfer });
+
+      // Drop on foundation DropZone
+      const foundationTexts = screen.getAllByText('組札');
+      const dropZone = foundationTexts[0].closest('[role="presentation"]');
+      mockExec.mockClear();
+      mockExec.mockResolvedValue(playingState);
+      fireEvent.dragOver(dropZone as HTMLElement, { dataTransfer });
+      fireEvent.drop(dropZone as HTMLElement, { dataTransfer });
+
+      await waitFor(() =>
+        expect(mockExec).toHaveBeenCalledWith(
+          'move',
+          expect.objectContaining({ zone: 'reserve' }),
+          expect.objectContaining({ zone: 'foundation' }),
+        ),
+      );
+    });
   });
 });

--- a/frontend/src/pages/CanfieldPage.tsx
+++ b/frontend/src/pages/CanfieldPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react';
-import { canfieldApi } from '../api/gameApi';
+import { type CanfieldMoveZone, canfieldApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
+import { DropZone } from '../components/DropZone';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
@@ -15,6 +16,7 @@ import { PhaseIndicator } from '../components/PhaseIndicator';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { btnDanger, btnOutline, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import { CanfieldPhase } from '../types/phases';
@@ -67,6 +69,19 @@ export function CanfieldPage() {
 
   const phase = state?.phase ?? CanfieldPhase.PLAYING;
   const isPlaying = phase === CanfieldPhase.PLAYING;
+
+  // Drag-and-drop: dispatches the same move command as button-based interaction.
+  const dispatchMove = useCallback(
+    (source: CanfieldMoveZone, target: CanfieldMoveZone) => {
+      void execApi('move', source, target);
+    },
+    [execApi],
+  );
+  const dnd = useSolitaireDragDrop<CanfieldMoveZone>({
+    onMove: dispatchMove,
+    isPlaying,
+    disabled: loading,
+  });
   const isGameClear = phase === CanfieldPhase.GAME_CLEAR;
   const isEnded = phase === CanfieldPhase.GAME_CLEAR || phase === CanfieldPhase.GAME_OVER;
 
@@ -100,21 +115,31 @@ export function CanfieldPage() {
       <div className="flex-1 overflow-y-auto px-4 pt-3 lg:px-8">
         {/* Foundation */}
         <div className="mb-3 flex gap-2">
-          {state.foundation.map((pile, i) => (
-            <div
-              key={`f-${i}`}
-              className="relative rounded border border-white/30"
-              style={{ width: cardWidth, height: cardHeight }}
-            >
-              {pile.length > 0 ? (
-                <AnimatedCard card={pile[pile.length - 1]} width={cardWidth} />
-              ) : (
-                <span className="absolute inset-0 flex items-center justify-center text-xs text-white/40">
-                  {t('foundation')}
-                </span>
-              )}
-            </div>
-          ))}
+          {state.foundation.map((pile, i) => {
+            const fZone: CanfieldMoveZone = { zone: 'foundation', col: i };
+            return (
+              <DropZone
+                key={`f-${i}`}
+                isDropTarget={dnd.isDropTarget(fZone)}
+                onDragOver={dnd.handleDragOver(fZone)}
+                onDrop={dnd.handleDrop(fZone)}
+                onDragLeave={dnd.handleDragLeave}
+              >
+                <div
+                  className="relative rounded border border-white/30"
+                  style={{ width: cardWidth, height: cardHeight }}
+                >
+                  {pile.length > 0 ? (
+                    <AnimatedCard card={pile[pile.length - 1]} width={cardWidth} />
+                  ) : (
+                    <span className="absolute inset-0 flex items-center justify-center text-xs text-white/40">
+                      {t('foundation')}
+                    </span>
+                  )}
+                </div>
+              </DropZone>
+            );
+          })}
         </div>
 
         {/* Stock / Waste / Reserve */}
@@ -142,7 +167,15 @@ export function CanfieldPage() {
           <div className="flex flex-col items-center">
             <div style={{ width: cardWidth, height: cardHeight }}>
               {topWaste ? (
-                <AnimatedCard card={topWaste} width={cardWidth} />
+                <button
+                  type="button"
+                  draggable={isPlaying && !loading}
+                  onDragStart={dnd.handleDragStart({ zone: 'waste' })}
+                  onDragEnd={dnd.handleDragEnd}
+                  className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${dnd.isDragSource({ zone: 'waste' }) ? 'opacity-50' : ''}`}
+                >
+                  <AnimatedCard card={topWaste} width={cardWidth} draggable={false} />
+                </button>
               ) : (
                 <div
                   className="rounded border border-dashed border-white/30"
@@ -156,7 +189,15 @@ export function CanfieldPage() {
           <div className="flex flex-col items-center">
             <div style={{ width: cardWidth, height: cardHeight }}>
               {topReserve ? (
-                <AnimatedCard card={topReserve} width={cardWidth} />
+                <button
+                  type="button"
+                  draggable={isPlaying && !loading}
+                  onDragStart={dnd.handleDragStart({ zone: 'reserve' })}
+                  onDragEnd={dnd.handleDragEnd}
+                  className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${dnd.isDragSource({ zone: 'reserve' }) ? 'opacity-50' : ''}`}
+                >
+                  <AnimatedCard card={topReserve} width={cardWidth} draggable={false} />
+                </button>
               ) : (
                 <div
                   className="rounded border border-dashed border-white/30"
@@ -172,66 +213,87 @@ export function CanfieldPage() {
 
         {/* Tableau */}
         <div className="mb-3 flex gap-2">
-          {state.tableau.map((col, i) => (
-            <div key={`t-${i}`} className="flex flex-col gap-1">
-              <span className="text-xs text-white/70">#{i}</span>
-              <div className="relative" style={{ width: cardWidth, minHeight: cardHeight }}>
-                {col.length === 0 ? (
-                  <div
-                    className="rounded border border-dashed border-white/30"
-                    style={{ width: cardWidth, height: cardHeight }}
-                  />
-                ) : (
-                  col.map((tc, j) => (
-                    <div key={`t-${i}-${j}`} className="absolute" style={{ top: j * 24, left: 0 }}>
-                      <AnimatedCard card={tc.card} width={cardWidth} />
-                    </div>
-                  ))
+          {state.tableau.map((col, i) => {
+            const tZone: CanfieldMoveZone = { zone: 'tableau', col: i };
+            return (
+              <div key={`t-${i}`} className="flex flex-col gap-1">
+                <span className="text-xs text-white/70">#{i}</span>
+                <DropZone
+                  isDropTarget={dnd.isDropTarget(tZone)}
+                  onDragOver={dnd.handleDragOver(tZone)}
+                  onDrop={dnd.handleDrop(tZone)}
+                  onDragLeave={dnd.handleDragLeave}
+                >
+                  <div className="relative" style={{ width: cardWidth, minHeight: cardHeight }}>
+                    {col.length === 0 ? (
+                      <div
+                        className="rounded border border-dashed border-white/30"
+                        style={{ width: cardWidth, height: cardHeight }}
+                      />
+                    ) : (
+                      col.map((tc, j) => {
+                        const cardZone: CanfieldMoveZone = { zone: 'tableau', col: i, cardIndex: j };
+                        return (
+                          <div key={`t-${i}-${j}`} className="absolute" style={{ top: j * 24, left: 0 }}>
+                            <button
+                              type="button"
+                              draggable={isPlaying && !loading}
+                              onDragStart={dnd.handleDragStart(cardZone)}
+                              onDragEnd={dnd.handleDragEnd}
+                              className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
+                            >
+                              <AnimatedCard card={tc.card} width={cardWidth} draggable={false} />
+                            </button>
+                          </div>
+                        );
+                      })
+                    )}
+                  </div>
+                </DropZone>
+                {isPlaying && (
+                  <div className="flex flex-col gap-1">
+                    <button
+                      type="button"
+                      className={`${btnOutline} ${focusRingWhite} text-xs`}
+                      onClick={() => handleMoveWasteToTableau(i)}
+                      disabled={!topWaste || loading}
+                    >
+                      W→{i}
+                    </button>
+                    <button
+                      type="button"
+                      className={`${btnOutline} ${focusRingWhite} text-xs`}
+                      onClick={() => handleMoveReserveToTableau(i)}
+                      disabled={!topReserve || loading}
+                    >
+                      R→{i}
+                    </button>
+                    <button
+                      type="button"
+                      className={`${btnOutline} ${focusRingWhite} text-xs`}
+                      onClick={() => handleMoveTableauToFoundation(i)}
+                      disabled={col.length === 0 || loading}
+                    >
+                      →F
+                    </button>
+                    {state.tableau.map((_, j) =>
+                      j === i ? null : (
+                        <button
+                          key={`t-${i}-to-${j}`}
+                          type="button"
+                          className={`${btnOutline} ${focusRingWhite} text-xs`}
+                          onClick={() => handleMoveTableauToTableau(i, col.length - 1, j)}
+                          disabled={col.length === 0 || loading}
+                        >
+                          →T{j}
+                        </button>
+                      ),
+                    )}
+                  </div>
                 )}
               </div>
-              {isPlaying && (
-                <div className="flex flex-col gap-1">
-                  <button
-                    type="button"
-                    className={`${btnOutline} ${focusRingWhite} text-xs`}
-                    onClick={() => handleMoveWasteToTableau(i)}
-                    disabled={!topWaste || loading}
-                  >
-                    W→{i}
-                  </button>
-                  <button
-                    type="button"
-                    className={`${btnOutline} ${focusRingWhite} text-xs`}
-                    onClick={() => handleMoveReserveToTableau(i)}
-                    disabled={!topReserve || loading}
-                  >
-                    R→{i}
-                  </button>
-                  <button
-                    type="button"
-                    className={`${btnOutline} ${focusRingWhite} text-xs`}
-                    onClick={() => handleMoveTableauToFoundation(i)}
-                    disabled={col.length === 0 || loading}
-                  >
-                    →F
-                  </button>
-                  {state.tableau.map((_, j) =>
-                    j === i ? null : (
-                      <button
-                        key={`t-${i}-to-${j}`}
-                        type="button"
-                        className={`${btnOutline} ${focusRingWhite} text-xs`}
-                        onClick={() => handleMoveTableauToTableau(i, col.length - 1, j)}
-                        disabled={col.length === 0 || loading}
-                      >
-                        →T{j}
-                      </button>
-                    ),
-                  )}
-                </div>
-              )}
-            </div>
-          ))}
+            );
+          })}
         </div>
 
         <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />

--- a/internal/adapter/controller/CanfieldCuiController.go
+++ b/internal/adapter/controller/CanfieldCuiController.go
@@ -49,6 +49,10 @@ func (c *CanfieldCuiController) handleMove(args []string) string {
 	if len(args) == 0 {
 		return cuiutil.PromptRequest(i18n.T("canfield.promptSourceZone"), "m {0}")
 	}
+	// Shorthand: m <fromCol> [<toCol>] — tableau-to-tableau top card
+	if _, err := strconv.Atoi(args[0]); err == nil {
+		return c.handleMoveShorthand(args)
+	}
 	from := args[0]
 	if from != "w" && from != "t" && from != "r" {
 		return i18n.Tf("canfield.invalidFromZone", "val", from)
@@ -140,4 +144,16 @@ func (c *CanfieldCuiController) handleMoveFromTableau(args []string) string {
 		return i18n.Tf("invalidColumn", "val", args[3])
 	}
 	return c.ci.MoveTableauToTableau(fromCol, cardIdx, toCol)
+}
+
+func (c *CanfieldCuiController) handleMoveShorthand(args []string) string {
+	fromCol, _ := strconv.Atoi(args[0])
+	if len(args) < 2 {
+		return cuiutil.PromptRequest(i18n.T("promptToColumn"), fmt.Sprintf("m %s {0}", args[0]))
+	}
+	toCol, err := strconv.Atoi(args[1])
+	if err != nil {
+		return i18n.Tf("invalidColumn", "val", args[1])
+	}
+	return c.ci.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/CanfieldCuiController_test.go
+++ b/internal/adapter/controller/CanfieldCuiController_test.go
@@ -206,6 +206,31 @@ func TestCanfieldCuiControllerMoveErrors(t *testing.T) {
 	})
 }
 
+func TestCanfieldCuiControllerMoveShorthand(t *testing.T) {
+	t.Run("m <from> <to> moves top card", func(t *testing.T) {
+		ci := newMockCanfieldInteractor()
+		c := NewCanfieldCuiController(ci)
+		ci.On("MoveTableauToTableau", 0, -1, 1).Return("move_output")
+		assert.Equal(t, "move_output", c.Exec("m 0 1"))
+	})
+
+	t.Run("m <from> prompts for destination", func(t *testing.T) {
+		ci := newMockCanfieldInteractor()
+		c := NewCanfieldCuiController(ci)
+		result := c.Exec("m 0")
+		assert.True(t, cuiutil.IsPromptRequest(result))
+		_, tmpl := cuiutil.ParsePromptRequest(result)
+		assert.Equal(t, "m 0 {0}", tmpl)
+	})
+
+	t.Run("m <from> <invalid> returns error", func(t *testing.T) {
+		ci := newMockCanfieldInteractor()
+		c := NewCanfieldCuiController(ci)
+		result := c.Exec("m 0 abc")
+		assert.Contains(t, result, "abc")
+	})
+}
+
 func TestCanfieldCuiControllerUnknown(t *testing.T) {
 	ci := newMockCanfieldInteractor()
 	c := NewCanfieldCuiController(ci)

--- a/internal/adapter/controller/FortyThievesCuiController.go
+++ b/internal/adapter/controller/FortyThievesCuiController.go
@@ -51,6 +51,10 @@ func (c *FortyThievesCuiController) handleMove(args []string) string {
 	if len(args) == 0 {
 		return cuiutil.PromptRequest(i18n.T("fortythieves.promptSourceZone"), "m {0}")
 	}
+	// Shorthand: m <fromCol> [<toCol>] — tableau-to-tableau top card
+	if _, err := strconv.Atoi(args[0]); err == nil {
+		return c.handleMoveShorthand(args)
+	}
 	from := args[0]
 	if from != "w" && from != "t" {
 		return i18n.Tf("fortythieves.invalidFromZone", "val", from)
@@ -125,4 +129,16 @@ func (c *FortyThievesCuiController) handleMoveFromTableau(args []string) string 
 	}
 
 	return c.fi.MoveTableauToTableau(fromCol, cardIdx, toCol)
+}
+
+func (c *FortyThievesCuiController) handleMoveShorthand(args []string) string {
+	fromCol, _ := strconv.Atoi(args[0])
+	if len(args) < 2 {
+		return cuiutil.PromptRequest(i18n.T("promptToColumn"), fmt.Sprintf("m %s {0}", args[0]))
+	}
+	toCol, err := strconv.Atoi(args[1])
+	if err != nil {
+		return i18n.Tf("invalidColumn", "val", args[1])
+	}
+	return c.fi.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/FortyThievesCuiController_test.go
+++ b/internal/adapter/controller/FortyThievesCuiController_test.go
@@ -196,3 +196,28 @@ func TestFortyThievesCuiControllerMoveErrors(t *testing.T) {
 		assert.Contains(t, result, "xyz")
 	})
 }
+
+func TestFortyThievesCuiControllerMoveShorthand(t *testing.T) {
+	t.Run("m <from> <to> moves top card", func(t *testing.T) {
+		fi := newMockFortyThievesInteractor()
+		c := NewFortyThievesCuiController(fi)
+		fi.On("MoveTableauToTableau", 0, -1, 1).Return("move_output")
+		assert.Equal(t, "move_output", c.Exec("m 0 1"))
+	})
+
+	t.Run("m <from> prompts for destination", func(t *testing.T) {
+		fi := newMockFortyThievesInteractor()
+		c := NewFortyThievesCuiController(fi)
+		result := c.Exec("m 0")
+		assert.True(t, cuiutil.IsPromptRequest(result))
+		_, tmpl := cuiutil.ParsePromptRequest(result)
+		assert.Equal(t, "m 0 {0}", tmpl)
+	})
+
+	t.Run("m <from> <invalid> returns error", func(t *testing.T) {
+		fi := newMockFortyThievesInteractor()
+		c := NewFortyThievesCuiController(fi)
+		result := c.Exec("m 0 abc")
+		assert.Contains(t, result, "abc")
+	})
+}

--- a/internal/adapter/controller/FreeCellCuiController.go
+++ b/internal/adapter/controller/FreeCellCuiController.go
@@ -49,6 +49,10 @@ func (c *FreeCellCuiController) handleMove(args []string) string {
 	if len(args) == 0 {
 		return cuiutil.PromptRequest(i18n.T("freecell.promptSourceZone"), "m {0}")
 	}
+	// Shorthand: m <fromCol> [<toCol>] — tableau-to-tableau top card
+	if _, err := strconv.Atoi(args[0]); err == nil {
+		return c.handleMoveShorthand(args)
+	}
 	from := args[0]
 	if from != "t" && from != "c" {
 		return i18n.Tf("freecell.invalidFromZone", "val", from)
@@ -156,4 +160,16 @@ func (c *FreeCellCuiController) handleMoveFromFreeCell(args []string) string {
 	default:
 		return i18n.Tf("freecell.invalidToZone", "val", args[1])
 	}
+}
+
+func (c *FreeCellCuiController) handleMoveShorthand(args []string) string {
+	fromCol, _ := strconv.Atoi(args[0])
+	if len(args) < 2 {
+		return cuiutil.PromptRequest(i18n.T("promptToColumn"), fmt.Sprintf("m %s {0}", args[0]))
+	}
+	toCol, err := strconv.Atoi(args[1])
+	if err != nil {
+		return i18n.Tf("invalidColumn", "val", args[1])
+	}
+	return c.fi.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/FreeCellCuiController_test.go
+++ b/internal/adapter/controller/FreeCellCuiController_test.go
@@ -186,6 +186,31 @@ func TestFreeCellCuiController_MoveTableauCardIdxChainedWizard(t *testing.T) {
 	assert.Equal(t, "m t 0 3 t {0}", tmpl)
 }
 
+func TestFreeCellCuiController_MoveShorthand(t *testing.T) {
+	t.Run("m <from> <to> moves top card", func(t *testing.T) {
+		m := newMockFreeCellInteractor()
+		c := NewFreeCellCuiController(m)
+		m.On("MoveTableauToTableau", 0, -1, 1).Return("move_output")
+		assert.Equal(t, "move_output", c.Exec("m 0 1"))
+	})
+
+	t.Run("m <from> prompts for destination", func(t *testing.T) {
+		m := newMockFreeCellInteractor()
+		c := NewFreeCellCuiController(m)
+		result := c.Exec("m 0")
+		assert.True(t, cuiutil.IsPromptRequest(result))
+		_, tmpl := cuiutil.ParsePromptRequest(result)
+		assert.Equal(t, "m 0 {0}", tmpl)
+	})
+
+	t.Run("m <from> <invalid> returns error", func(t *testing.T) {
+		m := newMockFreeCellInteractor()
+		c := NewFreeCellCuiController(m)
+		result := c.Exec("m 0 abc")
+		assert.Contains(t, result, "abc")
+	})
+}
+
 func TestFreeCellCuiController_UnknownCommand(t *testing.T) {
 	m := newMockFreeCellInteractor()
 	c := NewFreeCellCuiController(m)

--- a/internal/adapter/controller/KlondikeCuiController.go
+++ b/internal/adapter/controller/KlondikeCuiController.go
@@ -58,6 +58,10 @@ func (c *KlondikeCuiController) handleMove(args []string) string {
 	if len(args) == 0 {
 		return cuiutil.PromptRequest(i18n.T("klondike.promptSourceZone"), "m {0}")
 	}
+	// Shorthand: m <fromCol> [<toCol>] — tableau-to-tableau top card
+	if _, err := strconv.Atoi(args[0]); err == nil {
+		return c.handleMoveShorthand(args)
+	}
 	from := args[0]
 	if from != "w" && from != "t" {
 		return i18n.Tf("klondike.invalidFromZone", "val", from)
@@ -133,4 +137,16 @@ func (c *KlondikeCuiController) handleMoveFromTableau(args []string) string {
 	}
 
 	return c.ki.MoveTableauToTableau(fromCol, cardIdx, toCol)
+}
+
+func (c *KlondikeCuiController) handleMoveShorthand(args []string) string {
+	fromCol, _ := strconv.Atoi(args[0])
+	if len(args) < 2 {
+		return cuiutil.PromptRequest(i18n.T("promptToColumn"), fmt.Sprintf("m %s {0}", args[0]))
+	}
+	toCol, err := strconv.Atoi(args[1])
+	if err != nil {
+		return i18n.Tf("invalidColumn", "val", args[1])
+	}
+	return c.ki.MoveTableauToTableau(fromCol, -1, toCol)
 }

--- a/internal/adapter/controller/KlondikeCuiController_test.go
+++ b/internal/adapter/controller/KlondikeCuiController_test.go
@@ -200,6 +200,31 @@ func TestKlondikeCuiControllerMoveErrors(t *testing.T) {
 	})
 }
 
+func TestKlondikeCuiControllerMoveShorthand(t *testing.T) {
+	t.Run("m <from> <to> moves top card", func(t *testing.T) {
+		ki := newMockKlondikeInteractor()
+		c := NewKlondikeCuiController(ki)
+		ki.On("MoveTableauToTableau", 0, -1, 1).Return("move_output")
+		assert.Equal(t, "move_output", c.Exec("m 0 1"))
+	})
+
+	t.Run("m <from> prompts for destination", func(t *testing.T) {
+		ki := newMockKlondikeInteractor()
+		c := NewKlondikeCuiController(ki)
+		result := c.Exec("m 0")
+		assert.True(t, cuiutil.IsPromptRequest(result))
+		_, tmpl := cuiutil.ParsePromptRequest(result)
+		assert.Equal(t, "m 0 {0}", tmpl)
+	})
+
+	t.Run("m <from> <invalid> returns error", func(t *testing.T) {
+		ki := newMockKlondikeInteractor()
+		c := NewKlondikeCuiController(ki)
+		result := c.Exec("m 0 abc")
+		assert.Contains(t, result, "abc")
+	})
+}
+
 func TestKlondikeCuiControllerUnknown(t *testing.T) {
 	ki := newMockKlondikeInteractor()
 	c := NewKlondikeCuiController(ki)

--- a/internal/adapter/controller/SpiderCuiController.go
+++ b/internal/adapter/controller/SpiderCuiController.go
@@ -55,10 +55,15 @@ func (c *SpiderCuiController) Exec(command string) string {
 
 // handleMove 移動コマンドを処理
 // Format: m t <fromCol> <cardIdx> t <toCol>
+// Shorthand: m <fromCol> <toCol> (top card) or m <fromCol> <cardIdx> <toCol>
 func (c *SpiderCuiController) handleMove(args []string) string {
 	// Wizard-style prompts for missing arguments
 	if len(args) == 0 {
 		return cuiutil.PromptRequest(i18n.T("promptFromColumn"), "m t {0}")
+	}
+	// Shorthand: numeric first arg means tableau shorthand
+	if _, err := strconv.Atoi(args[0]); err == nil {
+		return c.handleMoveShorthand(args)
 	}
 	if args[0] != "t" {
 		return i18n.T("spider.moveUsage")
@@ -86,6 +91,31 @@ func (c *SpiderCuiController) handleMove(args []string) string {
 	toCol, err := strconv.Atoi(args[4])
 	if err != nil {
 		return i18n.Tf("invalidColumn", "val", args[4])
+	}
+	return c.si.MoveTableauToTableau(fromCol, cardIdx, toCol)
+}
+
+func (c *SpiderCuiController) handleMoveShorthand(args []string) string {
+	fromCol, _ := strconv.Atoi(args[0])
+	if len(args) < 2 {
+		return cuiutil.PromptRequest(i18n.T("promptToColumn"), fmt.Sprintf("m %s {0}", args[0]))
+	}
+	// m <fromCol> <toCol> — top card move
+	if len(args) == 2 {
+		toCol, err := strconv.Atoi(args[1])
+		if err != nil {
+			return i18n.Tf("invalidColumn", "val", args[1])
+		}
+		return c.si.MoveTableauToTableau(fromCol, -1, toCol)
+	}
+	// m <fromCol> <cardIdx> <toCol>
+	cardIdx, err := strconv.Atoi(args[1])
+	if err != nil {
+		return i18n.Tf("invalidCardIndex", "val", args[1])
+	}
+	toCol, err := strconv.Atoi(args[2])
+	if err != nil {
+		return i18n.Tf("invalidColumn", "val", args[2])
 	}
 	return c.si.MoveTableauToTableau(fromCol, cardIdx, toCol)
 }

--- a/internal/adapter/controller/SpiderCuiController.go
+++ b/internal/adapter/controller/SpiderCuiController.go
@@ -59,7 +59,7 @@ func (c *SpiderCuiController) Exec(command string) string {
 func (c *SpiderCuiController) handleMove(args []string) string {
 	// Wizard-style prompts for missing arguments
 	if len(args) == 0 {
-		return cuiutil.PromptRequest(i18n.T("promptFromColumn"), "m t {0}")
+		return cuiutil.PromptRequest(i18n.T("promptFromColumn"), "m {0}")
 	}
 	// Shorthand: numeric first arg means tableau shorthand
 	if _, err := strconv.Atoi(args[0]); err == nil {

--- a/internal/adapter/controller/SpiderCuiController_test.go
+++ b/internal/adapter/controller/SpiderCuiController_test.go
@@ -183,6 +183,52 @@ func TestSpiderCuiControllerUndo(t *testing.T) {
 	assert.Equal(t, "undo_output", c.Exec("undo"))
 }
 
+func TestSpiderCuiControllerMoveShorthand(t *testing.T) {
+	t.Run("m <from> <to> moves top card", func(t *testing.T) {
+		si := newMockSpiderInteractor()
+		c := NewSpiderCuiController(si)
+		si.On("MoveTableauToTableau", 0, -1, 1).Return("move_output")
+		assert.Equal(t, "move_output", c.Exec("m 0 1"))
+	})
+
+	t.Run("m <from> <idx> <to> moves with card index", func(t *testing.T) {
+		si := newMockSpiderInteractor()
+		c := NewSpiderCuiController(si)
+		si.On("MoveTableauToTableau", 0, 2, 1).Return("move_output")
+		assert.Equal(t, "move_output", c.Exec("m 0 2 1"))
+	})
+
+	t.Run("m <from> prompts for destination", func(t *testing.T) {
+		si := newMockSpiderInteractor()
+		c := NewSpiderCuiController(si)
+		result := c.Exec("m 0")
+		assert.True(t, cuiutil.IsPromptRequest(result))
+		_, tmpl := cuiutil.ParsePromptRequest(result)
+		assert.Equal(t, "m 0 {0}", tmpl)
+	})
+
+	t.Run("m <from> <invalid> returns error", func(t *testing.T) {
+		si := newMockSpiderInteractor()
+		c := NewSpiderCuiController(si)
+		result := c.Exec("m 0 abc")
+		assert.Contains(t, result, "abc")
+	})
+
+	t.Run("m <from> <idx> <invalid> returns error", func(t *testing.T) {
+		si := newMockSpiderInteractor()
+		c := NewSpiderCuiController(si)
+		result := c.Exec("m 0 2 abc")
+		assert.Contains(t, result, "abc")
+	})
+
+	t.Run("m <from> <invalidIdx> <to> returns error", func(t *testing.T) {
+		si := newMockSpiderInteractor()
+		c := NewSpiderCuiController(si)
+		result := c.Exec("m 0 abc 1")
+		assert.Contains(t, result, "abc")
+	})
+}
+
 func TestSpiderCuiControllerUnknown(t *testing.T) {
 	si := newMockSpiderInteractor()
 	c := NewSpiderCuiController(si)


### PR DESCRIPTION
## Summary
- **#1312**: Add numeric shorthand `m <fromCol> <toCol>` for tableau-to-tableau top-card moves across all 5 solitaire CUI controllers (FreeCell, Klondike, Spider, FortyThieves, Canfield). Spider additionally supports `m <from> <idx> <to>` for card-index moves. Single-number input (`m <from>`) triggers the existing wizard prompt for the destination column.
- **#1313**: Integrate `useSolitaireDragDrop` + `DropZone` into CanfieldPage — the only solitaire game missing drag-and-drop. Waste, reserve, foundation, and tableau zones all support drag-and-drop with consistent visual feedback (opacity-50 on drag source, blue ring on drop target).

Closes #1312
Closes #1313

## Test plan
- [x] All 18 new shorthand alias tests pass across 5 CUI controllers
- [x] All 5 new Canfield DnD tests pass (draggable attrs, waste→tableau, reserve→foundation)
- [x] `go test -tags test ./internal/adapter/controller/` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `tsc --noEmit` — clean
- [x] `biome check .` — clean
- [x] `bun run test` — 307/308 files pass (NavBar.test.tsx pre-existing timeout)
- [ ] Manual: CLI `m 0 1` shorthand in klondike/freecell/spider/fortythieves/canfield
- [ ] Manual: Drag cards in Canfield web UI between waste/reserve/foundation/tableau