### PR TITLE
refactor(pages): migrate Holdem/Omaha/OmahaHiLo to GamePageShell

### DIFF
--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -12,20 +12,15 @@ import { EquityDisplay } from '../components/EquityDisplay';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HudStats } from '../components/HudStats';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { PokerTableLayout } from '../components/PokerTableLayout';
 import { RoundResults } from '../components/RoundResults';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions, useIsMobile } from '../hooks/useCardDimensions';
@@ -34,7 +29,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
@@ -201,7 +195,6 @@ function HoldemPageContent() {
     bindings: actionBindings,
     enabled: canAct && !loading,
   });
-  useGameRoundGuard(!!state && !state.gameEndFlag);
 
   if (!state)
     return (
@@ -212,30 +205,39 @@ function HoldemPageContent() {
     );
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.holdem.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.holdem')} />
-      {/* Phase indicator + info bar */}
-      <PhaseIndicator phaseName={phaseNames[phase] ?? t('phase.init')} isHumanTurn={canAct}>
-        <span data-tutorial="he-pot-display">
-          {tc('label.pot')} <strong>{state?.pot ?? 0}</strong>
-        </span>
-        <span>
-          SB/BB:{' '}
-          <strong>
-            {state?.smallBlind ?? 0}/{state?.bigBlind ?? 0}
-          </strong>
-        </span>
-        <span>
-          {tc('label.dealer')} <strong>Player {state?.dealerIdx ?? 0}</strong>
-        </span>
-        {state?.tournamentMode && (
-          <span>{t('handNumber', { count: state.handCount, level: state.blindLevelHands })}</span>
-        )}
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/holdem" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.holdem')}
+      gameThemeBg={gameTheme.holdem.bg}
+      phaseName={phaseNames[phase] ?? t('phase.init')}
+      isHumanTurn={canAct}
+      gamePath="/holdem"
+      gameEndFlag={phase === HoldemPhase.END}
+      onCelebrate={() => playSound('winFanfare')}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={
+        <>
+          <span data-tutorial="he-pot-display">
+            {tc('label.pot')} <strong>{state?.pot ?? 0}</strong>
+          </span>
+          <span>
+            SB/BB:{' '}
+            <strong>
+              {state?.smallBlind ?? 0}/{state?.bigBlind ?? 0}
+            </strong>
+          </span>
+          <span>
+            {tc('label.dealer')} <strong>Player {state?.dealerIdx ?? 0}</strong>
+          </span>
+          {state?.tournamentMode && (
+            <span>{t('handNumber', { count: state.handCount, level: state.blindLevelHands })}</span>
+          )}
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </>
+      }
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -523,8 +525,6 @@ function HoldemPageContent() {
           </GameFooter>
         </>
       )}
-      <WinCelebration show={phase === HoldemPhase.END} onCelebrate={() => playSound('winFanfare')} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/OmahaHiLoPage.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.tsx
@@ -12,20 +12,15 @@ import { EquityDisplay } from '../components/EquityDisplay';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HudStats } from '../components/HudStats';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { PokerTableLayout } from '../components/PokerTableLayout';
 import { RoundResults } from '../components/RoundResults';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions, useIsLargeDesktop, useIsMobile } from '../hooks/useCardDimensions';
@@ -34,7 +29,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
@@ -202,8 +196,6 @@ function OmahaHiLoPageContent() {
     enabled: canAct && !loading,
   });
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
-
   if (!state)
     return (
       <GameSkeleton
@@ -213,30 +205,39 @@ function OmahaHiLoPageContent() {
     );
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.omahahilo.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.omahahilo')} />
-      {/* Phase indicator + info bar */}
-      <PhaseIndicator phaseName={phaseNames[phase] ?? t('phase.init')} isHumanTurn={canAct}>
-        <span data-tutorial="ohl-pot-display">
-          {tc('label.pot')} <strong>{state?.pot ?? 0}</strong>
-        </span>
-        <span>
-          SB/BB:{' '}
-          <strong>
-            {state?.smallBlind ?? 0}/{state?.bigBlind ?? 0}
-          </strong>
-        </span>
-        <span>
-          {tc('label.dealer')} <strong>Player {state?.dealerIdx ?? 0}</strong>
-        </span>
-        {state?.tournamentMode && (
-          <span>{t('handNumber', { count: state.handCount, level: state.blindLevelHands })}</span>
-        )}
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/omahahilo" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.omahahilo')}
+      gameThemeBg={gameTheme.omahahilo.bg}
+      phaseName={phaseNames[phase] ?? t('phase.init')}
+      isHumanTurn={canAct}
+      gamePath="/omahahilo"
+      gameEndFlag={phase === OmahaPhase.END}
+      onCelebrate={() => playSound('winFanfare')}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={
+        <>
+          <span data-tutorial="ohl-pot-display">
+            {tc('label.pot')} <strong>{state?.pot ?? 0}</strong>
+          </span>
+          <span>
+            SB/BB:{' '}
+            <strong>
+              {state?.smallBlind ?? 0}/{state?.bigBlind ?? 0}
+            </strong>
+          </span>
+          <span>
+            {tc('label.dealer')} <strong>Player {state?.dealerIdx ?? 0}</strong>
+          </span>
+          {state?.tournamentMode && (
+            <span>{t('handNumber', { count: state.handCount, level: state.blindLevelHands })}</span>
+          )}
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </>
+      }
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -530,8 +531,6 @@ function OmahaHiLoPageContent() {
           </GameFooter>
         </>
       )}
