### PR TITLE
docs: fix UML design doc drift to reflect 101 games

### DIFF
--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -6,7 +6,7 @@
 
 - [1. クラス図](#1-クラス図)
   - [1.1 コアドメイン (カード・プレイヤー)](#11-コアドメイン-カードプレイヤー)
-  - [1.2 ゲームドメイン (全94ゲーム)](#12-ゲームドメイン-全94ゲーム)
+  - [1.2 ゲームドメイン (全101ゲーム)](#12-ゲームドメイン-全101ゲーム)
   - [1.3 ユースケース層 (Interactor・Presenter)](#13-ユースケース層-interactorpresenter)
   - [1.4 アダプタ層 (Controller・Presenter実装)](#14-アダプタ層-controllerpresenter実装)
   - [1.5 インフラストラクチャ層](#15-インフラストラクチャ層)
@@ -151,7 +151,7 @@ classDiagram
     GamePlayer *-- ChipHolder : mixin
 ```
 
-### 1.2 ゲームドメイン (全94ゲーム)
+### 1.2 ゲームドメイン (全101ゲーム)
 
 #### ベッティング系ゲーム
 
@@ -1610,7 +1610,7 @@ classDiagram
     note for GamePresenter "各ゲームの Presenter は\nGamePresenter[G] の型エイリアス\nまたは拡張インターフェース"
 ```
 
-**Interactor パターン (全94ゲーム共通)**
+**Interactor パターン (全101ゲーム共通)**
 
 ```mermaid
 classDiagram
@@ -1682,8 +1682,8 @@ classDiagram
     GameCuiPresenter ..|> GamePresenter : implements
     GameWebPresenter ..|> GamePresenter : implements
 
-    note for GameCuiController "95ゲーム × CUI/Web = 190 Controller\nGameCuiController / GameWebController は\n各ゲーム毎に具体的な実装が存在"
-    note for GameCuiPresenter "95ゲーム × CUI/Web = 190 Presenter 実装"
+    note for GameCuiController "101ゲーム × CUI/Web = 202 Controller\nGameCuiController / GameWebController は\n各ゲーム毎に具体的な実装が存在"
+    note for GameCuiPresenter "101ゲーム × CUI/Web = 202 Presenter 実装"
 ```
 
 ### 1.5 インフラストラクチャ層

--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -433,7 +433,7 @@ classDiagram
         +object messageParams
     }
 
-    note for BlackJackResponse "各ゲームが固有のResponse型を持つ\n(全94ゲーム分存在)\n共通フィールド: message, messageCode, messageParams"
+    note for BlackJackResponse "各ゲームが固有のResponse型を持つ\n(全101ゲーム分存在)\n共通フィールド: message, messageCode, messageParams"
 ```
 
 **フェーズ定数 (全ゲーム)**
@@ -864,7 +864,7 @@ classDiagram
     class actionLogApi {
         +blackjack() Promise~ActionLogResponse~
         +poker() Promise~ActionLogResponse~
-        ...全94ゲーム()
+        ...全101ゲーム()
     }
 
     BlackJackApi --> gameApi : uses postJson/gameExec
@@ -926,7 +926,7 @@ classDiagram
 
     RedDogApi --> gameApi : uses postJson/gameExec
 
-    note for BlackJackApi "全94ゲーム分のAPI Objectが存在\n(blackjack, spanish21, poker, oldmaid, daifugo,\nsevens, doubt, holdem, omaha, omahahilo, shortdeck,\npineapple, crazypineapple, hearts, memory, klondike, freecell,\nseahaventowers, cruel, baccarat, spades, twotenjack, crazyeights,\nginrummy, canasta, spider, spiderette, napoleon, mighty,\nindianpoker, videopoker, deuceswild, jokerpoker, euchre, pyramid, tripeaks,\ncribbage, threecard, caribbeanstud, texasholdembonus,\nultimatetexasholdem, mississippistud, ohhell, bridge, speed,\ngofish, pinochle, golf, pigtail,\nsevencardstud, clocksolitaire, durak,\nfortythieves, paigow, war, canfield, fiftyone, yukon, russiansolitaire, scorpion, accordion, whist,\nletitride, pokersquares, pageone, reddog, razz, badugi, trash,\nsevenbridge, president, cassino, calculation, crescent, spiteandmalice,\nskat, shithead, nertz, slapjack, egyptianratscrew, bakersdozen, tonk,\ncasinowar, pitch, dragontiger, blackjackswitch, montecarlo, contractrummy, belote,\noasispoker, beleagueredcastle, piquet, casinoholdem, callbreak)"
+    note for BlackJackApi "全101ゲーム分のAPI Objectが存在\n(blackjack, spanish21, poker, oldmaid, daifugo,\nsevens, doubt, holdem, omaha, omahahilo, shortdeck,\npineapple, crazypineapple, hearts, memory, klondike, freecell,\nseahaventowers, cruel, baccarat, spades, twotenjack, crazyeights,\nginrummy, canasta, spider, spiderette, napoleon, mighty,\nindianpoker, videopoker, deuceswild, jokerpoker, euchre, pyramid, tripeaks,\ncribbage, threecard, caribbeanstud, texasholdembonus,\nultimatetexasholdem, mississippistud, ohhell, bridge, speed,\ngofish, pinochle, golf, pigtail,\nsevencardstud, clocksolitaire, durak,\nfortythieves, paigow, war, canfield, fiftyone, yukon, russiansolitaire, scorpion, accordion, whist,\nletitride, pokersquares, pageone, reddog, razz, badugi, trash,\nsevenbridge, president, cassino, calculation, crescent, spiteandmalice,\nskat, shithead, nertz, slapjack, egyptianratscrew, bakersdozen, tonk,\ncasinowar, pitch, dragontiger, blackjackswitch, montecarlo, contractrummy, belote,\noasispoker, beleagueredcastle, piquet, casinoholdem, callbreak,\nhighcardflush, fourcardpoker, briscola, tarneeb, gaps, rummy500, eightoff)"
 ```
 
 ### 1.3 Hook 層 (共通Hook)
@@ -1305,7 +1305,7 @@ classDiagram
 
     useCanastaGame --> useGameApi : uses
 
-    note for useBlackJackGame "全94ゲーム分の固有Hookが存在\n各HookはuseGameApiで統一的にAPI呼出し\n必要に応じてuseCardSelectionを合成"
+    note for useBlackJackGame "全101ゲーム分の固有Hookが存在\n各HookはuseGameApiで統一的にAPI呼出し\n必要に応じてuseCardSelectionを合成"
 ```
 
 ### 1.5 コンポーネント層
@@ -1904,7 +1904,7 @@ classDiagram
     GamePage --> PokerTableLayout : renders (Hold'em/Omaha/ShortDeck/Pineapple/SevenCardStud/Razz)
     PokerTableLayout --> CpuPlayerCard : wraps
 
-    note for GamePage "全94ゲームページが同一パターンで構成\nuseGamePageSetup → ゲーム固有Hook → 描画"
+    note for GamePage "全101ゲームページが同一パターンで構成\nuseGamePageSetup → ゲーム固有Hook → 描画"
 ```
 
 ### 1.7 i18n・プロバイダー・ルーティング
@@ -1927,16 +1927,16 @@ classDiagram
         +HashRouter
         +ErrorBoundary
         +NavBar
-        +Routes (95ゲーム)
+        +Routes (101ゲーム)
     }
 
     class gameCategories {
-        +table: [BlackJack, Spanish21, Baccarat, ThreeCard, CaribbeanStud, OasisPoker, TexasHoldemBonus, CasinoHoldem, UltimateTexasHoldem, PaiGow, LetItRide, RedDog, CasinoWar, DragonTiger, BlackJackSwitch, MississippiStud]
+        +table: [BlackJack, Spanish21, Baccarat, ThreeCard, CaribbeanStud, OasisPoker, TexasHoldemBonus, CasinoHoldem, UltimateTexasHoldem, PaiGow, LetItRide, RedDog, CasinoWar, DragonTiger, BlackJackSwitch, MississippiStud, HighCardFlush, FourCardPoker]
         +poker: [Poker, Holdem, Omaha, OmahaHiLo, ShortDeck, Pineapple, CrazyPineapple, SevenCardStud, Razz, Badugi, IndianPoker, VideoPoker, DeucesWild, JokerPoker]
-        +trickTaking: [Hearts, Spades, Pitch, TwoTenJack, OhHell, Euchre, Bridge, Napoleon, Whist, Belote, Mighty, Piquet, CallBreak, Tarneeb]
+        +trickTaking: [Hearts, Spades, Pitch, TwoTenJack, OhHell, Euchre, Bridge, Napoleon, Whist, Belote, Mighty, Piquet, CallBreak, Tarneeb, Briscola]
         +matching: [OldMaid, Doubt, Durak, Daifugo, President, Cassino, Sevens, CrazyEights, PageOne, Speed, GoFish, Pinochle, PigsTail, War, FiftyOne, Trash, SpiteAndMalice, Skat, Shithead, Nertz, Slapjack, EgyptianRatscrew]
-        +solitaire: [Klondike, FreeCell, SeahavenTowers, Spider, Spiderette, Pyramid, TriPeaks, Golf, Memory, ClockSolitaire, FortyThieves, BakersDozen, BeleagueredCastle, Canfield, Yukon, RussianSolitaire, Cruel, Scorpion, Accordion, PokerSquares, MonteCarlo, Calculation, Crescent]
-        +rummy: [GinRummy, Tonk, Canasta, Cribbage, SevenBridge, ContractRummy]
+        +solitaire: [Klondike, FreeCell, EightOff, SeahavenTowers, Spider, Spiderette, Pyramid, Gaps, TriPeaks, Golf, Memory, ClockSolitaire, FortyThieves, BakersDozen, BeleagueredCastle, Canfield, Yukon, RussianSolitaire, Cruel, Scorpion, Accordion, PokerSquares, MonteCarlo, Calculation, Crescent]
+        +rummy: [GinRummy, Tonk, Canasta, Cribbage, SevenBridge, ContractRummy, Rummy500]
     }
 
     class TutorialProvider {
@@ -1950,11 +1950,11 @@ classDiagram
     App --> i18n : initializes
     App --> gameCategories : routes from
     App --> NavBar : renders
-    App --> GamePage : routes to 95 pages
+    App --> GamePage : routes to 101 pages
     GamePage --> TutorialProvider : wraps (per-game)
     TutorialProvider --> TutorialOverlay : renders when active
 
-    note for i18n "97名前空間: common + 95ゲーム固有 + tutorial\n翻訳ファイル: locales/{ja,en}/game.json"
+    note for i18n "103名前空間: common + 101ゲーム固有 + tutorial\n翻訳ファイル: locales/{ja,en}/game.json"
 ```
 
 ---


### PR DESCRIPTION
## Summary

Fixes stale game-count references and missing recent games in the UML design diagrams. Surfaced by \`/doc-drift-check --fix\`.

- **\`docs/design/backend.md\`** — bumped 5 stale \`94\`/\`95\` game-count references to \`101\` across ToC, section header, Interactor pattern note, and Controller/Presenter notes (\`101 × CUI/Web = 202\`).
- **\`docs/design/frontend.md\`** — bumped 7 stale game-count references; added the 6 missing recent games (\`HighCardFlush\`, \`FourCardPoker\`, \`Briscola\`, \`EightOff\`, \`Gaps\`, \`Rummy500\`) to the \`gameCategories\` class diagram; appended the 7 missing API names (the 6 above plus \`Tarneeb\`) to the BlackJackApi list note; updated the i18n namespace count to \`103名前空間: common + 101ゲーム固有 + tutorial\`.

Source of truth: \`internal/infrastructure/games/registry.go\` (101 entries) and \`frontend/src/constants/gameRoutes.ts\` (101 routes).

## Verified no drift in

\`CLAUDE.md\` (worker table), \`README.md\` (features table), \`docs/games.md\`, \`docs/architecture.md\` (101 endpoints), \`api/openapi.yaml\`, \`docs/adr/README.md\` (25 ADRs indexed), all 202 game manuals (\`docs/manual/{cui,web}/\`), frontend i18n locales (103 ja + 103 en), versions (Go 1.25.8 / toolchain 1.26.0 is ADR-0027-justified).

## Flagged separately (not in this PR)

\`frontend/src/constants/cuiManualTexts.ts\` is missing CUI manual imports for \`/montecarlo\`, \`/oasispoker\`, \`/piquet\` (98 imports vs 101 in the web equivalent). May be intentional (no CLI mode for those games) or pre-existing drift. Documented in #1835 for separate triage.

## Test plan

- [x] \`grep "94ゲーム\\|95ゲーム\\|97名前空間"\` returns no matches in \`docs/design/\`
- [ ] Mermaid diagrams render cleanly on GitHub (visual check)
- [ ] Decide on the \`cuiManualTexts.ts\` 3-game gap (issue #1835)

Closes #1835