### PR TITLE
feat: improve CLI discoverability and web UX (#1348-#1351)

### DIFF
--- a/frontend/src/components/oldmaid/OldMaidPlayerArea.test.tsx
+++ b/frontend/src/components/oldmaid/OldMaidPlayerArea.test.tsx
@@ -56,6 +56,31 @@ describe('OldMaidPlayerArea compactNonTarget', () => {
   });
 });
 
+describe('OldMaidPlayerArea CPU highlight', () => {
+  const selectableProps = { ...defaultProps, isTarget: true, isHumanTurn: true };
+
+  it('applies gold border and glow to highlighted card', () => {
+    render(<OldMaidPlayerArea {...selectableProps} player={makeCpuPlayer(3)} highlightedCardIdx={1} />);
+    // Selectable cards are rendered as buttons; style is on the img inside
+    const buttons = screen.getAllByRole('button');
+    const imgs = buttons.map((btn) => btn.querySelector('img')!);
+    // Highlighted card (index 1) should have gold border and box-shadow
+    expect(imgs[1]).toHaveStyle({ border: '2px solid #D4A853' });
+    expect(imgs[1]).toHaveStyle({ boxShadow: '0 0 10px rgba(212, 168, 83, 0.6)' });
+    // Non-highlighted card (index 0) should have transparent border
+    expect(imgs[0]).toHaveStyle({ border: '2px solid transparent' });
+  });
+
+  it('does not highlight when highlightedCardIdx is -1', () => {
+    render(<OldMaidPlayerArea {...selectableProps} player={makeCpuPlayer(3)} highlightedCardIdx={-1} />);
+    const buttons = screen.getAllByRole('button');
+    for (const btn of buttons) {
+      const img = btn.querySelector('img')!;
+      expect(img).toHaveStyle({ border: '2px solid transparent' });
+    }
+  });
+});
+
 describe('OldMaidPlayerArea keyboard reordering', () => {
   const threeCards = [makeCard('SPADE', 1), makeCard('HEART', 5), makeCard('DIAMOND', 10)];
 

--- a/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
+++ b/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
@@ -168,10 +168,10 @@ export function OldMaidPlayerArea({
                 border: isHighlighted ? '2px solid #D4A853' : '2px solid transparent',
                 borderRadius: 4,
                 cursor: 'pointer',
+                transition: 'transform 0.2s, border-color 0.2s, box-shadow 0.2s',
                 ...(isHighlighted
                   ? {
                       transform: 'translateY(-8px)',
-                      transition: 'transform 0.2s, border-color 0.2s, box-shadow 0.2s',
                       boxShadow: '0 0 10px rgba(212, 168, 83, 0.6)',
                     }
                   : {}),

--- a/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
+++ b/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
@@ -165,10 +165,16 @@ export function OldMaidPlayerArea({
             {Array.from({ length: showCount }, (_, i) => {
               const isHighlighted = isTarget && !player.isHuman && i === highlightedCardIdx;
               const cardStyle: React.CSSProperties = {
-                border: '2px solid transparent',
+                border: isHighlighted ? '2px solid #D4A853' : '2px solid transparent',
                 borderRadius: 4,
                 cursor: 'pointer',
-                ...(isHighlighted ? { transform: 'translateY(-8px)', transition: 'transform 0.2s' } : {}),
+                ...(isHighlighted
+                  ? {
+                      transform: 'translateY(-8px)',
+                      transition: 'transform 0.2s, border-color 0.2s, box-shadow 0.2s',
+                      boxShadow: '0 0 10px rgba(212, 168, 83, 0.6)',
+                    }
+                  : {}),
               };
               return (
                 <CardBack

--- a/frontend/src/hooks/useSpeedGame.ts
+++ b/frontend/src/hooks/useSpeedGame.ts
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { speedApi } from '../api/gameApi';
-import type { SpeedConfig } from '../types/card';
+import type { Card, SpeedConfig } from '../types/card';
 import { SpeedPhase } from '../types/phases';
+import { isAdjacentRank } from '../utils/speedUtils';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
 import { useGameConfig } from './useGameConfig';
@@ -46,6 +47,26 @@ export function useSpeedGame() {
     [gameExec, selectedCardIndices],
   );
 
+  /** Smart-click: select a card and auto-play if only one valid pile exists. */
+  const handleSmartClick = useCallback(
+    (cardIdx: number, handCards: Card[], centerPiles: Card[]) => {
+      const card = handCards[cardIdx];
+      if (!card) {
+        toggleCard(cardIdx);
+        return;
+      }
+      const validPiles = centerPiles
+        .map((pile, i) => (pile && isAdjacentRank(card.value, pile.value) ? i : -1))
+        .filter((i) => i >= 0);
+      if (validPiles.length === 1) {
+        gameExec('play', cardIdx, validPiles[0]);
+      } else {
+        toggleCard(cardIdx);
+      }
+    },
+    [gameExec, toggleCard],
+  );
+
   const handleFlip = useCallback(() => {
     gameExec('flip');
   }, [gameExec]);
@@ -83,6 +104,7 @@ export function useSpeedGame() {
     handleConfigChange,
     handleToggle,
     handlePlay,
+    handleSmartClick,
     handleFlip,
     handleHint,
     retry,

--- a/frontend/src/pages/SpeedPage.test.tsx
+++ b/frontend/src/pages/SpeedPage.test.tsx
@@ -177,25 +177,34 @@ describe('SpeedPage', () => {
     await waitFor(() => expect(screen.getByText('ゲーム終了')).toBeInTheDocument());
   });
 
-  it('selects and deselects a hand card on click', async () => {
+  it('selects and deselects a hand card on click when no single valid pile', async () => {
     renderWithProviders(<SpeedPage />);
     await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
-    const cardBtn = screen.getByRole('button', { name: 'SPADE 4' });
+    // DIAMOND 2 is not adjacent to either center pile (5 or 9), so it toggles normally
+    const cardBtn = screen.getByRole('button', { name: 'DIAMOND 2' });
     fireEvent.click(cardBtn);
     expect(cardBtn).toHaveAttribute('aria-pressed', 'true');
     fireEvent.click(cardBtn);
     expect(cardBtn).toHaveAttribute('aria-pressed', 'false');
   });
 
+  it('auto-plays a card via smart-click when only one valid pile exists', async () => {
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
+    // SPADE 4 is adjacent to pile 0 (value 5) only → smart-click auto-plays
+    fireEvent.click(screen.getByRole('button', { name: 'SPADE 4' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', 0, 0));
+  });
+
   it('plays a card to a center pile when a card is selected', async () => {
     renderWithProviders(<SpeedPage />);
     await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
-    // Select a hand card
-    fireEvent.click(screen.getByRole('button', { name: 'SPADE 4' }));
-    // Click first center pile
+    // DIAMOND 2 has no valid piles, so it toggles selection first
+    fireEvent.click(screen.getByRole('button', { name: 'DIAMOND 2' }));
+    // Then click first center pile manually
     const pileBtns = screen.getAllByRole('button', { name: /台札/ });
     fireEvent.click(pileBtns[0]);
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', 0, 0));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', 3, 0));
   });
 
   it('clicking hint button calls hint command', async () => {

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -69,8 +69,8 @@ function SpeedPageContent() {
     retry,
     speedConfig,
     selectedCardIndices,
-    toggleCard,
     handlePlay,
+    handleSmartClick,
     handleFlip,
     handleHint,
     handleConfigChange,
@@ -177,7 +177,7 @@ function SpeedPageContent() {
                   <button
                     type="button"
                     key={`${card.design}-${card.value}-${idx}`}
-                    onClick={() => toggleCard(idx)}
+                    onClick={() => handleSmartClick(idx, humanPlayer.cards, state.centerPiles)}
                     disabled={!isPlayPhase || loading}
                     aria-label={`${card.design} ${card.value}`}
                     aria-pressed={selectedCardIndices.includes(idx)}

--- a/frontend/src/utils/speedUtils.test.ts
+++ b/frontend/src/utils/speedUtils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { isAdjacentRank } from './speedUtils';
+
+describe('isAdjacentRank', () => {
+  it('returns true for adjacent ranks', () => {
+    expect(isAdjacentRank(1, 2)).toBe(true);
+    expect(isAdjacentRank(5, 4)).toBe(true);
+    expect(isAdjacentRank(12, 13)).toBe(true);
+  });
+
+  it('returns true for K↔A wrap-around', () => {
+    expect(isAdjacentRank(1, 13)).toBe(true);
+    expect(isAdjacentRank(13, 1)).toBe(true);
+  });
+
+  it('returns false for non-adjacent ranks', () => {
+    expect(isAdjacentRank(1, 3)).toBe(false);
+    expect(isAdjacentRank(5, 10)).toBe(false);
+    expect(isAdjacentRank(7, 7)).toBe(false);
+  });
+});

--- a/frontend/src/utils/speedUtils.ts
+++ b/frontend/src/utils/speedUtils.ts
@@ -1,0 +1,8 @@
+/** Maximum card value (King = 13). */
+const CARD_VALUE_MAX = 13;
+
+/** Check if two card ranks are adjacent (with K↔A wrap-around). */
+export function isAdjacentRank(a: number, b: number): boolean {
+  const diff = Math.abs(a - b);
+  return diff === 1 || diff === CARD_VALUE_MAX - 1;
+}

--- a/internal/adapter/controller/DaifugoCuiController.go
+++ b/internal/adapter/controller/DaifugoCuiController.go
@@ -190,7 +190,7 @@ func (c *DaifugoCuiController) Exec(command string) string {
 					return "Rules:\n" + formatDaifugoRuleList(&cfg), true
 				}
 				if len(args) < 2 {
-					return "Usage: sr <rule> <0|1> | sr list\nRules: 8cut, 11back, seq, exchange, 5skip, 7pass, 10discard, spade3, capital, 9reverse, coupdetat, numberlock, sandstorm, emperor, seqrev, seqlock, illegal, 12bomber, blindexchange.\nUse 'suitlockmode' for suit lock (0-2), '5skipcount' for skip count.", true
+					return "Usage: sr <rule> <0|1> | sr list\nRules: " + strings.Join(daifugoRuleKeys, ", ") + ".\nUse 'suitlockmode' for suit lock (0-2), '5skipcount' for skip count.", true
 				}
 				if !setDaifugoRule(nil, args[0], false) {
 					return fmt.Sprintf("Unknown rule: %s.", args[0]), true

--- a/internal/adapter/controller/DaifugoCuiController.go
+++ b/internal/adapter/controller/DaifugoCuiController.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -17,6 +18,73 @@ type DaifugoCuiController struct {
 // NewDaifugoCuiController コンストラクタ
 func NewDaifugoCuiController(dgi usecase.DaifugoInteractorIF) *DaifugoCuiController {
 	return &DaifugoCuiController{dgi: dgi}
+}
+
+// daifugoRuleKeys is the ordered list of all boolean rule keys for sr commands.
+var daifugoRuleKeys = []string{
+	"8cut", "11back", "seq", "exchange", "5skip", "7pass", "10discard",
+	"spade3", "capital", "9reverse", "coupdetat", "numberlock", "sandstorm",
+	"emperor", "seqrev", "seqlock", "illegal", "12bomber", "blindexchange",
+}
+
+// getDaifugoRule returns the current value of a boolean rule flag. Returns (false, false) if unknown.
+func getDaifugoRule(cfg *domain.DaifugoConfig, key string) (value bool, ok bool) {
+	switch key {
+	case "8cut":
+		return cfg.EightCutEnabled, true
+	case "11back":
+		return cfg.ElevenBackEnabled, true
+	case "seq":
+		return cfg.SequenceEnabled, true
+	case "exchange":
+		return cfg.CardExchangeEnabled, true
+	case "5skip":
+		return cfg.FiveSkipEnabled, true
+	case "7pass":
+		return cfg.SevenPassEnabled, true
+	case "10discard":
+		return cfg.TenDiscardEnabled, true
+	case "spade3":
+		return cfg.SpadeThreeEnabled, true
+	case "capital":
+		return cfg.CapitalFallEnabled, true
+	case "9reverse":
+		return cfg.NineReverseEnabled, true
+	case "coupdetat":
+		return cfg.CoupDetatEnabled, true
+	case "numberlock":
+		return cfg.NumberLockEnabled, true
+	case "sandstorm":
+		return cfg.SandstormEnabled, true
+	case "emperor":
+		return cfg.EmperorEnabled, true
+	case "seqrev":
+		return cfg.SequenceRevolutionEnabled, true
+	case "seqlock":
+		return cfg.SequenceLockEnabled, true
+	case "illegal":
+		return cfg.IllegalFinishEnabled, true
+	case "12bomber":
+		return cfg.QueenBomberEnabled, true
+	case "blindexchange":
+		return cfg.BlindExchangeEnabled, true
+	default:
+		return false, false
+	}
+}
+
+// formatDaifugoRuleList returns a formatted string showing all rules with their current ON/OFF status.
+func formatDaifugoRuleList(cfg *domain.DaifugoConfig) string {
+	var b strings.Builder
+	for _, key := range daifugoRuleKeys {
+		val, _ := getDaifugoRule(cfg, key)
+		status := "OFF"
+		if val {
+			status = "ON"
+		}
+		fmt.Fprintf(&b, "  %-16s %s\n", key, status)
+	}
+	return b.String()
 }
 
 // setDaifugoRule sets a boolean rule flag on the config by key. Returns false if the key is unknown.
@@ -117,8 +185,12 @@ func (c *DaifugoCuiController) Exec(command string) string {
 					return c.dgi.ResetWithConfig(cfg)
 				})
 			case "sr", "setrule":
+				if len(args) >= 1 && args[0] == "list" {
+					cfg := c.dgi.GetConfig()
+					return "Rules:\n" + formatDaifugoRuleList(&cfg), true
+				}
 				if len(args) < 2 {
-					return "Usage: sr <rule> <0|1>. Rules: 8cut, 11back, seq, exchange, 5skip, 7pass, 10discard, spade3, capital, 9reverse, coupdetat, numberlock, sandstorm, emperor, seqrev, seqlock, illegal, 12bomber, blindexchange. Use 'suitlockmode' for suit lock (0-2), '5skipcount' for skip count.", true
+					return "Usage: sr <rule> <0|1> | sr list\nRules: 8cut, 11back, seq, exchange, 5skip, 7pass, 10discard, spade3, capital, 9reverse, coupdetat, numberlock, sandstorm, emperor, seqrev, seqlock, illegal, 12bomber, blindexchange.\nUse 'suitlockmode' for suit lock (0-2), '5skipcount' for skip count.", true
 				}
 				if !setDaifugoRule(nil, args[0], false) {
 					return fmt.Sprintf("Unknown rule: %s.", args[0]), true

--- a/internal/adapter/controller/DaifugoCuiController_test.go
+++ b/internal/adapter/controller/DaifugoCuiController_test.go
@@ -249,13 +249,36 @@ func TestDaifugoCuiController_SetRule_LongCommand(t *testing.T) {
 func TestDaifugoCuiController_SetRule_NoArgs(t *testing.T) {
 	mi := new(mockUsecases.MockDaifugoInteractor)
 	c := controller.NewDaifugoCuiController(mi)
-	assert.Contains(t, c.Exec("sr"), "Usage: sr <rule> <0|1>")
+	result := c.Exec("sr")
+	assert.Contains(t, result, "Usage: sr <rule> <0|1> | sr list")
+	assert.Contains(t, result, "8cut")
+}
+
+func TestDaifugoCuiController_SetRule_List(t *testing.T) {
+	mi := new(mockUsecases.MockDaifugoInteractor)
+	c := controller.NewDaifugoCuiController(mi)
+	mi.On("GetConfig").Return(domain.DefaultDaifugoConfig())
+	result := c.Exec("sr list")
+	assert.Contains(t, result, "Rules:")
+	// Default config: 8cut ON, 5skip OFF
+	assert.Contains(t, result, "8cut")
+	assert.Contains(t, result, "ON")
+	assert.Contains(t, result, "5skip")
+	assert.Contains(t, result, "OFF")
+}
+
+func TestDaifugoCuiController_SetRule_List_LongCommand(t *testing.T) {
+	mi := new(mockUsecases.MockDaifugoInteractor)
+	c := controller.NewDaifugoCuiController(mi)
+	mi.On("GetConfig").Return(domain.DefaultDaifugoConfig())
+	result := c.Exec("setrule list")
+	assert.Contains(t, result, "Rules:")
 }
 
 func TestDaifugoCuiController_SetRule_OneArg(t *testing.T) {
 	mi := new(mockUsecases.MockDaifugoInteractor)
 	c := controller.NewDaifugoCuiController(mi)
-	assert.Contains(t, c.Exec("sr 8cut"), "Usage: sr <rule> <0|1>")
+	assert.Contains(t, c.Exec("sr 8cut"), "Usage: sr <rule> <0|1> | sr list")
 }
 
 func TestDaifugoCuiController_SetRule_UnknownRule(t *testing.T) {

--- a/internal/adapter/controller/FreeCellCuiController.go
+++ b/internal/adapter/controller/FreeCellCuiController.go
@@ -26,9 +26,11 @@ func (c *FreeCellCuiController) Exec(command string) string {
 		func(args []string) string {
 			return c.fi.Reset()
 		},
-		[]string{"m", "move", "g", "giveup", "h", "hint", "ac", "autocomplete", "log", "l", "u", "undo"},
+		[]string{"m", "move", "f", "g", "giveup", "h", "hint", "ac", "autocomplete", "log", "l", "u", "undo"},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
+			case "f":
+				return c.handleFoundationShorthand(args), true
 			case "m", "move":
 				return c.handleMove(args), true
 			case "g", "giveup":
@@ -160,6 +162,18 @@ func (c *FreeCellCuiController) handleMoveFromFreeCell(args []string) string {
 	default:
 		return i18n.Tf("freecell.invalidToZone", "val", args[1])
 	}
+}
+
+// handleFoundationShorthand handles `f <col>` (tableau-to-foundation).
+func (c *FreeCellCuiController) handleFoundationShorthand(args []string) string {
+	if len(args) == 0 {
+		return cuiutil.PromptRequest(i18n.T("promptFromColumn"), "f {0}")
+	}
+	col, err := strconv.Atoi(args[0])
+	if err != nil {
+		return i18n.Tf("invalidColumn", "val", args[0])
+	}
+	return c.fi.MoveTableauToFoundation(col)
 }
 
 func (c *FreeCellCuiController) handleMoveShorthand(args []string) string {

--- a/internal/adapter/controller/FreeCellCuiController_test.go
+++ b/internal/adapter/controller/FreeCellCuiController_test.go
@@ -211,6 +211,31 @@ func TestFreeCellCuiController_MoveShorthand(t *testing.T) {
 	})
 }
 
+func TestFreeCellCuiController_FoundationShorthand(t *testing.T) {
+	t.Run("f <col> moves tableau to foundation", func(t *testing.T) {
+		m := newMockFreeCellInteractor()
+		c := NewFreeCellCuiController(m)
+		m.On("MoveTableauToFoundation", 2).Return("tf_output")
+		assert.Equal(t, "tf_output", c.Exec("f 2"))
+	})
+
+	t.Run("f with no args prompts for column", func(t *testing.T) {
+		m := newMockFreeCellInteractor()
+		c := NewFreeCellCuiController(m)
+		result := c.Exec("f")
+		assert.True(t, cuiutil.IsPromptRequest(result))
+		_, tmpl := cuiutil.ParsePromptRequest(result)
+		assert.Equal(t, "f {0}", tmpl)
+	})
+
+	t.Run("f <invalid> returns error", func(t *testing.T) {
+		m := newMockFreeCellInteractor()
+		c := NewFreeCellCuiController(m)
+		result := c.Exec("f abc")
+		assert.Contains(t, result, "abc")
+	})
+}
+
 func TestFreeCellCuiController_UnknownCommand(t *testing.T) {
 	m := newMockFreeCellInteractor()
 	c := NewFreeCellCuiController(m)

--- a/internal/adapter/controller/KlondikeCuiController.go
+++ b/internal/adapter/controller/KlondikeCuiController.go
@@ -33,11 +33,13 @@ func (c *KlondikeCuiController) Exec(command string) string {
 			}
 			return c.ki.Reset()
 		},
-		[]string{"d", "draw", "m", "move", "g", "giveup", "h", "hint", "ac", "autocomplete", "log", "l", "u", "undo"},
+		[]string{"d", "draw", "m", "move", "f", "g", "giveup", "h", "hint", "ac", "autocomplete", "log", "l", "u", "undo"},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "d", "draw":
 				return c.ki.Draw(), true
+			case "f":
+				return c.handleFoundationShorthand(args), true
 			case "m", "move":
 				return c.handleMove(args), true
 			case "g", "giveup":
@@ -137,6 +139,18 @@ func (c *KlondikeCuiController) handleMoveFromTableau(args []string) string {
 	}
 
 	return c.ki.MoveTableauToTableau(fromCol, cardIdx, toCol)
+}
+
+// handleFoundationShorthand handles `f` (waste-to-foundation) and `f <col>` (tableau-to-foundation).
+func (c *KlondikeCuiController) handleFoundationShorthand(args []string) string {
+	if len(args) == 0 {
+		return c.ki.MoveWasteToFoundation()
+	}
+	col, err := strconv.Atoi(args[0])
+	if err != nil {
+		return i18n.Tf("invalidColumn", "val", args[0])
+	}
+	return c.ki.MoveTableauToFoundation(col)
 }
 
 func (c *KlondikeCuiController) handleMoveShorthand(args []string) string {

--- a/internal/adapter/controller/KlondikeCuiController_test.go
+++ b/internal/adapter/controller/KlondikeCuiController_test.go
@@ -225,6 +225,29 @@ func TestKlondikeCuiControllerMoveShorthand(t *testing.T) {
 	})
 }
 
+func TestKlondikeCuiControllerFoundationShorthand(t *testing.T) {
+	t.Run("f with no args moves waste to foundation", func(t *testing.T) {
+		ki := newMockKlondikeInteractor()
+		c := NewKlondikeCuiController(ki)
+		ki.On("MoveWasteToFoundation").Return("wf_output")
+		assert.Equal(t, "wf_output", c.Exec("f"))
+	})
+
+	t.Run("f <col> moves tableau to foundation", func(t *testing.T) {
+		ki := newMockKlondikeInteractor()
+		c := NewKlondikeCuiController(ki)
+		ki.On("MoveTableauToFoundation", 3).Return("tf_output")
+		assert.Equal(t, "tf_output", c.Exec("f 3"))
+	})
+
+	t.Run("f <invalid> returns error", func(t *testing.T) {
+		ki := newMockKlondikeInteractor()
+		c := NewKlondikeCuiController(ki)
+		result := c.Exec("f abc")
+		assert.Contains(t, result, "abc")
+	})
+}
+
 func TestKlondikeCuiControllerUnknown(t *testing.T) {
 	ki := newMockKlondikeInteractor()
 	c := NewKlondikeCuiController(ki)

--- a/internal/i18n/locales/en/daifugo.json
+++ b/internal/i18n/locales/en/daifugo.json
@@ -4,5 +4,5 @@
   "helpSort": "  sort [0-2]           sort hand (0=strength, 1=suit, 2=number)",
   "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Normal, 1=Easy, 2=Hard)",
   "helpSetJoker": "  sj [0-2]             joker count",
-  "helpSetRule": "  sr <rule> <0|1>      toggle local rule"
+  "helpSetRule": "  sr <rule> <0|1>      toggle local rule (sr list to show all)"
 }

--- a/internal/i18n/locales/en/freecell.json
+++ b/internal/i18n/locales/en/freecell.json
@@ -6,6 +6,8 @@
   "helpMoveTC": "  m t <col> c <cell>   move tableau to free cell",
   "helpMoveCT": "  m c <cell> t <col>   move free cell to tableau",
   "helpMoveCF": "  m c <cell> f         move free cell to foundation",
+  "helpMoveShorthand": "  m <col> <col>        move tableau top card (shorthand)",
+  "helpFoundation": "  f <col>              move tableau to foundation (shorthand)",
   "helpGiveUp": "  g                    give up",
   "helpHint": "  h                    hint",
   "helpAutoComplete": "  ac                   auto-complete"

--- a/internal/i18n/locales/en/klondike.json
+++ b/internal/i18n/locales/en/klondike.json
@@ -5,6 +5,8 @@
   "helpMoveWF": "  m w f                move waste to foundation",
   "helpMoveTF": "  m t <col> f          move tableau to foundation",
   "helpMoveTT": "  m t <col> <idx> t <col>  move tableau to tableau",
+  "helpMoveShorthand": "  m <col> <col>        move tableau top card (shorthand)",
+  "helpFoundation": "  f [<col>]            move to foundation (waste or tableau)",
   "helpGiveUp": "  g                    give up",
   "helpHint": "  h                    hint",
   "helpAutoComplete": "  ac                   auto-complete"

--- a/internal/i18n/locales/en/spider.json
+++ b/internal/i18n/locales/en/spider.json
@@ -2,6 +2,7 @@
   "helpTitle": "Spider Solitaire",
   "helpDeal": "  d                    deal from stock",
   "helpMove": "  m t <col> <idx> t <col>  move tableau to tableau",
+  "helpMoveShorthand": "  m <col> <col>        move top card (shorthand)",
   "helpGiveUp": "  g                    give up",
   "helpHint": "  h                    hint",
   "helpAutoComplete": "  ac                   auto-complete"

--- a/internal/i18n/locales/ja/daifugo.json
+++ b/internal/i18n/locales/ja/daifugo.json
@@ -4,5 +4,5 @@
   "helpSort": "  sort [0-2]           sort hand (0=strength, 1=suit, 2=number)",
   "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Normal, 1=Easy, 2=Hard)",
   "helpSetJoker": "  sj [0-2]             joker count",
-  "helpSetRule": "  sr <rule> <0|1>      toggle local rule"
+  "helpSetRule": "  sr <rule> <0|1>      ルール切替 (sr list で一覧表示)"
 }

--- a/internal/i18n/locales/ja/freecell.json
+++ b/internal/i18n/locales/ja/freecell.json
@@ -6,6 +6,8 @@
   "helpMoveTC": "  m t <col> c <cell>   move tableau to free cell",
   "helpMoveCT": "  m c <cell> t <col>   move free cell to tableau",
   "helpMoveCF": "  m c <cell> f         move free cell to foundation",
+  "helpMoveShorthand": "  m <col> <col>        タブロー間移動 (省略形)",
+  "helpFoundation": "  f <col>              タブローから組札へ (省略形)",
   "helpGiveUp": "  g                    give up",
   "helpHint": "  h                    hint",
   "helpAutoComplete": "  ac                   auto-complete"

--- a/internal/i18n/locales/ja/klondike.json
+++ b/internal/i18n/locales/ja/klondike.json
@@ -5,6 +5,8 @@
   "helpMoveWF": "  m w f                move waste to foundation",
   "helpMoveTF": "  m t <col> f          move tableau to foundation",
   "helpMoveTT": "  m t <col> <idx> t <col>  move tableau to tableau",
+  "helpMoveShorthand": "  m <col> <col>        タブロー間移動 (省略形)",
+  "helpFoundation": "  f [<col>]            組札へ移動 (山札またはタブロー)",
   "helpGiveUp": "  g                    give up",
   "helpHint": "  h                    hint",
   "helpAutoComplete": "  ac                   auto-complete"

--- a/internal/i18n/locales/ja/spider.json
+++ b/internal/i18n/locales/ja/spider.json
@@ -2,6 +2,7 @@
   "helpTitle": "Spider Solitaire (スパイダーソリティア)",
   "helpDeal": "  d                    deal from stock",
   "helpMove": "  m t <col> <idx> t <col>  move tableau to tableau",
+  "helpMoveShorthand": "  m <col> <col>        最上段移動 (省略形)",
   "helpGiveUp": "  g                    give up",
   "helpHint": "  h                    hint",
   "helpAutoComplete": "  ac                   auto-complete"


### PR DESCRIPTION
## Summary
- **#1348 Daifugo CLI**: Add `sr list` subcommand showing all 19 rules with ON/OFF state, update help text with `sr list` mention
- **#1349 Speed Web**: Smart-click auto-plays hand card when only one valid center pile exists (uses `isAdjacentRank` check), falling back to toggle when 0 or 2 piles are valid
- **#1350 Old Maid Web**: Enhanced CPU psychology highlight with gold border (`#D4A853`) and glow effect (`box-shadow`) in addition to the existing `translateY(-8px)` lift
- **#1351 Solitaire CLI**: Add `f [<col>]` shorthand for foundation moves in Klondike and FreeCell; document `m <col> <col>` shorthand in help text for all three solitaire games

Closes #1348, Closes #1349, Closes #1350, Closes #1351

## Test plan
- [x] Go tests pass: `go test -tags test ./...`
- [x] Go lint passes: `golangci-lint run ./...`
- [x] Frontend type check passes
- [x] Daifugo `sr list` shows rules with correct ON/OFF states
- [x] Speed smart-click auto-plays SPADE 4 on pile with value 5
- [x] Speed smart-click falls back to toggle for cards with 0 or 2 valid piles
- [x] Old Maid highlighted card has gold border and glow
- [x] Klondike `f` moves waste-to-foundation, `f <col>` moves tableau-to-foundation
- [x] FreeCell `f <col>` moves tableau-to-foundation, `f` prompts for column
- [ ] Verify Speed smart-click in browser
- [ ] Verify Old Maid highlight visibility on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)