### PR TITLE
fix(solitaire): gate AutoComplete button until success is guaranteed

### DIFF
--- a/frontend/src/i18n/locales/en/fortythieves.json
+++ b/frontend/src/i18n/locales/en/fortythieves.json
@@ -17,6 +17,7 @@
   "landscapeBanner": "Landscape mode recommended",
   "hint": "Hint",
   "autoComplete": "Auto Complete",
+  "autoCompleteNotReady": "Available when stock and waste are empty",
   "undo": "Undo",
   "stalemate": "Stalemate",
   "playing": "Move cards to build foundations",

--- a/frontend/src/i18n/locales/en/klondike.json
+++ b/frontend/src/i18n/locales/en/klondike.json
@@ -14,6 +14,7 @@
   "giveup": "Give Up",
   "hint": "Hint",
   "autoComplete": "Auto Complete",
+  "autoCompleteNotReady": "Available once every card is face up",
   "undo": "Undo",
   "empty": "Empty",
   "gameClear": "Game Clear! Moves: {{moveCount}}",

--- a/frontend/src/i18n/locales/en/klondike.json
+++ b/frontend/src/i18n/locales/en/klondike.json
@@ -14,7 +14,7 @@
   "giveup": "Give Up",
   "hint": "Hint",
   "autoComplete": "Auto Complete",
-  "autoCompleteNotReady": "Available once every card is face up",
+  "autoCompleteNotReady": "Available when stock is empty and every card is face up",
   "undo": "Undo",
   "empty": "Empty",
   "gameClear": "Game Clear! Moves: {{moveCount}}",

--- a/frontend/src/i18n/locales/en/spider.json
+++ b/frontend/src/i18n/locales/en/spider.json
@@ -13,6 +13,7 @@
   "giveup": "Give Up",
   "hint": "Hint",
   "autoComplete": "Auto Complete",
+  "autoCompleteNotReady": "Available when stock is empty and every card is face up",
   "undo": "Undo",
   "empty": "Empty",
   "score": "Score",

--- a/frontend/src/i18n/locales/en/yukon.json
+++ b/frontend/src/i18n/locales/en/yukon.json
@@ -11,6 +11,7 @@
   "giveup": "Give Up",
   "hint": "Hint",
   "autoComplete": "Auto Complete",
+  "autoCompleteNotReady": "Available once every card is face up",
   "undo": "Undo",
   "empty": "Empty",
   "gameClear": "Game Clear! Moves: {{moveCount}}",

--- a/frontend/src/i18n/locales/ja/fortythieves.json
+++ b/frontend/src/i18n/locales/ja/fortythieves.json
@@ -17,6 +17,7 @@
   "landscapeBanner": "横画面での表示を推奨します",
   "hint": "ヒント",
   "autoComplete": "自動完成",
+  "autoCompleteNotReady": "山札とウェイストが空になるとクリックできます",
   "undo": "元に戻す",
   "stalemate": "手詰まりです",
   "playing": "カードを移動してください",

--- a/frontend/src/i18n/locales/ja/klondike.json
+++ b/frontend/src/i18n/locales/ja/klondike.json
@@ -14,6 +14,7 @@
   "giveup": "ギブアップ",
   "hint": "ヒント",
   "autoComplete": "自動完成",
+  "autoCompleteNotReady": "全カードが表向きになるとクリックできます",
   "undo": "元に戻す",
   "empty": "空",
   "gameClear": "ゲームクリア！ 手数: {{moveCount}}",

--- a/frontend/src/i18n/locales/ja/klondike.json
+++ b/frontend/src/i18n/locales/ja/klondike.json
@@ -14,7 +14,7 @@
   "giveup": "ギブアップ",
   "hint": "ヒント",
   "autoComplete": "自動完成",
-  "autoCompleteNotReady": "全カードが表向きになるとクリックできます",
+  "autoCompleteNotReady": "山札が空で全カードが表向きになるとクリックできます",
   "undo": "元に戻す",
   "empty": "空",
   "gameClear": "ゲームクリア！ 手数: {{moveCount}}",

