### PR TITLE
fix(e2e): update calculation spec to match localised foundation aria-label

### DIFF
--- a/frontend/e2e/calculation.spec.ts
+++ b/frontend/e2e/calculation.spec.ts
@@ -8,9 +8,11 @@ test.describe('Calculation E2E', () => {
     // Wait for the move-count readout
     await expect(page.getByText(/手数/).first()).toBeVisible({ timeout: TIMEOUT_TRANSITION });
 
-    // Foundations row: 4 foundations with step labels
-    await expect(page.getByLabel(/Foundation 0 \+1/).first()).toBeVisible({ timeout: TIMEOUT_TRANSITION });
-    await expect(page.getByLabel(/Foundation 3 \+4/).first()).toBeVisible({ timeout: TIMEOUT_TRANSITION });
+    // Foundations row: 4 foundations with step labels. Use the JA-locale label
+    // ("ファンデーション") since PR #1971 localised the aria-label and the Playwright
+    // suite runs against the JA-default browser.
+    await expect(page.getByLabel(/ファンデーション 0 \+1/).first()).toBeVisible({ timeout: TIMEOUT_TRANSITION });
+    await expect(page.getByLabel(/ファンデーション 3 \+4/).first()).toBeVisible({ timeout: TIMEOUT_TRANSITION });
 
     // Control buttons while playing
     await expect(page.getByRole('button', { name: 'ヒント' }).first()).toBeVisible({ timeout: TIMEOUT_TRANSITION });


### PR DESCRIPTION
## Summary

PR #1971 localised the Calculation page's foundation \`aria-label\` from \`Foundation\` to \`t('foundation')\` (which renders as \`ファンデーション\` in the JA-default test browser). I updated the unit tests in that PR but missed the Playwright spec — \`e2e/calculation.spec.ts\` still queries \`/Foundation N \\+X/\` and now times out on every PR queued after #1971 merged.

This is a one-file follow-up that updates the two \`getByLabel\` regexes to the JA label so the E2E suite goes green again. Unblocks PRs #1973–#1978.

## Test plan

- [x] \`bunx biome check\` on the spec
- [ ] CI: E2E \`Calculation E2E › navigates to calculation and renders the initial board\` flips green