### PR TITLE
refactor(cui): route SevensCuiPresenter through buildCuiOutput (closes #1701)

### DIFF
--- a/internal/adapter/presenter/SevensCuiPresenter.go
+++ b/internal/adapter/presenter/SevensCuiPresenter.go
@@ -1,7 +1,6 @@
 package presenter
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -120,74 +119,76 @@ func (p *SevensCuiPresenter) ActionLogOutput(s interfaces.SevensGame) string {
 
 // Output renders the current game state for the active locale (#1699).
 func (p *SevensCuiPresenter) Output(s interfaces.SevensGame, lastErr error) string {
-	var b strings.Builder
-
-	b.WriteString("==========\n")
-	b.WriteString(i18n.T("sevens.helpTitle") + "\n")
 	config := s.GetConfig()
-	sevensRuleLabels(&b, &config)
-	b.WriteString("==========\n")
 
-	for i := 0; i < s.GetPlayerCnt(); i++ {
-		b.WriteString(sevensPlayerStr(s.GetPlayer(i), i))
+	// The original output put rule badges between the title and the mid-divider
+	// (inside the header block). buildCuiOutput appends "\n" after the title, so
+	// we splice the rules in right after the title and trim the trailing "\n"
+	// that sevensRuleLabels adds, to avoid a blank line before the mid-divider.
+	title := i18n.T("sevens.helpTitle")
+	var rb strings.Builder
+	sevensRuleLabels(&rb, &config)
+	if rules := strings.TrimRight(rb.String(), "\n"); rules != "" {
+		title = title + "\n" + rules
 	}
 
-	b.WriteString("----------\n")
-
-	// Board state
-	b.WriteString(i18n.T("sevens.boardLabel") + "\n")
-	suits := []int{domain.CardDesignSpade, domain.CardDesignClover, domain.CardDesignHeart, domain.CardDesignDiamond}
-	suitNames := []string{"SPADE", "CLOVER", "HEART", "DIAMOND"}
-	mins := s.GetTableMinVals()
-	maxs := s.GetTableMaxVals()
-	for i, suit := range suits {
-		b.WriteString(i18n.Tf("sevens.boardSuitRange",
-			"suit", suitNames[i],
-			"min", strconv.Itoa(mins[suit]),
-			"max", strconv.Itoa(maxs[suit])) + "\n")
-	}
-
-	// Human's previous action
-	humanAction := s.GetHumanAction()
-	if humanAction != nil {
-		b.WriteString(sevensActionStr(cuiPlayerName(s.GetPlayer(humanAction.PlayerIdx), humanAction.PlayerIdx), humanAction))
-	}
-
-	// CPU action history
-	cpuActions := s.GetCpuActions()
-	if len(cpuActions) > 0 {
-		b.WriteString(color.Bold(i18n.T("sevens.cpuActionsLabel")) + "\n")
-		for _, action := range cpuActions {
-			actPlayerName := cuiPlayerName(s.GetPlayer(action.PlayerIdx), action.PlayerIdx)
-			b.WriteString(sevensActionStr(actPlayerName, action))
-		}
-	}
-
-	if lastErr != nil {
-		fmt.Fprintf(&b, "%s\n", color.Red(lastErr.Error()))
-	}
-
-	if s.GetGameEndFlag() {
-		b.WriteString(i18n.T("sevens.gameEnd") + "\n")
+	return buildCuiOutput(title, func(b *strings.Builder) {
 		for i := 0; i < s.GetPlayerCnt(); i++ {
-			player := s.GetPlayer(i)
-			if player == nil {
-				continue
-			}
-			b.WriteString(i18n.Tf("sevens.rankLine",
-				"name", cuiPlayerName(player, i),
-				"rank", strconv.Itoa(player.GetRank())) + "\n")
+			b.WriteString(sevensPlayerStr(s.GetPlayer(i), i))
 		}
-	} else {
-		currentTurn := s.GetCurrentTurn()
-		currentName := cuiPlayerName(s.GetPlayer(currentTurn), currentTurn)
-		b.WriteString(i18n.Tf("sevens.turnLine", "name", currentName) + "\n")
-		b.WriteString(i18n.T("sevens.playHint") + "\n")
-		if config.JokerCount > 0 {
-			b.WriteString(i18n.T("sevens.jokerHint") + "\n")
-		}
-	}
 
-	b.WriteString("==========\n")
-	return b.String()
+		b.WriteString("----------\n")
+
+		// Board state
+		b.WriteString(i18n.T("sevens.boardLabel") + "\n")
+		suits := []int{domain.CardDesignSpade, domain.CardDesignClover, domain.CardDesignHeart, domain.CardDesignDiamond}
+		suitNames := []string{"SPADE", "CLOVER", "HEART", "DIAMOND"}
+		mins := s.GetTableMinVals()
+		maxs := s.GetTableMaxVals()
+		for i, suit := range suits {
+			b.WriteString(i18n.Tf("sevens.boardSuitRange",
+				"suit", suitNames[i],
+				"min", strconv.Itoa(mins[suit]),
+				"max", strconv.Itoa(maxs[suit])) + "\n")
+		}
+
+		// Human's previous action
+		humanAction := s.GetHumanAction()
+		if humanAction != nil {
+			b.WriteString(sevensActionStr(cuiPlayerName(s.GetPlayer(humanAction.PlayerIdx), humanAction.PlayerIdx), humanAction))
+		}
+
+		// CPU action history
+		cpuActions := s.GetCpuActions()
+		if len(cpuActions) > 0 {
+			b.WriteString(color.Bold(i18n.T("sevens.cpuActionsLabel")) + "\n")
+			for _, action := range cpuActions {
+				actPlayerName := cuiPlayerName(s.GetPlayer(action.PlayerIdx), action.PlayerIdx)
+				b.WriteString(sevensActionStr(actPlayerName, action))
+			}
+		}
+
+		cuiErrorBlock(b, lastErr)
+
+		if s.GetGameEndFlag() {
+			b.WriteString(i18n.T("sevens.gameEnd") + "\n")
+			for i := 0; i < s.GetPlayerCnt(); i++ {
+				player := s.GetPlayer(i)
+				if player == nil {
+					continue
+				}
+				b.WriteString(i18n.Tf("sevens.rankLine",
+					"name", cuiPlayerName(player, i),
+					"rank", strconv.Itoa(player.GetRank())) + "\n")
+			}
+		} else {
+			currentTurn := s.GetCurrentTurn()
+			currentName := cuiPlayerName(s.GetPlayer(currentTurn), currentTurn)
+			b.WriteString(i18n.Tf("sevens.turnLine", "name", currentName) + "\n")
+			b.WriteString(i18n.T("sevens.playHint") + "\n")
+			if config.JokerCount > 0 {
+				b.WriteString(i18n.T("sevens.jokerHint") + "\n")
+			}
+		}
+	})
 }


### PR DESCRIPTION
**Final (9/9)** of the hand-rolled-shell migrations under #1701. After this lands, all 71 CuiPresenters either route through `buildCuiOutput` (61 — these 9 + the 52 originally migrated) or use the casino-style \`----------\` shell (10, intentionally left out of scope).

## Sevens-specific complication

Sevens is the trickiest of the 9 because it inserts the "Rules:" badge line **between the title and the mid-divider** — inside the header block:

\`\`\`
==========
Sevens (7並べ)
ルール: [トンネル] [ジョーカー1枚]   ← inside the header
==========
<body>
==========
\`\`\`

\`buildCuiOutput\`'s shape is \`==========\n<title>\n==========\n<body>\n==========\n\`, which doesn't natively support extra header lines. To preserve the original layout, the rule labels are **spliced into the title argument** with the trailing newline trimmed:

\`\`\`go
title := i18n.T(\"sevens.helpTitle\")
var rb strings.Builder
sevensRuleLabels(&rb, &config)
if rules := strings.TrimRight(rb.String(), \"\n\"); rules != \"\" {
    title = title + \"\n\" + rules
}
return buildCuiOutput(title, ...)
\`\`\`

This keeps rule badges visually attached to the title (in the header block, before the mid-divider) exactly as before.

## Visible output change

**None.** Sevens is the only one of the 9 that already had a trailing footer (line 191 of the pre-refactor file), so this migration is purely a shell-helper substitution.

## Verification

- \`go test -tags test ./internal/adapter/presenter/...\` — pass, incl. \`TestNoJapaneseStringLiteralsInCuiPresenters\`
- \`golangci-lint\` — 0 issues
- Manual smoke test: \`echo \"switch sevens\\nquit\" | go run ./cmd/trumpcards\` produces output identical to develop.

## #1701 status after this lands

| Sub-PR | Presenter | Status |
|---|---|---|
| #1792 | IndianPoker (pilot) | open |
| #1793 | Badugi | open |
| #1794 | Poker | open |
| #1795 | Holdem | open |
| #1796 | ShortDeck | open |
| #1797 | Pineapple | open |
| #1798 | SevenCardStud | open |
| #1799 | Omaha | open |
| #1800 | Sevens (this PR, closes #1701) | open |

61/71 CuiPresenters route through buildCuiOutput. 10 casino-style presenters use the \`----------\` shape (out of scope).

Closes #1701