### PR TITLE
fix(layout): GamePageShell に relative を付けて mobile CPU action toast がブランド帯と重なるのを修正

### DIFF
--- a/frontend/src/components/GamePageShell.test.tsx
+++ b/frontend/src/components/GamePageShell.test.tsx
@@ -281,4 +281,18 @@ describe('GamePageShell', () => {
     expect(screen.queryByText('あなたのターン')).not.toBeInTheDocument();
     expect(screen.queryByText('待機中')).not.toBeInTheDocument();
   });
+
+  it('establishes a positioning context so absolute-positioned children stay inside the page (#1900)', () => {
+    // Regression: ISSUE-005 — without `relative` on the outer container,
+    // absolutely-positioned descendants like CpuActionToast escape to the
+    // viewport and overlap the mobile NavBar's brand bar. Found by /qa on
+    // 2026-05-20 (mobile poker, top-left "Trump Cards" overlap).
+    const { container } = render(
+      <GamePageShell {...baseProps}>
+        <div data-testid="anchor" />
+      </GamePageShell>,
+    );
+    const outer = container.firstElementChild as HTMLElement;
+    expect(outer.className).toContain('relative');
+  });
 });

--- a/frontend/src/components/GamePageShell.tsx
+++ b/frontend/src/components/GamePageShell.tsx
@@ -90,7 +90,7 @@ export function GamePageShell({
   // long-form games (Hearts, Spades, Skat, …) don't silently lose state.
   useGameRoundGuard(!gameEndFlag);
   return (
-    <div key={outerKey} className={`flex-1 flex flex-col min-h-0 ${gameThemeBg}`} aria-busy={loading}>
+    <div key={outerKey} className={`relative flex-1 flex flex-col min-h-0 ${gameThemeBg}`} aria-busy={loading}>
       <GamePageHeading title={title} />
       <PhaseIndicator phaseName={phaseName} isHumanTurn={isHumanTurn}>
         {headerExtra}


### PR DESCRIPTION
## Summary

- モバイル poker などで CPU アクションログのトーストが NavBar の "Trump Cards" ブランド帯と重なって読めない Medium バグを修正
- `GamePageShell` の外側 div に `relative` を追加して absolute 配置の子をページ本文領域に閉じ込める
- リグレッションテスト追加

## 何が起きていた (Bug)

`CpuActionToast` は `absolute top-0 left-0 right-0 z-20` で配置されている。`absolute` 要素は **最も近い positioned ancestor** に対して位置決めされるが、`GamePageShell` の外側コンテナにも `<main>` にも `position: relative` が無く、結果として **viewport** に対して `top:0` で浮いてしまい、NavBar (z-30) の真下のはずが NavBar に潜り込んで重なっていた。

QA 報告 ISSUE-005 のスクリーンショット: モバイル poker で `Player 1: Check / Player 3: Raise (20)` が "Trump Cards" の裏に潜り込んでいた。

## 修正 (Fix)

`GamePageShell` 外側 div に `relative` を追加:

```diff
- <div key={outerKey} className={`flex-1 flex flex-col min-h-0 ${gameThemeBg}`} ...>
+ <div key={outerKey} className={`relative flex-1 flex flex-col min-h-0 ${gameThemeBg}`} ...>
```

これで absolute 配置の子要素は `<GamePageShell>` の本文領域内に閉じる。NavBar はその領域の外（flex column の前のスロット）なので重ならない。

CpuActionToast 自身は変更不要 — `top-0` は now page 本文領域のトップ、つまり NavBar の直下を指すようになる。

## 影響範囲

`GamePageShell` を使用するすべてのページ（multi-CPU 系の poker / holdem / hearts / spades 等を含む大半のゲーム）。`position: relative` の追加は absolute 配置のない子要素には影響しないので、副作用なし。

## リグレッションテスト

`GamePageShell.test.tsx` に新規テスト追加:
- shell を render し、outer container の `className` に `relative` が含まれることを assert
- pre-fix では含まれていなかった

## Test plan

- [x] `bun run test src/components/GamePageShell.test.tsx` → 21/21 pass (新規1件含む)
- [x] `bun run check` → 既存 7 info のみ
- [x] `bunx tsc -b` → exit 0
- [ ] Render dev で実機 (375x812): poker で CPU アクションログが NavBar と重ならない
- [ ] デスクトップ poker / holdem 等で副作用が無い
- [ ] 他ゲーム (Hearts, Klondike, BlackJack) で UI に副作用が無い

Closes #1900
