### PR TITLE
refactor(i18n): route LetItRideCuiPresenter output through i18n (#1699)

### DIFF
--- a/internal/adapter/presenter/LetItRideCuiPresenter.go
+++ b/internal/adapter/presenter/LetItRideCuiPresenter.go
@@ -2,11 +2,13 @@ package presenter
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 // LetItRideCuiPresenter レット・イット・ライドCUIプレゼンタークラス
@@ -18,20 +20,23 @@ func (lp *LetItRideCuiPresenter) Output(lir interfaces.LetItRideGame, lastErr er
 	var sb strings.Builder
 
 	sb.WriteString("----------\n")
-	fmt.Fprintf(&sb, "chips: %d\n", lir.GetChips())
-	fmt.Fprintf(&sb, "phase: %s\n", lp.phaseStr(lir.GetPhase()))
+	fmt.Fprintf(&sb, "%s\n", i18n.Tf("letitride.chipsLine", "chips", strconv.Itoa(lir.GetChips())))
+	fmt.Fprintf(&sb, "%s\n", i18n.Tf("letitride.phaseLine", "phase", lp.phaseStr(lir.GetPhase())))
 
 	if lir.GetBetAmount() > 0 {
-		fmt.Fprintf(&sb, "bet: %d x %d active\n", lir.GetBetAmount(), lp.activeBetCount(lir))
+		fmt.Fprintf(&sb, "%s\n", i18n.Tf("letitride.betLine",
+			"amount", strconv.Itoa(lir.GetBetAmount()),
+			"active", strconv.Itoa(lp.activeBetCount(lir)),
+		))
 	}
 
 	playerHand := lir.GetPlayerHand()
 	if len(playerHand) > 0 {
-		sb.WriteString("--- " + color.Bold("PLAYER") + " ---\n")
+		sb.WriteString("--- " + color.Bold(i18n.T("letitride.playerHeader")) + " ---\n")
 		if lir.GetPhase() == domain.LetItRidePhaseEnd {
 			rank := lir.GetHandRank()
 			if rank >= 0 && rank < len(domain.PokerHandNames) {
-				fmt.Fprintf(&sb, "hand: %s\n", domain.PokerHandNames[rank])
+				fmt.Fprintf(&sb, "%s\n", i18n.Tf("letitride.handLine", "hand", domain.PokerHandNames[rank]))
 			}
 		}
 		parts := make([]string, len(playerHand))
@@ -44,7 +49,7 @@ func (lp *LetItRideCuiPresenter) Output(lir interfaces.LetItRideGame, lastErr er
 
 	communityCards := lir.GetCommunityCards()
 	if len(communityCards) > 0 {
-		sb.WriteString("--- " + color.Bold("COMMUNITY") + " ---\n")
+		sb.WriteString("--- " + color.Bold(i18n.T("letitride.communityHeader")) + " ---\n")
 		parts := make([]string, len(communityCards))
 		switch lir.GetPhase() {
 		case domain.LetItRidePhaseBet, domain.LetItRidePhaseFirstDecision:
@@ -72,18 +77,19 @@ func (lp *LetItRideCuiPresenter) Output(lir interfaces.LetItRideGame, lastErr er
 	}
 
 	if lir.GetGameEndFlag() {
-		fmt.Fprintf(&sb, "bet1: %s  bet2: %s  bet3: %s\n",
-			lp.betStatusStr(lir.GetBet1Active()),
-			lp.betStatusStr(lir.GetBet2Active()),
-			lp.betStatusStr(lir.GetBet3Active()))
+		fmt.Fprintf(&sb, "%s\n", i18n.Tf("letitride.betsLine",
+			"bet1", lp.betStatusStr(lir.GetBet1Active()),
+			"bet2", lp.betStatusStr(lir.GetBet2Active()),
+			"bet3", lp.betStatusStr(lir.GetBet3Active()),
+		))
 		switch lir.GetResult() {
 		case domain.GameResultWin:
-			sb.WriteString(color.Green("Player wins!") + "\n")
+			sb.WriteString(color.Green(i18n.T("letitride.playerWins")) + "\n")
 		case domain.GameResultLose:
-			sb.WriteString(color.Red("Player loses.") + "\n")
+			sb.WriteString(color.Red(i18n.T("letitride.playerLoses")) + "\n")
 		default:
 		}
-		fmt.Fprintf(&sb, "total payout: %d\n", lir.GetTotalPayout())
+		fmt.Fprintf(&sb, "%s\n", i18n.Tf("letitride.totalPayoutLine", "payout", strconv.Itoa(lir.GetTotalPayout())))
 		sb.WriteString("----------\n")
 	}
 
@@ -99,24 +105,24 @@ func (lp *LetItRideCuiPresenter) ActionLogOutput(lir interfaces.LetItRideGame) s
 func (lp *LetItRideCuiPresenter) phaseStr(phase int) string {
 	switch phase {
 	case domain.LetItRidePhaseBet:
-		return "BET"
+		return i18n.T("letitride.phaseBet")
 	case domain.LetItRidePhaseFirstDecision:
-		return "FIRST DECISION"
+		return i18n.T("letitride.phaseFirstDecision")
 	case domain.LetItRidePhaseSecondDecision:
-		return "SECOND DECISION"
+		return i18n.T("letitride.phaseSecondDecision")
 	case domain.LetItRidePhaseEnd:
-		return "END"
+		return i18n.T("letitride.phaseEnd")
 	default:
-		return "UNKNOWN"
+		return i18n.T("letitride.phaseUnknown")
 	}
 }
 
 // betStatusStr ベット状態文字列
 func (lp *LetItRideCuiPresenter) betStatusStr(active bool) string {
 	if active {
-		return color.Green("RIDE")
+		return color.Green(i18n.T("letitride.betStatusRide"))
 	}
-	return color.Yellow("PULL")
+	return color.Yellow(i18n.T("letitride.betStatusPull"))
 }
 
 // activeBetCount アクティブベット数

--- a/internal/adapter/presenter/LetItRideCuiPresenter_test.go
+++ b/internal/adapter/presenter/LetItRideCuiPresenter_test.go
@@ -36,7 +36,7 @@ func TestLetItRideCuiPresenter_Output_BetPhase(t *testing.T) {
 	setupLetItRideCuiMockDefaults(m)
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "chips: 1000")
+	assert.Contains(t, result, "チップ: 1000")
 	assert.Contains(t, result, "BET")
 }
 
@@ -134,8 +134,8 @@ func TestLetItRideCuiPresenter_Output_EndPhase_Win(t *testing.T) {
 	m.On("GetTotalPayout").Return(900)
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "Player wins!")
-	assert.Contains(t, result, "total payout: 900")
+	assert.Contains(t, result, "プレイヤーの勝ち")
+	assert.Contains(t, result, "合計払戻し: 900")
 }
 
 func TestLetItRideCuiPresenter_Output_EndPhase_Loss(t *testing.T) {
@@ -156,7 +156,7 @@ func TestLetItRideCuiPresenter_Output_EndPhase_Loss(t *testing.T) {
 	m.On("GetTotalPayout").Return(0)
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "Player loses.")
+	assert.Contains(t, result, "プレイヤーの負け")
 }
 
 func TestLetItRideCuiPresenter_Output_UnknownPhase(t *testing.T) {

--- a/internal/adapter/presenter/LetItRideCuiPresenter_test.go
+++ b/internal/adapter/presenter/LetItRideCuiPresenter_test.go
@@ -134,7 +134,7 @@ func TestLetItRideCuiPresenter_Output_EndPhase_Win(t *testing.T) {
 	m.On("GetTotalPayout").Return(900)
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "プレイヤーの勝ち")
+	assert.Contains(t, result, "プレイヤーの勝ち！")
 	assert.Contains(t, result, "合計払戻し: 900")
 }
 
@@ -156,7 +156,7 @@ func TestLetItRideCuiPresenter_Output_EndPhase_Loss(t *testing.T) {
 	m.On("GetTotalPayout").Return(0)
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "プレイヤーの負け")
+	assert.Contains(t, result, "プレイヤーの負け。")
 }
 
 func TestLetItRideCuiPresenter_Output_UnknownPhase(t *testing.T) {

--- a/internal/i18n/locales/en/letitride.json
+++ b/internal/i18n/locales/en/letitride.json
@@ -2,5 +2,22 @@
   "helpTitle": "Let It Ride",
   "helpBet": "  b <amount>           bet (places 3 equal bets)",
   "helpPull": "  p                    pull (withdraw current bet)",
-  "helpLetItRide": "  l                    let it ride (keep current bet)"
+  "helpLetItRide": "  l                    let it ride (keep current bet)",
+  "chipsLine": "chips: {{chips}}",
+  "phaseLine": "phase: {{phase}}",
+  "betLine": "bet: {{amount}} x {{active}} active",
+  "handLine": "hand: {{hand}}",
+  "betsLine": "bet1: {{bet1}}  bet2: {{bet2}}  bet3: {{bet3}}",
+  "playerHeader": "PLAYER",
+  "communityHeader": "COMMUNITY",
+  "phaseBet": "BET",
+  "phaseFirstDecision": "FIRST DECISION",
+  "phaseSecondDecision": "SECOND DECISION",
+  "phaseEnd": "END",
+  "phaseUnknown": "UNKNOWN",
+  "betStatusRide": "RIDE",
+  "betStatusPull": "PULL",
+  "playerWins": "Player wins!",
+  "playerLoses": "Player loses.",
+  "totalPayoutLine": "total payout: {{payout}}"
 }

--- a/internal/i18n/locales/ja/letitride.json
+++ b/internal/i18n/locales/ja/letitride.json
@@ -2,5 +2,22 @@
   "helpTitle": "Let It Ride (レット・イット・ライド)",
   "helpBet": "  b <金額>             ベット (3口分を賭ける)",
   "helpPull": "  p                    プル (ベットを取り下げる)",
-  "helpLetItRide": "  l                    レット・イット・ライド (ベットを維持)"
+  "helpLetItRide": "  l                    レット・イット・ライド (ベットを維持)",
+  "chipsLine": "チップ: {{chips}}",
+  "phaseLine": "フェーズ: {{phase}}",
+  "betLine": "ベット: {{amount}} x {{active}} アクティブ",
+  "handLine": "ハンド: {{hand}}",
+  "betsLine": "ベット1: {{bet1}}  ベット2: {{bet2}}  ベット3: {{bet3}}",
+  "playerHeader": "PLAYER",
+  "communityHeader": "COMMUNITY",
+  "phaseBet": "BET",
+  "phaseFirstDecision": "FIRST DECISION",
+  "phaseSecondDecision": "SECOND DECISION",
+  "phaseEnd": "END",
+  "phaseUnknown": "UNKNOWN",
+  "betStatusRide": "RIDE",
+  "betStatusPull": "PULL",
+  "playerWins": "プレイヤーの勝ち！",
+  "playerLoses": "プレイヤーの負け。",
+  "totalPayoutLine": "合計払戻し: {{payout}}"
 }


### PR DESCRIPTION
Ninth of the 10 holdout presenters under #1699. Same pattern as #1782-#1789.

## Changes

- **`internal/i18n/locales/{ja,en}/letitride.json`** — added 18 keys: chipsLine / phaseLine / betLine / handLine / betsLine / playerHeader / communityHeader / phase\* x5 / betStatus{Ride,Pull} / playerWins / playerLoses / totalPayoutLine.
- **`internal/adapter/presenter/LetItRideCuiPresenter.go`** — routed `Output()`, `phaseStr()`, and `betStatusStr()` through `i18n.T` / `i18n.Tf` with `strconv.Itoa`.
- **`internal/adapter/presenter/LetItRideCuiPresenter_test.go`** — updated assertions to the new JA output for localized lines.

## Localization choices

Same as previous PRs: phase codes, section headers (`PLAYER` / `COMMUNITY`), `RIDE` / `PULL` bet-status labels, the `??` hidden-card placeholder, and `PokerHandNames` stay English on both sides.

## Verification

- `go test -tags test ./internal/adapter/presenter/...` — pass, incl. `TestNoJapaneseStringLiteralsInCuiPresenters`
- `golangci-lint run ./internal/adapter/presenter/...` — 0 issues
- `goimports -w` applied

## Remaining for #1699

1 ASCII-only presenter: BlackJack (last and largest at 264 lines).

Refs #1699