-      <WinCelebration show={phase === OmahaPhase.END} onCelebrate={() => playSound('winFanfare')} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -12,20 +12,15 @@ import { EquityDisplay } from '../components/EquityDisplay';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HudStats } from '../components/HudStats';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { PokerTableLayout } from '../components/PokerTableLayout';
 import { RoundResults } from '../components/RoundResults';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions, useIsLargeDesktop, useIsMobile } from '../hooks/useCardDimensions';
@@ -34,7 +29,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
@@ -201,8 +195,6 @@ function OmahaPageContent() {
     enabled: canAct && !loading,
   });
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
-
   if (!state)
     return (
       <GameSkeleton
@@ -212,30 +204,39 @@ function OmahaPageContent() {
     );
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.omaha.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.omaha')} />
-      {/* Phase indicator + info bar */}
-      <PhaseIndicator phaseName={phaseNames[phase] ?? t('phase.init')} isHumanTurn={canAct}>
-        <span data-tutorial="oh-pot-display">
-          {tc('label.pot')} <strong>{state?.pot ?? 0}</strong>
-        </span>
-        <span>
-          SB/BB:{' '}
-          <strong>
-            {state?.smallBlind ?? 0}/{state?.bigBlind ?? 0}
-          </strong>
-        </span>
-        <span>
-          {tc('label.dealer')} <strong>Player {state?.dealerIdx ?? 0}</strong>
-        </span>
-        {state?.tournamentMode && (
-          <span>{t('handNumber', { count: state.handCount, level: state.blindLevelHands })}</span>
-        )}
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/omaha" />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc('nav.omaha')}
+      gameThemeBg={gameTheme.omaha.bg}
+      phaseName={phaseNames[phase] ?? t('phase.init')}
+      isHumanTurn={canAct}
+      gamePath="/omaha"
+      gameEndFlag={phase === OmahaPhase.END}
+      onCelebrate={() => playSound('winFanfare')}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={
+        <>
+          <span data-tutorial="oh-pot-display">
+            {tc('label.pot')} <strong>{state?.pot ?? 0}</strong>
+          </span>
+          <span>
+            SB/BB:{' '}
+            <strong>
+              {state?.smallBlind ?? 0}/{state?.bigBlind ?? 0}
+            </strong>
+          </span>
+          <span>
+            {tc('label.dealer')} <strong>Player {state?.dealerIdx ?? 0}</strong>
+          </span>
+          {state?.tournamentMode && (
+            <span>{t('handNumber', { count: state.handCount, level: state.blindLevelHands })}</span>
+          )}
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </>
+      }
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -529,8 +530,6 @@ function OmahaPageContent() {
           </GameFooter>
         </>
       )}
-      <WinCelebration show={phase === OmahaPhase.END} onCelebrate={() => playSound('winFanfare')} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }


### PR DESCRIPTION
## Summary
- Migrates `HoldemPage`, `OmahaPage`, and `OmahaHiLoPage` to the shared `GamePageShell`.
- All three share the same layout pattern: phase-based end signal (`phase === END`) without a composed `isGameEnd`, plus a wide header with pot, blinds, dealer and tournament hand-count chips. Chips + `CliToggle` go via `headerExtra`; `gameEndFlag` uses the phase comparison directly. `isHumanTurn={canAct}` pulses the indicator during the human's turn through the betting rounds.
- OmahaHiLo intentionally still references `OmahaPhase` (not a separate `OmahaHiLoPhase` enum) — the Hi/Lo split scoring is server-side and does not change the client phase ladder.

Continues the rollout for #1650 (3 pages per PR cadence).

## Test plan
- [x] `bun run test -- --run src/pages/HoldemPage.test.tsx` — 113/113 pass.
- [x] `bun run test -- --run src/pages/OmahaPage.test.tsx` — 111/111 pass.
- [x] `bun run test -- --run src/pages/OmahaHiLoPage.test.tsx` — 111/111 pass.
- [x] `bun run check` — Biome + design tokens clean.
- [ ] Local `bun run build` skipped (WSL2 OOM); rely on CI.