### PR TITLE
feat(doubt): keep CPU tell visible during doubt judgment phase

### DIFF
--- a/frontend/src/hooks/useDoubtGame.ts
+++ b/frontend/src/hooks/useDoubtGame.ts
@@ -37,7 +37,8 @@ export function actionDesc(
 ): string {
   const p = players[action.playerIdx];
   const name = p ? playerName(p.id, p.isHuman) : `Player ${action.playerIdx}`;
-  return t('actionDesc', { name, count: action.cardCount, value: valueName(action.claimedValue) });
+  const key = action.hasTell ? 'actionDescWithTell' : 'actionDesc';
+  return t(key, { name, count: action.cardCount, value: valueName(action.claimedValue) });
 }
 
 /** Hook that manages Doubt game state, countdown timer, and player actions. */

--- a/frontend/src/i18n/locales/en/doubt.json
+++ b/frontend/src/i18n/locales/en/doubt.json
@@ -8,6 +8,7 @@
   "table": "Table",
   "tableCards": "Table Cards: {{count}}",
   "actionDesc": "{{name}} played {{count}} card(s) (claimed: {{value}})",
+  "actionDescWithTell": "{{name}} played {{count}} card(s) (claimed: {{value}}) — appears nervous…",
   "doubtQuestion": "Doubt?",
   "countdown": "{{sec}} sec left",
   "cpuDoubters": "CPU doubters: {{names}}",

--- a/frontend/src/i18n/locales/ja/doubt.json
+++ b/frontend/src/i18n/locales/ja/doubt.json
@@ -8,6 +8,7 @@
   "table": "テーブル",
   "tableCards": "場のカード: {{count}}枚",
   "actionDesc": "{{name}}が{{count}}枚出しました (宣言: {{value}})",
+  "actionDescWithTell": "{{name}}が{{count}}枚出しました (宣言: {{value}}) — 緊張しているようだ…",
   "doubtQuestion": "ダウトしますか？",
   "countdown": "残り {{sec}} 秒",
   "cpuDoubters": "ダウト宣言CPU: {{names}}",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -232,24 +232,20 @@ input:not([type]):focus-visible {
 
 @keyframes sweat-drop {
   0% {
-    opacity: 0;
-    transform: translateY(-4px);
+    opacity: 0.6;
+    transform: translateY(-2px);
   }
-  30% {
+  50% {
     opacity: 1;
-    transform: translateY(0);
-  }
-  70% {
-    opacity: 1;
-    transform: translateY(0);
+    transform: translateY(2px);
   }
   100% {
-    opacity: 0;
-    transform: translateY(4px);
+    opacity: 0.6;
+    transform: translateY(-2px);
   }
 }
 .animate-sweat-drop {
-  animation: sweat-drop 2s ease-in-out;
+  animation: sweat-drop 1.5s ease-in-out infinite;
 }
 
 /* Rotate chevron when sidebar category is open */

--- a/frontend/src/pages/DoubtPage.test.tsx
+++ b/frontend/src/pages/DoubtPage.test.tsx
@@ -936,6 +936,27 @@ describe('DoubtPage', () => {
     expect(screen.queryByLabelText('テル')).not.toBeInTheDocument();
   });
 
+  it('appends tell hint text to cpu action log when hasTell is true', async () => {
+    const s: DoubtResponse = {
+      ...humanTurnState,
+      cpuActions: [{ playerIdx: 1, claimedValue: 3, cardCount: 2, isBluff: true, hasTell: true }],
+    };
+    mockExec.mockResolvedValue(s);
+    renderWithProviders(<DoubtPage />);
+    await waitFor(() => expect(screen.getByText(/緊張しているようだ/)).toBeInTheDocument());
+  });
+
+  it('does not append tell hint text to cpu action log when hasTell is false', async () => {
+    const s: DoubtResponse = {
+      ...humanTurnState,
+      cpuActions: [{ playerIdx: 1, claimedValue: 3, cardCount: 2, isBluff: true, hasTell: false }],
+    };
+    mockExec.mockResolvedValue(s);
+    renderWithProviders(<DoubtPage />);
+    await waitFor(() => expect(screen.getByText('CPU 1')).toBeInTheDocument());
+    expect(screen.queryByText(/緊張しているようだ/)).not.toBeInTheDocument();
+  });
+
   // ── Settings panel ────────────────────────────────────────────────────────
 
   it('renders settings panel with default values', async () => {


### PR DESCRIPTION
## Summary

- Replace one-shot fade-out `sweat-drop` animation with a looping "breathing" pulse so the 💧 tell stays visible for the entire doubt-judgment window instead of disappearing after 2 seconds.
- Append a 「緊張しているようだ…」 / "appears nervous…" suffix to action-log entries when the action's `hasTell` is true, so users reading the log don't have to watch the CPU avatars to catch the cue.
- Drives off existing `hasTell` action data — no new server fields required.

## Test plan

- [x] `cd frontend && bun run test -- --run DoubtPage` (104/104 pass; new tests cover tell-suffix in action log, both true and false branches)
- [x] `cd frontend && bun run check`
- [x] `cd frontend && bun run build`
- [ ] Smoke test in Doubt: trigger a CPU bluff with a tell and verify the 💧 keeps pulsing through the whole countdown
- [ ] Verify action log line shows "緊張しているようだ…" (ja) / "appears nervous…" (en)

Closes #1514