### PR TITLE
feat(gofish, oldmaid): show transient CPU-action bubble on player areas

### DIFF
--- a/frontend/src/components/CpuActionBubble.test.tsx
+++ b/frontend/src/components/CpuActionBubble.test.tsx
@@ -1,0 +1,69 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CpuActionBubble } from './CpuActionBubble';
+
+describe('CpuActionBubble', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders no visible bubble initially but keeps an empty sr-only live region', () => {
+    render(<CpuActionBubble message={undefined} triggerKey={undefined} />);
+    expect(screen.queryByTestId('cpu-action-bubble')).not.toBeInTheDocument();
+    expect(screen.getByTestId('cpu-action-bubble-live')).toBeInTheDocument();
+  });
+
+  it('shows the bubble when message + triggerKey are set', () => {
+    render(<CpuActionBubble message="CPU 1 asks for 5" triggerKey="turn-1" />);
+    const bubble = screen.getByTestId('cpu-action-bubble');
+    expect(bubble).toHaveTextContent('CPU 1 asks for 5');
+    expect(bubble).toHaveAttribute('role', 'status');
+    expect(bubble).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('auto-dismisses after durationMs', () => {
+    render(<CpuActionBubble message="hello" triggerKey="k1" durationMs={1000} />);
+    expect(screen.getByTestId('cpu-action-bubble')).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+    expect(screen.getByTestId('cpu-action-bubble')).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(2);
+    });
+    expect(screen.queryByTestId('cpu-action-bubble')).not.toBeInTheDocument();
+  });
+
+  it('re-shows and resets the timer when triggerKey changes even if message is identical', () => {
+    const { rerender } = render(<CpuActionBubble message="ping" triggerKey="k1" durationMs={500} />);
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    rerender(<CpuActionBubble message="ping" triggerKey="k2" durationMs={500} />);
+    // Still visible right after re-trigger.
+    expect(screen.getByTestId('cpu-action-bubble')).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    // Would have been dismissed without re-trigger (400+400 > 500), but timer was reset.
+    expect(screen.getByTestId('cpu-action-bubble')).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(101);
+    });
+    expect(screen.queryByTestId('cpu-action-bubble')).not.toBeInTheDocument();
+  });
+
+  it('does not show the bubble when triggerKey is undefined', () => {
+    render(<CpuActionBubble message="hello" triggerKey={undefined} />);
+    expect(screen.queryByTestId('cpu-action-bubble')).not.toBeInTheDocument();
+  });
+
+  it('does not show the bubble when message is empty', () => {
+    render(<CpuActionBubble message="" triggerKey="k" />);
+    expect(screen.queryByTestId('cpu-action-bubble')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/CpuActionBubble.test.tsx
+++ b/frontend/src/components/CpuActionBubble.test.tsx
@@ -66,4 +66,34 @@ describe('CpuActionBubble', () => {
     render(<CpuActionBubble message="" triggerKey="k" />);
     expect(screen.queryByTestId('cpu-action-bubble')).not.toBeInTheDocument();
   });
+
+  // Regression: a mid-visibility clear of triggerKey / message used to leave
+  // the bubble on screen forever because the effect early-returned before
+  // setting visible=false. See PR #1498 review.
+  it('hides immediately when triggerKey clears mid-visibility', () => {
+    const { rerender } = render(<CpuActionBubble message="hello" triggerKey="k1" durationMs={5000} />);
+    expect(screen.getByTestId('cpu-action-bubble')).toBeInTheDocument();
+    rerender(<CpuActionBubble message="hello" triggerKey={undefined} durationMs={5000} />);
+    expect(screen.queryByTestId('cpu-action-bubble')).not.toBeInTheDocument();
+    expect(screen.getByTestId('cpu-action-bubble-live')).toBeInTheDocument();
+  });
+
+  it('hides immediately when message clears mid-visibility', () => {
+    const { rerender } = render(<CpuActionBubble message="hello" triggerKey="k1" durationMs={5000} />);
+    expect(screen.getByTestId('cpu-action-bubble')).toBeInTheDocument();
+    rerender(<CpuActionBubble message={undefined} triggerKey="k1" durationMs={5000} />);
+    expect(screen.queryByTestId('cpu-action-bubble')).not.toBeInTheDocument();
+  });
+
+  // The sr-only live region must stay mounted across every state transition
+  // so assistive tech doesn't miss announcements that land between mounts.
+  it('keeps the sr-only live region mounted after auto-dismiss', () => {
+    render(<CpuActionBubble message="hi" triggerKey="k" durationMs={100} />);
+    expect(screen.getByTestId('cpu-action-bubble')).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(screen.queryByTestId('cpu-action-bubble')).not.toBeInTheDocument();
+    expect(screen.getByTestId('cpu-action-bubble-live')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/CpuActionBubble.tsx
+++ b/frontend/src/components/CpuActionBubble.tsx
@@ -30,7 +30,14 @@ export function CpuActionBubble({ message, triggerKey, durationMs = 2500, classN
   const reduced = useReducedMotion();
 
   useEffect(() => {
-    if (triggerKey === undefined || !message) return;
+    // When the upstream event is gone (triggerKey cleared or message emptied),
+    // hide the bubble eagerly rather than waiting for the timer — otherwise a
+    // mid-visibility prop clear would leave the bubble on screen indefinitely.
+    if (triggerKey === undefined || !message) {
+      clearTimeout(timerRef.current);
+      setVisible(false);
+      return;
+    }
     setVisible(true);
     clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => setVisible(false), durationMs);

--- a/frontend/src/components/CpuActionBubble.tsx
+++ b/frontend/src/components/CpuActionBubble.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from 'react';
+import { useReducedMotion } from '../hooks/useReducedMotion';
+
+interface CpuActionBubbleProps {
+  /** Text shown in the bubble. Pass an empty string or undefined to hide. */
+  message: string | undefined;
+  /**
+   * Opaque identifier for the event. The bubble is re-shown (and the dismiss
+   * timer is reset) whenever this value changes, even if `message` is
+   * identical — e.g. CPU A asks for 5, CPU B asks for 5.
+   */
+  triggerKey: string | number | undefined;
+  /** Milliseconds before auto-dismissing. Defaults to 2500. */
+  durationMs?: number;
+  /** Extra Tailwind classes for positioning. */
+  className?: string;
+}
+
+/**
+ * Transient floating speech bubble announcing a CPU action (Go Fish ask,
+ * Old Maid draw, …). Auto-dismisses after `durationMs` and re-shows when
+ * `triggerKey` changes. The bubble is also a `role="status"`
+ * `aria-live="polite"` region so screen readers pick up each new event.
+ *
+ * Honors `prefers-reduced-motion`: animation is suppressed when set.
+ */
+export function CpuActionBubble({ message, triggerKey, durationMs = 2500, className = '' }: CpuActionBubbleProps) {
+  const [visible, setVisible] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const reduced = useReducedMotion();
+
+  useEffect(() => {
+    if (triggerKey === undefined || !message) return;
+    setVisible(true);
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setVisible(false), durationMs);
+    return () => clearTimeout(timerRef.current);
+  }, [triggerKey, message, durationMs]);
+
+  if (!visible || !message) {
+    // Keep an always-mounted sr-only live region so assistive tech can pick up
+    // announcements that land within the polite-region throttling window.
+    return (
+      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only" data-testid="cpu-action-bubble-live">
+        {message ?? ''}
+      </div>
+    );
+  }
+
+  const animation = reduced ? '' : 'animate-[slideDown_0.25s_ease-out] ';
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      data-testid="cpu-action-bubble"
+      className={`pointer-events-none ${animation}inline-block rounded-full bg-ds-accent/90 px-3 py-1 text-white text-xs font-bold shadow-lg ${className}`}
+    >
+      {message}
+    </div>
+  );
+}

--- a/frontend/src/components/gofish/GoFishPlayerArea.test.tsx
+++ b/frontend/src/components/gofish/GoFishPlayerArea.test.tsx
@@ -44,4 +44,41 @@ describe('GoFishPlayerArea', () => {
     renderWithProviders(<GoFishPlayerArea player={cpuPlayer} isSelected={false} onSelect={vi.fn()} disabled={false} />);
     expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'false');
   });
+
+  it('does not render an ask bubble when askAnnotation is absent', () => {
+    renderWithProviders(<GoFishPlayerArea player={cpuPlayer} isSelected={false} onSelect={vi.fn()} disabled={false} />);
+    expect(screen.queryByTestId('cpu-action-bubble')).not.toBeInTheDocument();
+  });
+
+  it('renders hit bubble with count when askAnnotation.receivedCount > 0', () => {
+    renderWithProviders(
+      <GoFishPlayerArea
+        player={cpuPlayer}
+        isSelected={false}
+        onSelect={vi.fn()}
+        disabled={false}
+        askAnnotation={{ rank: 5, receivedCount: 2, triggerKey: 't-1' }}
+      />,
+    );
+    const bubble = screen.getByTestId('cpu-action-bubble');
+    // "5 → ..." or "5 → 2枚！" — must contain both rank and count tokens.
+    expect(bubble.textContent).toMatch(/5/);
+    expect(bubble.textContent).toMatch(/2/);
+  });
+
+  it('renders miss bubble with Go Fish when receivedCount is 0', () => {
+    renderWithProviders(
+      <GoFishPlayerArea
+        player={cpuPlayer}
+        isSelected={false}
+        onSelect={vi.fn()}
+        disabled={false}
+        askAnnotation={{ rank: 11, receivedCount: 0, triggerKey: 't-2' }}
+      />,
+    );
+    const bubble = screen.getByTestId('cpu-action-bubble');
+    // 11 → 'J' via valueName
+    expect(bubble.textContent).toMatch(/J/);
+    expect(bubble.textContent).toMatch(/Go Fish/);
+  });
 });

--- a/frontend/src/components/gofish/GoFishPlayerArea.test.tsx
+++ b/frontend/src/components/gofish/GoFishPlayerArea.test.tsx
@@ -45,9 +45,13 @@ describe('GoFishPlayerArea', () => {
     expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'false');
   });
 
-  it('does not render an ask bubble when askAnnotation is absent', () => {
+  it('does not render a visible ask bubble when askAnnotation is absent', () => {
     renderWithProviders(<GoFishPlayerArea player={cpuPlayer} isSelected={false} onSelect={vi.fn()} disabled={false} />);
+    // Visible bubble must be absent…
     expect(screen.queryByTestId('cpu-action-bubble')).not.toBeInTheDocument();
+    // …but the sr-only live region stays mounted so announcements aren't
+    // missed between mounts (see PR #1498 review).
+    expect(screen.getByTestId('cpu-action-bubble-live')).toBeInTheDocument();
   });
 
   it('renders hit bubble with count when askAnnotation.receivedCount > 0', () => {

--- a/frontend/src/components/gofish/GoFishPlayerArea.tsx
+++ b/frontend/src/components/gofish/GoFishPlayerArea.tsx
@@ -43,11 +43,12 @@ export function GoFishPlayerArea({ player, isSelected, onSelect, disabled, askAn
 
   return (
     <div className="relative">
-      {bubbleMessage && (
-        <div className="absolute -top-2 right-2 z-10">
-          <CpuActionBubble message={bubbleMessage} triggerKey={askAnnotation?.triggerKey} />
-        </div>
-      )}
+      {/* Always mount CpuActionBubble so its sr-only live region stays in the
+          DOM across renders. Without this, unmounting would cause screen
+          readers to miss announcements that land between mounts. */}
+      <div className="absolute -top-2 right-2 z-10">
+        <CpuActionBubble message={bubbleMessage} triggerKey={askAnnotation?.triggerKey} />
+      </div>
       <button
         type="button"
         onClick={() => onSelect(player.id)}

--- a/frontend/src/components/gofish/GoFishPlayerArea.tsx
+++ b/frontend/src/components/gofish/GoFishPlayerArea.tsx
@@ -1,32 +1,66 @@
 import { useTranslation } from 'react-i18next';
 import type { GoFishPlayerData } from '../../types/card';
+import { valueName } from '../../utils/cardUtils';
 import { playerName } from '../../utils/playerUtils';
+import { CpuActionBubble } from '../CpuActionBubble';
+
+/** Optional transient "last ask" annotation rendered as a speech bubble. */
+export interface GoFishAskAnnotation {
+  /** The rank that was asked (1-13). */
+  rank: number;
+  /** Number of cards actually received. Zero means "Go Fish" miss. */
+  receivedCount: number;
+  /** Stable identity used to re-trigger the bubble animation. */
+  triggerKey: string | number;
+}
 
 interface GoFishPlayerAreaProps {
   player: GoFishPlayerData;
   isSelected: boolean;
   onSelect: (idx: number) => void;
   disabled: boolean;
+  /**
+   * When set, a short-lived speech bubble is rendered above the player area
+   * summarizing the last ask that targeted this player. Pass `undefined` to
+   * hide the bubble.
+   */
+  askAnnotation?: GoFishAskAnnotation;
 }
 
 /** Renders an opponent's card count and book count, clickable to select as ask target. */
-export function GoFishPlayerArea({ player, isSelected, onSelect, disabled }: GoFishPlayerAreaProps) {
+export function GoFishPlayerArea({ player, isSelected, onSelect, disabled, askAnnotation }: GoFishPlayerAreaProps) {
   const { t } = useTranslation('gofish');
   const name = playerName(player.id, player.isHuman);
 
+  const bubbleMessage = askAnnotation
+    ? askAnnotation.receivedCount > 0
+      ? t('bubble.askHit', {
+          rank: valueName(askAnnotation.rank),
+          count: askAnnotation.receivedCount,
+        })
+      : t('bubble.askMiss', { rank: valueName(askAnnotation.rank) })
+    : undefined;
+
   return (
-    <button
-      type="button"
-      onClick={() => onSelect(player.id)}
-      disabled={disabled}
-      className={`w-full mb-2 p-2 rounded text-left transition-colors ${
-        isSelected ? 'bg-ds-warning/30 ring-2 ring-ds-warning' : 'bg-black/30 hover:bg-black/40'
-      } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
-      aria-pressed={isSelected}
-    >
-      <div className="text-ds-text-muted text-sm">
-        {name}: {t('deck', { count: player.cardCount })} | {t('books', { count: player.bookCount })}
-      </div>
-    </button>
+    <div className="relative">
+      {bubbleMessage && (
+        <div className="absolute -top-2 right-2 z-10">
+          <CpuActionBubble message={bubbleMessage} triggerKey={askAnnotation?.triggerKey} />
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={() => onSelect(player.id)}
+        disabled={disabled}
+        className={`w-full mb-2 p-2 rounded text-left transition-colors ${
+          isSelected ? 'bg-ds-warning/30 ring-2 ring-ds-warning' : 'bg-black/30 hover:bg-black/40'
+        } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+        aria-pressed={isSelected}
+      >
+        <div className="text-ds-text-muted text-sm">
+          {name}: {t('deck', { count: player.cardCount })} | {t('books', { count: player.bookCount })}
+        </div>
+      </button>
+    </div>
   );
 }

--- a/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
+++ b/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
@@ -6,7 +6,14 @@ import type { OldMaidPlayerData } from '../../types/card';
 import { cardAlt } from '../../utils/cardAlt';
 import { playerName } from '../../utils/playerUtils';
 import { CardBack, CardImage } from '../CardImage';
+import { CpuActionBubble } from '../CpuActionBubble';
 import { StatusBadge } from '../StatusBadge';
+
+/** Optional transient announcement bubble rendered at the top of a player area. */
+export interface PlayerAreaBubble {
+  message: string;
+  triggerKey: string | number;
+}
 
 /** CSS class for Old Maid player area layout. */
 export const playerAreaClass = `${playerAreaBase} p-2 flex-[1_1_140px] min-w-[120px]`;
@@ -24,6 +31,11 @@ interface PlayerAreaProps {
   onReorder?: (indices: number[]) => void;
   /** When true, non-target CPU players hide card back images to save space. */
   compactNonTarget?: boolean;
+  /**
+   * When set, a transient floating bubble is shown at the top of the area
+   * (e.g. "just drew a card") with live-region semantics for screen readers.
+   */
+  bubble?: PlayerAreaBubble;
 }
 
 /** Renders a player area for Old Maid with draw targets, hand display, and reorder support. */
@@ -39,6 +51,7 @@ export function OldMaidPlayerArea({
   onDraw,
   onReorder,
   compactNonTarget,
+  bubble,
 }: PlayerAreaProps) {
   const { t } = useTranslation('oldmaid');
   const { t: tc } = useTranslation('common');
@@ -130,8 +143,13 @@ export function OldMaidPlayerArea({
   return (
     <div
       id={`player-area-${player.id}`}
-      className={`${playerAreaClass}${conditionalClass ? ` ${conditionalClass}` : ''}`}
+      className={`relative ${playerAreaClass}${conditionalClass ? ` ${conditionalClass}` : ''}`}
     >
+      {bubble && (
+        <div className="absolute -top-2 left-1/2 -translate-x-1/2 z-10">
+          <CpuActionBubble message={bubble.message} triggerKey={bubble.triggerKey} />
+        </div>
+      )}
       <div className="text-white font-bold mb-1 text-sm">
         {playerName(player.id, player.isHuman)}
         {player.isFinished && <StatusBadge variant="success">{tc('status.finished')}</StatusBadge>}

--- a/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
+++ b/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
@@ -145,11 +145,12 @@ export function OldMaidPlayerArea({
       id={`player-area-${player.id}`}
       className={`relative ${playerAreaClass}${conditionalClass ? ` ${conditionalClass}` : ''}`}
     >
-      {bubble && (
-        <div className="absolute -top-2 left-1/2 -translate-x-1/2 z-10">
-          <CpuActionBubble message={bubble.message} triggerKey={bubble.triggerKey} />
-        </div>
-      )}
+      {/* Always mount CpuActionBubble so its sr-only live region stays in the
+          DOM across renders. Without this, unmounting would cause screen
+          readers to miss announcements that land between mounts. */}
+      <div className="absolute -top-2 left-1/2 -translate-x-1/2 z-10">
+        <CpuActionBubble message={bubble?.message} triggerKey={bubble?.triggerKey} />
+      </div>
       <div className="text-white font-bold mb-1 text-sm">
         {playerName(player.id, player.isHuman)}
         {player.isFinished && <StatusBadge variant="success">{tc('status.finished')}</StatusBadge>}

--- a/frontend/src/i18n/locales/en/gofish.json
+++ b/frontend/src/i18n/locales/en/gofish.json
@@ -22,6 +22,10 @@
     "miss": "{{asker}} asked {{target}} for rank {{rank}} → Go Fish!",
     "bookFormed": "Book complete! Rank {{rank}}"
   },
+  "bubble": {
+    "askHit": "{{rank}} → +{{count}}",
+    "askMiss": "{{rank}}? → Go Fish!"
+  },
   "result": {
     "humanWin": "Game over! You win!",
     "cpuWin": "Game over! CPU {{cpuId}} wins!"

--- a/frontend/src/i18n/locales/en/oldmaid.json
+++ b/frontend/src/i18n/locales/en/oldmaid.json
@@ -61,5 +61,9 @@
     "selectCardToMove": "Select card to move: {{card}}",
     "deselectCard": "Deselect {{card}}",
     "moveHere": "Move {{card}} to position {{to}}"
+  },
+  "bubble": {
+    "drewFrom": "← from {{from}}",
+    "drewAndPaired": "← from {{from}} (paired)"
   }
 }

--- a/frontend/src/i18n/locales/ja/gofish.json
+++ b/frontend/src/i18n/locales/ja/gofish.json
@@ -22,6 +22,10 @@
     "miss": "{{asker}} が {{target}} にランク {{rank}} を要求 → Go Fish!",
     "bookFormed": "ブック完成！ ランク {{rank}}"
   },
+  "bubble": {
+    "askHit": "{{rank}} → {{count}}枚！",
+    "askMiss": "{{rank}}? → Go Fish!"
+  },
   "result": {
     "humanWin": "ゲーム終了！ あなたの勝ち！",
     "cpuWin": "ゲーム終了！ CPU {{cpuId}}の勝ち！"

--- a/frontend/src/i18n/locales/ja/oldmaid.json
+++ b/frontend/src/i18n/locales/ja/oldmaid.json
@@ -61,5 +61,9 @@
     "selectCardToMove": "並び替えるカード: {{card}}",
     "deselectCard": "{{card}} の選択を解除",
     "moveHere": "{{card}} をここ（{{to}}番目）に移動"
+  },
+  "bubble": {
+    "drewFrom": "← {{from}} から",
+    "drewAndPaired": "← {{from}} から (ペア成立)"
   }
 }

--- a/frontend/src/pages/GoFishPage.tsx
+++ b/frontend/src/pages/GoFishPage.tsx
@@ -182,13 +182,19 @@ function GoFishPageContent() {
                 // targeted by the most recent ask. `turnNumber` guarantees a
                 // fresh triggerKey even when two consecutive asks have the
                 // same rank and target. See issue #1490.
-                const isLastTargeted = state.lastAsk !== null && state.lastAsk.targetIdx === p.id;
+                //
+                // `cardsReceived` is serialized by the Go backend with
+                // `omitempty`, so on a miss the field is absent entirely —
+                // using `?.length ?? 0` instead of `.length` avoids the
+                // TypeError that otherwise crashes the page before CPU turns
+                // finish.
+                const lastAsk = state.lastAsk;
                 const askAnnotation =
-                  isLastTargeted && state.lastAsk
+                  lastAsk && lastAsk.targetIdx === p.id
                     ? {
-                        rank: state.lastAsk.rank,
-                        receivedCount: state.lastAsk.cardsReceived.length,
-                        triggerKey: `${state.turnNumber}-${state.lastAsk.playerIdx}-${state.lastAsk.targetIdx}-${state.lastAsk.rank}`,
+                        rank: lastAsk.rank,
+                        receivedCount: lastAsk.cardsReceived?.length ?? 0,
+                        triggerKey: `${state.turnNumber}-${lastAsk.playerIdx}-${lastAsk.targetIdx}-${lastAsk.rank}`,
                       }
                     : undefined;
                 return (

--- a/frontend/src/pages/GoFishPage.tsx
+++ b/frontend/src/pages/GoFishPage.tsx
@@ -177,15 +177,31 @@ function GoFishPageContent() {
 
             {/* CPU player areas */}
             <div data-tutorial="gf-cpu-area">
-              {cpuPlayers.map((p) => (
-                <GoFishPlayerArea
-                  key={p.id}
-                  player={p}
-                  isSelected={selectedTarget === p.id}
-                  onSelect={handleSelectTarget}
-                  disabled={!isHumanTurn || loading}
-                />
-              ))}
+              {cpuPlayers.map((p) => {
+                // Surface a transient bubble on whichever player was just
+                // targeted by the most recent ask. `turnNumber` guarantees a
+                // fresh triggerKey even when two consecutive asks have the
+                // same rank and target. See issue #1490.
+                const isLastTargeted = state.lastAsk !== null && state.lastAsk.targetIdx === p.id;
+                const askAnnotation =
+                  isLastTargeted && state.lastAsk
+                    ? {
+                        rank: state.lastAsk.rank,
+                        receivedCount: state.lastAsk.cardsReceived.length,
+                        triggerKey: `${state.turnNumber}-${state.lastAsk.playerIdx}-${state.lastAsk.targetIdx}-${state.lastAsk.rank}`,
+                      }
+                    : undefined;
+                return (
+                  <GoFishPlayerArea
+                    key={p.id}
+                    player={p}
+                    isSelected={selectedTarget === p.id}
+                    onSelect={handleSelectTarget}
+                    disabled={!isHumanTurn || loading}
+                    askAnnotation={askAnnotation}
+                  />
+                );
+              })}
             </div>
 
             {/* Rank selector */}

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -246,7 +246,11 @@ function OldMaidPageContent() {
                           : t('bubble.drewFrom', {
                               from: findPlayerName(state.players, state.lastDrawFromIdx),
                             }),
-                      triggerKey: `${state.lastDrawPlayerIdx}-${state.lastDrawFromIdx}-${state.lastDrawCard?.design ?? 'x'}-${state.lastDrawCard?.value ?? 0}`,
+                      // Prepend the monotonic drawHistory length so identical
+                      // back-to-back draws (same player, same target, same
+                      // card bouncing back, e.g. Joker) still re-trigger the
+                      // animation. Go Fish gets this for free via turnNumber.
+                      triggerKey: `${state.drawHistory?.length ?? 0}-${state.lastDrawPlayerIdx}-${state.lastDrawFromIdx}-${state.lastDrawCard?.design ?? 'x'}-${state.lastDrawCard?.value ?? 0}`,
                     }
                   : undefined;
                 return (

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -230,31 +230,52 @@ function OldMaidPageContent() {
 
             {/* CPU row */}
             <div className="flex gap-2 flex-wrap mb-2 justify-center" data-tutorial="om-cpu-area">
-              {cpuPlayers.map((player) => (
-                <OldMaidPlayerArea
-                  key={player.id}
-                  player={player}
-                  isTarget={state.nextDrawTargetIdx === player.id}
-                  isHumanTurn={isHumanTurn}
-                  gameEndFlag={state.gameEndFlag}
-                  loading={loading}
-                  highlightedCardIdx={state.nextDrawTargetIdx === player.id ? state.cpuHighlightedCardIdx : -1}
-                  isSuspect={suspectPins.has(player.id)}
-                  compactNonTarget={isMobile}
-                  onToggleSuspect={() =>
-                    setSuspectPins((prev) => {
-                      const next = new Set(prev);
-                      if (next.has(player.id)) {
-                        next.delete(player.id);
-                      } else {
-                        next.add(player.id);
-                      }
-                      return next;
-                    })
-                  }
-                  onDraw={(drawIdx) => gameExec('draw', drawIdx)}
-                />
-              ))}
+              {cpuPlayers.map((player) => {
+                // Surface a transient bubble on the CPU that just drew so the
+                // player can visually track who acted without reading the log.
+                // See issue #1490.
+                const isDrawer =
+                  !state.gameEndFlag && state.hasDrawn && state.lastDrawPlayerIdx === player.id && !player.isHuman;
+                const bubble = isDrawer
+                  ? {
+                      message:
+                        state.lastDiscardedPairs > 0
+                          ? t('bubble.drewAndPaired', {
+                              from: findPlayerName(state.players, state.lastDrawFromIdx),
+                            })
+                          : t('bubble.drewFrom', {
+                              from: findPlayerName(state.players, state.lastDrawFromIdx),
+                            }),
+                      triggerKey: `${state.lastDrawPlayerIdx}-${state.lastDrawFromIdx}-${state.lastDrawCard?.design ?? 'x'}-${state.lastDrawCard?.value ?? 0}`,
+                    }
+                  : undefined;
+                return (
+                  <OldMaidPlayerArea
+                    key={player.id}
+                    player={player}
+                    isTarget={state.nextDrawTargetIdx === player.id}
+                    isHumanTurn={isHumanTurn}
+                    gameEndFlag={state.gameEndFlag}
+                    loading={loading}
+                    highlightedCardIdx={state.nextDrawTargetIdx === player.id ? state.cpuHighlightedCardIdx : -1}
+                    isSuspect={suspectPins.has(player.id)}
+                    compactNonTarget={isMobile}
+                    onToggleSuspect={() =>
+                      setSuspectPins((prev) => {
+                        const next = new Set(prev);
+                        if (next.has(player.id)) {
+                          next.delete(player.id);
+                        } else {
+                          next.add(player.id);
+                        }
+                        return next;
+                      })
+                    }
+                    onDraw={(drawIdx) => gameExec('draw', drawIdx)}
+                    bubble={bubble}
+                  />
+                );
+              })}
             </div>
 
             {/* Discarded Area */}


### PR DESCRIPTION
## Summary

- Add a shared \`CpuActionBubble\` component — a floating, auto-dismissing (~2.5 s) \`role=\"status\" aria-live=\"polite\"\` badge that animates in with \`slideDown\` and re-fires when its \`triggerKey\` changes. Respects \`prefers-reduced-motion\`. 6 unit tests.
- **Go Fish**: \`GoFishPlayerArea\` now accepts an optional \`askAnnotation\` and shows the asked rank with outcome (\`5 → +2\` on hit, \`5? → Go Fish!\` on miss) above the targeted CPU. The triggerKey bundles \`turnNumber + asker + target + rank\` so identical back-to-back asks still animate.
- **Old Maid**: \`OldMaidPlayerArea\` now accepts an optional \`bubble\` prop and shows \"← from CPU 1\" (or \"(paired)\" when the draw formed a pair) above whichever CPU just drew.

Visual reinforcement makes CPU-vs-CPU turns easier to follow without having to read the action log every round, while keeping the existing textual log intact. SR support via the live region built into the bubble component.

Scope note: the issue asked for full card-movement animation between players. That requires Framer Motion layout animations and a design pass; it's deliberately out of scope for this LOW-severity fix. The bubble is a proportional, shippable step that covers the \"who did what to whom\" information need described in the issue.

Closes #1490

## Test plan

- [x] \`bun run test -- --run src/components/CpuActionBubble.test.tsx\` — 6 pass
- [x] \`bun run test -- --run src/components/gofish/GoFishPlayerArea.test.tsx\` — 7 pass (5 existing + 2 new)
- [x] \`bun run test -- --run src/pages/GoFishPage.test.tsx src/pages/OldMaidPage.test.tsx\` — 143 pass
- [x] \`bun run check\` — no new warnings
- [ ] Manual verify: Go Fish hit/miss bubble placement; Old Maid draw bubble placement