### PR TITLE
feat(frontend): show BlackJack rule abbreviations help text inline

### DIFF
--- a/frontend/src/components/blackjack/BjBetPhaseControls.test.tsx
+++ b/frontend/src/components/blackjack/BjBetPhaseControls.test.tsx
@@ -333,4 +333,24 @@ describe('BjBetPhaseControls', () => {
     expect(screen.getByRole('button', { name: 'S17' })).not.toHaveAttribute('title');
     expect(screen.getByRole('button', { name: 'DAS ON' })).not.toHaveAttribute('title');
   });
+
+  it('wires aria-describedby on side bets and rule toggles to their help text ids', () => {
+    render(<BjBetPhaseControls {...defaultProps()} />);
+    expect(screen.getByLabelText('PP (ペアベット):')).toHaveAttribute('aria-describedby', 'bj-pp-help');
+    expect(screen.getByLabelText('21+3:')).toHaveAttribute('aria-describedby', 'bj-t3-help');
+    expect(screen.getByRole('button', { name: 'S17' })).toHaveAttribute('aria-describedby', 'bj-soft17-help');
+    expect(screen.getByRole('button', { name: 'DAS ON' })).toHaveAttribute('aria-describedby', 'bj-das-help');
+  });
+
+  it('renders the four help text paragraphs with the matching ids so aria-describedby resolves', () => {
+    const { container } = render(<BjBetPhaseControls {...defaultProps()} />);
+    expect(container.querySelector('#bj-pp-help')).toHaveTextContent('Perfect Pairs: 最初の2枚がペアなら配当');
+    expect(container.querySelector('#bj-t3-help')).toHaveTextContent(
+      '21+3: 最初の2枚+ディーラー1枚でポーカー役が成立すれば配当',
+    );
+    expect(container.querySelector('#bj-soft17-help')).toHaveTextContent(
+      'H17=ソフト17でヒット / S17=ソフト17でスタンド',
+    );
+    expect(container.querySelector('#bj-das-help')).toHaveTextContent('DAS=スプリット後にダブルダウン可');
+  });
 });

--- a/frontend/src/components/blackjack/BjBetPhaseControls.test.tsx
+++ b/frontend/src/components/blackjack/BjBetPhaseControls.test.tsx
@@ -305,4 +305,32 @@ describe('BjBetPhaseControls', () => {
     const details = container.querySelector('details');
     expect(details).not.toHaveAttribute('open');
   });
+
+  it('renders Perfect Pairs help text inline so touch users can see it', () => {
+    render(<BjBetPhaseControls {...defaultProps()} />);
+    expect(screen.getByText('Perfect Pairs: 最初の2枚がペアなら配当')).toBeInTheDocument();
+  });
+
+  it('renders 21+3 help text inline so touch users can see it', () => {
+    render(<BjBetPhaseControls {...defaultProps()} />);
+    expect(screen.getByText('21+3: 最初の2枚+ディーラー1枚でポーカー役が成立すれば配当')).toBeInTheDocument();
+  });
+
+  it('renders soft 17 help text inline so touch users can see it', () => {
+    render(<BjBetPhaseControls {...defaultProps()} />);
+    expect(screen.getByText('H17=ソフト17でヒット / S17=ソフト17でスタンド')).toBeInTheDocument();
+  });
+
+  it('renders DAS help text inline so touch users can see it', () => {
+    render(<BjBetPhaseControls {...defaultProps()} />);
+    expect(screen.getByText('DAS=スプリット後にダブルダウン可')).toBeInTheDocument();
+  });
+
+  it('does not rely on title attribute tooltips for side bets and rule toggles', () => {
+    render(<BjBetPhaseControls {...defaultProps()} />);
+    expect(screen.getByLabelText('PP (ペアベット):')).not.toHaveAttribute('title');
+    expect(screen.getByLabelText('21+3:')).not.toHaveAttribute('title');
+    expect(screen.getByRole('button', { name: 'S17' })).not.toHaveAttribute('title');
+    expect(screen.getByRole('button', { name: 'DAS ON' })).not.toHaveAttribute('title');
+  });
 });

--- a/frontend/src/components/blackjack/BjBetPhaseControls.tsx
+++ b/frontend/src/components/blackjack/BjBetPhaseControls.tsx
@@ -115,6 +115,7 @@ export function BjBetPhaseControls(props: BjBetPhaseControlsProps) {
               onChange={(e) => props.onPerfectPairsBetChange(Number(e.target.value))}
               className="w-20 px-2 py-1 rounded text-sm"
               disabled={props.loading}
+              aria-describedby="bj-pp-help"
             />
             <label htmlFor="bj-t3-bet" className="text-white text-sm">
               {t('sideBetLabel.t3')}
@@ -129,10 +130,13 @@ export function BjBetPhaseControls(props: BjBetPhaseControlsProps) {
               onChange={(e) => props.onTwentyOnePlus3BetChange(Number(e.target.value))}
               className="w-20 px-2 py-1 rounded text-sm"
               disabled={props.loading}
+              aria-describedby="bj-t3-help"
             />
           </div>
-          <p className="text-ds-text-muted text-xs text-center">{t('sideBetTooltip.pp')}</p>
-          <p className="text-ds-text-muted text-xs text-center">{t('sideBetTooltip.t3')}</p>
+          <div className="text-ds-text-muted text-xs text-center">
+            <p id="bj-pp-help">{t('sideBetTooltip.pp')}</p>
+            <p id="bj-t3-help">{t('sideBetTooltip.t3')}</p>
+          </div>
           {/* Deck & CPU count */}
           <div className="flex items-center justify-center gap-2 flex-wrap">
             <label htmlFor="bj-deck-count" className="text-white text-sm">
@@ -185,6 +189,7 @@ export function BjBetPhaseControls(props: BjBetPhaseControlsProps) {
               className={props.dealerHitsSoft17 ? btnSuccess : btnWarning}
               disabled={props.loading}
               onClick={props.onToggleSoft17}
+              aria-describedby="bj-soft17-help"
             >
               {props.dealerHitsSoft17 ? 'H17' : 'S17'}
             </button>
@@ -210,13 +215,16 @@ export function BjBetPhaseControls(props: BjBetPhaseControlsProps) {
               ))}
             </select>
           </div>
-          <p className="text-ds-text-muted text-xs text-center">{t('soft17Tooltip')}</p>
+          <p id="bj-soft17-help" className="text-ds-text-muted text-xs text-center">
+            {t('soft17Tooltip')}
+          </p>
           <div className="flex items-center justify-center gap-2 flex-wrap">
             <button
               type="button"
               className={props.doubleAfterSplit ? btnSuccess : btnWarning}
               disabled={props.loading}
               onClick={props.onToggleDAS}
+              aria-describedby="bj-das-help"
             >
               {t('das')} {props.doubleAfterSplit ? 'ON' : 'OFF'}
             </button>
@@ -253,7 +261,9 @@ export function BjBetPhaseControls(props: BjBetPhaseControlsProps) {
               ))}
             </select>
           </div>
