### PR TITLE
refactor: DRY game registration and dispatcher boilerplate (#1458-#1464)

### DIFF
--- a/internal/adapter/controller/AccordionWebController.go
+++ b/internal/adapter/controller/AccordionWebController.go
@@ -64,8 +64,6 @@ func newAccordionDefaultOutput(msg string) *AccordionWebOutput {
 
 func accordionDispatch(bc *baseController, w http.ResponseWriter, ai usecase.AccordionInteractorIF, param AccordionWebInput, newDefault func(string) *AccordionWebOutput) bool {
 	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, ai.Reset())
 	case "m", "move":
 		return accordionMoveDispatch(bc, w, ai, param, newDefault)
 	case "g", "giveup":
@@ -79,7 +77,7 @@ func accordionDispatch(bc *baseController, w http.ResponseWriter, ai usecase.Acc
 		}
 		bc.writePresenterResponse(w, ai.UndoN(*param.N))
 	default:
-		return dispatchHintAndLog(param.Command, bc, w, ai.Hint, ai.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, ai.Reset, ai.Hint, ai.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/BaccaratWebController.go
+++ b/internal/adapter/controller/BaccaratWebController.go
@@ -64,8 +64,6 @@ func newBaccaratDefaultOutput(msg string) *BaccaratWebOutput {
 
 func baccaratDispatch(bc *baseController, w http.ResponseWriter, bi usecase.BaccaratInteractorIF, param BaccaratWebInput, _ func(string) *BaccaratWebOutput) bool {
 	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, bi.Reset())
 	case "b", "bet":
 		bt := deref(param.BetType)
 		ppBet := deref(param.PlayerPairBet)
@@ -74,7 +72,7 @@ func baccaratDispatch(bc *baseController, w http.ResponseWriter, bi usecase.Bacc
 	case "ch", "clearhistory":
 		bc.writePresenterResponse(w, bi.ClearHistory())
 	default:
-		return dispatchLog(param.Command, bc, w, bi.ActionLog)
+		return dispatchResetAndLog(param.Command, bc, w, bi.Reset, bi.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/CanfieldWebController.go
+++ b/internal/adapter/controller/CanfieldWebController.go
@@ -70,8 +70,6 @@ func newCanfieldDefaultOutput(msg string) *CanfieldWebOutput {
 
 func canfieldDispatch(bc *baseController, w http.ResponseWriter, ci usecase.CanfieldInteractorIF, param CanfieldWebInput, newDefault func(string) *CanfieldWebOutput) bool {
 	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, ci.Reset())
 	case "d", "draw":
 		bc.writePresenterResponse(w, ci.Draw())
 	case "m", "move":
@@ -89,7 +87,7 @@ func canfieldDispatch(bc *baseController, w http.ResponseWriter, ci usecase.Canf
 		}
 		bc.writePresenterResponse(w, ci.UndoN(*param.N))
 	default:
-		return dispatchHintAndLog(param.Command, bc, w, ci.Hint, ci.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, ci.Reset, ci.Hint, ci.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/CaribbeanStudWebController.go
+++ b/internal/adapter/controller/CaribbeanStudWebController.go
@@ -52,8 +52,6 @@ func newCaribbeanStudDefaultOutput(msg string) *CaribbeanStudWebOutput {
 
 func caribbeanStudDispatch(bc *baseController, w http.ResponseWriter, ci usecase.CaribbeanStudInteractorIF, param CaribbeanStudWebInput, _ func(string) *CaribbeanStudWebOutput) bool {
 	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, ci.Reset())
 	case "b", "bet":
 		jackpot := deref(param.JackpotBet)
 		bc.writePresenterResponse(w, ci.Bet(param.Amount, jackpot))
@@ -62,7 +60,7 @@ func caribbeanStudDispatch(bc *baseController, w http.ResponseWriter, ci usecase
 	case "f", "fold":
 		bc.writePresenterResponse(w, ci.Fold())
 	default:
-		return dispatchLog(param.Command, bc, w, ci.ActionLog)
+		return dispatchResetAndLog(param.Command, bc, w, ci.Reset, ci.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/ClockSolitaireWebController.go
+++ b/internal/adapter/controller/ClockSolitaireWebController.go
@@ -45,15 +45,9 @@ func newClockSolitaireDefaultOutput(msg string) *ClockSolitaireWebOutput {
 }
 
 func clockSolitaireDispatch(bc *baseController, w http.ResponseWriter, ci usecase.ClockSolitaireInteractorIF, param ClockSolitaireWebInput, _ func(string) *ClockSolitaireWebOutput) bool {
-	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, ci.Reset())
-	case "s", "step":
-		bc.writePresenterResponse(w, ci.Step())
-	case "a", "autoplay":
+	if param.Command == "a" || param.Command == "autoplay" {
 		bc.writePresenterResponse(w, ci.AutoPlay())
-	default:
-		return dispatchLog(param.Command, bc, w, ci.ActionLog)
+		return true
 	}
-	return true
+	return dispatchResetStepLog(param.Command, bc, w, ci)
 }

--- a/internal/adapter/controller/FortyThievesWebController.go
+++ b/internal/adapter/controller/FortyThievesWebController.go
@@ -70,8 +70,6 @@ func newFortyThievesDefaultOutput(msg string) *FortyThievesWebOutput {
 
 func fortyThievesDispatch(bc *baseController, w http.ResponseWriter, fi usecase.FortyThievesInteractorIF, param FortyThievesWebInput, newDefault func(string) *FortyThievesWebOutput) bool {
 	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, fi.Reset())
 	case "d", "draw":
 		bc.writePresenterResponse(w, fi.Draw())
 	case "m", "move":
@@ -89,7 +87,7 @@ func fortyThievesDispatch(bc *baseController, w http.ResponseWriter, fi usecase.
 		}
 		bc.writePresenterResponse(w, fi.UndoN(*param.N))
 	default:
-		return dispatchHintAndLog(param.Command, bc, w, fi.Hint, fi.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, fi.Reset, fi.Hint, fi.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/FreeCellWebController.go
+++ b/internal/adapter/controller/FreeCellWebController.go
@@ -64,8 +64,6 @@ func newFreeCellDefaultOutput(msg string) *FreeCellWebOutput {
 
 func freeCellDispatch(bc *baseController, w http.ResponseWriter, fi usecase.FreeCellInteractorIF, param FreeCellWebInput, newDefault func(string) *FreeCellWebOutput) bool {
 	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, fi.Reset())
 	case "m", "move":
 		return freeCellMoveDispatch(bc, w, fi, param, newDefault)
 	case "g", "giveup":
@@ -81,7 +79,7 @@ func freeCellDispatch(bc *baseController, w http.ResponseWriter, fi usecase.Free
 		}
 		bc.writePresenterResponse(w, fi.UndoN(*param.N))
 	default:
-		return dispatchHintAndLog(param.Command, bc, w, fi.Hint, fi.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, fi.Reset, fi.Hint, fi.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/GolfWebController.go
+++ b/internal/adapter/controller/GolfWebController.go
@@ -58,8 +58,6 @@ func newGolfDefaultOutput(msg string) *GolfWebOutput {
 
 func golfDispatch(bc *baseController, w http.ResponseWriter, gi usecase.GolfInteractorIF, param GolfWebInput, newDefault func(string) *GolfWebOutput) bool {
 	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, gi.Reset())
 	case "d", "draw":
 		bc.writePresenterResponse(w, gi.Draw())
 	case "rm", "remove":
@@ -79,7 +77,7 @@ func golfDispatch(bc *baseController, w http.ResponseWriter, gi usecase.GolfInte
 		}
 		bc.writePresenterResponse(w, gi.UndoN(*param.N))
 	default:
-		return dispatchHintAndLog(param.Command, bc, w, gi.Hint, gi.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, gi.Reset, gi.Hint, gi.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/LetItRideWebController.go
+++ b/internal/adapter/controller/LetItRideWebController.go
@@ -50,8 +50,6 @@ func newLetItRideDefaultOutput(msg string) *LetItRideWebOutput {
 
 func letItRideDispatch(bc *baseController, w http.ResponseWriter, li usecase.LetItRideInteractorIF, param LetItRideWebInput, _ func(string) *LetItRideWebOutput) bool {
 	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, li.Reset())
 	case "b", "bet":
 		bc.writePresenterResponse(w, li.Bet(param.Amount))
 	case "p", "pull":
@@ -59,7 +57,7 @@ func letItRideDispatch(bc *baseController, w http.ResponseWriter, li usecase.Let
 	case "l", "letitride":
 		bc.writePresenterResponse(w, li.LetItRide())
 	default:
-		return dispatchLog(param.Command, bc, w, li.ActionLog)
+		return dispatchResetAndLog(param.Command, bc, w, li.Reset, li.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/PaiGowWebController.go
+++ b/internal/adapter/controller/PaiGowWebController.go
@@ -60,8 +60,6 @@ func newPaiGowDefaultOutput(msg string) *PaiGowWebOutput {
 
 func paiGowDispatch(bc *baseController, w http.ResponseWriter, pi usecase.PaiGowInteractorIF, param PaiGowWebInput, _ func(string) *PaiGowWebOutput) bool {
 	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, pi.Reset())
 	case "b", "bet":
 		bc.writePresenterResponse(w, pi.Bet(param.Amount))
 	case "s", "set":
@@ -69,7 +67,7 @@ func paiGowDispatch(bc *baseController, w http.ResponseWriter, pi usecase.PaiGow
 		low1 := deref(param.Low1)
 		bc.writePresenterResponse(w, pi.SetHands(low0, low1))
 	default:
-		return dispatchLog(param.Command, bc, w, pi.ActionLog)
+		return dispatchResetAndLog(param.Command, bc, w, pi.Reset, pi.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/PokerSquaresWebController.go
+++ b/internal/adapter/controller/PokerSquaresWebController.go
@@ -51,8 +51,6 @@ func newPokerSquaresDefaultOutput(msg string) *PokerSquaresWebOutput {
 
 func pokerSquaresDispatch(bc *baseController, w http.ResponseWriter, pi usecase.PokerSquaresInteractorIF, param PokerSquaresWebInput, newDefault func(string) *PokerSquaresWebOutput) bool {
 	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, pi.Reset())
 	case "p", "place":
 		if param.Row == nil || param.Col == nil {
 			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: row and col are required."))
@@ -64,7 +62,7 @@ func pokerSquaresDispatch(bc *baseController, w http.ResponseWriter, pi usecase.
 	case "g", "giveup":
 		bc.writePresenterResponse(w, pi.GiveUp())
 	default:
-		return dispatchLog(param.Command, bc, w, pi.ActionLog)
+		return dispatchResetAndLog(param.Command, bc, w, pi.Reset, pi.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/PyramidWebController.go
+++ b/internal/adapter/controller/PyramidWebController.go
@@ -69,8 +69,6 @@ func newPyramidDefaultOutput(msg string) *PyramidWebOutput {
 
 func pyramidDispatch(bc *baseController, w http.ResponseWriter, pi usecase.PyramidInteractorIF, param PyramidWebInput, newDefault func(string) *PyramidWebOutput) bool {
 	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, pi.Reset())
 	case "d", "draw":
 		bc.writePresenterResponse(w, pi.Draw())
 	case "rm", "remove":
@@ -86,7 +84,7 @@ func pyramidDispatch(bc *baseController, w http.ResponseWriter, pi usecase.Pyram
 		}
 		bc.writePresenterResponse(w, pi.UndoN(*param.N))
 	default:
-		return dispatchHintAndLog(param.Command, bc, w, pi.Hint, pi.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, pi.Reset, pi.Hint, pi.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/RedDogWebController.go
+++ b/internal/adapter/controller/RedDogWebController.go
@@ -44,8 +44,6 @@ func newRedDogDefaultOutput(msg string) *RedDogWebOutput {
 
 func redDogDispatch(bc *baseController, w http.ResponseWriter, ri usecase.RedDogInteractorIF, param RedDogWebInput, _ func(string) *RedDogWebOutput) bool {
 	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, ri.Reset())
 	case "b", "bet":
 		bc.writePresenterResponse(w, ri.Bet(param.Amount))
 	case "raise":
@@ -53,7 +51,7 @@ func redDogDispatch(bc *baseController, w http.ResponseWriter, ri usecase.RedDog
 	case "s", "stay":
 		bc.writePresenterResponse(w, ri.Stay())
 	default:
-		return dispatchLog(param.Command, bc, w, ri.ActionLog)
+		return dispatchResetAndLog(param.Command, bc, w, ri.Reset, ri.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/ScorpionWebController.go
+++ b/internal/adapter/controller/ScorpionWebController.go
@@ -59,8 +59,6 @@ func newScorpionDefaultOutput(msg string) *ScorpionWebOutput {
 
 func scorpionDispatch(bc *baseController, w http.ResponseWriter, si usecase.ScorpionInteractorIF, param ScorpionWebInput, newDefault func(string) *ScorpionWebOutput) bool {
 	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, si.Reset())
 	case "d", "deal":
 		bc.writePresenterResponse(w, si.Deal())
 	case "m", "move":
@@ -78,7 +76,7 @@ func scorpionDispatch(bc *baseController, w http.ResponseWriter, si usecase.Scor
 		}
 		bc.writePresenterResponse(w, si.UndoN(*param.N))
 	default:
-		return dispatchHintAndLog(param.Command, bc, w, si.Hint, si.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, si.Reset, si.Hint, si.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/ThreeCardWebController.go
+++ b/internal/adapter/controller/ThreeCardWebController.go
@@ -53,8 +53,6 @@ func newThreeCardDefaultOutput(msg string) *ThreeCardWebOutput {
 
 func threeCardDispatch(bc *baseController, w http.ResponseWriter, ti usecase.ThreeCardInteractorIF, param ThreeCardWebInput, _ func(string) *ThreeCardWebOutput) bool {
 	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, ti.Reset())
 	case "b", "bet":
 		ppBet := deref(param.PairPlusBet)
 		bc.writePresenterResponse(w, ti.Bet(param.Amount, ppBet))
@@ -63,7 +61,7 @@ func threeCardDispatch(bc *baseController, w http.ResponseWriter, ti usecase.Thr
 	case "f", "fold":
 		bc.writePresenterResponse(w, ti.Fold())
 	default:
-		return dispatchLog(param.Command, bc, w, ti.ActionLog)
+		return dispatchResetAndLog(param.Command, bc, w, ti.Reset, ti.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/TrashWebController.go
+++ b/internal/adapter/controller/TrashWebController.go
@@ -57,8 +57,6 @@ func newTrashDefaultOutput(msg string) *TrashWebOutput {
 
 func trashDispatch(bc *baseController, w http.ResponseWriter, ti usecase.TrashInteractorIF, param TrashWebInput, newDefault func(string) *TrashWebOutput) bool {
 	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, ti.Reset())
 	case "d", "draw":
 		bc.writePresenterResponse(w, ti.Draw())
 	case "p", "place", "placeWild":
@@ -70,7 +68,7 @@ func trashDispatch(bc *baseController, w http.ResponseWriter, ti usecase.TrashIn
 	case "cpu":
 		bc.writePresenterResponse(w, ti.CpuStep())
 	default:
-		return dispatchLog(param.Command, bc, w, ti.ActionLog)
+		return dispatchResetAndLog(param.Command, bc, w, ti.Reset, ti.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/TriPeaksWebController.go
+++ b/internal/adapter/controller/TriPeaksWebController.go
@@ -60,8 +60,6 @@ func newTriPeaksDefaultOutput(msg string) *TriPeaksWebOutput {
 
 func triPeaksDispatch(bc *baseController, w http.ResponseWriter, ti usecase.TriPeaksInteractorIF, param TriPeaksWebInput, newDefault func(string) *TriPeaksWebOutput) bool {
 	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, ti.Reset())
 	case "d", "draw":
 		bc.writePresenterResponse(w, ti.Draw())
 	case "rm", "remove":
@@ -81,7 +79,7 @@ func triPeaksDispatch(bc *baseController, w http.ResponseWriter, ti usecase.TriP
 		}
 		bc.writePresenterResponse(w, ti.UndoN(*param.N))
 	default:
-		return dispatchHintAndLog(param.Command, bc, w, ti.Hint, ti.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, ti.Reset, ti.Hint, ti.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/VideoPokerWebController.go
+++ b/internal/adapter/controller/VideoPokerWebController.go
@@ -46,8 +46,6 @@ func newVideoPokerDefaultOutput(msg string) *VideoPokerWebOutput {
 
 func videoPokerDispatch(bc *baseController, w http.ResponseWriter, vi usecase.VideoPokerInteractorIF, param VideoPokerWebInput, _ func(string) *VideoPokerWebOutput) bool {
 	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, vi.Reset())
 	case "b", "bet":
 		bc.writePresenterResponse(w, vi.Bet(param.Amount))
 	case "h", "hold":
@@ -57,7 +55,7 @@ func videoPokerDispatch(bc *baseController, w http.ResponseWriter, vi usecase.Vi
 		}
 		bc.writePresenterResponse(w, vi.Hold(indices))
 	default:
-		return dispatchLog(param.Command, bc, w, vi.ActionLog)
+		return dispatchResetAndLog(param.Command, bc, w, vi.Reset, vi.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/WarWebController.go
+++ b/internal/adapter/controller/WarWebController.go
@@ -75,7 +75,8 @@ func warDispatch(
 	param WarWebInput,
 	_ func(string) *WarWebOutput,
 ) bool {
-	if param.Command == "r" || param.Command == "reset" {
+	switch param.Command {
+	case "r", "reset":
 		bc.writePresenterResponse(w, wi.ResetWithConfig(param.ToConfig()))
 		return true
 	}

--- a/internal/adapter/controller/WarWebController.go
+++ b/internal/adapter/controller/WarWebController.go
@@ -75,15 +75,9 @@ func warDispatch(
 	param WarWebInput,
 	_ func(string) *WarWebOutput,
 ) bool {
-	switch param.Command {
-	case "r", "reset":
+	if param.Command == "r" || param.Command == "reset" {
 		bc.writePresenterResponse(w, wi.ResetWithConfig(param.ToConfig()))
-	case "s", "step":
-		bc.writePresenterResponse(w, wi.Step())
-	case "log", "l":
-		bc.writePresenterResponse(w, wi.ActionLog())
-	default:
-		return false
+		return true
 	}
-	return true
+	return dispatchResetStepLog(param.Command, bc, w, wi)
 }

--- a/internal/adapter/controller/YukonWebController.go
+++ b/internal/adapter/controller/YukonWebController.go
@@ -60,8 +60,6 @@ func newYukonDefaultOutput(msg string) *YukonWebOutput {
 
 func yukonDispatch(bc *baseController, w http.ResponseWriter, yi usecase.YukonInteractorIF, param YukonWebInput, newDefault func(string) *YukonWebOutput) bool {
 	switch param.Command {
-	case "r", "reset":
-		bc.writePresenterResponse(w, yi.Reset())
 	case "m", "move":
 		return yukonMoveDispatch(bc, w, yi, param, newDefault)
 	case "g", "giveup":
@@ -77,7 +75,7 @@ func yukonDispatch(bc *baseController, w http.ResponseWriter, yi usecase.YukonIn
 		}
 		bc.writePresenterResponse(w, yi.UndoN(*param.N))
 	default:
-		return dispatchHintAndLog(param.Command, bc, w, yi.Hint, yi.ActionLog)
+		return dispatchResetHintAndLog(param.Command, bc, w, yi.Reset, yi.Hint, yi.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/web_dispatch_helper.go
+++ b/internal/adapter/controller/web_dispatch_helper.go
@@ -28,7 +28,7 @@ func dispatchHintAndLog(cmd string, bc *baseController, w http.ResponseWriter, h
 // dispatchResetAndLog handles "r"/"reset" and "log"/"l" for games whose reset
 // takes no arguments — resetFn is typically interactor.Reset. Games that need
 // configurable reset (ResetWithConfig, etc.) keep their own case and should
-// fall through to dispatchLog instead.
+// fall through to dispatchLog or dispatchResetStepLog instead.
 func dispatchResetAndLog(cmd string, bc *baseController, w http.ResponseWriter, resetFn, actionLogFn func() string) bool {
 	switch cmd {
 	case "r", "reset":
@@ -72,7 +72,7 @@ type resetStepLogger interface {
 // commands that recur across most simple game dispatchers. Returns true if
 // the command was handled. Games that need a custom reset (e.g. ResetWithConfig)
 // should intercept "r"/"reset" themselves before falling through to this helper.
-func dispatchResetStepLog[I resetStepLogger](cmd string, bc *baseController, w http.ResponseWriter, i I) bool {
+func dispatchResetStepLog(cmd string, bc *baseController, w http.ResponseWriter, i resetStepLogger) bool {
 	switch cmd {
 	case "r", "reset":
 		bc.writePresenterResponse(w, i.Reset())

--- a/internal/adapter/controller/web_dispatch_helper.go
+++ b/internal/adapter/controller/web_dispatch_helper.go
@@ -24,3 +24,65 @@ func dispatchHintAndLog(cmd string, bc *baseController, w http.ResponseWriter, h
 	}
 	return false
 }
+
+// dispatchResetAndLog handles "r"/"reset" and "log"/"l" for games whose reset
+// takes no arguments — resetFn is typically interactor.Reset. Games that need
+// configurable reset (ResetWithConfig, etc.) keep their own case and should
+// fall through to dispatchLog instead.
+func dispatchResetAndLog(cmd string, bc *baseController, w http.ResponseWriter, resetFn, actionLogFn func() string) bool {
+	switch cmd {
+	case "r", "reset":
+		bc.writePresenterResponse(w, resetFn())
+		return true
+	case "log", "l":
+		bc.writePresenterResponse(w, actionLogFn())
+		return true
+	}
+	return false
+}
+
+// dispatchResetHintAndLog handles "r"/"reset", "h"/"hint", and "log"/"l" for
+// solitaire-style games that expose hints and a no-arg Reset(). Games without
+// a Hint() method should use dispatchResetAndLog instead.
+func dispatchResetHintAndLog(cmd string, bc *baseController, w http.ResponseWriter, resetFn, hintFn, actionLogFn func() string) bool {
+	switch cmd {
+	case "r", "reset":
+		bc.writePresenterResponse(w, resetFn())
+		return true
+	case "h", "hint":
+		bc.writePresenterResponse(w, hintFn())
+		return true
+	case "log", "l":
+		bc.writePresenterResponse(w, actionLogFn())
+		return true
+	}
+	return false
+}
+
+// resetStepLogger is the minimal interactor surface needed for the common
+// reset/step/log command trio. Declared here — at the consumer — rather than
+// in usecase, per the "accept interfaces, return structs" convention.
+type resetStepLogger interface {
+	Reset() string
+	Step() string
+	ActionLog() string
+}
+
+// dispatchResetStepLog handles the "r"/"reset", "s"/"step", and "log"/"l"
+// commands that recur across most simple game dispatchers. Returns true if
+// the command was handled. Games that need a custom reset (e.g. ResetWithConfig)
+// should intercept "r"/"reset" themselves before falling through to this helper.
+func dispatchResetStepLog[I resetStepLogger](cmd string, bc *baseController, w http.ResponseWriter, i I) bool {
+	switch cmd {
+	case "r", "reset":
+		bc.writePresenterResponse(w, i.Reset())
+		return true
+	case "s", "step":
+		bc.writePresenterResponse(w, i.Step())
+		return true
+	case "log", "l":
+		bc.writePresenterResponse(w, i.ActionLog())
+		return true
+	}
+	return false
+}

--- a/internal/adapter/controller/web_dispatch_helper_test.go
+++ b/internal/adapter/controller/web_dispatch_helper_test.go
@@ -1,0 +1,144 @@
+//go:build test
+
+package controller
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeResetStepLogger records which interactor method was invoked — the
+// interactor surface is uniform across simple games, so a stub is enough to
+// prove dispatchResetStepLog routes each command to the right method.
+type fakeResetStepLogger struct {
+	resetCalls int
+	stepCalls  int
+	logCalls   int
+}
+
+func (f *fakeResetStepLogger) Reset() string {
+	f.resetCalls++
+	return `{"method":"reset"}`
+}
+
+func (f *fakeResetStepLogger) Step() string {
+	f.stepCalls++
+	return `{"method":"step"}`
+}
+
+func (f *fakeResetStepLogger) ActionLog() string {
+	f.logCalls++
+	return `{"method":"log"}`
+}
+
+func TestDispatchResetStepLog(t *testing.T) {
+	cases := []struct {
+		cmd      string
+		wantBody string
+		wantFn   func(*fakeResetStepLogger) int
+	}{
+		{"r", `{"method":"reset"}`, func(f *fakeResetStepLogger) int { return f.resetCalls }},
+		{"reset", `{"method":"reset"}`, func(f *fakeResetStepLogger) int { return f.resetCalls }},
+		{"s", `{"method":"step"}`, func(f *fakeResetStepLogger) int { return f.stepCalls }},
+		{"step", `{"method":"step"}`, func(f *fakeResetStepLogger) int { return f.stepCalls }},
+		{"l", `{"method":"log"}`, func(f *fakeResetStepLogger) int { return f.logCalls }},
+		{"log", `{"method":"log"}`, func(f *fakeResetStepLogger) int { return f.logCalls }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.cmd, func(t *testing.T) {
+			bc := &baseController{}
+			w := httptest.NewRecorder()
+			f := &fakeResetStepLogger{}
+			ok := dispatchResetStepLog(tc.cmd, bc, w, f)
+			assert.True(t, ok)
+			assert.Equal(t, 1, tc.wantFn(f))
+			assert.Equal(t, tc.wantBody, strings.TrimSpace(w.Body.String()))
+		})
+	}
+}
+
+func TestDispatchResetStepLog_Unknown(t *testing.T) {
+	bc := &baseController{}
+	w := httptest.NewRecorder()
+	f := &fakeResetStepLogger{}
+	ok := dispatchResetStepLog("unknown", bc, w, f)
+	assert.False(t, ok)
+	assert.Equal(t, 0, f.resetCalls+f.stepCalls+f.logCalls)
+	assert.Empty(t, w.Body.String())
+}
+
+// counter returns a func() string that records invocations into *n and
+// returns a fixed JSON body. Keeps the dispatchResetAndLog /
+// dispatchResetHintAndLog tests compact.
+func counter(n *int, body string) func() string {
+	return func() string {
+		*n++
+		return body
+	}
+}
+
+func TestDispatchResetAndLog(t *testing.T) {
+	cases := []struct {
+		cmd         string
+		wantBody    string
+		wantReset   int
+		wantLog     int
+		wantHandled bool
+	}{
+		{"r", `{"m":"reset"}`, 1, 0, true},
+		{"reset", `{"m":"reset"}`, 1, 0, true},
+		{"log", `{"m":"log"}`, 0, 1, true},
+		{"l", `{"m":"log"}`, 0, 1, true},
+		{"nope", "", 0, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.cmd, func(t *testing.T) {
+			bc := &baseController{}
+			w := httptest.NewRecorder()
+			var rCalls, lCalls int
+			ok := dispatchResetAndLog(tc.cmd, bc, w,
+				counter(&rCalls, `{"m":"reset"}`),
+				counter(&lCalls, `{"m":"log"}`))
+			assert.Equal(t, tc.wantHandled, ok)
+			assert.Equal(t, tc.wantReset, rCalls)
+			assert.Equal(t, tc.wantLog, lCalls)
+			assert.Equal(t, tc.wantBody, strings.TrimSpace(w.Body.String()))
+		})
+	}
+}
+
+func TestDispatchResetHintAndLog(t *testing.T) {
+	cases := []struct {
+		cmd                 string
+		wantBody            string
+		wantR, wantH, wantL int
+		wantHandled         bool
+	}{
+		{"r", `{"m":"reset"}`, 1, 0, 0, true},
+		{"reset", `{"m":"reset"}`, 1, 0, 0, true},
+		{"h", `{"m":"hint"}`, 0, 1, 0, true},
+		{"hint", `{"m":"hint"}`, 0, 1, 0, true},
+		{"log", `{"m":"log"}`, 0, 0, 1, true},
+		{"l", `{"m":"log"}`, 0, 0, 1, true},
+		{"nope", "", 0, 0, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.cmd, func(t *testing.T) {
+			bc := &baseController{}
+			w := httptest.NewRecorder()
+			var rCalls, hCalls, lCalls int
+			ok := dispatchResetHintAndLog(tc.cmd, bc, w,
+				counter(&rCalls, `{"m":"reset"}`),
+				counter(&hCalls, `{"m":"hint"}`),
+				counter(&lCalls, `{"m":"log"}`))
+			assert.Equal(t, tc.wantHandled, ok)
+			assert.Equal(t, tc.wantR, rCalls)
+			assert.Equal(t, tc.wantH, hCalls)
+			assert.Equal(t, tc.wantL, lCalls)
+			assert.Equal(t, tc.wantBody, strings.TrimSpace(w.Body.String()))
+		})
+	}
+}

--- a/internal/domain/Holdem.go
+++ b/internal/domain/Holdem.go
@@ -58,6 +58,7 @@ const (
 // Holdem テキサスホールデムクラス
 type Holdem struct {
 	communityCardBettingBase
+	tournamentBase  // handCount / rebuyCounts / addonUsed, shared across poker variants (issue #1463)
 	trumpCards      *TrumpCards
 	players         []*HoldemPlayer
 	communityCards  []*Card
@@ -72,10 +73,7 @@ type Holdem struct {
 	vpipTracked     []bool // 当該ハンドでVPIP済みかどうか
 	pfrTracked      []bool // 当該ハンドでPFR済みかどうか
 	threeBetTracked []bool // 当該ハンドで3Bet追跡済みかどうか
-	handCount       int    // ハンド数 (トーナメントモード用)
 	lastCpuError    error  // CPU行動エラーの最後のフォールバック記録 (テスト検出用)
-	rebuyCounts     []int  // プレイヤーごとのリバイ回数
-	addonUsed       []bool // プレイヤーごとのアドオン使用フラグ
 	rebuyPhaseType  int    // 0=none, 1=rebuy pending, 2=addon pending
 	actionLog       []*ActionLogEntry
 	humanProfile    *BettingHumanProfile
@@ -84,7 +82,7 @@ type Holdem struct {
 
 // NewHoldem コンストラクタ
 func NewHoldem(trumpCards *TrumpCards, players []*HoldemPlayer, config HoldemConfig) *Holdem {
-	return &Holdem{
+	h := &Holdem{
 		communityCardBettingBase: communityCardBettingBase{
 			actedFlags: make([]bool, len(players)),
 		},
@@ -98,11 +96,11 @@ func NewHoldem(trumpCards *TrumpCards, players []*HoldemPlayer, config HoldemCon
 		vpipTracked:     make([]bool, len(players)),
 		pfrTracked:      make([]bool, len(players)),
 		threeBetTracked: make([]bool, len(players)),
-		rebuyCounts:     make([]int, len(players)),
-		addonUsed:       make([]bool, len(players)),
 		config:          config,
 		phase:           HoldemPhaseInit,
 	}
+	h.initTournamentState(len(players))
+	return h
 }
 
 // NewDefaultHoldem returns Holdem with the default table size and DefaultHoldemConfig.
@@ -892,7 +890,5 @@ func (h *Holdem) Resize(players []*HoldemPlayer) {
 	h.vpipTracked = make([]bool, n)
 	h.pfrTracked = make([]bool, n)
 	h.threeBetTracked = make([]bool, n)
-	h.rebuyCounts = make([]int, n)
-	h.addonUsed = make([]bool, n)
-	h.handCount = 0
+	h.initTournamentState(n)
 }

--- a/internal/domain/Omaha.go
+++ b/internal/domain/Omaha.go
@@ -53,10 +53,8 @@ type Omaha struct {
 	vpipTracked     []bool
 	pfrTracked      []bool
 	threeBetTracked []bool
-	handCount       int
+	tournamentBase  // handCount / rebuyCounts / addonUsed (issue #1463)
 	lastCpuError    error
-	rebuyCounts     []int
-	addonUsed       []bool
 	rebuyPhaseType  int
 	actionLog       []*ActionLogEntry
 	humanProfile    *BettingHumanProfile
@@ -65,7 +63,7 @@ type Omaha struct {
 
 // NewOmaha コンストラクタ
 func NewOmaha(trumpCards *TrumpCards, players []*OmahaPlayer, config OmahaConfig) *Omaha {
-	return &Omaha{
+	o := &Omaha{
 		communityCardBettingBase: communityCardBettingBase{
 			actedFlags: make([]bool, len(players)),
 		},
@@ -79,11 +77,11 @@ func NewOmaha(trumpCards *TrumpCards, players []*OmahaPlayer, config OmahaConfig
 		vpipTracked:     make([]bool, len(players)),
 		pfrTracked:      make([]bool, len(players)),
 		threeBetTracked: make([]bool, len(players)),
-		rebuyCounts:     make([]int, len(players)),
-		addonUsed:       make([]bool, len(players)),
 		config:          config,
 		phase:           OmahaPhaseInit,
 	}
+	o.initTournamentState(len(players))
+	return o
 }
 
 // NewDefaultOmaha returns Omaha with the default table size and DefaultOmahaConfig.
@@ -1441,7 +1439,5 @@ func (o *Omaha) Resize(players []*OmahaPlayer) {
 	o.vpipTracked = make([]bool, n)
 	o.pfrTracked = make([]bool, n)
 	o.threeBetTracked = make([]bool, n)
-	o.rebuyCounts = make([]int, n)
-	o.addonUsed = make([]bool, n)
-	o.handCount = 0
+	o.initTournamentState(n)
 }

--- a/internal/domain/Pineapple.go
+++ b/internal/domain/Pineapple.go
@@ -53,10 +53,8 @@ type Pineapple struct {
 	vpipTracked     []bool
 	pfrTracked      []bool
 	threeBetTracked []bool
-	handCount       int
+	tournamentBase  // handCount / rebuyCounts / addonUsed (issue #1463)
 	lastCpuError    error
-	rebuyCounts     []int
-	addonUsed       []bool
 	rebuyPhaseType  int
 	actionLog       []*ActionLogEntry
 	humanProfile    *BettingHumanProfile
@@ -66,7 +64,7 @@ type Pineapple struct {
 
 // NewPineapple コンストラクタ
 func NewPineapple(trumpCards *TrumpCards, players []*PineapplePlayer, config PineappleConfig) *Pineapple {
-	return &Pineapple{
+	p := &Pineapple{
 		communityCardBettingBase: communityCardBettingBase{
 			actedFlags: make([]bool, len(players)),
 		},
@@ -80,12 +78,12 @@ func NewPineapple(trumpCards *TrumpCards, players []*PineapplePlayer, config Pin
 		vpipTracked:     make([]bool, len(players)),
 		pfrTracked:      make([]bool, len(players)),
 		threeBetTracked: make([]bool, len(players)),
-		rebuyCounts:     make([]int, len(players)),
-		addonUsed:       make([]bool, len(players)),
 		discardDone:     make([]bool, len(players)),
 		config:          config,
 		phase:           PineapplePhaseInit,
 	}
+	p.initTournamentState(len(players))
+	return p
 }
 
 // NewDefaultPineapple returns Pineapple with the default table size and
@@ -1221,8 +1219,6 @@ func (p *Pineapple) Resize(players []*PineapplePlayer) {
 	p.vpipTracked = make([]bool, n)
 	p.pfrTracked = make([]bool, n)
 	p.threeBetTracked = make([]bool, n)
-	p.rebuyCounts = make([]int, n)
-	p.addonUsed = make([]bool, n)
 	p.discardDone = make([]bool, n)
-	p.handCount = 0
+	p.initTournamentState(n)
 }

--- a/internal/domain/SevenCardStud.go
+++ b/internal/domain/SevenCardStud.go
@@ -75,10 +75,8 @@ type SevenCardStud struct {
 	vpipTracked      []bool
 	pfrTracked       []bool
 	threeBetTracked  []bool
-	handCount        int
+	tournamentBase   // handCount / rebuyCounts / addonUsed (issue #1463)
 	lastCpuError     error
-	rebuyCounts      []int
-	addonUsed        []bool
 	rebuyPhaseType   int
 	actionLog        []*ActionLogEntry
 	humanProfile     *BettingHumanProfile
@@ -90,7 +88,7 @@ type SevenCardStud struct {
 // NewSevenCardStud コンストラクタ
 func NewSevenCardStud(trumpCards *TrumpCards, players []*SevenCardStudPlayer, config SevenCardStudConfig) *SevenCardStud {
 	n := len(players)
-	return &SevenCardStud{
+	s := &SevenCardStud{
 		trumpCards:       trumpCards,
 		players:          players,
 		sidePots:         make([]SidePot, 0),
@@ -101,12 +99,12 @@ func NewSevenCardStud(trumpCards *TrumpCards, players []*SevenCardStudPlayer, co
 		vpipTracked:      make([]bool, n),
 		pfrTracked:       make([]bool, n),
 		threeBetTracked:  make([]bool, n),
-		rebuyCounts:      make([]int, n),
-		addonUsed:        make([]bool, n),
 		config:           config,
 		phase:            SevenCardStudPhaseInit,
 		bringInPlayerIdx: -1,
 	}
+	s.initTournamentState(n)
+	return s
 }
 
 // NewRazz Razz (A-5 ローボール) コンストラクタ
@@ -992,9 +990,7 @@ func (s *SevenCardStud) Resize(players []*SevenCardStudPlayer) {
 	s.vpipTracked = make([]bool, n)
 	s.pfrTracked = make([]bool, n)
 	s.threeBetTracked = make([]bool, n)
-	s.rebuyCounts = make([]int, n)
-	s.addonUsed = make([]bool, n)
-	s.handCount = 0
+	s.initTournamentState(n)
 }
 
 // --- JSON ---

--- a/internal/domain/ShortDeck.go
+++ b/internal/domain/ShortDeck.go
@@ -53,10 +53,8 @@ type ShortDeck struct {
 	vpipTracked     []bool
 	pfrTracked      []bool
 	threeBetTracked []bool
-	handCount       int
+	tournamentBase  // handCount / rebuyCounts / addonUsed (issue #1463)
 	lastCpuError    error
-	rebuyCounts     []int
-	addonUsed       []bool
 	rebuyPhaseType  int
 	actionLog       []*ActionLogEntry
 	humanProfile    *BettingHumanProfile
@@ -65,7 +63,7 @@ type ShortDeck struct {
 
 // NewShortDeck コンストラクタ
 func NewShortDeck(trumpCards *TrumpCards, players []*ShortDeckPlayer, config ShortDeckConfig) *ShortDeck {
-	return &ShortDeck{
+	sd := &ShortDeck{
 		communityCardBettingBase: communityCardBettingBase{
 			actedFlags: make([]bool, len(players)),
 		},
@@ -79,11 +77,11 @@ func NewShortDeck(trumpCards *TrumpCards, players []*ShortDeckPlayer, config Sho
 		vpipTracked:     make([]bool, len(players)),
 		pfrTracked:      make([]bool, len(players)),
 		threeBetTracked: make([]bool, len(players)),
-		rebuyCounts:     make([]int, len(players)),
-		addonUsed:       make([]bool, len(players)),
 		config:          config,
 		phase:           ShortDeckPhaseInit,
 	}
+	sd.initTournamentState(len(players))
+	return sd
 }
 
 // NewDefaultShortDeck returns ShortDeck with the default table size and
@@ -1407,7 +1405,5 @@ func (sd *ShortDeck) Resize(players []*ShortDeckPlayer) {
 	sd.vpipTracked = make([]bool, n)
 	sd.pfrTracked = make([]bool, n)
 	sd.threeBetTracked = make([]bool, n)
-	sd.rebuyCounts = make([]int, n)
-	sd.addonUsed = make([]bool, n)
-	sd.handCount = 0
+	sd.initTournamentState(n)
 }

--- a/internal/domain/interfaces/fortythieves.go
+++ b/internal/domain/interfaces/fortythieves.go
@@ -4,7 +4,7 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 
 // FortyThievesGame フォーティシーブスゲームインタフェース
 type FortyThievesGame interface {
-	BaseGame
+	SolitaireGame
 	// Reset ゲームを初期化する
 	Reset()
 	// Draw 山札からカードをめくる
@@ -17,21 +17,8 @@ type FortyThievesGame interface {
 	MoveTableauToTableau(fromCol, cardIndex, toCol int) error
 	// MoveTableauToFoundation タブローからファンデーションにカードを移動する
 	MoveTableauToFoundation(col int) error
-	// GiveUp ギブアップする
-	GiveUp()
 	// GetHint ヒントを取得する
 	GetHint() *domain.FortyThievesHint
-	// AutoComplete 自動完了を実行する
-	AutoComplete() error
-	// Undo 操作を元に戻す
-	Undo() error
-
-	// CanUndo 元に戻す操作が可能かを返す
-	CanUndo() bool
-	// UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す
-	UndoToEscape() int
-	// UndoN n回連続でアンドゥを実行する
-	UndoN(n int) error
 	// GetPhase 現在のフェーズを取得する
 	GetPhase() domain.FortyThievesPhase
 	// GetMoveCount 移動回数を取得する

--- a/internal/domain/interfaces/freecell.go
+++ b/internal/domain/interfaces/freecell.go
@@ -4,7 +4,7 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 
 // FreeCellGame フリーセルゲームインタフェース
 type FreeCellGame interface {
-	BaseGame
+	SolitaireGame
 	// Reset ゲームを初期化する
 	Reset()
 	// MoveTableauToTableau タブロー間でカードを移動する
@@ -17,21 +17,8 @@ type FreeCellGame interface {
 	MoveFreeCellToTableau(cell, col int) error
 	// MoveFreeCellToFoundation フリーセルからファンデーションにカードを移動する
 	MoveFreeCellToFoundation(cell int) error
-	// GiveUp ギブアップする
-	GiveUp()
 	// GetHint ヒントを取得する
 	GetHint() *domain.FreeCellHint
-	// AutoComplete 自動完了を実行する
-	AutoComplete() error
-	// Undo 操作を元に戻す
-	Undo() error
-
-	// CanUndo 元に戻す操作が可能かを返す
-	CanUndo() bool
-	// UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す
-	UndoToEscape() int
-	// UndoN n回連続でアンドゥを実行する
-	UndoN(n int) error
 	// GetPhase 現在のフェーズを取得する
 	GetPhase() domain.FreeCellPhase
 	// GetMoveCount 移動回数を取得する

--- a/internal/domain/interfaces/klondike.go
+++ b/internal/domain/interfaces/klondike.go
@@ -4,7 +4,7 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 
 // KlondikeGame クロンダイクゲームインタフェース
 type KlondikeGame interface {
-	BaseGame
+	SolitaireGame
 	// Reset ゲームを初期化する
 	Reset()
 	// ResetWithConfig 指定設定でゲームを初期化する
@@ -19,21 +19,8 @@ type KlondikeGame interface {
 	MoveTableauToTableau(fromCol, cardIndex, toCol int) error
 	// MoveTableauToFoundation タブローからファンデーションにカードを移動する
 	MoveTableauToFoundation(col int) error
-	// GiveUp ギブアップする
-	GiveUp()
 	// GetHint ヒントを取得する
 	GetHint() *domain.KlondikeHint
-	// AutoComplete 自動完了を実行する
-	AutoComplete() error
-	// Undo 操作を元に戻す
-	Undo() error
-
-	// CanUndo 元に戻す操作が可能かを返す
-	CanUndo() bool
-	// UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す
-	UndoToEscape() int
-	// UndoN n回連続でアンドゥを実行する
-	UndoN(n int) error
 	// GetPhase 現在のフェーズを取得する
 	GetPhase() domain.KlondikePhase
 	// GetMoveCount 移動回数を取得する

--- a/internal/domain/interfaces/scorpion.go
+++ b/internal/domain/interfaces/scorpion.go
@@ -4,27 +4,15 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 
 // ScorpionGame スコーピオンゲームインタフェース
 type ScorpionGame interface {
-	BaseGame
+	SolitaireGame
 	// Reset ゲームを初期化する
 	Reset()
 	// Deal ストックから先頭3列にカードを配る
 	Deal() error
 	// MoveTableauToTableau タブロー間でカードを移動する
 	MoveTableauToTableau(fromCol, cardIndex, toCol int) error
-	// GiveUp ギブアップする
-	GiveUp()
 	// GetHint ヒントを取得する
 	GetHint() *domain.ScorpionHint
-	// AutoComplete 自動完了を実行する
-	AutoComplete() error
-	// Undo 操作を元に戻す
-	Undo() error
-	// CanUndo 元に戻す操作が可能かを返す
-	CanUndo() bool
-	// UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す
-	UndoToEscape() int
-	// UndoN n回連続でアンドゥを実行する
-	UndoN(n int) error
 	// GetPhase 現在のフェーズを取得する
 	GetPhase() domain.ScorpionPhase
 	// GetMoveCount 移動回数を取得する

--- a/internal/domain/interfaces/solitaire.go
+++ b/internal/domain/interfaces/solitaire.go
@@ -1,14 +1,6 @@
 package interfaces
 
-// SolitaireGame groups the methods shared by the solitaire-family interfaces
-// (Klondike, Spider, FreeCell, FortyThieves, Yukon, Scorpion). Extracted per
-// issue #1461 to reduce duplication across the 10+ solitaire interfaces.
-//
-// Games missing one of these methods (e.g. Pyramid has no AutoComplete,
-// Canfield has no UndoToEscape) do not embed SolitaireGame — they keep
-// their current method lists. Adding a partial-SolitaireGame variant would
-// introduce combinatorial interface sprawl without clear benefit, so the
-// pragmatic choice is "embed when the full set applies".
+// SolitaireGame groups the undo/give-up/autocomplete methods shared by solitaire-family interfaces.
 type SolitaireGame interface {
 	BaseGame
 	// GiveUp marks the current game as abandoned.

--- a/internal/domain/interfaces/solitaire.go
+++ b/internal/domain/interfaces/solitaire.go
@@ -1,0 +1,27 @@
+package interfaces
+
+// SolitaireGame groups the methods shared by the solitaire-family interfaces
+// (Klondike, Spider, FreeCell, FortyThieves, Yukon, Scorpion). Extracted per
+// issue #1461 to reduce duplication across the 10+ solitaire interfaces.
+//
+// Games missing one of these methods (e.g. Pyramid has no AutoComplete,
+// Canfield has no UndoToEscape) do not embed SolitaireGame — they keep
+// their current method lists. Adding a partial-SolitaireGame variant would
+// introduce combinatorial interface sprawl without clear benefit, so the
+// pragmatic choice is "embed when the full set applies".
+type SolitaireGame interface {
+	BaseGame
+	// GiveUp marks the current game as abandoned.
+	GiveUp()
+	// Undo reverses the last move; returns an error if nothing can be undone.
+	Undo() error
+	// CanUndo reports whether at least one move is available to undo.
+	CanUndo() bool
+	// UndoN reverses the last n moves; no-ops past the head of the history.
+	UndoN(n int) error
+	// UndoToEscape returns the number of undos required to escape a stalemate.
+	UndoToEscape() int
+	// AutoComplete runs the auto-complete routine when the board is trivially
+	// solvable (all cards face-up, no blocking moves).
+	AutoComplete() error
+}

--- a/internal/domain/interfaces/spider.go
+++ b/internal/domain/interfaces/spider.go
@@ -4,7 +4,7 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 
 // SpiderGame スパイダーソリティアゲームインタフェース
 type SpiderGame interface {
-	BaseGame
+	SolitaireGame
 	// Reset ゲームを初期化する
 	Reset()
 	// ResetWithConfig 指定設定でゲームを初期化する
@@ -13,21 +13,8 @@ type SpiderGame interface {
 	Deal() error
 	// MoveTableauToTableau タブロー間でカードを移動する
 	MoveTableauToTableau(fromCol, cardIndex, toCol int) error
-	// GiveUp ギブアップする
-	GiveUp()
 	// GetHint ヒントを取得する
 	GetHint() *domain.SpiderHint
-	// AutoComplete 自動完了を実行する
-	AutoComplete() error
-	// Undo 操作を元に戻す
-	Undo() error
-
-	// CanUndo 元に戻す操作が可能かを返す
-	CanUndo() bool
-	// UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す
-	UndoToEscape() int
-	// UndoN n回連続でアンドゥを実行する
-	UndoN(n int) error
 	// GetPhase 現在のフェーズを取得する
 	GetPhase() domain.SpiderPhase
 	// GetMoveCount 移動回数を取得する

--- a/internal/domain/interfaces/yukon.go
+++ b/internal/domain/interfaces/yukon.go
@@ -4,27 +4,15 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 
 // YukonGame ユーコンゲームインタフェース
 type YukonGame interface {
-	BaseGame
+	SolitaireGame
 	// Reset ゲームを初期化する
 	Reset()
 	// MoveTableauToTableau タブロー間でカードを移動する
 	MoveTableauToTableau(fromCol, cardIndex, toCol int) error
 	// MoveTableauToFoundation タブローからファンデーションにカードを移動する
 	MoveTableauToFoundation(col int) error
-	// GiveUp ギブアップする
-	GiveUp()
 	// GetHint ヒントを取得する
 	GetHint() *domain.YukonHint
-	// AutoComplete 自動完了を実行する
-	AutoComplete() error
-	// Undo 操作を元に戻す
-	Undo() error
-	// CanUndo 元に戻す操作が可能かを返す
-	CanUndo() bool
-	// UndoToEscape 膠着状態から抜けるために必要なアンドゥ回数を返す
-	UndoToEscape() int
-	// UndoN n回連続でアンドゥを実行する
-	UndoN(n int) error
 	// GetPhase 現在のフェーズを取得する
 	GetPhase() domain.YukonPhase
 	// GetMoveCount 移動回数を取得する

--- a/internal/domain/tournament_base.go
+++ b/internal/domain/tournament_base.go
@@ -1,0 +1,31 @@
+package domain
+
+// tournamentBase groups the rebuy/addon/handCount state shared by the
+// tournament-mode poker variants (Holdem, Omaha, ShortDeck, Pineapple,
+// SevenCardStud). Extracted per issue #1463 so rule changes to tournament
+// mechanics (e.g. a new maximum rebuy rule) can be made in one place.
+//
+// Usage: embed in a poker domain struct so the three fields promote onto
+// the outer type. Call initTournamentState(playerCount) from the
+// constructor and from any Resize that changes the player count — both
+// rebuy/addon slices need to match len(players) or index accesses panic.
+//
+// Migration is deliberately incremental: each game can adopt the
+// embedding independently because promoted-field access leaves existing
+// h.handCount / h.rebuyCounts / h.addonUsed call sites unchanged. The
+// JSON snapshot shape is preserved as long as the owning struct declares
+// its own exported fields for HandCount/RebuyCounts/AddonUsed (they all
+// currently do), so no Marshal/Unmarshal rework is required.
+type tournamentBase struct {
+	rebuyCounts []int  // プレイヤーごとのリバイ回数
+	addonUsed   []bool // プレイヤーごとのアドオン使用フラグ
+	handCount   int    // ハンド数 (トーナメントモード用)
+}
+
+// initTournamentState reinitialises the tournament slices for playerCount.
+// Safe to call on a zero-value tournamentBase; resets handCount to 0.
+func (t *tournamentBase) initTournamentState(playerCount int) {
+	t.rebuyCounts = make([]int, playerCount)
+	t.addonUsed = make([]bool, playerCount)
+	t.handCount = 0
+}

--- a/internal/domain/tournament_base.go
+++ b/internal/domain/tournament_base.go
@@ -1,21 +1,6 @@
 package domain
 
-// tournamentBase groups the rebuy/addon/handCount state shared by the
-// tournament-mode poker variants (Holdem, Omaha, ShortDeck, Pineapple,
-// SevenCardStud). Extracted per issue #1463 so rule changes to tournament
-// mechanics (e.g. a new maximum rebuy rule) can be made in one place.
-//
-// Usage: embed in a poker domain struct so the three fields promote onto
-// the outer type. Call initTournamentState(playerCount) from the
-// constructor and from any Resize that changes the player count — both
-// rebuy/addon slices need to match len(players) or index accesses panic.
-//
-// Migration is deliberately incremental: each game can adopt the
-// embedding independently because promoted-field access leaves existing
-// h.handCount / h.rebuyCounts / h.addonUsed call sites unchanged. The
-// JSON snapshot shape is preserved as long as the owning struct declares
-// its own exported fields for HandCount/RebuyCounts/AddonUsed (they all
-// currently do), so no Marshal/Unmarshal rework is required.
+// tournamentBase holds the rebuy/addon/handCount state shared by tournament-mode poker variants.
 type tournamentBase struct {
 	rebuyCounts []int  // プレイヤーごとのリバイ回数
 	addonUsed   []bool // プレイヤーごとのアドオン使用フラグ

--- a/internal/infrastructure/games/binding.go
+++ b/internal/infrastructure/games/binding.go
@@ -4,17 +4,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 )
 
-// WebBinding captures the ingredients needed to wire a game into the HTTP
-// server in a single declaration. One WebBinding value replaces the four
-// arguments previously passed to BindWebControllerFor, so a game can
-// express its server-side registration once — near the game's own code if
-// desired — instead of as a multi-line closure inside games_server.go.
-// See issue #1458 for the motivation.
-//
-// Type parameters:
-//   - I — the interactor interface (e.g. usecase.BlackJackInteractorIF)
-//   - P — the web input struct (e.g. BlackJackWebInput)
-//   - O — the web output struct pointer (e.g. *BlackJackWebOutput)
+// WebBinding captures the ingredients needed to wire a game into the HTTP server in a single declaration.
 type WebBinding[I any, P controller.WebInput, O any] struct {
 	// Name is the canonical short name — must match an entry in registry.
 	Name string

--- a/internal/infrastructure/games/binding.go
+++ b/internal/infrastructure/games/binding.go
@@ -1,0 +1,35 @@
+package games
+
+import (
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
+)
+
+// WebBinding captures the ingredients needed to wire a game into the HTTP
+// server in a single declaration. One WebBinding value replaces the four
+// arguments previously passed to BindWebControllerFor, so a game can
+// express its server-side registration once — near the game's own code if
+// desired — instead of as a multi-line closure inside games_server.go.
+// See issue #1458 for the motivation.
+//
+// Type parameters:
+//   - I — the interactor interface (e.g. usecase.BlackJackInteractorIF)
+//   - P — the web input struct (e.g. BlackJackWebInput)
+//   - O — the web output struct pointer (e.g. *BlackJackWebOutput)
+type WebBinding[I any, P controller.WebInput, O any] struct {
+	// Name is the canonical short name — must match an entry in registry.
+	Name string
+
+	// NewInteractor produces a fresh interactor bound to a fresh presenter.
+	NewInteractor func() I
+
+	// NewController is the NewXxxWebController (in-memory session) variant.
+	NewController func(func() I) *controller.GameWebController[I, P, O]
+}
+
+// Bind registers this binding as the server-side factory for the named
+// game. Panics via BindWebController if Name is not a known game.
+func (b WebBinding[I, P, O]) Bind() {
+	BindWebController(b.Name, func() WebController {
+		return b.NewController(b.NewInteractor)
+	})
+}

--- a/internal/infrastructure/games/classic/classic.go
+++ b/internal/infrastructure/games/classic/classic.go
@@ -183,12 +183,18 @@ func init() {
 			return usecase.RestorePageOneInteractor(data, new(presenter.PageOneWebPresenter))
 		},
 		controller.NewPageOneWebControllerWithProvider)
-	games.RegisterKVGame("trash", games.CategoryClassic,
-		func() usecase.TrashInteractorIF {
+	// Proof-of-concept migration to the issue #1458 WorkerBinding pattern.
+	// The remaining games can be migrated incrementally without breaking
+	// the mixed use of Bind()/RegisterKVGame.
+	games.WorkerBinding[usecase.TrashInteractorIF, controller.TrashWebInput, *controller.TrashWebOutput]{
+		Name:     "trash",
+		Category: games.CategoryClassic,
+		NewInteractor: func() usecase.TrashInteractorIF {
 			return usecase.NewTrashInteractor(domain.NewDefaultTrash(), new(presenter.TrashWebPresenter))
 		},
-		func(data []byte) (usecase.TrashInteractorIF, error) {
+		RestoreInteractor: func(data []byte) (usecase.TrashInteractorIF, error) {
 			return usecase.RestoreTrashInteractor(data, new(presenter.TrashWebPresenter))
 		},
-		controller.NewTrashWebControllerWithProvider)
+		NewControllerWithProvider: controller.NewTrashWebControllerWithProvider,
+	}.Bind()
 }

--- a/internal/infrastructure/games/games_server.go
+++ b/internal/infrastructure/games/games_server.go
@@ -298,9 +298,14 @@ func init() {
 			return usecase.NewAccordionInteractor(domain.NewDefaultAccordion(), new(presenter.AccordionWebPresenter))
 		},
 		controller.NewAccordionWebController)
-	BindWebControllerFor("trash",
-		func() usecase.TrashInteractorIF {
+	// Proof-of-concept migration to the issue #1458 WebBinding pattern.
+	// The remaining games can be migrated incrementally without breaking
+	// the mixed use of Bind()/BindWebControllerFor.
+	WebBinding[usecase.TrashInteractorIF, controller.TrashWebInput, *controller.TrashWebOutput]{
+		Name: "trash",
+		NewInteractor: func() usecase.TrashInteractorIF {
 			return usecase.NewTrashInteractor(domain.NewDefaultTrash(), new(presenter.TrashWebPresenter))
 		},
-		controller.NewTrashWebController)
+		NewController: controller.NewTrashWebController,
+	}.Bind()
 }

--- a/internal/infrastructure/games/registry.go
+++ b/internal/infrastructure/games/registry.go
@@ -30,7 +30,10 @@ const (
 	CategorySolo
 )
 
-// String returns the lowercase worker name (casino/classic/solo).
+// String returns the lowercase worker name (casino/classic/solo). Panics on
+// an unknown value — consistent with BindWebController/BindWorker, which also
+// panic on API misuse. A silent fallback would mask bugs such as reading an
+// uninitialised Category or forgetting a case after adding a new value.
 func (c Category) String() string {
 	switch c {
 	case CategoryCasino:
@@ -39,8 +42,9 @@ func (c Category) String() string {
 		return "classic"
 	case CategorySolo:
 		return "solo"
+	default:
+		panic(fmt.Sprintf("games: unknown Category %d", int(c)))
 	}
-	return fmt.Sprintf("Category(%d)", int(c))
 }
 
 // WebController is the minimal handler interface implemented by every

--- a/internal/infrastructure/games/registry_test.go
+++ b/internal/infrastructure/games/registry_test.go
@@ -1,6 +1,7 @@
 package games
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/ui"
@@ -65,13 +66,24 @@ func TestCategoryString(t *testing.T) {
 		CategoryCasino:  "casino",
 		CategoryClassic: "classic",
 		CategorySolo:    "solo",
-		Category(99):    "Category(99)",
 	}
 	for cat, want := range cases {
 		if got := cat.String(); got != want {
 			t.Errorf("Category(%d).String() = %q, want %q", int(cat), got, want)
 		}
 	}
+}
+
+// TestCategoryStringPanicsOnUnknown asserts that String() panics on an
+// undefined Category value so API misuse surfaces immediately — matching
+// BindWebController/BindWorker's panic-on-misuse policy.
+func TestCategoryStringPanicsOnUnknown(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on unknown Category, got none")
+		}
+	}()
+	_ = Category(99).String()
 }
 
 func TestAllEntriesAreValid(t *testing.T) {
@@ -112,6 +124,18 @@ func TestRegistryMatchesCLI(t *testing.T) {
 	for i, name := range cliNames {
 		if all[i].Name != name {
 			t.Errorf("order mismatch at index %d: CLI=%q, registry=%q", i, name, all[i].Name)
+		}
+	}
+}
+
+// TestCLIRegistryHasDescriptionForEach asserts that every CLI gameRegistry
+// entry carries a non-empty Description. Empty descriptions are a common
+// drift symptom: someone copy-pastes a new entry, forgets to fill it, and
+// the CLI silently ships a blank name in its listings.
+func TestCLIRegistryHasDescriptionForEach(t *testing.T) {
+	for name, desc := range ui.GameDescriptions() {
+		if strings.TrimSpace(desc) == "" {
+			t.Errorf("game %q has empty Description in ui.gameRegistry", name)
 		}
 	}
 }

--- a/internal/infrastructure/games/worker_binding.go
+++ b/internal/infrastructure/games/worker_binding.go
@@ -7,14 +7,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/worker"
 )
 
-// WorkerBinding captures the ingredients needed to wire a game into a
-// Cloudflare Worker. Lives under the js && wasm build tag because the
-// SnapshotIF constraint comes from the worker package, which is only
-// available when building Cloudflare Worker binaries.
-//
-// A game's per-category file (casino/classic/solo.go) can construct a
-// WorkerBinding and call Bind() to replace the multi-line
-// RegisterKVGame call with a single declaration. See issue #1458.
+// WorkerBinding captures the ingredients needed to wire a game into a Cloudflare Worker.
 type WorkerBinding[I worker.SnapshotIF, P controller.WebInput, O any] struct {
 	Name     string
 	Category Category

--- a/internal/infrastructure/games/worker_binding.go
+++ b/internal/infrastructure/games/worker_binding.go
@@ -1,0 +1,41 @@
+//go:build js && wasm
+
+package games
+
+import (
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/worker"
+)
+
+// WorkerBinding captures the ingredients needed to wire a game into a
+// Cloudflare Worker. Lives under the js && wasm build tag because the
+// SnapshotIF constraint comes from the worker package, which is only
+// available when building Cloudflare Worker binaries.
+//
+// A game's per-category file (casino/classic/solo.go) can construct a
+// WorkerBinding and call Bind() to replace the multi-line
+// RegisterKVGame call with a single declaration. See issue #1458.
+type WorkerBinding[I worker.SnapshotIF, P controller.WebInput, O any] struct {
+	Name     string
+	Category Category
+
+	// NewInteractor produces a fresh interactor bound to a fresh presenter
+	// (used when no prior KV state exists for this session).
+	NewInteractor func() I
+
+	// RestoreInteractor rehydrates an interactor from serialised KV state.
+	RestoreInteractor func(data []byte) (I, error)
+
+	// NewControllerWithProvider is the NewXxxWebControllerWithProvider
+	// (KV-session) variant the worker uses to inject a session provider.
+	NewControllerWithProvider func(
+		controller.SessionProvider[I], func() I,
+	) *controller.GameWebController[I, P, O]
+}
+
+// Bind registers this binding via RegisterKVGame. Panics via BindWorker if
+// Name is unknown or Category does not match the registry.
+func (b WorkerBinding[I, P, O]) Bind() {
+	RegisterKVGame(b.Name, b.Category,
+		b.NewInteractor, b.RestoreInteractor, b.NewControllerWithProvider)
+}

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -88,19 +88,13 @@ var gameRegistry = []GameRegistryEntry{
 			})
 	}},
 	{Name: "sevens", Description: "Sevens (7並べ)", NewCui: func() cuiGame {
-		return newCuiGame(
+		return cuiEntry(
 			controller.NewSevensCuiController(usecase.NewSevensInteractor(
 				domain.NewDefaultSevens(), new(presenter.SevensCuiPresenter))),
-			[]string{
-				i18n.T("sevens.helpTitle"),
-				"",
-				i18n.T("gameCommands"),
-				i18n.T("sevens.helpPlay"),
-				"",
-				i18n.T("session"),
-				"  r [tunnel] [joker=N] [strategy] [passes=N]  reset with options",
-				i18n.T("quitEntry"),
-				i18n.T("helpEntry"),
+			CuiHelpSpec{
+				TitleKey:      "sevens.helpTitle",
+				CommandKeys:   []string{"sevens.helpPlay"},
+				ResetOverride: "  r [tunnel] [joker=N] [strategy] [passes=N]  reset with options",
 			})
 	}},
 	{Name: "doubt", Description: "Doubt (ダウト)", NewCui: func() cuiGame { return NewDoubtCui() }},

--- a/internal/infrastructure/ui/help_text.go
+++ b/internal/infrastructure/ui/help_text.go
@@ -21,6 +21,12 @@ type CuiHelpSpec struct {
 	// ExtraSettingLines are literal lines appended after SettingKeys in the
 	// settings section. Used for settings not yet in i18n.
 	ExtraSettingLines []string
+	// ResetOverride, when non-empty, replaces the default i18n.T("resetEntry")
+	// line in the session section. Used by games whose reset command accepts
+	// options (e.g. Sevens: "r [tunnel] [joker=N] [strategy] [passes=N]").
+	// Extracted per issue #1460 so such games can use the standard template
+	// instead of bypassing BuildCuiHelp with a raw []string.
+	ResetOverride string
 }
 
 // BuildCuiHelp assembles standard CUI help text from spec. Order:
@@ -45,10 +51,14 @@ func BuildCuiHelp(spec CuiHelpSpec) []string {
 		}
 		lines = append(lines, spec.ExtraSettingLines...)
 	}
+	resetLine := i18n.T("resetEntry")
+	if spec.ResetOverride != "" {
+		resetLine = spec.ResetOverride
+	}
 	lines = append(lines,
 		"",
 		i18n.T("session"),
-		i18n.T("resetEntry"),
+		resetLine,
 		i18n.T("quitEntry"),
 		i18n.T("helpEntry"),
 	)


### PR DESCRIPTION
## Summary

Bundled refactor addressing issues **#1458–#1464**. Three issues are complete; four are scaffolded POCs that can be finished in follow-up PRs.

### Complete

- **Closes #1464** — `Category.String()` panics on unknown values instead of returning a silent fallback, matching `BindWorker` / `BindWebController`'s panic-on-misuse policy.
- **Closes #1463** — extract `tournamentBase` holding `rebuyCounts` / `addonUsed` / `handCount`; migrate `Holdem`, `Omaha`, `ShortDeck`, `Pineapple`, and `SevenCardStud` to embed it.
- **Closes #1462** — add three dispatch helpers and migrate 20 controllers:
  - `dispatchResetStepLog` → War, ClockSolitaire (the only two with `Step()`)
  - `dispatchResetAndLog` → 9 plain-`Reset()` + log controllers (ThreeCard, PokerSquares, PaiGow, VideoPoker, Baccarat, RedDog, CaribbeanStud, LetItRide, Trash)
  - `dispatchResetHintAndLog` → 9 solitaire controllers (Accordion, TriPeaks, Pyramid, Yukon, FreeCell, Scorpion, FortyThieves, Canfield, Golf)
  - The 35 `ResetWithConfig(...)` controllers are **intentionally unchanged** — their config shapes differ per game, so a generic helper would not reduce lines.

### Partial (POCs — do not close)

- **#1461** — `SolitaireGame` interface extracted (embeds `BaseGame` + `GiveUp` / `Undo` / `CanUndo` / `UndoN` / `UndoToEscape` / `AutoComplete`). Klondike, Spider, FreeCell, FortyThieves, Yukon, Scorpion interfaces now embed it. The Interactor-layer helper (`solitaireActions[G]`) is not yet done.
- **#1458** — `WebBinding` / `WorkerBinding` generic types added. `trash` migrated as the reference. Remaining 57 games still use `BindWebControllerFor` / `RegisterKVGame`.
- **#1460** — `CuiHelpSpec.ResetOverride` added; `sevens` migrated off the legacy `newCuiGame([]string{...})` form. Other non-standard CUI entries remain.
- **#1459** — `TestCLIRegistryHasDescriptionForEach` added to catch empty `Description` entries in `ui.gameRegistry`.

### Stats

- 43 files changed, +460 / −221
- Controller coverage: **95.4%**
- `golangci-lint run ./...`: **0 issues**
- `go test -tags test ./...`: **all green**

## Test plan

- [ ] `go test -tags test ./...` — all packages green
- [ ] `golangci-lint run ./...` — 0 issues
- [ ] `go build ./...` — non-WASM build clean
- [ ] `make build-workers` — verify TinyGo still dead-code-eliminates per-category (trash moved to `WorkerBinding` shouldn't change the bundle footprint for `classic`)
- [ ] Manual smoke on War + ClockSolitaire + one of each dispatcher group (Baccarat, TriPeaks)