### PR TITLE
feat(pageone): triple-up the 'one card left' visual + a11y cue

### DIFF
--- a/frontend/src/i18n/locales/en/pageone.json
+++ b/frontend/src/i18n/locales/en/pageone.json
@@ -29,6 +29,8 @@
   "skipButton": "Skip (Penalty)",
   "nextRound": "Next Round",
   "declaredBadge": "PAGE ONE!",
+  "lastCardBanner": "⚠ Only 1 card left — don't forget to declare Page One!",
+  "cpuLastCardBadge": "⚠ 1 card left",
   "playPhase": "Play a card or draw from the pile",
   "mustDeclarePhase": "Only 1 card left! Declare Page One!",
   "roundEnd": "Round over",

--- a/frontend/src/i18n/locales/ja/pageone.json
+++ b/frontend/src/i18n/locales/ja/pageone.json
@@ -29,6 +29,8 @@
   "skipButton": "スキップ（ペナルティ）",
   "nextRound": "次のラウンド",
   "declaredBadge": "PAGE ONE!",
+  "lastCardBanner": "⚠ 残り1枚！ページワン宣言を忘れずに",
+  "cpuLastCardBadge": "⚠ 残り1枚",
   "playPhase": "カードを出すか、山札から引いてください",
   "mustDeclarePhase": "手札が残り1枚です！「ページワン！」と宣言してください",
   "roundEnd": "ラウンド終了",

--- a/frontend/src/pages/PageOnePage.test.tsx
+++ b/frontend/src/pages/PageOnePage.test.tsx
@@ -149,6 +149,57 @@ describe('PageOnePage', () => {
     await waitFor(() => expect(screen.getByText('スコア')).toBeInTheDocument());
   });
 
+  it('shows the last-card warning banner when the human is at 1 undeclared card during play', async () => {
+    const oneCardPlayState: PageOneResponse = {
+      ...playPhaseState,
+      players: [
+        { ...playPhaseState.players[0], cardCount: 1, cards: [{ design: 'SPADE', value: 1 }] },
+        ...playPhaseState.players.slice(1),
+      ],
+    };
+    mockExec.mockResolvedValue(oneCardPlayState);
+    renderWithProviders(<PageOnePage />);
+    await waitFor(() => expect(screen.getByTestId('po-last-card-banner')).toBeInTheDocument());
+    expect(screen.getByTestId('po-last-card-banner')).toHaveAttribute('aria-live', 'assertive');
+  });
+
+  it('hides the last-card banner once the human has declared', async () => {
+    const declaredState: PageOneResponse = {
+      ...playPhaseState,
+      players: [
+        { ...playPhaseState.players[0], cardCount: 1, cards: [{ design: 'SPADE', value: 1 }], hasDeclared: true },
+        ...playPhaseState.players.slice(1),
+      ],
+    };
+    mockExec.mockResolvedValue(declaredState);
+    renderWithProviders(<PageOnePage />);
+    await waitFor(() => expect(screen.getByText('スコア')).toBeInTheDocument());
+    expect(screen.queryByTestId('po-last-card-banner')).not.toBeInTheDocument();
+  });
+
+  it('pulses the declare button when the human must declare', async () => {
+    mockExec.mockResolvedValue(mustDeclareState);
+    renderWithProviders(<PageOnePage />);
+    await waitFor(() => expect(screen.getByTestId('po-declare-btn')).toBeInTheDocument());
+    expect(screen.getByTestId('po-declare-btn').className).toContain('animate-pulse');
+  });
+
+  it('highlights a CPU at 1 card with the warning badge', async () => {
+    const cpuOneCardState: PageOneResponse = {
+      ...playPhaseState,
+      players: [
+        playPhaseState.players[0],
+        { ...playPhaseState.players[1], cardCount: 1 },
+        playPhaseState.players[2],
+        playPhaseState.players[3],
+      ],
+    };
+    mockExec.mockResolvedValue(cpuOneCardState);
+    renderWithProviders(<PageOnePage />);
+    await waitFor(() => expect(screen.getByTestId('po-cpu-1-last-card-badge')).toBeInTheDocument());
+    expect(screen.queryByTestId('po-cpu-2-last-card-badge')).not.toBeInTheDocument();
+  });
+
   it('shows 次のゲーム at game-end and fires reset directly (no confirm)', async () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<PageOnePage />);

