### PR TITLE
feat(bakersdozen,calculation,golf): persist undo history across KV restores

### DIFF
--- a/internal/domain/BakersDozen.go
+++ b/internal/domain/BakersDozen.go
@@ -504,7 +504,17 @@ func (s *bakersDozenSnapshot) UnmarshalJSON(data []byte) error {
 		}
 	}
 	s.tableau = j.Tableau
+	for i := range BakersDozenTableauCnt {
+		if s.tableau[i] == nil {
+			s.tableau[i] = make([]*BakersDozenTableauCard, 0)
+		}
+	}
 	s.foundation = j.Foundation
+	for i := range BakersDozenFoundationCnt {
+		if s.foundation[i] == nil {
+			s.foundation[i] = make([]*Card, 0)
+		}
+	}
 	s.phase = j.Phase
 	s.moveCount = j.MoveCount
 	s.isStalemate = j.IsStalemate
@@ -554,7 +564,17 @@ func (bd *BakersDozen) UnmarshalJSON(data []byte) error {
 		bd.trumpCards = NewTrumpCardsWithDecks(1, 0)
 	}
 	bd.tableau = j.Tableau
+	for i := range BakersDozenTableauCnt {
+		if bd.tableau[i] == nil {
+			bd.tableau[i] = make([]*BakersDozenTableauCard, 0)
+		}
+	}
 	bd.foundation = j.Foundation
+	for i := range BakersDozenFoundationCnt {
+		if bd.foundation[i] == nil {
+			bd.foundation[i] = make([]*Card, 0)
+		}
+	}
 	bd.phase = j.Phase
 	bd.moveCount = j.MoveCount
 	bd.actionLog = j.ActionLog

