### PR TITLE
feat(frontend): add keyboard shortcuts to Speed

### DIFF
--- a/frontend/src/pages/SpeedPage.test.tsx
+++ b/frontend/src/pages/SpeedPage.test.tsx
@@ -250,6 +250,23 @@ describe('SpeedPage', () => {
     expect(flipPileBtns[0]).toHaveClass('animate-pulse');
   });
 
+  it('keyboard shortcut: digit key smart-plays the matching hand card', async () => {
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
+    // Hand index 0 is SPADE 4 (single-valid-pile → smart-click auto-plays to pile 0)
+    fireEvent.keyDown(window, { key: '1' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', 0, 0));
+  });
+
+  it('keyboard shortcut: ArrowRight plays the selected card to right pile', async () => {
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
+    // Select a card with no auto-pile so it stays selected
+    fireEvent.click(screen.getByRole('button', { name: 'DIAMOND 2' }));
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', 3, 1));
+  });
+
   it('renders the auto-flip settings toggle', async () => {
     renderWithProviders(<SpeedPage />);
     await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());

--- a/frontend/src/pages/SpeedPage.test.tsx
+++ b/frontend/src/pages/SpeedPage.test.tsx
@@ -267,6 +267,41 @@ describe('SpeedPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', 3, 1));
   });
 
+  it('keyboard shortcut: ArrowLeft plays the selected card to left pile', async () => {
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: 'DIAMOND 2' }));
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', 3, 0));
+  });
+
+  it('keyboard shortcut: arrow keys are ignored when no card is selected', async () => {
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('keyboard shortcut: digit beyond hand size is ignored', async () => {
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(window, { key: '5' });
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('keyboard shortcut: modifier keys (Ctrl/Alt/Meta) bypass the handler', async () => {
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(window, { key: '1', ctrlKey: true });
+    fireEvent.keyDown(window, { key: 'ArrowLeft', altKey: true });
+    fireEvent.keyDown(window, { key: '2', metaKey: true });
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
   it('renders the auto-flip settings toggle', async () => {
     renderWithProviders(<SpeedPage />);
     await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import type { speedApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -97,41 +97,39 @@ function SpeedPageContent() {
   const { handleCommand } = useCliGame(gameExec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
   // Keyboard shortcuts: 1..N select a hand card; ←/→ play selected card to left/right center pile.
-  // Active only when CLI mode is off and a play phase is in progress. Respects input focus.
+  // Active only when CLI mode is off and a play phase is in progress. Respects input focus
+  // and skips when modifier keys (Ctrl/Alt/Meta) are held to avoid hijacking browser shortcuts.
+  // Latest state and handlers are read via refs so the listener is registered only once
+  // per enable/disable transition rather than on every state update (e.g. each CPU move).
   const isPlayPhaseForKeys = state?.phase === SpeedPhase.PLAY;
-  const handCardCount = state?.players?.[0]?.cards.length ?? 0;
+  const keyHandlersRef = useRef({ state, handleSmartClick, handlePlay, selectedCardIndices });
+  keyHandlersRef.current = { state, handleSmartClick, handlePlay, selectedCardIndices };
   useEffect(() => {
     if (cliEnabled || !isPlayPhaseForKeys || loading) return;
     const onKey = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement | null;
       if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) return;
+      if (e.ctrlKey || e.altKey || e.metaKey) return;
+      const cur = keyHandlersRef.current;
+      if (!cur.state) return;
       if (e.key >= '1' && e.key <= '9') {
         const idx = Number.parseInt(e.key, 10) - 1;
-        if (idx < handCardCount && state) {
+        if (idx < cur.state.players[0].cards.length) {
           e.preventDefault();
-          handleSmartClick(idx, state.players[0].cards, state.centerPiles);
+          cur.handleSmartClick(idx, cur.state.players[0].cards, cur.state.centerPiles);
         }
         return;
       }
       if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
-        if (selectedCardIndices.length === 1) {
+        if (cur.selectedCardIndices.length === 1) {
           e.preventDefault();
-          handlePlay(e.key === 'ArrowLeft' ? 0 : 1);
+          cur.handlePlay(e.key === 'ArrowLeft' ? 0 : 1);
         }
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [
-    cliEnabled,
-    isPlayPhaseForKeys,
-    loading,
-    handCardCount,
-    state,
-    handleSmartClick,
-    handlePlay,
-    selectedCardIndices,
-  ]);
+  }, [cliEnabled, isPlayPhaseForKeys, loading]);
 
   if (!state || state.players.length < 2) return <SpeedSkeleton />;
 

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import type { speedApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -95,6 +95,43 @@ function SpeedPageContent() {
     [],
   );
   const { handleCommand } = useCliGame(gameExec, cliConfig, state, { addInput, addOutput, addError, clearLog });
+
+  // Keyboard shortcuts: 1..N select a hand card; ←/→ play selected card to left/right center pile.
+  // Active only when CLI mode is off and a play phase is in progress. Respects input focus.
+  const isPlayPhaseForKeys = state?.phase === SpeedPhase.PLAY;
+  const handCardCount = state?.players?.[0]?.cards.length ?? 0;
+  useEffect(() => {
+    if (cliEnabled || !isPlayPhaseForKeys || loading) return;
+    const onKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) return;
+      if (e.key >= '1' && e.key <= '9') {
+        const idx = Number.parseInt(e.key, 10) - 1;
+        if (idx < handCardCount && state) {
+          e.preventDefault();
+          handleSmartClick(idx, state.players[0].cards, state.centerPiles);
+        }
+        return;
+      }
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+        if (selectedCardIndices.length === 1) {
+          e.preventDefault();
+          handlePlay(e.key === 'ArrowLeft' ? 0 : 1);
+        }
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [
+    cliEnabled,
+    isPlayPhaseForKeys,
+    loading,
+    handCardCount,
+    state,
+    handleSmartClick,
+    handlePlay,
+    selectedCardIndices,
+  ]);
 
   if (!state || state.players.length < 2) return <SpeedSkeleton />;
 


### PR DESCRIPTION
Closes #1374

## Summary
- Add 1..9 to smart-play a hand card (auto-plays when only one valid pile, otherwise selects)
- Add ArrowLeft / ArrowRight to play the currently selected card to the left/right center pile
- Active only when CLI mode is off, the play phase is in progress, and focus is not in an input
- Reduces tap/click count on desktop and improves accessibility for keyboard-only users

Touch-gesture (swipe) handling was deferred to keep this change minimal and dependency-free; the existing one-tap smart-click already covers the common single-valid-pile case on mobile.

## Test plan
- [x] New unit tests cover digit-key smart play and Arrow-key selected-card play
- [x] \`bun run test\` passes
- [x] \`bun run check\` passes
- [x] \`bun run build\` passes