### PR TITLE
feat(trash): auto-place wild when only one face-down slot remains (#1565)

### DIFF
--- a/internal/domain/Trash.go
+++ b/internal/domain/Trash.go
@@ -166,14 +166,15 @@ func (t *Trash) placeWildAt(idx int) {
 }
 
 // onlyEmptySlot returns the slot index (0..TrashSlotCnt-1) when the player
-// at idx has exactly one face-down slot left, or -1 if there are zero or
-// more than one. Used to gate auto-placement of wild cards (issue #1565):
+// at playerIdx has exactly one face-down slot left, or -1 if there are zero
+// or more than one. Used to gate auto-placement of wild cards (issue #1565):
 // with no empty slot we should never have reached this code path, and with
 // two or more we want the human to keep their tactical choice.
+//
+// Unexported and only called from resolveChain with t.current, which the
+// game state machine guarantees to be in [0, TrashPlayerCnt) — no bounds
+// guard needed (PR #1584 review).
 func (t *Trash) onlyEmptySlot(playerIdx int) int {
-	if playerIdx < 0 || playerIdx >= TrashPlayerCnt {
-		return -1
-	}
 	found := -1
 	for i, s := range t.players[playerIdx].Slots {
 		if s.FaceUp {

--- a/internal/domain/Trash.go
+++ b/internal/domain/Trash.go
@@ -126,17 +126,31 @@ func (t *Trash) PlaceWild(pos int) error {
 	if pos < 1 || pos > TrashSlotCnt {
 		return errors.New("invalid position")
 	}
-	p := &t.players[t.current]
 	idx := pos - 1
-	if p.Slots[idx].FaceUp {
+	if t.players[t.current].Slots[idx].FaceUp {
 		return errors.New("slot already filled")
 	}
+	t.placeWildAt(idx)
+	if t.phase == TrashPhasePlayerTurn {
+		t.resolveChain()
+	}
+	return nil
+}
+
+// placeWildAt is the shared core of explicit wild placement (PlaceWild) and
+// the single-empty-slot auto-placement triggered from resolveChain (issue
+// #1565). It assumes idx is in range and refers to a face-down slot — both
+// callers validate before invoking. The phase is left at PlayerTurn on a
+// non-winning placement so the caller decides whether to keep resolving the
+// chain (auto path stays in the loop; explicit path re-enters resolveChain).
+func (t *Trash) placeWildAt(idx int) {
+	p := &t.players[t.current]
 	wild := t.pending
 	old := p.Slots[idx].Card
 	p.Slots[idx].Card = wild
 	p.Slots[idx].FaceUp = true
 	t.pending = old
-	t.appendLog("placeWild", fmt.Sprintf("プレイヤー%dが位置%dにワイルドを配置", t.current, pos), []*Card{wild})
+	t.appendLog("placeWild", fmt.Sprintf("プレイヤー%dが位置%dにワイルドを配置", t.current, idx+1), []*Card{wild})
 
 	if t.isWin(t.current) {
 		t.winner = t.current
@@ -146,11 +160,31 @@ func (t *Trash) PlaceWild(pos int) error {
 			t.pending = nil
 		}
 		t.appendLog("win", fmt.Sprintf("プレイヤー%dの勝利", t.current), nil)
-		return nil
+		return
 	}
 	t.phase = TrashPhasePlayerTurn
-	t.resolveChain()
-	return nil
+}
+
+// onlyEmptySlot returns the slot index (0..TrashSlotCnt-1) when the player
+// at idx has exactly one face-down slot left, or -1 if there are zero or
+// more than one. Used to gate auto-placement of wild cards (issue #1565):
+// with no empty slot we should never have reached this code path, and with
+// two or more we want the human to keep their tactical choice.
+func (t *Trash) onlyEmptySlot(playerIdx int) int {
+	if playerIdx < 0 || playerIdx >= TrashPlayerCnt {
+		return -1
+	}
+	found := -1
+	for i, s := range t.players[playerIdx].Slots {
+		if s.FaceUp {
+			continue
+		}
+		if found != -1 {
+			return -1
+		}
+		found = i
+	}
+	return found
 }
 
 // IsCpuTurn 現在のターンがCPUか
@@ -264,11 +298,23 @@ func (t *Trash) GetActionLog() []*ActionLogEntry { return t.actionLog }
 // --- Private helpers ---
 
 // resolveChain pendingカードを順次解決する。連鎖中にAwaitWild/GameOver/EndTurnのいずれかに到達したら終了。
+//
+// Auto-placement (issue #1565): when a wild card surfaces and the current
+// player has exactly one face-down slot left, the wild is placed directly
+// instead of transitioning to TrashPhaseAwaitWild. This removes a forced
+// click for an outcome that has no meaningful choice — the only legal
+// destination — and matches the tempo Trash relies on. With multiple
+// empty slots the human still chooses; CPUs continue to auto-place via
+// CpuStep regardless of count.
 func (t *Trash) resolveChain() {
 	for t.pending != nil && t.phase == TrashPhasePlayerTurn {
 		c := t.pending
 		switch {
 		case isTrashWild(c):
+			if idx := t.onlyEmptySlot(t.current); idx >= 0 {
+				t.placeWildAt(idx)
+				continue
+			}
 			t.phase = TrashPhaseAwaitWild
 			return
 		case isTrashEndTurn(c):

--- a/internal/domain/Trash_test.go
+++ b/internal/domain/Trash_test.go
@@ -110,6 +110,74 @@ func TestTrashDrawJokerAwaitsPlacement(t *testing.T) {
 	assert.Equal(t, TrashPhaseAwaitWild, tr.GetPhase())
 }
 
+// TestTrashDrawWildAutoPlacesWithSingleEmptySlot pins issue #1565: when a
+// wild card surfaces and the human has exactly one face-down slot, the
+// game must auto-place the wild instead of asking the user to pick — there
+// is no meaningful choice and the forced click breaks Trash's tempo.
+func TestTrashDrawWildAutoPlacesWithSingleEmptySlot(t *testing.T) {
+	t.Run("King wild auto-placed and chain continues", func(t *testing.T) {
+		tr := NewDefaultTrash()
+		tr.Reset()
+		// Positions 1-9 face-up; only position 10 is face-down. After the wild lands
+		// there, the displaced face-down card (a 5) is the new pending; with
+		// position 5 face-up it cannot place and the turn ends.
+		var slots [TrashSlotCnt]TrashSlot
+		for i := range TrashSlotCnt - 1 {
+			slots[i] = TrashSlot{Card: NewCard(CardDesignSpade, i+1, false), FaceUp: true}
+		}
+		slots[TrashSlotCnt-1] = TrashSlot{Card: NewCard(CardDesignHeart, 5, false), FaceUp: false}
+		tr.SetPlayerSlots(TrashHumanIdx, slots)
+		tr.SetStock([]*Card{NewCard(CardDesignDiamond, 13, false)})
+
+		require.NoError(t, tr.Draw())
+
+		out := tr.GetPlayerSlots(TrashHumanIdx)
+		assert.True(t, out[TrashSlotCnt-1].FaceUp, "single-empty slot should be auto-flipped")
+		assert.Equal(t, 13, out[TrashSlotCnt-1].Card.GetValue(), "wild should occupy the auto-placed slot")
+		// Phase must NOT be AwaitWild — the forced-click was eliminated.
+		assert.NotEqual(t, TrashPhaseAwaitWild, tr.GetPhase(),
+			"auto-placement must skip the AwaitWild prompt")
+	})
+
+	t.Run("Joker wild auto-placed and triggers win", func(t *testing.T) {
+		tr := NewDefaultTrash()
+		tr.Reset()
+		// Single face-down slot at position 10 holds a Q (end-turn card). The
+		// wild lands there flipping it; the displaced Q would normally end the
+		// turn, but a complete face-up board first triggers a win.
+		var slots [TrashSlotCnt]TrashSlot
+		for i := range TrashSlotCnt - 1 {
+			slots[i] = TrashSlot{Card: NewCard(CardDesignSpade, i+1, false), FaceUp: true}
+		}
+		slots[TrashSlotCnt-1] = TrashSlot{Card: NewCard(CardDesignSpade, 12, false), FaceUp: false}
+		tr.SetPlayerSlots(TrashHumanIdx, slots)
+		tr.SetStock([]*Card{NewCard(CardDesignJoker, 1, false)})
+
+		require.NoError(t, tr.Draw())
+
+		assert.Equal(t, TrashPhaseGameOver, tr.GetPhase(), "completing the board must win")
+		assert.Equal(t, TrashHumanIdx, tr.GetWinner())
+	})
+
+	t.Run("two empty slots still prompts (no auto)", func(t *testing.T) {
+		tr := NewDefaultTrash()
+		tr.Reset()
+		var slots [TrashSlotCnt]TrashSlot
+		for i := range TrashSlotCnt - 2 {
+			slots[i] = TrashSlot{Card: NewCard(CardDesignSpade, i+1, false), FaceUp: true}
+		}
+		slots[8] = TrashSlot{Card: NewCard(CardDesignHeart, 9, false), FaceUp: false}
+		slots[9] = TrashSlot{Card: NewCard(CardDesignHeart, 10, false), FaceUp: false}
+		tr.SetPlayerSlots(TrashHumanIdx, slots)
+		tr.SetStock([]*Card{NewCard(CardDesignDiamond, 13, false)})
+
+		require.NoError(t, tr.Draw())
+
+		assert.Equal(t, TrashPhaseAwaitWild, tr.GetPhase(),
+			"two empty slots is a real choice; the human must pick")
+	})
+}
+
 func TestTrashDrawJackEndsTurn(t *testing.T) {
 	tr := NewDefaultTrash()
 	tr.Reset()

--- a/internal/domain/Trash_test.go
+++ b/internal/domain/Trash_test.go
@@ -115,12 +115,15 @@ func TestTrashDrawJokerAwaitsPlacement(t *testing.T) {
 // game must auto-place the wild instead of asking the user to pick — there
 // is no meaningful choice and the forced click breaks Trash's tempo.
 func TestTrashDrawWildAutoPlacesWithSingleEmptySlot(t *testing.T) {
-	t.Run("King wild auto-placed and chain continues", func(t *testing.T) {
+	t.Run("King wild auto-placed wins and discards the displaced card", func(t *testing.T) {
+		// Filling the only face-down slot completes the board, so isWin
+		// is always true on auto-placement (PR #1584 review). The
+		// displaced face-down card cannot continue the chain — it is
+		// pushed to the discard pile by the win path. We pin both
+		// invariants here: AwaitWild is skipped, GameOver is reached,
+		// and the displaced 5 lands on the discard pile.
 		tr := NewDefaultTrash()
 		tr.Reset()
-		// Positions 1-9 face-up; only position 10 is face-down. After the wild lands
-		// there, the displaced face-down card (a 5) is the new pending; with
-		// position 5 face-up it cannot place and the turn ends.
 		var slots [TrashSlotCnt]TrashSlot
 		for i := range TrashSlotCnt - 1 {
 			slots[i] = TrashSlot{Card: NewCard(CardDesignSpade, i+1, false), FaceUp: true}
@@ -137,6 +140,13 @@ func TestTrashDrawWildAutoPlacesWithSingleEmptySlot(t *testing.T) {
 		// Phase must NOT be AwaitWild — the forced-click was eliminated.
 		assert.NotEqual(t, TrashPhaseAwaitWild, tr.GetPhase(),
 			"auto-placement must skip the AwaitWild prompt")
+		// The single-slot auto-fill always completes the board, so the
+		// game ends and the displaced 5 is discarded.
+		assert.Equal(t, TrashPhaseGameOver, tr.GetPhase())
+		assert.Equal(t, TrashHumanIdx, tr.GetWinner())
+		require.NotNil(t, tr.GetDiscardTop())
+		assert.Equal(t, 5, tr.GetDiscardTop().GetValue(),
+			"displaced face-down card should land on the discard pile")
 	})
 
 	t.Run("Joker wild auto-placed and triggers win", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #1565. Trash relies on the *draw → place → repeat* tempo, but a wild card that surfaces while only **one** face-down slot remains forces a click that has zero strategic content — the only legal destination is the only empty slot. This PR detects that case in `resolveChain` and places the wild directly, leaving the multi-empty-slot case alone (real tactical choice).

## What changed

- `internal/domain/Trash.go`
  - `resolveChain`: when a wild surfaces, call `onlyEmptySlot(currentPlayer)`. If exactly one is found, route through the new `placeWildAt(idx)` and continue resolving. Multiple empty slots still transition to `TrashPhaseAwaitWild`.
  - `placeWildAt(idx)`: extracted shared core of explicit `PlaceWild` and the auto path so they cannot drift in win-detection or `appendLog` formatting.
  - `onlyEmptySlot(playerIdx)`: helper returning the slot index iff exactly one face-down slot remains, else `-1`.
  - `PlaceWild` reduced to validation + `placeWildAt` + (optionally) `resolveChain`.
- `internal/domain/Trash_test.go`
  - `TestTrashDrawWildAutoPlacesWithSingleEmptySlot` (3 sub-cases):
    1. King lands on the lone face-down slot, chain continues, AwaitWild is **not** entered.
    2. Joker completes the board and triggers `TrashPhaseGameOver` with the human as winner.
    3. Two empty slots still produce `AwaitWild` — the human keeps the choice.

## Frontend

The frontend already highlights face-down slots during `AwaitWild` with `ring-ds-info` (`TrashPage.tsx:326`), so item 2 of the issue (visual guide) is satisfied without changes here. CPU paths were already auto-placing via `CpuStep`, so the human and CPU now share the same single-slot logic.

## Test plan

- [x] `go test -tags test ./internal/domain/...` passes (incl. all existing TrashPlaceWild* and the 3 new sub-cases)
- [x] `go test -tags test ./...` passes (no presenter/controller regressions)
- [x] `goimports -w` applied; awaiting `golangci-lint` confirmation in CI