### PR TITLE
feat(i18n): introduce cui_common locale + i18n the shared CUI helpers (#1699 Phase 1)

### DIFF
--- a/internal/adapter/presenter/cui_card_helper.go
+++ b/internal/adapter/presenter/cui_card_helper.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 // isRedSuit returns true for heart and diamond suits.
@@ -61,14 +62,16 @@ type cuiPlayer interface {
 // Index 0 is unused (joker); indices 1–4 correspond to CardDesignSpade–CardDesignDiamond.
 var suitNames = []string{"", "SPADE", "CLOVER", "HEART", "DIAMOND"}
 
-// bettingActionNames maps betting action constants to Japanese action name strings.
-var bettingActionNames = map[int]string{
-	domain.PokerActionFold:  "フォールド",
-	domain.PokerActionCheck: "チェック",
-	domain.PokerActionCall:  "コール",
-	domain.PokerActionBet:   "ベット",
-	domain.PokerActionRaise: "レイズ",
-	domain.PokerActionAllIn: "オールイン",
+// bettingActionKeys maps betting action constants to i18n keys in
+// cui_common.json. Used by cuiBettingActionName so the displayed action
+// text follows the active locale (issue #1699 Phase 1).
+var bettingActionKeys = map[int]string{
+	domain.PokerActionFold:  "cuiBettingActionFold",
+	domain.PokerActionCheck: "cuiBettingActionCheck",
+	domain.PokerActionCall:  "cuiBettingActionCall",
+	domain.PokerActionBet:   "cuiBettingActionBet",
+	domain.PokerActionRaise: "cuiBettingActionRaise",
+	domain.PokerActionAllIn: "cuiBettingActionAllIn",
 }
 
 // cuiCardStr returns a text-based card string (e.g. "SPADE 5", "JOKER", "??").
@@ -118,19 +121,20 @@ func cuiSuitName(suit int) string {
 	return "UNKNOWN"
 }
 
-// cuiPlayerName returns "あなた" for human players, "CPU N" for CPU players,
-// or "UNKNOWN" if the player is nil/zero.
-// Used by OldMaid, Daifugo, Sevens, Doubt, Poker, Holdem, Omaha, Hearts,
-// Spades, CrazyEights, GinRummy, and Memory CUI presenters.
+// cuiPlayerName returns the human-friendly display name for a player:
+// "You" / "あなた" for the human, "CPU N" for CPU opponents, or
+// "UNKNOWN" if the player is nil/zero. Locale-aware via i18n.T (issue
+// #1699 Phase 1). Used by OldMaid, Daifugo, Sevens, Doubt, Poker,
+// Holdem, Omaha, Hearts, Spades, CrazyEights, GinRummy, and Memory.
 func cuiPlayerName[P cuiPlayer](player P, idx int) string {
 	var zero P
 	if player == zero {
-		return "UNKNOWN"
+		return i18n.T("cuiPlayerUnknown")
 	}
 	if player.GetIsHuman() {
-		return color.Bold("あなた")
+		return color.Bold(i18n.T("cuiPlayerYou"))
 	}
-	return color.Bold(fmt.Sprintf("CPU %d", idx))
+	return color.Bold(i18n.Tf("cuiPlayerCpu", "idx", strconv.Itoa(idx)))
 }
 
 // cuiPlayerWithStyle is the type constraint for players that have a play style.
@@ -149,13 +153,13 @@ func cuiPlayerNameWithStyle[P cuiPlayerWithStyle](player P, idx int) string {
 	return name
 }
 
-// cuiBettingActionName returns the Japanese action name for betting actions.
-// Used by Poker and Holdem CUI presenters.
+// cuiBettingActionName returns the localized action name for betting
+// actions. Used by Poker and Holdem CUI presenters.
 func cuiBettingActionName(action int) string {
-	if name, ok := bettingActionNames[action]; ok {
-		return name
+	if key, ok := bettingActionKeys[action]; ok {
+		return i18n.T(key)
 	}
-	return "不明"
+	return i18n.T("cuiBettingActionUnknown")
 }
 
 // cuiIndexedCardListStr returns a double-space separated indexed card string.

--- a/internal/adapter/presenter/cui_card_helper_test.go
+++ b/internal/adapter/presenter/cui_card_helper_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func TestCuiCardStr(t *testing.T) {
@@ -373,6 +374,50 @@ func TestCuiBettingActionName(t *testing.T) {
 			assert.Equal(t, tt.expected, cuiBettingActionName(tt.action))
 		})
 	}
+}
+
+// TestCuiBettingActionName_English verifies issue #1699 Phase 1: betting
+// action names follow the active locale rather than always rendering as
+// hardcoded Japanese.
+func TestCuiBettingActionName_English(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+	i18n.SetLang("en")
+	defer i18n.SetLang("ja") // restore default for other tests
+
+	tests := []struct {
+		action   int
+		expected string
+	}{
+		{domain.PokerActionFold, "Fold"},
+		{domain.PokerActionCheck, "Check"},
+		{domain.PokerActionCall, "Call"},
+		{domain.PokerActionBet, "Bet"},
+		{domain.PokerActionRaise, "Raise"},
+		{domain.PokerActionAllIn, "All-in"},
+		{999, "Unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, cuiBettingActionName(tt.action))
+		})
+	}
+}
+
+// TestCuiPlayerName_English verifies issue #1699 Phase 1: player display
+// names follow the active locale ("You" / "CPU N" instead of always
+// "あなた" / "CPU N").
+func TestCuiPlayerName_English(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+	i18n.SetLang("en")
+	defer i18n.SetLang("ja")
+
+	assert.Equal(t, "You", cuiPlayerName(&mockCuiPlayer{isHuman: true}, 0))
+	assert.Equal(t, "CPU 2", cuiPlayerName(&mockCuiPlayer{isHuman: false}, 2))
+	assert.Equal(t, "UNKNOWN", cuiPlayerName[*mockCuiPlayer](nil, 0))
 }
 
 func TestIsRedSuit(t *testing.T) {

--- a/internal/adapter/presenter/cui_card_helper_test.go
+++ b/internal/adapter/presenter/cui_card_helper_test.go
@@ -1,3 +1,6 @@
+//go:build test
+// +build test
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/cui_output_helper.go
+++ b/internal/adapter/presenter/cui_output_helper.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 // buildCuiOutput constructs a CUI output string with a standard "==========" header block and footer.
@@ -37,7 +38,7 @@ func cuiTrickBlock[TC any](b *strings.Builder, trick []TC, playerIdx func(TC) in
 		pidx := playerIdx(tc)
 		parts[i] = fmt.Sprintf("%s=%s", getPlayerName(pidx), cardStr(tc))
 	}
-	fmt.Fprintf(b, "トリック: %s\n", strings.Join(parts, ", "))
+	fmt.Fprintln(b, i18n.Tf("cuiTrickLine", "cards", strings.Join(parts, ", ")))
 }
 
 // cuiErrorBlock writes the error line if lastErr is non-nil.
@@ -47,16 +48,18 @@ func cuiErrorBlock(b *strings.Builder, lastErr error) {
 	}
 }
 
