### PR TITLE
refactor(pages): migrate Durak/Euchre/FiftyOne to GamePageShell

### DIFF
--- a/frontend/src/pages/DurakPage.tsx
+++ b/frontend/src/pages/DurakPage.tsx
@@ -178,7 +178,7 @@ function DurakPageContent() {
       phaseName={phaseName}
       isHumanTurn={isHumanTurn}
       gamePath="/durak"
-      gameEndFlag={!!state.gameEndFlag}
+      gameEndFlag={isGameEnd}
       winShow={humanWon}
       onCelebrate={() => playSound('winFanfare')}
       loading={loading}

--- a/frontend/src/pages/DurakPage.tsx
+++ b/frontend/src/pages/DurakPage.tsx
@@ -6,16 +6,11 @@ import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
@@ -23,7 +18,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { CPU_DIFFICULTY_OPTIONS, useDurakGame } from '../hooks/useDurakGame';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnOutline, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
@@ -121,8 +115,6 @@ function DurakPageContent() {
     void gameExec('reset', undefined, undefined, durakConfig);
   }, [gameExec, hideActionLog, durakConfig]);
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
-
   if (!state)
     return (
       <GameSkeleton
@@ -177,15 +169,24 @@ function DurakPageContent() {
     }
   };
 
-  return (
-    <div className={`flex-1 flex flex-col min-h-0 ${theme.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.durak')} />
-      <PhaseIndicator phaseName={phaseName} isHumanTurn={isHumanTurn}>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/durak" />
-      </PhaseIndicator>
+  const humanWon = isGameEnd && humanPlayer !== undefined && state.loserIdx >= 0 && state.loserIdx !== humanPlayer.id;
 
+  return (
+    <GamePageShell
+      title={tc('nav.durak')}
+      gameThemeBg={theme.bg}
+      phaseName={phaseName}
+      isHumanTurn={isHumanTurn}
+      gamePath="/durak"
+      gameEndFlag={!!state.gameEndFlag}
+      winShow={humanWon}
+      onCelebrate={() => playSound('winFanfare')}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={<CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />}
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -442,11 +443,6 @@ function DurakPageContent() {
           </GameFooter>
         </>
       )}
-      <WinCelebration
-        show={isGameEnd && humanPlayer !== undefined && state.loserIdx >= 0 && state.loserIdx !== humanPlayer.id}
-        onCelebrate={() => playSound('winFanfare')}
-      />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/EuchrePage.tsx
+++ b/frontend/src/pages/EuchrePage.tsx
@@ -207,7 +207,7 @@ function EuchrePageContent() {
       phaseName={phaseNames[state.phase]}
       isHumanTurn={isHumanBidTurn || isHumanTurn || isHumanDiscard}
       gamePath="/euchre"
-      gameEndFlag={!!state.gameEndFlag}
+      gameEndFlag={isGameEnd}
       onCelebrate={() => playSound('winFanfare')}
       loading={loading}
       confirmOpen={confirmOpen}

--- a/frontend/src/pages/EuchrePage.tsx
+++ b/frontend/src/pages/EuchrePage.tsx
@@ -7,17 +7,12 @@ import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { TrickDisplay } from '../components/TrickDisplay';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
@@ -26,7 +21,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useEuchreGame } from '../hooks/useEuchreGame';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
@@ -188,8 +182,6 @@ function EuchrePageContent() {
     });
   }, [apiExec, hideActionLog, euchreConfig.cpuDifficulty, euchreConfig.pointLimit]);
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
-
   if (!state)
     return <GameSkeleton gameKey="euchre" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 5 }} />;
 
@@ -209,15 +201,20 @@ function EuchrePageContent() {
   const suitName = (suit: number) => (SUIT_NAMES[suit] ? t(SUIT_NAMES[suit]) : '');
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.euchre.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.euchre')} />
-      {/* Phase indicator */}
-      <PhaseIndicator phaseName={phaseNames[state.phase]} isHumanTurn={isHumanBidTurn || isHumanTurn || isHumanDiscard}>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/euchre" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.euchre')}
+      gameThemeBg={gameTheme.euchre.bg}
+      phaseName={phaseNames[state.phase]}
+      isHumanTurn={isHumanBidTurn || isHumanTurn || isHumanDiscard}
+      gamePath="/euchre"
+      gameEndFlag={!!state.gameEndFlag}
+      onCelebrate={() => playSound('winFanfare')}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={<CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />}
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -591,8 +588,6 @@ function EuchrePageContent() {
           </GameFooter>
         </>
       )}
-      <WinCelebration show={!!state?.gameEndFlag} onCelebrate={() => playSound('winFanfare')} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/FiftyOnePage.tsx
+++ b/frontend/src/pages/FiftyOnePage.tsx
@@ -160,8 +160,8 @@ function FiftyOnePageContent() {
       phaseName={phaseName}
       isHumanTurn={isHumanTurn}
       gamePath="/fiftyone"
-      gameEndFlag={!!isGameEnd}
-      winShow={isGameEnd && humanWon}
+      gameEndFlag={isGameEnd}
+      winShow={humanWon}
       loading={loading}
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}

--- a/frontend/src/pages/FiftyOnePage.tsx
+++ b/frontend/src/pages/FiftyOnePage.tsx
@@ -6,17 +6,12 @@ import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
@@ -24,7 +19,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useMountReset } from '../hooks/useMountReset';
 import { gameTheme } from '../styles/gameTheme';
 import type { FiftyOneResponse } from '../types/card';
@@ -76,7 +70,6 @@ function FiftyOnePageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('fiftyone');
   const { state, loading, error, exec: execApi, retry } = useGameApi(fiftyoneApi.exec);
-  useGameRoundGuard(!!state && !state.gameEndFlag);
   const { cardWidth } = useCardDimensions();
   const [cpuDifficulty, setCpuDifficulty] = useState(1);
   const [selectedHandIdx, setSelectedHandIdx] = useState<number | null>(null);
@@ -161,14 +154,20 @@ function FiftyOnePageContent() {
   const canExchange = isHumanTurn && selectedHandIdx !== null && selectedTableIdx !== null;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.fiftyone.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.fiftyone')} />
-      <PhaseIndicator phaseName={phaseName} isHumanTurn={isHumanTurn}>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/fiftyone" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.fiftyone')}
+      gameThemeBg={gameTheme.fiftyone.bg}
+      phaseName={phaseName}
+      isHumanTurn={isHumanTurn}
+      gamePath="/fiftyone"
+      gameEndFlag={!!isGameEnd}
+      winShow={isGameEnd && humanWon}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={<CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />}
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -326,11 +325,8 @@ function FiftyOnePageContent() {
               />
             </div>
           </GameFooter>
-
-          <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-          <WinCelebration show={isGameEnd && humanWon} />
         </>
       )}
-    </div>
+    </GamePageShell>
   );
 }


### PR DESCRIPTION
## Summary
- Migrates `DurakPage`, `EuchrePage`, and `FiftyOnePage` to the shared `GamePageShell`, dropping duplicated `GamePageHeading` / `PhaseIndicator` / `TutorialButton` / `ManualButton` / `WinCelebration` / `GameResetDialog` / `useGameRoundGuard` wiring on each page.
- Durak passes `winShow={humanWon}` via override (only celebrates when the human is not the loser); `onCelebrate=playSound('winFanfare')` retained.
- Euchre uses `isHumanTurn = isHumanBidTurn || isHumanTurn || isHumanDiscard` so the pulse fires across all three human-active phases.
- FiftyOne passes `winShow={isGameEnd && humanWon}`; the original page suppressed `onCelebrate` (silent on CPU wins), and the migrated version stays silent.

Continues the rollout for #1650 (3 pages per PR cadence).

## Test plan
- [x] `bun run test -- --run src/pages/DurakPage.test.tsx` — 21/21 pass.
- [x] `bun run test -- --run src/pages/EuchrePage.test.tsx` — 63/63 pass.
- [x] `bun run test -- --run src/pages/FiftyOnePage.test.tsx` — 6/6 pass.
- [x] `bun run check` — Biome + design tokens clean.
- [ ] Local `bun run build` skipped (WSL2 OOM); rely on CI.