### PR TITLE
refactor(pages): migrate BakersDozen/Canfield/ClockSolitaire to GamePageShell

### DIFF
--- a/frontend/src/pages/BakersDozenPage.tsx
+++ b/frontend/src/pages/BakersDozenPage.tsx
@@ -197,7 +197,7 @@ function BakersDozenPageContent() {
       cancelReset={cancelReset}
       headerExtra={
         <>
-          <span>
+          <span className="text-sm text-ds-text-muted">
             {t('moveCount')}: {state.moveCount}
           </span>
           <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />

--- a/frontend/src/pages/BakersDozenPage.tsx
+++ b/frontend/src/pages/BakersDozenPage.tsx
@@ -8,18 +8,13 @@ import { DropZone } from '../components/DropZone';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useBakersDozenGame } from '../hooks/useBakersDozenGame';
@@ -28,7 +23,6 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -175,8 +169,6 @@ function BakersDozenPageContent() {
     enabled: !!isPlayingForKbd && !loading,
   });
 
-  useGameRoundGuard(isGameRoundActive(state));
-
   if (!state) return <GameSkeleton gameKey="bakersdozen" layout={{ kind: 'tableau', topRow: 4, tableau: 13 }} />;
 
   const isPlaying = state.phase === BakersDozenPhase.PLAYING;
