### PR TITLE
feat(pinochle): click-to-highlight meld badges during the meld phase

### DIFF
--- a/frontend/src/i18n/locales/en/pinochle.json
+++ b/frontend/src/i18n/locales/en/pinochle.json
@@ -25,6 +25,7 @@
   "highestBid": "Highest Bid",
   "trumpSuit": "Trump Suit",
   "meldScore": "Meld Score",
+  "meldHighlightHint": "Click a meld badge to highlight the cards that form it",
   "trickPoints": "Trick Points",
   "round": "Round",
   "trick": "Trick",

--- a/frontend/src/i18n/locales/ja/pinochle.json
+++ b/frontend/src/i18n/locales/ja/pinochle.json
@@ -25,6 +25,7 @@
   "highestBid": "最高ビッド",
   "trumpSuit": "切り札",
   "meldScore": "メルド得点",
+  "meldHighlightHint": "メルドバッジをクリックすると手札の対応カードがハイライトされます",
   "trickPoints": "トリック得点",
   "round": "ラウンド",
   "trick": "トリック",

--- a/frontend/src/pages/PinochlePage.test.tsx
+++ b/frontend/src/pages/PinochlePage.test.tsx
@@ -198,6 +198,60 @@ describe('PinochlePage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('meld'));
   });
 
+  it('clicking a meld badge highlights the matching cards in the human hand', async () => {
+    // Construct a meld-phase state where the human holds the cards forming
+    // a Common Marriage (K♥ + Q♥), plus an unrelated A♠ that should NOT
+    // glow when the marriage badge is selected.
+    const meldStateWithHumanMeld: PinochleResponse = {
+      ...meldPhaseState,
+      players: makePlayers([
+        {
+          id: 0,
+          isHuman: true,
+          cardCount: 3,
+          cards: [
+            { design: 'HEART', value: 13 },
+            { design: 'HEART', value: 12 },
+            { design: 'SPADE', value: 1 },
+          ],
+        },
+      ]),
+      playerMelds: [
+        [
+          {
+            type: 1, // PinochleMeldCommonMarriage
+            points: 20,
+            cards: [
+              { design: 'HEART', value: 13 },
+              { design: 'HEART', value: 12 },
+            ],
+          },
+        ],
+        [],
+        [],
+        [],
+      ],
+    };
+    mockExec.mockResolvedValue(meldStateWithHumanMeld);
+    renderWithProviders(<PinochlePage />);
+    await waitFor(() => expect(screen.getByTestId('pn-meld-badge-0')).toBeInTheDocument());
+
+    // Before click — no card carries the highlight marker.
+    expect(screen.queryByLabelText('♥ K')).not.toHaveAttribute('data-meld-highlighted');
+    expect(screen.queryByLabelText('♥ Q')).not.toHaveAttribute('data-meld-highlighted');
+
+    fireEvent.click(screen.getByTestId('pn-meld-badge-0'));
+
+    // After click — both Hearts in the meld glow; the unrelated Spade A doesn't.
+    expect(screen.getByLabelText('♥ K')).toHaveAttribute('data-meld-highlighted', 'true');
+    expect(screen.getByLabelText('♥ Q')).toHaveAttribute('data-meld-highlighted', 'true');
+    expect(screen.getByLabelText('♠ A')).not.toHaveAttribute('data-meld-highlighted');
+
+    // Clicking the active badge a second time clears the highlight.
+    fireEvent.click(screen.getByTestId('pn-meld-badge-0'));
+    expect(screen.getByLabelText('♥ K')).not.toHaveAttribute('data-meld-highlighted');
+  });
+
   it('renders play phase with human cards', async () => {
     mockExec.mockResolvedValue(playPhaseState);
     renderWithProviders(<PinochlePage />);

--- a/frontend/src/pages/PinochlePage.tsx
+++ b/frontend/src/pages/PinochlePage.tsx
@@ -172,6 +172,18 @@ function PinochlePageContent() {
     }
   }, [state?.phase]);
 
