### PR TITLE
refactor(ui): i18n-ize duplicated poker help blocks

### DIFF
--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -85,5 +85,20 @@
   "webServerRunning": "Server is running at http://{{addr}}",
   "webServerStop": "Press Ctrl+C to stop",
   "webServerShutdown": "Shutting down server...",
-  "webServerStopped": "Server stopped."
+  "webServerStopped": "Server stopped.",
+  "tournament.helpRebuy": "  rb                   rebuy",
+  "tournament.helpSkipRebuy": "  sr                   skip rebuy",
+  "tournament.helpAddOn": "  ad                   add-on",
+  "tournament.helpSkipAddOn": "  sa                   skip add-on",
+  "tournament.helpDiscard": "  d <index>            discard",
+  "tournament.helpSmallBlind": "  sb <amount>          small blind (>=1)",
+  "tournament.helpBigBlind": "  bb <amount>          big blind (>=2)",
+  "tournament.helpLevelUpHands": "  lh <hands>           blind level-up hands (>=1)",
+  "tournament.helpTableSize": "  ts [4|6|9]           table size",
+  "stud.helpAnte": "  ante <amount>        ante (>=1)",
+  "stud.helpBringIn": "  bi <amount>          bring-in (>=1)",
+  "stud.helpSmallBet": "  sb <amount>          small bet (>=1)",
+  "stud.helpBigBet": "  bb <amount>          big bet (>=1)",
+  "stud.helpLevelUpHands": "  lh <hands>           ante level-up hands (>=1)",
+  "stud.helpTableSize": "  ts [2-7]             table size"
 }

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -85,5 +85,20 @@
   "webServerRunning": "サーバーが http://{{addr}} で起動しました",
   "webServerStop": "Ctrl+C で停止できます",
   "webServerShutdown": "サーバーをシャットダウン中...",
-  "webServerStopped": "サーバーを停止しました。"
+  "webServerStopped": "サーバーを停止しました。",
+  "tournament.helpRebuy": "  rb                   リバイ",
+  "tournament.helpSkipRebuy": "  sr                   リバイスキップ",
+  "tournament.helpAddOn": "  ad                   アドオン",
+  "tournament.helpSkipAddOn": "  sa                   アドオンスキップ",
+  "tournament.helpDiscard": "  d <index>            手札を捨てる",
+  "tournament.helpSmallBlind": "  sb <amount>          スモールブラインド (>=1)",
+  "tournament.helpBigBlind": "  bb <amount>          ビッグブラインド (>=2)",
+  "tournament.helpLevelUpHands": "  lh <hands>           ブラインドレベルアップ手数 (>=1)",
+  "tournament.helpTableSize": "  ts [4|6|9]           テーブルサイズ",
+  "stud.helpAnte": "  ante <amount>        アンテ (>=1)",
+  "stud.helpBringIn": "  bi <amount>          ブリングイン (>=1)",
+  "stud.helpSmallBet": "  sb <amount>          スモールベット (>=1)",
+  "stud.helpBigBet": "  bb <amount>          ビッグベット (>=1)",
+  "stud.helpLevelUpHands": "  lh <hands>           アンテレベルアップ手数 (>=1)",
+  "stud.helpTableSize": "  ts [2-7]             テーブルサイズ"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -34,6 +34,43 @@ func cuiEntry(ctrl CuiExecer, spec CuiHelpSpec) cuiGame {
 	return newCuiGame(ctrl, BuildCuiHelp(spec))
 }
 
