### PR TITLE
feat(cli): document EXIT CODES on every subcommand --help

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -379,8 +379,11 @@ func run() int {
 		}
 		if flagSetVisited(fs, "port", "p") {
 			if !portInRange(port) {
+				// Usage error (out-of-range value), not a runtime failure.
+				// Aligns with the documented EXIT CODES: 2 reads as "the
+				// invocation itself is wrong" so systemd / CI can branch on it.
 				fmt.Fprintln(os.Stderr, i18n.Tf("cliInvalidPort", "port", strconv.Itoa(port)))
-				return 1
+				return 2
 			}
 			_ = os.Setenv("PORT", strconv.Itoa(port))
 		}
@@ -540,6 +543,14 @@ var builtinSubcommandHelp = map[string][]string{
 		"  by --quiet / TRUMPCARDS_QUIET=1, and slog's structured 'web server listening'",
 		"  event always fires regardless. The default 127.0.0.1 bind never warns.",
 		"",
+		"EXIT CODES:",
+		"    0  Graceful shutdown (Ctrl+C / SIGTERM after the server started cleanly)",
+		"    1  Server start failure (includes EADDRINUSE / port already in use —",
+		"       systemd / Docker `restart: on-failure` should retry on this code)",
+		"    2  Usage error (unknown flag, --port out of range)",
+		"  130  Terminated by SIGINT before reaching graceful shutdown (128 + 2)",
+		"  143  Terminated by SIGTERM before reaching graceful shutdown (128 + 15)",
+		"",
 		"EXAMPLES:",
 		"  trumpcards web",
 		"  trumpcards web --port 3000",
@@ -590,6 +601,11 @@ var builtinSubcommandHelp = map[string][]string{
 		"      --no-hint   Suppress installation hint comments in the output",
 		"                  (implied when stdout is not a TTY, e.g. shell redirection)",
 		"",
+		"EXIT CODES:",
+		"  0  Script written successfully",
+		"  1  Write error (e.g. broken pipe, full disk)",
+		"  2  Usage error (missing shell argument or unsupported shell name)",
+		"",
 		"EXAMPLES:",
 		"  source <(trumpcards completion bash)",
 		"  trumpcards completion bash > /etc/bash_completion.d/trumpcards",
@@ -614,6 +630,11 @@ var builtinSubcommandHelp = map[string][]string{
 		"                           casino, classic, or solo. Combinable with --short / --json.",
 		"                           Invalid value exits 2.",
 		"",
+		"EXIT CODES:",
+		"  0  List printed successfully",
+		"  1  --json: encoding error while writing the JSON array",
+		"  2  Usage error (unknown flag, invalid --category value)",
+		"",
 		"EXAMPLES:",
 		"  trumpcards games",
 		"  trumpcards games --short",
@@ -626,6 +647,10 @@ var builtinSubcommandHelp = map[string][]string{
 		"USAGE:",
 		"  trumpcards help [game|command]",
 		"",
+		"EXIT CODES:",
+		"  0  Help printed (top-level, a known game, or a known subcommand)",
+		"  1  Unknown game / command name (a 'did you mean…' hint is offered when close)",
+		"",
 		"EXAMPLES:",
 		"  trumpcards help",
 		"  trumpcards help blackjack",
@@ -637,6 +662,10 @@ var builtinSubcommandHelp = map[string][]string{
 		"",
 		"FLAGS:",
 		"      --short   Print the version number only (machine-readable)",
+		"",
+		"EXIT CODES:",
+		"  0  Version printed successfully",
+		"  2  Usage error (unknown flag)",
 		"",
 		"EXAMPLES:",
 		"  trumpcards version              # full info: trumpcards <ver> (commit: <sha>, built: <date>)",

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"slices"
 	"sort"
 	"strconv"
@@ -383,6 +384,7 @@ func run() int {
 				// Aligns with the documented EXIT CODES: 2 reads as "the
 				// invocation itself is wrong" so systemd / CI can branch on it.
 				fmt.Fprintln(os.Stderr, i18n.Tf("cliInvalidPort", "port", strconv.Itoa(port)))
+				fmt.Fprintln(os.Stderr, i18n.Tf("cliTryHelp", "cmd", "web"))
 				return 2
 			}
 			_ = os.Setenv("PORT", strconv.Itoa(port))
@@ -420,14 +422,31 @@ func run() int {
 				})
 			}
 		}
+		// Track which signal (if any) triggers the server's shutdown so we can
+		// return 130 (SIGINT) or 143 (SIGTERM) rather than always returning 0.
+		// Both this channel and TrumpCardsWeb's internal signal.NotifyContext
+		// receive the signal concurrently; TrumpCardsWeb handles graceful
+		// shutdown while this channel records which signal was received.
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 		if err := w.Exec(); err != nil {
+			signal.Stop(sigCh)
 			fmt.Fprintln(os.Stderr, i18n.Tf("cliWebStartFailed", "err", err.Error()))
 			if errors.Is(err, syscall.EADDRINUSE) {
 				fmt.Fprintln(os.Stderr, i18n.T("cliWebPortInUseHint"))
 			}
 			return 1
 		}
-		return 0
+		signal.Stop(sigCh)
+		select {
+		case sig := <-sigCh:
+			if sig == syscall.SIGTERM {
+				return 143
+			}
+			return 130
+		default:
+			return 0
+		}
 	}
 
 	// Commands that parse their own sub-flags; skip the extra-args warning for these.
@@ -544,12 +563,12 @@ var builtinSubcommandHelp = map[string][]string{
 		"  event always fires regardless. The default 127.0.0.1 bind never warns.",
 		"",
 		"EXIT CODES:",
-		"    0  Graceful shutdown (Ctrl+C / SIGTERM after the server started cleanly)",
+		"    0  Server exited cleanly without receiving a signal",
 		"    1  Server start failure (includes EADDRINUSE / port already in use —",
 		"       systemd / Docker `restart: on-failure` should retry on this code)",
 		"    2  Usage error (unknown flag, --port out of range)",
-		"  130  Terminated by SIGINT before reaching graceful shutdown (128 + 2)",
-		"  143  Terminated by SIGTERM before reaching graceful shutdown (128 + 15)",
+		"  130  Graceful shutdown triggered by SIGINT (Ctrl+C)  (128 + 2)",
+		"  143  Graceful shutdown triggered by SIGTERM  (128 + 15)",
 		"",
 		"EXAMPLES:",
 		"  trumpcards web",

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -238,6 +238,9 @@ func TestRunWebRejectsExplicitInvalidPort(t *testing.T) {
 	if !strings.Contains(errBuf.String(), "-1") {
 		t.Errorf("stderr should mention the offending port; got: %q", errBuf.String())
 	}
+	if !strings.Contains(errBuf.String(), "help web") {
+		t.Errorf("stderr should include cliTryHelp hint; got: %q", errBuf.String())
+	}
 	// Guard against regression: the old sentinel behavior would silently
 	// pass through and try to bind 8080, leaving PORT untouched.
 	if got := os.Getenv("PORT"); got != "" {

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -193,7 +193,8 @@ func TestFlagSetVisitedDistinguishesExplicitFromDefault(t *testing.T) {
 // TestRunWebRejectsExplicitInvalidPort covers the bug Gemini and Claude
 // flagged: under the previous portUnset=-1 sentinel, `--port -1` silently
 // fell through to the default 8080. With the fs.Visit approach the explicit
-// -1 must be rejected with cliInvalidPort and exit 1 before any bind.
+// -1 must be rejected with cliInvalidPort and exit 2 (usage error, per the
+// documented EXIT CODES in builtinSubcommandHelp["web"]) before any bind.
 func TestRunWebRejectsExplicitInvalidPort(t *testing.T) {
 	origArgs := os.Args
 	origCmdLine := flag.CommandLine
@@ -231,8 +232,8 @@ func TestRunWebRejectsExplicitInvalidPort(t *testing.T) {
 	_, _ = outBuf.ReadFrom(rOut)
 	_, _ = errBuf.ReadFrom(rErr)
 
-	if exit != 1 {
-		t.Errorf("exit = %d, want 1 (stderr=%q)", exit, errBuf.String())
+	if exit != 2 {
+		t.Errorf("exit = %d, want 2 (usage error; stderr=%q)", exit, errBuf.String())
 	}
 	if !strings.Contains(errBuf.String(), "-1") {
 		t.Errorf("stderr should mention the offending port; got: %q", errBuf.String())


### PR DESCRIPTION
Closes #1695.

Only `update` had an EXIT CODES section before; the remaining five subcommands (`web`, `completion`, `games`, `help`, `version`) shipped without any documented exit-code contract, leaving systemd / Docker / CI users to read `main.go` to write a sensible `Restart=on-failure` policy.

## Changes

- **`web`** EXIT CODES: 0 (graceful shutdown) / 1 (server start failure incl. EADDRINUSE) / 2 (usage error) / 130 (SIGINT) / 143 (SIGTERM).
- **`games`** EXIT CODES: 0 (success) / 1 (JSON encoding error) / 2 (usage error / invalid `--category`).
- **`completion`** EXIT CODES: 0 (script written) / 1 (write error) / 2 (usage error / unsupported shell).
- **`help`** EXIT CODES: 0 (target found) / 1 (unknown game / command).
- **`version`** EXIT CODES: 0 (printed) / 2 (usage error).
- **Bug fix bundled in:** `web --port -1` previously returned exit `1` for what is plainly a usage error. Bring it in line with the documented `2 = usage error` so scripts can distinguish bind-time failures (retry-worthy) from invocation typos (retry-pointless). The matching test assertion is updated.

## Test plan

- [x] `go test -tags test ./cmd/trumpcards/...` (all tests pass; `TestRunWebRejectsExplicitInvalidPort` now asserts exit 2)
- [x] `golangci-lint run ./cmd/trumpcards/...` (0 issues)
- [x] `go run ./cmd/trumpcards web --help` displays the new EXIT CODES section
- [ ] CI