### PR TITLE
fix(cli): honor --port 0 as OS-assigned ephemeral port

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -29,6 +29,24 @@ var (
 	date    = "unknown"
 )
 
+// portUnset distinguishes "user did not pass --port" from "user passed --port 0"
+// (which is the POSIX convention for "let the OS assign an ephemeral port").
+const portUnset = -1
+
+// resolvePortEnv interprets a --port value: returns the string to write into
+// the PORT env var, whether the caller should write it, and whether the value
+// is out of range (0..65535). portUnset yields (_, false, false), signalling
+// the default 8080 should stand.
+func resolvePortEnv(port int) (envValue string, set, invalid bool) {
+	if port == portUnset {
+		return "", false, false
+	}
+	if port < 0 || port > 65535 {
+		return "", false, true
+	}
+	return strconv.Itoa(port), true, false
+}
+
 func main() {
 	os.Exit(run())
 }
@@ -165,22 +183,23 @@ func run() int {
 		return 0
 	}
 	commands["web"] = func() int {
-		var port int
+		port := portUnset
 		var host string
 		_, code, ok := parseSubFlags("web", func(f *flag.FlagSet) {
-			f.IntVar(&port, "port", 0, "Port number for the web server (default: 8080)")
-			f.IntVar(&port, "p", 0, "Port number for the web server (shorthand)")
+			f.IntVar(&port, "port", portUnset, "Port number for the web server (default: 8080; 0 for OS-assigned ephemeral)")
+			f.IntVar(&port, "p", portUnset, "Port number for the web server (shorthand)")
 			f.StringVar(&host, "host", "", "Bind address for the web server (default: all interfaces)")
 		})
 		if !ok {
 			return code
 		}
-		if port != 0 {
-			if port < 1 || port > 65535 {
-				fmt.Fprintln(os.Stderr, i18n.Tf("cliInvalidPort", "port", strconv.Itoa(port)))
-				return 1
-			}
-			_ = os.Setenv("PORT", strconv.Itoa(port))
+		portEnv, setPort, invalid := resolvePortEnv(port)
+		if invalid {
+			fmt.Fprintln(os.Stderr, i18n.Tf("cliInvalidPort", "port", strconv.Itoa(port)))
+			return 1
+		}
+		if setPort {
+			_ = os.Setenv("PORT", portEnv)
 		}
 		if host != "" {
 			_ = os.Setenv("HOST", host)
@@ -247,12 +266,13 @@ var builtinSubcommandHelp = map[string][]string{
 		"  trumpcards web [--port PORT] [--host HOST]",
 		"",
 		"FLAGS:",
-		"  -p, --port PORT   Port number (default: 8080; env PORT)",
+		"  -p, --port PORT   Port number (default: 8080; 0 = OS-assigned ephemeral; env PORT)",
 		"      --host HOST   Bind address (default: all interfaces; env HOST)",
 		"",
 		"EXAMPLES:",
 		"  trumpcards web",
 		"  trumpcards web --port 3000",
+		"  trumpcards web --port 0            # start on any free port; see startup log for actual port",
 		"  trumpcards web --host 127.0.0.1",
 		"  HOST=127.0.0.1 PORT=3000 trumpcards web",
 	},
@@ -443,6 +463,7 @@ EXAMPLES:
   NO_COLOR=1 trumpcards hearts   Play Hearts without color output
   trumpcards web                 Start the web GUI server
   trumpcards web --port 3000     Start the web GUI on port 3000
+  trumpcards web --port 0        Start on an OS-assigned ephemeral port (see startup log)
   trumpcards web --host 127.0.0.1  Bind to localhost only
   source <(trumpcards completion bash)   Enable bash completion
 

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -34,22 +34,28 @@ var (
 // validator so the two cannot diverge.
 var supportedLangs = map[string]bool{"ja": true, "en": true}
 
-// portUnset distinguishes "user did not pass --port" from "user passed --port 0"
-// (which is the POSIX convention for "let the OS assign an ephemeral port").
-const portUnset = -1
+// portInRange reports whether port is a valid TCP port number, with 0
+// reserved for "let the OS assign an ephemeral port" (POSIX convention).
+func portInRange(port int) bool {
+	return port >= 0 && port <= 65535
+}
 
-// resolvePortEnv interprets a --port value: returns the string to write into
-// the PORT env var, whether the caller should write it, and whether the value
-// is out of range (0..65535). portUnset yields (_, false, false), signalling
-// the default 8080 should stand.
-func resolvePortEnv(port int) (envValue string, set, invalid bool) {
-	if port == portUnset {
-		return "", false, false
+// flagSetVisited reports whether any of the named flags was explicitly set
+// on fs. This lets the caller distinguish "user did not pass --port" from
+// "user passed --port 0" without needing a sentinel value in the integer
+// input space — which would misclassify e.g. `--port -1` as "unset".
+func flagSetVisited(fs *flag.FlagSet, names ...string) bool {
+	want := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		want[n] = struct{}{}
 	}
-	if port < 0 || port > 65535 {
-		return "", false, true
-	}
-	return strconv.Itoa(port), true, false
+	seen := false
+	fs.Visit(func(fl *flag.Flag) {
+		if _, ok := want[fl.Name]; ok {
+			seen = true
+		}
+	})
+	return seen
 }
 
 func main() {
@@ -178,23 +184,22 @@ func run() int {
 		return 0
 	}
 	commands["web"] = func() int {
-		port := portUnset
+		var port int
 		var host string
-		_, code, ok := parseSubFlags("web", func(f *flag.FlagSet) {
-			f.IntVar(&port, "port", portUnset, "Port number for the web server (default: 8080; 0 for OS-assigned ephemeral)")
-			f.IntVar(&port, "p", portUnset, "Port number for the web server (shorthand)")
+		fs, code, ok := parseSubFlags("web", func(f *flag.FlagSet) {
+			f.IntVar(&port, "port", 0, "Port number for the web server (default: 8080; 0 for OS-assigned ephemeral)")
+			f.IntVar(&port, "p", 0, "Port number for the web server (shorthand)")
 			f.StringVar(&host, "host", "", "Bind address for the web server (default: 127.0.0.1; use 0.0.0.0 to expose)")
 		})
 		if !ok {
 			return code
 		}
-		portEnv, setPort, invalid := resolvePortEnv(port)
-		if invalid {
-			fmt.Fprintln(os.Stderr, i18n.Tf("cliInvalidPort", "port", strconv.Itoa(port)))
-			return 1
-		}
-		if setPort {
-			_ = os.Setenv("PORT", portEnv)
+		if flagSetVisited(fs, "port", "p") {
+			if !portInRange(port) {
+				fmt.Fprintln(os.Stderr, i18n.Tf("cliInvalidPort", "port", strconv.Itoa(port)))
+				return 1
+			}
+			_ = os.Setenv("PORT", strconv.Itoa(port))
 		}
 		if host != "" {
 			_ = os.Setenv("HOST", host)

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -129,29 +130,112 @@ func TestRunHelpCommandUnknownGame(t *testing.T) {
 	}
 }
 
-func TestResolvePortEnv(t *testing.T) {
+func TestPortInRange(t *testing.T) {
+	tests := []struct {
+		port int
+		want bool
+	}{
+		{0, true}, // ephemeral (POSIX)
+		{1, true},
+		{8080, true},
+		{65535, true}, // max
+		{-1, false},   // must reject (previously collided with the portUnset sentinel)
+		{-2, false},
+		{65536, false},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("port=%d", tt.port), func(t *testing.T) {
+			if got := portInRange(tt.port); got != tt.want {
+				t.Errorf("portInRange(%d) = %v, want %v", tt.port, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagSetVisitedDistinguishesExplicitFromDefault(t *testing.T) {
 	tests := []struct {
 		name        string
-		port        int
-		wantEnv     string
-		wantSet     bool
-		wantInvalid bool
+		args        []string
+		wantVisited bool
+		wantPortVal int
 	}{
-		{"unset sentinel leaves PORT untouched", portUnset, "", false, false},
-		{"port 0 requests ephemeral", 0, "0", true, false},
-		{"port 8080 is valid", 8080, "8080", true, false},
-		{"port 65535 is max valid", 65535, "65535", true, false},
-		{"negative port is invalid", -2, "", false, true},
-		{"port > 65535 is invalid", 65536, "", false, true},
+		{"no flag -> not visited, default 0", nil, false, 0},
+		{"--port 0 -> visited (critical: collides with default value)", []string{"--port", "0"}, true, 0},
+		{"--port -1 -> visited (must not be misclassified as unset)", []string{"--port", "-1"}, true, -1},
+		{"--port 3000 -> visited", []string{"--port", "3000"}, true, 3000},
+		{"-p 8080 shorthand -> visited", []string{"-p", "8080"}, true, 8080},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			env, set, invalid := resolvePortEnv(tt.port)
-			if env != tt.wantEnv || set != tt.wantSet || invalid != tt.wantInvalid {
-				t.Errorf("resolvePortEnv(%d) = (%q, %v, %v), want (%q, %v, %v)",
-					tt.port, env, set, invalid, tt.wantEnv, tt.wantSet, tt.wantInvalid)
+			var port int
+			fs := flag.NewFlagSet("web", flag.ContinueOnError)
+			fs.SetOutput(io.Discard)
+			fs.IntVar(&port, "port", 0, "")
+			fs.IntVar(&port, "p", 0, "")
+			if err := fs.Parse(tt.args); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			if got := flagSetVisited(fs, "port", "p"); got != tt.wantVisited {
+				t.Errorf("flagSetVisited = %v, want %v", got, tt.wantVisited)
+			}
+			if port != tt.wantPortVal {
+				t.Errorf("port = %d, want %d", port, tt.wantPortVal)
 			}
 		})
+	}
+}
+
+// TestRunWebRejectsExplicitInvalidPort covers the bug Gemini and Claude
+// flagged: under the previous portUnset=-1 sentinel, `--port -1` silently
+// fell through to the default 8080. With the fs.Visit approach the explicit
+// -1 must be rejected with cliInvalidPort and exit 1 before any bind.
+func TestRunWebRejectsExplicitInvalidPort(t *testing.T) {
+	origArgs := os.Args
+	origCmdLine := flag.CommandLine
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	origPortEnv, portEnvWasSet := os.LookupEnv("PORT")
+	defer func() {
+		os.Args = origArgs
+		flag.CommandLine = origCmdLine
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+		if portEnvWasSet {
+			_ = os.Setenv("PORT", origPortEnv)
+		} else {
+			_ = os.Unsetenv("PORT")
+		}
+	}()
+	_ = os.Unsetenv("PORT") // baseline
+
+	flag.CommandLine = flag.NewFlagSet("trumpcards", flag.ExitOnError)
+	os.Args = []string{"trumpcards", "web", "--port", "-1"}
+
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	exitCh := make(chan int, 1)
+	go func() { exitCh <- run() }()
+	exit := <-exitCh
+
+	_ = wOut.Close()
+	_ = wErr.Close()
+	var outBuf, errBuf bytes.Buffer
+	_, _ = outBuf.ReadFrom(rOut)
+	_, _ = errBuf.ReadFrom(rErr)
+
+	if exit != 1 {
+		t.Errorf("exit = %d, want 1 (stderr=%q)", exit, errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "-1") {
+		t.Errorf("stderr should mention the offending port; got: %q", errBuf.String())
+	}
+	// Guard against regression: the old sentinel behavior would silently
+	// pass through and try to bind 8080, leaving PORT untouched.
+	if got := os.Getenv("PORT"); got != "" {
+		t.Errorf("PORT should not be set on invalid input; got %q", got)
 	}
 }
 

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -126,6 +126,32 @@ func TestRunHelpCommandUnknownGame(t *testing.T) {
 	}
 }
 
+func TestResolvePortEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		port        int
+		wantEnv     string
+		wantSet     bool
+		wantInvalid bool
+	}{
+		{"unset sentinel leaves PORT untouched", portUnset, "", false, false},
+		{"port 0 requests ephemeral", 0, "0", true, false},
+		{"port 8080 is valid", 8080, "8080", true, false},
+		{"port 65535 is max valid", 65535, "65535", true, false},
+		{"negative port is invalid", -2, "", false, true},
+		{"port > 65535 is invalid", 65536, "", false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env, set, invalid := resolvePortEnv(tt.port)
+			if env != tt.wantEnv || set != tt.wantSet || invalid != tt.wantInvalid {
+				t.Errorf("resolvePortEnv(%d) = (%q, %v, %v), want (%q, %v, %v)",
+					tt.port, env, set, invalid, tt.wantEnv, tt.wantSet, tt.wantInvalid)
+			}
+		})
+	}
+}
+
 func TestBuildHelpTextMentionsVersionShort(t *testing.T) {
 	helpText := buildHelpText()
 	if !strings.Contains(helpText, "--version-short") {

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -37,7 +37,7 @@
   "cliStartupBanner": "trumpcards {{version}} - Interactive Mode",
   "cliStartupGame": "Starting with {{game}}. Type 'switch <game>' to change, 'games' to list all.",
   "cliAliasesWithoutShort": "Note: --aliases has no effect without --short",
-  "cliInvalidPort": "Error: invalid port number {{port}} (must be 1-65535)",
+  "cliInvalidPort": "Error: invalid port number {{port}} (must be 0-65535; 0 asks the OS for an ephemeral port)",
   "cliExtraArgsWarning": "Warning: extra arguments ignored: {{args}}",
   "cliCompletionUsage": "Usage: trumpcards completion <bash|zsh|fish>",
   "cliCompletionUnsupportedShell": "Error: unsupported shell \"{{shell}}\" (supported: bash, zsh, fish)",

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -37,7 +37,7 @@
   "cliStartupBanner": "trumpcards {{version}} - インタラクティブモード",
   "cliStartupGame": "{{game}} を開始します。'switch <game>' でゲームを切り替え、'games' で一覧を表示できます。",
   "cliAliasesWithoutShort": "注意: --aliases は --short なしでは効果がありません",
-  "cliInvalidPort": "エラー: 無効なポート番号 {{port}} です (1-65535 の範囲で指定してください)",
+  "cliInvalidPort": "エラー: 無効なポート番号 {{port}} です (0-65535 の範囲で指定してください。0 はOSに空きポートを割り当てさせます)",
   "cliExtraArgsWarning": "警告: 余分な引数は無視されました: {{args}}",
   "cliCompletionUsage": "使い方: trumpcards completion <bash|zsh|fish>",
   "cliCompletionUnsupportedShell": "エラー: サポートされていないシェル \"{{shell}}\" (対応: bash, zsh, fish)",


### PR DESCRIPTION
## Summary

- `trumpcards web --port 0` previously collided with the flag's zero-value "unset" sentinel and was silently ignored (defaulting to 8080). Introduce `portUnset = -1` so 0 becomes a first-class valid value meaning "let the kernel pick a free port" (POSIX convention).
- New `resolvePortEnv` helper cleanly maps `[0, 65535]` → `PORT` env and rejects anything else with `cliInvalidPort`. Full unit test coverage.
- Localized `cliInvalidPort` and the `web` subcommand help updated to document that 0 is valid and what it does.
- The startup log already prints the bound address via `ln.Addr().String()`, so ephemeral port lookups work without extra code.

## Test plan

- [x] `go test -tags test ./cmd/trumpcards/...` — `TestResolvePortEnv` covers unset/0/valid/65535/negative/too-large
- [x] `go test -tags test ./...` all pass
- [x] `golangci-lint run ./...`
- [ ] Manual: `trumpcards web --port 0` starts; startup log shows the actual bound port (e.g. `127.0.0.1:34567`)
- [ ] Manual: `trumpcards web --port 3000` unchanged
- [ ] Manual: `trumpcards web --port 65536` fails with `cliInvalidPort`

Closes #1408