### PR TITLE
refactor(frontend): split NavBar logic into reusable nav hooks and language toggle

### DIFF
--- a/frontend/src/components/DesktopSidebar.tsx
+++ b/frontend/src/components/DesktopSidebar.tsx
@@ -1,10 +1,12 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useLocation } from 'react-router-dom';
 import { gameCategories, gameRoutes } from '../constants/gameRoutes';
 import { SITE_NAME } from '../constants/site';
 import { useFavoriteGames } from '../hooks/useFavoriteGames';
+import { useGameRouteSearch } from '../hooks/useGameRouteSearch';
 import { focusRingWhite } from '../styles/buttonStyles';
+import { NavLangToggle } from './nav/NavLangToggle';
 import { SoundToggle } from './SoundToggle';
 import { TutorialProgressPanel } from './tutorial/TutorialProgressPanel';
 
@@ -14,30 +16,10 @@ const routeByPath = new Map(gameRoutes.map((r) => [r.path, r]));
 /** Persistent left sidebar navigation for large desktop (≥1024px) with search, favorites, categories, and tutorial progress. */
 export function DesktopSidebar() {
   const { pathname } = useLocation();
-  const { t, i18n } = useTranslation('common');
-  const currentLang = i18n.language;
+  const { t } = useTranslation('common');
   const [searchTerm, setSearchTerm] = useState('');
   const { favorites, isFavorite, toggleFavorite } = useFavoriteGames();
-
-  /** Pre-compute bilingual names for search filtering. */
-  const searchableRoutes = useMemo(
-    () =>
-      gameRoutes.map((route) => ({
-        route,
-        ja: i18n.t(route.labelKey, { lng: 'ja', ns: 'common' }).toLowerCase(),
-        en: i18n.t(route.labelKey, { lng: 'en', ns: 'common' }).toLowerCase(),
-      })),
-    [i18n],
-  );
-
-  /** Filter game routes by bilingual name match. */
-  const filteredPaths = useMemo(() => {
-    if (!searchTerm) return null;
-    const lower = searchTerm.toLowerCase();
-    return new Set(
-      searchableRoutes.filter(({ ja, en }) => ja.includes(lower) || en.includes(lower)).map(({ route }) => route.path),
-    );
-  }, [searchTerm, searchableRoutes]);
+  const { filteredPaths } = useGameRouteSearch(searchTerm);
 
   return (
     <aside
@@ -208,26 +190,7 @@ export function DesktopSidebar() {
 
       {/* Language + Sound controls */}
       <div className="border-t border-ds-border-subtle px-3 py-2 flex items-center justify-between">
-        <div className="flex gap-0.5">
-          <button
-            type="button"
-            aria-label={t('nav.switchToJa')}
-            aria-pressed={currentLang === 'ja'}
-            onClick={() => i18n.changeLanguage('ja')}
-            className={`px-2 py-1 text-xs font-bold rounded-l transition-colors ${currentLang === 'ja' ? 'bg-ds-accent text-ds-text-on-accent' : 'bg-ds-surface-elevated text-ds-text-primary hover:bg-ds-surface-elevated-hover'}`}
-          >
-            JA
-          </button>
-          <button
-            type="button"
-            aria-label={t('nav.switchToEn')}
-            aria-pressed={currentLang === 'en'}
-            onClick={() => i18n.changeLanguage('en')}
-            className={`px-2 py-1 text-xs font-bold rounded-r transition-colors ${currentLang === 'en' ? 'bg-ds-accent text-ds-text-on-accent' : 'bg-ds-surface-elevated text-ds-text-primary hover:bg-ds-surface-elevated-hover'}`}
-          >
-            EN
-          </button>
-        </div>
+        <NavLangToggle size="sm" />
         <SoundToggle />
       </div>
     </aside>

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -1,13 +1,16 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useLocation } from 'react-router-dom';
 import { gameCategories, gameRoutes } from '../constants/gameRoutes';
 import { SITE_NAME } from '../constants/site';
 import { useIsMediumDesktop, useIsMobile } from '../hooks/useCardDimensions';
+import { useDetailsOutsideClick } from '../hooks/useDetailsOutsideClick';
 import { useFavoriteGames } from '../hooks/useFavoriteGames';
+import { useGameRouteSearch } from '../hooks/useGameRouteSearch';
+import { useNavFocusTrap } from '../hooks/useNavFocusTrap';
 import { useRecentGames } from '../hooks/useRecentGames';
 import { focusRingWhite } from '../styles/buttonStyles';
-import { getFocusableElements } from '../utils/dom';
+import { NavLangToggle } from './nav/NavLangToggle';
 import { SoundToggle } from './SoundToggle';
 import { TutorialProgressPanel } from './tutorial/TutorialProgressPanel';
 
@@ -53,46 +56,13 @@ function CloseIcon() {
   );
 }
 
-interface LangToggleProps {
-  currentLang: string;
-  i18n: { changeLanguage: (lng: string) => void };
-  t: (key: string) => string;
-}
-
-/** Language toggle buttons (JA / EN). */
-function LangToggle({ currentLang, i18n, t }: LangToggleProps) {
-  return (
-    <div className="flex gap-0.5">
-      <button
-        type="button"
-        aria-label={t('nav.switchToJa')}
-        aria-pressed={currentLang === 'ja'}
-        onClick={() => i18n.changeLanguage('ja')}
-        className={`px-3 py-2 text-xs font-bold rounded-l min-h-[44px] transition-colors ${currentLang === 'ja' ? 'bg-ds-accent text-ds-text-on-accent' : 'bg-ds-surface-elevated text-ds-text-primary hover:bg-ds-surface-elevated-hover'}`}
-      >
-        JA
-      </button>
-      <button
-        type="button"
-        aria-label={t('nav.switchToEn')}
-        aria-pressed={currentLang === 'en'}
-        onClick={() => i18n.changeLanguage('en')}
-        className={`px-3 py-2 text-xs font-bold rounded-r min-h-[44px] transition-colors ${currentLang === 'en' ? 'bg-ds-accent text-ds-text-on-accent' : 'bg-ds-surface-elevated text-ds-text-primary hover:bg-ds-surface-elevated-hover'}`}
-      >
-        EN
-      </button>
-    </div>
-  );
-}
-
 /** Lookup map from path to game route for recent/favorite rendering. */
 const routeByPath = new Map(gameRoutes.map((r) => [r.path, r]));
 
 /** Renders the top navigation bar with game links grouped by category and language toggle. */
 export function NavBar() {
   const { pathname } = useLocation();
-  const { t, i18n } = useTranslation('common');
-  const currentLang = i18n.language;
+  const { t } = useTranslation('common');
   const [isOpen, setIsOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const isMobile = useIsMobile();
@@ -101,74 +71,9 @@ export function NavBar() {
   const { favorites, isFavorite, toggleFavorite } = useFavoriteGames();
   const navRef = useRef<HTMLElement>(null);
   const toggleRef = useRef<HTMLButtonElement>(null);
-  const wasOpen = useRef(false);
 
-  useEffect(() => {
-    const justOpened = isOpen && !wasOpen.current;
-    const justClosed = !isOpen && wasOpen.current;
-    wasOpen.current = isOpen;
-
-    if (justClosed && toggleRef.current) {
-      toggleRef.current.focus();
-    }
-
-    if (!isOpen || !navRef.current) return;
-    const nav = navRef.current;
-
-    // Only move focus on the open transition; re-running the effect for a
-    // viewport resize (isMobile flip) must not steal focus from the user.
-    if (justOpened) {
-      const initial = getFocusableElements(nav)[0];
-      initial?.focus();
-    }
-
-    // Focus trap is scoped to mobile, where the menu covers the viewport
-    // like a modal. On tablet+ (sm:flex) the nav renders inline and a trap
-    // would prevent normal Tab flow into page content.
-    if (!isMobile) return;
-
-    const handleTab = (e: KeyboardEvent) => {
-      if (e.key !== 'Tab') return;
-      const focusable = getFocusableElements(nav);
-      if (focusable.length === 0) return;
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      const active = document.activeElement as HTMLElement | null;
-      if (e.shiftKey) {
-        if (active === first || !nav.contains(active)) {
-          e.preventDefault();
-          last.focus();
-        }
-      } else {
-        if (active === last || !nav.contains(active)) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    };
-
-    document.addEventListener('keydown', handleTab);
-    return () => document.removeEventListener('keydown', handleTab);
-  }, [isOpen, isMobile]);
-
-  // Close nav dropdown on outside click (large desktop only).
-  // On mobile/tablet, categories are always-open so this must be skipped
-  // to prevent a layout shift between mousedown and mouseup that causes
-  // clicks to land on the wrong game link.
-  useEffect(() => {
-    const handleOutsideClick = (e: MouseEvent) => {
-      if (isMobile || isMediumDesktop) return;
-      if (!navRef.current) return;
-      const openDetails = navRef.current.querySelectorAll('details[open]');
-      for (const details of openDetails) {
-        if (!details.contains(e.target as Node)) {
-          details.removeAttribute('open');
-        }
-      }
-    };
-    document.addEventListener('mousedown', handleOutsideClick);
-    return () => document.removeEventListener('mousedown', handleOutsideClick);
-  }, [isMobile, isMediumDesktop]);
+  useNavFocusTrap(navRef, toggleRef, isOpen, isMobile);
+  useDetailsOutsideClick(navRef, !isMobile && !isMediumDesktop);
 
   const closeMenu = useCallback(() => {
     setIsOpen(false);
@@ -181,24 +86,7 @@ export function NavBar() {
     }
   };
 
-  /** Pre-compute bilingual names for search filtering.
-   * Uses explicit lng overrides so the result is language-independent. */
-  const searchableRoutes = useMemo(
-    () =>
-      gameRoutes.map((route) => ({
-        route,
-        ja: i18n.t(route.labelKey, { lng: 'ja', ns: 'common' }).toLowerCase(),
-        en: i18n.t(route.labelKey, { lng: 'en', ns: 'common' }).toLowerCase(),
-      })),
-    [i18n.t],
-  );
-
-  /** Filter game routes by bilingual name match. */
-  const filteredRoutes = useMemo(() => {
-    if (!searchTerm) return null;
-    const lower = searchTerm.toLowerCase();
-    return searchableRoutes.filter(({ ja, en }) => ja.includes(lower) || en.includes(lower)).map(({ route }) => route);
-  }, [searchTerm, searchableRoutes]);
+  const { filteredRoutes } = useGameRouteSearch(searchTerm);
 
   return (
     <div className="glass-panel--dark lg:hidden relative z-30 pt-[env(safe-area-inset-top)] pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)]">
@@ -212,7 +100,7 @@ export function NavBar() {
         </Link>
         <div className="flex items-center gap-2">
           <SoundToggle />
-          <LangToggle currentLang={currentLang} i18n={i18n} t={t} />
+          <NavLangToggle />
           <button
             ref={toggleRef}
             type="button"
@@ -389,7 +277,7 @@ export function NavBar() {
         <TutorialProgressPanel />
         <div className="hidden sm:flex sm:items-center sm:gap-2">
           <SoundToggle />
-          <LangToggle currentLang={currentLang} i18n={i18n} t={t} />
+          <NavLangToggle />
         </div>
       </nav>
     </div>

--- a/frontend/src/components/nav/NavLangToggle.test.tsx
+++ b/frontend/src/components/nav/NavLangToggle.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import i18n from 'i18next';
+import { afterEach, describe, expect, it } from 'vitest';
+import { NavLangToggle } from './NavLangToggle';
+
+afterEach(() => {
+  i18n.changeLanguage('ja');
+});
+
+describe('NavLangToggle', () => {
+  it('renders JA and EN buttons with the project i18n labels', () => {
+    render(<NavLangToggle />);
+    expect(screen.getByRole('button', { name: i18n.t('nav.switchToJa') })).toHaveTextContent('JA');
+    expect(screen.getByRole('button', { name: i18n.t('nav.switchToEn') })).toHaveTextContent('EN');
+  });
+
+  it('marks JA as the pressed button when current language is ja (default test setup)', () => {
+    render(<NavLangToggle />);
+    expect(screen.getByRole('button', { name: i18n.t('nav.switchToJa') })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: i18n.t('nav.switchToEn') })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('switches language to en and flips aria-pressed when EN is clicked', () => {
+    render(<NavLangToggle />);
+    fireEvent.click(screen.getByRole('button', { name: i18n.t('nav.switchToEn') }));
+    expect(i18n.language).toBe('en');
+    expect(screen.getByRole('button', { name: i18n.t('nav.switchToEn') })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: i18n.t('nav.switchToJa') })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('switches back to ja and flips aria-pressed when JA is clicked', () => {
+    render(<NavLangToggle />);
+    fireEvent.click(screen.getByRole('button', { name: i18n.t('nav.switchToEn') }));
+    fireEvent.click(screen.getByRole('button', { name: i18n.t('nav.switchToJa') }));
+    expect(i18n.language).toBe('ja');
+    expect(screen.getByRole('button', { name: i18n.t('nav.switchToJa') })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: i18n.t('nav.switchToEn') })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('applies the md size classes by default (44 px touch target)', () => {
+    render(<NavLangToggle />);
+    const ja = screen.getByRole('button', { name: i18n.t('nav.switchToJa') });
+    expect(ja.className).toContain('px-3');
+    expect(ja.className).toContain('py-2');
+    expect(ja.className).toContain('min-h-[44px]');
+  });
+
+  it('applies the sm size classes when size="sm"', () => {
+    render(<NavLangToggle size="sm" />);
+    const ja = screen.getByRole('button', { name: i18n.t('nav.switchToJa') });
+    expect(ja.className).toContain('px-2');
+    expect(ja.className).toContain('py-1');
+    expect(ja.className).not.toContain('min-h-[44px]');
+  });
+});

--- a/frontend/src/components/nav/NavLangToggle.tsx
+++ b/frontend/src/components/nav/NavLangToggle.tsx
@@ -1,0 +1,43 @@
+import { useTranslation } from 'react-i18next';
+
+/** Size variant — `'md'` matches the NavBar (44 px touch target), `'sm'` matches the desktop sidebar. */
+export type NavLangToggleSize = 'sm' | 'md';
+
+interface NavLangToggleProps {
+  /** Visual size; defaults to `'md'` to preserve mobile/tablet touch target. */
+  size?: NavLangToggleSize;
+}
+
+const SIZE_CLASS: Record<NavLangToggleSize, string> = {
+  sm: 'px-2 py-1',
+  md: 'px-3 py-2 min-h-[44px]',
+};
+
+/** JA / EN language toggle pair, shared between NavBar and DesktopSidebar. */
+export function NavLangToggle({ size = 'md' }: NavLangToggleProps) {
+  const { t, i18n } = useTranslation('common');
+  const currentLang = i18n.language;
+  const sizeCls = SIZE_CLASS[size];
+  return (
+    <div className="flex gap-0.5">
+      <button
+        type="button"
+        aria-label={t('nav.switchToJa')}
+        aria-pressed={currentLang === 'ja'}
+        onClick={() => i18n.changeLanguage('ja')}
+        className={`${sizeCls} text-xs font-bold rounded-l transition-colors ${currentLang === 'ja' ? 'bg-ds-accent text-ds-text-on-accent' : 'bg-ds-surface-elevated text-ds-text-primary hover:bg-ds-surface-elevated-hover'}`}
+      >
+        JA
+      </button>
+      <button
+        type="button"
+        aria-label={t('nav.switchToEn')}
+        aria-pressed={currentLang === 'en'}
+        onClick={() => i18n.changeLanguage('en')}
+        className={`${sizeCls} text-xs font-bold rounded-r transition-colors ${currentLang === 'en' ? 'bg-ds-accent text-ds-text-on-accent' : 'bg-ds-surface-elevated text-ds-text-primary hover:bg-ds-surface-elevated-hover'}`}
+      >
+        EN
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useDetailsOutsideClick.test.ts
+++ b/frontend/src/hooks/useDetailsOutsideClick.test.ts
@@ -1,0 +1,61 @@
+import { renderHook } from '@testing-library/react';
+import { useRef } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useDetailsOutsideClick } from './useDetailsOutsideClick';
+
+describe('useDetailsOutsideClick', () => {
+  afterEach(() => {
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+  });
+
+  function setupContainer(): { container: HTMLElement; details: HTMLDetailsElement } {
+    const container = document.createElement('section');
+    const details = document.createElement('details');
+    details.setAttribute('open', '');
+    const inside = document.createElement('p');
+    inside.textContent = 'inside';
+    details.appendChild(inside);
+    container.appendChild(details);
+    document.body.appendChild(container);
+    return { container, details };
+  }
+
+  function dispatchMouseDownOutside(): void {
+    const outside = document.createElement('div');
+    document.body.appendChild(outside);
+    outside.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+  }
+
+  it('closes open details on outside mousedown when enabled', () => {
+    const { container, details } = setupContainer();
+    renderHook(() => {
+      const ref = useRef(container);
+      useDetailsOutsideClick(ref, true);
+    });
+    dispatchMouseDownOutside();
+    expect(details.hasAttribute('open')).toBe(false);
+  });
+
+  it('leaves details open when disabled', () => {
+    const { container, details } = setupContainer();
+    renderHook(() => {
+      const ref = useRef(container);
+      useDetailsOutsideClick(ref, false);
+    });
+    dispatchMouseDownOutside();
+    expect(details.hasAttribute('open')).toBe(true);
+  });
+
+  it('keeps details open when the click is inside the details', () => {
+    const { container, details } = setupContainer();
+    renderHook(() => {
+      const ref = useRef(container);
+      useDetailsOutsideClick(ref, true);
+    });
+    const inner = details.querySelector('p');
+    inner?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(details.hasAttribute('open')).toBe(true);
+  });
+});

--- a/frontend/src/hooks/useDetailsOutsideClick.ts
+++ b/frontend/src/hooks/useDetailsOutsideClick.ts
@@ -1,0 +1,26 @@
+import { type RefObject, useEffect } from 'react';
+
+/**
+ * Close any open `<details>` element under `containerRef` when the user
+ * mousedowns outside that details. Only runs while `enabled` is true.
+ *
+ * The mobile/tablet nav keeps categories always-open, so the caller passes
+ * `enabled = false` on those breakpoints to avoid the layout shift between
+ * mousedown and mouseup that would otherwise land clicks on the wrong link.
+ */
+export function useDetailsOutsideClick(containerRef: RefObject<HTMLElement | null>, enabled: boolean): void {
+  useEffect(() => {
+    if (!enabled) return;
+    const handleOutsideClick = (e: MouseEvent) => {
+      if (!containerRef.current) return;
+      const openDetails = containerRef.current.querySelectorAll('details[open]');
+      for (const details of openDetails) {
+        if (!details.contains(e.target as Node)) {
+          details.removeAttribute('open');
+        }
+      }
+    };
+    document.addEventListener('mousedown', handleOutsideClick);
+    return () => document.removeEventListener('mousedown', handleOutsideClick);
+  }, [enabled, containerRef]);
+}

--- a/frontend/src/hooks/useGameRouteSearch.test.ts
+++ b/frontend/src/hooks/useGameRouteSearch.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useGameRouteSearch } from './useGameRouteSearch';
+
+describe('useGameRouteSearch', () => {
+  it('returns null arrays when search term is empty', () => {
+    const { result } = renderHook(() => useGameRouteSearch(''));
+    expect(result.current.filteredRoutes).toBeNull();
+    expect(result.current.filteredPaths).toBeNull();
+  });
+
+  it('matches against the Japanese label by default (ja test setup)', () => {
+    // The test bootstrap initializes ja translations; "ブラックジャック" is the
+    // Japanese label for blackjack. We use a substring so the test does not
+    // hard-code the exact phrase and stays robust to label tweaks.
+    const { result } = renderHook(() => useGameRouteSearch('ブラック'));
+    const routes = result.current.filteredRoutes ?? [];
+    expect(routes.length).toBeGreaterThan(0);
+    expect(routes.some((r) => r.labelKey === 'nav.blackjack')).toBe(true);
+  });
+
+  it('matches against the English label even when the active language is ja', () => {
+    // i18n test setup loads both ja and en bundles. Searching English text
+    // while ja is the active language must still match — that is the whole
+    // point of pulling both lng overrides into the searchable index.
+    const { result } = renderHook(() => useGameRouteSearch('blackjack'));
+    const routes = result.current.filteredRoutes ?? [];
+    expect(routes.some((r) => r.labelKey === 'nav.blackjack')).toBe(true);
+  });
+
+  it('returns an empty result set for unmatched input', () => {
+    const { result } = renderHook(() => useGameRouteSearch('zzz-no-such-game'));
+    expect(result.current.filteredRoutes).toEqual([]);
+    expect(result.current.filteredPaths?.size).toBe(0);
+  });
+
+  it('is case-insensitive', () => {
+    const a = renderHook(() => useGameRouteSearch('BLACKJACK')).result.current.filteredRoutes;
+    const b = renderHook(() => useGameRouteSearch('blackjack')).result.current.filteredRoutes;
+    expect(a?.length).toBe(b?.length);
+    expect(a?.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/hooks/useGameRouteSearch.ts
+++ b/frontend/src/hooks/useGameRouteSearch.ts
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { type GameRoute, gameRoutes } from '../constants/gameRoutes';
+
+/** Result of a bilingual game route search. */
+export interface UseGameRouteSearchResult {
+  /** Matching routes when `searchTerm` is non-empty, otherwise `null` (caller should fall back to its category view). */
+  filteredRoutes: GameRoute[] | null;
+  /** Set of paths that match — convenience for callers like DesktopSidebar that already iterate `gameRoutes`. */
+  filteredPaths: Set<string> | null;
+}
+
+/**
+ * Filters {@link gameRoutes} by a bilingual (ja/en) substring match against
+ * each route's translated label. NavBar and DesktopSidebar both call this so
+ * the search behavior stays in lockstep when new games are added.
+ */
+export function useGameRouteSearch(searchTerm: string): UseGameRouteSearchResult {
+  const { i18n } = useTranslation('common');
+
+  const searchableRoutes = useMemo(
+    () =>
+      gameRoutes.map((route) => ({
+        route,
+        ja: i18n.t(route.labelKey, { lng: 'ja', ns: 'common' }).toLowerCase(),
+        en: i18n.t(route.labelKey, { lng: 'en', ns: 'common' }).toLowerCase(),
+      })),
+    [i18n],
+  );
+
+  return useMemo(() => {
+    if (!searchTerm) return { filteredRoutes: null, filteredPaths: null };
+    const lower = searchTerm.toLowerCase();
+    const matches = searchableRoutes
+      .filter(({ ja, en }) => ja.includes(lower) || en.includes(lower))
+      .map(({ route }) => route);
+    return {
+      filteredRoutes: matches,
+      filteredPaths: new Set(matches.map((r) => r.path)),
+    };
+  }, [searchTerm, searchableRoutes]);
+}

--- a/frontend/src/hooks/useGameRouteSearch.ts
+++ b/frontend/src/hooks/useGameRouteSearch.ts
@@ -18,6 +18,9 @@ export interface UseGameRouteSearchResult {
 export function useGameRouteSearch(searchTerm: string): UseGameRouteSearchResult {
   const { i18n } = useTranslation('common');
 
+  // Both i18n.t calls pass explicit lng overrides, so the index is language-
+  // independent. Depending on i18n.t (not the whole i18n instance) keeps the
+  // index from rebuilding on every JA ↔ EN toggle (PR #1572 review).
   const searchableRoutes = useMemo(
     () =>
       gameRoutes.map((route) => ({
@@ -25,7 +28,7 @@ export function useGameRouteSearch(searchTerm: string): UseGameRouteSearchResult
         ja: i18n.t(route.labelKey, { lng: 'ja', ns: 'common' }).toLowerCase(),
         en: i18n.t(route.labelKey, { lng: 'en', ns: 'common' }).toLowerCase(),
       })),
-    [i18n],
+    [i18n.t],
   );
 
   return useMemo(() => {

--- a/frontend/src/hooks/useNavFocusTrap.test.ts
+++ b/frontend/src/hooks/useNavFocusTrap.test.ts
@@ -1,0 +1,139 @@
+import { renderHook } from '@testing-library/react';
+import { useRef } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useNavFocusTrap } from './useNavFocusTrap';
+
+interface SetupOptions {
+  isOpen: boolean;
+  isActive: boolean;
+  /** Pre-set the toggle button as the document's active element before the effect runs. */
+  toggleStartsFocused?: boolean;
+}
+
+interface SetupResult {
+  container: HTMLElement;
+  toggle: HTMLButtonElement;
+  buttons: HTMLButtonElement[];
+  rerender: (props: SetupOptions) => void;
+}
+
+/** Sets up a nav container with three buttons + an out-of-nav toggle button. */
+function setup(initial: SetupOptions): SetupResult {
+  const toggle = document.createElement('button');
+  toggle.textContent = 'toggle';
+  document.body.appendChild(toggle);
+
+  const container = document.createElement('nav');
+  const buttons: HTMLButtonElement[] = [];
+  for (const label of ['first', 'second', 'last']) {
+    const btn = document.createElement('button');
+    btn.textContent = label;
+    container.appendChild(btn);
+    buttons.push(btn);
+  }
+  document.body.appendChild(container);
+
+  if (initial.toggleStartsFocused) {
+    toggle.focus();
+  }
+
+  const { rerender } = renderHook(
+    ({ isOpen, isActive }: SetupOptions) => {
+      const containerRef = useRef(container);
+      const restoreRef = useRef(toggle);
+      useNavFocusTrap(containerRef, restoreRef, isOpen, isActive);
+    },
+    { initialProps: initial },
+  );
+
+  return { container, toggle, buttons, rerender };
+}
+
+function pressTab(shift = false): void {
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: shift, bubbles: true }));
+}
+
+describe('useNavFocusTrap', () => {
+  afterEach(() => {
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+  });
+
+  it('moves focus to the first focusable element when isOpen flips true', () => {
+    const { buttons, rerender } = setup({ isOpen: false, isActive: true, toggleStartsFocused: true });
+    rerender({ isOpen: true, isActive: true });
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  it('restores focus to the toggle button when isOpen flips false', () => {
+    const { toggle, rerender } = setup({ isOpen: true, isActive: true });
+    // Sanity: open transition focused the first button (not the toggle).
+    expect(document.activeElement).not.toBe(toggle);
+    rerender({ isOpen: false, isActive: true });
+    expect(document.activeElement).toBe(toggle);
+  });
+
+  it('does not install the Tab handler when isActive is false (tablet+)', () => {
+    const { buttons } = setup({ isOpen: true, isActive: false });
+    // Open-transition focus still moves to the first button…
+    expect(document.activeElement).toBe(buttons[0]);
+    // …but Tab from the last button does NOT wrap (no trap installed).
+    buttons[buttons.length - 1].focus();
+    pressTab();
+    // No preventDefault means the browser would advance focus naturally;
+    // since happy-dom does not implement Tab navigation, the active element
+    // simply stays where it was. The key assertion is that focus did NOT
+    // jump back to the first button (which would prove a trap is installed).
+    expect(document.activeElement).toBe(buttons[buttons.length - 1]);
+  });
+
+  it('wraps Tab from the last focusable element back to the first', () => {
+    const { buttons } = setup({ isOpen: true, isActive: true });
+    buttons[buttons.length - 1].focus();
+    pressTab();
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  it('wraps Shift+Tab from the first focusable element back to the last', () => {
+    const { buttons } = setup({ isOpen: true, isActive: true });
+    buttons[0].focus();
+    pressTab(true);
+    expect(document.activeElement).toBe(buttons[buttons.length - 1]);
+  });
+
+  it('wraps Tab forward when active element has escaped the container', () => {
+    // Reproduces the "focus escaped the nav" path from useNavFocusTrap.ts:56
+    // (`!container.contains(active)`). The toggle button lives outside the
+    // container, so focusing it before the Tab keydown forces that branch.
+    const { buttons, toggle } = setup({ isOpen: true, isActive: true });
+    toggle.focus();
+    pressTab();
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  it('wraps Shift+Tab to the last focusable when active element has escaped', () => {
+    const { buttons, toggle } = setup({ isOpen: true, isActive: true });
+    toggle.focus();
+    pressTab(true);
+    expect(document.activeElement).toBe(buttons[buttons.length - 1]);
+  });
+
+  it('ignores non-Tab keydown events', () => {
+    const { buttons } = setup({ isOpen: true, isActive: true });
+    buttons[1].focus();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+    // No trap re-targeting should happen for non-Tab keys.
+    expect(document.activeElement).toBe(buttons[1]);
+  });
+
+  it('does not move focus on an isActive flip while staying open', () => {
+    // Re-running the effect because of an isActive flip (viewport resize)
+    // must not steal focus from the user mid-interaction.
+    const { buttons, rerender } = setup({ isOpen: true, isActive: true });
+    buttons[1].focus();
+    rerender({ isOpen: true, isActive: false });
+    expect(document.activeElement).toBe(buttons[1]);
+  });
+});

--- a/frontend/src/hooks/useNavFocusTrap.ts
+++ b/frontend/src/hooks/useNavFocusTrap.ts
@@ -1,0 +1,66 @@
+import { type RefObject, useEffect, useRef } from 'react';
+import { getFocusableElements } from '../utils/dom';
+
+/**
+ * Mobile nav focus trap with focus restore.
+ *
+ * - When `isOpen` flips to true, focus moves to the first focusable element inside `containerRef`.
+ * - When `isOpen` flips to false, focus is restored to `restoreRef` (the toggle button).
+ * - While `isActive` (mobile only) and `isOpen` are both true, Tab/Shift+Tab cycle inside the container.
+ *
+ * The trap is intentionally skipped on tablet+ because the nav renders inline
+ * on those breakpoints and a trap would prevent normal Tab flow into page content.
+ */
+export function useNavFocusTrap(
+  containerRef: RefObject<HTMLElement | null>,
+  restoreRef: RefObject<HTMLElement | null>,
+  isOpen: boolean,
+  isActive: boolean,
+): void {
+  const wasOpen = useRef(false);
+
+  useEffect(() => {
+    const justOpened = isOpen && !wasOpen.current;
+    const justClosed = !isOpen && wasOpen.current;
+    wasOpen.current = isOpen;
+
+    if (justClosed && restoreRef.current) {
+      restoreRef.current.focus();
+    }
+
+    if (!isOpen || !containerRef.current) return;
+    const container = containerRef.current;
+
+    // Only move focus on the open transition; re-running the effect for a
+    // viewport resize (isActive flip) must not steal focus from the user.
+    if (justOpened) {
+      const initial = getFocusableElements(container)[0];
+      initial?.focus();
+    }
+
+    if (!isActive) return;
+
+    const handleTab = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      const focusable = getFocusableElements(container);
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey) {
+        if (active === first || !container.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last || !container.contains(active)) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleTab);
+    return () => document.removeEventListener('keydown', handleTab);
+  }, [isOpen, isActive, containerRef, restoreRef]);
+}


### PR DESCRIPTION
## Summary

`NavBar.tsx` had grown to 397 lines and tangled three orthogonal concerns — focus trap, outside-click closure, and bilingual game route search — alongside its rendering. `DesktopSidebar` duplicated the search-filter logic verbatim, so adding a new game required updating both files in lockstep.

This PR pulls each concern into its own hook and shares the language toggle:

- **`useGameRouteSearch`** (`src/hooks/useGameRouteSearch.ts` + test) — bilingual ja/en filter; returns both the filtered list (`GameRoute[]`) and a path `Set<string>` so NavBar and DesktopSidebar can each consume the shape they prefer
- **`useNavFocusTrap`** (`src/hooks/useNavFocusTrap.ts`) — focus restore + Tab/Shift+Tab cycling, scoped to mobile so tablet+ keeps normal Tab flow
- **`useDetailsOutsideClick`** (`src/hooks/useDetailsOutsideClick.ts` + test) — closes any open `<details>` inside the container on outside mousedown, gated by an `enabled` flag so mobile / medium-desktop keeps categories always-open
- **`nav/NavLangToggle`** (`src/components/nav/NavLangToggle.tsx`) — JA / EN button pair with a `size` variant; both NavBar and DesktopSidebar now render through it instead of duplicating the markup

`NavBar` drops from 397 lines to ~270 lines; `DesktopSidebar` drops the duplicate `searchableRoutes` memo and the inline language toggle.

## Behavioral compatibility

- No DOM structure, ARIA attributes, or `data-testid` values change — existing `NavBar.test.tsx` (192 tests) and `DesktopSidebar.test.tsx` (32 tests) pass unchanged
- New tests added: `useGameRouteSearch.test.ts` (5 cases — empty, ja match, en cross-language match, no-match, case-insensitivity) and `useDetailsOutsideClick.test.ts` (3 cases — closes when enabled, no-op when disabled, ignores inner clicks)

## Test plan

- [x] `bun run check` — biome clean (4 pre-existing warnings unrelated to this PR)
- [x] `bun run build` — succeeds
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run test -- --run NavBar` — all groups pass when run separately (full bulk-run OOMs on this 2 GB host but is unrelated to refactor; see DesktopSidebar 32/32 and language-switch test passing in isolation)
- [x] `bun run test -- --run DesktopSidebar` — 32/32 pass
- [x] `bun run test -- --run useGameRouteSearch useDetailsOutsideClick` — 8/8 pass

Closes #1551