### PR TITLE
ci: install Node.js 24 for wrangler in Cloudflare deploy jobs

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -62,6 +62,11 @@ jobs:
           WORKER_NAME: ${{ matrix.worker }}
         run: make "build-worker-${WORKER_NAME}"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -95,6 +100,11 @@ jobs:
       name: ${{ github.ref == 'refs/heads/master' && 'production' || 'staging' }}
     steps:
       - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary

- Cloudflare deploy run [25200158789](https://github.com/yuta-yoshinaga/go_trumpcards/actions/runs/25200158789) failed with `Wrangler requires at least Node.js v22.0.0. You are using v20.20.2.`
- The `deploy-workers` and `deploy-pages` jobs only set up Bun, so `bunx wrangler` resolved the runner's preinstalled Node.js v20 and aborted before deploying.
- Add `actions/setup-node@v6` with `node-version: 24` ahead of the Bun setup in both jobs so `bunx wrangler deploy` / `bunx wrangler pages deploy` run on a supported Node runtime. Matches the pattern already used in `deploy-pages.yml` (docs deploy).

## Test plan

- [ ] CI: Cloudflare deploy workflow succeeds for all three workers (casino, classic, solo)
- [ ] CI: Pages deploy succeeds and frontend is served from the staging URL