### PR TITLE
feat(frontend): improve mobile tap targets in 10-column tableau games

### DIFF
--- a/frontend/src/hooks/useResponsiveTableau.test.ts
+++ b/frontend/src/hooks/useResponsiveTableau.test.ts
@@ -27,13 +27,28 @@ describe('useResponsiveTableau', () => {
     expect(result.current.co).toBe(CARD_DIMENSIONS.largeDesktop.cardOverlap);
   });
 
-  it('shrinks card width to fit 10 columns on a 375px mobile viewport', () => {
+  it('shrinks card width to fit 10 columns on a 375px mobile viewport (default px-2/gap-1)', () => {
     setWidth(375);
     const { result } = renderHook(() => useResponsiveTableau(10));
-    // Expected ~ floor((375 - 16 - 9*4) / 10) = 32, clamped to [28, 40].
-    expect(result.current.cw).toBeGreaterThanOrEqual(28);
+    // floor((375 - 16 padX - 9 * 4 gap) / 10) = floor(32.3) = 32, clamped to [24, mobile.cardWidth].
+    expect(result.current.cw).toBe(32);
     expect(result.current.cw).toBeLessThanOrEqual(CARD_DIMENSIONS.mobile.cardWidth);
     expect(result.current.ch).toBe(Math.round(result.current.cw * 1.5));
+  });
+
+  it('honors custom padX/gapPx so SpiderPage (px-4 / gap-0.5) gets accurate sizing', () => {
+    setWidth(375);
+    const { result } = renderHook(() => useResponsiveTableau(10, { padX: 32, gapPx: 2 }));
+    // floor((375 - 32 padX - 9 * 2 gap) / 10) = floor(32.5) = 32 — matches Spider's actual layout.
+    expect(result.current.cw).toBe(32);
+  });
+
+  it('diverges from defaults on a narrower viewport when Spider-style padding is used', () => {
+    setWidth(320);
+    const ftLike = renderHook(() => useResponsiveTableau(10)).result.current;
+    const spiderLike = renderHook(() => useResponsiveTableau(10, { padX: 32, gapPx: 2 })).result.current;
+    // Different layouts → different card widths once the viewport is tight enough.
+    expect(spiderLike.cw).not.toBe(ftLike.cw);
   });
 
   it('exposes a larger tap strip per stacked card on mobile (co >= 0.55 * cw)', () => {

--- a/frontend/src/hooks/useResponsiveTableau.test.ts
+++ b/frontend/src/hooks/useResponsiveTableau.test.ts
@@ -1,0 +1,81 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { CARD_DIMENSIONS } from './useCardDimensions';
+import { useResponsiveTableau } from './useResponsiveTableau';
+
+const setWidth = (w: number) =>
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: w });
+
+describe('useResponsiveTableau', () => {
+  const originalInnerWidth = window.innerWidth;
+
+  afterEach(() => setWidth(originalInnerWidth));
+
+  it('returns desktop preset when viewport is at desktop breakpoint', () => {
+    setWidth(800);
+    const { result } = renderHook(() => useResponsiveTableau(10));
+    expect(result.current.cw).toBe(CARD_DIMENSIONS.desktop.cardWidth);
+    expect(result.current.ch).toBe(CARD_DIMENSIONS.desktop.cardHeight);
+    expect(result.current.co).toBe(CARD_DIMENSIONS.desktop.cardOverlap);
+  });
+
+  it('returns large-desktop preset above 1024px', () => {
+    setWidth(1280);
+    const { result } = renderHook(() => useResponsiveTableau(10));
+    expect(result.current.cw).toBe(CARD_DIMENSIONS.largeDesktop.cardWidth);
+    expect(result.current.ch).toBe(CARD_DIMENSIONS.largeDesktop.cardHeight);
+    expect(result.current.co).toBe(CARD_DIMENSIONS.largeDesktop.cardOverlap);
+  });
+
+  it('shrinks card width to fit 10 columns on a 375px mobile viewport', () => {
+    setWidth(375);
+    const { result } = renderHook(() => useResponsiveTableau(10));
+    // Expected ~ floor((375 - 16 - 9*4) / 10) = 32, clamped to [28, 40].
+    expect(result.current.cw).toBeGreaterThanOrEqual(28);
+    expect(result.current.cw).toBeLessThanOrEqual(CARD_DIMENSIONS.mobile.cardWidth);
+    expect(result.current.ch).toBe(Math.round(result.current.cw * 1.5));
+  });
+
+  it('exposes a larger tap strip per stacked card on mobile (co >= 0.55 * cw)', () => {
+    setWidth(375);
+    const { result } = renderHook(() => useResponsiveTableau(10));
+    const ratio = result.current.co / result.current.cw;
+    expect(ratio).toBeGreaterThanOrEqual(0.55);
+  });
+
+  it('clamps to a minimum card width even on very narrow viewports', () => {
+    setWidth(280);
+    const { result } = renderHook(() => useResponsiveTableau(10));
+    expect(result.current.cw).toBeGreaterThanOrEqual(24);
+  });
+
+  it('uses fewer columns to keep cards readable when fewer columns are passed', () => {
+    setWidth(375);
+    const tenCol = renderHook(() => useResponsiveTableau(10)).result.current;
+    const eightCol = renderHook(() => useResponsiveTableau(8)).result.current;
+    expect(eightCol.cw).toBeGreaterThan(tenCol.cw);
+  });
+
+  it('updates on resize', () => {
+    setWidth(800);
+    const { result } = renderHook(() => useResponsiveTableau(10));
+    expect(result.current.cw).toBe(CARD_DIMENSIONS.desktop.cardWidth);
+    act(() => {
+      setWidth(375);
+      window.dispatchEvent(new Event('resize'));
+    });
+    expect(result.current.cw).toBeLessThanOrEqual(CARD_DIMENSIONS.mobile.cardWidth);
+  });
+
+  it('returns wasteFan derived from card width on mobile', () => {
+    setWidth(375);
+    const { result } = renderHook(() => useResponsiveTableau(10));
+    expect(result.current.wasteFan).toBe(Math.round(result.current.cw * 0.3));
+  });
+
+  it('returns the desktop wasteFan default on desktop', () => {
+    setWidth(800);
+    const { result } = renderHook(() => useResponsiveTableau(10));
+    expect(result.current.wasteFan).toBe(15);
+  });
+});

--- a/frontend/src/hooks/useResponsiveTableau.ts
+++ b/frontend/src/hooks/useResponsiveTableau.ts
@@ -1,0 +1,56 @@
+import { useMemo } from 'react';
+import { CARD_DIMENSIONS, useCardDimensions, useWindowWidth } from './useCardDimensions';
+
+/** Responsive card dimensions for a multi-column tableau layout. */
+export interface ResponsiveTableauDimensions {
+  /** Card width in pixels. */
+  cw: number;
+  /** Card height in pixels (1.5 × cw). */
+  ch: number;
+  /** Vertical step (in px) between consecutive stacked cards. */
+  co: number;
+  /** Horizontal fan offset (in px) used by waste piles next to the tableau. */
+  wasteFan: number;
+}
+
+/** Minimum visual card width in px. Anything smaller is unreadable on a 375 px portrait phone. */
+const MIN_CARD_WIDTH = 24;
+/**
+ * Vertical-overlap ratio for stacked cards on mobile.
+ *
+ * Why: with 10-column tableaux on a 375 px viewport each column is ~32 px wide, well below the
+ * WCAG 2.5.5 AAA 44×44 px tap target. We can't widen the card without horizontal scroll, so we
+ * widen the *vertical* tap strip instead by exposing more of each face-up card. 0.58 keeps the
+ * top of the next card visible while giving every card a tap-strip of ~0.42 × ch ≈ 20 px (vs 15
+ * at the previous 0.48 ratio) on a 32-px-wide card. See issue #1648.
+ */
+const MOBILE_VERTICAL_OVERLAP_RATIO = 0.58;
+/** Default fan offset in px used when the waste pile is rendered alongside the tableau. */
+const DESKTOP_WASTE_FAN = 15;
+
+/**
+ * Hook that returns responsive card dimensions for an N-column tableau.
+ *
+ * On mobile viewports (< 640 px) the card width is computed from the available viewport so all
+ * `numCols` columns fit without horizontal scroll. On desktop / large-desktop the standard
+ * preset from {@link CARD_DIMENSIONS} is returned unchanged.
+ */
+export function useResponsiveTableau(numCols: number): ResponsiveTableauDimensions {
+  const { cardHeight, cardOverlap, cardWidth, isMobile } = useCardDimensions();
+  const windowWidth = useWindowWidth();
+
+  return useMemo<ResponsiveTableauDimensions>(() => {
+    if (!isMobile) {
+      return { cw: cardWidth, ch: cardHeight, co: cardOverlap, wasteFan: DESKTOP_WASTE_FAN };
+    }
+    const padX = 16;
+    const gapPx = 4;
+    const availableWidth = windowWidth - padX - (numCols - 1) * gapPx;
+    const colW = Math.floor(availableWidth / numCols);
+    const cw = Math.min(Math.max(colW, MIN_CARD_WIDTH), cardWidth);
+    const ch = Math.round(cw * 1.5);
+    const co = Math.round(cw * MOBILE_VERTICAL_OVERLAP_RATIO);
+    const wasteFan = Math.round(cw * 0.3);
+    return { cw, ch, co, wasteFan };
+  }, [isMobile, windowWidth, numCols, cardWidth, cardHeight, cardOverlap]);
+}

--- a/frontend/src/hooks/useResponsiveTableau.ts
+++ b/frontend/src/hooks/useResponsiveTableau.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { CARD_DIMENSIONS, useCardDimensions, useWindowWidth } from './useCardDimensions';
+import { useCardDimensions, useWindowWidth } from './useCardDimensions';
 
 /** Responsive card dimensions for a multi-column tableau layout. */
 export interface ResponsiveTableauDimensions {
@@ -11,6 +11,14 @@ export interface ResponsiveTableauDimensions {
   co: number;
   /** Horizontal fan offset (in px) used by waste piles next to the tableau. */
   wasteFan: number;
+}
+
+/** Caller-supplied mobile layout dimensions matching the page's actual CSS. */
+export interface ResponsiveTableauConfig {
+  /** Total horizontal padding (left + right) of the tableau's scroll container, in px. Defaults to 16 (Tailwind `px-2`). */
+  padX?: number;
+  /** Gap between adjacent tableau columns, in px. Defaults to 4 (Tailwind `gap-1`). */
+  gapPx?: number;
 }
 
 /** Minimum visual card width in px. Anything smaller is unreadable on a 375 px portrait phone. */
@@ -27,24 +35,33 @@ const MIN_CARD_WIDTH = 24;
 const MOBILE_VERTICAL_OVERLAP_RATIO = 0.58;
 /** Default fan offset in px used when the waste pile is rendered alongside the tableau. */
 const DESKTOP_WASTE_FAN = 15;
+const DEFAULT_PAD_X = 16;
+const DEFAULT_GAP_PX = 4;
 
 /**
  * Hook that returns responsive card dimensions for an N-column tableau.
  *
  * On mobile viewports (< 640 px) the card width is computed from the available viewport so all
  * `numCols` columns fit without horizontal scroll. On desktop / large-desktop the standard
- * preset from {@link CARD_DIMENSIONS} is returned unchanged.
+ * preset from `CARD_DIMENSIONS` is returned unchanged.
+ *
+ * The optional `config` lets callers override the assumed scroll-container padding and inter-column
+ * gap so the calculation matches the page's actual Tailwind classes — without it the math implicitly
+ * assumes `px-2` / `gap-1`.
  */
-export function useResponsiveTableau(numCols: number): ResponsiveTableauDimensions {
+export function useResponsiveTableau(
+  numCols: number,
+  config: ResponsiveTableauConfig = {},
+): ResponsiveTableauDimensions {
   const { cardHeight, cardOverlap, cardWidth, isMobile } = useCardDimensions();
   const windowWidth = useWindowWidth();
+  const padX = config.padX ?? DEFAULT_PAD_X;
+  const gapPx = config.gapPx ?? DEFAULT_GAP_PX;
 
   return useMemo<ResponsiveTableauDimensions>(() => {
     if (!isMobile) {
       return { cw: cardWidth, ch: cardHeight, co: cardOverlap, wasteFan: DESKTOP_WASTE_FAN };
     }
-    const padX = 16;
-    const gapPx = 4;
     const availableWidth = windowWidth - padX - (numCols - 1) * gapPx;
     const colW = Math.floor(availableWidth / numCols);
     const cw = Math.min(Math.max(colW, MIN_CARD_WIDTH), cardWidth);
@@ -52,5 +69,5 @@ export function useResponsiveTableau(numCols: number): ResponsiveTableauDimensio
     const co = Math.round(cw * MOBILE_VERTICAL_OVERLAP_RATIO);
     const wasteFan = Math.round(cw * 0.3);
     return { cw, ch, co, wasteFan };
-  }, [isMobile, windowWidth, numCols, cardWidth, cardHeight, cardOverlap]);
+  }, [isMobile, windowWidth, numCols, padX, gapPx, cardWidth, cardHeight, cardOverlap]);
 }

--- a/frontend/src/pages/FortyThievesPage.tsx
+++ b/frontend/src/pages/FortyThievesPage.tsx
@@ -23,13 +23,13 @@ import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
-import { useCardDimensions, useWindowWidth } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useFortyThievesGame } from '../hooks/useFortyThievesGame';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { useResponsiveTableau } from '../hooks/useResponsiveTableau';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -123,22 +123,7 @@ function FortyThievesPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('fortythieves', state);
-  const { cardHeight, cardOverlap, cardWidth, isMobile } = useCardDimensions();
-  const windowWidth = useWindowWidth();
-
-  // Responsive card dimensions for 10-column layout
-  const ft = useMemo(() => {
-    if (!isMobile) return { cw: cardWidth, ch: cardHeight, co: cardOverlap, wasteFan: 15 };
-    const padX = 16;
-    const gapPx = 4;
-    const cols = 10;
-    const colW = Math.floor((windowWidth - padX - (cols - 1) * gapPx) / cols);
-    const cw = Math.min(Math.max(colW, 24), cardWidth);
-    const ch = Math.round(cw * 1.5);
-    const co = Math.round(cw * 0.48);
-    const wasteFan = Math.round(cw * 0.3);
-    return { cw, ch, co, wasteFan };
-  }, [isMobile, windowWidth, cardWidth, cardHeight, cardOverlap]);
+  const ft = useResponsiveTableau(10);
 
   const isPlayingForKbd = state?.phase === FortyThievesPhase.PLAYING;
 

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -29,6 +29,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { useResponsiveTableau } from '../hooks/useResponsiveTableau';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSpiderGame } from '../hooks/useSpiderGame';
 import { useSound } from '../providers/SoundProvider';
