### PR TITLE
refactor(games): DRY worker KV bindings in casino/classic/solo

### DIFF
--- a/internal/infrastructure/games/casino/casino.go
+++ b/internal/infrastructure/games/casino/casino.go
@@ -6,213 +6,156 @@
 package casino
 
 import (
-	"net/http"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/games"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/worker"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
 func init() {
-	games.BindWorker("blackjack", games.CategoryCasino, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/blackjack/exec", "blackjack:",
-			func() usecase.BlackJackInteractorIF {
-				return usecase.NewBlackJackInteractor(domain.NewDefaultBlackJack(), new(presenter.BlackJackWebPresenter))
-			},
-			func(data []byte) (usecase.BlackJackInteractorIF, error) {
-				return usecase.RestoreBlackJackInteractor(data, new(presenter.BlackJackWebPresenter))
-			},
-			controller.NewBlackJackWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("poker", games.CategoryCasino, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/poker/exec", "poker:",
-			func() usecase.PokerInteractorIF {
-				return usecase.NewPokerInteractor(domain.NewDefaultPoker(), new(presenter.PokerWebPresenter))
-			},
-			func(data []byte) (usecase.PokerInteractorIF, error) {
-				return usecase.RestorePokerInteractor(data, new(presenter.PokerWebPresenter))
-			},
-			controller.NewPokerWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("holdem", games.CategoryCasino, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/holdem/exec", "holdem:",
-			func() usecase.HoldemInteractorIF {
-				return usecase.NewHoldemInteractor(domain.NewDefaultHoldem(), new(presenter.HoldemWebPresenter))
-			},
-			func(data []byte) (usecase.HoldemInteractorIF, error) {
-				return usecase.RestoreHoldemInteractor(data, new(presenter.HoldemWebPresenter))
-			},
-			controller.NewHoldemWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("omaha", games.CategoryCasino, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/omaha/exec", "omaha:",
-			func() usecase.OmahaInteractorIF {
-				return usecase.NewOmahaInteractor(domain.NewDefaultOmaha(), new(presenter.OmahaWebPresenter))
-			},
-			func(data []byte) (usecase.OmahaInteractorIF, error) {
-				return usecase.RestoreOmahaInteractor(data, new(presenter.OmahaWebPresenter))
-			},
-			controller.NewOmahaWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("shortdeck", games.CategoryCasino, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/shortdeck/exec", "shortdeck:",
-			func() usecase.ShortDeckInteractorIF {
-				return usecase.NewShortDeckInteractor(domain.NewDefaultShortDeck(), new(presenter.ShortDeckWebPresenter))
-			},
-			func(data []byte) (usecase.ShortDeckInteractorIF, error) {
-				return usecase.RestoreShortDeckInteractor(data, new(presenter.ShortDeckWebPresenter))
-			},
-			controller.NewShortDeckWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("pineapple", games.CategoryCasino, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/pineapple/exec", "pineapple:",
-			func() usecase.PineappleInteractorIF {
-				return usecase.NewPineappleInteractor(domain.NewDefaultPineapple(), new(presenter.PineappleWebPresenter))
-			},
-			func(data []byte) (usecase.PineappleInteractorIF, error) {
-				return usecase.RestorePineappleInteractor(data, new(presenter.PineappleWebPresenter))
-			},
-			controller.NewPineappleWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("baccarat", games.CategoryCasino, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/baccarat/exec", "baccarat:",
-			func() usecase.BaccaratInteractorIF {
-				return usecase.NewBaccaratInteractor(domain.NewDefaultBaccarat(), new(presenter.BaccaratWebPresenter))
-			},
-			func(data []byte) (usecase.BaccaratInteractorIF, error) {
-				return usecase.RestoreBaccaratInteractor(data, new(presenter.BaccaratWebPresenter))
-			},
-			controller.NewBaccaratWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("indianpoker", games.CategoryCasino, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/indianpoker/exec", "indianpoker:",
-			func() usecase.IndianPokerInteractorIF {
-				return usecase.NewIndianPokerInteractor(domain.NewDefaultIndianPoker(), new(presenter.IndianPokerWebPresenter))
-			},
-			func(data []byte) (usecase.IndianPokerInteractorIF, error) {
-				return usecase.RestoreIndianPokerInteractor(data, new(presenter.IndianPokerWebPresenter))
-			},
-			controller.NewIndianPokerWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("videopoker", games.CategoryCasino, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/videopoker/exec", "videopoker:",
-			func() usecase.VideoPokerInteractorIF {
-				return usecase.NewVideoPokerInteractor(domain.NewDefaultVideoPoker(), new(presenter.VideoPokerWebPresenter))
-			},
-			func(data []byte) (usecase.VideoPokerInteractorIF, error) {
-				return usecase.RestoreVideoPokerInteractor(data, new(presenter.VideoPokerWebPresenter))
-			},
-			controller.NewVideoPokerWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("deuceswild", games.CategoryCasino, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/deuceswild/exec", "deuceswild:",
-			func() usecase.VideoPokerInteractorIF {
-				return usecase.NewVideoPokerInteractor(domain.NewDeucesWildVideoPoker(), new(presenter.VideoPokerWebPresenter))
-			},
-			func(data []byte) (usecase.VideoPokerInteractorIF, error) {
-				return usecase.RestoreVideoPokerInteractor(data, new(presenter.VideoPokerWebPresenter))
-			},
-			controller.NewVideoPokerWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("jokerpoker", games.CategoryCasino, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/jokerpoker/exec", "jokerpoker:",
-			func() usecase.VideoPokerInteractorIF {
-				return usecase.NewVideoPokerInteractor(domain.NewJokerPokerVideoPoker(), new(presenter.VideoPokerWebPresenter))
-			},
-			func(data []byte) (usecase.VideoPokerInteractorIF, error) {
-				return usecase.RestoreVideoPokerInteractor(data, new(presenter.VideoPokerWebPresenter))
-			},
-			controller.NewVideoPokerWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("threecard", games.CategoryCasino, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/threecard/exec", "threecard:",
-			func() usecase.ThreeCardInteractorIF {
-				return usecase.NewThreeCardInteractor(domain.NewDefaultThreeCard(), new(presenter.ThreeCardWebPresenter))
-			},
-			func(data []byte) (usecase.ThreeCardInteractorIF, error) {
-				return usecase.RestoreThreeCardInteractor(data, new(presenter.ThreeCardWebPresenter))
-			},
-			controller.NewThreeCardWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("sevencardstud", games.CategoryCasino, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/sevencardstud/exec", "sevencardstud:",
-			func() usecase.SevenCardStudInteractorIF {
-				return usecase.NewSevenCardStudInteractor(domain.NewDefaultSevenCardStud(), new(presenter.SevenCardStudWebPresenter))
-			},
-			func(data []byte) (usecase.SevenCardStudInteractorIF, error) {
-				return usecase.RestoreSevenCardStudInteractor(data, new(presenter.SevenCardStudWebPresenter))
-			},
-			controller.NewSevenCardStudWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("paigow", games.CategoryCasino, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/paigow/exec", "paigow:",
-			func() usecase.PaiGowInteractorIF {
-				return usecase.NewPaiGowInteractor(domain.NewDefaultPaiGow(), new(presenter.PaiGowWebPresenter))
-			},
-			func(data []byte) (usecase.PaiGowInteractorIF, error) {
-				return usecase.RestorePaiGowInteractor(data, new(presenter.PaiGowWebPresenter))
-			},
-			controller.NewPaiGowWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("caribbeanstud", games.CategoryCasino, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/caribbeanstud/exec", "caribbeanstud:",
-			func() usecase.CaribbeanStudInteractorIF {
-				return usecase.NewCaribbeanStudInteractor(domain.NewDefaultCaribbeanStud(), new(presenter.CaribbeanStudWebPresenter))
-			},
-			func(data []byte) (usecase.CaribbeanStudInteractorIF, error) {
-				return usecase.RestoreCaribbeanStudInteractor(data, new(presenter.CaribbeanStudWebPresenter))
-			},
-			controller.NewCaribbeanStudWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("letitride", games.CategoryCasino, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/letitride/exec", "letitride:",
-			func() usecase.LetItRideInteractorIF {
-				return usecase.NewLetItRideInteractor(domain.NewDefaultLetItRide(), new(presenter.LetItRideWebPresenter))
-			},
-			func(data []byte) (usecase.LetItRideInteractorIF, error) {
-				return usecase.RestoreLetItRideInteractor(data, new(presenter.LetItRideWebPresenter))
-			},
-			controller.NewLetItRideWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("reddog", games.CategoryCasino, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/reddog/exec", "reddog:",
-			func() usecase.RedDogInteractorIF {
-				return usecase.NewRedDogInteractor(domain.NewDefaultRedDog(), new(presenter.RedDogWebPresenter))
-			},
-			func(data []byte) (usecase.RedDogInteractorIF, error) {
-				return usecase.RestoreRedDogInteractor(data, new(presenter.RedDogWebPresenter))
-			},
-			controller.NewRedDogWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("razz", games.CategoryCasino, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/razz/exec", "razz:",
-			func() usecase.SevenCardStudInteractorIF {
-				return usecase.NewSevenCardStudInteractor(domain.NewDefaultRazz(), new(presenter.SevenCardStudWebPresenter))
-			},
-			func(data []byte) (usecase.SevenCardStudInteractorIF, error) {
-				return usecase.RestoreSevenCardStudInteractor(data, new(presenter.SevenCardStudWebPresenter))
-			},
-			controller.NewSevenCardStudWebControllerWithProvider,
-		)
-	})
+	games.RegisterKVGame("blackjack", games.CategoryCasino,
+		func() usecase.BlackJackInteractorIF {
+			return usecase.NewBlackJackInteractor(domain.NewDefaultBlackJack(), new(presenter.BlackJackWebPresenter))
+		},
+		func(data []byte) (usecase.BlackJackInteractorIF, error) {
+			return usecase.RestoreBlackJackInteractor(data, new(presenter.BlackJackWebPresenter))
+		},
+		controller.NewBlackJackWebControllerWithProvider)
+	games.RegisterKVGame("poker", games.CategoryCasino,
+		func() usecase.PokerInteractorIF {
+			return usecase.NewPokerInteractor(domain.NewDefaultPoker(), new(presenter.PokerWebPresenter))
+		},
+		func(data []byte) (usecase.PokerInteractorIF, error) {
+			return usecase.RestorePokerInteractor(data, new(presenter.PokerWebPresenter))
+		},
+		controller.NewPokerWebControllerWithProvider)
+	games.RegisterKVGame("holdem", games.CategoryCasino,
+		func() usecase.HoldemInteractorIF {
+			return usecase.NewHoldemInteractor(domain.NewDefaultHoldem(), new(presenter.HoldemWebPresenter))
+		},
+		func(data []byte) (usecase.HoldemInteractorIF, error) {
+			return usecase.RestoreHoldemInteractor(data, new(presenter.HoldemWebPresenter))
+		},
+		controller.NewHoldemWebControllerWithProvider)
+	games.RegisterKVGame("omaha", games.CategoryCasino,
+		func() usecase.OmahaInteractorIF {
+			return usecase.NewOmahaInteractor(domain.NewDefaultOmaha(), new(presenter.OmahaWebPresenter))
+		},
+		func(data []byte) (usecase.OmahaInteractorIF, error) {
+			return usecase.RestoreOmahaInteractor(data, new(presenter.OmahaWebPresenter))
+		},
+		controller.NewOmahaWebControllerWithProvider)
+	games.RegisterKVGame("shortdeck", games.CategoryCasino,
+		func() usecase.ShortDeckInteractorIF {
+			return usecase.NewShortDeckInteractor(domain.NewDefaultShortDeck(), new(presenter.ShortDeckWebPresenter))
+		},
+		func(data []byte) (usecase.ShortDeckInteractorIF, error) {
+			return usecase.RestoreShortDeckInteractor(data, new(presenter.ShortDeckWebPresenter))
+		},
+		controller.NewShortDeckWebControllerWithProvider)
+	games.RegisterKVGame("pineapple", games.CategoryCasino,
+		func() usecase.PineappleInteractorIF {
+			return usecase.NewPineappleInteractor(domain.NewDefaultPineapple(), new(presenter.PineappleWebPresenter))
+		},
+		func(data []byte) (usecase.PineappleInteractorIF, error) {
+			return usecase.RestorePineappleInteractor(data, new(presenter.PineappleWebPresenter))
+		},
+		controller.NewPineappleWebControllerWithProvider)
+	games.RegisterKVGame("baccarat", games.CategoryCasino,
+		func() usecase.BaccaratInteractorIF {
+			return usecase.NewBaccaratInteractor(domain.NewDefaultBaccarat(), new(presenter.BaccaratWebPresenter))
+		},
+		func(data []byte) (usecase.BaccaratInteractorIF, error) {
+			return usecase.RestoreBaccaratInteractor(data, new(presenter.BaccaratWebPresenter))
+		},
+		controller.NewBaccaratWebControllerWithProvider)
+	games.RegisterKVGame("indianpoker", games.CategoryCasino,
+		func() usecase.IndianPokerInteractorIF {
+			return usecase.NewIndianPokerInteractor(domain.NewDefaultIndianPoker(), new(presenter.IndianPokerWebPresenter))
+		},
+		func(data []byte) (usecase.IndianPokerInteractorIF, error) {
+			return usecase.RestoreIndianPokerInteractor(data, new(presenter.IndianPokerWebPresenter))
+		},
+		controller.NewIndianPokerWebControllerWithProvider)
+	games.RegisterKVGame("videopoker", games.CategoryCasino,
+		func() usecase.VideoPokerInteractorIF {
+			return usecase.NewVideoPokerInteractor(domain.NewDefaultVideoPoker(), new(presenter.VideoPokerWebPresenter))
+		},
+		func(data []byte) (usecase.VideoPokerInteractorIF, error) {
+			return usecase.RestoreVideoPokerInteractor(data, new(presenter.VideoPokerWebPresenter))
+		},
+		controller.NewVideoPokerWebControllerWithProvider)
+	games.RegisterKVGame("deuceswild", games.CategoryCasino,
+		func() usecase.VideoPokerInteractorIF {
+			return usecase.NewVideoPokerInteractor(domain.NewDeucesWildVideoPoker(), new(presenter.VideoPokerWebPresenter))
+		},
+		func(data []byte) (usecase.VideoPokerInteractorIF, error) {
+			return usecase.RestoreVideoPokerInteractor(data, new(presenter.VideoPokerWebPresenter))
+		},
+		controller.NewVideoPokerWebControllerWithProvider)
+	games.RegisterKVGame("jokerpoker", games.CategoryCasino,
+		func() usecase.VideoPokerInteractorIF {
+			return usecase.NewVideoPokerInteractor(domain.NewJokerPokerVideoPoker(), new(presenter.VideoPokerWebPresenter))
+		},
+		func(data []byte) (usecase.VideoPokerInteractorIF, error) {
+			return usecase.RestoreVideoPokerInteractor(data, new(presenter.VideoPokerWebPresenter))
+		},
+		controller.NewVideoPokerWebControllerWithProvider)
+	games.RegisterKVGame("threecard", games.CategoryCasino,
+		func() usecase.ThreeCardInteractorIF {
+			return usecase.NewThreeCardInteractor(domain.NewDefaultThreeCard(), new(presenter.ThreeCardWebPresenter))
+		},
+		func(data []byte) (usecase.ThreeCardInteractorIF, error) {
+			return usecase.RestoreThreeCardInteractor(data, new(presenter.ThreeCardWebPresenter))
+		},
+		controller.NewThreeCardWebControllerWithProvider)
+	games.RegisterKVGame("sevencardstud", games.CategoryCasino,
+		func() usecase.SevenCardStudInteractorIF {
+			return usecase.NewSevenCardStudInteractor(domain.NewDefaultSevenCardStud(), new(presenter.SevenCardStudWebPresenter))
+		},
+		func(data []byte) (usecase.SevenCardStudInteractorIF, error) {
+			return usecase.RestoreSevenCardStudInteractor(data, new(presenter.SevenCardStudWebPresenter))
+		},
+		controller.NewSevenCardStudWebControllerWithProvider)
+	games.RegisterKVGame("paigow", games.CategoryCasino,
+		func() usecase.PaiGowInteractorIF {
+			return usecase.NewPaiGowInteractor(domain.NewDefaultPaiGow(), new(presenter.PaiGowWebPresenter))
+		},
+		func(data []byte) (usecase.PaiGowInteractorIF, error) {
+			return usecase.RestorePaiGowInteractor(data, new(presenter.PaiGowWebPresenter))
+		},
+		controller.NewPaiGowWebControllerWithProvider)
+	games.RegisterKVGame("caribbeanstud", games.CategoryCasino,
+		func() usecase.CaribbeanStudInteractorIF {
+			return usecase.NewCaribbeanStudInteractor(domain.NewDefaultCaribbeanStud(), new(presenter.CaribbeanStudWebPresenter))
+		},
+		func(data []byte) (usecase.CaribbeanStudInteractorIF, error) {
+			return usecase.RestoreCaribbeanStudInteractor(data, new(presenter.CaribbeanStudWebPresenter))
+		},
+		controller.NewCaribbeanStudWebControllerWithProvider)
+	games.RegisterKVGame("letitride", games.CategoryCasino,
+		func() usecase.LetItRideInteractorIF {
+			return usecase.NewLetItRideInteractor(domain.NewDefaultLetItRide(), new(presenter.LetItRideWebPresenter))
+		},
+		func(data []byte) (usecase.LetItRideInteractorIF, error) {
+			return usecase.RestoreLetItRideInteractor(data, new(presenter.LetItRideWebPresenter))
+		},
+		controller.NewLetItRideWebControllerWithProvider)
+	games.RegisterKVGame("reddog", games.CategoryCasino,
+		func() usecase.RedDogInteractorIF {
+			return usecase.NewRedDogInteractor(domain.NewDefaultRedDog(), new(presenter.RedDogWebPresenter))
+		},
+		func(data []byte) (usecase.RedDogInteractorIF, error) {
+			return usecase.RestoreRedDogInteractor(data, new(presenter.RedDogWebPresenter))
+		},
+		controller.NewRedDogWebControllerWithProvider)
+	games.RegisterKVGame("razz", games.CategoryCasino,
+		func() usecase.SevenCardStudInteractorIF {
+			return usecase.NewSevenCardStudInteractor(domain.NewDefaultRazz(), new(presenter.SevenCardStudWebPresenter))
+		},
+		func(data []byte) (usecase.SevenCardStudInteractorIF, error) {
+			return usecase.RestoreSevenCardStudInteractor(data, new(presenter.SevenCardStudWebPresenter))
+		},
+		controller.NewSevenCardStudWebControllerWithProvider)
 }

--- a/internal/infrastructure/games/classic/classic.go
+++ b/internal/infrastructure/games/classic/classic.go
@@ -7,246 +7,180 @@
 package classic
 
 import (
-	"net/http"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/games"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/worker"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
 func init() {
-	games.BindWorker("oldmaid", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/oldmaid/exec", "oldmaid:",
-			func() usecase.OldMaidInteractorIF {
-				return usecase.NewOldMaidInteractor(domain.NewDefaultOldMaid(), new(presenter.OldMaidWebPresenter))
-			},
-			func(data []byte) (usecase.OldMaidInteractorIF, error) {
-				return usecase.RestoreOldMaidInteractor(data, new(presenter.OldMaidWebPresenter))
-			},
-			controller.NewOldMaidWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("daifugo", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/daifugo/exec", "daifugo:",
-			func() usecase.DaifugoInteractorIF {
-				return usecase.NewDaifugoInteractor(domain.NewDefaultDaifugo(), new(presenter.DaifugoWebPresenter))
-			},
-			func(data []byte) (usecase.DaifugoInteractorIF, error) {
-				return usecase.RestoreDaifugoInteractor(data, new(presenter.DaifugoWebPresenter))
-			},
-			controller.NewDaifugoWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("sevens", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/sevens/exec", "sevens:",
-			func() usecase.SevensInteractorIF {
-				return usecase.NewSevensInteractor(domain.NewDefaultSevens(), new(presenter.SevensWebPresenter))
-			},
-			func(data []byte) (usecase.SevensInteractorIF, error) {
-				return usecase.RestoreSevensInteractor(data, new(presenter.SevensWebPresenter))
-			},
-			controller.NewSevensWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("doubt", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/doubt/exec", "doubt:",
-			func() usecase.DoubtInteractorIF {
-				return usecase.NewDoubtInteractor(domain.NewDefaultDoubt(), new(presenter.DoubtWebPresenter))
-			},
-			func(data []byte) (usecase.DoubtInteractorIF, error) {
-				return usecase.RestoreDoubtInteractor(data, new(presenter.DoubtWebPresenter))
-			},
-			controller.NewDoubtWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("hearts", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/hearts/exec", "hearts:",
-			func() usecase.HeartsInteractorIF {
-				return usecase.NewHeartsInteractor(domain.NewDefaultHearts(), new(presenter.HeartsWebPresenter))
-			},
-			func(data []byte) (usecase.HeartsInteractorIF, error) {
-				return usecase.RestoreHeartsInteractor(data, new(presenter.HeartsWebPresenter))
-			},
-			controller.NewHeartsWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("spades", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/spades/exec", "spades:",
-			func() usecase.SpadesInteractorIF {
-				return usecase.NewSpadesInteractor(domain.NewDefaultSpades(), new(presenter.SpadesWebPresenter))
-			},
-			func(data []byte) (usecase.SpadesInteractorIF, error) {
-				return usecase.RestoreSpadesInteractor(data, new(presenter.SpadesWebPresenter))
-			},
-			controller.NewSpadesWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("crazyeights", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/crazyeights/exec", "crazyeights:",
-			func() usecase.CrazyEightsInteractorIF {
-				return usecase.NewCrazyEightsInteractor(domain.NewDefaultCrazyEights(), new(presenter.CrazyEightsWebPresenter))
-			},
-			func(data []byte) (usecase.CrazyEightsInteractorIF, error) {
-				return usecase.RestoreCrazyEightsInteractor(data, new(presenter.CrazyEightsWebPresenter))
-			},
-			controller.NewCrazyEightsWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("napoleon", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/napoleon/exec", "napoleon:",
-			func() usecase.NapoleonInteractorIF {
-				return usecase.NewNapoleonInteractor(domain.NewDefaultNapoleon(), new(presenter.NapoleonWebPresenter))
-			},
-			func(data []byte) (usecase.NapoleonInteractorIF, error) {
-				return usecase.RestoreNapoleonInteractor(data, new(presenter.NapoleonWebPresenter))
-			},
-			controller.NewNapoleonWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("euchre", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/euchre/exec", "euchre:",
-			func() usecase.EuchreInteractorIF {
-				return usecase.NewEuchreInteractor(domain.NewDefaultEuchre(), new(presenter.EuchreWebPresenter))
-			},
-			func(data []byte) (usecase.EuchreInteractorIF, error) {
-				return usecase.RestoreEuchreInteractor(data, new(presenter.EuchreWebPresenter))
-			},
-			controller.NewEuchreWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("ohhell", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/ohhell/exec", "ohhell:",
-			func() usecase.OhHellInteractorIF {
-				return usecase.NewOhHellInteractor(domain.NewDefaultOhHell(), new(presenter.OhHellWebPresenter))
-			},
-			func(data []byte) (usecase.OhHellInteractorIF, error) {
-				return usecase.RestoreOhHellInteractor(data, new(presenter.OhHellWebPresenter))
-			},
-			controller.NewOhHellWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("bridge", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/bridge/exec", "bridge:",
-			func() usecase.BridgeInteractorIF {
-				return usecase.NewBridgeInteractor(domain.NewDefaultBridge(), new(presenter.BridgeWebPresenter))
-			},
-			func(data []byte) (usecase.BridgeInteractorIF, error) {
-				return usecase.RestoreBridgeInteractor(data, new(presenter.BridgeWebPresenter))
-			},
-			controller.NewBridgeWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("speed", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/speed/exec", "speed:",
-			func() usecase.SpeedInteractorIF {
-				return usecase.NewSpeedInteractor(domain.NewDefaultSpeed(), new(presenter.SpeedWebPresenter))
-			},
-			func(data []byte) (usecase.SpeedInteractorIF, error) {
-				return usecase.RestoreSpeedInteractor(data, new(presenter.SpeedWebPresenter))
-			},
-			controller.NewSpeedWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("gofish", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/gofish/exec", "gofish:",
-			func() usecase.GoFishInteractorIF {
-				return usecase.NewGoFishInteractor(domain.NewDefaultGoFish(), new(presenter.GoFishWebPresenter))
-			},
-			func(data []byte) (usecase.GoFishInteractorIF, error) {
-				return usecase.RestoreGoFishInteractor(data, new(presenter.GoFishWebPresenter))
-			},
-			controller.NewGoFishWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("pinochle", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/pinochle/exec", "pinochle:",
-			func() usecase.PinochleInteractorIF {
-				return usecase.NewPinochleInteractor(domain.NewDefaultPinochle(), new(presenter.PinochleWebPresenter))
-			},
-			func(data []byte) (usecase.PinochleInteractorIF, error) {
-				return usecase.RestorePinochleInteractor(data, new(presenter.PinochleWebPresenter))
-			},
-			controller.NewPinochleWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("pigtail", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/pigtail/exec", "pigtail:",
-			func() usecase.PigsTailInteractorIF {
-				return usecase.NewPigsTailInteractor(domain.NewDefaultPigsTail(), new(presenter.PigsTailWebPresenter))
-			},
-			func(data []byte) (usecase.PigsTailInteractorIF, error) {
-				return usecase.RestorePigsTailInteractor(data, new(presenter.PigsTailWebPresenter))
-			},
-			controller.NewPigsTailWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("durak", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/durak/exec", "durak:",
-			func() usecase.DurakInteractorIF {
-				return usecase.NewDurakInteractor(domain.NewDefaultDurak(), new(presenter.DurakWebPresenter))
-			},
-			func(data []byte) (usecase.DurakInteractorIF, error) {
-				return usecase.RestoreDurakInteractor(data, new(presenter.DurakWebPresenter))
-			},
-			controller.NewDurakWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("twotenjack", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/twotenjack/exec", "twotenjack:",
-			func() usecase.TwoTenJackInteractorIF {
-				return usecase.NewTwoTenJackInteractor(domain.NewDefaultTwoTenJack(), new(presenter.TwoTenJackWebPresenter))
-			},
-			func(data []byte) (usecase.TwoTenJackInteractorIF, error) {
-				return usecase.RestoreTwoTenJackInteractor(data, new(presenter.TwoTenJackWebPresenter))
-			},
-			controller.NewTwoTenJackWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("war", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/war/exec", "war:",
-			func() usecase.WarInteractorIF {
-				return usecase.NewWarInteractor(domain.NewDefaultWar(), new(presenter.WarWebPresenter))
-			},
-			func(data []byte) (usecase.WarInteractorIF, error) {
-				return usecase.RestoreWarInteractor(data, new(presenter.WarWebPresenter))
-			},
-			controller.NewWarWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("fiftyone", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/fiftyone/exec", "fiftyone:",
-			func() usecase.FiftyOneInteractorIF {
-				return usecase.NewFiftyOneInteractor(domain.NewDefaultFiftyOne(), new(presenter.FiftyOneWebPresenter))
-			},
-			func(data []byte) (usecase.FiftyOneInteractorIF, error) {
-				return usecase.RestoreFiftyOneInteractor(data, new(presenter.FiftyOneWebPresenter))
-			},
-			controller.NewFiftyOneWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("whist", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/whist/exec", "whist:",
-			func() usecase.WhistInteractorIF {
-				return usecase.NewWhistInteractor(domain.NewDefaultWhist(), new(presenter.WhistWebPresenter))
-			},
-			func(data []byte) (usecase.WhistInteractorIF, error) {
-				return usecase.RestoreWhistInteractor(data, new(presenter.WhistWebPresenter))
-			},
-			controller.NewWhistWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("pageone", games.CategoryClassic, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/pageone/exec", "pageone:",
-			func() usecase.PageOneInteractorIF {
-				return usecase.NewPageOneInteractor(domain.NewDefaultPageOne(), new(presenter.PageOneWebPresenter))
-			},
-			func(data []byte) (usecase.PageOneInteractorIF, error) {
-				return usecase.RestorePageOneInteractor(data, new(presenter.PageOneWebPresenter))
-			},
-			controller.NewPageOneWebControllerWithProvider,
-		)
-	})
+	games.RegisterKVGame("oldmaid", games.CategoryClassic,
+		func() usecase.OldMaidInteractorIF {
+			return usecase.NewOldMaidInteractor(domain.NewDefaultOldMaid(), new(presenter.OldMaidWebPresenter))
+		},
+		func(data []byte) (usecase.OldMaidInteractorIF, error) {
+			return usecase.RestoreOldMaidInteractor(data, new(presenter.OldMaidWebPresenter))
+		},
+		controller.NewOldMaidWebControllerWithProvider)
+	games.RegisterKVGame("daifugo", games.CategoryClassic,
+		func() usecase.DaifugoInteractorIF {
+			return usecase.NewDaifugoInteractor(domain.NewDefaultDaifugo(), new(presenter.DaifugoWebPresenter))
+		},
+		func(data []byte) (usecase.DaifugoInteractorIF, error) {
+			return usecase.RestoreDaifugoInteractor(data, new(presenter.DaifugoWebPresenter))
+		},
+		controller.NewDaifugoWebControllerWithProvider)
+	games.RegisterKVGame("sevens", games.CategoryClassic,
+		func() usecase.SevensInteractorIF {
+			return usecase.NewSevensInteractor(domain.NewDefaultSevens(), new(presenter.SevensWebPresenter))
+		},
+		func(data []byte) (usecase.SevensInteractorIF, error) {
+			return usecase.RestoreSevensInteractor(data, new(presenter.SevensWebPresenter))
+		},
+		controller.NewSevensWebControllerWithProvider)
+	games.RegisterKVGame("doubt", games.CategoryClassic,
+		func() usecase.DoubtInteractorIF {
+			return usecase.NewDoubtInteractor(domain.NewDefaultDoubt(), new(presenter.DoubtWebPresenter))
+		},
+		func(data []byte) (usecase.DoubtInteractorIF, error) {
+			return usecase.RestoreDoubtInteractor(data, new(presenter.DoubtWebPresenter))
+		},
+		controller.NewDoubtWebControllerWithProvider)
+	games.RegisterKVGame("hearts", games.CategoryClassic,
+		func() usecase.HeartsInteractorIF {
+			return usecase.NewHeartsInteractor(domain.NewDefaultHearts(), new(presenter.HeartsWebPresenter))
+		},
+		func(data []byte) (usecase.HeartsInteractorIF, error) {
+			return usecase.RestoreHeartsInteractor(data, new(presenter.HeartsWebPresenter))
+		},
+		controller.NewHeartsWebControllerWithProvider)
+	games.RegisterKVGame("spades", games.CategoryClassic,
+		func() usecase.SpadesInteractorIF {
+			return usecase.NewSpadesInteractor(domain.NewDefaultSpades(), new(presenter.SpadesWebPresenter))
+		},
+		func(data []byte) (usecase.SpadesInteractorIF, error) {
+			return usecase.RestoreSpadesInteractor(data, new(presenter.SpadesWebPresenter))
+		},
+		controller.NewSpadesWebControllerWithProvider)
+	games.RegisterKVGame("crazyeights", games.CategoryClassic,
+		func() usecase.CrazyEightsInteractorIF {
+			return usecase.NewCrazyEightsInteractor(domain.NewDefaultCrazyEights(), new(presenter.CrazyEightsWebPresenter))
+		},
+		func(data []byte) (usecase.CrazyEightsInteractorIF, error) {
+			return usecase.RestoreCrazyEightsInteractor(data, new(presenter.CrazyEightsWebPresenter))
+		},
+		controller.NewCrazyEightsWebControllerWithProvider)
+	games.RegisterKVGame("napoleon", games.CategoryClassic,
+		func() usecase.NapoleonInteractorIF {
+			return usecase.NewNapoleonInteractor(domain.NewDefaultNapoleon(), new(presenter.NapoleonWebPresenter))
+		},
+		func(data []byte) (usecase.NapoleonInteractorIF, error) {
+			return usecase.RestoreNapoleonInteractor(data, new(presenter.NapoleonWebPresenter))
+		},
+		controller.NewNapoleonWebControllerWithProvider)
+	games.RegisterKVGame("euchre", games.CategoryClassic,
+		func() usecase.EuchreInteractorIF {
+			return usecase.NewEuchreInteractor(domain.NewDefaultEuchre(), new(presenter.EuchreWebPresenter))
+		},
+		func(data []byte) (usecase.EuchreInteractorIF, error) {
+			return usecase.RestoreEuchreInteractor(data, new(presenter.EuchreWebPresenter))
+		},
+		controller.NewEuchreWebControllerWithProvider)
+	games.RegisterKVGame("ohhell", games.CategoryClassic,
+		func() usecase.OhHellInteractorIF {
+			return usecase.NewOhHellInteractor(domain.NewDefaultOhHell(), new(presenter.OhHellWebPresenter))
+		},
+		func(data []byte) (usecase.OhHellInteractorIF, error) {
+			return usecase.RestoreOhHellInteractor(data, new(presenter.OhHellWebPresenter))
+		},
+		controller.NewOhHellWebControllerWithProvider)
+	games.RegisterKVGame("bridge", games.CategoryClassic,
+		func() usecase.BridgeInteractorIF {
+			return usecase.NewBridgeInteractor(domain.NewDefaultBridge(), new(presenter.BridgeWebPresenter))
+		},
+		func(data []byte) (usecase.BridgeInteractorIF, error) {
+			return usecase.RestoreBridgeInteractor(data, new(presenter.BridgeWebPresenter))
+		},
+		controller.NewBridgeWebControllerWithProvider)
+	games.RegisterKVGame("speed", games.CategoryClassic,
+		func() usecase.SpeedInteractorIF {
+			return usecase.NewSpeedInteractor(domain.NewDefaultSpeed(), new(presenter.SpeedWebPresenter))
+		},
+		func(data []byte) (usecase.SpeedInteractorIF, error) {
+			return usecase.RestoreSpeedInteractor(data, new(presenter.SpeedWebPresenter))
+		},
+		controller.NewSpeedWebControllerWithProvider)
+	games.RegisterKVGame("gofish", games.CategoryClassic,
+		func() usecase.GoFishInteractorIF {
+			return usecase.NewGoFishInteractor(domain.NewDefaultGoFish(), new(presenter.GoFishWebPresenter))
+		},
+		func(data []byte) (usecase.GoFishInteractorIF, error) {
+			return usecase.RestoreGoFishInteractor(data, new(presenter.GoFishWebPresenter))
+		},
+		controller.NewGoFishWebControllerWithProvider)
+	games.RegisterKVGame("pinochle", games.CategoryClassic,
+		func() usecase.PinochleInteractorIF {
+			return usecase.NewPinochleInteractor(domain.NewDefaultPinochle(), new(presenter.PinochleWebPresenter))
+		},
+		func(data []byte) (usecase.PinochleInteractorIF, error) {
+			return usecase.RestorePinochleInteractor(data, new(presenter.PinochleWebPresenter))
+		},
+		controller.NewPinochleWebControllerWithProvider)
+	games.RegisterKVGame("pigtail", games.CategoryClassic,
+		func() usecase.PigsTailInteractorIF {
+			return usecase.NewPigsTailInteractor(domain.NewDefaultPigsTail(), new(presenter.PigsTailWebPresenter))
+		},
+		func(data []byte) (usecase.PigsTailInteractorIF, error) {
+			return usecase.RestorePigsTailInteractor(data, new(presenter.PigsTailWebPresenter))
+		},
+		controller.NewPigsTailWebControllerWithProvider)
+	games.RegisterKVGame("durak", games.CategoryClassic,
+		func() usecase.DurakInteractorIF {
+			return usecase.NewDurakInteractor(domain.NewDefaultDurak(), new(presenter.DurakWebPresenter))
+		},
+		func(data []byte) (usecase.DurakInteractorIF, error) {
+			return usecase.RestoreDurakInteractor(data, new(presenter.DurakWebPresenter))
+		},
+		controller.NewDurakWebControllerWithProvider)
+	games.RegisterKVGame("twotenjack", games.CategoryClassic,
+		func() usecase.TwoTenJackInteractorIF {
+			return usecase.NewTwoTenJackInteractor(domain.NewDefaultTwoTenJack(), new(presenter.TwoTenJackWebPresenter))
+		},
+		func(data []byte) (usecase.TwoTenJackInteractorIF, error) {
+			return usecase.RestoreTwoTenJackInteractor(data, new(presenter.TwoTenJackWebPresenter))
+		},
+		controller.NewTwoTenJackWebControllerWithProvider)
+	games.RegisterKVGame("war", games.CategoryClassic,
+		func() usecase.WarInteractorIF {
+			return usecase.NewWarInteractor(domain.NewDefaultWar(), new(presenter.WarWebPresenter))
+		},
+		func(data []byte) (usecase.WarInteractorIF, error) {
+			return usecase.RestoreWarInteractor(data, new(presenter.WarWebPresenter))
+		},
+		controller.NewWarWebControllerWithProvider)
+	games.RegisterKVGame("fiftyone", games.CategoryClassic,
+		func() usecase.FiftyOneInteractorIF {
+			return usecase.NewFiftyOneInteractor(domain.NewDefaultFiftyOne(), new(presenter.FiftyOneWebPresenter))
+		},
+		func(data []byte) (usecase.FiftyOneInteractorIF, error) {
+			return usecase.RestoreFiftyOneInteractor(data, new(presenter.FiftyOneWebPresenter))
+		},
+		controller.NewFiftyOneWebControllerWithProvider)
+	games.RegisterKVGame("whist", games.CategoryClassic,
+		func() usecase.WhistInteractorIF {
+			return usecase.NewWhistInteractor(domain.NewDefaultWhist(), new(presenter.WhistWebPresenter))
+		},
+		func(data []byte) (usecase.WhistInteractorIF, error) {
+			return usecase.RestoreWhistInteractor(data, new(presenter.WhistWebPresenter))
+		},
+		controller.NewWhistWebControllerWithProvider)
+	games.RegisterKVGame("pageone", games.CategoryClassic,
+		func() usecase.PageOneInteractorIF {
+			return usecase.NewPageOneInteractor(domain.NewDefaultPageOne(), new(presenter.PageOneWebPresenter))
+		},
+		func(data []byte) (usecase.PageOneInteractorIF, error) {
+			return usecase.RestorePageOneInteractor(data, new(presenter.PageOneWebPresenter))
+		},
+		controller.NewPageOneWebControllerWithProvider)
 }

--- a/internal/infrastructure/games/solo/solo.go
+++ b/internal/infrastructure/games/solo/solo.go
@@ -6,191 +6,140 @@
 package solo
 
 import (
-	"net/http"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/games"
-	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/worker"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
 func init() {
-	games.BindWorker("memory", games.CategorySolo, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/memory/exec", "memory:",
-			func() usecase.MemoryInteractorIF {
-				return usecase.NewMemoryInteractor(domain.NewDefaultMemory(), new(presenter.MemoryWebPresenter))
-			},
-			func(data []byte) (usecase.MemoryInteractorIF, error) {
-				return usecase.RestoreMemoryInteractor(data, new(presenter.MemoryWebPresenter))
-			},
-			controller.NewMemoryWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("klondike", games.CategorySolo, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/klondike/exec", "klondike:",
-			func() usecase.KlondikeInteractorIF {
-				return usecase.NewKlondikeInteractor(domain.NewDefaultKlondike(), new(presenter.KlondikeWebPresenter))
-			},
-			func(data []byte) (usecase.KlondikeInteractorIF, error) {
-				return usecase.RestoreKlondikeInteractor(data, new(presenter.KlondikeWebPresenter))
-			},
-			controller.NewKlondikeWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("freecell", games.CategorySolo, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/freecell/exec", "freecell:",
-			func() usecase.FreeCellInteractorIF {
-				return usecase.NewFreeCellInteractor(domain.NewDefaultFreeCell(), new(presenter.FreeCellWebPresenter))
-			},
-			func(data []byte) (usecase.FreeCellInteractorIF, error) {
-				return usecase.RestoreFreeCellInteractor(data, new(presenter.FreeCellWebPresenter))
-			},
-			controller.NewFreeCellWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("ginrummy", games.CategorySolo, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/ginrummy/exec", "ginrummy:",
-			func() usecase.GinRummyInteractorIF {
-				return usecase.NewGinRummyInteractor(domain.NewDefaultGinRummy(), new(presenter.GinRummyWebPresenter))
-			},
-			func(data []byte) (usecase.GinRummyInteractorIF, error) {
-				return usecase.RestoreGinRummyInteractor(data, new(presenter.GinRummyWebPresenter))
-			},
-			controller.NewGinRummyWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("canasta", games.CategorySolo, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/canasta/exec", "canasta:",
-			func() usecase.CanastaInteractorIF {
-				return usecase.NewCanastaInteractor(domain.NewDefaultCanasta(), new(presenter.CanastaWebPresenter))
-			},
-			func(data []byte) (usecase.CanastaInteractorIF, error) {
-				return usecase.RestoreCanastaInteractor(data, new(presenter.CanastaWebPresenter))
-			},
-			controller.NewCanastaWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("spider", games.CategorySolo, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/spider/exec", "spider:",
-			func() usecase.SpiderInteractorIF {
-				return usecase.NewSpiderInteractor(domain.NewDefaultSpider(), new(presenter.SpiderWebPresenter))
-			},
-			func(data []byte) (usecase.SpiderInteractorIF, error) {
-				return usecase.RestoreSpiderInteractor(data, new(presenter.SpiderWebPresenter))
-			},
-			controller.NewSpiderWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("pyramid", games.CategorySolo, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/pyramid/exec", "pyramid:",
-			func() usecase.PyramidInteractorIF {
-				return usecase.NewPyramidInteractor(domain.NewDefaultPyramid(), new(presenter.PyramidWebPresenter))
-			},
-			func(data []byte) (usecase.PyramidInteractorIF, error) {
-				return usecase.RestorePyramidInteractor(data, new(presenter.PyramidWebPresenter))
-			},
-			controller.NewPyramidWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("tripeaks", games.CategorySolo, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/tripeaks/exec", "tripeaks:",
-			func() usecase.TriPeaksInteractorIF {
-				return usecase.NewTriPeaksInteractor(domain.NewDefaultTriPeaks(), new(presenter.TriPeaksWebPresenter))
-			},
-			func(data []byte) (usecase.TriPeaksInteractorIF, error) {
-				return usecase.RestoreTriPeaksInteractor(data, new(presenter.TriPeaksWebPresenter))
-			},
-			controller.NewTriPeaksWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("cribbage", games.CategorySolo, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/cribbage/exec", "cribbage:",
-			func() usecase.CribbageInteractorIF {
-				return usecase.NewCribbageInteractor(domain.NewDefaultCribbage(), new(presenter.CribbageWebPresenter))
-			},
-			func(data []byte) (usecase.CribbageInteractorIF, error) {
-				return usecase.RestoreCribbageInteractor(data, new(presenter.CribbageWebPresenter))
-			},
-			controller.NewCribbageWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("golf", games.CategorySolo, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/golf/exec", "golf:",
-			func() usecase.GolfInteractorIF {
-				return usecase.NewGolfInteractor(domain.NewDefaultGolf(), new(presenter.GolfWebPresenter))
-			},
-			func(data []byte) (usecase.GolfInteractorIF, error) {
-				return usecase.RestoreGolfInteractor(data, new(presenter.GolfWebPresenter))
-			},
-			controller.NewGolfWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("clocksolitaire", games.CategorySolo, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/clocksolitaire/exec", "clocksolitaire:",
-			func() usecase.ClockSolitaireInteractorIF {
-				return usecase.NewClockSolitaireInteractor(domain.NewDefaultClockSolitaire(), new(presenter.ClockSolitaireWebPresenter))
-			},
-			func(data []byte) (usecase.ClockSolitaireInteractorIF, error) {
-				return usecase.RestoreClockSolitaireInteractor(data, new(presenter.ClockSolitaireWebPresenter))
-			},
-			controller.NewClockSolitaireWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("fortythieves", games.CategorySolo, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/fortythieves/exec", "fortythieves:",
-			func() usecase.FortyThievesInteractorIF {
-				return usecase.NewFortyThievesInteractor(domain.NewDefaultFortyThieves(), new(presenter.FortyThievesWebPresenter))
-			},
-			func(data []byte) (usecase.FortyThievesInteractorIF, error) {
-				return usecase.RestoreFortyThievesInteractor(data, new(presenter.FortyThievesWebPresenter))
-			},
-			controller.NewFortyThievesWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("canfield", games.CategorySolo, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/canfield/exec", "canfield:",
-			func() usecase.CanfieldInteractorIF {
-				return usecase.NewCanfieldInteractor(domain.NewDefaultCanfield(), new(presenter.CanfieldWebPresenter))
-			},
-			func(data []byte) (usecase.CanfieldInteractorIF, error) {
-				return usecase.RestoreCanfieldInteractor(data, new(presenter.CanfieldWebPresenter))
-			},
-			controller.NewCanfieldWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("yukon", games.CategorySolo, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/yukon/exec", "yukon:",
-			func() usecase.YukonInteractorIF {
-				return usecase.NewYukonInteractor(domain.NewDefaultYukon(), new(presenter.YukonWebPresenter))
-			},
-			func(data []byte) (usecase.YukonInteractorIF, error) {
-				return usecase.RestoreYukonInteractor(data, new(presenter.YukonWebPresenter))
-			},
-			controller.NewYukonWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("pokersquares", games.CategorySolo, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/pokersquares/exec", "pokersquares:",
-			func() usecase.PokerSquaresInteractorIF {
-				return usecase.NewPokerSquaresInteractor(domain.NewDefaultPokerSquares(), new(presenter.PokerSquaresWebPresenter))
-			},
-			func(data []byte) (usecase.PokerSquaresInteractorIF, error) {
-				return usecase.RestorePokerSquaresInteractor(data, new(presenter.PokerSquaresWebPresenter))
-			},
-			controller.NewPokerSquaresWebControllerWithProvider,
-		)
-	})
-	games.BindWorker("scorpion", games.CategorySolo, func(mux *http.ServeMux) error {
-		return worker.RegisterKV(mux, "/scorpion/exec", "scorpion:",
-			func() usecase.ScorpionInteractorIF {
-				return usecase.NewScorpionInteractor(domain.NewDefaultScorpion(), new(presenter.ScorpionWebPresenter))
-			},
-			func(data []byte) (usecase.ScorpionInteractorIF, error) {
-				return usecase.RestoreScorpionInteractor(data, new(presenter.ScorpionWebPresenter))
-			},
-			controller.NewScorpionWebControllerWithProvider,
-		)
-	})
+	games.RegisterKVGame("memory", games.CategorySolo,
+		func() usecase.MemoryInteractorIF {
+			return usecase.NewMemoryInteractor(domain.NewDefaultMemory(), new(presenter.MemoryWebPresenter))
+		},
+		func(data []byte) (usecase.MemoryInteractorIF, error) {
+			return usecase.RestoreMemoryInteractor(data, new(presenter.MemoryWebPresenter))
+		},
+		controller.NewMemoryWebControllerWithProvider)
+	games.RegisterKVGame("klondike", games.CategorySolo,
+		func() usecase.KlondikeInteractorIF {
+			return usecase.NewKlondikeInteractor(domain.NewDefaultKlondike(), new(presenter.KlondikeWebPresenter))
+		},
+		func(data []byte) (usecase.KlondikeInteractorIF, error) {
+			return usecase.RestoreKlondikeInteractor(data, new(presenter.KlondikeWebPresenter))
+		},
+		controller.NewKlondikeWebControllerWithProvider)
+	games.RegisterKVGame("freecell", games.CategorySolo,
+		func() usecase.FreeCellInteractorIF {
+			return usecase.NewFreeCellInteractor(domain.NewDefaultFreeCell(), new(presenter.FreeCellWebPresenter))
+		},
+		func(data []byte) (usecase.FreeCellInteractorIF, error) {
+			return usecase.RestoreFreeCellInteractor(data, new(presenter.FreeCellWebPresenter))
+		},
+		controller.NewFreeCellWebControllerWithProvider)
+	games.RegisterKVGame("ginrummy", games.CategorySolo,
+		func() usecase.GinRummyInteractorIF {
+			return usecase.NewGinRummyInteractor(domain.NewDefaultGinRummy(), new(presenter.GinRummyWebPresenter))
+		},
+		func(data []byte) (usecase.GinRummyInteractorIF, error) {
+			return usecase.RestoreGinRummyInteractor(data, new(presenter.GinRummyWebPresenter))
+		},
+		controller.NewGinRummyWebControllerWithProvider)
+	games.RegisterKVGame("canasta", games.CategorySolo,
+		func() usecase.CanastaInteractorIF {
+			return usecase.NewCanastaInteractor(domain.NewDefaultCanasta(), new(presenter.CanastaWebPresenter))
+		},
+		func(data []byte) (usecase.CanastaInteractorIF, error) {
+			return usecase.RestoreCanastaInteractor(data, new(presenter.CanastaWebPresenter))
+		},
+		controller.NewCanastaWebControllerWithProvider)
+	games.RegisterKVGame("spider", games.CategorySolo,
+		func() usecase.SpiderInteractorIF {
+			return usecase.NewSpiderInteractor(domain.NewDefaultSpider(), new(presenter.SpiderWebPresenter))
+		},
+		func(data []byte) (usecase.SpiderInteractorIF, error) {
+			return usecase.RestoreSpiderInteractor(data, new(presenter.SpiderWebPresenter))
+		},
+		controller.NewSpiderWebControllerWithProvider)
+	games.RegisterKVGame("pyramid", games.CategorySolo,
+		func() usecase.PyramidInteractorIF {
+			return usecase.NewPyramidInteractor(domain.NewDefaultPyramid(), new(presenter.PyramidWebPresenter))
+		},
+		func(data []byte) (usecase.PyramidInteractorIF, error) {
+			return usecase.RestorePyramidInteractor(data, new(presenter.PyramidWebPresenter))
+		},
+		controller.NewPyramidWebControllerWithProvider)
+	games.RegisterKVGame("tripeaks", games.CategorySolo,
+		func() usecase.TriPeaksInteractorIF {
+			return usecase.NewTriPeaksInteractor(domain.NewDefaultTriPeaks(), new(presenter.TriPeaksWebPresenter))
+		},
+		func(data []byte) (usecase.TriPeaksInteractorIF, error) {
+			return usecase.RestoreTriPeaksInteractor(data, new(presenter.TriPeaksWebPresenter))
+		},
+		controller.NewTriPeaksWebControllerWithProvider)
+	games.RegisterKVGame("cribbage", games.CategorySolo,
+		func() usecase.CribbageInteractorIF {
+			return usecase.NewCribbageInteractor(domain.NewDefaultCribbage(), new(presenter.CribbageWebPresenter))
+		},
+		func(data []byte) (usecase.CribbageInteractorIF, error) {
+			return usecase.RestoreCribbageInteractor(data, new(presenter.CribbageWebPresenter))
+		},
+		controller.NewCribbageWebControllerWithProvider)
+	games.RegisterKVGame("golf", games.CategorySolo,
+		func() usecase.GolfInteractorIF {
+			return usecase.NewGolfInteractor(domain.NewDefaultGolf(), new(presenter.GolfWebPresenter))
+		},
+		func(data []byte) (usecase.GolfInteractorIF, error) {
+			return usecase.RestoreGolfInteractor(data, new(presenter.GolfWebPresenter))
+		},
+		controller.NewGolfWebControllerWithProvider)
+	games.RegisterKVGame("clocksolitaire", games.CategorySolo,
+		func() usecase.ClockSolitaireInteractorIF {
+			return usecase.NewClockSolitaireInteractor(domain.NewDefaultClockSolitaire(), new(presenter.ClockSolitaireWebPresenter))
+		},
+		func(data []byte) (usecase.ClockSolitaireInteractorIF, error) {
+			return usecase.RestoreClockSolitaireInteractor(data, new(presenter.ClockSolitaireWebPresenter))
+		},
+		controller.NewClockSolitaireWebControllerWithProvider)
+	games.RegisterKVGame("fortythieves", games.CategorySolo,
+		func() usecase.FortyThievesInteractorIF {
+			return usecase.NewFortyThievesInteractor(domain.NewDefaultFortyThieves(), new(presenter.FortyThievesWebPresenter))
+		},
+		func(data []byte) (usecase.FortyThievesInteractorIF, error) {
+			return usecase.RestoreFortyThievesInteractor(data, new(presenter.FortyThievesWebPresenter))
+		},
+		controller.NewFortyThievesWebControllerWithProvider)
+	games.RegisterKVGame("canfield", games.CategorySolo,
+		func() usecase.CanfieldInteractorIF {
+			return usecase.NewCanfieldInteractor(domain.NewDefaultCanfield(), new(presenter.CanfieldWebPresenter))
+		},
+		func(data []byte) (usecase.CanfieldInteractorIF, error) {
+			return usecase.RestoreCanfieldInteractor(data, new(presenter.CanfieldWebPresenter))
+		},
+		controller.NewCanfieldWebControllerWithProvider)
+	games.RegisterKVGame("yukon", games.CategorySolo,
+		func() usecase.YukonInteractorIF {
+			return usecase.NewYukonInteractor(domain.NewDefaultYukon(), new(presenter.YukonWebPresenter))
+		},
+		func(data []byte) (usecase.YukonInteractorIF, error) {
+			return usecase.RestoreYukonInteractor(data, new(presenter.YukonWebPresenter))
+		},
+		controller.NewYukonWebControllerWithProvider)
+	games.RegisterKVGame("pokersquares", games.CategorySolo,
+		func() usecase.PokerSquaresInteractorIF {
+			return usecase.NewPokerSquaresInteractor(domain.NewDefaultPokerSquares(), new(presenter.PokerSquaresWebPresenter))
+		},
+		func(data []byte) (usecase.PokerSquaresInteractorIF, error) {
+			return usecase.RestorePokerSquaresInteractor(data, new(presenter.PokerSquaresWebPresenter))
+		},
+		controller.NewPokerSquaresWebControllerWithProvider)
+	games.RegisterKVGame("scorpion", games.CategorySolo,
+		func() usecase.ScorpionInteractorIF {
+			return usecase.NewScorpionInteractor(domain.NewDefaultScorpion(), new(presenter.ScorpionWebPresenter))
+		},
+		func(data []byte) (usecase.ScorpionInteractorIF, error) {
+			return usecase.RestoreScorpionInteractor(data, new(presenter.ScorpionWebPresenter))
+		},
+		controller.NewScorpionWebControllerWithProvider)
 }

--- a/internal/infrastructure/games/worker_helper.go
+++ b/internal/infrastructure/games/worker_helper.go
@@ -1,0 +1,26 @@
+//go:build js && wasm
+
+package games
+
+import (
+	"net/http"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/worker"
+)
+
+// RegisterKVGame binds a KV-backed handler for name under the given category.
+// URL path and KV prefix are derived from name by the project convention
+// (/<name>/exec and "<name>:"), so each call site only has to supply the
+// ingredients that actually vary per game.
+func RegisterKVGame[I worker.SnapshotIF, P controller.WebInput, O any](
+	name string,
+	category Category,
+	factory func() I,
+	restore func([]byte) (I, error),
+	newCtrl func(controller.SessionProvider[I], func() I) *controller.GameWebController[I, P, O],
+) {
+	BindWorker(name, category, func(mux *http.ServeMux) error {
+		return worker.RegisterKV(mux, "/"+name+"/exec", name+":", factory, restore, newCtrl)
+	})
+}


### PR DESCRIPTION
## Summary

Adds `games.RegisterKVGame[I, P, O]` (build tag `js && wasm`) that wraps `BindWorker` + `worker.RegisterKV` and derives `/<name>/exec` + `"<name>:"` KV prefix from the name by convention. Every casino/classic/solo binding migrates to the helper.

| File | Before | After | Delta |
|------|--------|-------|-------|
| casino.go | 218 | 161 | -26% |
| classic.go | 252 | 186 | -26% |
| solo.go | 196 | 145 | -26% |
| **total** | **666** | **518** | **-22%** |

Plus 26 lines of new helper. Net: **-148 lines**.

### Why

- URL path & KV prefix conventions live in one place — call sites can't drift.
- 55 near-identical 11-line blocks become 6-line calls.
- TinyGo DCE behavior preserved (helper shares the `js && wasm` build tag; inner `worker.RegisterKV` signature unchanged).
- Future cross-cutting changes (middleware, metrics) land in one spot.

Closes #1413

## Test plan

- [x] `go build ./...` (server)
- [x] `GOOS=js GOARCH=wasm go build ./cmd/workers/{casino,classic,solo}/...`
- [x] `go test -tags test ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `goimports -w` on modified files
- [ ] `make build-workers` on CI to verify TinyGo output size is unchanged (not run locally — no tinygo)