### PR TITLE
fix(cli): accept --lang and --no-color after the game name

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -264,15 +264,23 @@ func run() int {
 		arg = canonical
 	}
 	if handler, ok := commands[arg]; ok {
-		// `<game> --help` / `<game> -h`: Go's flag package stops parsing at the first
-		// non-flag argument, so these trailing flags land in Args(). Intercept them
-		// and print that game's help instead of launching the game. Subcommands in
-		// subFlagCommands are handled by parseSubFlags (which catches flag.ErrHelp).
-		if !subFlagCommands[arg] && hasHelpFlag(flag.Args()[1:]) {
-			return runHelpCommand([]string{arg}, helpText, os.Stdout, os.Stderr)
-		}
-		if flag.NArg() > 1 && !subFlagCommands[arg] {
-			fmt.Fprintln(os.Stderr, i18n.Tf("cliExtraArgsWarning", "args", strings.Join(flag.Args()[1:], " ")))
+		if !subFlagCommands[arg] {
+			// Apply --lang / --no-color when they land after the game name so
+			// `trumpcards <game> --lang en` matches the prepositional form.
+			// Done before the help short-circuit so `<game> --lang en --help`
+			// renders help in the requested locale.
+			extras := applyTrailingGlobalFlags(flag.Args()[1:], quiet, os.Stderr)
+			// `<game> --help` / `<game> -h`: Go's flag package stops parsing at
+			// the first non-flag argument, so these trailing flags land in Args().
+			// Intercept them and print that game's help instead of launching the
+			// game. Subcommands in subFlagCommands are handled by parseSubFlags
+			// (which catches flag.ErrHelp).
+			if hasHelpFlag(extras) {
+				return runHelpCommand([]string{arg}, helpText, os.Stdout, os.Stderr)
+			}
+			if len(extras) > 0 {
+				fmt.Fprintln(os.Stderr, i18n.Tf("cliExtraArgsWarning", "args", strings.Join(extras, " ")))
+			}
 		}
 		return handler()
 	}
@@ -507,6 +515,57 @@ func updateExitCode(err error) int {
 	}
 }
 
+// applyTrailingGlobalFlags scans args for global flags (`--lang`, `--no-color`)
+// that landed after the game name because Go's flag package stops parsing at
+// the first positional argument. Each recognized flag is applied to the runtime
+// (i18n locale / color streams) and stripped from the returned slice so the
+// caller's "extra args" warning fires only for genuinely unknown trailing
+// tokens. Unsupported `--lang` values fall back to the existing locale and emit
+// the usual cliUnsupportedLang warning on stderr (suppressed when quiet).
+func applyTrailingGlobalFlags(args []string, quiet bool, stderr io.Writer) []string {
+	rest := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		var langVal string
+		var haveLang, haveNoColor bool
+		switch {
+		case a == "--lang" || a == "-lang":
+			haveLang = true
+			if i+1 < len(args) {
+				langVal = args[i+1]
+				i++
+			}
+		case strings.HasPrefix(a, "--lang="):
+			langVal = strings.TrimPrefix(a, "--lang=")
+			haveLang = true
+		case strings.HasPrefix(a, "-lang="):
+			langVal = strings.TrimPrefix(a, "-lang=")
+			haveLang = true
+		case a == "--no-color" || a == "-no-color":
+			haveNoColor = true
+		}
+		switch {
+		case haveLang:
+			switch {
+			case supportedLangs[langVal]:
+				i18n.SetLang(langVal)
+			case langVal == "":
+				// Bare `--lang` with no value mirrors detectBootstrapLang's tolerant
+				// behavior — silently ignore rather than emit an empty-value warning.
+			case !quiet:
+				_, _ = fmt.Fprintln(stderr, i18n.Tf("cliUnsupportedLang", "lang", langVal))
+				_, _ = fmt.Fprintln(stderr, i18n.T("cliSupportedLangs"))
+			}
+		case haveNoColor:
+			color.SetStdoutColor(false)
+			color.SetStderrColor(false)
+		default:
+			rest = append(rest, a)
+		}
+	}
+	return rest
+}
+
 // hasHelpFlag reports whether args contains a help flag. It accepts all four
 // forms Go's flag package treats as equivalent for a help flag registered as
 // both "help" and "h": "-h", "--h", "-help", "--help".
@@ -564,6 +623,8 @@ EXAMPLES:
   trumpcards blackjack           Play BlackJack
   trumpcards blackjack --help    Show BlackJack's in-game commands
   trumpcards --lang en poker     Play Poker in English
