### PR TITLE
chore: revert temporary diagnostics from sevens staging bug investigation

### DIFF
--- a/internal/adapter/controller/kv_session_provider.go
+++ b/internal/adapter/controller/kv_session_provider.go
@@ -69,12 +69,7 @@ func (p *KVSessionProvider[T]) Acquire(id string, factory func() T) (T, SessionR
 
 	if p.ns != nil {
 		data, err := p.ns.GetString(key, nil)
-		switch {
-		case err != nil:
-			slog.Error("KV GetString failed", "key", key, "error", err)
-		case data == "" || data == kvNullSentinel:
-			// Key not found — fall through to factory().
-		default:
+		if err == nil && data != "" && data != kvNullSentinel {
 			restored, uerr := p.unmarshal([]byte(data))
 			if uerr == nil {
 				val = restored

--- a/internal/usecase/SevensInteractor.go
+++ b/internal/usecase/SevensInteractor.go
@@ -85,10 +85,7 @@ func (si *SevensInteractor) ActionLog() string {
 // runCpuTurns ゲームが終わるか人間の手番になるまでCPUターンを実行
 // 人間の手番になった場合でも選択肢がなければ自動処理する
 func (si *SevensInteractor) runCpuTurns() {
-	// Defensive cap: a non-terminating loop here would otherwise produce
-	// Cloudflare's "Worker hung" 1101 with no actionable detail. 200 turns
-	// is well above any legitimate game (4 players × 13 cards × passes).
-	for iter := 0; !si.Game.GetGameEndFlag() && iter < 200; iter++ {
+	for !si.Game.GetGameEndFlag() {
 		if si.Game.IsHumanTurn() {
 			// 人間に選択肢がなければ自動処理 (失格)
 			if !si.Game.HasAnyOption(si.Game.GetCurrentTurn()) {


### PR DESCRIPTION
## Summary

Cleans up two temporary diagnostic measures left over from the staging Sevens bug investigation, now that root causes are identified and fixed.

| Source | What was added | Why removable now |
|---|---|---|
| #1641 | `slog.Error(\"KV GetString failed\", ...)` branch in `KVSessionProvider.Acquire` | PR was tagged \"will be reverted once the source of the '<' payload is identified.\" Root cause = JS-null-as-\"<null>\"-string from syumai/workers binding, fixed permanently in #1642. The `data_len`/`data_prefix` dumps were already removed by #1642's restructure; this removes the last residual log branch. |
| #1643 | 200-iter cap in `runCpuTurns` | Cap was defensive against a hypothetical hung CPU loop, but the actual bug turned out to be a TinyGo stack overflow (fixed in #1645 by removing slog traces and bumping stack to 128KB). No infinite loop has ever been observed — the cap is speculative defense over the original unbounded loop. |

**Kept** (these are the actual permanent fixes from this investigation):

- `recoverymw` — panic → JSON 500 with CORS headers preserved
- `kvNullSentinel` constant + handling — the real KV binding workaround (#1642)
- `tinygo -stack-size=128KB` in Makefile — necessary for Sevens Reset to succeed

## Test plan

- [x] `go test -tags test ./...` (all green)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `goimports -w` on modified files
- [ ] After merge: confirm staging Sevens reset still returns full JSON
- [ ] After merge: spot-check Sevens Reset/Play/Joker flows in browser