### PR TITLE
refactor(frontend): swap text-white for text-ds-text-primary across Holdem-family pages

### DIFF
--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -113,7 +113,7 @@ function StatTooltip({ id, label, tooltipText }: { id: string; label: string; to
       {label}
       <span
         id={id}
-        className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 whitespace-nowrap rounded bg-ds-surface-elevated px-2 py-1 text-xs text-white opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+        className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 whitespace-nowrap rounded bg-ds-surface-elevated px-2 py-1 text-xs text-ds-text-primary opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
         role="tooltip"
       >
         {tooltipText}
@@ -277,7 +277,7 @@ function HoldemPageContent() {
             {(() => {
               const communityCardsContent = (
                 <>
-                  <div className="text-white text-lg mb-1.5">{t('communityCards')}</div>
+                  <div className="text-ds-text-primary text-lg mb-1.5">{t('communityCards')}</div>
                   <div className="flex flex-wrap gap-2">
                     {state?.communityCards?.length
                       ? state.communityCards.map((card) => (
@@ -356,7 +356,7 @@ function HoldemPageContent() {
             {/* Human player */}
             {humanPlayer && (
               <div className="mb-2" data-tutorial="he-player-hand">
-                <div className="text-white text-lg mb-1">
+                <div className="text-ds-text-primary text-lg mb-1">
                   {t('yourHand')}
                   <span className="ml-3 text-xs">
                     {tc('betting.chips')} {humanPlayer.chips}
@@ -439,7 +439,7 @@ function HoldemPageContent() {
             {/* Rebuy/Addon controls */}
             {isRebuyPhase && (
               <div className="mb-2 text-center" data-testid="rebuy-controls">
-                <p className="text-white mb-2">
+                <p className="text-ds-text-primary mb-2">
                   {t('rebuy.prompt', { chips: state?.rebuyChips, used: humanRebuyCount, max: state?.rebuyMaxCount })}
                 </p>
                 <div className="flex justify-center gap-2">
@@ -464,7 +464,7 @@ function HoldemPageContent() {
             )}
             {isAddonPhase && (
               <div className="mb-2 text-center" data-testid="addon-controls">
-                <p className="text-white mb-2">{t('addon.prompt', { chips: state?.addonChips })}</p>
+                <p className="text-ds-text-primary mb-2">{t('addon.prompt', { chips: state?.addonChips })}</p>
                 <div className="flex justify-center gap-2">
                   <button
                     type="button"
@@ -513,12 +513,12 @@ function HoldemPageContent() {
 
             {/* Settings + Reset */}
             <details className="mb-1" data-tutorial="he-learning-mode" open={learningMode || undefined}>
-              <summary className="cursor-pointer select-none text-white text-sm font-bold py-1">
+              <summary className="cursor-pointer select-none text-ds-text-primary text-sm font-bold py-1">
                 {tc('settings.title')}
               </summary>
               <div className="flex flex-col gap-2 py-1">
                 <div className="flex items-center gap-2" data-testid="learning-mode-toggle">
-                  <label htmlFor="learningModeCheckbox" className="text-white text-sm cursor-pointer">
+                  <label htmlFor="learningModeCheckbox" className="text-ds-text-primary text-sm cursor-pointer">
                     {t('learning.toggle')}
                   </label>
                   <input
@@ -532,11 +532,11 @@ function HoldemPageContent() {
                   <EquityDisplay equity={state.equity} potOdds={state.potOdds} />
                 )}
                 <div className="flex items-center gap-3">
-                  <label className="text-white text-sm flex items-center gap-1">
+                  <label className="text-ds-text-primary text-sm flex items-center gap-1">
                     <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
                     {tc('hint.toggle', { ns: 'tutorial' })}
                   </label>
-                  <label className="text-white text-sm flex items-center gap-1">
+                  <label className="text-ds-text-primary text-sm flex items-center gap-1">
                     <input type="checkbox" checked={cpuMetaAI} onChange={(e) => setCpuMetaAI(e.target.checked)} />
                     {t('settings.cpuMetaAI')}
                   </label>

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -113,7 +113,7 @@ function StatTooltip({ id, label, tooltipText }: { id: string; label: string; to
       {label}
       <span
         id={id}
-        className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 whitespace-nowrap rounded bg-ds-surface-elevated px-2 py-1 text-xs text-white opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+        className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 whitespace-nowrap rounded bg-ds-surface-elevated px-2 py-1 text-xs text-ds-text-primary opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
         role="tooltip"
       >
         {tooltipText}
@@ -276,7 +276,7 @@ function OmahaPageContent() {
             {(() => {
               const communityCardsContent = (
                 <>
-                  <div className="text-white text-lg mb-1.5">{t('communityCards')}</div>
+                  <div className="text-ds-text-primary text-lg mb-1.5">{t('communityCards')}</div>
                   <div className="flex flex-wrap gap-2">
                     {state?.communityCards?.length
                       ? state.communityCards.map((card) => (
@@ -355,7 +355,7 @@ function OmahaPageContent() {
             {/* Human player */}
             {humanPlayer && (
               <div className="mb-2" data-tutorial="oh-player-hand">
-                <div className="text-white text-lg mb-1">
+                <div className="text-ds-text-primary text-lg mb-1">
                   {t('yourHand')}
                   <span className="ml-3 text-xs">
                     {tc('betting.chips')} {humanPlayer.chips}
@@ -437,7 +437,7 @@ function OmahaPageContent() {
             {/* Rebuy/Addon controls */}
             {isRebuyPhase && (
               <div className="mb-2 text-center" data-testid="rebuy-controls">
-                <p className="text-white mb-2">
+                <p className="text-ds-text-primary mb-2">
                   {t('rebuy.prompt', { chips: state?.rebuyChips, used: humanRebuyCount, max: state?.rebuyMaxCount })}
                 </p>
                 <div className="flex justify-center gap-2">
@@ -462,7 +462,7 @@ function OmahaPageContent() {
             )}
             {isAddonPhase && (
               <div className="mb-2 text-center" data-testid="addon-controls">
-                <p className="text-white mb-2">{t('addon.prompt', { chips: state?.addonChips })}</p>
+                <p className="text-ds-text-primary mb-2">{t('addon.prompt', { chips: state?.addonChips })}</p>
                 <div className="flex justify-center gap-2">
                   <button
                     type="button"
@@ -511,12 +511,12 @@ function OmahaPageContent() {
 
             {/* Settings + Reset */}
             <details className="mb-1" open={learningMode || undefined}>
-              <summary className="cursor-pointer select-none text-white text-sm font-bold py-1">
+              <summary className="cursor-pointer select-none text-ds-text-primary text-sm font-bold py-1">
                 {tc('settings.title')}
               </summary>
               <div className="flex flex-col gap-2 py-1">
                 <div className="flex items-center gap-2" data-testid="learning-mode-toggle">
-                  <label htmlFor="learningModeCheckbox" className="text-white text-sm cursor-pointer">
+                  <label htmlFor="learningModeCheckbox" className="text-ds-text-primary text-sm cursor-pointer">
                     {t('learning.toggle')}
                   </label>
                   <input
@@ -530,11 +530,11 @@ function OmahaPageContent() {
                   <EquityDisplay equity={state.equity} potOdds={state.potOdds} />
                 )}
                 <div className="flex items-center gap-3">
-                  <label className="text-white text-sm flex items-center gap-1">
+                  <label className="text-ds-text-primary text-sm flex items-center gap-1">
                     <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
                     {tc('hint.toggle', { ns: 'tutorial' })}
                   </label>
-                  <label className="text-white text-sm flex items-center gap-1">
+                  <label className="text-ds-text-primary text-sm flex items-center gap-1">
                     <input type="checkbox" checked={cpuMetaAI} onChange={(e) => setCpuMetaAI(e.target.checked)} />
                     {t('settings.cpuMetaAI')}
                   </label>

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -120,7 +120,7 @@ function StatTooltip({ id, label, tooltipText }: { id: string; label: string; to
       {label}
       <span
         id={id}
-        className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 whitespace-nowrap rounded bg-ds-surface-elevated px-2 py-1 text-xs text-white opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+        className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 whitespace-nowrap rounded bg-ds-surface-elevated px-2 py-1 text-xs text-ds-text-primary opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
         role="tooltip"
       >
         {tooltipText}
@@ -310,7 +310,7 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
             {(() => {
               const communityCardsContent = (
                 <>
-                  <div className="text-white text-lg mb-1.5">{t('communityCards')}</div>
+                  <div className="text-ds-text-primary text-lg mb-1.5">{t('communityCards')}</div>
                   <div className="flex flex-wrap gap-2">
                     {state?.communityCards?.length
                       ? state.communityCards.map((card) => (
@@ -389,7 +389,7 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
             {/* Human player */}
             {humanPlayer && (
               <div className="mb-2" data-tutorial="pn-player-hand">
-                <div className="text-white text-lg mb-1">
+                <div className="text-ds-text-primary text-lg mb-1">
                   {t('yourHand')}
                   <span className="ml-3 text-xs">
                     {tc('betting.chips')} {humanPlayer.chips}
@@ -459,7 +459,7 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
             {/* Discard controls */}
             {canDiscard && (
               <div className="mb-2 text-center" data-testid="discard-controls" data-tutorial="pn-discard-controls">
-                <p className="text-white mb-2">{t('discard.select')}</p>
+                <p className="text-ds-text-primary mb-2">{t('discard.select')}</p>
                 <button
                   type="button"
                   className={`${btnPrimary} min-w-[90px]`}
@@ -503,7 +503,7 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
             {/* Rebuy/Addon controls */}
             {isRebuyPhase && (
               <div className="mb-2 text-center" data-testid="rebuy-controls">
-                <p className="text-white mb-2">
+                <p className="text-ds-text-primary mb-2">
                   {t('rebuy.prompt', { chips: state?.rebuyChips, used: humanRebuyCount, max: state?.rebuyMaxCount })}
                 </p>
                 <div className="flex justify-center gap-2">
@@ -528,7 +528,7 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
             )}
             {isAddonPhase && (
               <div className="mb-2 text-center" data-testid="addon-controls">
-                <p className="text-white mb-2">{t('addon.prompt', { chips: state?.addonChips })}</p>
+                <p className="text-ds-text-primary mb-2">{t('addon.prompt', { chips: state?.addonChips })}</p>
                 <div className="flex justify-center gap-2">
                   <button
                     type="button"
@@ -577,12 +577,12 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
 
             {/* Settings + Reset */}
             <details className="mb-1" data-tutorial="pn-learning-mode" open={learningMode || undefined}>
-              <summary className="cursor-pointer select-none text-white text-sm font-bold py-1">
+              <summary className="cursor-pointer select-none text-ds-text-primary text-sm font-bold py-1">
                 {tc('settings.title')}
               </summary>
               <div className="flex flex-col gap-2 py-1">
                 <div className="flex items-center gap-2" data-testid="learning-mode-toggle">
-                  <label htmlFor="learningModeCheckbox" className="text-white text-sm cursor-pointer">
+                  <label htmlFor="learningModeCheckbox" className="text-ds-text-primary text-sm cursor-pointer">
                     {t('learning.toggle')}
                   </label>
                   <input
@@ -596,11 +596,11 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
                   <EquityDisplay equity={state.equity} potOdds={state.potOdds} />
                 )}
                 <div className="flex items-center gap-3">
-                  <label className="text-white text-sm flex items-center gap-1">
+                  <label className="text-ds-text-primary text-sm flex items-center gap-1">
                     <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
                     {tc('hint.toggle', { ns: 'tutorial' })}
                   </label>
-                  <label className="text-white text-sm flex items-center gap-1">
+                  <label className="text-ds-text-primary text-sm flex items-center gap-1">
                     <input type="checkbox" checked={cpuMetaAI} onChange={(e) => setCpuMetaAI(e.target.checked)} />
                     {t('settings.cpuMetaAI')}
                   </label>

--- a/frontend/src/pages/RazzPage.tsx
+++ b/frontend/src/pages/RazzPage.tsx
@@ -285,7 +285,7 @@ function RazzPageContent() {
             <CpuAccordion playerCount={cpuPlayers.length} dataTutorial="razz-cpu-area">
               {cpuPlayers.map((p) => (
                 <div key={p.id} className="mb-3 p-2 rounded bg-black/30">
-                  <div className="text-white text-sm mb-1">
+                  <div className="text-ds-text-primary text-sm mb-1">
                     CPU {p.id}
                     <span className="ml-2 text-xs text-ds-text-muted">{p.playStyleName}</span>
                     <span className="ml-2 text-xs">
@@ -366,7 +366,7 @@ function RazzPageContent() {
             {/* Human player */}
             {humanPlayer && (
               <div className="mb-2" data-tutorial="razz-player-hand">
-                <div className="text-white text-lg mb-1">
+                <div className="text-ds-text-primary text-lg mb-1">
                   {t('yourHand')}
                   <span className="ml-3 text-xs">
                     {tc('betting.chips')} {humanPlayer.chips}
@@ -460,7 +460,7 @@ function RazzPageContent() {
             {/* Rebuy/Addon controls */}
             {isRebuyPhase && (
               <div className="mb-2 text-center" data-testid="rebuy-controls">
-                <p className="text-white mb-2">
+                <p className="text-ds-text-primary mb-2">
                   {t('rebuy.prompt', { chips: state?.rebuyChips, used: humanRebuyCount, max: state?.rebuyMaxCount })}
                 </p>
                 <div className="flex justify-center gap-2">
@@ -485,7 +485,7 @@ function RazzPageContent() {
             )}
             {isAddonPhase && (
               <div className="mb-2 text-center" data-testid="addon-controls">
-                <p className="text-white mb-2">{t('addon.prompt', { chips: state?.addonChips })}</p>
+                <p className="text-ds-text-primary mb-2">{t('addon.prompt', { chips: state?.addonChips })}</p>
                 <div className="flex justify-center gap-2">
                   <button
                     type="button"
@@ -534,15 +534,15 @@ function RazzPageContent() {
 
             {/* Settings + Reset */}
             <details className="mb-1">
-              <summary className="cursor-pointer select-none text-white text-sm font-bold py-1">
+              <summary className="cursor-pointer select-none text-ds-text-primary text-sm font-bold py-1">
                 {tc('settings.title')}
               </summary>
               <div className="flex items-center gap-3 py-1">
-                <label className="text-white text-sm flex items-center gap-1">
+                <label className="text-ds-text-primary text-sm flex items-center gap-1">
                   <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
                   {tc('hint.toggle', { ns: 'tutorial' })}
                 </label>
-                <label className="text-white text-sm flex items-center gap-1">
+                <label className="text-ds-text-primary text-sm flex items-center gap-1">
                   <input type="checkbox" checked={cpuMetaAI} onChange={(e) => setCpuMetaAI(e.target.checked)} />
                   {t('settings.cpuMetaAI')}
                 </label>

--- a/frontend/src/pages/SevenCardStudPage.tsx
+++ b/frontend/src/pages/SevenCardStudPage.tsx
@@ -289,7 +289,7 @@ function SevenCardStudPageContent() {
             <CpuAccordion playerCount={cpuPlayers.length} dataTutorial="scs-cpu-area">
               {cpuPlayers.map((p) => (
                 <div key={p.id} className="mb-3 p-2 rounded bg-black/30">
-                  <div className="text-white text-sm mb-1">
+                  <div className="text-ds-text-primary text-sm mb-1">
                     CPU {p.id}
                     <span className="ml-2 text-xs text-ds-text-muted">{p.playStyleName}</span>
                     <span className="ml-2 text-xs">
@@ -370,7 +370,7 @@ function SevenCardStudPageContent() {
             {/* Human player */}
             {humanPlayer && (
               <div className="mb-2" data-tutorial="scs-player-hand">
-                <div className="text-white text-lg mb-1">
+                <div className="text-ds-text-primary text-lg mb-1">
                   {t('yourHand')}
                   <span className="ml-3 text-xs">
                     {tc('betting.chips')} {humanPlayer.chips}
@@ -464,7 +464,7 @@ function SevenCardStudPageContent() {
             {/* Rebuy/Addon controls */}
             {isRebuyPhase && (
               <div className="mb-2 text-center" data-testid="rebuy-controls">
-                <p className="text-white mb-2">
+                <p className="text-ds-text-primary mb-2">
                   {t('rebuy.prompt', { chips: state?.rebuyChips, used: humanRebuyCount, max: state?.rebuyMaxCount })}
                 </p>
                 <div className="flex justify-center gap-2">
@@ -489,7 +489,7 @@ function SevenCardStudPageContent() {
             )}
             {isAddonPhase && (
               <div className="mb-2 text-center" data-testid="addon-controls">
-                <p className="text-white mb-2">{t('addon.prompt', { chips: state?.addonChips })}</p>
+                <p className="text-ds-text-primary mb-2">{t('addon.prompt', { chips: state?.addonChips })}</p>
                 <div className="flex justify-center gap-2">
                   <button
                     type="button"
@@ -538,15 +538,15 @@ function SevenCardStudPageContent() {
 
             {/* Settings + Reset */}
             <details className="mb-1">
-              <summary className="cursor-pointer select-none text-white text-sm font-bold py-1">
+              <summary className="cursor-pointer select-none text-ds-text-primary text-sm font-bold py-1">
                 {tc('settings.title')}
               </summary>
               <div className="flex items-center gap-3 py-1">
-                <label className="text-white text-sm flex items-center gap-1">
+                <label className="text-ds-text-primary text-sm flex items-center gap-1">
                   <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
                   {tc('hint.toggle', { ns: 'tutorial' })}
                 </label>
-                <label className="text-white text-sm flex items-center gap-1">
+                <label className="text-ds-text-primary text-sm flex items-center gap-1">
                   <input type="checkbox" checked={cpuMetaAI} onChange={(e) => setCpuMetaAI(e.target.checked)} />
                   {t('settings.cpuMetaAI')}
                 </label>

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -113,7 +113,7 @@ function StatTooltip({ id, label, tooltipText }: { id: string; label: string; to
       {label}
       <span
         id={id}
-        className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 whitespace-nowrap rounded bg-ds-surface-elevated px-2 py-1 text-xs text-white opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+        className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 whitespace-nowrap rounded bg-ds-surface-elevated px-2 py-1 text-xs text-ds-text-primary opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
         role="tooltip"
       >
         {tooltipText}
@@ -275,7 +275,7 @@ function ShortDeckPageContent() {
             {(() => {
               const communityCardsContent = (
                 <>
-                  <div className="text-white text-lg mb-1.5">{t('communityCards')}</div>
+                  <div className="text-ds-text-primary text-lg mb-1.5">{t('communityCards')}</div>
                   <div className="flex flex-wrap gap-2">
                     {state?.communityCards?.length
                       ? state.communityCards.map((card) => (
@@ -354,7 +354,7 @@ function ShortDeckPageContent() {
             {/* Human player */}
             {humanPlayer && (
               <div className="mb-2" data-tutorial="sd-player-hand">
-                <div className="text-white text-lg mb-1">
+                <div className="text-ds-text-primary text-lg mb-1">
                   {t('yourHand')}
                   <span className="ml-3 text-xs">
                     {tc('betting.chips')} {humanPlayer.chips}
@@ -436,7 +436,7 @@ function ShortDeckPageContent() {
             {/* Rebuy/Addon controls */}
             {isRebuyPhase && (
               <div className="mb-2 text-center" data-testid="rebuy-controls">
-                <p className="text-white mb-2">
+                <p className="text-ds-text-primary mb-2">
                   {t('rebuy.prompt', { chips: state?.rebuyChips, used: humanRebuyCount, max: state?.rebuyMaxCount })}
                 </p>
                 <div className="flex justify-center gap-2">
@@ -461,7 +461,7 @@ function ShortDeckPageContent() {
             )}
             {isAddonPhase && (
               <div className="mb-2 text-center" data-testid="addon-controls">
-                <p className="text-white mb-2">{t('addon.prompt', { chips: state?.addonChips })}</p>
+                <p className="text-ds-text-primary mb-2">{t('addon.prompt', { chips: state?.addonChips })}</p>
                 <div className="flex justify-center gap-2">
                   <button
                     type="button"
@@ -510,12 +510,12 @@ function ShortDeckPageContent() {
 
             {/* Settings + Reset */}
             <details className="mb-1" data-tutorial="sd-learning-mode" open={learningMode || undefined}>
-              <summary className="cursor-pointer select-none text-white text-sm font-bold py-1">
+              <summary className="cursor-pointer select-none text-ds-text-primary text-sm font-bold py-1">
                 {tc('settings.title')}
               </summary>
               <div className="flex flex-col gap-2 py-1">
                 <div className="flex items-center gap-2" data-testid="learning-mode-toggle">
-                  <label htmlFor="learningModeCheckbox" className="text-white text-sm cursor-pointer">
+                  <label htmlFor="learningModeCheckbox" className="text-ds-text-primary text-sm cursor-pointer">
                     {t('learning.toggle')}
                   </label>
                   <input
@@ -529,11 +529,11 @@ function ShortDeckPageContent() {
                   <EquityDisplay equity={state.equity} potOdds={state.potOdds} />
                 )}
                 <div className="flex items-center gap-3">
-                  <label className="text-white text-sm flex items-center gap-1">
+                  <label className="text-ds-text-primary text-sm flex items-center gap-1">
                     <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
                     {tc('hint.toggle', { ns: 'tutorial' })}
                   </label>
-                  <label className="text-white text-sm flex items-center gap-1">
+                  <label className="text-ds-text-primary text-sm flex items-center gap-1">
                     <input type="checkbox" checked={cpuMetaAI} onChange={(e) => setCpuMetaAI(e.target.checked)} />
                     {t('settings.cpuMetaAI')}
                   </label>


### PR DESCRIPTION
## Summary

Continues #1544's staged sweep through page-level files. The six Holdem-family pages share a near-identical layout (community cards heading, dealer/turn message paragraphs, learning-mode + tournament checkboxes, surface-elevated tooltip), and all of them inherit the same `text-white` markup for body / heading / label copy. None are button or saturated-bg sites.

### Replaced (51 sites across 6 pages)

| Page | Sites |
|---|---:|
| `HoldemPage` | 9 |
| `OmahaPage` | 9 |
| `ShortDeckPage` | 9 |
| `PineapplePage` | 10 |
| `SevenCardStudPage` | 7 |
| `RazzPage` | 7 |

Patterns swapped uniformly across all six:
- tooltip body on `bg-ds-surface-elevated`
- community-cards heading (`text-lg`)
- action heading (`text-lg`)
- dialog body paragraphs
- settings summary + checkbox/select labels
- (Stud variants only) player-line headings

After this PR every Holdem-family page reports 0 `text-white` usages.

## Test plan

- [x] `bun run test -- --run HoldemPage OmahaPage ShortDeckPage PineapplePage SevenCardStudPage RazzPage` — 427/427 pass
- [x] `bun run check` — clean (4 pre-existing warnings unrelated)
- [x] No DOM, attribute, or content changes; only the warm tint shift

Refs #1544

Remaining `text-white` count after this PR: ~132 sites across non-Holdem pages and remaining components, to be tackled in subsequent slices.