### PR TITLE
feat(cli): exit 1 on non-EOF stdin read error in interactive mode (#1839)

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -511,8 +511,10 @@ func run() int {
 		fmt.Fprintln(os.Stderr, i18n.Tf("cliStartupGame", "game", startGame))
 	}
 	manager := ui.NewGameManager(startGame)
-	ui.RunInteractiveCuiLoop(manager)
-	return 0
+	// Issue #1839: propagate stdin read-error exit code so systemd / CI /
+	// supervisors can detect a broken terminal session, not just a clean
+	// EOF. EOF and "exit" still return 0.
+	return ui.RunInteractiveCuiLoop(manager)
 }
 
 // resolveStartGame resolves the --start flag value into a canonical game
@@ -1121,7 +1123,7 @@ ENVIRONMENT VARIABLES:
 
 EXIT CODES:
    0  Success (normal exit, EOF, or 'exit' command)
-   1  General error (e.g., web server failed to start)
+   1  General error (e.g., web server failed to start, interactive input read error)
    2  Usage error (invalid flags, unknown category, missing required argument)
   10  'update --check': a newer version is available (non-error signal for scripts)
   75  'update': user declined the confirmation prompt
@@ -1314,12 +1316,12 @@ func buildGameCommands() map[string]func() int {
 		e := entry // capture loop variable
 		commands[e.Name] = func() int {
 			g := e.NewCui()
+			// Issue #1839: thread the CUI loop's exit code up to the OS so
+			// stdin read errors surface as exit 1, not silently as 0.
 			if realtimeGames[e.Name] {
-				ui.RunRealtimeCuiLoop(e.Name, g.Controller(), g.HelpLines())
-			} else {
-				ui.RunCuiLoop(e.Name, g.Controller(), g.HelpLines())
+				return ui.RunRealtimeCuiLoop(e.Name, g.Controller(), g.HelpLines())
 			}
-			return 0
+			return ui.RunCuiLoop(e.Name, g.Controller(), g.HelpLines())
 		}
 	}
 	return commands

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -511,9 +511,6 @@ func run() int {
 		fmt.Fprintln(os.Stderr, i18n.Tf("cliStartupGame", "game", startGame))
 	}
 	manager := ui.NewGameManager(startGame)
-	// Issue #1839: propagate stdin read-error exit code so systemd / CI /
-	// supervisors can detect a broken terminal session, not just a clean
-	// EOF. EOF and "exit" still return 0.
 	return ui.RunInteractiveCuiLoop(manager)
 }
 
