### PR TITLE
fix(speed): add Space/Enter keyboard shortcut for Flip

### DIFF
--- a/frontend/src/pages/SpeedPage.test.tsx
+++ b/frontend/src/pages/SpeedPage.test.tsx
@@ -250,6 +250,32 @@ describe('SpeedPage', () => {
     expect(flipPileBtns[0]).toHaveClass('animate-pulse');
   });
 
+  it('keyboard shortcut: Space triggers flip when stuck', async () => {
+    mockExec.mockResolvedValue(stuckState);
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByTestId('flip-button')).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(window, { key: ' ' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('flip'));
+  });
+
+  it('keyboard shortcut: Enter triggers flip when stuck', async () => {
+    mockExec.mockResolvedValue(stuckState);
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByTestId('flip-button')).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(window, { key: 'Enter' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('flip'));
+  });
+
+  it('keyboard shortcut: Space is ignored during play phase', async () => {
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(window, { key: ' ' });
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
   it('keyboard shortcut: digit key smart-plays the matching hand card', async () => {
     renderWithProviders(<SpeedPage />);
     await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -96,22 +96,32 @@ function SpeedPageContent() {
   );
   const { handleCommand } = useCliGame(gameExec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
-  // Keyboard shortcuts: 1..N select a hand card; ←/→ play selected card to left/right center pile.
-  // Active only when CLI mode is off and a play phase is in progress. Respects input focus
-  // and skips when modifier keys (Ctrl/Alt/Meta) are held to avoid hijacking browser shortcuts.
-  // Latest state and handlers are read via refs so the listener is registered only once
+  // Keyboard shortcuts: 1..N select a hand card; ←/→ play selected card to left/right center pile;
+  // Space/Enter triggers Flip during STUCK phase.
+  // Active only when CLI mode is off and a play phase or stuck phase is in progress. Respects
+  // input focus and skips when modifier keys (Ctrl/Alt/Meta) are held to avoid hijacking browser
+  // shortcuts. Latest state and handlers are read via refs so the listener is registered only once
   // per enable/disable transition rather than on every state update (e.g. each CPU move).
   const isPlayPhaseForKeys = state?.phase === SpeedPhase.PLAY;
-  const keyHandlersRef = useRef({ state, handleSmartClick, handlePlay, selectedCardIndices });
-  keyHandlersRef.current = { state, handleSmartClick, handlePlay, selectedCardIndices };
+  const isStuckForKeys = state?.phase === SpeedPhase.STUCK;
+  const keyboardActive = isPlayPhaseForKeys || isStuckForKeys;
+  const keyHandlersRef = useRef({ state, handleSmartClick, handlePlay, selectedCardIndices, handleFlip });
+  keyHandlersRef.current = { state, handleSmartClick, handlePlay, selectedCardIndices, handleFlip };
   useEffect(() => {
-    if (cliEnabled || !isPlayPhaseForKeys || loading) return;
+    if (cliEnabled || !keyboardActive || loading) return;
     const onKey = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement | null;
       if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) return;
       if (e.ctrlKey || e.altKey || e.metaKey) return;
       const cur = keyHandlersRef.current;
       if (!cur.state) return;
+      if (cur.state.phase === SpeedPhase.STUCK) {
+        if (e.key === ' ' || e.key === 'Spacebar' || e.key === 'Enter') {
+          e.preventDefault();
+          cur.handleFlip();
+        }
+        return;
+      }
       if (e.key >= '1' && e.key <= '9') {
         const idx = Number.parseInt(e.key, 10) - 1;
         if (idx < cur.state.players[0].cards.length) {
@@ -129,7 +139,7 @@ function SpeedPageContent() {
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [cliEnabled, isPlayPhaseForKeys, loading]);
+  }, [cliEnabled, keyboardActive, loading]);
 
   if (!state || state.players.length < 2) return <SpeedSkeleton />;
 


### PR DESCRIPTION
## Summary

- Adds Space and Enter keyboard shortcuts that fire `Flip` when the Speed game enters the stuck (膠着) phase.
- Keeps existing digit / arrow shortcuts in the play phase untouched.
- Respects input focus + modifier keys (Ctrl/Alt/Meta) so browser shortcuts are not hijacked.

Closes #1415

## Test plan

- [x] `bun run test -- --run SpeedPage` — new shortcut tests pass (Space, Enter, no-op during play phase).
- [x] Existing digit / arrow keyboard tests still pass.