### PR TITLE
refactor(motion): internalize default deal/flip SFX in AnimatedCard/Back; drop ~194 duplicate inline callbacks (#1845)

### DIFF
--- a/frontend/src/components/TrickDisplay.test.tsx
+++ b/frontend/src/components/TrickDisplay.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import type { Card } from '../types/card';
 import { TrickDisplay, type TrickDisplayCard, type TrickDisplayPlayer } from './TrickDisplay';
 
@@ -54,11 +54,8 @@ describe('TrickDisplay', () => {
     expect(screen.getByText('CPU 7')).toBeInTheDocument();
   });
 
-  it('renders correctly when onCardDealComplete is provided', () => {
-    const onDeal = vi.fn();
-    render(
-      <TrickDisplay currentTrick={trick} players={players} cardWidth={40} label="label" onCardDealComplete={onDeal} />,
-    );
+  it('renders one AnimatedCard per trick entry', () => {
+    render(<TrickDisplay currentTrick={trick} players={players} cardWidth={40} label="label" />);
     expect(screen.getAllByTestId('animated-card')).toHaveLength(2);
   });
 });

--- a/frontend/src/components/TrickDisplay.tsx
+++ b/frontend/src/components/TrickDisplay.tsx
@@ -26,23 +26,15 @@ export interface TrickDisplayProps {
   label: string;
   /** Value for the `data-tutorial` attribute (e.g. `"ht-trick-display"`). */
   dataTutorial?: string;
-  /** Forwarded to {@link AnimatedCard#onDealComplete}; typically plays a deal sound. */
-  onCardDealComplete?: () => void;
 }
 
 /**
  * Shared trick-display area for trick-taking games (Hearts, Spades, Euchre, Bridge,
  * Napoleon, OhHell, TwoTenJack, Whist). Renders each played card with the player's
- * name underneath, or nothing when the trick is empty.
+ * name underneath, or nothing when the trick is empty. AnimatedCard plays the
+ * default deal SFX itself, so callers no longer need to thread a sound callback.
  */
-export function TrickDisplay({
-  currentTrick,
-  players,
-  cardWidth,
-  label,
-  dataTutorial,
-  onCardDealComplete,
-}: TrickDisplayProps) {
+export function TrickDisplay({ currentTrick, players, cardWidth, label, dataTutorial }: TrickDisplayProps) {
   if (currentTrick.length === 0) {
     return null;
   }
@@ -52,7 +44,7 @@ export function TrickDisplay({
       <div className="flex gap-2">
         {currentTrick.map((trickCard) => (
           <div key={`trick-${trickCard.playerIdx}`} className="text-center">
-            <AnimatedCard card={trickCard.card} width={cardWidth} onDealComplete={onCardDealComplete} />
+            <AnimatedCard card={trickCard.card} width={cardWidth} />
             <div className="text-game-text-muted text-xs mt-1">
               {playerName(
                 players[trickCard.playerIdx]?.id ?? trickCard.playerIdx,

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -235,11 +235,7 @@ export function VideoPokerGameContent({
                         aria-label={displayHeld[i] ? `${tNs('hold')} ${i}` : tNs('card', { index: i })}
                         aria-pressed={displayHeld[i] ?? false}
                       >
-                        <AnimatedCard
-                          card={card}
-                          width={cardWidth}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                        />
+                        <AnimatedCard card={card} width={cardWidth} />
                       </button>
                       {displayHeld[i] && <span className="text-ds-warning text-xs font-bold mt-1">{tNs('hold')}</span>}
                     </div>

--- a/frontend/src/components/motion/AnimatedCard.test.tsx
+++ b/frontend/src/components/motion/AnimatedCard.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import type { Card } from '../../types/card';
 import { AnimatedCard } from './AnimatedCard';
@@ -10,6 +11,31 @@ vi.mock('../../hooks/useReducedMotion', () => ({
 }));
 
 import { useReducedMotion } from '../../hooks/useReducedMotion';
+
+const mockPlaySound = vi.fn();
+
+// Mock the SoundProvider module: useOptionalSound returns a spyable
+// playSound. This lets us assert on the default-SFX contract introduced
+// by issue #1845 without spinning up the real provider (and its Howler
+// init) in unit tests.
+vi.mock('../../providers/SoundProvider', () => ({
+  useOptionalSound: () => ({ playSound: mockPlaySound, muted: false, toggleMute: vi.fn() }),
+}));
+
+function renderAndCompleteAnim(node: ReactNode) {
+  // Framer Motion fires onAnimationComplete naturally; jsdom doesn't run
+  // its RAF loop in tests, so we invoke the wrapper via the motion.div's
+  // onAnimationComplete callback. Easiest path: render and walk the
+  // motion.div instance through its callback prop. With the vi.mock for
+  // useReducedMotion forcing animated mode, the motion.div is rendered;
+  // we trigger animation completion by dispatching a custom event the
+  // component already listens for via framer-motion. In practice, the
+  // simplest contract test is to set up the mock and assert on the
+  // playSound call after first animation cycle — framer-motion fires
+  // onAnimationComplete synchronously on mount in jsdom when no real
+  // animation can run.
+  return render(node);
+}
 
 describe('AnimatedCard', () => {
   it('renders animated wrapper when motion is enabled', () => {
@@ -76,5 +102,30 @@ describe('AnimatedCard', () => {
     const onDealComplete = vi.fn();
     render(<AnimatedCard card={mockCard} onDealComplete={onDealComplete} />);
     expect(screen.queryByTestId('animated-card')).not.toBeInTheDocument();
+  });
+
+  describe('default SFX contract (issue #1845)', () => {
+    // After issue #1845, AnimatedCard internally plays the 'cardDeal' SFX
+    // on deal-in completion. Page-level callsites no longer need to
+    // duplicate this. The `silent` prop opts out for parents that play
+    // their own placement sound. Tests below pin the contract — framer-
+    // motion fires onAnimationComplete synchronously in jsdom (no real
+    // animation runs), so we can assert on the spy directly after render.
+    it('accepts the silent prop without rendering changes', () => {
+      vi.mocked(useReducedMotion).mockReturnValue(false);
+      renderAndCompleteAnim(<AnimatedCard card={mockCard} silent />);
+      expect(screen.getByTestId('animated-card')).toBeInTheDocument();
+    });
+
+    it('still mounts when called outside a SoundProvider (graceful degrade)', () => {
+      // useOptionalSound returns null when there is no provider; the
+      // component must not throw. The mock at the top of this file makes
+      // useOptionalSound non-null here, but the design contract — using
+      // useOptionalSound rather than useSound — is what allows isolated
+      // tests like this whole file to render AnimatedCard at all. This
+      // test pins the design choice as documentation.
+      vi.mocked(useReducedMotion).mockReturnValue(false);
+      expect(() => render(<AnimatedCard card={mockCard} />)).not.toThrow();
+    });
   });
 });

--- a/frontend/src/components/motion/AnimatedCard.test.tsx
+++ b/frontend/src/components/motion/AnimatedCard.test.tsx
@@ -1,8 +1,47 @@
-import { render, screen } from '@testing-library/react';
-import type { ReactNode } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useOptionalSound } from '../../providers/SoundProvider';
 import type { Card } from '../../types/card';
 import { AnimatedCard } from './AnimatedCard';
+
+// Override the global framer-motion mock from `src/test/setup.ts` so
+// onAnimationComplete fires on mount via useEffect. The default mock
+// strips animation props entirely, which would mean the deal callback
+// — and therefore the default SFX path this file is verifying — never
+// runs. Mirrors `AnimatedCardBack.test.tsx`.
+vi.mock('framer-motion', async () => {
+  const React = await import('react');
+  function createMotionProxy() {
+    return new Proxy(
+      {},
+      {
+        get: (_target: Record<string, unknown>, prop: string) =>
+          React.forwardRef((props: Record<string, unknown>, ref: React.Ref<HTMLElement>) => {
+            const {
+              initial: _i,
+              animate: _a,
+              exit: _e,
+              transition: _t,
+              whileHover: _wh,
+              whileTap: _wt,
+              layout: _l,
+              layoutId: _li,
+              onAnimationComplete,
+              ...rest
+            } = props;
+            const cb = onAnimationComplete as (() => void) | undefined;
+            React.useEffect(() => {
+              cb?.();
+            }, [cb]);
+            return React.createElement(prop, { ...rest, ref });
+          }),
+      },
+    );
+  }
+  const AnimatePresence = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children);
+  return { motion: createMotionProxy(), AnimatePresence };
+});
 
 const mockCard: Card = { design: 'SPADE', value: 1 };
 
@@ -14,30 +53,20 @@ import { useReducedMotion } from '../../hooks/useReducedMotion';
 
 const mockPlaySound = vi.fn();
 
-// Mock the SoundProvider module: useOptionalSound returns a spyable
-// playSound. This lets us assert on the default-SFX contract introduced
-// by issue #1845 without spinning up the real provider (and its Howler
-// init) in unit tests.
+// Mock the SoundProvider module so tests can render AnimatedCard
+// without wrapping in <SoundProvider>. The mocked useOptionalSound
+// returns a spyable playSound by default; individual tests override
+// it via vi.mocked(useOptionalSound).mockReturnValueOnce(null) to
+// exercise the provider-less code path. See issue #1845.
 vi.mock('../../providers/SoundProvider', () => ({
-  useOptionalSound: () => ({ playSound: mockPlaySound, muted: false, toggleMute: vi.fn() }),
+  useOptionalSound: vi.fn(() => ({ playSound: mockPlaySound, muted: false, toggleMute: vi.fn() })),
 }));
 
-function renderAndCompleteAnim(node: ReactNode) {
-  // Framer Motion fires onAnimationComplete naturally; jsdom doesn't run
-  // its RAF loop in tests, so we invoke the wrapper via the motion.div's
-  // onAnimationComplete callback. Easiest path: render and walk the
-  // motion.div instance through its callback prop. With the vi.mock for
-  // useReducedMotion forcing animated mode, the motion.div is rendered;
-  // we trigger animation completion by dispatching a custom event the
-  // component already listens for via framer-motion. In practice, the
-  // simplest contract test is to set up the mock and assert on the
-  // playSound call after first animation cycle — framer-motion fires
-  // onAnimationComplete synchronously on mount in jsdom when no real
-  // animation can run.
-  return render(node);
-}
-
 describe('AnimatedCard', () => {
+  beforeEach(() => {
+    mockPlaySound.mockClear();
+  });
+
   it('renders animated wrapper when motion is enabled', () => {
     vi.mocked(useReducedMotion).mockReturnValue(false);
     render(<AnimatedCard card={mockCard} />);
@@ -105,25 +134,34 @@ describe('AnimatedCard', () => {
   });
 
   describe('default SFX contract (issue #1845)', () => {
-    // After issue #1845, AnimatedCard internally plays the 'cardDeal' SFX
-    // on deal-in completion. Page-level callsites no longer need to
-    // duplicate this. The `silent` prop opts out for parents that play
-    // their own placement sound. Tests below pin the contract — framer-
-    // motion fires onAnimationComplete synchronously in jsdom (no real
-    // animation runs), so we can assert on the spy directly after render.
-    it('accepts the silent prop without rendering changes', () => {
+    it('plays cardDeal on deal-in completion', async () => {
       vi.mocked(useReducedMotion).mockReturnValue(false);
-      renderAndCompleteAnim(<AnimatedCard card={mockCard} silent />);
-      expect(screen.getByTestId('animated-card')).toBeInTheDocument();
+      render(<AnimatedCard card={mockCard} />);
+      await waitFor(() => expect(mockPlaySound).toHaveBeenCalledWith('cardDeal', { pitchVariation: 0.03 }));
     });
 
-    it('still mounts when called outside a SoundProvider (graceful degrade)', () => {
-      // useOptionalSound returns null when there is no provider; the
-      // component must not throw. The mock at the top of this file makes
-      // useOptionalSound non-null here, but the design contract — using
-      // useOptionalSound rather than useSound — is what allows isolated
-      // tests like this whole file to render AnimatedCard at all. This
-      // test pins the design choice as documentation.
+    it('also fires onDealComplete after the default SFX', async () => {
+      vi.mocked(useReducedMotion).mockReturnValue(false);
+      const onDealComplete = vi.fn();
+      render(<AnimatedCard card={mockCard} onDealComplete={onDealComplete} />);
+      await waitFor(() => expect(onDealComplete).toHaveBeenCalledTimes(1));
+      expect(mockPlaySound).toHaveBeenCalledWith('cardDeal', { pitchVariation: 0.03 });
+    });
+
+    it('does not play sound when silent=true (but still fires onDealComplete)', async () => {
+      vi.mocked(useReducedMotion).mockReturnValue(false);
+      const onDealComplete = vi.fn();
+      render(<AnimatedCard card={mockCard} silent onDealComplete={onDealComplete} />);
+      // onDealComplete is the side-effect hook callers can still opt into;
+      // wait for it to confirm the animation cycle ran. Then assert no SFX.
+      await waitFor(() => expect(onDealComplete).toHaveBeenCalledTimes(1));
+      expect(mockPlaySound).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when rendered outside a SoundProvider', () => {
+      // Force useOptionalSound to behave as if no provider is mounted.
+      // The component must degrade silently rather than crash.
+      vi.mocked(useOptionalSound).mockReturnValueOnce(null);
       vi.mocked(useReducedMotion).mockReturnValue(false);
       expect(() => render(<AnimatedCard card={mockCard} />)).not.toThrow();
     });

--- a/frontend/src/components/motion/AnimatedCard.tsx
+++ b/frontend/src/components/motion/AnimatedCard.tsx
@@ -1,6 +1,7 @@
 import { motion } from 'framer-motion';
 import { useRef } from 'react';
 import { useReducedMotion } from '../../hooks/useReducedMotion';
+import { useOptionalSound } from '../../providers/SoundProvider';
 import { dealSpring, hoverLift, selectLift } from '../../styles/motionPresets';
 import { CardImage } from '../CardImage';
 
@@ -13,7 +14,17 @@ interface AnimatedCardProps extends React.ComponentProps<typeof CardImage> {
   layoutId?: string;
   /** Additional class name for the motion wrapper div. */
   wrapperClassName?: string;
-  /** Callback fired when the deal-in animation completes. */
+  /**
+   * Suppress the default 'cardDeal' SFX. Useful for silent re-renders
+   * or when a parent already plays a louder placement sound.
+   */
+  silent?: boolean;
+  /**
+   * Optional callback fired after the deal-in animation completes,
+   * in addition to the default SFX. Most call sites can omit this;
+   * pass one only when extra side-effects (e.g., onPlace plumbing in
+   * AnimatedPile) need to fire alongside the default sound.
+   */
   onDealComplete?: () => void;
 }
 
@@ -23,10 +34,12 @@ export function AnimatedCard({
   isSelected = false,
   layoutId,
   wrapperClassName,
+  silent = false,
   onDealComplete,
   ...rest
 }: AnimatedCardProps) {
   const reduced = useReducedMotion();
+  const sound = useOptionalSound();
   // Guard: onAnimationComplete fires for any animation (hover, selection), not just the initial deal.
   // Use a ref so the deal callback fires exactly once per component instance.
   const dealCalledRef = useRef(false);
@@ -53,6 +66,7 @@ export function AnimatedCard({
       onAnimationComplete={() => {
         if (!dealCalledRef.current) {
           dealCalledRef.current = true;
+          if (!silent) sound?.playSound('cardDeal', { pitchVariation: 0.03 });
           onDealComplete?.();
         }
       }}

--- a/frontend/src/components/motion/AnimatedCardBack.test.tsx
+++ b/frontend/src/components/motion/AnimatedCardBack.test.tsx
@@ -6,6 +6,14 @@ vi.mock('../../hooks/useReducedMotion', () => ({
   useReducedMotion: vi.fn(() => false),
 }));
 
+const mockPlaySound = vi.fn();
+
+// Mock SoundProvider so tests can render the component without a
+// provider wrap. Mirrors AnimatedCard.test.tsx (issue #1845).
+vi.mock('../../providers/SoundProvider', () => ({
+  useOptionalSound: () => ({ playSound: mockPlaySound, muted: false, toggleMute: vi.fn() }),
+}));
+
 import { useReducedMotion } from '../../hooks/useReducedMotion';
 
 describe('AnimatedCardBack', () => {
@@ -61,5 +69,15 @@ describe('AnimatedCardBack', () => {
     const onFlipComplete = vi.fn();
     render(<AnimatedCardBack onFlipComplete={onFlipComplete} />);
     expect(screen.queryByTestId('animated-card-back')).not.toBeInTheDocument();
+  });
+
+  describe('default SFX contract (issue #1845)', () => {
+    // AnimatedCardBack internally plays the 'cardFlip' SFX on flip-in
+    // completion so page callsites no longer need to thread it.
+    it('accepts the silent prop without rendering changes', () => {
+      vi.mocked(useReducedMotion).mockReturnValue(false);
+      render(<AnimatedCardBack silent />);
+      expect(screen.getByTestId('animated-card-back')).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/motion/AnimatedCardBack.test.tsx
+++ b/frontend/src/components/motion/AnimatedCardBack.test.tsx
@@ -1,22 +1,63 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useOptionalSound } from '../../providers/SoundProvider';
 import { AnimatedCardBack } from './AnimatedCardBack';
 
 vi.mock('../../hooks/useReducedMotion', () => ({
   useReducedMotion: vi.fn(() => false),
 }));
 
+// Override the global framer-motion mock so onAnimationComplete fires
+// on mount via useEffect. See AnimatedCard.test.tsx for the rationale.
+vi.mock('framer-motion', async () => {
+  const React = await import('react');
+  function createMotionProxy() {
+    return new Proxy(
+      {},
+      {
+        get: (_target: Record<string, unknown>, prop: string) =>
+          React.forwardRef((props: Record<string, unknown>, ref: React.Ref<HTMLElement>) => {
+            const {
+              initial: _i,
+              animate: _a,
+              exit: _e,
+              transition: _t,
+              whileHover: _wh,
+              whileTap: _wt,
+              layout: _l,
+              layoutId: _li,
+              onAnimationComplete,
+              ...rest
+            } = props;
+            const cb = onAnimationComplete as (() => void) | undefined;
+            React.useEffect(() => {
+              cb?.();
+            }, [cb]);
+            return React.createElement(prop, { ...rest, ref });
+          }),
+      },
+    );
+  }
+  const AnimatePresence = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children);
+  return { motion: createMotionProxy(), AnimatePresence };
+});
+
 const mockPlaySound = vi.fn();
 
 // Mock SoundProvider so tests can render the component without a
 // provider wrap. Mirrors AnimatedCard.test.tsx (issue #1845).
 vi.mock('../../providers/SoundProvider', () => ({
-  useOptionalSound: () => ({ playSound: mockPlaySound, muted: false, toggleMute: vi.fn() }),
+  useOptionalSound: vi.fn(() => ({ playSound: mockPlaySound, muted: false, toggleMute: vi.fn() })),
 }));
 
 import { useReducedMotion } from '../../hooks/useReducedMotion';
 
 describe('AnimatedCardBack', () => {
+  beforeEach(() => {
+    mockPlaySound.mockClear();
+  });
+
   it('renders animated wrapper when motion is enabled', () => {
     vi.mocked(useReducedMotion).mockReturnValue(false);
     render(<AnimatedCardBack />);
@@ -72,12 +113,32 @@ describe('AnimatedCardBack', () => {
   });
 
   describe('default SFX contract (issue #1845)', () => {
-    // AnimatedCardBack internally plays the 'cardFlip' SFX on flip-in
-    // completion so page callsites no longer need to thread it.
-    it('accepts the silent prop without rendering changes', () => {
+    it('plays cardFlip on flip-in completion', async () => {
       vi.mocked(useReducedMotion).mockReturnValue(false);
-      render(<AnimatedCardBack silent />);
-      expect(screen.getByTestId('animated-card-back')).toBeInTheDocument();
+      render(<AnimatedCardBack />);
+      await waitFor(() => expect(mockPlaySound).toHaveBeenCalledWith('cardFlip'));
+    });
+
+    it('also fires onFlipComplete after the default SFX', async () => {
+      vi.mocked(useReducedMotion).mockReturnValue(false);
+      const onFlipComplete = vi.fn();
+      render(<AnimatedCardBack onFlipComplete={onFlipComplete} />);
+      await waitFor(() => expect(onFlipComplete).toHaveBeenCalledTimes(1));
+      expect(mockPlaySound).toHaveBeenCalledWith('cardFlip');
+    });
+
+    it('does not play sound when silent=true (but still fires onFlipComplete)', async () => {
+      vi.mocked(useReducedMotion).mockReturnValue(false);
+      const onFlipComplete = vi.fn();
+      render(<AnimatedCardBack silent onFlipComplete={onFlipComplete} />);
+      await waitFor(() => expect(onFlipComplete).toHaveBeenCalledTimes(1));
+      expect(mockPlaySound).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when rendered outside a SoundProvider', () => {
+      vi.mocked(useOptionalSound).mockReturnValueOnce(null);
+      vi.mocked(useReducedMotion).mockReturnValue(false);
+      expect(() => render(<AnimatedCardBack />)).not.toThrow();
     });
   });
 });

--- a/frontend/src/components/motion/AnimatedCardBack.tsx
+++ b/frontend/src/components/motion/AnimatedCardBack.tsx
@@ -1,6 +1,7 @@
 import { motion } from 'framer-motion';
 import { useRef } from 'react';
 import { useReducedMotion } from '../../hooks/useReducedMotion';
+import { useOptionalSound } from '../../providers/SoundProvider';
 import { flipSpring } from '../../styles/motionPresets';
 import { CardBack } from '../CardImage';
 
@@ -9,13 +10,26 @@ interface AnimatedCardBackProps extends React.ComponentProps<typeof CardBack> {
   dealDelay?: number;
   /** Shared layout animation ID. */
   layoutId?: string;
-  /** Callback fired when the flip-in animation completes. */
+  /** Suppress the default 'cardFlip' SFX. */
+  silent?: boolean;
+  /**
+   * Optional callback fired after the flip-in animation completes,
+   * in addition to the default SFX. Pass only when extra side-effects
+   * need to fire alongside the default sound.
+   */
   onFlipComplete?: () => void;
 }
 
 /** Renders an animated face-down card back with deal and optional flip animation. */
-export function AnimatedCardBack({ dealDelay = 0, layoutId, onFlipComplete, ...rest }: AnimatedCardBackProps) {
+export function AnimatedCardBack({
+  dealDelay = 0,
+  layoutId,
+  silent = false,
+  onFlipComplete,
+  ...rest
+}: AnimatedCardBackProps) {
   const reduced = useReducedMotion();
+  const sound = useOptionalSound();
   // Guard: onAnimationComplete fires for any animation, not just the initial flip.
   // Use a ref so the flip callback fires exactly once per component instance.
   const flipCalledRef = useRef(false);
@@ -36,6 +50,7 @@ export function AnimatedCardBack({ dealDelay = 0, layoutId, onFlipComplete, ...r
       onAnimationComplete={() => {
         if (!flipCalledRef.current) {
           flipCalledRef.current = true;
+          if (!silent) sound?.playSound('cardFlip');
           onFlipComplete?.();
         }
       }}

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -300,12 +300,7 @@ function BaccaratPageContent() {
                 </div>
                 <div className="flex justify-center gap-2">
                   {state.playerHand.map((card, i) => (
-                    <AnimatedCard
-                      key={`p-${card.design}-${card.value}-${i}`}
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard key={`p-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                   ))}
                 </div>
               </div>
@@ -319,12 +314,7 @@ function BaccaratPageContent() {
                 </div>
                 <div className="flex justify-center gap-2">
                   {state.bankerHand.map((card, i) => (
-                    <AnimatedCard
-                      key={`b-${card.design}-${card.value}-${i}`}
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard key={`b-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                   ))}
                 </div>
               </div>

--- a/frontend/src/pages/BadugiPage.tsx
+++ b/frontend/src/pages/BadugiPage.tsx
@@ -313,11 +313,7 @@ function BadugiPageContent() {
                           boxSizing: 'border-box',
                         }}
                       >
-                        <AnimatedCard
-                          card={card}
-                          width={cardWidth}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                        />
+                        <AnimatedCard card={card} width={cardWidth} />
                       </button>
                     );
                   })}

--- a/frontend/src/pages/BakersDozenPage.tsx
+++ b/frontend/src/pages/BakersDozenPage.tsx
@@ -241,7 +241,6 @@ function BakersDozenPageContent() {
                             width={bd.cw}
                             draggable={false}
                             dealDelay={isAutoCompleting ? idx * 0.15 : 0}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         </button>
                       ) : (
@@ -321,7 +320,6 @@ function BakersDozenPageContent() {
                                       draggable={false}
                                       style={{ width: '100%' }}
                                       wrapperClassName="block w-full"
-                                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                                     />
                                   </button>
                                 ) : null}

--- a/frontend/src/pages/BeleagueredCastlePage.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.tsx
@@ -225,7 +225,6 @@ function BeleagueredCastlePageContent() {
                           draggable={false}
                           style={{ width: '100%' }}
                           wrapperClassName="block w-full"
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       </button>
                     ) : null}
@@ -302,7 +301,6 @@ function BeleagueredCastlePageContent() {
                               width={dims.cw}
                               draggable={false}
                               dealDelay={isAutoCompleting ? idx * 0.15 : 0}
-                              onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                             />
                           </button>
                         ) : (

--- a/frontend/src/pages/BelotePage.tsx
+++ b/frontend/src/pages/BelotePage.tsx
@@ -17,7 +17,6 @@ import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
-import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -87,7 +86,6 @@ export const BelotePage = withTutorial(BelotePageContent, 'belote', BELOTE_TUTOR
 function BelotePageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('belote');
-  const { playSound } = useSound();
   const {
     state,
     loading,
@@ -246,7 +244,6 @@ function BelotePageContent() {
           cardWidth={cardWidth}
           label={t('currentTrick')}
           dataTutorial="be-trick-display"
-          onCardDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
         />
 
         {/* Team scores */}

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -363,12 +363,9 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
                       card={card}
                       width={cardWidth}
                       dealDelay={idx * 0.2}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                     />
                   ))}
-                  {!state.dealer.score && (
-                    <AnimatedCardBack width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
-                  )}
+                  {!state.dealer.score && <AnimatedCardBack width={cardWidth} />}
                 </div>
               </div>
             )}
@@ -444,7 +441,6 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
                           card={card}
                           width={cardWidth}
                           dealDelay={cardIdx * 0.12}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       ))}
                     </div>

--- a/frontend/src/pages/BlackJackSwitchPage.tsx
+++ b/frontend/src/pages/BlackJackSwitchPage.tsx
@@ -149,12 +149,7 @@ function BlackJackSwitchPageContent() {
                 </div>
                 <div className="flex justify-center gap-2 flex-wrap">
                   {state.dealerCards.map((c, i) => (
-                    <CardSlot
-                      key={`dealer-${i}`}
-                      card={c}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <CardSlot key={`dealer-${i}`} card={c} width={cardWidth} />
                   ))}
                 </div>
               </div>
@@ -178,12 +173,7 @@ function BlackJackSwitchPageContent() {
                       </div>
                       <div className="flex justify-center gap-1 flex-wrap">
                         {hand.cards.map((c, j) => (
-                          <CardSlot
-                            key={`hand-${idx}-${j}`}
-                            card={c}
-                            width={cardWidth}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                          />
+                          <CardSlot key={`hand-${idx}-${j}`} card={c} width={cardWidth} />
                         ))}
                       </div>
                       {isEndPhase && (
@@ -283,7 +273,7 @@ function BlackJackSwitchPageContent() {
 }
 
 /** Renders a face-up card or a face-down placeholder when card is null. */
-function CardSlot({ card, width, onDealComplete }: { card: Card | null; width: number; onDealComplete: () => void }) {
+function CardSlot({ card, width }: { card: Card | null; width: number }) {
   if (!card) {
     return (
       <div
@@ -293,7 +283,7 @@ function CardSlot({ card, width, onDealComplete }: { card: Card | null; width: n
       />
     );
   }
-  return <AnimatedCard card={card} width={width} onDealComplete={onDealComplete} />;
+  return <AnimatedCard card={card} width={width} />;
 }
 
 function handResultKey(result: number): string {

--- a/frontend/src/pages/BridgePage.tsx
+++ b/frontend/src/pages/BridgePage.tsx
@@ -328,7 +328,6 @@ function BridgePageContent() {
                   cardWidth={cardWidth}
                   label={t('currentTrick')}
                   dataTutorial="br-trick-display"
-                  onCardDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                 />
 
                 {/* Dummy hand */}
@@ -337,12 +336,7 @@ function BridgePageContent() {
                     <div className="text-ds-text-muted text-sm mb-1">{t('dummyHand')}</div>
                     <div className="flex gap-1 flex-wrap">
                       {state.dummyHand.map((card, idx) => (
-                        <AnimatedCard
-                          key={`dummy-${card.design}-${card.value}-${idx}`}
-                          card={card}
-                          width={cardWidth}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                        />
+                        <AnimatedCard key={`dummy-${card.design}-${card.value}-${idx}`} card={card} width={cardWidth} />
                       ))}
                     </div>
                   </div>
@@ -504,11 +498,7 @@ function BridgePageContent() {
                       ...(isMobile ? { minWidth: solitaireMinColWidth, flexShrink: 0 } : {}),
                     }}
                   >
-                    <AnimatedCard
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={card} width={cardWidth} />
                   </button>
                 ))}
               </div>

--- a/frontend/src/pages/CallBreakPage.tsx
+++ b/frontend/src/pages/CallBreakPage.tsx
@@ -28,7 +28,6 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
-import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -111,7 +110,6 @@ export const CallBreakPage = withTutorial(CallBreakPageContent, 'callbreak', CB_
 function CallBreakPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('callbreak');
-  const { playSound } = useSound();
   const {
     state,
     loading,
@@ -266,7 +264,6 @@ function CallBreakPageContent() {
                   cardWidth={cardWidth}
                   label={t('currentTrick')}
                   dataTutorial="cb-trick-display"
-                  onCardDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                 />
               </div>
 

--- a/frontend/src/pages/CanastaPage.tsx
+++ b/frontend/src/pages/CanastaPage.tsx
@@ -212,11 +212,7 @@ function CanastaPageContent() {
                 {/* Discard pile top */}
                 {state.discardTop && (
                   <div className="my-3 p-3 rounded bg-black/40 flex items-center gap-3" data-tutorial="ca-draw-area">
-                    <AnimatedCard
-                      card={state.discardTop}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={state.discardTop} width={cardWidth} />
                     <div className="text-ds-text-muted text-sm">
                       {tc('common:discardTop', { defaultValue: 'Discard' })}
                     </div>
@@ -246,12 +242,7 @@ function CanastaPageContent() {
                               : `(${m.cards.length})`}
                           </span>
                           {m.cards.map((card, ci) => (
-                            <AnimatedCard
-                              key={`meld-${pi}-${mi}-${ci}`}
-                              card={card}
-                              width={cardWidth * 0.6}
-                              onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                            />
+                            <AnimatedCard key={`meld-${pi}-${mi}-${ci}`} card={card} width={cardWidth * 0.6} />
                           ))}
                         </div>
                       ))}
@@ -259,12 +250,7 @@ function CanastaPageContent() {
                         <div className="flex flex-wrap gap-1 mt-1">
                           <span className="text-xs text-ds-error self-center mr-1">{t('red3s')}</span>
                           {p.red3s.map((card, ri) => (
-                            <AnimatedCard
-                              key={`red3-${pi}-${ri}`}
-                              card={card}
-                              width={cardWidth * 0.6}
-                              onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                            />
+                            <AnimatedCard key={`red3-${pi}-${ri}`} card={card} width={cardWidth * 0.6} />
                           ))}
                         </div>
                       )}
@@ -315,7 +301,6 @@ function CanastaPageContent() {
                                 key={`cpu-${card.design}-${card.value}-${idx}`}
                                 card={card}
                                 width={cardWidth * 0.7}
-                                onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                               />
                             ))}
                           </div>
@@ -362,11 +347,7 @@ function CanastaPageContent() {
                       boxSizing: 'border-box',
                     }}
                   >
-                    <AnimatedCard
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={card} width={cardWidth} />
                   </button>
                 ))}
               </div>

--- a/frontend/src/pages/CaribbeanStudPage.tsx
+++ b/frontend/src/pages/CaribbeanStudPage.tsx
@@ -257,12 +257,7 @@ function CaribbeanStudPageContent() {
                 </div>
                 <div className="flex justify-center gap-2 flex-wrap">
                   {state.playerHand.map((card, i) => (
-                    <AnimatedCard
-                      key={`p-${card.design}-${card.value}-${i}`}
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard key={`p-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                   ))}
                 </div>
               </div>
@@ -286,12 +281,7 @@ function CaribbeanStudPageContent() {
                     isMaskedCard(card) ? (
                       <AnimatedCardBack key={`d-back-${i}`} width={cardWidth} />
                     ) : (
-                      <AnimatedCard
-                        key={`d-${card.design}-${card.value}-${i}`}
-                        card={card}
-                        width={cardWidth}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard key={`d-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                     ),
                   )}
                 </div>

--- a/frontend/src/pages/CasinoHoldemPage.tsx
+++ b/frontend/src/pages/CasinoHoldemPage.tsx
@@ -242,12 +242,7 @@ function CasinoHoldemPageContent() {
                 </div>
                 <div className="flex justify-center gap-2 flex-wrap">
                   {state.community.map((card, i) => (
-                    <AnimatedCard
-                      key={`c-${card.design}-${card.value}-${i}`}
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard key={`c-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                   ))}
                 </div>
               </div>
@@ -266,12 +261,7 @@ function CasinoHoldemPageContent() {
                     isMaskedCard(card) ? (
                       <AnimatedCardBack key={`d-back-${i}`} width={cardWidth} />
                     ) : (
-                      <AnimatedCard
-                        key={`d-${card.design}-${card.value}-${i}`}
-                        card={card}
-                        width={cardWidth}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard key={`d-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                     ),
                   )}
                 </div>
@@ -288,12 +278,7 @@ function CasinoHoldemPageContent() {
                 </div>
                 <div className="flex justify-center gap-2 flex-wrap">
                   {state.playerHand.map((card, i) => (
-                    <AnimatedCard
-                      key={`p-${card.design}-${card.value}-${i}`}
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard key={`p-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                   ))}
                 </div>
               </div>

--- a/frontend/src/pages/CasinoWarPage.tsx
+++ b/frontend/src/pages/CasinoWarPage.tsx
@@ -172,21 +172,13 @@ function CasinoWarPageContent() {
                   {state.playerCard && (
                     <div className="flex flex-col items-center">
                       <div className="text-ds-text-primary text-sm mb-1">{t('label.playerCard')}</div>
-                      <AnimatedCard
-                        card={state.playerCard}
-                        width={cardWidth}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard card={state.playerCard} width={cardWidth} />
                     </div>
                   )}
                   {state.dealerCard && (
                     <div className="flex flex-col items-center">
                       <div className="text-ds-text-primary text-sm mb-1">{t('label.dealerCard')}</div>
-                      <AnimatedCard
-                        card={state.dealerCard}
-                        width={cardWidth}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard card={state.dealerCard} width={cardWidth} />
                     </div>
                   )}
                 </div>
@@ -211,21 +203,13 @@ function CasinoWarPageContent() {
                   {state.playerWarCard && (
                     <div className="flex flex-col items-center">
                       <div className="text-ds-text-primary text-sm mb-1">{t('label.playerCard')}</div>
-                      <AnimatedCard
-                        card={state.playerWarCard}
-                        width={cardWidth}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard card={state.playerWarCard} width={cardWidth} />
                     </div>
                   )}
                   {state.dealerWarCard && (
                     <div className="flex flex-col items-center">
                       <div className="text-ds-text-primary text-sm mb-1">{t('label.dealerCard')}</div>
-                      <AnimatedCard
-                        card={state.dealerWarCard}
-                        width={cardWidth}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard card={state.dealerWarCard} width={cardWidth} />
                     </div>
                   )}
                 </div>

--- a/frontend/src/pages/CrazyEightsPage.tsx
+++ b/frontend/src/pages/CrazyEightsPage.tsx
@@ -235,11 +235,7 @@ function CrazyEightsPageContent() {
                 {/* Discard pile top */}
                 {state.discardTop && (
                   <div className="my-3 p-3 rounded bg-black/40 flex items-center gap-3" data-tutorial="ce-discard-pile">
-                    <AnimatedCard
-                      card={state.discardTop}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={state.discardTop} width={cardWidth} />
                     <div className="text-ds-text-muted text-sm">
                       <div>{t('discardTop')}</div>
                       {state.chosenSuit > 0 && (
@@ -327,11 +323,7 @@ function CrazyEightsPageContent() {
                       boxSizing: 'border-box',
                     }}
                   >
-                    <AnimatedCard
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={card} width={cardWidth} />
                   </button>
                 ))}
               </div>

--- a/frontend/src/pages/CrescentPage.tsx
+++ b/frontend/src/pages/CrescentPage.tsx
@@ -233,12 +233,7 @@ function CrescentPageContent() {
                                 })}
                                 className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite}`}
                               >
-                                <AnimatedCard
-                                  card={pile[pile.length - 1]}
-                                  width={tableauDim.cw}
-                                  draggable={false}
-                                  onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                                />
+                                <AnimatedCard card={pile[pile.length - 1]} width={tableauDim.cw} draggable={false} />
                               </button>
                             ) : (
                               <button
@@ -316,7 +311,6 @@ function CrescentPageContent() {
                                       draggable={false}
                                       style={{ width: '100%' }}
                                       wrapperClassName="block w-full"
-                                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                                     />
                                   </button>
                                 ) : null}

--- a/frontend/src/pages/CribbagePage.tsx
+++ b/frontend/src/pages/CribbagePage.tsx
@@ -306,11 +306,7 @@ function CribbagePageContent() {
                 {/* Starter card */}
                 {state.starter && (
                   <div className="my-3 p-3 rounded bg-black/40 flex items-center gap-3">
-                    <AnimatedCard
-                      card={state.starter}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={state.starter} width={cardWidth} />
                     <div className="text-ds-text-muted text-sm">
                       <div>{t('starter')}</div>
                     </div>
@@ -329,7 +325,6 @@ function CribbagePageContent() {
                           key={`peg-${card.design}-${card.value}-${idx}`}
                           card={card}
                           width={cardWidth * 0.8}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       ))}
                     </div>
@@ -346,7 +341,6 @@ function CribbagePageContent() {
                           key={`crib-${card.design}-${card.value}-${idx}`}
                           card={card}
                           width={cardWidth * 0.8}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       ))}
                     </div>
@@ -409,7 +403,6 @@ function CribbagePageContent() {
                               key={`cpu-${card.design}-${card.value}-${idx}`}
                               card={card}
                               width={cardWidth * 0.8}
-                              onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                             />
                           ))}
                         </div>
@@ -488,11 +481,7 @@ function CribbagePageContent() {
                       boxSizing: 'border-box',
                     }}
                   >
-                    <AnimatedCard
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={card} width={cardWidth} />
                   </button>
                 ))}
               </div>

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -275,12 +275,7 @@ function DaifugoPageContent() {
                   <span className="text-ds-text-muted">{t('tableEmpty')}</span>
                 ) : (
                   state.tableCards.map((card) => (
-                    <AnimatedCard
-                      key={`${card.design}-${card.value}`}
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard key={`${card.design}-${card.value}`} card={card} width={cardWidth} />
                   ))
                 )}
               </div>

--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -407,12 +407,7 @@ function DoubtPageContent() {
                     {state.lastDoubtResult.revealedCards.length > 0 && (
                       <div className="flex flex-wrap gap-1 mt-1">
                         {state.lastDoubtResult.revealedCards.map((card, i) => (
-                          <AnimatedCard
-                            key={`${card.design}-${card.value}-${i}`}
-                            card={card}
-                            width={cardWidth}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                          />
+                          <AnimatedCard key={`${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                         ))}
                       </div>
                     )}

--- a/frontend/src/pages/DragonTigerPage.tsx
+++ b/frontend/src/pages/DragonTigerPage.tsx
@@ -146,21 +146,13 @@ function DragonTigerPageContent() {
                   {state.dragonCard && (
                     <div className="flex flex-col items-center">
                       <div className="text-ds-warning text-sm font-bold mb-1">{t('label.dragon')}</div>
-                      <AnimatedCard
-                        card={state.dragonCard}
-                        width={cardWidth}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard card={state.dragonCard} width={cardWidth} />
                     </div>
                   )}
                   {state.tigerCard && (
                     <div className="flex flex-col items-center">
                       <div className="text-ds-info text-sm font-bold mb-1">{t('label.tiger')}</div>
-                      <AnimatedCard
-                        card={state.tigerCard}
-                        width={cardWidth}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard card={state.tigerCard} width={cardWidth} />
                     </div>
                   )}
                 </div>

--- a/frontend/src/pages/DurakPage.tsx
+++ b/frontend/src/pages/DurakPage.tsx
@@ -263,11 +263,7 @@ function DurakPageContent() {
                           }`}
                           onClick={() => setSelectedAttackIdx(selectedAttackIdx === i ? null : i)}
                         >
-                          <AnimatedCard
-                            card={pair.attack}
-                            width={cardWidth * 0.8}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                          />
+                          <AnimatedCard card={pair.attack} width={cardWidth * 0.8} />
                           {pair.defense ? (
                             <AnimatedCard card={pair.defense} width={cardWidth * 0.8} />
                           ) : (
@@ -360,12 +356,7 @@ function DurakPageContent() {
                       className={`cursor-pointer transition-transform ${selectedCardIdx === i ? '-translate-y-2' : ''}`}
                       onClick={() => setSelectedCardIdx(selectedCardIdx === i ? null : i)}
                     >
-                      <AnimatedCard
-                        card={card}
-                        width={cardWidth}
-                        isSelected={selectedCardIdx === i}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard card={card} width={cardWidth} isSelected={selectedCardIdx === i} />
                     </button>
                   ))}
                 </div>

--- a/frontend/src/pages/EightOffPage.tsx
+++ b/frontend/src/pages/EightOffPage.tsx
@@ -237,12 +237,7 @@ function EightOffPageContent() {
                             onDragEnd={dnd.handleDragEnd}
                             className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${isSourceSelected('freecell', undefined, idx) ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(freeCellZone) ? 'opacity-50' : ''}`}
                           >
-                            <AnimatedCard
-                              card={card}
-                              width={cardWidth}
-                              draggable={false}
-                              onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                            />
+                            <AnimatedCard card={card} width={cardWidth} draggable={false} />
                           </button>
                         ) : (
                           <button
@@ -293,7 +288,6 @@ function EightOffPageContent() {
                               width={cardWidth}
                               draggable={false}
                               dealDelay={isAutoCompleting ? idx * 0.15 : 0}
-                              onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                             />
                           </button>
                         ) : (
@@ -393,7 +387,6 @@ function EightOffPageContent() {
                                         width={cardWidth}
                                         draggable={false}
                                         style={{ width: '100%' }}
-                                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                                       />
                                     </button>
                                   ) : (

--- a/frontend/src/pages/EuchrePage.tsx
+++ b/frontend/src/pages/EuchrePage.tsx
@@ -297,11 +297,7 @@ function EuchrePageContent() {
                   <div className="my-2 text-center">
                     <div className="text-ds-text-muted text-sm mb-1">{t('faceUpCard')}</div>
                     <div className="inline-block">
-                      <AnimatedCard
-                        card={state.faceUpCard}
-                        width={cardWidth}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard card={state.faceUpCard} width={cardWidth} />
                     </div>
                   </div>
                 )}
@@ -313,7 +309,6 @@ function EuchrePageContent() {
                   cardWidth={cardWidth}
                   label={t('currentTrick')}
                   dataTutorial="eu-trick-display"
-                  onCardDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                 />
 
                 {/* Partnership info */}
@@ -460,11 +455,7 @@ function EuchrePageContent() {
                       ...(isMobile ? { minWidth: solitaireMinColWidth, flexShrink: 0 } : {}),
                     }}
                   >
-                    <AnimatedCard
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={card} width={cardWidth} />
                   </button>
                 ))}
               </div>

--- a/frontend/src/pages/FortyThievesPage.tsx
+++ b/frontend/src/pages/FortyThievesPage.tsx
@@ -214,7 +214,6 @@ function FortyThievesPageContent() {
                       width={ft.cw}
                       onClick={isPlaying ? handleDraw : undefined}
                       ariaLabel={t('draw')}
-                      onFlipComplete={() => playSound('cardFlip')}
                     />
                   ) : (
                     <div
@@ -244,12 +243,7 @@ function FortyThievesPageContent() {
                       onDragEnd={dnd.handleDragEnd}
                       className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${isSourceSelected('waste') ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource({ zone: 'waste' }) ? 'opacity-50' : ''}`}
                     >
-                      <AnimatedCard
-                        card={wasteDisplay[0]}
-                        width={ft.cw}
-                        draggable={false}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard card={wasteDisplay[0]} width={ft.cw} draggable={false} />
                     </button>
                   ) : (
                     <div
@@ -293,7 +287,6 @@ function FortyThievesPageContent() {
                               width={ft.cw}
                               draggable={false}
                               dealDelay={isAutoCompleting ? idx * 0.15 : 0}
-                              onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                             />
                           </button>
                         ) : (
@@ -376,15 +369,10 @@ function FortyThievesPageContent() {
                                       draggable={false}
                                       style={{ width: '100%' }}
                                       wrapperClassName="block w-full"
-                                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                                     />
                                   </button>
                                 ) : (
-                                  <AnimatedCardBack
-                                    width={ft.cw}
-                                    className="w-full"
-                                    onFlipComplete={() => playSound('cardFlip')}
-                                  />
+                                  <AnimatedCardBack width={ft.cw} className="w-full" />
                                 )}
                               </div>
                             );

--- a/frontend/src/pages/FourCardPokerPage.tsx
+++ b/frontend/src/pages/FourCardPokerPage.tsx
@@ -197,12 +197,7 @@ function FourCardPokerPageContent() {
             </div>
             <div className="flex justify-center gap-2">
               {state.playerHand.map((card, i) => (
-                <AnimatedCard
-                  key={`p-${card.design}-${card.value}-${i}`}
-                  card={card}
-                  width={cardWidth}
-                  onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                />
+                <AnimatedCard key={`p-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
               ))}
             </div>
           </div>
@@ -220,12 +215,7 @@ function FourCardPokerPageContent() {
             </div>
             <div className="flex justify-center gap-2">
               {state.dealerHand.map((card, i) => (
-                <AnimatedCard
-                  key={`d-${card.design}-${card.value}-${i}`}
-                  card={card}
-                  width={cardWidth}
-                  onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                />
+                <AnimatedCard key={`d-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
               ))}
             </div>
           </div>

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -237,12 +237,7 @@ function FreeCellPageContent() {
                             onDragEnd={dnd.handleDragEnd}
                             className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${isSourceSelected('freecell', undefined, idx) ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(freeCellZone) ? 'opacity-50' : ''}`}
                           >
-                            <AnimatedCard
-                              card={card}
-                              width={cardWidth}
-                              draggable={false}
-                              onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                            />
+                            <AnimatedCard card={card} width={cardWidth} draggable={false} />
                           </button>
                         ) : (
                           <button
@@ -293,7 +288,6 @@ function FreeCellPageContent() {
                               width={cardWidth}
                               draggable={false}
                               dealDelay={isAutoCompleting ? idx * 0.15 : 0}
-                              onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                             />
                           </button>
                         ) : (
@@ -393,7 +387,6 @@ function FreeCellPageContent() {
                                         width={cardWidth}
                                         draggable={false}
                                         style={{ width: '100%' }}
-                                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                                       />
                                     </button>
                                   ) : (

--- a/frontend/src/pages/GinRummyPage.tsx
+++ b/frontend/src/pages/GinRummyPage.tsx
@@ -239,11 +239,7 @@ function GinRummyPageContent() {
                 {/* Discard pile top */}
                 {state.discardTop && (
                   <div className="my-3 p-3 rounded bg-black/40 flex items-center gap-3">
-                    <AnimatedCard
-                      card={state.discardTop}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={state.discardTop} width={cardWidth} />
                     <div className="text-ds-text-muted text-sm">
                       <div>{t('discardTop')}</div>
                     </div>
@@ -261,7 +257,6 @@ function GinRummyPageContent() {
                             key={`meld-${meldIdx}-${card.design}-${card.value}-${cardIdx}`}
                             card={card}
                             width={cardWidth * 0.7}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))}
                       </div>
@@ -290,7 +285,6 @@ function GinRummyPageContent() {
                               key={`cpu-${card.design}-${card.value}-${idx}`}
                               card={card}
                               width={cardWidth * 0.8}
-                              onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                             />
                           ))}
                         </div>
@@ -358,11 +352,7 @@ function GinRummyPageContent() {
                       boxSizing: 'border-box',
                     }}
                   >
-                    <AnimatedCard
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={card} width={cardWidth} />
                   </button>
                 ))}
               </div>

--- a/frontend/src/pages/GoFishPage.tsx
+++ b/frontend/src/pages/GoFishPage.tsx
@@ -273,11 +273,7 @@ function GoFishPageContent() {
                       boxSizing: 'border-box',
                     }}
                   >
-                    <AnimatedCard
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={card} width={cardWidth} />
                   </button>
                 ))}
               </div>

--- a/frontend/src/pages/GolfPage.tsx
+++ b/frontend/src/pages/GolfPage.tsx
@@ -216,11 +216,7 @@ function GolfPageContent() {
                             isHinted && exposed ? 'ring-2 ring-ds-warning' : ''
                           } ${!exposed ? 'opacity-60' : ''}`}
                         >
-                          <AnimatedCard
-                            card={gc.card}
-                            width={effectiveCardWidth}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                          />
+                          <AnimatedCard card={gc.card} width={effectiveCardWidth} />
                         </button>
                       </div>
                     );
@@ -240,7 +236,6 @@ function GolfPageContent() {
                     width={effectiveCardWidth}
                     onClick={isPlaying ? handleDraw : undefined}
                     ariaLabel={t('draw')}
-                    onFlipComplete={() => playSound('cardFlip')}
                   />
                 ) : (
                   <div
@@ -255,11 +250,7 @@ function GolfPageContent() {
               <div className="text-center">
                 <div className="text-game-text-muted text-xs mb-1">{t('waste')}</div>
                 {state.waste.length > 0 ? (
-                  <AnimatedCard
-                    card={state.waste[state.waste.length - 1]}
-                    width={effectiveCardWidth}
-                    onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                  />
+                  <AnimatedCard card={state.waste[state.waste.length - 1]} width={effectiveCardWidth} />
                 ) : (
                   <div
                     style={{ width: effectiveCardWidth, height: cardHeight }}

--- a/frontend/src/pages/HeartsPage.tsx
+++ b/frontend/src/pages/HeartsPage.tsx
@@ -23,7 +23,6 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useHeartsGame } from '../hooks/useHeartsGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
-import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -97,7 +96,6 @@ export const HeartsPage = withTutorial(HeartsPageContent, 'hearts', HT_TUTORIAL_
 function HeartsPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('hearts');
-  const { playSound } = useSound();
   const {
     state,
     loading,
@@ -271,7 +269,6 @@ function HeartsPageContent() {
                   cardWidth={cardWidth}
                   label={t('currentTrick')}
                   dataTutorial="ht-trick-display"
-                  onCardDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                 />
               </div>
 

--- a/frontend/src/pages/HighCardFlushPage.tsx
+++ b/frontend/src/pages/HighCardFlushPage.tsx
@@ -198,12 +198,7 @@ function HighCardFlushPageContent() {
             </div>
             <div className="flex justify-center flex-wrap gap-2">
               {state.playerHand.map((card, i) => (
-                <AnimatedCard
-                  key={`p-${card.design}-${card.value}-${i}`}
-                  card={card}
-                  width={cardWidth}
-                  onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                />
+                <AnimatedCard key={`p-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
               ))}
             </div>
           </div>
@@ -225,12 +220,7 @@ function HighCardFlushPageContent() {
             </div>
             <div className="flex justify-center flex-wrap gap-2">
               {state.dealerHand.map((card, i) => (
-                <AnimatedCard
-                  key={`d-${card.design}-${card.value}-${i}`}
-                  card={card}
-                  width={cardWidth}
-                  onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                />
+                <AnimatedCard key={`d-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
               ))}
             </div>
           </div>

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -258,12 +258,9 @@ function HoldemPageContent() {
                             card={card}
                             width={cardWidth}
                             style={placeholderCardStyle}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))
-                      : Array.from({ length: 5 }).map((_, i) => (
-                          <AnimatedCardBack key={i} width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
-                        ))}
+                      : Array.from({ length: 5 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                   </div>
                 </>
               );
@@ -362,13 +359,10 @@ function HoldemPageContent() {
                           card={card}
                           width={cardWidth}
                           style={placeholderCardStyle}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       ))
                     : !humanPlayer.folded &&
-                      Array.from({ length: 2 }).map((_, i) => (
-                        <AnimatedCardBack key={i} width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
-                      ))}
+                      Array.from({ length: 2 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                 </div>
               </div>
             )}

--- a/frontend/src/pages/IndianPokerPage.tsx
+++ b/frontend/src/pages/IndianPokerPage.tsx
@@ -238,14 +238,9 @@ function IndianPokerPageContent() {
                     </div>
                     <div className={isMobile ? 'flex justify-center' : 'flex flex-wrap gap-1'}>
                       {p.card ? (
-                        <AnimatedCard
-                          card={p.card}
-                          width={cardWidth}
-                          style={placeholderCardStyle}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                        />
+                        <AnimatedCard card={p.card} width={cardWidth} style={placeholderCardStyle} />
                       ) : (
-                        <AnimatedCardBack width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
+                        <AnimatedCardBack width={cardWidth} />
                       )}
                     </div>
                   </div>
@@ -287,14 +282,9 @@ function IndianPokerPageContent() {
                 </div>
                 <div className="flex flex-wrap gap-1.5 mb-2">
                   {isShowdown && humanPlayer.card ? (
-                    <AnimatedCard
-                      card={humanPlayer.card}
-                      width={cardWidth}
-                      style={placeholderCardStyle}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={humanPlayer.card} width={cardWidth} style={placeholderCardStyle} />
                   ) : !humanPlayer.folded ? (
-                    <AnimatedCardBack width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
+                    <AnimatedCardBack width={cardWidth} />
                   ) : null}
                 </div>
               </div>

--- a/frontend/src/pages/KlondikePage.tsx
+++ b/frontend/src/pages/KlondikePage.tsx
@@ -273,7 +273,6 @@ function KlondikePageContent() {
                       width={kl.cw}
                       onClick={isPlaying ? handleDraw : undefined}
                       ariaLabel={t('draw')}
-                      onFlipComplete={() => playSound('cardFlip')}
                     />
                   ) : (
                     <button
@@ -316,19 +315,10 @@ function KlondikePageContent() {
                                 onDragEnd={dnd.handleDragEnd}
                                 className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${isSourceSelected('waste') ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource({ zone: 'waste' }) ? 'opacity-50' : ''}`}
                               >
-                                <AnimatedCard
-                                  card={card}
-                                  width={kl.cw}
-                                  draggable={false}
-                                  onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                                />
+                                <AnimatedCard card={card} width={kl.cw} draggable={false} />
                               </button>
                             ) : (
-                              <AnimatedCard
-                                card={card}
-                                width={kl.cw}
-                                onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                              />
+                              <AnimatedCard card={card} width={kl.cw} />
                             )}
                           </div>
                         );
@@ -377,7 +367,6 @@ function KlondikePageContent() {
                               width={kl.cw}
                               draggable={false}
                               dealDelay={isAutoCompleting ? idx * 0.15 : 0}
-                              onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                             />
                           </button>
                         ) : (
@@ -460,15 +449,10 @@ function KlondikePageContent() {
                                       draggable={false}
                                       style={{ width: '100%' }}
                                       wrapperClassName="block w-full"
-                                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                                     />
                                   </button>
                                 ) : (
-                                  <AnimatedCardBack
-                                    width={kl.cw}
-                                    className="w-full"
-                                    onFlipComplete={() => playSound('cardFlip')}
-                                  />
+                                  <AnimatedCardBack width={kl.cw} className="w-full" />
                                 )}
                               </div>
                             );

--- a/frontend/src/pages/LetItRidePage.tsx
+++ b/frontend/src/pages/LetItRidePage.tsx
@@ -248,12 +248,7 @@ function LetItRidePageContent() {
                 </div>
                 <div className="flex justify-center gap-2 flex-wrap">
                   {state.playerHand.map((card, i) => (
-                    <AnimatedCard
-                      key={`p-${card.design}-${card.value}-${i}`}
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard key={`p-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                   ))}
                 </div>
               </div>
@@ -269,12 +264,7 @@ function LetItRidePageContent() {
                     isMaskedCard(card) ? (
                       <AnimatedCardBack key={`c-back-${i}`} width={cardWidth} />
                     ) : (
-                      <AnimatedCard
-                        key={`c-${card.design}-${card.value}-${i}`}
-                        card={card}
-                        width={cardWidth}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard key={`c-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                     ),
                   )}
                 </div>

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -258,13 +258,7 @@ function MemoryPageContent() {
                         <img src="/images/z01.png" alt="" className="w-full h-full object-contain rounded" />
                       </div>
                       <div className="memory-card-front">
-                        {bc.card && (
-                          <AnimatedCard
-                            card={bc.card}
-                            width={cardWidth}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                          />
-                        )}
+                        {bc.card && <AnimatedCard card={bc.card} width={cardWidth} />}
                       </div>
                     </div>
                   </button>

--- a/frontend/src/pages/MightyPage.tsx
+++ b/frontend/src/pages/MightyPage.tsx
@@ -319,12 +319,7 @@ function MightyPageContent() {
                 {/* Partner card info */}
                 {state.partnerCard && (
                   <div className="text-ds-text-muted text-center text-sm mb-2" data-tutorial="mighty-partner-info">
-                    {t('partnerCard')}:{' '}
-                    <AnimatedCard
-                      card={state.partnerCard}
-                      width={cardWidth * 0.6}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    {t('partnerCard')}: <AnimatedCard card={state.partnerCard} width={cardWidth * 0.6} />
                     <span className="ml-2 text-xs">
                       {state.partnerRevealed ? t('partnerRevealed') : t('partnerHidden')}
                     </span>
@@ -362,12 +357,7 @@ function MightyPageContent() {
                     <div className="text-ds-text-muted text-sm mb-1">{t('kittyLabel')}</div>
                     <div className="flex gap-2">
                       {state.kitty.map((card, idx) => (
-                        <AnimatedCard
-                          key={`kitty-${card.design}-${card.value}-${idx}`}
-                          card={card}
-                          width={cardWidth}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                        />
+                        <AnimatedCard key={`kitty-${card.design}-${card.value}-${idx}`} card={card} width={cardWidth} />
                       ))}
                     </div>
                   </div>
@@ -380,7 +370,6 @@ function MightyPageContent() {
                   cardWidth={cardWidth}
                   label={t('currentTrick')}
                   dataTutorial="mighty-trick-display"
-                  onCardDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                 />
               </div>
 
@@ -568,11 +557,7 @@ function MightyPageContent() {
                         boxSizing: 'border-box',
                       }}
                     >
-                      <AnimatedCard
-                        card={card}
-                        width={cardWidth}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard card={card} width={cardWidth} />
                     </button>
                   ))}
                 </div>

--- a/frontend/src/pages/MississippiStudPage.tsx
+++ b/frontend/src/pages/MississippiStudPage.tsx
@@ -200,12 +200,7 @@ function MississippiStudPageContent() {
             </div>
             <div className="flex justify-center gap-2 flex-wrap">
               {state.playerHand.map((card, i) => (
-                <AnimatedCard
-                  key={`p-${card.design}-${card.value}-${i}`}
-                  card={card}
-                  width={cardWidth}
-                  onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                />
+                <AnimatedCard key={`p-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
               ))}
             </div>
           </div>
@@ -221,12 +216,7 @@ function MississippiStudPageContent() {
                 isMaskedCard(card) ? (
                   <AnimatedCardBack key={`c-back-${i}`} width={cardWidth} />
                 ) : (
-                  <AnimatedCard
-                    key={`c-${card.design}-${card.value}-${i}`}
-                    card={card}
-                    width={cardWidth}
-                    onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                  />
+                  <AnimatedCard key={`c-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                 ),
               )}
             </div>

--- a/frontend/src/pages/NapoleonPage.tsx
+++ b/frontend/src/pages/NapoleonPage.tsx
@@ -302,12 +302,7 @@ function NapoleonPageContent() {
                 {/* Adjutant card info */}
                 {state.adjutantCard && (
                   <div className="text-ds-text-muted text-center text-sm mb-2" data-tutorial="np-adjutant-info">
-                    {t('adjutantCard')}:{' '}
-                    <AnimatedCard
-                      card={state.adjutantCard}
-                      width={cardWidth * 0.6}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    {t('adjutantCard')}: <AnimatedCard card={state.adjutantCard} width={cardWidth * 0.6} />
                   </div>
                 )}
 
@@ -341,12 +336,7 @@ function NapoleonPageContent() {
                     <div className="text-ds-text-muted text-sm mb-1">{t('kittyLabel')}</div>
                     <div className="flex gap-2">
                       {state.kitty.map((card, idx) => (
-                        <AnimatedCard
-                          key={`kitty-${card.design}-${card.value}-${idx}`}
-                          card={card}
-                          width={cardWidth}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                        />
+                        <AnimatedCard key={`kitty-${card.design}-${card.value}-${idx}`} card={card} width={cardWidth} />
                       ))}
                     </div>
                   </div>
@@ -359,7 +349,6 @@ function NapoleonPageContent() {
                   cardWidth={cardWidth}
                   label={t('currentTrick')}
                   dataTutorial="np-trick-display"
-                  onCardDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                 />
               </div>
 
@@ -547,11 +536,7 @@ function NapoleonPageContent() {
                         boxSizing: 'border-box',
                       }}
                     >
-                      <AnimatedCard
-                        card={card}
-                        width={cardWidth}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard card={card} width={cardWidth} />
                     </button>
                   ))}
                 </div>

--- a/frontend/src/pages/OasisPokerPage.tsx
+++ b/frontend/src/pages/OasisPokerPage.tsx
@@ -300,11 +300,7 @@ function OasisPokerPageContent() {
                           .filter(Boolean)
                           .join(' ')}
                       >
-                        <AnimatedCard
-                          card={card}
-                          width={cardWidth}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                        />
+                        <AnimatedCard card={card} width={cardWidth} />
                       </button>
                     );
                   })}
@@ -330,12 +326,7 @@ function OasisPokerPageContent() {
                     isMaskedCard(card) ? (
                       <AnimatedCardBack key={`d-back-${i}`} width={cardWidth} />
                     ) : (
-                      <AnimatedCard
-                        key={`d-${card.design}-${card.value}-${i}`}
-                        card={card}
-                        width={cardWidth}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard key={`d-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                     ),
                   )}
                 </div>

--- a/frontend/src/pages/OhHellPage.tsx
+++ b/frontend/src/pages/OhHellPage.tsx
@@ -301,11 +301,7 @@ function OhHellPageContent() {
                 {state.trumpCard && (
                   <div className="my-2 flex justify-center">
                     <div className="text-center">
-                      <AnimatedCard
-                        card={state.trumpCard}
-                        width={cardWidth}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard card={state.trumpCard} width={cardWidth} />
                     </div>
                   </div>
                 )}
@@ -317,7 +313,6 @@ function OhHellPageContent() {
                   cardWidth={cardWidth}
                   label={t('currentTrick')}
                   dataTutorial="oh-trick-display"
-                  onCardDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                 />
               </div>
 
@@ -483,11 +478,7 @@ function OhHellPageContent() {
                         boxSizing: 'border-box',
                       }}
                     >
-                      <AnimatedCard
-                        card={card}
-                        width={cardWidth}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard card={card} width={cardWidth} />
                     </button>
                   ))}
                 </div>

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -296,14 +296,10 @@ function OldMaidPageContent() {
               <div className="flex justify-center my-2" data-testid="card-reveal-area">
                 {revealedCard ? (
                   <div className="animate-flipIn">
-                    <AnimatedCard
-                      card={revealedCard}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={revealedCard} width={cardWidth} />
                   </div>
                 ) : (
-                  <AnimatedCardBack width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
+                  <AnimatedCardBack width={cardWidth} />
                 )}
               </div>
             )}

--- a/frontend/src/pages/OmahaHiLoPage.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.tsx
@@ -258,12 +258,9 @@ function OmahaHiLoPageContent() {
                             card={card}
                             width={cardWidth}
                             style={placeholderCardStyle}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))
-                      : Array.from({ length: 5 }).map((_, i) => (
-                          <AnimatedCardBack key={i} width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
-                        ))}
+                      : Array.from({ length: 5 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                   </div>
                 </>
               );
@@ -369,13 +366,10 @@ function OmahaHiLoPageContent() {
                           card={card}
                           width={cardWidth}
                           style={placeholderCardStyle}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       ))
                     : !humanPlayer.folded &&
-                      Array.from({ length: 4 }).map((_, i) => (
-                        <AnimatedCardBack key={i} width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
-                      ))}
+                      Array.from({ length: 4 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                 </div>
               </div>
             )}

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -257,12 +257,9 @@ function OmahaPageContent() {
                             card={card}
                             width={cardWidth}
                             style={placeholderCardStyle}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))
-                      : Array.from({ length: 5 }).map((_, i) => (
-                          <AnimatedCardBack key={i} width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
-                        ))}
+                      : Array.from({ length: 5 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                   </div>
                 </>
               );
@@ -368,13 +365,10 @@ function OmahaPageContent() {
                           card={card}
                           width={cardWidth}
                           style={placeholderCardStyle}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       ))
                     : !humanPlayer.folded &&
-                      Array.from({ length: 4 }).map((_, i) => (
-                        <AnimatedCardBack key={i} width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
-                      ))}
+                      Array.from({ length: 4 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                 </div>
               </div>
             )}

--- a/frontend/src/pages/PageOnePage.tsx
+++ b/frontend/src/pages/PageOnePage.tsx
@@ -220,11 +220,7 @@ function PageOnePageContent() {
               <div>
                 {state.discardTop && (
                   <div className="my-3 p-3 rounded bg-black/40 flex items-center gap-3" data-tutorial="po-discard-pile">
-                    <AnimatedCard
-                      card={state.discardTop}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={state.discardTop} width={cardWidth} />
                     <div className="text-ds-text-muted text-sm">
                       <div>{t('discardTop')}</div>
                     </div>
@@ -337,11 +333,7 @@ function PageOnePageContent() {
                       boxSizing: 'border-box',
                     }}
                   >
-                    <AnimatedCard
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={card} width={cardWidth} />
                   </button>
                 ))}
               </div>

--- a/frontend/src/pages/PaiGowPage.tsx
+++ b/frontend/src/pages/PaiGowPage.tsx
@@ -232,11 +232,7 @@ function PaiGowPageContent() {
                       aria-pressed={selectedIndices.includes(i)}
                       aria-label={`Card ${i}`}
                     >
-                      <AnimatedCard
-                        card={card}
-                        width={cardWidth}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard card={card} width={cardWidth} />
                     </button>
                   ))}
                 </div>
@@ -256,12 +252,7 @@ function PaiGowPageContent() {
                     </div>
                     <div className="flex justify-center gap-2">
                       {state.playerHighHand.map((card, i) => (
-                        <AnimatedCard
-                          key={`ph-${card.design}-${card.value}-${i}`}
-                          card={card}
-                          width={cardWidth}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                        />
+                        <AnimatedCard key={`ph-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                       ))}
                     </div>
                   </div>
@@ -276,12 +267,7 @@ function PaiGowPageContent() {
                     </div>
                     <div className="flex justify-center gap-2">
                       {state.playerLowHand.map((card, i) => (
-                        <AnimatedCard
-                          key={`pl-${card.design}-${card.value}-${i}`}
-                          card={card}
-                          width={cardWidth}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                        />
+                        <AnimatedCard key={`pl-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                       ))}
                     </div>
                   </div>
@@ -298,12 +284,7 @@ function PaiGowPageContent() {
                     </div>
                     <div className="flex justify-center gap-2">
                       {state.dealerHighHand.map((card, i) => (
-                        <AnimatedCard
-                          key={`dh-${card.design}-${card.value}-${i}`}
-                          card={card}
-                          width={cardWidth}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                        />
+                        <AnimatedCard key={`dh-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                       ))}
                     </div>
                   </div>
@@ -318,12 +299,7 @@ function PaiGowPageContent() {
                     </div>
                     <div className="flex justify-center gap-2">
                       {state.dealerLowHand.map((card, i) => (
-                        <AnimatedCard
-                          key={`dl-${card.design}-${card.value}-${i}`}
-                          card={card}
-                          width={cardWidth}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                        />
+                        <AnimatedCard key={`dl-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                       ))}
                     </div>
                   </div>

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -287,12 +287,9 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
                             card={card}
                             width={cardWidth}
                             style={placeholderCardStyle}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))
-                      : Array.from({ length: 5 }).map((_, i) => (
-                          <AnimatedCardBack key={i} width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
-                        ))}
+                      : Array.from({ length: 5 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                   </div>
                 </>
               );
@@ -396,17 +393,11 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
                           disabled={!canDiscard}
                           style={selectedCardStyle(canDiscard && selectedDiscard === idx)}
                         >
-                          <AnimatedCard
-                            card={card}
-                            width={cardWidth}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                          />
+                          <AnimatedCard card={card} width={cardWidth} />
                         </button>
                       ))
                     : !humanPlayer.folded &&
-                      Array.from({ length: 3 }).map((_, i) => (
-                        <AnimatedCardBack key={i} width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
-                      ))}
+                      Array.from({ length: 3 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                 </div>
               </div>
             )}

--- a/frontend/src/pages/PinochlePage.tsx
+++ b/frontend/src/pages/PinochlePage.tsx
@@ -288,11 +288,7 @@ function PinochlePageContent() {
                 <div className="flex gap-2 justify-center">
                   {state.currentTrick.map((tc, i) => (
                     <div key={i} className="text-center">
-                      <AnimatedCard
-                        card={tc.card}
-                        width={cardWidth * 0.8}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard card={tc.card} width={cardWidth * 0.8} />
                       <div className="text-xs text-ds-text-muted mt-1">P{tc.playerIdx}</div>
                     </div>
                   ))}
@@ -384,11 +380,7 @@ function PinochlePageContent() {
                         boxSizing: 'border-box',
                       }}
                     >
-                      <AnimatedCard
-                        card={card}
-                        width={cardWidth}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard card={card} width={cardWidth} />
                     </button>
                   );
                 })}

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -313,11 +313,7 @@ function PokerPageContent() {
                           boxSizing: 'border-box',
                         }}
                       >
-                        <AnimatedCard
-                          card={card}
-                          width={cardWidth}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                        />
+                        <AnimatedCard card={card} width={cardWidth} />
                       </button>
                     );
                   })}

--- a/frontend/src/pages/PokerSquaresPage.tsx
+++ b/frontend/src/pages/PokerSquaresPage.tsx
@@ -165,11 +165,7 @@ function PokerSquaresPageContent() {
                     {t('label.currentCard')} ({state.placedCount}/25)
                   </div>
                   {state.currentCard ? (
-                    <AnimatedCard
-                      card={state.currentCard}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={state.currentCard} width={cardWidth} />
                   ) : (
                     <div
                       style={{ width: cardWidth, height: Math.round(cardWidth * 1.4) }}

--- a/frontend/src/pages/PyramidPage.tsx
+++ b/frontend/src/pages/PyramidPage.tsx
@@ -231,11 +231,7 @@ function PyramidPageContent() {
                               isSelected('pyramid', rowIdx, colIdx) ? 'ring-2 ring-ds-warning' : ''
                             } ${!exposed ? 'opacity-60' : ''}`}
                           >
-                            <AnimatedCard
-                              card={pc.card}
-                              width={effectiveCardWidth}
-                              onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                            />
+                            <AnimatedCard card={pc.card} width={effectiveCardWidth} />
                           </button>
                         </div>
                       );
@@ -257,7 +253,6 @@ function PyramidPageContent() {
                     width={effectiveCardWidth}
                     onClick={isPlaying ? handleDraw : undefined}
                     ariaLabel={t('draw')}
-                    onFlipComplete={() => playSound('cardFlip')}
                   />
                 ) : (
                   <div
@@ -286,11 +281,7 @@ function PyramidPageContent() {
                       isSelected('waste') ? 'ring-2 ring-ds-warning' : ''
                     }`}
                   >
-                    <AnimatedCard
-                      card={state.waste[state.waste.length - 1]}
-                      width={effectiveCardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={state.waste[state.waste.length - 1]} width={effectiveCardWidth} />
                   </button>
                 ) : (
                   <div

--- a/frontend/src/pages/RazzPage.tsx
+++ b/frontend/src/pages/RazzPage.tsx
@@ -317,13 +317,10 @@ function RazzPageContent() {
                             card={card}
                             width={cardWidth}
                             style={placeholderCardStyle}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))
                       : !p.folded &&
-                        Array.from({ length: 4 }).map((_, i) => (
-                          <AnimatedCardBack key={i} width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
-                        ))}
+                        Array.from({ length: 4 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                   </div>
                   {/* Hole cards (face-down unless showdown) */}
                   <div className="text-ds-text-muted text-xs mb-0.5">{t('holeCards')}</div>
@@ -335,15 +332,12 @@ function RazzPageContent() {
                             card={card}
                             width={cardWidth}
                             style={placeholderCardStyle}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))
                       : !p.folded &&
                         Array.from({
                           length: (state?.phase ?? 0) >= SevenCardStudPhase.SEVENTH_STREET ? 3 : 2,
-                        }).map((_, i) => (
-                          <AnimatedCardBack key={i} width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
-                        ))}
+                        }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                   </div>
                 </div>
               ))}
@@ -397,13 +391,10 @@ function RazzPageContent() {
                           card={card}
                           width={cardWidth}
                           style={placeholderCardStyle}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       ))
                     : !humanPlayer.folded &&
-                      Array.from({ length: 4 }).map((_, i) => (
-                        <AnimatedCardBack key={i} width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
-                      ))}
+                      Array.from({ length: 4 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                 </div>
                 {/* Hole cards */}
                 <div className="text-ds-text-muted text-xs mb-0.5">{t('holeCards')}</div>
@@ -415,13 +406,10 @@ function RazzPageContent() {
                           card={card}
                           width={cardWidth}
                           style={placeholderCardStyle}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       ))
                     : !humanPlayer.folded &&
-                      Array.from({ length: 3 }).map((_, i) => (
-                        <AnimatedCardBack key={i} width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
-                      ))}
+                      Array.from({ length: 3 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                 </div>
               </div>
             )}

--- a/frontend/src/pages/RedDogPage.tsx
+++ b/frontend/src/pages/RedDogPage.tsx
@@ -187,12 +187,7 @@ function RedDogPageContent() {
                 <div className="text-ds-warning font-bold text-center mb-1">{t('label.initial')}</div>
                 <div className="flex justify-center gap-2 flex-wrap">
                   {state.initialCards.map((card, i) => (
-                    <AnimatedCard
-                      key={`i-${card.design}-${card.value}-${i}`}
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard key={`i-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                   ))}
                 </div>
                 {state.spread > 0 && (isSpreadDecision || isEndPhase) && (
@@ -207,11 +202,7 @@ function RedDogPageContent() {
               <div className="mb-4">
                 <div className="text-ds-info font-bold text-center mb-1">{t('label.third')}</div>
                 <div className="flex justify-center">
-                  <AnimatedCard
-                    card={state.thirdCard}
-                    width={cardWidth}
-                    onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                  />
+                  <AnimatedCard card={state.thirdCard} width={cardWidth} />
                 </div>
               </div>
             )}

--- a/frontend/src/pages/Rummy500Page.tsx
+++ b/frontend/src/pages/Rummy500Page.tsx
@@ -193,11 +193,7 @@ function Rummy500PageContent() {
                       className={`transition-transform ${focusRingCard}`}
                       style={{ background: 'none', padding: 0, borderRadius: 8 }}
                     >
-                      <AnimatedCard
-                        card={card}
-                        width={cardWidth * 0.7}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard card={card} width={cardWidth * 0.7} />
                     </button>
                   ))}
                 </div>
@@ -224,7 +220,6 @@ function Rummy500PageContent() {
                             key={`meld-${p.id}-${mIdx}-${card.design}-${card.value}-${ci}`}
                             card={card}
                             width={cardWidth * 0.6}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))}
                       </div>
@@ -265,11 +260,7 @@ function Rummy500PageContent() {
                   boxSizing: 'border-box',
                 }}
               >
-                <AnimatedCard
-                  card={card}
-                  width={cardWidth}
-                  onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                />
+                <AnimatedCard card={card} width={cardWidth} />
               </button>
             ))}
           </div>

--- a/frontend/src/pages/SeahavenTowersPage.tsx
+++ b/frontend/src/pages/SeahavenTowersPage.tsx
@@ -235,12 +235,7 @@ function SeahavenTowersPageContent() {
                             onDragEnd={dnd.handleDragEnd}
                             className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${isSourceSelected('reserved', undefined, idx) ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(reservedZone) ? 'opacity-50' : ''}`}
                           >
-                            <AnimatedCard
-                              card={card}
-                              width={cardWidth}
-                              draggable={false}
-                              onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                            />
+                            <AnimatedCard card={card} width={cardWidth} draggable={false} />
                           </button>
                         ) : (
                           <button
@@ -291,7 +286,6 @@ function SeahavenTowersPageContent() {
                               width={cardWidth}
                               draggable={false}
                               dealDelay={isAutoCompleting ? idx * 0.15 : 0}
-                              onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                             />
                           </button>
                         ) : (
@@ -391,7 +385,6 @@ function SeahavenTowersPageContent() {
                                         width={cardWidth}
                                         draggable={false}
                                         style={{ width: '100%' }}
-                                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                                       />
                                     </button>
                                   ) : (

--- a/frontend/src/pages/SevenBridgePage.tsx
+++ b/frontend/src/pages/SevenBridgePage.tsx
@@ -183,11 +183,7 @@ function SevenBridgePageContent() {
               <div data-tutorial="sb-draw-area">
                 {state?.discardTop && (
                   <div className="my-3 p-3 rounded bg-black/40 flex items-center gap-3">
-                    <AnimatedCard
-                      card={state.discardTop}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={state.discardTop} width={cardWidth} />
                     <div className="text-ds-text-muted text-sm">{t('discardTop')}</div>
                   </div>
                 )}
@@ -207,7 +203,6 @@ function SevenBridgePageContent() {
                               key={`cpu-${card.design}-${card.value}-${idx}`}
                               card={card}
                               width={cardWidth * 0.8}
-                              onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                             />
                           ))}
                         </div>
@@ -221,7 +216,6 @@ function SevenBridgePageContent() {
                                   key={`cpu-meld-${mi}-${c.design}-${c.value}-${ci}`}
                                   card={c}
                                   width={cardWidth * 0.6}
-                                  onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                                 />
                               ))}
                             </div>
@@ -293,11 +287,7 @@ function SevenBridgePageContent() {
                       boxSizing: 'border-box',
                     }}
                   >
-                    <AnimatedCard
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={card} width={cardWidth} />
                   </button>
                 ))}
                 {humanPlayer.melds.length > 0 && (
@@ -310,7 +300,6 @@ function SevenBridgePageContent() {
                             key={`me-meld-${mi}-${c.design}-${c.value}-${ci}`}
                             card={c}
                             width={cardWidth * 0.6}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))}
                       </div>

--- a/frontend/src/pages/SevenCardStudPage.tsx
+++ b/frontend/src/pages/SevenCardStudPage.tsx
@@ -318,13 +318,10 @@ function SevenCardStudPageContent() {
                             card={card}
                             width={cardWidth}
                             style={placeholderCardStyle}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))
                       : !p.folded &&
-                        Array.from({ length: 4 }).map((_, i) => (
-                          <AnimatedCardBack key={i} width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
-                        ))}
+                        Array.from({ length: 4 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                   </div>
                   {/* Hole cards (face-down unless showdown) */}
                   <div className="text-ds-text-muted text-xs mb-0.5">{t('holeCards')}</div>
@@ -336,15 +333,12 @@ function SevenCardStudPageContent() {
                             card={card}
                             width={cardWidth}
                             style={placeholderCardStyle}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))
                       : !p.folded &&
                         Array.from({
                           length: (state?.phase ?? 0) >= SevenCardStudPhase.SEVENTH_STREET ? 3 : 2,
-                        }).map((_, i) => (
-                          <AnimatedCardBack key={i} width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
-                        ))}
+                        }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                   </div>
                 </div>
               ))}
@@ -398,13 +392,10 @@ function SevenCardStudPageContent() {
                           card={card}
                           width={cardWidth}
                           style={placeholderCardStyle}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       ))
                     : !humanPlayer.folded &&
-                      Array.from({ length: 4 }).map((_, i) => (
-                        <AnimatedCardBack key={i} width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
-                      ))}
+                      Array.from({ length: 4 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                 </div>
                 {/* Hole cards */}
                 <div className="text-ds-text-muted text-xs mb-0.5">{t('holeCards')}</div>
@@ -416,13 +407,10 @@ function SevenCardStudPageContent() {
                           card={card}
                           width={cardWidth}
                           style={placeholderCardStyle}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       ))
                     : !humanPlayer.folded &&
-                      Array.from({ length: 3 }).map((_, i) => (
-                        <AnimatedCardBack key={i} width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
-                      ))}
+                      Array.from({ length: 3 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                 </div>
               </div>
             )}

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -257,12 +257,9 @@ function ShortDeckPageContent() {
                             card={card}
                             width={cardWidth}
                             style={placeholderCardStyle}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))
-                      : Array.from({ length: 5 }).map((_, i) => (
-                          <AnimatedCardBack key={i} width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
-                        ))}
+                      : Array.from({ length: 5 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                   </div>
                 </>
               );
@@ -362,13 +359,10 @@ function ShortDeckPageContent() {
                           card={card}
                           width={cardWidth}
                           style={placeholderCardStyle}
-                          onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                         />
                       ))
                     : !humanPlayer.folded &&
-                      Array.from({ length: 2 }).map((_, i) => (
-                        <AnimatedCardBack key={i} width={cardWidth} onFlipComplete={() => playSound('cardFlip')} />
-                      ))}
+                      Array.from({ length: 2 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                 </div>
               </div>
             )}

--- a/frontend/src/pages/SpadesPage.tsx
+++ b/frontend/src/pages/SpadesPage.tsx
@@ -24,7 +24,6 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useSpadesGame } from '../hooks/useSpadesGame';
-import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -96,7 +95,6 @@ export const SpadesPage = withTutorial(SpadesPageContent, 'spades', SP_TUTORIAL_
 function SpadesPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('spades');
-  const { playSound } = useSound();
   const {
     state,
     loading,
@@ -266,7 +264,6 @@ function SpadesPageContent() {
                   cardWidth={cardWidth}
                   label={t('currentTrick')}
                   dataTutorial="sp-trick-display"
-                  onCardDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                 />
               </div>
 

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -179,7 +179,7 @@ function SpeedPageContent() {
               </span>
               <div className="flex gap-1">
                 {Array.from({ length: cpuPlayer.cardCount }).map((_, i) => (
-                  <AnimatedCardBack key={i} width={cardWidth * 0.7} onFlipComplete={() => playSound('cardFlip')} />
+                  <AnimatedCardBack key={i} width={cardWidth * 0.7} />
                 ))}
               </div>
               <span className="text-sm text-ds-text-muted">
@@ -198,13 +198,7 @@ function SpeedPageContent() {
                   className={`transition-transform hover:scale-105 disabled:opacity-50 ${focusRingCard}${isStuck && !loading ? ' animate-pulse cursor-pointer' : ''}`}
                   aria-label={isStuck ? t('flipButton') : `${t('centerPile')} ${pi}`}
                 >
-                  {card && (
-                    <AnimatedCard
-                      card={card}
-                      width={cardWidth * 1.2}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
-                  )}
+                  {card && <AnimatedCard card={card} width={cardWidth * 1.2} />}
                 </button>
               ))}
             </div>
@@ -229,11 +223,7 @@ function SpeedPageContent() {
                     className={`transition-transform ${focusRingCard}`}
                     style={selectedCardStyle(selectedCardIndices.includes(idx))}
                   >
-                    <AnimatedCard
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={card} width={cardWidth} />
                   </button>
                 ))}
               </div>

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -244,7 +244,6 @@ function SpiderPageContent() {
                     width={tableau.cw}
                     onClick={isPlaying ? handleDealGuarded : undefined}
                     ariaLabel={t('deal')}
-                    onFlipComplete={() => playSound('cardFlip')}
                   />
                 ) : (
                   <div
@@ -331,15 +330,10 @@ function SpiderPageContent() {
                                         width={tableau.cw}
                                         draggable={false}
                                         style={{ width: '100%' }}
-                                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                                       />
                                     </button>
                                   ) : (
-                                    <AnimatedCardBack
-                                      width={tableau.cw}
-                                      style={{ width: '100%' }}
-                                      onFlipComplete={() => playSound('cardFlip')}
-                                    />
+                                    <AnimatedCardBack width={tableau.cw} style={{ width: '100%' }} />
                                   )}
                                 </div>
                               );

--- a/frontend/src/pages/SpiderettePage.tsx
+++ b/frontend/src/pages/SpiderettePage.tsx
@@ -188,7 +188,6 @@ function SpiderettePageContent() {
                 width={tableau.cw}
                 onClick={isPlaying ? handleDealGuarded : undefined}
                 ariaLabel={t('deal')}
-                onFlipComplete={() => playSound('cardFlip')}
               />
             ) : (
               <div
@@ -266,15 +265,10 @@ function SpiderettePageContent() {
                                     width={tableau.cw}
                                     draggable={false}
                                     style={{ width: '100%' }}
-                                    onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                                   />
                                 </button>
                               ) : (
-                                <AnimatedCardBack
-                                  width={tableau.cw}
-                                  style={{ width: '100%' }}
-                                  onFlipComplete={() => playSound('cardFlip')}
-                                />
+                                <AnimatedCardBack width={tableau.cw} style={{ width: '100%' }} />
                               )}
                             </div>
                           );

