### PR TITLE
feat(ui): mobile/desktop viewport optimization for game pages

### DIFF
--- a/frontend/src/components/PlayerHandSection.test.tsx
+++ b/frontend/src/components/PlayerHandSection.test.tsx
@@ -50,6 +50,13 @@ describe('PlayerHandSection (desktop)', () => {
     const { container } = render(<PlayerHandSection {...baseProps} isMobile={false} dataTutorialPrefix="sp" />);
     expect(container.querySelector('[data-tutorial="sp-player-hand"]')).toBeInTheDocument();
   });
+
+  it('applies lg:flex-nowrap and lg:overflow-x-auto classes for desktop single-row layout', () => {
+    const { container } = render(<PlayerHandSection {...baseProps} isMobile={false} />);
+    const hand = container.querySelector('[data-tutorial="ht-player-hand"]');
+    expect(hand).toHaveClass('lg:flex-nowrap');
+    expect(hand).toHaveClass('lg:overflow-x-auto');
+  });
 });
 
 describe('PlayerHandSection (mobile)', () => {

--- a/frontend/src/components/PlayerHandSection.tsx
+++ b/frontend/src/components/PlayerHandSection.tsx
@@ -54,7 +54,7 @@ export function PlayerHandSection({
   }
 
   return (
-    <div className="flex flex-wrap gap-1 mb-2" data-tutorial={dataTutorial}>
+    <div className="flex flex-wrap lg:flex-nowrap lg:overflow-x-auto gap-1 mb-2" data-tutorial={dataTutorial}>
       {humanPlayer.cards.map((card, idx) => {
         const isSelected = selectedCardIndices.includes(idx);
         return (

--- a/frontend/src/pages/BaccaratPage.test.tsx
+++ b/frontend/src/pages/BaccaratPage.test.tsx
@@ -470,4 +470,14 @@ describe('BaccaratPage', () => {
     fireEvent.click(checkbox);
     expect(mockSetHintEnabled).toHaveBeenCalledWith(true);
   });
+
+  it('payout table is rendered as a collapsible details element in bet phase', async () => {
+    mockExec.mockResolvedValue(betPhaseState);
+    const { container } = renderWithProviders(<BaccaratPage />);
+    await waitFor(() => expect(screen.getByText('配当表')).toBeInTheDocument());
+    const details = container.querySelector('details');
+    expect(details).toBeInTheDocument();
+    const summary = details?.querySelector('summary');
+    expect(summary).toHaveTextContent('配当表');
+  });
 });

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -277,14 +277,16 @@ function BaccaratPageContent() {
             {isBetPhase && state.playerHand.length === 0 && (
               <div className="flex flex-col items-center justify-center py-6 gap-4">
                 <p className="text-white/50 text-lg">{t('betGuide')}</p>
-                <div className="bg-black/30 rounded-lg p-4 w-full max-w-sm">
-                  <div className="text-white font-bold text-sm mb-2">{t('payoutRef.title')}</div>
-                  <ul className="text-white/70 text-sm space-y-1">
+                <details className="bg-black/30 rounded-lg w-full max-w-sm">
+                  <summary className="cursor-pointer select-none px-4 py-2 text-white font-bold text-sm">
+                    {t('payoutRef.title')}
+                  </summary>
+                  <ul className="text-white/70 text-sm space-y-1 px-4 pb-3">
                     {(['playerWin', 'bankerWin', 'tie', 'playerPair', 'bankerPair'] as const).map((key) => (
                       <li key={key}>{t(`payoutRef.${key}`)}</li>
                     ))}
                   </ul>
-                </div>
+                </details>
               </div>
             )}
             <GameMessageBox

--- a/frontend/src/pages/BridgePage.test.tsx
+++ b/frontend/src/pages/BridgePage.test.tsx
@@ -427,4 +427,37 @@ describe('BridgePage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'スキップ' }));
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
   });
+
+  it('renders CPU info as collapsible details on mobile', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      const { container } = renderWithProviders(<BridgePage />);
+      await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+      const allDetails = container.querySelectorAll('details');
+      const cpuDetails = Array.from(allDetails).find((d) =>
+        d.querySelector('summary')?.textContent?.includes('CPU対戦相手'),
+      );
+      expect(cpuDetails).toBeInTheDocument();
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
+
+  it('renders score table as collapsible details on mobile', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      const { container } = renderWithProviders(<BridgePage />);
+      await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+      const scoreDetails = container.querySelector('details[data-tutorial="br-team-scores"]');
+      expect(scoreDetails).toBeInTheDocument();
+      const summary = scoreDetails?.querySelector('summary');
+      expect(summary).toHaveTextContent('チームスコア');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
 });

--- a/frontend/src/pages/BridgePage.tsx
+++ b/frontend/src/pages/BridgePage.tsx
@@ -376,46 +376,99 @@ function BridgePageContent() {
               {/* Right: info sidebar */}
               <div>
                 {/* CPU players */}
-                {state.players
-                  .filter((p) => !p.isHuman)
-                  .map((p) => (
-                    <div key={p.id} className="mb-2 p-2 rounded bg-black/30">
-                      <div className="text-white/70 text-sm">
-                        {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} | {t('team', { n: p.team })}{' '}
-                        | {t('trickCount', { count: p.trickCount })}
-                        {state.dealerIdx === p.id ? ` | ${t('dealer')}` : ''}
-                        {state.declarerIdx === p.id ? ` | ${t('declarer')}` : ''}
-                        {state.dummyIdx === p.id ? ` | ${t('dummy')}` : ''}
-                      </div>
+                {isMobile ? (
+                  <details className="mb-2 p-2 rounded bg-black/30">
+                    <summary className="cursor-pointer select-none text-white/70 text-sm">
+                      {tc('game.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
+                    </summary>
+                    <div className="mt-1">
+                      {state.players
+                        .filter((p) => !p.isHuman)
+                        .map((p) => (
+                          <div key={p.id} className="text-white/70 text-sm py-0.5">
+                            {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
+                            {t('team', { n: p.team })} | {t('trickCount', { count: p.trickCount })}
+                            {state.dealerIdx === p.id ? ` | ${t('dealer')}` : ''}
+                            {state.declarerIdx === p.id ? ` | ${t('declarer')}` : ''}
+                            {state.dummyIdx === p.id ? ` | ${t('dummy')}` : ''}
+                          </div>
+                        ))}
                     </div>
-                  ))}
+                  </details>
+                ) : (
+                  state.players
+                    .filter((p) => !p.isHuman)
+                    .map((p) => (
+                      <div key={p.id} className="mb-2 p-2 rounded bg-black/30">
+                        <div className="text-white/70 text-sm">
+                          {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
+                          {t('team', { n: p.team })} | {t('trickCount', { count: p.trickCount })}
+                          {state.dealerIdx === p.id ? ` | ${t('dealer')}` : ''}
+                          {state.declarerIdx === p.id ? ` | ${t('declarer')}` : ''}
+                          {state.dummyIdx === p.id ? ` | ${t('dummy')}` : ''}
+                        </div>
+                      </div>
+                    ))
+                )}
 
                 {/* Team scores */}
-                <div className="my-3 p-2 rounded bg-black/30" data-tutorial="br-team-scores">
-                  <div className="text-white/70 text-sm mb-1">{t('teamScores')}</div>
-                  <table className="w-full text-sm text-white/70">
-                    <thead>
-                      <tr>
-                        <th scope="col" className="text-left">
-                          {t('team', { n: '' })}
-                        </th>
-                        <th scope="col">{tc('button.score', { defaultValue: 'Score' })}</th>
-                        <th scope="col">{t('gamesWon')}</th>
-                        <th scope="col">{t('belowLine')}</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {state.teamScores.map((score, idx) => (
-                        <tr key={idx} className={idx === humanTeam ? 'text-ds-accent' : ''}>
-                          <td>{idx === humanTeam ? t('teamYou', { n: idx }) : t('team', { n: idx })}</td>
-                          <td className="text-center">{score}</td>
-                          <td className="text-center">{state.gamesWon[idx]}</td>
-                          <td className="text-center">{state.belowLine[idx]}</td>
+                {isMobile ? (
+                  <details
+                    className="my-3 p-2 rounded bg-black/30"
+                    data-tutorial="br-team-scores"
+                    open={isRoundEnd || isGameEnd || undefined}
+                  >
+                    <summary className="cursor-pointer select-none text-white/70 text-sm">{t('teamScores')}</summary>
+                    <table className="w-full text-sm text-white/70 mt-1">
+                      <thead>
+                        <tr>
+                          <th scope="col" className="text-left">
+                            {t('team', { n: '' })}
+                          </th>
+                          <th scope="col">{tc('button.score', { defaultValue: 'Score' })}</th>
+                          <th scope="col">{t('gamesWon')}</th>
+                          <th scope="col">{t('belowLine')}</th>
                         </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
+                      </thead>
+                      <tbody>
+                        {state.teamScores.map((score, idx) => (
+                          <tr key={idx} className={idx === humanTeam ? 'text-ds-accent' : ''}>
+                            <td>{idx === humanTeam ? t('teamYou', { n: idx }) : t('team', { n: idx })}</td>
+                            <td className="text-center">{score}</td>
+                            <td className="text-center">{state.gamesWon[idx]}</td>
+                            <td className="text-center">{state.belowLine[idx]}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </details>
+                ) : (
+                  <div className="my-3 p-2 rounded bg-black/30" data-tutorial="br-team-scores">
+                    <div className="text-white/70 text-sm mb-1">{t('teamScores')}</div>
+                    <table className="w-full text-sm text-white/70">
+                      <thead>
+                        <tr>
+                          <th scope="col" className="text-left">
+                            {t('team', { n: '' })}
+                          </th>
+                          <th scope="col">{tc('button.score', { defaultValue: 'Score' })}</th>
+                          <th scope="col">{t('gamesWon')}</th>
+                          <th scope="col">{t('belowLine')}</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {state.teamScores.map((score, idx) => (
+                          <tr key={idx} className={idx === humanTeam ? 'text-ds-accent' : ''}>
+                            <td>{idx === humanTeam ? t('teamYou', { n: idx }) : t('team', { n: idx })}</td>
+                            <td className="text-center">{score}</td>
+                            <td className="text-center">{state.gamesWon[idx]}</td>
+                            <td className="text-center">{state.belowLine[idx]}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
               </div>
             </div>
 
@@ -480,7 +533,7 @@ function BridgePageContent() {
               </div>
             )}
 
-            <div className="flex gap-2 items-center flex-wrap" data-tutorial="br-play-button">
+            <div className="flex gap-1 items-center flex-wrap" data-tutorial="br-play-button">
               {(isHumanBidTurn || isHumanTurn) && (
                 <button type="button" className={btnSuccess} onClick={handleHint} disabled={loading || hintLoading}>
                   {tc('button.hint')}
@@ -489,9 +542,9 @@ function BridgePageContent() {
 
               {/* Bid phase controls */}
               {isHumanBidTurn && (
-                <span data-tutorial="br-bid-controls" className="flex gap-2 items-center flex-wrap">
+                <span data-tutorial="br-bid-controls" className="flex gap-1 items-center flex-wrap">
                   <select
-                    className="text-sm rounded bg-black/50 text-white px-2 py-1"
+                    className="text-xs rounded bg-black/50 text-white px-1.5 py-0.5"
                     value={bidLevel}
                     onChange={(e) => setBidLevel(Number(e.target.value))}
                     aria-label={t('bidLevel')}
@@ -503,7 +556,7 @@ function BridgePageContent() {
                     ))}
                   </select>
                   <select
-                    className="text-sm rounded bg-black/50 text-white px-2 py-1"
+                    className="text-xs rounded bg-black/50 text-white px-1.5 py-0.5"
                     value={bidSuit}
                     onChange={(e) => setBidSuit(Number(e.target.value))}
                     aria-label={t('bidSuit')}

--- a/frontend/src/pages/BridgePage.tsx
+++ b/frontend/src/pages/BridgePage.tsx
@@ -379,7 +379,7 @@ function BridgePageContent() {
                 {isMobile ? (
                   <details className="mb-2 p-2 rounded bg-black/30">
                     <summary className="cursor-pointer select-none text-white/70 text-sm">
-                      {tc('game.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
+                      {tc('label.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
                     </summary>
                     <div className="mt-1">
                       {state.players

--- a/frontend/src/pages/EuchrePage.test.tsx
+++ b/frontend/src/pages/EuchrePage.test.tsx
@@ -822,4 +822,37 @@ describe('EuchrePage', () => {
       Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
     }
   });
+
+  it('renders CPU info as collapsible details on mobile', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      const { container } = renderWithProviders(<EuchrePage />);
+      await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+      const allDetails = container.querySelectorAll('details');
+      const cpuDetails = Array.from(allDetails).find((d) =>
+        d.querySelector('summary')?.textContent?.includes('CPU対戦相手'),
+      );
+      expect(cpuDetails).toBeInTheDocument();
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
+
+  it('renders score table as collapsible details on mobile', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      const { container } = renderWithProviders(<EuchrePage />);
+      await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+      const scoreDetails = container.querySelector('details[data-tutorial="eu-score-table"]');
+      expect(scoreDetails).toBeInTheDocument();
+      const summary = scoreDetails?.querySelector('summary');
+      expect(summary).toHaveTextContent('チームスコア');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
 });

--- a/frontend/src/pages/EuchrePage.tsx
+++ b/frontend/src/pages/EuchrePage.tsx
@@ -343,40 +343,87 @@ function EuchrePageContent() {
               {/* Right: info sidebar */}
               <div>
                 {/* CPU players */}
-                {state.players
-                  .filter((p) => !p.isHuman)
-                  .map((p) => (
-                    <div key={p.id} className="mb-2 p-2 rounded bg-black/30">
-                      <div className="text-white/70 text-sm">
-                        {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} | {t('team', { n: p.team })}{' '}
-                        | {t('trickCount', { count: p.trickCount })}
-                        {state.dealerIdx === p.id ? ` | ${t('dealer')}` : ''}
-                      </div>
+                {isMobile ? (
+                  <details className="mb-2 p-2 rounded bg-black/30">
+                    <summary className="cursor-pointer select-none text-white/70 text-sm">
+                      {tc('game.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
+                    </summary>
+                    <div className="mt-1">
+                      {state.players
+                        .filter((p) => !p.isHuman)
+                        .map((p) => (
+                          <div key={p.id} className="text-white/70 text-sm py-0.5">
+                            {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
+                            {t('team', { n: p.team })} | {t('trickCount', { count: p.trickCount })}
+                            {state.dealerIdx === p.id ? ` | ${t('dealer')}` : ''}
+                          </div>
+                        ))}
                     </div>
-                  ))}
+                  </details>
+                ) : (
+                  state.players
+                    .filter((p) => !p.isHuman)
+                    .map((p) => (
+                      <div key={p.id} className="mb-2 p-2 rounded bg-black/30">
+                        <div className="text-white/70 text-sm">
+                          {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
+                          {t('team', { n: p.team })} | {t('trickCount', { count: p.trickCount })}
+                          {state.dealerIdx === p.id ? ` | ${t('dealer')}` : ''}
+                        </div>
+                      </div>
+                    ))
+                )}
 
                 {/* Team scores */}
-                <div className="my-3 p-2 rounded bg-black/30" data-tutorial="eu-score-table">
-                  <div className="text-white/70 text-sm mb-1">{t('teamScores')}</div>
-                  <table className="w-full text-sm text-white/70">
-                    <thead>
-                      <tr>
-                        <th scope="col" className="text-left">
-                          {t('team', { n: '' })}
-                        </th>
-                        <th scope="col">{tc('button.score', { defaultValue: 'Score' })}</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {state.teamScores.map((score, idx) => (
-                        <tr key={idx} className={idx === humanTeam ? 'text-ds-accent' : ''}>
-                          <td>{idx === humanTeam ? t('teamYou', { n: idx }) : t('team', { n: idx })}</td>
-                          <td className="text-center">{score}</td>
+                {isMobile ? (
+                  <details
+                    className="my-3 p-2 rounded bg-black/30"
+                    data-tutorial="eu-score-table"
+                    open={isRoundEnd || isGameEnd || undefined}
+                  >
+                    <summary className="cursor-pointer select-none text-white/70 text-sm">{t('teamScores')}</summary>
+                    <table className="w-full text-sm text-white/70 mt-1">
+                      <thead>
+                        <tr>
+                          <th scope="col" className="text-left">
+                            {t('team', { n: '' })}
+                          </th>
+                          <th scope="col">{tc('button.score', { defaultValue: 'Score' })}</th>
                         </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
+                      </thead>
+                      <tbody>
+                        {state.teamScores.map((score, idx) => (
+                          <tr key={idx} className={idx === humanTeam ? 'text-ds-accent' : ''}>
+                            <td>{idx === humanTeam ? t('teamYou', { n: idx }) : t('team', { n: idx })}</td>
+                            <td className="text-center">{score}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </details>
+                ) : (
+                  <div className="my-3 p-2 rounded bg-black/30" data-tutorial="eu-score-table">
+                    <div className="text-white/70 text-sm mb-1">{t('teamScores')}</div>
+                    <table className="w-full text-sm text-white/70">
+                      <thead>
+                        <tr>
+                          <th scope="col" className="text-left">
+                            {t('team', { n: '' })}
+                          </th>
+                          <th scope="col">{tc('button.score', { defaultValue: 'Score' })}</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {state.teamScores.map((score, idx) => (
+                          <tr key={idx} className={idx === humanTeam ? 'text-ds-accent' : ''}>
+                            <td>{idx === humanTeam ? t('teamYou', { n: idx }) : t('team', { n: idx })}</td>
+                            <td className="text-center">{score}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
               </div>
             </div>
 

--- a/frontend/src/pages/EuchrePage.tsx
+++ b/frontend/src/pages/EuchrePage.tsx
@@ -346,7 +346,7 @@ function EuchrePageContent() {
                 {isMobile ? (
                   <details className="mb-2 p-2 rounded bg-black/30">
                     <summary className="cursor-pointer select-none text-white/70 text-sm">
-                      {tc('game.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
+                      {tc('label.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
                     </summary>
                     <div className="mt-1">
                       {state.players

--- a/frontend/src/pages/HeartsPage.test.tsx
+++ b/frontend/src/pages/HeartsPage.test.tsx
@@ -772,4 +772,40 @@ describe('HeartsPage', () => {
       Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
     }
   });
+
+  it('renders CPU info as collapsible details on mobile', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    window.dispatchEvent(new Event('resize'));
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      const { container } = renderWithProviders(<HeartsPage />);
+      await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+      await waitFor(() => {
+        const allDetails = container.querySelectorAll('details');
+        const cpuDetails = Array.from(allDetails).find((d) =>
+          d.querySelector('summary')?.textContent?.includes('CPU対戦相手'),
+        );
+        expect(cpuDetails).toBeTruthy();
+      });
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
+
+  it('renders score table as collapsible details on mobile', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      const { container } = renderWithProviders(<HeartsPage />);
+      await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+      const scoreDetails = container.querySelector('details[data-tutorial="ht-score-table"]');
+      expect(scoreDetails).toBeInTheDocument();
+      const summary = scoreDetails?.querySelector('summary');
+      expect(summary).toHaveTextContent('スコア');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
 });

--- a/frontend/src/pages/HeartsPage.tsx
+++ b/frontend/src/pages/HeartsPage.tsx
@@ -288,44 +288,95 @@ function HeartsPageContent() {
               {/* Right: info sidebar */}
               <div>
                 {/* CPU players */}
-                {state.players
-                  .filter((p) => !p.isHuman)
-                  .map((p) => (
-                    <div key={p.id} className="mb-2 p-2 rounded bg-black/30">
-                      <div className="text-white/70 text-sm">
-                        {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
-                        {t('cumulativeScore', { score: p.cumulativeScore })} |{' '}
-                        {t('roundScore', { score: p.roundScore })}
-                      </div>
+                {isMobile ? (
+                  <details className="mb-2 p-2 rounded bg-black/30">
+                    <summary className="cursor-pointer select-none text-white/70 text-sm">
+                      {tc('game.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
+                    </summary>
+                    <div className="mt-1">
+                      {state.players
+                        .filter((p) => !p.isHuman)
+                        .map((p) => (
+                          <div key={p.id} className="text-white/70 text-sm py-0.5">
+                            {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
+                            {t('cumulativeScore', { score: p.cumulativeScore })} |{' '}
+                            {t('roundScore', { score: p.roundScore })}
+                          </div>
+                        ))}
                     </div>
-                  ))}
+                  </details>
+                ) : (
+                  state.players
+                    .filter((p) => !p.isHuman)
+                    .map((p) => (
+                      <div key={p.id} className="mb-2 p-2 rounded bg-black/30">
+                        <div className="text-white/70 text-sm">
+                          {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
+                          {t('cumulativeScore', { score: p.cumulativeScore })} |{' '}
+                          {t('roundScore', { score: p.roundScore })}
+                        </div>
+                      </div>
+                    ))
+                )}
 
                 {/* Score table */}
-                <div className="my-3 p-2 rounded bg-black/30" data-tutorial="ht-score-table">
-                  <div className="text-white/70 text-sm mb-1">{t('scores')}</div>
-                  <table className="w-full text-sm text-white/70">
-                    <thead>
-                      <tr>
-                        <th scope="col" className="text-left">
-                          {t('scoresPlayer')}
-                        </th>
-                        <th scope="col">{t('scoresRound')}</th>
-                        <th scope="col">{t('scoresTotal')}</th>
-                        <th scope="col">{t('scoresTricks')}</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {state.players.map((p) => (
-                        <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
-                          <td>{playerName(p.id, p.isHuman)}</td>
-                          <td className="text-center">{p.roundScore}</td>
-                          <td className="text-center">{p.cumulativeScore}</td>
-                          <td className="text-center">{p.trickCount}</td>
+                {isMobile ? (
+                  <details
+                    className="my-3 p-2 rounded bg-black/30"
+                    data-tutorial="ht-score-table"
+                    open={isRoundEnd || isGameEnd || undefined}
+                  >
+                    <summary className="cursor-pointer select-none text-white/70 text-sm">{t('scores')}</summary>
+                    <table className="w-full text-sm text-white/70 mt-1">
+                      <thead>
+                        <tr>
+                          <th scope="col" className="text-left">
+                            {t('scoresPlayer')}
+                          </th>
+                          <th scope="col">{t('scoresRound')}</th>
+                          <th scope="col">{t('scoresTotal')}</th>
+                          <th scope="col">{t('scoresTricks')}</th>
                         </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
+                      </thead>
+                      <tbody>
+                        {state.players.map((p) => (
+                          <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
+                            <td>{playerName(p.id, p.isHuman)}</td>
+                            <td className="text-center">{p.roundScore}</td>
+                            <td className="text-center">{p.cumulativeScore}</td>
+                            <td className="text-center">{p.trickCount}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </details>
+                ) : (
+                  <div className="my-3 p-2 rounded bg-black/30" data-tutorial="ht-score-table">
+                    <div className="text-white/70 text-sm mb-1">{t('scores')}</div>
+                    <table className="w-full text-sm text-white/70">
+                      <thead>
+                        <tr>
+                          <th scope="col" className="text-left">
+                            {t('scoresPlayer')}
+                          </th>
+                          <th scope="col">{t('scoresRound')}</th>
+                          <th scope="col">{t('scoresTotal')}</th>
+                          <th scope="col">{t('scoresTricks')}</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {state.players.map((p) => (
+                          <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
+                            <td>{playerName(p.id, p.isHuman)}</td>
+                            <td className="text-center">{p.roundScore}</td>
+                            <td className="text-center">{p.cumulativeScore}</td>
+                            <td className="text-center">{p.trickCount}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
                 <RoundScoreAnnouncement
                   active={isRoundEnd || isGameEnd}
                   entries={state.players.map((p) => ({

--- a/frontend/src/pages/HeartsPage.tsx
+++ b/frontend/src/pages/HeartsPage.tsx
@@ -291,7 +291,7 @@ function HeartsPageContent() {
                 {isMobile ? (
                   <details className="mb-2 p-2 rounded bg-black/30">
                     <summary className="cursor-pointer select-none text-white/70 text-sm">
-                      {tc('game.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
+                      {tc('label.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
                     </summary>
                     <div className="mt-1">
                       {state.players

--- a/frontend/src/pages/HoldemPage.test.tsx
+++ b/frontend/src/pages/HoldemPage.test.tsx
@@ -1468,4 +1468,13 @@ describe('HoldemPage', () => {
       expect(stickyDiv).toHaveClass('sticky');
     });
   });
+
+  it('wraps settings in collapsible details element', async () => {
+    mockExec.mockResolvedValue(preFlopState);
+    const { container } = renderWithProviders(<HoldemPage />);
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+    const allSummaries = container.querySelectorAll('details summary');
+    const settingsSummary = Array.from(allSummaries).find((s) => s.textContent?.includes('設定'));
+    expect(settingsSummary).toBeTruthy();
+  });
 });

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -347,28 +347,6 @@ function HoldemPageContent() {
 
           {/* Sticky footer: player hand + buttons */}
           <GameFooter className={`${gameTheme.holdem.footer} px-5 py-3`}>
-            {/* Learning mode toggle */}
-            <div
-              className="flex items-center gap-2 mb-2"
-              data-testid="learning-mode-toggle"
-              data-tutorial="he-learning-mode"
-            >
-              <label htmlFor="learningModeCheckbox" className="text-white text-sm cursor-pointer">
-                {t('learning.toggle')}
-              </label>
-              <input
-                id="learningModeCheckbox"
-                type="checkbox"
-                checked={learningMode}
-                onChange={(e) => setLearningMode(e.target.checked)}
-              />
-            </div>
-
-            {/* Equity display */}
-            {learningMode && state?.equity && state.potOdds != null && (
-              <EquityDisplay equity={state.equity} potOdds={state.potOdds} />
-            )}
-
             {/* Human player */}
             {humanPlayer && (
               <div className="mb-2" data-tutorial="he-player-hand">
@@ -528,15 +506,38 @@ function HoldemPageContent() {
             )}
 
             {/* Settings + Reset */}
-            <div className="text-center flex items-center justify-center gap-3" data-tutorial="he-reset-button">
-              <label className="text-white text-sm flex items-center gap-1">
-                <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
-                {tc('hint.toggle', { ns: 'tutorial' })}
-              </label>
-              <label className="text-white text-sm flex items-center gap-1">
-                <input type="checkbox" checked={cpuMetaAI} onChange={(e) => setCpuMetaAI(e.target.checked)} />
-                {t('settings.cpuMetaAI')}
-              </label>
+            <details className="mb-1" data-tutorial="he-learning-mode">
+              <summary className="cursor-pointer select-none text-white text-sm font-bold py-1">
+                {tc('settings.title')}
+              </summary>
+              <div className="flex flex-col gap-2 py-1">
+                <div className="flex items-center gap-2" data-testid="learning-mode-toggle">
+                  <label htmlFor="learningModeCheckbox" className="text-white text-sm cursor-pointer">
+                    {t('learning.toggle')}
+                  </label>
+                  <input
+                    id="learningModeCheckbox"
+                    type="checkbox"
+                    checked={learningMode}
+                    onChange={(e) => setLearningMode(e.target.checked)}
+                  />
+                </div>
+                {learningMode && state?.equity && state.potOdds != null && (
+                  <EquityDisplay equity={state.equity} potOdds={state.potOdds} />
+                )}
+                <div className="flex items-center gap-3">
+                  <label className="text-white text-sm flex items-center gap-1">
+                    <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
+                    {tc('hint.toggle', { ns: 'tutorial' })}
+                  </label>
+                  <label className="text-white text-sm flex items-center gap-1">
+                    <input type="checkbox" checked={cpuMetaAI} onChange={(e) => setCpuMetaAI(e.target.checked)} />
+                    {t('settings.cpuMetaAI')}
+                  </label>
+                </div>
+              </div>
+            </details>
+            <div className="text-center" data-tutorial="he-reset-button">
               <button
                 type="button"
                 className={`${btnOutline} min-w-[90px]`}

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -506,7 +506,7 @@ function HoldemPageContent() {
             )}
 
             {/* Settings + Reset */}
-            <details className="mb-1" data-tutorial="he-learning-mode">
+            <details className="mb-1" data-tutorial="he-learning-mode" open={learningMode || undefined}>
               <summary className="cursor-pointer select-none text-white text-sm font-bold py-1">
                 {tc('settings.title')}
               </summary>

--- a/frontend/src/pages/NapoleonPage.test.tsx
+++ b/frontend/src/pages/NapoleonPage.test.tsx
@@ -1095,4 +1095,37 @@ describe('NapoleonPage', () => {
       Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
     }
   });
+
+  it('renders CPU info as collapsible details on mobile', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      const { container } = renderWithProviders(<NapoleonPage />);
+      await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+      const allDetails = container.querySelectorAll('details');
+      const cpuDetails = Array.from(allDetails).find((d) =>
+        d.querySelector('summary')?.textContent?.includes('CPU対戦相手'),
+      );
+      expect(cpuDetails).toBeInTheDocument();
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
+
+  it('renders score table as collapsible details on mobile', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      const { container } = renderWithProviders(<NapoleonPage />);
+      await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+      const scoreDetails = container.querySelector('details[data-tutorial="np-score-table"]');
+      expect(scoreDetails).toBeInTheDocument();
+      const summary = scoreDetails?.querySelector('summary');
+      expect(summary).toHaveTextContent('スコア');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
 });

--- a/frontend/src/pages/NapoleonPage.tsx
+++ b/frontend/src/pages/NapoleonPage.tsx
@@ -373,62 +373,130 @@ function NapoleonPageContent() {
               {/* Right: info sidebar */}
               <div>
                 {/* CPU players */}
-                {state.players
-                  .filter((p) => !p.isHuman)
-                  .map((p) => (
-                    <div key={p.id} className="mb-2 p-2 rounded bg-black/30">
-                      <div className="text-white/70 text-sm">
-                        {playerName(p.id, p.isHuman)}
-                        {roleBadge(p)}: {t('cards', { count: p.cardCount })} |{' '}
-                        {t('cumulativeScore', { score: p.cumulativeScore })} |{' '}
-                        {t('roundScore', { score: p.roundScore })} |{' '}
-                        {p.bid >= 0 ? t('bid', { n: p.bid }) : t('bidNone')} |{' '}
-                        {t('pictureCards', { count: p.pictureCards })}
-                      </div>
+                {isMobile ? (
+                  <details className="mb-2 p-2 rounded bg-black/30">
+                    <summary className="cursor-pointer select-none text-white/70 text-sm">
+                      {tc('game.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
+                    </summary>
+                    <div className="mt-1">
+                      {state.players
+                        .filter((p) => !p.isHuman)
+                        .map((p) => (
+                          <div key={p.id} className="text-white/70 text-sm py-0.5">
+                            {playerName(p.id, p.isHuman)}
+                            {roleBadge(p)}: {t('cards', { count: p.cardCount })} |{' '}
+                            {t('cumulativeScore', { score: p.cumulativeScore })} |{' '}
+                            {t('roundScore', { score: p.roundScore })} |{' '}
+                            {p.bid >= 0 ? t('bid', { n: p.bid }) : t('bidNone')} |{' '}
+                            {t('pictureCards', { count: p.pictureCards })}
+                          </div>
+                        ))}
                     </div>
-                  ))}
+                  </details>
+                ) : (
+                  state.players
+                    .filter((p) => !p.isHuman)
+                    .map((p) => (
+                      <div key={p.id} className="mb-2 p-2 rounded bg-black/30">
+                        <div className="text-white/70 text-sm">
+                          {playerName(p.id, p.isHuman)}
+                          {roleBadge(p)}: {t('cards', { count: p.cardCount })} |{' '}
+                          {t('cumulativeScore', { score: p.cumulativeScore })} |{' '}
+                          {t('roundScore', { score: p.roundScore })} |{' '}
+                          {p.bid >= 0 ? t('bid', { n: p.bid }) : t('bidNone')} |{' '}
+                          {t('pictureCards', { count: p.pictureCards })}
+                        </div>
+                      </div>
+                    ))
+                )}
 
                 {/* Score table */}
-                <div className="my-3 p-2 rounded bg-black/30 relative" data-tutorial="np-score-table">
-                  <div className="text-white/70 text-sm mb-1">{t('scores')}</div>
-                  <div className="overflow-x-auto -mx-2 px-2">
-                    <table className="w-full text-sm text-white/70 min-w-[420px]">
-                      <thead>
-                        <tr>
-                          <th scope="col" className="text-left">
-                            {t('scoresPlayer')}
-                          </th>
-                          <th scope="col">{t('scoresRole')}</th>
-                          <th scope="col">{t('scoresBid')}</th>
-                          <th scope="col">{t('scoresPictureCards')}</th>
-                          <th scope="col">{t('scoresTricks')}</th>
-                          <th scope="col">{t('scoresRound')}</th>
-                          <th scope="col">{t('scoresTotal')}</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {state.players.map((p) => (
-                          <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
-                            <td>{playerName(p.id, p.isHuman)}</td>
-                            <td className="text-center">
-                              {p.isNapoleon
-                                ? t('role.napoleon')
-                                : p.isAdjutant && (p.adjutantRevealed || state.adjutantRevealed)
-                                  ? t('role.adjutant')
-                                  : '-'}
-                            </td>
-                            <td className="text-center">{p.bid >= 0 ? p.bid : '-'}</td>
-                            <td className="text-center">{p.pictureCards}</td>
-                            <td className="text-center">{p.trickCount}</td>
-                            <td className="text-center">{p.roundScore}</td>
-                            <td className="text-center">{p.cumulativeScore}</td>
+                {isMobile ? (
+                  <details
+                    className="my-3 p-2 rounded bg-black/30 relative"
+                    data-tutorial="np-score-table"
+                    open={isRoundEnd || isGameEnd || undefined}
+                  >
+                    <summary className="cursor-pointer select-none text-white/70 text-sm">{t('scores')}</summary>
+                    <div className="overflow-x-auto -mx-2 px-2">
+                      <table className="w-full text-sm text-white/70 min-w-[420px] mt-1">
+                        <thead>
+                          <tr>
+                            <th scope="col" className="text-left">
+                              {t('scoresPlayer')}
+                            </th>
+                            <th scope="col">{t('scoresRole')}</th>
+                            <th scope="col">{t('scoresBid')}</th>
+                            <th scope="col">{t('scoresPictureCards')}</th>
+                            <th scope="col">{t('scoresTricks')}</th>
+                            <th scope="col">{t('scoresRound')}</th>
+                            <th scope="col">{t('scoresTotal')}</th>
                           </tr>
-                        ))}
-                      </tbody>
-                    </table>
+                        </thead>
+                        <tbody>
+                          {state.players.map((p) => (
+                            <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
+                              <td>{playerName(p.id, p.isHuman)}</td>
+                              <td className="text-center">
+                                {p.isNapoleon
+                                  ? t('role.napoleon')
+                                  : p.isAdjutant && (p.adjutantRevealed || state.adjutantRevealed)
+                                    ? t('role.adjutant')
+                                    : '-'}
+                              </td>
+                              <td className="text-center">{p.bid >= 0 ? p.bid : '-'}</td>
+                              <td className="text-center">{p.pictureCards}</td>
+                              <td className="text-center">{p.trickCount}</td>
+                              <td className="text-center">{p.roundScore}</td>
+                              <td className="text-center">{p.cumulativeScore}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                    <ScrollFadeHint />
+                  </details>
+                ) : (
+                  <div className="my-3 p-2 rounded bg-black/30 relative" data-tutorial="np-score-table">
+                    <div className="text-white/70 text-sm mb-1">{t('scores')}</div>
+                    <div className="overflow-x-auto -mx-2 px-2">
+                      <table className="w-full text-sm text-white/70 min-w-[420px]">
+                        <thead>
+                          <tr>
+                            <th scope="col" className="text-left">
+                              {t('scoresPlayer')}
+                            </th>
+                            <th scope="col">{t('scoresRole')}</th>
+                            <th scope="col">{t('scoresBid')}</th>
+                            <th scope="col">{t('scoresPictureCards')}</th>
+                            <th scope="col">{t('scoresTricks')}</th>
+                            <th scope="col">{t('scoresRound')}</th>
+                            <th scope="col">{t('scoresTotal')}</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {state.players.map((p) => (
+                            <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
+                              <td>{playerName(p.id, p.isHuman)}</td>
+                              <td className="text-center">
+                                {p.isNapoleon
+                                  ? t('role.napoleon')
+                                  : p.isAdjutant && (p.adjutantRevealed || state.adjutantRevealed)
+                                    ? t('role.adjutant')
+                                    : '-'}
+                              </td>
+                              <td className="text-center">{p.bid >= 0 ? p.bid : '-'}</td>
+                              <td className="text-center">{p.pictureCards}</td>
+                              <td className="text-center">{p.trickCount}</td>
+                              <td className="text-center">{p.roundScore}</td>
+                              <td className="text-center">{p.cumulativeScore}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
                   </div>
-                  {isMobile && <ScrollFadeHint />}
-                </div>
+                )}
                 <RoundScoreAnnouncement
                   active={isRoundEnd || isGameEnd}
                   entries={state.players.map((p) => ({

--- a/frontend/src/pages/NapoleonPage.tsx
+++ b/frontend/src/pages/NapoleonPage.tsx
@@ -376,7 +376,7 @@ function NapoleonPageContent() {
                 {isMobile ? (
                   <details className="mb-2 p-2 rounded bg-black/30">
                     <summary className="cursor-pointer select-none text-white/70 text-sm">
-                      {tc('game.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
+                      {tc('label.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
                     </summary>
                     <div className="mt-1">
                       {state.players

--- a/frontend/src/pages/OhHellPage.test.tsx
+++ b/frontend/src/pages/OhHellPage.test.tsx
@@ -533,4 +533,37 @@ describe('OhHellPage', () => {
       expect(screen.getByText(/CPU 1.*\u672a\u30d3\u30c3\u30c9/)).toBeInTheDocument();
     });
   });
+
+  it('renders CPU info as collapsible details on mobile', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      const { container } = renderWithProviders(<OhHellPage />);
+      await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+      const allDetails = container.querySelectorAll('details');
+      const cpuDetails = Array.from(allDetails).find((d) =>
+        d.querySelector('summary')?.textContent?.includes('CPU対戦相手'),
+      );
+      expect(cpuDetails).toBeInTheDocument();
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
+
+  it('renders score table as collapsible details on mobile', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      const { container } = renderWithProviders(<OhHellPage />);
+      await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+      const scoreDetails = container.querySelector('details[data-tutorial="oh-score-table"]');
+      expect(scoreDetails).toBeInTheDocument();
+      const summary = scoreDetails?.querySelector('summary');
+      expect(summary).toHaveTextContent('スコア');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
 });

--- a/frontend/src/pages/OhHellPage.tsx
+++ b/frontend/src/pages/OhHellPage.tsx
@@ -327,7 +327,7 @@ function OhHellPageContent() {
                 {isMobile ? (
                   <details className="mb-2 p-2 rounded bg-black/30">
                     <summary className="cursor-pointer select-none text-white/70 text-sm">
-                      {tc('game.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
+                      {tc('label.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
                     </summary>
                     <div className="mt-1">
                       {state.players

--- a/frontend/src/pages/OhHellPage.tsx
+++ b/frontend/src/pages/OhHellPage.tsx
@@ -324,50 +324,106 @@ function OhHellPageContent() {
               {/* Right: info sidebar */}
               <div>
                 {/* CPU players */}
-                {state.players
-                  .filter((p) => !p.isHuman)
-                  .map((p) => (
-                    <div key={p.id} className="mb-2 p-2 rounded bg-black/30">
-                      <div className="text-white/70 text-sm">
-                        {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
-                        {t('cumulativeScore', { score: p.cumulativeScore })} |{' '}
-                        {t('roundScore', { score: p.roundScore })} |{' '}
-                        {p.bid >= 0 ? t('bid', { n: p.bid }) : t('bidNone')}
-                      </div>
+                {isMobile ? (
+                  <details className="mb-2 p-2 rounded bg-black/30">
+                    <summary className="cursor-pointer select-none text-white/70 text-sm">
+                      {tc('game.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
+                    </summary>
+                    <div className="mt-1">
+                      {state.players
+                        .filter((p) => !p.isHuman)
+                        .map((p) => (
+                          <div key={p.id} className="text-white/70 text-sm py-0.5">
+                            {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
+                            {t('cumulativeScore', { score: p.cumulativeScore })} |{' '}
+                            {t('roundScore', { score: p.roundScore })} |{' '}
+                            {p.bid >= 0 ? t('bid', { n: p.bid }) : t('bidNone')}
+                          </div>
+                        ))}
                     </div>
-                  ))}
+                  </details>
+                ) : (
+                  state.players
+                    .filter((p) => !p.isHuman)
+                    .map((p) => (
+                      <div key={p.id} className="mb-2 p-2 rounded bg-black/30">
+                        <div className="text-white/70 text-sm">
+                          {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
+                          {t('cumulativeScore', { score: p.cumulativeScore })} |{' '}
+                          {t('roundScore', { score: p.roundScore })} |{' '}
+                          {p.bid >= 0 ? t('bid', { n: p.bid }) : t('bidNone')}
+                        </div>
+                      </div>
+                    ))
+                )}
 
                 {/* Score table */}
-                <div className="my-3 p-2 rounded bg-black/30 relative" data-tutorial="oh-score-table">
-                  <div className="text-white/70 text-sm mb-1">{t('scores')}</div>
-                  <div className="overflow-x-auto -mx-2 px-2">
-                    <table className="w-full text-sm text-white/70 min-w-[360px]">
-                      <thead>
-                        <tr>
-                          <th scope="col" className="text-left">
-                            {t('scoresPlayer')}
-                          </th>
-                          <th scope="col">{t('scoresBid')}</th>
-                          <th scope="col">{t('scoresTricks')}</th>
-                          <th scope="col">{t('scoresRound')}</th>
-                          <th scope="col">{t('scoresTotal')}</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {state.players.map((p) => (
-                          <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
-                            <td>{playerName(p.id, p.isHuman)}</td>
-                            <td className="text-center">{p.bid >= 0 ? p.bid : '-'}</td>
-                            <td className="text-center">{p.trickCount}</td>
-                            <td className="text-center">{p.roundScore}</td>
-                            <td className="text-center">{p.cumulativeScore}</td>
+                {isMobile ? (
+                  <details
+                    className="my-3 p-2 rounded bg-black/30 relative"
+                    data-tutorial="oh-score-table"
+                    open={isRoundEnd || isGameEnd || undefined}
+                  >
+                    <summary className="cursor-pointer select-none text-white/70 text-sm">{t('scores')}</summary>
+                    <div className="overflow-x-auto -mx-2 px-2">
+                      <table className="w-full text-sm text-white/70 min-w-[360px] mt-1">
+                        <thead>
+                          <tr>
+                            <th scope="col" className="text-left">
+                              {t('scoresPlayer')}
+                            </th>
+                            <th scope="col">{t('scoresBid')}</th>
+                            <th scope="col">{t('scoresTricks')}</th>
+                            <th scope="col">{t('scoresRound')}</th>
+                            <th scope="col">{t('scoresTotal')}</th>
                           </tr>
-                        ))}
-                      </tbody>
-                    </table>
+                        </thead>
+                        <tbody>
+                          {state.players.map((p) => (
+                            <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
+                              <td>{playerName(p.id, p.isHuman)}</td>
+                              <td className="text-center">{p.bid >= 0 ? p.bid : '-'}</td>
+                              <td className="text-center">{p.trickCount}</td>
+                              <td className="text-center">{p.roundScore}</td>
+                              <td className="text-center">{p.cumulativeScore}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                    <ScrollFadeHint />
+                  </details>
+                ) : (
+                  <div className="my-3 p-2 rounded bg-black/30 relative" data-tutorial="oh-score-table">
+                    <div className="text-white/70 text-sm mb-1">{t('scores')}</div>
+                    <div className="overflow-x-auto -mx-2 px-2">
+                      <table className="w-full text-sm text-white/70 min-w-[360px]">
+                        <thead>
+                          <tr>
+                            <th scope="col" className="text-left">
+                              {t('scoresPlayer')}
+                            </th>
+                            <th scope="col">{t('scoresBid')}</th>
+                            <th scope="col">{t('scoresTricks')}</th>
+                            <th scope="col">{t('scoresRound')}</th>
+                            <th scope="col">{t('scoresTotal')}</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {state.players.map((p) => (
+                            <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
+                              <td>{playerName(p.id, p.isHuman)}</td>
+                              <td className="text-center">{p.bid >= 0 ? p.bid : '-'}</td>
+                              <td className="text-center">{p.trickCount}</td>
+                              <td className="text-center">{p.roundScore}</td>
+                              <td className="text-center">{p.cumulativeScore}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
                   </div>
-                  {isMobile && <ScrollFadeHint />}
-                </div>
+                )}
                 <RoundScoreAnnouncement
                   active={isRoundEnd || isGameEnd}
                   entries={state.players.map((p) => ({

--- a/frontend/src/pages/OmahaPage.test.tsx
+++ b/frontend/src/pages/OmahaPage.test.tsx
@@ -1470,4 +1470,13 @@ describe('OmahaPage', () => {
     await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
     expect(screen.queryByTestId('cpu-accordion')).not.toBeInTheDocument();
   });
+
+  it('wraps settings in collapsible details element', async () => {
+    mockExec.mockResolvedValue(preFlopState);
+    const { container } = renderWithProviders(<OmahaPage />);
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+    const allSummaries = container.querySelectorAll('details summary');
+    const settingsSummary = Array.from(allSummaries).find((s) => s.textContent?.includes('設定'));
+    expect(settingsSummary).toBeTruthy();
+  });
 });

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -504,7 +504,7 @@ function OmahaPageContent() {
             )}
 
             {/* Settings + Reset */}
-            <details className="mb-1">
+            <details className="mb-1" open={learningMode || undefined}>
               <summary className="cursor-pointer select-none text-white text-sm font-bold py-1">
                 {tc('settings.title')}
               </summary>

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -346,24 +346,6 @@ function OmahaPageContent() {
 
           {/* Sticky footer: player hand + buttons */}
           <GameFooter className={`${gameTheme.omaha.footer} px-5 py-3`}>
-            {/* Learning mode toggle */}
-            <div className="flex items-center gap-2 mb-2" data-testid="learning-mode-toggle">
-              <label htmlFor="learningModeCheckbox" className="text-white text-sm cursor-pointer">
-                {t('learning.toggle')}
-              </label>
-              <input
-                id="learningModeCheckbox"
-                type="checkbox"
-                checked={learningMode}
-                onChange={(e) => setLearningMode(e.target.checked)}
-              />
-            </div>
-
-            {/* Equity display */}
-            {learningMode && state?.equity && state.potOdds != null && (
-              <EquityDisplay equity={state.equity} potOdds={state.potOdds} />
-            )}
-
             {/* Human player */}
             {humanPlayer && (
               <div className="mb-2" data-tutorial="oh-player-hand">
@@ -522,15 +504,38 @@ function OmahaPageContent() {
             )}
 
             {/* Settings + Reset */}
-            <div className="text-center flex items-center justify-center gap-3" data-tutorial="oh-reset-button">
-              <label className="text-white text-sm flex items-center gap-1">
-                <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
-                {tc('hint.toggle', { ns: 'tutorial' })}
-              </label>
-              <label className="text-white text-sm flex items-center gap-1">
-                <input type="checkbox" checked={cpuMetaAI} onChange={(e) => setCpuMetaAI(e.target.checked)} />
-                {t('settings.cpuMetaAI')}
-              </label>
+            <details className="mb-1">
+              <summary className="cursor-pointer select-none text-white text-sm font-bold py-1">
+                {tc('settings.title')}
+              </summary>
+              <div className="flex flex-col gap-2 py-1">
+                <div className="flex items-center gap-2" data-testid="learning-mode-toggle">
+                  <label htmlFor="learningModeCheckbox" className="text-white text-sm cursor-pointer">
+                    {t('learning.toggle')}
+                  </label>
+                  <input
+                    id="learningModeCheckbox"
+                    type="checkbox"
+                    checked={learningMode}
+                    onChange={(e) => setLearningMode(e.target.checked)}
+                  />
+                </div>
+                {learningMode && state?.equity && state.potOdds != null && (
+                  <EquityDisplay equity={state.equity} potOdds={state.potOdds} />
+                )}
+                <div className="flex items-center gap-3">
+                  <label className="text-white text-sm flex items-center gap-1">
+                    <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
+                    {tc('hint.toggle', { ns: 'tutorial' })}
+                  </label>
+                  <label className="text-white text-sm flex items-center gap-1">
+                    <input type="checkbox" checked={cpuMetaAI} onChange={(e) => setCpuMetaAI(e.target.checked)} />
+                    {t('settings.cpuMetaAI')}
+                  </label>
+                </div>
+              </div>
+            </details>
+            <div className="text-center" data-tutorial="oh-reset-button">
               <button
                 type="button"
                 className={`${btnOutline} min-w-[90px]`}

--- a/frontend/src/pages/PineapplePage.test.tsx
+++ b/frontend/src/pages/PineapplePage.test.tsx
@@ -244,4 +244,13 @@ describe('PineapplePage', () => {
     fireEvent.click(resetBtn);
     expect(screen.getByText('本当にゲームをリセットしますか？')).toBeInTheDocument();
   });
+
+  it('wraps settings in collapsible details element', async () => {
+    mockExec.mockResolvedValue(preFlopState);
+    const { container } = renderWithProviders(<PineapplePage />);
+    await waitFor(() => expect(screen.getByText('あなたの手札')).toBeInTheDocument());
+    const allSummaries = container.querySelectorAll('details summary');
+    const settingsSummary = Array.from(allSummaries).find((s) => s.textContent?.includes('設定'));
+    expect(settingsSummary).toBeTruthy();
+  });
 });

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -363,28 +363,6 @@ function PineapplePageContent() {
 
           {/* Sticky footer: player hand + buttons */}
           <GameFooter className={`${gameTheme.holdem.footer} px-5 py-3`}>
-            {/* Learning mode toggle */}
-            <div
-              className="flex items-center gap-2 mb-2"
-              data-testid="learning-mode-toggle"
-              data-tutorial="pn-learning-mode"
-            >
-              <label htmlFor="learningModeCheckbox" className="text-white text-sm cursor-pointer">
-                {t('learning.toggle')}
-              </label>
-              <input
-                id="learningModeCheckbox"
-                type="checkbox"
-                checked={learningMode}
-                onChange={(e) => setLearningMode(e.target.checked)}
-              />
-            </div>
-
-            {/* Equity display */}
-            {learningMode && state?.equity && state.potOdds != null && (
-              <EquityDisplay equity={state.equity} potOdds={state.potOdds} />
-            )}
-
             {/* Human player */}
             {humanPlayer && (
               <div className="mb-2" data-tutorial="pn-player-hand">
@@ -574,15 +552,38 @@ function PineapplePageContent() {
             )}
 
             {/* Settings + Reset */}
-            <div className="text-center flex items-center justify-center gap-3" data-tutorial="pn-reset-button">
-              <label className="text-white text-sm flex items-center gap-1">
-                <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
-                {tc('hint.toggle', { ns: 'tutorial' })}
-              </label>
-              <label className="text-white text-sm flex items-center gap-1">
-                <input type="checkbox" checked={cpuMetaAI} onChange={(e) => setCpuMetaAI(e.target.checked)} />
-                {t('settings.cpuMetaAI')}
-              </label>
+            <details className="mb-1" data-tutorial="pn-learning-mode">
+              <summary className="cursor-pointer select-none text-white text-sm font-bold py-1">
+                {tc('settings.title')}
+              </summary>
+              <div className="flex flex-col gap-2 py-1">
+                <div className="flex items-center gap-2" data-testid="learning-mode-toggle">
+                  <label htmlFor="learningModeCheckbox" className="text-white text-sm cursor-pointer">
+                    {t('learning.toggle')}
+                  </label>
+                  <input
+                    id="learningModeCheckbox"
+                    type="checkbox"
+                    checked={learningMode}
+                    onChange={(e) => setLearningMode(e.target.checked)}
+                  />
+                </div>
+                {learningMode && state?.equity && state.potOdds != null && (
+                  <EquityDisplay equity={state.equity} potOdds={state.potOdds} />
+                )}
+                <div className="flex items-center gap-3">
+                  <label className="text-white text-sm flex items-center gap-1">
+                    <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
+                    {tc('hint.toggle', { ns: 'tutorial' })}
+                  </label>
+                  <label className="text-white text-sm flex items-center gap-1">
+                    <input type="checkbox" checked={cpuMetaAI} onChange={(e) => setCpuMetaAI(e.target.checked)} />
+                    {t('settings.cpuMetaAI')}
+                  </label>
+                </div>
+              </div>
+            </details>
+            <div className="text-center" data-tutorial="pn-reset-button">
               <button
                 type="button"
                 className={`${btnOutline} min-w-[90px]`}

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -552,7 +552,7 @@ function PineapplePageContent() {
             )}
 
             {/* Settings + Reset */}
-            <details className="mb-1" data-tutorial="pn-learning-mode">
+            <details className="mb-1" data-tutorial="pn-learning-mode" open={learningMode || undefined}>
               <summary className="cursor-pointer select-none text-white text-sm font-bold py-1">
                 {tc('settings.title')}
               </summary>

--- a/frontend/src/pages/SevenCardStudPage.test.tsx
+++ b/frontend/src/pages/SevenCardStudPage.test.tsx
@@ -719,4 +719,13 @@ describe('SevenCardStudPage', () => {
     renderWithProviders(<SevenCardStudPage />);
     await waitFor(() => expect(screen.getByText('[オールイン]')).toBeInTheDocument());
   });
+
+  it('wraps settings in collapsible details element', async () => {
+    mockExec.mockResolvedValue(initState);
+    const { container } = renderWithProviders(<SevenCardStudPage />);
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+    const allSummaries = container.querySelectorAll('details summary');
+    const settingsSummary = Array.from(allSummaries).find((s) => s.textContent?.includes('設定'));
+    expect(settingsSummary).toBeTruthy();
+  });
 });

--- a/frontend/src/pages/SevenCardStudPage.tsx
+++ b/frontend/src/pages/SevenCardStudPage.tsx
@@ -531,15 +531,22 @@ function SevenCardStudPageContent() {
             )}
 
             {/* Settings + Reset */}
-            <div className="text-center flex items-center justify-center gap-3" data-tutorial="scs-reset-button">
-              <label className="text-white text-sm flex items-center gap-1">
-                <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
-                {tc('hint.toggle', { ns: 'tutorial' })}
-              </label>
-              <label className="text-white text-sm flex items-center gap-1">
-                <input type="checkbox" checked={cpuMetaAI} onChange={(e) => setCpuMetaAI(e.target.checked)} />
-                {t('settings.cpuMetaAI')}
-              </label>
+            <details className="mb-1">
+              <summary className="cursor-pointer select-none text-white text-sm font-bold py-1">
+                {tc('settings.title')}
+              </summary>
+              <div className="flex items-center gap-3 py-1">
+                <label className="text-white text-sm flex items-center gap-1">
+                  <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
+                  {tc('hint.toggle', { ns: 'tutorial' })}
+                </label>
+                <label className="text-white text-sm flex items-center gap-1">
+                  <input type="checkbox" checked={cpuMetaAI} onChange={(e) => setCpuMetaAI(e.target.checked)} />
+                  {t('settings.cpuMetaAI')}
+                </label>
+              </div>
+            </details>
+            <div className="text-center" data-tutorial="scs-reset-button">
               <button
                 type="button"
                 className={`${btnOutline} min-w-[90px]`}

--- a/frontend/src/pages/ShortDeckPage.test.tsx
+++ b/frontend/src/pages/ShortDeckPage.test.tsx
@@ -1111,4 +1111,13 @@ describe('ShortDeckPage', () => {
       expect(stickyDiv).toHaveClass('sticky');
     });
   });
+
+  it('wraps settings in collapsible details element', async () => {
+    mockExec.mockResolvedValue(preFlopState);
+    const { container } = renderWithProviders(<ShortDeckPage />);
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+    const allSummaries = container.querySelectorAll('details summary');
+    const settingsSummary = Array.from(allSummaries).find((s) => s.textContent?.includes('設定'));
+    expect(settingsSummary).toBeTruthy();
+  });
 });

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -503,7 +503,7 @@ function ShortDeckPageContent() {
             )}
 
             {/* Settings + Reset */}
-            <details className="mb-1" data-tutorial="sd-learning-mode">
+            <details className="mb-1" data-tutorial="sd-learning-mode" open={learningMode || undefined}>
               <summary className="cursor-pointer select-none text-white text-sm font-bold py-1">
                 {tc('settings.title')}
               </summary>

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -345,28 +345,6 @@ function ShortDeckPageContent() {
 
           {/* Sticky footer: player hand + buttons */}
           <GameFooter className={`${gameTheme.shortdeck.footer} px-5 py-3`}>
-            {/* Learning mode toggle */}
-            <div
-              className="flex items-center gap-2 mb-2"
-              data-testid="learning-mode-toggle"
-              data-tutorial="sd-learning-mode"
-            >
-              <label htmlFor="learningModeCheckbox" className="text-white text-sm cursor-pointer">
-                {t('learning.toggle')}
-              </label>
-              <input
-                id="learningModeCheckbox"
-                type="checkbox"
-                checked={learningMode}
-                onChange={(e) => setLearningMode(e.target.checked)}
-              />
-            </div>
-
-            {/* Equity display */}
-            {learningMode && state?.equity && state.potOdds != null && (
-              <EquityDisplay equity={state.equity} potOdds={state.potOdds} />
-            )}
-
             {/* Human player */}
             {humanPlayer && (
               <div className="mb-2" data-tutorial="sd-player-hand">
@@ -525,15 +503,38 @@ function ShortDeckPageContent() {
             )}
 
             {/* Settings + Reset */}
-            <div className="text-center flex items-center justify-center gap-3" data-tutorial="sd-reset-button">
-              <label className="text-white text-sm flex items-center gap-1">
-                <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
-                {tc('hint.toggle', { ns: 'tutorial' })}
-              </label>
-              <label className="text-white text-sm flex items-center gap-1">
-                <input type="checkbox" checked={cpuMetaAI} onChange={(e) => setCpuMetaAI(e.target.checked)} />
-                {t('settings.cpuMetaAI')}
-              </label>
+            <details className="mb-1" data-tutorial="sd-learning-mode">
+              <summary className="cursor-pointer select-none text-white text-sm font-bold py-1">
+                {tc('settings.title')}
+              </summary>
+              <div className="flex flex-col gap-2 py-1">
+                <div className="flex items-center gap-2" data-testid="learning-mode-toggle">
+                  <label htmlFor="learningModeCheckbox" className="text-white text-sm cursor-pointer">
+                    {t('learning.toggle')}
+                  </label>
+                  <input
+                    id="learningModeCheckbox"
+                    type="checkbox"
+                    checked={learningMode}
+                    onChange={(e) => setLearningMode(e.target.checked)}
+                  />
+                </div>
+                {learningMode && state?.equity && state.potOdds != null && (
+                  <EquityDisplay equity={state.equity} potOdds={state.potOdds} />
+                )}
+                <div className="flex items-center gap-3">
+                  <label className="text-white text-sm flex items-center gap-1">
+                    <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
+                    {tc('hint.toggle', { ns: 'tutorial' })}
+                  </label>
+                  <label className="text-white text-sm flex items-center gap-1">
+                    <input type="checkbox" checked={cpuMetaAI} onChange={(e) => setCpuMetaAI(e.target.checked)} />
+                    {t('settings.cpuMetaAI')}
+                  </label>
+                </div>
+              </div>
+            </details>
+            <div className="text-center" data-tutorial="sd-reset-button">
               <button
                 type="button"
                 className={`${btnOutline} min-w-[90px]`}

--- a/frontend/src/pages/SpadesPage.test.tsx
+++ b/frontend/src/pages/SpadesPage.test.tsx
@@ -733,4 +733,37 @@ describe('SpadesPage', () => {
       Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
     }
   });
+
+  it('renders CPU info as collapsible details on mobile', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      const { container } = renderWithProviders(<SpadesPage />);
+      await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+      const allDetails = container.querySelectorAll('details');
+      const cpuDetails = Array.from(allDetails).find((d) =>
+        d.querySelector('summary')?.textContent?.includes('CPU対戦相手'),
+      );
+      expect(cpuDetails).toBeInTheDocument();
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
+
+  it('renders score table as collapsible details on mobile', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      const { container } = renderWithProviders(<SpadesPage />);
+      await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+      const scoreDetails = container.querySelector('details[data-tutorial="sp-score-table"]');
+      expect(scoreDetails).toBeInTheDocument();
+      const summary = scoreDetails?.querySelector('summary');
+      expect(summary).toHaveTextContent('スコア');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
 });

--- a/frontend/src/pages/SpadesPage.tsx
+++ b/frontend/src/pages/SpadesPage.tsx
@@ -274,52 +274,110 @@ function SpadesPageContent() {
               {/* Right: info sidebar */}
               <div>
                 {/* CPU players */}
-                {state.players
-                  .filter((p) => !p.isHuman)
-                  .map((p) => (
-                    <div key={p.id} className="mb-2 p-2 rounded bg-black/30">
-                      <div className="text-white/70 text-sm">
-                        {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
-                        {t('cumulativeScore', { score: p.cumulativeScore })} |{' '}
-                        {t('roundScore', { score: p.roundScore })} |{' '}
-                        {p.bid >= 0 ? t('bid', { n: p.bid }) : t('bidNone')} | {t('bags', { count: p.bags })}
-                      </div>
+                {isMobile ? (
+                  <details className="mb-2 p-2 rounded bg-black/30">
+                    <summary className="cursor-pointer select-none text-white/70 text-sm">
+                      {tc('game.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
+                    </summary>
+                    <div className="mt-1">
+                      {state.players
+                        .filter((p) => !p.isHuman)
+                        .map((p) => (
+                          <div key={p.id} className="text-white/70 text-sm py-0.5">
+                            {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
+                            {t('cumulativeScore', { score: p.cumulativeScore })} |{' '}
+                            {t('roundScore', { score: p.roundScore })} |{' '}
+                            {p.bid >= 0 ? t('bid', { n: p.bid }) : t('bidNone')} | {t('bags', { count: p.bags })}
+                          </div>
+                        ))}
                     </div>
-                  ))}
+                  </details>
+                ) : (
+                  state.players
+                    .filter((p) => !p.isHuman)
+                    .map((p) => (
+                      <div key={p.id} className="mb-2 p-2 rounded bg-black/30">
+                        <div className="text-white/70 text-sm">
+                          {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
+                          {t('cumulativeScore', { score: p.cumulativeScore })} |{' '}
+                          {t('roundScore', { score: p.roundScore })} |{' '}
+                          {p.bid >= 0 ? t('bid', { n: p.bid }) : t('bidNone')} | {t('bags', { count: p.bags })}
+                        </div>
+                      </div>
+                    ))
+                )}
 
                 {/* Score table */}
-                <div className="my-3 p-2 rounded bg-black/30 relative" data-tutorial="sp-score-table">
-                  <div className="text-white/70 text-sm mb-1">{t('scores')}</div>
-                  <div className="overflow-x-auto -mx-2 px-2">
-                    <table className="w-full text-sm text-white/70 min-w-[360px]">
-                      <thead>
-                        <tr>
-                          <th scope="col" className="text-left">
-                            {t('scoresPlayer')}
-                          </th>
-                          <th scope="col">{t('scoresBid')}</th>
-                          <th scope="col">{t('scoresTricks')}</th>
-                          <th scope="col">{t('scoresBags')}</th>
-                          <th scope="col">{t('scoresRound')}</th>
-                          <th scope="col">{t('scoresTotal')}</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {state.players.map((p) => (
-                          <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
-                            <td>{playerName(p.id, p.isHuman)}</td>
-                            <td className="text-center">{p.bid >= 0 ? p.bid : '-'}</td>
-                            <td className="text-center">{p.trickCount}</td>
-                            <td className="text-center">{p.bags}</td>
-                            <td className="text-center">{p.roundScore}</td>
-                            <td className="text-center">{p.cumulativeScore}</td>
+                {isMobile ? (
+                  <details
+                    className="my-3 p-2 rounded bg-black/30 relative"
+                    data-tutorial="sp-score-table"
+                    open={isRoundEnd || isGameEnd || undefined}
+                  >
+                    <summary className="cursor-pointer select-none text-white/70 text-sm">{t('scores')}</summary>
+                    <div className="overflow-x-auto -mx-2 px-2">
+                      <table className="w-full text-sm text-white/70 min-w-[360px] mt-1">
+                        <thead>
+                          <tr>
+                            <th scope="col" className="text-left">
+                              {t('scoresPlayer')}
+                            </th>
+                            <th scope="col">{t('scoresBid')}</th>
+                            <th scope="col">{t('scoresTricks')}</th>
+                            <th scope="col">{t('scoresBags')}</th>
+                            <th scope="col">{t('scoresRound')}</th>
+                            <th scope="col">{t('scoresTotal')}</th>
                           </tr>
-                        ))}
-                      </tbody>
-                    </table>
+                        </thead>
+                        <tbody>
+                          {state.players.map((p) => (
+                            <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
+                              <td>{playerName(p.id, p.isHuman)}</td>
+                              <td className="text-center">{p.bid >= 0 ? p.bid : '-'}</td>
+                              <td className="text-center">{p.trickCount}</td>
+                              <td className="text-center">{p.bags}</td>
+                              <td className="text-center">{p.roundScore}</td>
+                              <td className="text-center">{p.cumulativeScore}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                    <ScrollFadeHint />
+                  </details>
+                ) : (
+                  <div className="my-3 p-2 rounded bg-black/30 relative" data-tutorial="sp-score-table">
+                    <div className="text-white/70 text-sm mb-1">{t('scores')}</div>
+                    <div className="overflow-x-auto -mx-2 px-2">
+                      <table className="w-full text-sm text-white/70 min-w-[360px]">
+                        <thead>
+                          <tr>
+                            <th scope="col" className="text-left">
+                              {t('scoresPlayer')}
+                            </th>
+                            <th scope="col">{t('scoresBid')}</th>
+                            <th scope="col">{t('scoresTricks')}</th>
+                            <th scope="col">{t('scoresBags')}</th>
+                            <th scope="col">{t('scoresRound')}</th>
+                            <th scope="col">{t('scoresTotal')}</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {state.players.map((p) => (
+                            <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
+                              <td>{playerName(p.id, p.isHuman)}</td>
+                              <td className="text-center">{p.bid >= 0 ? p.bid : '-'}</td>
+                              <td className="text-center">{p.trickCount}</td>
+                              <td className="text-center">{p.bags}</td>
+                              <td className="text-center">{p.roundScore}</td>
+                              <td className="text-center">{p.cumulativeScore}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
                   </div>
-                  {isMobile && <ScrollFadeHint />}
-                </div>
+                )}
                 <RoundScoreAnnouncement
                   active={isRoundEnd || isGameEnd}
                   entries={state.players.map((p) => ({

--- a/frontend/src/pages/SpadesPage.tsx
+++ b/frontend/src/pages/SpadesPage.tsx
@@ -277,7 +277,7 @@ function SpadesPageContent() {
                 {isMobile ? (
                   <details className="mb-2 p-2 rounded bg-black/30">
                     <summary className="cursor-pointer select-none text-white/70 text-sm">
-                      {tc('game.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
+                      {tc('label.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
                     </summary>
                     <div className="mt-1">
                       {state.players

--- a/frontend/src/pages/TwoTenJackPage.test.tsx
+++ b/frontend/src/pages/TwoTenJackPage.test.tsx
@@ -285,4 +285,37 @@ describe('TwoTenJackPage', () => {
     renderWithProviders(<TwoTenJackPage />);
     await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
   });
+
+  it('renders CPU info as collapsible details on mobile', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      const { container } = renderWithProviders(<TwoTenJackPage />);
+      await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+      const allDetails = container.querySelectorAll('details');
+      const cpuDetails = Array.from(allDetails).find((d) =>
+        d.querySelector('summary')?.textContent?.includes('CPU対戦相手'),
+      );
+      expect(cpuDetails).toBeInTheDocument();
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
+
+  it('renders score table as collapsible details on mobile', async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      const { container } = renderWithProviders(<TwoTenJackPage />);
+      await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+      const scoreDetails = container.querySelector('details[data-tutorial="tt-score-table"]');
+      expect(scoreDetails).toBeInTheDocument();
+      const summary = scoreDetails?.querySelector('summary');
+      expect(summary).toHaveTextContent('スコア');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+    }
+  });
 });

--- a/frontend/src/pages/TwoTenJackPage.tsx
+++ b/frontend/src/pages/TwoTenJackPage.tsx
@@ -272,47 +272,103 @@ function TwoTenJackPageContent() {
               </div>
 
               <div>
-                {state.players
-                  .filter((p) => !p.isHuman)
-                  .map((p) => (
-                    <div key={p.id} className="mb-2 p-2 rounded bg-black/30">
-                      <div className="text-white/70 text-sm">
-                        {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
-                        {t('cumulativeScore', { score: p.cumulativeScore })} | {t('tricks', { count: p.trickCount })} |{' '}
-                        {t('capturedPoints', { count: p.capturedPoints })}
-                      </div>
+                {/* CPU players */}
+                {isMobile ? (
+                  <details className="mb-2 p-2 rounded bg-black/30">
+                    <summary className="cursor-pointer select-none text-white/70 text-sm">
+                      {tc('game.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
+                    </summary>
+                    <div className="mt-1">
+                      {state.players
+                        .filter((p) => !p.isHuman)
+                        .map((p) => (
+                          <div key={p.id} className="text-white/70 text-sm py-0.5">
+                            {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
+                            {t('cumulativeScore', { score: p.cumulativeScore })} |{' '}
+                            {t('tricks', { count: p.trickCount })} | {t('capturedPoints', { count: p.capturedPoints })}
+                          </div>
+                        ))}
                     </div>
-                  ))}
+                  </details>
+                ) : (
+                  state.players
+                    .filter((p) => !p.isHuman)
+                    .map((p) => (
+                      <div key={p.id} className="mb-2 p-2 rounded bg-black/30">
+                        <div className="text-white/70 text-sm">
+                          {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
+                          {t('cumulativeScore', { score: p.cumulativeScore })} | {t('tricks', { count: p.trickCount })}{' '}
+                          | {t('capturedPoints', { count: p.capturedPoints })}
+                        </div>
+                      </div>
+                    ))
+                )}
 
-                <div className="my-3 p-2 rounded bg-black/30 relative" data-tutorial="tt-score-table">
-                  <div className="text-white/70 text-sm mb-1">{t('scores')}</div>
-                  <div className="overflow-x-auto -mx-2 px-2">
-                    <table className="w-full text-sm text-white/70 min-w-[320px]">
-                      <thead>
-                        <tr>
-                          <th scope="col" className="text-left">
-                            {t('scoresTeam')}
-                          </th>
-                          <th scope="col">{t('scoresCaptured')}</th>
-                          <th scope="col">{t('scoresTotal')}</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        <tr className="text-ds-accent">
-                          <td>{t('team0')}</td>
-                          <td className="text-center">{team0Captured}</td>
-                          <td className="text-center">{team0Total}</td>
-                        </tr>
-                        <tr>
-                          <td>{t('team1')}</td>
-                          <td className="text-center">{team1Captured}</td>
-                          <td className="text-center">{team1Total}</td>
-                        </tr>
-                      </tbody>
-                    </table>
+                {/* Score table */}
+                {isMobile ? (
+                  <details
+                    className="my-3 p-2 rounded bg-black/30 relative"
+                    data-tutorial="tt-score-table"
+                    open={isRoundEnd || isGameEnd || undefined}
+                  >
+                    <summary className="cursor-pointer select-none text-white/70 text-sm">{t('scores')}</summary>
+                    <div className="overflow-x-auto -mx-2 px-2">
+                      <table className="w-full text-sm text-white/70 min-w-[320px] mt-1">
+                        <thead>
+                          <tr>
+                            <th scope="col" className="text-left">
+                              {t('scoresTeam')}
+                            </th>
+                            <th scope="col">{t('scoresCaptured')}</th>
+                            <th scope="col">{t('scoresTotal')}</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr className="text-ds-accent">
+                            <td>{t('team0')}</td>
+                            <td className="text-center">{team0Captured}</td>
+                            <td className="text-center">{team0Total}</td>
+                          </tr>
+                          <tr>
+                            <td>{t('team1')}</td>
+                            <td className="text-center">{team1Captured}</td>
+                            <td className="text-center">{team1Total}</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                    <ScrollFadeHint />
+                  </details>
+                ) : (
+                  <div className="my-3 p-2 rounded bg-black/30 relative" data-tutorial="tt-score-table">
+                    <div className="text-white/70 text-sm mb-1">{t('scores')}</div>
+                    <div className="overflow-x-auto -mx-2 px-2">
+                      <table className="w-full text-sm text-white/70 min-w-[320px]">
+                        <thead>
+                          <tr>
+                            <th scope="col" className="text-left">
+                              {t('scoresTeam')}
+                            </th>
+                            <th scope="col">{t('scoresCaptured')}</th>
+                            <th scope="col">{t('scoresTotal')}</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr className="text-ds-accent">
+                            <td>{t('team0')}</td>
+                            <td className="text-center">{team0Captured}</td>
+                            <td className="text-center">{team0Total}</td>
+                          </tr>
+                          <tr>
+                            <td>{t('team1')}</td>
+                            <td className="text-center">{team1Captured}</td>
+                            <td className="text-center">{team1Total}</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
                   </div>
-                  {isMobile && <ScrollFadeHint />}
-                </div>
+                )}
                 <RoundScoreAnnouncement
                   active={isRoundEnd || isGameEnd}
                   entries={[

--- a/frontend/src/pages/TwoTenJackPage.tsx
+++ b/frontend/src/pages/TwoTenJackPage.tsx
@@ -276,7 +276,7 @@ function TwoTenJackPageContent() {
                 {isMobile ? (
                   <details className="mb-2 p-2 rounded bg-black/30">
                     <summary className="cursor-pointer select-none text-white/70 text-sm">
-                      {tc('game.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
+                      {tc('label.cpuOpponents', { count: state.players.filter((p) => !p.isHuman).length })}
                     </summary>
                     <div className="mt-1">
                       {state.players


### PR DESCRIPTION
## Summary

- **#1317**: Baccarat payout table collapsed by default on mobile (matches Blackjack `<details>` pattern)
- **#1318**: Poker pages (Holdem, Omaha, ShortDeck, Pineapple, SevenCardStud) move learning mode + hint/MetaAI settings into collapsible `<details>` to free footer vertical space for action buttons
- **#1319**: Bridge bid controls gap/padding tightened to reduce wrapping on 375px viewport
- **#1320**: Trick-taking pages (Hearts, Spades, Napoleon, Euchre, OhHell, TwoTenJack, Bridge) wrap CPU info and score tables in `<details>` on mobile; auto-expand on round/game end; desktop layout unchanged
- **#1321**: `PlayerHandSection` adds `lg:flex-nowrap lg:overflow-x-auto` so 13-card hands display in a single row on desktop

Closes #1317, Closes #1318, Closes #1319, Closes #1320, Closes #1321

## Test plan

- [x] All 14 modified test files pass (770 tests)
- [x] `bun run build` passes
- [x] `bun run check` passes (Biome lint clean)
- [ ] Manual: verify Baccarat bet phase payout table is collapsed by default on mobile
- [ ] Manual: verify Holdem/Omaha/ShortDeck/Pineapple action buttons visible without scroll on 375x667
- [ ] Manual: verify Bridge bid controls fit in fewer lines on 375x667
- [ ] Manual: verify Hearts/Spades/etc. score table collapsed on mobile, auto-opens on round end
- [ ] Manual: verify Hearts/Bridge 13-card hand renders in one row on 1280px desktop