### PR TITLE
chore(sevens): trace Reset/Play/runCpuTurns to localize stack overflow (diagnostic)

### DIFF
--- a/internal/usecase/SevensInteractor.go
+++ b/internal/usecase/SevensInteractor.go
@@ -1,6 +1,8 @@
 package usecase
 
 import (
+	"log/slog"
+
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -39,30 +41,47 @@ func NewSevensInteractor(s interfaces.SevensGame, sp presenter.SevensPresenter) 
 
 // ResetWithConfig 設定付きゲーム初期化
 func (si *SevensInteractor) ResetWithConfig(cfg domain.SevensConfig) string {
+	slog.Info("sevens.trace", "at", "ResetWithConfig:enter")
 	si.Game.SetConfig(cfg)
+	slog.Info("sevens.trace", "at", "ResetWithConfig:after-SetConfig")
 	si.Game.Reset()
+	slog.Info("sevens.trace", "at", "ResetWithConfig:after-Game.Reset")
 	si.runCpuTurns()
-	return si.sp.Output(si.Game, nil)
+	slog.Info("sevens.trace", "at", "ResetWithConfig:after-runCpuTurns")
+	out := si.sp.Output(si.Game, nil)
+	slog.Info("sevens.trace", "at", "ResetWithConfig:after-Output", "out_len", len(out))
+	return out
 }
 
 // Reset ゲーム初期化
 func (si *SevensInteractor) Reset() string {
+	slog.Info("sevens.trace", "at", "Reset:enter")
 	si.Game.Reset()
+	slog.Info("sevens.trace", "at", "Reset:after-Game.Reset")
 	si.runCpuTurns()
-	return si.sp.Output(si.Game, nil)
+	slog.Info("sevens.trace", "at", "Reset:after-runCpuTurns")
+	out := si.sp.Output(si.Game, nil)
+	slog.Info("sevens.trace", "at", "Reset:after-Output", "out_len", len(out))
+	return out
 }
 
 // Play 人間プレイヤーがカードを出す (または パスする)
 // idx: 出すカードのインデックス。-1 の場合はパス。
 func (si *SevensInteractor) Play(idx int) string {
+	slog.Info("sevens.trace", "at", "Play:enter", "idx", idx)
 	if out, blocked := guardNotPlayable(si.Game, si.sp); blocked {
+		slog.Info("sevens.trace", "at", "Play:blocked")
 		return out
 	}
 	err := si.Game.PlayerPlay(idx)
+	slog.Info("sevens.trace", "at", "Play:after-PlayerPlay", "err", err)
 	if err == nil && !si.Game.GetGameEndFlag() {
 		si.runCpuTurns()
+		slog.Info("sevens.trace", "at", "Play:after-runCpuTurns")
 	}
-	return si.sp.Output(si.Game, err)
+	out := si.sp.Output(si.Game, err)
+	slog.Info("sevens.trace", "at", "Play:after-Output", "out_len", len(out))
+	return out
 }
 
 // PlayJoker 人間プレイヤーがジョーカーを指定ポジションに出す
@@ -85,18 +104,29 @@ func (si *SevensInteractor) ActionLog() string {
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 // 人間の手番になった場合でも選択肢がなければ自動処理する
 func (si *SevensInteractor) runCpuTurns() {
+	iter := 0
 	for !si.Game.GetGameEndFlag() {
+		iter++
+		if iter > 200 {
+			slog.Error("sevens.trace", "at", "runCpuTurns:iter-cap", "iter", iter, "current", si.Game.GetCurrentTurn(), "isHuman", si.Game.IsHumanTurn())
+			return
+		}
+		slog.Info("sevens.trace", "at", "runCpuTurns:iter", "iter", iter, "current", si.Game.GetCurrentTurn(), "isHuman", si.Game.IsHumanTurn())
 		if si.Game.IsHumanTurn() {
 			// 人間に選択肢がなければ自動処理 (失格)
 			if !si.Game.HasAnyOption(si.Game.GetCurrentTurn()) {
 				si.Game.AutoHandleNoOption()
+				slog.Info("sevens.trace", "at", "runCpuTurns:after-AutoHandleNoOption")
 			} else {
+				slog.Info("sevens.trace", "at", "runCpuTurns:break-human-has-option")
 				break
 			}
 		} else {
 			si.Game.CpuPlay()
+			slog.Info("sevens.trace", "at", "runCpuTurns:after-CpuPlay")
 		}
 	}
+	slog.Info("sevens.trace", "at", "runCpuTurns:exit", "iter", iter)
 }
 
 // RestoreSevensInteractor deserialises JSON into a SevensInteractor.


### PR DESCRIPTION
## Summary
Diagnostic-only — wraps each call-boundary in `SevensInteractor` (`Reset`, `ResetWithConfig`, `Play`, `runCpuTurns`) with `slog.Info(\"sevens.trace\", \"at\", \"<location>\")`. After deploy, `wrangler tail go-trumpcards-classic-staging` will show the last `at=...` value before the WASM trap, narrowing the `panic: runtime error: stack overflow` reported in PR #1640's follow-up to one of:
- `Game.SetConfig` / `Game.Reset`
- `runCpuTurns` (iteration count + per-iter state)
- `Presenter.Output`

## Why traces, not recover()
TinyGo's `defer recover()` cannot catch stack-exhaustion (the recovery defer needs stack space that has already been consumed). Even at function-scope, recover does not run, so the WASM module aborts and Cloudflare returns its 1101 page without CORS headers — exactly what we see today on `/sevens/exec`.

Tracing is the cheapest way to localize the offending leg without introducing native test coverage that doesn't exercise the TinyGo runtime.

## Defensive safety net
Adds an `iter > 200` cap inside `runCpuTurns` that logs and returns. If the panic is actually a non-terminating loop (which Cloudflare reports as \"detected that your Worker's code had hung\" — same client-visible 1101), the cap prevents the worker from being killed by the runtime watchdog, and the `iter-cap` log tells us so explicitly.

## Plan
1. Merge → wait for staging deploy.
2. `wrangler tail` + reproduce sevens reset → read the captured trace.
3. Open follow-up PR with the actual fix.
4. Revert this diagnostic logging in the same follow-up.

## Test plan
- [x] `go test -tags test ./internal/usecase/...` — green
- [x] `golangci-lint run ./internal/usecase/...` — 0 issues
- [x] `GOOS=js GOARCH=wasm go build ./cmd/workers/classic` — green
- [ ] After deploy: `wrangler tail` shows the last `sevens.trace at=...` before the panic.