### PR TITLE
feat(nav): default-expand all sidebar categories with persisted collapses

### DIFF
--- a/frontend/src/components/DesktopSidebar.test.tsx
+++ b/frontend/src/components/DesktopSidebar.test.tsx
@@ -32,6 +32,10 @@ afterEach(() => {
   i18n.changeLanguage('ja');
   localStorage.removeItem('trumpcards-favorite-games');
   localStorage.removeItem('trumpcards-recent-games');
+  // Accordion expansion state bleeds across tests otherwise — the
+  // "toggles category open/closed on click" test writes a collapse, and
+  // the "expands every category by default" assertions then fail.
+  localStorage.removeItem('trumpcards-category-expansion');
 });
 
 describe('DesktopSidebar', () => {

--- a/frontend/src/components/DesktopSidebar.test.tsx
+++ b/frontend/src/components/DesktopSidebar.test.tsx
@@ -256,34 +256,34 @@ describe('DesktopSidebar', () => {
       }
     });
 
-    it('expands category containing the active game', () => {
+    it('expands every category by default on first visit', () => {
+      // #1698: every category must be discoverable on first load so the
+      // 77-game catalog is visible without 5 extra clicks. Across all 6
+      // categories, every <details> should start with the `open` attribute.
       renderSidebar('/poker');
-      const pokerCategory = screen.getByText(labelFor('nav.category.poker'));
-      expect(pokerCategory.closest('details')).toHaveAttribute('open');
+      const allCategories = ['nav.category.table', 'nav.category.poker', 'nav.category.solitaire'];
+      for (const labelKey of allCategories) {
+        const heading = screen.getByText(labelFor(labelKey));
+        expect(heading.closest('details')).toHaveAttribute('open');
+      }
     });
 
-    it('collapses categories without the active game', () => {
-      renderSidebar('/poker');
-      const tableCategory = screen.getByText(labelFor('nav.category.table'));
-      expect(tableCategory.closest('details')).not.toHaveAttribute('open');
-      const solitaireCategory = screen.getByText(labelFor('nav.category.solitaire'));
-      expect(solitaireCategory.closest('details')).not.toHaveAttribute('open');
-    });
-
-    it('expands table category by default when on home page', () => {
+    it('expands every category by default on the home page', () => {
       renderSidebar('/');
-      const tableCategory = screen.getByText(labelFor('nav.category.table'));
-      expect(tableCategory.closest('details')).toHaveAttribute('open');
+      for (const labelKey of ['nav.category.table', 'nav.category.poker', 'nav.category.solitaire']) {
+        const heading = screen.getByText(labelFor(labelKey));
+        expect(heading.closest('details')).toHaveAttribute('open');
+      }
     });
 
     it('toggles category open/closed on click', () => {
       renderSidebar('/poker');
       const tableCategory = screen.getByText(labelFor('nav.category.table'));
-      expect(tableCategory.closest('details')).not.toHaveAttribute('open');
-      fireEvent.click(tableCategory);
       expect(tableCategory.closest('details')).toHaveAttribute('open');
       fireEvent.click(tableCategory);
       expect(tableCategory.closest('details')).not.toHaveAttribute('open');
+      fireEvent.click(tableCategory);
+      expect(tableCategory.closest('details')).toHaveAttribute('open');
     });
   });
 

--- a/frontend/src/components/DesktopSidebar.tsx
+++ b/frontend/src/components/DesktopSidebar.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Link, useLocation } from 'react-router-dom';
 import { gameCategories, gameRoutes } from '../constants/gameRoutes';
 import { SITE_NAME } from '../constants/site';
+import { useCategoryExpansion } from '../hooks/useCategoryExpansion';
 import { useFavoriteGames } from '../hooks/useFavoriteGames';
 import { useGameRouteSearch } from '../hooks/useGameRouteSearch';
 import { useRecentGames } from '../hooks/useRecentGames';
@@ -20,6 +21,7 @@ export function DesktopSidebar() {
   const { t } = useTranslation('common');
   const [searchTerm, setSearchTerm] = useState('');
   const { favorites, isFavorite, toggleFavorite } = useFavoriteGames();
+  const { isExpanded, setExpanded } = useCategoryExpansion();
   const recentGames = useRecentGames(pathname);
   const { filteredPaths } = useGameRouteSearch(searchTerm);
 
@@ -174,9 +176,13 @@ export function DesktopSidebar() {
           </div>
         ) : (
           gameCategories.map(({ labelKey, icon: catIcon, routes }) => {
-            const hasActivePage = routes.some(({ path }) => path === pathname);
             return (
-              <details key={labelKey} className="sidebar-category mb-1" open={hasActivePage}>
+              <details
+                key={labelKey}
+                className="sidebar-category mb-1"
+                open={isExpanded(labelKey)}
+                onToggle={(e) => setExpanded(labelKey, e.currentTarget.open)}
+              >
                 <summary className="text-ds-text-muted text-[10px] uppercase tracking-wider px-1 py-1 font-semibold flex items-center gap-1 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
                   <span aria-hidden="true">{catIcon}</span> {t(labelKey)}
                   <span className="ml-auto text-[8px] text-ds-text-muted sidebar-category-chevron" aria-hidden="true">

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -225,15 +225,17 @@ export function NavBar() {
         ) : (
           <div className="flex flex-col gap-1 sm:flex-row sm:flex-wrap sm:flex-1 sm:justify-end sm:gap-3">
             {gameCategories.map(({ labelKey, icon: catIcon, routes }) => {
-              const hasActivePage = routes.some(({ path }) => path === pathname);
               return (
                 <details
                   key={labelKey}
                   className="nav-category sm:flex sm:items-center"
-                  open={isMobile || hasActivePage}
+                  open
                   onToggle={(e) => {
-                    // On mobile or medium desktop (sm-lg), force details to stay open
-                    if ((isMobile || isMediumDesktop) && !e.currentTarget.open) {
+                    // NavBar is lg:hidden, so we are always on mobile or
+                    // medium desktop. Force categories to stay open on every
+                    // applicable breakpoint so the full 77-game catalog is
+                    // discoverable on first visit (#1698).
+                    if (!e.currentTarget.open) {
                       e.currentTarget.open = true;
                     }
                   }}

--- a/frontend/src/hooks/useCategoryExpansion.test.ts
+++ b/frontend/src/hooks/useCategoryExpansion.test.ts
@@ -1,0 +1,53 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { CATEGORY_EXPANSION_KEY, useCategoryExpansion } from './useCategoryExpansion';
+
+describe('useCategoryExpansion', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults every category to expanded on first visit (no stored state)', () => {
+    const { result } = renderHook(() => useCategoryExpansion());
+    expect(result.current.isExpanded('nav.category.table')).toBe(true);
+    expect(result.current.isExpanded('nav.category.solitaire')).toBe(true);
+    expect(result.current.isExpanded('something.never.seen.before')).toBe(true);
+  });
+
+  it('persists a collapse to localStorage', () => {
+    const { result } = renderHook(() => useCategoryExpansion());
+    act(() => {
+      result.current.setExpanded('nav.category.table', false);
+    });
+    expect(result.current.isExpanded('nav.category.table')).toBe(false);
+    const stored = JSON.parse(localStorage.getItem(CATEGORY_EXPANSION_KEY) ?? '{}');
+    expect(stored).toEqual({ 'nav.category.table': false });
+  });
+
+  it('restores a saved collapse on a fresh hook instance', () => {
+    localStorage.setItem(CATEGORY_EXPANSION_KEY, JSON.stringify({ 'nav.category.poker': false }));
+    const { result } = renderHook(() => useCategoryExpansion());
+    expect(result.current.isExpanded('nav.category.poker')).toBe(false);
+    expect(result.current.isExpanded('nav.category.table')).toBe(true); // missing keys still default to open
+  });
+
+  it('ignores corrupted localStorage entries', () => {
+    localStorage.setItem(CATEGORY_EXPANSION_KEY, 'not json');
+    const { result } = renderHook(() => useCategoryExpansion());
+    expect(result.current.isExpanded('nav.category.table')).toBe(true);
+  });
+
+  it('skips writes when the value did not change (no-op toggle)', () => {
+    const { result } = renderHook(() => useCategoryExpansion());
+    expect(localStorage.getItem(CATEGORY_EXPANSION_KEY)).toBeNull();
+    act(() => {
+      // Default is true, setting it to true again should be a no-op.
+      result.current.setExpanded('nav.category.table', true);
+    });
+    expect(localStorage.getItem(CATEGORY_EXPANSION_KEY)).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useCategoryExpansion.ts
+++ b/frontend/src/hooks/useCategoryExpansion.ts
@@ -38,22 +38,27 @@ export function useCategoryExpansion() {
 
   const isExpanded = useCallback((labelKey: string) => map[labelKey] !== false, [map]);
 
-  const setExpanded = useCallback((labelKey: string, open: boolean) => {
-    setMap((prev) => {
+  const setExpanded = useCallback(
+    (labelKey: string, open: boolean) => {
       // Missing entries are treated as "open" (the implicit default), so a
       // toggle that lands on the same value is a no-op — including the very
-      // first interaction where prev[labelKey] is undefined and open is true.
-      const current = prev[labelKey] ?? true;
-      if (current === open) return prev;
-      const next = { ...prev, [labelKey]: open };
+      // first interaction where map[labelKey] is undefined and open is true.
+      const current = map[labelKey] ?? true;
+      if (current === open) return;
+      const next = { ...map, [labelKey]: open };
+      // Side effect outside the setState updater: React may invoke updater
+      // functions more than once (e.g. StrictMode in development), so calling
+      // localStorage.setItem inside one would write twice for the same
+      // transition. Computing next state up here keeps the updater pure.
       try {
         localStorage.setItem(CATEGORY_EXPANSION_KEY, JSON.stringify(next));
       } catch {
         /* private mode / storage full / etc. */
       }
-      return next;
-    });
-  }, []);
+      setMap(next);
+    },
+    [map],
+  );
 
   return { isExpanded, setExpanded };
 }

--- a/frontend/src/hooks/useCategoryExpansion.ts
+++ b/frontend/src/hooks/useCategoryExpansion.ts
@@ -1,0 +1,59 @@
+import { useCallback, useState } from 'react';
+
+/** localStorage key for sidebar / nav category accordion state. */
+export const CATEGORY_EXPANSION_KEY = 'trumpcards-category-expansion';
+
+/**
+ * Per-category expansion state. Missing keys are treated as `true`
+ * (expanded) so newly-added categories surface to existing visitors,
+ * and so the very first visit shows everything.
+ */
+type ExpansionMap = Record<string, boolean>;
+
+/** Reads the saved expansion map, falling back to an empty (= all open) map. */
+function readMap(): ExpansionMap {
+  try {
+    const raw = localStorage.getItem(CATEGORY_EXPANSION_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const result: ExpansionMap = {};
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof v === 'boolean') result[k] = v;
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Hook that tracks whether each navigation category accordion is
+ * expanded. Defaults every category to `true` on first visit (so all
+ * 77 games are discoverable), and persists user-toggled collapses to
+ * localStorage so repeat visitors see their preferred layout.
+ */
+export function useCategoryExpansion() {
+  const [map, setMap] = useState<ExpansionMap>(readMap);
+
+  const isExpanded = useCallback((labelKey: string) => map[labelKey] !== false, [map]);
+
+  const setExpanded = useCallback((labelKey: string, open: boolean) => {
+    setMap((prev) => {
+      // Missing entries are treated as "open" (the implicit default), so a
+      // toggle that lands on the same value is a no-op — including the very
+      // first interaction where prev[labelKey] is undefined and open is true.
+      const current = prev[labelKey] ?? true;
+      if (current === open) return prev;
+      const next = { ...prev, [labelKey]: open };
+      try {
+        localStorage.setItem(CATEGORY_EXPANSION_KEY, JSON.stringify(next));
+      } catch {
+        /* private mode / storage full / etc. */
+      }
+      return next;
+    });
+  }, []);
+
+  return { isExpanded, setExpanded };
+}


### PR DESCRIPTION
Closes #1698.

The DesktopSidebar accordion previously opened only the category containing the active route, hiding 5 of 6 categories (~53 of 77 games) on first visit. NavBar's medium-desktop view had the same problem. This collapses the gap between repeat visitors (already optimised via favorites/recents) and first-time visitors who couldn't see the full catalogue.

## Changes

- **`useCategoryExpansion`** (new hook + tests) — persists per-category accordion state to `localStorage` under `trumpcards-category-expansion`. Missing entries are treated as expanded, so first-visit users see every category, and so newly-added categories surface to existing users without manual storage clears.
- **DesktopSidebar** — reads / writes through the hook on `<details>` (`open={isExpanded(labelKey)}` + `onToggle`). Removes the old `hasActivePage` logic.
- **NavBar** — drops `hasActivePage`, forces every category open at all applicable breakpoints. NavBar is `lg:hidden` so persistence doesn't apply there; the existing onToggle guard is repurposed to keep all categories open on mobile + medium-desktop.
- **DesktopSidebar tests** — replace the old "only one open" assertions with the new "all open by default + collapse-persists" contract.

## Behaviour

| Scenario | Before | After |
|---|---|---|
| First visit (`/`) | 1 category open (table) | 6 categories open |
| Visit `/poker` | 1 category open (poker) | 6 categories open |
| User collapses Solitaire, reloads | Solitaire reopens | Solitaire stays collapsed |
| Visit on medium desktop (sm-lg) | Only category with active page open | All open |
| Visit on mobile | All open (unchanged) | All open |

## Test plan

- [x] `bun run test -- --run useCategoryExpansion DesktopSidebar` — 39 passed
- [x] `bun run test -- --run -t accordion NavBar` — 2 passed
- [x] `bun run check` — Biome + design-tokens clean
- [ ] CI: full `bun run build && check && test`
- [ ] Manual: load `/` on a fresh browser, confirm all 6 categories visible. Collapse one, reload, confirm it stays collapsed. Resize through breakpoints, confirm mobile/medium force everything open.