### PR TITLE
refactor(pages): migrate CasinoWar/EgyptianRatscrew/Slapjack to GamePageShell

### DIFF
--- a/frontend/src/pages/CasinoWarPage.tsx
+++ b/frontend/src/pages/CasinoWarPage.tsx
@@ -8,16 +8,11 @@ import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -26,7 +21,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useMountReset } from '../hooks/useMountReset';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
@@ -97,8 +91,6 @@ function CasinoWarPageContent() {
 
   useActionKeyboardNav({ bindings: actionBindings, enabled: !!state && !loading });
 
-  useGameRoundGuard(isGameRoundActive(state));
-
   if (!state) {
     return (
       <div className={`flex-1 flex items-center justify-center ${gameTheme.casinowar.bg}`}>
@@ -123,17 +115,27 @@ function CasinoWarPageContent() {
           : t('phase.end');
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.casinowar.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.casinowar')} />
-      <PhaseIndicator phaseName={phaseName}>
-        <span>
-          {t('label.chips')}: {state.chips}
-        </span>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/casinowar" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.casinowar')}
+      gameThemeBg={gameTheme.casinowar.bg}
+      phaseName={phaseName}
+      gamePath="/casinowar"
+      gameEndFlag={isEndPhase}
+      winShow={isEndPhase && state.result > 0}
+      onCelebrate={() => playSound('winFanfare')}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={
+        <>
+          <span>
+            {t('label.chips')}: {state.chips}
+          </span>
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </>
+      }
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -292,8 +294,6 @@ function CasinoWarPageContent() {
           </GameFooter>
         </>
       )}
-      <WinCelebration show={isEndPhase && state.result > 0} onCelebrate={() => playSound('winFanfare')} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/EgyptianRatscrewPage.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.tsx
@@ -143,7 +143,7 @@ function EgyptianRatscrewPageContent() {
       title={tc('nav.egyptianratscrew')}
       gameThemeBg={gameTheme.egyptianratscrew.bg}
       phaseName={phaseName}
-      isHumanTurn={!isGameEnd && state.isHumanTurn}
+      isHumanTurn={isGameEnd ? undefined : state.isHumanTurn}
       gamePath="/egyptianratscrew"
       gameEndFlag={isGameEnd}
       winShow={humanWon}

--- a/frontend/src/pages/EgyptianRatscrewPage.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.tsx
@@ -6,16 +6,11 @@ import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
@@ -23,7 +18,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useMountReset } from '../hooks/useMountReset';
 import { gameTheme } from '../styles/gameTheme';
 import type { EgyptianRatscrewResponse } from '../types/card';
@@ -68,7 +62,6 @@ function EgyptianRatscrewPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('egyptianratscrew');
   const { state, loading, error, exec: execApi, retry } = useGameApi(egyptianRatscrewApi.exec);
-  useGameRoundGuard(!!state && !state.gameEndFlag);
   const { cardWidth } = useCardDimensions();
   const {
     hint: frontendHint,
@@ -146,14 +139,20 @@ function EgyptianRatscrewPageContent() {
   const lastEvent = state.lastEventKind;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.egyptianratscrew.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.egyptianratscrew')} />
-      <PhaseIndicator phaseName={phaseName} isHumanTurn={!isGameEnd && state.isHumanTurn}>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/egyptianratscrew" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.egyptianratscrew')}
+      gameThemeBg={gameTheme.egyptianratscrew.bg}
+      phaseName={phaseName}
+      isHumanTurn={!isGameEnd && state.isHumanTurn}
+      gamePath="/egyptianratscrew"
+      gameEndFlag={isGameEnd}
+      winShow={humanWon}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={<CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />}
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -313,11 +312,8 @@ function EgyptianRatscrewPageContent() {
               />
             </div>
           </GameFooter>
-
-          <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-          <WinCelebration show={isGameEnd && humanWon} />
         </>
       )}
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -145,7 +145,7 @@ function SlapjackPageContent() {
       title={tc('nav.slapjack')}
       gameThemeBg={gameTheme.slapjack.bg}
       phaseName={phaseName}
-      isHumanTurn={!isGameEnd && state.isHumanTurn}
+      isHumanTurn={isGameEnd ? undefined : state.isHumanTurn}
       gamePath="/slapjack"
       gameEndFlag={isGameEnd}
       winShow={humanWon}

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -6,16 +6,11 @@ import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
@@ -23,7 +18,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useMountReset } from '../hooks/useMountReset';
 import { gameTheme } from '../styles/gameTheme';
 import type { SlapjackResponse } from '../types/card';
@@ -67,7 +61,6 @@ function SlapjackPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('slapjack');
   const { state, loading, error, exec: execApi, retry } = useGameApi(slapjackApi.exec);
-  useGameRoundGuard(!!state && !state.gameEndFlag);
   const { cardWidth } = useCardDimensions();
   const {
     hint: frontendHint,
@@ -148,14 +141,20 @@ function SlapjackPageContent() {
   const lastEvent = state.lastEventKind;
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.slapjack.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.slapjack')} />
-      <PhaseIndicator phaseName={phaseName} isHumanTurn={!isGameEnd && state.isHumanTurn}>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/slapjack" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.slapjack')}
+      gameThemeBg={gameTheme.slapjack.bg}
+      phaseName={phaseName}
+      isHumanTurn={!isGameEnd && state.isHumanTurn}
+      gamePath="/slapjack"
+      gameEndFlag={isGameEnd}
+      winShow={humanWon}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={<CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />}
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -310,11 +309,8 @@ function SlapjackPageContent() {
               />
             </div>
           </GameFooter>
-
-          <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-          <WinCelebration show={isGameEnd && humanWon} />
         </>
       )}
-    </div>
+    </GamePageShell>
   );
 }


### PR DESCRIPTION
## Summary
- Migrates `CasinoWarPage`, `EgyptianRatscrewPage`, and `SlapjackPage` to the shared `GamePageShell`.
- **CasinoWar** is single-player vs. dealer with no `isHumanTurn` label; chips chip + `CliToggle` go via `headerExtra`. `winShow={isEndPhase && state.result > 0}` preserves the original "celebrate only on player win" guard.
- **EgyptianRatscrew** / **Slapjack**: composed `isGameEnd = gameEndFlag || phase === GAME_END`, so they pass `gameEndFlag={isGameEnd}` per the rule established in #1735 / #1737. Both keep `winShow={humanWon}` (silent celebration on CPU win — `onCelebrate` was unset in the original and stays unset).

Continues the rollout for #1650 (3 pages per PR cadence).

## Test plan
- [x] `bun run test -- --run src/pages/CasinoWarPage.test.tsx` — 12/12 pass.
- [x] `bun run test -- --run src/pages/EgyptianRatscrewPage.test.tsx` — 11/11 pass.
- [x] `bun run test -- --run src/pages/SlapjackPage.test.tsx` — 11/11 pass.
- [x] `bun run check` — Biome + design tokens clean.
- [ ] Local `bun run build` skipped (WSL2 OOM); rely on CI.