### PR TITLE
docs: sync backend.md class-diagram counts with 55-game registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ go_trumpcardsが目指す未来は、**あらゆる人がクリエイターと�
 
 ## Features
 
-Go + Clean Architecture で実装した51種類のトランプゲーム。CLI と Web GUI（React + Go REST API）の2つのインターフェースで遊べます。Web GUI は日英多言語対応。
+Go + Clean Architecture で実装した55種類のトランプゲーム。CLI と Web GUI（React + Go REST API）の2つのインターフェースで遊べます。Web GUI は日英多言語対応。
 
 | ゲーム | コマンド | マニュアル |
 |--------|----------|------------|

--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -1555,8 +1555,8 @@ classDiagram
     GameCuiPresenter ..|> GamePresenter : implements
     GameWebPresenter ..|> GamePresenter : implements
 
-    note for GameCuiController "41ゲーム × CUI/Web = 82 Controller\nGameCuiController / GameWebController は\n各ゲーム毎に具体的な実装が存在"
-    note for GameCuiPresenter "41ゲーム × CUI/Web = 82 Presenter 実装"
+    note for GameCuiController "55ゲーム × CUI/Web = 110 Controller\nGameCuiController / GameWebController は\n各ゲーム毎に具体的な実装が存在"
+    note for GameCuiPresenter "55ゲーム × CUI/Web = 110 Presenter 実装"
 ```
 
 ### 1.5 インフラストラクチャ層
@@ -1623,8 +1623,8 @@ classDiagram
         +Exec(input string) string
     }
 
-    TrumpCardsWeb --> "*" GameWebController : holds 46 controllers
-    GameManager --> "*" CuiExecer : holds 46 games
+    TrumpCardsWeb --> "*" GameWebController : holds 55 controllers
+    GameManager --> "*" CuiExecer : holds 55 games
     GameCui ..|> CuiExecer : implements
     GameCui --> GameCuiController : delegates
 ```


### PR DESCRIPTION
## Summary

55-game registry と stale な表記が残っていたドキュメントを整合。

1. `README.md:18` — Features 冒頭の「**51種類**のトランプゲーム」→「**55種類**」
2. `docs/design/backend.md` §1.4 Adapter 層の Mermaid class diagram ノート — `41ゲーム × 82 Controller/Presenter` → `55 × 110`
3. `docs/design/backend.md` §1.5 Infrastructure 層の関連線ラベル — `holds 46 controllers/games` → `holds 55`

修正箇所は文言のみ。ビルド・型チェック・テストには影響なし。

Closes #1423（該当の 3 件の drift について）

## Scope note

Issue #1423 で挙げた以下 2 件は、本 PR のスコープ外（別途対応が必要）:
- `docs/design/backend.md §3.41–3.48` の state machine 欠落 8 件（ゲームロジック読解が必要）
- `frontend/src/types/phases.ts` のヘッダ JSDoc 不整合（方針判断が必要）

## Test plan

- [x] `git diff` で変更が文言のみであることを確認
- [ ] GitHub 上で README / Mermaid のレンダリングが壊れていないか目視