### PR TITLE
refactor(i18n): route BaccaratCuiPresenter output through i18n (#1699)

### DIFF
--- a/internal/adapter/presenter/BaccaratCuiPresenter.go
+++ b/internal/adapter/presenter/BaccaratCuiPresenter.go
@@ -2,11 +2,13 @@ package presenter
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 // BaccaratCuiPresenter バカラCUIプレゼンタークラス
@@ -18,14 +20,13 @@ func (bp *BaccaratCuiPresenter) Output(b interfaces.BaccaratGame, lastErr error)
 	var sb strings.Builder
 
 	sb.WriteString("----------\n")
-	fmt.Fprintf(&sb, "chips: %d\n", b.GetChips())
-	fmt.Fprintf(&sb, "phase: %s\n", bp.phaseStr(b.GetPhase()))
+	fmt.Fprintf(&sb, "%s\n", i18n.Tf("baccarat.chipsLine", "chips", strconv.Itoa(b.GetChips())))
+	fmt.Fprintf(&sb, "%s\n", i18n.Tf("baccarat.phaseLine", "phase", bp.phaseStr(b.GetPhase())))
 
-	// プレイヤーハンド
 	playerHand := b.GetPlayerHand()
 	if len(playerHand) > 0 {
-		sb.WriteString("--- " + color.Bold("PLAYER") + " ---\n")
-		fmt.Fprintf(&sb, "value: %d\n", b.GetPlayerHandValue())
+		sb.WriteString("--- " + color.Bold(i18n.T("baccarat.playerHeader")) + " ---\n")
+		fmt.Fprintf(&sb, "%s\n", i18n.Tf("baccarat.valueLine", "value", strconv.Itoa(b.GetPlayerHandValue())))
 		parts := make([]string, len(playerHand))
 		for i, card := range playerHand {
 			parts[i] = cuiCardStr(card)
@@ -34,11 +35,10 @@ func (bp *BaccaratCuiPresenter) Output(b interfaces.BaccaratGame, lastErr error)
 		sb.WriteString("\n")
 	}
 
-	// バンカーハンド
 	bankerHand := b.GetBankerHand()
 	if len(bankerHand) > 0 {
-		sb.WriteString("--- " + color.Bold("BANKER") + " ---\n")
-		fmt.Fprintf(&sb, "value: %d\n", b.GetBankerHandValue())
+		sb.WriteString("--- " + color.Bold(i18n.T("baccarat.bankerHeader")) + " ---\n")
+		fmt.Fprintf(&sb, "%s\n", i18n.Tf("baccarat.valueLine", "value", strconv.Itoa(b.GetBankerHandValue())))
 		parts := make([]string, len(bankerHand))
 		for i, card := range bankerHand {
 			parts[i] = cuiCardStr(card)
@@ -49,24 +49,25 @@ func (bp *BaccaratCuiPresenter) Output(b interfaces.BaccaratGame, lastErr error)
 
 	sb.WriteString("----------\n")
 
-	// エラーメッセージ
 	if lastErr != nil {
 		fmt.Fprintf(&sb, "%s\n", color.Red(lastErr.Error()))
 	}
 
-	// ゲーム結果
 	if b.GetGameEndFlag() {
-		fmt.Fprintf(&sb, "bet: %d on %s\n", b.GetBetAmount(), bp.betTypeStr(b.GetBetType()))
+		fmt.Fprintf(&sb, "%s\n", i18n.Tf("baccarat.betLine",
+			"amount", strconv.Itoa(b.GetBetAmount()),
+			"type", bp.betTypeStr(b.GetBetType()),
+		))
 		switch b.GetResult() {
 		case domain.GameResultWin:
-			sb.WriteString(color.Green("Player wins!") + "\n")
+			sb.WriteString(color.Green(i18n.T("baccarat.playerWins")) + "\n")
 		case domain.GameResultLose:
-			sb.WriteString(color.Red("Banker wins!") + "\n")
+			sb.WriteString(color.Red(i18n.T("baccarat.bankerWins")) + "\n")
 		case domain.GameResultDraw:
-			sb.WriteString(color.Yellow("Tie!") + "\n")
+			sb.WriteString(color.Yellow(i18n.T("baccarat.tie")) + "\n")
 		default:
 		}
-		fmt.Fprintf(&sb, "payout: %d\n", b.GetPayout())
+		fmt.Fprintf(&sb, "%s\n", i18n.Tf("baccarat.payoutLine", "payout", strconv.Itoa(b.GetPayout())))
 		sb.WriteString("----------\n")
 	}
 
@@ -82,11 +83,11 @@ func (bp *BaccaratCuiPresenter) ActionLogOutput(b interfaces.BaccaratGame) strin
 func (bp *BaccaratCuiPresenter) phaseStr(phase int) string {
 	switch phase {
 	case domain.BaccaratPhaseBet:
-		return "BET"
+		return i18n.T("baccarat.phaseBet")
 	case domain.BaccaratPhaseEnd:
-		return "END"
+		return i18n.T("baccarat.phaseEnd")
 	default:
-		return "UNKNOWN"
+		return i18n.T("baccarat.phaseUnknown")
 	}
 }
 
@@ -94,12 +95,12 @@ func (bp *BaccaratCuiPresenter) phaseStr(phase int) string {
 func (bp *BaccaratCuiPresenter) betTypeStr(betType int) string {
 	switch betType {
 	case domain.BaccaratBetPlayer:
-		return "PLAYER"
+		return i18n.T("baccarat.betTypePlayer")
 	case domain.BaccaratBetBanker:
-		return "BANKER"
+		return i18n.T("baccarat.betTypeBanker")
 	case domain.BaccaratBetTie:
-		return "TIE"
+		return i18n.T("baccarat.betTypeTie")
 	default:
-		return "UNKNOWN"
+		return i18n.T("baccarat.betTypeUnknown")
 	}
 }

--- a/internal/adapter/presenter/BaccaratCuiPresenter.go
+++ b/internal/adapter/presenter/BaccaratCuiPresenter.go
@@ -1,7 +1,6 @@
 package presenter
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -20,13 +19,13 @@ func (bp *BaccaratCuiPresenter) Output(b interfaces.BaccaratGame, lastErr error)
 	var sb strings.Builder
 
 	sb.WriteString("----------\n")
-	fmt.Fprintf(&sb, "%s\n", i18n.Tf("baccarat.chipsLine", "chips", strconv.Itoa(b.GetChips())))
-	fmt.Fprintf(&sb, "%s\n", i18n.Tf("baccarat.phaseLine", "phase", bp.phaseStr(b.GetPhase())))
+	sb.WriteString(i18n.Tf("baccarat.chipsLine", "chips", strconv.Itoa(b.GetChips())) + "\n")
+	sb.WriteString(i18n.Tf("baccarat.phaseLine", "phase", bp.phaseStr(b.GetPhase())) + "\n")
 
 	playerHand := b.GetPlayerHand()
 	if len(playerHand) > 0 {
 		sb.WriteString("--- " + color.Bold(i18n.T("baccarat.playerHeader")) + " ---\n")
-		fmt.Fprintf(&sb, "%s\n", i18n.Tf("baccarat.valueLine", "value", strconv.Itoa(b.GetPlayerHandValue())))
+		sb.WriteString(i18n.Tf("baccarat.valueLine", "value", strconv.Itoa(b.GetPlayerHandValue())) + "\n")
 		parts := make([]string, len(playerHand))
 		for i, card := range playerHand {
 			parts[i] = cuiCardStr(card)
@@ -38,7 +37,7 @@ func (bp *BaccaratCuiPresenter) Output(b interfaces.BaccaratGame, lastErr error)
 	bankerHand := b.GetBankerHand()
 	if len(bankerHand) > 0 {
 		sb.WriteString("--- " + color.Bold(i18n.T("baccarat.bankerHeader")) + " ---\n")
-		fmt.Fprintf(&sb, "%s\n", i18n.Tf("baccarat.valueLine", "value", strconv.Itoa(b.GetBankerHandValue())))
+		sb.WriteString(i18n.Tf("baccarat.valueLine", "value", strconv.Itoa(b.GetBankerHandValue())) + "\n")
 		parts := make([]string, len(bankerHand))
 		for i, card := range bankerHand {
 			parts[i] = cuiCardStr(card)
@@ -50,14 +49,14 @@ func (bp *BaccaratCuiPresenter) Output(b interfaces.BaccaratGame, lastErr error)
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		fmt.Fprintf(&sb, "%s\n", color.Red(lastErr.Error()))
+		sb.WriteString(color.Red(lastErr.Error()) + "\n")
 	}
 
 	if b.GetGameEndFlag() {
-		fmt.Fprintf(&sb, "%s\n", i18n.Tf("baccarat.betLine",
+		sb.WriteString(i18n.Tf("baccarat.betLine",
 			"amount", strconv.Itoa(b.GetBetAmount()),
 			"type", bp.betTypeStr(b.GetBetType()),
-		))
+		) + "\n")
 		switch b.GetResult() {
 		case domain.GameResultWin:
 			sb.WriteString(color.Green(i18n.T("baccarat.playerWins")) + "\n")
@@ -67,7 +66,7 @@ func (bp *BaccaratCuiPresenter) Output(b interfaces.BaccaratGame, lastErr error)
 			sb.WriteString(color.Yellow(i18n.T("baccarat.tie")) + "\n")
 		default:
 		}
-		fmt.Fprintf(&sb, "%s\n", i18n.Tf("baccarat.payoutLine", "payout", strconv.Itoa(b.GetPayout())))
+		sb.WriteString(i18n.Tf("baccarat.payoutLine", "payout", strconv.Itoa(b.GetPayout())) + "\n")
 		sb.WriteString("----------\n")
 	}
 

--- a/internal/adapter/presenter/BaccaratCuiPresenter_test.go
+++ b/internal/adapter/presenter/BaccaratCuiPresenter_test.go
@@ -34,8 +34,8 @@ func TestBaccaratCuiPresenter_Output_BetPhase(t *testing.T) {
 	setupBaccaratCuiMockDefaults(m)
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "chips: 1000")
-	assert.Contains(t, result, "phase: BET")
+	assert.Contains(t, result, "チップ: 1000")
+	assert.Contains(t, result, "フェーズ: BET")
 }
 
 func TestBaccaratCuiPresenter_Output_EndPhase_PlayerWins(t *testing.T) {
@@ -64,11 +64,11 @@ func TestBaccaratCuiPresenter_Output_EndPhase_PlayerWins(t *testing.T) {
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "phase: END")
+	assert.Contains(t, result, "フェーズ: END")
 	assert.Contains(t, result, "PLAYER")
 	assert.Contains(t, result, "BANKER")
-	assert.Contains(t, result, "Player wins!")
-	assert.Contains(t, result, "payout: 200")
+	assert.Contains(t, result, "プレイヤーの勝ち")
+	assert.Contains(t, result, "払戻し: 200")
 	assert.Contains(t, result, "SPADE 9")
 }
 
@@ -96,7 +96,7 @@ func TestBaccaratCuiPresenter_Output_EndPhase_BankerWins(t *testing.T) {
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "Banker wins!")
+	assert.Contains(t, result, "バンカーの勝ち")
 	assert.Contains(t, result, "BANKER")
 }
 
@@ -124,7 +124,7 @@ func TestBaccaratCuiPresenter_Output_EndPhase_Tie(t *testing.T) {
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "Tie!")
+	assert.Contains(t, result, "タイ")
 	assert.Contains(t, result, "TIE")
 }
 
@@ -174,7 +174,7 @@ func TestBaccaratCuiPresenter_Output_EndPhase_UnknownResult(t *testing.T) {
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "payout: 0")
+	assert.Contains(t, result, "払戻し: 0")
 }
 
 func TestBaccaratCuiPresenter_Output_UnknownBetType(t *testing.T) {

--- a/internal/i18n/locales/en/baccarat.json
+++ b/internal/i18n/locales/en/baccarat.json
@@ -1,4 +1,21 @@
 {
   "helpTitle": "Baccarat",
-  "helpBet": "  b <amount> <type>    bet (type: 0=Player, 1=Banker, 2=Tie)"
+  "helpBet": "  b <amount> <type>    bet (type: 0=Player, 1=Banker, 2=Tie)",
+  "chipsLine": "chips: {{chips}}",
+  "phaseLine": "phase: {{phase}}",
+  "valueLine": "value: {{value}}",
+  "playerHeader": "PLAYER",
+  "bankerHeader": "BANKER",
+  "phaseBet": "BET",
+  "phaseEnd": "END",
+  "phaseUnknown": "UNKNOWN",
+  "betTypePlayer": "PLAYER",
+  "betTypeBanker": "BANKER",
+  "betTypeTie": "TIE",
+  "betTypeUnknown": "UNKNOWN",
+  "betLine": "bet: {{amount}} on {{type}}",
+  "playerWins": "Player wins!",
+  "bankerWins": "Banker wins!",
+  "tie": "Tie!",
+  "payoutLine": "payout: {{payout}}"
 }

--- a/internal/i18n/locales/ja/baccarat.json
+++ b/internal/i18n/locales/ja/baccarat.json
@@ -1,4 +1,21 @@
 {
   "helpTitle": "Baccarat (バカラ)",
-  "helpBet": "  b <amount> <type>    bet (type: 0=Player, 1=Banker, 2=Tie)"
+  "helpBet": "  b <amount> <type>    bet (type: 0=Player, 1=Banker, 2=Tie)",
+  "chipsLine": "チップ: {{chips}}",
+  "phaseLine": "フェーズ: {{phase}}",
+  "valueLine": "値: {{value}}",
+  "playerHeader": "PLAYER",
+  "bankerHeader": "BANKER",
+  "phaseBet": "BET",
+  "phaseEnd": "END",
+  "phaseUnknown": "UNKNOWN",
+  "betTypePlayer": "PLAYER",
+  "betTypeBanker": "BANKER",
+  "betTypeTie": "TIE",
+  "betTypeUnknown": "UNKNOWN",
+  "betLine": "ベット: {{amount}} ({{type}})",
+  "playerWins": "プレイヤーの勝ち！",
+  "bankerWins": "バンカーの勝ち！",
+  "tie": "タイ！",
+  "payoutLine": "払戻し: {{payout}}"
 }


### PR DESCRIPTION
Fourth of the 10 holdout presenters under #1699. Same pattern as #1782 (VideoPoker pilot) / #1783 (RedDog) / #1784 (CasinoWar).

## Changes

- **`internal/i18n/locales/{ja,en}/baccarat.json`** — added 18 keys: chipsLine / phaseLine / valueLine / playerHeader / bankerHeader / phase\* x3 / betType\* x4 / betLine / playerWins / bankerWins / tie / payoutLine.
- **`internal/adapter/presenter/BaccaratCuiPresenter.go`** — routed `Output()`, `phaseStr()`, and `betTypeStr()` through `i18n.T` / `i18n.Tf` with `strconv.Itoa`.
- **`internal/adapter/presenter/BaccaratCuiPresenter_test.go`** — updated assertions to the new JA output for localized lines.

## Localization choices

Same as #1783/#1784: phase codes (`BET` / `END` / `UNKNOWN`), bet-type codes (`PLAYER` / `BANKER` / `TIE` / `UNKNOWN`), and section headers (`PLAYER` / `BANKER`) are kept as **English short-codes on both sides** — opaque labels meant to read identically across locales.

## Verification

- `go test -tags test ./internal/adapter/presenter/...` — pass, incl. `TestNoJapaneseStringLiteralsInCuiPresenters`
- `golangci-lint run ./internal/adapter/presenter/...` — 0 issues
- `goimports -w` applied

## Remaining for #1699

6 ASCII-only presenters: BlackJack, CaribbeanStud, LetItRide, PaiGow, TexasHoldemBonus, ThreeCard.

Refs #1699