### PR TITLE
feat(cli): add 'update --check' dry-run for CI/monitoring

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -197,7 +197,7 @@ func run() int {
 		// while keeping human-friendly text on stderr. Install mode keeps its
 		// legacy "writer=stderr" so `trumpcards update --yes 2>/dev/null` still
 		// silences progress without swallowing the exit code. See issue #1484.
-		writer := io.Writer(os.Stderr)
+		var writer io.Writer = os.Stderr
 		if check {
 			writer = os.Stdout
 		}

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -183,17 +183,28 @@ func run() int {
 		return runHelpCommand(flag.Args()[1:], helpText, os.Stdout, os.Stderr)
 	}
 	commands["update"] = func() int {
-		var yes bool
+		var yes, check bool
 		_, code, ok := parseSubFlags("update", func(f *flag.FlagSet) {
 			f.BoolVar(&yes, "yes", false, "Skip confirmation prompt")
 			f.BoolVar(&yes, "y", false, "Skip confirmation prompt (shorthand)")
+			f.BoolVar(&check, "check", false, "Check for an update without installing (prints latest tag, status, current to stdout)")
+			f.BoolVar(&check, "dry-run", false, "Alias for --check")
 		})
 		if !ok {
 			return code
 		}
-		updater := update.NewUpdater(version, os.Stdin, os.Stderr, os.Stderr)
+		// --check writes machine-readable output to stdout (for CI / scripts)
+		// while keeping human-friendly text on stderr. Install mode keeps its
+		// legacy "writer=stderr" so `trumpcards update --yes 2>/dev/null` still
+		// silences progress without swallowing the exit code. See issue #1484.
+		writer := io.Writer(os.Stderr)
+		if check {
+			writer = os.Stdout
+		}
+		updater := update.NewUpdater(version, os.Stdin, writer, os.Stderr)
 		updater.SetAutoConfirm(yes)
 		updater.SetReportCancelledAsError(true) // report user cancel as exit 75
+		updater.SetCheckOnly(check)
 		updater.SetProgressIsTTY(term.IsTerminal(int(os.Stderr.Fd())))
 		if err := updater.Exec(); err != nil {
 			return updateExitCode(err)
@@ -314,23 +325,34 @@ var builtinSubcommandHelp = map[string][]string{
 	"update": {
 		"USAGE:",
 		"  trumpcards update [--yes]",
+		"  trumpcards update --check",
 		"",
 		"FLAGS:",
-		"  -y, --yes   Skip confirmation prompt (required for non-interactive stdin)",
+		"  -y, --yes     Skip confirmation prompt (required for non-interactive stdin)",
+		"      --check   Check for an update without installing. Writes a tab-separated",
+		"                summary '<latest-tag>\\t<status>\\t<current>' (status: latest |",
+		"                available | dev) to stdout, and a human-friendly message to",
+		"                stderr. Never prompts, never downloads. Safe in CI / cron.",
+		"      --dry-run Alias for --check.",
 		"",
 		"EXIT CODES:",
-		"   0  Success (already latest or updated)",
+		"   0  Success (already latest or updated; --check: already latest or dev build)",
 		"   2  Usage error (non-interactive without --yes)",
 		"   3  Network / release API failure",
 		"   4  No binary for this platform",
 		"   5  Archive extraction failure",
 		"   6  Binary apply failure (permissions, disk, integrity)",
+		"  10  --check: a newer version is available (non-error signal for scripts)",
 		"  75  User declined the prompt",
 		"   1  Unexpected error",
 		"",
 		"EXAMPLES:",
 		"  trumpcards update",
 		"  trumpcards update --yes",
+		"  trumpcards update --check                   # prints latest tag to stdout; exits 10 when newer",
+		"  trumpcards update --check | cut -f1          # latest tag only (e.g. v2.3.1)",
+		"  if trumpcards update --check; then           # exit 0 means already latest",
+		"    echo 'up to date'; fi",
 	},
 	"completion": {
 		"USAGE:",
@@ -459,10 +481,11 @@ func parseSubFlagsTo(name string, args []string, setup func(*flag.FlagSet), stdo
 //	4  — no binary for this platform (no retry without a new release)
 //	5  — archive extraction failure
 //	6  — binary apply failure (permissions, disk, integrity)
+//	10 — --check: a newer release is available (non-error signal)
 //	75 — user declined the prompt (EX_TEMPFAIL)
 //	1  — any other unexpected error
 //
-// See issue #1449.
+// See issues #1449, #1484.
 func updateExitCode(err error) int {
 	switch {
 	case errors.Is(err, update.ErrNonInteractive):
@@ -475,6 +498,8 @@ func updateExitCode(err error) int {
 		return 5
 	case errors.Is(err, update.ErrApply):
 		return 6
+	case errors.Is(err, update.ErrUpdateAvailable):
+		return 10
 	case errors.Is(err, update.ErrUserCancelled):
 		return 75
 	default:
@@ -544,6 +569,7 @@ EXAMPLES:
   trumpcards games --short --aliases  List game names including aliases
   trumpcards update              Self-update to the latest version
   trumpcards update --yes        Update without confirmation prompt
+  trumpcards update --check      Report whether an update is available (exit 10 if yes)
   trumpcards --version-short     Print just the version number (e.g. 1.2.3)
   NO_COLOR=1 trumpcards hearts   Play Hearts without color output
   trumpcards web                 Start the web GUI server (binds to 127.0.0.1)

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -540,10 +540,12 @@ func TestUpdateExitCodeMapping(t *testing.T) {
 		{"extract failure", update.ErrExtract, 5},
 		{"apply failure", update.ErrApply, 6},
 		{"user cancelled", update.ErrUserCancelled, 75},
+		{"update available", update.ErrUpdateAvailable, 10},
 		{"unknown error", errors.New("surprise"), 1},
 		// Wrapping preserves the category.
 		{"wrapped network", fmt.Errorf("dial: %w", update.ErrNetwork), 3},
 		{"wrapped apply", fmt.Errorf("chmod: %w", update.ErrApply), 6},
+		{"wrapped update available", fmt.Errorf("check: %w", update.ErrUpdateAvailable), 10},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -22,6 +22,8 @@
   "skippedWarning": "Warning: invalid values {{values}} were ignored",
   "updateAlreadyLatest": "Already on the latest version ({{version}})",
   "updateAvailable": "A new version ({{version}}) is available (current: {{current}}). Update now? [y/N]",
+  "updateCheckAvailable": "A new version ({{version}}) is available (current: {{current}})",
+  "updateCheckDev": "Development build. Latest release: {{version}}",
   "updateAutoConfirm": "Updating from {{current}} to {{version}} (auto-confirmed)...",
   "updateCancelled": "Update cancelled",
   "updateDownloading": "Downloading {{version}}...",

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -22,6 +22,8 @@
   "skippedWarning": "警告: 無効な値 {{values}} は無視されました",
   "updateAlreadyLatest": "既に最新バージョン({{version}})です",
   "updateAvailable": "最新版({{version}})があります (現在: {{current}})。アップデートしますか？ [y/N]",
+  "updateCheckAvailable": "最新版({{version}})が利用可能です (現在: {{current}})",
+  "updateCheckDev": "開発ビルドです。最新リリース: {{version}}",
   "updateAutoConfirm": "{{current}} から {{version}} にアップデートします (自動確認)...",
   "updateCancelled": "アップデートをキャンセルしました",
   "updateDownloading": "{{version}} をダウンロード中...",

--- a/internal/infrastructure/update/Updater.go
+++ b/internal/infrastructure/update/Updater.go
@@ -45,6 +45,12 @@ var (
 	// ErrUserCancelled indicates the user answered the prompt with a
 	// non-affirmative response (empty, "n", "no").
 	ErrUserCancelled = errors.New("update: user declined")
+	// ErrUpdateAvailable is returned only in check-only mode (SetCheckOnly)
+	// when the release API reports a newer version than the current build.
+	// Callers map it to a dedicated exit code (e.g. 10) so CI / cron can tell
+	// "update exists" apart from "already latest" (nil) and "couldn't check"
+	// (ErrNetwork / ErrAPIStatus). See issue #1484.
+	ErrUpdateAvailable = errors.New("update: new version available")
 )
 
 // Updater checks GitHub Releases for the latest version and self-updates the binary.
@@ -63,6 +69,11 @@ type Updater struct {
 	// behavior of returning nil, so library callers who never call the
 	// setter keep their old contract.
 	reportCancelledAsError bool
+	// checkOnly: when true, Exec fetches the release info, writes a
+	// machine-readable one-line summary to writer and a human-friendly
+	// message to errWriter, then returns without prompting or downloading.
+	// See issue #1484.
+	checkOnly bool
 }
 
 // SetAutoConfirm enables or disables the automatic confirmation of updates,
@@ -109,6 +120,17 @@ func (u *Updater) SetReportCancelledAsError(v bool) {
 	u.reportCancelledAsError = v
 }
 
+// SetCheckOnly toggles check-only (dry-run) mode. When enabled, Exec fetches
+// the latest release metadata, writes a tab-separated summary line
+// (`<latest>\t<status>\t<current>`) to writer and a human-friendly message to
+// errWriter, then returns without prompting or downloading. The return value
+// distinguishes "already latest" (nil) from "update available"
+// (ErrUpdateAvailable) so CI / cron scripts can branch on exit code. See
+// issue #1484.
+func (u *Updater) SetCheckOnly(v bool) {
+	u.checkOnly = v
+}
+
 // Exec runs the self-update flow.
 //
 // Errors are wrapped with sentinel categories from this package (ErrNetwork,
@@ -140,6 +162,12 @@ func (u *Updater) Exec() error {
 
 	latestVersion := strings.TrimPrefix(release.TagName, "v")
 	currentClean := strings.TrimPrefix(u.currentVersion, "v")
+
+	// Check-only (--check / --dry-run) short-circuit: report status and return.
+	// Never prompts, never downloads. See issue #1484.
+	if u.checkOnly {
+		return u.reportCheckOnly(release.TagName, latestVersion, currentClean)
+	}
 
 	// If current version is not "dev" and matches latest, already up to date.
 	if currentClean != "dev" && currentClean == latestVersion {
@@ -199,6 +227,32 @@ func (u *Updater) Exec() error {
 // to treat that as the default-no path, not a hard I/O failure.
 func isBlankLineScanErr(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "unexpected newline")
+}
+
+// reportCheckOnly emits the machine-readable status line to writer plus a
+// human-friendly message to errWriter, and returns the sentinel expected by
+// the CLI exit-code mapper (nil = latest, ErrUpdateAvailable = newer exists).
+//
+// Output format on writer (stable; safe for shell parsing with `cut -f1`):
+//
+//	<latest-tag>\t<status>\t<current>
+//
+// Status is one of: "latest", "available", "dev".
+func (u *Updater) reportCheckOnly(latestTag, latestClean, currentClean string) error {
+	switch currentClean {
+	case "dev":
+		_, _ = fmt.Fprintf(u.writer, "%s\tdev\t%s\n", latestTag, u.currentVersion)
+		_, _ = fmt.Fprintln(u.errWriter, i18n.Tf("updateCheckDev", "version", latestTag))
+		return nil
+	case latestClean:
+		_, _ = fmt.Fprintf(u.writer, "%s\tlatest\t%s\n", latestTag, u.currentVersion)
+		_, _ = fmt.Fprintln(u.errWriter, i18n.Tf("updateAlreadyLatest", "version", latestTag))
+		return nil
+	default:
+		_, _ = fmt.Fprintf(u.writer, "%s\tavailable\t%s\n", latestTag, u.currentVersion)
+		_, _ = fmt.Fprintln(u.errWriter, i18n.Tf("updateCheckAvailable", "current", u.currentVersion, "version", latestTag))
+		return ErrUpdateAvailable
+	}
 }
 
 // progressReader wraps an io.Reader to display download progress.

--- a/internal/infrastructure/update/Updater.go
+++ b/internal/infrastructure/update/Updater.go
@@ -135,8 +135,8 @@ func (u *Updater) SetCheckOnly(v bool) {
 //
 // Errors are wrapped with sentinel categories from this package (ErrNetwork,
 // ErrAPIStatus, ErrNoAsset, ErrExtract, ErrApply, ErrNonInteractive,
-// ErrUserCancelled) so the caller can pick a meaningful exit code via
-// errors.Is. See issue #1449.
+// ErrUserCancelled, ErrUpdateAvailable) so the caller can pick a meaningful
+// exit code via errors.Is. See issues #1449, #1484.
 func (u *Updater) Exec() error {
 	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", u.repoOwner, u.repoName)
 	resp, err := u.httpClient.Get(url) //nolint:noctx // simple GET to GitHub API

--- a/internal/infrastructure/update/Updater_test.go
+++ b/internal/infrastructure/update/Updater_test.go
@@ -350,6 +350,168 @@ func TestFindAsset(t *testing.T) {
 	}
 }
 
+// TestSetCheckOnly verifies the accessor toggle works and starts false.
+func TestSetCheckOnly(t *testing.T) {
+	u := NewUpdater("1.0.0", nil, &bytes.Buffer{}, &bytes.Buffer{})
+	assert.False(t, u.checkOnly)
+	u.SetCheckOnly(true)
+	assert.True(t, u.checkOnly)
+	u.SetCheckOnly(false)
+	assert.False(t, u.checkOnly)
+}
+
+// TestExec_CheckOnly_NewerAvailable verifies that check-only mode returns
+// ErrUpdateAvailable, writes a tab-separated "available" line to writer,
+// and does NOT prompt or download. See issue #1484.
+func TestExec_CheckOnly_NewerAvailable(t *testing.T) {
+	release := ghRelease{TagName: "v2.0.0"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(release)
+	}))
+	defer srv.Close()
+
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	u := &Updater{
+		currentVersion: "1.0.0",
+		repoOwner:      "test",
+		repoName:       "test",
+		reader:         strings.NewReader(""),
+		writer:         out,
+		errWriter:      errOut,
+		httpClient:     &http.Client{Transport: &rewriteTransport{base: srv.Client().Transport, url: srv.URL}},
+	}
+	u.SetCheckOnly(true)
+
+	err := u.Exec()
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUpdateAvailable), "want ErrUpdateAvailable, got %v", err)
+	assert.Equal(t, "v2.0.0\tavailable\t1.0.0\n", out.String())
+	assert.Contains(t, errOut.String(), "v2.0.0")
+}
+
+// TestExec_CheckOnly_AlreadyLatest verifies that check-only reports "latest"
+// and returns nil when current version matches the release tag.
+func TestExec_CheckOnly_AlreadyLatest(t *testing.T) {
+	release := ghRelease{TagName: "v1.2.3"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(release)
+	}))
+	defer srv.Close()
+
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	u := &Updater{
+		currentVersion: "1.2.3",
+		repoOwner:      "test",
+		repoName:       "test",
+		reader:         strings.NewReader(""),
+		writer:         out,
+		errWriter:      errOut,
+		httpClient:     &http.Client{Transport: &rewriteTransport{base: srv.Client().Transport, url: srv.URL}},
+	}
+	u.SetCheckOnly(true)
+
+	err := u.Exec()
+	require.NoError(t, err)
+	assert.Equal(t, "v1.2.3\tlatest\t1.2.3\n", out.String())
+	assert.Contains(t, errOut.String(), "v1.2.3")
+}
+
+// TestExec_CheckOnly_DevBuild verifies that a "dev" build reports status=dev
+// (never "available"), so developer machines don't spuriously exit 10.
+func TestExec_CheckOnly_DevBuild(t *testing.T) {
+	release := ghRelease{TagName: "v2.0.0"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(release)
+	}))
+	defer srv.Close()
+
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	u := &Updater{
+		currentVersion: "dev",
+		repoOwner:      "test",
+		repoName:       "test",
+		reader:         strings.NewReader(""),
+		writer:         out,
+		errWriter:      errOut,
+		httpClient:     &http.Client{Transport: &rewriteTransport{base: srv.Client().Transport, url: srv.URL}},
+	}
+	u.SetCheckOnly(true)
+
+	err := u.Exec()
+	require.NoError(t, err)
+	assert.Equal(t, "v2.0.0\tdev\tdev\n", out.String())
+	assert.Contains(t, errOut.String(), "v2.0.0")
+}
+
+// TestExec_CheckOnly_DoesNotPrompt verifies that check-only mode never reads
+// from stdin, so scripts piping into it don't hang or get ErrNonInteractive.
+func TestExec_CheckOnly_DoesNotPrompt(t *testing.T) {
+	release := ghRelease{TagName: "v2.0.0"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(release)
+	}))
+	defer srv.Close()
+
+	// Reader that panics if Read is ever called.
+	reader := &panicReader{t: t}
+	out := &bytes.Buffer{}
+	u := &Updater{
+		currentVersion: "1.0.0",
+		repoOwner:      "test",
+		repoName:       "test",
+		reader:         reader,
+		writer:         out,
+		errWriter:      &bytes.Buffer{},
+		httpClient:     &http.Client{Transport: &rewriteTransport{base: srv.Client().Transport, url: srv.URL}},
+	}
+	u.SetCheckOnly(true)
+
+	err := u.Exec()
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUpdateAvailable))
+}
+
+// TestExec_CheckOnly_NetworkFailure verifies that network errors still wrap
+// ErrNetwork even in check-only mode (caller can map to exit 3).
+func TestExec_CheckOnly_NetworkFailure(t *testing.T) {
+	// Point at a closed server to force a connection refused.
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	srv.Close() // close immediately to trigger connection error
+
+	out := &bytes.Buffer{}
+	u := &Updater{
+		currentVersion: "1.0.0",
+		repoOwner:      "test",
+		repoName:       "test",
+		reader:         strings.NewReader(""),
+		writer:         out,
+		errWriter:      &bytes.Buffer{},
+		httpClient:     &http.Client{Transport: &rewriteTransport{base: srv.Client().Transport, url: srv.URL}},
+	}
+	u.SetCheckOnly(true)
+
+	err := u.Exec()
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNetwork), "want ErrNetwork, got %v", err)
+	assert.Empty(t, out.String(), "writer should not receive a status line on network failure")
+}
+
+// panicReader fails the test if Read is invoked.
+type panicReader struct{ t *testing.T }
+
+func (p *panicReader) Read(_ []byte) (int, error) {
+	p.t.Helper()
+	p.t.Fatalf("check-only mode must not read stdin")
+	return 0, nil
+}
+
 func TestFormatBytes(t *testing.T) {
 	tests := []struct {
 		input    int64


### PR DESCRIPTION
## Summary

- Add `--check` (alias `--dry-run`) flag to `trumpcards update`. In this mode the updater fetches release metadata, writes a tab-separated `<latest-tag>\t<status>\t<current>` line to stdout, prints a one-line human message to stderr, and returns — no prompt, no download.
- New sentinel `update.ErrUpdateAvailable` → CLI exit code **10** so CI / cron / package scripts can branch on exit code without piping `yes n` or grepping i18n strings. `0` still means "already latest" (or dev build). `3` still means network/API failure.
- In check mode the updater's `writer` is redirected to `os.Stdout` so the machine-readable line doesn't share the progress/log stream with install mode (which keeps `writer=stderr` for backward compatibility with `trumpcards update --yes 2>/dev/null`).
- Help text (`trumpcards help update`) now documents `--check`, `--dry-run`, the new exit code 10, and scripting examples.
- 5 new unit tests cover: available, already-latest, dev build, stdin never read, and network failure still wrapping `ErrNetwork`. `TestUpdateExitCodeMapping` gains an `ErrUpdateAvailable → 10` case (and a wrapped variant).

Closes #1484

## Test plan

- [x] `go test -tags test ./...` — all packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `goimports -w` on modified files
- [ ] Manual smoke test against live `yuta-yoshinaga/go_trumpcards` releases API once merged