### PR TITLE
feat(speed): tighten auto-flip and show countdown progress (#1867)

### DIFF
--- a/frontend/src/components/AutoFlipCountdown.test.tsx
+++ b/frontend/src/components/AutoFlipCountdown.test.tsx
@@ -2,6 +2,9 @@ import { act, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AutoFlipCountdown } from './AutoFlipCountdown';
 
+/** Format helper used in tests — mirrors what callers do (e.g. via i18n). */
+const fmt = (n: number): string => `in ${n}s`;
+
 describe('AutoFlipCountdown', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -11,7 +14,7 @@ describe('AutoFlipCountdown', () => {
   });
 
   it('shows ceil of the remaining seconds at mount', () => {
-    render(<AutoFlipCountdown durationMs={1500} ariaLabel="aria" remainingLabel="in {{n}}s" />);
+    render(<AutoFlipCountdown durationMs={1500} ariaLabel="aria" formatRemaining={fmt} />);
     const timer = screen.getByRole('timer', { name: 'aria' });
     expect(timer).toBeInTheDocument();
     expect(timer.querySelector('text')?.textContent).toBe('2');
@@ -19,7 +22,7 @@ describe('AutoFlipCountdown', () => {
   });
 
   it('drains to 0 once the duration has elapsed', () => {
-    render(<AutoFlipCountdown durationMs={1500} ariaLabel="aria" remainingLabel="in {{n}}s" />);
+    render(<AutoFlipCountdown durationMs={1500} ariaLabel="aria" formatRemaining={fmt} />);
     act(() => {
       vi.advanceTimersByTime(1600);
     });
@@ -28,8 +31,22 @@ describe('AutoFlipCountdown', () => {
   });
 
   it('exposes aria-label and aria-live for screen-reader announcements', () => {
-    render(<AutoFlipCountdown durationMs={1500} ariaLabel="Countdown" remainingLabel="in {{n}}s" />);
+    render(<AutoFlipCountdown durationMs={1500} ariaLabel="Countdown" formatRemaining={fmt} />);
     const timer = screen.getByRole('timer', { name: 'Countdown' });
     expect(timer).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('re-formats the screen-reader announcement on each tick (not pre-interpolated)', () => {
+    const formatRemaining = vi.fn((n: number) => `${n} sec`);
+    render(<AutoFlipCountdown durationMs={1500} ariaLabel="aria" formatRemaining={formatRemaining} />);
+    // Initial: 2s remaining.
+    expect(screen.getByText('2 sec')).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    // After 1s elapsed: 1s remaining ⇒ the formatter must have been re-invoked
+    // with the new value (the bug Gemini caught was passing an already-interpolated
+    // string, which would freeze the announcement at "2 sec").
+    expect(screen.getByText('1 sec')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/AutoFlipCountdown.test.tsx
+++ b/frontend/src/components/AutoFlipCountdown.test.tsx
@@ -1,0 +1,35 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AutoFlipCountdown } from './AutoFlipCountdown';
+
+describe('AutoFlipCountdown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows ceil of the remaining seconds at mount', () => {
+    render(<AutoFlipCountdown durationMs={1500} ariaLabel="aria" remainingLabel="in {{n}}s" />);
+    const timer = screen.getByRole('timer', { name: 'aria' });
+    expect(timer).toBeInTheDocument();
+    expect(timer.querySelector('text')?.textContent).toBe('2');
+    expect(screen.getByText('in 2s')).toBeInTheDocument();
+  });
+
+  it('drains to 0 once the duration has elapsed', () => {
+    render(<AutoFlipCountdown durationMs={1500} ariaLabel="aria" remainingLabel="in {{n}}s" />);
+    act(() => {
+      vi.advanceTimersByTime(1600);
+    });
+    const timer = screen.getByRole('timer');
+    expect(timer.querySelector('text')?.textContent).toBe('0');
+  });
+
+  it('exposes aria-label and aria-live for screen-reader announcements', () => {
+    render(<AutoFlipCountdown durationMs={1500} ariaLabel="Countdown" remainingLabel="in {{n}}s" />);
+    const timer = screen.getByRole('timer', { name: 'Countdown' });
+    expect(timer).toHaveAttribute('aria-live', 'polite');
+  });
+});

--- a/frontend/src/components/AutoFlipCountdown.tsx
+++ b/frontend/src/components/AutoFlipCountdown.tsx
@@ -10,34 +10,44 @@ export interface AutoFlipCountdownProps {
   /** Accessible label announced to screen readers. */
   ariaLabel: string;
   /**
-   * Localised template used to compose the remaining-seconds string.
-   * Must contain `{{n}}`; replaced with the integer second count.
+   * Formatter that produces the screen-reader announcement for the current
+   * remaining-seconds value. Called once per render — passing a function (not
+   * a pre-interpolated string) is required so the announcement updates on
+   * every tick.
    */
-  remainingLabel: string;
+  formatRemaining: (remainingSeconds: number) => string;
 }
 
 const STROKE_WIDTH_RATIO = 0.12;
-const TICK_INTERVAL_MS = 60;
 
 /**
  * Renders a small circular SVG countdown that drains over `durationMs`.
  * The remaining seconds are also rendered in the centre and announced
  * via `aria-live`. Honours `prefers-reduced-motion` by skipping the
  * animation and showing only the numeric countdown.
+ *
+ * Animation is driven by `requestAnimationFrame` so the indicator
+ * stays smooth and naturally pauses when the tab is backgrounded.
  */
-export function AutoFlipCountdown({ durationMs, size = 56, ariaLabel, remainingLabel }: AutoFlipCountdownProps) {
+export function AutoFlipCountdown({ durationMs, size = 56, ariaLabel, formatRemaining }: AutoFlipCountdownProps) {
   const reduced = useReducedMotion();
   const [elapsed, setElapsed] = useState(0);
 
   useEffect(() => {
     setElapsed(0);
-    const id = window.setInterval(() => {
-      setElapsed((prev) => {
-        const next = prev + TICK_INTERVAL_MS;
-        return next >= durationMs ? durationMs : next;
-      });
-    }, TICK_INTERVAL_MS);
-    return () => window.clearInterval(id);
+    let raf = 0;
+    const start = Date.now();
+    const tick = (): void => {
+      const next = Date.now() - start;
+      if (next >= durationMs) {
+        setElapsed(durationMs);
+        return;
+      }
+      setElapsed(next);
+      raf = window.requestAnimationFrame(tick);
+    };
+    raf = window.requestAnimationFrame(tick);
+    return () => window.cancelAnimationFrame(raf);
   }, [durationMs]);
 
   const radius = size / 2 - (size * STROKE_WIDTH_RATIO) / 2;
@@ -91,7 +101,7 @@ export function AutoFlipCountdown({ durationMs, size = 56, ariaLabel, remainingL
           {remainingSeconds}
         </text>
       </svg>
-      <span className="sr-only">{remainingLabel.replace('{{n}}', String(remainingSeconds))}</span>
+      <span className="sr-only">{formatRemaining(remainingSeconds)}</span>
     </div>
   );
 }

--- a/frontend/src/components/AutoFlipCountdown.tsx
+++ b/frontend/src/components/AutoFlipCountdown.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react';
+import { useReducedMotion } from '../hooks/useReducedMotion';
+
+/** Props for the AutoFlipCountdown component. */
+export interface AutoFlipCountdownProps {
+  /** Total countdown duration in milliseconds. */
+  durationMs: number;
+  /** Diameter of the indicator in pixels. */
+  size?: number;
+  /** Accessible label announced to screen readers. */
+  ariaLabel: string;
+  /**
+   * Localised template used to compose the remaining-seconds string.
+   * Must contain `{{n}}`; replaced with the integer second count.
+   */
+  remainingLabel: string;
+}
+
+const STROKE_WIDTH_RATIO = 0.12;
+const TICK_INTERVAL_MS = 60;
+
+/**
+ * Renders a small circular SVG countdown that drains over `durationMs`.
+ * The remaining seconds are also rendered in the centre and announced
+ * via `aria-live`. Honours `prefers-reduced-motion` by skipping the
+ * animation and showing only the numeric countdown.
+ */
+export function AutoFlipCountdown({ durationMs, size = 56, ariaLabel, remainingLabel }: AutoFlipCountdownProps) {
+  const reduced = useReducedMotion();
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    setElapsed(0);
+    const id = window.setInterval(() => {
+      setElapsed((prev) => {
+        const next = prev + TICK_INTERVAL_MS;
+        return next >= durationMs ? durationMs : next;
+      });
+    }, TICK_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, [durationMs]);
+
+  const radius = size / 2 - (size * STROKE_WIDTH_RATIO) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const progress = Math.min(elapsed / durationMs, 1);
+  const offset = circumference * progress;
+  const remainingSeconds = Math.max(0, Math.ceil((durationMs - elapsed) / 1000));
+
+  return (
+    <div
+      className="flex flex-col items-center justify-center"
+      role="timer"
+      aria-live="polite"
+      aria-label={ariaLabel}
+      data-testid="auto-flip-countdown"
+    >
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} aria-hidden="true">
+        <title>{ariaLabel}</title>
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeOpacity={0.2}
+          strokeWidth={size * STROKE_WIDTH_RATIO}
+        />
+        {!reduced && (
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={size * STROKE_WIDTH_RATIO}
+            strokeDasharray={circumference}
+            strokeDashoffset={offset}
+            transform={`rotate(-90 ${size / 2} ${size / 2})`}
+            strokeLinecap="round"
+          />
+        )}
+        <text
+          x="50%"
+          y="50%"
+          textAnchor="middle"
+          dominantBaseline="central"
+          fontSize={size * 0.4}
+          fontWeight="bold"
+          fill="currentColor"
+        >
+          {remainingSeconds}
+        </text>
+      </svg>
+      <span className="sr-only">{remainingLabel.replace('{{n}}', String(remainingSeconds))}</span>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useSpeedGame.ts
+++ b/frontend/src/hooks/useSpeedGame.ts
@@ -14,7 +14,7 @@ export const DEFAULT_SPEED_CONFIG: SpeedConfig = {
 };
 
 /** Delay in milliseconds before an automatic flip fires while stuck. */
-export const AUTO_FLIP_DELAY_MS = 2500;
+export const AUTO_FLIP_DELAY_MS = 1500;
 
 /** CPU difficulty options for Speed settings. */
 export const CPU_DIFFICULTY_OPTIONS = [

--- a/frontend/src/i18n/locales/en/speed.json
+++ b/frontend/src/i18n/locales/en/speed.json
@@ -15,6 +15,8 @@
   "flipButton": "Flip",
   "stuckMessage": "Stuck! Press flip to turn over new center cards.",
   "autoFlipInline": "Auto-flip",
+  "autoFlipCountdownAria": "Auto-flip countdown",
+  "autoFlipCountdownRemaining": "Auto-flip in {{n}} second(s)",
   "settings": {
     "title": "Settings",
     "cpuDifficulty": "CPU Difficulty",

--- a/frontend/src/i18n/locales/ja/speed.json
+++ b/frontend/src/i18n/locales/ja/speed.json
@@ -15,6 +15,8 @@
   "flipButton": "めくる",
   "stuckMessage": "膠着状態です。めくるボタンを押してください。",
   "autoFlipInline": "自動でめくる",
+  "autoFlipCountdownAria": "自動めくりカウントダウン",
+  "autoFlipCountdownRemaining": "あと {{n}} 秒で自動めくり",
   "settings": {
     "title": "設定",
     "cpuDifficulty": "CPU難易度",

--- a/frontend/src/pages/SpeedPage.test.tsx
+++ b/frontend/src/pages/SpeedPage.test.tsx
@@ -241,6 +241,13 @@ describe('SpeedPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('flip'));
   });
 
+  it('shows the auto-flip countdown when stuck with auto-flip enabled', async () => {
+    mockExec.mockResolvedValue(stuckState);
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(screen.getByTestId('auto-flip-countdown')).toBeInTheDocument());
+    expect(screen.getByRole('timer', { name: '自動めくりカウントダウン' })).toBeInTheDocument();
+  });
+
   it('center piles have pulse animation when stuck', async () => {
     mockExec.mockResolvedValue(stuckState);
     renderWithProviders(<SpeedPage />);

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { speedApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
+import { AutoFlipCountdown } from '../components/AutoFlipCountdown';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
@@ -19,7 +20,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { CPU_DIFFICULTY_OPTIONS, useSpeedGame } from '../hooks/useSpeedGame';
+import { AUTO_FLIP_DELAY_MS, CPU_DIFFICULTY_OPTIONS, useSpeedGame } from '../hooks/useSpeedGame';
 import { useSound } from '../providers/SoundProvider';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import type { SpeedResponse } from '../types/card';
@@ -238,6 +239,16 @@ function SpeedPageContent() {
                 aria-live="polite"
               >
                 <p className="text-ds-warning font-bold text-base sm:text-lg">{t('stuckMessage')}</p>
+                {speedConfig.autoFlip && !loading && (
+                  <div className="text-ds-warning">
+                    <AutoFlipCountdown
+                      key={`stuck-${state.message}-${state.centerPiles.map((c) => c?.value ?? 0).join(',')}`}
+                      durationMs={AUTO_FLIP_DELAY_MS}
+                      ariaLabel={t('autoFlipCountdownAria')}
+                      remainingLabel={t('autoFlipCountdownRemaining', { n: 0 })}
+                    />
+                  </div>
+                )}
                 <button
                   type="button"
                   onClick={handleFlip}

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -245,7 +245,7 @@ function SpeedPageContent() {
                       key={`stuck-${state.message}-${state.centerPiles.map((c) => c?.value ?? 0).join(',')}`}
                       durationMs={AUTO_FLIP_DELAY_MS}
                       ariaLabel={t('autoFlipCountdownAria')}
-                      remainingLabel={t('autoFlipCountdownRemaining', { n: 0 })}
+                      formatRemaining={(n) => t('autoFlipCountdownRemaining', { n })}
                     />
                   </div>
                 )}


### PR DESCRIPTION
## Summary

Drop the silent 2.5s auto-flip wait to 1.5s and surface a circular SVG countdown between the centre piles while we wait. The toggle (\`settings.autoFlip\`, inline checkbox in the stuck panel) still lets players opt back into the manual flow.

Closes #1867.

## Test plan

- [x] \`bun run test -- --run src/components/AutoFlipCountdown src/pages/SpeedPage\`
- [x] \`bunx biome check\` on modified files
- [ ] tsc + full build (CI)
- [ ] Manual: confirm auto-flip fires after ~1.5s and the indicator drains visibly; reduced-motion still shows the number.