### PR TITLE
fix(sevens): remove diagnostic slog traces and bump TinyGo stack to 128KB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,14 @@ define build_worker
 	@echo "Building worker: $(1)"
 	@mkdir -p workers/$(1)/build
 	$(ASSETS_GEN) -mode=tinygo -o workers/$(1)/build
-	# -stack-size=64KB: TinyGo's default 16KB main stack overflows when
+	# -stack-size=128KB: TinyGo's default 16KB main stack overflows when
 	# encoding/json walks the deep MarshalJSON chain produced by the
 	# Player → GamePlayer → RankedGamePlayer → SevensPlayer (etc.) embedded
-	# pointer hierarchy. 64KB gives ~4× headroom and fits within the
-	# Cloudflare Workers free-tier 1MB gzipped limit. See PR #1640 follow-up.
-	$(TINYGO) build -o workers/$(1)/build/app.wasm -target wasm -stack-size=64KB -no-debug -opt=z ./cmd/workers/$(1)
+	# pointer hierarchy. 64KB was still insufficient for Sevens Reset →
+	# runCpuTurns → Output on staging, so we bump to 128KB. The flag only
+	# reserves linear memory at runtime (binary stays well under the
+	# Cloudflare Workers free-tier 1MB gzipped limit).
+	$(TINYGO) build -o workers/$(1)/build/app.wasm -target wasm -stack-size=128KB -no-debug -opt=z ./cmd/workers/$(1)
 	$(WASM_OPT) --enable-bulk-memory --enable-nontrapping-float-to-int --enable-sign-ext -Oz workers/$(1)/build/app.wasm -o workers/$(1)/build/app.wasm
 	@RAW=$$(stat -c%s workers/$(1)/build/app.wasm); GZIP=$$(gzip -c workers/$(1)/build/app.wasm | wc -c); \
 	echo "  $(1): $$RAW bytes raw, $$GZIP bytes gzip"

--- a/internal/usecase/SevensInteractor.go
+++ b/internal/usecase/SevensInteractor.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"log/slog"
-
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
@@ -41,47 +39,30 @@ func NewSevensInteractor(s interfaces.SevensGame, sp presenter.SevensPresenter) 
 
 // ResetWithConfig 設定付きゲーム初期化
 func (si *SevensInteractor) ResetWithConfig(cfg domain.SevensConfig) string {
-	slog.Info("sevens.trace", "at", "ResetWithConfig:enter")
 	si.Game.SetConfig(cfg)
-	slog.Info("sevens.trace", "at", "ResetWithConfig:after-SetConfig")
 	si.Game.Reset()
-	slog.Info("sevens.trace", "at", "ResetWithConfig:after-Game.Reset")
 	si.runCpuTurns()
-	slog.Info("sevens.trace", "at", "ResetWithConfig:after-runCpuTurns")
-	out := si.sp.Output(si.Game, nil)
-	slog.Info("sevens.trace", "at", "ResetWithConfig:after-Output", "out_len", len(out))
-	return out
+	return si.sp.Output(si.Game, nil)
 }
 
 // Reset ゲーム初期化
 func (si *SevensInteractor) Reset() string {
-	slog.Info("sevens.trace", "at", "Reset:enter")
 	si.Game.Reset()
-	slog.Info("sevens.trace", "at", "Reset:after-Game.Reset")
 	si.runCpuTurns()
-	slog.Info("sevens.trace", "at", "Reset:after-runCpuTurns")
-	out := si.sp.Output(si.Game, nil)
-	slog.Info("sevens.trace", "at", "Reset:after-Output", "out_len", len(out))
-	return out
+	return si.sp.Output(si.Game, nil)
 }
 
 // Play 人間プレイヤーがカードを出す (または パスする)
 // idx: 出すカードのインデックス。-1 の場合はパス。
 func (si *SevensInteractor) Play(idx int) string {
-	slog.Info("sevens.trace", "at", "Play:enter", "idx", idx)
 	if out, blocked := guardNotPlayable(si.Game, si.sp); blocked {
-		slog.Info("sevens.trace", "at", "Play:blocked")
 		return out
 	}
 	err := si.Game.PlayerPlay(idx)
-	slog.Info("sevens.trace", "at", "Play:after-PlayerPlay", "err", err)
 	if err == nil && !si.Game.GetGameEndFlag() {
 		si.runCpuTurns()
-		slog.Info("sevens.trace", "at", "Play:after-runCpuTurns")
 	}
-	out := si.sp.Output(si.Game, err)
-	slog.Info("sevens.trace", "at", "Play:after-Output", "out_len", len(out))
-	return out
+	return si.sp.Output(si.Game, err)
 }
 
 // PlayJoker 人間プレイヤーがジョーカーを指定ポジションに出す
