### PR TITLE
docs: tighten CLAUDE.md cross-references and surface DRY helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,13 +22,8 @@ go run ./cmd/trumpcards                    # Interactive mode (switch games with
 go run ./cmd/trumpcards --lang en          # Interactive mode in English
 go run ./cmd/trumpcards <game>             # Run a specific game (e.g., blackjack, poker, holdem)
 go run ./cmd/trumpcards --lang en <game>   # Run in English
-# Available games: blackjack, poker, oldmaid, daifugo, sevens, doubt, holdem, omaha,
-# shortdeck, pineapple, crazypineapple, hearts, memory, klondike, freecell, baccarat, spades,
-# twotenjack, crazyeights, ginrummy, spider, napoleon, indianpoker, videopoker,
-# deuceswild, jokerpoker, euchre, pyramid, tripeaks, cribbage, threecard, caribbeanstud, texasholdembonus, ohhell,
-# bridge, speed, gofish, canasta, pinochle, golf, pigtail, sevencardstud,
-# clocksolitaire, durak, fortythieves, paigow, war, canfield, fiftyone, yukon, whist,
-# letitride, pokersquares, pageone, reddog, razz, badugi, scorpion, accordion, trash, sevenbridge, president, cassino, spanish21, calculation, spiteandmalice, skat, shithead, nertz, slapjack, egyptianratscrew, bakersdozen, tonk
+# Run `go run ./cmd/trumpcards games --short` for the canonical list of game names
+# (the SSoT lives in `internal/infrastructure/games/registry.go`).
 go run ./cmd/trumpcards games      # List all available games
 go run ./cmd/trumpcards games --short  # List game names only (for scripting)
 go run ./cmd/trumpcards update     # Self-update to the latest version

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -2,6 +2,30 @@
 
 This directory contains the React frontend (Vite + React + TypeScript).
 
