### PR TITLE
chore: bump tinygo to 0.41.1 and unify go.mod to 1.26.0

### DIFF
--- a/.github/workflows/cloudflare-workers-build.yml
+++ b/.github/workflows/cloudflare-workers-build.yml
@@ -31,11 +31,11 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - uses: acifani/setup-tinygo@v2
         with:
-          tinygo-version: '0.40.1'
+          tinygo-version: '0.41.1'
 
       - name: Install wasm-opt
         run: sudo apt-get install -y binaryen

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -42,11 +42,11 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - uses: acifani/setup-tinygo@v2
         with:
-          tinygo-version: '0.40.1'
+          tinygo-version: '0.41.1'
 
       - name: Install wasm-opt
         run: sudo apt-get install -y binaryen

--- a/docs/adr/0027-cloudflare-workers-wasm.md
+++ b/docs/adr/0027-cloudflare-workers-wasm.md
@@ -58,6 +58,10 @@ Go 1.26 の代わりに TinyGo 0.40.1（Go 1.25 対応）を使用し、Wasm バ
 - **コールドスタート解消**: Workers はリクエスト駆動のため、Docker PaaS のようなスリープ→起動の遅延がない
 - **go-json-rest 依存の除去**: TinyGo 互換性のために `go-json-rest` を標準 `net/http` に置き換えた（PR #1012）。結果として外部依存が1つ減り、コードも約2,000行削減された
 - **モック ファイルのビルドタグ**: 全モックファイルに `//go:build test` タグを追加。TinyGo ビルドから `testify/mock` を除外するために必要だった
-- **Go バージョン制約**: TinyGo が Go 1.25 までしかサポートしないため、`go.mod` に `go 1.25.8` を指定。`toolchain go1.26.0` ディレクティブにより通常開発は Go 1.26 を使用
+- **Go バージョン制約**: ~~TinyGo が Go 1.25 までしかサポートしないため、`go.mod` に `go 1.25.8` を指定。`toolchain go1.26.0` ディレクティブにより通常開発は Go 1.26 を使用~~ → TinyGo 0.41.0（2026-04 リリース）で Go 1.26 サポートが追加されたため、`go.mod` を `go 1.26.0` に統一し `toolchain` ディレクティブを撤去（後述「更新履歴」を参照）
 - **メソッドプレフィックスルーティング不可**: TinyGo の `net/http` は Go 1.22 の `"POST /path"` パターンを未サポート。Workers エントリポイントでは通常の `"/path"` パターンを使用
 - **セッション管理**: `SessionProvider[T]` インターフェースにより、Docker 版（インメモリ `MemorySessionProvider`）と Workers 版（`KVSessionProvider` + Cloudflare KV）を統一的に扱う。KV 版はゲームドメインオブジェクトを JSON シリアライズして永続化し、TTL=1時間で自動削除される。KV 無料枠（書き込み 1,000回/日）のためデモ用途に限定。全26ゲーム対応済み（詳細は [ADR-0028](0028-kv-session-persistence.md) を参照）
+
+## 更新履歴
+
+- **2026-04-25**: TinyGo を `0.40.1` → `0.41.1` に更新。TinyGo 0.41.0 で Go 1.26 サポートが追加されたため、`go.mod` を `go 1.25.8` + `toolchain go1.26.0` のデュアル構成から `go 1.26.0` 単独に統一。CI ワークフロー（`deploy-cloudflare.yml`、`cloudflare-workers-build.yml`）の `setup-go` も `1.25` → `1.26` に揃えた

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,6 +104,6 @@ Also ensure `frontend/src/api/gameApi.ts` `workerUrl` maps the game to the corre
 
 ### TinyGo constraints
 
-- `go.mod` specifies `go 1.25.8` (TinyGo's latest supported Go version) with `toolchain go1.26.0` for local development
+- TinyGo 0.41.1 (Go 1.26 対応) を使用。`go.mod` の Go バージョンは `go 1.26.0` に統一済み
 - Mock files require `//go:build test` tag to exclude `testify/mock` from WASM builds
 - `net/http` method-prefixed routing (`"POST /path"`) is not supported; Worker entry points use plain `"/path"` patterns

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/yuta-yoshinaga/go_trumpcards
 
-go 1.25.8
-
-toolchain go1.26.0
+go 1.26.0
 
 require (
 	github.com/minio/selfupdate v0.6.0


### PR DESCRIPTION
## Summary
- TinyGo 0.41.0 で Go 1.26 サポートが追加されたため（[release notes](https://github.com/tinygo-org/tinygo/releases/tag/v0.41.0)）、`go.mod` のデュアルバージョン戦略（`go 1.25.8` + `toolchain go1.26.0`）を解消し `go 1.26.0` 単独に統一
- 0.41.0 の net モジュール後方互換問題を修正したパッチ版 [0.41.1](https://github.com/tinygo-org/tinygo/releases/tag/v0.41.1) を採用
- CI ワークフロー（`deploy-cloudflare.yml`、`cloudflare-workers-build.yml`）の `tinygo-version` を 0.40.1 → 0.41.1、`setup-go` の `go-version` を 1.25 → 1.26 に更新
- `docs/architecture.md` の TinyGo constraints と `docs/adr/0027-cloudflare-workers-wasm.md` の更新履歴を追記

## Why
ADR-0027 で「TinyGo の Go 1.26 サポートが入ったらデュアルバージョン戦略を解消する」と記載していた条件が満たされた。

## Test plan
- [x] `go build ./...`
- [x] `go test -tags test ./...` 全パッケージ pass
- [x] `golangci-lint run ./...` 0 issues
- [x] `frontend bun run check` pass（既存の non-null assertion warning のみで、本変更とは無関係）
- [x] `frontend bun run build` 成功
- [x] `frontend bun run test` 5659 件 pass（worker timeout は WSL メモリ起因のノイズ）
- [ ] CI `cloudflare-workers-build.yml` で TinyGo 0.41.1 ビルドの gzip サイズが 1MB 以下に収まることを確認（ローカルに tinygo 未インストールのため CI 検証が必須）
- [ ] ステージング環境（`develop` マージ後の自動デプロイ）で 3 Worker（casino/classic/solo）が動作することを確認