### PR TITLE
fix(cli): drop misleading --aliases warning for games subcommand

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -106,39 +106,12 @@ func run() int {
 		var short, aliases bool
 		_, code, ok := parseSubFlags("games", func(f *flag.FlagSet) {
 			f.BoolVar(&short, "short", false, "Print game names only")
-			f.BoolVar(&aliases, "aliases", false, "Include aliases in output (with --short)")
+			f.BoolVar(&aliases, "aliases", false, "With --short, also print each alias on its own line (long output always includes aliases inline)")
 		})
 		if !ok {
 			return code
 		}
-		if aliases && !short {
-			fmt.Fprintln(os.Stderr, i18n.T("cliAliasesWithoutShort"))
-		}
-		// Build reverse alias map: canonical name -> sorted list of aliases.
-		reverseAliases := make(map[string][]string)
-		for alias, canonical := range ui.GameAliases {
-			reverseAliases[canonical] = append(reverseAliases[canonical], alias)
-		}
-		for k := range reverseAliases {
-			sort.Strings(reverseAliases[k])
-		}
-		descs := ui.GameDescriptions()
-		for _, name := range ui.GameNames() {
-			if short {
-				fmt.Println(name)
-				if aliases {
-					for _, alias := range reverseAliases[name] {
-						fmt.Println(alias)
-					}
-				}
-			} else {
-				line := fmt.Sprintf("  %-16s %s", name, descs[name])
-				if aliasList := reverseAliases[name]; len(aliasList) > 0 {
-					line += fmt.Sprintf("  [aliases: %s]", strings.Join(aliasList, ", "))
-				}
-				fmt.Println(line)
-			}
-		}
+		printGames(short, aliases, os.Stdout)
 		return 0
 	}
 	commands["completion"] = func() int {
@@ -282,7 +255,8 @@ var builtinSubcommandHelp = map[string][]string{
 		"",
 		"FLAGS:",
 		"      --short     Print game names only (for scripting)",
-		"      --aliases   Include aliases (requires --short)",
+		"      --aliases   With --short, also print each alias on its own line",
+		"                  (long output always includes aliases inline)",
 		"",
 		"EXAMPLES:",
 		"  trumpcards games",
@@ -412,7 +386,7 @@ GAMES:
 	}
 	sb.WriteString(`
 COMMANDS:
-  games        List all available games (--short for names only, --aliases to include aliases with --short)
+  games        List all available games (--short for names only; with --short, --aliases adds alias lines)
   help [game]  Show this help, or a specific game's help text
   completion   Generate shell completion script (bash, zsh, fish)
   update       Self-update to the latest version
@@ -456,6 +430,39 @@ ENVIRONMENT VARIABLES:
                     Example: PORT=3000 trumpcards web
 `)
 	return sb.String()
+}
+
+// printGames writes the game list to w in the format selected by `short`.
+// With short=false (long mode), each line shows the canonical name, description,
+// and any aliases inline. With short=true, only canonical names are printed,
+// one per line — and if aliases is also true, every alias gets its own line.
+// The `aliases` flag is a no-op in long mode because aliases are always shown
+// inline there.
+func printGames(short, aliases bool, w io.Writer) {
+	reverseAliases := make(map[string][]string)
+	for alias, canonical := range ui.GameAliases {
+		reverseAliases[canonical] = append(reverseAliases[canonical], alias)
+	}
+	for k := range reverseAliases {
+		sort.Strings(reverseAliases[k])
+	}
+	descs := ui.GameDescriptions()
+	for _, name := range ui.GameNames() {
+		if short {
+			_, _ = fmt.Fprintln(w, name)
+			if aliases {
+				for _, alias := range reverseAliases[name] {
+					_, _ = fmt.Fprintln(w, alias)
+				}
+			}
+		} else {
+			line := fmt.Sprintf("  %-16s %s", name, descs[name])
+			if aliasList := reverseAliases[name]; len(aliasList) > 0 {
+				line += fmt.Sprintf("  [aliases: %s]", strings.Join(aliasList, ", "))
+			}
+			_, _ = fmt.Fprintln(w, line)
+		}
+	}
 }
 
 // buildGameCommands generates command handlers for all games from the registry.

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -439,14 +439,22 @@ ENVIRONMENT VARIABLES:
 // The `aliases` flag is a no-op in long mode because aliases are always shown
 // inline there.
 func printGames(short, aliases bool, w io.Writer) {
-	reverseAliases := make(map[string][]string)
-	for alias, canonical := range ui.GameAliases {
-		reverseAliases[canonical] = append(reverseAliases[canonical], alias)
+	var reverseAliases map[string][]string
+	if !short || aliases {
+		reverseAliases = make(map[string][]string)
+		for alias, canonical := range ui.GameAliases {
+			reverseAliases[canonical] = append(reverseAliases[canonical], alias)
+		}
+		for k := range reverseAliases {
+			sort.Strings(reverseAliases[k])
+		}
 	}
-	for k := range reverseAliases {
-		sort.Strings(reverseAliases[k])
+
+	var descs map[string]string
+	if !short {
+		descs = ui.GameDescriptions()
 	}
-	descs := ui.GameDescriptions()
+
 	for _, name := range ui.GameNames() {
 		if short {
 			_, _ = fmt.Fprintln(w, name)

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -132,3 +132,60 @@ func TestBuildHelpTextMentionsVersionShort(t *testing.T) {
 		t.Errorf("help text should document --version-short; got:\n%s", helpText)
 	}
 }
+
+func TestPrintGamesLongModeAlwaysIncludesAliases(t *testing.T) {
+	// Pick a canonical name with known aliases, e.g. ginrummy -> gin.
+	var withAlias string
+	for alias, canonical := range ui.GameAliases {
+		if alias != "" && canonical != "" {
+			withAlias = canonical
+			break
+		}
+	}
+	if withAlias == "" {
+		t.Skip("no aliases registered; cannot verify long-mode alias inlining")
+	}
+	var buf bytes.Buffer
+	// aliases=false — long mode must STILL show aliases inline.
+	printGames(false, false, &buf)
+	out := buf.String()
+	if !strings.Contains(out, "[aliases:") {
+		t.Errorf("long mode output should contain inline '[aliases:' for games with aliases; got:\n%s", out)
+	}
+}
+
+func TestPrintGamesShortModeRespectsAliasesFlag(t *testing.T) {
+	var withAlias string
+	var aliasSample string
+	for alias, canonical := range ui.GameAliases {
+		if alias != "" && canonical != "" {
+			withAlias = canonical
+			aliasSample = alias
+			break
+		}
+	}
+	if withAlias == "" {
+		t.Skip("no aliases registered")
+	}
+
+	var without, with bytes.Buffer
+	printGames(true, false, &without)
+	printGames(true, true, &with)
+
+	// Without --aliases, alias lines should not appear.
+	if strings.Contains(without.String(), "\n"+aliasSample+"\n") || strings.HasPrefix(without.String(), aliasSample+"\n") {
+		t.Errorf("short mode without --aliases should not list alias %q; got:\n%s", aliasSample, without.String())
+	}
+	// With --aliases, alias lines must appear.
+	if !strings.Contains(with.String(), aliasSample) {
+		t.Errorf("short mode with --aliases should list alias %q; got:\n%s", aliasSample, with.String())
+	}
+}
+
+func TestCliAliasesWithoutShortKeyRemoved(t *testing.T) {
+	// The `cliAliasesWithoutShort` warning contradicted the long-mode behavior
+	// and was removed; ensure it hasn't crept back into either locale.
+	if got := i18n.T("cliAliasesWithoutShort"); got != "cliAliasesWithoutShort" && got != "" {
+		t.Errorf("i18n key 'cliAliasesWithoutShort' should be removed but still resolves to: %q", got)
+	}
+}

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -36,7 +36,6 @@
   "emptyInputHint": "Type 'help' for available commands.",
   "cliStartupBanner": "trumpcards {{version}} - Interactive Mode",
   "cliStartupGame": "Starting with {{game}}. Type 'switch <game>' to change, 'games' to list all.",
-  "cliAliasesWithoutShort": "Note: --aliases has no effect without --short",
   "cliInvalidPort": "Error: invalid port number {{port}} (must be 1-65535)",
   "cliExtraArgsWarning": "Warning: extra arguments ignored: {{args}}",
   "cliCompletionUsage": "Usage: trumpcards completion <bash|zsh|fish>",

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -36,7 +36,6 @@
   "emptyInputHint": "'help' でコマンド一覧を表示します。",
   "cliStartupBanner": "trumpcards {{version}} - インタラクティブモード",
   "cliStartupGame": "{{game}} を開始します。'switch <game>' でゲームを切り替え、'games' で一覧を表示できます。",
-  "cliAliasesWithoutShort": "注意: --aliases は --short なしでは効果がありません",
   "cliInvalidPort": "エラー: 無効なポート番号 {{port}} です (1-65535 の範囲で指定してください)",
   "cliExtraArgsWarning": "警告: 余分な引数は無視されました: {{args}}",
   "cliCompletionUsage": "使い方: trumpcards completion <bash|zsh|fish>",


### PR DESCRIPTION
## Summary

- Remove the `Note: --aliases has no effect without --short` warning emitted by `trumpcards games --aliases`. The warning contradicted the actual long-mode output, which always includes `[aliases: ...]` inline.
- Extract the games print loop into a `printGames` helper so short/long and with/without `--aliases` variants can be unit tested.
- Drop the now-unused `cliAliasesWithoutShort` key from both locales.
- Clarify the `--aliases` help text: it splits aliases into separate lines only under `--short` (long output always shows them inline).

## Test plan

- [x] `go test -tags test ./cmd/trumpcards/...` — new tests cover the 3 output modes
- [x] `go test -tags test ./...` all pass
- [x] `golangci-lint run ./...`
- [ ] Manual: `trumpcards games --aliases` (no `--short`) no longer prints the misleading warning and still lists aliases inline

Closes #1406