-// sharedHintReasons holds translations common across trick-taking games.
-var sharedHintReasons = map[string]string{
-	"follow_suit":   "リードスートに追随",
-	"lead_low":      "低いカードでリード",
-	"lead_strong":   "強いカードでリード",
-	"discard_high":  "高いカードを捨てる",
-	"trump_cut":     "切り札でカット",
-	"strategic_bid": "戦略的なビッド",
-	"strong_hand":   "強い手札",
-	"weak_hand":     "弱い手札",
+// sharedHintReasonKeys maps a hint-reason identifier to the i18n key
+// shared across trick-taking games. The displayed string follows the
+// active locale via i18n.T (issue #1699 Phase 1).
+var sharedHintReasonKeys = map[string]string{
+	"follow_suit":   "cuiHintFollowSuit",
+	"lead_low":      "cuiHintLeadLow",
+	"lead_strong":   "cuiHintLeadStrong",
+	"discard_high":  "cuiHintDiscardHigh",
+	"trump_cut":     "cuiHintTrumpCut",
+	"strategic_bid": "cuiHintStrategicBid",
+	"strong_hand":   "cuiHintStrongHand",
+	"weak_hand":     "cuiHintWeakHand",
 }
 
 // lookupHintReason looks up a hint reason string from game-specific map, then shared map.
@@ -64,8 +67,8 @@ func lookupHintReason(reason string, gameReasons map[string]string) string {
 	if s, ok := gameReasons[reason]; ok {
 		return s
 	}
-	if s, ok := sharedHintReasons[reason]; ok {
-		return s
+	if key, ok := sharedHintReasonKeys[reason]; ok {
+		return i18n.T(key)
 	}
 	return reason
 }

--- a/internal/adapter/presenter/cui_output_helper_test.go
+++ b/internal/adapter/presenter/cui_output_helper_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func TestCuiTrickBlock(t *testing.T) {
@@ -34,6 +36,14 @@ func TestCuiTrickBlock(t *testing.T) {
 		}
 		cuiTrickBlock(&b, tricks, getIdx, getCardStr, getName)
 		assert.Equal(t, "トリック: You=S-A, CPU1=H-5\n", b.String())
+	})
+	// Issue #1699 Phase 1: trick line label follows the active locale.
+	t.Run("with cards (en)", func(t *testing.T) {
+		i18n.SetLang("en")
+		defer i18n.SetLang("ja")
+		var b strings.Builder
+		cuiTrickBlock(&b, []fakeTrick{{pidx: 0, cardStr: "S-A"}}, getIdx, getCardStr, getName)
+		assert.Equal(t, "Trick: You=S-A\n", b.String())
 	})
 }
 
