### PR TITLE
fix(ui): enforce 44px minimum touch target on settings inputs

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -134,6 +134,17 @@ These use design system tokens for game UX color-coding. They are scoped to poke
 | 2xl | 48px | Large section spacing |
 | 3xl | 64px | Page section padding |
 
+## Interactive Element Minimum Size
+
+All interactive controls (buttons, links, checkbox/radio labels, selects, text/number inputs) must hit a 44×44 CSS px tap target — WCAG 2.5.5 AAA. The 24×24 fallback (WCAG 2.2 AA) is reserved for inline glyphs that cannot be visually enlarged without breaking layout, and even then the surrounding hit area should be padded to 44px.
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `tap-target-min` | 44px | Primary minimum for all tappable controls (buttons, labels wrapping checkbox/radio, select, text/number inputs) |
+| `tap-target-aa-min` | 24px | Fallback for inline icon-only triggers; only acceptable when the surrounding label/parent provides ≥44px tap area |
+
+Visual size of a checkbox or radio dot may stay at ~16-20px so the element still reads as a "checkbox" — but the wrapping `<label>` must carry `min-h-[44px]` so the entire row is tappable. Buttons follow this rule by default via `buttonStyles.ts:base` (`min-h-[44px]`). Selects and number inputs in card-game settings panels expand vertically to meet the threshold.
+
 ## Layout
 - **Approach:** Grid-disciplined — strict alignment for game UI, consistent card grid sizing
 - **Grid:** Desktop: sidebar (240px fixed) + fluid main. Mobile: single column with hamburger nav

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -650,7 +650,7 @@ func TestApplyTrailingGlobalFlags(t *testing.T) {
 			name:        "--lang followed by flag token treats it as lang value",
 			args:        []string{"--lang", "--no-color"},
 			wantRest:    []string{},
-			wantLang:    "ja", // "--no-color" is not a supported lang, falls back
+			wantLang:    "ja",  // "--no-color" is not a supported lang, falls back
 			wantNoColor: false, // --no-color was consumed as the lang value, not processed
 			wantWarn:    "--no-color",
 		},
@@ -706,4 +706,3 @@ func TestApplyTrailingGlobalFlags(t *testing.T) {
 		})
 	}
 }
-

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -270,7 +270,7 @@ export function VideoPokerGameContent({
               </div>
             )}
             <div className="flex justify-center pb-2">
-              <label className="text-white text-sm flex items-center gap-1">
+              <label className="text-white text-sm flex items-center gap-2 min-h-[44px]">
                 <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
                 {tc('hint.toggle', { ns: 'tutorial' })}
               </label>

--- a/frontend/src/components/common/ChipBetInput.test.tsx
+++ b/frontend/src/components/common/ChipBetInput.test.tsx
@@ -47,4 +47,12 @@ describe('ChipBetInput', () => {
     expect(input.step).toBe('5');
     expect(input.disabled).toBe(true);
   });
+
+  it('input meets the 44px minimum touch target (WCAG 2.5.5)', () => {
+    // Issue #1510: chip bet number inputs are tapped during fast bet entry
+    // (Baccarat / Three Card / Pai Gow); below 44px they're easy to miss.
+    render(<ChipBetInput id="bet" label="Bet" value={50} onChange={() => {}} max={500} />);
+    const input = screen.getByLabelText('Bet');
+    expect(input.className).toContain('min-h-[44px]');
+  });
 });

--- a/frontend/src/components/common/ChipBetInput.tsx
+++ b/frontend/src/components/common/ChipBetInput.tsx
@@ -53,7 +53,7 @@ export function ChipBetInput({
           onChange(Math.max(min, Math.min(parsed, max)));
         }}
         disabled={disabled}
-        className={`${widthClass} px-2 py-1 rounded text-sm`}
+        className={`${widthClass} px-3 py-2 rounded text-base min-h-[44px]`}
       />
     </div>
   );

--- a/frontend/src/components/common/SettingsPanel.test.tsx
+++ b/frontend/src/components/common/SettingsPanel.test.tsx
@@ -350,6 +350,36 @@ describe('SettingsPanel', () => {
     expect(select.options).toHaveLength(0);
   });
 
