### PR TITLE
feat(pokersquares): preview row/col score on hover (#1868)

### DIFF
--- a/frontend/src/i18n/locales/en/pokersquares.json
+++ b/frontend/src/i18n/locales/en/pokersquares.json
@@ -29,5 +29,17 @@
   "hint": {
     "placeSynergy": "Place here to build toward a stronger poker hand",
     "placeAny": "Place in any empty cell"
+  },
+  "hand": {
+    "highCard": "High Card",
+    "onePair": "One Pair",
+    "twoPair": "Two Pair",
+    "threeOfAKind": "Three of a Kind",
+    "straight": "Straight",
+    "flush": "Flush",
+    "fullHouse": "Full House",
+    "fourOfAKind": "Four of a Kind",
+    "straightFlush": "Straight Flush",
+    "royalFlush": "Royal Flush"
   }
 }

--- a/frontend/src/i18n/locales/ja/pokersquares.json
+++ b/frontend/src/i18n/locales/ja/pokersquares.json
@@ -29,5 +29,17 @@
   "hint": {
     "placeSynergy": "役ができやすいマスに配置することを推奨",
     "placeAny": "いずれかの空きマスに配置します"
+  },
+  "hand": {
+    "highCard": "ハイカード",
+    "onePair": "ワンペア",
+    "twoPair": "ツーペア",
+    "threeOfAKind": "スリーカード",
+    "straight": "ストレート",
+    "flush": "フラッシュ",
+    "fullHouse": "フルハウス",
+    "fourOfAKind": "フォーカード",
+    "straightFlush": "ストレートフラッシュ",
+    "royalFlush": "ロイヤルフラッシュ"
   }
 }

--- a/frontend/src/pages/PokerSquaresPage.test.tsx
+++ b/frontend/src/pages/PokerSquaresPage.test.tsx
@@ -281,4 +281,25 @@ describe('PokerSquaresPage', () => {
     await waitFor(() => expect(screen.getByRole('log')).toBeInTheDocument());
     expect(screen.queryByTestId('ps-board')).not.toBeInTheDocument();
   });
+
+  it('shows the projected row score when hovering a cell that would complete a row', async () => {
+    // Row 0 has four 9's of different suits — placing a 5 at (0,4) completes a four-of-a-kind (50 pts).
+    const board = emptyBoard();
+    board[0][0] = { card: card('SPADE', 9) };
+    board[0][1] = { card: card('CLOVER', 9) };
+    board[0][2] = { card: card('HEART', 9) };
+    board[0][3] = { card: card('DIAMOND', 9) };
+    mockApi.mockResolvedValue({
+      ...playingState,
+      board,
+      currentCard: card('SPADE', 5),
+      placedCount: 4,
+    });
+    renderWithProviders(<PokerSquaresPage />);
+    const cell = await screen.findByTestId('cell-0-4');
+    fireEvent.pointerEnter(cell);
+    await waitFor(() => expect(screen.getByTestId('cell-0-4')).toHaveAttribute('data-cross-hover', 'true'));
+    const preview = await screen.findByTestId('row-score-preview-0');
+    expect(preview.textContent).toContain('+50');
+  });
 });

--- a/frontend/src/pages/PokerSquaresPage.tsx
+++ b/frontend/src/pages/PokerSquaresPage.tsx
@@ -23,13 +23,14 @@ import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { PokerSquaresResponse } from '../types/card';
+import type { Card, PokerSquaresResponse } from '../types/card';
 import { PokerSquaresPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { POKERSQUARES_HELP, parsePokerSquaresCommand } from '../utils/cli/commands/pokersquaresCommands';
 import { formatPokerSquaresState } from '../utils/cli/formatters/pokersquaresFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { evaluateFiveCardHand, pokerHandKey, pokerSquaresRankToScore } from '../utils/pokerSquaresUtils';
 
 const POKER_SQUARES_PHASE_KEYS: Readonly<Record<number, string>> = {
   [PokerSquaresPhase.PLAYING]: 'playing',
@@ -100,6 +101,32 @@ function PokerSquaresPageContent() {
       setCrossHover(null);
     }
   }, [loading, state?.board, crossHover]);