@@ -191,19 +183,27 @@ function BakersDozenPageContent() {
     selectedSource.cardIndex === cardIndex;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.bakersdozen.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.bakersdozen')} />
-      {/* Phase indicator */}
-      <PhaseIndicator
-        phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}
-      >
-        <span>
-          {t('moveCount')}: {state.moveCount}
-        </span>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/bakersdozen" />
-      </PhaseIndicator>
+    <GamePageShell
+      title={tc('nav.bakersdozen')}
+      gameThemeBg={gameTheme.bakersdozen.bg}
+      phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}
+      gamePath="/bakersdozen"
+      gameEndFlag={isEnded}
+      winShow={isGameClear}
+      onCelebrate={() => playSound('winFanfare')}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={
+        <>
+          <span>
+            {t('moveCount')}: {state.moveCount}
+          </span>
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </>
+      }
+    >
       <LandscapeBanner message={t('landscapeBanner')} />
 
       {cliEnabled ? (
@@ -445,8 +445,6 @@ function BakersDozenPageContent() {
           </GameFooter>
         </>
       )}
-      <WinCelebration show={state.phase === BakersDozenPhase.GAME_CLEAR} onCelebrate={() => playSound('winFanfare')} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/CanfieldPage.tsx
+++ b/frontend/src/pages/CanfieldPage.tsx
@@ -8,17 +8,12 @@ import { DropZone } from '../components/DropZone';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
@@ -26,7 +21,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useMountReset } from '../hooks/useMountReset';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { btnDanger, btnOutline, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -75,7 +69,6 @@ function CanfieldPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('canfield');
   const { state, loading, error, exec: execApi, retry } = useGameApi(canfieldApi.exec);
-  useGameRoundGuard(isGameRoundActive(state));
   const { cardWidth, cardHeight } = useCardDimensions();
   const {
     hint: frontendHint,
@@ -167,20 +160,29 @@ function CanfieldPageContent() {
   const topReserve = state.reserve.length > 0 ? state.reserve[state.reserve.length - 1] : null;
 
   return (
-    <div className={`flex min-h-screen flex-1 flex-col ${theme.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.canfield')} />
-      <PhaseIndicator phaseName={phaseName}>
-        <span className="text-sm text-ds-text-muted">
-          {t('baseRank')}: {state.baseRank || '?'}
-        </span>
-        <span className="text-sm text-ds-text-muted">
-          {t('moveCount')}: {state.moveCount}
-        </span>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/canfield" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.canfield')}
+      gameThemeBg={theme.bg}
+      phaseName={phaseName}
+      gamePath="/canfield"
+      gameEndFlag={isEnded}
+      winShow={isGameClear}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={
+        <>
+          <span className="text-sm text-ds-text-muted">
+            {t('baseRank')}: {state.baseRank || '?'}
+          </span>
+          <span className="text-sm text-ds-text-muted">
+            {t('moveCount')}: {state.moveCount}
+          </span>
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </>
+      }
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -471,9 +473,6 @@ function CanfieldPageContent() {
           </GameFooter>
         </>
       )}
-
-      <WinCelebration show={isGameClear} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/ClockSolitairePage.tsx
+++ b/frontend/src/pages/ClockSolitairePage.tsx
@@ -6,17 +6,12 @@ import { CliToggle } from '../components/cli/CliToggle';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
@@ -24,7 +19,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useMountReset } from '../hooks/useMountReset';
 import { btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -75,7 +69,6 @@ function ClockSolitairePageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('clocksolitaire');
   const { state, loading, error, exec: execApi, retry } = useGameApi(clocksolitaireApi.exec);
-  useGameRoundGuard(isGameRoundActive(state));
   const handleReset = useCallback(() => execApi('reset'), [execApi]);
   const handleStep = useCallback(() => execApi('step'), [execApi]);
   const handleAutoPlay = useCallback(() => execApi('autoplay'), [execApi]);
@@ -148,17 +141,26 @@ function ClockSolitairePageContent() {
   const radius = Math.min(cardWidth * 5, 180);
 
   return (
-    <div className={`flex min-h-screen flex-1 flex-col ${theme.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.clocksolitaire')} />
-      <PhaseIndicator phaseName={phaseName}>
-        <span className="text-sm text-ds-text-muted">
-          {t('stepCount')}: {state.stepCount}
-        </span>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/clocksolitaire" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.clocksolitaire')}
+      gameThemeBg={theme.bg}
+      phaseName={phaseName}
+      gamePath="/clocksolitaire"
+      gameEndFlag={isEnded}
+      winShow={isGameClear}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={
+        <>
+          <span className="text-sm text-ds-text-muted">
+            {t('stepCount')}: {state.stepCount}
+          </span>
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </>
+      }
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -323,10 +325,7 @@ function ClockSolitairePageContent() {
           </GameFooter>
         </>
       )}
-
-      <WinCelebration show={state.phase === ClockSolitairePhase.GAME_CLEAR} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }
 


### PR DESCRIPTION
## Summary
- Migrates `BakersDozenPage`, `CanfieldPage`, and `ClockSolitairePage` to the shared `GamePageShell`, dropping duplicated `GamePageHeading` / `PhaseIndicator` / `TutorialButton` / `ManualButton` / `WinCelebration` / `GameResetDialog` / `useGameRoundGuard` wiring on each page.
- All three are single-player solitaire variants with no "your turn / waiting" indicator, so they omit `isHumanTurn` (relying on the optional shape introduced in #1729).
- BakersDozen keeps `onCelebrate=playSound('winFanfare')`. Canfield and ClockSolitaire never wired up a celebration callback, so the migrated versions intentionally remain silent.
- Canfield and ClockSolitaire previously used a non-standard `flex min-h-screen flex-1 flex-col` outer container (vs. every other page's `flex-1 flex flex-col min-h-0`); the migration unifies them on the standard layout used by `GamePageShell`.

Continues the rollout for #1650 (3 pages per PR cadence). Builds on the merged #1729 and #1730 (no longer stacked — both have already landed on develop).

## Test plan
- [x] `bun run test -- --run src/pages/BakersDozenPage.test.tsx` — 12/12 pass.
- [x] `bun run test -- --run src/pages/CanfieldPage.test.tsx` — 22/22 pass.
- [x] `bun run test -- --run src/pages/ClockSolitairePage.test.tsx` — 12/12 pass.
- [x] `bun run check` — Biome + design tokens clean.
- [ ] Local `bun run build` skipped (WSL2 OOM); rely on CI.