### PR TITLE
refactor(pages): migrate Russian/Scorpion/Spider to GamePageShell

### DIFF
--- a/frontend/src/components/GamePageShell.test.tsx
+++ b/frontend/src/components/GamePageShell.test.tsx
@@ -232,6 +232,24 @@ describe('GamePageShell', () => {
     expect(onCelebrate).toHaveBeenCalledOnce();
   });
 
+  it('renders headerEnd after ManualButton (right of buttons)', () => {
+    render(
+      <GamePageShell
+        {...baseProps}
+        headerExtra={<span data-testid="header-extra">extra</span>}
+        headerEnd={<span data-testid="header-end">end</span>}
+      >
+        <div />
+      </GamePageShell>,
+    );
+    const extra = screen.getByTestId('header-extra');
+    const manual = screen.getByRole('button', { name: 'manual-/hearts' });
+    const end = screen.getByTestId('header-end');
+    // headerExtra → TutorialButton → ManualButton → headerEnd, in DOM order.
+    expect(extra.compareDocumentPosition(manual) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(manual.compareDocumentPosition(end) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it('omits the turn-indicator span when isHumanTurn is not provided', () => {
     render(
       <GamePageShell {...propsWithoutTurn}>

--- a/frontend/src/components/GamePageShell.tsx
+++ b/frontend/src/components/GamePageShell.tsx
@@ -41,8 +41,14 @@ export interface GamePageShellProps {
   confirmReset: () => void;
   /** Callback to cancel the reset action. */
   cancelReset: () => void;
-  /** Extra elements rendered inside the PhaseIndicator alongside TutorialButton/ManualButton. */
+  /** Extra elements rendered inside the PhaseIndicator before TutorialButton/ManualButton. */
   headerExtra?: ReactNode;
+  /**
+   * Extra elements rendered inside the PhaseIndicator after ManualButton.
+   * Use this when a stat or chip needs to appear at the right edge of the header
+   * (e.g. Spider's `completed: N/8`). Most pages will only need `headerExtra`.
+   */
+  headerEnd?: ReactNode;
   /**
    * Game-specific content placed between the PhaseIndicator and the win/reset overlays.
    * Typically includes: settings panel, scrollable game area, and GameFooter.
@@ -70,6 +76,7 @@ export function GamePageShell({
   confirmReset,
   cancelReset,
   headerExtra,
+  headerEnd,
   children,
 }: GamePageShellProps) {
   // long-form games (Hearts, Spades, Skat, …) don't silently lose state.
@@ -81,6 +88,7 @@ export function GamePageShell({
         {headerExtra}
         <TutorialButton />
         <ManualButton gamePath={gamePath} />
+        {headerEnd}
       </PhaseIndicator>
       {children}
       <WinCelebration show={winShow ?? gameEndFlag} onCelebrate={onCelebrate} />

--- a/frontend/src/pages/RussianSolitairePage.tsx
+++ b/frontend/src/pages/RussianSolitairePage.tsx
@@ -8,19 +8,14 @@ import { DropZone } from '../components/DropZone';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions, useWindowWidth } from '../hooks/useCardDimensions';
@@ -29,7 +24,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useMountReset } from '../hooks/useMountReset';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
@@ -295,7 +289,6 @@ function RussianSolitairePageContent() {
     bindings: actionBindings,
     enabled: !!isPlayingForKbd && !loading,
   });
-  useGameRoundGuard(isGameRoundActive(state));
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
 
@@ -314,19 +307,26 @@ function RussianSolitairePageContent() {
     selectedSource.cardIndex === cardIndex;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.russiansolitaire.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.russiansolitaire')} />
-      <PhaseIndicator
-        phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}
-      >
-        <span>
-          {t('moveCount')}: {state.moveCount}
-        </span>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/russiansolitaire" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.russiansolitaire')}
+      gameThemeBg={gameTheme.russiansolitaire.bg}
+      phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}
+      gamePath="/russiansolitaire"
+      gameEndFlag={isEnded}
+      winShow={isGameClear}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={
+        <>
+          <span>
+            {t('moveCount')}: {state.moveCount}
+          </span>
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </>
+      }
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -570,9 +570,6 @@ function RussianSolitairePageContent() {
           </div>
         </>
       )}
-
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-      {isGameClear && <WinCelebration show={true} />}
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/ScorpionPage.tsx
+++ b/frontend/src/pages/ScorpionPage.tsx
@@ -8,19 +8,14 @@ import { DropZone } from '../components/DropZone';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions, useWindowWidth } from '../hooks/useCardDimensions';
@@ -29,7 +24,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useMountReset } from '../hooks/useMountReset';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
@@ -304,7 +298,6 @@ function ScorpionPageContent() {
     bindings: actionBindings,
     enabled: !!isPlayingForKbd && !loading,
   });
-  useGameRoundGuard(isGameRoundActive(state));
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
 
@@ -322,22 +315,29 @@ function ScorpionPageContent() {
     selectedSource.cardIndex === cardIndex;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.scorpion.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.scorpion')} />
-      <PhaseIndicator
-        phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}
-      >
-        <span>
-          {t('moveCount')}: {state.moveCount}
-        </span>
-        <span data-tutorial="sc-stock">
-          {t('stock')}: {state.stockCount} / {t('completed')}: {state.completedSuits}/4
-        </span>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/scorpion" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.scorpion')}
+      gameThemeBg={gameTheme.scorpion.bg}
+      phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}
+      gamePath="/scorpion"
+      gameEndFlag={isEnded}
+      winShow={isGameClear}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={
+        <>
+          <span>
+            {t('moveCount')}: {state.moveCount}
+          </span>
+          <span data-tutorial="sc-stock">
+            {t('stock')}: {state.stockCount} / {t('completed')}: {state.completedSuits}/4
+          </span>
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </>
+      }
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -533,9 +533,6 @@ function ScorpionPageContent() {
           </div>
         </>
       )}
-
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-      {isGameClear && <WinCelebration show={true} />}
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/SpiderPage.test.tsx
+++ b/frontend/src/pages/SpiderPage.test.tsx
@@ -15,6 +15,15 @@ vi.mock('../hooks/useGameHint', () => ({
   useGameHint: vi.fn(() => ({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() })),
 }));
 
+const playSoundMock = vi.fn();
+vi.mock('../providers/SoundProvider', async () => {
+  const actual = await vi.importActual<typeof import('../providers/SoundProvider')>('../providers/SoundProvider');
+  return {
+    ...actual,
+    useSound: () => ({ playSound: playSoundMock, muted: false, toggleMute: vi.fn() }),
+  };
+});
+
 const mockExec = vi.mocked(spiderApi.exec);
 
 function makeTableau(cols: SpiderTableauCard[][]): SpiderTableauCard[][] {
@@ -72,6 +81,7 @@ const gameOverState: SpiderResponse = {
 beforeEach(() => {
   mockExec.mockResolvedValue(playingState);
   vi.mocked(useGameHint).mockReturnValue({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() });
+  playSoundMock.mockClear();
 });
 
 describe('SpiderPage', () => {
@@ -223,6 +233,12 @@ describe('SpiderPage', () => {
     mockExec.mockResolvedValue(gameClearState);
     renderWithProviders(<SpiderPage />);
     await waitFor(() => expect(screen.getByTestId('phase-indicator')).toHaveTextContent('ゲームクリア'));
+  });
+
+  it('game clear plays winFanfare sound via onCelebrate', async () => {
+    mockExec.mockResolvedValue(gameClearState);
+    renderWithProviders(<SpiderPage />);
+    await waitFor(() => expect(playSoundMock).toHaveBeenCalledWith('winFanfare'));
   });
 
   it('game over shows phase text', async () => {

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -8,26 +8,20 @@ import { DropZone } from '../components/DropZone';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useResponsiveTableau } from '../hooks/useResponsiveTableau';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSpiderGame } from '../hooks/useSpiderGame';
@@ -184,8 +178,6 @@ function SpiderPageContent() {
     enabled: !!isPlayingForKbd && !loading,
   });
 
-  useGameRoundGuard(isGameRoundActive(state));
-
   if (!state) return <GameSkeleton gameKey="spider" layout={{ kind: 'tableau', topRow: 3, tableau: 10 }} />;
 
   const isPlaying = state.phase === SpiderPhase.PLAYING;
@@ -203,26 +195,33 @@ function SpiderPageContent() {
   const autoCompleteReady = state.stockCount === 0 && isTableauAllFaceUp(state.tableau);
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.spider.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.spider')} />
-      {/* Phase indicator */}
-      <PhaseIndicator
-        phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}
-      >
-        <span>
-          {t('moveCount')}: {state.moveCount}
-        </span>
-        <span className="ml-3">
-          {t('score')}: {state.score}
-        </span>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/spider" />
-        <span className="ml-3" data-tutorial="spd-completed-suits">
-          {t('completed')}: {state.completedSuits}/8
-        </span>
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.spider')}
+      gameThemeBg={gameTheme.spider.bg}
+      phaseName={isGameClear ? t('phase.gameClear') : isGameOver ? t('phase.gameOver') : t('phase.playing')}
+      gamePath="/spider"
+      gameEndFlag={isEnded}
+      winShow={isGameClear}
+      onCelebrate={() => playSound('winFanfare')}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={
+        <>
+          <span>
+            {t('moveCount')}: {state.moveCount}
+          </span>
+          <span className="ml-3">
+            {t('score')}: {state.score}
+          </span>
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+          <span className="ml-3" data-tutorial="spd-completed-suits">
+            {t('completed')}: {state.completedSuits}/8
+          </span>
+        </>
+      }
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -483,8 +482,6 @@ function SpiderPageContent() {
           </GameFooter>
         </>
       )}
-      <WinCelebration show={state.phase === SpiderPhase.GAME_CLEAR} onCelebrate={() => playSound('winFanfare')} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -216,10 +216,12 @@ function SpiderPageContent() {
             {t('score')}: {state.score}
           </span>
           <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-          <span className="ml-3" data-tutorial="spd-completed-suits">
-            {t('completed')}: {state.completedSuits}/8
-          </span>
         </>
+      }
+      headerEnd={
+        <span className="ml-3" data-tutorial="spd-completed-suits">
+          {t('completed')}: {state.completedSuits}/8
+        </span>
       }
     >
       {cliEnabled ? (


### PR DESCRIPTION
## Summary
- Migrates `RussianSolitairePage`, `ScorpionPage`, and `SpiderPage` to the shared `GamePageShell`, dropping duplicated `GamePageHeading` / `PhaseIndicator` / `TutorialButton` / `ManualButton` / `WinCelebration` / `GameResetDialog` / `useGameRoundGuard` wiring on each page.
- All three are single-player solitaire variants with no "your turn / waiting" indicator, so they omit `isHumanTurn` (relying on the optional shape introduced in #1729).
- Spider keeps `onCelebrate=playSound('winFanfare')`. Russian and Scorpion previously rendered `<WinCelebration show={true} />` without an `onCelebrate` callback, so the migrated versions intentionally remain silent.

Continues the rollout for #1650 (3 pages per PR cadence).

## Test plan
- [x] `bun run test -- --run src/pages/RussianSolitairePage.test.tsx` — 15/15 pass.
- [x] `bun run test -- --run src/pages/ScorpionPage.test.tsx` — 38/38 pass.
- [x] `bun run test -- --run src/pages/SpiderPage.test.tsx` — 54/54 pass.
- [x] `bun run check` — Biome + design tokens clean.
- [ ] Local `bun run build` skipped (WSL2 OOM); rely on CI.