### PR TITLE
docs: sync UML design docs with 62-game registry

### DIFF
--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -6,7 +6,7 @@
 
 - [1. クラス図](#1-クラス図)
   - [1.1 コアドメイン (カード・プレイヤー)](#11-コアドメイン-カードプレイヤー)
-  - [1.2 ゲームドメイン (全58ゲーム)](#12-ゲームドメイン-全58ゲーム)
+  - [1.2 ゲームドメイン (全62ゲーム)](#12-ゲームドメイン-全62ゲーム)
   - [1.3 ユースケース層 (Interactor・Presenter)](#13-ユースケース層-interactorpresenter)
   - [1.4 アダプタ層 (Controller・Presenter実装)](#14-アダプタ層-controllerpresenter実装)
   - [1.5 インフラストラクチャ層](#15-インフラストラクチャ層)
@@ -138,7 +138,7 @@ classDiagram
     GamePlayer *-- ChipHolder : mixin
 ```
 
-### 1.2 ゲームドメイン (全58ゲーム)
+### 1.2 ゲームドメイン (全62ゲーム)
 
 #### ベッティング系ゲーム
 
@@ -1483,7 +1483,7 @@ classDiagram
     note for GamePresenter "各ゲームの Presenter は\nGamePresenter[G] の型エイリアス\nまたは拡張インターフェース"
 ```
 
-**Interactor パターン (全58ゲーム共通)**
+**Interactor パターン (全62ゲーム共通)**
 
 ```mermaid
 classDiagram
@@ -1555,8 +1555,8 @@ classDiagram
     GameCuiPresenter ..|> GamePresenter : implements
     GameWebPresenter ..|> GamePresenter : implements
 
-    note for GameCuiController "58ゲーム × CUI/Web = 116 Controller\nGameCuiController / GameWebController は\n各ゲーム毎に具体的な実装が存在"
-    note for GameCuiPresenter "58ゲーム × CUI/Web = 116 Presenter 実装"
+    note for GameCuiController "62ゲーム × CUI/Web = 124 Controller\nGameCuiController / GameWebController は\n各ゲーム毎に具体的な実装が存在"
+    note for GameCuiPresenter "62ゲーム × CUI/Web = 124 Presenter 実装"
 ```
 
 ### 1.5 インフラストラクチャ層
@@ -1623,8 +1623,8 @@ classDiagram
         +Exec(input string) string
     }
 
-    TrumpCardsWeb --> "*" GameWebController : holds 58 controllers
-    GameManager --> "*" CuiExecer : holds 58 games
+    TrumpCardsWeb --> "*" GameWebController : holds 62 controllers
+    GameManager --> "*" CuiExecer : holds 62 games
     GameCui ..|> CuiExecer : implements
     GameCui --> GameCuiController : delegates
 ```

--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -399,7 +399,7 @@ classDiagram
         +object messageParams
     }
 
-    note for BlackJackResponse "各ゲームが固有のResponse型を持つ\n(全58ゲーム分存在)\n共通フィールド: message, messageCode, messageParams"
+    note for BlackJackResponse "各ゲームが固有のResponse型を持つ\n(全62ゲーム分存在)\n共通フィールド: message, messageCode, messageParams"
 ```
 
 **フェーズ定数 (全ゲーム)**
@@ -803,7 +803,7 @@ classDiagram
     class actionLogApi {
         +blackjack() Promise~ActionLogResponse~
         +poker() Promise~ActionLogResponse~
-        ...全58ゲーム()
+        ...全62ゲーム()
     }
 
     BlackJackApi --> gameApi : uses postJson/gameExec
@@ -865,7 +865,7 @@ classDiagram
 
     RedDogApi --> gameApi : uses postJson/gameExec
 
-    note for BlackJackApi "全58ゲーム分のAPI Objectが存在\n(blackjack, poker, oldmaid, daifugo,\nsevens, doubt, holdem, omaha, shortdeck,\npineapple, hearts, memory, klondike, freecell,\nbaccarat, spades, twotenjack, crazyeights, ginrummy, canasta,\nspider, napoleon, indianpoker, videopoker,\ndeuceswild, jokerpoker, euchre, pyramid, tripeaks,\ncribbage, threecard, caribbeanstud, ohhell, bridge, speed,\ngofish, pinochle, golf, pigtail,\nsevencardstud, clocksolitaire, durak,\nfortythieves, paigow, war, canfield, fiftyone, yukon, scorpion, accordion, whist,\nletitride, pokersquares, pageone, reddog, razz, badugi, trash)"
+    note for BlackJackApi "全62ゲーム分のAPI Objectが存在\n(blackjack, spanish21, poker, oldmaid, daifugo,\nsevens, doubt, holdem, omaha, shortdeck,\npineapple, hearts, memory, klondike, freecell,\nbaccarat, spades, twotenjack, crazyeights, ginrummy, canasta,\nspider, napoleon, indianpoker, videopoker,\ndeuceswild, jokerpoker, euchre, pyramid, tripeaks,\ncribbage, threecard, caribbeanstud, ohhell, bridge, speed,\ngofish, pinochle, golf, pigtail,\nsevencardstud, clocksolitaire, durak,\nfortythieves, paigow, war, canfield, fiftyone, yukon, scorpion, accordion, whist,\nletitride, pokersquares, pageone, reddog, razz, badugi, trash,\nsevenbridge, president, cassino)"
 ```
 
 ### 1.3 Hook 層 (共通Hook)
@@ -1244,7 +1244,7 @@ classDiagram
 
     useCanastaGame --> useGameApi : uses
 
-    note for useBlackJackGame "全58ゲーム分の固有Hookが存在\n各HookはuseGameApiで統一的にAPI呼出し\n必要に応じてuseCardSelectionを合成"
+    note for useBlackJackGame "全62ゲーム分の固有Hookが存在\n各HookはuseGameApiで統一的にAPI呼出し\n必要に応じてuseCardSelectionを合成"
 ```
 
 ### 1.5 コンポーネント層
@@ -1816,7 +1816,7 @@ classDiagram
     GamePage --> PokerTableLayout : renders (Hold'em/Omaha/ShortDeck/Pineapple/SevenCardStud/Razz)
     PokerTableLayout --> CpuPlayerCard : wraps
 
-    note for GamePage "全58ゲームページが同一パターンで構成\nuseGamePageSetup → ゲーム固有Hook → 描画"
+    note for GamePage "全62ゲームページが同一パターンで構成\nuseGamePageSetup → ゲーム固有Hook → 描画"
 ```
 
 ### 1.7 i18n・プロバイダー・ルーティング
@@ -1839,16 +1839,16 @@ classDiagram
         +HashRouter
         +ErrorBoundary
         +NavBar
-        +Routes (58ゲーム)
+        +Routes (62ゲーム)
     }
 
     class gameCategories {
-        +table: [BlackJack, Baccarat, ThreeCard, PaiGow, CaribbeanStud, LetItRide, RedDog]
+        +table: [BlackJack, Spanish21, Baccarat, ThreeCard, CaribbeanStud, PaiGow, LetItRide, RedDog]
         +poker: [Poker, Holdem, Omaha, ShortDeck, Pineapple, SevenCardStud, Razz, Badugi, IndianPoker, VideoPoker, DeucesWild, JokerPoker]
-        +trickTaking: [Hearts, Spades, OhHell, Euchre, Bridge, Napoleon, TwoTenJack, Whist]
-        +matching: [OldMaid, Doubt, Daifugo, Sevens, CrazyEights, Speed, GoFish, Pinochle, PigsTail, Durak, War, FiftyOne, PageOne, Trash]
+        +trickTaking: [Hearts, Spades, TwoTenJack, OhHell, Euchre, Bridge, Napoleon, Whist]
+        +matching: [OldMaid, Doubt, Durak, Daifugo, President, Cassino, Sevens, CrazyEights, PageOne, Speed, GoFish, Pinochle, PigsTail, War, FiftyOne, Trash]
         +solitaire: [Klondike, FreeCell, Spider, Pyramid, TriPeaks, Golf, Memory, ClockSolitaire, FortyThieves, Canfield, Yukon, Scorpion, Accordion, PokerSquares]
-        +rummy: [GinRummy, Canasta, Cribbage]
+        +rummy: [GinRummy, Canasta, Cribbage, SevenBridge]
     }
 
     class TutorialProvider {
@@ -1862,11 +1862,11 @@ classDiagram
     App --> i18n : initializes
     App --> gameCategories : routes from
     App --> NavBar : renders
-    App --> GamePage : routes to 58 pages
+    App --> GamePage : routes to 62 pages
     GamePage --> TutorialProvider : wraps (per-game)
     TutorialProvider --> TutorialOverlay : renders when active
 
-    note for i18n "60名前空間: common + 58ゲーム固有 + tutorial\n翻訳ファイル: locales/{ja,en}/game.json"
+    note for i18n "64名前空間: common + 62ゲーム固有 + tutorial\n翻訳ファイル: locales/{ja,en}/game.json"
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Updates stale **"58 games / 116 Controllers / 60 namespaces"** references in `docs/design/backend.md` (7 lines) and `docs/design/frontend.md` (9 locations) to match the current **62-game** registry.
- Extends the `gameCategories` class + API-Object list in `docs/design/frontend.md` to include the four games added since the last doc sync: `sevenbridge`, `president`, `cassino`, `spanish21`.
- No other docs were drifting — game list / Web API endpoints / openapi.yaml / frontend i18n / ADR index / versions are all already in sync.

Found via `/doc-drift-check --fix`. Full drift report on the linked issue.

Closes #1481

## Test plan

- [x] `grep "58ゲーム\|58 games\|58 controllers" docs/design/` returns nothing
- [x] `grep -c '{Name:' internal/infrastructure/games/registry.go` → 62 (matches updated docs)
- [x] Category placements for Spanish21/Cassino/President/SevenBridge match `frontend/src/constants/gameRoutes.ts`
- [ ] Reviewer sanity-checks the diff against the current registry