### PR TITLE
refactor(frontend): swap text-white for text-ds-text-primary in tutorial + SettingsPanel

### DIFF
--- a/frontend/src/components/common/SettingsPanel.tsx
+++ b/frontend/src/components/common/SettingsPanel.tsx
@@ -48,7 +48,7 @@ export function SettingsPanel({ title, groups }: SettingsPanelProps) {
         </svg>
         {title}
       </summary>
-      <div className="glass-panel rounded-lg p-3 mt-1 text-xs text-white">
+      <div className="glass-panel rounded-lg p-3 mt-1 text-xs text-ds-text-primary">
         {groups.map((group, gi) => {
           const content = (
             <div className="flex flex-wrap gap-x-4 gap-y-1">

--- a/frontend/src/components/tutorial/TutorialProgressPanel.tsx
+++ b/frontend/src/components/tutorial/TutorialProgressPanel.tsx
@@ -11,7 +11,7 @@ export function TutorialProgressPanel() {
 
   return (
     <details className="glass-panel rounded-lg px-3 py-2 mx-2 mb-2">
-      <summary className="cursor-pointer text-white font-bold text-sm select-none">
+      <summary className="cursor-pointer text-ds-text-primary font-bold text-sm select-none">
         {t('progress.title', { defaultValue: 'Tutorial Progress' })} — {completedCount}/{totalCount}
       </summary>
 

--- a/frontend/src/components/tutorial/TutorialSuggestDialog.tsx
+++ b/frontend/src/components/tutorial/TutorialSuggestDialog.tsx
@@ -89,7 +89,7 @@ export function TutorialSuggestDialog({
           if (e.key === 'Escape') onSkip();
         }}
       >
-        <h2 id="suggest-dialog-title" className="text-lg font-bold text-white mb-2">
+        <h2 id="suggest-dialog-title" className="text-lg font-bold text-ds-text-primary mb-2">
           {t('firstVisit.title')}
         </h2>
         <p id="suggest-dialog-desc" className="text-ds-text-primary mb-4">

--- a/frontend/src/components/tutorial/TutorialTooltip.tsx
+++ b/frontend/src/components/tutorial/TutorialTooltip.tsx
@@ -25,7 +25,7 @@ export function TutorialTooltip({ message, stepIndex, totalSteps, onNext, onSkip
 
   return (
     <div role="status" aria-live="polite" className="glass-panel rounded-lg shadow-xl p-4 max-w-xs">
-      <p className="text-white text-sm mb-3">{message}</p>
+      <p className="text-ds-text-primary text-sm mb-3">{message}</p>
       <div className="flex items-center justify-between">
         <span className="text-ds-text-muted text-xs">
           {stepIndex + 1} / {totalSteps}


### PR DESCRIPTION
## Summary

Continues #1544's staged sweep of pure-white body text. The four remaining offenders in `src/components/tutorial/` and the `SettingsPanel` in `src/components/common/` all sit on `glass-panel` translucent surfaces where DESIGN.md's warm-ivory `--text-primary` (#E8E0D4) is the intended token, not pure `#FFFFFF`.

| File | Element |
|---|---|
| `tutorial/TutorialProgressPanel.tsx` | progress summary |
| `tutorial/TutorialSuggestDialog.tsx` | title `<h2>` |
| `tutorial/TutorialTooltip.tsx` | tooltip body `<p>` |
| `common/SettingsPanel.tsx` | description `<div>` |

These are body / label / heading text on dark glass — all match the issue's "replace" rule, and none are button-on-saturated-background contrast cases.

## Test plan

- [x] `bun run test -- --run TutorialProgressPanel TutorialSuggestDialog TutorialTooltip SettingsPanel` — 77/77 pass
- [x] `bun run check` — clean (4 pre-existing warnings unrelated)
- [x] No DOM, attribute, or text content changes; only the warm tint shift on the four labels above

Refs #1544

Remaining `text-white` count after this PR: 212 sites across pages and game-folder components, to be tackled in subsequent slices per the issue's per-folder PR plan.