--- a/frontend/src/pages/PageOnePage.tsx
+++ b/frontend/src/pages/PageOnePage.tsx
@@ -158,8 +158,10 @@ function PageOnePageContent() {
   const isHumanTurn = isPlayPhase && state.players[state.currentPlayerIdx]?.isHuman === true;
   const isHumanMustDeclare = isMustDeclare && state.players[state.currentPlayerIdx]?.isHuman === true;
   // Last-card alert: easy to miss the "Page One!" declaration window without strong feedback.
-  const humanAtOneCard = (humanPlayer?.cards.length ?? 0) === 1 && !humanPlayer?.hasDeclared;
-  const showLastCardBanner = !isGameEnd && !isRoundEnd && humanAtOneCard;
+  // Use cardCount for both human + CPU so the "1 card left" check stays consistent across roles.
+  const isGameActive = !isGameEnd && !isRoundEnd;
+  const humanAtOneCard = (humanPlayer?.cardCount ?? 0) === 1 && !humanPlayer?.hasDeclared;
+  const showLastCardBanner = isGameActive && humanAtOneCard;
 
   return (
     <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.pageone.bg}`} aria-busy={loading}>
@@ -249,13 +251,13 @@ function PageOnePageContent() {
                 {state.players
                   .filter((p) => !p.isHuman)
                   .map((p) => {
-                    const cpuAtOne = p.cardCount === 1 && !p.hasDeclared && !isRoundEnd && !isGameEnd;
+                    const cpuAtOne = p.cardCount === 1 && !p.hasDeclared && isGameActive;
                     return (
                       <div
                         key={p.id}
                         data-testid={`po-cpu-${p.id}`}
                         className={`mb-2 p-2 rounded ${
-                          cpuAtOne ? 'bg-ds-warning/15 ring-1 ring-ds-warning' : 'bg-black/30'
+                          cpuAtOne ? 'bg-ds-warning/15 ring-2 ring-ds-warning' : 'bg-black/30'
                         }`}
                       >
                         <div className="text-ds-text-muted text-sm">
@@ -266,8 +268,12 @@ function PageOnePageContent() {
                           {cpuAtOne && (
                             <span
                               data-testid={`po-cpu-${p.id}-last-card-badge`}
-                              className="ml-2 inline-block px-2 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs font-bold animate-pulse"
+                              className="ml-2 inline-flex items-center gap-1 px-2 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs font-bold"
                             >
+                              <span
+                                aria-hidden="true"
+                                className="inline-block w-2 h-2 rounded-full bg-ds-warning animate-pulse"
+                              />
                               {t('cpuLastCardBadge')}
                             </span>
                           )}
@@ -309,8 +315,9 @@ function PageOnePageContent() {
                 role="alert"
                 aria-live="assertive"
                 data-testid="po-last-card-banner"
-                className="mb-2 px-3 py-2 rounded bg-ds-warning/20 border border-ds-warning text-ds-warning text-sm font-bold animate-pulse"
+                className="mb-2 px-3 py-2 rounded bg-ds-warning/20 border-2 border-ds-warning text-ds-warning text-sm font-bold flex items-center gap-2"
               >
+                <span aria-hidden="true" className="inline-block w-2 h-2 rounded-full bg-ds-warning animate-pulse" />
                 {t('lastCardBanner')}
               </div>
             )}

--- a/frontend/src/pages/PageOnePage.tsx
+++ b/frontend/src/pages/PageOnePage.tsx
@@ -157,6 +157,9 @@ function PageOnePageContent() {
   const isGameEnd = state.phase === PageOnePhase.GAME_END || state.gameEndFlag;
   const isHumanTurn = isPlayPhase && state.players[state.currentPlayerIdx]?.isHuman === true;
   const isHumanMustDeclare = isMustDeclare && state.players[state.currentPlayerIdx]?.isHuman === true;
+  // Last-card alert: easy to miss the "Page One!" declaration window without strong feedback.
+  const humanAtOneCard = (humanPlayer?.cards.length ?? 0) === 1 && !humanPlayer?.hasDeclared;
+  const showLastCardBanner = !isGameEnd && !isRoundEnd && humanAtOneCard;
 
   return (
     <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.pageone.bg}`} aria-busy={loading}>
