### PR TITLE
refactor(pages): migrate TriPeaks/Pyramid/Memory to GamePageShell

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -20,6 +20,7 @@ Every game page (`src/pages/<X>Page.tsx`) follows the same skeleton — copy fro
    - Pass `headerExtra` for any per-page header chips (e.g. `<CliToggle>`, chip / score readouts).
    - Pass `winShow` when the celebration condition is stricter than plain `gameEndFlag` (e.g. `humanWon` for two-player games where only the human's win is celebrated).
    - Pass `onCelebrate` to trigger sound effects or other side effects when the celebration starts.
+   - Omit `isHumanTurn` for single-player solitaire pages with no "your turn / waiting" concept — the shell forwards `undefined` to `PhaseIndicator` and the turn label is hidden.
 
 Shared building blocks:
 

--- a/frontend/src/components/GamePageShell.test.tsx
+++ b/frontend/src/components/GamePageShell.test.tsx
@@ -58,6 +58,18 @@ const baseProps = {
   cancelReset: vi.fn(),
 };
 
+const propsWithoutTurn = {
+  title: 'TriPeaks',
+  gameThemeBg: 'bg-game-bg-blue',
+  phaseName: 'Play Phase',
+  gamePath: '/tripeaks',
+  gameEndFlag: false,
+  loading: false,
+  confirmOpen: false,
+  confirmReset: vi.fn(),
+  cancelReset: vi.fn(),
+};
+
 describe('GamePageShell', () => {
   it('renders children inside the shell', () => {
     render(
@@ -218,5 +230,18 @@ describe('GamePageShell', () => {
     );
     fireEvent.click(screen.getByTestId('win-celebration'));
     expect(onCelebrate).toHaveBeenCalledOnce();
+  });
+
+  it('omits the turn-indicator span when isHumanTurn is not provided', () => {
+    render(
+      <GamePageShell {...propsWithoutTurn}>
+        <div />
+      </GamePageShell>,
+    );
+    // PhaseIndicator should still render the phase name…
+    expect(screen.getByText('Play Phase')).toBeInTheDocument();
+    // …but no "your turn / waiting" label is rendered when the prop is undefined.
+    expect(screen.queryByText('あなたのターン')).not.toBeInTheDocument();
+    expect(screen.queryByText('待機中')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/GamePageShell.tsx
+++ b/frontend/src/components/GamePageShell.tsx
@@ -15,8 +15,12 @@ export interface GamePageShellProps {
   gameThemeBg: string;
   /** Current phase label shown in the PhaseIndicator. */
   phaseName: string;
-  /** Whether it is the human player's turn, controls the turn indicator color. */
-  isHumanTurn: boolean;
+  /**
+   * Whether it is the human player's turn, controls the turn indicator color.
+   * Optional — when omitted, the PhaseIndicator hides the turn indicator entirely
+   * (used by single-player solitaire pages without a "your turn / waiting" concept).
+   */
+  isHumanTurn?: boolean;
   /** Path used by ManualButton to load the game manual (e.g., "/hearts"). */
   gamePath: string;
   /** Whether a game-end condition has been reached, controls WinCelebration default and the round-leave guard. */

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -7,17 +7,12 @@ import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -25,7 +20,6 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { AUTO_NEXT_DELAY_OPTIONS, CPU_DIFFICULTY_OPTIONS, useMemoryGame } from '../hooks/useMemoryGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
@@ -133,8 +127,6 @@ function MemoryPageContent() {
     void exec('reset', undefined, { cpuDifficulty: memoryConfig.cpuDifficulty });
   }, [exec, hideActionLog, memoryConfig.cpuDifficulty]);
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
-
   if (!state)
     return (
       <GameSkeleton
@@ -157,15 +149,21 @@ function MemoryPageContent() {
   const isHumanTurn = (isFlip1 || isFlip2) && state.players[state.currentPlayerIdx]?.isHuman === true;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.memory.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.memory')} />
-      {/* Phase indicator */}
-      <PhaseIndicator phaseName={phaseNames[state.phase]} isHumanTurn={isHumanTurn}>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/memory" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.memory')}
+      gameThemeBg={gameTheme.memory.bg}
+      phaseName={phaseNames[state.phase]}
+      isHumanTurn={isHumanTurn}
+      gamePath="/memory"
+      gameEndFlag={!!isGameEnd}
+      winShow={!!state.gameEndFlag}
+      onCelebrate={() => playSound('winFanfare')}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={<CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />}
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -318,8 +316,6 @@ function MemoryPageContent() {
           </GameFooter>
         </>
       )}
-      <WinCelebration show={!!state?.gameEndFlag} onCelebrate={() => playSound('winFanfare')} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/PyramidPage.tsx
+++ b/frontend/src/pages/PyramidPage.tsx
@@ -7,19 +7,14 @@ import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions, useWindowWidth } from '../hooks/useCardDimensions';
@@ -27,7 +22,6 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePyramidGame } from '../hooks/usePyramidGame';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -140,8 +134,6 @@ function PyramidPageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
-  useGameRoundGuard(isGameRoundActive(state));
-
   if (!state)
     return <GameSkeleton gameKey="pyramid" layout={{ kind: 'tiered-rows', rows: [1, 2, 3, 4], stockWaste: true }} />;
 
@@ -167,20 +159,27 @@ function PyramidPageContent() {
   const pyramidWidth = maxCols * (effectiveCardWidth + cardGap) - cardGap;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.pyramid.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.pyramid')} />
-      {/* Phase indicator */}
-      <PhaseIndicator
-        phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}
-      >
-        <span>
-          {t('moveCount')}: {state.moveCount}
-        </span>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/pyramid" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.pyramid')}
+      gameThemeBg={gameTheme.pyramid.bg}
+      phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}
+      gamePath="/pyramid"
+      gameEndFlag={isEnded}
+      winShow={isGameClear}
+      onCelebrate={() => playSound('winFanfare')}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={
+        <>
+          <span>
+            {t('moveCount')}: {state.moveCount}
+          </span>
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </>
+      }
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -395,8 +394,6 @@ function PyramidPageContent() {
           </GameFooter>
         </>
       )}
-      <WinCelebration show={state.phase === PyramidPhase.GAME_CLEAR} onCelebrate={() => playSound('winFanfare')} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/TriPeaksPage.tsx
+++ b/frontend/src/pages/TriPeaksPage.tsx
@@ -7,19 +7,14 @@ import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions, useWindowWidth } from '../hooks/useCardDimensions';
@@ -27,7 +22,6 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useTriPeaksGame } from '../hooks/useTriPeaksGame';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -147,8 +141,6 @@ function TriPeaksPageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
-  useGameRoundGuard(isGameRoundActive(state));
-
   if (!state)
     return <GameSkeleton gameKey="tripeaks" layout={{ kind: 'tiered-rows', rows: [3, 6, 9, 10], stockWaste: true }} />;
 
@@ -169,19 +161,27 @@ function TriPeaksPageContent() {
     : cardWidth;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.tripeaks.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.tripeaks')} />
-      <PhaseIndicator
-        phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}
-      >
-        <span>
-          {t('moveCount')}: {state.moveCount}
-        </span>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/tripeaks" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.tripeaks')}
+      gameThemeBg={gameTheme.tripeaks.bg}
+      phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}
+      gamePath="/tripeaks"
+      gameEndFlag={isEnded}
+      winShow={isGameClear}
+      onCelebrate={() => playSound('winFanfare')}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={
+        <>
+          <span>
+            {t('moveCount')}: {state.moveCount}
+          </span>
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </>
+      }
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -375,8 +375,6 @@ function TriPeaksPageContent() {
           </GameFooter>
         </>
       )}
-      <WinCelebration show={state.phase === TriPeaksPhase.GAME_CLEAR} onCelebrate={() => playSound('winFanfare')} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }


