### PR TITLE
refactor: hoist 19 hardcoded card placeholder borders into placeholderCardStyle (#1844)

### DIFF
--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -33,6 +33,7 @@ import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { placeholderCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -256,7 +257,7 @@ function HoldemPageContent() {
                             key={`${card.design}-${card.value}`}
                             card={card}
                             width={cardWidth}
-                            style={{ border: '3px solid transparent' }}
+                            style={placeholderCardStyle}
                             onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))
@@ -360,7 +361,7 @@ function HoldemPageContent() {
                           key={`${card.design}-${card.value}`}
                           card={card}
                           width={cardWidth}
-                          style={{ border: '3px solid transparent' }}
+                          style={placeholderCardStyle}
                           onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       ))

--- a/frontend/src/pages/IndianPokerPage.tsx
+++ b/frontend/src/pages/IndianPokerPage.tsx
@@ -28,6 +28,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
+import { placeholderCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { IndianPokerResponse } from '../types/card';
@@ -240,7 +241,7 @@ function IndianPokerPageContent() {
                         <AnimatedCard
                           card={p.card}
                           width={cardWidth}
-                          style={{ border: '3px solid transparent' }}
+                          style={placeholderCardStyle}
                           onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       ) : (
@@ -289,7 +290,7 @@ function IndianPokerPageContent() {
                     <AnimatedCard
                       card={humanPlayer.card}
                       width={cardWidth}
-                      style={{ border: '3px solid transparent' }}
+                      style={placeholderCardStyle}
                       onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                     />
                   ) : !humanPlayer.folded ? (

--- a/frontend/src/pages/OmahaHiLoPage.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.tsx
@@ -33,6 +33,7 @@ import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { placeholderCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -256,7 +257,7 @@ function OmahaHiLoPageContent() {
                             key={`${card.design}-${card.value}`}
                             card={card}
                             width={cardWidth}
-                            style={{ border: '3px solid transparent' }}
+                            style={placeholderCardStyle}
                             onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))
@@ -367,7 +368,7 @@ function OmahaHiLoPageContent() {
                           key={`${card.design}-${card.value}`}
                           card={card}
                           width={cardWidth}
-                          style={{ border: '3px solid transparent' }}
+                          style={placeholderCardStyle}
                           onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       ))

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -33,6 +33,7 @@ import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { placeholderCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -255,7 +256,7 @@ function OmahaPageContent() {
                             key={`${card.design}-${card.value}`}
                             card={card}
                             width={cardWidth}
-                            style={{ border: '3px solid transparent' }}
+                            style={placeholderCardStyle}
                             onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))
@@ -366,7 +367,7 @@ function OmahaPageContent() {
                           key={`${card.design}-${card.value}`}
                           card={card}
                           width={cardWidth}
-                          style={{ border: '3px solid transparent' }}
+                          style={placeholderCardStyle}
                           onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       ))

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -33,7 +33,7 @@ import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
-import { selectedCardStyle } from '../styles/cardStyles';
+import { placeholderCardStyle, selectedCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -286,7 +286,7 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
                             key={`${card.design}-${card.value}`}
                             card={card}
                             width={cardWidth}
-                            style={{ border: '3px solid transparent' }}
+                            style={placeholderCardStyle}
                             onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))

--- a/frontend/src/pages/RazzPage.tsx
+++ b/frontend/src/pages/RazzPage.tsx
@@ -29,6 +29,7 @@ import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { placeholderCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -315,7 +316,7 @@ function RazzPageContent() {
                             key={`${card.design}-${card.value}`}
                             card={card}
                             width={cardWidth}
-                            style={{ border: '3px solid transparent' }}
+                            style={placeholderCardStyle}
                             onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))
@@ -333,7 +334,7 @@ function RazzPageContent() {
                             key={`${card.design}-${card.value}`}
                             card={card}
                             width={cardWidth}
-                            style={{ border: '3px solid transparent' }}
+                            style={placeholderCardStyle}
                             onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))
@@ -395,7 +396,7 @@ function RazzPageContent() {
                           key={`${card.design}-${card.value}`}
                           card={card}
                           width={cardWidth}
-                          style={{ border: '3px solid transparent' }}
+                          style={placeholderCardStyle}
                           onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       ))
@@ -413,7 +414,7 @@ function RazzPageContent() {
                           key={`${card.design}-${card.value}`}
                           card={card}
                           width={cardWidth}
-                          style={{ border: '3px solid transparent' }}
+                          style={placeholderCardStyle}
                           onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       ))