-          <p className="text-ds-text-muted text-xs text-center">{t('dasTooltip')}</p>
+          <p id="bj-das-help" className="text-ds-text-muted text-xs text-center">
+            {t('dasTooltip')}
+          </p>
         </div>
       </details>
 

--- a/frontend/src/components/blackjack/BjBetPhaseControls.tsx
+++ b/frontend/src/components/blackjack/BjBetPhaseControls.tsx
@@ -102,7 +102,7 @@ export function BjBetPhaseControls(props: BjBetPhaseControlsProps) {
         <div className="mt-2 space-y-2 glass-panel rounded-lg p-3">
           {/* Side bets */}
           <div className="flex items-center justify-center gap-2 flex-wrap">
-            <label htmlFor="bj-pp-bet" className="text-white text-sm" title={t('sideBetTooltip.pp')}>
+            <label htmlFor="bj-pp-bet" className="text-white text-sm">
               {t('sideBetLabel.pp')}
             </label>
             <input
@@ -116,7 +116,7 @@ export function BjBetPhaseControls(props: BjBetPhaseControlsProps) {
               className="w-20 px-2 py-1 rounded text-sm"
               disabled={props.loading}
             />
-            <label htmlFor="bj-t3-bet" className="text-white text-sm" title={t('sideBetTooltip.t3')}>
+            <label htmlFor="bj-t3-bet" className="text-white text-sm">
               {t('sideBetLabel.t3')}
             </label>
             <input
@@ -131,6 +131,8 @@ export function BjBetPhaseControls(props: BjBetPhaseControlsProps) {
               disabled={props.loading}
             />
           </div>
+          <p className="text-ds-text-muted text-xs text-center">{t('sideBetTooltip.pp')}</p>
+          <p className="text-ds-text-muted text-xs text-center">{t('sideBetTooltip.t3')}</p>
           {/* Deck & CPU count */}
           <div className="flex items-center justify-center gap-2 flex-wrap">
             <label htmlFor="bj-deck-count" className="text-white text-sm">
@@ -183,7 +185,6 @@ export function BjBetPhaseControls(props: BjBetPhaseControlsProps) {
               className={props.dealerHitsSoft17 ? btnSuccess : btnWarning}
               disabled={props.loading}
               onClick={props.onToggleSoft17}
-              title={t('soft17Tooltip')}
             >
               {props.dealerHitsSoft17 ? 'H17' : 'S17'}
             </button>
@@ -209,13 +210,13 @@ export function BjBetPhaseControls(props: BjBetPhaseControlsProps) {
               ))}
             </select>
           </div>
+          <p className="text-ds-text-muted text-xs text-center">{t('soft17Tooltip')}</p>
           <div className="flex items-center justify-center gap-2 flex-wrap">
             <button
               type="button"
               className={props.doubleAfterSplit ? btnSuccess : btnWarning}
               disabled={props.loading}
               onClick={props.onToggleDAS}
-              title={t('dasTooltip')}
             >
               {t('das')} {props.doubleAfterSplit ? 'ON' : 'OFF'}
             </button>
@@ -252,6 +253,7 @@ export function BjBetPhaseControls(props: BjBetPhaseControlsProps) {
               ))}
             </select>
           </div>
+          <p className="text-ds-text-muted text-xs text-center">{t('dasTooltip')}</p>
         </div>
       </details>
 


### PR DESCRIPTION
## Summary
- Remove `title=` tooltips from `Perfect Pairs (PP)`, `21+3 (T3)`, `H17/S17`, and `DAS` controls in `BjBetPhaseControls.tsx`.
- Render the same i18n strings (`sideBetTooltip.pp`, `sideBetTooltip.t3`, `soft17Tooltip`, `dasTooltip`) as always-visible explanatory paragraphs below each row, scoped inside the existing collapsible advanced-settings panel so the layout only changes when the user actively expands settings.

`title=` attributes are hover-only on desktop and effectively invisible on touch devices and to most screen readers. Inline help text is reachable on every device without adding extra disclosure widgets or state.

Closes #1541

## Test plan
- [x] `bun run test -- --run BjBetPhaseControls` — 49 tests pass (5 new assertions covering inline help text + absence of `title` attribute)
- [x] `bun run check` (biome) — clean for the modified files
- [ ] Manually verify on mobile that PP/21+3/H17/S17/DAS explanations are visible after tapping the advanced settings disclosure