+
+  // While the player hovers an empty cell, compute the (hypothetical) row + col scores
+  // they would lock in by placing `currentCard` there. We can only score full lines, so
+  // the preview surfaces only when this placement would complete the row or column.
+  const preview = useMemo(() => {
+    if (!state || !crossHover || !state.currentCard) return null;
+    const board = state.board;
+    if (board[crossHover.row]?.[crossHover.col]?.card) return null;
+
+    const placedCard = state.currentCard;
+    const rowCards: (Card | null)[] = board[crossHover.row].map((c, ci) =>
+      ci === crossHover.col ? placedCard : c.card,
+    );
+    const colCards: (Card | null)[] = board.map((r, ri) =>
+      ri === crossHover.row ? placedCard : r[crossHover.col].card,
+    );
+
+    const rowComplete: Card[] | null = rowCards.every((c): c is Card => c != null) ? (rowCards as Card[]) : null;
+    const colComplete: Card[] | null = colCards.every((c): c is Card => c != null) ? (colCards as Card[]) : null;
+    const rowRank = rowComplete ? evaluateFiveCardHand(rowComplete) : null;
+    const colRank = colComplete ? evaluateFiveCardHand(colComplete) : null;
+    return {
+      row: rowRank != null ? { rank: rowRank, score: pokerSquaresRankToScore(rowRank) } : null,
+      col: colRank != null ? { rank: colRank, score: pokerSquaresRankToScore(colRank) } : null,
+    };
+  }, [state, crossHover]);
 
   const handlePlace = (row: number, col: number) => {
     execApi('place', row, col);
@@ -241,19 +268,30 @@ function PokerSquaresPageContent() {
                       >
                         {state.rowScores.map((s, i) => {
                           const highlighted = crossHover?.row === i;
+                          const rowPreview = highlighted ? preview?.row : null;
                           return (
                             <div
                               key={`row-score-${i}`}
                               data-testid={`row-score-${i}`}
                               data-cross-hover={highlighted ? 'true' : undefined}
                               style={{ height: Math.round(cardWidth * 1.4) }}
-                              className={`flex items-center justify-center text-sm font-mono px-2 rounded min-w-[2.5rem] ${
+                              className={`flex flex-col items-center justify-center text-sm font-mono px-2 rounded min-w-[3rem] ${
                                 highlighted
                                   ? 'text-ds-accent bg-ds-accent/15 ring-1 ring-ds-accent'
                                   : 'text-ds-text-primary bg-black/30'
                               }`}
                             >
-                              {s}
+                              <span>{s}</span>
+                              {rowPreview && rowPreview.score - s !== 0 && (
+                                <span
+                                  data-testid={`row-score-preview-${i}`}
+                                  className="text-[10px] text-ds-success leading-none mt-0.5"
+                                >
+                                  {`+${rowPreview.score - s}`}
+                                  <br />
+                                  {t(`hand.${pokerHandKey(rowPreview.rank)}`)}
+                                </span>
+                              )}
                             </div>
                           );
                         })}
@@ -266,6 +304,7 @@ function PokerSquaresPageContent() {
                     >
                       {state.colScores.map((s, i) => {
                         const highlighted = crossHover?.col === i;
+                        const colPreview = highlighted ? preview?.col : null;
                         return (
                           <div
                             key={`col-score-${i}`}
@@ -279,6 +318,15 @@ function PokerSquaresPageContent() {
                             }`}
                           >
                             {s}
+                            {colPreview && colPreview.score - s !== 0 && (
+                              <div
+                                data-testid={`col-score-preview-${i}`}
+                                className="text-[10px] text-ds-success leading-none mt-0.5"
+                              >
+                                +{colPreview.score - s}
+                                <div>{t(`hand.${pokerHandKey(colPreview.rank)}`)}</div>
+                              </div>
+                            )}
                           </div>
                         );
                       })}

--- a/frontend/src/pages/PokerSquaresPage.tsx
+++ b/frontend/src/pages/PokerSquaresPage.tsx
@@ -283,14 +283,13 @@ function PokerSquaresPageContent() {
                             >
                               <span>{s}</span>
                               {rowPreview && rowPreview.score - s !== 0 && (
-                                <span
+                                <div
                                   data-testid={`row-score-preview-${i}`}
                                   className="text-[10px] text-ds-success leading-none mt-0.5"
                                 >
-                                  {`+${rowPreview.score - s}`}
-                                  <br />
-                                  {t(`hand.${pokerHandKey(rowPreview.rank)}`)}
-                                </span>
+                                  +{rowPreview.score - s}
+                                  <div>{t(`hand.${pokerHandKey(rowPreview.rank)}`)}</div>
+                                </div>
                               )}
                             </div>
                           );

--- a/frontend/src/utils/pokerSquaresUtils.test.ts
+++ b/frontend/src/utils/pokerSquaresUtils.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign } from '../types/card';
+import { evaluateFiveCardHand, PokerHand, pokerSquaresRankToScore } from './pokerSquaresUtils';
+
+const card = (design: CardDesign, value: number): Card => ({ design, value });
+
+describe('evaluateFiveCardHand', () => {
+  it('returns null when fewer than 5 cards are given', () => {
+    expect(evaluateFiveCardHand([card('SPADE', 5)])).toBeNull();
+  });
+
+  it('detects high card', () => {
+    expect(
+      evaluateFiveCardHand([
+        card('SPADE', 2),
+        card('CLOVER', 5),
+        card('HEART', 9),
+        card('DIAMOND', 11),
+        card('SPADE', 13),
+      ]),
+    ).toBe(PokerHand.HighCard);
+  });
+
+  it('detects one pair', () => {
+    expect(
+      evaluateFiveCardHand([
+        card('SPADE', 2),
+        card('CLOVER', 2),
+        card('HEART', 9),
+        card('DIAMOND', 11),
+        card('SPADE', 13),
+      ]),
+    ).toBe(PokerHand.OnePair);
+  });
+
+  it('detects two pair', () => {
+    expect(
+      evaluateFiveCardHand([
+        card('SPADE', 2),
+        card('CLOVER', 2),
+        card('HEART', 9),
+        card('DIAMOND', 9),
+        card('SPADE', 13),
+      ]),
+    ).toBe(PokerHand.TwoPair);
+  });
+
+  it('detects three of a kind', () => {
+    expect(
+      evaluateFiveCardHand([
+        card('SPADE', 7),
+        card('CLOVER', 7),
+        card('HEART', 7),
+        card('DIAMOND', 11),
+        card('SPADE', 13),
+      ]),
+    ).toBe(PokerHand.ThreeOfAKind);
+  });
+
+  it('detects straight (sequential)', () => {
+    expect(
+      evaluateFiveCardHand([
+        card('SPADE', 5),
+        card('CLOVER', 6),
+        card('HEART', 7),
+        card('DIAMOND', 8),
+        card('SPADE', 9),
+      ]),
+    ).toBe(PokerHand.Straight);
+  });
+
+  it('detects A-2-3-4-5 wheel straight', () => {
+    expect(
+      evaluateFiveCardHand([
+        card('SPADE', 1),
+        card('CLOVER', 2),
+        card('HEART', 3),
+        card('DIAMOND', 4),
+        card('SPADE', 5),
+      ]),
+    ).toBe(PokerHand.Straight);
+  });
+
+  it('detects 10-J-Q-K-A high straight', () => {
+    expect(
+      evaluateFiveCardHand([
+        card('SPADE', 10),
+        card('CLOVER', 11),
+        card('HEART', 12),
+        card('DIAMOND', 13),
+        card('SPADE', 1),
+      ]),
+    ).toBe(PokerHand.Straight);
+  });
+
+  it('detects flush (same suit, non-straight)', () => {
+    expect(
+      evaluateFiveCardHand([
+        card('SPADE', 2),
+        card('SPADE', 5),
+        card('SPADE', 9),
+        card('SPADE', 11),
+        card('SPADE', 13),
+      ]),
+    ).toBe(PokerHand.Flush);
+  });
+
+  it('detects full house', () => {
+    expect(
+      evaluateFiveCardHand([
+        card('SPADE', 7),
+        card('CLOVER', 7),
+        card('HEART', 7),
+        card('DIAMOND', 11),
+        card('SPADE', 11),
+      ]),
+    ).toBe(PokerHand.FullHouse);
+  });
+
+  it('detects four of a kind', () => {
+    expect(
+      evaluateFiveCardHand([
+        card('SPADE', 9),
+        card('CLOVER', 9),
+        card('HEART', 9),
+        card('DIAMOND', 9),
+        card('SPADE', 13),
+      ]),
+    ).toBe(PokerHand.FourOfAKind);
+  });
+
+  it('detects straight flush', () => {
+    expect(
+      evaluateFiveCardHand([card('SPADE', 5), card('SPADE', 6), card('SPADE', 7), card('SPADE', 8), card('SPADE', 9)]),
+    ).toBe(PokerHand.StraightFlush);
+  });
+
+  it('detects royal flush', () => {
+    expect(
+      evaluateFiveCardHand([
+        card('SPADE', 10),
+        card('SPADE', 11),
+        card('SPADE', 12),
+        card('SPADE', 13),
+        card('SPADE', 1),
+      ]),
+    ).toBe(PokerHand.RoyalFlush);
+  });
+});
+
+describe('pokerSquaresRankToScore', () => {
+  it('matches the American scoring table', () => {
+    expect(pokerSquaresRankToScore(PokerHand.HighCard)).toBe(0);
+    expect(pokerSquaresRankToScore(PokerHand.OnePair)).toBe(2);
+    expect(pokerSquaresRankToScore(PokerHand.TwoPair)).toBe(5);
+    expect(pokerSquaresRankToScore(PokerHand.ThreeOfAKind)).toBe(10);
+    expect(pokerSquaresRankToScore(PokerHand.Straight)).toBe(15);
+    expect(pokerSquaresRankToScore(PokerHand.Flush)).toBe(20);
+    expect(pokerSquaresRankToScore(PokerHand.FullHouse)).toBe(25);
+    expect(pokerSquaresRankToScore(PokerHand.FourOfAKind)).toBe(50);
+    expect(pokerSquaresRankToScore(PokerHand.StraightFlush)).toBe(75);
+    expect(pokerSquaresRankToScore(PokerHand.RoyalFlush)).toBe(100);
+  });
+});

--- a/frontend/src/utils/pokerSquaresUtils.test.ts
+++ b/frontend/src/utils/pokerSquaresUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Card, CardDesign } from '../types/card';
-import { evaluateFiveCardHand, PokerHand, pokerSquaresRankToScore } from './pokerSquaresUtils';
+import { evaluateFiveCardHand, PokerHand, pokerHandKey, pokerSquaresRankToScore } from './pokerSquaresUtils';
 
 const card = (design: CardDesign, value: number): Card => ({ design, value });
 
