### PR TITLE
refactor: solitaireActions helper + TrickDisplay component (#1461, #1466)

### DIFF
--- a/frontend/src/components/TrickDisplay.test.tsx
+++ b/frontend/src/components/TrickDisplay.test.tsx
@@ -54,7 +54,7 @@ describe('TrickDisplay', () => {
     expect(screen.getByText('CPU 7')).toBeInTheDocument();
   });
 
-  it('forwards onCardDealComplete to each AnimatedCard', () => {
+  it('renders correctly when onCardDealComplete is provided', () => {
     const onDeal = vi.fn();
     render(
       <TrickDisplay currentTrick={trick} players={players} cardWidth={40} label="label" onCardDealComplete={onDeal} />,

--- a/frontend/src/components/TrickDisplay.test.tsx
+++ b/frontend/src/components/TrickDisplay.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { Card } from '../types/card';
+import { TrickDisplay, type TrickDisplayCard, type TrickDisplayPlayer } from './TrickDisplay';
+
+const card: Card = { design: 'SPADE', value: 1 };
+
+const players: TrickDisplayPlayer[] = [
+  { id: 0, isHuman: true },
+  { id: 1, isHuman: false },
+  { id: 2, isHuman: false },
+];
+
+const trick: TrickDisplayCard[] = [
+  { playerIdx: 0, card },
+  { playerIdx: 1, card: { design: 'HEART', value: 10 } },
+];
+
+describe('TrickDisplay', () => {
+  it('renders nothing when the trick is empty', () => {
+    const { container } = render(
+      <TrickDisplay currentTrick={[]} players={players} cardWidth={40} label="Current trick" />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders one card per trick entry with the label', () => {
+    render(<TrickDisplay currentTrick={trick} players={players} cardWidth={40} label="現在のトリック" />);
+    expect(screen.getByText('現在のトリック')).toBeInTheDocument();
+    expect(screen.getAllByTestId('animated-card')).toHaveLength(2);
+  });
+
+  it('resolves player display names from the players array', () => {
+    render(<TrickDisplay currentTrick={trick} players={players} cardWidth={40} label="label" />);
+    expect(screen.getByText('あなた')).toBeInTheDocument();
+    expect(screen.getByText('CPU 1')).toBeInTheDocument();
+  });
+
+  it('applies data-tutorial attribute when provided', () => {
+    const { container } = render(
+      <TrickDisplay
+        currentTrick={trick}
+        players={players}
+        cardWidth={40}
+        label="label"
+        dataTutorial="ht-trick-display"
+      />,
+    );
+    expect(container.querySelector('[data-tutorial="ht-trick-display"]')).toBeInTheDocument();
+  });
+
+  it('falls back to CPU label when player index is out of range', () => {
+    render(<TrickDisplay currentTrick={[{ playerIdx: 7, card }]} players={players} cardWidth={40} label="label" />);
+    expect(screen.getByText('CPU 7')).toBeInTheDocument();
+  });
+
+  it('forwards onCardDealComplete to each AnimatedCard', () => {
+    const onDeal = vi.fn();
+    render(
+      <TrickDisplay currentTrick={trick} players={players} cardWidth={40} label="label" onCardDealComplete={onDeal} />,
+    );
+    expect(screen.getAllByTestId('animated-card')).toHaveLength(2);
+  });
+});

--- a/frontend/src/components/TrickDisplay.tsx
+++ b/frontend/src/components/TrickDisplay.tsx
@@ -1,0 +1,67 @@
+import type { Card } from '../types/card';
+import { playerName } from '../utils/playerUtils';
+import { AnimatedCard } from './motion/AnimatedCard';
+
+/** One card played into the current trick. Matches all trick-taking game TrickCard shapes. */
+export interface TrickDisplayCard {
+  playerIdx: number;
+  card: Card;
+}
+
+/** Minimal player reference used for display-name resolution. */
+export interface TrickDisplayPlayer {
+  id: number;
+  isHuman: boolean;
+}
+
+/** Props for {@link TrickDisplay}. */
+export interface TrickDisplayProps {
+  /** Cards currently on the trick. When empty, the component renders nothing. */
+  currentTrick: TrickDisplayCard[];
+  /** All players; indexed by `trickCard.playerIdx`. */
+  players: TrickDisplayPlayer[];
+  /** Card width in px forwarded to {@link AnimatedCard}. */
+  cardWidth: number;
+  /** Localised label, e.g. `t('currentTrick')`. */
+  label: string;
+  /** Value for the `data-tutorial` attribute (e.g. `"ht-trick-display"`). */
+  dataTutorial?: string;
+  /** Forwarded to {@link AnimatedCard#onDealComplete}; typically plays a deal sound. */
+  onCardDealComplete?: () => void;
+}
+
+/**
+ * Shared trick-display area for trick-taking games (Hearts, Spades, Euchre, Bridge,
+ * Napoleon, OhHell, TwoTenJack, Whist). Renders each played card with the player's
+ * name underneath, or nothing when the trick is empty.
+ */
+export function TrickDisplay({
+  currentTrick,
+  players,
+  cardWidth,
+  label,
+  dataTutorial,
+  onCardDealComplete,
+}: TrickDisplayProps) {
+  if (currentTrick.length === 0) {
+    return null;
+  }
+  return (
+    <div className="my-3 p-3 rounded bg-black/40" data-tutorial={dataTutorial}>
+      <div className="text-ds-text-muted text-sm mb-1">{label}</div>
+      <div className="flex gap-2">
+        {currentTrick.map((trickCard) => (
+          <div key={`trick-${trickCard.playerIdx}`} className="text-center">
+            <AnimatedCard card={trickCard.card} width={cardWidth} onDealComplete={onCardDealComplete} />
+            <div className="text-game-text-muted text-xs mt-1">
+              {playerName(
+                players[trickCard.playerIdx]?.id ?? trickCard.playerIdx,
+                players[trickCard.playerIdx]?.isHuman ?? false,
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/BridgePage.tsx
+++ b/frontend/src/pages/BridgePage.tsx
@@ -15,6 +15,7 @@ import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { BridgeSkeleton } from '../components/skeleton/BridgeSkeleton';
+import { TrickDisplay } from '../components/TrickDisplay';
 import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
 import { CPU_DIFFICULTY_OPTIONS, useBridgeGame } from '../hooks/useBridgeGame';
@@ -327,28 +328,14 @@ function BridgePageContent() {
                 )}
 
                 {/* Current trick */}
-                {state.currentTrick.length > 0 && (
-                  <div className="my-3 p-3 rounded bg-black/40" data-tutorial="br-trick-display">
-                    <div className="text-ds-text-muted text-sm mb-1">{t('currentTrick')}</div>
-                    <div className="flex gap-2">
-                      {state.currentTrick.map((trickCard) => (
-                        <div key={`trick-${trickCard.playerIdx}`} className="text-center">
-                          <AnimatedCard
-                            card={trickCard.card}
-                            width={cardWidth}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                          />
-                          <div className="text-game-text-muted text-xs mt-1">
-                            {playerName(
-                              state.players[trickCard.playerIdx]?.id ?? trickCard.playerIdx,
-                              state.players[trickCard.playerIdx]?.isHuman ?? false,
-                            )}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
+                <TrickDisplay
+                  currentTrick={state.currentTrick}
+                  players={state.players}
+                  cardWidth={cardWidth}
+                  label={t('currentTrick')}
+                  dataTutorial="br-trick-display"
+                  onCardDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
+                />
 
                 {/* Dummy hand */}
                 {state.openingLeadDone && state.dummyHand && state.dummyHand.length > 0 && (

--- a/frontend/src/pages/EuchrePage.tsx
+++ b/frontend/src/pages/EuchrePage.tsx
@@ -16,6 +16,7 @@ import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { EuchreSkeleton } from '../components/skeleton/EuchreSkeleton';
+import { TrickDisplay } from '../components/TrickDisplay';
 import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -312,28 +313,14 @@ function EuchrePageContent() {
                 )}
 
                 {/* Current trick */}
-                {state.currentTrick.length > 0 && (
-                  <div className="my-3 p-3 rounded bg-black/40" data-tutorial="eu-trick-display">
-                    <div className="text-ds-text-muted text-sm mb-1">{t('currentTrick')}</div>
-                    <div className="flex gap-2">
-                      {state.currentTrick.map((trickCard) => (
-                        <div key={`trick-${trickCard.playerIdx}`} className="text-center">
-                          <AnimatedCard
-                            card={trickCard.card}
-                            width={cardWidth}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                          />
-                          <div className="text-game-text-muted text-xs mt-1">
-                            {playerName(
-                              state.players[trickCard.playerIdx]?.id ?? trickCard.playerIdx,
-                              state.players[trickCard.playerIdx]?.isHuman ?? false,
-                            )}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
+                <TrickDisplay
+                  currentTrick={state.currentTrick}
+                  players={state.players}
+                  cardWidth={cardWidth}
+                  label={t('currentTrick')}
+                  dataTutorial="eu-trick-display"
+                  onCardDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
+                />
 
                 {/* Partnership info */}
                 {humanPlayer && (

--- a/frontend/src/pages/HeartsPage.tsx
+++ b/frontend/src/pages/HeartsPage.tsx
@@ -10,10 +10,10 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { PlayerHandSection } from '../components/PlayerHandSection';
 import { RoundScoreAnnouncement } from '../components/RoundScoreAnnouncement';
 import { HeartsSkeleton } from '../components/skeleton/HeartsSkeleton';
+import { TrickDisplay } from '../components/TrickDisplay';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
@@ -271,28 +271,14 @@ function HeartsPageContent() {
                 )}
 
                 {/* Current trick */}
-                {state.currentTrick.length > 0 && (
-                  <div className="my-3 p-3 rounded bg-black/40" data-tutorial="ht-trick-display">
-                    <div className="text-ds-text-muted text-sm mb-1">{t('currentTrick')}</div>
-                    <div className="flex gap-2">
-                      {state.currentTrick.map((trickCard) => (
-                        <div key={`trick-${trickCard.playerIdx}`} className="text-center">
-                          <AnimatedCard
-                            card={trickCard.card}
-                            width={cardWidth}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                          />
-                          <div className="text-game-text-muted text-xs mt-1">
-                            {playerName(
-                              state.players[trickCard.playerIdx]?.id ?? trickCard.playerIdx,
-                              state.players[trickCard.playerIdx]?.isHuman ?? false,
-                            )}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
+                <TrickDisplay
+                  currentTrick={state.currentTrick}
+                  players={state.players}
+                  cardWidth={cardWidth}
+                  label={t('currentTrick')}
+                  dataTutorial="ht-trick-display"
+                  onCardDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
+                />
               </div>
 
               {/* Right: info sidebar */}

--- a/frontend/src/pages/NapoleonPage.tsx
+++ b/frontend/src/pages/NapoleonPage.tsx
@@ -19,6 +19,7 @@ import { PhaseIndicator } from '../components/PhaseIndicator';
 import { RoundScoreAnnouncement } from '../components/RoundScoreAnnouncement';
 import { ScrollFadeHint } from '../components/ScrollFadeHint';
 import { NapoleonSkeleton } from '../components/skeleton/NapoleonSkeleton';
+import { TrickDisplay } from '../components/TrickDisplay';
 import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -356,28 +357,14 @@ function NapoleonPageContent() {
                 )}
 
                 {/* Current trick */}
-                {state.currentTrick.length > 0 && (
-                  <div className="my-3 p-3 rounded bg-black/40" data-tutorial="np-trick-display">
-                    <div className="text-ds-text-muted text-sm mb-1">{t('currentTrick')}</div>
-                    <div className="flex gap-2">
-                      {state.currentTrick.map((trickCard) => (
-                        <div key={`trick-${trickCard.playerIdx}`} className="text-center">
-                          <AnimatedCard
-                            card={trickCard.card}
-                            width={cardWidth}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                          />
-                          <div className="text-game-text-muted text-xs mt-1">
-                            {playerName(
-                              state.players[trickCard.playerIdx]?.id ?? trickCard.playerIdx,
-                              state.players[trickCard.playerIdx]?.isHuman ?? false,
-                            )}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
+                <TrickDisplay
+                  currentTrick={state.currentTrick}
+                  players={state.players}
+                  cardWidth={cardWidth}
+                  label={t('currentTrick')}
+                  dataTutorial="np-trick-display"
+                  onCardDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
+                />
               </div>
 
               {/* Right: info sidebar */}

--- a/frontend/src/pages/OhHellPage.tsx
+++ b/frontend/src/pages/OhHellPage.tsx
@@ -19,6 +19,7 @@ import { PhaseIndicator } from '../components/PhaseIndicator';
 import { RoundScoreAnnouncement } from '../components/RoundScoreAnnouncement';
 import { ScrollFadeHint } from '../components/ScrollFadeHint';
 import { OhHellSkeleton } from '../components/skeleton/OhHellSkeleton';
+import { TrickDisplay } from '../components/TrickDisplay';
 import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -316,28 +317,14 @@ function OhHellPageContent() {
                 )}
 
                 {/* Current trick */}
-                {state.currentTrick.length > 0 && (
-                  <div className="my-3 p-3 rounded bg-black/40" data-tutorial="oh-trick-display">
-                    <div className="text-ds-text-muted text-sm mb-1">{t('currentTrick')}</div>
-                    <div className="flex gap-2">
-                      {state.currentTrick.map((trickCard) => (
-                        <div key={`trick-${trickCard.playerIdx}`} className="text-center">
-                          <AnimatedCard
-                            card={trickCard.card}
-                            width={cardWidth}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                          />
-                          <div className="text-game-text-muted text-xs mt-1">
-                            {playerName(
-                              state.players[trickCard.playerIdx]?.id ?? trickCard.playerIdx,
-                              state.players[trickCard.playerIdx]?.isHuman ?? false,
-                            )}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
+                <TrickDisplay
+                  currentTrick={state.currentTrick}
+                  players={state.players}
+                  cardWidth={cardWidth}
+                  label={t('currentTrick')}
+                  dataTutorial="oh-trick-display"
+                  onCardDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
+                />
               </div>
 
               {/* Right: info sidebar */}

--- a/frontend/src/pages/SpadesPage.tsx
+++ b/frontend/src/pages/SpadesPage.tsx
@@ -10,11 +10,11 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { PlayerHandSection } from '../components/PlayerHandSection';
 import { RoundScoreAnnouncement } from '../components/RoundScoreAnnouncement';
 import { ScrollFadeHint } from '../components/ScrollFadeHint';
 import { SpadesSkeleton } from '../components/skeleton/SpadesSkeleton';
+import { TrickDisplay } from '../components/TrickDisplay';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
@@ -266,28 +266,14 @@ function SpadesPageContent() {
                 )}
 
                 {/* Current trick */}
-                {state.currentTrick.length > 0 && (
-                  <div className="my-3 p-3 rounded bg-black/40" data-tutorial="sp-trick-display">
-                    <div className="text-ds-text-muted text-sm mb-1">{t('currentTrick')}</div>
-                    <div className="flex gap-2">
-                      {state.currentTrick.map((trickCard) => (
-                        <div key={`trick-${trickCard.playerIdx}`} className="text-center">
-                          <AnimatedCard
-                            card={trickCard.card}
-                            width={cardWidth}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                          />
-                          <div className="text-game-text-muted text-xs mt-1">
-                            {playerName(
-                              state.players[trickCard.playerIdx]?.id ?? trickCard.playerIdx,
-                              state.players[trickCard.playerIdx]?.isHuman ?? false,
-                            )}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
+                <TrickDisplay
+                  currentTrick={state.currentTrick}
+                  players={state.players}
+                  cardWidth={cardWidth}
+                  label={t('currentTrick')}
+                  dataTutorial="sp-trick-display"
+                  onCardDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
+                />
               </div>
 
               {/* Right: info sidebar */}

--- a/frontend/src/pages/TwoTenJackPage.tsx
+++ b/frontend/src/pages/TwoTenJackPage.tsx
@@ -10,11 +10,11 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { PlayerHandSection } from '../components/PlayerHandSection';
 import { RoundScoreAnnouncement } from '../components/RoundScoreAnnouncement';
 import { ScrollFadeHint } from '../components/ScrollFadeHint';
 import { TwoTenJackSkeleton } from '../components/skeleton/TwoTenJackSkeleton';
+import { TrickDisplay } from '../components/TrickDisplay';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
@@ -256,28 +256,14 @@ function TwoTenJackPageContent() {
                   </div>
                 )}
 
-                {state.currentTrick.length > 0 && (
-                  <div className="my-3 p-3 rounded bg-black/40" data-tutorial="tt-trick-display">
-                    <div className="text-ds-text-muted text-sm mb-1">{t('currentTrick')}</div>
-                    <div className="flex gap-2">
-                      {state.currentTrick.map((trickCard) => (
-                        <div key={`trick-${trickCard.playerIdx}`} className="text-center">
-                          <AnimatedCard
-                            card={trickCard.card}
-                            width={cardWidth}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                          />
-                          <div className="text-game-text-muted text-xs mt-1">
-                            {playerName(
-                              state.players[trickCard.playerIdx]?.id ?? trickCard.playerIdx,
-                              state.players[trickCard.playerIdx]?.isHuman ?? false,
-                            )}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
+                <TrickDisplay
+                  currentTrick={state.currentTrick}
+                  players={state.players}
+                  cardWidth={cardWidth}
+                  label={t('currentTrick')}
+                  dataTutorial="tt-trick-display"
+                  onCardDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
+                />
               </div>
 
               <div>

--- a/frontend/src/pages/WhistPage.tsx
+++ b/frontend/src/pages/WhistPage.tsx
@@ -10,11 +10,11 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { PlayerHandSection } from '../components/PlayerHandSection';
 import { RoundScoreAnnouncement } from '../components/RoundScoreAnnouncement';
 import { ScrollFadeHint } from '../components/ScrollFadeHint';
 import { WhistSkeleton } from '../components/skeleton/WhistSkeleton';
+import { TrickDisplay } from '../components/TrickDisplay';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
@@ -244,28 +244,14 @@ function WhistPageContent() {
               {/* Left: game play area */}
               <div>
                 {/* Current trick */}
-                {state.currentTrick.length > 0 && (
-                  <div className="my-3 p-3 rounded bg-black/40" data-tutorial="wh-trick-display">
-                    <div className="text-ds-text-muted text-sm mb-1">{t('currentTrick')}</div>
-                    <div className="flex gap-2">
-                      {state.currentTrick.map((trickCard) => (
-                        <div key={`trick-${trickCard.playerIdx}`} className="text-center">
-                          <AnimatedCard
-                            card={trickCard.card}
-                            width={cardWidth}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                          />
-                          <div className="text-game-text-muted text-xs mt-1">
-                            {playerName(
-                              state.players[trickCard.playerIdx]?.id ?? trickCard.playerIdx,
-                              state.players[trickCard.playerIdx]?.isHuman ?? false,
-                            )}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
+                <TrickDisplay
+                  currentTrick={state.currentTrick}
+                  players={state.players}
+                  cardWidth={cardWidth}
+                  label={t('currentTrick')}
+                  dataTutorial="wh-trick-display"
+                  onCardDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
+                />
               </div>
 
               {/* Right: info sidebar */}

--- a/internal/usecase/FortyThievesInteractor.go
+++ b/internal/usecase/FortyThievesInteractor.go
@@ -40,12 +40,17 @@ type FortyThievesInteractorIF interface {
 type FortyThievesInteractor struct {
 	GameBase[interfaces.FortyThievesGame]
 	ftp presenter.FortyThievesPresenter
+	solitaireActions[interfaces.FortyThievesGame]
 }
 
 // NewFortyThievesInteractor コンストラクタ
 func NewFortyThievesInteractor(ft interfaces.FortyThievesGame, ftp presenter.FortyThievesPresenter) *FortyThievesInteractor {
 	mustNotNil("FortyThievesInteractor", map[string]any{"ft": ft, "ftp": ftp})
-	return &FortyThievesInteractor{GameBase: GameBase[interfaces.FortyThievesGame]{Game: ft}, ftp: ftp}
+	return &FortyThievesInteractor{
+		GameBase:         GameBase[interfaces.FortyThievesGame]{Game: ft},
+		ftp:              ftp,
+		solitaireActions: newSolitaireActions[interfaces.FortyThievesGame](ft, ftp),
+	}
 }
 
 // Reset ゲーム初期化
@@ -78,19 +83,9 @@ func (fi *FortyThievesInteractor) MoveTableauToFoundation(col int) string {
 	return execAndPresent(fi.Game, fi.ftp, func() error { return fi.Game.MoveTableauToFoundation(col) })
 }
 
-// GiveUp ギブアップ
-func (fi *FortyThievesInteractor) GiveUp() string {
-	return runAndPresent(fi.Game, fi.ftp, fi.Game.GiveUp)
-}
-
 // Hint ヒント取得
 func (fi *FortyThievesInteractor) Hint() string {
 	return fi.ftp.HintOutput(fi.Game)
-}
-
-// AutoComplete オートコンプリート
-func (fi *FortyThievesInteractor) AutoComplete() string {
-	return execAndPresent(fi.Game, fi.ftp, fi.Game.AutoComplete)
 }
 
 // ActionLog 棋譜を出力する
@@ -98,19 +93,13 @@ func (fi *FortyThievesInteractor) ActionLog() string {
 	return fi.ftp.ActionLogOutput(fi.Game)
 }
 
-// Undo アンドゥ
-func (fi *FortyThievesInteractor) Undo() string {
-	return execAndPresent(fi.Game, fi.ftp, fi.Game.Undo)
-}
-
-// UndoN n回連続アンドゥ
-func (fi *FortyThievesInteractor) UndoN(n int) string {
-	return execAndPresent(fi.Game, fi.ftp, func() error { return fi.Game.UndoN(n) })
-}
-
 // RestoreFortyThievesInteractor deserialises JSON into a FortyThievesInteractor.
 func RestoreFortyThievesInteractor(data []byte, ftp presenter.FortyThievesPresenter) (*FortyThievesInteractor, error) {
 	return restoreAndBuild[domain.FortyThieves](data, func(g *domain.FortyThieves) *FortyThievesInteractor {
-		return &FortyThievesInteractor{GameBase: GameBase[interfaces.FortyThievesGame]{Game: g}, ftp: ftp}
+		return &FortyThievesInteractor{
+			GameBase:         GameBase[interfaces.FortyThievesGame]{Game: g},
+			ftp:              ftp,
+			solitaireActions: newSolitaireActions[interfaces.FortyThievesGame](g, ftp),
+		}
 	})
 }

--- a/internal/usecase/FreeCellInteractor.go
+++ b/internal/usecase/FreeCellInteractor.go
@@ -40,12 +40,17 @@ type FreeCellInteractorIF interface {
 type FreeCellInteractor struct {
 	GameBase[interfaces.FreeCellGame]
 	fp presenter.FreeCellPresenter
+	solitaireActions[interfaces.FreeCellGame]
 }
 
 // NewFreeCellInteractor コンストラクタ
 func NewFreeCellInteractor(f interfaces.FreeCellGame, fp presenter.FreeCellPresenter) *FreeCellInteractor {
 	mustNotNil("FreeCellInteractor", map[string]any{"f": f, "fp": fp})
-	return &FreeCellInteractor{GameBase: GameBase[interfaces.FreeCellGame]{Game: f}, fp: fp}
+	return &FreeCellInteractor{
+		GameBase:         GameBase[interfaces.FreeCellGame]{Game: f},
+		fp:               fp,
+		solitaireActions: newSolitaireActions[interfaces.FreeCellGame](f, fp),
+	}
 }
 
 // Reset ゲーム初期化
@@ -78,19 +83,9 @@ func (fi *FreeCellInteractor) MoveFreeCellToFoundation(cell int) string {
 	return execAndPresent(fi.Game, fi.fp, func() error { return fi.Game.MoveFreeCellToFoundation(cell) })
 }
 
-// GiveUp ギブアップ
-func (fi *FreeCellInteractor) GiveUp() string {
-	return runAndPresent(fi.Game, fi.fp, fi.Game.GiveUp)
-}
-
 // Hint ヒント取得
 func (fi *FreeCellInteractor) Hint() string {
 	return fi.fp.HintOutput(fi.Game)
-}
-
-// AutoComplete オートコンプリート
-func (fi *FreeCellInteractor) AutoComplete() string {
-	return execAndPresent(fi.Game, fi.fp, fi.Game.AutoComplete)
 }
 
 // ActionLog 棋譜を出力する
@@ -98,19 +93,13 @@ func (fi *FreeCellInteractor) ActionLog() string {
 	return fi.fp.ActionLogOutput(fi.Game)
 }
 
-// Undo アンドゥ
-func (fi *FreeCellInteractor) Undo() string {
-	return execAndPresent(fi.Game, fi.fp, fi.Game.Undo)
-}
-
-// UndoN n回連続アンドゥ
-func (fi *FreeCellInteractor) UndoN(n int) string {
-	return execAndPresent(fi.Game, fi.fp, func() error { return fi.Game.UndoN(n) })
-}
-
 // RestoreFreeCellInteractor deserialises JSON into a FreeCellInteractor.
 func RestoreFreeCellInteractor(data []byte, fp presenter.FreeCellPresenter) (*FreeCellInteractor, error) {
 	return restoreAndBuild[domain.FreeCell](data, func(g *domain.FreeCell) *FreeCellInteractor {
-		return &FreeCellInteractor{GameBase: GameBase[interfaces.FreeCellGame]{Game: g}, fp: fp}
+		return &FreeCellInteractor{
+			GameBase:         GameBase[interfaces.FreeCellGame]{Game: g},
+			fp:               fp,
+			solitaireActions: newSolitaireActions[interfaces.FreeCellGame](g, fp),
+		}
 	})
 }

--- a/internal/usecase/KlondikeInteractor.go
+++ b/internal/usecase/KlondikeInteractor.go
@@ -42,12 +42,17 @@ type KlondikeInteractorIF interface {
 type KlondikeInteractor struct {
 	GameBase[interfaces.KlondikeGame]
 	kp presenter.KlondikePresenter
+	solitaireActions[interfaces.KlondikeGame]
 }
 
 // NewKlondikeInteractor コンストラクタ
 func NewKlondikeInteractor(k interfaces.KlondikeGame, kp presenter.KlondikePresenter) *KlondikeInteractor {
 	mustNotNil("KlondikeInteractor", map[string]any{"k": k, "kp": kp})
-	return &KlondikeInteractor{GameBase: GameBase[interfaces.KlondikeGame]{Game: k}, kp: kp}
+	return &KlondikeInteractor{
+		GameBase:         GameBase[interfaces.KlondikeGame]{Game: k},
+		kp:               kp,
+		solitaireActions: newSolitaireActions[interfaces.KlondikeGame](k, kp),
+	}
 }
 
 // Reset ゲーム初期化
@@ -85,19 +90,9 @@ func (ki *KlondikeInteractor) MoveTableauToFoundation(col int) string {
 	return execAndPresent(ki.Game, ki.kp, func() error { return ki.Game.MoveTableauToFoundation(col) })
 }
 
-// GiveUp ギブアップ
-func (ki *KlondikeInteractor) GiveUp() string {
-	return runAndPresent(ki.Game, ki.kp, ki.Game.GiveUp)
-}
-
 // Hint ヒント取得
 func (ki *KlondikeInteractor) Hint() string {
 	return ki.kp.HintOutput(ki.Game)
-}
-
-// AutoComplete オートコンプリート
-func (ki *KlondikeInteractor) AutoComplete() string {
-	return execAndPresent(ki.Game, ki.kp, ki.Game.AutoComplete)
 }
 
 // ActionLog 棋譜を出力する
@@ -105,19 +100,13 @@ func (ki *KlondikeInteractor) ActionLog() string {
 	return ki.kp.ActionLogOutput(ki.Game)
 }
 
-// Undo アンドゥ
-func (ki *KlondikeInteractor) Undo() string {
-	return execAndPresent(ki.Game, ki.kp, ki.Game.Undo)
-}
-
-// UndoN n回連続アンドゥ
-func (ki *KlondikeInteractor) UndoN(n int) string {
-	return execAndPresent(ki.Game, ki.kp, func() error { return ki.Game.UndoN(n) })
-}
-
 // RestoreKlondikeInteractor deserialises JSON into a KlondikeInteractor.
 func RestoreKlondikeInteractor(data []byte, kp presenter.KlondikePresenter) (*KlondikeInteractor, error) {
 	return restoreAndBuild[domain.Klondike](data, func(g *domain.Klondike) *KlondikeInteractor {
-		return &KlondikeInteractor{GameBase: GameBase[interfaces.KlondikeGame]{Game: g}, kp: kp}
+		return &KlondikeInteractor{
+			GameBase:         GameBase[interfaces.KlondikeGame]{Game: g},
+			kp:               kp,
+			solitaireActions: newSolitaireActions[interfaces.KlondikeGame](g, kp),
+		}
 	})
 }

--- a/internal/usecase/ScorpionInteractor.go
+++ b/internal/usecase/ScorpionInteractor.go
@@ -34,12 +34,17 @@ type ScorpionInteractorIF interface {
 type ScorpionInteractor struct {
 	GameBase[interfaces.ScorpionGame]
 	sp presenter.ScorpionPresenter
+	solitaireActions[interfaces.ScorpionGame]
 }
 
 // NewScorpionInteractor コンストラクタ
 func NewScorpionInteractor(s interfaces.ScorpionGame, sp presenter.ScorpionPresenter) *ScorpionInteractor {
 	mustNotNil("ScorpionInteractor", map[string]any{"s": s, "sp": sp})
-	return &ScorpionInteractor{GameBase: GameBase[interfaces.ScorpionGame]{Game: s}, sp: sp}
+	return &ScorpionInteractor{
+		GameBase:         GameBase[interfaces.ScorpionGame]{Game: s},
+		sp:               sp,
+		solitaireActions: newSolitaireActions[interfaces.ScorpionGame](s, sp),
+	}
 }
 
 // Reset ゲーム初期化
@@ -59,19 +64,9 @@ func (si *ScorpionInteractor) MoveTableauToTableau(fromCol, cardIndex, toCol int
 	})
 }
 
-// GiveUp ギブアップ
-func (si *ScorpionInteractor) GiveUp() string {
-	return runAndPresent(si.Game, si.sp, si.Game.GiveUp)
-}
-
 // Hint ヒント取得
 func (si *ScorpionInteractor) Hint() string {
 	return si.sp.HintOutput(si.Game)
-}
-
-// AutoComplete オートコンプリート
-func (si *ScorpionInteractor) AutoComplete() string {
-	return execAndPresent(si.Game, si.sp, si.Game.AutoComplete)
 }
 
 // ActionLog 棋譜を出力する
@@ -79,19 +74,13 @@ func (si *ScorpionInteractor) ActionLog() string {
 	return si.sp.ActionLogOutput(si.Game)
 }
 
-// Undo アンドゥ
-func (si *ScorpionInteractor) Undo() string {
-	return execAndPresent(si.Game, si.sp, si.Game.Undo)
-}
-
-// UndoN n回連続アンドゥ
-func (si *ScorpionInteractor) UndoN(n int) string {
-	return execAndPresent(si.Game, si.sp, func() error { return si.Game.UndoN(n) })
-}
-
 // RestoreScorpionInteractor deserialises JSON into a ScorpionInteractor.
 func RestoreScorpionInteractor(data []byte, sp presenter.ScorpionPresenter) (*ScorpionInteractor, error) {
 	return restoreAndBuild[domain.Scorpion](data, func(g *domain.Scorpion) *ScorpionInteractor {
-		return &ScorpionInteractor{GameBase: GameBase[interfaces.ScorpionGame]{Game: g}, sp: sp}
+		return &ScorpionInteractor{
+			GameBase:         GameBase[interfaces.ScorpionGame]{Game: g},
+			sp:               sp,
+			solitaireActions: newSolitaireActions[interfaces.ScorpionGame](g, sp),
+		}
 	})
 }

--- a/internal/usecase/SpiderInteractor.go
+++ b/internal/usecase/SpiderInteractor.go
@@ -36,12 +36,17 @@ type SpiderInteractorIF interface {
 type SpiderInteractor struct {
 	GameBase[interfaces.SpiderGame]
 	sp presenter.SpiderPresenter
+	solitaireActions[interfaces.SpiderGame]
 }
 
 // NewSpiderInteractor コンストラクタ
 func NewSpiderInteractor(s interfaces.SpiderGame, sp presenter.SpiderPresenter) *SpiderInteractor {
 	mustNotNil("SpiderInteractor", map[string]any{"s": s, "sp": sp})
-	return &SpiderInteractor{GameBase: GameBase[interfaces.SpiderGame]{Game: s}, sp: sp}
+	return &SpiderInteractor{
+		GameBase:         GameBase[interfaces.SpiderGame]{Game: s},
+		sp:               sp,
+		solitaireActions: newSolitaireActions[interfaces.SpiderGame](s, sp),
+	}
 }
 
 // Reset ゲーム初期化
@@ -64,19 +69,9 @@ func (si *SpiderInteractor) MoveTableauToTableau(fromCol, cardIndex, toCol int) 
 	return execAndPresent(si.Game, si.sp, func() error { return si.Game.MoveTableauToTableau(fromCol, cardIndex, toCol) })
 }
 
-// GiveUp ギブアップ
-func (si *SpiderInteractor) GiveUp() string {
-	return runAndPresent(si.Game, si.sp, si.Game.GiveUp)
-}
-
 // Hint ヒント取得
 func (si *SpiderInteractor) Hint() string {
 	return si.sp.HintOutput(si.Game)
-}
-
-// AutoComplete オートコンプリート
-func (si *SpiderInteractor) AutoComplete() string {
-	return execAndPresent(si.Game, si.sp, si.Game.AutoComplete)
 }
 
 // ActionLog 棋譜を出力する
@@ -84,19 +79,13 @@ func (si *SpiderInteractor) ActionLog() string {
 	return si.sp.ActionLogOutput(si.Game)
 }
 
-// Undo アンドゥ
-func (si *SpiderInteractor) Undo() string {
-	return execAndPresent(si.Game, si.sp, si.Game.Undo)
-}
-
-// UndoN n回連続アンドゥ
-func (si *SpiderInteractor) UndoN(n int) string {
-	return execAndPresent(si.Game, si.sp, func() error { return si.Game.UndoN(n) })
-}
-
 // RestoreSpiderInteractor deserialises JSON into a SpiderInteractor.
 func RestoreSpiderInteractor(data []byte, sp presenter.SpiderPresenter) (*SpiderInteractor, error) {
 	return restoreAndBuild[domain.Spider](data, func(g *domain.Spider) *SpiderInteractor {
-		return &SpiderInteractor{GameBase: GameBase[interfaces.SpiderGame]{Game: g}, sp: sp}
+		return &SpiderInteractor{
+			GameBase:         GameBase[interfaces.SpiderGame]{Game: g},
+			sp:               sp,
+			solitaireActions: newSolitaireActions[interfaces.SpiderGame](g, sp),
+		}
 	})
 }

--- a/internal/usecase/YukonInteractor.go
+++ b/internal/usecase/YukonInteractor.go
@@ -34,12 +34,17 @@ type YukonInteractorIF interface {
 type YukonInteractor struct {
 	GameBase[interfaces.YukonGame]
 	yp presenter.YukonPresenter
+	solitaireActions[interfaces.YukonGame]
 }
 
 // NewYukonInteractor コンストラクタ
 func NewYukonInteractor(y interfaces.YukonGame, yp presenter.YukonPresenter) *YukonInteractor {
 	mustNotNil("YukonInteractor", map[string]any{"y": y, "yp": yp})
-	return &YukonInteractor{GameBase: GameBase[interfaces.YukonGame]{Game: y}, yp: yp}
+	return &YukonInteractor{
+		GameBase:         GameBase[interfaces.YukonGame]{Game: y},
+		yp:               yp,
+		solitaireActions: newSolitaireActions[interfaces.YukonGame](y, yp),
+	}
 }
 
 // Reset ゲーム初期化
@@ -59,19 +64,9 @@ func (yi *YukonInteractor) MoveTableauToFoundation(col int) string {
 	return execAndPresent(yi.Game, yi.yp, func() error { return yi.Game.MoveTableauToFoundation(col) })
 }
 
-// GiveUp ギブアップ
-func (yi *YukonInteractor) GiveUp() string {
-	return runAndPresent(yi.Game, yi.yp, yi.Game.GiveUp)
-}
-
 // Hint ヒント取得
 func (yi *YukonInteractor) Hint() string {
 	return yi.yp.HintOutput(yi.Game)
-}
-
-// AutoComplete オートコンプリート
-func (yi *YukonInteractor) AutoComplete() string {
-	return execAndPresent(yi.Game, yi.yp, yi.Game.AutoComplete)
 }
 
 // ActionLog 棋譜を出力する
@@ -79,19 +74,13 @@ func (yi *YukonInteractor) ActionLog() string {
 	return yi.yp.ActionLogOutput(yi.Game)
 }
 
-// Undo アンドゥ
-func (yi *YukonInteractor) Undo() string {
-	return execAndPresent(yi.Game, yi.yp, yi.Game.Undo)
-}
-
-// UndoN n回連続アンドゥ
-func (yi *YukonInteractor) UndoN(n int) string {
-	return execAndPresent(yi.Game, yi.yp, func() error { return yi.Game.UndoN(n) })
-}
-
 // RestoreYukonInteractor deserialises JSON into a YukonInteractor.
 func RestoreYukonInteractor(data []byte, yp presenter.YukonPresenter) (*YukonInteractor, error) {
 	return restoreAndBuild[domain.Yukon](data, func(g *domain.Yukon) *YukonInteractor {
-		return &YukonInteractor{GameBase: GameBase[interfaces.YukonGame]{Game: g}, yp: yp}
+		return &YukonInteractor{
+			GameBase:         GameBase[interfaces.YukonGame]{Game: g},
+			yp:               yp,
+			solitaireActions: newSolitaireActions[interfaces.YukonGame](g, yp),
+		}
 	})
 }

--- a/internal/usecase/solitaire_actions.go
+++ b/internal/usecase/solitaire_actions.go
@@ -1,0 +1,35 @@
+package usecase
+
+import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+
+// solitaireActions はソリティア系インタラクターの GiveUp/AutoComplete/Undo/UndoN 委譲を共通化する。
+// 各ゲームのインタラクター構造体に埋め込んで使用する (tournamentActions と同パターン)。
+type solitaireActions[G interfaces.SolitaireGame] struct {
+	game G
+	pres outputPresenter[G]
+}
+
+// newSolitaireActions コンストラクタ
+func newSolitaireActions[G interfaces.SolitaireGame](game G, pres outputPresenter[G]) solitaireActions[G] {
+	return solitaireActions[G]{game: game, pres: pres}
+}
+
+// GiveUp ギブアップ
+func (s solitaireActions[G]) GiveUp() string {
+	return runAndPresent(s.game, s.pres, s.game.GiveUp)
+}
+
+// AutoComplete オートコンプリート
+func (s solitaireActions[G]) AutoComplete() string {
+	return execAndPresent(s.game, s.pres, s.game.AutoComplete)
+}
+
+// Undo アンドゥ
+func (s solitaireActions[G]) Undo() string {
+	return execAndPresent(s.game, s.pres, s.game.Undo)
+}
+
+// UndoN n回連続アンドゥ
+func (s solitaireActions[G]) UndoN(n int) string {
+	return execAndPresent(s.game, s.pres, func() error { return s.game.UndoN(n) })
+}

--- a/internal/usecase/solitaire_actions_test.go
+++ b/internal/usecase/solitaire_actions_test.go
@@ -50,6 +50,7 @@ func TestSolitaireActions(t *testing.T) {
 			result := tt.callMethod(sa)
 			assert.Equal(t, tt.name+" output", result)
 			mg.AssertExpectations(t)
+			mp.AssertExpectations(t)
 		})
 
 		if tt.returnsErr {
@@ -65,6 +66,8 @@ func TestSolitaireActions(t *testing.T) {
 
 				result := tt.callMethod(sa)
 				assert.Equal(t, tt.name+" error output", result)
+				mg.AssertExpectations(t)
+				mp.AssertExpectations(t)
 			})
 		}
 	}

--- a/internal/usecase/solitaire_actions_test.go
+++ b/internal/usecase/solitaire_actions_test.go
@@ -1,0 +1,71 @@
+//go:build test
+
+package usecase
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
+)
+
+func newTestSolitaireActions() (solitaireActions[interfaces.KlondikeGame], *interfaces.MockKlondikeGame, *presenter.MockKlondikePresenter) {
+	mg := new(interfaces.MockKlondikeGame)
+	mp := new(presenter.MockKlondikePresenter)
+	sa := newSolitaireActions[interfaces.KlondikeGame](mg, mp)
+	return sa, mg, mp
+}
+
+func TestSolitaireActions(t *testing.T) {
+	tests := []struct {
+		name       string
+		gameMethod string
+		returnsErr bool
+		callMethod func(solitaireActions[interfaces.KlondikeGame]) string
+	}{
+		{"GiveUp", "GiveUp", false, func(sa solitaireActions[interfaces.KlondikeGame]) string { return sa.GiveUp() }},
+		{"AutoComplete", "AutoComplete", true, func(sa solitaireActions[interfaces.KlondikeGame]) string { return sa.AutoComplete() }},
+		{"Undo", "Undo", true, func(sa solitaireActions[interfaces.KlondikeGame]) string { return sa.Undo() }},
+		{"UndoN", "UndoN", true, func(sa solitaireActions[interfaces.KlondikeGame]) string { return sa.UndoN(3) }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"_success", func(t *testing.T) {
+			sa, mg, mp := newTestSolitaireActions()
+			if tt.returnsErr {
+				if tt.gameMethod == "UndoN" {
+					mg.On(tt.gameMethod, 3).Return(nil)
+				} else {
+					mg.On(tt.gameMethod).Return(nil)
+				}
+			} else {
+				mg.On(tt.gameMethod).Return()
+			}
+			mp.On("Output", mg, mock.Anything).Return(tt.name + " output")
+
+			result := tt.callMethod(sa)
+			assert.Equal(t, tt.name+" output", result)
+			mg.AssertExpectations(t)
+		})
+
+		if tt.returnsErr {
+			t.Run(tt.name+"_error", func(t *testing.T) {
+				sa, mg, mp := newTestSolitaireActions()
+				boom := errors.New(tt.name + " failed")
+				if tt.gameMethod == "UndoN" {
+					mg.On(tt.gameMethod, 3).Return(boom)
+				} else {
+					mg.On(tt.gameMethod).Return(boom)
+				}
+				mp.On("Output", mg, boom).Return(tt.name + " error output")
+
+				result := tt.callMethod(sa)
+				assert.Equal(t, tt.name+" error output", result)
+			})
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **#1461** — Extract common `GiveUp`/`AutoComplete`/`Undo`/`UndoN` delegation for solitaire interactors into a generic `solitaireActions[G SolitaireGame]` helper (mirrors `tournamentActions`). Removes ~150 lines of duplicated boilerplate from Klondike, FreeCell, Spider, FortyThieves, Yukon, and Scorpion interactors.
- **#1466** — Extract shared `<TrickDisplay/>` component for trick-taking games. Hearts, Spades, Euchre, Bridge, Napoleon, OhHell, TwoTenJack, and Whist pages each rendered an identical ~22-line block for the current trick — replaced with a single component call. Reduces ~170 lines of duplication.
- **#1465** — Already resolved by the existing `execCuiCommand` + `unknownCommandMessage` unified path (see `internal/adapter/controller/cui_controller_helper.go`). All 55 `*CuiController.go` files route unknown commands through `unknownCommandMessage`, which uses `cuiutil.SuggestCommand` for Levenshtein-based "did you mean" suggestions. Closing with no code change.

Net diff: **+375 / -312 lines**, with 10 new tests (4 usecase + 6 component).

## Test plan

- [x] `go test -tags test ./...` — all packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bun run build` — frontend build succeeds
- [x] `bun run check` — biome clean (pre-existing TrashPage warning only)
- [x] `bun run test HeartsPage SpadesPage EuchrePage BridgePage NapoleonPage OhHellPage TwoTenJackPage WhistPage` — 382 tests pass
- [x] `bun run test TrickDisplay` — 6 new tests pass
- [x] `go test -tags test ./internal/usecase/ -run TestSolitaireActions` — 7 new tests pass

Closes #1461
Closes #1465
Closes #1466