### PR TITLE
feat(nertz): shake + red-flash collision feedback on rejected foundation moves (#1866)

### DIFF
--- a/frontend/src/pages/NertzPage.test.tsx
+++ b/frontend/src/pages/NertzPage.test.tsx
@@ -222,4 +222,36 @@ describe('NertzPage', () => {
       }),
     );
   });
+
+  it('flashes the target foundation when a move to it is rejected (collision)', async () => {
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/nertz']}>
+        <NertzPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByText(/♥7/)).toBeInTheDocument());
+    fireEvent.click(screen.getByText('♥7').closest('button') as HTMLElement);
+
+    // Reject the next move (simulates CPU getting there first).
+    mockExec.mockRejectedValueOnce(new Error('collision'));
+    fireEvent.click(screen.getByTestId('nertz-foundation-0'));
+    await waitFor(() => expect(screen.getByTestId('nertz-foundation-0')).toHaveAttribute('data-collided', 'true'));
+    expect(screen.getByTestId('nertz-foundation-0').className).toMatch(/animate-shake/);
+  });
+
+  it('does not blow up the page when a foundation move is rejected (game continues)', async () => {
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/nertz']}>
+        <NertzPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByText(/♥7/)).toBeInTheDocument());
+    fireEvent.click(screen.getByText('♥7').closest('button') as HTMLElement);
+
+    mockExec.mockRejectedValueOnce(new Error('boom'));
+    fireEvent.click(screen.getByTestId('nertz-foundation-1'));
+    await waitFor(() => expect(screen.getByTestId('nertz-foundation-1')).toHaveAttribute('data-collided', 'true'));
+    // Foundation grid is still rendered; the page didn't unmount into ErrorAlert.
+    expect(screen.getAllByTestId(/nertz-foundation-/)).toHaveLength(8);
+  });
 });

--- a/frontend/src/pages/NertzPage.test.tsx
+++ b/frontend/src/pages/NertzPage.test.tsx
@@ -254,4 +254,29 @@ describe('NertzPage', () => {
     // Foundation grid is still rendered; the page didn't unmount into ErrorAlert.
     expect(screen.getAllByTestId(/nertz-foundation-/)).toHaveLength(8);
   });
+
+  it('does not attribute a later unrelated error to a previously-resolved foundation move', async () => {
+    // Bug 1 from the gemini/Claude review: after a foundation move succeeds, the
+    // pending-foundation ref must be cleared so a later unrelated error (e.g. a
+    // failing tick) does not flash that foundation.
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/nertz']}>
+        <NertzPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByText(/♥7/)).toBeInTheDocument());
+    fireEvent.click(screen.getByText('♥7').closest('button') as HTMLElement);
+
+    // Successful foundation move → state updates → pending ref must be cleared.
+    fireEvent.click(screen.getByTestId('nertz-foundation-2'));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('m', expect.objectContaining({})));
+
+    // Now a different action fails — must NOT light up foundation 2.
+    mockExec.mockRejectedValueOnce(new Error('tick boom'));
+    fireEvent.click(screen.getByText('♥7').closest('button') as HTMLElement); // re-select
+    fireEvent.click(screen.getByTestId('nertz-foundation-3')); // dispatch to a different cell
+    // Only foundation 3 (the new target) should be marked, not foundation 2.
+    await waitFor(() => expect(screen.getByTestId('nertz-foundation-3')).toHaveAttribute('data-collided', 'true'));
+    expect(screen.getByTestId('nertz-foundation-2')).not.toHaveAttribute('data-collided');
+  });
 });

