### PR TITLE
feat(ux): add useBodyScrollLock hook and apply to all modals

### DIFF
--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { useBodyScrollLock } from '../hooks/useBodyScrollLock';
 import { btnDanger, btnSecondary } from '../styles/buttonStyles';
 import { getFocusableElements } from '../utils/dom';
 
@@ -20,6 +21,8 @@ export interface ConfirmDialogProps {
 export function ConfirmDialog(props: ConfirmDialogProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<Element | null>(null);
+
+  useBodyScrollLock(props.open);
 
   useEffect(() => {
     if (!props.open) return;

--- a/frontend/src/components/ManualModal.tsx
+++ b/frontend/src/components/ManualModal.tsx
@@ -6,6 +6,7 @@ import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { cuiManualTexts, isCliModeEnabled } from '../constants/cuiManualTexts';
 import { manualTexts } from '../constants/manualTexts';
+import { useBodyScrollLock } from '../hooks/useBodyScrollLock';
 import { btnSecondary } from '../styles/buttonStyles';
 import { getFocusableElements } from '../utils/dom';
 import { MermaidBlock } from './MermaidBlock';
@@ -43,6 +44,8 @@ export function ManualModal({ open, onClose, gamePath }: ManualModalProps) {
   const { t } = useTranslation('common');
   const dialogRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<Element | null>(null);
+
+  useBodyScrollLock(open);
 
   useEffect(() => {
     if (!open) return;

--- a/frontend/src/components/daifugo/DaifugoRulesBadges.tsx
+++ b/frontend/src/components/daifugo/DaifugoRulesBadges.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useBodyScrollLock } from '../../hooks/useBodyScrollLock';
 import { useIsMobile } from '../../hooks/useCardDimensions';
 import type { DaifugoResponse } from '../../types/card';
 import { getFocusableElements } from '../../utils/dom';
@@ -90,15 +91,13 @@ function RulesBadgeModal({
 }) {
   const dialogRef = useRef<HTMLDivElement>(null);
 
+  useBodyScrollLock(true);
+
   useEffect(() => {
     const previousFocus = document.activeElement as HTMLElement;
     const dialog = dialogRef.current as HTMLElement;
     const focusable = getFocusableElements(dialog);
     if (focusable.length > 0) focusable[0].focus();
-
-    // Prevent background scrolling
-    const originalOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -124,7 +123,6 @@ function RulesBadgeModal({
     document.addEventListener('keydown', handleKeyDown);
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
-      document.body.style.overflow = originalOverflow;
       previousFocus?.focus();
     };
   }, [onClose]);

--- a/frontend/src/components/tutorial/TutorialOverlay.tsx
+++ b/frontend/src/components/tutorial/TutorialOverlay.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
+import { useBodyScrollLock } from '../../hooks/useBodyScrollLock';
 import type { TutorialStep } from '../../types/tutorial';
 import { getFocusableElements } from '../ConfirmDialog';
 import { TutorialTooltip } from './TutorialTooltip';
@@ -72,14 +73,7 @@ export function TutorialOverlay({ step, stepIndex, totalSteps, onNext, onSkip, r
   const tooltipRef = useRef<HTMLDivElement>(null);
   const [spotlightRect, setSpotlightRect] = useState<SpotlightRect | null>(null);
 
-  // Lock background scroll while overlay is visible
-  useLayoutEffect(() => {
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    return () => {
-      document.body.style.overflow = prev;
-    };
-  }, []);
+  useBodyScrollLock(true);
 
   // Find and observe the target element
   useEffect(() => {

--- a/frontend/src/components/tutorial/TutorialSuggestDialog.tsx
+++ b/frontend/src/components/tutorial/TutorialSuggestDialog.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useLayoutEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useBodyScrollLock } from '../../hooks/useBodyScrollLock';
 import { btnPrimary, btnSecondary } from '../../styles/buttonStyles';
 import { getFocusableElements } from '../../utils/dom';
 
@@ -29,15 +30,7 @@ export function TutorialSuggestDialog({
   const dialogRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<Element | null>(null);
 
-  // Lock background scroll while dialog is visible
-  useLayoutEffect(() => {
-    if (!open) return;
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    return () => {
-      document.body.style.overflow = prev;
-    };
-  }, [open]);
+  useBodyScrollLock(open);
 
   useEffect(() => {
     if (!open) return;

--- a/frontend/src/hooks/useBodyScrollLock.test.ts
+++ b/frontend/src/hooks/useBodyScrollLock.test.ts
@@ -1,0 +1,56 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useBodyScrollLock } from './useBodyScrollLock';
+
+describe('useBodyScrollLock', () => {
+  afterEach(() => {
+    document.body.style.overflow = '';
+  });
+
+  it('does nothing when active is false', () => {
+    document.body.style.overflow = 'auto';
+    renderHook(() => useBodyScrollLock(false));
+    expect(document.body.style.overflow).toBe('auto');
+  });
+
+  it('sets body overflow to hidden when active is true', () => {
+    renderHook(() => useBodyScrollLock(true));
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('restores the previous overflow value on unmount', () => {
+    document.body.style.overflow = 'scroll';
+    const { unmount } = renderHook(() => useBodyScrollLock(true));
+    expect(document.body.style.overflow).toBe('hidden');
+    unmount();
+    expect(document.body.style.overflow).toBe('scroll');
+  });
+
+  it('restores when active flips from true to false', () => {
+    document.body.style.overflow = 'auto';
+    const { rerender } = renderHook(({ active }) => useBodyScrollLock(active), {
+      initialProps: { active: true },
+    });
+    expect(document.body.style.overflow).toBe('hidden');
+    rerender({ active: false });
+    expect(document.body.style.overflow).toBe('auto');
+  });
+
+  it('locks when active flips from false to true', () => {
+    document.body.style.overflow = 'auto';
+    const { rerender } = renderHook(({ active }) => useBodyScrollLock(active), {
+      initialProps: { active: false },
+    });
+    expect(document.body.style.overflow).toBe('auto');
+    act(() => rerender({ active: true }));
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('preserves empty string overflow on restore', () => {
+    document.body.style.overflow = '';
+    const { unmount } = renderHook(() => useBodyScrollLock(true));
+    expect(document.body.style.overflow).toBe('hidden');
+    unmount();
+    expect(document.body.style.overflow).toBe('');
+  });
+});

--- a/frontend/src/hooks/useBodyScrollLock.ts
+++ b/frontend/src/hooks/useBodyScrollLock.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+/**
+ * Locks body scroll while `active` is true. Saves and restores the previous
+ * `document.body.style.overflow` on unmount or when `active` becomes false,
+ * so nested modals stack cleanly without leaking `overflow: hidden` after
+ * the last modal closes.
+ */
+export function useBodyScrollLock(active: boolean): void {
+  useEffect(() => {
+    if (!active) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [active]);
+}

--- a/frontend/src/hooks/useBodyScrollLock.ts
+++ b/frontend/src/hooks/useBodyScrollLock.ts
@@ -1,13 +1,15 @@
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 
 /**
  * Locks body scroll while `active` is true. Saves and restores the previous
  * `document.body.style.overflow` on unmount or when `active` becomes false,
  * so nested modals stack cleanly without leaking `overflow: hidden` after
- * the last modal closes.
+ * the last modal closes. Uses useLayoutEffect so the scrollbar toggle
+ * happens synchronously before the browser paints, avoiding a flicker
+ * where the modal appears one frame ahead of the scroll lock.
  */
 export function useBodyScrollLock(active: boolean): void {
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!active) return;
     const prev = document.body.style.overflow;
     document.body.style.overflow = 'hidden';


### PR DESCRIPTION
## Summary

- New `useBodyScrollLock(active)` hook in `frontend/src/hooks/` that locks `document.body.style.overflow` while active and restores the previous value on cleanup (stackable).
- Apply it to every modal-like component so background scroll is consistently frozen:
  - `ConfirmDialog` (used by every `GameResetDialog`) — new
  - `ManualModal` — new
  - `TutorialOverlay` — replace ad-hoc `document.body.style.overflow` mutation
  - `TutorialSuggestDialog` — replace ad-hoc mutation
  - `DaifugoRulesBadges` modal — replace ad-hoc mutation
- Unit tests for the hook (6 cases covering active/inactive, unmount restore, true↔false flips, and empty-string preservation).

Fixes the mobile UX issue where flick-scroll inside `ManualModal` leaks through to the game page, and the background-drift when `GameResetDialog` opens on iOS Safari. Also centralizes any future iOS-specific hardening (e.g. `position: fixed` + scroll restore) in one place.

Closes #1410

## Test plan

- [x] `bun run test -- --run useBodyScrollLock` — 6/6 passed
- [x] `bun run test -- --run ConfirmDialog ManualModal TutorialOverlay TutorialSuggestDialog DaifugoRulesBadges` — 114/114 passed
- [x] `bun run build` — succeeds
- [x] `bun run check` — no new warnings (only 2 pre-existing `OldMaidPlayerArea.test.tsx` warnings unchanged)