### PR TITLE
chore(kv): log data length + prefix on unmarshal failure (diagnostic)

### DIFF
--- a/internal/adapter/controller/kv_session_provider.go
+++ b/internal/adapter/controller/kv_session_provider.go
@@ -66,7 +66,25 @@ func (p *KVSessionProvider[T]) Acquire(id string, factory func() T) (T, SessionR
 				val = restored
 				return val, p.releaseFunc(key, &val), true
 			}
-			slog.Error("KV unmarshal failed, creating new session", "key", key, "error", err)
+			// Diagnostic: include data length and a printable prefix so we can
+			// see what GetString actually returned (e.g. an HTML error page vs
+			// truncated JSON vs corrupted state). Remove once root cause is
+			// identified — see PR #1640 follow-up.
+			prefix := data
+			if len(prefix) > 80 {
+				prefix = prefix[:80] + "..."
+			}
+			slog.Error(
+				"KV unmarshal failed, creating new session",
+				"key", key,
+				"error", err,
+				"data_len", len(data),
+				"data_prefix", prefix,
+			)
+		} else if err != nil {
+			// Also log unexpected GetString errors (separate from the
+			// "key not found" path which returns ("", nil)).
+			slog.Error("KV GetString failed", "key", key, "error", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary
Diagnostic-only addition to `kv_session_provider.go` to identify the source of the `invalid character '<' looking for beginning of value` errors observed during PR #1640 follow-up investigation.

## Context
`wrangler tail go-trumpcards-classic-staging` against the deployed worker (after PR #1640 deploy) shows that **every** sevens request — even on fresh, never-seen-before session IDs — logs:

```
KV unmarshal failed, creating new session
  key=sevens:paniclog-1777826900
  error="invalid character '<' looking for beginning of value"
```

This is one of three distinct failures observed (the other two are a `runtime error: stack overflow` during reset and a `runtime error: nil pointer dereference` during pass — handled in separate follow-ups).

`GetString` on a fresh key should return `("", nil)`, so the fact that we hit the unmarshal branch at all means **something** is being returned that starts with `<`. Without the actual bytes we can't tell if it's:
- A Cloudflare HTML error page (5xx leak from the KV API)
- An XML/SOAP fault
- Truncated/corrupted JSON
- A binding-level layer issue in `syumai/workers`

## Change
- On unmarshal failure: log `data_len` + first 80 bytes of `data`.
- On a non-nil `GetString` error (separate path): log it as a distinct `slog.Error` so we can distinguish "binding returned an error" vs "binding returned data we couldn't parse".

## Plan
1. Merge → wait for staging deploy.
2. `wrangler tail` + reproduce sevens 2nd request → read the captured prefix.
3. Fix root cause in a follow-up PR.
4. Revert this diagnostic logging in the same follow-up.

## Test plan
- [x] `go test -tags test ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOOS=js GOARCH=wasm go build ./cmd/workers/{casino,classic,solo}` — green
- [ ] After deploy: `wrangler tail` captures the actual data prefix and reveals the source of the `<` byte.