### PR TITLE
docs: fix stale game-count drift (55/57 → 58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ go_trumpcardsが目指す未来は、**あらゆる人がクリエイターと�
 
 ## Features
 
-Go + Clean Architecture で実装した57種類のトランプゲーム。CLI と Web GUI（React + Go REST API）の2つのインターフェースで遊べます。Web GUI は日英多言語対応。
+Go + Clean Architecture で実装した58種類のトランプゲーム。CLI と Web GUI（React + Go REST API）の2つのインターフェースで遊べます。Web GUI は日英多言語対応。
 
 | ゲーム | コマンド | マニュアル |
 |--------|----------|------------|

--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -6,7 +6,7 @@
 
 - [1. クラス図](#1-クラス図)
   - [1.1 コアドメイン (カード・プレイヤー)](#11-コアドメイン-カードプレイヤー)
-  - [1.2 ゲームドメイン (全55ゲーム)](#12-ゲームドメイン-全55ゲーム)
+  - [1.2 ゲームドメイン (全58ゲーム)](#12-ゲームドメイン-全58ゲーム)
   - [1.3 ユースケース層 (Interactor・Presenter)](#13-ユースケース層-interactorpresenter)
   - [1.4 アダプタ層 (Controller・Presenter実装)](#14-アダプタ層-controllerpresenter実装)
   - [1.5 インフラストラクチャ層](#15-インフラストラクチャ層)
@@ -138,7 +138,7 @@ classDiagram
     GamePlayer *-- ChipHolder : mixin
 ```
 
-### 1.2 ゲームドメイン (全55ゲーム)
+### 1.2 ゲームドメイン (全58ゲーム)
 
 #### ベッティング系ゲーム
 
@@ -1483,7 +1483,7 @@ classDiagram
     note for GamePresenter "各ゲームの Presenter は\nGamePresenter[G] の型エイリアス\nまたは拡張インターフェース"
 ```
 
-**Interactor パターン (全55ゲーム共通)**
+**Interactor パターン (全58ゲーム共通)**
 
 ```mermaid
 classDiagram
@@ -1555,8 +1555,8 @@ classDiagram
     GameCuiPresenter ..|> GamePresenter : implements
     GameWebPresenter ..|> GamePresenter : implements
 
-    note for GameCuiController "55ゲーム × CUI/Web = 110 Controller\nGameCuiController / GameWebController は\n各ゲーム毎に具体的な実装が存在"
-    note for GameCuiPresenter "55ゲーム × CUI/Web = 110 Presenter 実装"
+    note for GameCuiController "58ゲーム × CUI/Web = 116 Controller\nGameCuiController / GameWebController は\n各ゲーム毎に具体的な実装が存在"
+    note for GameCuiPresenter "58ゲーム × CUI/Web = 116 Presenter 実装"
 ```
 
 ### 1.5 インフラストラクチャ層
@@ -1623,8 +1623,8 @@ classDiagram
         +Exec(input string) string
     }
 
-    TrumpCardsWeb --> "*" GameWebController : holds 55 controllers
-    GameManager --> "*" CuiExecer : holds 55 games
+    TrumpCardsWeb --> "*" GameWebController : holds 58 controllers
+    GameManager --> "*" CuiExecer : holds 58 games
     GameCui ..|> CuiExecer : implements
     GameCui --> GameCuiController : delegates
 ```

--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -399,7 +399,7 @@ classDiagram
         +object messageParams
     }
 
-    note for BlackJackResponse "各ゲームが固有のResponse型を持つ\n(全55ゲーム分存在)\n共通フィールド: message, messageCode, messageParams"
+    note for BlackJackResponse "各ゲームが固有のResponse型を持つ\n(全58ゲーム分存在)\n共通フィールド: message, messageCode, messageParams"
 ```
 
 **フェーズ定数 (全ゲーム)**
@@ -803,7 +803,7 @@ classDiagram
     class actionLogApi {
         +blackjack() Promise~ActionLogResponse~
         +poker() Promise~ActionLogResponse~
-        ...全55ゲーム()
+        ...全58ゲーム()
     }
 
     BlackJackApi --> gameApi : uses postJson/gameExec
@@ -865,7 +865,7 @@ classDiagram
 
     RedDogApi --> gameApi : uses postJson/gameExec
 
-    note for BlackJackApi "全55ゲーム分のAPI Objectが存在\n(blackjack, poker, oldmaid, daifugo,\nsevens, doubt, holdem, omaha, shortdeck,\npineapple, hearts, memory, klondike, freecell,\nbaccarat, spades, twotenjack, crazyeights, ginrummy, canasta,\nspider, napoleon, indianpoker, videopoker,\ndeuceswild, jokerpoker, euchre, pyramid, tripeaks,\ncribbage, threecard, caribbeanstud, ohhell, bridge, speed,\ngofish, pinochle, golf, pigtail,\nsevencardstud, clocksolitaire, durak,\nfortythieves, paigow, war, canfield, fiftyone, yukon, scorpion, whist,\nletitride, pokersquares, pageone, reddog, razz)"
+    note for BlackJackApi "全58ゲーム分のAPI Objectが存在\n(blackjack, poker, oldmaid, daifugo,\nsevens, doubt, holdem, omaha, shortdeck,\npineapple, hearts, memory, klondike, freecell,\nbaccarat, spades, twotenjack, crazyeights, ginrummy, canasta,\nspider, napoleon, indianpoker, videopoker,\ndeuceswild, jokerpoker, euchre, pyramid, tripeaks,\ncribbage, threecard, caribbeanstud, ohhell, bridge, speed,\ngofish, pinochle, golf, pigtail,\nsevencardstud, clocksolitaire, durak,\nfortythieves, paigow, war, canfield, fiftyone, yukon, scorpion, accordion, whist,\nletitride, pokersquares, pageone, reddog, razz, badugi, trash)"
 ```
 
 ### 1.3 Hook 層 (共通Hook)
@@ -1244,7 +1244,7 @@ classDiagram
 
     useCanastaGame --> useGameApi : uses
 
-    note for useBlackJackGame "全55ゲーム分の固有Hookが存在\n各HookはuseGameApiで統一的にAPI呼出し\n必要に応じてuseCardSelectionを合成"
+    note for useBlackJackGame "全58ゲーム分の固有Hookが存在\n各HookはuseGameApiで統一的にAPI呼出し\n必要に応じてuseCardSelectionを合成"
 ```
 
 ### 1.5 コンポーネント層
@@ -1816,7 +1816,7 @@ classDiagram
     GamePage --> PokerTableLayout : renders (Hold'em/Omaha/ShortDeck/Pineapple/SevenCardStud/Razz)
     PokerTableLayout --> CpuPlayerCard : wraps
 
-    note for GamePage "全55ゲームページが同一パターンで構成\nuseGamePageSetup → ゲーム固有Hook → 描画"
+    note for GamePage "全58ゲームページが同一パターンで構成\nuseGamePageSetup → ゲーム固有Hook → 描画"
 ```
 
 ### 1.7 i18n・プロバイダー・ルーティング
@@ -1839,15 +1839,15 @@ classDiagram
         +HashRouter
         +ErrorBoundary
         +NavBar
-        +Routes (55ゲーム)
+        +Routes (58ゲーム)
     }
 
     class gameCategories {
         +table: [BlackJack, Baccarat, ThreeCard, PaiGow, CaribbeanStud, LetItRide, RedDog]
-        +poker: [Poker, Holdem, Omaha, ShortDeck, Pineapple, SevenCardStud, Razz, IndianPoker, VideoPoker, DeucesWild, JokerPoker]
+        +poker: [Poker, Holdem, Omaha, ShortDeck, Pineapple, SevenCardStud, Razz, Badugi, IndianPoker, VideoPoker, DeucesWild, JokerPoker]
         +trickTaking: [Hearts, Spades, OhHell, Euchre, Bridge, Napoleon, TwoTenJack, Whist]
-        +matching: [OldMaid, Doubt, Daifugo, Sevens, CrazyEights, Speed, GoFish, Pinochle, PigsTail, Durak, War, FiftyOne, PageOne]
-        +solitaire: [Klondike, FreeCell, Spider, Pyramid, TriPeaks, Golf, Memory, ClockSolitaire, FortyThieves, Canfield, Yukon, Scorpion, PokerSquares]
+        +matching: [OldMaid, Doubt, Daifugo, Sevens, CrazyEights, Speed, GoFish, Pinochle, PigsTail, Durak, War, FiftyOne, PageOne, Trash]
+        +solitaire: [Klondike, FreeCell, Spider, Pyramid, TriPeaks, Golf, Memory, ClockSolitaire, FortyThieves, Canfield, Yukon, Scorpion, Accordion, PokerSquares]
         +rummy: [GinRummy, Canasta, Cribbage]
     }
 
@@ -1862,11 +1862,11 @@ classDiagram
     App --> i18n : initializes
     App --> gameCategories : routes from
     App --> NavBar : renders
-    App --> GamePage : routes to 55 pages
+    App --> GamePage : routes to 58 pages
     GamePage --> TutorialProvider : wraps (per-game)
     TutorialProvider --> TutorialOverlay : renders when active
 
-    note for i18n "57名前空間: common + 55ゲーム固有 + tutorial\n翻訳ファイル: locales/{ja,en}/game.json"
+    note for i18n "60名前空間: common + 58ゲーム固有 + tutorial\n翻訳ファイル: locales/{ja,en}/game.json"
 ```
 
 ---

--- a/internal/infrastructure/games/games_server.go
+++ b/internal/infrastructure/games/games_server.go
@@ -11,7 +11,7 @@ import (
 
 // init attaches the HTTP-server-side factory for every game. The build tag
 // excludes this file from Cloudflare Worker (TinyGo) binaries so that their
-// Web-server-only controllers/dispatchers do not drag in 55 games of code.
+// Web-server-only controllers/dispatchers do not drag in 58 games of code.
 func init() {
 	BindWebControllerFor("blackjack",
 		func() usecase.BlackJackInteractorIF {

--- a/internal/infrastructure/games/registry.go
+++ b/internal/infrastructure/games/registry.go
@@ -5,7 +5,7 @@
 // binaries (TinyGo / WASM) stay under the 1 MB gzipped free-tier limit:
 //
 //   - registry.go (this file, no tag)  — types and bare metadata (Name +
-//     Category) for all 55 games. Cheap; no references to game code.
+//     Category) for all 58 games. Cheap; no references to game code.
 //   - games_server.go (!js || !wasm)   — installs Web-server factories for
 //     every game via BindWebController. Imported by TrumpCardsWeb.
 //   - casino/, classic/, solo/ (js && wasm) — per-category worker bindings.


### PR DESCRIPTION
## Summary
- Canonical count is **58 games** (`internal/infrastructure/games/registry.go`), but several docs and source comments still referenced 55 or 57. Detected via `/doc-drift-check` and corrected mechanically.
- Also added the 3 games missing from UML notes: `Accordion`, `Badugi`, `Trash`.

## Changes

### Source comments
- `internal/infrastructure/games/registry.go` — "all 55 games" → "all 58 games"
- `internal/infrastructure/games/games_server.go` — "55 games of code" → "58 games of code"

### README
- `README.md` — "57種類のトランプゲーム" → "58種類のトランプゲーム"

### `docs/design/backend.md`
- TOC + section heading: "全55ゲーム" → "全58ゲーム"
- Interactor/Controller/Presenter notes: 55 → 58 (and 110 → 116 for CUI/Web pair count)
- Relationship labels: "holds 55 games/controllers" → "holds 58 …"

### `docs/design/frontend.md`
- Response/API/Hook/GamePage/App/i18n notes: 55 → 58, and "57名前空間" → "60名前空間"
- `BlackJackApi` game-list note — added `accordion`, `badugi`, `trash`
- `gameCategories` class — added `Badugi` (poker), `Trash` (matching), `Accordion` (solitaire)

## Audited, no drift found
- Web API endpoints: 58 in code = 58 in `api/openapi.yaml` = matches `docs/architecture.md`
- Frontend i18n (ja/en 60-namespace symmetric, dynamic glob loading)
- `gameRoutes.ts`, `pages/*Page.tsx`, `manualTexts.ts` (58/58)
- `docs/manual/{cui,web}/` each have 58 files
- ADR index and auto-memory

## Deferred (out of scope for drift)
- `CLAUDE.md` Go 1.26.x vs `go.mod` 1.25.8 — intentional for TinyGo, per memory
- Authoring a dedicated UML section 2.24 for `AccordionPage` and full sequence diagrams for Accordion/Trash/Badugi

## Test plan
- [x] `go build ./...` — passes
- [x] `goimports -w` run on modified Go files
- [ ] CI: `golangci-lint`, CodeQL
- [ ] Mermaid renders correctly in updated design docs

Closes #1445