### PR TITLE
feat(pigtail): lay the deck out in a tappable circle (#1869)

### DIFF
--- a/frontend/src/components/CircularDeck.test.tsx
+++ b/frontend/src/components/CircularDeck.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CircularDeck } from './CircularDeck';
+
+describe('CircularDeck', () => {
+  it('renders the empty placeholder when no cards remain', () => {
+    render(<CircularDeck count={0} cardWidth={32} onDrawCard={vi.fn()} drawAriaLabel="draw" />);
+    expect(screen.getByTestId('circular-deck-empty')).toBeInTheDocument();
+  });
+
+  it('renders one button per card up to the cap', () => {
+    render(<CircularDeck count={5} cardWidth={32} onDrawCard={vi.fn()} drawAriaLabel="draw" />);
+    expect(screen.getAllByRole('button')).toHaveLength(5);
+  });
+
+  it('caps the number of rendered cards regardless of count', () => {
+    render(<CircularDeck count={100} cardWidth={32} onDrawCard={vi.fn()} drawAriaLabel="draw" />);
+    // MAX_VISIBLE_CARDS = 26
+    expect(screen.getAllByRole('button')).toHaveLength(26);
+  });
+
+  it('fires onDrawCard when any card is tapped', () => {
+    const onDrawCard = vi.fn();
+    render(<CircularDeck count={4} cardWidth={32} onDrawCard={onDrawCard} drawAriaLabel="draw" />);
+    fireEvent.click(screen.getAllByRole('button')[2]);
+    expect(onDrawCard).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire onDrawCard while disabled', () => {
+    const onDrawCard = vi.fn();
+    render(<CircularDeck count={3} cardWidth={32} onDrawCard={onDrawCard} drawAriaLabel="draw" disabled />);
+    fireEvent.click(screen.getAllByRole('button')[0]);
+    expect(onDrawCard).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/CircularDeck.tsx
+++ b/frontend/src/components/CircularDeck.tsx
@@ -1,0 +1,90 @@
+import { CardBack } from './CardImage';
+
+/** Props for the {@link CircularDeck} component. */
+export interface CircularDeckProps {
+  /** Number of face-down cards laid out around the ring. */
+  count: number;
+  /** Card width in pixels. */
+  cardWidth: number;
+  /** Diameter of the imaginary circle (px). */
+  diameter?: number;
+  /** Tap handler invoked when any card on the ring is clicked. */
+  onDrawCard: () => void;
+  /** Disables tap interaction. */
+  disabled?: boolean;
+  /** Localised aria-label for the tap targets, e.g. "Draw a card". */
+  drawAriaLabel: string;
+  /** Optional data-tutorial attribute for tutorial highlighting. */
+  dataTutorial?: string;
+}
+
+const MIN_DIAMETER = 120;
+const MAX_VISIBLE_CARDS = 26;
+
+/**
+ * Lays out `count` face-down cards in a ring so the player can tap any of them
+ * to draw "that" card. The drawn card is decided by the backend; the ring is
+ * purely an affordance to bring back the physical feel of the game.
+ *
+ * When the deck has fewer cards than the visual cap (`MAX_VISIBLE_CARDS`) the
+ * ring renders one per card. Beyond the cap the cap itself is used to avoid
+ * overlapping tap targets.
+ */
+export function CircularDeck({
+  count,
+  cardWidth,
+  diameter = MIN_DIAMETER,
+  onDrawCard,
+  disabled = false,
+  drawAriaLabel,
+  dataTutorial,
+}: CircularDeckProps) {
+  const visible = Math.max(0, Math.min(count, MAX_VISIBLE_CARDS));
+  const ringDiameter = Math.max(diameter, MIN_DIAMETER);
+  const cardHeight = Math.round(cardWidth * 1.4);
+
+  if (visible === 0) {
+    return (
+      <div
+        className="text-ds-text-muted text-sm text-center"
+        data-tutorial={dataTutorial}
+        data-testid="circular-deck-empty"
+      >
+        —
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="relative mx-auto"
+      style={{ width: ringDiameter + cardWidth, height: ringDiameter + cardHeight }}
+      data-tutorial={dataTutorial}
+      data-testid="circular-deck"
+    >
+      {Array.from({ length: visible }, (_, i) => {
+        const angle = (i / visible) * 2 * Math.PI - Math.PI / 2;
+        const cx = ringDiameter / 2 + (ringDiameter / 2) * Math.cos(angle);
+        const cy = ringDiameter / 2 + (ringDiameter / 2) * Math.sin(angle);
+        return (
+          <button
+            type="button"
+            key={`ring-${i}`}
+            onClick={onDrawCard}
+            disabled={disabled}
+            aria-label={`${drawAriaLabel} #${i + 1}`}
+            data-testid={`circular-deck-card-${i}`}
+            className="absolute p-0 m-0 border-0 bg-transparent disabled:opacity-40 disabled:cursor-not-allowed transition-transform hover:scale-110"
+            style={{
+              left: cx,
+              top: cy,
+              transform: `translate(-50%, -50%) rotate(${(angle * 180) / Math.PI + 90}deg)`,
+            }}
+          >
+            <CardBack width={cardWidth} />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/CircularDeck.tsx
+++ b/frontend/src/components/CircularDeck.tsx
@@ -20,6 +20,10 @@ export interface CircularDeckProps {
 
 const MIN_DIAMETER = 120;
 const MAX_VISIBLE_CARDS = 26;
+/** Card aspect ratio (height / width). Matches `CARD_NATURAL_HEIGHT / CARD_NATURAL_WIDTH` in `CardImage.tsx`. */
+const CARD_ASPECT = 1.5;
+/** WCAG 2.5.5 AAA minimum tap-target dimension (px). Per `frontend/CLAUDE.md`. */
+const MIN_TAP_TARGET_PX = 44;
 
 /**
  * Lays out `count` face-down cards in a ring so the player can tap any of them
@@ -41,7 +45,7 @@ export function CircularDeck({
 }: CircularDeckProps) {
   const visible = Math.max(0, Math.min(count, MAX_VISIBLE_CARDS));
   const ringDiameter = Math.max(diameter, MIN_DIAMETER);
-  const cardHeight = Math.round(cardWidth * 1.4);
+  const cardHeight = Math.round(cardWidth * CARD_ASPECT);
 
   if (visible === 0) {
     return (
@@ -64,8 +68,11 @@ export function CircularDeck({
     >
       {Array.from({ length: visible }, (_, i) => {
         const angle = (i / visible) * 2 * Math.PI - Math.PI / 2;
-        const cx = ringDiameter / 2 + (ringDiameter / 2) * Math.cos(angle);
-        const cy = ringDiameter / 2 + (ringDiameter / 2) * Math.sin(angle);
+        // Shift the ring centre by half a card so cards at every cardinal
+        // direction stay fully inside the container (the original calc placed
+        // the centre at `ringDiameter/2` which clipped the left and top cards).
+        const cx = cardWidth / 2 + (ringDiameter / 2) * (1 + Math.cos(angle));
+        const cy = cardHeight / 2 + (ringDiameter / 2) * (1 + Math.sin(angle));
         return (
           <button
             type="button"
@@ -74,10 +81,14 @@ export function CircularDeck({
             disabled={disabled}
             aria-label={`${drawAriaLabel} #${i + 1}`}
             data-testid={`circular-deck-card-${i}`}
-            className="absolute p-0 m-0 border-0 bg-transparent disabled:opacity-40 disabled:cursor-not-allowed transition-transform hover:scale-110"
+            className="absolute p-0 m-0 border-0 bg-transparent disabled:opacity-40 disabled:cursor-not-allowed transition-transform hover:scale-110 flex items-center justify-center"
             style={{
               left: cx,
               top: cy,
+              // Pad the interactive area to meet WCAG 2.5.5 AAA (44×44 minimum)
+              // even when the visible card art is smaller.
+              minWidth: MIN_TAP_TARGET_PX,
+              minHeight: MIN_TAP_TARGET_PX,
               transform: `translate(-50%, -50%) rotate(${(angle * 180) / Math.PI + 90}deg)`,
             }}
           >

--- a/frontend/src/pages/PigsTailPage.test.tsx
+++ b/frontend/src/pages/PigsTailPage.test.tsx
@@ -68,6 +68,17 @@ const humanLoseState: PigsTailResponse = {
 
 beforeEach(() => {
   mockExec.mockResolvedValue(baseState);
+  // Reset CLI mode to the default so tests that toggle it on (e.g. the
+  // CLI-terminal case) don't leak state into the next test in source order.
+  mockUseCliMode.mockReturnValue({
+    cliEnabled: false,
+    toggleCli: vi.fn(),
+    logEntries: [],
+    addInput: vi.fn(),
+    addOutput: vi.fn(),
+    addError: vi.fn(),
+    clearLog: vi.fn(),
+  });
 });
 
 describe('PigsTailPage', () => {
@@ -181,16 +192,6 @@ describe('PigsTailPage', () => {
   });
 
   it('renders the circular deck and dispatches draw when a ring card is tapped', async () => {
-    // The previous test enables CLI mode globally on the mock; reset so the page renders the standard UI.
-    mockUseCliMode.mockReturnValue({
-      cliEnabled: false,
-      toggleCli: vi.fn(),
-      logEntries: [],
-      addInput: vi.fn(),
-      addOutput: vi.fn(),
-      addError: vi.fn(),
-      clearLog: vi.fn(),
-    });
     renderWithProviders(<PigsTailPage />);
     await waitFor(() => expect(screen.getByTestId('circular-deck')).toBeInTheDocument());
 

--- a/frontend/src/pages/PigsTailPage.test.tsx
+++ b/frontend/src/pages/PigsTailPage.test.tsx
@@ -88,7 +88,7 @@ describe('PigsTailPage', () => {
   it('renders game state with circle and center info', async () => {
     renderWithProviders(<PigsTailPage />);
     await waitFor(() => {
-      expect(screen.getByText('52')).toBeInTheDocument();
+      expect(screen.getByText(/52/)).toBeInTheDocument();
     });
   });
 
@@ -178,5 +178,24 @@ describe('PigsTailPage', () => {
       expect(screen.getByRole('textbox')).toBeInTheDocument();
     });
     expect(screen.queryByRole('button', { name: '山札から引く' })).not.toBeInTheDocument();
+  });
+
+  it('renders the circular deck and dispatches draw when a ring card is tapped', async () => {
+    // The previous test enables CLI mode globally on the mock; reset so the page renders the standard UI.
+    mockUseCliMode.mockReturnValue({
+      cliEnabled: false,
+      toggleCli: vi.fn(),
+      logEntries: [],
+      addInput: vi.fn(),
+      addOutput: vi.fn(),
+      addError: vi.fn(),
+      clearLog: vi.fn(),
+    });
+    renderWithProviders(<PigsTailPage />);
+    await waitFor(() => expect(screen.getByTestId('circular-deck')).toBeInTheDocument());
+
+    mockExec.mockClear();
+    fireEvent.click(screen.getByTestId('circular-deck-card-0'));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw'));
   });
 });

--- a/frontend/src/pages/PigsTailPage.tsx
+++ b/frontend/src/pages/PigsTailPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { pigtailApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
+import { CircularDeck } from '../components/CircularDeck';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { GameFooter } from '../components/GameFooter';
@@ -140,13 +141,19 @@ function PigsTailPageContent() {
         <>
           <div className="flex-1 overflow-y-auto px-4 py-2 space-y-3">
             {/* Circle & Center area */}
-            <div className="flex justify-center gap-8 items-center" data-tutorial="pt-circle-area">
-              <div className="text-center">
-                <div className="text-xs text-ds-text-muted mb-1">{t('label.circle')}</div>
-                <div className="w-16 h-16 rounded-full bg-ds-info/60 border-2 border-ds-info/40 flex items-center justify-center text-2xl font-bold text-white">
-                  {state.circleCount}
-                </div>
+            <div className="flex flex-col items-center gap-3" data-tutorial="pt-circle-area">
+              <div className="text-xs text-ds-text-muted">
+                {t('label.circle')}: {state.circleCount}
               </div>
+              <CircularDeck
+                count={state.circleCount}
+                cardWidth={32}
+                diameter={160}
+                onDrawCard={handleDraw}
+                disabled={loading || isGameEnd || !isHumanTurn}
+                drawAriaLabel={t('button.draw')}
+                dataTutorial="pt-circle-deck"
+              />
               <div className="text-center" data-tutorial="pt-center-area">
                 <div className="text-xs text-ds-text-muted mb-1">
                   {t('label.center')} ({state.centerCount})

--- a/frontend/src/pages/PigsTailPage.tsx
+++ b/frontend/src/pages/PigsTailPage.tsx
@@ -152,7 +152,6 @@ function PigsTailPageContent() {
                 onDrawCard={handleDraw}
                 disabled={loading || isGameEnd || !isHumanTurn}
                 drawAriaLabel={t('button.draw')}
-                dataTutorial="pt-circle-deck"
               />
               <div className="text-center" data-tutorial="pt-center-area">
                 <div className="text-xs text-ds-text-muted mb-1">


### PR DESCRIPTION
## Summary

Replaces the single \"circle: 52\" pill on Pig's Tail with an actual ring of face-down cards (capped at 26 visible cards for tap-target spacing) and lets the player tap any of them to draw. The backend still decides which card comes off the deck — the new layout just restores the physical-feeling \"pick the one that looks lucky\" experience the analogue game has. The original draw button remains as a keyboard / accessibility fallback.

Closes #1869.

## Test plan

- [x] \`bun run test -- --run src/components/CircularDeck src/pages/PigsTailPage\`
- [x] \`bunx biome check\` on modified files
- [ ] tsc + full build (CI)
- [ ] Manual: tap a few ring cards on mobile and confirm each draw call lands.