### PR TITLE
fix: add missing CUI manual files to Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,9 @@ WORKDIR /app/frontend
 COPY frontend/package.json frontend/bun.lock ./
 RUN bun install --frozen-lockfile
 
-# Copy game manual Markdown files referenced by manualTexts.ts via ?raw imports
+# Copy game manual Markdown files referenced by manualTexts.ts and cuiManualTexts.ts via ?raw imports
 COPY docs/manual/web/ ../docs/manual/web/
+COPY docs/manual/cui/ ../docs/manual/cui/
 
 # Copy remaining frontend source and build
 # Output goes to ../public (i.e. /app/public) per vite.config.ts


### PR DESCRIPTION
## Summary
- The Dockerfile only copied `docs/manual/web/` but `cuiManualTexts.ts` imports from `docs/manual/cui/`, causing the Vite build to fail on Render with `Could not resolve "../../../docs/manual/cui/baccarat.md?raw"`.
- Added the missing `COPY docs/manual/cui/ ../docs/manual/cui/` to the frontend builder stage.

## Test plan
- [ ] Verify Render deploy succeeds after merge