--- a/frontend/src/pages/TarneebPage.tsx
+++ b/frontend/src/pages/TarneebPage.tsx
@@ -28,7 +28,6 @@ import {
   TARNEEB_POINT_LIMIT_OPTIONS,
   useTarneebGame,
 } from '../hooks/useTarneebGame';
-import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -111,7 +110,6 @@ export const TarneebPage = withTutorial(TarneebPageContent, 'tarneeb', TARNEEB_T
 function TarneebPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('tarneeb');
-  const { playSound } = useSound();
   const {
     state,
     loading,
@@ -290,7 +288,6 @@ function TarneebPageContent() {
                   cardWidth={cardWidth}
                   label={t('currentTrick')}
                   dataTutorial="tn-trick-display"
-                  onCardDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                 />
               </div>
 

--- a/frontend/src/pages/TexasHoldemBonusPage.tsx
+++ b/frontend/src/pages/TexasHoldemBonusPage.tsx
@@ -261,12 +261,7 @@ function TexasHoldemBonusPageContent() {
                 </div>
                 <div className="flex justify-center gap-2 flex-wrap">
                   {state.community.map((card, i) => (
-                    <AnimatedCard
-                      key={`c-${card.design}-${card.value}-${i}`}
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard key={`c-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                   ))}
                 </div>
               </div>
@@ -285,12 +280,7 @@ function TexasHoldemBonusPageContent() {
                     isMaskedCard(card) ? (
                       <AnimatedCardBack key={`d-back-${i}`} width={cardWidth} />
                     ) : (
-                      <AnimatedCard
-                        key={`d-${card.design}-${card.value}-${i}`}
-                        card={card}
-                        width={cardWidth}
-                        onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                      />
+                      <AnimatedCard key={`d-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                     ),
                   )}
                 </div>
@@ -307,12 +297,7 @@ function TexasHoldemBonusPageContent() {
                 </div>
                 <div className="flex justify-center gap-2 flex-wrap">
                   {state.playerHand.map((card, i) => (
-                    <AnimatedCard
-                      key={`p-${card.design}-${card.value}-${i}`}
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard key={`p-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                   ))}
                 </div>
               </div>

--- a/frontend/src/pages/ThreeCardPage.tsx
+++ b/frontend/src/pages/ThreeCardPage.tsx
@@ -225,12 +225,7 @@ function ThreeCardPageContent() {
                 </div>
                 <div className="flex justify-center gap-2">
                   {state.playerHand.map((card, i) => (
-                    <AnimatedCard
-                      key={`p-${card.design}-${card.value}-${i}`}
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard key={`p-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                   ))}
                 </div>
               </div>
@@ -252,12 +247,7 @@ function ThreeCardPageContent() {
                 </div>
                 <div className="flex justify-center gap-2">
                   {state.dealerHand.map((card, i) => (
-                    <AnimatedCard
-                      key={`d-${card.design}-${card.value}-${i}`}
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard key={`d-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                   ))}
                 </div>
               </div>

--- a/frontend/src/pages/TonkPage.tsx
+++ b/frontend/src/pages/TonkPage.tsx
@@ -228,11 +228,7 @@ function TonkPageContent() {
               <div>
                 {state.discardTop && (
                   <div className="my-3 p-3 rounded bg-black/40 flex items-center gap-3">
-                    <AnimatedCard
-                      card={state.discardTop}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={state.discardTop} width={cardWidth} />
                     <div className="text-ds-text-muted text-sm">
                       <div>{t('discardTop')}</div>
                     </div>
@@ -249,7 +245,6 @@ function TonkPageContent() {
                             key={`meld-${meldIdx}-${card.design}-${card.value}-${cardIdx}`}
                             card={card}
                             width={cardWidth * 0.7}
-                            onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                           />
                         ))}
                       </div>
@@ -275,7 +270,6 @@ function TonkPageContent() {
                               key={`cpu-${card.design}-${card.value}-${idx}`}
                               card={card}
                               width={cardWidth * 0.8}
-                              onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                             />
                           ))}
                         </div>
@@ -342,11 +336,7 @@ function TonkPageContent() {
                       boxSizing: 'border-box',
                     }}
                   >
-                    <AnimatedCard
-                      card={card}
-                      width={cardWidth}
-                      onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                    />
+                    <AnimatedCard card={card} width={cardWidth} />
                   </button>
                 ))}
               </div>

--- a/frontend/src/pages/TriPeaksPage.tsx
+++ b/frontend/src/pages/TriPeaksPage.tsx
@@ -231,11 +231,7 @@ function TriPeaksPageContent() {
                               isHinted ? 'ring-2 ring-ds-warning' : ''
                             } ${!exposed ? 'opacity-60' : ''}`}
                           >
-                            <AnimatedCard
-                              card={tc2.card}
-                              width={effectiveCardWidth}
-                              onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                            />
+                            <AnimatedCard card={tc2.card} width={effectiveCardWidth} />
                           </button>
                         </div>
                       );
@@ -256,7 +252,6 @@ function TriPeaksPageContent() {
                     width={effectiveCardWidth}
                     onClick={isPlaying ? handleDraw : undefined}
                     ariaLabel={t('draw')}
-                    onFlipComplete={() => playSound('cardFlip')}
                   />
                 ) : (
                   <div
@@ -271,11 +266,7 @@ function TriPeaksPageContent() {
               <div className="text-center">
                 <div className="text-game-text-muted text-xs mb-1">{t('waste')}</div>
                 {state.waste.length > 0 ? (
-                  <AnimatedCard
-                    card={state.waste[state.waste.length - 1]}
-                    width={effectiveCardWidth}
-                    onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                  />
+                  <AnimatedCard card={state.waste[state.waste.length - 1]} width={effectiveCardWidth} />
                 ) : (
                   <div
                     style={{ width: effectiveCardWidth, height: cardHeight }}

--- a/frontend/src/pages/TwoTenJackPage.tsx
+++ b/frontend/src/pages/TwoTenJackPage.tsx
@@ -24,7 +24,6 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useTwoTenJackGame } from '../hooks/useTwoTenJackGame';
-import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -97,7 +96,6 @@ export const TwoTenJackPage = withTutorial(TwoTenJackPageContent, 'twotenjack', 
 function TwoTenJackPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('twotenjack');
-  const { playSound } = useSound();
   const {
     state,
     loading,
@@ -256,7 +254,6 @@ function TwoTenJackPageContent() {
                   cardWidth={cardWidth}
                   label={t('currentTrick')}
                   dataTutorial="tt-trick-display"
-                  onCardDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                 />
               </div>
 

--- a/frontend/src/pages/UltimateTexasHoldemPage.tsx
+++ b/frontend/src/pages/UltimateTexasHoldemPage.tsx
@@ -254,12 +254,7 @@ function UltimateTexasHoldemPageContent() {
             </div>
             <div className="flex justify-center gap-2 flex-wrap">
               {state.community.map((card, i) => (
-                <AnimatedCard
-                  key={`c-${card.design}-${card.value}-${i}`}
-                  card={card}
-                  width={cardWidth}
-                  onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                />
+                <AnimatedCard key={`c-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
               ))}
             </div>
           </div>
@@ -278,12 +273,7 @@ function UltimateTexasHoldemPageContent() {
                 isMaskedCard(card) ? (
                   <AnimatedCardBack key={`d-back-${i}`} width={cardWidth} />
                 ) : (
-                  <AnimatedCard
-                    key={`d-${card.design}-${card.value}-${i}`}
-                    card={card}
-                    width={cardWidth}
-                    onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                  />
+                  <AnimatedCard key={`d-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                 ),
               )}
             </div>
@@ -300,12 +290,7 @@ function UltimateTexasHoldemPageContent() {
             </div>
             <div className="flex justify-center gap-2 flex-wrap">
               {state.playerHand.map((card, i) => (
-                <AnimatedCard
-                  key={`p-${card.design}-${card.value}-${i}`}
-                  card={card}
-                  width={cardWidth}
-                  onDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
-                />
+                <AnimatedCard key={`p-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
               ))}
             </div>
           </div>

--- a/frontend/src/pages/WhistPage.tsx
+++ b/frontend/src/pages/WhistPage.tsx
@@ -24,7 +24,6 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useWhistGame } from '../hooks/useWhistGame';
-import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -90,7 +89,6 @@ export const WhistPage = withTutorial(WhistPageContent, 'whist', WH_TUTORIAL_STE
 function WhistPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('whist');
-  const { playSound } = useSound();
   const {
     state,
     loading,
@@ -244,7 +242,6 @@ function WhistPageContent() {
                   cardWidth={cardWidth}
                   label={t('currentTrick')}
                   dataTutorial="wh-trick-display"
-                  onCardDealComplete={() => playSound('cardDeal', { pitchVariation: 0.03 })}
                 />
               </div>
 

--- a/frontend/src/providers/SoundProvider.tsx
+++ b/frontend/src/providers/SoundProvider.tsx
@@ -143,3 +143,14 @@ export function useSound(): SoundContextValue {
   }
   return context;
 }
+
+/**
+ * Variant of `useSound` that returns `null` when called outside a
+ * `SoundProvider` instead of throwing. Used by leaf presentational
+ * components (e.g., `AnimatedCard`) that should play their default SFX
+ * when wired into the real app but degrade gracefully in unit tests
+ * that render them in isolation without a provider.
+ */
+export function useOptionalSound(): SoundContextValue | null {
+  return useContext(SoundContext);
+}


### PR DESCRIPTION
## Summary

Hoist the universally-identical \`playSound('cardDeal', { pitchVariation: 0.03 })\` and \`playSound('cardFlip')\` callbacks out of every page and into \`AnimatedCard\` / \`AnimatedCardBack\`. Pages no longer need to thread sound through every card; deal/flip are intrinsic to the components themselves.

### Component changes

- **\`AnimatedCard\`** now calls \`useOptionalSound()\` and plays \`cardDeal\` on deal-in completion. New \`silent\` prop opts out.
- **\`AnimatedCardBack\`** same pattern for \`cardFlip\`.
- **\`useOptionalSound\`** (new, in \`SoundProvider.tsx\`) — non-throwing variant of \`useSound\` that returns \`null\` when called outside a provider, so leaf components can depend on the sound context without forcing every unit test to wrap.

### Callsite removal (~194 inline callbacks deleted)

| Pattern | Before | After |
|---|---:|---:|
| \`onDealComplete={() => playSound('cardDeal', ...)}\` | 157 | 0 |
| \`onFlipComplete={() => playSound('cardFlip')}\` | 37 | 0 |
| \`onCardDealComplete={() => playSound('cardDeal', ...)}\` (TrickDisplay) | 13 | 0 |

Plus:
- Removed the now-redundant \`onCardDealComplete\` prop on \`TrickDisplay\` and the \`onDealComplete\` parameter on \`BlackJackSwitchPage\`'s \`CardSlot\` wrapper.
- Removed 7 \`const { playSound } = useSound()\` destructures + their imports across pages whose only sound usage was cardDeal (Belote, CallBreak, Hearts, Spades, Tarneeb, TwoTenJack, Whist).

### Net diff

\`77 files changed, 249 insertions(+), 743 deletions(-)\` — **−494 lines**.

### Kept (additional side-effects)

\`AnimatedPile\` keeps its inline \`onDealComplete\` because it plumbs additional \`onPlace\` / \`onComplete\` callbacks beyond sound.

## Backward compatibility

- \`onDealComplete\` / \`onFlipComplete\` props remain on \`AnimatedCard\` / \`AnimatedCardBack\`, optional, and still fire after the default SFX. Existing extra-side-effect callers (currently only \`AnimatedPile\`) continue to work.
- Cards rendered outside a \`SoundProvider\` (unit tests) no longer throw; they just don't play.

## Test plan

- [x] \`bun run check\` clean.
- [x] Motion-component suite: 34/34 in \`AnimatedCard\`, \`AnimatedCardBack\`, \`AnimatedPile\`, \`TrickDisplay\` tests.
- [x] Sampled 13 affected page test files (BlackJack, BlackJackSwitch, Holdem, Poker, Mighty, Euchre, …): 619/619.
- [x] Full local \`bun run test\`: 7267 tests passed across 484/485 test files. The single non-pass was an OOM (Node v8 OOMErrorHandler) on \`NavBar.test.tsx\` worker — local WSL2 2 GB RAM constraint, not a code failure; NavBar already mocks \`useSound\` and is unaffected by this PR. CI has more memory and should run cleanly.
- [x] New tests pin the design contract: \`silent\` prop accepted; component renders outside a \`SoundProvider\` without throwing.

Closes #1845