### PR TITLE
fix(discover): submit useEffect から axes 依存ループを切って空プロファイル送信を防止

### DIFF
--- a/frontend/src/pages/DiscoverPage.test.tsx
+++ b/frontend/src/pages/DiscoverPage.test.tsx
@@ -78,6 +78,32 @@ describe('DiscoverPage', () => {
     });
   });
 
+  it('submits the actual answer values to the URL, not all blanks (#1896)', async () => {
+    // Regression: ISSUE-001 — the submit useEffect listed `axes` in its dep
+    // array and called resetDraft() which mutated `axes` to EMPTY_ANSWERS.
+    // That fired the effect a second time, re-encoding the now-empty draft
+    // into the URL and silently overwriting the just-pushed good URL.
+    // Found by /qa on 2026-05-20
+    // Report: .gstack/qa-reports/qa-report-go-trumpcards-dev-2026-05-20.md
+    const { getLastPath } = setup();
+    for (let i = 0; i < 8; i++) {
+      await act(async () => {
+        fireEvent.keyDown(window, { key: '1' });
+      });
+    }
+    await waitFor(() => {
+      expect(getLastPath()).toMatch(/^\/discover\/result\?/);
+    });
+    const finalPath = getLastPath();
+    // Every key '1' selects option index 0 — every axis slot must be '0,0'.
+    // Pre-fix, this was 'm=-,-&s=-,-&so=-,-&t=-,-' regardless of the answers.
+    expect(finalPath).toContain('m=0,0');
+    expect(finalPath).toContain('s=0,0');
+    expect(finalPath).toContain('so=0,0');
+    expect(finalPath).toContain('t=0,0');
+    expect(finalPath).not.toMatch(/=-,-/);
+  });
+
   it('skip button advances without recording an answer', () => {
     setup();
     // Buttons rendered: mood Q1 options + skip; click the last one (skip).

--- a/frontend/src/pages/DiscoverPage.tsx
+++ b/frontend/src/pages/DiscoverPage.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from 'framer-motion';
-import { useCallback, useEffect, useReducer } from 'react';
+import { useCallback, useEffect, useReducer, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { DiscoverShell } from '../components/discover/DiscoverShell';
@@ -92,16 +92,22 @@ export function DiscoverPage() {
   const handleBack = useCallback(() => dispatch({ type: 'back' }), []);
 
   // Submit when the user finishes the last question.
+  // `resetDraft()` clears `axes` to all-null, which is itself a dependency of
+  // this effect — without the ref guard the effect re-fires with empty axes
+  // and a second navigate() overwrites the good URL with `m=-,-&s=-,-&...`.
+  const submittedRef = useRef(false);
   useEffect(() => {
     if (state.step < TOTAL_QUESTIONS) return;
+    if (submittedRef.current) return;
+    submittedRef.current = true;
     const query = encodeMood({
       mood: [axes.mood[0], axes.mood[1]],
       skill: [axes.skill[0], axes.skill[1]],
       social: [axes.social[0], axes.social[1]],
       theme: [axes.theme[0], axes.theme[1]],
     });
-    resetDraft();
     navigate(`/discover/result?${query}`, { replace: false });
+    resetDraft();
   }, [state.step, axes, navigate, resetDraft]);
 
   // Keyboard shortcuts: digit keys pick options; Backspace goes back.


### PR DESCRIPTION
## Summary

- Discover アンケート完了時に回答が消えて空プロファイルで結果ページに遷移する Critical バグを修正
- `submit useEffect` の `axes` 依存ループを `useRef` ガードで遮断
- jsdom 上で再現するリグレッションテストを追加

## 何が起きていた (Bug)

`/discover` の8問アンケート完走時に、URL が `?m=-,-&s=-,-&so=-,-&t=-,-` （全軸空）で結果ページに遷移し、レコメンドエンジンに回答が一切渡らない。"MORE HINTS, MORE PRECISE" フォールバック画面が必ず出る。

## 根本原因 (Root Cause)

`DiscoverPage.tsx` の submit useEffect:
```ts
useEffect(() => {
  if (state.step < TOTAL_QUESTIONS) return;
  const query = encodeMood({ mood: ..., skill: ..., ... });
  resetDraft();          // ← setAxes(EMPTY) を発火 → axes 変化
  navigate(`/discover/result?${query}`, { replace: false });
}, [state.step, axes, navigate, resetDraft]); // ← axes が dep
```

`resetDraft()` が `useSurveyDraft` の `setAxes(EMPTY_ANSWERS)` を呼ぶため `axes` が変化。effect は `axes` 依存なので再実行され、二度目は `encodeMood({all-null})` → `m=-,-&...` → `navigate(replace=false)` で good URL を空 URL が上書き。

## 修正 (Fix)

- `useRef` で `submittedRef` を持たせて effect の二度目以降を no-op に
- `navigate` を先、`resetDraft` を後に並べ替え

## リグレッションテスト

`DiscoverPage.test.tsx` に新規テスト追加:
- キー `1` を 8 回押して全質問に option 0 で回答
- 最終 URL に `m=0,0` / `s=0,0` / `so=0,0` / `t=0,0` が含まれることを assert
- pre-fix では `=-,-` パターンになっていた

## Test plan

- [x] `bun run test src/pages/DiscoverPage.test.tsx` → 6/6 pass (新規1件含む)
- [x] `bun run check` → 既存 7 info のみ（PR の差分とは無関係）
- [x] `bun run build` → ✓ built in 17m 8s
- [ ] Render dev 環境で実機確認: アンケート完走 → 結果ページの URL に値が乗っている
- [ ] Render dev で複数の axis 組み合わせでも fallback ではなく EDITOR'S PICK が出る

Closes #1896
