### PR TITLE
refactor(frontend): swap text-white for text-ds-text-primary in daifugo/sevens/oldmaid components

### DIFF
--- a/frontend/src/components/daifugo/DaifugoCpuCompact.tsx
+++ b/frontend/src/components/daifugo/DaifugoCpuCompact.tsx
@@ -17,7 +17,7 @@ export function DaifugoCpuCompact({ player, isCurrentTurn }: { player: DaifugoPl
       id={`player-area-${player.id}`}
       className={`flex flex-shrink-0 items-center gap-1.5 rounded-[8px] px-2 py-1 text-xs whitespace-nowrap bg-black/20 ${conditionalClass}`}
     >
-      <span className="text-white font-bold">{playerName(player.id, player.isHuman)}</span>
+      <span className="text-ds-text-primary font-bold">{playerName(player.id, player.isHuman)}</span>
       {player.isFinished ? (
         <span className="text-game-text-muted">{t(`rank.${player.rank}`)}</span>
       ) : (

--- a/frontend/src/components/daifugo/DaifugoHumanArea.tsx
+++ b/frontend/src/components/daifugo/DaifugoHumanArea.tsx
@@ -37,7 +37,7 @@ export function DaifugoHumanArea({
       id={`player-area-${player.id}`}
       className={`${playerAreaClass}${conditionalClass ? ` ${conditionalClass}` : ''}`}
     >
-      <div className="text-white font-bold mb-1">
+      <div className="text-ds-text-primary font-bold mb-1">
         {playerName(player.id, player.isHuman)}
         {player.isFinished && (
           <StatusBadge variant="success">{t('finishedWithRank', { rank: t(`rank.${player.rank}`) })}</StatusBadge>

--- a/frontend/src/components/daifugo/DaifugoRulesBadges.tsx
+++ b/frontend/src/components/daifugo/DaifugoRulesBadges.tsx
@@ -228,7 +228,7 @@ export function DaifugoRulesBadges({ state }: { state: DaifugoResponse }) {
           {b.label}
           <span
             role="tooltip"
-            className="hidden group-hover/badge:block group-focus/badge:block absolute bottom-full left-1/2 -translate-x-1/2 mb-1 bg-ds-surface-elevated text-white text-xs rounded px-2 py-1 whitespace-nowrap z-10 font-normal"
+            className="hidden group-hover/badge:block group-focus/badge:block absolute bottom-full left-1/2 -translate-x-1/2 mb-1 bg-ds-surface-elevated text-ds-text-primary text-xs rounded px-2 py-1 whitespace-nowrap z-10 font-normal"
           >
             {b.description}
           </span>

--- a/frontend/src/components/oldmaid/OldMaidDrawHistory.tsx
+++ b/frontend/src/components/oldmaid/OldMaidDrawHistory.tsx
@@ -24,7 +24,7 @@ export function OldMaidDrawHistory({
 
   return (
     <div className="bg-black/50 rounded-lg my-2 p-2" data-testid="draw-history-timeline">
-      <div className="text-white font-bold text-xs mb-1">{t('history.title')}</div>
+      <div className="text-ds-text-primary font-bold text-xs mb-1">{t('history.title')}</div>
       <div ref={scrollRef} className="max-h-[120px] overflow-y-auto text-xs text-game-text-muted">
         {entries.map((entry, i) => {
           const from = findPlayerName(players, entry.drawPlayerIdx);

--- a/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
+++ b/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
@@ -151,7 +151,7 @@ export function OldMaidPlayerArea({
       <div className="absolute -top-2 left-1/2 -translate-x-1/2 z-10">
         <CpuActionBubble message={bubble?.message} triggerKey={bubble?.triggerKey} />
       </div>
-      <div className="text-white font-bold mb-1 text-sm">
+      <div className="text-ds-text-primary font-bold mb-1 text-sm">
         {playerName(player.id, player.isHuman)}
         {player.isFinished && <StatusBadge variant="success">{tc('status.finished')}</StatusBadge>}
         {isTarget && !player.isHuman && !player.isFinished && !gameEndFlag && (
@@ -265,7 +265,7 @@ export function OldMaidPlayerArea({
               );
             })}
             {player.cardCount > 10 && (
-              <span className="text-white self-center ml-0.5 text-xs">+{player.cardCount - 10}</span>
+              <span className="text-ds-text-primary self-center ml-0.5 text-xs">+{player.cardCount - 10}</span>
             )}
           </>
         ) : compactNonTarget && !isTarget && !player.isHuman ? null : (
@@ -274,7 +274,7 @@ export function OldMaidPlayerArea({
               <CardBack key={i} width={cardWidth} />
             ))}
             {player.cardCount > 10 && (
-              <span className="text-white self-center ml-0.5 text-xs">+{player.cardCount - 10}</span>
+              <span className="text-ds-text-primary self-center ml-0.5 text-xs">+{player.cardCount - 10}</span>
             )}
           </>
         )}

--- a/frontend/src/components/oldmaid/OldMaidSettingsDialog.tsx
+++ b/frontend/src/components/oldmaid/OldMaidSettingsDialog.tsx
@@ -98,13 +98,13 @@ export function OldMaidSettingsDialog({
           if (e.key === 'Escape') onClose();
         }}
       >
-        <h2 id="oldmaid-settings-title" className="text-lg font-bold text-white mb-4">
+        <h2 id="oldmaid-settings-title" className="text-lg font-bold text-ds-text-primary mb-4">
           {t('setup.title')}
         </h2>
         <div className="flex flex-col gap-3">
           <fieldset className="flex flex-col gap-3 border-0 p-0 m-0">
-            <legend className="text-white font-bold mb-1">{t('setup.modeSelect')}</legend>
-            <label className="flex items-center gap-2 text-white cursor-pointer min-h-[44px]">
+            <legend className="text-ds-text-primary font-bold mb-1">{t('setup.modeSelect')}</legend>
+            <label className="flex items-center gap-2 text-ds-text-primary cursor-pointer min-h-[44px]">
               <input
                 type="radio"
                 name="oldmaid-mode"
@@ -114,7 +114,7 @@ export function OldMaidSettingsDialog({
               />
               {t('setup.normal')}
             </label>
-            <label className="flex items-center gap-2 text-white cursor-pointer min-h-[44px]">
+            <label className="flex items-center gap-2 text-ds-text-primary cursor-pointer min-h-[44px]">
               <input
                 type="radio"
                 name="oldmaid-mode"
@@ -127,8 +127,8 @@ export function OldMaidSettingsDialog({
           </fieldset>
           <div className="border-t border-white/20 my-1" />
           <fieldset className="flex flex-col gap-3 border-0 p-0 m-0">
-            <legend className="text-white font-bold mb-1">{t('setup.cpuSettings')}</legend>
-            <label className="flex items-center gap-2 text-white cursor-pointer min-h-[44px]">
+            <legend className="text-ds-text-primary font-bold mb-1">{t('setup.cpuSettings')}</legend>
+            <label className="flex items-center gap-2 text-ds-text-primary cursor-pointer min-h-[44px]">
               <input
                 type="checkbox"
                 checked={cpuPlacementStrategy}
@@ -136,11 +136,11 @@ export function OldMaidSettingsDialog({
               />
               {t('setup.cpuStrategy')}
             </label>
-            <label className="flex items-center gap-2 text-white cursor-pointer min-h-[44px]">
+            <label className="flex items-center gap-2 text-ds-text-primary cursor-pointer min-h-[44px]">
               <input type="checkbox" checked={cpuMemoryAI} onChange={(e) => onMemoryAIChange(e.target.checked)} />
               {t('setup.cpuMemoryAI')}
             </label>
-            <label className="flex items-center gap-2 text-white cursor-pointer min-h-[44px]">
+            <label className="flex items-center gap-2 text-ds-text-primary cursor-pointer min-h-[44px]">
               <input
                 type="checkbox"
                 checked={cpuHesitationEnabled}
@@ -148,7 +148,7 @@ export function OldMaidSettingsDialog({
               />
               {t('setup.cpuHesitation')}
             </label>
-            <label className="flex items-center gap-2 text-white cursor-pointer min-h-[44px]">
+            <label className="flex items-center gap-2 text-ds-text-primary cursor-pointer min-h-[44px]">
               <input type="checkbox" checked={cpuMetaAI} onChange={(e) => onMetaAIChange(e.target.checked)} />
               {t('setup.cpuMetaAI')}
             </label>

--- a/frontend/src/components/sevens/SevensBoard.tsx
+++ b/frontend/src/components/sevens/SevensBoard.tsx
@@ -35,7 +35,7 @@ function Board({
   const isMobile = useIsMobile();
   return (
     <div className="bg-black/30 rounded-[10px] py-2 px-2 sm:px-3.5 my-2">
-      <div className="text-white font-bold mb-1.5 text-sm">
+      <div className="text-ds-text-primary font-bold mb-1.5 text-sm">
         {t('board')}
         {tunnelEnabled && <span className="text-ds-warning text-xs ml-2">{t('tunnelTag')}</span>}
         {jokerSelecting && <span className="text-ds-success text-xs ml-2">{t('jokerSelectHint')}</span>}

--- a/frontend/src/components/sevens/SevensHumanArea.tsx
+++ b/frontend/src/components/sevens/SevensHumanArea.tsx
@@ -43,7 +43,7 @@ function HumanArea({
       : '';
   return (
     <div className={`${playerAreaClass}${conditionalClass ? ` ${conditionalClass}` : ''}`}>
-      <div className="text-white font-bold mb-1">
+      <div className="text-ds-text-primary font-bold mb-1">
         {playerName(player.id, player.isHuman)}
         {player.isFinished && <StatusBadge variant="success">{t('rankLabel', { rank: player.rank })}</StatusBadge>}
       </div>


### PR DESCRIPTION
## Summary

Continues #1544's staged sweep through game-folder components. The eight files below all use pure white for body / label / heading text on glass and translucent dark surfaces — the exact case DESIGN.md calls out for the warm-ivory `--text-primary` token.

### Replaced (18 sites across 8 files)

| File | What |
|---|---|
| `daifugo/DaifugoCpuCompact` | player name span |
| `daifugo/DaifugoHumanArea` | section heading |
| `daifugo/DaifugoRulesBadges` | tooltip body on `bg-ds-surface-elevated` |
| `sevens/SevensBoard` | section title |
| `sevens/SevensHumanArea` | section heading |
| `oldmaid/OldMaidDrawHistory` | history title |
| `oldmaid/OldMaidPlayerArea` | player name + 2 card-overflow spans (`+N`) |
| `oldmaid/OldMaidSettingsDialog` | dialog `<h2>`, 2 `<legend>`s, 6 checkbox `<label>`s |

### Intentionally NOT touched (saturated button / badge surfaces)

These match the issue's "do NOT replace" rule for high-saturation pairings where pure white preserves AA contrast:

- `daifugo/DaifugoRulesBadges` line 198 — `bg-ds-warning` badge
- `oldmaid/OldMaidPlayerArea` line 164 — `bg-ds-error/60` action button
- `gofish/GoFishBooksDisplay` line 22 — `bg-ds-success/50` pill

## Test plan

- [x] `bun run test -- --run DaifugoCpuCompact DaifugoHumanArea DaifugoRulesBadges SevensBoard SevensHumanArea OldMaidDrawHistory OldMaidPlayerArea OldMaidSettingsDialog GoFishBooksDisplay` — 143/143 pass
- [x] `bun run check` — clean (4 pre-existing warnings unrelated)
- [x] No DOM, attribute, or content changes; only the warm tint shift

Refs #1544

Remaining `text-white` count after this PR: ~183 sites across pages and remaining components, to be tackled in subsequent slices.