### PR TITLE
fix(discover): 選択肢の素早い2連打で次の質問がスキップされる問題を per-step lock で防止

### DIFF
--- a/frontend/src/pages/DiscoverPage.test.tsx
+++ b/frontend/src/pages/DiscoverPage.test.tsx
@@ -115,6 +115,22 @@ describe('DiscoverPage', () => {
     expect(screen.getByLabelText(/Question 2 of 8/i)).toBeInTheDocument();
   });
 
+  it('ignores rapid double-fire of the same option (#1898)', async () => {
+    // Regression: ISSUE-003 — two rapid clicks on an option used to fire
+    // handleSelect twice with the same captured `current`, calling
+    // dispatch({type:'advance'}) twice and skipping the next question. The
+    // user would land on Q3 instead of Q2, with the in-between sub-dim
+    // silently left null. Verified by /qa on 2026-05-20.
+    setup();
+    await act(async () => {
+      // Both fires happen inside one batch — both see the Q1 closure.
+      fireEvent.keyDown(window, { key: '1' });
+      fireEvent.keyDown(window, { key: '1' });
+    });
+    // After a single answer, we expect Q2 — not Q3.
+    expect(screen.getByLabelText(/Question 2 of 8/i)).toBeInTheDocument();
+  });
+
   it('Backspace returns to the previous question', () => {
     setup();
     act(() => {

--- a/frontend/src/pages/DiscoverPage.tsx
+++ b/frontend/src/pages/DiscoverPage.tsx
@@ -74,20 +74,35 @@ export function DiscoverPage() {
 
   const current = stepToAxisQuestion(state.step);
 
+  // Drop a second answer fired before the next question's render — without
+  // this guard, two clicks within the same React batch share the *same*
+  // captured `current` and `dispatch({type:'advance'})` runs twice, silently
+  // skipping the next sub-dimension. The lock releases whenever `state.step`
+  // actually moves, so legitimate keyboard runs (one key per question)
+  // are unaffected. See #1898.
+  const lockedStepRef = useRef<number | null>(null);
+  if (lockedStepRef.current !== null && lockedStepRef.current !== state.step) {
+    lockedStepRef.current = null;
+  }
+
   const handleSelect = useCallback(
     (optIdx: number) => {
       if (!current) return;
+      if (lockedStepRef.current === state.step) return;
+      lockedStepRef.current = state.step;
       setAnswer(current.axis, current.qIdx, optIdx);
       dispatch({ type: 'advance' });
     },
-    [current, setAnswer],
+    [current, state.step, setAnswer],
   );
 
   const handleSkip = useCallback(() => {
     if (!current) return;
+    if (lockedStepRef.current === state.step) return;
+    lockedStepRef.current = state.step;
     setAnswer(current.axis, current.qIdx, null);
     dispatch({ type: 'advance' });
-  }, [current, setAnswer]);
+  }, [current, state.step, setAnswer]);
 
   const handleBack = useCallback(() => dispatch({ type: 'back' }), []);
 


### PR DESCRIPTION
## Summary

- 同一質問内の選択肢を素早く2連打すると次の質問が静かにスキップされる Medium バグを修正
- `useRef` で per-step lock を持たせて2発目以降を no-op に
- リグレッションテスト追加

## 何が起きていた (Bug)

`/discover` のいずれかの質問で選択肢を素早く2連打すると、ページが Q+2 に飛んで Q+1 を一切表示せずスキップ、対応する sub-dim が `null` のまま記録されていた。トラックパッドの二重発火・タッチ環境・素早い操作で簡単に再現する。

QA で確認: Q3 「Beginner」を2連打 → Q4 を skip → Q5 着地。`localStorage` の `skill:[0,null]`（Q4 が null）。

## 根本原因 (Root Cause)

`handleSelect` は `useCallback` で `[current, setAnswer]` に bind されている。2連発の click は同じバッチ内で発火するので両方とも **同じ captured `current`** を見る:

1. click 1: `setAnswer(skill, 0, 0)` → `dispatch({type:'advance'})` (step 2→3)
2. click 2: 同じ closure → `setAnswer(skill, 0, 0)` (idempotent) → `dispatch({type:'advance'})` (step 3→4)

結果として Q4 がスキップ。`setAnswer` の idempotency に乗っかって、`skill[1]` は null のまま残る。

## 修正 (Fix)

`useRef<number | null>` で「最後に lock を取った step」を持つ。同じ step で 2 回目以降の発火が来たら no-op。step が実際に進んだら ref をクリアして次の回答を受け付ける:

```ts
const lockedStepRef = useRef<number | null>(null);
if (lockedStepRef.current !== null && lockedStepRef.current !== state.step) {
  lockedStepRef.current = null;
}

const handleSelect = useCallback((optIdx: number) => {
  if (!current) return;
  if (lockedStepRef.current === state.step) return;
  lockedStepRef.current = state.step;
  setAnswer(current.axis, current.qIdx, optIdx);
  dispatch({ type: 'advance' });
}, [current, state.step, setAnswer]);
```

同じガードを `handleSkip` にも適用。キーボード（`'1'..'4'`）も `handleSelect` を呼ぶので同じガードを通る。

## なぜ lockout タイマーではなく per-step lock か

- 「N ms 以内の連打を抑止」より「同じ質問の答えは 1 回まで」のほうがバグの本質に対するガード
- タイマーだとレイテンシーの長い環境（モバイル・低速 CPU）で誤抑止する余地がある
- step が変わったら lock 解除なので、legit な高速連続回答（Q1 → Q2 → ...）は速度制限なし

## リグレッションテスト

`DiscoverPage.test.tsx` に新規テスト追加:
- `fireEvent.keyDown(window, { key: '1' })` を同期で 2 連発
- DOM が `Question 2 of 8` を表示すること（= Q3 に飛んでいない）

pre-fix では `Question 3 of 8` 以降に飛んでいた。

## Test plan

- [x] `bun run test src/pages/DiscoverPage.test.tsx` → 7/7 pass (新規1件含む)
- [x] `bun run check` → 既存 7 info のみ
- [x] `bunx tsc -b` → exit 0
- [ ] Render dev で実機: 選択肢の2連打が静かにスキップしない
- [ ] キーボード `'1'` 2連打も無視される

Closes #1898
