### PR TITLE
feat(solitaire): dynamic Y-offset for 10-column tableaux on mobile

### DIFF
--- a/frontend/src/hooks/useCardDimensions.ts
+++ b/frontend/src/hooks/useCardDimensions.ts
@@ -56,6 +56,19 @@ export function useWindowWidth(): number {
   return width;
 }
 
+/** Shared hook that tracks viewport height with resize listener. */
+export function useWindowHeight(): number {
+  const [height, setHeight] = useState(() => window.innerHeight);
+
+  useEffect(() => {
+    const handleResize = () => setHeight(window.innerHeight);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return height;
+}
+
 /**
  * Hook that tracks viewport breakpoint category, only triggering re-renders
  * when the viewport crosses SM_BREAKPOINT (640px) or LG_BREAKPOINT (1024px).

--- a/frontend/src/hooks/useResponsiveTableau.test.ts
+++ b/frontend/src/hooks/useResponsiveTableau.test.ts
@@ -122,6 +122,14 @@ describe('useResponsiveTableau', () => {
       expect(tallestCol).toBeLessThanOrEqual(667 - 300);
     });
 
+    it('does not trigger compression when maxColCards is 1 (single-card column)', () => {
+      setWidth(375);
+      setHeight(667);
+      const natural = renderHook(() => useResponsiveTableau(10)).result.current;
+      const single = renderHook(() => useResponsiveTableau(10, { maxColCards: 1 })).result.current;
+      expect(single.co).toBe(natural.co);
+    });
+
     it('never compresses below the minimum overlap so cards always have a tap strip', () => {
       setWidth(375);
       setHeight(300); // pathologically short viewport

--- a/frontend/src/hooks/useResponsiveTableau.test.ts
+++ b/frontend/src/hooks/useResponsiveTableau.test.ts
@@ -5,11 +5,17 @@ import { useResponsiveTableau } from './useResponsiveTableau';
 
 const setWidth = (w: number) =>
   Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: w });
+const setHeight = (h: number) =>
+  Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: h });
 
 describe('useResponsiveTableau', () => {
   const originalInnerWidth = window.innerWidth;
+  const originalInnerHeight = window.innerHeight;
 
-  afterEach(() => setWidth(originalInnerWidth));
+  afterEach(() => {
+    setWidth(originalInnerWidth);
+    setHeight(originalInnerHeight);
+  });
 
   it('returns desktop preset when viewport is at desktop breakpoint', () => {
     setWidth(800);
@@ -92,5 +98,53 @@ describe('useResponsiveTableau', () => {
     setWidth(800);
     const { result } = renderHook(() => useResponsiveTableau(10));
     expect(result.current.wasteFan).toBe(15);
+  });
+
+  describe('dynamic Y-offset (maxColCards)', () => {
+    it('leaves co at the natural ratio when tallest column fits in the viewport', () => {
+      setWidth(375);
+      setHeight(667);
+      const natural = renderHook(() => useResponsiveTableau(10)).result.current;
+      const fitting = renderHook(() => useResponsiveTableau(10, { maxColCards: 4 })).result.current;
+      // 4 short cards × natural overlap (~18px) + ch (~48px) ≈ 102 px — easily fits.
+      expect(fitting.co).toBe(natural.co);
+    });
+
+    it('compresses co so the tallest column fits the available vertical space', () => {
+      setWidth(375);
+      setHeight(667);
+      // 25 cards stacked at natural overlap (~18 px) would consume 25*18+ch = ~498 px,
+      // overflowing the ~367 px tableau budget (667 - 300 reserved chrome). Hook must shrink co.
+      const { result } = renderHook(() => useResponsiveTableau(10, { maxColCards: 25 }));
+      const ch = result.current.ch;
+      const co = result.current.co;
+      const tallestCol = (25 - 1) * co + ch;
+      expect(tallestCol).toBeLessThanOrEqual(667 - 300);
+    });
+
+    it('never compresses below the minimum overlap so cards always have a tap strip', () => {
+      setWidth(375);
+      setHeight(300); // pathologically short viewport
+      const { result } = renderHook(() => useResponsiveTableau(10, { maxColCards: 30 }));
+      expect(result.current.co).toBeGreaterThanOrEqual(8);
+    });
+
+    it('respects a caller-supplied reservedHeightPx', () => {
+      setWidth(375);
+      setHeight(667);
+      // Looser reservation (200 px) → more room → larger co.
+      const tight = renderHook(() => useResponsiveTableau(10, { maxColCards: 20, reservedHeightPx: 400 })).result
+        .current;
+      const loose = renderHook(() => useResponsiveTableau(10, { maxColCards: 20, reservedHeightPx: 200 })).result
+        .current;
+      expect(loose.co).toBeGreaterThan(tight.co);
+    });
+
+    it('does not affect desktop dimensions', () => {
+      setWidth(1280);
+      setHeight(800);
+      const { result } = renderHook(() => useResponsiveTableau(10, { maxColCards: 30 }));
+      expect(result.current.co).toBe(CARD_DIMENSIONS.largeDesktop.cardOverlap);
+    });
   });
 });

--- a/frontend/src/hooks/useResponsiveTableau.ts
+++ b/frontend/src/hooks/useResponsiveTableau.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useCardDimensions, useWindowWidth } from './useCardDimensions';
+import { useCardDimensions, useWindowHeight, useWindowWidth } from './useCardDimensions';
 
 /** Responsive card dimensions for a multi-column tableau layout. */
 export interface ResponsiveTableauDimensions {
@@ -19,6 +19,18 @@ export interface ResponsiveTableauConfig {
   padX?: number;
   /** Gap between adjacent tableau columns, in px. Defaults to 4 (Tailwind `gap-1`). */
   gapPx?: number;
+  /**
+   * Current length of the longest tableau column. When provided on a mobile viewport, the hook
+   * shrinks the per-card vertical overlap so the tallest column fits without scrolling.
+   * Omit for layouts where columns can never grow tall enough to overflow (#1861).
+   */
+  maxColCards?: number;
+  /**
+   * Vertical pixels reserved for non-tableau chrome (header, stock row, footer, settings, message
+   * box). Subtracted from `window.innerHeight` to derive the tableau's vertical budget. Defaults
+   * to 300 px which matches the standard solo-game shell on a 667 px viewport.
+   */
+  reservedHeightPx?: number;
 }
 
 /** Minimum visual card width in px. Anything smaller is unreadable on a 375 px portrait phone. */
@@ -33,10 +45,21 @@ const MIN_CARD_WIDTH = 24;
  * at the previous 0.48 ratio) on a 32-px-wide card. See issue #1648.
  */
 const MOBILE_VERTICAL_OVERLAP_RATIO = 0.58;
+/**
+ * Hard floor for the per-card vertical step when the dynamic Y-offset compressor (#1861) kicks
+ * in. Below ~8 px the next card's top edge disappears entirely, leaving no peek/tap strip.
+ */
+const MIN_VERTICAL_OVERLAP = 8;
 /** Default fan offset in px used when the waste pile is rendered alongside the tableau. */
 const DESKTOP_WASTE_FAN = 15;
 const DEFAULT_PAD_X = 16;
 const DEFAULT_GAP_PX = 4;
+/**
+ * Pixels of vertical viewport consumed by the standard game-page chrome (PhaseIndicator,
+ * stock/foundation row, hint+message+actionlog, GameFooter). Calibrated against the solo-game
+ * shell at 375×667 — callers can override via `reservedHeightPx` when their layout differs.
+ */
+const DEFAULT_RESERVED_HEIGHT_PX = 300;
 
 /**
  * Hook that returns responsive card dimensions for an N-column tableau.
@@ -47,7 +70,8 @@ const DEFAULT_GAP_PX = 4;
  *
  * The optional `config` lets callers override the assumed scroll-container padding and inter-column
  * gap so the calculation matches the page's actual Tailwind classes — without it the math implicitly
- * assumes `px-2` / `gap-1`.
+ * assumes `px-2` / `gap-1`. When `maxColCards` is supplied, the per-card vertical overlap is also
+ * compressed on mobile so the tallest column fits without vertical scrolling (#1861).
  */
 export function useResponsiveTableau(
   numCols: number,
@@ -55,8 +79,11 @@ export function useResponsiveTableau(
 ): ResponsiveTableauDimensions {
   const { cardHeight, cardOverlap, cardWidth, isMobile } = useCardDimensions();
   const windowWidth = useWindowWidth();
+  const windowHeight = useWindowHeight();
   const padX = config.padX ?? DEFAULT_PAD_X;
   const gapPx = config.gapPx ?? DEFAULT_GAP_PX;
+  const maxColCards = config.maxColCards;
+  const reservedHeightPx = config.reservedHeightPx ?? DEFAULT_RESERVED_HEIGHT_PX;
 
   return useMemo<ResponsiveTableauDimensions>(() => {
     if (!isMobile) {
@@ -66,8 +93,26 @@ export function useResponsiveTableau(
     const colW = Math.floor(availableWidth / numCols);
     const cw = Math.min(Math.max(colW, MIN_CARD_WIDTH), cardWidth);
     const ch = Math.round(cw * 1.5);
-    const co = Math.round(cw * MOBILE_VERTICAL_OVERLAP_RATIO);
+    const naturalCo = Math.round(cw * MOBILE_VERTICAL_OVERLAP_RATIO);
+    let co = naturalCo;
+    if (maxColCards && maxColCards > 1) {
+      const availableHeight = windowHeight - reservedHeightPx;
+      const fittingCo = Math.floor((availableHeight - ch) / (maxColCards - 1));
+      co = Math.max(MIN_VERTICAL_OVERLAP, Math.min(naturalCo, fittingCo));
+    }
     const wasteFan = Math.round(cw * 0.3);
     return { cw, ch, co, wasteFan };
-  }, [isMobile, windowWidth, numCols, padX, gapPx, cardWidth, cardHeight, cardOverlap]);
+  }, [
+    isMobile,
+    windowWidth,
+    windowHeight,
+    numCols,
+    padX,
+    gapPx,
+    maxColCards,
+    reservedHeightPx,
+    cardWidth,
+    cardHeight,
+    cardOverlap,
+  ]);
 }

--- a/frontend/src/hooks/useResponsiveTableau.ts
+++ b/frontend/src/hooks/useResponsiveTableau.ts
@@ -95,7 +95,7 @@ export function useResponsiveTableau(
     const ch = Math.round(cw * 1.5);
     const naturalCo = Math.round(cw * MOBILE_VERTICAL_OVERLAP_RATIO);
     let co = naturalCo;
-    if (maxColCards && maxColCards > 1) {
+    if (maxColCards !== undefined && maxColCards > 1) {
       const availableHeight = windowHeight - reservedHeightPx;
       const fittingCo = Math.floor((availableHeight - ch) / (maxColCards - 1));
       co = Math.max(MIN_VERTICAL_OVERLAP, Math.min(naturalCo, fittingCo));

--- a/frontend/src/pages/FortyThievesPage.tsx
+++ b/frontend/src/pages/FortyThievesPage.tsx
@@ -124,6 +124,8 @@ function FortyThievesPageContent() {
     () => state?.tableau.reduce((m, col) => (col.length > m ? col.length : m), 0) ?? 0,
     [state?.tableau],
   );
+  // Forty Thieves uses `px-2 sm:px-4 lg:px-8` (padX=16 on mobile) and `gap-1 sm:gap-2`
+  // (gapPx=4 on mobile), which matches the hook's defaults — no overrides needed.
   const ft = useResponsiveTableau(10, { maxColCards });
 
   const isPlayingForKbd = state?.phase === FortyThievesPhase.PLAYING;

--- a/frontend/src/pages/FortyThievesPage.tsx
+++ b/frontend/src/pages/FortyThievesPage.tsx
@@ -117,7 +117,14 @@ function FortyThievesPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('fortythieves', state);
-  const ft = useResponsiveTableau(10);
+  // Live longest-column length: shrinks the per-card vertical step on mobile so the tallest
+  // tableau column fits within 375×667 without scrolling (#1861). Forty Thieves columns start
+  // at 4 cards but accumulate quickly as descending same-suit sequences are built.
+  const maxColCards = useMemo(
+    () => state?.tableau.reduce((m, col) => (col.length > m ? col.length : m), 0) ?? 0,
+    [state?.tableau],
+  );
+  const ft = useResponsiveTableau(10, { maxColCards });
 
   const isPlayingForKbd = state?.phase === FortyThievesPhase.PLAYING;
 

--- a/frontend/src/pages/SeahavenTowersPage.tsx
+++ b/frontend/src/pages/SeahavenTowersPage.tsx
@@ -17,11 +17,11 @@ import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
-import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useResponsiveTableau } from '../hooks/useResponsiveTableau';
 import { useSeahavenTowersGame } from '../hooks/useSeahavenTowersGame';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
@@ -103,7 +103,23 @@ function SeahavenTowersPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('seahaventowers', state);
-  const { cardHeight, cardOverlap, cardWidth } = useCardDimensions();
+  // Live longest-column length: shrinks the per-card vertical step on mobile so the tallest
+  // tableau column fits within 375×667 without scrolling (#1861).
+  const maxColCards = useMemo(
+    () => state?.tableau.reduce((m, col) => (col.length > m ? col.length : m), 0) ?? 0,
+    [state?.tableau],
+  );
+  // Container uses `pt-3 px-4 lg:px-8` (padX=32 on mobile) and `gap-0.5` between tableau
+  // columns (gapPx=2). Matches Spider's layout knobs so 10 columns fit a 375 px viewport.
+  const {
+    cw: cardWidth,
+    ch: cardHeight,
+    co: cardOverlap,
+  } = useResponsiveTableau(10, {
+    padX: 32,
+    gapPx: 2,
+    maxColCards,
+  });
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('seahaventowers');
   const cliConfig: CliGameConfig<SeahavenTowersResponse, Parameters<typeof seahaventowersApi.exec>> = useMemo(

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -110,10 +110,17 @@ function SpiderPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('spider', state);
+  // Live longest-column length: shrinks the per-card vertical step on mobile so the tallest
+  // tableau column fits within 375×667 without scrolling (#1861). Spider columns grow long
+  // (initial deal up to 6, +5 stock deals = ~11 minimum, plus accumulated sequences).
+  const maxColCards = useMemo(
+    () => state?.tableau.reduce((m, col) => (col.length > m ? col.length : m), 0) ?? 0,
+    [state?.tableau],
+  );
   // Responsive 10-column dimensions matching this page's `px-4` scroll container and `gap-0.5`
   // tableau so a 375 px viewport doesn't crush each card below 28 px (#1648). Stock uses the
   // same dimensions so cards don't visibly pop when the deal animation moves them to the tableau.
-  const tableau = useResponsiveTableau(10, { padX: 32, gapPx: 2 });
+  const tableau = useResponsiveTableau(10, { padX: 32, gapPx: 2, maxColCards });
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('spider');
   const cliConfig: CliGameConfig<SpiderResponse, Parameters<typeof spiderApi.exec>> = useMemo(


### PR DESCRIPTION
Closes #1861.

## Summary
- Extend `useResponsiveTableau` with `maxColCards` + `reservedHeightPx` config. On mobile, when the longest column's natural overlap would overflow the viewport, the per-card vertical step (`co`) is compressed so the column fits without scrolling. A hard floor of 8 px keeps the next card's top peek visible as a tap strip.
- Migrate `SeahavenTowersPage` off the raw `useCardDimensions` hook so it picks up both the width-fitting (#1648) and the new height-fitting (#1861) behavior, matching Spider's `{ padX: 32, gapPx: 2 }` layout knobs.
- Pass live `maxColCards` (derived from `state.tableau`) into Spider, Forty Thieves, and Seahaven Towers so the overlap recomputes as columns grow during play.
- Add `useWindowHeight` hook in `useCardDimensions.ts` (mirrors the existing `useWindowWidth`).

## Why
The mobile UX principle in `docs/architecture.md` / `DESIGN.md` is "scroll-zero is top priority". On a 375×667 portrait viewport, the natural overlap (`cw * 0.58`) plus card height puts the bottom of a 15-card column off-screen — forcing players to scroll mid-game, which is exactly what the rule forbids. Compressing the overlap dynamically keeps every card visible without sacrificing readable card width.

## Test plan
- [x] `bun run test -- --run useResponsiveTableau SpiderPage SeahavenTowersPage FortyThievesPage useCardDimensions` → 158/158 pass (6 new tests cover the dynamic-Y-offset paths)
- [x] `bun run check` → exit 0 (only pre-existing useTemplate infos in DiscoverPage tests)
- [x] `bun run build` → green
- [ ] Manual: load Spider / Forty Thieves / Seahaven Towers at 375×667, play until at least one column has ~12+ cards, confirm no vertical scrollbar appears.