### PR TITLE
feat(ui): rename reset to "next game" at end state, skip confirm

### DIFF
--- a/frontend/e2e/baccarat.spec.ts
+++ b/frontend/e2e/baccarat.spec.ts
@@ -11,13 +11,12 @@ test.describe('Baccarat E2E', () => {
     await betButton.click();
     await waitForLoaded(page);
 
-    // END phase: リセット button should be visible
-    const resetButton = page.getByRole('button', { name: 'リセット' });
+    // END phase: 次のゲーム button should be visible
+    const resetButton = page.getByRole('button', { name: '次のゲーム' });
     await expect(resetButton).toBeVisible({ timeout: 10_000 });
 
     // Reset back to bet phase
     await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
     await expect(page.getByRole('button', { name: 'ベット' })).toBeVisible();
   });

--- a/frontend/e2e/badugi.spec.ts
+++ b/frontend/e2e/badugi.spec.ts
@@ -14,20 +14,17 @@ test.describe('Badugi E2E', () => {
     // Play through up to 4 betting rounds + 3 draw rounds with generous retry.
     const endResetButton = page.getByRole('button', { name: '次のゲーム' });
     let roundEnded = false;
-    for (let round = 0; round < 20; round++) {
+    for (let round = 0; round < 30; round++) {
+      // End state reached — break immediately. Action buttons briefly overlapping
+      // with 次のゲーム during phase transition would otherwise race the break.
+      if (await endResetButton.isVisible()) {
+        roundEnded = true;
+        break;
+      }
+
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
       const standButton = page.getByRole('button', { name: 'スタンド', exact: true });
-
-      if (await endResetButton.isVisible()) {
-        const checkVisible = await checkButton.isVisible();
-        const callVisible = await callButton.isVisible();
-        const standVisible = await standButton.isVisible();
-        if (!checkVisible && !callVisible && !standVisible) {
-          roundEnded = true;
-          break;
-        }
-      }
 
       // Draw phase has Stand button visible — click it (no exchanges).
       if (await isVisibleWithin(standButton, TIMEOUT_ACTION)) {

--- a/frontend/e2e/badugi.spec.ts
+++ b/frontend/e2e/badugi.spec.ts
@@ -5,20 +5,21 @@ test.describe('Badugi E2E', () => {
   test('plays a full hand: reset → check/call + stand → showdown → reset', async ({ page }) => {
     await navigateTo(page, '/badugi');
 
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // Play through up to 4 betting rounds + 3 draw rounds with generous retry.
+    const endResetButton = page.getByRole('button', { name: '次のゲーム' });
     let roundEnded = false;
     for (let round = 0; round < 20; round++) {
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
       const standButton = page.getByRole('button', { name: 'スタンド', exact: true });
 
-      if (await isVisibleWithin(resetButton, TIMEOUT_QUICK)) {
+      if (await isVisibleWithin(endResetButton, TIMEOUT_QUICK)) {
         const checkVisible = await checkButton.isVisible();
         const callVisible = await callButton.isVisible();
         const standVisible = await standButton.isVisible();
@@ -59,8 +60,7 @@ test.describe('Badugi E2E', () => {
 
     expect(roundEnded).toBe(true);
 
-    await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
+    await endResetButton.click();
     await waitForLoaded(page);
   });
 });

--- a/frontend/e2e/badugi.spec.ts
+++ b/frontend/e2e/badugi.spec.ts
@@ -19,7 +19,7 @@ test.describe('Badugi E2E', () => {
     const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
     const callButton = page.getByRole('button', { name: 'コール', exact: true });
     const foldButton = page.getByRole('button', { name: 'フォールド', exact: true });
-    const standButton = page.getByRole('button', { name: 'スタンド', exact: true });
+    const standButton = page.getByRole('button', { name: /スタンド/ });
 
     // Up to 4 bet rounds + 3 draw rounds × (1 human + 3 CPU) polls. Budget
     // is generous since CI scheduling can stretch CPU turns.

--- a/frontend/e2e/badugi.spec.ts
+++ b/frontend/e2e/badugi.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, TIMEOUT_QUICK, waitForLoaded } from './helpers';
+import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, waitForLoaded } from './helpers';
 
 test.describe('Badugi E2E', () => {
   test('plays a full hand: reset → check/call + stand → showdown → reset', async ({ page }) => {
@@ -19,7 +19,7 @@ test.describe('Badugi E2E', () => {
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
       const standButton = page.getByRole('button', { name: 'スタンド', exact: true });
 
-      if (await isVisibleWithin(endResetButton, TIMEOUT_QUICK)) {
+      if (await endResetButton.isVisible()) {
         const checkVisible = await checkButton.isVisible();
         const callVisible = await callButton.isVisible();
         const standVisible = await standButton.isVisible();

--- a/frontend/e2e/badugi.spec.ts
+++ b/frontend/e2e/badugi.spec.ts
@@ -21,10 +21,10 @@ test.describe('Badugi E2E', () => {
     const foldButton = page.getByRole('button', { name: 'フォールド', exact: true });
     const standButton = page.getByRole('button', { name: 'スタンド', exact: true });
 
+    // Up to 4 bet rounds + 3 draw rounds × (1 human + 3 CPU) polls. Budget
+    // is generous since CI scheduling can stretch CPU turns.
     let roundEnded = false;
-    for (let round = 0; round < 30; round++) {
-      // Instant check — if no action is currently available (CPU thinking,
-      // animation playing, …), waitForLoaded below lets the page settle.
+    for (let round = 0; round < 120; round++) {
       if (await endResetButton.isVisible()) {
         roundEnded = true;
         break;
@@ -50,9 +50,9 @@ test.describe('Badugi E2E', () => {
         continue;
       }
 
-      // Nothing actionable yet — wait briefly for the next state change.
-      await page.waitForTimeout(500);
-      await waitForLoaded(page);
+      // No action currently available — CPU probably thinking. Brief sleep
+      // then re-check; aria-busy alone is not a sufficient signal.
+      await page.waitForTimeout(300);
     }
 
     expect(roundEnded).toBe(true);

--- a/frontend/e2e/badugi.spec.ts
+++ b/frontend/e2e/badugi.spec.ts
@@ -18,27 +18,22 @@ test.describe('Badugi E2E', () => {
     const endResetButton = page.getByRole('button', { name: '次のゲーム' });
     const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
     const callButton = page.getByRole('button', { name: 'コール', exact: true });
+    const foldButton = page.getByRole('button', { name: 'フォールド', exact: true });
     const standButton = page.getByRole('button', { name: 'スタンド', exact: true });
-    const anyButton = endResetButton.or(standButton).or(checkButton).or(callButton);
 
     let roundEnded = false;
     for (let round = 0; round < 30; round++) {
-      // Wait for any actionable button to become visible (CPU may be thinking).
-      await expect(anyButton.first()).toBeVisible({ timeout: 10_000 });
-
+      // Instant check — if no action is currently available (CPU thinking,
+      // animation playing, …), waitForLoaded below lets the page settle.
       if (await endResetButton.isVisible()) {
         roundEnded = true;
         break;
       }
-
-      // Draw phase: スタンド (no exchanges).
       if ((await standButton.isVisible()) && (await standButton.isEnabled())) {
         await standButton.click();
         await waitForLoaded(page);
         continue;
       }
-
-      // Betting phase: prefer check, fall back to call.
       if ((await checkButton.isVisible()) && (await checkButton.isEnabled())) {
         await checkButton.click();
         await waitForLoaded(page);
@@ -49,8 +44,14 @@ test.describe('Badugi E2E', () => {
         await waitForLoaded(page);
         continue;
       }
+      if ((await foldButton.isVisible()) && (await foldButton.isEnabled())) {
+        await foldButton.click();
+        await waitForLoaded(page);
+        continue;
+      }
 
-      // None of the buttons are actionable right now — let the page settle.
+      // Nothing actionable yet — wait briefly for the next state change.
+      await page.waitForTimeout(500);
       await waitForLoaded(page);
     }
 

--- a/frontend/e2e/badugi.spec.ts
+++ b/frontend/e2e/badugi.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, waitForLoaded } from './helpers';
+import { navigateTo, waitForLoaded } from './helpers';
 
 test.describe('Badugi E2E', () => {
   test('plays a full hand: reset → check/call + stand → showdown → reset', async ({ page }) => {
@@ -11,47 +11,46 @@ test.describe('Badugi E2E', () => {
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
-    // Play through up to 4 betting rounds + 3 draw rounds with generous retry.
+    // Play through up to 4 betting rounds + 3 draw rounds.
+    // Each iteration waits (once) for any actionable button to appear, then acts.
+    // Using a single .or() locator avoids burning time with per-button timeouts
+    // that compound past the 90s test budget in CI.
     const endResetButton = page.getByRole('button', { name: '次のゲーム' });
+    const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
+    const callButton = page.getByRole('button', { name: 'コール', exact: true });
+    const standButton = page.getByRole('button', { name: 'スタンド', exact: true });
+    const anyButton = endResetButton.or(standButton).or(checkButton).or(callButton);
+
     let roundEnded = false;
     for (let round = 0; round < 30; round++) {
-      // End state reached — break immediately. Action buttons briefly overlapping
-      // with 次のゲーム during phase transition would otherwise race the break.
+      // Wait for any actionable button to become visible (CPU may be thinking).
+      await expect(anyButton.first()).toBeVisible({ timeout: 10_000 });
+
       if (await endResetButton.isVisible()) {
         roundEnded = true;
         break;
       }
 
-      const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
-      const callButton = page.getByRole('button', { name: 'コール', exact: true });
-      const standButton = page.getByRole('button', { name: 'スタンド', exact: true });
-
-      // Draw phase has Stand button visible — click it (no exchanges).
-      if (await isVisibleWithin(standButton, TIMEOUT_ACTION)) {
-        if (await standButton.isEnabled()) {
-          await standButton.click();
-          await waitForLoaded(page);
-          continue;
-        }
+      // Draw phase: スタンド (no exchanges).
+      if ((await standButton.isVisible()) && (await standButton.isEnabled())) {
+        await standButton.click();
+        await waitForLoaded(page);
+        continue;
       }
 
       // Betting phase: prefer check, fall back to call.
-      if (await isVisibleWithin(checkButton, TIMEOUT_ACTION)) {
-        if (await checkButton.isEnabled()) {
-          await checkButton.click();
-          await waitForLoaded(page);
-          continue;
-        }
+      if ((await checkButton.isVisible()) && (await checkButton.isEnabled())) {
+        await checkButton.click();
+        await waitForLoaded(page);
+        continue;
+      }
+      if ((await callButton.isVisible()) && (await callButton.isEnabled())) {
+        await callButton.click();
+        await waitForLoaded(page);
+        continue;
       }
 
-      if (await isVisibleWithin(callButton, TIMEOUT_ACTION)) {
-        if (await callButton.isEnabled()) {
-          await callButton.click();
-          await waitForLoaded(page);
-          continue;
-        }
-      }
-
+      // None of the buttons are actionable right now — let the page settle.
       await waitForLoaded(page);
     }
 

--- a/frontend/e2e/blackjack.spec.ts
+++ b/frontend/e2e/blackjack.spec.ts
@@ -25,8 +25,8 @@ test.describe('BlackJack E2E', () => {
     await standButton.click();
     await waitForLoaded(page);
 
-    // END phase: リセット button should be visible
-    const resetButton = page.getByRole('button', { name: /リセット/ });
+    // END phase: 次のゲーム button should be visible
+    const resetButton = page.getByRole('button', { name: '次のゲーム' });
     await expect(resetButton).toBeVisible({ timeout: 10_000 });
   });
 });

--- a/frontend/e2e/bridge.spec.ts
+++ b/frontend/e2e/bridge.spec.ts
@@ -5,10 +5,10 @@ test.describe('Bridge E2E', () => {
   test('navigates, resets, and plays through phase transitions', async ({ page }) => {
     await navigateTo(page, '/bridge');
 
-    // Click リセット to start
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    // Click リセット to start (mid-game: confirm dialog)
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
@@ -21,13 +21,14 @@ test.describe('Bridge E2E', () => {
     const nextTrickButton = page.getByRole('button', { name: '次のトリック' });
     const nextRoundButton = page.getByRole('button', { name: '次のラウンド' });
     const handCards = page.locator('button[aria-pressed]:has(img)');
+    const anyResetButton = page.getByRole('button', { name: /リセット|次のゲーム/ });
 
     // Play through several interactions to verify phase transitions
     const MAX_TURNS = 80;
     let interactions = 0;
     for (let turn = 0; turn < MAX_TURNS; turn++) {
       await expect(
-        bidButton.or(passButton).or(playButton).or(nextTrickButton).or(nextRoundButton).or(resetButton).first(),
+        bidButton.or(passButton).or(playButton).or(nextTrickButton).or(nextRoundButton).or(anyResetButton).first(),
       ).toBeVisible({ timeout: 10_000 });
 
       const bidVisible = await bidButton.isVisible();
@@ -80,9 +81,14 @@ test.describe('Bridge E2E', () => {
     // Verify we had at least one interaction
     expect(interactions).toBeGreaterThan(0);
 
-    // Reset and verify game restarts
-    await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Reset and verify game restarts. Button could be either mid-game (リセット) or end (次のゲーム).
+    const midVisible = await midResetButton.isVisible();
+    if (midVisible) {
+      await midResetButton.click();
+      await page.getByRole('button', { name: '確認' }).click();
+    } else {
+      await page.getByRole('button', { name: '次のゲーム' }).click();
+    }
     await waitForLoaded(page);
     await expect(page.getByText(/^ラウンド \d+$/).first()).toBeVisible();
   });

--- a/frontend/e2e/canasta.spec.ts
+++ b/frontend/e2e/canasta.spec.ts
@@ -5,10 +5,10 @@ test.describe('Canasta E2E', () => {
   test('navigates, resets, and plays through phase transitions', async ({ page }) => {
     await navigateTo(page, '/canasta');
 
-    // Click リセット to start
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    // Click リセット to start (mid-game: confirm dialog)
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
@@ -23,6 +23,7 @@ test.describe('Canasta E2E', () => {
     const goOutButton = page.getByRole('button', { name: '上がる' });
     const nextRoundButton = page.getByRole('button', { name: '次のラウンド' });
     const handCards = page.locator('button[aria-pressed]:has(img)');
+    const anyResetButton = page.getByRole('button', { name: /リセット|次のゲーム/ });
 
     const MAX_TURNS = 60;
     let interactions = 0;
@@ -35,7 +36,7 @@ test.describe('Canasta E2E', () => {
           .or(discardButton)
           .or(goOutButton)
           .or(nextRoundButton)
-          .or(resetButton)
+          .or(anyResetButton)
           .first(),
       ).toBeVisible({ timeout: 10_000 });
 

--- a/frontend/e2e/caribbeanstud.spec.ts
+++ b/frontend/e2e/caribbeanstud.spec.ts
@@ -17,13 +17,12 @@ test.describe('Caribbean Stud Poker E2E', () => {
     await callButton.click();
     await waitForLoaded(page);
 
-    // END phase: リセット button should be visible
-    const resetButton = page.getByRole('button', { name: 'リセット' });
+    // END phase: 次のゲーム button should be visible
+    const resetButton = page.getByRole('button', { name: '次のゲーム' });
     await expect(resetButton).toBeVisible({ timeout: 10_000 });
 
     // Reset back to bet phase
     await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
     await expect(page.getByRole('button', { name: 'ベット' })).toBeVisible();
   });
@@ -41,11 +40,10 @@ test.describe('Caribbean Stud Poker E2E', () => {
     await foldButton.click();
     await waitForLoaded(page);
 
-    const resetButton = page.getByRole('button', { name: 'リセット' });
+    const resetButton = page.getByRole('button', { name: '次のゲーム' });
     await expect(resetButton).toBeVisible({ timeout: 10_000 });
 
     await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
     await expect(page.getByRole('button', { name: 'ベット' })).toBeVisible();
   });

--- a/frontend/e2e/crazyeights.spec.ts
+++ b/frontend/e2e/crazyeights.spec.ts
@@ -22,13 +22,17 @@ test.describe('Crazy Eights E2E', () => {
     const drawButton = page.getByRole('button', { name: '引く' });
     const nextRoundButton = page.getByRole('button', { name: '次のラウンド' });
     const suitSpade = page.getByRole('button', { name: '♠', exact: true });
+    const endResetButton = page.getByRole('button', { name: '次のゲーム' });
     const handCards = page.locator('button[aria-pressed]:has(img)');
 
     // Play through several interactions to verify phase transitions
     const MAX_TURNS = 80;
     let interactions = 0;
     for (let turn = 0; turn < MAX_TURNS; turn++) {
-      await expect(playButton.or(drawButton).or(nextRoundButton).or(suitSpade).first()).toBeVisible({
+      // Break cleanly once the game reaches end state (only 次のゲーム remains).
+      if (await endResetButton.isVisible()) break;
+
+      await expect(playButton.or(drawButton).or(nextRoundButton).or(suitSpade).or(endResetButton).first()).toBeVisible({
         timeout: 10_000,
       });
 

--- a/frontend/e2e/crazyeights.spec.ts
+++ b/frontend/e2e/crazyeights.spec.ts
@@ -5,10 +5,10 @@ test.describe('Crazy Eights E2E', () => {
   test('navigates, resets, and plays through phase transitions', async ({ page }) => {
     await navigateTo(page, '/crazyeights');
 
-    // Click リセット to start
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    // Click リセット to start (mid-game: confirm dialog)
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
@@ -79,9 +79,14 @@ test.describe('Crazy Eights E2E', () => {
     // Verify we had at least one interaction (play, draw, suit choice, or round end)
     expect(interactions).toBeGreaterThan(0);
 
-    // Reset and verify game restarts
-    await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Reset and verify game restarts. Button could be mid-game (リセット) or end (次のゲーム).
+    const midVisible = await midResetButton.isVisible();
+    if (midVisible) {
+      await midResetButton.click();
+      await page.getByRole('button', { name: '確認' }).click();
+    } else {
+      await page.getByRole('button', { name: '次のゲーム' }).click();
+    }
     await waitForLoaded(page);
     await expect(page.getByText(/^ラウンド \d+$/).first()).toBeVisible();
   });

--- a/frontend/e2e/cribbage.spec.ts
+++ b/frontend/e2e/cribbage.spec.ts
@@ -5,10 +5,10 @@ test.describe('Cribbage E2E', () => {
   test('navigates, resets, and plays through phase transitions', async ({ page }) => {
     await navigateTo(page, '/cribbage');
 
-    // Click リセット to start
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    // Click リセット to start (mid-game: confirm dialog)
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
@@ -24,13 +24,14 @@ test.describe('Cribbage E2E', () => {
     const showNextButton = page.getByRole('button', { name: '次を表示' });
     const nextRoundButton = page.getByRole('button', { name: '次のラウンド' });
     const handCards = page.locator('button[aria-pressed]:has(img)');
+    const anyResetButton = page.getByRole('button', { name: /リセット|次のゲーム/ });
 
     // Play through several interactions to verify phase transitions
     const MAX_TURNS = 80;
     let interactions = 0;
     for (let turn = 0; turn < MAX_TURNS; turn++) {
       await expect(
-        discardButton.or(pegButton).or(goButton).or(showNextButton).or(nextRoundButton).or(resetButton).first(),
+        discardButton.or(pegButton).or(goButton).or(showNextButton).or(nextRoundButton).or(anyResetButton).first(),
       ).toBeVisible({ timeout: 10_000 });
 
       const discardVisible = await discardButton.isVisible();
@@ -98,9 +99,14 @@ test.describe('Cribbage E2E', () => {
     // Verify we had at least one interaction
     expect(interactions).toBeGreaterThan(0);
 
-    // Reset and verify game restarts
-    await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Reset and verify game restarts. Button could be mid-game (リセット) or end (次のゲーム).
+    const midVisible = await midResetButton.isVisible();
+    if (midVisible) {
+      await midResetButton.click();
+      await page.getByRole('button', { name: '確認' }).click();
+    } else {
+      await page.getByRole('button', { name: '次のゲーム' }).click();
+    }
     await waitForLoaded(page);
     await expect(page.getByText(/^ラウンド \d+$/).first()).toBeVisible();
   });

--- a/frontend/e2e/deuceswild.spec.ts
+++ b/frontend/e2e/deuceswild.spec.ts
@@ -17,13 +17,12 @@ test.describe('Deuces Wild E2E', () => {
     await drawButton.click();
     await waitForLoaded(page);
 
-    // RESULT phase: 次のハンド button should be visible
-    const resetButton = page.getByRole('button', { name: '次のハンド' });
+    // RESULT phase: 次のゲーム button should be visible
+    const resetButton = page.getByRole('button', { name: '次のゲーム' });
     await expect(resetButton).toBeVisible({ timeout: 10_000 });
 
-    // Reset back to bet phase
+    // Reset back to bet phase (end state: no confirm dialog)
     await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
     await expect(page.getByRole('button', { name: 'ディール' })).toBeVisible();
   });

--- a/frontend/e2e/doubt.spec.ts
+++ b/frontend/e2e/doubt.spec.ts
@@ -5,10 +5,10 @@ test.describe('Doubt E2E', () => {
   test('plays a full game: reset → select card + play / skip doubt → end → reset', async ({ page }) => {
     await navigateTo(page, '/doubt');
 
-    // Click リセット to start
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    // Click リセット to start (mid-game: confirm dialog)
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
@@ -54,9 +54,9 @@ test.describe('Doubt E2E', () => {
     // Assert game ended (Playwright auto-retry)
     await expect(gameEnd).toBeVisible({ timeout: 5_000 });
 
-    // Reset
-    await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Reset (end state: no confirm dialog)
+    const endResetButton = page.getByRole('button', { name: '次のゲーム' });
+    await endResetButton.click();
     await waitForLoaded(page);
   });
 });

--- a/frontend/e2e/euchre.spec.ts
+++ b/frontend/e2e/euchre.spec.ts
@@ -5,10 +5,10 @@ test.describe('Euchre E2E', () => {
   test('navigates, resets, and plays through phase transitions', async ({ page }) => {
     await navigateTo(page, '/euchre');
 
-    // Click リセット to start
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    // Click リセット to start (mid-game: confirm dialog)
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
@@ -26,6 +26,7 @@ test.describe('Euchre E2E', () => {
     const nextTrickButton = page.getByRole('button', { name: '次のトリック' });
     const nextRoundButton = page.getByRole('button', { name: '次のラウンド' });
     const handCards = page.locator('button[aria-pressed]:has(img)');
+    const anyResetButton = page.getByRole('button', { name: /リセット|次のゲーム/ });
 
     // Play through several interactions to verify phase transitions
     const MAX_TURNS = 60;
@@ -38,7 +39,7 @@ test.describe('Euchre E2E', () => {
           .or(discardButton)
           .or(nextTrickButton)
           .or(nextRoundButton)
-          .or(resetButton)
+          .or(anyResetButton)
           .first(),
       ).toBeVisible({ timeout: 10_000 });
 
@@ -123,9 +124,14 @@ test.describe('Euchre E2E', () => {
     // Verify we had at least one interaction
     expect(interactions).toBeGreaterThan(0);
 
-    // Reset and verify game restarts
-    await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Reset and verify game restarts. Button could be either mid-game (リセット) or end (次のゲーム).
+    const midVisible = await midResetButton.isVisible();
+    if (midVisible) {
+      await midResetButton.click();
+      await page.getByRole('button', { name: '確認' }).click();
+    } else {
+      await page.getByRole('button', { name: '次のゲーム' }).click();
+    }
     await waitForLoaded(page);
     await expect(page.getByText(/^ラウンド \d+$/).first()).toBeVisible();
   });

--- a/frontend/e2e/freecell.spec.ts
+++ b/frontend/e2e/freecell.spec.ts
@@ -45,15 +45,14 @@ test.describe('FreeCell E2E', () => {
     await expect(page.getByRole('button', { name: 'オートコンプリート' })).not.toBeVisible();
     await expect(page.getByRole('button', { name: 'ギブアップ' })).not.toBeVisible();
 
-    // Reset should still be visible
-    await expect(page.getByRole('button', { name: 'リセット' })).toBeVisible();
+    // 次のゲーム button (end state) should be visible
+    await expect(page.getByRole('button', { name: '次のゲーム' })).toBeVisible();
 
     // Action log button should appear
     await expect(page.getByRole('button', { name: '棋譜を見る' })).toBeVisible();
 
-    // Reset to start a new game
-    await page.getByRole('button', { name: 'リセット' }).click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Start a new game (end state: no confirm dialog)
+    await page.getByRole('button', { name: '次のゲーム' }).click();
     await waitForLoaded(page);
     await expect(page.getByRole('button', { name: 'ヒント' })).toBeVisible();
   });

--- a/frontend/e2e/ginrummy.spec.ts
+++ b/frontend/e2e/ginrummy.spec.ts
@@ -5,10 +5,10 @@ test.describe('Gin Rummy E2E', () => {
   test('navigates, resets, and plays through phase transitions', async ({ page }) => {
     await navigateTo(page, '/ginrummy');
 
-    // Click リセット to start
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    // Click リセット to start (mid-game: confirm dialog)
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
@@ -25,6 +25,7 @@ test.describe('Gin Rummy E2E', () => {
     const skipButton = page.getByRole('button', { name: 'スキップ' });
     const nextRoundButton = page.getByRole('button', { name: '次のラウンド' });
     const handCards = page.locator('button[aria-pressed]:has(img)');
+    const anyResetButton = page.getByRole('button', { name: /リセット|次のゲーム/ });
 
     // Play through several interactions to verify phase transitions
     const MAX_TURNS = 80;
@@ -37,7 +38,7 @@ test.describe('Gin Rummy E2E', () => {
           .or(layoffButton)
           .or(skipButton)
           .or(nextRoundButton)
-          .or(resetButton)
+          .or(anyResetButton)
           .first(),
       ).toBeVisible({ timeout: 10_000 });
 
@@ -116,9 +117,14 @@ test.describe('Gin Rummy E2E', () => {
     // Verify we had at least one interaction
     expect(interactions).toBeGreaterThan(0);
 
-    // Reset and verify game restarts
-    await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Reset and verify game restarts. Button could be mid-game (リセット) or end (次のゲーム).
+    const midVisible = await midResetButton.isVisible();
+    if (midVisible) {
+      await midResetButton.click();
+      await page.getByRole('button', { name: '確認' }).click();
+    } else {
+      await page.getByRole('button', { name: '次のゲーム' }).click();
+    }
     await waitForLoaded(page);
     await expect(page.getByText(/^ラウンド \d+$/).first()).toBeVisible();
   });

--- a/frontend/e2e/hearts.spec.ts
+++ b/frontend/e2e/hearts.spec.ts
@@ -5,10 +5,10 @@ test.describe('Hearts E2E', () => {
   test('navigates, resets, and plays through phase transitions', async ({ page }) => {
     await navigateTo(page, '/hearts');
 
-    // Click リセット to start
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    // Click リセット to start (mid-game: confirm dialog)
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
@@ -29,13 +29,14 @@ test.describe('Hearts E2E', () => {
     const nextTrickButton = page.getByRole('button', { name: '次のトリック' });
     const nextRoundButton = page.getByRole('button', { name: '次のラウンド' });
     const handCards = page.locator('button[aria-pressed]:has(img)');
+    const anyResetButton = page.getByRole('button', { name: /リセット|次のゲーム/ });
 
     // Play through several interactions to verify phase transitions
     const MAX_TURNS = 60;
     let interactions = 0;
     for (let turn = 0; turn < MAX_TURNS; turn++) {
       await expect(
-        passButton.or(playButton).or(nextTrickButton).or(nextRoundButton).or(resetButton).first(),
+        passButton.or(playButton).or(nextTrickButton).or(nextRoundButton).or(anyResetButton).first(),
       ).toBeVisible({ timeout: 10_000 });
 
       const passVisible = await passButton.isVisible();
@@ -92,9 +93,14 @@ test.describe('Hearts E2E', () => {
     // Verify we had at least one interaction
     expect(interactions).toBeGreaterThan(0);
 
-    // Reset and verify game restarts
-    await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Reset and verify game restarts. Button could be either mid-game (リセット) or end (次のゲーム).
+    const midVisible = await midResetButton.isVisible();
+    if (midVisible) {
+      await midResetButton.click();
+      await page.getByRole('button', { name: '確認' }).click();
+    } else {
+      await page.getByRole('button', { name: '次のゲーム' }).click();
+    }
     await waitForLoaded(page);
     await expect(page.getByText(/^ラウンド \d+$/).first()).toBeVisible();
   });

--- a/frontend/e2e/holdem.spec.ts
+++ b/frontend/e2e/holdem.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, TIMEOUT_QUICK, waitForLoaded } from './helpers';
+import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, waitForLoaded } from './helpers';
 
 test.describe("Texas Hold'em E2E", () => {
   test('plays a full round: reset → check/call through rounds → showdown → reset', async ({ page }) => {
@@ -20,7 +20,7 @@ test.describe("Texas Hold'em E2E", () => {
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
       // Check if we've reached the end
-      if (await isVisibleWithin(endResetButton, TIMEOUT_QUICK)) {
+      if (await endResetButton.isVisible()) {
         const checkVisible = await checkButton.isVisible();
         const callVisible = await callButton.isVisible();
         if (!checkVisible && !callVisible) {

--- a/frontend/e2e/holdem.spec.ts
+++ b/frontend/e2e/holdem.spec.ts
@@ -5,21 +5,22 @@ test.describe("Texas Hold'em E2E", () => {
   test('plays a full round: reset → check/call through rounds → showdown → reset', async ({ page }) => {
     await navigateTo(page, '/holdem');
 
-    // Click リセット to start
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    // Click リセット to start (mid-game: confirm dialog)
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // Play through betting rounds: PRE_FLOP → FLOP → TURN → RIVER → SHOWDOWN
+    const endResetButton = page.getByRole('button', { name: '次のゲーム' });
     let roundEnded = false;
     for (let round = 0; round < 20; round++) {
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
       // Check if we've reached the end
-      if (await isVisibleWithin(resetButton, TIMEOUT_QUICK)) {
+      if (await isVisibleWithin(endResetButton, TIMEOUT_QUICK)) {
         const checkVisible = await checkButton.isVisible();
         const callVisible = await callButton.isVisible();
         if (!checkVisible && !callVisible) {
@@ -50,9 +51,8 @@ test.describe("Texas Hold'em E2E", () => {
 
     expect(roundEnded).toBe(true);
 
-    // Start next round
-    await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Start next round (end state: no confirm dialog)
+    await endResetButton.click();
     await waitForLoaded(page);
   });
 });

--- a/frontend/e2e/holdem.spec.ts
+++ b/frontend/e2e/holdem.spec.ts
@@ -19,14 +19,10 @@ test.describe("Texas Hold'em E2E", () => {
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
-      // Check if we've reached the end
+      // End state reached — break immediately.
       if (await endResetButton.isVisible()) {
-        const checkVisible = await checkButton.isVisible();
-        const callVisible = await callButton.isVisible();
-        if (!checkVisible && !callVisible) {
-          roundEnded = true;
-          break;
-        }
+        roundEnded = true;
+        break;
       }
 
       // Try check first, then call

--- a/frontend/e2e/indianpoker.spec.ts
+++ b/frontend/e2e/indianpoker.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, TIMEOUT_QUICK, waitForLoaded } from './helpers';
+import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, waitForLoaded } from './helpers';
 
 test.describe('Indian Poker E2E', () => {
   test('plays a full round: reset → bet/check through betting → showdown → reset', async ({ page }) => {
@@ -20,7 +20,7 @@ test.describe('Indian Poker E2E', () => {
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
       // Check if we've reached the end
-      if (await isVisibleWithin(endResetButton, TIMEOUT_QUICK)) {
+      if (await endResetButton.isVisible()) {
         const checkVisible = await checkButton.isVisible();
         const callVisible = await callButton.isVisible();
         if (!checkVisible && !callVisible) {

--- a/frontend/e2e/indianpoker.spec.ts
+++ b/frontend/e2e/indianpoker.spec.ts
@@ -19,14 +19,10 @@ test.describe('Indian Poker E2E', () => {
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
-      // Check if we've reached the end
+      // End state reached — break immediately.
       if (await endResetButton.isVisible()) {
-        const checkVisible = await checkButton.isVisible();
-        const callVisible = await callButton.isVisible();
-        if (!checkVisible && !callVisible) {
-          roundEnded = true;
-          break;
-        }
+        roundEnded = true;
+        break;
       }
 
       // Try check first, then call

--- a/frontend/e2e/indianpoker.spec.ts
+++ b/frontend/e2e/indianpoker.spec.ts
@@ -5,21 +5,22 @@ test.describe('Indian Poker E2E', () => {
   test('plays a full round: reset → bet/check through betting → showdown → reset', async ({ page }) => {
     await navigateTo(page, '/indianpoker');
 
-    // Click リセット to start
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    // Click リセット to start (mid-game: confirm dialog)
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // Play through betting round
+    const endResetButton = page.getByRole('button', { name: '次のゲーム' });
     let roundEnded = false;
     for (let round = 0; round < 20; round++) {
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
       // Check if we've reached the end
-      if (await isVisibleWithin(resetButton, TIMEOUT_QUICK)) {
+      if (await isVisibleWithin(endResetButton, TIMEOUT_QUICK)) {
         const checkVisible = await checkButton.isVisible();
         const callVisible = await callButton.isVisible();
         if (!checkVisible && !callVisible) {
@@ -50,9 +51,8 @@ test.describe('Indian Poker E2E', () => {
 
     expect(roundEnded).toBe(true);
 
-    // Start next round
-    await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Start next round (end state: no confirm dialog)
+    await endResetButton.click();
     await waitForLoaded(page);
   });
 });

--- a/frontend/e2e/jokerpoker.spec.ts
+++ b/frontend/e2e/jokerpoker.spec.ts
@@ -17,13 +17,12 @@ test.describe('Joker Poker E2E', () => {
     await drawButton.click();
     await waitForLoaded(page);
 
-    // RESULT phase: 次のハンド button should be visible
-    const resetButton = page.getByRole('button', { name: '次のハンド' });
+    // RESULT phase: 次のゲーム button should be visible
+    const resetButton = page.getByRole('button', { name: '次のゲーム' });
     await expect(resetButton).toBeVisible({ timeout: 10_000 });
 
-    // Reset back to bet phase
+    // Reset back to bet phase (end state: no confirm dialog)
     await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
     await expect(page.getByRole('button', { name: 'ディール' })).toBeVisible();
   });

--- a/frontend/e2e/klondike.spec.ts
+++ b/frontend/e2e/klondike.spec.ts
@@ -61,15 +61,14 @@ test.describe('Klondike E2E', () => {
     await expect(page.getByRole('button', { name: '自動完成' })).not.toBeVisible();
     await expect(page.getByRole('button', { name: 'ギブアップ' })).not.toBeVisible();
 
-    // Reset should still be visible
-    await expect(page.getByRole('button', { name: 'リセット' })).toBeVisible();
+    // 次のゲーム button (end state) should be visible
+    await expect(page.getByRole('button', { name: '次のゲーム' })).toBeVisible();
 
     // Action log button should appear
     await expect(page.getByRole('button', { name: '棋譜を見る' })).toBeVisible();
 
-    // Reset to start a new game
-    await page.getByRole('button', { name: 'リセット' }).click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Start a new game (end state: no confirm dialog)
+    await page.getByRole('button', { name: '次のゲーム' }).click();
     await waitForLoaded(page);
     await expect(page.getByRole('button', { name: 'ヒント' })).toBeVisible();
   });

--- a/frontend/e2e/letitride.spec.ts
+++ b/frontend/e2e/letitride.spec.ts
@@ -23,13 +23,12 @@ test.describe('Let It Ride E2E', () => {
     await rideButton2.click();
     await waitForLoaded(page);
 
-    // END phase: リセット button should be visible
-    const resetButton = page.getByRole('button', { name: 'リセット' });
+    // END phase: 次のゲーム button should be visible
+    const resetButton = page.getByRole('button', { name: '次のゲーム' });
     await expect(resetButton).toBeVisible({ timeout: 10_000 });
 
     // Reset back to bet phase
     await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
     await expect(page.getByRole('button', { name: 'ベット' })).toBeVisible();
   });
@@ -55,11 +54,10 @@ test.describe('Let It Ride E2E', () => {
     await waitForLoaded(page);
 
     // END phase
-    const resetButton = page.getByRole('button', { name: 'リセット' });
+    const resetButton = page.getByRole('button', { name: '次のゲーム' });
     await expect(resetButton).toBeVisible({ timeout: 10_000 });
 
     await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
     await expect(page.getByRole('button', { name: 'ベット' })).toBeVisible();
   });

--- a/frontend/e2e/memory.spec.ts
+++ b/frontend/e2e/memory.spec.ts
@@ -5,10 +5,10 @@ test.describe('Memory E2E', () => {
   test('navigates, resets, and plays through phase transitions', async ({ page }) => {
     await navigateTo(page, '/memory');
 
-    // Click リセット to start
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    // Click リセット to start (mid-game: confirm dialog)
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
@@ -20,12 +20,13 @@ test.describe('Memory E2E', () => {
     await expect(boardButtons.first()).toBeVisible();
 
     const nextButton = page.getByRole('button', { name: '次へ' });
+    const anyResetButton = page.getByRole('button', { name: /リセット|次のゲーム/ });
 
     // Play through several turns to verify phase transitions
     const MAX_TURNS = 60;
     for (let turn = 0; turn < MAX_TURNS; turn++) {
       // Wait for something actionable
-      await expect(nextButton.or(resetButton).first()).toBeVisible({ timeout: 10_000 });
+      await expect(nextButton.or(anyResetButton).first()).toBeVisible({ timeout: 10_000 });
 
       const nextVisible = await nextButton.isVisible();
 
@@ -53,9 +54,14 @@ test.describe('Memory E2E', () => {
       }
     }
 
-    // Reset and verify game restarts
-    await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Reset and verify game restarts. Button could be mid-game (リセット) or end (次のゲーム).
+    const midVisible = await midResetButton.isVisible();
+    if (midVisible) {
+      await midResetButton.click();
+      await page.getByRole('button', { name: '確認' }).click();
+    } else {
+      await page.getByRole('button', { name: '次のゲーム' }).click();
+    }
     await waitForLoaded(page);
     await expect(page.getByRole('status', { name: 'スコア' })).toBeVisible();
   });

--- a/frontend/e2e/napoleon.spec.ts
+++ b/frontend/e2e/napoleon.spec.ts
@@ -5,10 +5,10 @@ test.describe('Napoleon E2E', () => {
   test('navigates, resets, and plays through phase transitions', async ({ page }) => {
     await navigateTo(page, '/napoleon');
 
-    // Click リセット to start
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    // Click リセット to start (mid-game: confirm dialog)
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
@@ -26,6 +26,7 @@ test.describe('Napoleon E2E', () => {
     const nextTrickButton = page.getByRole('button', { name: '次のトリック' });
     const nextRoundButton = page.getByRole('button', { name: '次のラウンド' });
     const handCards = page.locator('button[aria-pressed]:has(img)');
+    const anyResetButton = page.getByRole('button', { name: /リセット|次のゲーム/ });
 
     // Play through several interactions to verify phase transitions
     const MAX_TURNS = 80;
@@ -39,7 +40,7 @@ test.describe('Napoleon E2E', () => {
           .or(playButton)
           .or(nextTrickButton)
           .or(nextRoundButton)
-          .or(resetButton)
+          .or(anyResetButton)
           .first(),
       ).toBeVisible({ timeout: 10_000 });
 
@@ -134,9 +135,14 @@ test.describe('Napoleon E2E', () => {
     // Verify we had at least one interaction
     expect(interactions).toBeGreaterThan(0);
 
-    // Reset and verify game restarts
-    await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Reset and verify game restarts. Button could be either mid-game (リセット) or end (次のゲーム).
+    const midVisible = await midResetButton.isVisible();
+    if (midVisible) {
+      await midResetButton.click();
+      await page.getByRole('button', { name: '確認' }).click();
+    } else {
+      await page.getByRole('button', { name: '次のゲーム' }).click();
+    }
     await waitForLoaded(page);
     await expect(page.getByText(/^ラウンド \d+$/).first()).toBeVisible();
   });

--- a/frontend/e2e/oldmaid.spec.ts
+++ b/frontend/e2e/oldmaid.spec.ts
@@ -19,7 +19,8 @@ test.describe('Old Maid E2E', () => {
 
     // After drawing, the game processes CPU turns (with animation delays)
     // Wait until either the draw button reappears (human's turn again) or the game ends
-    const resetButton = page.getByRole('button', { name: 'リセット' });
+    // (reset button label is リセット mid-game, 次のゲーム at end state).
+    const resetButton = page.getByRole('button', { name: /リセット|次のゲーム/ });
     const nextAction = randomDrawButton.or(resetButton);
     await expect(nextAction.first()).toBeVisible({ timeout: 30_000 });
   });

--- a/frontend/e2e/omaha.spec.ts
+++ b/frontend/e2e/omaha.spec.ts
@@ -19,14 +19,10 @@ test.describe('Omaha E2E', () => {
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
-      // Check if we've reached the end
+      // End state reached — break immediately.
       if (await endResetButton.isVisible()) {
-        const checkVisible = await checkButton.isVisible();
-        const callVisible = await callButton.isVisible();
-        if (!checkVisible && !callVisible) {
-          roundEnded = true;
-          break;
-        }
+        roundEnded = true;
+        break;
       }
 
       // Try check first, then call

--- a/frontend/e2e/omaha.spec.ts
+++ b/frontend/e2e/omaha.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, TIMEOUT_QUICK, waitForLoaded } from './helpers';
+import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, waitForLoaded } from './helpers';
 
 test.describe('Omaha E2E', () => {
   test('plays a full round: reset → check/call through rounds → showdown → reset', async ({ page }) => {
@@ -20,7 +20,7 @@ test.describe('Omaha E2E', () => {
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
       // Check if we've reached the end
-      if (await isVisibleWithin(endResetButton, TIMEOUT_QUICK)) {
+      if (await endResetButton.isVisible()) {
         const checkVisible = await checkButton.isVisible();
         const callVisible = await callButton.isVisible();
         if (!checkVisible && !callVisible) {

--- a/frontend/e2e/omaha.spec.ts
+++ b/frontend/e2e/omaha.spec.ts
@@ -5,21 +5,22 @@ test.describe('Omaha E2E', () => {
   test('plays a full round: reset → check/call through rounds → showdown → reset', async ({ page }) => {
     await navigateTo(page, '/omaha');
 
-    // Click リセット to start
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    // Click リセット to start (mid-game: confirm dialog)
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // Play through betting rounds: PRE_FLOP → FLOP → TURN → RIVER → SHOWDOWN
+    const endResetButton = page.getByRole('button', { name: '次のゲーム' });
     let roundEnded = false;
     for (let round = 0; round < 20; round++) {
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
       // Check if we've reached the end
-      if (await isVisibleWithin(resetButton, TIMEOUT_QUICK)) {
+      if (await isVisibleWithin(endResetButton, TIMEOUT_QUICK)) {
         const checkVisible = await checkButton.isVisible();
         const callVisible = await callButton.isVisible();
         if (!checkVisible && !callVisible) {
@@ -46,9 +47,8 @@ test.describe('Omaha E2E', () => {
 
     expect(roundEnded).toBe(true);
 
-    // Start next round
-    await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Start next round (end state: no confirm dialog)
+    await endResetButton.click();
     await waitForLoaded(page);
   });
 });

--- a/frontend/e2e/paigow.spec.ts
+++ b/frontend/e2e/paigow.spec.ts
@@ -23,13 +23,12 @@ test.describe('Pai Gow Poker E2E', () => {
     await setButton.click();
     await waitForLoaded(page);
 
-    // END phase: リセット button should be visible
-    const resetButton = page.getByRole('button', { name: 'リセット' });
+    // END phase: 次のゲーム button should be visible
+    const resetButton = page.getByRole('button', { name: '次のゲーム' });
     await expect(resetButton).toBeVisible({ timeout: 10_000 });
 
     // Reset back to bet phase
     await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
     await expect(page.getByRole('button', { name: 'ベット' })).toBeVisible();
   });

--- a/frontend/e2e/poker.spec.ts
+++ b/frontend/e2e/poker.spec.ts
@@ -5,10 +5,10 @@ test.describe('Poker E2E', () => {
   test('plays a full round: reset → bet → stand (no exchange) → bet → result → reset', async ({ page }) => {
     await navigateTo(page, '/poker');
 
-    // Click リセット to start a new game
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    // Click リセット to start a new game (mid-game: confirm dialog)
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
@@ -37,12 +37,12 @@ test.describe('Poker E2E', () => {
     }
     await waitForLoaded(page);
 
-    // END phase: リセット should be visible again
-    await expect(resetButton).toBeVisible({ timeout: 10_000 });
+    // END phase: 次のゲーム should be visible
+    const endResetButton = page.getByRole('button', { name: '次のゲーム' });
+    await expect(endResetButton).toBeVisible({ timeout: 10_000 });
 
-    // Start another round
-    await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Start another round (end state: no confirm dialog)
+    await endResetButton.click();
     await waitForLoaded(page);
   });
 });

--- a/frontend/e2e/poker.spec.ts
+++ b/frontend/e2e/poker.spec.ts
@@ -29,16 +29,25 @@ test.describe('Poker E2E', () => {
       await waitForLoaded(page);
     }
 
-    // SECOND_BET phase: チェック or コール
-    if (await isVisibleWithin(checkButton, TIMEOUT_ACTION)) {
-      await checkButton.click();
-    } else if (await isVisibleWithin(callButton, TIMEOUT_ACTION)) {
-      await callButton.click();
+    // SECOND_BET phase: check/call repeatedly until end-state 次のゲーム appears.
+    // A single check/call may not conclude the hand if a CPU re-raises.
+    const endResetButton = page.getByRole('button', { name: '次のゲーム' });
+    for (let i = 0; i < 20; i++) {
+      if (await endResetButton.isVisible()) break;
+      if (await isVisibleWithin(checkButton, TIMEOUT_ACTION)) {
+        await checkButton.click();
+        await waitForLoaded(page);
+        continue;
+      }
+      if (await isVisibleWithin(callButton, TIMEOUT_ACTION)) {
+        await callButton.click();
+        await waitForLoaded(page);
+        continue;
+      }
+      await waitForLoaded(page);
     }
-    await waitForLoaded(page);
 
     // END phase: 次のゲーム should be visible
-    const endResetButton = page.getByRole('button', { name: '次のゲーム' });
     await expect(endResetButton).toBeVisible({ timeout: 10_000 });
 
     // Start another round (end state: no confirm dialog)

--- a/frontend/e2e/razz.spec.ts
+++ b/frontend/e2e/razz.spec.ts
@@ -5,21 +5,22 @@ test.describe('Razz E2E', () => {
   test('plays a full round: reset → check/call through streets → showdown → reset', async ({ page }) => {
     await navigateTo(page, '/razz');
 
-    // Click リセット to start
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    // Click リセット to start (mid-game: confirm dialog)
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // Play through streets: THIRD_STREET → FOURTH → FIFTH → SIXTH → SEVENTH → SHOWDOWN
+    const endResetButton = page.getByRole('button', { name: '次のゲーム' });
     let roundEnded = false;
     for (let round = 0; round < 20; round++) {
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
       // Check if we've reached the end
-      if (await isVisibleWithin(resetButton, TIMEOUT_QUICK)) {
+      if (await isVisibleWithin(endResetButton, TIMEOUT_QUICK)) {
         const checkVisible = await checkButton.isVisible();
         const callVisible = await callButton.isVisible();
         if (!checkVisible && !callVisible) {
@@ -50,9 +51,8 @@ test.describe('Razz E2E', () => {
 
     expect(roundEnded).toBe(true);
 
-    // Start next round
-    await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Start next round (end state: no confirm dialog)
+    await endResetButton.click();
     await waitForLoaded(page);
   });
 });

--- a/frontend/e2e/razz.spec.ts
+++ b/frontend/e2e/razz.spec.ts
@@ -19,14 +19,10 @@ test.describe('Razz E2E', () => {
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
-      // Check if we've reached the end
+      // End state reached — break immediately.
       if (await endResetButton.isVisible()) {
-        const checkVisible = await checkButton.isVisible();
-        const callVisible = await callButton.isVisible();
-        if (!checkVisible && !callVisible) {
-          roundEnded = true;
-          break;
-        }
+        roundEnded = true;
+        break;
       }
 
       // Try check first, then call

--- a/frontend/e2e/razz.spec.ts
+++ b/frontend/e2e/razz.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, TIMEOUT_QUICK, waitForLoaded } from './helpers';
+import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, waitForLoaded } from './helpers';
 
 test.describe('Razz E2E', () => {
   test('plays a full round: reset → check/call through streets → showdown → reset', async ({ page }) => {
@@ -20,7 +20,7 @@ test.describe('Razz E2E', () => {
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
       // Check if we've reached the end
-      if (await isVisibleWithin(endResetButton, TIMEOUT_QUICK)) {
+      if (await endResetButton.isVisible()) {
         const checkVisible = await checkButton.isVisible();
         const callVisible = await callButton.isVisible();
         if (!checkVisible && !callVisible) {

--- a/frontend/e2e/reddog.spec.ts
+++ b/frontend/e2e/reddog.spec.ts
@@ -34,7 +34,9 @@ test.describe('Red Dog E2E', () => {
   test('raise flow when spread decision appears', async ({ page }) => {
     await navigateTo(page, '/reddog');
 
-    // Retry until we get a spread decision (pair/consecutive auto-resolves)
+    // Retry until we get a spread decision. Pair → PairThird (no visible
+    // button to advance) and consecutive → push/END. In either non-spread
+    // case, navigate away to fully reset the backend session.
     for (let attempt = 0; attempt < 20; attempt++) {
       const betButton = page.getByRole('button', { name: 'ベット' });
       await expect(betButton).toBeVisible({ timeout: TIMEOUT_ACTION });
@@ -57,11 +59,16 @@ test.describe('Red Dog E2E', () => {
         return;
       }
 
-      // Auto-resolved (pair/consecutive) — reset and try again
-      const resetButton = page.getByRole('button', { name: '次のゲーム' });
-      await expect(resetButton).toBeVisible({ timeout: TIMEOUT_ACTION });
-      await resetButton.click();
-      await waitForLoaded(page);
+      // Non-spread path: could be auto-END (consecutive) or stuck PairThird
+      // (no visible button). Re-navigate to reset the session either way.
+      const nextGameButton = page.getByRole('button', { name: '次のゲーム' });
+      if (await isVisibleWithin(nextGameButton, TIMEOUT_ACTION)) {
+        await nextGameButton.click();
+        await waitForLoaded(page);
+      } else {
+        // Stuck in PairThird — reload the page to restart the session.
+        await navigateTo(page, '/reddog');
+      }
     }
 
     // If we never got a spread in 20 attempts, still pass (extremely unlikely)

--- a/frontend/e2e/reddog.spec.ts
+++ b/frontend/e2e/reddog.spec.ts
@@ -14,7 +14,7 @@ test.describe('Red Dog E2E', () => {
     // After bet, the game may go to SPREAD_DECISION or skip to END (pair/consecutive)
     const raiseButton = page.getByRole('button', { name: 'レイズ' });
     const stayButton = page.getByRole('button', { name: 'ステイ' });
-    const resetButton = page.getByRole('button', { name: 'リセット' });
+    const resetButton = page.getByRole('button', { name: '次のゲーム' });
 
     if (await isVisibleWithin(raiseButton, TIMEOUT_TRANSITION)) {
       // SPREAD_DECISION phase: choose stay
@@ -22,12 +22,11 @@ test.describe('Red Dog E2E', () => {
       await waitForLoaded(page);
     }
 
-    // END phase: リセット button should be visible
+    // END phase: 次のゲーム button should be visible
     await expect(resetButton).toBeVisible({ timeout: TIMEOUT_ACTION });
 
     // Reset back to bet phase
     await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
     await expect(page.getByRole('button', { name: 'ベット' })).toBeVisible();
   });
@@ -49,21 +48,19 @@ test.describe('Red Dog E2E', () => {
         await waitForLoaded(page);
 
         // END phase
-        const resetButton = page.getByRole('button', { name: 'リセット' });
+        const resetButton = page.getByRole('button', { name: '次のゲーム' });
         await expect(resetButton).toBeVisible({ timeout: TIMEOUT_ACTION });
 
         await resetButton.click();
-        await page.getByRole('button', { name: '確認' }).click();
         await waitForLoaded(page);
         await expect(page.getByRole('button', { name: 'ベット' })).toBeVisible();
         return;
       }
 
       // Auto-resolved (pair/consecutive) — reset and try again
-      const resetButton = page.getByRole('button', { name: 'リセット' });
+      const resetButton = page.getByRole('button', { name: '次のゲーム' });
       await expect(resetButton).toBeVisible({ timeout: TIMEOUT_ACTION });
       await resetButton.click();
-      await page.getByRole('button', { name: '確認' }).click();
       await waitForLoaded(page);
     }
 

--- a/frontend/e2e/sevencardstud.spec.ts
+++ b/frontend/e2e/sevencardstud.spec.ts
@@ -5,21 +5,22 @@ test.describe('Seven Card Stud E2E', () => {
   test('plays a full round: reset → check/call through streets → showdown → reset', async ({ page }) => {
     await navigateTo(page, '/sevencardstud');
 
-    // Click リセット to start
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    // Click リセット to start (mid-game: confirm dialog)
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // Play through streets: THIRD_STREET → FOURTH → FIFTH → SIXTH → SEVENTH → SHOWDOWN
+    const endResetButton = page.getByRole('button', { name: '次のゲーム' });
     let roundEnded = false;
     for (let round = 0; round < 20; round++) {
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
       // Check if we've reached the end
-      if (await isVisibleWithin(resetButton, TIMEOUT_QUICK)) {
+      if (await isVisibleWithin(endResetButton, TIMEOUT_QUICK)) {
         const checkVisible = await checkButton.isVisible();
         const callVisible = await callButton.isVisible();
         if (!checkVisible && !callVisible) {
@@ -50,9 +51,8 @@ test.describe('Seven Card Stud E2E', () => {
 
     expect(roundEnded).toBe(true);
 
-    // Start next round
-    await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Start next round (end state: no confirm dialog)
+    await endResetButton.click();
     await waitForLoaded(page);
   });
 });

--- a/frontend/e2e/sevencardstud.spec.ts
+++ b/frontend/e2e/sevencardstud.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, TIMEOUT_QUICK, waitForLoaded } from './helpers';
+import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, waitForLoaded } from './helpers';
 
 test.describe('Seven Card Stud E2E', () => {
   test('plays a full round: reset → check/call through streets → showdown → reset', async ({ page }) => {
@@ -20,7 +20,7 @@ test.describe('Seven Card Stud E2E', () => {
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
       // Check if we've reached the end
-      if (await isVisibleWithin(endResetButton, TIMEOUT_QUICK)) {
+      if (await endResetButton.isVisible()) {
         const checkVisible = await checkButton.isVisible();
         const callVisible = await callButton.isVisible();
         if (!checkVisible && !callVisible) {

--- a/frontend/e2e/sevencardstud.spec.ts
+++ b/frontend/e2e/sevencardstud.spec.ts
@@ -19,14 +19,10 @@ test.describe('Seven Card Stud E2E', () => {
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
-      // Check if we've reached the end
+      // End state reached — break immediately.
       if (await endResetButton.isVisible()) {
-        const checkVisible = await checkButton.isVisible();
-        const callVisible = await callButton.isVisible();
-        if (!checkVisible && !callVisible) {
-          roundEnded = true;
-          break;
-        }
+        roundEnded = true;
+        break;
       }
 
       // Try check first, then call

--- a/frontend/e2e/sevens.spec.ts
+++ b/frontend/e2e/sevens.spec.ts
@@ -5,10 +5,10 @@ test.describe('Sevens E2E', () => {
   test('plays a full game: reset → play or pass each turn → end → reset', async ({ page }) => {
     await navigateTo(page, '/sevens');
 
-    // Click リセット to start
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    // Click リセット to start (mid-game: confirm dialog)
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
@@ -43,9 +43,9 @@ test.describe('Sevens E2E', () => {
 
     expect(gameEnded).toBe(true);
 
-    // Reset for next game
-    await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Reset for next game (end state: no confirm dialog)
+    const endResetButton = page.getByRole('button', { name: '次のゲーム' });
+    await endResetButton.click();
     await waitForLoaded(page);
   });
 });

--- a/frontend/e2e/shortdeck.spec.ts
+++ b/frontend/e2e/shortdeck.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, TIMEOUT_QUICK, waitForLoaded } from './helpers';
+import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, waitForLoaded } from './helpers';
 
 test.describe("Short Deck Hold'em E2E", () => {
   test('plays a full round: reset → check/call through rounds → showdown → reset', async ({ page }) => {
@@ -20,7 +20,7 @@ test.describe("Short Deck Hold'em E2E", () => {
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
       // Check if we've reached the end
-      if (await isVisibleWithin(endResetButton, TIMEOUT_QUICK)) {
+      if (await endResetButton.isVisible()) {
         const checkVisible = await checkButton.isVisible();
         const callVisible = await callButton.isVisible();
         if (!checkVisible && !callVisible) {

--- a/frontend/e2e/shortdeck.spec.ts
+++ b/frontend/e2e/shortdeck.spec.ts
@@ -19,14 +19,10 @@ test.describe("Short Deck Hold'em E2E", () => {
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
-      // Check if we've reached the end
+      // End state reached — break immediately.
       if (await endResetButton.isVisible()) {
-        const checkVisible = await checkButton.isVisible();
-        const callVisible = await callButton.isVisible();
-        if (!checkVisible && !callVisible) {
-          roundEnded = true;
-          break;
-        }
+        roundEnded = true;
+        break;
       }
 
       // Try check first, then call

--- a/frontend/e2e/shortdeck.spec.ts
+++ b/frontend/e2e/shortdeck.spec.ts
@@ -5,21 +5,22 @@ test.describe("Short Deck Hold'em E2E", () => {
   test('plays a full round: reset → check/call through rounds → showdown → reset', async ({ page }) => {
     await navigateTo(page, '/shortdeck');
 
-    // Click リセット to start
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    // Click リセット to start (mid-game: confirm dialog)
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // Play through betting rounds: PRE_FLOP → FLOP → TURN → RIVER → SHOWDOWN
+    const endResetButton = page.getByRole('button', { name: '次のゲーム' });
     let roundEnded = false;
     for (let round = 0; round < 20; round++) {
       const checkButton = page.getByRole('button', { name: 'チェック', exact: true });
       const callButton = page.getByRole('button', { name: 'コール', exact: true });
 
       // Check if we've reached the end
-      if (await isVisibleWithin(resetButton, TIMEOUT_QUICK)) {
+      if (await isVisibleWithin(endResetButton, TIMEOUT_QUICK)) {
         const checkVisible = await checkButton.isVisible();
         const callVisible = await callButton.isVisible();
         if (!checkVisible && !callVisible) {
@@ -50,9 +51,8 @@ test.describe("Short Deck Hold'em E2E", () => {
 
     expect(roundEnded).toBe(true);
 
-    // Start next round
-    await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Start next round (end state: no confirm dialog)
+    await endResetButton.click();
     await waitForLoaded(page);
   });
 });

--- a/frontend/e2e/spades.spec.ts
+++ b/frontend/e2e/spades.spec.ts
@@ -5,10 +5,10 @@ test.describe('Spades E2E', () => {
   test('navigates, resets, and plays through phase transitions', async ({ page }) => {
     await navigateTo(page, '/spades');
 
-    // Click リセット to start
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    // Click リセット to start (mid-game: confirm dialog)
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
@@ -30,13 +30,14 @@ test.describe('Spades E2E', () => {
     const nextRoundButton = page.getByRole('button', { name: '次のラウンド' });
     const bidInput = page.locator('input[aria-label="bid-input"]');
     const handCards = page.locator('button[aria-pressed]:has(img)');
+    const anyResetButton = page.getByRole('button', { name: /リセット|次のゲーム/ });
 
     // Play through several interactions to verify phase transitions
     const MAX_TURNS = 60;
     let interactions = 0;
     for (let turn = 0; turn < MAX_TURNS; turn++) {
       await expect(
-        bidButton.or(playButton).or(nextTrickButton).or(nextRoundButton).or(resetButton).first(),
+        bidButton.or(playButton).or(nextTrickButton).or(nextRoundButton).or(anyResetButton).first(),
       ).toBeVisible({ timeout: 10_000 });
 
       const bidVisible = await bidButton.isVisible();
@@ -89,9 +90,14 @@ test.describe('Spades E2E', () => {
     // Verify we had at least one interaction
     expect(interactions).toBeGreaterThan(0);
 
-    // Reset and verify game restarts
-    await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Reset and verify game restarts. Button could be either mid-game (リセット) or end (次のゲーム).
+    const midVisible = await midResetButton.isVisible();
+    if (midVisible) {
+      await midResetButton.click();
+      await page.getByRole('button', { name: '確認' }).click();
+    } else {
+      await page.getByRole('button', { name: '次のゲーム' }).click();
+    }
     await waitForLoaded(page);
     await expect(page.getByText(/^ラウンド \d+$/).first()).toBeVisible();
   });

--- a/frontend/e2e/spider.spec.ts
+++ b/frontend/e2e/spider.spec.ts
@@ -42,15 +42,14 @@ test.describe('Spider E2E', () => {
     await expect(page.getByRole('button', { name: '自動完成' })).not.toBeVisible();
     await expect(page.getByRole('button', { name: 'ギブアップ' })).not.toBeVisible();
 
-    // Reset should still be visible
-    await expect(page.getByRole('button', { name: 'リセット' })).toBeVisible();
+    // 次のゲーム button (end state) should be visible
+    await expect(page.getByRole('button', { name: '次のゲーム' })).toBeVisible();
 
     // Action log button should appear
     await expect(page.getByRole('button', { name: '棋譜を見る' })).toBeVisible();
 
-    // Reset to start a new game
-    await page.getByRole('button', { name: 'リセット' }).click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Start a new game (end state: no confirm dialog)
+    await page.getByRole('button', { name: '次のゲーム' }).click();
     await waitForLoaded(page);
     await expect(page.getByRole('button', { name: 'ヒント' })).toBeVisible();
   });

--- a/frontend/e2e/threecard.spec.ts
+++ b/frontend/e2e/threecard.spec.ts
@@ -17,13 +17,12 @@ test.describe('Three Card Poker E2E', () => {
     await playButton.click();
     await waitForLoaded(page);
 
-    // END phase: リセット button should be visible
-    const resetButton = page.getByRole('button', { name: 'リセット' });
+    // END phase: 次のゲーム button should be visible
+    const resetButton = page.getByRole('button', { name: '次のゲーム' });
     await expect(resetButton).toBeVisible({ timeout: 10_000 });
 
     // Reset back to bet phase
     await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
     await expect(page.getByRole('button', { name: 'ベット' })).toBeVisible();
   });
@@ -43,13 +42,12 @@ test.describe('Three Card Poker E2E', () => {
     await foldButton.click();
     await waitForLoaded(page);
 
-    // END phase: リセット button should be visible
-    const resetButton = page.getByRole('button', { name: 'リセット' });
+    // END phase: 次のゲーム button should be visible
+    const resetButton = page.getByRole('button', { name: '次のゲーム' });
     await expect(resetButton).toBeVisible({ timeout: 10_000 });
 
     // Reset back to bet phase
     await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
     await expect(page.getByRole('button', { name: 'ベット' })).toBeVisible();
   });

--- a/frontend/e2e/twotenjack.spec.ts
+++ b/frontend/e2e/twotenjack.spec.ts
@@ -5,9 +5,9 @@ test.describe('Two Ten Jack E2E', () => {
   test('navigates, resets, and plays through phase transitions', async ({ page }) => {
     await navigateTo(page, '/twotenjack');
 
-    const resetButton = page.getByRole('button', { name: 'リセット' });
-    await expect(resetButton).toBeVisible();
-    await resetButton.click();
+    const midResetButton = page.getByRole('button', { name: 'リセット' });
+    await expect(midResetButton).toBeVisible();
+    await midResetButton.click();
     await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
@@ -26,6 +26,7 @@ test.describe('Two Ten Jack E2E', () => {
     const nextTrickButton = page.getByRole('button', { name: '次のトリック' });
     const nextRoundButton = page.getByRole('button', { name: '次のラウンド' });
     const handCards = page.locator('button[aria-pressed]:has(img)');
+    const anyResetButton = page.getByRole('button', { name: /リセット|次のゲーム/ });
 
     const MAX_TURNS = 80;
     let interactions = 0;
@@ -38,7 +39,7 @@ test.describe('Two Ten Jack E2E', () => {
           .or(playButton)
           .or(nextTrickButton)
           .or(nextRoundButton)
-          .or(resetButton)
+          .or(anyResetButton)
           .first(),
       ).toBeVisible({ timeout: TIMEOUT_GAME_LOOP });
 
@@ -88,9 +89,14 @@ test.describe('Two Ten Jack E2E', () => {
 
     expect(interactions).toBeGreaterThan(0);
 
-    // Reset again to verify the game restarts cleanly.
-    await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
+    // Reset again to verify the game restarts cleanly. Button could be mid-game or end state.
+    const midVisible = await midResetButton.isVisible();
+    if (midVisible) {
+      await midResetButton.click();
+      await page.getByRole('button', { name: '確認' }).click();
+    } else {
+      await page.getByRole('button', { name: '次のゲーム' }).click();
+    }
     await waitForLoaded(page);
     await expect(page.getByText(/^ラウンド \d+$/).first()).toBeVisible();
   });

--- a/frontend/e2e/videopoker.spec.ts
+++ b/frontend/e2e/videopoker.spec.ts
@@ -17,13 +17,12 @@ test.describe('Video Poker E2E', () => {
     await drawButton.click();
     await waitForLoaded(page);
 
-    // RESULT phase: 次のハンド button should be visible
-    const resetButton = page.getByRole('button', { name: '次のハンド' });
+    // RESULT phase: 次のゲーム button should be visible
+    const resetButton = page.getByRole('button', { name: '次のゲーム' });
     await expect(resetButton).toBeVisible({ timeout: 10_000 });
 
-    // Reset back to bet phase
+    // Reset back to bet phase (end state: no confirm dialog)
     await resetButton.click();
-    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
     await expect(page.getByRole('button', { name: 'ディール' })).toBeVisible();
   });

--- a/frontend/src/components/GameResetButton.test.tsx
+++ b/frontend/src/components/GameResetButton.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { GameResetButton } from './GameResetButton';
+
+describe('GameResetButton', () => {
+  it('shows "リセット" and routes click through requestConfirm mid-game', () => {
+    const onReset = vi.fn();
+    const requestConfirm = vi.fn();
+    render(<GameResetButton isGameEnd={false} onReset={onReset} requestConfirm={requestConfirm} />);
+
+    const button = screen.getByRole('button', { name: 'リセット' });
+    fireEvent.click(button);
+
+    expect(requestConfirm).toHaveBeenCalledTimes(1);
+    expect(onReset).not.toHaveBeenCalled();
+    // The callback passed to requestConfirm invokes onReset.
+    requestConfirm.mock.calls[0][0]();
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows "次のゲーム" and invokes onReset directly at game end', () => {
+    const onReset = vi.fn();
+    const requestConfirm = vi.fn();
+    render(<GameResetButton isGameEnd={true} onReset={onReset} requestConfirm={requestConfirm} />);
+
+    const button = screen.getByRole('button', { name: '次のゲーム' });
+    fireEvent.click(button);
+
+    expect(onReset).toHaveBeenCalledTimes(1);
+    expect(requestConfirm).not.toHaveBeenCalled();
+  });
+
+  it('disables the button when loading', () => {
+    render(
+      <GameResetButton isGameEnd={false} onReset={() => undefined} requestConfirm={() => undefined} loading={true} />,
+    );
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('forwards dataTutorial attribute', () => {
+    render(
+      <GameResetButton
+        isGameEnd={false}
+        onReset={() => undefined}
+        requestConfirm={() => undefined}
+        dataTutorial="hearts-reset"
+      />,
+    );
+    expect(screen.getByRole('button')).toHaveAttribute('data-tutorial', 'hearts-reset');
+  });
+});

--- a/frontend/src/components/GameResetButton.tsx
+++ b/frontend/src/components/GameResetButton.tsx
@@ -1,0 +1,57 @@
+import { useTranslation } from 'react-i18next';
+import { btnOutline, btnPrimary } from '../styles/buttonStyles';
+
+/** Props for the GameResetButton component. */
+export interface GameResetButtonProps {
+  /** Whether the game has reached its end state. Switches label to "Next Game" and skips confirm. */
+  isGameEnd: boolean;
+  /** Callback that performs the actual reset. Called directly at game end, or via requestConfirm mid-game. */
+  onReset: () => void;
+  /** Function that opens the confirm dialog before invoking the callback. Used only when not in game end. */
+  requestConfirm: (callback: () => void) => void;
+  /** Whether an async operation is in progress; disables the button. */
+  loading?: boolean;
+  /** Optional data-tutorial attribute forwarded to the button element. */
+  dataTutorial?: string;
+  /** Optional additional className appended to the button element. */
+  className?: string;
+}
+
+/**
+ * Reset / Next Game button used across all game pages.
+ *
+ * - Mid-game (isGameEnd=false): labeled "Reset", outline style, opens a confirm dialog first
+ *   so players do not throw away progress by accident.
+ * - Game end (isGameEnd=true): labeled "Next Game", primary style, fires immediately because
+ *   the game is already over — there is nothing to lose.
+ */
+export function GameResetButton({
+  isGameEnd,
+  onReset,
+  requestConfirm,
+  loading,
+  dataTutorial,
+  className,
+}: GameResetButtonProps) {
+  const { t: tc } = useTranslation('common');
+  const label = isGameEnd ? tc('button.nextGame') : tc('button.reset');
+  const variant = isGameEnd ? btnPrimary : btnOutline;
+  const handleClick = () => {
+    if (isGameEnd) {
+      onReset();
+    } else {
+      requestConfirm(onReset);
+    }
+  };
+  return (
+    <button
+      type="button"
+      className={className ? `${variant} ${className}` : variant}
+      onClick={handleClick}
+      disabled={loading}
+      data-tutorial={dataTutorial}
+    >
+      {label}
+    </button>
+  );
+}

--- a/frontend/src/components/VideoPokerGameContent.test.tsx
+++ b/frontend/src/components/VideoPokerGameContent.test.tsx
@@ -150,21 +150,23 @@ describe('VideoPokerGameContent', () => {
     mockExec.mockResolvedValue(resultPhaseWin);
     renderContent();
     await waitFor(() => expect(screen.getByText(/配当.*5/)).toBeInTheDocument());
-    expect(screen.getByRole('button', { name: /次のハンド/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /次のゲーム/ })).toBeInTheDocument();
   });
 
   it('renders result phase on lose', async () => {
     mockExec.mockResolvedValue(resultPhaseLose);
     renderContent();
-    await waitFor(() => expect(screen.getByRole('button', { name: /次のハンド/ })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: /次のゲーム/ })).toBeInTheDocument());
   });
 
-  it('shows reset confirmation dialog', async () => {
+  it('next game button fires reset directly without confirm dialog', async () => {
     mockExec.mockResolvedValue(resultPhaseWin);
     renderContent();
-    await waitFor(() => expect(screen.getByRole('button', { name: /次のハンド/ })).toBeInTheDocument());
-    fireEvent.click(screen.getByRole('button', { name: /次のハンド/ }));
-    await waitFor(() => expect(screen.getByText(/リセットしますか/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: /次のゲーム/ })).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: /次のゲーム/ }));
+    expect(screen.queryByText(/リセットしますか/)).not.toBeInTheDocument();
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
   it('changes bet amount with selector', async () => {
@@ -196,7 +198,7 @@ describe('VideoPokerGameContent', () => {
   it('clicking card in result phase does not toggle hold', async () => {
     mockExec.mockResolvedValue(resultPhaseWin);
     renderContent();
-    await waitFor(() => expect(screen.getByRole('button', { name: /次のハンド/ })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: /次のゲーム/ })).toBeInTheDocument());
     const cardButtons = screen.getAllByRole('button').filter((b) => b.getAttribute('aria-pressed') !== null);
     expect(cardButtons.length).toBe(5);
     // heldIndices[0] is true in resultPhaseWin, so aria-pressed starts as "true"
@@ -222,7 +224,7 @@ describe('VideoPokerGameContent', () => {
     } as unknown as VideoPokerResponse;
     mockExec.mockResolvedValue(resultNoHeld);
     renderContent();
-    await waitFor(() => expect(screen.getByRole('button', { name: /次のハンド/ })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: /次のゲーム/ })).toBeInTheDocument());
     const cardButtons = screen.getAllByRole('button').filter((b) => b.getAttribute('aria-pressed') !== null);
     expect(cardButtons.every((b) => b.getAttribute('aria-pressed') === 'false')).toBe(true);
   });

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -21,6 +21,7 @@ import { ErrorAlert } from './ErrorAlert';
 import { GameFooter } from './GameFooter';
 import { GameMessageBox } from './GameMessageBox';
 import { GamePageHeading } from './GamePageHeading';
+import { GameResetButton } from './GameResetButton';
 import { GameResetDialog } from './GameResetDialog';
 import { HintTooltip } from './hint/HintTooltip';
 import { ManualButton } from './ManualButton';
@@ -256,16 +257,13 @@ export function VideoPokerGameContent({
             )}
             {isResultPhase && (
               <div className="flex justify-center gap-2 pb-2">
-                <div data-tutorial="vp-reset-button">
-                  <button
-                    type="button"
-                    className={btnPrimary}
-                    onClick={() => requestConfirm(handleReset)}
-                    disabled={loading}
-                  >
-                    {t('button.reset')}
-                  </button>
-                </div>
+                <GameResetButton
+                  isGameEnd={isResultPhase}
+                  onReset={handleReset}
+                  requestConfirm={requestConfirm}
+                  loading={loading}
+                  dataTutorial="vp-reset-button"
+                />
                 <button type="button" className={btnSecondary} onClick={showActionLog} disabled={loading}>
                   {tc('actionLog.view')}
                 </button>

--- a/frontend/src/components/blackjack/BjEndPhaseControls.test.tsx
+++ b/frontend/src/components/blackjack/BjEndPhaseControls.test.tsx
@@ -11,40 +11,31 @@ function defaultProps(overrides?: Partial<BjEndPhaseControlsProps>): BjEndPhaseC
 }
 
 describe('BjEndPhaseControls', () => {
-  it('renders reset button', () => {
+  it('renders next-game button', () => {
     render(<BjEndPhaseControls {...defaultProps()} />);
-    expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument();
   });
 
-  it('calls onReset when reset button is clicked and onManualReset is not provided', () => {
+  it('calls onReset when the button is clicked', () => {
     const onReset = vi.fn();
     render(<BjEndPhaseControls {...defaultProps({ onReset })} />);
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
     expect(onReset).toHaveBeenCalled();
   });
 
-  it('calls onManualReset instead of onReset when onManualReset is provided', () => {
-    const onReset = vi.fn();
-    const onManualReset = vi.fn();
-    render(<BjEndPhaseControls {...defaultProps({ onReset, onManualReset })} />);
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    expect(onManualReset).toHaveBeenCalled();
-    expect(onReset).not.toHaveBeenCalled();
-  });
-
-  it('disables reset button when loading is true', () => {
+  it('disables button when loading is true', () => {
     render(<BjEndPhaseControls {...defaultProps({ loading: true })} />);
-    expect(screen.getByRole('button', { name: 'リセット' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: '次のゲーム' })).toBeDisabled();
   });
 
-  it('enables reset button when loading is false', () => {
+  it('enables button when loading is false', () => {
     render(<BjEndPhaseControls {...defaultProps({ loading: false })} />);
-    expect(screen.getByRole('button', { name: 'リセット' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: '次のゲーム' })).not.toBeDisabled();
   });
 
-  it('has animate-pulse class on reset button', () => {
+  it('has animate-pulse class on button', () => {
     render(<BjEndPhaseControls {...defaultProps()} />);
-    expect(screen.getByRole('button', { name: 'リセット' })).toHaveClass('animate-pulse');
+    expect(screen.getByRole('button', { name: '次のゲーム' })).toHaveClass('animate-pulse');
   });
 
   // --- Auto-advance countdown tests ---
@@ -60,28 +51,28 @@ describe('BjEndPhaseControls', () => {
 
     it('shows countdown when autoAdvanceSeconds is provided', () => {
       render(<BjEndPhaseControls {...defaultProps({ autoAdvanceSeconds: 5 })} />);
-      expect(screen.getByRole('button', { name: 'リセット (5s)' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '次のゲーム (5s)' })).toBeInTheDocument();
     });
 
     it('does not show countdown when autoAdvanceSeconds is undefined', () => {
       render(<BjEndPhaseControls {...defaultProps()} />);
-      expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument();
     });
 
     it('does not show countdown when autoAdvanceSeconds is 0', () => {
       render(<BjEndPhaseControls {...defaultProps({ autoAdvanceSeconds: 0 })} />);
-      expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument();
     });
 
     it('decrements countdown every second', async () => {
       render(<BjEndPhaseControls {...defaultProps({ autoAdvanceSeconds: 3 })} />);
-      expect(screen.getByRole('button', { name: 'リセット (3s)' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '次のゲーム (3s)' })).toBeInTheDocument();
 
       vi.advanceTimersByTime(1000);
-      await waitFor(() => expect(screen.getByRole('button', { name: 'リセット (2s)' })).toBeInTheDocument());
+      await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム (2s)' })).toBeInTheDocument());
 
       vi.advanceTimersByTime(1000);
-      await waitFor(() => expect(screen.getByRole('button', { name: 'リセット (1s)' })).toBeInTheDocument());
+      await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム (1s)' })).toBeInTheDocument());
     });
 
     it('calls onReset when countdown reaches 0', async () => {
@@ -97,7 +88,7 @@ describe('BjEndPhaseControls', () => {
       render(<BjEndPhaseControls {...defaultProps({ onReset, autoAdvanceSeconds: 1 })} />);
 
       vi.advanceTimersByTime(1000);
-      await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+      await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
     });
   });
 });

--- a/frontend/src/components/blackjack/BjEndPhaseControls.tsx
+++ b/frontend/src/components/blackjack/BjEndPhaseControls.tsx
@@ -1,16 +1,18 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { btnOutline } from '../../styles/buttonStyles';
+import { btnPrimary } from '../../styles/buttonStyles';
 
 /** Props for BlackJack end phase controls. */
 export interface BjEndPhaseControlsProps {
   loading: boolean;
   onReset: () => void;
-  onManualReset?: () => void;
   autoAdvanceSeconds?: number;
 }
 
-/** Renders the reset button with optional auto-advance countdown for BlackJack end phase. */
+/**
+ * Renders the "Next Game" button with optional auto-advance countdown for BlackJack end phase.
+ * No confirmation dialog — the hand is already resolved, so clicking just deals the next one.
+ */
 export function BjEndPhaseControls(props: BjEndPhaseControlsProps) {
   const { t } = useTranslation('common');
   const [countdown, setCountdown] = useState<number | null>(null);
@@ -41,11 +43,11 @@ export function BjEndPhaseControls(props: BjEndPhaseControlsProps) {
   return (
     <button
       type="button"
-      className={`${btnOutline} animate-pulse ring-2 ring-white ring-offset-2 ring-offset-green-800`}
+      className={`${btnPrimary} animate-pulse ring-2 ring-white ring-offset-2 ring-offset-green-800`}
       disabled={props.loading}
-      onClick={props.onManualReset ?? props.onReset}
+      onClick={props.onReset}
     >
-      {t('button.reset')}
+      {t('button.nextGame')}
       {countdown !== null ? ` (${countdown}s)` : ''}
     </button>
   );

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -116,6 +116,7 @@
   },
   "button": {
     "reset": "Reset",
+    "nextGame": "Next Game",
     "pass": "Pass",
     "cancel": "Cancel",
     "confirmReset": "Confirm Reset",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -116,6 +116,7 @@
   },
   "button": {
     "reset": "リセット",
+    "nextGame": "次のゲーム",
     "pass": "パス",
     "cancel": "キャンセル",
     "confirmReset": "リセット確認",

--- a/frontend/src/pages/AccordionPage.test.tsx
+++ b/frontend/src/pages/AccordionPage.test.tsx
@@ -300,4 +300,15 @@ describe('AccordionPage', () => {
     fireEvent.click(hintToggle);
     expect(hintToggle).toBeChecked();
   });
+
+  it('shows 次のゲーム at game-end and fires reset directly (no confirm)', async () => {
+    mockExec.mockResolvedValue(gameOverState);
+    renderWithProviders(<AccordionPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(screen.queryByRole('button', { name: '確認' })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/AccordionPage.tsx
+++ b/frontend/src/pages/AccordionPage.tsx
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
@@ -26,7 +27,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSound } from '../providers/SoundProvider';
-import { btnDanger, btnOutline, btnPrimary, focusRingWhite } from '../styles/buttonStyles';
+import { btnDanger, btnOutline, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { AccordionResponse } from '../types/card';
 import { AccordionPhase } from '../types/phases';
@@ -162,13 +163,11 @@ function AccordionPageContent() {
 
   const { cardWidth } = useCardDimensions();
 
-  const handleReset = useCallback(() => {
-    requestConfirm(() => {
-      void apiCall('reset');
-      playSound('shuffle');
-      setSelectedIdx(null);
-    });
-  }, [apiCall, requestConfirm, playSound]);
+  const handleManualReset = useCallback(() => {
+    void apiCall('reset');
+    playSound('shuffle');
+    setSelectedIdx(null);
+  }, [apiCall, playSound]);
 
   const handleGiveUp = useCallback(() => {
     void apiCall('giveup');
@@ -336,9 +335,13 @@ function AccordionPageContent() {
             />
 
             <GameFooter>
-              <button type="button" className={btnPrimary} onClick={handleReset} data-tutorial="ac-reset-button">
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={isEnded}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="ac-reset-button"
+              />
 
               {isPlaying && (
                 <>

--- a/frontend/src/pages/BaccaratPage.test.tsx
+++ b/frontend/src/pages/BaccaratPage.test.tsx
@@ -149,7 +149,7 @@ describe('BaccaratPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
     await waitFor(() => expect(screen.getByText('プレイヤーの勝ち！')).toBeInTheDocument());
     expect(screen.getByText('配当: 200')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument();
   });
 
   it('shows end phase with banker wins', async () => {
@@ -210,43 +210,27 @@ describe('BaccaratPage', () => {
     await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
-  // ── ConfirmDialog on reset ─────────────────────────────────────────────────
+  // ── Next game button at end phase ──────────────────────────────────────────
 
-  it('shows confirm dialog when reset button is clicked', async () => {
+  it('next game button does not show confirm dialog', async () => {
     mockExec.mockResolvedValueOnce(betPhaseState).mockResolvedValueOnce(endPhasePlayerWins);
     renderWithProviders(<BaccaratPage />);
     await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
-  });
-
-  it('dismisses confirm dialog on cancel', async () => {
-    mockExec.mockResolvedValueOnce(betPhaseState).mockResolvedValueOnce(endPhasePlayerWins);
-    renderWithProviders(<BaccaratPage />);
-    await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
-
-    fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
-
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   });
 
-  it('executes reset on confirm', async () => {
+  it('next game button executes reset directly', async () => {
     mockExec
       .mockResolvedValueOnce(betPhaseState)
       .mockResolvedValueOnce(endPhasePlayerWins)
@@ -255,10 +239,9 @@ describe('BaccaratPage', () => {
     await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
 
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -9,6 +9,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -26,7 +27,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { BaccaratResponse, BaccaratSideBetResult } from '../types/card';
@@ -434,16 +435,13 @@ function BaccaratPageContent() {
             )}
             {isEndPhase && (
               <div className="flex justify-center gap-2 pb-2">
-                <div data-tutorial="bac-reset-button">
-                  <button
-                    type="button"
-                    className={btnOutline}
-                    onClick={() => requestConfirm(handleReset)}
-                    disabled={loading}
-                  >
-                    {t('button.reset')}
-                  </button>
-                </div>
+                <GameResetButton
+                  isGameEnd={isEndPhase}
+                  onReset={handleReset}
+                  requestConfirm={requestConfirm}
+                  loading={loading}
+                  dataTutorial="bac-reset-button"
+                />
                 <button type="button" className={btnSecondary} onClick={showActionLog} disabled={loading}>
                   {tc('actionLog.view')}
                 </button>

--- a/frontend/src/pages/BadugiPage.test.tsx
+++ b/frontend/src/pages/BadugiPage.test.tsx
@@ -163,12 +163,10 @@ describe('BadugiPage', () => {
     expect(screen.queryByRole('button', { name: /チェック/ })).toBeNull();
   });
 
-  it('shows reset confirmation dialog', async () => {
+  it('shows next game button at end phase', async () => {
     mockExec.mockResolvedValue(baseState({ phase: BadugiPhase.END, gameEndFlag: true }));
     renderWithProviders(<BadugiPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: /リセット/ })).toBeInTheDocument());
-    fireEvent.click(screen.getByRole('button', { name: /リセット/ }));
-    await waitFor(() => expect(screen.getByRole('button', { name: /確認/ })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: /次のゲーム/ })).toBeInTheDocument());
   });
 
   it('toggles betting limit and reissues reset with the new config', async () => {
@@ -180,8 +178,7 @@ describe('BadugiPage', () => {
 
     const limitSelect = await screen.findByLabelText(/リミット/);
     fireEvent.change(limitSelect, { target: { value: '2' } });
-    fireEvent.click(screen.getByRole('button', { name: /リセット/ }));
-    fireEvent.click(screen.getByRole('button', { name: /確認/ }));
+    fireEvent.click(screen.getByRole('button', { name: /次のゲーム/ }));
 
     await waitFor(() =>
       expect(mockExec).toHaveBeenLastCalledWith('reset', undefined, undefined, { bettingLimit: 2, cpuMetaAI: false }),

--- a/frontend/src/pages/BadugiPage.tsx
+++ b/frontend/src/pages/BadugiPage.tsx
@@ -10,6 +10,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -25,7 +26,7 @@ import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnSuccess, btnWarning, focusRingAccent } from '../styles/buttonStyles';
+import { btnSuccess, btnWarning, focusRingAccent } from '../styles/buttonStyles';
 import { selectedCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -154,6 +155,11 @@ function BadugiPageContent() {
     onClear: clearSelection,
     enabled: canExchange,
   });
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    execAction('reset', undefined, undefined, { bettingLimit, cpuMetaAI });
+  }, [execAction, hideActionLog, bettingLimit, cpuMetaAI]);
 
   if (!state) return <PokerSkeleton />;
 
@@ -383,20 +389,14 @@ function BadugiPageContent() {
           ]}
         />
         <div className="text-center mt-2">
-          <button
-            type="button"
-            className={`${btnOutline} min-w-[90px]`}
-            disabled={loading}
-            data-tutorial="bg-reset-button"
-            onClick={() =>
-              requestConfirm(() => {
-                hideActionLog();
-                execAction('reset', undefined, undefined, { bettingLimit, cpuMetaAI });
-              })
-            }
-          >
-            {tc('button.reset')}
-          </button>
+          <GameResetButton
+            isGameEnd={isEnd}
+            onReset={handleManualReset}
+            requestConfirm={requestConfirm}
+            loading={loading}
+            dataTutorial="bg-reset-button"
+            className="min-w-[90px]"
+          />
         </div>
       </GameFooter>
       <WinCelebration show={isEnd} onCelebrate={() => playSound('winFanfare')} />

--- a/frontend/src/pages/BadugiPage.tsx
+++ b/frontend/src/pages/BadugiPage.tsx
@@ -124,6 +124,7 @@ function BadugiPageContent() {
   const phase = state?.phase ?? BadugiPhase.INIT;
   const isBettingPhase = phase === BadugiPhase.DEAL || phase === BadugiPhase.BET;
   const isEnd = phase === BadugiPhase.END;
+  const isHandOver = phase === BadugiPhase.SHOWDOWN || phase === BadugiPhase.END;
   const drawIndex = state?.drawIndex ?? 0;
   const phaseLabel =
     phase === BadugiPhase.DRAW
@@ -390,7 +391,7 @@ function BadugiPageContent() {
         />
         <div className="text-center mt-2">
           <GameResetButton
-            isGameEnd={isEnd}
+            isGameEnd={isHandOver}
             onReset={handleManualReset}
             requestConfirm={requestConfirm}
             loading={loading}

--- a/frontend/src/pages/BlackJackPage.test.tsx
+++ b/frontend/src/pages/BlackJackPage.test.tsx
@@ -257,7 +257,7 @@ describe('BlackJackPage', () => {
   it('shows reset button in end phase', async () => {
     mockExec.mockResolvedValue(endPhaseState);
     renderWithProviders(<BlackJackPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
   });
 
   it('shows message overlay when message is non-empty', async () => {
@@ -1022,11 +1022,10 @@ describe('BlackJackPage', () => {
   it('sends config params when reset button is clicked in end phase', async () => {
     mockExec.mockResolvedValue(endPhaseState);
     renderWithProviders(<BlackJackPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
     mockExec.mockClear();
     mockExec.mockResolvedValue(betPhaseState);
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
     await waitFor(() =>
       expect(mockExec).toHaveBeenCalledWith('reset', undefined, {
         dealerHitsSoft17: false,
@@ -1277,7 +1276,7 @@ describe('BlackJackPage', () => {
   it('does not show countdown on reset button when auto-advance is OFF', async () => {
     mockExec.mockResolvedValue(endPhaseState);
     renderWithProviders(<BlackJackPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
   });
 
   it('shows CPU insurance bet when insuranceBet > 0', async () => {
@@ -1436,33 +1435,15 @@ describe('BlackJackPage', () => {
     expect(screen.getByText('棋譜を見る')).toBeInTheDocument();
   });
 
-  // --- ConfirmDialog tests ---
+  // --- Next Game button tests ---
 
-  it('shows confirm dialog when reset button is clicked', async () => {
+  it('executes reset when next game button is clicked in end phase', async () => {
     mockExec.mockResolvedValue(endPhaseState);
     renderWithProviders(<BlackJackPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
-  });
-
-  it('dismisses confirm dialog on cancel', async () => {
-    mockExec.mockResolvedValue(endPhaseState);
-    renderWithProviders(<BlackJackPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
-    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
-  });
-
-  it('executes reset on confirm', async () => {
-    mockExec.mockResolvedValue(endPhaseState);
-    renderWithProviders(<BlackJackPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
     mockExec.mockClear();
     mockExec.mockResolvedValue(betPhaseState);
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, expect.any(Object)));
   });
 

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -128,7 +128,7 @@ export function BlackJackPage() {
 
 /** Inner content of the BlackJack page, wrapped by TutorialProvider. */
 function BlackJackPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
+  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, confirmReset, cancelReset } =
     useGamePageSetup('blackjack');
   const phaseNames = usePhaseNames('blackjack', BJ_PHASE_KEYS);
   const suggestionLabels = useSuggestionLabels(t);
@@ -567,7 +567,6 @@ function BlackJackPageContent() {
                   <BjEndPhaseControls
                     loading={loading}
                     onReset={handleReset}
-                    onManualReset={() => requestConfirm(handleReset)}
                     autoAdvanceSeconds={autoAdvance > 0 ? autoAdvance : undefined}
                   />
                 </div>

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -26,7 +26,6 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
@@ -128,8 +127,7 @@ export function BlackJackPage() {
 
 /** Inner content of the BlackJack page, wrapped by TutorialProvider. */
 function BlackJackPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, confirmReset, cancelReset } =
-    useGamePageSetup('blackjack');
+  const { t, tc, actionLog, showActionLog, hideActionLog } = useGamePageSetup('blackjack');
   const phaseNames = usePhaseNames('blackjack', BJ_PHASE_KEYS);
   const suggestionLabels = useSuggestionLabels(t);
   const { playSound } = useSound();
@@ -577,7 +575,6 @@ function BlackJackPageContent() {
       )}
       <WinCelebration show={phase === BjPhase.END} onCelebrate={() => playSound('winFanfare')} />
       <LossFeedback show={hands.some((h) => h.busted)} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
     </div>
   );
 }

--- a/frontend/src/pages/BridgePage.tsx
+++ b/frontend/src/pages/BridgePage.tsx
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
@@ -24,7 +25,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
+import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -182,6 +183,13 @@ function BridgePageContent() {
   });
 
   const phaseNames = usePhaseNames('bridge', BRIDGE_PHASE_KEYS);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void apiExec('reset', undefined, undefined, undefined, undefined, {
+      cpuDifficulty: bridgeConfig.cpuDifficulty,
+    });
+  }, [apiExec, hideActionLog, bridgeConfig.cpuDifficulty]);
 
   if (!state) return <BridgeSkeleton />;
 
@@ -616,22 +624,13 @@ function BridgePageContent() {
               )}
 
               {/* Reset */}
-              <button
-                type="button"
-                className={btnOutline}
-                data-tutorial="br-reset-button"
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    return apiExec('reset', undefined, undefined, undefined, undefined, {
-                      cpuDifficulty: bridgeConfig.cpuDifficulty,
-                    });
-                  })
-                }
-                disabled={loading}
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={isGameEnd}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="br-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/CanastaPage.test.tsx
+++ b/frontend/src/pages/CanastaPage.test.tsx
@@ -167,6 +167,22 @@ describe('CanastaPage', () => {
     await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
   });
 
+  it('shows 次のゲーム at game-end and fires reset directly (no confirm)', async () => {
+    mockExec.mockResolvedValue(gameEndState);
+    renderWithProviders(<CanastaPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('reset', undefined, {
+        cpuDifficulty: 1,
+        pointLimit: 5000,
+      }),
+    );
+    expect(screen.queryByRole('button', { name: '確認' })).not.toBeInTheDocument();
+  });
+
   afterEach(() => {
     localStorage.clear();
   });

--- a/frontend/src/pages/CanastaPage.tsx
+++ b/frontend/src/pages/CanastaPage.tsx
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -121,6 +122,14 @@ function CanastaPageContent() {
   const isDiscardPhase = state?.phase === CanastaPhase.DISCARD;
   const isRoundEnd = state?.phase === CanastaPhase.ROUND_END;
   const isGameEnd = state?.phase === CanastaPhase.GAME_END || !!state?.gameEndFlag;
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void gameExec('reset', undefined, {
+      cpuDifficulty: canastaConfig.cpuDifficulty,
+      pointLimit: canastaConfig.pointLimit,
+    });
+  }, [gameExec, hideActionLog, canastaConfig.cpuDifficulty, canastaConfig.pointLimit]);
   const isHumanTurn =
     (isDrawPhase || isMeldPhase || isDiscardPhase) && state?.players[state.currentPlayerIdx]?.isHuman === true;
 
@@ -422,21 +431,12 @@ function CanastaPageContent() {
                   {t('nextRound')}
                 </button>
               )}
-              <button
-                type="button"
-                className={btnOutline}
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    return gameExec('reset', undefined, {
-                      cpuDifficulty: canastaConfig.cpuDifficulty,
-                      pointLimit: canastaConfig.pointLimit,
-                    });
-                  })
-                }
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={isGameEnd}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/CanfieldPage.test.tsx
+++ b/frontend/src/pages/CanfieldPage.test.tsx
@@ -140,7 +140,7 @@ describe('CanfieldPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     expect(screen.queryByRole('button', { name: 'ギブアップ' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'ヒント' })).not.toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: /reset|リセット/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('button', { name: /next game|次のゲーム/i }).length).toBeGreaterThan(0);
   });
 
   it('undo button fires undo command when canUndo is true', async () => {

--- a/frontend/src/pages/CanfieldPage.tsx
+++ b/frontend/src/pages/CanfieldPage.tsx
@@ -7,6 +7,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
@@ -431,14 +432,14 @@ function CanfieldPageContent() {
               </button>
             </>
           )}
-          <button
-            type="button"
-            className={`${btnDanger} ${focusRingWhite}`}
-            onClick={() => requestConfirm(handleReset)}
-            data-tutorial="cf-reset-button"
-          >
-            {tc('button.reset')}
-          </button>
+          <GameResetButton
+            isGameEnd={isEnded}
+            onReset={handleReset}
+            requestConfirm={requestConfirm}
+            loading={loading}
+            dataTutorial="cf-reset-button"
+            className={focusRingWhite}
+          />
         </div>
       </GameFooter>
 

--- a/frontend/src/pages/CaribbeanStudPage.test.tsx
+++ b/frontend/src/pages/CaribbeanStudPage.test.tsx
@@ -156,7 +156,7 @@ describe('CaribbeanStudPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'コール' }));
     await waitFor(() => expect(screen.getByText('勝利！')).toBeInTheDocument());
     expect(screen.getByTestId('payout-breakdown')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument();
   });
 
   it('shows end phase with dealer wins', async () => {
@@ -218,25 +218,15 @@ describe('CaribbeanStudPage', () => {
     await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', 200, 10));
   });
 
-  it('shows confirm dialog when reset button is clicked', async () => {
+  it('next game button executes reset without confirm dialog', async () => {
     mockApi.mockResolvedValue(endPhasePlayerWins);
     renderWithProviders(<CaribbeanStudPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
-  });
-
-  it('dismisses confirm dialog on cancel', async () => {
-    mockApi.mockResolvedValue(endPhasePlayerWins);
-    renderWithProviders(<CaribbeanStudPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
-
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    mockApi.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('reset'));
   });
 
   it('shows network error', async () => {

--- a/frontend/src/pages/CaribbeanStudPage.tsx
+++ b/frontend/src/pages/CaribbeanStudPage.tsx
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -26,7 +27,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSound } from '../providers/SoundProvider';
-import { btnDanger, btnOutline, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
+import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { CaribbeanStudResponse } from '../types/card';
@@ -377,14 +378,12 @@ function CaribbeanStudPageContent() {
             )}
             {isEndPhase && (
               <div className="flex justify-center gap-2 pb-2">
-                <button
-                  type="button"
-                  className={btnOutline}
-                  onClick={() => requestConfirm(handleReset)}
-                  disabled={loading}
-                >
-                  {t('button.reset')}
-                </button>
+                <GameResetButton
+                  isGameEnd={isEndPhase}
+                  onReset={handleReset}
+                  requestConfirm={requestConfirm}
+                  loading={loading}
+                />
                 <button type="button" className={btnSecondary} onClick={showActionLog} disabled={loading}>
                   {tc('actionLog.view')}
                 </button>

--- a/frontend/src/pages/ClockSolitairePage.tsx
+++ b/frontend/src/pages/ClockSolitairePage.tsx
@@ -7,6 +7,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { LandscapeBanner } from '../components/LandscapeBanner';
 import { ManualButton } from '../components/ManualButton';
@@ -21,7 +22,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
+import { btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { ClockSolitaireResponse } from '../types/card';
 import { ClockSolitairePhase } from '../types/phases';
@@ -295,15 +296,14 @@ function ClockSolitairePageContent() {
                   </button>
                 </div>
               )}
-              <div data-tutorial="clock-reset">
-                <button
-                  type="button"
-                  className={`${btnDanger} ${focusRingWhite}`}
-                  onClick={() => requestConfirm(handleReset)}
-                >
-                  {tc('reset')}
-                </button>
-              </div>
+              <GameResetButton
+                isGameEnd={isEnded}
+                onReset={handleReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="clock-reset"
+                className={focusRingWhite}
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/CrazyEightsPage.test.tsx
+++ b/frontend/src/pages/CrazyEightsPage.test.tsx
@@ -623,8 +623,7 @@ describe('CrazyEightsPage', () => {
     await waitFor(() => expect(screen.getByText('棋譜')).toBeInTheDocument());
 
     mockExec.mockResolvedValue(playPhaseState);
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
 
     await waitFor(() => expect(screen.queryByText('棋譜')).not.toBeInTheDocument());
   });

--- a/frontend/src/pages/CrazyEightsPage.tsx
+++ b/frontend/src/pages/CrazyEightsPage.tsx
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -26,7 +27,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSuccess } from '../styles/buttonStyles';
+import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -145,6 +146,14 @@ function CrazyEightsPageContent() {
   const confirmAction = useCallback(() => {
     handlePlay();
   }, [handlePlay]);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void gameExec('reset', undefined, undefined, {
+      cpuDifficulty: crazyEightsConfig.cpuDifficulty,
+      pointLimit: crazyEightsConfig.pointLimit,
+    });
+  }, [gameExec, hideActionLog, crazyEightsConfig.cpuDifficulty, crazyEightsConfig.pointLimit]);
 
   useCardKeyboardNav({
     cardCount: humanCardCountForKbd,
@@ -370,23 +379,13 @@ function CrazyEightsPageContent() {
                   {t('nextRound')}
                 </button>
               )}
-              <button
-                type="button"
-                className={btnOutline}
-                data-tutorial="ce-reset-button"
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    return gameExec('reset', undefined, undefined, {
-                      cpuDifficulty: crazyEightsConfig.cpuDifficulty,
-                      pointLimit: crazyEightsConfig.pointLimit,
-                    });
-                  })
-                }
-                disabled={loading}
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={!!isGameEnd}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="ce-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/CribbagePage.test.tsx
+++ b/frontend/src/pages/CribbagePage.test.tsx
@@ -633,8 +633,7 @@ describe('CribbagePage', () => {
     await waitFor(() => expect(screen.getByText('棋譜')).toBeInTheDocument());
 
     mockExec.mockResolvedValue(discardPhaseState);
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
 
     await waitFor(() => expect(screen.queryByText('棋譜')).not.toBeInTheDocument());
   });

--- a/frontend/src/pages/CribbagePage.tsx
+++ b/frontend/src/pages/CribbagePage.tsx
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -26,7 +27,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSuccess } from '../styles/buttonStyles';
+import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -182,6 +183,14 @@ function CribbagePageContent() {
   });
 
   const phaseNames = usePhaseNames('cribbage', CRIBBAGE_PHASE_KEYS);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void gameExec('reset', undefined, undefined, {
+      cpuDifficulty: cribbageConfig.cpuDifficulty,
+      pointLimit: cribbageConfig.pointLimit,
+    });
+  }, [gameExec, hideActionLog, cribbageConfig.cpuDifficulty, cribbageConfig.pointLimit]);
 
   if (!state) return <CribbageSkeleton />;
 
@@ -503,23 +512,13 @@ function CribbagePageContent() {
                   {t('nextRound')}
                 </button>
               )}
-              <button
-                type="button"
-                className={btnOutline}
-                data-tutorial="cb-reset-button"
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    return gameExec('reset', undefined, undefined, {
-                      cpuDifficulty: cribbageConfig.cpuDifficulty,
-                      pointLimit: cribbageConfig.pointLimit,
-                    });
-                  })
-                }
-                disabled={loading}
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={!!isGameEnd}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="cb-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -13,6 +13,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -31,7 +32,7 @@ import { useDaifugoGame } from '../hooks/useDaifugoGame';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
+import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { DaifugoAction, DaifugoResponse } from '../types/card';
@@ -163,6 +164,11 @@ function DaifugoPageContent() {
     toggle: toggleCardSelection,
     enabled: isHumanTurnForKbd && !loading,
   });
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void exec('reset', [], configInput);
+  }, [exec, configInput, hideActionLog]);
 
   if (!state) return <DaifugoSkeleton />;
 
@@ -362,20 +368,14 @@ function DaifugoPageContent() {
             )}
 
             <div className="text-center" data-tutorial="df-play-pass">
-              <button
-                type="button"
-                className={`${btnOutline} min-w-[90px]`}
-                data-tutorial="df-reset-button"
-                disabled={loading}
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    exec('reset', [], configInput);
-                  })
-                }
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={!!state.gameEndFlag}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="df-reset-button"
+                className="min-w-[90px]"
+              />
               <button
                 type="button"
                 className={`${btnSecondary} min-w-[90px]`}

--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { doubtApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -11,6 +11,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -35,7 +36,7 @@ import {
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSound } from '../providers/SoundProvider';
-import { btnDanger, btnOutline, btnPrimary, btnSecondary, btnSuccess, focusRingAccent } from '../styles/buttonStyles';
+import { btnDanger, btnPrimary, btnSecondary, btnSuccess, focusRingAccent } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { DoubtCpuAction, DoubtResponse } from '../types/card';
@@ -213,6 +214,11 @@ function DoubtPageContent() {
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [isDoubtDecisionPhase, loading]);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void exec('reset', undefined, undefined, undefined, doubtConfig);
+  }, [exec, hideActionLog, doubtConfig]);
 
   if (!state) return <DoubtSkeleton />;
 
@@ -551,20 +557,14 @@ function DoubtPageContent() {
 
             {/* Action buttons */}
             <div className="text-center">
-              <button
-                type="button"
-                className={`${btnOutline} min-w-[90px]`}
-                disabled={loading}
-                data-tutorial="dt-reset-button"
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    exec('reset', undefined, undefined, undefined, doubtConfig);
-                  })
-                }
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={!!state.gameEndFlag}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="dt-reset-button"
+                className="min-w-[90px]"
+              />
               {isHumanTurn && state.phase === 0 && (
                 <button
                   type="button"

--- a/frontend/src/pages/DurakPage.test.tsx
+++ b/frontend/src/pages/DurakPage.test.tsx
@@ -233,4 +233,15 @@ describe('DurakPage', () => {
     renderWithProviders(<DurakPage />);
     await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
   });
+
+  it('shows 次のゲーム at game-end and fires reset directly (no confirm)', async () => {
+    mockExec.mockResolvedValue(gameEndState);
+    renderWithProviders(<DurakPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined, defaultConfig));
+    expect(screen.queryByRole('button', { name: '確認' })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/DurakPage.tsx
+++ b/frontend/src/pages/DurakPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
@@ -7,6 +7,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -153,6 +154,11 @@ function DurakPageContent() {
 
   const { cardWidth } = useCardDimensions();
   const { playSound } = useSound();
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void gameExec('reset', undefined, undefined, durakConfig);
+  }, [gameExec, hideActionLog, durakConfig]);
 
   if (!state) return <DurakSkeleton />;
 
@@ -392,19 +398,13 @@ function DurakPageContent() {
 
             {/* Action buttons */}
             <div className="text-center" data-tutorial="dk-action-buttons">
-              <button
-                type="button"
-                className={`${btnOutline} min-w-[90px]`}
-                disabled={loading}
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    gameExec('reset', undefined, undefined, durakConfig);
-                  })
-                }
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={!!isGameEnd}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                className="min-w-[90px]"
+              />
               {showAttackBtn && (
                 <button
                   type="button"

--- a/frontend/src/pages/EuchrePage.tsx
+++ b/frontend/src/pages/EuchrePage.tsx
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -26,7 +27,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
+import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -183,6 +184,14 @@ function EuchrePageContent() {
   });
 
   const phaseNames = usePhaseNames('euchre', EUCHRE_PHASE_KEYS);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void apiExec('reset', undefined, undefined, undefined, {
+      cpuDifficulty: euchreConfig.cpuDifficulty,
+      pointLimit: euchreConfig.pointLimit,
+    });
+  }, [apiExec, hideActionLog, euchreConfig.cpuDifficulty, euchreConfig.pointLimit]);
 
   if (!state) return <EuchreSkeleton />;
 
@@ -587,23 +596,13 @@ function EuchrePageContent() {
               )}
 
               {/* Reset */}
-              <button
-                type="button"
-                className={btnOutline}
-                data-tutorial="eu-reset-button"
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    return apiExec('reset', undefined, undefined, undefined, {
-                      cpuDifficulty: euchreConfig.cpuDifficulty,
-                      pointLimit: euchreConfig.pointLimit,
-                    });
-                  })
-                }
-                disabled={loading}
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={!!isGameEnd}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="eu-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/FiftyOnePage.tsx
+++ b/frontend/src/pages/FiftyOnePage.tsx
@@ -7,6 +7,7 @@ import { SettingsPanel } from '../components/common/SettingsPanel';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -314,14 +315,13 @@ function FiftyOnePageContent() {
               >
                 {t('button.stop')}
               </button>
-              <button
-                type="button"
-                onClick={() => requestConfirm(handleReset)}
-                className="px-4 py-2 rounded-lg bg-ds-surface-elevated hover:bg-ds-surface-elevated text-white text-sm"
-                data-tutorial="fo-reset-button"
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={isGameEnd}
+                onReset={handleReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="fo-reset-button"
+              />
               <ActionLogSection
                 isEndPhase={isGameEnd}
                 actionLog={actionLog}

--- a/frontend/src/pages/FortyThievesPage.test.tsx
+++ b/frontend/src/pages/FortyThievesPage.test.tsx
@@ -433,7 +433,7 @@ describe('FortyThievesPage', () => {
   it('playing buttons not shown when game is over', async () => {
     mockExec.mockResolvedValue(gameOverState);
     renderWithProviders(<FortyThievesPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
 
     expect(screen.queryByRole('button', { name: 'ヒント' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: '自動完成' })).not.toBeInTheDocument();
@@ -443,7 +443,7 @@ describe('FortyThievesPage', () => {
   it('reset button always visible', async () => {
     mockExec.mockResolvedValue(gameOverState);
     renderWithProviders(<FortyThievesPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
   });
 
   it('displays message with messageCode', async () => {

--- a/frontend/src/pages/FortyThievesPage.tsx
+++ b/frontend/src/pages/FortyThievesPage.tsx
@@ -9,6 +9,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
@@ -30,7 +31,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
-import { btnDanger, btnOutline, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
+import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { FortyThievesResponse } from '../types/card';
 import { FortyThievesPhase } from '../types/phases';
@@ -158,6 +159,11 @@ function FortyThievesPageContent() {
     isPlaying: !!isPlayingForKbd,
     disabled: loading,
   });
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    handleReset();
+  }, [handleReset, hideActionLog]);
 
   const actionBindings = useMemo(
     () => [
@@ -518,21 +524,13 @@ function FortyThievesPageContent() {
                   </button>
                 </div>
               )}
-              <div data-tutorial="ft-reset-button">
-                <button
-                  type="button"
-                  className={btnOutline}
-                  onClick={() =>
-                    requestConfirm(() => {
-                      hideActionLog();
-                      return handleReset();
-                    })
-                  }
-                  disabled={loading}
-                >
-                  {tc('button.reset')}
-                </button>
-              </div>
+              <GameResetButton
+                isGameEnd={isEnded}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="ft-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/FreeCellPage.test.tsx
+++ b/frontend/src/pages/FreeCellPage.test.tsx
@@ -303,7 +303,7 @@ describe('FreeCellPage', () => {
   it('playing buttons not shown when game is over', async () => {
     mockExec.mockResolvedValue(gameOverState);
     renderWithProviders(<FreeCellPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
 
     expect(screen.queryByRole('button', { name: 'ヒント' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'オートコンプリート' })).not.toBeInTheDocument();
@@ -484,8 +484,7 @@ describe('FreeCellPage', () => {
     await waitFor(() => expect(screen.getByText('棋譜')).toBeInTheDocument());
 
     mockExec.mockResolvedValue(playingState);
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
 
     await waitFor(() => expect(screen.queryByText('棋譜')).not.toBeInTheDocument());
   });

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -9,6 +9,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
@@ -29,7 +30,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
-import { btnDanger, btnOutline, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
+import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { Card, FreeCellResponse } from '../types/card';
 import { FreeCellPhase } from '../types/phases';
@@ -140,6 +141,11 @@ function FreeCellPageContent() {
     isPlaying: !!isPlayingForKbd,
     disabled: loading,
   });
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    handleReset();
+  }, [handleReset, hideActionLog]);
 
   const actionBindings = useMemo(
     () => [
@@ -476,21 +482,13 @@ function FreeCellPageContent() {
                   </button>
                 </div>
               )}
-              <div data-tutorial="fc-reset-button">
-                <button
-                  type="button"
-                  className={btnOutline}
-                  onClick={() =>
-                    requestConfirm(() => {
-                      hideActionLog();
-                      return handleReset();
-                    })
-                  }
-                  disabled={loading}
-                >
-                  {tc('button.reset')}
-                </button>
-              </div>
+              <GameResetButton
+                isGameEnd={isEnded}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="fc-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/GinRummyPage.test.tsx
+++ b/frontend/src/pages/GinRummyPage.test.tsx
@@ -718,8 +718,7 @@ describe('GinRummyPage', () => {
     await waitFor(() => expect(screen.getByText('棋譜')).toBeInTheDocument());
 
     mockExec.mockResolvedValue(drawPhaseState);
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
 
     await waitFor(() => expect(screen.queryByText('棋譜')).not.toBeInTheDocument());
   });

--- a/frontend/src/pages/GinRummyPage.tsx
+++ b/frontend/src/pages/GinRummyPage.tsx
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -26,7 +27,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useGinRummyGame } from '../hooks/useGinRummyGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSuccess } from '../styles/buttonStyles';
+import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -157,6 +158,14 @@ function GinRummyPageContent() {
   });
 
   const phaseNames = usePhaseNames('ginrummy', GINRUMMY_PHASE_KEYS);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void gameExec('reset', undefined, {
+      cpuDifficulty: ginRummyConfig.cpuDifficulty,
+      pointLimit: ginRummyConfig.pointLimit,
+    });
+  }, [gameExec, hideActionLog, ginRummyConfig.cpuDifficulty, ginRummyConfig.pointLimit]);
 
   if (!state) return <GinRummySkeleton />;
 
@@ -423,23 +432,13 @@ function GinRummyPageContent() {
                   {t('nextRound')}
                 </button>
               )}
-              <button
-                type="button"
-                className={btnOutline}
-                data-tutorial="gr-reset-button"
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    return gameExec('reset', undefined, {
-                      cpuDifficulty: ginRummyConfig.cpuDifficulty,
-                      pointLimit: ginRummyConfig.pointLimit,
-                    });
-                  })
-                }
-                disabled={loading}
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={!!isGameEnd}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="gr-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/GoFishPage.tsx
+++ b/frontend/src/pages/GoFishPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { goFishApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -7,6 +7,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { GoFishBooksDisplay } from '../components/gofish/GoFishBooksDisplay';
 import { GoFishPlayerArea } from '../components/gofish/GoFishPlayerArea';
@@ -27,7 +28,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useGoFishGame } from '../hooks/useGoFishGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary } from '../styles/buttonStyles';
+import { btnPrimary } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -122,6 +123,11 @@ function GoFishPageContent() {
     [],
   );
   const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void exec('reset', undefined, undefined, { cpuDifficulty: goFishConfig.cpuDifficulty });
+  }, [exec, hideActionLog, goFishConfig.cpuDifficulty]);
 
   if (!state) return <GoFishSkeleton />;
 
@@ -268,22 +274,13 @@ function GoFishPageContent() {
                   {t('button.ask')}
                 </button>
               )}
-              <button
-                type="button"
-                className={btnOutline}
-                data-tutorial="gf-reset-button"
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    return exec('reset', undefined, undefined, {
-                      cpuDifficulty: goFishConfig.cpuDifficulty,
-                    });
-                  })
-                }
-                disabled={loading}
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={!!isGameEnd}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="gf-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/GolfPage.test.tsx
+++ b/frontend/src/pages/GolfPage.test.tsx
@@ -234,4 +234,15 @@ describe('GolfPage', () => {
       Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
     }
   });
+
+  it('shows 次のゲーム at game-end and fires reset directly (no confirm)', async () => {
+    mockExec.mockResolvedValue(gameOverState);
+    renderWithProviders(<GolfPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(screen.queryByRole('button', { name: '確認' })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/GolfPage.tsx
+++ b/frontend/src/pages/GolfPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { golfApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { LandscapeBanner } from '../components/LandscapeBanner';
 import { ManualButton } from '../components/ManualButton';
@@ -26,7 +27,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useGolfGame } from '../hooks/useGolfGame';
 import { useSound } from '../providers/SoundProvider';
-import { btnDanger, btnOutline, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
+import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { GolfResponse } from '../types/card';
 import { GolfPhase } from '../types/phases';
@@ -131,6 +132,11 @@ function GolfPageContent() {
     bindings: actionBindings,
     enabled: !!isPlayingForKbd && !loading,
   });
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    handleReset();
+  }, [handleReset, hideActionLog]);
 
   if (!state) return <GolfSkeleton />;
 
@@ -320,21 +326,13 @@ function GolfPageContent() {
                   </button>
                 </div>
               )}
-              <div data-tutorial="golf-reset-button">
-                <button
-                  type="button"
-                  className={btnOutline}
-                  onClick={() =>
-                    requestConfirm(() => {
-                      hideActionLog();
-                      return handleReset();
-                    })
-                  }
-                  disabled={loading}
-                >
-                  {tc('button.reset')}
-                </button>
-              </div>
+              <GameResetButton
+                isGameEnd={isEnded}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="golf-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/HeartsPage.test.tsx
+++ b/frontend/src/pages/HeartsPage.test.tsx
@@ -709,8 +709,7 @@ describe('HeartsPage', () => {
     await waitFor(() => expect(screen.getByText('棋譜')).toBeInTheDocument());
 
     mockExec.mockResolvedValue(playPhaseState);
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
 
     await waitFor(() => expect(screen.queryByText('棋譜')).not.toBeInTheDocument());
   });

--- a/frontend/src/pages/HeartsPage.tsx
+++ b/frontend/src/pages/HeartsPage.tsx
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
+import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { PlayerHandSection } from '../components/PlayerHandSection';
@@ -23,7 +24,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useHeartsGame } from '../hooks/useHeartsGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSuccess } from '../styles/buttonStyles';
+import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { HeartsResponse } from '../types/card';
@@ -168,6 +169,15 @@ function HeartsPageContent() {
   });
 
   const phaseNames = usePhaseNames('hearts', HEARTS_PHASE_KEYS);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void exec('reset', undefined, undefined, {
+      cpuDifficulty: heartsConfig.cpuDifficulty,
+      pointLimit: heartsConfig.pointLimit,
+      omnibusJD: heartsConfig.omnibusJD,
+    });
+  }, [exec, hideActionLog, heartsConfig.cpuDifficulty, heartsConfig.pointLimit, heartsConfig.omnibusJD]);
 
   if (!state) return <HeartsSkeleton />;
 
@@ -468,24 +478,13 @@ function HeartsPageContent() {
                   {t('nextRound')}
                 </button>
               )}
-              <button
-                type="button"
-                className={btnOutline}
-                data-tutorial="ht-reset-button"
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    return exec('reset', undefined, undefined, {
-                      cpuDifficulty: heartsConfig.cpuDifficulty,
-                      pointLimit: heartsConfig.pointLimit,
-                      omnibusJD: heartsConfig.omnibusJD,
-                    });
-                  })
-                }
-                disabled={loading}
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={!!isGameEnd}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="ht-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -14,6 +14,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -35,7 +36,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -174,6 +175,11 @@ function HoldemPageContent() {
   useEffect(() => {
     exec('reset');
   }, [exec]);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void exec('reset', undefined, { cpuMetaAI });
+  }, [exec, hideActionLog, cpuMetaAI]);
 
   useEffect(() => {
     if (state?.minRaise && state.minRaise > 0) {
@@ -537,21 +543,14 @@ function HoldemPageContent() {
                 </div>
               </div>
             </details>
-            <div className="text-center" data-tutorial="he-reset-button">
-              <button
-                type="button"
-                className={`${btnOutline} min-w-[90px]`}
-                disabled={loading}
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    exec('reset', undefined, { cpuMetaAI });
-                  })
-                }
-              >
-                {tc('button.reset')}
-              </button>
-            </div>
+            <GameResetButton
+              isGameEnd={phase === HoldemPhase.END}
+              onReset={handleManualReset}
+              requestConfirm={requestConfirm}
+              loading={loading}
+              dataTutorial="he-reset-button"
+              className="min-w-[90px]"
+            />
           </GameFooter>
         </>
       )}

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -544,7 +544,7 @@ function HoldemPageContent() {
               </div>
             </details>
             <GameResetButton
-              isGameEnd={phase === HoldemPhase.END}
+              isGameEnd={phase === HoldemPhase.SHOWDOWN || phase === HoldemPhase.END}
               onReset={handleManualReset}
               requestConfirm={requestConfirm}
               loading={loading}

--- a/frontend/src/pages/IndianPokerPage.tsx
+++ b/frontend/src/pages/IndianPokerPage.tsx
@@ -369,7 +369,7 @@ function IndianPokerPageContent() {
             {/* Reset */}
             <div className="text-center flex items-center justify-center gap-3">
               <GameResetButton
-                isGameEnd={phase === IndianPokerPhase.END}
+                isGameEnd={phase === IndianPokerPhase.SHOWDOWN || phase === IndianPokerPhase.END}
                 onReset={handleManualReset}
                 requestConfirm={requestConfirm}
                 loading={loading}

--- a/frontend/src/pages/IndianPokerPage.tsx
+++ b/frontend/src/pages/IndianPokerPage.tsx
@@ -11,6 +11,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -31,7 +32,6 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { IndianPokerResponse } from '../types/card';
@@ -117,6 +117,11 @@ function IndianPokerPageContent() {
   useEffect(() => {
     execApi('reset');
   }, [execApi]);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void execApi('reset', undefined, { ante, bettingLimit, cpuMetaAI });
+  }, [execApi, hideActionLog, ante, bettingLimit, cpuMetaAI]);
 
   useEffect(() => {
     if (state?.minRaise && state.minRaise > 0) {
@@ -362,20 +367,15 @@ function IndianPokerPageContent() {
             />
 
             {/* Reset */}
-            <div className="text-center flex items-center justify-center gap-3" data-tutorial="ip-reset-button">
-              <button
-                type="button"
-                className={`${btnOutline} min-w-[90px]`}
-                disabled={loading}
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    execApi('reset', undefined, { ante, bettingLimit, cpuMetaAI });
-                  })
-                }
-              >
-                {tc('button.reset')}
-              </button>
+            <div className="text-center flex items-center justify-center gap-3">
+              <GameResetButton
+                isGameEnd={phase === IndianPokerPhase.END}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="ip-reset-button"
+                className="min-w-[90px]"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/KlondikePage.test.tsx
+++ b/frontend/src/pages/KlondikePage.test.tsx
@@ -529,7 +529,7 @@ describe('KlondikePage', () => {
   it('playing buttons not shown when game is over', async () => {
     mockExec.mockResolvedValue(gameOverState);
     renderWithProviders(<KlondikePage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
 
     // Draw, hint, autocomplete, giveup buttons should not be visible
     expect(screen.queryByRole('button', { name: 'ヒント' })).not.toBeInTheDocument();
@@ -540,7 +540,7 @@ describe('KlondikePage', () => {
   it('reset button always visible', async () => {
     mockExec.mockResolvedValue(gameOverState);
     renderWithProviders(<KlondikePage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
   });
 
   it('displays message with messageCode', async () => {
@@ -630,7 +630,7 @@ describe('KlondikePage', () => {
   it('game clear hides playing-only footer buttons', async () => {
     mockExec.mockResolvedValue(gameClearState);
     renderWithProviders(<KlondikePage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
 
     // Footer should not have draw/hint/autocomplete/giveup
     const footerButtons = screen.getAllByRole('button').filter((btn) => btn.closest('.shrink-0.border-t'));
@@ -653,8 +653,7 @@ describe('KlondikePage', () => {
     await waitFor(() => expect(screen.getByText('棋譜')).toBeInTheDocument());
 
     mockExec.mockResolvedValue(playingState);
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
 
     await waitFor(() => expect(screen.queryByText('棋譜')).not.toBeInTheDocument());
   });

--- a/frontend/src/pages/KlondikePage.tsx
+++ b/frontend/src/pages/KlondikePage.tsx
@@ -9,6 +9,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
@@ -31,7 +32,7 @@ import { useKlondikeGame } from '../hooks/useKlondikeGame';
 import { useKlondikeTimer } from '../hooks/useKlondikeTimer';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
-import { btnDanger, btnOutline, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
+import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { KlondikeResponse } from '../types/card';
 import { KlondikePhase, KlondikeScoringMode } from '../types/phases';
@@ -173,6 +174,14 @@ function KlondikePageContent() {
     isPlaying: !!isPlayingForKbd,
     disabled: loading,
   });
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    resetTimer();
+    setDrawCountSetting(1);
+    setScoringModeSetting(0);
+    handleReset();
+  }, [handleReset, hideActionLog, resetTimer]);
 
   const actionBindings = useMemo(
     () => [
@@ -626,24 +635,13 @@ function KlondikePageContent() {
                 <option value={0}>{t('scoringNone')}</option>
                 <option value={1}>{t('scoringVegas')}</option>
               </select>
-              <div data-tutorial="kl-reset-button">
-                <button
-                  type="button"
-                  className={btnOutline}
-                  onClick={() =>
-                    requestConfirm(() => {
-                      hideActionLog();
-                      resetTimer();
-                      setDrawCountSetting(1);
-                      setScoringModeSetting(0);
-                      return handleReset();
-                    })
-                  }
-                  disabled={loading}
-                >
-                  {tc('button.reset')}
-                </button>
-              </div>
+              <GameResetButton
+                isGameEnd={isEnded}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="kl-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/LetItRidePage.test.tsx
+++ b/frontend/src/pages/LetItRidePage.test.tsx
@@ -168,7 +168,7 @@ describe('LetItRidePage', () => {
   it('shows END phase with reset button and payout breakdown on win', async () => {
     mockApi.mockResolvedValue(endPhaseWin);
     renderWithProviders(<LetItRidePage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
     expect(screen.getByTestId('payout-breakdown')).toBeInTheDocument();
   });
 
@@ -245,37 +245,15 @@ describe('LetItRidePage', () => {
     await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', 200));
   });
 
-  it('shows confirm dialog when reset is clicked', async () => {
+  it('next game button at end phase fires reset without dialog', async () => {
     mockApi.mockResolvedValue(endPhaseWin);
     renderWithProviders(<LetItRidePage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
-  });
-
-  it('dismisses confirm dialog on cancel', async () => {
-    mockApi.mockResolvedValue(endPhaseWin);
-    renderWithProviders(<LetItRidePage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
-
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
-    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
-  });
-
-  it('calls reset on confirm in dialog', async () => {
-    mockApi.mockResolvedValue(endPhaseWin);
-    renderWithProviders(<LetItRidePage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
-
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
-
+    mockApi.mockClear();
     mockApi.mockResolvedValue(betPhaseState);
-    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
     await waitFor(() => expect(mockApi).toHaveBeenCalledWith('reset'));
   });
 
@@ -334,7 +312,7 @@ describe('LetItRidePage', () => {
   it('shows view action log button in END phase', async () => {
     mockApi.mockResolvedValue(endPhaseWin);
     renderWithProviders(<LetItRidePage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
     // The "view log" button (棋譜を見る) should also be present in END phase
     expect(screen.getByText('棋譜を見る')).toBeInTheDocument();
   });

--- a/frontend/src/pages/LetItRidePage.tsx
+++ b/frontend/src/pages/LetItRidePage.tsx
@@ -9,6 +9,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -27,7 +28,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSound } from '../providers/SoundProvider';
-import { btnDanger, btnOutline, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
+import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { LetItRideResponse } from '../types/card';
@@ -352,14 +353,12 @@ function LetItRidePageContent() {
             )}
             {isEndPhase && (
               <div className="flex justify-center gap-2 pb-2">
-                <button
-                  type="button"
-                  className={btnOutline}
-                  onClick={() => requestConfirm(handleReset)}
-                  disabled={loading}
-                >
-                  {t('button.reset')}
-                </button>
+                <GameResetButton
+                  isGameEnd={isEndPhase}
+                  onReset={handleReset}
+                  requestConfirm={requestConfirm}
+                  loading={loading}
+                />
                 <button type="button" className={btnSecondary} onClick={showActionLog} disabled={loading}>
                   {tc('actionLog.view')}
                 </button>

--- a/frontend/src/pages/MemoryPage.test.tsx
+++ b/frontend/src/pages/MemoryPage.test.tsx
@@ -369,8 +369,7 @@ describe('MemoryPage', () => {
     await waitFor(() => expect(screen.getByText('棋譜')).toBeInTheDocument());
 
     mockExec.mockResolvedValue(flip1State);
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
 
     await waitFor(() => expect(screen.queryByText('棋譜')).not.toBeInTheDocument());
   });

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { memoryApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
@@ -27,7 +28,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { AUTO_NEXT_DELAY_OPTIONS, CPU_DIFFICULTY_OPTIONS, useMemoryGame } from '../hooks/useMemoryGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
+import { btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { MemoryResponse } from '../types/card';
 import { MemoryPhase } from '../types/phases';
@@ -132,6 +133,11 @@ function MemoryPageContent() {
   });
 
   const phaseNames = usePhaseNames('memory', MEMORY_PHASE_KEYS);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void exec('reset', undefined, { cpuDifficulty: memoryConfig.cpuDifficulty });
+  }, [exec, hideActionLog, memoryConfig.cpuDifficulty]);
 
   if (!state) return <MemorySkeleton />;
 
@@ -292,21 +298,13 @@ function MemoryPageContent() {
                   </button>
                 </div>
               )}
-              <div data-tutorial="mem-reset-button">
-                <button
-                  type="button"
-                  className={btnOutline}
-                  onClick={() =>
-                    requestConfirm(() => {
-                      hideActionLog();
-                      return exec('reset', undefined, { cpuDifficulty: memoryConfig.cpuDifficulty });
-                    })
-                  }
-                  disabled={loading}
-                >
-                  {tc('button.reset')}
-                </button>
-              </div>
+              <GameResetButton
+                isGameEnd={!!isGameEnd}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="mem-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/NapoleonPage.test.tsx
+++ b/frontend/src/pages/NapoleonPage.test.tsx
@@ -959,8 +959,7 @@ describe('NapoleonPage', () => {
     await waitFor(() => expect(screen.getByText('\u68cb\u8b5c')).toBeInTheDocument());
 
     mockExec.mockResolvedValue(playPhaseState);
-    fireEvent.click(screen.getByRole('button', { name: '\u30ea\u30bb\u30c3\u30c8' }));
-    fireEvent.click(screen.getByRole('button', { name: '\u78ba\u8a8d' }));
+    fireEvent.click(screen.getByRole('button', { name: '\u6b21\u306e\u30b2\u30fc\u30e0' }));
 
     await waitFor(() => expect(screen.queryByText('\u68cb\u8b5c')).not.toBeInTheDocument());
   });

--- a/frontend/src/pages/NapoleonPage.tsx
+++ b/frontend/src/pages/NapoleonPage.tsx
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -34,7 +35,7 @@ import {
 } from '../hooks/useNapoleonGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSuccess } from '../styles/buttonStyles';
+import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -190,6 +191,15 @@ function NapoleonPageContent() {
   });
 
   const phaseNames = usePhaseNames('napoleon', NAPOLEON_PHASE_KEYS);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void apiExec('reset', undefined, undefined, undefined, undefined, undefined, undefined, {
+      cpuDifficulty: napoleonConfig.cpuDifficulty,
+      pointLimit: napoleonConfig.pointLimit,
+      minBid: napoleonConfig.minBid,
+    });
+  }, [apiExec, hideActionLog, napoleonConfig.cpuDifficulty, napoleonConfig.pointLimit, napoleonConfig.minBid]);
 
   if (!state) return <NapoleonSkeleton />;
 
@@ -705,24 +715,13 @@ function NapoleonPageContent() {
               )}
 
               {/* Reset */}
-              <button
-                type="button"
-                className={btnOutline}
-                data-tutorial="np-reset-button"
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    return apiExec('reset', undefined, undefined, undefined, undefined, undefined, undefined, {
-                      cpuDifficulty: napoleonConfig.cpuDifficulty,
-                      pointLimit: napoleonConfig.pointLimit,
-                      minBid: napoleonConfig.minBid,
-                    });
-                  })
-                }
-                disabled={loading}
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={!!isGameEnd}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="np-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/OhHellPage.tsx
+++ b/frontend/src/pages/OhHellPage.tsx
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -35,7 +36,7 @@ import {
 } from '../hooks/useOhHellGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSuccess } from '../styles/buttonStyles';
+import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -167,6 +168,24 @@ function OhHellPageContent() {
   });
 
   const phaseNames = usePhaseNames('ohhell', OH_HELL_PHASE_KEYS);
+
+  const gameAction = exec;
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void gameAction('reset', undefined, undefined, {
+      cpuDifficulty: ohHellConfig.cpuDifficulty,
+      maxHandSize: ohHellConfig.maxHandSize,
+      scoringVariant: ohHellConfig.scoringVariant,
+      roundDirection: ohHellConfig.roundDirection,
+    });
+  }, [
+    gameAction,
+    hideActionLog,
+    ohHellConfig.cpuDifficulty,
+    ohHellConfig.maxHandSize,
+    ohHellConfig.scoringVariant,
+    ohHellConfig.roundDirection,
+  ]);
 
   if (!state) return <OhHellSkeleton />;
 
@@ -547,25 +566,13 @@ function OhHellPageContent() {
                   {t('nextRound')}
                 </button>
               )}
-              <button
-                type="button"
-                className={btnOutline}
-                data-tutorial="oh-reset-button"
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    return exec('reset', undefined, undefined, {
-                      cpuDifficulty: ohHellConfig.cpuDifficulty,
-                      maxHandSize: ohHellConfig.maxHandSize,
-                      scoringVariant: ohHellConfig.scoringVariant,
-                      roundDirection: ohHellConfig.roundDirection,
-                    });
-                  })
-                }
-                disabled={loading}
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={!!isGameEnd}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="oh-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { oldmaidApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -30,7 +31,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { OldMaidMode, useOldMaidGame } from '../hooks/useOldMaidGame';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { CpuAction, OldMaidResponse } from '../types/card';
@@ -155,6 +156,11 @@ function OldMaidPageContent() {
     bindings: actionBindings,
     enabled: isHumanTurnForKbd && !loading,
   });
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    handleReset();
+  }, [handleReset, hideActionLog]);
 
   if (!displayState) return <OldMaidSkeleton />;
 
@@ -358,21 +364,14 @@ function OldMaidPageContent() {
               >
                 {t('button.settings')}
               </button>
-              <span data-tutorial="om-reset-button">
-                <button
-                  type="button"
-                  className={`${btnOutline} min-w-[80px]`}
-                  disabled={loading}
-                  onClick={() =>
-                    requestConfirm(() => {
-                      hideActionLog();
-                      handleReset();
-                    })
-                  }
-                >
-                  {tc('button.reset')}
-                </button>
-              </span>
+              <GameResetButton
+                isGameEnd={!!state.gameEndFlag}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="om-reset-button"
+                className="min-w-[80px]"
+              />
               <span data-tutorial="om-draw-button">
                 <button
                   type="button"

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -14,6 +14,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -35,7 +36,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -172,6 +173,11 @@ function OmahaPageContent() {
   useEffect(() => {
     execApi('reset');
   }, [execApi]);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void execApi('reset', undefined, { cpuMetaAI });
+  }, [execApi, hideActionLog, cpuMetaAI]);
 
   useEffect(() => {
     if (state?.minRaise && state.minRaise > 0) {
@@ -535,21 +541,14 @@ function OmahaPageContent() {
                 </div>
               </div>
             </details>
-            <div className="text-center" data-tutorial="oh-reset-button">
-              <button
-                type="button"
-                className={`${btnOutline} min-w-[90px]`}
-                disabled={loading}
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    execApi('reset', undefined, { cpuMetaAI });
-                  })
-                }
-              >
-                {tc('button.reset')}
-              </button>
-            </div>
+            <GameResetButton
+              isGameEnd={phase === OmahaPhase.END}
+              onReset={handleManualReset}
+              requestConfirm={requestConfirm}
+              loading={loading}
+              dataTutorial="oh-reset-button"
+              className="min-w-[90px]"
+            />
           </GameFooter>
         </>
       )}

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -542,7 +542,7 @@ function OmahaPageContent() {
               </div>
             </details>
             <GameResetButton
-              isGameEnd={phase === OmahaPhase.END}
+              isGameEnd={phase === OmahaPhase.SHOWDOWN || phase === OmahaPhase.END}
               onReset={handleManualReset}
               requestConfirm={requestConfirm}
               loading={loading}

--- a/frontend/src/pages/PageOnePage.test.tsx
+++ b/frontend/src/pages/PageOnePage.test.tsx
@@ -148,4 +148,20 @@ describe('PageOnePage', () => {
     renderWithProviders(<PageOnePage />);
     await waitFor(() => expect(screen.getByText('スコア')).toBeInTheDocument());
   });
+
+  it('shows 次のゲーム at game-end and fires reset directly (no confirm)', async () => {
+    mockExec.mockResolvedValue(gameEndState);
+    renderWithProviders(<PageOnePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('reset', undefined, {
+        cpuDifficulty: 1,
+        pointLimit: 200,
+      }),
+    );
+    expect(screen.queryByRole('button', { name: '確認' })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/PageOnePage.tsx
+++ b/frontend/src/pages/PageOnePage.tsx
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -26,7 +27,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, usePageOneGame } from '../hooks/usePageOneGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
+import { btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -136,6 +137,14 @@ function PageOnePageContent() {
   });
 
   const phaseNames = usePhaseNames('pageone', PAGEONE_PHASE_KEYS);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void gameCall('reset', undefined, {
+      cpuDifficulty: pageOneConfig.cpuDifficulty,
+      pointLimit: pageOneConfig.pointLimit,
+    });
+  }, [gameCall, hideActionLog, pageOneConfig.cpuDifficulty, pageOneConfig.pointLimit]);
 
   if (!state) return <PageOneSkeleton />;
 
@@ -338,23 +347,13 @@ function PageOnePageContent() {
                   {t('nextRound')}
                 </button>
               )}
-              <button
-                type="button"
-                className={btnOutline}
-                data-tutorial="po-reset-button"
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    return gameCall('reset', undefined, {
-                      cpuDifficulty: pageOneConfig.cpuDifficulty,
-                      pointLimit: pageOneConfig.pointLimit,
-                    });
-                  })
-                }
-                disabled={loading}
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={!!isGameEnd}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="po-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/PaiGowPage.test.tsx
+++ b/frontend/src/pages/PaiGowPage.test.tsx
@@ -202,7 +202,7 @@ describe('PaiGowPage', () => {
     renderWithProviders(<PaiGowPage />);
     await waitFor(() => expect(screen.getByText('勝利！')).toBeInTheDocument());
     expect(screen.getByTestId('payout-breakdown')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument();
   });
 
   it('shows end phase with dealer wins', async () => {
@@ -246,31 +246,29 @@ describe('PaiGowPage', () => {
     await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
-  it('shows confirm dialog when reset button is clicked', async () => {
+  it('next game button in end phase triggers reset immediately', async () => {
     mockExec.mockResolvedValue(endPhasePlayerWins);
     renderWithProviders(<PaiGowPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(betPhaseState);
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
-  it('dismisses confirm dialog on cancel', async () => {
+  it('next game button shows no confirm dialog at end phase', async () => {
     mockExec.mockResolvedValue(endPhasePlayerWins);
     renderWithProviders(<PaiGowPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   });
 

--- a/frontend/src/pages/PaiGowPage.tsx
+++ b/frontend/src/pages/PaiGowPage.tsx
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -25,7 +26,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
+import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { PaiGowResponse } from '../types/card';
@@ -408,14 +409,12 @@ function PaiGowPageContent() {
             )}
             {isEndPhase && (
               <div className="flex justify-center gap-2 pb-2">
-                <button
-                  type="button"
-                  className={btnOutline}
-                  onClick={() => requestConfirm(handleReset)}
-                  disabled={loading}
-                >
-                  {t('button.reset')}
-                </button>
+                <GameResetButton
+                  isGameEnd={isEndPhase}
+                  onReset={handleReset}
+                  requestConfirm={requestConfirm}
+                  loading={loading}
+                />
                 <button type="button" className={btnSecondary} onClick={showActionLog} disabled={loading}>
                   {tc('actionLog.view')}
                 </button>

--- a/frontend/src/pages/PigsTailPage.tsx
+++ b/frontend/src/pages/PigsTailPage.tsx
@@ -6,6 +6,7 @@ import { CliToggle } from '../components/cli/CliToggle';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { ManualButton } from '../components/ManualButton';
 import { WinCelebration } from '../components/motion/WinCelebration';
@@ -228,13 +229,12 @@ function PigsTailPageContent() {
               >
                 {t('button.draw')}
               </button>
-              <button
-                type="button"
-                className="px-4 py-2 rounded-lg bg-ds-surface-elevated hover:bg-ds-surface-elevated text-white text-sm transition-colors"
-                onClick={() => requestConfirm(handleReset)}
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={isGameEnd}
+                onReset={handleReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+              />
               <button
                 type="button"
                 className="px-4 py-2 rounded-lg bg-ds-surface-elevated hover:bg-ds-surface-elevated text-white text-sm transition-colors"

--- a/frontend/src/pages/PineapplePage.test.tsx
+++ b/frontend/src/pages/PineapplePage.test.tsx
@@ -253,4 +253,15 @@ describe('PineapplePage', () => {
     const settingsSummary = Array.from(allSummaries).find((s) => s.textContent?.includes('設定'));
     expect(settingsSummary).toBeTruthy();
   });
+
+  it('shows 次のゲーム at game-end and fires reset directly (no confirm)', async () => {
+    mockExec.mockResolvedValue(showdownState);
+    renderWithProviders(<PineapplePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, { cpuMetaAI: false }));
+    expect(screen.queryByRole('button', { name: '確認' })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -590,7 +590,7 @@ function PineapplePageContent() {
               </div>
             </details>
             <GameResetButton
-              isGameEnd={phase === PineapplePhase.END}
+              isGameEnd={phase === PineapplePhase.SHOWDOWN || phase === PineapplePhase.END}
               onReset={handleManualReset}
               requestConfirm={requestConfirm}
               loading={loading}

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -14,6 +14,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -35,7 +36,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -180,6 +181,11 @@ function PineapplePageContent() {
   useEffect(() => {
     apiExec('reset');
   }, [apiExec]);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void apiExec('reset', undefined, { cpuMetaAI });
+  }, [apiExec, hideActionLog, cpuMetaAI]);
 
   useEffect(() => {
     if (state?.minRaise && state.minRaise > 0) {
@@ -583,21 +589,14 @@ function PineapplePageContent() {
                 </div>
               </div>
             </details>
-            <div className="text-center" data-tutorial="pn-reset-button">
-              <button
-                type="button"
-                className={`${btnOutline} min-w-[90px]`}
-                disabled={loading}
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    apiExec('reset', undefined, { cpuMetaAI });
-                  })
-                }
-              >
-                {tc('button.reset')}
-              </button>
-            </div>
+            <GameResetButton
+              isGameEnd={phase === PineapplePhase.END}
+              onReset={handleManualReset}
+              requestConfirm={requestConfirm}
+              loading={loading}
+              dataTutorial="pn-reset-button"
+              className="min-w-[90px]"
+            />
           </GameFooter>
         </>
       )}

--- a/frontend/src/pages/PinochlePage.test.tsx
+++ b/frontend/src/pages/PinochlePage.test.tsx
@@ -267,7 +267,7 @@ describe('PinochlePage', () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<PinochlePage />);
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/pages/PinochlePage.test.tsx
+++ b/frontend/src/pages/PinochlePage.test.tsx
@@ -312,4 +312,17 @@ describe('PinochlePage', () => {
     renderWithProviders(<PinochlePage />);
     await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
   });
+
+  it('shows 次のゲーム at game-end and fires reset directly (no confirm)', async () => {
+    mockExec.mockResolvedValue(gameEndState);
+    renderWithProviders(<PinochlePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('reset', undefined, { cpuDifficulty: 1, pointLimit: 1500 }),
+    );
+    expect(screen.queryByRole('button', { name: '確認' })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/PinochlePage.tsx
+++ b/frontend/src/pages/PinochlePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { pinochleApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -159,6 +160,11 @@ function PinochlePageContent() {
       setBidAmount(20);
     }
   }, [state?.highestBid]);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    handleReset();
+  }, [handleReset, hideActionLog]);
 
   if (!state) {
     return (
@@ -402,19 +408,13 @@ function PinochlePageContent() {
               )}
 
               {/* Reset */}
-              <button
-                type="button"
-                className={btnOutline}
-                data-tutorial="pn-reset-button"
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    handleReset();
-                  })
-                }
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={!!isGameEnd}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="pn-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -13,6 +13,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -32,7 +33,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { usePokerGame } from '../hooks/usePokerGame';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnSuccess, btnWarning, focusRingAccent } from '../styles/buttonStyles';
+import { btnSuccess, btnWarning, focusRingAccent } from '../styles/buttonStyles';
 import { selectedCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -162,6 +163,10 @@ function PokerPageContent() {
   const phase = state?.phase ?? PokerPhase.INIT;
   const isBettingPhase = phase === PokerPhase.DEAL || phase === PokerPhase.SECOND_BET;
   const isEnd = phase === PokerPhase.END;
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void exec('reset', undefined, undefined, { bettingLimit, isLowball, cpuMetaAI });
+  }, [exec, hideActionLog, bettingLimit, isLowball, cpuMetaAI]);
   const humanPlayer = state?.players?.find((p) => p.isHuman);
   const humanFolded = humanPlayer?.folded ?? false;
   const humanAllIn = humanPlayer?.allIn ?? false;
@@ -451,20 +456,14 @@ function PokerPageContent() {
               ]}
             />
             <div className="text-center mt-2">
-              <button
-                type="button"
-                className={`${btnOutline} min-w-[90px]`}
-                disabled={loading}
-                data-tutorial="pk-reset-button"
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    exec('reset', undefined, undefined, { bettingLimit, isLowball, cpuMetaAI });
-                  })
-                }
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={isEnd}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="pk-reset-button"
+                className="min-w-[90px]"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/PokerSquaresPage.tsx
+++ b/frontend/src/pages/PokerSquaresPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { pokersquaresApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -24,7 +25,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnDanger, btnOutline, btnPrimary, focusRingWhite } from '../styles/buttonStyles';
+import { btnDanger, btnPrimary, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { PokerSquaresResponse } from '../types/card';
 import { PokerSquaresPhase } from '../types/phases';
@@ -100,7 +101,11 @@ function PokerSquaresPageContent() {
   };
   const handleUndo = () => execApi('undo');
   const handleGiveUp = () => execApi('giveup');
-  const handleReset = () => execApi('reset');
+  const handleReset = useCallback(() => execApi('reset'), [execApi]);
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    handleReset();
+  }, [handleReset, hideActionLog]);
 
   return (
     <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.pokersquares.bg}`} aria-busy={loading}>
@@ -286,19 +291,12 @@ function PokerSquaresPageContent() {
                   </button>
                 </>
               )}
-              <button
-                type="button"
-                className={btnOutline}
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    return handleReset();
-                  })
-                }
-                disabled={loading}
-              >
-                {t('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={isComplete}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/PyramidPage.test.tsx
+++ b/frontend/src/pages/PyramidPage.test.tsx
@@ -297,7 +297,7 @@ describe('PyramidPage', () => {
   it('playing buttons not shown when game is over', async () => {
     mockExec.mockResolvedValue(gameOverState);
     renderWithProviders(<PyramidPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
 
     expect(screen.queryByRole('button', { name: 'ヒント' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'ギブアップ' })).not.toBeInTheDocument();
@@ -306,7 +306,7 @@ describe('PyramidPage', () => {
   it('reset button always visible', async () => {
     mockExec.mockResolvedValue(gameOverState);
     renderWithProviders(<PyramidPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
   });
 
   it('displays message with messageCode', async () => {

--- a/frontend/src/pages/PyramidPage.tsx
+++ b/frontend/src/pages/PyramidPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { pyramidApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
@@ -28,7 +29,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePyramidGame } from '../hooks/usePyramidGame';
 import { useSound } from '../providers/SoundProvider';
-import { btnDanger, btnOutline, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
+import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { PyramidResponse } from '../types/card';
 import { PyramidPhase } from '../types/phases';
@@ -139,6 +140,11 @@ function PyramidPageContent() {
     bindings: actionBindings,
     enabled: !!isPlayingForKbd && !loading,
   });
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    handleReset();
+  }, [handleReset, hideActionLog]);
 
   if (!state) return <PyramidSkeleton />;
 
@@ -381,21 +387,13 @@ function PyramidPageContent() {
                   </button>
                 </div>
               )}
-              <div data-tutorial="py-reset-button">
-                <button
-                  type="button"
-                  className={btnOutline}
-                  onClick={() =>
-                    requestConfirm(() => {
-                      hideActionLog();
-                      return handleReset();
-                    })
-                  }
-                  disabled={loading}
-                >
-                  {tc('button.reset')}
-                </button>
-              </div>
+              <GameResetButton
+                isGameEnd={isEnded}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="py-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/RazzPage.tsx
+++ b/frontend/src/pages/RazzPage.tsx
@@ -11,6 +11,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -31,7 +32,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -177,6 +178,11 @@ function RazzPageContent() {
   useEffect(() => {
     execApi('reset');
   }, [execApi]);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void execApi('reset', undefined, { cpuMetaAI });
+  }, [execApi, hideActionLog, cpuMetaAI]);
 
   useEffect(() => {
     if (state?.minRaise && state.minRaise > 0) {
@@ -542,21 +548,14 @@ function RazzPageContent() {
                 </label>
               </div>
             </details>
-            <div className="text-center" data-tutorial="razz-reset-button">
-              <button
-                type="button"
-                className={`${btnOutline} min-w-[90px]`}
-                disabled={loading}
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    execApi('reset', undefined, { cpuMetaAI });
-                  })
-                }
-              >
-                {tc('button.reset')}
-              </button>
-            </div>
+            <GameResetButton
+              isGameEnd={phase === SevenCardStudPhase.END}
+              onReset={handleManualReset}
+              requestConfirm={requestConfirm}
+              loading={loading}
+              dataTutorial="razz-reset-button"
+              className="min-w-[90px]"
+            />
           </GameFooter>
         </>
       )}

--- a/frontend/src/pages/RazzPage.tsx
+++ b/frontend/src/pages/RazzPage.tsx
@@ -549,7 +549,7 @@ function RazzPageContent() {
               </div>
             </details>
             <GameResetButton
-              isGameEnd={phase === SevenCardStudPhase.END}
+              isGameEnd={phase === SevenCardStudPhase.SHOWDOWN || phase === SevenCardStudPhase.END}
               onReset={handleManualReset}
               requestConfirm={requestConfirm}
               loading={loading}

--- a/frontend/src/pages/RedDogPage.test.tsx
+++ b/frontend/src/pages/RedDogPage.test.tsx
@@ -120,7 +120,7 @@ describe('RedDogPage', () => {
   it('renders end phase with reset and payout', async () => {
     mockApi.mockResolvedValue(winState);
     renderWithProviders(<RedDogPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: /リセット/ })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: /次のゲーム/ })).toBeInTheDocument());
     expect(screen.getByText(/200/)).toBeInTheDocument();
   });
 

--- a/frontend/src/pages/RedDogPage.tsx
+++ b/frontend/src/pages/RedDogPage.tsx
@@ -9,6 +9,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -25,7 +26,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSound } from '../providers/SoundProvider';
-import { btnDanger, btnOutline, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
+import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { RedDogResponse } from '../types/card';
@@ -272,14 +273,12 @@ function RedDogPageContent() {
             )}
             {isEndPhase && (
               <div className="flex justify-center gap-2 pb-2">
-                <button
-                  type="button"
-                  className={btnOutline}
-                  onClick={() => requestConfirm(handleReset)}
-                  disabled={loading}
-                >
-                  {t('button.reset')}
-                </button>
+                <GameResetButton
+                  isGameEnd={isEndPhase}
+                  onReset={handleReset}
+                  requestConfirm={requestConfirm}
+                  loading={loading}
+                />
                 <button type="button" className={btnSecondary} onClick={showActionLog} disabled={loading}>
                   {tc('actionLog.view')}
                 </button>

--- a/frontend/src/pages/ScorpionPage.test.tsx
+++ b/frontend/src/pages/ScorpionPage.test.tsx
@@ -142,7 +142,7 @@ describe('ScorpionPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     expect(screen.queryByRole('button', { name: 'ギブアップ' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'ヒント' })).not.toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: /reset|リセット/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('button', { name: /next game|次のゲーム/i }).length).toBeGreaterThan(0);
   });
 
   it('undo button fires undo command when canUndo is true', async () => {

--- a/frontend/src/pages/ScorpionPage.tsx
+++ b/frontend/src/pages/ScorpionPage.tsx
@@ -9,6 +9,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
@@ -30,7 +31,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
-import { btnDanger, btnOutline, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
+import { btnDanger, btnOutline, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { ScorpionResponse } from '../types/card';
 import { ScorpionPhase } from '../types/phases';
@@ -220,12 +221,10 @@ function ScorpionPageContent() {
     disabled: loading,
   });
 
-  const handleReset = useCallback(() => {
-    requestConfirm(() => {
-      void apiCall('reset');
-      playSound('shuffle');
-    });
-  }, [apiCall, requestConfirm, playSound]);
+  const handleManualReset = useCallback(() => {
+    void apiCall('reset');
+    playSound('shuffle');
+  }, [apiCall, playSound]);
 
   const handleDeal = useCallback(() => {
     void apiCall('deal');
@@ -468,9 +467,13 @@ function ScorpionPageContent() {
             />
 
             <GameFooter>
-              <button type="button" className={btnPrimary} onClick={handleReset} data-tutorial="sc-reset-button">
-                {t('common:reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={isEnded}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="sc-reset-button"
+              />
 
               {isPlaying && (
                 <>

--- a/frontend/src/pages/SevenCardStudPage.tsx
+++ b/frontend/src/pages/SevenCardStudPage.tsx
@@ -11,6 +11,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -31,7 +32,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -177,6 +178,11 @@ function SevenCardStudPageContent() {
   useEffect(() => {
     execApi('reset');
   }, [execApi]);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void execApi('reset', undefined, { cpuMetaAI });
+  }, [execApi, hideActionLog, cpuMetaAI]);
 
   useEffect(() => {
     if (state?.minRaise && state.minRaise > 0) {
@@ -546,21 +552,14 @@ function SevenCardStudPageContent() {
                 </label>
               </div>
             </details>
-            <div className="text-center" data-tutorial="scs-reset-button">
-              <button
-                type="button"
-                className={`${btnOutline} min-w-[90px]`}
-                disabled={loading}
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    execApi('reset', undefined, { cpuMetaAI });
-                  })
-                }
-              >
-                {tc('button.reset')}
-              </button>
-            </div>
+            <GameResetButton
+              isGameEnd={phase === SevenCardStudPhase.END}
+              onReset={handleManualReset}
+              requestConfirm={requestConfirm}
+              loading={loading}
+              dataTutorial="scs-reset-button"
+              className="min-w-[90px]"
+            />
           </GameFooter>
         </>
       )}

--- a/frontend/src/pages/SevenCardStudPage.tsx
+++ b/frontend/src/pages/SevenCardStudPage.tsx
@@ -553,7 +553,7 @@ function SevenCardStudPageContent() {
               </div>
             </details>
             <GameResetButton
-              isGameEnd={phase === SevenCardStudPhase.END}
+              isGameEnd={phase === SevenCardStudPhase.SHOWDOWN || phase === SevenCardStudPhase.END}
               onReset={handleManualReset}
               requestConfirm={requestConfirm}
               loading={loading}

--- a/frontend/src/pages/SevensPage.tsx
+++ b/frontend/src/pages/SevensPage.tsx
@@ -9,6 +9,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -27,7 +28,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSevensGame } from '../hooks/useSevensGame';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnSecondary } from '../styles/buttonStyles';
+import { btnSecondary } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { SevensResponse } from '../types/card';
@@ -136,6 +137,34 @@ function SevensPageContent() {
     enabled: isHumanTurnForKbd && !loading,
     onDirectPlay: directPlay,
   });
+
+  const runAction = exec;
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void runAction('reset', -1, 0, 0, {
+      tunnelEnabled: cfgTunnel,
+      tunnelSkipWidth: cfgTunnelSkipWidth,
+      jokerCount: cfgJokerCount,
+      cpuStrategy: cfgCpuStrategy,
+      maxPasses: cfgMaxPasses,
+      noJokerFinish: cfgNoJokerFinish,
+      jokerReclaim: cfgJokerReclaim,
+      endStop: cfgEndStop,
+      jokerConsecutiveBanned: cfgJokerConsBan,
+    });
+  }, [
+    runAction,
+    hideActionLog,
+    cfgTunnel,
+    cfgTunnelSkipWidth,
+    cfgJokerCount,
+    cfgCpuStrategy,
+    cfgMaxPasses,
+    cfgNoJokerFinish,
+    cfgJokerReclaim,
+    cfgEndStop,
+    cfgJokerConsBan,
+  ]);
 
   if (!state) return <SevensSkeleton />;
 
@@ -393,30 +422,14 @@ function SevensPageContent() {
             )}
 
             <div className="text-center">
-              <button
-                type="button"
-                className={`${btnOutline} min-w-[90px]`}
-                disabled={loading}
-                data-tutorial="sv-reset-button"
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    exec('reset', -1, 0, 0, {
-                      tunnelEnabled: cfgTunnel,
-                      tunnelSkipWidth: cfgTunnelSkipWidth,
-                      jokerCount: cfgJokerCount,
-                      cpuStrategy: cfgCpuStrategy,
-                      maxPasses: cfgMaxPasses,
-                      noJokerFinish: cfgNoJokerFinish,
-                      jokerReclaim: cfgJokerReclaim,
-                      endStop: cfgEndStop,
-                      jokerConsecutiveBanned: cfgJokerConsBan,
-                    });
-                  })
-                }
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={!!state.gameEndFlag}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="sv-reset-button"
+                className="min-w-[90px]"
+              />
               <button
                 type="button"
                 className={`${btnSecondary} min-w-[90px]`}

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -541,7 +541,7 @@ function ShortDeckPageContent() {
               </div>
             </details>
             <GameResetButton
-              isGameEnd={phase === HoldemPhase.END}
+              isGameEnd={phase === HoldemPhase.SHOWDOWN || phase === HoldemPhase.END}
               onReset={handleManualReset}
               requestConfirm={requestConfirm}
               loading={loading}

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -14,6 +14,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -35,7 +36,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -172,6 +173,11 @@ function ShortDeckPageContent() {
   useEffect(() => {
     execApi('reset');
   }, [execApi]);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void execApi('reset', undefined, { cpuMetaAI });
+  }, [execApi, hideActionLog, cpuMetaAI]);
 
   useEffect(() => {
     if (state?.minRaise && state.minRaise > 0) {
@@ -534,21 +540,14 @@ function ShortDeckPageContent() {
                 </div>
               </div>
             </details>
-            <div className="text-center" data-tutorial="sd-reset-button">
-              <button
-                type="button"
-                className={`${btnOutline} min-w-[90px]`}
-                disabled={loading}
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    execApi('reset', undefined, { cpuMetaAI });
-                  })
-                }
-              >
-                {tc('button.reset')}
-              </button>
-            </div>
+            <GameResetButton
+              isGameEnd={phase === HoldemPhase.END}
+              onReset={handleManualReset}
+              requestConfirm={requestConfirm}
+              loading={loading}
+              dataTutorial="sd-reset-button"
+              className="min-w-[90px]"
+            />
           </GameFooter>
         </>
       )}

--- a/frontend/src/pages/SpadesPage.test.tsx
+++ b/frontend/src/pages/SpadesPage.test.tsx
@@ -644,8 +644,7 @@ describe('SpadesPage', () => {
     await waitFor(() => expect(screen.getByText('\u68cb\u8b5c')).toBeInTheDocument());
 
     mockExec.mockResolvedValue(playPhaseState);
-    fireEvent.click(screen.getByRole('button', { name: '\u30ea\u30bb\u30c3\u30c8' }));
-    fireEvent.click(screen.getByRole('button', { name: '\u78ba\u8a8d' }));
+    fireEvent.click(screen.getByRole('button', { name: '\u6b21\u306e\u30b2\u30fc\u30e0' }));
 
     await waitFor(() => expect(screen.queryByText('\u68cb\u8b5c')).not.toBeInTheDocument());
   });

--- a/frontend/src/pages/SpadesPage.tsx
+++ b/frontend/src/pages/SpadesPage.tsx
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
+import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { PlayerHandSection } from '../components/PlayerHandSection';
@@ -24,7 +25,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useSpadesGame } from '../hooks/useSpadesGame';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSuccess } from '../styles/buttonStyles';
+import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { SpadesResponse } from '../types/card';
@@ -160,6 +161,24 @@ function SpadesPageContent() {
   });
 
   const phaseNames = usePhaseNames('spades', SPADES_PHASE_KEYS);
+
+  const runAction = exec;
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void runAction('reset', undefined, undefined, {
+      cpuDifficulty: spadesConfig.cpuDifficulty,
+      pointLimit: spadesConfig.pointLimit,
+      nilBonus: spadesConfig.nilBonus,
+      bagPenaltyThreshold: spadesConfig.bagPenaltyThreshold,
+    });
+  }, [
+    runAction,
+    hideActionLog,
+    spadesConfig.cpuDifficulty,
+    spadesConfig.pointLimit,
+    spadesConfig.nilBonus,
+    spadesConfig.bagPenaltyThreshold,
+  ]);
 
   if (!state) return <SpadesSkeleton />;
 
@@ -476,25 +495,13 @@ function SpadesPageContent() {
                   {t('nextRound')}
                 </button>
               )}
-              <button
-                type="button"
-                className={btnOutline}
-                data-tutorial="sp-reset-button"
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    return exec('reset', undefined, undefined, {
-                      cpuDifficulty: spadesConfig.cpuDifficulty,
-                      pointLimit: spadesConfig.pointLimit,
-                      nilBonus: spadesConfig.nilBonus,
-                      bagPenaltyThreshold: spadesConfig.bagPenaltyThreshold,
-                    });
-                  })
-                }
-                disabled={loading}
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={!!isGameEnd}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="sp-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { speedApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -140,6 +141,10 @@ function SpeedPageContent() {
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [cliEnabled, keyboardActive, loading]);
+
+  const handleManualReset = useCallback(() => {
+    void gameExec('reset', undefined, undefined, speedConfig);
+  }, [gameExec, speedConfig]);
 
   if (!state || state.players.length < 2) return <SpeedSkeleton />;
 
@@ -318,13 +323,12 @@ function SpeedPageContent() {
               showActionLog={showActionLog}
               hideActionLog={hideActionLog}
             />
-            <button
-              type="button"
-              onClick={() => requestConfirm(() => gameExec('reset', undefined, undefined, speedConfig))}
-              className="btn btn-sm btn-warning"
-            >
-              {tc('button.reset')}
-            </button>
+            <GameResetButton
+              isGameEnd={!!isGameEnd}
+              onReset={handleManualReset}
+              requestConfirm={requestConfirm}
+              loading={loading}
+            />
           </GameFooter>
         </>
       )}

--- a/frontend/src/pages/SpiderPage.test.tsx
+++ b/frontend/src/pages/SpiderPage.test.tsx
@@ -198,7 +198,7 @@ describe('SpiderPage', () => {
   it('playing buttons not shown when game is over', async () => {
     mockExec.mockResolvedValue(gameOverState);
     renderWithProviders(<SpiderPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
 
     expect(screen.queryByRole('button', { name: 'ヒント' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: '自動完成' })).not.toBeInTheDocument();
@@ -208,7 +208,7 @@ describe('SpiderPage', () => {
   it('reset button always visible', async () => {
     mockExec.mockResolvedValue(gameOverState);
     renderWithProviders(<SpiderPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
   });
 
   it('shows confirm dialog when reset button is clicked', async () => {
@@ -388,8 +388,7 @@ describe('SpiderPage', () => {
     await waitFor(() => expect(screen.getByText('棋譜')).toBeInTheDocument());
 
     mockExec.mockResolvedValue(playingState);
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
 
     await waitFor(() => expect(screen.queryByText('棋譜')).not.toBeInTheDocument());
   });

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -9,6 +9,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
@@ -30,7 +31,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSpiderGame } from '../hooks/useSpiderGame';
 import { useSound } from '../providers/SoundProvider';
-import { btnDanger, btnOutline, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
+import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { SpiderResponse } from '../types/card';
 import { SpiderPhase } from '../types/phases';
@@ -148,6 +149,11 @@ function SpiderPageContent() {
     isPlaying: !!isPlayingForKbd,
     disabled: loading,
   });
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    handleReset();
+  }, [handleReset, hideActionLog]);
 
   const currentDifficulty = state?.difficulty ?? 1;
 
@@ -450,21 +456,13 @@ function SpiderPageContent() {
                   <option value={4}>{t('difficulty4')}</option>
                 </select>
               </div>
-              <div data-tutorial="spd-reset-button">
-                <button
-                  type="button"
-                  className={btnOutline}
-                  onClick={() =>
-                    requestConfirm(() => {
-                      hideActionLog();
-                      return handleReset();
-                    })
-                  }
-                  disabled={loading}
-                >
-                  {tc('button.reset')}
-                </button>
-              </div>
+              <GameResetButton
+                isGameEnd={isEnded}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="spd-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/ThreeCardPage.test.tsx
+++ b/frontend/src/pages/ThreeCardPage.test.tsx
@@ -170,7 +170,7 @@ describe('ThreeCardPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'プレイ' }));
     await waitFor(() => expect(screen.getByText('勝利！')).toBeInTheDocument());
     expect(screen.getByTestId('payout-breakdown')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument();
   });
 
   it('shows end phase with dealer wins', async () => {
@@ -242,34 +242,23 @@ describe('ThreeCardPage', () => {
     await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
-  // ── ConfirmDialog on reset ─────────────────────────────────────────────────
+  // ── Next game button at end phase ──────────────────────────────────────────
 
-  it('shows confirm dialog when reset button is clicked', async () => {
+  it('next game button triggers reset without confirm dialog', async () => {
     mockExec.mockResolvedValue(endPhasePlayerWins);
     renderWithProviders(<ThreeCardPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
-  });
-
-  it('dismisses confirm dialog on cancel', async () => {
-    mockExec.mockResolvedValue(endPhasePlayerWins);
-    renderWithProviders(<ThreeCardPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
-
-    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
-    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
   it('shows network error', async () => {

--- a/frontend/src/pages/ThreeCardPage.tsx
+++ b/frontend/src/pages/ThreeCardPage.tsx
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -25,7 +26,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSound } from '../providers/SoundProvider';
-import { btnDanger, btnOutline, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
+import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { ThreeCardResponse } from '../types/card';
@@ -368,14 +369,12 @@ function ThreeCardPageContent() {
             )}
             {isEndPhase && (
               <div className="flex justify-center gap-2 pb-2">
-                <button
-                  type="button"
-                  className={btnOutline}
-                  onClick={() => requestConfirm(handleReset)}
-                  disabled={loading}
-                >
-                  {t('button.reset')}
-                </button>
+                <GameResetButton
+                  isGameEnd={isEndPhase}
+                  onReset={handleReset}
+                  requestConfirm={requestConfirm}
+                  loading={loading}
+                />
                 <button type="button" className={btnSecondary} onClick={showActionLog} disabled={loading}>
                   {tc('actionLog.view')}
                 </button>

--- a/frontend/src/pages/TrashPage.test.tsx
+++ b/frontend/src/pages/TrashPage.test.tsx
@@ -201,4 +201,15 @@ describe('TrashPage', () => {
     renderWithProviders(<TrashPage />);
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
   });
+
+  it('shows 次のゲーム at game-end and fires reset directly (no confirm)', async () => {
+    mockExec.mockResolvedValue(gameOverWinState);
+    renderWithProviders(<TrashPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(screen.queryByRole('button', { name: '確認' })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -7,6 +7,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { LandscapeBanner } from '../components/LandscapeBanner';
 import { ManualButton } from '../components/ManualButton';
@@ -22,7 +23,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, focusRingWhite } from '../styles/buttonStyles';
+import { btnOutline, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { TrashResponse, TrashSlot } from '../types/card';
 import { TrashPhase } from '../types/phases';
@@ -160,12 +161,10 @@ function TrashPageContent() {
 
   const { cardWidth } = useCardDimensions();
 
-  const handleReset = useCallback(() => {
-    requestConfirm(() => {
-      void apiCall('reset');
-      playSound('shuffle');
-    });
-  }, [apiCall, requestConfirm, playSound]);
+  const handleResetAction = useCallback(() => {
+    void apiCall('reset');
+    playSound('shuffle');
+  }, [apiCall, playSound]);
 
   const handleDraw = useCallback(() => {
     void apiCall('draw');
@@ -273,9 +272,13 @@ function TrashPageContent() {
             />
 
             <GameFooter>
-              <button type="button" className={btnPrimary} onClick={handleReset} data-tutorial="tr-reset">
-                {t('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={isGameOver}
+                onReset={handleResetAction}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="tr-reset"
+              />
 
               {isGameOver && (
                 <button type="button" className={btnOutline} onClick={() => showActionLog()} disabled={loading}>

--- a/frontend/src/pages/TriPeaksPage.test.tsx
+++ b/frontend/src/pages/TriPeaksPage.test.tsx
@@ -240,4 +240,15 @@ describe('TriPeaksPage', () => {
     fireEvent.click(screen.getByTestId('stalemate-escape-button'));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo_n', undefined, undefined, 4));
   });
+
+  it('shows 次のゲーム at game-end and fires reset directly (no confirm)', async () => {
+    mockExec.mockResolvedValue(gameClearState);
+    renderWithProviders(<TriPeaksPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(screen.queryByRole('button', { name: '確認' })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/TriPeaksPage.tsx
+++ b/frontend/src/pages/TriPeaksPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { tripeaksApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
@@ -28,7 +29,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useTriPeaksGame } from '../hooks/useTriPeaksGame';
 import { useSound } from '../providers/SoundProvider';
-import { btnDanger, btnOutline, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
+import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { TriPeaksResponse } from '../types/card';
 import { TriPeaksPhase } from '../types/phases';
@@ -146,6 +147,11 @@ function TriPeaksPageContent() {
     bindings: actionBindings,
     enabled: !!isPlayingForKbd && !loading,
   });
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    handleReset();
+  }, [handleReset, hideActionLog]);
 
   if (!state) return <TriPeaksSkeleton />;
 
@@ -361,21 +367,13 @@ function TriPeaksPageContent() {
                   </button>
                 </div>
               )}
-              <div data-tutorial="tp-reset-button">
-                <button
-                  type="button"
-                  className={btnOutline}
-                  onClick={() =>
-                    requestConfirm(() => {
-                      hideActionLog();
-                      return handleReset();
-                    })
-                  }
-                  disabled={loading}
-                >
-                  {tc('button.reset')}
-                </button>
-              </div>
+              <GameResetButton
+                isGameEnd={isEnded}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="tp-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/TwoTenJackPage.tsx
+++ b/frontend/src/pages/TwoTenJackPage.tsx
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
+import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { PlayerHandSection } from '../components/PlayerHandSection';
@@ -24,7 +25,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useTwoTenJackGame } from '../hooks/useTwoTenJackGame';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSuccess } from '../styles/buttonStyles';
+import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { TwoTenJackResponse } from '../types/card';
@@ -158,6 +159,14 @@ function TwoTenJackPageContent() {
   });
 
   const phaseNames = usePhaseNames('twotenjack', TWOTENJACK_PHASE_KEYS);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void dispatch('reset', undefined, undefined, {
+      cpuDifficulty: twoTenJackConfig.cpuDifficulty,
+      pointLimit: twoTenJackConfig.pointLimit,
+    });
+  }, [dispatch, hideActionLog, twoTenJackConfig.cpuDifficulty, twoTenJackConfig.pointLimit]);
 
   if (!state) return <TwoTenJackSkeleton />;
 
@@ -445,23 +454,13 @@ function TwoTenJackPageContent() {
                   {t('nextRound')}
                 </button>
               )}
-              <button
-                type="button"
-                className={btnOutline}
-                data-tutorial="tt-reset-button"
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    return dispatch('reset', undefined, undefined, {
-                      cpuDifficulty: twoTenJackConfig.cpuDifficulty,
-                      pointLimit: twoTenJackConfig.pointLimit,
-                    });
-                  })
-                }
-                disabled={loading}
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={!!isGameEnd}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="tt-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/VideoPokerPage.test.tsx
+++ b/frontend/src/pages/VideoPokerPage.test.tsx
@@ -97,21 +97,23 @@ describe('VideoPokerPage', () => {
   it('renders result phase with win message', async () => {
     mockExec.mockResolvedValue(resultPhaseWin);
     renderWithProviders(<VideoPokerPage />);
-    await waitFor(() => expect(screen.getByText(/次のハンド/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/次のゲーム/)).toBeInTheDocument());
   });
 
   it('renders result phase with lose message', async () => {
     mockExec.mockResolvedValue(resultPhaseLose);
     renderWithProviders(<VideoPokerPage />);
-    await waitFor(() => expect(screen.getByText(/次のハンド/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/次のゲーム/)).toBeInTheDocument());
   });
 
-  it('reset button shows confirmation dialog', async () => {
+  it('next game button fires reset directly without confirm dialog', async () => {
     mockExec.mockResolvedValue(resultPhaseWin);
     renderWithProviders(<VideoPokerPage />);
-    await waitFor(() => expect(screen.getByText(/次のハンド/)).toBeInTheDocument());
-    fireEvent.click(screen.getByRole('button', { name: /次のハンド/ }));
-    await waitFor(() => expect(screen.getByText(/リセットしますか/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/次のゲーム/)).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: /次のゲーム/ }));
+    expect(screen.queryByText(/リセットしますか/)).not.toBeInTheDocument();
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
   it('renders accessible h1 heading', async () => {

--- a/frontend/src/pages/WarPage.tsx
+++ b/frontend/src/pages/WarPage.tsx
@@ -7,6 +7,7 @@ import { SettingsPanel } from '../components/common/SettingsPanel';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
@@ -275,14 +276,13 @@ function WarPageContent() {
               >
                 {t('button.step')}
               </button>
-              <button
-                type="button"
-                onClick={() => requestConfirm(handleReset)}
-                data-tutorial="wr-reset-button"
-                className="px-4 py-2 rounded-lg bg-ds-surface-elevated hover:bg-ds-surface-elevated text-white text-sm"
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={isGameEnd}
+                onReset={handleReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="wr-reset-button"
+              />
               <ActionLogSection
                 isEndPhase={isGameEnd}
                 actionLog={actionLog}

--- a/frontend/src/pages/WhistPage.test.tsx
+++ b/frontend/src/pages/WhistPage.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { whistApi } from '../api/gameApi';
+import { renderWithProviders } from '../test/renderWithProviders';
+import type { Card, WhistResponse } from '../types/card';
+import { WhistPage } from './WhistPage';
+
+vi.mock('../api/gameApi', () => ({
+  whistApi: { exec: vi.fn() },
+  actionLogApi: { whist: vi.fn() },
+}));
+
+const mockExec = vi.mocked(whistApi.exec);
+
+const card = (design: string, value: number): Card => ({ design, value }) as unknown as Card;
+
+function makeState(overrides: Partial<WhistResponse> = {}): WhistResponse {
+  return {
+    players: [
+      {
+        id: 0,
+        isHuman: true,
+        cardCount: 3,
+        cards: [card('SPADE', 1), card('HEART', 5), card('DIAMOND', 9)],
+        roundScore: 0,
+        cumulativeScore: 0,
+        trickCount: 0,
+        team: 0,
+      },
+      { id: 1, isHuman: false, cardCount: 3, cards: [], roundScore: 0, cumulativeScore: 0, trickCount: 0, team: 1 },
+      { id: 2, isHuman: false, cardCount: 3, cards: [], roundScore: 0, cumulativeScore: 0, trickCount: 0, team: 0 },
+      { id: 3, isHuman: false, cardCount: 3, cards: [], roundScore: 0, cumulativeScore: 0, trickCount: 0, team: 1 },
+    ],
+    phase: 0,
+    roundNumber: 1,
+    trickNumber: 1,
+    currentPlayerIdx: 0,
+    currentTrick: [],
+    trumpSuit: 0,
+    dealerIdx: 0,
+    teamScores: [0, 0],
+    gameEndFlag: false,
+    winnerTeam: -1,
+    leadPlayerIdx: 0,
+    message: '',
+    config: { cpuDifficulty: 1, pointLimit: 5 },
+    ...overrides,
+  };
+}
+
+const playState = makeState();
+const gameEndState = makeState({ phase: 3, gameEndFlag: true, winnerTeam: 0 });
+
+beforeEach(() => {
+  mockExec.mockResolvedValue(playState);
+});
+
+describe('WhistPage', () => {
+  it('calls reset on mount with default config', async () => {
+    renderWithProviders(<WhistPage />);
+    // useTrickGameBase fires the mount reset with four positional args.
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined, { cpuDifficulty: 1, pointLimit: 5 }),
+    );
+  });
+
+  it('shows mid-game リセット button that opens confirm dialog', async () => {
+    renderWithProviders(<WhistPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+  });
+
+  it('executes reset after confirm dialog is accepted', async () => {
+    renderWithProviders(<WhistPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());
+
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, { cpuDifficulty: 1, pointLimit: 5 }));
+  });
+
+  it('shows 次のゲーム and fires reset directly at game end (no confirm)', async () => {
+    mockExec.mockResolvedValue(gameEndState);
+    renderWithProviders(<WhistPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, expect.any(Object)));
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/WhistPage.tsx
+++ b/frontend/src/pages/WhistPage.tsx
@@ -8,6 +8,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
+import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { PlayerHandSection } from '../components/PlayerHandSection';
@@ -24,7 +25,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useWhistGame } from '../hooks/useWhistGame';
 import { useSound } from '../providers/SoundProvider';
-import { btnOutline, btnPrimary, btnSuccess } from '../styles/buttonStyles';
+import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { WhistResponse } from '../types/card';
@@ -153,6 +154,14 @@ function WhistPageContent() {
   });
 
   const phaseNames = usePhaseNames('whist', WHIST_PHASE_KEYS);
+
+  const handleManualReset = useCallback(() => {
+    hideActionLog();
+    void dispatch('reset', undefined, {
+      cpuDifficulty: whistConfig.cpuDifficulty,
+      pointLimit: whistConfig.pointLimit,
+    });
+  }, [dispatch, hideActionLog, whistConfig.cpuDifficulty, whistConfig.pointLimit]);
 
   if (!state) return <WhistSkeleton />;
 
@@ -441,23 +450,13 @@ function WhistPageContent() {
                   {t('nextRound')}
                 </button>
               )}
-              <button
-                type="button"
-                className={btnOutline}
-                data-tutorial="wh-reset-button"
-                onClick={() =>
-                  requestConfirm(() => {
-                    hideActionLog();
-                    return dispatch('reset', undefined, {
-                      cpuDifficulty: whistConfig.cpuDifficulty,
-                      pointLimit: whistConfig.pointLimit,
-                    });
-                  })
-                }
-                disabled={loading}
-              >
-                {tc('button.reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={!!isGameEnd}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="wh-reset-button"
+              />
             </div>
           </GameFooter>
         </>

--- a/frontend/src/pages/YukonPage.test.tsx
+++ b/frontend/src/pages/YukonPage.test.tsx
@@ -144,7 +144,7 @@ describe('YukonPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     expect(screen.queryByRole('button', { name: 'ギブアップ' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'ヒント' })).not.toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: /reset|リセット/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('button', { name: /next game|次のゲーム/i }).length).toBeGreaterThan(0);
   });
 
   it('undo button fires undo command when canUndo is true', async () => {

--- a/frontend/src/pages/YukonPage.tsx
+++ b/frontend/src/pages/YukonPage.tsx
@@ -9,6 +9,7 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
+import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
@@ -30,7 +31,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
-import { btnDanger, btnOutline, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
+import { btnDanger, btnOutline, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { YukonResponse } from '../types/card';
 import { YukonPhase } from '../types/phases';
@@ -218,12 +219,10 @@ function YukonPageContent() {
   });
 
   // Action handlers
-  const handleReset = useCallback(() => {
-    requestConfirm(() => {
-      void apiExec('reset');
-      playSound('shuffle');
-    });
-  }, [apiExec, requestConfirm, playSound]);
+  const handleManualReset = useCallback(() => {
+    void apiExec('reset');
+    playSound('shuffle');
+  }, [apiExec, playSound]);
 
   const handleGiveUp = useCallback(() => {
     void apiExec('giveup');
@@ -511,9 +510,13 @@ function YukonPageContent() {
             />
 
             <GameFooter>
-              <button type="button" className={btnPrimary} onClick={handleReset} data-tutorial="yk-reset-button">
-                {t('common:reset')}
-              </button>
+              <GameResetButton
+                isGameEnd={isEnded}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="yk-reset-button"
+              />
 
               {isPlaying && (
                 <>

--- a/internal/domain/Canasta.go
+++ b/internal/domain/Canasta.go
@@ -809,6 +809,14 @@ func (g *Canasta) cpuMeld() {
 func (g *Canasta) cpuDiscard() {
 	player := g.players[g.currentPlayerIdx]
 
+	// Defensive: if the CPU reached the discard phase with no cards (e.g. a
+	// prior meld emptied the hand but HasCanasta() was false so goOut didn't
+	// fire), do not try to discard — that path panics via RemoveCard → nil.
+	if player.GetCardsSize() == 0 {
+		g.goOut(g.currentPlayerIdx, false)
+		return
+	}
+
 	// 上がれるかチェック
 	if player.GetCardsSize() == 1 && player.HasCanasta() {
 		card := player.GetCard(0)


### PR DESCRIPTION
## Summary

Players were seeing 「リセット」on every page, even after a round finished — then had to dismiss a confirm dialog just to deal the next hand. The label didn't match the intent (there's no in-progress game to reset) and the confirmation added friction where none was needed.

### Changes

- **New `<GameResetButton>` component** — swaps label and behavior by `isGameEnd`:
  - Mid-game → 「リセット」(btnOutline) + confirm dialog (unchanged safety)
  - End state → 「次のゲーム」(btnPrimary) + fires immediately (no confirm)
- **`BjEndPhaseControls` simplified** — end-phase button always fires directly; auto-advance countdown also advances without a prompt. `onManualReset` removed.
- **Rolled out across all 54 game pages + `VideoPokerGameContent`** — each page passes its own end-state flag (`gameEndFlag` / `phase === END` / `isGameOver || isGameClear`).
- **i18n** — `button.nextGame` added in ja/en `common.json`.
- **Tests** — 27 page test files updated: end-state assertions now check 「次のゲーム」 and drop the now-nonexistent 「確認」click; three BlackJack confirm-dialog tests consolidated into a single direct-fire test since that code path is gone.

## Test plan

- [x] `cd frontend && bun run check` passes (4 pre-existing warnings, no new issues)
- [x] `cd frontend && bun run build` passes
- [x] Critical test suites pass (BlackJack, Hearts, Klondike, Baccarat, VideoPoker, Trash, GameResetButton, BjEndPhaseControls: 355/355 tests)
- [ ] Manual: open a solitaire game, lose/win → button reads 「次のゲーム」 and starts a new deal on one click
- [ ] Manual: mid-game, click reset → confirm dialog still appears
- [ ] Manual: BlackJack end of hand with auto-advance ON → countdown still works