### PR TITLE
fix(cli): treat LANG=C/POSIX/C.UTF-8 as placeholder, suppress warning

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -34,6 +34,24 @@ var (
 // validator so the two cannot diverge.
 var supportedLangs = map[string]bool{"ja": true, "en": true}
 
+// posixLocalePlaceholders are POSIX placeholder locale prefixes that signal
+// "no language preference" rather than a specific unsupported language.
+// They are the default in Docker base images (debian-slim, distroless), CI
+// runners (GitHub Actions, GitLab CI), and minimal Linux installs, so warning
+// about them on every invocation creates noise without information value.
+// Treat them as silent fallback to the default locale, matching gettext's
+// convention. See issue #1534.
+var posixLocalePlaceholders = map[string]bool{"C": true, "POSIX": true}
+
+// isPosixLocalePlaceholder reports whether prefix is a POSIX locale
+// placeholder (e.g. the "C" in "C.UTF-8"). Comparison is case-sensitive
+// because real-world LANG values use the canonical uppercase forms ("C",
+// "POSIX"); a lowercase "c" is unusual enough that it is more likely a typo
+// for a real language code than the placeholder, so we let it warn through.
+func isPosixLocalePlaceholder(prefix string) bool {
+	return posixLocalePlaceholders[prefix]
+}
+
 // portInRange reports whether port is a valid TCP port number, with 0
 // reserved for "let the OS assign an ephemeral port" (POSIX convention).
 func portInRange(port int) bool {
@@ -130,9 +148,13 @@ func run() int {
 		if idx := strings.IndexAny(envLang, "_-."); idx >= 0 {
 			prefix = envLang[:idx]
 		}
-		if supportedLangs[prefix] {
+		switch {
+		case supportedLangs[prefix]:
 			detectedLang = prefix
-		} else if !quiet {
+		case isPosixLocalePlaceholder(prefix):
+			// C / POSIX / C.UTF-8 are placeholders, not language preferences;
+			// silently fall back to the default. See issue #1534.
+		case !quiet:
 			langEnvWarn = envLang
 		}
 	}

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -345,6 +345,118 @@ func TestRunUnsupportedLangFlagFallsBackAndWarns(t *testing.T) {
 	}
 }
 
+// TestRunPosixLocalePlaceholderEnvSuppressesWarn verifies issue #1534: LANG
+// values that are POSIX locale placeholders ("C", "POSIX", "C.UTF-8") do NOT
+// trigger the cliLangEnvFallback warning, because they are the default in
+// Docker base images, CI runners, and minimal Linux installs and signal
+// "no language preference" rather than a specific unsupported language.
+// Real unsupported languages (e.g. "fr_FR.UTF-8") still warn — the placeholder
+// suppression must be a pinpoint exception, not a general silencer.
+func TestRunPosixLocalePlaceholderEnvSuppressesWarn(t *testing.T) {
+	origArgs := os.Args
+	origCmdLine := flag.CommandLine
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	origQuiet, quietWasSet := os.LookupEnv("TRUMPCARDS_QUIET")
+	origLang, langWasSet := os.LookupEnv("LANG")
+	defer func() {
+		os.Args = origArgs
+		flag.CommandLine = origCmdLine
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+		if quietWasSet {
+			_ = os.Setenv("TRUMPCARDS_QUIET", origQuiet)
+		} else {
+			_ = os.Unsetenv("TRUMPCARDS_QUIET")
+		}
+		if langWasSet {
+			_ = os.Setenv("LANG", origLang)
+		} else {
+			_ = os.Unsetenv("LANG")
+		}
+		i18n.SetLang("ja")
+	}()
+
+	cases := []struct {
+		name     string
+		lang     string
+		wantWarn bool
+	}{
+		{"LANG=C suppresses warning", "C", false},
+		{"LANG=POSIX suppresses warning", "POSIX", false},
+		{"LANG=C.UTF-8 suppresses warning (Docker default)", "C.UTF-8", false},
+		{"LANG=C.utf8 suppresses warning (no hyphen variant)", "C.utf8", false},
+		{"LANG=POSIX.UTF-8 suppresses warning", "POSIX.UTF-8", false},
+		{"LANG=fr_FR.UTF-8 still warns (real unsupported language)", "fr_FR.UTF-8", true},
+		{"LANG=zz still warns (unknown prefix)", "zz", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_ = os.Unsetenv("TRUMPCARDS_QUIET")
+			_ = os.Setenv("LANG", tc.lang)
+			flag.CommandLine = flag.NewFlagSet("trumpcards", flag.ExitOnError)
+			os.Args = []string{"trumpcards", "games", "--short"}
+
+			rOut, wOut, _ := os.Pipe()
+			rErr, wErr, _ := os.Pipe()
+			os.Stdout = wOut
+			os.Stderr = wErr
+
+			exitCh := make(chan int, 1)
+			go func() { exitCh <- run() }()
+			exit := <-exitCh
+
+			_ = wOut.Close()
+			_ = wErr.Close()
+			var outBuf, errBuf bytes.Buffer
+			_, _ = outBuf.ReadFrom(rOut)
+			_, _ = errBuf.ReadFrom(rErr)
+
+			if exit != 0 {
+				t.Fatalf("exit = %d, want 0 (stderr=%q)", exit, errBuf.String())
+			}
+			// Detect the LANG-fallback warning specifically by looking for the
+			// offending value on stderr; other unrelated warnings would not
+			// embed `tc.lang`.
+			gotWarn := strings.Contains(errBuf.String(), tc.lang)
+			if gotWarn != tc.wantWarn {
+				t.Errorf("warning emitted: got=%v, want=%v (stderr=%q)", gotWarn, tc.wantWarn, errBuf.String())
+			}
+			if outBuf.Len() == 0 {
+				t.Errorf("expected non-empty stdout from `games --short`; got empty")
+			}
+		})
+	}
+}
+
+// TestIsPosixLocalePlaceholder unit-tests the predicate used to gate the
+// LANG-fallback warning. Kept separate from the integration test above so a
+// regression in the predicate is easy to localize.
+func TestIsPosixLocalePlaceholder(t *testing.T) {
+	tests := []struct {
+		prefix string
+		want   bool
+	}{
+		{"C", true},
+		{"POSIX", true},
+		// Predicate operates on the prefix (split at . / _ / -) so callers
+		// must strip the codeset themselves; the predicate sees only "C".
+		{"c", false},     // case-sensitive: real LANG values use uppercase
+		{"posix", false}, // ditto
+		{"en", false},
+		{"ja", false},
+		{"fr", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.prefix, func(t *testing.T) {
+			if got := isPosixLocalePlaceholder(tt.prefix); got != tt.want {
+				t.Errorf("isPosixLocalePlaceholder(%q) = %v, want %v", tt.prefix, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunUnknownTopLevelFlagIsI18nError(t *testing.T) {
 	// Redirect stderr and stdout through os.Pipe so we can capture what
 	// run() writes when it encounters an unknown top-level flag.


### PR DESCRIPTION
## Summary

- POSIX locale placeholders (`C`, `POSIX`, `C.UTF-8`) are no longer flagged as "unsupported language" — they signal "no language preference" and are the default in Docker base images / CI runners / minimal Linux installs, so the previous warning fired noisily on every invocation in those environments.
- Real unsupported language values (e.g. `fr_FR.UTF-8`, `zz`) continue to warn, so the existing typo-detection signal is preserved.
- Tiny: `+136 / -2` across `cmd/trumpcards/main.go` and `cmd/trumpcards/main_test.go`.

Closes #1534

## Behavior

```sh
# Before
$ LANG=C.UTF-8 trumpcards games --short
注意: LANG="C.UTF-8" はサポートされていない言語です。ja をデフォルトとして使用します (TRUMPCARDS_QUIET=1 で抑止可能)
blackjack
poker
...

# After
$ LANG=C.UTF-8 trumpcards games --short
blackjack
poker
...

# Unchanged: real unsupported languages still warn
$ LANG=fr_FR.UTF-8 trumpcards games --short
注意: LANG="fr_FR.UTF-8" はサポートされていない言語です。ja をデフォルトとして使用します ...
blackjack
...
```

## Implementation

- Add `posixLocalePlaceholders = {C, POSIX}` and `isPosixLocalePlaceholder(prefix)` helper near the existing `supportedLangs` SSoT.
- The LANG detection block in `run()` now switches on three cases: supported → use, placeholder → silent fallback, otherwise → warn.
- Case-sensitive match: real-world `LANG` uses canonical uppercase `C` / `POSIX`; a lowercase `c` is more likely a typo than the placeholder, so it still warns through.
- `detectBootstrapLang` already silently falls back for any unsupported prefix, so no change is needed there.

## Test plan

- [x] `go test -tags test ./cmd/trumpcards/ -run "TestRunPosixLocalePlaceholderEnvSuppressesWarn|TestIsPosixLocalePlaceholder"` passes
- [x] `go test -tags test -race ./cmd/trumpcards/...` passes
- [x] `golangci-lint run ./cmd/trumpcards/...` clean
- [x] `goimports -w` applied
- [x] Manual: `LANG=C trumpcards`, `LANG=POSIX trumpcards`, `LANG=C.UTF-8 trumpcards`, `LANG=POSIX.UTF-8 trumpcards`, `LANG=C.utf8 trumpcards` → no warning
- [x] Manual: `LANG=fr_FR.UTF-8 trumpcards`, `LANG=zz trumpcards` → warning still fires (regression check)
- [x] Manual: `LANG="" trumpcards` → no warning (empty path unchanged)

## Notes

- Two unrelated tests (`TestCleanupLoop_EvictsOnTick`, `TestSlapjackCuiPresenter_Output/last_event_wrong_slap_cpu`) flaked once during the full `-race` run on a memory-pressured local machine but passed on isolated re-run; both packages are untouched by this change.
- Issues #1535 / #1536 from the same review are tracked separately.