### PR TITLE
refactor(cui): route IndianPokerCuiPresenter through buildCuiOutput (#1701)

### DIFF
--- a/internal/adapter/presenter/IndianPokerCuiPresenter.go
+++ b/internal/adapter/presenter/IndianPokerCuiPresenter.go
@@ -1,7 +1,6 @@
 package presenter
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -21,97 +20,89 @@ func (p *IndianPokerCuiPresenter) ActionLogOutput(ip interfaces.IndianPokerGame)
 
 // Output renders the current game state for the active locale (#1699).
 func (p *IndianPokerCuiPresenter) Output(ip interfaces.IndianPokerGame, lastErr error) string {
-	var b strings.Builder
+	return buildCuiOutput(i18n.T("indianpoker.outputTitle"), func(b *strings.Builder) {
+		b.WriteString(i18n.Tf("indianpoker.dealerLine", "idx", strconv.Itoa(ip.GetDealerIdx())) + "\n")
+		b.WriteString(i18n.Tf("indianpoker.potLine", "pot", strconv.Itoa(ip.GetPot())) + "\n")
 
-	b.WriteString("==========\n")
-	b.WriteString(i18n.T("indianpoker.outputTitle") + "\n")
-	b.WriteString("==========\n")
-
-	b.WriteString(i18n.Tf("indianpoker.dealerLine", "idx", strconv.Itoa(ip.GetDealerIdx())) + "\n")
-	b.WriteString(i18n.Tf("indianpoker.potLine", "pot", strconv.Itoa(ip.GetPot())) + "\n")
-
-	cfg := ip.GetConfig()
-	if int(cfg.BettingLimit) < len(domain.BettingLimitNames) {
-		b.WriteString(i18n.Tf("indianpoker.limitLine", "name", domain.BettingLimitNames[cfg.BettingLimit]) + "\n")
-	}
-
-	b.WriteString(i18n.Tf("indianpoker.anteLine", "ante", strconv.Itoa(cfg.Ante)) + "\n")
-
-	b.WriteString("----------\n")
-	isShowdown := ip.GetPhase() == domain.IndianPokerPhaseShowdown || ip.GetPhase() == domain.IndianPokerPhaseEnd
-	for i := 0; i < ip.GetPlayerCnt(); i++ {
-		player := ip.GetPlayer(i)
-		b.WriteString(cuiPlayerNameWithStyle(player, i))
-		b.WriteString(i18n.Tf("indianpoker.playerChips", "chips", strconv.Itoa(player.GetChips())))
-
-		if player.GetFolded() {
-			b.WriteString(color.BoldYellow(i18n.T("indianpoker.playerFolded")))
-		} else if player.GetAllIn() {
-			b.WriteString(color.BoldYellow(i18n.T("indianpoker.playerAllIn")))
+		cfg := ip.GetConfig()
+		if int(cfg.BettingLimit) < len(domain.BettingLimitNames) {
+			b.WriteString(i18n.Tf("indianpoker.limitLine", "name", domain.BettingLimitNames[cfg.BettingLimit]) + "\n")
 		}
 
-		if player.GetCurrentBet() > 0 {
-			b.WriteString(i18n.Tf("indianpoker.playerBet", "bet", strconv.Itoa(player.GetCurrentBet())))
-		}
-		b.WriteString("\n")
+		b.WriteString(i18n.Tf("indianpoker.anteLine", "ante", strconv.Itoa(cfg.Ante)) + "\n")
 
-		// Indian Poker: humans never see their own card until showdown,
-		// while CPU cards are always visible (everyone-but-yourself rule).
-		if player.GetCardsSize() > 0 {
-			if player.GetIsHuman() {
-				if isShowdown {
-					b.WriteString(i18n.Tf("indianpoker.cardLine", "card", cuiCardStrEmoji(player.GetCard(0))) + "\n")
-				} else {
-					b.WriteString(i18n.T("indianpoker.cardHidden") + "\n")
-				}
-			} else {
-				b.WriteString(i18n.Tf("indianpoker.cardLine", "card", cuiCardStrEmoji(player.GetCard(0))) + "\n")
-			}
-		}
-	}
-
-	cpuActions := ip.GetCpuActions()
-	if len(cpuActions) > 0 {
 		b.WriteString("----------\n")
-		b.WriteString(color.Bold(i18n.T("indianpoker.cpuActionsHeader")) + "\n")
-		for _, action := range cpuActions {
-			b.WriteString(i18n.Tf("indianpoker.cpuActionLine",
-				"idx", strconv.Itoa(action.PlayerIdx),
-				"action", cuiBettingActionName(action.Action)))
-			if action.Amount > 0 {
-				b.WriteString(i18n.Tf("indianpoker.cpuActionAmount", "amount", strconv.Itoa(action.Amount)))
+		isShowdown := ip.GetPhase() == domain.IndianPokerPhaseShowdown || ip.GetPhase() == domain.IndianPokerPhaseEnd
+		for i := 0; i < ip.GetPlayerCnt(); i++ {
+			player := ip.GetPlayer(i)
+			b.WriteString(cuiPlayerNameWithStyle(player, i))
+			b.WriteString(i18n.Tf("indianpoker.playerChips", "chips", strconv.Itoa(player.GetChips())))
+
+			if player.GetFolded() {
+				b.WriteString(color.BoldYellow(i18n.T("indianpoker.playerFolded")))
+			} else if player.GetAllIn() {
+				b.WriteString(color.BoldYellow(i18n.T("indianpoker.playerAllIn")))
+			}
+
+			if player.GetCurrentBet() > 0 {
+				b.WriteString(i18n.Tf("indianpoker.playerBet", "bet", strconv.Itoa(player.GetCurrentBet())))
 			}
 			b.WriteString("\n")
-		}
-	}
 
-	results := ip.GetRoundResults()
-	if len(results) > 0 && isShowdown {
-		b.WriteString("==========\n")
-		b.WriteString(color.Bold(i18n.T("indianpoker.resultsHeader")) + "\n")
-		for _, r := range results {
-			name := cuiPlayerName(ip.GetPlayer(r.PlayerIdx), r.PlayerIdx)
-			if r.Card != nil {
-				b.WriteString(i18n.Tf("indianpoker.resultCard",
-					"name", name,
-					"card", cuiCardStrEmoji(r.Card)))
-			} else {
-				b.WriteString(i18n.Tf("indianpoker.resultName", "name", name))
+			// Indian Poker: humans never see their own card until showdown,
+			// while CPU cards are always visible (everyone-but-yourself rule).
+			if player.GetCardsSize() > 0 {
+				if player.GetIsHuman() {
+					if isShowdown {
+						b.WriteString(i18n.Tf("indianpoker.cardLine", "card", cuiCardStrEmoji(player.GetCard(0))) + "\n")
+					} else {
+						b.WriteString(i18n.T("indianpoker.cardHidden") + "\n")
+					}
+				} else {
+					b.WriteString(i18n.Tf("indianpoker.cardLine", "card", cuiCardStrEmoji(player.GetCard(0))) + "\n")
+				}
 			}
-			if r.WonAmount > 0 {
-				b.WriteString(i18n.Tf("indianpoker.wonAmount", "total", strconv.Itoa(r.WonAmount)))
-			}
-			b.WriteString("\n")
 		}
-	}
 
-	if lastErr != nil {
-		fmt.Fprintf(&b, "%s\n", color.Red(lastErr.Error()))
-	}
+		cpuActions := ip.GetCpuActions()
+		if len(cpuActions) > 0 {
+			b.WriteString("----------\n")
+			b.WriteString(color.Bold(i18n.T("indianpoker.cpuActionsHeader")) + "\n")
+			for _, action := range cpuActions {
+				b.WriteString(i18n.Tf("indianpoker.cpuActionLine",
+					"idx", strconv.Itoa(action.PlayerIdx),
+					"action", cuiBettingActionName(action.Action)))
+				if action.Amount > 0 {
+					b.WriteString(i18n.Tf("indianpoker.cpuActionAmount", "amount", strconv.Itoa(action.Amount)))
+				}
+				b.WriteString("\n")
+			}
+		}
 
-	if ip.GetGameEndFlag() {
-		b.WriteString(i18n.T("indianpoker.gameEnd") + "\n")
-	}
+		results := ip.GetRoundResults()
+		if len(results) > 0 && isShowdown {
+			b.WriteString("==========\n")
+			b.WriteString(color.Bold(i18n.T("indianpoker.resultsHeader")) + "\n")
+			for _, r := range results {
+				name := cuiPlayerName(ip.GetPlayer(r.PlayerIdx), r.PlayerIdx)
+				if r.Card != nil {
+					b.WriteString(i18n.Tf("indianpoker.resultCard",
+						"name", name,
+						"card", cuiCardStrEmoji(r.Card)))
+				} else {
+					b.WriteString(i18n.Tf("indianpoker.resultName", "name", name))
+				}
+				if r.WonAmount > 0 {
+					b.WriteString(i18n.Tf("indianpoker.wonAmount", "total", strconv.Itoa(r.WonAmount)))
+				}
+				b.WriteString("\n")
+			}
+		}
 
-	return b.String()
+		cuiErrorBlock(b, lastErr)
+
+		if ip.GetGameEndFlag() {
+			b.WriteString(i18n.T("indianpoker.gameEnd") + "\n")
+		}
+	})
 }


### PR DESCRIPTION
Pilot for #1701 (CuiPresenter shell-helper consolidation).

## Scope correction vs. issue text

The issue describes 71 presenters with hand-rolled shells. Today on develop the actual state is:

| | |
|---|---|
| **52** of 71 | already use the existing `buildCuiOutput` helper (`internal/adapter/presenter/cui_output_helper.go`) ✓ |
| **9** of 71 | still hand-roll \`==========\n<title>\n==========\n...\n==========\n\` |
| **10** of 71 | use a different `----------` separator shape (the casino games — out of scope for this helper) |

So the actionable scope is **9 holdouts**, all poker-family (Badugi, Holdem, IndianPoker, Omaha, Pineapple, Poker, Sevens, ShortDeck, SevenCardStud). One PR per game, smallest first. **IndianPoker (117 lines) is the pilot.**

## Changes

- **`internal/adapter/presenter/IndianPokerCuiPresenter.go`** — wrapped `Output()` in `buildCuiOutput(i18n.T("indianpoker.outputTitle"), ...)`, removed the 3 hand-written `==========` writes, switched the error block to the existing `cuiErrorBlock(b, lastErr)` helper. `fmt` import becomes unused and is dropped.

## Visible output change

A trailing `==========\n` footer is now printed (the helper always closes with one). Previously this presenter ended without a footer — anomalous compared to the 52 migrated peers (Hearts, Spades, Spider, Klondike, etc.). Bringing it into alignment is part of the consolidation point.

Before:
\`\`\`
==========
Indian Poker
==========
<body>
[CPU行動]
  Player 1: チェック
  ...
\`\`\`
After:
\`\`\`
==========
Indian Poker
==========
<body>
[CPU行動]
  Player 1: チェック
  ...
==========
\`\`\`

## Verification

- `go test -tags test ./internal/adapter/presenter/...` — pass, incl. `TestNoJapaneseStringLiteralsInCuiPresenters`
- `golangci-lint run ./internal/adapter/presenter/...` — 0 issues
- `goimports -w` applied
- Manual smoke test via `go run ./cmd/trumpcards` confirms the shell renders correctly.

## Remaining for #1701

8 hand-rolled-shell presenters: Badugi, Holdem, Omaha, Pineapple, Poker, Sevens, ShortDeck, SevenCardStud.

The 10 `----------`-shaped casino presenters (just migrated to i18n in #1782-#1791) are intentionally **out of scope** — they don't fit the `buildCuiOutput` shape and the issue's "spec change risk" point doesn't apply (their shell is its own thing).

Refs #1701