### PR TITLE
refactor(cui): route ShortDeckCuiPresenter through buildCuiOutput (#1701)

### DIFF
--- a/internal/adapter/presenter/ShortDeckCuiPresenter.go
+++ b/internal/adapter/presenter/ShortDeckCuiPresenter.go
@@ -1,7 +1,6 @@
 package presenter
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -21,156 +20,148 @@ func (p *ShortDeckCuiPresenter) ActionLogOutput(o interfaces.ShortDeckGame) stri
 
 // Output renders the current game state for the active locale (#1699).
 func (p *ShortDeckCuiPresenter) Output(o interfaces.ShortDeckGame, lastErr error) string {
-	var b strings.Builder
-
-	b.WriteString("==========\n")
-	b.WriteString(i18n.T("shortdeck.outputTitle") + "\n")
-	b.WriteString("==========\n")
-
-	cfg := o.GetConfig()
-	if cfg.TournamentMode {
-		b.WriteString(i18n.Tf("shortdeck.tournamentLine",
-			"hand", strconv.Itoa(o.GetHandCount()),
-			"sb", strconv.Itoa(cfg.SmallBlind),
-			"bb", strconv.Itoa(cfg.BigBlind),
-			"levelup", strconv.Itoa(cfg.BlindLevelHands)) + "\n")
-		if cfg.RebuyEnabled {
-			b.WriteString(i18n.Tf("shortdeck.rebuyLine",
-				"chips", strconv.Itoa(cfg.RebuyChips),
-				"max", strconv.Itoa(cfg.RebuyMaxCount),
-				"period", strconv.Itoa(cfg.RebuyPeriodHands)) + "\n")
-		}
-		if cfg.AddonEnabled {
-			b.WriteString(i18n.Tf("shortdeck.addonLine",
-				"chips", strconv.Itoa(cfg.AddonChips),
-				"after", strconv.Itoa(cfg.AddonAfterHand)) + "\n")
-		}
-	}
-
-	b.WriteString(i18n.Tf("shortdeck.tableMax", "n", strconv.Itoa(o.GetPlayerCnt())) + "\n")
-	b.WriteString(i18n.Tf("shortdeck.dealerLine", "idx", strconv.Itoa(o.GetDealerIdx())) + "\n")
-
-	cc := o.GetCommunityCards()
-	if len(cc) == 0 {
-		b.WriteString(i18n.T("shortdeck.communityNone") + "\n")
-	} else {
-		b.WriteString(i18n.Tf("shortdeck.communityCards", "cards", cuiCardSliceStrEmoji(cc)) + "\n")
-	}
-
-	b.WriteString(i18n.Tf("shortdeck.potLine", "pot", strconv.Itoa(o.GetPot())) + "\n")
-
-	if int(cfg.BettingLimit) < len(domain.BettingLimitNames) {
-		b.WriteString(i18n.Tf("shortdeck.limitLine", "name", domain.BettingLimitNames[cfg.BettingLimit]) + "\n")
-	}
-
-	b.WriteString("----------\n")
-	for i := 0; i < o.GetPlayerCnt(); i++ {
-		player := o.GetPlayer(i)
-		b.WriteString(cuiPlayerNameWithStyle(player, i))
-		b.WriteString(i18n.Tf("shortdeck.playerChips", "chips", strconv.Itoa(player.GetChips())))
-
-		if player.GetTotalHands() > 0 {
-			b.WriteString(i18n.Tf("shortdeck.playerStats",
-				"vpip", strconv.Itoa(player.GetVPIP()),
-				"pfr", strconv.Itoa(player.GetPFR()),
-				"tb", strconv.Itoa(player.GetThreeBet()),
-				"af", player.GetAFDisplay()))
-		}
-
-		if player.GetFolded() {
-			b.WriteString(color.BoldYellow(i18n.T("shortdeck.playerFolded")))
-		} else if player.GetAllIn() {
-			b.WriteString(color.BoldYellow(i18n.T("shortdeck.playerAllIn")))
-		}
-
-		if player.GetCurrentBet() > 0 {
-			b.WriteString(i18n.Tf("shortdeck.playerBet", "bet", strconv.Itoa(player.GetCurrentBet())))
-		}
-		b.WriteString("\n")
-
-		if player.GetIsHuman() && !player.GetFolded() {
-			b.WriteString(i18n.Tf("shortdeck.humanHand", "cards", cuiCardListStrEmoji(player)) + "\n")
-		}
-	}
-
-	cpuActions := o.GetCpuActions()
-	if len(cpuActions) > 0 {
-		b.WriteString("----------\n")
-		b.WriteString(color.Bold(i18n.T("shortdeck.cpuActionsHeader")) + "\n")
-		for _, action := range cpuActions {
-			b.WriteString(i18n.Tf("shortdeck.cpuActionLine",
-				"idx", strconv.Itoa(action.PlayerIdx),
-				"action", cuiBettingActionName(action.Action)))
-			if action.Amount > 0 {
-				b.WriteString(i18n.Tf("shortdeck.cpuActionAmount", "amount", strconv.Itoa(action.Amount)))
-			}
-			b.WriteString("\n")
-		}
-	}
-
-	results := o.GetRoundResults()
-	if len(results) > 0 && (o.GetPhase() == domain.ShortDeckPhaseEnd || o.GetPhase() == domain.ShortDeckPhaseShowdown) {
-		b.WriteString("==========\n")
-		b.WriteString(color.Bold(i18n.T("shortdeck.resultsHeader")) + "\n")
-		for _, r := range results {
-			name := cuiPlayerName(o.GetPlayer(r.PlayerIdx), r.PlayerIdx)
-			kickers := ""
-			if ks := domain.FormatKickers(r.Kickers); ks != "" {
-				kickers = i18n.Tf("shortdeck.resultKickers", "kickers", ks)
-			}
-			switch {
-			case r.Mucked:
-				b.WriteString(i18n.Tf("shortdeck.resultMucked", "name", name))
-			case r.HandName != "":
-				b.WriteString(i18n.Tf("shortdeck.resultHand",
-					"name", name,
-					"hand", r.HandName,
-					"kickers", kickers))
-			default:
-				b.WriteString(i18n.Tf("shortdeck.resultName", "name", name))
-			}
-			if r.WonAmount > 0 {
-				b.WriteString(i18n.Tf("shortdeck.wonAmount", "total", strconv.Itoa(r.WonAmount)))
-			}
-			b.WriteString("\n")
-		}
-	}
-
-	if o.IsMuckAvailable() {
-		b.WriteString("----------\n")
-		b.WriteString(i18n.T("shortdeck.muckPrompt") + "\n")
-	}
-
-	if o.GetPhase() == domain.ShortDeckPhaseRebuy {
-		b.WriteString("----------\n")
-		switch o.GetRebuyPhaseType() {
-		case domain.ShortDeckRebuyPhaseRebuy:
-			rebuyCounts := o.GetRebuyCounts()
-			humanIdx := -1
-			for i := 0; i < o.GetPlayerCnt(); i++ {
-				if o.GetPlayer(i).GetIsHuman() {
-					humanIdx = i
-					break
-				}
-			}
-			if humanIdx >= 0 {
-				b.WriteString(i18n.Tf("shortdeck.rebuyPrompt",
+	return buildCuiOutput(i18n.T("shortdeck.outputTitle"), func(b *strings.Builder) {
+		cfg := o.GetConfig()
+		if cfg.TournamentMode {
+			b.WriteString(i18n.Tf("shortdeck.tournamentLine",
+				"hand", strconv.Itoa(o.GetHandCount()),
+				"sb", strconv.Itoa(cfg.SmallBlind),
+				"bb", strconv.Itoa(cfg.BigBlind),
+				"levelup", strconv.Itoa(cfg.BlindLevelHands)) + "\n")
+			if cfg.RebuyEnabled {
+				b.WriteString(i18n.Tf("shortdeck.rebuyLine",
 					"chips", strconv.Itoa(cfg.RebuyChips),
-					"used", strconv.Itoa(rebuyCounts[humanIdx]),
-					"max", strconv.Itoa(cfg.RebuyMaxCount)) + "\n")
+					"max", strconv.Itoa(cfg.RebuyMaxCount),
+					"period", strconv.Itoa(cfg.RebuyPeriodHands)) + "\n")
 			}
-		case domain.ShortDeckRebuyPhaseAddon:
-			b.WriteString(i18n.Tf("shortdeck.addonPrompt", "chips", strconv.Itoa(cfg.AddonChips)) + "\n")
+			if cfg.AddonEnabled {
+				b.WriteString(i18n.Tf("shortdeck.addonLine",
+					"chips", strconv.Itoa(cfg.AddonChips),
+					"after", strconv.Itoa(cfg.AddonAfterHand)) + "\n")
+			}
 		}
-	}
 
-	if lastErr != nil {
-		fmt.Fprintf(&b, "%s\n", color.Red(lastErr.Error()))
-	}
+		b.WriteString(i18n.Tf("shortdeck.tableMax", "n", strconv.Itoa(o.GetPlayerCnt())) + "\n")
+		b.WriteString(i18n.Tf("shortdeck.dealerLine", "idx", strconv.Itoa(o.GetDealerIdx())) + "\n")
 
-	if o.GetGameEndFlag() {
-		b.WriteString(i18n.T("shortdeck.gameEnd") + "\n")
-	}
+		cc := o.GetCommunityCards()
+		if len(cc) == 0 {
+			b.WriteString(i18n.T("shortdeck.communityNone") + "\n")
+		} else {
+			b.WriteString(i18n.Tf("shortdeck.communityCards", "cards", cuiCardSliceStrEmoji(cc)) + "\n")
+		}
 
-	return b.String()
+		b.WriteString(i18n.Tf("shortdeck.potLine", "pot", strconv.Itoa(o.GetPot())) + "\n")
+
+		if int(cfg.BettingLimit) < len(domain.BettingLimitNames) {
+			b.WriteString(i18n.Tf("shortdeck.limitLine", "name", domain.BettingLimitNames[cfg.BettingLimit]) + "\n")
+		}
+
+		b.WriteString("----------\n")
+		for i := 0; i < o.GetPlayerCnt(); i++ {
+			player := o.GetPlayer(i)
+			b.WriteString(cuiPlayerNameWithStyle(player, i))
+			b.WriteString(i18n.Tf("shortdeck.playerChips", "chips", strconv.Itoa(player.GetChips())))
+
+			if player.GetTotalHands() > 0 {
+				b.WriteString(i18n.Tf("shortdeck.playerStats",
+					"vpip", strconv.Itoa(player.GetVPIP()),
+					"pfr", strconv.Itoa(player.GetPFR()),
+					"tb", strconv.Itoa(player.GetThreeBet()),
+					"af", player.GetAFDisplay()))
+			}
+
+			if player.GetFolded() {
+				b.WriteString(color.BoldYellow(i18n.T("shortdeck.playerFolded")))
+			} else if player.GetAllIn() {
+				b.WriteString(color.BoldYellow(i18n.T("shortdeck.playerAllIn")))
+			}
+
+			if player.GetCurrentBet() > 0 {
+				b.WriteString(i18n.Tf("shortdeck.playerBet", "bet", strconv.Itoa(player.GetCurrentBet())))
+			}
+			b.WriteString("\n")
+
+			if player.GetIsHuman() && !player.GetFolded() {
+				b.WriteString(i18n.Tf("shortdeck.humanHand", "cards", cuiCardListStrEmoji(player)) + "\n")
+			}
+		}
+
+		cpuActions := o.GetCpuActions()
+		if len(cpuActions) > 0 {
+			b.WriteString("----------\n")
+			b.WriteString(color.Bold(i18n.T("shortdeck.cpuActionsHeader")) + "\n")
+			for _, action := range cpuActions {
+				b.WriteString(i18n.Tf("shortdeck.cpuActionLine",
+					"idx", strconv.Itoa(action.PlayerIdx),
+					"action", cuiBettingActionName(action.Action)))
+				if action.Amount > 0 {
+					b.WriteString(i18n.Tf("shortdeck.cpuActionAmount", "amount", strconv.Itoa(action.Amount)))
+				}
+				b.WriteString("\n")
+			}
+		}
+
+		results := o.GetRoundResults()
+		if len(results) > 0 && (o.GetPhase() == domain.ShortDeckPhaseEnd || o.GetPhase() == domain.ShortDeckPhaseShowdown) {
+			b.WriteString("==========\n")
+			b.WriteString(color.Bold(i18n.T("shortdeck.resultsHeader")) + "\n")
+			for _, r := range results {
+				name := cuiPlayerName(o.GetPlayer(r.PlayerIdx), r.PlayerIdx)
+				kickers := ""
+				if ks := domain.FormatKickers(r.Kickers); ks != "" {
+					kickers = i18n.Tf("shortdeck.resultKickers", "kickers", ks)
+				}
+				switch {
+				case r.Mucked:
+					b.WriteString(i18n.Tf("shortdeck.resultMucked", "name", name))
+				case r.HandName != "":
+					b.WriteString(i18n.Tf("shortdeck.resultHand",
+						"name", name,
+						"hand", r.HandName,
+						"kickers", kickers))
+				default:
+					b.WriteString(i18n.Tf("shortdeck.resultName", "name", name))
+				}
+				if r.WonAmount > 0 {
+					b.WriteString(i18n.Tf("shortdeck.wonAmount", "total", strconv.Itoa(r.WonAmount)))
+				}
+				b.WriteString("\n")
+			}
+		}
+
+		if o.IsMuckAvailable() {
+			b.WriteString("----------\n")
+			b.WriteString(i18n.T("shortdeck.muckPrompt") + "\n")
+		}
+
+		if o.GetPhase() == domain.ShortDeckPhaseRebuy {
+			b.WriteString("----------\n")
+			switch o.GetRebuyPhaseType() {
+			case domain.ShortDeckRebuyPhaseRebuy:
+				rebuyCounts := o.GetRebuyCounts()
+				humanIdx := -1
+				for i := 0; i < o.GetPlayerCnt(); i++ {
+					if o.GetPlayer(i).GetIsHuman() {
+						humanIdx = i
+						break
+					}
+				}
+				if humanIdx >= 0 {
+					b.WriteString(i18n.Tf("shortdeck.rebuyPrompt",
+						"chips", strconv.Itoa(cfg.RebuyChips),
+						"used", strconv.Itoa(rebuyCounts[humanIdx]),
+						"max", strconv.Itoa(cfg.RebuyMaxCount)) + "\n")
+				}
+			case domain.ShortDeckRebuyPhaseAddon:
+				b.WriteString(i18n.Tf("shortdeck.addonPrompt", "chips", strconv.Itoa(cfg.AddonChips)) + "\n")
+			}
+		}
+
+		cuiErrorBlock(b, lastErr)
+
+		if o.GetGameEndFlag() {
+			b.WriteString(i18n.T("shortdeck.gameEnd") + "\n")
+		}
+	})
 }


### PR DESCRIPTION
Fifth of the 9 hand-rolled-shell migrations under #1701. Mirror of #1795 (Holdem) — ShortDeck shares the same structure.

Visible change: trailing `==========\n` footer.

Verification: `go test -tags test`, `golangci-lint` — both green.

Remaining: Omaha, Pineapple, Sevens, SevenCardStud.

Refs #1701