+  trumpcards poker --lang en     Same — global flags also accepted after the game name
+  trumpcards blackjack --no-color  Play BlackJack with color disabled
   trumpcards games               List all available games
   trumpcards games --short       List game names only (for scripting)
   trumpcards games --short --aliases  List game names including aliases

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -526,23 +526,34 @@ func applyTrailingGlobalFlags(args []string, quiet bool, stderr io.Writer) []str
 	rest := make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {
 		a := args[i]
+		if a == "--" {
+			rest = append(rest, args[i:]...)
+			break
+		}
 		var langVal string
-		var haveLang, haveNoColor bool
+		var haveLang, haveNoColor, consumed bool
 		switch {
 		case a == "--lang" || a == "-lang":
-			haveLang = true
+			haveLang, consumed = true, true
 			if i+1 < len(args) {
 				langVal = args[i+1]
 				i++
 			}
 		case strings.HasPrefix(a, "--lang="):
 			langVal = strings.TrimPrefix(a, "--lang=")
-			haveLang = true
+			haveLang, consumed = true, true
 		case strings.HasPrefix(a, "-lang="):
 			langVal = strings.TrimPrefix(a, "-lang=")
-			haveLang = true
+			haveLang, consumed = true, true
 		case a == "--no-color" || a == "-no-color":
-			haveNoColor = true
+			haveNoColor, consumed = true, true
+		case strings.HasPrefix(a, "--no-color=") || strings.HasPrefix(a, "-no-color="):
+			val := a[strings.Index(a, "=")+1:]
+			b, err := strconv.ParseBool(val)
+			if err == nil {
+				consumed = true
+				haveNoColor = b
+			}
 		}
 		switch {
 		case haveLang:
@@ -559,7 +570,7 @@ func applyTrailingGlobalFlags(args []string, quiet bool, stderr io.Writer) []str
 		case haveNoColor:
 			color.SetStdoutColor(false)
 			color.SetStderrColor(false)
-		default:
+		case !consumed:
 			rest = append(rest, a)
 		}
 	}

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/ui"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/update"
@@ -554,4 +555,130 @@ func TestUpdateExitCodeMapping(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestApplyTrailingGlobalFlags exercises issue #1509: --lang / --no-color
+// must take effect even when they appear after the game name. The helper
+// strips recognized flags from args, applies them to the runtime, and leaves
+// genuinely unknown trailing tokens for the caller's extra-args warning.
+func TestApplyTrailingGlobalFlags(t *testing.T) {
+	// Restore globals after each subtest so the suite stays order-independent.
+	origLang := i18n.Lang()
+	origStdoutNo := color.NoColorStdout()
+	origStderrNo := color.NoColorStderr()
+	t.Cleanup(func() {
+		i18n.SetLang(origLang)
+		color.SetStdoutColor(!origStdoutNo)
+		color.SetStderrColor(!origStderrNo)
+	})
+
+	tests := []struct {
+		name        string
+		args        []string
+		quiet       bool
+		wantRest    []string
+		wantLang    string
+		wantNoColor bool
+		wantWarn    string // substring expected on stderr; empty = no output
+	}{
+		{
+			name:     "no flags -> args passthrough",
+			args:     []string{"foo", "bar"},
+			wantRest: []string{"foo", "bar"},
+			wantLang: "ja",
+		},
+		{
+			name:     "--lang en sets locale and is consumed",
+			args:     []string{"--lang", "en"},
+			wantRest: []string{},
+			wantLang: "en",
+		},
+		{
+			name:     "-lang en (single-dash form) accepted",
+			args:     []string{"-lang", "en"},
+			wantRest: []string{},
+			wantLang: "en",
+		},
+		{
+			name:     "--lang=en (equals form) accepted",
+			args:     []string{"--lang=en"},
+			wantRest: []string{},
+			wantLang: "en",
+		},
+		{
+			name:        "--no-color disables both streams",
+			args:        []string{"--no-color"},
+			wantRest:    []string{},
+			wantLang:    "ja",
+			wantNoColor: true,
+		},
+		{
+			name:     "unsupported --lang warns and falls back",
+			args:     []string{"--lang", "klingon"},
+			wantRest: []string{},
+			wantLang: "ja",
+			wantWarn: "klingon",
+		},
+		{
+			name:     "unsupported --lang stays silent under quiet",
+			args:     []string{"--lang", "klingon"},
+			quiet:    true,
+			wantRest: []string{},
+			wantLang: "ja",
+		},
+		{
+			name:        "mixed: known flags consumed, extras returned",
+			args:        []string{"foo", "--lang", "en", "--no-color", "bar"},
+			wantRest:    []string{"foo", "bar"},
+			wantLang:    "en",
+			wantNoColor: true,
+		},
+		{
+			name:     "trailing --lang without value is ignored, not consumed",
+			args:     []string{"--lang"},
+			wantRest: []string{},
+			wantLang: "ja",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset to a known baseline before each subtest.
+			i18n.SetLang("ja")
+			color.SetStdoutColor(true)
+			color.SetStderrColor(true)
+
+			var stderr bytes.Buffer
+			got := applyTrailingGlobalFlags(tt.args, tt.quiet, &stderr)
+
+			if !equalStringSlices(got, tt.wantRest) {
+				t.Errorf("rest = %#v, want %#v", got, tt.wantRest)
+			}
+			if i18n.Lang() != tt.wantLang {
+				t.Errorf("lang = %q, want %q", i18n.Lang(), tt.wantLang)
+			}
+			if color.NoColorStdout() != tt.wantNoColor || color.NoColorStderr() != tt.wantNoColor {
+				t.Errorf("no-color stdout/stderr = %v/%v, want both %v",
+					color.NoColorStdout(), color.NoColorStderr(), tt.wantNoColor)
+			}
+			if tt.wantWarn == "" {
+				if stderr.Len() != 0 {
+					t.Errorf("expected no stderr; got %q", stderr.String())
+				}
+			} else if !strings.Contains(stderr.String(), tt.wantWarn) {
+				t.Errorf("stderr missing %q: %q", tt.wantWarn, stderr.String())
+			}
+		})
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -639,6 +640,41 @@ func TestApplyTrailingGlobalFlags(t *testing.T) {
 			wantRest: []string{},
 			wantLang: "ja",
 		},
+		{
+			name:     "--lang= (equals form, empty value) silently consumed",
+			args:     []string{"--lang="},
+			wantRest: []string{},
+			wantLang: "ja",
+		},
+		{
+			name:        "--lang followed by flag token treats it as lang value",
+			args:        []string{"--lang", "--no-color"},
+			wantRest:    []string{},
+			wantLang:    "ja", // "--no-color" is not a supported lang, falls back
+			wantNoColor: false, // --no-color was consumed as the lang value, not processed
+			wantWarn:    "--no-color",
+		},
+		{
+			name:        "--no-color=true disables both streams",
+			args:        []string{"--no-color=true"},
+			wantRest:    []string{},
+			wantLang:    "ja",
+			wantNoColor: true,
+		},
+		{
+			name:        "--no-color=false is consumed without disabling color",
+			args:        []string{"--no-color=false"},
+			wantRest:    []string{},
+			wantLang:    "ja",
+			wantNoColor: false,
+		},
+		{
+			name:        "-- stops flag scanning; remainder including -- passed through",
+			args:        []string{"--lang", "en", "--", "--no-color"},
+			wantRest:    []string{"--", "--no-color"},
+			wantLang:    "en",
+			wantNoColor: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -650,7 +686,7 @@ func TestApplyTrailingGlobalFlags(t *testing.T) {
 			var stderr bytes.Buffer
 			got := applyTrailingGlobalFlags(tt.args, tt.quiet, &stderr)
 
-			if !equalStringSlices(got, tt.wantRest) {
+			if !slices.Equal(got, tt.wantRest) {
 				t.Errorf("rest = %#v, want %#v", got, tt.wantRest)
 			}
 			if i18n.Lang() != tt.wantLang {
@@ -671,14 +707,3 @@ func TestApplyTrailingGlobalFlags(t *testing.T) {
 	}
 }
 
-func equalStringSlices(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}


### PR DESCRIPTION
Closes #1509

## Summary
- `trumpcards <game> --lang en` / `--no-color` now take effect (previously silently dropped with an "extra args ignored" warning).
- Added `applyTrailingGlobalFlags` to scan postpositional args, re-apply recognized globals to i18n / color state, and strip them — the legacy extra-args warning fires only for genuinely unknown trailing tokens.
- Run before the `<game> --help` short-circuit so `<game> --lang en --help` renders help in the requested locale.
- EXAMPLES in the top-level help advertise the new postpositional form.

## Behavior matrix
| Invocation | Before | After |
|---|---|---|
| `trumpcards --lang en blackjack` | English UI | English UI (unchanged) |
| `trumpcards blackjack --lang en` | warn + JA UI | **English UI** |
| `trumpcards blackjack --no-color` | warn + colored output | **no-color output** |
| `trumpcards blackjack --lang en --help` | JA help | **English help** |
| `trumpcards blackjack --bogus` | warn (kept) | warn (kept) |

## Test plan
- [x] `go test -tags test ./cmd/trumpcards/` (table-driven coverage of `applyTrailingGlobalFlags`)
- [x] `go test -tags test -race ./cmd/trumpcards/`
- [x] `go test -tags test ./...`
- [x] `golangci-lint run ./cmd/trumpcards/...`
- [x] Manual: `trumpcards blackjack --lang en --help` → English help text
- [x] Manual: `trumpcards blackjack --lang fr --help` → JA help with `cliUnsupportedLang` warning on stderr