### PR TITLE
fix(cli): route top-level flag parse errors through i18n

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -29,6 +29,11 @@ var (
 	date    = "unknown"
 )
 
+// supportedLangs is the single source of truth for which i18n locales the CLI
+// accepts, shared by bootstrap detection (pre-Parse) and the post-Parse
+// validator so the two cannot diverge.
+var supportedLangs = map[string]bool{"ja": true, "en": true}
+
 func main() {
 	os.Exit(run())
 }
@@ -38,9 +43,12 @@ func run() int {
 
 	// Route parse errors through i18n. Default is ExitOnError with English
 	// output to stderr; switch to ContinueOnError + a discarded sink so we
-	// can wrap the error in cliFlagError ourselves.
+	// own error rendering. We also suppress FlagSet.Usage — the flag package
+	// calls it internally before returning the error, which would print the
+	// help text once before our handler prints it again.
 	flag.CommandLine.Init(os.Args[0], flag.ContinueOnError)
 	flag.CommandLine.SetOutput(io.Discard)
+	flag.CommandLine.Usage = func() {}
 
 	lang := flag.String("lang", "", "language (ja or en)")
 	showVersion := flag.Bool("version", false, "Show version information")
@@ -49,9 +57,6 @@ func run() int {
 	noColorFlag := flag.Bool("no-color", false, "Disable color output")
 	showHelp := flag.Bool("help", false, "Show this help message")
 	flag.BoolVar(showHelp, "h", false, "Show this help message (shorthand)")
-	flag.Usage = func() {
-		fmt.Fprint(os.Stderr, helpText)
-	}
 
 	// Resolve the locale from LANG env + any --lang in os.Args before Parse
 	// so a flag error (e.g. --bogus) is rendered in the user's language,
@@ -59,10 +64,8 @@ func run() int {
 	i18n.SetLang(detectBootstrapLang(os.Args[1:], os.Getenv("LANG")))
 
 	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
-			_, _ = fmt.Fprint(os.Stdout, helpText)
-			return 0
-		}
+		// NB: -h / --help are registered above so flag.Parse handles them
+		// itself and returns nil; flag.ErrHelp is therefore unreachable here.
 		_, _ = fmt.Fprintln(os.Stderr, i18n.Tf("cliFlagError", "err", err.Error()))
 		_, _ = fmt.Fprint(os.Stderr, helpText)
 		return 2
@@ -93,7 +96,6 @@ func run() int {
 	// An explicit --lang with an unsupported value is a hard error (exit 2);
 	// an unsupported LANG env value emits a one-line warning and falls back to "ja"
 	// (suppress with TRUMPCARDS_QUIET=1).
-	supportedLangs := map[string]bool{"ja": true, "en": true}
 	detectedLang := "ja"
 	var langEnvWarn string // deferred until SetLang is called so i18n resolves
 	if envLang := os.Getenv("LANG"); envLang != "" {
@@ -480,28 +482,40 @@ ENVIRONMENT VARIABLES:
 
 // detectBootstrapLang returns the locale to use before flag parsing runs,
 // so any flag-parse error can be emitted in the user's preferred language.
-// Resolution order mirrors the post-parse logic: an explicit `--lang`
-// (or `-lang`, with optional `=value`) in args wins, then LANG env, then "ja".
-// Unsupported values fall through to the next source rather than causing a fault.
+// Resolution mirrors Go's flag.Parse best-effort: an explicit `--lang`
+// (or `-lang`, with optional `=value`) in args wins with last-occurrence
+// semantics, scanning stops at the first non-flag arg or at `--`, then
+// LANG env, then "ja". Unsupported values fall through to the next source.
+// This is best-effort; the authoritative locale is still resolved after
+// flag.Parse.
 func detectBootstrapLang(args []string, langEnv string) string {
-	supported := map[string]bool{"ja": true, "en": true}
 	fromEnv := "ja"
 	if langEnv != "" {
 		prefix := langEnv
 		if idx := strings.IndexAny(langEnv, "_-."); idx >= 0 {
 			prefix = langEnv[:idx]
 		}
-		if supported[prefix] {
+		if supportedLangs[prefix] {
 			fromEnv = prefix
 		}
 	}
-	for i := range args {
+	fromArgs := ""
+	for i := 0; i < len(args); i++ {
 		a := args[i]
+		// End-of-flags terminator: flag.Parse stops here.
+		if a == "--" {
+			break
+		}
+		// First non-flag positional arg (game name): flag.Parse stops here too.
+		if !strings.HasPrefix(a, "-") {
+			break
+		}
 		var val string
 		switch {
 		case a == "--lang" || a == "-lang":
 			if i+1 < len(args) {
 				val = args[i+1]
+				i++ // consume the value so a non-flag value doesn't stop the scan
 			}
 		case strings.HasPrefix(a, "--lang="):
 			val = strings.TrimPrefix(a, "--lang=")
@@ -510,9 +524,12 @@ func detectBootstrapLang(args []string, langEnv string) string {
 		default:
 			continue
 		}
-		if supported[val] {
-			return val
+		if supportedLangs[val] {
+			fromArgs = val // last-valid-wins, matching flag.Parse behavior
 		}
+	}
+	if fromArgs != "" {
+		return fromArgs
 	}
 	return fromEnv
 }

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -36,6 +36,12 @@ func main() {
 func run() int {
 	helpText := buildHelpText()
 
+	// Route parse errors through i18n. Default is ExitOnError with English
+	// output to stderr; switch to ContinueOnError + a discarded sink so we
+	// can wrap the error in cliFlagError ourselves.
+	flag.CommandLine.Init(os.Args[0], flag.ContinueOnError)
+	flag.CommandLine.SetOutput(io.Discard)
+
 	lang := flag.String("lang", "", "language (ja or en)")
 	showVersion := flag.Bool("version", false, "Show version information")
 	flag.BoolVar(showVersion, "V", false, "Show version information (shorthand)")
@@ -46,7 +52,21 @@ func run() int {
 	flag.Usage = func() {
 		fmt.Fprint(os.Stderr, helpText)
 	}
-	flag.Parse()
+
+	// Resolve the locale from LANG env + any --lang in os.Args before Parse
+	// so a flag error (e.g. --bogus) is rendered in the user's language,
+	// not English.
+	i18n.SetLang(detectBootstrapLang(os.Args[1:], os.Getenv("LANG")))
+
+	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			_, _ = fmt.Fprint(os.Stdout, helpText)
+			return 0
+		}
+		_, _ = fmt.Fprintln(os.Stderr, i18n.Tf("cliFlagError", "err", err.Error()))
+		_, _ = fmt.Fprint(os.Stderr, helpText)
+		return 2
+	}
 
 	if *showHelp {
 		_, _ = fmt.Fprint(os.Stdout, helpText)
@@ -456,6 +476,45 @@ ENVIRONMENT VARIABLES:
                     Example: PORT=3000 trumpcards web
 `)
 	return sb.String()
+}
+
+// detectBootstrapLang returns the locale to use before flag parsing runs,
+// so any flag-parse error can be emitted in the user's preferred language.
+// Resolution order mirrors the post-parse logic: an explicit `--lang`
+// (or `-lang`, with optional `=value`) in args wins, then LANG env, then "ja".
+// Unsupported values fall through to the next source rather than causing a fault.
+func detectBootstrapLang(args []string, langEnv string) string {
+	supported := map[string]bool{"ja": true, "en": true}
+	fromEnv := "ja"
+	if langEnv != "" {
+		prefix := langEnv
+		if idx := strings.IndexAny(langEnv, "_-."); idx >= 0 {
+			prefix = langEnv[:idx]
+		}
+		if supported[prefix] {
+			fromEnv = prefix
+		}
+	}
+	for i := range args {
+		a := args[i]
+		var val string
+		switch {
+		case a == "--lang" || a == "-lang":
+			if i+1 < len(args) {
+				val = args[i+1]
+			}
+		case strings.HasPrefix(a, "--lang="):
+			val = strings.TrimPrefix(a, "--lang=")
+		case strings.HasPrefix(a, "-lang="):
+			val = strings.TrimPrefix(a, "-lang=")
+		default:
+			continue
+		}
+		if supported[val] {
+			return val
+		}
+	}
+	return fromEnv
 }
 
 // buildGameCommands generates command handlers for all games from the registry.

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"flag"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -167,7 +168,12 @@ func TestRunUnknownTopLevelFlagIsI18nError(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			flag.CommandLine = flag.NewFlagSet(tc.args[0], flag.ContinueOnError)
+			// Simulate production: Go's package init gives flag.CommandLine a
+			// Usage func that writes the help text. A fresh FlagSet has
+			// Usage=nil by default, which would hide a regression where we
+			// forget to suppress the internal Usage callback.
+			flag.CommandLine = flag.NewFlagSet(tc.args[0], flag.ExitOnError)
+			flag.CommandLine.Usage = func() { _, _ = fmt.Fprint(os.Stderr, "USAGE: simulated-prod-help\n") }
 			os.Args = tc.args
 
 			rOut, wOut, _ := os.Pipe()
@@ -195,6 +201,9 @@ func TestRunUnknownTopLevelFlagIsI18nError(t *testing.T) {
 			if !strings.Contains(errStr, tc.wantInclude) {
 				t.Errorf("stderr should include offending flag %q; got: %q", tc.wantInclude, firstLine(errStr))
 			}
+			if n := strings.Count(errStr, "USAGE:"); n != 1 {
+				t.Errorf("help text should be printed exactly once; got %d USAGE: markers", n)
+			}
 		})
 	}
 }
@@ -221,6 +230,12 @@ func TestDetectBootstrapLang(t *testing.T) {
 		{"--lang garbage ignored -> fall back to LANG", []string{"--lang", "klingon"}, "en_US.UTF-8", "en"},
 		{"--lang with no value -> ignore", []string{"--lang"}, "en_US.UTF-8", "en"},
 		{"--lang appears after other flag", []string{"--bogus", "--lang", "en"}, "", "en"},
+		// Gemini review: must mirror flag.Parse semantics.
+		{"stops at first positional arg (like flag.Parse)", []string{"blackjack", "--lang", "en"}, "", "ja"},
+		{"stops at -- end-of-flags terminator", []string{"--", "--lang", "en"}, "", "ja"},
+		{"last --lang wins on repeat", []string{"--lang", "ja", "--lang", "en"}, "", "en"},
+		{"last --lang=form wins on repeat", []string{"--lang=en", "--lang=ja"}, "", "ja"},
+		{"unsupported last value keeps earlier valid one", []string{"--lang", "en", "--lang", "klingon"}, "", "en"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"flag"
+	"os"
 	"strings"
 	"testing"
 
@@ -123,6 +125,109 @@ func TestRunHelpCommandUnknownGame(t *testing.T) {
 	}
 	if stderr.Len() == 0 {
 		t.Errorf("expected error output on stderr for unknown game")
+	}
+}
+
+func TestRunUnknownTopLevelFlagIsI18nError(t *testing.T) {
+	// Redirect stderr and stdout through os.Pipe so we can capture what
+	// run() writes when it encounters an unknown top-level flag.
+	// `flag.CommandLine` is global state, so we restore it after each run.
+	origArgs := os.Args
+	origCmdLine := flag.CommandLine
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	defer func() {
+		os.Args = origArgs
+		flag.CommandLine = origCmdLine
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}()
+
+	cases := []struct {
+		name        string
+		args        []string
+		wantExit    int
+		wantPrefix  string
+		wantInclude string
+	}{
+		{
+			name:        "ja locale wraps error in cliFlagError",
+			args:        []string{"trumpcards", "--lang", "ja", "--bogus"},
+			wantExit:    2,
+			wantPrefix:  "エラー: 不明なオプション",
+			wantInclude: "-bogus",
+		},
+		{
+			name:        "en locale wraps error in cliFlagError",
+			args:        []string{"trumpcards", "--lang", "en", "--bogus"},
+			wantExit:    2,
+			wantPrefix:  "Error: invalid option",
+			wantInclude: "-bogus",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			flag.CommandLine = flag.NewFlagSet(tc.args[0], flag.ContinueOnError)
+			os.Args = tc.args
+
+			rOut, wOut, _ := os.Pipe()
+			rErr, wErr, _ := os.Pipe()
+			os.Stdout = wOut
+			os.Stderr = wErr
+
+			exitCh := make(chan int, 1)
+			go func() { exitCh <- run() }()
+			exit := <-exitCh
+
+			_ = wOut.Close()
+			_ = wErr.Close()
+			var outBuf, errBuf bytes.Buffer
+			_, _ = outBuf.ReadFrom(rOut)
+			_, _ = errBuf.ReadFrom(rErr)
+
+			if exit != tc.wantExit {
+				t.Errorf("exit = %d, want %d (stderr=%q)", exit, tc.wantExit, errBuf.String())
+			}
+			errStr := errBuf.String()
+			if !strings.HasPrefix(errStr, tc.wantPrefix) {
+				t.Errorf("stderr should start with i18n envelope %q; got prefix %q", tc.wantPrefix, firstLine(errStr))
+			}
+			if !strings.Contains(errStr, tc.wantInclude) {
+				t.Errorf("stderr should include offending flag %q; got: %q", tc.wantInclude, firstLine(errStr))
+			}
+		})
+	}
+}
+
+func firstLine(s string) string {
+	line, _, _ := strings.Cut(s, "\n")
+	return line
+}
+
+func TestDetectBootstrapLang(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		langEnv string
+		want    string
+	}{
+		{"empty args, empty env -> default", nil, "", "ja"},
+		{"LANG=en_US.UTF-8 -> en", nil, "en_US.UTF-8", "en"},
+		{"LANG=ja_JP.UTF-8 -> ja", nil, "ja_JP.UTF-8", "ja"},
+		{"LANG=fr -> ja (unsupported falls back)", nil, "fr", "ja"},
+		{"--lang en overrides LANG", []string{"--lang", "en"}, "ja_JP.UTF-8", "en"},
+		{"--lang=ja overrides LANG", []string{"--lang=ja"}, "en_US.UTF-8", "ja"},
+		{"-lang en (single dash) also works", []string{"-lang", "en"}, "", "en"},
+		{"--lang garbage ignored -> fall back to LANG", []string{"--lang", "klingon"}, "en_US.UTF-8", "en"},
+		{"--lang with no value -> ignore", []string{"--lang"}, "en_US.UTF-8", "en"},
+		{"--lang appears after other flag", []string{"--bogus", "--lang", "en"}, "", "en"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectBootstrapLang(tt.args, tt.langEnv); got != tt.want {
+				t.Errorf("detectBootstrapLang(%v, %q) = %q, want %q", tt.args, tt.langEnv, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -50,6 +50,7 @@
   "cliLangEnvFallback": "Note: LANG=\"{{lang}}\" is not a supported language, defaulting to ja (set TRUMPCARDS_QUIET=1 to silence)",
   "cliSubcommandFlagError": "Error: trumpcards {{cmd}}: {{err}}",
   "cliTryHelp": "Run 'trumpcards help {{cmd}}' for usage.",
+  "cliFlagError": "Error: invalid option ({{err}})",
   "metaAIRequired": "Meta-AI setting is required (0=off, 1=on).",
   "invalidMetaAI": "Invalid value: {{val}}. Please enter 0 or 1.",
   "cancelled": "Cancelled.",

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -50,6 +50,7 @@
   "cliLangEnvFallback": "注意: LANG=\"{{lang}}\" はサポートされていない言語です。ja をデフォルトとして使用します (TRUMPCARDS_QUIET=1 で抑止可能)",
   "cliSubcommandFlagError": "エラー: trumpcards {{cmd}}: {{err}}",
   "cliTryHelp": "使い方は 'trumpcards help {{cmd}}' を実行してください。",
+  "cliFlagError": "エラー: 不明なオプションです ({{err}})",
   "metaAIRequired": "メタAI設定が必要です (0=オフ, 1=オン)。",
   "invalidMetaAI": "無効な値です: {{val}}。0 または 1 を入力してください。",
   "cancelled": "キャンセルしました。",


### PR DESCRIPTION
## Summary

- Top-level `flag.Parse()` previously let Go's English `flag provided but not defined` line leak to stderr even under `--lang ja`.
- Switch `flag.CommandLine` to `ContinueOnError` + discarded sink, then wrap parse errors in a new `cliFlagError` i18n key (ja / en).
- Resolve the locale from `LANG` env + any `--lang` in `os.Args` **before** `Parse()` via `detectBootstrapLang`, so the error itself is rendered in the user's language even though the flag that triggered it comes after `--lang` on the command line.
- `flag.ErrHelp` (e.g. `--help`) still prints localized help to stdout and exits 0.

## Test plan

- [x] `go test -tags test ./cmd/trumpcards/...` — new `TestDetectBootstrapLang` (10 cases) and `TestRunUnknownTopLevelFlagIsI18nError` (ja + en)
- [x] `go test -tags test ./...` all pass
- [x] `golangci-lint run ./...`
- [ ] Manual: `trumpcards --lang ja --bogus` -> stderr starts with `エラー: 不明なオプション`, exits 2
- [ ] Manual: `trumpcards --lang en --bogus` -> stderr starts with `Error: invalid option`, exits 2
- [ ] Manual: `trumpcards --help` still prints localized help on stdout

Closes #1407