### PR TITLE
refactor(i18n): route RedDogCuiPresenter output through i18n (#1699)

### DIFF
--- a/internal/adapter/presenter/RedDogCuiPresenter.go
+++ b/internal/adapter/presenter/RedDogCuiPresenter.go
@@ -2,11 +2,13 @@ package presenter
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 // RedDogCuiPresenter レッドドッグCUIプレゼンタークラス
@@ -17,22 +19,22 @@ func (rp *RedDogCuiPresenter) Output(rd interfaces.RedDogGame, lastErr error) st
 	var sb strings.Builder
 
 	sb.WriteString("----------\n")
-	fmt.Fprintf(&sb, "chips: %d\n", rd.GetChips())
-	fmt.Fprintf(&sb, "phase: %s\n", rp.phaseStr(rd.GetPhase()))
+	fmt.Fprintf(&sb, "%s\n", i18n.Tf("reddog.chipsLine", "chips", strconv.Itoa(rd.GetChips())))
+	fmt.Fprintf(&sb, "%s\n", i18n.Tf("reddog.phaseLine", "phase", rp.phaseStr(rd.GetPhase())))
 	if rd.GetAnte() > 0 {
-		fmt.Fprintf(&sb, "ante: %d", rd.GetAnte())
+		sb.WriteString(i18n.Tf("reddog.anteLine", "ante", strconv.Itoa(rd.GetAnte())))
 		if rd.GetRaise() > 0 {
-			fmt.Fprintf(&sb, "  raise: %d", rd.GetRaise())
+			sb.WriteString(i18n.Tf("reddog.raiseInline", "raise", strconv.Itoa(rd.GetRaise())))
 		}
 		sb.WriteString("\n")
 	}
 	if rd.GetPhase() == domain.RedDogPhaseSpreadDecision || rd.GetPhase() == domain.RedDogPhaseEnd {
-		fmt.Fprintf(&sb, "spread: %d\n", rd.GetSpread())
+		fmt.Fprintf(&sb, "%s\n", i18n.Tf("reddog.spreadLine", "spread", strconv.Itoa(rd.GetSpread())))
 	}
 
 	initial := rd.GetInitialCards()
 	if len(initial) > 0 {
-		sb.WriteString("--- " + color.Bold("INITIAL") + " ---\n")
+		sb.WriteString("--- " + color.Bold(i18n.T("reddog.initialHeader")) + " ---\n")
 		parts := make([]string, len(initial))
 		for i, c := range initial {
 			parts[i] = cuiCardStr(c)
@@ -42,7 +44,7 @@ func (rp *RedDogCuiPresenter) Output(rd interfaces.RedDogGame, lastErr error) st
 	}
 
 	if rd.GetThirdCard() != nil {
-		sb.WriteString("--- " + color.Bold("THIRD") + " ---\n")
+		sb.WriteString("--- " + color.Bold(i18n.T("reddog.thirdHeader")) + " ---\n")
 		sb.WriteString(cuiCardStr(rd.GetThirdCard()))
 		sb.WriteString("\n")
 	}
@@ -56,13 +58,13 @@ func (rp *RedDogCuiPresenter) Output(rd interfaces.RedDogGame, lastErr error) st
 	if rd.GetGameEndFlag() {
 		switch rd.GetResult() {
 		case domain.GameResultWin:
-			sb.WriteString(color.Green("Player wins!") + "\n")
+			sb.WriteString(color.Green(i18n.T("reddog.playerWins")) + "\n")
 		case domain.GameResultLose:
-			sb.WriteString(color.Red("Player loses.") + "\n")
+			sb.WriteString(color.Red(i18n.T("reddog.playerLoses")) + "\n")
 		default:
-			sb.WriteString(color.Yellow("Push.") + "\n")
+			sb.WriteString(color.Yellow(i18n.T("reddog.push")) + "\n")
 		}
-		fmt.Fprintf(&sb, "total payout: %d\n", rd.GetTotalPayout())
+		fmt.Fprintf(&sb, "%s\n", i18n.Tf("reddog.totalPayoutLine", "payout", strconv.Itoa(rd.GetTotalPayout())))
 		sb.WriteString("----------\n")
 	}
 
@@ -78,16 +80,16 @@ func (rp *RedDogCuiPresenter) ActionLogOutput(rd interfaces.RedDogGame) string {
 func (rp *RedDogCuiPresenter) phaseStr(phase int) string {
 	switch phase {
 	case domain.RedDogPhaseBet:
-		return "BET"
+		return i18n.T("reddog.phaseBet")
 	case domain.RedDogPhaseInitialDealt:
-		return "INITIAL DEALT"
+		return i18n.T("reddog.phaseInitialDealt")
 	case domain.RedDogPhaseSpreadDecision:
-		return "SPREAD DECISION"
+		return i18n.T("reddog.phaseSpreadDecision")
 	case domain.RedDogPhasePairThird:
-		return "PAIR THIRD"
+		return i18n.T("reddog.phasePairThird")
 	case domain.RedDogPhaseEnd:
-		return "END"
+		return i18n.T("reddog.phaseEnd")
 	default:
-		return "UNKNOWN"
+		return i18n.T("reddog.phaseUnknown")
 	}
 }

--- a/internal/adapter/presenter/RedDogCuiPresenter.go
+++ b/internal/adapter/presenter/RedDogCuiPresenter.go
@@ -19,8 +19,8 @@ func (rp *RedDogCuiPresenter) Output(rd interfaces.RedDogGame, lastErr error) st
 	var sb strings.Builder
 
 	sb.WriteString("----------\n")
-	fmt.Fprintf(&sb, "%s\n", i18n.Tf("reddog.chipsLine", "chips", strconv.Itoa(rd.GetChips())))
-	fmt.Fprintf(&sb, "%s\n", i18n.Tf("reddog.phaseLine", "phase", rp.phaseStr(rd.GetPhase())))
+	sb.WriteString(i18n.Tf("reddog.chipsLine", "chips", strconv.Itoa(rd.GetChips())) + "\n")
+	sb.WriteString(i18n.Tf("reddog.phaseLine", "phase", rp.phaseStr(rd.GetPhase())) + "\n")
 	if rd.GetAnte() > 0 {
 		sb.WriteString(i18n.Tf("reddog.anteLine", "ante", strconv.Itoa(rd.GetAnte())))
 		if rd.GetRaise() > 0 {
@@ -29,7 +29,7 @@ func (rp *RedDogCuiPresenter) Output(rd interfaces.RedDogGame, lastErr error) st
 		sb.WriteString("\n")
 	}
 	if rd.GetPhase() == domain.RedDogPhaseSpreadDecision || rd.GetPhase() == domain.RedDogPhaseEnd {
-		fmt.Fprintf(&sb, "%s\n", i18n.Tf("reddog.spreadLine", "spread", strconv.Itoa(rd.GetSpread())))
+		sb.WriteString(i18n.Tf("reddog.spreadLine", "spread", strconv.Itoa(rd.GetSpread())) + "\n")
 	}
 
 	initial := rd.GetInitialCards()
@@ -64,7 +64,7 @@ func (rp *RedDogCuiPresenter) Output(rd interfaces.RedDogGame, lastErr error) st
 		default:
 			sb.WriteString(color.Yellow(i18n.T("reddog.push")) + "\n")
 		}
-		fmt.Fprintf(&sb, "%s\n", i18n.Tf("reddog.totalPayoutLine", "payout", strconv.Itoa(rd.GetTotalPayout())))
+		sb.WriteString(i18n.Tf("reddog.totalPayoutLine", "payout", strconv.Itoa(rd.GetTotalPayout())) + "\n")
 		sb.WriteString("----------\n")
 	}
 

--- a/internal/adapter/presenter/RedDogCuiPresenter.go
+++ b/internal/adapter/presenter/RedDogCuiPresenter.go
@@ -1,7 +1,6 @@
 package presenter
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -52,7 +51,7 @@ func (rp *RedDogCuiPresenter) Output(rd interfaces.RedDogGame, lastErr error) st
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		fmt.Fprintf(&sb, "%s\n", color.Red(lastErr.Error()))
+		sb.WriteString(color.Red(lastErr.Error()) + "\n")
 	}
 
 	if rd.GetGameEndFlag() {

--- a/internal/adapter/presenter/RedDogCuiPresenter_test.go
+++ b/internal/adapter/presenter/RedDogCuiPresenter_test.go
@@ -30,7 +30,7 @@ func TestRedDogCuiPresenter_Output_BetPhase(t *testing.T) {
 	setupRedDogCuiMockDefaults(m)
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "chips: 1000")
+	assert.Contains(t, result, "チップ: 1000")
 	assert.Contains(t, result, "BET")
 }
 
@@ -63,8 +63,8 @@ func TestRedDogCuiPresenter_Output_SpreadDecision(t *testing.T) {
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "SPREAD DECISION")
 	assert.Contains(t, result, "INITIAL")
-	assert.Contains(t, result, "spread: 4")
-	assert.Contains(t, result, "ante: 100")
+	assert.Contains(t, result, "スプレッド: 4")
+	assert.Contains(t, result, "アンテ: 100")
 }
 
 func TestRedDogCuiPresenter_Output_EndWin(t *testing.T) {
@@ -87,10 +87,10 @@ func TestRedDogCuiPresenter_Output_EndWin(t *testing.T) {
 	m.On("GetTotalPayout").Return(400)
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "Player wins")
+	assert.Contains(t, result, "プレイヤーの勝ち")
 	assert.Contains(t, result, "THIRD")
-	assert.Contains(t, result, "raise: 100")
-	assert.Contains(t, result, "total payout: 400")
+	assert.Contains(t, result, "レイズ: 100")
+	assert.Contains(t, result, "合計払戻し: 400")
 }
 
 func TestRedDogCuiPresenter_Output_EndLose(t *testing.T) {
@@ -109,7 +109,7 @@ func TestRedDogCuiPresenter_Output_EndLose(t *testing.T) {
 	m2.On("GetResult").Return(domain.GameResultLose)
 	m2.On("GetTotalPayout").Return(0)
 	result := p.Output(m2, nil)
-	assert.Contains(t, result, "Player loses")
+	assert.Contains(t, result, "プレイヤーの負け")
 }
 
 func TestRedDogCuiPresenter_Output_EndPush(t *testing.T) {
@@ -126,7 +126,7 @@ func TestRedDogCuiPresenter_Output_EndPush(t *testing.T) {
 	m.On("GetResult").Return(domain.GameResultDraw)
 	m.On("GetTotalPayout").Return(100)
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "Push")
+	assert.Contains(t, result, "プッシュ")
 }
 
 func TestRedDogCuiPresenter_PhaseStr_AllBranches(t *testing.T) {

--- a/internal/i18n/locales/en/reddog.json
+++ b/internal/i18n/locales/en/reddog.json
@@ -2,5 +2,22 @@
   "helpTitle": "Red Dog",
   "helpBet": "  b <amount>           bet (places ante and deals 2 cards)",
   "helpRaise": "  raise <amount>       raise (up to ante)",
-  "helpStay": "  s                    stay (draw third card without raising)"
+  "helpStay": "  s                    stay (draw third card without raising)",
+  "chipsLine": "chips: {{chips}}",
+  "phaseLine": "phase: {{phase}}",
+  "anteLine": "ante: {{ante}}",
+  "raiseInline": "  raise: {{raise}}",
+  "spreadLine": "spread: {{spread}}",
+  "initialHeader": "INITIAL",
+  "thirdHeader": "THIRD",
+  "phaseBet": "BET",
+  "phaseInitialDealt": "INITIAL DEALT",
+  "phaseSpreadDecision": "SPREAD DECISION",
+  "phasePairThird": "PAIR THIRD",
+  "phaseEnd": "END",
+  "phaseUnknown": "UNKNOWN",
+  "playerWins": "Player wins!",
+  "playerLoses": "Player loses.",
+  "push": "Push.",
+  "totalPayoutLine": "total payout: {{payout}}"
 }

--- a/internal/i18n/locales/ja/reddog.json
+++ b/internal/i18n/locales/ja/reddog.json
@@ -2,5 +2,22 @@
   "helpTitle": "Red Dog (レッドドッグ) コマンド",
   "helpBet": "  b <金額>             ベット (アンテを賭けて2枚配る)",
   "helpRaise": "  raise <金額>         レイズ (最大アンテと同額)",
-  "helpStay": "  s                    ステイ (レイズせず3枚目を引く)"
+  "helpStay": "  s                    ステイ (レイズせず3枚目を引く)",
+  "chipsLine": "チップ: {{chips}}",
+  "phaseLine": "フェーズ: {{phase}}",
+  "anteLine": "アンテ: {{ante}}",
+  "raiseInline": "  レイズ: {{raise}}",
+  "spreadLine": "スプレッド: {{spread}}",
+  "initialHeader": "INITIAL",
+  "thirdHeader": "THIRD",
+  "phaseBet": "BET",
+  "phaseInitialDealt": "INITIAL DEALT",
+  "phaseSpreadDecision": "SPREAD DECISION",
+  "phasePairThird": "PAIR THIRD",
+  "phaseEnd": "END",
+  "phaseUnknown": "UNKNOWN",
+  "playerWins": "プレイヤーの勝ち！",
+  "playerLoses": "プレイヤーの負け。",
+  "push": "プッシュ。",
+  "totalPayoutLine": "合計払戻し: {{payout}}"
 }


