### PR TITLE
refactor(oldmaid): migrate to GamePageShell + add outerKey prop

### DIFF
--- a/frontend/src/components/GamePageShell.test.tsx
+++ b/frontend/src/components/GamePageShell.test.tsx
@@ -250,6 +250,25 @@ describe('GamePageShell', () => {
     expect(manual.compareDocumentPosition(end) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
+  it('remounts the outer container when outerKey changes (drives shake animation)', () => {
+    const { container, rerender } = render(
+      <GamePageShell {...baseProps} outerKey={0}>
+        <div data-testid="game-body" />
+      </GamePageShell>,
+    );
+    const firstBody = screen.getByTestId('game-body');
+    rerender(
+      <GamePageShell {...baseProps} outerKey={1}>
+        <div data-testid="game-body" />
+      </GamePageShell>,
+    );
+    // Changing outerKey forces React to unmount the previous subtree and mount a new one,
+    // which is what restarts the shake CSS animation. Verify by ensuring the body element
+    // is no longer the same DOM node.
+    expect(container.contains(firstBody)).toBe(false);
+    expect(screen.getByTestId('game-body')).toBeInTheDocument();
+  });
+
   it('omits the turn-indicator span when isHumanTurn is not provided', () => {
     render(
       <GamePageShell {...propsWithoutTurn}>

--- a/frontend/src/components/GamePageShell.tsx
+++ b/frontend/src/components/GamePageShell.tsx
@@ -41,6 +41,13 @@ export interface GamePageShellProps {
   confirmReset: () => void;
   /** Callback to cancel the reset action. */
   cancelReset: () => void;
+  /**
+   * Optional `key` applied to the outer container. Use for animations that must
+   * restart on demand by remounting the subtree (e.g., Old Maid's shake-key
+   * pattern, where the wrapper needs to re-mount every time an invalid action
+   * triggers `animate-shake`).
+   */
+  outerKey?: string | number;
   /** Extra elements rendered inside the PhaseIndicator before TutorialButton/ManualButton. */
   headerExtra?: ReactNode;
   /**
@@ -75,6 +82,7 @@ export function GamePageShell({
   confirmOpen,
   confirmReset,
   cancelReset,
+  outerKey,
   headerExtra,
   headerEnd,
   children,
@@ -82,7 +90,7 @@ export function GamePageShell({
   // long-form games (Hearts, Spades, Skat, …) don't silently lose state.
   useGameRoundGuard(!gameEndFlag);
   return (
-    <div className={`flex-1 flex flex-col min-h-0 ${gameThemeBg}`} aria-busy={loading}>
+    <div key={outerKey} className={`flex-1 flex flex-col min-h-0 ${gameThemeBg}`} aria-busy={loading}>
       <GamePageHeading title={title} />
       <PhaseIndicator phaseName={phaseName} isHumanTurn={isHumanTurn}>
         {headerExtra}

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -8,21 +8,16 @@ import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
-import { GamePageHeading } from '../components/GamePageHeading';
+import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
-import { GameResetDialog } from '../components/GameResetDialog';
 import { HintTooltip } from '../components/hint/HintTooltip';
-import { ManualButton } from '../components/ManualButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
-import { WinCelebration } from '../components/motion/WinCelebration';
 import { OldMaidDiscardedArea } from '../components/oldmaid/OldMaidDiscardedArea';
 import { OldMaidDrawHistory } from '../components/oldmaid/OldMaidDrawHistory';
 import { OldMaidPlayerArea } from '../components/oldmaid/OldMaidPlayerArea';
 import { OldMaidSettingsDialog } from '../components/oldmaid/OldMaidSettingsDialog';
-import { PhaseIndicator } from '../components/PhaseIndicator';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
-import { TutorialButton } from '../components/tutorial/TutorialButton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -30,7 +25,6 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
 import { OldMaidMode, useOldMaidGame } from '../hooks/useOldMaidGame';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
@@ -104,7 +98,6 @@ function OldMaidPageContent() {
     setSetupHesitation,
     setSetupMetaAI,
   } = useOldMaidGame();
-  useGameRoundGuard(!!displayState && !displayState.gameEndFlag);
   const {
     hint: frontendHint,
     hintEnabled: frontendHintEnabled,
@@ -194,19 +187,21 @@ function OldMaidPageContent() {
   }
 
   return (
-    <div
-      key={shakeKey}
-      className={`flex-1 flex flex-col min-h-0 ${gameTheme.oldmaid.bg}${shakeKey > 0 ? ' animate-shake' : ''}`}
-      aria-busy={loading}
-      aria-live="polite"
+    <GamePageShell
+      title={tc('nav.oldmaid')}
+      gameThemeBg={`${gameTheme.oldmaid.bg}${shakeKey > 0 ? ' animate-shake' : ''}`}
+      phaseName={state.gameEndFlag ? t('phase.end') : t('phase.play')}
+      isHumanTurn={isHumanTurn}
+      gamePath="/oldmaid"
+      gameEndFlag={!!state.gameEndFlag}
+      onCelebrate={() => playSound('winFanfare')}
+      loading={loading}
+      confirmOpen={confirmOpen}
+      confirmReset={confirmReset}
+      cancelReset={cancelReset}
+      outerKey={shakeKey}
+      headerExtra={<CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />}
     >
-      <GamePageHeading title={tc('nav.oldmaid')} />
-      <PhaseIndicator phaseName={state.gameEndFlag ? t('phase.end') : t('phase.play')} isHumanTurn={isHumanTurn}>
-        <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
-        <TutorialButton />
-        <ManualButton gamePath="/oldmaid" />
-      </PhaseIndicator>
-
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
@@ -430,8 +425,6 @@ function OldMaidPageContent() {
           </GameFooter>
         </>
       )}
-      <WinCelebration show={!!state?.gameEndFlag} onCelebrate={() => playSound('winFanfare')} />
-      <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
       <OldMaidSettingsDialog
         open={settingsOpen}
         mode={setupMode}
@@ -453,6 +446,6 @@ function OldMaidPageContent() {
           setSettingsOpen(false);
         }}
       />
-    </div>
+    </GamePageShell>
   );
 }


### PR DESCRIPTION
Closes #1650.

Completes the GamePageShell migration. OldMaidPage was the last page held back because its outer wrapper used `<div key={shakeKey}>` to remount-and-restart the `animate-shake` CSS animation.

## Changes

- **`GamePageShell`**: new optional `outerKey?: string | number` prop, forwarded as `key` to the root container — pages that need to remount the subtree on demand (shake feedback, etc.) can now do so through the shell instead of bypassing it.
- **`OldMaidPage`**: drops the bespoke outer `<div>`, `GamePageHeading`, `PhaseIndicator`, `TutorialButton`, `ManualButton`, `WinCelebration`, `GameResetDialog`, and `useGameRoundGuard`. Shake remounting is preserved by passing `outerKey={shakeKey}` and appending `animate-shake` through the existing `gameThemeBg` slot. The outer `aria-live="polite"` is dropped because PhaseIndicator already announces phase changes.
- **`GamePageShell.test.tsx`**: new test verifies `outerKey` change forces remount of the inner subtree.

## Test plan

- [x] `bun run test -- --run OldMaidPage GamePageShell` (118 passed)
- [x] `bun run check` (Biome + design tokens clean)
- [ ] CI: full `bun run build && check && test` + Playwright pass
- [ ] Manual: trigger an invalid play in Old Maid; confirm shake animation still fires