### PR TITLE
feat(gaps): mark locked prefix cards with a 🔒 badge (#1864)

### DIFF
--- a/frontend/src/i18n/locales/en/gaps.json
+++ b/frontend/src/i18n/locales/en/gaps.json
@@ -12,6 +12,8 @@
   "giveup": "Give Up",
   "hint": "Hint",
   "gap": "Gap",
+  "lockedAria": "locked card (survives redeal)",
+  "lockedTooltip": "Locked (will survive the next redeal)",
   "playing": "Playing",
   "stalemate": "Stalemate",
   "gameClear": "Game Clear! Moves: {{moveCount}}",

--- a/frontend/src/i18n/locales/ja/gaps.json
+++ b/frontend/src/i18n/locales/ja/gaps.json
@@ -12,6 +12,8 @@
   "giveup": "ギブアップ",
   "hint": "ヒント",
   "gap": "空き",
+  "lockedAria": "ロック済み",
+  "lockedTooltip": "ロック済み (次のリディール後も残ります)",
   "playing": "プレイ中",
   "stalemate": "手詰まりです",
   "gameClear": "ゲームクリア！ 手数: {{moveCount}}",

--- a/frontend/src/i18n/locales/ja/gaps.json
+++ b/frontend/src/i18n/locales/ja/gaps.json
@@ -12,7 +12,7 @@
   "giveup": "ギブアップ",
   "hint": "ヒント",
   "gap": "空き",
-  "lockedAria": "ロック済み",
+  "lockedAria": "ロック済み (次のリディール後も残ります)",
   "lockedTooltip": "ロック済み (次のリディール後も残ります)",
   "playing": "プレイ中",
   "stalemate": "手詰まりです",

--- a/frontend/src/pages/GapsPage.test.tsx
+++ b/frontend/src/pages/GapsPage.test.tsx
@@ -142,4 +142,21 @@ describe('GapsPage', () => {
     renderWithProviders(<GapsPage />);
     await waitFor(() => expect(screen.queryByRole('button', { name: 'ギブアップ' })).not.toBeInTheDocument());
   });
+
+  it('renders a lock badge for each card that forms the row prefix starting from 2', async () => {
+    // makeGrid seeds every row with 2..13 of the same suit ⇒ the first 12 cells of each row are locked.
+    renderWithProviders(<GapsPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    expect(screen.getByTestId('gaps-locked-0-0')).toBeInTheDocument();
+    expect(screen.getByTestId('gaps-locked-0-11')).toBeInTheDocument();
+  });
+
+  it('does not lock a row whose leftmost card is not a 2', async () => {
+    const grid = makeGrid();
+    grid[0] = [card('HEART', 5), card('HEART', 6), ...Array.from({ length: 11 }, () => null)];
+    mockedRun.mockResolvedValue({ ...playingState, grid });
+    renderWithProviders(<GapsPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    expect(screen.queryByTestId('gaps-locked-0-0')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/GapsPage.tsx
+++ b/frontend/src/pages/GapsPage.tsx
@@ -172,19 +172,21 @@ function GapsPageContent() {
                     );
                   }
                   const isLocked = cIdx < lockedCount;
+                  // Locked cards survive redeal — make them visually fixed by
+                  // dropping the draggable affordance, so users don't try to
+                  // move them and end up with a no-op drop.
+                  const ringClass = isHintFrom ? 'ring-2 ring-ds-warning' : isLocked ? 'ring-2 ring-ds-success' : '';
                   return (
                     <button
                       type="button"
                       key={`cell-${rIdx.toString()}-${cIdx.toString()}`}
-                      draggable={isPlaying && !loading}
+                      draggable={isPlaying && !loading && !isLocked}
                       onDragStart={dnd.handleDragStart(zone)}
                       onDragEnd={dnd.handleDragEnd}
                       aria-label={isLocked ? `${cardAlt(cell)} ${t('lockedAria')}` : cardAlt(cell)}
                       disabled={!isPlaying || loading}
                       data-testid={isLocked ? `gaps-locked-${rIdx}-${cIdx}` : undefined}
-                      className={`relative p-0 border-0 bg-transparent rounded ${focusRingWhite} ${
-                        isHintFrom ? 'ring-2 ring-ds-warning' : ''
-                      } ${dnd.isDragSource(zone) ? 'opacity-50' : ''} ${isLocked ? 'ring-2 ring-ds-success' : ''}`}
+                      className={`relative p-0 border-0 bg-transparent rounded ${focusRingWhite} ${ringClass} ${dnd.isDragSource(zone) ? 'opacity-50' : ''}`}
                     >
                       <AnimatedCard card={cell} width={cardWidth} />
                       {isLocked && (

--- a/frontend/src/pages/GapsPage.tsx
+++ b/frontend/src/pages/GapsPage.tsx
@@ -22,6 +22,7 @@ import { gameTheme } from '../styles/gameTheme';
 import { GapsPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { gapsLockedPrefixLengths } from '../utils/gapsUtils';
 
 const GAPS_TUTORIAL_STEPS: TutorialStep[] = [
   {
@@ -114,6 +115,7 @@ function GapsPageContent() {
   const isGameClear = state.phase === GapsPhase.GAME_CLEAR;
   const isGameOver = state.phase === GapsPhase.GAME_OVER;
   const isEnded = isGameClear || isGameOver;
+  const lockedPrefixLengths = gapsLockedPrefixLengths(state.grid);
 
   return (
     <GamePageShell
@@ -142,48 +144,64 @@ function GapsPageContent() {
 
       <div className="flex-1 overflow-y-auto pt-3 px-4 lg:px-8">
         <div data-tutorial="gaps-grid" className="flex flex-col items-center gap-1 mb-3">
-          {state.grid.map((row, rIdx) => (
-            <div key={`row-${rIdx.toString()}`} className="flex gap-1">
-              {row.map((cell, cIdx) => {
-                const zone: GapsMoveZone = { zone: 'grid', row: rIdx, col: cIdx };
-                const isHintFrom = state.hint && state.hint.fromRow === rIdx && state.hint.fromCol === cIdx;
-                const isHintTo = state.hint && state.hint.toRow === rIdx && state.hint.toCol === cIdx;
-                if (cell === null) {
+          {state.grid.map((row, rIdx) => {
+            const lockedCount = lockedPrefixLengths[rIdx] ?? 0;
+            return (
+              <div key={`row-${rIdx.toString()}`} className="flex gap-1">
+                {row.map((cell, cIdx) => {
+                  const zone: GapsMoveZone = { zone: 'grid', row: rIdx, col: cIdx };
+                  const isHintFrom = state.hint && state.hint.fromRow === rIdx && state.hint.fromCol === cIdx;
+                  const isHintTo = state.hint && state.hint.toRow === rIdx && state.hint.toCol === cIdx;
+                  if (cell === null) {
+                    return (
+                      <button
+                        type="button"
+                        key={`cell-${rIdx.toString()}-${cIdx.toString()}`}
+                        onDragOver={dnd.handleDragOver(zone)}
+                        onDragLeave={dnd.handleDragLeave}
+                        onDrop={dnd.handleDrop(zone)}
+                        aria-label={t('gap')}
+                        className={`rounded border-2 ${
+                          dnd.isDropTarget(zone)
+                            ? 'border-ds-warning bg-ds-warning/20'
+                            : 'border-dashed border-white/30'
+                        } ${isHintTo ? 'ring-2 ring-ds-warning' : ''} ${focusRingWhite}`}
+                        style={{ width: cardWidth, height: cardHeight }}
+                        disabled={!isPlaying || loading}
+                      />
+                    );
+                  }
+                  const isLocked = cIdx < lockedCount;
                   return (
                     <button
                       type="button"
                       key={`cell-${rIdx.toString()}-${cIdx.toString()}`}
-                      onDragOver={dnd.handleDragOver(zone)}
-                      onDragLeave={dnd.handleDragLeave}
-                      onDrop={dnd.handleDrop(zone)}
-                      aria-label={t('gap')}
-                      className={`rounded border-2 ${
-                        dnd.isDropTarget(zone) ? 'border-ds-warning bg-ds-warning/20' : 'border-dashed border-white/30'
-                      } ${isHintTo ? 'ring-2 ring-ds-warning' : ''} ${focusRingWhite}`}
-                      style={{ width: cardWidth, height: cardHeight }}
+                      draggable={isPlaying && !loading}
+                      onDragStart={dnd.handleDragStart(zone)}
+                      onDragEnd={dnd.handleDragEnd}
+                      aria-label={isLocked ? `${cardAlt(cell)} ${t('lockedAria')}` : cardAlt(cell)}
                       disabled={!isPlaying || loading}
-                    />
+                      data-testid={isLocked ? `gaps-locked-${rIdx}-${cIdx}` : undefined}
+                      className={`relative p-0 border-0 bg-transparent rounded ${focusRingWhite} ${
+                        isHintFrom ? 'ring-2 ring-ds-warning' : ''
+                      } ${dnd.isDragSource(zone) ? 'opacity-50' : ''} ${isLocked ? 'ring-2 ring-ds-success' : ''}`}
+                    >
+                      <AnimatedCard card={cell} width={cardWidth} />
+                      {isLocked && (
+                        <span
+                          aria-hidden="true"
+                          title={t('lockedTooltip')}
+                          className="absolute top-0.5 right-0.5 text-[10px] leading-none bg-ds-success/80 text-ds-text-on-accent rounded-sm px-1 py-0.5 shadow"
+                        >
+                          🔒
+                        </span>
+                      )}
+                    </button>
                   );
-                }
-                return (
-                  <button
-                    type="button"
-                    key={`cell-${rIdx.toString()}-${cIdx.toString()}`}
-                    draggable={isPlaying && !loading}
-                    onDragStart={dnd.handleDragStart(zone)}
-                    onDragEnd={dnd.handleDragEnd}
-                    aria-label={cardAlt(cell)}
-                    disabled={!isPlaying || loading}
-                    className={`p-0 border-0 bg-transparent rounded ${focusRingWhite} ${
-                      isHintFrom ? 'ring-2 ring-ds-warning' : ''
-                    } ${dnd.isDragSource(zone) ? 'opacity-50' : ''}`}
-                  >
-                    <AnimatedCard card={cell} width={cardWidth} />
-                  </button>
-                );
-              })}
-            </div>
-          ))}
+                })}
+              </div>
+            );
+          })}
         </div>
 
         <div data-tutorial="gaps-hint-display">

--- a/frontend/src/utils/gapsUtils.test.ts
+++ b/frontend/src/utils/gapsUtils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign } from '../types/card';
+import { gapsLockedPrefixLengths } from './gapsUtils';
+
+const card = (design: CardDesign, value: number): Card => ({ design, value });
+
+describe('gapsLockedPrefixLengths', () => {
+  it('returns 0 for a row with no leading 2', () => {
+    expect(gapsLockedPrefixLengths([[card('SPADE', 5), card('SPADE', 6)]])).toEqual([0]);
+  });
+
+  it('returns 0 for a row whose first cell is empty', () => {
+    expect(gapsLockedPrefixLengths([[null, card('SPADE', 2)]])).toEqual([0]);
+  });
+
+  it('counts the run while suit + sequential value hold', () => {
+    const row = [card('HEART', 2), card('HEART', 3), card('HEART', 4), card('SPADE', 5), card('HEART', 6)];
+    expect(gapsLockedPrefixLengths([row])).toEqual([3]);
+  });
+
+  it('stops the lock at the first gap', () => {
+    const row = [card('HEART', 2), card('HEART', 3), null, card('HEART', 4)];
+    expect(gapsLockedPrefixLengths([row])).toEqual([2]);
+  });
+
+  it('handles a full 13-card run', () => {
+    const row: (Card | null)[] = [];
+    for (let v = 2; v <= 13; v++) row.push(card('SPADE', v));
+    expect(gapsLockedPrefixLengths([row])).toEqual([row.length]);
+  });
+
+  it('computes a value per row independently', () => {
+    const grid = [[card('SPADE', 2), card('SPADE', 3)], [card('HEART', 5)], [], [card('CLOVER', 2)]];
+    expect(gapsLockedPrefixLengths(grid)).toEqual([2, 0, 0, 1]);
+  });
+});

--- a/frontend/src/utils/gapsUtils.test.ts
+++ b/frontend/src/utils/gapsUtils.test.ts
@@ -18,6 +18,12 @@ describe('gapsLockedPrefixLengths', () => {
     expect(gapsLockedPrefixLengths([row])).toEqual([3]);
   });
 
+  it('stops the lock at the first suit mismatch even if the value sequence is correct', () => {
+    // The 3 is sequential (2 + 1) but the suit changes — must break.
+    const row = [card('SPADE', 2), card('HEART', 3), card('HEART', 4)];
+    expect(gapsLockedPrefixLengths([row])).toEqual([1]);
+  });
+
   it('stops the lock at the first gap', () => {
     const row = [card('HEART', 2), card('HEART', 3), null, card('HEART', 4)];
     expect(gapsLockedPrefixLengths([row])).toEqual([2]);

--- a/frontend/src/utils/gapsUtils.ts
+++ b/frontend/src/utils/gapsUtils.ts
@@ -29,8 +29,9 @@ function lockedPrefixLengthForRow(row: readonly (Card | null)[]): number {
       locked++;
       continue;
     }
-    const prev = row[c - 1];
-    if (prev == null) break;
+    // `row[c-1]` is guaranteed non-null: the previous iteration either set
+    // `cur` and continued (so this cell was non-null) or broke out of the loop.
+    const prev = row[c - 1] as Card;
     if (cur.design !== prev.design || cur.value !== prev.value + 1) break;
     locked++;
   }

--- a/frontend/src/utils/gapsUtils.ts
+++ b/frontend/src/utils/gapsUtils.ts
@@ -1,0 +1,38 @@
+import type { Card } from '../types/card';
+
+/** Anchor rank for the leftmost column of a Gaps row (must be a 2). */
+export const GAPS_ANCHOR_RANK = 2;
+
+/**
+ * Compute the locked-prefix length of each row on a Gaps board.
+ * A card at `grid[r][c]` is locked when it forms an unbroken run starting
+ * with a 2 in column 0 and ascending by one of the same suit thereafter.
+ *
+ * Mirrors `lockedPrefixLengths` in `internal/domain/Gaps.go`. Locked cards
+ * survive a redeal, so the UI uses this to mark them visually.
+ *
+ * Returns an array whose length matches the input — empty/short rows are
+ * handled by returning the count of locked cards (0 when the leftmost card
+ * is missing or not a 2).
+ */
+export function gapsLockedPrefixLengths(grid: readonly (readonly (Card | null)[])[]): number[] {
+  return grid.map((row) => lockedPrefixLengthForRow(row));
+}
+
+function lockedPrefixLengthForRow(row: readonly (Card | null)[]): number {
+  let locked = 0;
+  for (let c = 0; c < row.length; c++) {
+    const cur = row[c];
+    if (cur == null) break;
+    if (c === 0) {
+      if (cur.value !== GAPS_ANCHOR_RANK) break;
+      locked++;
+      continue;
+    }
+    const prev = row[c - 1];
+    if (prev == null) break;
+    if (cur.design !== prev.design || cur.value !== prev.value + 1) break;
+    locked++;
+  }
+  return locked;
+}


### PR DESCRIPTION
## Summary

Highlights every Gaps card that participates in the locked left-prefix run (starts with a 2 in column 0, ascends by 1 in the same suit thereafter) so players can read which cards will survive the next redeal at a glance. The lock detection lives entirely on the frontend in \`gapsUtils.ts\` and mirrors \`lockedPrefixLengths\` in \`internal/domain/Gaps.go\` — pure UI change, no API.

Closes #1864.

## Test plan

- [x] \`bun run test -- --run src/utils/gapsUtils src/pages/GapsPage\`
- [x] \`bunx biome check\` on modified files
- [ ] tsc + full build (CI)
- [ ] Manual: play a few moves and verify the lock badge appears/disappears as the prefix grows / breaks.