### PR TITLE
feat(frontend): tendency badges on poker HUD stats (#1564)

### DIFF
--- a/frontend/src/components/HudStats.test.tsx
+++ b/frontend/src/components/HudStats.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { afTendency, HudStats, pfrTendency, threeBetTendency, vpipTendency } from './HudStats';
+
+describe('HudStats tendency classifiers', () => {
+  describe('vpipTendency', () => {
+    it.each([
+      [10, 'tight'],
+      [19, 'tight'],
+      [20, 'normal'],
+      [25, 'normal'],
+      [35, 'normal'],
+      [36, 'loose'],
+      [60, 'loose'],
+    ])('vpip=%d -> %s', (value, want) => {
+      expect(vpipTendency(value)).toBe(want);
+    });
+  });
+
+  describe('pfrTendency', () => {
+    it.each([
+      [5, 'passive'],
+      [9, 'passive'],
+      [10, 'balanced'],
+      [25, 'balanced'],
+      [26, 'aggressive'],
+      [50, 'aggressive'],
+    ])('pfr=%d -> %s', (value, want) => {
+      expect(pfrTendency(value)).toBe(want);
+    });
+  });
+
+  describe('threeBetTendency', () => {
+    it.each([
+      [0, 'passive'],
+      [3, 'passive'],
+      [4, 'balanced'],
+      [9, 'balanced'],
+      [10, 'aggressive'],
+      [20, 'aggressive'],
+    ])('threeBet=%d -> %s', (value, want) => {
+      expect(threeBetTendency(value)).toBe(want);
+    });
+  });
+
+  describe('afTendency', () => {
+    it.each([
+      ['0', 'passive'],
+      ['0.9', 'passive'],
+      ['1', 'balanced'],
+      ['2.5', 'balanced'],
+      ['3', 'balanced'],
+      ['3.1', 'aggressive'],
+      ['10', 'aggressive'],
+    ])('af=%s -> %s', (value, want) => {
+      expect(afTendency(value)).toBe(want);
+    });
+
+    it('non-numeric values fall back to balanced (no misleading red)', () => {
+      // The server sometimes ships "∞" or "—" for AF when calls = 0; we must
+      // never surface those as "aggressive" since the badge would be a lie.
+      expect(afTendency('∞')).toBe('balanced');
+      expect(afTendency('—')).toBe('balanced');
+      expect(afTendency('')).toBe('balanced');
+    });
+  });
+});
+
+describe('HudStats component', () => {
+  it('renders all four telemetry values with tendency markers', () => {
+    render(<HudStats vpip={45} pfr={30} threeBet={12} af="3.5" />);
+    const hud = screen.getByTestId('hud-stats');
+    expect(hud).toBeInTheDocument();
+    // Loose VPIP
+    expect(screen.getByTestId('hud-vpip-tendency')).toHaveAttribute('data-tendency', 'loose');
+    expect(screen.getByTestId('hud-vpip-tendency')).toHaveTextContent('45%');
+    // Aggressive PFR / 3Bet / AF
+    expect(screen.getByTestId('hud-pfr-tendency')).toHaveAttribute('data-tendency', 'aggressive');
+    expect(screen.getByTestId('hud-3bet-tendency')).toHaveAttribute('data-tendency', 'aggressive');
+    expect(screen.getByTestId('hud-af-tendency')).toHaveAttribute('data-tendency', 'aggressive');
+  });
+
+  it('classifies a tight passive opponent', () => {
+    render(<HudStats vpip={15} pfr={5} threeBet={2} af="0.5" />);
+    expect(screen.getByTestId('hud-vpip-tendency')).toHaveAttribute('data-tendency', 'tight');
+    expect(screen.getByTestId('hud-pfr-tendency')).toHaveAttribute('data-tendency', 'passive');
+    expect(screen.getByTestId('hud-3bet-tendency')).toHaveAttribute('data-tendency', 'passive');
+    expect(screen.getByTestId('hud-af-tendency')).toHaveAttribute('data-tendency', 'passive');
+  });
+
+  it('uses the namespace prop for i18n lookups', () => {
+    // The shared component must accept a custom namespace so omaha /
+    // shortdeck / pineapple variant pages can render their own tooltip
+    // copy without duplicating the component. The default namespace is
+    // 'holdem' for backward compatibility.
+    render(<HudStats vpip={25} pfr={15} threeBet={6} af="2.0" namespace="omaha" />);
+    expect(screen.getByTestId('hud-stats')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/HudStats.tsx
+++ b/frontend/src/components/HudStats.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import { useTranslation } from 'react-i18next';
 
 /**
@@ -14,9 +15,12 @@ type Tendency = 'tight' | 'normal' | 'loose' | 'passive' | 'balanced' | 'aggress
 /**
  * StatTooltip renders a label that reveals a tooltip on hover/focus.
  * Mirrors the inline tooltips that previously lived on each poker page;
- * extracted to deduplicate four near-identical copies. See issue #1564.
+ * extracted to deduplicate four near-identical copies. Uses `useId` so
+ * each instance gets a unique DOM id even when multiple HudStats rows
+ * are rendered (one per CPU player). See issue #1564.
  */
-function StatTooltip({ id, label, tooltipText }: { id: string; label: string; tooltipText: string }) {
+function StatTooltip({ label, tooltipText }: { label: string; tooltipText: string }) {
+  const id = useId();
   return (
     <button
       type="button"
@@ -134,19 +138,19 @@ export function HudStats({ vpip, pfr, threeBet, af, namespace = 'holdem' }: HudS
   const afT = afTendency(af);
   return (
     <span className="ml-2 text-ds-info text-[0.8em] hidden md:inline" data-testid="hud-stats">
-      <StatTooltip id="tooltip-vpip" label={t('stats.vpip')} tooltipText={t('stats.vpipTooltip')} />:
+      <StatTooltip label={t('stats.vpip')} tooltipText={t('stats.vpipTooltip')} />:
       <span className={tendencyClass(vpipT)} data-testid="hud-vpip-tendency" data-tendency={vpipT}>
         {vpip}%
       </span>{' '}
-      <StatTooltip id="tooltip-pfr" label={t('stats.pfr')} tooltipText={t('stats.pfrTooltip')} />:
+      <StatTooltip label={t('stats.pfr')} tooltipText={t('stats.pfrTooltip')} />:
       <span className={tendencyClass(pfrT)} data-testid="hud-pfr-tendency" data-tendency={pfrT}>
         {pfr}%
       </span>{' '}
-      <StatTooltip id="tooltip-3bet" label={t('stats.threeBet')} tooltipText={t('stats.threeBetTooltip')} />:
+      <StatTooltip label={t('stats.threeBet')} tooltipText={t('stats.threeBetTooltip')} />:
       <span className={tendencyClass(threeBetT)} data-testid="hud-3bet-tendency" data-tendency={threeBetT}>
         {threeBet}%
       </span>{' '}
-      <StatTooltip id="tooltip-af" label={t('stats.af')} tooltipText={t('stats.afTooltip')} />:
+      <StatTooltip label={t('stats.af')} tooltipText={t('stats.afTooltip')} />:
       <span className={tendencyClass(afT)} data-testid="hud-af-tendency" data-tendency={afT}>
         {af}
       </span>

--- a/frontend/src/components/HudStats.tsx
+++ b/frontend/src/components/HudStats.tsx
@@ -1,0 +1,155 @@
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Tendency labels classify a player's playing style from their HUD stats so
+ * a non-poker-savvy user can read "VPIP 45% (Loose)" instead of having to
+ * memorize that 45% is a wide range. The thresholds match commonly-cited
+ * poker theory ranges (Tight < 20 < Normal < 35 < Loose; Passive < 1 AF < 3
+ * < Aggressive). They are not meant to be precise — the goal is intuitive
+ * color-coded triage so casual players can enjoy the CPU style variation
+ * (TAG / LAG / GTO etc.) without studying definitions first. See issue #1564.
+ */
+type Tendency = 'tight' | 'normal' | 'loose' | 'passive' | 'balanced' | 'aggressive';
+
+/**
+ * StatTooltip renders a label that reveals a tooltip on hover/focus.
+ * Mirrors the inline tooltips that previously lived on each poker page;
+ * extracted to deduplicate four near-identical copies. See issue #1564.
+ */
+function StatTooltip({ id, label, tooltipText }: { id: string; label: string; tooltipText: string }) {
+  return (
+    <button
+      type="button"
+      className="group relative cursor-help bg-transparent border-none p-0 font-inherit text-inherit inline"
+      aria-describedby={id}
+    >
+      {label}
+      <span
+        id={id}
+        className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 whitespace-nowrap rounded bg-ds-surface-elevated px-2 py-1 text-xs text-ds-text-primary opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+        role="tooltip"
+      >
+        {tooltipText}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * vpipTendency classifies VPIP into Tight / Normal / Loose.
+ * Exported for direct test access — the thresholds are the SSoT for both
+ * the rendered badge and any future linter rules. See issue #1564.
+ */
+export function vpipTendency(value: number): Tendency {
+  if (value > 35) return 'loose';
+  if (value < 20) return 'tight';
+  return 'normal';
+}
+
+/**
+ * pfrTendency classifies PFR (preflop raise %) into Passive / Balanced /
+ * Aggressive. PFR strictly less than VPIP is the norm; the absolute value
+ * is what drives perceived aggression. See issue #1564.
+ */
+export function pfrTendency(value: number): Tendency {
+  if (value > 25) return 'aggressive';
+  if (value < 10) return 'passive';
+  return 'balanced';
+}
+
+/**
+ * threeBetTendency classifies 3Bet % into Passive / Balanced / Aggressive.
+ * See issue #1564.
+ */
+export function threeBetTendency(value: number): Tendency {
+  if (value > 9) return 'aggressive';
+  if (value < 4) return 'passive';
+  return 'balanced';
+}
+
+/**
+ * afTendency classifies AF (aggression factor) into Passive / Balanced /
+ * Aggressive. AF arrives as a string ("1.5", "∞", "0") because the server
+ * formats it; non-numeric values fall back to "balanced" so a weird
+ * payload cannot surface a misleading red badge. See issue #1564.
+ */
+export function afTendency(af: string): Tendency {
+  const n = Number.parseFloat(af);
+  if (!Number.isFinite(n)) return 'balanced';
+  if (n > 3) return 'aggressive';
+  if (n < 1) return 'passive';
+  return 'balanced';
+}
+
+/**
+ * tendencyClass maps a tendency to the design-system color class used for
+ * the badge text. Loose / Aggressive surface as `text-ds-error` (warm
+ * warning red — high engagement), Tight / Passive as `text-ds-info` (cool
+ * blue — calm/conservative), and Normal / Balanced as `text-ds-text-muted`
+ * so they recede visually. See issue #1564.
+ */
+function tendencyClass(t: Tendency): string {
+  switch (t) {
+    case 'loose':
+    case 'aggressive':
+      return 'text-ds-error';
+    case 'tight':
+    case 'passive':
+      return 'text-ds-info';
+    default:
+      return 'text-ds-text-muted';
+  }
+}
+
+/**
+ * HudStats props — accepts the four poker telemetry fields that ship in
+ * every poker variant's API response, plus an optional i18n namespace
+ * that lets variant pages (e.g. crazypineapple sharing logic with
+ * pineapple) reuse this component without duplicating tooltip copy.
+ */
+type HudStatsProps = {
+  vpip: number;
+  pfr: number;
+  threeBet: number;
+  af: string;
+  /** i18n namespace that owns `stats.*` and `tendency.*` keys. Defaults
+   * to "holdem" so existing callers continue to work. Variants pass
+   * their own ("omaha", "shortdeck", "pineapple", …). */
+  namespace?: string;
+};
+
+/**
+ * HudStats renders the per-CPU poker telemetry row (VPIP / PFR / 3Bet /
+ * AF) with color-coded tendency badges (Tight/Loose, Passive/Aggressive)
+ * so casual players can read CPU style at a glance instead of memorizing
+ * threshold percentages. Replaces the four near-identical local copies
+ * that previously lived on Holdem/Omaha/ShortDeck/Pineapple pages. See
+ * issue #1564.
+ */
+export function HudStats({ vpip, pfr, threeBet, af, namespace = 'holdem' }: HudStatsProps) {
+  const { t } = useTranslation(namespace);
+  const vpipT = vpipTendency(vpip);
+  const pfrT = pfrTendency(pfr);
+  const threeBetT = threeBetTendency(threeBet);
+  const afT = afTendency(af);
+  return (
+    <span className="ml-2 text-ds-info text-[0.8em] hidden md:inline" data-testid="hud-stats">
+      <StatTooltip id="tooltip-vpip" label={t('stats.vpip')} tooltipText={t('stats.vpipTooltip')} />:
+      <span className={tendencyClass(vpipT)} data-testid="hud-vpip-tendency" data-tendency={vpipT}>
+        {vpip}%
+      </span>{' '}
+      <StatTooltip id="tooltip-pfr" label={t('stats.pfr')} tooltipText={t('stats.pfrTooltip')} />:
+      <span className={tendencyClass(pfrT)} data-testid="hud-pfr-tendency" data-tendency={pfrT}>
+        {pfr}%
+      </span>{' '}
+      <StatTooltip id="tooltip-3bet" label={t('stats.threeBet')} tooltipText={t('stats.threeBetTooltip')} />:
+      <span className={tendencyClass(threeBetT)} data-testid="hud-3bet-tendency" data-tendency={threeBetT}>
+        {threeBet}%
+      </span>{' '}
+      <StatTooltip id="tooltip-af" label={t('stats.af')} tooltipText={t('stats.afTooltip')} />:
+      <span className={tendencyClass(afT)} data-testid="hud-af-tendency" data-tendency={afT}>
+        {af}
+      </span>
+    </span>
+  );
+}

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import { holdemApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { BettingControls } from '../components/BettingControls';
@@ -16,6 +15,7 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
 import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
+import { HudStats } from '../components/HudStats';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
@@ -102,37 +102,6 @@ const HOLDEM_PHASE_KEYS: Readonly<Record<number, string>> = {
   [HoldemPhase.END]: 'end',
   [HoldemPhase.REBUY]: 'rebuy',
 };
-
-function StatTooltip({ id, label, tooltipText }: { id: string; label: string; tooltipText: string }) {
-  return (
-    <button
-      type="button"
-      className="group relative cursor-help bg-transparent border-none p-0 font-inherit text-inherit inline"
-      aria-describedby={id}
-    >
-      {label}
-      <span
-        id={id}
-        className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 whitespace-nowrap rounded bg-ds-surface-elevated px-2 py-1 text-xs text-ds-text-primary opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
-        role="tooltip"
-      >
-        {tooltipText}
-      </span>
-    </button>
-  );
-}
-
-function HudStats({ vpip, pfr, threeBet, af }: { vpip: number; pfr: number; threeBet: number; af: string }) {
-  const { t } = useTranslation('holdem');
-  return (
-    <span className="ml-2 text-ds-info text-[0.8em] hidden md:inline" data-testid="hud-stats">
-      <StatTooltip id="tooltip-vpip" label={t('stats.vpip')} tooltipText={t('stats.vpipTooltip')} />:{vpip}%{' '}
-      <StatTooltip id="tooltip-pfr" label={t('stats.pfr')} tooltipText={t('stats.pfrTooltip')} />:{pfr}%{' '}
-      <StatTooltip id="tooltip-3bet" label={t('stats.threeBet')} tooltipText={t('stats.threeBetTooltip')} />:{threeBet}%{' '}
-      <StatTooltip id="tooltip-af" label={t('stats.af')} tooltipText={t('stats.afTooltip')} />:{af}
-    </span>
-  );
-}
 
 /** Renders the Texas Hold'em game page with community cards, betting, and showdown. */
 export function HoldemPage() {

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import { omahaApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { BettingControls } from '../components/BettingControls';
@@ -16,6 +15,7 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
 import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
+import { HudStats } from '../components/HudStats';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
@@ -102,37 +102,6 @@ const OMAHA_PHASE_KEYS: Readonly<Record<number, string>> = {
   [OmahaPhase.END]: 'end',
   [OmahaPhase.REBUY]: 'rebuy',
 };
-
-function StatTooltip({ id, label, tooltipText }: { id: string; label: string; tooltipText: string }) {
-  return (
-    <button
-      type="button"
-      className="group relative cursor-help bg-transparent border-none p-0 font-inherit text-inherit inline"
-      aria-describedby={id}
-    >
-      {label}
-      <span
-        id={id}
-        className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 whitespace-nowrap rounded bg-ds-surface-elevated px-2 py-1 text-xs text-ds-text-primary opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
-        role="tooltip"
-      >
-        {tooltipText}
-      </span>
-    </button>
-  );
-}
-
-function HudStats({ vpip, pfr, threeBet, af }: { vpip: number; pfr: number; threeBet: number; af: string }) {
-  const { t } = useTranslation('omaha');
-  return (
-    <span className="ml-2 text-ds-info text-[0.8em] hidden md:inline" data-testid="hud-stats">
-      <StatTooltip id="tooltip-vpip" label={t('stats.vpip')} tooltipText={t('stats.vpipTooltip')} />:{vpip}%{' '}
-      <StatTooltip id="tooltip-pfr" label={t('stats.pfr')} tooltipText={t('stats.pfrTooltip')} />:{pfr}%{' '}
-      <StatTooltip id="tooltip-3bet" label={t('stats.threeBet')} tooltipText={t('stats.threeBetTooltip')} />:{threeBet}%{' '}
-      <StatTooltip id="tooltip-af" label={t('stats.af')} tooltipText={t('stats.afTooltip')} />:{af}
-    </span>
-  );
-}
 
 /** Renders the Omaha Hold'em game page with community cards, betting, and showdown. */
 export function OmahaPage() {
@@ -303,7 +272,13 @@ function OmahaPageContent() {
                   showHandName={isShowdown}
                   extraInfo={
                     player.totalHands > 0 ? (
-                      <HudStats vpip={player.vpip} pfr={player.pfr} threeBet={player.threeBet} af={player.af} />
+                      <HudStats
+                        namespace="omaha"
+                        vpip={player.vpip}
+                        pfr={player.pfr}
+                        threeBet={player.threeBet}
+                        af={player.af}
+                      />
                     ) : undefined
                   }
                 />
@@ -362,6 +337,7 @@ function OmahaPageContent() {
                   </span>
                   {humanPlayer.totalHands > 0 && (
                     <HudStats
+                      namespace="omaha"
                       vpip={humanPlayer.vpip}
                       pfr={humanPlayer.pfr}
                       threeBet={humanPlayer.threeBet}

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import { crazyPineappleApi, pineappleApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { BettingControls } from '../components/BettingControls';
@@ -16,6 +15,7 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
 import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
+import { HudStats } from '../components/HudStats';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
@@ -109,49 +109,6 @@ const PINEAPPLE_PHASE_KEYS: Readonly<Record<number, string>> = {
   [PineapplePhase.REBUY]: 'rebuy',
   [PineapplePhase.DISCARD]: 'discard',
 };
-
-function StatTooltip({ id, label, tooltipText }: { id: string; label: string; tooltipText: string }) {
-  return (
-    <button
-      type="button"
-      className="group relative cursor-help bg-transparent border-none p-0 font-inherit text-inherit inline"
-      aria-describedby={id}
-    >
-      {label}
-      <span
-        id={id}
-        className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 whitespace-nowrap rounded bg-ds-surface-elevated px-2 py-1 text-xs text-ds-text-primary opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
-        role="tooltip"
-      >
-        {tooltipText}
-      </span>
-    </button>
-  );
-}
-
-function HudStats({
-  namespace,
-  vpip,
-  pfr,
-  threeBet,
-  af,
-}: {
-  namespace: string;
-  vpip: number;
-  pfr: number;
-  threeBet: number;
-  af: string;
-}) {
-  const { t } = useTranslation(namespace);
-  return (
-    <span className="ml-2 text-ds-info text-[0.8em] hidden md:inline" data-testid="hud-stats">
-      <StatTooltip id="tooltip-vpip" label={t('stats.vpip')} tooltipText={t('stats.vpipTooltip')} />:{vpip}%{' '}
-      <StatTooltip id="tooltip-pfr" label={t('stats.pfr')} tooltipText={t('stats.pfrTooltip')} />:{pfr}%{' '}
-      <StatTooltip id="tooltip-3bet" label={t('stats.threeBet')} tooltipText={t('stats.threeBetTooltip')} />:{threeBet}%{' '}
-      <StatTooltip id="tooltip-af" label={t('stats.af')} tooltipText={t('stats.afTooltip')} />:{af}
-    </span>
-  );
-}
 
 /** Variant of the Pineapple page: standard "pineapple" or the Crazy Pineapple
  * variant (discard happens after the flop betting round instead of before). */

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import { shortdeckApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { BettingControls } from '../components/BettingControls';
@@ -16,6 +15,7 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageHeading } from '../components/GamePageHeading';
 import { GameResetButton } from '../components/GameResetButton';
 import { GameResetDialog } from '../components/GameResetDialog';
+import { HudStats } from '../components/HudStats';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
@@ -102,37 +102,6 @@ const SHORTDECK_PHASE_KEYS: Readonly<Record<number, string>> = {
   [HoldemPhase.END]: 'end',
   [HoldemPhase.REBUY]: 'rebuy',
 };
-
-function StatTooltip({ id, label, tooltipText }: { id: string; label: string; tooltipText: string }) {
-  return (
-    <button
-      type="button"
-      className="group relative cursor-help bg-transparent border-none p-0 font-inherit text-inherit inline"
-      aria-describedby={id}
-    >
-      {label}
-      <span
-        id={id}
-        className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 whitespace-nowrap rounded bg-ds-surface-elevated px-2 py-1 text-xs text-ds-text-primary opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
-        role="tooltip"
-      >
-        {tooltipText}
-      </span>
-    </button>
-  );
-}
-
-function HudStats({ vpip, pfr, threeBet, af }: { vpip: number; pfr: number; threeBet: number; af: string }) {
-  const { t } = useTranslation('shortdeck');
-  return (
-    <span className="ml-2 text-ds-info text-[0.8em] hidden md:inline" data-testid="hud-stats">
-      <StatTooltip id="tooltip-vpip" label={t('stats.vpip')} tooltipText={t('stats.vpipTooltip')} />:{vpip}%{' '}
-      <StatTooltip id="tooltip-pfr" label={t('stats.pfr')} tooltipText={t('stats.pfrTooltip')} />:{pfr}%{' '}
-      <StatTooltip id="tooltip-3bet" label={t('stats.threeBet')} tooltipText={t('stats.threeBetTooltip')} />:{threeBet}%{' '}
-      <StatTooltip id="tooltip-af" label={t('stats.af')} tooltipText={t('stats.afTooltip')} />:{af}
-    </span>
-  );
-}
 
 /** Renders the Short Deck Hold'em game page with community cards, betting, and showdown. */
 export function ShortDeckPage() {
@@ -302,7 +271,7 @@ function ShortDeckPageContent() {
                   showHandName={isShowdown}
                   extraInfo={
                     p.totalHands > 0 ? (
-                      <HudStats vpip={p.vpip} pfr={p.pfr} threeBet={p.threeBet} af={p.af} />
+                      <HudStats namespace="shortdeck" vpip={p.vpip} pfr={p.pfr} threeBet={p.threeBet} af={p.af} />
                     ) : undefined
                   }
                 />
@@ -361,6 +330,7 @@ function ShortDeckPageContent() {
                   </span>
                   {humanPlayer.totalHands > 0 && (
                     <HudStats
+                      namespace="shortdeck"
                       vpip={humanPlayer.vpip}
                       pfr={humanPlayer.pfr}
                       threeBet={humanPlayer.threeBet}


### PR DESCRIPTION
## Summary

Closes #1564. Casual players seeing *"VPIP 45%"* on a CPU player have no way to know whether 45% means *loose* or *tight* without studying poker theory. The CPU profile variation (TAG / LAG / GTO etc.) is wasted on them. This PR adds **color-coded tendency badges** next to each HUD stat so the playing style is readable at a glance.

## What changed

- **New shared component** `frontend/src/components/HudStats.tsx` consolidates the four near-identical local copies (Holdem / Omaha / ShortDeck / Pineapple+CrazyPineapple) plus the duplicated `StatTooltip`. Accepts an optional `namespace` prop (default `'holdem'`) so variant pages keep their own tooltip copy without duplicating the component.
- **Tendency classifiers** (`vpipTendency`, `pfrTendency`, `threeBetTendency`, `afTendency`) are exported so the threshold rules are the SSoT — both the badge and any future linter/test live off the same numbers.

### Tendency thresholds (commonly-cited poker theory ranges)

| Stat | Cool (blue) | Neutral (muted) | Warm (red) |
|------|-------------|-----------------|------------|
| VPIP | `< 20` Tight | `20–35` Normal | `> 35` Loose |
| PFR  | `< 10` Passive | `10–25` Balanced | `> 25` Aggressive |
| 3Bet | `< 4` Passive | `4–9` Balanced | `> 9` Aggressive |
| AF   | `< 1` Passive | `1–3` Balanced | `> 3` Aggressive |

DESIGN.md tokens used: `text-ds-error` for Loose/Aggressive (warm warning red), `text-ds-info` for Tight/Passive (cool blue), `text-ds-text-muted` for Normal/Balanced (recedes).

## Edge cases

- **Non-numeric AF strings** (`"∞"`, `"—"`, `""`) fall back to *balanced* so a weird payload cannot surface a misleading red badge.
- HudStats keeps the existing `hidden md:inline` rule, so mobile UX is unchanged (the row is desktop-only by design).

## Test plan

- [x] **30 new sub-cases** in `HudStats.test.tsx`:
  - 27 boundary cases across vpip/pfr/3bet/af thresholds (one on each side of every threshold).
  - Loose-aggressive opponent renders all four with the expected `data-tendency` attributes.
  - Tight-passive opponent renders all four with the expected `data-tendency` attributes.
  - Custom `namespace` prop exercised for omaha (the Pineapple variant code path).
- [x] All 348 unit tests across the 4 affected page files still pass (`HoldemPage`, `OmahaPage`, `ShortDeckPage`, `PineapplePage`, `CrazyPineapplePage`, plus `HudStats`).
- [x] `tsc -b` clean (with `NODE_OPTIONS=--max-old-space-size=4096` due to 2 GB RAM ceiling on the WSL2 box; CI machines have plenty).
- [x] `bun run check` clean for the changed files (4 pre-existing warnings remain in unrelated `*.test.tsx`).

## Risks

- The HoldemPage default namespace for `HudStats` is `'holdem'`, so HoldemPage callers don't need a `namespace` prop. The other pages explicitly pass `'omaha'` / `'shortdeck'` / `variant` (pineapple/crazypineapple).
- The thresholds are opinionated; if user feedback wants different ranges, the change is a one-line tweak per classifier — the SSoT keeps the behavior synchronized between component and tests.