### PR TITLE
refactor(games): DRY BindWebController boilerplate in games_server.go

### DIFF
--- a/internal/infrastructure/games/games_server.go
+++ b/internal/infrastructure/games/games_server.go
@@ -13,279 +13,279 @@ import (
 // excludes this file from Cloudflare Worker (TinyGo) binaries so that their
 // Web-server-only controllers/dispatchers do not drag in 55 games of code.
 func init() {
-	BindWebController("blackjack", func() WebController {
-		return controller.NewBlackJackWebController(func() usecase.BlackJackInteractorIF {
+	BindWebControllerFor("blackjack",
+		func() usecase.BlackJackInteractorIF {
 			return usecase.NewBlackJackInteractor(domain.NewDefaultBlackJack(), new(presenter.BlackJackWebPresenter))
-		})
-	})
-	BindWebController("poker", func() WebController {
-		return controller.NewPokerWebController(func() usecase.PokerInteractorIF {
+		},
+		controller.NewBlackJackWebController)
+	BindWebControllerFor("poker",
+		func() usecase.PokerInteractorIF {
 			return usecase.NewPokerInteractor(domain.NewDefaultPoker(), new(presenter.PokerWebPresenter))
-		})
-	})
-	BindWebController("oldmaid", func() WebController {
-		return controller.NewOldMaidWebController(func() usecase.OldMaidInteractorIF {
+		},
+		controller.NewPokerWebController)
+	BindWebControllerFor("oldmaid",
+		func() usecase.OldMaidInteractorIF {
 			return usecase.NewOldMaidInteractor(domain.NewDefaultOldMaid(), new(presenter.OldMaidWebPresenter))
-		})
-	})
-	BindWebController("daifugo", func() WebController {
-		return controller.NewDaifugoWebController(func() usecase.DaifugoInteractorIF {
+		},
+		controller.NewOldMaidWebController)
+	BindWebControllerFor("daifugo",
+		func() usecase.DaifugoInteractorIF {
 			return usecase.NewDaifugoInteractor(domain.NewDefaultDaifugo(), new(presenter.DaifugoWebPresenter))
-		})
-	})
-	BindWebController("sevens", func() WebController {
-		return controller.NewSevensWebController(func() usecase.SevensInteractorIF {
+		},
+		controller.NewDaifugoWebController)
+	BindWebControllerFor("sevens",
+		func() usecase.SevensInteractorIF {
 			return usecase.NewSevensInteractor(domain.NewDefaultSevens(), new(presenter.SevensWebPresenter))
-		})
-	})
-	BindWebController("doubt", func() WebController {
-		return controller.NewDoubtWebController(func() usecase.DoubtInteractorIF {
+		},
+		controller.NewSevensWebController)
+	BindWebControllerFor("doubt",
+		func() usecase.DoubtInteractorIF {
 			return usecase.NewDoubtInteractor(domain.NewDefaultDoubt(), new(presenter.DoubtWebPresenter))
-		})
-	})
-	BindWebController("holdem", func() WebController {
-		return controller.NewHoldemWebController(func() usecase.HoldemInteractorIF {
+		},
+		controller.NewDoubtWebController)
+	BindWebControllerFor("holdem",
+		func() usecase.HoldemInteractorIF {
 			return usecase.NewHoldemInteractor(domain.NewDefaultHoldem(), new(presenter.HoldemWebPresenter))
-		})
-	})
-	BindWebController("omaha", func() WebController {
-		return controller.NewOmahaWebController(func() usecase.OmahaInteractorIF {
+		},
+		controller.NewHoldemWebController)
+	BindWebControllerFor("omaha",
+		func() usecase.OmahaInteractorIF {
 			return usecase.NewOmahaInteractor(domain.NewDefaultOmaha(), new(presenter.OmahaWebPresenter))
-		})
-	})
-	BindWebController("shortdeck", func() WebController {
-		return controller.NewShortDeckWebController(func() usecase.ShortDeckInteractorIF {
+		},
+		controller.NewOmahaWebController)
+	BindWebControllerFor("shortdeck",
+		func() usecase.ShortDeckInteractorIF {
 			return usecase.NewShortDeckInteractor(domain.NewDefaultShortDeck(), new(presenter.ShortDeckWebPresenter))
-		})
-	})
-	BindWebController("pineapple", func() WebController {
-		return controller.NewPineappleWebController(func() usecase.PineappleInteractorIF {
+		},
+		controller.NewShortDeckWebController)
+	BindWebControllerFor("pineapple",
+		func() usecase.PineappleInteractorIF {
 			return usecase.NewPineappleInteractor(domain.NewDefaultPineapple(), new(presenter.PineappleWebPresenter))
-		})
-	})
-	BindWebController("hearts", func() WebController {
-		return controller.NewHeartsWebController(func() usecase.HeartsInteractorIF {
+		},
+		controller.NewPineappleWebController)
+	BindWebControllerFor("hearts",
+		func() usecase.HeartsInteractorIF {
 			return usecase.NewHeartsInteractor(domain.NewDefaultHearts(), new(presenter.HeartsWebPresenter))
-		})
-	})
-	BindWebController("memory", func() WebController {
-		return controller.NewMemoryWebController(func() usecase.MemoryInteractorIF {
+		},
+		controller.NewHeartsWebController)
+	BindWebControllerFor("memory",
+		func() usecase.MemoryInteractorIF {
 			return usecase.NewMemoryInteractor(domain.NewDefaultMemory(), new(presenter.MemoryWebPresenter))
-		})
-	})
-	BindWebController("klondike", func() WebController {
-		return controller.NewKlondikeWebController(func() usecase.KlondikeInteractorIF {
+		},
+		controller.NewMemoryWebController)
+	BindWebControllerFor("klondike",
+		func() usecase.KlondikeInteractorIF {
 			return usecase.NewKlondikeInteractor(domain.NewDefaultKlondike(), new(presenter.KlondikeWebPresenter))
-		})
-	})
-	BindWebController("freecell", func() WebController {
-		return controller.NewFreeCellWebController(func() usecase.FreeCellInteractorIF {
+		},
+		controller.NewKlondikeWebController)
+	BindWebControllerFor("freecell",
+		func() usecase.FreeCellInteractorIF {
 			return usecase.NewFreeCellInteractor(domain.NewDefaultFreeCell(), new(presenter.FreeCellWebPresenter))
-		})
-	})
-	BindWebController("baccarat", func() WebController {
-		return controller.NewBaccaratWebController(func() usecase.BaccaratInteractorIF {
+		},
+		controller.NewFreeCellWebController)
+	BindWebControllerFor("baccarat",
+		func() usecase.BaccaratInteractorIF {
 			return usecase.NewBaccaratInteractor(domain.NewDefaultBaccarat(), new(presenter.BaccaratWebPresenter))
-		})
-	})
-	BindWebController("spades", func() WebController {
-		return controller.NewSpadesWebController(func() usecase.SpadesInteractorIF {
+		},
+		controller.NewBaccaratWebController)
+	BindWebControllerFor("spades",
+		func() usecase.SpadesInteractorIF {
 			return usecase.NewSpadesInteractor(domain.NewDefaultSpades(), new(presenter.SpadesWebPresenter))
-		})
-	})
-	BindWebController("crazyeights", func() WebController {
-		return controller.NewCrazyEightsWebController(func() usecase.CrazyEightsInteractorIF {
+		},
+		controller.NewSpadesWebController)
+	BindWebControllerFor("crazyeights",
+		func() usecase.CrazyEightsInteractorIF {
 			return usecase.NewCrazyEightsInteractor(domain.NewDefaultCrazyEights(), new(presenter.CrazyEightsWebPresenter))
-		})
-	})
-	BindWebController("ginrummy", func() WebController {
-		return controller.NewGinRummyWebController(func() usecase.GinRummyInteractorIF {
+		},
+		controller.NewCrazyEightsWebController)
+	BindWebControllerFor("ginrummy",
+		func() usecase.GinRummyInteractorIF {
 			return usecase.NewGinRummyInteractor(domain.NewDefaultGinRummy(), new(presenter.GinRummyWebPresenter))
-		})
-	})
-	BindWebController("canasta", func() WebController {
-		return controller.NewCanastaWebController(func() usecase.CanastaInteractorIF {
+		},
+		controller.NewGinRummyWebController)
+	BindWebControllerFor("canasta",
+		func() usecase.CanastaInteractorIF {
 			return usecase.NewCanastaInteractor(domain.NewDefaultCanasta(), new(presenter.CanastaWebPresenter))
-		})
-	})
-	BindWebController("spider", func() WebController {
-		return controller.NewSpiderWebController(func() usecase.SpiderInteractorIF {
+		},
+		controller.NewCanastaWebController)
+	BindWebControllerFor("spider",
+		func() usecase.SpiderInteractorIF {
 			return usecase.NewSpiderInteractor(domain.NewDefaultSpider(), new(presenter.SpiderWebPresenter))
-		})
-	})
-	BindWebController("napoleon", func() WebController {
-		return controller.NewNapoleonWebController(func() usecase.NapoleonInteractorIF {
+		},
+		controller.NewSpiderWebController)
+	BindWebControllerFor("napoleon",
+		func() usecase.NapoleonInteractorIF {
 			return usecase.NewNapoleonInteractor(domain.NewDefaultNapoleon(), new(presenter.NapoleonWebPresenter))
-		})
-	})
-	BindWebController("indianpoker", func() WebController {
-		return controller.NewIndianPokerWebController(func() usecase.IndianPokerInteractorIF {
+		},
+		controller.NewNapoleonWebController)
+	BindWebControllerFor("indianpoker",
+		func() usecase.IndianPokerInteractorIF {
 			return usecase.NewIndianPokerInteractor(domain.NewDefaultIndianPoker(), new(presenter.IndianPokerWebPresenter))
-		})
-	})
-	BindWebController("videopoker", func() WebController {
-		return controller.NewVideoPokerWebController(func() usecase.VideoPokerInteractorIF {
+		},
+		controller.NewIndianPokerWebController)
+	BindWebControllerFor("videopoker",
+		func() usecase.VideoPokerInteractorIF {
 			return usecase.NewVideoPokerInteractor(domain.NewDefaultVideoPoker(), new(presenter.VideoPokerWebPresenter))
-		})
-	})
-	BindWebController("deuceswild", func() WebController {
-		return controller.NewVideoPokerWebController(func() usecase.VideoPokerInteractorIF {
+		},
+		controller.NewVideoPokerWebController)
+	BindWebControllerFor("deuceswild",
+		func() usecase.VideoPokerInteractorIF {
 			return usecase.NewVideoPokerInteractor(domain.NewDeucesWildVideoPoker(), new(presenter.VideoPokerWebPresenter))
-		})
-	})
-	BindWebController("jokerpoker", func() WebController {
-		return controller.NewVideoPokerWebController(func() usecase.VideoPokerInteractorIF {
+		},
+		controller.NewVideoPokerWebController)
+	BindWebControllerFor("jokerpoker",
+		func() usecase.VideoPokerInteractorIF {
 			return usecase.NewVideoPokerInteractor(domain.NewJokerPokerVideoPoker(), new(presenter.VideoPokerWebPresenter))
-		})
-	})
-	BindWebController("euchre", func() WebController {
-		return controller.NewEuchreWebController(func() usecase.EuchreInteractorIF {
+		},
+		controller.NewVideoPokerWebController)
+	BindWebControllerFor("euchre",
+		func() usecase.EuchreInteractorIF {
 			return usecase.NewEuchreInteractor(domain.NewDefaultEuchre(), new(presenter.EuchreWebPresenter))
-		})
-	})
-	BindWebController("pyramid", func() WebController {
-		return controller.NewPyramidWebController(func() usecase.PyramidInteractorIF {
+		},
+		controller.NewEuchreWebController)
+	BindWebControllerFor("pyramid",
+		func() usecase.PyramidInteractorIF {
 			return usecase.NewPyramidInteractor(domain.NewDefaultPyramid(), new(presenter.PyramidWebPresenter))
-		})
-	})
-	BindWebController("tripeaks", func() WebController {
-		return controller.NewTriPeaksWebController(func() usecase.TriPeaksInteractorIF {
+		},
+		controller.NewPyramidWebController)
+	BindWebControllerFor("tripeaks",
+		func() usecase.TriPeaksInteractorIF {
 			return usecase.NewTriPeaksInteractor(domain.NewDefaultTriPeaks(), new(presenter.TriPeaksWebPresenter))
-		})
-	})
-	BindWebController("cribbage", func() WebController {
-		return controller.NewCribbageWebController(func() usecase.CribbageInteractorIF {
+		},
+		controller.NewTriPeaksWebController)
+	BindWebControllerFor("cribbage",
+		func() usecase.CribbageInteractorIF {
 			return usecase.NewCribbageInteractor(domain.NewDefaultCribbage(), new(presenter.CribbageWebPresenter))
-		})
-	})
-	BindWebController("threecard", func() WebController {
-		return controller.NewThreeCardWebController(func() usecase.ThreeCardInteractorIF {
+		},
+		controller.NewCribbageWebController)
+	BindWebControllerFor("threecard",
+		func() usecase.ThreeCardInteractorIF {
 			return usecase.NewThreeCardInteractor(domain.NewDefaultThreeCard(), new(presenter.ThreeCardWebPresenter))
-		})
-	})
-	BindWebController("ohhell", func() WebController {
-		return controller.NewOhHellWebController(func() usecase.OhHellInteractorIF {
+		},
+		controller.NewThreeCardWebController)
+	BindWebControllerFor("ohhell",
+		func() usecase.OhHellInteractorIF {
 			return usecase.NewOhHellInteractor(domain.NewDefaultOhHell(), new(presenter.OhHellWebPresenter))
-		})
-	})
-	BindWebController("bridge", func() WebController {
-		return controller.NewBridgeWebController(func() usecase.BridgeInteractorIF {
+		},
+		controller.NewOhHellWebController)
+	BindWebControllerFor("bridge",
+		func() usecase.BridgeInteractorIF {
 			return usecase.NewBridgeInteractor(domain.NewDefaultBridge(), new(presenter.BridgeWebPresenter))
-		})
-	})
-	BindWebController("speed", func() WebController {
-		return controller.NewSpeedWebController(func() usecase.SpeedInteractorIF {
+		},
+		controller.NewBridgeWebController)
+	BindWebControllerFor("speed",
+		func() usecase.SpeedInteractorIF {
 			return usecase.NewSpeedInteractor(domain.NewDefaultSpeed(), new(presenter.SpeedWebPresenter))
-		})
-	})
-	BindWebController("gofish", func() WebController {
-		return controller.NewGoFishWebController(func() usecase.GoFishInteractorIF {
+		},
+		controller.NewSpeedWebController)
+	BindWebControllerFor("gofish",
+		func() usecase.GoFishInteractorIF {
 			return usecase.NewGoFishInteractor(domain.NewDefaultGoFish(), new(presenter.GoFishWebPresenter))
-		})
-	})
-	BindWebController("pinochle", func() WebController {
-		return controller.NewPinochleWebController(func() usecase.PinochleInteractorIF {
+		},
+		controller.NewGoFishWebController)
+	BindWebControllerFor("pinochle",
+		func() usecase.PinochleInteractorIF {
 			return usecase.NewPinochleInteractor(domain.NewDefaultPinochle(), new(presenter.PinochleWebPresenter))
-		})
-	})
-	BindWebController("golf", func() WebController {
-		return controller.NewGolfWebController(func() usecase.GolfInteractorIF {
+		},
+		controller.NewPinochleWebController)
+	BindWebControllerFor("golf",
+		func() usecase.GolfInteractorIF {
 			return usecase.NewGolfInteractor(domain.NewDefaultGolf(), new(presenter.GolfWebPresenter))
-		})
-	})
-	BindWebController("pigtail", func() WebController {
-		return controller.NewPigsTailWebController(func() usecase.PigsTailInteractorIF {
+		},
+		controller.NewGolfWebController)
+	BindWebControllerFor("pigtail",
+		func() usecase.PigsTailInteractorIF {
 			return usecase.NewPigsTailInteractor(domain.NewDefaultPigsTail(), new(presenter.PigsTailWebPresenter))
-		})
-	})
-	BindWebController("sevencardstud", func() WebController {
-		return controller.NewSevenCardStudWebController(func() usecase.SevenCardStudInteractorIF {
+		},
+		controller.NewPigsTailWebController)
+	BindWebControllerFor("sevencardstud",
+		func() usecase.SevenCardStudInteractorIF {
 			return usecase.NewSevenCardStudInteractor(domain.NewDefaultSevenCardStud(), new(presenter.SevenCardStudWebPresenter))
-		})
-	})
-	BindWebController("clocksolitaire", func() WebController {
-		return controller.NewClockSolitaireWebController(func() usecase.ClockSolitaireInteractorIF {
+		},
+		controller.NewSevenCardStudWebController)
+	BindWebControllerFor("clocksolitaire",
+		func() usecase.ClockSolitaireInteractorIF {
 			return usecase.NewClockSolitaireInteractor(domain.NewDefaultClockSolitaire(), new(presenter.ClockSolitaireWebPresenter))
-		})
-	})
-	BindWebController("durak", func() WebController {
-		return controller.NewDurakWebController(func() usecase.DurakInteractorIF {
+		},
+		controller.NewClockSolitaireWebController)
+	BindWebControllerFor("durak",
+		func() usecase.DurakInteractorIF {
 			return usecase.NewDurakInteractor(domain.NewDefaultDurak(), new(presenter.DurakWebPresenter))
-		})
-	})
-	BindWebController("fortythieves", func() WebController {
-		return controller.NewFortyThievesWebController(func() usecase.FortyThievesInteractorIF {
+		},
+		controller.NewDurakWebController)
+	BindWebControllerFor("fortythieves",
+		func() usecase.FortyThievesInteractorIF {
 			return usecase.NewFortyThievesInteractor(domain.NewDefaultFortyThieves(), new(presenter.FortyThievesWebPresenter))
-		})
-	})
-	BindWebController("paigow", func() WebController {
-		return controller.NewPaiGowWebController(func() usecase.PaiGowInteractorIF {
+		},
+		controller.NewFortyThievesWebController)
+	BindWebControllerFor("paigow",
+		func() usecase.PaiGowInteractorIF {
 			return usecase.NewPaiGowInteractor(domain.NewDefaultPaiGow(), new(presenter.PaiGowWebPresenter))
-		})
-	})
-	BindWebController("twotenjack", func() WebController {
-		return controller.NewTwoTenJackWebController(func() usecase.TwoTenJackInteractorIF {
+		},
+		controller.NewPaiGowWebController)
+	BindWebControllerFor("twotenjack",
+		func() usecase.TwoTenJackInteractorIF {
 			return usecase.NewTwoTenJackInteractor(domain.NewDefaultTwoTenJack(), new(presenter.TwoTenJackWebPresenter))
-		})
-	})
-	BindWebController("caribbeanstud", func() WebController {
-		return controller.NewCaribbeanStudWebController(func() usecase.CaribbeanStudInteractorIF {
+		},
+		controller.NewTwoTenJackWebController)
+	BindWebControllerFor("caribbeanstud",
+		func() usecase.CaribbeanStudInteractorIF {
 			return usecase.NewCaribbeanStudInteractor(domain.NewDefaultCaribbeanStud(), new(presenter.CaribbeanStudWebPresenter))
-		})
-	})
-	BindWebController("war", func() WebController {
-		return controller.NewWarWebController(func() usecase.WarInteractorIF {
+		},
+		controller.NewCaribbeanStudWebController)
+	BindWebControllerFor("war",
+		func() usecase.WarInteractorIF {
 			return usecase.NewWarInteractor(domain.NewDefaultWar(), new(presenter.WarWebPresenter))
-		})
-	})
-	BindWebController("canfield", func() WebController {
-		return controller.NewCanfieldWebController(func() usecase.CanfieldInteractorIF {
+		},
+		controller.NewWarWebController)
+	BindWebControllerFor("canfield",
+		func() usecase.CanfieldInteractorIF {
 			return usecase.NewCanfieldInteractor(domain.NewDefaultCanfield(), new(presenter.CanfieldWebPresenter))
-		})
-	})
-	BindWebController("fiftyone", func() WebController {
-		return controller.NewFiftyOneWebController(func() usecase.FiftyOneInteractorIF {
+		},
+		controller.NewCanfieldWebController)
+	BindWebControllerFor("fiftyone",
+		func() usecase.FiftyOneInteractorIF {
 			return usecase.NewFiftyOneInteractor(domain.NewDefaultFiftyOne(), new(presenter.FiftyOneWebPresenter))
-		})
-	})
-	BindWebController("yukon", func() WebController {
-		return controller.NewYukonWebController(func() usecase.YukonInteractorIF {
+		},
+		controller.NewFiftyOneWebController)
+	BindWebControllerFor("yukon",
+		func() usecase.YukonInteractorIF {
 			return usecase.NewYukonInteractor(domain.NewDefaultYukon(), new(presenter.YukonWebPresenter))
-		})
-	})
-	BindWebController("whist", func() WebController {
-		return controller.NewWhistWebController(func() usecase.WhistInteractorIF {
+		},
+		controller.NewYukonWebController)
+	BindWebControllerFor("whist",
+		func() usecase.WhistInteractorIF {
 			return usecase.NewWhistInteractor(domain.NewDefaultWhist(), new(presenter.WhistWebPresenter))
-		})
-	})
-	BindWebController("letitride", func() WebController {
-		return controller.NewLetItRideWebController(func() usecase.LetItRideInteractorIF {
+		},
+		controller.NewWhistWebController)
+	BindWebControllerFor("letitride",
+		func() usecase.LetItRideInteractorIF {
 			return usecase.NewLetItRideInteractor(domain.NewDefaultLetItRide(), new(presenter.LetItRideWebPresenter))
-		})
-	})
-	BindWebController("pokersquares", func() WebController {
-		return controller.NewPokerSquaresWebController(func() usecase.PokerSquaresInteractorIF {
+		},
+		controller.NewLetItRideWebController)
+	BindWebControllerFor("pokersquares",
+		func() usecase.PokerSquaresInteractorIF {
 			return usecase.NewPokerSquaresInteractor(domain.NewDefaultPokerSquares(), new(presenter.PokerSquaresWebPresenter))
-		})
-	})
-	BindWebController("pageone", func() WebController {
-		return controller.NewPageOneWebController(func() usecase.PageOneInteractorIF {
+		},
+		controller.NewPokerSquaresWebController)
+	BindWebControllerFor("pageone",
+		func() usecase.PageOneInteractorIF {
 			return usecase.NewPageOneInteractor(domain.NewDefaultPageOne(), new(presenter.PageOneWebPresenter))
-		})
-	})
-	BindWebController("reddog", func() WebController {
-		return controller.NewRedDogWebController(func() usecase.RedDogInteractorIF {
+		},
+		controller.NewPageOneWebController)
+	BindWebControllerFor("reddog",
+		func() usecase.RedDogInteractorIF {
 			return usecase.NewRedDogInteractor(domain.NewDefaultRedDog(), new(presenter.RedDogWebPresenter))
-		})
-	})
-	BindWebController("razz", func() WebController {
-		return controller.NewSevenCardStudWebController(func() usecase.SevenCardStudInteractorIF {
+		},
+		controller.NewRedDogWebController)
+	BindWebControllerFor("razz",
+		func() usecase.SevenCardStudInteractorIF {
 			return usecase.NewSevenCardStudInteractor(domain.NewDefaultRazz(), new(presenter.SevenCardStudWebPresenter))
-		})
-	})
-	BindWebController("scorpion", func() WebController {
-		return controller.NewScorpionWebController(func() usecase.ScorpionInteractorIF {
+		},
+		controller.NewSevenCardStudWebController)
+	BindWebControllerFor("scorpion",
+		func() usecase.ScorpionInteractorIF {
 			return usecase.NewScorpionInteractor(domain.NewDefaultScorpion(), new(presenter.ScorpionWebPresenter))
-		})
-	})
+		},
+		controller.NewScorpionWebController)
 }

--- a/internal/infrastructure/games/server_helper.go
+++ b/internal/infrastructure/games/server_helper.go
@@ -1,0 +1,21 @@
+//go:build !js || !wasm
+
+package games
+
+import (
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
+)
+
+// BindWebControllerFor is a thin generic wrapper over BindWebController that
+// removes the double-closure boilerplate shared by every game. Callers pass
+// the interactor factory and the matching NewXxxWebController constructor;
+// the outer `func() WebController` closure is supplied here.
+func BindWebControllerFor[I any, P controller.WebInput, O any](
+	name string,
+	newInteractor func() I,
+	newCtrl func(func() I) *controller.GameWebController[I, P, O],
+) {
+	BindWebController(name, func() WebController {
+		return newCtrl(newInteractor)
+	})
+}


### PR DESCRIPTION
## Summary

Introduces `BindWebControllerFor` — a typed generic helper that removes the outer `func() WebController` closure repeated 55 times in `games_server.go`. Call sites now read as "name, interactor factory, controller constructor" rather than a doubly-nested closure.

- **New**: `internal/infrastructure/games/server_helper.go` (21 lines, `!js || !wasm`)
- **Rewritten**: `internal/infrastructure/games/games_server.go` — 55 registrations migrated to the helper

### Why

- Eliminates one level of closure nesting at every call site.
- Future cross-cutting changes (middleware, metrics, feature flags) now land in one spot.
- Makes it harder to typo the controller / interactor pairing at the call site — the helper's signature enforces the shape.

Note: line count of `games_server.go` is roughly unchanged because `gofmt` requires the factory closure to be on its own lines. The original issue's `-60 LOC` estimate was aspirational; the qualitative DRY and extensibility wins are what matter.

Closes #1414

## Test plan

- [x] `go build ./...`
- [x] `go test -tags test ./...`
- [x] `golangci-lint run ./internal/infrastructure/games/...`
- [x] `goimports -w` on modified files
- [ ] Manual smoke: `go run ./cmd/trumpcards web` + hit `/blackjack/exec` and `/hearts/exec` (not run locally)