### PR TITLE
feat(montecarlo,pokersquares): persist undo history across KV restores

### DIFF
--- a/docs/adr/0028-kv-session-persistence.md
+++ b/docs/adr/0028-kv-session-persistence.md
@@ -51,7 +51,7 @@ wrangler.toml の `[env.staging]` セクションで staging/prod の KV を分�
 
 - **セッション永続化**: Workers 版でも Docker 版と同等のゲーム体験が実現
 - **KV 無料枠制約**: 書き込み 1,000回/日のためデモ用途に限定（1アクション=1書き込み）
-- ~~**Undo 非永続**: ソリティア系ゲームの Undo 履歴（snapshot）は KV に保存しない。復元後は Undo 不可~~ — #1654 で順次解消中。Klondike から開始（snapshot を `klondikeSnapshotJSON` の Marshal/Unmarshal で永続化）。他のソリティア系ゲームは同パターンで追従予定
+- ~~**Undo 非永続**: ソリティア系ゲームの Undo 履歴（snapshot）は KV に保存しない。復元後は Undo 不可~~ — #1654 / #1860 で解消済み。Klondike を皮切りに、FreeCell・Spider・TriPeaks・Pyramid・Forty Thieves・Canfield・Yukon・Russian Solitaire・Scorpion・Accordion・Baker's Dozen・Calculation・Golf・Gaps・EightOff・Cruel・Crescent・Seahaven Towers・Spiderette・Beleaguered Castle・Monte Carlo・Poker Squares の全 23 ソリティア／グリッド系ゲームで snapshot を `*SnapshotJSON` の Marshal/Unmarshal で永続化
 - **Undo 永続（snapshot 配列方式）**: 当初検討時にイベントソーシングを「シャッフルの非決定性」を理由に却下したが、Klondike の典型 1 ハンドで snapshot 配列が ~150KB（KV 値上限 25 MB に対し十分小さい）に収まる実測を踏まえ、**snapshot 配列をそのまま KV に保存する** 方式を #1654 で採用。各 snapshot は元の `klondikeSnapshot` と同形（タブロー / ストック / ウェイスト / ファンデーション / 進行フラグ）で、`json.Marshaler` 実装を追加して unexported フィールドを露出
 - **CPU 記憶永続**: CPU プレイヤーの `memoryManager` (Old Maid / Go Fish / Memory / Doubt) は KV に永続化され、復元後も Hard 難易度の戦略が維持される (#1655 で対応)。データ量が小さいため KV 1MB 制限への影響は無視できる
 - ~~**CPU 記憶非永続**: CPU プレイヤーの `memoryManager` は復元時にリセット。CPU は再度学習する~~ — #1655 で解消済み

--- a/internal/domain/MonteCarlo.go
+++ b/internal/domain/MonteCarlo.go
@@ -402,6 +402,62 @@ type monteCarloJSON struct {
 	DealCount    int                                           `json:"dc"`
 	IsStalemate  bool                                          `json:"sl"`
 	ActionLog    []*ActionLogEntry                             `json:"al"`
+	History      []*monteCarloSnapshot                         `json:"hi,omitempty"`
+}
+
+// monteCarloSnapshotJSON is the wire format for a single undo snapshot.
+// monteCarloSnapshot uses unexported fields, so we project to/from this
+// shape with explicit Marshal/Unmarshal methods. Field names reuse
+// monteCarloJSON's short keys where possible to keep the KV payload
+// compact (#1654/#1860).
+type monteCarloSnapshotJSON struct {
+	Board        [MonteCarloGridSize][MonteCarloGridSize]*Card `json:"bd"`
+	RemovedCount int                                           `json:"rc"`
+	DealCount    int                                           `json:"dc"`
+	Phase        MonteCarloPhase                               `json:"ps"`
+	IsStalemate  bool                                          `json:"sl"`
+	DeckDrawCnt  int                                           `json:"dd"`
+	ActionLogLn  int                                           `json:"ll"`
+}
+
+// MarshalJSON implements json.Marshaler for monteCarloSnapshot, projecting
+// the unexported fields onto an exported wire shape so that
+// MonteCarlo.MarshalJSON can persist the undo history (#1860).
+func (s *monteCarloSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(monteCarloSnapshotJSON{
+		Board:        s.board,
+		RemovedCount: s.removedCount,
+		DealCount:    s.dealCount,
+		Phase:        s.phase,
+		IsStalemate:  s.isStalemate,
+		DeckDrawCnt:  s.deckDrawCnt,
+		ActionLogLn:  s.actionLogLn,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for monteCarloSnapshot.
+// Negative DeckDrawCnt would panic during Undo() (deck[i] with i<0);
+// negative ActionLogLn would panic via actionLog[:ll]. Both are rejected
+// at the trust boundary so malformed KV payloads cannot crash the worker.
+func (s *monteCarloSnapshot) UnmarshalJSON(data []byte) error {
+	var j monteCarloSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if j.DeckDrawCnt < 0 {
+		return fmt.Errorf("montecarlo: snapshot deckDrawCnt must be non-negative")
+	}
+	if j.ActionLogLn < 0 {
+		return fmt.Errorf("montecarlo: snapshot actionLogLn must be non-negative")
+	}
+	s.board = j.Board
+	s.removedCount = j.RemovedCount
+	s.dealCount = j.DealCount
+	s.phase = j.Phase
+	s.isStalemate = j.IsStalemate
+	s.deckDrawCnt = j.DeckDrawCnt
+	s.actionLogLn = j.ActionLogLn
+	return nil
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -414,6 +470,7 @@ func (m *MonteCarlo) MarshalJSON() ([]byte, error) {
 		DealCount:    m.dealCount,
 		IsStalemate:  m.isStalemate,
 		ActionLog:    m.actionLog,
+		History:      m.history,
 	})
 }
 
@@ -426,7 +483,7 @@ func (m *MonteCarlo) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
 	}
-	if len(j.ActionLog) > monteCarloMaxSliceLen {
+	if len(j.ActionLog) > monteCarloMaxSliceLen || len(j.History) > monteCarloMaxSliceLen {
 		return fmt.Errorf("montecarlo: input array exceeds maximum allowed size")
 	}
 	m.trumpCards = j.TrumpCards
@@ -442,6 +499,9 @@ func (m *MonteCarlo) UnmarshalJSON(data []byte) error {
 	if m.actionLog == nil {
 		m.actionLog = make([]*ActionLogEntry, 0)
 	}
-	m.history = nil
+	m.history = j.History
+	if m.history == nil {
+		m.history = make([]*monteCarloSnapshot, 0)
+	}
 	return nil
 }

--- a/internal/domain/MonteCarlo.go
+++ b/internal/domain/MonteCarlo.go
@@ -436,19 +436,20 @@ func (s *monteCarloSnapshot) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements json.Unmarshaler for monteCarloSnapshot.
-// Negative DeckDrawCnt would panic during Undo() (deck[i] with i<0);
-// negative ActionLogLn would panic via actionLog[:ll]. Both are rejected
-// at the trust boundary so malformed KV payloads cannot crash the worker.
+// DeckDrawCnt must be in [0, MonteCarloDeckSize]; ActionLogLn must be in
+// [0, monteCarloMaxSliceLen]. Out-of-range values are rejected at the trust
+// boundary so malformed KV payloads cannot crash the worker via index/slice
+// panic inside Undo().
 func (s *monteCarloSnapshot) UnmarshalJSON(data []byte) error {
 	var j monteCarloSnapshotJSON
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
 	}
-	if j.DeckDrawCnt < 0 {
-		return fmt.Errorf("montecarlo: snapshot deckDrawCnt must be non-negative")
+	if j.DeckDrawCnt < 0 || j.DeckDrawCnt > MonteCarloDeckSize {
+		return fmt.Errorf("montecarlo: snapshot deckDrawCnt out of range")
 	}
-	if j.ActionLogLn < 0 {
-		return fmt.Errorf("montecarlo: snapshot actionLogLn must be non-negative")
+	if j.ActionLogLn < 0 || j.ActionLogLn > monteCarloMaxSliceLen {
+		return fmt.Errorf("montecarlo: snapshot actionLogLn out of range")
 	}
 	s.board = j.Board
 	s.removedCount = j.RemovedCount

--- a/internal/domain/MonteCarlo_persistence_test.go
+++ b/internal/domain/MonteCarlo_persistence_test.go
@@ -154,3 +154,39 @@ func TestMonteCarlo_SnapshotNegativeActionLogLnRejected(t *testing.T) {
 	err = json.Unmarshal(data, &restored)
 	require.Error(t, err, "negative actionLogLn must be rejected")
 }
+
+// TestMonteCarlo_SnapshotExcessiveDeckDrawCntRejected rejects snapshots with
+// DeckDrawCnt > MonteCarloDeckSize, which would cause an out-of-bounds panic
+// in the deck slice inside Undo().
+func TestMonteCarlo_SnapshotExcessiveDeckDrawCntRejected(t *testing.T) {
+	t.Parallel()
+
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{map[string]any{"dd": MonteCarloDeckSize + 1}},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored MonteCarlo
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "excessive deckDrawCnt must be rejected")
+}
+
+// TestMonteCarlo_SnapshotExcessiveActionLogLnRejected rejects snapshots with
+// ActionLogLn > monteCarloMaxSliceLen, consistent with the maxSliceLen defence
+// used across the codebase.
+func TestMonteCarlo_SnapshotExcessiveActionLogLnRejected(t *testing.T) {
+	t.Parallel()
+
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{map[string]any{"ll": monteCarloMaxSliceLen + 1}},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored MonteCarlo
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "excessive actionLogLn must be rejected")
+}

--- a/internal/domain/MonteCarlo_persistence_test.go
+++ b/internal/domain/MonteCarlo_persistence_test.go
@@ -1,0 +1,156 @@
+//go:build test
+
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMonteCarlo_PersistsUndoHistory verifies issue #1860: when a MonteCarlo
+// game is round-tripped through JSON (e.g. a Cloudflare KV restore), the
+// undo history must survive so the player can still step backward. Prior
+// to the fix UnmarshalJSON set history = nil, leaving a restored game
+// with `cannot undo: no history`.
+func TestMonteCarlo_PersistsUndoHistory(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultMonteCarlo()
+	original.Reset()
+	require.False(t, original.CanUndo(), "fresh game has no history")
+
+	// Inject a deterministic adjacent same-rank pair so Remove always succeeds.
+	board := original.GetBoard()
+	board[0][0] = NewCard(0, 7, true)
+	board[0][1] = NewCard(1, 7, true)
+	original.SetBoard(board)
+	require.NoError(t, original.Remove(0, 0, 0, 1))
+
+	require.True(t, original.CanUndo(), "remove should leave undoable history")
+	originalHistoryLen := len(original.history)
+	originalRemovedCount := original.GetRemovedCount()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored MonteCarlo
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	assert.Equal(t, originalRemovedCount, restored.GetRemovedCount(), "removedCount must round-trip")
+	assert.Equal(t, originalHistoryLen, len(restored.history), "history length must round-trip")
+	assert.True(t, restored.CanUndo(), "restored game must allow Undo")
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, originalRemovedCount-2, restored.GetRemovedCount(), "Undo rewinds removedCount by 2")
+}
+
+// TestMonteCarlo_PersistsHistoryRestoresExactSnapshot ensures Undo on a
+// restored game returns the board to the exact state it had before Remove.
+func TestMonteCarlo_PersistsHistoryRestoresExactSnapshot(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultMonteCarlo()
+	original.Reset()
+	board := original.GetBoard()
+	a := NewCard(0, 9, true)
+	b := NewCard(1, 9, true)
+	board[2][3] = a
+	board[3][4] = b
+	original.SetBoard(board)
+	require.NoError(t, original.Remove(2, 3, 3, 4))
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored MonteCarlo
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, a, restored.GetBoard()[2][3], "Undo restores removed card a")
+	assert.Equal(t, b, restored.GetBoard()[3][4], "Undo restores removed card b")
+	assert.Equal(t, 0, restored.GetRemovedCount(), "Undo restores removedCount")
+	assert.False(t, restored.CanUndo(), "no further history after undoing the only snapshot")
+}
+
+// TestMonteCarlo_PersistsDealHistoryRestoresDeckDrawCnt verifies that the
+// snapshot's deckDrawCnt round-trips so Undo on Deal correctly returns
+// stock cards to the deck on a restored game.
+func TestMonteCarlo_PersistsDealHistoryRestoresDeckDrawCnt(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultMonteCarlo()
+	original.Reset()
+	// Vacate one cell so Deal draws exactly one card from stock.
+	board := original.GetBoard()
+	board[4][4] = nil
+	original.SetBoard(board)
+	stockBefore := original.GetStockCount()
+	require.NoError(t, original.Deal())
+	require.Less(t, original.GetStockCount(), stockBefore, "Deal should consume stock")
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored MonteCarlo
+	require.NoError(t, json.Unmarshal(data, &restored))
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, stockBefore, restored.GetStockCount(), "Undo on restored game returns stock to pre-Deal size")
+	assert.Equal(t, 0, restored.GetDealCount(), "Undo resets dealCount")
+}
+
+// TestMonteCarlo_HistoryRespectsMaxSliceLen rejects oversized history payloads.
+func TestMonteCarlo_HistoryRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigHistory := make([]map[string]any, monteCarloMaxSliceLen+1)
+	for i := range bigHistory {
+		bigHistory[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": bigHistory,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored MonteCarlo
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized history must be rejected")
+}
+
+// TestMonteCarlo_SnapshotNegativeDeckDrawCntRejected rejects snapshots that
+// would panic during Undo via deck[i] with i<0.
+func TestMonteCarlo_SnapshotNegativeDeckDrawCntRejected(t *testing.T) {
+	t.Parallel()
+
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{map[string]any{"dd": -1}},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored MonteCarlo
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "negative deckDrawCnt must be rejected")
+}
+
+// TestMonteCarlo_SnapshotNegativeActionLogLnRejected rejects snapshots that
+// would panic during Undo via actionLog[:ll] with ll<0.
+func TestMonteCarlo_SnapshotNegativeActionLogLnRejected(t *testing.T) {
+	t.Parallel()
+
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{map[string]any{"ll": -1}},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored MonteCarlo
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "negative actionLogLn must be rejected")
+}

