### PR TITLE
refactor(frontend): swap text-white for text-ds-text-primary across remaining pages

### DIFF
--- a/frontend/src/pages/AccordionPage.tsx
+++ b/frontend/src/pages/AccordionPage.tsx
@@ -293,11 +293,11 @@ function AccordionPageContent() {
                     aria-label={top ? `${idx}: ${cardAlt(top)}` : `${idx}: empty`}
                   >
                     {top && <AnimatedCard card={top} width={cardWidth} />}
-                    <span className="absolute top-0 left-0 text-[10px] bg-black/40 text-white rounded-br px-1">
+                    <span className="absolute top-0 left-0 text-[10px] bg-black/40 text-ds-text-primary rounded-br px-1">
                       {idx}
                     </span>
                     {pile.size > 1 && (
-                      <span className="absolute bottom-0 right-0 text-[10px] bg-black/60 text-white rounded-tl px-1">
+                      <span className="absolute bottom-0 right-0 text-[10px] bg-black/60 text-ds-text-primary rounded-tl px-1">
                         +{pile.size - 1}
                       </span>
                     )}

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -337,7 +337,9 @@ function BaccaratPageContent() {
 
             {/* Payout info */}
             {isEndPhase && (
-              <div className="text-ds-text-primary text-center font-bold mb-2">{t('label.payout', { payout: state.payout })}</div>
+              <div className="text-ds-text-primary text-center font-bold mb-2">
+                {t('label.payout', { payout: state.payout })}
+              </div>
             )}
 
             {/* Side bet results */}
@@ -347,7 +349,9 @@ function BaccaratPageContent() {
 
             {/* Big Road */}
             <div className="flex flex-col items-center">
-              {state.history.length > 0 && <div className="text-ds-text-primary text-sm font-bold mb-1">{t('road.title')}</div>}
+              {state.history.length > 0 && (
+                <div className="text-ds-text-primary text-sm font-bold mb-1">{t('road.title')}</div>
+              )}
               <BigRoadGrid history={state.history} />
               {state.history.length > 0 && (
                 <button

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -171,7 +171,7 @@ function SideBetResultsDisplay({
   return (
     <div className="mb-2 text-center" data-testid="side-bet-results">
       {results.map((r) => (
-        <div key={r.betType} className="text-white text-sm">
+        <div key={r.betType} className="text-ds-text-primary text-sm">
           {r.betType === 1 ? t('sideBet.playerPair') : t('sideBet.bankerPair')}:{' '}
           {r.resultType === 1 ? t('sideBet.pair') : t('sideBet.noPair')} ({t('label.payout', { payout: r.payout })})
         </div>
@@ -280,7 +280,7 @@ function BaccaratPageContent() {
               <div className="flex flex-col items-center justify-center py-6 gap-4">
                 <p className="text-ds-text-muted text-lg">{t('betGuide')}</p>
                 <details className="bg-black/30 rounded-lg w-full max-w-sm">
-                  <summary className="cursor-pointer select-none px-4 py-2 text-white font-bold text-sm">
+                  <summary className="cursor-pointer select-none px-4 py-2 text-ds-text-primary font-bold text-sm">
                     {t('payoutRef.title')}
                   </summary>
                   <ul className="text-ds-text-muted text-sm space-y-1 px-4 pb-3">
@@ -337,7 +337,7 @@ function BaccaratPageContent() {
 
             {/* Payout info */}
             {isEndPhase && (
-              <div className="text-white text-center font-bold mb-2">{t('label.payout', { payout: state.payout })}</div>
+              <div className="text-ds-text-primary text-center font-bold mb-2">{t('label.payout', { payout: state.payout })}</div>
             )}
 
             {/* Side bet results */}
@@ -347,7 +347,7 @@ function BaccaratPageContent() {
 
             {/* Big Road */}
             <div className="flex flex-col items-center">
-              {state.history.length > 0 && <div className="text-white text-sm font-bold mb-1">{t('road.title')}</div>}
+              {state.history.length > 0 && <div className="text-ds-text-primary text-sm font-bold mb-1">{t('road.title')}</div>}
               <BigRoadGrid history={state.history} />
               {state.history.length > 0 && (
                 <button
@@ -395,7 +395,7 @@ function BaccaratPageContent() {
                   max={state.chips}
                 />
                 <div className="flex items-center gap-2">
-                  <label htmlFor="baccarat-bet-type" className="text-white text-sm">
+                  <label htmlFor="baccarat-bet-type" className="text-ds-text-primary text-sm">
                     {t('label.betTarget')}
                   </label>
                   <select

--- a/frontend/src/pages/BadugiPage.tsx
+++ b/frontend/src/pages/BadugiPage.tsx
@@ -177,7 +177,7 @@ function BadugiPageContent() {
         <span>
           {tc('label.dealer')} <strong>Player {state?.dealerIdx ?? 0}</strong>
         </span>
-        <span className="text-xs bg-black/20 text-white px-2 py-0.5 rounded">
+        <span className="text-xs bg-black/20 text-ds-text-primary px-2 py-0.5 rounded">
           {drawIndex === 0 ? t('preDrawLabel') : t('drawBadge', { n: drawIndex })}
         </span>
       </PhaseIndicator>
@@ -218,7 +218,7 @@ function BadugiPageContent() {
 
         {/* CPU exchanges log */}
         {state?.cpuExchanges && state.cpuExchanges.length > 0 && (
-          <div className="bg-black/30 rounded p-2 mb-3 text-white text-xs">
+          <div className="bg-black/30 rounded p-2 mb-3 text-ds-text-primary text-xs">
             <div className="font-bold mb-1">{t('cpuExchange')}</div>
             {state.cpuExchanges.map((ex, i) => (
               <div key={`${i}-${ex.playerIdx}`}>
@@ -234,7 +234,7 @@ function BadugiPageContent() {
         {/* Human player */}
         {humanPlayer && (
           <div className="mb-2" data-tutorial="bg-player-hand">
-            <div className="text-white text-lg mb-1">
+            <div className="text-ds-text-primary text-lg mb-1">
               {t('yourHand')}
               <span className="ml-3 text-xs">
                 {tc('betting.chips')} {humanPlayer.chips}

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -311,7 +311,7 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
               <div className="flex flex-col items-center justify-center py-6 gap-4">
                 <p className="text-ds-text-muted text-lg">{t('betGuide')}</p>
                 <details className="bg-black/30 rounded-lg w-full max-w-sm">
-                  <summary className="cursor-pointer select-none px-4 py-2 text-white font-bold text-sm">
+                  <summary className="cursor-pointer select-none px-4 py-2 text-ds-text-primary font-bold text-sm">
                     {t('payoutRef.title')}
                   </summary>
                   <ul className="text-ds-text-muted text-sm space-y-1 px-4 pb-3">
@@ -339,11 +339,11 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
             )}
             {phase !== BjPhase.BET && (
               <div data-tutorial="bj-dealer-hand">
-                <h2 className="text-white">
+                <h2 className="text-ds-text-primary">
                   {t('dealerHand')}
                   {dealerHitsSoft17 ? ' (H17)' : ' (S17)'}
                 </h2>
-                <p className="text-white">
+                <p className="text-ds-text-primary">
                   {t('score')} {state.dealer.score ? state.dealer.score : ''}
                 </p>
                 <div className="flex flex-wrap gap-2">
@@ -412,7 +412,7 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
               <div className="mb-2" data-tutorial="bj-player-hand">
                 {hands.map((hand, handIndex) => (
                   <div key={`hand-${handIndex}`} className="mb-2">
-                    <h2 className="text-white mt-0 mb-0.5">
+                    <h2 className="text-ds-text-primary mt-0 mb-0.5">
                       {hands.length > 1 ? t('hand', { idx: handIndex + 1 }) : t('playerHand')}
                       {handIndex === currentHandIdx &&
                         (phase === BjPhase.ACTION || phase === BjPhase.EARLY_SURRENDER) &&
@@ -424,7 +424,7 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
                         surrendered={hand.surrendered}
                       />
                     </h2>
-                    <p className="text-white mt-0 mb-0.5">
+                    <p className="text-ds-text-primary mt-0 mb-0.5">
                       {t('score')} {hand.score} / {tc('betting.currentBet')} {hand.bet}
                     </p>
                     <div className="flex flex-wrap gap-1.5">
@@ -541,7 +541,7 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
                     />
                   </div>
                   <div className="flex items-center justify-center gap-2 mt-2">
-                    <label htmlFor="bj-auto-advance" className="text-white text-sm">
+                    <label htmlFor="bj-auto-advance" className="text-ds-text-primary text-sm">
                       {t('autoAdvance')}
                     </label>
                     <select

--- a/frontend/src/pages/BridgePage.tsx
+++ b/frontend/src/pages/BridgePage.tsx
@@ -253,7 +253,7 @@ function BridgePageContent() {
           {/* Scrollable area */}
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>
             {/* Round/Trick info */}
-            <div className="text-white text-center mb-2">
+            <div className="text-ds-text-primary text-center mb-2">
               <span className="mr-4">{t('round', { n: state.roundNumber })}</span>
               {isPlayPhase && <span className="mr-4">{t('trick', { n: state.trickNumber })}</span>}
               {contractDisplay() && <span className="mr-4">{contractDisplay()}</span>}
@@ -541,7 +541,7 @@ function BridgePageContent() {
               {isHumanBidTurn && (
                 <span data-tutorial="br-bid-controls" className="flex gap-1 items-center flex-wrap">
                   <select
-                    className="text-xs rounded bg-black/50 text-white px-1.5 py-0.5"
+                    className="text-xs rounded bg-black/50 text-ds-text-primary px-1.5 py-0.5"
                     value={bidLevel}
                     onChange={(e) => setBidLevel(Number(e.target.value))}
                     aria-label={t('bidLevel')}
@@ -553,7 +553,7 @@ function BridgePageContent() {
                     ))}
                   </select>
                   <select
-                    className="text-xs rounded bg-black/50 text-white px-1.5 py-0.5"
+                    className="text-xs rounded bg-black/50 text-ds-text-primary px-1.5 py-0.5"
                     value={bidSuit}
                     onChange={(e) => setBidSuit(Number(e.target.value))}
                     aria-label={t('bidSuit')}

--- a/frontend/src/pages/CanastaPage.tsx
+++ b/frontend/src/pages/CanastaPage.tsx
@@ -148,7 +148,7 @@ function CanastaPageContent() {
 
   if (!state) {
     return (
-      <div className="p-4 text-center text-white">
+      <div className="p-4 text-center text-ds-text-primary">
         <p>{tc('status.thinking')}</p>
       </div>
     );
@@ -204,7 +204,7 @@ function CanastaPageContent() {
           />
 
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>
-            <div className="text-white text-center mb-2">
+            <div className="text-ds-text-primary text-center mb-2">
               <span className="mr-4">{t('round', { n: state.roundNumber })}</span>
               <span>
                 {t('drawPile', { count: state.drawPileCount })} / {t('discardPile', { count: state.discardPileCount })}

--- a/frontend/src/pages/CaribbeanStudPage.tsx
+++ b/frontend/src/pages/CaribbeanStudPage.tsx
@@ -187,7 +187,7 @@ function CaribbeanStudPageContent() {
               messageParams={state.messageParams}
             />
 
-            <label className="flex items-center gap-1 text-white text-xs justify-center mb-2 cursor-pointer">
+            <label className="flex items-center gap-1 text-ds-text-primary text-xs justify-center mb-2 cursor-pointer">
               <input
                 type="checkbox"
                 checked={frontendHintEnabled}
@@ -204,7 +204,7 @@ function CaribbeanStudPageContent() {
               <div className="flex flex-col items-center justify-center py-4 gap-4">
                 <p className="text-ds-text-muted text-lg">{t('betGuide')}</p>
                 <details className="bg-black/30 rounded-lg w-full max-w-sm">
-                  <summary className="cursor-pointer select-none px-4 py-2 text-white font-bold text-sm">
+                  <summary className="cursor-pointer select-none px-4 py-2 text-ds-text-primary font-bold text-sm">
                     {t('payoutRef.title')}
                   </summary>
                   <div className="px-4 pb-3 text-ds-text-muted text-sm space-y-2">
@@ -301,7 +301,7 @@ function CaribbeanStudPageContent() {
             )}
 
             {isEndPhase && (
-              <div className="text-white text-center text-sm mb-2" data-testid="payout-breakdown">
+              <div className="text-ds-text-primary text-center text-sm mb-2" data-testid="payout-breakdown">
                 {state.antePayout !== 0 && (
                   <div>
                     {t('payout.ante')}: {state.antePayout}
@@ -332,7 +332,7 @@ function CaribbeanStudPageContent() {
             {isBetPhase && (
               <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="csp-bet-controls">
                 <div className="flex items-center gap-2">
-                  <label htmlFor="caribbeanstud-ante-amount" className="text-white text-sm">
+                  <label htmlFor="caribbeanstud-ante-amount" className="text-ds-text-primary text-sm">
                     {t('label.ante')}
                   </label>
                   <input
@@ -347,7 +347,7 @@ function CaribbeanStudPageContent() {
                   />
                 </div>
                 <div className="flex items-center gap-2">
-                  <label htmlFor="caribbeanstud-jackpot-amount" className="text-white text-sm">
+                  <label htmlFor="caribbeanstud-jackpot-amount" className="text-ds-text-primary text-sm">
                     {t('label.jackpot')}
                   </label>
                   <input

--- a/frontend/src/pages/CassinoPage.tsx
+++ b/frontend/src/pages/CassinoPage.tsx
@@ -328,7 +328,7 @@ function CassinoPageContent() {
                   aria-label={t('label.buildValue')}
                   value={String(declaredValue)}
                   onChange={(e) => setDeclaredValue(Number.parseInt(e.target.value, 10))}
-                  className="px-2 py-2 rounded bg-black/30 text-white text-sm"
+                  className="px-2 py-2 rounded bg-black/30 text-ds-text-primary text-sm"
                   data-testid="build-value-select"
                 >
                   {BUILD_VALUE_OPTIONS.map((o) => (

--- a/frontend/src/pages/CrazyEightsPage.tsx
+++ b/frontend/src/pages/CrazyEightsPage.tsx
@@ -224,7 +224,7 @@ function CrazyEightsPageContent() {
           />
 
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>
-            <div className="text-white text-center mb-2">
+            <div className="text-ds-text-primary text-center mb-2">
               <span className="mr-4">{t('round', { n: state.roundNumber })}</span>
               <span>{t('drawPile', { count: state.drawPileCount })}</span>
             </div>

--- a/frontend/src/pages/CribbagePage.tsx
+++ b/frontend/src/pages/CribbagePage.tsx
@@ -266,7 +266,7 @@ function CribbagePageContent() {
           />
 
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>
-            <div className="text-white text-center mb-2">
+            <div className="text-ds-text-primary text-center mb-2">
               <span className="mr-4">{t('round', { n: state.roundNumber })}</span>
               <span>{t('dealer', { name: playerName(state.dealerIdx, state.players[state.dealerIdx]?.isHuman) })}</span>
             </div>

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -257,7 +257,7 @@ function DaifugoPageContent() {
               onDragOver={(e) => e.preventDefault()}
               onDrop={handleDrop}
             >
-              <div className="text-white font-bold mb-1.5">{t('tableCards')}</div>
+              <div className="text-ds-text-primary font-bold mb-1.5">{t('tableCards')}</div>
               <div className="flex flex-wrap gap-1">
                 {!state.tableCards || state.tableCards.length === 0 ? (
                   <span className="text-ds-text-muted">{t('tableEmpty')}</span>
@@ -313,7 +313,7 @@ function DaifugoPageContent() {
             )}
 
             {state.cpuActions && state.cpuActions.length > 0 && (
-              <div className="bg-black/40 rounded-lg text-white py-2 px-3.5 my-2 whitespace-pre-line text-xs">
+              <div className="bg-black/40 rounded-lg text-ds-text-primary py-2 px-3.5 my-2 whitespace-pre-line text-xs">
                 {[tc('label.cpuActions'), ...state.cpuActions.map((a) => actionDescription(state.players, a))].join(
                   '\n',
                 )}

--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -315,7 +315,7 @@ function DoubtPageContent() {
               <div>
                 {/* Table area */}
                 <div className="bg-black/30 rounded-[10px] py-2.5 px-3.5 my-2" data-tutorial="dt-table-area">
-                  <div className="text-white font-bold mb-1">{t('table')}</div>
+                  <div className="text-ds-text-primary font-bold mb-1">{t('table')}</div>
                   <div className="text-game-text-muted text-sm">{t('tableCards', { count: state.tableCardCount })}</div>
                   {state.lastAction && (
                     <div className="text-ds-warning text-xs mt-1">{actionDesc(state.lastAction, state.players, t)}</div>
@@ -327,7 +327,7 @@ function DoubtPageContent() {
                   <div className="bg-black/40 rounded-[10px] py-3 px-4 my-2" data-tutorial="dt-doubt-window">
                     {cpuPlayed ? (
                       <>
-                        <div className="text-white font-bold mb-2">{t('doubtQuestion')}</div>
+                        <div className="text-ds-text-primary font-bold mb-2">{t('doubtQuestion')}</div>
                         {state.lastAction && (
                           <div
                             className="bg-ds-warning/20 border-2 border-ds-warning rounded-lg py-2 px-3 mb-2 text-center animate-pulse"
@@ -363,7 +363,7 @@ function DoubtPageContent() {
                       </>
                     ) : (
                       <>
-                        <div className="text-white font-bold mb-2">{t('cpuJudging')}</div>
+                        <div className="text-ds-text-primary font-bold mb-2">{t('cpuJudging')}</div>
                         {state.cpuDoubters.length > 0 && (
                           <div className="text-ds-error text-sm mb-2">
                             {t('cpuDoubtExclaim', {
@@ -382,7 +382,7 @@ function DoubtPageContent() {
                 {/* Last doubt result */}
                 {state.lastDoubtResult && (
                   <div className="bg-black/40 rounded-lg py-2 px-3.5 my-2 text-xs">
-                    <div className="text-white font-bold mb-1">{t('doubtResult.title')}</div>
+                    <div className="text-ds-text-primary font-bold mb-1">{t('doubtResult.title')}</div>
                     <div className={state.lastDoubtResult.wasLying ? 'text-ds-error' : 'text-ds-success'}>
                       {state.lastDoubtResult.wasLying ? t('doubtResult.wasLying') : t('doubtResult.wasTruth')}
                     </div>
@@ -462,7 +462,7 @@ function DoubtPageContent() {
                 {/* Meta-AI info */}
                 {state.metaAI?.enabled && (
                   <div className="bg-black/40 rounded-lg py-2 px-3.5 my-2 text-xs">
-                    <div className="text-white font-bold mb-1">{t('metaAI.title')}</div>
+                    <div className="text-ds-text-primary font-bold mb-1">{t('metaAI.title')}</div>
                     <div className="text-game-text-muted">
                       {t('metaAI.gamesPlayed', { count: state.metaAI.gamesPlayed })}
                     </div>
@@ -488,7 +488,7 @@ function DoubtPageContent() {
             {/* Human player info */}
             {humanPlayer && (
               <div className="mb-2" data-tutorial="dt-player-hand">
-                <div className="text-white font-bold text-sm mb-1">
+                <div className="text-ds-text-primary font-bold text-sm mb-1">
                   {t('yourCards', { count: humanPlayer.cardCount })}
                   {isHumanTurn && state.phase === 0 && (
                     <span className="text-ds-success text-xs ml-2">{t('selectPrompt')}</span>
@@ -512,7 +512,7 @@ function DoubtPageContent() {
                 {/* Claimed value input (shown when cards are selected) */}
                 {showClaimInput && (
                   <div className="mt-2 flex items-center gap-2" data-tutorial="dt-claim-input">
-                    <label htmlFor="claim-input" className="text-white text-sm">
+                    <label htmlFor="claim-input" className="text-ds-text-primary text-sm">
                       {t('claimedValue')}
                     </label>
                     <input

--- a/frontend/src/pages/DurakPage.tsx
+++ b/frontend/src/pages/DurakPage.tsx
@@ -256,7 +256,7 @@ function DurakPageContent() {
               <div>
                 {/* Trump info */}
                 <div className="bg-black/30 rounded-[10px] py-2.5 px-3.5 my-2" data-tutorial="dk-trump-info">
-                  <div className="text-white font-bold mb-1">
+                  <div className="text-ds-text-primary font-bold mb-1">
                     {t('trump')}: {suitSymbol(state.trumpSuit)}
                     {state.trumpCard && (
                       <span className="ml-2">
@@ -271,7 +271,7 @@ function DurakPageContent() {
 
                 {/* Table pairs */}
                 <div className="bg-black/30 rounded-[10px] py-2.5 px-3.5 my-2" data-tutorial="dk-table-cards">
-                  <div className="text-white font-bold mb-1">{t('table')}</div>
+                  <div className="text-ds-text-primary font-bold mb-1">{t('table')}</div>
                   {state.tablePairs.length === 0 ? (
                     <div className="text-game-text-muted text-sm">{t('tableEmpty')}</div>
                   ) : (
@@ -347,7 +347,7 @@ function DurakPageContent() {
                         state.currentTurn === player.id ? 'ring-2 ring-ds-warning' : ''
                       }`}
                     >
-                      <div className="text-white text-sm font-bold">
+                      <div className="text-ds-text-primary text-sm font-bold">
                         {playerName(player.id, false)}
                         {state.attackerIdx === player.id && (
                           <span className="text-ds-error text-xs ml-1">({t('attacker')})</span>
@@ -368,7 +368,7 @@ function DurakPageContent() {
           <GameFooter className={`${theme.footer} px-4 py-2.5`}>
             {humanPlayer && (
               <div className="mb-2" data-tutorial="dk-player-hand">
-                <div className="text-white font-bold text-sm mb-1">
+                <div className="text-ds-text-primary font-bold text-sm mb-1">
                   {humanPlayer.cardCount}
                   {isAttacker && <span className="text-ds-error text-xs ml-2">({t('attacker')})</span>}
                   {isDefender && <span className="text-ds-info text-xs ml-2">({t('defender')})</span>}

--- a/frontend/src/pages/EuchrePage.tsx
+++ b/frontend/src/pages/EuchrePage.tsx
@@ -265,7 +265,7 @@ function EuchrePageContent() {
           {/* Scrollable area */}
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>
             {/* Round/Trick info */}
-            <div className="text-white text-center mb-2">
+            <div className="text-ds-text-primary text-center mb-2">
               <span className="mr-4">{t('round', { n: state.roundNumber })}</span>
               <span className="mr-4">{t('trick', { n: state.trickNumber })}</span>
               {state.trumpSuit > 0 && <span>{t('trumpSuit', { suit: suitName(state.trumpSuit) })}</span>}
@@ -534,7 +534,7 @@ function EuchrePageContent() {
                         {t(SUIT_NAMES[s])}
                       </button>
                     ))}
-                  <label className="text-white text-sm flex items-center gap-1">
+                  <label className="text-ds-text-primary text-sm flex items-center gap-1">
                     <input type="checkbox" checked={goAlone} onChange={(e) => setGoAlone(e.target.checked)} />
                     {t('goAloneCheck')}
                   </label>

--- a/frontend/src/pages/GinRummyPage.tsx
+++ b/frontend/src/pages/GinRummyPage.tsx
@@ -228,7 +228,7 @@ function GinRummyPageContent() {
           />
 
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>
-            <div className="text-white text-center mb-2">
+            <div className="text-ds-text-primary text-center mb-2">
               <span className="mr-4">{t('round', { n: state.roundNumber })}</span>
               <span>{t('drawPile', { count: state.drawPileCount })}</span>
             </div>

--- a/frontend/src/pages/GoFishPage.tsx
+++ b/frontend/src/pages/GoFishPage.tsx
@@ -163,7 +163,7 @@ function GoFishPageContent() {
           {/* Scrollable area */}
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>
             {/* Turn, deck info & hint toggle */}
-            <div className="text-white text-center mb-2 flex items-center justify-center gap-4">
+            <div className="text-ds-text-primary text-center mb-2 flex items-center justify-center gap-4">
               <span>{t('deck', { count: state.deckRemaining })}</span>
               <label className="inline-flex items-center gap-1 text-sm cursor-pointer">
                 <input

--- a/frontend/src/pages/HeartsPage.tsx
+++ b/frontend/src/pages/HeartsPage.tsx
@@ -254,7 +254,7 @@ function HeartsPageContent() {
           {/* Scrollable area */}
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>
             {/* Round/Trick info */}
-            <div className="text-white text-center mb-2">
+            <div className="text-ds-text-primary text-center mb-2">
               <span className="mr-4">{t('round', { n: state.roundNumber })}</span>
               <span className="mr-4">{t('trick', { n: state.trickNumber })}</span>
               <span>{state.heartsBroken ? t('heartsBroken') : t('heartsNotBroken')}</span>

--- a/frontend/src/pages/IndianPokerPage.tsx
+++ b/frontend/src/pages/IndianPokerPage.tsx
@@ -216,7 +216,7 @@ function IndianPokerPageContent() {
                 ?.filter((p) => !p.isHuman)
                 .map((p) => (
                   <div key={p.id} className={isMobile ? 'text-center' : 'mb-3'}>
-                    <div className={`text-white text-sm mb-1 ${isMobile ? 'truncate' : ''}`}>
+                    <div className={`text-ds-text-primary text-sm mb-1 ${isMobile ? 'truncate' : ''}`}>
                       {tc('player.cpu', { id: p.id })}
                       {!isMobile && <span className="text-ds-text-muted text-xs"> ({p.playStyleName})</span>}
                       <span className={`text-xs ${isMobile ? 'block' : 'ml-2'}`}>
@@ -266,7 +266,7 @@ function IndianPokerPageContent() {
             {/* Human player */}
             {humanPlayer && (
               <div className="mb-2" data-tutorial="ip-player-card">
-                <div className="text-white text-lg mb-1">
+                <div className="text-ds-text-primary text-lg mb-1">
                   {t('yourCard')}
                   <span className="ml-3 text-xs">
                     {tc('betting.chips')} {humanPlayer.chips}

--- a/frontend/src/pages/KlondikePage.tsx
+++ b/frontend/src/pages/KlondikePage.tsx
@@ -610,7 +610,7 @@ function KlondikePageContent() {
                   handleResetWithConfig({ drawCount: n, scoringMode: scoringModeSetting });
                   resetTimer();
                 }}
-                className="bg-ds-surface-elevated text-white text-sm rounded px-2 py-1"
+                className="bg-ds-surface-elevated text-ds-text-primary text-sm rounded px-2 py-1"
                 aria-label={t('drawMode')}
               >
                 <option value={1}>{t('drawMode1')}</option>
@@ -629,7 +629,7 @@ function KlondikePageContent() {
                   handleResetWithConfig({ drawCount: drawCountSetting, scoringMode: n });
                   resetTimer();
                 }}
-                className="bg-ds-surface-elevated text-white text-sm rounded px-2 py-1"
+                className="bg-ds-surface-elevated text-ds-text-primary text-sm rounded px-2 py-1"
                 aria-label={t('scoringMode')}
               >
                 <option value={0}>{t('scoringNone')}</option>

--- a/frontend/src/pages/LetItRidePage.tsx
+++ b/frontend/src/pages/LetItRidePage.tsx
@@ -195,7 +195,7 @@ function LetItRidePageContent() {
               messageParams={state.messageParams}
             />
 
-            <label className="flex items-center gap-1 text-white text-xs justify-center mb-2 cursor-pointer">
+            <label className="flex items-center gap-1 text-ds-text-primary text-xs justify-center mb-2 cursor-pointer">
               <input
                 type="checkbox"
                 checked={frontendHintEnabled}
@@ -212,7 +212,7 @@ function LetItRidePageContent() {
               <div className="flex flex-col items-center justify-center py-4 gap-4">
                 <p className="text-ds-text-muted text-lg">{t('betGuide')}</p>
                 <details className="bg-black/30 rounded-lg w-full max-w-sm">
-                  <summary className="cursor-pointer select-none px-4 py-2 text-white font-bold text-sm">
+                  <summary className="cursor-pointer select-none px-4 py-2 text-ds-text-primary font-bold text-sm">
                     {t('payoutRef.title')}
                   </summary>
                   <div className="px-4 pb-3 text-ds-text-muted text-sm space-y-2">
@@ -285,7 +285,7 @@ function LetItRidePageContent() {
             )}
 
             {!isBetPhase && (
-              <div className="flex justify-center gap-4 text-white text-sm mb-2" data-testid="bet-status">
+              <div className="flex justify-center gap-4 text-ds-text-primary text-sm mb-2" data-testid="bet-status">
                 <span>
                   {t('label.bet1')}: {state.bet1Active ? t('label.active') : t('label.pulled')}
                 </span>
@@ -299,7 +299,7 @@ function LetItRidePageContent() {
             )}
 
             {isEndPhase && (
-              <div className="text-white text-center text-sm mb-2" data-testid="payout-breakdown">
+              <div className="text-ds-text-primary text-center text-sm mb-2" data-testid="payout-breakdown">
                 {state.bet1Payout !== 0 && (
                   <div>
                     {t('payout.bet1')}: {state.bet1Payout}

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -207,7 +207,7 @@ function MemoryPageContent() {
           <div className="flex-1 overflow-y-auto lg:overflow-hidden lg:flex lg:flex-col pt-3 lg:pt-1 px-4 lg:px-8">
             {/* Player scores – compact inline layout to maximise board visibility */}
             <div
-              className="my-1 px-2 py-1 rounded bg-black/30 text-white text-sm flex flex-wrap items-center gap-y-0.5 lg:shrink-0"
+              className="my-1 px-2 py-1 rounded bg-black/30 text-ds-text-primary text-sm flex flex-wrap items-center gap-y-0.5 lg:shrink-0"
               data-tutorial="mem-score-table"
               role="status"
               aria-label={t('scores')}

--- a/frontend/src/pages/NapoleonPage.tsx
+++ b/frontend/src/pages/NapoleonPage.tsx
@@ -290,7 +290,7 @@ function NapoleonPageContent() {
           {/* Scrollable area */}
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>
             {/* Round/Trick info */}
-            <div className="text-white text-center mb-2">
+            <div className="text-ds-text-primary text-center mb-2">
               <span className="mr-4">{t('round', { n: state.roundNumber })}</span>
               <span className="mr-4">{t('trick', { n: state.trickNumber })}</span>
               {trumpLabel && (
@@ -594,7 +594,7 @@ function NapoleonPageContent() {
                     max={17}
                     value={bidValue}
                     onChange={(e) => setBidValue(Number(e.target.value))}
-                    className="w-16 px-2 py-1 rounded bg-white/20 text-white text-center"
+                    className="w-16 px-2 py-1 rounded bg-white/20 text-ds-text-primary text-center"
                     aria-label="bid-input"
                   />
                   <button type="button" className={btnPrimary} onClick={() => handleBid(bidValue)} disabled={loading}>
@@ -612,7 +612,7 @@ function NapoleonPageContent() {
                   <select
                     value={trumpSuitValue}
                     onChange={(e) => setTrumpSuitValue(Number(e.target.value))}
-                    className="px-2 py-1 rounded bg-white/20 text-white"
+                    className="px-2 py-1 rounded bg-white/20 text-ds-text-primary"
                     aria-label="trump-suit"
                   >
                     {[1, 2, 3, 4].map((s) => (
@@ -624,7 +624,7 @@ function NapoleonPageContent() {
                   <select
                     value={adjSuitValue}
                     onChange={(e) => setAdjSuitValue(Number(e.target.value))}
-                    className="px-2 py-1 rounded bg-white/20 text-white"
+                    className="px-2 py-1 rounded bg-white/20 text-ds-text-primary"
                     aria-label="adjutant-suit"
                   >
                     <option value={0}>JOKER</option>
@@ -638,7 +638,7 @@ function NapoleonPageContent() {
                     <select
                       value={adjValueValue}
                       onChange={(e) => setAdjValueValue(Number(e.target.value))}
-                      className="px-2 py-1 rounded bg-white/20 text-white"
+                      className="px-2 py-1 rounded bg-white/20 text-ds-text-primary"
                       aria-label="adjutant-value"
                     >
                       {Array.from({ length: 13 }, (_, i) => i + 1).map((v) => (

--- a/frontend/src/pages/NertzPage.tsx
+++ b/frontend/src/pages/NertzPage.tsx
@@ -158,7 +158,7 @@ function NertzPageContent() {
   if (!state || !human) {
     return (
       <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.nertz.bg}`}>
-        <div className="flex-1 flex items-center justify-center text-white">
+        <div className="flex-1 flex items-center justify-center text-ds-text-primary">
           <p>{tc('common.loading')}</p>
         </div>
       </div>
@@ -179,7 +179,7 @@ function NertzPageContent() {
       cancelReset={cancelReset}
     >
       <div className="flex-1 overflow-y-auto px-3 py-2 space-y-4">
-        <div className="bg-black/30 text-white p-3 rounded text-sm flex flex-wrap gap-x-4 gap-y-1">
+        <div className="bg-black/30 text-ds-text-primary p-3 rounded text-sm flex flex-wrap gap-x-4 gap-y-1">
           <span>
             {t('labels.round')}: {state.roundNumber}
           </span>
@@ -195,7 +195,7 @@ function NertzPageContent() {
 
         <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
 
-        <div data-tutorial="nertz-foundations" className="bg-black/30 text-white p-3 rounded">
+        <div data-tutorial="nertz-foundations" className="bg-black/30 text-ds-text-primary p-3 rounded">
           <div className="text-xs uppercase tracking-wide text-ds-text-muted mb-2">{t('labels.foundation')}</div>
           <div className="flex flex-wrap gap-2">
             {state.foundations.map((f, idx) => (
@@ -213,7 +213,7 @@ function NertzPageContent() {
         </div>
 
         {state.players.length > 1 && (
-          <div className="bg-black/30 text-white p-3 rounded text-sm space-y-1">
+          <div className="bg-black/30 text-ds-text-primary p-3 rounded text-sm space-y-1">
             {state.players
               .filter((p) => !p.isHuman)
               .map((p) => (
@@ -230,7 +230,7 @@ function NertzPageContent() {
           </div>
         )}
 
-        <div className="bg-black/30 text-white p-3 rounded space-y-2">
+        <div className="bg-black/30 text-ds-text-primary p-3 rounded space-y-2">
           <div className="flex flex-wrap gap-3 items-start">
             <div data-tutorial="nertz-pile" className="space-y-1">
               <div className="text-xs uppercase tracking-wide text-ds-text-muted">{t('labels.nertz')}</div>

--- a/frontend/src/pages/OhHellPage.tsx
+++ b/frontend/src/pages/OhHellPage.tsx
@@ -280,12 +280,12 @@ function OhHellPageContent() {
           {/* Scrollable area */}
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>
             {/* Round/Trick/Trump info */}
-            <div className="text-white text-center mb-2">
+            <div className="text-ds-text-primary text-center mb-2">
               <span className="mr-4">{t('round', { n: state.roundNumber, total: state.totalRounds })}</span>
               <span className="mr-4">{t('trick', { n: state.trickNumber })}</span>
               <span className="mr-4">{t('handSize', { n: state.handSize })}</span>
             </div>
-            <div className="text-white text-center mb-2">
+            <div className="text-ds-text-primary text-center mb-2">
               <span className="mr-4">{t('trump', { suit: t(`suitName.${state.trumpSuit}`) })}</span>
               <span>{t('dealer', { name: dealerName })}</span>
             </div>
@@ -525,7 +525,7 @@ function OhHellPageContent() {
                     max={state.handSize}
                     value={bidValue}
                     onChange={(e) => setBidValue(Number(e.target.value))}
-                    className="w-16 px-2 py-1 rounded bg-white/20 text-white text-center"
+                    className="w-16 px-2 py-1 rounded bg-white/20 text-ds-text-primary text-center"
                     aria-label="bid-input"
                   />
                   <button type="button" className={btnPrimary} onClick={() => handleBid(bidValue)} disabled={loading}>

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -304,7 +304,7 @@ function OldMaidPageContent() {
 
             {/* Status */}
             {statusLines.length > 0 && (
-              <div className="bg-black/50 rounded-lg text-white py-2 px-3 my-2 whitespace-pre-line text-sm">
+              <div className="bg-black/50 rounded-lg text-ds-text-primary py-2 px-3 my-2 whitespace-pre-line text-sm">
                 {statusLines.join('\n')}
               </div>
             )}
@@ -338,7 +338,7 @@ function OldMaidPageContent() {
 
             {/* JijiNuki: show removed card at game end */}
             {state.gameEndFlag && state.removedCard && (
-              <div className="text-center my-2 text-white text-sm">
+              <div className="text-center my-2 text-ds-text-primary text-sm">
                 {t('removedCard', { card: cardLabel(state.removedCard) })}
               </div>
             )}

--- a/frontend/src/pages/PageOnePage.tsx
+++ b/frontend/src/pages/PageOnePage.tsx
@@ -206,7 +206,7 @@ function PageOnePageContent() {
           />
 
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>
-            <div className="text-white text-center mb-2">
+            <div className="text-ds-text-primary text-center mb-2">
               <span className="mr-4">{t('round', { n: state.roundNumber })}</span>
               <span>{t('drawPile', { count: state.drawPileCount })}</span>
             </div>

--- a/frontend/src/pages/PaiGowPage.tsx
+++ b/frontend/src/pages/PaiGowPage.tsx
@@ -334,7 +334,7 @@ function PaiGowPageContent() {
                 )}
 
                 {/* Payout breakdown */}
-                <div className="text-white text-center text-sm mb-2" data-testid="payout-breakdown">
+                <div className="text-ds-text-primary text-center text-sm mb-2" data-testid="payout-breakdown">
                   {state.payout !== 0 && (
                     <div>
                       {t('label.payout')}: {state.payout}
@@ -376,7 +376,7 @@ function PaiGowPageContent() {
             {isBetPhase && (
               <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="pg-bet-controls">
                 <div className="flex items-center gap-2">
-                  <label htmlFor="paigow-bet-amount" className="text-white text-sm">
+                  <label htmlFor="paigow-bet-amount" className="text-ds-text-primary text-sm">
                     {t('label.bet')}
                   </label>
                   <input

--- a/frontend/src/pages/PigsTailPage.tsx
+++ b/frontend/src/pages/PigsTailPage.tsx
@@ -198,7 +198,7 @@ function PigsTailPageContent() {
                       : 'bg-black/30'
                   } ${isGameEnd && state.loserIdx === idx ? 'bg-ds-error/40 border border-ds-error/50' : ''}`}
                 >
-                  <span className="text-white text-sm font-medium">
+                  <span className="text-ds-text-primary text-sm font-medium">
                     {player.isHuman ? tc('player.you') : `CPU ${player.id}`}
                   </span>
                   <span className="text-ds-text-primary text-sm">
@@ -237,7 +237,7 @@ function PigsTailPageContent() {
               />
               <button
                 type="button"
-                className="px-4 py-2 rounded-lg bg-ds-surface-elevated hover:bg-ds-surface-elevated text-white text-sm transition-colors"
+                className="px-4 py-2 rounded-lg bg-ds-surface-elevated hover:bg-ds-surface-elevated text-ds-text-primary text-sm transition-colors"
                 onClick={showActionLog}
               >
                 {tc('actionLog.view')}

--- a/frontend/src/pages/PinochlePage.tsx
+++ b/frontend/src/pages/PinochlePage.tsx
@@ -168,7 +168,7 @@ function PinochlePageContent() {
 
   if (!state) {
     return (
-      <div className="p-4 text-center text-white">
+      <div className="p-4 text-center text-ds-text-primary">
         <p>{tc('status.thinking')}</p>
       </div>
     );
@@ -229,7 +229,7 @@ function PinochlePageContent() {
 
           <div className="flex-1 overflow-y-auto pt-3 px-4 lg:px-8">
             {/* Game Info */}
-            <div className="text-white text-center mb-2 text-sm" data-tutorial="pn-game-info">
+            <div className="text-ds-text-primary text-center mb-2 text-sm" data-tutorial="pn-game-info">
               <span className="mr-4">
                 {t('round')}: {state.roundNumber} / {t('trick')}: {state.trickNumber}
               </span>

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -243,7 +243,7 @@ function PokerPageContent() {
 
             {/* CPU exchanges log */}
             {state?.cpuExchanges && state.cpuExchanges.length > 0 && (
-              <div className="bg-black/30 rounded p-2 mb-3 text-white text-xs">
+              <div className="bg-black/30 rounded p-2 mb-3 text-ds-text-primary text-xs">
                 <div className="font-bold mb-1">{t('cpuExchange')}</div>
                 {state.cpuExchanges.map((ex, i) => (
                   <div key={`${i}-${ex.playerIdx}`}>
@@ -262,7 +262,7 @@ function PokerPageContent() {
             {/* Human player */}
             {humanPlayer && (
               <div className="mb-2" data-tutorial="pk-player-hand">
-                <div className="text-white text-lg mb-1">
+                <div className="text-ds-text-primary text-lg mb-1">
                   {t('yourHand')}
                   <span className="ml-3 text-xs">
                     {tc('betting.chips')} {humanPlayer.chips}
@@ -361,7 +361,7 @@ function PokerPageContent() {
 
             {/* Draw odds panel */}
             {canExchange && odds?.some((o) => o.probability > 0) && (
-              <div className="bg-black/40 rounded-lg px-4 py-2 mb-2 text-white text-xs" data-testid="odds-panel">
+              <div className="bg-black/40 rounded-lg px-4 py-2 mb-2 text-ds-text-primary text-xs" data-testid="odds-panel">
                 <div className="font-bold mb-1">{t('drawOdds')}</div>
                 {odds
                   .filter((o) => o.probability > 0)

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -361,7 +361,10 @@ function PokerPageContent() {
 
             {/* Draw odds panel */}
             {canExchange && odds?.some((o) => o.probability > 0) && (
-              <div className="bg-black/40 rounded-lg px-4 py-2 mb-2 text-ds-text-primary text-xs" data-testid="odds-panel">
+              <div
+                className="bg-black/40 rounded-lg px-4 py-2 mb-2 text-ds-text-primary text-xs"
+                data-testid="odds-panel"
+              >
                 <div className="font-bold mb-1">{t('drawOdds')}</div>
                 {odds
                   .filter((o) => o.probability > 0)

--- a/frontend/src/pages/PokerSquaresPage.tsx
+++ b/frontend/src/pages/PokerSquaresPage.tsx
@@ -224,7 +224,7 @@ function PokerSquaresPageContent() {
                             key={`row-score-${i}`}
                             data-testid={`row-score-${i}`}
                             style={{ height: Math.round(cardWidth * 1.4) }}
-                            className="flex items-center justify-center text-white text-sm font-mono px-2 rounded bg-black/30 min-w-[2.5rem]"
+                            className="flex items-center justify-center text-ds-text-primary text-sm font-mono px-2 rounded bg-black/30 min-w-[2.5rem]"
                           >
                             {s}
                           </div>
@@ -241,7 +241,7 @@ function PokerSquaresPageContent() {
                           key={`col-score-${i}`}
                           data-testid={`col-score-${i}`}
                           style={{ width: cardWidth }}
-                          className="text-center text-white text-sm font-mono py-1 rounded bg-black/30"
+                          className="text-center text-ds-text-primary text-sm font-mono py-1 rounded bg-black/30"
                         >
                           {s}
                         </div>
@@ -250,7 +250,7 @@ function PokerSquaresPageContent() {
                   </div>
                 </div>
 
-                <div className="text-center text-white text-lg font-bold mb-2" data-testid="total-score">
+                <div className="text-center text-ds-text-primary text-lg font-bold mb-2" data-testid="total-score">
                   {t('label.totalScore')}: {state.totalScore}
                 </div>
 

--- a/frontend/src/pages/RedDogPage.tsx
+++ b/frontend/src/pages/RedDogPage.tsx
@@ -109,7 +109,7 @@ function RedDogPageContent() {
   if (!state) {
     return (
       <div className={`flex-1 flex items-center justify-center ${gameTheme.reddog.bg}`}>
-        <div className="text-white">Loading...</div>
+        <div className="text-ds-text-primary">Loading...</div>
       </div>
     );
   }
@@ -157,7 +157,7 @@ function RedDogPageContent() {
               messageParams={state.messageParams}
             />
 
-            <label className="flex items-center gap-1 text-white text-xs justify-center mb-2 cursor-pointer">
+            <label className="flex items-center gap-1 text-ds-text-primary text-xs justify-center mb-2 cursor-pointer">
               <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
               {tc('hint.toggle', { ns: 'tutorial' })}
             </label>
@@ -168,7 +168,7 @@ function RedDogPageContent() {
               <div className="flex flex-col items-center justify-center py-4 gap-4">
                 <p className="text-ds-text-muted text-lg">{t('betGuide')}</p>
                 <details className="bg-black/30 rounded-lg w-full max-w-sm">
-                  <summary className="cursor-pointer select-none px-4 py-2 text-white font-bold text-sm">
+                  <summary className="cursor-pointer select-none px-4 py-2 text-ds-text-primary font-bold text-sm">
                     {t('payoutRef.title')}
                   </summary>
                   <div className="px-4 pb-3 text-ds-text-muted text-sm space-y-1">
@@ -199,7 +199,7 @@ function RedDogPageContent() {
                   ))}
                 </div>
                 {state.spread > 0 && (isSpreadDecision || isEndPhase) && (
-                  <div className="text-white text-center text-sm mt-2">
+                  <div className="text-ds-text-primary text-center text-sm mt-2">
                     {t('label.spread')}: {state.spread}
                   </div>
                 )}
@@ -220,7 +220,7 @@ function RedDogPageContent() {
             )}
 
             {isEndPhase && (
-              <div className="text-white text-center text-sm mb-2" data-testid="payout-breakdown">
+              <div className="text-ds-text-primary text-center text-sm mb-2" data-testid="payout-breakdown">
                 <div className="font-bold">
                   {t('payout.total')}: {state.totalPayout}
                 </div>

--- a/frontend/src/pages/SevenBridgePage.tsx
+++ b/frontend/src/pages/SevenBridgePage.tsx
@@ -178,7 +178,7 @@ function SevenBridgePageContent() {
           />
 
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>
-            <div className="text-white text-center mb-2">
+            <div className="text-ds-text-primary text-center mb-2">
               <span className="mr-4">{t('round', { n: state?.roundNumber ?? 0 })}</span>
               <span>{t('drawPile', { count: state?.drawPileCount ?? 0 })}</span>
             </div>

--- a/frontend/src/pages/SevensPage.tsx
+++ b/frontend/src/pages/SevensPage.tsx
@@ -356,12 +356,12 @@ function SevensPageContent() {
 
             {state.cpuActions && state.cpuActions.length > 0 && (
               <div className="bg-black/40 rounded-lg py-2 px-3.5 my-2 text-xs">
-                <span className="text-white">{tc('label.cpuActions')}</span>
+                <span className="text-ds-text-primary">{tc('label.cpuActions')}</span>
                 {state.cpuActions.map((a, i) => (
                   <div
                     key={`cpu-action-${a.playerIdx}-${i}`}
                     data-testid={a.forcedPass ? `cpu-action-forced-pass-${i}` : `cpu-action-${i}`}
-                    className={a.forcedPass ? 'text-ds-warning/80' : 'text-white'}
+                    className={a.forcedPass ? 'text-ds-warning/80' : 'text-ds-text-primary'}
                   >
                     {actionDesc(state.players, a, t)}
                   </div>

--- a/frontend/src/pages/ShitheadPage.tsx
+++ b/frontend/src/pages/ShitheadPage.tsx
@@ -65,7 +65,7 @@ function ShitheadPageContent() {
   if (!state) {
     return (
       <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.shithead.bg}`}>
-        <div className="flex-1 flex items-center justify-center text-white">
+        <div className="flex-1 flex items-center justify-center text-ds-text-primary">
           <p>{tc('common.loading')}</p>
         </div>
       </div>
@@ -94,7 +94,7 @@ function ShitheadPageContent() {
         {error && <ErrorAlert message={error} onRetry={retry} />}
 
         {/* CPU player rows */}
-        <div className="bg-black/30 text-white p-3 rounded text-sm space-y-1">
+        <div className="bg-black/30 text-ds-text-primary p-3 rounded text-sm space-y-1">
           {state.players
             .filter((p) => !p.isHuman)
             .map((p) => (
@@ -115,7 +115,7 @@ function ShitheadPageContent() {
         <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
 
         {/* Discard pile and stock */}
-        <div data-tutorial="sh-discard" className="bg-black/30 text-white p-3 rounded">
+        <div data-tutorial="sh-discard" className="bg-black/30 text-ds-text-primary p-3 rounded">
           <div className="flex flex-wrap items-center gap-3 text-sm">
             <span>
               {t('labels.discardPile')}: {state.discardPile.length === 0 ? '—' : describeTopCard(state.discardPile)}
@@ -130,7 +130,7 @@ function ShitheadPageContent() {
 
         {/* Human player area */}
         {humanPlayer && (
-          <div data-tutorial="sh-player-hand" className="bg-black/30 text-white p-3 rounded space-y-2">
+          <div data-tutorial="sh-player-hand" className="bg-black/30 text-ds-text-primary p-3 rounded space-y-2">
             <div className="text-sm">
               {t('labels.you')} —{' '}
               {humanPlayer.isFinished

--- a/frontend/src/pages/SkatPage.tsx
+++ b/frontend/src/pages/SkatPage.tsx
@@ -97,7 +97,7 @@ function SkatPageContent() {
   if (!state) {
     return (
       <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.skat.bg}`}>
-        <div className="flex-1 flex items-center justify-center text-white">
+        <div className="flex-1 flex items-center justify-center text-ds-text-primary">
           <p>{t('common.loading')}</p>
         </div>
       </div>
@@ -136,7 +136,7 @@ function SkatPageContent() {
         {error && <ErrorAlert message={error} onRetry={retry} />}
 
         {/* Round / declarer / game info */}
-        <div className="bg-black/30 text-white p-3 rounded space-y-1 text-sm">
+        <div className="bg-black/30 text-ds-text-primary p-3 rounded space-y-1 text-sm">
           <div>
             {t('round')}: {state.roundNumber} | {t('dealer')}: CPU {state.dealerIdx} | {t('currentBid')}:{' '}
             {state.currentBid}
@@ -171,7 +171,7 @@ function SkatPageContent() {
 
         {/* Skat (face-up at round end) */}
         {state.originalSkat && state.originalSkat.length > 0 && (
-          <div className="bg-black/30 text-white p-3 rounded">
+          <div className="bg-black/30 text-ds-text-primary p-3 rounded">
             <div className="text-sm mb-1">{t('skatLabel')}:</div>
             <div className="flex gap-2">
               {state.originalSkat.map((c, i) => (
@@ -196,7 +196,7 @@ function SkatPageContent() {
         )}
 
         {/* Player scores */}
-        <div className="bg-black/30 text-white p-3 rounded text-sm">
+        <div className="bg-black/30 text-ds-text-primary p-3 rounded text-sm">
           <table className="w-full">
             <thead>
               <tr>

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -288,7 +288,7 @@ function SlapjackPageContent() {
                 type="button"
                 onClick={handleSlap}
                 disabled={loading || isGameEnd || state.centerPileSize === 0}
-                className={`px-6 py-2 rounded-lg text-white font-bold disabled:opacity-40 disabled:cursor-not-allowed ${
+                className={`px-6 py-2 rounded-lg text-ds-text-primary font-bold disabled:opacity-40 disabled:cursor-not-allowed ${
                   state.isTopJack
                     ? 'bg-ds-warning hover:bg-ds-warning-hover animate-pulse'
                     : 'bg-ds-error hover:bg-ds-error'

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -288,7 +288,7 @@ function SlapjackPageContent() {
                 type="button"
                 onClick={handleSlap}
                 disabled={loading || isGameEnd || state.centerPileSize === 0}
-                className={`px-6 py-2 rounded-lg text-ds-text-primary font-bold disabled:opacity-40 disabled:cursor-not-allowed ${
+                className={`px-6 py-2 rounded-lg text-white font-bold disabled:opacity-40 disabled:cursor-not-allowed ${
                   state.isTopJack
                     ? 'bg-ds-warning hover:bg-ds-warning-hover animate-pulse'
                     : 'bg-ds-error hover:bg-ds-error'

--- a/frontend/src/pages/SpadesPage.tsx
+++ b/frontend/src/pages/SpadesPage.tsx
@@ -249,7 +249,7 @@ function SpadesPageContent() {
           {/* Scrollable area */}
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>
             {/* Round/Trick info */}
-            <div className="text-white text-center mb-2">
+            <div className="text-ds-text-primary text-center mb-2">
               <span className="mr-4">{t('round', { n: state.roundNumber })}</span>
               <span className="mr-4">{t('trick', { n: state.trickNumber })}</span>
               <span>{state.spadesBroken ? t('spadesBroken') : t('spadesNotBroken')}</span>
@@ -453,7 +453,7 @@ function SpadesPageContent() {
                     max={13}
                     value={bidValue}
                     onChange={(e) => setBidValue(Number(e.target.value))}
-                    className="w-16 px-2 py-1 rounded bg-white/20 text-white text-center"
+                    className="w-16 px-2 py-1 rounded bg-white/20 text-ds-text-primary text-center"
                     aria-label="bid-input"
                   />
                   <button type="button" className={btnPrimary} onClick={() => handleBid(bidValue)} disabled={loading}>

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -448,7 +448,7 @@ function SpiderPageContent() {
                   onChange={(e) => {
                     handleResetWithConfig({ difficulty: Number(e.target.value) });
                   }}
-                  className="bg-ds-surface-elevated text-white text-sm rounded px-2 py-1"
+                  className="bg-ds-surface-elevated text-ds-text-primary text-sm rounded px-2 py-1"
                   aria-label={t('difficulty')}
                 >
                   <option value={1}>{t('difficulty1')}</option>

--- a/frontend/src/pages/ThreeCardPage.tsx
+++ b/frontend/src/pages/ThreeCardPage.tsx
@@ -183,7 +183,7 @@ function ThreeCardPageContent() {
               <div className="flex flex-col items-center justify-center py-4 gap-4">
                 <p className="text-ds-text-muted text-lg">{t('betGuide')}</p>
                 <details className="bg-black/30 rounded-lg w-full max-w-sm">
-                  <summary className="cursor-pointer select-none px-4 py-2 text-white font-bold text-sm">
+                  <summary className="cursor-pointer select-none px-4 py-2 text-ds-text-primary font-bold text-sm">
                     {t('payoutRef.title')}
                   </summary>
                   <div className="px-4 pb-3 text-ds-text-muted text-sm space-y-2">
@@ -269,7 +269,7 @@ function ThreeCardPageContent() {
 
             {/* Payout breakdown */}
             {isEndPhase && (
-              <div className="text-white text-center text-sm mb-2" data-testid="payout-breakdown">
+              <div className="text-ds-text-primary text-center text-sm mb-2" data-testid="payout-breakdown">
                 {state.antePayout !== 0 && (
                   <div>
                     {t('payout.ante')}: {state.antePayout}
@@ -323,7 +323,7 @@ function ThreeCardPageContent() {
             {isBetPhase && (
               <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="tc-bet-controls">
                 <div className="flex items-center gap-2">
-                  <label htmlFor="threecard-ante-amount" className="text-white text-sm">
+                  <label htmlFor="threecard-ante-amount" className="text-ds-text-primary text-sm">
                     {t('label.ante')}
                   </label>
                   <input
@@ -338,7 +338,7 @@ function ThreeCardPageContent() {
                   />
                 </div>
                 <div className="flex items-center gap-2">
-                  <label htmlFor="threecard-pairplus-amount" className="text-white text-sm">
+                  <label htmlFor="threecard-pairplus-amount" className="text-ds-text-primary text-sm">
                     {t('label.pairPlus')}
                   </label>
                   <input

--- a/frontend/src/pages/TwoTenJackPage.tsx
+++ b/frontend/src/pages/TwoTenJackPage.tsx
@@ -240,7 +240,7 @@ function TwoTenJackPageContent() {
           />
 
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>
-            <div className="text-white text-center mb-2">
+            <div className="text-ds-text-primary text-center mb-2">
               <span className="mr-4">{t('round', { n: state.roundNumber })}</span>
               <span className="mr-4">{t('trick', { n: state.trickNumber })}</span>
               <span>

--- a/frontend/src/pages/WhistPage.tsx
+++ b/frontend/src/pages/WhistPage.tsx
@@ -230,7 +230,7 @@ function WhistPageContent() {
           {/* Scrollable area */}
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>
             {/* Round/Trick/Trump info */}
-            <div className="text-white text-center mb-2" data-tutorial="wh-trump-info">
+            <div className="text-ds-text-primary text-center mb-2" data-tutorial="wh-trump-info">
               <span className="mr-4">{t('round', { n: state.roundNumber })}</span>
               <span className="mr-4">{t('trick', { n: state.trickNumber })}</span>
               <span>


### PR DESCRIPTION
## Summary

Continues #1544's staged sweep. After the previous Holdem-family slice (PR #1578), the rest of `frontend/src/pages/` still carried **129 `text-white` sites** for body / heading / label / paragraph copy across 46 pages. This PR applies the same warm-ivory `--text-primary` swap to every site whose own line does **not** carry a saturated background utility (`bg-ds-success` / `warning` / `error` / `info` / `accent` or `bg-poker-*`).

The script that drove the sweep treats each `text-white`-bearing line in isolation and only rewrites it when no saturated bg class is co-located on that line, so high-contrast button / badge / alert pairings keep their pure white intentionally.

## Counts

- **110 sites replaced across 42 pages**
- **19 sites kept** (saturated bg buttons / badges / alerts), spread across:
  - `CassinoPage` info pills (`bg-ds-info/60`, `bg-ds-warning/60`)
  - `DaifugoPage`, `FiftyOnePage`, `OldMaidPage` error / warning badges
  - `PigsTailPage` info-pill controls
  - `PokerPage`, `PresidentPage` button rows on `bg-ds-info` / `bg-ds-success`
  - `SpeedPage`, `WarPage`, `SlapjackPage` saturated banners

## Test plan

- [x] `bun run test -- --run BlackJackPage DoubtPage NertzPage NapoleonPage RedDogPage` — 337/337 pass on the five highest-edit pages (representative smoke)
- [x] No test file asserts on `text-white` className strings, so the swap is invisible to assertions
- [x] `bun run check` — clean (4 pre-existing warnings unrelated)
- [x] No DOM, attribute, or text content changes; only the warm tint shift

Refs #1544

Remaining `text-white` count after this PR: 22 sites (game-specific components in `hearts/`, `poker/`, `betting/`, etc. plus the 19 saturated-bg keepers above) — ready for any final per-folder slice.