+  // Memoised highlight keys — the underlying meld card list rarely changes,
+  // and recomputing the Set on every render (incl. unrelated state churn like
+  // bidAmount edits) is wasted work. Computed before the early return so the
+  // hook order stays stable on first render when state is still null.
+  const highlightedCardKeys = useMemo(() => {
+    if (!state || highlightedMeldIdx === null) return new Set<string>();
+    const humanIdxLocal = state.players.findIndex((p) => p.isHuman);
+    const meld = humanIdxLocal >= 0 ? state.playerMelds[humanIdxLocal]?.[highlightedMeldIdx] : null;
+    if (!meld) return new Set<string>();
+    return new Set<string>(meld.cards.map((c) => `${c.design}-${c.value}`));
+  }, [state, highlightedMeldIdx]);
+
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) {
@@ -189,15 +201,6 @@ function PinochlePageContent() {
   const isTrumpTurn = phase === PinochlePhase.TRUMP && state.players?.[state.currentPlayerIdx]?.isHuman;
   const isPlayTurn = phase === PinochlePhase.PLAY && state.players?.[state.currentPlayerIdx]?.isHuman;
   const isGameEnd = phase === PinochlePhase.GAME_END || state.gameEndFlag;
-  // Build a Set of "design-value" keys so the hand renderer can ring every
-  // copy of a card that participates in the highlighted meld. Pinochle uses
-  // a double deck, so two copies of the same rank+suit are equivalent for
-  // the meld and should both glow.
-  const highlightedMeld =
-    humanIdx >= 0 && highlightedMeldIdx !== null ? state.playerMelds[humanIdx]?.[highlightedMeldIdx] : null;
-  const highlightedCardKeys = new Set<string>(
-    highlightedMeld?.cards.map((c: { design: string; value: number }) => `${c.design}-${c.value}`) ?? [],
-  );
 
   return (
     <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.pinochle.bg}`} aria-busy={loading}>
@@ -373,7 +376,7 @@ function PinochlePageContent() {
                       disabled={loading || !isPlayTurn || !isValid}
                       aria-label={cardAlt(card)}
                       data-meld-highlighted={inHighlightedMeld ? 'true' : undefined}
-                      className={`transition-transform${inHighlightedMeld ? ' ring-4 ring-ds-accent' : ''}`}
+                      className={`transition${inHighlightedMeld ? ' ring-4 ring-ds-accent' : ''}`}
                       style={{
                         background: 'none',
                         padding: 0,

--- a/frontend/src/pages/PinochlePage.tsx
+++ b/frontend/src/pages/PinochlePage.tsx
@@ -126,6 +126,10 @@ function PinochlePageContent() {
   const phaseNames = usePhaseNames('pinochle', PINOCHLE_PHASE_KEYS);
 
   const [bidAmount, setBidAmount] = useState(20);
+  // Index into the human player's meld list. When set, every hand card whose
+  // (design, value) appears in that meld is ringed so the player can read the
+  // meld back to the cards. Reset on phase exit.
+  const [highlightedMeldIdx, setHighlightedMeldIdx] = useState<number | null>(null);
 
   // Auto-update bid amount when highest bid changes
   // CLI mode
@@ -160,6 +164,14 @@ function PinochlePageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
+  // Drop the meld highlight whenever the meld phase exits so a stale ring
+  // doesn't carry into the trick-play phase.
+  useEffect(() => {
+    if (state?.phase !== PinochlePhase.MELD) {
+      setHighlightedMeldIdx(null);
+    }
+  }, [state?.phase]);
+
   useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state) {
@@ -172,10 +184,20 @@ function PinochlePageContent() {
 
   const phase = state.phase;
   const humanPlayer = state.players?.find((p) => p.isHuman);
+  const humanIdx = humanPlayer ? state.players.indexOf(humanPlayer) : -1;
   const isBidTurn = phase === PinochlePhase.BID && state.players?.[state.bidPlayerIdx]?.isHuman;
   const isTrumpTurn = phase === PinochlePhase.TRUMP && state.players?.[state.currentPlayerIdx]?.isHuman;
   const isPlayTurn = phase === PinochlePhase.PLAY && state.players?.[state.currentPlayerIdx]?.isHuman;
   const isGameEnd = phase === PinochlePhase.GAME_END || state.gameEndFlag;
+  // Build a Set of "design-value" keys so the hand renderer can ring every
+  // copy of a card that participates in the highlighted meld. Pinochle uses
+  // a double deck, so two copies of the same rank+suit are equivalent for
+  // the meld and should both glow.
+  const highlightedMeld =
+    humanIdx >= 0 && highlightedMeldIdx !== null ? state.playerMelds[humanIdx]?.[highlightedMeldIdx] : null;
+  const highlightedCardKeys = new Set<string>(
+    highlightedMeld?.cards.map((c: { design: string; value: number }) => `${c.design}-${c.value}`) ?? [],
+  );
 
   return (
     <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.pinochle.bg}`} aria-busy={loading}>
@@ -284,13 +306,36 @@ function PinochlePageContent() {
                   melds.length > 0 ? (
                     <div key={pIdx} className="text-ds-text-muted text-sm mb-1">
                       <span className="font-semibold">{playerName(pIdx, state.players[pIdx]?.isHuman)}: </span>
-                      {melds.map((m: PinochleMeldData, mIdx: number) => (
-                        <span key={mIdx} className="mr-2">
-                          {t(`meldTypes.${m.type}`)} ({m.points})
-                        </span>
-                      ))}
+                      {melds.map((m: PinochleMeldData, mIdx: number) => {
+                        const isHumanMeld = pIdx === humanIdx && phase === PinochlePhase.MELD;
+                        const isActive = isHumanMeld && highlightedMeldIdx === mIdx;
+                        if (!isHumanMeld) {
+                          return (
+                            <span key={mIdx} className="mr-2">
+                              {t(`meldTypes.${m.type}`)} ({m.points})
+                            </span>
+                          );
+                        }
+                        return (
+                          <button
+                            key={mIdx}
+                            type="button"
+                            onClick={() => setHighlightedMeldIdx((prev) => (prev === mIdx ? null : mIdx))}
+                            data-testid={`pn-meld-badge-${mIdx}`}
+                            data-active={isActive ? 'true' : undefined}
+                            className={`mr-2 inline-block px-2 py-0.5 rounded text-xs ${
+                              isActive ? 'bg-ds-accent text-black font-bold' : 'bg-black/20 hover:bg-ds-accent/30'
+                            }`}
+                          >
+                            {t(`meldTypes.${m.type}`)} ({m.points})
+                          </button>
+                        );
+                      })}
                     </div>
                   ) : null,
+                )}
+                {phase === PinochlePhase.MELD && highlightedCardKeys.size > 0 && (
+                  <div className="text-ds-text-muted text-xs mt-1">{t('meldHighlightHint')}</div>
                 )}
               </div>
             )}
