### PR TITLE
feat(common): CPU animation speed setting (Normal/Fast/Instant)

### DIFF
--- a/frontend/src/components/common/ReplaySpeedSettingsPanel.test.tsx
+++ b/frontend/src/components/common/ReplaySpeedSettingsPanel.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { REPLAY_SPEED_STORAGE_KEY } from '../../hooks/useReplaySpeed';
+import { ReplaySpeedSettingsPanel } from './ReplaySpeedSettingsPanel';
+
+describe('ReplaySpeedSettingsPanel', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders the speed select with the persisted value', () => {
+    localStorage.setItem(REPLAY_SPEED_STORAGE_KEY, 'fast');
+    render(<ReplaySpeedSettingsPanel />);
+    const select = screen.getByLabelText('CPUアニメーション速度') as HTMLSelectElement;
+    expect(select.value).toBe('fast');
+  });
+
+  it('persists the chosen speed back to localStorage', () => {
+    render(<ReplaySpeedSettingsPanel />);
+    const select = screen.getByLabelText('CPUアニメーション速度') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'instant' } });
+    expect(select.value).toBe('instant');
+    expect(localStorage.getItem(REPLAY_SPEED_STORAGE_KEY)).toBe('instant');
+  });
+
+  it('offers all three speed options', () => {
+    render(<ReplaySpeedSettingsPanel />);
+    const select = screen.getByLabelText('CPUアニメーション速度') as HTMLSelectElement;
+    const values = Array.from(select.options).map((o) => o.value);
+    expect(values).toEqual(['normal', 'fast', 'instant']);
+  });
+});

--- a/frontend/src/components/common/ReplaySpeedSettingsPanel.test.tsx
+++ b/frontend/src/components/common/ReplaySpeedSettingsPanel.test.tsx
@@ -1,7 +1,10 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import i18n from 'i18next';
 import { afterEach, describe, expect, it } from 'vitest';
 import { REPLAY_SPEED_STORAGE_KEY } from '../../hooks/useReplaySpeed';
 import { ReplaySpeedSettingsPanel } from './ReplaySpeedSettingsPanel';
