### PR TITLE
feat(canasta): explain disabled draw-from-discard and highlight frozen pile

### DIFF
--- a/frontend/src/i18n/locales/en/canasta.json
+++ b/frontend/src/i18n/locales/en/canasta.json
@@ -35,6 +35,13 @@
   "goOutButton": "Go out",
   "nextRound": "Next round",
   "selectPair": "Select a pair (2 natural cards matching the top discard)",
+  "drawDiscardReason": {
+    "selectTwo": "Select 2 natural cards from your hand matching the top discard",
+    "frozen": "Frozen: wild cards cannot substitute for naturals",
+    "selectOneMore": "Select one more card",
+    "tooMany": "Select at most 2 cards"
+  },
+  "frozenIndicator": "❄️ Frozen",
   "selectMeld": "Select cards to meld",
   "result": {
     "humanWin": "You win!",

--- a/frontend/src/i18n/locales/ja/canasta.json
+++ b/frontend/src/i18n/locales/ja/canasta.json
@@ -35,6 +35,13 @@
   "goOutButton": "上がる",
   "nextRound": "次のラウンド",
   "selectPair": "ペアを選択してください（トップカードと同ランクの2枚）",
+  "drawDiscardReason": {
+    "selectTwo": "手札からトップカードと同ランクの2枚を選択してください",
+    "frozen": "フリーズ中はワイルドカードでの代用ができません",
+    "selectOneMore": "もう1枚選択してください",
+    "tooMany": "選択は2枚までです"
+  },
+  "frozenIndicator": "❄️ フリーズ",
   "selectMeld": "メルドするカードを選択してください",
   "result": {
     "humanWin": "あなたの勝利！",

--- a/frontend/src/pages/CanastaPage.test.tsx
+++ b/frontend/src/pages/CanastaPage.test.tsx
@@ -183,6 +183,22 @@ describe('CanastaPage', () => {
     expect(screen.queryByRole('button', { name: '確認' })).not.toBeInTheDocument();
   });
 
+  it('shows the disabled reason for draw-from-discard when no cards are selected', async () => {
+    renderWithProviders(<CanastaPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '捨て札を取る' })).toBeInTheDocument());
+    const reason = screen.getByTestId('ca-draw-discard-reason');
+    expect(reason).toHaveTextContent('手札からトップカードと同ランクの2枚を選択してください');
+  });
+
+  it('renders the frozen badge and reason when the discard pile is frozen', async () => {
+    mockExec.mockResolvedValue({ ...drawPhaseState, isFrozen: true });
+    renderWithProviders(<CanastaPage />);
+    await waitFor(() => expect(screen.getByTestId('ca-frozen-badge')).toBeInTheDocument());
+    expect(screen.getByTestId('ca-draw-discard-reason')).toHaveTextContent(
+      'フリーズ中はワイルドカードでの代用ができません',
+    );
+  });
+
   afterEach(() => {
     localStorage.clear();
   });

--- a/frontend/src/pages/CanastaPage.test.tsx
+++ b/frontend/src/pages/CanastaPage.test.tsx
@@ -199,6 +199,47 @@ describe('CanastaPage', () => {
     );
   });
 
