### PR TITLE
UI/UX polish bundle: #1609-#1615 (leave guard, gameTheme, tap targets, sidebar recents, ErrorBoundary, ChipBetInput)

### DIFF
--- a/docs/new-game-checklist.md
+++ b/docs/new-game-checklist.md
@@ -20,8 +20,8 @@ When adding a new game, follow this checklist to avoid post-feat fix commits. Co
 
 ## Frontend (React)
 
-9. **Page**: `frontend/src/pages/<Game>Page.tsx` with test file, reuse `useGamePageSetup` hook, `usePhaseNames`, `gameReplay`, `useCardDimensions`, `gameExec` API helper
-10. **Shared components**: Use `PhaseIndicator`, `SettingsPanel`, `ConfirmDialog`, `ActionLogSection`, `GameFooter`, `GameMessageBox`, `AnimatedCardBack`, `ErrorBoundary`
+9. **Page**: `frontend/src/pages/<Game>Page.tsx` with test file, reuse `useGamePageSetup` hook, `usePhaseNames`, `gameReplay`, `useCardDimensions`, `gameExec` API helper. Add `useGameRoundGuard(!!state && !state.gameEndFlag)` so accidental tab close / reload during a round triggers the browser leave warning (pages using `GamePageShell` get this for free; otherwise call the hook directly).
+10. **Shared components**: Use `PhaseIndicator`, `SettingsPanel`, `ConfirmDialog`, `ActionLogSection`, `GameFooter`, `GameMessageBox`, `AnimatedCardBack`, `ErrorBoundary`. Add a `GameKey` entry in `frontend/src/styles/gameTheme.ts` and reference `gameTheme.<key>` (do not reuse another game's key; the strict union type catches missing entries at compile time).
 11. **CLI mode**: Wire `useCliMode`, `useCliGame`, `CliToggle`, and `CliTerminal` in the page. At minimum add a stub config (`parseCommand` returns error, empty `helpText`). Place `CliToggle` inside `PhaseIndicator` and wrap GUI content with `{cliEnabled ? <CliTerminal .../> : <>{/* GUI */}</>}`
 12. **i18n**: Add `frontend/src/i18n/locales/{ja,en}/<game>.json` translation files (include `tutorial` keys if tutorial is added)
 13. **Router**: Add route in `frontend/src/App.tsx` and NavBar entry in `frontend/src/constants/gameRoutes.ts`

--- a/frontend/src/components/DesktopSidebar.test.tsx
+++ b/frontend/src/components/DesktopSidebar.test.tsx
@@ -13,7 +13,10 @@ vi.mock('../providers/SoundProvider', () => ({
   })),
 }));
 