@@ -160,5 +160,20 @@ describe('pokerSquaresRankToScore', () => {
     expect(pokerSquaresRankToScore(PokerHand.FourOfAKind)).toBe(50);
     expect(pokerSquaresRankToScore(PokerHand.StraightFlush)).toBe(75);
     expect(pokerSquaresRankToScore(PokerHand.RoyalFlush)).toBe(100);
+  });
+});
+
+describe('pokerHandKey', () => {
+  it('returns the i18n key suffix for each rank', () => {
+    expect(pokerHandKey(PokerHand.HighCard)).toBe('highCard');
+    expect(pokerHandKey(PokerHand.OnePair)).toBe('onePair');
+    expect(pokerHandKey(PokerHand.TwoPair)).toBe('twoPair');
+    expect(pokerHandKey(PokerHand.ThreeOfAKind)).toBe('threeOfAKind');
+    expect(pokerHandKey(PokerHand.Straight)).toBe('straight');
+    expect(pokerHandKey(PokerHand.Flush)).toBe('flush');
+    expect(pokerHandKey(PokerHand.FullHouse)).toBe('fullHouse');
+    expect(pokerHandKey(PokerHand.FourOfAKind)).toBe('fourOfAKind');
+    expect(pokerHandKey(PokerHand.StraightFlush)).toBe('straightFlush');
+    expect(pokerHandKey(PokerHand.RoyalFlush)).toBe('royalFlush');
   });
 });

