### PR TITLE
feat(doubt): animate CUI doubt window with bell + countdown (#1862)

### DIFF
--- a/internal/infrastructure/ui/DoubtCui.go
+++ b/internal/infrastructure/ui/DoubtCui.go
@@ -3,9 +3,13 @@ package ui
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
+	"strconv"
 	"strings"
 	"time"
+
+	"golang.org/x/term"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
@@ -98,7 +102,7 @@ func (cui *DoubtCui) Exec() {
 
 // handleDoubtWindow ダウト待機ウィンドウを処理する
 // 人間がカードを出した場合: CPUダウターのみ即時処理
-// CPUがカードを出した場合: 10秒間人間のダウト入力を待ち、CPUダウターと合算して処理
+// CPUがカードを出した場合: 設定秒数だけ人間のダウト入力を待ち、CPUダウターと合算して処理
 func (cui *DoubtCui) handleDoubtWindow() {
 	lastAction := cui.game.GetLastAction()
 	if lastAction == nil {
@@ -123,18 +127,31 @@ func (cui *DoubtCui) handleDoubtWindow() {
 	var allDoubters []int
 
 	if humanCanDoubt {
-		timeout := time.Duration(cui.game.GetConfig().DoubtWindowSec) * time.Second
-		fmt.Println(i18n.Tf("doubt.doubtPrompt", "sec", fmt.Sprintf("%d", cui.game.GetConfig().DoubtWindowSec)))
-		select {
-		case input := <-cui.inputCh:
-			trimmed := strings.TrimSpace(input)
-			fields := strings.Fields(trimmed)
-			if len(fields) > 0 && (fields[0] == "d" || fields[0] == "doubt") {
-				allDoubters = append(allDoubters, humanIdx) // 人間がダウト
+		windowSec := cui.game.GetConfig().DoubtWindowSec
+		ticker := time.NewTicker(time.Second)
+		ticks := make(chan struct{})
+		done := make(chan struct{})
+		go func() {
+			defer close(ticks)
+			for {
+				select {
+				case <-ticker.C:
+					select {
+					case ticks <- struct{}{}:
+					case <-done:
+						return
+					}
+				case <-done:
+					return
+				}
 			}
-		case <-time.After(timeout):
-			fmt.Println(i18n.T("doubt.timeout"))
+		}()
+		tty := term.IsTerminal(int(os.Stdout.Fd()))
+		if runDoubtCountdown(os.Stdout, windowSec, cui.inputCh, ticks, tty) {
+			allDoubters = append(allDoubters, humanIdx) // 人間がダウト
 		}
+		close(done)
+		ticker.Stop()
 	}
 
 	allDoubters = append(allDoubters, cpuDoubters...)
@@ -149,5 +166,65 @@ func (cui *DoubtCui) handleDoubtWindow() {
 	} else {
 		res := cui.dc.Exec("s")
 		fmt.Println(res)
+	}
+}
+
+// runDoubtCountdown renders the human doubt-window prompt and waits for
+// either an input on inputCh or windowSec ticks. Returns true when the
+// caller typed "d"/"doubt" (first whitespace token) before the window
+// expired, false on any other input or on timeout.
+//
+// In TTY mode the helper emits BEL (\a) once on entry so a user looking
+// away from the terminal hears the alert, then rewrites the seconds
+// indicator in place via \r + ANSI erase-to-end on every tick. In
+// non-TTY mode (CI logs, piped output) it falls back to a single
+// prompt line so the transcript stays readable. See issue #1862.
+//
+// The tick channel is injected so tests can drive the countdown
+// deterministically; production code wires it to a 1s time.Ticker.
+func runDoubtCountdown(w io.Writer, windowSec int, inputCh <-chan string, ticks <-chan struct{}, tty bool) bool {
+	promptFor := func(sec int) string {
+		return i18n.Tf("doubt.doubtPrompt", "sec", strconv.Itoa(sec))
+	}
+
+	if tty {
+		// BEL + first prompt without a trailing newline so the next tick can
+		// overwrite the same row.
+		_, _ = fmt.Fprint(w, "\a"+promptFor(windowSec))
+	} else {
+		_, _ = fmt.Fprintln(w, promptFor(windowSec))
+	}
+
+	remaining := windowSec
+	for {
+		select {
+		case input := <-inputCh:
+			if tty {
+				_, _ = fmt.Fprintln(w) // close the in-place line cleanly
+			}
+			fields := strings.Fields(strings.TrimSpace(input))
+			return len(fields) > 0 && (fields[0] == "d" || fields[0] == "doubt")
+		case _, ok := <-ticks:
+			if !ok {
+				if tty {
+					_, _ = fmt.Fprintln(w)
+				}
+				_, _ = fmt.Fprintln(w, i18n.T("doubt.timeout"))
+				return false
+			}
+			remaining--
+			if remaining <= 0 {
+				if tty {
+					_, _ = fmt.Fprintln(w)
+				}
+				_, _ = fmt.Fprintln(w, i18n.T("doubt.timeout"))
+				return false
+			}
+			if tty {
+				// \r repositions to column 0; \x1b[K clears anything left over
+				// from a longer previous render (e.g., 10→9 loses a digit).
+				_, _ = fmt.Fprint(w, "\r"+promptFor(remaining)+"\x1b[K")
+			}
+		}
 	}
 }

--- a/internal/infrastructure/ui/DoubtCui.go
+++ b/internal/infrastructure/ui/DoubtCui.go
@@ -127,10 +127,15 @@ func (cui *DoubtCui) handleDoubtWindow() {
 	var allDoubters []int
 
 	if humanCanDoubt {
+		// Drop any keystrokes the user typed during the preceding CPU turn so
+		// the doubt window only sees input entered after the prompt appears.
+		cui.drainInput()
 		windowSec := cui.game.GetConfig().DoubtWindowSec
 		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
 		ticks := make(chan struct{})
 		done := make(chan struct{})
+		defer close(done)
 		go func() {
 			defer close(ticks)
 			for {
@@ -150,8 +155,6 @@ func (cui *DoubtCui) handleDoubtWindow() {
 		if runDoubtCountdown(os.Stdout, windowSec, cui.inputCh, ticks, tty) {
 			allDoubters = append(allDoubters, humanIdx) // 人間がダウト
 		}
-		close(done)
-		ticker.Stop()
 	}
 
 	allDoubters = append(allDoubters, cpuDoubters...)
@@ -199,19 +202,13 @@ func runDoubtCountdown(w io.Writer, windowSec int, inputCh <-chan string, ticks 
 	for {
 		select {
 		case input := <-inputCh:
-			if tty {
-				_, _ = fmt.Fprintln(w) // close the in-place line cleanly
-			}
-			fields := strings.Fields(strings.TrimSpace(input))
+			// In TTY mode the terminal's Enter echo already advanced the cursor
+			// to a fresh row, so the helper does not emit its own newline; in
+			// non-TTY mode the prompt was printed with a trailing newline up
+			// front. strings.Fields already trims whitespace on both sides.
+			fields := strings.Fields(input)
 			return len(fields) > 0 && (fields[0] == "d" || fields[0] == "doubt")
-		case _, ok := <-ticks:
-			if !ok {
-				if tty {
-					_, _ = fmt.Fprintln(w)
-				}
-				_, _ = fmt.Fprintln(w, i18n.T("doubt.timeout"))
-				return false
-			}
+		case <-ticks:
 			remaining--
 			if remaining <= 0 {
 				if tty {

--- a/internal/infrastructure/ui/DoubtCui_test.go
+++ b/internal/infrastructure/ui/DoubtCui_test.go
@@ -12,8 +12,10 @@ import (
 
 // TestRunDoubtCountdown_TTYReturnsTrueOnDoubtInput exercises the happy path:
 // the user types "d" while the countdown is running, so the helper must
-// return true without consuming any timer ticks and must close the in-place
-// prompt line with a newline so the next CUI line starts cleanly.
+// return true without consuming any timer ticks. In TTY mode the helper
+// does NOT emit its own closing newline — the terminal's Enter echo
+// already advanced the cursor, so a self-emitted "\n" would leave a
+// blank gap before the next CUI line.
 func TestRunDoubtCountdown_TTYReturnsTrueOnDoubtInput(t *testing.T) {
 	var buf bytes.Buffer
 	in := make(chan string, 1)
@@ -26,7 +28,7 @@ func TestRunDoubtCountdown_TTYReturnsTrueOnDoubtInput(t *testing.T) {
 	out := buf.String()
 	assert.Contains(t, out, "\a", "TTY mode must emit the bell on entry")
 	assert.Contains(t, out, "[10s]", "initial prompt must show the full window")
-	assert.True(t, strings.HasSuffix(out, "\n"), "must terminate the in-place line with a newline so subsequent output is not glued to the prompt")
+	assert.False(t, strings.HasSuffix(out, "\n"), "TTY input path must not emit its own newline; the terminal's Enter echo provides it")
 }
 
 // TestRunDoubtCountdown_TTYRedrawsEachTickAndTimesOut walks the countdown
@@ -100,4 +102,18 @@ func TestRunDoubtCountdown_BlankInputDoesNotDoubt(t *testing.T) {
 	got := runDoubtCountdown(&buf, 5, in, ticks, false)
 
 	assert.False(t, got)
+}
+
+// TestRunDoubtCountdown_WhitespacePaddedInputAccepted pins the contract
+// that strings.Fields handles leading/trailing whitespace on its own,
+// so the dropped explicit TrimSpace cannot regress doubt parsing.
+func TestRunDoubtCountdown_WhitespacePaddedInputAccepted(t *testing.T) {
+	var buf bytes.Buffer
+	in := make(chan string, 1)
+	ticks := make(chan struct{})
+
+	in <- "   d   "
+	got := runDoubtCountdown(&buf, 5, in, ticks, false)
+
+	assert.True(t, got)
 }

--- a/internal/infrastructure/ui/DoubtCui_test.go
+++ b/internal/infrastructure/ui/DoubtCui_test.go
@@ -1,0 +1,103 @@
+//go:build test
+
+package ui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRunDoubtCountdown_TTYReturnsTrueOnDoubtInput exercises the happy path:
+// the user types "d" while the countdown is running, so the helper must
+// return true without consuming any timer ticks and must close the in-place
+// prompt line with a newline so the next CUI line starts cleanly.
+func TestRunDoubtCountdown_TTYReturnsTrueOnDoubtInput(t *testing.T) {
+	var buf bytes.Buffer
+	in := make(chan string, 1)
+	ticks := make(chan struct{})
+
+	in <- "d"
+	got := runDoubtCountdown(&buf, 10, in, ticks, true)
+
+	assert.True(t, got)
+	out := buf.String()
+	assert.Contains(t, out, "\a", "TTY mode must emit the bell on entry")
+	assert.Contains(t, out, "[10s]", "initial prompt must show the full window")
+	assert.True(t, strings.HasSuffix(out, "\n"), "must terminate the in-place line with a newline so subsequent output is not glued to the prompt")
+}
+
+// TestRunDoubtCountdown_TTYRedrawsEachTickAndTimesOut walks the countdown
+// from windowSec=3 down to timeout, verifying that each tick rewrites the
+// seconds in-place via \r and that the final tick prints the timeout banner.
+func TestRunDoubtCountdown_TTYRedrawsEachTickAndTimesOut(t *testing.T) {
+	var buf bytes.Buffer
+	in := make(chan string)
+	ticks := make(chan struct{}, 3)
+
+	// 3 ticks consume the entire window (3 → 2 → 1 → timeout).
+	ticks <- struct{}{}
+	ticks <- struct{}{}
+	ticks <- struct{}{}
+
+	got := runDoubtCountdown(&buf, 3, in, ticks, true)
+
+	assert.False(t, got)
+	out := buf.String()
+	assert.Contains(t, out, "[3s]", "must render the initial countdown value")
+	assert.Contains(t, out, "[2s]", "must redraw after the first tick")
+	assert.Contains(t, out, "[1s]", "must redraw on every tick down to 1")
+	assert.NotContains(t, out, "[0s]", "must not render a zero-second prompt; the final tick is the timeout")
+	assert.Contains(t, out, "\r", "TTY redraws must use carriage return")
+	assert.Contains(t, out, "Timeout: skipping doubt", "timeout banner must appear after the final tick")
+}
+
+// TestRunDoubtCountdown_NonTTYPrintsPromptOnceAndNoBell verifies the
+// fallback path: when stdout is not a terminal (CI logs, piped output)
+// the helper prints the prompt once with a trailing newline, never emits
+// \a or \r, and still drives the input/timeout state machine.
+func TestRunDoubtCountdown_NonTTYPrintsPromptOnceAndNoBell(t *testing.T) {
+	var buf bytes.Buffer
+	in := make(chan string)
+	ticks := make(chan struct{}, 1)
+	ticks <- struct{}{} // 1 tick is the entire window
+
+	got := runDoubtCountdown(&buf, 1, in, ticks, false)
+
+	assert.False(t, got)
+	out := buf.String()
+	assert.NotContains(t, out, "\a", "non-TTY mode must not emit the terminal bell")
+	assert.NotContains(t, out, "\r", "non-TTY mode must not use carriage returns")
+	assert.Equal(t, 1, strings.Count(out, "[1s]"), "non-TTY must print the prompt exactly once")
+	assert.Contains(t, out, "Timeout: skipping doubt")
+}
+
+// TestRunDoubtCountdown_DoubtKeywordAccepted treats "doubt" the same as "d",
+// matching the existing handleDoubtWindow contract (case-sensitive, first
+// whitespace-separated token).
+func TestRunDoubtCountdown_DoubtKeywordAccepted(t *testing.T) {
+	var buf bytes.Buffer
+	in := make(chan string, 1)
+	ticks := make(chan struct{})
+
+	in <- "doubt now"
+	got := runDoubtCountdown(&buf, 5, in, ticks, false)
+
+	assert.True(t, got)
+}
+
+// TestRunDoubtCountdown_BlankInputDoesNotDoubt verifies that an empty
+// Enter press resolves the window as "skip", matching the legacy behavior
+// where only the literal "d"/"doubt" first token raises a doubt.
+func TestRunDoubtCountdown_BlankInputDoesNotDoubt(t *testing.T) {
+	var buf bytes.Buffer
+	in := make(chan string, 1)
+	ticks := make(chan struct{})
+
+	in <- ""
+	got := runDoubtCountdown(&buf, 5, in, ticks, false)
+
+	assert.False(t, got)
+}


### PR DESCRIPTION
## Summary
- `handleDoubtWindow` now drives a 1s `time.Ticker` and delegates rendering to a new `runDoubtCountdown` helper that updates `[Ns]` in place via `\r` + ANSI erase-to-end.
- Emits a one-shot BEL (`\a`) on entry so a player looking away from the terminal hears the alert (TTY only).
- Non-TTY targets (CI logs, piped output) fall back to a single prompt line so transcripts stay readable.
- Helper takes injected `inputCh` + tick channel, making the countdown, timeout, and input-accept paths deterministically testable.

Closes #1862.

## Test plan
- [x] `go test -tags test -race -count=1 ./internal/infrastructure/ui/...` — passes (new countdown tests + existing suite)
- [x] `golangci-lint run ./internal/infrastructure/ui/...` — 0 issues
- [x] `goimports -w` on modified files
- [ ] Manual smoke (reviewer): `go run ./cmd/trumpcards doubt`, wait for a CPU play and confirm the `[10s]` indicator counts down in place and the bell sounds once.