@@ -104,29 +85,21 @@ func (si *SevensInteractor) ActionLog() string {
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 // 人間の手番になった場合でも選択肢がなければ自動処理する
 func (si *SevensInteractor) runCpuTurns() {
-	iter := 0
-	for !si.Game.GetGameEndFlag() {
-		iter++
-		if iter > 200 {
-			slog.Error("sevens.trace", "at", "runCpuTurns:iter-cap", "iter", iter, "current", si.Game.GetCurrentTurn(), "isHuman", si.Game.IsHumanTurn())
-			return
-		}
-		slog.Info("sevens.trace", "at", "runCpuTurns:iter", "iter", iter, "current", si.Game.GetCurrentTurn(), "isHuman", si.Game.IsHumanTurn())
+	// Defensive cap: a non-terminating loop here would otherwise produce
+	// Cloudflare's "Worker hung" 1101 with no actionable detail. 200 turns
+	// is well above any legitimate game (4 players × 13 cards × passes).
+	for iter := 0; !si.Game.GetGameEndFlag() && iter < 200; iter++ {
 		if si.Game.IsHumanTurn() {
 			// 人間に選択肢がなければ自動処理 (失格)
 			if !si.Game.HasAnyOption(si.Game.GetCurrentTurn()) {
 				si.Game.AutoHandleNoOption()
-				slog.Info("sevens.trace", "at", "runCpuTurns:after-AutoHandleNoOption")
 			} else {
-				slog.Info("sevens.trace", "at", "runCpuTurns:break-human-has-option")
 				break
 			}
 		} else {
 			si.Game.CpuPlay()
-			slog.Info("sevens.trace", "at", "runCpuTurns:after-CpuPlay")
 		}
 	}
-	slog.Info("sevens.trace", "at", "runCpuTurns:exit", "iter", iter)
 }
 
 // RestoreSevensInteractor deserialises JSON into a SevensInteractor.


### PR DESCRIPTION
## Summary

Staging Cloudflare worker has been silently returning HTTP 200 with empty body for `POST /sevens/exec` `command=reset` since the diagnostic traces landed in #1643 — verified locally with curl against the live staging endpoint:

| Endpoint | Deploy | Sevens reset |
|---|---|---|
| `*classic` (production, master 5/1) | no traces, 16KB stack | ✅ 1300+ byte JSON |
| `*classic-staging` (develop, today) | traces + 64KB stack | ❌ 200 / **0 bytes** |
| `*classic-staging` hearts | same binary | ✅ 1097 byte JSON |

Hearts works on the same staging binary, isolating the regression to the Sevens code path. The 20 `slog.Info` calls added in #1643 inflate per-frame stack via `syscall/js` enough to push `Reset → runCpuTurns → Output` past the 64KB budget set by #1644. The wasm trap can't be recovered, so the buffered response body is discarded → 200 + empty body.

This PR applies both mitigations the issue analysis pointed to:

- **Remove the diagnostic `slog.Info` traces** from `SevensInteractor` (their job is done — root cause is identified). Keep the 200-iter cap in `runCpuTurns` as a defensive guard, but make it a silent break.
- **Bump TinyGo stack from 64KB to 128KB** in the Makefile. `-stack-size` only reserves runtime linear memory, so binary stays well under the 1MB gzipped free-tier limit.

## Test plan

- [x] `go test -tags test ./...` (all green)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `goimports -w` on modified files
- [ ] After merge: verify staging `POST /sevens/exec command=reset` returns full JSON (not 0 bytes)
- [ ] After merge: spot-check Sevens E2E flows in browser against staging