### PR TITLE
refactor(nertz): align Web API naming with peer games

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6685,7 +6685,7 @@ paths:
         | Command     | Aliases     | Description |
         |-------------|-------------|-------------|
         | `reset`     | `r`         | Start / restart a match (optional `config`) |
-        | `nextRound` | `nr`        | Start next round after RoundEnd |
+        | `nextround` | `nr`        | Start next round after RoundEnd |
         | `tick`      |             | Advance pending CPU actions one step |
         | `draw`      | `d`         | Draw `drawCount` cards from stock to waste (`playerIdx`) |
         | `move`      | `m`         | Move a card between zones (see body) |
@@ -6716,7 +6716,7 @@ paths:
               properties:
                 command:
                   type: string
-                  enum: [reset, r, nextRound, nr, tick, draw, d, move, m, undo, u, hint, log, l]
+                  enum: [reset, r, nextround, nr, tick, draw, d, move, m, undo, u, hint, log, l]
                 playerIdx:
                   type: integer
                   description: 0 = human; CPUs are 1..N-1
@@ -6805,7 +6805,7 @@ paths:
                 properties:
                   phase:
                     type: integer
-                  roundNo:
+                  roundNumber:
                     type: integer
                   winnerIdx:
                     type: integer
@@ -6832,7 +6832,7 @@ paths:
                       properties:
                         name:
                           type: string
-                        isCpu:
+                        isHuman:
                           type: boolean
                         deckIdx:
                           type: integer