-function renderSidebar(initialPath = '/') {
+// Default to a non-game path so useRecentGames does not record the current page
+// and produce a duplicate "Recent" link alongside the categorized one. Tests
+// that need a specific game path (or `/`) pass it explicitly.
+function renderSidebar(initialPath = '/nonexistent') {
   return render(
     <MemoryRouter initialEntries={[initialPath]}>
       <DesktopSidebar />
@@ -28,6 +31,7 @@ function labelFor(labelKey: string): string {
 afterEach(() => {
   i18n.changeLanguage('ja');
   localStorage.removeItem('trumpcards-favorite-games');
+  localStorage.removeItem('trumpcards-recent-games');
 });
 
 describe('DesktopSidebar', () => {
@@ -59,7 +63,11 @@ describe('DesktopSidebar', () => {
 
   it('marks active game with aria-current="page"', () => {
     renderSidebar('/poker');
-    expect(screen.getByRole('link', { name: labelFor('nav.poker') })).toHaveAttribute('aria-current', 'page');
+    // /poker also gets recorded in recent games, producing a duplicate link.
+    const pokerLinks = screen.getAllByRole('link', { name: labelFor('nav.poker') });
+    for (const link of pokerLinks) {
+      expect(link).toHaveAttribute('aria-current', 'page');
+    }
     expect(screen.getByRole('link', { name: labelFor('nav.hearts') })).not.toHaveAttribute('aria-current');
   });
 
@@ -68,6 +76,27 @@ describe('DesktopSidebar', () => {
     for (const { path, labelKey } of gameRoutes) {
       expect(screen.getByRole('link', { name: labelFor(labelKey) })).toHaveAttribute('href', path);
     }
+  });
+
+  describe('recent games', () => {
+    it('does not render section when no recent games stored', () => {
+      renderSidebar();
+      expect(screen.queryByText(i18n.t('nav.recentGames'))).not.toBeInTheDocument();
+    });
+
+    it('renders section when recent games are stored', () => {
+      localStorage.setItem('trumpcards-recent-games', JSON.stringify(['/poker', '/hearts']));
+      renderSidebar();
+      expect(screen.getByText(i18n.t('nav.recentGames'))).toBeInTheDocument();
+    });
+
+    it('hides section during search', () => {
+      localStorage.setItem('trumpcards-recent-games', JSON.stringify(['/poker']));
+      renderSidebar();
+      const input = screen.getByPlaceholderText(i18n.t('nav.searchPlaceholder'));
+      fireEvent.change(input, { target: { value: 'test' } });
+      expect(screen.queryByText(i18n.t('nav.recentGames'))).not.toBeInTheDocument();
+    });
   });
 
   describe('search', () => {

--- a/frontend/src/components/DesktopSidebar.tsx
+++ b/frontend/src/components/DesktopSidebar.tsx
@@ -5,6 +5,7 @@ import { gameCategories, gameRoutes } from '../constants/gameRoutes';
 import { SITE_NAME } from '../constants/site';
 import { useFavoriteGames } from '../hooks/useFavoriteGames';
 import { useGameRouteSearch } from '../hooks/useGameRouteSearch';
+import { useRecentGames } from '../hooks/useRecentGames';
 import { focusRingWhite } from '../styles/buttonStyles';
 import { NavLangToggle } from './nav/NavLangToggle';
 import { SoundToggle } from './SoundToggle';
@@ -19,6 +20,7 @@ export function DesktopSidebar() {
   const { t } = useTranslation('common');
   const [searchTerm, setSearchTerm] = useState('');
   const { favorites, isFavorite, toggleFavorite } = useFavoriteGames();
+  const recentGames = useRecentGames(pathname);
   const { filteredPaths } = useGameRouteSearch(searchTerm);
 
   return (
@@ -65,7 +67,7 @@ export function DesktopSidebar() {
             }}
             placeholder={t('nav.searchPlaceholder')}
             aria-label={t('nav.searchPlaceholder')}
-            className="flex-1 px-2 py-1.5 text-xs bg-ds-surface-elevated text-ds-text-primary rounded border border-ds-border-subtle placeholder-ds-text-muted min-w-0"
+            className="flex-1 px-2 py-2 text-sm bg-ds-surface-elevated text-ds-text-primary rounded border border-ds-border-subtle placeholder-ds-text-muted min-w-0 min-h-[44px]"
           />
           {searchTerm && (
             <button
@@ -97,7 +99,33 @@ export function DesktopSidebar() {
                     key={`fav-${gamePath}`}
                     to={gamePath}
                     aria-current={pathname === gamePath ? 'page' : undefined}
-                    className={`inline-flex items-center gap-1.5 px-2 py-1.5 text-xs rounded transition-colors ${pathname === gamePath ? 'bg-ds-accent text-ds-text-on-accent' : 'text-ds-text-primary hover:bg-ds-surface-elevated-hover'}`}
+                    className={`inline-flex items-center gap-1.5 px-2 py-2 text-sm rounded transition-colors min-h-[44px] ${pathname === gamePath ? 'bg-ds-accent text-ds-text-on-accent' : 'text-ds-text-primary hover:bg-ds-surface-elevated-hover'}`}
+                  >
+                    <span aria-hidden="true">{route.icon}</span>
+                    {t(route.labelKey)}
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Recent Games */}
+        {!filteredPaths && recentGames.length > 0 && (
+          <div className="mb-2">
+            <span className="text-ds-text-muted text-[10px] uppercase tracking-wider px-1 font-semibold">
+              {t('nav.recentGames')}
+            </span>
+            <div className="mt-1 flex flex-col gap-0.5">
+              {recentGames.map((gamePath) => {
+                const route = routeByPath.get(gamePath);
+                if (!route) return null;
+                return (
+                  <Link
+                    key={`recent-${gamePath}`}
+                    to={gamePath}
+                    aria-current={pathname === gamePath ? 'page' : undefined}
+                    className={`inline-flex items-center gap-1.5 px-2 py-2 text-sm rounded transition-colors min-h-[44px] ${pathname === gamePath ? 'bg-ds-accent text-ds-text-on-accent' : 'text-ds-text-primary hover:bg-ds-surface-elevated-hover'}`}
                   >
                     <span aria-hidden="true">{route.icon}</span>
                     {t(route.labelKey)}
@@ -127,7 +155,7 @@ export function DesktopSidebar() {
                     <Link
                       to={path}
                       aria-current={pathname === path ? 'page' : undefined}
-                      className={`inline-flex items-center gap-1.5 px-2 py-1.5 text-xs rounded transition-colors flex-1 ${pathname === path ? 'bg-ds-accent text-ds-text-on-accent' : 'text-ds-text-primary hover:bg-ds-surface-elevated-hover'}`}
+                      className={`inline-flex items-center gap-1.5 px-2 py-2 text-sm rounded transition-colors flex-1 min-h-[44px] ${pathname === path ? 'bg-ds-accent text-ds-text-on-accent' : 'text-ds-text-primary hover:bg-ds-surface-elevated-hover'}`}
                     >
                       <span aria-hidden="true">{icon}</span>
                       {t(routeLabel)}
@@ -161,7 +189,7 @@ export function DesktopSidebar() {
                       <Link
                         to={path}
                         aria-current={pathname === path ? 'page' : undefined}
-                        className={`inline-flex items-center gap-1.5 px-2 py-1.5 text-xs rounded transition-colors flex-1 ${pathname === path ? 'bg-ds-accent text-ds-text-on-accent' : 'text-ds-text-primary hover:bg-ds-surface-elevated-hover'}`}
+                        className={`inline-flex items-center gap-1.5 px-2 py-2 text-sm rounded transition-colors flex-1 min-h-[44px] ${pathname === path ? 'bg-ds-accent text-ds-text-on-accent' : 'text-ds-text-primary hover:bg-ds-surface-elevated-hover'}`}
                       >
                         <span aria-hidden="true">{icon}</span>
                         {t(routeLabel)}

--- a/frontend/src/components/ErrorBoundary.test.tsx
+++ b/frontend/src/components/ErrorBoundary.test.tsx
@@ -6,6 +6,10 @@ import { ErrorBoundary } from './ErrorBoundary';
 
 const errorTitle = jaCommon.label.errorBoundaryTitle;
 const retryLabel = jaCommon.label.errorBoundaryRetry;
+const reloadLabel = jaCommon.label.errorBoundaryReload;
+const reportLabel = jaCommon.label.errorBoundaryReport;
+const detailsLabel = jaCommon.label.errorBoundaryDetails;
+const repeatedLabel = jaCommon.label.errorBoundaryRepeated;
 
 function ThrowingChild(): ReactNode {
   throw new Error('test error');
@@ -80,6 +84,64 @@ describe('ErrorBoundary', () => {
 
     expect(screen.getByText('recovered')).toBeInTheDocument();
     expect(screen.queryByText(errorTitle)).not.toBeInTheDocument();
+    vi.restoreAllMocks();
+  });
+
+  it('renders reload button and report link alongside retry', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByRole('button', { name: reloadLabel })).toBeInTheDocument();
+    const reportLink = screen.getByRole('link', { name: reportLabel });
+    expect(reportLink).toHaveAttribute('href');
+    expect(reportLink.getAttribute('href')).toContain('github.com/yuta-yoshinaga/go_trumpcards/issues/new');
+    expect(reportLink).toHaveAttribute('target', '_blank');
+    expect(reportLink).toHaveAttribute('rel', expect.stringContaining('noopener'));
+    vi.restoreAllMocks();
+  });
+
+  it('shows error details inside a collapsed <details>', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>,
+    );
+    const summary = screen.getByText(detailsLabel);
+    expect(summary).toBeInTheDocument();
+    expect(summary.closest('details')).toBeInTheDocument();
+    expect(screen.getByText(/Error: test error/)).toBeInTheDocument();
+    vi.restoreAllMocks();
+  });
+
+  it('shows the repeated-retry warning after the threshold', () => {
+    let shouldThrow = true;
+
+    function MaybeThrow(): ReactNode {
+      if (shouldThrow) {
+        throw new Error('boom');
+      }
+      return <p>ok</p>;
+    }
+
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <ErrorBoundary>
+        <MaybeThrow />
+      </ErrorBoundary>,
+    );
+    expect(screen.queryByText(repeatedLabel)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: retryLabel }));
+    fireEvent.click(screen.getByRole('button', { name: retryLabel }));
+    expect(screen.getByText(repeatedLabel)).toBeInTheDocument();
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole('button', { name: retryLabel }));
+    expect(screen.getByText('ok')).toBeInTheDocument();
     vi.restoreAllMocks();
   });
 });

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -52,7 +52,7 @@ class ErrorBoundaryInner extends Component<ErrorBoundaryProps, ErrorBoundaryStat
   buildIssueUrl(): string {
     const { error } = this.state;
     const title = encodeURIComponent(`[Bug] ${error?.name ?? 'Unknown error'}: ${error?.message ?? ''}`);
-    const stack = error?.stack ?? '(none)';
+    const stack = (error?.stack ?? '(none)').slice(0, 1000);
     const body = encodeURIComponent(
       `**URL:** ${typeof window !== 'undefined' ? window.location.href : '(unknown)'}\n` +
         `**User Agent:** ${typeof navigator !== 'undefined' ? navigator.userAgent : '(unknown)'}\n` +

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -2,7 +2,7 @@ import type { ErrorInfo, ReactNode } from 'react';
 import { Component } from 'react';
 import type { WithTranslation } from 'react-i18next';
 import { withTranslation } from 'react-i18next';
-import { btnPrimary } from '../styles/buttonStyles';
+import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 
 interface ErrorBoundaryProps extends WithTranslation {
   children: ReactNode;
@@ -10,44 +10,104 @@ interface ErrorBoundaryProps extends WithTranslation {
 
 interface ErrorBoundaryState {
   hasError: boolean;
+  error: Error | null;
+  errorInfo: ErrorInfo | null;
+  retryCount: number;
 }
+
+/** GitHub repo issue endpoint used to pre-fill bug report links from the fallback UI. */
+const ISSUE_URL = 'https://github.com/yuta-yoshinaga/go_trumpcards/issues/new';
+
+/** Threshold (inclusive) at which the fallback warns that retrying keeps producing the same crash. */
+const REPEATED_RETRY_THRESHOLD = 2;
 
 class ErrorBoundaryInner extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   constructor(props: ErrorBoundaryProps) {
     super(props);
-    this.state = { hasError: false };
+    this.state = { hasError: false, error: null, errorInfo: null, retryCount: 0 };
   }
 
-  static getDerivedStateFromError(): ErrorBoundaryState {
-    return { hasError: true };
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return { hasError: true, error };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo): void {
     console.error('ErrorBoundary caught:', error, info);
+    this.setState({ errorInfo: info });
   }
 
   handleRetry = () => {
-    this.setState({ hasError: false });
+    this.setState((prev) => ({
+      hasError: false,
+      error: null,
+      errorInfo: null,
+      retryCount: prev.retryCount + 1,
+    }));
   };
 
+  handleReload = () => {
+    window.location.reload();
+  };
+
+  buildIssueUrl(): string {
+    const { error } = this.state;
+    const title = encodeURIComponent(`[Bug] ${error?.name ?? 'Unknown error'}: ${error?.message ?? ''}`);
+    const stack = error?.stack ?? '(none)';
+    const body = encodeURIComponent(
+      `**URL:** ${typeof window !== 'undefined' ? window.location.href : '(unknown)'}\n` +
+        `**User Agent:** ${typeof navigator !== 'undefined' ? navigator.userAgent : '(unknown)'}\n` +
+        `**Error:** ${error?.name ?? ''}: ${error?.message ?? ''}\n` +
+        `**Stack:**\n\`\`\`\n${stack}\n\`\`\`\n`,
+    );
+    return `${ISSUE_URL}?title=${title}&body=${body}`;
+  }
+
   render() {
-    if (this.state.hasError) {
-      const { t } = this.props;
-      return (
-        <div
-          role="alert"
-          className="flex flex-col items-center justify-center h-full bg-ds-surface text-ds-text-primary gap-4"
-        >
-          <h1 className="text-2xl font-bold">{t('label.errorBoundaryTitle')}</h1>
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+    const { t } = this.props;
+    const { error, retryCount } = this.state;
+    const showStack = import.meta.env.DEV && error?.stack;
+    return (
+      <div
+        role="alert"
+        className="flex flex-col items-center justify-center h-full bg-ds-surface text-ds-text-primary gap-4 p-6 max-w-prose mx-auto"
+      >
+        <h1 className="text-2xl font-bold">{t('label.errorBoundaryTitle')}</h1>
+        <p className="text-ds-text-muted text-sm text-center">{t('label.errorBoundaryHelp')}</p>
+
+        <div className="flex gap-2 flex-wrap justify-center">
           <button type="button" onClick={this.handleRetry} className={btnPrimary}>
             {t('label.errorBoundaryRetry')}
           </button>
+          <button type="button" onClick={this.handleReload} className={btnSecondary}>
+            {t('label.errorBoundaryReload')}
+          </button>
+          <a href={this.buildIssueUrl()} target="_blank" rel="noopener noreferrer" className={btnSecondary}>
+            {t('label.errorBoundaryReport')}
+          </a>
         </div>
-      );
-    }
-    return this.props.children;
+
+        {retryCount >= REPEATED_RETRY_THRESHOLD && (
+          <p role="status" className="text-ds-warning text-sm">
+            {t('label.errorBoundaryRepeated')}
+          </p>
+        )}
+
+        {error && (
+          <details className="w-full text-xs text-ds-text-muted">
+            <summary className="cursor-pointer">{t('label.errorBoundaryDetails')}</summary>
+            <pre className="mt-2 whitespace-pre-wrap break-all bg-black/30 p-3 rounded">
+              {error.name}: {error.message}
+              {showStack ? `\n\n${error.stack}` : ''}
+            </pre>
+          </details>
+        )}
+      </div>
+    );
   }
 }
 
-/** Error boundary component that catches render errors and shows a retry screen. */
+/** Error boundary component that catches render errors and shows recovery actions, error details, and a pre-filled issue report link. */
 export const ErrorBoundary = withTranslation()(ErrorBoundaryInner);

--- a/frontend/src/components/GamePageShell.tsx
+++ b/frontend/src/components/GamePageShell.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { GamePageHeading } from './GamePageHeading';
 import { GameResetDialog } from './GameResetDialog';
 import { ManualButton } from './ManualButton';
@@ -57,6 +58,9 @@ export function GamePageShell({
   headerExtra,
   children,
 }: GamePageShellProps) {
+  // Issue #1609: warn before tab close / reload while a round is active so
+  // long-form games (Hearts, Spades, Skat, …) don't silently lose state.
+  useGameRoundGuard(!gameEndFlag);
   return (
     <div className={`flex-1 flex flex-col min-h-0 ${gameThemeBg}`} aria-busy={loading}>
       <GamePageHeading title={title} />

--- a/frontend/src/components/GamePageShell.tsx
+++ b/frontend/src/components/GamePageShell.tsx
@@ -58,7 +58,6 @@ export function GamePageShell({
   headerExtra,
   children,
 }: GamePageShellProps) {
-  // Issue #1609: warn before tab close / reload while a round is active so
   // long-form games (Hearts, Spades, Skat, …) don't silently lose state.
   useGameRoundGuard(!gameEndFlag);
   return (

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -156,8 +156,6 @@ export function VideoPokerGameContent({
     bindings: actionBindings,
     enabled: !!state && !loading,
   });
-
-  // Issue #1609: warn before tab close / reload while a video poker round is active.
   useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return null;

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -7,6 +7,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -155,6 +156,9 @@ export function VideoPokerGameContent({
     bindings: actionBindings,
     enabled: !!state && !loading,
   });
+
+  // Issue #1609: warn before tab close / reload while a video poker round is active.
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return null;
 

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -7,7 +7,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -158,7 +158,7 @@ export function VideoPokerGameContent({
   });
 
   // Issue #1609: warn before tab close / reload while a video poker round is active.
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return null;
 

--- a/frontend/src/components/blackjack/BjBetPhaseControls.test.tsx
+++ b/frontend/src/components/blackjack/BjBetPhaseControls.test.tsx
@@ -39,7 +39,8 @@ function defaultProps(overrides?: Partial<BjBetPhaseControlsProps>): BjBetPhaseC
 describe('BjBetPhaseControls', () => {
   it('renders bet amount input with provided value', () => {
     render(<BjBetPhaseControls {...defaultProps({ betAmount: 50 })} />);
-    expect(screen.getByLabelText('ベット額:')).toHaveValue(50);
+    // ChipBetInput now uses type=text + inputMode=numeric (#1615) — value is a string.
+    expect(screen.getByLabelText('ベット額:')).toHaveValue('50');
   });
 
   it('calls onBetAmountChange when bet input changes', () => {
@@ -150,7 +151,7 @@ describe('BjBetPhaseControls', () => {
 
   it('renders PP input with provided value', () => {
     render(<BjBetPhaseControls {...defaultProps({ perfectPairsBet: 20 })} />);
-    expect(screen.getByLabelText('PP (ペアベット):')).toHaveValue(20);
+    expect(screen.getByLabelText('PP (ペアベット):')).toHaveValue('20');
   });
 
   it('calls onPerfectPairsBetChange when PP input changes', () => {
@@ -162,7 +163,7 @@ describe('BjBetPhaseControls', () => {
 
   it('renders 21+3 input with provided value', () => {
     render(<BjBetPhaseControls {...defaultProps({ twentyOnePlus3Bet: 40 })} />);
-    expect(screen.getByLabelText('21+3:')).toHaveValue(40);
+    expect(screen.getByLabelText('21+3:')).toHaveValue('40');
   });
 
   it('calls onTwentyOnePlus3BetChange when 21+3 input changes', () => {

--- a/frontend/src/components/cli/CliTerminal.tsx
+++ b/frontend/src/components/cli/CliTerminal.tsx
@@ -112,7 +112,7 @@ export function CliTerminal({ logEntries, onCommand, disabled }: CliTerminalProp
           onKeyDown={handleKeyDown}
           disabled={disabled}
           placeholder={t('cli.prompt')}
-          className="flex-1 bg-transparent text-ds-text-primary outline-none placeholder:text-ds-text-muted"
+          className="flex-1 bg-transparent text-ds-text-primary outline-none placeholder:text-ds-text-muted min-h-[44px] py-2"
           aria-label={t('cli.prompt')}
           autoComplete="off"
           spellCheck={false}

--- a/frontend/src/components/common/ChipBetInput.test.tsx
+++ b/frontend/src/components/common/ChipBetInput.test.tsx
@@ -97,10 +97,10 @@ describe('ChipBetInput', () => {
     expect(onChange).toHaveBeenCalledWith(999999999);
   });
 
-  it('does not invoke onChange when input parses to NaN under autoClamp=false', () => {
-    // Number("") === 0 (covered above), but Number("abc") === NaN. Without the guard
-    // running before the !autoClamp branch, callers would have to defensively check
-    // for NaN; this test pins the guard's placement.
+  it('does not invoke onChange when raw input has no digits under autoClamp=false', () => {
+    // Issue #1615: switched to type=text + inputMode=numeric. To preserve the
+    // prior "type=number rejects NaN" UX, all-non-digit input is dropped before
+    // calling onChange (rather than clamped to 0).
     const onChange = vi.fn();
     const { container } = render(
       <ChipBetInput id="bet" label="Bet" value={20} onChange={onChange} max={50} autoClamp={false} />,
@@ -111,5 +111,30 @@ describe('ChipBetInput', () => {
     Object.defineProperty(input, 'value', { get: () => 'abc', configurable: true });
     fireEvent.change(input);
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('uses inputMode=numeric to surface the digit keyboard on mobile', () => {
+    render(<ChipBetInput id="bet" label="Bet" value={50} onChange={() => {}} max={500} />);
+    const input = screen.getByLabelText('Bet');
+    expect(input).toHaveAttribute('type', 'text');
+    expect(input).toHaveAttribute('inputmode', 'numeric');
+    expect(input).toHaveAttribute('pattern', '[0-9]*');
+  });
+
+  it('strips non-digit characters from typed input before parsing', () => {
+    const onChange = vi.fn();
+    render(<ChipBetInput id="bet" label="Bet" value={50} onChange={onChange} max={500} />);
+    fireEvent.change(screen.getByLabelText('Bet'), { target: { value: '1.2e5' } });
+    // '1.2e5' → '125' after stripping; clamped under max=500 → 125.
+    expect(onChange).toHaveBeenLastCalledWith(125);
+  });
+
+  it('blurs the input on wheel events to prevent accidental scroll changes', () => {
+    render(<ChipBetInput id="bet" label="Bet" value={50} onChange={() => {}} max={500} />);
+    const input = screen.getByLabelText('Bet') as HTMLInputElement;
+    input.focus();
+    expect(document.activeElement).toBe(input);
+    fireEvent.wheel(input, { deltaY: 100 });
+    expect(document.activeElement).not.toBe(input);
   });
 });

--- a/frontend/src/components/common/ChipBetInput.test.tsx
+++ b/frontend/src/components/common/ChipBetInput.test.tsx
@@ -98,9 +98,8 @@ describe('ChipBetInput', () => {
   });
 
   it('does not invoke onChange when raw input has no digits under autoClamp=false', () => {
-    // Issue #1615: switched to type=text + inputMode=numeric. To preserve the
-    // prior "type=number rejects NaN" UX, all-non-digit input is dropped before
-    // calling onChange (rather than clamped to 0).
+    // The text/inputMode=numeric input drops all-non-digit input before
+    // calling onChange to preserve the type=number "reject NaN" behavior.
     const onChange = vi.fn();
     const { container } = render(
       <ChipBetInput id="bet" label="Bet" value={20} onChange={onChange} max={50} autoClamp={false} />,

--- a/frontend/src/components/common/ChipBetInput.tsx
+++ b/frontend/src/components/common/ChipBetInput.tsx
@@ -60,7 +60,11 @@ export function ChipBetInput({
       </label>
       <input
         id={id}
-        type="number"
+        type="text"
+        inputMode="numeric"
+        pattern="[0-9]*"
+        autoComplete="off"
+        enterKeyHint="done"
         min={min}
         max={max}
         step={step}
@@ -68,8 +72,11 @@ export function ChipBetInput({
         aria-invalid={invalid || undefined}
         aria-describedby={describedBy}
         onChange={(e) => {
-          const parsed = Number(e.target.value);
-          if (Number.isNaN(parsed)) return;
+          const raw = e.target.value;
+          const cleaned = raw.replace(/[^0-9]/g, '');
+          // User typed only non-digit chars: reject (mirrors prior type=number rejection of NaN input).
+          if (raw !== '' && cleaned === '') return;
+          const parsed = cleaned === '' ? 0 : Number(cleaned);
           if (!autoClamp) {
             onChange(parsed);
             return;
@@ -77,6 +84,7 @@ export function ChipBetInput({
           const upper = max ?? Number.POSITIVE_INFINITY;
           onChange(Math.max(min, Math.min(parsed, upper)));
         }}
+        onWheel={(e) => e.currentTarget.blur()}
         disabled={disabled}
         className={`${widthClass} px-3 py-2 rounded text-base min-h-[44px] ${errorClasses}`}
       />

--- a/frontend/src/components/common/SettingsPanel.test.tsx
+++ b/frontend/src/components/common/SettingsPanel.test.tsx
@@ -199,7 +199,7 @@ describe('SettingsPanel', () => {
     expect(screen.getByText('G2')).toBeInTheDocument();
   });
 
-  it('renders tooltip on checkbox hover with aria-describedby', () => {
+  it('reveals checkbox tooltip via the help button (touch-accessible toggle)', () => {
     const { container } = render(
       <SettingsPanel
         title="Settings"
@@ -210,15 +210,19 @@ describe('SettingsPanel', () => {
         ]}
       />,
     );
-    const tooltip = screen.getByText('Help text');
-    expect(tooltip).toBeInTheDocument();
-    expect(tooltip).toHaveAttribute('id', 'cb1-tooltip');
-    expect(tooltip).toHaveAttribute('role', 'tooltip');
+    // Tooltip text is hidden until the help button is tapped.
+    expect(screen.queryByText('Help text')).not.toBeInTheDocument();
+    // aria-describedby is wired up regardless so screen-reader users still get it on focus.
     const checkbox = container.querySelector('#cb1') as HTMLInputElement;
     expect(checkbox).toHaveAttribute('aria-describedby', 'cb1-tooltip');
+    const helpBtn = screen.getByRole('button', { name: /Show help|説明を表示/ });
+    fireEvent.click(helpBtn);
+    const tooltip = screen.getByText('Help text');
+    expect(tooltip).toHaveAttribute('id', 'cb1-tooltip');
+    expect(tooltip).toHaveAttribute('role', 'tooltip');
   });
 
-  it('renders tooltip on select hover with aria-describedby', () => {
+  it('reveals select tooltip via the help button', () => {
     render(
       <SettingsPanel
         title="Settings"
@@ -238,12 +242,65 @@ describe('SettingsPanel', () => {
         ]}
       />,
     );
-    const tooltip = screen.getByText('Select help');
-    expect(tooltip).toBeInTheDocument();
-    expect(tooltip).toHaveAttribute('id', 'sel1-tooltip');
-    expect(tooltip).toHaveAttribute('role', 'tooltip');
+    expect(screen.queryByText('Select help')).not.toBeInTheDocument();
     const select = screen.getByLabelText('Sel');
     expect(select).toHaveAttribute('aria-describedby', 'sel1-tooltip');
+    const helpBtn = screen.getByRole('button', { name: /Show help|説明を表示/ });
+    fireEvent.click(helpBtn);
+    const tooltip = screen.getByText('Select help');
+    expect(tooltip).toHaveAttribute('id', 'sel1-tooltip');
+    expect(tooltip).toHaveAttribute('role', 'tooltip');
+  });
+
+  it('toggles tooltip closed on a second help button click', () => {
+    render(
+      <SettingsPanel
+        title="Settings"
+        groups={[
+          {
+            items: [{ type: 'checkbox', id: 'cb1', label: 'With tip', checked: false, tooltip: 'Help text' }],
+          },
+        ]}
+      />,
+    );
+    const helpBtn = screen.getByRole('button', { name: /Show help|説明を表示/ });
+    fireEvent.click(helpBtn);
+    expect(screen.getByText('Help text')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Hide help|説明を非表示/ }));
+    expect(screen.queryByText('Help text')).not.toBeInTheDocument();
+  });
+
+  it('closes the open tooltip when Escape is pressed', () => {
+    render(
+      <SettingsPanel
+        title="Settings"
+        groups={[
+          {
+            items: [{ type: 'checkbox', id: 'cb1', label: 'With tip', checked: false, tooltip: 'Help text' }],
+          },
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Show help|説明を表示/ }));
+    expect(screen.getByText('Help text')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByText('Help text')).not.toBeInTheDocument();
+  });
+
+  it('does not toggle the checkbox when the help button inside the row is clicked', () => {
+    const onToggle = vi.fn();
+    render(
+      <SettingsPanel
+        title="Settings"
+        groups={[
+          {
+            items: [{ type: 'checkbox', id: 'cb1', label: 'Item', checked: false, tooltip: 'Help', onToggle }],
+          },
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Show help|説明を表示/ }));
+    expect(onToggle).not.toHaveBeenCalled();
   });
 
   it('does not set aria-describedby when no tooltip on checkbox', () => {

--- a/frontend/src/components/common/SettingsPanel.tsx
+++ b/frontend/src/components/common/SettingsPanel.tsx
@@ -1,3 +1,6 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
 /** A single setting item (checkbox or select) in the settings panel. */
 export interface SettingsItem {
   type: 'checkbox' | 'select';
@@ -28,6 +31,50 @@ interface SettingsPanelProps {
 
 /** Renders a collapsible settings panel with grouped checkboxes and selects. */
 export function SettingsPanel({ title, groups }: SettingsPanelProps) {
+  const { t } = useTranslation('common');
+  const [openTipId, setOpenTipId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (openTipId === null) return;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpenTipId(null);
+    };
+    document.addEventListener('keydown', handleEsc);
+    return () => document.removeEventListener('keydown', handleEsc);
+  }, [openTipId]);
+
+  const renderHelp = (item: SettingsItem) => {
+    if (!item.tooltip) return null;
+    const isOpen = openTipId === item.id;
+    return (
+      <>
+        <button
+          type="button"
+          aria-label={isOpen ? t('settings.hideHelp') : t('settings.showHelp')}
+          aria-expanded={isOpen}
+          aria-controls={`${item.id}-tooltip`}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setOpenTipId(isOpen ? null : item.id);
+          }}
+          className="text-ds-text-muted hover:text-ds-accent w-11 h-11 inline-flex items-center justify-center rounded-full text-xs"
+        >
+          (?)
+        </button>
+        {isOpen && (
+          <span
+            id={`${item.id}-tooltip`}
+            role="tooltip"
+            className="basis-full text-xs text-ds-text-muted mt-1 max-w-prose"
+          >
+            {item.tooltip}
+          </span>
+        )}
+      </>
+    );
+  };
+
   return (
     <details className="px-4 pt-2">
       <summary className="text-ds-text-primary text-sm cursor-pointer select-none inline-flex items-center gap-1.5 hover:text-ds-accent transition-colors py-1">
@@ -54,32 +101,22 @@ export function SettingsPanel({ title, groups }: SettingsPanelProps) {
             <div className="flex flex-wrap gap-x-4 gap-y-1">
               {group.items.map((item) =>
                 item.type === 'checkbox' ? (
-                  <label
-                    key={item.id}
-                    htmlFor={item.id}
-                    className="flex items-center gap-2 cursor-pointer relative group/tip min-h-[44px] px-1"
-                  >
-                    <input
-                      id={item.id}
-                      type="checkbox"
-                      checked={item.checked ?? false}
-                      disabled={item.disabled}
-                      onChange={(e) => item.onToggle?.(e.target.checked)}
-                      aria-describedby={item.tooltip ? `${item.id}-tooltip` : undefined}
-                    />
-                    {item.label}
-                    {item.tooltip && (
-                      <span
-                        id={`${item.id}-tooltip`}
-                        role="tooltip"
-                        className="hidden group-hover/tip:block group-focus-within/tip:block absolute bottom-full left-0 mb-1 bg-ds-surface-elevated text-ds-text-primary text-xs rounded px-2 py-1 whitespace-nowrap z-10"
-                      >
-                        {item.tooltip}
-                      </span>
-                    )}
-                  </label>
+                  <span key={item.id} className="flex flex-wrap items-center gap-2 px-1">
+                    <label htmlFor={item.id} className="flex items-center gap-2 cursor-pointer min-h-[44px]">
+                      <input
+                        id={item.id}
+                        type="checkbox"
+                        checked={item.checked ?? false}
+                        disabled={item.disabled}
+                        onChange={(e) => item.onToggle?.(e.target.checked)}
+                        aria-describedby={item.tooltip ? `${item.id}-tooltip` : undefined}
+                      />
+                      {item.label}
+                    </label>
+                    {renderHelp(item)}
+                  </span>
                 ) : (
-                  <span key={item.id} className="flex items-center gap-2 relative group/tip min-h-[44px] px-1">
+                  <span key={item.id} className="flex flex-wrap items-center gap-2 min-h-[44px] px-1">
                     <label htmlFor={item.id}>{item.label}</label>
                     <select
                       id={item.id}
@@ -95,15 +132,7 @@ export function SettingsPanel({ title, groups }: SettingsPanelProps) {
                         </option>
                       ))}
                     </select>
-                    {item.tooltip && (
-                      <span
-                        id={`${item.id}-tooltip`}
-                        role="tooltip"
-                        className="hidden group-hover/tip:block group-focus-within/tip:block absolute bottom-full left-0 mb-1 bg-ds-surface-elevated text-ds-text-primary text-xs rounded px-2 py-1 whitespace-nowrap z-10"
-                      >
-                        {item.tooltip}
-                      </span>
-                    )}
+                    {renderHelp(item)}
                   </span>
                 ),
               )}

--- a/frontend/src/hooks/useGameRoundGuard.test.ts
+++ b/frontend/src/hooks/useGameRoundGuard.test.ts
@@ -1,6 +1,33 @@
 import { renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { useGameRoundGuard } from './useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from './useGameRoundGuard';
+
+describe('isGameRoundActive', () => {
+  it('returns false for null', () => {
+    expect(isGameRoundActive(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isGameRoundActive(undefined)).toBe(false);
+  });
+
+  it('returns false for non-object primitives', () => {
+    expect(isGameRoundActive(42)).toBe(false);
+    expect(isGameRoundActive('active')).toBe(false);
+  });
+
+  it('returns false when gameEndFlag is true', () => {
+    expect(isGameRoundActive({ gameEndFlag: true })).toBe(false);
+  });
+
+  it('returns true for an object without gameEndFlag', () => {
+    expect(isGameRoundActive({ phase: 'deal' })).toBe(true);
+  });
+
+  it('returns true when gameEndFlag is false', () => {
+    expect(isGameRoundActive({ gameEndFlag: false })).toBe(true);
+  });
+});
 
 describe('useGameRoundGuard', () => {
   afterEach(() => {

--- a/frontend/src/hooks/useGameRoundGuard.test.ts
+++ b/frontend/src/hooks/useGameRoundGuard.test.ts
@@ -1,0 +1,31 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useGameRoundGuard } from './useGameRoundGuard';
+
+describe('useGameRoundGuard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('registers a beforeunload listener with the i18n confirm message when active', () => {
+    let registered: ((e: BeforeUnloadEvent) => unknown) | null = null;
+    vi.spyOn(window, 'addEventListener').mockImplementation((ev, handler) => {
+      if (ev === 'beforeunload') registered = handler as (e: BeforeUnloadEvent) => unknown;
+    });
+    renderHook(() => useGameRoundGuard(true));
+    expect(registered).not.toBeNull();
+    const event = { preventDefault: vi.fn(), returnValue: '' } as unknown as BeforeUnloadEvent;
+    // biome-ignore lint/style/noNonNullAssertion: null check above confirms registered is set
+    registered!(event);
+    expect(event.preventDefault).toHaveBeenCalled();
+    // Tests run with ja locale loaded.
+    expect(event.returnValue).toBe('ページを離れると現在のラウンドが破棄されます。続けますか？');
+  });
+
+  it('does not register listener when inactive', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    renderHook(() => useGameRoundGuard(false));
+    const beforeUnloadCalls = addSpy.mock.calls.filter(([ev]) => ev === 'beforeunload');
+    expect(beforeUnloadCalls).toHaveLength(0);
+  });
+});

--- a/frontend/src/hooks/useGameRoundGuard.ts
+++ b/frontend/src/hooks/useGameRoundGuard.ts
@@ -30,10 +30,6 @@ export function isGameRoundActive(state: unknown): boolean {
  * own phase state. When `true`, the browser-level `beforeunload` warning is
  * armed; SPA navigation is intentionally not intercepted (see the underlying
  * hook for rationale).
- *
- * Issue #1609 — applied across all long-form game pages so that accidental
- * tab close / reload during a round consistently warns the user, instead of
- * the prior BlackJack-only behavior.
  */
 export function useGameRoundGuard(active: boolean) {
   const { t } = useTranslation('common');

--- a/frontend/src/hooks/useGameRoundGuard.ts
+++ b/frontend/src/hooks/useGameRoundGuard.ts
@@ -2,6 +2,26 @@ import { useTranslation } from 'react-i18next';
 import { useGameLeaveGuard } from './useGameLeaveGuard';
 
 /**
+ * Returns whether a round is in progress for the given game state.
+ *
+ * Accepts any state shape — most game responses expose `gameEndFlag`, but a
+ * handful (solitaire and similar single-player games) only carry a `phase`
+ * field. Callers can pass the state directly without per-page type
+ * gymnastics; pages that need a stricter check (e.g., "round done but not
+ * yet reset") should compute their own boolean and pass it instead.
+ *
+ * Returns false when state is null/undefined (no active round) or when
+ * `gameEndFlag` is explicitly true. Otherwise returns true.
+ */
+export function isGameRoundActive(state: unknown): boolean {
+  if (state == null || typeof state !== 'object') return false;
+  if ('gameEndFlag' in state && (state as { gameEndFlag?: unknown }).gameEndFlag === true) {
+    return false;
+  }
+  return true;
+}
+
+/**
  * Convenience wrapper around {@link useGameLeaveGuard} that resolves the
  * confirm message from the shared `button.confirmLeaveRoundMessage` i18n key,
  * removing the boilerplate from every game page.

--- a/frontend/src/hooks/useGameRoundGuard.ts
+++ b/frontend/src/hooks/useGameRoundGuard.ts
@@ -1,0 +1,21 @@
+import { useTranslation } from 'react-i18next';
+import { useGameLeaveGuard } from './useGameLeaveGuard';
+
+/**
+ * Convenience wrapper around {@link useGameLeaveGuard} that resolves the
+ * confirm message from the shared `button.confirmLeaveRoundMessage` i18n key,
+ * removing the boilerplate from every game page.
+ *
+ * Pages should pass a single `isRoundInProgress` predicate computed from their
+ * own phase state. When `true`, the browser-level `beforeunload` warning is
+ * armed; SPA navigation is intentionally not intercepted (see the underlying
+ * hook for rationale).
+ *
+ * Issue #1609 — applied across all long-form game pages so that accidental
+ * tab close / reload during a round consistently warns the user, instead of
+ * the prior BlackJack-only behavior.
+ */
+export function useGameRoundGuard(active: boolean) {
+  const { t } = useTranslation('common');
+  useGameLeaveGuard(active, t('button.confirmLeaveRoundMessage'));
+}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -101,7 +101,9 @@
     "loading": "Loading…"
   },
   "settings": {
-    "title": "Settings"
+    "title": "Settings",
+    "showHelp": "Show help",
+    "hideHelp": "Hide help"
   },
   "player": {
     "you": "You",
@@ -199,7 +201,12 @@
     "mucked": "Mucked",
     "player": "Player",
     "errorBoundaryTitle": "An error occurred",
-    "errorBoundaryRetry": "Retry"
+    "errorBoundaryRetry": "Retry",
+    "errorBoundaryReload": "Reload page",
+    "errorBoundaryReport": "Report issue",
+    "errorBoundaryHelp": "Sorry — choose how to recover below.",
+    "errorBoundaryRepeated": "The same error keeps occurring. Please reload the page.",
+    "errorBoundaryDetails": "Show error details"
   },
   "messageCode": {
     "blackjack.result.draw": "It is a draw.",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -101,7 +101,9 @@
     "loading": "読み込み中…"
   },
   "settings": {
-    "title": "設定"
+    "title": "設定",
+    "showHelp": "説明を表示",
+    "hideHelp": "説明を非表示"
   },
   "player": {
     "you": "あなた",
@@ -199,7 +201,12 @@
     "mucked": "マック",
     "player": "プレイヤー",
     "errorBoundaryTitle": "エラーが発生しました",
-    "errorBoundaryRetry": "再試行"
+    "errorBoundaryRetry": "再試行",
+    "errorBoundaryReload": "ページをリロード",
+    "errorBoundaryReport": "問題を報告",
+    "errorBoundaryHelp": "申し訳ありません。下のボタンで対応をお選びいただけます。",
+    "errorBoundaryRepeated": "同じエラーが繰り返されています。ページをリロードしてください。",
+    "errorBoundaryDetails": "エラーの詳細を表示"
   },
   "messageCode": {
     "blackjack.result.draw": "引き分けです。",

--- a/frontend/src/pages/AccordionPage.tsx
+++ b/frontend/src/pages/AccordionPage.tsx
@@ -26,6 +26,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnOutline, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -221,6 +222,9 @@ function AccordionPageContent() {
     [selectedIdx, dispatchMove],
   );
 
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+  useGameRoundGuard(!!state && !state.gameEndFlag);
+
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
   if (!state) return <KlondikeSkeleton />;
 
@@ -232,7 +236,7 @@ function AccordionPageContent() {
   const phaseName = isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing');
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.klondike.bg}`} aria-busy={loading}>
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.accordion.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.accordion')} />
       <PhaseIndicator phaseName={phaseName}>
         <span>

--- a/frontend/src/pages/AccordionPage.tsx
+++ b/frontend/src/pages/AccordionPage.tsx
@@ -221,8 +221,6 @@ function AccordionPageContent() {
     },
     [selectedIdx, dispatchMove],
   );
-
-  // Issue #1609: warn before tab close / reload while a round is in progress.
   useGameRoundGuard(isGameRoundActive(state));
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;

--- a/frontend/src/pages/AccordionPage.tsx
+++ b/frontend/src/pages/AccordionPage.tsx
@@ -26,7 +26,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnOutline, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -223,7 +223,7 @@ function AccordionPageContent() {
   );
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
   if (!state) return <KlondikeSkeleton />;

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -26,6 +26,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -240,6 +241,10 @@ function BaccaratPageContent() {
     bindings: actionBindings,
     enabled: !!state && !loading,
   });
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <BaccaratSkeleton />;
 

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -26,7 +26,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -244,7 +244,7 @@ function BaccaratPageContent() {
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <BaccaratSkeleton />;
 

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -242,8 +242,6 @@ function BaccaratPageContent() {
     enabled: !!state && !loading,
   });
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <BaccaratSkeleton />;

--- a/frontend/src/pages/BadugiPage.tsx
+++ b/frontend/src/pages/BadugiPage.tsx
@@ -183,8 +183,6 @@ function BadugiPageContent() {
     execAction('reset', undefined, undefined, { bettingLimit, cpuMetaAI });
   }, [execAction, hideActionLog, bettingLimit, cpuMetaAI]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <PokerSkeleton />;

--- a/frontend/src/pages/BadugiPage.tsx
+++ b/frontend/src/pages/BadugiPage.tsx
@@ -30,6 +30,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnSuccess, btnWarning, focusRingAccent } from '../styles/buttonStyles';
 import { selectedCardStyle } from '../styles/cardStyles';
@@ -182,10 +183,14 @@ function BadugiPageContent() {
     execAction('reset', undefined, undefined, { bettingLimit, cpuMetaAI });
   }, [execAction, hideActionLog, bettingLimit, cpuMetaAI]);
 
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
+
   if (!state) return <PokerSkeleton />;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.poker.bg}`} aria-busy={loading}>
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.badugi.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.badugi')} />
       {/* Phase indicator + info bar */}
       <PhaseIndicator phaseName={phaseLabel} isHumanTurn={canAct || canExchange}>
@@ -255,7 +260,7 @@ function BadugiPageContent() {
           </div>
 
           {/* Sticky footer: player hand + buttons */}
-          <GameFooter className={`${gameTheme.poker.footer} px-5 py-3`}>
+          <GameFooter className={`${gameTheme.badugi.footer} px-5 py-3`}>
             {/* Human player */}
             {humanPlayer && (
               <div className="mb-2" data-tutorial="bg-player-hand">

--- a/frontend/src/pages/BakersDozenPage.tsx
+++ b/frontend/src/pages/BakersDozenPage.tsx
@@ -28,6 +28,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -180,6 +181,10 @@ function BakersDozenPageContent() {
     bindings: actionBindings,
     enabled: !!isPlayingForKbd && !loading,
   });
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <BakersDozenSkeleton />;
 

--- a/frontend/src/pages/BakersDozenPage.tsx
+++ b/frontend/src/pages/BakersDozenPage.tsx
@@ -182,8 +182,6 @@ function BakersDozenPageContent() {
     enabled: !!isPlayingForKbd && !loading,
   });
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <BakersDozenSkeleton />;

--- a/frontend/src/pages/BakersDozenPage.tsx
+++ b/frontend/src/pages/BakersDozenPage.tsx
@@ -28,7 +28,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -184,7 +184,7 @@ function BakersDozenPageContent() {
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <BakersDozenSkeleton />;
 

--- a/frontend/src/pages/BlackJackPage.test.tsx
+++ b/frontend/src/pages/BlackJackPage.test.tsx
@@ -979,7 +979,9 @@ describe('BlackJackPage', () => {
     renderWithProviders(<BlackJackPage />);
     await waitFor(() => expect(screen.getByLabelText('ベット額:')).toBeInTheDocument());
     fireEvent.change(screen.getByLabelText('ベット額:'), { target: { value: '50' } });
-    expect(screen.getByLabelText('ベット額:')).toHaveValue(50);
+    // ChipBetInput now uses type=text + inputMode=numeric (#1615), so the
+    // displayed value is a string rather than a number.
+    expect(screen.getByLabelText('ベット額:')).toHaveValue('50');
     mockExec.mockClear();
     mockExec.mockResolvedValue(actionPhaseState);
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -41,8 +41,8 @@ import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
-import { useGameLeaveGuard } from '../hooks/useGameLeaveGuard';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -195,7 +195,7 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
     phase === BjPhase.EARLY_SURRENDER ||
     phase === BjPhase.INSURANCE ||
     phase === BjPhase.ACTION;
-  useGameLeaveGuard(isRoundInProgress, tc('button.confirmLeaveRoundMessage'));
+  useGameRoundGuard(isRoundInProgress);
   const hands = state?.hands ?? [];
   const currentHandIdx = state?.currentHandIdx ?? 0;
   const currentHand = hands[currentHandIdx];
@@ -259,10 +259,7 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
   if (!state) return <BlackJackSkeleton />;
 
   return (
-    <div
-      className={`flex-1 flex flex-col min-h-0 ${gameTheme[themeKey]?.bg ?? gameTheme.blackjack.bg}`}
-      aria-busy={loading}
-    >
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme[themeKey].bg}`} aria-busy={loading}>
       <GamePageHeading title={tc(navTitleKey)} />
       {/* Phase indicator + info bar */}
       <PhaseIndicator
@@ -406,7 +403,7 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
           </div>
 
           {/* Sticky footer: player hand + result + buttons */}
-          <GameFooter className={`${gameTheme[themeKey]?.footer ?? gameTheme.blackjack.footer} px-4 py-3`}>
+          <GameFooter className={`${gameTheme[themeKey].footer} px-4 py-3`}>
             {/* Player hands */}
             {phase !== BjPhase.BET && hands.length > 0 && (
               <div className="mb-2" data-tutorial="bj-player-hand">
@@ -548,7 +545,7 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
                       id="bj-auto-advance"
                       value={autoAdvance}
                       onChange={(e) => setAutoAdvance(Number(e.target.value))}
-                      className="px-2 py-1 rounded text-sm"
+                      className="px-3 py-2 rounded text-sm min-h-[44px]"
                     >
                       <option value={0}>OFF</option>
                       <option value={3}>{t('autoAdvanceSec', { sec: 3 })}</option>

--- a/frontend/src/pages/BridgePage.tsx
+++ b/frontend/src/pages/BridgePage.tsx
@@ -24,6 +24,7 @@ import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
@@ -191,6 +192,10 @@ function BridgePageContent() {
       cpuDifficulty: bridgeConfig.cpuDifficulty,
     });
   }, [apiExec, hideActionLog, bridgeConfig.cpuDifficulty]);
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <BridgeSkeleton />;
 

--- a/frontend/src/pages/BridgePage.tsx
+++ b/frontend/src/pages/BridgePage.tsx
@@ -193,8 +193,6 @@ function BridgePageContent() {
     });
   }, [apiExec, hideActionLog, bridgeConfig.cpuDifficulty]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <BridgeSkeleton />;

--- a/frontend/src/pages/CalculationPage.tsx
+++ b/frontend/src/pages/CalculationPage.tsx
@@ -27,6 +27,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnOutline, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -275,7 +276,11 @@ function CalculationPageContent() {
     [source],
   );
 
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+  useGameRoundGuard(!!state && !state.gameEndFlag);
+
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
+
   if (!state) return <KlondikeSkeleton />;
 
   const isPlaying = state.phase === CalculationPhase.PLAYING;

--- a/frontend/src/pages/CalculationPage.tsx
+++ b/frontend/src/pages/CalculationPage.tsx
@@ -27,7 +27,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnOutline, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -277,7 +277,7 @@ function CalculationPageContent() {
   );
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
 

--- a/frontend/src/pages/CalculationPage.tsx
+++ b/frontend/src/pages/CalculationPage.tsx
@@ -275,8 +275,6 @@ function CalculationPageContent() {
     },
     [source],
   );
-
-  // Issue #1609: warn before tab close / reload while a round is in progress.
   useGameRoundGuard(isGameRoundActive(state));
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;

--- a/frontend/src/pages/CanastaPage.tsx
+++ b/frontend/src/pages/CanastaPage.tsx
@@ -147,8 +147,6 @@ function CanastaPageContent() {
     enabled: !!isHumanTurn && !loading,
   });
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) {

--- a/frontend/src/pages/CanastaPage.tsx
+++ b/frontend/src/pages/CanastaPage.tsx
@@ -24,6 +24,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnOutline, btnPrimary, btnSuccess } from '../styles/buttonStyles';
@@ -145,6 +146,10 @@ function CanastaPageContent() {
     onClear: clearSelection,
     enabled: !!isHumanTurn && !loading,
   });
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) {
     return (

--- a/frontend/src/pages/CanfieldPage.tsx
+++ b/frontend/src/pages/CanfieldPage.tsx
@@ -26,6 +26,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { btnDanger, btnOutline, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -80,6 +81,8 @@ function CanfieldPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('canfield');
   const { state, loading, error, exec: execApi, retry } = useGameApi(canfieldApi.exec);
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+  useGameRoundGuard(!!state && !state.gameEndFlag);
   const { cardWidth, cardHeight } = useCardDimensions();
   const {
     hint: frontendHint,

--- a/frontend/src/pages/CanfieldPage.tsx
+++ b/frontend/src/pages/CanfieldPage.tsx
@@ -81,7 +81,6 @@ function CanfieldPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('canfield');
   const { state, loading, error, exec: execApi, retry } = useGameApi(canfieldApi.exec);
-  // Issue #1609: warn before tab close / reload while a round is in progress.
   useGameRoundGuard(isGameRoundActive(state));
   const { cardWidth, cardHeight } = useCardDimensions();
   const {

--- a/frontend/src/pages/CanfieldPage.tsx
+++ b/frontend/src/pages/CanfieldPage.tsx
@@ -26,7 +26,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { btnDanger, btnOutline, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -82,7 +82,7 @@ function CanfieldPageContent() {
     useGamePageSetup('canfield');
   const { state, loading, error, exec: execApi, retry } = useGameApi(canfieldApi.exec);
   // Issue #1609: warn before tab close / reload while a round is in progress.
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
   const { cardWidth, cardHeight } = useCardDimensions();
   const {
     hint: frontendHint,

--- a/frontend/src/pages/CaribbeanStudPage.tsx
+++ b/frontend/src/pages/CaribbeanStudPage.tsx
@@ -26,7 +26,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -142,7 +142,7 @@ function CaribbeanStudPageContent() {
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <CaribbeanStudSkeleton />;
 

--- a/frontend/src/pages/CaribbeanStudPage.tsx
+++ b/frontend/src/pages/CaribbeanStudPage.tsx
@@ -26,6 +26,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -139,6 +140,10 @@ function CaribbeanStudPageContent() {
     enabled: !!state && !loading,
   });
 
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
+
   if (!state) return <CaribbeanStudSkeleton />;
 
   const handleBet = () => {
@@ -160,7 +165,7 @@ function CaribbeanStudPageContent() {
   const phaseName = isBetPhase ? t('phase.bet') : isActionPhase ? t('phase.action') : t('phase.end');
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.threecard.bg}`} aria-busy={loading}>
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.caribbeanstud.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.caribbeanstud')} />
       <PhaseIndicator phaseName={phaseName}>
         <span>
@@ -326,7 +331,7 @@ function CaribbeanStudPageContent() {
             {actionLog && <ActionLogPanel entries={actionLog} onClose={hideActionLog} />}
           </div>
 
-          <GameFooter className={`${gameTheme.threecard.footer} px-4 pt-3`}>
+          <GameFooter className={`${gameTheme.caribbeanstud.footer} px-4 pt-3`}>
             <ErrorAlert message={error} onRetry={retry} />
             <SettingsPanel title={t('settings.title')} groups={[]} />
             {isBetPhase && (

--- a/frontend/src/pages/CaribbeanStudPage.tsx
+++ b/frontend/src/pages/CaribbeanStudPage.tsx
@@ -140,8 +140,6 @@ function CaribbeanStudPageContent() {
     enabled: !!state && !loading,
   });
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <CaribbeanStudSkeleton />;

--- a/frontend/src/pages/CassinoPage.tsx
+++ b/frontend/src/pages/CassinoPage.tsx
@@ -22,6 +22,8 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { gameTheme } from '../styles/gameTheme';
 import type { CassinoResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import {
@@ -133,9 +135,13 @@ function CassinoPageContent() {
 
   const onReset = useCallback(() => handleResetWithConfig(), [handleResetWithConfig]);
 
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
+
   if (!state || state.players.length < 4) {
     return (
-      <div className="flex-1 flex items-center justify-center bg-game-bg-green text-ds-text-muted" aria-busy>
+      <div className={`flex-1 flex items-center justify-center ${gameTheme.cassino.bg} text-ds-text-muted`} aria-busy>
         {tc('common.loading')}
       </div>
     );
@@ -151,7 +157,7 @@ function CassinoPageContent() {
   const phaseName = isGameEnd ? t('phase.end') : t(`phase.${state.phase}`, t('phase.play'));
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-game-bg-green" aria-busy={loading}>
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.cassino.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.cassino')} />
       <PhaseIndicator phaseName={phaseName} isHumanTurn={isHumanTurn}>
         <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
@@ -312,7 +318,7 @@ function CassinoPageContent() {
             ]}
           />
 
-          <GameFooter className="bg-game-bg-green-dark border-white/20 px-4 py-2.5">
+          <GameFooter className={`${gameTheme.cassino.footer} px-4 py-2.5`}>
             <div className="flex gap-2 justify-center flex-wrap items-center" data-tutorial="cs-actions">
               <button
                 type="button"

--- a/frontend/src/pages/CassinoPage.tsx
+++ b/frontend/src/pages/CassinoPage.tsx
@@ -135,8 +135,6 @@ function CassinoPageContent() {
 
   const onReset = useCallback(() => handleResetWithConfig(), [handleResetWithConfig]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state || state.players.length < 4) {

--- a/frontend/src/pages/ClockSolitairePage.tsx
+++ b/frontend/src/pages/ClockSolitairePage.tsx
@@ -74,7 +74,6 @@ function ClockSolitairePageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('clocksolitaire');
   const { state, loading, error, exec: execApi, retry } = useGameApi(clocksolitaireApi.exec);
-  // Issue #1609: warn before tab close / reload while a round is in progress.
   useGameRoundGuard(isGameRoundActive(state));
   const handleReset = useCallback(() => execApi('reset'), [execApi]);
   const handleStep = useCallback(() => execApi('step'), [execApi]);

--- a/frontend/src/pages/ClockSolitairePage.tsx
+++ b/frontend/src/pages/ClockSolitairePage.tsx
@@ -24,6 +24,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { ClockSolitaireResponse } from '../types/card';
@@ -73,6 +74,8 @@ function ClockSolitairePageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('clocksolitaire');
   const { state, loading, error, exec: execApi, retry } = useGameApi(clocksolitaireApi.exec);
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+  useGameRoundGuard(!!state && !state.gameEndFlag);
   const handleReset = useCallback(() => execApi('reset'), [execApi]);
   const handleStep = useCallback(() => execApi('step'), [execApi]);
   const handleAutoPlay = useCallback(() => execApi('autoplay'), [execApi]);

--- a/frontend/src/pages/ClockSolitairePage.tsx
+++ b/frontend/src/pages/ClockSolitairePage.tsx
@@ -24,7 +24,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { ClockSolitaireResponse } from '../types/card';
@@ -75,7 +75,7 @@ function ClockSolitairePageContent() {
     useGamePageSetup('clocksolitaire');
   const { state, loading, error, exec: execApi, retry } = useGameApi(clocksolitaireApi.exec);
   // Issue #1609: warn before tab close / reload while a round is in progress.
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
   const handleReset = useCallback(() => execApi('reset'), [execApi]);
   const handleStep = useCallback(() => execApi('step'), [execApi]);
   const handleAutoPlay = useCallback(() => execApi('autoplay'), [execApi]);

--- a/frontend/src/pages/CrazyEightsPage.tsx
+++ b/frontend/src/pages/CrazyEightsPage.tsx
@@ -25,6 +25,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useCrazyEightsGame } from '../hooks/useCrazyEightsGame';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
@@ -164,6 +165,10 @@ function CrazyEightsPageContent() {
   });
 
   const phaseNames = usePhaseNames('crazyeights', CRAZYEIGHTS_PHASE_KEYS);
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <CrazyEightsSkeleton />;
 

--- a/frontend/src/pages/CrazyEightsPage.tsx
+++ b/frontend/src/pages/CrazyEightsPage.tsx
@@ -166,8 +166,6 @@ function CrazyEightsPageContent() {
 
   const phaseNames = usePhaseNames('crazyeights', CRAZYEIGHTS_PHASE_KEYS);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <CrazyEightsSkeleton />;

--- a/frontend/src/pages/CribbagePage.tsx
+++ b/frontend/src/pages/CribbagePage.tsx
@@ -193,8 +193,6 @@ function CribbagePageContent() {
     });
   }, [gameExec, hideActionLog, cribbageConfig.cpuDifficulty, cribbageConfig.pointLimit]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <CribbageSkeleton />;

--- a/frontend/src/pages/CribbagePage.tsx
+++ b/frontend/src/pages/CribbagePage.tsx
@@ -25,6 +25,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useCribbageGame } from '../hooks/useCribbageGame';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
@@ -191,6 +192,10 @@ function CribbagePageContent() {
       pointLimit: cribbageConfig.pointLimit,
     });
   }, [gameExec, hideActionLog, cribbageConfig.cpuDifficulty, cribbageConfig.pointLimit]);
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <CribbageSkeleton />;
 

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -173,8 +173,6 @@ function DaifugoPageContent() {
     void exec('reset', [], configInput);
   }, [exec, configInput, hideActionLog]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <DaifugoSkeleton />;

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -32,6 +32,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useDaifugoGame } from '../hooks/useDaifugoGame';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -171,6 +172,10 @@ function DaifugoPageContent() {
     hideActionLog();
     void exec('reset', [], configInput);
   }, [exec, configInput, hideActionLog]);
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <DaifugoSkeleton />;
 

--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -221,8 +221,6 @@ function DoubtPageContent() {
     void exec('reset', undefined, undefined, undefined, doubtConfig);
   }, [exec, hideActionLog, doubtConfig]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <DoubtSkeleton />;

--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -35,6 +35,7 @@ import {
 } from '../hooks/useDoubtGame';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess, focusRingAccent } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
@@ -219,6 +220,10 @@ function DoubtPageContent() {
     hideActionLog();
     void exec('reset', undefined, undefined, undefined, doubtConfig);
   }, [exec, hideActionLog, doubtConfig]);
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <DoubtSkeleton />;
 

--- a/frontend/src/pages/DurakPage.tsx
+++ b/frontend/src/pages/DurakPage.tsx
@@ -160,8 +160,6 @@ function DurakPageContent() {
     void gameExec('reset', undefined, undefined, durakConfig);
   }, [gameExec, hideActionLog, durakConfig]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <DurakSkeleton />;

--- a/frontend/src/pages/DurakPage.tsx
+++ b/frontend/src/pages/DurakPage.tsx
@@ -24,6 +24,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { CPU_DIFFICULTY_OPTIONS, useDurakGame } from '../hooks/useDurakGame';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnOutline, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
@@ -38,8 +39,7 @@ const PHASE_ATTACK = 0;
 const PHASE_DEFEND = 1;
 const PHASE_BOUT_END = 2;
 
-/** Fallback theme for durak (matching/pass category). */
-const theme = gameTheme.durak ?? { bg: 'bg-game-bg-green', footer: 'bg-game-bg-green-dark border-white/20' };
+const theme = gameTheme.durak;
 
 /** Durak tutorial step definitions. */
 const DURAK_TUTORIAL_STEPS: TutorialStep[] = [
@@ -159,6 +159,10 @@ function DurakPageContent() {
     hideActionLog();
     void gameExec('reset', undefined, undefined, durakConfig);
   }, [gameExec, hideActionLog, durakConfig]);
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <DurakSkeleton />;
 

--- a/frontend/src/pages/EgyptianRatscrewPage.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.tsx
@@ -74,7 +74,6 @@ function EgyptianRatscrewPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('egyptianratscrew');
   const { state, loading, error, exec: execApi, retry } = useGameApi(egyptianRatscrewApi.exec);
-  // Issue #1609: warn before tab close / reload while a round is in progress.
   useGameRoundGuard(!!state && !state.gameEndFlag);
   const { cardWidth } = useCardDimensions();
   const {

--- a/frontend/src/pages/EgyptianRatscrewPage.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.tsx
@@ -23,6 +23,8 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { gameTheme } from '../styles/gameTheme';
 import type { EgyptianRatscrewResponse } from '../types/card';
 import { EgyptianRatscrewEventKind, EgyptianRatscrewPendingKind, EgyptianRatscrewPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
@@ -72,6 +74,8 @@ function EgyptianRatscrewPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('egyptianratscrew');
   const { state, loading, error, exec: execApi, retry } = useGameApi(egyptianRatscrewApi.exec);
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+  useGameRoundGuard(!!state && !state.gameEndFlag);
   const { cardWidth } = useCardDimensions();
   const {
     hint: frontendHint,
@@ -128,7 +132,9 @@ function EgyptianRatscrewPageContent() {
 
   if (!state || state.players.length < 2) {
     return (
-      <div className="flex-1 flex flex-col min-h-0 bg-game-bg-green items-center justify-center text-ds-text-muted">
+      <div
+        className={`flex-1 flex flex-col min-h-0 ${gameTheme.egyptianratscrew.bg} items-center justify-center text-ds-text-muted`}
+      >
         Loading…
       </div>
     );
@@ -149,7 +155,7 @@ function EgyptianRatscrewPageContent() {
   const lastEvent = state.lastEventKind;
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-game-bg-green" aria-busy={loading}>
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.egyptianratscrew.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.egyptianratscrew')} />
       <PhaseIndicator phaseName={phaseName} isHumanTurn={!isGameEnd && state.isHumanTurn}>
         <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
@@ -275,7 +281,7 @@ function EgyptianRatscrewPageContent() {
             ]}
           />
 
-          <GameFooter className="bg-game-bg-green-dark border-white/20 px-4 py-2.5">
+          <GameFooter className={`${gameTheme.egyptianratscrew.footer} px-4 py-2.5`}>
             <div className="flex gap-2 justify-center">
               <button
                 type="button"

--- a/frontend/src/pages/EuchrePage.tsx
+++ b/frontend/src/pages/EuchrePage.tsx
@@ -26,6 +26,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useEuchreGame } from '../hooks/useEuchreGame';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
@@ -193,6 +194,10 @@ function EuchrePageContent() {
       pointLimit: euchreConfig.pointLimit,
     });
   }, [apiExec, hideActionLog, euchreConfig.cpuDifficulty, euchreConfig.pointLimit]);
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <EuchreSkeleton />;
 

--- a/frontend/src/pages/EuchrePage.tsx
+++ b/frontend/src/pages/EuchrePage.tsx
@@ -195,8 +195,6 @@ function EuchrePageContent() {
     });
   }, [apiExec, hideActionLog, euchreConfig.cpuDifficulty, euchreConfig.pointLimit]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <EuchreSkeleton />;

--- a/frontend/src/pages/FiftyOnePage.tsx
+++ b/frontend/src/pages/FiftyOnePage.tsx
@@ -24,6 +24,8 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { gameTheme } from '../styles/gameTheme';
 import type { FiftyOneResponse } from '../types/card';
 import { FiftyOnePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
@@ -80,6 +82,8 @@ function FiftyOnePageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('fiftyone');
   const { state, loading, error, exec: execApi, retry } = useGameApi(fiftyoneApi.exec);
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+  useGameRoundGuard(!!state && !state.gameEndFlag);
   const { cardWidth } = useCardDimensions();
   const [cpuDifficulty, setCpuDifficulty] = useState(1);
   const [selectedHandIdx, setSelectedHandIdx] = useState<number | null>(null);
@@ -165,7 +169,7 @@ function FiftyOnePageContent() {
   const canExchange = isHumanTurn && selectedHandIdx !== null && selectedTableIdx !== null;
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-game-bg-green" aria-busy={loading}>
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.fiftyone.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.fiftyone')} />
       <PhaseIndicator phaseName={phaseName} isHumanTurn={isHumanTurn}>
         <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
@@ -286,7 +290,7 @@ function FiftyOnePageContent() {
             ]}
           />
 
-          <GameFooter className="bg-game-bg-green-dark border-white/20 px-4 py-2.5">
+          <GameFooter className={`${gameTheme.fiftyone.footer} px-4 py-2.5`}>
             <div className="flex gap-2 justify-center flex-wrap" data-tutorial="fo-action-buttons">
               <button
                 type="button"

--- a/frontend/src/pages/FiftyOnePage.tsx
+++ b/frontend/src/pages/FiftyOnePage.tsx
@@ -82,7 +82,6 @@ function FiftyOnePageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('fiftyone');
   const { state, loading, error, exec: execApi, retry } = useGameApi(fiftyoneApi.exec);
-  // Issue #1609: warn before tab close / reload while a round is in progress.
   useGameRoundGuard(!!state && !state.gameEndFlag);
   const { cardWidth } = useCardDimensions();
   const [cpuDifficulty, setCpuDifficulty] = useState(1);

--- a/frontend/src/pages/FortyThievesPage.tsx
+++ b/frontend/src/pages/FortyThievesPage.tsx
@@ -29,6 +29,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useFortyThievesGame } from '../hooks/useFortyThievesGame';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -180,6 +181,10 @@ function FortyThievesPageContent() {
     bindings: actionBindings,
     enabled: !!isPlayingForKbd && !loading,
   });
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <FortyThievesSkeleton />;
 

--- a/frontend/src/pages/FortyThievesPage.tsx
+++ b/frontend/src/pages/FortyThievesPage.tsx
@@ -29,7 +29,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useFortyThievesGame } from '../hooks/useFortyThievesGame';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -184,7 +184,7 @@ function FortyThievesPageContent() {
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <FortyThievesSkeleton />;
 

--- a/frontend/src/pages/FortyThievesPage.tsx
+++ b/frontend/src/pages/FortyThievesPage.tsx
@@ -182,8 +182,6 @@ function FortyThievesPageContent() {
     enabled: !!isPlayingForKbd && !loading,
   });
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <FortyThievesSkeleton />;

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -28,7 +28,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useFreeCellGame } from '../hooks/useFreeCellGame';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -165,7 +165,7 @@ function FreeCellPageContent() {
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <FreeCellSkeleton />;
 

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -28,6 +28,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useFreeCellGame } from '../hooks/useFreeCellGame';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -161,6 +162,10 @@ function FreeCellPageContent() {
     bindings: actionBindings,
     enabled: !!isPlayingForKbd && !loading,
   });
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <FreeCellSkeleton />;
 

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -163,8 +163,6 @@ function FreeCellPageContent() {
     enabled: !!isPlayingForKbd && !loading,
   });
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <FreeCellSkeleton />;

--- a/frontend/src/pages/GinRummyPage.tsx
+++ b/frontend/src/pages/GinRummyPage.tsx
@@ -168,8 +168,6 @@ function GinRummyPageContent() {
     });
   }, [gameExec, hideActionLog, ginRummyConfig.cpuDifficulty, ginRummyConfig.pointLimit]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <GinRummySkeleton />;

--- a/frontend/src/pages/GinRummyPage.tsx
+++ b/frontend/src/pages/GinRummyPage.tsx
@@ -24,6 +24,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useGinRummyGame } from '../hooks/useGinRummyGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
@@ -166,6 +167,10 @@ function GinRummyPageContent() {
       pointLimit: ginRummyConfig.pointLimit,
     });
   }, [gameExec, hideActionLog, ginRummyConfig.cpuDifficulty, ginRummyConfig.pointLimit]);
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <GinRummySkeleton />;
 

--- a/frontend/src/pages/GoFishPage.tsx
+++ b/frontend/src/pages/GoFishPage.tsx
@@ -130,8 +130,6 @@ function GoFishPageContent() {
     void exec('reset', undefined, undefined, { cpuDifficulty: goFishConfig.cpuDifficulty });
   }, [exec, hideActionLog, goFishConfig.cpuDifficulty]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <GoFishSkeleton />;

--- a/frontend/src/pages/GoFishPage.tsx
+++ b/frontend/src/pages/GoFishPage.tsx
@@ -25,6 +25,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useGoFishGame } from '../hooks/useGoFishGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
@@ -128,6 +129,10 @@ function GoFishPageContent() {
     hideActionLog();
     void exec('reset', undefined, undefined, { cpuDifficulty: goFishConfig.cpuDifficulty });
   }, [exec, hideActionLog, goFishConfig.cpuDifficulty]);
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <GoFishSkeleton />;
 

--- a/frontend/src/pages/GolfPage.tsx
+++ b/frontend/src/pages/GolfPage.tsx
@@ -25,6 +25,7 @@ import { useCardDimensions, useWindowWidth } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useGolfGame } from '../hooks/useGolfGame';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -137,6 +138,10 @@ function GolfPageContent() {
     hideActionLog();
     handleReset();
   }, [handleReset, hideActionLog]);
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <GolfSkeleton />;
 

--- a/frontend/src/pages/GolfPage.tsx
+++ b/frontend/src/pages/GolfPage.tsx
@@ -25,7 +25,7 @@ import { useCardDimensions, useWindowWidth } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useGolfGame } from '../hooks/useGolfGame';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -141,7 +141,7 @@ function GolfPageContent() {
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <GolfSkeleton />;
 

--- a/frontend/src/pages/GolfPage.tsx
+++ b/frontend/src/pages/GolfPage.tsx
@@ -139,8 +139,6 @@ function GolfPageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <GolfSkeleton />;

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -209,8 +209,6 @@ function HoldemPageContent() {
     bindings: actionBindings,
     enabled: canAct && !loading,
   });
-
-  // Issue #1609: warn before tab close / reload while a Holdem hand is active.
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <HoldemSkeleton />;

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -34,6 +34,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
@@ -208,6 +209,9 @@ function HoldemPageContent() {
     bindings: actionBindings,
     enabled: canAct && !loading,
   });
+
+  // Issue #1609: warn before tab close / reload while a Holdem hand is active.
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <HoldemSkeleton />;
 

--- a/frontend/src/pages/IndianPokerPage.tsx
+++ b/frontend/src/pages/IndianPokerPage.tsx
@@ -30,6 +30,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -175,6 +176,10 @@ function IndianPokerPageContent() {
     bindings: actionBindings,
     enabled: canAct && !loading,
   });
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <HoldemSkeleton />;
 

--- a/frontend/src/pages/IndianPokerPage.tsx
+++ b/frontend/src/pages/IndianPokerPage.tsx
@@ -177,8 +177,6 @@ function IndianPokerPageContent() {
     enabled: canAct && !loading,
   });
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <HoldemSkeleton />;

--- a/frontend/src/pages/KlondikePage.tsx
+++ b/frontend/src/pages/KlondikePage.tsx
@@ -28,6 +28,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useKlondikeGame } from '../hooks/useKlondikeGame';
 import { useKlondikeTimer } from '../hooks/useKlondikeTimer';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
@@ -198,6 +199,10 @@ function KlondikePageContent() {
     bindings: actionBindings,
     enabled: !!isPlayingForKbd && !loading,
   });
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <KlondikeSkeleton />;
 

--- a/frontend/src/pages/KlondikePage.tsx
+++ b/frontend/src/pages/KlondikePage.tsx
@@ -28,7 +28,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useKlondikeGame } from '../hooks/useKlondikeGame';
 import { useKlondikeTimer } from '../hooks/useKlondikeTimer';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
@@ -202,7 +202,7 @@ function KlondikePageContent() {
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <KlondikeSkeleton />;
 

--- a/frontend/src/pages/KlondikePage.tsx
+++ b/frontend/src/pages/KlondikePage.tsx
@@ -200,8 +200,6 @@ function KlondikePageContent() {
     enabled: !!isPlayingForKbd && !loading,
   });
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <KlondikeSkeleton />;

--- a/frontend/src/pages/LetItRidePage.tsx
+++ b/frontend/src/pages/LetItRidePage.tsx
@@ -27,7 +27,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -144,7 +144,7 @@ function LetItRidePageContent() {
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <LetItRideSkeleton />;
 

--- a/frontend/src/pages/LetItRidePage.tsx
+++ b/frontend/src/pages/LetItRidePage.tsx
@@ -27,6 +27,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -140,6 +141,10 @@ function LetItRidePageContent() {
     bindings: actionBindings,
     enabled: !!state && !loading,
   });
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <LetItRideSkeleton />;
 

--- a/frontend/src/pages/LetItRidePage.tsx
+++ b/frontend/src/pages/LetItRidePage.tsx
@@ -142,8 +142,6 @@ function LetItRidePageContent() {
     enabled: !!state && !loading,
   });
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <LetItRideSkeleton />;

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -25,6 +25,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { AUTO_NEXT_DELAY_OPTIONS, CPU_DIFFICULTY_OPTIONS, useMemoryGame } from '../hooks/useMemoryGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
@@ -138,6 +139,10 @@ function MemoryPageContent() {
     hideActionLog();
     void exec('reset', undefined, { cpuDifficulty: memoryConfig.cpuDifficulty });
   }, [exec, hideActionLog, memoryConfig.cpuDifficulty]);
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <MemorySkeleton />;
 

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -140,8 +140,6 @@ function MemoryPageContent() {
     void exec('reset', undefined, { cpuDifficulty: memoryConfig.cpuDifficulty });
   }, [exec, hideActionLog, memoryConfig.cpuDifficulty]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <MemorySkeleton />;

--- a/frontend/src/pages/NapoleonPage.tsx
+++ b/frontend/src/pages/NapoleonPage.tsx
@@ -28,6 +28,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import {
   CPU_DIFFICULTY_OPTIONS,
   MIN_BID_OPTIONS,
@@ -201,6 +202,10 @@ function NapoleonPageContent() {
       minBid: napoleonConfig.minBid,
     });
   }, [apiExec, hideActionLog, napoleonConfig.cpuDifficulty, napoleonConfig.pointLimit, napoleonConfig.minBid]);
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <NapoleonSkeleton />;
 

--- a/frontend/src/pages/NapoleonPage.tsx
+++ b/frontend/src/pages/NapoleonPage.tsx
@@ -203,8 +203,6 @@ function NapoleonPageContent() {
     });
   }, [apiExec, hideActionLog, napoleonConfig.cpuDifficulty, napoleonConfig.pointLimit, napoleonConfig.minBid]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <NapoleonSkeleton />;

--- a/frontend/src/pages/OhHellPage.tsx
+++ b/frontend/src/pages/OhHellPage.tsx
@@ -189,8 +189,6 @@ function OhHellPageContent() {
     ohHellConfig.roundDirection,
   ]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <OhHellSkeleton />;

--- a/frontend/src/pages/OhHellPage.tsx
+++ b/frontend/src/pages/OhHellPage.tsx
@@ -28,6 +28,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import {
   CPU_DIFFICULTY_OPTIONS,
   MAX_HAND_SIZE_OPTIONS,
@@ -187,6 +188,10 @@ function OhHellPageContent() {
     ohHellConfig.scoringVariant,
     ohHellConfig.roundDirection,
   ]);
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <OhHellSkeleton />;
 

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -110,7 +110,6 @@ function OldMaidPageContent() {
     setSetupHesitation,
     setSetupMetaAI,
   } = useOldMaidGame();
-  // Issue #1609: warn before tab close / reload while a round is in progress.
   useGameRoundGuard(!!displayState && !displayState.gameEndFlag);
   const {
     hint: frontendHint,

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -29,6 +29,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { OldMaidMode, useOldMaidGame } from '../hooks/useOldMaidGame';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
@@ -109,6 +110,8 @@ function OldMaidPageContent() {
     setSetupHesitation,
     setSetupMetaAI,
   } = useOldMaidGame();
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+  useGameRoundGuard(!!displayState && !displayState.gameEndFlag);
   const {
     hint: frontendHint,
     hintEnabled: frontendHintEnabled,

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -34,6 +34,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
@@ -207,6 +208,10 @@ function OmahaPageContent() {
     bindings: actionBindings,
     enabled: canAct && !loading,
   });
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <OmahaSkeleton />;
 

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -209,8 +209,6 @@ function OmahaPageContent() {
     enabled: canAct && !loading,
   });
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <OmahaSkeleton />;

--- a/frontend/src/pages/PageOnePage.tsx
+++ b/frontend/src/pages/PageOnePage.tsx
@@ -24,6 +24,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, usePageOneGame } from '../hooks/usePageOneGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
@@ -145,6 +146,10 @@ function PageOnePageContent() {
       pointLimit: pageOneConfig.pointLimit,
     });
   }, [gameCall, hideActionLog, pageOneConfig.cpuDifficulty, pageOneConfig.pointLimit]);
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <PageOneSkeleton />;
 

--- a/frontend/src/pages/PageOnePage.tsx
+++ b/frontend/src/pages/PageOnePage.tsx
@@ -147,8 +147,6 @@ function PageOnePageContent() {
     });
   }, [gameCall, hideActionLog, pageOneConfig.cpuDifficulty, pageOneConfig.pointLimit]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <PageOneSkeleton />;

--- a/frontend/src/pages/PaiGowPage.tsx
+++ b/frontend/src/pages/PaiGowPage.tsx
@@ -25,7 +25,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -166,7 +166,7 @@ function PaiGowPageContent() {
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <PaiGowSkeleton />;
 

--- a/frontend/src/pages/PaiGowPage.tsx
+++ b/frontend/src/pages/PaiGowPage.tsx
@@ -164,8 +164,6 @@ function PaiGowPageContent() {
     enabled: !!state && !loading,
   });
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <PaiGowSkeleton />;

--- a/frontend/src/pages/PaiGowPage.tsx
+++ b/frontend/src/pages/PaiGowPage.tsx
@@ -25,6 +25,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -162,6 +163,10 @@ function PaiGowPageContent() {
     bindings: actionBindings,
     enabled: !!state && !loading,
   });
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <PaiGowSkeleton />;
 

--- a/frontend/src/pages/PigsTailPage.tsx
+++ b/frontend/src/pages/PigsTailPage.tsx
@@ -83,7 +83,6 @@ function PigsTailPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('pigtail');
   const { state, loading, exec: execApi } = useGameApi(pigtailApi.exec);
-  // Issue #1609: warn before tab close / reload while a round is in progress.
   useGameRoundGuard(!!state && !state.gameEndFlag);
   const handleDraw = useCallback(() => execApi('draw'), [execApi]);
   const handleReset = useCallback(() => execApi('reset'), [execApi]);

--- a/frontend/src/pages/PigsTailPage.tsx
+++ b/frontend/src/pages/PigsTailPage.tsx
@@ -20,7 +20,9 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { gameTheme } from '../styles/gameTheme';
 import type { PigsTailResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
@@ -81,6 +83,8 @@ function PigsTailPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('pigtail');
   const { state, loading, exec: execApi } = useGameApi(pigtailApi.exec);
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+  useGameRoundGuard(!!state && !state.gameEndFlag);
   const handleDraw = useCallback(() => execApi('draw'), [execApi]);
   const handleReset = useCallback(() => execApi('reset'), [execApi]);
   const { hint, hintEnabled, setHintEnabled } = useGameHint('pigtail', state);
@@ -132,7 +136,7 @@ function PigsTailPageContent() {
   const loserIsHuman = isGameEnd && state.loserIdx >= 0 && state.players[state.loserIdx]?.isHuman === true;
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-game-bg-green" aria-busy={loading}>
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.pigtail.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.pigtail')} />
       <PhaseIndicator phaseName={currentPhaseName ?? ''}>
         <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
@@ -223,7 +227,7 @@ function PigsTailPageContent() {
 
           {hintEnabled && hint && <HintTooltip reason={t(hint.reason)} confidence={hint.confidence} />}
 
-          <GameFooter className="bg-game-bg-green-dark border-white/20 px-4 py-2.5">
+          <GameFooter className={`${gameTheme.pigtail.footer} px-4 py-2.5`}>
             <div className="flex gap-2 justify-center items-center flex-wrap">
               <label className="flex items-center gap-1 text-ds-text-primary text-xs">
                 <input

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -231,8 +231,6 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
     enabled: canAct && !loading,
   });
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <HoldemSkeleton />;

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -34,6 +34,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
@@ -230,10 +231,14 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
     enabled: canAct && !loading,
   });
 
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
+
   if (!state) return <HoldemSkeleton />;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.holdem.bg}`} aria-busy={loading}>
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme[variant].bg}`} aria-busy={loading}>
       <GamePageHeading title={tc(`nav.${variant}`)} />
       {/* Phase indicator + info bar */}
       <PhaseIndicator phaseName={phaseNames[phase] ?? t('phase.init')} isHumanTurn={canAct || canDiscard}>
@@ -342,7 +347,7 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
           </div>
 
           {/* Sticky footer: player hand + buttons */}
-          <GameFooter className={`${gameTheme.holdem.footer} px-5 py-3`}>
+          <GameFooter className={`${gameTheme[variant].footer} px-5 py-3`}>
             {/* Human player */}
             {humanPlayer && (
               <div className="mb-2" data-tutorial="pn-player-hand">

--- a/frontend/src/pages/PinochlePage.tsx
+++ b/frontend/src/pages/PinochlePage.tsx
@@ -167,8 +167,6 @@ function PinochlePageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) {

--- a/frontend/src/pages/PinochlePage.tsx
+++ b/frontend/src/pages/PinochlePage.tsx
@@ -22,6 +22,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, usePinochleGame } from '../hooks/usePinochleGame';
 import { useSound } from '../providers/SoundProvider';
@@ -165,6 +166,10 @@ function PinochlePageContent() {
     hideActionLog();
     handleReset();
   }, [handleReset, hideActionLog]);
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) {
     return (

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -30,6 +30,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { usePokerGame } from '../hooks/usePokerGame';
 import { useSound } from '../providers/SoundProvider';
@@ -185,6 +186,10 @@ function PokerPageContent() {
     onClear: clearSelection,
     enabled: canExchange,
   });
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <PokerSkeleton />;
 

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -187,8 +187,6 @@ function PokerPageContent() {
     enabled: canExchange,
   });
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <PokerSkeleton />;

--- a/frontend/src/pages/PokerSquaresPage.tsx
+++ b/frontend/src/pages/PokerSquaresPage.tsx
@@ -23,7 +23,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, focusRingWhite } from '../styles/buttonStyles';
@@ -71,7 +71,7 @@ function PokerSquaresPageContent() {
   const { playSound } = useSound();
   const { state, loading, error, exec: execApi, retry } = useGameApi(pokersquaresApi.exec);
   // Issue #1609: warn before tab close / reload while a round is in progress.
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
   const {
     hint: frontendHint,
     hintEnabled: frontendHintEnabled,

--- a/frontend/src/pages/PokerSquaresPage.tsx
+++ b/frontend/src/pages/PokerSquaresPage.tsx
@@ -23,6 +23,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, focusRingWhite } from '../styles/buttonStyles';
@@ -69,6 +70,8 @@ function PokerSquaresPageContent() {
   const { cardWidth } = useCardDimensions();
   const { playSound } = useSound();
   const { state, loading, error, exec: execApi, retry } = useGameApi(pokersquaresApi.exec);
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+  useGameRoundGuard(!!state && !state.gameEndFlag);
   const {
     hint: frontendHint,
     hintEnabled: frontendHintEnabled,

--- a/frontend/src/pages/PokerSquaresPage.tsx
+++ b/frontend/src/pages/PokerSquaresPage.tsx
@@ -70,7 +70,6 @@ function PokerSquaresPageContent() {
   const { cardWidth } = useCardDimensions();
   const { playSound } = useSound();
   const { state, loading, error, exec: execApi, retry } = useGameApi(pokersquaresApi.exec);
-  // Issue #1609: warn before tab close / reload while a round is in progress.
   useGameRoundGuard(isGameRoundActive(state));
   const {
     hint: frontendHint,

--- a/frontend/src/pages/PresidentPage.tsx
+++ b/frontend/src/pages/PresidentPage.tsx
@@ -124,8 +124,6 @@ function PresidentPageContent() {
 
   const onReset = useCallback(() => handleResetWithConfig(), [handleResetWithConfig]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state || state.players.length < 4) {

--- a/frontend/src/pages/PresidentPage.tsx
+++ b/frontend/src/pages/PresidentPage.tsx
@@ -21,7 +21,9 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePresidentGame } from '../hooks/usePresidentGame';
+import { gameTheme } from '../styles/gameTheme';
 import type { PresidentResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import {
@@ -122,9 +124,13 @@ function PresidentPageContent() {
 
   const onReset = useCallback(() => handleResetWithConfig(), [handleResetWithConfig]);
 
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
+
   if (!state || state.players.length < 4) {
     return (
-      <div className="flex-1 flex items-center justify-center bg-game-bg-green text-ds-text-muted" aria-busy>
+      <div className={`flex-1 flex items-center justify-center ${gameTheme.president.bg} text-ds-text-muted`} aria-busy>
         {tc('common.loading')}
       </div>
     );
@@ -138,7 +144,7 @@ function PresidentPageContent() {
   const phaseName = isGameEnd ? t('phase.end') : t('phase.play');
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-game-bg-green" aria-busy={loading}>
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.president.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.president')} />
       <PhaseIndicator phaseName={phaseName} isHumanTurn={isHumanTurn}>
         <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
@@ -276,7 +282,7 @@ function PresidentPageContent() {
             ]}
           />
 
-          <GameFooter className="bg-game-bg-green-dark border-white/20 px-4 py-2.5">
+          <GameFooter className={`${gameTheme.president.footer} px-4 py-2.5`}>
             <div className="flex gap-2 justify-center flex-wrap" data-tutorial="pr-play-pass">
               <button
                 type="button"

--- a/frontend/src/pages/PyramidPage.tsx
+++ b/frontend/src/pages/PyramidPage.tsx
@@ -27,6 +27,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePyramidGame } from '../hooks/usePyramidGame';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -145,6 +146,10 @@ function PyramidPageContent() {
     hideActionLog();
     handleReset();
   }, [handleReset, hideActionLog]);
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <PyramidSkeleton />;
 

--- a/frontend/src/pages/PyramidPage.tsx
+++ b/frontend/src/pages/PyramidPage.tsx
@@ -147,8 +147,6 @@ function PyramidPageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <PyramidSkeleton />;

--- a/frontend/src/pages/PyramidPage.tsx
+++ b/frontend/src/pages/PyramidPage.tsx
@@ -27,7 +27,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePyramidGame } from '../hooks/usePyramidGame';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -149,7 +149,7 @@ function PyramidPageContent() {
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <PyramidSkeleton />;
 

--- a/frontend/src/pages/RazzPage.tsx
+++ b/frontend/src/pages/RazzPage.tsx
@@ -30,6 +30,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
@@ -244,6 +245,10 @@ function RazzPageContent() {
     bindings: actionBindings,
     enabled: canAct && !loading,
   });
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <HoldemSkeleton />;
 

--- a/frontend/src/pages/RazzPage.tsx
+++ b/frontend/src/pages/RazzPage.tsx
@@ -246,8 +246,6 @@ function RazzPageContent() {
     enabled: canAct && !loading,
   });
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <HoldemSkeleton />;

--- a/frontend/src/pages/RedDogPage.tsx
+++ b/frontend/src/pages/RedDogPage.tsx
@@ -25,7 +25,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -109,7 +109,7 @@ function RedDogPageContent() {
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) {
     return (

--- a/frontend/src/pages/RedDogPage.tsx
+++ b/frontend/src/pages/RedDogPage.tsx
@@ -107,8 +107,6 @@ function RedDogPageContent() {
 
   useActionKeyboardNav({ bindings: actionBindings, enabled: !!state && !loading });
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) {

--- a/frontend/src/pages/RedDogPage.tsx
+++ b/frontend/src/pages/RedDogPage.tsx
@@ -25,6 +25,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -105,6 +106,10 @@ function RedDogPageContent() {
   );
 
   useActionKeyboardNav({ bindings: actionBindings, enabled: !!state && !loading });
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) {
     return (

--- a/frontend/src/pages/ScorpionPage.tsx
+++ b/frontend/src/pages/ScorpionPage.tsx
@@ -298,8 +298,6 @@ function ScorpionPageContent() {
     bindings: actionBindings,
     enabled: !!isPlayingForKbd && !loading,
   });
-
-  // Issue #1609: warn before tab close / reload while a round is in progress.
   useGameRoundGuard(isGameRoundActive(state));
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;

--- a/frontend/src/pages/ScorpionPage.tsx
+++ b/frontend/src/pages/ScorpionPage.tsx
@@ -29,7 +29,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnOutline, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -300,7 +300,7 @@ function ScorpionPageContent() {
   });
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
 

--- a/frontend/src/pages/ScorpionPage.tsx
+++ b/frontend/src/pages/ScorpionPage.tsx
@@ -29,6 +29,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnOutline, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -298,7 +299,11 @@ function ScorpionPageContent() {
     enabled: !!isPlayingForKbd && !loading,
   });
 
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+  useGameRoundGuard(!!state && !state.gameEndFlag);
+
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
+
   if (!state) return <KlondikeSkeleton />;
 
   const isPlaying = state.phase === ScorpionPhase.PLAYING;
@@ -313,7 +318,7 @@ function ScorpionPageContent() {
     selectedSource.cardIndex === cardIndex;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.klondike.bg}`} aria-busy={loading}>
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.scorpion.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.scorpion')} />
       <PhaseIndicator
         phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}

--- a/frontend/src/pages/SevenBridgePage.tsx
+++ b/frontend/src/pages/SevenBridgePage.tsx
@@ -97,7 +97,6 @@ function SevenBridgePageContent() {
     retry,
     callApi,
   } = useSevenBridgeGame();
-  // Issue #1609: warn before tab close / reload while a round is in progress.
   useGameRoundGuard(!!state && !state.gameEndFlag);
   const {
     hint: frontendHint,

--- a/frontend/src/pages/SevenBridgePage.tsx
+++ b/frontend/src/pages/SevenBridgePage.tsx
@@ -20,6 +20,7 @@ import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useSevenBridgeGame } from '../hooks/useSevenBridgeGame';
 import { useSound } from '../providers/SoundProvider';
@@ -96,6 +97,8 @@ function SevenBridgePageContent() {
     retry,
     callApi,
   } = useSevenBridgeGame();
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+  useGameRoundGuard(!!state && !state.gameEndFlag);
   const {
     hint: frontendHint,
     hintEnabled: frontendHintEnabled,

--- a/frontend/src/pages/SevenCardStudPage.tsx
+++ b/frontend/src/pages/SevenCardStudPage.tsx
@@ -246,8 +246,6 @@ function SevenCardStudPageContent() {
     enabled: canAct && !loading,
   });
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <HoldemSkeleton />;

--- a/frontend/src/pages/SevenCardStudPage.tsx
+++ b/frontend/src/pages/SevenCardStudPage.tsx
@@ -30,6 +30,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
@@ -244,6 +245,10 @@ function SevenCardStudPageContent() {
     bindings: actionBindings,
     enabled: canAct && !loading,
   });
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <HoldemSkeleton />;
 

--- a/frontend/src/pages/SevensPage.tsx
+++ b/frontend/src/pages/SevensPage.tsx
@@ -26,6 +26,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSevensGame } from '../hooks/useSevensGame';
 import { useSound } from '../providers/SoundProvider';
 import { btnSecondary } from '../styles/buttonStyles';
@@ -165,6 +166,10 @@ function SevensPageContent() {
     cfgEndStop,
     cfgJokerConsBan,
   ]);
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <SevensSkeleton />;
 

--- a/frontend/src/pages/SevensPage.tsx
+++ b/frontend/src/pages/SevensPage.tsx
@@ -167,8 +167,6 @@ function SevensPageContent() {
     cfgJokerConsBan,
   ]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <SevensSkeleton />;

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -34,6 +34,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
@@ -206,6 +207,10 @@ function ShortDeckPageContent() {
     bindings: actionBindings,
     enabled: canAct && !loading,
   });
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <ShortDeckSkeleton />;
 

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -208,8 +208,6 @@ function ShortDeckPageContent() {
     enabled: canAct && !loading,
   });
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <ShortDeckSkeleton />;

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -23,6 +23,8 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { gameTheme } from '../styles/gameTheme';
 import type { SlapjackResponse } from '../types/card';
 import { SlapjackEventKind, SlapjackPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
@@ -71,6 +73,8 @@ function SlapjackPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('slapjack');
   const { state, loading, error, exec: execApi, retry } = useGameApi(slapjackApi.exec);
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+  useGameRoundGuard(!!state && !state.gameEndFlag);
   const { cardWidth } = useCardDimensions();
   const {
     hint: frontendHint,
@@ -136,7 +140,9 @@ function SlapjackPageContent() {
 
   if (!state || state.players.length < 2) {
     return (
-      <div className="flex-1 flex flex-col min-h-0 bg-game-bg-green items-center justify-center text-ds-text-muted">
+      <div
+        className={`flex-1 flex flex-col min-h-0 ${gameTheme.slapjack.bg} items-center justify-center text-ds-text-muted`}
+      >
         Loading…
       </div>
     );
@@ -151,7 +157,7 @@ function SlapjackPageContent() {
   const lastEvent = state.lastEventKind;
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-game-bg-green" aria-busy={loading}>
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.slapjack.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.slapjack')} />
       <PhaseIndicator phaseName={phaseName} isHumanTurn={!isGameEnd && state.isHumanTurn}>
         <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
@@ -272,7 +278,7 @@ function SlapjackPageContent() {
             ]}
           />
 
-          <GameFooter className="bg-game-bg-green-dark border-white/20 px-4 py-2.5">
+          <GameFooter className={`${gameTheme.slapjack.footer} px-4 py-2.5`}>
             <div className="flex gap-2 justify-center">
               <button
                 type="button"

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -73,7 +73,6 @@ function SlapjackPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('slapjack');
   const { state, loading, error, exec: execApi, retry } = useGameApi(slapjackApi.exec);
-  // Issue #1609: warn before tab close / reload while a round is in progress.
   useGameRoundGuard(!!state && !state.gameEndFlag);
   const { cardWidth } = useCardDimensions();
   const {

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -24,6 +24,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { CPU_DIFFICULTY_OPTIONS, useSpeedGame } from '../hooks/useSpeedGame';
 import { useSound } from '../providers/SoundProvider';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
@@ -77,6 +78,8 @@ function SpeedPageContent() {
     handleConfigChange,
     handleToggle,
   } = useSpeedGame();
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+  useGameRoundGuard(!!state && !state.gameEndFlag);
   const {
     hint: frontendHint,
     hintEnabled: frontendHintEnabled,

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -78,7 +78,6 @@ function SpeedPageContent() {
     handleConfigChange,
     handleToggle,
   } = useSpeedGame();
-  // Issue #1609: warn before tab close / reload while a round is in progress.
   useGameRoundGuard(!!state && !state.gameEndFlag);
   const {
     hint: frontendHint,

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -28,6 +28,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSpiderGame } from '../hooks/useSpiderGame';
 import { useSound } from '../providers/SoundProvider';
@@ -172,6 +173,10 @@ function SpiderPageContent() {
     bindings: actionBindings,
     enabled: !!isPlayingForKbd && !loading,
   });
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <SpiderSkeleton />;
 

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -28,7 +28,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSpiderGame } from '../hooks/useSpiderGame';
 import { useSound } from '../providers/SoundProvider';
@@ -176,7 +176,7 @@ function SpiderPageContent() {
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <SpiderSkeleton />;
 

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -174,8 +174,6 @@ function SpiderPageContent() {
     enabled: !!isPlayingForKbd && !loading,
   });
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <SpiderSkeleton />;

--- a/frontend/src/pages/SpiteAndMalicePage.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.tsx
@@ -24,7 +24,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnOutline, btnPrimary, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -233,7 +233,7 @@ function SpiteAndMalicePageContent() {
   );
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
 

--- a/frontend/src/pages/SpiteAndMalicePage.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.tsx
@@ -231,8 +231,6 @@ function SpiteAndMalicePageContent() {
     },
     [apiCall, selection, isHumanTurn, isGameOver, playSound],
   );
-
-  // Issue #1609: warn before tab close / reload while a round is in progress.
   useGameRoundGuard(isGameRoundActive(state));
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;

--- a/frontend/src/pages/SpiteAndMalicePage.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.tsx
@@ -24,6 +24,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnOutline, btnPrimary, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -231,7 +232,11 @@ function SpiteAndMalicePageContent() {
     [apiCall, selection, isHumanTurn, isGameOver, playSound],
   );
 
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+  useGameRoundGuard(!!state && !state.gameEndFlag);
+
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
+
   if (!state) return <KlondikeSkeleton />;
 
   const phaseName = isGameOver ? t('phase.gameOver') : state.current === 1 ? t('phase.cpuTurn') : t('phase.playerTurn');
@@ -243,7 +248,7 @@ function SpiteAndMalicePageContent() {
   const selectionIsHand = selection?.kind === 'hand';
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.klondike.bg}`} aria-busy={loading}>
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.spiteandmalice.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.spiteandmalice')} />
       <PhaseIndicator phaseName={phaseName}>
         <span>

--- a/frontend/src/pages/TexasHoldemBonusPage.tsx
+++ b/frontend/src/pages/TexasHoldemBonusPage.tsx
@@ -150,8 +150,6 @@ function TexasHoldemBonusPageContent() {
     enabled: !!state && !loading,
   });
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <TexasHoldemBonusSkeleton />;

--- a/frontend/src/pages/TexasHoldemBonusPage.tsx
+++ b/frontend/src/pages/TexasHoldemBonusPage.tsx
@@ -26,7 +26,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -152,7 +152,7 @@ function TexasHoldemBonusPageContent() {
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <TexasHoldemBonusSkeleton />;
 

--- a/frontend/src/pages/TexasHoldemBonusPage.tsx
+++ b/frontend/src/pages/TexasHoldemBonusPage.tsx
@@ -26,6 +26,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -148,6 +149,10 @@ function TexasHoldemBonusPageContent() {
     bindings: actionBindings,
     enabled: !!state && !loading,
   });
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <TexasHoldemBonusSkeleton />;
 

--- a/frontend/src/pages/ThreeCardPage.tsx
+++ b/frontend/src/pages/ThreeCardPage.tsx
@@ -25,6 +25,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -128,6 +129,10 @@ function ThreeCardPageContent() {
     bindings: actionBindings,
     enabled: !!state && !loading,
   });
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <ThreeCardSkeleton />;
 

--- a/frontend/src/pages/ThreeCardPage.tsx
+++ b/frontend/src/pages/ThreeCardPage.tsx
@@ -25,7 +25,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -132,7 +132,7 @@ function ThreeCardPageContent() {
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <ThreeCardSkeleton />;
 

--- a/frontend/src/pages/ThreeCardPage.tsx
+++ b/frontend/src/pages/ThreeCardPage.tsx
@@ -130,8 +130,6 @@ function ThreeCardPageContent() {
     enabled: !!state && !loading,
   });
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <ThreeCardSkeleton />;

--- a/frontend/src/pages/TonkPage.tsx
+++ b/frontend/src/pages/TonkPage.tsx
@@ -160,8 +160,6 @@ function TonkPageContent() {
     });
   }, [gameExec, hideActionLog, tonkConfig.cpuDifficulty, tonkConfig.pointLimit]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <TonkSkeleton />;

--- a/frontend/src/pages/TonkPage.tsx
+++ b/frontend/src/pages/TonkPage.tsx
@@ -24,6 +24,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useTonkGame } from '../hooks/useTonkGame';
 import { useSound } from '../providers/SoundProvider';
@@ -158,6 +159,10 @@ function TonkPageContent() {
       pointLimit: tonkConfig.pointLimit,
     });
   }, [gameExec, hideActionLog, tonkConfig.cpuDifficulty, tonkConfig.pointLimit]);
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <TonkSkeleton />;
 

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -24,6 +24,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnOutline, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -187,7 +188,11 @@ function TrashPageContent() {
     [apiCall, state, playSound],
   );
 
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+  useGameRoundGuard(!!state && !state.gameEndFlag);
+
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
+
   if (!state) return <KlondikeSkeleton />;
 
   const isGameOver = state.phase === TrashPhase.GAME_OVER;
@@ -203,7 +208,7 @@ function TrashPageContent() {
         : t('phase.playerTurn');
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.klondike.bg}`} aria-busy={loading}>
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.trash.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.trash')} />
       <PhaseIndicator phaseName={phaseName}>
         <span>

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -24,7 +24,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnOutline, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -189,7 +189,7 @@ function TrashPageContent() {
   );
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
 

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -187,8 +187,6 @@ function TrashPageContent() {
     },
     [apiCall, state, playSound],
   );
-
-  // Issue #1609: warn before tab close / reload while a round is in progress.
   useGameRoundGuard(isGameRoundActive(state));
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;

--- a/frontend/src/pages/TriPeaksPage.tsx
+++ b/frontend/src/pages/TriPeaksPage.tsx
@@ -27,7 +27,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useTriPeaksGame } from '../hooks/useTriPeaksGame';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -156,7 +156,7 @@ function TriPeaksPageContent() {
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <TriPeaksSkeleton />;
 

--- a/frontend/src/pages/TriPeaksPage.tsx
+++ b/frontend/src/pages/TriPeaksPage.tsx
@@ -154,8 +154,6 @@ function TriPeaksPageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
-  // Issue #1609: warn before tab close / reload while a round is in progress.
-
   useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return <TriPeaksSkeleton />;

--- a/frontend/src/pages/TriPeaksPage.tsx
+++ b/frontend/src/pages/TriPeaksPage.tsx
@@ -27,6 +27,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useTriPeaksGame } from '../hooks/useTriPeaksGame';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -152,6 +153,10 @@ function TriPeaksPageContent() {
     hideActionLog();
     handleReset();
   }, [handleReset, hideActionLog]);
+
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+
+  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) return <TriPeaksSkeleton />;
 

--- a/frontend/src/pages/WarPage.tsx
+++ b/frontend/src/pages/WarPage.tsx
@@ -73,7 +73,6 @@ function WarPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('war');
   const { state, loading, error, exec: execApi, retry } = useGameApi(warApi.exec);
-  // Issue #1609: warn before tab close / reload while a round is in progress.
   useGameRoundGuard(!!state && !state.gameEndFlag);
   const { cardWidth } = useCardDimensions();
   const [maxRounds, setMaxRounds] = useState(DEFAULT_MAX_ROUNDS);

--- a/frontend/src/pages/WarPage.tsx
+++ b/frontend/src/pages/WarPage.tsx
@@ -24,6 +24,8 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { gameTheme } from '../styles/gameTheme';
 import type { WarResponse } from '../types/card';
 import { WarPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
@@ -71,6 +73,8 @@ function WarPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('war');
   const { state, loading, error, exec: execApi, retry } = useGameApi(warApi.exec);
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+  useGameRoundGuard(!!state && !state.gameEndFlag);
   const { cardWidth } = useCardDimensions();
   const [maxRounds, setMaxRounds] = useState(DEFAULT_MAX_ROUNDS);
   const {
@@ -131,7 +135,7 @@ function WarPageContent() {
         : t('phase.reveal');
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-game-bg-green" aria-busy={loading}>
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.war.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.war')} />
       <PhaseIndicator phaseName={phaseName} isHumanTurn={!isGameEnd}>
         <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
@@ -264,7 +268,7 @@ function WarPageContent() {
             ]}
           />
 
-          <GameFooter className="bg-game-bg-green-dark border-white/20 px-4 py-2.5">
+          <GameFooter className={`${gameTheme.war.footer} px-4 py-2.5`}>
             <div className="flex gap-2 justify-center">
               <button
                 type="button"

--- a/frontend/src/pages/YukonPage.tsx
+++ b/frontend/src/pages/YukonPage.tsx
@@ -29,7 +29,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnOutline, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -293,7 +293,7 @@ function YukonPageContent() {
   });
 
   // Issue #1609: warn before tab close / reload while a round is in progress.
-  useGameRoundGuard(!!state && !state.gameEndFlag);
+  useGameRoundGuard(isGameRoundActive(state));
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
 

--- a/frontend/src/pages/YukonPage.tsx
+++ b/frontend/src/pages/YukonPage.tsx
@@ -29,6 +29,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnOutline, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -291,7 +292,11 @@ function YukonPageContent() {
     enabled: !!isPlayingForKbd && !loading,
   });
 
+  // Issue #1609: warn before tab close / reload while a round is in progress.
+  useGameRoundGuard(!!state && !state.gameEndFlag);
+
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
+
   if (!state) return <KlondikeSkeleton />;
 
   const isPlaying = state.phase === YukonPhase.PLAYING;
@@ -307,7 +312,7 @@ function YukonPageContent() {
     selectedSource.cardIndex === cardIndex;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.klondike.bg}`} aria-busy={loading}>
+    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.yukon.bg}`} aria-busy={loading}>
       <GamePageHeading title={tc('nav.yukon')} />
       <PhaseIndicator
         phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}

--- a/frontend/src/pages/YukonPage.tsx
+++ b/frontend/src/pages/YukonPage.tsx
@@ -291,8 +291,6 @@ function YukonPageContent() {
     bindings: actionBindings,
     enabled: !!isPlayingForKbd && !loading,
   });
-
-  // Issue #1609: warn before tab close / reload while a round is in progress.
   useGameRoundGuard(isGameRoundActive(state));
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;

--- a/frontend/src/styles/gameTheme.test.ts
+++ b/frontend/src/styles/gameTheme.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { gameRoutes } from '../constants/gameRoutes';
 import { gameTheme } from './gameTheme';
 
 describe('gameTheme', () => {
@@ -36,5 +37,16 @@ describe('gameTheme', () => {
       expect(value.bg, `${key}.bg`).toBeTruthy();
       expect(value.footer, `${key}.footer`).toBeTruthy();
     }
+  });
+
+  it('covers every game listed in gameRoutes', () => {
+    // Issue #1610: silent fallback on a missing key let new games ship without
+    // their own theme. The strict GameKey union catches this at compile time;
+    // this test guards against route additions that drift away from the union.
+    const themeKeys = new Set(Object.keys(gameTheme));
+    const missing = gameRoutes
+      .map((r) => (r.path === '/' ? 'blackjack' : r.path.replace(/^\//, '')))
+      .filter((key) => !themeKeys.has(key));
+    expect(missing).toEqual([]);
   });
 });

--- a/frontend/src/styles/gameTheme.test.ts
+++ b/frontend/src/styles/gameTheme.test.ts
@@ -40,9 +40,7 @@ describe('gameTheme', () => {
   });
 
   it('covers every game listed in gameRoutes', () => {
-    // Issue #1610: silent fallback on a missing key let new games ship without
-    // their own theme. The strict GameKey union catches this at compile time;
-    // this test guards against route additions that drift away from the union.
+    // Guards against route additions that drift away from the GameKey union.
     const themeKeys = new Set(Object.keys(gameTheme));
     const missing = gameRoutes
       .map((r) => (r.path === '/' ? 'blackjack' : r.path.replace(/^\//, '')))

--- a/frontend/src/styles/gameTheme.ts
+++ b/frontend/src/styles/gameTheme.ts
@@ -1,64 +1,189 @@
-/** Background and footer theme classes for each game, organized by category. */
-export const gameTheme: Record<string, { bg: string; footer: string }> = {
+/**
+ * Background and footer theme classes for each game, organized by category.
+ *
+ * Every game listed in `gameRoutes.ts` (and the canonical Go registry) must have
+ * an entry here. The strict `Record<GameKey, ...>` type makes a missing key a
+ * compile-time error so new games cannot ship without a theme. Variants that
+ * intentionally share a theme with another game declare that explicitly via
+ * value reuse — e.g., `pineapple`/`crazypineapple` reuse the holdem palette but
+ * keep their own keys so future divergence is a one-line change.
+ */
+export type GameKey =
   // Table games
-  blackjack: { bg: 'bg-game-bg-green-bright', footer: 'bg-game-bg-green-bright-dark border-white/20' },
-  spanish21: { bg: 'bg-game-bg-green-bright', footer: 'bg-game-bg-green-bright-dark border-white/20' },
-  baccarat: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
-  threecard: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
-  texasholdembonus: { bg: 'bg-game-bg-green-poker', footer: 'bg-game-bg-green-poker-dark border-white/20' },
-  paigow: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
-  letitride: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
-  reddog: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
+  | 'blackjack'
+  | 'spanish21'
+  | 'baccarat'
+  | 'threecard'
+  | 'caribbeanstud'
+  | 'texasholdembonus'
+  | 'paigow'
+  | 'letitride'
+  | 'reddog'
   // Poker
-  poker: { bg: 'bg-game-bg-green-poker', footer: 'bg-game-bg-green-poker-dark border-white/20' },
-  holdem: { bg: 'bg-game-bg-green-poker', footer: 'bg-game-bg-green-poker-dark border-white/20' },
-  omaha: { bg: 'bg-game-bg-green-poker', footer: 'bg-game-bg-green-poker-dark border-white/20' },
-  shortdeck: { bg: 'bg-game-bg-green-poker', footer: 'bg-game-bg-green-poker-dark border-white/20' },
-  sevencardstud: { bg: 'bg-game-bg-green-poker', footer: 'bg-game-bg-green-poker-dark border-white/20' },
-  razz: { bg: 'bg-game-bg-green-poker', footer: 'bg-game-bg-green-poker-dark border-white/20' },
-  indianpoker: { bg: 'bg-game-bg-green-poker', footer: 'bg-game-bg-green-poker-dark border-white/20' },
-  videopoker: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
-  deuceswild: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
-  jokerpoker: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
+  | 'poker'
+  | 'holdem'
+  | 'omaha'
+  | 'shortdeck'
+  | 'pineapple'
+  | 'crazypineapple'
+  | 'sevencardstud'
+  | 'razz'
+  | 'badugi'
+  | 'indianpoker'
+  | 'videopoker'
+  | 'deuceswild'
+  | 'jokerpoker'
   // Trick-taking
-  hearts: { bg: 'bg-game-bg-blue', footer: 'bg-game-bg-blue-dark border-white/20' },
-  spades: { bg: 'bg-game-bg-blue', footer: 'bg-game-bg-blue-dark border-white/20' },
-  ohhell: { bg: 'bg-game-bg-blue', footer: 'bg-game-bg-blue-dark border-white/20' },
-  euchre: { bg: 'bg-game-bg-blue', footer: 'bg-game-bg-blue-dark border-white/20' },
-  bridge: { bg: 'bg-game-bg-blue', footer: 'bg-game-bg-blue-dark border-white/20' },
-  napoleon: { bg: 'bg-game-bg-blue', footer: 'bg-game-bg-blue-dark border-white/20' },
-  pinochle: { bg: 'bg-game-bg-blue', footer: 'bg-game-bg-blue-dark border-white/20' },
-  twotenjack: { bg: 'bg-game-bg-blue', footer: 'bg-game-bg-blue-dark border-white/20' },
-  whist: { bg: 'bg-game-bg-blue', footer: 'bg-game-bg-blue-dark border-white/20' },
-  skat: { bg: 'bg-game-bg-blue', footer: 'bg-game-bg-blue-dark border-white/20' },
-  // Matching/Pass — unified to green
-  oldmaid: { bg: 'bg-game-bg-green', footer: 'bg-game-bg-green-dark border-white/20' },
-  doubt: { bg: 'bg-game-bg-green', footer: 'bg-game-bg-green-dark border-white/20' },
-  durak: { bg: 'bg-game-bg-green', footer: 'bg-game-bg-green-dark border-white/20' },
-  daifugo: { bg: 'bg-game-bg-green', footer: 'bg-game-bg-green-dark border-white/20' },
-  sevens: { bg: 'bg-game-bg-green', footer: 'bg-game-bg-green-dark border-white/20' },
-  crazyeights: { bg: 'bg-game-bg-green', footer: 'bg-game-bg-green-dark border-white/20' },
-  pageone: { bg: 'bg-game-bg-green', footer: 'bg-game-bg-green-dark border-white/20' },
-  gofish: { bg: 'bg-game-bg-green', footer: 'bg-game-bg-green-dark border-white/20' },
-  shithead: { bg: 'bg-game-bg-green', footer: 'bg-game-bg-green-dark border-white/20' },
-  nertz: { bg: 'bg-game-bg-green', footer: 'bg-game-bg-green-dark border-white/20' },
-  // Solitaire — unified to casino
-  klondike: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
-  freecell: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
-  spider: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
-  pyramid: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
-  tripeaks: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
-  golf: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
-  memory: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
-  clocksolitaire: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
-  fortythieves: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
-  bakersdozen: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
-  canfield: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
-  pokersquares: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
-  calculation: { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' },
-  // Counting/Rummy — unified to blue
-  ginrummy: { bg: 'bg-game-bg-blue', footer: 'bg-game-bg-blue-dark border-white/20' },
-  tonk: { bg: 'bg-game-bg-blue', footer: 'bg-game-bg-blue-dark border-white/20' },
-  canasta: { bg: 'bg-game-bg-blue', footer: 'bg-game-bg-blue-dark border-white/20' },
-  cribbage: { bg: 'bg-game-bg-blue', footer: 'bg-game-bg-blue-dark border-white/20' },
+  | 'hearts'
+  | 'spades'
+  | 'twotenjack'
+  | 'ohhell'
+  | 'euchre'
+  | 'bridge'
+  | 'napoleon'
+  | 'whist'
+  | 'pinochle'
+  | 'skat'
+  // Matching/Pass
+  | 'oldmaid'
+  | 'doubt'
+  | 'durak'
+  | 'daifugo'
+  | 'president'
+  | 'cassino'
+  | 'sevens'
+  | 'crazyeights'
+  | 'pageone'
+  | 'speed'
+  | 'gofish'
+  | 'pigtail'
+  | 'war'
+  | 'fiftyone'
+  | 'trash'
+  | 'spiteandmalice'
+  | 'shithead'
+  | 'nertz'
+  | 'slapjack'
+  | 'egyptianratscrew'
+  // Solitaire
+  | 'klondike'
+  | 'freecell'
+  | 'spider'
+  | 'pyramid'
+  | 'tripeaks'
+  | 'golf'
+  | 'memory'
+  | 'clocksolitaire'
+  | 'fortythieves'
+  | 'bakersdozen'
+  | 'canfield'
+  | 'yukon'
+  | 'scorpion'
+  | 'accordion'
+  | 'pokersquares'
+  | 'calculation'
+  // Counting/Rummy
+  | 'ginrummy'
+  | 'tonk'
+  | 'canasta'
+  | 'cribbage'
+  | 'sevenbridge';
+
+/** Theme classes (Tailwind) applied to the page background and footer for each game. */
+export interface GameThemeClasses {
+  /** Background class for the outer game container. */
+  bg: string;
+  /** Background + border classes for the sticky footer. */
+  footer: string;
+}
+
+const POKER = { bg: 'bg-game-bg-green-poker', footer: 'bg-game-bg-green-poker-dark border-white/20' } as const;
+const CASINO = { bg: 'bg-game-bg-casino', footer: 'bg-game-bg-casino-dark border-white/20' } as const;
+const BLUE = { bg: 'bg-game-bg-blue', footer: 'bg-game-bg-blue-dark border-white/20' } as const;
+const GREEN = { bg: 'bg-game-bg-green', footer: 'bg-game-bg-green-dark border-white/20' } as const;
+const BRIGHT_GREEN = {
+  bg: 'bg-game-bg-green-bright',
+  footer: 'bg-game-bg-green-bright-dark border-white/20',
+} as const;
+
+export const gameTheme: Record<GameKey, GameThemeClasses> = {
+  // Table games
+  blackjack: BRIGHT_GREEN,
+  spanish21: BRIGHT_GREEN,
+  baccarat: CASINO,
+  threecard: CASINO,
+  caribbeanstud: CASINO,
+  texasholdembonus: POKER,
+  paigow: CASINO,
+  letitride: CASINO,
+  reddog: CASINO,
+  // Poker
+  poker: POKER,
+  holdem: POKER,
+  omaha: POKER,
+  shortdeck: POKER,
+  pineapple: POKER,
+  crazypineapple: POKER,
+  sevencardstud: POKER,
+  razz: POKER,
+  badugi: POKER,
+  indianpoker: POKER,
+  videopoker: CASINO,
+  deuceswild: CASINO,
+  jokerpoker: CASINO,
+  // Trick-taking
+  hearts: BLUE,
+  spades: BLUE,
+  twotenjack: BLUE,
+  ohhell: BLUE,
+  euchre: BLUE,
+  bridge: BLUE,
+  napoleon: BLUE,
+  whist: BLUE,
+  pinochle: BLUE,
+  skat: BLUE,
+  // Matching/Pass
+  oldmaid: GREEN,
+  doubt: GREEN,
+  durak: GREEN,
+  daifugo: GREEN,
+  president: GREEN,
+  cassino: GREEN,
+  sevens: GREEN,
+  crazyeights: GREEN,
+  pageone: GREEN,
+  speed: GREEN,
+  gofish: GREEN,
+  pigtail: GREEN,
+  war: GREEN,
+  fiftyone: GREEN,
+  trash: GREEN,
+  spiteandmalice: GREEN,
+  shithead: GREEN,
+  nertz: GREEN,
+  slapjack: GREEN,
+  egyptianratscrew: GREEN,
+  // Solitaire
+  klondike: CASINO,
+  freecell: CASINO,
+  spider: CASINO,
+  pyramid: CASINO,
+  tripeaks: CASINO,
+  golf: CASINO,
+  memory: CASINO,
+  clocksolitaire: CASINO,
+  fortythieves: CASINO,
+  bakersdozen: CASINO,
+  canfield: CASINO,
+  yukon: CASINO,
+  scorpion: CASINO,
+  accordion: CASINO,
+  pokersquares: CASINO,
+  calculation: CASINO,
+  // Counting/Rummy
+  ginrummy: BLUE,
+  tonk: BLUE,
+  canasta: BLUE,
+  cribbage: BLUE,
+  sevenbridge: BLUE,
 };


### PR DESCRIPTION
## Summary

Bundles seven UI/UX issues into one PR (`#1609`-`#1615`):

| Issue | Change |
|-------|--------|
| #1609 | New `useGameRoundGuard` hook applied across all 73 game pages (directly, via `GamePageShell`, or via `VideoPokerGameContent`) so reload/tab-close during a round warns the user instead of being BlackJack-only. |
| #1610 | `gameTheme` filled for the 18 missing games, every consumer switched to its own key (no more cross-game `gameTheme.holdem.bg` from PineapplePage etc.), exported as strict `Record<GameKey, ...>`. The silent `?? gameTheme.blackjack` fallback in BlackJackPage is removed. |
| #1611 | `SettingsPanel` tooltips made touch-accessible: explicit `(?)` toggle button, Escape-to-close, `aria-describedby` preserved for screen readers. |
| #1612 | Tap-target violations of DESIGN.md WCAG 2.5.5 AAA (44x44) fixed on BlackJack auto-advance select, CLI input, and DesktopSidebar search + category links. |
| #1613 | Recent Games section added to `DesktopSidebar` to match mobile NavBar parity (reuses the existing `useRecentGames` hook + `nav.recentGames` i18n key). |
| #1614 | `ErrorBoundary` fallback rebuilt with reload + pre-filled GitHub issue link, collapsible error details, repeated-retry warning, and richer i18n strings. |
| #1615 | `ChipBetInput` migrated from `type=\"number\"` to `type=\"text\" inputMode=\"numeric\"` with an `onWheel`-blur guard — fixes iOS spinner / wheel-scroll / NaN-input issues across the 8 casino pages that bet via this component. |

## Test plan

- [x] `bunx biome check . && bun scripts/check-design-tokens.mjs` — clean
- [x] `bun run build` — passes (with `NODE_OPTIONS=--max-old-space-size=4096`)
- [x] Targeted Vitest suites pass for every modified file individually (DesktopSidebar, ErrorBoundary, ChipBetInput, SettingsPanel, gameTheme, useGameRoundGuard, OldMaidPage, GinRummyPage, etc.)
- [x] Full Vitest run: 408/409 test files pass, 6084 tests pass; the one OOM in the NavBar test worker is pre-existing on `develop` and unrelated to this PR (verified by reproducing on stash).
- [x] `go build ./...` — clean (no Go code changed but verified for safety).
- [x] `docs/new-game-checklist.md` updated to require `useGameRoundGuard` and a `GameKey` entry for new games.

Closes #1609
Closes #1610
Closes #1611
Closes #1612
Closes #1613
Closes #1614
Closes #1615