### PR TITLE
feat(pokersquares): cross-highlight row+col on cell hover

### DIFF
--- a/frontend/src/pages/PokerSquaresPage.test.tsx
+++ b/frontend/src/pages/PokerSquaresPage.test.tsx
@@ -212,6 +212,60 @@ describe('PokerSquaresPage', () => {
     expect(screen.getByTestId('col-score-4')).toHaveTextContent('8');
   });
 
+  it('cross-highlights the row, column, and matching score badges when an empty cell is hovered', async () => {
+    mockApi.mockResolvedValue(playingState);
+    renderWithProviders(<PokerSquaresPage />);
+    await waitFor(() => expect(screen.getByTestId('cell-2-3')).toBeInTheDocument());
+
+    fireEvent.pointerEnter(screen.getByTestId('cell-2-3'));
+
+    // Hovered cell + every cell in row 2 and col 3 should carry the cross-hover marker.
+    expect(screen.getByTestId('cell-2-3')).toHaveAttribute('data-cross-hover', 'true');
+    expect(screen.getByTestId('cell-2-0')).toHaveAttribute('data-cross-hover', 'true');
+    expect(screen.getByTestId('cell-0-3')).toHaveAttribute('data-cross-hover', 'true');
+    expect(screen.getByTestId('cell-4-3')).toHaveAttribute('data-cross-hover', 'true');
+    // A cell off the cross stays unmarked.
+    expect(screen.getByTestId('cell-0-0')).not.toHaveAttribute('data-cross-hover');
+
+    // Score badges for the hovered line should highlight; others should not.
+    expect(screen.getByTestId('row-score-2')).toHaveAttribute('data-cross-hover', 'true');
+    expect(screen.getByTestId('col-score-3')).toHaveAttribute('data-cross-hover', 'true');
+    expect(screen.getByTestId('row-score-0')).not.toHaveAttribute('data-cross-hover');
+    expect(screen.getByTestId('col-score-0')).not.toHaveAttribute('data-cross-hover');
+  });
+
+  it('clears cross-highlight when the pointer leaves the cell', async () => {
+    mockApi.mockResolvedValue(playingState);
+    renderWithProviders(<PokerSquaresPage />);
+    await waitFor(() => expect(screen.getByTestId('cell-1-1')).toBeInTheDocument());
+
+    const cell = screen.getByTestId('cell-1-1');
+    fireEvent.pointerEnter(cell);
+    expect(cell).toHaveAttribute('data-cross-hover', 'true');
+    fireEvent.pointerLeave(cell);
+    expect(cell).not.toHaveAttribute('data-cross-hover');
+    expect(screen.getByTestId('row-score-1')).not.toHaveAttribute('data-cross-hover');
+  });
+
+  it('does not cross-highlight when hovering a filled cell', async () => {
+    const filledState: PokerSquaresResponse = {
+      ...playingState,
+      board: (() => {
+        const b = emptyBoard();
+        b[0][0] = { card: card('HEART', 13) };
+        return b;
+      })(),
+      placedCount: 1,
+    };
+    mockApi.mockResolvedValue(filledState);
+    renderWithProviders(<PokerSquaresPage />);
+    await waitFor(() => expect(screen.getByTestId('cell-0-0')).toBeInTheDocument());
+
+    fireEvent.pointerEnter(screen.getByTestId('cell-0-0'));
+    expect(screen.getByTestId('cell-0-0')).not.toHaveAttribute('data-cross-hover');
+    expect(screen.getByTestId('row-score-0')).not.toHaveAttribute('data-cross-hover');
+  });
+
   it('renders the CLI terminal when CLI mode is enabled', async () => {
     mockUseCliMode.mockReturnValue({
       cliEnabled: true,

--- a/frontend/src/pages/PokerSquaresPage.tsx
+++ b/frontend/src/pages/PokerSquaresPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { pokersquaresApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -94,6 +94,19 @@ function PokerSquaresPageContent() {
   // and the corresponding row/col score badges so they can preview which lines a placement affects.
   const [crossHover, setCrossHover] = useState<{ row: number; col: number } | null>(null);
   const clearCrossHover = useCallback(() => setCrossHover(null), []);
+
+  // Disabled buttons do not always fire pointerleave/blur, so the hover state can get stuck after
+  // a click (cell becomes filled) or while an API call is in flight. Clear defensively whenever
+  // the loading flag flips on or the hovered cell becomes filled by the latest server state.
+  useEffect(() => {
+    if (loading) {
+      setCrossHover(null);
+      return;
+    }
+    if (crossHover && state?.board[crossHover.row]?.[crossHover.col]?.card) {
+      setCrossHover(null);
+    }
+  }, [loading, state?.board, crossHover]);
 
   const handlePlace = (row: number, col: number) => {
     execApi('place', row, col);

--- a/frontend/src/pages/PokerSquaresPage.tsx
+++ b/frontend/src/pages/PokerSquaresPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { pokersquaresApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -90,6 +90,11 @@ function PokerSquaresPageContent() {
   const isComplete = state?.phase === PokerSquaresPhase.COMPLETE;
   const isPlaying = state?.phase === PokerSquaresPhase.PLAYING;
 
+  // Cross-highlight: while the player hovers/focuses an empty cell, highlight its row + column
+  // and the corresponding row/col score badges so they can preview which lines a placement affects.
+  const [crossHover, setCrossHover] = useState<{ row: number; col: number } | null>(null);
+  const clearCrossHover = useCallback(() => setCrossHover(null), []);
+
   const handlePlace = (row: number, col: number) => {
     execApi('place', row, col);
   };
@@ -174,20 +179,27 @@ function PokerSquaresPageContent() {
                             const cellAction = `cell-${rowIdx}-${colIdx}`;
                             const isHintTarget =
                               frontendHintEnabled && frontendHint?.targetAction === cellAction && !filled;
+                            const inCross =
+                              crossHover !== null && (crossHover.row === rowIdx || crossHover.col === colIdx);
                             return (
                               <button
                                 type="button"
                                 key={`cell-${rowIdx}-${colIdx}`}
                                 data-testid={`cell-${rowIdx}-${colIdx}`}
                                 data-hint-action={cellAction}
+                                data-cross-hover={inCross ? 'true' : undefined}
                                 aria-label={
                                   cell.card ? cardAlt(cell.card) : `${t('label.empty')} ${rowIdx + 1}-${colIdx + 1}`
                                 }
                                 onClick={() => handlePlace(rowIdx, colIdx)}
+                                onPointerEnter={() => !filled && setCrossHover({ row: rowIdx, col: colIdx })}
+                                onPointerLeave={clearCrossHover}
+                                onFocus={() => !filled && setCrossHover({ row: rowIdx, col: colIdx })}
+                                onBlur={clearCrossHover}
                                 disabled={!isPlaying || loading || filled || !state.currentCard}
                                 className={`p-0 border-0 bg-transparent rounded ${focusRingWhite} ${
                                   filled ? '' : 'cursor-pointer'
-                                } ${isHintTarget ? 'ring-2 ring-ds-warning' : ''}`}
+                                } ${isHintTarget ? 'ring-2 ring-ds-warning' : ''}${inCross ? ' bg-white/10' : ''}`}
                               >
                                 {cell.card ? (
                                   <AnimatedCard card={cell.card} width={cardWidth} />
@@ -197,7 +209,9 @@ function PokerSquaresPageContent() {
                                       width: cardWidth,
                                       height: Math.round(cardWidth * 1.4),
                                     }}
-                                    className="rounded border-2 border-dashed border-white/30 flex items-center justify-center text-game-text-muted text-xs"
+                                    className={`rounded border-2 border-dashed flex items-center justify-center text-game-text-muted text-xs ${
+                                      inCross ? 'border-ds-accent' : 'border-white/30'
+                                    }`}
                                   >
                                     +
                                   </div>
@@ -213,16 +227,24 @@ function PokerSquaresPageContent() {
                         data-testid="ps-row-scores"
                         data-tutorial="ps-scores"
                       >
-                        {state.rowScores.map((s, i) => (
-                          <div
-                            key={`row-score-${i}`}
-                            data-testid={`row-score-${i}`}
-                            style={{ height: Math.round(cardWidth * 1.4) }}
-                            className="flex items-center justify-center text-ds-text-primary text-sm font-mono px-2 rounded bg-black/30 min-w-[2.5rem]"
-                          >
-                            {s}
-                          </div>
-                        ))}
+                        {state.rowScores.map((s, i) => {
+                          const highlighted = crossHover?.row === i;
+                          return (
+                            <div
+                              key={`row-score-${i}`}
+                              data-testid={`row-score-${i}`}
+                              data-cross-hover={highlighted ? 'true' : undefined}
+                              style={{ height: Math.round(cardWidth * 1.4) }}
+                              className={`flex items-center justify-center text-sm font-mono px-2 rounded min-w-[2.5rem] ${
+                                highlighted
+                                  ? 'text-ds-accent bg-ds-accent/15 ring-1 ring-ds-accent'
+                                  : 'text-ds-text-primary bg-black/30'
+                              }`}
+                            >
+                              {s}
+                            </div>
+                          );
+                        })}
                       </div>
                     </div>
                     <div
@@ -230,16 +252,24 @@ function PokerSquaresPageContent() {
                       style={{ gridTemplateColumns: `repeat(5, minmax(0, 1fr))` }}
                       data-testid="ps-col-scores"
                     >
-                      {state.colScores.map((s, i) => (
-                        <div
-                          key={`col-score-${i}`}
-                          data-testid={`col-score-${i}`}
-                          style={{ width: cardWidth }}
-                          className="text-center text-ds-text-primary text-sm font-mono py-1 rounded bg-black/30"
-                        >
-                          {s}
-                        </div>
-                      ))}
+                      {state.colScores.map((s, i) => {
+                        const highlighted = crossHover?.col === i;
+                        return (
+                          <div
+                            key={`col-score-${i}`}
+                            data-testid={`col-score-${i}`}
+                            data-cross-hover={highlighted ? 'true' : undefined}
+                            style={{ width: cardWidth }}
+                            className={`text-center text-sm font-mono py-1 rounded ${
+                              highlighted
+                                ? 'text-ds-accent bg-ds-accent/15 ring-1 ring-ds-accent'
+                                : 'text-ds-text-primary bg-black/30'
+                            }`}
+                          >
+                            {s}
+                          </div>
+                        );
+                      })}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Hover/focus on an empty cell in the 5x5 grid now highlights every cell on its row + column, plus the matching row-score and col-score badges. Filled cells are inert.
- Pointer-enter/leave plus focus/blur cover desktop, keyboard, and mobile-tap selection.
- New \`data-cross-hover\` attribute drives the styling and is the assertion target in tests.

## Test plan
- [x] \`bun run test -- --run PokerSquaresPage\` (17/17 pass; 3 new: cell+score highlight on hover, clears on leave, filled cell stays inert)
- [x] \`bun run check\` clean
- [x] \`bunx tsc --noEmit\` clean
- [ ] Frontend build via GH Actions (local OOM)

Closes #1665