### PR TITLE
fix(i18n,holdem,shortdeck): restore English outputTitle in JA UI

### DIFF
--- a/internal/i18n/locales/ja/holdem.json
+++ b/internal/i18n/locales/ja/holdem.json
@@ -22,7 +22,7 @@
   "invalidLevelHand": "無効なハンド数です: {{val}}。1以上の数値を入力してください。",
   "tableSizeRequired": "テーブルサイズが必要です (4, 6, または 9)。",
   "invalidTableSize": "無効なテーブルサイズです: {{val}}。4, 6, または 9 を入力してください。",
-  "outputTitle": "テキサスホールデム",
+  "outputTitle": "Texas Hold'em",
   "tournamentLine": "トーナメント ハンド#{{hand}} SB:{{sb}} BB:{{bb}} (レベルアップ:{{levelup}}ハンド毎)",
   "rebuyLine": "リバイ: {{chips}}チップ (最大{{max}}回, {{period}}ハンド目まで)",
   "addonLine": "アドオン: {{chips}}チップ ({{after}}ハンド目に提供)",

--- a/internal/i18n/locales/ja/shortdeck.json
+++ b/internal/i18n/locales/ja/shortdeck.json
@@ -8,7 +8,7 @@
   "helpAllIn": "  a                    オールイン",
   "helpBettingLimit": "  bl [0-2]             ベッティングリミット (0=Fixed, 1=PotLimit, 2=NoLimit)",
   "helpTournament": "  tm [0-1]             トーナメントモード",
-  "outputTitle": "ショートデックホールデム",
+  "outputTitle": "Short Deck Hold'em",
   "tournamentLine": "トーナメント ハンド#{{hand}} SB:{{sb}} BB:{{bb}} (レベルアップ:{{levelup}}ハンド毎)",
   "rebuyLine": "リバイ: {{chips}}チップ (最大{{max}}回, {{period}}ハンド目まで)",
   "addonLine": "アドオン: {{chips}}チップ ({{after}}ハンド目に提供)",


### PR DESCRIPTION
## Summary

PR #1767 migrated `HoldemCuiPresenter` / `ShortDeckCuiPresenter` to i18n and changed the JA `outputTitle` to katakana ("テキサスホールデム" / "ショートデックホールデム"). This:

1. Broke `TestHoldemCuiPresenter_Output/initial_state_with_no_community_cards` and `TestShortDeckCuiPresenter_Output/initial_state_with_no_community_cards` (they assert the JA UI title contains the English game name, which has been the long-standing UX).
2. Changed the JA UI silently — the prior hardcoded title was just `"Texas Hold'em"` / `"Short Deck Hold'em"`.

This PR restores the JA `outputTitle` keys to `"Texas Hold'em"` and `"Short Deck Hold'em"`, matching the pre-migration UX and the existing test expectations.

The EN locale entries are unchanged.

## Test plan
- [x] `go test -tags test -run 'TestHoldemCuiPresenter_Output|TestShortDeckCuiPresenter_Output' ./internal/adapter/presenter/` passes locally
- [ ] CI green