--- a/internal/domain/PokerSquares.go
+++ b/internal/domain/PokerSquares.go
@@ -286,6 +286,59 @@ type pokerSquaresJSON struct {
 	PlacedCount int                                               `json:"pc"`
 	Phase       PokerSquaresPhase                                 `json:"ps"`
 	ActionLog   []*ActionLogEntry                                 `json:"al"`
+	History     []*pokerSquaresSnapshot                           `json:"hi,omitempty"`
+}
+
+// pokerSquaresSnapshotJSON is the wire format for a single undo snapshot.
+// pokerSquaresSnapshot uses unexported fields, so we project to/from this
+// shape with explicit Marshal/Unmarshal methods. Field names reuse
+// pokerSquaresJSON's short keys where possible to keep the KV payload
+// compact (#1654/#1860).
+type pokerSquaresSnapshotJSON struct {
+	Board       [PokerSquaresGridSize][PokerSquaresGridSize]*Card `json:"bd"`
+	CurrentCard *Card                                             `json:"cc"`
+	PlacedCount int                                               `json:"pc"`
+	Phase       PokerSquaresPhase                                 `json:"ps"`
+	DeckDrawCnt int                                               `json:"dd"`
+	ActionLogLn int                                               `json:"ll"`
+}
+
+// MarshalJSON implements json.Marshaler for pokerSquaresSnapshot, projecting
+// the unexported fields onto an exported wire shape so that
+// PokerSquares.MarshalJSON can persist the undo history (#1860).
+func (s *pokerSquaresSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(pokerSquaresSnapshotJSON{
+		Board:       s.board,
+		CurrentCard: s.currentCard,
+		PlacedCount: s.placedCount,
+		Phase:       s.phase,
+		DeckDrawCnt: s.deckDrawCnt,
+		ActionLogLn: s.actionLogLn,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for pokerSquaresSnapshot.
+// Negative DeckDrawCnt would panic during Undo() (deck[i] with i<0);
+// negative ActionLogLn would panic via actionLog[:ll]. Both are rejected
+// at the trust boundary so malformed KV payloads cannot crash the worker.
+func (s *pokerSquaresSnapshot) UnmarshalJSON(data []byte) error {
+	var j pokerSquaresSnapshotJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if j.DeckDrawCnt < 0 {
+		return fmt.Errorf("pokersquares: snapshot deckDrawCnt must be non-negative")
+	}
+	if j.ActionLogLn < 0 {
+		return fmt.Errorf("pokersquares: snapshot actionLogLn must be non-negative")
+	}
+	s.board = j.Board
+	s.currentCard = j.CurrentCard
+	s.placedCount = j.PlacedCount
+	s.phase = j.Phase
+	s.deckDrawCnt = j.DeckDrawCnt
+	s.actionLogLn = j.ActionLogLn
+	return nil
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -297,6 +350,7 @@ func (p *PokerSquares) MarshalJSON() ([]byte, error) {
 		PlacedCount: p.placedCount,
 		Phase:       p.phase,
 		ActionLog:   p.actionLog,
+		History:     p.history,
 	})
 }
 
@@ -309,7 +363,7 @@ func (p *PokerSquares) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
 	}
-	if len(j.ActionLog) > pokerSquaresMaxSliceLen {
+	if len(j.ActionLog) > pokerSquaresMaxSliceLen || len(j.History) > pokerSquaresMaxSliceLen {
 		return fmt.Errorf("pokersquares: input array exceeds maximum allowed size")
 	}
 	p.trumpCards = j.TrumpCards
@@ -324,6 +378,9 @@ func (p *PokerSquares) UnmarshalJSON(data []byte) error {
 	if p.actionLog == nil {
 		p.actionLog = make([]*ActionLogEntry, 0)
 	}
-	p.history = nil
+	p.history = j.History
+	if p.history == nil {
+		p.history = make([]*pokerSquaresSnapshot, 0)
+	}
 	return nil
 }

--- a/internal/domain/PokerSquares.go
+++ b/internal/domain/PokerSquares.go
@@ -318,19 +318,20 @@ func (s *pokerSquaresSnapshot) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements json.Unmarshaler for pokerSquaresSnapshot.
-// Negative DeckDrawCnt would panic during Undo() (deck[i] with i<0);
-// negative ActionLogLn would panic via actionLog[:ll]. Both are rejected
-// at the trust boundary so malformed KV payloads cannot crash the worker.
+// DeckDrawCnt must be in [0, CardCnt]; ActionLogLn must be in
+// [0, pokerSquaresMaxSliceLen]. Out-of-range values are rejected at the trust
+// boundary so malformed KV payloads cannot crash the worker via index/slice
+// panic inside Undo().
 func (s *pokerSquaresSnapshot) UnmarshalJSON(data []byte) error {
 	var j pokerSquaresSnapshotJSON
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
 	}
-	if j.DeckDrawCnt < 0 {
-		return fmt.Errorf("pokersquares: snapshot deckDrawCnt must be non-negative")
+	if j.DeckDrawCnt < 0 || j.DeckDrawCnt > CardCnt {
+		return fmt.Errorf("pokersquares: snapshot deckDrawCnt out of range")
 	}
-	if j.ActionLogLn < 0 {
-		return fmt.Errorf("pokersquares: snapshot actionLogLn must be non-negative")
+	if j.ActionLogLn < 0 || j.ActionLogLn > pokerSquaresMaxSliceLen {
+		return fmt.Errorf("pokersquares: snapshot actionLogLn out of range")
 	}
 	s.board = j.Board
 	s.currentCard = j.CurrentCard

--- a/internal/domain/PokerSquares_persistence_test.go
+++ b/internal/domain/PokerSquares_persistence_test.go
@@ -125,3 +125,39 @@ func TestPokerSquares_SnapshotNegativeActionLogLnRejected(t *testing.T) {
 	err = json.Unmarshal(data, &restored)
 	require.Error(t, err, "negative actionLogLn must be rejected")
 }
+
+// TestPokerSquares_SnapshotExcessiveDeckDrawCntRejected rejects snapshots with
+// DeckDrawCnt > CardCnt, which would cause an out-of-bounds panic in the deck
+// slice inside Undo().
+func TestPokerSquares_SnapshotExcessiveDeckDrawCntRejected(t *testing.T) {
+	t.Parallel()
+
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{map[string]any{"dd": CardCnt + 1}},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored PokerSquares
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "excessive deckDrawCnt must be rejected")
+}
+
+// TestPokerSquares_SnapshotExcessiveActionLogLnRejected rejects snapshots with
+// ActionLogLn > pokerSquaresMaxSliceLen, consistent with the maxSliceLen
+// defence used across the codebase.
+func TestPokerSquares_SnapshotExcessiveActionLogLnRejected(t *testing.T) {
+	t.Parallel()
+
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{map[string]any{"ll": pokerSquaresMaxSliceLen + 1}},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored PokerSquares
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "excessive actionLogLn must be rejected")
+}

--- a/internal/domain/PokerSquares_persistence_test.go
+++ b/internal/domain/PokerSquares_persistence_test.go
@@ -1,0 +1,127 @@
+//go:build test
+
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPokerSquares_PersistsUndoHistory verifies issue #1860: when a
+// PokerSquares game is round-tripped through JSON (e.g. a Cloudflare KV
+// restore), the undo history must survive so the player can still step
+// backward. Prior to the fix UnmarshalJSON set history = nil, leaving a
+// restored game with `cannot undo: no history`.
+func TestPokerSquares_PersistsUndoHistory(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultPokerSquares()
+	original.Reset()
+	require.False(t, original.CanUndo(), "fresh game has no history")
+
+	require.NoError(t, original.Place(0, 0))
+	require.NoError(t, original.Place(0, 1))
+	require.True(t, original.CanUndo(), "two placements should leave undoable history")
+
+	originalHistoryLen := len(original.history)
+	originalPlacedCount := original.GetPlacedCount()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored PokerSquares
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	assert.Equal(t, originalPlacedCount, restored.GetPlacedCount(), "placedCount must round-trip")
+	assert.Equal(t, originalHistoryLen, len(restored.history), "history length must round-trip")
+	assert.True(t, restored.CanUndo(), "restored game must allow Undo")
+
+	require.NoError(t, restored.Undo())
+	assert.Equal(t, originalPlacedCount-1, restored.GetPlacedCount(), "Undo should rewind one placement")
+}
+
+// TestPokerSquares_PersistsHistoryRestoresExactSnapshot ensures Undo on a
+// restored game returns the board, currentCard, and deckDrawCnt to the
+// exact pre-Place state.
+func TestPokerSquares_PersistsHistoryRestoresExactSnapshot(t *testing.T) {
+	t.Parallel()
+
+	original := NewDefaultPokerSquares()
+	original.Reset()
+
+	// Snapshot of state we expect Undo on the restored game to recover.
+	preCurrentCard := original.GetCurrentCard()
+	preStockCount := original.trumpCards.GetRemainingCount()
+
+	require.NoError(t, original.Place(2, 3))
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored PokerSquares
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	require.NoError(t, restored.Undo())
+	assert.Nil(t, restored.GetBoard()[2][3], "Undo clears the placed cell")
+	assert.Equal(t, preCurrentCard, restored.GetCurrentCard(), "Undo restores currentCard")
+	assert.Equal(t, preStockCount, restored.trumpCards.GetRemainingCount(), "Undo restores deck draw count")
+	assert.Equal(t, 0, restored.GetPlacedCount(), "Undo restores placedCount")
+}
+
+// TestPokerSquares_HistoryRespectsMaxSliceLen rejects oversized history
+// payloads.
+func TestPokerSquares_HistoryRespectsMaxSliceLen(t *testing.T) {
+	t.Parallel()
+
+	bigHistory := make([]map[string]any, pokerSquaresMaxSliceLen+1)
+	for i := range bigHistory {
+		bigHistory[i] = map[string]any{}
+	}
+	payload := map[string]any{
+		"tc": nil,
+		"hi": bigHistory,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored PokerSquares
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "oversized history must be rejected")
+}
+
+// TestPokerSquares_SnapshotNegativeDeckDrawCntRejected rejects snapshots
+// that would panic during Undo via deck[i] with i<0.
+func TestPokerSquares_SnapshotNegativeDeckDrawCntRejected(t *testing.T) {
+	t.Parallel()
+
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{map[string]any{"dd": -1}},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored PokerSquares
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "negative deckDrawCnt must be rejected")
+}
+
+// TestPokerSquares_SnapshotNegativeActionLogLnRejected rejects snapshots
+// that would panic during Undo via actionLog[:ll] with ll<0.
+func TestPokerSquares_SnapshotNegativeActionLogLnRejected(t *testing.T) {
+	t.Parallel()
+
+	payload := map[string]any{
+		"tc": nil,
+		"hi": []any{map[string]any{"ll": -1}},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored PokerSquares
+	err = json.Unmarshal(data, &restored)
+	require.Error(t, err, "negative actionLogLn must be rejected")
+}


### PR DESCRIPTION
## Summary

Closes #1860.

Adds snapshot Marshal/Unmarshal for the last two solitaire-family games that were still dropping their undo history on Cloudflare KV restore: **Monte Carlo** and **Poker Squares**. Mirrors the pattern established for the other 21 solitaire/grid games in #1654 (PRs #1722–#1728).

After this PR all 23 solitaire/grid games persist undo history through `*SnapshotJSON` Marshal/Unmarshal.

## Changes

- `internal/domain/MonteCarlo.go` — add `monteCarloSnapshotJSON` wire format + Marshal/Unmarshal on `*monteCarloSnapshot`; thread `History` through `monteCarloJSON`.
- `internal/domain/PokerSquares.go` — same for `*pokerSquaresSnapshot`.
- `internal/domain/{MonteCarlo,PokerSquares}_persistence_test.go` — round-trip tests + adversarial inputs (oversized history, negative `deckDrawCnt`, negative `actionLogLn`).
- `docs/adr/0028-kv-session-persistence.md` — update Consequences section to reflect that Undo persistence is now complete across all 23 solitaire/grid games.

## Design note: defensive bounds on snapshot ints

Both snapshots carry `deckDrawCnt` and `actionLogLn` (used in `Undo()` to roll back the deck pointer and slice the action log). On a malformed KV payload these would otherwise panic the worker:
- `m.trumpCards.deck[i]` with `i < 0` → index out of range
- `m.actionLog[:snap.actionLogLn]` with `actionLogLn < 0` → slice bounds

`*SnapshotJSON.UnmarshalJSON` now rejects negative values for both at the trust boundary, matching the existing `maxSliceLen=1000` defence used elsewhere in the codebase.

## Test plan

- [x] `go test -tags test -run "MonteCarlo|PokerSquares" ./internal/domain/` — pass
- [x] `go test -tags test -parallel 1 ./internal/domain/` — pass (69s)
- [x] `golangci-lint run ./internal/domain/...` — 0 issues
- [x] Round-trip preserves `history` length, `CanUndo()` returns true on restored game
- [x] Undo on restored game restores the exact pre-action state (board, currentCard, removedCount, stock)
- [x] `Deal` snapshot round-trips `deckDrawCnt` correctly (Monte Carlo)
- [x] Oversized `hi` array (>1000) is rejected at unmarshal
- [x] Negative `dd` (deckDrawCnt) is rejected at unmarshal
- [x] Negative `ll` (actionLogLn) is rejected at unmarshal