### PR TITLE
fix(web): default trumpcards web to 127.0.0.1 bind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,11 @@ WORKDIR /app
 COPY --from=go-builder --chown=nonroot:nonroot /app/go_trumpcards .
 COPY --from=frontend-builder --chown=nonroot:nonroot /app/public ./public
 
-# Use a non-privileged port; the server reads the PORT environment variable
+# Use a non-privileged port; the server reads the PORT environment variable.
+# Bind to all interfaces inside the container so Docker's port mapping can
+# forward external traffic; the server defaults to 127.0.0.1 otherwise.
 ENV APP_ENV=production
+ENV HOST=0.0.0.0
 ENV PORT=8080
 EXPOSE 8080
 

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -170,7 +170,7 @@ func run() int {
 		_, code, ok := parseSubFlags("web", func(f *flag.FlagSet) {
 			f.IntVar(&port, "port", 0, "Port number for the web server (default: 8080)")
 			f.IntVar(&port, "p", 0, "Port number for the web server (shorthand)")
-			f.StringVar(&host, "host", "", "Bind address for the web server (default: all interfaces)")
+			f.StringVar(&host, "host", "", "Bind address for the web server (default: 127.0.0.1; use 0.0.0.0 to expose)")
 		})
 		if !ok {
 			return code
@@ -248,13 +248,13 @@ var builtinSubcommandHelp = map[string][]string{
 		"",
 		"FLAGS:",
 		"  -p, --port PORT   Port number (default: 8080; env PORT)",
-		"      --host HOST   Bind address (default: all interfaces; env HOST)",
+		"      --host HOST   Bind address (default: 127.0.0.1; use 0.0.0.0 to expose; env HOST)",
 		"",
 		"EXAMPLES:",
 		"  trumpcards web",
 		"  trumpcards web --port 3000",
-		"  trumpcards web --host 127.0.0.1",
-		"  HOST=127.0.0.1 PORT=3000 trumpcards web",
+		"  trumpcards web --host 0.0.0.0",
+		"  HOST=0.0.0.0 PORT=3000 trumpcards web",
 	},
 	"update": {
 		"USAGE:",
@@ -441,17 +441,17 @@ EXAMPLES:
   trumpcards update --yes        Update without confirmation prompt
   trumpcards --version-short     Print just the version number (e.g. 1.2.3)
   NO_COLOR=1 trumpcards hearts   Play Hearts without color output
-  trumpcards web                 Start the web GUI server
+  trumpcards web                 Start the web GUI server (binds to 127.0.0.1)
   trumpcards web --port 3000     Start the web GUI on port 3000
-  trumpcards web --host 127.0.0.1  Bind to localhost only
+  trumpcards web --host 0.0.0.0  Expose the web GUI on all interfaces
   source <(trumpcards completion bash)   Enable bash completion
 
 ENVIRONMENT VARIABLES:
   NO_COLOR          Disable color output on both stdout and stderr when set
                     (see https://no-color.org/)
                     Example: NO_COLOR=1 trumpcards blackjack
-  HOST              Bind address for the web server (default: all interfaces)
-                    Example: HOST=127.0.0.1 trumpcards web
+  HOST              Bind address for the web server (default: 127.0.0.1)
+                    Example: HOST=0.0.0.0 trumpcards web
   PORT              Port number for the web server (default: 8080)
                     Example: PORT=3000 trumpcards web
 `)

--- a/internal/infrastructure/web/TrumpCardsWeb.go
+++ b/internal/infrastructure/web/TrumpCardsWeb.go
@@ -119,8 +119,13 @@ func (web *TrumpCardsWeb) Exec() error {
 	return runErr
 }
 
+// getListenAddr returns the "host:port" address the web server should bind to.
+// Default is 127.0.0.1:8080; set HOST=0.0.0.0 to expose on all interfaces.
 func getListenAddr() string {
 	host := os.Getenv("HOST")
+	if host == "" {
+		host = "127.0.0.1"
+	}
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"

--- a/internal/infrastructure/web/TrumpCardsWeb_test.go
+++ b/internal/infrastructure/web/TrumpCardsWeb_test.go
@@ -1,0 +1,54 @@
+package web
+
+import (
+	"testing"
+)
+
+func TestGetListenAddr(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		port string
+		want string
+	}{
+		{
+			name: "defaults to loopback and 8080 when neither env var is set",
+			host: "",
+			port: "",
+			want: "127.0.0.1:8080",
+		},
+		{
+			name: "honors HOST env var",
+			host: "0.0.0.0",
+			port: "",
+			want: "0.0.0.0:8080",
+		},
+		{
+			name: "honors PORT env var",
+			host: "",
+			port: "3000",
+			want: "127.0.0.1:3000",
+		},
+		{
+			name: "honors both HOST and PORT",
+			host: "192.168.1.1",
+			port: "9000",
+			want: "192.168.1.1:9000",
+		},
+		{
+			name: "HOST=0.0.0.0 exposes on all interfaces",
+			host: "0.0.0.0",
+			port: "8080",
+			want: "0.0.0.0:8080",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HOST", tt.host)
+			t.Setenv("PORT", tt.port)
+			if got := getListenAddr(); got != tt.want {
+				t.Errorf("getListenAddr() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `trumpcards web` now defaults to binding 127.0.0.1 instead of all interfaces. To expose on the LAN, pass `--host 0.0.0.0` (or set `HOST=0.0.0.0`).
- Dockerfile sets `ENV HOST=0.0.0.0` so published ports keep working inside containers.
- Help text, builtin subcommand help, and the ENVIRONMENT VARIABLES section updated to reflect the new default.

## Why

Local dev CLIs (vite, next dev, jupyter, rails s) bind to loopback by default for safety; binding to 0.0.0.0 silently exposes the web GUI on any network the machine is attached to.

## Test plan

- [x] `go test -tags test ./internal/infrastructure/web/...` — new `TestGetListenAddr` table
- [x] `go test -tags test ./...` all pass
- [x] `golangci-lint run ./...`
- [ ] Manual: `trumpcards web` logs `127.0.0.1:8080` and rejects LAN connections
- [ ] Manual: `trumpcards web --host 0.0.0.0` still listens on all interfaces
- [ ] Manual: `docker run --rm -d -p 8080:8080 go_trumpcards` is reachable via published port

Closes #1405