### PR DESCRIPTION
## Summary
- Migrates `TriPeaksPage`, `PyramidPage`, and `MemoryPage` to the shared `GamePageShell`, dropping duplicated `GamePageHeading` / `PhaseIndicator` / `TutorialButton` / `ManualButton` / `WinCelebration` / `GameResetDialog` / `useGameRoundGuard` wiring on each page.
- Makes `GamePageShell.isHumanTurn` optional so single-player solitaire pages without a "your turn / waiting" concept (TriPeaks, Pyramid) keep their original behaviour. `PhaseIndicator` already supports the optional shape, so this just plumbs it through. WarPage and Memory continue to pass an explicit value.
- Documents the new optional `isHumanTurn` knob in the migration recipe in `frontend/CLAUDE.md`.

Continues the rollout for #1650 (WarPage was the original pilot in #1723). Issue stays open until the remaining ~66 pages are migrated.

## Test plan
- [x] `bun run test -- --run src/components/GamePageShell.test.tsx` — 18/18 pass (added one case covering `isHumanTurn` undefined).
- [x] `bun run test -- --run src/pages/TriPeaksPage.test.tsx` — 22/22 pass.
- [x] `bun run test -- --run src/pages/PyramidPage.test.tsx` — 44/44 pass.
- [x] `bun run test -- --run src/pages/MemoryPage.test.tsx` — 45/45 pass.
- [x] `bun run test -- --run src/pages/WarPage.test.tsx` — 8/8 pass (sanity check after the shell prop change).
- [x] `bun run check` — Biome + design tokens clean.
- [ ] Local `bun run build` skipped (WSL2 OOM); rely on CI.