### PR TITLE
feat(cli): add --json and --category to games subcommand

### DIFF
--- a/cmd/trumpcards/completion.go
+++ b/cmd/trumpcards/completion.go
@@ -138,8 +138,12 @@ func writeBashCompletion(w io.Writer) error {
             COMPREPLY=( $(compgen -W "--port -p --host" -- "$cur") )
             return
             ;;
-        games|--short|--aliases)
-            COMPREPLY=( $(compgen -W "--short --aliases" -- "$cur") )
+        --category)
+            COMPREPLY=( $(compgen -W "casino classic solo" -- "$cur") )
+            return
+            ;;
+        games|--short|--aliases|--json)
+            COMPREPLY=( $(compgen -W "--short --aliases --json --category" -- "$cur") )
             return
             ;;
     esac
@@ -198,7 +202,9 @@ _trumpcards() {
                 games)
                     _arguments \
                         '--short[Print game names only]' \
-                        '--aliases[Include aliases in output]'
+                        '--aliases[Include aliases in output]' \
+                        '--json[Emit machine-readable JSON]' \
+                        '--category[Filter by category]:category:(casino classic solo)'
                     ;;
                 web)
                     _arguments \
@@ -245,6 +251,8 @@ complete -c trumpcards -n '__fish_seen_subcommand_from update' -l yes -s y -d 'S
 # games subcommand
 complete -c trumpcards -n '__fish_seen_subcommand_from games' -l short -d 'Print game names only'
 complete -c trumpcards -n '__fish_seen_subcommand_from games' -l aliases -d 'Include aliases in output'
+complete -c trumpcards -n '__fish_seen_subcommand_from games' -l json -d 'Emit machine-readable JSON'
+complete -c trumpcards -n '__fish_seen_subcommand_from games' -l category -x -a 'casino classic solo' -d 'Filter by category'
 
 # web subcommand
 complete -c trumpcards -n '__fish_seen_subcommand_from web' -l port -s p -d 'Port number' -x

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -60,10 +60,18 @@ func portInRange(port int) bool {
 	return port >= 0 && port <= 65535
 }
 
-// validCategoryNames is the canonical set of `--category` filter values; the
-// strings must stay in lockstep with games.Category.String() so the predicate
-// neither drops a real category nor accepts a typo. See issue #1535.
-var validCategoryNames = map[string]bool{"casino": true, "classic": true, "solo": true}
+// validCategoryNames is the canonical set of `--category` filter values,
+// derived from the games registry at package load so it stays in lockstep
+// with games.Category.String() automatically. Adding a new Category to the
+// games package is enough — no manual sync here. See issue #1535 and
+// PR #1538 review feedback.
+var validCategoryNames = func() map[string]bool {
+	seen := make(map[string]bool)
+	for _, g := range games.All() {
+		seen[g.Category.String()] = true
+	}
+	return seen
+}()
 
 // validCategory reports whether s names a registered game category. Comparison
 // is case-sensitive to match games.Category.String()'s canonical lowercase form.