--- a/frontend/src/i18n/locales/ja/spider.json
+++ b/frontend/src/i18n/locales/ja/spider.json
@@ -13,6 +13,7 @@
   "giveup": "ギブアップ",
   "hint": "ヒント",
   "autoComplete": "自動完成",
+  "autoCompleteNotReady": "山札が空で全カードが表向きになるとクリックできます",
   "undo": "元に戻す",
   "empty": "空",
   "score": "スコア",

--- a/frontend/src/i18n/locales/ja/yukon.json
+++ b/frontend/src/i18n/locales/ja/yukon.json
@@ -11,6 +11,7 @@
   "giveup": "ギブアップ",
   "hint": "ヒント",
   "autoComplete": "自動完成",
+  "autoCompleteNotReady": "全カードが表向きになるとクリックできます",
   "undo": "元に戻す",
   "empty": "空",
   "gameClear": "ゲームクリア！ 手数: {{moveCount}}",

--- a/frontend/src/pages/FortyThievesPage.test.tsx
+++ b/frontend/src/pages/FortyThievesPage.test.tsx
@@ -195,15 +195,27 @@ describe('FortyThievesPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
   });
 
-  it('clicking auto complete button dispatches autocomplete', async () => {
+  it('clicking auto complete button dispatches autocomplete when ready', async () => {
+    const readyState: FortyThievesResponse = {
+      ...playingState,
+      stockCount: 0,
+      waste: [],
+    };
+    mockExec.mockResolvedValue(readyState);
     renderWithProviders(<FortyThievesPage />);
     await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
 
     mockExec.mockClear();
-    mockExec.mockResolvedValue(playingState);
+    mockExec.mockResolvedValue(readyState);
     fireEvent.click(screen.getByRole('button', { name: '自動完成' }));
 
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
+  });
+
+  it('auto complete button is disabled while stock or waste has cards', async () => {
+    renderWithProviders(<FortyThievesPage />);
+    await waitFor(() => expect(screen.getByTestId('autocomplete-button')).toBeInTheDocument());
+    expect(screen.getByTestId('autocomplete-button')).toBeDisabled();
   });
 
   it('clicking give up button dispatches giveup', async () => {

--- a/frontend/src/pages/FortyThievesPage.tsx
+++ b/frontend/src/pages/FortyThievesPage.tsx
@@ -36,6 +36,7 @@ import type { FortyThievesResponse } from '../types/card';
 import { FortyThievesPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { isTableauAllFaceUp } from '../utils/solitaireUtils';
 
 const FOUNDATION_SUITS = ['♠', '♠', '♣', '♣', '♥', '♥', '♦', '♦'] as const;
 
@@ -180,6 +181,7 @@ function FortyThievesPageContent() {
   const isGameClear = state.phase === FortyThievesPhase.GAME_CLEAR;
   const isGameOver = state.phase === FortyThievesPhase.GAME_OVER;
   const isEnded = isGameClear || isGameOver;
+  const autoCompleteReady = state.stockCount === 0 && state.waste.length === 0 && isTableauAllFaceUp(state.tableau);
 
   const isSourceSelected = (zone: string, col?: number, cardIndex?: number) =>
     selectedSource !== null &&
@@ -498,9 +500,11 @@ function FortyThievesPageContent() {
                   </button>
                   <button
                     type="button"
-                    className={btnSuccess}
+                    className={`${btnSuccess}${autoCompleteReady && !loading && !isAutoCompleting ? ' animate-pulse ring-2 ring-ds-success' : ''}`}
                     onClick={handleAutoComplete}
-                    disabled={loading || isAutoCompleting}
+                    disabled={loading || isAutoCompleting || !autoCompleteReady}
+                    data-testid="autocomplete-button"
+                    title={autoCompleteReady ? undefined : t('autoCompleteNotReady')}
                   >
                     {t('autoComplete')}
                   </button>

--- a/frontend/src/pages/KlondikePage.test.tsx
+++ b/frontend/src/pages/KlondikePage.test.tsx
@@ -230,17 +230,18 @@ describe('KlondikePage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
   });
 
-  it('clicking auto complete button dispatches autocomplete when all tableau face-up', async () => {
-    const allFaceUpState: KlondikeResponse = {
+  it('clicking auto complete button dispatches autocomplete when stock empty and tableau face-up', async () => {
+    const readyState: KlondikeResponse = {
       ...playingState,
+      stockCount: 0,
       tableau: makeTableau([[{ card: card('SPADE', 13), faceUp: true }], [], [], [], [], [], []]),
     };
-    mockExec.mockResolvedValue(allFaceUpState);
+    mockExec.mockResolvedValue(readyState);
     renderWithProviders(<KlondikePage />);
     await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
 
     mockExec.mockClear();
-    mockExec.mockResolvedValue(allFaceUpState);
+    mockExec.mockResolvedValue(readyState);
     fireEvent.click(screen.getByRole('button', { name: '自動完成' }));
 
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
@@ -255,12 +256,27 @@ describe('KlondikePage', () => {
     expect(btn.className).not.toContain('animate-pulse');
   });
 
-  it('auto complete button pulses when all tableau face-up', async () => {
-    const allFaceUpState: KlondikeResponse = {
+  it('auto complete button is disabled while stock still has cards (even if tableau all face-up)', async () => {
+    const tableauFaceUpButStockRemaining: KlondikeResponse = {
       ...playingState,
+      stockCount: 5,
       tableau: makeTableau([[{ card: card('SPADE', 13), faceUp: true }], [], [], [], [], [], []]),
     };
-    mockExec.mockResolvedValue(allFaceUpState);
+    mockExec.mockResolvedValue(tableauFaceUpButStockRemaining);
+    renderWithProviders(<KlondikePage />);
+    await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
+
+    const btn = screen.getByTestId('autocomplete-button');
+    expect(btn).toBeDisabled();
+  });
+
+  it('auto complete button pulses when stock empty and tableau all face-up', async () => {
+    const readyState: KlondikeResponse = {
+      ...playingState,
+      stockCount: 0,
+      tableau: makeTableau([[{ card: card('SPADE', 13), faceUp: true }], [], [], [], [], [], []]),
+    };
+    mockExec.mockResolvedValue(readyState);
     renderWithProviders(<KlondikePage />);
     await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
 

--- a/frontend/src/pages/KlondikePage.test.tsx
+++ b/frontend/src/pages/KlondikePage.test.tsx
@@ -230,15 +230,43 @@ describe('KlondikePage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
   });
 
-  it('clicking auto complete button dispatches autocomplete', async () => {
+  it('clicking auto complete button dispatches autocomplete when all tableau face-up', async () => {
+    const allFaceUpState: KlondikeResponse = {
+      ...playingState,
+      tableau: makeTableau([[{ card: card('SPADE', 13), faceUp: true }], [], [], [], [], [], []]),
+    };
+    mockExec.mockResolvedValue(allFaceUpState);
     renderWithProviders(<KlondikePage />);
     await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
 
     mockExec.mockClear();
-    mockExec.mockResolvedValue(playingState);
+    mockExec.mockResolvedValue(allFaceUpState);
     fireEvent.click(screen.getByRole('button', { name: '自動完成' }));
 
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
+  });
+
+  it('auto complete button is disabled and pulses hidden when tableau has face-down cards', async () => {
+    renderWithProviders(<KlondikePage />);
+    await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
+
+    const btn = screen.getByTestId('autocomplete-button');
+    expect(btn).toBeDisabled();
+    expect(btn.className).not.toContain('animate-pulse');
+  });
+
+  it('auto complete button pulses when all tableau face-up', async () => {
+    const allFaceUpState: KlondikeResponse = {
+      ...playingState,
+      tableau: makeTableau([[{ card: card('SPADE', 13), faceUp: true }], [], [], [], [], [], []]),
+    };
+    mockExec.mockResolvedValue(allFaceUpState);
+    renderWithProviders(<KlondikePage />);
+    await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
+
+    const btn = screen.getByTestId('autocomplete-button');
+    expect(btn).not.toBeDisabled();
+    expect(btn.className).toContain('animate-pulse');
   });
 
   it('clicking give up button dispatches giveup', async () => {

--- a/frontend/src/pages/KlondikePage.tsx
+++ b/frontend/src/pages/KlondikePage.tsx
@@ -212,7 +212,9 @@ function KlondikePageContent() {
 
   // Waste display: in 3-card mode show up to 3 fanned cards, only top clickable
   const wasteDisplay = state.drawCount === 3 ? state.waste.slice(-3) : state.waste.slice(-1);
-  const autoCompleteReady = isTableauAllFaceUp(state.tableau);
+  // Mirrors the backend's Klondike.AllFaceUp() guard: stock must be empty AND every tableau card face-up.
+  // (Waste cards are always face-up and AutoComplete pops them, so no waste check is needed.)
+  const autoCompleteReady = state.stockCount === 0 && isTableauAllFaceUp(state.tableau);
 
   return (
     <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.klondike.bg}`} aria-busy={loading}>

--- a/frontend/src/pages/KlondikePage.tsx
+++ b/frontend/src/pages/KlondikePage.tsx
@@ -40,6 +40,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { KLONDIKE_HELP, parseKlondikeCommand } from '../utils/cli/commands/klondikeCommands';
 import { formatKlondikeState } from '../utils/cli/formatters/klondikeFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { isTableauAllFaceUp } from '../utils/solitaireUtils';
 
 const FOUNDATION_SUITS = ['♠', '♣', '♥', '♦'] as const;
 
@@ -211,6 +212,7 @@ function KlondikePageContent() {
 
   // Waste display: in 3-card mode show up to 3 fanned cards, only top clickable
   const wasteDisplay = state.drawCount === 3 ? state.waste.slice(-3) : state.waste.slice(-1);
+  const autoCompleteReady = isTableauAllFaceUp(state.tableau);
 
   return (
     <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.klondike.bg}`} aria-busy={loading}>
@@ -566,9 +568,11 @@ function KlondikePageContent() {
                   </button>
                   <button
                     type="button"
-                    className={btnSuccess}
+                    className={`${btnSuccess}${autoCompleteReady && !loading && !isAutoCompleting ? ' animate-pulse ring-2 ring-ds-success' : ''}`}
                     onClick={handleAutoComplete}
-                    disabled={loading || isAutoCompleting}
+                    disabled={loading || isAutoCompleting || !autoCompleteReady}
+                    data-testid="autocomplete-button"
+                    title={autoCompleteReady ? undefined : t('autoCompleteNotReady')}
                   >
                     {t('autoComplete')}
                   </button>

--- a/frontend/src/pages/SpiderPage.test.tsx
+++ b/frontend/src/pages/SpiderPage.test.tsx
@@ -149,15 +149,27 @@ describe('SpiderPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
   });
 
-  it('clicking auto complete button dispatches autocomplete', async () => {
+  it('clicking auto complete button dispatches autocomplete when ready', async () => {
+    const readyState: SpiderResponse = {
+      ...playingState,
+      stockCount: 0,
+      tableau: makeTableau([[{ card: card('SPADE', 13), faceUp: true }], [], [], [], [], [], [], [], [], []]),
+    };
+    mockExec.mockResolvedValue(readyState);
     renderWithProviders(<SpiderPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '自動完成' })).toBeInTheDocument());
 
     mockExec.mockClear();
-    mockExec.mockResolvedValue(playingState);
+    mockExec.mockResolvedValue(readyState);
     fireEvent.click(screen.getByRole('button', { name: '自動完成' }));
 
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
+  });
+
+  it('auto complete button is disabled while stock remains or face-down cards exist', async () => {
+    renderWithProviders(<SpiderPage />);
+    await waitFor(() => expect(screen.getByTestId('autocomplete-button')).toBeInTheDocument());
+    expect(screen.getByTestId('autocomplete-button')).toBeDisabled();
   });
 
   it('clicking give up button dispatches giveup', async () => {

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -39,6 +39,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { parseSpiderCommand, SPIDER_HELP } from '../utils/cli/commands/spiderCommands';
 import { formatSpiderState } from '../utils/cli/formatters/spiderFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { isTableauAllFaceUp } from '../utils/solitaireUtils';
 
 /** Spider Solitaire tutorial step definitions. */
 const SPD_TUTORIAL_STEPS: TutorialStep[] = [
@@ -180,6 +181,7 @@ function SpiderPageContent() {
     selectedSource.cardIndex === cardIndex;
 
   const dealsRemaining = Math.floor(state.stockCount / 10);
+  const autoCompleteReady = state.stockCount === 0 && isTableauAllFaceUp(state.tableau);
 
   return (
     <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.spider.bg}`} aria-busy={loading}>
@@ -415,9 +417,11 @@ function SpiderPageContent() {
                   </button>
                   <button
                     type="button"
-                    className={btnSuccess}
+                    className={`${btnSuccess}${autoCompleteReady && !loading && !isAutoCompleting ? ' animate-pulse ring-2 ring-ds-success' : ''}`}
                     onClick={handleAutoComplete}
-                    disabled={loading || isAutoCompleting}
+                    disabled={loading || isAutoCompleting || !autoCompleteReady}
+                    data-testid="autocomplete-button"
+                    title={autoCompleteReady ? undefined : t('autoCompleteNotReady')}
                   >
                     {t('autoComplete')}
                   </button>

--- a/frontend/src/pages/YukonPage.test.tsx
+++ b/frontend/src/pages/YukonPage.test.tsx
@@ -95,12 +95,33 @@ describe('YukonPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
   });
 
-  it('autocomplete button triggers autocomplete command', async () => {
+  it('autocomplete button triggers autocomplete command when all face-up', async () => {
+    const readyState: YukonResponse = {
+      ...playingState,
+      tableau: [
+        [{ card: card('SPADE', 13), faceUp: true }],
+        [{ card: card('HEART', 8), faceUp: true }],
+        [{ card: card('CLOVER', 5), faceUp: true }],
+        [{ card: card('DIAMOND', 10), faceUp: true }],
+        [{ card: card('SPADE', 3), faceUp: true }],
+        [{ card: card('HEART', 7), faceUp: true }],
+        [{ card: card('CLOVER', 2), faceUp: true }],
+      ],
+    };
+    mockExec.mockResolvedValue(readyState);
     renderWithProviders(<YukonPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(readyState);
     const btn = screen.getByRole('button', { name: '自動完成' });
     btn.click();
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
+  });
+
+  it('autocomplete button is disabled while face-down cards exist', async () => {
+    renderWithProviders(<YukonPage />);
+    await waitFor(() => expect(screen.getByTestId('autocomplete-button')).toBeInTheDocument());
+    expect(screen.getByTestId('autocomplete-button')).toBeDisabled();
   });
 
   it('giveup button triggers giveup command', async () => {

--- a/frontend/src/pages/YukonPage.tsx
+++ b/frontend/src/pages/YukonPage.tsx
@@ -37,6 +37,7 @@ import { YukonPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import type { CliGameConfig } from '../utils/cli/types';
+import { isTableauAllFaceUp } from '../utils/solitaireUtils';
 
 const FOUNDATION_SUITS = ['♠', '♣', '♥', '♦'] as const;
 const noop = () => {};
@@ -298,6 +299,7 @@ function YukonPageContent() {
   const isGameClear = state.phase === YukonPhase.GAME_CLEAR;
   const isGameOver = state.phase === YukonPhase.GAME_OVER;
   const isEnded = isGameClear || isGameOver;
+  const autoCompleteReady = isTableauAllFaceUp(state.tableau);
 
   const isSourceSelected = (zone: string, col?: number, cardIndex?: number) =>
     selectedSource !== null &&
@@ -518,7 +520,14 @@ function YukonPageContent() {
                   <button type="button" className={btnOutline} onClick={handleHint} disabled={loading}>
                     {t('hint')}
                   </button>
-                  <button type="button" className={btnSuccess} onClick={handleAutoComplete} disabled={loading}>
+                  <button
+                    type="button"
+                    className={`${btnSuccess}${autoCompleteReady && !loading ? ' animate-pulse ring-2 ring-ds-success' : ''}`}
+                    onClick={handleAutoComplete}
+                    disabled={loading || !autoCompleteReady}
+                    data-testid="autocomplete-button"
+                    title={autoCompleteReady ? undefined : t('autoCompleteNotReady')}
+                  >
                     {t('autoComplete')}
                   </button>
                   <button

--- a/frontend/src/utils/solitaireUtils.test.ts
+++ b/frontend/src/utils/solitaireUtils.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { isTableauAllFaceUp } from './solitaireUtils';
+
+describe('isTableauAllFaceUp', () => {
+  it('returns true for an empty tableau', () => {
+    expect(isTableauAllFaceUp([])).toBe(true);
+  });
+
+  it('returns true when every cell is face-up', () => {
+    expect(isTableauAllFaceUp([[{ faceUp: true }], [{ faceUp: true }, { faceUp: true }]])).toBe(true);
+  });
+
+  it('returns false when any cell is face-down', () => {
+    expect(isTableauAllFaceUp([[{ faceUp: true }], [{ faceUp: false }, { faceUp: true }]])).toBe(false);
+  });
+
+  it('returns true when columns are empty arrays', () => {
+    expect(isTableauAllFaceUp([[], [], []])).toBe(true);
+  });
+});

--- a/frontend/src/utils/solitaireUtils.ts
+++ b/frontend/src/utils/solitaireUtils.ts
@@ -1,0 +1,23 @@
+/**
+ * Utilities shared across solitaire-style games (Klondike, Spider, Yukon, Forty Thieves).
+ */
+
+/** Minimal tableau card shape — any solitaire card with a face-up flag. */
+interface TableauCardLike {
+  faceUp: boolean;
+}
+
+/**
+ * Returns true when every card in the tableau is face-up. This is the standard
+ * prerequisite for a safe "auto-complete" run on games that use a face-down stock
+ * (Klondike, Spider, Yukon, Forty Thieves) — once no hidden cards remain, the
+ * remaining cards can always be sent to the foundation.
+ */
+export function isTableauAllFaceUp(tableau: readonly (readonly TableauCardLike[])[]): boolean {
+  for (const col of tableau) {
+    for (const cell of col) {
+      if (!cell.faceUp) return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary

Stops displaying an always-enabled AutoComplete button in solitaire games when it cannot actually make progress. Instead the button is disabled with a localized \`title\` explanation until its game-specific ready condition is met, then pulses with a ds-success ring once it is.

Per-game ready condition:

| Game          | Condition |
|---------------|-----------|
| Klondike      | every tableau card is face-up |
| Yukon         | every tableau card is face-up |
| Spider        | stock empty AND every tableau card face-up |
| Forty Thieves | stock empty AND waste empty (all tableau cards are face-up by rule) |
| FreeCell      | unchanged — no face-down cards, button always works |

Also adds the new helper \`isTableauAllFaceUp\` in \`frontend/src/utils/solitaireUtils.ts\`.

Closes #1419

## Test plan

- [x] \`bun run test -- --run solitaireUtils KlondikePage SpiderPage YukonPage FortyThievesPage\` — new "ready" / "disabled" / pulse tests pass, existing flows updated to build a ready state before clicking AutoComplete.
- [x] \`bun run check\` passes (two unrelated pre-existing biome warnings in OldMaid tests only).