+
+const labelText = () => i18n.t('settings.replaySpeed.label', { ns: 'common' });
 
 describe('ReplaySpeedSettingsPanel', () => {
   afterEach(() => {
@@ -11,13 +14,13 @@ describe('ReplaySpeedSettingsPanel', () => {
   it('renders the speed select with the persisted value', () => {
     localStorage.setItem(REPLAY_SPEED_STORAGE_KEY, 'fast');
     render(<ReplaySpeedSettingsPanel />);
-    const select = screen.getByLabelText('CPUアニメーション速度') as HTMLSelectElement;
+    const select = screen.getByLabelText(labelText()) as HTMLSelectElement;
     expect(select.value).toBe('fast');
   });
 
   it('persists the chosen speed back to localStorage', () => {
     render(<ReplaySpeedSettingsPanel />);
-    const select = screen.getByLabelText('CPUアニメーション速度') as HTMLSelectElement;
+    const select = screen.getByLabelText(labelText()) as HTMLSelectElement;
     fireEvent.change(select, { target: { value: 'instant' } });
     expect(select.value).toBe('instant');
     expect(localStorage.getItem(REPLAY_SPEED_STORAGE_KEY)).toBe('instant');
@@ -25,7 +28,7 @@ describe('ReplaySpeedSettingsPanel', () => {
 
   it('offers all three speed options', () => {
     render(<ReplaySpeedSettingsPanel />);
-    const select = screen.getByLabelText('CPUアニメーション速度') as HTMLSelectElement;
+    const select = screen.getByLabelText(labelText()) as HTMLSelectElement;
     const values = Array.from(select.options).map((o) => o.value);
     expect(values).toEqual(['normal', 'fast', 'instant']);
   });

--- a/frontend/src/components/common/ReplaySpeedSettingsPanel.tsx
+++ b/frontend/src/components/common/ReplaySpeedSettingsPanel.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { type ReplaySpeed, useReplaySpeed } from '../../hooks/useReplaySpeed';
+import { isReplaySpeed, type ReplaySpeed, useReplaySpeed } from '../../hooks/useReplaySpeed';
 import { type SettingsGroup, SettingsPanel } from './SettingsPanel';
 
 const SPEED_OPTIONS: ReadonlyArray<ReplaySpeed> = ['normal', 'fast', 'instant'];
@@ -29,7 +29,13 @@ export function ReplaySpeedSettingsPanel() {
             value,
             label: t(`settings.replaySpeed.${value}`),
           })),
-          onSelect: (value) => setSpeed(value as ReplaySpeed),
+          // SettingsPanel's onSelect emits the raw <option> value. The select
+          // is rendered exclusively from SPEED_OPTIONS, but `isReplaySpeed`
+          // makes the cast type-safe even if a future refactor adds a stray
+          // option (and silences the assertion the linter would otherwise need).
+          onSelect: (value) => {
+            if (isReplaySpeed(value)) setSpeed(value);
+          },
         },
       ],
     },

--- a/frontend/src/components/common/ReplaySpeedSettingsPanel.tsx
+++ b/frontend/src/components/common/ReplaySpeedSettingsPanel.tsx
@@ -1,0 +1,39 @@
+import { useTranslation } from 'react-i18next';
+import { type ReplaySpeed, useReplaySpeed } from '../../hooks/useReplaySpeed';
+import { type SettingsGroup, SettingsPanel } from './SettingsPanel';
+
+const SPEED_OPTIONS: ReadonlyArray<ReplaySpeed> = ['normal', 'fast', 'instant'];
+
+/**
+ * Renders a small settings panel that lets the player tune the CPU replay
+ * animation speed (Normal / Fast / Instant). The choice is persisted globally
+ * so it carries across every game that uses {@link runReplay}.
+ *
+ * Designed to sit alongside an existing per-game `<SettingsPanel>` on pages
+ * that animate CPU turns (Daifugo, Old Maid, Sevens, President — see #1649).
+ */
+export function ReplaySpeedSettingsPanel() {
+  const { t } = useTranslation('common');
+  const [speed, setSpeed] = useReplaySpeed();
+
+  const groups: SettingsGroup[] = [
+    {
+      items: [
+        {
+          type: 'select',
+          id: 'cpu-replay-speed',
+          label: t('settings.replaySpeed.label'),
+          tooltip: t('settings.replaySpeed.tooltip'),
+          value: speed,
+          options: SPEED_OPTIONS.map((value) => ({
+            value,
+            label: t(`settings.replaySpeed.${value}`),
+          })),
+          onSelect: (value) => setSpeed(value as ReplaySpeed),
+        },
+      ],
+    },
+  ];
+
+  return <SettingsPanel title={t('settings.replaySpeed.title')} groups={groups} />;
+}

--- a/frontend/src/hooks/gameReplay.test.ts
+++ b/frontend/src/hooks/gameReplay.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { type ReplayConfig, runReplay, shouldSkipReplay } from './gameReplay';
+import { REPLAY_DELAY_MS, type ReplayConfig, runReplay, shouldSkipReplay } from './gameReplay';
+import { REPLAY_SPEED_STORAGE_KEY } from './useReplaySpeed';
 
 describe('runReplay', () => {
   beforeEach(() => {
@@ -90,6 +91,60 @@ describe('runReplay', () => {
     expect(setDisplayState).toHaveBeenNthCalledWith(1, 'human');
     expect(setDisplayState).toHaveBeenNthCalledWith(2, 'r1');
     expect(setDisplayState).toHaveBeenNthCalledWith(3, 'final');
+  });
+
+  it('scales delays by the persisted CPU replay speed (fast)', async () => {
+    localStorage.setItem(REPLAY_SPEED_STORAGE_KEY, 'fast');
+    try {
+      const setDisplayState = vi.fn();
+      const config: ReplayConfig<string> = {
+        buildReplayStates: () => ['r1'],
+        buildHumanActionState: () => 'human',
+      };
+
+      const promise = runReplay('final', setDisplayState, config);
+
+      // 'fast' = 0.3 multiplier, so 800 -> 240ms. After 239ms only the human
+      // state has been shown; after the full 240ms we move on.
+      await vi.advanceTimersByTimeAsync(239);
+      expect(setDisplayState).toHaveBeenCalledTimes(1);
+      expect(setDisplayState).toHaveBeenCalledWith('human');
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(setDisplayState).toHaveBeenNthCalledWith(2, 'r1');
+
+      await vi.runAllTimersAsync();
+      await promise;
+      expect(setDisplayState).toHaveBeenLastCalledWith('final');
+    } finally {
+      localStorage.removeItem(REPLAY_SPEED_STORAGE_KEY);
+    }
+  });
+
+  it('collapses delays to zero on instant speed', async () => {
+    localStorage.setItem(REPLAY_SPEED_STORAGE_KEY, 'instant');
+    try {
+      const setDisplayState = vi.fn();
+      const config: ReplayConfig<string> = {
+        buildReplayStates: () => ['r1', 'r2'],
+        buildHumanActionState: () => 'human',
+      };
+
+      const promise = runReplay('final', setDisplayState, config);
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(setDisplayState).toHaveBeenNthCalledWith(1, 'human');
+      expect(setDisplayState).toHaveBeenNthCalledWith(2, 'r1');
+      expect(setDisplayState).toHaveBeenNthCalledWith(3, 'r2');
+      expect(setDisplayState).toHaveBeenNthCalledWith(4, 'final');
+    } finally {
+      localStorage.removeItem(REPLAY_SPEED_STORAGE_KEY);
+    }
+  });
+
+  it('keeps base delay constant when speed is normal', () => {
+    expect(REPLAY_DELAY_MS).toBe(800);
   });
 
   it('uses custom getActionDelay per action', async () => {

--- a/frontend/src/hooks/gameReplay.ts
+++ b/frontend/src/hooks/gameReplay.ts
@@ -1,8 +1,19 @@
+import { getReplaySpeedMultiplier } from './useReplaySpeed';
+
 /** Default delay in milliseconds between replay animation steps. */
 export const REPLAY_DELAY_MS = 800;
 
 /** Return a promise that resolves after the given milliseconds. */
 export const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Apply the user's CPU replay speed preference (#1649) to a base delay.
+ * Multiplier is read fresh from localStorage so settings changes take effect
+ * on the very next replay step.
+ */
+function scaledDelay(baseMs: number): number {
+  return Math.round(baseMs * getReplaySpeedMultiplier());
+}
 
 /** Configuration for the replay animation runner. */
 export interface ReplayConfig<TState> {
@@ -38,7 +49,7 @@ export async function runReplay<TState>(
   const humanState = config.buildHumanActionState?.(finalState) ?? null;
   if (humanState) {
     setDisplayState(humanState);
-    await delay(REPLAY_DELAY_MS);
+    await delay(scaledDelay(REPLAY_DELAY_MS));
   }
 
   const replayStates = config.buildReplayStates(finalState);
@@ -50,7 +61,7 @@ export async function runReplay<TState>(
   for (let i = 0; i < replayStates.length; i++) {
     setDisplayState(replayStates[i]);
     const actionDelay = config.getActionDelay?.(finalState, i) ?? REPLAY_DELAY_MS;
-    await delay(actionDelay);
+    await delay(scaledDelay(actionDelay));
   }
 
   setDisplayState(finalState);

--- a/frontend/src/hooks/useReplaySpeed.test.ts
+++ b/frontend/src/hooks/useReplaySpeed.test.ts
@@ -1,0 +1,71 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_REPLAY_SPEED,
+  getReplaySpeedMultiplier,
+  multiplierForSpeed,
+  REPLAY_SPEED_STORAGE_KEY,
+  useReplaySpeed,
+} from './useReplaySpeed';
+
+describe('useReplaySpeed', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults to normal when nothing is stored', () => {
+    const { result } = renderHook(() => useReplaySpeed());
+    expect(result.current[0]).toBe(DEFAULT_REPLAY_SPEED);
+  });
+
+  it('reads a previously persisted value on mount', () => {
+    localStorage.setItem(REPLAY_SPEED_STORAGE_KEY, 'fast');
+    const { result } = renderHook(() => useReplaySpeed());
+    expect(result.current[0]).toBe('fast');
+  });
+
+  it('falls back to default when stored value is invalid', () => {
+    localStorage.setItem(REPLAY_SPEED_STORAGE_KEY, 'turbo');
+    const { result } = renderHook(() => useReplaySpeed());
+    expect(result.current[0]).toBe(DEFAULT_REPLAY_SPEED);
+  });
+
+  it('persists changes to localStorage', () => {
+    const { result } = renderHook(() => useReplaySpeed());
+    act(() => result.current[1]('instant'));
+    expect(result.current[0]).toBe('instant');
+    expect(localStorage.getItem(REPLAY_SPEED_STORAGE_KEY)).toBe('instant');
+  });
+});
+
+describe('multiplierForSpeed', () => {
+  it.each([
+    ['normal', 1],
+    ['fast', 0.3],
+    ['instant', 0],
+  ] as const)('returns %s -> %s', (speed, expected) => {
+    expect(multiplierForSpeed(speed)).toBe(expected);
+  });
+});
+
+describe('getReplaySpeedMultiplier', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns 1 when nothing is stored', () => {
+    expect(getReplaySpeedMultiplier()).toBe(1);
+  });
+
+  it('reads the live localStorage value', () => {
+    localStorage.setItem(REPLAY_SPEED_STORAGE_KEY, 'fast');
+    expect(getReplaySpeedMultiplier()).toBe(0.3);
+    localStorage.setItem(REPLAY_SPEED_STORAGE_KEY, 'instant');
+    expect(getReplaySpeedMultiplier()).toBe(0);
+  });
+
+  it('falls back to 1 when stored value is invalid', () => {
+    localStorage.setItem(REPLAY_SPEED_STORAGE_KEY, 'turbo');
+    expect(getReplaySpeedMultiplier()).toBe(1);
+  });
+});

--- a/frontend/src/hooks/useReplaySpeed.test.ts
+++ b/frontend/src/hooks/useReplaySpeed.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   DEFAULT_REPLAY_SPEED,
   getReplaySpeedMultiplier,
+  isReplaySpeed,
   multiplierForSpeed,
   REPLAY_SPEED_STORAGE_KEY,
   useReplaySpeed,
@@ -35,6 +36,63 @@ describe('useReplaySpeed', () => {
     act(() => result.current[1]('instant'));
     expect(result.current[0]).toBe('instant');
     expect(localStorage.getItem(REPLAY_SPEED_STORAGE_KEY)).toBe('instant');
+  });
+
+  it('syncs to changes from another tab via the storage event', () => {
+    const { result } = renderHook(() => useReplaySpeed());
+    expect(result.current[0]).toBe(DEFAULT_REPLAY_SPEED);
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: REPLAY_SPEED_STORAGE_KEY,
+          newValue: 'fast',
+        }),
+      );
+    });
+    expect(result.current[0]).toBe('fast');
+  });
+
+  it('falls back to default when another tab clears the key', () => {
+    localStorage.setItem(REPLAY_SPEED_STORAGE_KEY, 'instant');
+    const { result } = renderHook(() => useReplaySpeed());
+    expect(result.current[0]).toBe('instant');
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: REPLAY_SPEED_STORAGE_KEY,
+          newValue: null,
+        }),
+      );
+    });
+    expect(result.current[0]).toBe(DEFAULT_REPLAY_SPEED);
+  });
+
+  it('ignores storage events for unrelated keys or invalid values', () => {
+    const { result } = renderHook(() => useReplaySpeed());
+    expect(result.current[0]).toBe(DEFAULT_REPLAY_SPEED);
+
+    act(() => {
+      window.dispatchEvent(new StorageEvent('storage', { key: 'someOther', newValue: 'fast' }));
+      window.dispatchEvent(new StorageEvent('storage', { key: REPLAY_SPEED_STORAGE_KEY, newValue: 'turbo' }));
+    });
+    expect(result.current[0]).toBe(DEFAULT_REPLAY_SPEED);
+  });
+});
+
+describe('isReplaySpeed', () => {
+  it.each([
+    ['normal', true],
+    ['fast', true],
+    ['instant', true],
+    ['turbo', false],
+    ['', false],
+    [null, false],
+    [undefined, false],
+    [42, false],
+  ] as const)('returns %s -> %s', (value, expected) => {
+    expect(isReplaySpeed(value)).toBe(expected);
   });
 });
 

