### PR TITLE
feat(spider/scorpion): shake empty columns when deal is blocked

### DIFF
--- a/frontend/src/i18n/locales/en/scorpion.json
+++ b/frontend/src/i18n/locales/en/scorpion.json
@@ -21,6 +21,7 @@
   "noHint": "No hint available",
   "hintAvailable": "Hint available",
   "stalemate": "Stalemate",
+  "cannotDealEmptyColExists": "Fill every empty column before dealing",
   "landscapeBanner": "Landscape mode recommended",
   "frontendHint": {
     "moveToTableau": "A card can be moved between tableau columns",

--- a/frontend/src/i18n/locales/en/spider.json
+++ b/frontend/src/i18n/locales/en/spider.json
@@ -28,6 +28,7 @@
   "hintAvailable": "Hint available",
   "stalemate": "No more moves",
   "dealsRemaining": "{{count}} deals remaining",
+  "cannotDealEmptyColExists": "Fill every empty column before dealing",
   "tutorial": {
     "stockPile": "Stock pile. Click to deal one card to each column. All columns must have cards.",
     "tableau": "Tableau columns. Arrange cards in same-suit descending order. Ace-to-King sequences are removed.",

--- a/frontend/src/i18n/locales/ja/scorpion.json
+++ b/frontend/src/i18n/locales/ja/scorpion.json
@@ -21,6 +21,7 @@
   "noHint": "ヒントはありません",
   "hintAvailable": "ヒントがあります",
   "stalemate": "手詰まりです",
+  "cannotDealEmptyColExists": "空の列をすべて埋めないと配れません",
   "landscapeBanner": "横向き画面推奨",
   "frontendHint": {
     "moveToTableau": "場札間で移動可能なカードがあります",

--- a/frontend/src/i18n/locales/ja/spider.json
+++ b/frontend/src/i18n/locales/ja/spider.json
@@ -28,6 +28,7 @@
   "hintAvailable": "ヒントがあります",
   "stalemate": "手詰まりです",
   "dealsRemaining": "残り{{count}}回配れます",
+  "cannotDealEmptyColExists": "空の列をすべて埋めないと配れません",
   "tutorial": {
     "stockPile": "山札です。クリックすると各列に1枚ずつカードが配られます。全ての列にカードがある必要があります。",
     "tableau": "タブローです。同じスートの降順でカードを並べます。AからKまで揃うと自動的に除去されます。",

--- a/frontend/src/pages/ScorpionPage.test.tsx
+++ b/frontend/src/pages/ScorpionPage.test.tsx
@@ -114,6 +114,52 @@ describe('ScorpionPage', () => {
     expect(screen.getByRole('button', { name: '配る' })).toBeDisabled();
   });
 
+  it('clicking deal with empty columns triggers shake on empty placeholders and skips API', async () => {
+    const stateWithEmptyCol: ScorpionResponse = {
+      ...playingState,
+      tableau: [
+        [{ card: card('SPADE', 13), faceUp: true }],
+        [], // empty
+        [{ card: card('CLOVER', 5), faceUp: true }],
+        [{ card: card('DIAMOND', 10), faceUp: true }],
+        [{ card: card('SPADE', 3), faceUp: true }],
+        [{ card: card('HEART', 7), faceUp: true }],
+        [{ card: card('CLOVER', 2), faceUp: true }],
+      ],
+    };
+    mockExec.mockResolvedValue(stateWithEmptyCol);
+    renderWithProviders(<ScorpionPage />);
+    await waitFor(() => expect(screen.getByTestId('sc-empty-col-1')).toBeInTheDocument());
+    expect(screen.getByTestId('sc-empty-col-1').className).not.toContain('animate-shake');
+
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '配る' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sc-empty-col-1').className).toContain('animate-shake');
+    });
+    expect(mockExec).not.toHaveBeenCalledWith('deal');
+  });
+
+  it('deal button exposes empty-column reason via title when blocked', async () => {
+    const stateWithEmptyCol: ScorpionResponse = {
+      ...playingState,
+      tableau: [
+        [{ card: card('SPADE', 13), faceUp: true }],
+        [],
+        [{ card: card('CLOVER', 5), faceUp: true }],
+        [{ card: card('DIAMOND', 10), faceUp: true }],
+        [{ card: card('SPADE', 3), faceUp: true }],
+        [{ card: card('HEART', 7), faceUp: true }],
+        [{ card: card('CLOVER', 2), faceUp: true }],
+      ],
+    };
+    mockExec.mockResolvedValue(stateWithEmptyCol);
+    renderWithProviders(<ScorpionPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '配る' })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: '配る' })).toHaveAttribute('title', '空の列をすべて埋めないと配れません');
+  });
+
   it('autocomplete button triggers autocomplete command', async () => {
     renderWithProviders(<ScorpionPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));

--- a/frontend/src/pages/ScorpionPage.tsx
+++ b/frontend/src/pages/ScorpionPage.tsx
@@ -224,6 +224,18 @@ function ScorpionPageContent() {
     playSound('cardPlace');
   }, [apiCall, playSound]);
 