+  it('switches the reason to selectOneMore once the player selects one card', async () => {
+    renderWithProviders(<CanastaPage />);
+    await waitFor(() => expect(screen.getByTestId('ca-draw-discard-reason')).toBeInTheDocument());
+    const handCards = screen.getAllByRole('button', { pressed: false }).filter((b) => b.hasAttribute('aria-pressed'));
+    fireEvent.click(handCards[0]);
+    expect(screen.getByTestId('ca-draw-discard-reason')).toHaveTextContent('もう1枚選択してください');
+  });
+
+  it('clears the reason and enables the draw button when exactly 2 cards are selected', async () => {
+    renderWithProviders(<CanastaPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '捨て札を取る' })).toBeInTheDocument());
+    const handCards = screen.getAllByRole('button', { pressed: false }).filter((b) => b.hasAttribute('aria-pressed'));
+    fireEvent.click(handCards[0]);
+    fireEvent.click(handCards[1]);
+    expect(screen.queryByTestId('ca-draw-discard-reason')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '捨て札を取る' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: '捨て札を取る' })).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('warns when more than 2 cards are selected', async () => {
+    renderWithProviders(<CanastaPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '捨て札を取る' })).toBeInTheDocument());
+    const handCards = screen.getAllByRole('button', { pressed: false }).filter((b) => b.hasAttribute('aria-pressed'));
+    fireEvent.click(handCards[0]);
+    fireEvent.click(handCards[1]);
+    fireEvent.click(handCards[2]);
+    expect(screen.getByTestId('ca-draw-discard-reason')).toHaveTextContent('選択は2枚までです');
+    expect(screen.getByRole('button', { name: '捨て札を取る' })).toBeDisabled();
+  });
+
+  it('keeps the frozen warning visible while the player has only picked one card', async () => {
+    mockExec.mockResolvedValue({ ...drawPhaseState, isFrozen: true });
+    renderWithProviders(<CanastaPage />);
+    await waitFor(() => expect(screen.getByTestId('ca-frozen-badge')).toBeInTheDocument());
+    const handCards = screen.getAllByRole('button', { pressed: false }).filter((b) => b.hasAttribute('aria-pressed'));
+    fireEvent.click(handCards[0]);
+    expect(screen.getByTestId('ca-draw-discard-reason')).toHaveTextContent(
+      'フリーズ中はワイルドカードでの代用ができません',
+    );
+  });
+
   afterEach(() => {
     localStorage.clear();
   });

