### PR TITLE
feat(badugi): protect completed 4-card Badugi from accidental dismantling

### DIFF
--- a/frontend/src/i18n/locales/en/badugi.json
+++ b/frontend/src/i18n/locales/en/badugi.json
@@ -13,6 +13,7 @@
   "exchangeInstruction": "Click the cards you want to exchange, then press Exchange or Stand.",
   "exchangeLabel": "Exchange",
   "standLabel": "Stand pat",
+  "completeBadugiBanner": "✨ Badugi complete — stand pat recommended",
   "cpuExchange": "CPU draws:",
   "cpuExchangeEntry": "Player {{idx}} (draw {{draw}}): exchanged {{count}}",
   "exchangeCount": "Drew: {{count}}",

--- a/frontend/src/i18n/locales/ja/badugi.json
+++ b/frontend/src/i18n/locales/ja/badugi.json
@@ -13,6 +13,7 @@
   "exchangeInstruction": "交換したいカードをクリックして選択し、「交換」または「スタンド」を押してください。",
   "exchangeLabel": "交換",
   "standLabel": "スタンド (交換なし)",
+  "completeBadugiBanner": "✨ バドゥーギ完成！スタンドパット推奨",
   "cpuExchange": "CPUドロー:",
   "cpuExchangeEntry": "Player {{idx}} (draw {{draw}}): {{count}}枚交換",
   "exchangeCount": "交換: {{count}}枚",

--- a/frontend/src/pages/BadugiPage.test.tsx
+++ b/frontend/src/pages/BadugiPage.test.tsx
@@ -185,6 +185,44 @@ describe('BadugiPage', () => {
     );
   });
 