+  it('checkbox label meets the 44px minimum touch target (WCAG 2.5.5)', () => {
+    // Issue #1510: tap area for checkbox rows must be at least 44px so the
+    // 16px native checkbox does not become a "miss me" target on mobile.
+    const { container } = render(
+      <SettingsPanel
+        title="Settings"
+        groups={[{ items: [{ type: 'checkbox', id: 'cb1', label: 'Tap me', checked: false }] }]}
+      />,
+    );
+    const label = container.querySelector('label[for="cb1"]') as HTMLLabelElement;
+    expect(label.className).toContain('min-h-[44px]');
+  });
+
+  it('select wrapper meets the 44px minimum touch target (WCAG 2.5.5)', () => {
+    // Issue #1510: dropdowns at 22-24px high are below WCAG 2.2 AA. Aligning
+    // them with the 44px button baseline removes the visual hierarchy mismatch.
+    render(
+      <SettingsPanel
+        title="Settings"
+        groups={[
+          {
+            items: [{ type: 'select', id: 'sel1', label: 'Pick', value: '1', options: [{ value: '1', label: 'One' }] }],
+          },
+        ]}
+      />,
+    );
+    const select = screen.getByLabelText('Pick');
+    expect(select.className).toContain('min-h-[44px]');
+  });
+
   it('renders multiple groups with mixed titled and untitled', () => {
     const groups: SettingsGroup[] = [
       { items: [{ type: 'checkbox', id: 'c1', label: 'Untitled item', checked: false }] },

--- a/frontend/src/components/common/SettingsPanel.tsx
+++ b/frontend/src/components/common/SettingsPanel.tsx
@@ -79,7 +79,7 @@ export function SettingsPanel({ title, groups }: SettingsPanelProps) {
                     )}
                   </label>
                 ) : (
-                  <span key={item.id} className="flex items-center gap-2 relative group/tip min-h-[44px]">
+                  <span key={item.id} className="flex items-center gap-2 relative group/tip min-h-[44px] px-1">
                     <label htmlFor={item.id}>{item.label}</label>
                     <select
                       id={item.id}

--- a/frontend/src/components/common/SettingsPanel.tsx
+++ b/frontend/src/components/common/SettingsPanel.tsx
@@ -57,7 +57,7 @@ export function SettingsPanel({ title, groups }: SettingsPanelProps) {
                   <label
                     key={item.id}
                     htmlFor={item.id}
-                    className="flex items-center gap-1 cursor-pointer relative group/tip"
+                    className="flex items-center gap-2 cursor-pointer relative group/tip min-h-[44px] px-1"
                   >
                     <input
                       id={item.id}
@@ -79,13 +79,13 @@ export function SettingsPanel({ title, groups }: SettingsPanelProps) {
                     )}
                   </label>
                 ) : (
-                  <span key={item.id} className="flex items-center gap-1 relative group/tip">
+                  <span key={item.id} className="flex items-center gap-2 relative group/tip min-h-[44px]">
                     <label htmlFor={item.id}>{item.label}</label>
                     <select
                       id={item.id}
                       value={item.value}
                       onChange={(e) => item.onSelect?.(e.target.value)}
-                      className="bg-ds-surface-elevated text-ds-text-primary disabled:text-ds-text-muted disabled:opacity-70 rounded px-1 py-0.5"
+                      className="bg-ds-surface-elevated text-ds-text-primary disabled:text-ds-text-muted disabled:opacity-70 rounded px-2 py-2 min-h-[44px]"
                       disabled={item.disabled}
                       aria-describedby={item.tooltip ? `${item.id}-tooltip` : undefined}
                     >

--- a/frontend/src/components/oldmaid/OldMaidSettingsDialog.test.tsx
+++ b/frontend/src/components/oldmaid/OldMaidSettingsDialog.test.tsx
@@ -160,4 +160,15 @@ describe('OldMaidSettingsDialog', () => {
     const fieldset = legend.closest('fieldset');
     expect(fieldset).toBeInTheDocument();
   });
+
+  it('every radio/checkbox label meets the 44px minimum touch target (WCAG 2.5.5)', () => {
+    // Issue #1510: setup dialog stacks 6 small toggles; below 44px tap area
+    // mobile users mis-toggle adjacent options.
+    const { container } = render(<OldMaidSettingsDialog {...defaultProps} />);
+    const labels = container.querySelectorAll('label.flex.items-center');
+    expect(labels.length).toBeGreaterThanOrEqual(6);
+    for (const label of labels) {
+      expect(label.className).toContain('min-h-[44px]');
+    }
+  });
 });

