### PR TITLE
feat(discover): v1.1 polish — i18n lazy-load / DR-4 transitions / felt bg / mobile CTA / UML

### DIFF
--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -12,6 +12,7 @@
   - [1.5 コンポーネント層](#15-コンポーネント層)
   - [1.6 ページコンポーネント層](#16-ページコンポーネント層)
   - [1.7 i18n・プロバイダー・ルーティング](#17-i18nプロバイダールーティング)
+  - [1.8 AI Game Concierge (/discover)](#18-ai-game-concierge-discover)
 - [2. シーケンス図](#2-シーケンス図)
   - [2.1 ゲームアクション実行フロー](#21-ゲームアクション実行フロー)
   - [2.2 CPUリプレイアニメーションフロー](#22-cpuリプレイアニメーションフロー)
@@ -38,6 +39,7 @@
   - [2.23 TrashPage フェーズ別レンダリングフロー](#223-trashpage-フェーズ別レンダリングフロー)
   - [2.24 RussianSolitairePage フェーズ別レンダリングフロー](#224-russiansolitairepage-フェーズ別レンダリングフロー)
   - [2.25 MightyPage フェーズ別レンダリングフロー](#225-mightypage-フェーズ別レンダリングフロー)
+  - [2.26 AI Game Concierge サーベイ → 結果フロー](#226-ai-game-concierge-サーベイ--結果フロー)
 - [3. ステートマシン図](#3-ステートマシン図)
   - [3.1 ゲームページ表示状態](#31-ゲームページ表示状態)
   - [3.2 カード選択状態 (useCardSelection)](#32-カード選択状態-usecardselection)
@@ -47,6 +49,7 @@
   - [3.6 チュートリアル状態 (useTutorial)](#36-チュートリアル状態-usetutorial)
   - [3.7 CLIモード状態 (useCliMode + useCliGame)](#37-cliモード状態-useclimode--usecligame)
   - [3.8 Mighty フェーズ遷移 (MightyPhase)](#38-mighty-フェーズ遷移-mightyphase)
+  - [3.9 Discover サーベイステップ遷移 (SurveyState)](#39-discover-サーベイステップ遷移-surveystate)
 
 ---
 
@@ -1957,6 +1960,167 @@ classDiagram
     note for i18n "103名前空間: common + 101ゲーム固有 + tutorial\n翻訳ファイル: locales/{ja,en}/game.json"
 ```
 
+### 1.8 AI Game Concierge (/discover)
+
+`/discover` (サーベイ) と `/discover/result` (結果) の関係する型・コンポーネント・hook・util の依存関係です。`profile: GameProfile` は `gameRoutes` の必須フィールドとして TypeScript レベルで強制されます。
+
+```mermaid
+classDiagram
+    class AxisDef {
+        +number questionCount
+        +string labelI18nKey
+        +string[] questionI18nKeys
+        +AxisOption[] options
+    }
+
+    class AxisOption {
+        +string key
+        +string i18nKey
+    }
+
+    class AXES {
+        <<const>>
+        +AxisDef mood
+        +AxisDef skill
+        +AxisDef social
+        +AxisDef theme
+    }
+
+    class GameProfile {
+        +number[] mood
+        +number[] skill
+        +number[] social
+        +number[] theme
+    }
+
+    class GameRoute {
+        +string path
+        +string labelKey
+        +string icon
+        +string page
+        +GameProfile profile
+    }
+
+    class UserMood {
+        +AxisAnswer[] mood
+        +AxisAnswer[] skill
+        +AxisAnswer[] social
+        +AxisAnswer[] theme
+    }
+
+    class RecommendationResult {
+        +ScoredGame[] top3
+        +ScoredGame stretch
+        +ScoredGame[] also
+    }
+
+    class recommendationScoring {
+        <<utility>>
+        +axisScore(profile, answers) number
+        +score(game, mood) number
+        +dominantAxis(game, mood) AxisKey
+        +profileDistance(a, b) number
+        +recommend(games, mood) RecommendationResult
+    }
+
+    class urlMoodCodec {
+        <<utility>>
+        +encodeMood(mood) string
+        +parseMood(query) UserMoodInput|null
+        +parseSearchParams(params) UserMoodInput|null
+        +hasAnyAnswer(mood) boolean
+    }
+
+    class useSurveyDraft {
+        <<hook>>
+        +Record axes
+        +setAnswer(axis, qIdx, value) void
+        +reset() void
+    }
+
+    class useGameRecommendations {
+        <<hook>>
+        +input UserMood
+        +output RecommendationResult
+    }
+
+    class useDiscoverI18nBundle {
+        <<hook>>
+        +dynamic import discover.json
+        +i18n.addResourceBundle
+        +returns ready boolean
+    }
+
+    class DiscoverPage {
+        +SurveyState state via useReducer
+        +keyboard 1-N and Backspace
+        +submit navigates discover-result
+    }
+
+    class DiscoverResultPage {
+        +parseSearchParams from URL
+        +useGameRecommendations
+        +fallback when !hasAnyAnswer
+    }
+
+    class DiscoverShell {
+        <<component>>
+        +DR-6 felt frame on lg+
+    }
+
+    class DiscoverSkeleton {
+        <<component>>
+        +DR-3 placeholder during bundle load
+    }
+
+    class MoodQuestion {
+        <<component>>
+        +renders options + skip
+    }
+
+    class SurveyProgress {
+        <<component>>
+        +8-card deck, current highlighted
+    }
+
+    class RecommendationCard {
+        <<component>>
+        +hero|row variant
+    }
+
+    class StretchPickCard {
+        <<component>>
+        +dashed gold border
+    }
+
+    AXES *-- AxisDef : 4 axes
+    AxisDef *-- AxisOption : options
+    GameRoute --> GameProfile : profile
+    GameProfile ..> AXES : index aligned with options
+    recommendationScoring ..> AXES : reads weights / SOCIAL_SOLO_IDX
+    recommendationScoring ..> GameRoute : ranks
+    useGameRecommendations --> recommendationScoring : memoizes recommend()
+    urlMoodCodec ..> AXES : validates option counts
+    useSurveyDraft ..> AXES : axis keys
+    DiscoverPage --> useSurveyDraft : draft state
+    DiscoverPage --> useDiscoverI18nBundle : lazy bundle
+    DiscoverPage --> MoodQuestion : current step
+    DiscoverPage --> SurveyProgress : 1..8 indicator
+    DiscoverPage --> DiscoverShell : felt frame
+    DiscoverPage --> DiscoverSkeleton : while loading
+    DiscoverPage --> urlMoodCodec : encodeMood on submit
+    DiscoverResultPage --> useGameRecommendations : top3 + stretch + also
+    DiscoverResultPage --> urlMoodCodec : parseSearchParams / hasAnyAnswer
+    DiscoverResultPage --> RecommendationCard : hero + rows
+    DiscoverResultPage --> StretchPickCard : stretch pick
+    DiscoverResultPage --> DiscoverShell : felt frame
+    DiscoverResultPage --> useDiscoverI18nBundle : lazy bundle
+
+    note for GameProfile "Vector values are integers 0..PROFILE_MAX (=5).\nIndex order is locked to AXES.<axis>.options ordering."
+    note for urlMoodCodec "Wire format: m=2,3&s=0,-&so=1,1&t=-,-\nskip token = '-' (one hyphen)"
+    note for useSurveyDraft "localStorage key: trumpcards-discover-draft\nVersion-tagged blob; mismatch wipes & restarts."
+```
+
 ---
 
 ## 2. シーケンス図
@@ -2877,6 +3041,68 @@ sequenceDiagram
     Hook-->>Page: 再レンダリング → 次ラウンドUI or ゲーム終了UI
 ```
 
+### 2.26 AI Game Concierge サーベイ → 結果フロー
+
+ユーザーが Sidebar/NavBar CTA から `/discover` を開き、8問のアンケートを進めて `/discover/result` で推薦結果を見るまで。i18n bundle は `/discover` mount 時に遅延ロードされ、その間 `DiscoverSkeleton` が表示されます。
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Sidebar as DesktopSidebar/NavBar
+    participant Page as DiscoverPage
+    participant Bundle as useDiscoverI18nBundle
+    participant i18n as i18next
+    participant Draft as useSurveyDraft
+    participant LS as localStorage
+    participant Result as DiscoverResultPage
+    participant Codec as urlMoodCodec
+    participant Recs as useGameRecommendations
+
+    User->>Sidebar: tap "🎲 おすすめを探す"
+    Sidebar->>Page: navigate /discover
+
+    Page->>Bundle: useDiscoverI18nBundle()
+    alt bundle not yet loaded
+        Bundle->>i18n: hasResourceBundle('discover') → false
+        Bundle->>Bundle: dynamic import('locales/{lang}/discover.json')
+        Page-->>User: DiscoverSkeleton (DR-3)
+        Bundle->>i18n: addResourceBundle(lang, 'discover', json)
+        Bundle-->>Page: ready=true
+    end
+
+    Page->>Draft: useSurveyDraft() → restored axes
+    Draft->>LS: read trumpcards-discover-draft
+    LS-->>Draft: { v: 1, axes } | null
+    Page->>Page: firstUnansweredStep(axes) → initial step
+
+    loop 8 questions (advance/back)
+        Page-->>User: MoodQuestion (current axis/qIdx)
+        User->>Page: select option N (1-N key or click)
+        Page->>Draft: setAnswer(axis, qIdx, idx)
+        Draft->>LS: persist (try/catch)
+        Page->>Page: dispatch advance — slide animation (DR-4)
+    end
+
+    Page->>Codec: encodeMood({ axes }) → "m=...&s=...&so=...&t=..."
+    Page->>Draft: reset() → clears localStorage
+    Page->>Result: navigate /discover/result?<query>
+
+    Result->>Bundle: useDiscoverI18nBundle() (already ready in most flows)
+    Result->>Codec: parseSearchParams(params) → UserMoodInput|null
+    alt parsed === null
+        Result->>Result: navigate('/discover', { replace: true })
+    end
+    Result->>Codec: hasAnyAnswer(mood) → boolean
+    Result->>Recs: useGameRecommendations(toUserMood(mood))
+    Recs-->>Result: { top3, stretch, also }
+
+    alt all-skip mood
+        Result-->>User: fallback hero (warm dashed border + 2 CTA)
+    else
+        Result-->>User: hero card (TOP1) + TOP2/3 + Stretch + Also rows
+    end
+```
+
 ---
 
 ## 3. ステートマシン図
@@ -3039,3 +3265,40 @@ stateDiagram-v2
     note right of PLAY : MightyPhase.PLAY = 3\n通常 play(cardIndex)\nまたは jokerlead(cardIndex,jokerLeadSuit)
     note right of ROUND_END : MightyPhase.ROUND_END = 5\nスコア = (|points-bid|+1)×倍率\nNoTrump 倍率 = 2, セルフフレンド ×2
 ```
+
+### 3.9 Discover サーベイステップ遷移 (SurveyState)
+
+`DiscoverPage` の `useReducer` が管理する step pointer (`0..TOTAL_QUESTIONS`) の遷移。マウント時に `firstUnansweredStep(restoredAxes)` で localStorage から再開位置を計算し、advance/back で 1 ステップずつ移動、`TOTAL_QUESTIONS` 到達で submit effect が発火して `/discover/result` へ遷移します。
+
+```mermaid
+stateDiagram-v2
+    [*] --> Restoring : mount
+
+    Restoring --> Step0 : firstUnansweredStep = 0
+    Restoring --> StepN : firstUnansweredStep = N (resume from draft)
+
+    state "Step N (0..7)" as StepN {
+        [*] --> Showing
+        Showing --> Showing : back / Backspace = max(step-1, 0)
+        Showing --> Animating : advance (select option or skip)
+        Animating --> Showing : transition complete (DR-4 200ms ease-out)
+    }
+
+    Step0 --> StepN : advance
+    StepN --> Submitted : advance from step=7
+    StepN --> StepN : back
+
+    state Submitted {
+        [*] --> Encoding
+        Encoding --> Clearing : encodeMood ok
+        Clearing --> Navigating : draft cleared
+        Navigating --> [*] : navigate /discover/result?...
+    }
+
+    Submitted --> [*]
+
+    note right of Restoring : axes = useSurveyDraft() (lazy useState)\nfirstUnansweredStep walks 0..7 looking\nfor the first (axis, qIdx) with null answer.
+    note right of StepN : current = stepToAxisQuestion(step)\nMoodQuestion renders 1 question.\nReducer pure = advance | back.
+    note right of Submitted : Submit effect deps include state.step.\nresetDraft() removes localStorage entry.
+```
+

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -150,6 +150,17 @@ export function NavBar() {
             )}
           </div>
         )}
+        {!filteredRoutes && (
+          <Link
+            to="/discover"
+            aria-current={pathname.startsWith('/discover') ? 'page' : undefined}
+            onClick={closeMenu}
+            className={`inline-flex items-center gap-1.5 px-3 py-2 text-xs font-medium rounded min-h-[44px] border-l-2 border-ds-accent bg-gradient-to-r from-[rgba(212,168,83,0.12)] to-[rgba(212,168,83,0.04)] text-ds-text-primary hover:bg-[rgba(212,168,83,0.18)] transition-colors ${focusRingWhite}`}
+          >
+            <span aria-hidden="true">🎲</span>
+            {t('nav.discover')}
+          </Link>
+        )}
         {isMobile && !filteredRoutes && favorites.length > 0 && (
           <div className="flex flex-col gap-1">
             <span className="text-ds-text-muted text-xs uppercase tracking-wider px-1 py-1">

--- a/frontend/src/components/discover/DiscoverShell.tsx
+++ b/frontend/src/components/discover/DiscoverShell.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+
+/** Props for the felt-textured shell wrapping `/discover` pages. */
+export interface DiscoverShellProps {
+  readonly children: ReactNode;
+  /**
+   * Optional test id forwarded to the outer wrapper so callers can find the
+   * concierge container in DOM-level tests.
+   */
+  readonly testId?: string;
+}
+
+/**
+ * Visual shell for the AI Game Concierge pages (DR-6).
+ *
+ * On desktop (≥1024px) renders the page content inside a max-w-[600px]
+ * frame against a dark felt-green diagonal-stripe background, giving a
+ * private-card-room feel and visually separating the concierge flow
+ * from the standard game pages. On smaller widths the felt is dropped
+ * and the frame spans the viewport so the content remains readable
+ * on phones.
+ */
+export function DiscoverShell({ children, testId }: DiscoverShellProps) {
+  return (
+    <div
+      data-testid={testId}
+      className="discover-shell flex-1 min-h-0 flex flex-col bg-ds-bg lg:bg-game-bg-green-dark lg:bg-[image:repeating-linear-gradient(45deg,var(--color-game-bg-green-dark)_0px,var(--color-game-bg-green-dark)_2px,transparent_2px,transparent_6px)]"
+    >
+      <div className="flex-1 min-h-0 flex flex-col w-full lg:max-w-[600px] lg:mx-auto lg:bg-ds-bg lg:shadow-[0_0_64px_rgba(0,0,0,0.6)]">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/discover/DiscoverSkeleton.test.tsx
+++ b/frontend/src/components/discover/DiscoverSkeleton.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { TOTAL_QUESTIONS } from '../../constants/discoverAxes';
+import { DiscoverSkeleton } from './DiscoverSkeleton';
+
+describe('DiscoverSkeleton', () => {
+  it('renders a status region with aria-busy', () => {
+    render(<DiscoverSkeleton />);
+    const status = screen.getByRole('status');
+    expect(status).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('renders TOTAL_QUESTIONS card placeholders + 4 option rows', () => {
+    const { container } = render(<DiscoverSkeleton />);
+    // 8 deck card placeholders are <li> elements with aria-hidden parent.
+    const deck = container.querySelector('ul[aria-hidden="true"]');
+    expect(deck?.children).toHaveLength(TOTAL_QUESTIONS);
+    // 4 option-row placeholders (separate <ul>).
+    const optionRows = container.querySelectorAll('ul')[1]?.children;
+    expect(optionRows).toHaveLength(4);
+  });
+});

--- a/frontend/src/components/discover/DiscoverSkeleton.tsx
+++ b/frontend/src/components/discover/DiscoverSkeleton.tsx
@@ -1,0 +1,36 @@
+/**
+ * Layout-preserving skeleton shown while the lazy `discover` i18n bundle
+ * loads. Renders an 8-card deck progress placeholder, a question-text
+ * block, and four option rows so the survey doesn't shift layout when
+ * the real content swaps in (DR-3).
+ */
+export function DiscoverSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label="Loading"
+      className="flex-1 min-h-0 flex flex-col items-center justify-start px-4 py-8 gap-6"
+    >
+      <ul aria-hidden="true" className="flex gap-1.5 items-end justify-center">
+        {Array.from({ length: 8 }, (_, i) => (
+          <li
+            key={`skeleton-card-${i + 1}`}
+            className={
+              i === 0 ? 'w-7 h-10 rounded-sm bg-ds-surface-elevated' : 'w-5 h-7 rounded-sm bg-ds-surface-elevated/60'
+            }
+          />
+        ))}
+      </ul>
+      <div className="w-full max-w-md flex flex-col gap-4">
+        <div className="h-3 w-24 rounded bg-ds-surface-elevated/80" />
+        <div className="h-6 w-3/4 rounded bg-ds-surface-elevated" />
+        <ul className="flex flex-col gap-2">
+          {Array.from({ length: 4 }, (_, i) => (
+            <li key={`skeleton-opt-${i + 1}`} className="h-14 w-full rounded-md bg-ds-surface-elevated/70" />
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useDiscoverI18nBundle.test.tsx
+++ b/frontend/src/hooks/useDiscoverI18nBundle.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import i18n from 'i18next';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { __resetDiscoverI18nBundleCacheForTests, useDiscoverI18nBundle } from './useDiscoverI18nBundle';
+
+const NS = 'discover';
+
+describe('useDiscoverI18nBundle', () => {
+  // The test setup eagerly loads discover into both ja and en (skipLazy: false).
+  // We snapshot and restore those bundles per test so we can drive the hook
+  // through the "not loaded yet" path explicitly.
+  let snapshotJa: ReturnType<typeof i18n.getResourceBundle> | undefined;
+  let snapshotEn: ReturnType<typeof i18n.getResourceBundle> | undefined;
+
+  beforeEach(() => {
+    snapshotJa = i18n.getResourceBundle('ja', NS);
+    snapshotEn = i18n.getResourceBundle('en', NS);
+    __resetDiscoverI18nBundleCacheForTests();
+  });
+
+  afterEach(() => {
+    if (snapshotJa) i18n.addResourceBundle('ja', NS, snapshotJa, true, true);
+    if (snapshotEn) i18n.addResourceBundle('en', NS, snapshotEn, true, true);
+    __resetDiscoverI18nBundleCacheForTests();
+    i18n.changeLanguage('ja');
+  });
+
+  it('returns true immediately when the bundle is already loaded', () => {
+    const { result } = renderHook(() => useDiscoverI18nBundle());
+    expect(result.current).toBe(true);
+  });
+
+  it('loads the bundle via dynamic import and flips ready to true', async () => {
+    i18n.removeResourceBundle('ja', NS);
+    i18n.removeResourceBundle('en', NS);
+    const { result } = renderHook(() => useDiscoverI18nBundle());
+    // First synchronous read is false (resource missing).
+    expect(result.current).toBe(false);
+    // After dynamic import resolves, hook re-renders with ready=true.
+    await waitFor(() => expect(result.current).toBe(true));
+    expect(i18n.hasResourceBundle('ja', NS)).toBe(true);
+  });
+
+  it('normalizes BCP-47 region tags (en-US) down to the base lang (en)', async () => {
+    i18n.removeResourceBundle('ja', NS);
+    i18n.removeResourceBundle('en', NS);
+    await act(async () => {
+      await i18n.changeLanguage('en-US');
+    });
+    const { result } = renderHook(() => useDiscoverI18nBundle());
+    await waitFor(() => expect(result.current).toBe(true));
+    // Must register against the base lang `en`, not `en-US`.
+    expect(i18n.hasResourceBundle('en', NS)).toBe(true);
+    expect(i18n.hasResourceBundle('en-US', NS)).toBe(false);
+  });
+
+  it('falls back to ja when an unknown locale resolves to a missing bundle', async () => {
+    i18n.removeResourceBundle('ja', NS);
+    i18n.removeResourceBundle('en', NS);
+    await act(async () => {
+      await i18n.changeLanguage('zz');
+    });
+    const { result } = renderHook(() => useDiscoverI18nBundle());
+    await waitFor(() => expect(result.current).toBe(true));
+    expect(i18n.hasResourceBundle('ja', NS)).toBe(true);
+  });
+
+  it('dedupes concurrent loads — only one in-flight import per language', async () => {
+    i18n.removeResourceBundle('ja', NS);
+    i18n.removeResourceBundle('en', NS);
+    const addSpy = vi.spyOn(i18n, 'addResourceBundle');
+    const a = renderHook(() => useDiscoverI18nBundle());
+    const b = renderHook(() => useDiscoverI18nBundle());
+    await waitFor(() => expect(a.result.current).toBe(true));
+    await waitFor(() => expect(b.result.current).toBe(true));
+    // The bundle should have been registered exactly once despite two
+    // simultaneous renders.
+    expect(addSpy).toHaveBeenCalledTimes(1);
+    addSpy.mockRestore();
+  });
+});

--- a/frontend/src/hooks/useDiscoverI18nBundle.ts
+++ b/frontend/src/hooks/useDiscoverI18nBundle.ts
@@ -2,9 +2,35 @@ import i18n from 'i18next';
 import { useEffect, useState } from 'react';
 
 const NAMESPACE = 'discover';
+/** Locales for which a `discover.json` bundle exists on disk. */
+const SUPPORTED_LANGS = ['ja', 'en'] as const;
+type SupportedLang = (typeof SUPPORTED_LANGS)[number];
+const FALLBACK_LANG: SupportedLang = 'ja';
 
 /** Module cache so the dynamic imports only run once per language per session. */
-const inFlight = new Map<string, Promise<void>>();
+const inFlight = new Map<SupportedLang, Promise<void>>();
+
+/**
+ * Resolve an i18next language tag (which may be BCP-47, e.g. `en-US`)
+ * down to one of the locales we actually ship — falling back to ja so
+ * users on unsupported locales still get a real bundle instead of a
+ * silent 404 + permanent skeleton.
+ */
+function resolveLang(raw: string | undefined): SupportedLang {
+  const base = (raw || FALLBACK_LANG).split('-')[0];
+  return (SUPPORTED_LANGS as readonly string[]).includes(base) ? (base as SupportedLang) : FALLBACK_LANG;
+}
+
+/** Vite-statically-analyzable glob of every shippable discover bundle. */
+const discoverBundles = import.meta.glob<{ default: Record<string, unknown> }>('../i18n/locales/*/discover.json');
+
+/** Resolve the loader function for a given supported lang. */
+function loaderFor(lang: SupportedLang): () => Promise<{ default: Record<string, unknown> }> {
+  const key = `../i18n/locales/${lang}/discover.json`;
+  const loader = discoverBundles[key];
+  if (!loader) throw new Error(`[useDiscoverI18nBundle] missing bundle for ${lang}`);
+  return loader;
+}
 
 /**
  * Dynamically import the `discover` i18n bundle for the current language
@@ -14,37 +40,52 @@ const inFlight = new Map<string, Promise<void>>();
  *
  * The discover bundle is excluded from the eager glob in `buildResources`
  * so users who never visit `/discover` do not pay its ~25–35 KB gzipped
- * weight. Loading is keyed by language; switching languages mid-session
- * triggers a fresh import for the new locale.
+ * weight. Loading is keyed by the resolved supported language; on import
+ * failure we fall back to the ja bundle so the user is never stranded on
+ * the skeleton (network failures, missing locale, etc.).
  */
 export function useDiscoverI18nBundle(): boolean {
   const [, force] = useState(0);
-  const lang = i18n.language || 'ja';
-  const ready = i18n.hasResourceBundle(lang, NAMESPACE);
+  const lang = resolveLang(i18n.language);
+  const ready = i18n.hasResourceBundle(lang, NAMESPACE) || i18n.hasResourceBundle(FALLBACK_LANG, NAMESPACE);
 
   useEffect(() => {
     if (i18n.hasResourceBundle(lang, NAMESPACE)) return;
-    const key = lang;
-    const cached = inFlight.get(key);
+    const cached = inFlight.get(lang);
     if (cached) {
       cached.then(() => force((n) => n + 1));
       return;
     }
-    const load = import(`../i18n/locales/${lang}/discover.json`)
-      .then((mod: { default: Record<string, unknown> }) => {
-        i18n.addResourceBundle(lang, NAMESPACE, mod.default, true, true);
-      })
-      .catch((err: unknown) => {
+    const tryLoad = (target: SupportedLang) =>
+      loaderFor(target)().then((mod) => {
+        i18n.addResourceBundle(target, NAMESPACE, mod.default, true, true);
+      });
+    const load = tryLoad(lang)
+      .catch((primaryErr: unknown) => {
         if (import.meta.env.DEV) {
-          console.warn(`[useDiscoverI18nBundle] failed to load ${lang}:`, err);
+          console.warn(`[useDiscoverI18nBundle] failed to load ${lang}, trying ${FALLBACK_LANG}:`, primaryErr);
         }
+        if (lang === FALLBACK_LANG) return;
+        return tryLoad(FALLBACK_LANG).catch((fallbackErr: unknown) => {
+          if (import.meta.env.DEV) {
+            console.warn(`[useDiscoverI18nBundle] fallback ${FALLBACK_LANG} also failed:`, fallbackErr);
+          }
+        });
       })
       .finally(() => {
-        inFlight.delete(key);
+        inFlight.delete(lang);
         force((n) => n + 1);
       });
-    inFlight.set(key, load);
+    inFlight.set(lang, load);
   }, [lang]);
 
   return ready;
+}
+
+/**
+ * Test-only: clear the module-level in-flight cache. Production code
+ * never calls this; tests use it to isolate hook invocations.
+ */
+export function __resetDiscoverI18nBundleCacheForTests(): void {
+  inFlight.clear();
 }

--- a/frontend/src/hooks/useDiscoverI18nBundle.ts
+++ b/frontend/src/hooks/useDiscoverI18nBundle.ts
@@ -1,0 +1,50 @@
+import i18n from 'i18next';
+import { useEffect, useState } from 'react';
+
+const NAMESPACE = 'discover';
+
+/** Module cache so the dynamic imports only run once per language per session. */
+const inFlight = new Map<string, Promise<void>>();
+
+/**
+ * Dynamically import the `discover` i18n bundle for the current language
+ * and register it via `i18n.addResourceBundle`. Returns `true` once the
+ * resource bundle is ready (or was already present), so the caller can
+ * render a skeleton while it loads.
+ *
+ * The discover bundle is excluded from the eager glob in `buildResources`
+ * so users who never visit `/discover` do not pay its ~25–35 KB gzipped
+ * weight. Loading is keyed by language; switching languages mid-session
+ * triggers a fresh import for the new locale.
+ */
+export function useDiscoverI18nBundle(): boolean {
+  const [, force] = useState(0);
+  const lang = i18n.language || 'ja';
+  const ready = i18n.hasResourceBundle(lang, NAMESPACE);
+
+  useEffect(() => {
+    if (i18n.hasResourceBundle(lang, NAMESPACE)) return;
+    const key = lang;
+    const cached = inFlight.get(key);
+    if (cached) {
+      cached.then(() => force((n) => n + 1));
+      return;
+    }
+    const load = import(`../i18n/locales/${lang}/discover.json`)
+      .then((mod: { default: Record<string, unknown> }) => {
+        i18n.addResourceBundle(lang, NAMESPACE, mod.default, true, true);
+      })
+      .catch((err: unknown) => {
+        if (import.meta.env.DEV) {
+          console.warn(`[useDiscoverI18nBundle] failed to load ${lang}:`, err);
+        }
+      })
+      .finally(() => {
+        inFlight.delete(key);
+        force((n) => n + 1);
+      });
+    inFlight.set(key, load);
+  }, [lang]);
+
+  return ready;
+}

--- a/frontend/src/i18n/buildResources.ts
+++ b/frontend/src/i18n/buildResources.ts
@@ -1,11 +1,38 @@
-/** Extract namespace name from glob path (e.g. './locales/ja/blackjack.json' → 'blackjack'). */
+/**
+ * Namespaces that the eager glob should skip at runtime. These bundles
+ * are loaded on demand by their owning page (currently only `discover`,
+ * which mounts on `/discover` and is ~25-35 KB gzipped — not worth
+ * carrying for users who never open the concierge).
+ */
+export const LAZY_NAMESPACES: ReadonlySet<string> = new Set<string>(['discover']);
+
+/** Options for the resource builder. */
+export interface BuildResourcesOptions {
+  /**
+   * If `true` (default), namespaces listed in `LAZY_NAMESPACES` are
+   * dropped from the eager-loaded resource map. Tests pass `false` so
+   * every namespace is available without a dynamic import in jsdom.
+   */
+  readonly skipLazy?: boolean;
+}
+
+/**
+ * Extract namespace name from glob path (e.g. `./locales/ja/blackjack.json` → `blackjack`)
+ * and return the resources map. By default lazy namespaces are filtered
+ * out so the runtime bundle stays slim; pass `{ skipLazy: false }` to
+ * include them (test setup uses this).
+ */
 export function buildResources(
   modules: Record<string, Record<string, string>>,
+  options: BuildResourcesOptions = {},
 ): Record<string, Record<string, string>> {
+  const { skipLazy = true } = options;
   const resources: Record<string, Record<string, string>> = {};
   for (const [path, mod] of Object.entries(modules)) {
     const name = path.split('/').pop()?.replace('.json', '');
-    if (name) resources[name] = mod;
+    if (!name) continue;
+    if (skipLazy && LAZY_NAMESPACES.has(name)) continue;
+    resources[name] = mod;
   }
   return resources;
 }

--- a/frontend/src/pages/DiscoverPage.skeleton.test.tsx
+++ b/frontend/src/pages/DiscoverPage.skeleton.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../test/renderWithProviders';
+
+// Hoisted mock: pretend the bundle is still loading so we exercise the
+// `if (!bundleReady) return <DiscoverSkeleton />` branch in DiscoverPage.
+vi.mock('../hooks/useDiscoverI18nBundle', () => ({
+  useDiscoverI18nBundle: () => false,
+}));
+
+// Importing after vi.mock so the page sees the mocked hook.
+import { DiscoverPage } from './DiscoverPage';
+
+describe('DiscoverPage skeleton branch', () => {
+  it('renders the DiscoverSkeleton placeholder while the bundle is loading', () => {
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/discover']}>
+        <Routes>
+          <Route path="/discover" element={<DiscoverPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    const statuses = screen.getAllByRole('status');
+    expect(statuses.length).toBeGreaterThan(0);
+    expect(statuses.some((s) => s.getAttribute('aria-busy') === 'true')).toBe(true);
+  });
+});

--- a/frontend/src/pages/DiscoverPage.tsx
+++ b/frontend/src/pages/DiscoverPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useReducer } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { DiscoverShell } from '../components/discover/DiscoverShell';
 import { MoodQuestion } from '../components/discover/MoodQuestion';
 import { SurveyProgress } from '../components/discover/SurveyProgress';
 import { AXES, AXIS_KEYS, type AxisKey, TOTAL_QUESTIONS } from '../constants/discoverAxes';
@@ -119,29 +120,31 @@ export function DiscoverPage() {
   }
 
   return (
-    <div className="flex-1 min-h-0 flex flex-col items-center justify-start px-4 py-8 gap-6">
-      <SurveyProgress current={state.step + 1} />
-      <div className="w-full max-w-md">
-        <MoodQuestion
-          axis={AXES[current.axis]}
-          questionIndex={current.qIdx}
-          selected={axes[current.axis][current.qIdx]}
-          onSelect={handleSelect}
-          onSkip={handleSkip}
-          questionNumber={state.step + 1}
-          totalQuestions={TOTAL_QUESTIONS}
-        />
-        {state.step > 0 && (
-          <button
-            type="button"
-            onClick={handleBack}
-            className={`mt-4 text-xs text-ds-text-muted hover:text-ds-text-primary underline ${focusRingWhite}`}
-          >
-            {t('action.back')}
-          </button>
-        )}
+    <DiscoverShell testId="discover-survey">
+      <div className="flex-1 min-h-0 flex flex-col items-center justify-start px-4 py-8 gap-6">
+        <SurveyProgress current={state.step + 1} />
+        <div className="w-full max-w-md">
+          <MoodQuestion
+            axis={AXES[current.axis]}
+            questionIndex={current.qIdx}
+            selected={axes[current.axis][current.qIdx]}
+            onSelect={handleSelect}
+            onSkip={handleSkip}
+            questionNumber={state.step + 1}
+            totalQuestions={TOTAL_QUESTIONS}
+          />
+          {state.step > 0 && (
+            <button
+              type="button"
+              onClick={handleBack}
+              className={`mt-4 text-xs text-ds-text-muted hover:text-ds-text-primary underline ${focusRingWhite}`}
+            >
+              {t('action.back')}
+            </button>
+          )}
+        </div>
       </div>
-    </div>
+    </DiscoverShell>
   );
 }
 

--- a/frontend/src/pages/DiscoverPage.tsx
+++ b/frontend/src/pages/DiscoverPage.tsx
@@ -2,9 +2,11 @@ import { useCallback, useEffect, useReducer } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { DiscoverShell } from '../components/discover/DiscoverShell';
+import { DiscoverSkeleton } from '../components/discover/DiscoverSkeleton';
 import { MoodQuestion } from '../components/discover/MoodQuestion';
 import { SurveyProgress } from '../components/discover/SurveyProgress';
 import { AXES, AXIS_KEYS, type AxisKey, TOTAL_QUESTIONS } from '../constants/discoverAxes';
+import { useDiscoverI18nBundle } from '../hooks/useDiscoverI18nBundle';
 import { useSurveyDraft } from '../hooks/useSurveyDraft';
 import { focusRingWhite } from '../styles/buttonStyles';
 import { encodeMood } from '../utils/urlMoodCodec';
@@ -51,6 +53,7 @@ function firstUnansweredStep(axes: ReturnType<typeof useSurveyDraft>['axes']): n
 export function DiscoverPage() {
   const { t } = useTranslation('discover');
   const navigate = useNavigate();
+  const bundleReady = useDiscoverI18nBundle();
   const { axes, setAnswer, reset: resetDraft } = useSurveyDraft();
   // `useSurveyDraft` lazy-initializes `axes` from localStorage on its first
   // render, so the `axes` we read here on first paint is already the
@@ -117,6 +120,14 @@ export function DiscoverPage() {
   if (!current) {
     // Submitted — the effect above is navigating away; render an empty shell.
     return null;
+  }
+
+  if (!bundleReady) {
+    return (
+      <DiscoverShell testId="discover-survey">
+        <DiscoverSkeleton />
+      </DiscoverShell>
+    );
   }
 
   return (

--- a/frontend/src/pages/DiscoverPage.tsx
+++ b/frontend/src/pages/DiscoverPage.tsx
@@ -1,3 +1,4 @@
+import { AnimatePresence, motion } from 'framer-motion';
 import { useCallback, useEffect, useReducer } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -7,6 +8,7 @@ import { MoodQuestion } from '../components/discover/MoodQuestion';
 import { SurveyProgress } from '../components/discover/SurveyProgress';
 import { AXES, AXIS_KEYS, type AxisKey, TOTAL_QUESTIONS } from '../constants/discoverAxes';
 import { useDiscoverI18nBundle } from '../hooks/useDiscoverI18nBundle';
+import { useReducedMotion } from '../hooks/useReducedMotion';
 import { useSurveyDraft } from '../hooks/useSurveyDraft';
 import { focusRingWhite } from '../styles/buttonStyles';
 import { encodeMood } from '../utils/urlMoodCodec';
@@ -54,6 +56,7 @@ export function DiscoverPage() {
   const { t } = useTranslation('discover');
   const navigate = useNavigate();
   const bundleReady = useDiscoverI18nBundle();
+  const reducedMotion = useReducedMotion();
   const { axes, setAnswer, reset: resetDraft } = useSurveyDraft();
   // `useSurveyDraft` lazy-initializes `axes` from localStorage on its first
   // render, so the `axes` we read here on first paint is already the
@@ -130,20 +133,31 @@ export function DiscoverPage() {
     );
   }
 
+  // DR-4: slide-in / slide-out on step change, reduced to a 50ms fade
+  // when the user prefers reduced motion (DR-7 #3).
+  const transition = reducedMotion ? { duration: 0.05 } : { duration: 0.2, ease: 'easeOut' as const };
+  const initial = reducedMotion ? { opacity: 0 } : { opacity: 0, x: 24 };
+  const animate = reducedMotion ? { opacity: 1 } : { opacity: 1, x: 0 };
+  const exit = reducedMotion ? { opacity: 0 } : { opacity: 0, x: -24 };
+
   return (
     <DiscoverShell testId="discover-survey">
       <div className="flex-1 min-h-0 flex flex-col items-center justify-start px-4 py-8 gap-6">
         <SurveyProgress current={state.step + 1} />
         <div className="w-full max-w-md">
-          <MoodQuestion
-            axis={AXES[current.axis]}
-            questionIndex={current.qIdx}
-            selected={axes[current.axis][current.qIdx]}
-            onSelect={handleSelect}
-            onSkip={handleSkip}
-            questionNumber={state.step + 1}
-            totalQuestions={TOTAL_QUESTIONS}
-          />
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.div key={state.step} initial={initial} animate={animate} exit={exit} transition={transition}>
+              <MoodQuestion
+                axis={AXES[current.axis]}
+                questionIndex={current.qIdx}
+                selected={axes[current.axis][current.qIdx]}
+                onSelect={handleSelect}
+                onSkip={handleSkip}
+                questionNumber={state.step + 1}
+                totalQuestions={TOTAL_QUESTIONS}
+              />
+            </motion.div>
+          </AnimatePresence>
           {state.step > 0 && (
             <button
               type="button"

--- a/frontend/src/pages/DiscoverPage.tsx
+++ b/frontend/src/pages/DiscoverPage.tsx
@@ -13,9 +13,14 @@ import { useSurveyDraft } from '../hooks/useSurveyDraft';
 import { focusRingWhite } from '../styles/buttonStyles';
 import { encodeMood } from '../utils/urlMoodCodec';
 
+/** Direction of the most recent step change — drives the slide animation. */
+type SlideDirection = 'forward' | 'backward';
+
 interface SurveyState {
   /** Current step, 0..TOTAL_QUESTIONS (TOTAL means "submitted"). */
   readonly step: number;
+  /** Direction of the last transition, so motion follows navigation. */
+  readonly direction: SlideDirection;
 }
 
 type Action = { type: 'advance' } | { type: 'back' };
@@ -23,9 +28,9 @@ type Action = { type: 'advance' } | { type: 'back' };
 function reducer(state: SurveyState, action: Action): SurveyState {
   switch (action.type) {
     case 'advance':
-      return { step: Math.min(state.step + 1, TOTAL_QUESTIONS) };
+      return { step: Math.min(state.step + 1, TOTAL_QUESTIONS), direction: 'forward' };
     case 'back':
-      return { step: Math.max(state.step - 1, 0) };
+      return { step: Math.max(state.step - 1, 0), direction: 'backward' };
   }
 }
 
@@ -64,6 +69,7 @@ export function DiscoverPage() {
   // the step pointer in one shot — no post-mount effect needed.
   const [state, dispatch] = useReducer(reducer, axes, (initialAxes) => ({
     step: firstUnansweredStep(initialAxes),
+    direction: 'forward' as SlideDirection,
   }));
 
   const current = stepToAxisQuestion(state.step);
@@ -134,11 +140,15 @@ export function DiscoverPage() {
   }
 
   // DR-4: slide-in / slide-out on step change, reduced to a 50ms fade
-  // when the user prefers reduced motion (DR-7 #3).
+  // when the user prefers reduced motion (DR-7 #3). The slide direction
+  // follows the user's navigation — forward enters from the right and
+  // exits to the left; backward reverses both sides so Back feels like
+  // "rewinding" rather than another forward step.
+  const dirSign = state.direction === 'forward' ? 1 : -1;
   const transition = reducedMotion ? { duration: 0.05 } : { duration: 0.2, ease: 'easeOut' as const };
-  const initial = reducedMotion ? { opacity: 0 } : { opacity: 0, x: 24 };
+  const initial = reducedMotion ? { opacity: 0 } : { opacity: 0, x: 24 * dirSign };
   const animate = reducedMotion ? { opacity: 1 } : { opacity: 1, x: 0 };
-  const exit = reducedMotion ? { opacity: 0 } : { opacity: 0, x: -24 };
+  const exit = reducedMotion ? { opacity: 0 } : { opacity: 0, x: -24 * dirSign };
 
   return (
     <DiscoverShell testId="discover-survey">

--- a/frontend/src/pages/DiscoverResultPage.test.tsx
+++ b/frontend/src/pages/DiscoverResultPage.test.tsx
@@ -1,10 +1,10 @@
 /**
  * @vitest-environment jsdom
  */
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import i18n from 'i18next';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../test/renderWithProviders';
 import { DiscoverResultPage } from './DiscoverResultPage';
 
@@ -57,5 +57,24 @@ describe('DiscoverResultPage', () => {
     });
     // A hero recommendation heading is rendered instead.
     expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+  });
+
+  it('fallback hero "browse" button scrolls the TOP3 section into view', async () => {
+    // Stub scrollIntoView since jsdom does not implement it. The button's
+    // onClick path is part of the fullySkipped branch coverage.
+    const scrollSpy = vi.fn();
+    HTMLElement.prototype.scrollIntoView = scrollSpy;
+    renderAt('/discover/result?m=-,-&s=-,-&so=-,-&t=-,-');
+    const browse = await screen.findByRole('button', {
+      name: i18n.t('discover:fallback.action.browse'),
+    });
+    fireEvent.click(browse);
+    expect(scrollSpy).toHaveBeenCalledWith({ behavior: 'smooth' });
+  });
+
+  it('renders the retake link back to /discover', async () => {
+    renderAt('/discover/result?m=0,0&s=0,0&so=1,1&t=0,0');
+    const retake = await screen.findByRole('link', { name: i18n.t('discover:action.retake') });
+    expect(retake).toHaveAttribute('href', '/discover');
   });
 });

--- a/frontend/src/pages/DiscoverResultPage.tsx
+++ b/frontend/src/pages/DiscoverResultPage.tsx
@@ -2,8 +2,10 @@ import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { DiscoverShell } from '../components/discover/DiscoverShell';
+import { DiscoverSkeleton } from '../components/discover/DiscoverSkeleton';
 import { RecommendationCard } from '../components/discover/RecommendationCard';
 import { StretchPickCard } from '../components/discover/StretchPickCard';
+import { useDiscoverI18nBundle } from '../hooks/useDiscoverI18nBundle';
 import { useGameRecommendations } from '../hooks/useGameRecommendations';
 import { btnPrimary, btnSecondary, focusRingWhite } from '../styles/buttonStyles';
 import { hasAnyAnswer, parseSearchParams, type UserMoodInput } from '../utils/urlMoodCodec';
@@ -28,6 +30,7 @@ export function DiscoverResultPage() {
   const { t } = useTranslation('discover');
   const [params] = useSearchParams();
   const navigate = useNavigate();
+  const bundleReady = useDiscoverI18nBundle();
 
   const parsed = useMemo(() => parseSearchParams(params), [params]);
 
@@ -48,6 +51,14 @@ export function DiscoverResultPage() {
   const recs = useGameRecommendations(toUserMood(moodInput));
 
   if (parsed === null) return null;
+
+  if (!bundleReady) {
+    return (
+      <DiscoverShell testId="discover-result">
+        <DiscoverSkeleton />
+      </DiscoverShell>
+    );
+  }
 
   return (
     <DiscoverShell testId="discover-result">

--- a/frontend/src/pages/DiscoverResultPage.tsx
+++ b/frontend/src/pages/DiscoverResultPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { DiscoverShell } from '../components/discover/DiscoverShell';
 import { RecommendationCard } from '../components/discover/RecommendationCard';
 import { StretchPickCard } from '../components/discover/StretchPickCard';
 import { useGameRecommendations } from '../hooks/useGameRecommendations';
@@ -49,69 +50,73 @@ export function DiscoverResultPage() {
   if (parsed === null) return null;
 
   return (
-    <div className="flex-1 min-h-0 flex flex-col items-center px-4 py-8 gap-6">
-      <div className="w-full max-w-[600px] flex flex-col gap-8">
-        {fullySkipped ? (
-          <section className="flex flex-col gap-4 px-5 py-6 border-2 border-dashed border-ds-border rounded-md">
-            <p className="text-xs uppercase tracking-[0.18em] text-ds-accent">{t('fallback.eyebrow')}</p>
-            <h1 className="font-serif text-[28px] leading-[1.15] text-ds-text-primary">{t('fallback.title')}</h1>
-            <p className="text-sm text-ds-text-muted leading-relaxed">{t('fallback.body')}</p>
-            <div className="flex gap-3">
-              <Link to="/discover" className={btnPrimary}>
-                {t('fallback.action.retry')}
-              </Link>
-              <button
-                type="button"
-                onClick={() => document.getElementById('top3')?.scrollIntoView({ behavior: 'smooth' })}
-                className={`${btnSecondary} ${focusRingWhite}`}
-              >
-                {t('fallback.action.browse')}
-              </button>
-            </div>
-          </section>
-        ) : (
-          recs.top3[0] && <RecommendationCard game={recs.top3[0].game} variant="hero" topAxis={recs.top3[0].topAxis} />
-        )}
+    <DiscoverShell testId="discover-result">
+      <div className="flex-1 min-h-0 flex flex-col items-center px-4 py-8 gap-6">
+        <div className="w-full max-w-[600px] flex flex-col gap-8">
+          {fullySkipped ? (
+            <section className="flex flex-col gap-4 px-5 py-6 border-2 border-dashed border-ds-border rounded-md">
+              <p className="text-xs uppercase tracking-[0.18em] text-ds-accent">{t('fallback.eyebrow')}</p>
+              <h1 className="font-serif text-[28px] leading-[1.15] text-ds-text-primary">{t('fallback.title')}</h1>
+              <p className="text-sm text-ds-text-muted leading-relaxed">{t('fallback.body')}</p>
+              <div className="flex gap-3">
+                <Link to="/discover" className={btnPrimary}>
+                  {t('fallback.action.retry')}
+                </Link>
+                <button
+                  type="button"
+                  onClick={() => document.getElementById('top3')?.scrollIntoView({ behavior: 'smooth' })}
+                  className={`${btnSecondary} ${focusRingWhite}`}
+                >
+                  {t('fallback.action.browse')}
+                </button>
+              </div>
+            </section>
+          ) : (
+            recs.top3[0] && (
+              <RecommendationCard game={recs.top3[0].game} variant="hero" topAxis={recs.top3[0].topAxis} />
+            )
+          )}
 
-        {recs.top3.slice(1).length > 0 && (
-          <section id="top3" className="flex flex-col gap-3">
-            <h2 className="text-xs uppercase tracking-[0.15em] text-ds-text-muted">{t('section.top3')}</h2>
-            <ul className="flex flex-col gap-2">
-              {recs.top3.slice(1).map((s) => (
-                <li key={s.game.path}>
-                  <RecommendationCard game={s.game} variant="row" topAxis={s.topAxis} />
-                </li>
-              ))}
-            </ul>
-          </section>
-        )}
+          {recs.top3.slice(1).length > 0 && (
+            <section id="top3" className="flex flex-col gap-3">
+              <h2 className="text-xs uppercase tracking-[0.15em] text-ds-text-muted">{t('section.top3')}</h2>
+              <ul className="flex flex-col gap-2">
+                {recs.top3.slice(1).map((s) => (
+                  <li key={s.game.path}>
+                    <RecommendationCard game={s.game} variant="row" topAxis={s.topAxis} />
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
 
-        {recs.stretch && !fullySkipped && (
-          <section>
-            <StretchPickCard game={recs.stretch.game} />
-          </section>
-        )}
+          {recs.stretch && !fullySkipped && (
+            <section>
+              <StretchPickCard game={recs.stretch.game} />
+            </section>
+          )}
 
-        {recs.also.length > 0 && (
-          <section className="flex flex-col gap-3">
-            <h2 className="text-xs uppercase tracking-[0.15em] text-ds-text-muted">{t('section.also')}</h2>
-            <ul className="flex flex-col gap-2">
-              {recs.also.map((s) => (
-                <li key={s.game.path}>
-                  <RecommendationCard game={s.game} variant="row" topAxis={s.topAxis} />
-                </li>
-              ))}
-            </ul>
-          </section>
-        )}
+          {recs.also.length > 0 && (
+            <section className="flex flex-col gap-3">
+              <h2 className="text-xs uppercase tracking-[0.15em] text-ds-text-muted">{t('section.also')}</h2>
+              <ul className="flex flex-col gap-2">
+                {recs.also.map((s) => (
+                  <li key={s.game.path}>
+                    <RecommendationCard game={s.game} variant="row" topAxis={s.topAxis} />
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
 
-        <div className="flex gap-3 mt-2">
-          <Link to="/discover" className={btnSecondary}>
-            {t('action.retake')}
-          </Link>
+          <div className="flex gap-3 mt-2">
+            <Link to="/discover" className={btnSecondary}>
+              {t('action.retake')}
+            </Link>
+          </div>
         </div>
       </div>
-    </div>
+    </DiscoverShell>
   );
 }
 

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -71,8 +71,11 @@ const enModules = import.meta.glob('../i18n/locales/en/*.json', {
   import: 'default',
 }) as Record<string, Record<string, string>>;
 
-const jaResources = buildResources(jaModules);
-const enResources = buildResources(enModules);
+// Tests include the lazy namespaces eagerly so callers don't have to
+// orchestrate dynamic imports inside jsdom — the runtime path that
+// loads `discover` on /discover mount is covered by a dedicated test.
+const jaResources = buildResources(jaModules, { skipLazy: false });
+const enResources = buildResources(enModules, { skipLazy: false });
 
 i18n.use(initReactI18next).init({
   lng: 'ja',


### PR DESCRIPTION
Closes #1848.

PR #1847 で ship した AI Game Concierge (#1846) の v1 polish 残課題をまとめて対応。設計レビュー (`/plan-design-review` + `/plan-eng-review`) で同意済の以下項目を実装。

## Summary

- `discover` i18n bundle (~25-35 KB gzipped per locale × 2) を eager-glob から外して `/discover` mount 時の dynamic import に。ロード中は layout-preserving な `DiscoverSkeleton` を表示 (DR-3)
- 質問遷移時のスライドアニメーションを `framer-motion` で追加 (DR-4)。`useReducedMotion=true` で 50ms フェードに縮退 (DR-7 #3)
- デスクトップ ≥1024px で felt 風背景 + max-w-600 のフレーム (DR-6)
- モバイル NavBar に `/discover` への gold CTA を追加
- `docs/design/frontend.md` に class / sequence / state machine の 3 枚を追加

## Commits

| Commit | Item |
|---|---|
| `4311fb71` | (4) Mobile NavBar CTA |
| `3b87f505` | (3) `DiscoverShell` で felt frame |
| `0059471c` | (1) i18n bundle の lazy-load + `DiscoverSkeleton` |
| `b1e5bd3e` | (2) DR-4 質問遷移 (framer-motion + reduced-motion 経路) |
| `8b5ba9f1` | (5) UML 3 枚追加 |

## やらない (別 issue)

- (6) Blurb 作者ボイス refinement — エンジニア作業ではない
- (7) Game Journey Tour v2 — Approach C 由来、スコープ別

## Test plan

- [ ] `cd frontend && bun run check` (biome) passes
- [ ] `bunx tsc -p tsconfig.json --noEmit` passes
- [ ] `bun run test` 全パス (ローカルでは utils / hooks / pages / components / constants の 211 files / 1934 tests が通る; NavBar.test.tsx は WSL の Node OOM 既知問題で CI に任せる)
- [ ] `/discover` をデスクトップで開く → ≥1024px で felt 背景 + 600px フレームが見える
- [ ] モバイル幅で NavBar の `🎲` CTA から `/discover` へ遷移
- [ ] 質問選択 → スライド遷移 → 次の問題が出る
- [ ] `prefers-reduced-motion` 有効環境でスライドが 50ms フェードに縮退
- [ ] localStorage 初期状態でリロード → 同じ進行位置から再開できる