### PR TITLE
refactor(1396-1398): BuildCuiHelp, NewDefault factories (partial), Makefile cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.test
 *.out
 coverage.html
+/build/
 /cli
 /go_trumpcards
 /server

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 TINYGO ?= tinygo
 WASM_OPT ?= wasm-opt
 ASSETS_GEN := go run github.com/syumai/workers/cmd/workers-assets-gen
+COVERAGE_DIR := build/coverage
 
-.PHONY: build-workers build-worker-casino build-worker-classic build-worker-solo clean-workers deploy-workers
+.PHONY: build-workers build-worker-casino build-worker-classic build-worker-solo clean-workers deploy-workers coverage clean-cov
 
 build-workers: build-worker-casino build-worker-classic build-worker-solo
 
@@ -32,3 +33,14 @@ deploy-workers: build-workers
 	cd workers/casino && bunx wrangler deploy
 	cd workers/classic && bunx wrangler deploy
 	cd workers/solo && bunx wrangler deploy
+
+coverage: ## Run tests with coverage, writing profile and HTML report to build/coverage/.
+	@mkdir -p $(COVERAGE_DIR)
+	go test -tags test -coverprofile=$(COVERAGE_DIR)/coverage.out -covermode=atomic ./...
+	go tool cover -html=$(COVERAGE_DIR)/coverage.out -o $(COVERAGE_DIR)/coverage.html
+	@echo "Coverage written to $(COVERAGE_DIR)/"
+
+clean-cov: ## Remove coverage profile artifacts (root-level *.out, coverage.html, build/coverage).
+	@find . -maxdepth 1 -type f \( -name '*.out' -o -name 'coverage.html' \) -delete
+	@rm -rf $(COVERAGE_DIR)
+	@echo "Removed coverage artifacts"

