### PR TITLE
fix(frontend): expand Doubt countdown options for a11y

### DIFF
--- a/frontend/src/hooks/useDoubtGame.ts
+++ b/frontend/src/hooks/useDoubtGame.ts
@@ -17,7 +17,7 @@ export const DEFAULT_DOUBT_CONFIG: DoubtConfig = {
 };
 
 /** Available doubt window duration options in seconds. */
-export const DOUBT_WINDOW_OPTIONS = [3, 5, 10] as const;
+export const DOUBT_WINDOW_OPTIONS = [3, 5, 10, 15, 30, 60] as const;
 
 /** CPU memory level options for Doubt. */
 export const CPU_MEMORY_OPTIONS = [


### PR DESCRIPTION
Closes #1373

## Summary
- Add 15s, 30s, 60s to `DOUBT_WINDOW_OPTIONS` so users who need more time (reduced-motion, screen readers, slower operation) can pick a longer doubt window
- Default remains 10s — no behavior change for existing users

## Test plan
- [x] `bun run test` passes
- [x] `bun run check` passes
- [x] `bun run build` passes