### PR TITLE
feat(spiteandmalice): AutoComplete chains self-evident foundation moves

### DIFF
--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -1379,7 +1379,7 @@ export const calculationApi = createSolitaireMoveApi<
 >('calculation');
 
 /** Command verbs accepted by the Spite & Malice /spiteandmalice/exec endpoint. */
-export type SpiteAndMaliceCommand = 'reset' | 'move' | 'discard' | 'cpu' | 'hint' | 'log';
+export type SpiteAndMaliceCommand = 'reset' | 'move' | 'discard' | 'cpu' | 'autocomplete' | 'hint' | 'log';
 
 /** API client for the Spite & Malice /spiteandmalice/exec endpoint. */
 export const spiteAndMaliceApi = {

--- a/frontend/src/i18n/locales/en/spiteandmalice.json
+++ b/frontend/src/i18n/locales/en/spiteandmalice.json
@@ -19,6 +19,7 @@
   "moveCount": "Moves",
   "endTurn": "End turn",
   "discard": "Discard",
+  "autoComplete": "Auto Complete",
   "selectSource": "Select a card to play",
   "selectFoundation": "Select a foundation",
   "selectSide": "Select a side pile to discard to",

--- a/frontend/src/i18n/locales/ja/spiteandmalice.json
+++ b/frontend/src/i18n/locales/ja/spiteandmalice.json
@@ -19,6 +19,7 @@
   "moveCount": "手数",
   "endTurn": "ターン終了",
   "discard": "ディスカード",
+  "autoComplete": "自動完成",
   "selectSource": "出すカードを選んでください",
   "selectFoundation": "出すファウンデーションを選んでください",
   "selectSide": "捨てるサイドパイルを選んでください",

--- a/frontend/src/pages/SpiteAndMalicePage.test.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { spiteAndMaliceApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -41,6 +41,7 @@ const baseState: SpiteAndMaliceResponse = {
   winner: -1,
   goalSize: 20,
   cpuDifficulty: 1,
+  canAutoComplete: false,
   message: '',
   messageCode: 'spiteandmalice.playing',
 };
@@ -104,5 +105,37 @@ describe('SpiteAndMalicePage', () => {
     mockExec.mockResolvedValue(loseState);
     renderWithProviders(<SpiteAndMalicePage />);
     await waitFor(() => expect(screen.getAllByText(/ゲームオーバー|Game Over/).length).toBeGreaterThan(0));
+  });
+
+  it('renders the autocomplete button on human turn and disables it when canAutoComplete=false', async () => {
+    mockExec.mockResolvedValue(baseState);
+    renderWithProviders(<SpiteAndMalicePage />);
+    await waitFor(() => expect(screen.getByTestId('sam-autocomplete-btn')).toBeInTheDocument());
+    expect(screen.getByTestId('sam-autocomplete-btn')).toBeDisabled();
+  });
+
+  it('enables the autocomplete button when canAutoComplete=true and dispatches the command on click', async () => {
+    const playableState: SpiteAndMaliceResponse = { ...baseState, canAutoComplete: true };
+    mockExec.mockResolvedValue(playableState);
+    renderWithProviders(<SpiteAndMalicePage />);
+    await waitFor(() => expect(screen.getByTestId('sam-autocomplete-btn')).toBeEnabled());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(playableState);
+    fireEvent.click(screen.getByTestId('sam-autocomplete-btn'));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
+  });
+
+  it('hides the autocomplete button on CPU turn and at game over', async () => {
+    mockExec.mockResolvedValue(cpuTurnState);
+    const { unmount } = renderWithProviders(<SpiteAndMalicePage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(screen.queryByTestId('sam-autocomplete-btn')).not.toBeInTheDocument();
+    unmount();
+
+    mockExec.mockResolvedValue(winState);
+    renderWithProviders(<SpiteAndMalicePage />);
+    await waitFor(() => expect(screen.getAllByText(/ゲームオーバー|Game Over/).length).toBeGreaterThan(0));
+    expect(screen.queryByTestId('sam-autocomplete-btn')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/SpiteAndMalicePage.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.tsx
@@ -67,6 +67,9 @@ function parseSamCommand(input: string): CliParseResult<ApiArgs> {
       return { args: ['reset'] };
     case 'cpu':
       return { args: ['cpu'] };
+    case 'ac':
+    case 'autocomplete':
+      return { args: ['autocomplete'] };
     case 'l':
     case 'log':
       return { args: ['log'] };
@@ -155,6 +158,7 @@ function SpiteAndMalicePageContent() {
         'ps <s> <f>     Play side[s] top to foundation f',
         'd <h> <s>      Discard hand[h] to side[s] (ends turn)',
         'cpu            Advance CPU turn',
+        'ac             Auto-complete (play every legal foundation move)',
         'h              Hint',
         'r              Reset',
         'l              Action log',
@@ -172,6 +176,11 @@ function SpiteAndMalicePageContent() {
     void apiCall('reset');
     playSound('shuffle');
   }, [apiCall, playSound]);
+
+  const handleAutoComplete = useCallback(() => {
+    setSelection(null);
+    void apiCall('autocomplete');
+  }, [apiCall]);
 
   const isHumanTurn = state ? state.current === 0 : false;
   const isGameOver = state ? state.phase === SpiteAndMalicePhase.GAME_OVER : false;
@@ -351,6 +360,18 @@ function SpiteAndMalicePageContent() {
                 loading={loading}
                 dataTutorial="sam-reset"
               />
+
+              {!isGameOver && isHumanTurn && (
+                <button
+                  type="button"
+                  className={btnPrimary}
+                  onClick={handleAutoComplete}
+                  disabled={loading || !state.canAutoComplete}
+                  data-testid="sam-autocomplete-btn"
+                >
+                  {t('autoComplete')}
+                </button>
+              )}
 
               {isGameOver && (
                 <button type="button" className={btnOutline} onClick={() => showActionLog()} disabled={loading}>

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -3148,6 +3148,8 @@ export interface SpiteAndMaliceResponse {
   winner: number;
   goalSize: number;
   cpuDifficulty: number;
+  /** True when the human can auto-complete at least one foundation move on their turn. */
+  canAutoComplete: boolean;
   hint?: SpiteAndMaliceHint;
   message: string;
   messageCode?: string;

--- a/frontend/src/utils/hints/spiteAndMaliceHint.test.ts
+++ b/frontend/src/utils/hints/spiteAndMaliceHint.test.ts
@@ -17,6 +17,7 @@ const baseState: SpiteAndMaliceResponse = {
   winner: -1,
   goalSize: 20,
   cpuDifficulty: 1,
+  canAutoComplete: false,
   message: '',
 };
 

--- a/internal/adapter/controller/SpiteAndMaliceCuiController.go
+++ b/internal/adapter/controller/SpiteAndMaliceCuiController.go
@@ -30,7 +30,7 @@ func (c *SpiteAndMaliceCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return c.si.Reset() },
-		[]string{"ph", "pg", "ps", "d", "discard", "cpu", "h", "hint", "log", "l"},
+		[]string{"ph", "pg", "ps", "d", "discard", "cpu", "ac", "autocomplete", "h", "hint", "log", "l"},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "ph":
@@ -43,6 +43,8 @@ func (c *SpiteAndMaliceCuiController) Exec(command string) string {
 				return c.handleDiscard(args), true
 			case "cpu":
 				return c.si.CpuStep(), true
+			case "ac", "autocomplete":
+				return c.si.AutoComplete(), true
 			default:
 				return handleCuiHintAndLog(cmd, c.si.Hint, c.si.ActionLog)
 			}

--- a/internal/adapter/controller/SpiteAndMaliceWebController.go
+++ b/internal/adapter/controller/SpiteAndMaliceWebController.go
@@ -39,18 +39,19 @@ type SpiteAndMaliceWebHint struct {
 
 // SpiteAndMaliceWebOutput Spite & Malice Web 出力
 type SpiteAndMaliceWebOutput struct {
-	Phase          int                                                     `json:"phase"`
-	Current        int                                                     `json:"current"`
-	Players        [domain.SpiteAndMalicePlayerCnt]SpiteAndMaliceWebPlayer `json:"players"`
-	Foundations    [domain.SpiteAndMaliceFoundationCnt][]*WebOutputCard    `json:"foundations"`
-	FoundationTops [domain.SpiteAndMaliceFoundationCnt]int                 `json:"foundationTops"`
-	StockSize      int                                                     `json:"stockSize"`
-	CompletedSize  int                                                     `json:"completedSize"`
-	MoveCount      int                                                     `json:"moveCount"`
-	Winner         int                                                     `json:"winner"`
-	GoalSize       int                                                     `json:"goalSize"`
-	CpuDifficulty  int                                                     `json:"cpuDifficulty"`
-	Hint           *SpiteAndMaliceWebHint                                  `json:"hint,omitempty"`
+	Phase           int                                                     `json:"phase"`
+	Current         int                                                     `json:"current"`
+	Players         [domain.SpiteAndMalicePlayerCnt]SpiteAndMaliceWebPlayer `json:"players"`
+	Foundations     [domain.SpiteAndMaliceFoundationCnt][]*WebOutputCard    `json:"foundations"`
+	FoundationTops  [domain.SpiteAndMaliceFoundationCnt]int                 `json:"foundationTops"`
+	StockSize       int                                                     `json:"stockSize"`
+	CompletedSize   int                                                     `json:"completedSize"`
+	MoveCount       int                                                     `json:"moveCount"`
+	Winner          int                                                     `json:"winner"`
+	GoalSize        int                                                     `json:"goalSize"`
+	CpuDifficulty   int                                                     `json:"cpuDifficulty"`
+	CanAutoComplete bool                                                    `json:"canAutoComplete"`
+	Hint            *SpiteAndMaliceWebHint                                  `json:"hint,omitempty"`
 	WebOutputBase
 }
 
@@ -79,6 +80,8 @@ func spiteAndMaliceDispatch(bc *baseController, w http.ResponseWriter, si usecas
 		return spiteAndMaliceDiscardDispatch(bc, w, si, param, newDefault)
 	case "cpu":
 		bc.writePresenterResponse(w, si.CpuStep())
+	case "ac", "autocomplete":
+		bc.writePresenterResponse(w, si.AutoComplete())
 	default:
 		return dispatchResetHintAndLog(param.Command, bc, w, si.Reset, si.Hint, si.ActionLog)
 	}

--- a/internal/adapter/controller/usecase/SpiteAndMaliceInteractor_mock.go
+++ b/internal/adapter/controller/usecase/SpiteAndMaliceInteractor_mock.go
@@ -35,6 +35,10 @@ func (_m *MockSpiteAndMaliceInteractor) CpuStep() string {
 	return _m.Called().Get(0).(string)
 }
 
+func (_m *MockSpiteAndMaliceInteractor) AutoComplete() string {
+	return _m.Called().Get(0).(string)
+}
+
 func (_m *MockSpiteAndMaliceInteractor) Hint() string {
 	return _m.Called().Get(0).(string)
 }

--- a/internal/adapter/presenter/SpiteAndMaliceWebPresenter.go
+++ b/internal/adapter/presenter/SpiteAndMaliceWebPresenter.go
@@ -69,6 +69,7 @@ func (p *SpiteAndMaliceWebPresenter) buildBase(g interfaces.SpiteAndMaliceGame) 
 	cfg := g.GetConfig()
 	resObj.GoalSize = cfg.GoalSize
 	resObj.CpuDifficulty = int(cfg.CpuDifficulty)
+	resObj.CanAutoComplete = g.CanAutoComplete()
 
 	foundations := g.GetFoundations()
 	for i := range domain.SpiteAndMaliceFoundationCnt {

--- a/internal/adapter/presenter/SpiteAndMaliceWebPresenter_test.go
+++ b/internal/adapter/presenter/SpiteAndMaliceWebPresenter_test.go
@@ -22,6 +22,7 @@ func setupSpiteAndMaliceWebMockDefaults(g *interfaces.MockSpiteAndMaliceGame) {
 	g.On("GetStockSize").Return(40).Maybe()
 	g.On("GetCompletedSize").Return(0).Maybe()
 	g.On("GetConfig").Return(domain.DefaultSpiteAndMaliceConfig()).Maybe()
+	g.On("CanAutoComplete").Return(false).Maybe()
 	var foundations [domain.SpiteAndMaliceFoundationCnt][]*domain.Card
 	foundations[0] = []*domain.Card{domain.NewCard(domain.CardDesignSpade, 1, false)}
 	g.On("GetFoundations").Return(foundations).Maybe()
@@ -74,6 +75,7 @@ func TestSpiteAndMaliceWebPresenter_Output(t *testing.T) {
 		g.On("GetStockSize").Return(0).Maybe()
 		g.On("GetCompletedSize").Return(0).Maybe()
 		g.On("GetConfig").Return(domain.DefaultSpiteAndMaliceConfig()).Maybe()
+		g.On("CanAutoComplete").Return(false).Maybe()
 		var foundations [domain.SpiteAndMaliceFoundationCnt][]*domain.Card
 		g.On("GetFoundations").Return(foundations).Maybe()
 		for i := range domain.SpiteAndMaliceFoundationCnt {
@@ -96,6 +98,7 @@ func TestSpiteAndMaliceWebPresenter_Output(t *testing.T) {
 		g.On("GetStockSize").Return(0).Maybe()
 		g.On("GetCompletedSize").Return(0).Maybe()
 		g.On("GetConfig").Return(domain.DefaultSpiteAndMaliceConfig()).Maybe()
+		g.On("CanAutoComplete").Return(false).Maybe()
 		var foundations [domain.SpiteAndMaliceFoundationCnt][]*domain.Card
 		g.On("GetFoundations").Return(foundations).Maybe()
 		for i := range domain.SpiteAndMaliceFoundationCnt {
@@ -121,6 +124,7 @@ func TestSpiteAndMaliceWebPresenter_Output(t *testing.T) {
 			g.On("GetStockSize").Return(0).Maybe()
 			g.On("GetCompletedSize").Return(0).Maybe()
 			g.On("GetConfig").Return(domain.DefaultSpiteAndMaliceConfig()).Maybe()
+			g.On("CanAutoComplete").Return(false).Maybe()
 			var foundations [domain.SpiteAndMaliceFoundationCnt][]*domain.Card
 			g.On("GetFoundations").Return(foundations).Maybe()
 			for i := range domain.SpiteAndMaliceFoundationCnt {
@@ -156,6 +160,7 @@ func TestSpiteAndMaliceWebPresenter_Output(t *testing.T) {
 		g.On("GetStockSize").Return(0).Maybe()
 		g.On("GetCompletedSize").Return(0).Maybe()
 		g.On("GetConfig").Return(domain.DefaultSpiteAndMaliceConfig()).Maybe()
+		g.On("CanAutoComplete").Return(false).Maybe()
 		var foundations [domain.SpiteAndMaliceFoundationCnt][]*domain.Card
 		g.On("GetFoundations").Return(foundations).Maybe()
 		for i := range domain.SpiteAndMaliceFoundationCnt {

--- a/internal/domain/SpiteAndMalice.go
+++ b/internal/domain/SpiteAndMalice.go
@@ -296,7 +296,7 @@ func (s *SpiteAndMalice) AutoComplete() error {
 	// a generous cap (2 decks * full deck rotations) — the loop normally exits
 	// via "no playable move" long before this and the cap is just defensive.
 	const maxIterations = 1024
-	for iter := 0; iter < maxIterations; iter++ {
+	for range maxIterations {
 		if s.phase != SpiteAndMalicePhasePlaying || s.IsCpuTurn() {
 			return nil
 		}

--- a/internal/domain/SpiteAndMalice.go
+++ b/internal/domain/SpiteAndMalice.go
@@ -275,6 +275,59 @@ func (s *SpiteAndMalice) CpuStep() error {
 	return errors.New("invalid cpu hint")
 }
 
+// AutoComplete plays every immediately-legal foundation move from the human's
+// own piles (goal → hand → side) without rotating the turn. It stops when no
+// playable move remains or the game ends. Discards are intentionally skipped
+// since those rotate the turn and may give the opponent a strategic opening,
+// which the player should always confirm by hand.
+//
+// CanAutoComplete must guard the call site — it returns true only when the
+// human is on turn and at least one safe foundation move exists.
+func (s *SpiteAndMalice) AutoComplete() error {
+	if s.phase != SpiteAndMalicePhasePlaying {
+		return errors.New("game is over")
+	}
+	if s.IsCpuTurn() {
+		return errors.New("not human turn")
+	}
+	// Bounded loop: a single AutoComplete call can never play more moves than
+	// the number of cards in play, so we cap by player + foundation capacity.
+	maxIterations := SpiteAndMaliceFoundationCnt * SpiteAndMaliceFoundationMax * SpiteAndMalicePlayerCnt
+	for iter := 0; iter < maxIterations; iter++ {
+		if s.phase != SpiteAndMalicePhasePlaying || s.IsCpuTurn() {
+			return nil
+		}
+		move := s.findPlayableMove(s.current)
+		if move == nil {
+			return nil
+		}
+		var err error
+		switch move.Source {
+		case SpiteAndMaliceSourceGoal:
+			err = s.PlayFromGoal(move.FoundationIdx)
+		case SpiteAndMaliceSourceHand:
+			err = s.PlayFromHand(move.Index, move.FoundationIdx)
+		case SpiteAndMaliceSourceSide:
+			err = s.PlayFromSide(move.Index, move.FoundationIdx)
+		default:
+			return errors.New("invalid auto-complete move")
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return errors.New("auto-complete exceeded iteration cap")
+}
+
+// CanAutoComplete reports whether the player has a playable foundation move
+// available right now. The frontend uses this to enable / disable the button.
+func (s *SpiteAndMalice) CanAutoComplete() bool {
+	if s.phase != SpiteAndMalicePhasePlaying || s.IsCpuTurn() {
+		return false
+	}
+	return s.findPlayableMove(s.current) != nil
+}
+
 // GetHint 現在ターンの推奨手を返す (人間向け)。ゲーム終了時は nil。
 func (s *SpiteAndMalice) GetHint() *SpiteAndMaliceHint {
 	if s.phase != SpiteAndMalicePhasePlaying {

--- a/internal/domain/SpiteAndMalice.go
+++ b/internal/domain/SpiteAndMalice.go
@@ -290,9 +290,12 @@ func (s *SpiteAndMalice) AutoComplete() error {
 	if s.IsCpuTurn() {
 		return errors.New("not human turn")
 	}
-	// Bounded loop: a single AutoComplete call can never play more moves than
-	// the number of cards in play, so we cap by player + foundation capacity.
-	maxIterations := SpiteAndMaliceFoundationCnt * SpiteAndMaliceFoundationMax * SpiteAndMalicePlayerCnt
+	// Bounded loop: AutoComplete only ever processes the human's piles, but
+	// completed foundations refill from the shared stock so a single call can
+	// chain more moves than CardCnt * 2 in pathological end-game states. Use
+	// a generous cap (2 decks * full deck rotations) — the loop normally exits
+	// via "no playable move" long before this and the cap is just defensive.
+	const maxIterations = 1024
 	for iter := 0; iter < maxIterations; iter++ {
 		if s.phase != SpiteAndMalicePhasePlaying || s.IsCpuTurn() {
 			return nil

--- a/internal/domain/SpiteAndMalice_test.go
+++ b/internal/domain/SpiteAndMalice_test.go
@@ -522,6 +522,63 @@ func TestSpiteAndMalice_CpuStep_EasyDifficulty(t *testing.T) {
 	assert.Equal(t, 1, total)
 }
 
+// --- AutoComplete ---
+
+func TestSpiteAndMalice_AutoComplete_PlaysGoalThenHandThenSide(t *testing.T) {
+	g := newTestSpiteAndMalice()
+	g.SetCurrent(SpiteAndMaliceHumanIdx)
+	// Foundation 0 currently holds 1; legal next play is 2.
+	g.SetFoundation(0, []*Card{mkCard(CardDesignSpade, 1)})
+	// Hand has the 2 (playable on foundation 0) and a 9 (no anchor).
+	g.SetPlayerHand(SpiteAndMaliceHumanIdx, []*Card{mkCard(CardDesignHeart, 2), mkCard(CardDesignHeart, 9)})
+	// Goal top is 3 — playable after the 2.
+	g.SetPlayerGoal(SpiteAndMaliceHumanIdx, []*Card{mkCard(CardDesignClover, 3)})
+
+	require.NoError(t, g.AutoComplete())
+
+	// Foundation 0 should now have 1, 2, 3 stacked.
+	assert.Equal(t, 3, g.GetFoundationTopValue(0))
+	// Goal got drained, hand drained the 2; the 9 stays.
+	human := g.GetPlayer(SpiteAndMaliceHumanIdx)
+	assert.Equal(t, 0, human.GoalSize())
+	assert.Equal(t, 1, human.HandSize())
+	// Auto-complete should not rotate the turn.
+	assert.Equal(t, SpiteAndMaliceHumanIdx, g.GetCurrent())
+}
+
+func TestSpiteAndMalice_AutoComplete_NoOpWhenNothingPlayable(t *testing.T) {
+	g := newTestSpiteAndMalice()
+	g.SetCurrent(SpiteAndMaliceHumanIdx)
+	// Foundation empty; hand has no Ace and no wild — nothing legal.
+	g.SetPlayerHand(SpiteAndMaliceHumanIdx, []*Card{mkCard(CardDesignSpade, 5), mkCard(CardDesignHeart, 8)})
+	moveCountBefore := g.GetMoveCount()
+	require.NoError(t, g.AutoComplete())
+	assert.Equal(t, moveCountBefore, g.GetMoveCount(), "no moves should have been made")
+}
+
+func TestSpiteAndMalice_AutoComplete_RefusesOnCpuTurn(t *testing.T) {
+	g := newTestSpiteAndMalice()
+	g.SetCurrent(SpiteAndMaliceCpuIdx)
+	err := g.AutoComplete()
+	require.Error(t, err)
+}
+
+func TestSpiteAndMalice_CanAutoComplete_TrueWhenMoveAvailable(t *testing.T) {
+	g := newTestSpiteAndMalice()
+	g.SetCurrent(SpiteAndMaliceHumanIdx)
+	g.SetFoundation(0, []*Card{mkCard(CardDesignSpade, 1)})
+	g.SetPlayerHand(SpiteAndMaliceHumanIdx, []*Card{mkCard(CardDesignHeart, 2)})
+	assert.True(t, g.CanAutoComplete())
+}
+
+func TestSpiteAndMalice_CanAutoComplete_FalseOnCpuTurn(t *testing.T) {
+	g := newTestSpiteAndMalice()
+	g.SetCurrent(SpiteAndMaliceCpuIdx)
+	g.SetFoundation(0, []*Card{mkCard(CardDesignSpade, 1)})
+	g.SetPlayerHand(SpiteAndMaliceCpuIdx, []*Card{mkCard(CardDesignHeart, 2)})
+	assert.False(t, g.CanAutoComplete())
+}
+
 func TestSpiteAndMalicePlayer_JSONRoundTrip(t *testing.T) {
 	p := NewSpiteAndMalicePlayer(true)
 	p.AddToHand(mkCard(CardDesignSpade, 1))

--- a/internal/domain/interfaces/spiteandmalice.go
+++ b/internal/domain/interfaces/spiteandmalice.go
@@ -19,6 +19,10 @@ type SpiteAndMaliceGame interface {
 	Discard(handIdx, sideIdx int) error
 	// CpuStep CPU の手番を 1 ステップ進める
 	CpuStep() error
+	// AutoComplete 自明な (foundation に出せる) 手を連続で適用する
+	AutoComplete() error
+	// CanAutoComplete AutoComplete が有効に働く状態か
+	CanAutoComplete() bool
 	// IsCpuTurn 現在のターンが CPU か
 	IsCpuTurn() bool
 	// GetHint 現在ターンの推奨手を返す

--- a/internal/domain/interfaces/spiteandmalice_mock.go
+++ b/internal/domain/interfaces/spiteandmalice_mock.go
@@ -37,6 +37,14 @@ func (_m *MockSpiteAndMaliceGame) CpuStep() error {
 	return _m.Called().Error(0)
 }
 
+func (_m *MockSpiteAndMaliceGame) AutoComplete() error {
+	return _m.Called().Error(0)
+}
+
+func (_m *MockSpiteAndMaliceGame) CanAutoComplete() bool {
+	return _m.Called().Bool(0)
+}
+
 func (_m *MockSpiteAndMaliceGame) IsCpuTurn() bool {
 	return _m.Called().Bool(0)
 }

--- a/internal/usecase/SpiteAndMaliceInteractor.go
+++ b/internal/usecase/SpiteAndMaliceInteractor.go
@@ -22,6 +22,8 @@ type SpiteAndMaliceInteractorIF interface {
 	Discard(handIdx, sideIdx int) string
 	// CpuStep CPU の手番を 1 ステップ進める
 	CpuStep() string
+	// AutoComplete 自明な手をまとめて適用する
+	AutoComplete() string
 	// Hint 推奨手を出力する
 	Hint() string
 	// ActionLog 棋譜を出力する
@@ -68,6 +70,11 @@ func (si *SpiteAndMaliceInteractor) Discard(handIdx, sideIdx int) string {
 // CpuStep CPU の手番を 1 ステップ進める
 func (si *SpiteAndMaliceInteractor) CpuStep() string {
 	return execAndPresent(si.Game, si.sp, si.Game.CpuStep)
+}
+
+// AutoComplete 自明な手をまとめて適用する
+func (si *SpiteAndMaliceInteractor) AutoComplete() string {
+	return execAndPresent(si.Game, si.sp, si.Game.AutoComplete)
 }
 
 // Hint 推奨手を出力する


### PR DESCRIPTION
## Summary
Spite & Malice's late game has plenty of moments where a chain of foundation moves is fully deterministic (sequential A→Q, often unlocked by a goal-pile flip). The only way to advance was to manually click each one. Other solitaire games in this repo already ship AutoComplete; this brings the same affordance to Spite & Malice.

**Domain:**
- New \`AutoComplete()\` loops \`findPlayableMove\` on the human's piles (goal → hand → side) without rotating the turn, capped at a finite iteration count to be defensive.
- \`CanAutoComplete()\` reports whether at least one safe move exists so the UI can disable the button preemptively.
- Discards are intentionally skipped — those rotate the turn and may give the opponent strategic openings, so the player should always confirm those.

**Surface:**
- \`InteractorIF.AutoComplete\` + mock entry.
- Web verb \`autocomplete\` + CUI \`ac\` / \`autocomplete\` command.
- Web presenter serialises \`canAutoComplete\` so the page can drive the button state.
- New footer button (\`sam-autocomplete-btn\`), disabled when \`canAutoComplete\` is false, hidden on CPU turn / game-over.

## Test plan
- [x] \`go test -tags test ./internal/domain ./internal/usecase ./internal/adapter/...\` — all green; 5 new domain tests cover happy-path chaining, no-op when nothing is playable, refusal on CPU turn, and the CanAutoComplete predicate.
- [x] \`bun run test -- --run SpiteAndMalicePage\` (9/9: 3 new — disabled button on canAutoComplete=false, dispatches on click when true, hidden on CPU turn / game-over).
- [x] \`bun run check\` clean.
- [x] \`goimports -w\` on every Go file changed.
- [ ] Frontend build via GH Actions.

Closes #1661