### PR TITLE
fix(discover): drop redundant 'discover.' prefix from axis/option i18n keys

### DIFF
--- a/frontend/src/constants/discoverAxes.test.ts
+++ b/frontend/src/constants/discoverAxes.test.ts
@@ -53,10 +53,21 @@ describe('discoverAxes constants', () => {
     }
   });
 
-  it('every option has a discover.* i18n key', () => {
+  it('every option has an option.<axis>.* i18n key (no leading `discover.` — the namespace is supplied by useTranslation)', () => {
     for (const key of AXIS_KEYS) {
       for (const opt of AXES[key].options) {
-        expect(opt.i18nKey).toMatch(/^discover\.option\./);
+        expect(opt.i18nKey).toMatch(/^option\.[a-z]+\./);
+        expect(opt.i18nKey).not.toMatch(/^discover\./);
+      }
+    }
+  });
+
+  it('every axis label and question key omits the `discover.` namespace prefix', () => {
+    for (const key of AXIS_KEYS) {
+      expect(AXES[key].labelI18nKey).toMatch(/^axis\.[a-z]+\.label$/);
+      expect(AXES[key].labelI18nKey).not.toMatch(/^discover\./);
+      for (const qk of AXES[key].questionI18nKeys) {
+        expect(qk).toMatch(/^axis\.[a-z]+\.q[12]$/);
       }
     }
   });

--- a/frontend/src/constants/discoverAxes.test.ts
+++ b/frontend/src/constants/discoverAxes.test.ts
@@ -56,7 +56,7 @@ describe('discoverAxes constants', () => {
   it('every option has an option.<axis>.* i18n key (no leading `discover.` — the namespace is supplied by useTranslation)', () => {
     for (const key of AXIS_KEYS) {
       for (const opt of AXES[key].options) {
-        expect(opt.i18nKey).toMatch(/^option\.[a-z]+\./);
+        expect(opt.i18nKey).toMatch(new RegExp('^option\\.' + key + '\\.'));
         expect(opt.i18nKey).not.toMatch(/^discover\./);
       }
     }
@@ -64,10 +64,10 @@ describe('discoverAxes constants', () => {
 
   it('every axis label and question key omits the `discover.` namespace prefix', () => {
     for (const key of AXIS_KEYS) {
-      expect(AXES[key].labelI18nKey).toMatch(/^axis\.[a-z]+\.label$/);
+      expect(AXES[key].labelI18nKey).toMatch(new RegExp('^axis\\.' + key + '\\.label$'));
       expect(AXES[key].labelI18nKey).not.toMatch(/^discover\./);
       for (const qk of AXES[key].questionI18nKeys) {
-        expect(qk).toMatch(/^axis\.[a-z]+\.q[12]$/);
+        expect(qk).toMatch(new RegExp('^axis\\.' + key + '\\.q[12]$'));
       }
     }
   });

--- a/frontend/src/constants/discoverAxes.ts
+++ b/frontend/src/constants/discoverAxes.ts
@@ -16,7 +16,11 @@
 export interface AxisOption {
   /** Stable kebab-case identifier (do not rename without migrating data). */
   readonly key: string;
-  /** i18n key in the lazy-loaded `discover` namespace. */
+  /**
+   * i18n key resolved within the `discover` namespace — do NOT include
+   * a leading `discover.` prefix, since callers already pass the
+   * namespace via `useTranslation('discover')`.
+   */
   readonly i18nKey: string;
 }
 
@@ -24,9 +28,16 @@ export interface AxisOption {
 export interface AxisDef {
   /** Number of questions asked for this axis (premise: 2 per axis). */
   readonly questionCount: 2;
-  /** i18n key for the axis label (e.g. shown in result `topAxis` chip). */
+  /**
+   * i18n key for the axis label (e.g. shown in result `topAxis` chip).
+   * Resolved within the `discover` namespace — do NOT include a leading
+   * `discover.` prefix.
+   */
   readonly labelI18nKey: string;
-  /** i18n keys for the 2 question prompts (order = question index 0, 1). */
+  /**
+   * i18n keys for the 2 question prompts (order = question index 0, 1).
+   * Resolved within the `discover` namespace.
+   */
   readonly questionI18nKeys: readonly [string, string];
   /** Ordered list of options; index is the wire format. */
   readonly options: readonly AxisOption[];
@@ -59,45 +70,45 @@ export const SOCIAL_PENALTY = 0.5;
 export const AXES: Readonly<Record<AxisKey, AxisDef>> = {
   mood: {
     questionCount: 2,
-    labelI18nKey: 'discover.axis.mood.label',
-    questionI18nKeys: ['discover.axis.mood.q1', 'discover.axis.mood.q2'],
+    labelI18nKey: 'axis.mood.label',
+    questionI18nKeys: ['axis.mood.q1', 'axis.mood.q2'],
     options: [
-      { key: 'quiet_focus', i18nKey: 'discover.option.mood.quiet_focus' },
-      { key: 'lively', i18nKey: 'discover.option.mood.lively' },
-      { key: 'thoughtful', i18nKey: 'discover.option.mood.thoughtful' },
-      { key: 'quick', i18nKey: 'discover.option.mood.quick' },
+      { key: 'quiet_focus', i18nKey: 'option.mood.quiet_focus' },
+      { key: 'lively', i18nKey: 'option.mood.lively' },
+      { key: 'thoughtful', i18nKey: 'option.mood.thoughtful' },
+      { key: 'quick', i18nKey: 'option.mood.quick' },
     ],
   },
   skill: {
     questionCount: 2,
-    labelI18nKey: 'discover.axis.skill.label',
-    questionI18nKeys: ['discover.axis.skill.q1', 'discover.axis.skill.q2'],
+    labelI18nKey: 'axis.skill.label',
+    questionI18nKeys: ['axis.skill.q1', 'axis.skill.q2'],
     options: [
-      { key: 'beginner', i18nKey: 'discover.option.skill.beginner' },
-      { key: 'intermediate', i18nKey: 'discover.option.skill.intermediate' },
-      { key: 'advanced', i18nKey: 'discover.option.skill.advanced' },
-      { key: 'learning_rules', i18nKey: 'discover.option.skill.learning_rules' },
+      { key: 'beginner', i18nKey: 'option.skill.beginner' },
+      { key: 'intermediate', i18nKey: 'option.skill.intermediate' },
+      { key: 'advanced', i18nKey: 'option.skill.advanced' },
+      { key: 'learning_rules', i18nKey: 'option.skill.learning_rules' },
     ],
   },
   social: {
     questionCount: 2,
-    labelI18nKey: 'discover.axis.social.label',
-    questionI18nKeys: ['discover.axis.social.q1', 'discover.axis.social.q2'],
+    labelI18nKey: 'axis.social.label',
+    questionI18nKeys: ['axis.social.q1', 'axis.social.q2'],
     options: [
-      { key: 'solo', i18nKey: 'discover.option.social.solo' },
-      { key: 'vs_cpu', i18nKey: 'discover.option.social.vs_cpu' },
-      { key: 'with_friends', i18nKey: 'discover.option.social.with_friends' },
+      { key: 'solo', i18nKey: 'option.social.solo' },
+      { key: 'vs_cpu', i18nKey: 'option.social.vs_cpu' },
+      { key: 'with_friends', i18nKey: 'option.social.with_friends' },
     ],
   },
   theme: {
     questionCount: 2,
-    labelI18nKey: 'discover.axis.theme.label',
-    questionI18nKeys: ['discover.axis.theme.q1', 'discover.axis.theme.q2'],
+    labelI18nKey: 'axis.theme.label',
+    questionI18nKeys: ['axis.theme.q1', 'axis.theme.q2'],
     options: [
-      { key: 'casino', i18nKey: 'discover.option.theme.casino' },
-      { key: 'european', i18nKey: 'discover.option.theme.european' },
-      { key: 'western', i18nKey: 'discover.option.theme.western' },
-      { key: 'japanese_household', i18nKey: 'discover.option.theme.japanese_household' },
+      { key: 'casino', i18nKey: 'option.theme.casino' },
+      { key: 'european', i18nKey: 'option.theme.european' },
+      { key: 'western', i18nKey: 'option.theme.western' },
+      { key: 'japanese_household', i18nKey: 'option.theme.japanese_household' },
     ],
   },
 } as const;

--- a/frontend/src/pages/DiscoverPage.test.tsx
+++ b/frontend/src/pages/DiscoverPage.test.tsx
@@ -5,6 +5,7 @@ import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import i18n from 'i18next';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AXES } from '../constants/discoverAxes';
 import { renderWithProviders } from '../test/renderWithProviders';
 import { DiscoverPage } from './DiscoverPage';
 
@@ -51,11 +52,11 @@ describe('DiscoverPage', () => {
 
   it('renders translated question and option text, not raw i18n keys', () => {
     setup();
-    const q1 = i18n.t('discover:axis.mood.q1');
-    const opt1 = i18n.t('discover:option.mood.quiet_focus');
+    const q1 = i18n.t('discover:' + AXES.mood.questionI18nKeys[0]);
+    const opt1 = i18n.t('discover:' + AXES.mood.options[0].i18nKey);
     // Sanity: the bundle resolves both keys to real Japanese strings.
-    expect(q1).not.toBe('discover:axis.mood.q1');
-    expect(opt1).not.toBe('discover:option.mood.quiet_focus');
+    expect(q1).not.toBe('discover:' + AXES.mood.questionI18nKeys[0]);
+    expect(opt1).not.toBe('discover:' + AXES.mood.options[0].i18nKey);
     expect(screen.getByRole('heading', { level: 2, name: q1 })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: new RegExp(opt1) })).toBeInTheDocument();
   });

--- a/frontend/src/pages/DiscoverPage.test.tsx
+++ b/frontend/src/pages/DiscoverPage.test.tsx
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import i18n from 'i18next';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -46,6 +47,17 @@ describe('DiscoverPage', () => {
   it('renders the first question on mount', () => {
     setup();
     expect(screen.getByRole('heading')).toBeInTheDocument();
+  });
+
+  it('renders translated question and option text, not raw i18n keys', () => {
+    setup();
+    const q1 = i18n.t('discover:axis.mood.q1');
+    const opt1 = i18n.t('discover:option.mood.quiet_focus');
+    // Sanity: the bundle resolves both keys to real Japanese strings.
+    expect(q1).not.toBe('discover:axis.mood.q1');
+    expect(opt1).not.toBe('discover:option.mood.quiet_focus');
+    expect(screen.getByRole('heading', { level: 2, name: q1 })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: new RegExp(opt1) })).toBeInTheDocument();
   });
 
   it('advances through 8 questions via keyboard digit shortcuts and navigates to /discover/result', async () => {


### PR DESCRIPTION
## Summary

`/discover` のサーベイ画面で、質問文と選択肢が i18n キーそのまま（例: `discover.axis.mood.q1` / `discover.option.mood.quiet_focus`）で表示されていた。

原因は `frontend/src/constants/discoverAxes.ts` の i18n キーが二重 namespace になっていたこと:

- `useTranslation('discover')` が namespace を `discover` に固定 → t() の引数は `discover` バンドル内のキーパス
- ところが定数側のキーが `discover.axis.mood.q1` 形式だったため、i18next は `discover` → `axis` → `mood` → `q1` というネストパスを `discover` バンドル内で探しに行く（その階層は存在しない）→ キー文字列がそのまま fallback で表示される

同 namespace の `t('action.skip')` 等は prefix 無しだったので普通に翻訳されていて見落とされやすい状態だった。

## Changes

- `discoverAxes.ts`: `labelI18nKey` / `questionI18nKeys` / `options[].i18nKey` の `discover.` prefix を全部剥がす（実バンドル構造に合わせる）
- TSDoc に「namespace は `useTranslation('discover')` 側で付くので prefix 入れるな」と明記
- `discoverAxes.test.ts`: 旧 `^discover\.option\.` 正規表現は壊れた契約を強制していたので修正。`^option\.<axis>\.` / `^axis\.<axis>\.q[12]$` / `^axis\.<axis>\.label$` を assert し、`discover.` で始まっていないことも明示
- `DiscoverPage.test.tsx`: 「レンダリングされた heading と最初の option が **生のキーではなく実訳文** を含む」DOM レベル回帰テストを追加（既存テストは aria-label / heading 存在のみで本文を見ていなかった）

## Verification

- `bun run test -- --run DiscoverPage discoverAxes` — 全パス（赤→緑確認済み）
- `bun run check` — Biome OK
- `bun run build` — `NODE_OPTIONS=--max-old-space-size=4096` で `built in 2m 54s`（成功、エラーなし）
- 実 dev サーバ + Chromium で `/#/discover` を開いて、質問文「今、どんな気分でカードを触りたい？」と選択肢「静かに集中したい」等が正しく日本語で表示されることを目視確認

## Test plan

- [ ] CI 緑
- [ ] `/#/discover` で質問・選択肢が日本語表示
- [ ] 英語切替時も同様（en バンドルも同じネスト構造なので自動で直る）