### PR TITLE
refactor(cui): route PineappleCuiPresenter through buildCuiOutput (#1701)

### DIFF
--- a/internal/adapter/presenter/PineappleCuiPresenter.go
+++ b/internal/adapter/presenter/PineappleCuiPresenter.go
@@ -1,7 +1,6 @@
 package presenter
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -21,162 +20,154 @@ func (pp *PineappleCuiPresenter) ActionLogOutput(p interfaces.PineappleGame) str
 
 // Output renders the current game state for the active locale (#1699).
 func (pp *PineappleCuiPresenter) Output(p interfaces.PineappleGame, lastErr error) string {
-	var b strings.Builder
-
-	b.WriteString("==========\n")
-	b.WriteString(i18n.T("pineapple.helpTitle") + "\n")
-	b.WriteString("==========\n")
-
-	cfg := p.GetConfig()
-	if cfg.TournamentMode {
-		b.WriteString(i18n.Tf("pineapple.tournamentLine",
-			"hand", strconv.Itoa(p.GetHandCount()),
-			"sb", strconv.Itoa(cfg.SmallBlind),
-			"bb", strconv.Itoa(cfg.BigBlind),
-			"levelup", strconv.Itoa(cfg.BlindLevelHands)) + "\n")
-		if cfg.RebuyEnabled {
-			b.WriteString(i18n.Tf("pineapple.rebuyLine",
-				"chips", strconv.Itoa(cfg.RebuyChips),
-				"max", strconv.Itoa(cfg.RebuyMaxCount),
-				"period", strconv.Itoa(cfg.RebuyPeriodHands)) + "\n")
-		}
-		if cfg.AddonEnabled {
-			b.WriteString(i18n.Tf("pineapple.addonLine",
-				"chips", strconv.Itoa(cfg.AddonChips),
-				"after", strconv.Itoa(cfg.AddonAfterHand)) + "\n")
-		}
-	}
-
-	b.WriteString(i18n.Tf("pineapple.tableMax", "n", strconv.Itoa(p.GetPlayerCnt())) + "\n")
-	b.WriteString(i18n.Tf("pineapple.dealerLine", "idx", strconv.Itoa(p.GetDealerIdx())) + "\n")
-
-	cc := p.GetCommunityCards()
-	if len(cc) == 0 {
-		b.WriteString(i18n.T("pineapple.communityNone") + "\n")
-	} else {
-		b.WriteString(i18n.Tf("pineapple.communityCards", "cards", cuiCardSliceStrEmoji(cc)) + "\n")
-	}
-
-	b.WriteString(i18n.Tf("pineapple.potLine", "pot", strconv.Itoa(p.GetPot())) + "\n")
-
-	if int(cfg.BettingLimit) < len(domain.BettingLimitNames) {
-		b.WriteString(i18n.Tf("pineapple.limitLine", "name", domain.BettingLimitNames[cfg.BettingLimit]) + "\n")
-	}
-
-	b.WriteString("----------\n")
-	for i := 0; i < p.GetPlayerCnt(); i++ {
-		player := p.GetPlayer(i)
-		b.WriteString(cuiPlayerNameWithStyle(player, i))
-		b.WriteString(i18n.Tf("pineapple.playerChips", "chips", strconv.Itoa(player.GetChips())))
-
-		if player.GetTotalHands() > 0 {
-			b.WriteString(i18n.Tf("pineapple.playerStats",
-				"vpip", strconv.Itoa(player.GetVPIP()),
-				"pfr", strconv.Itoa(player.GetPFR()),
-				"tb", strconv.Itoa(player.GetThreeBet()),
-				"af", player.GetAFDisplay()))
-		}
-
-		if player.GetFolded() {
-			b.WriteString(color.BoldYellow(i18n.T("pineapple.playerFolded")))
-		} else if player.GetAllIn() {
-			b.WriteString(color.BoldYellow(i18n.T("pineapple.playerAllIn")))
-		}
-
-		if player.GetCurrentBet() > 0 {
-			b.WriteString(i18n.Tf("pineapple.playerBet", "bet", strconv.Itoa(player.GetCurrentBet())))
-		}
-		b.WriteString("\n")
-
-		if player.GetIsHuman() && !player.GetFolded() {
-			b.WriteString(i18n.Tf("pineapple.humanHand", "cards", cuiCardListStrEmoji(player)) + "\n")
-		}
-	}
-
-	cpuActions := p.GetCpuActions()
-	if len(cpuActions) > 0 {
-		b.WriteString("----------\n")
-		b.WriteString(color.Bold(i18n.T("pineapple.cpuActionsHeader")) + "\n")
-		for _, action := range cpuActions {
-			b.WriteString(i18n.Tf("pineapple.cpuActionLine",
-				"idx", strconv.Itoa(action.PlayerIdx),
-				"action", cuiBettingActionName(action.Action)))
-			if action.Amount > 0 {
-				b.WriteString(i18n.Tf("pineapple.cpuActionAmount", "amount", strconv.Itoa(action.Amount)))
-			}
-			b.WriteString("\n")
-		}
-	}
-
-	if p.GetPhase() == domain.PineapplePhaseDiscard {
-		b.WriteString("----------\n")
-		b.WriteString(i18n.T("pineapple.discardHeader") + "\n")
-		b.WriteString(i18n.T("pineapple.discardPrompt") + "\n")
-	}
-
-	results := p.GetRoundResults()
-	if len(results) > 0 && (p.GetPhase() == domain.PineapplePhaseEnd || p.GetPhase() == domain.PineapplePhaseShowdown) {
-		b.WriteString("==========\n")
-		b.WriteString(color.Bold(i18n.T("pineapple.resultsHeader")) + "\n")
-		for _, r := range results {
-			name := cuiPlayerName(p.GetPlayer(r.PlayerIdx), r.PlayerIdx)
-			kickers := ""
-			if ks := domain.FormatKickers(r.Kickers); ks != "" {
-				kickers = i18n.Tf("pineapple.resultKickers", "kickers", ks)
-			}
-			switch {
-			case r.Mucked:
-				b.WriteString(i18n.Tf("pineapple.resultMucked", "name", name))
-			case r.HandName != "":
-				b.WriteString(i18n.Tf("pineapple.resultHand",
-					"name", name,
-					"hand", r.HandName,
-					"kickers", kickers))
-			default:
-				b.WriteString(i18n.Tf("pineapple.resultName", "name", name))
-			}
-			if r.WonAmount > 0 {
-				b.WriteString(i18n.Tf("pineapple.wonAmount", "total", strconv.Itoa(r.WonAmount)))
-			}
-			b.WriteString("\n")
-		}
-	}
-
-	if p.IsMuckAvailable() {
-		b.WriteString("----------\n")
-		b.WriteString(i18n.T("pineapple.muckPrompt") + "\n")
-	}
-
-	if p.GetPhase() == domain.PineapplePhaseRebuy {
-		b.WriteString("----------\n")
-		switch p.GetRebuyPhaseType() {
-		case domain.PineappleRebuyPhaseRebuy:
-			rebuyCounts := p.GetRebuyCounts()
-			humanIdx := -1
-			for i := 0; i < p.GetPlayerCnt(); i++ {
-				if p.GetPlayer(i).GetIsHuman() {
-					humanIdx = i
-					break
-				}
-			}
-			if humanIdx >= 0 {
-				b.WriteString(i18n.Tf("pineapple.rebuyPrompt",
+	return buildCuiOutput(i18n.T("pineapple.helpTitle"), func(b *strings.Builder) {
+		cfg := p.GetConfig()
+		if cfg.TournamentMode {
+			b.WriteString(i18n.Tf("pineapple.tournamentLine",
+				"hand", strconv.Itoa(p.GetHandCount()),
+				"sb", strconv.Itoa(cfg.SmallBlind),
+				"bb", strconv.Itoa(cfg.BigBlind),
+				"levelup", strconv.Itoa(cfg.BlindLevelHands)) + "\n")
+			if cfg.RebuyEnabled {
+				b.WriteString(i18n.Tf("pineapple.rebuyLine",
 					"chips", strconv.Itoa(cfg.RebuyChips),
-					"used", strconv.Itoa(rebuyCounts[humanIdx]),
-					"max", strconv.Itoa(cfg.RebuyMaxCount)) + "\n")
+					"max", strconv.Itoa(cfg.RebuyMaxCount),
+					"period", strconv.Itoa(cfg.RebuyPeriodHands)) + "\n")
 			}
-		case domain.PineappleRebuyPhaseAddon:
-			b.WriteString(i18n.Tf("pineapple.addonPrompt", "chips", strconv.Itoa(cfg.AddonChips)) + "\n")
+			if cfg.AddonEnabled {
+				b.WriteString(i18n.Tf("pineapple.addonLine",
+					"chips", strconv.Itoa(cfg.AddonChips),
+					"after", strconv.Itoa(cfg.AddonAfterHand)) + "\n")
+			}
 		}
-	}
 
-	if lastErr != nil {
-		fmt.Fprintf(&b, "%s\n", color.Red(lastErr.Error()))
-	}
+		b.WriteString(i18n.Tf("pineapple.tableMax", "n", strconv.Itoa(p.GetPlayerCnt())) + "\n")
+		b.WriteString(i18n.Tf("pineapple.dealerLine", "idx", strconv.Itoa(p.GetDealerIdx())) + "\n")
 
-	if p.GetGameEndFlag() {
-		b.WriteString(i18n.T("pineapple.gameEnd") + "\n")
-	}
+		cc := p.GetCommunityCards()
+		if len(cc) == 0 {
+			b.WriteString(i18n.T("pineapple.communityNone") + "\n")
+		} else {
+			b.WriteString(i18n.Tf("pineapple.communityCards", "cards", cuiCardSliceStrEmoji(cc)) + "\n")
+		}
 
-	return b.String()
+		b.WriteString(i18n.Tf("pineapple.potLine", "pot", strconv.Itoa(p.GetPot())) + "\n")
+
+		if int(cfg.BettingLimit) < len(domain.BettingLimitNames) {
+			b.WriteString(i18n.Tf("pineapple.limitLine", "name", domain.BettingLimitNames[cfg.BettingLimit]) + "\n")
+		}
+
+		b.WriteString("----------\n")
+		for i := 0; i < p.GetPlayerCnt(); i++ {
+			player := p.GetPlayer(i)
+			b.WriteString(cuiPlayerNameWithStyle(player, i))
+			b.WriteString(i18n.Tf("pineapple.playerChips", "chips", strconv.Itoa(player.GetChips())))
+
+			if player.GetTotalHands() > 0 {
+				b.WriteString(i18n.Tf("pineapple.playerStats",
+					"vpip", strconv.Itoa(player.GetVPIP()),
+					"pfr", strconv.Itoa(player.GetPFR()),
+					"tb", strconv.Itoa(player.GetThreeBet()),
+					"af", player.GetAFDisplay()))
+			}
+
+			if player.GetFolded() {
+				b.WriteString(color.BoldYellow(i18n.T("pineapple.playerFolded")))
+			} else if player.GetAllIn() {
+				b.WriteString(color.BoldYellow(i18n.T("pineapple.playerAllIn")))
+			}
+
+			if player.GetCurrentBet() > 0 {
+				b.WriteString(i18n.Tf("pineapple.playerBet", "bet", strconv.Itoa(player.GetCurrentBet())))
+			}
+			b.WriteString("\n")
+
+			if player.GetIsHuman() && !player.GetFolded() {
+				b.WriteString(i18n.Tf("pineapple.humanHand", "cards", cuiCardListStrEmoji(player)) + "\n")
+			}
+		}
+
+		cpuActions := p.GetCpuActions()
+		if len(cpuActions) > 0 {
+			b.WriteString("----------\n")
+			b.WriteString(color.Bold(i18n.T("pineapple.cpuActionsHeader")) + "\n")
+			for _, action := range cpuActions {
+				b.WriteString(i18n.Tf("pineapple.cpuActionLine",
+					"idx", strconv.Itoa(action.PlayerIdx),
+					"action", cuiBettingActionName(action.Action)))
+				if action.Amount > 0 {
+					b.WriteString(i18n.Tf("pineapple.cpuActionAmount", "amount", strconv.Itoa(action.Amount)))
+				}
+				b.WriteString("\n")
+			}
+		}
+
+		if p.GetPhase() == domain.PineapplePhaseDiscard {
+			b.WriteString("----------\n")
+			b.WriteString(i18n.T("pineapple.discardHeader") + "\n")
+			b.WriteString(i18n.T("pineapple.discardPrompt") + "\n")
+		}
+
+		results := p.GetRoundResults()
+		if len(results) > 0 && (p.GetPhase() == domain.PineapplePhaseEnd || p.GetPhase() == domain.PineapplePhaseShowdown) {
+			b.WriteString("==========\n")
+			b.WriteString(color.Bold(i18n.T("pineapple.resultsHeader")) + "\n")
+			for _, r := range results {
+				name := cuiPlayerName(p.GetPlayer(r.PlayerIdx), r.PlayerIdx)
+				kickers := ""
+				if ks := domain.FormatKickers(r.Kickers); ks != "" {
+					kickers = i18n.Tf("pineapple.resultKickers", "kickers", ks)
+				}
+				switch {
+				case r.Mucked:
+					b.WriteString(i18n.Tf("pineapple.resultMucked", "name", name))
+				case r.HandName != "":
+					b.WriteString(i18n.Tf("pineapple.resultHand",
+						"name", name,
+						"hand", r.HandName,
+						"kickers", kickers))
+				default:
+					b.WriteString(i18n.Tf("pineapple.resultName", "name", name))
+				}
+				if r.WonAmount > 0 {
+					b.WriteString(i18n.Tf("pineapple.wonAmount", "total", strconv.Itoa(r.WonAmount)))
+				}
+				b.WriteString("\n")
+			}
+		}
+
+		if p.IsMuckAvailable() {
+			b.WriteString("----------\n")
+			b.WriteString(i18n.T("pineapple.muckPrompt") + "\n")
+		}
+
+		if p.GetPhase() == domain.PineapplePhaseRebuy {
+			b.WriteString("----------\n")
+			switch p.GetRebuyPhaseType() {
+			case domain.PineappleRebuyPhaseRebuy:
+				rebuyCounts := p.GetRebuyCounts()
+				humanIdx := -1
+				for i := 0; i < p.GetPlayerCnt(); i++ {
+					if p.GetPlayer(i).GetIsHuman() {
+						humanIdx = i
+						break
+					}
+				}
+				if humanIdx >= 0 {
+					b.WriteString(i18n.Tf("pineapple.rebuyPrompt",
+						"chips", strconv.Itoa(cfg.RebuyChips),
+						"used", strconv.Itoa(rebuyCounts[humanIdx]),
+						"max", strconv.Itoa(cfg.RebuyMaxCount)) + "\n")
+				}
+			case domain.PineappleRebuyPhaseAddon:
+				b.WriteString(i18n.Tf("pineapple.addonPrompt", "chips", strconv.Itoa(cfg.AddonChips)) + "\n")
+			}
+		}
+
+		cuiErrorBlock(b, lastErr)
+
+		if p.GetGameEndFlag() {
+			b.WriteString(i18n.T("pineapple.gameEnd") + "\n")
+		}
+	})
 }


### PR DESCRIPTION
Sixth of the 9 hand-rolled-shell migrations under #1701. Pineapple shares the Holdem/ShortDeck structure (community cards, tournament mode, rebuy) plus its own discard-phase prompt.

Visible change: trailing `==========\n` footer.

Verification: `go test`, `golangci-lint` — both green.

Remaining: Omaha, Sevens, SevenCardStud.

Refs #1701