--- a/frontend/src/components/oldmaid/OldMaidSettingsDialog.tsx
+++ b/frontend/src/components/oldmaid/OldMaidSettingsDialog.tsx
@@ -104,7 +104,7 @@ export function OldMaidSettingsDialog({
         <div className="flex flex-col gap-3">
           <fieldset className="flex flex-col gap-3 border-0 p-0 m-0">
             <legend className="text-white font-bold mb-1">{t('setup.modeSelect')}</legend>
-            <label className="flex items-center gap-2 text-white cursor-pointer">
+            <label className="flex items-center gap-2 text-white cursor-pointer min-h-[44px]">
               <input
                 type="radio"
                 name="oldmaid-mode"
@@ -114,7 +114,7 @@ export function OldMaidSettingsDialog({
               />
               {t('setup.normal')}
             </label>
-            <label className="flex items-center gap-2 text-white cursor-pointer">
+            <label className="flex items-center gap-2 text-white cursor-pointer min-h-[44px]">
               <input
                 type="radio"
                 name="oldmaid-mode"
@@ -128,7 +128,7 @@ export function OldMaidSettingsDialog({
           <div className="border-t border-white/20 my-1" />
           <fieldset className="flex flex-col gap-3 border-0 p-0 m-0">
             <legend className="text-white font-bold mb-1">{t('setup.cpuSettings')}</legend>
-            <label className="flex items-center gap-2 text-white cursor-pointer">
+            <label className="flex items-center gap-2 text-white cursor-pointer min-h-[44px]">
               <input
                 type="checkbox"
                 checked={cpuPlacementStrategy}
@@ -136,11 +136,11 @@ export function OldMaidSettingsDialog({
               />
               {t('setup.cpuStrategy')}
             </label>
-            <label className="flex items-center gap-2 text-white cursor-pointer">
+            <label className="flex items-center gap-2 text-white cursor-pointer min-h-[44px]">
               <input type="checkbox" checked={cpuMemoryAI} onChange={(e) => onMemoryAIChange(e.target.checked)} />
               {t('setup.cpuMemoryAI')}
             </label>
-            <label className="flex items-center gap-2 text-white cursor-pointer">
+            <label className="flex items-center gap-2 text-white cursor-pointer min-h-[44px]">
               <input
                 type="checkbox"
                 checked={cpuHesitationEnabled}
@@ -148,7 +148,7 @@ export function OldMaidSettingsDialog({
               />
               {t('setup.cpuHesitation')}
             </label>
-            <label className="flex items-center gap-2 text-white cursor-pointer">
+            <label className="flex items-center gap-2 text-white cursor-pointer min-h-[44px]">
               <input type="checkbox" checked={cpuMetaAI} onChange={(e) => onMetaAIChange(e.target.checked)} />
               {t('setup.cpuMetaAI')}
             </label>

--- a/frontend/src/components/tutorial/TutorialSuggestDialog.tsx
+++ b/frontend/src/components/tutorial/TutorialSuggestDialog.tsx
@@ -95,7 +95,7 @@ export function TutorialSuggestDialog({
         <p id="suggest-dialog-desc" className="text-ds-text-primary mb-4">
           {t('firstVisit.message')}
         </p>
-        <label className="flex items-center gap-2 text-sm text-ds-text-muted mb-4 cursor-pointer">
+        <label className="flex items-center gap-2 text-sm text-ds-text-muted mb-4 cursor-pointer min-h-[44px]">
           <input
             type="checkbox"
             checked={dontShowAgain}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -95,11 +95,15 @@ textarea {
   font-size: 16px;
 }
 
-/* Dark-themed select elements for game UI */
+/* Dark-themed select elements for game UI.
+   min-height enforces the 44px touch target baseline (DESIGN.md, WCAG 2.5.5)
+   so dropdowns line up with btnPrimary/btnSecondary across all 65 games
+   without needing per-component min-h-[44px] classes. */
 select {
   background-color: var(--color-ds-surface-elevated);
   color: var(--color-ds-text-primary);
   border: 1px solid var(--color-ds-border-subtle);
+  min-height: 44px;
 }
 
 select:focus-visible {
@@ -127,13 +131,18 @@ h3 {
   font-variant-numeric: tabular-nums;
 }
 
-/* Dark-themed number/text inputs for game UI */
+/* Dark-themed number/text inputs for game UI.
+   min-height enforces the 44px touch target baseline (DESIGN.md, WCAG 2.5.5).
+   Components that already pass `min-h-[44px]` (e.g. NavBar mobile search) are
+   unaffected; everything else now meets the threshold without per-component
+   overrides. */
 input[type="number"],
 input[type="text"],
 input[type="search"] {
   background-color: var(--color-ds-surface-elevated);
   color: var(--color-ds-text-primary);
   border: 1px solid var(--color-ds-border-subtle);
+  min-height: 44px;
 }
 
 /* Accent color for checkboxes and radios on dark theme */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -135,10 +135,12 @@ h3 {
    min-height enforces the 44px touch target baseline (DESIGN.md, WCAG 2.5.5).
    Components that already pass `min-h-[44px]` (e.g. NavBar mobile search) are
    unaffected; everything else now meets the threshold without per-component
-   overrides. */
+   overrides. `input:not([type])` covers bare `<input>` (defaults to text)
+   which the explicit selectors miss. */
 input[type="number"],
 input[type="text"],
-input[type="search"] {
+input[type="search"],
+input:not([type]) {
   background-color: var(--color-ds-surface-elevated);
   color: var(--color-ds-text-primary);
   border: 1px solid var(--color-ds-border-subtle);
@@ -153,7 +155,8 @@ input[type="radio"] {
 
 input[type="number"]:focus-visible,
 input[type="text"]:focus-visible,
-input[type="search"]:focus-visible {
+input[type="search"]:focus-visible,
+input:not([type]):focus-visible {
   outline: none;
   box-shadow:
     0 0 0 2px var(--color-ds-bg),


### PR DESCRIPTION
Closes #1510

## Summary
Bring form controls up to WCAG 2.5.5 AAA / 2.2 AA tap target size (44×44 CSS px). Buttons already meet this baseline via `buttonStyles.ts:base`; this PR closes the gap on checkboxes, radios, selects, and number inputs across all 65 games.

## Changes
- **`SettingsPanel.tsx`** — checkbox label and select wrapper gain `min-h-[44px]`; padding bumped from `px-1 py-0.5` to `px-2 py-2` and gap from `gap-1` to `gap-2`.
- **`ChipBetInput.tsx`** — input bumps to `px-3 py-2 text-base min-h-[44px]` (Baccarat / Caribbean Stud / Three Card / Pai Gow / Let It Ride).
- **`OldMaidSettingsDialog.tsx`** — all 6 labels (2 radio + 4 checkbox) gain `min-h-[44px]`.
- **`TutorialSuggestDialog.tsx`**, **`VideoPokerGameContent.tsx`** — toggle labels gain the same class.
- **`index.css`** — `select`, `input[type="number|text|search"]` get a global `min-height: 44px` so unmigrated call sites (e.g. BettingControls, BjBetPhaseControls) inherit the baseline without per-component edits.
- **`DESIGN.md`** — new "Interactive Element Minimum Size" section documents the 44px rule with `tap-target-min` / `tap-target-aa-min` tokens.

## Test plan
- [x] `bun run test -- --run common/SettingsPanel common/ChipBetInput oldmaid/OldMaidSettingsDialog` — 3 files, 52 tests pass (4 new TDD tests assert `min-h-[44px]` class)
- [x] `bun run test -- --run tutorial VideoPokerGameContent BettingControls blackjack` — 22 files, 407 tests pass (verifies CSS changes don't regress consumers of selects/inputs)
- [x] `bun run check` — biome lint + design-tokens, exit 0 (pre-existing warnings only)
- [x] `bun run build` — tsc + vite build complete (~23min on 2GB box)
- [ ] Manual: visit settings panels for blackjack, hearts, oldmaid, baccarat on a mobile-sized viewport and confirm rows are not cropped (deferred — UI verification by reviewer)