### PR TITLE
refactor(i18n): auto-discover locale files via fs.ReadDir

### DIFF
--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -84,12 +84,6 @@ var globalNamespaces = map[string]bool{
 // the entries into a single map. Per-game files are namespaced as
 // "<file>.<key>"; files in globalNamespaces (common, cui_common) are merged
 // flat so their keys are reusable across the codebase.
-//
-// Discovery is automatic via fs.ReadDir over the embedded locales tree —
-// dropping a new locales/<lang>/<game>.json on disk is sufficient to
-// register it. The previous hand-maintained slice repeatedly drifted out
-// of sync with the on-disk files (eleven latent bugs caught in #1699
-// Phase 3 alone), so the slice is gone for good.
 func loadTranslations(fsys fs.FS, lang string) map[string]string {
 	result := map[string]string{}
 	entries, err := fs.ReadDir(fsys, "locales/"+lang)

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -80,16 +80,32 @@ var globalNamespaces = map[string]bool{
 	"cui_common": true,
 }
 
+// loadTranslations reads every *.json file under locales/<lang>/ and merges
+// the entries into a single map. Per-game files are namespaced as
+// "<file>.<key>"; files in globalNamespaces (common, cui_common) are merged
+// flat so their keys are reusable across the codebase.
+//
+// Discovery is automatic via fs.ReadDir over the embedded locales tree —
+// dropping a new locales/<lang>/<game>.json on disk is sufficient to
+// register it. The previous hand-maintained slice repeatedly drifted out
+// of sync with the on-disk files (eleven latent bugs caught in #1699
+// Phase 3 alone), so the slice is gone for good.
 func loadTranslations(fsys fs.FS, lang string) map[string]string {
 	result := map[string]string{}
-	// Adding a file here that should be merged into the global namespace
-	// (no "<file>." key prefix) requires also adding it to globalNamespaces
-	// above. The two declarations are companions: this slice picks the file
-	// up at all, and the map decides whether its keys are prefixed.
-	files := []string{"common", "cui_common", "blackjack", "poker", "oldmaid", "daifugo", "sevens", "doubt", "holdem", "omaha", "omahahilo", "shortdeck", "hearts", "memory", "klondike", "freecell", "baccarat", "spades", "crazyeights", "ginrummy", "spider", "napoleon", "indianpoker", "videopoker", "euchre", "pyramid", "cribbage", "tripeaks", "threecard", "ohhell", "pineapple", "crazypineapple", "speed", "pigtail", "sevencardstud", "clocksolitaire", "twotenjack", "caribbeanstud", "texasholdembonus", "war", "canfield", "fiftyone", "yukon", "whist", "pageone", "reddog", "razz", "badugi", "scorpion", "accordion", "trash", "spanish21", "skat", "shithead", "nertz", "slapjack", "egyptianratscrew", "tonk", "casinowar", "pinochle", "pitch", "bridge", "pokersquares", "calculation", "bakersdozen", "golf", "russiansolitaire", "fortythieves", "gofish", "canasta", "sevenbridge", "durak", "president", "cassino", "spiteandmalice"}
-	for _, file := range files {
-		path := "locales/" + lang + "/" + file + ".json"
-		data, err := fs.ReadFile(fsys, path)
+	entries, err := fs.ReadDir(fsys, "locales/"+lang)
+	if err != nil {
+		return result
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		file := strings.TrimSuffix(name, ".json")
+		data, err := fs.ReadFile(fsys, "locales/"+lang+"/"+name)
 		if err != nil {
 			continue
 		}

--- a/internal/i18n/i18n_internal_test.go
+++ b/internal/i18n/i18n_internal_test.go
@@ -1,6 +1,9 @@
 package i18n
 
 import (
+	"encoding/json"
+	"io/fs"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -69,9 +72,8 @@ func TestLoadTranslations_AutoDiscovery(t *testing.T) {
 
 // TestLoadTranslations_AllExistingLocaleFilesResolve guards against the
 // pre-refactor failure mode (locale file present on disk but not in the
-// hand-maintained slice). With auto-discovery this list is dynamic, so
-// the test just sanity-checks that every JSON file embedded by the
-// `//go:embed` directives produces at least one key in the loaded map.
+// hand-maintained slice). For every embedded *.json, at least one of
+// that file's own keys must appear in the loaded translation map.
 func TestLoadTranslations_AllExistingLocaleFilesResolve(t *testing.T) {
 	for _, lang := range []string{"ja", "en"} {
 		entries, err := localesFS.ReadDir("locales/" + lang)
@@ -79,38 +81,37 @@ func TestLoadTranslations_AllExistingLocaleFilesResolve(t *testing.T) {
 		loaded := loadTranslations(localesFS, lang)
 
 		for _, entry := range entries {
-			if entry.IsDir() {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
 				continue
 			}
-			name := entry.Name()
-			if !endsWithJSON(name) {
-				continue
-			}
-			file := name[:len(name)-len(".json")]
-			// Either the file is global-namespaced (cui_common, common)
-			// or its keys appear under the file.* prefix. Either way at
-			// least one key must be in the loaded map for the file to
-			// have contributed.
-			assert.True(t, hasFileContribution(loaded, file),
-				"locale file %s/%s loaded zero keys — auto-discovery regression?", lang, name)
+			file := strings.TrimSuffix(entry.Name(), ".json")
+			assert.True(t, hasFileContribution(localesFS, loaded, lang, file),
+				"locale file %s/%s loaded zero keys — auto-discovery regression?",
+				lang, entry.Name())
 		}
 	}
 }
 
-func endsWithJSON(name string) bool {
-	const suffix = ".json"
-	return len(name) >= len(suffix) && name[len(name)-len(suffix):] == suffix
-}
-
-func hasFileContribution(loaded map[string]string, file string) bool {
-	if globalNamespaces[file] {
-		// Global namespaces don't include the file prefix; just verify
-		// the map is non-empty as a coarse signal.
-		return len(loaded) > 0
+// hasFileContribution checks whether any of the keys defined in
+// locales/<lang>/<file>.json actually made it into `loaded`. This proves
+// the file's own contents are visible (not merely that some other file
+// happened to load), which is what TestLoadTranslations_AllExistingLocaleFilesResolve
+// guards against.
+func hasFileContribution(fsys fs.FS, loaded map[string]string, lang, file string) bool {
+	data, err := fs.ReadFile(fsys, "locales/"+lang+"/"+file+".json")
+	if err != nil {
+		return false
 	}
-	prefix := file + "."
-	for k := range loaded {
-		if len(k) > len(prefix) && k[:len(prefix)] == prefix {
+	var m map[string]string
+	if err := json.Unmarshal(data, &m); err != nil {
+		return false
+	}
+	for k := range m {
+		key := k
+		if !globalNamespaces[file] {
+			key = file + "." + k
+		}
+		if _, ok := loaded[key]; ok {
 			return true
 		}
 	}

--- a/internal/i18n/i18n_internal_test.go
+++ b/internal/i18n/i18n_internal_test.go
@@ -30,3 +30,89 @@ func TestLoadTranslations_ValidLang(t *testing.T) {
 	assert.NotEmpty(t, result)
 	assert.Equal(t, "Goodbye.", result["bye"])
 }
+
+// TestLoadTranslations_AutoDiscovery verifies that the loader picks up any
+// *.json file dropped under locales/<lang>/ without requiring a code edit.
+// This is the core invariant of the auto-discovery refactor — the old
+// hand-maintained `files` slice repeatedly drifted out of sync (eleven
+// loader-divergence bugs were caught and fixed across #1699 Phase 3 alone),
+// so the regression we are guarding against is "new locale file added but
+// not registered → keys silently return as the literal key string."
+func TestLoadTranslations_AutoDiscovery(t *testing.T) {
+	fsys := fstest.MapFS{
+		"locales/xx/common.json":     &fstest.MapFile{Data: []byte(`{"globalKey":"GLOBAL"}`)},
+		"locales/xx/cui_common.json": &fstest.MapFile{Data: []byte(`{"cuiShared":"SHARED"}`)},
+		"locales/xx/blackjack.json":  &fstest.MapFile{Data: []byte(`{"helpTitle":"BJ"}`)},
+		"locales/xx/newgame.json":    &fstest.MapFile{Data: []byte(`{"helpTitle":"NEW"}`)},
+		// Non-JSON files and subdirectories must be ignored.
+		"locales/xx/README.md":       &fstest.MapFile{Data: []byte("not json")},
+		"locales/xx/sub/nested.json": &fstest.MapFile{Data: []byte(`{"nope":"x"}`)},
+	}
+
+	result := loadTranslations(fsys, "xx")
+
+	// Global namespaces (common, cui_common) merge flat.
+	assert.Equal(t, "GLOBAL", result["globalKey"])
+	assert.Equal(t, "SHARED", result["cuiShared"])
+
+	// Per-game files are namespaced by file name. The previously-unknown
+	// `newgame.json` works without any code change — that's the whole
+	// point of the refactor.
+	assert.Equal(t, "BJ", result["blackjack.helpTitle"])
+	assert.Equal(t, "NEW", result["newgame.helpTitle"])
+
+	// README.md and the nested sub/ directory must not contribute keys.
+	assert.NotContains(t, result, "README")
+	assert.NotContains(t, result, "nope")
+	assert.NotContains(t, result, "sub.nested.nope")
+}
+
+// TestLoadTranslations_AllExistingLocaleFilesResolve guards against the
+// pre-refactor failure mode (locale file present on disk but not in the
+// hand-maintained slice). With auto-discovery this list is dynamic, so
+// the test just sanity-checks that every JSON file embedded by the
+// `//go:embed` directives produces at least one key in the loaded map.
+func TestLoadTranslations_AllExistingLocaleFilesResolve(t *testing.T) {
+	for _, lang := range []string{"ja", "en"} {
+		entries, err := localesFS.ReadDir("locales/" + lang)
+		assert.NoError(t, err)
+		loaded := loadTranslations(localesFS, lang)
+
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			if !endsWithJSON(name) {
+				continue
+			}
+			file := name[:len(name)-len(".json")]
+			// Either the file is global-namespaced (cui_common, common)
+			// or its keys appear under the file.* prefix. Either way at
+			// least one key must be in the loaded map for the file to
+			// have contributed.
+			assert.True(t, hasFileContribution(loaded, file),
+				"locale file %s/%s loaded zero keys — auto-discovery regression?", lang, name)
+		}
+	}
+}
+
+func endsWithJSON(name string) bool {
+	const suffix = ".json"
+	return len(name) >= len(suffix) && name[len(name)-len(suffix):] == suffix
+}
+
+func hasFileContribution(loaded map[string]string, file string) bool {
+	if globalNamespaces[file] {
+		// Global namespaces don't include the file prefix; just verify
+		// the map is non-empty as a coarse signal.
+		return len(loaded) > 0
+	}
+	prefix := file + "."
+	for k := range loaded {
+		if len(k) > len(prefix) && k[:len(prefix)] == prefix {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Replace the hand-maintained \`files\` slice in \`internal/i18n/i18n.go\` with an \`fs.ReadDir\` walk over \`locales/<lang>/\`. Dropping a new locale JSON on disk is now sufficient to register its keys — no separate code edit needed.

## Why now

The hand-maintained slice was the source of repeated loader-divergence bugs. Across the #1699 Phase 3 migration we caught **eleven** locale files that existed on disk but weren't read by the loader because they had been omitted from the slice:

| PR | Files added back to loader |
|---|---|
| #1762 | \`bridge\` |
| #1773 | \`calculation\`, \`bakersdozen\`, \`golf\`, \`russiansolitaire\` |
| #1774 | \`fortythieves\` |
| #1776 | \`gofish\` |
| #1777 | \`canasta\`, \`sevenbridge\` |
| #1778 | \`durak\`, \`president\`, \`cassino\`, \`spiteandmalice\` |

In every case the symptoms were identical and silent: \`i18n.T(\"<game>.helpTitle\")\` returned the literal key string, breaking both CUI titles and Web-presenter \`MessageCode\` lookups. The Gemini reviewer originally suggested this refactor on #1773; we deferred it until migrations were complete so the rebase pain stayed contained.

## What changed

- \`loadTranslations\` now uses \`fs.ReadDir(fsys, \"locales/\"+lang)\` to enumerate \`*.json\` files at load time.
- The 65+ entry \`files\` slice is gone.
- The companion \`globalNamespaces\` map (\`common\`, \`cui_common\`) is **kept** — it controls whether a file's keys merge flat or with a \`<file>.\` prefix. It only changes when a new global namespace is introduced (twice in the lifetime of the package; never the source of a divergence bug).

## Compatibility

| Aspect | Before | After |
|---|---|---|
| \`loadTranslations\` signature | \`(fs.FS, lang)\` | unchanged |
| Per-game key namespace | \`<file>.<key>\` | unchanged |
| Global key namespace | flat | unchanged |
| Malformed JSON handling | skip silently | unchanged |
| Iteration order on collision | slice order | lexical (ReadDir sorted). \`common\` < \`cui_common\` in both, so observably identical. |
| Subdirectories / non-JSON files | implicitly ignored | explicitly ignored |
| Adding a new locale file | edit slice + drop JSON | drop JSON only |

## Tests added

- **\`TestLoadTranslations_AutoDiscovery\`** uses \`fstest.MapFS\` to verify that a previously-unknown game file is picked up automatically, that global namespaces still merge flat, and that non-JSON files and subdirectories are ignored.
- **\`TestLoadTranslations_AllExistingLocaleFilesResolve\`** walks every embedded \`*.json\` and asserts each contributes at least one key, guarding against future regressions of this exact bug class.

The existing \`TestLoadTranslations_MissingFile\`, \`_InvalidJSON\`, and \`_ValidLang\` tests cover the error and happy paths and continue to pass.

## Conflicts with in-flight PRs

This change conflicts with #1776, #1777, and #1778 — each of those adds entries to the slice this PR deletes. The conflict resolution on rebase is mechanical: the slice no longer exists, so the conflict marker can simply be deleted in full (the new locale files those PRs add are picked up by ReadDir without any code change).

Suggested merge order:
1. Merge #1775, #1776, #1777, #1778 (Phase 3 batches D–G) first.
2. Rebase this PR on the resulting develop and resolve the conflict by deleting the slice additions.
3. Merge.

## Test plan
- [x] \`go test -tags test ./internal/i18n/...\` — all pass (existing + 2 new tests)
- [x] \`go test -tags test ./...\` — all packages green
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`goimports -w internal/i18n/i18n.go internal/i18n/i18n_internal_test.go\`