### PR TITLE
feat(domain): persist CPU memoryManager state across KV restores

### DIFF
--- a/docs/adr/0028-kv-session-persistence.md
+++ b/docs/adr/0028-kv-session-persistence.md
@@ -52,5 +52,6 @@ wrangler.toml の `[env.staging]` セクションで staging/prod の KV を分�
 - **セッション永続化**: Workers 版でも Docker 版と同等のゲーム体験が実現
 - **KV 無料枠制約**: 書き込み 1,000回/日のためデモ用途に限定（1アクション=1書き込み）
 - **Undo 非永続**: ソリティア系ゲームの Undo 履歴（snapshot）は KV に保存しない。復元後は Undo 不可
-- **CPU 記憶非永続**: CPU プレイヤーの `memoryManager` は復元時にリセット。CPU は再度学習する
+- **CPU 記憶永続**: CPU プレイヤーの `memoryManager` (Old Maid / Go Fish / Memory / Doubt) は KV に永続化され、復元後も Hard 難易度の戦略が維持される (#1655 で対応)。データ量が小さいため KV 1MB 制限への影響は無視できる
+- ~~**CPU 記憶非永続**: CPU プレイヤーの `memoryManager` は復元時にリセット。CPU は再度学習する~~ — #1655 で解消済み
 - **コード量増加**: 全26ゲームに MarshalJSON/UnmarshalJSON を追加（約5,000行）。パターンは統一されており保守性は維持

--- a/internal/domain/DoubtPlayer.go
+++ b/internal/domain/DoubtPlayer.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"encoding/json"
+	"fmt"
 	"math/rand"
 )
 
