### PR TITLE
fix(a11y): scope live regions, add focus trap, dual-cue selection (#1393-#1395)

### DIFF
--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -1256,6 +1256,8 @@ classDiagram
         +レスポンシブ ハンバーガーメニュー
         +カテゴリ折りたたみ (モバイル)
         +絵文字アイコン表示
+        +モバイル時 focus trap (Tab ラップ)
+        +お気に入りトグル aria-pressed + 色変化
     }
 
     class GameRoute {
@@ -1273,7 +1275,7 @@ classDiagram
     class PhaseIndicator {
         +string phaseName
         +boolean isYourTurn
-        +aria-live polite
+        +内部 sr-only ライブリージョン (aria-live polite, aria-atomic)
     }
 
     class SettingsPanel {

--- a/frontend/src/components/GamePageShell.test.tsx
+++ b/frontend/src/components/GamePageShell.test.tsx
@@ -167,4 +167,22 @@ describe('GamePageShell', () => {
     );
     expect(screen.getByRole('button', { name: 'manual-/spades' })).toBeInTheDocument();
   });
+
+  it('does not place aria-live on the outer container', () => {
+    const { container } = render(
+      <GamePageShell {...baseProps}>
+        <div />
+      </GamePageShell>,
+    );
+    expect(container.firstChild).not.toHaveAttribute('aria-live');
+  });
+
+  it('still forwards loading to aria-busy on the outer container', () => {
+    const { container } = render(
+      <GamePageShell {...baseProps} loading={true}>
+        <div />
+      </GamePageShell>,
+    );
+    expect(container.firstChild).toHaveAttribute('aria-busy', 'true');
+  });
 });