@@ -245,16 +248,33 @@ function PageOnePageContent() {
               <div>
                 {state.players
                   .filter((p) => !p.isHuman)
-                  .map((p) => (
-                    <div key={p.id} className="mb-2 p-2 rounded bg-black/30">
-                      <div className="text-ds-text-muted text-sm">
-                        {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
-                        {t('cumulativeScore', { score: p.cumulativeScore })} |{' '}
-                        {t('roundScore', { score: p.roundScore })}
-                        {p.hasDeclared ? ` • ${t('declaredBadge')}` : ''}
+                  .map((p) => {
+                    const cpuAtOne = p.cardCount === 1 && !p.hasDeclared && !isRoundEnd && !isGameEnd;
+                    return (
+                      <div
+                        key={p.id}
+                        data-testid={`po-cpu-${p.id}`}
+                        className={`mb-2 p-2 rounded ${
+                          cpuAtOne ? 'bg-ds-warning/15 ring-1 ring-ds-warning' : 'bg-black/30'
+                        }`}
+                      >
+                        <div className="text-ds-text-muted text-sm">
+                          {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
+                          {t('cumulativeScore', { score: p.cumulativeScore })} |{' '}
+                          {t('roundScore', { score: p.roundScore })}
+                          {p.hasDeclared ? ` • ${t('declaredBadge')}` : ''}
+                          {cpuAtOne && (
+                            <span
+                              data-testid={`po-cpu-${p.id}-last-card-badge`}
+                              className="ml-2 inline-block px-2 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs font-bold animate-pulse"
+                            >
+                              {t('cpuLastCardBadge')}
+                            </span>
+                          )}
+                        </div>
                       </div>
-                    </div>
-                  ))}
+                    );
+                  })}
 
                 <div className="my-3 p-2 rounded bg-black/30">
                   <div className="text-ds-text-muted text-sm mb-1">{t('scores')}</div>
@@ -284,6 +304,16 @@ function PageOnePageContent() {
           </div>
 
           <GameFooter className={`${gameTheme.pageone.footer} px-4 py-2.5`}>
+            {showLastCardBanner && (
+              <div
+                role="alert"
+                aria-live="assertive"
+                data-testid="po-last-card-banner"
+                className="mb-2 px-3 py-2 rounded bg-ds-warning/20 border border-ds-warning text-ds-warning text-sm font-bold animate-pulse"
+              >
+                {t('lastCardBanner')}
+              </div>
+            )}
             {humanPlayer && (
               <div className="flex flex-wrap gap-1 mb-2" data-tutorial="po-player-hand">
                 {humanPlayer.cards.map((card, idx) => (
@@ -336,7 +366,13 @@ function PageOnePageContent() {
               )}
               {isHumanMustDeclare && (
                 <div className="flex gap-2" data-tutorial="po-declare">
-                  <button type="button" className={btnSuccess} onClick={handleDeclare} disabled={loading}>
+                  <button
+                    type="button"
+                    className={`${btnSuccess} ring-2 ring-ds-warning animate-pulse`}
+                    onClick={handleDeclare}
+                    disabled={loading}
+                    data-testid="po-declare-btn"
+                  >
                     {t('declareButton')}
                   </button>
                   <button type="button" className={btnWarning} onClick={handleSkipDeclare} disabled={loading}>


### PR DESCRIPTION
## Summary
- Sticky banner above the player's hand whenever they hold one undeclared card (role=alert, aria-live=assertive).
- Pulsing accent ring on the Page One! button during the must-declare phase.
- Per-CPU warning badge highlighting opponents who are also down to one card.

## Test plan
- [x] \`bun run test -- --run PageOnePage\` (15/15: existing + 4 new — banner appears, banner hidden after declaration, declare button pulses, CPU badge appears only on the right opponent)
- [x] \`bun run check\` clean
- [x] \`bunx tsc --noEmit\` clean
- [ ] Frontend build via GH Actions

Closes #1656