### PR TITLE
fix(i18n/discover): MAYBE A STRETCH カードを blurb.<slug> フォールバックに切り替えて生キー漏れを止める

### DIFF
--- a/frontend/src/components/discover/StretchPickCard.test.tsx
+++ b/frontend/src/components/discover/StretchPickCard.test.tsx
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 import { render, screen } from '@testing-library/react';
+import i18n from 'i18next';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
 import { gameRoutes } from '../../constants/gameRoutes';
@@ -19,5 +20,28 @@ describe('StretchPickCard', () => {
     );
     expect(screen.getByRole('heading')).toBeInTheDocument();
     expect(screen.getByRole('link')).toHaveAttribute('href', briscola.path);
+  });
+
+  it('renders the blurb fallback (not the raw i18n key) when stretch.<slug> is missing (#1897)', () => {
+    // Regression: ISSUE-002 — `stretch.<slug>` entries were never added to
+    // discover.json, so every Stretch card showed the literal key string
+    // (e.g. "stretch.briscola") in place of the description.
+    // Found by /qa on 2026-05-20
+    // Report: .gstack/qa-reports/qa-report-go-trumpcards-dev-2026-05-20.md
+    const slug = briscola.page.toLowerCase();
+    const blurb = i18n.t(`discover:blurb.${slug}`);
+    // Sanity: the blurb namespace really has briscola.
+    expect(blurb).not.toBe(`discover:blurb.${slug}`);
+    expect(blurb).not.toBe(`blurb.${slug}`);
+
+    render(
+      <MemoryRouter>
+        <StretchPickCard game={briscola} />
+      </MemoryRouter>,
+    );
+    // The raw stretch key must never reach the DOM.
+    expect(screen.queryByText(`stretch.${slug}`)).toBeNull();
+    // The blurb fallback should be visible.
+    expect(screen.getByText(blurb)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/discover/StretchPickCard.tsx
+++ b/frontend/src/components/discover/StretchPickCard.tsx
@@ -11,12 +11,19 @@ export interface StretchPickCardProps {
 /**
  * "Ever-so-slightly off-piste" recommendation. Dashed gold border + warm
  * gradient background, drawing the eye without competing with the hero.
+ *
+ * The blurb prefers a stretch-specific copy (`discover.stretch.<slug>`) if
+ * the locale provides one, and falls back to the regular game blurb
+ * (`discover.blurb.<slug>`) otherwise. Every game has a blurb entry so the
+ * fallback always resolves; per-slug stretch copy can be added later
+ * without changing this component.
  */
 export function StretchPickCard({ game }: StretchPickCardProps) {
   const { t } = useTranslation('discover');
   const labelT = useTranslation('common').t;
   const slug = game.page.toLowerCase();
   const blurbKey = `stretch.${slug}`;
+  const blurbFallback = t(`blurb.${slug}`);
   const gameName = labelT(game.labelKey);
 
   return (
@@ -28,7 +35,7 @@ export function StretchPickCard({ game }: StretchPickCardProps) {
         </span>
         {gameName}
       </h2>
-      <p className="text-sm text-ds-text-muted leading-relaxed">{t(blurbKey)}</p>
+      <p className="text-sm text-ds-text-muted leading-relaxed">{t(blurbKey, { defaultValue: blurbFallback })}</p>
       <Link to={game.path} className={`${btnSecondary} self-start ${focusRingWhite}`}>
         {t('stretch.action')}
       </Link>


### PR DESCRIPTION
## Summary

- 全 `MAYBE A STRETCH` カードで `stretch.<slug>` という生 i18n キーがそのまま表示される High バグを修正
- StretchPickCard を既存の `discover.blurb.<slug>` にフォールバックさせる
- リグレッションテスト追加

## 何が起きていた (Bug)

`StretchPickCard` は `discover.stretch.<slug>` を `t()` に渡していたが、`discover.json` には `stretch.eyebrow` と `stretch.action` しか定義が無く、すべての stretch カードの説明文が `stretch.skat` のような生キーで描画されていた（ja / en 両方）。

QA で確認した漏れキー例:
- `stretch.skat`, `stretch.bridge`, `stretch.whist`, `stretch.napoleon`
- `stretch.crescent`, `stretch.tripeaks`, `stretch.ultimatetexasholdem`

## 解決アプローチ (Why blurb fallback over per-slug stretch copy)

候補は2つあった:
1. **全 stretch ゲーム × 2 言語 ぶんの専用コピーを書き下ろす** — リッチだが 101 × 2 = 202 エントリの執筆コストが大きく、Stretch の候補プールは `recommendationScoring` で動的に決まるので「どの 101 ゲーム全部に必要か」も明確にしないと網羅できない。
2. **既存の `discover.blurb.<slug>` にフォールバック** — `RecommendationCard`（編集者ピック / TOP3）と同じデータソース。全 101 ゲーム × 2 言語ぶんの blurb はすでに存在する。defaultValue を使えば、後で stretch 用コピーを書き足したら自動的にそちらが優先される。

(2) を採用。

## 修正 (Fix)

```diff
- <p ...>{t(blurbKey)}</p>
+ <p ...>{t(blurbKey, { defaultValue: blurbFallback })}</p>
```

- `blurbFallback = t('blurb.<slug>')` を事前計算
- 後から stretch 専用コピーを追加した場合は defaultValue より優先されるので、改修不要

## リグレッションテスト

`StretchPickCard.test.tsx` に新規テスト追加:
- briscola で描画
- `stretch.briscola` という生キーが DOM に出ないことを assert
- `blurb.briscola` の翻訳テキストが代わりに表示されることを assert

## Test plan

- [x] `bun run test src/components/discover/StretchPickCard.test.tsx` → 2/2 pass
- [x] `bun run test src/components/discover/` + `src/pages/DiscoverResultPage.test.tsx` → 20/20 pass
- [x] `bun run check` → 既存 7 info のみ
- [x] `bunx tsc -b` → exit 0
- [ ] Render dev で複数の axes 組み合わせで stretch カードに正しい説明文が出る

Closes #1897
