### PR TITLE
feat(russiansolitaire,scorpion,accordion): persist undo history across KV restores

### DIFF
--- a/internal/domain/Accordion.go
+++ b/internal/domain/Accordion.go
@@ -294,12 +294,58 @@ func (a *Accordion) appendLog(actionType, detail string, cards []*Card) {
 
 // accordionJSON is the JSON wire format for Accordion.
 type accordionJSON struct {
-	TrumpCards  *TrumpCards       `json:"tc"`
-	Piles       [][]*Card         `json:"pl"`
-	Phase       AccordionPhase    `json:"ps"`
-	MoveCount   int               `json:"mc"`
-	ActionLog   []*ActionLogEntry `json:"al"`
-	IsStalemate bool              `json:"sl"`
+	TrumpCards  *TrumpCards          `json:"tc"`
+	Piles       [][]*Card            `json:"pl"`
+	Phase       AccordionPhase       `json:"ps"`
+	MoveCount   int                  `json:"mc"`
+	ActionLog   []*ActionLogEntry    `json:"al"`
+	IsStalemate bool                 `json:"sl"`
+	History     []*accordionSnapshot `json:"hi,omitempty"`
+}
+
+// accordionSnapshotJSON is the wire format for a single undo snapshot.
+// accordionSnapshot uses unexported fields, so we project to/from this
+// shape with explicit Marshal/Unmarshal methods. Field names match
+// accordionJSON's short keys to keep the KV payload compact (#1654).
+type accordionSnapshotJSON struct {
+	Piles       [][]*Card      `json:"pl"`
+	Phase       AccordionPhase `json:"ps"`
+	MoveCount   int            `json:"mc"`
+	IsStalemate bool           `json:"sl"`
+}
+
+// MarshalJSON implements json.Marshaler for accordionSnapshot.
+func (s *accordionSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(accordionSnapshotJSON{
+		Piles:       s.piles,
+		Phase:       s.phase,
+		MoveCount:   s.moveCount,
+		IsStalemate: s.isStalemate,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for accordionSnapshot.
+func (s *accordionSnapshot) UnmarshalJSON(data []byte) error {
+	var j accordionSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if len(j.Piles) > accordionMaxSliceLen {
+		return fmt.Errorf("accordion: snapshot piles exceeds maximum allowed size")
+	}
+	for _, pile := range j.Piles {
+		if len(pile) > accordionMaxSliceLen {
+			return fmt.Errorf("accordion: snapshot pile exceeds maximum allowed size")
+		}
+	}
+	s.piles = j.Piles
+	if s.piles == nil {
+		s.piles = make([][]*Card, 0)
+	}
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	s.isStalemate = j.IsStalemate
+	return nil
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -311,6 +357,7 @@ func (a *Accordion) MarshalJSON() ([]byte, error) {
 		MoveCount:   a.moveCount,
 		ActionLog:   a.actionLog,
 		IsStalemate: a.isStalemate,
+		History:     a.history,
 	})
 }
 
@@ -326,7 +373,8 @@ func (a *Accordion) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
 	}
-	if len(j.Piles) > accordionMaxSliceLen || len(j.ActionLog) > accordionMaxSliceLen {
+	if len(j.Piles) > accordionMaxSliceLen || len(j.ActionLog) > accordionMaxSliceLen ||
+		len(j.History) > accordionMaxSliceLen {
 		return fmt.Errorf("accordion: input array exceeds maximum allowed size")
 	}
 	for _, pile := range j.Piles {
@@ -348,7 +396,10 @@ func (a *Accordion) UnmarshalJSON(data []byte) error {
 	if a.actionLog == nil {
 		a.actionLog = make([]*ActionLogEntry, 0)
 	}
-	a.history = nil
+	a.history = j.History
+	if a.history == nil {
+		a.history = make([]*accordionSnapshot, 0)
+	}
 	a.isStalemate = j.IsStalemate
 	return nil
 }

--- a/internal/domain/Accordion_persistence_test.go
+++ b/internal/domain/Accordion_persistence_test.go
@@ -1,0 +1,143 @@
+//go:build test
+
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAccordion_PersistsUndoHistory verifies issue #1654: when an
+// Accordion game is round-tripped through JSON (e.g. a Cloudflare KV
+// restore), the undo history must survive so the player can still step
+// backward.
+//
+// Accordion's Move depends on rank/suit alignment of the random initial
+// deal, so the test calls takeSnapshot() directly (same package). This
+// still exercises the full Marshal/Unmarshal round-trip for the snapshot
+// wire format.
+func TestAccordion_PersistsUndoHistory(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultAccordion()
+	original.Reset()
+	require.False(t, original.CanUndo(), "fresh game has no history")
+
+	original.takeSnapshot()
+	original.takeSnapshot()
+	require.True(t, original.CanUndo(), "two snapshots should leave undoable history")
+	originalHistoryLen := len(original.history)
+	originalMoveCount := original.GetMoveCount()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored Accordion
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	assert.Equal(t, originalMoveCount, restored.GetMoveCount(), "moveCount must round-trip")
+	assert.Equal(t, originalHistoryLen, len(restored.history), "history length must round-trip")
+	assert.True(t, restored.CanUndo(), "restored game must allow Undo")
+}
+
+// TestAccordion_PersistsHistoryRestoresExactSnapshot ensures the snapshot
+// fields are preserved exactly so an Undo on the restored game matches
+// the pre-snapshot state.
+func TestAccordion_PersistsHistoryRestoresExactSnapshot(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultAccordion()
+	original.Reset()
+
+	// Snapshot the initial state, then mutate and snapshot again.
+	original.takeSnapshot()
+	preMutationPilesLen := len(original.piles)
+
+	// Force a state change so Undo will visibly rewind.
+	original.piles = original.piles[:len(original.piles)-1]
+	original.takeSnapshot()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored Accordion
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	// First Undo restores from second snapshot (post-mutation, one fewer pile);
+	// second Undo restores from first snapshot (pre-mutation initial state).
+	require.NoError(t, restored.Undo())
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, preMutationPilesLen, len(restored.piles),
+		"second Undo restores piles length")
+}
+
+// TestAccordion_HistoryRespectsMaxSliceLen rejects oversized history.
+func TestAccordion_HistoryRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigHistory := make([]map[string]any, accordionMaxSliceLen+1)
+	for i := range bigHistory {
+		bigHistory[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": bigHistory,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Accordion
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized history must be rejected")
+}
+
+// TestAccordion_SnapshotPilesRespectsMaxSliceLen rejects payloads with an
+// oversized Piles outer slice inside a history snapshot.
+func TestAccordion_SnapshotPilesRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigPiles := make([]any, accordionMaxSliceLen+1)
+	for i := range bigPiles {
+		bigPiles[i] = []any{}
+	}
+	snapshot := map[string]any{
+		"pl": bigPiles,
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Accordion
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot piles must be rejected")
+}
+
+// TestAccordion_SnapshotPileColumnRespectsMaxSliceLen rejects payloads
+// with an oversized inner Pile entry inside a history snapshot.
+func TestAccordion_SnapshotPileColumnRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigPile := make([]map[string]any, accordionMaxSliceLen+1)
+	for i := range bigPile {
+		bigPile[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"pl": []any{bigPile},
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Accordion
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot pile entry must be rejected")
+}

--- a/internal/domain/RussianSolitaire.go
+++ b/internal/domain/RussianSolitaire.go
@@ -521,6 +521,54 @@ type russianSolitaireJSON struct {
 	MoveCount   int                                                `json:"mc"`
 	ActionLog   []*ActionLogEntry                                  `json:"al"`
 	IsStalemate bool                                               `json:"sl"`
+	History     []*russianSolitaireSnapshot                        `json:"hi,omitempty"`
+}
+
+// russianSolitaireSnapshotJSON is the wire format for a single undo
+// snapshot. russianSolitaireSnapshot uses unexported fields, so we project
+// to/from this shape with explicit Marshal/Unmarshal methods. Field names
+// match russianSolitaireJSON's short keys to keep the KV payload compact (#1654).
+type russianSolitaireSnapshotJSON struct {
+	Tableau     [RussianSolitaireTableauCnt][]*KlondikeTableauCard `json:"tb"`
+	Foundation  [RussianSolitaireFoundationCnt][]*Card             `json:"fd"`
+	Phase       RussianSolitairePhase                              `json:"ps"`
+	MoveCount   int                                                `json:"mc"`
+	IsStalemate bool                                               `json:"sl"`
+}
+
+// MarshalJSON implements json.Marshaler for russianSolitaireSnapshot.
+func (s *russianSolitaireSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(russianSolitaireSnapshotJSON{
+		Tableau:     s.tableau,
+		Foundation:  s.foundation,
+		Phase:       s.phase,
+		MoveCount:   s.moveCount,
+		IsStalemate: s.isStalemate,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for russianSolitaireSnapshot.
+func (s *russianSolitaireSnapshot) UnmarshalJSON(data []byte) error {
+	var j russianSolitaireSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	for _, col := range j.Tableau {
+		if len(col) > russianSolitaireMaxSliceLen {
+			return fmt.Errorf("russiansolitaire: snapshot tableau column exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Foundation {
+		if len(pile) > russianSolitaireMaxSliceLen {
+			return fmt.Errorf("russiansolitaire: snapshot foundation pile exceeds maximum allowed size")
+		}
+	}
+	s.tableau = j.Tableau
+	s.foundation = j.Foundation
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	s.isStalemate = j.IsStalemate
+	return nil
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -533,6 +581,7 @@ func (y *RussianSolitaire) MarshalJSON() ([]byte, error) {
 		MoveCount:   y.moveCount,
 		ActionLog:   y.actionLog,
 		IsStalemate: y.isStalemate,
+		History:     y.history,
 	})
 }
 
@@ -545,12 +594,18 @@ func (y *RussianSolitaire) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
 	}
-	if len(j.ActionLog) > russianSolitaireMaxSliceLen {
+	if len(j.ActionLog) > russianSolitaireMaxSliceLen ||
+		len(j.History) > russianSolitaireMaxSliceLen {
 		return fmt.Errorf("russiansolitaire: input array exceeds maximum allowed size")
 	}
-	for i := range RussianSolitaireTableauCnt {
-		if len(j.Tableau[i]) > russianSolitaireMaxSliceLen {
-			return fmt.Errorf("russiansolitaire: input array exceeds maximum allowed size")
+	for _, col := range j.Tableau {
+		if len(col) > russianSolitaireMaxSliceLen {
+			return fmt.Errorf("russiansolitaire: tableau column exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Foundation {
+		if len(pile) > russianSolitaireMaxSliceLen {
+			return fmt.Errorf("russiansolitaire: foundation pile exceeds maximum allowed size")
 		}
 	}
 
@@ -566,8 +621,10 @@ func (y *RussianSolitaire) UnmarshalJSON(data []byte) error {
 	if y.actionLog == nil {
 		y.actionLog = make([]*ActionLogEntry, 0)
 	}
-	// Undo history is not serialised; set to nil on restore.
-	y.history = nil
+	y.history = j.History
+	if y.history == nil {
+		y.history = make([]*russianSolitaireSnapshot, 0)
+	}
 	y.isStalemate = j.IsStalemate
 	return nil
 }

--- a/internal/domain/RussianSolitaire_persistence_test.go
+++ b/internal/domain/RussianSolitaire_persistence_test.go
@@ -1,0 +1,191 @@
+//go:build test
+
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRussianSolitaire_PersistsUndoHistory verifies issue #1654: when a
+// RussianSolitaire game is round-tripped through JSON (e.g. a Cloudflare
+// KV restore), the undo history must survive so the player can still
+// step backward.
+//
+// RussianSolitaire has no deterministic public action — every Move is
+// shape-dependent on the random initial deal — so the test calls
+// takeSnapshot() directly (same package). This still exercises the full
+// Marshal/Unmarshal round-trip for the snapshot wire format.
+func TestRussianSolitaire_PersistsUndoHistory(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultRussianSolitaire()
+	original.Reset()
+	require.False(t, original.CanUndo(), "fresh game has no history")
+
+	original.takeSnapshot()
+	original.takeSnapshot()
+	require.True(t, original.CanUndo(), "two snapshots should leave undoable history")
+	originalHistoryLen := len(original.history)
+	originalMoveCount := original.GetMoveCount()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored RussianSolitaire
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	assert.Equal(t, originalMoveCount, restored.GetMoveCount(), "moveCount must round-trip")
+	assert.Equal(t, originalHistoryLen, len(restored.history), "history length must round-trip")
+	assert.True(t, restored.CanUndo(), "restored game must allow Undo")
+}
+
+// TestRussianSolitaire_PersistsHistoryRestoresExactSnapshot ensures the
+// snapshot fields are preserved exactly so an Undo on the restored game
+// matches the pre-snapshot state.
+func TestRussianSolitaire_PersistsHistoryRestoresExactSnapshot(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultRussianSolitaire()
+	original.Reset()
+
+	// Snapshot the initial state, then mutate and snapshot again.
+	original.takeSnapshot()
+	preMutationTableau0Len := len(original.tableau[0])
+
+	// Force a state change so Undo will visibly rewind.
+	original.tableau[0] = original.tableau[0][:0]
+	original.takeSnapshot()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored RussianSolitaire
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	// The first Undo restores from the second snapshot (post-mutation, with
+	// tableau[0] empty); the second Undo restores from the first snapshot
+	// (pre-mutation initial state). Only after both pops should tableau[0]
+	// regain its original length.
+	require.NoError(t, restored.Undo())
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, preMutationTableau0Len, len(restored.tableau[0]),
+		"second Undo restores tableau[0] length")
+}
+
+// TestRussianSolitaire_HistoryRespectsMaxSliceLen rejects oversized history.
+func TestRussianSolitaire_HistoryRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigHistory := make([]map[string]any, russianSolitaireMaxSliceLen+1)
+	for i := range bigHistory {
+		bigHistory[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": bigHistory,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored RussianSolitaire
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized history must be rejected")
+}
+
+// TestRussianSolitaire_TopLevelTableauColumnRespectsMaxSliceLen rejects
+// payloads with an oversized Tableau column at the top level.
+func TestRussianSolitaire_TopLevelTableauColumnRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigCol := make([]map[string]any, russianSolitaireMaxSliceLen+1)
+	for i := range bigCol {
+		bigCol[i] = map[string]any{}
+	}
+	tableau := make([]any, 7)
+	tableau[0] = bigCol
+	payload := map[string]any{
+		"tc": nil,
+		"tb": tableau,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored RussianSolitaire
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized top-level tableau column must be rejected")
+}
+
+// TestRussianSolitaire_TopLevelFoundationPileRespectsMaxSliceLen rejects
+// payloads with an oversized Foundation pile at the top level.
+func TestRussianSolitaire_TopLevelFoundationPileRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigPile := make([]map[string]any, russianSolitaireMaxSliceLen+1)
+	for i := range bigPile {
+		bigPile[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"fd": []any{bigPile, nil, nil, nil},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored RussianSolitaire
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized top-level foundation pile must be rejected")
+}
+
+// TestRussianSolitaire_SnapshotTableauColumnRespectsMaxSliceLen rejects
+// payloads with an oversized tableau column inside a history snapshot.
+func TestRussianSolitaire_SnapshotTableauColumnRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigCol := make([]map[string]any, russianSolitaireMaxSliceLen+1)
+	for i := range bigCol {
+		bigCol[i] = map[string]any{}
+	}
+	tableau := make([]any, 7)
+	tableau[0] = bigCol
+	snapshot := map[string]any{
+		"tb": tableau,
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored RussianSolitaire
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot tableau column must be rejected")
+}
+
+// TestRussianSolitaire_SnapshotFoundationPileRespectsMaxSliceLen rejects
+// payloads with an oversized foundation pile inside a history snapshot.
+func TestRussianSolitaire_SnapshotFoundationPileRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigPile := make([]map[string]any, russianSolitaireMaxSliceLen+1)
+	for i := range bigPile {
+		bigPile[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"fd": []any{bigPile, nil, nil, nil},
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored RussianSolitaire
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot foundation pile must be rejected")
+}

--- a/internal/domain/Scorpion.go
+++ b/internal/domain/Scorpion.go
@@ -541,6 +541,58 @@ type scorpionJSON struct {
 	MoveCount      int                                        `json:"mc"`
 	ActionLog      []*ActionLogEntry                          `json:"al"`
 	IsStalemate    bool                                       `json:"sl"`
+	History        []*scorpionSnapshot                        `json:"hi,omitempty"`
+}
+
+// scorpionSnapshotJSON is the wire format for a single undo snapshot.
+// scorpionSnapshot uses unexported fields, so we project to/from this
+// shape with explicit Marshal/Unmarshal methods. Field names match
+// scorpionJSON's short keys to keep the KV payload compact (#1654).
+type scorpionSnapshotJSON struct {
+	Tableau        [ScorpionTableauCnt][]*KlondikeTableauCard `json:"tb"`
+	Stock          []*Card                                    `json:"st"`
+	CompletedSuits int                                        `json:"cs"`
+	Phase          ScorpionPhase                              `json:"ps"`
+	MoveCount      int                                        `json:"mc"`
+	IsStalemate    bool                                       `json:"sl"`
+}
+
+// MarshalJSON implements json.Marshaler for scorpionSnapshot.
+func (s *scorpionSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(scorpionSnapshotJSON{
+		Tableau:        s.tableau,
+		Stock:          s.stock,
+		CompletedSuits: s.completedSuits,
+		Phase:          s.phase,
+		MoveCount:      s.moveCount,
+		IsStalemate:    s.isStalemate,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for scorpionSnapshot.
+func (s *scorpionSnapshot) UnmarshalJSON(data []byte) error {
+	var j scorpionSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if len(j.Stock) > scorpionMaxSliceLen {
+		return fmt.Errorf("scorpion: snapshot array exceeds maximum allowed size")
+	}
+	for _, col := range j.Tableau {
+		if len(col) > scorpionMaxSliceLen {
+			return fmt.Errorf("scorpion: snapshot tableau column exceeds maximum allowed size")
+		}
+	}
+	s.tableau = j.Tableau
+	s.stock = j.Stock
+	if s.stock == nil {
+		s.stock = make([]*Card, 0)
+	}
+	s.completedSuits = j.CompletedSuits
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	s.isStalemate = j.IsStalemate
+	return nil
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -554,6 +606,7 @@ func (s *Scorpion) MarshalJSON() ([]byte, error) {
 		MoveCount:      s.moveCount,
 		ActionLog:      s.actionLog,
 		IsStalemate:    s.isStalemate,
+		History:        s.history,
 	})
 }
 
@@ -566,12 +619,13 @@ func (s *Scorpion) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
 	}
-	if len(j.Stock) > scorpionMaxSliceLen || len(j.ActionLog) > scorpionMaxSliceLen {
+	if len(j.Stock) > scorpionMaxSliceLen || len(j.ActionLog) > scorpionMaxSliceLen ||
+		len(j.History) > scorpionMaxSliceLen {
 		return fmt.Errorf("scorpion: input array exceeds maximum allowed size")
 	}
-	for i := range ScorpionTableauCnt {
-		if len(j.Tableau[i]) > scorpionMaxSliceLen {
-			return fmt.Errorf("scorpion: input array exceeds maximum allowed size")
+	for _, col := range j.Tableau {
+		if len(col) > scorpionMaxSliceLen {
+			return fmt.Errorf("scorpion: tableau column exceeds maximum allowed size")
 		}
 	}
 	s.trumpCards = j.TrumpCards
@@ -590,7 +644,10 @@ func (s *Scorpion) UnmarshalJSON(data []byte) error {
 	if s.actionLog == nil {
 		s.actionLog = make([]*ActionLogEntry, 0)
 	}
-	s.history = nil
+	s.history = j.History
+	if s.history == nil {
+		s.history = make([]*scorpionSnapshot, 0)
+	}
 	s.isStalemate = j.IsStalemate
 	return nil
 }

--- a/internal/domain/Scorpion.go
+++ b/internal/domain/Scorpion.go
@@ -576,7 +576,7 @@ func (s *scorpionSnapshot) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if len(j.Stock) > scorpionMaxSliceLen {
-		return fmt.Errorf("scorpion: snapshot array exceeds maximum allowed size")
+		return fmt.Errorf("scorpion: snapshot stock exceeds maximum allowed size")
 	}
 	for _, col := range j.Tableau {
 		if len(col) > scorpionMaxSliceLen {

--- a/internal/domain/Scorpion_persistence_test.go
+++ b/internal/domain/Scorpion_persistence_test.go
@@ -1,0 +1,159 @@
+//go:build test
+
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestScorpion_PersistsUndoHistory verifies issue #1654: when a Scorpion
+// game is round-tripped through JSON (e.g. a Cloudflare KV restore), the
+// undo history must survive so the player can still step backward.
+func TestScorpion_PersistsUndoHistory(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultScorpion()
+	original.Reset()
+	require.False(t, original.CanUndo(), "fresh game has no history")
+
+	// Deal is deterministic — after Reset the stock has 3 cards regardless
+	// of shuffle, and Deal places one card per face-down column.
+	require.NoError(t, original.Deal())
+	require.True(t, original.CanUndo(), "Deal should leave undoable history")
+	originalHistoryLen := len(original.history)
+	originalMoveCount := original.GetMoveCount()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored Scorpion
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	assert.Equal(t, originalMoveCount, restored.GetMoveCount(), "moveCount must round-trip")
+	assert.Equal(t, originalHistoryLen, len(restored.history), "history length must round-trip")
+	assert.True(t, restored.CanUndo(), "restored game must allow Undo")
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, originalMoveCount-1, restored.GetMoveCount(), "Undo should rewind one step")
+}
+
+// TestScorpion_PersistsHistoryRestoresExactSnapshot ensures the snapshot
+// fields are preserved exactly so an Undo on a restored game returns to
+// the same state as the pre-action snapshot.
+func TestScorpion_PersistsHistoryRestoresExactSnapshot(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultScorpion()
+	original.Reset()
+
+	// Capture pre-Deal state
+	preDealStockLen := len(original.stock)
+
+	require.NoError(t, original.Deal())
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored Scorpion
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, preDealStockLen, len(restored.stock), "Undo restores stock length")
+}
+
+// TestScorpion_HistoryRespectsMaxSliceLen rejects oversized history.
+func TestScorpion_HistoryRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigHistory := make([]map[string]any, scorpionMaxSliceLen+1)
+	for i := range bigHistory {
+		bigHistory[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": bigHistory,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Scorpion
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized history must be rejected")
+}
+
+// TestScorpion_TopLevelTableauColumnRespectsMaxSliceLen rejects payloads
+// with an oversized Tableau column at the top level.
+func TestScorpion_TopLevelTableauColumnRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigCol := make([]map[string]any, scorpionMaxSliceLen+1)
+	for i := range bigCol {
+		bigCol[i] = map[string]any{}
+	}
+	tableau := make([]any, 7)
+	tableau[0] = bigCol
+	payload := map[string]any{
+		"tc": nil,
+		"tb": tableau,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Scorpion
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized top-level tableau column must be rejected")
+}
+
+// TestScorpion_SnapshotTableauColumnRespectsMaxSliceLen rejects payloads
+// with an oversized tableau column inside a history snapshot.
+func TestScorpion_SnapshotTableauColumnRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigCol := make([]map[string]any, scorpionMaxSliceLen+1)
+	for i := range bigCol {
+		bigCol[i] = map[string]any{}
+	}
+	tableau := make([]any, 7)
+	tableau[0] = bigCol
+	snapshot := map[string]any{
+		"tb": tableau,
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Scorpion
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot tableau column must be rejected")
+}
+
+// TestScorpion_SnapshotStockRespectsMaxSliceLen rejects payloads with
+// an oversized inner Stock slice inside a history snapshot.
+func TestScorpion_SnapshotStockRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigStock := make([]map[string]any, scorpionMaxSliceLen+1)
+	for i := range bigStock {
+		bigStock[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"st": bigStock,
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Scorpion
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot stock must be rejected")
+}


### PR DESCRIPTION
## Summary

Refs #1654 — extends the Klondike pilot pattern (#1722) to RussianSolitaire, Scorpion, and Accordion. Follows #1724 (FreeCell + TriPeaks), #1725 (Spider + Pyramid), and #1726 (FortyThieves + Canfield + Yukon).

Previously, when a Cloudflare Workers session was restored from KV, all three games' UnmarshalJSON deliberately set `history = nil`, so a player who reloaded a tab mid-game lost the entire undo stack. Now history round-trips through dedicated `*SnapshotJSON` wire types projecting the unexported snapshot fields, gated by per-snapshot maxSliceLen guards mirroring the top-level checks.

## Changes

- **RussianSolitaire**: `History []*russianSolitaireSnapshot` on `russianSolitaireJSON`; new `russianSolitaireSnapshotJSON` + `MarshalJSON`/`UnmarshalJSON`. Switches top-level Tableau guard from per-index loop to `range j.Tableau` (matching the snapshot pattern) with a specific error message, and adds a foundation pile guard at the top level (previously absent) plus inside each snapshot.
- **Scorpion**: `History []*scorpionSnapshot` on `scorpionJSON`; new `scorpionSnapshotJSON` + `MarshalJSON`/`UnmarshalJSON`. Switches top-level Tableau guard to `range`, adds snapshot tableau-column + stock guards.
- **Accordion**: `History []*accordionSnapshot` on `accordionJSON`; new `accordionSnapshotJSON` + `MarshalJSON`/`UnmarshalJSON`. Adds outer-piles + inner-pile guards inside each snapshot.

JSON keys mirror the existing short-key convention (`tb`, `st`, `fd`, `pl`, `cs`, `ps`, `mc`, `sl`) to keep KV payloads compact.

### Test note

RussianSolitaire and Accordion have no deterministic public action (every `Move*` is shape-dependent on the random initial deal), so their persistence tests call the package-private `takeSnapshot()` directly. This still exercises the full Marshal/Unmarshal round-trip for the snapshot wire format. Scorpion's `Deal()` is deterministic and used directly.

## Remaining solitaire games

After this PR (RussianSolitaire + Scorpion + Accordion), #1722 (Klondike pilot), #1724 (FreeCell + TriPeaks), #1725 (Spider + Pyramid), and #1726 (FortyThieves + Canfield + Yukon): BakersDozen, Calculation, Golf still need the same treatment. One more PR remains before #1654 can close.

## Test plan

- [x] `go test -tags test ./internal/domain/ -run "TestRussianSolitaire|TestScorpion|TestAccordion"` — all three games' tests pass
- [x] `go test -tags test ./internal/domain/...` — full domain suite green (70.4s)
- [x] `golangci-lint run ./internal/domain/...` — 0 issues
- [x] `goimports -w` on changed files
- [ ] CI: full `go test -tags test ./...`

### New tests (16 total)

- `TestRussianSolitaire_PersistsUndoHistory`, `TestRussianSolitaire_PersistsHistoryRestoresExactSnapshot`, `TestRussianSolitaire_HistoryRespectsMaxSliceLen`, `TestRussianSolitaire_TopLevelTableauColumnRespectsMaxSliceLen`, `TestRussianSolitaire_TopLevelFoundationPileRespectsMaxSliceLen`, `TestRussianSolitaire_SnapshotTableauColumnRespectsMaxSliceLen`, `TestRussianSolitaire_SnapshotFoundationPileRespectsMaxSliceLen`
- `TestScorpion_PersistsUndoHistory`, `TestScorpion_PersistsHistoryRestoresExactSnapshot`, `TestScorpion_HistoryRespectsMaxSliceLen`, `TestScorpion_TopLevelTableauColumnRespectsMaxSliceLen`, `TestScorpion_SnapshotTableauColumnRespectsMaxSliceLen`, `TestScorpion_SnapshotStockRespectsMaxSliceLen`
- `TestAccordion_PersistsUndoHistory`, `TestAccordion_PersistsHistoryRestoresExactSnapshot`, `TestAccordion_HistoryRespectsMaxSliceLen`, `TestAccordion_SnapshotPilesRespectsMaxSliceLen`, `TestAccordion_SnapshotPileColumnRespectsMaxSliceLen`