### PR TITLE
feat(cli): version subcommand, alias-aware suggestions, exit-codes help

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ go run ./cmd/trumpcards --lang en <game>   # Run in English
 go run ./cmd/trumpcards games      # List all available games
 go run ./cmd/trumpcards games --short  # List game names only (for scripting)
 go run ./cmd/trumpcards update     # Self-update to the latest version
+go run ./cmd/trumpcards version    # Show version information (equivalent to --version)
+go run ./cmd/trumpcards version --short  # Print version number only (machine-readable)
 go run ./cmd/trumpcards help       # Show top-level help
 go run ./cmd/trumpcards help blackjack  # Show help text for a specific game
 go run ./cmd/trumpcards web        # Start REST API + web GUI server (via CLI)

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ trumpcards --lang en blackjack   # ブラックジャック CLI (英語)
 trumpcards web                   # REST API + Web GUI サーバー起動
 trumpcards web --port 3000       # カスタムポートで起動 (--port フラグ)
 trumpcards update                # 最新版にセルフアップデート
+trumpcards version               # バージョン情報を表示 (--version と等価)
+trumpcards version --short       # バージョン番号のみ出力 (機械読み取り用)
 trumpcards help                  # ヘルプを表示
 trumpcards help blackjack        # 特定ゲームの操作方法を表示
 PORT=3000 trumpcards web         # カスタムポートで起動 (環境変数)

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -247,6 +247,21 @@ func run() int {
 	commands["help"] = func() int {
 		return runHelpCommand(flag.Args()[1:], helpText, os.Stdout, os.Stderr)
 	}
+	commands["version"] = func() int {
+		var short bool
+		_, code, ok := parseSubFlags("version", func(f *flag.FlagSet) {
+			f.BoolVar(&short, "short", false, "Print version number only (machine-readable)")
+		})
+		if !ok {
+			return code
+		}
+		if short {
+			fmt.Println(version)
+			return 0
+		}
+		fmt.Printf("trumpcards %s (commit: %s, built: %s)\n", version, commit, date)
+		return 0
+	}
 	commands["update"] = func() int {
 		var yes, check bool
 		_, code, ok := parseSubFlags("update", func(f *flag.FlagSet) {
@@ -321,7 +336,7 @@ func run() int {
 
 	// Commands that parse their own sub-flags; skip the extra-args warning for these.
 	// parseSubFlags-based commands handle extra-args warnings internally.
-	subFlagCommands := map[string]bool{"web": true, "completion": true, "games": true, "update": true, "help": true}
+	subFlagCommands := map[string]bool{"web": true, "completion": true, "games": true, "update": true, "help": true, "version": true}
 
 	arg := strings.ToLower(flag.Arg(0))
 	// Resolve game name aliases (e.g., "gin" -> "ginrummy", "7stud" -> "sevencardstud").
@@ -352,7 +367,7 @@ func run() int {
 
 	if arg != "" {
 		fmt.Fprintln(os.Stderr, i18n.Tf("cliUnknownGame", "name", arg))
-		if suggestion := cuiutil.SuggestCommand(arg, mapKeys(commands), 2); suggestion != "" {
+		if suggestion := cuiutil.SuggestCommand(arg, suggestionCandidates(commands), 2); suggestion != "" {
 			fmt.Fprintf(os.Stderr, "  %s\n", i18n.Tf("didYouMean", "name", suggestion))
 		}
 		fmt.Fprintln(os.Stderr)
@@ -483,6 +498,20 @@ var builtinSubcommandHelp = map[string][]string{
 		"  trumpcards help blackjack",
 		"  trumpcards help web",
 	},
+	"version": {
+		"USAGE:",
+		"  trumpcards version [--short]",
+		"",
+		"FLAGS:",
+		"      --short   Print the version number only (machine-readable)",
+		"",
+		"EXAMPLES:",
+		"  trumpcards version              # full info: trumpcards <ver> (commit: <sha>, built: <date>)",
+		"  trumpcards version --short      # just the version (e.g. 1.2.3)",
+		"",
+		"NOTES:",
+		"  Equivalent to the global --version / -V flag (and --version-short for --short).",
+	},
 }
 
 // runHelpCommand implements the `trumpcards help [game]` subcommand.
@@ -519,10 +548,63 @@ func runHelpCommand(args []string, helpText string, stdout, stderr io.Writer) in
 		return 0
 	}
 	_, _ = fmt.Fprintln(stderr, i18n.Tf("cliHelpUnknownGame", "name", target))
-	if suggestion := cuiutil.SuggestCommand(target, ui.GameNames(), 2); suggestion != "" {
+	if suggestion := cuiutil.SuggestCommand(target, helpSuggestionCandidates(), 2); suggestion != "" {
 		_, _ = fmt.Fprintf(stderr, "  %s\n", i18n.Tf("didYouMean", "name", suggestion))
 	}
 	return 1
+}
+
+// helpSuggestionCandidates returns the deduplicated set of canonical game
+// names, builtin subcommand names, and their game aliases. Used by
+// `runHelpCommand` so that `trumpcards help <typo>` recovers a likely
+// alias (e.g. `gni` -> `gin`) instead of a far-off canonical name. See
+// issue #1555.
+func helpSuggestionCandidates() []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0)
+	add := func(name string) {
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	for _, name := range ui.GameNames() {
+		add(name)
+	}
+	for name := range builtinSubcommandHelp {
+		add(name)
+	}
+	for alias := range ui.GameAliases {
+		add(alias)
+	}
+	return out
+}
+
+// suggestionCandidates returns the deduplicated set of registered top-level
+// commands (canonical game names plus builtin subcommands such as `web` or
+// `update`) and game aliases (e.g. `gin`, `7stud`) for "did you mean"
+// suggestions on unknown game names. Aliases are useful targets here because
+// users sometimes typo the alias, not the canonical, and a canonical-only
+// candidate list returns nonsense (`gni` -> `gofish` instead of `gin`).
+// See issue #1555.
+func suggestionCandidates(commands map[string]func() int) []string {
+	seen := make(map[string]struct{}, len(commands)+len(ui.GameAliases))
+	out := make([]string, 0, len(commands)+len(ui.GameAliases))
+	add := func(name string) {
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	for k := range commands {
+		add(k)
+	}
+	for alias := range ui.GameAliases {
+		add(alias)
+	}
+	return out
 }
 
 // parseSubFlags creates a FlagSet, applies setup, parses subcommand args, and
@@ -674,14 +756,6 @@ func hasHelpFlag(args []string) bool {
 	return false
 }
 
-func mapKeys(m map[string]func() int) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
-}
-
 // buildHelpText generates the CLI help text with the games section derived from the registry.
 func buildHelpText() string {
 	var sb strings.Builder
@@ -700,6 +774,7 @@ COMMANDS:
   help [game]  Show this help, or a specific game's help text
   completion   Generate shell completion script (bash, zsh, fish)
   update       Self-update to the latest version
+  version      Show version information (equivalent to --version; --short for machine-readable)
   web          Start REST API + web GUI server
 
   (no argument) Interactive mode with game switching
@@ -744,6 +819,17 @@ ENVIRONMENT VARIABLES:
                     Example: HOST=0.0.0.0 trumpcards web
   PORT              Port number for the web server (default: 8080)
                     Example: PORT=3000 trumpcards web
+
+EXIT CODES:
+   0  Success (normal exit, EOF, or 'exit' command)
+   1  General error (e.g., web server failed to start)
+   2  Usage error (invalid flags, unknown category, missing required argument)
+  10  'update --check': a newer version is available (non-error signal for scripts)
+  75  'update': user declined the confirmation prompt
+ 130  Terminated by SIGINT (Ctrl+C; POSIX 128 + 2)
+ 143  Terminated by SIGTERM (POSIX 128 + 15)
+
+  See 'trumpcards help update' for update-specific exit codes (3, 4, 5, 6).
 `)
 	return sb.String()
 }

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -560,8 +560,9 @@ func runHelpCommand(args []string, helpText string, stdout, stderr io.Writer) in
 // alias (e.g. `gni` -> `gin`) instead of a far-off canonical name. See
 // issue #1555.
 func helpSuggestionCandidates() []string {
-	seen := make(map[string]struct{})
-	out := make([]string, 0)
+	capacity := len(ui.GameNames()) + len(builtinSubcommandHelp) + len(ui.GameAliases)
+	seen := make(map[string]struct{}, capacity)
+	out := make([]string, 0, capacity)
 	add := func(name string) {
 		if _, ok := seen[name]; ok {
 			return

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -1089,3 +1089,149 @@ func TestApplyTrailingGlobalFlags(t *testing.T) {
 		})
 	}
 }
+
+// TestRunVersionSubcommand verifies issue #1552: `trumpcards version` is
+// equivalent to the `--version` flag, and `trumpcards version --short` is
+// equivalent to `--version-short`. The subcommand form matters because it
+// matches the conventions of `git`, `gh`, `kubectl`, etc.; users who type
+// the subcommand by habit must not see an "unknown game" error.
+func TestRunVersionSubcommand(t *testing.T) {
+	cases := []struct {
+		name      string
+		args      []string
+		wantExit  int
+		wantSubst string
+	}{
+		{
+			name:      "long form prints full version line",
+			args:      []string{"trumpcards", "version"},
+			wantExit:  0,
+			wantSubst: "trumpcards ",
+		},
+		{
+			name:      "--short prints just the version token",
+			args:      []string{"trumpcards", "version", "--short"},
+			wantExit:  0,
+			wantSubst: version,
+		},
+	}
+	origArgs := os.Args
+	origCmdLine := flag.CommandLine
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	defer func() {
+		os.Args = origArgs
+		flag.CommandLine = origCmdLine
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			flag.CommandLine = flag.NewFlagSet("trumpcards", flag.ExitOnError)
+			os.Args = tc.args
+
+			rOut, wOut, _ := os.Pipe()
+			rErr, wErr, _ := os.Pipe()
+			os.Stdout = wOut
+			os.Stderr = wErr
+
+			exitCh := make(chan int, 1)
+			go func() { exitCh <- run() }()
+			exit := <-exitCh
+
+			_ = wOut.Close()
+			_ = wErr.Close()
+			var outBuf, errBuf bytes.Buffer
+			_, _ = outBuf.ReadFrom(rOut)
+			_, _ = errBuf.ReadFrom(rErr)
+
+			if exit != tc.wantExit {
+				t.Errorf("exit = %d, want %d (stderr=%q)", exit, tc.wantExit, errBuf.String())
+			}
+			if !strings.Contains(outBuf.String(), tc.wantSubst) {
+				t.Errorf("stdout missing %q; got %q", tc.wantSubst, outBuf.String())
+			}
+			if errBuf.Len() != 0 {
+				t.Errorf("expected no stderr output; got %q", errBuf.String())
+			}
+		})
+	}
+}
+
+// TestSuggestionCandidatesIncludesAliases verifies issue #1555: the
+// "did you mean" candidate set must include game aliases so a typo of
+// the alias (`gni` -> `gin`) is recovered to the alias the user knows
+// about, rather than to a far-off canonical name (`gofish`).
+func TestSuggestionCandidatesIncludesAliases(t *testing.T) {
+	commands := map[string]func() int{
+		"ginrummy":      func() int { return 0 },
+		"sevencardstud": func() int { return 0 },
+		"gofish":        func() int { return 0 },
+	}
+	got := suggestionCandidates(commands)
+	gotSet := make(map[string]struct{}, len(got))
+	for _, n := range got {
+		gotSet[n] = struct{}{}
+	}
+	for _, want := range []string{"ginrummy", "sevencardstud", "gofish"} {
+		if _, ok := gotSet[want]; !ok {
+			t.Errorf("missing canonical %q from candidates: %v", want, got)
+		}
+	}
+	// At least one alias must appear; pick a known one if it exists.
+	if _, ok := ui.GameAliases["gin"]; ok {
+		if _, present := gotSet["gin"]; !present {
+			t.Errorf("alias 'gin' should be in candidates: %v", got)
+		}
+	}
+	// Spot-check dedup: if an alias collides with a canonical (it shouldn't,
+	// but the helper must still be idempotent), the slice must not contain
+	// the same string twice. We assert the invariant via len(map)==len(slice).
+	if len(gotSet) != len(got) {
+		t.Errorf("candidates contain duplicates: %v", got)
+	}
+}
+
+// TestHelpSuggestionCandidatesIncludesAliases verifies issue #1555: the
+// runHelpCommand suggestion path also pulls aliases, so `trumpcards help
+// gni` recovers to `gin` (or `ginrummy`) rather than a distant canonical.
+func TestHelpSuggestionCandidatesIncludesAliases(t *testing.T) {
+	got := helpSuggestionCandidates()
+	gotSet := make(map[string]struct{}, len(got))
+	for _, n := range got {
+		gotSet[n] = struct{}{}
+	}
+	if _, ok := ui.GameAliases["gin"]; ok {
+		if _, present := gotSet["gin"]; !present {
+			t.Errorf("alias 'gin' should be in help candidates: %v", got)
+		}
+	}
+	// Builtin subcommands should also be suggestable for `trumpcards help <cmd>` typos.
+	for _, want := range []string{"web", "update", "version"} {
+		if _, ok := gotSet[want]; !ok {
+			t.Errorf("missing builtin %q from help candidates: %v", want, got)
+		}
+	}
+}
+
+// TestBuildHelpTextHasExitCodes verifies issue #1556: the top-level --help
+// must document the exit-code policy so CI / cron / scripts can branch on
+// it without reading the source.
+func TestBuildHelpTextHasExitCodes(t *testing.T) {
+	helpText := buildHelpText()
+	for _, want := range []string{"EXIT CODES:", " 130 ", " 143 ", " 10 ", " 75 "} {
+		if !strings.Contains(helpText, want) {
+			t.Errorf("help text missing %q; got:\n%s", want, helpText)
+		}
+	}
+}
+
+// TestBuildHelpTextMentionsVersionSubcommand verifies issue #1552: the
+// COMMANDS section advertises the subcommand alongside the existing
+// flags so it is discoverable from `trumpcards --help`.
+func TestBuildHelpTextMentionsVersionSubcommand(t *testing.T) {
+	helpText := buildHelpText()
+	if !strings.Contains(helpText, "version") {
+		t.Errorf("help text should advertise the 'version' subcommand; got:\n%s", helpText)
+	}
+}


### PR DESCRIPTION
## Summary

Three small CLI UX improvements bundled because they all touch `cmd/trumpcards/main.go` and are independently uncontroversial:

- **Closes #1552** — `trumpcards version [--short]` mirrors `--version` / `--version-short` so users with the `git/gh/kubectl/docker version` habit no longer hit *"unknown game"*. Also discoverable via `trumpcards help version`.
- **Closes #1555** — `ui.GameAliases` keys are now part of the *did-you-mean* candidate set for unknown top-level args **and** for `trumpcards help <typo>`. A typo of an alias (`gni` → `gin`) now recovers to the alias the user knows about instead of a far-off canonical (`gofish`).
- **Closes #1556** — top-level `--help` gained an EXIT CODES section (0/1/2/10/75/130/143) with a pointer to `trumpcards help update` for update-specific 3..6.

## Test plan

- [x] `go test -tags test ./...` passes (incl. 4 new tests: version subcommand long+short, candidate set includes aliases & builtins, help text has EXIT CODES section, COMMANDS lists `version`)
- [x] `golangci-lint run ./...` clean
- [x] `goimports -w` applied
- [x] Manual smoke: `trumpcards version`, `trumpcards version --short`, `trumpcards help version`, `trumpcards gni` → suggests `gin`, `trumpcards --help` shows EXIT CODES.

## Notes

- `mapKeys` helper deleted (only call site replaced by `suggestionCandidates`).
- `version` added to `subFlagCommands` so the trailing-flags warning isn't double-applied; `parseSubFlags` handles its own extra-args feedback.