+// Shared poker-family help keys live here so a label change (e.g. renaming
+// "small blind" wording) updates every entry that uses them. See issue #1511.
+var (
+	// tournamentRebuyAddOnKeys covers the rebuy / add-on row used by every
+	// tournament-capable poker game.
+	tournamentRebuyAddOnKeys = []string{
+		"tournament.helpRebuy",
+		"tournament.helpSkipRebuy",
+		"tournament.helpAddOn",
+		"tournament.helpSkipAddOn",
+	}
+	// pineappleRebuyAddOnKeys is the same row prefixed with the discard line
+	// only Pineapple variants surface.
+	pineappleRebuyAddOnKeys = append(
+		[]string{"tournament.helpDiscard"},
+		tournamentRebuyAddOnKeys...,
+	)
+	// holdemBlindKeys are the blind / level-up / table-size settings shared
+	// by holdem, omaha, shortdeck, pineapple, crazypineapple.
+	holdemBlindKeys = []string{
+		"tournament.helpSmallBlind",
+		"tournament.helpBigBlind",
+		"tournament.helpLevelUpHands",
+		"tournament.helpTableSize",
+	}
+	// studAnteKeys are the ante / bring-in settings shared by sevencardstud
+	// and razz (both render through the SevenCardStud controller).
+	studAnteKeys = []string{
+		"stud.helpAnte",
+		"stud.helpBringIn",
+		"stud.helpSmallBet",
+		"stud.helpBigBet",
+		"stud.helpLevelUpHands",
+		"stud.helpTableSize",
+	}
+)
+
 // gameRegistry wires each game's CUI constructor. Name and Description are
 // carried by the games package (see internal/infrastructure/games/registry.go)
 // — this slice only holds the CLI-specific NewCui factory. Order mirrors the