--- a/frontend/src/pages/SevenCardStudPage.tsx
+++ b/frontend/src/pages/SevenCardStudPage.tsx
@@ -29,6 +29,7 @@ import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { placeholderCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -316,7 +317,7 @@ function SevenCardStudPageContent() {
                             key={`${card.design}-${card.value}`}
                             card={card}
                             width={cardWidth}
-                            style={{ border: '3px solid transparent' }}
+                            style={placeholderCardStyle}
                             onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))
@@ -334,7 +335,7 @@ function SevenCardStudPageContent() {
                             key={`${card.design}-${card.value}`}
                             card={card}
                             width={cardWidth}
-                            style={{ border: '3px solid transparent' }}
+                            style={placeholderCardStyle}
                             onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))
@@ -396,7 +397,7 @@ function SevenCardStudPageContent() {
                           key={`${card.design}-${card.value}`}
                           card={card}
                           width={cardWidth}
-                          style={{ border: '3px solid transparent' }}
+                          style={placeholderCardStyle}
                           onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       ))
@@ -414,7 +415,7 @@ function SevenCardStudPageContent() {
                           key={`${card.design}-${card.value}`}
                           card={card}
                           width={cardWidth}
-                          style={{ border: '3px solid transparent' }}
+                          style={placeholderCardStyle}
                           onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       ))

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -33,6 +33,7 @@ import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { placeholderCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -255,7 +256,7 @@ function ShortDeckPageContent() {
                             key={`${card.design}-${card.value}`}
                             card={card}
                             width={cardWidth}
-                            style={{ border: '3px solid transparent' }}
+                            style={placeholderCardStyle}
                             onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))
@@ -360,7 +361,7 @@ function ShortDeckPageContent() {
                           key={`${card.design}-${card.value}`}
                           card={card}
                           width={cardWidth}
-                          style={{ border: '3px solid transparent' }}
+                          style={placeholderCardStyle}
                           onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       ))

--- a/frontend/src/styles/cardStyles.ts
+++ b/frontend/src/styles/cardStyles.ts
@@ -8,6 +8,15 @@ export const focusRingCard =
 /** Tailwind classes for hover feedback on clickable cards (non-AnimatedCard). */
 export const hoverCardClass = 'cursor-pointer transition-[transform,box-shadow] duration-150';
 
+/**
+ * Transparent placeholder border for cards that are never selectable but
+ * sit next to selectable ones. Keeps their box-model width identical to a
+ * `selectedCardStyle(false)` card so the layout doesn't jump when selection
+ * toggles in adjacent rows. Single source of truth for the unselectable
+ * "no visual feedback" state.
+ */
+export const placeholderCardStyle: React.CSSProperties = { border: '3px solid transparent' };
+
 /** Return inline styles for a card with selection highlight and lift effect. */
 export function selectedCardStyle(isSelected: boolean): React.CSSProperties {
   return {


### PR DESCRIPTION
## Summary

Replace 19 inline `style={{ border: '3px solid transparent' }}` sites across 8 pages with a new `placeholderCardStyle` constant in `src/styles/cardStyles.ts`.

The `'3px solid transparent'` literal is a width-preserving placeholder for cards adjacent to selectable ones — they must reserve the same 3px that `selectedCardStyle(true)` uses so the layout doesn't shift on selection. Centralizing it:

- Kills 19 duplicated magic strings (DRY).
- Gives the unselectable card state a single source of truth so future DESIGN.md adjustments (border colour, thickness, glow…) don't have to grep across pages.
- Closes the same drift class that #1841 fixed for the selected variant — now both selected and placeholder states route through `cardStyles.ts`.

## Sites touched (19 / 8 files)

| File | Sites |
|---|---|
| `HoldemPage.tsx` | 2 |
| `OmahaPage.tsx` | 2 |
| `OmahaHiLoPage.tsx` | 2 |
| `ShortDeckPage.tsx` | 2 |
| `PineapplePage.tsx` | 1 |
| `IndianPokerPage.tsx` | 2 |
| `RazzPage.tsx` | 4 |
| `SevenCardStudPage.tsx` | 4 |

## Test plan

- [x] `bun run check` clean
- [x] `bun run test -- --run` 641/641 tests across the 8 affected pages pass
- [x] No tests asserted on the literal `'3px solid transparent'` for these sites; the only test files that do (`PokerPage.test.tsx`, `DaifugoHumanArea.test.tsx`, `DoubtHandCard.test.tsx`) test different sites that go through `selectedCardStyle(false)` and remain valid

Closes #1844