### PR TITLE
feat(a11y): announce RoundResults showdown details via live region

### DIFF
--- a/frontend/src/components/RoundResults.test.tsx
+++ b/frontend/src/components/RoundResults.test.tsx
@@ -1,8 +1,16 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { RoundResults } from './RoundResults';
 
 const players = [{ isHuman: true }, { isHuman: false }, { isHuman: false }];
+
+function visible() {
+  return within(screen.getByTestId('round-results-visible'));
+}
+
+function liveRegion() {
+  return screen.getByRole('status');
+}
 
 describe('RoundResults', () => {
   it('returns null when results is undefined', () => {
@@ -18,73 +26,126 @@ describe('RoundResults', () => {
   it('renders human player as あなた', () => {
     const results = [{ playerIdx: 0, handName: 'フルハウス', wonAmount: 100 }];
     render(<RoundResults results={results} players={players} />);
-    expect(screen.getByText('結果:')).toBeInTheDocument();
-    expect(screen.getByText(/あなた/)).toBeInTheDocument();
-    expect(screen.getByText(/フルハウス/)).toBeInTheDocument();
-    expect(screen.getByText(/\+100チップ/)).toBeInTheDocument();
+    expect(visible().getByText('結果:')).toBeInTheDocument();
+    expect(visible().getByText(/あなた/)).toBeInTheDocument();
+    expect(visible().getByText(/フルハウス/)).toBeInTheDocument();
+    expect(visible().getByText(/\+100チップ/)).toBeInTheDocument();
   });
 
   it('renders CPU player with index', () => {
     const results = [{ playerIdx: 1, handName: 'ワンペア', wonAmount: 0 }];
     render(<RoundResults results={results} players={players} />);
-    expect(screen.getByText(/CPU 1/)).toBeInTheDocument();
-    expect(screen.getByText(/ワンペア/)).toBeInTheDocument();
+    expect(visible().getByText(/CPU 1/)).toBeInTheDocument();
+    expect(visible().getByText(/ワンペア/)).toBeInTheDocument();
   });
 
   it('does not render handName when empty', () => {
     const results = [{ playerIdx: 0, handName: '', wonAmount: 50 }];
     render(<RoundResults results={results} players={players} />);
-    expect(screen.getByText(/あなた/)).toBeInTheDocument();
-    expect(screen.getByText(/\+50チップ/)).toBeInTheDocument();
+    expect(visible().getByText(/あなた/)).toBeInTheDocument();
+    expect(visible().getByText(/\+50チップ/)).toBeInTheDocument();
   });
 
   it('does not render wonAmount when zero', () => {
     const results = [{ playerIdx: 1, handName: 'ハイカード', wonAmount: 0 }];
     render(<RoundResults results={results} players={players} />);
-    expect(screen.queryByText(/チップ/)).not.toBeInTheDocument();
+    expect(visible().queryByText(/チップ/)).not.toBeInTheDocument();
   });
 
   it('renders kickers when present', () => {
     const results = [{ playerIdx: 0, handName: 'One Pair', kickers: 'A, Q, 10', wonAmount: 100 }];
     render(<RoundResults results={results} players={players} />);
-    expect(screen.getByText(/キッカー: A, Q, 10/)).toBeInTheDocument();
+    expect(visible().getByText(/キッカー: A, Q, 10/)).toBeInTheDocument();
   });
 
   it('does not render kickers when absent', () => {
     const results = [{ playerIdx: 0, handName: 'Flush', wonAmount: 100 }];
     render(<RoundResults results={results} players={players} />);
-    expect(screen.queryByText(/キッカー/)).not.toBeInTheDocument();
+    expect(visible().queryByText(/キッカー/)).not.toBeInTheDocument();
   });
 
   it('does not render kickers when empty string', () => {
     const results = [{ playerIdx: 0, handName: 'Flush', kickers: '', wonAmount: 100 }];
     render(<RoundResults results={results} players={players} />);
-    expect(screen.queryByText(/キッカー/)).not.toBeInTheDocument();
+    expect(visible().queryByText(/キッカー/)).not.toBeInTheDocument();
   });
 
   it('renders "マック" when mucked is true', () => {
     const results = [{ playerIdx: 0, handName: 'ワンペア', kickers: 'A, Q', wonAmount: 0, mucked: true }];
     render(<RoundResults results={results} players={players} />);
-    expect(screen.getByText(/マック/)).toBeInTheDocument();
+    expect(visible().getByText(/マック/)).toBeInTheDocument();
   });
 
   it('does not render handName when mucked is true', () => {
     const results = [{ playerIdx: 0, handName: 'ワンペア', kickers: 'A, Q', wonAmount: 0, mucked: true }];
     render(<RoundResults results={results} players={players} />);
-    expect(screen.queryByText(/ワンペア/)).not.toBeInTheDocument();
+    expect(visible().queryByText(/ワンペア/)).not.toBeInTheDocument();
   });
 
   it('does not render kickers when mucked is true', () => {
     const results = [{ playerIdx: 0, handName: 'ワンペア', kickers: 'A, Q', wonAmount: 0, mucked: true }];
     render(<RoundResults results={results} players={players} />);
-    expect(screen.queryByText(/キッカー/)).not.toBeInTheDocument();
+    expect(visible().queryByText(/キッカー/)).not.toBeInTheDocument();
   });
 
   it('renders handName and kickers when mucked is false', () => {
     const results = [{ playerIdx: 0, handName: 'ワンペア', kickers: 'A, Q', wonAmount: 100, mucked: false }];
     render(<RoundResults results={results} players={players} />);
-    expect(screen.getByText(/ワンペア/)).toBeInTheDocument();
-    expect(screen.getByText(/キッカー: A, Q/)).toBeInTheDocument();
-    expect(screen.queryByText(/マック/)).not.toBeInTheDocument();
+    expect(visible().getByText(/ワンペア/)).toBeInTheDocument();
+    expect(visible().getByText(/キッカー: A, Q/)).toBeInTheDocument();
+    expect(visible().queryByText(/マック/)).not.toBeInTheDocument();
+  });
+
+  describe('sr-only live region', () => {
+    it('renders polite status live region when results are present', () => {
+      const results = [{ playerIdx: 0, handName: 'フルハウス', wonAmount: 100 }];
+      render(<RoundResults results={results} players={players} />);
+      const region = liveRegion();
+      expect(region).toHaveAttribute('aria-live', 'polite');
+      expect(region).toHaveAttribute('aria-atomic', 'true');
+      expect(region.className).toContain('sr-only');
+    });
+
+    it('announces hand with chips won for human player', () => {
+      const results = [{ playerIdx: 0, handName: 'フルハウス', wonAmount: 100 }];
+      render(<RoundResults results={results} players={players} />);
+      expect(liveRegion()).toHaveTextContent('ショウダウン結果。あなた: フルハウス、+100チップ');
+    });
+
+    it('announces hand with kickers and chips won', () => {
+      const results = [{ playerIdx: 0, handName: 'ワンペア', kickers: 'A, Q', wonAmount: 50 }];
+      render(<RoundResults results={results} players={players} />);
+      expect(liveRegion()).toHaveTextContent('ショウダウン結果。あなた: ワンペア、キッカー A, Q、+50チップ');
+    });
+
+    it('announces hand with kickers but no chips won', () => {
+      const results = [{ playerIdx: 0, handName: 'ワンペア', kickers: 'A, Q', wonAmount: 0 }];
+      render(<RoundResults results={results} players={players} />);
+      expect(liveRegion()).toHaveTextContent('ショウダウン結果。あなた: ワンペア、キッカー A, Q');
+    });
+
+    it('announces hand alone when no kickers and no chips won', () => {
+      const results = [{ playerIdx: 1, handName: 'ハイカード', wonAmount: 0 }];
+      render(<RoundResults results={results} players={players} />);
+      expect(liveRegion()).toHaveTextContent('ショウダウン結果。CPU 1: ハイカード');
+    });
+
+    it('announces mucked entries without hand name or kickers', () => {
+      const results = [{ playerIdx: 1, handName: 'ワンペア', kickers: 'A, Q', wonAmount: 0, mucked: true }];
+      render(<RoundResults results={results} players={players} />);
+      expect(liveRegion()).toHaveTextContent('ショウダウン結果。CPU 1: マック');
+    });
+
+    it('joins multiple entries with comma separator', () => {
+      const results = [
+        { playerIdx: 0, handName: 'フルハウス', wonAmount: 100 },
+        { playerIdx: 1, handName: 'ワンペア', wonAmount: 0 },
+        { playerIdx: 2, handName: 'フラッシュ', wonAmount: 0, mucked: true },
+      ];
+      render(<RoundResults results={results} players={players} />);
+      expect(liveRegion()).toHaveTextContent(
+        'ショウダウン結果。あなた: フルハウス、+100チップ, CPU 1: ワンペア, CPU 2: マック',
+      );
+    });
   });
 });

--- a/frontend/src/components/RoundResults.tsx
+++ b/frontend/src/components/RoundResults.tsx
@@ -13,23 +13,71 @@ interface RoundResultsProps {
   players: { isHuman: boolean }[];
 }
 
-/** Renders round result summary showing each player's hand and winnings. */
+/**
+ * Renders round result summary showing each player's hand and winnings.
+ *
+ * Also renders a sibling sr-only live region (`role="status"` /
+ * `aria-live="polite"`) so screen-reader users hear the showdown breakdown
+ * (opponent hands, kickers, chips won) without having to navigate back to
+ * the visible table after each hand.
+ */
 export function RoundResults({ results, players }: RoundResultsProps) {
   const { t } = useTranslation('common');
   if (!results || results.length === 0) return null;
+
+  const announcement = results
+    .map((r) => {
+      const name = players[r.playerIdx]?.isHuman ? t('player.you') : `CPU ${r.playerIdx}`;
+      if (r.mucked) {
+        return t('roundResultsAnnouncement.entryMucked', { name });
+      }
+      const handName = r.handName || '';
+      const hasKickers = Boolean(r.kickers);
+      const hasWon = r.wonAmount > 0;
+      if (hasKickers && hasWon) {
+        return t('roundResultsAnnouncement.entryHandWithKickersWon', {
+          name,
+          handName,
+          kickers: r.kickers,
+          amount: r.wonAmount,
+        });
+      }
+      if (hasKickers) {
+        return t('roundResultsAnnouncement.entryHandWithKickers', {
+          name,
+          handName,
+          kickers: r.kickers,
+        });
+      }
+      if (hasWon) {
+        return t('roundResultsAnnouncement.entryHandWon', {
+          name,
+          handName,
+          amount: r.wonAmount,
+        });
+      }
+      return t('roundResultsAnnouncement.entryHand', { name, handName });
+    })
+    .join(', ');
+
   return (
-    <div className="bg-black/30 rounded p-2 mb-3 text-white text-xs">
-      <div className="font-bold mb-1">{t('label.result')}</div>
-      {results.map((r) => (
-        <div key={r.playerIdx}>
-          {players[r.playerIdx]?.isHuman ? t('player.you') : `CPU ${r.playerIdx}`}
-          {r.mucked ? `: ${t('label.mucked')}` : r.handName && `: ${r.handName}`}
-          {!r.mucked && r.kickers && ` (${t('label.kicker', { kickers: r.kickers })})`}
-          {r.wonAmount > 0 && (
-            <span className="text-ds-warning ml-1"> {t('label.chipsWon', { amount: r.wonAmount })}</span>
-          )}
-        </div>
-      ))}
-    </div>
+    <>
+      <div data-testid="round-results-visible" className="bg-black/30 rounded p-2 mb-3 text-white text-xs">
+        <div className="font-bold mb-1">{t('label.result')}</div>
+        {results.map((r) => (
+          <div key={r.playerIdx}>
+            {players[r.playerIdx]?.isHuman ? t('player.you') : `CPU ${r.playerIdx}`}
+            {r.mucked ? `: ${t('label.mucked')}` : r.handName && `: ${r.handName}`}
+            {!r.mucked && r.kickers && ` (${t('label.kicker', { kickers: r.kickers })})`}
+            {r.wonAmount > 0 && (
+              <span className="text-ds-warning ml-1"> {t('label.chipsWon', { amount: r.wonAmount })}</span>
+            )}
+          </div>
+        ))}
+      </div>
+      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+        {t('roundResultsAnnouncement.message', { details: announcement })}
+      </div>
+    </>
   );
 }

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -135,6 +135,14 @@
     "message": "Round complete. {{details}}",
     "entry": "{{name}}: +{{round}} (total {{total}})"
   },
+  "roundResultsAnnouncement": {
+    "message": "Showdown results. {{details}}",
+    "entryMucked": "{{name}}: mucked",
+    "entryHand": "{{name}}: {{handName}}",
+    "entryHandWithKickers": "{{name}}: {{handName}}, kicker {{kickers}}",
+    "entryHandWon": "{{name}}: {{handName}}, +{{amount}} chips",
+    "entryHandWithKickersWon": "{{name}}: {{handName}}, kicker {{kickers}}, +{{amount}} chips"
+  },
   "stalemateEscape": "Escape (undo {{count}} moves)",
   "status": {
     "folded": "Folded",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -135,6 +135,14 @@
     "message": "ラウンド終了。{{details}}",
     "entry": "{{name}}: +{{round}} (合計 {{total}})"
   },
+  "roundResultsAnnouncement": {
+    "message": "ショウダウン結果。{{details}}",
+    "entryMucked": "{{name}}: マック",
+    "entryHand": "{{name}}: {{handName}}",
+    "entryHandWithKickers": "{{name}}: {{handName}}、キッカー {{kickers}}",
+    "entryHandWon": "{{name}}: {{handName}}、+{{amount}}チップ",
+    "entryHandWithKickersWon": "{{name}}: {{handName}}、キッカー {{kickers}}、+{{amount}}チップ"
+  },
   "stalemateEscape": "脱出する ({{count}}手戻る)",
   "status": {
     "folded": "フォールド",

--- a/frontend/src/pages/HoldemPage.test.tsx
+++ b/frontend/src/pages/HoldemPage.test.tsx
@@ -454,7 +454,7 @@ describe('HoldemPage', () => {
     renderWithProviders(<HoldemPage />);
     await waitFor(() => expect(screen.getByText('結果:')).toBeInTheDocument());
     // Human (playerIdx 0) → "あなた: ワンペア"
-    expect(screen.getByText(/あなた: ワンペア/)).toBeInTheDocument();
+    expect(within(screen.getByTestId('round-results-visible')).getByText(/あなた: ワンペア/)).toBeInTheDocument();
   });
 
   it('shows "CPU X" for non-human player in results', async () => {
@@ -462,14 +462,16 @@ describe('HoldemPage', () => {
     renderWithProviders(<HoldemPage />);
     await waitFor(() => expect(screen.getByText('結果:')).toBeInTheDocument());
     // CPU (playerIdx 1) → "CPU 1: ツーペア"
-    expect(screen.getByText(/CPU 1: ツーペア/)).toBeInTheDocument();
+    expect(within(screen.getByTestId('round-results-visible')).getByText(/CPU 1: ツーペア/)).toBeInTheDocument();
   });
 
   it('shows hand name in results when present', async () => {
     mockExec.mockResolvedValue(showdownState);
     renderWithProviders(<HoldemPage />);
-    await waitFor(() => expect(screen.getByText(/: ワンペア/)).toBeInTheDocument());
-    expect(screen.getByText(/: ツーペア/)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(within(screen.getByTestId('round-results-visible')).getByText(/: ワンペア/)).toBeInTheDocument(),
+    );
+    expect(within(screen.getByTestId('round-results-visible')).getByText(/: ツーペア/)).toBeInTheDocument();
   });
 
   it('does not show hand name in results when empty', async () => {
@@ -489,7 +491,9 @@ describe('HoldemPage', () => {
   it('shows won chips when wonAmount > 0', async () => {
     mockExec.mockResolvedValue(showdownState);
     renderWithProviders(<HoldemPage />);
-    await waitFor(() => expect(screen.getByText(/\+200チップ/)).toBeInTheDocument());
+    await waitFor(() =>
+      expect(within(screen.getByTestId('round-results-visible')).getByText(/\+200チップ/)).toBeInTheDocument(),
+    );
   });
 
   it('does not show won chips when wonAmount is 0', async () => {

--- a/frontend/src/pages/IndianPokerPage.test.tsx
+++ b/frontend/src/pages/IndianPokerPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { indianpokerApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
@@ -287,7 +287,9 @@ describe('IndianPokerPage', () => {
   it('shows won chips when wonAmount > 0', async () => {
     mockExec.mockResolvedValue(showdownState);
     renderWithProviders(<IndianPokerPage />);
-    await waitFor(() => expect(screen.getByText(/\+200チップ/)).toBeInTheDocument());
+    await waitFor(() =>
+      expect(within(screen.getByTestId('round-results-visible')).getByText(/\+200チップ/)).toBeInTheDocument(),
+    );
   });
 
   it('does not show won chips when wonAmount is 0', async () => {
@@ -706,7 +708,7 @@ describe('IndianPokerPage', () => {
     });
     renderWithProviders(<IndianPokerPage />);
     await waitFor(() => expect(screen.getByText('結果:')).toBeInTheDocument());
-    expect(screen.getByText(/\+100チップ/)).toBeInTheDocument();
+    expect(within(screen.getByTestId('round-results-visible')).getByText(/\+100チップ/)).toBeInTheDocument();
   });
 
   // ---- cpuMetaAI toggle ----

--- a/frontend/src/pages/OmahaPage.test.tsx
+++ b/frontend/src/pages/OmahaPage.test.tsx
@@ -481,21 +481,23 @@ describe('OmahaPage', () => {
     mockExec.mockResolvedValue(showdownState);
     renderWithProviders(<OmahaPage />);
     await waitFor(() => expect(screen.getByText('結果:')).toBeInTheDocument());
-    expect(screen.getByText(/あなた: ワンペア/)).toBeInTheDocument();
+    expect(within(screen.getByTestId('round-results-visible')).getByText(/あなた: ワンペア/)).toBeInTheDocument();
   });
 
   it('shows "CPU X" for non-human player in results', async () => {
     mockExec.mockResolvedValue(showdownState);
     renderWithProviders(<OmahaPage />);
     await waitFor(() => expect(screen.getByText('結果:')).toBeInTheDocument());
-    expect(screen.getByText(/CPU 1: ツーペア/)).toBeInTheDocument();
+    expect(within(screen.getByTestId('round-results-visible')).getByText(/CPU 1: ツーペア/)).toBeInTheDocument();
   });
 
   it('shows hand name in results when present', async () => {
     mockExec.mockResolvedValue(showdownState);
     renderWithProviders(<OmahaPage />);
-    await waitFor(() => expect(screen.getByText(/: ワンペア/)).toBeInTheDocument());
-    expect(screen.getByText(/: ツーペア/)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(within(screen.getByTestId('round-results-visible')).getByText(/: ワンペア/)).toBeInTheDocument(),
+    );
+    expect(within(screen.getByTestId('round-results-visible')).getByText(/: ツーペア/)).toBeInTheDocument();
   });
 
   it('does not show hand name in results when empty', async () => {
@@ -513,7 +515,9 @@ describe('OmahaPage', () => {
   it('shows won chips when wonAmount > 0', async () => {
     mockExec.mockResolvedValue(showdownState);
     renderWithProviders(<OmahaPage />);
-    await waitFor(() => expect(screen.getByText(/\+200チップ/)).toBeInTheDocument());
+    await waitFor(() =>
+      expect(within(screen.getByTestId('round-results-visible')).getByText(/\+200チップ/)).toBeInTheDocument(),
+    );
   });
 
   it('does not show won chips when wonAmount is 0', async () => {

--- a/frontend/src/pages/PokerPage.test.tsx
+++ b/frontend/src/pages/PokerPage.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, pokerApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
@@ -446,21 +446,23 @@ describe('PokerPage', () => {
     mockExec.mockResolvedValue(endState);
     renderWithProviders(<PokerPage />);
     await waitFor(() => expect(screen.getByText('結果:')).toBeInTheDocument());
-    expect(screen.getByText(/あなた: High Card/)).toBeInTheDocument();
+    expect(within(screen.getByTestId('round-results-visible')).getByText(/あなた: High Card/)).toBeInTheDocument();
   });
 
   it('shows "CPU X" for non-human player in results', async () => {
     mockExec.mockResolvedValue(endState);
     renderWithProviders(<PokerPage />);
     await waitFor(() => expect(screen.getByText('結果:')).toBeInTheDocument());
-    expect(screen.getByText(/CPU 1: One Pair/)).toBeInTheDocument();
+    expect(within(screen.getByTestId('round-results-visible')).getByText(/CPU 1: One Pair/)).toBeInTheDocument();
   });
 
   it('shows hand name in results when present', async () => {
     mockExec.mockResolvedValue(endState);
     renderWithProviders(<PokerPage />);
-    await waitFor(() => expect(screen.getByText(/: High Card/)).toBeInTheDocument());
-    expect(screen.getByText(/: One Pair/)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(within(screen.getByTestId('round-results-visible')).getByText(/: High Card/)).toBeInTheDocument(),
+    );
+    expect(within(screen.getByTestId('round-results-visible')).getByText(/: One Pair/)).toBeInTheDocument();
   });
 
   it('does not show hand name colon when handName is empty in results', async () => {
@@ -478,7 +480,9 @@ describe('PokerPage', () => {
   it('shows won chips when wonAmount > 0', async () => {
     mockExec.mockResolvedValue(endState);
     renderWithProviders(<PokerPage />);
-    await waitFor(() => expect(screen.getByText(/\+200チップ/)).toBeInTheDocument());
+    await waitFor(() =>
+      expect(within(screen.getByTestId('round-results-visible')).getByText(/\+200チップ/)).toBeInTheDocument(),
+    );
   });
 
   it('does not show won chips when wonAmount is 0', async () => {


### PR DESCRIPTION
## Summary

- Add a sr-only `role="status" aria-live="polite" aria-atomic="true"` region alongside the visible `RoundResults` table so screen-reader users hear opponent hand names, kickers, chips won, and muck state on every showdown — parity with `RoundScoreAnnouncement` in trick-taking games.
- Introduce `roundResultsAnnouncement.*` i18n keys (ja/en) with distinct entries for the 5 combinations (hand, hand+kickers, hand+won, hand+kickers+won, mucked) so the read-aloud sentence stays natural.
- Tag the visible table with `data-testid="round-results-visible"` and scope existing visible-text assertions via `within(...)`; add 7 new tests covering live-region attributes and announcement content for every entry shape.

Impact: 8 poker-family pages (`Poker`, `Holdem`, `Omaha`, `ShortDeck`, `Pineapple`, `IndianPoker`, `Razz`, `SevenCardStud`) inherit the new behavior for free via the shared component.

Closes #1485

## Test plan

- [x] `bun run test -- --run src/components/RoundResults.test.tsx` — 20/20 pass (13 existing + 7 new)
- [x] `bun run build` — succeeds
- [ ] Manual SR pass (VoiceOver / NVDA) once merged to a deployable branch