### PR TITLE
refactor(pages): migrate Accordion/Calculation/Golf to GamePageShell

### DIFF
--- a/frontend/src/pages/AccordionPage.tsx
+++ b/frontend/src/pages/AccordionPage.tsx
@@ -7,18 +7,13 @@ import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -27,7 +22,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useMountReset } from '../hooks/useMountReset';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnOutline, focusRingWhite } from '../styles/buttonStyles';
@@ -256,7 +250,6 @@ function AccordionPageContent() {
     bindings: accordionBindings,
     enabled: state?.phase === AccordionPhase.PLAYING && !loading,
   });
-  useGameRoundGuard(isGameRoundActive(state));
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
   if (!state) return <GameSkeleton gameKey="accordion" layout={{ kind: 'tableau', topRow: 6, tableau: 7 }} />;
@@ -269,20 +262,29 @@ function AccordionPageContent() {
   const phaseName = isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing');
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.accordion.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.accordion')} />
-      <PhaseIndicator phaseName={phaseName}>
-        <span>
-          {t('moveCount')}: {state.moveCount}
-        </span>
-        <span>
-          {t('piles')}: {state.pileCount}
-        </span>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/accordion" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.accordion')}
+      gameThemeBg={gameTheme.accordion.bg}
+      phaseName={phaseName}
+      gamePath="/accordion"
+      gameEndFlag={isEnded}
+      winShow={isGameClear}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={
+        <>
+          <span>
+            {t('moveCount')}: {state.moveCount}
+          </span>
+          <span>
+            {t('piles')}: {state.pileCount}
+          </span>
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </>
+      }
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -415,9 +417,6 @@ function AccordionPageContent() {
           </div>
         </>
       )}
-
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-      {isGameClear && <WinCelebration show={true} />}
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/CalculationPage.tsx
+++ b/frontend/src/pages/CalculationPage.tsx
@@ -7,19 +7,14 @@ import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
@@ -27,7 +22,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useMountReset } from '../hooks/useMountReset';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnOutline, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -267,8 +261,6 @@ function CalculationPageContent() {
     },
     [source],
   );
-  useGameRoundGuard(isGameRoundActive(state));
-
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
 
   if (!state) return <GameSkeleton gameKey="calculation" layout={{ kind: 'tableau', topRow: 6, tableau: 7 }} />;
@@ -289,17 +281,27 @@ function CalculationPageContent() {
   const hintStock = state.hint?.fromZone === 'stock';
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.calculation.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.calculation')} />
-      <PhaseIndicator phaseName={phaseName}>
-        <span>
-          {t('moveCount')}: {state.moveCount}
-        </span>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/calculation" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.calculation')}
+      gameThemeBg={gameTheme.calculation.bg}
+      phaseName={phaseName}
+      gamePath="/calculation"
+      gameEndFlag={isEnded}
+      winShow={isGameClear}
+      onCelebrate={() => playSound('winFanfare')}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={
+        <>
+          <span>
+            {t('moveCount')}: {state.moveCount}
+          </span>
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </>
+      }
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -518,9 +520,6 @@ function CalculationPageContent() {
           </GameFooter>
         </>
       )}
-
-      <WinCelebration show={isGameClear} onCelebrate={() => playSound('winFanfare')} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/GolfPage.tsx
+++ b/frontend/src/pages/GolfPage.tsx
@@ -7,25 +7,19 @@ import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { LandscapeBanner } from '../components/LandscapeBanner';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions, useWindowWidth } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useGolfGame } from '../hooks/useGolfGame';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -132,8 +126,6 @@ function GolfPageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
-  useGameRoundGuard(isGameRoundActive(state));
-
   if (!state)
     return (
       <GameSkeleton
@@ -159,19 +151,27 @@ function GolfPageContent() {
     : cardWidth;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.golf.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.golf')} />
-      <PhaseIndicator
-        phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}
-      >
-        <span>
-          {t('moveCount')}: {state.moveCount}
-        </span>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/golf" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.golf')}
+      gameThemeBg={gameTheme.golf.bg}
+      phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}
+      gamePath="/golf"
+      gameEndFlag={isEnded}
+      winShow={isGameClear}
+      onCelebrate={() => playSound('winFanfare')}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={
+        <>
+          <span>
+            {t('moveCount')}: {state.moveCount}
+          </span>
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </>
+      }
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -339,8 +339,6 @@ function GolfPageContent() {
           </GameFooter>
         </>
       )}
-      <WinCelebration show={state.phase === GolfPhase.GAME_CLEAR} onCelebrate={() => playSound('winFanfare')} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }


### PR DESCRIPTION
## Summary
- Migrates `AccordionPage`, `CalculationPage`, and `GolfPage` to the shared `GamePageShell`, dropping duplicated `GamePageHeading` / `PhaseIndicator` / `TutorialButton` / `ManualButton` / `WinCelebration` / `GameResetDialog` / `useGameRoundGuard` wiring on each page.
- All three are single-player solitaire variants without a "your turn / waiting" indicator, so they omit `isHumanTurn` (uses the optional shape introduced in #1729).
- AccordionPage previously called `<WinCelebration show={true} />` without an `onCelebrate` callback; the migrated version intentionally leaves `onCelebrate` undefined to keep that silent celebration.

Continues the rollout for #1650 (3 pages per PR cadence). Stacked on top of #1729 — please merge #1729 first; this branch will rebase onto develop afterwards.

## Test plan
- [x] `bun run test -- --run src/pages/AccordionPage.test.tsx` — 29/29 pass.
- [x] `bun run test -- --run src/pages/CalculationPage.test.tsx` — 24/24 pass.
- [x] `bun run test -- --run src/pages/GolfPage.test.tsx` — 20/20 pass.
- [x] `bun run check` — Biome + design tokens clean.
- [ ] Local `bun run build` skipped (WSL2 OOM); rely on CI.