### PR TITLE
feat(GamePageShell): add winShow/onCelebrate props and migrate WarPage

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -14,7 +14,12 @@ Every game page (`src/pages/<X>Page.tsx`) follows the same skeleton — copy fro
 2. **Standard hooks**: `useGamePageSetup(gameName)` provides i18n + action-log + reset-confirm state; `useGameApi(apiFn, opts)` manages server state with loading / error / retry.
 3. **Mount-time reset**: pages call the api command `"reset"` inside a `useEffect` on mount to fetch a fresh game from the server.
 4. **Skeleton fallback**: render `<XSkeleton />` while `state` is `null`.
-5. **`GamePageShell`** wraps most pages and provides the background, page heading, phase indicator, reset confirmation dialog, and win celebration overlay (#1650). Migration recipe for unmigrated pages: replace the outer `<div className="flex-1 flex flex-col min-h-0 ${theme.bg}" aria-busy={loading}>` block with `<GamePageShell>`, drop the imports and JSX for `GamePageHeading`, `PhaseIndicator`, `TutorialButton`, `ManualButton`, `WinCelebration`, `GameResetDialog`, and `useGameRoundGuard` (the shell calls them), and pass `headerExtra` for any per-page header chips (e.g. `<CliToggle>`, chips/score readouts) and `winShow` / `onCelebrate` when the celebration condition or sound cue isn't a plain `gameEndFlag`.
+5. **`GamePageShell`** wraps most pages and provides the background, page heading, phase indicator, reset confirmation dialog, and win celebration overlay (#1650). Migration recipe for unmigrated pages:
+   - Replace the outer `<div className="flex-1 flex flex-col min-h-0 ${theme.bg}" aria-busy={loading}>` block with `<GamePageShell>`.
+   - Drop imports and JSX for `GamePageHeading`, `PhaseIndicator`, `TutorialButton`, `ManualButton`, `WinCelebration`, `GameResetDialog`, and `useGameRoundGuard` — the shell calls them all.
+   - Pass `headerExtra` for any per-page header chips (e.g. `<CliToggle>`, chip / score readouts).
+   - Pass `winShow` when the celebration condition is stricter than plain `gameEndFlag` (e.g. `humanWon` for two-player games where only the human's win is celebrated).
+   - Pass `onCelebrate` to trigger sound effects or other side effects when the celebration starts.
 
 Shared building blocks:
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -14,7 +14,7 @@ Every game page (`src/pages/<X>Page.tsx`) follows the same skeleton — copy fro
 2. **Standard hooks**: `useGamePageSetup(gameName)` provides i18n + action-log + reset-confirm state; `useGameApi(apiFn, opts)` manages server state with loading / error / retry.
 3. **Mount-time reset**: pages call the api command `"reset"` inside a `useEffect` on mount to fetch a fresh game from the server.
 4. **Skeleton fallback**: render `<XSkeleton />` while `state` is `null`.
-5. **`GamePageShell`** wraps most pages and provides the background, page heading, phase indicator, and reset confirmation dialog.
+5. **`GamePageShell`** wraps most pages and provides the background, page heading, phase indicator, reset confirmation dialog, and win celebration overlay (#1650). Migration recipe for unmigrated pages: replace the outer `<div className="flex-1 flex flex-col min-h-0 ${theme.bg}" aria-busy={loading}>` block with `<GamePageShell>`, drop the imports and JSX for `GamePageHeading`, `PhaseIndicator`, `TutorialButton`, `ManualButton`, `WinCelebration`, `GameResetDialog`, and `useGameRoundGuard` (the shell calls them), and pass `headerExtra` for any per-page header chips (e.g. `<CliToggle>`, chips/score readouts) and `winShow` / `onCelebrate` when the celebration condition or sound cue isn't a plain `gameEndFlag`.
 
 Shared building blocks:
 

--- a/frontend/src/components/GamePageShell.test.tsx
+++ b/frontend/src/components/GamePageShell.test.tsx
@@ -15,7 +15,12 @@ vi.mock('./ManualButton', () => ({
 }));
 
 vi.mock('./motion/WinCelebration', () => ({
-  WinCelebration: ({ show }: { show: boolean }) => (show ? <div data-testid="win-celebration">Win!</div> : null),
+  WinCelebration: ({ show, onCelebrate }: { show: boolean; onCelebrate?: () => void }) =>
+    show ? (
+      <button type="button" data-testid="win-celebration" onClick={() => onCelebrate?.()}>
+        Win!
+      </button>
+    ) : null,
 }));
 
 vi.mock('./GameResetDialog', () => ({
@@ -184,5 +189,34 @@ describe('GamePageShell', () => {
       </GamePageShell>,
     );
     expect(container.firstChild).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('uses winShow override when provided (suppress celebration even at game end)', () => {
+    render(
+      <GamePageShell {...baseProps} gameEndFlag={true} winShow={false}>
+        <div />
+      </GamePageShell>,
+    );
+    expect(screen.queryByTestId('win-celebration')).not.toBeInTheDocument();
+  });
+
+  it('uses winShow override when provided (show celebration before gameEndFlag flips)', () => {
+    render(
+      <GamePageShell {...baseProps} gameEndFlag={false} winShow={true}>
+        <div />
+      </GamePageShell>,
+    );
+    expect(screen.getByTestId('win-celebration')).toBeInTheDocument();
+  });
+
+  it('forwards onCelebrate to WinCelebration', () => {
+    const onCelebrate = vi.fn();
+    render(
+      <GamePageShell {...baseProps} gameEndFlag={true} onCelebrate={onCelebrate}>
+        <div />
+      </GamePageShell>,
+    );
+    fireEvent.click(screen.getByTestId('win-celebration'));
+    expect(onCelebrate).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/components/GamePageShell.tsx
+++ b/frontend/src/components/GamePageShell.tsx
@@ -19,8 +19,16 @@ export interface GamePageShellProps {
   isHumanTurn: boolean;
   /** Path used by ManualButton to load the game manual (e.g., "/hearts"). */
   gamePath: string;
-  /** Whether a game-end condition has been reached, controls WinCelebration. */
+  /** Whether a game-end condition has been reached, controls WinCelebration default and the round-leave guard. */
   gameEndFlag: boolean;
+  /**
+   * Optional override for whether to display the win celebration. Defaults to `gameEndFlag`.
+   * Pages that only celebrate on a player win (e.g., War, Slapjack, RedDog) should pass
+   * a stricter condition like `gameEndFlag && humanWon`.
+   */
+  winShow?: boolean;
+  /** Optional callback invoked when WinCelebration plays — typically used to trigger sound effects. */
+  onCelebrate?: () => void;
   /** Whether an async operation is in progress; forwarded to aria-busy on the outer container. */
   loading: boolean;
   /** Whether the reset confirmation dialog is open. */
@@ -51,6 +59,8 @@ export function GamePageShell({
   isHumanTurn,
   gamePath,
   gameEndFlag,
+  winShow,
+  onCelebrate,
   loading,
   confirmOpen,
   confirmReset,
@@ -69,7 +79,7 @@ export function GamePageShell({
         <ManualButton gamePath={gamePath} />
       </PhaseIndicator>
       {children}
-      <WinCelebration show={gameEndFlag} />
+      <WinCelebration show={winShow ?? gameEndFlag} onCelebrate={onCelebrate} />
       <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
     </div>
   );

--- a/frontend/src/pages/WarPage.tsx
+++ b/frontend/src/pages/WarPage.tsx
@@ -140,7 +140,7 @@ function WarPageContent() {
       isHumanTurn={!isGameEnd}
       gamePath="/war"
       gameEndFlag={isGameEnd}
-      winShow={isGameEnd && humanWon}
+      winShow={humanWon}
       loading={loading}
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}

--- a/frontend/src/pages/WarPage.tsx
+++ b/frontend/src/pages/WarPage.tsx
@@ -6,17 +6,12 @@ import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
@@ -24,7 +19,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useMountReset } from '../hooks/useMountReset';
 import { gameTheme } from '../styles/gameTheme';
 import type { WarResponse } from '../types/card';
@@ -73,7 +67,6 @@ function WarPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('war');
   const { state, loading, error, exec: execApi, retry } = useGameApi(warApi.exec);
-  useGameRoundGuard(!!state && !state.gameEndFlag);
   const { cardWidth } = useCardDimensions();
   const [maxRounds, setMaxRounds] = useState(DEFAULT_MAX_ROUNDS);
   const {
@@ -140,14 +133,20 @@ function WarPageContent() {
         : t('phase.reveal');
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.war.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.war')} />
-      <PhaseIndicator phaseName={phaseName} isHumanTurn={!isGameEnd}>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/war" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.war')}
+      gameThemeBg={gameTheme.war.bg}
+      phaseName={phaseName}
+      isHumanTurn={!isGameEnd}
+      gamePath="/war"
+      gameEndFlag={isGameEnd}
+      winShow={isGameEnd && humanWon}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={<CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />}
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -310,11 +309,8 @@ function WarPageContent() {
               />
             </div>
           </GameFooter>
-
-          <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-          <WinCelebration show={isGameEnd && humanWon} />
         </>
       )}
-    </div>
+    </GamePageShell>
   );
 }


### PR DESCRIPTION
## Summary

Refs #1650 — first incremental migration. \`GamePageShell\` only covered 7/77 game pages because it lacked extension points for two common patterns: a strict celebration condition (\`gameEndFlag && humanWon\`) and a sound-effect callback. This PR adds those two optional props and migrates \`WarPage\` as the first proof point. The rest of the ~70 unmigrated pages can now follow the same recipe in subsequent PRs.

- **\`GamePageShell\`** gains two optional props:
  - \`winShow?: boolean\` — overrides the default \`gameEndFlag\`. Lets pages like War / RedDog / Slapjack restrict the celebration to actual human wins.
  - \`onCelebrate?: () => void\` — forwarded to \`WinCelebration\`. Pages with a win sound (RedDog, etc.) can drop the inline \`<WinCelebration>\` and pass the cue here.
- **\`WarPage\`** migrated: removed the duplicated outer \`<div>\`, \`GamePageHeading\`, \`PhaseIndicator\`, \`TutorialButton\`, \`ManualButton\`, \`WinCelebration\`, \`GameResetDialog\`, \`useGameRoundGuard\` boilerplate and replaced with one \`<GamePageShell>\` wrapper using \`headerExtra\` for the CLI toggle and \`winShow={isGameEnd && humanWon}\`.
- **Documentation** — \`frontend/CLAUDE.md\` now documents the migration recipe (which imports/JSX to drop, which props to pass, which conditions need \`winShow\`/\`onCelebrate\`) so future PRs can mechanically migrate one or several pages at a time.

## Test plan

- [x] \`bun run test -- --run GamePageShell\` (17 tests; 3 new tests cover \`winShow=false\` suppress, \`winShow=true\` override, and \`onCelebrate\` forwarding)
- [x] \`bun run test -- --run WarPage\` (existing 10 page tests still pass after the migration)
- [x] \`bun run check\` (Biome + design tokens)
- [ ] CI: \`bun run build\`, full \`bun run test\`, Go test