--- a/frontend/src/pages/NertzPage.tsx
+++ b/frontend/src/pages/NertzPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { type NertzMoveZone, nertzApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -28,6 +28,9 @@ import type { CliGameConfig } from '../utils/cli/types';
 
 /** CPU tick interval in milliseconds while the round is active. */
 const NERTZ_TICK_INTERVAL_MS = 700;
+
+/** Duration to leave the collision shake/red-ring on a rejected foundation. */
+const NERTZ_COLLISION_FEEDBACK_MS = 500;
 
 /** Tutorial step definitions for the Nertz / Pounce page. */
 const NERTZ_TUTORIAL_STEPS: TutorialStep[] = [
@@ -134,6 +137,30 @@ function NertzPageContent() {
     [isHumanTurn],
   );
 
+  const [collidedFoundationIdx, setCollidedFoundationIdx] = useState<number | null>(null);
+  const [collisionTick, setCollisionTick] = useState(0);
+  // Tracks the target foundation of the most recent player-initiated move so we
+  // can attribute the next error from `useGameApi` to a specific cell.
+  const pendingFoundationRef = useRef<number | null>(null);
+  const prevErrorRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (error && error !== prevErrorRef.current && pendingFoundationRef.current !== null) {
+      setCollidedFoundationIdx(pendingFoundationRef.current);
+      setCollisionTick((n) => n + 1);
+      pendingFoundationRef.current = null;
+    }
+    prevErrorRef.current = error;
+  }, [error]);
+
+  useEffect(() => {
+    // `collisionTick` ensures repeated collisions on the same foundation reset the timer.
+    if (collidedFoundationIdx === null) return;
+    void collisionTick;
+    const id = window.setTimeout(() => setCollidedFoundationIdx(null), NERTZ_COLLISION_FEEDBACK_MS);
+    return () => window.clearTimeout(id);
+  }, [collidedFoundationIdx, collisionTick]);
+
   const dispatchMove = useCallback(
     (to: NertzMoveZone) => {
       if (!selection) return;
@@ -141,6 +168,9 @@ function NertzPageContent() {
         selection.kind === 'tableau'
           ? { zone: 'tableau', col: selection.col, cardIndex: selection.cardIndex }
           : { zone: selection.kind };
+      if (to.zone === 'foundation') {
+        pendingFoundationRef.current = to.idx;
+      }
       void apiCall('m', { playerIdx: 0, from, to });
       setSelection(null);
     },
@@ -204,8 +234,6 @@ function NertzPageContent() {
     return t('phase.playing');
   }, [isGameEnd, isRoundEnd, t]);
 
-  if (error) return <ErrorAlert message={error} onRetry={retry} />;
-
   if (!state || !human) {
     return (
       <div className={`flex-1 flex flex-col min-h-0 ${gameTheme.nertz.bg}`}>
@@ -255,6 +283,8 @@ function NertzPageContent() {
               messageParams={state.messageParams}
             />
 
+            {error && collidedFoundationIdx === null && <ErrorAlert message={error} onRetry={retry} />}
+
             <div data-tutorial="nertz-foundations" className="bg-black/30 text-ds-text-primary p-3 rounded">
               <div className="text-xs uppercase tracking-wide text-ds-text-muted mb-2">{t('labels.foundation')}</div>
               <div className="flex flex-wrap gap-2">
@@ -267,6 +297,7 @@ function NertzPageContent() {
                     onClick={() => handleFoundationClick(idx)}
                     disabled={!isHumanTurn || !selection}
                     ariaLabel={t('labels.foundationN', { n: idx, defaultValue: `Foundation ${idx}` })}
+                    collided={collidedFoundationIdx === idx}
                   />
                 ))}
               </div>
@@ -398,19 +429,24 @@ interface FoundationCellProps {
   onClick: () => void;
   disabled: boolean;
   ariaLabel: string;
+  /** Apply collision feedback (shake + red ring) when a move to this foundation was just rejected. */
+  collided?: boolean;
 }
 
-function FoundationCell({ idx, top, size, onClick, disabled, ariaLabel }: FoundationCellProps) {
+function FoundationCell({ idx, top, size, onClick, disabled, ariaLabel, collided = false }: FoundationCellProps) {
   const cls = disabled
     ? 'bg-ds-surface text-ds-text-muted border-ds-border-subtle'
     : 'bg-ds-surface-elevated text-ds-text-primary border-ds-border-subtle hover:bg-ds-surface-elevated-hover';
+  const collisionCls = collided ? 'animate-shake ring-2 ring-ds-error' : '';
   return (
     <button
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className={`min-w-[3rem] px-2 py-2 rounded border text-sm ${cls}`}
+      className={`min-w-[3rem] px-2 py-2 rounded border text-sm ${cls} ${collisionCls}`}
       aria-label={ariaLabel}
+      data-testid={`nertz-foundation-${idx}`}
+      data-collided={collided || undefined}
     >
       <span className="block text-xs leading-none">F{idx}</span>
       <span className="block text-base font-bold">{top ? `${suitSymbol(top.design)}${top.value}` : '—'}</span>

--- a/frontend/src/pages/NertzPage.tsx
+++ b/frontend/src/pages/NertzPage.tsx
@@ -139,16 +139,37 @@ function NertzPageContent() {
 
   const [collidedFoundationIdx, setCollidedFoundationIdx] = useState<number | null>(null);
   const [collisionTick, setCollisionTick] = useState(0);
+  // `isCollisionError` flags that the current `error` from useGameApi was
+  // attributed to a foundation collision (already conveyed via the shake
+  // animation). The global ErrorAlert is suppressed for the lifetime of that
+  // error so it does not pop in once the shake animation expires.
+  const [isCollisionError, setIsCollisionError] = useState(false);
   // Tracks the target foundation of the most recent player-initiated move so we
   // can attribute the next error from `useGameApi` to a specific cell.
   const pendingFoundationRef = useRef<number | null>(null);
   const prevErrorRef = useRef<string | null>(null);
 
+  // Successful moves call `setState(res)` on the useGameApi side; whenever a new
+  // state arrives we know the in-flight move resolved without error, so the
+  // stale foundation pointer must be cleared. Without this, a later unrelated
+  // error (a tick that fails) would attribute itself to the previous foundation
+  // and flash the wrong cell.
   useEffect(() => {
-    if (error && error !== prevErrorRef.current && pendingFoundationRef.current !== null) {
-      setCollidedFoundationIdx(pendingFoundationRef.current);
-      setCollisionTick((n) => n + 1);
-      pendingFoundationRef.current = null;
+    if (state) pendingFoundationRef.current = null;
+  }, [state]);
+
+  useEffect(() => {
+    if (error && error !== prevErrorRef.current) {
+      if (pendingFoundationRef.current !== null) {
+        setCollidedFoundationIdx(pendingFoundationRef.current);
+        setCollisionTick((n) => n + 1);
+        setIsCollisionError(true);
+        pendingFoundationRef.current = null;
+      } else {
+        setIsCollisionError(false);
+      }
+    } else if (!error) {
+      setIsCollisionError(false);
     }
     prevErrorRef.current = error;
   }, [error]);
@@ -283,7 +304,7 @@ function NertzPageContent() {
               messageParams={state.messageParams}
             />
 
-            {error && collidedFoundationIdx === null && <ErrorAlert message={error} onRetry={retry} />}
+            {error && !isCollisionError && <ErrorAlert message={error} onRetry={retry} />}
 
             <div data-tutorial="nertz-foundations" className="bg-black/30 text-ds-text-primary p-3 rounded">
               <div className="text-xs uppercase tracking-wide text-ds-text-muted mb-2">{t('labels.foundation')}</div>

--- a/frontend/src/pages/NertzPage.tsx
+++ b/frontend/src/pages/NertzPage.tsx
@@ -189,7 +189,7 @@ function NertzPageContent() {
         selection.kind === 'tableau'
           ? { zone: 'tableau', col: selection.col, cardIndex: selection.cardIndex }
           : { zone: selection.kind };
-      if (to.zone === 'foundation') {
+      if (to.zone === 'foundation' && to.idx !== undefined) {
         pendingFoundationRef.current = to.idx;
       }
       void apiCall('m', { playerIdx: 0, from, to });


### PR DESCRIPTION
## Summary

In Nertz a foundation move regularly loses the race to a CPU — the previous code surfaced that as a top-level \`ErrorAlert\` that replaced the entire game page (\`if (error) return <ErrorAlert ... />\`). This PR replaces the unmount with an in-place shake + red ring on the targeted foundation cell for 500ms and keeps the realtime game running. The global \`ErrorAlert\` still appears for non-collision errors.

Closes #1866.

## Test plan

- [x] \`bun run test -- --run src/pages/NertzPage\`
- [x] \`bunx biome check\` on modified files
- [ ] tsc + full build (CI)
- [ ] Manual: race a foundation drop against the CPU and confirm the foundation flashes red without breaking the page.