### PR TITLE
fix(test): make SlapjackCuiPresenter wrong-slap tests deterministic

### DIFF
--- a/internal/adapter/presenter/SlapjackCuiPresenter_test.go
+++ b/internal/adapter/presenter/SlapjackCuiPresenter_test.go
@@ -111,7 +111,12 @@ func TestSlapjackCuiPresenter_Output(t *testing.T) {
 
 	t.Run("last event wrong slap human", func(t *testing.T) {
 		g := setupSlapjackTest()
-		// Step a non-J card first
+		// Force a non-Jack on top of player 0's stock so Step always flips a
+		// non-Jack — without this the flipped card is whatever Reset() shuffled
+		// to the top, so ~1/13 of the time it's a Jack and the subsequent
+		// Slap(0) is registered as a CORRECT slap, breaking the assertion.
+		g.GetPlayer(0).ResetStock()
+		g.GetPlayer(0).AddToStockTop(domain.NewCard(domain.CardDesignSpade, 2, false))
 		assert.NoError(t, g.Step())
 		// Force the last event to wrong-slap by human via Slap
 		_ = g.Slap(0)
@@ -120,6 +125,9 @@ func TestSlapjackCuiPresenter_Output(t *testing.T) {
 
 	t.Run("last event wrong slap cpu", func(t *testing.T) {
 		g := setupSlapjackTest()
+		// Same determinism fix as the human variant above.
+		g.GetPlayer(0).ResetStock()
+		g.GetPlayer(0).AddToStockTop(domain.NewCard(domain.CardDesignSpade, 2, false))
 		assert.NoError(t, g.Step())
 		_ = g.Slap(1)
 		assert.Contains(t, p.Output(g, nil), "CPU が誤スラップ")


### PR DESCRIPTION
## Summary

\`TestSlapjackCuiPresenter_Output\`'s \`last_event_wrong_slap_human\` and \`last_event_wrong_slap_cpu\` subtests called \`Step()\` on a freshly-shuffled deck without controlling the top card. Roughly **1 in 13 runs** the flipped card was a Jack, so the subsequent \`Slap(0)\`/\`Slap(1)\` was a CORRECT slap and the assertion that the output contained \`誤スラップ\` failed.

The flake has been hitting CI on multiple unrelated PRs (#1573, #1574) because they happened to land on the unlucky shuffle.

## Fix

Mirror the deterministic pattern the "correct slap" subtests already use — \`ResetStock\` + \`AddToStockTop\` with a chosen card — but force a non-Jack (2♠) so \`Step\` always flips a non-Jack and the wrong-slap branch is the only one \`Slap\` can take.

## Test plan

- [x] \`go test -tags test ./internal/adapter/presenter/ -run TestSlapjackCuiPresenter_Output -count=20\` — 20/20 pass (was failing ~1/13 runs before)
- [x] \`golangci-lint run ./internal/adapter/presenter/...\` — 0 issues
- [x] \`goimports -w\` on modified file