--- a/frontend/src/utils/pokerSquaresUtils.ts
+++ b/frontend/src/utils/pokerSquaresUtils.ts
@@ -1,0 +1,95 @@
+import type { Card } from '../types/card';
+
+/** Hand rank constants used by Poker Squares — mirror the backend rank ints. */
+export const PokerHand = {
+  HighCard: 0,
+  OnePair: 1,
+  TwoPair: 2,
+  ThreeOfAKind: 3,
+  Straight: 4,
+  Flush: 5,
+  FullHouse: 6,
+  FourOfAKind: 7,
+  StraightFlush: 8,
+  RoyalFlush: 9,
+} as const;
+
+export type PokerHandRank = (typeof PokerHand)[keyof typeof PokerHand];
+
+/** American Poker Squares scoring (mirrors `pokerSquaresScoreTable` in Go). */
+const SCORE_TABLE: Record<PokerHandRank, number> = {
+  [PokerHand.HighCard]: 0,
+  [PokerHand.OnePair]: 2,
+  [PokerHand.TwoPair]: 5,
+  [PokerHand.ThreeOfAKind]: 10,
+  [PokerHand.Straight]: 15,
+  [PokerHand.Flush]: 20,
+  [PokerHand.FullHouse]: 25,
+  [PokerHand.FourOfAKind]: 50,
+  [PokerHand.StraightFlush]: 75,
+  [PokerHand.RoyalFlush]: 100,
+};
+
+/** Return the Poker Squares score for a hand rank. */
+export function pokerSquaresRankToScore(rank: PokerHandRank): number {
+  return SCORE_TABLE[rank] ?? 0;
+}
+
+/** i18n key suffix for a hand rank. */
+export function pokerHandKey(rank: PokerHandRank): string {
+  const names = [
+    'highCard',
+    'onePair',
+    'twoPair',
+    'threeOfAKind',
+    'straight',
+    'flush',
+    'fullHouse',
+    'fourOfAKind',
+    'straightFlush',
+    'royalFlush',
+  ] as const;
+  return names[rank];
+}
+
+/**
+ * Evaluate a 5-card poker hand. Returns `null` for any non-5-card input.
+ * Aces are low (value 1) when forming an A-2-3-4-5 straight and act as the
+ * high anchor for 10-J-Q-K-A (mirroring the Go backend's behaviour).
+ */
+export function evaluateFiveCardHand(cards: readonly Card[]): PokerHandRank | null {
+  if (cards.length !== 5) return null;
+
+  const values = cards.map((c) => c.value).sort((a, b) => a - b);
+  const designs = cards.map((c) => c.design);
+  const counts = countByValue(values);
+  const groupSizes = Object.values(counts).sort((a, b) => b - a);
+  const isFlush = designs.every((d) => d === designs[0]);
+  const isStraight = checkStraight(values);
+  const isRoyal = isStraight && values[0] === 1 && values[4] === 13 && values[1] === 10;
+
+  if (isFlush && isRoyal) return PokerHand.RoyalFlush;
+  if (isFlush && isStraight) return PokerHand.StraightFlush;
+  if (groupSizes[0] === 4) return PokerHand.FourOfAKind;
+  if (groupSizes[0] === 3 && groupSizes[1] === 2) return PokerHand.FullHouse;
+  if (isFlush) return PokerHand.Flush;
+  if (isStraight) return PokerHand.Straight;
+  if (groupSizes[0] === 3) return PokerHand.ThreeOfAKind;
+  if (groupSizes[0] === 2 && groupSizes[1] === 2) return PokerHand.TwoPair;
+  if (groupSizes[0] === 2) return PokerHand.OnePair;
+  return PokerHand.HighCard;
+}
+
+function countByValue(sortedValues: readonly number[]): Record<number, number> {
+  const out: Record<number, number> = {};
+  for (const v of sortedValues) out[v] = (out[v] ?? 0) + 1;
+  return out;
+}
+
+function checkStraight(sortedValues: readonly number[]): boolean {
+  // Five distinct sequential ranks, or the A-2-3-4-5 wheel.
+  if (new Set(sortedValues).size !== 5) return false;
+  if (sortedValues[4] - sortedValues[0] === 4) return true;
+  // 10-J-Q-K-A becomes [1, 10, 11, 12, 13] after sort. Treat that as a straight.
+  return sortedValues[0] === 1 && sortedValues[1] === 10 && sortedValues[4] === 13;
+}

