### PR TITLE
style: migrate shared components to design system tokens (refs #1411)

### DIFF
--- a/frontend/src/components/GameMessageBox.tsx
+++ b/frontend/src/components/GameMessageBox.tsx
@@ -32,7 +32,7 @@ export function GameMessageBox({
     <div
       role={role}
       aria-live={live}
-      className="glass-panel rounded-lg text-white text-center px-4 py-2 text-lg font-bold mb-2"
+      className="glass-panel rounded-lg text-ds-text-primary text-center px-4 py-2 text-lg font-bold mb-2"
     >
       {displayMessage}
     </div>

--- a/frontend/src/components/LandscapeBanner.tsx
+++ b/frontend/src/components/LandscapeBanner.tsx
@@ -7,7 +7,7 @@ interface LandscapeBannerProps {
 /** Banner suggesting landscape orientation on small portrait screens. */
 export function LandscapeBanner({ message }: LandscapeBannerProps) {
   return (
-    <div className="hidden portrait:flex sm:hidden items-center gap-2 px-4 py-2 bg-ds-warning/90 text-black text-sm font-medium">
+    <div className="hidden portrait:flex sm:hidden items-center gap-2 px-4 py-2 bg-ds-warning/90 text-ds-text-on-accent text-sm font-medium">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="20"

--- a/frontend/src/components/LandscapeBanner.tsx
+++ b/frontend/src/components/LandscapeBanner.tsx
@@ -7,7 +7,7 @@ interface LandscapeBannerProps {
 /** Banner suggesting landscape orientation on small portrait screens. */
 export function LandscapeBanner({ message }: LandscapeBannerProps) {
   return (
-    <div className="hidden portrait:flex sm:hidden items-center gap-2 px-4 py-2 bg-yellow-500/90 text-black text-sm font-medium">
+    <div className="hidden portrait:flex sm:hidden items-center gap-2 px-4 py-2 bg-ds-warning/90 text-black text-sm font-medium">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="20"

--- a/frontend/src/components/MermaidBlock.tsx
+++ b/frontend/src/components/MermaidBlock.tsx
@@ -44,7 +44,7 @@ export function MermaidBlock({ code }: { code: string }) {
 
   if (error) {
     return (
-      <pre className="text-red-400 text-xs overflow-x-auto">
+      <pre className="text-ds-error text-xs overflow-x-auto">
         <code>{code}</code>
       </pre>
     );

--- a/frontend/src/components/PhaseIndicator.test.tsx
+++ b/frontend/src/components/PhaseIndicator.test.tsx
@@ -17,7 +17,7 @@ describe('PhaseIndicator', () => {
       'animate-pulse',
       'font-bold',
       'text-base',
-      'bg-green-900/40',
+      'bg-ds-success/20',
       'px-2',
       'py-0.5',
       'rounded-full',

--- a/frontend/src/components/PhaseIndicator.tsx
+++ b/frontend/src/components/PhaseIndicator.tsx
@@ -19,7 +19,7 @@ export function PhaseIndicator({ phaseName, isHumanTurn, children }: PhaseIndica
 
   return (
     <div
-      className="shrink-0 glass-panel text-white text-sm px-5 py-2 flex flex-wrap gap-x-6 gap-y-1 items-center tabular-nums"
+      className="shrink-0 glass-panel text-ds-text-primary text-sm px-5 py-2 flex flex-wrap gap-x-6 gap-y-1 items-center tabular-nums"
       data-testid="phase-indicator"
     >
       <span>
@@ -29,7 +29,7 @@ export function PhaseIndicator({ phaseName, isHumanTurn, children }: PhaseIndica
         <span
           className={
             isHumanTurn
-              ? 'text-ds-success animate-pulse font-bold text-base bg-green-900/40 px-2 py-0.5 rounded-full'
+              ? 'text-ds-success animate-pulse font-bold text-base bg-ds-success/20 px-2 py-0.5 rounded-full'
               : 'text-game-text-muted'
           }
         >

--- a/frontend/src/components/hint/HintPulse.tsx
+++ b/frontend/src/components/hint/HintPulse.tsx
@@ -18,7 +18,7 @@ export function HintPulse({ active, reducedMotion, children }: HintPulseProps) {
     return (
       <span className="relative inline-flex" data-testid="hint-pulse">
         {children}
-        <span className="absolute -top-1 -right-1 text-yellow-400 text-xs" data-testid="hint-icon">
+        <span className="absolute -top-1 -right-1 text-ds-accent text-xs" data-testid="hint-icon">
           💡
         </span>
       </span>
@@ -29,7 +29,7 @@ export function HintPulse({ active, reducedMotion, children }: HintPulseProps) {
     <span className="relative inline-flex" data-testid="hint-pulse">
       {children}
       <span
-        className="absolute inset-0 rounded animate-pulse ring-2 ring-yellow-400 pointer-events-none"
+        className="absolute inset-0 rounded animate-pulse ring-2 ring-ds-accent pointer-events-none"
         data-testid="hint-ring"
       />
     </span>


### PR DESCRIPTION
## Summary

Issue #1411 documents 150+ design-system bypasses (raw `text-white/N` and Tailwind palette colors) across the frontend. The issue itself recommends splitting the work into multiple PRs: **(1) shared base components → (2) per-page migration → (3) lint rule + ADR**.

This PR covers **step (1)** only — the widely-reused base components whose classes leak into every page:

- `GameMessageBox`: `text-white` → `text-ds-text-primary`
- `PhaseIndicator`: `text-white` → `text-ds-text-primary`, `bg-green-900/40` → `bg-ds-success/20` (plus test update)
- `MermaidBlock`: `text-red-400` → `text-ds-error`
- `LandscapeBanner`: `bg-yellow-500/90` → `bg-ds-warning/90`
- `HintPulse`: `text-yellow-400` / `ring-yellow-400` → `text-ds-accent` / `ring-ds-accent`

Rationale for the token mapping follows DESIGN.md (`--accent` is the gold the design system is built around; `--success/warning/error` are the semantic signal colors; `--text-primary` is the warm neutral for foreground text on dark surfaces).

Per-page migration (`WarPage`, `BaccaratPage`, `GoFishPlayerArea`, etc.) and the lint rule are intentionally deferred to follow-up issues so this PR stays easy to review. The parent issue (#1411) stays open until all phases are complete.

Refs #1411

## Test plan

- [x] `bun run test -- --run GameMessageBox MermaidBlock LandscapeBanner PhaseIndicator HintPulse` — 29/29 passed
- [x] `bun run build` — succeeds
- [x] `bun run check` — no new warnings (only 2 pre-existing `OldMaidPlayerArea.test.tsx` warnings unchanged)
- [ ] Visual regression: open the app locally and confirm `GameMessageBox`, `PhaseIndicator`, `LandscapeBanner`, `HintPulse` still look correct on the casino/classic/solo pages that host them