### PR TITLE
refactor(frontend): introduce ChipBetInput common component

### DIFF
--- a/frontend/src/components/common/ChipBetInput.test.tsx
+++ b/frontend/src/components/common/ChipBetInput.test.tsx
@@ -19,6 +19,27 @@ describe('ChipBetInput', () => {
     expect(onChange).toHaveBeenCalledWith(120);
   });
 
+  it('clamps values above max to max', () => {
+    const onChange = vi.fn();
+    render(<ChipBetInput id="bet" label="Bet" value={10} onChange={onChange} max={500} />);
+    fireEvent.change(screen.getByLabelText('Bet'), { target: { value: '99999' } });
+    expect(onChange).toHaveBeenCalledWith(500);
+  });
+
+  it('clamps values below min to min', () => {
+    const onChange = vi.fn();
+    render(<ChipBetInput id="bet" label="Bet" value={50} onChange={onChange} max={500} min={20} />);
+    fireEvent.change(screen.getByLabelText('Bet'), { target: { value: '5' } });
+    expect(onChange).toHaveBeenCalledWith(20);
+  });
+
+  it('treats empty input as min (Number("") === 0 is clamped up)', () => {
+    const onChange = vi.fn();
+    render(<ChipBetInput id="bet" label="Bet" value={50} onChange={onChange} max={500} />);
+    fireEvent.change(screen.getByLabelText('Bet'), { target: { value: '' } });
+    expect(onChange).toHaveBeenCalledWith(10);
+  });
+
   it('respects custom min, step, and disabled props', () => {
     render(<ChipBetInput id="bet" label="Bet" value={5} onChange={() => {}} max={100} min={5} step={5} disabled />);
     const input = screen.getByLabelText('Bet') as HTMLInputElement;

--- a/frontend/src/components/common/ChipBetInput.test.tsx
+++ b/frontend/src/components/common/ChipBetInput.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ChipBetInput } from './ChipBetInput';
+
+describe('ChipBetInput', () => {
+  it('renders label associated with input via htmlFor', () => {
+    render(<ChipBetInput id="bet" label="Bet" value={50} onChange={() => {}} max={500} />);
+    const input = screen.getByLabelText('Bet') as HTMLInputElement;
+    expect(input.value).toBe('50');
+    expect(input.min).toBe('10');
+    expect(input.step).toBe('10');
+    expect(input.max).toBe('500');
+  });
+
+  it('calls onChange with parsed numeric value', () => {
+    const onChange = vi.fn();
+    render(<ChipBetInput id="bet" label="Bet" value={10} onChange={onChange} max={500} />);
+    fireEvent.change(screen.getByLabelText('Bet'), { target: { value: '120' } });
+    expect(onChange).toHaveBeenCalledWith(120);
+  });
+
+  it('respects custom min, step, and disabled props', () => {
+    render(<ChipBetInput id="bet" label="Bet" value={5} onChange={() => {}} max={100} min={5} step={5} disabled />);
+    const input = screen.getByLabelText('Bet') as HTMLInputElement;
+    expect(input.min).toBe('5');
+    expect(input.step).toBe('5');
+    expect(input.disabled).toBe(true);
+  });
+});

--- a/frontend/src/components/common/ChipBetInput.tsx
+++ b/frontend/src/components/common/ChipBetInput.tsx
@@ -47,7 +47,11 @@ export function ChipBetInput({
         max={max}
         step={step}
         value={value}
-        onChange={(e) => onChange(Number(e.target.value))}
+        onChange={(e) => {
+          const parsed = Number(e.target.value);
+          if (Number.isNaN(parsed)) return;
+          onChange(Math.max(min, Math.min(parsed, max)));
+        }}
         disabled={disabled}
         className={`${widthClass} px-2 py-1 rounded text-sm`}
       />

--- a/frontend/src/components/common/ChipBetInput.tsx
+++ b/frontend/src/components/common/ChipBetInput.tsx
@@ -1,0 +1,56 @@
+/** Props for ChipBetInput. */
+export interface ChipBetInputProps {
+  /** DOM id used to associate the label with the input. */
+  id: string;
+  /** Visible label text. */
+  label: string;
+  /** Current bet value. */
+  value: number;
+  /** Called with the new numeric value when the user edits the field. */
+  onChange: (value: number) => void;
+  /** Maximum allowed bet (typically the player's chip balance). */
+  max: number;
+  /** Minimum allowed bet. Defaults to 10. */
+  min?: number;
+  /** Step size. Defaults to 10. */
+  step?: number;
+  /** Disable the input. */
+  disabled?: boolean;
+  /** Tailwind width class for the input. Defaults to "w-24". */
+  widthClass?: string;
+}
+
+/**
+ * Reusable label + numeric chip-bet input used across casino games
+ * (Baccarat, Caribbean Stud, Three Card Poker, Pai Gow, Let It Ride).
+ */
+export function ChipBetInput({
+  id,
+  label,
+  value,
+  onChange,
+  max,
+  min = 10,
+  step = 10,
+  disabled,
+  widthClass = 'w-24',
+}: ChipBetInputProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <label htmlFor={id} className="text-white text-sm">
+        {label}
+      </label>
+      <input
+        id={id}
+        type="number"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        disabled={disabled}
+        className={`${widthClass} px-2 py-1 rounded text-sm`}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -3,6 +3,7 @@ import { baccaratApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { ChipBetInput } from '../components/common/ChipBetInput';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
@@ -385,21 +386,13 @@ function BaccaratPageContent() {
             />
             {isBetPhase && (
               <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="bac-bet-controls">
-                <div className="flex items-center gap-2">
-                  <label htmlFor="baccarat-bet-amount" className="text-white text-sm">
-                    {t('label.betAmount')}
-                  </label>
-                  <input
-                    id="baccarat-bet-amount"
-                    type="number"
-                    min={10}
-                    max={state.chips}
-                    step={10}
-                    value={betAmount}
-                    onChange={(e) => setBetAmount(Number(e.target.value))}
-                    className="w-24 px-2 py-1 rounded text-sm"
-                  />
-                </div>
+                <ChipBetInput
+                  id="baccarat-bet-amount"
+                  label={t('label.betAmount')}
+                  value={betAmount}
+                  onChange={setBetAmount}
+                  max={state.chips}
+                />
                 <div className="flex items-center gap-2">
                   <label htmlFor="baccarat-bet-type" className="text-white text-sm">
                     {t('label.betTarget')}
@@ -416,36 +409,24 @@ function BaccaratPageContent() {
                   </select>
                 </div>
                 {/* Side bet inputs */}
-                <div className="flex items-center gap-2">
-                  <label htmlFor="baccarat-pp-bet" className="text-white text-sm">
-                    {t('sideBet.playerPair')}
-                  </label>
-                  <input
-                    id="baccarat-pp-bet"
-                    type="number"
-                    min={0}
-                    max={state.chips}
-                    step={10}
-                    value={playerPairBet}
-                    onChange={(e) => setPlayerPairBet(Number(e.target.value))}
-                    className="w-20 px-2 py-1 rounded text-sm"
-                  />
-                </div>
-                <div className="flex items-center gap-2">
-                  <label htmlFor="baccarat-bp-bet" className="text-white text-sm">
-                    {t('sideBet.bankerPair')}
-                  </label>
-                  <input
-                    id="baccarat-bp-bet"
-                    type="number"
-                    min={0}
-                    max={state.chips}
-                    step={10}
-                    value={bankerPairBet}
-                    onChange={(e) => setBankerPairBet(Number(e.target.value))}
-                    className="w-20 px-2 py-1 rounded text-sm"
-                  />
-                </div>
+                <ChipBetInput
+                  id="baccarat-pp-bet"
+                  label={t('sideBet.playerPair')}
+                  value={playerPairBet}
+                  onChange={setPlayerPairBet}
+                  max={state.chips}
+                  min={0}
+                  widthClass="w-20"
+                />
+                <ChipBetInput
+                  id="baccarat-bp-bet"
+                  label={t('sideBet.bankerPair')}
+                  value={bankerPairBet}
+                  onChange={setBankerPairBet}
+                  max={state.chips}
+                  min={0}
+                  widthClass="w-20"
+                />
                 <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading}>
                   {t('button.bet')}
                 </button>

--- a/frontend/src/pages/LetItRidePage.tsx
+++ b/frontend/src/pages/LetItRidePage.tsx
@@ -3,6 +3,7 @@ import { letitrideApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { ChipBetInput } from '../components/common/ChipBetInput';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
@@ -327,21 +328,13 @@ function LetItRidePageContent() {
             <SettingsPanel title={t('settings.title')} groups={[]} />
             {isBetPhase && (
               <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="lir-bet-controls">
-                <div className="flex items-center gap-2">
-                  <label htmlFor="letitride-bet-amount" className="text-white text-sm">
-                    {t('label.bet')}
-                  </label>
-                  <input
-                    id="letitride-bet-amount"
-                    type="number"
-                    min={10}
-                    max={Math.floor(state.chips / 3)}
-                    step={10}
-                    value={betAmount}
-                    onChange={(e) => setBetAmount(Number(e.target.value))}
-                    className="w-24 px-2 py-1 rounded text-sm"
-                  />
-                </div>
+                <ChipBetInput
+                  id="letitride-bet-amount"
+                  label={t('label.bet')}
+                  value={betAmount}
+                  onChange={setBetAmount}
+                  max={Math.floor(state.chips / 3)}
+                />
                 <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading}>
                   {t('button.bet')}
                 </button>


### PR DESCRIPTION
Closes #1375

## Summary
- Extract the repeating label + numeric chip-bet \`<input>\` pattern shared across casino games into a single \`ChipBetInput\` component
- Migrate \`BaccaratPage\` (3 inputs) and \`LetItRidePage\` (1 input) to use it
- \`CaribbeanStudPage\`, \`ThreeCardPage\`, and \`PaiGowPage\` can adopt the same component in follow-up changes (kept out of this PR to limit blast radius)

## Test plan
- [x] New unit tests for \`ChipBetInput\` (label association, onChange, custom min/step/disabled)
- [x] \`bun run test\` passes (Baccarat, LetItRide, ChipBetInput suites)
- [x] \`bun run check\` passes
- [x] \`bun run build\` passes