### PR TITLE
feat(crazyeights): inline suit prompt after playing an 8 in CUI

### DIFF
--- a/internal/adapter/controller/CrazyEightsCuiController.go
+++ b/internal/adapter/controller/CrazyEightsCuiController.go
@@ -9,6 +9,16 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
+// CrazyEightsCuiController クレイジーエイトCUIコントローラークラス
+type CrazyEightsCuiController struct {
+	ci usecase.CrazyEightsInteractorIF
+}
+
+// NewCrazyEightsCuiController コンストラクタ
+func NewCrazyEightsCuiController(ci usecase.CrazyEightsInteractorIF) *CrazyEightsCuiController {
+	return &CrazyEightsCuiController{ci: ci}
+}
+
 // playWithSuitPrompt runs Play(idx) and, when the human just played an 8
 // (game is now waiting for a suit choice), inlines a follow-up suit prompt so
 // the user does not have to type "s <n>" on a separate line. The presenter
@@ -20,16 +30,6 @@ func (c *CrazyEightsCuiController) playWithSuitPrompt(cardIndex int) string {
 		return cuiutil.PromptRequest(i18n.T("crazyeights.promptSuit"), "s {0}")
 	}
 	return res
-}
-
-// CrazyEightsCuiController クレイジーエイトCUIコントローラークラス
-type CrazyEightsCuiController struct {
-	ci usecase.CrazyEightsInteractorIF
-}
-
-// NewCrazyEightsCuiController コンストラクタ
-func NewCrazyEightsCuiController(ci usecase.CrazyEightsInteractorIF) *CrazyEightsCuiController {
-	return &CrazyEightsCuiController{ci: ci}
 }
 
 // Exec コマンド実行

--- a/internal/adapter/controller/CrazyEightsCuiController.go
+++ b/internal/adapter/controller/CrazyEightsCuiController.go
@@ -5,8 +5,22 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
+
+// playWithSuitPrompt runs Play(idx) and, when the human just played an 8
+// (game is now waiting for a suit choice), inlines a follow-up suit prompt so
+// the user does not have to type "s <n>" on a separate line. The presenter
+// output for the play step is consumed by the prompt loop and replaced with
+// the post-suit state, mirroring how other "wizard" CUI flows behave.
+func (c *CrazyEightsCuiController) playWithSuitPrompt(cardIndex int) string {
+	res := c.ci.Play(cardIndex)
+	if c.ci.IsHumanChooseSuitTurn() {
+		return cuiutil.PromptRequest(i18n.T("crazyeights.promptSuit"), "s {0}")
+	}
+	return res
+}
 
 // CrazyEightsCuiController クレイジーエイトCUIコントローラークラス
 type CrazyEightsCuiController struct {
@@ -34,7 +48,7 @@ func (c *CrazyEightsCuiController) Exec(command string) string {
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
-				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Play)
+				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.playWithSuitPrompt)
 			case "d", "draw":
 				return c.ci.Draw(), true
 			case "s", "suit":

--- a/internal/adapter/controller/CrazyEightsCuiController_test.go
+++ b/internal/adapter/controller/CrazyEightsCuiController_test.go
@@ -100,6 +100,8 @@ func TestCrazyEightsCuiController_Exec(t *testing.T) {
 		assert.True(t, cuiutil.IsPromptRequest(result), "expected a PROMPT response, got %q", result)
 		_, tmpl := cuiutil.ParsePromptRequest(result)
 		assert.Equal(t, "s {0}", tmpl)
+		m.AssertCalled(t, "Play", 0)
+		m.AssertCalled(t, "IsHumanChooseSuitTurn")
 	})
 
 	t.Run("playing a non-8 returns the play result unchanged (no prompt)", func(t *testing.T) {
@@ -109,6 +111,8 @@ func TestCrazyEightsCuiController_Exec(t *testing.T) {
 		c := controller.NewCrazyEightsCuiController(m)
 		result := c.Exec("p 2")
 		assert.Equal(t, mockOutput, result)
+		m.AssertCalled(t, "Play", 2)
+		m.AssertCalled(t, "IsHumanChooseSuitTurn")
 	})
 
 	// draw

--- a/internal/adapter/controller/CrazyEightsCuiController_test.go
+++ b/internal/adapter/controller/CrazyEightsCuiController_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	mockUsecases "github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/usecase"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 )
@@ -25,6 +26,9 @@ func TestCrazyEightsCuiController_Exec(t *testing.T) {
 		m.On("Draw").Return(mockOutput)
 		m.On("NextRound").Return(mockOutput)
 		m.On("ActionLog").Return(mockOutput)
+		// Default: assume the play did NOT trigger the choose-suit phase. Tests
+		// that exercise the inline suit prompt override this expectation below.
+		m.On("IsHumanChooseSuitTurn").Return(false)
 		return m
 	}
 
