### PR TITLE
fix(poker-hud): hide stats below md (768px), not sm (640px)

### DIFF
--- a/frontend/src/pages/HoldemPage.test.tsx
+++ b/frontend/src/pages/HoldemPage.test.tsx
@@ -931,6 +931,26 @@ describe('HoldemPage', () => {
     expect(screen.queryByTestId('hud-stats')).not.toBeInTheDocument();
   });
 
+  // Regression: HUD must stay hidden below md (768px) so the 375×667 iPhone SE
+  // viewport doesn't lose card/chip space to stats. See issue #1488.
+  it('HUD stats span carries `hidden md:inline` so mobile viewports suppress it', async () => {
+    mockExec.mockResolvedValue({
+      ...preFlopState,
+      players: [
+        humanPlayer(),
+        cpuPlayer(1, { totalHands: 5, vpip: 60, pfr: 20, threeBet: 10, af: '2.5' }),
+        cpuPlayer(2),
+      ],
+    });
+    renderWithProviders(<HoldemPage />);
+    await waitFor(() => {
+      const statsElem = screen.getByTestId('hud-stats');
+      expect(statsElem.className).toContain('hidden');
+      expect(statsElem.className).toContain('md:inline');
+      expect(statsElem.className).not.toContain('sm:inline');
+    });
+  });
+
   // ---- SB/BB info bar ----
   it('shows SB/BB in info bar', async () => {
     mockExec.mockResolvedValue(preFlopState);

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -125,7 +125,7 @@ function StatTooltip({ id, label, tooltipText }: { id: string; label: string; to
 function HudStats({ vpip, pfr, threeBet, af }: { vpip: number; pfr: number; threeBet: number; af: string }) {
   const { t } = useTranslation('holdem');
   return (
-    <span className="ml-2 text-ds-info text-[0.8em] hidden sm:inline" data-testid="hud-stats">
+    <span className="ml-2 text-ds-info text-[0.8em] hidden md:inline" data-testid="hud-stats">
       <StatTooltip id="tooltip-vpip" label={t('stats.vpip')} tooltipText={t('stats.vpipTooltip')} />:{vpip}%{' '}
       <StatTooltip id="tooltip-pfr" label={t('stats.pfr')} tooltipText={t('stats.pfrTooltip')} />:{pfr}%{' '}
       <StatTooltip id="tooltip-3bet" label={t('stats.threeBet')} tooltipText={t('stats.threeBetTooltip')} />:{threeBet}%{' '}

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -125,7 +125,7 @@ function StatTooltip({ id, label, tooltipText }: { id: string; label: string; to
 function HudStats({ vpip, pfr, threeBet, af }: { vpip: number; pfr: number; threeBet: number; af: string }) {
   const { t } = useTranslation('omaha');
   return (
-    <span className="ml-2 text-ds-info text-[0.8em] hidden sm:inline" data-testid="hud-stats">
+    <span className="ml-2 text-ds-info text-[0.8em] hidden md:inline" data-testid="hud-stats">
       <StatTooltip id="tooltip-vpip" label={t('stats.vpip')} tooltipText={t('stats.vpipTooltip')} />:{vpip}%{' '}
       <StatTooltip id="tooltip-pfr" label={t('stats.pfr')} tooltipText={t('stats.pfrTooltip')} />:{pfr}%{' '}
       <StatTooltip id="tooltip-3bet" label={t('stats.threeBet')} tooltipText={t('stats.threeBetTooltip')} />:{threeBet}%{' '}

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -132,7 +132,7 @@ function StatTooltip({ id, label, tooltipText }: { id: string; label: string; to
 function HudStats({ vpip, pfr, threeBet, af }: { vpip: number; pfr: number; threeBet: number; af: string }) {
   const { t } = useTranslation('pineapple');
   return (
-    <span className="ml-2 text-ds-info text-[0.8em] hidden sm:inline" data-testid="hud-stats">
+    <span className="ml-2 text-ds-info text-[0.8em] hidden md:inline" data-testid="hud-stats">
       <StatTooltip id="tooltip-vpip" label={t('stats.vpip')} tooltipText={t('stats.vpipTooltip')} />:{vpip}%{' '}
       <StatTooltip id="tooltip-pfr" label={t('stats.pfr')} tooltipText={t('stats.pfrTooltip')} />:{pfr}%{' '}
       <StatTooltip id="tooltip-3bet" label={t('stats.threeBet')} tooltipText={t('stats.threeBetTooltip')} />:{threeBet}%{' '}

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -125,7 +125,7 @@ function StatTooltip({ id, label, tooltipText }: { id: string; label: string; to
 function HudStats({ vpip, pfr, threeBet, af }: { vpip: number; pfr: number; threeBet: number; af: string }) {
   const { t } = useTranslation('shortdeck');
   return (
-    <span className="ml-2 text-ds-info text-[0.8em] hidden sm:inline" data-testid="hud-stats">
+    <span className="ml-2 text-ds-info text-[0.8em] hidden md:inline" data-testid="hud-stats">
       <StatTooltip id="tooltip-vpip" label={t('stats.vpip')} tooltipText={t('stats.vpipTooltip')} />:{vpip}%{' '}
       <StatTooltip id="tooltip-pfr" label={t('stats.pfr')} tooltipText={t('stats.pfrTooltip')} />:{pfr}%{' '}
       <StatTooltip id="tooltip-3bet" label={t('stats.threeBet')} tooltipText={t('stats.threeBetTooltip')} />:{threeBet}%{' '}


### PR DESCRIPTION
## Summary

- Bump the HUD stats breakpoint from \`hidden sm:inline\` → \`hidden md:inline\` in HoldemPage, OmahaPage, ShortDeckPage, and PineapplePage so VPIP/PFR/3Bet/AF stop competing with card and chip layout on 641–767px viewports (iPhone landscape, narrow tablets, 4:3 portrait phones).
- Stats remain fully visible on md+ (768px+) where horizontal space is plentiful.
- Add a regression test on HoldemPage that pins \`hidden md:inline\` on the hud-stats element so future edits can't silently drop back to \`sm:\`.

Note on scope: the issue lists SevenCardStud, Razz, and IndianPoker, but those pages don't render an HudStats block today (only CpuPlayerCard/PlayerInfoBar without stats). The 4 pages touched here are the complete set that surface the HUD.

Closes #1488

## Test plan

- [x] \`bun run test -- --run src/pages/HoldemPage.test.tsx src/pages/OmahaPage.test.tsx src/pages/ShortDeckPage.test.tsx src/pages/PineapplePage.test.tsx\` — 316 pass
- [ ] Manual verify at 375×667 (iPhone SE), 414×896 (iPhone Pro), 768×1024 (iPad portrait), 1280×800 (desktop)