### PR TITLE
fix(tonk): replenish deck on every deal so 2nd reset isn't empty

### DIFF
--- a/internal/domain/Tonk.go
+++ b/internal/domain/Tonk.go
@@ -158,11 +158,7 @@ func (g *Tonk) NextRound() {
 
 // dealInitialCards 初期配布: 各プレイヤーにTonkHandSize枚、1枚を捨て札に
 func (g *Tonk) dealInitialCards() {
-	// Replenish the underlying deck — without this, a 2nd Reset (or NextRound
-	// after a normal hand) finds the deck drained from the previous deal and
-	// produces an empty drawPile, leaving the next round un-playable.
-	// Replenish (not Shuffle) so g.rng-driven determinism survives — the
-	// drawPile is shuffled separately below via the seeded rng.
+	// Refill draw counter so a 2nd deal isn't empty; Replenish (not Shuffle) keeps g.rng determinism.
 	g.trumpCards.Replenish()
 
 	g.drawPile = make([]*Card, 0, g.trumpCards.GetTotalCount())

--- a/internal/domain/Tonk.go
+++ b/internal/domain/Tonk.go
@@ -158,6 +158,13 @@ func (g *Tonk) NextRound() {
 
 // dealInitialCards 初期配布: 各プレイヤーにTonkHandSize枚、1枚を捨て札に
 func (g *Tonk) dealInitialCards() {
+	// Replenish the underlying deck — without this, a 2nd Reset (or NextRound
+	// after a normal hand) finds the deck drained from the previous deal and
+	// produces an empty drawPile, leaving the next round un-playable.
+	// Replenish (not Shuffle) so g.rng-driven determinism survives — the
+	// drawPile is shuffled separately below via the seeded rng.
+	g.trumpCards.Replenish()
+
 	g.drawPile = make([]*Card, 0, g.trumpCards.GetTotalCount())
 	for {
 		card := g.trumpCards.DrawCard()

--- a/internal/domain/Tonk_test.go
+++ b/internal/domain/Tonk_test.go
@@ -103,6 +103,39 @@ func TestTonk_Reset_NormalDeal(t *testing.T) {
 	// but the test should not fail spuriously
 }
 
+// TestTonk_ResetTwice guards against a regression where calling Reset() a
+// second time on the same Game instance left the underlying deck drained,
+// producing an empty deal (totalCards=0, drawPileCount=0). See bug repro
+// where the user clicks "次のゲーム" on Render dev / Cloudflare workers
+// and the next round arrives with no cards.
+func TestTonk_ResetTwice(t *testing.T) {
+	// Reach a "normal deal" (non-Tonk) state via the same retry loop used
+	// by TestTonk_Reset_NormalDeal so deal-time Tonk doesn't blank the deck.
+	for trial := 0; trial < 50; trial++ {
+		g := newTestTonk()
+		g.Reset()
+		if g.GetPhase() != domain.TonkPhaseDraw {
+			continue
+		}
+
+		// 2nd Reset on the SAME Game instance — the failure mode.
+		g.Reset()
+
+		if g.GetPhase() != domain.TonkPhaseDraw {
+			continue // Tonk on the second deal — retry the whole trial.
+		}
+		for i := 0; i < 2; i++ {
+			assert.Equal(t, 5, g.GetPlayer(i).GetCardsSize(),
+				"player %d hand should be 5 cards after 2nd Reset", i)
+		}
+		assert.Len(t, g.GetDiscardPile(), 1, "discard pile should hold 1 card after 2nd Reset")
+		assert.Equal(t, 41, g.GetDrawPileCount(),
+			"draw pile should hold 41 cards after 2nd Reset (52 - 10 hand - 1 discard)")
+		return
+	}
+	t.Fatal("never observed a non-Tonk deal across 50 trials")
+}
+
 func TestTonk_Getters(t *testing.T) {
 	g := newTestTonk()
 	g.Reset()

--- a/internal/domain/Tonk_test.go
+++ b/internal/domain/Tonk_test.go
@@ -108,32 +108,30 @@ func TestTonk_Reset_NormalDeal(t *testing.T) {
 // producing an empty deal (totalCards=0, drawPileCount=0). See bug repro
 // where the user clicks "次のゲーム" on Render dev / Cloudflare workers
 // and the next round arrives with no cards.
+//
+// Seed 1 is the first int64 where both the 1st and 2nd consecutive Reset
+// produce a normal (non-Tonk-on-deal) hand, so the assertions exercise the
+// regression path directly — no retry loop / probabilistic guard needed.
 func TestTonk_ResetTwice(t *testing.T) {
-	// Reach a "normal deal" (non-Tonk) state via the same retry loop used
-	// by TestTonk_Reset_NormalDeal so deal-time Tonk doesn't blank the deck.
-	for trial := 0; trial < 50; trial++ {
-		g := newTestTonk()
-		g.Reset()
-		if g.GetPhase() != domain.TonkPhaseDraw {
-			continue
-		}
+	g := newTestTonk()
+	g.SetRand(rand.New(rand.NewSource(1)))
 
-		// 2nd Reset on the SAME Game instance — the failure mode.
-		g.Reset()
+	g.Reset()
+	require.Equal(t, domain.TonkPhaseDraw, g.GetPhase(),
+		"seed 1 should produce a non-Tonk deal on 1st Reset")
 
-		if g.GetPhase() != domain.TonkPhaseDraw {
-			continue // Tonk on the second deal — retry the whole trial.
-		}
-		for i := 0; i < 2; i++ {
-			assert.Equal(t, 5, g.GetPlayer(i).GetCardsSize(),
-				"player %d hand should be 5 cards after 2nd Reset", i)
-		}
-		assert.Len(t, g.GetDiscardPile(), 1, "discard pile should hold 1 card after 2nd Reset")
-		assert.Equal(t, 41, g.GetDrawPileCount(),
-			"draw pile should hold 41 cards after 2nd Reset (52 - 10 hand - 1 discard)")
-		return
+	// 2nd Reset on the SAME Game instance — the failure mode.
+	g.Reset()
+	require.Equal(t, domain.TonkPhaseDraw, g.GetPhase(),
+		"seed 1 should produce a non-Tonk deal on 2nd Reset")
+
+	for i := 0; i < 2; i++ {
+		assert.Equal(t, 5, g.GetPlayer(i).GetCardsSize(),
+			"player %d hand should be 5 cards after 2nd Reset", i)
 	}
-	t.Fatal("never observed a non-Tonk deal across 50 trials")
+	assert.Len(t, g.GetDiscardPile(), 1, "discard pile should hold 1 card after 2nd Reset")
+	assert.Equal(t, 41, g.GetDrawPileCount(),
+		"draw pile should hold 41 cards after 2nd Reset (52 - 10 hand - 1 discard)")
 }
 
 func TestTonk_Getters(t *testing.T) {

--- a/internal/domain/TrumpCards.go
+++ b/internal/domain/TrumpCards.go
@@ -78,6 +78,14 @@ func (t *TrumpCards) Shuffle() {
 	t.deckInit()
 }
 
+// Replenish makes every card available to DrawCard again without changing
+// the underlying deck order. Call this when re-dealing on the same deck
+// (e.g. on a 2nd Reset) and randomization is handled separately by the
+// caller (typically a seeded `rand.Rand` shuffling the drawn pile).
+func (t *TrumpCards) Replenish() {
+	t.deckInit()
+}
+
 // GetRemainingCount 山札の残り枚数
 func (t *TrumpCards) GetRemainingCount() int {
 	return t.deckCnt - t.deckDrawCnt

--- a/internal/domain/TrumpCards_test.go
+++ b/internal/domain/TrumpCards_test.go
@@ -156,6 +156,42 @@ func TestTrumpCards_DrawCard(t *testing.T) {
 	})
 }
 
+func TestTrumpCards_Replenish(t *testing.T) {
+	t.Run("makes drawn cards available again without changing deck order", func(t *testing.T) {
+		tc := domain.NewTrumpCards(0)
+
+		// Capture the initial deck order by drawing all cards.
+		drawn := make([]*domain.Card, 0, 52)
+		for {
+			c := tc.DrawCard()
+			if c == nil {
+				break
+			}
+			drawn = append(drawn, c)
+		}
+		if tc.GetRemainingCount() != 0 {
+			t.Fatalf("setup: expected exhausted deck, got %d remaining", tc.GetRemainingCount())
+		}
+
+		// Replenish should restore full availability without shuffling.
+		tc.Replenish()
+		if got := tc.GetRemainingCount(); got != 52 {
+			t.Fatalf("expected 52 remaining after Replenish, got %d", got)
+		}
+
+		for i := 0; i < 52; i++ {
+			c := tc.DrawCard()
+			if c == nil {
+				t.Fatalf("DrawCard returned nil at index %d after Replenish", i)
+			}
+			if c.GetDesign() != drawn[i].GetDesign() || c.GetValue() != drawn[i].GetValue() {
+				t.Errorf("card %d differs from pre-Replenish order: got (%v,%d) want (%v,%d)",
+					i, c.GetDesign(), c.GetValue(), drawn[i].GetDesign(), drawn[i].GetValue())
+			}
+		}
+	})
+}
+
 func TestTrumpCards_GetRemainingCount(t *testing.T) {
 	t.Run("initial remaining equals total", func(t *testing.T) {
 		tc := domain.NewTrumpCards(0)


### PR DESCRIPTION
## Summary

- ユーザー報告「ラミー系のゲームで1ゲーム終了後に次のゲームへ進めずエラー」の真犯人 = **tonk** を修正
- `Reset()` (および `NextRound()`) 時に `TrumpCards` の draw counter が前ゲーム分のまま残り、`dealInitialCards()` で 1 枚も draw できず players=0 cards / drawPile=0 になっていた
- `TrumpCards.Replenish()` を新設し、`Tonk.dealInitialCards()` 冒頭で呼ぶ。`g.rng` の seeded determinism を壊さないよう `Shuffle()` ではなく order-preserving な API を分離

## Repro

```sh
SID="repro-$(date +%s)"
curl -X POST https://go-trumpcards-dev.onrender.com/tonk/exec \
  -H 'Content-Type: application/json' \
  -d "{\"command\":\"reset\",\"sessionId\":\"$SID\"}"
# 1st: 各 player 5 cards, drawPileCount=41 ✅
curl -X POST https://go-trumpcards-dev.onrender.com/tonk/exec \
  -H 'Content-Type: application/json' \
  -d "{\"command\":\"reset\",\"sessionId\":\"$SID\"}"
# 2nd (BUG): cardCount=0 / drawPileCount=0 ❌
```

E2E 検証では `次のゲーム` をクリック後 (= 同 sessionId で reset を再送) この状態に陥り、UI 上は drawPhase なのにカードが無く操作不能になる。Render Dev / Cloudflare Workers Staging 両方で 100% 再現していた。

## Root cause

`TrumpCards.DrawCard()` は内部の `deckDrawCnt` を進めるだけで自動的に補充しない。Tonk の `dealInitialCards()` は `g.trumpCards.DrawCard()` を nil が返るまで回して `drawPile` を作る。
- 初回 reset 後: `deckDrawCnt = 52`
- 2 回目 reset: `DrawCard()` が即 nil → `drawPile` は空
- 他ゲーム (`GinRummy`, `Sevens`, `Daifugo`, `Durak`, …) は reset で `trumpCards.Shuffle()` (＝ deckInit 経由でカウンタリセット) を呼んでいたが Tonk だけ欠けていた

## Fix

1. `TrumpCards.Replenish()` を追加: deck の順序を変えずに `deckInit()` だけ呼ぶ public API
2. `Tonk.dealInitialCards()` 冒頭で `g.trumpCards.Replenish()` を実行
   - `Shuffle()` ではなく `Replenish()` を選んだ理由: Tonk は `g.rng.Shuffle(drawPile)` で乱数化を担当しており、`TestTonk_TonkOnDeal_DeterministicSeed` (seed 359 / 478) が `g.SetRand(...)` のシード値に依存している。`trumpCards.Shuffle()` を呼ぶと `math/rand` グローバルが介入してこの determinism を壊す

## Tests

- ✅ `TestTonk_ResetTwice` (新): 同インスタンスで `Reset()` を 2 回呼んで 2 回目も 5+5 cards / drawPile=41 / discard=1 になることを assert。**修正前は確実に fail**、修正後 -race -count=20 で安定 pass
- ✅ `TestTrumpCards_Replenish` (新): draw 全消費後 `Replenish()` で 52 cards 復活、かつ deck order が変わらないことを assert
- ✅ 既存の `TestTonk_*` 全件 (`-count=5` で安定)、特に seed 依存の `TestTonk_TonkOnDeal_DeterministicSeed` が引き続き pass
- ✅ `go test -tags test ./internal/domain` (86s, ok) ※ `TestSeahavenTowersSolver_IterationLimitReturnsTrue` は既知 flake で再実行 pass
- ✅ `golangci-lint run ./...`: 0 issues

## 副次調査 (作業中に flag したが調査結果 = bug ではない)

96 ゲーム reset 二連打 API 比較で oldmaid / daifugo / durak / sevens にも total cardCount のずれがあったが、8 セッション×初回 reset の variance 検証で「自然な配布乱数の範囲内」と確認 (例: oldmaid 19-31, daifugo 51-54, durak 23-25, sevens 45-48)。これらは bug ではないため本 PR では触らない。

## Test plan

- [ ] CI で全テスト pass を確認
- [ ] merge 後 Render dev / Cloudflare workers staging に deploy
- [ ] ステージングで tonk を実プレイ→終局→「次のゲーム」が正しく動くことを目視確認