### PR TITLE
fix: run CPU exchanges after betting round transitions to exchange phase

### DIFF
--- a/internal/domain/Poker.go
+++ b/internal/domain/Poker.go
@@ -271,6 +271,14 @@ func (p *Poker) PlayerAction(action, amount, humanPlayMs int) error {
 
 	p.advanceTurn()
 	p.runCpuActions()
+
+	// ベッティングラウンド完了で交換フェーズに移行した場合、CPU交換を実行
+	if p.round.phase == PokerPhaseExchange && !p.round.gameEndFlag {
+		p.runCpuExchanges()
+		if p.isExchangeComplete() {
+			p.startSecondBettingRound()
+		}
+	}
 	return nil
 }
 

--- a/internal/domain/Poker.go
+++ b/internal/domain/Poker.go
@@ -273,11 +273,8 @@ func (p *Poker) PlayerAction(action, amount, humanPlayMs int) error {
 	p.runCpuActions()
 
 	// ベッティングラウンド完了で交換フェーズに移行した場合、CPU交換を実行
-	if p.round.phase == PokerPhaseExchange && !p.round.gameEndFlag {
-		p.runCpuExchanges()
-		if p.isExchangeComplete() {
-			p.startSecondBettingRound()
-		}
+	if p.round.phase == PokerPhaseExchange {
+		p.advanceExchangePhase()
 	}
 	return nil
 }
@@ -304,12 +301,7 @@ func (p *Poker) PlayerExchange(indices []int) error {
 
 	// 残りのCPU交換を実行
 	p.advanceTurn()
-	p.runCpuExchanges()
-
-	// 交換フェーズ完了判定
-	if p.isExchangeComplete() {
-		p.startSecondBettingRound()
-	}
+	p.advanceExchangePhase()
 
 	return nil
 }
@@ -329,12 +321,7 @@ func (p *Poker) PlayerStand() error {
 
 	// 残りのCPU交換を実行
 	p.advanceTurn()
-	p.runCpuExchanges()
-
-	// 交換フェーズ完了判定
-	if p.isExchangeComplete() {
-		p.startSecondBettingRound()
-	}
+	p.advanceExchangePhase()
 
 	return nil
 }
@@ -612,6 +599,18 @@ func (p *Poker) runCpuActions() {
 			return
 		}
 		p.advanceTurn()
+	}
+}
+
+// advanceExchangePhase runs remaining CPU exchanges and, if all players have
+// exchanged, starts the second betting round.
+func (p *Poker) advanceExchangePhase() {
+	if p.round.gameEndFlag {
+		return
+	}
+	p.runCpuExchanges()
+	if p.isExchangeComplete() {
+		p.startSecondBettingRound()
 	}
 }
 

--- a/internal/domain/Poker_test.go
+++ b/internal/domain/Poker_test.go
@@ -3359,3 +3359,42 @@ func TestPoker_MetaAI_PlayerActionRecordsAction(t *testing.T) {
 		assert.Nil(t, pk.GetHumanProfile())
 	})
 }
+
+// ---------------------------------------------------------------------------
+// PlayerAction transitions to exchange phase and runs CPU exchanges
+// ---------------------------------------------------------------------------
+
+func TestPoker_PlayerAction_TransitionsToExchangeAndRunsCpuExchanges(t *testing.T) {
+	// Human is dealer (index 0). After first betting round completes,
+	// exchange phase should start and CPU exchanges should run automatically
+	// so that currentTurn ends up on the human for card exchange.
+	pk, players := setupPokerForHumanAction(PokerPhaseDeal)
+	pk.SetDealerIdx(0) // human is dealer
+	// All CPUs have already acted; only human is unacted
+	pk.setActedFlags([]bool{false, true, true, true})
+	// Give CPUs two-pair+ hands so they exchange fewer cards (deterministic)
+	for i := 1; i < 4; i++ {
+		givePlayerHand(players[i], []*Card{
+			NewCard(CardDesignSpade, 10, false),
+			NewCard(CardDesignHeart, 10, false),
+			NewCard(CardDesignDiamond, 8, false),
+			NewCard(CardDesignClover, 8, false),
+			NewCard(CardDesignSpade, 14, false),
+		})
+	}
+
+	err := pk.PlayerAction(PokerActionCheck, 0, 0)
+	assert.NoError(t, err)
+
+	if pk.GetGameEndFlag() {
+		return
+	}
+
+	// After the check completes the first betting round, phase should be
+	// Exchange or SecondBet (if all CPUs exchanged and phase auto-advanced).
+	// Critically, if phase is Exchange, currentTurn must be the human.
+	if pk.GetPhase() == PokerPhaseExchange {
+		assert.True(t, players[pk.GetCurrentTurn()].GetIsHuman(),
+			"currentTurn should be the human player in exchange phase, got %d", pk.GetCurrentTurn())
+	}
+}

--- a/internal/domain/Poker_test.go
+++ b/internal/domain/Poker_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // ---------------------------------------------------------------------------
@@ -3384,17 +3385,26 @@ func TestPoker_PlayerAction_TransitionsToExchangeAndRunsCpuExchanges(t *testing.
 	}
 
 	err := pk.PlayerAction(PokerActionCheck, 0, 0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	if pk.GetGameEndFlag() {
 		return
 	}
 
-	// After the check completes the first betting round, phase should be
-	// Exchange or SecondBet (if all CPUs exchanged and phase auto-advanced).
-	// Critically, if phase is Exchange, currentTurn must be the human.
-	if pk.GetPhase() == PokerPhaseExchange {
-		assert.True(t, players[pk.GetCurrentTurn()].GetIsHuman(),
-			"currentTurn should be the human player in exchange phase, got %d", pk.GetCurrentTurn())
+	// After the check completes the first betting round, the phase must have
+	// advanced out of Deal — either Exchange (waiting for human to exchange)
+	// or SecondBet (all players exchanged and auto-advanced).
+	phase := pk.GetPhase()
+	assert.True(t,
+		phase == PokerPhaseExchange || phase == PokerPhaseSecondBet,
+		"expected phase to advance past Deal, got %d", phase,
+	)
+
+	if phase == PokerPhaseExchange {
+		assert.True(t,
+			players[pk.GetCurrentTurn()].GetIsHuman(),
+			"currentTurn should be the human player in exchange phase, got %d",
+			pk.GetCurrentTurn(),
+		)
 	}
 }


### PR DESCRIPTION
## Summary

- When the human player is the dealer in 5-Card Draw Poker, completing the first betting round transitions to the Exchange phase, but CPU exchange logic was never invoked — leaving `currentTurn` on a CPU player and blocking the human with "It is not your turn"
- Added a post-transition check in `PlayerAction`: if phase moved to Exchange, run `runCpuExchanges()` and auto-advance to second betting if all exchanges are complete
- Added regression test `TestPoker_PlayerAction_TransitionsToExchangeAndRunsCpuExchanges` covering the dealer-is-human scenario

Closes: N/A (bug found during manual play testing)

## Test plan

- [x] All existing Go tests pass (`go test -tags test ./internal/...`)
- [x] New regression test passes
- [x] `golangci-lint run ./internal/domain/` — 0 issues
- [x] Manual CUI test: `echo -e "c\ne 0 1\nq" | go run ./cmd/trumpcards poker` — exchange now works when human is dealer
- [ ] Verify via Web GUI that poker card exchange works in all dealer positions