@@ -116,7 +117,10 @@ function SpiderPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('spider', state);
-  const { cardHeight, cardOverlap, cardWidth } = useCardDimensions();
+  // Stock area uses the standard card preset; tableau uses responsive 10-column dimensions
+  // so a 375 px viewport doesn't crush each card below 28 px (#1648).
+  const { cardHeight, cardWidth } = useCardDimensions();
+  const tableau = useResponsiveTableau(10);
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('spider');
   const cliConfig: CliGameConfig<SpiderResponse, Parameters<typeof spiderApi.exec>> = useMemo(
@@ -272,14 +276,14 @@ function SpiderPageContent() {
                         onDragLeave={dnd.handleDragLeave}
                         className="relative block"
                       >
-                        <div className="relative" style={{ minHeight: cardHeight }}>
+                        <div className="relative" style={{ minHeight: tableau.ch }}>
                           {col.length === 0 ? (
                             <button
                               key={`empty-${colIdx.toString()}-${emptyDealAttemptKey.toString()}`}
                               type="button"
                               onClick={() => handleSelectTarget(tableauColZone)}
                               disabled={!isPlaying || loading || !selectedSource}
-                              style={{ height: cardHeight }}
+                              style={{ height: tableau.ch }}
                               data-testid={`spd-empty-col-${colIdx.toString()}`}
                               className={`w-full rounded border-2 border-dashed border-white/20 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}${emptyDealAttemptKey > 0 ? ' animate-shake border-ds-warning text-ds-warning' : ''}`}
                             >
@@ -296,7 +300,7 @@ function SpiderPageContent() {
                                 <div
                                   key={`tc-${colIdx.toString()}-${cardIdx.toString()}`}
                                   className="absolute left-0 right-0"
-                                  style={{ top: cardIdx * cardOverlap }}
+                                  style={{ top: cardIdx * tableau.co }}
                                 >
                                   {tc.faceUp && tc.card ? (
                                     <button
@@ -324,7 +328,7 @@ function SpiderPageContent() {
                                     >
                                       <AnimatedCard
                                         card={tc.card}
-                                        width={cardWidth}
+                                        width={tableau.cw}
                                         draggable={false}
                                         style={{ width: '100%' }}
                                         onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
@@ -332,7 +336,7 @@ function SpiderPageContent() {
                                     </button>
                                   ) : (
                                     <AnimatedCardBack
-                                      width={cardWidth}
+                                      width={tableau.cw}
                                       style={{ width: '100%' }}
                                       onFlipComplete={() => playSound('cardFlip')}
                                     />
@@ -341,7 +345,7 @@ function SpiderPageContent() {
                               );
                             })
                           )}
-                          {col.length > 0 && <div style={{ height: (col.length - 1) * cardOverlap + cardHeight }} />}
+                          {col.length > 0 && <div style={{ height: (col.length - 1) * tableau.co + tableau.ch }} />}
                         </div>
                       </DropZone>
                     </div>

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -23,7 +23,6 @@ import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
-import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
@@ -117,10 +116,10 @@ function SpiderPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('spider', state);
-  // Stock area uses the standard card preset; tableau uses responsive 10-column dimensions
-  // so a 375 px viewport doesn't crush each card below 28 px (#1648).
-  const { cardHeight, cardWidth } = useCardDimensions();
-  const tableau = useResponsiveTableau(10);
+  // Responsive 10-column dimensions matching this page's `px-4` scroll container and `gap-0.5`
+  // tableau so a 375 px viewport doesn't crush each card below 28 px (#1648). Stock uses the
+  // same dimensions so cards don't visibly pop when the deal animation moves them to the tableau.
+  const tableau = useResponsiveTableau(10, { padX: 32, gapPx: 2 });
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('spider');
   const cliConfig: CliGameConfig<SpiderResponse, Parameters<typeof spiderApi.exec>> = useMemo(
@@ -241,14 +240,14 @@ function SpiderPageContent() {
                 </div>
                 {state.stockCount > 0 ? (
                   <AnimatedCardBack
-                    width={cardWidth}
+                    width={tableau.cw}
                     onClick={isPlaying ? handleDealGuarded : undefined}
                     ariaLabel={t('deal')}
                     onFlipComplete={() => playSound('cardFlip')}
                   />
                 ) : (
                   <div
-                    style={{ width: cardWidth, height: cardHeight }}
+                    style={{ width: tableau.cw, height: tableau.ch }}
                     className="rounded border border-white/20 flex items-center justify-center text-game-text-muted text-xs"
                   >
                     {t('empty')}


### PR DESCRIPTION
Closes #1648

## Summary

- Extract a shared `useResponsiveTableau(numCols)` hook from the inline calc that lived in `FortyThievesPage`, and reuse it in `SpiderPage` so both 10-column tableau games behave consistently on mobile.
- Tune the mobile vertical-overlap ratio from 0.48 → 0.58 of card width. On a 375 px viewport (where each column is ~32 px wide and we can't grow the visual card without horizontal scroll), this raises the per-card tap strip from ~15 px to ~19 px, materially improving stacked-card selection accuracy without changing desktop layout.
- Add 9 unit tests covering the breakpoints, clamping, and resize behavior.

## Why

Issue #1648: 10-column tableaus on mobile (375×667) crush each card to ~30 px wide, well below the WCAG 2.5.5 AAA 44×44 px tap-target minimum. The mobile-ux design rule prohibits horizontal scroll, so we widen the *vertical* tap strip instead — the issue itself flags `useCardDimensions` overlap tuning as the recommended fix.

## What does NOT change

- Desktop and large-desktop layouts (the hook returns the standard preset above the `sm` breakpoint).
- Visual card size on mobile (still computed from viewport width — already as wide as it can fit).
- Stock card in Spider — still uses the standard preset since it's a single card.

## Test plan

- [x] `bun run test -- --run src/hooks/useResponsiveTableau.test.ts` — 9 new tests pass
- [x] `bun run test -- --run src/pages/SpiderPage.test.tsx` — 54 tests pass
- [x] `bun run test -- --run src/pages/FortyThievesPage.test.tsx` — 39 tests pass
- [x] `bun run check` — Biome + design tokens clean
- [ ] Manual smoke on mobile viewport: stacked cards in Spider/Forty Thieves are easier to tap (CI will run E2E)