### PR TITLE
fix(cli): address issues #1390 #1391 #1392 for CLI UX

### DIFF
--- a/cmd/trumpcards/completion.go
+++ b/cmd/trumpcards/completion.go
@@ -132,7 +132,7 @@ func writeBashCompletion(w io.Writer) error {
     esac
 
     if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "--help --lang --no-color --version -h -V" -- "$cur") )
+        COMPREPLY=( $(compgen -W "--help --lang --no-color --version --version-short -h -V" -- "$cur") )
         return
     fi
 
@@ -163,6 +163,7 @@ _trumpcards() {
     _arguments \
         '(-h --help)'{-h,--help}'[Show help message]' \
         '(-V --version)'{-V,--version}'[Show version information]' \
+        '--version-short[Print version number only]' \
         '--lang[Language]:language:(ja en)' \
         '--no-color[Disable color output]' \
         '1:command:->cmds' \
@@ -216,6 +217,7 @@ complete -c trumpcards -f
 # Global options
 complete -c trumpcards -l help -s h -d 'Show help message'
 complete -c trumpcards -l version -s V -d 'Show version information'
+complete -c trumpcards -l version-short -d 'Print version number only'
 complete -c trumpcards -l lang -x -a 'ja en' -d 'Language'
 complete -c trumpcards -l no-color -d 'Disable color output'
 

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -377,10 +377,13 @@ func parseSubFlagsTo(name string, args []string, setup func(*flag.FlagSet), stdo
 	return fs, 0, true
 }
 
-// hasHelpFlag reports whether args contains "-h" or "--help".
+// hasHelpFlag reports whether args contains a help flag. It accepts all four
+// forms Go's flag package treats as equivalent for a help flag registered as
+// both "help" and "h": "-h", "--h", "-help", "--help".
 func hasHelpFlag(args []string) bool {
 	for _, a := range args {
-		if a == "-h" || a == "--help" {
+		switch a {
+		case "-h", "--h", "-help", "--help":
 			return true
 		}
 	}

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -39,6 +39,7 @@ func run() int {
 	lang := flag.String("lang", "", "language (ja or en)")
 	showVersion := flag.Bool("version", false, "Show version information")
 	flag.BoolVar(showVersion, "V", false, "Show version information (shorthand)")
+	showVersionShort := flag.Bool("version-short", false, "Print version number only (machine-readable)")
 	noColorFlag := flag.Bool("no-color", false, "Disable color output")
 	showHelp := flag.Bool("help", false, "Show this help message")
 	flag.BoolVar(showHelp, "h", false, "Show this help message (shorthand)")
@@ -52,12 +53,17 @@ func run() int {
 		return 0
 	}
 
-	// Color control: NO_COLOR env var (https://no-color.org/), --no-color flag,
-	// or non-TTY stdout (pipe/redirect auto-detection).
-	if os.Getenv("NO_COLOR") != "" || *noColorFlag || !term.IsTerminal(int(os.Stdout.Fd())) {
-		color.SetNoColor(true)
-	}
+	// Color control: NO_COLOR env var (https://no-color.org/) and --no-color flag
+	// force color off on both streams. TTY auto-detection is done per stream so that
+	// `game | tee log.txt` keeps stderr colors and `game 2> err.log` keeps stdout colors.
+	forceOff := os.Getenv("NO_COLOR") != "" || *noColorFlag
+	color.SetStdoutColor(!forceOff && term.IsTerminal(int(os.Stdout.Fd())))
+	color.SetStderrColor(!forceOff && term.IsTerminal(int(os.Stderr.Fd())))
 
+	if *showVersionShort {
+		fmt.Println(version)
+		return 0
+	}
 	if *showVersion {
 		fmt.Printf("trumpcards %s (commit: %s, built: %s)\n", version, commit, date)
 		return 0
@@ -201,6 +207,13 @@ func run() int {
 		arg = canonical
 	}
 	if handler, ok := commands[arg]; ok {
+		// `<game> --help` / `<game> -h`: Go's flag package stops parsing at the first
+		// non-flag argument, so these trailing flags land in Args(). Intercept them
+		// and print that game's help instead of launching the game. Subcommands in
+		// subFlagCommands are handled by parseSubFlags (which catches flag.ErrHelp).
+		if !subFlagCommands[arg] && hasHelpFlag(flag.Args()[1:]) {
+			return runHelpCommand([]string{arg}, helpText, os.Stdout, os.Stderr)
+		}
 		if flag.NArg() > 1 && !subFlagCommands[arg] {
 			fmt.Fprintln(os.Stderr, i18n.Tf("cliExtraArgsWarning", "args", strings.Join(flag.Args()[1:], " ")))
 		}
@@ -364,6 +377,16 @@ func parseSubFlagsTo(name string, args []string, setup func(*flag.FlagSet), stdo
 	return fs, 0, true
 }
 
+// hasHelpFlag reports whether args contains "-h" or "--help".
+func hasHelpFlag(args []string) bool {
+	for _, a := range args {
+		if a == "-h" || a == "--help" {
+			return true
+		}
+	}
+	return false
+}
+
 func mapKeys(m map[string]func() int) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
@@ -397,18 +420,23 @@ COMMANDS:
 OPTIONS:
   -h, --help        Show this help message
   --lang ja|en      Language (default: ja)
-  --no-color        Disable color output
+  --no-color        Disable color output (stdout and stderr)
+                    Auto-detection is per-stream: stdout color is on only
+                    when stdout is a TTY; the same applies to stderr.
   -V, --version     Show version information
+  --version-short   Print version number only (machine-readable)
 
 EXAMPLES:
   trumpcards                     Start interactive mode (switch games with 'switch <game>')
   trumpcards blackjack           Play BlackJack
+  trumpcards blackjack --help    Show BlackJack's in-game commands
   trumpcards --lang en poker     Play Poker in English
   trumpcards games               List all available games
   trumpcards games --short       List game names only (for scripting)
   trumpcards games --short --aliases  List game names including aliases
   trumpcards update              Self-update to the latest version
   trumpcards update --yes        Update without confirmation prompt
+  trumpcards --version-short     Print just the version number (e.g. 1.2.3)
   NO_COLOR=1 trumpcards hearts   Play Hearts without color output
   trumpcards web                 Start the web GUI server
   trumpcards web --port 3000     Start the web GUI on port 3000
@@ -416,7 +444,8 @@ EXAMPLES:
   source <(trumpcards completion bash)   Enable bash completion
 
 ENVIRONMENT VARIABLES:
-  NO_COLOR          Disable color output when set (see https://no-color.org/)
+  NO_COLOR          Disable color output on both stdout and stderr when set
+                    (see https://no-color.org/)
                     Example: NO_COLOR=1 trumpcards blackjack
   HOST              Bind address for the web server (default: all interfaces)
                     Example: HOST=127.0.0.1 trumpcards web

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/ui"
+)
+
+func init() {
+	// Ensure translations are loaded so messages render in a stable locale during tests.
+	i18n.SetLang("ja")
+}
+
+func TestHasHelpFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"empty", nil, false},
+		{"no help flag", []string{"--lang", "en"}, false},
+		{"--help present", []string{"--help"}, true},
+		{"-h present", []string{"-h"}, true},
+		{"help mixed with other args", []string{"--lang", "en", "--help"}, true},
+		{"short flag among multiple", []string{"foo", "-h", "bar"}, true},
+		{"looks like help but is not", []string{"-help", "--h"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasHelpFlag(tt.args); got != tt.want {
+				t.Errorf("hasHelpFlag(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunHelpCommandForGame(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	helpText := buildHelpText()
+	code := runHelpCommand([]string{"blackjack"}, helpText, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runHelpCommand exit = %d, want 0", code)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("expected no stderr output, got %q", stderr.String())
+	}
+	out := stdout.String()
+	if out == "" {
+		t.Fatal("expected blackjack help on stdout, got empty output")
+	}
+	// The BlackJack CUI's HelpLines() always contain the standard quit command.
+	if !strings.Contains(out, "q") {
+		t.Errorf("expected blackjack help to mention quit command; got: %q", out)
+	}
+}
+
+func TestRunHelpCommandResolvesAlias(t *testing.T) {
+	// "gin" is a canonical alias for "ginrummy". If this alias ever disappears,
+	// pick another from ui.GameAliases — we just need one known alias for coverage.
+	if _, ok := ui.GameAliases["gin"]; !ok {
+		t.Skip("alias 'gin' not registered; alias resolution still covered by other paths")
+	}
+	var stdout, stderr bytes.Buffer
+	helpText := buildHelpText()
+	code := runHelpCommand([]string{"gin"}, helpText, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runHelpCommand(gin) exit = %d, want 0", code)
+	}
+	if stdout.Len() == 0 {
+		t.Errorf("expected alias 'gin' to resolve to ginrummy help; got empty stdout")
+	}
+}
+
+func TestRunHelpCommandUnknownGame(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	helpText := buildHelpText()
+	code := runHelpCommand([]string{"definitelynotagame"}, helpText, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("runHelpCommand(unknown) exit = %d, want 1", code)
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("expected no stdout on unknown game; got %q", stdout.String())
+	}
+	if stderr.Len() == 0 {
+		t.Errorf("expected error output on stderr for unknown game")
+	}
+}
+
+func TestBuildHelpTextMentionsVersionShort(t *testing.T) {
+	helpText := buildHelpText()
+	if !strings.Contains(helpText, "--version-short") {
+		t.Errorf("help text should document --version-short; got:\n%s", helpText)
+	}
+}

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -24,9 +24,11 @@ func TestHasHelpFlag(t *testing.T) {
 		{"no help flag", []string{"--lang", "en"}, false},
 		{"--help present", []string{"--help"}, true},
 		{"-h present", []string{"-h"}, true},
+		{"-help present (Go flag treats as --help)", []string{"-help"}, true},
+		{"--h present (Go flag treats as -h)", []string{"--h"}, true},
 		{"help mixed with other args", []string{"--lang", "en", "--help"}, true},
 		{"short flag among multiple", []string{"foo", "-h", "bar"}, true},
-		{"looks like help but is not", []string{"-help", "--h"}, false},
+		{"not a help flag", []string{"--helpful", "-help-me"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -71,6 +73,41 @@ func TestRunHelpCommandResolvesAlias(t *testing.T) {
 	}
 	if stdout.Len() == 0 {
 		t.Errorf("expected alias 'gin' to resolve to ginrummy help; got empty stdout")
+	}
+}
+
+func TestRunHelpCommandForBuiltinSubcommand(t *testing.T) {
+	// "web" is a builtin subcommand (not a game). runHelpCommand should fall
+	// through the game-registry lookup and emit the entry from builtinSubcommandHelp.
+	var stdout, stderr bytes.Buffer
+	helpText := buildHelpText()
+	code := runHelpCommand([]string{"web"}, helpText, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runHelpCommand(web) exit = %d, want 0", code)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("expected no stderr output; got %q", stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "trumpcards web") {
+		t.Errorf("expected web help text; got: %q", out)
+	}
+}
+
+func TestRunHelpCommandExtraArgs(t *testing.T) {
+	// Extra positional args after the game name should trigger a warning
+	// on stderr but still return the game's help on stdout with exit 0.
+	var stdout, stderr bytes.Buffer
+	helpText := buildHelpText()
+	code := runHelpCommand([]string{"blackjack", "extra"}, helpText, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runHelpCommand(blackjack extra) exit = %d, want 0", code)
+	}
+	if stdout.Len() == 0 {
+		t.Errorf("expected blackjack help on stdout despite extra args")
+	}
+	if stderr.Len() == 0 {
+		t.Errorf("expected extra-args warning on stderr; got empty")
 	}
 }
 

--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -61,6 +61,9 @@ func BoldYellow(s string) string { return wrap("\033[1;33m", s, noColorStdout.Lo
 // RedStderr wraps s with red ANSI color code honoring the stderr color flag.
 func RedStderr(s string) string { return wrap("\033[31m", s, noColorStderr.Load()) }
 
+// GreenStderr wraps s with green ANSI color code honoring the stderr color flag.
+func GreenStderr(s string) string { return wrap("\033[32m", s, noColorStderr.Load()) }
+
 // YellowStderr wraps s with yellow ANSI color code honoring the stderr color flag.
 func YellowStderr(s string) string { return wrap("\033[33m", s, noColorStderr.Load()) }
 

--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -2,39 +2,70 @@ package color
 
 import "sync/atomic"
 
-var noColor atomic.Bool
+// Independent flags for stdout and stderr color output. This lets the CLI
+// enable color on stderr while stdout is being piped (e.g. `trumpcards <game> | tee log.txt`)
+// and conversely disable stderr color when it is redirected to a file.
+var (
+	noColorStdout atomic.Bool
+	noColorStderr atomic.Bool
+)
 
-// SetNoColor sets whether color output is disabled.
-// When true, callers should suppress ANSI color escape codes.
+// SetNoColor disables color output for both stdout and stderr when v is true,
+// and enables it for both when v is false. Kept for backward compatibility with
+// callers that do not need per-stream control.
 func SetNoColor(v bool) {
-	noColor.Store(v)
+	noColorStdout.Store(v)
+	noColorStderr.Store(v)
 }
 
-// NoColor reports whether color output is disabled.
-func NoColor() bool {
-	return noColor.Load()
-}
+// SetStdoutColor enables (true) or disables (false) color output for stdout.
+func SetStdoutColor(enabled bool) { noColorStdout.Store(!enabled) }
+
+// SetStderrColor enables (true) or disables (false) color output for stderr.
+func SetStderrColor(enabled bool) { noColorStderr.Store(!enabled) }
+
+// NoColor reports whether stdout color output is disabled.
+// Retained for backward compatibility; prefer NoColorStdout / NoColorStderr.
+func NoColor() bool { return noColorStdout.Load() }
+
+// NoColorStdout reports whether color output is disabled for stdout.
+func NoColorStdout() bool { return noColorStdout.Load() }
+
+// NoColorStderr reports whether color output is disabled for stderr.
+func NoColorStderr() bool { return noColorStderr.Load() }
 
 const reset = "\033[0m"
 
-func wrap(code, s string) string {
-	if s == "" || noColor.Load() {
+func wrap(code, s string, off bool) string {
+	if s == "" || off {
 		return s
 	}
 	return code + s + reset
 }
 
-// Red wraps s with red ANSI color code.
-func Red(s string) string { return wrap("\033[31m", s) }
+// Red wraps s with red ANSI color code (stdout-targeted).
+func Red(s string) string { return wrap("\033[31m", s, noColorStdout.Load()) }
 
-// Green wraps s with green ANSI color code.
-func Green(s string) string { return wrap("\033[32m", s) }
+// Green wraps s with green ANSI color code (stdout-targeted).
+func Green(s string) string { return wrap("\033[32m", s, noColorStdout.Load()) }
 
-// Yellow wraps s with yellow ANSI color code.
-func Yellow(s string) string { return wrap("\033[33m", s) }
+// Yellow wraps s with yellow ANSI color code (stdout-targeted).
+func Yellow(s string) string { return wrap("\033[33m", s, noColorStdout.Load()) }
 
-// Bold wraps s with bold ANSI code.
-func Bold(s string) string { return wrap("\033[1m", s) }
+// Bold wraps s with bold ANSI code (stdout-targeted).
+func Bold(s string) string { return wrap("\033[1m", s, noColorStdout.Load()) }
 
-// BoldYellow wraps s with bold yellow ANSI code.
-func BoldYellow(s string) string { return wrap("\033[1;33m", s) }
+// BoldYellow wraps s with bold yellow ANSI code (stdout-targeted).
+func BoldYellow(s string) string { return wrap("\033[1;33m", s, noColorStdout.Load()) }
+
+// RedStderr wraps s with red ANSI color code honoring the stderr color flag.
+func RedStderr(s string) string { return wrap("\033[31m", s, noColorStderr.Load()) }
+
+// YellowStderr wraps s with yellow ANSI color code honoring the stderr color flag.
+func YellowStderr(s string) string { return wrap("\033[33m", s, noColorStderr.Load()) }
+
+// BoldStderr wraps s with bold ANSI code honoring the stderr color flag.
+func BoldStderr(s string) string { return wrap("\033[1m", s, noColorStderr.Load()) }
+
+// BoldYellowStderr wraps s with bold yellow ANSI code honoring the stderr color flag.
+func BoldYellowStderr(s string) string { return wrap("\033[1;33m", s, noColorStderr.Load()) }

--- a/internal/color/color_test.go
+++ b/internal/color/color_test.go
@@ -2,9 +2,18 @@ package color
 
 import "testing"
 
+func resetColorState(t *testing.T) {
+	t.Helper()
+	origStdout := NoColorStdout()
+	origStderr := NoColorStderr()
+	t.Cleanup(func() {
+		SetStdoutColor(!origStdout)
+		SetStderrColor(!origStderr)
+	})
+}
+
 func TestSetAndGetNoColor(t *testing.T) {
-	original := NoColor()
-	defer SetNoColor(original)
+	resetColorState(t)
 
 	tests := []struct {
 		name  string
@@ -20,13 +29,47 @@ func TestSetAndGetNoColor(t *testing.T) {
 			if got := NoColor(); got != tt.value {
 				t.Errorf("NoColor() = %v, want %v", got, tt.value)
 			}
+			if got := NoColorStdout(); got != tt.value {
+				t.Errorf("NoColorStdout() = %v, want %v", got, tt.value)
+			}
+			if got := NoColorStderr(); got != tt.value {
+				t.Errorf("NoColorStderr() = %v, want %v", got, tt.value)
+			}
+		})
+	}
+}
+
+func TestSetStdoutAndStderrColorIndependent(t *testing.T) {
+	resetColorState(t)
+
+	tests := []struct {
+		name       string
+		stdoutOn   bool
+		stderrOn   bool
+		wantStdout bool // expected NoColorStdout()
+		wantStderr bool // expected NoColorStderr()
+	}{
+		{"both on", true, true, false, false},
+		{"stdout on, stderr off", true, false, false, true},
+		{"stdout off, stderr on", false, true, true, false},
+		{"both off", false, false, true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetStdoutColor(tt.stdoutOn)
+			SetStderrColor(tt.stderrOn)
+			if got := NoColorStdout(); got != tt.wantStdout {
+				t.Errorf("NoColorStdout() = %v, want %v", got, tt.wantStdout)
+			}
+			if got := NoColorStderr(); got != tt.wantStderr {
+				t.Errorf("NoColorStderr() = %v, want %v", got, tt.wantStderr)
+			}
 		})
 	}
 }
 
 func TestColorFunctions(t *testing.T) {
-	original := NoColor()
-	defer SetNoColor(original)
+	resetColorState(t)
 
 	funcs := []struct {
 		name   string
@@ -59,17 +102,72 @@ func TestColorFunctions(t *testing.T) {
 	}
 }
 
+func TestStderrColorFunctions(t *testing.T) {
+	resetColorState(t)
+
+	funcs := []struct {
+		name   string
+		fn     func(string) string
+		prefix string
+	}{
+		{"RedStderr", RedStderr, "\033[31m"},
+		{"YellowStderr", YellowStderr, "\033[33m"},
+		{"BoldStderr", BoldStderr, "\033[1m"},
+		{"BoldYellowStderr", BoldYellowStderr, "\033[1;33m"},
+	}
+
+	for _, f := range funcs {
+		t.Run(f.name+"_stdout_off_stderr_on", func(t *testing.T) {
+			SetStdoutColor(false)
+			SetStderrColor(true)
+			got := f.fn("hello")
+			want := f.prefix + "hello" + "\033[0m"
+			if got != want {
+				t.Errorf("%s = %q, want %q (stdout disabled should not affect stderr)", f.name, got, want)
+			}
+		})
+		t.Run(f.name+"_stdout_on_stderr_off", func(t *testing.T) {
+			SetStdoutColor(true)
+			SetStderrColor(false)
+			if got := f.fn("hello"); got != "hello" {
+				t.Errorf("%s = %q, want %q (stderr disabled should strip ANSI)", f.name, got, "hello")
+			}
+		})
+	}
+}
+
 func TestColorFunctionsEmptyString(t *testing.T) {
-	original := NoColor()
-	defer SetNoColor(original)
+	resetColorState(t)
 
 	SetNoColor(false)
 	if got := Red(""); got != "" {
 		t.Errorf("Red(\"\") = %q, want %q", got, "")
 	}
+	if got := RedStderr(""); got != "" {
+		t.Errorf("RedStderr(\"\") = %q, want %q", got, "")
+	}
 
 	SetNoColor(true)
 	if got := Red(""); got != "" {
 		t.Errorf("Red(\"\") with NoColor = %q, want %q", got, "")
+	}
+	if got := RedStderr(""); got != "" {
+		t.Errorf("RedStderr(\"\") with NoColor = %q, want %q", got, "")
+	}
+}
+
+func TestStdoutColorFuncsIgnoreStderrFlag(t *testing.T) {
+	resetColorState(t)
+
+	SetStdoutColor(true)
+	SetStderrColor(false)
+	if got := Red("x"); got != "\033[31mx\033[0m" {
+		t.Errorf("Red should follow stdout flag; got %q", got)
+	}
+
+	SetStdoutColor(false)
+	SetStderrColor(true)
+	if got := Red("x"); got != "x" {
+		t.Errorf("Red should follow stdout flag (off); got %q", got)
 	}
 }

--- a/internal/color/color_test.go
+++ b/internal/color/color_test.go
@@ -111,6 +111,7 @@ func TestStderrColorFunctions(t *testing.T) {
 		prefix string
 	}{
 		{"RedStderr", RedStderr, "\033[31m"},
+		{"GreenStderr", GreenStderr, "\033[32m"},
 		{"YellowStderr", YellowStderr, "\033[33m"},
 		{"BoldStderr", BoldStderr, "\033[1m"},
 		{"BoldYellowStderr", BoldYellowStderr, "\033[1;33m"},


### PR DESCRIPTION
## Summary

Three small CLI UX fixes bundled together — all scoped to `cmd/trumpcards/main.go` plus the `internal/color` package, so they share review context and a single round of tests.

- **`trumpcards <game> --help` / `-h`** now prints that game's help instead of silently launching the game with an extra-args warning. Matches `git`, `docker`, `kubectl` conventions. Closes #1390.
- **`--version-short`** added for machine-readable scripting (asdf/mise/renovate-friendly). Existing `--version`/`-V` format is preserved. Closes #1391.
- **Per-stream color detection.** `color.SetStdoutColor` / `color.SetStderrColor` let `game | tee log.txt` keep stderr colors and `game 2> err.log` keep stdout colors. `NO_COLOR` / `--no-color` still force both streams off for spec compliance. Closes #1392.
- Shell completion (bash/zsh/fish) and help text updated to document the new `--version-short` flag and clarify the stream-aware color behavior.

## Test plan

- [x] `go test -tags test ./...` (all packages pass)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `goimports -w` on all modified files
- [x] Unit tests added:
  - `internal/color/color_test.go` — stdout/stderr flags independence, back-compat of `SetNoColor`/`NoColor`, `*Stderr` wrapper variants.
  - `cmd/trumpcards/main_test.go` — `hasHelpFlag`, `runHelpCommand` for game / alias / unknown / help-text content.
- [x] Manual smoke tests:
  - `trumpcards blackjack --help` → prints BlackJack help (stdout), exit 0
  - `trumpcards blackjack -h` → same
  - `trumpcards gin --help` → resolves alias to ginrummy help
  - `trumpcards web --help` → still works via `parseSubFlags` (no regression)
  - `trumpcards --version-short` → prints just `dev`
  - `trumpcards --version` → unchanged format

Closes #1390
Closes #1391
Closes #1392