### PR TITLE
ci(cloudflare): Pages デプロイに ASCII --commit-message を明示指定して 8000111 を回避

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -128,4 +128,14 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           PAGES_PROJECT: ${{ github.ref == 'refs/heads/master' && 'go-trumpcards' || 'go-trumpcards-staging' }}
-        run: bunx wrangler pages deploy public --project-name "$PAGES_PROJECT" --commit-dirty=true
+        # Cloudflare Pages API (code 8000111) intermittently rejects auto-detected
+        # commit messages that contain non-ASCII text even when it is valid UTF-8.
+        # Pass an explicit ASCII commit message + commit hash so the deploy is stable.
+        # GITHUB_SHA is runner-controlled (not user input), so it is safe to interpolate.
+        run: |
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          bunx wrangler pages deploy public \
+            --project-name "$PAGES_PROJECT" \
+            --commit-hash "$GITHUB_SHA" \
+            --commit-message "deploy $SHORT_SHA" \
+            --commit-dirty=true


### PR DESCRIPTION
## Summary

- Cloudflare Pages API が「日本語 (UTF-8 マルチバイト) コミットメッセージ」を断続的に `Invalid commit message, it must be a valid UTF-8 string [code: 8000111]` として拒否し、`Deploy Frontend (Pages)` が失敗していた（直近 #1909 / #1911 / #1912 のデプロイ）。
- Workers 側は影響を受けず、Pages デプロイのみ失敗するため、Run 26170094322 のような部分失敗が継続発生していた。
- `bunx wrangler pages deploy` に `--commit-hash "$GITHUB_SHA"` と `--commit-message "deploy <short-sha>"` を明示渡しすることで、CF が実際のコミットボディを読み込まなくなり、文字種・長さに依存した失敗を回避する。
- `GITHUB_SHA` は GitHub runner が注入する値で外部入力ではないため、shell 補間しても workflow injection の懸念はない（補足コメントを workflow に追記）。

## Failure evidence

| commit | bytes | result |
|---|---|---|
| 7b258556 (popstate) | 1216 | ✅ |
| 4dd65d8d (`` `relative` `` バッククォート) | 834 | ❌ |
| 8251f861 (`{{count}}` 中括弧) | 829 | ✅ |
| cdcbc1e4 (`<Navigate ... />` ボディ) | 1019 | ❌ |
| 73a5c308 (aria-live) | 910 | ❌ |

メッセージ長と相関しない＝CF API 側の不安定なバリデーション。

## Test plan

- [ ] PR の `Deploy to Cloudflare` ワークフローが緑になる（このコミット自体の Pages デプロイ成功で挙動を検証できる）
- [ ] develop マージ後、次回 push の `Deploy Frontend (Pages)` ジョブが pass する
- [ ] CF Pages dashboard の deployment 一覧で commit message が `deploy <sha>` 表記になっていることを確認