### PR TITLE
feat(videopoker variants): auto-hold hint-recommended cards on deal

### DIFF
--- a/frontend/src/components/VideoPokerGameContent.test.tsx
+++ b/frontend/src/components/VideoPokerGameContent.test.tsx
@@ -102,6 +102,9 @@ function renderContent() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Clear localStorage so the per-variant autoHold/hint toggles start at
+  // their hardcoded defaults rather than carrying state across test cases.
+  localStorage.clear();
 });
 
 describe('VideoPokerGameContent', () => {
@@ -134,6 +137,9 @@ describe('VideoPokerGameContent', () => {
       .mockResolvedValueOnce(resultPhaseWin);
     renderContent();
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    // Disable auto-hold before entering draw so the test can drive holds
+    // purely from explicit clicks (auto-hold seeds the state on phase entry).
+    fireEvent.click(screen.getByTestId('vp-auto-hold-toggle'));
     fireEvent.click(screen.getByRole('button', { name: /ディール/ }));
     await waitFor(() => expect(screen.getByRole('button', { name: /ドロー/ })).toBeInTheDocument());
 
@@ -157,6 +163,37 @@ describe('VideoPokerGameContent', () => {
     mockExec.mockResolvedValue(resultPhaseLose);
     renderContent();
     await waitFor(() => expect(screen.getByRole('button', { name: /次のゲーム/ })).toBeInTheDocument());
+  });
+
+  it('auto-hold pre-selects the hint-recommended cards on entering draw phase', async () => {
+    // drawPhaseState hand = [A♠, J♥, 5♣, 8♦, K♠]. With no pairs/draws, the
+    // base hint engine recommends holding the high cards (J + K → idx 1, 4).
+    mockExec.mockResolvedValueOnce(betPhaseState).mockResolvedValueOnce(drawPhaseState);
+    renderContent();
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    fireEvent.click(screen.getByRole('button', { name: /ディール/ }));
+    await waitFor(() => expect(screen.getByRole('button', { name: /ドロー/ })).toBeInTheDocument());
+
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.getAttribute('aria-pressed') !== null);
+    expect(cardButtons[0]).toHaveAttribute('aria-pressed', 'false'); // A — not a high card under threshold=11
+    expect(cardButtons[1]).toHaveAttribute('aria-pressed', 'true'); // J
+    expect(cardButtons[2]).toHaveAttribute('aria-pressed', 'false'); // 5
+    expect(cardButtons[3]).toHaveAttribute('aria-pressed', 'false'); // 8
+    expect(cardButtons[4]).toHaveAttribute('aria-pressed', 'true'); // K
+  });
+
+  it('toggling auto-hold off then dealing leaves all cards unheld', async () => {
+    mockExec.mockResolvedValueOnce(betPhaseState).mockResolvedValueOnce(drawPhaseState);
+    renderContent();
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    fireEvent.click(screen.getByTestId('vp-auto-hold-toggle'));
+    fireEvent.click(screen.getByRole('button', { name: /ディール/ }));
+    await waitFor(() => expect(screen.getByRole('button', { name: /ドロー/ })).toBeInTheDocument());
+
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.getAttribute('aria-pressed') !== null);
+    for (const btn of cardButtons) {
+      expect(btn).toHaveAttribute('aria-pressed', 'false');
+    }
   });
 
   it('next game button fires reset directly without confirm dialog', async () => {

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -8,13 +8,15 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { useLocalStorageToggle } from '../hooks/useLocalStorageToggle';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { VideoPokerResponse } from '../types/card';
+import type { Card, VideoPokerResponse } from '../types/card';
 import { VideoPokerPhase } from '../types/phases';
 import type { CliGameConfig } from '../utils/cli/types';
+import { getVideoPokerBaseHint } from '../utils/hints/videoPokerBaseHint';
 import { ActionLogPanel } from './ActionLogPanel';
 import { CliTerminal } from './cli/CliTerminal';
 import { CliToggle } from './cli/CliToggle';
@@ -30,6 +32,13 @@ import { AnimatedCard } from './motion/AnimatedCard';
 import { WinCelebration } from './motion/WinCelebration';
 import { PhaseIndicator } from './PhaseIndicator';
 import { TutorialButton } from './tutorial/TutorialButton';
+
+/** Per-variant predicate identifying wild cards (Deuces Wild = twos, Joker Poker = jokers, default = none). */
+const WILD_CARD_PREDICATE: Record<'videopoker' | 'deuceswild' | 'jokerpoker', (card: Card) => boolean> = {
+  videopoker: () => false,
+  deuceswild: (card) => card.value === 2,
+  jokerpoker: (card) => card.design === 'JOKER',
+};
 
 /** Props for the VideoPokerGameContent shared component. */
 export interface VideoPokerGameContentProps {
@@ -94,6 +103,12 @@ export function VideoPokerGameContent({
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
   const { hint, hintEnabled, setHintEnabled } = useGameHint(gameName, state);
+  // Auto-hold: when the deal completes, pre-select the cards the hint engine
+  // recommends so the player can hit Draw without re-discovering the optimal
+  // hold themselves. Off-by-default for variants that ship with hint=off so
+  // the player doesn't get spoiled before they ask for hints. Persisted per
+  // variant so each game (videopoker / deuceswild / jokerpoker) is independent.
+  const [autoHoldEnabled, setAutoHoldEnabled] = useLocalStorageToggle(`auto_hold_${gameName}`, true);
 
   useEffect(() => {
     execApi('reset');
@@ -103,10 +118,28 @@ export function VideoPokerGameContent({
   const isDrawPhase = state?.phase === VideoPokerPhase.DRAW;
   const isResultPhase = state?.phase === VideoPokerPhase.RESULT;
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-apply auto-hold only on the phase transition into DRAW (a fresh hand). Adding autoHoldEnabled / state / gameName to the deps would overwrite the player's manual hold edits whenever any of those change mid-draw.
   useEffect(() => {
-    if (isDrawPhase) {
-      setHeldCards([false, false, false, false, false]);
+    if (!isDrawPhase) return;
+    // Default: nothing held. When auto-hold is enabled, compute the
+    // recommendation directly via getVideoPokerBaseHint so it works
+    // regardless of whether the player has the hint UI toggled on.
+    const next: boolean[] = [false, false, false, false, false];
+    if (autoHoldEnabled && state) {
+      const autoHint = getVideoPokerBaseHint(state, WILD_CARD_PREDICATE[gameName]);
+      if (autoHint?.targetAction.startsWith('hold:')) {
+        const csv = autoHint.targetAction.slice('hold:'.length);
+        if (csv.length > 0) {
+          for (const raw of csv.split(',')) {
+            const idx = Number.parseInt(raw, 10);
+            if (Number.isInteger(idx) && idx >= 0 && idx < next.length) {
+              next[idx] = true;
+            }
+          }
+        }
+      }
     }
+    setHeldCards(next);
   }, [isDrawPhase]);
 
   const toggleHold = useCallback(
@@ -273,10 +306,19 @@ export function VideoPokerGameContent({
                 </button>
               </div>
             )}
-            <div className="flex justify-center pb-2">
+            <div className="flex flex-wrap justify-center gap-x-4 pb-2">
               <label className="text-ds-text-primary text-sm flex items-center gap-2 min-h-[44px]">
                 <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
                 {tc('hint.toggle', { ns: 'tutorial' })}
+              </label>
+              <label className="text-ds-text-primary text-sm flex items-center gap-2 min-h-[44px]">
+                <input
+                  type="checkbox"
+                  checked={autoHoldEnabled}
+                  onChange={(e) => setAutoHoldEnabled(e.target.checked)}
+                  data-testid="vp-auto-hold-toggle"
+                />
+                {t('label.autoHold')}
               </label>
             </div>
           </GameFooter>

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -105,9 +105,9 @@ export function VideoPokerGameContent({
   const { hint, hintEnabled, setHintEnabled } = useGameHint(gameName, state);
   // Auto-hold: when the deal completes, pre-select the cards the hint engine
   // recommends so the player can hit Draw without re-discovering the optimal
-  // hold themselves. Off-by-default for variants that ship with hint=off so
-  // the player doesn't get spoiled before they ask for hints. Persisted per
-  // variant so each game (videopoker / deuceswild / jokerpoker) is independent.
+  // hold themselves. Default ON to match real-machine behaviour; persisted
+  // per variant so each game (videopoker / deuceswild / jokerpoker) keeps
+  // its own toggle.
   const [autoHoldEnabled, setAutoHoldEnabled] = useLocalStorageToggle(`auto_hold_${gameName}`, true);
 
   useEffect(() => {

--- a/frontend/src/i18n/locales/en/deuceswild.json
+++ b/frontend/src/i18n/locales/en/deuceswild.json
@@ -4,7 +4,8 @@
     "chips": "Chips: {{chips}}",
     "bet": "Bet: {{bet}} coin(s)",
     "payout": "Payout: {{payout}}",
-    "betAmount": "Coins"
+    "betAmount": "Coins",
+    "autoHold": "Auto-hold"
   },
   "button": {
     "deal": "Deal",

--- a/frontend/src/i18n/locales/en/jokerpoker.json
+++ b/frontend/src/i18n/locales/en/jokerpoker.json
@@ -4,7 +4,8 @@
     "chips": "Chips: {{chips}}",
     "bet": "Bet: {{bet}} coin(s)",
     "payout": "Payout: {{payout}}",
-    "betAmount": "Coins"
+    "betAmount": "Coins",
+    "autoHold": "Auto-hold"
   },
   "button": {
     "deal": "Deal",

--- a/frontend/src/i18n/locales/en/videopoker.json
+++ b/frontend/src/i18n/locales/en/videopoker.json
@@ -4,7 +4,8 @@
     "chips": "Chips: {{chips}}",
     "bet": "Bet: {{bet}} coin(s)",
     "payout": "Payout: {{payout}}",
-    "betAmount": "Coins"
+    "betAmount": "Coins",
+    "autoHold": "Auto-hold"
   },
   "button": {
     "deal": "Deal",

--- a/frontend/src/i18n/locales/ja/deuceswild.json
+++ b/frontend/src/i18n/locales/ja/deuceswild.json
@@ -4,7 +4,8 @@
     "chips": "チップ: {{chips}}",
     "bet": "ベット: {{bet}}コイン",
     "payout": "配当: {{payout}}",
-    "betAmount": "コイン数"
+    "betAmount": "コイン数",
+    "autoHold": "自動ホールド"
   },
   "button": {
     "deal": "ディール",

--- a/frontend/src/i18n/locales/ja/jokerpoker.json
+++ b/frontend/src/i18n/locales/ja/jokerpoker.json
@@ -4,7 +4,8 @@
     "chips": "チップ: {{chips}}",
     "bet": "ベット: {{bet}}コイン",
     "payout": "配当: {{payout}}",
-    "betAmount": "コイン数"
+    "betAmount": "コイン数",
+    "autoHold": "自動ホールド"
   },
   "button": {
     "deal": "ディール",

--- a/frontend/src/i18n/locales/ja/videopoker.json
+++ b/frontend/src/i18n/locales/ja/videopoker.json
@@ -4,7 +4,8 @@
     "chips": "チップ: {{chips}}",
     "bet": "ベット: {{bet}}コイン",
     "payout": "配当: {{payout}}",
-    "betAmount": "コイン数"
+    "betAmount": "コイン数",
+    "autoHold": "自動ホールド"
   },
   "button": {
     "deal": "ディール",


### PR DESCRIPTION
## Summary
Casino video-poker terminals pre-select the cards a basic-strategy hint would recommend the moment a hand is dealt; the web port required all five holds to be picked manually. The shared \`VideoPokerGameContent\` now:

- Computes the hint directly via \`getVideoPokerBaseHint\` on phase transition into DRAW, independent of whether the hint UI is toggled on.
- Pre-populates \`heldCards\` from the recommended indices.
- Exposes a footer \`Auto-hold\` toggle (default ON, persisted per variant via \`useLocalStorageToggle('auto_hold_<game>')\`).
- Routes the variant-specific wild-card predicate (videopoker = none, deuceswild = 2s, jokerpoker = jokers) to the shared base hint.

Player can still toggle individual holds before pressing Draw — auto-hold only seeds the initial state, never overwrites manual edits later in the same hand.

## Test plan
- [x] \`bun run test -- --run VideoPokerGameContent\` (15/15: existing + 2 new — auto-hold pre-selects high cards on draw, toggling auto-hold off leaves all cards unheld)
- [x] Existing \`sends hold indices on draw\` test now toggles auto-hold off first to keep the click-driven assertion meaningful
- [x] \`bun run check\` clean
- [ ] Frontend build via GH Actions (local OOM)

Closes #1657