### PR TITLE
feat(freecell): block dragging stacks beyond the supermove limit

### DIFF
--- a/frontend/src/i18n/locales/en/freecell.json
+++ b/frontend/src/i18n/locales/en/freecell.json
@@ -17,6 +17,7 @@
   "foundationAriaLabel": "{{suit}} Foundation ({{cardCount}} cards)",
   "emptyFoundationAriaLabel": "{{suit}} Foundation (empty)",
   "emptyFreecellAriaLabel": "Free Cell {{idx}} (empty)",
+  "supermoveLimitTooltip": "Only {{limit}} card(s) can be moved at once",
   "tutorial": {
     "freeCells": "Free cells. Four temporary storage slots. More empty cells allow moving more cards at once.",
     "foundation": "Foundation piles. Build each suit from Ace to King.",

--- a/frontend/src/i18n/locales/ja/freecell.json
+++ b/frontend/src/i18n/locales/ja/freecell.json
@@ -17,6 +17,7 @@
   "foundationAriaLabel": "{{suit}} ファンデーション ({{cardCount}}枚)",
   "emptyFoundationAriaLabel": "{{suit}} ファンデーション (空)",
   "emptyFreecellAriaLabel": "フリーセル {{idx}} (空)",
+  "supermoveLimitTooltip": "一度に動かせるのは{{limit}}枚までです",
   "tutorial": {
     "freeCells": "フリーセルです。一時的にカードを置ける4つのスペースです。空きセルが多いほど多くのカードを一度に移動できます。",
     "foundation": "ファウンデーションです。各スートをAからKまで順番に積み上げます。",

--- a/frontend/src/pages/FreeCellPage.test.tsx
+++ b/frontend/src/pages/FreeCellPage.test.tsx
@@ -697,6 +697,68 @@ describe('FreeCellPage', () => {
       expect(cardButton).toHaveAttribute('draggable', 'true');
     });
 
+    it('marks only the deepest movable cards as draggable when free cells + empty cols are exhausted', async () => {
+      // Construct a stack of 3 cards in column 0 with all free cells full and no empty tableau cols.
+      // Supermove limit becomes (1+0)*2^0 = 1, so only the bottom card (cardIndex=2) can move.
+      const tightState: FreeCellResponse = {
+        ...playingState,
+        tableau: [
+          [card('SPADE', 13), card('HEART', 12), card('CLOVER', 11)],
+          [card('DIAMOND', 1)],
+          [card('SPADE', 2)],
+          [card('HEART', 3)],
+          [card('DIAMOND', 4)],
+          [card('CLOVER', 5)],
+          [card('SPADE', 6)],
+          [card('HEART', 7)],
+        ],
+        freeCells: [card('DIAMOND', 8), card('CLOVER', 9), card('SPADE', 10), card('HEART', 11)],
+      };
+      mockExec.mockResolvedValue(tightState);
+      renderWithProviders(<FreeCellPage />);
+      await waitFor(() => expect(screen.getByAltText('♠ K')).toBeInTheDocument());
+
+      // Bottom card of the 3-card stack is movable; the two above are not.
+      const topButton = screen.getByAltText('♠ K').closest('button') as HTMLButtonElement;
+      const middleButton = screen.getByAltText('♥ Q').closest('button') as HTMLButtonElement;
+      const bottomButton = screen.getByAltText('♣ J').closest('button') as HTMLButtonElement;
+      expect(bottomButton).toHaveAttribute('draggable', 'true');
+      expect(bottomButton).not.toHaveAttribute('data-supermove-blocked');
+      expect(middleButton).toHaveAttribute('draggable', 'false');
+      expect(middleButton).toHaveAttribute('data-supermove-blocked', 'true');
+      expect(topButton).toHaveAttribute('draggable', 'false');
+      expect(topButton).toHaveAttribute('data-supermove-blocked', 'true');
+    });
+
+    it('lets the entire stack drag when free cells + empty cols allow it', async () => {
+      // 3-card stack, 2 empty free cells, 0 empty cols → limit = (1+2)*2^0 = 3 → all 3 movable.
+      const looseState: FreeCellResponse = {
+        ...playingState,
+        tableau: [
+          [card('SPADE', 13), card('HEART', 12), card('CLOVER', 11)],
+          [card('DIAMOND', 1)],
+          [card('SPADE', 2)],
+          [card('HEART', 3)],
+          [card('DIAMOND', 4)],
+          [card('CLOVER', 5)],
+          [card('SPADE', 6)],
+          [card('HEART', 7)],
+        ],
+        freeCells: [card('DIAMOND', 8), card('CLOVER', 9), null, null],
+      };
+      mockExec.mockResolvedValue(looseState);
+      renderWithProviders(<FreeCellPage />);
+      await waitFor(() => expect(screen.getByAltText('♠ K')).toBeInTheDocument());
+
+      const topButton = screen.getByAltText('♠ K').closest('button') as HTMLButtonElement;
+      const middleButton = screen.getByAltText('♥ Q').closest('button') as HTMLButtonElement;
+      const bottomButton = screen.getByAltText('♣ J').closest('button') as HTMLButtonElement;
+      expect(topButton).toHaveAttribute('draggable', 'true');
+      expect(middleButton).toHaveAttribute('draggable', 'true');
+      expect(bottomButton).toHaveAttribute('draggable', 'true');
+      expect(topButton).not.toHaveAttribute('data-supermove-blocked');
+    });
+
     it('free cell card is draggable when playing', async () => {
       mockExec.mockResolvedValue(withFreeCellCardState);
       renderWithProviders(<FreeCellPage />);

--- a/frontend/src/pages/FreeCellPage.test.tsx
+++ b/frontend/src/pages/FreeCellPage.test.tsx
@@ -757,6 +757,8 @@ describe('FreeCellPage', () => {
       expect(middleButton).toHaveAttribute('draggable', 'true');
       expect(bottomButton).toHaveAttribute('draggable', 'true');
       expect(topButton).not.toHaveAttribute('data-supermove-blocked');
+      expect(middleButton).not.toHaveAttribute('data-supermove-blocked');
+      expect(bottomButton).not.toHaveAttribute('data-supermove-blocked');
     });
 
     it('free cell card is draggable when playing', async () => {

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -165,6 +165,15 @@ function FreeCellPageContent() {
   const isGameOver = state.phase === FreeCellPhase.GAME_OVER;
   const isEnded = isGameClear || isGameOver;
 
+  // Supermove limit: a tableau stack of N cards can only move when
+  // (1 + freeCells) * 2^emptyCols >= N. We compute the upper-bound limit (the
+  // optimistic case where the destination is NOT one of the empty columns) and
+  // mark anything deeper than that as undraggable, with a red ring + tooltip
+  // so the player sees the cap before the engine rejects the move.
+  const emptyFreeCells = state.freeCells.filter((c) => c === null).length;
+  const emptyTableauCols = state.tableau.filter((col: (Card | null)[]) => col.length === 0).length;
+  const supermoveLimit = (1 + emptyFreeCells) * 2 ** emptyTableauCols;
+
   const isSourceSelected = (zone: string, col?: number, cell?: number, cardIndex?: number) =>
     selectedSource !== null &&
     selectedSource.zone === zone &&
@@ -338,6 +347,8 @@ function FreeCellPageContent() {
                                 col: colIdx,
                                 cardIndex: cardIdx,
                               };
+                              const stackSize = col.length - cardIdx;
+                              const exceedsSupermove = stackSize > supermoveLimit;
                               return (
                                 <div
                                   key={`tc-${colIdx.toString()}-${cardIdx.toString()}`}
@@ -357,10 +368,16 @@ function FreeCellPageContent() {
                                       disabled={!isPlaying || loading}
                                       aria-label={cardAlt(card)}
                                       aria-pressed={isSourceSelected('tableau', colIdx, undefined, cardIdx)}
-                                      draggable={isPlaying && !loading}
+                                      draggable={isPlaying && !loading && !exceedsSupermove}
                                       onDragStart={dnd.handleDragStart(cardZone)}
                                       onDragEnd={dnd.handleDragEnd}
-                                      className={`p-0 border-0 bg-transparent cursor-pointer w-full rounded ${focusRingWhite} ${isSourceSelected('tableau', colIdx, undefined, cardIdx) ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
+                                      title={
+                                        exceedsSupermove
+                                          ? t('supermoveLimitTooltip', { limit: supermoveLimit })
+                                          : undefined
+                                      }
+                                      data-supermove-blocked={exceedsSupermove ? 'true' : undefined}
+                                      className={`p-0 border-0 bg-transparent cursor-pointer w-full rounded ${focusRingWhite} ${isSourceSelected('tableau', colIdx, undefined, cardIdx) ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}${exceedsSupermove ? ' opacity-60 ring-1 ring-ds-error' : ''}`}
                                     >
                                       <AnimatedCard
                                         card={card}

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -377,7 +377,16 @@ function FreeCellPageContent() {
                                           : undefined
                                       }
                                       data-supermove-blocked={exceedsSupermove ? 'true' : undefined}
-                                      className={`p-0 border-0 bg-transparent cursor-pointer w-full rounded ${focusRingWhite} ${isSourceSelected('tableau', colIdx, undefined, cardIdx) ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}${exceedsSupermove ? ' opacity-60 ring-1 ring-ds-error' : ''}`}
+                                      className={[
+                                        'p-0 border-0 bg-transparent cursor-pointer w-full rounded',
+                                        focusRingWhite,
+                                        isSourceSelected('tableau', colIdx, undefined, cardIdx) &&
+                                          'ring-2 ring-ds-warning',
+                                        dnd.isDragSource(cardZone) && 'opacity-50',
+                                        exceedsSupermove && 'opacity-60 ring-1 ring-ds-error',
+                                      ]
+                                        .filter(Boolean)
+                                        .join(' ')}
                                     >
                                       <AnimatedCard
                                         card={card}


### PR DESCRIPTION
## Summary
Card stacks deeper than the dynamic supermove limit \`(1+freeCells)*2^emptyCols\` were draggable in the UI even though the engine immediately rejected the drop. Players retried with no obvious cause.

The page now computes the optimistic upper-bound limit each render and:
- Sets \`draggable=false\` on cards that exceed the limit (counts from cardIndex to bottom of column).
- Adds a red ring + 60% opacity + localised \`title\` tooltip (\`Only N card(s) can be moved at once\`) so the cap is visible before commit.
- Adds \`data-supermove-blocked=\"true\"\` so tests can assert the visual cue.

Click-select stays available — engine still validates click-and-target flows for the same reason.

## Test plan
- [x] \`bun run test -- --run FreeCellPage\` (61/61: existing + 2 new — tight state blocks middle/top of 3-card stack, loose state lets all 3 drag)
- [x] \`bun run check\` clean
- [ ] Frontend build via GH Actions (local OOM)

Closes #1658