+  it('shows the complete-Badugi banner and pulses the stand button when the hand is already a 4-card Badugi', async () => {
+    // The default humanPlayer() has 4 distinct ranks AND 4 distinct suits → complete Badugi.
+    mockExec.mockResolvedValue(baseState({ phase: BadugiPhase.DRAW, drawIndex: 1, currentTurn: 0 }));
+    renderWithProviders(<BadugiPage />);
+    await waitFor(() => expect(screen.getByTestId('bg-stand-btn')).toBeInTheDocument());
+
+    expect(screen.getByTestId('bg-complete-badugi-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('bg-stand-btn').className).toContain('animate-pulse');
+  });
+
+  it('hides the banner and skips the pulse when the hand is incomplete (suit dupe)', async () => {
+    mockExec.mockResolvedValue(
+      baseState({
+        phase: BadugiPhase.DRAW,
+        drawIndex: 1,
+        currentTurn: 0,
+        players: [
+          humanPlayer({
+            cards: [
+              { design: 'SPADE', value: 1 },
+              { design: 'SPADE', value: 2 },
+              { design: 'DIAMOND', value: 3 },
+              { design: 'CLOVER', value: 4 },
+            ],
+          }),
+          cpuPlayer(1),
+          cpuPlayer(2),
+          cpuPlayer(3),
+        ],
+      }),
+    );
+    renderWithProviders(<BadugiPage />);
+    await waitFor(() => expect(screen.getByTestId('bg-stand-btn')).toBeInTheDocument());
+
+    expect(screen.queryByTestId('bg-complete-badugi-banner')).not.toBeInTheDocument();
+    expect(screen.getByTestId('bg-stand-btn').className).not.toContain('animate-pulse');
+  });
+
   it('marks a selected card as pressed in draw phase', async () => {
     mockExec.mockResolvedValue(baseState({ phase: BadugiPhase.DRAW, drawIndex: 1, currentTurn: 0 }));
     renderWithProviders(<BadugiPage />);

--- a/frontend/src/pages/BadugiPage.tsx
+++ b/frontend/src/pages/BadugiPage.tsx
@@ -163,7 +163,11 @@ function BadugiPageContent() {
   const cpuPlayers = useMemo(() => state?.players?.filter((p) => !p.isHuman) ?? [], [state?.players]);
   // Stand-pat protection: warn the player when their 4 cards are already a complete Badugi
   // (4 distinct ranks + 4 distinct suits). Exchanging from this state can only weaken the hand.
-  const humanHasCompleteBadugi = isCompleteBadugiHand(humanPlayer?.cards ?? []);
+  // Memoised so the Set allocations only run when the hand actually changes.
+  const humanHasCompleteBadugi = useMemo(
+    () => (canExchange ? isCompleteBadugiHand(humanPlayer?.cards ?? []) : false),
+    [canExchange, humanPlayer?.cards],
+  );
 
   useCardKeyboardNav({
     cardCount,

--- a/frontend/src/pages/BadugiPage.tsx
+++ b/frontend/src/pages/BadugiPage.tsx
@@ -40,6 +40,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { BadugiResponse } from '../types/card';
 import { BadugiPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { isCompleteBadugiHand } from '../utils/badugiUtils';
 import { cardAlt } from '../utils/cardAlt';
 import { BADUGI_HELP, parseBadugiCommand } from '../utils/cli/commands/badugiCommands';
 import { formatBadugiState } from '../utils/cli/formatters/badugiFormatter';
@@ -160,6 +161,9 @@ function BadugiPageContent() {
   const minRaise = state?.minRaise ?? 10;
   const cardCount = humanPlayer?.cards?.length ?? 0;
   const cpuPlayers = useMemo(() => state?.players?.filter((p) => !p.isHuman) ?? [], [state?.players]);
+  // Stand-pat protection: warn the player when their 4 cards are already a complete Badugi
+  // (4 distinct ranks + 4 distinct suits). Exchanging from this state can only weaken the hand.
+  const humanHasCompleteBadugi = isCompleteBadugiHand(humanPlayer?.cards ?? []);
 
   useCardKeyboardNav({
     cardCount,
@@ -361,19 +365,33 @@ function BadugiPageContent() {
             {/* Exchange controls */}
             {canExchange && (
               <div className="text-center mb-2" data-tutorial="bg-exchange-button">
+                {humanHasCompleteBadugi && (
+                  <div
+                    role="status"
+                    aria-live="polite"
+                    data-testid="bg-complete-badugi-banner"
+                    className="mb-2 inline-block px-3 py-1 rounded bg-ds-accent/15 border border-ds-accent text-ds-accent text-sm font-bold"
+                  >
+                    {t('completeBadugiBanner')}
+                  </div>
+                )}
                 <button
                   type="button"
                   className={`${btnWarning} min-w-[90px]`}
                   disabled={loading}
                   onClick={() => execAction('exchange', selected)}
+                  data-testid="bg-exchange-btn"
                 >
                   {t('exchangeLabel')}
                 </button>
                 <button
                   type="button"
-                  className={`${btnSuccess} min-w-[90px]`}
+                  className={`${btnSuccess} min-w-[90px]${
+                    humanHasCompleteBadugi ? ' ring-2 ring-ds-accent animate-pulse' : ''
+                  }`}
                   disabled={loading}
                   onClick={() => execAction('stand')}
+                  data-testid="bg-stand-btn"
                 >
                   {t('standLabel')}
                 </button>

--- a/frontend/src/utils/badugiUtils.test.ts
+++ b/frontend/src/utils/badugiUtils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign } from '../types/card';
+import { isCompleteBadugiHand } from './badugiUtils';
+
+const card = (design: CardDesign, value: number): Card => ({ design, value });
+
+describe('isCompleteBadugiHand', () => {
+  it('returns true when all 4 ranks and all 4 suits differ', () => {
+    expect(isCompleteBadugiHand([card('SPADE', 1), card('HEART', 2), card('DIAMOND', 3), card('CLOVER', 4)])).toBe(
+      true,
+    );
+  });
+
+  it('returns false when two cards share a rank', () => {
+    expect(isCompleteBadugiHand([card('SPADE', 1), card('HEART', 1), card('DIAMOND', 3), card('CLOVER', 4)])).toBe(
+      false,
+    );
+  });
+
+  it('returns false when two cards share a suit', () => {
+    expect(isCompleteBadugiHand([card('SPADE', 1), card('SPADE', 2), card('DIAMOND', 3), card('CLOVER', 4)])).toBe(
+      false,
+    );
+  });
+
+  it('returns false when fewer than 4 cards are supplied', () => {
+    expect(isCompleteBadugiHand([card('SPADE', 1), card('HEART', 2), card('DIAMOND', 3)])).toBe(false);
+  });
+
+  it('returns false when more than 4 cards are supplied', () => {
+    expect(
+      isCompleteBadugiHand([
+        card('SPADE', 1),
+        card('HEART', 2),
+        card('DIAMOND', 3),
+        card('CLOVER', 4),
+        card('SPADE', 5),
+      ]),
+    ).toBe(false);
+  });
+
+  it('returns false when a Joker appears (Badugi is jokerless)', () => {
+    expect(isCompleteBadugiHand([card('JOKER', 0), card('HEART', 2), card('DIAMOND', 3), card('CLOVER', 4)])).toBe(
+      false,
+    );
+  });
+});

--- a/frontend/src/utils/badugiUtils.ts
+++ b/frontend/src/utils/badugiUtils.ts
@@ -1,0 +1,19 @@
+import type { Card } from '../types/card';
+
+/**
+ * Returns true when a 4-card Badugi hand is "complete" — all four cards have
+ * different ranks AND different suits. This is the strongest possible Badugi
+ * shape; exchanging any card can only make it weaker, so the UI surfaces a
+ * stand-pat suggestion when this returns true.
+ */
+export function isCompleteBadugiHand(cards: ReadonlyArray<Card>): boolean {
+  if (cards.length !== 4) return false;
+  const ranks = new Set<number>();
+  const suits = new Set<string>();
+  for (const c of cards) {
+    if (c.design === 'JOKER') return false;
+    ranks.add(c.value);
+    suits.add(c.design);
+  }
+  return ranks.size === 4 && suits.size === 4;
+}

--- a/frontend/src/utils/badugiUtils.ts
+++ b/frontend/src/utils/badugiUtils.ts
@@ -12,8 +12,9 @@ export function isCompleteBadugiHand(cards: ReadonlyArray<Card>): boolean {
   const suits = new Set<string>();
   for (const c of cards) {
     if (c.design === 'JOKER') return false;
+    if (ranks.has(c.value) || suits.has(c.design)) return false;
     ranks.add(c.value);
     suits.add(c.design);
   }
-  return ranks.size === 4 && suits.size === 4;
+  return true;
 }


### PR DESCRIPTION
## Summary
- New \`isCompleteBadugiHand\` util detects a 4-card hand with 4 distinct ranks and 4 distinct suits.
- \`BadugiPage\` shows a 'Stand pat recommended' banner during the draw phase whenever the human's hand is already a complete Badugi, and adds a pulsing accent ring on the Stand button so it reads as the obvious next move.
- Exchange remains clickable for advanced players who actually want to deviate.

## Test plan
- [x] \`bun run test -- --run badugiUtils\` (6/6: 4 distinct, suit dupe, rank dupe, wrong card count, joker reject)
- [x] \`bun run test -- --run BadugiPage\` (14/14: existing tests + 2 new — banner + pulse for complete hand, none for incomplete)
- [x] \`bun run check\` clean
- [x] \`bunx tsc --noEmit\` clean
- [ ] Frontend build via GH Actions (local OOM)

Closes #1667