### PR TITLE
fix(cli): route CLI error output to stderr

### DIFF
--- a/internal/adapter/controller/BlackJackCuiController_test.go
+++ b/internal/adapter/controller/BlackJackCuiController_test.go
@@ -88,7 +88,7 @@ func TestBlackJackCuiController_Method(t *testing.T) {
 		assert.Equal(t, mockOutput, tbc.Exec("declineinsurance"))
 	})
 	t.Run("success Exec other", func(t *testing.T) {
-		assert.Equal(t, "コマンドが不明です: other", tbc.Exec("other"))
+		assert.Equal(t, "\x1eERR\x1eコマンドが不明です: other", tbc.Exec("other"))
 	})
 	t.Run("success Exec empty", func(t *testing.T) {
 		assert.Equal(t, "'help' でコマンド一覧を表示します。", tbc.Exec(""))

--- a/internal/adapter/controller/BlackJackCuiController_test.go
+++ b/internal/adapter/controller/BlackJackCuiController_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/usecase"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -88,7 +89,7 @@ func TestBlackJackCuiController_Method(t *testing.T) {
 		assert.Equal(t, mockOutput, tbc.Exec("declineinsurance"))
 	})
 	t.Run("success Exec other", func(t *testing.T) {
-		assert.Equal(t, "\x1eERR\x1eコマンドが不明です: other", tbc.Exec("other"))
+		assert.Equal(t, i18n.ErrorPrefix+"コマンドが不明です: other", tbc.Exec("other"))
 	})
 	t.Run("success Exec empty", func(t *testing.T) {
 		assert.Equal(t, "'help' でコマンド一覧を表示します。", tbc.Exec(""))

--- a/internal/adapter/controller/OldMaidCuiController_test.go
+++ b/internal/adapter/controller/OldMaidCuiController_test.go
@@ -58,7 +58,7 @@ func TestOldMaidCuiController_Method(t *testing.T) {
 		omiMock.AssertCalled(t, "Shuffle")
 	})
 	t.Run("success Exec other", func(t *testing.T) {
-		assert.Equal(t, "コマンドが不明です: other", tomc.Exec("other"))
+		assert.Equal(t, "\x1eERR\x1eコマンドが不明です: other", tomc.Exec("other"))
 	})
 	t.Run("success Exec empty", func(t *testing.T) {
 		assert.Equal(t, "'help' でコマンド一覧を表示します。", tomc.Exec(""))

--- a/internal/adapter/controller/OldMaidCuiController_test.go
+++ b/internal/adapter/controller/OldMaidCuiController_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/usecase"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -58,7 +59,7 @@ func TestOldMaidCuiController_Method(t *testing.T) {
 		omiMock.AssertCalled(t, "Shuffle")
 	})
 	t.Run("success Exec other", func(t *testing.T) {
-		assert.Equal(t, "\x1eERR\x1eコマンドが不明です: other", tomc.Exec("other"))
+		assert.Equal(t, i18n.ErrorPrefix+"コマンドが不明です: other", tomc.Exec("other"))
 	})
 	t.Run("success Exec empty", func(t *testing.T) {
 		assert.Equal(t, "'help' でコマンド一覧を表示します。", tomc.Exec(""))

--- a/internal/adapter/controller/PokerCuiController_test.go
+++ b/internal/adapter/controller/PokerCuiController_test.go
@@ -233,7 +233,7 @@ func TestPokerCuiController_Empty(t *testing.T) {
 func TestPokerCuiController_Unknown(t *testing.T) {
 	mi := new(mockUsecase.MockPokerInteractor)
 	c := NewPokerCuiController(mi)
-	assert.Equal(t, "コマンドが不明です: xyz", c.Exec("xyz"))
+	assert.Equal(t, "\x1eERR\x1eコマンドが不明です: xyz", c.Exec("xyz"))
 }
 
 // --- betting limit ---

--- a/internal/adapter/controller/PokerCuiController_test.go
+++ b/internal/adapter/controller/PokerCuiController_test.go
@@ -8,6 +8,7 @@ import (
 
 	mockUsecase "github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/usecase"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 // --- quit ---
@@ -233,7 +234,7 @@ func TestPokerCuiController_Empty(t *testing.T) {
 func TestPokerCuiController_Unknown(t *testing.T) {
 	mi := new(mockUsecase.MockPokerInteractor)
 	c := NewPokerCuiController(mi)
-	assert.Equal(t, "\x1eERR\x1eコマンドが不明です: xyz", c.Exec("xyz"))
+	assert.Equal(t, i18n.ErrorPrefix+"コマンドが不明です: xyz", c.Exec("xyz"))
 }
 
 // --- betting limit ---

--- a/internal/adapter/controller/cui_controller_helper.go
+++ b/internal/adapter/controller/cui_controller_helper.go
@@ -14,9 +14,9 @@ const suggestMaxDistance = 2
 // validCommands が指定されている場合、Levenshtein距離に基づく提案を含める。
 func unknownCommandMessage(command string, validCommands []string) string {
 	if suggestion := cuiutil.SuggestCommand(command, validCommands, suggestMaxDistance); suggestion != "" {
-		return i18n.Tf("unknownCommandWithSuggestion", "cmd", command, "suggestion", suggestion)
+		return i18n.MarkError(i18n.Tf("unknownCommandWithSuggestion", "cmd", command, "suggestion", suggestion))
 	}
-	return i18n.Tf("unknownCommand", "cmd", command)
+	return i18n.MarkError(i18n.Tf("unknownCommand", "cmd", command))
 }
 
 // commonCommands は全CUIコントローラーで共通のコマンド。

--- a/internal/adapter/controller/cui_controller_helper_test.go
+++ b/internal/adapter/controller/cui_controller_helper_test.go
@@ -6,20 +6,21 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func TestUnknownCommandMessage(t *testing.T) {
 	t.Run("no suggestion", func(t *testing.T) {
-		assert.Equal(t, "\x1eERR\x1eコマンドが不明です: foo", unknownCommandMessage("foo", nil))
+		assert.Equal(t, i18n.ErrorPrefix+"コマンドが不明です: foo", unknownCommandMessage("foo", nil))
 	})
 	t.Run("empty command", func(t *testing.T) {
-		assert.Equal(t, "\x1eERR\x1eコマンドが不明です: ", unknownCommandMessage("", nil))
+		assert.Equal(t, i18n.ErrorPrefix+"コマンドが不明です: ", unknownCommandMessage("", nil))
 	})
 	t.Run("with suggestion", func(t *testing.T) {
-		assert.Equal(t, "\x1eERR\x1eコマンドが不明です: hti。もしかして 'hit' ですか？", unknownCommandMessage("hti", []string{"hit", "stand"}))
+		assert.Equal(t, i18n.ErrorPrefix+"コマンドが不明です: hti。もしかして 'hit' ですか？", unknownCommandMessage("hti", []string{"hit", "stand"}))
 	})
 	t.Run("no close match", func(t *testing.T) {
-		assert.Equal(t, "\x1eERR\x1eコマンドが不明です: zzzzzzz", unknownCommandMessage("zzzzzzz", []string{"hit", "stand"}))
+		assert.Equal(t, i18n.ErrorPrefix+"コマンドが不明です: zzzzzzz", unknownCommandMessage("zzzzzzz", []string{"hit", "stand"}))
 	})
 }
 
@@ -78,11 +79,11 @@ func TestExecCuiCommand(t *testing.T) {
 
 	t.Run("unhandled game command with suggestion", func(t *testing.T) {
 		result := execCuiCommand("gam", resetFn, validCmds, gameHandler)
-		assert.Equal(t, "\x1eERR\x1eコマンドが不明です: gam。もしかして 'game' ですか？", result)
+		assert.Equal(t, i18n.ErrorPrefix+"コマンドが不明です: gam。もしかして 'game' ですか？", result)
 	})
 
 	t.Run("unhandled game command no suggestion", func(t *testing.T) {
 		result := execCuiCommand("zzzzzzz", resetFn, validCmds, gameHandler)
-		assert.Equal(t, "\x1eERR\x1eコマンドが不明です: zzzzzzz", result)
+		assert.Equal(t, i18n.ErrorPrefix+"コマンドが不明です: zzzzzzz", result)
 	})
 }

--- a/internal/adapter/controller/cui_controller_helper_test.go
+++ b/internal/adapter/controller/cui_controller_helper_test.go
@@ -10,16 +10,16 @@ import (
 
 func TestUnknownCommandMessage(t *testing.T) {
 	t.Run("no suggestion", func(t *testing.T) {
-		assert.Equal(t, "コマンドが不明です: foo", unknownCommandMessage("foo", nil))
+		assert.Equal(t, "\x1eERR\x1eコマンドが不明です: foo", unknownCommandMessage("foo", nil))
 	})
 	t.Run("empty command", func(t *testing.T) {
-		assert.Equal(t, "コマンドが不明です: ", unknownCommandMessage("", nil))
+		assert.Equal(t, "\x1eERR\x1eコマンドが不明です: ", unknownCommandMessage("", nil))
 	})
 	t.Run("with suggestion", func(t *testing.T) {
-		assert.Equal(t, "コマンドが不明です: hti。もしかして 'hit' ですか？", unknownCommandMessage("hti", []string{"hit", "stand"}))
+		assert.Equal(t, "\x1eERR\x1eコマンドが不明です: hti。もしかして 'hit' ですか？", unknownCommandMessage("hti", []string{"hit", "stand"}))
 	})
 	t.Run("no close match", func(t *testing.T) {
-		assert.Equal(t, "コマンドが不明です: zzzzzzz", unknownCommandMessage("zzzzzzz", []string{"hit", "stand"}))
+		assert.Equal(t, "\x1eERR\x1eコマンドが不明です: zzzzzzz", unknownCommandMessage("zzzzzzz", []string{"hit", "stand"}))
 	})
 }
 
@@ -78,11 +78,11 @@ func TestExecCuiCommand(t *testing.T) {
 
 	t.Run("unhandled game command with suggestion", func(t *testing.T) {
 		result := execCuiCommand("gam", resetFn, validCmds, gameHandler)
-		assert.Equal(t, "コマンドが不明です: gam。もしかして 'game' ですか？", result)
+		assert.Equal(t, "\x1eERR\x1eコマンドが不明です: gam。もしかして 'game' ですか？", result)
 	})
 
 	t.Run("unhandled game command no suggestion", func(t *testing.T) {
 		result := execCuiCommand("zzzzzzz", resetFn, validCmds, gameHandler)
-		assert.Equal(t, "コマンドが不明です: zzzzzzz", result)
+		assert.Equal(t, "\x1eERR\x1eコマンドが不明です: zzzzzzz", result)
 	})
 }

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -14,6 +14,28 @@ var localesFS embed.FS
 // QuitSentinel is the internal protocol value returned by controllers on quit.
 const QuitSentinel = "bye."
 
+// ErrorPrefix marks a CUI result as an error to be routed to stderr.
+// The prefix itself is stripped before display. Using ASCII Record Separator (0x1E)
+// keeps it invisible to users and unlikely to collide with any real content.
+const ErrorPrefix = "\x1eERR\x1e"
+
+// MarkError prefixes msg so the CUI runner routes it to stderr.
+// Returns msg unchanged if it is empty or already marked.
+func MarkError(msg string) string {
+	if msg == "" || strings.HasPrefix(msg, ErrorPrefix) {
+		return msg
+	}
+	return ErrorPrefix + msg
+}
+
+// StripErrorPrefix removes ErrorPrefix from msg and reports whether it was present.
+func StripErrorPrefix(msg string) (body string, isError bool) {
+	if strings.HasPrefix(msg, ErrorPrefix) {
+		return msg[len(ErrorPrefix):], true
+	}
+	return msg, false
+}
+
 var currentLang = "ja"
 var translations = map[string]string{}
 

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -91,6 +91,24 @@ func TestQuitSentinel(t *testing.T) {
 	assert.Equal(t, "bye.", i18n.QuitSentinel)
 }
 
+func TestMarkError(t *testing.T) {
+	assert.Equal(t, i18n.ErrorPrefix+"boom", i18n.MarkError("boom"))
+	assert.Equal(t, "", i18n.MarkError(""))
+	// idempotent
+	marked := i18n.MarkError("boom")
+	assert.Equal(t, marked, i18n.MarkError(marked))
+}
+
+func TestStripErrorPrefix(t *testing.T) {
+	body, isErr := i18n.StripErrorPrefix(i18n.ErrorPrefix + "boom")
+	assert.True(t, isErr)
+	assert.Equal(t, "boom", body)
+
+	body, isErr = i18n.StripErrorPrefix("ok")
+	assert.False(t, isErr)
+	assert.Equal(t, "ok", body)
+}
+
 func TestT_English_unknownCommand(t *testing.T) {
 	i18n.SetLang("en")
 	result := i18n.T("unknownCommand")

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -218,7 +218,7 @@ func (m *GameManager) switchGame(name string) string {
 		if suggestion := cuiutil.SuggestCommand(name, m.gameOrder, 2); suggestion != "" {
 			msg += "\n  " + i18n.Tf("didYouMean", "name", suggestion)
 		}
-		return msg
+		return i18n.MarkError(msg)
 	}
 	if name == m.currentGame {
 		return i18n.Tf("alreadyPlaying", "name", name)

--- a/internal/infrastructure/ui/cui_runner.go
+++ b/internal/infrastructure/ui/cui_runner.go
@@ -63,8 +63,17 @@ func RunInteractiveCuiLoop(manager *GameManager) {
 			fmt.Println(i18n.T("bye"))
 			break
 		}
-		fmt.Println(res)
+		printResult(res)
 	}
+}
+
+// printResult writes res to stdout, or to stderr when marked as an error.
+func printResult(res string) {
+	if body, isErr := i18n.StripErrorPrefix(res); isErr {
+		fmt.Fprintln(os.Stderr, body)
+		return
+	}
+	fmt.Println(res)
 }
 
 // RunCuiLoop 標準CUIゲームループを実行する
@@ -92,7 +101,7 @@ func RunCuiLoop(controller CuiExecer, helpLines []string) {
 			fmt.Println(i18n.T("bye"))
 			break
 		}
-		fmt.Println(res)
+		printResult(res)
 	}
 }
 


### PR DESCRIPTION
Closes #1376

## Summary
- Introduce `i18n.ErrorPrefix` sentinel with `MarkError`/`StripErrorPrefix` helpers
- CUI runner strips the prefix and writes marked results to `os.Stderr` (POSIX convention)
- Applied to `unknownCommandMessage` (all game controllers) and `unknownGame` in `GameManager`
- Other output paths unchanged — keeps terminal rendering order for normal gameplay

## Test plan
- [x] New unit tests for `MarkError` / `StripErrorPrefix`
- [x] Existing controller tests updated to expect the prefix
- [x] \`go test -tags test ./...\` passes
- [x] \`golangci-lint run ./...\` clean