### PR TITLE
ci: trigger deploy-pages on develop and split repomix for NotebookLM

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,7 +3,7 @@ name: Deploy Docs to GitHub Pages
 on:
   push:
     branches:
-      - master
+      - develop
 
 # Allow only one concurrent deployment, skipping runs queued between the
 # run in-progress and latest queued. However, do NOT cancel in-progress runs
@@ -105,10 +105,40 @@ jobs:
           cp -r frontend/docs/* _site/ts/
 
       - name: Run repomix
-        run: bunx repomix --output repomix-output.txt --style xml --compress --remove-empty-lines
+        run: bunx repomix --output repomix-output.txt --style xml --remove-empty-lines
 
-      - name: Copy repomix output
-        run: cp repomix-output.txt _site/repomix-output.txt
+      - name: Split repomix output for NotebookLM
+        run: |
+          mkdir -p _site/repomix
+          # NotebookLM limit is 500,000 characters (~500KB) per source.
+          # Split into 490KB chunks to stay safely under the limit.
+          split -b 490K -d --additional-suffix=.txt repomix-output.txt _site/repomix/repomix-part-
+          # Generate an index page listing all parts
+          cat > _site/repomix/index.html <<'REPOMIX_INDEX'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+          <meta charset="UTF-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <title>Repomix Output (split for NotebookLM)</title>
+          <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.min.css">
+          </head>
+          <body>
+          <h1>Repomix Output</h1>
+          <p>Split into chunks under 500KB for <a href="https://notebooklm.google.com/">NotebookLM</a> import.</p>
+          <p><a href="../">← Back to top</a></p>
+          <ul>
+          REPOMIX_INDEX
+          for f in _site/repomix/repomix-part-*.txt; do
+            name="$(basename "$f")"
+            size="$(du -h "$f" | cut -f1)"
+            echo "<li><a href=\"$name\">$name</a> ($size)</li>" >> _site/repomix/index.html
+          done
+          cat >> _site/repomix/index.html <<'REPOMIX_INDEX'
+          </ul>
+          </body>
+          </html>
+          REPOMIX_INDEX
 
       - name: Copy landing page
         run: cp docs/pages/index.html _site/index.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,10 +97,10 @@ infrastructure → adapter → usecase → domain
 
 ### GitHub Pages (Repomix)
 
-`master` ブランチへのマージ時に、GitHub Actions が [repomix](https://github.com/yamadashy/repomix) を実行し、リポジトリスナップショットを GitHub Pages にデプロイします:
+`develop` ブランチへのマージ時に、GitHub Actions が [repomix](https://github.com/yamadashy/repomix) を実行し、リポジトリスナップショットを GitHub Pages にデプロイします（NotebookLMインポート用に500KB以下に分割）:
 
 ```
-https://yuta-yoshinaga.github.io/go_trumpcards/repomix-output.txt
+https://yuta-yoshinaga.github.io/go_trumpcards/repomix/
 ```
 
 **初回セットアップ（リポジトリ管理者向け）:** Settings > Pages で Source を **GitHub Actions** に設定してください。

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ public/               # ビルド済みアセット
 ## Documentation
 
 - [API Documentation](https://yuta-yoshinaga.github.io/go_trumpcards/) — Go / TypeScript 自動生成ドキュメント
-- [Repomix Output](https://yuta-yoshinaga.github.io/go_trumpcards/repomix-output.txt) — AIコンテキスト用リポジトリスナップショット（master マージ時に自動生成）
+- [Repomix Output](https://yuta-yoshinaga.github.io/go_trumpcards/repomix/) — AIコンテキスト用リポジトリスナップショット（develop マージ時に自動生成、NotebookLMインポート用に分割）
 - [OpenAPI Spec](api/openapi.yaml)
 - [Architecture](docs/architecture.md)
 - [Backend Design (UML)](docs/design/backend.md) — クラス図・シーケンス図・状態遷移図

--- a/docs/adr/0023-api-documentation.md
+++ b/docs/adr/0023-api-documentation.md
@@ -31,7 +31,7 @@ Accepted
 ```
 _site/
   index.html          # リンク付きランディングページ
-  repomix-output.txt  # 圧縮リポジトリスナップショット
+  repomix/             # リポジトリスナップショット（NotebookLM用に分割）
   go/                  # Go APIドキュメント（パッケージごとのHTML）
   ts/                  # TypeScript APIドキュメント（HTML）
 ```

--- a/docs/pages/index.html
+++ b/docs/pages/index.html
@@ -20,7 +20,7 @@
   </ul>
   <h2>Other Resources</h2>
   <ul>
-    <li><a href="repomix-output.txt">Repomix Output</a> — Compressed repository snapshot for AI context</li>
+    <li><a href="repomix/">Repomix Output</a> — Repository snapshot split for NotebookLM import</li>
     <li><a href="https://github.com/yuta-yoshinaga/go_trumpcards">GitHub Repository</a></li>
   </ul>
 </body>


### PR DESCRIPTION
## Summary
- deploy-pages ワークフローのトリガーブランチを `master` → `develop` に変更
- repomix の `--compress` オプションを削除し、出力を490KBごとに分割してNotebookLMインポート上限（500KB/ソース）に対応
- 分割ファイル一覧のインデックスページを自動生成
- 関連ドキュメント（README, CONTRIBUTING, ADR, ランディングページ）のリンク・説明を更新

## Test plan
- [ ] develop へのマージ後、GitHub Actions の deploy-pages ワークフローが発火することを確認
- [ ] GitHub Pages の `/repomix/` にインデックスページと分割ファイルが配置されることを確認
- [ ] 分割ファイルが各490KB以下であることを確認
- [ ] NotebookLM に分割ファイルをインポートできることを確認