### PR TITLE
feat(tonk): celebrate Tonk-on-deal with dedicated banner overlay

### DIFF
--- a/frontend/src/components/TonkOnDealCelebration.test.tsx
+++ b/frontend/src/components/TonkOnDealCelebration.test.tsx
@@ -1,0 +1,78 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Card, CardDesign } from '../types/card';
+import { calcTonkHandTotal, TonkOnDealCelebration } from './TonkOnDealCelebration';
+
+const card = (design: CardDesign, value: number): Card => ({ design, value });
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('calcTonkHandTotal', () => {
+  it('uses Gin-Rummy values: A=1, 2-9 face, 10/J/Q/K=10', () => {
+    const hand = [card('SPADE', 1), card('HEART', 7), card('DIAMOND', 13), card('CLOVER', 11), card('SPADE', 11)];
+    // 1 + 7 + 10 + 10 + 10 = 38 (not Tonk, but the helper is unit-tested)
+    expect(calcTonkHandTotal(hand)).toBe(38);
+  });
+
+  it('returns 50 for the classic Tonk-on-deal high case (5 face cards)', () => {
+    const hand = [card('SPADE', 13), card('HEART', 12), card('DIAMOND', 11), card('CLOVER', 13), card('SPADE', 12)];
+    expect(calcTonkHandTotal(hand)).toBe(50);
+  });
+
+  it('returns 49 for the Tonk-on-deal low case (4 face cards + 9)', () => {
+    const hand = [card('SPADE', 13), card('HEART', 12), card('DIAMOND', 11), card('CLOVER', 13), card('SPADE', 9)];
+    expect(calcTonkHandTotal(hand)).toBe(49);
+  });
+
+  it('treats Joker as 0 to be defensive against unexpected input', () => {
+    const hand = [card('JOKER', 0)];
+    expect(calcTonkHandTotal(hand)).toBe(0);
+  });
+});
+
+describe('TonkOnDealCelebration', () => {
+  it('does not render when show=false', () => {
+    render(<TonkOnDealCelebration show={false} />);
+    expect(screen.queryByTestId('tonk-on-deal-celebration')).not.toBeInTheDocument();
+  });
+
+  it('renders the TONK! banner when show=true', () => {
+    render(
+      <TonkOnDealCelebration
+        show={true}
+        winnerCards={[card('SPADE', 13), card('HEART', 12), card('DIAMOND', 11), card('CLOVER', 13), card('SPADE', 12)]}
+        winnerName="あなた"
+      />,
+    );
+    expect(screen.getByTestId('tonk-on-deal-celebration')).toBeInTheDocument();
+    expect(screen.getByText('TONK!')).toBeInTheDocument();
+    expect(screen.getByText(/50/)).toBeInTheDocument();
+    expect(screen.getByText(/あなた/)).toBeInTheDocument();
+  });
+
+  it('auto-dismisses after the configured delay', () => {
+    render(<TonkOnDealCelebration show={true} dismissAfterMs={1500} winnerCards={[card('SPADE', 13)]} />);
+    expect(screen.getByTestId('tonk-on-deal-celebration')).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(screen.queryByTestId('tonk-on-deal-celebration')).not.toBeInTheDocument();
+  });
+
+  it('keeps banner visible when dismissAfterMs=0', () => {
+    render(<TonkOnDealCelebration show={true} dismissAfterMs={0} winnerCards={[]} />);
+    vi.advanceTimersByTime(10_000);
+    expect(screen.getByTestId('tonk-on-deal-celebration')).toBeInTheDocument();
+  });
+
+  it('uses assertive aria-live so screen readers announce the win', () => {
+    render(<TonkOnDealCelebration show={true} />);
+    expect(screen.getByTestId('tonk-on-deal-celebration')).toHaveAttribute('aria-live', 'assertive');
+  });
+});

