### PR TITLE
feat(cli): hint help on `trumpcards completion` missing arg (#1838)

### DIFF
--- a/cmd/trumpcards/completion.go
+++ b/cmd/trumpcards/completion.go
@@ -67,6 +67,7 @@ func runCompletion(args []string, stdoutIsTTY, noHint bool) int {
 func runCompletionTo(args []string, stdout, stderr io.Writer, stdoutIsTTY, noHint bool) int {
 	if len(args) != 1 {
 		_, _ = fmt.Fprintln(stderr, i18n.T("cliCompletionUsage"))
+		_, _ = fmt.Fprintln(stderr, i18n.Tf("cliTryHelp", "cmd", "completion"))
 		return 2
 	}
 	shell := args[0]

--- a/cmd/trumpcards/completion_test.go
+++ b/cmd/trumpcards/completion_test.go
@@ -134,6 +134,10 @@ func TestRunCompletion_NoArgs(t *testing.T) {
 	code := runCompletionTo(nil, &stdout, &stderr, false, false)
 	assert.Equal(t, 2, code)
 	assert.Contains(t, stderr.String(), "trumpcards completion")
+	// Issue #1838: missing-arg should also surface the same `help <cmd>`
+	// hint that parseSubFlagsTo emits for unknown flags, so the UX is
+	// symmetric across all subcommand error paths.
+	assert.Contains(t, stderr.String(), "help completion")
 }
 
 func TestRunCompletion_ExtraArgs(t *testing.T) {


### PR DESCRIPTION
## Summary

When `trumpcards completion` is invoked without the required `<bash|zsh|fish>` argument, also emit the same `cliTryHelp` line that `parseSubFlagsTo` emits for unknown flags. Brings missing-arg UX in line with flag-error UX so users land on `trumpcards help completion` (which already contains shell-specific install examples) in one round-trip.

## Before / After

```
$ trumpcards completion
Usage: trumpcards completion <bash|zsh|fish>
Run 'trumpcards help completion' for usage.   ← added
```

Exit code, stderr-only writes, and the existing `cliCompletionUsage` line are unchanged.

## Test plan

- [x] `go test -tags test -race ./cmd/trumpcards/... -run TestRunCompletion`
- [x] `golangci-lint run ./cmd/trumpcards/...`
- [x] `goimports -w` applied

Closes #1838