@@ -319,6 +364,7 @@ function PinochlePageContent() {
               <div className="flex flex-wrap gap-1 mb-2" data-tutorial="pn-player-hand">
                 {humanPlayer.cards.map((card, idx) => {
                   const isValid = state.validPlayIndices?.includes(idx);
+                  const inHighlightedMeld = highlightedCardKeys.has(`${card.design}-${card.value}`);
                   return (
                     <button
                       type="button"
@@ -326,7 +372,8 @@ function PinochlePageContent() {
                       onClick={() => isPlayTurn && isValid && handlePlay(idx)}
                       disabled={loading || !isPlayTurn || !isValid}
                       aria-label={cardAlt(card)}
-                      className="transition-transform"
+                      data-meld-highlighted={inHighlightedMeld ? 'true' : undefined}
+                      className={`transition-transform${inHighlightedMeld ? ' ring-4 ring-ds-accent' : ''}`}
                       style={{
                         background: 'none',
                         padding: 0,


### PR DESCRIPTION
## Summary
The available-melds panel already lists every meld the engine detects in the human's hand, but reading the score back to the cards still required scanning a 12-card spread. Each human-side badge is now a clickable button: tapping it rings every \`(design, value)\` match in the hand with a thick accent ring; a second tap clears it.

Pinochle uses a double deck, so two copies of the same rank+suit are equivalent for the meld — both glow on purpose. The highlight clears on phase exit so a stale ring never bleeds into trick play.

This is a pure-frontend change — the engine already serialises \`playerMelds\` per player.

## Test plan
- [x] \`bun run test -- --run PinochlePage\` (24/24: existing + 1 new — clicking the human-side meld badge marks the correct hand cards via \`data-meld-highlighted=true\` and toggling clears it)
- [x] \`bun run check\` clean
- [ ] Frontend build via GH Actions

Closes #1668