### PR TITLE
fix(workers): bump TinyGo stack to 64KB to fix Snapshot stack overflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,12 @@ define build_worker
 	@echo "Building worker: $(1)"
 	@mkdir -p workers/$(1)/build
 	$(ASSETS_GEN) -mode=tinygo -o workers/$(1)/build
-	# -stack-size=65536: TinyGo's default 16KB main stack overflows when
+	# -stack-size=64KB: TinyGo's default 16KB main stack overflows when
 	# encoding/json walks the deep MarshalJSON chain produced by the
 	# Player → GamePlayer → RankedGamePlayer → SevensPlayer (etc.) embedded
 	# pointer hierarchy. 64KB gives ~4× headroom and fits within the
 	# Cloudflare Workers free-tier 1MB gzipped limit. See PR #1640 follow-up.
-	$(TINYGO) build -o workers/$(1)/build/app.wasm -target wasm -stack-size=65536 -no-debug -opt=z ./cmd/workers/$(1)
+	$(TINYGO) build -o workers/$(1)/build/app.wasm -target wasm -stack-size=64KB -no-debug -opt=z ./cmd/workers/$(1)
 	$(WASM_OPT) --enable-bulk-memory --enable-nontrapping-float-to-int --enable-sign-ext -Oz workers/$(1)/build/app.wasm -o workers/$(1)/build/app.wasm
 	@RAW=$$(stat -c%s workers/$(1)/build/app.wasm); GZIP=$$(gzip -c workers/$(1)/build/app.wasm | wc -c); \
 	echo "  $(1): $$RAW bytes raw, $$GZIP bytes gzip"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,12 @@ define build_worker
 	@echo "Building worker: $(1)"
 	@mkdir -p workers/$(1)/build
 	$(ASSETS_GEN) -mode=tinygo -o workers/$(1)/build
-	$(TINYGO) build -o workers/$(1)/build/app.wasm -target wasm -no-debug -opt=z ./cmd/workers/$(1)
+	# -stack-size=65536: TinyGo's default 16KB main stack overflows when
+	# encoding/json walks the deep MarshalJSON chain produced by the
+	# Player → GamePlayer → RankedGamePlayer → SevensPlayer (etc.) embedded
+	# pointer hierarchy. 64KB gives ~4× headroom and fits within the
+	# Cloudflare Workers free-tier 1MB gzipped limit. See PR #1640 follow-up.
+	$(TINYGO) build -o workers/$(1)/build/app.wasm -target wasm -stack-size=65536 -no-debug -opt=z ./cmd/workers/$(1)
 	$(WASM_OPT) --enable-bulk-memory --enable-nontrapping-float-to-int --enable-sign-ext -Oz workers/$(1)/build/app.wasm -o workers/$(1)/build/app.wasm
 	@RAW=$$(stat -c%s workers/$(1)/build/app.wasm); GZIP=$$(gzip -c workers/$(1)/build/app.wasm | wc -c); \
 	echo "  $(1): $$RAW bytes raw, $$GZIP bytes gzip"


### PR DESCRIPTION
## Summary
Root-cause fix for the `panic: runtime error: stack overflow` observed on every `POST /sevens/exec` (and the 10 sibling classic games listed in PR #1640).

TinyGo's default **16KB** main stack overflows when `encoding/json` walks the deep `MarshalJSON` chain produced by the embedded pointer hierarchy used by every game's player type:

```
Sevens → sevensJSON → SevensPlayer → sevensPlayerJSON
                       └─ *RankedGamePlayer → rankedGamePlayerJSON
                                              └─ *GamePlayer → gamePlayerJSON
                                                                └─ *Player → playerJSON
                                                                              └─ []*Card → cardJSON
```

That's **~6 nested `json.Marshal` re-entries per player**, each costing a few KB of reflection-state stack frames. With 4 players + 52-card deck + action-log entries, cumulative stack usage exceeds 16KB and the WASM runtime traps. The trap aborts the worker before the recovery middleware's `defer recover()` can run, so Cloudflare returns its 1101 page without CORS headers — the original "通信エラー" symptom.

## How we got here

1. **PR #1641** added a diagnostic prefix log → revealed `data_prefix=<null>` (= syumai/workers KV miss sentinel).
2. **PR #1642** treated `<null>` as missing (cleared the spurious log line).
3. **PR #1643** added `slog.Info("sevens.trace", "at", ...)` around `Reset/Play/runCpuTurns`.
4. `wrangler tail` against the deployed staging worker showed the panic fires **after** `Reset:after-Output out_len=1382` — i.e. inside the deferred `releaseFunc()` where `Snapshot()` = `json.Marshal(b.Game)` runs.
5. Mainstream-Go `json.Marshal` of the same fully-`Reset()` state succeeds at 2923 bytes — so the code is correct; only TinyGo's fixed-size stack is the constraint.

## Change
Single Makefile line: add `-stack-size=65536` to the `tinygo build` invocation.

- `-stack-size=N` only changes a runtime memory-reservation constant; the gzipped binary size is essentially unchanged.
- 64KB gives ~4× headroom and is far below the 128MB Cloudflare Workers per-isolate runtime limit and the 1MB gzipped binary limit.
- Code semantics unchanged across all 11 games.

## Expected impact
This should also resolve the 10 sibling games listed in PR #1640's bug table that share the same `Player → GamePlayer → RankedGamePlayer → ...` chain:
ohhell, oldmaid, durak, daifugo, pageone, whist, president, skat, shithead, tonk.

## Follow-ups (not in this PR)
- **Structural fix** (proper): flatten each game's player wire struct so MarshalJSON does a single `json.Marshal` call instead of re-entering 5–6 levels deep. Removes the stack-pressure root cause and reduces JSON size. Larger refactor across all 11 player types.
- **Revert diagnostic logging**: roll back the trace `slog.Info` calls from PR #1643 once we confirm the panic is gone.
- **Investigate the nil-pointer dereference** observed on the 4th request (separate panic shape from this one).

## Test plan
- [x] `go test -tags test ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [ ] CI `tinygo-build (classic|casino|solo)` — verifies the flag is accepted by TinyGo
- [ ] After deploy: `wrangler tail` confirms `sevens.trace at=Reset:after-Output` is now followed by no panic on /sevens/exec
- [ ] After deploy: `https://go-trumpcards-staging.pages.dev/sevens` no longer surfaces "通信エラー"