--- a/frontend/src/pages/NertzPage.test.tsx
+++ b/frontend/src/pages/NertzPage.test.tsx
@@ -24,7 +24,7 @@ const baseConfig = {
 
 const playingState: NertzResponse = {
   phase: NertzPhase.PLAYING,
-  roundNo: 1,
+  roundNumber: 1,
   winnerIdx: -1,
   matchWinner: -1,
   moveCount: 0,
@@ -33,7 +33,7 @@ const playingState: NertzResponse = {
   players: [
     {
       name: 'You',
-      isCpu: false,
+      isHuman: true,
       deckIdx: 0,
       score: 0,
       nertzSize: 13,
@@ -49,7 +49,7 @@ const playingState: NertzResponse = {
     },
     {
       name: 'CPU1',
-      isCpu: true,
+      isHuman: false,
       deckIdx: 1,
       score: 0,
       nertzSize: 13,

--- a/frontend/src/pages/NertzPage.tsx
+++ b/frontend/src/pages/NertzPage.tsx
@@ -181,14 +181,14 @@ function NertzPageContent() {
       <div className="flex-1 overflow-y-auto px-3 py-2 space-y-4">
         <div className="bg-black/30 text-white p-3 rounded text-sm flex flex-wrap gap-x-4 gap-y-1">
           <span>
-            {t('labels.round')}: {state.roundNo}
+            {t('labels.round')}: {state.roundNumber}
           </span>
           <span>
             {t('labels.moveCount')}: {state.moveCount}
           </span>
           {state.players.map((p, i) => (
             <span key={`scoreline-${i}`}>
-              {p.isCpu ? `${t('labels.cpu')}${i}` : t('labels.you')}: {p.score} ({p.nertzSize})
+              {p.isHuman ? t('labels.you') : `${t('labels.cpu')}${i}`}: {p.score} ({p.nertzSize})
             </span>
           ))}
         </div>
@@ -215,7 +215,7 @@ function NertzPageContent() {
         {state.players.length > 1 && (
           <div className="bg-black/30 text-white p-3 rounded text-sm space-y-1">
             {state.players
-              .filter((p) => p.isCpu)
+              .filter((p) => !p.isHuman)
               .map((p) => (
                 <div key={`cpu-${p.deckIdx}`} className="flex justify-between">
                   <span>

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -2935,7 +2935,7 @@ export interface NertzTableauCard {
 /** Nertz player view (per-player tableau, nertz pile, waste, and stock). */
 export interface NertzPlayerData {
   name: string;
-  isCpu: boolean;
+  isHuman: boolean;
   deckIdx: number;
   score: number;
   nertzSize: number;
@@ -2982,7 +2982,7 @@ export interface NertzMoveZone {
 /** Full Nertz game state returned from the API. */
 export interface NertzResponse {
   phase: number;
-  roundNo: number;
+  roundNumber: number;
   winnerIdx: number;
   matchWinner: number;
   moveCount: number;

--- a/internal/adapter/controller/NertzWebController.go
+++ b/internal/adapter/controller/NertzWebController.go
@@ -42,7 +42,7 @@ type NertzWebTableauCard struct {
 // NertzWebPlayer プレイヤー出力
 type NertzWebPlayer struct {
 	Name      string                   `json:"name"`
-	IsCpu     bool                     `json:"isCpu"`
+	IsHuman   bool                     `json:"isHuman"`
 	DeckIdx   int                      `json:"deckIdx"`
 	Score     int                      `json:"score"`
 	NertzSize int                      `json:"nertzSize"`
@@ -72,7 +72,7 @@ type NertzWebHint struct {
 // NertzWebOutput Nertz Web 出力
 type NertzWebOutput struct {
 	Phase         int                   `json:"phase"`
-	RoundNo       int                   `json:"roundNo"`
+	RoundNumber   int                   `json:"roundNumber"`
 	WinnerIdx     int                   `json:"winnerIdx"`
 	MatchWinner   int                   `json:"matchWinner"`
 	MoveCount     int                   `json:"moveCount"`
@@ -119,7 +119,7 @@ func nertzDispatch(bc *baseController, w http.ResponseWriter, ni usecase.NertzIn
 		} else {
 			bc.writePresenterResponse(w, ni.Reset())
 		}
-	case "nr", "nextRound":
+	case "nr", "nextround":
 		bc.writePresenterResponse(w, ni.NextRound())
 	case "tick":
 		bc.writePresenterResponse(w, ni.Tick())

--- a/internal/adapter/controller/NertzWebController_test.go
+++ b/internal/adapter/controller/NertzWebController_test.go
@@ -98,6 +98,14 @@ func TestNertzWebController_Method(t *testing.T) {
 		recorded.BodyIs(expected)
 	})
 
+	// Issue #1532: long-form alias is lowercase to match Hearts / Skat / Whist.
+	t.Run("next round (lowercase alias)", func(t *testing.T) {
+		in := decode(`{"command":"nextround","sessionId":"s1"}`)
+		recorded := execRequest(t, ctrl.Exec, &in)
+		recorded.CodeIs(http.StatusOK)
+		recorded.BodyIs(expected)
+	})
+
 	t.Run("tick", func(t *testing.T) {
 		in := decode(`{"command":"tick","sessionId":"s1"}`)
 		recorded := execRequest(t, ctrl.Exec, &in)

--- a/internal/adapter/presenter/NertzWebPresenter.go
+++ b/internal/adapter/presenter/NertzWebPresenter.go
@@ -73,7 +73,7 @@ func (p *NertzWebPresenter) buildBase(g interfaces.NertzGame) *controller.NertzW
 	cfg := g.GetConfig()
 	resObj := &controller.NertzWebOutput{
 		Phase:         int(g.GetPhase()),
-		RoundNo:       g.GetRoundNo(),
+		RoundNumber:   g.GetRoundNo(),
 		WinnerIdx:     g.GetWinnerIdx(),
 		MatchWinner:   g.GetMatchWinner(),
 		MoveCount:     g.GetMoveCount(),
@@ -93,7 +93,7 @@ func (p *NertzWebPresenter) buildBase(g interfaces.NertzGame) *controller.NertzW
 		}
 		out := &controller.NertzWebPlayer{
 			Name:      pl.GetName(),
-			IsCpu:     pl.GetIsCpu(),
+			IsHuman:   !pl.GetIsCpu(),
 			DeckIdx:   pl.GetDeckIdx(),
 			Score:     pl.GetScore(),
 			NertzSize: pl.NertzSize(),

--- a/internal/adapter/presenter/NertzWebPresenter_test.go
+++ b/internal/adapter/presenter/NertzWebPresenter_test.go
@@ -68,6 +68,26 @@ func TestNertzWebPresenter_Output(t *testing.T) {
 		assert.Equal(t, 1, out.Players[0].StockSize)
 		assert.Len(t, out.Foundations, 2)
 		require.NotNil(t, out.Foundations[0].Top)
+		// Issue #1532: locked-in shape — RoundNumber populated, IsHuman is the
+		// inverse of the domain's IsCpu (so true for the human player at idx 0
+		// and false for CPU at idx 1, matching Slapjack / majority of games).
+		assert.Equal(t, 1, out.RoundNumber, "RoundNumber must be populated from GetRoundNo")
+		assert.True(t, out.Players[0].IsHuman, "human player (idx 0) must report IsHuman=true")
+		assert.False(t, out.Players[1].IsHuman, "CPU player (idx 1) must report IsHuman=false")
+	})
+
+	// TestNertzWebPresenter_JSONShape pins down the JSON-tag rename to lock
+	// in the public API contract. See issue #1532.
+	t.Run("JSON shape uses isHuman / roundNumber", func(t *testing.T) {
+		g := new(interfaces.MockNertzGame)
+		setupNertzWebMockDefaults(g)
+		raw := new(NertzWebPresenter).Output(g, nil)
+		// New canonical names must appear.
+		assert.Contains(t, raw, `"roundNumber":`, "JSON output must use roundNumber")
+		assert.Contains(t, raw, `"isHuman":`, "JSON output must use isHuman")
+		// Old legacy names must NOT appear (this is a breaking rename, not a dual emit).
+		assert.NotContains(t, raw, `"roundNo":`, "JSON output must not include legacy roundNo")
+		assert.NotContains(t, raw, `"isCpu":`, "JSON output must not include legacy isCpu")
 	})
 
 	t.Run("with error", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Three breaking-but-bundled renames to bring the Nertz Web API in lockstep with Hearts / Skat / Bridge / Slapjack so cross-game tooling and frontend consumers don't need per-game special-cases. Backend, frontend, OpenAPI, and tests all renamed in this single commit so the API never sits in a half-renamed state.

| Surface         | Before        | After         | Peer alignment        |
|-----------------|---------------|---------------|------------------------|
| Command alias   | `nextRound`   | `nextround`   | Hearts / Skat / Whist |
| Response field  | `roundNo`     | `roundNumber` | Skat / Hearts / Bridge|
| Player flag     | `isCpu`       | `isHuman` (inverted) | Slapjack and majority |

Closes #1532

## Out of scope (intentionally untouched)

- Domain layer's Go-internal `GetRoundNo`, `GetIsCpu`, `roundNo`, `isCpu` field names — not part of the public API.
- Persistence JSON tags `RoundNo` / `IsCpu` (with short keys `\"rn\"` / `\"ic\"`) used by KV session storage — renaming would break stored sessions and is unrelated to the API contract.
- Frontend i18n key `actions.nextRound` — internal React translation label, not the wire command.

The persistence-tag carve-out is documented in the commit so a future reviewer doesn't \"finish the rename\" and break stored sessions.

## Files changed

**Backend** (4)
- `internal/adapter/controller/NertzWebController.go` — struct fields and command alias.
- `internal/adapter/controller/NertzWebController_test.go` — adds a positive case for the lowercase `nextround` alias.
- `internal/adapter/presenter/NertzWebPresenter.go` — sets `IsHuman: !pl.GetIsCpu()` (inversion happens at the API boundary; domain getter unchanged).
- `internal/adapter/presenter/NertzWebPresenter_test.go` — pins the new JSON shape with **positive** assertions for `RoundNumber` / `IsHuman` AND **negative** assertions that the legacy `roundNo` / `isCpu` keys no longer appear in output (hard rename, not dual-emit).

**Frontend** (3)
- `frontend/src/types/card.ts` — `NertzPlayerData.isCpu` → `isHuman`; `NertzResponse.roundNo` → `roundNumber`.
- `frontend/src/pages/NertzPage.tsx` — scoreboard label and CPU filter flipped (`p.isCpu ? cpu : you` → `p.isHuman ? you : cpu`, `.filter((p) => p.isCpu)` → `.filter((p) => !p.isHuman)`); round display switches to `state.roundNumber`.
- `frontend/src/pages/NertzPage.test.tsx` — fixture mocks updated.

**OpenAPI** (1)
- `api/openapi.yaml /nertz/exec` — command enum, command-table description, request/response schemas all renamed.

## Test plan

- [x] `go test -tags test ./internal/adapter/...` — controller and presenter green, including the new lowercase-alias and JSON-shape tests.
- [x] `golangci-lint run ./internal/adapter/...` — clean.
- [x] `goimports -w` applied.
- [x] `bun run test --run src/pages` — 68 files / 2639 tests pass (NertzPage.test.tsx green).
- [x] `bun run build` — TypeScript check + Vite bundle produce successfully (raised heap due to local 2 GB constraint; not relevant on CI).
- [x] Manual grep confirmed no residual `isCpu` / `roundNo` / `nextRound` on the API surface — only the deliberate domain-internal and persistence-tag occurrences remain.

## Notes for reviewers

- The negative `assert.NotContains(raw, \`\"roundNo\":\`)` assertions in `NertzWebPresenter_test.go` are deliberate: they prevent a future presenter change from accidentally re-introducing the legacy keys (e.g. by adding a struct field with the old JSON tag).
- The OpenAPI command enum keeps both `r` and `nr` shorthands; only the long form changes.
- Front-end test fixtures use the inverted boolean — the test assertions on rendered output (e.g. \"You\" vs \"CPU\") are unchanged because the page logic now derives them from `isHuman` directly.