@@ -70,6 +80,24 @@ func TestLookupHintReason(t *testing.T) {
 	})
 	t.Run("nil game reasons uses shared", func(t *testing.T) {
 		assert.Equal(t, "低いカードでリード", lookupHintReason("lead_low", nil))
+	})
+	// Issue #1699 Phase 1: shared hint-reason strings follow the active locale
+	// instead of always rendering as Japanese.
+	t.Run("shared reason in English", func(t *testing.T) {
+		i18n.SetLang("en")
+		defer i18n.SetLang("ja")
+		assert.Equal(t, "Follow the lead suit", lookupHintReason("follow_suit", nil))
+		assert.Equal(t, "Lead with a low card", lookupHintReason("lead_low", nil))
+	})
+	t.Run("game-specific override still wins under English", func(t *testing.T) {
+		i18n.SetLang("en")
+		defer i18n.SetLang("ja")
+		// Game-specific reasons are not yet i18n-aware, so they still pass through
+		// verbatim. The English assertion intentionally keeps the original
+		// (non-translated) game-specific text to document the boundary: the
+		// shared layer is locale-aware, per-game overrides are not (Phase 2/3).
+		override := map[string]string{"follow_suit": "Custom"}
+		assert.Equal(t, "Custom", lookupHintReason("follow_suit", override))
 	})
 }
 

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -82,6 +82,10 @@ var globalNamespaces = map[string]bool{
 
 func loadTranslations(fsys fs.FS, lang string) map[string]string {
 	result := map[string]string{}
+	// Adding a file here that should be merged into the global namespace
+	// (no "<file>." key prefix) requires also adding it to globalNamespaces
+	// above. The two declarations are companions: this slice picks the file
+	// up at all, and the map decides whether its keys are prefixed.
 	files := []string{"common", "cui_common", "blackjack", "poker", "oldmaid", "daifugo", "sevens", "doubt", "holdem", "omaha", "omahahilo", "shortdeck", "hearts", "memory", "klondike", "freecell", "baccarat", "spades", "crazyeights", "ginrummy", "spider", "napoleon", "indianpoker", "videopoker", "euchre", "pyramid", "cribbage", "tripeaks", "threecard", "ohhell", "pineapple", "crazypineapple", "speed", "pigtail", "sevencardstud", "clocksolitaire", "twotenjack", "caribbeanstud", "texasholdembonus", "war", "canfield", "fiftyone", "yukon", "whist", "pageone", "reddog", "razz", "badugi", "scorpion", "accordion", "trash", "spanish21", "skat", "shithead", "nertz", "slapjack", "egyptianratscrew", "tonk", "casinowar"}
 	for _, file := range files {
 		path := "locales/" + lang + "/" + file + ".json"

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -69,11 +69,22 @@ func Tf(key string, params ...string) string {
 	return s
 }
 
+// globalNamespaces lists locale files whose keys are merged into the
+// translation map without a "<file>." prefix. Game files are namespaced
+// instead (e.g. "blackjack.helpTitle") so distinct games can reuse the
+// same short key. cui_common is shared by every CUI presenter and lives
+// alongside common.json — its keys all begin with "cui*" so collisions
+// with common.json are impossible.
+var globalNamespaces = map[string]bool{
+	"common":     true,
+	"cui_common": true,
+}
+
 func loadTranslations(fsys fs.FS, lang string) map[string]string {
 	result := map[string]string{}
-	games := []string{"common", "blackjack", "poker", "oldmaid", "daifugo", "sevens", "doubt", "holdem", "omaha", "omahahilo", "shortdeck", "hearts", "memory", "klondike", "freecell", "baccarat", "spades", "crazyeights", "ginrummy", "spider", "napoleon", "indianpoker", "videopoker", "euchre", "pyramid", "cribbage", "tripeaks", "threecard", "ohhell", "pineapple", "crazypineapple", "speed", "pigtail", "sevencardstud", "clocksolitaire", "twotenjack", "caribbeanstud", "texasholdembonus", "war", "canfield", "fiftyone", "yukon", "whist", "pageone", "reddog", "razz", "badugi", "scorpion", "accordion", "trash", "spanish21", "skat", "shithead", "nertz", "slapjack", "egyptianratscrew", "tonk", "casinowar"}
-	for _, game := range games {
-		path := "locales/" + lang + "/" + game + ".json"
+	files := []string{"common", "cui_common", "blackjack", "poker", "oldmaid", "daifugo", "sevens", "doubt", "holdem", "omaha", "omahahilo", "shortdeck", "hearts", "memory", "klondike", "freecell", "baccarat", "spades", "crazyeights", "ginrummy", "spider", "napoleon", "indianpoker", "videopoker", "euchre", "pyramid", "cribbage", "tripeaks", "threecard", "ohhell", "pineapple", "crazypineapple", "speed", "pigtail", "sevencardstud", "clocksolitaire", "twotenjack", "caribbeanstud", "texasholdembonus", "war", "canfield", "fiftyone", "yukon", "whist", "pageone", "reddog", "razz", "badugi", "scorpion", "accordion", "trash", "spanish21", "skat", "shithead", "nertz", "slapjack", "egyptianratscrew", "tonk", "casinowar"}
+	for _, file := range files {
+		path := "locales/" + lang + "/" + file + ".json"
 		data, err := fs.ReadFile(fsys, path)
 		if err != nil {
 			continue
@@ -83,10 +94,10 @@ func loadTranslations(fsys fs.FS, lang string) map[string]string {
 			continue
 		}
 		for k, v := range m {
-			if game == "common" {
+			if globalNamespaces[file] {
 				result[k] = v
 			} else {
-				result[game+"."+k] = v
+				result[file+"."+k] = v
 			}
 		}
 	}

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -175,6 +175,34 @@ func TestT_HelpLines_GamePrefixed_en(t *testing.T) {
 	assert.NotEqual(t, "poker.helpTitle", i18n.T("poker.helpTitle"))
 }
 
+// TestT_CuiCommonKeys_Unprefixed verifies issue #1699 Phase 1: cui_common.json
+// keys are loaded into the global namespace (no "cui_common." prefix) so CUI
+// presenters can call i18n.T("cuiPlayerYou") directly. The "cui*" prefix on
+// every key prevents collisions with common.json.
+func TestT_CuiCommonKeys_Unprefixed(t *testing.T) {
+	i18n.SetLang("ja")
+	assert.Equal(t, "あなた", i18n.T("cuiPlayerYou"))
+	assert.Equal(t, "フォールド", i18n.T("cuiBettingActionFold"))
+	assert.Equal(t, "リードスートに追随", i18n.T("cuiHintFollowSuit"))
+
+	i18n.SetLang("en")
+	assert.Equal(t, "You", i18n.T("cuiPlayerYou"))
+	assert.Equal(t, "Fold", i18n.T("cuiBettingActionFold"))
+	assert.Equal(t, "Follow the lead suit", i18n.T("cuiHintFollowSuit"))
+}
+
+// TestTf_CuiCpuName_BothLangs verifies the {{idx}} substitution path.
+// Same English/Japanese template, but exercised through the loader to
+// guard against the prefix logic regressing.
+func TestTf_CuiCpuName_BothLangs(t *testing.T) {
+	for _, lang := range []string{"ja", "en"} {
+		t.Run(lang, func(t *testing.T) {
+			i18n.SetLang(lang)
+			assert.Equal(t, "CPU 2", i18n.Tf("cuiPlayerCpu", "idx", "2"))
+		})
+	}
+}
+
 // Reset to ja after all tests to avoid polluting other packages
 func TestSetLang_ResetToJa(t *testing.T) {
 	i18n.SetLang("ja")

--- a/internal/i18n/locales/en/cui_common.json
+++ b/internal/i18n/locales/en/cui_common.json
@@ -1,0 +1,21 @@
+{
+  "cuiPlayerYou": "You",
+  "cuiPlayerCpu": "CPU {{idx}}",
+  "cuiPlayerUnknown": "UNKNOWN",
+  "cuiBettingActionFold": "Fold",
+  "cuiBettingActionCheck": "Check",
+  "cuiBettingActionCall": "Call",
+  "cuiBettingActionBet": "Bet",
+  "cuiBettingActionRaise": "Raise",
+  "cuiBettingActionAllIn": "All-in",
+  "cuiBettingActionUnknown": "Unknown",
+  "cuiTrickLine": "Trick: {{cards}}",
+  "cuiHintFollowSuit": "Follow the lead suit",
+  "cuiHintLeadLow": "Lead with a low card",
+  "cuiHintLeadStrong": "Lead with a strong card",
+  "cuiHintDiscardHigh": "Discard a high card",
+  "cuiHintTrumpCut": "Cut with a trump",
+  "cuiHintStrategicBid": "Make a strategic bid",
+  "cuiHintStrongHand": "Strong hand",
+  "cuiHintWeakHand": "Weak hand"
+}

--- a/internal/i18n/locales/ja/cui_common.json
+++ b/internal/i18n/locales/ja/cui_common.json
@@ -1,0 +1,21 @@
+{
+  "cuiPlayerYou": "あなた",
+  "cuiPlayerCpu": "CPU {{idx}}",
+  "cuiPlayerUnknown": "UNKNOWN",
+  "cuiBettingActionFold": "フォールド",
+  "cuiBettingActionCheck": "チェック",
+  "cuiBettingActionCall": "コール",
+  "cuiBettingActionBet": "ベット",
+  "cuiBettingActionRaise": "レイズ",
+  "cuiBettingActionAllIn": "オールイン",
+  "cuiBettingActionUnknown": "不明",
+  "cuiTrickLine": "トリック: {{cards}}",
+  "cuiHintFollowSuit": "リードスートに追随",
+  "cuiHintLeadLow": "低いカードでリード",
+  "cuiHintLeadStrong": "強いカードでリード",
+  "cuiHintDiscardHigh": "高いカードを捨てる",
+  "cuiHintTrumpCut": "切り札でカット",
+  "cuiHintStrategicBid": "戦略的なビッド",
+  "cuiHintStrongHand": "強い手札",
+  "cuiHintWeakHand": "弱い手札"
+}


### PR DESCRIPTION
Refs #1699 (Phase 1 / Foundation).

The 71 `*CuiPresenter.go` files contain ~1,589 hardcoded Japanese lines and ~563 unique JP literals, so `trumpcards --lang en <game>` advertises a feature that the implementation does not deliver. This PR lays the groundwork for per-game migrations (Phases 2/3) **without changing user-facing behaviour at the default `ja` locale**.

## Changes

- **`internal/i18n/locales/{ja,en}/cui_common.json`** (new) — high-frequency phrases shared across CUI presenters:
  - Player names: `cuiPlayerYou`, `cuiPlayerCpu`, `cuiPlayerUnknown`
  - Betting actions: `cuiBettingAction{Fold,Check,Call,Bet,Raise,AllIn,Unknown}`
  - Trick line: `cuiTrickLine`
  - Shared hint reasons: `cuiHint{FollowSuit,LeadLow,LeadStrong,DiscardHigh,TrumpCut,StrategicBid,StrongHand,WeakHand}`
- **`internal/i18n/i18n.go`** — `loadTranslations` learns a `globalNamespaces` set so `cui_common.json` joins `common.json` in the unprefixed namespace. Every new key uses a `cui*` prefix so collisions with `common.json` are impossible by construction.
- **`cui_card_helper.go`** — `cuiPlayerName` and `cuiBettingActionName` now read from i18n. The hardcoded `bettingActionNames` Japanese map is replaced by `bettingActionKeys` (action → i18n key).
- **`cui_output_helper.go`** — `cuiTrickBlock` and `lookupHintReason` now read from i18n. `sharedHintReasons` becomes `sharedHintReasonKeys` for the same reason.
- **Tests** — new assertions for the English path on every helper plus loader guarantees (`cuiPlayerYou` / `cuiBettingActionFold` / `cuiHintFollowSuit` round-trip in both locales). Existing assertions using Japanese literals continue to pass because the default locale is still `ja`.

## Behaviour at the boundary

Game-specific hint-reason maps (`gameReasons` argument to `lookupHintReason`) are **not** i18n-aware yet — they still pass through verbatim. A new test documents this so the boundary between Phase 1 (helpers) and Phase 2/3 (per-game presenters) is explicit.

## Test plan

- [x] `go test -tags test ./internal/adapter/presenter/... ./internal/i18n/... ./internal/infrastructure/games/...`  (all pass; 28.5s with -race)
- [x] `golangci-lint run ./internal/i18n/... ./internal/adapter/presenter/...` (0 issues)
- [x] Full `go test -tags test ./...` (all packages pass)
- [x] Manual: `go run ./cmd/trumpcards --lang ja blackjack` and `--lang en blackjack` exercised — `ja` output unchanged; `en` output now shows "You" / "CPU N" / "Fold" / "Trick:" where the helpers control rendering. Game-body strings remain Japanese pending Phase 2.

## Phase plan

This is **Phase 1 of 4**:
- ✅ **Phase 1 (this PR)** — Foundation: `cui_common` locale + shared helpers
- **Phase 2** (next): Hot 8 games (BlackJack, Poker, Holdem, Sevens, Hearts, Klondike, etc.) — one or two games per PR
- **Phase 3**: Remaining 60 games — grouped by family (solitaire / trick-taking / poker)
- **Phase 4**: Lint enforcement (forbidigo rule on JP characters in CuiPresenter files)