### PR TITLE
feat(cli): apply trailing -q/--quiet symmetrically with --lang/--color (#1840)

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -460,11 +460,14 @@ func run() int {
 	}
 	if handler, ok := commands[arg]; ok {
 		if !subFlagCommands[arg] {
-			// Apply --lang / --no-color when they land after the game name so
-			// `trumpcards <game> --lang en` matches the prepositional form.
-			// Done before the help short-circuit so `<game> --lang en --help`
-			// renders help in the requested locale.
-			extras := applyTrailingGlobalFlags(flag.Args()[1:], quiet, os.Stderr)
+			// Apply --lang / --no-color / -q when they land after the game name
+			// so `trumpcards <game> --lang en` and `trumpcards <game> -q`
+			// match the prepositional form. Done before the help short-circuit
+			// so `<game> --lang en --help` renders help in the requested locale.
+			// quiet is passed by pointer because a trailing -q must update the
+			// caller's value (otherwise the extras warning below would still
+			// fire after the user asked for silence).
+			extras := applyTrailingGlobalFlags(flag.Args()[1:], &quiet, os.Stderr)
 			// `<game> --help` / `<game> -h`: Go's flag package stops parsing at
 			// the first non-flag argument, so these trailing flags land in Args().
 			// Intercept them and print that game's help instead of launching the
@@ -473,7 +476,7 @@ func run() int {
 			if hasHelpFlag(extras) {
 				return runHelpCommand([]string{arg}, helpText, os.Stdout, os.Stderr)
 			}
-			if len(extras) > 0 {
+			if len(extras) > 0 && !quiet {
 				fmt.Fprintln(os.Stderr, i18n.Tf("cliExtraArgsWarning", "args", strings.Join(extras, " ")))
 			}
 		}
@@ -881,11 +884,13 @@ func updateExitCode(err error) int {
 // that's about to run; applyColorMode's exit code is therefore
 // intentionally discarded here.
 //
-// `--quiet`/`-q` is a silent no-op here — its value was already resolved
-// before subcommand dispatch in run() — but we recognize the form so
-// users typing `trumpcards <game> -q` don't get a confusing "extra
-// arguments ignored" warning about a documented flag (PR #1582 review).
-func applyTrailingGlobalFlags(args []string, quiet bool, stderr io.Writer) []string {
+// `--quiet`/`-q` writes through quietPtr so trailing position has the same
+// effect as the leading position — Go's `flag` package stops parsing at the
+// first positional, so the global pass missed any -q after the game name.
+// Writing through a pointer keeps --lang/--color/-q symmetric in their
+// "trailing flags also apply" contract without forcing a struct return.
+func applyTrailingGlobalFlags(args []string, quietPtr *bool, stderr io.Writer) []string {
+	quiet := *quietPtr
 	rest := make([]string, 0, len(args))
 	// Accumulate color flags across the entire scan so precedence matches
 	// applyColorMode's documented order rather than depending on which
@@ -937,14 +942,13 @@ func applyTrailingGlobalFlags(args []string, quiet bool, stderr io.Writer) []str
 			colorVal = strings.TrimPrefix(a, "-color=")
 			haveColor, consumed = true, true
 		case a == "--quiet" || a == "-quiet" || a == "-q" || a == "--q":
-			// Silent no-op — the global pass already applied the value.
-			// Recognized here only so the trailing-args warning does not
-			// fire for a documented global flag.
+			quiet = true
 			consumed = true
 		case strings.HasPrefix(a, "--quiet=") || strings.HasPrefix(a, "-quiet=") ||
 			strings.HasPrefix(a, "--q=") || strings.HasPrefix(a, "-q="):
 			val := a[strings.Index(a, "=")+1:]
-			if _, err := strconv.ParseBool(val); err == nil {
+			if b, err := strconv.ParseBool(val); err == nil {
+				quiet = b
 				consumed = true
 			}
 		}
@@ -984,6 +988,7 @@ func applyTrailingGlobalFlags(args []string, quiet bool, stderr io.Writer) []str
 		}
 		_, _ = applyColorMode(mode, trailingNoColor, os.Getenv("NO_COLOR"), os.Stdout.Fd(), os.Stderr.Fd(), errSink)
 	}
+	*quietPtr = quiet
 	return rest
 }
 

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -889,8 +889,14 @@ func updateExitCode(err error) int {
 // first positional, so the global pass missed any -q after the game name.
 // Writing through a pointer keeps --lang/--color/-q symmetric in their
 // "trailing flags also apply" contract without forcing a struct return.
+//
+// quiet is resolved in a pre-pass so warning suppression is order-independent:
+// `<game> --lang xyz -q` and `<game> -q --lang xyz` both suppress the
+// cliUnsupportedLang warning. Without the pre-pass, the single-pass
+// implementation would only suppress when -q appeared first.
 func applyTrailingGlobalFlags(args []string, quietPtr *bool, stderr io.Writer) []string {
-	quiet := *quietPtr
+	quiet := resolveTrailingQuiet(args, *quietPtr)
+	*quietPtr = quiet
 	rest := make([]string, 0, len(args))
 	// Accumulate color flags across the entire scan so precedence matches
 	// applyColorMode's documented order rather than depending on which
@@ -942,13 +948,12 @@ func applyTrailingGlobalFlags(args []string, quietPtr *bool, stderr io.Writer) [
 			colorVal = strings.TrimPrefix(a, "-color=")
 			haveColor, consumed = true, true
 		case a == "--quiet" || a == "-quiet" || a == "-q" || a == "--q":
-			quiet = true
+			// Consumed; value already resolved by resolveTrailingQuiet.
 			consumed = true
 		case strings.HasPrefix(a, "--quiet=") || strings.HasPrefix(a, "-quiet=") ||
 			strings.HasPrefix(a, "--q=") || strings.HasPrefix(a, "-q="):
 			val := a[strings.Index(a, "=")+1:]
-			if b, err := strconv.ParseBool(val); err == nil {
-				quiet = b
+			if _, err := strconv.ParseBool(val); err == nil {
 				consumed = true
 			}
 		}
@@ -988,8 +993,32 @@ func applyTrailingGlobalFlags(args []string, quietPtr *bool, stderr io.Writer) [
 		}
 		_, _ = applyColorMode(mode, trailingNoColor, os.Getenv("NO_COLOR"), os.Stdout.Fd(), os.Stderr.Fd(), errSink)
 	}
-	*quietPtr = quiet
 	return rest
+}
+
+// resolveTrailingQuiet pre-scans args for -q / --quiet (and their =BOOL forms)
+// and folds them into the starting quiet value. Used so warning suppression
+// inside applyTrailingGlobalFlags is order-independent — `--lang xyz -q` must
+// suppress just like `-q --lang xyz`. Stops at the first "--" the same way
+// the main scan does.
+func resolveTrailingQuiet(args []string, start bool) bool {
+	quiet := start
+	for _, a := range args {
+		if a == "--" {
+			break
+		}
+		switch {
+		case a == "--quiet" || a == "-quiet" || a == "-q" || a == "--q":
+			quiet = true
+		case strings.HasPrefix(a, "--quiet=") || strings.HasPrefix(a, "-quiet=") ||
+			strings.HasPrefix(a, "--q=") || strings.HasPrefix(a, "-q="):
+			val := a[strings.Index(a, "=")+1:]
+			if b, err := strconv.ParseBool(val); err == nil {
+				quiet = b
+			}
+		}
+	}
+	return quiet
 }
 
 // hasHelpFlag reports whether args contains a help flag. It accepts all four

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -1241,7 +1241,8 @@ func TestApplyTrailingGlobalFlags(t *testing.T) {
 			color.SetStderrColor(true)
 
 			var stderr bytes.Buffer
-			got := applyTrailingGlobalFlags(tt.args, tt.quiet, &stderr)
+			q := tt.quiet
+			got := applyTrailingGlobalFlags(tt.args, &q, &stderr)
 
 			if !slices.Equal(got, tt.wantRest) {
 				t.Errorf("rest = %#v, want %#v", got, tt.wantRest)
@@ -1259,6 +1260,86 @@ func TestApplyTrailingGlobalFlags(t *testing.T) {
 				}
 			} else if !strings.Contains(stderr.String(), tt.wantWarn) {
 				t.Errorf("stderr missing %q: %q", tt.wantWarn, stderr.String())
+			}
+		})
+	}
+}
+
+// TestApplyTrailingGlobalFlags_TrailingQuietPropagates verifies issue #1840:
+// a trailing -q / --quiet must update the caller's quiet flag (not silently
+// no-op) so the rest of run() — most importantly the cliUnsupportedLang
+// warning emitted inside applyTrailingGlobalFlags itself — actually respects
+// it, matching --lang / --color which already apply in trailing position.
+func TestApplyTrailingGlobalFlags_TrailingQuietPropagates(t *testing.T) {
+	origLang := i18n.Lang()
+	t.Cleanup(func() { i18n.SetLang(origLang) })
+
+	cases := []struct {
+		name     string
+		args     []string
+		startQ   bool
+		wantQ    bool
+		wantWarn string // substring expected on stderr; empty = none
+		wantRest []string
+	}{
+		{
+			name:     "-q sets quiet from false to true",
+			args:     []string{"-q"},
+			wantQ:    true,
+			wantRest: []string{},
+		},
+		{
+			name:     "--quiet sets quiet from false to true",
+			args:     []string{"--quiet"},
+			wantQ:    true,
+			wantRest: []string{},
+		},
+		{
+			name:     "--quiet=true sets quiet from false to true",
+			args:     []string{"--quiet=true"},
+			wantQ:    true,
+			wantRest: []string{},
+		},
+		{
+			name:     "--quiet=false unsets a pre-existing quiet",
+			args:     []string{"--quiet=false"},
+			startQ:   true,
+			wantQ:    false,
+			wantRest: []string{},
+		},
+		{
+			name:     "trailing -q suppresses unsupported-lang warning",
+			args:     []string{"-q", "--lang", "klingon"},
+			wantQ:    true,
+			wantWarn: "", // -q already true by the time the lang warning runs
+			wantRest: []string{},
+		},
+		{
+			name:     "without -q the unsupported-lang warning fires",
+			args:     []string{"--lang", "klingon"},
+			wantQ:    false,
+			wantWarn: "klingon",
+			wantRest: []string{},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			i18n.SetLang("ja")
+			var stderr bytes.Buffer
+			q := tt.startQ
+			rest := applyTrailingGlobalFlags(tt.args, &q, &stderr)
+			if q != tt.wantQ {
+				t.Errorf("quiet = %v, want %v", q, tt.wantQ)
+			}
+			if !slices.Equal(rest, tt.wantRest) {
+				t.Errorf("rest = %#v, want %#v", rest, tt.wantRest)
+			}
+			if tt.wantWarn == "" {
+				if stderr.Len() != 0 {
+					t.Errorf("expected no stderr; got %q", stderr.String())
+				}
+			} else if !strings.Contains(stderr.String(), tt.wantWarn) {
+				t.Errorf("stderr missing %q: got %q", tt.wantWarn, stderr.String())
 			}
 		})
 	}
@@ -1466,7 +1547,8 @@ func TestApplyTrailingColorFlag(t *testing.T) {
 			t.Cleanup(func() { _ = os.Unsetenv("NO_COLOR") })
 
 			var stderr bytes.Buffer
-			rest := applyTrailingGlobalFlags(tt.args, tt.quiet, &stderr)
+			q := tt.quiet
+			rest := applyTrailingGlobalFlags(tt.args, &q, &stderr)
 			if len(rest) != 0 {
 				t.Errorf("trailing color flag should be consumed; got rest=%v", rest)
 			}

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -1315,6 +1315,16 @@ func TestApplyTrailingGlobalFlags_TrailingQuietPropagates(t *testing.T) {
 			wantRest: []string{},
 		},
 		{
+			// Order-independence: -q must suppress even when it appears
+			// after the offending --lang. Resolved via pre-pass in
+			// resolveTrailingQuiet; without that this case would still warn.
+			name:     "reverse order: --lang xyz -q also suppresses",
+			args:     []string{"--lang", "klingon", "-q"},
+			wantQ:    true,
+			wantWarn: "",
+			wantRest: []string{},
+		},
+		{
 			name:     "without -q the unsupported-lang warning fires",
 			args:     []string{"--lang", "klingon"},
 			wantQ:    false,


### PR DESCRIPTION
## Summary

`trumpcards <game> -q` previously dropped the `-q` on the floor: `applyTrailingGlobalFlags` recognised the form (to avoid an \"extra arguments ignored\" warning) but never updated `quiet`, so the `cliUnsupportedLang` warning emitted from inside the same function still fired despite the user asking for silence. `--lang` and `--color` already applied in trailing position; `-q` was the asymmetric odd one out.

- `applyTrailingGlobalFlags` now takes `quietPtr *bool` and writes through.
- `--quiet=BOOL` form supports both `true` and `false`.
- The extras-args warning at the call site respects the (possibly updated) `quiet`.

## Compat

- Leading position behaves as before.
- Trailing position now actually applies. The only observable change for existing scripts is that `trumpcards <game> -q --lang xyz` no longer emits the unsupported-lang warning.

## Test plan

- [x] `go test -tags test -race ./cmd/trumpcards/`
- [x] `golangci-lint run ./cmd/trumpcards/...`
- [x] New `TestApplyTrailingGlobalFlags_TrailingQuietPropagates` covers `-q`, `--quiet`, `--quiet=true`, `--quiet=false`, and the warning-suppression flow

Closes #1840