--- a/cmd/workers/classic/main.go
+++ b/cmd/workers/classic/main.go
@@ -23,15 +23,7 @@ func main() {
 	// Hearts
 	must(worker.RegisterKV(mux, "/hearts/exec", "hearts:",
 		func() usecase.HeartsInteractorIF {
-			config := domain.DefaultHeartsConfig()
-			players := []*domain.HeartsPlayer{
-				domain.NewHeartsPlayer(true),
-				domain.NewHeartsPlayer(false),
-				domain.NewHeartsPlayer(false),
-				domain.NewHeartsPlayer(false),
-			}
-			hearts := domain.NewHearts(domain.NewTrumpCards(0), players, config)
-			return usecase.NewHeartsInteractor(hearts, new(presenter.HeartsWebPresenter))
+			return usecase.NewHeartsInteractor(domain.NewDefaultHearts(), new(presenter.HeartsWebPresenter))
 		},
 		func(data []byte) (usecase.HeartsInteractorIF, error) {
 			return usecase.RestoreHeartsInteractor(data, new(presenter.HeartsWebPresenter))
@@ -42,15 +34,7 @@ func main() {
 	// Spades
 	must(worker.RegisterKV(mux, "/spades/exec", "spades:",
 		func() usecase.SpadesInteractorIF {
-			config := domain.DefaultSpadesConfig()
-			players := []*domain.SpadesPlayer{
-				domain.NewSpadesPlayer(true),
-				domain.NewSpadesPlayer(false),
-				domain.NewSpadesPlayer(false),
-				domain.NewSpadesPlayer(false),
-			}
-			spades := domain.NewSpades(domain.NewTrumpCards(0), players, config)
-			return usecase.NewSpadesInteractor(spades, new(presenter.SpadesWebPresenter))
+			return usecase.NewSpadesInteractor(domain.NewDefaultSpades(), new(presenter.SpadesWebPresenter))
 		},
 		func(data []byte) (usecase.SpadesInteractorIF, error) {
 			return usecase.RestoreSpadesInteractor(data, new(presenter.SpadesWebPresenter))
@@ -173,15 +157,7 @@ func main() {
 	// Crazy Eights
 	must(worker.RegisterKV(mux, "/crazyeights/exec", "crazyeights:",
 		func() usecase.CrazyEightsInteractorIF {
-			config := domain.DefaultCrazyEightsConfig()
-			players := []*domain.CrazyEightsPlayer{
-				domain.NewCrazyEightsPlayer(true),
-				domain.NewCrazyEightsPlayer(false),
-				domain.NewCrazyEightsPlayer(false),
-				domain.NewCrazyEightsPlayer(false),
-			}
-			ce := domain.NewCrazyEights(domain.NewTrumpCards(0), players, config)
-			return usecase.NewCrazyEightsInteractor(ce, new(presenter.CrazyEightsWebPresenter))
+			return usecase.NewCrazyEightsInteractor(domain.NewDefaultCrazyEights(), new(presenter.CrazyEightsWebPresenter))
 		},
 		func(data []byte) (usecase.CrazyEightsInteractorIF, error) {
 			return usecase.RestoreCrazyEightsInteractor(data, new(presenter.CrazyEightsWebPresenter))
@@ -192,15 +168,7 @@ func main() {
 	// Oh Hell
 	must(worker.RegisterKV(mux, "/ohhell/exec", "ohhell:",
 		func() usecase.OhHellInteractorIF {
-			config := domain.DefaultOhHellConfig()
-			players := []*domain.OhHellPlayer{
-				domain.NewOhHellPlayer(true),
-				domain.NewOhHellPlayer(false),
-				domain.NewOhHellPlayer(false),
-				domain.NewOhHellPlayer(false),
-			}
-			ohHell := domain.NewOhHell(domain.NewTrumpCards(0), players, config)
-			return usecase.NewOhHellInteractor(ohHell, new(presenter.OhHellWebPresenter))
+			return usecase.NewOhHellInteractor(domain.NewDefaultOhHell(), new(presenter.OhHellWebPresenter))
 		},
 		func(data []byte) (usecase.OhHellInteractorIF, error) {
 			return usecase.RestoreOhHellInteractor(data, new(presenter.OhHellWebPresenter))

--- a/cmd/workers/solo/main.go
+++ b/cmd/workers/solo/main.go
@@ -83,15 +83,7 @@ func main() {
 	// Memory
 	must(worker.RegisterKV(mux, "/memory/exec", "memory:",
 		func() usecase.MemoryInteractorIF {
-			config := domain.DefaultMemoryConfig()
-			players := []*domain.MemoryPlayer{
-				domain.NewMemoryPlayer(true),
-				domain.NewMemoryPlayer(false),
-				domain.NewMemoryPlayer(false),
-				domain.NewMemoryPlayer(false),
-			}
-			memory := domain.NewMemory(domain.NewTrumpCards(0), players, config)
-			return usecase.NewMemoryInteractor(memory, new(presenter.MemoryWebPresenter))
+			return usecase.NewMemoryInteractor(domain.NewDefaultMemory(), new(presenter.MemoryWebPresenter))
 		},
 		func(data []byte) (usecase.MemoryInteractorIF, error) {
 			return usecase.RestoreMemoryInteractor(data, new(presenter.MemoryWebPresenter))

--- a/internal/domain/CrazyEights.go
+++ b/internal/domain/CrazyEights.go
@@ -59,6 +59,19 @@ func NewCrazyEights(trumpCards *TrumpCards, players []*CrazyEightsPlayer, config
 	}
 }
 
+// NewDefaultCrazyEights returns CrazyEights with the standard 4-player setup (1 human, 3 CPU)
+// and DefaultCrazyEightsConfig. Used as the single source of truth for CUI, Web, and Worker
+// construction sites.
+func NewDefaultCrazyEights() *CrazyEights {
+	players := []*CrazyEightsPlayer{
+		NewCrazyEightsPlayer(true),
+		NewCrazyEightsPlayer(false),
+		NewCrazyEightsPlayer(false),
+		NewCrazyEightsPlayer(false),
+	}
+	return NewCrazyEights(NewTrumpCards(0), players, DefaultCrazyEightsConfig())
+}
+
 // Reset ゲーム初期化
 func (g *CrazyEights) Reset() {
 	g.gameEndFlag = false

--- a/internal/domain/CrazyEights_test.go
+++ b/internal/domain/CrazyEights_test.go
@@ -50,6 +50,18 @@ func TestNewCrazyEights(t *testing.T) {
 	assert.False(t, g.GetGameEndFlag())
 }
 
+func TestNewDefaultCrazyEights(t *testing.T) {
+	g := domain.NewDefaultCrazyEights()
+	assert.NotNil(t, g)
+	assert.Equal(t, domain.CrazyEightsPlayerCnt, g.GetPlayerCnt())
+	assert.True(t, g.GetPlayer(0).GetIsHuman())
+	for i := 1; i < g.GetPlayerCnt(); i++ {
+		assert.False(t, g.GetPlayer(i).GetIsHuman(), "player %d should be CPU", i)
+	}
+	assert.Equal(t, -1, g.GetWinnerIdx())
+	assert.False(t, g.GetGameEndFlag())
+}
+
 func TestCrazyEights_Reset(t *testing.T) {
 	g := newTestCrazyEights()
 	g.Reset()

--- a/internal/domain/Hearts.go
+++ b/internal/domain/Hearts.go
@@ -93,6 +93,19 @@ func NewHearts(trumpCards *TrumpCards, players []*HeartsPlayer, config HeartsCon
 	}
 }
 
+// NewDefaultHearts returns Hearts with the standard 4-player setup (1 human, 3 CPU)
+// and DefaultHeartsConfig. Used as the single source of truth for CUI, Web, and Worker
+// construction sites.
+func NewDefaultHearts() *Hearts {
+	players := []*HeartsPlayer{
+		NewHeartsPlayer(true),
+		NewHeartsPlayer(false),
+		NewHeartsPlayer(false),
+		NewHeartsPlayer(false),
+	}
+	return NewHearts(NewTrumpCards(0), players, DefaultHeartsConfig())
+}
+
 // Reset ゲーム初期化: デッキをシャッフルして配布し、最初のフェーズを設定
 func (h *Hearts) Reset() {
 	h.gameEndFlag = false

--- a/internal/domain/Hearts_test.go
+++ b/internal/domain/Hearts_test.go
@@ -59,6 +59,18 @@ func TestNewHearts(t *testing.T) {
 	assert.Nil(t, h.GetActionLog())
 }
 
+func TestNewDefaultHearts(t *testing.T) {
+	h := domain.NewDefaultHearts()
+	assert.NotNil(t, h)
+	assert.Equal(t, domain.HeartsPlayerCnt, h.GetPlayerCnt())
+	assert.True(t, h.GetPlayer(0).GetIsHuman())
+	for i := 1; i < h.GetPlayerCnt(); i++ {
+		assert.False(t, h.GetPlayer(i).GetIsHuman(), "player %d should be CPU", i)
+	}
+	assert.Equal(t, -1, h.GetWinnerIdx())
+	assert.False(t, h.GetGameEndFlag())
+}
+
 // --- Reset ---
 
 func TestHearts_Reset(t *testing.T) {

--- a/internal/domain/Memory.go
+++ b/internal/domain/Memory.go
@@ -73,6 +73,19 @@ func NewMemory(trumpCards *TrumpCards, players []*MemoryPlayer, config MemoryCon
 	return m
 }
 
+// NewDefaultMemory returns Memory with the standard 4-player setup (1 human, 3 CPU)
+// and DefaultMemoryConfig. Used as the single source of truth for CUI, Web, and Worker
+// construction sites.
+func NewDefaultMemory() *Memory {
+	players := []*MemoryPlayer{
+		NewMemoryPlayer(true),
+		NewMemoryPlayer(false),
+		NewMemoryPlayer(false),
+		NewMemoryPlayer(false),
+	}
+	return NewMemory(NewTrumpCards(0), players, DefaultMemoryConfig())
+}
+
 // Reset ゲームリセット
 func (m *Memory) Reset() {
 	m.trumpCards.Shuffle()

--- a/internal/domain/Memory_test.go
+++ b/internal/domain/Memory_test.go
@@ -45,6 +45,18 @@ func TestNewMemory(t *testing.T) {
 	assert.Equal(t, -1, m.GetWinnerIdx())
 }
 
+func TestNewDefaultMemory(t *testing.T) {
+	m := NewDefaultMemory()
+	assert.NotNil(t, m)
+	assert.Equal(t, MemoryPlayerCnt, m.GetPlayerCnt())
+	assert.True(t, m.GetPlayer(0).GetIsHuman())
+	for i := 1; i < m.GetPlayerCnt(); i++ {
+		assert.False(t, m.GetPlayer(i).GetIsHuman(), "player %d should be CPU", i)
+	}
+	assert.Equal(t, -1, m.GetWinnerIdx())
+	assert.False(t, m.GetGameEndFlag())
+}
+
 func TestMemoryReset(t *testing.T) {
 	m := newTestMemory()
 	m.Reset()

--- a/internal/domain/OhHell.go
+++ b/internal/domain/OhHell.go
@@ -73,6 +73,19 @@ func NewOhHell(trumpCards *TrumpCards, players []*OhHellPlayer, config OhHellCon
 	}
 }
 
+// NewDefaultOhHell returns OhHell with the standard 4-player setup (1 human, 3 CPU)
+// and DefaultOhHellConfig. Used as the single source of truth for CUI, Web, and Worker
+// construction sites.
+func NewDefaultOhHell() *OhHell {
+	players := []*OhHellPlayer{
+		NewOhHellPlayer(true),
+		NewOhHellPlayer(false),
+		NewOhHellPlayer(false),
+		NewOhHellPlayer(false),
+	}
+	return NewOhHell(NewTrumpCards(0), players, DefaultOhHellConfig())
+}
+
 // Reset ゲーム初期化
 func (o *OhHell) Reset() {
 	o.gameEndFlag = false

--- a/internal/domain/OhHell_test.go
+++ b/internal/domain/OhHell_test.go
@@ -121,6 +121,18 @@ func TestNewOhHell(t *testing.T) {
 	assert.Equal(t, -1, o.GetTrumpSuit())
 }
 
+func TestNewDefaultOhHell(t *testing.T) {
+	o := domain.NewDefaultOhHell()
+	assert.NotNil(t, o)
+	assert.Equal(t, domain.OhHellPlayerCnt, o.GetPlayerCnt())
+	assert.True(t, o.GetPlayer(0).GetIsHuman())
+	for i := 1; i < o.GetPlayerCnt(); i++ {
+		assert.False(t, o.GetPlayer(i).GetIsHuman(), "player %d should be CPU", i)
+	}
+	assert.Equal(t, -1, o.GetWinnerIdx())
+	assert.False(t, o.GetGameEndFlag())
+}
+
 func TestOhHell_Reset(t *testing.T) {
 	o := newTestOhHell()
 	o.Reset()

--- a/internal/domain/Spades.go
+++ b/internal/domain/Spades.go
@@ -75,6 +75,19 @@ func NewSpades(trumpCards *TrumpCards, players []*SpadesPlayer, config SpadesCon
 	}
 }
 
+// NewDefaultSpades returns Spades with the standard 4-player setup (1 human, 3 CPU)
+// and DefaultSpadesConfig. Used as the single source of truth for CUI, Web, and Worker
+// construction sites.
+func NewDefaultSpades() *Spades {
+	players := []*SpadesPlayer{
+		NewSpadesPlayer(true),
+		NewSpadesPlayer(false),
+		NewSpadesPlayer(false),
+		NewSpadesPlayer(false),
+	}
+	return NewSpades(NewTrumpCards(0), players, DefaultSpadesConfig())
+}
+
 // Reset ゲーム初期化
 func (s *Spades) Reset() {
 	s.gameEndFlag = false

--- a/internal/domain/Spades_test.go
+++ b/internal/domain/Spades_test.go
@@ -39,6 +39,18 @@ func TestNewSpades(t *testing.T) {
 	assert.Equal(t, 0, s.GetRoundNumber())
 }
 
+func TestNewDefaultSpades(t *testing.T) {
+	s := domain.NewDefaultSpades()
+	assert.NotNil(t, s)
+	assert.Equal(t, domain.SpadesPlayerCnt, s.GetPlayerCnt())
+	assert.True(t, s.GetPlayer(0).GetIsHuman())
+	for i := 1; i < s.GetPlayerCnt(); i++ {
+		assert.False(t, s.GetPlayer(i).GetIsHuman(), "player %d should be CPU", i)
+	}
+	assert.Equal(t, -1, s.GetWinnerIdx())
+	assert.False(t, s.GetGameEndFlag())
+}
+
 func TestSpades_Reset(t *testing.T) {
 	s := newTestSpades()
 	s.Reset()

--- a/internal/infrastructure/ui/BaccaratCui.go
+++ b/internal/infrastructure/ui/BaccaratCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -14,17 +13,12 @@ func NewBaccaratCui() *genericCuiGame {
 		domain.NewDefaultBaccarat(),
 		new(presenter.BaccaratCuiPresenter),
 	))
-	return newCuiGame(bc, []string{
-		i18n.T("baccarat.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("baccarat.helpBet"),
-		"  log                  action log",
-		"  ch                   clear history",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(bc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:    "baccarat.helpTitle",
+		CommandKeys: []string{"baccarat.helpBet"},
+		ExtraCommandLines: []string{
+			"  log                  action log",
+			"  ch                   clear history",
+		},
+	}))
 }

--- a/internal/infrastructure/ui/BlackJackCui.go
+++ b/internal/infrastructure/ui/BlackJackCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -14,24 +13,17 @@ func NewBlackJackCui() *genericCuiGame {
 		domain.NewDefaultBlackJack(),
 		new(presenter.BlackJackCuiPresenter),
 	))
-	return newCuiGame(bjc, []string{
-		i18n.T("blackjack.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("blackjack.helpBet"),
-		i18n.T("blackjack.helpHit"),
-		i18n.T("blackjack.helpStand"),
-		i18n.T("blackjack.helpDouble"),
-		i18n.T("blackjack.helpSplit"),
-		i18n.T("blackjack.helpInsurance"),
-		i18n.T("blackjack.helpDeclineInsurance"),
-		"",
-		i18n.T("settings"),
-		i18n.T("blackjack.helpSetCpuCount"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(bjc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "blackjack.helpTitle",
+		CommandKeys: []string{
+			"blackjack.helpBet",
+			"blackjack.helpHit",
+			"blackjack.helpStand",
+			"blackjack.helpDouble",
+			"blackjack.helpSplit",
+			"blackjack.helpInsurance",
+			"blackjack.helpDeclineInsurance",
+		},
+		SettingKeys: []string{"blackjack.helpSetCpuCount"},
+	}))
 }

--- a/internal/infrastructure/ui/CanfieldCui.go
+++ b/internal/infrastructure/ui/CanfieldCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -12,25 +11,20 @@ import (
 func NewCanfieldCui() *genericCuiGame {
 	canfield := domain.NewCanfield(domain.NewTrumpCards(0))
 	cc := controller.NewCanfieldCuiController(usecase.NewCanfieldInteractor(canfield, new(presenter.CanfieldCuiPresenter)))
-	return newCuiGame(cc, []string{
-		i18n.T("canfield.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("canfield.helpDraw"),
-		i18n.T("canfield.helpMove"),
-		i18n.T("canfield.helpMoveWF"),
-		i18n.T("canfield.helpMoveRT"),
-		i18n.T("canfield.helpMoveRF"),
-		i18n.T("canfield.helpMoveTF"),
-		i18n.T("canfield.helpMoveTT"),
-		i18n.T("canfield.helpGiveUp"),
-		i18n.T("canfield.helpHint"),
-		i18n.T("canfield.helpAutoComplete"),
-		"  l                        action log",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(cc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "canfield.helpTitle",
+		CommandKeys: []string{
+			"canfield.helpDraw",
+			"canfield.helpMove",
+			"canfield.helpMoveWF",
+			"canfield.helpMoveRT",
+			"canfield.helpMoveRF",
+			"canfield.helpMoveTF",
+			"canfield.helpMoveTT",
+			"canfield.helpGiveUp",
+			"canfield.helpHint",
+			"canfield.helpAutoComplete",
+		},
+		ExtraCommandLines: []string{"  l                        action log"},
+	}))
 }

--- a/internal/infrastructure/ui/CaribbeanStudCui.go
+++ b/internal/infrastructure/ui/CaribbeanStudCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -14,18 +13,9 @@ func NewCaribbeanStudCui() *genericCuiGame {
 		domain.NewDefaultCaribbeanStud(),
 		new(presenter.CaribbeanStudCuiPresenter),
 	))
-	return newCuiGame(cs, []string{
-		i18n.T("caribbeanstud.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("caribbeanstud.helpBet"),
-		i18n.T("caribbeanstud.helpPlay"),
-		i18n.T("caribbeanstud.helpFold"),
-		"  log                  action log",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(cs, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:          "caribbeanstud.helpTitle",
+		CommandKeys:       []string{"caribbeanstud.helpBet", "caribbeanstud.helpPlay", "caribbeanstud.helpFold"},
+		ExtraCommandLines: []string{"  log                  action log"},
+	}))
 }

--- a/internal/infrastructure/ui/ClockSolitaireCui.go
+++ b/internal/infrastructure/ui/ClockSolitaireCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -12,17 +11,9 @@ import (
 func NewClockSolitaireCui() *genericCuiGame {
 	cs := domain.NewClockSolitaire(domain.NewTrumpCards(0))
 	cc := controller.NewClockSolitaireCuiController(usecase.NewClockSolitaireInteractor(cs, new(presenter.ClockSolitaireCuiPresenter)))
-	return newCuiGame(cc, []string{
-		i18n.T("clocksolitaire.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("clocksolitaire.helpStep"),
-		i18n.T("clocksolitaire.helpAutoPlay"),
-		"  l                        action log",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(cc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:          "clocksolitaire.helpTitle",
+		CommandKeys:       []string{"clocksolitaire.helpStep", "clocksolitaire.helpAutoPlay"},
+		ExtraCommandLines: []string{"  l                        action log"},
+	}))
 }

--- a/internal/infrastructure/ui/CrazyEightsCui.go
+++ b/internal/infrastructure/ui/CrazyEightsCui.go
@@ -4,38 +4,16 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
 // NewCrazyEightsCui コンストラクタ
 func NewCrazyEightsCui() *genericCuiGame {
-	config := domain.DefaultCrazyEightsConfig()
-	players := []*domain.CrazyEightsPlayer{
-		domain.NewCrazyEightsPlayer(true),
-		domain.NewCrazyEightsPlayer(false),
-		domain.NewCrazyEightsPlayer(false),
-		domain.NewCrazyEightsPlayer(false),
-	}
-	ce := domain.NewCrazyEights(domain.NewTrumpCards(0), players, config)
-	cc := controller.NewCrazyEightsCuiController(usecase.NewCrazyEightsInteractor(ce, new(presenter.CrazyEightsCuiPresenter)))
-	return newCuiGame(cc, []string{
-		i18n.T("crazyeights.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("crazyeights.helpPlay"),
-		i18n.T("crazyeights.helpDraw"),
-		i18n.T("crazyeights.helpSuit"),
-		i18n.T("crazyeights.helpNextRound"),
-		"  l                    action log",
-		"",
-		i18n.T("settings"),
-		i18n.T("crazyeights.helpSetDifficulty"),
-		i18n.T("crazyeights.helpSetLimit"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	cc := controller.NewCrazyEightsCuiController(usecase.NewCrazyEightsInteractor(domain.NewDefaultCrazyEights(), new(presenter.CrazyEightsCuiPresenter)))
+	return newCuiGame(cc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:          "crazyeights.helpTitle",
+		CommandKeys:       []string{"crazyeights.helpPlay", "crazyeights.helpDraw", "crazyeights.helpSuit", "crazyeights.helpNextRound"},
+		ExtraCommandLines: []string{"  l                    action log"},
+		SettingKeys:       []string{"crazyeights.helpSetDifficulty", "crazyeights.helpSetLimit"},
+	}))
 }

--- a/internal/infrastructure/ui/CribbageCui.go
+++ b/internal/infrastructure/ui/CribbageCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -17,24 +16,10 @@ func NewCribbageCui() *genericCuiGame {
 	}
 	g := domain.NewCribbage(domain.NewTrumpCards(0), players, config)
 	cc := controller.NewCribbageCuiController(usecase.NewCribbageInteractor(g, new(presenter.CribbageCuiPresenter)))
-	return newCuiGame(cc, []string{
-		i18n.T("cribbage.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("cribbage.helpDiscard"),
-		i18n.T("cribbage.helpPeg"),
-		i18n.T("cribbage.helpGo"),
-		i18n.T("cribbage.helpShowNext"),
-		i18n.T("cribbage.helpNextRound"),
-		"  l                    action log",
-		"",
-		i18n.T("settings"),
-		i18n.T("cribbage.helpSetDifficulty"),
-		i18n.T("cribbage.helpSetLimit"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(cc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:          "cribbage.helpTitle",
+		CommandKeys:       []string{"cribbage.helpDiscard", "cribbage.helpPeg", "cribbage.helpGo", "cribbage.helpShowNext", "cribbage.helpNextRound"},
+		ExtraCommandLines: []string{"  l                    action log"},
+		SettingKeys:       []string{"cribbage.helpSetDifficulty", "cribbage.helpSetLimit"},
+	}))
 }

--- a/internal/infrastructure/ui/DaifugoCui.go
+++ b/internal/infrastructure/ui/DaifugoCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -21,21 +20,9 @@ func NewDaifugoCui() *genericCuiGame {
 	dgc := controller.NewDaifugoCuiController(
 		usecase.NewDaifugoInteractor(daifugo, new(presenter.DaifugoCuiPresenter)),
 	)
-	return newCuiGame(dgc, []string{
-		i18n.T("daifugo.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("daifugo.helpPlay"),
-		i18n.T("daifugo.helpSort"),
-		"",
-		i18n.T("settings"),
-		i18n.T("daifugo.helpSetDifficulty"),
-		i18n.T("daifugo.helpSetJoker"),
-		i18n.T("daifugo.helpSetRule"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(dgc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:    "daifugo.helpTitle",
+		CommandKeys: []string{"daifugo.helpPlay", "daifugo.helpSort"},
+		SettingKeys: []string{"daifugo.helpSetDifficulty", "daifugo.helpSetJoker", "daifugo.helpSetRule"},
+	}))
 }

--- a/internal/infrastructure/ui/DeucesWildCui.go
+++ b/internal/infrastructure/ui/DeucesWildCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -14,17 +13,9 @@ func NewDeucesWildCui() *genericCuiGame {
 		domain.NewDeucesWildVideoPoker(),
 		new(presenter.VideoPokerCuiPresenter),
 	))
-	return newCuiGame(vc, []string{
-		i18n.T("deuceswild.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("videopoker.helpBet"),
-		i18n.T("videopoker.helpHold"),
-		"  log                  action log",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(vc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:          "deuceswild.helpTitle",
+		CommandKeys:       []string{"videopoker.helpBet", "videopoker.helpHold"},
+		ExtraCommandLines: []string{"  log                  action log"},
+	}))
 }

--- a/internal/infrastructure/ui/DoubtCui.go
+++ b/internal/infrastructure/ui/DoubtCui.go
@@ -46,24 +46,11 @@ func (cui *DoubtCui) Controller() CuiExecer { return cui.dc }
 
 // HelpLines returns the game's help lines.
 func (cui *DoubtCui) HelpLines() []string {
-	return []string{
-		i18n.T("doubt.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("doubt.helpPlay"),
-		i18n.T("doubt.helpDoubt"),
-		i18n.T("doubt.helpSkip"),
-		"",
-		i18n.T("settings"),
-		i18n.T("doubt.helpSetWindow"),
-		i18n.T("doubt.helpSetMemory"),
-		i18n.T("doubt.helpSetPenalty"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	}
+	return BuildCuiHelp(CuiHelpSpec{
+		TitleKey:    "doubt.helpTitle",
+		CommandKeys: []string{"doubt.helpPlay", "doubt.helpDoubt", "doubt.helpSkip"},
+		SettingKeys: []string{"doubt.helpSetWindow", "doubt.helpSetMemory", "doubt.helpSetPenalty"},
+	})
 }
 
 // inputReader 標準入力を読み込み inputCh に送るゴルーチン

--- a/internal/infrastructure/ui/EuchreCui.go
+++ b/internal/infrastructure/ui/EuchreCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -19,28 +18,20 @@ func NewEuchreCui() *genericCuiGame {
 	}
 	euchre := domain.NewEuchre(domain.NewTrumpCardsEuchre(), players, config)
 	ec := controller.NewEuchreCuiController(usecase.NewEuchreInteractor(euchre, new(presenter.EuchreCuiPresenter)))
-	return newCuiGame(ec, []string{
-		i18n.T("euchre.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("euchre.helpOrderUp"),
-		i18n.T("euchre.helpOrderUpAlone"),
-		i18n.T("euchre.helpPass"),
-		i18n.T("euchre.helpCall"),
-		i18n.T("euchre.helpCallAlone"),
-		i18n.T("euchre.helpDiscard"),
-		i18n.T("euchre.helpPlay"),
-		i18n.T("euchre.helpNext"),
-		i18n.T("euchre.helpNextRound"),
-		"  l                    action log",
-		"",
-		i18n.T("settings"),
-		i18n.T("euchre.helpSetDifficulty"),
-		i18n.T("euchre.helpSetLimit"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(ec, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "euchre.helpTitle",
+		CommandKeys: []string{
+			"euchre.helpOrderUp",
+			"euchre.helpOrderUpAlone",
+			"euchre.helpPass",
+			"euchre.helpCall",
+			"euchre.helpCallAlone",
+			"euchre.helpDiscard",
+			"euchre.helpPlay",
+			"euchre.helpNext",
+			"euchre.helpNextRound",
+		},
+		ExtraCommandLines: []string{"  l                    action log"},
+		SettingKeys:       []string{"euchre.helpSetDifficulty", "euchre.helpSetLimit"},
+	}))
 }

--- a/internal/infrastructure/ui/FiftyOneCui.go
+++ b/internal/infrastructure/ui/FiftyOneCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -20,20 +19,9 @@ func NewFiftyOneCui() *genericCuiGame {
 	foc := controller.NewFiftyOneCuiController(
 		usecase.NewFiftyOneInteractor(fo, new(presenter.FiftyOneCuiPresenter)),
 	)
-	return newCuiGame(foc, []string{
-		i18n.T("fiftyone.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("fiftyone.helpPlay"),
-		i18n.T("fiftyone.helpAll"),
-		i18n.T("fiftyone.helpStop"),
-		"",
-		i18n.T("settings"),
-		i18n.T("fiftyone.helpSetDifficulty"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(foc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:    "fiftyone.helpTitle",
+		CommandKeys: []string{"fiftyone.helpPlay", "fiftyone.helpAll", "fiftyone.helpStop"},
+		SettingKeys: []string{"fiftyone.helpSetDifficulty"},
+	}))
 }

--- a/internal/infrastructure/ui/FortyThievesCui.go
+++ b/internal/infrastructure/ui/FortyThievesCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -12,23 +11,18 @@ import (
 func NewFortyThievesCui() *genericCuiGame {
 	fortythieves := domain.NewFortyThieves(domain.NewTrumpCardsWithDecks(2, 0))
 	fc := controller.NewFortyThievesCuiController(usecase.NewFortyThievesInteractor(fortythieves, new(presenter.FortyThievesCuiPresenter)))
-	return newCuiGame(fc, []string{
-		i18n.T("fortythieves.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("fortythieves.helpDraw"),
-		i18n.T("fortythieves.helpMove"),
-		i18n.T("fortythieves.helpMoveWF"),
-		i18n.T("fortythieves.helpMoveTF"),
-		i18n.T("fortythieves.helpMoveTT"),
-		i18n.T("fortythieves.helpGiveUp"),
-		i18n.T("fortythieves.helpHint"),
-		i18n.T("fortythieves.helpAutoComplete"),
-		"  l                        action log",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(fc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "fortythieves.helpTitle",
+		CommandKeys: []string{
+			"fortythieves.helpDraw",
+			"fortythieves.helpMove",
+			"fortythieves.helpMoveWF",
+			"fortythieves.helpMoveTF",
+			"fortythieves.helpMoveTT",
+			"fortythieves.helpGiveUp",
+			"fortythieves.helpHint",
+			"fortythieves.helpAutoComplete",
+		},
+		ExtraCommandLines: []string{"  l                        action log"},
+	}))
 }

--- a/internal/infrastructure/ui/FreeCellCui.go
+++ b/internal/infrastructure/ui/FreeCellCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -12,24 +11,19 @@ import (
 func NewFreeCellCui() *genericCuiGame {
 	freeCell := domain.NewFreeCell(domain.NewTrumpCards(0))
 	fc := controller.NewFreeCellCuiController(usecase.NewFreeCellInteractor(freeCell, new(presenter.FreeCellCuiPresenter)))
-	return newCuiGame(fc, []string{
-		i18n.T("freecell.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("freecell.helpMove"),
-		i18n.T("freecell.helpMoveTF"),
-		i18n.T("freecell.helpMoveTT"),
-		i18n.T("freecell.helpMoveTC"),
-		i18n.T("freecell.helpMoveCT"),
-		i18n.T("freecell.helpMoveCF"),
-		i18n.T("freecell.helpGiveUp"),
-		i18n.T("freecell.helpHint"),
-		i18n.T("freecell.helpAutoComplete"),
-		"  l                        action log",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(fc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "freecell.helpTitle",
+		CommandKeys: []string{
+			"freecell.helpMove",
+			"freecell.helpMoveTF",
+			"freecell.helpMoveTT",
+			"freecell.helpMoveTC",
+			"freecell.helpMoveCT",
+			"freecell.helpMoveCF",
+			"freecell.helpGiveUp",
+			"freecell.helpHint",
+			"freecell.helpAutoComplete",
+		},
+		ExtraCommandLines: []string{"  l                        action log"},
+	}))
 }

--- a/internal/infrastructure/ui/GinRummyCui.go
+++ b/internal/infrastructure/ui/GinRummyCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -17,25 +16,17 @@ func NewGinRummyCui() *genericCuiGame {
 	}
 	gr := domain.NewGinRummy(domain.NewTrumpCards(0), players, config)
 	cc := controller.NewGinRummyCuiController(usecase.NewGinRummyInteractor(gr, new(presenter.GinRummyCuiPresenter)))
-	return newCuiGame(cc, []string{
-		i18n.T("ginrummy.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("ginrummy.helpDrawStock"),
-		i18n.T("ginrummy.helpDrawDiscard"),
-		i18n.T("ginrummy.helpDiscard"),
-		i18n.T("ginrummy.helpKnock"),
-		i18n.T("ginrummy.helpLayoff"),
-		i18n.T("ginrummy.helpNextRound"),
-		"  l                    action log",
-		"",
-		i18n.T("settings"),
-		i18n.T("ginrummy.helpSetDifficulty"),
-		i18n.T("ginrummy.helpSetLimit"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(cc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "ginrummy.helpTitle",
+		CommandKeys: []string{
+			"ginrummy.helpDrawStock",
+			"ginrummy.helpDrawDiscard",
+			"ginrummy.helpDiscard",
+			"ginrummy.helpKnock",
+			"ginrummy.helpLayoff",
+			"ginrummy.helpNextRound",
+		},
+		ExtraCommandLines: []string{"  l                    action log"},
+		SettingKeys:       []string{"ginrummy.helpSetDifficulty", "ginrummy.helpSetLimit"},
+	}))
 }

--- a/internal/infrastructure/ui/GoFishCui.go
+++ b/internal/infrastructure/ui/GoFishCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -20,18 +19,9 @@ func NewGoFishCui() *genericCuiGame {
 	gfc := controller.NewGoFishCuiController(
 		usecase.NewGoFishInteractor(goFish, new(presenter.GoFishCuiPresenter)),
 	)
-	return newCuiGame(gfc, []string{
-		i18n.T("gofish.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("gofish.helpAsk"),
-		"",
-		i18n.T("settings"),
-		i18n.T("gofish.helpSetDifficulty"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(gfc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:    "gofish.helpTitle",
+		CommandKeys: []string{"gofish.helpAsk"},
+		SettingKeys: []string{"gofish.helpSetDifficulty"},
+	}))
 }

--- a/internal/infrastructure/ui/GolfCui.go
+++ b/internal/infrastructure/ui/GolfCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -12,19 +11,9 @@ import (
 func NewGolfCui() *genericCuiGame {
 	golf := domain.NewGolf(domain.NewTrumpCards(0))
 	gc := controller.NewGolfCuiController(usecase.NewGolfInteractor(golf, new(presenter.GolfCuiPresenter)))
-	return newCuiGame(gc, []string{
-		i18n.T("golf.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("golf.helpDraw"),
-		i18n.T("golf.helpRemove"),
-		i18n.T("golf.helpGiveUp"),
-		i18n.T("golf.helpHint"),
-		"  l                        action log",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(gc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:          "golf.helpTitle",
+		CommandKeys:       []string{"golf.helpDraw", "golf.helpRemove", "golf.helpGiveUp", "golf.helpHint"},
+		ExtraCommandLines: []string{"  l                        action log"},
+	}))
 }

--- a/internal/infrastructure/ui/HeartsCui.go
+++ b/internal/infrastructure/ui/HeartsCui.go
@@ -4,38 +4,16 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
 // NewHeartsCui コンストラクタ
 func NewHeartsCui() *genericCuiGame {
-	config := domain.DefaultHeartsConfig()
-	players := []*domain.HeartsPlayer{
-		domain.NewHeartsPlayer(true),
-		domain.NewHeartsPlayer(false),
-		domain.NewHeartsPlayer(false),
-		domain.NewHeartsPlayer(false),
-	}
-	hearts := domain.NewHearts(domain.NewTrumpCards(0), players, config)
-	hc := controller.NewHeartsCuiController(usecase.NewHeartsInteractor(hearts, new(presenter.HeartsCuiPresenter)))
-	return newCuiGame(hc, []string{
-		i18n.T("hearts.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("hearts.helpPass"),
-		i18n.T("hearts.helpPlay"),
-		i18n.T("hearts.helpNext"),
-		i18n.T("hearts.helpNextRound"),
-		"  l                    action log",
-		"",
-		i18n.T("settings"),
-		i18n.T("hearts.helpSetDifficulty"),
-		i18n.T("hearts.helpSetLimit"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	hc := controller.NewHeartsCuiController(usecase.NewHeartsInteractor(domain.NewDefaultHearts(), new(presenter.HeartsCuiPresenter)))
+	return newCuiGame(hc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:          "hearts.helpTitle",
+		CommandKeys:       []string{"hearts.helpPass", "hearts.helpPlay", "hearts.helpNext", "hearts.helpNextRound"},
+		ExtraCommandLines: []string{"  l                    action log"},
+		SettingKeys:       []string{"hearts.helpSetDifficulty", "hearts.helpSetLimit"},
+	}))
 }

--- a/internal/infrastructure/ui/HoldemCui.go
+++ b/internal/infrastructure/ui/HoldemCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -13,32 +12,28 @@ func NewHoldemCui() *genericCuiGame {
 	cfg := domain.DefaultHoldemConfig()
 	holdem := domain.NewHoldem(domain.NewTrumpCards(0), domain.NewPlayersForTable(cfg.TableSize), cfg)
 	hc := controller.NewHoldemCuiController(usecase.NewHoldemInteractor(holdem, new(presenter.HoldemCuiPresenter)))
-	return newCuiGame(hc, []string{
-		i18n.T("holdem.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("holdem.helpFold"),
-		i18n.T("holdem.helpCheck"),
-		i18n.T("holdem.helpCall"),
-		i18n.T("holdem.helpBet"),
-		i18n.T("holdem.helpRaise"),
-		i18n.T("holdem.helpAllIn"),
-		"  rb                   rebuy",
-		"  sr                   skip rebuy",
-		"  ad                   add-on",
-		"  sa                   skip add-on",
-		"",
-		i18n.T("settings"),
-		i18n.T("holdem.helpBettingLimit"),
-		i18n.T("holdem.helpTournament"),
-		"  sb <amount>          small blind (>=1)",
-		"  bb <amount>          big blind (>=2)",
-		"  lh <hands>           blind level-up hands (>=1)",
-		"  ts [4|6|9]           table size",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(hc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "holdem.helpTitle",
+		CommandKeys: []string{
+			"holdem.helpFold",
+			"holdem.helpCheck",
+			"holdem.helpCall",
+			"holdem.helpBet",
+			"holdem.helpRaise",
+			"holdem.helpAllIn",
+		},
+		ExtraCommandLines: []string{
+			"  rb                   rebuy",
+			"  sr                   skip rebuy",
+			"  ad                   add-on",
+			"  sa                   skip add-on",
+		},
+		SettingKeys: []string{"holdem.helpBettingLimit", "holdem.helpTournament"},
+		ExtraSettingLines: []string{
+			"  sb <amount>          small blind (>=1)",
+			"  bb <amount>          big blind (>=2)",
+			"  lh <hands>           blind level-up hands (>=1)",
+			"  ts [4|6|9]           table size",
+		},
+	}))
 }

--- a/internal/infrastructure/ui/IndianPokerCui.go
+++ b/internal/infrastructure/ui/IndianPokerCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -13,25 +12,16 @@ func NewIndianPokerCui() *genericCuiGame {
 	cfg := domain.DefaultIndianPokerConfig()
 	ip := domain.NewIndianPoker(domain.NewTrumpCards(0), domain.NewIndianPokerPlayers(), cfg)
 	ipc := controller.NewIndianPokerCuiController(usecase.NewIndianPokerInteractor(ip, new(presenter.IndianPokerCuiPresenter)))
-	return newCuiGame(ipc, []string{
-		i18n.T("indianpoker.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("indianpoker.helpFold"),
-		i18n.T("indianpoker.helpCheck"),
-		i18n.T("indianpoker.helpCall"),
-		i18n.T("indianpoker.helpBet"),
-		i18n.T("indianpoker.helpRaise"),
-		i18n.T("indianpoker.helpAllIn"),
-		"",
-		i18n.T("settings"),
-		i18n.T("indianpoker.helpAnte"),
-		i18n.T("indianpoker.helpBettingLimit"),
-		i18n.T("indianpoker.helpMetaAI"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(ipc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "indianpoker.helpTitle",
+		CommandKeys: []string{
+			"indianpoker.helpFold",
+			"indianpoker.helpCheck",
+			"indianpoker.helpCall",
+			"indianpoker.helpBet",
+			"indianpoker.helpRaise",
+			"indianpoker.helpAllIn",
+		},
+		SettingKeys: []string{"indianpoker.helpAnte", "indianpoker.helpBettingLimit", "indianpoker.helpMetaAI"},
+	}))
 }

--- a/internal/infrastructure/ui/JokerPokerCui.go
+++ b/internal/infrastructure/ui/JokerPokerCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -14,17 +13,9 @@ func NewJokerPokerCui() *genericCuiGame {
 		domain.NewJokerPokerVideoPoker(),
 		new(presenter.VideoPokerCuiPresenter),
 	))
-	return newCuiGame(vc, []string{
-		i18n.T("jokerpoker.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("videopoker.helpBet"),
-		i18n.T("videopoker.helpHold"),
-		"  log                  action log",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(vc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:          "jokerpoker.helpTitle",
+		CommandKeys:       []string{"videopoker.helpBet", "videopoker.helpHold"},
+		ExtraCommandLines: []string{"  log                  action log"},
+	}))
 }

--- a/internal/infrastructure/ui/KlondikeCui.go
+++ b/internal/infrastructure/ui/KlondikeCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -12,23 +11,18 @@ import (
 func NewKlondikeCui() *genericCuiGame {
 	klondike := domain.NewKlondike(domain.NewTrumpCards(0))
 	kc := controller.NewKlondikeCuiController(usecase.NewKlondikeInteractor(klondike, new(presenter.KlondikeCuiPresenter)))
-	return newCuiGame(kc, []string{
-		i18n.T("klondike.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("klondike.helpDraw"),
-		i18n.T("klondike.helpMove"),
-		i18n.T("klondike.helpMoveWF"),
-		i18n.T("klondike.helpMoveTF"),
-		i18n.T("klondike.helpMoveTT"),
-		i18n.T("klondike.helpGiveUp"),
-		i18n.T("klondike.helpHint"),
-		i18n.T("klondike.helpAutoComplete"),
-		"  l                        action log",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(kc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "klondike.helpTitle",
+		CommandKeys: []string{
+			"klondike.helpDraw",
+			"klondike.helpMove",
+			"klondike.helpMoveWF",
+			"klondike.helpMoveTF",
+			"klondike.helpMoveTT",
+			"klondike.helpGiveUp",
+			"klondike.helpHint",
+			"klondike.helpAutoComplete",
+		},
+		ExtraCommandLines: []string{"  l                        action log"},
+	}))
 }

--- a/internal/infrastructure/ui/LetItRideCui.go
+++ b/internal/infrastructure/ui/LetItRideCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -14,18 +13,9 @@ func NewLetItRideCui() *genericCuiGame {
 		domain.NewDefaultLetItRide(),
 		new(presenter.LetItRideCuiPresenter),
 	))
-	return newCuiGame(lc, []string{
-		i18n.T("letitride.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("letitride.helpBet"),
-		i18n.T("letitride.helpPull"),
-		i18n.T("letitride.helpLetItRide"),
-		"  log                  action log",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(lc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:          "letitride.helpTitle",
+		CommandKeys:       []string{"letitride.helpBet", "letitride.helpPull", "letitride.helpLetItRide"},
+		ExtraCommandLines: []string{"  log                  action log"},
+	}))
 }

--- a/internal/infrastructure/ui/MemoryCui.go
+++ b/internal/infrastructure/ui/MemoryCui.go
@@ -4,35 +4,16 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
 // NewMemoryCui コンストラクタ
 func NewMemoryCui() *genericCuiGame {
-	config := domain.DefaultMemoryConfig()
-	players := []*domain.MemoryPlayer{
-		domain.NewMemoryPlayer(true),
-		domain.NewMemoryPlayer(false),
-		domain.NewMemoryPlayer(false),
-		domain.NewMemoryPlayer(false),
-	}
-	memory := domain.NewMemory(domain.NewTrumpCards(0), players, config)
-	mc := controller.NewMemoryCuiController(usecase.NewMemoryInteractor(memory, new(presenter.MemoryCuiPresenter)))
-	return newCuiGame(mc, []string{
-		i18n.T("memory.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("memory.helpFlip"),
-		i18n.T("memory.helpNext"),
-		"  l                    action log",
-		"",
-		i18n.T("settings"),
-		i18n.T("memory.helpSetDifficulty"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	mc := controller.NewMemoryCuiController(usecase.NewMemoryInteractor(domain.NewDefaultMemory(), new(presenter.MemoryCuiPresenter)))
+	return newCuiGame(mc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:          "memory.helpTitle",
+		CommandKeys:       []string{"memory.helpFlip", "memory.helpNext"},
+		ExtraCommandLines: []string{"  l                    action log"},
+		SettingKeys:       []string{"memory.helpSetDifficulty"},
+	}))
 }

--- a/internal/infrastructure/ui/NapoleonCui.go
+++ b/internal/infrastructure/ui/NapoleonCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -19,26 +18,17 @@ func NewNapoleonCui() *genericCuiGame {
 	}
 	napoleon := domain.NewNapoleon(domain.NewTrumpCards(1), players, config)
 	nc := controller.NewNapoleonCuiController(usecase.NewNapoleonInteractor(napoleon, new(presenter.NapoleonCuiPresenter)))
-	return newCuiGame(nc, []string{
-		i18n.T("napoleon.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("napoleon.helpBid"),
-		i18n.T("napoleon.helpTrump"),
-		i18n.T("napoleon.helpExchange"),
-		i18n.T("napoleon.helpPlay"),
-		i18n.T("napoleon.helpNext"),
-		i18n.T("napoleon.helpNextRound"),
-		"  l                    action log",
-		"",
-		i18n.T("settings"),
-		i18n.T("napoleon.helpSetDifficulty"),
-		i18n.T("napoleon.helpSetLimit"),
-		i18n.T("napoleon.helpSetMinBid"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(nc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "napoleon.helpTitle",
+		CommandKeys: []string{
+			"napoleon.helpBid",
+			"napoleon.helpTrump",
+			"napoleon.helpExchange",
+			"napoleon.helpPlay",
+			"napoleon.helpNext",
+			"napoleon.helpNextRound",
+		},
+		ExtraCommandLines: []string{"  l                    action log"},
+		SettingKeys:       []string{"napoleon.helpSetDifficulty", "napoleon.helpSetLimit", "napoleon.helpSetMinBid"},
+	}))
 }

--- a/internal/infrastructure/ui/OhHellCui.go
+++ b/internal/infrastructure/ui/OhHellCui.go
@@ -4,38 +4,16 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
 // NewOhHellCui コンストラクタ
 func NewOhHellCui() *genericCuiGame {
-	config := domain.DefaultOhHellConfig()
-	players := []*domain.OhHellPlayer{
-		domain.NewOhHellPlayer(true),
-		domain.NewOhHellPlayer(false),
-		domain.NewOhHellPlayer(false),
-		domain.NewOhHellPlayer(false),
-	}
-	ohHell := domain.NewOhHell(domain.NewTrumpCards(0), players, config)
-	oc := controller.NewOhHellCuiController(usecase.NewOhHellInteractor(ohHell, new(presenter.OhHellCuiPresenter)))
-	return newCuiGame(oc, []string{
-		i18n.T("ohhell.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("ohhell.helpBid"),
-		i18n.T("ohhell.helpPlay"),
-		i18n.T("ohhell.helpNext"),
-		i18n.T("ohhell.helpNextRound"),
-		"  l                    action log",
-		"",
-		i18n.T("settings"),
-		i18n.T("ohhell.helpSetDifficulty"),
-		i18n.T("ohhell.helpSetMaxHand"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	oc := controller.NewOhHellCuiController(usecase.NewOhHellInteractor(domain.NewDefaultOhHell(), new(presenter.OhHellCuiPresenter)))
+	return newCuiGame(oc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:          "ohhell.helpTitle",
+		CommandKeys:       []string{"ohhell.helpBid", "ohhell.helpPlay", "ohhell.helpNext", "ohhell.helpNextRound"},
+		ExtraCommandLines: []string{"  l                    action log"},
+		SettingKeys:       []string{"ohhell.helpSetDifficulty", "ohhell.helpSetMaxHand"},
+	}))
 }

--- a/internal/infrastructure/ui/OldMaidCui.go
+++ b/internal/infrastructure/ui/OldMaidCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -20,22 +19,9 @@ func NewOldMaidCui() *genericCuiGame {
 	omc := controller.NewOldMaidCuiController(
 		usecase.NewOldMaidInteractor(oldMaid, new(presenter.OldMaidCuiPresenter)),
 	)
-	return newCuiGame(omc, []string{
-		i18n.T("oldmaid.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("oldmaid.helpDraw"),
-		i18n.T("oldmaid.helpShuffle"),
-		i18n.T("oldmaid.helpReorder"),
-		"",
-		i18n.T("settings"),
-		i18n.T("oldmaid.helpSetMode"),
-		i18n.T("oldmaid.helpSetPlacement"),
-		i18n.T("oldmaid.helpSetMemoryAI"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(omc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:    "oldmaid.helpTitle",
+		CommandKeys: []string{"oldmaid.helpDraw", "oldmaid.helpShuffle", "oldmaid.helpReorder"},
+		SettingKeys: []string{"oldmaid.helpSetMode", "oldmaid.helpSetPlacement", "oldmaid.helpSetMemoryAI"},
+	}))
 }

--- a/internal/infrastructure/ui/OmahaCui.go
+++ b/internal/infrastructure/ui/OmahaCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -13,32 +12,28 @@ func NewOmahaCui() *genericCuiGame {
 	cfg := domain.DefaultOmahaConfig()
 	omaha := domain.NewOmaha(domain.NewTrumpCards(0), domain.NewOmahaPlayersForTable(cfg.TableSize), cfg)
 	oc := controller.NewOmahaCuiController(usecase.NewOmahaInteractor(omaha, new(presenter.OmahaCuiPresenter)))
-	return newCuiGame(oc, []string{
-		i18n.T("omaha.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("omaha.helpFold"),
-		i18n.T("omaha.helpCheck"),
-		i18n.T("omaha.helpCall"),
-		i18n.T("omaha.helpBet"),
-		i18n.T("omaha.helpRaise"),
-		i18n.T("omaha.helpAllIn"),
-		"  rb                   rebuy",
-		"  sr                   skip rebuy",
-		"  ad                   add-on",
-		"  sa                   skip add-on",
-		"",
-		i18n.T("settings"),
-		i18n.T("omaha.helpBettingLimit"),
-		i18n.T("omaha.helpTournament"),
-		"  sb <amount>          small blind (>=1)",
-		"  bb <amount>          big blind (>=2)",
-		"  lh <hands>           blind level-up hands (>=1)",
-		"  ts [4|6|9]           table size",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(oc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "omaha.helpTitle",
+		CommandKeys: []string{
+			"omaha.helpFold",
+			"omaha.helpCheck",
+			"omaha.helpCall",
+			"omaha.helpBet",
+			"omaha.helpRaise",
+			"omaha.helpAllIn",
+		},
+		ExtraCommandLines: []string{
+			"  rb                   rebuy",
+			"  sr                   skip rebuy",
+			"  ad                   add-on",
+			"  sa                   skip add-on",
+		},
+		SettingKeys: []string{"omaha.helpBettingLimit", "omaha.helpTournament"},
+		ExtraSettingLines: []string{
+			"  sb <amount>          small blind (>=1)",
+			"  bb <amount>          big blind (>=2)",
+			"  lh <hands>           blind level-up hands (>=1)",
+			"  ts [4|6|9]           table size",
+		},
+	}))
 }

--- a/internal/infrastructure/ui/PageOneCui.go
+++ b/internal/infrastructure/ui/PageOneCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -19,24 +18,16 @@ func NewPageOneCui() *genericCuiGame {
 	}
 	po := domain.NewPageOne(domain.NewTrumpCards(0), players, config)
 	cc := controller.NewPageOneCuiController(usecase.NewPageOneInteractor(po, new(presenter.PageOneCuiPresenter)))
-	return newCuiGame(cc, []string{
-		i18n.T("pageone.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("pageone.helpPlay"),
-		i18n.T("pageone.helpDraw"),
-		i18n.T("pageone.helpDeclare"),
-		i18n.T("pageone.helpSkip"),
-		i18n.T("pageone.helpNextRound"),
-		"  l                    action log",
-		"",
-		i18n.T("settings"),
-		i18n.T("pageone.helpSetDifficulty"),
-		i18n.T("pageone.helpSetLimit"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(cc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "pageone.helpTitle",
+		CommandKeys: []string{
+			"pageone.helpPlay",
+			"pageone.helpDraw",
+			"pageone.helpDeclare",
+			"pageone.helpSkip",
+			"pageone.helpNextRound",
+		},
+		ExtraCommandLines: []string{"  l                    action log"},
+		SettingKeys:       []string{"pageone.helpSetDifficulty", "pageone.helpSetLimit"},
+	}))
 }

--- a/internal/infrastructure/ui/PaiGowCui.go
+++ b/internal/infrastructure/ui/PaiGowCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -14,17 +13,9 @@ func NewPaiGowCui() *genericCuiGame {
 		domain.NewDefaultPaiGow(),
 		new(presenter.PaiGowCuiPresenter),
 	))
-	return newCuiGame(pgc, []string{
-		i18n.T("paigow.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("paigow.helpBet"),
-		i18n.T("paigow.helpSet"),
-		"  log                  action log",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(pgc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:          "paigow.helpTitle",
+		CommandKeys:       []string{"paigow.helpBet", "paigow.helpSet"},
+		ExtraCommandLines: []string{"  log                  action log"},
+	}))
 }

--- a/internal/infrastructure/ui/PigsTailCui.go
+++ b/internal/infrastructure/ui/PigsTailCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -20,15 +19,8 @@ func NewPigsTailCui() *genericCuiGame {
 	ptc := controller.NewPigsTailCuiController(
 		usecase.NewPigsTailInteractor(pigsTail, new(presenter.PigsTailCuiPresenter)),
 	)
-	return newCuiGame(ptc, []string{
-		i18n.T("pigtail.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("pigtail.helpAction"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(ptc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:    "pigtail.helpTitle",
+		CommandKeys: []string{"pigtail.helpAction"},
+	}))
 }

--- a/internal/infrastructure/ui/PineappleCui.go
+++ b/internal/infrastructure/ui/PineappleCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -13,33 +12,29 @@ func NewPineappleCui() *genericCuiGame {
 	cfg := domain.DefaultPineappleConfig()
 	pineapple := domain.NewPineapple(domain.NewTrumpCards(0), domain.NewPineapplePlayersForTable(cfg.TableSize), cfg)
 	pc := controller.NewPineappleCuiController(usecase.NewPineappleInteractor(pineapple, new(presenter.PineappleCuiPresenter)))
-	return newCuiGame(pc, []string{
-		i18n.T("pineapple.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("pineapple.helpFold"),
-		i18n.T("pineapple.helpCheck"),
-		i18n.T("pineapple.helpCall"),
-		i18n.T("pineapple.helpBet"),
-		i18n.T("pineapple.helpRaise"),
-		i18n.T("pineapple.helpAllIn"),
-		"  d <index>            discard",
-		"  rb                   rebuy",
-		"  sr                   skip rebuy",
-		"  ad                   add-on",
-		"  sa                   skip add-on",
-		"",
-		i18n.T("settings"),
-		i18n.T("pineapple.helpBettingLimit"),
-		i18n.T("pineapple.helpTournament"),
-		"  sb <amount>          small blind (>=1)",
-		"  bb <amount>          big blind (>=2)",
-		"  lh <hands>           blind level-up hands (>=1)",
-		"  ts [4|6|9]           table size",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(pc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "pineapple.helpTitle",
+		CommandKeys: []string{
+			"pineapple.helpFold",
+			"pineapple.helpCheck",
+			"pineapple.helpCall",
+			"pineapple.helpBet",
+			"pineapple.helpRaise",
+			"pineapple.helpAllIn",
+		},
+		ExtraCommandLines: []string{
+			"  d <index>            discard",
+			"  rb                   rebuy",
+			"  sr                   skip rebuy",
+			"  ad                   add-on",
+			"  sa                   skip add-on",
+		},
+		SettingKeys: []string{"pineapple.helpBettingLimit", "pineapple.helpTournament"},
+		ExtraSettingLines: []string{
+			"  sb <amount>          small blind (>=1)",
+			"  bb <amount>          big blind (>=2)",
+			"  lh <hands>           blind level-up hands (>=1)",
+			"  ts [4|6|9]           table size",
+		},
+	}))
 }

--- a/internal/infrastructure/ui/PinochleCui.go
+++ b/internal/infrastructure/ui/PinochleCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -19,26 +18,18 @@ func NewPinochleCui() *genericCuiGame {
 	}
 	pinochle := domain.NewPinochle(domain.NewTrumpCardsPinochle(), players, config)
 	pc := controller.NewPinochleCuiController(usecase.NewPinochleInteractor(pinochle, new(presenter.PinochleCuiPresenter)))
-	return newCuiGame(pc, []string{
-		i18n.T("pinochle.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("pinochle.helpBid"),
-		i18n.T("pinochle.helpPass"),
-		i18n.T("pinochle.helpTrump"),
-		i18n.T("pinochle.helpMeld"),
-		i18n.T("pinochle.helpPlay"),
-		i18n.T("pinochle.helpNext"),
-		i18n.T("pinochle.helpNextRound"),
-		"  l                    action log",
-		"",
-		i18n.T("settings"),
-		i18n.T("pinochle.helpSetDifficulty"),
-		i18n.T("pinochle.helpSetLimit"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(pc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "pinochle.helpTitle",
+		CommandKeys: []string{
+			"pinochle.helpBid",
+			"pinochle.helpPass",
+			"pinochle.helpTrump",
+			"pinochle.helpMeld",
+			"pinochle.helpPlay",
+			"pinochle.helpNext",
+			"pinochle.helpNextRound",
+		},
+		ExtraCommandLines: []string{"  l                    action log"},
+		SettingKeys:       []string{"pinochle.helpSetDifficulty", "pinochle.helpSetLimit"},
+	}))
 }

--- a/internal/infrastructure/ui/PokerCui.go
+++ b/internal/infrastructure/ui/PokerCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -19,26 +18,18 @@ func NewPokerCui() *genericCuiGame {
 	}
 	poker := domain.NewPoker(domain.NewTrumpCards(config.JokerCount), players, config)
 	pc := controller.NewPokerCuiController(usecase.NewPokerInteractor(poker, new(presenter.PokerCuiPresenter)))
-	return newCuiGame(pc, []string{
-		i18n.T("poker.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("poker.helpBet"),
-		i18n.T("poker.helpCall"),
-		i18n.T("poker.helpRaise"),
-		i18n.T("poker.helpCheck"),
-		i18n.T("poker.helpFold"),
-		i18n.T("poker.helpAllIn"),
-		i18n.T("poker.helpExchange"),
-		i18n.T("poker.helpStand"),
-		"",
-		i18n.T("settings"),
-		i18n.T("poker.helpBettingLimit"),
-		i18n.T("poker.helpLowball"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(pc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "poker.helpTitle",
+		CommandKeys: []string{
+			"poker.helpBet",
+			"poker.helpCall",
+			"poker.helpRaise",
+			"poker.helpCheck",
+			"poker.helpFold",
+			"poker.helpAllIn",
+			"poker.helpExchange",
+			"poker.helpStand",
+		},
+		SettingKeys: []string{"poker.helpBettingLimit", "poker.helpLowball"},
+	}))
 }

--- a/internal/infrastructure/ui/PyramidCui.go
+++ b/internal/infrastructure/ui/PyramidCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -12,22 +11,17 @@ import (
 func NewPyramidCui() *genericCuiGame {
 	pyramid := domain.NewPyramid(domain.NewTrumpCards(0))
 	pc := controller.NewPyramidCuiController(usecase.NewPyramidInteractor(pyramid, new(presenter.PyramidCuiPresenter)))
-	return newCuiGame(pc, []string{
-		i18n.T("pyramid.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("pyramid.helpDraw"),
-		i18n.T("pyramid.helpRemoveKing"),
-		i18n.T("pyramid.helpRemovePair"),
-		i18n.T("pyramid.helpRemoveWaste"),
-		i18n.T("pyramid.helpRemoveWasteKing"),
-		i18n.T("pyramid.helpGiveUp"),
-		i18n.T("pyramid.helpHint"),
-		"  l                        action log",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(pc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "pyramid.helpTitle",
+		CommandKeys: []string{
+			"pyramid.helpDraw",
+			"pyramid.helpRemoveKing",
+			"pyramid.helpRemovePair",
+			"pyramid.helpRemoveWaste",
+			"pyramid.helpRemoveWasteKing",
+			"pyramid.helpGiveUp",
+			"pyramid.helpHint",
+		},
+		ExtraCommandLines: []string{"  l                        action log"},
+	}))
 }

--- a/internal/infrastructure/ui/RazzCui.go
+++ b/internal/infrastructure/ui/RazzCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -13,34 +12,30 @@ func NewRazzCui() *genericCuiGame {
 	cfg := domain.DefaultRazzConfig()
 	r := domain.NewRazz(domain.NewTrumpCards(0), domain.NewSevenCardStudPlayersForTable(cfg.TableSize), cfg)
 	sc := controller.NewSevenCardStudCuiController(usecase.NewSevenCardStudInteractor(r, new(presenter.SevenCardStudCuiPresenter)))
-	return newCuiGame(sc, []string{
-		i18n.T("razz.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("sevencardstud.helpFold"),
-		i18n.T("sevencardstud.helpCheck"),
-		i18n.T("sevencardstud.helpCall"),
-		i18n.T("sevencardstud.helpBet"),
-		i18n.T("sevencardstud.helpRaise"),
-		i18n.T("sevencardstud.helpAllIn"),
-		"  rb                   rebuy",
-		"  sr                   skip rebuy",
-		"  ad                   add-on",
-		"  sa                   skip add-on",
-		"",
-		i18n.T("settings"),
-		i18n.T("sevencardstud.helpBettingLimit"),
-		i18n.T("sevencardstud.helpTournament"),
-		"  ante <amount>        ante (>=1)",
-		"  bi <amount>          bring-in (>=1)",
-		"  sb <amount>          small bet (>=1)",
-		"  bb <amount>          big bet (>=1)",
-		"  lh <hands>           ante level-up hands (>=1)",
-		"  ts [2-7]             table size",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(sc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "razz.helpTitle",
+		CommandKeys: []string{
+			"sevencardstud.helpFold",
+			"sevencardstud.helpCheck",
+			"sevencardstud.helpCall",
+			"sevencardstud.helpBet",
+			"sevencardstud.helpRaise",
+			"sevencardstud.helpAllIn",
+		},
+		ExtraCommandLines: []string{
+			"  rb                   rebuy",
+			"  sr                   skip rebuy",
+			"  ad                   add-on",
+			"  sa                   skip add-on",
+		},
+		SettingKeys: []string{"sevencardstud.helpBettingLimit", "sevencardstud.helpTournament"},
+		ExtraSettingLines: []string{
+			"  ante <amount>        ante (>=1)",
+			"  bi <amount>          bring-in (>=1)",
+			"  sb <amount>          small bet (>=1)",
+			"  bb <amount>          big bet (>=1)",
+			"  lh <hands>           ante level-up hands (>=1)",
+			"  ts [2-7]             table size",
+		},
+	}))
 }

--- a/internal/infrastructure/ui/RedDogCui.go
+++ b/internal/infrastructure/ui/RedDogCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -14,18 +13,9 @@ func NewRedDogCui() *genericCuiGame {
 		domain.NewDefaultRedDog(),
 		new(presenter.RedDogCuiPresenter),
 	))
-	return newCuiGame(rc, []string{
-		i18n.T("reddog.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("reddog.helpBet"),
-		i18n.T("reddog.helpRaise"),
-		i18n.T("reddog.helpStay"),
-		"  log                  action log",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(rc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:          "reddog.helpTitle",
+		CommandKeys:       []string{"reddog.helpBet", "reddog.helpRaise", "reddog.helpStay"},
+		ExtraCommandLines: []string{"  log                  action log"},
+	}))
 }

--- a/internal/infrastructure/ui/ScorpionCui.go
+++ b/internal/infrastructure/ui/ScorpionCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -12,21 +11,16 @@ import (
 func NewScorpionCui() *genericCuiGame {
 	scorpion := domain.NewScorpion(domain.NewTrumpCards(0))
 	sc := controller.NewScorpionCuiController(usecase.NewScorpionInteractor(scorpion, new(presenter.ScorpionCuiPresenter)))
-	return newCuiGame(sc, []string{
-		i18n.T("scorpion.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("scorpion.helpMove"),
-		i18n.T("scorpion.helpMoveTT"),
-		i18n.T("scorpion.helpDeal"),
-		i18n.T("scorpion.helpGiveUp"),
-		i18n.T("scorpion.helpHint"),
-		i18n.T("scorpion.helpAutoComplete"),
-		"  l                        action log",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(sc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "scorpion.helpTitle",
+		CommandKeys: []string{
+			"scorpion.helpMove",
+			"scorpion.helpMoveTT",
+			"scorpion.helpDeal",
+			"scorpion.helpGiveUp",
+			"scorpion.helpHint",
+			"scorpion.helpAutoComplete",
+		},
+		ExtraCommandLines: []string{"  l                        action log"},
+	}))
 }

--- a/internal/infrastructure/ui/SevenCardStudCui.go
+++ b/internal/infrastructure/ui/SevenCardStudCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -13,34 +12,30 @@ func NewSevenCardStudCui() *genericCuiGame {
 	cfg := domain.DefaultSevenCardStudConfig()
 	scs := domain.NewSevenCardStud(domain.NewTrumpCards(0), domain.NewSevenCardStudPlayersForTable(cfg.TableSize), cfg)
 	sc := controller.NewSevenCardStudCuiController(usecase.NewSevenCardStudInteractor(scs, new(presenter.SevenCardStudCuiPresenter)))
-	return newCuiGame(sc, []string{
-		i18n.T("sevencardstud.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("sevencardstud.helpFold"),
-		i18n.T("sevencardstud.helpCheck"),
-		i18n.T("sevencardstud.helpCall"),
-		i18n.T("sevencardstud.helpBet"),
-		i18n.T("sevencardstud.helpRaise"),
-		i18n.T("sevencardstud.helpAllIn"),
-		"  rb                   rebuy",
-		"  sr                   skip rebuy",
-		"  ad                   add-on",
-		"  sa                   skip add-on",
-		"",
-		i18n.T("settings"),
-		i18n.T("sevencardstud.helpBettingLimit"),
-		i18n.T("sevencardstud.helpTournament"),
-		"  ante <amount>        ante (>=1)",
-		"  bi <amount>          bring-in (>=1)",
-		"  sb <amount>          small bet (>=1)",
-		"  bb <amount>          big bet (>=1)",
-		"  lh <hands>           ante level-up hands (>=1)",
-		"  ts [2-7]             table size",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(sc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "sevencardstud.helpTitle",
+		CommandKeys: []string{
+			"sevencardstud.helpFold",
+			"sevencardstud.helpCheck",
+			"sevencardstud.helpCall",
+			"sevencardstud.helpBet",
+			"sevencardstud.helpRaise",
+			"sevencardstud.helpAllIn",
+		},
+		ExtraCommandLines: []string{
+			"  rb                   rebuy",
+			"  sr                   skip rebuy",
+			"  ad                   add-on",
+			"  sa                   skip add-on",
+		},
+		SettingKeys: []string{"sevencardstud.helpBettingLimit", "sevencardstud.helpTournament"},
+		ExtraSettingLines: []string{
+			"  ante <amount>        ante (>=1)",
+			"  bi <amount>          bring-in (>=1)",
+			"  sb <amount>          small bet (>=1)",
+			"  bb <amount>          big bet (>=1)",
+			"  lh <hands>           ante level-up hands (>=1)",
+			"  ts [2-7]             table size",
+		},
+	}))
 }

--- a/internal/infrastructure/ui/ShortDeckCui.go
+++ b/internal/infrastructure/ui/ShortDeckCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -13,32 +12,28 @@ func NewShortDeckCui() *genericCuiGame {
 	cfg := domain.DefaultShortDeckConfig()
 	sd := domain.NewShortDeck(domain.NewTrumpCardsShortDeck(), domain.NewShortDeckPlayersForTable(cfg.TableSize), cfg)
 	sc := controller.NewShortDeckCuiController(usecase.NewShortDeckInteractor(sd, new(presenter.ShortDeckCuiPresenter)))
-	return newCuiGame(sc, []string{
-		i18n.T("shortdeck.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("shortdeck.helpFold"),
-		i18n.T("shortdeck.helpCheck"),
-		i18n.T("shortdeck.helpCall"),
-		i18n.T("shortdeck.helpBet"),
-		i18n.T("shortdeck.helpRaise"),
-		i18n.T("shortdeck.helpAllIn"),
-		"  rb                   rebuy",
-		"  sr                   skip rebuy",
-		"  ad                   add-on",
-		"  sa                   skip add-on",
-		"",
-		i18n.T("settings"),
-		i18n.T("shortdeck.helpBettingLimit"),
-		i18n.T("shortdeck.helpTournament"),
-		"  sb <amount>          small blind (>=1)",
-		"  bb <amount>          big blind (>=2)",
-		"  lh <hands>           blind level-up hands (>=1)",
-		"  ts [4|6|9]           table size",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(sc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "shortdeck.helpTitle",
+		CommandKeys: []string{
+			"shortdeck.helpFold",
+			"shortdeck.helpCheck",
+			"shortdeck.helpCall",
+			"shortdeck.helpBet",
+			"shortdeck.helpRaise",
+			"shortdeck.helpAllIn",
+		},
+		ExtraCommandLines: []string{
+			"  rb                   rebuy",
+			"  sr                   skip rebuy",
+			"  ad                   add-on",
+			"  sa                   skip add-on",
+		},
+		SettingKeys: []string{"shortdeck.helpBettingLimit", "shortdeck.helpTournament"},
+		ExtraSettingLines: []string{
+			"  sb <amount>          small blind (>=1)",
+			"  bb <amount>          big blind (>=2)",
+			"  lh <hands>           blind level-up hands (>=1)",
+			"  ts [4|6|9]           table size",
+		},
+	}))
 }

--- a/internal/infrastructure/ui/SpadesCui.go
+++ b/internal/infrastructure/ui/SpadesCui.go
@@ -4,38 +4,16 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
 // NewSpadesCui コンストラクタ
 func NewSpadesCui() *genericCuiGame {
-	config := domain.DefaultSpadesConfig()
-	players := []*domain.SpadesPlayer{
-		domain.NewSpadesPlayer(true),
-		domain.NewSpadesPlayer(false),
-		domain.NewSpadesPlayer(false),
-		domain.NewSpadesPlayer(false),
-	}
-	spades := domain.NewSpades(domain.NewTrumpCards(0), players, config)
-	sc := controller.NewSpadesCuiController(usecase.NewSpadesInteractor(spades, new(presenter.SpadesCuiPresenter)))
-	return newCuiGame(sc, []string{
-		i18n.T("spades.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("spades.helpBid"),
-		i18n.T("spades.helpPlay"),
-		i18n.T("spades.helpNext"),
-		i18n.T("spades.helpNextRound"),
-		"  l                    action log",
-		"",
-		i18n.T("settings"),
-		i18n.T("spades.helpSetDifficulty"),
-		i18n.T("spades.helpSetLimit"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	sc := controller.NewSpadesCuiController(usecase.NewSpadesInteractor(domain.NewDefaultSpades(), new(presenter.SpadesCuiPresenter)))
+	return newCuiGame(sc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:          "spades.helpTitle",
+		CommandKeys:       []string{"spades.helpBid", "spades.helpPlay", "spades.helpNext", "spades.helpNextRound"},
+		ExtraCommandLines: []string{"  l                    action log"},
+		SettingKeys:       []string{"spades.helpSetDifficulty", "spades.helpSetLimit"},
+	}))
 }

--- a/internal/infrastructure/ui/SpeedCui.go
+++ b/internal/infrastructure/ui/SpeedCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -19,20 +18,9 @@ func NewSpeedCui() *genericCuiGame {
 	sc := controller.NewSpeedCuiController(
 		usecase.NewSpeedInteractor(game, new(presenter.SpeedCuiPresenter)),
 	)
-	return newCuiGame(sc, []string{
-		i18n.T("speed.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("speed.helpPlay"),
-		i18n.T("speed.helpFlip"),
-		i18n.T("speed.helpHint"),
-		"",
-		i18n.T("settings"),
-		i18n.T("speed.helpSetDifficulty"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(sc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:    "speed.helpTitle",
+		CommandKeys: []string{"speed.helpPlay", "speed.helpFlip", "speed.helpHint"},
+		SettingKeys: []string{"speed.helpSetDifficulty"},
+	}))
 }

--- a/internal/infrastructure/ui/SpiderCui.go
+++ b/internal/infrastructure/ui/SpiderCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -12,20 +11,15 @@ import (
 func NewSpiderCui() *genericCuiGame {
 	spider := domain.NewSpider(domain.NewTrumpCardsWithSuits(domain.SpiderTotalCards, []int{domain.CardDesignSpade}))
 	sc := controller.NewSpiderCuiController(usecase.NewSpiderInteractor(spider, new(presenter.SpiderCuiPresenter)))
-	return newCuiGame(sc, []string{
-		i18n.T("spider.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("spider.helpDeal"),
-		i18n.T("spider.helpMove"),
-		i18n.T("spider.helpGiveUp"),
-		i18n.T("spider.helpHint"),
-		i18n.T("spider.helpAutoComplete"),
-		"  l                        action log",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(sc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "spider.helpTitle",
+		CommandKeys: []string{
+			"spider.helpDeal",
+			"spider.helpMove",
+			"spider.helpGiveUp",
+			"spider.helpHint",
+			"spider.helpAutoComplete",
+		},
+		ExtraCommandLines: []string{"  l                        action log"},
+	}))
 }

--- a/internal/infrastructure/ui/ThreeCardCui.go
+++ b/internal/infrastructure/ui/ThreeCardCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -14,18 +13,9 @@ func NewThreeCardCui() *genericCuiGame {
 		domain.NewDefaultThreeCard(),
 		new(presenter.ThreeCardCuiPresenter),
 	))
-	return newCuiGame(tc, []string{
-		i18n.T("threecard.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("threecard.helpBet"),
-		i18n.T("threecard.helpPlay"),
-		i18n.T("threecard.helpFold"),
-		"  log                  action log",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(tc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:          "threecard.helpTitle",
+		CommandKeys:       []string{"threecard.helpBet", "threecard.helpPlay", "threecard.helpFold"},
+		ExtraCommandLines: []string{"  log                  action log"},
+	}))
 }

--- a/internal/infrastructure/ui/TriPeaksCui.go
+++ b/internal/infrastructure/ui/TriPeaksCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -12,19 +11,14 @@ import (
 func NewTriPeaksCui() *genericCuiGame {
 	triPeaks := domain.NewTriPeaks(domain.NewTrumpCards(0))
 	tc := controller.NewTriPeaksCuiController(usecase.NewTriPeaksInteractor(triPeaks, new(presenter.TriPeaksCuiPresenter)))
-	return newCuiGame(tc, []string{
-		i18n.T("tripeaks.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("tripeaks.helpDraw"),
-		i18n.T("tripeaks.helpRemove"),
-		i18n.T("tripeaks.helpGiveUp"),
-		i18n.T("tripeaks.helpHint"),
-		"  l                        action log",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(tc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "tripeaks.helpTitle",
+		CommandKeys: []string{
+			"tripeaks.helpDraw",
+			"tripeaks.helpRemove",
+			"tripeaks.helpGiveUp",
+			"tripeaks.helpHint",
+		},
+		ExtraCommandLines: []string{"  l                        action log"},
+	}))
 }

--- a/internal/infrastructure/ui/TwoTenJackCui.go
+++ b/internal/infrastructure/ui/TwoTenJackCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -19,23 +18,15 @@ func NewTwoTenJackCui() *genericCuiGame {
 	}
 	ttj := domain.NewTwoTenJack(domain.NewTrumpCards(0), players, config)
 	tc := controller.NewTwoTenJackCuiController(usecase.NewTwoTenJackInteractor(ttj, new(presenter.TwoTenJackCuiPresenter)))
-	return newCuiGame(tc, []string{
-		i18n.T("twotenjack.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("twotenjack.helpDeclare"),
-		i18n.T("twotenjack.helpPlay"),
-		i18n.T("twotenjack.helpNext"),
-		i18n.T("twotenjack.helpNextRound"),
-		"  l                    action log",
-		"",
-		i18n.T("settings"),
-		i18n.T("twotenjack.helpSetDifficulty"),
-		i18n.T("twotenjack.helpSetLimit"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(tc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "twotenjack.helpTitle",
+		CommandKeys: []string{
+			"twotenjack.helpDeclare",
+			"twotenjack.helpPlay",
+			"twotenjack.helpNext",
+			"twotenjack.helpNextRound",
+		},
+		ExtraCommandLines: []string{"  l                    action log"},
+		SettingKeys:       []string{"twotenjack.helpSetDifficulty", "twotenjack.helpSetLimit"},
+	}))
 }

--- a/internal/infrastructure/ui/VideoPokerCui.go
+++ b/internal/infrastructure/ui/VideoPokerCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -14,17 +13,9 @@ func NewVideoPokerCui() *genericCuiGame {
 		domain.NewDefaultVideoPoker(),
 		new(presenter.VideoPokerCuiPresenter),
 	))
-	return newCuiGame(vc, []string{
-		i18n.T("videopoker.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("videopoker.helpBet"),
-		i18n.T("videopoker.helpHold"),
-		"  log                  action log",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(vc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:          "videopoker.helpTitle",
+		CommandKeys:       []string{"videopoker.helpBet", "videopoker.helpHold"},
+		ExtraCommandLines: []string{"  log                  action log"},
+	}))
 }

--- a/internal/infrastructure/ui/WarCui.go
+++ b/internal/infrastructure/ui/WarCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -19,18 +18,9 @@ func NewWarCui() *genericCuiGame {
 	wc := controller.NewWarCuiController(
 		usecase.NewWarInteractor(game, new(presenter.WarCuiPresenter)),
 	)
-	return newCuiGame(wc, []string{
-		i18n.T("war.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("war.helpStep"),
-		"",
-		i18n.T("settings"),
-		i18n.T("war.helpSetMax"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(wc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:    "war.helpTitle",
+		CommandKeys: []string{"war.helpStep"},
+		SettingKeys: []string{"war.helpSetMax"},
+	}))
 }

--- a/internal/infrastructure/ui/WhistCui.go
+++ b/internal/infrastructure/ui/WhistCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -19,22 +18,10 @@ func NewWhistCui() *genericCuiGame {
 	}
 	whist := domain.NewWhist(domain.NewTrumpCards(0), players, config)
 	wc := controller.NewWhistCuiController(usecase.NewWhistInteractor(whist, new(presenter.WhistCuiPresenter)))
-	return newCuiGame(wc, []string{
-		i18n.T("whist.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("whist.helpPlay"),
-		i18n.T("whist.helpNext"),
-		i18n.T("whist.helpNextRound"),
-		"  l                    action log",
-		"",
-		i18n.T("settings"),
-		i18n.T("whist.helpSetDifficulty"),
-		i18n.T("whist.helpSetLimit"),
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(wc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey:          "whist.helpTitle",
+		CommandKeys:       []string{"whist.helpPlay", "whist.helpNext", "whist.helpNextRound"},
+		ExtraCommandLines: []string{"  l                    action log"},
+		SettingKeys:       []string{"whist.helpSetDifficulty", "whist.helpSetLimit"},
+	}))
 }

--- a/internal/infrastructure/ui/YukonCui.go
+++ b/internal/infrastructure/ui/YukonCui.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -12,21 +11,16 @@ import (
 func NewYukonCui() *genericCuiGame {
 	yukon := domain.NewYukon(domain.NewTrumpCards(0))
 	yc := controller.NewYukonCuiController(usecase.NewYukonInteractor(yukon, new(presenter.YukonCuiPresenter)))
-	return newCuiGame(yc, []string{
-		i18n.T("yukon.helpTitle"),
-		"",
-		i18n.T("gameCommands"),
-		i18n.T("yukon.helpMove"),
-		i18n.T("yukon.helpMoveTF"),
-		i18n.T("yukon.helpMoveTT"),
-		i18n.T("yukon.helpGiveUp"),
-		i18n.T("yukon.helpHint"),
-		i18n.T("yukon.helpAutoComplete"),
-		"  l                        action log",
-		"",
-		i18n.T("session"),
-		i18n.T("resetEntry"),
-		i18n.T("quitEntry"),
-		i18n.T("helpEntry"),
-	})
+	return newCuiGame(yc, BuildCuiHelp(CuiHelpSpec{
+		TitleKey: "yukon.helpTitle",
+		CommandKeys: []string{
+			"yukon.helpMove",
+			"yukon.helpMoveTF",
+			"yukon.helpMoveTT",
+			"yukon.helpGiveUp",
+			"yukon.helpHint",
+			"yukon.helpAutoComplete",
+		},
+		ExtraCommandLines: []string{"  l                        action log"},
+	}))
 }

--- a/internal/infrastructure/ui/help_text.go
+++ b/internal/infrastructure/ui/help_text.go
@@ -1,0 +1,52 @@
+package ui
+
+import "github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
+
+// CuiHelpSpec describes the variable parts of a game's help text.
+// The shared scaffold (gameCommands header, settings header, session header,
+// reset/quit/help entries) is supplied by BuildCuiHelp.
+type CuiHelpSpec struct {
+	// TitleKey is the i18n key for the help title line (e.g. "hearts.helpTitle").
+	TitleKey string
+	// CommandKeys are i18n keys for game-specific command lines, in display order.
+	CommandKeys []string
+	// ExtraCommandLines are literal lines appended after CommandKeys but before
+	// the settings section. Used for entries not yet in i18n (e.g. action log,
+	// clear-history) whose spacing is per-game column-aligned.
+	ExtraCommandLines []string
+	// SettingKeys are i18n keys for game-specific setting lines. If both this
+	// and ExtraSettingLines are empty the settings section (header + entries)
+	// is omitted entirely.
+	SettingKeys []string
+	// ExtraSettingLines are literal lines appended after SettingKeys in the
+	// settings section. Used for settings not yet in i18n.
+	ExtraSettingLines []string
+}
+
+// BuildCuiHelp assembles standard CUI help text from spec. Order:
+// title, blank, gameCommands header, command keys, extra command lines,
+// blank + settings header + setting keys (only when non-empty),
+// blank + session header + reset + quit + help.
+func BuildCuiHelp(spec CuiHelpSpec) []string {
+	lines := make([]string, 0, 8+len(spec.CommandKeys)+len(spec.ExtraCommandLines)+len(spec.SettingKeys)+len(spec.ExtraSettingLines))
+	lines = append(lines, i18n.T(spec.TitleKey), "", i18n.T("gameCommands"))
+	for _, k := range spec.CommandKeys {
+		lines = append(lines, i18n.T(k))
+	}
+	lines = append(lines, spec.ExtraCommandLines...)
+	if len(spec.SettingKeys) > 0 || len(spec.ExtraSettingLines) > 0 {
+		lines = append(lines, "", i18n.T("settings"))
+		for _, k := range spec.SettingKeys {
+			lines = append(lines, i18n.T(k))
+		}
+		lines = append(lines, spec.ExtraSettingLines...)
+	}
+	lines = append(lines,
+		"",
+		i18n.T("session"),
+		i18n.T("resetEntry"),
+		i18n.T("quitEntry"),
+		i18n.T("helpEntry"),
+	)
+	return lines
+}

--- a/internal/infrastructure/ui/help_text.go
+++ b/internal/infrastructure/ui/help_text.go
@@ -28,7 +28,11 @@ type CuiHelpSpec struct {
 // blank + settings header + setting keys (only when non-empty),
 // blank + session header + reset + quit + help.
 func BuildCuiHelp(spec CuiHelpSpec) []string {
-	lines := make([]string, 0, 8+len(spec.CommandKeys)+len(spec.ExtraCommandLines)+len(spec.SettingKeys)+len(spec.ExtraSettingLines))
+	// 10 fixed lines: title + blank + gameCommands header + blank + settings header +
+	// blank + session header + reset + quit + help. The two "blank + settings header" lines
+	// are included unconditionally in capacity; the slight over-allocation when the settings
+	// section is skipped is harmless.
+	lines := make([]string, 0, 10+len(spec.CommandKeys)+len(spec.ExtraCommandLines)+len(spec.SettingKeys)+len(spec.ExtraSettingLines))
 	lines = append(lines, i18n.T(spec.TitleKey), "", i18n.T("gameCommands"))
 	for _, k := range spec.CommandKeys {
 		lines = append(lines, i18n.T(k))

--- a/internal/infrastructure/ui/help_text_test.go
+++ b/internal/infrastructure/ui/help_text_test.go
@@ -1,0 +1,147 @@
+//go:build test
+
+package ui
+
+import (
+	"testing"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
+)
+
+func TestBuildCuiHelp_includesScaffolding(t *testing.T) {
+	got := BuildCuiHelp(CuiHelpSpec{
+		TitleKey:    "hearts.helpTitle",
+		CommandKeys: []string{"hearts.helpPass"},
+		SettingKeys: []string{"hearts.helpSetLimit"},
+	})
+
+	want := []string{
+		i18n.T("hearts.helpTitle"),
+		"",
+		i18n.T("gameCommands"),
+		i18n.T("hearts.helpPass"),
+		"",
+		i18n.T("settings"),
+		i18n.T("hearts.helpSetLimit"),
+		"",
+		i18n.T("session"),
+		i18n.T("resetEntry"),
+		i18n.T("quitEntry"),
+		i18n.T("helpEntry"),
+	}
+	assertLines(t, got, want)
+}
+
+func TestBuildCuiHelp_omitsSettingsWhenEmpty(t *testing.T) {
+	got := BuildCuiHelp(CuiHelpSpec{
+		TitleKey:    "baccarat.helpTitle",
+		CommandKeys: []string{"baccarat.helpBet"},
+		ExtraCommandLines: []string{
+			"  log                  action log",
+		},
+	})
+
+	want := []string{
+		i18n.T("baccarat.helpTitle"),
+		"",
+		i18n.T("gameCommands"),
+		i18n.T("baccarat.helpBet"),
+		"  log                  action log",
+		"",
+		i18n.T("session"),
+		i18n.T("resetEntry"),
+		i18n.T("quitEntry"),
+		i18n.T("helpEntry"),
+	}
+	assertLines(t, got, want)
+}
+
+func TestBuildCuiHelp_extraLinesAppearBeforeSettings(t *testing.T) {
+	got := BuildCuiHelp(CuiHelpSpec{
+		TitleKey:          "spades.helpTitle",
+		CommandKeys:       []string{"spades.helpBid", "spades.helpPlay"},
+		ExtraCommandLines: []string{"  l                    action log"},
+		SettingKeys:       []string{"spades.helpSetDifficulty"},
+	})
+
+	// Find "settings" header in output and verify action log appears before it.
+	settingsIdx := -1
+	actionLogIdx := -1
+	for i, line := range got {
+		if line == i18n.T("settings") {
+			settingsIdx = i
+		}
+		if line == "  l                    action log" {
+			actionLogIdx = i
+		}
+	}
+	if settingsIdx == -1 || actionLogIdx == -1 {
+		t.Fatalf("missing markers: settingsIdx=%d actionLogIdx=%d (got=%v)", settingsIdx, actionLogIdx, got)
+	}
+	if actionLogIdx >= settingsIdx {
+		t.Errorf("action log (%d) should precede settings header (%d)", actionLogIdx, settingsIdx)
+	}
+}
+
+func TestBuildCuiHelp_settingsIncludesExtraLines(t *testing.T) {
+	got := BuildCuiHelp(CuiHelpSpec{
+		TitleKey:          "holdem.helpTitle",
+		CommandKeys:       []string{"holdem.helpFold"},
+		SettingKeys:       []string{"holdem.helpBettingLimit"},
+		ExtraSettingLines: []string{"  sb <amount>          small blind (>=1)"},
+	})
+
+	want := []string{
+		i18n.T("holdem.helpTitle"),
+		"",
+		i18n.T("gameCommands"),
+		i18n.T("holdem.helpFold"),
+		"",
+		i18n.T("settings"),
+		i18n.T("holdem.helpBettingLimit"),
+		"  sb <amount>          small blind (>=1)",
+		"",
+		i18n.T("session"),
+		i18n.T("resetEntry"),
+		i18n.T("quitEntry"),
+		i18n.T("helpEntry"),
+	}
+	assertLines(t, got, want)
+}
+
+func TestBuildCuiHelp_settingsOnlyExtraLines(t *testing.T) {
+	got := BuildCuiHelp(CuiHelpSpec{
+		TitleKey:          "test.helpTitle",
+		CommandKeys:       []string{"test.helpCmd"},
+		ExtraSettingLines: []string{"  x <n>    custom setting"},
+	})
+
+	// Expect "", settings header, extra setting line, "", session, ...
+	want := []string{
+		i18n.T("test.helpTitle"),
+		"",
+		i18n.T("gameCommands"),
+		i18n.T("test.helpCmd"),
+		"",
+		i18n.T("settings"),
+		"  x <n>    custom setting",
+		"",
+		i18n.T("session"),
+		i18n.T("resetEntry"),
+		i18n.T("quitEntry"),
+		i18n.T("helpEntry"),
+	}
+	assertLines(t, got, want)
+}
+
+func assertLines(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("len mismatch: got %d want %d\ngot=%v\nwant=%v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("line %d: got %q want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/infrastructure/web/TrumpCardsWeb.go
+++ b/internal/infrastructure/web/TrumpCardsWeb.go
@@ -126,26 +126,10 @@ func (web *TrumpCardsWeb) registerAll() {
 		return usecase.NewShortDeckInteractor(sd, new(presenter.ShortDeckWebPresenter))
 	}))
 	web.register("hearts", controller.NewHeartsWebController(func() usecase.HeartsInteractorIF {
-		config := domain.DefaultHeartsConfig()
-		players := []*domain.HeartsPlayer{
-			domain.NewHeartsPlayer(true),
-			domain.NewHeartsPlayer(false),
-			domain.NewHeartsPlayer(false),
-			domain.NewHeartsPlayer(false),
-		}
-		hearts := domain.NewHearts(domain.NewTrumpCards(0), players, config)
-		return usecase.NewHeartsInteractor(hearts, new(presenter.HeartsWebPresenter))
+		return usecase.NewHeartsInteractor(domain.NewDefaultHearts(), new(presenter.HeartsWebPresenter))
 	}))
 	web.register("memory", controller.NewMemoryWebController(func() usecase.MemoryInteractorIF {
-		config := domain.DefaultMemoryConfig()
-		players := []*domain.MemoryPlayer{
-			domain.NewMemoryPlayer(true),
-			domain.NewMemoryPlayer(false),
-			domain.NewMemoryPlayer(false),
-			domain.NewMemoryPlayer(false),
-		}
-		memory := domain.NewMemory(domain.NewTrumpCards(0), players, config)
-		return usecase.NewMemoryInteractor(memory, new(presenter.MemoryWebPresenter))
+		return usecase.NewMemoryInteractor(domain.NewDefaultMemory(), new(presenter.MemoryWebPresenter))
 	}))
 	web.register("klondike", controller.NewKlondikeWebController(func() usecase.KlondikeInteractorIF {
 		klondike := domain.NewKlondike(domain.NewTrumpCards(0))
@@ -160,26 +144,10 @@ func (web *TrumpCardsWeb) registerAll() {
 		return usecase.NewBaccaratInteractor(baccarat, new(presenter.BaccaratWebPresenter))
 	}))
 	web.register("spades", controller.NewSpadesWebController(func() usecase.SpadesInteractorIF {
-		config := domain.DefaultSpadesConfig()
-		players := []*domain.SpadesPlayer{
-			domain.NewSpadesPlayer(true),
-			domain.NewSpadesPlayer(false),
-			domain.NewSpadesPlayer(false),
-			domain.NewSpadesPlayer(false),
-		}
-		spades := domain.NewSpades(domain.NewTrumpCards(0), players, config)
-		return usecase.NewSpadesInteractor(spades, new(presenter.SpadesWebPresenter))
+		return usecase.NewSpadesInteractor(domain.NewDefaultSpades(), new(presenter.SpadesWebPresenter))
 	}))
 	web.register("crazyeights", controller.NewCrazyEightsWebController(func() usecase.CrazyEightsInteractorIF {
-		config := domain.DefaultCrazyEightsConfig()
-		players := []*domain.CrazyEightsPlayer{
-			domain.NewCrazyEightsPlayer(true),
-			domain.NewCrazyEightsPlayer(false),
-			domain.NewCrazyEightsPlayer(false),
-			domain.NewCrazyEightsPlayer(false),
-		}
-		ce := domain.NewCrazyEights(domain.NewTrumpCards(0), players, config)
-		return usecase.NewCrazyEightsInteractor(ce, new(presenter.CrazyEightsWebPresenter))
+		return usecase.NewCrazyEightsInteractor(domain.NewDefaultCrazyEights(), new(presenter.CrazyEightsWebPresenter))
 	}))
 	web.register("ginrummy", controller.NewGinRummyWebController(func() usecase.GinRummyInteractorIF {
 		config := domain.DefaultGinRummyConfig()
@@ -263,15 +231,7 @@ func (web *TrumpCardsWeb) registerAll() {
 		)
 	}))
 	web.register("ohhell", controller.NewOhHellWebController(func() usecase.OhHellInteractorIF {
-		config := domain.DefaultOhHellConfig()
-		players := []*domain.OhHellPlayer{
-			domain.NewOhHellPlayer(true),
-			domain.NewOhHellPlayer(false),
-			domain.NewOhHellPlayer(false),
-			domain.NewOhHellPlayer(false),
-		}
-		ohHell := domain.NewOhHell(domain.NewTrumpCards(0), players, config)
-		return usecase.NewOhHellInteractor(ohHell, new(presenter.OhHellWebPresenter))
+		return usecase.NewOhHellInteractor(domain.NewDefaultOhHell(), new(presenter.OhHellWebPresenter))
 	}))
 	web.register("bridge", controller.NewBridgeWebController(func() usecase.BridgeInteractorIF {
 		config := domain.DefaultBridgeConfig()


### PR DESCRIPTION
## Summary

- **Closes #1397**: Introduces `BuildCuiHelp` + `CuiHelpSpec` so CUI factories declare only game-specific i18n keys; the shared scaffolding (`gameCommands`, `settings`, `session`, reset/quit/help entries) is centralized. 50 of 55 CUI factories migrated.
- **Closes #1398**: Adds `make coverage` and `make clean-cov`, ignores `/build/` in git, and removes 16 stale `*.out` artifacts from the repo root.
- **Advances #1396 (Phase 1a)**: Adds `NewDefault<Game>()` factories for Hearts, Spades, Memory, CrazyEights, and OhHell; updates all four construction sites (CUI / Web registry / classic worker / solo worker) for each. Remaining ~42 games are Phase 1b follow-up that should mirror this pattern.

### Stats
- 62 files changed, +816 / -1114 (net -298 lines)
- New helper `internal/infrastructure/ui/help_text.go` with 5 unit tests.

### Skipped from #1397 on purpose
- `BridgeCui.go`, `CanastaCui.go`: use raw literals (no i18n keys). Follow-up can migrate to i18n first.
- `DurakCui.go`: ends with `commonCommands` rather than the standard session footer.
- `PokerSquaresCui.go`: title is a hardcoded Japanese string, not an i18n key.
- `SevensCui.go`: uses a custom `r` reset line instead of `resetEntry`.

### Follow-up issue scope (not in this PR)
- #1396 Phase 1b: add `NewDefault` for the remaining ~42 games and refactor their CUI / Web / Worker callers. The factories added here serve as the template.
- #1396 Phase 2 (separate follow-up): unify Web + Worker into a single registry table (issue already scopes this as a later phase).

## Test plan

- [x] `go build ./...` (clean)
- [x] `go test -tags test ./...` (all ok; domain 72s, ui 0.08s, usecase 0.48s)
- [x] Narrow `golangci-lint run ./internal/infrastructure/ui/... ./internal/domain/...` reports `0 issues`
- [x] `make clean-cov` removes all accumulated `*.out` files
- [x] `make coverage` generates `build/coverage/coverage.{out,html}`
- [ ] Frontend tests re-run post-merge (1 flaky failure observed pre-merge in an unrelated test; no frontend files touched in this PR)