@@ -14,23 +15,55 @@ type cardMemoryEntry struct {
 // GetTurnSeen MemoryEntryインターフェース実装
 func (e cardMemoryEntry) GetTurnSeen() int { return e.turnSeen }
 
+// cardMemoryEntryJSON is the wire format for cardMemoryEntry. Fields on the
+// underlying struct are unexported so we need an explicit marshaller.
+type cardMemoryEntryJSON struct {
+	Value    int `json:"v"`
+	TurnSeen int `json:"t"`
+}
+
+// MarshalJSON implements json.Marshaler.
+func (e cardMemoryEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(cardMemoryEntryJSON{
+		Value:    e.value,
+		TurnSeen: e.turnSeen,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (e *cardMemoryEntry) UnmarshalJSON(data []byte) error {
+	var j cardMemoryEntryJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	e.value = j.Value
+	e.turnSeen = j.TurnSeen
+	return nil
+}
+
 // DoubtPlayer ダウトプレイヤークラス
 type DoubtPlayer struct {
 	*GamePlayer
 	memoryManager[cardMemoryEntry]
 }
 
-// doubtPlayerJSON is the JSON wire format for DoubtPlayer.
+// doubtPlayerMaxMemoryLen caps the deserialised memory slice length so a
+// hostile session blob cannot allocate unbounded memory.
+const doubtPlayerMaxMemoryLen = 1000
+
+// doubtPlayerJSON is the JSON wire format for DoubtPlayer. Persisting
+// cardMemories keeps Hard-difficulty CPUs from forgetting every revealed
+// value when a session is restored (see ADR-0028 / issue #1655).
 type doubtPlayerJSON struct {
-	GamePlayer *GamePlayer `json:"gp"`
-	// CPU memory (cardMemories) is intentionally omitted;
-	// CPU will re-learn after restore.
+	GamePlayer   *GamePlayer       `json:"gp"`
+	CardMemories []cardMemoryEntry `json:"cm,omitempty"`
 }
 
 // MarshalJSON implements json.Marshaler.
 func (p *DoubtPlayer) MarshalJSON() ([]byte, error) {
 	return json.Marshal(doubtPlayerJSON{
-		GamePlayer: p.GamePlayer,
+		GamePlayer:   p.GamePlayer,
+		CardMemories: p.cardMemories,
 	})
 }
 
@@ -40,13 +73,15 @@ func (p *DoubtPlayer) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
 	}
+	if len(j.CardMemories) > doubtPlayerMaxMemoryLen {
+		return fmt.Errorf("doubtPlayer: input array exceeds maximum allowed size")
+	}
 	if j.GamePlayer != nil {
 		p.GamePlayer = j.GamePlayer
 	} else {
 		p.GamePlayer = NewGamePlayer(false)
 	}
-	// CPU memory is reset on restore; CPU will re-learn.
-	p.ResetMemory()
+	p.cardMemories = j.CardMemories
 	return nil
 }
 

--- a/internal/domain/DoubtPlayer_persistence_test.go
+++ b/internal/domain/DoubtPlayer_persistence_test.go
@@ -1,0 +1,32 @@
+//go:build test
+
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDoubtPlayer_JSONRoundTrip_PreservesCardMemories verifies that #1655's
+// CPU memory survives a Marshal/Unmarshal cycle for Doubt. Before the fix
+// `cardMemories` was intentionally dropped on restore so the Hard CPU lost
+// every value it had counted.
+func TestDoubtPlayer_JSONRoundTrip_PreservesCardMemories(t *testing.T) {
+	p := NewDoubtPlayer(false)
+	p.AddMemory(cardMemoryEntry{value: 5, turnSeen: 1})
+	p.AddMemory(cardMemoryEntry{value: 5, turnSeen: 3})
+	p.AddMemory(cardMemoryEntry{value: 11, turnSeen: 4})
+
+	data, err := json.Marshal(p)
+	require.NoError(t, err)
+
+	var restored DoubtPlayer
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	assert.Equal(t, 2, restored.CountKnownCards(5))
+	assert.Equal(t, 1, restored.CountKnownCards(11))
+	assert.Equal(t, 0, restored.CountKnownCards(7))
+}

--- a/internal/domain/GoFish.go
+++ b/internal/domain/GoFish.go
@@ -64,6 +64,43 @@ type goFishMemoryEntry struct {
 // GetTurnSeen MemoryEntry インタフェース
 func (e goFishMemoryEntry) GetTurnSeen() int { return e.turnSeen }
 
+// goFishMemoryEntryJSON is the wire format for goFishMemoryEntry. The struct
+// fields are unexported, so without an explicit marshaller the entries would
+// silently round-trip as zero values and the Hard CPU would lose its
+// ask-history after a session restore.
+type goFishMemoryEntryJSON struct {
+	AskerIdx  int  `json:"a"`
+	TargetIdx int  `json:"g"`
+	Rank      int  `json:"r"`
+	HadCards  bool `json:"h"`
+	TurnSeen  int  `json:"t"`
+}
+
+// MarshalJSON implements json.Marshaler.
+func (e goFishMemoryEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(goFishMemoryEntryJSON{
+		AskerIdx:  e.askerIdx,
+		TargetIdx: e.targetIdx,
+		Rank:      e.rank,
+		HadCards:  e.hadCards,
+		TurnSeen:  e.turnSeen,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (e *goFishMemoryEntry) UnmarshalJSON(data []byte) error {
+	var j goFishMemoryEntryJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	e.askerIdx = j.AskerIdx
+	e.targetIdx = j.TargetIdx
+	e.rank = j.Rank
+	e.hadCards = j.HadCards
+	e.turnSeen = j.TurnSeen
+	return nil
+}
+
 // GoFish Go Fishゲームクラス
 type GoFish struct {
 	trumpCards  *TrumpCards

--- a/internal/domain/GoFish.go
+++ b/internal/domain/GoFish.go
@@ -676,6 +676,10 @@ func (g *GoFish) GetHumanAction() *GoFishCpuAction { return g.humanAction }
 // GetActionLog 棋譜を取得する
 func (g *GoFish) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
+// goFishMaxSliceLen caps slice sizes during deserialisation, matching
+// ADR-0028's defensive policy for KV-restored session blobs.
+const goFishMaxSliceLen = 1000
+
 // goFishJSON is the JSON wire format for GoFish.
 type goFishJSON struct {
 	TrumpCards        *TrumpCards         `json:"tc"`
@@ -731,6 +735,13 @@ func (g *GoFish) UnmarshalJSON(data []byte) error {
 	var j goFishJSON
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
+	}
+	if len(j.Players) > goFishMaxSliceLen ||
+		len(j.LastCardsReceived) > goFishMaxSliceLen ||
+		len(j.CpuActions) > goFishMaxSliceLen ||
+		len(j.ActionLog) > goFishMaxSliceLen ||
+		len(j.CpuMemories) > goFishMaxSliceLen {
+		return fmt.Errorf("goFish: input array exceeds maximum allowed size")
 	}
 	g.trumpCards = j.TrumpCards
 	g.players = j.Players

--- a/internal/domain/GoFish_test.go
+++ b/internal/domain/GoFish_test.go
@@ -287,6 +287,25 @@ func TestGoFish_JSON_RoundTrip(t *testing.T) {
 	assert.Equal(t, g.GetConfig(), restored.GetConfig())
 }
 
+// TestGoFish_JSON_RoundTrip_PreservesCpuMemories pins #1655: goFishMemoryEntry
+// fields are unexported, so the previous wire format silently flattened every
+// entry to its zero value on restore. The round-trip must keep ask history.
+func TestGoFish_JSON_RoundTrip_PreservesCpuMemories(t *testing.T) {
+	g := newTestGoFish()
+	g.cpuMemories = []goFishMemoryEntry{
+		{askerIdx: 0, targetIdx: 2, rank: 5, hadCards: false, turnSeen: 1},
+		{askerIdx: 1, targetIdx: 3, rank: 11, hadCards: true, turnSeen: 4},
+	}
+
+	data, err := json.Marshal(g)
+	require.NoError(t, err)
+
+	var restored GoFish
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	assert.Equal(t, g.cpuMemories, restored.cpuMemories)
+}
+
 func TestGoFish_ActionLog(t *testing.T) {
 	g := newTestGoFish()
 	g.players[0].AddCard(NewCard(CardDesignSpade, 3, false))

--- a/internal/domain/GoFish_test.go
+++ b/internal/domain/GoFish_test.go
@@ -4,6 +4,7 @@ package domain
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -285,6 +286,27 @@ func TestGoFish_JSON_RoundTrip(t *testing.T) {
 	assert.Equal(t, g.GetTurnNumber(), restored.GetTurnNumber())
 	assert.Equal(t, g.GetDeckRemaining(), restored.GetDeckRemaining())
 	assert.Equal(t, g.GetConfig(), restored.GetConfig())
+}
+
+// TestGoFish_UnmarshalJSON_RejectsOversizedCpuMemories pins ADR-0028's policy
+// that every deserialised slice field is bounded — the GoFish unmarshaller
+// previously had no guard at all, so a hostile session blob could allocate
+// arbitrary heap before any check ran.
+func TestGoFish_UnmarshalJSON_RejectsOversizedCpuMemories(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString(`{"cm":[`)
+	for i := 0; i < goFishMaxSliceLen+1; i++ {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteString(`{"a":0,"g":1,"r":2,"h":false,"t":0}`)
+	}
+	sb.WriteString(`]}`)
+
+	var g GoFish
+	err := json.Unmarshal([]byte(sb.String()), &g)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed size")
 }
 
 // TestGoFish_JSON_RoundTrip_PreservesCpuMemories pins #1655: goFishMemoryEntry

--- a/internal/domain/MemoryPlayer.go
+++ b/internal/domain/MemoryPlayer.go
@@ -16,6 +16,35 @@ type memoryCardEntry struct {
 // GetTurnSeen MemoryEntryインターフェース実装
 func (e memoryCardEntry) GetTurnSeen() int { return e.turnSeen }
 
+// memoryCardEntryJSON is the wire format for memoryCardEntry. Fields on the
+// underlying struct are unexported so we need an explicit marshaller.
+type memoryCardEntryJSON struct {
+	Position int `json:"p"`
+	Rank     int `json:"r"`
+	TurnSeen int `json:"t"`
+}
+
+// MarshalJSON implements json.Marshaler.
+func (e memoryCardEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(memoryCardEntryJSON{
+		Position: e.position,
+		Rank:     e.rank,
+		TurnSeen: e.turnSeen,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (e *memoryCardEntry) UnmarshalJSON(data []byte) error {
+	var j memoryCardEntryJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	e.position = j.Position
+	e.rank = j.Rank
+	e.turnSeen = j.TurnSeen
+	return nil
+}
+
 // MemoryPlayer 神経衰弱プレイヤークラス
 type MemoryPlayer struct {
 	*GamePlayer
@@ -112,21 +141,23 @@ func (p *MemoryPlayer) GetMemoryCount() int {
 	return len(p.cardMemories)
 }
 
-// memoryPlayerJSON is the JSON wire format for MemoryPlayer.
+// memoryPlayerJSON is the JSON wire format for MemoryPlayer. Persisting
+// cardMemories keeps the Hard-difficulty CPU from forgetting every revealed
+// card when a session is restored (see ADR-0028 / issue #1655).
 type memoryPlayerJSON struct {
-	GamePlayer *GamePlayer `json:"gp"`
-	PairCount  int         `json:"pc"`
-	Pairs      [][2]*Card  `json:"pa"`
-	// CPU memory (cardMemories) is intentionally omitted;
-	// CPU will re-learn after restore.
+	GamePlayer   *GamePlayer       `json:"gp"`
+	PairCount    int               `json:"pc"`
+	Pairs        [][2]*Card        `json:"pa"`
+	CardMemories []memoryCardEntry `json:"cm,omitempty"`
 }
 
 // MarshalJSON implements json.Marshaler.
 func (p *MemoryPlayer) MarshalJSON() ([]byte, error) {
 	return json.Marshal(memoryPlayerJSON{
-		GamePlayer: p.GamePlayer,
-		PairCount:  p.pairCount,
-		Pairs:      p.pairs,
+		GamePlayer:   p.GamePlayer,
+		PairCount:    p.pairCount,
+		Pairs:        p.pairs,
+		CardMemories: p.cardMemories,
 	})
 }
 
@@ -139,7 +170,7 @@ func (p *MemoryPlayer) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
 	}
-	if len(j.Pairs) > memoryPlayerMaxSliceLen {
+	if len(j.Pairs) > memoryPlayerMaxSliceLen || len(j.CardMemories) > memoryPlayerMaxSliceLen {
 		return fmt.Errorf("memoryPlayer: input array exceeds maximum allowed size")
 	}
 	if j.GamePlayer != nil {
@@ -152,7 +183,6 @@ func (p *MemoryPlayer) UnmarshalJSON(data []byte) error {
 	if p.pairs == nil {
 		p.pairs = make([][2]*Card, 0)
 	}
-	// CPU memory is reset on restore; CPU will re-learn.
-	p.ResetMemory()
+	p.cardMemories = j.CardMemories
 	return nil
 }

--- a/internal/domain/MemoryPlayer_persistence_test.go
+++ b/internal/domain/MemoryPlayer_persistence_test.go
@@ -1,0 +1,34 @@
+//go:build test
+
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMemoryPlayer_JSONRoundTrip_PreservesCardMemories verifies that #1655's
+// memoryManager state survives a Marshal/Unmarshal cycle. Before the fix the
+// CPU memory was intentionally dropped, causing Hard difficulty CPUs to forget
+// every revealed card after a session restore.
+func TestMemoryPlayer_JSONRoundTrip_PreservesCardMemories(t *testing.T) {
+	p := NewMemoryPlayer(false)
+	p.AddMemory(memoryCardEntry{position: 3, rank: 7, turnSeen: 2})
+	p.AddMemory(memoryCardEntry{position: 12, rank: 7, turnSeen: 4})
+	p.AddMemory(memoryCardEntry{position: 25, rank: 13, turnSeen: 5})
+
+	data, err := json.Marshal(p)
+	require.NoError(t, err)
+
+	var restored MemoryPlayer
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	assert.Equal(t, 3, restored.GetMemoryCount())
+	pos1, pos2, found := restored.FindKnownMatch(7)
+	assert.True(t, found)
+	assert.Equal(t, 3, pos1)
+	assert.Equal(t, 12, pos2)
+}


### PR DESCRIPTION
## Summary
- ADR-0028 originally listed *CPU 記憶非永続* as a consequence — Old Maid / Go Fish / Memory / Doubt CPUs reset to Easy-equivalent play after a page reload.
- Persist `cardMemories` / `cpuMemories` in the KV-backed session blob so Hard-difficulty CPUs keep their state across restores.
- Three concrete gaps fixed:
  - `goFishMemoryEntry` has unexported fields; without an explicit marshaller the wire format silently round-tripped every entry as zero values.
  - `DoubtPlayer.UnmarshalJSON` and `MemoryPlayer.UnmarshalJSON` intentionally dropped `cardMemories`. Both now serialize the slice with `maxSliceLen=1000` validation, matching ADR-0028's defensive deserialization pattern.
  - `cardMemoryEntry` / `memoryCardEntry` also have unexported fields and needed their own marshallers before the parent slices could survive a round-trip.
- ADR-0028 *Consequences* updated: *CPU 記憶永続* replaces the prior bullet, with the strikethrough kept for traceability.

## Test plan
- [x] `go test -tags test -race ./internal/domain/...` — green (313s race run)
- [x] `golangci-lint run ./internal/domain/...` — 0 issues
- [x] `go build ./...` — clean (server + worker entry points)
- [x] New round-trip tests assert memory survives Marshal→Unmarshal:
  - `TestGoFish_JSON_RoundTrip_PreservesCpuMemories`
  - `TestDoubtPlayer_JSONRoundTrip_PreservesCardMemories`
  - `TestMemoryPlayer_JSONRoundTrip_PreservesCardMemories`

Closes #1655