### PR TITLE
docs: fix game count drift (76/73 → 77) across docs and registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Go implementations of 76 trump card game algorithms (blackjack, poker, hearts, klondike, baccarat, ...). Run `go run ./cmd/trumpcards games --short` for the canonical list. Clean Architecture with CLI and Web GUI (React + Go REST API).
+Go implementations of 77 trump card game algorithms (blackjack, poker, hearts, klondike, baccarat, ...). Run `go run ./cmd/trumpcards games --short` for the canonical list. Clean Architecture with CLI and Web GUI (React + Go REST API).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ go_trumpcardsが目指す未来は、**あらゆる人がクリエイターと�
 
 ## Features
 
-Go + Clean Architecture で実装した76種類のトランプゲーム。CLI と Web GUI（React + Go REST API）の2つのインターフェースで遊べます。Web GUI は日英多言語対応。
+Go + Clean Architecture で実装した77種類のトランプゲーム。CLI と Web GUI（React + Go REST API）の2つのインターフェースで遊べます。Web GUI は日英多言語対応。
 
 | ゲーム | コマンド | マニュアル |
 |--------|----------|------------|

--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -6,7 +6,7 @@
 
 - [1. クラス図](#1-クラス図)
   - [1.1 コアドメイン (カード・プレイヤー)](#11-コアドメイン-カードプレイヤー)
-  - [1.2 ゲームドメイン (全73ゲーム)](#12-ゲームドメイン-全73ゲーム)
+  - [1.2 ゲームドメイン (全77ゲーム)](#12-ゲームドメイン-全77ゲーム)
   - [1.3 ユースケース層 (Interactor・Presenter)](#13-ユースケース層-interactorpresenter)
   - [1.4 アダプタ層 (Controller・Presenter実装)](#14-アダプタ層-controllerpresenter実装)
   - [1.5 インフラストラクチャ層](#15-インフラストラクチャ層)
@@ -149,7 +149,7 @@ classDiagram
     GamePlayer *-- ChipHolder : mixin
 ```
 
-### 1.2 ゲームドメイン (全73ゲーム)
+### 1.2 ゲームドメイン (全77ゲーム)
 
 #### ベッティング系ゲーム
 
@@ -1544,7 +1544,7 @@ classDiagram
     note for GamePresenter "各ゲームの Presenter は\nGamePresenter[G] の型エイリアス\nまたは拡張インターフェース"
 ```
 
-**Interactor パターン (全73ゲーム共通)**
+**Interactor パターン (全77ゲーム共通)**
 
 ```mermaid
 classDiagram
@@ -1616,8 +1616,8 @@ classDiagram
     GameCuiPresenter ..|> GamePresenter : implements
     GameWebPresenter ..|> GamePresenter : implements
 
-    note for GameCuiController "73ゲーム × CUI/Web = 146 Controller\nGameCuiController / GameWebController は\n各ゲーム毎に具体的な実装が存在"
-    note for GameCuiPresenter "73ゲーム × CUI/Web = 146 Presenter 実装"
+    note for GameCuiController "77ゲーム × CUI/Web = 154 Controller\nGameCuiController / GameWebController は\n各ゲーム毎に具体的な実装が存在"
+    note for GameCuiPresenter "77ゲーム × CUI/Web = 154 Presenter 実装"
 ```
 
 ### 1.5 インフラストラクチャ層
@@ -1684,8 +1684,8 @@ classDiagram
         +Exec(input string) string
     }
 
-    TrumpCardsWeb --> "*" GameWebController : holds 62 controllers
-    GameManager --> "*" CuiExecer : holds 62 games
+    TrumpCardsWeb --> "*" GameWebController : holds 77 controllers
+    GameManager --> "*" CuiExecer : holds 77 games
     GameCui ..|> CuiExecer : implements
     GameCui --> GameCuiController : delegates
 ```

--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -431,7 +431,7 @@ classDiagram
         +object messageParams
     }
 
-    note for BlackJackResponse "各ゲームが固有のResponse型を持つ\n(全73ゲーム分存在)\n共通フィールド: message, messageCode, messageParams"
+    note for BlackJackResponse "各ゲームが固有のResponse型を持つ\n(全77ゲーム分存在)\n共通フィールド: message, messageCode, messageParams"
 ```
 
 **フェーズ定数 (全ゲーム)**
@@ -851,7 +851,7 @@ classDiagram
     class actionLogApi {
         +blackjack() Promise~ActionLogResponse~
         +poker() Promise~ActionLogResponse~
-        ...全73ゲーム()
+        ...全77ゲーム()
     }
 
     BlackJackApi --> gameApi : uses postJson/gameExec
@@ -913,7 +913,7 @@ classDiagram
 
     RedDogApi --> gameApi : uses postJson/gameExec
 
-    note for BlackJackApi "全73ゲーム分のAPI Objectが存在\n(blackjack, spanish21, poker, oldmaid, daifugo,\nsevens, doubt, holdem, omaha, shortdeck,\npineapple, crazypineapple, hearts, memory, klondike, freecell,\nbaccarat, spades, twotenjack, crazyeights, ginrummy, canasta,\nspider, napoleon, indianpoker, videopoker,\ndeuceswild, jokerpoker, euchre, pyramid, tripeaks,\ncribbage, threecard, caribbeanstud, texasholdembonus, ohhell, bridge, speed,\ngofish, pinochle, golf, pigtail,\nsevencardstud, clocksolitaire, durak,\nfortythieves, paigow, war, canfield, fiftyone, yukon, scorpion, accordion, whist,\nletitride, pokersquares, pageone, reddog, razz, badugi, trash,\nsevenbridge, president, cassino, calculation, spiteandmalice,\nskat, shithead, nertz, slapjack, egyptianratscrew, bakersdozen, tonk)"
+    note for BlackJackApi "全77ゲーム分のAPI Objectが存在\n(blackjack, spanish21, poker, oldmaid, daifugo,\nsevens, doubt, holdem, omaha, shortdeck,\npineapple, crazypineapple, hearts, memory, klondike, freecell,\nbaccarat, spades, twotenjack, crazyeights, ginrummy, canasta,\nspider, napoleon, indianpoker, videopoker,\ndeuceswild, jokerpoker, euchre, pyramid, tripeaks,\ncribbage, threecard, caribbeanstud, texasholdembonus, ohhell, bridge, speed,\ngofish, pinochle, golf, pigtail,\nsevencardstud, clocksolitaire, durak,\nfortythieves, paigow, war, canfield, fiftyone, yukon, scorpion, accordion, whist,\nletitride, pokersquares, pageone, reddog, razz, badugi, trash,\nsevenbridge, president, cassino, calculation, spiteandmalice,\nskat, shithead, nertz, slapjack, egyptianratscrew, bakersdozen, tonk)"
 ```
 
 ### 1.3 Hook 層 (共通Hook)
@@ -1292,7 +1292,7 @@ classDiagram
 
     useCanastaGame --> useGameApi : uses
 
-    note for useBlackJackGame "全73ゲーム分の固有Hookが存在\n各HookはuseGameApiで統一的にAPI呼出し\n必要に応じてuseCardSelectionを合成"
+    note for useBlackJackGame "全77ゲーム分の固有Hookが存在\n各HookはuseGameApiで統一的にAPI呼出し\n必要に応じてuseCardSelectionを合成"
 ```
 
 ### 1.5 コンポーネント層
@@ -1874,7 +1874,7 @@ classDiagram
     GamePage --> PokerTableLayout : renders (Hold'em/Omaha/ShortDeck/Pineapple/SevenCardStud/Razz)
     PokerTableLayout --> CpuPlayerCard : wraps
 
-    note for GamePage "全73ゲームページが同一パターンで構成\nuseGamePageSetup → ゲーム固有Hook → 描画"
+    note for GamePage "全77ゲームページが同一パターンで構成\nuseGamePageSetup → ゲーム固有Hook → 描画"
 ```
 
 ### 1.7 i18n・プロバイダー・ルーティング
@@ -1897,7 +1897,7 @@ classDiagram
         +HashRouter
         +ErrorBoundary
         +NavBar
-        +Routes (73ゲーム)
+        +Routes (77ゲーム)
     }
 
     class gameCategories {
@@ -1920,11 +1920,11 @@ classDiagram
     App --> i18n : initializes
     App --> gameCategories : routes from
     App --> NavBar : renders
-    App --> GamePage : routes to 62 pages
+    App --> GamePage : routes to 77 pages
     GamePage --> TutorialProvider : wraps (per-game)
     TutorialProvider --> TutorialOverlay : renders when active
 
-    note for i18n "75名前空間: common + 73ゲーム固有 + tutorial\n翻訳ファイル: locales/{ja,en}/game.json"
+    note for i18n "79名前空間: common + 77ゲーム固有 + tutorial\n翻訳ファイル: locales/{ja,en}/game.json"
 ```
 
 ---

--- a/internal/infrastructure/games/registry.go
+++ b/internal/infrastructure/games/registry.go
@@ -5,7 +5,7 @@
 // binaries (TinyGo / WASM) stay under the 1 MB gzipped free-tier limit:
 //
 //   - registry.go (this file, no tag)  — types and bare metadata (Name +
-//     Category) for all 73 games. Cheap; no references to game code.
+//     Category) for all 77 games. Cheap; no references to game code.
 //   - games_server.go (!js || !wasm)   — installs Web-server factories for
 //     every game via BindWebController. Imported by TrumpCardsWeb.
 //   - casino/, classic/, solo/ (js && wasm) — per-category worker bindings.


### PR DESCRIPTION
## Summary

- Synchronizes stale game counts (`76`, `73`, `62`, `75`) across docs and the registry header to the canonical **77 games** after the Pitch addition (#1596).
- Surfaced by `/doc-drift-check`. Mechanical count-only fixes — no behavior or game logic changes.
- Remaining structural gaps (missing state-machine / class diagrams for newly added games in `docs/design/{backend,frontend}.md`) are intentionally **deferred** to a follow-up PR; they need new diagram content, not number replacements.

Closes #1637.

## Changes

| File | Fix |
|------|-----|
| `internal/infrastructure/games/registry.go` | Package doc comment: "all 73 games" → "all 77 games" |
| `CLAUDE.md` | "76 trump card game algorithms" → "77 …" |
| `README.md` | "76種類のトランプゲーム" → "77種類のトランプゲーム" |
| `docs/design/backend.md` | 全73ゲーム → 全77ゲーム (3); 73ゲーム×CUI/Web=146 → 77ゲーム×CUI/Web=154 (2); "holds 62 controllers/games" → "holds 77 …" |
| `docs/design/frontend.md` | 全73ゲーム → 全77ゲーム (4); "Routes (73ゲーム)" → 77; "75名前空間: common + 73ゲーム + tutorial" → "79名前空間: common + 77 + tutorial"; "routes to 62 pages" → 77 |

## Test plan

- [x] `go build ./...` (registry.go is doc-comment-only — build green)
- [ ] CI: `golangci-lint run ./...`
- [ ] CI: `go test -tags test ./...`
- [ ] CI: frontend `bun run check` / `bun run build` / `bun run test` (no frontend code touched, but the docs build picks these up)
- [x] Visual verification: `grep -nE "73 ?(ゲーム|games)|76 ?(ゲーム|games)|62 (games|controllers|pages)|75 ?名前空間"` returns no hits in modified files