### PR TITLE
feat(cli): collapse top-level --help GAMES into category summary

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -969,16 +969,21 @@ const gameCategoryPreview = 5
 // `git --help` / `kubectl --help` / `cargo --help` style.
 func buildHelpText() string {
 	var sb strings.Builder
+	categories := games.AllCategories()
+	categoryNames := make([]string, len(categories))
+	for i, c := range categories {
+		categoryNames[i] = c.String()
+	}
 	fmt.Fprintf(&sb, `USAGE:
   trumpcards [--lang ja|en] [game]
   trumpcards --help
 
 GAMES:
-  %d games across 3 categories. Run 'trumpcards games' for the full list,
-  or 'trumpcards games --category <casino|classic|solo>' to filter.
+  %d games across %d categories. Run 'trumpcards games' for the full list,
+  or 'trumpcards games --category <%s>' to filter.
 
-`, len(ui.GameRegistry()))
-	for _, cat := range []games.Category{games.CategoryCasino, games.CategoryClassic, games.CategorySolo} {
+`, len(ui.GameRegistry()), len(categories), strings.Join(categoryNames, "|"))
+	for _, cat := range categories {
 		entries := games.ByCategory(cat)
 		preview := make([]string, 0, gameCategoryPreview)
 		for i, g := range entries {

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -953,17 +953,45 @@ func hasHelpFlag(args []string) bool {
 	return false
 }
 
-// buildHelpText generates the CLI help text with the games section derived from the registry.
+// gameCategoryPreview is the number of representative game names rendered per
+// category in the top-level --help GAMES summary. Five names is enough to
+// hint at the variety in each category (e.g. casino → blackjack, baccarat,
+// poker, omaha, holdem) without pushing COMMANDS / OPTIONS off the screen.
+const gameCategoryPreview = 5
+
+// buildHelpText generates the CLI help text with the games section derived
+// from the registry.
+//
+// The GAMES section used to enumerate every one of the 77 games (#1694),
+// which pushed COMMANDS / OPTIONS / EXIT CODES off the visible terminal in
+// the common 24–40 line case. Now it presents a category-grouped summary
+// with a pointer to `trumpcards games` for the full list, mirroring the
+// `git --help` / `kubectl --help` / `cargo --help` style.
 func buildHelpText() string {
 	var sb strings.Builder
-	sb.WriteString(`USAGE:
+	fmt.Fprintf(&sb, `USAGE:
   trumpcards [--lang ja|en] [game]
   trumpcards --help
 
 GAMES:
-`)
-	for _, entry := range ui.GameRegistry() {
-		fmt.Fprintf(&sb, "  %-16s %s\n", entry.Name, entry.Description())
+  %d games across 3 categories. Run 'trumpcards games' for the full list,
+  or 'trumpcards games --category <casino|classic|solo>' to filter.
+
+`, len(ui.GameRegistry()))
+	for _, cat := range []games.Category{games.CategoryCasino, games.CategoryClassic, games.CategorySolo} {
+		entries := games.ByCategory(cat)
+		preview := make([]string, 0, gameCategoryPreview)
+		for i, g := range entries {
+			if i >= gameCategoryPreview {
+				break
+			}
+			preview = append(preview, g.Name)
+		}
+		more := ""
+		if len(entries) > gameCategoryPreview {
+			more = ", …"
+		}
+		fmt.Fprintf(&sb, "  %-8s (%2d)  %s%s\n", cat.String(), len(entries), strings.Join(preview, ", "), more)
 	}
 	sb.WriteString(`
 COMMANDS:

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -1699,3 +1699,38 @@ func TestBuildHelpTextDocumentsStartFlag(t *testing.T) {
 		}
 	}
 }
+
+// TestBuildHelpTextGamesSummaryStaysCompact verifies issue #1694: the
+// top-level --help GAMES section must NOT enumerate every one of the 77
+// games (which used to push COMMANDS / OPTIONS off a 24-line terminal).
+// Instead it shows a category-grouped summary and points at
+// `trumpcards games` for the full list.
+func TestBuildHelpTextGamesSummaryStaysCompact(t *testing.T) {
+	helpText := buildHelpText()
+
+	// The category summary must appear, with a pointer to `games`.
+	for _, want := range []string{"GAMES:", "trumpcards games", "casino", "classic", "solo"} {
+		if !strings.Contains(helpText, want) {
+			t.Errorf("help text missing %q; got:\n%s", want, helpText)
+		}
+	}
+
+	// The COMMANDS section must reach the top of the screen on a 24-line
+	// terminal — this is the regression from #1694. With 6 USAGE lines and
+	// a 5-line GAMES summary we expect COMMANDS to land within the first 20
+	// lines (the issue had it at line ~84).
+	lines := strings.Split(helpText, "\n")
+	commandsIdx := -1
+	for i, line := range lines {
+		if strings.HasPrefix(line, "COMMANDS:") {
+			commandsIdx = i
+			break
+		}
+	}
+	if commandsIdx < 0 {
+		t.Fatalf("COMMANDS: header not found in help text")
+	}
+	if commandsIdx > 20 {
+		t.Errorf("COMMANDS: appears at line %d; expected <= 20 so it stays visible on a default terminal", commandsIdx+1)
+	}
+}

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -1730,7 +1730,9 @@ func TestBuildHelpTextGamesSummaryStaysCompact(t *testing.T) {
 	if commandsIdx < 0 {
 		t.Fatalf("COMMANDS: header not found in help text")
 	}
-	if commandsIdx > 20 {
+	// commandsIdx is 0-based; index 20 = line 21, which would violate the
+	// stated "first 20 lines" bound. Use >= so the guard is strict.
+	if commandsIdx >= 20 {
 		t.Errorf("COMMANDS: appears at line %d; expected <= 20 so it stays visible on a default terminal", commandsIdx+1)
 	}
 }

--- a/internal/infrastructure/games/registry.go
+++ b/internal/infrastructure/games/registry.go
@@ -188,6 +188,16 @@ func ByCategory(cat Category) []Game {
 	return out
 }
 
+// AllCategories returns every Category value in canonical display order
+// (casino, classic, solo). The returned slice is fresh per call so callers
+// cannot mutate package state. Adding a new Category value to the iota above
+// requires extending this slice — that intentional coupling is the SSoT
+// guarantee that consumers (e.g. the CLI --help summary) cannot drift out
+// of sync with the registry.
+func AllCategories() []Category {
+	return []Category{CategoryCasino, CategoryClassic, CategorySolo}
+}
+
 // descriptionCache holds Name→Description for every registered game. Built
 // once at package load from the static registry; safe to return by reference
 // because the registry is never mutated after init.


### PR DESCRIPTION
Closes #1694.

The GAMES section enumerated every one of the 77 games on its own line, so `trumpcards --help` opened with ~77 game lines before COMMANDS / OPTIONS / EXIT CODES — pushing discoverability of `web`, `update`, `--start`, etc. off a 24–40 line terminal. New users would see only "games" and miss the rest of the surface entirely.

## Changes

Replace the per-game enumeration with a category-grouped summary, mirroring `git --help` / `kubectl --help` / `cargo --help`:

```
GAMES:
  77 games across 3 categories. Run 'trumpcards games' for the full list,
  or 'trumpcards games --category <casino|classic|solo>' to filter.

  casino   (24)  blackjack, poker, holdem, omaha, omahahilo, …
  classic  (32)  oldmaid, daifugo, sevens, doubt, hearts, …
  solo     (21)  memory, klondike, freecell, ginrummy, canasta, …
```

COMMANDS now lands at line ~13 (was line ~84). The full list remains one subcommand away — `trumpcards games` / `trumpcards games --short` / `trumpcards games --category solo` — which the new summary explicitly points at.

`gameCategoryPreview = 5` is the per-category preview length (private const). Five names is enough to hint at variety without growing the section.

## Test plan

- [x] `go test -tags test -race ./cmd/trumpcards/...` (all pass; new `TestBuildHelpTextGamesSummaryStaysCompact` guards COMMANDS staying within the first 20 lines)
- [x] `golangci-lint run ./cmd/trumpcards/...` (0 issues)
- [x] Manual: `go run ./cmd/trumpcards --help | head -30` shows the new summary + COMMANDS visible
- [ ] CI