### PR TITLE
feat(cribbage): auto-declare Go when the human has no playable card

### DIFF
--- a/frontend/src/i18n/locales/en/cribbage.json
+++ b/frontend/src/i18n/locales/en/cribbage.json
@@ -21,6 +21,7 @@
   "discardButton": "Discard to Crib",
   "pegButton": "Play Card",
   "goButton": "Go",
+  "autoGoNotice": "No playable card — Go was declared automatically",
   "showNextButton": "Show Next",
   "nextRound": "Next Round",
   "discardPhase": "Select 2 cards to discard to the crib",

--- a/frontend/src/i18n/locales/ja/cribbage.json
+++ b/frontend/src/i18n/locales/ja/cribbage.json
@@ -21,6 +21,7 @@
   "discardButton": "クリブに捨てる",
   "pegButton": "カードを出す",
   "goButton": "Go",
+  "autoGoNotice": "出せるカードがないため Go を自動宣言しました",
   "showNextButton": "次を表示",
   "nextRound": "次のラウンド",
   "discardPhase": "クリブに捨てるカードを2枚選んでください",

--- a/frontend/src/pages/CribbagePage.test.tsx
+++ b/frontend/src/pages/CribbagePage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, cribbageApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
@@ -217,6 +217,56 @@ describe('CribbagePage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'カードを出す' }));
 
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('peg', 0));
+  });
+
+  it('auto-dispatches go after a brief delay when the human has no playable card and shows the notice', async () => {
+    vi.useFakeTimers();
+    try {
+      const goState: CribbageResponse = {
+        ...peggingPhaseState,
+        pegCount: 28,
+        players: [
+          {
+            ...peggingPhaseState.players[0],
+            cardCount: 1,
+            cards: [{ design: 'HEART', value: 10 }], // 28+10=38 > 31, no playable card.
+          },
+          peggingPhaseState.players[1],
+        ],
+      };
+      mockExec.mockResolvedValue(goState);
+      renderWithProviders(<CribbagePage />);
+      // The auto-Go notice appears as soon as the no-playable state is reflected.
+      await vi.waitFor(() => expect(screen.getByTestId('cb-auto-go-notice')).toBeInTheDocument());
+
+      mockExec.mockClear();
+      mockExec.mockResolvedValue(goState);
+      // Advance past the 1s delay; the timeout should fire 'go' without any user click.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(mockExec).toHaveBeenCalledWith('go');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not auto-dispatch go when the human has at least one playable card', async () => {
+    vi.useFakeTimers();
+    try {
+      mockExec.mockResolvedValue(peggingPhaseState);
+      renderWithProviders(<CribbagePage />);
+      await vi.waitFor(() => expect(screen.getByRole('button', { name: 'Go' })).toBeInTheDocument());
+      // No notice while the player can still peg.
+      expect(screen.queryByTestId('cb-auto-go-notice')).not.toBeInTheDocument();
+      mockExec.mockClear();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      expect(mockExec).not.toHaveBeenCalledWith('go');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('calls go command when go button is clicked', async () => {

--- a/frontend/src/pages/CribbagePage.tsx
+++ b/frontend/src/pages/CribbagePage.tsx
@@ -194,15 +194,14 @@ function CribbagePageContent() {
   // briefly reads the toast before the turn rotates to the opponent. Computed
   // here (before the early return) so the hooks order stays stable across
   // renders.
+  const currentPlayer = state?.players[state.currentPlayerIdx ?? -1];
   const shouldAutoGo =
     state?.phase === CribbagePhase.PEGGING &&
-    state?.players[state.currentPlayerIdx]?.isHuman === true &&
-    !state?.players
-      .find((p) => p.isHuman)
-      ?.cards?.some((c) => {
-        const cv = c.value >= 10 ? 10 : c.value;
-        return state.pegCount + cv <= 31;
-      }) &&
+    currentPlayer?.isHuman === true &&
+    !currentPlayer.cards?.some((c) => {
+      const cv = c.value >= 10 ? 10 : c.value;
+      return state.pegCount + cv <= 31;
+    }) &&
     !loading;
   const [autoGoNoticeVisible, setAutoGoNoticeVisible] = useState(false);
   useEffect(() => {

--- a/frontend/src/pages/CribbagePage.tsx
+++ b/frontend/src/pages/CribbagePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { cribbageApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -188,6 +188,35 @@ function CribbagePageContent() {
 
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
+  // Auto-Go: when the human is on the pegging turn but holds no playable card,
+  // there is no actual decision left — the rule forces a Go declaration.
+  // Schedule the call after a short delay so the player notices the cause and
+  // briefly reads the toast before the turn rotates to the opponent. Computed
+  // here (before the early return) so the hooks order stays stable across
+  // renders.
+  const shouldAutoGo =
+    state?.phase === CribbagePhase.PEGGING &&
+    state?.players[state.currentPlayerIdx]?.isHuman === true &&
+    !state?.players
+      .find((p) => p.isHuman)
+      ?.cards?.some((c) => {
+        const cv = c.value >= 10 ? 10 : c.value;
+        return state.pegCount + cv <= 31;
+      }) &&
+    !loading;
+  const [autoGoNoticeVisible, setAutoGoNoticeVisible] = useState(false);
+  useEffect(() => {
+    if (!shouldAutoGo) {
+      setAutoGoNoticeVisible(false);
+      return;
+    }
+    setAutoGoNoticeVisible(true);
+    const timer = setTimeout(() => {
+      handleGo();
+    }, 1000);
+    return () => clearTimeout(timer);
+  }, [shouldAutoGo, handleGo]);
+
   if (!state)
     return (
       <GameSkeleton
@@ -212,6 +241,7 @@ function CribbagePageContent() {
     });
 
   const nonDealerIsHuman = state.players[1 - state.dealerIdx]?.isHuman === true;
+
   const scoreLabels = [
     nonDealerIsHuman ? t('handScoreLabels.you') : t('handScoreLabels.cpu'),
     nonDealerIsHuman ? t('handScoreLabels.cpu') : t('handScoreLabels.you'),
@@ -491,6 +521,16 @@ function CribbagePageContent() {
               )}
               {isPeggingPhase && isHumanTurn && (
                 <>
+                  {autoGoNoticeVisible && (
+                    <div
+                      role="status"
+                      aria-live="polite"
+                      data-testid="cb-auto-go-notice"
+                      className="px-3 py-1.5 rounded bg-ds-info/15 border border-ds-info text-ds-info text-sm"
+                    >
+                      {t('autoGoNotice')}
+                    </div>
+                  )}
                   <button
                     type="button"
                     className={btnPrimary}


### PR DESCRIPTION
## Summary
- Pegging phase: when the human's remaining cards all exceed the 31 count, dispatch \`go\` automatically after a short (~1s) delay so the turn rotates to the opponent without a forced click.
- Toast (\`role=status\`, \`aria-live=polite\`) appears for the duration of the delay so the player sees the cause of the auto-action.
- Timer is fully cancellable — clears whenever \`shouldAutoGo\` flips off (loading, phase change, new playable card from server, etc.).

## Test plan
- [x] \`bun run test -- --run CribbagePage\` (51/51: existing + 2 new — auto-fires after delay when no playable card; does not fire when the player can still peg)
- [x] \`bun run check\` clean
- [x] \`bunx tsc --noEmit\` clean
- [ ] Frontend build via GH Actions (local OOM)

Closes #1666