--- a/frontend/src/components/GamePageShell.tsx
+++ b/frontend/src/components/GamePageShell.tsx
@@ -58,7 +58,7 @@ export function GamePageShell({
   children,
 }: GamePageShellProps) {
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameThemeBg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameThemeBg}`} aria-busy={loading}>
       <GamePageHeading title={title} />
       <PhaseIndicator phaseName={phaseName} isHumanTurn={isHumanTurn}>
         {headerExtra}

--- a/frontend/src/components/MobileHandGrid.test.tsx
+++ b/frontend/src/components/MobileHandGrid.test.tsx
@@ -70,6 +70,23 @@ describe('MobileHandGrid', () => {
     expect(buttons[12]).toHaveAttribute('aria-pressed', 'true');
   });
 
+  it('renders a ✓ badge only on selected cards', () => {
+    const cards = makeCards(5);
+    render(<MobileHandGrid cards={cards} selectedIndices={[1, 3]} onToggle={() => {}} cardWidth={40} />);
+    const badges = screen.getAllByTestId('selected-badge');
+    expect(badges).toHaveLength(2);
+    for (const badge of badges) {
+      expect(badge.textContent).toBe('✓');
+      expect(badge).toHaveAttribute('aria-hidden', 'true');
+    }
+  });
+
+  it('does not render any ✓ badge when no card is selected', () => {
+    const cards = makeCards(5);
+    render(<MobileHandGrid cards={cards} selectedIndices={[]} onToggle={() => {}} cardWidth={40} />);
+    expect(screen.queryAllByTestId('selected-badge')).toHaveLength(0);
+  });
+
   it('passes dataTutorial as data-tutorial attribute', () => {
     const cards = makeCards(5);
     const { container } = render(

--- a/frontend/src/components/MobileHandGrid.tsx
+++ b/frontend/src/components/MobileHandGrid.tsx
@@ -79,6 +79,7 @@ export function MobileHandGrid({ cards, selectedIndices, onToggle, cardWidth, da
                     background: 'none',
                     padding: 0,
                     borderRadius: 8,
+                    position: 'relative',
                     ...selectedCardStyle(isSelected),
                     transition: 'transform 0.15s, border 0.15s, box-shadow 0.15s, margin-left 0.15s',
                     boxSizing: 'border-box',
@@ -92,6 +93,15 @@ export function MobileHandGrid({ cards, selectedIndices, onToggle, cardWidth, da
                     className={reduced ? undefined : 'animate-card-deal-in'}
                     style={reduced ? undefined : { animationDelay: `${i * DEAL_IN_STAGGER_S}s` }}
                   />
+                  {isSelected && (
+                    <span
+                      aria-hidden="true"
+                      data-testid="selected-badge"
+                      className="absolute top-1 right-1 bg-ds-accent text-ds-text-on-accent rounded-full w-5 h-5 flex items-center justify-center text-xs font-bold shadow-md"
+                    >
+                      ✓
+                    </span>
+                  )}
                 </button>
               );
             })}

--- a/frontend/src/components/NavBar.test.tsx
+++ b/frontend/src/components/NavBar.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import i18n from 'i18next';
 import { MemoryRouter } from 'react-router-dom';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { gameCategories, gameRoutes } from '../constants/gameRoutes';
 import { NavBar } from './NavBar';
 
@@ -215,6 +215,65 @@ describe('NavBar', () => {
       const nav = screen.getByRole('navigation');
       fireEvent.keyDown(nav, { key: 'Tab' });
       expect(nav).not.toHaveClass('hidden');
+    });
+
+    describe('focus trap (mobile)', () => {
+      const originalInnerWidth = window.innerWidth;
+
+      beforeEach(() => {
+        Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+        window.dispatchEvent(new Event('resize'));
+      });
+
+      afterEach(() => {
+        Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalInnerWidth });
+        window.dispatchEvent(new Event('resize'));
+      });
+
+      it('wraps Tab from the last focusable element back to the first', () => {
+        renderNavBar();
+        fireEvent.click(screen.getByRole('button', { name: i18n.t('nav.openMenu') }));
+        const nav = screen.getByRole('navigation');
+        const focusable = nav.querySelectorAll<HTMLElement>('a[href], button, input');
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        last.focus();
+        expect(document.activeElement).toBe(last);
+        const tabEvent = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+        document.dispatchEvent(tabEvent);
+        expect(tabEvent.defaultPrevented).toBe(true);
+        expect(document.activeElement).toBe(first);
+      });
+
+      it('wraps Shift+Tab from the first focusable element to the last', () => {
+        renderNavBar();
+        fireEvent.click(screen.getByRole('button', { name: i18n.t('nav.openMenu') }));
+        const nav = screen.getByRole('navigation');
+        const focusable = nav.querySelectorAll<HTMLElement>('a[href], button, input');
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        first.focus();
+        const tabEvent = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true, cancelable: true });
+        document.dispatchEvent(tabEvent);
+        expect(tabEvent.defaultPrevented).toBe(true);
+        expect(document.activeElement).toBe(last);
+      });
+
+      it('pulls focus back into the nav when Tab is pressed outside', () => {
+        renderNavBar();
+        fireEvent.click(screen.getByRole('button', { name: i18n.t('nav.openMenu') }));
+        const nav = screen.getByRole('navigation');
+        const outside = document.createElement('button');
+        document.body.appendChild(outside);
+        outside.focus();
+        expect(document.activeElement).toBe(outside);
+        const tabEvent = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+        document.dispatchEvent(tabEvent);
+        expect(tabEvent.defaultPrevented).toBe(true);
+        const focusable = nav.querySelectorAll<HTMLElement>('a[href], button, input');
+        expect(document.activeElement).toBe(focusable[0]);
+        document.body.removeChild(outside);
+      });
     });
   });
 
@@ -440,6 +499,26 @@ describe('NavBar', () => {
       window.dispatchEvent(new Event('resize'));
       renderNavBar();
       expect(screen.queryByText(i18n.t('nav.favoriteGames'))).not.toBeInTheDocument();
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: original });
+      window.dispatchEvent(new Event('resize'));
+      localStorage.removeItem('trumpcards-favorite-games');
+    });
+
+    it('exposes aria-pressed on the favorite toggle and flips color classes on toggle', () => {
+      localStorage.removeItem('trumpcards-favorite-games');
+      const original = window.innerWidth;
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+      window.dispatchEvent(new Event('resize'));
+      renderNavBar();
+      fireEvent.click(screen.getByRole('button', { name: i18n.t('nav.openMenu') }));
+      const [firstStar] = screen.getAllByRole('button', { name: i18n.t('nav.addFavorite') });
+      expect(firstStar).toHaveAttribute('aria-pressed', 'false');
+      expect(firstStar.className).toContain('text-ds-text-muted');
+      fireEvent.click(firstStar);
+      const toggled = screen.getAllByRole('button', { name: i18n.t('nav.removeFavorite') })[0];
+      expect(toggled).toHaveAttribute('aria-pressed', 'true');
+      expect(toggled.className).toContain('text-ds-accent');
+      expect(toggled.className).not.toContain('text-ds-text-muted');
       Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: original });
       window.dispatchEvent(new Event('resize'));
       localStorage.removeItem('trumpcards-favorite-games');

--- a/frontend/src/components/NavBar.test.tsx
+++ b/frontend/src/components/NavBar.test.tsx
@@ -274,6 +274,21 @@ describe('NavBar', () => {
         expect(document.activeElement).toBe(focusable[0]);
         document.body.removeChild(outside);
       });
+
+      it('does not reset focus when the viewport resizes while the menu is open', () => {
+        renderNavBar();
+        fireEvent.click(screen.getByRole('button', { name: i18n.t('nav.openMenu') }));
+        const nav = screen.getByRole('navigation');
+        const focusable = nav.querySelectorAll<HTMLElement>('a[href], button, input');
+        const mid = focusable[Math.floor(focusable.length / 2)];
+        mid.focus();
+        expect(document.activeElement).toBe(mid);
+        // Cross the mobile breakpoint while the menu is still open — the
+        // effect re-runs because isMobile flips, but focus must be preserved.
+        Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1024 });
+        window.dispatchEvent(new Event('resize'));
+        expect(document.activeElement).toBe(mid);
+      });
     });
   });
 

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -7,6 +7,7 @@ import { useIsMediumDesktop, useIsMobile } from '../hooks/useCardDimensions';
 import { useFavoriteGames } from '../hooks/useFavoriteGames';
 import { useRecentGames } from '../hooks/useRecentGames';
 import { focusRingWhite } from '../styles/buttonStyles';
+import { getFocusableElements } from '../utils/dom';
 import { SoundToggle } from './SoundToggle';
 import { TutorialProgressPanel } from './tutorial/TutorialProgressPanel';
 
@@ -103,15 +104,44 @@ export function NavBar() {
   const wasOpen = useRef(false);
 
   useEffect(() => {
-    if (isOpen && navRef.current) {
-      const firstInteractive = navRef.current.querySelector<HTMLElement>('input, a');
-      firstInteractive?.focus();
-    }
     if (!isOpen && wasOpen.current && toggleRef.current) {
       toggleRef.current.focus();
     }
     wasOpen.current = isOpen;
-  }, [isOpen]);
+
+    if (!isOpen || !navRef.current) return;
+    const nav = navRef.current;
+    const firstInteractive = nav.querySelector<HTMLElement>('input, a');
+    firstInteractive?.focus();
+
+    // Focus trap is scoped to mobile, where the menu covers the viewport
+    // like a modal. On tablet+ (sm:flex) the nav renders inline and a trap
+    // would prevent normal Tab flow into page content.
+    if (!isMobile) return;
+
+    const handleTab = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      const focusable = getFocusableElements(nav);
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey) {
+        if (active === first || !nav.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last || !nav.contains(active)) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleTab);
+    return () => document.removeEventListener('keydown', handleTab);
+  }, [isOpen, isMobile]);
 
   // Close nav dropdown on outside click (large desktop only).
   // On mobile/tablet, categories are always-open so this must be skipped
@@ -331,8 +361,11 @@ export function NavBar() {
                           <button
                             type="button"
                             aria-label={isFavorite(path) ? t('nav.removeFavorite') : t('nav.addFavorite')}
+                            aria-pressed={isFavorite(path)}
                             onClick={() => toggleFavorite(path)}
-                            className="text-ds-accent min-h-[44px] min-w-[44px] flex items-center justify-center text-sm shrink-0"
+                            className={`min-h-[44px] min-w-[44px] flex items-center justify-center text-sm shrink-0 transition-colors ${
+                              isFavorite(path) ? 'text-ds-accent' : 'text-ds-text-muted hover:text-ds-accent'
+                            }`}
                           >
                             {isFavorite(path) ? '★' : '☆'}
                           </button>

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -104,15 +104,23 @@ export function NavBar() {
   const wasOpen = useRef(false);
 
   useEffect(() => {
-    if (!isOpen && wasOpen.current && toggleRef.current) {
+    const justOpened = isOpen && !wasOpen.current;
+    const justClosed = !isOpen && wasOpen.current;
+    wasOpen.current = isOpen;
+
+    if (justClosed && toggleRef.current) {
       toggleRef.current.focus();
     }
-    wasOpen.current = isOpen;
 
     if (!isOpen || !navRef.current) return;
     const nav = navRef.current;
-    const firstInteractive = nav.querySelector<HTMLElement>('input, a');
-    firstInteractive?.focus();
+
+    // Only move focus on the open transition; re-running the effect for a
+    // viewport resize (isMobile flip) must not steal focus from the user.
+    if (justOpened) {
+      const initial = getFocusableElements(nav)[0];
+      initial?.focus();
+    }
 
     // Focus trap is scoped to mobile, where the menu covers the viewport
     // like a modal. On tablet+ (sm:flex) the nav renders inline and a trap

--- a/frontend/src/components/PhaseIndicator.test.tsx
+++ b/frontend/src/components/PhaseIndicator.test.tsx
@@ -46,8 +46,18 @@ describe('PhaseIndicator', () => {
     expect(screen.getByText('ポット: 100')).toBeInTheDocument();
   });
 
-  it('has aria-live polite', () => {
+  it('does not place aria-live on the outer container', () => {
     render(<PhaseIndicator phaseName="テスト" />);
-    expect(screen.getByTestId('phase-indicator')).toHaveAttribute('aria-live', 'polite');
+    expect(screen.getByTestId('phase-indicator')).not.toHaveAttribute('aria-live');
+  });
+
+  it('exposes a scoped sr-only live region for phase announcements', () => {
+    render(<PhaseIndicator phaseName="ベットフェーズ" isHumanTurn={true} />);
+    const statusNode = screen.getByTestId('phase-announcement');
+    expect(statusNode).toHaveAttribute('aria-live', 'polite');
+    expect(statusNode).toHaveAttribute('aria-atomic', 'true');
+    expect(statusNode).toHaveClass('sr-only');
+    expect(statusNode.textContent).toContain('ベットフェーズ');
+    expect(statusNode.textContent).toContain('あなたのターン');
   });
 });

--- a/frontend/src/components/PhaseIndicator.tsx
+++ b/frontend/src/components/PhaseIndicator.tsx
@@ -11,10 +11,15 @@ interface PhaseIndicatorProps {
 export function PhaseIndicator({ phaseName, isHumanTurn, children }: PhaseIndicatorProps) {
   const { t } = useTranslation('common');
 
+  const turnLabel =
+    isHumanTurn === undefined ? '' : isHumanTurn ? t('turnIndicator.yourTurn') : t('turnIndicator.waiting');
+  const announcementText = turnLabel
+    ? t('turnIndicator.announcement', { phase: phaseName, turn: turnLabel })
+    : t('turnIndicator.phaseOnly', { phase: phaseName });
+
   return (
     <div
       className="shrink-0 glass-panel text-white text-sm px-5 py-2 flex flex-wrap gap-x-6 gap-y-1 items-center tabular-nums"
-      aria-live="polite"
       data-testid="phase-indicator"
     >
       <span>
@@ -28,10 +33,13 @@ export function PhaseIndicator({ phaseName, isHumanTurn, children }: PhaseIndica
               : 'text-game-text-muted'
           }
         >
-          {isHumanTurn ? t('turnIndicator.yourTurn') : t('turnIndicator.waiting')}
+          {turnLabel}
         </span>
       )}
       {children}
+      <span aria-live="polite" aria-atomic="true" className="sr-only" data-testid="phase-announcement">
+        {announcementText}
+      </span>
     </div>
   );
 }

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -160,7 +160,7 @@ export function VideoPokerGameContent({
   const displayHeld = isDrawPhase ? heldCards : (state.heldIndices ?? []);
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme[gameName].bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme[gameName].bg}`} aria-busy={loading}>
       <GamePageHeading title={tc(`nav.${gameName}`)} />
       <PhaseIndicator phaseName={phaseName} isHumanTurn={isBetPhase || isDrawPhase}>
         <span>{t('label.chips', { chips: state.chips })}</span>

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -146,7 +146,9 @@
   },
   "turnIndicator": {
     "yourTurn": "Your Turn",
-    "waiting": "Waiting"
+    "waiting": "Waiting",
+    "phaseOnly": "Current phase: {{phase}}",
+    "announcement": "Current phase: {{phase}}, {{turn}}"
   },
   "card": {
     "back": "Card back",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -146,7 +146,9 @@
   },
   "turnIndicator": {
     "yourTurn": "あなたのターン",
-    "waiting": "待機中"
+    "waiting": "待機中",
+    "phaseOnly": "現在のフェーズ: {{phase}}",
+    "announcement": "現在のフェーズ: {{phase}}、{{turn}}"
   },
   "card": {
     "back": "カード裏面",

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -255,7 +255,7 @@ function BaccaratPageContent() {
   };
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.baccarat.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.baccarat.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.baccarat')} />
       {/* Phase indicator */}
       <PhaseIndicator phaseName={isBetPhase ? t('phase.bet') : t('phase.end')}>

--- a/frontend/src/pages/BlackJackPage.test.tsx
+++ b/frontend/src/pages/BlackJackPage.test.tsx
@@ -705,7 +705,7 @@ describe('BlackJackPage', () => {
     renderWithProviders(<BlackJackPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).not.toBeDisabled());
 
-    const container = screen.getByRole('button', { name: 'ベット' }).closest('[aria-live]') as HTMLElement;
+    const container = screen.getByRole('button', { name: 'ベット' }).closest('[aria-busy]') as HTMLElement;
     expect(container).toHaveAttribute('aria-busy', 'false');
 
     let resolve!: (value: BlackJackResponse) => void;

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -242,7 +242,7 @@ function BlackJackPageContent() {
   if (!state) return <BlackJackSkeleton />;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.blackjack.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.blackjack.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.blackjack')} />
       {/* Phase indicator + info bar */}
       <PhaseIndicator

--- a/frontend/src/pages/BridgePage.tsx
+++ b/frontend/src/pages/BridgePage.tsx
@@ -206,7 +206,7 @@ function BridgePageContent() {
   };
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.bridge.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.bridge.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.bridge')} />
       {/* Phase indicator */}
       <PhaseIndicator phaseName={phaseNames[state.phase]} isHumanTurn={isHumanBidTurn || isHumanTurn}>

--- a/frontend/src/pages/CanastaPage.tsx
+++ b/frontend/src/pages/CanastaPage.tsx
@@ -146,7 +146,7 @@ function CanastaPageContent() {
   }
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.canasta.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.canasta.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.canasta')} />
       <PhaseIndicator phaseName={phaseNames[state.phase]} isHumanTurn={isHumanTurn}>
         <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />

--- a/frontend/src/pages/CanfieldPage.tsx
+++ b/frontend/src/pages/CanfieldPage.tsx
@@ -148,7 +148,7 @@ function CanfieldPageContent() {
   const topReserve = state.reserve.length > 0 ? state.reserve[state.reserve.length - 1] : null;
 
   return (
-    <div className={`flex min-h-screen flex-1 flex-col ${theme.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex min-h-screen flex-1 flex-col ${theme.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.canfield')} />
       <PhaseIndicator phaseName={phaseName}>
         <span className="text-sm text-white/70">

--- a/frontend/src/pages/CaribbeanStudPage.tsx
+++ b/frontend/src/pages/CaribbeanStudPage.tsx
@@ -159,7 +159,7 @@ function CaribbeanStudPageContent() {
   const phaseName = isBetPhase ? t('phase.bet') : isActionPhase ? t('phase.action') : t('phase.end');
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.threecard.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.threecard.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.caribbeanstud')} />
       <PhaseIndicator phaseName={phaseName}>
         <span>

--- a/frontend/src/pages/ClockSolitairePage.tsx
+++ b/frontend/src/pages/ClockSolitairePage.tsx
@@ -143,7 +143,7 @@ function ClockSolitairePageContent() {
   const radius = Math.min(cardWidth * 5, 180);
 
   return (
-    <div className={`flex min-h-screen flex-1 flex-col ${theme.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex min-h-screen flex-1 flex-col ${theme.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.clocksolitaire')} />
       <PhaseIndicator phaseName={phaseName}>
         <span className="text-sm text-white/70">

--- a/frontend/src/pages/CrazyEightsPage.tsx
+++ b/frontend/src/pages/CrazyEightsPage.tsx
@@ -166,7 +166,7 @@ function CrazyEightsPageContent() {
   const isHumanTurn = isPlayPhase && state.players[state.currentPlayerIdx]?.isHuman === true;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.crazyeights.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.crazyeights.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.crazyeights')} />
       <PhaseIndicator phaseName={phaseNames[state.phase]} isHumanTurn={isHumanTurn || isChooseSuit}>
         <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />

--- a/frontend/src/pages/CribbagePage.tsx
+++ b/frontend/src/pages/CribbagePage.tsx
@@ -208,7 +208,7 @@ function CribbagePageContent() {
   ];
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.cribbage.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.cribbage.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.cribbage')} />
       <PhaseIndicator phaseName={phaseNames[state.phase]} isHumanTurn={isHumanTurn}>
         <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />

--- a/frontend/src/pages/DaifugoPage.test.tsx
+++ b/frontend/src/pages/DaifugoPage.test.tsx
@@ -789,7 +789,7 @@ describe('DaifugoPage', () => {
     renderWithProviders(<DaifugoPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'パス' })).not.toBeDisabled());
 
-    const container = screen.getByRole('button', { name: 'パス' }).closest('[aria-live]') as HTMLElement;
+    const container = screen.getByRole('button', { name: 'パス' }).closest('[aria-busy]') as HTMLElement;
     expect(container).toHaveAttribute('aria-busy', 'false');
 
     let resolve!: (value: DaifugoResponse) => void;

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -199,7 +199,7 @@ function DaifugoPageContent() {
   ] as const;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.daifugo.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.daifugo.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.daifugo')} />
       <PhaseIndicator phaseName={state.gameEndFlag ? t('phase.end') : t('phase.play')} isHumanTurn={isHumanTurn}>
         <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />

--- a/frontend/src/pages/DoubtPage.test.tsx
+++ b/frontend/src/pages/DoubtPage.test.tsx
@@ -351,7 +351,7 @@ describe('DoubtPage', () => {
     renderWithProviders(<DoubtPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).not.toBeDisabled());
 
-    const container = screen.getByRole('button', { name: 'リセット' }).closest('[aria-live]') as HTMLElement;
+    const container = screen.getByRole('button', { name: 'リセット' }).closest('[aria-busy]') as HTMLElement;
     expect(container).toHaveAttribute('aria-busy', 'false');
 
     let resolve!: (value: DoubtResponse) => void;

--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -192,7 +192,7 @@ function DoubtPageContent() {
   );
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.doubt.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.doubt.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.doubt')} />
       {/* Phase indicator */}
       <PhaseIndicator

--- a/frontend/src/pages/DurakPage.tsx
+++ b/frontend/src/pages/DurakPage.tsx
@@ -195,7 +195,7 @@ function DurakPageContent() {
   };
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${theme.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${theme.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.durak')} />
       <PhaseIndicator phaseName={phaseName} isHumanTurn={isHumanTurn}>
         <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />

--- a/frontend/src/pages/EuchrePage.tsx
+++ b/frontend/src/pages/EuchrePage.tsx
@@ -202,7 +202,7 @@ function EuchrePageContent() {
   const suitName = (suit: number) => (SUIT_NAMES[suit] ? t(SUIT_NAMES[suit]) : '');
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.euchre.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.euchre.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.euchre')} />
       {/* Phase indicator */}
       <PhaseIndicator phaseName={phaseNames[state.phase]} isHumanTurn={isHumanBidTurn || isHumanTurn || isHumanDiscard}>

--- a/frontend/src/pages/FiftyOnePage.tsx
+++ b/frontend/src/pages/FiftyOnePage.tsx
@@ -164,7 +164,7 @@ function FiftyOnePageContent() {
   const canExchange = isHumanTurn && selectedHandIdx !== null && selectedTableIdx !== null;
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-game-bg-green" aria-busy={loading} aria-live="polite">
+    <div className="flex-1 flex flex-col min-h-0 bg-game-bg-green" aria-busy={loading}>
       <GamePageHeading title={tc('nav.fiftyone')} />
       <PhaseIndicator phaseName={phaseName} isHumanTurn={isHumanTurn}>
         <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />

--- a/frontend/src/pages/FortyThievesPage.tsx
+++ b/frontend/src/pages/FortyThievesPage.tsx
@@ -191,7 +191,7 @@ function FortyThievesPageContent() {
   const wasteDisplay = state.waste.slice(-1);
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.fortythieves.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.fortythieves.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.fortythieves')} />
       {/* Phase indicator */}
       <PhaseIndicator

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -171,7 +171,7 @@ function FreeCellPageContent() {
     selectedSource.cardIndex === cardIndex;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.freecell.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.freecell.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.freecell')} />
       <PhaseIndicator
         phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}

--- a/frontend/src/pages/GinRummyPage.tsx
+++ b/frontend/src/pages/GinRummyPage.tsx
@@ -170,7 +170,7 @@ function GinRummyPageContent() {
     (isDrawPhase || isDiscardPhase || isLayoffPhase) && state.players[state.currentPlayerIdx]?.isHuman === true;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.ginrummy.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.ginrummy.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.ginrummy')} />
       <PhaseIndicator phaseName={phaseNames[state.phase]} isHumanTurn={isHumanTurn}>
         <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />

--- a/frontend/src/pages/GoFishPage.tsx
+++ b/frontend/src/pages/GoFishPage.tsx
@@ -137,7 +137,7 @@ function GoFishPageContent() {
   const humanRanks = humanPlayer ? [...new Set(humanPlayer.cards.map((c) => c.value))].sort((a, b) => a - b) : [];
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.gofish.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.gofish.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.gofish')} />
       <PhaseIndicator phaseName={phaseNames[state.phase]} isHumanTurn={isHumanTurn}>
         <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />

--- a/frontend/src/pages/GolfPage.tsx
+++ b/frontend/src/pages/GolfPage.tsx
@@ -151,7 +151,7 @@ function GolfPageContent() {
     : cardWidth;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.golf.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.golf.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.golf')} />
       <PhaseIndicator
         phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}

--- a/frontend/src/pages/HoldemPage.test.tsx
+++ b/frontend/src/pages/HoldemPage.test.tsx
@@ -861,7 +861,7 @@ describe('HoldemPage', () => {
     renderWithProviders(<HoldemPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).not.toBeDisabled());
 
-    const container = screen.getByRole('button', { name: 'ベット' }).closest('[aria-live]') as HTMLElement;
+    const container = screen.getByRole('button', { name: 'ベット' }).closest('[aria-busy]') as HTMLElement;
     expect(container).toHaveAttribute('aria-busy', 'false');
 
     let resolve!: (value: HoldemResponse) => void;

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -237,7 +237,7 @@ function HoldemPageContent() {
   if (!state) return <HoldemSkeleton />;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.holdem.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.holdem.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.holdem')} />
       {/* Phase indicator + info bar */}
       <PhaseIndicator phaseName={phaseNames[phase] ?? t('phase.init')} isHumanTurn={canAct}>

--- a/frontend/src/pages/IndianPokerPage.test.tsx
+++ b/frontend/src/pages/IndianPokerPage.test.tsx
@@ -608,7 +608,7 @@ describe('IndianPokerPage', () => {
     renderWithProviders(<IndianPokerPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).not.toBeDisabled());
 
-    const container = screen.getByRole('button', { name: 'ベット' }).closest('[aria-live]') as HTMLElement;
+    const container = screen.getByRole('button', { name: 'ベット' }).closest('[aria-busy]') as HTMLElement;
     expect(container).toHaveAttribute('aria-busy', 'false');
 
     let resolve!: (value: IndianPokerResponse) => void;

--- a/frontend/src/pages/IndianPokerPage.tsx
+++ b/frontend/src/pages/IndianPokerPage.tsx
@@ -181,7 +181,7 @@ function IndianPokerPageContent() {
   }));
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.indianpoker.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.indianpoker.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.indianpoker')} />
       {/* Phase indicator + info bar */}
       <PhaseIndicator phaseName={phaseNames[phase] ?? t('phase.init')} isHumanTurn={canAct}>

--- a/frontend/src/pages/KlondikePage.tsx
+++ b/frontend/src/pages/KlondikePage.tsx
@@ -213,7 +213,7 @@ function KlondikePageContent() {
   const wasteDisplay = state.drawCount === 3 ? state.waste.slice(-3) : state.waste.slice(-1);
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.klondike.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.klondike.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.klondike')} />
       {/* Phase indicator */}
       <PhaseIndicator

--- a/frontend/src/pages/LetItRidePage.tsx
+++ b/frontend/src/pages/LetItRidePage.tsx
@@ -167,7 +167,7 @@ function LetItRidePageContent() {
         : t('phase.end');
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.letitride.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.letitride.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.letitride')} />
       <PhaseIndicator phaseName={phaseName}>
         <span>

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -131,7 +131,7 @@ function MemoryPageContent() {
   const isHumanTurn = (isFlip1 || isFlip2) && state.players[state.currentPlayerIdx]?.isHuman === true;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.memory.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.memory.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.memory')} />
       {/* Phase indicator */}
       <PhaseIndicator phaseName={phaseNames[state.phase]} isHumanTurn={isHumanTurn}>

--- a/frontend/src/pages/NapoleonPage.tsx
+++ b/frontend/src/pages/NapoleonPage.tsx
@@ -215,7 +215,7 @@ function NapoleonPageContent() {
   const trumpLabel = state.trumpSuit > 0 ? t(`suitName.${SUIT_KEYS[state.trumpSuit]}`) : '';
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.napoleon.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.napoleon.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.napoleon')} />
       {/* Phase indicator */}
       <PhaseIndicator

--- a/frontend/src/pages/OhHellPage.tsx
+++ b/frontend/src/pages/OhHellPage.tsx
@@ -185,7 +185,7 @@ function OhHellPageContent() {
   );
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.ohhell.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.ohhell.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.ohhell')} />
       {/* Phase indicator */}
       <PhaseIndicator phaseName={phaseNames[state.phase]} isHumanTurn={isHumanBidTurn || isHumanTurn}>

--- a/frontend/src/pages/OldMaidPage.test.tsx
+++ b/frontend/src/pages/OldMaidPage.test.tsx
@@ -804,7 +804,7 @@ describe('OldMaidPage', () => {
   it('sets aria-busy on game screen while loading', async () => {
     await startGame();
 
-    const container = screen.getByRole('button', { name: 'リセット' }).closest('[aria-live]') as HTMLElement;
+    const container = screen.getByRole('button', { name: 'リセット' }).closest('[aria-busy]') as HTMLElement;
     expect(container).toHaveAttribute('aria-busy', 'false');
 
     let resolve!: (value: OldMaidResponse) => void;
@@ -1012,7 +1012,7 @@ describe('OldMaidPage', () => {
 
     // After the 600ms reveal timer, shake is triggered
     await waitFor(() => {
-      const container = screen.getByRole('button', { name: 'リセット' }).closest('[aria-live]') as HTMLElement;
+      const container = screen.getByRole('button', { name: 'リセット' }).closest('[aria-busy]') as HTMLElement;
       expect(container.className).toContain('animate-shake');
     });
   });
@@ -1033,7 +1033,7 @@ describe('OldMaidPage', () => {
     await waitFor(() => {
       expect(screen.getByTestId('card-reveal-area').querySelector('img[alt="♥ 5"]')).toBeInTheDocument();
     });
-    const container = screen.getByRole('button', { name: 'リセット' }).closest('[aria-live]') as HTMLElement;
+    const container = screen.getByRole('button', { name: 'リセット' }).closest('[aria-busy]') as HTMLElement;
     expect(container.className).not.toContain('animate-shake');
   });
 

--- a/frontend/src/pages/OmahaPage.test.tsx
+++ b/frontend/src/pages/OmahaPage.test.tsx
@@ -885,7 +885,7 @@ describe('OmahaPage', () => {
     renderWithProviders(<OmahaPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).not.toBeDisabled());
 
-    const container = screen.getByRole('button', { name: 'ベット' }).closest('[aria-live]') as HTMLElement;
+    const container = screen.getByRole('button', { name: 'ベット' }).closest('[aria-busy]') as HTMLElement;
     expect(container).toHaveAttribute('aria-busy', 'false');
 
     let resolve!: (value: OmahaResponse) => void;

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -236,7 +236,7 @@ function OmahaPageContent() {
   if (!state) return <OmahaSkeleton />;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.omaha.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.omaha.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.omaha')} />
       {/* Phase indicator + info bar */}
       <PhaseIndicator phaseName={phaseNames[phase] ?? t('phase.init')} isHumanTurn={canAct}>

--- a/frontend/src/pages/PageOnePage.tsx
+++ b/frontend/src/pages/PageOnePage.tsx
@@ -148,7 +148,7 @@ function PageOnePageContent() {
   const isHumanMustDeclare = isMustDeclare && state.players[state.currentPlayerIdx]?.isHuman === true;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.pageone.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.pageone.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.pageone')} />
       <PhaseIndicator phaseName={phaseNames[state.phase]} isHumanTurn={isHumanTurn || isHumanMustDeclare}>
         <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />

--- a/frontend/src/pages/PaiGowPage.tsx
+++ b/frontend/src/pages/PaiGowPage.tsx
@@ -181,7 +181,7 @@ function PaiGowPageContent() {
   const phaseName = isBetPhase ? t('phase.bet') : isSetHandsPhase ? t('phase.setHands') : t('phase.end');
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.paigow.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.paigow.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.paigow')} />
       {/* Phase indicator */}
       <PhaseIndicator phaseName={phaseName}>

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -253,7 +253,7 @@ function PineapplePageContent() {
   if (!state) return <HoldemSkeleton />;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.holdem.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.holdem.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.pineapple')} />
       {/* Phase indicator + info bar */}
       <PhaseIndicator phaseName={phaseNames[phase] ?? t('phase.init')} isHumanTurn={canAct || canDiscard}>

--- a/frontend/src/pages/PinochlePage.tsx
+++ b/frontend/src/pages/PinochlePage.tsx
@@ -176,7 +176,7 @@ function PinochlePageContent() {
   const isGameEnd = phase === PinochlePhase.GAME_END || state.gameEndFlag;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.pinochle.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.pinochle.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.pinochle')} />
       <PhaseIndicator phaseName={phaseNames[phase]} isHumanTurn={isBidTurn || isTrumpTurn || isPlayTurn}>
         <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />

--- a/frontend/src/pages/PokerPage.test.tsx
+++ b/frontend/src/pages/PokerPage.test.tsx
@@ -1013,7 +1013,7 @@ describe('PokerPage', () => {
     renderWithProviders(<PokerPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).not.toBeDisabled());
 
-    const container = screen.getByRole('button', { name: 'ベット' }).closest('[aria-live]') as HTMLElement;
+    const container = screen.getByRole('button', { name: 'ベット' }).closest('[aria-busy]') as HTMLElement;
     expect(container).toHaveAttribute('aria-busy', 'false');
 
     let resolve!: (value: PokerResponse) => void;

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -184,7 +184,7 @@ function PokerPageContent() {
   if (!state) return <PokerSkeleton />;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.poker.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.poker.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.poker')} />
       {/* Phase indicator + info bar */}
       <PhaseIndicator phaseName={phaseNames[phase] ?? t('phase.init')} isHumanTurn={canAct || canExchange}>

--- a/frontend/src/pages/PokerSquaresPage.tsx
+++ b/frontend/src/pages/PokerSquaresPage.tsx
@@ -103,7 +103,7 @@ function PokerSquaresPageContent() {
   const handleReset = () => execApi('reset');
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.pokersquares.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.pokersquares.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.pokersquares')} />
       <PhaseIndicator phaseName={state ? phaseNames[state.phase] : ''}>
         {state && (

--- a/frontend/src/pages/PyramidPage.tsx
+++ b/frontend/src/pages/PyramidPage.tsx
@@ -164,7 +164,7 @@ function PyramidPageContent() {
   const pyramidWidth = maxCols * (effectiveCardWidth + cardGap) - cardGap;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.pyramid.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.pyramid.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.pyramid')} />
       {/* Phase indicator */}
       <PhaseIndicator

--- a/frontend/src/pages/RazzPage.tsx
+++ b/frontend/src/pages/RazzPage.tsx
@@ -242,7 +242,7 @@ function RazzPageContent() {
   if (!state) return <HoldemSkeleton />;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.razz.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.razz.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.razz')} />
       {/* Phase indicator + info bar */}
       <PhaseIndicator phaseName={phaseNames[phase] ?? t('phase.init')} isHumanTurn={canAct}>

--- a/frontend/src/pages/RedDogPage.tsx
+++ b/frontend/src/pages/RedDogPage.tsx
@@ -129,7 +129,7 @@ function RedDogPageContent() {
           : t('phase.initialDealt');
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.reddog.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.reddog.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.reddog')} />
       <PhaseIndicator phaseName={phaseName}>
         <span>

--- a/frontend/src/pages/ScorpionPage.tsx
+++ b/frontend/src/pages/ScorpionPage.tsx
@@ -314,7 +314,7 @@ function ScorpionPageContent() {
     selectedSource.cardIndex === cardIndex;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.klondike.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.klondike.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.scorpion')} />
       <PhaseIndicator
         phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}

--- a/frontend/src/pages/SevensPage.test.tsx
+++ b/frontend/src/pages/SevensPage.test.tsx
@@ -921,7 +921,7 @@ describe('SevensPage', () => {
     renderWithProviders(<SevensPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'パス' })).not.toBeDisabled());
 
-    const container = screen.getByRole('button', { name: 'パス' }).closest('[aria-live]') as HTMLElement;
+    const container = screen.getByRole('button', { name: 'パス' }).closest('[aria-busy]') as HTMLElement;
     expect(container).toHaveAttribute('aria-busy', 'false');
 
     let resolve!: (value: SevensResponse) => void;

--- a/frontend/src/pages/SevensPage.tsx
+++ b/frontend/src/pages/SevensPage.tsx
@@ -257,7 +257,7 @@ function SevensPageContent() {
   ];
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.sevens.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.sevens.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.sevens')} />
       <PhaseIndicator phaseName={state.gameEndFlag ? t('phase.end') : t('phase.play')} isHumanTurn={isHumanTurn}>
         <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -235,7 +235,7 @@ function ShortDeckPageContent() {
   if (!state) return <ShortDeckSkeleton />;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.shortdeck.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.shortdeck.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.shortdeck')} />
       {/* Phase indicator + info bar */}
       <PhaseIndicator phaseName={phaseNames[phase] ?? t('phase.init')} isHumanTurn={canAct}>

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -147,7 +147,7 @@ function SpeedPageContent() {
       : t('phase.play');
 
   return (
-    <div className="flex flex-col h-full gap-2 p-2" aria-busy={loading} aria-live="polite">
+    <div className="flex flex-col h-full gap-2 p-2" aria-busy={loading}>
       <GamePageHeading title={tc('nav.speed')} />
       <PhaseIndicator phaseName={phaseName} isHumanTurn={isPlayPhase}>
         <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -182,7 +182,7 @@ function SpiderPageContent() {
   const dealsRemaining = Math.floor(state.stockCount / 10);
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.spider.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.spider.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.spider')} />
       {/* Phase indicator */}
       <PhaseIndicator

--- a/frontend/src/pages/ThreeCardPage.tsx
+++ b/frontend/src/pages/ThreeCardPage.tsx
@@ -149,7 +149,7 @@ function ThreeCardPageContent() {
   const phaseName = isBetPhase ? t('phase.bet') : isActionPhase ? t('phase.action') : t('phase.end');
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.threecard.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.threecard.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.threecard')} />
       {/* Phase indicator */}
       <PhaseIndicator phaseName={phaseName}>

--- a/frontend/src/pages/TriPeaksPage.tsx
+++ b/frontend/src/pages/TriPeaksPage.tsx
@@ -166,7 +166,7 @@ function TriPeaksPageContent() {
     : cardWidth;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.tripeaks.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.tripeaks.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.tripeaks')} />
       <PhaseIndicator
         phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}

--- a/frontend/src/pages/WarPage.tsx
+++ b/frontend/src/pages/WarPage.tsx
@@ -130,7 +130,7 @@ function WarPageContent() {
         : t('phase.reveal');
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-game-bg-green" aria-busy={loading} aria-live="polite">
+    <div className="flex-1 flex flex-col min-h-0 bg-game-bg-green" aria-busy={loading}>
       <GamePageHeading title={tc('nav.war')} />
       <PhaseIndicator phaseName={phaseName} isHumanTurn={!isGameEnd}>
         <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />

--- a/frontend/src/pages/YukonPage.tsx
+++ b/frontend/src/pages/YukonPage.tsx
@@ -306,7 +306,7 @@ function YukonPageContent() {
     selectedSource.cardIndex === cardIndex;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.klondike.bg}`} aria-busy={loading} aria-live="polite">
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.klondike.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.yukon')} />
       <PhaseIndicator
         phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}


### PR DESCRIPTION
## Summary

- **#1393** — Remove `aria-live=\"polite\"` from `GamePageShell` and 46 game pages/components (BlackJackPage, HoldemPage, DoubtPage, VideoPokerGameContent, etc.). Replace the page-wide live region with a tight `sr-only` live region inside `PhaseIndicator` that announces the current phase + turn state using i18n strings (`turnIndicator.phaseOnly` / `turnIndicator.announcement`). This eliminates the SR \"text flood\" and the nested live-region ambiguity between the shell and PhaseIndicator.
- **#1394** — Add a mobile focus trap to `NavBar` so Tab/Shift+Tab wrap within the open hamburger menu instead of escaping to background content. Reuses the existing `getFocusableElements` helper (already used by `ConfirmDialog` / `ManualModal`). Escape-to-close + focus restore continue to work.
- **#1395** — Add dual visual cues for selection state:
  - `MobileHandGrid`: render a gold ✓ badge at the top-right of selected cards (alongside the existing border/offset).
  - `NavBar` mobile favorite toggle: add `aria-pressed` and switch inactive color from accent→muted with `hover:text-ds-accent`, matching the `LangToggle` dual-cue pattern.

Updated page tests that relied on `closest('[aria-live]')` to use `closest('[aria-busy]')`. Refreshed `PhaseIndicator`, `GamePageShell`, `NavBar`, `MobileHandGrid` tests and extended `docs/design/frontend.md` UML class notes.

Closes #1393
Closes #1394
Closes #1395

## Test plan

- [x] `bun run build` passes
- [x] `bun run check` passes (2 pre-existing warnings in `OldMaidPlayerArea.test.tsx` unrelated to this PR)
- [x] New PhaseIndicator / GamePageShell / MobileHandGrid tests pass
- [x] NavBar focus trap tests pass (Tab wraps, Shift+Tab wraps, outside-Tab pulls back)
- [x] NavBar favorite toggle asserts `aria-pressed` + color class flip
- [x] Representative page-test suites pass (BlackJack, Holdem, Omaha, ShortDeck, Doubt, Daifugo, Sevens, Memory, OldMaid, IndianPoker, Hearts, Spades, etc.)
- [ ] Manual SR smoke (NVDA/VoiceOver) after merge to confirm phase transitions are announced once