### PR TITLE
feat(speed): emphasize stuck state and add inline auto-flip toggle

### DIFF
--- a/frontend/src/i18n/locales/en/speed.json
+++ b/frontend/src/i18n/locales/en/speed.json
@@ -14,6 +14,7 @@
   "playButton": "Play",
   "flipButton": "Flip",
   "stuckMessage": "Stuck! Press flip to turn over new center cards.",
+  "autoFlipInline": "Auto-flip",
   "settings": {
     "title": "Settings",
     "cpuDifficulty": "CPU Difficulty",

--- a/frontend/src/i18n/locales/ja/speed.json
+++ b/frontend/src/i18n/locales/ja/speed.json
@@ -14,6 +14,7 @@
   "playButton": "出す",
   "flipButton": "めくる",
   "stuckMessage": "膠着状態です。めくるボタンを押してください。",
+  "autoFlipInline": "自動でめくる",
   "settings": {
     "title": "設定",
     "cpuDifficulty": "CPU難易度",

--- a/frontend/src/pages/SpeedPage.test.tsx
+++ b/frontend/src/pages/SpeedPage.test.tsx
@@ -333,6 +333,54 @@ describe('SpeedPage', () => {
     await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
     expect(screen.getByLabelText('膠着時に自動でめくる')).toBeInTheDocument();
   });
+
+  it('renders an inline auto-flip toggle when stuck', async () => {
+    mockExec.mockResolvedValue(stuckState);
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByTestId('flip-button')).toBeInTheDocument());
+    expect(screen.getByTestId('inline-auto-flip-toggle')).toBeInTheDocument();
+  });
+
+  it('does not render the inline auto-flip toggle in play phase', async () => {
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
+    expect(screen.queryByTestId('inline-auto-flip-toggle')).not.toBeInTheDocument();
+  });
+
+  it('inline auto-flip toggle reflects current speedConfig.autoFlip', async () => {
+    mockExec.mockResolvedValue(stuckState);
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByTestId('inline-auto-flip-toggle')).toBeInTheDocument());
+    const toggle = screen.getByTestId('inline-auto-flip-toggle') as HTMLInputElement;
+    expect(toggle.checked).toBe(true);
+  });
+
+  it('clicking the inline auto-flip toggle disables auto-flip', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockExec.mockResolvedValue(stuckState);
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByTestId('inline-auto-flip-toggle')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('inline-auto-flip-toggle'));
+    mockExec.mockClear();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(mockExec).not.toHaveBeenCalledWith('flip');
+    vi.useRealTimers();
+  });
+
+  it('renders an emphasized stuck container when stuck', async () => {
+    mockExec.mockResolvedValue(stuckState);
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByTestId('flip-button')).toBeInTheDocument());
+    expect(screen.getByTestId('stuck-emphasis-container')).toBeInTheDocument();
+  });
+
+  it('does not render the stuck emphasis container in play phase', async () => {
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
+    expect(screen.queryByTestId('stuck-emphasis-container')).not.toBeInTheDocument();
+  });
 });
 
 describe('SpeedPage auto-flip timer', () => {

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -252,7 +252,7 @@ function SpeedPageContent() {
                 role="status"
                 aria-live="polite"
               >
-                <p className="text-ds-warning font-bold text-base sm:text-lg animate-pulse">{t('stuckMessage')}</p>
+                <p className="text-ds-warning font-bold text-base sm:text-lg">{t('stuckMessage')}</p>
                 <button
                   type="button"
                   onClick={handleFlip}
@@ -262,7 +262,7 @@ function SpeedPageContent() {
                 >
                   {t('flipButton')}
                 </button>
-                <label className="flex items-center gap-2 text-xs text-ds-text-primary cursor-pointer min-h-[44px] px-1">
+                <label className="flex items-center gap-2 text-sm text-ds-text-primary cursor-pointer min-h-[44px] px-1">
                   <input
                     type="checkbox"
                     checked={speedConfig.autoFlip}

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -244,10 +244,15 @@ function SpeedPageContent() {
               </div>
             </div>
 
-            {/* Stuck message & flip button */}
+            {/* Stuck message, flip button, and inline auto-flip toggle */}
             {isStuck && (
-              <div className="flex flex-col items-center gap-2">
-                <p className="text-ds-warning font-bold">{t('stuckMessage')}</p>
+              <div
+                className="flex flex-col items-center gap-2 bg-ds-warning/10 ring-2 ring-ds-warning rounded-lg p-3"
+                data-testid="stuck-emphasis-container"
+                role="status"
+                aria-live="polite"
+              >
+                <p className="text-ds-warning font-bold text-base sm:text-lg animate-pulse">{t('stuckMessage')}</p>
                 <button
                   type="button"
                   onClick={handleFlip}
@@ -257,6 +262,15 @@ function SpeedPageContent() {
                 >
                   {t('flipButton')}
                 </button>
+                <label className="flex items-center gap-2 text-xs text-ds-text-primary cursor-pointer min-h-[44px] px-1">
+                  <input
+                    type="checkbox"
+                    checked={speedConfig.autoFlip}
+                    onChange={(e) => handleToggle('autoFlip', e.target.checked)}
+                    data-testid="inline-auto-flip-toggle"
+                  />
+                  {t('autoFlipInline')}
+                </label>
               </div>
             )}
 


### PR DESCRIPTION
## Summary

- Wrap the Speed stuck-phase section (banner + flip button + new inline toggle) in a warning-tinted container with `bg-ds-warning/10 ring-2 ring-ds-warning` styling and a pulsing 「膠着状態です。めくるボタンを押してください」 banner so the state change registers in fast-paced play.
- Add an inline 「自動でめくる」 / "Auto-flip" checkbox right next to the flip button, two-way bound to `speedConfig.autoFlip`. Users can toggle auto-flip mid-game without opening the settings panel.
- Marks the stuck container as `role="status" aria-live="polite"` so screen-reader users hear the state change once.

## Test plan

- [x] `cd frontend && bun run test -- --run SpeedPage` (43/43 pass; 6 new tests cover the inline toggle, the emphasis container, and the auto-flip disable path)
- [x] `cd frontend && bun run check`
- [x] `cd frontend && bun run build`
- [ ] Smoke test in Speed: enter stuck phase, verify banner is prominent, toggle inline auto-flip and verify it disables the 2.5s auto-flip
- [ ] Confirm existing settings-panel auto-flip toggle still mirrors the inline one

Closes #1515