### PR TITLE
refactor(i18n): route PaiGowCuiPresenter output through i18n (#1699)

### DIFF
--- a/internal/adapter/presenter/PaiGowCuiPresenter.go
+++ b/internal/adapter/presenter/PaiGowCuiPresenter.go
@@ -2,11 +2,13 @@ package presenter
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 // PaiGowCuiPresenter パイガオポーカーCUIプレゼンタークラス
@@ -18,14 +20,13 @@ func (pp *PaiGowCuiPresenter) Output(pg interfaces.PaiGowGame, lastErr error) st
 	var sb strings.Builder
 
 	sb.WriteString("----------\n")
-	fmt.Fprintf(&sb, "chips: %d\n", pg.GetChips())
-	fmt.Fprintf(&sb, "phase: %s\n", pp.phaseStr(pg.GetPhase()))
+	fmt.Fprintf(&sb, "%s\n", i18n.Tf("paigow.chipsLine", "chips", strconv.Itoa(pg.GetChips())))
+	fmt.Fprintf(&sb, "%s\n", i18n.Tf("paigow.phaseLine", "phase", pp.phaseStr(pg.GetPhase())))
 
-	// プレイヤーカード
 	playerCards := pg.GetPlayerCards()
 	if len(playerCards) > 0 {
-		sb.WriteString("--- " + color.Bold("PLAYER") + " ---\n")
-		sb.WriteString("cards: ")
+		sb.WriteString("--- " + color.Bold(i18n.T("paigow.playerHeader")) + " ---\n")
+		sb.WriteString(i18n.T("paigow.cardsLabel"))
 		parts := make([]string, len(playerCards))
 		for i, c := range playerCards {
 			parts[i] = fmt.Sprintf("[%d]%s", i, cuiCardStr(c))
@@ -34,52 +35,59 @@ func (pp *PaiGowCuiPresenter) Output(pg interfaces.PaiGowGame, lastErr error) st
 		sb.WriteString("\n")
 	}
 
-	// ハイハンド・ローハンド（ENDフェーズ）
 	if pg.GetPhase() == domain.PaiGowPhaseEnd {
 		highHand := pg.GetPlayerHighHand()
 		if len(highHand) > 0 {
-			rank := pg.GetPlayerHighRank()
-			fmt.Fprintf(&sb, "  high: %s (%s)\n", cuiCardSliceStr(highHand), pp.highHandRankStr(rank))
+			fmt.Fprintf(&sb, "%s\n", i18n.Tf("paigow.highLine",
+				"cards", cuiCardSliceStr(highHand),
+				"rank", pp.highHandRankStr(pg.GetPlayerHighRank()),
+			))
 		}
 		lowHand := pg.GetPlayerLowHand()
 		if len(lowHand) > 0 {
-			rank := pg.GetPlayerLowRank()
-			fmt.Fprintf(&sb, "  low:  %s (%s)\n", cuiCardSliceStr(lowHand), pp.lowHandRankStr(rank))
+			fmt.Fprintf(&sb, "%s\n", i18n.Tf("paigow.lowLine",
+				"cards", cuiCardSliceStr(lowHand),
+				"rank", pp.lowHandRankStr(pg.GetPlayerLowRank()),
+			))
 		}
 
-		// ディーラー
-		sb.WriteString("--- " + color.Bold("DEALER") + " ---\n")
+		sb.WriteString("--- " + color.Bold(i18n.T("paigow.dealerHeader")) + " ---\n")
 		dealerHigh := pg.GetDealerHighHand()
 		if len(dealerHigh) > 0 {
-			rank := pg.GetDealerHighRank()
-			fmt.Fprintf(&sb, "  high: %s (%s)\n", cuiCardSliceStr(dealerHigh), pp.highHandRankStr(rank))
+			fmt.Fprintf(&sb, "%s\n", i18n.Tf("paigow.highLine",
+				"cards", cuiCardSliceStr(dealerHigh),
+				"rank", pp.highHandRankStr(pg.GetDealerHighRank()),
+			))
 		}
 		dealerLow := pg.GetDealerLowHand()
 		if len(dealerLow) > 0 {
-			rank := pg.GetDealerLowRank()
-			fmt.Fprintf(&sb, "  low:  %s (%s)\n", cuiCardSliceStr(dealerLow), pp.lowHandRankStr(rank))
+			fmt.Fprintf(&sb, "%s\n", i18n.Tf("paigow.lowLine",
+				"cards", cuiCardSliceStr(dealerLow),
+				"rank", pp.lowHandRankStr(pg.GetDealerLowRank()),
+			))
 		}
 	}
 
 	sb.WriteString("----------\n")
 
-	// エラーメッセージ
 	if lastErr != nil {
 		fmt.Fprintf(&sb, "%s\n", color.Red(lastErr.Error()))
 	}
 
-	// ゲーム結果
 	if pg.GetGameEndFlag() {
-		fmt.Fprintf(&sb, "bet: %d\n", pg.GetBet())
+		fmt.Fprintf(&sb, "%s\n", i18n.Tf("paigow.betLine", "bet", strconv.Itoa(pg.GetBet())))
 		switch pg.GetResult() {
 		case domain.GameResultWin:
-			sb.WriteString(color.Green("Player wins!") + "\n")
-			fmt.Fprintf(&sb, "payout: %d (commission: %d)\n", pg.GetPayout(), pg.GetCommission())
+			sb.WriteString(color.Green(i18n.T("paigow.playerWins")) + "\n")
+			fmt.Fprintf(&sb, "%s\n", i18n.Tf("paigow.payoutWithCommissionLine",
+				"payout", strconv.Itoa(pg.GetPayout()),
+				"commission", strconv.Itoa(pg.GetCommission()),
+			))
 		case domain.GameResultLose:
-			sb.WriteString(color.Red("Dealer wins!") + "\n")
+			sb.WriteString(color.Red(i18n.T("paigow.dealerWins")) + "\n")
 		case domain.GameResultDraw:
-			sb.WriteString(color.Yellow("Push!") + "\n")
-			fmt.Fprintf(&sb, "payout: %d\n", pg.GetPayout())
+			sb.WriteString(color.Yellow(i18n.T("paigow.push")) + "\n")
+			fmt.Fprintf(&sb, "%s\n", i18n.Tf("paigow.payoutLine", "payout", strconv.Itoa(pg.GetPayout())))
 		default:
 		}
 		sb.WriteString("----------\n")
@@ -97,13 +105,13 @@ func (pp *PaiGowCuiPresenter) ActionLogOutput(pg interfaces.PaiGowGame) string {
 func (pp *PaiGowCuiPresenter) phaseStr(phase int) string {
 	switch phase {
 	case domain.PaiGowPhaseBet:
-		return "BET"
+		return i18n.T("paigow.phaseBet")
 	case domain.PaiGowPhaseSetHands:
-		return "SET HANDS"
+		return i18n.T("paigow.phaseSetHands")
 	case domain.PaiGowPhaseEnd:
-		return "END"
+		return i18n.T("paigow.phaseEnd")
 	default:
-		return "UNKNOWN"
+		return i18n.T("paigow.phaseUnknown")
 	}
 }
 
@@ -112,7 +120,7 @@ func (pp *PaiGowCuiPresenter) highHandRankStr(rank int) string {
 	if rank >= 0 && rank < len(domain.PokerHandNames) {
 		return domain.PokerHandNames[rank]
 	}
-	return "Unknown"
+	return i18n.T("paigow.rankUnknown")
 }
 
 // lowHandRankStr ローハンドランク文字列
@@ -120,5 +128,5 @@ func (pp *PaiGowCuiPresenter) lowHandRankStr(rank int) string {
 	if rank >= 0 && rank < len(domain.PaiGowLowHandNames) {
 		return domain.PaiGowLowHandNames[rank]
 	}
-	return "Unknown"
+	return i18n.T("paigow.rankUnknown")
 }

--- a/internal/adapter/presenter/PaiGowCuiPresenter.go
+++ b/internal/adapter/presenter/PaiGowCuiPresenter.go
@@ -20,8 +20,8 @@ func (pp *PaiGowCuiPresenter) Output(pg interfaces.PaiGowGame, lastErr error) st
 	var sb strings.Builder
 
 	sb.WriteString("----------\n")
-	fmt.Fprintf(&sb, "%s\n", i18n.Tf("paigow.chipsLine", "chips", strconv.Itoa(pg.GetChips())))
-	fmt.Fprintf(&sb, "%s\n", i18n.Tf("paigow.phaseLine", "phase", pp.phaseStr(pg.GetPhase())))
+	sb.WriteString(i18n.Tf("paigow.chipsLine", "chips", strconv.Itoa(pg.GetChips())) + "\n")
+	sb.WriteString(i18n.Tf("paigow.phaseLine", "phase", pp.phaseStr(pg.GetPhase())) + "\n")
 
 	playerCards := pg.GetPlayerCards()
 	if len(playerCards) > 0 {
@@ -38,56 +38,56 @@ func (pp *PaiGowCuiPresenter) Output(pg interfaces.PaiGowGame, lastErr error) st
 	if pg.GetPhase() == domain.PaiGowPhaseEnd {
 		highHand := pg.GetPlayerHighHand()
 		if len(highHand) > 0 {
-			fmt.Fprintf(&sb, "%s\n", i18n.Tf("paigow.highLine",
+			sb.WriteString(i18n.Tf("paigow.highLine",
 				"cards", cuiCardSliceStr(highHand),
 				"rank", pp.highHandRankStr(pg.GetPlayerHighRank()),
-			))
+			) + "\n")
 		}
 		lowHand := pg.GetPlayerLowHand()
 		if len(lowHand) > 0 {
-			fmt.Fprintf(&sb, "%s\n", i18n.Tf("paigow.lowLine",
+			sb.WriteString(i18n.Tf("paigow.lowLine",
 				"cards", cuiCardSliceStr(lowHand),
 				"rank", pp.lowHandRankStr(pg.GetPlayerLowRank()),
-			))
+			) + "\n")
 		}
 
 		sb.WriteString("--- " + color.Bold(i18n.T("paigow.dealerHeader")) + " ---\n")
 		dealerHigh := pg.GetDealerHighHand()
 		if len(dealerHigh) > 0 {
-			fmt.Fprintf(&sb, "%s\n", i18n.Tf("paigow.highLine",
+			sb.WriteString(i18n.Tf("paigow.highLine",
 				"cards", cuiCardSliceStr(dealerHigh),
 				"rank", pp.highHandRankStr(pg.GetDealerHighRank()),
-			))
+			) + "\n")
 		}
 		dealerLow := pg.GetDealerLowHand()
 		if len(dealerLow) > 0 {
-			fmt.Fprintf(&sb, "%s\n", i18n.Tf("paigow.lowLine",
+			sb.WriteString(i18n.Tf("paigow.lowLine",
 				"cards", cuiCardSliceStr(dealerLow),
 				"rank", pp.lowHandRankStr(pg.GetDealerLowRank()),
-			))
+			) + "\n")
 		}
 	}
 
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
-		fmt.Fprintf(&sb, "%s\n", color.Red(lastErr.Error()))
+		sb.WriteString(color.Red(lastErr.Error()) + "\n")
 	}
 
 	if pg.GetGameEndFlag() {
-		fmt.Fprintf(&sb, "%s\n", i18n.Tf("paigow.betLine", "bet", strconv.Itoa(pg.GetBet())))
+		sb.WriteString(i18n.Tf("paigow.betLine", "bet", strconv.Itoa(pg.GetBet())) + "\n")
 		switch pg.GetResult() {
 		case domain.GameResultWin:
 			sb.WriteString(color.Green(i18n.T("paigow.playerWins")) + "\n")
-			fmt.Fprintf(&sb, "%s\n", i18n.Tf("paigow.payoutWithCommissionLine",
+			sb.WriteString(i18n.Tf("paigow.payoutWithCommissionLine",
 				"payout", strconv.Itoa(pg.GetPayout()),
 				"commission", strconv.Itoa(pg.GetCommission()),
-			))
+			) + "\n")
 		case domain.GameResultLose:
 			sb.WriteString(color.Red(i18n.T("paigow.dealerWins")) + "\n")
 		case domain.GameResultDraw:
 			sb.WriteString(color.Yellow(i18n.T("paigow.push")) + "\n")
-			fmt.Fprintf(&sb, "%s\n", i18n.Tf("paigow.payoutLine", "payout", strconv.Itoa(pg.GetPayout())))
+			sb.WriteString(i18n.Tf("paigow.payoutLine", "payout", strconv.Itoa(pg.GetPayout())) + "\n")
 		default:
 		}
 		sb.WriteString("----------\n")

--- a/internal/adapter/presenter/PaiGowCuiPresenter_test.go
+++ b/internal/adapter/presenter/PaiGowCuiPresenter_test.go
@@ -39,8 +39,8 @@ func TestPaiGowCuiPresenter_Output_BetPhase(t *testing.T) {
 	setupPaiGowCuiMockDefaults(m)
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "chips: 1000")
-	assert.Contains(t, result, "phase: BET")
+	assert.Contains(t, result, "チップ: 1000")
+	assert.Contains(t, result, "フェーズ: BET")
 }
 
 func TestPaiGowCuiPresenter_Output_SetHandsPhase(t *testing.T) {
@@ -76,7 +76,7 @@ func TestPaiGowCuiPresenter_Output_SetHandsPhase(t *testing.T) {
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "phase: SET HANDS")
+	assert.Contains(t, result, "フェーズ: SET HANDS")
 	assert.Contains(t, result, "[0]")
 	assert.Contains(t, result, "[6]")
 }
@@ -115,9 +115,9 @@ func TestPaiGowCuiPresenter_Output_PlayerWins(t *testing.T) {
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "Player wins!")
-	assert.Contains(t, result, "payout: 190")
-	assert.Contains(t, result, "commission: 10")
+	assert.Contains(t, result, "プレイヤーの勝ち")
+	assert.Contains(t, result, "払戻し: 190")
+	assert.Contains(t, result, "手数料: 10")
 }
 
 func TestPaiGowCuiPresenter_Output_DealerWins(t *testing.T) {
@@ -145,7 +145,7 @@ func TestPaiGowCuiPresenter_Output_DealerWins(t *testing.T) {
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "Dealer wins!")
+	assert.Contains(t, result, "ディーラーの勝ち")
 }
 
 func TestPaiGowCuiPresenter_Output_Push(t *testing.T) {
@@ -173,8 +173,8 @@ func TestPaiGowCuiPresenter_Output_Push(t *testing.T) {
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "Push!")
-	assert.Contains(t, result, "payout: 100")
+	assert.Contains(t, result, "プッシュ")
+	assert.Contains(t, result, "払戻し: 100")
 }
 
 func TestPaiGowCuiPresenter_Output_EndPhaseWithHands(t *testing.T) {
@@ -220,8 +220,8 @@ func TestPaiGowCuiPresenter_Output_EndPhaseWithHands(t *testing.T) {
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "high:")
-	assert.Contains(t, result, "low:")
+	assert.Contains(t, result, "ハイ:")
+	assert.Contains(t, result, "ロー:")
 	assert.Contains(t, result, "DEALER")
 	assert.Contains(t, result, "Straight")
 	assert.Contains(t, result, "High Card")

--- a/internal/i18n/locales/en/paigow.json
+++ b/internal/i18n/locales/en/paigow.json
@@ -1,5 +1,23 @@
 {
   "helpTitle": "Pai Gow Poker",
   "helpBet": "  b <amount>           bet",
-  "helpSet": "  s <idx1> <idx2>      set low hand (choose 2 card indices)"
+  "helpSet": "  s <idx1> <idx2>      set low hand (choose 2 card indices)",
+  "chipsLine": "chips: {{chips}}",
+  "phaseLine": "phase: {{phase}}",
+  "cardsLabel": "cards: ",
+  "highLine": "  high: {{cards}} ({{rank}})",
+  "lowLine": "  low:  {{cards}} ({{rank}})",
+  "playerHeader": "PLAYER",
+  "dealerHeader": "DEALER",
+  "phaseBet": "BET",
+  "phaseSetHands": "SET HANDS",
+  "phaseEnd": "END",
+  "phaseUnknown": "UNKNOWN",
+  "rankUnknown": "Unknown",
+  "betLine": "bet: {{bet}}",
+  "playerWins": "Player wins!",
+  "dealerWins": "Dealer wins!",
+  "push": "Push!",
+  "payoutLine": "payout: {{payout}}",
+  "payoutWithCommissionLine": "payout: {{payout}} (commission: {{commission}})"
 }

--- a/internal/i18n/locales/ja/paigow.json
+++ b/internal/i18n/locales/ja/paigow.json
@@ -1,5 +1,23 @@
 {
   "helpTitle": "Pai Gow Poker (パイガオポーカー)",
   "helpBet": "  b <金額>             ベット",
-  "helpSet": "  s <idx1> <idx2>      ローハンド設定 (カードのインデックスを2つ選択)"
+  "helpSet": "  s <idx1> <idx2>      ローハンド設定 (カードのインデックスを2つ選択)",
+  "chipsLine": "チップ: {{chips}}",
+  "phaseLine": "フェーズ: {{phase}}",
+  "cardsLabel": "カード: ",
+  "highLine": "  ハイ: {{cards}} ({{rank}})",
+  "lowLine": "  ロー: {{cards}} ({{rank}})",
+  "playerHeader": "PLAYER",
+  "dealerHeader": "DEALER",
+  "phaseBet": "BET",
+  "phaseSetHands": "SET HANDS",
+  "phaseEnd": "END",
+  "phaseUnknown": "UNKNOWN",
+  "rankUnknown": "Unknown",
+  "betLine": "ベット: {{bet}}",
+  "playerWins": "プレイヤーの勝ち！",
+  "dealerWins": "ディーラーの勝ち！",
+  "push": "プッシュ！",
+  "payoutLine": "払戻し: {{payout}}",
+  "payoutWithCommissionLine": "払戻し: {{payout}} (手数料: {{commission}})"
 }


### PR DESCRIPTION
Seventh of the 10 holdout presenters under #1699. Same pattern as #1782-#1787.

## Changes

- **`internal/i18n/locales/{ja,en}/paigow.json`** — added 21 keys covering chips/phase, the per-hand high/low rendering (`highLine`/`lowLine` with separate `cards` and `rank` substitutions), `betLine`, `payoutLine`, the variant `payoutWithCommissionLine`, `phaseSetHands`, and the `Unknown` rank fallback.
- **`internal/adapter/presenter/PaiGowCuiPresenter.go`** — routed `Output()`, `phaseStr()`, and the rank fallback through `i18n.T` / `i18n.Tf` with `strconv.Itoa`.
- **`internal/adapter/presenter/PaiGowCuiPresenter_test.go`** — updated assertions to the new JA output for localized lines.

## Localization choices

Same as previous PRs: phase codes (`BET` / `SET HANDS` / `END` / `UNKNOWN`), section headers (`PLAYER` / `DEALER`), and rank names (from `domain.PokerHandNames` and `domain.PaiGowLowHandNames`) stay English on both sides.

## Verification

- `go test -tags test ./internal/adapter/presenter/...` — pass, incl. `TestNoJapaneseStringLiteralsInCuiPresenters`
- `golangci-lint run ./internal/adapter/presenter/...` — 0 issues
- `goimports -w` applied

## Remaining for #1699

3 ASCII-only presenters: BlackJack, LetItRide, TexasHoldemBonus.

Refs #1699