### PR TITLE
fix(daifugo): compact mobile CPU row to eliminate 496px scroll

### DIFF
--- a/frontend/src/components/daifugo/DaifugoCpuCompact.test.tsx
+++ b/frontend/src/components/daifugo/DaifugoCpuCompact.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { DaifugoPlayerData } from '../../types/card';
+import { DaifugoCpuCompact } from './DaifugoCpuCompact';
+
+function makePlayer(overrides: Partial<DaifugoPlayerData> = {}): DaifugoPlayerData {
+  return {
+    id: 1,
+    isHuman: false,
+    isFinished: false,
+    rank: 0,
+    cardCount: 13,
+    cards: [],
+    ...overrides,
+  };
+}
+
+describe('DaifugoCpuCompact', () => {
+  it('renders player name and card count on one row', () => {
+    render(<DaifugoCpuCompact player={makePlayer({ id: 1, cardCount: 13 })} isCurrentTurn={false} />);
+    expect(screen.getByText('CPU 1')).toBeInTheDocument();
+    expect(screen.getByText('13枚')).toBeInTheDocument();
+  });
+
+  it('applies current-turn highlight when it is this CPUs turn', () => {
+    const { container } = render(<DaifugoCpuCompact player={makePlayer()} isCurrentTurn />);
+    const root = container.firstChild as HTMLElement;
+    expect(root.className).toMatch(/border-game-status-waiting/);
+  });
+
+  it('does not apply current-turn highlight when not this CPUs turn', () => {
+    const { container } = render(<DaifugoCpuCompact player={makePlayer()} isCurrentTurn={false} />);
+    const root = container.firstChild as HTMLElement;
+    expect(root.className).not.toMatch(/border-game-status-waiting/);
+  });
+
+  it('shows finished rank label instead of card count when finished', () => {
+    render(<DaifugoCpuCompact player={makePlayer({ isFinished: true, rank: 1 })} isCurrentTurn={false} />);
+    expect(screen.getByText('大富豪')).toBeInTheDocument();
+    expect(screen.queryByText(/枚/)).not.toBeInTheDocument();
+  });
+
+  it('dims the row when finished', () => {
+    const { container } = render(
+      <DaifugoCpuCompact player={makePlayer({ isFinished: true, rank: 2 })} isCurrentTurn={false} />,
+    );
+    const root = container.firstChild as HTMLElement;
+    expect(root.className).toMatch(/opacity-50/);
+  });
+
+  it('shows illegalFinishPenalty badge when penalty is true', () => {
+    render(<DaifugoCpuCompact player={makePlayer({ illegalFinishPenalty: true })} isCurrentTurn={false} />);
+    expect(screen.getByText('反則上がり')).toBeInTheDocument();
+  });
+
+  it('does not show illegalFinishPenalty badge when penalty is falsy', () => {
+    render(<DaifugoCpuCompact player={makePlayer()} isCurrentTurn={false} />);
+    expect(screen.queryByText('反則上がり')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/daifugo/DaifugoCpuCompact.tsx
+++ b/frontend/src/components/daifugo/DaifugoCpuCompact.tsx
@@ -8,14 +8,14 @@ import { StatusBadge } from '../StatusBadge';
 export function DaifugoCpuCompact({ player, isCurrentTurn }: { player: DaifugoPlayerData; isCurrentTurn: boolean }) {
   const { t } = useTranslation('daifugo');
   const conditionalClass = player.isFinished
-    ? finishedPlayerClass
+    ? `${finishedPlayerClass} border-2 border-transparent`
     : isCurrentTurn
       ? activeTurnClass
-      : 'border border-white/10';
+      : 'border-2 border-white/10';
   return (
     <div
       id={`player-area-${player.id}`}
-      className={`flex items-center gap-1.5 rounded-[8px] px-2 py-1 text-xs whitespace-nowrap bg-black/20 ${conditionalClass}`}
+      className={`flex flex-shrink-0 items-center gap-1.5 rounded-[8px] px-2 py-1 text-xs whitespace-nowrap bg-black/20 ${conditionalClass}`}
     >
       <span className="text-white font-bold">{playerName(player.id, player.isHuman)}</span>
       {player.isFinished ? (

--- a/frontend/src/components/daifugo/DaifugoCpuCompact.tsx
+++ b/frontend/src/components/daifugo/DaifugoCpuCompact.tsx
@@ -1,0 +1,29 @@
+import { useTranslation } from 'react-i18next';
+import { activeTurnClass, finishedPlayerClass } from '../../styles/gameConstants';
+import type { DaifugoPlayerData } from '../../types/card';
+import { playerName } from '../../utils/playerUtils';
+import { StatusBadge } from '../StatusBadge';
+
+/** Renders a compact single-row CPU summary for Daifugo (used on mobile to avoid vertical overflow). */
+export function DaifugoCpuCompact({ player, isCurrentTurn }: { player: DaifugoPlayerData; isCurrentTurn: boolean }) {
+  const { t } = useTranslation('daifugo');
+  const conditionalClass = player.isFinished
+    ? finishedPlayerClass
+    : isCurrentTurn
+      ? activeTurnClass
+      : 'border border-white/10';
+  return (
+    <div
+      id={`player-area-${player.id}`}
+      className={`flex items-center gap-1.5 rounded-[8px] px-2 py-1 text-xs whitespace-nowrap bg-black/20 ${conditionalClass}`}
+    >
+      <span className="text-white font-bold">{playerName(player.id, player.isHuman)}</span>
+      {player.isFinished ? (
+        <span className="text-game-text-muted">{t(`rank.${player.rank}`)}</span>
+      ) : (
+        <span className="text-game-text-muted">{t('cardCount', { count: player.cardCount })}</span>
+      )}
+      {player.illegalFinishPenalty && <StatusBadge variant="danger">{t('badge.illegalFinishPenalty')}</StatusBadge>}
+    </div>
+  );
+}

--- a/frontend/src/pages/DaifugoPage.test.tsx
+++ b/frontend/src/pages/DaifugoPage.test.tsx
@@ -178,6 +178,33 @@ describe('DaifugoPage', () => {
     });
   });
 
+  it('renders compact CPU row on mobile viewport', async () => {
+    const originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    window.dispatchEvent(new Event('resize'));
+    try {
+      const { container } = renderWithProviders(<DaifugoPage />);
+      await waitFor(() => {
+        expect(screen.getByText('CPU 1')).toBeInTheDocument();
+        expect(screen.getByText('4枚')).toBeInTheDocument();
+      });
+      // On mobile the CPU row uses the compact flex+overflow layout; the
+      // desktop CPU card (DaifugoCpuArea with flex-[1_1_180px]) must not render
+      // for any CPU. The human area (player-area-0) still uses playerAreaClass.
+      for (const cpuId of [1, 2, 3]) {
+        const cpuNode = container.querySelector(`#player-area-${cpuId}`);
+        expect(cpuNode?.className ?? '').not.toMatch(/flex-\[1_1_180px\]/);
+      }
+    } finally {
+      Object.defineProperty(window, 'innerWidth', {
+        writable: true,
+        configurable: true,
+        value: originalInnerWidth,
+      });
+      window.dispatchEvent(new Event('resize'));
+    }
+  });
+
   it('shows empty table message when tableCards is empty', async () => {
     renderWithProviders(<DaifugoPage />);
     await waitFor(() => expect(screen.getByText('（なし）')).toBeInTheDocument());

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -237,7 +237,7 @@ function DaifugoPageContent() {
               ]}
             />
             {isMobile ? (
-              <div className="flex gap-1.5 mb-2 overflow-x-auto">
+              <div className="flex gap-1.5 mb-2 overflow-x-auto py-3">
                 {cpuPlayers.map((player) => (
                   <DaifugoCpuCompact key={player.id} player={player} isCurrentTurn={state.currentTurn === player.id} />
                 ))}

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -5,6 +5,7 @@ import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { DaifugoCpuArea } from '../components/daifugo/DaifugoCpuArea';
+import { DaifugoCpuCompact } from '../components/daifugo/DaifugoCpuCompact';
 import { DaifugoExchangeLog } from '../components/daifugo/DaifugoExchangeLog';
 import { DaifugoHumanArea } from '../components/daifugo/DaifugoHumanArea';
 import { DaifugoRulesBadges } from '../components/daifugo/DaifugoRulesBadges';
@@ -23,7 +24,7 @@ import { PhaseIndicator } from '../components/PhaseIndicator';
 import { DaifugoSkeleton } from '../components/skeleton/DaifugoSkeleton';
 import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
-import { useCardDimensions } from '../hooks/useCardDimensions';
+import { useCardDimensions, useIsMobile } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useCardSwipeSelection } from '../hooks/useCardSwipeSelection';
 import { useCliGame } from '../hooks/useCliGame';
@@ -137,6 +138,7 @@ function DaifugoPageContent() {
   } = useGameHint('daifugo', state);
 
   const { cardWidth } = useCardDimensions();
+  const isMobile = useIsMobile();
   const { playSound } = useSound();
 
   const isHumanTurnForKbd = !!state && !state.gameEndFlag && !!state.players[state.currentTurn]?.isHuman;
@@ -234,11 +236,19 @@ function DaifugoPageContent() {
                 },
               ]}
             />
-            <div className="flex gap-2.5 flex-wrap mb-2.5">
-              {cpuPlayers.map((player) => (
-                <DaifugoCpuArea key={player.id} player={player} isCurrentTurn={state.currentTurn === player.id} />
-              ))}
-            </div>
+            {isMobile ? (
+              <div className="flex gap-1.5 mb-2 overflow-x-auto">
+                {cpuPlayers.map((player) => (
+                  <DaifugoCpuCompact key={player.id} player={player} isCurrentTurn={state.currentTurn === player.id} />
+                ))}
+              </div>
+            ) : (
+              <div className="flex gap-2.5 flex-wrap mb-2.5">
+                {cpuPlayers.map((player) => (
+                  <DaifugoCpuArea key={player.id} player={player} isCurrentTurn={state.currentTurn === player.id} />
+                ))}
+              </div>
+            )}
 
             {/* biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop target; keyboard play uses select+button */}
             <div


### PR DESCRIPTION
## Summary

- **Fix**: Compress 3 stacked CPU cards on Daifugo mobile into a single-row summary (~40px vs previous ~225px), eliminating the 496px of forced scrolling on iPhone SE (375×667).
- **Scope**: mobile-only (`useIsMobile()`). Desktop continues to render the existing `DaifugoCpuArea` grid — no visual change on ≥ sm.
- **New component**: `DaifugoCpuCompact` renders `CPU N / N枚` (or rank when finished) with the current-turn outline and the `illegalFinishPenalty` badge preserved.

## Test plan

- [x] `bun run test -- --run src/components/daifugo src/pages/DaifugoPage.test.tsx` → 168/168 pass (includes new mobile-viewport assertion)
- [x] `bun run build` → OK
- [x] `bun run check` → 0 issues in touched files (4 pre-existing unrelated warnings left untouched)
- [x] `go test -tags test ./...` → all green
- [x] `golangci-lint run ./...` → 0 issues
- [ ] Visually verify on Pretext/iPhone SE viewport — no scroll needed to reach hand + play buttons

Closes #1494