### PR TITLE
refactor: migrate IndianPoker/Pineapple/VideoPokerGameContent to GamePageShell

### DIFF
--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -7,7 +7,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { isGameRoundActive, useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useLocalStorageToggle } from '../hooks/useLocalStorageToggle';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
@@ -23,15 +22,10 @@ import { CliToggle } from './cli/CliToggle';
 import { ErrorAlert } from './ErrorAlert';
 import { GameFooter } from './GameFooter';
 import { GameMessageBox } from './GameMessageBox';
-import { GamePageHeading } from './GamePageHeading';
+import { GamePageShell } from './GamePageShell';
 import { GameResetButton } from './GameResetButton';
-import { GameResetDialog } from './GameResetDialog';
 import { HintTooltip } from './hint/HintTooltip';
-import { ManualButton } from './ManualButton';
 import { AnimatedCard } from './motion/AnimatedCard';
-import { WinCelebration } from './motion/WinCelebration';
-import { PhaseIndicator } from './PhaseIndicator';
-import { TutorialButton } from './tutorial/TutorialButton';
 
 /** Per-variant predicate identifying wild cards (Deuces Wild = twos, Joker Poker = jokers, default = none). */
 const WILD_CARD_PREDICATE: Record<'videopoker' | 'deuceswild' | 'jokerpoker', (card: Card) => boolean> = {
@@ -189,22 +183,32 @@ export function VideoPokerGameContent({
     bindings: actionBindings,
     enabled: !!state && !loading,
   });
-  useGameRoundGuard(isGameRoundActive(state));
 
   if (!state) return null;
 
   const displayHeld = isDrawPhase ? heldCards : (state.heldIndices ?? []);
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme[gameName].bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc(`nav.${gameName}`)} />
-      <PhaseIndicator phaseName={phaseName} isHumanTurn={isBetPhase || isDrawPhase}>
-        <span>{t('label.chips', { chips: state.chips })}</span>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath={gamePath} />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc(`nav.${gameName}`)}
+      gameThemeBg={gameTheme[gameName].bg}
+      phaseName={phaseName}
+      isHumanTurn={isBetPhase || isDrawPhase}
+      gamePath={gamePath}
+      gameEndFlag={isResultPhase}
+      winShow={isResultPhase && state.result === 1}
+      onCelebrate={() => playSound('winFanfare')}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={
+        <>
+          <span>{t('label.chips', { chips: state.chips })}</span>
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </>
+      }
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -324,8 +328,6 @@ export function VideoPokerGameContent({
           </GameFooter>
         </>
       )}
-      <WinCelebration show={isResultPhase && state.result === 1} onCelebrate={() => playSound('winFanfare')} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/IndianPokerPage.tsx
+++ b/frontend/src/pages/IndianPokerPage.tsx
@@ -185,7 +185,8 @@ function IndianPokerPageContent() {
       phaseName={phaseNames[phase] ?? t('phase.init')}
       isHumanTurn={canAct}
       gamePath="/indianpoker"
-      gameEndFlag={phase === IndianPokerPhase.END}
+      gameEndFlag={!!state.gameEndFlag}
+      winShow={phase === IndianPokerPhase.END}
       onCelebrate={() => playSound('winFanfare')}
       loading={loading}
       confirmOpen={confirmOpen}

--- a/frontend/src/pages/IndianPokerPage.tsx
+++ b/frontend/src/pages/IndianPokerPage.tsx
@@ -10,18 +10,13 @@ import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { RoundResults } from '../components/RoundResults';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions, useIsMobile } from '../hooks/useCardDimensions';
@@ -30,7 +25,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
@@ -169,8 +163,6 @@ function IndianPokerPageContent() {
     enabled: canAct && !loading,
   });
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
-
   if (!state)
     return (
       <GameSkeleton
@@ -187,24 +179,35 @@ function IndianPokerPageContent() {
   }));
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.indianpoker.bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc('nav.indianpoker')} />
-      {/* Phase indicator + info bar */}
-      <PhaseIndicator phaseName={phaseNames[phase] ?? t('phase.init')} isHumanTurn={canAct}>
-        <span>
-          {tc('label.pot')} <strong>{state.pot ?? 0}</strong>
-        </span>
-        <span>
-          {t('ante')} <strong>{state.ante ?? 0}</strong>
-        </span>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/indianpoker" />
+    <GamePageShell
+      title={tc('nav.indianpoker')}
+      gameThemeBg={gameTheme.indianpoker.bg}
+      phaseName={phaseNames[phase] ?? t('phase.init')}
+      isHumanTurn={canAct}
+      gamePath="/indianpoker"
+      gameEndFlag={phase === IndianPokerPhase.END}
+      onCelebrate={() => playSound('winFanfare')}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={
+        <>
+          <span>
+            {tc('label.pot')} <strong>{state.pot ?? 0}</strong>
+          </span>
+          <span>
+            {t('ante')} <strong>{state.ante ?? 0}</strong>
+          </span>
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </>
+      }
+      headerEnd={
         <span>
           {tc('label.dealer')} <strong>Player {state.dealerIdx ?? 0}</strong>
         </span>
-      </PhaseIndicator>
-
+      }
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -381,8 +384,6 @@ function IndianPokerPageContent() {
           </GameFooter>
         </>
       )}
