### PR TITLE
fix(pineapple): use selectedCardStyle helper for discard selection (#1841)

### DIFF
--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -394,11 +394,11 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
                           aria-pressed={canDiscard ? selectedDiscard === idx : undefined}
                           className={canDiscard ? 'cursor-pointer' : 'cursor-default'}
                           disabled={!canDiscard}
+                          style={selectedCardStyle(canDiscard && selectedDiscard === idx)}
                         >
                           <AnimatedCard
                             card={card}
                             width={cardWidth}
-                            style={selectedCardStyle(canDiscard && selectedDiscard === idx)}
                             onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         </button>

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -33,6 +33,7 @@ import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { selectedCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -397,10 +398,7 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
                           <AnimatedCard
                             card={card}
                             width={cardWidth}
-                            style={{
-                              border:
-                                canDiscard && selectedDiscard === idx ? '3px solid #f59e0b' : '3px solid transparent',
-                            }}
+                            style={selectedCardStyle(canDiscard && selectedDiscard === idx)}
                             onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         </button>


### PR DESCRIPTION
## Summary

PineapplePage's discard-selectable card used an inline border with the magic color `#f59e0b` (Tailwind amber-500, unrelated to the design tokens). Replace with the shared `selectedCardStyle()` helper from `src/styles/cardStyles.ts` so:

- The blue \"selected = card-selected token + 8px lift + glow\" pattern used by Poker / Mighty / Euchre / GoFish / CrazyEights / Oh Hell / Napoleon / PageOne / SevenBridge is now consistent on Pineapple too.
- Selection feedback is multi-modal (border + transform + box-shadow), not just color — better for color-vision deficiency.
- The `--color-game-card-selected` design token becomes the SSoT; future theme changes propagate automatically.

## Before / After

```tsx
// Before
<AnimatedCard
  style={{
    border: canDiscard && selectedDiscard === idx ? '3px solid #f59e0b' : '3px solid transparent',
  }}
/>

// After
<AnimatedCard style={selectedCardStyle(canDiscard && selectedDiscard === idx)} />
```

## Test plan

- [x] `bun run check` (biome + design-tokens) — clean
- [x] `bun run test -- --run PineapplePage` — 12/12 pass
- [x] `bun run build` not run locally (Node OOM on 2 GB host — CI handles it)

Closes #1841