### PR TITLE
fix(kv): treat "<null>" sentinel as key-not-found

### DIFF
--- a/internal/adapter/controller/kv_session_provider.go
+++ b/internal/adapter/controller/kv_session_provider.go
@@ -11,6 +11,15 @@ import (
 
 const kvSessionTTL = 3600 // 1 hour in seconds
 
+// kvNullSentinel is the literal string returned by syumai/workers
+// kv.GetString when the key does not exist. The underlying JS KV.get()
+// resolves to JS null on miss, and syscall/js Value.String() formats null
+// as "<null>" — so the binding surfaces that exact 6-byte string instead
+// of an empty result. Treat it as "key not found" alongside "".
+//
+// See: github.com/syumai/workers@v0.32.0/cloudflare/kv/get.go GetString.
+const kvNullSentinel = "<null>"
+
 // KVSessionProvider stores session state in Cloudflare KV.
 // It reads the session on Acquire and writes it back on Release.
 //
@@ -60,31 +69,18 @@ func (p *KVSessionProvider[T]) Acquire(id string, factory func() T) (T, SessionR
 
 	if p.ns != nil {
 		data, err := p.ns.GetString(key, nil)
-		if err == nil && data != "" {
-			restored, err := p.unmarshal([]byte(data))
-			if err == nil {
+		switch {
+		case err != nil:
+			slog.Error("KV GetString failed", "key", key, "error", err)
+		case data == "" || data == kvNullSentinel:
+			// Key not found — fall through to factory().
+		default:
+			restored, uerr := p.unmarshal([]byte(data))
+			if uerr == nil {
 				val = restored
 				return val, p.releaseFunc(key, &val), true
 			}
-			// Diagnostic: include data length and a printable prefix so we can
-			// see what GetString actually returned (e.g. an HTML error page vs
-			// truncated JSON vs corrupted state). Remove once root cause is
-			// identified — see PR #1640 follow-up.
-			prefix := data
-			if len(prefix) > 80 {
-				prefix = prefix[:80] + "..."
-			}
-			slog.Error(
-				"KV unmarshal failed, creating new session",
-				"key", key,
-				"error", err,
-				"data_len", len(data),
-				"data_prefix", prefix,
-			)
-		} else if err != nil {
-			// Also log unexpected GetString errors (separate from the
-			// "key not found" path which returns ("", nil)).
-			slog.Error("KV GetString failed", "key", key, "error", err)
+			slog.Error("KV unmarshal failed, creating new session", "key", key, "error", uerr)
 		}
 	}
 


### PR DESCRIPTION
## Summary
`syumai/workers v0.32.0 cloudflare/kv/get.go GetString` calls `js.Value.String()` unconditionally on the result of JS `KV.get()`. When the key does not exist, `KV.get` resolves to JS `null`, and per `syscall/js` docs `Value.String()` formats `null` as the literal 6-byte string `"<null>"` — not `""`.

Our previous check `err == nil && data != ""` therefore entered the unmarshal branch on **every** fresh sessionId. Unmarshal would fail with `invalid character '<' looking for beginning of value`, we'd log `KV unmarshal failed`, and only then fall through to `factory()`.

## Confirmation
Running `wrangler tail go-trumpcards-classic-staging` after merging the diagnostic logging in #1641, against a fresh `paniclog-...` sessionId on the sevens worker:

```
ERROR KV unmarshal failed, creating new session
  key=sevens:diag-1777827915
  error="invalid character '<' looking for beginning of value"
  data_len=6  data_prefix=<null>     ← exactly len("<null>") == 6
```

That nails it — every Acquire on a missing key was unnecessarily round-tripping through unmarshal-and-fail.

## Change
- Treat `data == "<null>"` as missing alongside `data == ""`.
- Restructure to a `switch` so the `GetString` error path and the unmarshal error path log distinct messages (previously both logged `KV unmarshal failed`).
- Remove the diagnostic `data_len` / `data_prefix` logging from #1641 — the source of the `<` is identified.

## Scope note
This fix only addresses the spurious `<null>` log and unnecessary unmarshal attempt. It does **not** fix:
- `panic: runtime error: stack overflow` on sevens reset (PR #1640 follow-up)
- `panic: runtime error: nil pointer dereference` on sevens pass (PR #1640 follow-up)

Both will be tackled in separate PRs.

## Test plan
- [x] `go test -tags test ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOOS=js GOARCH=wasm go build ./cmd/workers/{casino,classic,solo}` — green
- [ ] After deploy: `wrangler tail` confirms no more `KV unmarshal failed` spam on fresh sessions.