### PR TITLE
fix(sevens): emphasise joker-placeable cells with blue pulse highlight

### DIFF
--- a/frontend/src/components/sevens/SevensBoard.test.tsx
+++ b/frontend/src/components/sevens/SevensBoard.test.tsx
@@ -148,6 +148,20 @@ describe('SevensBoard', () => {
     expect(button.style.color).toBe('white');
   });
 
+  it('joker placeable cells pulse and have ds-info ring', () => {
+    render(<SevensBoard {...defaultProps} jokerSelecting={true} />);
+    const button = screen.getByLabelText('SPADE 6 に配置') as HTMLElement;
+    expect(button.className).toContain('animate-pulse');
+    expect(button.className).toContain('ring-ds-info');
+    expect(button.dataset.jokerPlaceable).toBe('true');
+  });
+
+  it('joker placeable cells use ds-info background (blue highlight)', () => {
+    render(<SevensBoard {...defaultProps} jokerSelecting={true} />);
+    const button = screen.getByLabelText('SPADE 6 に配置') as HTMLElement;
+    expect(button.style.background).toBe('var(--color-ds-info)');
+  });
+
   it('grid has horizontal scroll wrapper', () => {
     const { container } = render(<SevensBoard {...defaultProps} />);
     const scrollWrapper = container.querySelector('.overflow-x-auto');

--- a/frontend/src/components/sevens/SevensBoard.test.tsx
+++ b/frontend/src/components/sevens/SevensBoard.test.tsx
@@ -148,10 +148,11 @@ describe('SevensBoard', () => {
     expect(button.style.color).toBe('white');
   });
 
-  it('joker placeable cells pulse and have ds-info ring', () => {
+  it('joker placeable cells pulse (motion-safe) and have ds-info ring', () => {
     render(<SevensBoard {...defaultProps} jokerSelecting={true} />);
     const button = screen.getByLabelText('SPADE 6 に配置') as HTMLElement;
-    expect(button.className).toContain('animate-pulse');
+    // Pinned to the motion-safe: variant so OS "Reduce Motion" users never see the pulse.
+    expect(button.className).toContain('motion-safe:animate-pulse');
     expect(button.className).toContain('ring-ds-info');
     expect(button.dataset.jokerPlaceable).toBe('true');
   });

--- a/frontend/src/components/sevens/SevensBoard.tsx
+++ b/frontend/src/components/sevens/SevensBoard.tsx
@@ -85,7 +85,7 @@ function Board({
                         type="button"
                         onClick={() => onJokerPlace?.(idx, v)}
                         aria-label={t('placeAriaLabel', { suit: suitName(idx), value: valueName(v) })}
-                        className={`${baseClass}${bold} ring-2 ring-ds-info ring-offset-1 ring-offset-black/30 animate-pulse cursor-pointer p-0 hover:brightness-110`}
+                        className={`${baseClass}${bold} ring-2 ring-ds-info ring-offset-1 ring-offset-black/30 motion-safe:animate-pulse cursor-pointer p-0 hover:brightness-110`}
                         style={colors}
                         data-testid="board-cell"
                         data-joker-placeable="true"

--- a/frontend/src/components/sevens/SevensBoard.tsx
+++ b/frontend/src/components/sevens/SevensBoard.tsx
@@ -15,7 +15,7 @@ interface BoardProps {
 
 /** Cell background and text color style based on card placement state. */
 function cellColors(placed: boolean, isCenter: boolean, canPlace: boolean): React.CSSProperties {
-  if (canPlace) return { background: 'var(--color-game-card-selected)', color: 'white' };
+  if (canPlace) return { background: 'var(--color-ds-info)', color: 'white' };
   if (placed)
     return isCenter
       ? { background: 'var(--color-game-status-waiting)', color: 'var(--color-game-text-strong)' }
@@ -85,9 +85,10 @@ function Board({
                         type="button"
                         onClick={() => onJokerPlace?.(idx, v)}
                         aria-label={t('placeAriaLabel', { suit: suitName(idx), value: valueName(v) })}
-                        className={`${baseClass}${bold} border border-ds-info cursor-pointer p-0`}
+                        className={`${baseClass}${bold} ring-2 ring-ds-info ring-offset-1 ring-offset-black/30 animate-pulse cursor-pointer p-0 hover:brightness-110`}
                         style={colors}
                         data-testid="board-cell"
+                        data-joker-placeable="true"
                       >
                         {valueName(v)}
                       </button>


### PR DESCRIPTION
## Summary

- When a joker is selected, the Sevens board now highlights every playable empty cell with the ds-info (blue) background, an info ring, and a subtle pulse animation.
- Adds \`data-joker-placeable="true"\` for testability.
- Click-to-place behaviour was already wired via \`onJokerPlace(suit, value)\` — this PR strengthens the "tap here" affordance so users don't confuse it with a suit/value dialog flow.

Closes #1418

## Test plan

- [x] \`bun run test -- --run SevensBoard\` — new pulse + ring + bg tests pass.
- [x] Existing click-to-place, aria-label, tunnel highlight tests unchanged.