-      <WinCelebration show={phase === IndianPokerPhase.END} onCelebrate={() => playSound('winFanfare')} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -239,7 +239,8 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
       phaseName={phaseNames[phase] ?? t('phase.init')}
       isHumanTurn={canAct || canDiscard}
       gamePath={`/${variant}`}
-      gameEndFlag={phase === PineapplePhase.END}
+      gameEndFlag={!!state?.gameEndFlag}
+      winShow={phase === PineapplePhase.END}
       onCelebrate={() => playSound('winFanfare')}
       loading={loading}
       confirmOpen={confirmOpen}

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -12,20 +12,15 @@ import { EquityDisplay } from '../components/EquityDisplay';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HudStats } from '../components/HudStats';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { PokerTableLayout } from '../components/PokerTableLayout';
 import { RoundResults } from '../components/RoundResults';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions, useIsMobile } from '../hooks/useCardDimensions';
@@ -34,7 +29,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
@@ -230,8 +224,6 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
     enabled: canAct && !loading,
   });
 
-  useGameRoundGuard(!!state && !state.gameEndFlag);
-
   if (!state)
     return (
       <GameSkeleton
@@ -241,30 +233,39 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
     );
 
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameTheme[variant].bg}`} aria-busy={loading}>
-      <GamePageHeading title={tc(`nav.${variant}`)} />
-      {/* Phase indicator + info bar */}
-      <PhaseIndicator phaseName={phaseNames[phase] ?? t('phase.init')} isHumanTurn={canAct || canDiscard}>
-        <span data-tutorial="pn-pot-display">
-          {tc('label.pot')} <strong>{state?.pot ?? 0}</strong>
-        </span>
-        <span>
-          SB/BB:{' '}
-          <strong>
-            {state?.smallBlind ?? 0}/{state?.bigBlind ?? 0}
-          </strong>
-        </span>
-        <span>
-          {tc('label.dealer')} <strong>Player {state?.dealerIdx ?? 0}</strong>
-        </span>
-        {state?.tournamentMode && (
-          <span>{t('handNumber', { count: state.handCount, level: state.blindLevelHands })}</span>
-        )}
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath={`/${variant}`} />
-      </PhaseIndicator>
-
+    <GamePageShell
+      title={tc(`nav.${variant}`)}
+      gameThemeBg={gameTheme[variant].bg}
+      phaseName={phaseNames[phase] ?? t('phase.init')}
+      isHumanTurn={canAct || canDiscard}
+      gamePath={`/${variant}`}
+      gameEndFlag={phase === PineapplePhase.END}
+      onCelebrate={() => playSound('winFanfare')}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      headerExtra={
+        <>
+          <span data-tutorial="pn-pot-display">
+            {tc('label.pot')} <strong>{state?.pot ?? 0}</strong>
+          </span>
+          <span>
+            SB/BB:{' '}
+            <strong>
+              {state?.smallBlind ?? 0}/{state?.bigBlind ?? 0}
+            </strong>
+          </span>
+          <span>
+            {tc('label.dealer')} <strong>Player {state?.dealerIdx ?? 0}</strong>
+          </span>
+          {state?.tournamentMode && (
+            <span>{t('handNumber', { count: state.handCount, level: state.blindLevelHands })}</span>
+          )}
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </>
+      }
+    >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -583,8 +584,6 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
           </GameFooter>
         </>
       )}
-      <WinCelebration show={phase === PineapplePhase.END} onCelebrate={() => playSound('winFanfare')} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
-    </div>
+    </GamePageShell>
   );
 }


### PR DESCRIPTION
Refs #1650. Covers IndianPoker + Pineapple (incl. CrazyPineapple variant) + VideoPokerGameContent (incl. VideoPoker/JokerPoker/DeucesWild wrapper pages). Tests 66/66, 12/12 (Pineapple+CrazyPineapple), 10/10 (VideoPoker variants) pass.