### PR TITLE
refactor(pages): migrate PigsTail/Trash/Tonk to GamePageShell

### DIFF
--- a/frontend/src/pages/PigsTailPage.tsx
+++ b/frontend/src/pages/PigsTailPage.tsx
@@ -5,22 +5,16 @@ import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { ManualButton } from '../components/ManualButton';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { gameTheme } from '../styles/gameTheme';
@@ -77,7 +71,6 @@ function PigsTailPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('pigtail');
   const { state, loading, exec: execApi } = useGameApi(pigtailApi.exec);
-  useGameRoundGuard(!!state && !state.gameEndFlag);
   const handleDraw = useCallback(() => execApi('draw'), [execApi]);
   const handleReset = useCallback(() => execApi('reset'), [execApi]);
   const { hint, hintEnabled, setHintEnabled } = useGameHint('pigtail', state);
@@ -128,14 +121,19 @@ function PigsTailPageContent() {
   const loserIsHuman = isGameEnd && state.loserIdx >= 0 && state.players[state.loserIdx]?.isHuman === true;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.pigtail.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.pigtail')} />
-      <PhaseIndicator phaseName={currentPhaseName ?? ''}>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/pigtail" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.pigtail')}
+      gameThemeBg={gameTheme.pigtail.bg}
+      phaseName={currentPhaseName ?? ''}
+      gamePath="/pigtail"
+      gameEndFlag={!!isGameEnd}
+      winShow={isGameEnd && !loserIsHuman}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={<CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />}
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -255,16 +253,14 @@ function PigsTailPageContent() {
             </div>
           </GameFooter>
 
-          <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
           <ActionLogSection
             isEndPhase={isGameEnd}
             actionLog={actionLog}
             showActionLog={showActionLog}
             hideActionLog={hideActionLog}
           />
-          <WinCelebration show={isGameEnd && !loserIsHuman} />
         </>
       )}
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/TonkPage.tsx
+++ b/frontend/src/pages/TonkPage.tsx
@@ -7,17 +7,12 @@ import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { TonkOnDealCelebration } from '../components/TonkOnDealCelebration';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
@@ -25,7 +20,6 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useTonkGame } from '../hooks/useTonkGame';
 import { useSound } from '../providers/SoundProvider';
@@ -154,8 +148,6 @@ function TonkPageContent() {
     });
   }, [gameExec, hideActionLog, tonkConfig.cpuDifficulty, tonkConfig.pointLimit]);
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
-
   if (!state)
     return (
       <GameSkeleton
@@ -172,14 +164,20 @@ function TonkPageContent() {
   const isHumanTurn = (isDrawPhase || isDiscardPhase) && state.players[state.currentPlayerIdx]?.isHuman === true;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.tonk.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.tonk')} />
-      <PhaseIndicator phaseName={phaseNames[state.phase]} isHumanTurn={isHumanTurn}>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/tonk" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.tonk')}
+      gameThemeBg={gameTheme.tonk.bg}
+      phaseName={phaseNames[state.phase]}
+      isHumanTurn={isHumanTurn}
+      gamePath="/tonk"
+      gameEndFlag={!!state.gameEndFlag}
+      onCelebrate={() => playSound('winFanfare')}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={<CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />}
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -414,7 +412,6 @@ function TonkPageContent() {
           </GameFooter>
         </>
       )}
-      <WinCelebration show={!!state?.gameEndFlag} onCelebrate={() => playSound('winFanfare')} />
       {(() => {
         // Tonk-on-deal sets winnerIdx >= 0; guard defensively so we never index
         // players[-1] (which would surface as "CPU 0 wins" via playerName).
@@ -430,7 +427,6 @@ function TonkPageContent() {
           />
         );
       })()}
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/TonkPage.tsx
+++ b/frontend/src/pages/TonkPage.tsx
@@ -167,10 +167,10 @@ function TonkPageContent() {
     <GamePageShell
       title={tc('nav.tonk')}
       gameThemeBg={gameTheme.tonk.bg}
-      phaseName={phaseNames[state.phase]}
+      phaseName={phaseNames[state.phase] ?? ''}
       isHumanTurn={isHumanTurn}
       gamePath="/tonk"
-      gameEndFlag={!!state.gameEndFlag}
+      gameEndFlag={isGameEnd}
       onCelebrate={() => playSound('winFanfare')}
       loading={loading}
       confirmOpen={confirmOpen}

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -6,17 +6,12 @@ import { CliToggle } from '../components/cli/CliToggle';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
@@ -24,7 +19,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useMountReset } from '../hooks/useMountReset';
 import { useSound } from '../providers/SoundProvider';
 import { btnOutline, focusRingWhite } from '../styles/buttonStyles';
@@ -179,7 +173,6 @@ function TrashPageContent() {
     },
     [apiCall, state, playSound],
   );
-  useGameRoundGuard(isGameRoundActive(state));
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
 
@@ -198,17 +191,26 @@ function TrashPageContent() {
         : t('phase.playerTurn');
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.trash.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.trash')} />
-      <PhaseIndicator phaseName={phaseName}>
-        <span>
-          {tc('moveCount', { defaultValue: 'Moves' })}: {state.moveCount}
-        </span>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/trash" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.trash')}
+      gameThemeBg={gameTheme.trash.bg}
+      phaseName={phaseName}
+      gamePath="/trash"
+      gameEndFlag={isGameOver}
+      winShow={isGameOver && state.winner === 0}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={
+        <>
+          <span>
+            {tc('moveCount', { defaultValue: 'Moves' })}: {state.moveCount}
+          </span>
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </>
+      }
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -298,10 +300,7 @@ function TrashPageContent() {
           </div>
         </>
       )}
-
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-      {isGameOver && state.winner === 0 && <WinCelebration show={true} />}
-    </div>
+    </GamePageShell>
   );
 }
 


### PR DESCRIPTION
## Summary
- Migrates `PigsTailPage`, `TrashPage`, and `TonkPage` to the shared `GamePageShell`, dropping duplicated `GamePageHeading` / `PhaseIndicator` / `TutorialButton` / `ManualButton` / `WinCelebration` / `GameResetDialog` / `useGameRoundGuard` wiring on each page.
- PigsTail and Trash both omit `isHumanTurn` (their original `PhaseIndicator` had no turn label). Both pass `winShow` overrides to gate the celebration on a human-side condition (`!loserIsHuman` for PigsTail, `state.winner === 0` for Trash) and the original WinCelebration callbacks were absent, so `onCelebrate` stays unset.
- Trash also passes a `moveCount` span alongside the `CliToggle` via `headerExtra`, matching the pre-migration header layout.
- Tonk passes a plain `isHumanTurn` and `onCelebrate=playSound('winFanfare')`. Its bespoke `TonkOnDealCelebration` overlay stays inside `children` so it co-exists with the standard celebration the shell renders.

Continues the rollout for #1650 (3 pages per PR cadence).

## Test plan
- [x] `bun run test -- --run src/pages/PigsTailPage.test.tsx` — 11/11 pass.
- [x] `bun run test -- --run src/pages/TrashPage.test.tsx` — 16/16 pass.
- [x] TonkPage has no unit-test file in this repo, so the page change is verified via the build/lint pipeline; CI will exercise the page during E2E.
- [x] `bun run check` — Biome + design tokens clean.
- [ ] Local `bun run build` skipped (WSL2 OOM); rely on CI.