@@ -113,27 +150,17 @@ var gameRegistry = []GameRegistryEntry{
 				domain.NewDefaultHoldem(), new(presenter.HoldemCuiPresenter))),
 			CuiHelpSpec{
 				TitleKey: "holdem.helpTitle",
-				CommandKeys: []string{
+				CommandKeys: append([]string{
 					"holdem.helpFold",
 					"holdem.helpCheck",
 					"holdem.helpCall",
 					"holdem.helpBet",
 					"holdem.helpRaise",
 					"holdem.helpAllIn",
-				},
-				ExtraCommandLines: []string{
-					"  rb                   rebuy",
-					"  sr                   skip rebuy",
-					"  ad                   add-on",
-					"  sa                   skip add-on",
-				},
-				SettingKeys: []string{"holdem.helpBettingLimit", "holdem.helpTournament"},
-				ExtraSettingLines: []string{
-					"  sb <amount>          small blind (>=1)",
-					"  bb <amount>          big blind (>=2)",
-					"  lh <hands>           blind level-up hands (>=1)",
-					"  ts [4|6|9]           table size",
-				},
+				}, tournamentRebuyAddOnKeys...),
+				SettingKeys: append([]string{
+					"holdem.helpBettingLimit", "holdem.helpTournament",
+				}, holdemBlindKeys...),
 			})
 	}},
 	{Name: "omaha", NewCui: func() cuiGame {
@@ -142,27 +169,17 @@ var gameRegistry = []GameRegistryEntry{
 				domain.NewDefaultOmaha(), new(presenter.OmahaCuiPresenter))),
 			CuiHelpSpec{
 				TitleKey: "omaha.helpTitle",
-				CommandKeys: []string{
+				CommandKeys: append([]string{
 					"omaha.helpFold",
 					"omaha.helpCheck",
 					"omaha.helpCall",
 					"omaha.helpBet",
 					"omaha.helpRaise",
 					"omaha.helpAllIn",
-				},
-				ExtraCommandLines: []string{
-					"  rb                   rebuy",
-					"  sr                   skip rebuy",
-					"  ad                   add-on",
-					"  sa                   skip add-on",
-				},
-				SettingKeys: []string{"omaha.helpBettingLimit", "omaha.helpTournament"},
-				ExtraSettingLines: []string{
-					"  sb <amount>          small blind (>=1)",
-					"  bb <amount>          big blind (>=2)",
-					"  lh <hands>           blind level-up hands (>=1)",
-					"  ts [4|6|9]           table size",
-				},
+				}, tournamentRebuyAddOnKeys...),
+				SettingKeys: append([]string{
+					"omaha.helpBettingLimit", "omaha.helpTournament",
+				}, holdemBlindKeys...),
 			})
 	}},
 	{Name: "shortdeck", NewCui: func() cuiGame {
@@ -171,27 +188,17 @@ var gameRegistry = []GameRegistryEntry{
 				domain.NewDefaultShortDeck(), new(presenter.ShortDeckCuiPresenter))),
 			CuiHelpSpec{
 				TitleKey: "shortdeck.helpTitle",
-				CommandKeys: []string{
+				CommandKeys: append([]string{
 					"shortdeck.helpFold",
 					"shortdeck.helpCheck",
 					"shortdeck.helpCall",
 					"shortdeck.helpBet",
 					"shortdeck.helpRaise",
 					"shortdeck.helpAllIn",
-				},
-				ExtraCommandLines: []string{
-					"  rb                   rebuy",
-					"  sr                   skip rebuy",
-					"  ad                   add-on",
-					"  sa                   skip add-on",
-				},
-				SettingKeys: []string{"shortdeck.helpBettingLimit", "shortdeck.helpTournament"},
-				ExtraSettingLines: []string{
-					"  sb <amount>          small blind (>=1)",
-					"  bb <amount>          big blind (>=2)",
-					"  lh <hands>           blind level-up hands (>=1)",
-					"  ts [4|6|9]           table size",
-				},
+				}, tournamentRebuyAddOnKeys...),
+				SettingKeys: append([]string{
+					"shortdeck.helpBettingLimit", "shortdeck.helpTournament",
+				}, holdemBlindKeys...),
 			})
 	}},
 	{Name: "pineapple", NewCui: func() cuiGame {
@@ -200,28 +207,17 @@ var gameRegistry = []GameRegistryEntry{
 				domain.NewDefaultPineapple(), new(presenter.PineappleCuiPresenter))),
 			CuiHelpSpec{
 				TitleKey: "pineapple.helpTitle",
-				CommandKeys: []string{
+				CommandKeys: append([]string{
 					"pineapple.helpFold",
 					"pineapple.helpCheck",
 					"pineapple.helpCall",
 					"pineapple.helpBet",
 					"pineapple.helpRaise",
 					"pineapple.helpAllIn",
-				},
-				ExtraCommandLines: []string{
-					"  d <index>            discard",
-					"  rb                   rebuy",
-					"  sr                   skip rebuy",
-					"  ad                   add-on",
-					"  sa                   skip add-on",
-				},
-				SettingKeys: []string{"pineapple.helpBettingLimit", "pineapple.helpTournament"},
-				ExtraSettingLines: []string{
-					"  sb <amount>          small blind (>=1)",
-					"  bb <amount>          big blind (>=2)",
-					"  lh <hands>           blind level-up hands (>=1)",
-					"  ts [4|6|9]           table size",
-				},
+				}, pineappleRebuyAddOnKeys...),
+				SettingKeys: append([]string{
+					"pineapple.helpBettingLimit", "pineapple.helpTournament",
+				}, holdemBlindKeys...),
 			})
 	}},
 	{Name: "crazypineapple", NewCui: func() cuiGame {
@@ -230,28 +226,17 @@ var gameRegistry = []GameRegistryEntry{
 				domain.NewDefaultCrazyPineapple(), new(presenter.PineappleCuiPresenter))),
 			CuiHelpSpec{
 				TitleKey: "crazypineapple.helpTitle",
-				CommandKeys: []string{
+				CommandKeys: append([]string{
 					"crazypineapple.helpFold",
 					"crazypineapple.helpCheck",
 					"crazypineapple.helpCall",
 					"crazypineapple.helpBet",
 					"crazypineapple.helpRaise",
 					"crazypineapple.helpAllIn",
-				},
-				ExtraCommandLines: []string{
-					"  d <index>            discard",
-					"  rb                   rebuy",
-					"  sr                   skip rebuy",
-					"  ad                   add-on",
-					"  sa                   skip add-on",
-				},
-				SettingKeys: []string{"crazypineapple.helpBettingLimit", "crazypineapple.helpTournament"},
-				ExtraSettingLines: []string{
-					"  sb <amount>          small blind (>=1)",
-					"  bb <amount>          big blind (>=2)",
-					"  lh <hands>           blind level-up hands (>=1)",
-					"  ts [4|6|9]           table size",
-				},
+				}, pineappleRebuyAddOnKeys...),
+				SettingKeys: append([]string{
+					"crazypineapple.helpBettingLimit", "crazypineapple.helpTournament",
+				}, holdemBlindKeys...),
 			})
 	}},
 	{Name: "hearts", NewCui: func() cuiGame {
@@ -650,29 +635,17 @@ var gameRegistry = []GameRegistryEntry{
 				domain.NewDefaultSevenCardStud(), new(presenter.SevenCardStudCuiPresenter))),
 			CuiHelpSpec{
 				TitleKey: "sevencardstud.helpTitle",
-				CommandKeys: []string{
+				CommandKeys: append([]string{
 					"sevencardstud.helpFold",
 					"sevencardstud.helpCheck",
 					"sevencardstud.helpCall",
 					"sevencardstud.helpBet",
 					"sevencardstud.helpRaise",
 					"sevencardstud.helpAllIn",
-				},
-				ExtraCommandLines: []string{
-					"  rb                   rebuy",
-					"  sr                   skip rebuy",
-					"  ad                   add-on",
-					"  sa                   skip add-on",
-				},
-				SettingKeys: []string{"sevencardstud.helpBettingLimit", "sevencardstud.helpTournament"},
-				ExtraSettingLines: []string{
-					"  ante <amount>        ante (>=1)",
-					"  bi <amount>          bring-in (>=1)",
-					"  sb <amount>          small bet (>=1)",
-					"  bb <amount>          big bet (>=1)",
-					"  lh <hands>           ante level-up hands (>=1)",
-					"  ts [2-7]             table size",
-				},
+				}, tournamentRebuyAddOnKeys...),
+				SettingKeys: append([]string{
+					"sevencardstud.helpBettingLimit", "sevencardstud.helpTournament",
+				}, studAnteKeys...),
 			})
 	}},
 	{Name: "clocksolitaire", NewCui: func() cuiGame {
@@ -909,29 +882,17 @@ var gameRegistry = []GameRegistryEntry{
 				domain.NewDefaultRazz(), new(presenter.SevenCardStudCuiPresenter))),
 			CuiHelpSpec{
 				TitleKey: "razz.helpTitle",
-				CommandKeys: []string{
+				CommandKeys: append([]string{
 					"sevencardstud.helpFold",
 					"sevencardstud.helpCheck",
 					"sevencardstud.helpCall",
 					"sevencardstud.helpBet",
 					"sevencardstud.helpRaise",
 					"sevencardstud.helpAllIn",
-				},
-				ExtraCommandLines: []string{
-					"  rb                   rebuy",
-					"  sr                   skip rebuy",
-					"  ad                   add-on",
-					"  sa                   skip add-on",
-				},
-				SettingKeys: []string{"sevencardstud.helpBettingLimit", "sevencardstud.helpTournament"},
-				ExtraSettingLines: []string{
-					"  ante <amount>        ante (>=1)",
-					"  bi <amount>          bring-in (>=1)",
-					"  sb <amount>          small bet (>=1)",
-					"  bb <amount>          big bet (>=1)",
-					"  lh <hands>           ante level-up hands (>=1)",
-					"  ts [2-7]             table size",
-				},
+				}, tournamentRebuyAddOnKeys...),
+				SettingKeys: append([]string{
+					"sevencardstud.helpBettingLimit", "sevencardstud.helpTournament",
+				}, studAnteKeys...),
 			})
 	}},
 	{Name: "scorpion", NewCui: func() cuiGame {

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -46,11 +46,17 @@ var (
 		"tournament.helpSkipAddOn",
 	}
 	// pineappleRebuyAddOnKeys is the same row prefixed with the discard line
-	// only Pineapple variants surface.
-	pineappleRebuyAddOnKeys = append(
-		[]string{"tournament.helpDiscard"},
-		tournamentRebuyAddOnKeys...,
-	)
+	// only Pineapple variants surface. Spelled out as a flat literal (rather
+	// than `append([]string{...}, tournamentRebuyAddOnKeys...)`) so the keys
+	// don't depend on package-level init order and can't accidentally alias
+	// the shared slice.
+	pineappleRebuyAddOnKeys = []string{
+		"tournament.helpDiscard",
+		"tournament.helpRebuy",
+		"tournament.helpSkipRebuy",
+		"tournament.helpAddOn",
+		"tournament.helpSkipAddOn",
+	}
 	// holdemBlindKeys are the blind / level-up / table-size settings shared
 	// by holdem, omaha, shortdeck, pineapple, crazypineapple.
 	holdemBlindKeys = []string{

--- a/internal/infrastructure/ui/help_text_test.go
+++ b/internal/infrastructure/ui/help_text_test.go
@@ -200,6 +200,18 @@ func TestPokerHelpUsesI18n(t *testing.T) {
 			},
 		},
 		{
+			// Pinned separately from pineapple so a copy-paste swap of
+			// tournamentRebuyAddOnKeys for pineappleRebuyAddOnKeys here would
+			// fail this case loudly instead of going unnoticed.
+			name: "crazypineapple JA includes the discard line too",
+			game: "crazypineapple",
+			lang: "ja",
+			mustContain: []string{
+				"手札を捨てる",
+				"リバイ",
+			},
+		},
+		{
 			name: "sevencardstud JA shows ante and bring-in translations",
 			game: "sevencardstud",
 			lang: "ja",

--- a/internal/infrastructure/ui/help_text_test.go
+++ b/internal/infrastructure/ui/help_text_test.go
@@ -3,6 +3,7 @@
 package ui
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
@@ -150,6 +151,97 @@ func TestBuildCuiHelp_bodyShortCircuitsScaffold(t *testing.T) {
 		SettingKeys: []string{"hearts.helpSetLimit"},
 	})
 	assertLines(t, got, body)
+}
+
+// TestPokerHelpUsesI18n covers issue #1511: tournament rebuy/blind and stud
+// ante/bring-in help lines must come from i18n keys so JA users see localized
+// text instead of the English literals that used to live in ExtraCommandLines /
+// ExtraSettingLines. Locale is restored to "en" (matching TestMain) at the end.
+func TestPokerHelpUsesI18n(t *testing.T) {
+	defer i18n.SetLang("en")
+
+	tests := []struct {
+		name        string
+		game        string // registry name
+		lang        string
+		mustContain []string
+	}{
+		{
+			name: "holdem JA shows tournament + blind translations",
+			game: "holdem",
+			lang: "ja",
+			mustContain: []string{
+				"リバイ",             // tournament.helpRebuy
+				"アドオン",            // tournament.helpAddOn
+				"スモールブラインド (>=1)", // tournament.helpSmallBlind
+				"ブラインドレベルアップ手数 (>=1)", // tournament.helpLevelUpHands
+				"テーブルサイズ",             // tournament.helpTableSize
+			},
+		},
+		{
+			name: "holdem EN keeps existing English wording",
+			game: "holdem",
+			lang: "en",
+			mustContain: []string{
+				"rebuy",
+				"add-on",
+				"small blind (>=1)",
+				"blind level-up hands (>=1)",
+				"table size",
+			},
+		},
+		{
+			name: "pineapple JA includes localized discard line",
+			game: "pineapple",
+			lang: "ja",
+			mustContain: []string{
+				"手札を捨てる", // tournament.helpDiscard
+				"リバイ",
+			},
+		},
+		{
+			name: "sevencardstud JA shows ante and bring-in translations",
+			game: "sevencardstud",
+			lang: "ja",
+			mustContain: []string{
+				"アンテ (>=1)",         // stud.helpAnte
+				"ブリングイン (>=1)",      // stud.helpBringIn
+				"スモールベット (>=1)",     // stud.helpSmallBet
+				"ビッグベット (>=1)",      // stud.helpBigBet
+				"アンテレベルアップ手数 (>=1)", // stud.helpLevelUpHands
+			},
+		},
+		{
+			name: "razz JA shares the stud ante block",
+			game: "razz",
+			lang: "ja",
+			mustContain: []string{
+				"アンテ (>=1)",
+				"ブリングイン (>=1)",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			i18n.SetLang(tc.lang)
+			var entry *GameRegistryEntry
+			for i := range gameRegistry {
+				if gameRegistry[i].Name == tc.game {
+					entry = &gameRegistry[i]
+					break
+				}
+			}
+			if entry == nil {
+				t.Fatalf("game %q not found in registry", tc.game)
+			}
+			joined := strings.Join(entry.NewCui().HelpLines(), "\n")
+			for _, want := range tc.mustContain {
+				if !strings.Contains(joined, want) {
+					t.Errorf("help for %s (lang=%s) missing %q\nfull help:\n%s", tc.game, tc.lang, want, joined)
+				}
+			}
+		})
+	}
 }
 
 func assertLines(t *testing.T, got, want []string) {


### PR DESCRIPTION
Closes #1511

## Summary
- Move the 39 lines of duplicated English literals in `GameManager.go` (rebuy/add-on, blind, discard, stud ante/bring-in) into `tournament.*` and `stud.*` i18n keys in `common.json` (ja/en).
- Collapse the seven duplicated blocks (holdem, omaha, shortdeck, pineapple, crazypineapple, sevencardstud, razz) into four shared package-level slices: `tournamentRebuyAddOnKeys`, `pineappleRebuyAddOnKeys`, `holdemBlindKeys`, `studAnteKeys`.
- JA users now see localized rebuy / blind / ante text instead of English mixed into the JA UI. A label change in `common.json` updates all seven games at once.

## Diff
| File | Change |
|---|---|
| `internal/infrastructure/ui/GameManager.go` | -~80 lines net via the shared key slices |
| `internal/i18n/locales/{ja,en}/common.json` | +15 keys each under `tournament.*` and `stud.*` |
| `internal/infrastructure/ui/help_text_test.go` | new `TestPokerHelpUsesI18n` (JA + EN regression) |

## Manual verification
\`\`\`
$ trumpcards --lang ja help holdem
  rb                   リバイ
  sr                   リバイスキップ
  ad                   アドオン
  sa                   アドオンスキップ
  sb <amount>          スモールブラインド (>=1)
  bb <amount>          ビッグブラインド (>=2)
  lh <hands>           ブラインドレベルアップ手数 (>=1)
  ts [4|6|9]           テーブルサイズ

$ trumpcards --lang en help holdem
  rb                   rebuy
  sr                   skip rebuy
  ad                   add-on
  sa                   skip add-on
  sb <amount>          small blind (>=1)
  bb <amount>          big blind (>=2)
  lh <hands>           blind level-up hands (>=1)
  ts [4|6|9]           table size
\`\`\`

## Test plan
- [x] `go test -tags test ./internal/infrastructure/ui/` (new TestPokerHelpUsesI18n covers holdem/pineapple/sevencardstud/razz in JA and an EN regression)
- [x] `go test -tags test ./...` — all packages green
- [x] `golangci-lint run ./internal/infrastructure/ui/...` — 0 issues
- [x] `goimports -w` on touched files
- [x] Manual: `trumpcards --lang ja help holdem` / `--lang en help holdem` / `--lang ja help sevencardstud`

## Notes
- The `Extra*Lines` mechanism in `CuiHelpSpec` is preserved for genuinely game-specific lines (e.g. `"  l  action log"`); only the duplicated poker rows were i18n-ized.
- The `pineappleRebuyAddOnKeys` slice prefixes the discard line for Pineapple variants so the asymmetry stays explicit.