### PR TITLE
feat(freecell,tripeaks): persist undo history across KV restores

### DIFF
--- a/internal/domain/FreeCell.go
+++ b/internal/domain/FreeCell.go
@@ -743,6 +743,59 @@ type freeCellJSON struct {
 	MoveCount   int                            `json:"mc"`
 	ActionLog   []*ActionLogEntry              `json:"al"`
 	IsStalemate bool                           `json:"sm"`
+	History     []*freeCellSnapshot            `json:"hi,omitempty"`
+}
+
+// freeCellSnapshotJSON is the wire format for a single undo snapshot.
+// freeCellSnapshot uses unexported fields, so we project to/from this
+// shape with explicit Marshal/Unmarshal methods. Field names match
+// freeCellJSON's short keys to keep the KV payload compact (#1654).
+type freeCellSnapshotJSON struct {
+	Tableau     [FreeCellTableauCnt][]*Card    `json:"tb"`
+	FreeCells   [FreeCellCellCnt]*Card         `json:"fc"`
+	Foundation  [FreeCellFoundationCnt][]*Card `json:"fd"`
+	Phase       FreeCellPhase                  `json:"ps"`
+	MoveCount   int                            `json:"mc"`
+	IsStalemate bool                           `json:"sm"`
+}
+
+// MarshalJSON implements json.Marshaler for freeCellSnapshot, projecting
+// the unexported fields onto an exported wire shape so that
+// FreeCell.MarshalJSON can persist the undo history (#1654).
+func (s *freeCellSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(freeCellSnapshotJSON{
+		Tableau:     s.tableau,
+		FreeCells:   s.freeCells,
+		Foundation:  s.foundation,
+		Phase:       s.phase,
+		MoveCount:   s.moveCount,
+		IsStalemate: s.isStalemate,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for freeCellSnapshot.
+func (s *freeCellSnapshot) UnmarshalJSON(data []byte) error {
+	var j freeCellSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	for _, col := range j.Tableau {
+		if len(col) > freeCellMaxSliceLen {
+			return fmt.Errorf("freeCell: snapshot tableau column exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Foundation {
+		if len(pile) > freeCellMaxSliceLen {
+			return fmt.Errorf("freeCell: snapshot foundation pile exceeds maximum allowed size")
+		}
+	}
+	s.tableau = j.Tableau
+	s.freeCells = j.FreeCells
+	s.foundation = j.Foundation
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	s.isStalemate = j.IsStalemate
+	return nil
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -756,6 +809,7 @@ func (f *FreeCell) MarshalJSON() ([]byte, error) {
 		MoveCount:   f.moveCount,
 		ActionLog:   f.actionLog,
 		IsStalemate: f.isStalemate,
+		History:     f.history,
 	})
 }
 
@@ -768,8 +822,18 @@ func (f *FreeCell) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
 	}
-	if len(j.ActionLog) > freeCellMaxSliceLen {
+	if len(j.ActionLog) > freeCellMaxSliceLen || len(j.History) > freeCellMaxSliceLen {
 		return fmt.Errorf("freeCell: input array exceeds maximum allowed size")
+	}
+	for _, col := range j.Tableau {
+		if len(col) > freeCellMaxSliceLen {
+			return fmt.Errorf("freeCell: tableau column exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Foundation {
+		if len(pile) > freeCellMaxSliceLen {
+			return fmt.Errorf("freeCell: foundation pile exceeds maximum allowed size")
+		}
 	}
 
 	f.trumpCards = j.TrumpCards
@@ -785,8 +849,10 @@ func (f *FreeCell) UnmarshalJSON(data []byte) error {
 	if f.actionLog == nil {
 		f.actionLog = make([]*ActionLogEntry, 0)
 	}
-	// Undo history is not serialised; set to nil on restore.
-	f.history = nil
+	f.history = j.History
+	if f.history == nil {
+		f.history = make([]*freeCellSnapshot, 0)
+	}
 	f.isStalemate = j.IsStalemate
 	return nil
 }

--- a/internal/domain/FreeCell_persistence_test.go
+++ b/internal/domain/FreeCell_persistence_test.go
@@ -121,6 +121,50 @@ func TestFreeCell_SnapshotTableauColumnRespectsMaxSliceLen(t *testing.T) {
 	require.Error(t, err, "oversized snapshot tableau column must be rejected")
 }
 
+// TestFreeCell_TopLevelTableauColumnRespectsMaxSliceLen rejects payloads
+// with an oversized Tableau column at the top level (not nested inside a
+// snapshot). Mirrors the snapshot-level guard so callers cannot bypass
+// the OOM defence by inflating the live tableau directly.
+func TestFreeCell_TopLevelTableauColumnRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigCol := make([]map[string]any, freeCellMaxSliceLen+1)
+	for i := range bigCol {
+		bigCol[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"tb": []any{bigCol, nil, nil, nil, nil, nil, nil, nil},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored FreeCell
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized top-level tableau column must be rejected")
+}
+
+// TestFreeCell_TopLevelFoundationPileRespectsMaxSliceLen rejects payloads
+// with an oversized Foundation pile at the top level.
+func TestFreeCell_TopLevelFoundationPileRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigPile := make([]map[string]any, freeCellMaxSliceLen+1)
+	for i := range bigPile {
+		bigPile[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"fd": []any{bigPile, nil, nil, nil},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored FreeCell
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized top-level foundation pile must be rejected")
+}
+
 // TestFreeCell_SnapshotFoundationPileRespectsMaxSliceLen rejects payloads
 // that smuggle an oversized inner Foundation pile inside a history snapshot.
 func TestFreeCell_SnapshotFoundationPileRespectsMaxSliceLen(t *testing.T) {

--- a/internal/domain/FreeCell_persistence_test.go
+++ b/internal/domain/FreeCell_persistence_test.go
@@ -1,0 +1,146 @@
+//go:build test
+
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFreeCell_PersistsUndoHistory verifies issue #1654: when a FreeCell
+// game is round-tripped through JSON (e.g. a Cloudflare KV restore), the
+// undo history must survive so the player can still step backward. Prior
+// to the fix UnmarshalJSON set history = nil, leaving a restored game
+// with `cannot undo: no history`.
+func TestFreeCell_PersistsUndoHistory(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultFreeCell()
+	original.Reset()
+	require.False(t, original.CanUndo(), "fresh game has no history")
+
+	// Two deterministic moves: any tableau column has cards after Reset
+	// and free cells 0/1 are empty, so these always succeed.
+	require.NoError(t, original.MoveTableauToFreeCell(0, 0))
+	require.NoError(t, original.MoveTableauToFreeCell(1, 1))
+	require.True(t, original.CanUndo(), "two moves should leave undoable history")
+	originalHistoryLen := len(original.history)
+	originalMoveCount := original.GetMoveCount()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored FreeCell
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	assert.Equal(t, originalMoveCount, restored.GetMoveCount(), "moveCount must round-trip")
+	assert.Equal(t, originalHistoryLen, len(restored.history), "history length must round-trip")
+	assert.True(t, restored.CanUndo(), "restored game must allow Undo")
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, originalMoveCount-1, restored.GetMoveCount(), "Undo should rewind one step")
+}
+
+// TestFreeCell_PersistsHistoryRestoresExactSnapshot ensures the snapshot
+// fields (tableau, freeCells, foundation, moveCount) are preserved exactly
+// so an Undo on a restored game returns to the same state the game would
+// have had before the action that produced the snapshot.
+func TestFreeCell_PersistsHistoryRestoresExactSnapshot(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultFreeCell()
+	original.Reset()
+	require.NoError(t, original.MoveTableauToFreeCell(0, 0))
+
+	// Capture the state we expect Undo on the restored game to recover.
+	preMoveTableau0Len := len(original.tableau[0])
+	preMoveFreeCell1 := original.freeCells[1]
+
+	require.NoError(t, original.MoveTableauToFreeCell(1, 1))
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored FreeCell
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, preMoveTableau0Len, len(restored.tableau[0]), "Undo restores tableau length")
+	assert.Equal(t, preMoveFreeCell1, restored.freeCells[1], "Undo restores free cell occupancy")
+}
+
+// TestFreeCell_HistoryRespectsMaxSliceLen rejects malicious payloads that
+// attempt to exhaust memory through an oversized history array — same
+// defence as the existing maxSliceLen guards on actionLog.
+func TestFreeCell_HistoryRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigHistory := make([]map[string]any, freeCellMaxSliceLen+1)
+	for i := range bigHistory {
+		bigHistory[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": bigHistory,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored FreeCell
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized history must be rejected")
+}
+
+// TestFreeCell_SnapshotTableauColumnRespectsMaxSliceLen rejects payloads
+// that smuggle an oversized inner Tableau column inside a history snapshot.
+// Without the per-column guard inside freeCellSnapshot.UnmarshalJSON,
+// 1000 history entries × 8 cols × 1000 cards would still allocate ~8M
+// pointers despite the existing maxSliceLen check on the history length.
+func TestFreeCell_SnapshotTableauColumnRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigCol := make([]map[string]any, freeCellMaxSliceLen+1)
+	for i := range bigCol {
+		bigCol[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"tb": []any{bigCol, nil, nil, nil, nil, nil, nil, nil},
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored FreeCell
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot tableau column must be rejected")
+}
+
+// TestFreeCell_SnapshotFoundationPileRespectsMaxSliceLen rejects payloads
+// that smuggle an oversized inner Foundation pile inside a history snapshot.
+func TestFreeCell_SnapshotFoundationPileRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigPile := make([]map[string]any, freeCellMaxSliceLen+1)
+	for i := range bigPile {
+		bigPile[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"fd": []any{bigPile, nil, nil, nil},
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored FreeCell
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot foundation pile must be rejected")
+}

--- a/internal/domain/TriPeaks.go
+++ b/internal/domain/TriPeaks.go
@@ -512,6 +512,58 @@ type triPeaksJSON struct {
 	MoveCount   int                                           `json:"mc"`
 	ActionLog   []*ActionLogEntry                             `json:"al"`
 	IsStalemate bool                                          `json:"sm"`
+	History     []*triPeaksSnapshot                           `json:"hi,omitempty"`
+}
+
+// triPeaksSnapshotJSON is the wire format for a single undo snapshot.
+// triPeaksSnapshot uses unexported fields, so we project to/from this
+// shape with explicit Marshal/Unmarshal methods. Field names match
+// triPeaksJSON's short keys to keep the KV payload compact (#1654).
+type triPeaksSnapshotJSON struct {
+	Layout      [TriPeaksRowCnt][TriPeaksColCnt]*TriPeaksCard `json:"ly"`
+	Stock       []*Card                                       `json:"st"`
+	Waste       []*Card                                       `json:"wa"`
+	Phase       TriPeaksPhase                                 `json:"ps"`
+	MoveCount   int                                           `json:"mc"`
+	IsStalemate bool                                          `json:"sm"`
+}
+
+// MarshalJSON implements json.Marshaler for triPeaksSnapshot, projecting
+// the unexported fields onto an exported wire shape so that
+// TriPeaks.MarshalJSON can persist the undo history (#1654).
+func (s *triPeaksSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(triPeaksSnapshotJSON{
+		Layout:      s.layout,
+		Stock:       s.stock,
+		Waste:       s.waste,
+		Phase:       s.phase,
+		MoveCount:   s.moveCount,
+		IsStalemate: s.isStalemate,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for triPeaksSnapshot.
+func (s *triPeaksSnapshot) UnmarshalJSON(data []byte) error {
+	var j triPeaksSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if len(j.Stock) > triPeaksMaxSliceLen || len(j.Waste) > triPeaksMaxSliceLen {
+		return fmt.Errorf("tripeaks: snapshot array exceeds maximum allowed size")
+	}
+	s.layout = j.Layout
+	s.stock = j.Stock
+	if s.stock == nil {
+		s.stock = make([]*Card, 0)
+	}
+	s.waste = j.Waste
+	if s.waste == nil {
+		s.waste = make([]*Card, 0)
+	}
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	s.isStalemate = j.IsStalemate
+	return nil
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -525,6 +577,7 @@ func (t *TriPeaks) MarshalJSON() ([]byte, error) {
 		MoveCount:   t.moveCount,
 		ActionLog:   t.actionLog,
 		IsStalemate: t.isStalemate,
+		History:     t.history,
 	})
 }
 
@@ -538,7 +591,7 @@ func (t *TriPeaks) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if len(j.Stock) > triPeaksMaxSliceLen || len(j.Waste) > triPeaksMaxSliceLen ||
-		len(j.ActionLog) > triPeaksMaxSliceLen {
+		len(j.ActionLog) > triPeaksMaxSliceLen || len(j.History) > triPeaksMaxSliceLen {
 		return fmt.Errorf("tripeaks: input array exceeds maximum allowed size")
 	}
 
@@ -561,8 +614,10 @@ func (t *TriPeaks) UnmarshalJSON(data []byte) error {
 	if t.actionLog == nil {
 		t.actionLog = make([]*ActionLogEntry, 0)
 	}
-	// Undo history is not serialised; set to nil on restore.
-	t.history = nil
+	t.history = j.History
+	if t.history == nil {
+		t.history = make([]*triPeaksSnapshot, 0)
+	}
 	t.isStalemate = j.IsStalemate
 	return nil
 }

--- a/internal/domain/TriPeaks_persistence_test.go
+++ b/internal/domain/TriPeaks_persistence_test.go
@@ -115,3 +115,29 @@ func TestTriPeaks_SnapshotStockRespectsMaxSliceLen(t *testing.T) {
 	err = json.Unmarshal(data, &restored)
 	require.Error(t, err, "oversized snapshot stock must be rejected")
 }
+
+// TestTriPeaks_SnapshotWasteRespectsMaxSliceLen rejects payloads that
+// smuggle an oversized inner Waste slice inside a history snapshot.
+// The Stock and Waste branches share a combined `||` guard, so this is
+// a separate test to exercise the Waste path explicitly.
+func TestTriPeaks_SnapshotWasteRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigWaste := make([]map[string]any, triPeaksMaxSliceLen+1)
+	for i := range bigWaste {
+		bigWaste[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"wa": bigWaste,
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored TriPeaks
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot waste must be rejected")
+}

--- a/internal/domain/TriPeaks_persistence_test.go
+++ b/internal/domain/TriPeaks_persistence_test.go
@@ -1,0 +1,117 @@
+//go:build test
+
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTriPeaks_PersistsUndoHistory verifies issue #1654: when a TriPeaks
+// game is round-tripped through JSON (e.g. a Cloudflare KV restore), the
+// undo history must survive so the player can still step backward. Prior
+// to the fix UnmarshalJSON set history = nil, leaving a restored game
+// with `cannot undo: no history`.
+func TestTriPeaks_PersistsUndoHistory(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultTriPeaks()
+	original.Reset()
+	require.False(t, original.CanUndo(), "fresh game has no history")
+
+	// Draw is deterministic — after Reset the stock has cards regardless of shuffle.
+	require.NoError(t, original.Draw())
+	require.NoError(t, original.Draw())
+	require.True(t, original.CanUndo(), "two draws should leave undoable history")
+	originalHistoryLen := len(original.history)
+	originalMoveCount := original.GetMoveCount()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored TriPeaks
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	assert.Equal(t, originalMoveCount, restored.GetMoveCount(), "moveCount must round-trip")
+	assert.Equal(t, originalHistoryLen, len(restored.history), "history length must round-trip")
+	assert.True(t, restored.CanUndo(), "restored game must allow Undo")
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, originalMoveCount-1, restored.GetMoveCount(), "Undo should rewind one step")
+}
+
+// TestTriPeaks_PersistsHistoryRestoresExactSnapshot ensures the snapshot
+// fields (layout, stock, waste) are preserved exactly so an Undo on a
+// restored game returns the same state the game would have had before the
+// action that produced the snapshot.
+func TestTriPeaks_PersistsHistoryRestoresExactSnapshot(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultTriPeaks()
+	original.Reset()
+	require.NoError(t, original.Draw())
+
+	preDrawWasteLen := len(original.waste)
+	preDrawStockLen := len(original.stock)
+
+	require.NoError(t, original.Draw())
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored TriPeaks
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, preDrawWasteLen, len(restored.waste), "Undo restores waste length")
+	assert.Equal(t, preDrawStockLen, len(restored.stock), "Undo restores stock length")
+}
+
+// TestTriPeaks_HistoryRespectsMaxSliceLen rejects malicious payloads that
+// attempt to exhaust memory through an oversized history array — same
+// defence as the existing maxSliceLen guards on stock/waste/actionLog.
+func TestTriPeaks_HistoryRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigHistory := make([]map[string]any, triPeaksMaxSliceLen+1)
+	for i := range bigHistory {
+		bigHistory[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": bigHistory,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored TriPeaks
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized history must be rejected")
+}
+
+// TestTriPeaks_SnapshotStockRespectsMaxSliceLen rejects payloads that
+// smuggle an oversized inner Stock slice inside a history snapshot.
+func TestTriPeaks_SnapshotStockRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigStock := make([]map[string]any, triPeaksMaxSliceLen+1)
+	for i := range bigStock {
+		bigStock[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"st": bigStock,
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored TriPeaks
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot stock must be rejected")
+}


### PR DESCRIPTION
## Summary

Refs #1654 — extends the Klondike pilot pattern (#1722) to FreeCell and TriPeaks.

Previously, when a Cloudflare Workers session was restored from KV, both `FreeCell.UnmarshalJSON` and `TriPeaks.UnmarshalJSON` deliberately set `history = nil`, so a player who reloaded a tab mid-game lost the entire undo stack. ADR-0028 originally rejected this on the assumption that storing snapshots would blow KV size, but in practice a typical solitaire hand serializes to ~150 KB of history (well under the 25 MB KV value limit), so storing the snapshot array end-to-end is the simpler fix vs. event sourcing — the same trade-off the Klondike pilot adopted.

## Changes

- **FreeCell**: Add `History []*freeCellSnapshot` to `freeCellJSON`; new `freeCellSnapshotJSON` wire type + `MarshalJSON`/`UnmarshalJSON` on `freeCellSnapshot` (unexported fields → exported wire shape). `History`, top-level Tableau/Foundation columns, and each snapshot's Tableau/Foundation columns all gated by `freeCellMaxSliceLen=1000`.
- **TriPeaks**: Add `History []*triPeaksSnapshot` to `triPeaksJSON`; new `triPeaksSnapshotJSON` wire type + `MarshalJSON`/`UnmarshalJSON` on `triPeaksSnapshot`. `History`, top-level Stock/Waste, and each snapshot's Stock/Waste gated by `triPeaksMaxSliceLen=1000`.

JSON keys mirror the existing short-key convention (`tb`, `st`, `wa`, `fd`, `ly`, `ps`, `mc`, `sm`) to keep KV payloads compact.

## Remaining solitaire games

After this PR (FreeCell + TriPeaks): Spider, Pyramid, FortyThieves, Canfield, Yukon, RussianSolitaire, Scorpion, Accordion, BakersDozen, Calculation, Golf still need the same treatment. Issue #1654 stays open until the full rollout completes.

## Test plan

- [x] `go test -tags test ./internal/domain/ -run TestFreeCell` — all FreeCell tests pass
- [x] `go test -tags test ./internal/domain/ -run TestTriPeaks` — all TriPeaks tests pass
- [x] `go test -tags test ./internal/domain/...` — full domain suite green (80.6s)
- [x] `golangci-lint run ./internal/domain/...` — 0 issues
- [x] `goimports -w` on changed files
- [ ] CI: full `go test -tags test ./...`

### New tests

- `TestFreeCell_PersistsUndoHistory` — round-trip preserves history length & moveCount; restored game allows Undo
- `TestFreeCell_PersistsHistoryRestoresExactSnapshot` — Undo on restored game restores exact pre-action tableau/free-cell state
- `TestFreeCell_HistoryRespectsMaxSliceLen` — oversized history payload rejected
- `TestFreeCell_SnapshotTableauColumnRespectsMaxSliceLen` — oversized inner tableau column inside a snapshot rejected
- `TestFreeCell_SnapshotFoundationPileRespectsMaxSliceLen` — oversized inner foundation pile inside a snapshot rejected
- `TestTriPeaks_PersistsUndoHistory`, `TestTriPeaks_PersistsHistoryRestoresExactSnapshot`, `TestTriPeaks_HistoryRespectsMaxSliceLen`, `TestTriPeaks_SnapshotStockRespectsMaxSliceLen` — equivalents for TriPeaks