### PR TITLE
fix(card): suppress iOS Safari long-press callout on card images

### DIFF
--- a/frontend/src/components/CardImage.test.tsx
+++ b/frontend/src/components/CardImage.test.tsx
@@ -106,6 +106,12 @@ describe('CardImage', () => {
     img.dispatchEvent(event);
     expect(onDrop).toHaveBeenCalledTimes(1);
   });
+
+  it('disables text selection so iOS Safari does not start a selection during drag', () => {
+    const card: Card = { design: 'SPADE', value: 1 };
+    render(<CardImage card={card} />);
+    expect(screen.getByRole('img')).toHaveStyle({ userSelect: 'none' });
+  });
 });
 
 describe('CardBack', () => {
@@ -175,5 +181,10 @@ describe('CardBack', () => {
     const styleAttr = screen.getByRole('img').getAttribute('style') ?? '';
     expect(styleAttr).toContain('var(--color-ds-card-back-border)');
     expect(styleAttr).toContain('var(--shadow-ds-card-back)');
+  });
+
+  it('disables text selection so iOS Safari does not start a selection during drag', () => {
+    render(<CardBack />);
+    expect(screen.getByRole('img')).toHaveStyle({ userSelect: 'none' });
   });
 });

--- a/frontend/src/components/CardImage.test.tsx
+++ b/frontend/src/components/CardImage.test.tsx
@@ -110,7 +110,7 @@ describe('CardImage', () => {
   it('disables text selection so iOS Safari does not start a selection during drag', () => {
     const card: Card = { design: 'SPADE', value: 1 };
     render(<CardImage card={card} />);
-    expect(screen.getByRole('img')).toHaveStyle({ userSelect: 'none' });
+    expect(screen.getByRole('img')).toHaveStyle({ userSelect: 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none' });
   });
 });
 
@@ -185,6 +185,6 @@ describe('CardBack', () => {
 
   it('disables text selection so iOS Safari does not start a selection during drag', () => {
     render(<CardBack />);
-    expect(screen.getByRole('img')).toHaveStyle({ userSelect: 'none' });
+    expect(screen.getByRole('img')).toHaveStyle({ userSelect: 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none' });
   });
 });

--- a/frontend/src/components/CardImage.tsx
+++ b/frontend/src/components/CardImage.tsx
@@ -31,6 +31,13 @@ interface CardImageProps {
 const CARD_NATURAL_WIDTH = 200;
 const CARD_NATURAL_HEIGHT = 300;
 
+/** Suppresses iOS Safari long-press callout and text selection on card images. */
+const noCalloutStyle = {
+  WebkitTouchCallout: 'none',
+  WebkitUserSelect: 'none',
+  userSelect: 'none',
+} as React.CSSProperties;
+
 /** Renders a face-up playing card image. */
 export function CardImage({
   card,
@@ -55,9 +62,7 @@ export function CardImage({
         maxWidth: '100%',
         borderRadius: 6,
         display: 'block',
-        WebkitTouchCallout: 'none',
-        WebkitUserSelect: 'none',
-        userSelect: 'none',
+        ...noCalloutStyle,
         ...style,
       }}
       className={className}
@@ -97,9 +102,7 @@ export function CardBack({ width, style, className, onClick, ariaLabel }: CardBa
         display: 'block',
         border: '1px solid var(--color-ds-card-back-border)',
         boxShadow: 'var(--shadow-ds-card-back)',
-        WebkitTouchCallout: 'none',
-        WebkitUserSelect: 'none',
-        userSelect: 'none',
+        ...noCalloutStyle,
         ...style,
       }}
       className={className}

--- a/frontend/src/components/CardImage.tsx
+++ b/frontend/src/components/CardImage.tsx
@@ -50,7 +50,16 @@ export function CardImage({
       width={CARD_NATURAL_WIDTH}
       height={CARD_NATURAL_HEIGHT}
       loading="lazy"
-      style={{ width: w, maxWidth: '100%', borderRadius: 6, display: 'block', ...style }}
+      style={{
+        width: w,
+        maxWidth: '100%',
+        borderRadius: 6,
+        display: 'block',
+        WebkitTouchCallout: 'none',
+        WebkitUserSelect: 'none',
+        userSelect: 'none',
+        ...style,
+      }}
       className={className}
       draggable={draggable}
       onDragStart={onDragStart}
@@ -88,6 +97,9 @@ export function CardBack({ width, style, className, onClick, ariaLabel }: CardBa
         display: 'block',
         border: '1px solid var(--color-ds-card-back-border)',
         boxShadow: 'var(--shadow-ds-card-back)',
+        WebkitTouchCallout: 'none',
+        WebkitUserSelect: 'none',
+        userSelect: 'none',
         ...style,
       }}
       className={className}


### PR DESCRIPTION
## Summary

- iOS Safari でカード画像を長押しすると「画像を保存／コピー」のコールアウトメニューや拡大プレビューが表示され、ドラッグ&ドロップ系ゲームの UX を阻害していた
- `CardImage` / `CardBack` のインラインスタイルに `-webkit-touch-callout: none`、`-webkit-user-select: none`、`user-select: none` を追加して抑止
- 共通コンポーネントなので Klondike, FreeCell, Spider, Yukon, Scorpion, Canfield, FortyThieves と Daifugo / OldMaid の全カードで効果

## Test plan

- [x] `bun run test` — 31/31 passed (CardImage)
- [x] `bunx biome check` — clean (changed files)
- [x] `bun run build` — success
- [ ] 実機 iOS Safari でカードの長押しで保存メニューが出ないこと、ドラッグ操作が阻害されないことを確認