### PR TITLE
refactor(domain): dedupe Welford + AdaptStrength across HumanProfiles

### DIFF
--- a/internal/domain/BettingHumanProfile.go
+++ b/internal/domain/BettingHumanProfile.go
@@ -114,7 +114,7 @@ func (p *BettingHumanProfile) RecordFoldToBet(folded bool) {
 // RecordHesitation 迷い時間(ms)を記録する (Welford's online algorithm)
 // ms <= 0 の場合は何もしない (CUI等で計測不可の場合)
 func (p *BettingHumanProfile) RecordHesitation(ms int) {
-	welfordUpdate(ms, &p.HesitationCount, &p.HesitationMean, &p.HesitationM2)
+	welfordUpdate(&p.HesitationCount, &p.HesitationMean, &p.HesitationM2, ms)
 }
 
 // BluffRate 指定ブラケットのアグレッシブ率を返す (データなしの場合0.5)
@@ -145,7 +145,7 @@ func (p *BettingHumanProfile) HesitationStdDev() float64 {
 
 // HesitationZScore 指定msの迷い時間のz-scoreを返す (データ不足の場合0)
 func (p *BettingHumanProfile) HesitationZScore(ms int) float64 {
-	return welfordZScore(ms, p.HesitationCount, p.HesitationMean, p.HesitationM2)
+	return welfordZScore(p.HesitationCount, p.HesitationMean, p.HesitationM2, ms)
 }
 
 // HesitationBoost 指定msの迷い時間に対するコール確率ブーストを返す

--- a/internal/domain/BettingHumanProfile.go
+++ b/internal/domain/BettingHumanProfile.go
@@ -2,7 +2,6 @@ package domain
 
 import (
 	"encoding/json"
-	"math"
 )
 
 // BettingHumanProfileBracketData はブラケット別アグレッシブ行動のJSON出力形式
@@ -115,15 +114,7 @@ func (p *BettingHumanProfile) RecordFoldToBet(folded bool) {
 // RecordHesitation 迷い時間(ms)を記録する (Welford's online algorithm)
 // ms <= 0 の場合は何もしない (CUI等で計測不可の場合)
 func (p *BettingHumanProfile) RecordHesitation(ms int) {
-	if ms <= 0 {
-		return
-	}
-	p.HesitationCount++
-	x := float64(ms)
-	delta := x - p.HesitationMean
-	p.HesitationMean += delta / float64(p.HesitationCount)
-	delta2 := x - p.HesitationMean
-	p.HesitationM2 += delta * delta2
+	welfordUpdate(ms, &p.HesitationCount, &p.HesitationMean, &p.HesitationM2)
 }
 
 // BluffRate 指定ブラケットのアグレッシブ率を返す (データなしの場合0.5)
@@ -144,44 +135,22 @@ func (p *BettingHumanProfile) FoldRate() float64 {
 
 // AdaptStrength 適応強度を返す (0.0 ~ 0.2)
 func (p *BettingHumanProfile) AdaptStrength() float64 {
-	games := p.GamesPlayed
-	if games > metaAIMaxAdaptGames {
-		games = metaAIMaxAdaptGames
-	}
-	return float64(games) * metaAIAdaptPerGame
+	return computeAdaptStrength(p.GamesPlayed)
 }
 
 // HesitationStdDev 迷い時間の標準偏差を返す (データ不足の場合0)
 func (p *BettingHumanProfile) HesitationStdDev() float64 {
-	if p.HesitationCount < 2 {
-		return 0
-	}
-	return math.Sqrt(p.HesitationM2 / float64(p.HesitationCount-1))
+	return welfordStdDev(p.HesitationCount, p.HesitationM2)
 }
 
 // HesitationZScore 指定msの迷い時間のz-scoreを返す (データ不足の場合0)
 func (p *BettingHumanProfile) HesitationZScore(ms int) float64 {
-	sd := p.HesitationStdDev()
-	if sd == 0 {
-		return 0
-	}
-	return (float64(ms) - p.HesitationMean) / sd
+	return welfordZScore(ms, p.HesitationCount, p.HesitationMean, p.HesitationM2)
 }
 
 // HesitationBoost 指定msの迷い時間に対するコール確率ブーストを返す
 func (p *BettingHumanProfile) HesitationBoost(ms int) float64 {
-	if p.HesitationCount < hesitationMinPlays {
-		return 0
-	}
-	z := p.HesitationZScore(ms)
-	if z <= hesitationZThreshold {
-		return 0
-	}
-	boost := (z - hesitationZThreshold) * hesitationWeight
-	if boost > maxHesitationBoost {
-		return maxHesitationBoost
-	}
-	return boost
+	return hesitationBoost(p.HesitationCount, p.HesitationMean, p.HesitationM2, ms)
 }
 
 // AdjustedCallChance ブラフ率と迷い時間に基づいて調整済みコール確率を返す

--- a/internal/domain/DoubtHumanProfile.go
+++ b/internal/domain/DoubtHumanProfile.go
@@ -132,7 +132,7 @@ func (p *DoubtHumanProfile) AdaptStrength() float64 {
 // RecordHesitation 迷い時間(ms)を記録する (Welford's online algorithm)
 // ms <= 0 の場合は何もしない (CUI等で計測不可の場合)
 func (p *DoubtHumanProfile) RecordHesitation(ms int) {
-	welfordUpdate(ms, &p.HesitationCount, &p.HesitationMean, &p.HesitationM2)
+	welfordUpdate(&p.HesitationCount, &p.HesitationMean, &p.HesitationM2, ms)
 }
 
 // HesitationStdDev 迷い時間の標準偏差を返す (データ不足の場合0)
@@ -142,7 +142,7 @@ func (p *DoubtHumanProfile) HesitationStdDev() float64 {
 
 // HesitationZScore 指定msの迷い時間のz-scoreを返す (データ不足の場合0)
 func (p *DoubtHumanProfile) HesitationZScore(ms int) float64 {
-	return welfordZScore(ms, p.HesitationCount, p.HesitationMean, p.HesitationM2)
+	return welfordZScore(p.HesitationCount, p.HesitationMean, p.HesitationM2, ms)
 }
 
 // HesitationBoost 指定msの迷い時間に対するダウト確率ブーストを返す

--- a/internal/domain/DoubtHumanProfile.go
+++ b/internal/domain/DoubtHumanProfile.go
@@ -2,7 +2,6 @@ package domain
 
 import (
 	"encoding/json"
-	"math"
 )
 
 // DoubtHumanProfileBracketData はブラケット別ブラフ行動のJSON出力形式
@@ -81,18 +80,6 @@ type DoubtHumanProfile struct {
 	HesitationM2 float64
 }
 
-// hesitationMinPlays 迷い時間ブーストを有効にするための最小データ点数
-const hesitationMinPlays = 3
-
-// hesitationZThreshold z-scoreがこの値を超えた場合にブーストが発生する
-const hesitationZThreshold = 1.0
-
-// hesitationWeight z-score超過分に対するブースト重み
-const hesitationWeight = 0.05
-
-// maxHesitationBoost 迷い時間ブーストの上限
-const maxHesitationBoost = 0.10
-
 // doubtHandSizeBracket 手札枚数をブラケット(0-2)に分類する
 func doubtHandSizeBracket(handSize int) int {
 	if handSize <= 4 {
@@ -137,66 +124,30 @@ func (p *DoubtHumanProfile) DoubtAccuracy() float64 {
 	return float64(p.DoubtCorrect) / float64(p.DoubtTotal)
 }
 
-// metaAIMaxAdaptGames 適応が最大に達するゲーム数
-const metaAIMaxAdaptGames = 5
-
-// metaAIAdaptPerGame 1ゲームあたりの適応強度
-const metaAIAdaptPerGame = 0.04
-
 // AdaptStrength 適応強度を返す (0.0 ~ 0.2)
 func (p *DoubtHumanProfile) AdaptStrength() float64 {
-	games := p.GamesPlayed
-	if games > metaAIMaxAdaptGames {
-		games = metaAIMaxAdaptGames
-	}
-	return float64(games) * metaAIAdaptPerGame
+	return computeAdaptStrength(p.GamesPlayed)
 }
 
 // RecordHesitation 迷い時間(ms)を記録する (Welford's online algorithm)
 // ms <= 0 の場合は何もしない (CUI等で計測不可の場合)
 func (p *DoubtHumanProfile) RecordHesitation(ms int) {
-	if ms <= 0 {
-		return
-	}
-	p.HesitationCount++
-	x := float64(ms)
-	delta := x - p.HesitationMean
-	p.HesitationMean += delta / float64(p.HesitationCount)
-	delta2 := x - p.HesitationMean
-	p.HesitationM2 += delta * delta2
+	welfordUpdate(ms, &p.HesitationCount, &p.HesitationMean, &p.HesitationM2)
 }
 
 // HesitationStdDev 迷い時間の標準偏差を返す (データ不足の場合0)
 func (p *DoubtHumanProfile) HesitationStdDev() float64 {
-	if p.HesitationCount < 2 {
-		return 0
-	}
-	return math.Sqrt(p.HesitationM2 / float64(p.HesitationCount-1))
+	return welfordStdDev(p.HesitationCount, p.HesitationM2)
 }
 
 // HesitationZScore 指定msの迷い時間のz-scoreを返す (データ不足の場合0)
 func (p *DoubtHumanProfile) HesitationZScore(ms int) float64 {
-	sd := p.HesitationStdDev()
-	if sd == 0 {
-		return 0
-	}
-	return (float64(ms) - p.HesitationMean) / sd
+	return welfordZScore(ms, p.HesitationCount, p.HesitationMean, p.HesitationM2)
 }
 
 // HesitationBoost 指定msの迷い時間に対するダウト確率ブーストを返す
 func (p *DoubtHumanProfile) HesitationBoost(ms int) float64 {
-	if p.HesitationCount < hesitationMinPlays {
-		return 0
-	}
-	z := p.HesitationZScore(ms)
-	if z <= hesitationZThreshold {
-		return 0
-	}
-	boost := (z - hesitationZThreshold) * hesitationWeight
-	if boost > maxHesitationBoost {
-		return maxHesitationBoost
-	}
-	return boost
+	return hesitationBoost(p.HesitationCount, p.HesitationMean, p.HesitationM2, ms)
 }
 
 // AdjustedDoubtChance ブラフ率と迷い時間に基づいて調整済みダウト確率を返す

--- a/internal/domain/IndianPokerHumanProfile.go
+++ b/internal/domain/IndianPokerHumanProfile.go
@@ -115,7 +115,7 @@ func (p *IndianPokerHumanProfile) RecordFoldToBet(folded bool) {
 // RecordHesitation 迷い時間(ms)を記録する (Welford's online algorithm)
 // ms <= 0 の場合は何もしない (CUI等で計測不可の場合)
 func (p *IndianPokerHumanProfile) RecordHesitation(ms int) {
-	welfordUpdate(ms, &p.HesitationCount, &p.HesitationMean, &p.HesitationM2)
+	welfordUpdate(&p.HesitationCount, &p.HesitationMean, &p.HesitationM2, ms)
 }
 
 // BluffRate 指定ブラケットのアグレッシブ率を返す (データなしの場合0.5)
@@ -146,7 +146,7 @@ func (p *IndianPokerHumanProfile) HesitationStdDev() float64 {
 
 // HesitationZScore 指定msの迷い時間のz-scoreを返す (データ不足の場合0)
 func (p *IndianPokerHumanProfile) HesitationZScore(ms int) float64 {
-	return welfordZScore(ms, p.HesitationCount, p.HesitationMean, p.HesitationM2)
+	return welfordZScore(p.HesitationCount, p.HesitationMean, p.HesitationM2, ms)
 }
 
 // HesitationBoost 指定msの迷い時間に対するコール確率ブーストを返す

--- a/internal/domain/IndianPokerHumanProfile.go
+++ b/internal/domain/IndianPokerHumanProfile.go
@@ -2,7 +2,6 @@ package domain
 
 import (
 	"encoding/json"
-	"math"
 )
 
 // IndianPokerHumanProfileBracketData はブラケット別アグレッシブ行動のJSON出力形式
@@ -116,15 +115,7 @@ func (p *IndianPokerHumanProfile) RecordFoldToBet(folded bool) {
 // RecordHesitation 迷い時間(ms)を記録する (Welford's online algorithm)
 // ms <= 0 の場合は何もしない (CUI等で計測不可の場合)
 func (p *IndianPokerHumanProfile) RecordHesitation(ms int) {
-	if ms <= 0 {
-		return
-	}
-	p.HesitationCount++
-	x := float64(ms)
-	delta := x - p.HesitationMean
-	p.HesitationMean += delta / float64(p.HesitationCount)
-	delta2 := x - p.HesitationMean
-	p.HesitationM2 += delta * delta2
+	welfordUpdate(ms, &p.HesitationCount, &p.HesitationMean, &p.HesitationM2)
 }
 
 // BluffRate 指定ブラケットのアグレッシブ率を返す (データなしの場合0.5)
@@ -145,41 +136,22 @@ func (p *IndianPokerHumanProfile) FoldRate() float64 {
 
 // AdaptStrength 適応強度を返す (0.0 ~ 0.2)
 func (p *IndianPokerHumanProfile) AdaptStrength() float64 {
-	games := min(p.GamesPlayed, metaAIMaxAdaptGames)
-	return float64(games) * metaAIAdaptPerGame
+	return computeAdaptStrength(p.GamesPlayed)
 }
 
 // HesitationStdDev 迷い時間の標準偏差を返す (データ不足の場合0)
 func (p *IndianPokerHumanProfile) HesitationStdDev() float64 {
-	if p.HesitationCount < 2 {
-		return 0
-	}
-	return math.Sqrt(p.HesitationM2 / float64(p.HesitationCount-1))
+	return welfordStdDev(p.HesitationCount, p.HesitationM2)
 }
 
 // HesitationZScore 指定msの迷い時間のz-scoreを返す (データ不足の場合0)
 func (p *IndianPokerHumanProfile) HesitationZScore(ms int) float64 {
-	sd := p.HesitationStdDev()
-	if sd == 0 {
-		return 0
-	}
-	return (float64(ms) - p.HesitationMean) / sd
+	return welfordZScore(ms, p.HesitationCount, p.HesitationMean, p.HesitationM2)
 }
 
 // HesitationBoost 指定msの迷い時間に対するコール確率ブーストを返す
 func (p *IndianPokerHumanProfile) HesitationBoost(ms int) float64 {
-	if p.HesitationCount < hesitationMinPlays {
-		return 0
-	}
-	z := p.HesitationZScore(ms)
-	if z <= hesitationZThreshold {
-		return 0
-	}
-	boost := (z - hesitationZThreshold) * hesitationWeight
-	if boost > maxHesitationBoost {
-		return maxHesitationBoost
-	}
-	return boost
+	return hesitationBoost(p.HesitationCount, p.HesitationMean, p.HesitationM2, ms)
 }
 
 // AdjustedCallChance ブラフ率と迷い時間に基づいて調整済みコール確率を返す

--- a/internal/domain/hesitation.go
+++ b/internal/domain/hesitation.go
@@ -1,5 +1,7 @@
 package domain
 
+import "math"
+
 // 迷い時間ディレイ (ミリ秒) の共通範囲定数
 const (
 	hesitationFastMin   = 300 // 速い反応 (ペア成立, ブラフ急ぎ)
@@ -7,3 +9,101 @@ const (
 	hesitationMediumMin = 600 // 中間の反応 (正直, 通常)
 	hesitationMediumMax = 1000
 )
+
+// Meta-AI adaptation tuning constants, shared by every HumanProfile.
+// See issue #1486 — previously scattered across DoubtHumanProfile.go.
+const (
+	// hesitationMinPlays 迷い時間ブーストを有効にするための最小データ点数
+	hesitationMinPlays = 3
+	// hesitationZThreshold z-scoreがこの値を超えた場合にブーストが発生する
+	hesitationZThreshold = 1.0
+	// hesitationWeight z-score超過分に対するブースト重み
+	hesitationWeight = 0.05
+	// maxHesitationBoost 迷い時間ブーストの上限
+	maxHesitationBoost = 0.10
+	// metaAIMaxAdaptGames 適応が最大に達するゲーム数
+	metaAIMaxAdaptGames = 5
+	// metaAIAdaptPerGame 1ゲームあたりの適応強度
+	metaAIAdaptPerGame = 0.04
+)
+
+// Welford's online algorithm and meta-AI adaptation helpers shared by every
+// HumanProfile that tracks hesitation time. The three profile structs
+// (Betting, IndianPoker, Doubt) all need:
+//
+//   - Streaming mean/variance of hesitation times (numerically stable).
+//   - A bounded linear ramp from GamesPlayed → adapt strength.
+//   - A z-score-based probability boost once enough samples exist.
+//
+// Previously each profile carried its own copy of these methods — 5 × 3 =
+// 15 identical bodies that drifted slightly (e.g. `IndianPoker` used
+// `min(...)` while the other two used a manual `if` clamp). Extracting them
+// here removes the drift risk while leaving each profile's public API (and
+// JSON shape) untouched. See issue #1486.
+
+// welfordUpdate applies one sample of Welford's online algorithm to the
+// given streaming accumulators. Samples where ms <= 0 are ignored (used by
+// callers that cannot measure, e.g. the CUI).
+//
+// Mutates *count, *mean, and *m2 in place so that the caller's JSON-tagged
+// fields remain the source of truth.
+func welfordUpdate(ms int, count *int, mean, m2 *float64) {
+	if ms <= 0 {
+		return
+	}
+	*count++
+	x := float64(ms)
+	delta := x - *mean
+	*mean += delta / float64(*count)
+	delta2 := x - *mean
+	*m2 += delta * delta2
+}
+
+// welfordStdDev returns the sample standard deviation from Welford
+// accumulators. Returns 0 when count < 2 (undefined, not a real deviation).
+func welfordStdDev(count int, m2 float64) float64 {
+	if count < 2 {
+		return 0
+	}
+	return math.Sqrt(m2 / float64(count-1))
+}
+
+// welfordZScore returns (ms - mean) / stddev for the current sample against
+// the accumulator, or 0 when the stddev is 0 (insufficient data).
+func welfordZScore(ms int, count int, mean, m2 float64) float64 {
+	sd := welfordStdDev(count, m2)
+	if sd == 0 {
+		return 0
+	}
+	return (float64(ms) - mean) / sd
+}
+
+// hesitationBoost returns a positive probability-adjustment when the sample
+// ms is sufficiently slower than the player's own baseline. Returns 0 when
+// data is insufficient (count < hesitationMinPlays), z-score is at/below
+// threshold, or clamped at maxHesitationBoost.
+//
+// Shared by every HumanProfile that applies a "player hesitated → lean
+// toward a call/doubt/bluff" adjustment.
+func hesitationBoost(count int, mean, m2 float64, ms int) float64 {
+	if count < hesitationMinPlays {
+		return 0
+	}
+	z := welfordZScore(ms, count, mean, m2)
+	if z <= hesitationZThreshold {
+		return 0
+	}
+	boost := (z - hesitationZThreshold) * hesitationWeight
+	if boost > maxHesitationBoost {
+		return maxHesitationBoost
+	}
+	return boost
+}
+
+// computeAdaptStrength ramps linearly from 0 to metaAIMaxAdaptGames *
+// metaAIAdaptPerGame as the session progresses. Games beyond
+// metaAIMaxAdaptGames add no further adaptation (clamped).
+func computeAdaptStrength(gamesPlayed int) float64 {
+	games := min(gamesPlayed, metaAIMaxAdaptGames)
+	return float64(games) * metaAIAdaptPerGame
+}

--- a/internal/domain/hesitation.go
+++ b/internal/domain/hesitation.go
@@ -11,7 +11,6 @@ const (
 )
 
 // Meta-AI adaptation tuning constants, shared by every HumanProfile.
-// See issue #1486 — previously scattered across DoubtHumanProfile.go.
 const (
 	// hesitationMinPlays 迷い時間ブーストを有効にするための最小データ点数
 	hesitationMinPlays = 3
@@ -35,11 +34,9 @@ const (
 //   - A bounded linear ramp from GamesPlayed → adapt strength.
 //   - A z-score-based probability boost once enough samples exist.
 //
-// Previously each profile carried its own copy of these methods — 5 × 3 =
-// 15 identical bodies that drifted slightly (e.g. `IndianPoker` used
-// `min(...)` while the other two used a manual `if` clamp). Extracting them
-// here removes the drift risk while leaving each profile's public API (and
-// JSON shape) untouched. See issue #1486.
+// All helpers below group the Welford accumulator triple (count, mean, m2)
+// first and put the per-call sample `ms` last, so call sites can skim
+// signatures consistently.
 
 // welfordUpdate applies one sample of Welford's online algorithm to the
 // given streaming accumulators. Samples where ms <= 0 are ignored (used by
@@ -47,7 +44,7 @@ const (
 //
 // Mutates *count, *mean, and *m2 in place so that the caller's JSON-tagged
 // fields remain the source of truth.
-func welfordUpdate(ms int, count *int, mean, m2 *float64) {
+func welfordUpdate(count *int, mean, m2 *float64, ms int) {
 	if ms <= 0 {
 		return
 	}
@@ -70,7 +67,7 @@ func welfordStdDev(count int, m2 float64) float64 {
 
 // welfordZScore returns (ms - mean) / stddev for the current sample against
 // the accumulator, or 0 when the stddev is 0 (insufficient data).
-func welfordZScore(ms int, count int, mean, m2 float64) float64 {
+func welfordZScore(count int, mean, m2 float64, ms int) float64 {
 	sd := welfordStdDev(count, m2)
 	if sd == 0 {
 		return 0
@@ -89,7 +86,7 @@ func hesitationBoost(count int, mean, m2 float64, ms int) float64 {
 	if count < hesitationMinPlays {
 		return 0
 	}
-	z := welfordZScore(ms, count, mean, m2)
+	z := welfordZScore(count, mean, m2, ms)
 	if z <= hesitationZThreshold {
 		return 0
 	}

--- a/internal/domain/hesitation_test.go
+++ b/internal/domain/hesitation_test.go
@@ -1,0 +1,136 @@
+package domain
+
+import (
+	"math"
+	"testing"
+)
+
+// Welford's algorithm must be numerically stable — a sanity property test
+// that the shared helpers match a two-pass mean/variance on well-behaved
+// input. See issue #1486.
+func TestWelfordUpdate_MatchesTwoPass(t *testing.T) {
+	samples := []int{450, 520, 610, 300, 780, 900, 1100, 420, 560, 680}
+
+	// Reference pass: naive mean/variance.
+	sum := 0.0
+	for _, s := range samples {
+		sum += float64(s)
+	}
+	wantMean := sum / float64(len(samples))
+	var ssq float64
+	for _, s := range samples {
+		diff := float64(s) - wantMean
+		ssq += diff * diff
+	}
+	wantSD := math.Sqrt(ssq / float64(len(samples)-1))
+
+	// Streaming pass via the helper under test.
+	var count int
+	var mean, m2 float64
+	for _, s := range samples {
+		welfordUpdate(s, &count, &mean, &m2)
+	}
+	gotSD := welfordStdDev(count, m2)
+
+	if count != len(samples) {
+		t.Errorf("count = %d, want %d", count, len(samples))
+	}
+	if math.Abs(mean-wantMean) > 1e-9 {
+		t.Errorf("mean = %f, want %f", mean, wantMean)
+	}
+	if math.Abs(gotSD-wantSD) > 1e-9 {
+		t.Errorf("stddev = %f, want %f", gotSD, wantSD)
+	}
+}
+
+// welfordUpdate must ignore non-positive samples (CUI can't measure) so
+// counts never get inflated and the mean stays pure.
+func TestWelfordUpdate_IgnoresNonPositive(t *testing.T) {
+	tests := []struct {
+		name   string
+		sample int
+	}{
+		{"zero", 0},
+		{"negative", -100},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var count int
+			var mean, m2 float64
+			welfordUpdate(tt.sample, &count, &mean, &m2)
+			if count != 0 || mean != 0 || m2 != 0 {
+				t.Errorf("non-positive sample %d mutated accumulators: count=%d mean=%f m2=%f",
+					tt.sample, count, mean, m2)
+			}
+		})
+	}
+}
+
+// welfordStdDev must return 0 when count < 2 (sample variance needs n-1).
+func TestWelfordStdDev_InsufficientData(t *testing.T) {
+	if got := welfordStdDev(0, 0); got != 0 {
+		t.Errorf("count=0 stddev = %f, want 0", got)
+	}
+	if got := welfordStdDev(1, 123.4); got != 0 {
+		t.Errorf("count=1 stddev = %f, want 0 (single sample has undefined variance)", got)
+	}
+}
+
+// welfordZScore must return 0 when the accumulator has no variance signal.
+func TestWelfordZScore_InsufficientData(t *testing.T) {
+	if got := welfordZScore(500, 1, 500, 0); got != 0 {
+		t.Errorf("single-sample z-score = %f, want 0", got)
+	}
+}
+
+// computeAdaptStrength clamps games above metaAIMaxAdaptGames so a
+// long-running session never pushes adapt strength past its ceiling.
+func TestComputeAdaptStrength_ClampsAtMax(t *testing.T) {
+	cap := float64(metaAIMaxAdaptGames) * metaAIAdaptPerGame
+	tests := []struct {
+		games int
+		want  float64
+	}{
+		{0, 0},
+		{1, metaAIAdaptPerGame},
+		{metaAIMaxAdaptGames, cap},
+		{metaAIMaxAdaptGames + 1, cap}, // clamped
+		{1_000_000, cap},               // still clamped
+	}
+	for _, tt := range tests {
+		if got := computeAdaptStrength(tt.games); math.Abs(got-tt.want) > 1e-12 {
+			t.Errorf("computeAdaptStrength(%d) = %f, want %f", tt.games, got, tt.want)
+		}
+	}
+}
+
+// hesitationBoost must return 0 until there are at least hesitationMinPlays
+// samples, regardless of how extreme the z-score would otherwise be.
+func TestHesitationBoost_MinimumSamples(t *testing.T) {
+	// Populate with just under the threshold so a z-score CAN be computed
+	// but the boost path short-circuits on count < hesitationMinPlays.
+	var count int
+	var mean, m2 float64
+	for i := 0; i < hesitationMinPlays-1; i++ {
+		welfordUpdate(500+i*100, &count, &mean, &m2)
+	}
+	if got := hesitationBoost(count, mean, m2, 5000); got != 0 {
+		t.Errorf("hesitationBoost with count=%d = %f, want 0 (below hesitationMinPlays=%d)",
+			count, got, hesitationMinPlays)
+	}
+}
+
+// hesitationBoost must cap at maxHesitationBoost even when the raw z-score
+// overshoot is enormous.
+func TestHesitationBoost_CapsAtMax(t *testing.T) {
+	var count int
+	var mean, m2 float64
+	for _, s := range []int{500, 510, 490, 505, 495} {
+		welfordUpdate(s, &count, &mean, &m2)
+	}
+	// 100x the mean → z-score in the tens; boost must still clamp.
+	got := hesitationBoost(count, mean, m2, 50_000)
+	if got != maxHesitationBoost {
+		t.Errorf("hesitationBoost(huge-ms) = %f, want capped at %f", got, maxHesitationBoost)
+	}
+}

--- a/internal/domain/hesitation_test.go
+++ b/internal/domain/hesitation_test.go
@@ -7,7 +7,7 @@ import (
 
 // Welford's algorithm must be numerically stable — a sanity property test
 // that the shared helpers match a two-pass mean/variance on well-behaved
-// input. See issue #1486.
+// input.
 func TestWelfordUpdate_MatchesTwoPass(t *testing.T) {
 	samples := []int{450, 520, 610, 300, 780, 900, 1100, 420, 560, 680}
 
@@ -28,7 +28,7 @@ func TestWelfordUpdate_MatchesTwoPass(t *testing.T) {
 	var count int
 	var mean, m2 float64
 	for _, s := range samples {
-		welfordUpdate(s, &count, &mean, &m2)
+		welfordUpdate(&count, &mean, &m2, s)
 	}
 	gotSD := welfordStdDev(count, m2)
 
@@ -57,7 +57,7 @@ func TestWelfordUpdate_IgnoresNonPositive(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var count int
 			var mean, m2 float64
-			welfordUpdate(tt.sample, &count, &mean, &m2)
+			welfordUpdate(&count, &mean, &m2, tt.sample)
 			if count != 0 || mean != 0 || m2 != 0 {
 				t.Errorf("non-positive sample %d mutated accumulators: count=%d mean=%f m2=%f",
 					tt.sample, count, mean, m2)
@@ -78,7 +78,7 @@ func TestWelfordStdDev_InsufficientData(t *testing.T) {
 
 // welfordZScore must return 0 when the accumulator has no variance signal.
 func TestWelfordZScore_InsufficientData(t *testing.T) {
-	if got := welfordZScore(500, 1, 500, 0); got != 0 {
+	if got := welfordZScore(1, 500, 0, 500); got != 0 {
 		t.Errorf("single-sample z-score = %f, want 0", got)
 	}
 }
@@ -112,7 +112,7 @@ func TestHesitationBoost_MinimumSamples(t *testing.T) {
 	var count int
 	var mean, m2 float64
 	for i := 0; i < hesitationMinPlays-1; i++ {
-		welfordUpdate(500+i*100, &count, &mean, &m2)
+		welfordUpdate(&count, &mean, &m2, 500+i*100)
 	}
 	if got := hesitationBoost(count, mean, m2, 5000); got != 0 {
 		t.Errorf("hesitationBoost with count=%d = %f, want 0 (below hesitationMinPlays=%d)",
@@ -126,11 +126,47 @@ func TestHesitationBoost_CapsAtMax(t *testing.T) {
 	var count int
 	var mean, m2 float64
 	for _, s := range []int{500, 510, 490, 505, 495} {
-		welfordUpdate(s, &count, &mean, &m2)
+		welfordUpdate(&count, &mean, &m2, s)
 	}
 	// 100x the mean → z-score in the tens; boost must still clamp.
 	got := hesitationBoost(count, mean, m2, 50_000)
 	if got != maxHesitationBoost {
 		t.Errorf("hesitationBoost(huge-ms) = %f, want capped at %f", got, maxHesitationBoost)
+	}
+}
+
+// hesitationBoost must return 0 when the z-score sits at or below the
+// configured threshold — a player who didn't visibly hesitate gives the
+// CPU no signal, even if enough samples exist. Covers the branch that the
+// "cap" and "minimum samples" tests miss.
+func TestHesitationBoost_BelowThreshold(t *testing.T) {
+	var count int
+	var mean, m2 float64
+	for _, s := range []int{500, 510, 490, 505, 495} {
+		welfordUpdate(&count, &mean, &m2, s)
+	}
+	// 501 ms is barely above the ~500 ms cluster — z-score well below 1.0.
+	if got := hesitationBoost(count, mean, m2, 501); got != 0 {
+		t.Errorf("hesitationBoost(barely-above-mean) = %f, want 0 (z <= threshold)", got)
+	}
+}
+
+// hesitationBoost must return a positive, uncapped value when the z-score
+// is moderately above the threshold — the linear ramp before the max clamp
+// needs coverage too.
+func TestHesitationBoost_PositiveBelowCap(t *testing.T) {
+	var count int
+	var mean, m2 float64
+	for _, s := range []int{500, 510, 490, 505, 495} {
+		welfordUpdate(&count, &mean, &m2, s)
+	}
+	// ~520 ms is ≈2 stddevs above the tight cluster around 500 — above the
+	// 1.0 threshold but nowhere near the boost cap.
+	got := hesitationBoost(count, mean, m2, 520)
+	if got <= 0 {
+		t.Errorf("hesitationBoost(520) = %f, want positive", got)
+	}
+	if got >= maxHesitationBoost {
+		t.Errorf("hesitationBoost(520) = %f, must stay strictly below cap %f", got, maxHesitationBoost)
 	}
 }


### PR DESCRIPTION
## Summary

Extract the Welford online-algorithm update, the adapt-strength clamp, and the hesitation-boost formula out of \`BettingHumanProfile\`, \`IndianPokerHumanProfile\`, and \`DoubtHumanProfile\` into four unexported helpers in the new \`hesitation.go\`:

- \`welfordUpdate\` — streaming mean/variance
- \`welfordStdDev\` — sample stddev, 0 when n < 2
- \`welfordZScore\` — z-score, 0 when stddev is 0
- \`hesitationBoost\` — capped z-score → probability adjust
- \`computeAdaptStrength\` — linear ramp clamped at \`metaAIMaxAdaptGames\`

Also pull the meta-AI tuning constants (\`hesitationMinPlays\`, \`hesitationZThreshold\`, \`hesitationWeight\`, \`maxHesitationBoost\`, \`metaAIMaxAdaptGames\`, \`metaAIAdaptPerGame\`) out of \`DoubtHumanProfile\` where they happened to live, into \`hesitation.go\` beside the math that uses them.

Each profile's public methods (\`RecordHesitation\`, \`HesitationStdDev\`, \`HesitationZScore\`, \`HesitationBoost\`, \`AdaptStrength\`) now delegate in one line. Field layout and JSON tags are untouched, so previously saved profiles remain round-trippable.

**Why this matters** — the three \`AdaptStrength\` implementations had already silently drifted (IndianPoker switched to \`min(...)\` while the other two kept a manual \`if > max\` clamp). Same math, but a future edit to one would miss the others. Single source now.

Adds 6 property-based tests for the new helpers covering Welford's numerical match vs a two-pass reference, non-positive-sample guard, insufficient-data short-circuits, adapt-strength clamp, min-samples threshold, and hesitation-boost cap.

Scope note: I kept the existing per-profile \`Xxxx\`HumanProfile\`Data\` Export/Import/\`ImportXxxxJSON\` surface intact even though two of those JSON-unmarshal helpers are trivially thin. Collapsing them would require changing call sites, which this PR avoids in order to keep the blast radius to \`internal/domain\` and preserve the 80%+ branch coverage standard through the existing profile-level test suites.

Closes #1486

## Test plan

- [x] \`go test -tags test ./...\` — all packages pass
- [x] \`golangci-lint run ./internal/domain/...\` — 0 issues
- [x] \`goimports -w\` on modified files
- [x] 6 new unit tests for the shared helpers (all pass)
- [x] Existing \`*HumanProfile_test.go\` and \`*HumanProfile_persistence_test.go\` suites unchanged and green — confirms delegation is behavior-preserving