### PR TITLE
docs: fix game-count drift in design docs and code comments

### DIFF
--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -6,7 +6,7 @@
 
 - [1. クラス図](#1-クラス図)
   - [1.1 コアドメイン (カード・プレイヤー)](#11-コアドメイン-カードプレイヤー)
-  - [1.2 ゲームドメイン (全81ゲーム)](#12-ゲームドメイン-全81ゲーム)
+  - [1.2 ゲームドメイン (全86ゲーム)](#12-ゲームドメイン-全86ゲーム)
   - [1.3 ユースケース層 (Interactor・Presenter)](#13-ユースケース層-interactorpresenter)
   - [1.4 アダプタ層 (Controller・Presenter実装)](#14-アダプタ層-controllerpresenter実装)
   - [1.5 インフラストラクチャ層](#15-インフラストラクチャ層)
@@ -149,7 +149,7 @@ classDiagram
     GamePlayer *-- ChipHolder : mixin
 ```
 
-### 1.2 ゲームドメイン (全81ゲーム)
+### 1.2 ゲームドメイン (全86ゲーム)
 
 #### ベッティング系ゲーム
 
@@ -1544,7 +1544,7 @@ classDiagram
     note for GamePresenter "各ゲームの Presenter は\nGamePresenter[G] の型エイリアス\nまたは拡張インターフェース"
 ```
 
-**Interactor パターン (全81ゲーム共通)**
+**Interactor パターン (全86ゲーム共通)**
 
 ```mermaid
 classDiagram
@@ -1616,8 +1616,8 @@ classDiagram
     GameCuiPresenter ..|> GamePresenter : implements
     GameWebPresenter ..|> GamePresenter : implements
 
-    note for GameCuiController "81ゲーム × CUI/Web = 162 Controller\nGameCuiController / GameWebController は\n各ゲーム毎に具体的な実装が存在"
-    note for GameCuiPresenter "81ゲーム × CUI/Web = 162 Presenter 実装"
+    note for GameCuiController "86ゲーム × CUI/Web = 172 Controller\nGameCuiController / GameWebController は\n各ゲーム毎に具体的な実装が存在"
+    note for GameCuiPresenter "86ゲーム × CUI/Web = 172 Presenter 実装"
 ```
 
 ### 1.5 インフラストラクチャ層
@@ -1684,8 +1684,8 @@ classDiagram
         +Exec(input string) string
     }
 
-    TrumpCardsWeb --> "*" GameWebController : holds 81 controllers
-    GameManager --> "*" CuiExecer : holds 81 games
+    TrumpCardsWeb --> "*" GameWebController : holds 86 controllers
+    GameManager --> "*" CuiExecer : holds 86 games
     GameCui ..|> CuiExecer : implements
     GameCui --> GameCuiController : delegates
 ```

--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -431,7 +431,7 @@ classDiagram
         +object messageParams
     }
 
-    note for BlackJackResponse "各ゲームが固有のResponse型を持つ\n(全81ゲーム分存在)\n共通フィールド: message, messageCode, messageParams"
+    note for BlackJackResponse "各ゲームが固有のResponse型を持つ\n(全86ゲーム分存在)\n共通フィールド: message, messageCode, messageParams"
 ```
 
 **フェーズ定数 (全ゲーム)**
@@ -851,7 +851,7 @@ classDiagram
     class actionLogApi {
         +blackjack() Promise~ActionLogResponse~
         +poker() Promise~ActionLogResponse~
-        ...全81ゲーム()
+        ...全86ゲーム()
     }
 
     BlackJackApi --> gameApi : uses postJson/gameExec
@@ -913,7 +913,7 @@ classDiagram
 
     RedDogApi --> gameApi : uses postJson/gameExec
 
-    note for BlackJackApi "全81ゲーム分のAPI Objectが存在\n(blackjack, spanish21, poker, oldmaid, daifugo,\nsevens, doubt, holdem, omaha, omahahilo, shortdeck,\npineapple, crazypineapple, hearts, memory, klondike, freecell,\nbaccarat, spades, twotenjack, crazyeights, ginrummy, canasta,\nspider, napoleon, indianpoker, videopoker,\ndeuceswild, jokerpoker, euchre, pyramid, tripeaks,\ncribbage, threecard, caribbeanstud, texasholdembonus, ohhell, bridge, speed,\ngofish, pinochle, golf, pigtail,\nsevencardstud, clocksolitaire, durak,\nfortythieves, paigow, war, canfield, fiftyone, yukon, russiansolitaire, scorpion, accordion, whist,\nletitride, pokersquares, pageone, reddog, razz, badugi, trash,\nsevenbridge, president, cassino, calculation, spiteandmalice,\nskat, shithead, nertz, slapjack, egyptianratscrew, bakersdozen, tonk,\ncasinowar, pitch, dragontiger, blackjackswitch, montecarlo, contractrummy)"
+    note for BlackJackApi "全86ゲーム分のAPI Objectが存在\n(blackjack, spanish21, poker, oldmaid, daifugo,\nsevens, doubt, holdem, omaha, omahahilo, shortdeck,\npineapple, crazypineapple, hearts, memory, klondike, freecell,\nbaccarat, spades, twotenjack, crazyeights, ginrummy, canasta,\nspider, spiderette, napoleon, indianpoker, videopoker,\ndeuceswild, jokerpoker, euchre, pyramid, tripeaks,\ncribbage, threecard, caribbeanstud, texasholdembonus,\nultimatetexasholdem, mississippistud, ohhell, bridge, speed,\ngofish, pinochle, golf, pigtail,\nsevencardstud, clocksolitaire, durak,\nfortythieves, paigow, war, canfield, fiftyone, yukon, russiansolitaire, scorpion, accordion, whist,\nletitride, pokersquares, pageone, reddog, razz, badugi, trash,\nsevenbridge, president, cassino, calculation, crescent, spiteandmalice,\nskat, shithead, nertz, slapjack, egyptianratscrew, bakersdozen, tonk,\ncasinowar, pitch, dragontiger, blackjackswitch, montecarlo, contractrummy, belote)"
 ```
 
 ### 1.3 Hook 層 (共通Hook)
@@ -1292,7 +1292,7 @@ classDiagram
 
     useCanastaGame --> useGameApi : uses
 
-    note for useBlackJackGame "全81ゲーム分の固有Hookが存在\n各HookはuseGameApiで統一的にAPI呼出し\n必要に応じてuseCardSelectionを合成"
+    note for useBlackJackGame "全86ゲーム分の固有Hookが存在\n各HookはuseGameApiで統一的にAPI呼出し\n必要に応じてuseCardSelectionを合成"
 ```
 
 ### 1.5 コンポーネント層
@@ -1874,7 +1874,7 @@ classDiagram
     GamePage --> PokerTableLayout : renders (Hold'em/Omaha/ShortDeck/Pineapple/SevenCardStud/Razz)
     PokerTableLayout --> CpuPlayerCard : wraps
 
-    note for GamePage "全81ゲームページが同一パターンで構成\nuseGamePageSetup → ゲーム固有Hook → 描画"
+    note for GamePage "全86ゲームページが同一パターンで構成\nuseGamePageSetup → ゲーム固有Hook → 描画"
 ```
 
 ### 1.7 i18n・プロバイダー・ルーティング
@@ -1897,7 +1897,7 @@ classDiagram
         +HashRouter
         +ErrorBoundary
         +NavBar
-        +Routes (81ゲーム)
+        +Routes (86ゲーム)
     }
 
     class gameCategories {
@@ -1924,7 +1924,7 @@ classDiagram
     GamePage --> TutorialProvider : wraps (per-game)
     TutorialProvider --> TutorialOverlay : renders when active
 
-    note for i18n "83名前空間: common + 81ゲーム固有 + tutorial\n翻訳ファイル: locales/{ja,en}/game.json"
+    note for i18n "88名前空間: common + 86ゲーム固有 + tutorial\n翻訳ファイル: locales/{ja,en}/game.json"
 ```
 
 ---

--- a/frontend/src/hooks/useCategoryExpansion.ts
+++ b/frontend/src/hooks/useCategoryExpansion.ts
@@ -30,7 +30,7 @@ function readMap(): ExpansionMap {
 /**
  * Hook that tracks whether each navigation category accordion is
  * expanded. Defaults every category to `true` on first visit (so all
- * 84 games are discoverable), and persists user-toggled collapses to
+ * 86 games are discoverable), and persists user-toggled collapses to
  * localStorage so repeat visitors see their preferred layout.
  */
 export function useCategoryExpansion() {

--- a/internal/infrastructure/games/registry.go
+++ b/internal/infrastructure/games/registry.go
@@ -5,7 +5,7 @@
 // binaries (TinyGo / WASM) stay under the 1 MB gzipped free-tier limit:
 //
 //   - registry.go (this file, no tag)  — types and bare metadata (Name +
-//     Category) for all 84 games. Cheap; no references to game code.
+//     Category) for all 86 games. Cheap; no references to game code.
 //   - games_server.go (!js || !wasm)   — installs Web-server factories for
 //     every game via BindWebController. Imported by TrumpCardsWeb.
 //   - casino/, classic/, solo/ (js && wasm) — per-category worker bindings.


### PR DESCRIPTION
## Summary

The canonical game registry (`internal/infrastructure/games/registry.go`) holds **86 games**, but several places still claimed **81** (design docs) or **84** (code comments). Found via `/doc-drift-check --fix`.

- `docs/design/backend.md` — 5 stale "81ゲーム/81 games" + derived 162 Controller/Presenter → 172
- `docs/design/frontend.md` — 8 refs ("81ゲーム", "83名前空間"); also added 5 missing games to the BlackJackApi note enumeration (`belote`, `crescent`, `mississippistud`, `spiderette`, `ultimatetexasholdem`)
- `internal/infrastructure/games/registry.go:8` — package comment "84 games" → "86 games"
- `frontend/src/hooks/useCategoryExpansion.ts:33` — JSDoc "84 games" → "86 games"

Confirmed consistent (no drift) elsewhere: CLI game list, manuals (86 cui + 86 web), web API endpoints (86 across `TrumpCardsWeb.go`/`openapi.yaml`/`architecture.md`), frontend i18n parity (ja/en 88:88), worker bindings, ADR index (25/25), and version pins.

Closes #1814

## Test plan

- [x] `grep -nE '(^|[^0-9])81([^0-9]|$)' docs/design/*.md` returns no game-count matches
- [x] `grep "84 games\|84ゲーム" internal/infrastructure/games/registry.go frontend/src/hooks/useCategoryExpansion.ts` returns nothing
- [ ] CI passes (`golangci-lint`, `go test`, frontend `bun run check`/`bun run test`)