--- a/frontend/src/hooks/useReplaySpeed.ts
+++ b/frontend/src/hooks/useReplaySpeed.ts
@@ -1,0 +1,64 @@
+import { useCallback, useState } from 'react';
+
+/** CPU replay animation speed preference (#1649). */
+export type ReplaySpeed = 'normal' | 'fast' | 'instant';
+
+/** localStorage key used to persist {@link ReplaySpeed}. */
+export const REPLAY_SPEED_STORAGE_KEY = 'cpuReplaySpeed';
+
+/** Default speed when the user has not chosen one. */
+export const DEFAULT_REPLAY_SPEED: ReplaySpeed = 'normal';
+
+const VALID_SPEEDS: ReadonlySet<ReplaySpeed> = new Set<ReplaySpeed>(['normal', 'fast', 'instant']);
+
+/** Reads a {@link ReplaySpeed} from localStorage, falling back to the default. */
+function readSpeed(): ReplaySpeed {
+  try {
+    const raw = localStorage.getItem(REPLAY_SPEED_STORAGE_KEY);
+    if (raw && VALID_SPEEDS.has(raw as ReplaySpeed)) return raw as ReplaySpeed;
+  } catch {
+    // localStorage unavailable (private mode, SSR) — fall through to default
+  }
+  return DEFAULT_REPLAY_SPEED;
+}
+
+/** Returns the multiplier applied to replay delays for the given speed. */
+export function multiplierForSpeed(speed: ReplaySpeed): number {
+  switch (speed) {
+    case 'fast':
+      return 0.3;
+    case 'instant':
+      return 0;
+    default:
+      return 1;
+  }
+}
+
+/**
+ * Reads the current replay-speed multiplier from localStorage.
+ * Designed to be called per-delay so changes mid-animation take effect on the
+ * next step. Returns 1 (normal) when nothing is stored or the value is invalid.
+ */
+export function getReplaySpeedMultiplier(): number {
+  return multiplierForSpeed(readSpeed());
+}
+
+/**
+ * Persistent React state for the CPU replay speed.
+ * Stored under {@link REPLAY_SPEED_STORAGE_KEY} so the choice carries across
+ * games and reloads.
+ */
+export function useReplaySpeed(): [ReplaySpeed, (next: ReplaySpeed) => void] {
+  const [speed, setSpeed] = useState<ReplaySpeed>(() => readSpeed());
+
+  const setAndPersist = useCallback((next: ReplaySpeed) => {
+    setSpeed(next);
+    try {
+      localStorage.setItem(REPLAY_SPEED_STORAGE_KEY, next);
+    } catch {
+      // ignore quota / private-mode errors
+    }
+  }, []);
+
+  return [speed, setAndPersist];
+}

