### PR TITLE
feat(sevens): translucent joker glyph + auto-place when only one slot

### DIFF
--- a/frontend/src/components/sevens/SevensBoard.tsx
+++ b/frontend/src/components/sevens/SevensBoard.tsx
@@ -91,7 +91,8 @@ function Board({
                         data-joker-placeable="true"
                       >
                         {/* Translucent joker glyph hints that this cell will accept the held joker.
-                            The cell label (rank) sits underneath at full strength so the value is still legible. */}
+                            The rank label is rendered after this span so it stacks on top in DOM
+                            order, keeping the value legible at full strength. */}
                         <span
                           aria-hidden="true"
                           className="absolute inset-0 flex items-center justify-center text-[0.85em] opacity-40"

--- a/frontend/src/components/sevens/SevensBoard.tsx
+++ b/frontend/src/components/sevens/SevensBoard.tsx
@@ -85,12 +85,20 @@ function Board({
                         type="button"
                         onClick={() => onJokerPlace?.(idx, v)}
                         aria-label={t('placeAriaLabel', { suit: suitName(idx), value: valueName(v) })}
-                        className={`${baseClass}${bold} ring-2 ring-ds-info ring-offset-1 ring-offset-black/30 motion-safe:animate-pulse cursor-pointer p-0 hover:brightness-110`}
+                        className={`${baseClass}${bold} relative ring-2 ring-ds-info ring-offset-1 ring-offset-black/30 motion-safe:animate-pulse cursor-pointer p-0 hover:brightness-110`}
                         style={colors}
                         data-testid="board-cell"
                         data-joker-placeable="true"
                       >
-                        {valueName(v)}
+                        {/* Translucent joker glyph hints that this cell will accept the held joker.
+                            The cell label (rank) sits underneath at full strength so the value is still legible. */}
+                        <span
+                          aria-hidden="true"
+                          className="absolute inset-0 flex items-center justify-center text-[0.85em] opacity-40"
+                        >
+                          🃏
+                        </span>
+                        <span className="relative">{valueName(v)}</span>
                       </button>
                     );
                   }

--- a/frontend/src/pages/SevensPage.tsx
+++ b/frontend/src/pages/SevensPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import type { sevensApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -38,7 +38,7 @@ import { parseSevensCommand, SEVENS_HELP } from '../utils/cli/commands/sevensCom
 import { formatSevensState } from '../utils/cli/formatters/sevensFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
-import { actionDesc } from '../utils/sevensUtils';
+import { actionDesc, listJokerPlacements } from '../utils/sevensUtils';
 
 /** Sevens tutorial step definitions. */
 const SV_TUTORIAL_STEPS: TutorialStep[] = [
@@ -161,6 +161,23 @@ function SevensPageContent() {
   ]);
 
   useGameRoundGuard(!!state && !state.gameEndFlag);
+
+  // Auto-place: when the player has just selected a joker and the board offers
+  // exactly one legal slot, skip the redundant click and dispatch the placement
+  // immediately. Anything more than one slot still requires the player to pick
+  // (otherwise we'd remove their strategic choice).
+  useEffect(() => {
+    if (jokerCardIdx === null || !state || loading) return;
+    const slots = listJokerPlacements(
+      state.tablePlaced,
+      state.config.tunnelEnabled,
+      state.config.endStopEnabled,
+      state.config.tunnelSkipWidth,
+    );
+    if (slots.length === 1) {
+      handleJokerPlace(slots[0].suit, slots[0].value);
+    }
+  }, [jokerCardIdx, state, loading, handleJokerPlace]);
 
   if (!state)
     return (

--- a/frontend/src/pages/SevensPage.tsx
+++ b/frontend/src/pages/SevensPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { sevensApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -166,18 +166,45 @@ function SevensPageContent() {
   // exactly one legal slot, skip the redundant click and dispatch the placement
   // immediately. Anything more than one slot still requires the player to pick
   // (otherwise we'd remove their strategic choice).
+  //
+  // Important: useSevensGame only clears jokerCardIdx on a *successful* api
+  // response. If the placement fails (network error, server-side validation),
+  // loading flips back to false but jokerCardIdx is still non-null, which
+  // would cause the effect to re-fire and dispatch the same failing placement
+  // forever. We guard with a ref that tracks "we already tried auto-placing
+  // for this jokerCardIdx", and only reset it once the index changes.
+  const tablePlacedForAuto = state?.tablePlaced;
+  const tunnelEnabledForAuto = state?.config.tunnelEnabled;
+  const endStopEnabledForAuto = state?.config.endStopEnabled;
+  const tunnelSkipWidthForAuto = state?.config.tunnelSkipWidth;
+  const lastAutoAttemptedRef = useRef<number | null>(null);
   useEffect(() => {
-    if (jokerCardIdx === null || !state || loading) return;
+    // Reset the guard whenever the joker selection clears or changes.
+    if (jokerCardIdx === null) {
+      lastAutoAttemptedRef.current = null;
+      return;
+    }
+    if (lastAutoAttemptedRef.current === jokerCardIdx) return;
+    if (loading || tablePlacedForAuto === undefined) return;
     const slots = listJokerPlacements(
-      state.tablePlaced,
-      state.config.tunnelEnabled,
-      state.config.endStopEnabled,
-      state.config.tunnelSkipWidth,
+      tablePlacedForAuto,
+      tunnelEnabledForAuto ?? false,
+      endStopEnabledForAuto ?? false,
+      tunnelSkipWidthForAuto ?? 0,
     );
     if (slots.length === 1) {
+      lastAutoAttemptedRef.current = jokerCardIdx;
       handleJokerPlace(slots[0].suit, slots[0].value);
     }
-  }, [jokerCardIdx, state, loading, handleJokerPlace]);
+  }, [
+    jokerCardIdx,
+    loading,
+    tablePlacedForAuto,
+    tunnelEnabledForAuto,
+    endStopEnabledForAuto,
+    tunnelSkipWidthForAuto,
+    handleJokerPlace,
+  ]);
 
   if (!state)
     return (

--- a/frontend/src/utils/sevensUtils.test.ts
+++ b/frontend/src/utils/sevensUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isCardPlayable, isPositionPlayable, wrapValue } from './sevensUtils';
+import { isCardPlayable, isPositionPlayable, listJokerPlacements, wrapValue } from './sevensUtils';
 
 describe('wrapValue', () => {
   it('returns value unchanged for 1-13', () => {
@@ -86,5 +86,33 @@ describe('isCardPlayable with tunnelSkipWidth', () => {
     expect(isCardPlayable(joker, board7Only, false, false, [joker], false, false, false, 0)).toBe(true);
     // With skip=3, additional positions are playable
     expect(isCardPlayable(joker, board7Only, false, false, [joker], false, false, false, 3)).toBe(true);
+  });
+});
+
+describe('listJokerPlacements', () => {
+  it('returns the 6 and 8 positions on each suit when only 7 is placed', () => {
+    // Standard opening: every suit has only its 7 placed.
+    const board7Only = [0, 128, 128, 128, 128];
+    const slots = listJokerPlacements(board7Only, false, false, 0);
+    // 4 suits * 2 neighbours (6 and 8) = 8 placements
+    expect(slots).toHaveLength(8);
+    // Spot-check that suit 1 (♠) offers values 6 and 8.
+    const spadeValues = slots
+      .filter((s) => s.suit === 1)
+      .map((s) => s.value)
+      .sort((a, b) => a - b);
+    expect(spadeValues).toEqual([6, 8]);
+  });
+
+  it('returns a single slot when only one suit has been opened', () => {
+    // Bit 7 set on spade only.
+    const board = [0, 128, 0, 0, 0];
+    const slots = listJokerPlacements(board, false, false, 0);
+    expect(slots).toHaveLength(2); // 6 and 8 of spades
+  });
+
+  it('returns an empty list when the board is empty (no anchors to extend)', () => {
+    const empty = [0, 0, 0, 0, 0];
+    expect(listJokerPlacements(empty, false, false, 0)).toEqual([]);
   });
 });

--- a/frontend/src/utils/sevensUtils.ts
+++ b/frontend/src/utils/sevensUtils.ts
@@ -86,6 +86,28 @@ export function hasAnyPlayablePosition(
   return false;
 }
 
+/**
+ * Returns every (suit, value) coordinate where the joker can legally land.
+ * Used by the page to auto-place the joker when there is exactly one option,
+ * so the player avoids a redundant click on a single highlighted cell.
+ */
+export function listJokerPlacements(
+  tablePlaced: number[],
+  tunnelEnabled: boolean,
+  endStopEnabled: boolean,
+  tunnelSkipWidth = 0,
+): Array<{ suit: number; value: number }> {
+  const result: Array<{ suit: number; value: number }> = [];
+  for (let suit = 1; suit <= 4; suit++) {
+    for (let v = 1; v <= 13; v++) {
+      if (isPositionPlayable(tablePlaced, suit, v, tunnelEnabled, endStopEnabled, tunnelSkipWidth)) {
+        result.push({ suit, value: v });
+      }
+    }
+  }
+  return result;
+}
+
 /** Check if a hand contains only joker cards. */
 export function hasOnlyJokers(cards: Card[]): boolean {
   return cards.length > 0 && cards.every((c) => c.design === 'JOKER');


### PR DESCRIPTION
## Summary
- Faded 🃏 glyph sits behind the rank text on every legally-placeable cell while a joker is selected, so the player sees at a glance which squares the held joker can occupy.
- New \`listJokerPlacements\` util enumerates every legal (suit, value) coordinate. SevensPage runs an effect when joker mode activates: if the board offers exactly one legal slot, dispatch the placement immediately — there is no decision left to make. Two-or-more options still wait for the player.

## Test plan
- [x] \`bun run test -- --run sevensUtils\` (17/17: existing + 3 new — listJokerPlacements with standard opening / single-suit opened / empty board)
- [x] \`bun run test -- --run SevensBoard\` (27/27: glyph addition didn't regress the existing placement-cell tests)
- [x] \`bun run test -- --run SevensPage\` (106/106 — auto-place effect doesn't trip the existing flow tests)
- [x] \`bun run check\` clean
- [ ] Frontend build via GH Actions (local OOM)

Closes #1659