@@ -1316,8 +1313,6 @@ func buildGameCommands() map[string]func() int {
 		e := entry // capture loop variable
 		commands[e.Name] = func() int {
 			g := e.NewCui()
-			// Issue #1839: thread the CUI loop's exit code up to the OS so
-			// stdin read errors surface as exit 1, not silently as 0.
 			if realtimeGames[e.Name] {
 				return ui.RunRealtimeCuiLoop(e.Name, g.Controller(), g.HelpLines())
 			}

--- a/internal/infrastructure/ui/cui_runner.go
+++ b/internal/infrastructure/ui/cui_runner.go
@@ -142,9 +142,12 @@ func filterByPrefix(candidates []string, token string) []string {
 	return out
 }
 
-// RunInteractiveCuiLoop runs an interactive multi-game CUI loop with game switching support.
-// The manager handles help/? commands internally; other commands are delegated to the current game.
-func RunInteractiveCuiLoop(manager *GameManager) {
+// RunInteractiveCuiLoop runs an interactive multi-game CUI loop with game
+// switching support. Returns 0 on normal exit (EOF, "quit", "exit", or
+// QuitSentinel from a game) and 1 when stdin reads fail with a non-EOF I/O
+// error (issue #1839). The manager handles help/? commands internally;
+// other commands are delegated to the current game.
+func RunInteractiveCuiLoop(manager *GameManager) int {
 	setupSignalHandler()
 	initMsg := manager.InitCurrentGame()
 	if initMsg != "" {
@@ -158,16 +161,22 @@ func RunInteractiveCuiLoop(manager *GameManager) {
 	// CuiExecer interface and we don't know the concrete type.
 	installCompleter(reader, manager)
 	for {
-		input, exit := readInput(reader, manager.CurrentGame())
+		input, exit, ioErr := readInput(reader, manager.CurrentGame())
+		if ioErr != nil {
+			return 1
+		}
 		if exit {
-			break
+			return 0
 		}
 		reader.AppendHistory(input)
 		res := manager.Exec(input)
-		res = handlePromptLoop(reader, manager, res, manager.CurrentGame(), os.Stdout)
+		res, ioErr = handlePromptLoop(reader, manager, res, manager.CurrentGame(), os.Stdout)
+		if ioErr != nil {
+			return 1
+		}
 		if res == i18n.QuitSentinel {
 			fmt.Println(i18n.T("bye"))
-			break
+			return 0
 		}
 		printResult(res)
 	}
@@ -187,8 +196,10 @@ func printResult(res string) {
 // prompt — this gives scrollback context and lets users tell ターミナル/タブ
 // apart when running multiple games in parallel. Pass "" to keep the legacy
 // bare "> " prompt. helpLines is shown when the user types "help" / "?".
-// See issue #1605.
-func RunCuiLoop(gameName string, controller CuiExecer, helpLines []string) {
+//
+// Returns 0 on normal exit (EOF, "quit", QuitSentinel) and 1 when stdin
+// reads fail with a non-EOF I/O error (issue #1839). See issue #1605.
+func RunCuiLoop(gameName string, controller CuiExecer, helpLines []string) int {
 	setupSignalHandler()
 	fmt.Println(controller.Exec("r"))
 	fmt.Println(i18n.T("typeHelp"))
@@ -200,9 +211,12 @@ func RunCuiLoop(gameName string, controller CuiExecer, helpLines []string) {
 		installCompleter(reader, nil)
 	}
 	for {
-		input, exit := readInput(reader, gameName)
+		input, exit, ioErr := readInput(reader, gameName)
+		if ioErr != nil {
+			return 1
+		}
 		if exit {
-			break
+			return 0
 		}
 		reader.AppendHistory(input)
 		trimmed := strings.TrimSpace(input)
@@ -213,35 +227,45 @@ func RunCuiLoop(gameName string, controller CuiExecer, helpLines []string) {
 			continue
 		}
 		res := controller.Exec(input)
-		res = handlePromptLoop(reader, controller, res, gameName, os.Stdout)
+		res, ioErr = handlePromptLoop(reader, controller, res, gameName, os.Stdout)
+		if ioErr != nil {
+			return 1
+		}
 		if res == i18n.QuitSentinel {
 			fmt.Println(i18n.T("bye"))
-			break
+			return 0
 		}
 		printResult(res)
 	}
 }
 
-// handlePromptLoop handles interactive prompting when a controller returns a prompt request.
-// It loops until the controller returns a non-prompt result (allowing chained wizard-style prompts).
-func handlePromptLoop(reader LineReader, execer CuiExecer, result, gameName string, w io.Writer) string {
+// handlePromptLoop handles interactive prompting when a controller returns a
+// prompt request. It loops until the controller returns a non-prompt result
+// (allowing chained wizard-style prompts). Returns (result, ioErr); ioErr is
+// non-nil only when an inner stdin read fails with a non-EOF error so the
+// top-level runner can exit non-zero (issue #1839). EOF stays a clean quit
+// (QuitSentinel + nil error), matching the bye-on-Ctrl+D contract.
+func handlePromptLoop(reader LineReader, execer CuiExecer, result, gameName string, w io.Writer) (string, error) {
 	for cuiutil.IsPromptRequest(result) {
 		promptMsg, tmpl := cuiutil.ParsePromptRequest(result)
 		if tmpl == "" {
 			// Malformed prompt; treat as regular message.
-			return promptMsg
+			return promptMsg, nil
 		}
 		_, _ = fmt.Fprintln(w, promptMsg)
-		input, exit := readInput(reader, gameName)
+		input, exit, ioErr := readInput(reader, gameName)
+		if ioErr != nil {
+			return i18n.QuitSentinel, ioErr
+		}
 		if exit {
-			return i18n.QuitSentinel
+			return i18n.QuitSentinel, nil
 		}
 		input = strings.TrimSpace(input)
 		if input == "" {
-			return i18n.T("cancelled")
+			return i18n.T("cancelled"), nil
 		}
 		fullCmd := cuiutil.FillTemplate(tmpl, input)
 		result = execer.Exec(fullCmd)
 	}
-	return result
+	return result, nil
 }

--- a/internal/infrastructure/ui/cui_runner.go
+++ b/internal/infrastructure/ui/cui_runner.go
@@ -166,6 +166,7 @@ func RunInteractiveCuiLoop(manager *GameManager) int {
 			return 1
 		}
 		if exit {
+			fmt.Println(i18n.T("bye"))
 			return 0
 		}
 		reader.AppendHistory(input)
@@ -216,6 +217,7 @@ func RunCuiLoop(gameName string, controller CuiExecer, helpLines []string) int {
 			return 1
 		}
 		if exit {
+			fmt.Println(i18n.T("bye"))
 			return 0
 		}
 		reader.AppendHistory(input)

--- a/internal/infrastructure/ui/input.go
+++ b/internal/infrastructure/ui/input.go
@@ -10,13 +10,21 @@ import (
 )
 
 // readInput reads one line from r, prepending the prompt with gameName when
-// non-empty. Returns (text, exit) — exit is true on EOF (pipe drained,
-// Ctrl+D, or Ctrl+C in liner-backed readers) and on any other read error.
+// non-empty. Returns (text, exit, ioErr):
+//
+//   - normal line: ("...", false, nil)
+//   - EOF (pipe drained, Ctrl+D, signalled-quit reader): ("", true, nil)
+//   - any other I/O error: ("", true, err)
+//
+// EOF and "exit" are clean shutdowns; only the non-EOF error path carries an
+// ioErr so callers can map it to a non-zero process exit code (issue #1839).
+// Matches the Updater's stdin contract (Updater.go: scan errors propagate as
+// errors), giving the whole CLI a consistent exit-code-on-stdin-failure rule.
 //
 // The prompt is constructed here rather than in cui_runner.go so the same
 // "[gameName] > " format is used by the top-level loop and the wizard-style
 // prompt loop (issue #1605).
-func readInput(r LineReader, gameName string) (text string, exit bool) {
+func readInput(r LineReader, gameName string) (text string, exit bool, ioErr error) {
 	prompt := "> "
 	if gameName != "" {
 		prompt = "[" + gameName + "] > "
@@ -25,10 +33,10 @@ func readInput(r LineReader, gameName string) (text string, exit bool) {
 	if err != nil {
 		if errors.Is(err, io.EOF) {
 			fmt.Println(i18n.T("bye"))
-		} else {
-			fmt.Fprintln(os.Stderr, i18n.Tf("inputReadError", "error", err.Error()))
+			return "", true, nil
 		}
-		return "", true
+		fmt.Fprintln(os.Stderr, i18n.Tf("inputReadError", "error", err.Error()))
+		return "", true, err
 	}
-	return line, false
+	return line, false, nil
 }

--- a/internal/infrastructure/ui/input.go
+++ b/internal/infrastructure/ui/input.go
@@ -14,16 +14,18 @@ import (
 //
 //   - normal line: ("...", false, nil)
 //   - EOF (pipe drained, Ctrl+D, signalled-quit reader): ("", true, nil)
-//   - any other I/O error: ("", true, err)
+//   - any other I/O error: ("", true, err); inputReadError already written to stderr
 //
-// EOF and "exit" are clean shutdowns; only the non-EOF error path carries an
-// ioErr so callers can map it to a non-zero process exit code (issue #1839).
-// Matches the Updater's stdin contract (Updater.go: scan errors propagate as
-// errors), giving the whole CLI a consistent exit-code-on-stdin-failure rule.
+// Side effects are deliberately scoped to error reporting: the "bye" goodbye
+// line is printed by the top-level loop on EOF, not here, so a Ctrl+D inside
+// a wizard-style prompt only prints "bye" once rather than twice. EOF and
+// "exit" remain clean shutdowns; only the non-EOF path carries an ioErr so
+// callers can map it to a non-zero process exit code. Matches the Updater's
+// stdin contract (Updater.go: scan errors propagate as errors).
 //
 // The prompt is constructed here rather than in cui_runner.go so the same
 // "[gameName] > " format is used by the top-level loop and the wizard-style
-// prompt loop (issue #1605).
+// prompt loop.
 func readInput(r LineReader, gameName string) (text string, exit bool, ioErr error) {
 	prompt := "> "
 	if gameName != "" {
@@ -32,7 +34,6 @@ func readInput(r LineReader, gameName string) (text string, exit bool, ioErr err
 	line, err := r.Prompt(prompt)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
-			fmt.Println(i18n.T("bye"))
 			return "", true, nil
 		}
 		fmt.Fprintln(os.Stderr, i18n.Tf("inputReadError", "error", err.Error()))

--- a/internal/infrastructure/ui/input_test.go
+++ b/internal/infrastructure/ui/input_test.go
@@ -4,6 +4,7 @@ package ui
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 
@@ -50,11 +51,34 @@ func TestReadInput_WithGameName(t *testing.T) {
 			t.Parallel()
 			var promptBuf bytes.Buffer
 			reader := newScannerLineReader(strings.NewReader(tt.input), &promptBuf)
-			text, exit := readInput(reader, tt.gameName)
+			text, exit, ioErr := readInput(reader, tt.gameName)
 
 			assert.Equal(t, tt.wantPrompt, promptBuf.String())
 			assert.Equal(t, tt.wantText, text)
 			assert.Equal(t, tt.wantExit, exit)
+			// EOF and normal lines must both report a nil ioErr; only
+			// non-EOF I/O errors carry one (issue #1839).
+			assert.NoError(t, ioErr)
 		})
 	}
+}
+
+// erroringLineReader returns a fixed non-EOF error from Prompt. Used to
+// exercise the issue #1839 contract where readInput surfaces real read
+// failures as a non-nil ioErr while keeping EOF clean.
+type erroringLineReader struct{ err error }
+
+func (e *erroringLineReader) Prompt(_ string) (string, error)      { return "", e.err }
+func (e *erroringLineReader) AppendHistory(_ string)               {}
+func (e *erroringLineReader) SetCompleter(_ func(string) []string) {}
+func (e *erroringLineReader) Close() error                         { return nil }
+
+func TestReadInput_NonEOFError_ReturnsIOErr(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("pty hung up")
+	reader := &erroringLineReader{err: sentinel}
+	text, exit, ioErr := readInput(reader, "blackjack")
+	assert.Empty(t, text)
+	assert.True(t, exit, "non-EOF error must still stop the loop")
+	assert.ErrorIs(t, ioErr, sentinel, "non-EOF error must propagate as ioErr")
 }

--- a/internal/infrastructure/ui/prompt_loop_test.go
+++ b/internal/infrastructure/ui/prompt_loop_test.go
@@ -4,6 +4,7 @@ package ui
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 
@@ -35,7 +36,8 @@ func TestHandlePromptLoop_NoPrompt(t *testing.T) {
 	var buf bytes.Buffer
 	reader := newScannerLineReader(strings.NewReader(""), &buf)
 	me := &promptMockExecer{}
-	result := handlePromptLoop(reader, me, "normal result", "", &buf)
+	result, err := handlePromptLoop(reader, me, "normal result", "", &buf)
+	assert.NoError(t, err)
 	assert.Equal(t, "normal result", result)
 	assert.Empty(t, me.calls)
 }
@@ -47,7 +49,8 @@ func TestHandlePromptLoop_SinglePrompt(t *testing.T) {
 	reader := newScannerLineReader(strings.NewReader("100\n"), &buf)
 	me := &promptMockExecer{results: []string{"bet ok"}}
 	prompt := cuiutil.PromptRequest("Enter bet amount:", "b {0}")
-	result := handlePromptLoop(reader, me, prompt, "", &buf)
+	result, err := handlePromptLoop(reader, me, prompt, "", &buf)
+	assert.NoError(t, err)
 	assert.Equal(t, "bet ok", result)
 	assert.Equal(t, []string{"b 100"}, me.calls)
 	assert.Contains(t, buf.String(), "Enter bet amount:")
@@ -61,7 +64,8 @@ func TestHandlePromptLoop_ChainedPrompts(t *testing.T) {
 	secondPrompt := cuiutil.PromptRequest("Enter column:", "m t {0}")
 	me := &promptMockExecer{results: []string{secondPrompt, "move ok"}}
 	firstPrompt := cuiutil.PromptRequest("Enter source zone:", "m {0}")
-	result := handlePromptLoop(reader, me, firstPrompt, "klondike", &buf)
+	result, err := handlePromptLoop(reader, me, firstPrompt, "klondike", &buf)
+	assert.NoError(t, err)
 	assert.Equal(t, "move ok", result)
 	assert.Equal(t, []string{"m t", "m t 3"}, me.calls)
 }
@@ -72,7 +76,8 @@ func TestHandlePromptLoop_EmptyInput_Cancels(t *testing.T) {
 	reader := newScannerLineReader(strings.NewReader("\n"), &buf)
 	me := &promptMockExecer{}
 	prompt := cuiutil.PromptRequest("Enter amount:", "b {0}")
-	result := handlePromptLoop(reader, me, prompt, "", &buf)
+	result, err := handlePromptLoop(reader, me, prompt, "", &buf)
+	assert.NoError(t, err)
 	assert.Equal(t, i18n.T("cancelled"), result)
 	assert.Empty(t, me.calls)
 }
@@ -83,7 +88,8 @@ func TestHandlePromptLoop_EOF_ReturnsQuit(t *testing.T) {
 	reader := newScannerLineReader(strings.NewReader(""), &buf)
 	me := &promptMockExecer{}
 	prompt := cuiutil.PromptRequest("Enter amount:", "b {0}")
-	result := handlePromptLoop(reader, me, prompt, "", &buf)
+	result, err := handlePromptLoop(reader, me, prompt, "", &buf)
+	assert.NoError(t, err, "EOF inside a prompt is still a clean shutdown")
 	assert.Equal(t, i18n.QuitSentinel, result)
 	assert.Empty(t, me.calls)
 }
@@ -99,7 +105,7 @@ func TestHandlePromptLoop_GameNameInPrompt(t *testing.T) {
 	reader := newScannerLineReader(strings.NewReader("100\n"), &buf)
 	me := &promptMockExecer{results: []string{"bet ok"}}
 	prompt := cuiutil.PromptRequest("Enter bet amount:", "b {0}")
-	_ = handlePromptLoop(reader, me, prompt, "blackjack", &buf)
+	_, _ = handlePromptLoop(reader, me, prompt, "blackjack", &buf)
 	assert.Contains(t, buf.String(), "[blackjack] > ", "prompt must include gameName context")
 }
 
@@ -110,7 +116,25 @@ func TestHandlePromptLoop_MalformedPrompt(t *testing.T) {
 	me := &promptMockExecer{}
 	// Malformed: no tab separator, so template is empty
 	malformed := "PROMPT:Just a message"
-	result := handlePromptLoop(reader, me, malformed, "", &buf)
+	result, err := handlePromptLoop(reader, me, malformed, "", &buf)
+	assert.NoError(t, err)
 	assert.Equal(t, "Just a message", result)
+	assert.Empty(t, me.calls)
+}
+
+// TestHandlePromptLoop_NonEOFError_PropagatesIOErr verifies issue #1839: a
+// non-EOF stdin failure inside a wizard-style prompt surfaces as ioErr so the
+// top-level runner can return exit 1, not 0. EOF is unchanged (covered by
+// TestHandlePromptLoop_EOF_ReturnsQuit above).
+func TestHandlePromptLoop_NonEOFError_PropagatesIOErr(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	sentinel := errors.New("pty hung up")
+	reader := &erroringLineReader{err: sentinel}
+	me := &promptMockExecer{}
+	prompt := cuiutil.PromptRequest("Enter amount:", "b {0}")
+	result, err := handlePromptLoop(reader, me, prompt, "", &buf)
+	assert.ErrorIs(t, err, sentinel)
+	assert.Equal(t, i18n.QuitSentinel, result)
 	assert.Empty(t, me.calls)
 }

--- a/internal/infrastructure/ui/realtime_cui_runner.go
+++ b/internal/infrastructure/ui/realtime_cui_runner.go
@@ -111,22 +111,25 @@ func writeRealtimeOutput(w io.Writer, out string) {
 // stdio), it falls back to the standard line-mode loop so non-interactive
 // scripts keep working.
 //
+// Returns 0 on normal exit and the line-mode loop's code (0 normally, 1 on
+// non-EOF stdin error — issue #1839) when it falls back. The realtime loop
+// itself only exits on user quit / signal / stdin EOF, all of which are
+// clean shutdowns.
+//
 // Signal handling is local rather than via the package-level
 // setupSignalHandler — the latter calls os.Exit on SIGINT/SIGTERM, which
 // bypasses the deferred term.Restore and leaves the user's terminal in
 // raw mode. Here we close a quit channel instead, letting the loop return
 // normally and the deferred restore run.
-func RunRealtimeCuiLoop(gameName string, controller CuiExecer, helpLines []string) {
+func RunRealtimeCuiLoop(gameName string, controller CuiExecer, helpLines []string) int {
 	stdinFd := int(os.Stdin.Fd())
 	if !term.IsTerminal(stdinFd) {
-		RunCuiLoop(gameName, controller, helpLines)
-		return
+		return RunCuiLoop(gameName, controller, helpLines)
 	}
 	state, err := term.MakeRaw(stdinFd)
 	if err != nil {
 		// Raw mode failed (rare — e.g., unusual shells); degrade to line mode.
-		RunCuiLoop(gameName, controller, helpLines)
-		return
+		return RunCuiLoop(gameName, controller, helpLines)
 	}
 	defer func() { _ = term.Restore(stdinFd, state) }()
 
@@ -174,6 +177,7 @@ func RunRealtimeCuiLoop(gameName string, controller CuiExecer, helpLines []strin
 	realtimeCuiCore(controller, keys, ticks, quit, os.Stdout, SlapjackRealtimeKeyMap)
 	close(done)
 	fmt.Println(i18n.T("bye"))
+	return 0
 }
 
 // readRealtimeKeys reads single bytes from r and forwards them as runes.

--- a/internal/infrastructure/ui/realtime_cui_runner.go
+++ b/internal/infrastructure/ui/realtime_cui_runner.go
@@ -149,7 +149,10 @@ func RunRealtimeCuiLoop(gameName string, controller CuiExecer, helpLines []strin
 	}()
 
 	keys := make(chan rune)
-	go readRealtimeKeys(os.Stdin, keys)
+	// Buffered so the reader goroutine never blocks waiting for us to
+	// consume the final error after we've already returned from the core.
+	errCh := make(chan error, 1)
+	go readRealtimeKeys(os.Stdin, keys, errCh)
 
 	ticker := time.NewTicker(SlapjackRealtimeTickInterval)
 	defer ticker.Stop()
@@ -176,20 +179,40 @@ func RunRealtimeCuiLoop(gameName string, controller CuiExecer, helpLines []strin
 
 	realtimeCuiCore(controller, keys, ticks, quit, os.Stdout, SlapjackRealtimeKeyMap)
 	close(done)
+	// Pick up any non-EOF stdin error the reader recorded before the keys
+	// channel closed. Non-blocking: EOF / signal exits leave errCh empty.
+	select {
+	case err := <-errCh:
+		if err != nil {
+			fmt.Fprintln(os.Stderr, i18n.Tf("inputReadError", "error", err.Error()))
+			return 1
+		}
+	default:
+	}
 	fmt.Println(i18n.T("bye"))
 	return 0
 }
 
 // readRealtimeKeys reads single bytes from r and forwards them as runes.
-// Closes keys on EOF or unrecoverable error so the core loop exits.
-func readRealtimeKeys(r io.Reader, keys chan<- rune) {
+// Closes keys on EOF or unrecoverable error so the core loop exits, and
+// sends the error on errCh for non-EOF failures so the caller can surface
+// them as exit 1 instead of swallowing them. EOF sends nothing — it is a
+// clean shutdown.
+func readRealtimeKeys(r io.Reader, keys chan<- rune, errCh chan<- error) {
 	defer close(keys)
 	br := bufio.NewReader(r)
 	for {
 		b, err := br.ReadByte()
 		if err != nil {
-			if errors.Is(err, io.EOF) {
-				return
+			if !errors.Is(err, io.EOF) {
+				// Non-blocking: errCh is buffered with cap 1 and is only
+				// ever sent to here, so this select cannot block; the
+				// default branch guards against any future redesign that
+				// might bypass that invariant.
+				select {
+				case errCh <- err:
+				default:
+				}
 			}
 			return
 		}

--- a/internal/infrastructure/ui/realtime_cui_runner_test.go
+++ b/internal/infrastructure/ui/realtime_cui_runner_test.go
@@ -4,12 +4,61 @@ package ui
 
 import (
 	"bytes"
+	"errors"
+	"io"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// erroringByteReader returns a fixed non-EOF error after streaming zero
+// bytes. Used to exercise the readRealtimeKeys contract that non-EOF read
+// failures are surfaced on errCh while keys is still closed cleanly.
+type erroringByteReader struct{ err error }
+
+func (e *erroringByteReader) Read(_ []byte) (int, error) { return 0, e.err }
+
+// TestReadRealtimeKeys_EOFLeavesErrChEmpty verifies that a clean EOF stops
+// the reader without writing to errCh — the caller must see no error and
+// can return exit 0.
+func TestReadRealtimeKeys_EOFLeavesErrChEmpty(t *testing.T) {
+	t.Parallel()
+	keys := make(chan rune)
+	errCh := make(chan error, 1)
+	go readRealtimeKeys(&erroringByteReader{err: io.EOF}, keys, errCh)
+	// Drain keys; the goroutine must close it without sending anything.
+	for range keys {
+		t.Fatalf("expected no key bytes on EOF reader")
+	}
+	select {
+	case got := <-errCh:
+		t.Fatalf("EOF must not surface on errCh, got %v", got)
+	default:
+	}
+}
+
+// TestReadRealtimeKeys_NonEOFErrorSurfacesOnErrCh verifies the contract the
+// realtime runner relies on for exit code 1: a non-EOF read failure both
+// closes keys (so realtimeCuiCore returns) and lands on errCh (so the
+// runner can map it to exit 1) — addresses gemini's "MUST" feedback.
+func TestReadRealtimeKeys_NonEOFErrorSurfacesOnErrCh(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("pty hung up")
+	keys := make(chan rune)
+	errCh := make(chan error, 1)
+	go readRealtimeKeys(&erroringByteReader{err: sentinel}, keys, errCh)
+	for range keys {
+		t.Fatalf("expected no key bytes on erroring reader")
+	}
+	select {
+	case got := <-errCh:
+		assert.ErrorIs(t, got, sentinel)
+	case <-time.After(time.Second):
+		t.Fatal("non-EOF reader error did not surface on errCh")
+	}
+}
 
 // realtimeMockExecer records every command Exec receives and returns
 // canned responses. Unmatched calls return an empty string so the


### PR DESCRIPTION
## Summary

Make interactive CUI loops propagate non-EOF stdin read failures as exit code 1, so a broken pty / dropped pipe / dying liner is detectable by systemd / CI / supervisor scripts instead of silently exiting 0.

- `readInput` now returns `(text, exit, ioErr)`. EOF → `("", true, nil)` (clean shutdown, still exits 0). Any other read error → `("", true, err)`.
- `RunInteractiveCuiLoop`, `RunCuiLoop`, and `RunRealtimeCuiLoop` return `int`; `handlePromptLoop` returns `(string, error)`. The top-level dispatchers in `main.go` thread the code up to the OS.
- `EXIT CODES` table updated: `1 General error (e.g., web server failed to start, interactive input read error)`.

Aligns the interactive CUI's exit contract with the Updater's stdin contract (`Updater.go` already propagates `fmt.Fscanln` errors as errors).

## Backward compatibility

- EOF and `exit`/`quit` still exit 0.
- Signals still exit 130/143.
- Only **non-EOF read errors** flip from 0 → 1.

## Test plan

- [x] `go test -tags test -race ./...`
- [x] `golangci-lint run ./internal/infrastructure/ui/... ./cmd/trumpcards/...`
- [x] `goimports -w` applied
- [x] New test `TestReadInput_NonEOFError_ReturnsIOErr` covers the new return path
- [x] New test `TestHandlePromptLoop_NonEOFError_PropagatesIOErr` covers wizard-prompt propagation
- [x] All pre-existing `readInput` / `handlePromptLoop` tests updated to the new arities

Closes #1839