### PR TITLE
refactor(frontend): swap text-white for text-ds-text-primary in shared cpu/log/equity components

### DIFF
--- a/frontend/src/components/ActionLogPanel.tsx
+++ b/frontend/src/components/ActionLogPanel.tsx
@@ -103,7 +103,7 @@ export function ActionLogPanel({ entries, onClose }: ActionLogPanelProps) {
       className="glass-panel rounded-lg p-4 my-2 max-h-[60vh] flex flex-col"
     >
       <div className="flex items-center justify-between mb-2">
-        <h3 id={titleId} className="text-white font-bold text-sm">
+        <h3 id={titleId} className="text-ds-text-primary font-bold text-sm">
           {t('actionLog.title')}
         </h3>
         <div className="flex gap-2">
@@ -121,7 +121,7 @@ export function ActionLogPanel({ entries, onClose }: ActionLogPanelProps) {
       <div data-testid="copy-announcer" aria-live="polite" aria-atomic="true" className="sr-only">
         {copied ? t('actionLog.copied') : ''}
       </div>
-      <pre className="flex-1 overflow-y-auto text-white text-xs whitespace-pre-wrap font-mono bg-black/40 rounded p-2">
+      <pre className="flex-1 overflow-y-auto text-ds-text-primary text-xs whitespace-pre-wrap font-mono bg-black/40 rounded p-2">
         {textContent}
       </pre>
     </section>

--- a/frontend/src/components/CpuAccordion.tsx
+++ b/frontend/src/components/CpuAccordion.tsx
@@ -19,7 +19,7 @@ export function CpuAccordion({ children, playerCount, dataTutorial }: CpuAccordi
       data-testid="cpu-accordion"
       {...(dataTutorial ? { 'data-tutorial': dataTutorial } : {})}
     >
-      <summary className="cursor-pointer select-none px-2 py-1.5 text-white text-sm font-bold">
+      <summary className="cursor-pointer select-none px-2 py-1.5 text-ds-text-primary text-sm font-bold">
         {t('label.cpuOpponents', { count: playerCount })}
       </summary>
       <div className="px-1 pb-1">{children}</div>

--- a/frontend/src/components/CpuActionLog.tsx
+++ b/frontend/src/components/CpuActionLog.tsx
@@ -14,7 +14,7 @@ export function CpuActionLog({ actions }: CpuActionLogProps) {
       role="log"
       aria-live="polite"
       aria-label={t('label.cpuActionLog')}
-      className="bg-black/30 rounded p-2 mb-3 text-white text-xs"
+      className="bg-black/30 rounded p-2 mb-3 text-ds-text-primary text-xs"
     >
       <div className="font-bold mb-1">{t('label.cpuAction')}</div>
       {actions.map((a, i) => (

--- a/frontend/src/components/CpuPlayerCard.tsx
+++ b/frontend/src/components/CpuPlayerCard.tsx
@@ -59,7 +59,7 @@ export function CpuPlayerCard({
   return (
     <div className="relative mb-3 rounded-lg p-2 bg-black/20 border border-white/10">
       {metaAi?.enabled && <MetaAiToast strategyStyle={strategyStyle} />}
-      <div className="text-white text-sm mb-1">
+      <div className="text-ds-text-primary text-sm mb-1">
         {t('player.cpu', { id: player.id })}{' '}
         <span className="text-ds-text-muted text-xs">({player.playStyleName})</span>
         {metaAi?.enabled && strategyStyle && (

--- a/frontend/src/components/CpuTurnArea.test.tsx
+++ b/frontend/src/components/CpuTurnArea.test.tsx
@@ -147,6 +147,6 @@ describe('CpuTurnArea', () => {
       <CpuTurnArea playerId={1} isHuman={false} isCurrentTurn={false} isFinished={false} className={baseClass} />,
     );
     const nameDiv = container.querySelector('.font-bold');
-    expect(nameDiv?.className).toBe('text-white font-bold mb-1');
+    expect(nameDiv?.className).toBe('text-ds-text-primary font-bold mb-1');
   });
 });

--- a/frontend/src/components/CpuTurnArea.tsx
+++ b/frontend/src/components/CpuTurnArea.tsx
@@ -33,7 +33,7 @@ export function CpuTurnArea({
   const conditionalClass = isFinished && dimFinished ? finishedPlayerClass : isCurrentTurn ? activeTurnClass : '';
   return (
     <div id={id} className={`${className}${conditionalClass ? ` ${conditionalClass}` : ''}`}>
-      <div className={`text-white font-bold mb-1${nameClassName ? ` ${nameClassName}` : ''}`}>
+      <div className={`text-ds-text-primary font-bold mb-1${nameClassName ? ` ${nameClassName}` : ''}`}>
         {playerName(playerId, isHuman)}
         {isFinished && finishedLabel && <StatusBadge variant="success">{finishedLabel}</StatusBadge>}
         {isCurrentTurn && !isFinished && <StatusBadge variant="warning">{t('status.thinking')}</StatusBadge>}

--- a/frontend/src/components/EquityDisplay.tsx
+++ b/frontend/src/components/EquityDisplay.tsx
@@ -19,7 +19,7 @@ export function EquityDisplay({ equity, potOdds }: EquityDisplayProps) {
     <div className="bg-black/30 rounded-lg p-3 mb-2" data-testid="equity-display">
       <div className="flex items-center gap-4 mb-2">
         <div className="flex-1">
-          <div className="text-white text-sm mb-1">
+          <div className="text-ds-text-primary text-sm mb-1">
             {t('learning.equity')}: <strong>{winPct}%</strong>
           </div>
           <div className="w-full bg-ds-surface rounded-full h-2.5">
@@ -30,7 +30,7 @@ export function EquityDisplay({ equity, potOdds }: EquityDisplayProps) {
             />
           </div>
         </div>
-        <div className="text-white text-sm">
+        <div className="text-ds-text-primary text-sm">
           {t('learning.potOdds')}: <strong>{potOdds.toFixed(1)}%</strong>
         </div>
       </div>
@@ -54,7 +54,7 @@ export function EquityDisplay({ equity, potOdds }: EquityDisplayProps) {
       </button>
 
       {showHandOdds && (
-        <table className="w-full text-xs text-white mt-2" data-testid="hand-odds-table">
+        <table className="w-full text-xs text-ds-text-primary mt-2" data-testid="hand-odds-table">
           <thead>
             <tr className="border-b border-white/20">
               <th className="text-left py-1">Hand</th>

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -210,14 +210,16 @@ export function VideoPokerGameContent({
             )}
 
             {isResultPhase && state.payout > 0 && (
-              <div className="text-white text-center font-bold mb-2">{t('label.payout', { payout: state.payout })}</div>
+              <div className="text-ds-text-primary text-center font-bold mb-2">
+                {t('label.payout', { payout: state.payout })}
+              </div>
             )}
 
             {isBetPhase && (
               <div className="flex-1 flex flex-col items-center justify-center" data-tutorial="vp-bet-controls">
                 <ErrorAlert message={error} onRetry={retry} />
                 <div className="flex items-center gap-2">
-                  <label htmlFor="vp-bet-amount" className="text-white text-sm">
+                  <label htmlFor="vp-bet-amount" className="text-ds-text-primary text-sm">
                     {t('label.betAmount')}
                   </label>
                   <select
@@ -270,7 +272,7 @@ export function VideoPokerGameContent({
               </div>
             )}
             <div className="flex justify-center pb-2">
-              <label className="text-white text-sm flex items-center gap-2 min-h-[44px]">
+              <label className="text-ds-text-primary text-sm flex items-center gap-2 min-h-[44px]">
                 <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
                 {tc('hint.toggle', { ns: 'tutorial' })}
               </label>


### PR DESCRIPTION
## Summary

Continues #1544's staged sweep. The seven shared, non-game-specific components below use pure white for body / label / heading text on glass and translucent dark surfaces — exactly the case DESIGN.md says should use the warm-ivory `--text-primary` token instead.

### Replaced (11 sites across 7 files)

| Component | What |
|---|---|
| `CpuAccordion` | opponents summary |
| `CpuActionLog` | log container body text (`bg-black/30` panel) |
| `CpuPlayerCard` | player name line |
| `CpuTurnArea` | player-name heading (test snapshot updated) |
| `ActionLogPanel` | title `<h3>` + log `<pre>` (`bg-black/40`) |
| `EquityDisplay` | equity / pot odds labels + hand-odds `<table>` |
| `VideoPokerGameContent` | payout banner, bet-amount label, hint-toggle label |

### Intentionally NOT touched

These match the issue's "do NOT replace" rule for high-contrast button / alert / focus / badge surfaces:

- `CpuActionBubble` — `bg-ds-accent/90`
- `CpuActionToast` / `MetaAiToast` — `bg-black/70` alert toasts
- `DropZone` focus-visible state — focus indicator on `bg-black/80`
- `ErrorAlert` — `bg-ds-error`
- `StatusBadge` — `bg-game-status-active` / `bg-game-status-out` pills

## Test plan

- [x] `bun run test -- --run CpuAccordion CpuActionLog CpuPlayerCard CpuTurnArea ActionLogPanel EquityDisplay VideoPokerGameContent` — 79/79 pass (one snapshot assertion in `CpuTurnArea.test.tsx` updated)
- [x] `bun run check` — clean (4 pre-existing warnings unrelated)
- [x] Only DOM className text changes; no behavior, attribute, or content changes

Refs #1544

Remaining `text-white` count after this PR: ~201 sites across pages and game-folder components, to be tackled in subsequent slices.