### PR DESCRIPTION
Second of the 10 holdout presenters under #1699 (after VideoPoker #1782 pilot). Same pattern: EN preserves byte-identical wording, JA gets proper translations.

## Changes

- **`internal/i18n/locales/{ja,en}/reddog.json`** — added 17 keys covering every presenter literal (chipsLine / phaseLine / anteLine / raiseInline / spreadLine / initialHeader / thirdHeader / phase\* x6 / playerWins / playerLoses / push / totalPayoutLine).
- **`internal/adapter/presenter/RedDogCuiPresenter.go`** — routed `Output()` and `phaseStr()` through `i18n.T` / `i18n.Tf` with `strconv.Itoa` for int substitutions.
- **`internal/adapter/presenter/RedDogCuiPresenter_test.go`** — updated assertions to the new JA output for localized lines.

## Localization choices

- Phase codes (`BET` / `INITIAL DEALT` / `SPREAD DECISION` / `PAIR THIRD` / `END` / `UNKNOWN`) and the section headers (`INITIAL` / `THIRD`) are kept as **English short-codes even on the JA side** — they are opaque labels meant to be uniform across locales (matching how casino software typically displays phase codes). The localized text gets the human-readable lines (chips / ante / raise / spread / Player wins / Push / total payout).

## Verification

- `go test -tags test ./internal/adapter/presenter/...` — all pass, incl. `TestNoJapaneseStringLiteralsInCuiPresenters`
- `golangci-lint run ./internal/adapter/presenter/...` — 0 issues
- `goimports -w` applied

## Remaining for #1699

8 ASCII-only presenters: Baccarat, BlackJack, CaribbeanStud, CasinoWar, LetItRide, PaiGow, TexasHoldemBonus, ThreeCard.

Refs #1699