### PR TITLE
feat(routing): 未知ルート用 NotFoundPage を追加し silent redirect を廃止

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { SkeletonBar } from './components/skeleton/SkeletonBar';
 import { gameRoutes } from './constants/gameRoutes';
 import { DiscoverPage } from './pages/DiscoverPage';
 import { DiscoverResultPage } from './pages/DiscoverResultPage';
+import { NotFoundPage } from './pages/NotFoundPage';
 import { resolvePageComponent } from './utils/resolvePageComponent';
 
 // Vite resolves this glob at build time; each match becomes its own chunk
@@ -74,9 +75,9 @@ export default function App() {
                 <Route path="/discover/result" element={<DiscoverResultPage />} />
                 {/* BlackJack lives at "/", but external links may use "/blackjack". */}
                 <Route path="/blackjack" element={<Navigate to="/" replace />} />
-                {/* Unknown hash routes (e.g., "#/notagame") fall back to home
-                    instead of rendering an empty <main>. */}
-                <Route path="*" element={<Navigate to="/" replace />} />
+                {/* Unknown hash routes (e.g., "#/notagame") render the 404
+                    surface instead of silently redirecting home — #1902. */}
+                <Route path="*" element={<NotFoundPage />} />
               </Routes>
             </main>
           </div>

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -538,5 +538,13 @@
     "unknownCommandWithSuggestion": "Unknown command: {{cmd}}. Did you mean: {{suggestion}}",
     "emptyInput": "Please enter a command. Type 'help' for help.",
     "helpCommon": "Common commands: r/reset (reset), help/? (help), clear (clear log)"
+  },
+  "notFound": {
+    "eyebrow": "PAGE NOT FOUND",
+    "title": "We couldn't find that page",
+    "body": "The link may be stale or the URL might be off. Pick a destination below.",
+    "requestedPath": "Requested path",
+    "actionDiscover": "Find a game",
+    "actionHome": "Back to home"
   }
 }

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -538,5 +538,13 @@
     "unknownCommandWithSuggestion": "不明なコマンド: {{cmd}}。もしかして: {{suggestion}}",
     "emptyInput": "コマンドを入力してください。'help' でヘルプを表示",
     "helpCommon": "共通コマンド: r/reset (リセット), help/? (ヘルプ), clear (ログクリア)"
+  },
+  "notFound": {
+    "eyebrow": "PAGE NOT FOUND",
+    "title": "お探しのページは見つかりません",
+    "body": "リンクが古いか、URL に誤りがあるかもしれません。下から行き先を選んでください。",
+    "requestedPath": "要求されたパス",
+    "actionDiscover": "おすすめを探す",
+    "actionHome": "ホームに戻る"
   }
 }

--- a/frontend/src/pages/NotFoundPage.test.tsx
+++ b/frontend/src/pages/NotFoundPage.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { NotFoundPage } from './NotFoundPage';
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="*" element={<NotFoundPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('NotFoundPage (#1902)', () => {
+  it('renders the not-found heading instead of silently redirecting', () => {
+    renderAt('/nonexistent');
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+  });
+
+  it('shows the requested path so the user can spot a typo', () => {
+    renderAt('/games/xyz');
+    expect(screen.getByText(/\/games\/xyz/)).toBeInTheDocument();
+  });
+
+  it('offers a Discover CTA linking to /discover', () => {
+    renderAt('/foo/bar/baz');
+    const link = screen.getAllByRole('link').find((a) => a.getAttribute('href') === '/discover');
+    expect(link).toBeDefined();
+  });
+
+  it('offers a Home CTA linking to /', () => {
+    renderAt('/foo/bar/baz');
+    const link = screen.getAllByRole('link').find((a) => a.getAttribute('href') === '/');
+    expect(link).toBeDefined();
+  });
+});

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from 'react-i18next';
+import { Link, useLocation } from 'react-router-dom';
+import { btnPrimary, btnSecondary, focusRingWhite } from '../styles/buttonStyles';
+
+/**
+ * 404 fallback for unknown hash routes (e.g. `#/notagame`,
+ * `#/games/xyz`). Replaces the previous silent `<Navigate to="/" />`
+ * redirect so users get a clear "this page doesn't exist" surface
+ * with paths back to the Discover survey or the home page.
+ */
+export function NotFoundPage() {
+  const { t } = useTranslation('common');
+  const location = useLocation();
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center px-6 py-12 gap-6 bg-ds-surface text-ds-text-primary">
+      <p className="text-xs uppercase tracking-[0.18em] text-ds-accent">{t('notFound.eyebrow')}</p>
+      <h1 className="font-serif text-[32px] leading-[1.15] tracking-[-0.01em] text-center">{t('notFound.title')}</h1>
+      <p className="text-sm text-ds-text-muted text-center max-w-md">{t('notFound.body')}</p>
+      <p className="text-xs text-ds-text-muted font-mono break-all">
+        {t('notFound.requestedPath')}: {location.pathname}
+      </p>
+      <div className="flex flex-wrap gap-3 justify-center">
+        <Link to="/discover" className={`${btnPrimary} ${focusRingWhite}`}>
+          {t('notFound.actionDiscover')}
+        </Link>
+        <Link to="/" className={`${btnSecondary} ${focusRingWhite}`}>
+          {t('notFound.actionHome')}
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default NotFoundPage;


### PR DESCRIPTION
## Summary

- 未知ルートが silent にホームへ転送される Low バグを修正
- `NotFoundPage` コンポーネントを新規追加して catch-all で表示
- リグレッションテスト追加

## 何が起きていた (Bug)

`App.tsx` の `<Route path="*" element={<Navigate to="/" replace />} />` により、`/#/nonexistent`, `/#/games/xyz`, `/#/foo/bar/baz` などすべての未知ルートが **無言でホームに転送** されていた。ユーザーは何が起きたかわからずホームに着地、ボット/スクレイパには全パス 200 を返す形にもなっていて SEO 的にも不健全。

## 修正 (Fix)

`NotFoundPage` コンポーネントを新設:
- "PAGE NOT FOUND" eyebrow（既存の Discover hero と統一感）
- 404 メッセージとガイダンス
- 要求された path を mono フォントで表示（typo の発見補助）
- "おすすめを探す" / "ホームに戻る" の 2 CTA

`App.tsx` の catch-all を `<NotFoundPage />` に差し替え。BlackJack のレガシー path (`/blackjack` → `/` redirect) は維持。

i18n キー `common.notFound.*` を ja / en 両言語で追加:
- ja: お探しのページは見つかりません / リンクが古いか、URL に誤りが…
- en: We couldn't find that page / The link may be stale or the URL might be off.

## リグレッションテスト

`NotFoundPage.test.tsx` (新規) に 4 件:
- heading が描画される (silent redirect ではない)
- 要求された path（例: `/games/xyz`）が DOM に出る
- "おすすめを探す" CTA が `/discover` にリンク
- "ホームに戻る" CTA が `/` にリンク

## Test plan

- [x] `bun run test src/pages/NotFoundPage.test.tsx` → 4/4 pass
- [x] `bun run check` → 既存 7 info のみ（NotFoundPage に lint エラーなし）
- [x] `bunx tsc -b` → exit 0
- [ ] Render dev 実機 `/#/nonexistent` で 404 ページが出る
- [ ] CTA ボタンから /discover / / へ正常遷移
- [ ] ja / en 切り替えでテキストが切り替わる

Closes #1902
