### PR TITLE
feat(reflex): wire Space/Enter shortcuts on Slapjack and Egyptian Ratscrew (#1871)

### DIFF
--- a/frontend/src/components/KbdBadge.test.tsx
+++ b/frontend/src/components/KbdBadge.test.tsx
@@ -1,0 +1,12 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { KbdBadge } from './KbdBadge';
+
+describe('KbdBadge', () => {
+  it('renders the label inside a <kbd>', () => {
+    const { container } = render(<KbdBadge label="Space" />);
+    const kbd = container.querySelector('kbd');
+    expect(kbd).not.toBeNull();
+    expect(kbd?.textContent).toBe('Space');
+  });
+});

--- a/frontend/src/components/KbdBadge.tsx
+++ b/frontend/src/components/KbdBadge.tsx
@@ -1,0 +1,17 @@
+/** Props for the {@link KbdBadge} component. */
+export interface KbdBadgeProps {
+  /** Key label rendered inside the badge (e.g. "Space", "Enter", "S"). */
+  label: string;
+}
+
+/**
+ * Renders a small `<kbd>` chip used to advertise keyboard shortcuts on
+ * action buttons. The badge is non-interactive — purely an affordance.
+ */
+export function KbdBadge({ label }: KbdBadgeProps) {
+  return (
+    <kbd className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded border border-white/40 bg-white/15 text-[10px] font-mono leading-none">
+      {label}
+    </kbd>
+  );
+}

--- a/frontend/src/components/KbdBadge.tsx
+++ b/frontend/src/components/KbdBadge.tsx
@@ -9,9 +9,15 @@ export interface KbdBadgeProps {
  * action buttons. The badge is non-interactive — purely an affordance.
  */
 export function KbdBadge({ label }: KbdBadgeProps) {
+  // The kbd is purely a visual affordance — the parent button's accessible
+  // name (e.g. "Slap!") already conveys the action, so we hide the chip's
+  // text from assistive tech to avoid screen readers announcing
+  // "Slap! Space". Wrapping the label in an aria-hidden span (rather than
+  // putting aria-hidden on the <kbd> itself) keeps biome's a11y rule happy
+  // and still excludes the badge text from the accessible-name computation.
   return (
     <kbd className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded border border-white/40 bg-white/15 text-[10px] font-mono leading-none">
-      {label}
+      <span aria-hidden="true">{label}</span>
     </kbd>
   );
 }

--- a/frontend/src/hooks/useReflexShortcuts.test.ts
+++ b/frontend/src/hooks/useReflexShortcuts.test.ts
@@ -48,6 +48,8 @@ describe('useReflexShortcuts', () => {
 
     press('Enter', { ctrlKey: true });
     press(' ', { metaKey: true });
+    press(' ', { shiftKey: true }); // Shift+Space = browser scroll-up; must not slap
+    press('Enter', { shiftKey: true });
     expect(onStep).not.toHaveBeenCalled();
     expect(onSlap).not.toHaveBeenCalled();
   });
@@ -66,6 +68,35 @@ describe('useReflexShortcuts', () => {
 
     expect(onStep).not.toHaveBeenCalled();
     expect(onSlap).not.toHaveBeenCalled();
+  });
+
+  it('skips when the target is a <button> or <select> (avoids hijacking native activation)', () => {
+    const onStep = vi.fn();
+    const onSlap = vi.fn();
+    renderHook(() => useReflexShortcuts({ onStep, onSlap, enabled: true }));
+
+    for (const tag of ['button', 'select'] as const) {
+      const el = document.createElement(tag);
+      document.body.appendChild(el);
+      el.focus();
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      document.body.removeChild(el);
+    }
+
+    expect(onStep).not.toHaveBeenCalled();
+    expect(onSlap).not.toHaveBeenCalled();
+  });
+
+  it('respects per-action gates (stepEnabled / slapEnabled)', () => {
+    const onStep = vi.fn();
+    const onSlap = vi.fn();
+    renderHook(() => useReflexShortcuts({ onStep, onSlap, enabled: true, stepEnabled: false, slapEnabled: true }));
+
+    press('Enter'); // step disabled — should be ignored
+    press(' '); // slap enabled — should fire
+    expect(onStep).not.toHaveBeenCalled();
+    expect(onSlap).toHaveBeenCalledTimes(1);
   });
 
   it('honours the latest handler refs across re-renders', () => {

--- a/frontend/src/hooks/useReflexShortcuts.test.ts
+++ b/frontend/src/hooks/useReflexShortcuts.test.ts
@@ -1,0 +1,89 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useReflexShortcuts } from './useReflexShortcuts';
+
+function press(key: string, options: KeyboardEventInit = {}): boolean {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...options });
+  return window.dispatchEvent(event);
+}
+
+describe('useReflexShortcuts', () => {
+  it('triggers onStep on Enter / S / s', () => {
+    const onStep = vi.fn();
+    const onSlap = vi.fn();
+    renderHook(() => useReflexShortcuts({ onStep, onSlap, enabled: true }));
+
+    press('Enter');
+    press('s');
+    press('S');
+    expect(onStep).toHaveBeenCalledTimes(3);
+    expect(onSlap).not.toHaveBeenCalled();
+  });
+
+  it('triggers onSlap on Space', () => {
+    const onStep = vi.fn();
+    const onSlap = vi.fn();
+    renderHook(() => useReflexShortcuts({ onStep, onSlap, enabled: true }));
+
+    press(' ');
+    expect(onSlap).toHaveBeenCalledTimes(1);
+    expect(onStep).not.toHaveBeenCalled();
+  });
+
+  it('does nothing while disabled', () => {
+    const onStep = vi.fn();
+    const onSlap = vi.fn();
+    renderHook(() => useReflexShortcuts({ onStep, onSlap, enabled: false }));
+
+    press('Enter');
+    press(' ');
+    expect(onStep).not.toHaveBeenCalled();
+    expect(onSlap).not.toHaveBeenCalled();
+  });
+
+  it('ignores keystrokes while a modifier is held (browser shortcuts)', () => {
+    const onStep = vi.fn();
+    const onSlap = vi.fn();
+    renderHook(() => useReflexShortcuts({ onStep, onSlap, enabled: true }));
+
+    press('Enter', { ctrlKey: true });
+    press(' ', { metaKey: true });
+    expect(onStep).not.toHaveBeenCalled();
+    expect(onSlap).not.toHaveBeenCalled();
+  });
+
+  it('skips when the target is an editable element', () => {
+    const onStep = vi.fn();
+    const onSlap = vi.fn();
+    renderHook(() => useReflexShortcuts({ onStep, onSlap, enabled: true }));
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    document.body.removeChild(input);
+
+    expect(onStep).not.toHaveBeenCalled();
+    expect(onSlap).not.toHaveBeenCalled();
+  });
+
+  it('honours the latest handler refs across re-renders', () => {
+    const initialStep = vi.fn();
+    const initialSlap = vi.fn();
+    const { rerender } = renderHook(({ onStep, onSlap }) => useReflexShortcuts({ onStep, onSlap, enabled: true }), {
+      initialProps: { onStep: initialStep, onSlap: initialSlap },
+    });
+
+    const nextStep = vi.fn();
+    const nextSlap = vi.fn();
+    rerender({ onStep: nextStep, onSlap: nextSlap });
+
+    press('Enter');
+    press(' ');
+    expect(initialStep).not.toHaveBeenCalled();
+    expect(initialSlap).not.toHaveBeenCalled();
+    expect(nextStep).toHaveBeenCalledTimes(1);
+    expect(nextSlap).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/useReflexShortcuts.ts
+++ b/frontend/src/hooks/useReflexShortcuts.ts
@@ -6,37 +6,76 @@ export interface UseReflexShortcutsOptions {
   onStep: () => void;
   /** Triggered when a slap key (Space) is pressed. */
   onSlap: () => void;
-  /** When false the listener is detached (e.g. CLI mode, game over). */
+  /**
+   * Master switch — when false the listener is detached entirely (CLI mode,
+   * game over, etc.).
+   */
   enabled: boolean;
+  /**
+   * Per-action gates so the keyboard shortcut mirrors the action button's
+   * `disabled` state. Without these the hook would still fire `onStep` on
+   * the CPU's turn even though the visible step button is greyed out.
+   */
+  stepEnabled?: boolean;
+  /** Whether the slap shortcut is currently legal (e.g. centre pile is non-empty). */
+  slapEnabled?: boolean;
 }
 
 /**
  * Global keyboard shortcuts for the real-time reflex games
  * (Slapjack, Egyptian Ratscrew). Wires Enter / S → step and Space → slap.
  *
- * Skips when the focus is in an editable element, when modifier keys are
- * held, and re-uses a ref so the listener does not re-bind on every parent
- * re-render (which happens roughly once per CPU tick).
+ * Skips when the focus is in an editable element (or a focused
+ * `<button>` / `<select>` — Space/Enter there must drive the native
+ * activation, not the global game shortcut), when modifier keys are
+ * held, and re-uses a ref so the listener does not re-bind on every
+ * parent re-render (which happens roughly once per CPU tick).
+ *
+ * `stepEnabled` / `slapEnabled` default to `true` so existing callers
+ * stay backward-compatible; pass them as the same expression that
+ * disables the matching action button to keep keyboard and pointer UX
+ * in lock-step.
  */
-export function useReflexShortcuts({ onStep, onSlap, enabled }: UseReflexShortcutsOptions): void {
-  const handlersRef = useRef({ onStep, onSlap });
-  handlersRef.current = { onStep, onSlap };
+export function useReflexShortcuts({
+  onStep,
+  onSlap,
+  enabled,
+  stepEnabled = true,
+  slapEnabled = true,
+}: UseReflexShortcutsOptions): void {
+  const handlersRef = useRef({ onStep, onSlap, stepEnabled, slapEnabled });
+  handlersRef.current = { onStep, onSlap, stepEnabled, slapEnabled };
 
   useEffect(() => {
     if (!enabled) return;
     const handler = (event: KeyboardEvent): void => {
-      if (event.ctrlKey || event.altKey || event.metaKey) return;
+      // Modifiers reserve the keystroke for the browser / OS:
+      //   - Shift+Space is "page-up", Shift+Enter is form submit-into-newline.
+      //   - Ctrl/Alt/Meta combinations are user OS shortcuts.
+      if (event.ctrlKey || event.altKey || event.metaKey || event.shiftKey) return;
       const target = event.target as HTMLElement | null;
-      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) return;
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.tagName === 'SELECT' ||
+          target.tagName === 'BUTTON' ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
 
+      const cur = handlersRef.current;
       if (event.key === ' ' || event.key === 'Spacebar') {
+        if (!cur.slapEnabled) return;
         event.preventDefault();
-        handlersRef.current.onSlap();
+        cur.onSlap();
         return;
       }
       if (event.key === 'Enter' || event.key === 's' || event.key === 'S') {
+        if (!cur.stepEnabled) return;
         event.preventDefault();
-        handlersRef.current.onStep();
+        cur.onStep();
       }
     };
     window.addEventListener('keydown', handler);

--- a/frontend/src/hooks/useReflexShortcuts.ts
+++ b/frontend/src/hooks/useReflexShortcuts.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+
+/** Options for {@link useReflexShortcuts}. */
+export interface UseReflexShortcutsOptions {
+  /** Triggered when a step/flip key (Enter or S) is pressed. */
+  onStep: () => void;
+  /** Triggered when a slap key (Space) is pressed. */
+  onSlap: () => void;
+  /** When false the listener is detached (e.g. CLI mode, game over). */
+  enabled: boolean;
+}
+
+/**
+ * Global keyboard shortcuts for the real-time reflex games
+ * (Slapjack, Egyptian Ratscrew). Wires Enter / S → step and Space → slap.
+ *
+ * Skips when the focus is in an editable element, when modifier keys are
+ * held, and re-uses a ref so the listener does not re-bind on every parent
+ * re-render (which happens roughly once per CPU tick).
+ */
+export function useReflexShortcuts({ onStep, onSlap, enabled }: UseReflexShortcutsOptions): void {
+  const handlersRef = useRef({ onStep, onSlap });
+  handlersRef.current = { onStep, onSlap };
+
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (event: KeyboardEvent): void => {
+      if (event.ctrlKey || event.altKey || event.metaKey) return;
+      const target = event.target as HTMLElement | null;
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) return;
+
+      if (event.key === ' ' || event.key === 'Spacebar') {
+        event.preventDefault();
+        handlersRef.current.onSlap();
+        return;
+      }
+      if (event.key === 'Enter' || event.key === 's' || event.key === 'S') {
+        event.preventDefault();
+        handlersRef.current.onStep();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [enabled]);
+}

--- a/frontend/src/i18n/locales/en/egyptianratscrew.json
+++ b/frontend/src/i18n/locales/en/egyptianratscrew.json
@@ -2,6 +2,10 @@
   "button": {
     "step": "Flip"
   },
+  "kbd": {
+    "step": "Enter",
+    "slap": "Space"
+  },
   "phase": {
     "play": "Playing",
     "slap": "PAIR/SANDWICH!",

--- a/frontend/src/i18n/locales/en/egyptianratscrew.json
+++ b/frontend/src/i18n/locales/en/egyptianratscrew.json
@@ -3,7 +3,7 @@
     "step": "Flip"
   },
   "kbd": {
-    "step": "Enter",
+    "step": "Enter / S",
     "slap": "Space"
   },
   "phase": {

--- a/frontend/src/i18n/locales/en/slapjack.json
+++ b/frontend/src/i18n/locales/en/slapjack.json
@@ -2,6 +2,10 @@
   "button": {
     "step": "Flip"
   },
+  "kbd": {
+    "step": "Enter",
+    "slap": "Space"
+  },
   "phase": {
     "play": "Playing",
     "slap": "JACK!",

--- a/frontend/src/i18n/locales/en/slapjack.json
+++ b/frontend/src/i18n/locales/en/slapjack.json
@@ -3,7 +3,7 @@
     "step": "Flip"
   },
   "kbd": {
-    "step": "Enter",
+    "step": "Enter / S",
     "slap": "Space"
   },
   "phase": {

--- a/frontend/src/i18n/locales/ja/egyptianratscrew.json
+++ b/frontend/src/i18n/locales/ja/egyptianratscrew.json
@@ -3,7 +3,7 @@
     "step": "めくる"
   },
   "kbd": {
-    "step": "Enter",
+    "step": "Enter / S",
     "slap": "Space"
   },
   "phase": {

--- a/frontend/src/i18n/locales/ja/egyptianratscrew.json
+++ b/frontend/src/i18n/locales/ja/egyptianratscrew.json
@@ -2,6 +2,10 @@
   "button": {
     "step": "めくる"
   },
+  "kbd": {
+    "step": "Enter",
+    "slap": "Space"
+  },
   "phase": {
     "play": "進行中",
     "slap": "ペア/サンドイッチ！",

--- a/frontend/src/i18n/locales/ja/slapjack.json
+++ b/frontend/src/i18n/locales/ja/slapjack.json
@@ -3,7 +3,7 @@
     "step": "めくる"
   },
   "kbd": {
-    "step": "Enter",
+    "step": "Enter / S",
     "slap": "Space"
   },
   "phase": {

--- a/frontend/src/i18n/locales/ja/slapjack.json
+++ b/frontend/src/i18n/locales/ja/slapjack.json
@@ -2,6 +2,10 @@
   "button": {
     "step": "めくる"
   },
+  "kbd": {
+    "step": "Enter",
+    "slap": "Space"
+  },
   "phase": {
     "play": "進行中",
     "slap": "Jだ！",

--- a/frontend/src/pages/EgyptianRatscrewPage.test.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.test.tsx
@@ -177,4 +177,28 @@ describe('EgyptianRatscrewPage', () => {
     fireEvent.change(select, { target: { value: '2' } });
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', { config: { cpuDifficulty: 2 } }));
   });
+
+  it('renders Enter and Space keyboard badges on step/slap buttons', async () => {
+    renderWithProviders(<EgyptianRatscrewPage />);
+    await waitFor(() => expect(screen.getByTestId('step-button')).toBeInTheDocument());
+    expect(screen.getByTestId('step-button').textContent).toContain('Enter');
+    expect(screen.getByTestId('slap-button').textContent).toContain('Space');
+  });
+
+  it('Space keypress triggers slap during play', async () => {
+    mockExec.mockResolvedValueOnce(slappableState);
+    renderWithProviders(<EgyptianRatscrewPage />);
+    await waitFor(() => expect(screen.getByTestId('slap-button')).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(window, { key: ' ' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('slap'));
+  });
+
+  it('Enter keypress triggers step during play', async () => {
+    renderWithProviders(<EgyptianRatscrewPage />);
+    await waitFor(() => expect(screen.getByTestId('step-button')).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(window, { key: 'Enter' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('step'));
+  });
 });

--- a/frontend/src/pages/EgyptianRatscrewPage.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.tsx
@@ -118,7 +118,15 @@ function EgyptianRatscrewPageContent() {
 
   const reflexShortcutsEnabled =
     !!state && !state.gameEndFlag && state.phase !== EgyptianRatscrewPhase.GAME_END && !cliEnabled && !loading;
-  useReflexShortcuts({ onStep: handleStep, onSlap: handleSlap, enabled: reflexShortcutsEnabled });
+  useReflexShortcuts({
+    onStep: handleStep,
+    onSlap: handleSlap,
+    enabled: reflexShortcutsEnabled,
+    // Mirror the step / slap button `disabled` predicates so the keyboard
+    // shortcut never fires when the visible button is greyed out.
+    stepEnabled: !!state?.isHumanTurn,
+    slapEnabled: (state?.centerPileSize ?? 0) > 0,
+  });
 
   if (!state || state.players.length < 2) {
     return (

--- a/frontend/src/pages/EgyptianRatscrewPage.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.tsx
@@ -9,6 +9,7 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
+import { KbdBadge } from '../components/KbdBadge';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { withTutorial } from '../components/tutorial/withTutorial';
@@ -19,6 +20,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
+import { useReflexShortcuts } from '../hooks/useReflexShortcuts';
 import { gameTheme } from '../styles/gameTheme';
 import type { EgyptianRatscrewResponse } from '../types/card';
 import { EgyptianRatscrewEventKind, EgyptianRatscrewPendingKind, EgyptianRatscrewPhase } from '../types/phases';
@@ -113,6 +115,10 @@ function EgyptianRatscrewPageContent() {
     [],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
+
+  const reflexShortcutsEnabled =
+    !!state && !state.gameEndFlag && state.phase !== EgyptianRatscrewPhase.GAME_END && !cliEnabled && !loading;
+  useReflexShortcuts({ onStep: handleStep, onSlap: handleSlap, enabled: reflexShortcutsEnabled });
 
   if (!state || state.players.length < 2) {
     return (
@@ -282,6 +288,7 @@ function EgyptianRatscrewPageContent() {
                 data-tutorial="er-step-button"
               >
                 {t('button.step')}
+                <KbdBadge label={t('kbd.step')} />
               </button>
               <button
                 type="button"
@@ -296,6 +303,7 @@ function EgyptianRatscrewPageContent() {
                 data-tutorial="er-slap-button"
               >
                 {t('egyptianratscrew.slap')}
+                <KbdBadge label={t('kbd.slap')} />
               </button>
               <GameResetButton
                 isGameEnd={isGameEnd}

--- a/frontend/src/pages/SlapjackPage.test.tsx
+++ b/frontend/src/pages/SlapjackPage.test.tsx
@@ -162,4 +162,28 @@ describe('SlapjackPage', () => {
     fireEvent.change(select, { target: { value: '2' } });
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', { config: { cpuDifficulty: 2 } }));
   });
+
+  it('renders Enter and Space keyboard badges on step/slap buttons', async () => {
+    renderWithProviders(<SlapjackPage />);
+    await waitFor(() => expect(screen.getByTestId('step-button')).toBeInTheDocument());
+    expect(screen.getByTestId('step-button').textContent).toContain('Enter');
+    expect(screen.getByTestId('slap-button').textContent).toContain('Space');
+  });
+
+  it('Space keypress triggers slap during play', async () => {
+    mockExec.mockResolvedValueOnce(jackOnTopState);
+    renderWithProviders(<SlapjackPage />);
+    await waitFor(() => expect(screen.getByTestId('slap-button')).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(window, { key: ' ' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('slap'));
+  });
+
+  it('Enter keypress triggers step during play', async () => {
+    renderWithProviders(<SlapjackPage />);
+    await waitFor(() => expect(screen.getByTestId('step-button')).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(window, { key: 'Enter' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('step'));
+  });
 });

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -126,7 +126,15 @@ function SlapjackPageContent() {
 
   const reflexShortcutsEnabled =
     !!state && !state.gameEndFlag && state.phase !== SlapjackPhase.GAME_END && !cliEnabled && !loading;
-  useReflexShortcuts({ onStep: handleStep, onSlap: handleSlap, enabled: reflexShortcutsEnabled });
+  useReflexShortcuts({
+    onStep: handleStep,
+    onSlap: handleSlap,
+    enabled: reflexShortcutsEnabled,
+    // Mirror the step / slap button `disabled` predicates so the keyboard
+    // shortcut never fires when the visible button is greyed out.
+    stepEnabled: !!state?.isHumanTurn,
+    slapEnabled: (state?.centerPileSize ?? 0) > 0,
+  });
 
   if (!state || state.players.length < 2) {
     return (

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -9,6 +9,7 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
+import { KbdBadge } from '../components/KbdBadge';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { withTutorial } from '../components/tutorial/withTutorial';
@@ -19,6 +20,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
+import { useReflexShortcuts } from '../hooks/useReflexShortcuts';
 import { gameTheme } from '../styles/gameTheme';
 import type { SlapjackResponse } from '../types/card';
 import { SlapjackEventKind, SlapjackPhase } from '../types/phases';
@@ -121,6 +123,10 @@ function SlapjackPageContent() {
     [],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
+
+  const reflexShortcutsEnabled =
+    !!state && !state.gameEndFlag && state.phase !== SlapjackPhase.GAME_END && !cliEnabled && !loading;
+  useReflexShortcuts({ onStep: handleStep, onSlap: handleSlap, enabled: reflexShortcutsEnabled });
 
   if (!state || state.players.length < 2) {
     return (
@@ -279,6 +285,7 @@ function SlapjackPageContent() {
                 data-tutorial="sj-step-button"
               >
                 {t('button.step')}
+                <KbdBadge label={t('kbd.step')} />
               </button>
               <button
                 type="button"
@@ -293,6 +300,7 @@ function SlapjackPageContent() {
                 data-tutorial="sj-slap-button"
               >
                 {t('slapjack.slap')}
+                <KbdBadge label={t('kbd.slap')} />
               </button>
               <GameResetButton
                 isGameEnd={isGameEnd}


### PR DESCRIPTION
## Summary

Adds Space (slap) and Enter / S (flip) keyboard shortcuts to the Slapjack and Egyptian Ratscrew Web pages, plus small \`<kbd>\` badges on the action buttons to advertise the shortcut. A shared \`useReflexShortcuts\` hook keeps the wiring tiny and re-usable; it ignores keystrokes targeting editable elements and any key combos with a modifier so it doesn't hijack browser shortcuts.

Closes #1871.

## Test plan

- [x] \`bun run test -- --run src/hooks/useReflexShortcuts src/components/KbdBadge src/pages/SlapjackPage src/pages/EgyptianRatscrewPage\`
- [x] \`bunx biome check\` on modified files
- [ ] tsc + full build (CI)
- [ ] Manual: confirm Space/Enter trigger the same actions as the buttons on both pages.