--- a/frontend/src/pages/CanastaPage.tsx
+++ b/frontend/src/pages/CanastaPage.tsx
@@ -114,10 +114,13 @@ function CanastaPageContent() {
   const drawDiscardReason = useMemo(() => {
     if (!isDrawPhase) return '';
     const n = selectedCardIndices.length;
-    if (n === 0) return state?.isFrozen ? t('drawDiscardReason.frozen') : t('drawDiscardReason.selectTwo');
-    if (n === 1) return t('drawDiscardReason.selectOneMore');
     if (n > 2) return t('drawDiscardReason.tooMany');
-    return '';
+    if (n === 2) return '';
+    // Frozen takes priority while the player is still picking — the wildcard restriction
+    // is the load-bearing rule players forget; surface it whether they've picked 0 or 1 cards.
+    if (state?.isFrozen) return t('drawDiscardReason.frozen');
+    if (n === 1) return t('drawDiscardReason.selectOneMore');
+    return t('drawDiscardReason.selectTwo');
   }, [isDrawPhase, selectedCardIndices.length, state?.isFrozen, t]);
 
   const handleManualReset = useCallback(() => {
@@ -233,7 +236,8 @@ function CanastaPageContent() {
                       <span
                         className="absolute top-1 right-2 text-ds-info text-xs font-bold"
                         data-testid="ca-frozen-badge"
-                        role="status"
+                        role="img"
+                        aria-label={t('frozenIndicator')}
                       >
                         {t('frozenIndicator')}
                       </span>
@@ -389,8 +393,8 @@ function CanastaPageContent() {
                       className={btnPrimary}
                       onClick={handleDrawDiscard}
                       disabled={loading || selectedCardIndices.length !== 2}
-                      title={drawDiscardReason}
-                      aria-describedby="ca-draw-discard-reason"
+                      title={drawDiscardReason || undefined}
+                      aria-describedby={drawDiscardReason ? 'ca-draw-discard-reason' : undefined}
                     >
                       {t('drawDiscardButton')}
                     </button>

--- a/frontend/src/pages/CanastaPage.tsx
+++ b/frontend/src/pages/CanastaPage.tsx
@@ -111,6 +111,15 @@ function CanastaPageContent() {
   const isRoundEnd = state?.phase === CanastaPhase.ROUND_END;
   const isGameEnd = state?.phase === CanastaPhase.GAME_END || !!state?.gameEndFlag;
 
+  const drawDiscardReason = useMemo(() => {
+    if (!isDrawPhase) return '';
+    const n = selectedCardIndices.length;
+    if (n === 0) return state?.isFrozen ? t('drawDiscardReason.frozen') : t('drawDiscardReason.selectTwo');
+    if (n === 1) return t('drawDiscardReason.selectOneMore');
+    if (n > 2) return t('drawDiscardReason.tooMany');
+    return '';
+  }, [isDrawPhase, selectedCardIndices.length, state?.isFrozen, t]);
+
   const handleManualReset = useCallback(() => {
     hideActionLog();
     void gameExec('reset', undefined, {
@@ -211,9 +220,24 @@ function CanastaPageContent() {
               <div>
                 {/* Discard pile top */}
                 {state.discardTop && (
-                  <div className="my-3 p-3 rounded bg-black/40 flex items-center gap-3" data-tutorial="ca-draw-area">
+                  <div
+                    className={`my-3 p-3 rounded flex items-center gap-3 relative ${
+                      state.isFrozen ? 'bg-ds-info/20 ring-2 ring-ds-info' : 'bg-black/40'
+                    }`}
+                    data-tutorial="ca-draw-area"
+                    data-testid="ca-discard-pile"
+                  >
                     <AnimatedCard card={state.discardTop} width={cardWidth} />
                     <div className="text-ds-text-muted text-sm">{t('discardTop')}</div>
+                    {state.isFrozen && (
+                      <span
+                        className="absolute top-1 right-2 text-ds-info text-xs font-bold"
+                        data-testid="ca-frozen-badge"
+                        role="status"
+                      >
+                        {t('frozenIndicator')}
+                      </span>
+                    )}
                   </div>
                 )}
 
@@ -355,18 +379,31 @@ function CanastaPageContent() {
 
             <div className="flex gap-2 items-center flex-wrap" data-tutorial="ca-actions">
               {isDrawPhase && isHumanTurn && (
-                <div className="flex gap-2">
-                  <button type="button" className={btnPrimary} onClick={handleDrawStock} disabled={loading}>
-                    {t('drawStockButton')}
-                  </button>
-                  <button
-                    type="button"
-                    className={btnPrimary}
-                    onClick={handleDrawDiscard}
-                    disabled={loading || selectedCardIndices.length !== 2}
-                  >
-                    {t('drawDiscardButton')}
-                  </button>
+                <div className="flex gap-2 flex-col">
+                  <div className="flex gap-2">
+                    <button type="button" className={btnPrimary} onClick={handleDrawStock} disabled={loading}>
+                      {t('drawStockButton')}
+                    </button>
+                    <button
+                      type="button"
+                      className={btnPrimary}
+                      onClick={handleDrawDiscard}
+                      disabled={loading || selectedCardIndices.length !== 2}
+                      title={drawDiscardReason}
+                      aria-describedby="ca-draw-discard-reason"
+                    >
+                      {t('drawDiscardButton')}
+                    </button>
+                  </div>
+                  {drawDiscardReason && (
+                    <div
+                      id="ca-draw-discard-reason"
+                      data-testid="ca-draw-discard-reason"
+                      className="text-xs text-ds-text-muted"
+                    >
+                      {drawDiscardReason}
+                    </div>
+                  )}
                 </div>
               )}
               {isMeldPhase && isHumanTurn && (


### PR DESCRIPTION
## Summary
- Frozen badge (❄️ Frozen) + ring overlay on the discard pile when state.isFrozen
- Inline reason caption + native tooltip on the draw-from-discard button
- ja/en strings for selectTwo / frozen / selectOneMore / tooMany reasons

Closes #1875

## Test plan
- [x] CanastaPage test: disabled reason rendered when nothing selected
- [x] CanastaPage test: frozen badge + frozen reason rendered when isFrozen
- [x] Existing 11 CanastaPage tests still pass