### PR TITLE
refactor(i18n): route VideoPokerCuiPresenter output through i18n (#1699)

### DIFF
--- a/internal/adapter/presenter/VideoPokerCuiPresenter.go
+++ b/internal/adapter/presenter/VideoPokerCuiPresenter.go
@@ -2,11 +2,13 @@ package presenter
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 // VideoPokerCuiPresenter ビデオポーカーCUIプレゼンタークラス
@@ -18,19 +20,19 @@ func (vpp *VideoPokerCuiPresenter) Output(vp interfaces.VideoPokerGame, lastErr 
 	var sb strings.Builder
 
 	sb.WriteString("----------\n")
-	fmt.Fprintf(&sb, "chips: %d\n", vp.GetChips())
-	fmt.Fprintf(&sb, "phase: %s\n", vpp.phaseStr(vp.GetPhase()))
+	fmt.Fprintf(&sb, "%s\n", i18n.Tf("videopoker.chipsLine", "chips", strconv.Itoa(vp.GetChips())))
+	fmt.Fprintf(&sb, "%s\n", i18n.Tf("videopoker.phaseLine", "phase", vpp.phaseStr(vp.GetPhase())))
 
-	// ハンド表示
 	hand := vp.GetHand()
 	if len(hand) > 0 {
-		sb.WriteString("--- HAND ---\n")
+		sb.WriteString(i18n.T("videopoker.handHeader") + "\n")
 		held := vp.GetHeldIndices()
+		holdLabel := i18n.T("videopoker.holdLabel")
 		parts := make([]string, len(hand))
 		for i, card := range hand {
 			s := cuiCardStr(card)
 			if held[i] {
-				s += " [HOLD]"
+				s += " " + holdLabel
 			}
 			parts[i] = s
 		}
@@ -40,20 +42,18 @@ func (vpp *VideoPokerCuiPresenter) Output(vp interfaces.VideoPokerGame, lastErr 
 
 	sb.WriteString("----------\n")
 
-	// エラーメッセージ
 	if lastErr != nil {
 		fmt.Fprintf(&sb, "%s\n", color.Red(lastErr.Error()))
 	}
 
-	// ゲーム結果
 	if vp.GetGameEndFlag() {
-		fmt.Fprintf(&sb, "bet: %d coin(s)\n", vp.GetBetAmount())
+		fmt.Fprintf(&sb, "%s\n", i18n.Tf("videopoker.betLine", "bet", strconv.Itoa(vp.GetBetAmount())))
 		if vp.GetResult() == domain.GameResultWin {
-			fmt.Fprintf(&sb, "%s\n", color.Green(vp.GetHandName()+"! You win!"))
+			fmt.Fprintf(&sb, "%s\n", color.Green(i18n.Tf("videopoker.winLine", "handName", vp.GetHandName())))
 		} else {
-			sb.WriteString(color.Red("No winning hand.") + "\n")
+			sb.WriteString(color.Red(i18n.T("videopoker.noWin")) + "\n")
 		}
-		fmt.Fprintf(&sb, "payout: %d\n", vp.GetPayout())
+		fmt.Fprintf(&sb, "%s\n", i18n.Tf("videopoker.payoutLine", "payout", strconv.Itoa(vp.GetPayout())))
 		sb.WriteString("----------\n")
 	}
 
@@ -69,12 +69,12 @@ func (vpp *VideoPokerCuiPresenter) ActionLogOutput(vp interfaces.VideoPokerGame)
 func (vpp *VideoPokerCuiPresenter) phaseStr(phase int) string {
 	switch phase {
 	case domain.VideoPokerPhaseBet:
-		return "BET"
+		return i18n.T("videopoker.phaseBet")
 	case domain.VideoPokerPhaseDraw:
-		return "DRAW"
+		return i18n.T("videopoker.phaseDraw")
 	case domain.VideoPokerPhaseResult:
-		return "RESULT"
+		return i18n.T("videopoker.phaseResult")
 	default:
-		return "UNKNOWN"
+		return i18n.T("videopoker.phaseUnknown")
 	}
 }

--- a/internal/adapter/presenter/VideoPokerCuiPresenter.go
+++ b/internal/adapter/presenter/VideoPokerCuiPresenter.go
@@ -1,7 +1,6 @@
 package presenter
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -20,8 +19,8 @@ func (vpp *VideoPokerCuiPresenter) Output(vp interfaces.VideoPokerGame, lastErr 
 	var sb strings.Builder
 
 	sb.WriteString("----------\n")
-	fmt.Fprintf(&sb, "%s\n", i18n.Tf("videopoker.chipsLine", "chips", strconv.Itoa(vp.GetChips())))
-	fmt.Fprintf(&sb, "%s\n", i18n.Tf("videopoker.phaseLine", "phase", vpp.phaseStr(vp.GetPhase())))
+	sb.WriteString(i18n.Tf("videopoker.chipsLine", "chips", strconv.Itoa(vp.GetChips())) + "\n")
+	sb.WriteString(i18n.Tf("videopoker.phaseLine", "phase", vpp.phaseStr(vp.GetPhase())) + "\n")
 
 	hand := vp.GetHand()
 	if len(hand) > 0 {
@@ -43,17 +42,17 @@ func (vpp *VideoPokerCuiPresenter) Output(vp interfaces.VideoPokerGame, lastErr 
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		fmt.Fprintf(&sb, "%s\n", color.Red(lastErr.Error()))
+		sb.WriteString(color.Red(lastErr.Error()) + "\n")
 	}
 
 	if vp.GetGameEndFlag() {
-		fmt.Fprintf(&sb, "%s\n", i18n.Tf("videopoker.betLine", "bet", strconv.Itoa(vp.GetBetAmount())))
+		sb.WriteString(i18n.Tf("videopoker.betLine", "bet", strconv.Itoa(vp.GetBetAmount())) + "\n")
 		if vp.GetResult() == domain.GameResultWin {
-			fmt.Fprintf(&sb, "%s\n", color.Green(i18n.Tf("videopoker.winLine", "handName", vp.GetHandName())))
+			sb.WriteString(color.Green(i18n.Tf("videopoker.winLine", "handName", vp.GetHandName())) + "\n")
 		} else {
 			sb.WriteString(color.Red(i18n.T("videopoker.noWin")) + "\n")
 		}
-		fmt.Fprintf(&sb, "%s\n", i18n.Tf("videopoker.payoutLine", "payout", strconv.Itoa(vp.GetPayout())))
+		sb.WriteString(i18n.Tf("videopoker.payoutLine", "payout", strconv.Itoa(vp.GetPayout())) + "\n")
 		sb.WriteString("----------\n")
 	}
 

--- a/internal/adapter/presenter/VideoPokerCuiPresenter_test.go
+++ b/internal/adapter/presenter/VideoPokerCuiPresenter_test.go
@@ -29,8 +29,8 @@ func TestVideoPokerCuiPresenter_Output_BetPhase(t *testing.T) {
 	setupVideoPokerCuiMockDefaults(m)
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "chips: 1000")
-	assert.Contains(t, result, "phase: BET")
+	assert.Contains(t, result, "チップ: 1000")
+	assert.Contains(t, result, "フェーズ: ベット")
 }
 
 func TestVideoPokerCuiPresenter_Output_DrawPhase_WithHand(t *testing.T) {
@@ -55,9 +55,9 @@ func TestVideoPokerCuiPresenter_Output_DrawPhase_WithHand(t *testing.T) {
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "phase: DRAW")
-	assert.Contains(t, result, "[HOLD]")
-	assert.Contains(t, result, "HAND")
+	assert.Contains(t, result, "フェーズ: ドロー")
+	assert.Contains(t, result, "[ホールド]")
+	assert.Contains(t, result, "手札")
 }
 
 func TestVideoPokerCuiPresenter_Output_ResultPhase_Win(t *testing.T) {
@@ -82,9 +82,9 @@ func TestVideoPokerCuiPresenter_Output_ResultPhase_Win(t *testing.T) {
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "phase: RESULT")
-	assert.Contains(t, result, "Four of a Kind! You win!")
-	assert.Contains(t, result, "payout: 25")
+	assert.Contains(t, result, "フェーズ: リザルト")
+	assert.Contains(t, result, "Four of a Kind! あなたの勝利です！")
+	assert.Contains(t, result, "払戻し: 25")
 }
 
 func TestVideoPokerCuiPresenter_Output_ResultPhase_Lose(t *testing.T) {
@@ -109,8 +109,8 @@ func TestVideoPokerCuiPresenter_Output_ResultPhase_Lose(t *testing.T) {
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "No winning hand.")
-	assert.Contains(t, result, "payout: 0")
+	assert.Contains(t, result, "役なし。")
+	assert.Contains(t, result, "払戻し: 0")
 }
 
 func TestVideoPokerCuiPresenter_Output_Error(t *testing.T) {
@@ -124,10 +124,10 @@ func TestVideoPokerCuiPresenter_Output_Error(t *testing.T) {
 
 func TestVideoPokerCuiPresenter_phaseStr(t *testing.T) {
 	p := new(VideoPokerCuiPresenter)
-	assert.Equal(t, "BET", p.phaseStr(domain.VideoPokerPhaseBet))
-	assert.Equal(t, "DRAW", p.phaseStr(domain.VideoPokerPhaseDraw))
-	assert.Equal(t, "RESULT", p.phaseStr(domain.VideoPokerPhaseResult))
-	assert.Equal(t, "UNKNOWN", p.phaseStr(99))
+	assert.Equal(t, "ベット", p.phaseStr(domain.VideoPokerPhaseBet))
+	assert.Equal(t, "ドロー", p.phaseStr(domain.VideoPokerPhaseDraw))
+	assert.Equal(t, "リザルト", p.phaseStr(domain.VideoPokerPhaseResult))
+	assert.Equal(t, "不明", p.phaseStr(99))
 }
 
 func TestVideoPokerCuiPresenter_ActionLogOutput(t *testing.T) {

--- a/internal/i18n/locales/en/videopoker.json
+++ b/internal/i18n/locales/en/videopoker.json
@@ -1,5 +1,17 @@
 {
   "helpTitle": "Video Poker (Jacks or Better)",
   "helpBet": "  b <coins>            bet 1-5 coins and deal",
-  "helpHold": "  h [0 1 2 3 4]       hold cards at indices (empty = hold all)"
+  "helpHold": "  h [0 1 2 3 4]       hold cards at indices (empty = hold all)",
+  "chipsLine": "chips: {{chips}}",
+  "phaseLine": "phase: {{phase}}",
+  "phaseBet": "BET",
+  "phaseDraw": "DRAW",
+  "phaseResult": "RESULT",
+  "phaseUnknown": "UNKNOWN",
+  "handHeader": "--- HAND ---",
+  "holdLabel": "[HOLD]",
+  "betLine": "bet: {{bet}} coin(s)",
+  "winLine": "{{handName}}! You win!",
+  "noWin": "No winning hand.",
+  "payoutLine": "payout: {{payout}}"
 }

--- a/internal/i18n/locales/ja/videopoker.json
+++ b/internal/i18n/locales/ja/videopoker.json
@@ -1,5 +1,17 @@
 {
   "helpTitle": "Video Poker (ビデオポーカー)",
   "helpBet": "  b <coins>            1〜5コインを賭けてディール",
-  "helpHold": "  h [0 1 2 3 4]       ホールドするカードのインデックス (空 = 全てホールド)"
+  "helpHold": "  h [0 1 2 3 4]       ホールドするカードのインデックス (空 = 全てホールド)",
+  "chipsLine": "チップ: {{chips}}",
+  "phaseLine": "フェーズ: {{phase}}",
+  "phaseBet": "ベット",
+  "phaseDraw": "ドロー",
+  "phaseResult": "リザルト",
+  "phaseUnknown": "不明",
+  "handHeader": "--- 手札 ---",
+  "holdLabel": "[ホールド]",
+  "betLine": "ベット: {{bet}} コイン",
+  "winLine": "{{handName}}! あなたの勝利です！",
+  "noWin": "役なし。",
+  "payoutLine": "払戻し: {{payout}}"
 }


### PR DESCRIPTION
Pilot for the final batch of `*CuiPresenter.go` i18n migrations under #1699.

10 / 71 presenters were still bypassing i18n. They squeaked past the lint guard added in #1781 only because their string literals happened to be ASCII-only English (with JP comments). For Japanese users this meant the game body never localized — `--lang ja` showed `phase: BET` / `chips: 1000` / `[HOLD]` / `Four of a Kind! You win!` verbatim.

Migrating them one PR at a time. **VideoPoker is the smallest (80 lines, no shared helpers)** and was chosen as the pilot to lock in the pattern before tackling the larger ones.

## Changes

- **`internal/i18n/locales/{ja,en}/videopoker.json`** — added 12 keys covering every presenter literal: `chipsLine` / `phaseLine` / `phase{Bet,Draw,Result,Unknown}` / `handHeader` / `holdLabel` / `betLine` / `winLine` / `noWin` / `payoutLine`. EN side preserves the previous wording byte-for-byte (`chips: 1000`, `phase: BET`, `[HOLD]`, `bet: 3 coin(s)`, `Four of a Kind! You win!`, `No winning hand.`, `payout: 25`) so the English UX is unchanged.
- **`internal/adapter/presenter/VideoPokerCuiPresenter.go`** — routed `Output()` and `phaseStr()` through `i18n.T` / `i18n.Tf` with `strconv.Itoa` for int substitutions.
- **`internal/adapter/presenter/VideoPokerCuiPresenter_test.go`** — updated assertions to expect the new JA output. The Go i18n module defaults to ja in tests (`i18n.go:124` pre-loads ja), matching the convention already used by `PageOneCuiPresenter_test.go` and other migrated presenters.

## Pattern (for the remaining 9)

1. Add ja + en keys to `internal/i18n/locales/{ja,en}/<game>.json` — keep en byte-identical to the current literal output.
2. Replace literals with `i18n.T("<game>.key")` / `i18n.Tf("<game>.key", "param", value)`.
3. Use `strconv.Itoa(n)` (not `fmt.Sprintf("%d", n)`) for int → string when feeding `Tf`.
4. Update tests to assert on the new ja output.

## Verification

- `go test -tags test ./internal/adapter/presenter/...` — all pass, incl. `TestNoJapaneseStringLiteralsInCuiPresenters`
- `golangci-lint run ./internal/adapter/presenter/...` — 0 issues
- `goimports -w` applied on touched Go files

## Remaining for #1699

9 ASCII-only presenters: Baccarat, BlackJack, CaribbeanStud, CasinoWar, LetItRide, PaiGow, RedDog, TexasHoldemBonus, ThreeCard. Each will follow as its own small PR with the same pattern.

Refs #1699