+## Design system
+
+**Always read [`../DESIGN.md`](../DESIGN.md) before making any visual / UI changes.** Fonts, colors, spacing, motion, and the WCAG 2.5.5 AAA tap-target rule (44×44 px minimum for interactive controls) are defined there. Game background colors live in `src/styles/gameTheme.ts` (SSoT — every game page should reference its own key, not hardcode another game's theme).
+
+## Standard page structure
+
+Every game page (`src/pages/<X>Page.tsx`) follows the same skeleton — copy from an existing page like `SpadesPage.tsx` or `HeartsPage.tsx` rather than inventing a new structure. Key elements:
+
+1. **Outer `XPage` exports the TutorialWrapper, inner `XPageContent` holds the implementation** — this split is required because `TutorialWrapper` provides the context that hooks inside `XPageContent` consume.
+2. **Standard hooks**: `useGamePageSetup(gameName)` provides i18n + action-log + reset-confirm state; `useGameApi(apiFn, opts)` manages server state with loading / error / retry.
+3. **Mount-time reset**: pages call the api command `"reset"` inside a `useEffect` on mount to fetch a fresh game from the server.
+4. **Skeleton fallback**: render `<XSkeleton />` while `state` is `null`.
+5. **`GamePageShell`** wraps most pages and provides the background, page heading, phase indicator, and reset confirmation dialog.
+
+Shared building blocks:
+
+| Hook / component | Purpose |
+|------------------|---------|
+| `useGamePageSetup(gameName)` | i18n (`t`, `tc`), action-log state, reset-confirm dialog state |
+| `useGameApi(apiFn, opts)` | Server-state management with loading / error / retry |
+| `GamePageShell` | Background + heading + phase indicator + reset dialog wrapper (most pages use this) |
+| `TutorialWrapper` | Tutorial provider + i18n init (always wraps the exported `XPage`) |
+| `useCliMode` + `useCliGame` + `<CliTerminal>` + `<CliToggle>` | CLI fallback mode (BlackJack / Poker / etc.) |
+
 ## Package Manager Rule
 
 **Always use `bun` instead of `npm`/`node`, and `bunx` instead of `npx`.** This project uses Bun as the sole JavaScript runtime, package manager, and script runner. Never invoke `node ./node_modules/...` directly — use `bun` or `bunx` instead.

--- a/internal/CLAUDE.md
+++ b/internal/CLAUDE.md
@@ -46,6 +46,19 @@ Card games involve shuffling, so tests must not depend on random outcomes:
 - **Force deterministic draws in OldMaid**: Give the target player exactly 1 card so `rand.Intn(1)` always returns 0
 - **Never assert on shuffled deck order**: Set up game state manually via `AddCard` instead of relying on `Reset`/`Shuffle`
 
+## Game registration helpers (use these — don't hand-roll boilerplate)
+
+The `internal/infrastructure/games/` package provides DRY helpers for the per-game registration pattern. Always use them instead of writing nested closures:
+
+| Helper | Where | Purpose |
+|--------|-------|---------|
+| `BindWebControllerFor[I, P, O]` | `games/server_helper.go` | One-call HTTP-server registration. Used by `games_server.go` (server build only, build tag `!js \|\| !wasm`). |
+| `RegisterKVGame[I, P, O]` | `games/worker_helper.go` | One-call Cloudflare-Worker (KV-backed) registration. Used by per-category sub-packages (`casino/`, `classic/`, `solo/`) under build tag `js && wasm`. |
+| `webControllerPair[I, P, O]` | `adapter/controller/web_controller_pair.go` | Generates `NewXWebController` + `NewXWebControllerWithProvider` together. Called inside per-game `*WebController.go`. |
+| `execCuiCommand` + `handleCuiLog` | `adapter/controller/cui_controller_helper.go` | Common CUI command parsing (`q`/`quit`/`r`/`reset` + suggestion-based unknown-command messages). Every `*CuiController.Exec` should delegate to it. |
+
+The build-tag split (`!js \|\| !wasm` for the server, `js && wasm` for workers) is what keeps each Cloudflare Worker binary under the 1 MB gzipped free-tier limit by letting TinyGo dead-code-eliminate the games from the other two categories. See the package doc comment in `games/registry.go` for the full design rationale.
+
 ## Formatting
 
 **After editing any Go source file, always run `goimports -w` on the modified files before committing.** Use `goimports`, not `gofmt`.


### PR DESCRIPTION
## Summary

- **`CLAUDE.md` (root)**: 73-game inline list を削除し、SSoT (`cmd/trumpcards games --short` / `internal/infrastructure/games/registry.go`) への参照に置換。同種の drift は #1601 でも修正履歴あり。
- **`internal/CLAUDE.md`**: 既存の game-registration helpers (`BindWebControllerFor`, `RegisterKVGame`, `webControllerPair`, `execCuiCommand` + `cui_controller_helper.go`) と build-tag 設計 (`!js || !wasm` vs `js && wasm`) を周知するセクションを追加。新規 contributor が boilerplate を書きすぎないようガイド。
- **`frontend/CLAUDE.md`**: `../DESIGN.md` への明示的リンク (frontend 専属セッションでの見落とし防止) + 71 ゲームページが共通で使う標準構造 (`useGamePageSetup` / `useGameApi` / `GamePageShell` / `TutorialWrapper`) の表を追加。

合計 +39 / -7 行。実装ロジックには変更なし、ドキュメントのみ。

## Test plan

- [x] CLAUDE.md / internal/CLAUDE.md / frontend/CLAUDE.md がそれぞれ markdown としてレンダリング可能
- [x] 参照しているシンボル (`BindWebControllerFor`, `useGamePageSetup`, `GamePageShell` 等) が実在することを `grep` で確認済み
- [x] `git diff --stat` で変更 3 ファイル / +39 -7 行を確認
- [ ] CodeQL / golangci-lint パス (CI で確認)