### PR TITLE
fix(frontend): improve a11y and error visibility (#1365)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,16 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <script>
+      (() => {
+        try {
+          const s = localStorage.getItem('i18nextLng');
+          if (s && (s === 'en' || s.indexOf('en-') === 0)) {
+            document.documentElement.lang = 'en';
+          }
+        } catch (_) { /* ignore */ }
+      })();
+    </script>
     <title>Trump Card Games</title>
     <link rel="apple-touch-icon" href="/images/favicon.ico" />
     <link rel="shortcut icon" href="/images/favicon.ico" />

--- a/frontend/src/components/CpuActionToast.test.tsx
+++ b/frontend/src/components/CpuActionToast.test.tsx
@@ -120,6 +120,41 @@ describe('CpuActionToast', () => {
     expect(screen.getByRole('status').className).not.toContain('slideDown');
   });
 
+  it('does not dismiss on Escape while an aria-modal dialog is open', () => {
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('aria-modal', 'true');
+    document.body.appendChild(dialog);
+
+    const actions = [{ playerIdx: 1, action: 2, amount: 0 }];
+    render(<CpuActionToast actions={actions} />);
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Escape' });
+    });
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    document.body.removeChild(dialog);
+  });
+
+  it('restores focus to the trigger element when dismissed', () => {
+    const trigger = document.createElement('button');
+    trigger.textContent = 'trigger';
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const actions = [{ playerIdx: 1, action: 2, amount: 0 }];
+    const { rerender } = render(<CpuActionToast actions={undefined} />);
+    rerender(<CpuActionToast actions={actions} />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Escape' });
+    });
+    expect(document.activeElement).toBe(trigger);
+    document.body.removeChild(trigger);
+  });
+
   it('applies the slide-down animation when reduced motion is off', () => {
     mockReduced.mockReturnValue(false);
     const actions = [{ playerIdx: 1, action: 2, amount: 0 }];

--- a/frontend/src/components/CpuActionToast.test.tsx
+++ b/frontend/src/components/CpuActionToast.test.tsx
@@ -136,6 +136,63 @@ describe('CpuActionToast', () => {
     document.body.removeChild(dialog);
   });
 
+  it('does not clobber triggerRef when new actions arrive while toast is already visible', () => {
+    const initialTrigger = document.createElement('button');
+    initialTrigger.textContent = 'initial-trigger';
+    document.body.appendChild(initialTrigger);
+    initialTrigger.focus();
+
+    const actions1 = [{ playerIdx: 1, action: 2, amount: 0 }];
+    const { rerender } = render(<CpuActionToast actions={undefined} />);
+    rerender(<CpuActionToast actions={actions1} />);
+
+    // Focus the toast's close button to simulate user tabbing into it
+    const closeBtn = screen.getByRole('button', { name: 'button.dismiss' });
+    closeBtn.focus();
+    expect(document.activeElement).toBe(closeBtn);
+
+    // New action while toast already visible → triggerRef must NOT be overwritten
+    const actions2 = [
+      { playerIdx: 1, action: 2, amount: 0 },
+      { playerIdx: 2, action: 3, amount: 40 },
+    ];
+    rerender(<CpuActionToast actions={actions2} />);
+
+    // Blur focus so activeElement is body (simulating toast unmount on dismiss)
+    closeBtn.blur();
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Escape' });
+    });
+    expect(document.activeElement).toBe(initialTrigger);
+    document.body.removeChild(initialTrigger);
+  });
+
+  it('does not hijack focus when user has moved focus elsewhere before dismissal', () => {
+    const trigger = document.createElement('button');
+    trigger.textContent = 'trigger';
+    const other = document.createElement('button');
+    other.textContent = 'other';
+    document.body.appendChild(trigger);
+    document.body.appendChild(other);
+    trigger.focus();
+
+    const actions = [{ playerIdx: 1, action: 2, amount: 0 }];
+    const { rerender } = render(<CpuActionToast actions={undefined} />);
+    rerender(<CpuActionToast actions={actions} />);
+
+    // User moves focus to a different element while toast is visible
+    other.focus();
+    expect(document.activeElement).toBe(other);
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Escape' });
+    });
+    // Focus must stay on `other`, not jump back to trigger
+    expect(document.activeElement).toBe(other);
+    document.body.removeChild(trigger);
+    document.body.removeChild(other);
+  });
+
   it('restores focus to the trigger element when dismissed', () => {
     const trigger = document.createElement('button');
     trigger.textContent = 'trigger';

--- a/frontend/src/components/CpuActionToast.tsx
+++ b/frontend/src/components/CpuActionToast.tsx
@@ -26,8 +26,10 @@ export function CpuActionToast({ actions }: CpuActionToastProps) {
 
   useEffect(() => {
     if (len > 0 && len !== prevLenRef.current) {
-      triggerRef.current = document.activeElement;
-      setVisible(true);
+      setVisible((prev) => {
+        if (!prev) triggerRef.current = document.activeElement;
+        return true;
+      });
       clearTimeout(timerRef.current);
       timerRef.current = setTimeout(() => setVisible(false), DISMISS_MS);
     }
@@ -37,7 +39,11 @@ export function CpuActionToast({ actions }: CpuActionToastProps) {
 
   useEffect(() => {
     if (!visible) {
-      if (triggerRef.current instanceof HTMLElement && document.contains(triggerRef.current)) {
+      if (
+        document.activeElement === document.body &&
+        triggerRef.current instanceof HTMLElement &&
+        document.contains(triggerRef.current)
+      ) {
         triggerRef.current.focus();
       }
       triggerRef.current = null;

--- a/frontend/src/components/CpuActionToast.tsx
+++ b/frontend/src/components/CpuActionToast.tsx
@@ -20,11 +20,13 @@ export function CpuActionToast({ actions }: CpuActionToastProps) {
   const [visible, setVisible] = useState(false);
   const prevLenRef = useRef(0);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const triggerRef = useRef<Element | null>(null);
 
   const len = actions?.length ?? 0;
 
   useEffect(() => {
     if (len > 0 && len !== prevLenRef.current) {
+      triggerRef.current = document.activeElement;
       setVisible(true);
       clearTimeout(timerRef.current);
       timerRef.current = setTimeout(() => setVisible(false), DISMISS_MS);
@@ -34,9 +36,17 @@ export function CpuActionToast({ actions }: CpuActionToastProps) {
   }, [len]);
 
   useEffect(() => {
-    if (!visible) return;
+    if (!visible) {
+      if (triggerRef.current instanceof HTMLElement && document.contains(triggerRef.current)) {
+        triggerRef.current.focus();
+      }
+      triggerRef.current = null;
+      return;
+    }
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setVisible(false);
+      if (e.key !== 'Escape') return;
+      if (document.querySelector('[role="dialog"][aria-modal="true"]')) return;
+      setVisible(false);
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
@@ -62,7 +72,7 @@ export function CpuActionToast({ actions }: CpuActionToastProps) {
         type="button"
         onClick={() => setVisible(false)}
         aria-label={t('button.dismiss')}
-        className="absolute top-0 right-1 px-2 py-0.5 text-white/70 hover:text-white focus:outline-none focus:ring-2 focus:ring-ds-accent"
+        className="absolute top-0 right-1 px-2 py-0.5 text-white/70 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-ds-accent"
       >
         ×
       </button>

--- a/frontend/src/components/DropZone.test.tsx
+++ b/frontend/src/components/DropZone.test.tsx
@@ -108,6 +108,33 @@ describe('DropZone', () => {
     expect(wrapper.getAttribute('aria-label')).toBe('ファウンデーション');
   });
 
+  it('does not use role="region" when ariaLabel is absent even if onKeyboardDrop is provided', () => {
+    const { container } = render(
+      <DropZone isDropTarget={false} onDragOver={vi.fn()} onDrop={vi.fn()} onKeyboardDrop={vi.fn()}>
+        <span>child</span>
+      </DropZone>,
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.getAttribute('role')).toBe('presentation');
+    expect(wrapper.getAttribute('aria-label')).toBeNull();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('adds position:relative when keyboard affordance is enabled', () => {
+    const { container } = render(
+      <DropZone
+        isDropTarget={false}
+        onDragOver={vi.fn()}
+        onDrop={vi.fn()}
+        ariaLabel="foundation"
+        onKeyboardDrop={vi.fn()}
+      >
+        <span>child</span>
+      </DropZone>,
+    );
+    expect((container.firstChild as HTMLElement).className).toContain('relative');
+  });
+
   it('does not render a keyboard-drop button when onKeyboardDrop is omitted', () => {
     render(
       <DropZone isDropTarget={false} onDragOver={vi.fn()} onDrop={vi.fn()} ariaLabel="foundation">

--- a/frontend/src/components/DropZone.test.tsx
+++ b/frontend/src/components/DropZone.test.tsx
@@ -57,6 +57,66 @@ describe('DropZone', () => {
     expect(onDrop).toHaveBeenCalled();
   });
 
+  it('renders a keyboard-drop button when onKeyboardDrop and ariaLabel are provided', () => {
+    const onKeyboardDrop = vi.fn();
+    render(
+      <DropZone
+        isDropTarget={false}
+        onDragOver={vi.fn()}
+        onDrop={vi.fn()}
+        ariaLabel="ファウンデーション: スペード"
+        onKeyboardDrop={onKeyboardDrop}
+      >
+        <span>child</span>
+      </DropZone>,
+    );
+    const button = screen.getByRole('button', { name: 'ファウンデーション: スペード' });
+    fireEvent.click(button);
+    expect(onKeyboardDrop).toHaveBeenCalled();
+  });
+
+  it('disables the keyboard-drop button when keyboardDropDisabled is true', () => {
+    render(
+      <DropZone
+        isDropTarget={false}
+        onDragOver={vi.fn()}
+        onDrop={vi.fn()}
+        ariaLabel="foundation"
+        onKeyboardDrop={vi.fn()}
+        keyboardDropDisabled={true}
+      >
+        <span>child</span>
+      </DropZone>,
+    );
+    expect(screen.getByRole('button', { name: 'foundation' })).toBeDisabled();
+  });
+
+  it('uses role="region" with aria-label when keyboard drop is enabled', () => {
+    const { container } = render(
+      <DropZone
+        isDropTarget={false}
+        onDragOver={vi.fn()}
+        onDrop={vi.fn()}
+        ariaLabel="ファウンデーション"
+        onKeyboardDrop={vi.fn()}
+      >
+        <span>child</span>
+      </DropZone>,
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.getAttribute('role')).toBe('region');
+    expect(wrapper.getAttribute('aria-label')).toBe('ファウンデーション');
+  });
+
+  it('does not render a keyboard-drop button when onKeyboardDrop is omitted', () => {
+    render(
+      <DropZone isDropTarget={false} onDragOver={vi.fn()} onDrop={vi.fn()} ariaLabel="foundation">
+        <span>child</span>
+      </DropZone>,
+    );
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
   it('calls onDragLeave when provided', () => {
     const onDragLeave = vi.fn();
     const { container } = render(

--- a/frontend/src/components/DropZone.tsx
+++ b/frontend/src/components/DropZone.tsx
@@ -22,7 +22,9 @@ interface DropZoneProps {
   ariaLabel?: string;
   /**
    * Optional click handler that commits a move using the caller's currently-selected card.
-   * When provided, a keyboard-focusable button appears (visually hidden until focused).
+   * When provided together with `ariaLabel`, a keyboard-focusable button appears (visually
+   * hidden until focused). The wrapper gains `position: relative` automatically so the
+   * focus overlay stays contained; callers do not need to add it to `className`.
    */
   onKeyboardDrop?: () => void;
   /** When true, the keyboard-drop button is rendered disabled (e.g., no card selected). */
@@ -52,9 +54,10 @@ export function DropZone({
   keyboardDropDisabled,
   keyboardDropLabel,
 }: DropZoneProps) {
+  const keyboardAffordance = onKeyboardDrop !== undefined && !!ariaLabel;
   const highlightClass = isDropTarget ? 'ring-2 ring-blue-400 rounded' : '';
-  const combinedClass = [highlightClass, className].filter(Boolean).join(' ');
-  const keyboardAffordance = onKeyboardDrop !== undefined;
+  const positionClass = keyboardAffordance ? 'relative' : '';
+  const combinedClass = [positionClass, highlightClass, className].filter(Boolean).join(' ');
   const label = keyboardDropLabel ?? ariaLabel;
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop is a progressive enhancement; the keyboard affordance below is the accessible path.
@@ -68,7 +71,7 @@ export function DropZone({
       aria-label={keyboardAffordance ? ariaLabel : undefined}
     >
       {children}
-      {keyboardAffordance && label && (
+      {keyboardAffordance && (
         <button
           type="button"
           onClick={onKeyboardDrop}

--- a/frontend/src/components/DropZone.tsx
+++ b/frontend/src/components/DropZone.tsx
@@ -14,26 +14,71 @@ interface DropZoneProps {
   className?: string;
   /** Content rendered inside the drop zone. */
   children: ReactNode;
+  /**
+   * Accessible label describing what this zone represents (e.g., "ファウンデーション: スペード").
+   * When provided together with `onKeyboardDrop`, a keyboard-accessible "move here" button is
+   * rendered so assistive-tech users can drop the currently-selected card without drag events.
+   */
+  ariaLabel?: string;
+  /**
+   * Optional click handler that commits a move using the caller's currently-selected card.
+   * When provided, a keyboard-focusable button appears (visually hidden until focused).
+   */
+  onKeyboardDrop?: () => void;
+  /** When true, the keyboard-drop button is rendered disabled (e.g., no card selected). */
+  keyboardDropDisabled?: boolean;
+  /** Label for the keyboard-drop button. Defaults to ariaLabel. */
+  keyboardDropLabel?: string;
 }
 
 /**
  * Thin wrapper that receives HTML5 drag events and applies a visual highlight
  * when it is the active drop target. Used to wrap cards and empty pile
  * placeholders in solitaire games.
+ *
+ * When `onKeyboardDrop` is supplied, the zone becomes a `role="region"` and
+ * exposes a visually-hidden-until-focused button so keyboard and screen-reader
+ * users can drop the selected card without triggering HTML5 drag events.
  */
-export function DropZone({ isDropTarget, onDragOver, onDrop, onDragLeave, className, children }: DropZoneProps) {
+export function DropZone({
+  isDropTarget,
+  onDragOver,
+  onDrop,
+  onDragLeave,
+  className,
+  children,
+  ariaLabel,
+  onKeyboardDrop,
+  keyboardDropDisabled,
+  keyboardDropLabel,
+}: DropZoneProps) {
   const highlightClass = isDropTarget ? 'ring-2 ring-blue-400 rounded' : '';
   const combinedClass = [highlightClass, className].filter(Boolean).join(' ');
+  const keyboardAffordance = onKeyboardDrop !== undefined;
+  const label = keyboardDropLabel ?? ariaLabel;
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop is a progressive enhancement; click-based interaction on inner buttons is the accessible path.
+    // biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop is a progressive enhancement; the keyboard affordance below is the accessible path.
+    // biome-ignore lint/a11y/useAriaPropsSupportedByRole: aria-label is only set when role is "region", which supports it.
     <div
       className={combinedClass}
       onDragOver={onDragOver}
       onDrop={onDrop}
       onDragLeave={onDragLeave}
-      role="presentation"
+      role={keyboardAffordance ? 'region' : 'presentation'}
+      aria-label={keyboardAffordance ? ariaLabel : undefined}
     >
       {children}
+      {keyboardAffordance && label && (
+        <button
+          type="button"
+          onClick={onKeyboardDrop}
+          disabled={keyboardDropDisabled}
+          aria-label={label}
+          className="sr-only focus-visible:not-sr-only focus-visible:absolute focus-visible:inset-0 focus-visible:z-10 focus-visible:flex focus-visible:items-center focus-visible:justify-center focus-visible:rounded focus-visible:bg-black/80 focus-visible:px-2 focus-visible:py-1 focus-visible:text-white focus-visible:text-xs focus-visible:ring-2 focus-visible:ring-ds-accent disabled:opacity-50"
+        >
+          {label}
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/hooks/usePokerGame.test.ts
+++ b/frontend/src/hooks/usePokerGame.test.ts
@@ -272,6 +272,36 @@ describe('usePokerGame', () => {
     expect(result.current.odds).toBeNull();
   });
 
+  it('sets oddsError when API rejects, clears it on next success via retryOdds', async () => {
+    mockExec.mockResolvedValue(exchangeState);
+    const { result } = renderHook(() => usePokerGame(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.canExchange).toBe(true));
+
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    mockExec.mockRejectedValueOnce(new Error('network down'));
+
+    act(() => result.current.toggleCard(0));
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    vi.useRealTimers();
+    await waitFor(() => expect(result.current.oddsError).toBe('oddsFetchFailed'));
+    expect(result.current.odds).toBeNull();
+
+    // Retry succeeds → error cleared
+    const oddsData = [{ handRank: 1, handName: 'ワンペア', probability: 0.4, count: 4, total: 10 }];
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    mockExec.mockResolvedValue({ ...exchangeState, odds: oddsData });
+    act(() => result.current.retryOdds());
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    vi.useRealTimers();
+
+    await waitFor(() => expect(result.current.odds).toEqual(oddsData));
+    expect(result.current.oddsError).toBeNull();
+  });
+
   it('cancels pending debounce timer on unmount (clearTimeout branch)', async () => {
     mockExec.mockResolvedValue(exchangeState);
     const { result, unmount } = renderHook(() => usePokerGame(), { wrapper: createWrapper() });

--- a/frontend/src/hooks/usePokerGame.ts
+++ b/frontend/src/hooks/usePokerGame.ts
@@ -10,6 +10,7 @@ import { useGameApi } from './useGameApi';
 export function usePokerGame() {
   const { selected, setSelected, clear: clearSelection } = useCardSelection();
   const [odds, setOdds] = useState<PokerOdds[] | null>(null);
+  const [oddsError, setOddsError] = useState<string | null>(null);
   const oddsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const oddsGenRef = useRef(0);
   const mountedRef = useRef(true);
@@ -17,6 +18,7 @@ export function usePokerGame() {
   const onSuccess = useCallback(() => {
     clearSelection();
     setOdds(null);
+    setOddsError(null);
     oddsGenRef.current++;
   }, [clearSelection]);
 
@@ -41,31 +43,46 @@ export function usePokerGame() {
   const canExchangeRef = useRef(canExchange);
   canExchangeRef.current = canExchange;
 
+  const fetchOdds = useCallback((cardIndices: number[]) => {
+    if (oddsTimerRef.current !== null) clearTimeout(oddsTimerRef.current);
+    if (cardIndices.length === 0) {
+      setOdds(null);
+      setOddsError(null);
+      return;
+    }
+    oddsTimerRef.current = setTimeout(() => {
+      if (!mountedRef.current) return;
+      const gen = ++oddsGenRef.current;
+      pokerApi
+        .exec('odds', cardIndices)
+        .then((res) => {
+          if (gen !== oddsGenRef.current) return;
+          setOdds(res.odds ?? null);
+          setOddsError(null);
+        })
+        .catch((err) => {
+          if (gen !== oddsGenRef.current) return;
+          setOddsError('oddsFetchFailed');
+          console.error('Poker odds fetch error:', err);
+        });
+    }, 300);
+  }, []);
+
   const toggleCard = useCallback(
     (idx: number) => {
       if (!canExchangeRef.current) return;
       setSelected((prev) => {
         const next = toggleArrayItem(prev, idx);
-        if (oddsTimerRef.current !== null) clearTimeout(oddsTimerRef.current);
-        if (next.length === 0) {
-          setOdds(null);
-        } else {
-          oddsTimerRef.current = setTimeout(() => {
-            if (!mountedRef.current) return;
-            const gen = ++oddsGenRef.current;
-            pokerApi
-              .exec('odds', next)
-              .then((res) => {
-                if (gen === oddsGenRef.current) setOdds(res.odds ?? null);
-              })
-              .catch((err) => console.error('Failed to fetch poker odds:', err));
-          }, 300);
-        }
+        fetchOdds(next);
         return next;
       });
     },
-    [setSelected],
+    [setSelected, fetchOdds],
   );
+
+  const retryOdds = useCallback(() => {
+    fetchOdds(selected);
+  }, [fetchOdds, selected]);
 
   return {
     state,
@@ -76,6 +93,8 @@ export function usePokerGame() {
     toggleCard,
     clearSelection,
     odds,
+    oddsError,
+    retryOdds,
     canExchange,
     retry,
   };

--- a/frontend/src/i18n/locales/en/poker.json
+++ b/frontend/src/i18n/locales/en/poker.json
@@ -12,6 +12,8 @@
   "exchangeLabel": "Exchange",
   "standLabel": "Stand",
   "drawOdds": "Draw Odds:",
+  "oddsFetchFailed": "Failed to fetch odds.",
+  "oddsRetry": "Retry",
   "cpuExchange": "CPU Exchange:",
   "cpuExchangeEntry": "Player {{idx}}: exchanged {{count}} card(s)",
   "exchangeCount": "Exchanged: {{count}}",

--- a/frontend/src/i18n/locales/ja/poker.json
+++ b/frontend/src/i18n/locales/ja/poker.json
@@ -12,6 +12,8 @@
   "exchangeLabel": "交換",
   "standLabel": "スタンド",
   "drawOdds": "ドローオッズ:",
+  "oddsFetchFailed": "オッズの取得に失敗しました。",
+  "oddsRetry": "再試行",
   "cpuExchange": "CPU交換:",
   "cpuExchangeEntry": "Player {{idx}}: {{count}}枚交換",
   "exchangeCount": "交換: {{count}}枚",

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -104,8 +104,20 @@ function PokerPageContent() {
   const { cardWidth } = useCardDimensions();
   const { playSound } = useSound();
   const isMobile = useIsMobile();
-  const { state, loading, error, exec, retry, selected, toggleCard, clearSelection, odds, canExchange } =
-    usePokerGame();
+  const {
+    state,
+    loading,
+    error,
+    exec,
+    retry,
+    selected,
+    toggleCard,
+    clearSelection,
+    odds,
+    oddsError,
+    retryOdds,
+    canExchange,
+  } = usePokerGame();
   const { hint, hintEnabled, setHintEnabled } = useGameHint('poker', state);
 
   // CLI mode
@@ -354,6 +366,22 @@ function PokerPageContent() {
                       <span>{(o.probability * 100).toFixed(1)}%</span>
                     </div>
                   ))}
+              </div>
+            )}
+            {canExchange && oddsError && (
+              <div
+                role="alert"
+                className="bg-ds-error/20 border border-ds-error rounded-lg px-4 py-2 mb-2 text-white text-xs flex items-center justify-between gap-2"
+                data-testid="odds-error"
+              >
+                <span>{t('oddsFetchFailed')}</span>
+                <button
+                  type="button"
+                  onClick={retryOdds}
+                  className="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ds-accent"
+                >
+                  {t('oddsRetry')}
+                </button>
               </div>
             )}
 


### PR DESCRIPTION
## Summary

Addresses 5 UI/UX issues raised in #1365.

- **#1 CpuActionToast Escape hijack** — skip Esc handling when an `aria-modal` dialog is open; restore focus to the previously-active element when the toast dismisses, so Esc no longer wipes toast + modal simultaneously and focus doesn't fall to `<body>`.
- **#2 DropZone keyboard a11y (infrastructure)** — DropZone now accepts optional `onKeyboardDrop` + `ariaLabel` + `keyboardDropDisabled` props. When provided, the zone becomes `role="region"` with an sr-only-until-focused "move here" button, making it possible for pages to expose a keyboard-accessible drop path without touching drag semantics. Per-page wiring (Space/Enter card selection + handler passing) for the ~15 solitaire pages is intentionally deferred to a follow-up PR to keep the scope reviewable.
- **#3 Poker odds silent catch** — `usePokerGame` now exposes `oddsError` + `retryOdds`. `PokerPage` renders an inline alert + retry button when odds fetch fails.
- **#4 `<html lang>` bootstrap** — `index.html` reads `localStorage.i18nextLng` synchronously and updates `document.documentElement.lang` before React mounts, so the initial frame and JS-failure fallback have the correct language attribute (WCAG 3.1.1).
- **#5 focus-visible consistency** — migrated `CpuActionToast`'s close button to `focus-visible:ring` (the only remaining `focus:ring` usage).

Includes unit tests for the new toast, DropZone, and odds-error behaviors.

Closes #1365

## Test plan

- [x] `bun run build` passes
- [x] `bun run check` (biome) clean on touched files
- [x] `bun run test` — 331 files / 5235 tests pass
- [ ] Manual: open a confirm dialog while a CPU toast is visible → Esc closes only the dialog; focus returns to trigger
- [ ] Manual: temporarily break the odds endpoint → odds-error banner appears with working retry
- [ ] Manual: set localStorage `i18nextLng=en`, reload → `<html lang="en">` on initial paint