### PR TITLE
fix(discover): ブラウザ戻るが質問を 1 問ずつ巻き戻すように popstate ハンドラを追加

### DIFF
--- a/frontend/src/pages/DiscoverPage.test.tsx
+++ b/frontend/src/pages/DiscoverPage.test.tsx
@@ -137,11 +137,31 @@ describe('DiscoverPage', () => {
     // page. With the popstate listener and per-advance pushState, back walks
     // questions inside the survey. Found by /qa on 2026-05-20.
     setup();
+    // Two advances cover both the forward-push effect AND the subsequent
+    // backward branch (step > 0 with direction === 'backward' skips the push).
     await act(async () => {
       fireEvent.keyDown(window, { key: '1' });
     });
+    await act(async () => {
+      fireEvent.keyDown(window, { key: '1' });
+    });
+    expect(screen.getByLabelText(/Question 3 of 8/i)).toBeInTheDocument();
+    // popstate walks back to Q2.
+    await act(async () => {
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
     expect(screen.getByLabelText(/Question 2 of 8/i)).toBeInTheDocument();
-    // Simulate the browser firing popstate as if the user pressed Back.
+    // popstate again walks back to Q1.
+    await act(async () => {
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+    expect(screen.getByLabelText(/Question 1 of 8/i)).toBeInTheDocument();
+  });
+
+  it('popstate at the first question is a no-op (no exit, no negative step) (#1899)', async () => {
+    setup();
+    // Mount at Q1 — fire popstate without advancing. Handler must not
+    // dispatch since state.step === 0, and the user stays on Q1.
     await act(async () => {
       window.dispatchEvent(new PopStateEvent('popstate'));
     });

--- a/frontend/src/pages/DiscoverPage.test.tsx
+++ b/frontend/src/pages/DiscoverPage.test.tsx
@@ -131,6 +131,23 @@ describe('DiscoverPage', () => {
     expect(screen.getByLabelText(/Question 2 of 8/i)).toBeInTheDocument();
   });
 
+  it('browser back walks to the previous question instead of exiting Discover (#1899)', async () => {
+    // Regression: ISSUE-004 — the browser back button used to pop /discover
+    // off the history stack entirely, dumping the user back on the previous
+    // page. With the popstate listener and per-advance pushState, back walks
+    // questions inside the survey. Found by /qa on 2026-05-20.
+    setup();
+    await act(async () => {
+      fireEvent.keyDown(window, { key: '1' });
+    });
+    expect(screen.getByLabelText(/Question 2 of 8/i)).toBeInTheDocument();
+    // Simulate the browser firing popstate as if the user pressed Back.
+    await act(async () => {
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+    expect(screen.getByLabelText(/Question 1 of 8/i)).toBeInTheDocument();
+  });
+
   it('Backspace returns to the previous question', () => {
     setup();
     act(() => {

--- a/frontend/src/pages/DiscoverPage.tsx
+++ b/frontend/src/pages/DiscoverPage.tsx
@@ -125,6 +125,29 @@ export function DiscoverPage() {
     resetDraft();
   }, [state.step, axes, navigate, resetDraft]);
 
+  // Browser back integration (#1899). Each forward advance pushes a history
+  // entry so a subsequent browser-back lands within /discover instead of
+  // exiting the survey. The popstate listener catches that back press and
+  // dispatches the in-survey back action, so the native button walks
+  // through questions exactly like the on-page "← previous question" link.
+  // We only push on `forward` transitions — a back-walk would otherwise
+  // re-stack entries we just consumed.
+  useEffect(() => {
+    if (state.step === 0) return;
+    if (state.direction !== 'forward') return;
+    window.history.pushState({ discoverStep: state.step }, '');
+  }, [state.step, state.direction]);
+
+  useEffect(() => {
+    function onPopState() {
+      if (state.step > 0) {
+        dispatch({ type: 'back' });
+      }
+    }
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, [state.step]);
+
   // Keyboard shortcuts: digit keys pick options; Backspace goes back.
   useEffect(() => {
     function onKey(ev: KeyboardEvent) {


### PR DESCRIPTION
## Summary

- ブラウザ戻るが Discover の中間質問ではなく Discover 全体を抜けてしまう Medium バグを修正
- 各 forward advance で `pushState` し、`popstate` で in-survey back を発火
- リグレッションテスト追加

## 何が起きていた (Bug)

`/discover` で Q1, Q2 と進めた状態でブラウザの戻るボタンを押すと、`/discover` ごと履歴から pop されて直前ページ（ホーム）に戻ってしまう。中間の質問に戻るには内部の "← 前の質問へ" ボタンを使うしかなく、マルチステップウィザードでの標準的な期待に反する。

## 修正アプローチ (Why this approach)

候補:
- **A. URL に `?q=N` を付けて React Router に管理させる** — URL がブックマーカブルになるがクエリ↔state の同期コードが増える。
- **B. beforeunload の確認ダイアログ** — SPA 内のナビゲーションでは fire しないので、ブラウザ戻るは捕捉できない。
- **C. popstate を直接 listen して in-survey back を dispatch** — 既存の state machine に直結。URL 表示は変わらないが、機能的に「戻る = 前の質問」が実現する。

(C) を採用 — 既存の `state.step` / `dispatch({type:'back'})` をそのまま流用でき、視覚・キーボード・ブラウザの 3 経路をすべて同じ振る舞いに揃えられる。

## 修正 (Fix)

```ts
// Each forward advance pushes a history entry so a future browser-back lands
// on /discover instead of exiting.
useEffect(() => {
  if (state.step === 0) return;
  if (state.direction !== 'forward') return;
  window.history.pushState({ discoverStep: state.step }, '');
}, [state.step, state.direction]);

// Catch the back press and dispatch the in-survey back action.
useEffect(() => {
  function onPopState() {
    if (state.step > 0) {
      dispatch({ type: 'back' });
    }
  }
  window.addEventListener('popstate', onPopState);
  return () => window.removeEventListener('popstate', onPopState);
}, [state.step]);
```

- `direction === 'forward'` のときだけ push。backward では再 push しない（消費したスロットを再スタックしてしまうのを防ぐ）。
- step が 0 のときの popstate は素通し（ホームに戻る == 想定）。

## リグレッションテスト

`DiscoverPage.test.tsx` に新規テスト追加:
- Q1 回答後（Q2 表示中）に `PopStateEvent('popstate')` を window に dispatch
- DOM が `Question 1 of 8` に戻ること

pre-fix では Q2 のまま、もしくは error（DiscoverPage unmount 想定で `getByLabelText` が見つからない）。

## 既知の限界

- ドラフトを resume して mount した場合、現セッションで進めた分しか back できない。前セッションの advance に対応する history は存在しないため。これは通常のブラウザ履歴の挙動（タブ閉じたら履歴が消える）と一致。
- HashRouter 環境だが `pushState` の URL は明示せず（`null`）、`location.href` が維持されるため hash 表示は変わらない。

## Test plan

- [x] `bun run test src/pages/DiscoverPage.test.tsx` → 8/8 pass (新規1件含む)
- [x] `bun run check` → 既存 7 info のみ
- [x] `bunx tsc -b` → exit 0
- [ ] Render dev で実機: Q2 から戻る → Q1 表示。Q1 から戻る → ホームへ。
- [ ] モバイル（スワイプ戻る含む）でも同じ挙動

Closes #1899
