### PR TITLE
refactor(1396): NewDefault factories for remaining 40 games (Phase 1b)

### DIFF
--- a/cmd/workers/casino/main.go
+++ b/cmd/workers/casino/main.go
@@ -51,15 +51,7 @@ func main() {
 	// Poker
 	must(worker.RegisterKV(mux, "/poker/exec", "poker:",
 		func() usecase.PokerInteractorIF {
-			config := domain.DefaultPokerConfig()
-			players := []*domain.PokerPlayer{
-				domain.NewPokerPlayer(true, domain.PokerStyleBalanced),
-				domain.NewPokerPlayer(false, domain.PokerStyleConservative),
-				domain.NewPokerPlayer(false, domain.PokerStyleAggressive),
-				domain.NewPokerPlayer(false, domain.PokerStyleBluffer),
-			}
-			poker := domain.NewPoker(domain.NewTrumpCards(config.JokerCount), players, config)
-			return usecase.NewPokerInteractor(poker, new(presenter.PokerWebPresenter))
+			return usecase.NewPokerInteractor(domain.NewDefaultPoker(), new(presenter.PokerWebPresenter))
 		},
 		func(data []byte) (usecase.PokerInteractorIF, error) {
 			return usecase.RestorePokerInteractor(data, new(presenter.PokerWebPresenter))
@@ -70,9 +62,7 @@ func main() {
 	// Texas Hold'em
 	must(worker.RegisterKV(mux, "/holdem/exec", "holdem:",
 		func() usecase.HoldemInteractorIF {
-			cfg := domain.DefaultHoldemConfig()
-			holdem := domain.NewHoldem(domain.NewTrumpCards(0), domain.NewPlayersForTable(cfg.TableSize), cfg)
-			return usecase.NewHoldemInteractor(holdem, new(presenter.HoldemWebPresenter))
+			return usecase.NewHoldemInteractor(domain.NewDefaultHoldem(), new(presenter.HoldemWebPresenter))
 		},
 		func(data []byte) (usecase.HoldemInteractorIF, error) {
 			return usecase.RestoreHoldemInteractor(data, new(presenter.HoldemWebPresenter))
@@ -83,9 +73,7 @@ func main() {
 	// Omaha
 	must(worker.RegisterKV(mux, "/omaha/exec", "omaha:",
 		func() usecase.OmahaInteractorIF {
-			cfg := domain.DefaultOmahaConfig()
-			omaha := domain.NewOmaha(domain.NewTrumpCards(0), domain.NewOmahaPlayersForTable(cfg.TableSize), cfg)
-			return usecase.NewOmahaInteractor(omaha, new(presenter.OmahaWebPresenter))
+			return usecase.NewOmahaInteractor(domain.NewDefaultOmaha(), new(presenter.OmahaWebPresenter))
 		},
 		func(data []byte) (usecase.OmahaInteractorIF, error) {
 			return usecase.RestoreOmahaInteractor(data, new(presenter.OmahaWebPresenter))
@@ -96,9 +84,7 @@ func main() {
 	// Short Deck
 	must(worker.RegisterKV(mux, "/shortdeck/exec", "shortdeck:",
 		func() usecase.ShortDeckInteractorIF {
-			cfg := domain.DefaultShortDeckConfig()
-			sd := domain.NewShortDeck(domain.NewTrumpCardsShortDeck(), domain.NewShortDeckPlayersForTable(cfg.TableSize), cfg)
-			return usecase.NewShortDeckInteractor(sd, new(presenter.ShortDeckWebPresenter))
+			return usecase.NewShortDeckInteractor(domain.NewDefaultShortDeck(), new(presenter.ShortDeckWebPresenter))
 		},
 		func(data []byte) (usecase.ShortDeckInteractorIF, error) {
 			return usecase.RestoreShortDeckInteractor(data, new(presenter.ShortDeckWebPresenter))
@@ -109,9 +95,7 @@ func main() {
 	// Indian Poker
 	must(worker.RegisterKV(mux, "/indianpoker/exec", "indianpoker:",
 		func() usecase.IndianPokerInteractorIF {
-			cfg := domain.DefaultIndianPokerConfig()
-			ip := domain.NewIndianPoker(domain.NewTrumpCards(0), domain.NewIndianPokerPlayers(), cfg)
-			return usecase.NewIndianPokerInteractor(ip, new(presenter.IndianPokerWebPresenter))
+			return usecase.NewIndianPokerInteractor(domain.NewDefaultIndianPoker(), new(presenter.IndianPokerWebPresenter))
 		},
 		func(data []byte) (usecase.IndianPokerInteractorIF, error) {
 			return usecase.RestoreIndianPokerInteractor(data, new(presenter.IndianPokerWebPresenter))
@@ -178,9 +162,7 @@ func main() {
 	// Pineapple Poker
 	must(worker.RegisterKV(mux, "/pineapple/exec", "pineapple:",
 		func() usecase.PineappleInteractorIF {
-			cfg := domain.DefaultPineappleConfig()
-			pineapple := domain.NewPineapple(domain.NewTrumpCards(0), domain.NewPineapplePlayersForTable(cfg.TableSize), cfg)
-			return usecase.NewPineappleInteractor(pineapple, new(presenter.PineappleWebPresenter))
+			return usecase.NewPineappleInteractor(domain.NewDefaultPineapple(), new(presenter.PineappleWebPresenter))
 		},
 		func(data []byte) (usecase.PineappleInteractorIF, error) {
 			return usecase.RestorePineappleInteractor(data, new(presenter.PineappleWebPresenter))
@@ -191,9 +173,7 @@ func main() {
 	// Seven Card Stud
 	must(worker.RegisterKV(mux, "/sevencardstud/exec", "sevencardstud:",
 		func() usecase.SevenCardStudInteractorIF {
-			cfg := domain.DefaultSevenCardStudConfig()
-			scs := domain.NewSevenCardStud(domain.NewTrumpCards(0), domain.NewSevenCardStudPlayersForTable(cfg.TableSize), cfg)
-			return usecase.NewSevenCardStudInteractor(scs, new(presenter.SevenCardStudWebPresenter))
+			return usecase.NewSevenCardStudInteractor(domain.NewDefaultSevenCardStud(), new(presenter.SevenCardStudWebPresenter))
 		},
 		func(data []byte) (usecase.SevenCardStudInteractorIF, error) {
 			return usecase.RestoreSevenCardStudInteractor(data, new(presenter.SevenCardStudWebPresenter))
@@ -204,9 +184,7 @@ func main() {
 	// Razz
 	must(worker.RegisterKV(mux, "/razz/exec", "razz:",
 		func() usecase.SevenCardStudInteractorIF {
-			cfg := domain.DefaultRazzConfig()
-			r := domain.NewRazz(domain.NewTrumpCards(0), domain.NewSevenCardStudPlayersForTable(cfg.TableSize), cfg)
-			return usecase.NewSevenCardStudInteractor(r, new(presenter.SevenCardStudWebPresenter))
+			return usecase.NewSevenCardStudInteractor(domain.NewDefaultRazz(), new(presenter.SevenCardStudWebPresenter))
 		},
 		func(data []byte) (usecase.SevenCardStudInteractorIF, error) {
 			return usecase.RestoreSevenCardStudInteractor(data, new(presenter.SevenCardStudWebPresenter))

--- a/cmd/workers/classic/main.go
+++ b/cmd/workers/classic/main.go
@@ -45,15 +45,7 @@ func main() {
 	// Euchre
 	must(worker.RegisterKV(mux, "/euchre/exec", "euchre:",
 		func() usecase.EuchreInteractorIF {
-			config := domain.DefaultEuchreConfig()
-			players := []*domain.EuchrePlayer{
-				domain.NewEuchrePlayer(true, 0),
-				domain.NewEuchrePlayer(false, 1),
-				domain.NewEuchrePlayer(false, 0),
-				domain.NewEuchrePlayer(false, 1),
-			}
-			euchre := domain.NewEuchre(domain.NewTrumpCardsEuchre(), players, config)
-			return usecase.NewEuchreInteractor(euchre, new(presenter.EuchreWebPresenter))
+			return usecase.NewEuchreInteractor(domain.NewDefaultEuchre(), new(presenter.EuchreWebPresenter))
 		},
 		func(data []byte) (usecase.EuchreInteractorIF, error) {
 			return usecase.RestoreEuchreInteractor(data, new(presenter.EuchreWebPresenter))
@@ -64,15 +56,7 @@ func main() {
 	// Napoleon
 	must(worker.RegisterKV(mux, "/napoleon/exec", "napoleon:",
 		func() usecase.NapoleonInteractorIF {
-			config := domain.DefaultNapoleonConfig()
-			players := []*domain.NapoleonPlayer{
-				domain.NewNapoleonPlayer(true),
-				domain.NewNapoleonPlayer(false),
-				domain.NewNapoleonPlayer(false),
-				domain.NewNapoleonPlayer(false),
-			}
-			napoleon := domain.NewNapoleon(domain.NewTrumpCards(1), players, config)
-			return usecase.NewNapoleonInteractor(napoleon, new(presenter.NapoleonWebPresenter))
+			return usecase.NewNapoleonInteractor(domain.NewDefaultNapoleon(), new(presenter.NapoleonWebPresenter))
 		},
 		func(data []byte) (usecase.NapoleonInteractorIF, error) {
 			return usecase.RestoreNapoleonInteractor(data, new(presenter.NapoleonWebPresenter))
@@ -83,14 +67,7 @@ func main() {
 	// Old Maid
 	must(worker.RegisterKV(mux, "/oldmaid/exec", "oldmaid:",
 		func() usecase.OldMaidInteractorIF {
-			players := []*domain.OldMaidPlayer{
-				domain.NewOldMaidPlayer(true),
-				domain.NewOldMaidPlayer(false),
-				domain.NewOldMaidPlayer(false),
-				domain.NewOldMaidPlayer(false),
-			}
-			oldMaid := domain.NewOldMaid(domain.NewTrumpCards(1), players)
-			return usecase.NewOldMaidInteractor(oldMaid, new(presenter.OldMaidWebPresenter))
+			return usecase.NewOldMaidInteractor(domain.NewDefaultOldMaid(), new(presenter.OldMaidWebPresenter))
 		},
 		func(data []byte) (usecase.OldMaidInteractorIF, error) {
 			return usecase.RestoreOldMaidInteractor(data, new(presenter.OldMaidWebPresenter))
@@ -101,14 +78,7 @@ func main() {
 	// Doubt
 	must(worker.RegisterKV(mux, "/doubt/exec", "doubt:",
 		func() usecase.DoubtInteractorIF {
-			players := []*domain.DoubtPlayer{
-				domain.NewDoubtPlayer(true),
-				domain.NewDoubtPlayer(false),
-				domain.NewDoubtPlayer(false),
-				domain.NewDoubtPlayer(false),
-			}
-			doubt := domain.NewDoubt(domain.NewTrumpCards(0), players)
-			return usecase.NewDoubtInteractor(doubt, new(presenter.DoubtWebPresenter))
+			return usecase.NewDoubtInteractor(domain.NewDefaultDoubt(), new(presenter.DoubtWebPresenter))
 		},
 		func(data []byte) (usecase.DoubtInteractorIF, error) {
 			return usecase.RestoreDoubtInteractor(data, new(presenter.DoubtWebPresenter))
@@ -119,15 +89,7 @@ func main() {
 	// Daifugo
 	must(worker.RegisterKV(mux, "/daifugo/exec", "daifugo:",
 		func() usecase.DaifugoInteractorIF {
-			config := domain.DefaultDaifugoConfig()
-			players := []*domain.DaifugoPlayer{
-				domain.NewDaifugoPlayer(true),
-				domain.NewDaifugoPlayer(false),
-				domain.NewDaifugoPlayer(false),
-				domain.NewDaifugoPlayer(false),
-			}
-			daifugo := domain.NewDaifugo(domain.NewTrumpCards(config.JokerCount), players, config)
-			return usecase.NewDaifugoInteractor(daifugo, new(presenter.DaifugoWebPresenter))
+			return usecase.NewDaifugoInteractor(domain.NewDefaultDaifugo(), new(presenter.DaifugoWebPresenter))
 		},
 		func(data []byte) (usecase.DaifugoInteractorIF, error) {
 			return usecase.RestoreDaifugoInteractor(data, new(presenter.DaifugoWebPresenter))
@@ -138,15 +100,7 @@ func main() {
 	// Sevens
 	must(worker.RegisterKV(mux, "/sevens/exec", "sevens:",
 		func() usecase.SevensInteractorIF {
-			config := domain.DefaultSevensConfig()
-			players := []*domain.SevensPlayer{
-				domain.NewSevensPlayer(true),
-				domain.NewSevensPlayer(false),
-				domain.NewSevensPlayer(false),
-				domain.NewSevensPlayer(false),
-			}
-			sevens := domain.NewSevens(domain.NewTrumpCards(config.JokerCount), players, config)
-			return usecase.NewSevensInteractor(sevens, new(presenter.SevensWebPresenter))
+			return usecase.NewSevensInteractor(domain.NewDefaultSevens(), new(presenter.SevensWebPresenter))
 		},
 		func(data []byte) (usecase.SevensInteractorIF, error) {
 			return usecase.RestoreSevensInteractor(data, new(presenter.SevensWebPresenter))
@@ -179,15 +133,7 @@ func main() {
 	// Contract Bridge
 	must(worker.RegisterKV(mux, "/bridge/exec", "bridge:",
 		func() usecase.BridgeInteractorIF {
-			config := domain.DefaultBridgeConfig()
-			players := []*domain.BridgePlayer{
-				domain.NewBridgePlayer(true, 0),
-				domain.NewBridgePlayer(false, 1),
-				domain.NewBridgePlayer(false, 0),
-				domain.NewBridgePlayer(false, 1),
-			}
-			bridge := domain.NewBridge(domain.NewTrumpCards(0), players, config)
-			return usecase.NewBridgeInteractor(bridge, new(presenter.BridgeWebPresenter))
+			return usecase.NewBridgeInteractor(domain.NewDefaultBridge(), new(presenter.BridgeWebPresenter))
 		},
 		func(data []byte) (usecase.BridgeInteractorIF, error) {
 			return usecase.RestoreBridgeInteractor(data, new(presenter.BridgeWebPresenter))
@@ -198,13 +144,7 @@ func main() {
 	// Speed
 	must(worker.RegisterKV(mux, "/speed/exec", "speed:",
 		func() usecase.SpeedInteractorIF {
-			config := domain.DefaultSpeedConfig()
-			players := []*domain.SpeedPlayer{
-				domain.NewSpeedPlayer(true),
-				domain.NewSpeedPlayer(false),
-			}
-			speed := domain.NewSpeed(domain.NewTrumpCards(0), players, config)
-			return usecase.NewSpeedInteractor(speed, new(presenter.SpeedWebPresenter))
+			return usecase.NewSpeedInteractor(domain.NewDefaultSpeed(), new(presenter.SpeedWebPresenter))
 		},
 		func(data []byte) (usecase.SpeedInteractorIF, error) {
 			return usecase.RestoreSpeedInteractor(data, new(presenter.SpeedWebPresenter))
@@ -215,14 +155,7 @@ func main() {
 	// Go Fish
 	must(worker.RegisterKV(mux, "/gofish/exec", "gofish:",
 		func() usecase.GoFishInteractorIF {
-			players := []*domain.GoFishPlayer{
-				domain.NewGoFishPlayer(true),
-				domain.NewGoFishPlayer(false),
-				domain.NewGoFishPlayer(false),
-				domain.NewGoFishPlayer(false),
-			}
-			goFish := domain.NewGoFish(domain.NewTrumpCards(0), players)
-			return usecase.NewGoFishInteractor(goFish, new(presenter.GoFishWebPresenter))
+			return usecase.NewGoFishInteractor(domain.NewDefaultGoFish(), new(presenter.GoFishWebPresenter))
 		},
 		func(data []byte) (usecase.GoFishInteractorIF, error) {
 			return usecase.RestoreGoFishInteractor(data, new(presenter.GoFishWebPresenter))
@@ -233,15 +166,7 @@ func main() {
 	// Pinochle
 	must(worker.RegisterKV(mux, "/pinochle/exec", "pinochle:",
 		func() usecase.PinochleInteractorIF {
-			config := domain.DefaultPinochleConfig()
-			players := []*domain.PinochlePlayer{
-				domain.NewPinochlePlayer(true, 0),
-				domain.NewPinochlePlayer(false, 1),
-				domain.NewPinochlePlayer(false, 0),
-				domain.NewPinochlePlayer(false, 1),
-			}
-			pinochle := domain.NewPinochle(domain.NewTrumpCardsPinochle(), players, config)
-			return usecase.NewPinochleInteractor(pinochle, new(presenter.PinochleWebPresenter))
+			return usecase.NewPinochleInteractor(domain.NewDefaultPinochle(), new(presenter.PinochleWebPresenter))
 		},
 		func(data []byte) (usecase.PinochleInteractorIF, error) {
 			return usecase.RestorePinochleInteractor(data, new(presenter.PinochleWebPresenter))
@@ -252,14 +177,7 @@ func main() {
 	// Pig's Tail
 	must(worker.RegisterKV(mux, "/pigtail/exec", "pigtail:",
 		func() usecase.PigsTailInteractorIF {
-			players := []*domain.PigsTailPlayer{
-				domain.NewPigsTailPlayer(true),
-				domain.NewPigsTailPlayer(false),
-				domain.NewPigsTailPlayer(false),
-				domain.NewPigsTailPlayer(false),
-			}
-			pigsTail := domain.NewPigsTail(domain.NewTrumpCards(0), players)
-			return usecase.NewPigsTailInteractor(pigsTail, new(presenter.PigsTailWebPresenter))
+			return usecase.NewPigsTailInteractor(domain.NewDefaultPigsTail(), new(presenter.PigsTailWebPresenter))
 		},
 		func(data []byte) (usecase.PigsTailInteractorIF, error) {
 			return usecase.RestorePigsTailInteractor(data, new(presenter.PigsTailWebPresenter))
@@ -270,15 +188,7 @@ func main() {
 	// Two Ten Jack
 	must(worker.RegisterKV(mux, "/twotenjack/exec", "twotenjack:",
 		func() usecase.TwoTenJackInteractorIF {
-			config := domain.DefaultTwoTenJackConfig()
-			players := []*domain.TwoTenJackPlayer{
-				domain.NewTwoTenJackPlayer(true),
-				domain.NewTwoTenJackPlayer(false),
-				domain.NewTwoTenJackPlayer(false),
-				domain.NewTwoTenJackPlayer(false),
-			}
-			ttj := domain.NewTwoTenJack(domain.NewTrumpCards(0), players, config)
-			return usecase.NewTwoTenJackInteractor(ttj, new(presenter.TwoTenJackWebPresenter))
+			return usecase.NewTwoTenJackInteractor(domain.NewDefaultTwoTenJack(), new(presenter.TwoTenJackWebPresenter))
 		},
 		func(data []byte) (usecase.TwoTenJackInteractorIF, error) {
 			return usecase.RestoreTwoTenJackInteractor(data, new(presenter.TwoTenJackWebPresenter))
@@ -289,13 +199,7 @@ func main() {
 	// War
 	must(worker.RegisterKV(mux, "/war/exec", "war:",
 		func() usecase.WarInteractorIF {
-			config := domain.DefaultWarConfig()
-			players := []*domain.WarPlayer{
-				domain.NewWarPlayer(true),
-				domain.NewWarPlayer(false),
-			}
-			war := domain.NewWar(domain.NewTrumpCards(0), players, config)
-			return usecase.NewWarInteractor(war, new(presenter.WarWebPresenter))
+			return usecase.NewWarInteractor(domain.NewDefaultWar(), new(presenter.WarWebPresenter))
 		},
 		func(data []byte) (usecase.WarInteractorIF, error) {
 			return usecase.RestoreWarInteractor(data, new(presenter.WarWebPresenter))
@@ -306,14 +210,7 @@ func main() {
 	// Durak
 	must(worker.RegisterKV(mux, "/durak/exec", "durak:",
 		func() usecase.DurakInteractorIF {
-			players := []*domain.DurakPlayer{
-				domain.NewDurakPlayer(true),
-				domain.NewDurakPlayer(false),
-				domain.NewDurakPlayer(false),
-				domain.NewDurakPlayer(false),
-			}
-			d := domain.NewDurak(domain.NewTrumpCardsShortDeck(), players)
-			return usecase.NewDurakInteractor(d, new(presenter.DurakWebPresenter))
+			return usecase.NewDurakInteractor(domain.NewDefaultDurak(), new(presenter.DurakWebPresenter))
 		},
 		func(data []byte) (usecase.DurakInteractorIF, error) {
 			return usecase.RestoreDurakInteractor(data, new(presenter.DurakWebPresenter))
@@ -324,14 +221,7 @@ func main() {
 	// Fifty-one
 	must(worker.RegisterKV(mux, "/fiftyone/exec", "fiftyone:",
 		func() usecase.FiftyOneInteractorIF {
-			players := []*domain.FiftyOnePlayer{
-				domain.NewFiftyOnePlayer(true),
-				domain.NewFiftyOnePlayer(false),
-				domain.NewFiftyOnePlayer(false),
-				domain.NewFiftyOnePlayer(false),
-			}
-			fo := domain.NewFiftyOne(domain.NewTrumpCards(0), players)
-			return usecase.NewFiftyOneInteractor(fo, new(presenter.FiftyOneWebPresenter))
+			return usecase.NewFiftyOneInteractor(domain.NewDefaultFiftyOne(), new(presenter.FiftyOneWebPresenter))
 		},
 		func(data []byte) (usecase.FiftyOneInteractorIF, error) {
 			return usecase.RestoreFiftyOneInteractor(data, new(presenter.FiftyOneWebPresenter))
@@ -342,15 +232,7 @@ func main() {
 	// Whist
 	must(worker.RegisterKV(mux, "/whist/exec", "whist:",
 		func() usecase.WhistInteractorIF {
-			config := domain.DefaultWhistConfig()
-			players := []*domain.WhistPlayer{
-				domain.NewWhistPlayer(true, 0),
-				domain.NewWhistPlayer(false, 1),
-				domain.NewWhistPlayer(false, 0),
-				domain.NewWhistPlayer(false, 1),
-			}
-			whist := domain.NewWhist(domain.NewTrumpCards(0), players, config)
-			return usecase.NewWhistInteractor(whist, new(presenter.WhistWebPresenter))
+			return usecase.NewWhistInteractor(domain.NewDefaultWhist(), new(presenter.WhistWebPresenter))
 		},
 		func(data []byte) (usecase.WhistInteractorIF, error) {
 			return usecase.RestoreWhistInteractor(data, new(presenter.WhistWebPresenter))
@@ -361,15 +243,7 @@ func main() {
 	// Page One
 	must(worker.RegisterKV(mux, "/pageone/exec", "pageone:",
 		func() usecase.PageOneInteractorIF {
-			config := domain.DefaultPageOneConfig()
-			players := []*domain.PageOnePlayer{
-				domain.NewPageOnePlayer(true),
-				domain.NewPageOnePlayer(false),
-				domain.NewPageOnePlayer(false),
-				domain.NewPageOnePlayer(false),
-			}
-			po := domain.NewPageOne(domain.NewTrumpCards(0), players, config)
-			return usecase.NewPageOneInteractor(po, new(presenter.PageOneWebPresenter))
+			return usecase.NewPageOneInteractor(domain.NewDefaultPageOne(), new(presenter.PageOneWebPresenter))
 		},
 		func(data []byte) (usecase.PageOneInteractorIF, error) {
 			return usecase.RestorePageOneInteractor(data, new(presenter.PageOneWebPresenter))

--- a/cmd/workers/solo/main.go
+++ b/cmd/workers/solo/main.go
@@ -23,8 +23,7 @@ func main() {
 	// Klondike
 	must(worker.RegisterKV(mux, "/klondike/exec", "klondike:",
 		func() usecase.KlondikeInteractorIF {
-			klondike := domain.NewKlondike(domain.NewTrumpCards(0))
-			return usecase.NewKlondikeInteractor(klondike, new(presenter.KlondikeWebPresenter))
+			return usecase.NewKlondikeInteractor(domain.NewDefaultKlondike(), new(presenter.KlondikeWebPresenter))
 		},
 		func(data []byte) (usecase.KlondikeInteractorIF, error) {
 			return usecase.RestoreKlondikeInteractor(data, new(presenter.KlondikeWebPresenter))
@@ -35,8 +34,7 @@ func main() {
 	// FreeCell
 	must(worker.RegisterKV(mux, "/freecell/exec", "freecell:",
 		func() usecase.FreeCellInteractorIF {
-			freeCell := domain.NewFreeCell(domain.NewTrumpCards(0))
-			return usecase.NewFreeCellInteractor(freeCell, new(presenter.FreeCellWebPresenter))
+			return usecase.NewFreeCellInteractor(domain.NewDefaultFreeCell(), new(presenter.FreeCellWebPresenter))
 		},
 		func(data []byte) (usecase.FreeCellInteractorIF, error) {
 			return usecase.RestoreFreeCellInteractor(data, new(presenter.FreeCellWebPresenter))
@@ -47,8 +45,7 @@ func main() {
 	// Spider
 	must(worker.RegisterKV(mux, "/spider/exec", "spider:",
 		func() usecase.SpiderInteractorIF {
-			spider := domain.NewSpider(domain.NewTrumpCardsWithSuits(domain.SpiderTotalCards, []int{domain.CardDesignSpade}))
-			return usecase.NewSpiderInteractor(spider, new(presenter.SpiderWebPresenter))
+			return usecase.NewSpiderInteractor(domain.NewDefaultSpider(), new(presenter.SpiderWebPresenter))
 		},
 		func(data []byte) (usecase.SpiderInteractorIF, error) {
 			return usecase.RestoreSpiderInteractor(data, new(presenter.SpiderWebPresenter))
@@ -59,8 +56,7 @@ func main() {
 	// Pyramid
 	must(worker.RegisterKV(mux, "/pyramid/exec", "pyramid:",
 		func() usecase.PyramidInteractorIF {
-			pyramid := domain.NewPyramid(domain.NewTrumpCards(0))
-			return usecase.NewPyramidInteractor(pyramid, new(presenter.PyramidWebPresenter))
+			return usecase.NewPyramidInteractor(domain.NewDefaultPyramid(), new(presenter.PyramidWebPresenter))
 		},
 		func(data []byte) (usecase.PyramidInteractorIF, error) {
 			return usecase.RestorePyramidInteractor(data, new(presenter.PyramidWebPresenter))
@@ -71,8 +67,7 @@ func main() {
 	// TriPeaks
 	must(worker.RegisterKV(mux, "/tripeaks/exec", "tripeaks:",
 		func() usecase.TriPeaksInteractorIF {
-			triPeaks := domain.NewTriPeaks(domain.NewTrumpCards(0))
-			return usecase.NewTriPeaksInteractor(triPeaks, new(presenter.TriPeaksWebPresenter))
+			return usecase.NewTriPeaksInteractor(domain.NewDefaultTriPeaks(), new(presenter.TriPeaksWebPresenter))
 		},
 		func(data []byte) (usecase.TriPeaksInteractorIF, error) {
 			return usecase.RestoreTriPeaksInteractor(data, new(presenter.TriPeaksWebPresenter))
@@ -94,13 +89,7 @@ func main() {
 	// Gin Rummy
 	must(worker.RegisterKV(mux, "/ginrummy/exec", "ginrummy:",
 		func() usecase.GinRummyInteractorIF {
-			config := domain.DefaultGinRummyConfig()
-			players := []*domain.GinRummyPlayer{
-				domain.NewGinRummyPlayer(true),
-				domain.NewGinRummyPlayer(false),
-			}
-			gr := domain.NewGinRummy(domain.NewTrumpCards(0), players, config)
-			return usecase.NewGinRummyInteractor(gr, new(presenter.GinRummyWebPresenter))
+			return usecase.NewGinRummyInteractor(domain.NewDefaultGinRummy(), new(presenter.GinRummyWebPresenter))
 		},
 		func(data []byte) (usecase.GinRummyInteractorIF, error) {
 			return usecase.RestoreGinRummyInteractor(data, new(presenter.GinRummyWebPresenter))
@@ -111,13 +100,7 @@ func main() {
 	// Cribbage
 	must(worker.RegisterKV(mux, "/cribbage/exec", "cribbage:",
 		func() usecase.CribbageInteractorIF {
-			config := domain.DefaultCribbageConfig()
-			players := []*domain.CribbagePlayer{
-				domain.NewCribbagePlayer(true),
-				domain.NewCribbagePlayer(false),
-			}
-			cribbage := domain.NewCribbage(domain.NewTrumpCards(0), players, config)
-			return usecase.NewCribbageInteractor(cribbage, new(presenter.CribbageWebPresenter))
+			return usecase.NewCribbageInteractor(domain.NewDefaultCribbage(), new(presenter.CribbageWebPresenter))
 		},
 		func(data []byte) (usecase.CribbageInteractorIF, error) {
 			return usecase.RestoreCribbageInteractor(data, new(presenter.CribbageWebPresenter))
@@ -128,13 +111,7 @@ func main() {
 	// Canasta
 	must(worker.RegisterKV(mux, "/canasta/exec", "canasta:",
 		func() usecase.CanastaInteractorIF {
-			config := domain.DefaultCanastaConfig()
-			players := []*domain.CanastaPlayer{
-				domain.NewCanastaPlayer(true),
-				domain.NewCanastaPlayer(false),
-			}
-			canasta := domain.NewCanasta(domain.NewTrumpCardsWithDecks(2, 4), players, config)
-			return usecase.NewCanastaInteractor(canasta, new(presenter.CanastaWebPresenter))
+			return usecase.NewCanastaInteractor(domain.NewDefaultCanasta(), new(presenter.CanastaWebPresenter))
 		},
 		func(data []byte) (usecase.CanastaInteractorIF, error) {
 			return usecase.RestoreCanastaInteractor(data, new(presenter.CanastaWebPresenter))
@@ -145,8 +122,7 @@ func main() {
 	// Golf
 	must(worker.RegisterKV(mux, "/golf/exec", "golf:",
 		func() usecase.GolfInteractorIF {
-			golf := domain.NewGolf(domain.NewTrumpCards(0))
-			return usecase.NewGolfInteractor(golf, new(presenter.GolfWebPresenter))
+			return usecase.NewGolfInteractor(domain.NewDefaultGolf(), new(presenter.GolfWebPresenter))
 		},
 		func(data []byte) (usecase.GolfInteractorIF, error) {
 			return usecase.RestoreGolfInteractor(data, new(presenter.GolfWebPresenter))
@@ -157,8 +133,7 @@ func main() {
 	// Clock Solitaire
 	must(worker.RegisterKV(mux, "/clocksolitaire/exec", "clocksolitaire:",
 		func() usecase.ClockSolitaireInteractorIF {
-			cs := domain.NewClockSolitaire(domain.NewTrumpCards(0))
-			return usecase.NewClockSolitaireInteractor(cs, new(presenter.ClockSolitaireWebPresenter))
+			return usecase.NewClockSolitaireInteractor(domain.NewDefaultClockSolitaire(), new(presenter.ClockSolitaireWebPresenter))
 		},
 		func(data []byte) (usecase.ClockSolitaireInteractorIF, error) {
 			return usecase.RestoreClockSolitaireInteractor(data, new(presenter.ClockSolitaireWebPresenter))
@@ -169,8 +144,7 @@ func main() {
 	// Canfield
 	must(worker.RegisterKV(mux, "/canfield/exec", "canfield:",
 		func() usecase.CanfieldInteractorIF {
-			canfield := domain.NewCanfield(domain.NewTrumpCards(0))
-			return usecase.NewCanfieldInteractor(canfield, new(presenter.CanfieldWebPresenter))
+			return usecase.NewCanfieldInteractor(domain.NewDefaultCanfield(), new(presenter.CanfieldWebPresenter))
 		},
 		func(data []byte) (usecase.CanfieldInteractorIF, error) {
 			return usecase.RestoreCanfieldInteractor(data, new(presenter.CanfieldWebPresenter))
@@ -181,8 +155,7 @@ func main() {
 	// Forty Thieves
 	must(worker.RegisterKV(mux, "/fortythieves/exec", "fortythieves:",
 		func() usecase.FortyThievesInteractorIF {
-			ft := domain.NewFortyThieves(domain.NewTrumpCardsWithDecks(2, 0))
-			return usecase.NewFortyThievesInteractor(ft, new(presenter.FortyThievesWebPresenter))
+			return usecase.NewFortyThievesInteractor(domain.NewDefaultFortyThieves(), new(presenter.FortyThievesWebPresenter))
 		},
 		func(data []byte) (usecase.FortyThievesInteractorIF, error) {
 			return usecase.RestoreFortyThievesInteractor(data, new(presenter.FortyThievesWebPresenter))
@@ -193,8 +166,7 @@ func main() {
 	// Poker Squares
 	must(worker.RegisterKV(mux, "/pokersquares/exec", "pokersquares:",
 		func() usecase.PokerSquaresInteractorIF {
-			ps := domain.NewPokerSquares(domain.NewTrumpCards(0))
-			return usecase.NewPokerSquaresInteractor(ps, new(presenter.PokerSquaresWebPresenter))
+			return usecase.NewPokerSquaresInteractor(domain.NewDefaultPokerSquares(), new(presenter.PokerSquaresWebPresenter))
 		},
 		func(data []byte) (usecase.PokerSquaresInteractorIF, error) {
 			return usecase.RestorePokerSquaresInteractor(data, new(presenter.PokerSquaresWebPresenter))
@@ -205,8 +177,7 @@ func main() {
 	// Yukon
 	must(worker.RegisterKV(mux, "/yukon/exec", "yukon:",
 		func() usecase.YukonInteractorIF {
-			yukon := domain.NewYukon(domain.NewTrumpCards(0))
-			return usecase.NewYukonInteractor(yukon, new(presenter.YukonWebPresenter))
+			return usecase.NewYukonInteractor(domain.NewDefaultYukon(), new(presenter.YukonWebPresenter))
 		},
 		func(data []byte) (usecase.YukonInteractorIF, error) {
 			return usecase.RestoreYukonInteractor(data, new(presenter.YukonWebPresenter))
@@ -217,8 +188,7 @@ func main() {
 	// Scorpion
 	must(worker.RegisterKV(mux, "/scorpion/exec", "scorpion:",
 		func() usecase.ScorpionInteractorIF {
-			scorpion := domain.NewScorpion(domain.NewTrumpCards(0))
-			return usecase.NewScorpionInteractor(scorpion, new(presenter.ScorpionWebPresenter))
+			return usecase.NewScorpionInteractor(domain.NewDefaultScorpion(), new(presenter.ScorpionWebPresenter))
 		},
 		func(data []byte) (usecase.ScorpionInteractorIF, error) {
 			return usecase.RestoreScorpionInteractor(data, new(presenter.ScorpionWebPresenter))

--- a/internal/domain/Bridge.go
+++ b/internal/domain/Bridge.go
@@ -133,6 +133,20 @@ func NewBridge(trumpCards *TrumpCards, players []*BridgePlayer, config BridgeCon
 	}
 }
 
+// NewDefaultBridge returns Bridge with the standard 4-player setup
+// (North human team 0, East CPU team 1, South CPU team 0, West CPU team 1)
+// and DefaultBridgeConfig. Used as the single source of truth for CUI, Web,
+// and Worker construction sites.
+func NewDefaultBridge() *Bridge {
+	players := []*BridgePlayer{
+		NewBridgePlayer(true, 0),
+		NewBridgePlayer(false, 1),
+		NewBridgePlayer(false, 0),
+		NewBridgePlayer(false, 1),
+	}
+	return NewBridge(NewTrumpCards(0), players, DefaultBridgeConfig())
+}
+
 // Reset ゲーム初期化
 func (b *Bridge) Reset() {
 	b.gameEndFlag = false

--- a/internal/domain/Canasta.go
+++ b/internal/domain/Canasta.go
@@ -72,6 +72,17 @@ func NewCanasta(trumpCards *TrumpCards, players []*CanastaPlayer, config Canasta
 	}
 }
 
+// NewDefaultCanasta returns Canasta with the standard 2-player setup (1 human, 1 CPU)
+// using a 2-deck pack with 4 jokers and DefaultCanastaConfig.
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultCanasta() *Canasta {
+	players := []*CanastaPlayer{
+		NewCanastaPlayer(true),
+		NewCanastaPlayer(false),
+	}
+	return NewCanasta(NewTrumpCardsWithDecks(2, 4), players, DefaultCanastaConfig())
+}
+
 // Reset ゲーム初期化
 func (g *Canasta) Reset() {
 	g.gameEndFlag = false

--- a/internal/domain/Canfield.go
+++ b/internal/domain/Canfield.go
@@ -76,6 +76,12 @@ func NewCanfield(trumpCards *TrumpCards) *Canfield {
 	return &Canfield{trumpCards: trumpCards}
 }
 
+// NewDefaultCanfield returns Canfield with a standard single 52-card deck.
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultCanfield() *Canfield {
+	return NewCanfield(NewTrumpCards(0))
+}
+
 // Reset ゲームリセット
 func (c *Canfield) Reset() {
 	c.trumpCards.Shuffle()

--- a/internal/domain/ClockSolitaire.go
+++ b/internal/domain/ClockSolitaire.go
@@ -52,6 +52,12 @@ func NewClockSolitaire(trumpCards *TrumpCards) *ClockSolitaire {
 	}
 }
 
+// NewDefaultClockSolitaire returns ClockSolitaire with a standard single 52-card deck.
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultClockSolitaire() *ClockSolitaire {
+	return NewClockSolitaire(NewTrumpCards(0))
+}
+
 // Reset ゲームリセット
 func (cs *ClockSolitaire) Reset() {
 	cs.trumpCards.Shuffle()

--- a/internal/domain/Cribbage.go
+++ b/internal/domain/Cribbage.go
@@ -86,6 +86,17 @@ func NewCribbage(trumpCards *TrumpCards, players []*CribbagePlayer, config Cribb
 	}
 }
 
+// NewDefaultCribbage returns Cribbage with the standard 2-player setup (1 human, 1 CPU)
+// and DefaultCribbageConfig. Used as the single source of truth for CUI, Web, and Worker
+// construction sites.
+func NewDefaultCribbage() *Cribbage {
+	players := []*CribbagePlayer{
+		NewCribbagePlayer(true),
+		NewCribbagePlayer(false),
+	}
+	return NewCribbage(NewTrumpCards(0), players, DefaultCribbageConfig())
+}
+
 // Reset ゲーム初期化
 func (g *Cribbage) Reset() {
 	g.gameEndFlag = false

--- a/internal/domain/Daifugo.go
+++ b/internal/domain/Daifugo.go
@@ -142,6 +142,20 @@ func NewDaifugo(trumpCards *TrumpCards, players []*DaifugoPlayer, config Daifugo
 	}
 }
 
+// NewDefaultDaifugo returns Daifugo with the standard 4-player setup (1 human, 3 CPU)
+// and DefaultDaifugoConfig. Used as the single source of truth for CUI, Web, and Worker
+// construction sites.
+func NewDefaultDaifugo() *Daifugo {
+	config := DefaultDaifugoConfig()
+	players := []*DaifugoPlayer{
+		NewDaifugoPlayer(true),
+		NewDaifugoPlayer(false),
+		NewDaifugoPlayer(false),
+		NewDaifugoPlayer(false),
+	}
+	return NewDaifugo(NewTrumpCards(config.JokerCount), players, config)
+}
+
 // Reset ゲーム初期化
 func (d *Daifugo) Reset() {
 	// 前回のランクをプレイヤーオブジェクトに保存 (カード交換に使用)

--- a/internal/domain/Doubt.go
+++ b/internal/domain/Doubt.go
@@ -138,6 +138,18 @@ func NewDoubt(trumpCards *TrumpCards, players []*DoubtPlayer) *Doubt {
 	}
 }
 
+// NewDefaultDoubt returns Doubt with the standard 4-player setup (1 human, 3 CPU).
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultDoubt() *Doubt {
+	players := []*DoubtPlayer{
+		NewDoubtPlayer(true),
+		NewDoubtPlayer(false),
+		NewDoubtPlayer(false),
+		NewDoubtPlayer(false),
+	}
+	return NewDoubt(NewTrumpCards(0), players)
+}
+
 // Reset ゲーム初期化: シャッフルして各プレイヤーに均等配布
 func (d *Doubt) Reset() {
 	d.gameEndFlag = false

--- a/internal/domain/Durak.go
+++ b/internal/domain/Durak.go
@@ -94,6 +94,19 @@ func NewDurak(trumpCards *TrumpCards, players []*DurakPlayer) *Durak {
 	}
 }
 
+// NewDefaultDurak returns Durak with the standard 4-player setup (1 human, 3 CPU)
+// using the short deck. Used as the single source of truth for CUI, Web, and Worker
+// construction sites.
+func NewDefaultDurak() *Durak {
+	players := []*DurakPlayer{
+		NewDurakPlayer(true),
+		NewDurakPlayer(false),
+		NewDurakPlayer(false),
+		NewDurakPlayer(false),
+	}
+	return NewDurak(NewTrumpCardsShortDeck(), players)
+}
+
 // ---- 公開メソッド: ゲーム操作 ----
 
 // Reset ゲーム初期化

--- a/internal/domain/Euchre.go
+++ b/internal/domain/Euchre.go
@@ -92,6 +92,19 @@ func NewEuchre(trumpCards *TrumpCards, players []*EuchrePlayer, config EuchreCon
 	}
 }
 
+// NewDefaultEuchre returns Euchre with the standard 4-player team setup
+// (human team 0, alternating CPU teams) and DefaultEuchreConfig.
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultEuchre() *Euchre {
+	players := []*EuchrePlayer{
+		NewEuchrePlayer(true, 0),
+		NewEuchrePlayer(false, 1),
+		NewEuchrePlayer(false, 0),
+		NewEuchrePlayer(false, 1),
+	}
+	return NewEuchre(NewTrumpCardsEuchre(), players, DefaultEuchreConfig())
+}
+
 // Reset ゲーム初期化
 func (e *Euchre) Reset() {
 	e.gameEndFlag = false

--- a/internal/domain/FiftyOne.go
+++ b/internal/domain/FiftyOne.go
@@ -76,6 +76,18 @@ func NewFiftyOne(trumpCards *TrumpCards, players []*FiftyOnePlayer) *FiftyOne {
 	}
 }
 
+// NewDefaultFiftyOne returns FiftyOne with the standard 4-player setup (1 human, 3 CPU).
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultFiftyOne() *FiftyOne {
+	players := []*FiftyOnePlayer{
+		NewFiftyOnePlayer(true),
+		NewFiftyOnePlayer(false),
+		NewFiftyOnePlayer(false),
+		NewFiftyOnePlayer(false),
+	}
+	return NewFiftyOne(NewTrumpCards(0), players)
+}
+
 // Reset ゲームを初期化する
 func (fo *FiftyOne) Reset() {
 	// カードリセット

--- a/internal/domain/FortyThieves.go
+++ b/internal/domain/FortyThieves.go
@@ -75,6 +75,12 @@ func NewFortyThieves(trumpCards *TrumpCards) *FortyThieves {
 	}
 }
 
+// NewDefaultFortyThieves returns FortyThieves with two combined 52-card decks.
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultFortyThieves() *FortyThieves {
+	return NewFortyThieves(NewTrumpCardsWithDecks(2, 0))
+}
+
 // Reset ゲームリセット
 func (ft *FortyThieves) Reset() {
 	ft.trumpCards.Shuffle()

--- a/internal/domain/FreeCell.go
+++ b/internal/domain/FreeCell.go
@@ -67,6 +67,12 @@ func NewFreeCell(trumpCards *TrumpCards) *FreeCell {
 	}
 }
 
+// NewDefaultFreeCell returns FreeCell with a standard single 52-card deck.
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultFreeCell() *FreeCell {
+	return NewFreeCell(NewTrumpCards(0))
+}
+
 // Reset ゲームリセット
 func (f *FreeCell) Reset() {
 	f.trumpCards.Shuffle()

--- a/internal/domain/GinRummy.go
+++ b/internal/domain/GinRummy.go
@@ -73,6 +73,17 @@ func NewGinRummy(trumpCards *TrumpCards, players []*GinRummyPlayer, config GinRu
 	}
 }
 
+// NewDefaultGinRummy returns GinRummy with the standard 2-player setup (1 human, 1 CPU)
+// and DefaultGinRummyConfig. Used as the single source of truth for CUI, Web, and Worker
+// construction sites.
+func NewDefaultGinRummy() *GinRummy {
+	players := []*GinRummyPlayer{
+		NewGinRummyPlayer(true),
+		NewGinRummyPlayer(false),
+	}
+	return NewGinRummy(NewTrumpCards(0), players, DefaultGinRummyConfig())
+}
+
 // Reset ゲーム初期化
 func (g *GinRummy) Reset() {
 	g.gameEndFlag = false

--- a/internal/domain/GoFish.go
+++ b/internal/domain/GoFish.go
@@ -107,6 +107,18 @@ func NewGoFish(trumpCards *TrumpCards, players []*GoFishPlayer) *GoFish {
 	}
 }
 
+// NewDefaultGoFish returns GoFish with the standard 4-player setup (1 human, 3 CPU).
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultGoFish() *GoFish {
+	players := []*GoFishPlayer{
+		NewGoFishPlayer(true),
+		NewGoFishPlayer(false),
+		NewGoFishPlayer(false),
+		NewGoFishPlayer(false),
+	}
+	return NewGoFish(NewTrumpCards(0), players)
+}
+
 // Reset ゲームを初期化する
 func (g *GoFish) Reset() {
 	// プレイヤーリセット

--- a/internal/domain/Golf.go
+++ b/internal/domain/Golf.go
@@ -70,6 +70,12 @@ func NewGolf(trumpCards *TrumpCards) *Golf {
 	}
 }
 
+// NewDefaultGolf returns Golf with a standard single 52-card deck.
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultGolf() *Golf {
+	return NewGolf(NewTrumpCards(0))
+}
+
 // Reset ゲームリセット
 func (g *Golf) Reset() {
 	g.trumpCards.Shuffle()

--- a/internal/domain/Holdem.go
+++ b/internal/domain/Holdem.go
@@ -105,6 +105,13 @@ func NewHoldem(trumpCards *TrumpCards, players []*HoldemPlayer, config HoldemCon
 	}
 }
 
+// NewDefaultHoldem returns Holdem with the default table size and DefaultHoldemConfig.
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultHoldem() *Holdem {
+	cfg := DefaultHoldemConfig()
+	return NewHoldem(NewTrumpCards(0), NewPlayersForTable(cfg.TableSize), cfg)
+}
+
 // Reset ゲーム初期化
 func (h *Holdem) Reset() error {
 	h.phase = HoldemPhaseInit

--- a/internal/domain/IndianPoker.go
+++ b/internal/domain/IndianPoker.go
@@ -81,6 +81,13 @@ func NewIndianPoker(trumpCards *TrumpCards, players []*IndianPokerPlayer, config
 	}
 }
 
+// NewDefaultIndianPoker returns IndianPoker with the standard player setup and
+// DefaultIndianPokerConfig. Used as the single source of truth for CUI, Web,
+// and Worker construction sites.
+func NewDefaultIndianPoker() *IndianPoker {
+	return NewIndianPoker(NewTrumpCards(0), NewIndianPokerPlayers(), DefaultIndianPokerConfig())
+}
+
 // Reset ゲーム初期化
 func (ip *IndianPoker) Reset() error {
 	ip.phase = IndianPokerPhaseInit

--- a/internal/domain/Klondike.go
+++ b/internal/domain/Klondike.go
@@ -96,6 +96,12 @@ func NewKlondike(trumpCards *TrumpCards) *Klondike {
 	}
 }
 
+// NewDefaultKlondike returns Klondike with a standard single 52-card deck.
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultKlondike() *Klondike {
+	return NewKlondike(NewTrumpCards(0))
+}
+
 // ResetWithConfig 設定付きリセット
 func (k *Klondike) ResetWithConfig(cfg KlondikeConfig) {
 	if cfg.DrawCount == 3 {

--- a/internal/domain/Napoleon.go
+++ b/internal/domain/Napoleon.go
@@ -113,6 +113,19 @@ func NewNapoleon(trumpCards *TrumpCards, players []*NapoleonPlayer, config Napol
 	}
 }
 
+// NewDefaultNapoleon returns Napoleon with the standard 4-player setup (1 human, 3 CPU)
+// and DefaultNapoleonConfig. Used as the single source of truth for CUI, Web, and Worker
+// construction sites.
+func NewDefaultNapoleon() *Napoleon {
+	players := []*NapoleonPlayer{
+		NewNapoleonPlayer(true),
+		NewNapoleonPlayer(false),
+		NewNapoleonPlayer(false),
+		NewNapoleonPlayer(false),
+	}
+	return NewNapoleon(NewTrumpCards(1), players, DefaultNapoleonConfig())
+}
+
 // Reset ゲーム初期化
 func (n *Napoleon) Reset() {
 	n.round = napoleonRoundState{

--- a/internal/domain/NewDefault_test.go
+++ b/internal/domain/NewDefault_test.go
@@ -113,6 +113,8 @@ func TestNewDefaultBridge(t *testing.T) {
 	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, 4)
 	assert.Equal(t, 0, g.GetPlayer(0).GetTeam())
 	assert.Equal(t, 1, g.GetPlayer(1).GetTeam())
+	assert.Equal(t, 0, g.GetPlayer(2).GetTeam())
+	assert.Equal(t, 1, g.GetPlayer(3).GetTeam())
 }
 
 func TestNewDefaultEuchre(t *testing.T) {
@@ -121,6 +123,8 @@ func TestNewDefaultEuchre(t *testing.T) {
 	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, 4)
 	assert.Equal(t, 0, g.GetPlayer(0).GetTeam())
 	assert.Equal(t, 1, g.GetPlayer(1).GetTeam())
+	assert.Equal(t, 0, g.GetPlayer(2).GetTeam())
+	assert.Equal(t, 1, g.GetPlayer(3).GetTeam())
 }
 
 func TestNewDefaultPinochle(t *testing.T) {
@@ -129,6 +133,8 @@ func TestNewDefaultPinochle(t *testing.T) {
 	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, 4)
 	assert.Equal(t, 0, g.GetPlayer(0).GetTeam())
 	assert.Equal(t, 1, g.GetPlayer(1).GetTeam())
+	assert.Equal(t, 0, g.GetPlayer(2).GetTeam())
+	assert.Equal(t, 1, g.GetPlayer(3).GetTeam())
 }
 
 func TestNewDefaultWhist(t *testing.T) {
@@ -137,6 +143,8 @@ func TestNewDefaultWhist(t *testing.T) {
 	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, 4)
 	assert.Equal(t, 0, g.GetPlayer(0).GetTeam())
 	assert.Equal(t, 1, g.GetPlayer(1).GetTeam())
+	assert.Equal(t, 0, g.GetPlayer(2).GetTeam())
+	assert.Equal(t, 1, g.GetPlayer(3).GetTeam())
 }
 
 // 2-player games.
@@ -274,5 +282,5 @@ func TestNewDefaultRazz(t *testing.T) {
 func TestNewDefaultIndianPoker(t *testing.T) {
 	g := domain.NewDefaultIndianPoker()
 	assert.NotNil(t, g)
-	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, g.GetPlayerCnt())
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, 4)
 }

--- a/internal/domain/NewDefault_test.go
+++ b/internal/domain/NewDefault_test.go
@@ -1,0 +1,278 @@
+//go:build test
+
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+)
+
+// playerCounter is implemented by every game type that exposes player count.
+// Used in table-driven NewDefault tests to verify the factory wires up the
+// expected (1 human, N CPU) seating without depending on game-specific APIs.
+type playerCounter interface {
+	GetPlayerCnt() int
+}
+
+// assertHumanFirst checks that a multi-player game has the human seated at
+// index 0 and CPUs at indices 1..N-1.
+func assertHumanFirst(t *testing.T, g playerCounter, isHumanAt func(int) bool, expectedCnt int) {
+	t.Helper()
+	assert.Equal(t, expectedCnt, g.GetPlayerCnt(), "player count mismatch")
+	assert.True(t, isHumanAt(0), "player 0 must be human")
+	for i := 1; i < g.GetPlayerCnt(); i++ {
+		assert.False(t, isHumanAt(i), "player %d must be CPU", i)
+	}
+}
+
+func TestNewDefaultDaifugo(t *testing.T) {
+	g := domain.NewDefaultDaifugo()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, domain.DaifugoPlayerCnt)
+}
+
+func TestNewDefaultSevens(t *testing.T) {
+	g := domain.NewDefaultSevens()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, domain.SevensPlayerCnt)
+}
+
+func TestNewDefaultDoubt(t *testing.T) {
+	g := domain.NewDefaultDoubt()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, 4)
+}
+
+func TestNewDefaultOldMaid(t *testing.T) {
+	g := domain.NewDefaultOldMaid()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, 4)
+}
+
+func TestNewDefaultGoFish(t *testing.T) {
+	g := domain.NewDefaultGoFish()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, 4)
+}
+
+func TestNewDefaultPigsTail(t *testing.T) {
+	g := domain.NewDefaultPigsTail()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, 4)
+}
+
+func TestNewDefaultFiftyOne(t *testing.T) {
+	g := domain.NewDefaultFiftyOne()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, 4)
+}
+
+func TestNewDefaultDurak(t *testing.T) {
+	g := domain.NewDefaultDurak()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, 4)
+}
+
+func TestNewDefaultPageOne(t *testing.T) {
+	g := domain.NewDefaultPageOne()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, 4)
+}
+
+func TestNewDefaultTwoTenJack(t *testing.T) {
+	g := domain.NewDefaultTwoTenJack()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, 4)
+}
+
+func TestNewDefaultNapoleon(t *testing.T) {
+	g := domain.NewDefaultNapoleon()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, 4)
+}
+
+func TestNewDefaultPoker(t *testing.T) {
+	g := domain.NewDefaultPoker()
+	assert.NotNil(t, g)
+	players := g.GetPlayers()
+	assert.Len(t, players, 4)
+	assert.True(t, players[0].GetIsHuman(), "player 0 must be human")
+	for i := 1; i < len(players); i++ {
+		assert.False(t, players[i].GetIsHuman(), "player %d must be CPU", i)
+	}
+}
+
+// Team-based 4-player games: human is team 0, alternating teams.
+
+func TestNewDefaultBridge(t *testing.T) {
+	g := domain.NewDefaultBridge()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, 4)
+	assert.Equal(t, 0, g.GetPlayer(0).GetTeam())
+	assert.Equal(t, 1, g.GetPlayer(1).GetTeam())
+}
+
+func TestNewDefaultEuchre(t *testing.T) {
+	g := domain.NewDefaultEuchre()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, 4)
+	assert.Equal(t, 0, g.GetPlayer(0).GetTeam())
+	assert.Equal(t, 1, g.GetPlayer(1).GetTeam())
+}
+
+func TestNewDefaultPinochle(t *testing.T) {
+	g := domain.NewDefaultPinochle()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, 4)
+	assert.Equal(t, 0, g.GetPlayer(0).GetTeam())
+	assert.Equal(t, 1, g.GetPlayer(1).GetTeam())
+}
+
+func TestNewDefaultWhist(t *testing.T) {
+	g := domain.NewDefaultWhist()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, 4)
+	assert.Equal(t, 0, g.GetPlayer(0).GetTeam())
+	assert.Equal(t, 1, g.GetPlayer(1).GetTeam())
+}
+
+// 2-player games.
+
+func TestNewDefaultGinRummy(t *testing.T) {
+	g := domain.NewDefaultGinRummy()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, 2)
+}
+
+func TestNewDefaultCribbage(t *testing.T) {
+	g := domain.NewDefaultCribbage()
+	assert.NotNil(t, g)
+	assert.True(t, g.GetPlayer(0).GetIsHuman(), "player 0 must be human")
+	for i := 1; i < domain.CribbagePlayerCnt; i++ {
+		assert.False(t, g.GetPlayer(i).GetIsHuman(), "player %d must be CPU", i)
+	}
+}
+
+func TestNewDefaultSpeed(t *testing.T) {
+	g := domain.NewDefaultSpeed()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, domain.SpeedPlayerCnt)
+}
+
+func TestNewDefaultWar(t *testing.T) {
+	g := domain.NewDefaultWar()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, domain.WarPlayerCnt)
+}
+
+func TestNewDefaultCanasta(t *testing.T) {
+	g := domain.NewDefaultCanasta()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, 2)
+}
+
+// Solitaire and single-deck card games (no player count to assert).
+
+func TestNewDefaultKlondike(t *testing.T) {
+	assert.NotNil(t, domain.NewDefaultKlondike())
+}
+
+func TestNewDefaultFreeCell(t *testing.T) {
+	assert.NotNil(t, domain.NewDefaultFreeCell())
+}
+
+func TestNewDefaultSpider(t *testing.T) {
+	assert.NotNil(t, domain.NewDefaultSpider())
+}
+
+func TestNewDefaultPyramid(t *testing.T) {
+	assert.NotNil(t, domain.NewDefaultPyramid())
+}
+
+func TestNewDefaultTriPeaks(t *testing.T) {
+	assert.NotNil(t, domain.NewDefaultTriPeaks())
+}
+
+func TestNewDefaultGolf(t *testing.T) {
+	assert.NotNil(t, domain.NewDefaultGolf())
+}
+
+func TestNewDefaultClockSolitaire(t *testing.T) {
+	assert.NotNil(t, domain.NewDefaultClockSolitaire())
+}
+
+func TestNewDefaultCanfield(t *testing.T) {
+	assert.NotNil(t, domain.NewDefaultCanfield())
+}
+
+func TestNewDefaultFortyThieves(t *testing.T) {
+	assert.NotNil(t, domain.NewDefaultFortyThieves())
+}
+
+func TestNewDefaultYukon(t *testing.T) {
+	assert.NotNil(t, domain.NewDefaultYukon())
+}
+
+func TestNewDefaultScorpion(t *testing.T) {
+	assert.NotNil(t, domain.NewDefaultScorpion())
+}
+
+func TestNewDefaultPokerSquares(t *testing.T) {
+	assert.NotNil(t, domain.NewDefaultPokerSquares())
+}
+
+// Table-size based community-card games. We verify human is at seat 0
+// against the configured table size for each.
+
+func TestNewDefaultHoldem(t *testing.T) {
+	cfg := domain.DefaultHoldemConfig()
+	g := domain.NewDefaultHoldem()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, cfg.TableSize)
+}
+
+func TestNewDefaultOmaha(t *testing.T) {
+	cfg := domain.DefaultOmahaConfig()
+	g := domain.NewDefaultOmaha()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, cfg.TableSize)
+}
+
+func TestNewDefaultShortDeck(t *testing.T) {
+	cfg := domain.DefaultShortDeckConfig()
+	g := domain.NewDefaultShortDeck()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, cfg.TableSize)
+}
+
+func TestNewDefaultPineapple(t *testing.T) {
+	cfg := domain.DefaultPineappleConfig()
+	g := domain.NewDefaultPineapple()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, cfg.TableSize)
+}
+
+func TestNewDefaultSevenCardStud(t *testing.T) {
+	cfg := domain.DefaultSevenCardStudConfig()
+	g := domain.NewDefaultSevenCardStud()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, cfg.TableSize)
+	assert.False(t, g.GetIsLowball(), "stud should not be lowball")
+}
+
+func TestNewDefaultRazz(t *testing.T) {
+	cfg := domain.DefaultRazzConfig()
+	g := domain.NewDefaultRazz()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, cfg.TableSize)
+	assert.True(t, g.GetIsLowball(), "razz must be lowball")
+}
+
+func TestNewDefaultIndianPoker(t *testing.T) {
+	g := domain.NewDefaultIndianPoker()
+	assert.NotNil(t, g)
+	assertHumanFirst(t, g, func(i int) bool { return g.GetPlayer(i).GetIsHuman() }, g.GetPlayerCnt())
+}

--- a/internal/domain/OldMaid.go
+++ b/internal/domain/OldMaid.go
@@ -92,6 +92,19 @@ func NewOldMaid(trumpCards *TrumpCards, players []*OldMaidPlayer) *OldMaid {
 	}
 }
 
+// NewDefaultOldMaid returns OldMaid with the standard 4-player setup (1 human, 3 CPU)
+// using a deck with 1 joker. Used as the single source of truth for CUI, Web, and Worker
+// construction sites.
+func NewDefaultOldMaid() *OldMaid {
+	players := []*OldMaidPlayer{
+		NewOldMaidPlayer(true),
+		NewOldMaidPlayer(false),
+		NewOldMaidPlayer(false),
+		NewOldMaidPlayer(false),
+	}
+	return NewOldMaid(NewTrumpCards(1), players)
+}
+
 // SetConfig ゲーム設定をセット
 func (o *OldMaid) SetConfig(config OldMaidConfig) { o.config = config }
 

--- a/internal/domain/Omaha.go
+++ b/internal/domain/Omaha.go
@@ -86,6 +86,13 @@ func NewOmaha(trumpCards *TrumpCards, players []*OmahaPlayer, config OmahaConfig
 	}
 }
 
+// NewDefaultOmaha returns Omaha with the default table size and DefaultOmahaConfig.
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultOmaha() *Omaha {
+	cfg := DefaultOmahaConfig()
+	return NewOmaha(NewTrumpCards(0), NewOmahaPlayersForTable(cfg.TableSize), cfg)
+}
+
 // Reset ゲーム初期化
 func (o *Omaha) Reset() error {
 	o.phase = OmahaPhaseInit

--- a/internal/domain/PageOne.go
+++ b/internal/domain/PageOne.go
@@ -57,6 +57,19 @@ func NewPageOne(trumpCards *TrumpCards, players []*PageOnePlayer, config PageOne
 	}
 }
 
+// NewDefaultPageOne returns PageOne with the standard 4-player setup (1 human, 3 CPU)
+// and DefaultPageOneConfig. Used as the single source of truth for CUI, Web, and Worker
+// construction sites.
+func NewDefaultPageOne() *PageOne {
+	players := []*PageOnePlayer{
+		NewPageOnePlayer(true),
+		NewPageOnePlayer(false),
+		NewPageOnePlayer(false),
+		NewPageOnePlayer(false),
+	}
+	return NewPageOne(NewTrumpCards(0), players, DefaultPageOneConfig())
+}
+
 // Reset ゲーム初期化
 func (g *PageOne) Reset() {
 	g.gameEndFlag = false

--- a/internal/domain/PigsTail.go
+++ b/internal/domain/PigsTail.go
@@ -89,6 +89,18 @@ func NewPigsTail(trumpCards *TrumpCards, players []*PigsTailPlayer) *PigsTail {
 	}
 }
 
+// NewDefaultPigsTail returns PigsTail with the standard 4-player setup (1 human, 3 CPU).
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultPigsTail() *PigsTail {
+	players := []*PigsTailPlayer{
+		NewPigsTailPlayer(true),
+		NewPigsTailPlayer(false),
+		NewPigsTailPlayer(false),
+		NewPigsTailPlayer(false),
+	}
+	return NewPigsTail(NewTrumpCards(0), players)
+}
+
 // SetConfig ゲーム設定をセット
 func (pt *PigsTail) SetConfig(config PigsTailConfig) { pt.config = config }
 

--- a/internal/domain/Pineapple.go
+++ b/internal/domain/Pineapple.go
@@ -88,6 +88,14 @@ func NewPineapple(trumpCards *TrumpCards, players []*PineapplePlayer, config Pin
 	}
 }
 
+// NewDefaultPineapple returns Pineapple with the default table size and
+// DefaultPineappleConfig. Used as the single source of truth for CUI, Web,
+// and Worker construction sites.
+func NewDefaultPineapple() *Pineapple {
+	cfg := DefaultPineappleConfig()
+	return NewPineapple(NewTrumpCards(0), NewPineapplePlayersForTable(cfg.TableSize), cfg)
+}
+
 // Reset ゲーム初期化
 func (p *Pineapple) Reset() error {
 	p.phase = PineapplePhaseInit

--- a/internal/domain/Pinochle.go
+++ b/internal/domain/Pinochle.go
@@ -146,6 +146,19 @@ func NewPinochle(trumpCards *TrumpCards, players []*PinochlePlayer, config Pinoc
 	}
 }
 
+// NewDefaultPinochle returns Pinochle with the standard 4-player team setup
+// (human team 0, alternating CPU teams) and DefaultPinochleConfig.
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultPinochle() *Pinochle {
+	players := []*PinochlePlayer{
+		NewPinochlePlayer(true, 0),
+		NewPinochlePlayer(false, 1),
+		NewPinochlePlayer(false, 0),
+		NewPinochlePlayer(false, 1),
+	}
+	return NewPinochle(NewTrumpCardsPinochle(), players, DefaultPinochleConfig())
+}
+
 // Reset ゲーム初期化
 func (p *Pinochle) Reset() {
 	p.gameEndFlag = false

--- a/internal/domain/Poker.go
+++ b/internal/domain/Poker.go
@@ -132,6 +132,20 @@ func NewPoker(trumpCards *TrumpCards, players []*PokerPlayer, config PokerConfig
 	}
 }
 
+// NewDefaultPoker returns Poker with the standard 4-player setup (1 human balanced,
+// 3 CPU with mixed styles) and DefaultPokerConfig. Used as the single source of truth
+// for CUI, Web, and Worker construction sites.
+func NewDefaultPoker() *Poker {
+	config := DefaultPokerConfig()
+	players := []*PokerPlayer{
+		NewPokerPlayer(true, PokerStyleBalanced),
+		NewPokerPlayer(false, PokerStyleConservative),
+		NewPokerPlayer(false, PokerStyleAggressive),
+		NewPokerPlayer(false, PokerStyleBluffer),
+	}
+	return NewPoker(NewTrumpCards(config.JokerCount), players, config)
+}
+
 // Reset ゲーム初期化
 func (p *Poker) Reset() error {
 	p.round = pokerRoundState{

--- a/internal/domain/PokerSquares.go
+++ b/internal/domain/PokerSquares.go
@@ -64,6 +64,12 @@ func NewPokerSquares(tc *TrumpCards) *PokerSquares {
 	return &PokerSquares{trumpCards: tc}
 }
 
+// NewDefaultPokerSquares returns PokerSquares with a standard single 52-card deck.
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultPokerSquares() *PokerSquares {
+	return NewPokerSquares(NewTrumpCards(0))
+}
+
 // Reset はゲームを初期化する。デッキをシャッフルし、最初のカードを引く。
 func (p *PokerSquares) Reset() {
 	p.trumpCards.Shuffle()

--- a/internal/domain/Pyramid.go
+++ b/internal/domain/Pyramid.go
@@ -73,6 +73,12 @@ func NewPyramid(trumpCards *TrumpCards) *Pyramid {
 	}
 }
 
+// NewDefaultPyramid returns Pyramid with a standard single 52-card deck.
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultPyramid() *Pyramid {
+	return NewPyramid(NewTrumpCards(0))
+}
+
 // Reset ゲームリセット
 func (p *Pyramid) Reset() {
 	p.trumpCards.Shuffle()

--- a/internal/domain/Scorpion.go
+++ b/internal/domain/Scorpion.go
@@ -83,6 +83,12 @@ func NewScorpion(trumpCards *TrumpCards) *Scorpion {
 	}
 }
 
+// NewDefaultScorpion returns Scorpion with a standard single 52-card deck.
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultScorpion() *Scorpion {
+	return NewScorpion(NewTrumpCards(0))
+}
+
 // Reset ゲームリセット
 func (s *Scorpion) Reset() {
 	s.trumpCards.Shuffle()

--- a/internal/domain/SevenCardStud.go
+++ b/internal/domain/SevenCardStud.go
@@ -116,6 +116,22 @@ func NewRazz(trumpCards *TrumpCards, players []*SevenCardStudPlayer, config Seve
 	return s
 }
 
+// NewDefaultSevenCardStud returns SevenCardStud with the default table size and
+// DefaultSevenCardStudConfig. Used as the single source of truth for CUI, Web,
+// and Worker construction sites.
+func NewDefaultSevenCardStud() *SevenCardStud {
+	cfg := DefaultSevenCardStudConfig()
+	return NewSevenCardStud(NewTrumpCards(0), NewSevenCardStudPlayersForTable(cfg.TableSize), cfg)
+}
+
+// NewDefaultRazz returns Razz (A-5 lowball) with the default table size and
+// DefaultRazzConfig. Used as the single source of truth for CUI, Web, and Worker
+// construction sites.
+func NewDefaultRazz() *SevenCardStud {
+	cfg := DefaultRazzConfig()
+	return NewRazz(NewTrumpCards(0), NewSevenCardStudPlayersForTable(cfg.TableSize), cfg)
+}
+
 // GetIsLowball ローボールモードかどうか
 func (s *SevenCardStud) GetIsLowball() bool { return s.lowball }
 

--- a/internal/domain/Sevens.go
+++ b/internal/domain/Sevens.go
@@ -56,6 +56,20 @@ func NewSevens(trumpCards *TrumpCards, players []*SevensPlayer, config SevensCon
 	return s
 }
 
+// NewDefaultSevens returns Sevens with the standard 4-player setup (1 human, 3 CPU)
+// and DefaultSevensConfig. Used as the single source of truth for CUI, Web, and Worker
+// construction sites.
+func NewDefaultSevens() *Sevens {
+	config := DefaultSevensConfig()
+	players := []*SevensPlayer{
+		NewSevensPlayer(true),
+		NewSevensPlayer(false),
+		NewSevensPlayer(false),
+		NewSevensPlayer(false),
+	}
+	return NewSevens(NewTrumpCards(config.JokerCount), players, config)
+}
+
 // Reset ゲーム初期化
 func (s *Sevens) Reset() {
 	s.gameEndFlag = false

--- a/internal/domain/ShortDeck.go
+++ b/internal/domain/ShortDeck.go
@@ -86,6 +86,14 @@ func NewShortDeck(trumpCards *TrumpCards, players []*ShortDeckPlayer, config Sho
 	}
 }
 
+// NewDefaultShortDeck returns ShortDeck with the default table size and
+// DefaultShortDeckConfig using the short (6+) deck. Used as the single source
+// of truth for CUI, Web, and Worker construction sites.
+func NewDefaultShortDeck() *ShortDeck {
+	cfg := DefaultShortDeckConfig()
+	return NewShortDeck(NewTrumpCardsShortDeck(), NewShortDeckPlayersForTable(cfg.TableSize), cfg)
+}
+
 // Reset ゲーム初期化
 func (sd *ShortDeck) Reset() error {
 	sd.phase = ShortDeckPhaseInit

--- a/internal/domain/Speed.go
+++ b/internal/domain/Speed.go
@@ -59,6 +59,17 @@ func NewSpeed(trumpCards *TrumpCards, players []*SpeedPlayer, config SpeedConfig
 	return s
 }
 
+// NewDefaultSpeed returns Speed with the standard 2-player setup (1 human, 1 CPU)
+// and DefaultSpeedConfig. Used as the single source of truth for CUI, Web, and Worker
+// construction sites.
+func NewDefaultSpeed() *Speed {
+	players := []*SpeedPlayer{
+		NewSpeedPlayer(true),
+		NewSpeedPlayer(false),
+	}
+	return NewSpeed(NewTrumpCards(0), players, DefaultSpeedConfig())
+}
+
 // Reset ゲームをリセットして新しいゲームを開始する
 func (s *Speed) Reset() {
 	s.phase = SpeedPhasePlay

--- a/internal/domain/Spider.go
+++ b/internal/domain/Spider.go
@@ -75,6 +75,13 @@ func NewSpider(trumpCards *TrumpCards) *Spider {
 	}
 }
 
+// NewDefaultSpider returns Spider with the 1-suit difficulty using the
+// standard Spider card count (104 spade cards).
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultSpider() *Spider {
+	return NewSpider(NewTrumpCardsWithSuits(SpiderTotalCards, []int{CardDesignSpade}))
+}
+
 // ResetWithConfig 設定付きリセット
 func (s *Spider) ResetWithConfig(cfg SpiderConfig) {
 	switch cfg.Difficulty {

--- a/internal/domain/TriPeaks.go
+++ b/internal/domain/TriPeaks.go
@@ -113,6 +113,12 @@ func NewTriPeaks(trumpCards *TrumpCards) *TriPeaks {
 	}
 }
 
+// NewDefaultTriPeaks returns TriPeaks with a standard single 52-card deck.
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultTriPeaks() *TriPeaks {
+	return NewTriPeaks(NewTrumpCards(0))
+}
+
 // Reset ゲームリセット
 func (t *TriPeaks) Reset() {
 	t.trumpCards.Shuffle()

--- a/internal/domain/TwoTenJack.go
+++ b/internal/domain/TwoTenJack.go
@@ -80,6 +80,19 @@ func NewTwoTenJack(trumpCards *TrumpCards, players []*TwoTenJackPlayer, config T
 	}
 }
 
+// NewDefaultTwoTenJack returns TwoTenJack with the standard 4-player setup (1 human, 3 CPU)
+// and DefaultTwoTenJackConfig. Used as the single source of truth for CUI, Web, and Worker
+// construction sites.
+func NewDefaultTwoTenJack() *TwoTenJack {
+	players := []*TwoTenJackPlayer{
+		NewTwoTenJackPlayer(true),
+		NewTwoTenJackPlayer(false),
+		NewTwoTenJackPlayer(false),
+		NewTwoTenJackPlayer(false),
+	}
+	return NewTwoTenJack(NewTrumpCards(0), players, DefaultTwoTenJackConfig())
+}
+
 // Reset ゲーム初期化
 func (t *TwoTenJack) Reset() {
 	t.gameEndFlag = false

--- a/internal/domain/War.go
+++ b/internal/domain/War.go
@@ -69,6 +69,17 @@ func NewWar(trumpCards *TrumpCards, players []*WarPlayer, config WarConfig) *War
 	return w
 }
 
+// NewDefaultWar returns War with the standard 2-player setup (1 human, 1 CPU)
+// and DefaultWarConfig. Used as the single source of truth for CUI, Web, and Worker
+// construction sites.
+func NewDefaultWar() *War {
+	players := []*WarPlayer{
+		NewWarPlayer(true),
+		NewWarPlayer(false),
+	}
+	return NewWar(NewTrumpCards(0), players, DefaultWarConfig())
+}
+
 // Reset ゲームをリセットして新しいゲームを開始する
 func (w *War) Reset() {
 	w.phase = WarPhaseReveal

--- a/internal/domain/Whist.go
+++ b/internal/domain/Whist.go
@@ -70,6 +70,19 @@ func NewWhist(trumpCards *TrumpCards, players []*WhistPlayer, config WhistConfig
 	}
 }
 
+// NewDefaultWhist returns Whist with the standard 4-player team setup
+// (human team 0, alternating CPU teams) and DefaultWhistConfig.
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultWhist() *Whist {
+	players := []*WhistPlayer{
+		NewWhistPlayer(true, 0),
+		NewWhistPlayer(false, 1),
+		NewWhistPlayer(false, 0),
+		NewWhistPlayer(false, 1),
+	}
+	return NewWhist(NewTrumpCards(0), players, DefaultWhistConfig())
+}
+
 // Reset ゲーム初期化
 func (w *Whist) Reset() {
 	w.gameEndFlag = false

--- a/internal/domain/Yukon.go
+++ b/internal/domain/Yukon.go
@@ -61,6 +61,12 @@ func NewYukon(trumpCards *TrumpCards) *Yukon {
 	}
 }
 
+// NewDefaultYukon returns Yukon with a standard single 52-card deck.
+// Used as the single source of truth for CUI, Web, and Worker construction sites.
+func NewDefaultYukon() *Yukon {
+	return NewYukon(NewTrumpCards(0))
+}
+
 // Reset ゲームリセット
 func (y *Yukon) Reset() {
 	y.trumpCards.Shuffle()

--- a/internal/infrastructure/ui/BridgeCui.go
+++ b/internal/infrastructure/ui/BridgeCui.go
@@ -9,15 +9,7 @@ import (
 
 // NewBridgeCui コンストラクタ
 func NewBridgeCui() *genericCuiGame {
-	config := domain.DefaultBridgeConfig()
-	players := []*domain.BridgePlayer{
-		domain.NewBridgePlayer(true, 0),  // North (human, team 0)
-		domain.NewBridgePlayer(false, 1), // East (CPU, team 1)
-		domain.NewBridgePlayer(false, 0), // South (CPU, team 0)
-		domain.NewBridgePlayer(false, 1), // West (CPU, team 1)
-	}
-	bridge := domain.NewBridge(domain.NewTrumpCards(0), players, config)
-	bc := controller.NewBridgeCuiController(usecase.NewBridgeInteractor(bridge, new(presenter.BridgeCuiPresenter)))
+	bc := controller.NewBridgeCuiController(usecase.NewBridgeInteractor(domain.NewDefaultBridge(), new(presenter.BridgeCuiPresenter)))
 	return newCuiGame(bc, []string{
 		"=== Contract Bridge ===",
 		"",

--- a/internal/infrastructure/ui/CanastaCui.go
+++ b/internal/infrastructure/ui/CanastaCui.go
@@ -9,13 +9,7 @@ import (
 
 // NewCanastaCui コンストラクタ
 func NewCanastaCui() *genericCuiGame {
-	config := domain.DefaultCanastaConfig()
-	players := []*domain.CanastaPlayer{
-		domain.NewCanastaPlayer(true),
-		domain.NewCanastaPlayer(false),
-	}
-	canasta := domain.NewCanasta(domain.NewTrumpCardsWithDecks(2, 4), players, config)
-	cc := controller.NewCanastaCuiController(usecase.NewCanastaInteractor(canasta, new(presenter.CanastaCuiPresenter)))
+	cc := controller.NewCanastaCuiController(usecase.NewCanastaInteractor(domain.NewDefaultCanasta(), new(presenter.CanastaCuiPresenter)))
 	return newCuiGame(cc, []string{
 		"Canasta (カナスタ) Help",
 		"",

--- a/internal/infrastructure/ui/CanfieldCui.go
+++ b/internal/infrastructure/ui/CanfieldCui.go
@@ -9,8 +9,7 @@ import (
 
 // NewCanfieldCui コンストラクタ
 func NewCanfieldCui() *genericCuiGame {
-	canfield := domain.NewCanfield(domain.NewTrumpCards(0))
-	cc := controller.NewCanfieldCuiController(usecase.NewCanfieldInteractor(canfield, new(presenter.CanfieldCuiPresenter)))
+	cc := controller.NewCanfieldCuiController(usecase.NewCanfieldInteractor(domain.NewDefaultCanfield(), new(presenter.CanfieldCuiPresenter)))
 	return newCuiGame(cc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "canfield.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/ClockSolitaireCui.go
+++ b/internal/infrastructure/ui/ClockSolitaireCui.go
@@ -9,8 +9,7 @@ import (
 
 // NewClockSolitaireCui コンストラクタ
 func NewClockSolitaireCui() *genericCuiGame {
-	cs := domain.NewClockSolitaire(domain.NewTrumpCards(0))
-	cc := controller.NewClockSolitaireCuiController(usecase.NewClockSolitaireInteractor(cs, new(presenter.ClockSolitaireCuiPresenter)))
+	cc := controller.NewClockSolitaireCuiController(usecase.NewClockSolitaireInteractor(domain.NewDefaultClockSolitaire(), new(presenter.ClockSolitaireCuiPresenter)))
 	return newCuiGame(cc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey:          "clocksolitaire.helpTitle",
 		CommandKeys:       []string{"clocksolitaire.helpStep", "clocksolitaire.helpAutoPlay"},

--- a/internal/infrastructure/ui/CribbageCui.go
+++ b/internal/infrastructure/ui/CribbageCui.go
@@ -9,13 +9,7 @@ import (
 
 // NewCribbageCui コンストラクタ
 func NewCribbageCui() *genericCuiGame {
-	config := domain.DefaultCribbageConfig()
-	players := []*domain.CribbagePlayer{
-		domain.NewCribbagePlayer(true),
-		domain.NewCribbagePlayer(false),
-	}
-	g := domain.NewCribbage(domain.NewTrumpCards(0), players, config)
-	cc := controller.NewCribbageCuiController(usecase.NewCribbageInteractor(g, new(presenter.CribbageCuiPresenter)))
+	cc := controller.NewCribbageCuiController(usecase.NewCribbageInteractor(domain.NewDefaultCribbage(), new(presenter.CribbageCuiPresenter)))
 	return newCuiGame(cc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey:          "cribbage.helpTitle",
 		CommandKeys:       []string{"cribbage.helpDiscard", "cribbage.helpPeg", "cribbage.helpGo", "cribbage.helpShowNext", "cribbage.helpNextRound"},

--- a/internal/infrastructure/ui/DaifugoCui.go
+++ b/internal/infrastructure/ui/DaifugoCui.go
@@ -9,16 +9,8 @@ import (
 
 // NewDaifugoCui コンストラクタ
 func NewDaifugoCui() *genericCuiGame {
-	config := domain.DefaultDaifugoConfig()
-	players := []*domain.DaifugoPlayer{
-		domain.NewDaifugoPlayer(true),
-		domain.NewDaifugoPlayer(false),
-		domain.NewDaifugoPlayer(false),
-		domain.NewDaifugoPlayer(false),
-	}
-	daifugo := domain.NewDaifugo(domain.NewTrumpCards(config.JokerCount), players, config)
 	dgc := controller.NewDaifugoCuiController(
-		usecase.NewDaifugoInteractor(daifugo, new(presenter.DaifugoCuiPresenter)),
+		usecase.NewDaifugoInteractor(domain.NewDefaultDaifugo(), new(presenter.DaifugoCuiPresenter)),
 	)
 	return newCuiGame(dgc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey:    "daifugo.helpTitle",

--- a/internal/infrastructure/ui/DoubtCui.go
+++ b/internal/infrastructure/ui/DoubtCui.go
@@ -24,13 +24,7 @@ type DoubtCui struct {
 
 // NewDoubtCui コンストラクタ
 func NewDoubtCui() *DoubtCui {
-	players := []*domain.DoubtPlayer{
-		domain.NewDoubtPlayer(true),
-		domain.NewDoubtPlayer(false),
-		domain.NewDoubtPlayer(false),
-		domain.NewDoubtPlayer(false),
-	}
-	game := domain.NewDoubt(domain.NewTrumpCards(0), players)
+	game := domain.NewDefaultDoubt()
 	dc := controller.NewDoubtCuiController(
 		usecase.NewDoubtInteractor(game, new(presenter.DoubtCuiPresenter)),
 	)

--- a/internal/infrastructure/ui/DurakCui.go
+++ b/internal/infrastructure/ui/DurakCui.go
@@ -10,15 +10,8 @@ import (
 
 // NewDurakCui コンストラクタ
 func NewDurakCui() *genericCuiGame {
-	players := []*domain.DurakPlayer{
-		domain.NewDurakPlayer(true),
-		domain.NewDurakPlayer(false),
-		domain.NewDurakPlayer(false),
-		domain.NewDurakPlayer(false),
-	}
-	durak := domain.NewDurak(domain.NewTrumpCardsShortDeck(), players)
 	dc := controller.NewDurakCuiController(
-		usecase.NewDurakInteractor(durak, new(presenter.DurakCuiPresenter)),
+		usecase.NewDurakInteractor(domain.NewDefaultDurak(), new(presenter.DurakCuiPresenter)),
 	)
 	return newCuiGame(dc, []string{
 		i18n.T("durak.helpTitle"),

--- a/internal/infrastructure/ui/EuchreCui.go
+++ b/internal/infrastructure/ui/EuchreCui.go
@@ -9,15 +9,7 @@ import (
 
 // NewEuchreCui コンストラクタ
 func NewEuchreCui() *genericCuiGame {
-	config := domain.DefaultEuchreConfig()
-	players := []*domain.EuchrePlayer{
-		domain.NewEuchrePlayer(true, 0),
-		domain.NewEuchrePlayer(false, 1),
-		domain.NewEuchrePlayer(false, 0),
-		domain.NewEuchrePlayer(false, 1),
-	}
-	euchre := domain.NewEuchre(domain.NewTrumpCardsEuchre(), players, config)
-	ec := controller.NewEuchreCuiController(usecase.NewEuchreInteractor(euchre, new(presenter.EuchreCuiPresenter)))
+	ec := controller.NewEuchreCuiController(usecase.NewEuchreInteractor(domain.NewDefaultEuchre(), new(presenter.EuchreCuiPresenter)))
 	return newCuiGame(ec, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "euchre.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/FiftyOneCui.go
+++ b/internal/infrastructure/ui/FiftyOneCui.go
@@ -9,15 +9,8 @@ import (
 
 // NewFiftyOneCui コンストラクタ
 func NewFiftyOneCui() *genericCuiGame {
-	players := []*domain.FiftyOnePlayer{
-		domain.NewFiftyOnePlayer(true),
-		domain.NewFiftyOnePlayer(false),
-		domain.NewFiftyOnePlayer(false),
-		domain.NewFiftyOnePlayer(false),
-	}
-	fo := domain.NewFiftyOne(domain.NewTrumpCards(0), players)
 	foc := controller.NewFiftyOneCuiController(
-		usecase.NewFiftyOneInteractor(fo, new(presenter.FiftyOneCuiPresenter)),
+		usecase.NewFiftyOneInteractor(domain.NewDefaultFiftyOne(), new(presenter.FiftyOneCuiPresenter)),
 	)
 	return newCuiGame(foc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey:    "fiftyone.helpTitle",

--- a/internal/infrastructure/ui/FortyThievesCui.go
+++ b/internal/infrastructure/ui/FortyThievesCui.go
@@ -9,8 +9,7 @@ import (
 
 // NewFortyThievesCui コンストラクタ
 func NewFortyThievesCui() *genericCuiGame {
-	fortythieves := domain.NewFortyThieves(domain.NewTrumpCardsWithDecks(2, 0))
-	fc := controller.NewFortyThievesCuiController(usecase.NewFortyThievesInteractor(fortythieves, new(presenter.FortyThievesCuiPresenter)))
+	fc := controller.NewFortyThievesCuiController(usecase.NewFortyThievesInteractor(domain.NewDefaultFortyThieves(), new(presenter.FortyThievesCuiPresenter)))
 	return newCuiGame(fc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "fortythieves.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/FreeCellCui.go
+++ b/internal/infrastructure/ui/FreeCellCui.go
@@ -9,8 +9,7 @@ import (
 
 // NewFreeCellCui コンストラクタ
 func NewFreeCellCui() *genericCuiGame {
-	freeCell := domain.NewFreeCell(domain.NewTrumpCards(0))
-	fc := controller.NewFreeCellCuiController(usecase.NewFreeCellInteractor(freeCell, new(presenter.FreeCellCuiPresenter)))
+	fc := controller.NewFreeCellCuiController(usecase.NewFreeCellInteractor(domain.NewDefaultFreeCell(), new(presenter.FreeCellCuiPresenter)))
 	return newCuiGame(fc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "freecell.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/GinRummyCui.go
+++ b/internal/infrastructure/ui/GinRummyCui.go
@@ -9,13 +9,7 @@ import (
 
 // NewGinRummyCui コンストラクタ
 func NewGinRummyCui() *genericCuiGame {
-	config := domain.DefaultGinRummyConfig()
-	players := []*domain.GinRummyPlayer{
-		domain.NewGinRummyPlayer(true),
-		domain.NewGinRummyPlayer(false),
-	}
-	gr := domain.NewGinRummy(domain.NewTrumpCards(0), players, config)
-	cc := controller.NewGinRummyCuiController(usecase.NewGinRummyInteractor(gr, new(presenter.GinRummyCuiPresenter)))
+	cc := controller.NewGinRummyCuiController(usecase.NewGinRummyInteractor(domain.NewDefaultGinRummy(), new(presenter.GinRummyCuiPresenter)))
 	return newCuiGame(cc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "ginrummy.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/GoFishCui.go
+++ b/internal/infrastructure/ui/GoFishCui.go
@@ -9,15 +9,8 @@ import (
 
 // NewGoFishCui コンストラクタ
 func NewGoFishCui() *genericCuiGame {
-	players := []*domain.GoFishPlayer{
-		domain.NewGoFishPlayer(true),
-		domain.NewGoFishPlayer(false),
-		domain.NewGoFishPlayer(false),
-		domain.NewGoFishPlayer(false),
-	}
-	goFish := domain.NewGoFish(domain.NewTrumpCards(0), players)
 	gfc := controller.NewGoFishCuiController(
-		usecase.NewGoFishInteractor(goFish, new(presenter.GoFishCuiPresenter)),
+		usecase.NewGoFishInteractor(domain.NewDefaultGoFish(), new(presenter.GoFishCuiPresenter)),
 	)
 	return newCuiGame(gfc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey:    "gofish.helpTitle",

--- a/internal/infrastructure/ui/GolfCui.go
+++ b/internal/infrastructure/ui/GolfCui.go
@@ -9,8 +9,7 @@ import (
 
 // NewGolfCui コンストラクタ
 func NewGolfCui() *genericCuiGame {
-	golf := domain.NewGolf(domain.NewTrumpCards(0))
-	gc := controller.NewGolfCuiController(usecase.NewGolfInteractor(golf, new(presenter.GolfCuiPresenter)))
+	gc := controller.NewGolfCuiController(usecase.NewGolfInteractor(domain.NewDefaultGolf(), new(presenter.GolfCuiPresenter)))
 	return newCuiGame(gc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey:          "golf.helpTitle",
 		CommandKeys:       []string{"golf.helpDraw", "golf.helpRemove", "golf.helpGiveUp", "golf.helpHint"},

--- a/internal/infrastructure/ui/HoldemCui.go
+++ b/internal/infrastructure/ui/HoldemCui.go
@@ -9,9 +9,7 @@ import (
 
 // NewHoldemCui コンストラクタ
 func NewHoldemCui() *genericCuiGame {
-	cfg := domain.DefaultHoldemConfig()
-	holdem := domain.NewHoldem(domain.NewTrumpCards(0), domain.NewPlayersForTable(cfg.TableSize), cfg)
-	hc := controller.NewHoldemCuiController(usecase.NewHoldemInteractor(holdem, new(presenter.HoldemCuiPresenter)))
+	hc := controller.NewHoldemCuiController(usecase.NewHoldemInteractor(domain.NewDefaultHoldem(), new(presenter.HoldemCuiPresenter)))
 	return newCuiGame(hc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "holdem.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/IndianPokerCui.go
+++ b/internal/infrastructure/ui/IndianPokerCui.go
@@ -9,9 +9,7 @@ import (
 
 // NewIndianPokerCui コンストラクタ
 func NewIndianPokerCui() *genericCuiGame {
-	cfg := domain.DefaultIndianPokerConfig()
-	ip := domain.NewIndianPoker(domain.NewTrumpCards(0), domain.NewIndianPokerPlayers(), cfg)
-	ipc := controller.NewIndianPokerCuiController(usecase.NewIndianPokerInteractor(ip, new(presenter.IndianPokerCuiPresenter)))
+	ipc := controller.NewIndianPokerCuiController(usecase.NewIndianPokerInteractor(domain.NewDefaultIndianPoker(), new(presenter.IndianPokerCuiPresenter)))
 	return newCuiGame(ipc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "indianpoker.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/KlondikeCui.go
+++ b/internal/infrastructure/ui/KlondikeCui.go
@@ -9,8 +9,7 @@ import (
 
 // NewKlondikeCui コンストラクタ
 func NewKlondikeCui() *genericCuiGame {
-	klondike := domain.NewKlondike(domain.NewTrumpCards(0))
-	kc := controller.NewKlondikeCuiController(usecase.NewKlondikeInteractor(klondike, new(presenter.KlondikeCuiPresenter)))
+	kc := controller.NewKlondikeCuiController(usecase.NewKlondikeInteractor(domain.NewDefaultKlondike(), new(presenter.KlondikeCuiPresenter)))
 	return newCuiGame(kc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "klondike.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/NapoleonCui.go
+++ b/internal/infrastructure/ui/NapoleonCui.go
@@ -9,15 +9,7 @@ import (
 
 // NewNapoleonCui コンストラクタ
 func NewNapoleonCui() *genericCuiGame {
-	config := domain.DefaultNapoleonConfig()
-	players := []*domain.NapoleonPlayer{
-		domain.NewNapoleonPlayer(true),
-		domain.NewNapoleonPlayer(false),
-		domain.NewNapoleonPlayer(false),
-		domain.NewNapoleonPlayer(false),
-	}
-	napoleon := domain.NewNapoleon(domain.NewTrumpCards(1), players, config)
-	nc := controller.NewNapoleonCuiController(usecase.NewNapoleonInteractor(napoleon, new(presenter.NapoleonCuiPresenter)))
+	nc := controller.NewNapoleonCuiController(usecase.NewNapoleonInteractor(domain.NewDefaultNapoleon(), new(presenter.NapoleonCuiPresenter)))
 	return newCuiGame(nc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "napoleon.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/OldMaidCui.go
+++ b/internal/infrastructure/ui/OldMaidCui.go
@@ -9,15 +9,8 @@ import (
 
 // NewOldMaidCui コンストラクタ
 func NewOldMaidCui() *genericCuiGame {
-	players := []*domain.OldMaidPlayer{
-		domain.NewOldMaidPlayer(true),
-		domain.NewOldMaidPlayer(false),
-		domain.NewOldMaidPlayer(false),
-		domain.NewOldMaidPlayer(false),
-	}
-	oldMaid := domain.NewOldMaid(domain.NewTrumpCards(1), players)
 	omc := controller.NewOldMaidCuiController(
-		usecase.NewOldMaidInteractor(oldMaid, new(presenter.OldMaidCuiPresenter)),
+		usecase.NewOldMaidInteractor(domain.NewDefaultOldMaid(), new(presenter.OldMaidCuiPresenter)),
 	)
 	return newCuiGame(omc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey:    "oldmaid.helpTitle",

--- a/internal/infrastructure/ui/OmahaCui.go
+++ b/internal/infrastructure/ui/OmahaCui.go
@@ -9,9 +9,7 @@ import (
 
 // NewOmahaCui コンストラクタ
 func NewOmahaCui() *genericCuiGame {
-	cfg := domain.DefaultOmahaConfig()
-	omaha := domain.NewOmaha(domain.NewTrumpCards(0), domain.NewOmahaPlayersForTable(cfg.TableSize), cfg)
-	oc := controller.NewOmahaCuiController(usecase.NewOmahaInteractor(omaha, new(presenter.OmahaCuiPresenter)))
+	oc := controller.NewOmahaCuiController(usecase.NewOmahaInteractor(domain.NewDefaultOmaha(), new(presenter.OmahaCuiPresenter)))
 	return newCuiGame(oc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "omaha.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/PageOneCui.go
+++ b/internal/infrastructure/ui/PageOneCui.go
@@ -9,15 +9,7 @@ import (
 
 // NewPageOneCui コンストラクタ
 func NewPageOneCui() *genericCuiGame {
-	config := domain.DefaultPageOneConfig()
-	players := []*domain.PageOnePlayer{
-		domain.NewPageOnePlayer(true),
-		domain.NewPageOnePlayer(false),
-		domain.NewPageOnePlayer(false),
-		domain.NewPageOnePlayer(false),
-	}
-	po := domain.NewPageOne(domain.NewTrumpCards(0), players, config)
-	cc := controller.NewPageOneCuiController(usecase.NewPageOneInteractor(po, new(presenter.PageOneCuiPresenter)))
+	cc := controller.NewPageOneCuiController(usecase.NewPageOneInteractor(domain.NewDefaultPageOne(), new(presenter.PageOneCuiPresenter)))
 	return newCuiGame(cc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "pageone.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/PigsTailCui.go
+++ b/internal/infrastructure/ui/PigsTailCui.go
@@ -9,15 +9,8 @@ import (
 
 // NewPigsTailCui コンストラクタ
 func NewPigsTailCui() *genericCuiGame {
-	players := []*domain.PigsTailPlayer{
-		domain.NewPigsTailPlayer(true),
-		domain.NewPigsTailPlayer(false),
-		domain.NewPigsTailPlayer(false),
-		domain.NewPigsTailPlayer(false),
-	}
-	pigsTail := domain.NewPigsTail(domain.NewTrumpCards(0), players)
 	ptc := controller.NewPigsTailCuiController(
-		usecase.NewPigsTailInteractor(pigsTail, new(presenter.PigsTailCuiPresenter)),
+		usecase.NewPigsTailInteractor(domain.NewDefaultPigsTail(), new(presenter.PigsTailCuiPresenter)),
 	)
 	return newCuiGame(ptc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey:    "pigtail.helpTitle",

--- a/internal/infrastructure/ui/PineappleCui.go
+++ b/internal/infrastructure/ui/PineappleCui.go
@@ -9,9 +9,7 @@ import (
 
 // NewPineappleCui コンストラクタ
 func NewPineappleCui() *genericCuiGame {
-	cfg := domain.DefaultPineappleConfig()
-	pineapple := domain.NewPineapple(domain.NewTrumpCards(0), domain.NewPineapplePlayersForTable(cfg.TableSize), cfg)
-	pc := controller.NewPineappleCuiController(usecase.NewPineappleInteractor(pineapple, new(presenter.PineappleCuiPresenter)))
+	pc := controller.NewPineappleCuiController(usecase.NewPineappleInteractor(domain.NewDefaultPineapple(), new(presenter.PineappleCuiPresenter)))
 	return newCuiGame(pc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "pineapple.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/PinochleCui.go
+++ b/internal/infrastructure/ui/PinochleCui.go
@@ -9,15 +9,7 @@ import (
 
 // NewPinochleCui コンストラクタ
 func NewPinochleCui() *genericCuiGame {
-	config := domain.DefaultPinochleConfig()
-	players := []*domain.PinochlePlayer{
-		domain.NewPinochlePlayer(true, 0),
-		domain.NewPinochlePlayer(false, 1),
-		domain.NewPinochlePlayer(false, 0),
-		domain.NewPinochlePlayer(false, 1),
-	}
-	pinochle := domain.NewPinochle(domain.NewTrumpCardsPinochle(), players, config)
-	pc := controller.NewPinochleCuiController(usecase.NewPinochleInteractor(pinochle, new(presenter.PinochleCuiPresenter)))
+	pc := controller.NewPinochleCuiController(usecase.NewPinochleInteractor(domain.NewDefaultPinochle(), new(presenter.PinochleCuiPresenter)))
 	return newCuiGame(pc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "pinochle.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/PokerCui.go
+++ b/internal/infrastructure/ui/PokerCui.go
@@ -9,15 +9,7 @@ import (
 
 // NewPokerCui コンストラクタ
 func NewPokerCui() *genericCuiGame {
-	config := domain.DefaultPokerConfig()
-	players := []*domain.PokerPlayer{
-		domain.NewPokerPlayer(true, domain.PokerStyleBalanced),
-		domain.NewPokerPlayer(false, domain.PokerStyleConservative),
-		domain.NewPokerPlayer(false, domain.PokerStyleAggressive),
-		domain.NewPokerPlayer(false, domain.PokerStyleBluffer),
-	}
-	poker := domain.NewPoker(domain.NewTrumpCards(config.JokerCount), players, config)
-	pc := controller.NewPokerCuiController(usecase.NewPokerInteractor(poker, new(presenter.PokerCuiPresenter)))
+	pc := controller.NewPokerCuiController(usecase.NewPokerInteractor(domain.NewDefaultPoker(), new(presenter.PokerCuiPresenter)))
 	return newCuiGame(pc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "poker.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/PokerSquaresCui.go
+++ b/internal/infrastructure/ui/PokerSquaresCui.go
@@ -10,8 +10,7 @@ import (
 
 // NewPokerSquaresCui はコンストラクタ。
 func NewPokerSquaresCui() *genericCuiGame {
-	ps := domain.NewPokerSquares(domain.NewTrumpCards(0))
-	pc := controller.NewPokerSquaresCuiController(usecase.NewPokerSquaresInteractor(ps, new(presenter.PokerSquaresCuiPresenter)))
+	pc := controller.NewPokerSquaresCuiController(usecase.NewPokerSquaresInteractor(domain.NewDefaultPokerSquares(), new(presenter.PokerSquaresCuiPresenter)))
 	return newCuiGame(pc, []string{
 		"Poker Squares (ポーカー・スクエアズ)",
 		"",

--- a/internal/infrastructure/ui/PyramidCui.go
+++ b/internal/infrastructure/ui/PyramidCui.go
@@ -9,8 +9,7 @@ import (
 
 // NewPyramidCui コンストラクタ
 func NewPyramidCui() *genericCuiGame {
-	pyramid := domain.NewPyramid(domain.NewTrumpCards(0))
-	pc := controller.NewPyramidCuiController(usecase.NewPyramidInteractor(pyramid, new(presenter.PyramidCuiPresenter)))
+	pc := controller.NewPyramidCuiController(usecase.NewPyramidInteractor(domain.NewDefaultPyramid(), new(presenter.PyramidCuiPresenter)))
 	return newCuiGame(pc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "pyramid.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/RazzCui.go
+++ b/internal/infrastructure/ui/RazzCui.go
@@ -9,9 +9,7 @@ import (
 
 // NewRazzCui コンストラクタ
 func NewRazzCui() *genericCuiGame {
-	cfg := domain.DefaultRazzConfig()
-	r := domain.NewRazz(domain.NewTrumpCards(0), domain.NewSevenCardStudPlayersForTable(cfg.TableSize), cfg)
-	sc := controller.NewSevenCardStudCuiController(usecase.NewSevenCardStudInteractor(r, new(presenter.SevenCardStudCuiPresenter)))
+	sc := controller.NewSevenCardStudCuiController(usecase.NewSevenCardStudInteractor(domain.NewDefaultRazz(), new(presenter.SevenCardStudCuiPresenter)))
 	return newCuiGame(sc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "razz.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/ScorpionCui.go
+++ b/internal/infrastructure/ui/ScorpionCui.go
@@ -9,8 +9,7 @@ import (
 
 // NewScorpionCui コンストラクタ
 func NewScorpionCui() *genericCuiGame {
-	scorpion := domain.NewScorpion(domain.NewTrumpCards(0))
-	sc := controller.NewScorpionCuiController(usecase.NewScorpionInteractor(scorpion, new(presenter.ScorpionCuiPresenter)))
+	sc := controller.NewScorpionCuiController(usecase.NewScorpionInteractor(domain.NewDefaultScorpion(), new(presenter.ScorpionCuiPresenter)))
 	return newCuiGame(sc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "scorpion.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/SevenCardStudCui.go
+++ b/internal/infrastructure/ui/SevenCardStudCui.go
@@ -9,9 +9,7 @@ import (
 
 // NewSevenCardStudCui コンストラクタ
 func NewSevenCardStudCui() *genericCuiGame {
-	cfg := domain.DefaultSevenCardStudConfig()
-	scs := domain.NewSevenCardStud(domain.NewTrumpCards(0), domain.NewSevenCardStudPlayersForTable(cfg.TableSize), cfg)
-	sc := controller.NewSevenCardStudCuiController(usecase.NewSevenCardStudInteractor(scs, new(presenter.SevenCardStudCuiPresenter)))
+	sc := controller.NewSevenCardStudCuiController(usecase.NewSevenCardStudInteractor(domain.NewDefaultSevenCardStud(), new(presenter.SevenCardStudCuiPresenter)))
 	return newCuiGame(sc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "sevencardstud.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/SevensCui.go
+++ b/internal/infrastructure/ui/SevensCui.go
@@ -10,16 +10,8 @@ import (
 
 // NewSevensCui コンストラクタ
 func NewSevensCui() *genericCuiGame {
-	config := domain.DefaultSevensConfig()
-	players := []*domain.SevensPlayer{
-		domain.NewSevensPlayer(true),
-		domain.NewSevensPlayer(false),
-		domain.NewSevensPlayer(false),
-		domain.NewSevensPlayer(false),
-	}
-	sevens := domain.NewSevens(domain.NewTrumpCards(config.JokerCount), players, config)
 	sgc := controller.NewSevensCuiController(
-		usecase.NewSevensInteractor(sevens, new(presenter.SevensCuiPresenter)),
+		usecase.NewSevensInteractor(domain.NewDefaultSevens(), new(presenter.SevensCuiPresenter)),
 	)
 	return newCuiGame(sgc, []string{
 		i18n.T("sevens.helpTitle"),

--- a/internal/infrastructure/ui/ShortDeckCui.go
+++ b/internal/infrastructure/ui/ShortDeckCui.go
@@ -9,9 +9,7 @@ import (
 
 // NewShortDeckCui コンストラクタ
 func NewShortDeckCui() *genericCuiGame {
-	cfg := domain.DefaultShortDeckConfig()
-	sd := domain.NewShortDeck(domain.NewTrumpCardsShortDeck(), domain.NewShortDeckPlayersForTable(cfg.TableSize), cfg)
-	sc := controller.NewShortDeckCuiController(usecase.NewShortDeckInteractor(sd, new(presenter.ShortDeckCuiPresenter)))
+	sc := controller.NewShortDeckCuiController(usecase.NewShortDeckInteractor(domain.NewDefaultShortDeck(), new(presenter.ShortDeckCuiPresenter)))
 	return newCuiGame(sc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "shortdeck.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/SpeedCui.go
+++ b/internal/infrastructure/ui/SpeedCui.go
@@ -9,14 +9,8 @@ import (
 
 // NewSpeedCui コンストラクタ
 func NewSpeedCui() *genericCuiGame {
-	players := []*domain.SpeedPlayer{
-		domain.NewSpeedPlayer(true),
-		domain.NewSpeedPlayer(false),
-	}
-	config := domain.DefaultSpeedConfig()
-	game := domain.NewSpeed(domain.NewTrumpCards(0), players, config)
 	sc := controller.NewSpeedCuiController(
-		usecase.NewSpeedInteractor(game, new(presenter.SpeedCuiPresenter)),
+		usecase.NewSpeedInteractor(domain.NewDefaultSpeed(), new(presenter.SpeedCuiPresenter)),
 	)
 	return newCuiGame(sc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey:    "speed.helpTitle",

--- a/internal/infrastructure/ui/SpiderCui.go
+++ b/internal/infrastructure/ui/SpiderCui.go
@@ -9,8 +9,7 @@ import (
 
 // NewSpiderCui コンストラクタ
 func NewSpiderCui() *genericCuiGame {
-	spider := domain.NewSpider(domain.NewTrumpCardsWithSuits(domain.SpiderTotalCards, []int{domain.CardDesignSpade}))
-	sc := controller.NewSpiderCuiController(usecase.NewSpiderInteractor(spider, new(presenter.SpiderCuiPresenter)))
+	sc := controller.NewSpiderCuiController(usecase.NewSpiderInteractor(domain.NewDefaultSpider(), new(presenter.SpiderCuiPresenter)))
 	return newCuiGame(sc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "spider.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/TriPeaksCui.go
+++ b/internal/infrastructure/ui/TriPeaksCui.go
@@ -9,8 +9,7 @@ import (
 
 // NewTriPeaksCui コンストラクタ
 func NewTriPeaksCui() *genericCuiGame {
-	triPeaks := domain.NewTriPeaks(domain.NewTrumpCards(0))
-	tc := controller.NewTriPeaksCuiController(usecase.NewTriPeaksInteractor(triPeaks, new(presenter.TriPeaksCuiPresenter)))
+	tc := controller.NewTriPeaksCuiController(usecase.NewTriPeaksInteractor(domain.NewDefaultTriPeaks(), new(presenter.TriPeaksCuiPresenter)))
 	return newCuiGame(tc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "tripeaks.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/TwoTenJackCui.go
+++ b/internal/infrastructure/ui/TwoTenJackCui.go
@@ -9,15 +9,7 @@ import (
 
 // NewTwoTenJackCui コンストラクタ
 func NewTwoTenJackCui() *genericCuiGame {
-	config := domain.DefaultTwoTenJackConfig()
-	players := []*domain.TwoTenJackPlayer{
-		domain.NewTwoTenJackPlayer(true),
-		domain.NewTwoTenJackPlayer(false),
-		domain.NewTwoTenJackPlayer(false),
-		domain.NewTwoTenJackPlayer(false),
-	}
-	ttj := domain.NewTwoTenJack(domain.NewTrumpCards(0), players, config)
-	tc := controller.NewTwoTenJackCuiController(usecase.NewTwoTenJackInteractor(ttj, new(presenter.TwoTenJackCuiPresenter)))
+	tc := controller.NewTwoTenJackCuiController(usecase.NewTwoTenJackInteractor(domain.NewDefaultTwoTenJack(), new(presenter.TwoTenJackCuiPresenter)))
 	return newCuiGame(tc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "twotenjack.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/ui/WarCui.go
+++ b/internal/infrastructure/ui/WarCui.go
@@ -9,14 +9,8 @@ import (
 
 // NewWarCui コンストラクタ
 func NewWarCui() *genericCuiGame {
-	players := []*domain.WarPlayer{
-		domain.NewWarPlayer(true),
-		domain.NewWarPlayer(false),
-	}
-	config := domain.DefaultWarConfig()
-	game := domain.NewWar(domain.NewTrumpCards(0), players, config)
 	wc := controller.NewWarCuiController(
-		usecase.NewWarInteractor(game, new(presenter.WarCuiPresenter)),
+		usecase.NewWarInteractor(domain.NewDefaultWar(), new(presenter.WarCuiPresenter)),
 	)
 	return newCuiGame(wc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey:    "war.helpTitle",

--- a/internal/infrastructure/ui/WhistCui.go
+++ b/internal/infrastructure/ui/WhistCui.go
@@ -9,15 +9,7 @@ import (
 
 // NewWhistCui コンストラクタ
 func NewWhistCui() *genericCuiGame {
-	config := domain.DefaultWhistConfig()
-	players := []*domain.WhistPlayer{
-		domain.NewWhistPlayer(true, 0),
-		domain.NewWhistPlayer(false, 1),
-		domain.NewWhistPlayer(false, 0),
-		domain.NewWhistPlayer(false, 1),
-	}
-	whist := domain.NewWhist(domain.NewTrumpCards(0), players, config)
-	wc := controller.NewWhistCuiController(usecase.NewWhistInteractor(whist, new(presenter.WhistCuiPresenter)))
+	wc := controller.NewWhistCuiController(usecase.NewWhistInteractor(domain.NewDefaultWhist(), new(presenter.WhistCuiPresenter)))
 	return newCuiGame(wc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey:          "whist.helpTitle",
 		CommandKeys:       []string{"whist.helpPlay", "whist.helpNext", "whist.helpNextRound"},

--- a/internal/infrastructure/ui/YukonCui.go
+++ b/internal/infrastructure/ui/YukonCui.go
@@ -9,8 +9,7 @@ import (
 
 // NewYukonCui コンストラクタ
 func NewYukonCui() *genericCuiGame {
-	yukon := domain.NewYukon(domain.NewTrumpCards(0))
-	yc := controller.NewYukonCuiController(usecase.NewYukonInteractor(yukon, new(presenter.YukonCuiPresenter)))
+	yc := controller.NewYukonCuiController(usecase.NewYukonInteractor(domain.NewDefaultYukon(), new(presenter.YukonCuiPresenter)))
 	return newCuiGame(yc, BuildCuiHelp(CuiHelpSpec{
 		TitleKey: "yukon.helpTitle",
 		CommandKeys: []string{

--- a/internal/infrastructure/web/TrumpCardsWeb.go
+++ b/internal/infrastructure/web/TrumpCardsWeb.go
@@ -58,72 +58,28 @@ func (web *TrumpCardsWeb) registerAll() {
 		)
 	}))
 	web.register("poker", controller.NewPokerWebController(func() usecase.PokerInteractorIF {
-		config := domain.DefaultPokerConfig()
-		players := []*domain.PokerPlayer{
-			domain.NewPokerPlayer(true, domain.PokerStyleBalanced),
-			domain.NewPokerPlayer(false, domain.PokerStyleConservative),
-			domain.NewPokerPlayer(false, domain.PokerStyleAggressive),
-			domain.NewPokerPlayer(false, domain.PokerStyleBluffer),
-		}
-		poker := domain.NewPoker(domain.NewTrumpCards(config.JokerCount), players, config)
-		return usecase.NewPokerInteractor(poker, new(presenter.PokerWebPresenter))
+		return usecase.NewPokerInteractor(domain.NewDefaultPoker(), new(presenter.PokerWebPresenter))
 	}))
 	web.register("oldmaid", controller.NewOldMaidWebController(func() usecase.OldMaidInteractorIF {
-		players := []*domain.OldMaidPlayer{
-			domain.NewOldMaidPlayer(true),
-			domain.NewOldMaidPlayer(false),
-			domain.NewOldMaidPlayer(false),
-			domain.NewOldMaidPlayer(false),
-		}
-		oldMaid := domain.NewOldMaid(domain.NewTrumpCards(1), players)
-		return usecase.NewOldMaidInteractor(oldMaid, new(presenter.OldMaidWebPresenter))
+		return usecase.NewOldMaidInteractor(domain.NewDefaultOldMaid(), new(presenter.OldMaidWebPresenter))
 	}))
 	web.register("daifugo", controller.NewDaifugoWebController(func() usecase.DaifugoInteractorIF {
-		config := domain.DefaultDaifugoConfig()
-		players := []*domain.DaifugoPlayer{
-			domain.NewDaifugoPlayer(true),
-			domain.NewDaifugoPlayer(false),
-			domain.NewDaifugoPlayer(false),
-			domain.NewDaifugoPlayer(false),
-		}
-		daifugo := domain.NewDaifugo(domain.NewTrumpCards(config.JokerCount), players, config)
-		return usecase.NewDaifugoInteractor(daifugo, new(presenter.DaifugoWebPresenter))
+		return usecase.NewDaifugoInteractor(domain.NewDefaultDaifugo(), new(presenter.DaifugoWebPresenter))
 	}))
 	web.register("sevens", controller.NewSevensWebController(func() usecase.SevensInteractorIF {
-		config := domain.DefaultSevensConfig()
-		players := []*domain.SevensPlayer{
-			domain.NewSevensPlayer(true),
-			domain.NewSevensPlayer(false),
-			domain.NewSevensPlayer(false),
-			domain.NewSevensPlayer(false),
-		}
-		sevens := domain.NewSevens(domain.NewTrumpCards(config.JokerCount), players, config)
-		return usecase.NewSevensInteractor(sevens, new(presenter.SevensWebPresenter))
+		return usecase.NewSevensInteractor(domain.NewDefaultSevens(), new(presenter.SevensWebPresenter))
 	}))
 	web.register("doubt", controller.NewDoubtWebController(func() usecase.DoubtInteractorIF {
-		players := []*domain.DoubtPlayer{
-			domain.NewDoubtPlayer(true),
-			domain.NewDoubtPlayer(false),
-			domain.NewDoubtPlayer(false),
-			domain.NewDoubtPlayer(false),
-		}
-		doubt := domain.NewDoubt(domain.NewTrumpCards(0), players)
-		return usecase.NewDoubtInteractor(doubt, new(presenter.DoubtWebPresenter))
+		return usecase.NewDoubtInteractor(domain.NewDefaultDoubt(), new(presenter.DoubtWebPresenter))
 	}))
 	web.register("holdem", controller.NewHoldemWebController(func() usecase.HoldemInteractorIF {
-		cfg := domain.DefaultHoldemConfig()
-		holdem := domain.NewHoldem(domain.NewTrumpCards(0), domain.NewPlayersForTable(cfg.TableSize), cfg)
-		return usecase.NewHoldemInteractor(holdem, new(presenter.HoldemWebPresenter))
+		return usecase.NewHoldemInteractor(domain.NewDefaultHoldem(), new(presenter.HoldemWebPresenter))
 	}))
 	web.register("omaha", controller.NewOmahaWebController(func() usecase.OmahaInteractorIF {
-		cfg := domain.DefaultOmahaConfig()
-		omaha := domain.NewOmaha(domain.NewTrumpCards(0), domain.NewOmahaPlayersForTable(cfg.TableSize), cfg)
-		return usecase.NewOmahaInteractor(omaha, new(presenter.OmahaWebPresenter))
+		return usecase.NewOmahaInteractor(domain.NewDefaultOmaha(), new(presenter.OmahaWebPresenter))
 	}))
 	web.register("shortdeck", controller.NewShortDeckWebController(func() usecase.ShortDeckInteractorIF {
-		cfg := domain.DefaultShortDeckConfig()
-		sd := domain.NewShortDeck(domain.NewTrumpCardsShortDeck(), domain.NewShortDeckPlayersForTable(cfg.TableSize), cfg)
-		return usecase.NewShortDeckInteractor(sd, new(presenter.ShortDeckWebPresenter))
+		return usecase.NewShortDeckInteractor(domain.NewDefaultShortDeck(), new(presenter.ShortDeckWebPresenter))
 	}))
 	web.register("hearts", controller.NewHeartsWebController(func() usecase.HeartsInteractorIF {
 		return usecase.NewHeartsInteractor(domain.NewDefaultHearts(), new(presenter.HeartsWebPresenter))
@@ -132,16 +88,13 @@ func (web *TrumpCardsWeb) registerAll() {
 		return usecase.NewMemoryInteractor(domain.NewDefaultMemory(), new(presenter.MemoryWebPresenter))
 	}))
 	web.register("klondike", controller.NewKlondikeWebController(func() usecase.KlondikeInteractorIF {
-		klondike := domain.NewKlondike(domain.NewTrumpCards(0))
-		return usecase.NewKlondikeInteractor(klondike, new(presenter.KlondikeWebPresenter))
+		return usecase.NewKlondikeInteractor(domain.NewDefaultKlondike(), new(presenter.KlondikeWebPresenter))
 	}))
 	web.register("freecell", controller.NewFreeCellWebController(func() usecase.FreeCellInteractorIF {
-		freeCell := domain.NewFreeCell(domain.NewTrumpCards(0))
-		return usecase.NewFreeCellInteractor(freeCell, new(presenter.FreeCellWebPresenter))
+		return usecase.NewFreeCellInteractor(domain.NewDefaultFreeCell(), new(presenter.FreeCellWebPresenter))
 	}))
 	web.register("baccarat", controller.NewBaccaratWebController(func() usecase.BaccaratInteractorIF {
-		baccarat := domain.NewDefaultBaccarat()
-		return usecase.NewBaccaratInteractor(baccarat, new(presenter.BaccaratWebPresenter))
+		return usecase.NewBaccaratInteractor(domain.NewDefaultBaccarat(), new(presenter.BaccaratWebPresenter))
 	}))
 	web.register("spades", controller.NewSpadesWebController(func() usecase.SpadesInteractorIF {
 		return usecase.NewSpadesInteractor(domain.NewDefaultSpades(), new(presenter.SpadesWebPresenter))
@@ -150,33 +103,16 @@ func (web *TrumpCardsWeb) registerAll() {
 		return usecase.NewCrazyEightsInteractor(domain.NewDefaultCrazyEights(), new(presenter.CrazyEightsWebPresenter))
 	}))
 	web.register("ginrummy", controller.NewGinRummyWebController(func() usecase.GinRummyInteractorIF {
-		config := domain.DefaultGinRummyConfig()
-		players := []*domain.GinRummyPlayer{
-			domain.NewGinRummyPlayer(true),
-			domain.NewGinRummyPlayer(false),
-		}
-		gr := domain.NewGinRummy(domain.NewTrumpCards(0), players, config)
-		return usecase.NewGinRummyInteractor(gr, new(presenter.GinRummyWebPresenter))
+		return usecase.NewGinRummyInteractor(domain.NewDefaultGinRummy(), new(presenter.GinRummyWebPresenter))
 	}))
 	web.register("spider", controller.NewSpiderWebController(func() usecase.SpiderInteractorIF {
-		spider := domain.NewSpider(domain.NewTrumpCardsWithSuits(domain.SpiderTotalCards, []int{domain.CardDesignSpade}))
-		return usecase.NewSpiderInteractor(spider, new(presenter.SpiderWebPresenter))
+		return usecase.NewSpiderInteractor(domain.NewDefaultSpider(), new(presenter.SpiderWebPresenter))
 	}))
 	web.register("napoleon", controller.NewNapoleonWebController(func() usecase.NapoleonInteractorIF {
-		config := domain.DefaultNapoleonConfig()
-		players := []*domain.NapoleonPlayer{
-			domain.NewNapoleonPlayer(true),
-			domain.NewNapoleonPlayer(false),
-			domain.NewNapoleonPlayer(false),
-			domain.NewNapoleonPlayer(false),
-		}
-		napoleon := domain.NewNapoleon(domain.NewTrumpCards(1), players, config)
-		return usecase.NewNapoleonInteractor(napoleon, new(presenter.NapoleonWebPresenter))
+		return usecase.NewNapoleonInteractor(domain.NewDefaultNapoleon(), new(presenter.NapoleonWebPresenter))
 	}))
 	web.register("indianpoker", controller.NewIndianPokerWebController(func() usecase.IndianPokerInteractorIF {
-		cfg := domain.DefaultIndianPokerConfig()
-		ip := domain.NewIndianPoker(domain.NewTrumpCards(0), domain.NewIndianPokerPlayers(), cfg)
-		return usecase.NewIndianPokerInteractor(ip, new(presenter.IndianPokerWebPresenter))
+		return usecase.NewIndianPokerInteractor(domain.NewDefaultIndianPoker(), new(presenter.IndianPokerWebPresenter))
 	}))
 	web.register("videopoker", controller.NewVideoPokerWebController(func() usecase.VideoPokerInteractorIF {
 		return usecase.NewVideoPokerInteractor(
@@ -197,32 +133,16 @@ func (web *TrumpCardsWeb) registerAll() {
 		)
 	}))
 	web.register("euchre", controller.NewEuchreWebController(func() usecase.EuchreInteractorIF {
-		config := domain.DefaultEuchreConfig()
-		players := []*domain.EuchrePlayer{
-			domain.NewEuchrePlayer(true, 0),
-			domain.NewEuchrePlayer(false, 1),
-			domain.NewEuchrePlayer(false, 0),
-			domain.NewEuchrePlayer(false, 1),
-		}
-		euchre := domain.NewEuchre(domain.NewTrumpCardsEuchre(), players, config)
-		return usecase.NewEuchreInteractor(euchre, new(presenter.EuchreWebPresenter))
+		return usecase.NewEuchreInteractor(domain.NewDefaultEuchre(), new(presenter.EuchreWebPresenter))
 	}))
 	web.register("pyramid", controller.NewPyramidWebController(func() usecase.PyramidInteractorIF {
-		pyramid := domain.NewPyramid(domain.NewTrumpCards(0))
-		return usecase.NewPyramidInteractor(pyramid, new(presenter.PyramidWebPresenter))
+		return usecase.NewPyramidInteractor(domain.NewDefaultPyramid(), new(presenter.PyramidWebPresenter))
 	}))
 	web.register("tripeaks", controller.NewTriPeaksWebController(func() usecase.TriPeaksInteractorIF {
-		triPeaks := domain.NewTriPeaks(domain.NewTrumpCards(0))
-		return usecase.NewTriPeaksInteractor(triPeaks, new(presenter.TriPeaksWebPresenter))
+		return usecase.NewTriPeaksInteractor(domain.NewDefaultTriPeaks(), new(presenter.TriPeaksWebPresenter))
 	}))
 	web.register("cribbage", controller.NewCribbageWebController(func() usecase.CribbageInteractorIF {
-		config := domain.DefaultCribbageConfig()
-		players := []*domain.CribbagePlayer{
-			domain.NewCribbagePlayer(true),
-			domain.NewCribbagePlayer(false),
-		}
-		cribbage := domain.NewCribbage(domain.NewTrumpCards(0), players, config)
-		return usecase.NewCribbageInteractor(cribbage, new(presenter.CribbageWebPresenter))
+		return usecase.NewCribbageInteractor(domain.NewDefaultCribbage(), new(presenter.CribbageWebPresenter))
 	}))
 	web.register("threecard", controller.NewThreeCardWebController(func() usecase.ThreeCardInteractorIF {
 		return usecase.NewThreeCardInteractor(
@@ -234,101 +154,43 @@ func (web *TrumpCardsWeb) registerAll() {
 		return usecase.NewOhHellInteractor(domain.NewDefaultOhHell(), new(presenter.OhHellWebPresenter))
 	}))
 	web.register("bridge", controller.NewBridgeWebController(func() usecase.BridgeInteractorIF {
-		config := domain.DefaultBridgeConfig()
-		players := []*domain.BridgePlayer{
-			domain.NewBridgePlayer(true, 0),
-			domain.NewBridgePlayer(false, 1),
-			domain.NewBridgePlayer(false, 0),
-			domain.NewBridgePlayer(false, 1),
-		}
-		bridge := domain.NewBridge(domain.NewTrumpCards(0), players, config)
-		return usecase.NewBridgeInteractor(bridge, new(presenter.BridgeWebPresenter))
+		return usecase.NewBridgeInteractor(domain.NewDefaultBridge(), new(presenter.BridgeWebPresenter))
 	}))
 	web.register("pineapple", controller.NewPineappleWebController(func() usecase.PineappleInteractorIF {
-		cfg := domain.DefaultPineappleConfig()
-		pineapple := domain.NewPineapple(domain.NewTrumpCards(0), domain.NewPineapplePlayersForTable(cfg.TableSize), cfg)
-		return usecase.NewPineappleInteractor(pineapple, new(presenter.PineappleWebPresenter))
+		return usecase.NewPineappleInteractor(domain.NewDefaultPineapple(), new(presenter.PineappleWebPresenter))
 	}))
 	web.register("speed", controller.NewSpeedWebController(func() usecase.SpeedInteractorIF {
-		config := domain.DefaultSpeedConfig()
-		players := []*domain.SpeedPlayer{
-			domain.NewSpeedPlayer(true),
-			domain.NewSpeedPlayer(false),
-		}
-		speed := domain.NewSpeed(domain.NewTrumpCards(0), players, config)
-		return usecase.NewSpeedInteractor(speed, new(presenter.SpeedWebPresenter))
+		return usecase.NewSpeedInteractor(domain.NewDefaultSpeed(), new(presenter.SpeedWebPresenter))
 	}))
 	web.register("gofish", controller.NewGoFishWebController(func() usecase.GoFishInteractorIF {
-		players := []*domain.GoFishPlayer{
-			domain.NewGoFishPlayer(true),
-			domain.NewGoFishPlayer(false),
-			domain.NewGoFishPlayer(false),
-			domain.NewGoFishPlayer(false),
-		}
-		goFish := domain.NewGoFish(domain.NewTrumpCards(0), players)
-		return usecase.NewGoFishInteractor(goFish, new(presenter.GoFishWebPresenter))
+		return usecase.NewGoFishInteractor(domain.NewDefaultGoFish(), new(presenter.GoFishWebPresenter))
 	}))
 	web.register("canasta", controller.NewCanastaWebController(func() usecase.CanastaInteractorIF {
-		config := domain.DefaultCanastaConfig()
-		players := []*domain.CanastaPlayer{
-			domain.NewCanastaPlayer(true),
-			domain.NewCanastaPlayer(false),
-		}
-		canasta := domain.NewCanasta(domain.NewTrumpCardsWithDecks(2, 4), players, config)
-		return usecase.NewCanastaInteractor(canasta, new(presenter.CanastaWebPresenter))
+		return usecase.NewCanastaInteractor(domain.NewDefaultCanasta(), new(presenter.CanastaWebPresenter))
 	}))
 	web.register("pinochle", controller.NewPinochleWebController(func() usecase.PinochleInteractorIF {
-		config := domain.DefaultPinochleConfig()
-		players := []*domain.PinochlePlayer{
-			domain.NewPinochlePlayer(true, 0),
-			domain.NewPinochlePlayer(false, 1),
-			domain.NewPinochlePlayer(false, 0),
-			domain.NewPinochlePlayer(false, 1),
-		}
-		pinochle := domain.NewPinochle(domain.NewTrumpCardsPinochle(), players, config)
-		return usecase.NewPinochleInteractor(pinochle, new(presenter.PinochleWebPresenter))
+		return usecase.NewPinochleInteractor(domain.NewDefaultPinochle(), new(presenter.PinochleWebPresenter))
 	}))
 	web.register("golf", controller.NewGolfWebController(func() usecase.GolfInteractorIF {
-		golf := domain.NewGolf(domain.NewTrumpCards(0))
-		return usecase.NewGolfInteractor(golf, new(presenter.GolfWebPresenter))
+		return usecase.NewGolfInteractor(domain.NewDefaultGolf(), new(presenter.GolfWebPresenter))
 	}))
 	web.register("pigtail", controller.NewPigsTailWebController(func() usecase.PigsTailInteractorIF {
-		players := []*domain.PigsTailPlayer{
-			domain.NewPigsTailPlayer(true),
-			domain.NewPigsTailPlayer(false),
-			domain.NewPigsTailPlayer(false),
-			domain.NewPigsTailPlayer(false),
-		}
-		pigsTail := domain.NewPigsTail(domain.NewTrumpCards(0), players)
-		return usecase.NewPigsTailInteractor(pigsTail, new(presenter.PigsTailWebPresenter))
+		return usecase.NewPigsTailInteractor(domain.NewDefaultPigsTail(), new(presenter.PigsTailWebPresenter))
 	}))
 	web.register("sevencardstud", controller.NewSevenCardStudWebController(func() usecase.SevenCardStudInteractorIF {
-		cfg := domain.DefaultSevenCardStudConfig()
-		scs := domain.NewSevenCardStud(domain.NewTrumpCards(0), domain.NewSevenCardStudPlayersForTable(cfg.TableSize), cfg)
-		return usecase.NewSevenCardStudInteractor(scs, new(presenter.SevenCardStudWebPresenter))
+		return usecase.NewSevenCardStudInteractor(domain.NewDefaultSevenCardStud(), new(presenter.SevenCardStudWebPresenter))
 	}))
 	web.register("razz", controller.NewSevenCardStudWebController(func() usecase.SevenCardStudInteractorIF {
-		cfg := domain.DefaultRazzConfig()
-		r := domain.NewRazz(domain.NewTrumpCards(0), domain.NewSevenCardStudPlayersForTable(cfg.TableSize), cfg)
-		return usecase.NewSevenCardStudInteractor(r, new(presenter.SevenCardStudWebPresenter))
+		return usecase.NewSevenCardStudInteractor(domain.NewDefaultRazz(), new(presenter.SevenCardStudWebPresenter))
 	}))
 	web.register("clocksolitaire", controller.NewClockSolitaireWebController(func() usecase.ClockSolitaireInteractorIF {
-		cs := domain.NewClockSolitaire(domain.NewTrumpCards(0))
-		return usecase.NewClockSolitaireInteractor(cs, new(presenter.ClockSolitaireWebPresenter))
+		return usecase.NewClockSolitaireInteractor(domain.NewDefaultClockSolitaire(), new(presenter.ClockSolitaireWebPresenter))
 	}))
 	web.register("durak", controller.NewDurakWebController(func() usecase.DurakInteractorIF {
-		players := []*domain.DurakPlayer{
-			domain.NewDurakPlayer(true),
-			domain.NewDurakPlayer(false),
-			domain.NewDurakPlayer(false),
-			domain.NewDurakPlayer(false),
-		}
-		d := domain.NewDurak(domain.NewTrumpCardsShortDeck(), players)
-		return usecase.NewDurakInteractor(d, new(presenter.DurakWebPresenter))
+		return usecase.NewDurakInteractor(domain.NewDefaultDurak(), new(presenter.DurakWebPresenter))
 	}))
 	web.register("fortythieves", controller.NewFortyThievesWebController(func() usecase.FortyThievesInteractorIF {
-		ft := domain.NewFortyThieves(domain.NewTrumpCardsWithDecks(2, 0))
-		return usecase.NewFortyThievesInteractor(ft, new(presenter.FortyThievesWebPresenter))
+		return usecase.NewFortyThievesInteractor(domain.NewDefaultFortyThieves(), new(presenter.FortyThievesWebPresenter))
 	}))
 	web.register("paigow", controller.NewPaiGowWebController(func() usecase.PaiGowInteractorIF {
 		return usecase.NewPaiGowInteractor(
@@ -337,15 +199,7 @@ func (web *TrumpCardsWeb) registerAll() {
 		)
 	}))
 	web.register("twotenjack", controller.NewTwoTenJackWebController(func() usecase.TwoTenJackInteractorIF {
-		config := domain.DefaultTwoTenJackConfig()
-		players := []*domain.TwoTenJackPlayer{
-			domain.NewTwoTenJackPlayer(true),
-			domain.NewTwoTenJackPlayer(false),
-			domain.NewTwoTenJackPlayer(false),
-			domain.NewTwoTenJackPlayer(false),
-		}
-		ttj := domain.NewTwoTenJack(domain.NewTrumpCards(0), players, config)
-		return usecase.NewTwoTenJackInteractor(ttj, new(presenter.TwoTenJackWebPresenter))
+		return usecase.NewTwoTenJackInteractor(domain.NewDefaultTwoTenJack(), new(presenter.TwoTenJackWebPresenter))
 	}))
 	web.register("caribbeanstud", controller.NewCaribbeanStudWebController(func() usecase.CaribbeanStudInteractorIF {
 		return usecase.NewCaribbeanStudInteractor(
@@ -354,46 +208,22 @@ func (web *TrumpCardsWeb) registerAll() {
 		)
 	}))
 	web.register("war", controller.NewWarWebController(func() usecase.WarInteractorIF {
-		config := domain.DefaultWarConfig()
-		players := []*domain.WarPlayer{
-			domain.NewWarPlayer(true),
-			domain.NewWarPlayer(false),
-		}
-		war := domain.NewWar(domain.NewTrumpCards(0), players, config)
-		return usecase.NewWarInteractor(war, new(presenter.WarWebPresenter))
+		return usecase.NewWarInteractor(domain.NewDefaultWar(), new(presenter.WarWebPresenter))
 	}))
 	web.register("canfield", controller.NewCanfieldWebController(func() usecase.CanfieldInteractorIF {
-		canfield := domain.NewCanfield(domain.NewTrumpCards(0))
-		return usecase.NewCanfieldInteractor(canfield, new(presenter.CanfieldWebPresenter))
+		return usecase.NewCanfieldInteractor(domain.NewDefaultCanfield(), new(presenter.CanfieldWebPresenter))
 	}))
 	web.register("fiftyone", controller.NewFiftyOneWebController(func() usecase.FiftyOneInteractorIF {
-		players := []*domain.FiftyOnePlayer{
-			domain.NewFiftyOnePlayer(true),
-			domain.NewFiftyOnePlayer(false),
-			domain.NewFiftyOnePlayer(false),
-			domain.NewFiftyOnePlayer(false),
-		}
-		fo := domain.NewFiftyOne(domain.NewTrumpCards(0), players)
-		return usecase.NewFiftyOneInteractor(fo, new(presenter.FiftyOneWebPresenter))
+		return usecase.NewFiftyOneInteractor(domain.NewDefaultFiftyOne(), new(presenter.FiftyOneWebPresenter))
 	}))
 	web.register("yukon", controller.NewYukonWebController(func() usecase.YukonInteractorIF {
-		yukon := domain.NewYukon(domain.NewTrumpCards(0))
-		return usecase.NewYukonInteractor(yukon, new(presenter.YukonWebPresenter))
+		return usecase.NewYukonInteractor(domain.NewDefaultYukon(), new(presenter.YukonWebPresenter))
 	}))
 	web.register("scorpion", controller.NewScorpionWebController(func() usecase.ScorpionInteractorIF {
-		scorpion := domain.NewScorpion(domain.NewTrumpCards(0))
-		return usecase.NewScorpionInteractor(scorpion, new(presenter.ScorpionWebPresenter))
+		return usecase.NewScorpionInteractor(domain.NewDefaultScorpion(), new(presenter.ScorpionWebPresenter))
 	}))
 	web.register("whist", controller.NewWhistWebController(func() usecase.WhistInteractorIF {
-		config := domain.DefaultWhistConfig()
-		players := []*domain.WhistPlayer{
-			domain.NewWhistPlayer(true, 0),
-			domain.NewWhistPlayer(false, 1),
-			domain.NewWhistPlayer(false, 0),
-			domain.NewWhistPlayer(false, 1),
-		}
-		whist := domain.NewWhist(domain.NewTrumpCards(0), players, config)
-		return usecase.NewWhistInteractor(whist, new(presenter.WhistWebPresenter))
+		return usecase.NewWhistInteractor(domain.NewDefaultWhist(), new(presenter.WhistWebPresenter))
 	}))
 	web.register("letitride", controller.NewLetItRideWebController(func() usecase.LetItRideInteractorIF {
 		return usecase.NewLetItRideInteractor(
@@ -402,19 +232,10 @@ func (web *TrumpCardsWeb) registerAll() {
 		)
 	}))
 	web.register("pokersquares", controller.NewPokerSquaresWebController(func() usecase.PokerSquaresInteractorIF {
-		ps := domain.NewPokerSquares(domain.NewTrumpCards(0))
-		return usecase.NewPokerSquaresInteractor(ps, new(presenter.PokerSquaresWebPresenter))
+		return usecase.NewPokerSquaresInteractor(domain.NewDefaultPokerSquares(), new(presenter.PokerSquaresWebPresenter))
 	}))
 	web.register("pageone", controller.NewPageOneWebController(func() usecase.PageOneInteractorIF {
-		config := domain.DefaultPageOneConfig()
-		players := []*domain.PageOnePlayer{
-			domain.NewPageOnePlayer(true),
-			domain.NewPageOnePlayer(false),
-			domain.NewPageOnePlayer(false),
-			domain.NewPageOnePlayer(false),
-		}
-		po := domain.NewPageOne(domain.NewTrumpCards(0), players, config)
-		return usecase.NewPageOneInteractor(po, new(presenter.PageOneWebPresenter))
+		return usecase.NewPageOneInteractor(domain.NewDefaultPageOne(), new(presenter.PageOneWebPresenter))
 	}))
 	web.register("reddog", controller.NewRedDogWebController(func() usecase.RedDogInteractorIF {
 		return usecase.NewRedDogInteractor(


### PR DESCRIPTION
## Summary

Closes Phase 1b of #1396. PR #1402 (already merged) covered Phase 1a — 5 games + the `BuildCuiHelp` helper. This PR finishes the remaining ~40 games, completing the Phase 1 work the original issue scoped.

Adds `NewDefault<Game>()` to every domain type that was still constructed inline at multiple call sites, then collapses the matching CUI / Web registry / Cloudflare worker construction blocks to a single factory call per site.

## Factories added (40)

| Bucket | Games |
|---|---|
| Standard 4-player | Daifugo, Sevens, Doubt, OldMaid, GoFish, PigsTail, FiftyOne, Durak, PageOne, TwoTenJack, Napoleon, Poker |
| Team-based 4-player | Bridge, Euchre, Pinochle, Whist |
| 2-player | GinRummy, Cribbage, Speed, War, Canasta |
| Solitaire / single-deck | Klondike, FreeCell, Spider, Pyramid, TriPeaks, Golf, ClockSolitaire, Canfield, FortyThieves, Yukon, Scorpion, PokerSquares |
| Table-size based community | Holdem, Omaha, ShortDeck, Pineapple, SevenCardStud, Razz, IndianPoker |

`JokerPokerVideoPoker` / `DeucesWildVideoPoker` were intentionally not given new `NewDefault*` aliases — they are already single-arg factories, so call sites are already one line.

## Stats

- 84 files changed, **+788 / −655**
- TrumpCardsWeb.go: 507 → 246 lines (−261, ~52%)
- workers/casino/main.go: 285 → 197 lines
- workers/classic/main.go: 392 → 263 lines
- workers/solo/main.go: 241 → 175 lines

## Test plan

- [x] `go test -tags test ./...` — all pass (domain 64s, ui 0.3s)
- [x] `golangci-lint run ./internal/domain/... ./internal/infrastructure/ui/... ./internal/infrastructure/web/...` — `0 issues`
- [x] `goimports -w` on every modified file
- [x] `GOOS=js GOARCH=wasm go build ./cmd/workers/{casino,classic,solo}/...` — clean
- [x] New `internal/domain/NewDefault_test.go` adds a `TestNewDefault<Game>` for every new factory, asserting non-nil construction and (where applicable) the human-at-seat-0 invariant
- [ ] Frontend untouched in this PR

## Out of scope (deferred)

- **Phase 2 of #1396**: unify the Web + Worker registries into a single table so adding a game touches one place. The original issue already scopes this as a separate phase; today's PR is the prerequisite that makes it mechanical.
- **`SevensCui.go` / `BridgeCui.go` / `CanastaCui.go` / `DurakCui.go` / `PokerSquaresCui.go` help-text migration to `BuildCuiHelp`**: noted as deliberately skipped in PR #1402 because they use raw literals or non-standard footers. Construction is now via `NewDefault*` in this PR; help-text harmonization is a separate concern.