### PR TITLE
refactor(pages): migrate Daifugo/Cassino/Bridge to GamePageShell

### DIFF
--- a/frontend/src/pages/BridgePage.tsx
+++ b/frontend/src/pages/BridgePage.tsx
@@ -7,16 +7,11 @@ import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { TrickDisplay } from '../components/TrickDisplay';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { CPU_DIFFICULTY_OPTIONS, useBridgeGame } from '../hooks/useBridgeGame';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -24,7 +19,6 @@ import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
@@ -186,8 +180,6 @@ function BridgePageContent() {
     });
   }, [apiExec, hideActionLog, bridgeConfig.cpuDifficulty]);
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
-
   if (!state)
     return <GameSkeleton gameKey="bridge" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 13 }} />;
 
@@ -212,15 +204,20 @@ function BridgePageContent() {
   };
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.bridge.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.bridge')} />
-      {/* Phase indicator */}
-      <PhaseIndicator phaseName={phaseNames[state.phase]} isHumanTurn={isHumanBidTurn || isHumanTurn}>
-        <ManualButton gamePath="/bridge" />
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.bridge')}
+      gameThemeBg={gameTheme.bridge.bg}
+      phaseName={phaseNames[state.phase]}
+      isHumanTurn={isHumanBidTurn || isHumanTurn}
+      gamePath="/bridge"
+      gameEndFlag={isGameEnd}
+      onCelebrate={() => playSound('winFanfare')}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={<CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />}
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -619,8 +616,6 @@ function BridgePageContent() {
           </GameFooter>
         </>
       )}
-      <WinCelebration show={!!state?.gameEndFlag} onCelebrate={() => playSound('winFanfare')} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/CassinoPage.tsx
+++ b/frontend/src/pages/CassinoPage.tsx
@@ -5,16 +5,11 @@ import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCassinoGame } from '../hooks/useCassinoGame';
@@ -22,7 +17,6 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { gameTheme } from '../styles/gameTheme';
 import type { CassinoResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
@@ -128,8 +122,6 @@ function CassinoPageContent() {
 
   const onReset = useCallback(() => handleResetWithConfig(), [handleResetWithConfig]);
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
-
   if (!state || state.players.length < 4) {
     return (
       <div className={`flex-1 flex items-center justify-center ${gameTheme.cassino.bg} text-ds-text-muted`} aria-busy>
@@ -148,14 +140,20 @@ function CassinoPageContent() {
   const phaseName = isGameEnd ? t('phase.end') : t(`phase.${state.phase}`, t('phase.play'));
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.cassino.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.cassino')} />
-      <PhaseIndicator phaseName={phaseName} isHumanTurn={isHumanTurn}>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/cassino" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.cassino')}
+      gameThemeBg={gameTheme.cassino.bg}
+      phaseName={phaseName}
+      isHumanTurn={isHumanTurn}
+      gamePath="/cassino"
+      gameEndFlag={isGameEnd}
+      winShow={humanWon}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={<CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />}
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -377,11 +375,8 @@ function CassinoPageContent() {
               />
             </div>
           </GameFooter>
-
-          <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-          <WinCelebration show={isGameEnd && humanWon} />
         </>
       )}
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -14,16 +14,11 @@ import { DaifugoSettingsPanel } from '../components/daifugo/DaifugoSettingsPanel
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions, useIsMobile } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
@@ -33,7 +28,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useDaifugoGame } from '../hooks/useDaifugoGame';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
@@ -167,8 +161,6 @@ function DaifugoPageContent() {
     void exec('reset', [], configInput);
   }, [exec, configInput, hideActionLog]);
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
-
   if (!state)
     return (
       <GameSkeleton
@@ -219,13 +211,20 @@ function DaifugoPageContent() {
   ] as const;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.daifugo.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.daifugo')} />
-      <PhaseIndicator phaseName={state.gameEndFlag ? t('phase.end') : t('phase.play')} isHumanTurn={isHumanTurn}>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/daifugo" />
-      </PhaseIndicator>
+    <GamePageShell
+      title={tc('nav.daifugo')}
+      gameThemeBg={gameTheme.daifugo.bg}
+      phaseName={state.gameEndFlag ? t('phase.end') : t('phase.play')}
+      isHumanTurn={isHumanTurn}
+      gamePath="/daifugo"
+      gameEndFlag={!!state.gameEndFlag}
+      onCelebrate={() => playSound('winFanfare')}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={<CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />}
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -430,8 +429,6 @@ function DaifugoPageContent() {
           </GameFooter>
         </>
       )}
-      <WinCelebration show={!!state?.gameEndFlag} onCelebrate={() => playSound('winFanfare')} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }


### PR DESCRIPTION
## Summary
- Migrates `DaifugoPage`, `CassinoPage`, and `BridgePage` to the shared `GamePageShell`, dropping duplicated `GamePageHeading` / `PhaseIndicator` / `TutorialButton` / `ManualButton` / `WinCelebration` / `GameResetDialog` / `useGameRoundGuard` wiring on each page.
- Daifugo: no composed `isGameEnd` in this page, so passes raw `state.gameEndFlag` (the only end signal here).
- Cassino: aliases `isGameEnd = state.gameEndFlag`. Passes `gameEndFlag={isGameEnd}` and `winShow={humanWon}` (dropping the redundant `isGameEnd && humanWon` prefix the original had — `humanWon` already incorporates `isGameEnd`).
- Bridge: composed `isGameEnd = phase === GAME_END || state.gameEndFlag`, so passes `gameEndFlag={isGameEnd}` per the rule established in #1735 / #1737 fixups. `isHumanTurn = isHumanBidTurn || isHumanTurn` covers both bid and play phases.

Bridge originally rendered the header buttons in the order ManualButton, CliToggle, TutorialButton; the migrated version follows GamePageShell's standard order (CliToggle in `headerExtra`, then TutorialButton, then ManualButton). `data-tutorial` selectors still resolve to the same nodes.

Continues the rollout for #1650 (3 pages per PR cadence).

## Test plan
- [x] `bun run test -- --run src/pages/DaifugoPage.test.tsx` — 93/93 pass.
- [x] `bun run test -- --run src/pages/CassinoPage.test.tsx` — 16/16 pass.
- [x] `bun run test -- --run src/pages/BridgePage.test.tsx` — 32/32 pass.
- [x] `bun run check` — Biome + design tokens clean.
- [ ] Local `bun run build` skipped (WSL2 OOM); rely on CI.