### PR TITLE
refactor(presenter): use shared actionLogOutputJSON in 16 solitaire presenters

### DIFF
--- a/internal/adapter/presenter/AccordionWebPresenter.go
+++ b/internal/adapter/presenter/AccordionWebPresenter.go
@@ -56,10 +56,7 @@ func (p *AccordionWebPresenter) HintOutput(a interfaces.AccordionGame) string {
 
 // ActionLogOutput 棋譜をJSON出力
 func (p *AccordionWebPresenter) ActionLogOutput(a interfaces.AccordionGame) string {
-	if a.GetPhase() == domain.AccordionPhasePlaying {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(a.GetActionLog())
+	return actionLogOutputJSON(a)
 }
 
 // buildBase は共通フィールドを詰めたレスポンスオブジェクトを返す

--- a/internal/adapter/presenter/AccordionWebPresenter_test.go
+++ b/internal/adapter/presenter/AccordionWebPresenter_test.go
@@ -131,6 +131,7 @@ func TestAccordionWebPresenter_ActionLogOutput(t *testing.T) {
 		ag := new(interfaces.MockAccordionGame)
 		ag.On("GetPhase").Return(domain.AccordionPhasePlaying)
 
+		ag.On("GetGameEndFlag").Return(false)
 		p := new(AccordionWebPresenter)
 		result := p.ActionLogOutput(ag)
 		assert.Contains(t, result, "entries")
@@ -139,6 +140,7 @@ func TestAccordionWebPresenter_ActionLogOutput(t *testing.T) {
 	t.Run("game over", func(t *testing.T) {
 		ag := new(interfaces.MockAccordionGame)
 		ag.On("GetPhase").Return(domain.AccordionPhaseGameOver)
+		ag.On("GetGameEndFlag").Return(true)
 		ag.On("GetActionLog").Return([]*domain.ActionLogEntry{{TurnNumber: 1, ActionType: "move"}})
 
 		p := new(AccordionWebPresenter)

--- a/internal/adapter/presenter/CalculationWebPresenter.go
+++ b/internal/adapter/presenter/CalculationWebPresenter.go
@@ -57,10 +57,7 @@ func (p *CalculationWebPresenter) HintOutput(g interfaces.CalculationGame) strin
 
 // ActionLogOutput 棋譜をJSON出力
 func (p *CalculationWebPresenter) ActionLogOutput(g interfaces.CalculationGame) string {
-	if g.GetPhase() == domain.CalculationPhasePlaying {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(g.GetActionLog())
+	return actionLogOutputJSON(g)
 }
 
 // buildBase は共通フィールドを詰めたレスポンスオブジェクトを返す

--- a/internal/adapter/presenter/CalculationWebPresenter_test.go
+++ b/internal/adapter/presenter/CalculationWebPresenter_test.go
@@ -146,6 +146,7 @@ func TestCalculationWebPresenter_ActionLogOutput(t *testing.T) {
 	t.Run("playing", func(t *testing.T) {
 		g := new(interfaces.MockCalculationGame)
 		g.On("GetPhase").Return(domain.CalculationPhasePlaying)
+		g.On("GetGameEndFlag").Return(false)
 		result := new(CalculationWebPresenter).ActionLogOutput(g)
 		assert.Contains(t, result, "entries")
 	})
@@ -153,6 +154,7 @@ func TestCalculationWebPresenter_ActionLogOutput(t *testing.T) {
 	t.Run("game over", func(t *testing.T) {
 		g := new(interfaces.MockCalculationGame)
 		g.On("GetPhase").Return(domain.CalculationPhaseGameOver)
+		g.On("GetGameEndFlag").Return(true)
 		g.On("GetActionLog").Return([]*domain.ActionLogEntry{{TurnNumber: 1, ActionType: "move"}})
 		result := new(CalculationWebPresenter).ActionLogOutput(g)
 		assert.Contains(t, result, "entries")

--- a/internal/adapter/presenter/CanfieldWebPresenter.go
+++ b/internal/adapter/presenter/CanfieldWebPresenter.go
@@ -101,10 +101,7 @@ func (p *CanfieldWebPresenter) HintOutput(c interfaces.CanfieldGame) string {
 
 // ActionLogOutput 棋譜をJSON出力
 func (p *CanfieldWebPresenter) ActionLogOutput(c interfaces.CanfieldGame) string {
-	if c.GetPhase() == domain.CanfieldPhasePlaying {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(c.GetActionLog())
+	return actionLogOutputJSON(c)
 }
 
 func (p *CanfieldWebPresenter) buildBaseOutput(c interfaces.CanfieldGame) *controller.CanfieldWebOutput {

--- a/internal/adapter/presenter/CanfieldWebPresenter_test.go
+++ b/internal/adapter/presenter/CanfieldWebPresenter_test.go
@@ -116,6 +116,7 @@ func TestCanfieldWebPresenter_ActionLogOutput(t *testing.T) {
 	t.Run("playing", func(t *testing.T) {
 		cg := new(interfaces.MockCanfieldGame)
 		cg.On("GetPhase").Return(domain.CanfieldPhasePlaying)
+		cg.On("GetGameEndFlag").Return(false)
 		p := new(CanfieldWebPresenter)
 		_ = p.ActionLogOutput(cg)
 	})
@@ -123,6 +124,7 @@ func TestCanfieldWebPresenter_ActionLogOutput(t *testing.T) {
 	t.Run("cleared", func(t *testing.T) {
 		cg := new(interfaces.MockCanfieldGame)
 		cg.On("GetPhase").Return(domain.CanfieldPhaseGameClear)
+		cg.On("GetGameEndFlag").Return(true)
 		cg.On("GetActionLog").Return([]*domain.ActionLogEntry{{TurnNumber: 1, ActionType: "draw"}})
 		p := new(CanfieldWebPresenter)
 		_ = p.ActionLogOutput(cg)

--- a/internal/adapter/presenter/ClockSolitaireWebPresenter.go
+++ b/internal/adapter/presenter/ClockSolitaireWebPresenter.go
@@ -67,9 +67,5 @@ func (pr *ClockSolitaireWebPresenter) Output(g interfaces.ClockSolitaireGame, la
 
 // ActionLogOutput 棋譜をJSON出力
 func (pr *ClockSolitaireWebPresenter) ActionLogOutput(g interfaces.ClockSolitaireGame) string {
-	phase := g.GetPhase()
-	if phase == domain.ClockSolitairePhasePlaying {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(g.GetActionLog())
+	return actionLogOutputJSON(g)
 }

--- a/internal/adapter/presenter/ClockSolitaireWebPresenter_test.go
+++ b/internal/adapter/presenter/ClockSolitaireWebPresenter_test.go
@@ -163,6 +163,7 @@ func TestClockSolitaireWebPresenterActionLog_Playing(t *testing.T) {
 	gg := new(interfaces.MockClockSolitaireGame)
 	gg.On("GetPhase").Return(domain.ClockSolitairePhasePlaying)
 
+	gg.On("GetGameEndFlag").Return(false)
 	p := &ClockSolitaireWebPresenter{}
 	result := p.ActionLogOutput(gg)
 
@@ -175,6 +176,7 @@ func TestClockSolitaireWebPresenterActionLog_Playing(t *testing.T) {
 func TestClockSolitaireWebPresenterActionLog_GameOver(t *testing.T) {
 	gg := new(interfaces.MockClockSolitaireGame)
 	gg.On("GetPhase").Return(domain.ClockSolitairePhaseGameOver)
+	gg.On("GetGameEndFlag").Return(true)
 	gg.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, ActionType: "step", Detail: "test"},
 	})

--- a/internal/adapter/presenter/FortyThievesWebPresenter.go
+++ b/internal/adapter/presenter/FortyThievesWebPresenter.go
@@ -114,9 +114,5 @@ func (p *FortyThievesWebPresenter) HintOutput(ft interfaces.FortyThievesGame) st
 
 // ActionLogOutput 棋譜をJSON出力
 func (p *FortyThievesWebPresenter) ActionLogOutput(ft interfaces.FortyThievesGame) string {
-	phase := ft.GetPhase()
-	if phase == domain.FortyThievesPhasePlaying {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(ft.GetActionLog())
+	return actionLogOutputJSON(ft)
 }

--- a/internal/adapter/presenter/FortyThievesWebPresenter_test.go
+++ b/internal/adapter/presenter/FortyThievesWebPresenter_test.go
@@ -170,6 +170,7 @@ func TestFortyThievesWebPresenter_ActionLogOutput(t *testing.T) {
 		fg := new(interfaces.MockFortyThievesGame)
 		fg.On("GetPhase").Return(domain.FortyThievesPhasePlaying)
 
+		fg.On("GetGameEndFlag").Return(false)
 		p := new(FortyThievesWebPresenter)
 		result := p.ActionLogOutput(fg)
 		assert.Contains(t, result, "[]")
@@ -178,6 +179,7 @@ func TestFortyThievesWebPresenter_ActionLogOutput(t *testing.T) {
 	t.Run("game over returns log", func(t *testing.T) {
 		fg := new(interfaces.MockFortyThievesGame)
 		fg.On("GetPhase").Return(domain.FortyThievesPhaseGameOver)
+		fg.On("GetGameEndFlag").Return(true)
 		fg.On("GetActionLog").Return([]*domain.ActionLogEntry{
 			{TurnNumber: 1, ActionType: "draw", Detail: "test"},
 		})

--- a/internal/adapter/presenter/FreeCellWebPresenter.go
+++ b/internal/adapter/presenter/FreeCellWebPresenter.go
@@ -107,9 +107,5 @@ func (p *FreeCellWebPresenter) HintOutput(f interfaces.FreeCellGame) string {
 
 // ActionLogOutput 棋譜をJSON出力
 func (p *FreeCellWebPresenter) ActionLogOutput(f interfaces.FreeCellGame) string {
-	phase := f.GetPhase()
-	if phase == domain.FreeCellPhasePlaying {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(f.GetActionLog())
+	return actionLogOutputJSON(f)
 }

--- a/internal/adapter/presenter/GolfWebPresenter.go
+++ b/internal/adapter/presenter/GolfWebPresenter.go
@@ -105,9 +105,5 @@ func (pr *GolfWebPresenter) HintOutput(g interfaces.GolfGame) string {
 
 // ActionLogOutput 棋譜をJSON出力
 func (pr *GolfWebPresenter) ActionLogOutput(g interfaces.GolfGame) string {
-	phase := g.GetPhase()
-	if phase == domain.GolfPhasePlaying {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(g.GetActionLog())
+	return actionLogOutputJSON(g)
 }

--- a/internal/adapter/presenter/GolfWebPresenter_test.go
+++ b/internal/adapter/presenter/GolfWebPresenter_test.go
@@ -199,6 +199,7 @@ func TestGolfWebPresenterActionLogOutput(t *testing.T) {
 		gg := new(interfaces.MockGolfGame)
 		gg.On("GetPhase").Return(domain.GolfPhasePlaying)
 
+		gg.On("GetGameEndFlag").Return(false)
 		p := &GolfWebPresenter{}
 		result := p.ActionLogOutput(gg)
 		assert.Contains(t, result, "entries")
@@ -207,6 +208,7 @@ func TestGolfWebPresenterActionLogOutput(t *testing.T) {
 	t.Run("game over", func(t *testing.T) {
 		gg := new(interfaces.MockGolfGame)
 		gg.On("GetPhase").Return(domain.GolfPhaseGameOver)
+		gg.On("GetGameEndFlag").Return(true)
 		gg.On("GetActionLog").Return([]*domain.ActionLogEntry{})
 
 		p := &GolfWebPresenter{}

--- a/internal/adapter/presenter/KlondikeWebPresenter.go
+++ b/internal/adapter/presenter/KlondikeWebPresenter.go
@@ -125,9 +125,5 @@ func (p *KlondikeWebPresenter) HintOutput(k interfaces.KlondikeGame) string {
 
 // ActionLogOutput 棋譜をJSON出力
 func (p *KlondikeWebPresenter) ActionLogOutput(k interfaces.KlondikeGame) string {
-	phase := k.GetPhase()
-	if phase == domain.KlondikePhasePlaying {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(k.GetActionLog())
+	return actionLogOutputJSON(k)
 }

--- a/internal/adapter/presenter/KlondikeWebPresenter_test.go
+++ b/internal/adapter/presenter/KlondikeWebPresenter_test.go
@@ -338,6 +338,7 @@ func TestKlondikeWebPresenter_ActionLogOutput(t *testing.T) {
 		kg := new(interfaces.MockKlondikeGame)
 		kg.On("GetPhase").Return(domain.KlondikePhasePlaying)
 
+		kg.On("GetGameEndFlag").Return(false)
 		p := new(KlondikeWebPresenter)
 		result := p.ActionLogOutput(kg)
 		var out controller.ActionLogWebOutput
@@ -349,6 +350,7 @@ func TestKlondikeWebPresenter_ActionLogOutput(t *testing.T) {
 	t.Run("after game clear", func(t *testing.T) {
 		kg := new(interfaces.MockKlondikeGame)
 		kg.On("GetPhase").Return(domain.KlondikePhaseGameClear)
+		kg.On("GetGameEndFlag").Return(true)
 		kg.On("GetActionLog").Return([]*domain.ActionLogEntry{
 			{TurnNumber: 1, PlayerIdx: 0, ActionType: "draw", Detail: "test", Cards: nil},
 		})
@@ -364,6 +366,7 @@ func TestKlondikeWebPresenter_ActionLogOutput(t *testing.T) {
 	t.Run("after game over", func(t *testing.T) {
 		kg := new(interfaces.MockKlondikeGame)
 		kg.On("GetPhase").Return(domain.KlondikePhaseGameOver)
+		kg.On("GetGameEndFlag").Return(true)
 		kg.On("GetActionLog").Return([]*domain.ActionLogEntry{})
 
 		p := new(KlondikeWebPresenter)

--- a/internal/adapter/presenter/NertzWebPresenter.go
+++ b/internal/adapter/presenter/NertzWebPresenter.go
@@ -62,10 +62,7 @@ func (p *NertzWebPresenter) HintOutput(g interfaces.NertzGame) string {
 // み完全ログを返す (他のリアルタイム系ゲームと同じ運用 / PR #1528 レビュー指
 // 摘)。
 func (p *NertzWebPresenter) ActionLogOutput(g interfaces.NertzGame) string {
-	if g.GetPhase() == domain.NertzPhasePlaying {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(g.GetActionLog())
+	return actionLogOutputJSON(g)
 }
 
 // buildBase は共通フィールドを詰めたレスポンスオブジェクトを返す

--- a/internal/adapter/presenter/NertzWebPresenter_test.go
+++ b/internal/adapter/presenter/NertzWebPresenter_test.go
@@ -197,11 +197,13 @@ func TestNertzWebPresenter_ActionLogOutput(t *testing.T) {
 	t.Run("playing returns empty log", func(t *testing.T) {
 		g := new(interfaces.MockNertzGame)
 		g.On("GetPhase").Return(domain.NertzPhasePlaying)
+		g.On("GetGameEndFlag").Return(false)
 		assert.NotEmpty(t, new(NertzWebPresenter).ActionLogOutput(g))
 	})
 	t.Run("after round end returns full log", func(t *testing.T) {
 		g := new(interfaces.MockNertzGame)
 		g.On("GetPhase").Return(domain.NertzPhaseRoundEnd)
+		g.On("GetGameEndFlag").Return(true)
 		g.On("GetActionLog").Return([]*domain.ActionLogEntry{{TurnNumber: 1, ActionType: "moveNF"}})
 		assert.NotEmpty(t, new(NertzWebPresenter).ActionLogOutput(g))
 	})

--- a/internal/adapter/presenter/PokerSquaresWebPresenter.go
+++ b/internal/adapter/presenter/PokerSquaresWebPresenter.go
@@ -58,8 +58,5 @@ func (pr *PokerSquaresWebPresenter) Output(p interfaces.PokerSquaresGame, lastEr
 
 // ActionLogOutput は棋譜を JSON で出力する。
 func (pr *PokerSquaresWebPresenter) ActionLogOutput(p interfaces.PokerSquaresGame) string {
-	if p.GetPhase() == domain.PokerSquaresPhasePlaying {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(p.GetActionLog())
+	return actionLogOutputJSON(p)
 }

--- a/internal/adapter/presenter/PokerSquaresWebPresenter_test.go
+++ b/internal/adapter/presenter/PokerSquaresWebPresenter_test.go
@@ -87,6 +87,7 @@ func TestPokerSquaresWebPresenter_Output_Complete(t *testing.T) {
 func TestPokerSquaresWebPresenter_ActionLog_Playing(t *testing.T) {
 	pg := new(interfaces.MockPokerSquaresGame)
 	pg.On("GetPhase").Return(domain.PokerSquaresPhasePlaying)
+	pg.On("GetGameEndFlag").Return(false)
 	p := &PokerSquaresWebPresenter{}
 	result := p.ActionLogOutput(pg)
 	assert.Contains(t, result, "entries")
@@ -95,6 +96,7 @@ func TestPokerSquaresWebPresenter_ActionLog_Playing(t *testing.T) {
 func TestPokerSquaresWebPresenter_ActionLog_Complete(t *testing.T) {
 	pg := new(interfaces.MockPokerSquaresGame)
 	pg.On("GetPhase").Return(domain.PokerSquaresPhaseComplete)
+	pg.On("GetGameEndFlag").Return(true)
 	pg.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, ActionType: "place", Detail: "test"},
 	})

--- a/internal/adapter/presenter/PyramidWebPresenter.go
+++ b/internal/adapter/presenter/PyramidWebPresenter.go
@@ -105,9 +105,5 @@ func (pr *PyramidWebPresenter) HintOutput(p interfaces.PyramidGame) string {
 
 // ActionLogOutput 棋譜をJSON出力
 func (pr *PyramidWebPresenter) ActionLogOutput(p interfaces.PyramidGame) string {
-	phase := p.GetPhase()
-	if phase == domain.PyramidPhasePlaying {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(p.GetActionLog())
+	return actionLogOutputJSON(p)
 }

--- a/internal/adapter/presenter/PyramidWebPresenter_test.go
+++ b/internal/adapter/presenter/PyramidWebPresenter_test.go
@@ -224,6 +224,7 @@ func TestPyramidWebPresenterActionLogOutput_Playing(t *testing.T) {
 	pg := new(interfaces.MockPyramidGame)
 	pg.On("GetPhase").Return(domain.PyramidPhasePlaying)
 
+	pg.On("GetGameEndFlag").Return(false)
 	p := &PyramidWebPresenter{}
 	result := p.ActionLogOutput(pg)
 	assert.Contains(t, result, "entries")
@@ -232,6 +233,7 @@ func TestPyramidWebPresenterActionLogOutput_Playing(t *testing.T) {
 func TestPyramidWebPresenterActionLogOutput_GameOver(t *testing.T) {
 	pg := new(interfaces.MockPyramidGame)
 	pg.On("GetPhase").Return(domain.PyramidPhaseGameOver)
+	pg.On("GetGameEndFlag").Return(true)
 	pg.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, ActionType: "draw", Detail: "test"},
 	})

--- a/internal/adapter/presenter/ScorpionWebPresenter.go
+++ b/internal/adapter/presenter/ScorpionWebPresenter.go
@@ -57,10 +57,7 @@ func (p *ScorpionWebPresenter) HintOutput(s interfaces.ScorpionGame) string {
 
 // ActionLogOutput 棋譜をJSON出力
 func (p *ScorpionWebPresenter) ActionLogOutput(s interfaces.ScorpionGame) string {
-	if s.GetPhase() == domain.ScorpionPhasePlaying {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(s.GetActionLog())
+	return actionLogOutputJSON(s)
 }
 
 // buildBase は共通フィールドを詰めたレスポンスオブジェクトを返す

--- a/internal/adapter/presenter/ScorpionWebPresenter_test.go
+++ b/internal/adapter/presenter/ScorpionWebPresenter_test.go
@@ -142,6 +142,7 @@ func TestScorpionWebPresenter_ActionLogOutput(t *testing.T) {
 		sg := new(interfaces.MockScorpionGame)
 		sg.On("GetPhase").Return(domain.ScorpionPhasePlaying)
 
+		sg.On("GetGameEndFlag").Return(false)
 		p := new(ScorpionWebPresenter)
 		result := p.ActionLogOutput(sg)
 		assert.Contains(t, result, "entries")
@@ -150,6 +151,7 @@ func TestScorpionWebPresenter_ActionLogOutput(t *testing.T) {
 	t.Run("game over", func(t *testing.T) {
 		sg := new(interfaces.MockScorpionGame)
 		sg.On("GetPhase").Return(domain.ScorpionPhaseGameOver)
+		sg.On("GetGameEndFlag").Return(true)
 		sg.On("GetActionLog").Return([]*domain.ActionLogEntry{{TurnNumber: 1, ActionType: "move"}})
 
 		p := new(ScorpionWebPresenter)

--- a/internal/adapter/presenter/SpiderWebPresenter.go
+++ b/internal/adapter/presenter/SpiderWebPresenter.go
@@ -103,9 +103,5 @@ func (p *SpiderWebPresenter) HintOutput(s interfaces.SpiderGame) string {
 
 // ActionLogOutput 棋譜をJSON出力
 func (p *SpiderWebPresenter) ActionLogOutput(s interfaces.SpiderGame) string {
-	phase := s.GetPhase()
-	if phase == domain.SpiderPhasePlaying {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(s.GetActionLog())
+	return actionLogOutputJSON(s)
 }

--- a/internal/adapter/presenter/SpiderWebPresenter_test.go
+++ b/internal/adapter/presenter/SpiderWebPresenter_test.go
@@ -271,6 +271,7 @@ func TestSpiderWebPresenter_ActionLogOutput(t *testing.T) {
 		sg := new(interfaces.MockSpiderGame)
 		sg.On("GetPhase").Return(domain.SpiderPhasePlaying)
 
+		sg.On("GetGameEndFlag").Return(false)
 		p := new(SpiderWebPresenter)
 		result := p.ActionLogOutput(sg)
 		var out controller.ActionLogWebOutput
@@ -282,6 +283,7 @@ func TestSpiderWebPresenter_ActionLogOutput(t *testing.T) {
 	t.Run("after game clear", func(t *testing.T) {
 		sg := new(interfaces.MockSpiderGame)
 		sg.On("GetPhase").Return(domain.SpiderPhaseGameClear)
+		sg.On("GetGameEndFlag").Return(true)
 		sg.On("GetActionLog").Return([]*domain.ActionLogEntry{
 			{TurnNumber: 1, PlayerIdx: 0, ActionType: "move", Detail: "test", Cards: nil},
 		})
@@ -297,6 +299,7 @@ func TestSpiderWebPresenter_ActionLogOutput(t *testing.T) {
 	t.Run("after game over", func(t *testing.T) {
 		sg := new(interfaces.MockSpiderGame)
 		sg.On("GetPhase").Return(domain.SpiderPhaseGameOver)
+		sg.On("GetGameEndFlag").Return(true)
 		sg.On("GetActionLog").Return([]*domain.ActionLogEntry{})
 
 		p := new(SpiderWebPresenter)

--- a/internal/adapter/presenter/SpiteAndMaliceWebPresenter.go
+++ b/internal/adapter/presenter/SpiteAndMaliceWebPresenter.go
@@ -54,10 +54,7 @@ func (p *SpiteAndMaliceWebPresenter) HintOutput(g interfaces.SpiteAndMaliceGame)
 
 // ActionLogOutput 棋譜を JSON 出力
 func (p *SpiteAndMaliceWebPresenter) ActionLogOutput(g interfaces.SpiteAndMaliceGame) string {
-	if g.GetPhase() == domain.SpiteAndMalicePhasePlaying {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(g.GetActionLog())
+	return actionLogOutputJSON(g)
 }
 
 // buildBase は共通フィールドを詰めたレスポンスオブジェクトを返す

--- a/internal/adapter/presenter/SpiteAndMaliceWebPresenter_test.go
+++ b/internal/adapter/presenter/SpiteAndMaliceWebPresenter_test.go
@@ -212,11 +212,13 @@ func TestSpiteAndMaliceWebPresenter_ActionLogOutput(t *testing.T) {
 	t.Run("playing", func(t *testing.T) {
 		g := new(interfaces.MockSpiteAndMaliceGame)
 		g.On("GetPhase").Return(domain.SpiteAndMalicePhasePlaying)
+		g.On("GetGameEndFlag").Return(false)
 		assert.NotEmpty(t, new(SpiteAndMaliceWebPresenter).ActionLogOutput(g))
 	})
 	t.Run("game over", func(t *testing.T) {
 		g := new(interfaces.MockSpiteAndMaliceGame)
 		g.On("GetPhase").Return(domain.SpiteAndMalicePhaseGameOver)
+		g.On("GetGameEndFlag").Return(true)
 		g.On("GetActionLog").Return([]*domain.ActionLogEntry{{TurnNumber: 1, ActionType: "playHand"}})
 		assert.NotEmpty(t, new(SpiteAndMaliceWebPresenter).ActionLogOutput(g))
 	})

--- a/internal/adapter/presenter/TriPeaksWebPresenter.go
+++ b/internal/adapter/presenter/TriPeaksWebPresenter.go
@@ -106,9 +106,5 @@ func (pr *TriPeaksWebPresenter) HintOutput(t interfaces.TriPeaksGame) string {
 
 // ActionLogOutput 棋譜をJSON出力
 func (pr *TriPeaksWebPresenter) ActionLogOutput(t interfaces.TriPeaksGame) string {
-	phase := t.GetPhase()
-	if phase == domain.TriPeaksPhasePlaying {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(t.GetActionLog())
+	return actionLogOutputJSON(t)
 }

--- a/internal/adapter/presenter/TriPeaksWebPresenter_test.go
+++ b/internal/adapter/presenter/TriPeaksWebPresenter_test.go
@@ -201,6 +201,7 @@ func TestTriPeaksWebPresenterActionLogOutput(t *testing.T) {
 		tg := new(interfaces.MockTriPeaksGame)
 		tg.On("GetPhase").Return(domain.TriPeaksPhasePlaying)
 
+		tg.On("GetGameEndFlag").Return(false)
 		p := &TriPeaksWebPresenter{}
 		result := p.ActionLogOutput(tg)
 		assert.Contains(t, result, "entries")
@@ -209,6 +210,7 @@ func TestTriPeaksWebPresenterActionLogOutput(t *testing.T) {
 	t.Run("game over", func(t *testing.T) {
 		tg := new(interfaces.MockTriPeaksGame)
 		tg.On("GetPhase").Return(domain.TriPeaksPhaseGameOver)
+		tg.On("GetGameEndFlag").Return(true)
 		tg.On("GetActionLog").Return([]*domain.ActionLogEntry{})
 
 		p := &TriPeaksWebPresenter{}

--- a/internal/adapter/presenter/YukonWebPresenter.go
+++ b/internal/adapter/presenter/YukonWebPresenter.go
@@ -105,9 +105,5 @@ func (p *YukonWebPresenter) HintOutput(y interfaces.YukonGame) string {
 
 // ActionLogOutput 棋譜をJSON出力
 func (p *YukonWebPresenter) ActionLogOutput(y interfaces.YukonGame) string {
-	phase := y.GetPhase()
-	if phase == domain.YukonPhasePlaying {
-		return actionLogToJSON(nil)
-	}
-	return actionLogToJSON(y.GetActionLog())
+	return actionLogOutputJSON(y)
 }

--- a/internal/adapter/presenter/YukonWebPresenter_test.go
+++ b/internal/adapter/presenter/YukonWebPresenter_test.go
@@ -183,6 +183,7 @@ func TestYukonWebPresenter_ActionLogOutput(t *testing.T) {
 		yg := new(interfaces.MockYukonGame)
 		yg.On("GetPhase").Return(domain.YukonPhasePlaying)
 
+		yg.On("GetGameEndFlag").Return(false)
 		p := new(YukonWebPresenter)
 		result := p.ActionLogOutput(yg)
 		assert.Contains(t, result, "entries")
@@ -191,6 +192,7 @@ func TestYukonWebPresenter_ActionLogOutput(t *testing.T) {
 	t.Run("game over", func(t *testing.T) {
 		yg := new(interfaces.MockYukonGame)
 		yg.On("GetPhase").Return(domain.YukonPhaseGameOver)
+		yg.On("GetGameEndFlag").Return(true)
 		yg.On("GetActionLog").Return([]*domain.ActionLogEntry{
 			{TurnNumber: 1, ActionType: "move"},
 		})

--- a/internal/domain/Accordion.go
+++ b/internal/domain/Accordion.go
@@ -207,6 +207,9 @@ func (a *Accordion) GetPileCount() int { return len(a.piles) }
 // GetActionLog 棋譜取得
 func (a *Accordion) GetActionLog() []*ActionLogEntry { return a.actionLog }
 
+// GetGameEndFlag returns true once the game has left the playing phase.
+func (a *Accordion) GetGameEndFlag() bool { return a.phase != AccordionPhasePlaying }
+
 // IsStalemate 手詰まり状態取得
 func (a *Accordion) IsStalemate() bool { return a.isStalemate }
 

--- a/internal/domain/Calculation.go
+++ b/internal/domain/Calculation.go
@@ -317,6 +317,9 @@ func (c *Calculation) GetFoundations() [CalculationFoundationCnt][]*Card { retur
 // GetActionLog 棋譜取得
 func (c *Calculation) GetActionLog() []*ActionLogEntry { return c.actionLog }
 
+// GetGameEndFlag returns true once the game has left the playing phase.
+func (c *Calculation) GetGameEndFlag() bool { return c.phase != CalculationPhasePlaying }
+
 // IsStalemate 手詰まり状態取得
 func (c *Calculation) IsStalemate() bool { return c.isStalemate }
 

--- a/internal/domain/Canfield.go
+++ b/internal/domain/Canfield.go
@@ -446,6 +446,9 @@ func (c *Canfield) GetFoundation() [CanfieldFoundationCnt][]*Card { return c.fou
 // GetActionLog 棋譜取得
 func (c *Canfield) GetActionLog() []*ActionLogEntry { return c.actionLog }
 
+// GetGameEndFlag returns true once the game has left the playing phase.
+func (c *Canfield) GetGameEndFlag() bool { return c.phase != CanfieldPhasePlaying }
+
 // GetBaseRank ベースランク取得
 func (c *Canfield) GetBaseRank() int { return c.baseRank }
 

--- a/internal/domain/ClockSolitaire.go
+++ b/internal/domain/ClockSolitaire.go
@@ -206,6 +206,9 @@ func (cs *ClockSolitaire) GetActionLog() []*ActionLogEntry {
 	return cs.actionLog
 }
 
+// GetGameEndFlag returns true once the game has left the playing phase.
+func (cs *ClockSolitaire) GetGameEndFlag() bool { return cs.phase != ClockSolitairePhasePlaying }
+
 // clockSolitaireJSON is the JSON wire format for ClockSolitaire.
 type clockSolitaireJSON struct {
 	TrumpCards  *TrumpCards                                    `json:"tc"`

--- a/internal/domain/FortyThieves.go
+++ b/internal/domain/FortyThieves.go
@@ -414,6 +414,9 @@ func (ft *FortyThieves) GetFoundation() [FortyThievesFoundationCnt][]*Card { ret
 // GetActionLog 棋譜取得
 func (ft *FortyThieves) GetActionLog() []*ActionLogEntry { return ft.actionLog }
 
+// GetGameEndFlag returns true once the game has left the playing phase.
+func (ft *FortyThieves) GetGameEndFlag() bool { return ft.phase != FortyThievesPhasePlaying }
+
 // IsStalemate 手詰まり状態取得
 func (ft *FortyThieves) IsStalemate() bool { return ft.isStalemate }
 

--- a/internal/domain/FreeCell.go
+++ b/internal/domain/FreeCell.go
@@ -590,6 +590,9 @@ func (f *FreeCell) GetFoundation() [FreeCellFoundationCnt][]*Card { return f.fou
 // GetActionLog 棋譜取得
 func (f *FreeCell) GetActionLog() []*ActionLogEntry { return f.actionLog }
 
+// GetGameEndFlag returns true once the game has left the playing phase.
+func (f *FreeCell) GetGameEndFlag() bool { return f.phase != FreeCellPhasePlaying }
+
 // IsStalemate 手詰まり状態取得
 func (f *FreeCell) IsStalemate() bool { return f.isStalemate }
 

--- a/internal/domain/Golf.go
+++ b/internal/domain/Golf.go
@@ -276,6 +276,9 @@ func (g *Golf) GetLayout() [GolfColCnt][GolfRowCnt]*GolfCard {
 // GetActionLog 棋譜取得
 func (g *Golf) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
+// GetGameEndFlag returns true once the game has left the playing phase.
+func (g *Golf) GetGameEndFlag() bool { return g.phase != GolfPhasePlaying }
+
 // IsStalemate 手詰まり状態取得
 func (g *Golf) IsStalemate() bool { return g.isStalemate }
 

--- a/internal/domain/Klondike.go
+++ b/internal/domain/Klondike.go
@@ -518,6 +518,9 @@ func (k *Klondike) GetFoundation() [KlondikeFoundationCnt][]*Card { return k.fou
 // GetActionLog 棋譜取得
 func (k *Klondike) GetActionLog() []*ActionLogEntry { return k.actionLog }
 
+// GetGameEndFlag returns true once the game has left the playing phase.
+func (k *Klondike) GetGameEndFlag() bool { return k.phase != KlondikePhasePlaying }
+
 // IsStalemate 手詰まり状態取得
 func (k *Klondike) IsStalemate() bool { return k.isStalemate }
 

--- a/internal/domain/Nertz.go
+++ b/internal/domain/Nertz.go
@@ -865,6 +865,9 @@ func (g *Nertz) SetFoundations(fs []*NertzFoundation) { g.foundations = fs }
 // GetActionLog 棋譜
 func (g *Nertz) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
+// GetGameEndFlag returns true once the game has left the playing phase.
+func (g *Nertz) GetGameEndFlag() bool { return g.phase != NertzPhasePlaying }
+
 // GetMoveCount 手数
 func (g *Nertz) GetMoveCount() int { return g.moveCount }
 

--- a/internal/domain/PokerSquares.go
+++ b/internal/domain/PokerSquares.go
@@ -175,6 +175,9 @@ func (p *PokerSquares) SetPlacedCount(n int) { p.placedCount = n }
 // GetActionLog は棋譜を返す。
 func (p *PokerSquares) GetActionLog() []*ActionLogEntry { return p.actionLog }
 
+// GetGameEndFlag returns true once the game has left the playing phase.
+func (p *PokerSquares) GetGameEndFlag() bool { return p.phase != PokerSquaresPhasePlaying }
+
 // IsComplete はゲームが完了したかを返す。
 func (p *PokerSquares) IsComplete() bool {
 	return p.placedCount >= PokerSquaresTotalCells

--- a/internal/domain/Pyramid.go
+++ b/internal/domain/Pyramid.go
@@ -388,6 +388,9 @@ func (p *Pyramid) GetPyramid() [PyramidRowCnt][]*PyramidCard { return p.pyramid 
 // GetActionLog 棋譜取得
 func (p *Pyramid) GetActionLog() []*ActionLogEntry { return p.actionLog }
 
+// GetGameEndFlag returns true once the game has left the playing phase.
+func (p *Pyramid) GetGameEndFlag() bool { return p.phase != PyramidPhasePlaying }
+
 // IsStalemate 手詰まり状態取得
 func (p *Pyramid) IsStalemate() bool { return p.isStalemate }
 

--- a/internal/domain/Scorpion.go
+++ b/internal/domain/Scorpion.go
@@ -395,6 +395,9 @@ func (s *Scorpion) GetCompletedSuits() int { return s.completedSuits }
 // GetActionLog 棋譜取得
 func (s *Scorpion) GetActionLog() []*ActionLogEntry { return s.actionLog }
 
+// GetGameEndFlag returns true once the game has left the playing phase.
+func (s *Scorpion) GetGameEndFlag() bool { return s.phase != ScorpionPhasePlaying }
+
 // IsStalemate 手詰まり状態取得
 func (s *Scorpion) IsStalemate() bool { return s.isStalemate }
 

--- a/internal/domain/Spider.go
+++ b/internal/domain/Spider.go
@@ -413,6 +413,9 @@ func (s *Spider) GetCompletedSuits() int { return s.completedSuits }
 // GetActionLog 棋譜取得
 func (s *Spider) GetActionLog() []*ActionLogEntry { return s.actionLog }
 
+// GetGameEndFlag returns true once the game has left the playing phase.
+func (s *Spider) GetGameEndFlag() bool { return s.phase != SpiderPhasePlaying }
+
 // IsStalemate 手詰まり状態取得
 func (s *Spider) IsStalemate() bool { return s.isStalemate }
 

--- a/internal/domain/SpiteAndMalice.go
+++ b/internal/domain/SpiteAndMalice.go
@@ -339,6 +339,9 @@ func (s *SpiteAndMalice) GetPlayer(idx int) *SpiteAndMalicePlayer {
 // GetActionLog 棋譜取得
 func (s *SpiteAndMalice) GetActionLog() []*ActionLogEntry { return s.actionLog }
 
+// GetGameEndFlag returns true once the game has left the playing phase.
+func (s *SpiteAndMalice) GetGameEndFlag() bool { return s.phase != SpiteAndMalicePhasePlaying }
+
 // GetConfig 設定取得
 func (s *SpiteAndMalice) GetConfig() SpiteAndMaliceConfig { return s.config }
 

--- a/internal/domain/TriPeaks.go
+++ b/internal/domain/TriPeaks.go
@@ -335,6 +335,9 @@ func (t *TriPeaks) GetLayout() [TriPeaksRowCnt][TriPeaksColCnt]*TriPeaksCard {
 // GetActionLog 棋譜取得
 func (t *TriPeaks) GetActionLog() []*ActionLogEntry { return t.actionLog }
 
+// GetGameEndFlag returns true once the game has left the playing phase.
+func (t *TriPeaks) GetGameEndFlag() bool { return t.phase != TriPeaksPhasePlaying }
+
 // IsStalemate 手詰まり状態取得
 func (t *TriPeaks) IsStalemate() bool { return t.isStalemate }
 

--- a/internal/domain/Yukon.go
+++ b/internal/domain/Yukon.go
@@ -347,6 +347,9 @@ func (y *Yukon) GetFoundation() [YukonFoundationCnt][]*Card { return y.foundatio
 // GetActionLog 棋譜取得
 func (y *Yukon) GetActionLog() []*ActionLogEntry { return y.actionLog }
 
+// GetGameEndFlag returns true once the game has left the playing phase.
+func (y *Yukon) GetGameEndFlag() bool { return y.phase != YukonPhasePlaying }
+
 // IsStalemate 手詰まり状態取得
 func (y *Yukon) IsStalemate() bool { return y.isStalemate }
 

--- a/internal/domain/interfaces/accordion.go
+++ b/internal/domain/interfaces/accordion.go
@@ -5,6 +5,8 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 // AccordionGame アコーディオンゲームインタフェース
 type AccordionGame interface {
 	BaseGame
+	// GetGameEndFlag reports whether the game has left the playing phase.
+	GetGameEndFlag() bool
 	// Reset ゲームを初期化する
 	Reset()
 	// Move fromIdx のパイルを toIdx のパイルに重ねる

--- a/internal/domain/interfaces/accordion_mock.go
+++ b/internal/domain/interfaces/accordion_mock.go
@@ -92,3 +92,9 @@ func (_m *MockAccordionGame) GetActionLog() []*domain.ActionLogEntry {
 	}
 	return v.([]*domain.ActionLogEntry)
 }
+
+// GetGameEndFlag mocks the GetGameEndFlag call.
+func (_m *MockAccordionGame) GetGameEndFlag() bool {
+	ret := _m.Called()
+	return ret.Bool(0)
+}

--- a/internal/domain/interfaces/calculation.go
+++ b/internal/domain/interfaces/calculation.go
@@ -5,6 +5,8 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 // CalculationGame カルキュレーションゲームインタフェース
 type CalculationGame interface {
 	SolitaireGame
+	// GetGameEndFlag reports whether the game has left the playing phase.
+	GetGameEndFlag() bool
 	// Reset ゲームを初期化する
 	Reset()
 	// PlayStockToFoundation ストック最上段をファンデーションに置く

--- a/internal/domain/interfaces/calculation_mock.go
+++ b/internal/domain/interfaces/calculation_mock.go
@@ -83,3 +83,9 @@ func (_m *MockCalculationGame) GetActionLog() []*domain.ActionLogEntry {
 	}
 	return v.([]*domain.ActionLogEntry)
 }
+
+// GetGameEndFlag mocks the GetGameEndFlag call.
+func (_m *MockCalculationGame) GetGameEndFlag() bool {
+	ret := _m.Called()
+	return ret.Bool(0)
+}

--- a/internal/domain/interfaces/canfield.go
+++ b/internal/domain/interfaces/canfield.go
@@ -5,6 +5,8 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 // CanfieldGame キャンフィールドゲームインタフェース
 type CanfieldGame interface {
 	BaseGame
+	// GetGameEndFlag reports whether the game has left the playing phase.
+	GetGameEndFlag() bool
 	// Reset ゲームを初期化する
 	Reset()
 	// Draw 山札からカードをめくる

--- a/internal/domain/interfaces/canfield_mock.go
+++ b/internal/domain/interfaces/canfield_mock.go
@@ -137,3 +137,9 @@ func (_m *MockCanfieldGame) GetActionLog() []*domain.ActionLogEntry {
 	}
 	return v.([]*domain.ActionLogEntry)
 }
+
+// GetGameEndFlag mocks the GetGameEndFlag call.
+func (_m *MockCanfieldGame) GetGameEndFlag() bool {
+	ret := _m.Called()
+	return ret.Bool(0)
+}

--- a/internal/domain/interfaces/clocksolitaire.go
+++ b/internal/domain/interfaces/clocksolitaire.go
@@ -5,6 +5,8 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 // ClockSolitaireGame クロックソリティアゲームインタフェース
 type ClockSolitaireGame interface {
 	BaseGame
+	// GetGameEndFlag reports whether the game has left the playing phase.
+	GetGameEndFlag() bool
 	// Reset ゲームを初期化する
 	Reset()
 	// Step 1ステップ実行する

--- a/internal/domain/interfaces/clocksolitaire_mock.go
+++ b/internal/domain/interfaces/clocksolitaire_mock.go
@@ -64,3 +64,9 @@ func (_m *MockClockSolitaireGame) GetActionLog() []*domain.ActionLogEntry {
 	}
 	return v.([]*domain.ActionLogEntry)
 }
+
+// GetGameEndFlag mocks the GetGameEndFlag call.
+func (_m *MockClockSolitaireGame) GetGameEndFlag() bool {
+	ret := _m.Called()
+	return ret.Bool(0)
+}

--- a/internal/domain/interfaces/fortythieves.go
+++ b/internal/domain/interfaces/fortythieves.go
@@ -5,6 +5,8 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 // FortyThievesGame フォーティシーブスゲームインタフェース
 type FortyThievesGame interface {
 	SolitaireGame
+	// GetGameEndFlag reports whether the game has left the playing phase.
+	GetGameEndFlag() bool
 	// Reset ゲームを初期化する
 	Reset()
 	// Draw 山札からカードをめくる

--- a/internal/domain/interfaces/fortythieves_mock.go
+++ b/internal/domain/interfaces/fortythieves_mock.go
@@ -132,3 +132,9 @@ func (_m *MockFortyThievesGame) IsStalemate() bool {
 	ret := _m.Called()
 	return ret.Bool(0)
 }
+
+// GetGameEndFlag mocks the GetGameEndFlag call.
+func (_m *MockFortyThievesGame) GetGameEndFlag() bool {
+	ret := _m.Called()
+	return ret.Bool(0)
+}

--- a/internal/domain/interfaces/freecell.go
+++ b/internal/domain/interfaces/freecell.go
@@ -5,6 +5,8 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 // FreeCellGame フリーセルゲームインタフェース
 type FreeCellGame interface {
 	SolitaireGame
+	// GetGameEndFlag reports whether the game has left the playing phase.
+	GetGameEndFlag() bool
 	// Reset ゲームを初期化する
 	Reset()
 	// MoveTableauToTableau タブロー間でカードを移動する

--- a/internal/domain/interfaces/freecell_mock.go
+++ b/internal/domain/interfaces/freecell_mock.go
@@ -118,3 +118,9 @@ func (_m *MockFreeCellGame) IsStalemate() bool {
 	ret := _m.Called()
 	return ret.Bool(0)
 }
+
+// GetGameEndFlag mocks the GetGameEndFlag call.
+func (_m *MockFreeCellGame) GetGameEndFlag() bool {
+	ret := _m.Called()
+	return ret.Bool(0)
+}

--- a/internal/domain/interfaces/golf.go
+++ b/internal/domain/interfaces/golf.go
@@ -5,6 +5,8 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 // GolfGame ゴルフソリティアゲームインタフェース
 type GolfGame interface {
 	BaseGame
+	// GetGameEndFlag reports whether the game has left the playing phase.
+	GetGameEndFlag() bool
 	// Reset ゲームを初期化する
 	Reset()
 	// Draw 山札からカードをめくる

--- a/internal/domain/interfaces/golf_mock.go
+++ b/internal/domain/interfaces/golf_mock.go
@@ -112,3 +112,9 @@ func (_m *MockGolfGame) IsStalemate() bool {
 	ret := _m.Called()
 	return ret.Get(0).(bool)
 }
+
+// GetGameEndFlag mocks the GetGameEndFlag call.
+func (_m *MockGolfGame) GetGameEndFlag() bool {
+	ret := _m.Called()
+	return ret.Bool(0)
+}

--- a/internal/domain/interfaces/klondike.go
+++ b/internal/domain/interfaces/klondike.go
@@ -5,6 +5,8 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 // KlondikeGame クロンダイクゲームインタフェース
 type KlondikeGame interface {
 	SolitaireGame
+	// GetGameEndFlag reports whether the game has left the playing phase.
+	GetGameEndFlag() bool
 	// Reset ゲームを初期化する
 	Reset()
 	// ResetWithConfig 指定設定でゲームを初期化する

--- a/internal/domain/interfaces/klondike_mock.go
+++ b/internal/domain/interfaces/klondike_mock.go
@@ -151,3 +151,9 @@ func (_m *MockKlondikeGame) IsStalemate() bool {
 	ret := _m.Called()
 	return ret.Bool(0)
 }
+
+// GetGameEndFlag mocks the GetGameEndFlag call.
+func (_m *MockKlondikeGame) GetGameEndFlag() bool {
+	ret := _m.Called()
+	return ret.Bool(0)
+}

--- a/internal/domain/interfaces/nertz.go
+++ b/internal/domain/interfaces/nertz.go
@@ -5,6 +5,8 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 // NertzGame Nertz / Pounce ゲームインタフェース
 type NertzGame interface {
 	BaseGame
+	// GetGameEndFlag reports whether the game has left the playing phase.
+	GetGameEndFlag() bool
 	// Reset ゲームを初期化する
 	Reset()
 	// ResetWithConfig 設定を適用してゲームを初期化する

--- a/internal/domain/interfaces/nertz_mock.go
+++ b/internal/domain/interfaces/nertz_mock.go
@@ -129,3 +129,9 @@ func (_m *MockNertzGame) GetActionLog() []*domain.ActionLogEntry {
 	}
 	return v.([]*domain.ActionLogEntry)
 }
+
+// GetGameEndFlag mocks the GetGameEndFlag call.
+func (_m *MockNertzGame) GetGameEndFlag() bool {
+	ret := _m.Called()
+	return ret.Bool(0)
+}

--- a/internal/domain/interfaces/poker_squares.go
+++ b/internal/domain/interfaces/poker_squares.go
@@ -5,6 +5,8 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 // PokerSquaresGame はポーカー・スクエアズゲームのインタフェース。
 type PokerSquaresGame interface {
 	BaseGame
+	// GetGameEndFlag reports whether the game has left the playing phase.
+	GetGameEndFlag() bool
 	// Reset ゲームを初期化する
 	Reset()
 	// Place 現在のカードをセル(row, col)に配置する

--- a/internal/domain/interfaces/poker_squares_mock.go
+++ b/internal/domain/interfaces/poker_squares_mock.go
@@ -110,3 +110,9 @@ func (_m *MockPokerSquaresGame) GetActionLog() []*domain.ActionLogEntry {
 	}
 	return v.([]*domain.ActionLogEntry)
 }
+
+// GetGameEndFlag mocks the GetGameEndFlag call.
+func (_m *MockPokerSquaresGame) GetGameEndFlag() bool {
+	ret := _m.Called()
+	return ret.Bool(0)
+}

--- a/internal/domain/interfaces/pyramid.go
+++ b/internal/domain/interfaces/pyramid.go
@@ -5,6 +5,8 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 // PyramidGame ピラミッドゲームインタフェース
 type PyramidGame interface {
 	BaseGame
+	// GetGameEndFlag reports whether the game has left the playing phase.
+	GetGameEndFlag() bool
 	// Reset ゲームを初期化する
 	Reset()
 	// Draw 山札からカードをめくる

--- a/internal/domain/interfaces/pyramid_mock.go
+++ b/internal/domain/interfaces/pyramid_mock.go
@@ -127,3 +127,9 @@ func (_m *MockPyramidGame) IsStalemate() bool {
 	ret := _m.Called()
 	return ret.Bool(0)
 }
+
+// GetGameEndFlag mocks the GetGameEndFlag call.
+func (_m *MockPyramidGame) GetGameEndFlag() bool {
+	ret := _m.Called()
+	return ret.Bool(0)
+}

--- a/internal/domain/interfaces/scorpion.go
+++ b/internal/domain/interfaces/scorpion.go
@@ -5,6 +5,8 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 // ScorpionGame スコーピオンゲームインタフェース
 type ScorpionGame interface {
 	SolitaireGame
+	// GetGameEndFlag reports whether the game has left the playing phase.
+	GetGameEndFlag() bool
 	// Reset ゲームを初期化する
 	Reset()
 	// Deal ストックから先頭3列にカードを配る

--- a/internal/domain/interfaces/scorpion_mock.go
+++ b/internal/domain/interfaces/scorpion_mock.go
@@ -108,3 +108,9 @@ func (_m *MockScorpionGame) GetActionLog() []*domain.ActionLogEntry {
 	}
 	return v.([]*domain.ActionLogEntry)
 }
+
+// GetGameEndFlag mocks the GetGameEndFlag call.
+func (_m *MockScorpionGame) GetGameEndFlag() bool {
+	ret := _m.Called()
+	return ret.Bool(0)
+}

--- a/internal/domain/interfaces/spider.go
+++ b/internal/domain/interfaces/spider.go
@@ -5,6 +5,8 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 // SpiderGame スパイダーソリティアゲームインタフェース
 type SpiderGame interface {
 	SolitaireGame
+	// GetGameEndFlag reports whether the game has left the playing phase.
+	GetGameEndFlag() bool
 	// Reset ゲームを初期化する
 	Reset()
 	// ResetWithConfig 指定設定でゲームを初期化する

--- a/internal/domain/interfaces/spider_mock.go
+++ b/internal/domain/interfaces/spider_mock.go
@@ -122,3 +122,9 @@ func (_m *MockSpiderGame) IsStalemate() bool {
 	ret := _m.Called()
 	return ret.Bool(0)
 }
+
+// GetGameEndFlag mocks the GetGameEndFlag call.
+func (_m *MockSpiderGame) GetGameEndFlag() bool {
+	ret := _m.Called()
+	return ret.Bool(0)
+}

--- a/internal/domain/interfaces/spiteandmalice.go
+++ b/internal/domain/interfaces/spiteandmalice.go
@@ -5,6 +5,8 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 // SpiteAndMaliceGame Spite & Malice ゲームインタフェース
 type SpiteAndMaliceGame interface {
 	BaseGame
+	// GetGameEndFlag reports whether the game has left the playing phase.
+	GetGameEndFlag() bool
 	// Reset ゲームを初期化する
 	Reset()
 	// PlayFromHand 手札のカードをファウンデーションに出す

--- a/internal/domain/interfaces/spiteandmalice_mock.go
+++ b/internal/domain/interfaces/spiteandmalice_mock.go
@@ -112,3 +112,9 @@ func (_m *MockSpiteAndMaliceGame) GetActionLog() []*domain.ActionLogEntry {
 	}
 	return v.([]*domain.ActionLogEntry)
 }
+
+// GetGameEndFlag mocks the GetGameEndFlag call.
+func (_m *MockSpiteAndMaliceGame) GetGameEndFlag() bool {
+	ret := _m.Called()
+	return ret.Bool(0)
+}

--- a/internal/domain/interfaces/tripeaks.go
+++ b/internal/domain/interfaces/tripeaks.go
@@ -5,6 +5,8 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 // TriPeaksGame トリピークスゲームインタフェース
 type TriPeaksGame interface {
 	BaseGame
+	// GetGameEndFlag reports whether the game has left the playing phase.
+	GetGameEndFlag() bool
 	// Reset ゲームを初期化する
 	Reset()
 	// Draw 山札からカードをめくる

--- a/internal/domain/interfaces/tripeaks_mock.go
+++ b/internal/domain/interfaces/tripeaks_mock.go
@@ -112,3 +112,9 @@ func (_m *MockTriPeaksGame) IsStalemate() bool {
 	ret := _m.Called()
 	return ret.Get(0).(bool)
 }
+
+// GetGameEndFlag mocks the GetGameEndFlag call.
+func (_m *MockTriPeaksGame) GetGameEndFlag() bool {
+	ret := _m.Called()
+	return ret.Bool(0)
+}

--- a/internal/domain/interfaces/yukon.go
+++ b/internal/domain/interfaces/yukon.go
@@ -5,6 +5,8 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 // YukonGame ユーコンゲームインタフェース
 type YukonGame interface {
 	SolitaireGame
+	// GetGameEndFlag reports whether the game has left the playing phase.
+	GetGameEndFlag() bool
 	// Reset ゲームを初期化する
 	Reset()
 	// MoveTableauToTableau タブロー間でカードを移動する

--- a/internal/domain/interfaces/yukon_mock.go
+++ b/internal/domain/interfaces/yukon_mock.go
@@ -103,3 +103,9 @@ func (_m *MockYukonGame) GetActionLog() []*domain.ActionLogEntry {
 	}
 	return v.([]*domain.ActionLogEntry)
 }
+
+// GetGameEndFlag mocks the GetGameEndFlag call.
+func (_m *MockYukonGame) GetGameEndFlag() bool {
+	ret := _m.Called()
+	return ret.Bool(0)
+}


### PR DESCRIPTION
## Summary

The 16 solitaire-family `WebPresenter` types (Accordion, Calculation, Canfield, ClockSolitaire, FortyThieves, FreeCell, Golf, Klondike, Nertz, PokerSquares, Pyramid, Scorpion, Spider, SpiteAndMalice, TriPeaks, Yukon) each carried the same 5-line `ActionLogOutput` body, while the card-game presenters call the existing `actionLogOutputJSON` helper in a single line. The helper required a `gameEndLogger` interface (`GetGameEndFlag` + `GetActionLog`) that no solitaire interface satisfied, so the duplication kept growing.

This PR makes them share the helper:

- **Domain (`internal/domain/<Game>.go`)** — adds a one-line `GetGameEndFlag() bool` to each of the 16 structs (`return g.phase != XPhasePlaying`)
- **Interfaces (`internal/domain/interfaces/<game>.go`)** — adds the matching method to each `*Game` interface
- **Mocks (`*_mock.go`)** — adds the corresponding testify mock method
- **Presenter (`internal/adapter/presenter/<Game>WebPresenter.go`)** — replaces the inline phase compare with `return actionLogOutputJSON(g)`
- **Tests** — augments existing `On("GetPhase")` stubs with a single `On("GetGameEndFlag")` stub so the new code path is covered (additive; no other assertions changed)
- **Nertz** — the long comment explaining why the log is hidden during real-time play is preserved verbatim

## Test plan

- [x] `go test -tags test ./...` — all packages green
- [x] `golangci-lint run ./...` — 0 issues
- [x] `goimports -w` on all modified files
- [x] Solitaire `ActionLogOutput` tests still cover both playing and game-end branches

Closes #1547