### PR TITLE
feat(fortythieves,canfield,yukon): persist undo history across KV restores

### DIFF
--- a/internal/domain/Canfield.go
+++ b/internal/domain/Canfield.go
@@ -614,6 +614,73 @@ type canfieldJSON struct {
 	Phase      CanfieldPhase                              `json:"ps"`
 	MoveCount  int                                        `json:"mc"`
 	ActionLog  []*ActionLogEntry                          `json:"al"`
+	History    []*canfieldSnapshot                        `json:"hi,omitempty"`
+}
+
+// canfieldSnapshotJSON is the wire format for a single undo snapshot.
+// canfieldSnapshot uses unexported fields, so we project to/from this
+// shape with explicit Marshal/Unmarshal methods. Field names match
+// canfieldJSON's short keys to keep the KV payload compact (#1654).
+type canfieldSnapshotJSON struct {
+	Tableau    [CanfieldTableauCnt][]*CanfieldTableauCard `json:"tb"`
+	Reserve    []*Card                                    `json:"rv"`
+	Stock      []*Card                                    `json:"st"`
+	Waste      []*Card                                    `json:"wa"`
+	Foundation [CanfieldFoundationCnt][]*Card             `json:"fd"`
+	Phase      CanfieldPhase                              `json:"ps"`
+	MoveCount  int                                        `json:"mc"`
+}
+
+// MarshalJSON implements json.Marshaler for canfieldSnapshot.
+func (s *canfieldSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(canfieldSnapshotJSON{
+		Tableau:    s.tableau,
+		Reserve:    s.reserve,
+		Stock:      s.stock,
+		Waste:      s.waste,
+		Foundation: s.foundation,
+		Phase:      s.phase,
+		MoveCount:  s.moveCount,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for canfieldSnapshot.
+func (s *canfieldSnapshot) UnmarshalJSON(data []byte) error {
+	var j canfieldSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if len(j.Reserve) > canfieldMaxSliceLen || len(j.Stock) > canfieldMaxSliceLen ||
+		len(j.Waste) > canfieldMaxSliceLen {
+		return fmt.Errorf("canfield: snapshot array exceeds maximum allowed size")
+	}
+	for _, col := range j.Tableau {
+		if len(col) > canfieldMaxSliceLen {
+			return fmt.Errorf("canfield: snapshot tableau column exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Foundation {
+		if len(pile) > canfieldMaxSliceLen {
+			return fmt.Errorf("canfield: snapshot foundation pile exceeds maximum allowed size")
+		}
+	}
+	s.tableau = j.Tableau
+	s.reserve = j.Reserve
+	if s.reserve == nil {
+		s.reserve = make([]*Card, 0)
+	}
+	s.stock = j.Stock
+	if s.stock == nil {
+		s.stock = make([]*Card, 0)
+	}
+	s.waste = j.Waste
+	if s.waste == nil {
+		s.waste = make([]*Card, 0)
+	}
+	s.foundation = j.Foundation
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	return nil
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -629,6 +696,7 @@ func (c *Canfield) MarshalJSON() ([]byte, error) {
 		Phase:      c.phase,
 		MoveCount:  c.moveCount,
 		ActionLog:  c.actionLog,
+		History:    c.history,
 	})
 }
 
@@ -642,8 +710,19 @@ func (c *Canfield) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if len(j.Reserve) > canfieldMaxSliceLen || len(j.Stock) > canfieldMaxSliceLen ||
-		len(j.Waste) > canfieldMaxSliceLen || len(j.ActionLog) > canfieldMaxSliceLen {
+		len(j.Waste) > canfieldMaxSliceLen || len(j.ActionLog) > canfieldMaxSliceLen ||
+		len(j.History) > canfieldMaxSliceLen {
 		return fmt.Errorf("canfield: input array exceeds maximum allowed size")
+	}
+	for _, col := range j.Tableau {
+		if len(col) > canfieldMaxSliceLen {
+			return fmt.Errorf("canfield: tableau column exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Foundation {
+		if len(pile) > canfieldMaxSliceLen {
+			return fmt.Errorf("canfield: foundation pile exceeds maximum allowed size")
+		}
 	}
 	c.trumpCards = j.TrumpCards
 	if c.trumpCards == nil {
@@ -670,6 +749,9 @@ func (c *Canfield) UnmarshalJSON(data []byte) error {
 	if c.actionLog == nil {
 		c.actionLog = make([]*ActionLogEntry, 0)
 	}
-	c.history = nil
+	c.history = j.History
+	if c.history == nil {
+		c.history = make([]*canfieldSnapshot, 0)
+	}
 	return nil
 }

--- a/internal/domain/Canfield_persistence_test.go
+++ b/internal/domain/Canfield_persistence_test.go
@@ -130,3 +130,46 @@ func TestCanfield_SnapshotStockRespectsMaxSliceLen(t *testing.T) {
 	err = json.Unmarshal(data, &restored)
 	require.Error(t, err, "oversized snapshot stock must be rejected")
 }
+
+// TestCanfield_TopLevelTableauColumnRespectsMaxSliceLen rejects payloads
+// with an oversized Tableau column at the top level.
+func TestCanfield_TopLevelTableauColumnRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigCol := make([]map[string]any, canfieldMaxSliceLen+1)
+	for i := range bigCol {
+		bigCol[i] = map[string]any{}
+	}
+	// Canfield has 4 tableau columns.
+	payload := map[string]any{
+		"tc": nil,
+		"tb": []any{bigCol, nil, nil, nil},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Canfield
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized top-level tableau column must be rejected")
+}
+
+// TestCanfield_TopLevelFoundationPileRespectsMaxSliceLen rejects payloads
+// with an oversized Foundation pile at the top level.
+func TestCanfield_TopLevelFoundationPileRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigPile := make([]map[string]any, canfieldMaxSliceLen+1)
+	for i := range bigPile {
+		bigPile[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"fd": []any{bigPile, nil, nil, nil},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Canfield
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized top-level foundation pile must be rejected")
+}

--- a/internal/domain/Canfield_persistence_test.go
+++ b/internal/domain/Canfield_persistence_test.go
@@ -1,0 +1,132 @@
+//go:build test
+
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCanfield_PersistsUndoHistory verifies issue #1654.
+func TestCanfield_PersistsUndoHistory(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultCanfield()
+	original.Reset()
+	require.False(t, original.CanUndo(), "fresh game has no history")
+
+	require.NoError(t, original.Draw())
+	require.NoError(t, original.Draw())
+	require.True(t, original.CanUndo(), "two draws should leave undoable history")
+	originalHistoryLen := len(original.history)
+	originalMoveCount := original.GetMoveCount()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored Canfield
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	assert.Equal(t, originalMoveCount, restored.GetMoveCount(), "moveCount must round-trip")
+	assert.Equal(t, originalHistoryLen, len(restored.history), "history length must round-trip")
+	assert.True(t, restored.CanUndo(), "restored game must allow Undo")
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, originalMoveCount-1, restored.GetMoveCount(), "Undo should rewind one step")
+}
+
+// TestCanfield_PersistsHistoryRestoresExactSnapshot ensures the snapshot
+// fields are preserved exactly.
+func TestCanfield_PersistsHistoryRestoresExactSnapshot(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultCanfield()
+	original.Reset()
+	require.NoError(t, original.Draw())
+
+	preDrawWasteLen := len(original.waste)
+	preDrawStockLen := len(original.stock)
+
+	require.NoError(t, original.Draw())
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored Canfield
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, preDrawWasteLen, len(restored.waste), "Undo restores waste length")
+	assert.Equal(t, preDrawStockLen, len(restored.stock), "Undo restores stock length")
+}
+
+// TestCanfield_HistoryRespectsMaxSliceLen rejects oversized history.
+func TestCanfield_HistoryRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigHistory := make([]map[string]any, canfieldMaxSliceLen+1)
+	for i := range bigHistory {
+		bigHistory[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": bigHistory,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Canfield
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized history must be rejected")
+}
+
+// TestCanfield_SnapshotReserveRespectsMaxSliceLen rejects payloads with
+// an oversized inner Reserve slice inside a history snapshot.
+func TestCanfield_SnapshotReserveRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigReserve := make([]map[string]any, canfieldMaxSliceLen+1)
+	for i := range bigReserve {
+		bigReserve[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"rv": bigReserve,
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Canfield
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot reserve must be rejected")
+}
+
+// TestCanfield_SnapshotStockRespectsMaxSliceLen rejects payloads with
+// an oversized inner Stock slice inside a history snapshot.
+func TestCanfield_SnapshotStockRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigStock := make([]map[string]any, canfieldMaxSliceLen+1)
+	for i := range bigStock {
+		bigStock[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"st": bigStock,
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Canfield
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot stock must be rejected")
+}

--- a/internal/domain/FortyThieves.go
+++ b/internal/domain/FortyThieves.go
@@ -613,6 +613,69 @@ type fortyThievesJSON struct {
 	MoveCount   int                                                `json:"mc"`
 	ActionLog   []*ActionLogEntry                                  `json:"al"`
 	IsStalemate bool                                               `json:"sl"`
+	History     []*fortyThievesSnapshot                            `json:"hi,omitempty"`
+}
+
+// fortyThievesSnapshotJSON is the wire format for a single undo snapshot.
+// fortyThievesSnapshot uses unexported fields, so we project to/from this
+// shape with explicit Marshal/Unmarshal methods. Field names match
+// fortyThievesJSON's short keys to keep the KV payload compact (#1654).
+type fortyThievesSnapshotJSON struct {
+	Tableau     [FortyThievesTableauCnt][]*FortyThievesTableauCard `json:"tb"`
+	Stock       []*Card                                            `json:"st"`
+	Waste       []*Card                                            `json:"wa"`
+	Foundation  [FortyThievesFoundationCnt][]*Card                 `json:"fd"`
+	Phase       FortyThievesPhase                                  `json:"ps"`
+	MoveCount   int                                                `json:"mc"`
+	IsStalemate bool                                               `json:"sl"`
+}
+
+// MarshalJSON implements json.Marshaler for fortyThievesSnapshot.
+func (s *fortyThievesSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(fortyThievesSnapshotJSON{
+		Tableau:     s.tableau,
+		Stock:       s.stock,
+		Waste:       s.waste,
+		Foundation:  s.foundation,
+		Phase:       s.phase,
+		MoveCount:   s.moveCount,
+		IsStalemate: s.isStalemate,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for fortyThievesSnapshot.
+func (s *fortyThievesSnapshot) UnmarshalJSON(data []byte) error {
+	var j fortyThievesSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if len(j.Stock) > fortyThievesMaxSliceLen || len(j.Waste) > fortyThievesMaxSliceLen {
+		return fmt.Errorf("fortythieves: snapshot array exceeds maximum allowed size")
+	}
+	for _, col := range j.Tableau {
+		if len(col) > fortyThievesMaxSliceLen {
+			return fmt.Errorf("fortythieves: snapshot tableau column exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Foundation {
+		if len(pile) > fortyThievesMaxSliceLen {
+			return fmt.Errorf("fortythieves: snapshot foundation pile exceeds maximum allowed size")
+		}
+	}
+	s.tableau = j.Tableau
+	s.stock = j.Stock
+	if s.stock == nil {
+		s.stock = make([]*Card, 0)
+	}
+	s.waste = j.Waste
+	if s.waste == nil {
+		s.waste = make([]*Card, 0)
+	}
+	s.foundation = j.Foundation
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	s.isStalemate = j.IsStalemate
+	return nil
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -627,6 +690,7 @@ func (ft *FortyThieves) MarshalJSON() ([]byte, error) {
 		MoveCount:   ft.moveCount,
 		ActionLog:   ft.actionLog,
 		IsStalemate: ft.isStalemate,
+		History:     ft.history,
 	})
 }
 
@@ -640,8 +704,18 @@ func (ft *FortyThieves) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if len(j.Stock) > fortyThievesMaxSliceLen || len(j.Waste) > fortyThievesMaxSliceLen ||
-		len(j.ActionLog) > fortyThievesMaxSliceLen {
+		len(j.ActionLog) > fortyThievesMaxSliceLen || len(j.History) > fortyThievesMaxSliceLen {
 		return fmt.Errorf("fortythieves: input array exceeds maximum allowed size")
+	}
+	for _, col := range j.Tableau {
+		if len(col) > fortyThievesMaxSliceLen {
+			return fmt.Errorf("fortythieves: tableau column exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Foundation {
+		if len(pile) > fortyThievesMaxSliceLen {
+			return fmt.Errorf("fortythieves: foundation pile exceeds maximum allowed size")
+		}
 	}
 
 	ft.trumpCards = j.TrumpCards
@@ -664,8 +738,10 @@ func (ft *FortyThieves) UnmarshalJSON(data []byte) error {
 	if ft.actionLog == nil {
 		ft.actionLog = make([]*ActionLogEntry, 0)
 	}
-	// Undo history is not serialised; set to nil on restore.
-	ft.history = nil
+	ft.history = j.History
+	if ft.history == nil {
+		ft.history = make([]*fortyThievesSnapshot, 0)
+	}
 	ft.isStalemate = j.IsStalemate
 	return nil
 }

--- a/internal/domain/FortyThieves_persistence_test.go
+++ b/internal/domain/FortyThieves_persistence_test.go
@@ -1,0 +1,139 @@
+//go:build test
+
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFortyThieves_PersistsUndoHistory verifies issue #1654: when a
+// FortyThieves game is round-tripped through JSON (e.g. a Cloudflare KV
+// restore), the undo history must survive so the player can still step
+// backward.
+func TestFortyThieves_PersistsUndoHistory(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultFortyThieves()
+	original.Reset()
+	require.False(t, original.CanUndo(), "fresh game has no history")
+
+	// Draw is deterministic — after Reset the stock has cards regardless of shuffle.
+	require.NoError(t, original.Draw())
+	require.NoError(t, original.Draw())
+	require.True(t, original.CanUndo(), "two draws should leave undoable history")
+	originalHistoryLen := len(original.history)
+	originalMoveCount := original.GetMoveCount()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored FortyThieves
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	assert.Equal(t, originalMoveCount, restored.GetMoveCount(), "moveCount must round-trip")
+	assert.Equal(t, originalHistoryLen, len(restored.history), "history length must round-trip")
+	assert.True(t, restored.CanUndo(), "restored game must allow Undo")
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, originalMoveCount-1, restored.GetMoveCount(), "Undo should rewind one step")
+}
+
+// TestFortyThieves_PersistsHistoryRestoresExactSnapshot ensures the
+// snapshot fields are preserved exactly.
+func TestFortyThieves_PersistsHistoryRestoresExactSnapshot(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultFortyThieves()
+	original.Reset()
+	require.NoError(t, original.Draw())
+
+	preDrawWasteLen := len(original.waste)
+	preDrawStockLen := len(original.stock)
+
+	require.NoError(t, original.Draw())
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored FortyThieves
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, preDrawWasteLen, len(restored.waste), "Undo restores waste length")
+	assert.Equal(t, preDrawStockLen, len(restored.stock), "Undo restores stock length")
+}
+
+// TestFortyThieves_HistoryRespectsMaxSliceLen rejects oversized history.
+func TestFortyThieves_HistoryRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigHistory := make([]map[string]any, fortyThievesMaxSliceLen+1)
+	for i := range bigHistory {
+		bigHistory[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": bigHistory,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored FortyThieves
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized history must be rejected")
+}
+
+// TestFortyThieves_SnapshotStockRespectsMaxSliceLen rejects payloads
+// with an oversized inner Stock slice inside a history snapshot.
+func TestFortyThieves_SnapshotStockRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigStock := make([]map[string]any, fortyThievesMaxSliceLen+1)
+	for i := range bigStock {
+		bigStock[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"st": bigStock,
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored FortyThieves
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot stock must be rejected")
+}
+
+// TestFortyThieves_SnapshotTableauColumnRespectsMaxSliceLen rejects
+// payloads with an oversized inner tableau column inside a snapshot.
+func TestFortyThieves_SnapshotTableauColumnRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigCol := make([]map[string]any, fortyThievesMaxSliceLen+1)
+	for i := range bigCol {
+		bigCol[i] = map[string]any{}
+	}
+	// FortyThieves has 10 tableau columns.
+	tableau := make([]any, 10)
+	tableau[0] = bigCol
+	snapshot := map[string]any{
+		"tb": tableau,
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored FortyThieves
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot tableau column must be rejected")
+}

--- a/internal/domain/FortyThieves_persistence_test.go
+++ b/internal/domain/FortyThieves_persistence_test.go
@@ -137,3 +137,47 @@ func TestFortyThieves_SnapshotTableauColumnRespectsMaxSliceLen(t *testing.T) {
 	err = json.Unmarshal(data, &restored)
 	require.Error(t, err, "oversized snapshot tableau column must be rejected")
 }
+
+// TestFortyThieves_TopLevelTableauColumnRespectsMaxSliceLen rejects
+// payloads with an oversized Tableau column at the top level.
+func TestFortyThieves_TopLevelTableauColumnRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigCol := make([]map[string]any, fortyThievesMaxSliceLen+1)
+	for i := range bigCol {
+		bigCol[i] = map[string]any{}
+	}
+	tableau := make([]any, 10)
+	tableau[0] = bigCol
+	payload := map[string]any{
+		"tc": nil,
+		"tb": tableau,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored FortyThieves
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized top-level tableau column must be rejected")
+}
+
+// TestFortyThieves_TopLevelFoundationPileRespectsMaxSliceLen rejects
+// payloads with an oversized Foundation pile at the top level.
+func TestFortyThieves_TopLevelFoundationPileRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigPile := make([]map[string]any, fortyThievesMaxSliceLen+1)
+	for i := range bigPile {
+		bigPile[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"fd": []any{bigPile, nil, nil, nil, nil, nil, nil, nil},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored FortyThieves
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized top-level foundation pile must be rejected")
+}

--- a/internal/domain/FortyThieves_test.go
+++ b/internal/domain/FortyThieves_test.go
@@ -712,7 +712,7 @@ func TestFortyThieves_JSON(t *testing.T) {
 		assert.Equal(t, ft.GetMoveCount(), ft2.GetMoveCount())
 		assert.Equal(t, ft.GetStockCount(), ft2.GetStockCount())
 		assert.Equal(t, len(ft.GetWaste()), len(ft2.GetWaste()))
-		assert.False(t, ft2.CanUndo()) // history not serialized
+		assert.True(t, ft2.CanUndo()) // history is now serialized (#1654)
 	})
 
 	t.Run("unmarshal with nil trumpCards", func(t *testing.T) {

--- a/internal/domain/Yukon.go
+++ b/internal/domain/Yukon.go
@@ -527,6 +527,54 @@ type yukonJSON struct {
 	MoveCount   int                                     `json:"mc"`
 	ActionLog   []*ActionLogEntry                       `json:"al"`
 	IsStalemate bool                                    `json:"sl"`
+	History     []*yukonSnapshot                        `json:"hi,omitempty"`
+}
+
+// yukonSnapshotJSON is the wire format for a single undo snapshot.
+// yukonSnapshot uses unexported fields, so we project to/from this
+// shape with explicit Marshal/Unmarshal methods. Field names match
+// yukonJSON's short keys to keep the KV payload compact (#1654).
+type yukonSnapshotJSON struct {
+	Tableau     [YukonTableauCnt][]*KlondikeTableauCard `json:"tb"`
+	Foundation  [YukonFoundationCnt][]*Card             `json:"fd"`
+	Phase       YukonPhase                              `json:"ps"`
+	MoveCount   int                                     `json:"mc"`
+	IsStalemate bool                                    `json:"sl"`
+}
+
+// MarshalJSON implements json.Marshaler for yukonSnapshot.
+func (s *yukonSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(yukonSnapshotJSON{
+		Tableau:     s.tableau,
+		Foundation:  s.foundation,
+		Phase:       s.phase,
+		MoveCount:   s.moveCount,
+		IsStalemate: s.isStalemate,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for yukonSnapshot.
+func (s *yukonSnapshot) UnmarshalJSON(data []byte) error {
+	var j yukonSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	for _, col := range j.Tableau {
+		if len(col) > yukonMaxSliceLen {
+			return fmt.Errorf("yukon: snapshot tableau column exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Foundation {
+		if len(pile) > yukonMaxSliceLen {
+			return fmt.Errorf("yukon: snapshot foundation pile exceeds maximum allowed size")
+		}
+	}
+	s.tableau = j.Tableau
+	s.foundation = j.Foundation
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	s.isStalemate = j.IsStalemate
+	return nil
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -539,6 +587,7 @@ func (y *Yukon) MarshalJSON() ([]byte, error) {
 		MoveCount:   y.moveCount,
 		ActionLog:   y.actionLog,
 		IsStalemate: y.isStalemate,
+		History:     y.history,
 	})
 }
 
@@ -551,12 +600,17 @@ func (y *Yukon) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
 	}
-	if len(j.ActionLog) > yukonMaxSliceLen {
+	if len(j.ActionLog) > yukonMaxSliceLen || len(j.History) > yukonMaxSliceLen {
 		return fmt.Errorf("yukon: input array exceeds maximum allowed size")
 	}
 	for i := range YukonTableauCnt {
 		if len(j.Tableau[i]) > yukonMaxSliceLen {
 			return fmt.Errorf("yukon: input array exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Foundation {
+		if len(pile) > yukonMaxSliceLen {
+			return fmt.Errorf("yukon: foundation pile exceeds maximum allowed size")
 		}
 	}
 
@@ -572,8 +626,10 @@ func (y *Yukon) UnmarshalJSON(data []byte) error {
 	if y.actionLog == nil {
 		y.actionLog = make([]*ActionLogEntry, 0)
 	}
-	// Undo history is not serialised; set to nil on restore.
-	y.history = nil
+	y.history = j.History
+	if y.history == nil {
+		y.history = make([]*yukonSnapshot, 0)
+	}
 	y.isStalemate = j.IsStalemate
 	return nil
 }

--- a/internal/domain/Yukon.go
+++ b/internal/domain/Yukon.go
@@ -603,9 +603,9 @@ func (y *Yukon) UnmarshalJSON(data []byte) error {
 	if len(j.ActionLog) > yukonMaxSliceLen || len(j.History) > yukonMaxSliceLen {
 		return fmt.Errorf("yukon: input array exceeds maximum allowed size")
 	}
-	for i := range YukonTableauCnt {
-		if len(j.Tableau[i]) > yukonMaxSliceLen {
-			return fmt.Errorf("yukon: input array exceeds maximum allowed size")
+	for _, col := range j.Tableau {
+		if len(col) > yukonMaxSliceLen {
+			return fmt.Errorf("yukon: tableau column exceeds maximum allowed size")
 		}
 	}
 	for _, pile := range j.Foundation {

--- a/internal/domain/Yukon_persistence_test.go
+++ b/internal/domain/Yukon_persistence_test.go
@@ -1,0 +1,122 @@
+//go:build test
+
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestYukon_PersistsUndoHistory verifies issue #1654: when a Yukon game
+// is round-tripped through JSON (e.g. a Cloudflare KV restore), the undo
+// history must survive so the player can still step backward.
+//
+// Yukon has no deterministic public action like Draw — every move is
+// shape-dependent on the random initial deal — so the test calls
+// takeSnapshot() directly (same package). This still exercises the full
+// Marshal/Unmarshal round-trip for the snapshot wire format.
+func TestYukon_PersistsUndoHistory(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultYukon()
+	original.Reset()
+	require.False(t, original.CanUndo(), "fresh game has no history")
+
+	original.takeSnapshot()
+	original.takeSnapshot()
+	require.True(t, original.CanUndo(), "two snapshots should leave undoable history")
+	originalHistoryLen := len(original.history)
+	originalMoveCount := original.GetMoveCount()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored Yukon
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	assert.Equal(t, originalMoveCount, restored.GetMoveCount(), "moveCount must round-trip")
+	assert.Equal(t, originalHistoryLen, len(restored.history), "history length must round-trip")
+	assert.True(t, restored.CanUndo(), "restored game must allow Undo")
+}
+
+// TestYukon_PersistsHistoryRestoresExactSnapshot ensures the snapshot
+// fields are preserved exactly so an Undo on the restored game matches
+// the pre-snapshot state.
+func TestYukon_PersistsHistoryRestoresExactSnapshot(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultYukon()
+	original.Reset()
+
+	// Snapshot the initial state, then mutate and snapshot again.
+	original.takeSnapshot()
+	preMutationTableau0Len := len(original.tableau[0])
+
+	// Force a state change so Undo will visibly rewind.
+	original.tableau[0] = original.tableau[0][:0]
+	original.takeSnapshot()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored Yukon
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	// Undo once: returns to the snapshot we took just before clearing tableau[0]
+	// (which itself captured the post-clear state, since takeSnapshot copies the
+	// current state — confirm history pop count is correct).
+	require.NoError(t, restored.Undo())
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, preMutationTableau0Len, len(restored.tableau[0]),
+		"second Undo restores tableau[0] length")
+}
+
+// TestYukon_HistoryRespectsMaxSliceLen rejects oversized history.
+func TestYukon_HistoryRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigHistory := make([]map[string]any, yukonMaxSliceLen+1)
+	for i := range bigHistory {
+		bigHistory[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": bigHistory,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Yukon
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized history must be rejected")
+}
+
+// TestYukon_SnapshotTableauColumnRespectsMaxSliceLen rejects payloads
+// with an oversized tableau column inside a history snapshot.
+func TestYukon_SnapshotTableauColumnRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigCol := make([]map[string]any, yukonMaxSliceLen+1)
+	for i := range bigCol {
+		bigCol[i] = map[string]any{}
+	}
+	// Yukon has 7 tableau columns.
+	tableau := make([]any, 7)
+	tableau[0] = bigCol
+	snapshot := map[string]any{
+		"tb": tableau,
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Yukon
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot tableau column must be rejected")
+}

--- a/internal/domain/Yukon_persistence_test.go
+++ b/internal/domain/Yukon_persistence_test.go
@@ -65,9 +65,10 @@ func TestYukon_PersistsHistoryRestoresExactSnapshot(t *testing.T) {
 	var restored Yukon
 	require.NoError(t, json.Unmarshal(data, &restored))
 
-	// Undo once: returns to the snapshot we took just before clearing tableau[0]
-	// (which itself captured the post-clear state, since takeSnapshot copies the
-	// current state — confirm history pop count is correct).
+	// The first Undo restores from the second snapshot (post-mutation, with
+	// tableau[0] empty); the second Undo restores from the first snapshot
+	// (pre-mutation initial state). Only after both pops should tableau[0]
+	// regain its original length.
 	require.NoError(t, restored.Undo())
 	require.NoError(t, restored.Undo())
 	assert.Equal(t, preMutationTableau0Len, len(restored.tableau[0]),
@@ -119,4 +120,48 @@ func TestYukon_SnapshotTableauColumnRespectsMaxSliceLen(t *testing.T) {
 	var restored Yukon
 	err = json.Unmarshal(data, &restored)
 	require.Error(t, err, "oversized snapshot tableau column must be rejected")
+}
+
+// TestYukon_TopLevelTableauColumnRespectsMaxSliceLen rejects payloads
+// with an oversized Tableau column at the top level.
+func TestYukon_TopLevelTableauColumnRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigCol := make([]map[string]any, yukonMaxSliceLen+1)
+	for i := range bigCol {
+		bigCol[i] = map[string]any{}
+	}
+	tableau := make([]any, 7)
+	tableau[0] = bigCol
+	payload := map[string]any{
+		"tc": nil,
+		"tb": tableau,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Yukon
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized top-level tableau column must be rejected")
+}
+
+// TestYukon_TopLevelFoundationPileRespectsMaxSliceLen rejects payloads
+// with an oversized Foundation pile at the top level.
+func TestYukon_TopLevelFoundationPileRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigPile := make([]map[string]any, yukonMaxSliceLen+1)
+	for i := range bigPile {
+		bigPile[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"fd": []any{bigPile, nil, nil, nil},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Yukon
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized top-level foundation pile must be rejected")
 }


### PR DESCRIPTION
## Summary

Refs #1654 — extends the Klondike pilot pattern (#1722) to FortyThieves, Canfield, and Yukon. Follows #1724 (FreeCell + TriPeaks) and #1725 (Spider + Pyramid).

Previously, when a Cloudflare Workers session was restored from KV, all three games' UnmarshalJSON deliberately set `history = nil`, so a player who reloaded a tab mid-game lost the entire undo stack. Now history round-trips through dedicated `*SnapshotJSON` wire types projecting the unexported snapshot fields, gated by per-snapshot maxSliceLen guards mirroring the top-level checks.

## Changes

- **FortyThieves**: `History []*fortyThievesSnapshot` on `fortyThievesJSON`; new `fortyThievesSnapshotJSON` + `MarshalJSON`/`UnmarshalJSON`. Adds tableau column + foundation pile guards at the top-level `UnmarshalJSON` (previously absent) and inside each snapshot. Updates `TestFortyThieves_JSON` to assert the new behavior (`CanUndo()` is now `true` after round-trip).
- **Canfield**: `History []*canfieldSnapshot` on `canfieldJSON`; new `canfieldSnapshotJSON` + `MarshalJSON`/`UnmarshalJSON`. Adds tableau column + foundation pile guards.
- **Yukon**: `History []*yukonSnapshot` on `yukonJSON`; new `yukonSnapshotJSON` + `MarshalJSON`/`UnmarshalJSON`. Adds foundation pile guard at the top level (previously absent) plus snapshot-level tableau guard.

JSON keys mirror the existing short-key convention (`tb`, `st`, `wa`, `fd`, `rv`, `ps`, `mc`, `sl`) to keep KV payloads compact.

### Yukon test note

Yukon has no deterministic public action (every `Move*` is shape-dependent on the random initial deal), so its persistence test calls the package-private `takeSnapshot()` directly. This still exercises the full Marshal/Unmarshal round-trip for the snapshot wire format.

## Remaining solitaire games

After this PR (FortyThieves + Canfield + Yukon), #1724 (FreeCell + TriPeaks), and #1725 (Spider + Pyramid): RussianSolitaire, Scorpion, Accordion, BakersDozen, Calculation, Golf still need the same treatment. Issue #1654 stays open until the full rollout completes.

## Test plan

- [x] `go test -tags test ./internal/domain/ -run "TestFortyThieves|TestCanfield|TestYukon"` — all three games' tests pass
- [x] `go test -tags test ./internal/domain/...` — full domain suite green (61.9s)
- [x] `golangci-lint run ./internal/domain/...` — 0 issues
- [x] `goimports -w` on changed files
- [ ] CI: full `go test -tags test ./...`

### New tests (15 total)

- `TestFortyThieves_PersistsUndoHistory`, `TestFortyThieves_PersistsHistoryRestoresExactSnapshot`, `TestFortyThieves_HistoryRespectsMaxSliceLen`, `TestFortyThieves_SnapshotStockRespectsMaxSliceLen`, `TestFortyThieves_SnapshotTableauColumnRespectsMaxSliceLen`
- `TestCanfield_PersistsUndoHistory`, `TestCanfield_PersistsHistoryRestoresExactSnapshot`, `TestCanfield_HistoryRespectsMaxSliceLen`, `TestCanfield_SnapshotReserveRespectsMaxSliceLen`, `TestCanfield_SnapshotStockRespectsMaxSliceLen`
- `TestYukon_PersistsUndoHistory`, `TestYukon_PersistsHistoryRestoresExactSnapshot`, `TestYukon_HistoryRespectsMaxSliceLen`, `TestYukon_SnapshotTableauColumnRespectsMaxSliceLen`