### PR TITLE
fix(a11y/discover): 初期マウント時の aria-live を「開始しました」に分岐

### DIFF
--- a/frontend/src/components/discover/SurveyProgress.test.tsx
+++ b/frontend/src/components/discover/SurveyProgress.test.tsx
@@ -26,4 +26,21 @@ describe('SurveyProgress', () => {
     const done = cards.filter((c) => c.dataset.state === 'done');
     expect(done).toHaveLength(4);
   });
+
+  it('announces a "started" message on first mount (#1903), not "moved to 1 of 8"', () => {
+    // Regression: ISSUE-008 — `aria.progress` fired on initial mount,
+    // saying "Moved to 1 / 8 に進みました" / "Moved to 1 of 8" — which
+    // is wrong copy because the user didn't *advance*, they arrived.
+    // Found by /qa on 2026-05-20.
+    const { container } = render(<SurveyProgress current={1} />);
+    const live = container.querySelector('[aria-live="polite"]');
+    expect(live).not.toBeNull();
+    expect(live?.textContent ?? '').not.toMatch(/進みました|Moved to/);
+  });
+
+  it('announces a "moved to" message when current > 1', () => {
+    const { container } = render(<SurveyProgress current={3} />);
+    const live = container.querySelector('[aria-live="polite"]');
+    expect(live?.textContent ?? '').toMatch(/進みました/);
+  });
 });

--- a/frontend/src/components/discover/SurveyProgress.tsx
+++ b/frontend/src/components/discover/SurveyProgress.tsx
@@ -38,7 +38,7 @@ export function SurveyProgress({ current }: SurveyProgressProps) {
         })}
       </ul>
       <p aria-live="polite" aria-atomic="true" className="sr-only">
-        {t('aria.progress', { current, total })}
+        {current === 1 ? t('aria.start', { total }) : t('aria.progress', { current, total })}
       </p>
     </div>
   );

--- a/frontend/src/i18n/locales/en/discover.json
+++ b/frontend/src/i18n/locales/en/discover.json
@@ -24,7 +24,8 @@
   },
   "aria": {
     "question": "Question {{current}} of {{total}}",
-    "progress": "Moved to {{current}} of {{total}}"
+    "progress": "Moved to {{current}} of {{total}}",
+    "start": "Survey started — {{total}} questions"
   },
   "action": {
     "skip": "Skip this question",

--- a/frontend/src/i18n/locales/ja/discover.json
+++ b/frontend/src/i18n/locales/ja/discover.json
@@ -24,7 +24,8 @@
   },
   "aria": {
     "question": "Question {{current}} of {{total}}",
-    "progress": "{{current}} / {{total}} に進みました"
+    "progress": "{{current}} / {{total}} に進みました",
+    "start": "全 {{total}} 問のアンケートを開始しました"
   },
   "action": {
     "skip": "この質問は飛ばす",


### PR DESCRIPTION
## Summary

- Discover の sr-only live region が初期マウント時に「進みました」と読み上げる Low バグを修正
- `aria.start` を新規追加し、Q1 表示時は「開始しました」を流す
- リグレッションテスト追加

## 何が起きていた (Bug)

`SurveyProgress` は毎回 `t('aria.progress', { current, total })` を sr-only の `aria-live="polite"` に流していた。`current=1` の初期マウント時、SR ユーザーは「1 / 8 に進みました」/ "Moved to 1 of 8" を聞かされる。**ユーザーは "進んだ" のではなく "到着した"** ので、コピーが状況にミスマッチ。

## 修正 (Fix)

ja:
```diff
"aria": {
  "question": "Question {{current}} of {{total}}",
  "progress": "{{current}} / {{total}} に進みました",
+ "start": "全 {{total}} 問のアンケートを開始しました"
}
```

en:
```diff
"aria": {
  "question": "Question {{current}} of {{total}}",
  "progress": "Moved to {{current}} of {{total}}",
+ "start": "Survey started — {{total}} questions"
}
```

コンポーネント側:
```diff
- {t('aria.progress', { current, total })}
+ {current === 1 ? t('aria.start', { total }) : t('aria.progress', { current, total })}
```

`current === 1` のときだけ start メッセージ、Q2 以降は従来通り progress。

## リグレッションテスト

`SurveyProgress.test.tsx` に 2 件追加:
- `current=1` の live region に「進みました / Moved to」が **含まれない** ことを assert
- `current=3` の live region に「進みました」が **含まれる** ことを assert

## Test plan

- [x] `bun run test src/components/discover/SurveyProgress.test.tsx` → 5/5 pass (新規2件含む)
- [x] `bun run check` → 既存 7 info のみ
- [x] `bunx tsc -b` → exit 0
- [ ] Render dev 実機 SR で `/discover` ロード直後「アンケートを開始しました」が読まれる
- [ ] Q2 以降では「進みました」が読まれる

Closes #1903