--- a/frontend/src/hooks/useReplaySpeed.ts
+++ b/frontend/src/hooks/useReplaySpeed.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 /** CPU replay animation speed preference (#1649). */
 export type ReplaySpeed = 'normal' | 'fast' | 'instant';
@@ -9,13 +9,19 @@ export const REPLAY_SPEED_STORAGE_KEY = 'cpuReplaySpeed';
 /** Default speed when the user has not chosen one. */
 export const DEFAULT_REPLAY_SPEED: ReplaySpeed = 'normal';
 
-const VALID_SPEEDS: ReadonlySet<ReplaySpeed> = new Set<ReplaySpeed>(['normal', 'fast', 'instant']);
+/** All accepted {@link ReplaySpeed} values, used to validate untrusted input. */
+export const VALID_SPEEDS: ReadonlySet<ReplaySpeed> = new Set<ReplaySpeed>(['normal', 'fast', 'instant']);
+
+/** Type guard — returns true when `value` is one of the supported {@link ReplaySpeed} strings. */
+export function isReplaySpeed(value: unknown): value is ReplaySpeed {
+  return typeof value === 'string' && VALID_SPEEDS.has(value as ReplaySpeed);
+}
 
 /** Reads a {@link ReplaySpeed} from localStorage, falling back to the default. */
 function readSpeed(): ReplaySpeed {
   try {
     const raw = localStorage.getItem(REPLAY_SPEED_STORAGE_KEY);
-    if (raw && VALID_SPEEDS.has(raw as ReplaySpeed)) return raw as ReplaySpeed;
+    if (isReplaySpeed(raw)) return raw;
   } catch {
     // localStorage unavailable (private mode, SSR) — fall through to default
   }
@@ -50,6 +56,22 @@ export function getReplaySpeedMultiplier(): number {
  */
 export function useReplaySpeed(): [ReplaySpeed, (next: ReplaySpeed) => void] {
   const [speed, setSpeed] = useState<ReplaySpeed>(() => readSpeed());
+
+  // Cross-tab sync: when another tab updates the preference, mirror the change
+  // here so the visible select reflects the latest value (animation timing is
+  // already fresh because runReplay reads localStorage per step).
+  useEffect(() => {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== REPLAY_SPEED_STORAGE_KEY) return;
+      if (event.newValue === null) {
+        setSpeed(DEFAULT_REPLAY_SPEED);
+        return;
+      }
+      if (isReplaySpeed(event.newValue)) setSpeed(event.newValue);
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
 
   const setAndPersist = useCallback((next: ReplaySpeed) => {
     setSpeed(next);

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -107,7 +107,15 @@
   "settings": {
     "title": "Settings",
     "showHelp": "Show help",
-    "hideHelp": "Hide help"
+    "hideHelp": "Hide help",
+    "replaySpeed": {
+      "title": "Animation",
+      "label": "CPU animation speed",
+      "tooltip": "Adjust how fast CPU turn animations play back. Fast is roughly 3× speed; Instant skips delays entirely.",
+      "normal": "Normal",
+      "fast": "Fast",
+      "instant": "Instant"
+    }
   },
   "player": {
     "you": "You",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -107,7 +107,15 @@
   "settings": {
     "title": "設定",
     "showHelp": "説明を表示",
-    "hideHelp": "説明を非表示"
+    "hideHelp": "説明を非表示",
+    "replaySpeed": {
+      "title": "アニメーション設定",
+      "label": "CPUアニメーション速度",
+      "tooltip": "CPUターンのアニメーション再生速度を切り替えます。Fast は約3倍速、Instant はアニメーションを一気に進めます。",
+      "normal": "Normal",
+      "fast": "Fast",
+      "instant": "Instant"
+    }
   },
   "player": {
     "you": "あなた",

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -3,6 +3,7 @@ import type { daifugoApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { ReplaySpeedSettingsPanel } from '../components/common/ReplaySpeedSettingsPanel';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { DaifugoCpuArea } from '../components/daifugo/DaifugoCpuArea';
 import { DaifugoCpuCompact } from '../components/daifugo/DaifugoCpuCompact';
@@ -231,6 +232,7 @@ function DaifugoPageContent() {
         <>
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>
             <DaifugoSettingsPanel config={configInput} onChange={handleConfigChange} />
+            <ReplaySpeedSettingsPanel />
             <SettingsPanel
               title=""
               groups={[

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -3,6 +3,7 @@ import type { oldmaidApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { ReplaySpeedSettingsPanel } from '../components/common/ReplaySpeedSettingsPanel';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
@@ -226,6 +227,7 @@ function OldMaidPageContent() {
               },
             ]}
           />
+          <ReplaySpeedSettingsPanel />
           {/* Scrollable: CPU rows + discard + status + logs + result */}
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>
             {/* Mode badge */}

--- a/frontend/src/pages/PresidentPage.tsx
+++ b/frontend/src/pages/PresidentPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { ReplaySpeedSettingsPanel } from '../components/common/ReplaySpeedSettingsPanel';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
@@ -272,6 +273,7 @@ function PresidentPageContent() {
               },
             ]}
           />
+          <ReplaySpeedSettingsPanel />
 
           <GameFooter className={`${gameTheme.president.footer} px-4 py-2.5`}>
             <div className="flex gap-2 justify-center flex-wrap" data-tutorial="pr-play-pass">

--- a/frontend/src/pages/SevensPage.tsx
+++ b/frontend/src/pages/SevensPage.tsx
@@ -3,6 +3,7 @@ import type { sevensApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { ReplaySpeedSettingsPanel } from '../components/common/ReplaySpeedSettingsPanel';
 import type { SettingsGroup } from '../components/common/SettingsPanel';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
@@ -466,6 +467,7 @@ function SevensPageContent() {
 
             <div data-tutorial="sv-settings">
               <SettingsPanel title={t('config.title')} groups={settingsGroups} />
+              <ReplaySpeedSettingsPanel />
             </div>
 
             <ErrorAlert message={error} onRetry={retry} />

--- a/internal/domain/Tonk_test.go
+++ b/internal/domain/Tonk_test.go
@@ -730,8 +730,12 @@ func TestTonk_ScoreNormalKnock(t *testing.T) {
 
 func TestTonk_PlayerDiscard_GameEnded(t *testing.T) {
 	g := newTestTonk()
-	g.SetConfig(domain.TonkConfig{CpuDifficulty: domain.TonkCpuDifficultyNormal, PointLimit: 1})
+	// Reset() runs the random deal under newTestTonk's safe PointLimit (10000)
+	// so a Tonk-on-deal cannot pre-end the game. Apply the strict PointLimit=1
+	// only afterwards — the test's PlayerKnock(3) scoreRound is what should
+	// trip the game-end here, not the random deal.
 	g.Reset()
+	g.SetConfig(domain.TonkConfig{CpuDifficulty: domain.TonkCpuDifficultyNormal, PointLimit: 1})
 	giveHand(g.GetPlayer(0), []*domain.Card{
 		domain.NewCard(domain.CardDesignSpade, 1, false),
 		domain.NewCard(domain.CardDesignHeart, 1, false),


### PR DESCRIPTION
## Summary
- Adds a global, localStorage-persisted **CPU animation speed** preference (Normal / Fast / Instant) so the player can dial back or skip the 800 ms-per-step CPU replay animation that runs in CPU-driven games.
- Wires the new setting into the four pages that actually animate CPU turns through \`gameReplay.runReplay\`: Daifugo, Old Maid, Sevens, and President.
- \`gameReplay.ts\` now multiplies each delay by a multiplier read fresh from \`localStorage\` per step, so changes mid-animation take effect on the very next replay tick. Default (Normal = 1×) preserves existing behavior exactly.

## Implementation notes
- New \`useReplaySpeed\` hook + \`getReplaySpeedMultiplier\` pure helper under \`src/hooks/useReplaySpeed.ts\` (key \`cpuReplaySpeed\`, values \`'normal' | 'fast' | 'instant'\` → multiplier \`1 / 0.3 / 0\`). Invalid stored values fall back to Normal.
- Reusable \`<ReplaySpeedSettingsPanel>\` (collapsible, mirrors the existing \`SettingsPanel\` look) so each affected page just adds one element next to its current settings panel.
- Strings live in \`common.json\` (\`settings.replaySpeed.*\`), so any future page that wants the control just imports the panel.

## Test plan
- [x] \`bun run test -- --run src/hooks/useReplaySpeed.test.ts\` (10 cases, defaults / persistence / multiplier / invalid value)
- [x] \`bun run test -- --run src/hooks/gameReplay.test.ts\` (existing 11 + 3 new: fast scaling, instant collapse, base constant)
- [x] \`bun run test -- --run src/components/common/ReplaySpeedSettingsPanel.test.tsx\`
- [x] \`bun run test -- --run src/pages/DaifugoPage.test.tsx src/pages/OldMaidPage.test.tsx src/pages/SevensPage.test.tsx src/pages/PresidentPage.test.tsx\` (316 cases, all green)
- [x] \`bun run check\` (Biome + design tokens)
- [ ] CI: typecheck (\`tsc -b\`), build, full test suite (rely on GitHub Actions; local \`bun run build\` OOMs)

Closes #1649