### PR TITLE
refactor(cui): route PokerCuiPresenter through buildCuiOutput (#1701)

### DIFF
--- a/internal/adapter/presenter/PokerCuiPresenter.go
+++ b/internal/adapter/presenter/PokerCuiPresenter.go
@@ -16,130 +16,123 @@ type PokerCuiPresenter struct{}
 
 // Output renders the current game state for the active locale (#1699).
 func (pcp *PokerCuiPresenter) Output(p interfaces.PokerGame, lastErr error) string {
-	var b strings.Builder
-	players := p.GetPlayers()
-
-	b.WriteString("==========\n")
+	titleKey := "poker.outputTitle"
 	if p.GetConfig().IsLowball {
-		b.WriteString(i18n.T("poker.outputTitleLowball") + "\n")
-	} else {
-		b.WriteString(i18n.T("poker.outputTitle") + "\n")
+		titleKey = "poker.outputTitleLowball"
 	}
-	b.WriteString("==========\n")
+	return buildCuiOutput(i18n.T(titleKey), func(b *strings.Builder) {
+		players := p.GetPlayers()
 
-	b.WriteString(i18n.Tf("poker.dealerLine", "idx", strconv.Itoa(p.GetDealerIdx())) + "\n")
-	b.WriteString(i18n.Tf("poker.potLine", "pot", strconv.Itoa(p.GetPot())) + "\n")
+		b.WriteString(i18n.Tf("poker.dealerLine", "idx", strconv.Itoa(p.GetDealerIdx())) + "\n")
+		b.WriteString(i18n.Tf("poker.potLine", "pot", strconv.Itoa(p.GetPot())) + "\n")
 
-	if p.GetConfig().JokerCount > 0 {
-		b.WriteString(i18n.Tf("poker.jokerLine", "count", strconv.Itoa(p.GetConfig().JokerCount)) + "\n")
-	}
-
-	cfg := p.GetConfig()
-	if int(cfg.BettingLimit) < len(domain.BettingLimitNames) {
-		b.WriteString(i18n.Tf("poker.limitLine", "name", domain.BettingLimitNames[cfg.BettingLimit]) + "\n")
-	}
-
-	b.WriteString("----------\n")
-	isEnd := p.GetPhase() == domain.PokerPhaseEnd
-	for i, player := range players {
-		b.WriteString(cuiPlayerNameWithStyle(player, i))
-		b.WriteString(i18n.Tf("poker.playerChips", "chips", strconv.Itoa(player.GetChips())))
-
-		if player.GetFolded() {
-			b.WriteString(color.BoldYellow(i18n.T("poker.playerFolded")))
-		} else if player.GetAllIn() {
-			b.WriteString(color.BoldYellow(i18n.T("poker.playerAllIn")))
+		if p.GetConfig().JokerCount > 0 {
+			b.WriteString(i18n.Tf("poker.jokerLine", "count", strconv.Itoa(p.GetConfig().JokerCount)) + "\n")
 		}
 
-		if player.GetCurrentBet() > 0 {
-			b.WriteString(i18n.Tf("poker.playerBet", "bet", strconv.Itoa(player.GetCurrentBet())))
+		cfg := p.GetConfig()
+		if int(cfg.BettingLimit) < len(domain.BettingLimitNames) {
+			b.WriteString(i18n.Tf("poker.limitLine", "name", domain.BettingLimitNames[cfg.BettingLimit]) + "\n")
 		}
 
-		if player.GetExchangeCount() > 0 && (p.GetPhase() == domain.PokerPhaseSecondBet || isEnd) {
-			b.WriteString(i18n.Tf("poker.playerExchange", "count", strconv.Itoa(player.GetExchangeCount())))
-		}
-		b.WriteString("\n")
+		b.WriteString("----------\n")
+		isEnd := p.GetPhase() == domain.PokerPhaseEnd
+		for i, player := range players {
+			b.WriteString(cuiPlayerNameWithStyle(player, i))
+			b.WriteString(i18n.Tf("poker.playerChips", "chips", strconv.Itoa(player.GetChips())))
 
-		// Human's hand is always shown.
-		if player.GetIsHuman() && !player.GetFolded() {
-			handStr := cuiIndexedCardListStrEmoji(player)
-			if isEnd {
+			if player.GetFolded() {
+				b.WriteString(color.BoldYellow(i18n.T("poker.playerFolded")))
+			} else if player.GetAllIn() {
+				b.WriteString(color.BoldYellow(i18n.T("poker.playerAllIn")))
+			}
+
+			if player.GetCurrentBet() > 0 {
+				b.WriteString(i18n.Tf("poker.playerBet", "bet", strconv.Itoa(player.GetCurrentBet())))
+			}
+
+			if player.GetExchangeCount() > 0 && (p.GetPhase() == domain.PokerPhaseSecondBet || isEnd) {
+				b.WriteString(i18n.Tf("poker.playerExchange", "count", strconv.Itoa(player.GetExchangeCount())))
+			}
+			b.WriteString("\n")
+
+			// Human's hand is always shown.
+			if player.GetIsHuman() && !player.GetFolded() {
+				handStr := cuiIndexedCardListStrEmoji(player)
+				if isEnd {
+					b.WriteString(i18n.Tf("poker.humanHandWithName",
+						"cards", handStr,
+						"name", player.GetHandName()) + "\n")
+				} else {
+					b.WriteString(i18n.Tf("poker.humanHand", "cards", handStr) + "\n")
+				}
+			}
+
+			// CPU hands are revealed only at end-of-hand.
+			if !player.GetIsHuman() && isEnd && !player.GetFolded() {
 				b.WriteString(i18n.Tf("poker.humanHandWithName",
-					"cards", handStr,
+					"cards", cuiCardListStrEmoji(player),
 					"name", player.GetHandName()) + "\n")
-			} else {
-				b.WriteString(i18n.Tf("poker.humanHand", "cards", handStr) + "\n")
 			}
 		}
 
-		// CPU hands are revealed only at end-of-hand.
-		if !player.GetIsHuman() && isEnd && !player.GetFolded() {
-			b.WriteString(i18n.Tf("poker.humanHandWithName",
-				"cards", cuiCardListStrEmoji(player),
-				"name", player.GetHandName()) + "\n")
-		}
-	}
-
-	cpuActions := p.GetCpuActions()
-	if len(cpuActions) > 0 {
-		b.WriteString("----------\n")
-		b.WriteString(color.Bold(i18n.T("poker.cpuActionsHeader")) + "\n")
-		for _, action := range cpuActions {
-			b.WriteString(i18n.Tf("poker.cpuActionLine",
-				"idx", strconv.Itoa(action.PlayerIdx),
-				"action", cuiBettingActionName(action.Action)))
-			if action.Amount > 0 {
-				b.WriteString(i18n.Tf("poker.cpuActionAmount", "amount", strconv.Itoa(action.Amount)))
+		cpuActions := p.GetCpuActions()
+		if len(cpuActions) > 0 {
+			b.WriteString("----------\n")
+			b.WriteString(color.Bold(i18n.T("poker.cpuActionsHeader")) + "\n")
+			for _, action := range cpuActions {
+				b.WriteString(i18n.Tf("poker.cpuActionLine",
+					"idx", strconv.Itoa(action.PlayerIdx),
+					"action", cuiBettingActionName(action.Action)))
+				if action.Amount > 0 {
+					b.WriteString(i18n.Tf("poker.cpuActionAmount", "amount", strconv.Itoa(action.Amount)))
+				}
+				b.WriteString("\n")
 			}
-			b.WriteString("\n")
 		}
-	}
 
-	cpuExchanges := p.GetCpuExchanges()
-	if len(cpuExchanges) > 0 {
-		b.WriteString("----------\n")
-		b.WriteString(color.Bold(i18n.T("poker.cpuExchangesHeader")) + "\n")
-		for _, ex := range cpuExchanges {
-			b.WriteString(i18n.Tf("poker.cpuExchangeLine",
-				"idx", strconv.Itoa(ex.PlayerIdx),
-				"count", strconv.Itoa(ex.ExchangeCount)) + "\n")
+		cpuExchanges := p.GetCpuExchanges()
+		if len(cpuExchanges) > 0 {
+			b.WriteString("----------\n")
+			b.WriteString(color.Bold(i18n.T("poker.cpuExchangesHeader")) + "\n")
+			for _, ex := range cpuExchanges {
+				b.WriteString(i18n.Tf("poker.cpuExchangeLine",
+					"idx", strconv.Itoa(ex.PlayerIdx),
+					"count", strconv.Itoa(ex.ExchangeCount)) + "\n")
+			}
 		}
-	}
 
-	results := p.GetRoundResults()
-	if len(results) > 0 && isEnd {
-		b.WriteString("==========\n")
-		b.WriteString(color.Bold(i18n.T("poker.resultsHeader")) + "\n")
-		for _, r := range results {
-			name := cuiPlayerName(players[r.PlayerIdx], r.PlayerIdx)
-			kickers := ""
-			if ks := domain.FormatKickers(r.Kickers); ks != "" {
-				kickers = i18n.Tf("poker.resultKickers", "kickers", ks)
+		results := p.GetRoundResults()
+		if len(results) > 0 && isEnd {
+			b.WriteString("==========\n")
+			b.WriteString(color.Bold(i18n.T("poker.resultsHeader")) + "\n")
+			for _, r := range results {
+				name := cuiPlayerName(players[r.PlayerIdx], r.PlayerIdx)
+				kickers := ""
+				if ks := domain.FormatKickers(r.Kickers); ks != "" {
+					kickers = i18n.Tf("poker.resultKickers", "kickers", ks)
+				}
+				if r.HandName != "" {
+					b.WriteString(i18n.Tf("poker.resultHand",
+						"name", name,
+						"hand", r.HandName,
+						"kickers", kickers))
+				} else {
+					b.WriteString(i18n.Tf("poker.resultName", "name", name))
+				}
+				if r.WonAmount > 0 {
+					b.WriteString(i18n.Tf("poker.wonAmount", "total", strconv.Itoa(r.WonAmount)))
+				}
+				b.WriteString("\n")
 			}
-			if r.HandName != "" {
-				b.WriteString(i18n.Tf("poker.resultHand",
-					"name", name,
-					"hand", r.HandName,
-					"kickers", kickers))
-			} else {
-				b.WriteString(i18n.Tf("poker.resultName", "name", name))
-			}
-			if r.WonAmount > 0 {
-				b.WriteString(i18n.Tf("poker.wonAmount", "total", strconv.Itoa(r.WonAmount)))
-			}
-			b.WriteString("\n")
 		}
-	}
 
-	if lastErr != nil {
-		fmt.Fprintf(&b, "%s\n", color.Red(lastErr.Error()))
-	}
+		cuiErrorBlock(b, lastErr)
 
-	if p.GetGameEndFlag() {
-		b.WriteString(i18n.T("poker.gameEnd") + "\n")
-	}
-
-	return b.String()
+		if p.GetGameEndFlag() {
+			b.WriteString(i18n.T("poker.gameEnd") + "\n")
+		}
+	})
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.
@@ -148,13 +141,14 @@ func (pcp *PokerCuiPresenter) ActionLogOutput(p interfaces.PokerGame) string {
 }
 
 // OutputWithOdds appends the draw-odds table to the standard Output.
+// The base Output already ends with the buildCuiOutput "==========\n" footer,
+// so this appends only the odds-section body without a redundant divider.
 func (pcp *PokerCuiPresenter) OutputWithOdds(p interfaces.PokerGame, lastErr error, odds []domain.PokerDrawOdds) string {
 	base := pcp.Output(p, lastErr)
 	if len(odds) == 0 {
 		return base
 	}
 	var oddsBuilder strings.Builder
-	oddsBuilder.WriteString("==========\n")
 	oddsBuilder.WriteString(color.Bold(i18n.T("poker.drawOddsHeader")) + "\n")
 	for _, o := range odds {
 		oddsBuilder.WriteString(i18n.Tf("poker.drawOddsLine",


### PR DESCRIPTION
Third of the 9 hand-rolled-shell migrations under #1701 (after #1792 IndianPoker, #1793 Badugi).

## Changes

- `Output()` wrapped in `buildCuiOutput`. Title selection (lowball vs standard) hoisted into a local `titleKey` before the wrap so the helper still receives a single string.
- Error block uses `cuiErrorBlock(b, lastErr)`.
- **`OutputWithOdds()`** adjusted: it previously appended a separator `==========\n` then the odds header. Now that the base `Output()` ends with the `buildCuiOutput` footer (also `==========\n`), the redundant divider is dropped — odds section appends as a continuation.

## Visible change

- Trailing `==========\n` on `Output()` (matches the 52 migrated peers).
- `OutputWithOdds()` net-net: same divider count as before, just rearranged (base footer now serves as the divider, instead of an explicit one in the odds builder).

## Verification

- `go test -tags test ./internal/adapter/presenter/...` — pass, incl. `TestNoJapaneseStringLiteralsInCuiPresenters`
- `golangci-lint` — 0 issues

## Remaining for #1701

6: Holdem, Omaha, Pineapple, Sevens, ShortDeck, SevenCardStud.

Refs #1701