@@ -194,7 +202,7 @@ func run() int {
 	commands["games"] = func() int {
 		var short, aliases, asJSON bool
 		var category string
-		_, code, ok := parseSubFlags("games", func(f *flag.FlagSet) {
+		fs, code, ok := parseSubFlags("games", func(f *flag.FlagSet) {
 			f.BoolVar(&short, "short", false, "Print game names only")
 			f.BoolVar(&aliases, "aliases", false, "With --short, also print each alias on its own line (long output always includes aliases inline)")
 			f.BoolVar(&asJSON, "json", false, "Emit machine-readable JSON (array of {name, category, description, aliases})")
@@ -208,6 +216,14 @@ func run() int {
 			return 2
 		}
 		if asJSON {
+			// --short / --aliases are silently irrelevant in JSON mode (the
+			// schema is fixed). Warn the user instead of dropping the flags
+			// without feedback so a typo in scripts surfaces early. The warning
+			// goes to stderr so the JSON on stdout stays pure / pipeable. See
+			// PR #1538 review feedback.
+			if flagSetVisited(fs, "short", "aliases") {
+				fmt.Fprintln(os.Stderr, i18n.T("cliGamesJSONIgnoredFlags"))
+			}
 			if err := printGamesJSON(category, os.Stdout); err != nil {
 				fmt.Fprintln(os.Stderr, i18n.Tf("cliGamesJSONError", "err", err.Error()))
 				return 1
@@ -436,6 +452,9 @@ var builtinSubcommandHelp = map[string][]string{
 		"      --json               Emit machine-readable JSON: an array of",
 		"                           {name, category, description, aliases}.",
 		"                           aliases is always [] (never null) for stable schema.",
+		"                           Combines with --category; --short / --aliases have no",
+		"                           effect in JSON mode (the schema is fixed) and emit a",
+		"                           one-line warning to stderr if used together.",
 		"      --category CAT       Restrict output to one Cloudflare Worker category:",
 		"                           casino, classic, or solo. Combinable with --short / --json.",
 		"                           Invalid value exits 2.",
@@ -787,13 +806,7 @@ func detectBootstrapLang(args []string, langEnv string) string {
 func printGames(short, aliases bool, category string, w io.Writer) {
 	var reverseAliases map[string][]string
 	if !short || aliases {
-		reverseAliases = make(map[string][]string)
-		for alias, canonical := range ui.GameAliases {
-			reverseAliases[canonical] = append(reverseAliases[canonical], alias)
-		}
-		for k := range reverseAliases {
-			sort.Strings(reverseAliases[k])
-		}
+		reverseAliases = buildReverseAliases()
 	}
 
 	var descs map[string]string
@@ -801,7 +814,12 @@ func printGames(short, aliases bool, category string, w io.Writer) {
 		descs = ui.GameDescriptions()
 	}
 
-	categoryByName := gameCategoryByName()
+	// Only build the category index when a filter is active — otherwise the
+	// allocation is wasted because the gating predicate below is a no-op.
+	var categoryByName map[string]string
+	if category != "" {
+		categoryByName = gameCategoryByName()
+	}
 	for _, name := range ui.GameNames() {
 		if category != "" && categoryByName[name] != category {
 			continue
@@ -835,6 +853,21 @@ func gameCategoryByName() map[string]string {
 	return out
 }
 
+// buildReverseAliases inverts ui.GameAliases (alias → canonical) into
+// canonical → sorted aliases. Sorting per-key keeps output deterministic
+// despite Go's randomized map iteration. Shared by printGames and
+// printGamesJSON so the two render the same alias set in the same order.
+func buildReverseAliases() map[string][]string {
+	rev := make(map[string][]string)
+	for alias, canonical := range ui.GameAliases {
+		rev[canonical] = append(rev[canonical], alias)
+	}
+	for k := range rev {
+		sort.Strings(rev[k])
+	}
+	return rev
+}
+
 // printGamesJSON emits a JSON array describing every game (or only games in
 // the given category, if non-empty). Each entry is `{name, category,
 // description, aliases}`. Aliases is always a non-nil slice so the JSON
@@ -847,13 +880,7 @@ func printGamesJSON(category string, w io.Writer) error {
 		Description string   `json:"description"`
 		Aliases     []string `json:"aliases"`
 	}
-	reverseAliases := make(map[string][]string)
-	for alias, canonical := range ui.GameAliases {
-		reverseAliases[canonical] = append(reverseAliases[canonical], alias)
-	}
-	for k := range reverseAliases {
-		sort.Strings(reverseAliases[k])
-	}
+	reverseAliases := buildReverseAliases()
 	all := games.All()
 	out := make([]entry, 0, len(all))
 	for _, g := range all {

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -17,6 +18,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/games"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/ui"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/update"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/web"
@@ -56,6 +58,17 @@ func isPosixLocalePlaceholder(prefix string) bool {
 // reserved for "let the OS assign an ephemeral port" (POSIX convention).
 func portInRange(port int) bool {
 	return port >= 0 && port <= 65535
+}
+
+// validCategoryNames is the canonical set of `--category` filter values; the
+// strings must stay in lockstep with games.Category.String() so the predicate
+// neither drops a real category nor accepts a typo. See issue #1535.
+var validCategoryNames = map[string]bool{"casino": true, "classic": true, "solo": true}
+
+// validCategory reports whether s names a registered game category. Comparison
+// is case-sensitive to match games.Category.String()'s canonical lowercase form.
+func validCategory(s string) bool {
+	return validCategoryNames[s]
 }
 
 // flagSetVisited reports whether any of the named flags was explicitly set
@@ -179,15 +192,29 @@ func run() int {
 	// Build game commands from the registry (single source of truth).
 	commands := buildGameCommands()
 	commands["games"] = func() int {
-		var short, aliases bool
+		var short, aliases, asJSON bool
+		var category string
 		_, code, ok := parseSubFlags("games", func(f *flag.FlagSet) {
 			f.BoolVar(&short, "short", false, "Print game names only")
 			f.BoolVar(&aliases, "aliases", false, "With --short, also print each alias on its own line (long output always includes aliases inline)")
+			f.BoolVar(&asJSON, "json", false, "Emit machine-readable JSON (array of {name, category, description, aliases})")
+			f.StringVar(&category, "category", "", "Filter by category: casino|classic|solo")
 		})
 		if !ok {
 			return code
 		}
-		printGames(short, aliases, os.Stdout)
+		if category != "" && !validCategory(category) {
+			fmt.Fprintln(os.Stderr, i18n.Tf("cliInvalidCategory", "category", category))
+			return 2
+		}
+		if asJSON {
+			if err := printGamesJSON(category, os.Stdout); err != nil {
+				fmt.Fprintln(os.Stderr, i18n.Tf("cliGamesJSONError", "err", err.Error()))
+				return 1
+			}
+			return 0
+		}
+		printGames(short, aliases, category, os.Stdout)
 		return 0
 	}
 	commands["completion"] = func() int {
@@ -400,17 +427,26 @@ var builtinSubcommandHelp = map[string][]string{
 	},
 	"games": {
 		"USAGE:",
-		"  trumpcards games [--short] [--aliases]",
+		"  trumpcards games [--short] [--aliases] [--json] [--category casino|classic|solo]",
 		"",
 		"FLAGS:",
-		"      --short     Print game names only (for scripting)",
-		"      --aliases   With --short, also print each alias on its own line",
-		"                  (long output always includes aliases inline)",
+		"      --short              Print game names only (for scripting)",
+		"      --aliases            With --short, also print each alias on its own line",
+		"                           (long output always includes aliases inline)",
+		"      --json               Emit machine-readable JSON: an array of",
+		"                           {name, category, description, aliases}.",
+		"                           aliases is always [] (never null) for stable schema.",
+		"      --category CAT       Restrict output to one Cloudflare Worker category:",
+		"                           casino, classic, or solo. Combinable with --short / --json.",
+		"                           Invalid value exits 2.",
 		"",
 		"EXAMPLES:",
 		"  trumpcards games",
 		"  trumpcards games --short",
 		"  trumpcards games --short --aliases",
+		"  trumpcards games --category casino",
+		"  trumpcards games --json | jq -r '.[] | select(.category==\"solo\") | .name'",
+		"  trumpcards games --json --category classic",
 	},
 	"help": {
 		"USAGE:",
@@ -661,6 +697,8 @@ EXAMPLES:
   trumpcards games               List all available games
   trumpcards games --short       List game names only (for scripting)
   trumpcards games --short --aliases  List game names including aliases
+  trumpcards games --json        Machine-readable list (name, category, description, aliases)
+  trumpcards games --category solo  Filter by Cloudflare Worker category (casino|classic|solo)
   trumpcards update              Self-update to the latest version
   trumpcards update --yes        Update without confirmation prompt
   trumpcards update --check      Report whether an update is available (exit 10 if yes)
@@ -743,8 +781,10 @@ func detectBootstrapLang(args []string, langEnv string) string {
 // and any aliases inline. With short=true, only canonical names are printed,
 // one per line — and if aliases is also true, every alias gets its own line.
 // The `aliases` flag is a no-op in long mode because aliases are always shown
-// inline there.
-func printGames(short, aliases bool, w io.Writer) {
+// inline there. If category is non-empty, output is restricted to games whose
+// games.Category matches; the caller is expected to have validated category
+// via validCategory before invoking. See issue #1535.
+func printGames(short, aliases bool, category string, w io.Writer) {
 	var reverseAliases map[string][]string
 	if !short || aliases {
 		reverseAliases = make(map[string][]string)
@@ -761,7 +801,11 @@ func printGames(short, aliases bool, w io.Writer) {
 		descs = ui.GameDescriptions()
 	}
 
+	categoryByName := gameCategoryByName()
 	for _, name := range ui.GameNames() {
+		if category != "" && categoryByName[name] != category {
+			continue
+		}
 		if short {
 			_, _ = fmt.Fprintln(w, name)
 			if aliases {
@@ -777,6 +821,60 @@ func printGames(short, aliases bool, w io.Writer) {
 			_, _ = fmt.Fprintln(w, line)
 		}
 	}
+}
+
+// gameCategoryByName builds Name→Category-string from the games registry.
+// The strings come from games.Category.String() so they stay in lockstep
+// with the SSoT and validCategory's accepted values.
+func gameCategoryByName() map[string]string {
+	all := games.All()
+	out := make(map[string]string, len(all))
+	for _, g := range all {
+		out[g.Name] = g.Category.String()
+	}
+	return out
+}
+
+// printGamesJSON emits a JSON array describing every game (or only games in
+// the given category, if non-empty). Each entry is `{name, category,
+// description, aliases}`. Aliases is always a non-nil slice so the JSON
+// shape is stable: scripts can rely on `.aliases | length` working without a
+// null guard. See issue #1535.
+func printGamesJSON(category string, w io.Writer) error {
+	type entry struct {
+		Name        string   `json:"name"`
+		Category    string   `json:"category"`
+		Description string   `json:"description"`
+		Aliases     []string `json:"aliases"`
+	}
+	reverseAliases := make(map[string][]string)
+	for alias, canonical := range ui.GameAliases {
+		reverseAliases[canonical] = append(reverseAliases[canonical], alias)
+	}
+	for k := range reverseAliases {
+		sort.Strings(reverseAliases[k])
+	}
+	all := games.All()
+	out := make([]entry, 0, len(all))
+	for _, g := range all {
+		cat := g.Category.String()
+		if category != "" && cat != category {
+			continue
+		}
+		al := reverseAliases[g.Name]
+		if al == nil {
+			al = []string{} // emit `[]`, never `null` — stable schema for scripts.
+		}
+		out = append(out, entry{
+			Name:        g.Name,
+			Category:    cat,
+			Description: g.Description,
+			Aliases:     al,
+		})
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
 }
 
 // buildGameCommands generates command handlers for all games from the registry.

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -595,7 +596,7 @@ func TestPrintGamesLongModeAlwaysIncludesAliases(t *testing.T) {
 	}
 	var buf bytes.Buffer
 	// aliases=false — long mode must STILL show aliases inline.
-	printGames(false, false, &buf)
+	printGames(false, false, "", &buf)
 	out := buf.String()
 	if !strings.Contains(out, "[aliases:") {
 		t.Errorf("long mode output should contain inline '[aliases:' for games with aliases; got:\n%s", out)
@@ -617,8 +618,8 @@ func TestPrintGamesShortModeRespectsAliasesFlag(t *testing.T) {
 	}
 
 	var without, with bytes.Buffer
-	printGames(true, false, &without)
-	printGames(true, true, &with)
+	printGames(true, false, "", &without)
+	printGames(true, true, "", &with)
 
 	// Without --aliases, alias lines should not appear.
 	if strings.Contains(without.String(), "\n"+aliasSample+"\n") || strings.HasPrefix(without.String(), aliasSample+"\n") {
@@ -627,6 +628,190 @@ func TestPrintGamesShortModeRespectsAliasesFlag(t *testing.T) {
 	// With --aliases, alias lines must appear.
 	if !strings.Contains(with.String(), aliasSample) {
 		t.Errorf("short mode with --aliases should list alias %q; got:\n%s", aliasSample, with.String())
+	}
+}
+
+// TestValidCategory pins down the predicate used to gate `--category`. The
+// canonical strings must match games.Category.String() (casino / classic /
+// solo) — drift between the CLI list and the games-pkg enum would silently
+// reject valid categories or accept invalid ones.
+func TestValidCategory(t *testing.T) {
+	tests := []struct {
+		s    string
+		want bool
+	}{
+		{"casino", true},
+		{"classic", true},
+		{"solo", true},
+		{"Casino", false}, // case-sensitive — match games.Category.String() form
+		{"", false},
+		{"poker", false}, // game name, not a category
+		{"slot", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.s, func(t *testing.T) {
+			if got := validCategory(tt.s); got != tt.want {
+				t.Errorf("validCategory(%q) = %v, want %v", tt.s, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPrintGamesJSONFullEmitsEveryGame verifies that the JSON output of
+// `games --json` (no filter) is a JSON array containing one entry per game in
+// the registry, each with the expected schema.
+func TestPrintGamesJSONFullEmitsEveryGame(t *testing.T) {
+	var buf bytes.Buffer
+	if err := printGamesJSON("", &buf); err != nil {
+		t.Fatalf("printGamesJSON returned error: %v", err)
+	}
+	type entry struct {
+		Name        string   `json:"name"`
+		Category    string   `json:"category"`
+		Description string   `json:"description"`
+		Aliases     []string `json:"aliases"`
+	}
+	var got []entry
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\nraw=%s", err, buf.String())
+	}
+	if len(got) != len(ui.GameNames()) {
+		t.Errorf("entry count = %d, want %d", len(got), len(ui.GameNames()))
+	}
+	// Every entry must have a non-empty name and one of the three canonical categories.
+	for _, e := range got {
+		if e.Name == "" {
+			t.Errorf("entry has empty name: %+v", e)
+		}
+		if !validCategory(e.Category) {
+			t.Errorf("entry %q has invalid category %q", e.Name, e.Category)
+		}
+		if e.Description == "" {
+			t.Errorf("entry %q has empty description", e.Name)
+		}
+		// Aliases must be a non-nil slice so JSON renders [] not null.
+		if e.Aliases == nil {
+			t.Errorf("entry %q has nil aliases (want []); JSON shape must be stable", e.Name)
+		}
+	}
+}
+
+// TestPrintGamesJSONNullAliasesAvoided locks down the JSON shape requirement
+// that aliases is always `[]`, never `null`. Scripts that do
+// `.aliases | length` would crash on a null without this guarantee.
+func TestPrintGamesJSONNullAliasesAvoided(t *testing.T) {
+	var buf bytes.Buffer
+	if err := printGamesJSON("", &buf); err != nil {
+		t.Fatalf("printGamesJSON err: %v", err)
+	}
+	if strings.Contains(buf.String(), `"aliases":null`) {
+		t.Errorf("JSON output contains \"aliases\":null — must always emit [] for stable schema; got:\n%s", buf.String())
+	}
+}
+
+// TestPrintGamesJSONByCategory verifies that --category narrows the JSON
+// output to the matching subset and that the result is consistent with
+// games.ByCategory (the SSoT).
+func TestPrintGamesJSONByCategory(t *testing.T) {
+	for _, cat := range []string{"casino", "classic", "solo"} {
+		t.Run(cat, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := printGamesJSON(cat, &buf); err != nil {
+				t.Fatalf("printGamesJSON(%q) err: %v", cat, err)
+			}
+			var got []map[string]any
+			if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+				t.Fatalf("invalid JSON: %v\nraw=%s", err, buf.String())
+			}
+			if len(got) == 0 {
+				t.Fatalf("category %q produced 0 entries (every category should have games)", cat)
+			}
+			for _, e := range got {
+				if e["category"] != cat {
+					t.Errorf("entry %v has category %q, want %q", e["name"], e["category"], cat)
+				}
+			}
+		})
+	}
+}
+
+// TestPrintGamesByCategoryFiltersLong verifies the non-JSON long output
+// honors --category.
+func TestPrintGamesByCategoryFiltersLong(t *testing.T) {
+	var buf bytes.Buffer
+	printGames(false, false, "casino", &buf)
+	out := buf.String()
+	if !strings.Contains(out, "blackjack") {
+		t.Errorf("expected casino filter to include blackjack; got:\n%s", out)
+	}
+	// hearts is classic; must be excluded.
+	if strings.Contains(out, "hearts ") {
+		t.Errorf("expected casino filter to exclude classic-category 'hearts'; got:\n%s", out)
+	}
+}
+
+// TestPrintGamesByCategoryFiltersShort verifies short output honors --category.
+func TestPrintGamesByCategoryFiltersShort(t *testing.T) {
+	var buf bytes.Buffer
+	printGames(true, false, "solo", &buf)
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) == 0 || lines[0] == "" {
+		t.Fatalf("expected non-empty solo output; got:\n%s", buf.String())
+	}
+	// klondike is solo; must be present. blackjack is casino; must be absent.
+	hasKlondike, hasBlackjack := false, false
+	for _, l := range lines {
+		switch l {
+		case "klondike":
+			hasKlondike = true
+		case "blackjack":
+			hasBlackjack = true
+		}
+	}
+	if !hasKlondike {
+		t.Errorf("solo filter should include klondike; got:\n%s", buf.String())
+	}
+	if hasBlackjack {
+		t.Errorf("solo filter should exclude blackjack; got:\n%s", buf.String())
+	}
+}
+
+// TestRunGamesInvalidCategoryExits2 verifies that --category with an invalid
+// value rejects with exit 2 (POSIX usage error) and emits an i18n message
+// naming the offending value on stderr.
+func TestRunGamesInvalidCategoryExits2(t *testing.T) {
+	origArgs := os.Args
+	origCmdLine := flag.CommandLine
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	defer func() {
+		os.Args = origArgs
+		flag.CommandLine = origCmdLine
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}()
+	flag.CommandLine = flag.NewFlagSet("trumpcards", flag.ExitOnError)
+	os.Args = []string{"trumpcards", "games", "--category", "bogus"}
+
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	exitCh := make(chan int, 1)
+	go func() { exitCh <- run() }()
+	exit := <-exitCh
+	_ = wOut.Close()
+	_ = wErr.Close()
+	var outBuf, errBuf bytes.Buffer
+	_, _ = outBuf.ReadFrom(rOut)
+	_, _ = errBuf.ReadFrom(rErr)
+
+	if exit != 2 {
+		t.Errorf("exit = %d, want 2 (stderr=%q)", exit, errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "bogus") {
+		t.Errorf("stderr must name the offending category 'bogus'; got: %q", errBuf.String())
 	}
 }
 

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -823,6 +823,92 @@ func TestCliAliasesWithoutShortKeyRemoved(t *testing.T) {
 	}
 }
 
+// TestValidCategoryNamesDerivedFromRegistry verifies the validCategory set is
+// in lockstep with the games registry's actual categories. Adding a new
+// games.Category in the registry must automatically extend the CLI filter
+// without touching this file. See PR #1538 review feedback.
+func TestValidCategoryNamesDerivedFromRegistry(t *testing.T) {
+	// Walk every registered game's category via the same helper production
+	// uses; assert the predicate accepts it.
+	registryCategories := make(map[string]bool)
+	for name, cat := range gameCategoryByName() {
+		registryCategories[cat] = true
+		if !validCategory(cat) {
+			t.Errorf("registry has category %q (for game %q) but validCategory rejects it", cat, name)
+		}
+	}
+	if len(registryCategories) == 0 {
+		t.Fatal("expected at least one category in registry")
+	}
+	// And no extra entries that don't appear in the registry — that would
+	// mean validCategoryNames drifted away from the SSoT.
+	for cat := range validCategoryNames {
+		if !registryCategories[cat] {
+			t.Errorf("validCategory accepts %q but no game in the registry uses it", cat)
+		}
+	}
+}
+
+// TestRunGamesJSONIgnoredFlagsWarning verifies that passing --short or
+// --aliases together with --json emits a one-line warning to stderr
+// (the JSON schema is fixed; silently dropping flags hides script bugs).
+// See PR #1538 review feedback (observation #4).
+func TestRunGamesJSONIgnoredFlagsWarning(t *testing.T) {
+	origArgs := os.Args
+	origCmdLine := flag.CommandLine
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	defer func() {
+		os.Args = origArgs
+		flag.CommandLine = origCmdLine
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}()
+
+	cases := []struct {
+		name     string
+		args     []string
+		wantWarn bool
+	}{
+		{"--json --short warns", []string{"trumpcards", "games", "--json", "--short"}, true},
+		{"--json --aliases warns", []string{"trumpcards", "games", "--json", "--aliases"}, true},
+		{"--json alone is silent", []string{"trumpcards", "games", "--json"}, false},
+		{"--json --category solo is silent", []string{"trumpcards", "games", "--json", "--category", "solo"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			flag.CommandLine = flag.NewFlagSet("trumpcards", flag.ExitOnError)
+			os.Args = tc.args
+
+			rOut, wOut, _ := os.Pipe()
+			rErr, wErr, _ := os.Pipe()
+			os.Stdout = wOut
+			os.Stderr = wErr
+
+			exitCh := make(chan int, 1)
+			go func() { exitCh <- run() }()
+			exit := <-exitCh
+			_ = wOut.Close()
+			_ = wErr.Close()
+			var outBuf, errBuf bytes.Buffer
+			_, _ = outBuf.ReadFrom(rOut)
+			_, _ = errBuf.ReadFrom(rErr)
+
+			if exit != 0 {
+				t.Fatalf("exit = %d, want 0 (stderr=%q)", exit, errBuf.String())
+			}
+			// JSON must always end up on stdout regardless of warnings.
+			if outBuf.Len() == 0 || outBuf.String()[0] != '[' {
+				t.Errorf("expected a JSON array on stdout; got: %q", outBuf.String())
+			}
+			gotWarn := strings.Contains(errBuf.String(), "--json")
+			if gotWarn != tc.wantWarn {
+				t.Errorf("warning emitted: got=%v, want=%v (stderr=%q)", gotWarn, tc.wantWarn, errBuf.String())
+			}
+		})
+	}
+}
+
 // TestUpdateExitCodeMapping verifies that every sentinel error from the
 // updater maps to a distinct, documented exit code. Callers depend on this
 // mapping for retry / fallback logic. See issue #1449.

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -51,6 +51,7 @@
   "cliLangEnvFallback": "Note: LANG=\"{{lang}}\" is not a supported language, defaulting to ja (set TRUMPCARDS_QUIET=1 to silence)",
   "cliInvalidCategory": "Error: invalid category \"{{category}}\" (supported: casino, classic, solo)",
   "cliGamesJSONError": "Error: failed to encode games as JSON: {{err}}",
+  "cliGamesJSONIgnoredFlags": "Warning: --short / --aliases are ignored in --json mode (the JSON schema is fixed)",
   "cliSubcommandFlagError": "Error: trumpcards {{cmd}}: {{err}}",
   "cliTryHelp": "Run 'trumpcards help {{cmd}}' for usage.",
   "cliFlagError": "Error: invalid option ({{err}})",

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -49,6 +49,8 @@
   "cliHelpUnknownGame": "Unknown game: \"{{name}}\". Run 'trumpcards games' to see available games.",
   "updateNonInteractive": "Non-interactive stdin: re-run with --yes to auto-confirm.",
   "cliLangEnvFallback": "Note: LANG=\"{{lang}}\" is not a supported language, defaulting to ja (set TRUMPCARDS_QUIET=1 to silence)",
+  "cliInvalidCategory": "Error: invalid category \"{{category}}\" (supported: casino, classic, solo)",
+  "cliGamesJSONError": "Error: failed to encode games as JSON: {{err}}",
   "cliSubcommandFlagError": "Error: trumpcards {{cmd}}: {{err}}",
   "cliTryHelp": "Run 'trumpcards help {{cmd}}' for usage.",
   "cliFlagError": "Error: invalid option ({{err}})",

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -51,6 +51,7 @@
   "cliLangEnvFallback": "注意: LANG=\"{{lang}}\" はサポートされていない言語です。ja をデフォルトとして使用します (TRUMPCARDS_QUIET=1 で抑止可能)",
   "cliInvalidCategory": "エラー: 無効なカテゴリ「{{category}}」です (対応: casino, classic, solo)",
   "cliGamesJSONError": "エラー: ゲーム一覧の JSON 生成に失敗しました: {{err}}",
+  "cliGamesJSONIgnoredFlags": "警告: --json モードでは --short / --aliases は無視されます (JSON スキーマは固定)",
   "cliSubcommandFlagError": "エラー: trumpcards {{cmd}}: {{err}}",
   "cliTryHelp": "使い方は 'trumpcards help {{cmd}}' を実行してください。",
   "cliFlagError": "エラー: 不明なオプションです ({{err}})",

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -49,6 +49,8 @@
   "cliHelpUnknownGame": "不明なゲームです: \"{{name}}\"。'trumpcards games' でゲーム一覧を確認できます。",
   "updateNonInteractive": "標準入力が非対話モードです: --yes を付けて再実行してください。",
   "cliLangEnvFallback": "注意: LANG=\"{{lang}}\" はサポートされていない言語です。ja をデフォルトとして使用します (TRUMPCARDS_QUIET=1 で抑止可能)",
+  "cliInvalidCategory": "エラー: 無効なカテゴリ「{{category}}」です (対応: casino, classic, solo)",
+  "cliGamesJSONError": "エラー: ゲーム一覧の JSON 生成に失敗しました: {{err}}",
   "cliSubcommandFlagError": "エラー: trumpcards {{cmd}}: {{err}}",
   "cliTryHelp": "使い方は 'trumpcards help {{cmd}}' を実行してください。",
   "cliFlagError": "エラー: 不明なオプションです ({{err}})",


### PR DESCRIPTION
## Summary

- Adds `--json` (machine-readable schema) and `--category casino|classic|solo` (filter) to `trumpcards games`.
- Aliases is always `[]` in JSON, never `null`, so scripts can rely on `.aliases | length` without a null guard.
- Categories sourced from `games.Category.String()` to keep the CLI filter in lockstep with the SSoT.
- bash/zsh/fish completions learn the new flags and offer the three category values.

Closes #1535

## Behavior

```sh
$ trumpcards games --json | head -7
[
  {
    "name": "blackjack",
    "category": "casino",
    "description": "BlackJack (ブラックジャック)",
    "aliases": []
  },

# Filter by category (works with --short / --json / long)
$ trumpcards games --category solo --short | head -3
memory
klondike
freecell

# Invalid category exits 2 with i18n error
$ trumpcards games --category bogus
エラー: 無効なカテゴリ「bogus」です (対応: casino, classic, solo)
$ echo \$?
2

# Common scripting use case
$ trumpcards games --json | jq -r '.[] | select(.category=="solo") | .name' | wc -l
19
```

## Schema

```json
[
  {
    "name": "ginrummy",
    "category": "solo",
    "description": "Gin Rummy (ジンラミー)",
    "aliases": ["gin"]
  }
]
```

Stable contract:
- All four fields always present.
- `aliases` is always a JSON array (`[]` if none) — never `null`.
- `category` is exactly `"casino"`, `"classic"`, or `"solo"` (matches `games.Category.String()`).

## Implementation

- `validCategoryNames` map + `validCategory(s)` predicate (case-sensitive, matches the canonical lowercase form from `games.Category.String()`).
- `printGames` gains a `category` parameter; existing tests updated to pass `""` for "no filter".
- New `printGamesJSON(category, w)` returns `error` so encode failures are surfaced through a new i18n key (`cliGamesJSONError`).
- New i18n keys: `cliInvalidCategory`, `cliGamesJSONError` (ja + en).
- Help text under `builtinSubcommandHelp["games"]` and the top-level EXAMPLES list updated.

## Test plan

- [x] `go test -tags test ./cmd/trumpcards/...` passes (new tests: TestValidCategory, TestPrintGamesJSONFullEmitsEveryGame, TestPrintGamesJSONNullAliasesAvoided, TestPrintGamesJSONByCategory, TestPrintGamesByCategoryFiltersLong, TestPrintGamesByCategoryFiltersShort, TestRunGamesInvalidCategoryExits2)
- [x] `go test -tags test ./internal/i18n/...` passes (i18n key parity check)
- [x] `golangci-lint run ./cmd/trumpcards/...` clean
- [x] `goimports -w` applied
- [x] Manual: `--json` round-trips through `jq`; `--category casino|classic|solo` returns expected subsets; invalid category exits 2; bash completion offers `--json` / `--category` and the three category values
- [x] Existing `--short` / `--aliases` output unchanged (purely additive)

## Notes

- Pure addition; existing scripts using `--short` / `--aliases` are unaffected.
- Issue #1536 (web 0.0.0.0 exposure warning) is a separate PR.