--- a/internal/domain/BakersDozen.go
+++ b/internal/domain/BakersDozen.go
@@ -461,6 +461,54 @@ type bakersDozenJSON struct {
 	MoveCount   int                                              `json:"mc"`
 	ActionLog   []*ActionLogEntry                                `json:"al"`
 	IsStalemate bool                                             `json:"sl"`
+	History     []*bakersDozenSnapshot                           `json:"hi,omitempty"`
+}
+
+// bakersDozenSnapshotJSON is the wire format for a single undo snapshot.
+// bakersDozenSnapshot uses unexported fields, so we project to/from this
+// shape with explicit Marshal/Unmarshal methods. Field names match
+// bakersDozenJSON's short keys to keep the KV payload compact (#1654).
+type bakersDozenSnapshotJSON struct {
+	Tableau     [BakersDozenTableauCnt][]*BakersDozenTableauCard `json:"tb"`
+	Foundation  [BakersDozenFoundationCnt][]*Card                `json:"fd"`
+	Phase       BakersDozenPhase                                 `json:"ps"`
+	MoveCount   int                                              `json:"mc"`
+	IsStalemate bool                                             `json:"sl"`
+}
+
+// MarshalJSON implements json.Marshaler for bakersDozenSnapshot.
+func (s *bakersDozenSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(bakersDozenSnapshotJSON{
+		Tableau:     s.tableau,
+		Foundation:  s.foundation,
+		Phase:       s.phase,
+		MoveCount:   s.moveCount,
+		IsStalemate: s.isStalemate,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for bakersDozenSnapshot.
+func (s *bakersDozenSnapshot) UnmarshalJSON(data []byte) error {
+	var j bakersDozenSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	for _, col := range j.Tableau {
+		if len(col) > bakersDozenMaxSliceLen {
+			return fmt.Errorf("bakersdozen: snapshot tableau column exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Foundation {
+		if len(pile) > bakersDozenMaxSliceLen {
+			return fmt.Errorf("bakersdozen: snapshot foundation pile exceeds maximum allowed size")
+		}
+	}
+	s.tableau = j.Tableau
+	s.foundation = j.Foundation
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	s.isStalemate = j.IsStalemate
+	return nil
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -473,6 +521,7 @@ func (bd *BakersDozen) MarshalJSON() ([]byte, error) {
 		MoveCount:   bd.moveCount,
 		ActionLog:   bd.actionLog,
 		IsStalemate: bd.isStalemate,
+		History:     bd.history,
 	})
 }
 
@@ -485,8 +534,19 @@ func (bd *BakersDozen) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
 	}
-	if len(j.ActionLog) > bakersDozenMaxSliceLen {
+	if len(j.ActionLog) > bakersDozenMaxSliceLen ||
+		len(j.History) > bakersDozenMaxSliceLen {
 		return fmt.Errorf("bakersdozen: input array exceeds maximum allowed size")
+	}
+	for _, col := range j.Tableau {
+		if len(col) > bakersDozenMaxSliceLen {
+			return fmt.Errorf("bakersdozen: tableau column exceeds maximum allowed size")
+		}
+	}
+	for _, pile := range j.Foundation {
+		if len(pile) > bakersDozenMaxSliceLen {
+			return fmt.Errorf("bakersdozen: foundation pile exceeds maximum allowed size")
+		}
 	}
 
 	bd.trumpCards = j.TrumpCards
@@ -501,7 +561,10 @@ func (bd *BakersDozen) UnmarshalJSON(data []byte) error {
 	if bd.actionLog == nil {
 		bd.actionLog = make([]*ActionLogEntry, 0)
 	}
-	bd.history = nil
+	bd.history = j.History
+	if bd.history == nil {
+		bd.history = make([]*bakersDozenSnapshot, 0)
+	}
 	bd.isStalemate = j.IsStalemate
 	return nil
 }

--- a/internal/domain/BakersDozen_persistence_test.go
+++ b/internal/domain/BakersDozen_persistence_test.go
@@ -1,0 +1,185 @@
+//go:build test
+
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBakersDozen_PersistsUndoHistory verifies issue #1654.
+//
+// BakersDozen has no deterministic public action — every Move is
+// shape-dependent on the random initial deal — so the test calls
+// takeSnapshot() directly (same package). This still exercises the full
+// Marshal/Unmarshal round-trip for the snapshot wire format.
+func TestBakersDozen_PersistsUndoHistory(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultBakersDozen()
+	original.Reset()
+	require.False(t, original.CanUndo(), "fresh game has no history")
+
+	original.takeSnapshot()
+	original.takeSnapshot()
+	require.True(t, original.CanUndo(), "two snapshots should leave undoable history")
+	originalHistoryLen := len(original.history)
+	originalMoveCount := original.GetMoveCount()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored BakersDozen
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	assert.Equal(t, originalMoveCount, restored.GetMoveCount(), "moveCount must round-trip")
+	assert.Equal(t, originalHistoryLen, len(restored.history), "history length must round-trip")
+	assert.True(t, restored.CanUndo(), "restored game must allow Undo")
+}
+
+// TestBakersDozen_PersistsHistoryRestoresExactSnapshot ensures snapshot
+// fields are preserved exactly so an Undo on the restored game returns
+// to the pre-mutation state.
+func TestBakersDozen_PersistsHistoryRestoresExactSnapshot(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultBakersDozen()
+	original.Reset()
+
+	original.takeSnapshot()
+	preMutationTableau0Len := len(original.tableau[0])
+
+	original.tableau[0] = original.tableau[0][:0]
+	original.takeSnapshot()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored BakersDozen
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	// First Undo restores from second (post-mutation) snapshot; second Undo
+	// restores from first (pre-mutation) snapshot. tableau[0] regains its
+	// original length only after both pops.
+	require.NoError(t, restored.Undo())
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, preMutationTableau0Len, len(restored.tableau[0]),
+		"second Undo restores tableau[0] length")
+}
+
+// TestBakersDozen_HistoryRespectsMaxSliceLen rejects oversized history.
+func TestBakersDozen_HistoryRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigHistory := make([]map[string]any, bakersDozenMaxSliceLen+1)
+	for i := range bigHistory {
+		bigHistory[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": bigHistory,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored BakersDozen
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized history must be rejected")
+}
+
+// TestBakersDozen_TopLevelTableauColumnRespectsMaxSliceLen rejects
+// payloads with an oversized Tableau column at the top level.
+func TestBakersDozen_TopLevelTableauColumnRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigCol := make([]map[string]any, bakersDozenMaxSliceLen+1)
+	for i := range bigCol {
+		bigCol[i] = map[string]any{}
+	}
+	tableau := make([]any, 13)
+	tableau[0] = bigCol
+	payload := map[string]any{
+		"tc": nil,
+		"tb": tableau,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored BakersDozen
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized top-level tableau column must be rejected")
+}
+
+// TestBakersDozen_TopLevelFoundationPileRespectsMaxSliceLen rejects
+// payloads with an oversized Foundation pile at the top level.
+func TestBakersDozen_TopLevelFoundationPileRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigPile := make([]map[string]any, bakersDozenMaxSliceLen+1)
+	for i := range bigPile {
+		bigPile[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"fd": []any{bigPile, nil, nil, nil},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored BakersDozen
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized top-level foundation pile must be rejected")
+}
+
+// TestBakersDozen_SnapshotTableauColumnRespectsMaxSliceLen rejects
+// payloads with an oversized tableau column inside a snapshot.
+func TestBakersDozen_SnapshotTableauColumnRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigCol := make([]map[string]any, bakersDozenMaxSliceLen+1)
+	for i := range bigCol {
+		bigCol[i] = map[string]any{}
+	}
+	tableau := make([]any, 13)
+	tableau[0] = bigCol
+	snapshot := map[string]any{
+		"tb": tableau,
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored BakersDozen
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot tableau column must be rejected")
+}
+
+// TestBakersDozen_SnapshotFoundationPileRespectsMaxSliceLen rejects
+// payloads with an oversized foundation pile inside a snapshot.
+func TestBakersDozen_SnapshotFoundationPileRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigPile := make([]map[string]any, bakersDozenMaxSliceLen+1)
+	for i := range bigPile {
+		bigPile[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"fd": []any{bigPile, nil, nil, nil},
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored BakersDozen
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot foundation pile must be rejected")
+}

--- a/internal/domain/Calculation.go
+++ b/internal/domain/Calculation.go
@@ -445,6 +445,73 @@ type calculationJSON struct {
 	MoveCount   int                               `json:"mc"`
 	ActionLog   []*ActionLogEntry                 `json:"al"`
 	IsStalemate bool                              `json:"sl"`
+	History     []*calculationSnapshot            `json:"hi,omitempty"`
+}
+
+// calculationSnapshotJSON is the wire format for a single undo snapshot.
+// calculationSnapshot uses unexported fields, so we project to/from this
+// shape with explicit Marshal/Unmarshal methods. Field names match
+// calculationJSON's short keys to keep the KV payload compact (#1654).
+type calculationSnapshotJSON struct {
+	Foundations [CalculationFoundationCnt][]*Card `json:"fd"`
+	Wastes      [CalculationWasteCnt][]*Card      `json:"wa"`
+	Stock       []*Card                           `json:"st"`
+	Phase       CalculationPhase                  `json:"ps"`
+	MoveCount   int                               `json:"mc"`
+	IsStalemate bool                              `json:"sl"`
+}
+
+// MarshalJSON implements json.Marshaler for calculationSnapshot.
+func (s *calculationSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(calculationSnapshotJSON{
+		Foundations: s.foundations,
+		Wastes:      s.wastes,
+		Stock:       s.stock,
+		Phase:       s.phase,
+		MoveCount:   s.moveCount,
+		IsStalemate: s.isStalemate,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for calculationSnapshot.
+func (s *calculationSnapshot) UnmarshalJSON(data []byte) error {
+	var j calculationSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if len(j.Stock) > calculationMaxSliceLen {
+		return fmt.Errorf("calculation: snapshot stock exceeds maximum allowed size")
+	}
+	for i := range CalculationFoundationCnt {
+		if len(j.Foundations[i]) > calculationMaxSliceLen {
+			return fmt.Errorf("calculation: snapshot foundation %d exceeds maximum allowed size", i)
+		}
+	}
+	for i := range CalculationWasteCnt {
+		if len(j.Wastes[i]) > calculationMaxSliceLen {
+			return fmt.Errorf("calculation: snapshot waste %d exceeds maximum allowed size", i)
+		}
+	}
+	s.foundations = j.Foundations
+	for i := range CalculationFoundationCnt {
+		if s.foundations[i] == nil {
+			s.foundations[i] = make([]*Card, 0)
+		}
+	}
+	s.wastes = j.Wastes
+	for i := range CalculationWasteCnt {
+		if s.wastes[i] == nil {
+			s.wastes[i] = make([]*Card, 0)
+		}
+	}
+	s.stock = j.Stock
+	if s.stock == nil {
+		s.stock = make([]*Card, 0)
+	}
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	s.isStalemate = j.IsStalemate
+	return nil
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -458,6 +525,7 @@ func (c *Calculation) MarshalJSON() ([]byte, error) {
 		MoveCount:   c.moveCount,
 		ActionLog:   c.actionLog,
 		IsStalemate: c.isStalemate,
+		History:     c.history,
 	})
 }
 
@@ -470,7 +538,8 @@ func (c *Calculation) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
 	}
-	if len(j.Stock) > calculationMaxSliceLen || len(j.ActionLog) > calculationMaxSliceLen {
+	if len(j.Stock) > calculationMaxSliceLen || len(j.ActionLog) > calculationMaxSliceLen ||
+		len(j.History) > calculationMaxSliceLen {
 		return fmt.Errorf("calculation: input array exceeds maximum allowed size")
 	}
 	for i := range CalculationFoundationCnt {
@@ -510,8 +579,10 @@ func (c *Calculation) UnmarshalJSON(data []byte) error {
 	if c.actionLog == nil {
 		c.actionLog = make([]*ActionLogEntry, 0)
 	}
-	// Undo history is not serialised; set to nil on restore.
-	c.history = nil
+	c.history = j.History
+	if c.history == nil {
+		c.history = make([]*calculationSnapshot, 0)
+	}
 	c.isStalemate = j.IsStalemate
 	return nil
 }

--- a/internal/domain/Calculation_persistence_test.go
+++ b/internal/domain/Calculation_persistence_test.go
@@ -1,0 +1,158 @@
+//go:build test
+
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCalculation_PersistsUndoHistory verifies issue #1654.
+func TestCalculation_PersistsUndoHistory(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultCalculation()
+	original.Reset()
+	require.False(t, original.CanUndo(), "fresh game has no history")
+
+	// PlayStockToWaste(0) is deterministic — after Reset stock has cards
+	// regardless of shuffle, and waste 0 starts empty.
+	require.NoError(t, original.PlayStockToWaste(0))
+	require.NoError(t, original.PlayStockToWaste(1))
+	require.True(t, original.CanUndo(), "two plays should leave undoable history")
+	originalHistoryLen := len(original.history)
+	originalMoveCount := original.GetMoveCount()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored Calculation
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	assert.Equal(t, originalMoveCount, restored.GetMoveCount(), "moveCount must round-trip")
+	assert.Equal(t, originalHistoryLen, len(restored.history), "history length must round-trip")
+	assert.True(t, restored.CanUndo(), "restored game must allow Undo")
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, originalMoveCount-1, restored.GetMoveCount(), "Undo should rewind one step")
+}
+
+// TestCalculation_PersistsHistoryRestoresExactSnapshot ensures snapshot
+// fields are preserved exactly.
+func TestCalculation_PersistsHistoryRestoresExactSnapshot(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultCalculation()
+	original.Reset()
+	require.NoError(t, original.PlayStockToWaste(0))
+
+	prePlayWaste1Len := len(original.wastes[1])
+	prePlayStockLen := len(original.stock)
+
+	require.NoError(t, original.PlayStockToWaste(1))
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored Calculation
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, prePlayWaste1Len, len(restored.wastes[1]), "Undo restores waste 1 length")
+	assert.Equal(t, prePlayStockLen, len(restored.stock), "Undo restores stock length")
+}
+
+// TestCalculation_HistoryRespectsMaxSliceLen rejects oversized history.
+func TestCalculation_HistoryRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigHistory := make([]map[string]any, calculationMaxSliceLen+1)
+	for i := range bigHistory {
+		bigHistory[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": bigHistory,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Calculation
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized history must be rejected")
+}
+
+// TestCalculation_SnapshotStockRespectsMaxSliceLen rejects payloads
+// with an oversized inner Stock slice inside a snapshot.
+func TestCalculation_SnapshotStockRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigStock := make([]map[string]any, calculationMaxSliceLen+1)
+	for i := range bigStock {
+		bigStock[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"st": bigStock,
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Calculation
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot stock must be rejected")
+}
+
+// TestCalculation_SnapshotFoundationRespectsMaxSliceLen rejects payloads
+// with an oversized foundation pile inside a snapshot.
+func TestCalculation_SnapshotFoundationRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigPile := make([]map[string]any, calculationMaxSliceLen+1)
+	for i := range bigPile {
+		bigPile[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"fd": []any{bigPile, nil, nil, nil},
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Calculation
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot foundation must be rejected")
+}
+
+// TestCalculation_SnapshotWasteRespectsMaxSliceLen rejects payloads with
+// an oversized waste pile inside a snapshot.
+func TestCalculation_SnapshotWasteRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigPile := make([]map[string]any, calculationMaxSliceLen+1)
+	for i := range bigPile {
+		bigPile[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"wa": []any{bigPile, nil, nil, nil},
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Calculation
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot waste must be rejected")
+}

--- a/internal/domain/Golf.go
+++ b/internal/domain/Golf.go
@@ -439,6 +439,56 @@ type golfJSON struct {
 	MoveCount   int                               `json:"mc"`
 	ActionLog   []*ActionLogEntry                 `json:"al"`
 	IsStalemate bool                              `json:"sm"`
+	History     []*golfSnapshot                   `json:"hi,omitempty"`
+}
+
+// golfSnapshotJSON is the wire format for a single undo snapshot.
+// golfSnapshot uses unexported fields, so we project to/from this
+// shape with explicit Marshal/Unmarshal methods. Field names match
+// golfJSON's short keys to keep the KV payload compact (#1654).
+type golfSnapshotJSON struct {
+	Layout      [GolfColCnt][GolfRowCnt]*GolfCard `json:"ly"`
+	Stock       []*Card                           `json:"st"`
+	Waste       []*Card                           `json:"wa"`
+	Phase       GolfPhase                         `json:"ps"`
+	MoveCount   int                               `json:"mc"`
+	IsStalemate bool                              `json:"sm"`
+}
+
+// MarshalJSON implements json.Marshaler for golfSnapshot.
+func (s *golfSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(golfSnapshotJSON{
+		Layout:      s.layout,
+		Stock:       s.stock,
+		Waste:       s.waste,
+		Phase:       s.phase,
+		MoveCount:   s.moveCount,
+		IsStalemate: s.isStalemate,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for golfSnapshot.
+func (s *golfSnapshot) UnmarshalJSON(data []byte) error {
+	var j golfSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if len(j.Stock) > golfMaxSliceLen || len(j.Waste) > golfMaxSliceLen {
+		return fmt.Errorf("golf: snapshot array exceeds maximum allowed size")
+	}
+	s.layout = j.Layout
+	s.stock = j.Stock
+	if s.stock == nil {
+		s.stock = make([]*Card, 0)
+	}
+	s.waste = j.Waste
+	if s.waste == nil {
+		s.waste = make([]*Card, 0)
+	}
+	s.phase = j.Phase
+	s.moveCount = j.MoveCount
+	s.isStalemate = j.IsStalemate
+	return nil
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -452,6 +502,7 @@ func (g *Golf) MarshalJSON() ([]byte, error) {
 		MoveCount:   g.moveCount,
 		ActionLog:   g.actionLog,
 		IsStalemate: g.isStalemate,
+		History:     g.history,
 	})
 }
 
@@ -465,7 +516,7 @@ func (g *Golf) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if len(j.Stock) > golfMaxSliceLen || len(j.Waste) > golfMaxSliceLen ||
-		len(j.ActionLog) > golfMaxSliceLen {
+		len(j.ActionLog) > golfMaxSliceLen || len(j.History) > golfMaxSliceLen {
 		return fmt.Errorf("golf: input array exceeds maximum allowed size")
 	}
 
@@ -488,8 +539,10 @@ func (g *Golf) UnmarshalJSON(data []byte) error {
 	if g.actionLog == nil {
 		g.actionLog = make([]*ActionLogEntry, 0)
 	}
-	// Undo history is not serialised; set to nil on restore.
-	g.history = nil
+	g.history = j.History
+	if g.history == nil {
+		g.history = make([]*golfSnapshot, 0)
+	}
 	g.isStalemate = j.IsStalemate
 	return nil
 }

--- a/internal/domain/Golf.go
+++ b/internal/domain/Golf.go
@@ -473,8 +473,11 @@ func (s *golfSnapshot) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
 	}
-	if len(j.Stock) > golfMaxSliceLen || len(j.Waste) > golfMaxSliceLen {
-		return fmt.Errorf("golf: snapshot array exceeds maximum allowed size")
+	if len(j.Stock) > golfMaxSliceLen {
+		return fmt.Errorf("golf: snapshot stock exceeds maximum allowed size")
+	}
+	if len(j.Waste) > golfMaxSliceLen {
+		return fmt.Errorf("golf: snapshot waste exceeds maximum allowed size")
 	}
 	s.layout = j.Layout
 	s.stock = j.Stock

--- a/internal/domain/Golf_persistence_test.go
+++ b/internal/domain/Golf_persistence_test.go
@@ -1,0 +1,133 @@
+//go:build test
+
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGolf_PersistsUndoHistory verifies issue #1654.
+func TestGolf_PersistsUndoHistory(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultGolf()
+	original.Reset()
+	require.False(t, original.CanUndo(), "fresh game has no history")
+
+	// Draw is deterministic — after Reset the stock has cards regardless of shuffle.
+	require.NoError(t, original.Draw())
+	require.NoError(t, original.Draw())
+	require.True(t, original.CanUndo(), "two draws should leave undoable history")
+	originalHistoryLen := len(original.history)
+	originalMoveCount := original.GetMoveCount()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored Golf
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	assert.Equal(t, originalMoveCount, restored.GetMoveCount(), "moveCount must round-trip")
+	assert.Equal(t, originalHistoryLen, len(restored.history), "history length must round-trip")
+	assert.True(t, restored.CanUndo(), "restored game must allow Undo")
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, originalMoveCount-1, restored.GetMoveCount(), "Undo should rewind one step")
+}
+
+// TestGolf_PersistsHistoryRestoresExactSnapshot ensures snapshot fields
+// are preserved exactly.
+func TestGolf_PersistsHistoryRestoresExactSnapshot(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultGolf()
+	original.Reset()
+	require.NoError(t, original.Draw())
+
+	preDrawWasteLen := len(original.waste)
+	preDrawStockLen := len(original.stock)
+
+	require.NoError(t, original.Draw())
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored Golf
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, preDrawWasteLen, len(restored.waste), "Undo restores waste length")
+	assert.Equal(t, preDrawStockLen, len(restored.stock), "Undo restores stock length")
+}
+
+// TestGolf_HistoryRespectsMaxSliceLen rejects oversized history.
+func TestGolf_HistoryRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigHistory := make([]map[string]any, golfMaxSliceLen+1)
+	for i := range bigHistory {
+		bigHistory[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": bigHistory,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Golf
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized history must be rejected")
+}
+
+// TestGolf_SnapshotStockRespectsMaxSliceLen rejects payloads with an
+// oversized inner Stock slice inside a snapshot.
+func TestGolf_SnapshotStockRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigStock := make([]map[string]any, golfMaxSliceLen+1)
+	for i := range bigStock {
+		bigStock[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"st": bigStock,
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Golf
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot stock must be rejected")
+}
+
+// TestGolf_SnapshotWasteRespectsMaxSliceLen rejects payloads with an
+// oversized inner Waste slice inside a snapshot.
+func TestGolf_SnapshotWasteRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigWaste := make([]map[string]any, golfMaxSliceLen+1)
+	for i := range bigWaste {
+		bigWaste[i] = map[string]any{}
+	}
+	snapshot := map[string]any{
+		"wa": bigWaste,
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{snapshot},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored Golf
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized snapshot waste must be rejected")
+}


### PR DESCRIPTION
## Summary

Refs #1654 — **final batch** in the rollout. Extends the Klondike pilot pattern (#1722) to BakersDozen, Calculation, and Golf, completing the solitaire family started by #1724 (FreeCell + TriPeaks), #1725 (Spider + Pyramid), #1726 (FortyThieves + Canfield + Yukon), and #1727 (RussianSolitaire + Scorpion + Accordion).

Previously, when a Cloudflare Workers session was restored from KV, all three games' UnmarshalJSON deliberately set `history = nil`, so a player who reloaded a tab mid-game lost the entire undo stack. Now history round-trips through dedicated `*SnapshotJSON` wire types projecting the unexported snapshot fields, gated by per-snapshot maxSliceLen guards mirroring the top-level checks.

After this PR merges and #1727 lands, **issue #1654 can close**.

## Changes

- **BakersDozen**: `History []*bakersDozenSnapshot` on `bakersDozenJSON`; new `bakersDozenSnapshotJSON` + `MarshalJSON`/`UnmarshalJSON`. Adds tableau column + foundation pile guards at the top level (previously absent) and inside each snapshot.
- **Calculation**: `History []*calculationSnapshot` on `calculationJSON`; new `calculationSnapshotJSON` + `MarshalJSON`/`UnmarshalJSON`. Adds foundation/waste/stock guards inside each snapshot mirroring the existing top-level guards.
- **Golf**: `History []*golfSnapshot` on `golfJSON`; new `golfSnapshotJSON` + `MarshalJSON`/`UnmarshalJSON`. Adds stock + waste guards inside each snapshot.

JSON keys mirror the existing short-key convention (`tb`, `fd`, `wa`, `st`, `ly`, `ps`, `mc`, `sl`, `sm`) to keep KV payloads compact.

### Test note

BakersDozen has no deterministic public action (every `Move*` is shape-dependent on the random initial deal), so its persistence test calls the package-private `takeSnapshot()` directly. Calculation uses `PlayStockToWaste(0)` and Golf uses `Draw()` — both deterministic.

## Closes #1654 rollout

| Game | PR |
|------|----|
| Klondike (pilot) | #1722 ✅ merged |
| FreeCell + TriPeaks | #1724 |
| Spider + Pyramid | #1725 |
| FortyThieves + Canfield + Yukon | #1726 ✅ merged |
| RussianSolitaire + Scorpion + Accordion | #1727 |
| **BakersDozen + Calculation + Golf** | **this PR** |

## Test plan

- [x] `go test -tags test ./internal/domain/ -run "TestBakersDozen|TestCalculation|TestGolf"` — all three games' tests pass
- [x] `go test -tags test ./internal/domain/...` — full domain suite green (76.7s)
- [x] `golangci-lint run ./internal/domain/...` — 0 issues
- [x] `goimports -w` on changed files
- [ ] CI: full `go test -tags test ./...`

### New tests (19 total)

- **BakersDozen** (7): `TestBakersDozen_PersistsUndoHistory`, `TestBakersDozen_PersistsHistoryRestoresExactSnapshot`, `TestBakersDozen_HistoryRespectsMaxSliceLen`, `TestBakersDozen_TopLevelTableauColumnRespectsMaxSliceLen`, `TestBakersDozen_TopLevelFoundationPileRespectsMaxSliceLen`, `TestBakersDozen_SnapshotTableauColumnRespectsMaxSliceLen`, `TestBakersDozen_SnapshotFoundationPileRespectsMaxSliceLen`
- **Calculation** (6): `TestCalculation_PersistsUndoHistory`, `TestCalculation_PersistsHistoryRestoresExactSnapshot`, `TestCalculation_HistoryRespectsMaxSliceLen`, `TestCalculation_SnapshotStockRespectsMaxSliceLen`, `TestCalculation_SnapshotFoundationRespectsMaxSliceLen`, `TestCalculation_SnapshotWasteRespectsMaxSliceLen`
- **Golf** (6): `TestGolf_PersistsUndoHistory`, `TestGolf_PersistsHistoryRestoresExactSnapshot`, `TestGolf_HistoryRespectsMaxSliceLen`, `TestGolf_SnapshotStockRespectsMaxSliceLen`, `TestGolf_SnapshotWasteRespectsMaxSliceLen`