--- a/frontend/src/utils/pokerSquaresUtils.ts
+++ b/frontend/src/utils/pokerSquaresUtils.ts
@@ -32,24 +32,26 @@ const SCORE_TABLE: Record<PokerHandRank, number> = {
 
 /** Return the Poker Squares score for a hand rank. */
 export function pokerSquaresRankToScore(rank: PokerHandRank): number {
-  return SCORE_TABLE[rank] ?? 0;
+  return SCORE_TABLE[rank];
 }
+
+/** i18n key suffix for each hand rank, indexed by `PokerHandRank` value. */
+const POKER_HAND_KEYS = [
+  'highCard',
+  'onePair',
+  'twoPair',
+  'threeOfAKind',
+  'straight',
+  'flush',
+  'fullHouse',
+  'fourOfAKind',
+  'straightFlush',
+  'royalFlush',
+] as const;
 
 /** i18n key suffix for a hand rank. */
 export function pokerHandKey(rank: PokerHandRank): string {
-  const names = [
-    'highCard',
-    'onePair',
-    'twoPair',
-    'threeOfAKind',
-    'straight',
-    'flush',
-    'fullHouse',
-    'fourOfAKind',
-    'straightFlush',
-    'royalFlush',
-  ] as const;
-  return names[rank];
+  return POKER_HAND_KEYS[rank];
 }
 
 /**


### PR DESCRIPTION
## Summary

Hovering an empty cell on the Poker Squares board now surfaces a small \"+X / hand-name\" badge on the corresponding row and column score chips for any line the placement would complete. The poker-hand evaluator lives in \`pokerSquaresUtils.ts\` and mirrors the backend's \`evalFiveCardHand\` so the projected score matches what the server would award.

Closes #1868.

## Test plan

- [x] \`bun run test -- --run src/utils/pokerSquaresUtils src/pages/PokerSquaresPage\`
- [x] \`bunx biome check\` on modified files
- [ ] tsc + full build (CI)
- [ ] Manual: hover several near-complete rows/cols, place a card, confirm the actual score matches the previewed score.