### PR TITLE
refactor: apply cleanups from issue #1366 (items #2/#3/#4)

### DIFF
--- a/cmd/workers/casino/main.go
+++ b/cmd/workers/casino/main.go
@@ -21,7 +21,7 @@ func main() {
 	mux := http.NewServeMux()
 
 	// BlackJack
-	if err := worker.RegisterKV(mux, "/blackjack/exec", "blackjack:",
+	must(worker.RegisterKV(mux, "/blackjack/exec", "blackjack:",
 		func() usecase.BlackJackInteractorIF {
 			return usecase.NewBlackJackInteractor(
 				domain.NewDefaultBlackJack(),
@@ -32,12 +32,10 @@ func main() {
 			return usecase.RestoreBlackJackInteractor(data, new(presenter.BlackJackWebPresenter))
 		},
 		controller.NewBlackJackWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Baccarat
-	if err := worker.RegisterKV(mux, "/baccarat/exec", "baccarat:",
+	must(worker.RegisterKV(mux, "/baccarat/exec", "baccarat:",
 		func() usecase.BaccaratInteractorIF {
 			return usecase.NewBaccaratInteractor(
 				domain.NewDefaultBaccarat(),
@@ -48,12 +46,10 @@ func main() {
 			return usecase.RestoreBaccaratInteractor(data, new(presenter.BaccaratWebPresenter))
 		},
 		controller.NewBaccaratWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Poker
-	if err := worker.RegisterKV(mux, "/poker/exec", "poker:",
+	must(worker.RegisterKV(mux, "/poker/exec", "poker:",
 		func() usecase.PokerInteractorIF {
 			config := domain.DefaultPokerConfig()
 			players := []*domain.PokerPlayer{
@@ -69,12 +65,10 @@ func main() {
 			return usecase.RestorePokerInteractor(data, new(presenter.PokerWebPresenter))
 		},
 		controller.NewPokerWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Texas Hold'em
-	if err := worker.RegisterKV(mux, "/holdem/exec", "holdem:",
+	must(worker.RegisterKV(mux, "/holdem/exec", "holdem:",
 		func() usecase.HoldemInteractorIF {
 			cfg := domain.DefaultHoldemConfig()
 			holdem := domain.NewHoldem(domain.NewTrumpCards(0), domain.NewPlayersForTable(cfg.TableSize), cfg)
@@ -84,12 +78,10 @@ func main() {
 			return usecase.RestoreHoldemInteractor(data, new(presenter.HoldemWebPresenter))
 		},
 		controller.NewHoldemWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Omaha
-	if err := worker.RegisterKV(mux, "/omaha/exec", "omaha:",
+	must(worker.RegisterKV(mux, "/omaha/exec", "omaha:",
 		func() usecase.OmahaInteractorIF {
 			cfg := domain.DefaultOmahaConfig()
 			omaha := domain.NewOmaha(domain.NewTrumpCards(0), domain.NewOmahaPlayersForTable(cfg.TableSize), cfg)
@@ -99,12 +91,10 @@ func main() {
 			return usecase.RestoreOmahaInteractor(data, new(presenter.OmahaWebPresenter))
 		},
 		controller.NewOmahaWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Short Deck
-	if err := worker.RegisterKV(mux, "/shortdeck/exec", "shortdeck:",
+	must(worker.RegisterKV(mux, "/shortdeck/exec", "shortdeck:",
 		func() usecase.ShortDeckInteractorIF {
 			cfg := domain.DefaultShortDeckConfig()
 			sd := domain.NewShortDeck(domain.NewTrumpCardsShortDeck(), domain.NewShortDeckPlayersForTable(cfg.TableSize), cfg)
@@ -114,12 +104,10 @@ func main() {
 			return usecase.RestoreShortDeckInteractor(data, new(presenter.ShortDeckWebPresenter))
 		},
 		controller.NewShortDeckWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Indian Poker
-	if err := worker.RegisterKV(mux, "/indianpoker/exec", "indianpoker:",
+	must(worker.RegisterKV(mux, "/indianpoker/exec", "indianpoker:",
 		func() usecase.IndianPokerInteractorIF {
 			cfg := domain.DefaultIndianPokerConfig()
 			ip := domain.NewIndianPoker(domain.NewTrumpCards(0), domain.NewIndianPokerPlayers(), cfg)
@@ -129,12 +117,10 @@ func main() {
 			return usecase.RestoreIndianPokerInteractor(data, new(presenter.IndianPokerWebPresenter))
 		},
 		controller.NewIndianPokerWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Video Poker
-	if err := worker.RegisterKV(mux, "/videopoker/exec", "videopoker:",
+	must(worker.RegisterKV(mux, "/videopoker/exec", "videopoker:",
 		func() usecase.VideoPokerInteractorIF {
 			return usecase.NewVideoPokerInteractor(
 				domain.NewDefaultVideoPoker(),
@@ -145,12 +131,10 @@ func main() {
 			return usecase.RestoreVideoPokerInteractor(data, new(presenter.VideoPokerWebPresenter))
 		},
 		controller.NewVideoPokerWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Deuces Wild
-	if err := worker.RegisterKV(mux, "/deuceswild/exec", "deuceswild:",
+	must(worker.RegisterKV(mux, "/deuceswild/exec", "deuceswild:",
 		func() usecase.VideoPokerInteractorIF {
 			return usecase.NewVideoPokerInteractor(
 				domain.NewDeucesWildVideoPoker(),
@@ -161,12 +145,10 @@ func main() {
 			return usecase.RestoreVideoPokerInteractor(data, new(presenter.VideoPokerWebPresenter))
 		},
 		controller.NewVideoPokerWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Joker Poker
-	if err := worker.RegisterKV(mux, "/jokerpoker/exec", "jokerpoker:",
+	must(worker.RegisterKV(mux, "/jokerpoker/exec", "jokerpoker:",
 		func() usecase.VideoPokerInteractorIF {
 			return usecase.NewVideoPokerInteractor(
 				domain.NewJokerPokerVideoPoker(),
@@ -177,12 +159,10 @@ func main() {
 			return usecase.RestoreVideoPokerInteractor(data, new(presenter.VideoPokerWebPresenter))
 		},
 		controller.NewVideoPokerWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Three Card Poker
-	if err := worker.RegisterKV(mux, "/threecard/exec", "threecard:",
+	must(worker.RegisterKV(mux, "/threecard/exec", "threecard:",
 		func() usecase.ThreeCardInteractorIF {
 			return usecase.NewThreeCardInteractor(
 				domain.NewDefaultThreeCard(),
@@ -193,12 +173,10 @@ func main() {
 			return usecase.RestoreThreeCardInteractor(data, new(presenter.ThreeCardWebPresenter))
 		},
 		controller.NewThreeCardWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Pineapple Poker
-	if err := worker.RegisterKV(mux, "/pineapple/exec", "pineapple:",
+	must(worker.RegisterKV(mux, "/pineapple/exec", "pineapple:",
 		func() usecase.PineappleInteractorIF {
 			cfg := domain.DefaultPineappleConfig()
 			pineapple := domain.NewPineapple(domain.NewTrumpCards(0), domain.NewPineapplePlayersForTable(cfg.TableSize), cfg)
@@ -208,12 +186,10 @@ func main() {
 			return usecase.RestorePineappleInteractor(data, new(presenter.PineappleWebPresenter))
 		},
 		controller.NewPineappleWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Seven Card Stud
-	if err := worker.RegisterKV(mux, "/sevencardstud/exec", "sevencardstud:",
+	must(worker.RegisterKV(mux, "/sevencardstud/exec", "sevencardstud:",
 		func() usecase.SevenCardStudInteractorIF {
 			cfg := domain.DefaultSevenCardStudConfig()
 			scs := domain.NewSevenCardStud(domain.NewTrumpCards(0), domain.NewSevenCardStudPlayersForTable(cfg.TableSize), cfg)
@@ -223,12 +199,10 @@ func main() {
 			return usecase.RestoreSevenCardStudInteractor(data, new(presenter.SevenCardStudWebPresenter))
 		},
 		controller.NewSevenCardStudWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Pai Gow Poker
-	if err := worker.RegisterKV(mux, "/paigow/exec", "paigow:",
+	must(worker.RegisterKV(mux, "/paigow/exec", "paigow:",
 		func() usecase.PaiGowInteractorIF {
 			return usecase.NewPaiGowInteractor(
 				domain.NewDefaultPaiGow(),
@@ -239,12 +213,10 @@ func main() {
 			return usecase.RestorePaiGowInteractor(data, new(presenter.PaiGowWebPresenter))
 		},
 		controller.NewPaiGowWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Caribbean Stud Poker
-	if err := worker.RegisterKV(mux, "/caribbeanstud/exec", "caribbeanstud:",
+	must(worker.RegisterKV(mux, "/caribbeanstud/exec", "caribbeanstud:",
 		func() usecase.CaribbeanStudInteractorIF {
 			return usecase.NewCaribbeanStudInteractor(
 				domain.NewDefaultCaribbeanStud(),
@@ -255,12 +227,10 @@ func main() {
 			return usecase.RestoreCaribbeanStudInteractor(data, new(presenter.CaribbeanStudWebPresenter))
 		},
 		controller.NewCaribbeanStudWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Let It Ride
-	if err := worker.RegisterKV(mux, "/letitride/exec", "letitride:",
+	must(worker.RegisterKV(mux, "/letitride/exec", "letitride:",
 		func() usecase.LetItRideInteractorIF {
 			return usecase.NewLetItRideInteractor(
 				domain.NewDefaultLetItRide(),
@@ -271,13 +241,17 @@ func main() {
 			return usecase.RestoreLetItRideInteractor(data, new(presenter.LetItRideWebPresenter))
 		},
 		controller.NewLetItRideWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	var handler http.Handler = mux
 	if origins := corsmw.ParseOrigins(cloudflare.Getenv("CORS_ALLOWED_ORIGINS")); origins != nil {
 		handler = corsmw.Middleware(origins, mux)
 	}
 	workers.Serve(handler)
+}
+
+func must(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/cmd/workers/classic/main.go
+++ b/cmd/workers/classic/main.go
@@ -21,7 +21,7 @@ func main() {
 	mux := http.NewServeMux()
 
 	// Hearts
-	if err := worker.RegisterKV(mux, "/hearts/exec", "hearts:",
+	must(worker.RegisterKV(mux, "/hearts/exec", "hearts:",
 		func() usecase.HeartsInteractorIF {
 			config := domain.DefaultHeartsConfig()
 			players := []*domain.HeartsPlayer{
@@ -37,12 +37,10 @@ func main() {
 			return usecase.RestoreHeartsInteractor(data, new(presenter.HeartsWebPresenter))
 		},
 		controller.NewHeartsWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Spades
-	if err := worker.RegisterKV(mux, "/spades/exec", "spades:",
+	must(worker.RegisterKV(mux, "/spades/exec", "spades:",
 		func() usecase.SpadesInteractorIF {
 			config := domain.DefaultSpadesConfig()
 			players := []*domain.SpadesPlayer{
@@ -58,12 +56,10 @@ func main() {
 			return usecase.RestoreSpadesInteractor(data, new(presenter.SpadesWebPresenter))
 		},
 		controller.NewSpadesWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Euchre
-	if err := worker.RegisterKV(mux, "/euchre/exec", "euchre:",
+	must(worker.RegisterKV(mux, "/euchre/exec", "euchre:",
 		func() usecase.EuchreInteractorIF {
 			config := domain.DefaultEuchreConfig()
 			players := []*domain.EuchrePlayer{
@@ -79,12 +75,10 @@ func main() {
 			return usecase.RestoreEuchreInteractor(data, new(presenter.EuchreWebPresenter))
 		},
 		controller.NewEuchreWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Napoleon
-	if err := worker.RegisterKV(mux, "/napoleon/exec", "napoleon:",
+	must(worker.RegisterKV(mux, "/napoleon/exec", "napoleon:",
 		func() usecase.NapoleonInteractorIF {
 			config := domain.DefaultNapoleonConfig()
 			players := []*domain.NapoleonPlayer{
@@ -100,12 +94,10 @@ func main() {
 			return usecase.RestoreNapoleonInteractor(data, new(presenter.NapoleonWebPresenter))
 		},
 		controller.NewNapoleonWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Old Maid
-	if err := worker.RegisterKV(mux, "/oldmaid/exec", "oldmaid:",
+	must(worker.RegisterKV(mux, "/oldmaid/exec", "oldmaid:",
 		func() usecase.OldMaidInteractorIF {
 			players := []*domain.OldMaidPlayer{
 				domain.NewOldMaidPlayer(true),
@@ -120,12 +112,10 @@ func main() {
 			return usecase.RestoreOldMaidInteractor(data, new(presenter.OldMaidWebPresenter))
 		},
 		controller.NewOldMaidWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Doubt
-	if err := worker.RegisterKV(mux, "/doubt/exec", "doubt:",
+	must(worker.RegisterKV(mux, "/doubt/exec", "doubt:",
 		func() usecase.DoubtInteractorIF {
 			players := []*domain.DoubtPlayer{
 				domain.NewDoubtPlayer(true),
@@ -140,12 +130,10 @@ func main() {
 			return usecase.RestoreDoubtInteractor(data, new(presenter.DoubtWebPresenter))
 		},
 		controller.NewDoubtWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Daifugo
-	if err := worker.RegisterKV(mux, "/daifugo/exec", "daifugo:",
+	must(worker.RegisterKV(mux, "/daifugo/exec", "daifugo:",
 		func() usecase.DaifugoInteractorIF {
 			config := domain.DefaultDaifugoConfig()
 			players := []*domain.DaifugoPlayer{
@@ -161,12 +149,10 @@ func main() {
 			return usecase.RestoreDaifugoInteractor(data, new(presenter.DaifugoWebPresenter))
 		},
 		controller.NewDaifugoWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Sevens
-	if err := worker.RegisterKV(mux, "/sevens/exec", "sevens:",
+	must(worker.RegisterKV(mux, "/sevens/exec", "sevens:",
 		func() usecase.SevensInteractorIF {
 			config := domain.DefaultSevensConfig()
 			players := []*domain.SevensPlayer{
@@ -182,12 +168,10 @@ func main() {
 			return usecase.RestoreSevensInteractor(data, new(presenter.SevensWebPresenter))
 		},
 		controller.NewSevensWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Crazy Eights
-	if err := worker.RegisterKV(mux, "/crazyeights/exec", "crazyeights:",
+	must(worker.RegisterKV(mux, "/crazyeights/exec", "crazyeights:",
 		func() usecase.CrazyEightsInteractorIF {
 			config := domain.DefaultCrazyEightsConfig()
 			players := []*domain.CrazyEightsPlayer{
@@ -203,12 +187,10 @@ func main() {
 			return usecase.RestoreCrazyEightsInteractor(data, new(presenter.CrazyEightsWebPresenter))
 		},
 		controller.NewCrazyEightsWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Oh Hell
-	if err := worker.RegisterKV(mux, "/ohhell/exec", "ohhell:",
+	must(worker.RegisterKV(mux, "/ohhell/exec", "ohhell:",
 		func() usecase.OhHellInteractorIF {
 			config := domain.DefaultOhHellConfig()
 			players := []*domain.OhHellPlayer{
@@ -224,12 +206,10 @@ func main() {
 			return usecase.RestoreOhHellInteractor(data, new(presenter.OhHellWebPresenter))
 		},
 		controller.NewOhHellWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Contract Bridge
-	if err := worker.RegisterKV(mux, "/bridge/exec", "bridge:",
+	must(worker.RegisterKV(mux, "/bridge/exec", "bridge:",
 		func() usecase.BridgeInteractorIF {
 			config := domain.DefaultBridgeConfig()
 			players := []*domain.BridgePlayer{
@@ -245,12 +225,10 @@ func main() {
 			return usecase.RestoreBridgeInteractor(data, new(presenter.BridgeWebPresenter))
 		},
 		controller.NewBridgeWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Speed
-	if err := worker.RegisterKV(mux, "/speed/exec", "speed:",
+	must(worker.RegisterKV(mux, "/speed/exec", "speed:",
 		func() usecase.SpeedInteractorIF {
 			config := domain.DefaultSpeedConfig()
 			players := []*domain.SpeedPlayer{
@@ -264,12 +242,10 @@ func main() {
 			return usecase.RestoreSpeedInteractor(data, new(presenter.SpeedWebPresenter))
 		},
 		controller.NewSpeedWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Go Fish
-	if err := worker.RegisterKV(mux, "/gofish/exec", "gofish:",
+	must(worker.RegisterKV(mux, "/gofish/exec", "gofish:",
 		func() usecase.GoFishInteractorIF {
 			players := []*domain.GoFishPlayer{
 				domain.NewGoFishPlayer(true),
@@ -284,12 +260,10 @@ func main() {
 			return usecase.RestoreGoFishInteractor(data, new(presenter.GoFishWebPresenter))
 		},
 		controller.NewGoFishWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Pinochle
-	if err := worker.RegisterKV(mux, "/pinochle/exec", "pinochle:",
+	must(worker.RegisterKV(mux, "/pinochle/exec", "pinochle:",
 		func() usecase.PinochleInteractorIF {
 			config := domain.DefaultPinochleConfig()
 			players := []*domain.PinochlePlayer{
@@ -305,12 +279,10 @@ func main() {
 			return usecase.RestorePinochleInteractor(data, new(presenter.PinochleWebPresenter))
 		},
 		controller.NewPinochleWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Pig's Tail
-	if err := worker.RegisterKV(mux, "/pigtail/exec", "pigtail:",
+	must(worker.RegisterKV(mux, "/pigtail/exec", "pigtail:",
 		func() usecase.PigsTailInteractorIF {
 			players := []*domain.PigsTailPlayer{
 				domain.NewPigsTailPlayer(true),
@@ -325,12 +297,10 @@ func main() {
 			return usecase.RestorePigsTailInteractor(data, new(presenter.PigsTailWebPresenter))
 		},
 		controller.NewPigsTailWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Two Ten Jack
-	if err := worker.RegisterKV(mux, "/twotenjack/exec", "twotenjack:",
+	must(worker.RegisterKV(mux, "/twotenjack/exec", "twotenjack:",
 		func() usecase.TwoTenJackInteractorIF {
 			config := domain.DefaultTwoTenJackConfig()
 			players := []*domain.TwoTenJackPlayer{
@@ -346,12 +316,10 @@ func main() {
 			return usecase.RestoreTwoTenJackInteractor(data, new(presenter.TwoTenJackWebPresenter))
 		},
 		controller.NewTwoTenJackWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// War
-	if err := worker.RegisterKV(mux, "/war/exec", "war:",
+	must(worker.RegisterKV(mux, "/war/exec", "war:",
 		func() usecase.WarInteractorIF {
 			config := domain.DefaultWarConfig()
 			players := []*domain.WarPlayer{
@@ -365,12 +333,10 @@ func main() {
 			return usecase.RestoreWarInteractor(data, new(presenter.WarWebPresenter))
 		},
 		controller.NewWarWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Durak
-	if err := worker.RegisterKV(mux, "/durak/exec", "durak:",
+	must(worker.RegisterKV(mux, "/durak/exec", "durak:",
 		func() usecase.DurakInteractorIF {
 			players := []*domain.DurakPlayer{
 				domain.NewDurakPlayer(true),
@@ -385,12 +351,10 @@ func main() {
 			return usecase.RestoreDurakInteractor(data, new(presenter.DurakWebPresenter))
 		},
 		controller.NewDurakWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Fifty-one
-	if err := worker.RegisterKV(mux, "/fiftyone/exec", "fiftyone:",
+	must(worker.RegisterKV(mux, "/fiftyone/exec", "fiftyone:",
 		func() usecase.FiftyOneInteractorIF {
 			players := []*domain.FiftyOnePlayer{
 				domain.NewFiftyOnePlayer(true),
@@ -405,12 +369,10 @@ func main() {
 			return usecase.RestoreFiftyOneInteractor(data, new(presenter.FiftyOneWebPresenter))
 		},
 		controller.NewFiftyOneWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Whist
-	if err := worker.RegisterKV(mux, "/whist/exec", "whist:",
+	must(worker.RegisterKV(mux, "/whist/exec", "whist:",
 		func() usecase.WhistInteractorIF {
 			config := domain.DefaultWhistConfig()
 			players := []*domain.WhistPlayer{
@@ -426,12 +388,10 @@ func main() {
 			return usecase.RestoreWhistInteractor(data, new(presenter.WhistWebPresenter))
 		},
 		controller.NewWhistWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Page One
-	if err := worker.RegisterKV(mux, "/pageone/exec", "pageone:",
+	must(worker.RegisterKV(mux, "/pageone/exec", "pageone:",
 		func() usecase.PageOneInteractorIF {
 			config := domain.DefaultPageOneConfig()
 			players := []*domain.PageOnePlayer{
@@ -447,13 +407,17 @@ func main() {
 			return usecase.RestorePageOneInteractor(data, new(presenter.PageOneWebPresenter))
 		},
 		controller.NewPageOneWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	var handler http.Handler = mux
 	if origins := corsmw.ParseOrigins(cloudflare.Getenv("CORS_ALLOWED_ORIGINS")); origins != nil {
 		handler = corsmw.Middleware(origins, mux)
 	}
 	workers.Serve(handler)
+}
+
+func must(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/cmd/workers/solo/main.go
+++ b/cmd/workers/solo/main.go
@@ -21,7 +21,7 @@ func main() {
 	mux := http.NewServeMux()
 
 	// Klondike
-	if err := worker.RegisterKV(mux, "/klondike/exec", "klondike:",
+	must(worker.RegisterKV(mux, "/klondike/exec", "klondike:",
 		func() usecase.KlondikeInteractorIF {
 			klondike := domain.NewKlondike(domain.NewTrumpCards(0))
 			return usecase.NewKlondikeInteractor(klondike, new(presenter.KlondikeWebPresenter))
@@ -30,12 +30,10 @@ func main() {
 			return usecase.RestoreKlondikeInteractor(data, new(presenter.KlondikeWebPresenter))
 		},
 		controller.NewKlondikeWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// FreeCell
-	if err := worker.RegisterKV(mux, "/freecell/exec", "freecell:",
+	must(worker.RegisterKV(mux, "/freecell/exec", "freecell:",
 		func() usecase.FreeCellInteractorIF {
 			freeCell := domain.NewFreeCell(domain.NewTrumpCards(0))
 			return usecase.NewFreeCellInteractor(freeCell, new(presenter.FreeCellWebPresenter))
@@ -44,12 +42,10 @@ func main() {
 			return usecase.RestoreFreeCellInteractor(data, new(presenter.FreeCellWebPresenter))
 		},
 		controller.NewFreeCellWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Spider
-	if err := worker.RegisterKV(mux, "/spider/exec", "spider:",
+	must(worker.RegisterKV(mux, "/spider/exec", "spider:",
 		func() usecase.SpiderInteractorIF {
 			spider := domain.NewSpider(domain.NewTrumpCardsWithSuits(domain.SpiderTotalCards, []int{domain.CardDesignSpade}))
 			return usecase.NewSpiderInteractor(spider, new(presenter.SpiderWebPresenter))
@@ -58,12 +54,10 @@ func main() {
 			return usecase.RestoreSpiderInteractor(data, new(presenter.SpiderWebPresenter))
 		},
 		controller.NewSpiderWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Pyramid
-	if err := worker.RegisterKV(mux, "/pyramid/exec", "pyramid:",
+	must(worker.RegisterKV(mux, "/pyramid/exec", "pyramid:",
 		func() usecase.PyramidInteractorIF {
 			pyramid := domain.NewPyramid(domain.NewTrumpCards(0))
 			return usecase.NewPyramidInteractor(pyramid, new(presenter.PyramidWebPresenter))
@@ -72,12 +66,10 @@ func main() {
 			return usecase.RestorePyramidInteractor(data, new(presenter.PyramidWebPresenter))
 		},
 		controller.NewPyramidWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// TriPeaks
-	if err := worker.RegisterKV(mux, "/tripeaks/exec", "tripeaks:",
+	must(worker.RegisterKV(mux, "/tripeaks/exec", "tripeaks:",
 		func() usecase.TriPeaksInteractorIF {
 			triPeaks := domain.NewTriPeaks(domain.NewTrumpCards(0))
 			return usecase.NewTriPeaksInteractor(triPeaks, new(presenter.TriPeaksWebPresenter))
@@ -86,12 +78,10 @@ func main() {
 			return usecase.RestoreTriPeaksInteractor(data, new(presenter.TriPeaksWebPresenter))
 		},
 		controller.NewTriPeaksWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Memory
-	if err := worker.RegisterKV(mux, "/memory/exec", "memory:",
+	must(worker.RegisterKV(mux, "/memory/exec", "memory:",
 		func() usecase.MemoryInteractorIF {
 			config := domain.DefaultMemoryConfig()
 			players := []*domain.MemoryPlayer{
@@ -107,12 +97,10 @@ func main() {
 			return usecase.RestoreMemoryInteractor(data, new(presenter.MemoryWebPresenter))
 		},
 		controller.NewMemoryWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Gin Rummy
-	if err := worker.RegisterKV(mux, "/ginrummy/exec", "ginrummy:",
+	must(worker.RegisterKV(mux, "/ginrummy/exec", "ginrummy:",
 		func() usecase.GinRummyInteractorIF {
 			config := domain.DefaultGinRummyConfig()
 			players := []*domain.GinRummyPlayer{
@@ -126,12 +114,10 @@ func main() {
 			return usecase.RestoreGinRummyInteractor(data, new(presenter.GinRummyWebPresenter))
 		},
 		controller.NewGinRummyWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Cribbage
-	if err := worker.RegisterKV(mux, "/cribbage/exec", "cribbage:",
+	must(worker.RegisterKV(mux, "/cribbage/exec", "cribbage:",
 		func() usecase.CribbageInteractorIF {
 			config := domain.DefaultCribbageConfig()
 			players := []*domain.CribbagePlayer{
@@ -145,12 +131,10 @@ func main() {
 			return usecase.RestoreCribbageInteractor(data, new(presenter.CribbageWebPresenter))
 		},
 		controller.NewCribbageWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Canasta
-	if err := worker.RegisterKV(mux, "/canasta/exec", "canasta:",
+	must(worker.RegisterKV(mux, "/canasta/exec", "canasta:",
 		func() usecase.CanastaInteractorIF {
 			config := domain.DefaultCanastaConfig()
 			players := []*domain.CanastaPlayer{
@@ -164,12 +148,10 @@ func main() {
 			return usecase.RestoreCanastaInteractor(data, new(presenter.CanastaWebPresenter))
 		},
 		controller.NewCanastaWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Golf
-	if err := worker.RegisterKV(mux, "/golf/exec", "golf:",
+	must(worker.RegisterKV(mux, "/golf/exec", "golf:",
 		func() usecase.GolfInteractorIF {
 			golf := domain.NewGolf(domain.NewTrumpCards(0))
 			return usecase.NewGolfInteractor(golf, new(presenter.GolfWebPresenter))
@@ -178,12 +160,10 @@ func main() {
 			return usecase.RestoreGolfInteractor(data, new(presenter.GolfWebPresenter))
 		},
 		controller.NewGolfWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Clock Solitaire
-	if err := worker.RegisterKV(mux, "/clocksolitaire/exec", "clocksolitaire:",
+	must(worker.RegisterKV(mux, "/clocksolitaire/exec", "clocksolitaire:",
 		func() usecase.ClockSolitaireInteractorIF {
 			cs := domain.NewClockSolitaire(domain.NewTrumpCards(0))
 			return usecase.NewClockSolitaireInteractor(cs, new(presenter.ClockSolitaireWebPresenter))
@@ -192,12 +172,10 @@ func main() {
 			return usecase.RestoreClockSolitaireInteractor(data, new(presenter.ClockSolitaireWebPresenter))
 		},
 		controller.NewClockSolitaireWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Canfield
-	if err := worker.RegisterKV(mux, "/canfield/exec", "canfield:",
+	must(worker.RegisterKV(mux, "/canfield/exec", "canfield:",
 		func() usecase.CanfieldInteractorIF {
 			canfield := domain.NewCanfield(domain.NewTrumpCards(0))
 			return usecase.NewCanfieldInteractor(canfield, new(presenter.CanfieldWebPresenter))
@@ -206,12 +184,10 @@ func main() {
 			return usecase.RestoreCanfieldInteractor(data, new(presenter.CanfieldWebPresenter))
 		},
 		controller.NewCanfieldWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Forty Thieves
-	if err := worker.RegisterKV(mux, "/fortythieves/exec", "fortythieves:",
+	must(worker.RegisterKV(mux, "/fortythieves/exec", "fortythieves:",
 		func() usecase.FortyThievesInteractorIF {
 			ft := domain.NewFortyThieves(domain.NewTrumpCardsWithDecks(2, 0))
 			return usecase.NewFortyThievesInteractor(ft, new(presenter.FortyThievesWebPresenter))
@@ -220,12 +196,10 @@ func main() {
 			return usecase.RestoreFortyThievesInteractor(data, new(presenter.FortyThievesWebPresenter))
 		},
 		controller.NewFortyThievesWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Poker Squares
-	if err := worker.RegisterKV(mux, "/pokersquares/exec", "pokersquares:",
+	must(worker.RegisterKV(mux, "/pokersquares/exec", "pokersquares:",
 		func() usecase.PokerSquaresInteractorIF {
 			ps := domain.NewPokerSquares(domain.NewTrumpCards(0))
 			return usecase.NewPokerSquaresInteractor(ps, new(presenter.PokerSquaresWebPresenter))
@@ -234,12 +208,10 @@ func main() {
 			return usecase.RestorePokerSquaresInteractor(data, new(presenter.PokerSquaresWebPresenter))
 		},
 		controller.NewPokerSquaresWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	// Yukon
-	if err := worker.RegisterKV(mux, "/yukon/exec", "yukon:",
+	must(worker.RegisterKV(mux, "/yukon/exec", "yukon:",
 		func() usecase.YukonInteractorIF {
 			yukon := domain.NewYukon(domain.NewTrumpCards(0))
 			return usecase.NewYukonInteractor(yukon, new(presenter.YukonWebPresenter))
@@ -248,13 +220,17 @@ func main() {
 			return usecase.RestoreYukonInteractor(data, new(presenter.YukonWebPresenter))
 		},
 		controller.NewYukonWebControllerWithProvider,
-	); err != nil {
-		log.Fatal(err)
-	}
+	))
 
 	var handler http.Handler = mux
 	if origins := corsmw.ParseOrigins(cloudflare.Getenv("CORS_ALLOWED_ORIGINS")); origins != nil {
 		handler = corsmw.Middleware(origins, mux)
 	}
 	workers.Serve(handler)
+}
+
+func must(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/frontend/src/constants/videoPokerTutorial.ts
+++ b/frontend/src/constants/videoPokerTutorial.ts
@@ -1,0 +1,29 @@
+import type { TutorialStep } from '../types/tutorial';
+
+/** Shared tutorial step definitions for Video Poker variants (VP, Deuces Wild, Joker Poker). */
+export const VIDEO_POKER_TUTORIAL_STEPS: TutorialStep[] = [
+  {
+    target: '[data-tutorial="vp-bet-controls"]',
+    messageKey: 'tutorial.betControls',
+    placement: 'top',
+    advanceOn: 'next',
+  },
+  {
+    target: '[data-tutorial="vp-hand"]',
+    messageKey: 'tutorial.hand',
+    placement: 'bottom',
+    advanceOn: 'next',
+  },
+  {
+    target: '[data-tutorial="vp-draw-button"]',
+    messageKey: 'tutorial.drawButton',
+    placement: 'top',
+    advanceOn: 'next',
+  },
+  {
+    target: '[data-tutorial="vp-reset-button"]',
+    messageKey: 'tutorial.resetButton',
+    placement: 'top',
+    advanceOn: 'next',
+  },
+];

--- a/frontend/src/hooks/useTrickGameBase.ts
+++ b/frontend/src/hooks/useTrickGameBase.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
@@ -101,33 +101,33 @@ export function useTrickGameBase<TState, TArgs extends unknown[], TConfig extend
 
   const defaultConfigRef = useRef(defaultConfig);
 
-  // Trick-taking APIs all share the shape (command, arg1?, arg2?, config?). We
-  // widen once here so the command dispatch below stays type-safe and avoids
-  // scattering `as unknown as` casts across every handler.
-  const execCmd = useMemo(() => exec as unknown as (command: string, ...rest: unknown[]) => Promise<void>, [exec]);
-  const apiCmd = useMemo(() => apiFn as unknown as (command: string, ...rest: unknown[]) => Promise<TState>, [apiFn]);
+  // Trick-taking APIs all share the shape (command, arg1?, arg2?, config?).
+  // The generic TArgs tuple prevents a direct call, so each dispatch casts
+  // through this widened command signature. Casts are compile-time only.
+  type ExecCmd = (command: string, ...rest: unknown[]) => Promise<void>;
+  type ApiCmd = (command: string, ...rest: unknown[]) => Promise<TState>;
 
   useEffect(() => {
-    execCmd('reset', undefined, undefined, defaultConfigRef.current);
-  }, [execCmd]);
+    (exec as unknown as ExecCmd)('reset', undefined, undefined, defaultConfigRef.current);
+  }, [exec]);
 
   const handlePlay = useCallback(() => {
     if (selectedCardIndices.length !== 1) return;
-    execCmd('play', undefined, selectedCardIndices[0]);
-  }, [execCmd, selectedCardIndices]);
+    (exec as unknown as ExecCmd)('play', undefined, selectedCardIndices[0]);
+  }, [exec, selectedCardIndices]);
 
   const handleNextTrick = useCallback(() => {
-    execCmd('next');
-  }, [execCmd]);
+    (exec as unknown as ExecCmd)('next');
+  }, [exec]);
 
   const handleNextRound = useCallback(() => {
-    execCmd('nextround');
-  }, [execCmd]);
+    (exec as unknown as ExecCmd)('nextround');
+  }, [exec]);
 
   const handleHint = useCallback(async () => {
     setHintLoading(true);
     try {
-      const res = await apiCmd('hint');
+      const res = await (apiFn as unknown as ApiCmd)('hint');
       setHint(getHint(res) ?? null);
       setHintError(null);
     } catch {
@@ -135,7 +135,7 @@ export function useTrickGameBase<TState, TArgs extends unknown[], TConfig extend
     } finally {
       setHintLoading(false);
     }
-  }, [apiCmd, getHint]);
+  }, [apiFn, getHint]);
 
   return {
     state,

--- a/frontend/src/hooks/useTrickGameBase.ts
+++ b/frontend/src/hooks/useTrickGameBase.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
@@ -101,29 +101,33 @@ export function useTrickGameBase<TState, TArgs extends unknown[], TConfig extend
 
   const defaultConfigRef = useRef(defaultConfig);
 
-  type ExecAny = (...args: unknown[]) => Promise<void>;
+  // Trick-taking APIs all share the shape (command, arg1?, arg2?, config?). We
+  // widen once here so the command dispatch below stays type-safe and avoids
+  // scattering `as unknown as` casts across every handler.
+  const execCmd = useMemo(() => exec as unknown as (command: string, ...rest: unknown[]) => Promise<void>, [exec]);
+  const apiCmd = useMemo(() => apiFn as unknown as (command: string, ...rest: unknown[]) => Promise<TState>, [apiFn]);
 
   useEffect(() => {
-    (exec as unknown as ExecAny)('reset', undefined, undefined, defaultConfigRef.current);
-  }, [exec]);
+    execCmd('reset', undefined, undefined, defaultConfigRef.current);
+  }, [execCmd]);
 
   const handlePlay = useCallback(() => {
     if (selectedCardIndices.length !== 1) return;
-    (exec as unknown as ExecAny)('play', undefined, selectedCardIndices[0]);
-  }, [exec, selectedCardIndices]);
+    execCmd('play', undefined, selectedCardIndices[0]);
+  }, [execCmd, selectedCardIndices]);
 
   const handleNextTrick = useCallback(() => {
-    (exec as unknown as ExecAny)('next');
-  }, [exec]);
+    execCmd('next');
+  }, [execCmd]);
 
   const handleNextRound = useCallback(() => {
-    (exec as unknown as ExecAny)('nextround');
-  }, [exec]);
+    execCmd('nextround');
+  }, [execCmd]);
 
   const handleHint = useCallback(async () => {
     setHintLoading(true);
     try {
-      const res = await (apiFn as unknown as (...args: unknown[]) => Promise<TState>)('hint');
+      const res = await apiCmd('hint');
       setHint(getHint(res) ?? null);
       setHintError(null);
     } catch {
@@ -131,7 +135,7 @@ export function useTrickGameBase<TState, TArgs extends unknown[], TConfig extend
     } finally {
       setHintLoading(false);
     }
-  }, [apiFn, getHint]);
+  }, [apiCmd, getHint]);
 
   return {
     state,

--- a/frontend/src/pages/DeucesWildPage.tsx
+++ b/frontend/src/pages/DeucesWildPage.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { deuceswildApi } from '../api/gameApi';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
 import { VideoPokerGameContent } from '../components/VideoPokerGameContent';
-import type { TutorialStep } from '../types/tutorial';
+import { VIDEO_POKER_TUTORIAL_STEPS } from '../constants/videoPokerTutorial';
 import { DEUCESWILD_HELP, parseDeuceswildCommand } from '../utils/cli/commands/deuceswildCommands';
 import { formatDeuceswildState } from '../utils/cli/formatters/deuceswildFormatter';
 
@@ -21,34 +21,6 @@ const DW_PAYOUT_ROWS = [
   'threeOfAKind',
 ];
 
-/** Deuces Wild tutorial step definitions. */
-const DW_TUTORIAL_STEPS: TutorialStep[] = [
-  {
-    target: '[data-tutorial="vp-bet-controls"]',
-    messageKey: 'tutorial.betControls',
-    placement: 'top',
-    advanceOn: 'next',
-  },
-  {
-    target: '[data-tutorial="vp-hand"]',
-    messageKey: 'tutorial.hand',
-    placement: 'bottom',
-    advanceOn: 'next',
-  },
-  {
-    target: '[data-tutorial="vp-draw-button"]',
-    messageKey: 'tutorial.drawButton',
-    placement: 'top',
-    advanceOn: 'next',
-  },
-  {
-    target: '[data-tutorial="vp-reset-button"]',
-    messageKey: 'tutorial.resetButton',
-    placement: 'top',
-    advanceOn: 'next',
-  },
-];
-
 /** Renders the Deuces Wild game page. */
 export function DeucesWildPage() {
   const cliGameConfig = useMemo(
@@ -60,7 +32,7 @@ export function DeucesWildPage() {
     [],
   );
   return (
-    <TutorialWrapper gameName="deuceswild" steps={DW_TUTORIAL_STEPS}>
+    <TutorialWrapper gameName="deuceswild" steps={VIDEO_POKER_TUTORIAL_STEPS}>
       <VideoPokerGameContent
         gameName="deuceswild"
         i18nNamespace="deuceswild"

--- a/frontend/src/pages/JokerPokerPage.tsx
+++ b/frontend/src/pages/JokerPokerPage.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { jokerpokerApi } from '../api/gameApi';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
 import { VideoPokerGameContent } from '../components/VideoPokerGameContent';
-import type { TutorialStep } from '../types/tutorial';
+import { VIDEO_POKER_TUTORIAL_STEPS } from '../constants/videoPokerTutorial';
 import { JOKERPOKER_HELP, parseJokerpokerCommand } from '../utils/cli/commands/jokerpokerCommands';
 import { formatJokerpokerState } from '../utils/cli/formatters/jokerpokerFormatter';
 
@@ -22,34 +22,6 @@ const JP_PAYOUT_ROWS = [
   'kingsOrBetter',
 ];
 
-/** Joker Poker tutorial step definitions. */
-const JP_TUTORIAL_STEPS: TutorialStep[] = [
-  {
-    target: '[data-tutorial="vp-bet-controls"]',
-    messageKey: 'tutorial.betControls',
-    placement: 'top',
-    advanceOn: 'next',
-  },
-  {
-    target: '[data-tutorial="vp-hand"]',
-    messageKey: 'tutorial.hand',
-    placement: 'bottom',
-    advanceOn: 'next',
-  },
-  {
-    target: '[data-tutorial="vp-draw-button"]',
-    messageKey: 'tutorial.drawButton',
-    placement: 'top',
-    advanceOn: 'next',
-  },
-  {
-    target: '[data-tutorial="vp-reset-button"]',
-    messageKey: 'tutorial.resetButton',
-    placement: 'top',
-    advanceOn: 'next',
-  },
-];
-
 /** Renders the Joker Poker (Kings or Better) game page. */
 export function JokerPokerPage() {
   const cliGameConfig = useMemo(
@@ -61,7 +33,7 @@ export function JokerPokerPage() {
     [],
   );
   return (
-    <TutorialWrapper gameName="jokerpoker" steps={JP_TUTORIAL_STEPS}>
+    <TutorialWrapper gameName="jokerpoker" steps={VIDEO_POKER_TUTORIAL_STEPS}>
       <VideoPokerGameContent
         gameName="jokerpoker"
         i18nNamespace="jokerpoker"

--- a/frontend/src/pages/VideoPokerPage.tsx
+++ b/frontend/src/pages/VideoPokerPage.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { videopokerApi } from '../api/gameApi';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
 import { VideoPokerGameContent } from '../components/VideoPokerGameContent';
-import type { TutorialStep } from '../types/tutorial';
+import { VIDEO_POKER_TUTORIAL_STEPS } from '../constants/videoPokerTutorial';
 import { parseVideopokerCommand, VIDEOPOKER_HELP } from '../utils/cli/commands/videopokerCommands';
 import { formatVideopokerState } from '../utils/cli/formatters/videopokerFormatter';
 
@@ -20,34 +20,6 @@ const JOB_PAYOUT_ROWS = [
   'jacksOrBetter',
 ];
 
-/** Video Poker tutorial step definitions. */
-const VP_TUTORIAL_STEPS: TutorialStep[] = [
-  {
-    target: '[data-tutorial="vp-bet-controls"]',
-    messageKey: 'tutorial.betControls',
-    placement: 'top',
-    advanceOn: 'next',
-  },
-  {
-    target: '[data-tutorial="vp-hand"]',
-    messageKey: 'tutorial.hand',
-    placement: 'bottom',
-    advanceOn: 'next',
-  },
-  {
-    target: '[data-tutorial="vp-draw-button"]',
-    messageKey: 'tutorial.drawButton',
-    placement: 'top',
-    advanceOn: 'next',
-  },
-  {
-    target: '[data-tutorial="vp-reset-button"]',
-    messageKey: 'tutorial.resetButton',
-    placement: 'top',
-    advanceOn: 'next',
-  },
-];
-
 /** Renders the Video Poker (Jacks or Better) game page. */
 export function VideoPokerPage() {
   const cliGameConfig = useMemo(
@@ -59,7 +31,7 @@ export function VideoPokerPage() {
     [],
   );
   return (
-    <TutorialWrapper gameName="videopoker" steps={VP_TUTORIAL_STEPS}>
+    <TutorialWrapper gameName="videopoker" steps={VIDEO_POKER_TUTORIAL_STEPS}>
       <VideoPokerGameContent
         gameName="videopoker"
         i18nNamespace="videopoker"


### PR DESCRIPTION
## Summary

Addresses [issue #1366](https://github.com/yuta-yoshinaga/go_trumpcards/issues/1366) — DRY/KISS cleanups.

- **#2 (DRY)**: Extract shared Video Poker tutorial steps into `frontend/src/constants/videoPokerTutorial.ts` and consume it from `VideoPokerPage`, `DeucesWildPage`, `JokerPokerPage`. Eliminates ~80 lines of duplicated `TutorialStep[]` arrays.
- **#3 (DRY/KISS)**: Replace the repeated `if err := worker.RegisterKV(...); err != nil { log.Fatal(err) }` pattern in `cmd/workers/{solo,casino,classic}/main.go` with a local `must()` helper. Workers shrink from 1002 → 916 LOC without creating 50+ new packages.
- **#4 (KISS / type safety)**: Consolidate scattered `as unknown as ExecAny` casts in `useTrickGameBase` into a single `useMemo`-memoised widened-function pair. Command dispatch no longer casts at each call site.

### Item #1 was a false alarm

The issue claimed VideoPokerPage/DeucesWildPage/JokerPokerPage were missing `useGamePageSetup`. In fact `VideoPokerGameContent.tsx:77` already calls `useGamePageSetup(gameName)` internally for all 3 pages, so there is no missing setup. Skipped.

### Scope note on #3

The issue proposed per-game `Register` helpers in 50+ new packages. That's a large-surface refactor with low risk-adjusted payoff, so this PR takes the pragmatic middle step (kill the boilerplate via `must()`). Per-game packages can follow if/when we decide that structural split is worth it.

## Test plan

- [x] `GOOS=js GOARCH=wasm go build ./cmd/workers/{solo,casino,classic}` — clean
- [x] `GOOS=js GOARCH=wasm golangci-lint run ./cmd/workers/...` — 0 issues
- [x] `cd frontend && bun run check` — clean (pre-existing 2 warnings in OldMaidPlayerArea.test.tsx, unrelated)
- [x] `cd frontend && bun run test` — 5200/5200 tests pass (1 unhandled error is a pre-existing vitest worker-shutdown timeout on NavBar, unrelated)
- [ ] QA: manually verify VP/DW/JP tutorial still steps through identically
- [ ] QA: verify workers still register KV routes for all games

Closes #1366