### PR TITLE
refactor(frontend): createBlackJackLikeApi for blackjack/spanish21 (#1550)

### DIFF
--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -215,17 +215,31 @@ export type BlackJackCommand =
   | 'declineearlysurrender'
   | 'setsurrenderrule';
 
+/**
+ * Factory for BlackJack-shaped APIs whose request body is
+ * `{ command, amount, ...config, ...betOptions }`. Spanish 21 reuses the
+ * BlackJack response and command union, so both clients are constructed
+ * via the same factory rather than duplicating the eight-token shape.
+ *
+ * Kept narrow on purpose — only games that share the BlackJack command
+ * union and bet-option payload should use it. See issue #1550.
+ */
+function createBlackJackLikeApi(game: string) {
+  return {
+    exec: (
+      command: BlackJackCommand,
+      amount?: number,
+      config?: BlackJackConfigInput,
+      betOptions?: BlackJackBetOptions,
+    ) => gameExec<BlackJackResponse>(game, { command, amount, ...config, ...betOptions }),
+  };
+}
+
 /** API client for the BlackJack /blackjack/exec endpoint. */
-export const blackjackApi = {
-  exec: (command: BlackJackCommand, amount?: number, config?: BlackJackConfigInput, betOptions?: BlackJackBetOptions) =>
-    gameExec<BlackJackResponse>('blackjack', { command, amount, ...config, ...betOptions }),
-};
+export const blackjackApi = createBlackJackLikeApi('blackjack');
 
 /** API client for the Spanish 21 /spanish21/exec endpoint (shares BlackJack response shape). */
-export const spanish21Api = {
-  exec: (command: BlackJackCommand, amount?: number, config?: BlackJackConfigInput, betOptions?: BlackJackBetOptions) =>
-    gameExec<BlackJackResponse>('spanish21', { command, amount, ...config, ...betOptions }),
-};
+export const spanish21Api = createBlackJackLikeApi('spanish21');
 
 /** Configuration options for Poker game settings. */
 export interface PokerConfigInput {


### PR DESCRIPTION
## Summary

Closes #1550. Follow-up to PR #1574 (which already extracted the four major shapes: `createHoldemLikeApi`, `createBidPlayApi`, `createSolitaireMoveApi`, `createVideoPokerApi`, `createBetAmountApi`).

`blackjackApi` and `spanish21Api` carried byte-identical bodies that shared the eight-token signature `(command, amount?, config?, betOptions?)`. Extracted `createBlackJackLikeApi(game)` so each client is now a one-line declaration.

## Why this is the only safe extraction left

The issue text envisions folding all 59 APIs into 4–5 factories. In practice the remaining inline APIs each have a unique payload field that would force config-soup factories with weakened type safety:

| API pair | Sole-difference field | Cost of forcing a factory |
| -------- | ---------------------- | ------------------------- |
| `threecardApi` / `caribbeanstudApi` / `paigowApi` | `pairPlusBet` / `jackpotBet` / `fortuneBet` | Generic field-name parameter — type-system noise > line savings |
| `memoryApi` / `warApi` / `slapjackApi` | position / config-only / args.config | Three different shapes, no clean common subset |
| `pokerApi` / `badugiApi` | indices+amount+humanPlayMs+profile | Highly poker-specific |
| `oldmaidApi` | drawIdx+mode+placement+reorder+memory+hesitation | Six bespoke params; no parallel |

Forcing a factory on any of these would require either widening the parameter type to `Record<string, unknown>` (losing the `BlackJackBetOptions`-style compile-time field check that the current narrow declarations enforce) or adding a generic for the field name (turning `paigowApi.exec(cmd, 5, 10)` into `paigowApi.exec(cmd, 5, 'fortuneBet', 10)`, which is *worse* than the duplication).

`createBlackJackLikeApi` is narrow on purpose: only games that share the BlackJack command union and bet-option payload should use it.

## Test plan

- [x] **All 181 existing `gameApi.test.ts` tests pass** — the factory keeps the wire payload identical, so test assertions on URL + body shape don't need to change.
- [x] `tsc -b` clean (no type-system regressions; the factory preserves both `BlackJackCommand` narrowing and `BlackJackBetOptions` field-level safety).
- [x] `bun run check` — only 4 pre-existing warnings in unrelated files.

## What this completes

This + PR #1574 close out #1550. PR #1574 reduced the file from 1476 → 1443 lines and extracted the bulk-shape factories; this PR removes the last symmetric duplicate. Net: ~62 APIs → ~55 distinct declarations + 6 factories.