### PR TITLE
test(i18n): guard CuiPresenter sources against hardcoded JP string literals (#1699 Phase 4)

### DIFF
--- a/internal/adapter/presenter/SevensCuiPresenter.go
+++ b/internal/adapter/presenter/SevensCuiPresenter.go
@@ -141,7 +141,10 @@ func (p *SevensCuiPresenter) Output(s interfaces.SevensGame, lastErr error) stri
 	mins := s.GetTableMinVals()
 	maxs := s.GetTableMaxVals()
 	for i, suit := range suits {
-		fmt.Fprintf(&b, "  %s: %d〜%d\n", suitNames[i], mins[suit], maxs[suit])
+		b.WriteString(i18n.Tf("sevens.boardSuitRange",
+			"suit", suitNames[i],
+			"min", strconv.Itoa(mins[suit]),
+			"max", strconv.Itoa(maxs[suit])) + "\n")
 	}
 
 	// Human's previous action

--- a/internal/adapter/presenter/SkatCuiPresenter.go
+++ b/internal/adapter/presenter/SkatCuiPresenter.go
@@ -7,6 +7,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 // skatPlayerStr returns the display string for a single Skat player.
@@ -43,7 +44,7 @@ type SkatCuiPresenter struct{}
 
 // Output renders the game state as a CUI string.
 func (p *SkatCuiPresenter) Output(s interfaces.SkatGame, lastErr error) string {
-	return buildCuiOutput("Skat (スカート)", func(b *strings.Builder) {
+	return buildCuiOutput(i18n.T("skat.helpTitle"), func(b *strings.Builder) {
 		fmt.Fprintf(b, "Round: %d  Trick: %d  Dealer: %d (Fore=%d / Mid=%d / Rear=%d)\n",
 			s.GetRoundNumber(), s.GetTrickNumber(), s.GetDealerIdx(),
 			s.GetForehandIdx(), s.GetMiddlehandIdx(), s.GetRearhandIdx())
@@ -86,10 +87,10 @@ func (p *SkatCuiPresenter) Output(s interfaces.SkatGame, lastErr error) string {
 				name := cuiPlayerName(s.GetPlayer(actor), actor)
 				fmt.Fprintf(b, "Bidding: %s's turn\n", name)
 			}
-			b.WriteString("b 0/1 ・・・pass (0) or accept the active bid step (1)\n")
+			b.WriteString("b 0/1 - pass (0) or accept the active bid step (1)\n")
 		case domain.SkatPhaseSkatPickup:
 			b.WriteString("Skat pickup: declarer decides\n")
-			b.WriteString("ps 0/1 ・・・decline (0) or pick up the skat (1)\n")
+			b.WriteString("ps 0/1 - decline (0) or pick up the skat (1)\n")
 		case domain.SkatPhaseDiscard:
 			b.WriteString("Discard 2 cards into the skat\n")
 			b.WriteString("d <i> <j>\n")

--- a/internal/adapter/presenter/cui_no_japanese_literals_test.go
+++ b/internal/adapter/presenter/cui_no_japanese_literals_test.go
@@ -87,14 +87,20 @@ func TestNoJapaneseStringLiteralsInCuiPresenters(t *testing.T) {
 	t.Error(b.String())
 }
 
-// containsJapanese reports whether s contains hiragana, katakana, or CJK
-// ideographs. Half-width katakana (U+FF65-U+FF9F) is included.
+// containsJapanese reports whether s contains hiragana, katakana, CJK
+// punctuation, or CJK ideographs. Half-width katakana
+// (U+FF65–U+FF9F) is included; full-width ASCII (U+FF01–U+FF60) is
+// intentionally not — it overlaps with intentional decorative
+// punctuation in some game-output contexts and isn't strictly
+// "Japanese content."
 func containsJapanese(s string) bool {
 	for _, r := range s {
 		switch {
+		case r >= 0x3000 && r <= 0x303F: // CJK Symbols and Punctuation (、 。 「 」 　 …)
+			return true
 		case r >= 0x3041 && r <= 0x309F: // hiragana
 			return true
-		case r >= 0x30A0 && r <= 0x30FF: // katakana
+		case r >= 0x30A0 && r <= 0x30FF: // katakana (incl. ・ U+30FB)
 			return true
 		case r >= 0xFF65 && r <= 0xFF9F: // half-width katakana
 			return true

--- a/internal/adapter/presenter/cui_no_japanese_literals_test.go
+++ b/internal/adapter/presenter/cui_no_japanese_literals_test.go
@@ -1,0 +1,106 @@
+//go:build test
+
+package presenter_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"unicode"
+)
+
+// TestNoJapaneseStringLiteralsInCuiPresenters guards the i18n migration
+// (#1699 Phase 3 + Phase 4): every user-facing string in
+// internal/adapter/presenter/*CuiPresenter.go must come from i18n.T/Tf
+// rather than a hardcoded literal. If this test fails, route the new
+// string through internal/i18n/locales/{ja,en}/<game>.json instead of
+// embedding it in the Go source.
+//
+// The check intentionally targets only `*CuiPresenter.go` (the
+// presentation layer). GoDoc comments are out of scope — only string
+// literals in expression position are inspected. JA in test files,
+// Web presenters, controllers, infrastructure, etc. is unaffected.
+//
+// Phase 3 caught eleven loader-divergence bugs precisely because the
+// translation pipeline had no automated guard against drift; this test
+// closes that gap so the next time someone adds a presenter the lint
+// flags the bypass at PR time instead of code review.
+func TestNoJapaneseStringLiteralsInCuiPresenters(t *testing.T) {
+	files, err := filepath.Glob("*CuiPresenter.go")
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no *CuiPresenter.go files found — running from wrong dir?")
+	}
+
+	type violation struct {
+		file string
+		pos  token.Position
+		text string
+	}
+	var violations []violation
+
+	fset := token.NewFileSet()
+	for _, file := range files {
+		af, err := parser.ParseFile(fset, file, nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Errorf("parse %s: %v", file, err)
+			continue
+		}
+		ast.Inspect(af, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			val, err := strconv.Unquote(lit.Value)
+			if err != nil {
+				return true
+			}
+			if !containsJapanese(val) {
+				return true
+			}
+			violations = append(violations, violation{
+				file: file,
+				pos:  fset.Position(lit.Pos()),
+				text: lit.Value,
+			})
+			return true
+		})
+	}
+
+	if len(violations) == 0 {
+		return
+	}
+	var b strings.Builder
+	b.WriteString("hardcoded Japanese string literals in CuiPresenter source — route through i18n.T/Tf instead:\n")
+	for _, v := range violations {
+		b.WriteString("\n  ")
+		b.WriteString(v.pos.String())
+		b.WriteString(": ")
+		b.WriteString(v.text)
+	}
+	t.Error(b.String())
+}
+
+// containsJapanese reports whether s contains hiragana, katakana, or CJK
+// ideographs. Half-width katakana (U+FF65-U+FF9F) is included.
+func containsJapanese(s string) bool {
+	for _, r := range s {
+		switch {
+		case r >= 0x3041 && r <= 0x309F: // hiragana
+			return true
+		case r >= 0x30A0 && r <= 0x30FF: // katakana
+			return true
+		case r >= 0xFF65 && r <= 0xFF9F: // half-width katakana
+			return true
+		case unicode.Is(unicode.Han, r): // CJK ideographs
+			return true
+		}
+	}
+	return false
+}

--- a/internal/i18n/locales/en/sevens.json
+++ b/internal/i18n/locales/en/sevens.json
@@ -22,6 +22,7 @@
   "ruleEndStop": "[end-stop]",
   "ruleNoConsecutiveJokers": "[no consecutive jokers]",
   "boardLabel": "Board:",
+  "boardSuitRange": "  {{suit}}: {{min}}-{{max}}",
   "cpuActionsLabel": "[CPU actions]",
   "gameEnd": "Game over!",
   "rankLine": "  {{name}}: rank {{rank}}",

--- a/internal/i18n/locales/ja/sevens.json
+++ b/internal/i18n/locales/ja/sevens.json
@@ -22,6 +22,7 @@
   "ruleEndStop": "[片側ストップ]",
   "ruleNoConsecutiveJokers": "[ジョーカー連続禁止]",
   "boardLabel": "ボード:",
+  "boardSuitRange": "  {{suit}}: {{min}}〜{{max}}",
   "cpuActionsLabel": "[CPUの行動]",
   "gameEnd": "ゲーム終了！",
   "rankLine": "  {{name}}: {{rank}}位",


### PR DESCRIPTION
## Summary

Closes the i18n migration loop with an automated regression guard.

A new \`TestNoJapaneseStringLiteralsInCuiPresenters\` walks every
\`internal/adapter/presenter/*CuiPresenter.go\` source file via
\`go/ast\` and fails if any string literal contains hiragana, katakana,
half-width katakana, or CJK ideographs. The check is scoped to the
CUI presentation layer only — Go comments, test files, Web presenters,
controllers, and infrastructure are unaffected.

## Why an AST test instead of forbidigo

\`golangci-lint\`'s \`forbidigo\` matches function-call expressions, not
string-literal contents. To enforce \"no JP chars in string literals
under a specific directory,\" the cleanest fit is a tiny repo-local
test that uses \`go/ast\` to inspect \`*ast.BasicLit\` nodes. ~50 lines,
no new lint config, no new dependencies, runs as part of the existing
\`go test ./...\` flow.

## Why the migration matters

Phase 3 (#1699) caught **eleven** loader-divergence bugs — locale files
present on disk but unread by the loader, silently rendering keys as
the literal key string. The auto-discovery refactor (#1779) eliminated
the disk → loader gap; this test closes the source-code → i18n gap.
After this PR a future presenter that inlines a JP string instead of
calling \`i18n.T/Tf\` trips the test at PR time, not in production.

## Drive-by: 3 Skat baseline cleanups

The migration sweep missed three hardcoded JP literals in
\`SkatCuiPresenter.go\`. Cleaned up here so the new test passes from
day one:

| Line | Before | After |
|---|---|---|
| 46 | \`buildCuiOutput(\"Skat (スカート)\", …)\` | \`buildCuiOutput(i18n.T(\"skat.helpTitle\"), …)\` |
| 90 | \`\"b 0/1 ・・・pass (0) or accept …\"\` | \`\"b 0/1 - pass (0) or accept …\"\` |
| 93 | \`\"ps 0/1 ・・・decline (0) or pick up …\"\` | \`\"ps 0/1 - decline (0) or pick up …\"\` |

The first one routes through the existing \`skat.helpTitle\` locale
key (no JSON change needed). The other two used a full-width katakana
middle dot (U+30FB) as a visual separator inside otherwise-English
prompts; replaced with ASCII \`-\` to stay consistent with the rest of
Skat's English CUI output.

## Verification

- \`go test -tags test ./internal/adapter/presenter/ -run TestNoJapanese...\` passes on the cleaned-up baseline.
- Injected \`\"テスト\"\` into a CuiPresenter → test correctly fails with file:line:literal.
- \`go test -tags test ./...\` — all green.
- \`golangci-lint run ./internal/adapter/presenter/...\` — 0 issues.

## Phase 3 / 4 retrospective

| Phase | What it shipped |
|---|---|
| 1 | cui_common helpers (#1758) |
| 2 | 8 trick-taking presenter migrations |
| 3 | 50 game presenters migrated across 14 PRs (#1758-#1778) |
| Auto-discovery | Replaced hand-maintained \`files\` slice with \`fs.ReadDir\` (#1779) |
| Error unification | Last 4 hardcoded \`[エラー]\` banners → \`cuiErrorBlock\` (#1780) |
| **Phase 4 (this PR)** | **Automated regression guard** |

After this lands, the i18n migration is fully closed-loop: every CUI
presenter resolves through i18n, every locale file is auto-discovered,
every error banner uses the shared helper, and every regression is
caught at PR time.