+  // Empty-column deal guard: surfaces a shake animation + tooltip instead of failing silently.
+  const [emptyDealAttemptKey, setEmptyDealAttemptKey] = useState(0);
+  const hasEmptyColumn = useMemo(() => state?.tableau.some((col) => col.length === 0) ?? false, [state?.tableau]);
+  const dealBlockedByEmpty = hasEmptyColumn && (state?.stockCount ?? 0) > 0;
+  const handleDealGuarded = useCallback(() => {
+    if (dealBlockedByEmpty) {
+      setEmptyDealAttemptKey((k) => k + 1);
+      return;
+    }
+    handleDeal();
+  }, [dealBlockedByEmpty, handleDeal]);
+
   const handleGiveUp = useCallback(() => {
     void apiCall('giveup');
   }, [apiCall]);
@@ -281,9 +293,9 @@ function ScorpionPageContent() {
       { key: 'a', action: handleAutoComplete },
       { key: 'g', action: handleGiveUp },
       { key: 'z', action: handleUndo },
-      { key: 'd', action: handleDeal },
+      { key: 'd', action: handleDealGuarded },
     ],
-    [handleHint, handleAutoComplete, handleGiveUp, handleUndo, handleDeal],
+    [handleHint, handleAutoComplete, handleGiveUp, handleUndo, handleDealGuarded],
   );
 
   useActionKeyboardNav({
@@ -359,14 +371,16 @@ function ScorpionPageContent() {
                       isDropTarget={dnd.isDropTarget({ zone: 'tableau', col: colIdx })}
                     >
                       <button
+                        key={`empty-${colIdx.toString()}-${emptyDealAttemptKey.toString()}`}
                         type="button"
                         className={`border-2 border-dashed border-game-border rounded-lg flex items-center justify-center text-game-text-muted ${focusRingWhite} ${
                           selectedSource ? 'hover:ring-2 hover:ring-ds-warning cursor-pointer' : ''
-                        }`}
+                        }${emptyDealAttemptKey > 0 ? ' animate-shake border-ds-warning text-ds-warning' : ''}`}
                         style={{ width: sc.cw, height: sc.ch }}
                         onClick={() => selectedSource && handleSelectTarget('tableau', colIdx)}
                         disabled={!isPlaying || !selectedSource}
                         aria-label={`${t('empty')} ${t('tableau')} ${colIdx}`}
+                        data-testid={`sc-empty-col-${colIdx.toString()}`}
                       >
                         {t('empty')}
                       </button>
@@ -475,8 +489,9 @@ function ScorpionPageContent() {
                   <button
                     type="button"
                     className={btnSuccess}
-                    onClick={handleDeal}
+                    onClick={handleDealGuarded}
                     disabled={loading || state.stockCount === 0}
+                    title={dealBlockedByEmpty ? t('cannotDealEmptyColExists') : undefined}
                   >
                     {t('deal')}
                   </button>

--- a/frontend/src/pages/ScorpionPage.tsx
+++ b/frontend/src/pages/ScorpionPage.tsx
@@ -233,6 +233,8 @@ function ScorpionPageContent() {
       setEmptyDealAttemptKey((k) => k + 1);
       return;
     }
+    // Reset on a successful deal so a future empty-column attempt can re-trigger the shake.
+    setEmptyDealAttemptKey(0);
     handleDeal();
   }, [dealBlockedByEmpty, handleDeal]);
 

--- a/frontend/src/pages/SpiderPage.test.tsx
+++ b/frontend/src/pages/SpiderPage.test.tsx
@@ -108,17 +108,53 @@ describe('SpiderPage', () => {
     // Column index headers should not be rendered
   });
 
-  it('clicking deal button dispatches deal', async () => {
+  it('clicking deal button dispatches deal when no empty columns exist', async () => {
+    const filledTableauState: SpiderResponse = {
+      ...playingState,
+      tableau: makeTableau(Array.from({ length: 10 }, () => [{ card: card('SPADE', 13), faceUp: true }])),
+    };
+    mockExec.mockResolvedValue(filledTableauState);
     renderWithProviders(<SpiderPage />);
     await waitFor(() => expect(screen.getAllByRole('button', { name: '配る' }).length).toBeGreaterThanOrEqual(1));
 
     mockExec.mockClear();
-    mockExec.mockResolvedValue(playingState);
+    mockExec.mockResolvedValue(filledTableauState);
     // The footer button is the last one
     const dealButtons = screen.getAllByRole('button', { name: '配る' });
     fireEvent.click(dealButtons[dealButtons.length - 1]);
 
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('deal'));
+  });
+
+  it('clicking deal with empty columns triggers shake on empty placeholders and skips API', async () => {
+    // playingState has empty columns 2..9
+    renderWithProviders(<SpiderPage />);
+    await waitFor(() => expect(screen.getByTestId('spd-empty-col-2')).toBeInTheDocument());
+
+    // Before click: no shake class
+    expect(screen.getByTestId('spd-empty-col-2').className).not.toContain('animate-shake');
+
+    mockExec.mockClear();
+    const dealButtons = screen.getAllByRole('button', { name: '配る' });
+    fireEvent.click(dealButtons[dealButtons.length - 1]);
+
+    // After click: shake class applied to every empty column placeholder
+    await waitFor(() => {
+      expect(screen.getByTestId('spd-empty-col-2').className).toContain('animate-shake');
+    });
+    expect(screen.getByTestId('spd-empty-col-9').className).toContain('animate-shake');
+
+    // API was NOT called with deal
+    expect(mockExec).not.toHaveBeenCalledWith('deal');
+  });
+
+  it('deal button exposes empty-column reason via title when blocked', async () => {
+    renderWithProviders(<SpiderPage />);
+    await waitFor(() => expect(screen.getAllByRole('button', { name: '配る' }).length).toBeGreaterThanOrEqual(1));
+
+    const dealButtons = screen.getAllByRole('button', { name: '配る' });
+    const footerDeal = dealButtons[dealButtons.length - 1];
+    expect(footerDeal).toHaveAttribute('title', '空の列をすべて埋めないと配れません');
   });
 
   it('clicking undo button dispatches undo', async () => {
@@ -345,12 +381,16 @@ describe('SpiderPage', () => {
     }
   });
 
-  it('pressing d triggers deal in PLAYING phase', async () => {
-    mockExec.mockResolvedValue(playingState);
+  it('pressing d triggers deal in PLAYING phase when no empty columns', async () => {
+    const filledTableauState: SpiderResponse = {
+      ...playingState,
+      tableau: makeTableau(Array.from({ length: 10 }, () => [{ card: card('SPADE', 13), faceUp: true }])),
+    };
+    mockExec.mockResolvedValue(filledTableauState);
     renderWithProviders(<SpiderPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
     mockExec.mockClear();
-    mockExec.mockResolvedValue(playingState);
+    mockExec.mockResolvedValue(filledTableauState);
     fireEvent.keyDown(document, { key: 'd' });
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('deal'));
   });
@@ -417,11 +457,16 @@ describe('SpiderPage', () => {
   });
 
   it('stock card back is clickable during playing phase', async () => {
+    const filledTableauState: SpiderResponse = {
+      ...playingState,
+      tableau: makeTableau(Array.from({ length: 10 }, () => [{ card: card('SPADE', 13), faceUp: true }])),
+    };
+    mockExec.mockResolvedValue(filledTableauState);
     renderWithProviders(<SpiderPage />);
     await waitFor(() => expect(screen.getByText(/山札/)).toBeInTheDocument());
 
     mockExec.mockClear();
-    mockExec.mockResolvedValue(playingState);
+    mockExec.mockResolvedValue(filledTableauState);
     const dealLabels = screen.getAllByLabelText('配る');
     fireEvent.click(dealLabels[0]);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('deal'));

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -141,6 +141,8 @@ function SpiderPageContent() {
       setEmptyDealAttemptKey((k) => k + 1);
       return;
     }
+    // Reset on a successful deal so a future empty-column attempt can re-trigger the shake.
+    setEmptyDealAttemptKey(0);
     handleDeal();
   }, [dealBlockedByEmpty, handleDeal]);
 
@@ -406,7 +408,6 @@ function SpiderPageContent() {
                     onClick={handleDealGuarded}
                     disabled={loading || isAutoCompleting}
                     title={dealBlockedByEmpty ? t('cannotDealEmptyColExists') : undefined}
-                    aria-describedby={dealBlockedByEmpty ? 'spd-deal-blocked-reason' : undefined}
                   >
                     {t('deal')}
                   </button>

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { SpiderMoveZone, spiderApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -132,6 +132,18 @@ function SpiderPageContent() {
 
   const isPlayingForKbd = state?.phase === SpiderPhase.PLAYING;
 
+  // Empty-column deal guard: surfaces a shake animation + tooltip instead of failing silently.
+  const [emptyDealAttemptKey, setEmptyDealAttemptKey] = useState(0);
+  const hasEmptyColumn = useMemo(() => state?.tableau.some((col) => col.length === 0) ?? false, [state?.tableau]);
+  const dealBlockedByEmpty = hasEmptyColumn && (state?.stockCount ?? 0) > 0;
+  const handleDealGuarded = useCallback(() => {
+    if (dealBlockedByEmpty) {
+      setEmptyDealAttemptKey((k) => k + 1);
+      return;
+    }
+    handleDeal();
+  }, [dealBlockedByEmpty, handleDeal]);
+
   const dispatchMove = useCallback(
     (source: SpiderMoveZone, target: SpiderMoveZone) => {
       void exec('move', source, target);
@@ -153,13 +165,13 @@ function SpiderPageContent() {
 
   const actionBindings = useMemo(
     () => [
-      { key: 'd', action: handleDeal },
+      { key: 'd', action: handleDealGuarded },
       { key: 'h', action: handleHint },
       { key: 'a', action: handleAutoComplete },
       { key: 'g', action: handleGiveUp },
       { key: 'z', action: handleUndo },
     ],
-    [handleDeal, handleHint, handleAutoComplete, handleGiveUp, handleUndo],
+    [handleDealGuarded, handleHint, handleAutoComplete, handleGiveUp, handleUndo],
   );
 
   useActionKeyboardNav({
@@ -224,7 +236,7 @@ function SpiderPageContent() {
                 {state.stockCount > 0 ? (
                   <AnimatedCardBack
                     width={cardWidth}
-                    onClick={isPlaying ? handleDeal : undefined}
+                    onClick={isPlaying ? handleDealGuarded : undefined}
                     ariaLabel={t('deal')}
                     onFlipComplete={() => playSound('cardFlip')}
                   />
@@ -261,11 +273,13 @@ function SpiderPageContent() {
                         <div className="relative" style={{ minHeight: cardHeight }}>
                           {col.length === 0 ? (
                             <button
+                              key={`empty-${colIdx.toString()}-${emptyDealAttemptKey.toString()}`}
                               type="button"
                               onClick={() => handleSelectTarget(tableauColZone)}
                               disabled={!isPlaying || loading || !selectedSource}
                               style={{ height: cardHeight }}
-                              className={`w-full rounded border-2 border-dashed border-white/20 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}`}
+                              data-testid={`spd-empty-col-${colIdx.toString()}`}
+                              className={`w-full rounded border-2 border-dashed border-white/20 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}${emptyDealAttemptKey > 0 ? ' animate-shake border-ds-warning text-ds-warning' : ''}`}
                             >
                               {t('empty')}
                             </button>
@@ -389,8 +403,10 @@ function SpiderPageContent() {
                   <button
                     type="button"
                     className={btnPrimary}
-                    onClick={handleDeal}
+                    onClick={handleDealGuarded}
                     disabled={loading || isAutoCompleting}
+                    title={dealBlockedByEmpty ? t('cannotDealEmptyColExists') : undefined}
+                    aria-describedby={dealBlockedByEmpty ? 'spd-deal-blocked-reason' : undefined}
                   >
                     {t('deal')}
                   </button>


### PR DESCRIPTION
## Summary
- Spider Solitaire / Scorpion: when the player taps Deal while one or more tableau columns are empty (which the domain rule rejects), the empty placeholders now visibly shake using the existing \`animate-shake\` keyframes, and the Deal button advertises the rule via a \`title\` tooltip + the new \`cannotDealEmptyColExists\` i18n key (ja/en).
- Stock-card click and the \`d\` keyboard shortcut both go through the same guard — no silent dead-clicks, no need to wait for the API error.

## Test plan
- [x] \`bun run test -- --run SpiderPage\` (54 pass, including 3 new assertions: shake on empty cols, no API call when blocked, tooltip text)
- [x] \`bun run test -- --run ScorpionPage\` (38 pass, including 2 new assertions: shake + tooltip)
- [x] \`bun run check\` (Biome + design-tokens clean)
- [ ] Frontend build verified via GH Actions (local \`bun run build\` OOMs in this WSL environment)

Closes #1660