--- a/frontend/src/components/TonkOnDealCelebration.test.tsx
+++ b/frontend/src/components/TonkOnDealCelebration.test.tsx
@@ -37,9 +37,15 @@ describe('calcTonkHandTotal', () => {
 });
 
 describe('TonkOnDealCelebration', () => {
-  it('does not render when show=false', () => {
+  it('keeps the aria-live container in the DOM but hidden when show=false', () => {
     render(<TonkOnDealCelebration show={false} />);
-    expect(screen.queryByTestId('tonk-on-deal-celebration')).not.toBeInTheDocument();
+    // Container is always rendered so screen readers see a stable live region
+    // (announcements inside a region added on the same tick are often dropped).
+    const container = screen.getByTestId('tonk-on-deal-celebration');
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveAttribute('data-visible', 'false');
+    expect(container).toHaveClass('invisible');
+    expect(screen.queryByText('TONK!')).not.toBeInTheDocument();
   });
 
   it('renders the TONK! banner when show=true', () => {
@@ -50,7 +56,9 @@ describe('TonkOnDealCelebration', () => {
         winnerName="あなた"
       />,
     );
-    expect(screen.getByTestId('tonk-on-deal-celebration')).toBeInTheDocument();
+    const container = screen.getByTestId('tonk-on-deal-celebration');
+    expect(container).toHaveAttribute('data-visible', 'true');
+    expect(container).not.toHaveClass('invisible');
     expect(screen.getByText('TONK!')).toBeInTheDocument();
     expect(screen.getByText(/50/)).toBeInTheDocument();
     expect(screen.getByText(/あなた/)).toBeInTheDocument();
@@ -58,17 +66,20 @@ describe('TonkOnDealCelebration', () => {
 
   it('auto-dismisses after the configured delay', () => {
     render(<TonkOnDealCelebration show={true} dismissAfterMs={1500} winnerCards={[card('SPADE', 13)]} />);
-    expect(screen.getByTestId('tonk-on-deal-celebration')).toBeInTheDocument();
+    expect(screen.getByTestId('tonk-on-deal-celebration')).toHaveAttribute('data-visible', 'true');
     act(() => {
       vi.advanceTimersByTime(1500);
     });
-    expect(screen.queryByTestId('tonk-on-deal-celebration')).not.toBeInTheDocument();
+    // The live region remains in the DOM but is now hidden and the inner banner is gone.
+    const container = screen.getByTestId('tonk-on-deal-celebration');
+    expect(container).toHaveAttribute('data-visible', 'false');
+    expect(screen.queryByText('TONK!')).not.toBeInTheDocument();
   });
 
   it('keeps banner visible when dismissAfterMs=0', () => {
     render(<TonkOnDealCelebration show={true} dismissAfterMs={0} winnerCards={[]} />);
     vi.advanceTimersByTime(10_000);
-    expect(screen.getByTestId('tonk-on-deal-celebration')).toBeInTheDocument();
+    expect(screen.getByTestId('tonk-on-deal-celebration')).toHaveAttribute('data-visible', 'true');
   });
 
   it('uses assertive aria-live so screen readers announce the win', () => {

--- a/frontend/src/components/TonkOnDealCelebration.tsx
+++ b/frontend/src/components/TonkOnDealCelebration.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion';
-import { useEffect, useState } from 'react';
+import { type ReactElement, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useReducedMotion } from '../hooks/useReducedMotion';
 import type { Card } from '../types/card';
@@ -37,7 +37,7 @@ export function TonkOnDealCelebration({
   winnerCards = [],
   winnerName,
   dismissAfterMs = 3500,
-}: TonkOnDealCelebrationProps): JSX.Element | null {
+}: TonkOnDealCelebrationProps): ReactElement | null {
   const { t } = useTranslation('tonk');
   const reduced = useReducedMotion();
   const [visible, setVisible] = useState(false);

--- a/frontend/src/components/TonkOnDealCelebration.tsx
+++ b/frontend/src/components/TonkOnDealCelebration.tsx
@@ -55,36 +55,40 @@ export function TonkOnDealCelebration({
 
   const points = calcTonkHandTotal(winnerCards);
 
-  if (!visible) return null;
-
+  // Outer aria-live region is always present so screen readers see the
+  // announcement appear inside an existing live region instead of an entire
+  // new region popping into the DOM (the latter is silently dropped on
+  // several SR/browser combinations).
   return (
-    <motion.div
+    <div
       role="status"
       aria-live="assertive"
       data-testid="tonk-on-deal-celebration"
-      className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ duration: reduced ? 0 : 0.25 }}
+      data-visible={visible ? 'true' : 'false'}
+      className={`fixed inset-0 z-50 flex items-center justify-center pointer-events-none${visible ? '' : ' invisible'}`}
     >
-      <motion.div
-        className="px-8 py-6 rounded-2xl bg-black/80 border-2 border-ds-accent text-center shadow-2xl"
-        initial={reduced ? { scale: 1 } : { scale: 0.6, rotate: -4 }}
-        animate={{ scale: 1, rotate: 0 }}
-        transition={{ duration: reduced ? 0 : 0.45, type: 'spring', stiffness: 220, damping: 16 }}
-      >
-        <div className="text-ds-accent text-5xl sm:text-6xl font-bold tracking-widest drop-shadow">
-          {t('tonkOnDealBanner.title')}
-        </div>
-        {points > 0 && (
-          <div className="text-ds-text-primary text-xl sm:text-2xl mt-2">
-            {t('tonkOnDealBanner.points', { points })}
+      {visible && (
+        <motion.div
+          className="px-8 py-6 rounded-2xl bg-black/80 border-2 border-ds-accent text-center shadow-2xl"
+          initial={reduced ? { opacity: 1, scale: 1 } : { opacity: 0, scale: 0.6, rotate: -4 }}
+          animate={{ opacity: 1, scale: 1, rotate: 0 }}
+          transition={{ duration: reduced ? 0 : 0.45, type: 'spring', stiffness: 220, damping: 16 }}
+        >
+          <div className="text-ds-accent text-5xl sm:text-6xl font-bold tracking-widest drop-shadow">
+            {t('tonkOnDealBanner.title')}
           </div>
-        )}
-        {winnerName && (
-          <div className="text-ds-text-muted text-base mt-1">{t('tonkOnDealBanner.winner', { name: winnerName })}</div>
-        )}
-      </motion.div>
-    </motion.div>
+          {points > 0 && (
+            <div className="text-ds-text-primary text-xl sm:text-2xl mt-2">
+              {t('tonkOnDealBanner.points', { points })}
+            </div>
+          )}
+          {winnerName && (
+            <div className="text-ds-text-muted text-base mt-1">
+              {t('tonkOnDealBanner.winner', { name: winnerName })}
+            </div>
+          )}
+        </motion.div>
+      )}
+    </div>
   );
 }

--- a/frontend/src/components/TonkOnDealCelebration.tsx
+++ b/frontend/src/components/TonkOnDealCelebration.tsx
@@ -1,0 +1,90 @@
+import { motion } from 'framer-motion';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useReducedMotion } from '../hooks/useReducedMotion';
+import type { Card } from '../types/card';
+
+interface TonkOnDealCelebrationProps {
+  /** Whether the player or CPU achieved Tonk on the deal. */
+  show: boolean;
+  /** Cards that produced the Tonk total — used to compute the 49 / 50 sum displayed. */
+  winnerCards?: Card[];
+  /** Display name of the winner (e.g. translated player label). */
+  winnerName?: string;
+  /** Auto-dismiss delay in ms. Default 3500. Set to 0 to keep visible until prop flips. */
+  dismissAfterMs?: number;
+}
+
+/** Tonk uses Gin Rummy values: A=1, 2-9 face, 10/J/Q/K=10. Joker is unused for Tonk. */
+function tonkCardValue(card: Card): number {
+  if (card.design === 'JOKER') return 0;
+  if (card.value === 1) return 1;
+  if (card.value >= 10) return 10;
+  return card.value;
+}
+
+/** Sum of Gin-Rummy card values across a hand — produces 49 or 50 when Tonk-on-deal triggers. */
+export function calcTonkHandTotal(cards: Card[]): number {
+  return cards.reduce((sum, c) => sum + tonkCardValue(c), 0);
+}
+
+/**
+ * Full-screen celebratory overlay shown once when Tonk-on-deal (49/50 hand sum) triggers.
+ * Auto-dismisses after `dismissAfterMs` so the round-end UI behind it stays reachable.
+ */
+export function TonkOnDealCelebration({
+  show,
+  winnerCards = [],
+  winnerName,
+  dismissAfterMs = 3500,
+}: TonkOnDealCelebrationProps): JSX.Element | null {
+  const { t } = useTranslation('tonk');
+  const reduced = useReducedMotion();
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!show) {
+      setVisible(false);
+      return;
+    }
+    setVisible(true);
+    if (dismissAfterMs <= 0) return;
+    const timer = setTimeout(() => setVisible(false), dismissAfterMs);
+    return () => clearTimeout(timer);
+  }, [show, dismissAfterMs]);
+
+  const points = calcTonkHandTotal(winnerCards);
+
+  if (!visible) return null;
+
+  return (
+    <motion.div
+      role="status"
+      aria-live="assertive"
+      data-testid="tonk-on-deal-celebration"
+      className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: reduced ? 0 : 0.25 }}
+    >
+      <motion.div
+        className="px-8 py-6 rounded-2xl bg-black/80 border-2 border-ds-accent text-center shadow-2xl"
+        initial={reduced ? { scale: 1 } : { scale: 0.6, rotate: -4 }}
+        animate={{ scale: 1, rotate: 0 }}
+        transition={{ duration: reduced ? 0 : 0.45, type: 'spring', stiffness: 220, damping: 16 }}
+      >
+        <div className="text-ds-accent text-5xl sm:text-6xl font-bold tracking-widest drop-shadow">
+          {t('tonkOnDealBanner.title')}
+        </div>
+        {points > 0 && (
+          <div className="text-ds-text-primary text-xl sm:text-2xl mt-2">
+            {t('tonkOnDealBanner.points', { points })}
+          </div>
+        )}
+        {winnerName && (
+          <div className="text-ds-text-muted text-base mt-1">{t('tonkOnDealBanner.winner', { name: winnerName })}</div>
+        )}
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/frontend/src/i18n/locales/en/tonk.json
+++ b/frontend/src/i18n/locales/en/tonk.json
@@ -32,6 +32,11 @@
   "discardPhase": "Discard a card or knock (deadwood <= 5)",
   "roundEnd": "Round end",
   "tonkOnDeal": "Tonk on deal! Instant win",
+  "tonkOnDealBanner": {
+    "title": "TONK!",
+    "points": "{{points}} pts — instant win",
+    "winner": "{{name}} wins"
+  },
   "knockerMelds": "Knocker's melds",
   "knockerDeadwood": "Knocker's deadwood",
   "result": {

--- a/frontend/src/i18n/locales/ja/tonk.json
+++ b/frontend/src/i18n/locales/ja/tonk.json
@@ -32,6 +32,11 @@
   "discardPhase": "手札から1枚捨てるか、ノック (デッドウッド5点以下) してください",
   "roundEnd": "ラウンド終了",
   "tonkOnDeal": "配牌Tonk成立！即勝利です",
+  "tonkOnDealBanner": {
+    "title": "TONK!",
+    "points": "{{points}}点 即勝利",
+    "winner": "{{name}} の勝利"
+  },
   "knockerMelds": "ノッカーのメルド",
   "knockerDeadwood": "ノッカーのデッドウッド",
   "result": {

--- a/frontend/src/pages/TonkPage.tsx
+++ b/frontend/src/pages/TonkPage.tsx
@@ -16,6 +16,7 @@ import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { WinCelebration } from '../components/motion/WinCelebration';
 import { PhaseIndicator } from '../components/PhaseIndicator';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
+import { TonkOnDealCelebration } from '../components/TonkOnDealCelebration';
 import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -414,6 +415,11 @@ function TonkPageContent() {
         </>
       )}
       <WinCelebration show={!!state?.gameEndFlag} onCelebrate={() => playSound('winFanfare')} />
+      <TonkOnDealCelebration
+        show={!!state?.isTonk && (isRoundEnd || isGameEnd)}
+        winnerCards={state?.players[state?.winnerIdx ?? -1]?.cards ?? []}
+        winnerName={state ? playerName(state.winnerIdx, state.players[state.winnerIdx]?.isHuman ?? false) : undefined}
+      />
       <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
     </div>
   );

--- a/frontend/src/pages/TonkPage.tsx
+++ b/frontend/src/pages/TonkPage.tsx
@@ -415,11 +415,21 @@ function TonkPageContent() {
         </>
       )}
       <WinCelebration show={!!state?.gameEndFlag} onCelebrate={() => playSound('winFanfare')} />
-      <TonkOnDealCelebration
-        show={!!state?.isTonk && (isRoundEnd || isGameEnd)}
-        winnerCards={state?.players[state?.winnerIdx ?? -1]?.cards ?? []}
-        winnerName={state ? playerName(state.winnerIdx, state.players[state.winnerIdx]?.isHuman ?? false) : undefined}
-      />
+      {(() => {
+        // Tonk-on-deal sets winnerIdx >= 0; guard defensively so we never index
+        // players[-1] (which would surface as "CPU 0 wins" via playerName).
+        const winner =
+          state && state.winnerIdx >= 0 && state.winnerIdx < state.players.length
+            ? state.players[state.winnerIdx]
+            : undefined;
+        return (
+          <TonkOnDealCelebration
+            show={!!state?.isTonk && (isRoundEnd || isGameEnd) && winner !== undefined}
+            winnerCards={winner?.cards ?? []}
+            winnerName={winner ? playerName(winner.id, winner.isHuman) : undefined}
+          />
+        );
+      })()}
       <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
     </div>
   );


### PR DESCRIPTION
## Summary
- Adds \`TonkOnDealCelebration\` overlay shown for ~3.5s when the initial 5-card deal sums to 49/50 (instant-win edge case).
- Big \`TONK!\` title + computed point total + winner name; fades in/scales with framer-motion, announces via \`aria-live="assertive"\`.
- Pure unit util \`calcTonkHandTotal\` (Gin-Rummy values: A=1, 2-9 face, 10/J/Q/K=10, Joker=0).

## Test plan
- [x] \`bun run test -- --run TonkOnDealCelebration\` (9/9 pass: util math, render gating, auto-dismiss, aria-live)
- [x] \`bun run check\` (Biome + design-tokens clean)
- [x] \`bunx tsc --noEmit\` (clean)
- [ ] Frontend build verified via GH Actions (local OOM)

Closes #1664