### PR TITLE
fix(spiteandmalice): de-flake AutoComplete_NoOpWhenNothingPlayable

### DIFF
--- a/internal/domain/SpiteAndMalice_test.go
+++ b/internal/domain/SpiteAndMalice_test.go
@@ -551,6 +551,12 @@ func TestSpiteAndMalice_AutoComplete_NoOpWhenNothingPlayable(t *testing.T) {
 	g.SetCurrent(SpiteAndMaliceHumanIdx)
 	// Foundation empty; hand has no Ace and no wild — nothing legal.
 	g.SetPlayerHand(SpiteAndMaliceHumanIdx, []*Card{mkCard(CardDesignSpade, 5), mkCard(CardDesignHeart, 8)})
+	// Reset() leaves the goal pile shuffle-dependent; pin its top to a
+	// non-playable mid-rank so AutoComplete never plays from goal either.
+	g.SetPlayerGoal(SpiteAndMaliceHumanIdx, []*Card{mkCard(CardDesignClover, 7)})
+	for s := range SpiteAndMaliceSideCnt {
+		g.SetPlayerSide(SpiteAndMaliceHumanIdx, s, nil)
+	}
 	moveCountBefore := g.GetMoveCount()
 	require.NoError(t, g.AutoComplete())
 	assert.Equal(t, moveCountBefore, g.GetMoveCount(), "no moves should have been made")


### PR DESCRIPTION
## Summary
- `TestSpiteAndMalice_AutoComplete_NoOpWhenNothingPlayable` was shuffle-dependent: the test only set up a non-playable hand, but `SpiteAndMalice.Reset()` populates the goal pile with random cards from a shuffled stock and `AutoComplete` walks goal → hand → side. When the goal top happened to be an Ace, the test failed.
- Pin the goal pile to a non-playable mid-rank and clear the side piles, removing the shuffle dependency. Verified locally with `-count=200`.
- Surfaced as a CI failure on #1718 — same pattern as #f5cbf14e (de-flake `TestTonk_PlayerDiscard_GameEnded`).

## Test plan
- [x] `go test -tags test -count=200 ./internal/domain/ -run TestSpiteAndMalice_AutoComplete_NoOpWhenNothingPlayable` — 200/200 pass
- [x] `go test -tags test ./internal/domain/...` — green