@@ -85,6 +89,26 @@ func TestCrazyEightsCuiController_Exec(t *testing.T) {
 		c := controller.NewCrazyEightsCuiController(newMock())
 		result := c.Exec("p abc")
 		assert.Contains(t, result, "Invalid card index")
+	})
+
+	t.Run("playing an 8 inlines a suit prompt instead of forcing 's' on the next line", func(t *testing.T) {
+		m := new(mockUsecases.MockCrazyEightsInteractor)
+		m.On("Play", 0).Return(mockOutput)
+		m.On("IsHumanChooseSuitTurn").Return(true)
+		c := controller.NewCrazyEightsCuiController(m)
+		result := c.Exec("p 0")
+		assert.True(t, cuiutil.IsPromptRequest(result), "expected a PROMPT response, got %q", result)
+		_, tmpl := cuiutil.ParsePromptRequest(result)
+		assert.Equal(t, "s {0}", tmpl)
+	})
+
+	t.Run("playing a non-8 returns the play result unchanged (no prompt)", func(t *testing.T) {
+		m := new(mockUsecases.MockCrazyEightsInteractor)
+		m.On("Play", 2).Return(mockOutput)
+		m.On("IsHumanChooseSuitTurn").Return(false)
+		c := controller.NewCrazyEightsCuiController(m)
+		result := c.Exec("p 2")
+		assert.Equal(t, mockOutput, result)
 	})
 
 	// draw

--- a/internal/adapter/controller/usecase/CrazyEightsInteractor_mock.go
+++ b/internal/adapter/controller/usecase/CrazyEightsInteractor_mock.go
@@ -50,3 +50,8 @@ func (_m *MockCrazyEightsInteractor) Snapshot() ([]byte, error) {
 	ret := _m.Called()
 	return ret.Get(0).([]byte), ret.Error(1)
 }
+
+// IsHumanChooseSuitTurn モック
+func (_m *MockCrazyEightsInteractor) IsHumanChooseSuitTurn() bool {
+	return _m.Called().Bool(0)
+}

--- a/internal/i18n/locales/en/crazyeights.json
+++ b/internal/i18n/locales/en/crazyeights.json
@@ -5,5 +5,6 @@
   "helpSuit": "  s <1-4>              choose suit (1=♠, 2=♣, 3=♥, 4=♦)",
   "helpNextRound": "  nr                   next round",
   "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
-  "helpSetLimit": "  sl <n>               point limit"
+  "helpSetLimit": "  sl <n>               point limit",
+  "promptSuit": "Choose a suit (1=♠, 2=♣, 3=♥, 4=♦):"
 }

--- a/internal/i18n/locales/ja/crazyeights.json
+++ b/internal/i18n/locales/ja/crazyeights.json
@@ -5,5 +5,6 @@
   "helpSuit": "  s <1-4>              スート選択 (1=♠, 2=♣, 3=♥, 4=♦)",
   "helpNextRound": "  nr                   次のラウンドへ",
   "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)",
-  "helpSetLimit": "  sl <n>               ポイント上限"
+  "helpSetLimit": "  sl <n>               ポイント上限",
+  "promptSuit": "スートを選択してください (1=♠, 2=♣, 3=♥, 4=♦):"
 }

--- a/internal/usecase/CrazyEightsInteractor.go
+++ b/internal/usecase/CrazyEightsInteractor.go
@@ -26,6 +26,11 @@ type CrazyEightsInteractorIF interface {
 	GetConfig() domain.CrazyEightsConfig
 	// ActionLog 棋譜を出力する
 	ActionLog() string
+	// IsHumanChooseSuitTurn reports whether the human just played an 8 and the
+	// game is now waiting for them to pick a suit. Used by the CUI controller
+	// to issue an inline suit prompt instead of forcing the user to type 's'
+	// on the next line.
+	IsHumanChooseSuitTurn() bool
 }
 
 // CrazyEightsInteractor クレイジーエイトインタラクタークラス
@@ -110,6 +115,13 @@ func (ci *CrazyEightsInteractor) GetConfig() domain.CrazyEightsConfig {
 // ActionLog 棋譜を出力する
 func (ci *CrazyEightsInteractor) ActionLog() string {
 	return ci.gp.ActionLogOutput(ci.Game)
+}
+
+// IsHumanChooseSuitTurn reports whether the game is currently waiting for the
+// human to pick a suit (i.e. the human just played an 8). The CUI controller
+// uses this to inline a suit prompt right after a successful Play.
+func (ci *CrazyEightsInteractor) IsHumanChooseSuitTurn() bool {
+	return ci.Game.GetPhase() == domain.CrazyEightsPhaseChooseSuit && ci.Game.IsHumanTurn()
 }
 
 // runCpuTurns ゲームが終わるか人間の手番またはラウンド/ゲーム終了になるまでCPUターンを実行


### PR DESCRIPTION
## Summary
- After playing an 8, the CUI used to require a separate \`s <1-4>\` line. The play handler now returns a \`PROMPT\` response, and \`cui_runner\` re-dispatches \`s {0}\` with the player's next keystroke — single-flow wizard.
- New \`IsHumanChooseSuitTurn()\` helper on the interactor exposes the needed phase + turn check so the controller doesn't reach into the domain.
- Manual \`s <n>\` still works for the keyboard-warriors who prefer it.

## Test plan
- [x] \`go test -tags test ./internal/adapter/controller/ -run TestCrazyEightsCuiController_Exec\` (all pre-existing tests pass + 2 new — PROMPT path on choose-suit phase, plain result path otherwise)
- [x] \`go test -tags test ./internal/usecase/ -run CrazyEights\` clean
- [x] \`goimports -w\` on the changed files
- [ ] \`golangci-lint run ./...\` via GH Actions (local OOM)

Closes #1662