### PR TITLE
feat(spider,pyramid): persist undo history across KV restores

### DIFF
--- a/internal/domain/Pyramid.go
+++ b/internal/domain/Pyramid.go
@@ -546,6 +546,63 @@ type pyramidJSON struct {
 	MoveCount   int                           `json:"mc"`
 	ActionLog   []*ActionLogEntry             `json:"al"`
 	IsStalemate bool                          `json:"sm"`
+	History     []*pyramidSnapshot            `json:"hi,omitempty"`
+}
+
+// pyramidSnapshotJSON is the wire format for a single undo snapshot.
+// pyramidSnapshot uses unexported fields, so we project to/from this
+// shape with explicit Marshal/Unmarshal methods. Field names match
+// pyramidJSON's short keys to keep the KV payload compact (#1654).
+type pyramidSnapshotJSON struct {
+	Pyramid     [PyramidRowCnt][]*PyramidCard `json:"py"`
+	Stock       []*Card                       `json:"st"`
+	Waste       []*Card                       `json:"wa"`
+	Phase       PyramidPhase                  `json:"ps"`
+	MoveCount   int                           `json:"mc"`
+	IsStalemate bool                          `json:"sm"`
+}
+
+// MarshalJSON implements json.Marshaler for pyramidSnapshot, projecting
+// the unexported fields onto an exported wire shape so that
+// Pyramid.MarshalJSON can persist the undo history (#1654).
+func (s *pyramidSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(pyramidSnapshotJSON{
+		Pyramid:     s.pyramid,
+		Stock:       s.stock,
+		Waste:       s.waste,
+		Phase:       s.phase,
+		MoveCount:   s.moveCount,
+		IsStalemate: s.isStalemate,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for pyramidSnapshot.
+func (s *pyramidSnapshot) UnmarshalJSON(data []byte) error {
+	var j pyramidSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if len(j.Stock) > pyramidMaxSliceLen || len(j.Waste) > pyramidMaxSliceLen {
+		return fmt.Errorf("pyramid: snapshot array exceeds maximum allowed size")
+	}
+	for _, row := range j.Pyramid {
+		if len(row) > pyramidMaxSliceLen {
+			return fmt.Errorf("pyramid: snapshot pyramid row exceeds maximum allowed size")
+		}
+	}
+	s.pyramid = j.Pyramid
+	s.stock = j.Stock
+	if s.stock == nil {
+		s.stock = make([]*Card, 0)
+	}
+	s.waste = j.Waste
+	if s.waste == nil {
+		s.waste = make([]*Card, 0)
+	}
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	s.isStalemate = j.IsStalemate
+	return nil
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -559,6 +616,7 @@ func (p *Pyramid) MarshalJSON() ([]byte, error) {
 		MoveCount:   p.moveCount,
 		ActionLog:   p.actionLog,
 		IsStalemate: p.isStalemate,
+		History:     p.history,
 	})
 }
 
@@ -572,8 +630,13 @@ func (p *Pyramid) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if len(j.Stock) > pyramidMaxSliceLen || len(j.Waste) > pyramidMaxSliceLen ||
-		len(j.ActionLog) > pyramidMaxSliceLen {
+		len(j.ActionLog) > pyramidMaxSliceLen || len(j.History) > pyramidMaxSliceLen {
 		return fmt.Errorf("pyramid: input array exceeds maximum allowed size")
+	}
+	for _, row := range j.Pyramid {
+		if len(row) > pyramidMaxSliceLen {
+			return fmt.Errorf("pyramid: pyramid row exceeds maximum allowed size")
+		}
 	}
 
 	p.trumpCards = j.TrumpCards
@@ -595,8 +658,10 @@ func (p *Pyramid) UnmarshalJSON(data []byte) error {
 	if p.actionLog == nil {
 		p.actionLog = make([]*ActionLogEntry, 0)
 	}
-	// Undo history is not serialised; set to nil on restore.
-	p.history = nil
+	p.history = j.History
+	if p.history == nil {
+		p.history = make([]*pyramidSnapshot, 0)
+	}
 	p.isStalemate = j.IsStalemate
 	return nil
 }

--- a/internal/domain/Pyramid_persistence_test.go
+++ b/internal/domain/Pyramid_persistence_test.go
@@ -110,6 +110,30 @@ func TestPyramid_SnapshotStockRespectsMaxSliceLen(t *testing.T) {
 	require.Error(t, err, "oversized snapshot stock must be rejected")
 }
 
+// TestPyramid_SnapshotWasteRespectsMaxSliceLen rejects payloads that
+// smuggle an oversized inner Waste slice inside a history snapshot.
+func TestPyramid_SnapshotWasteRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigWaste := make([]map[string]any, pyramidMaxSliceLen+1)
+	for i := range bigWaste {
+		bigWaste[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"wa": bigWaste,
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Pyramid
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot waste must be rejected")
+}
+
 // TestPyramid_SnapshotPyramidRowRespectsMaxSliceLen rejects payloads that
 // smuggle an oversized Pyramid row slice inside a history snapshot.
 func TestPyramid_SnapshotPyramidRowRespectsMaxSliceLen(t *testing.T) {

--- a/internal/domain/Pyramid_persistence_test.go
+++ b/internal/domain/Pyramid_persistence_test.go
@@ -1,0 +1,135 @@
+//go:build test
+
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPyramid_PersistsUndoHistory verifies issue #1654: when a Pyramid
+// game is round-tripped through JSON (e.g. a Cloudflare KV restore), the
+// undo history must survive so the player can still step backward.
+func TestPyramid_PersistsUndoHistory(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultPyramid()
+	original.Reset()
+	require.False(t, original.CanUndo(), "fresh game has no history")
+
+	// Draw is deterministic — after Reset the stock has cards regardless of shuffle.
+	require.NoError(t, original.Draw())
+	require.NoError(t, original.Draw())
+	require.True(t, original.CanUndo(), "two draws should leave undoable history")
+	originalHistoryLen := len(original.history)
+	originalMoveCount := original.GetMoveCount()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored Pyramid
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	assert.Equal(t, originalMoveCount, restored.GetMoveCount(), "moveCount must round-trip")
+	assert.Equal(t, originalHistoryLen, len(restored.history), "history length must round-trip")
+	assert.True(t, restored.CanUndo(), "restored game must allow Undo")
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, originalMoveCount-1, restored.GetMoveCount(), "Undo should rewind one step")
+}
+
+// TestPyramid_PersistsHistoryRestoresExactSnapshot ensures the snapshot
+// fields (pyramid, stock, waste) are preserved exactly.
+func TestPyramid_PersistsHistoryRestoresExactSnapshot(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultPyramid()
+	original.Reset()
+	require.NoError(t, original.Draw())
+
+	preDrawWasteLen := len(original.waste)
+	preDrawStockLen := len(original.stock)
+
+	require.NoError(t, original.Draw())
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored Pyramid
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, preDrawWasteLen, len(restored.waste), "Undo restores waste length")
+	assert.Equal(t, preDrawStockLen, len(restored.stock), "Undo restores stock length")
+}
+
+// TestPyramid_HistoryRespectsMaxSliceLen rejects oversized history payloads.
+func TestPyramid_HistoryRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigHistory := make([]map[string]any, pyramidMaxSliceLen+1)
+	for i := range bigHistory {
+		bigHistory[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": bigHistory,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Pyramid
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized history must be rejected")
+}
+
+// TestPyramid_SnapshotStockRespectsMaxSliceLen rejects payloads that
+// smuggle an oversized inner Stock slice inside a history snapshot.
+func TestPyramid_SnapshotStockRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigStock := make([]map[string]any, pyramidMaxSliceLen+1)
+	for i := range bigStock {
+		bigStock[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"st": bigStock,
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Pyramid
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot stock must be rejected")
+}
+
+// TestPyramid_SnapshotPyramidRowRespectsMaxSliceLen rejects payloads that
+// smuggle an oversized Pyramid row slice inside a history snapshot.
+func TestPyramid_SnapshotPyramidRowRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigRow := make([]map[string]any, pyramidMaxSliceLen+1)
+	for i := range bigRow {
+		bigRow[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"py": []any{bigRow, nil, nil, nil, nil, nil, nil},
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Pyramid
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot pyramid row must be rejected")
+}

--- a/internal/domain/Spider.go
+++ b/internal/domain/Spider.go
@@ -622,6 +622,63 @@ type spiderJSON struct {
 	ActionLog      []*ActionLogEntry                      `json:"al"`
 	Difficulty     SpiderDifficulty                       `json:"df"`
 	IsStalemate    bool                                   `json:"sm"`
+	History        []*spiderSnapshot                      `json:"hi,omitempty"`
+}
+
+// spiderSnapshotJSON is the wire format for a single undo snapshot.
+// spiderSnapshot uses unexported fields, so we project to/from this
+// shape with explicit Marshal/Unmarshal methods. Field names match
+// spiderJSON's short keys to keep the KV payload compact (#1654).
+type spiderSnapshotJSON struct {
+	Tableau        [SpiderTableauCnt][]*SpiderTableauCard `json:"tb"`
+	Stock          []*Card                                `json:"st"`
+	CompletedSuits int                                    `json:"cs"`
+	Phase          SpiderPhase                            `json:"ps"`
+	MoveCount      int                                    `json:"mc"`
+	Score          int                                    `json:"sc"`
+	IsStalemate    bool                                   `json:"sm"`
+}
+
+// MarshalJSON implements json.Marshaler for spiderSnapshot, projecting
+// the unexported fields onto an exported wire shape so that
+// Spider.MarshalJSON can persist the undo history (#1654).
+func (s *spiderSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(spiderSnapshotJSON{
+		Tableau:        s.tableau,
+		Stock:          s.stock,
+		CompletedSuits: s.completedSuits,
+		Phase:          s.phase,
+		MoveCount:      s.moveCount,
+		Score:          s.score,
+		IsStalemate:    s.isStalemate,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for spiderSnapshot.
+func (s *spiderSnapshot) UnmarshalJSON(data []byte) error {
+	var j spiderSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if len(j.Stock) > spiderMaxSliceLen {
+		return fmt.Errorf("spider: snapshot array exceeds maximum allowed size")
+	}
+	for _, col := range j.Tableau {
+		if len(col) > spiderMaxSliceLen {
+			return fmt.Errorf("spider: snapshot tableau column exceeds maximum allowed size")
+		}
+	}
+	s.tableau = j.Tableau
+	s.stock = j.Stock
+	if s.stock == nil {
+		s.stock = make([]*Card, 0)
+	}
+	s.completedSuits = j.CompletedSuits
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	s.score = j.Score
+	s.isStalemate = j.IsStalemate
+	return nil
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -637,6 +694,7 @@ func (s *Spider) MarshalJSON() ([]byte, error) {
 		ActionLog:      s.actionLog,
 		Difficulty:     s.difficulty,
 		IsStalemate:    s.isStalemate,
+		History:        s.history,
 	})
 }
 
@@ -649,8 +707,14 @@ func (s *Spider) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
 	}
-	if len(j.Stock) > spiderMaxSliceLen || len(j.ActionLog) > spiderMaxSliceLen {
+	if len(j.Stock) > spiderMaxSliceLen || len(j.ActionLog) > spiderMaxSliceLen ||
+		len(j.History) > spiderMaxSliceLen {
 		return fmt.Errorf("spider: input array exceeds maximum allowed size")
+	}
+	for _, col := range j.Tableau {
+		if len(col) > spiderMaxSliceLen {
+			return fmt.Errorf("spider: tableau column exceeds maximum allowed size")
+		}
 	}
 
 	s.trumpCards = j.TrumpCards
@@ -670,8 +734,10 @@ func (s *Spider) UnmarshalJSON(data []byte) error {
 	if s.actionLog == nil {
 		s.actionLog = make([]*ActionLogEntry, 0)
 	}
-	// Undo history is not serialised; set to nil on restore.
-	s.history = nil
+	s.history = j.History
+	if s.history == nil {
+		s.history = make([]*spiderSnapshot, 0)
+	}
 	s.difficulty = j.Difficulty
 	if s.difficulty == 0 {
 		s.difficulty = SpiderDifficulty1Suit

--- a/internal/domain/Spider_persistence_test.go
+++ b/internal/domain/Spider_persistence_test.go
@@ -1,0 +1,134 @@
+//go:build test
+
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSpider_PersistsUndoHistory verifies issue #1654: when a Spider
+// game is round-tripped through JSON (e.g. a Cloudflare KV restore), the
+// undo history must survive so the player can still step backward.
+func TestSpider_PersistsUndoHistory(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultSpider()
+	original.Reset()
+	require.False(t, original.CanUndo(), "fresh game has no history")
+
+	// Deal is deterministic: after Reset every tableau column is non-empty
+	// and the stock has enough cards for at least one Deal.
+	require.NoError(t, original.Deal())
+	require.True(t, original.CanUndo(), "Deal should leave undoable history")
+	originalHistoryLen := len(original.history)
+	originalMoveCount := original.GetMoveCount()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored Spider
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	assert.Equal(t, originalMoveCount, restored.GetMoveCount(), "moveCount must round-trip")
+	assert.Equal(t, originalHistoryLen, len(restored.history), "history length must round-trip")
+	assert.True(t, restored.CanUndo(), "restored game must allow Undo")
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, originalMoveCount-1, restored.GetMoveCount(), "Undo should rewind one step")
+}
+
+// TestSpider_PersistsHistoryRestoresExactSnapshot ensures the snapshot
+// fields (tableau, stock, completedSuits, score) are preserved exactly.
+func TestSpider_PersistsHistoryRestoresExactSnapshot(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultSpider()
+	original.Reset()
+
+	preDealStockLen := len(original.stock)
+	preDealScore := original.score
+
+	require.NoError(t, original.Deal())
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored Spider
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, preDealStockLen, len(restored.stock), "Undo restores stock length")
+	assert.Equal(t, preDealScore, restored.score, "Undo restores score")
+}
+
+// TestSpider_HistoryRespectsMaxSliceLen rejects oversized history payloads.
+func TestSpider_HistoryRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigHistory := make([]map[string]any, spiderMaxSliceLen+1)
+	for i := range bigHistory {
+		bigHistory[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": bigHistory,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Spider
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized history must be rejected")
+}
+
+// TestSpider_SnapshotStockRespectsMaxSliceLen rejects payloads that
+// smuggle an oversized inner Stock slice inside a history snapshot.
+func TestSpider_SnapshotStockRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigStock := make([]map[string]any, spiderMaxSliceLen+1)
+	for i := range bigStock {
+		bigStock[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"st": bigStock,
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Spider
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot stock must be rejected")
+}
+
+// TestSpider_SnapshotTableauColumnRespectsMaxSliceLen rejects payloads
+// that smuggle an oversized Tableau column inside a history snapshot.
+func TestSpider_SnapshotTableauColumnRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigCol := make([]map[string]any, spiderMaxSliceLen+1)
+	for i := range bigCol {
+		bigCol[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"tb": []any{bigCol, nil, nil, nil, nil, nil, nil, nil, nil, nil},
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Spider
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot tableau column must be rejected")
+}


### PR DESCRIPTION
## Summary

Refs #1654 — extends the Klondike pilot pattern (#1722) to Spider and Pyramid. Follows PR #1724 (FreeCell + TriPeaks).

Previously, when a Cloudflare Workers session was restored from KV, both `Spider.UnmarshalJSON` and `Pyramid.UnmarshalJSON` deliberately set `history = nil`, so a player who reloaded a tab mid-game lost the entire undo stack. Now history round-trips through dedicated `*SnapshotJSON` wire types projecting the unexported snapshot fields onto an exported shape, with per-snapshot maxSliceLen guards mirroring the top-level checks.

## Changes

- **Spider**: Add `History []*spiderSnapshot` to `spiderJSON`; new `spiderSnapshotJSON` wire type + `MarshalJSON`/`UnmarshalJSON` on `spiderSnapshot`. Adds a tableau-column guard on the top-level UnmarshalJSON (previously absent) and inside each snapshot.
- **Pyramid**: Add `History []*pyramidSnapshot` to `pyramidJSON`; new `pyramidSnapshotJSON` wire type + `MarshalJSON`/`UnmarshalJSON` on `pyramidSnapshot`. Adds a pyramid-row guard on the top-level UnmarshalJSON (previously absent) and inside each snapshot.

JSON keys mirror the existing short-key convention (`tb`, `st`, `wa`, `py`, `cs`, `ps`, `mc`, `sm`, `sc`) to keep KV payloads compact.

## Remaining solitaire games

After this PR (Spider + Pyramid) and #1724 (FreeCell + TriPeaks): FortyThieves, Canfield, Yukon, RussianSolitaire, Scorpion, Accordion, BakersDozen, Calculation, Golf still need the same treatment. Issue #1654 stays open until the full rollout completes.

## Test plan

- [x] `go test -tags test ./internal/domain/ -run TestSpider` — all Spider tests pass
- [x] `go test -tags test ./internal/domain/ -run TestPyramid` — all Pyramid tests pass
- [x] `go test -tags test ./internal/domain/...` — full domain suite green (60.4s)
- [x] `golangci-lint run ./internal/domain/...` — 0 issues
- [x] `goimports -w` on changed files
- [ ] CI: full `go test -tags test ./...`

### New tests

- `TestSpider_PersistsUndoHistory`, `TestSpider_PersistsHistoryRestoresExactSnapshot`, `TestSpider_HistoryRespectsMaxSliceLen`, `TestSpider_SnapshotStockRespectsMaxSliceLen`, `TestSpider_SnapshotTableauColumnRespectsMaxSliceLen`
- `TestPyramid_PersistsUndoHistory`, `TestPyramid_PersistsHistoryRestoresExactSnapshot`, `TestPyramid_HistoryRespectsMaxSliceLen`, `TestPyramid_SnapshotStockRespectsMaxSliceLen`, `TestPyramid_SnapshotPyramidRowRespectsMaxSliceLen`