### PR TITLE
refactor(controller): extract PokerCommonInput / PokerBlindsInput mixins

### DIFF
--- a/internal/adapter/controller/HoldemWebController.go
+++ b/internal/adapter/controller/HoldemWebController.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -12,24 +11,12 @@ import (
 // HoldemWebInput テキサスホールデムWebインプット
 type HoldemWebInput struct {
 	BaseWebInput
-	Amount           int             `json:"amount,omitempty"`
-	HumanPlayMs      int             `json:"humanPlayMs,omitempty"`
-	SmallBlind       *int            `json:"smallBlind,omitempty"`
-	BigBlind         *int            `json:"bigBlind,omitempty"`
-	TournamentMode   *bool           `json:"tournamentMode,omitempty"`
-	BlindLevelHands  *int            `json:"blindLevelHands,omitempty"`
-	BlindMultiplier  *int            `json:"blindMultiplier,omitempty"`
-	BettingLimit     *int            `json:"bettingLimit,omitempty"`
-	TableSize        *int            `json:"tableSize,omitempty"`
-	RebuyEnabled     *bool           `json:"rebuyEnabled,omitempty"`
-	RebuyMaxCount    *int            `json:"rebuyMaxCount,omitempty"`
-	RebuyChips       *int            `json:"rebuyChips,omitempty"`
-	RebuyPeriodHands *int            `json:"rebuyPeriodHands,omitempty"`
-	AddonEnabled     *bool           `json:"addonEnabled,omitempty"`
-	AddonChips       *int            `json:"addonChips,omitempty"`
-	AddonAfterHand   *int            `json:"addonAfterHand,omitempty"`
-	CpuMetaAI        bool            `json:"cpuMetaAI,omitempty"`
-	Profile          json.RawMessage `json:"profile,omitempty"`
+	PokerCommonInput
+	PokerBlindsInput
+	Amount      int             `json:"amount,omitempty"`
+	HumanPlayMs int             `json:"humanPlayMs,omitempty"`
+	CpuMetaAI   bool            `json:"cpuMetaAI,omitempty"`
+	Profile     json.RawMessage `json:"profile,omitempty"`
 }
 
 // HoldemWebOutputPlayer テキサスホールデムWebアウトプットプレイヤー
@@ -153,12 +140,8 @@ func (p HoldemWebInput) ToConfig() (domain.HoldemConfig, error) {
 	applyIntIfGte(&cfg.BlindLevelHands, p.BlindLevelHands, 1)
 	applyIntIfGte(&cfg.BlindMultiplier, p.BlindMultiplier, 101)
 	applyBettingLimit(&cfg.BettingLimit, p.BettingLimit)
-	if p.TableSize != nil {
-		ts := *p.TableSize
-		if !domain.IsValidHoldemTableSize(ts) {
-			return domain.HoldemConfig{}, errors.New("param error: tableSize must be 4, 6, or 9")
-		}
-		cfg.TableSize = ts
+	if err := applyTableSize(&cfg.TableSize, p.TableSize, domain.IsValidHoldemTableSize, "param error: tableSize must be 4, 6, or 9"); err != nil {
+		return domain.HoldemConfig{}, err
 	}
 	applyRebuyConfig(&cfg.RebuyEnabled, &cfg.RebuyMaxCount, &cfg.RebuyChips, &cfg.RebuyPeriodHands,
 		p.RebuyEnabled, p.RebuyMaxCount, p.RebuyChips, p.RebuyPeriodHands)

--- a/internal/adapter/controller/PineappleWebController.go
+++ b/internal/adapter/controller/PineappleWebController.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -12,25 +11,13 @@ import (
 // PineappleWebInput パイナ���プルポーカーWebインプット
 type PineappleWebInput struct {
 	BaseWebInput
-	Amount           int             `json:"amount,omitempty"`
-	HumanPlayMs      int             `json:"humanPlayMs,omitempty"`
-	CardIdx          *int            `json:"cardIdx,omitempty"`
-	SmallBlind       *int            `json:"smallBlind,omitempty"`
-	BigBlind         *int            `json:"bigBlind,omitempty"`
-	TournamentMode   *bool           `json:"tournamentMode,omitempty"`
-	BlindLevelHands  *int            `json:"blindLevelHands,omitempty"`
-	BlindMultiplier  *int            `json:"blindMultiplier,omitempty"`
-	BettingLimit     *int            `json:"bettingLimit,omitempty"`
-	TableSize        *int            `json:"tableSize,omitempty"`
-	RebuyEnabled     *bool           `json:"rebuyEnabled,omitempty"`
-	RebuyMaxCount    *int            `json:"rebuyMaxCount,omitempty"`
-	RebuyChips       *int            `json:"rebuyChips,omitempty"`
-	RebuyPeriodHands *int            `json:"rebuyPeriodHands,omitempty"`
-	AddonEnabled     *bool           `json:"addonEnabled,omitempty"`
-	AddonChips       *int            `json:"addonChips,omitempty"`
-	AddonAfterHand   *int            `json:"addonAfterHand,omitempty"`
-	CpuMetaAI        bool            `json:"cpuMetaAI,omitempty"`
-	Profile          json.RawMessage `json:"profile,omitempty"`
+	PokerCommonInput
+	PokerBlindsInput
+	Amount      int             `json:"amount,omitempty"`
+	HumanPlayMs int             `json:"humanPlayMs,omitempty"`
+	CardIdx     *int            `json:"cardIdx,omitempty"`
+	CpuMetaAI   bool            `json:"cpuMetaAI,omitempty"`
+	Profile     json.RawMessage `json:"profile,omitempty"`
 }
 
 // PineappleWebOutput パイナップルポーカーWebアウトプット
@@ -51,12 +38,8 @@ func (p PineappleWebInput) ToConfig() (domain.PineappleConfig, error) {
 	applyIntIfGte(&cfg.BlindLevelHands, p.BlindLevelHands, 1)
 	applyIntIfGte(&cfg.BlindMultiplier, p.BlindMultiplier, 101)
 	applyBettingLimit(&cfg.BettingLimit, p.BettingLimit)
-	if p.TableSize != nil {
-		ts := *p.TableSize
-		if !domain.IsValidHoldemTableSize(ts) {
-			return domain.PineappleConfig{}, errors.New("param error: tableSize must be 4, 6, or 9")
-		}
-		cfg.TableSize = ts
+	if err := applyTableSize(&cfg.TableSize, p.TableSize, domain.IsValidHoldemTableSize, "param error: tableSize must be 4, 6, or 9"); err != nil {
+		return domain.PineappleConfig{}, err
 	}
 	applyRebuyConfig(&cfg.RebuyEnabled, &cfg.RebuyMaxCount, &cfg.RebuyChips, &cfg.RebuyPeriodHands,
 		p.RebuyEnabled, p.RebuyMaxCount, p.RebuyChips, p.RebuyPeriodHands)

--- a/internal/adapter/controller/SevenCardStudWebController.go
+++ b/internal/adapter/controller/SevenCardStudWebController.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -12,26 +11,17 @@ import (
 // SevenCardStudWebInput セブンカードスタッドWebインプット
 type SevenCardStudWebInput struct {
 	BaseWebInput
-	Amount           int             `json:"amount,omitempty"`
-	HumanPlayMs      int             `json:"humanPlayMs,omitempty"`
-	Ante             *int            `json:"ante,omitempty"`
-	BringIn          *int            `json:"bringIn,omitempty"`
-	SmallBet         *int            `json:"smallBet,omitempty"`
-	BigBet           *int            `json:"bigBet,omitempty"`
-	TournamentMode   *bool           `json:"tournamentMode,omitempty"`
-	AnteLevelHands   *int            `json:"anteLevelHands,omitempty"`
-	AnteMultiplier   *int            `json:"anteMultiplier,omitempty"`
-	BettingLimit     *int            `json:"bettingLimit,omitempty"`
-	TableSize        *int            `json:"tableSize,omitempty"`
-	RebuyEnabled     *bool           `json:"rebuyEnabled,omitempty"`
-	RebuyMaxCount    *int            `json:"rebuyMaxCount,omitempty"`
-	RebuyChips       *int            `json:"rebuyChips,omitempty"`
-	RebuyPeriodHands *int            `json:"rebuyPeriodHands,omitempty"`
-	AddonEnabled     *bool           `json:"addonEnabled,omitempty"`
-	AddonChips       *int            `json:"addonChips,omitempty"`
-	AddonAfterHand   *int            `json:"addonAfterHand,omitempty"`
-	CpuMetaAI        bool            `json:"cpuMetaAI,omitempty"`
-	Profile          json.RawMessage `json:"profile,omitempty"`
+	PokerCommonInput
+	Amount         int             `json:"amount,omitempty"`
+	HumanPlayMs    int             `json:"humanPlayMs,omitempty"`
+	Ante           *int            `json:"ante,omitempty"`
+	BringIn        *int            `json:"bringIn,omitempty"`
+	SmallBet       *int            `json:"smallBet,omitempty"`
+	BigBet         *int            `json:"bigBet,omitempty"`
+	AnteLevelHands *int            `json:"anteLevelHands,omitempty"`
+	AnteMultiplier *int            `json:"anteMultiplier,omitempty"`
+	CpuMetaAI      bool            `json:"cpuMetaAI,omitempty"`
+	Profile        json.RawMessage `json:"profile,omitempty"`
 }
 
 // SevenCardStudWebOutputPlayer セブンカードスタッドWebアウトプットプレイヤー
@@ -145,12 +135,8 @@ func (p SevenCardStudWebInput) ToConfig() (domain.SevenCardStudConfig, error) {
 	applyIntIfGte(&cfg.AnteLevelHands, p.AnteLevelHands, 1)
 	applyIntIfGte(&cfg.AnteMultiplier, p.AnteMultiplier, 101)
 	applyBettingLimit(&cfg.BettingLimit, p.BettingLimit)
-	if p.TableSize != nil {
-		ts := *p.TableSize
-		if !domain.IsValidSevenCardStudTableSize(ts) {
-			return domain.SevenCardStudConfig{}, errors.New("param error: tableSize must be 2-7")
-		}
-		cfg.TableSize = ts
+	if err := applyTableSize(&cfg.TableSize, p.TableSize, domain.IsValidSevenCardStudTableSize, "param error: tableSize must be 2-7"); err != nil {
+		return domain.SevenCardStudConfig{}, err
 	}
 	applyRebuyConfig(&cfg.RebuyEnabled, &cfg.RebuyMaxCount, &cfg.RebuyChips, &cfg.RebuyPeriodHands,
 		p.RebuyEnabled, p.RebuyMaxCount, p.RebuyChips, p.RebuyPeriodHands)

--- a/internal/adapter/controller/config_helpers.go
+++ b/internal/adapter/controller/config_helpers.go
@@ -51,6 +51,21 @@ func applyAddonConfig(addonEnabled *bool, addonChips, addonAfterHand *int,
 	applyIntIfGte(addonAfterHand, srcAfterHand, 1)
 }
 
+// applyTableSize validates src against isValid and writes it to *dst.
+// When src is nil, *dst is left unchanged. When src is non-nil but invalid,
+// errMsg is returned wrapped as a controller-style param error.
+func applyTableSize(dst *int, src *int, isValid func(int) bool, errMsg string) error {
+	if src == nil {
+		return nil
+	}
+	ts := *src
+	if !isValid(ts) {
+		return errors.New(errMsg)
+	}
+	*dst = ts
+	return nil
+}
+
 // validateAndApplyBlinds validates small/big blind values and applies them to dst pointers.
 // If only one blind is provided, the other is auto-adjusted.
 func validateAndApplyBlinds(sb, bb *int, sbPtr, bbPtr *int, defaultBB int) error {

--- a/internal/adapter/controller/poker_input_mixins.go
+++ b/internal/adapter/controller/poker_input_mixins.go
@@ -1,0 +1,30 @@
+package controller
+
+// PokerCommonInput holds the tournament/limit/rebuy/addon/tableSize fields
+// shared by every tournament-style poker WebInput (Holdem, Pineapple,
+// SevenCardStud, ...). It is meant to be embedded in those input structs
+// so they can be parsed from the same JSON shape and applied via the same
+// helpers without copy-pasting field declarations.
+type PokerCommonInput struct {
+	TournamentMode   *bool `json:"tournamentMode,omitempty"`
+	BettingLimit     *int  `json:"bettingLimit,omitempty"`
+	TableSize        *int  `json:"tableSize,omitempty"`
+	RebuyEnabled     *bool `json:"rebuyEnabled,omitempty"`
+	RebuyMaxCount    *int  `json:"rebuyMaxCount,omitempty"`
+	RebuyChips       *int  `json:"rebuyChips,omitempty"`
+	RebuyPeriodHands *int  `json:"rebuyPeriodHands,omitempty"`
+	AddonEnabled     *bool `json:"addonEnabled,omitempty"`
+	AddonChips       *int  `json:"addonChips,omitempty"`
+	AddonAfterHand   *int  `json:"addonAfterHand,omitempty"`
+}
+
+// PokerBlindsInput holds the small/big blind fields shared by the
+// Holdem-family poker WebInputs (Holdem, Pineapple, ...). SevenCardStud and
+// other Stud variants do not embed this because they use Ante/BringIn/Bet
+// fields instead.
+type PokerBlindsInput struct {
+	SmallBlind      *int `json:"smallBlind,omitempty"`
+	BigBlind        *int `json:"bigBlind,omitempty"`
+	BlindLevelHands *int `json:"blindLevelHands,omitempty"`
+	BlindMultiplier *int `json:"blindMultiplier,omitempty"`
+}

--- a/internal/adapter/controller/web_controller_config_test.go
+++ b/internal/adapter/controller/web_controller_config_test.go
@@ -1,6 +1,7 @@
 package controller_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +11,23 @@ import (
 )
 
 func boolPtr(v bool) *bool { return &v }
+
+// toConfigInput is the constraint satisfied by every *WebInput type whose
+// ToConfig() returns Cfg, allowing jsonToConfig to be reused across games.
+type toConfigInput[Cfg any] interface {
+	ToConfig() (Cfg, error)
+}
+
+// jsonToConfig unmarshals raw into a fresh In value and runs ToConfig on it.
+// Used to assert that the live JSON wire shape still survives mixin embedding.
+func jsonToConfig[In toConfigInput[Cfg], Cfg any](t *testing.T, raw []byte) (Cfg, error) {
+	t.Helper()
+	var in In
+	if err := json.Unmarshal(raw, &in); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return in.ToConfig()
+}
 
 // ---------------------------------------------------------------------------
 // BlackJackWebInput.HasConfigParams
@@ -277,7 +295,7 @@ func TestHoldemWebInput_ToConfig_Defaults(t *testing.T) {
 }
 
 func TestHoldemWebInput_ToConfig_BothBlindsSet(t *testing.T) {
-	p := controller.HoldemWebInput{SmallBlind: intPtr(10), BigBlind: intPtr(20)}
+	p := controller.HoldemWebInput{PokerBlindsInput: controller.PokerBlindsInput{SmallBlind: intPtr(10), BigBlind: intPtr(20)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, 10, cfg.SmallBlind)
@@ -289,7 +307,7 @@ func TestHoldemWebInput_ToConfig_OnlySmallBlindGeDefault(t *testing.T) {
 	def := domain.DefaultHoldemConfig()
 	// Set sb >= def.BigBlind to trigger auto-adjust
 	sb := def.BigBlind
-	p := controller.HoldemWebInput{SmallBlind: intPtr(sb)}
+	p := controller.HoldemWebInput{PokerBlindsInput: controller.PokerBlindsInput{SmallBlind: intPtr(sb)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, sb, cfg.SmallBlind)
@@ -299,7 +317,7 @@ func TestHoldemWebInput_ToConfig_OnlySmallBlindGeDefault(t *testing.T) {
 // Only SmallBlind provided but sb < default BigBlind: no auto-adjust, still sb < bb
 func TestHoldemWebInput_ToConfig_OnlySmallBlindLtDefault(t *testing.T) {
 	// default SmallBlind=5, BigBlind=10; setting sb=7 < 10, no auto-adjust; 7<10 is valid
-	p := controller.HoldemWebInput{SmallBlind: intPtr(7)}
+	p := controller.HoldemWebInput{PokerBlindsInput: controller.PokerBlindsInput{SmallBlind: intPtr(7)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, 7, cfg.SmallBlind)
@@ -308,7 +326,7 @@ func TestHoldemWebInput_ToConfig_OnlySmallBlindLtDefault(t *testing.T) {
 
 // Only BigBlind provided, bb > 1: auto-adjust SmallBlind
 func TestHoldemWebInput_ToConfig_OnlyBigBlindGt1(t *testing.T) {
-	p := controller.HoldemWebInput{BigBlind: intPtr(20)}
+	p := controller.HoldemWebInput{PokerBlindsInput: controller.PokerBlindsInput{BigBlind: intPtr(20)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, 10, cfg.SmallBlind)
@@ -317,7 +335,7 @@ func TestHoldemWebInput_ToConfig_OnlyBigBlindGt1(t *testing.T) {
 
 // Only BigBlind=2: auto sb = bb/2 = 1
 func TestHoldemWebInput_ToConfig_OnlyBigBlind2(t *testing.T) {
-	p := controller.HoldemWebInput{BigBlind: intPtr(2)}
+	p := controller.HoldemWebInput{PokerBlindsInput: controller.PokerBlindsInput{BigBlind: intPtr(2)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, 1, cfg.SmallBlind)
@@ -326,34 +344,34 @@ func TestHoldemWebInput_ToConfig_OnlyBigBlind2(t *testing.T) {
 
 // Only BigBlind=1: no auto-adjust (bb > 1 is false), but sb(5) >= bb(1) → error
 func TestHoldemWebInput_ToConfig_OnlyBigBlind1Error(t *testing.T) {
-	p := controller.HoldemWebInput{BigBlind: intPtr(1)}
+	p := controller.HoldemWebInput{PokerBlindsInput: controller.PokerBlindsInput{BigBlind: intPtr(1)}}
 	_, err := p.ToConfig()
 	assert.Error(t, err)
 }
 
 // sb >= bb error
 func TestHoldemWebInput_ToConfig_SmallBlindGeqBigBlind(t *testing.T) {
-	p := controller.HoldemWebInput{SmallBlind: intPtr(10), BigBlind: intPtr(10)}
+	p := controller.HoldemWebInput{PokerBlindsInput: controller.PokerBlindsInput{SmallBlind: intPtr(10), BigBlind: intPtr(10)}}
 	_, err := p.ToConfig()
 	assert.Error(t, err)
 }
 
 func TestHoldemWebInput_ToConfig_TournamentMode(t *testing.T) {
-	p := controller.HoldemWebInput{TournamentMode: boolPtr(true)}
+	p := controller.HoldemWebInput{PokerCommonInput: controller.PokerCommonInput{TournamentMode: boolPtr(true)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.True(t, cfg.TournamentMode)
 }
 
 func TestHoldemWebInput_ToConfig_BlindLevelHands_Valid(t *testing.T) {
-	p := controller.HoldemWebInput{BlindLevelHands: intPtr(5)}
+	p := controller.HoldemWebInput{PokerBlindsInput: controller.PokerBlindsInput{BlindLevelHands: intPtr(5)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, 5, cfg.BlindLevelHands)
 }
 
 func TestHoldemWebInput_ToConfig_BlindLevelHands_Zero(t *testing.T) {
-	p := controller.HoldemWebInput{BlindLevelHands: intPtr(0)}
+	p := controller.HoldemWebInput{PokerBlindsInput: controller.PokerBlindsInput{BlindLevelHands: intPtr(0)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	// 0 < 1, so not applied - default stays
@@ -361,14 +379,14 @@ func TestHoldemWebInput_ToConfig_BlindLevelHands_Zero(t *testing.T) {
 }
 
 func TestHoldemWebInput_ToConfig_BlindMultiplier_Valid(t *testing.T) {
-	p := controller.HoldemWebInput{BlindMultiplier: intPtr(150)}
+	p := controller.HoldemWebInput{PokerBlindsInput: controller.PokerBlindsInput{BlindMultiplier: intPtr(150)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, 150, cfg.BlindMultiplier)
 }
 
 func TestHoldemWebInput_ToConfig_BlindMultiplier_TooLow(t *testing.T) {
-	p := controller.HoldemWebInput{BlindMultiplier: intPtr(100)}
+	p := controller.HoldemWebInput{PokerBlindsInput: controller.PokerBlindsInput{BlindMultiplier: intPtr(100)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	// 100 < 101, so not applied - default stays
@@ -376,121 +394,228 @@ func TestHoldemWebInput_ToConfig_BlindMultiplier_TooLow(t *testing.T) {
 }
 
 func TestHoldemWebInput_ToConfig_BettingLimit_BelowMin(t *testing.T) {
-	p := controller.HoldemWebInput{BettingLimit: intPtr(-1)}
+	p := controller.HoldemWebInput{PokerCommonInput: controller.PokerCommonInput{BettingLimit: intPtr(-1)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, domain.BettingLimitType(0), cfg.BettingLimit)
 }
 
 func TestHoldemWebInput_ToConfig_BettingLimit_AboveMax(t *testing.T) {
-	p := controller.HoldemWebInput{BettingLimit: intPtr(5)}
+	p := controller.HoldemWebInput{PokerCommonInput: controller.PokerCommonInput{BettingLimit: intPtr(5)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, domain.BettingLimitType(2), cfg.BettingLimit)
 }
 
 func TestHoldemWebInput_ToConfig_BettingLimit_InRange(t *testing.T) {
-	p := controller.HoldemWebInput{BettingLimit: intPtr(1)}
+	p := controller.HoldemWebInput{PokerCommonInput: controller.PokerCommonInput{BettingLimit: intPtr(1)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, domain.BettingLimitType(1), cfg.BettingLimit)
 }
 
 func TestHoldemWebInput_ToConfig_TableSize_Valid(t *testing.T) {
-	p := controller.HoldemWebInput{TableSize: intPtr(6)}
+	p := controller.HoldemWebInput{PokerCommonInput: controller.PokerCommonInput{TableSize: intPtr(6)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, 6, cfg.TableSize)
 }
 
 func TestHoldemWebInput_ToConfig_TableSize_Invalid(t *testing.T) {
-	p := controller.HoldemWebInput{TableSize: intPtr(5)}
+	p := controller.HoldemWebInput{PokerCommonInput: controller.PokerCommonInput{TableSize: intPtr(5)}}
 	_, err := p.ToConfig()
 	assert.Error(t, err)
 }
 
 func TestHoldemWebInput_ToConfig_RebuyEnabled(t *testing.T) {
-	p := controller.HoldemWebInput{RebuyEnabled: boolPtr(true)}
+	p := controller.HoldemWebInput{PokerCommonInput: controller.PokerCommonInput{RebuyEnabled: boolPtr(true)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.True(t, cfg.RebuyEnabled)
 }
 
 func TestHoldemWebInput_ToConfig_RebuyMaxCount_Valid(t *testing.T) {
-	p := controller.HoldemWebInput{RebuyMaxCount: intPtr(5)}
+	p := controller.HoldemWebInput{PokerCommonInput: controller.PokerCommonInput{RebuyMaxCount: intPtr(5)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, 5, cfg.RebuyMaxCount)
 }
 
 func TestHoldemWebInput_ToConfig_RebuyMaxCount_Zero(t *testing.T) {
-	p := controller.HoldemWebInput{RebuyMaxCount: intPtr(0)}
+	p := controller.HoldemWebInput{PokerCommonInput: controller.PokerCommonInput{RebuyMaxCount: intPtr(0)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, domain.DefaultHoldemConfig().RebuyMaxCount, cfg.RebuyMaxCount)
 }
 
 func TestHoldemWebInput_ToConfig_RebuyChips_Valid(t *testing.T) {
-	p := controller.HoldemWebInput{RebuyChips: intPtr(500)}
+	p := controller.HoldemWebInput{PokerCommonInput: controller.PokerCommonInput{RebuyChips: intPtr(500)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, 500, cfg.RebuyChips)
 }
 
 func TestHoldemWebInput_ToConfig_RebuyChips_Zero(t *testing.T) {
-	p := controller.HoldemWebInput{RebuyChips: intPtr(0)}
+	p := controller.HoldemWebInput{PokerCommonInput: controller.PokerCommonInput{RebuyChips: intPtr(0)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, domain.DefaultHoldemConfig().RebuyChips, cfg.RebuyChips)
 }
 
 func TestHoldemWebInput_ToConfig_RebuyPeriodHands_Valid(t *testing.T) {
-	p := controller.HoldemWebInput{RebuyPeriodHands: intPtr(10)}
+	p := controller.HoldemWebInput{PokerCommonInput: controller.PokerCommonInput{RebuyPeriodHands: intPtr(10)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, 10, cfg.RebuyPeriodHands)
 }
 
 func TestHoldemWebInput_ToConfig_RebuyPeriodHands_Zero(t *testing.T) {
-	p := controller.HoldemWebInput{RebuyPeriodHands: intPtr(0)}
+	p := controller.HoldemWebInput{PokerCommonInput: controller.PokerCommonInput{RebuyPeriodHands: intPtr(0)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, domain.DefaultHoldemConfig().RebuyPeriodHands, cfg.RebuyPeriodHands)
 }
 
 func TestHoldemWebInput_ToConfig_AddonEnabled(t *testing.T) {
-	p := controller.HoldemWebInput{AddonEnabled: boolPtr(true)}
+	p := controller.HoldemWebInput{PokerCommonInput: controller.PokerCommonInput{AddonEnabled: boolPtr(true)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.True(t, cfg.AddonEnabled)
 }
 
 func TestHoldemWebInput_ToConfig_AddonChips_Valid(t *testing.T) {
-	p := controller.HoldemWebInput{AddonChips: intPtr(2000)}
+	p := controller.HoldemWebInput{PokerCommonInput: controller.PokerCommonInput{AddonChips: intPtr(2000)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, 2000, cfg.AddonChips)
 }
 
 func TestHoldemWebInput_ToConfig_AddonChips_Zero(t *testing.T) {
-	p := controller.HoldemWebInput{AddonChips: intPtr(0)}
+	p := controller.HoldemWebInput{PokerCommonInput: controller.PokerCommonInput{AddonChips: intPtr(0)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, domain.DefaultHoldemConfig().AddonChips, cfg.AddonChips)
 }
 
 func TestHoldemWebInput_ToConfig_AddonAfterHand_Valid(t *testing.T) {
-	p := controller.HoldemWebInput{AddonAfterHand: intPtr(15)}
+	p := controller.HoldemWebInput{PokerCommonInput: controller.PokerCommonInput{AddonAfterHand: intPtr(15)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, 15, cfg.AddonAfterHand)
 }
 
 func TestHoldemWebInput_ToConfig_AddonAfterHand_Zero(t *testing.T) {
-	p := controller.HoldemWebInput{AddonAfterHand: intPtr(0)}
+	p := controller.HoldemWebInput{PokerCommonInput: controller.PokerCommonInput{AddonAfterHand: intPtr(0)}}
 	cfg, err := p.ToConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, domain.DefaultHoldemConfig().AddonAfterHand, cfg.AddonAfterHand)
+}
+
+// ---------------------------------------------------------------------------
+// JSON wire compatibility: the embedded PokerCommonInput / PokerBlindsInput
+// mixins must keep deserializing the same flat JSON shape the frontend already
+// sends. These tests pin that contract so future mixin edits cannot silently
+// break the live API.
+// ---------------------------------------------------------------------------
+
+func TestHoldemWebInput_FlatJSON_PreservesAllFields(t *testing.T) {
+	raw := []byte(`{
+		"command": "reset",
+		"smallBlind": 25,
+		"bigBlind": 50,
+		"blindLevelHands": 8,
+		"blindMultiplier": 150,
+		"tournamentMode": true,
+		"bettingLimit": 2,
+		"tableSize": 6,
+		"rebuyEnabled": true,
+		"rebuyMaxCount": 4,
+		"rebuyChips": 1500,
+		"rebuyPeriodHands": 25,
+		"addonEnabled": true,
+		"addonChips": 2500,
+		"addonAfterHand": 30
+	}`)
+	cfg, err := jsonToConfig[controller.HoldemWebInput, domain.HoldemConfig](t, raw)
+	assert.NoError(t, err)
+	assert.Equal(t, 25, cfg.SmallBlind)
+	assert.Equal(t, 50, cfg.BigBlind)
+	assert.Equal(t, 8, cfg.BlindLevelHands)
+	assert.Equal(t, 150, cfg.BlindMultiplier)
+	assert.True(t, cfg.TournamentMode)
+	assert.Equal(t, domain.BettingLimitType(2), cfg.BettingLimit)
+	assert.Equal(t, 6, cfg.TableSize)
+	assert.True(t, cfg.RebuyEnabled)
+	assert.Equal(t, 4, cfg.RebuyMaxCount)
+	assert.Equal(t, 1500, cfg.RebuyChips)
+	assert.Equal(t, 25, cfg.RebuyPeriodHands)
+	assert.True(t, cfg.AddonEnabled)
+	assert.Equal(t, 2500, cfg.AddonChips)
+	assert.Equal(t, 30, cfg.AddonAfterHand)
+}
+
+func TestPineappleWebInput_FlatJSON_PreservesAllFields(t *testing.T) {
+	raw := []byte(`{
+		"command": "reset",
+		"smallBlind": 15,
+		"bigBlind": 30,
+		"tournamentMode": true,
+		"tableSize": 9,
+		"rebuyEnabled": true,
+		"rebuyChips": 800,
+		"addonEnabled": true,
+		"addonChips": 1200
+	}`)
+	cfg, err := jsonToConfig[controller.PineappleWebInput, domain.PineappleConfig](t, raw)
+	assert.NoError(t, err)
+	assert.Equal(t, 15, cfg.SmallBlind)
+	assert.Equal(t, 30, cfg.BigBlind)
+	assert.True(t, cfg.TournamentMode)
+	assert.Equal(t, 9, cfg.TableSize)
+	assert.True(t, cfg.RebuyEnabled)
+	assert.Equal(t, 800, cfg.RebuyChips)
+	assert.True(t, cfg.AddonEnabled)
+	assert.Equal(t, 1200, cfg.AddonChips)
+}
+
+func TestSevenCardStudWebInput_FlatJSON_PreservesAllFields(t *testing.T) {
+	raw := []byte(`{
+		"command": "reset",
+		"ante": 2,
+		"bringIn": 4,
+		"smallBet": 10,
+		"bigBet": 20,
+		"tournamentMode": true,
+		"anteLevelHands": 5,
+		"anteMultiplier": 200,
+		"bettingLimit": 1,
+		"tableSize": 4,
+		"rebuyEnabled": true,
+		"rebuyMaxCount": 2,
+		"rebuyChips": 500,
+		"rebuyPeriodHands": 10,
+		"addonEnabled": true,
+		"addonChips": 800,
+		"addonAfterHand": 15
+	}`)
+	cfg, err := jsonToConfig[controller.SevenCardStudWebInput, domain.SevenCardStudConfig](t, raw)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, cfg.Ante)
+	assert.Equal(t, 4, cfg.BringIn)
+	assert.Equal(t, 10, cfg.SmallBet)
+	assert.Equal(t, 20, cfg.BigBet)
+	assert.True(t, cfg.TournamentMode)
+	assert.Equal(t, 5, cfg.AnteLevelHands)
+	assert.Equal(t, 200, cfg.AnteMultiplier)
+	assert.Equal(t, domain.BettingLimitType(1), cfg.BettingLimit)
+	assert.Equal(t, 4, cfg.TableSize)
+	assert.True(t, cfg.RebuyEnabled)
+	assert.Equal(t, 2, cfg.RebuyMaxCount)
+	assert.Equal(t, 500, cfg.RebuyChips)
+	assert.Equal(t, 10, cfg.RebuyPeriodHands)
+	assert.True(t, cfg.AddonEnabled)
+	assert.Equal(t, 800, cfg.AddonChips)
+	assert.Equal(t, 15, cfg.AddonAfterHand)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`HoldemWebInput`, `PineappleWebInput`, and `SevenCardStudWebInput` re-declared the same 10 tournament / rebuy / addon / tableSize fields, plus Holdem and Pineapple shared 4 more blind fields. This pulls both clusters into reusable embedded structs so adding the next poker variant no longer requires hand-copying the bookkeeping. Each `ToConfig` also drops the inline `tableSize` validation block in favor of a small new `applyTableSize` helper.

- New `internal/adapter/controller/poker_input_mixins.go`
  - `PokerCommonInput`: TournamentMode, BettingLimit, TableSize, Rebuy×4, Addon×3 — embedded by all 3 inputs
  - `PokerBlindsInput`: SmallBlind, BigBlind, BlindLevelHands, BlindMultiplier — embedded by Holdem + Pineapple only (Stud uses its own Ante / BringIn / SmallBet / BigBet, which stay inline)
- `applyTableSize(dst, src, isValid, errMsg)` added in `config_helpers.go`; replaces the 6-line `if p.TableSize != nil { ... }` block in each ToConfig
- Existing `controller.HoldemWebInput{...}` test literals updated to nest the field inside the embedded struct (e.g. `HoldemWebInput{PokerBlindsInput: PokerBlindsInput{SmallBlind: intPtr(10)}}`); behavior unchanged

## Wire compatibility

Embedded fields flatten under `encoding/json`, so existing frontend payloads continue to deserialize unchanged. Three new regression tests pin that contract:

- `TestHoldemWebInput_FlatJSON_PreservesAllFields`
- `TestPineappleWebInput_FlatJSON_PreservesAllFields`
- `TestSevenCardStudWebInput_FlatJSON_PreservesAllFields`

They feed the legacy flat JSON shape through a shared `jsonToConfig[In, Cfg]` generic helper and assert every field arrives at the resulting config.

## Test plan

- [x] `go test -tags test ./...` — all packages green
- [x] `golangci-lint run ./...` — 0 issues
- [x] `goimports -w` on modified files
- [x] New flat-JSON regression tests pass for all three inputs

Closes #1548