### PR TITLE
feat(durak): stack attack/defense pairs and pulse undefended attacks

### DIFF
--- a/frontend/src/i18n/locales/en/durak.json
+++ b/frontend/src/i18n/locales/en/durak.json
@@ -15,6 +15,10 @@
   "stock": "Stock",
   "table": "Table",
   "tableEmpty": "(empty)",
+  "pair": {
+    "undefendedAria": "Undefended attack card ({{rank}})",
+    "defendedAria": "Defended pair"
+  },
   "attackButton": "Attack",
   "defendButton": "Defend",
   "passButton": "Pass",

--- a/frontend/src/i18n/locales/en/durak.json
+++ b/frontend/src/i18n/locales/en/durak.json
@@ -16,8 +16,8 @@
   "table": "Table",
   "tableEmpty": "(empty)",
   "pair": {
-    "undefendedAria": "Undefended attack card ({{rank}})",
-    "defendedAria": "Defended pair"
+    "undefendedAria": "Undefended attack: {{card}}",
+    "defendedAria": "Defended pair: {{attack}} defended by {{defense}}"
   },
   "attackButton": "Attack",
   "defendButton": "Defend",

--- a/frontend/src/i18n/locales/ja/durak.json
+++ b/frontend/src/i18n/locales/ja/durak.json
@@ -16,8 +16,8 @@
   "table": "テーブル",
   "tableEmpty": "（空）",
   "pair": {
-    "undefendedAria": "未防御の攻撃カード ({{rank}})",
-    "defendedAria": "防御済みのペア"
+    "undefendedAria": "未防御の攻撃: {{card}}",
+    "defendedAria": "防御済みペア: {{attack}} を {{defense}} で防御"
   },
   "attackButton": "攻撃",
   "defendButton": "防御",

--- a/frontend/src/i18n/locales/ja/durak.json
+++ b/frontend/src/i18n/locales/ja/durak.json
@@ -15,6 +15,10 @@
   "stock": "山札",
   "table": "テーブル",
   "tableEmpty": "（空）",
+  "pair": {
+    "undefendedAria": "未防御の攻撃カード ({{rank}})",
+    "defendedAria": "防御済みのペア"
+  },
   "attackButton": "攻撃",
   "defendButton": "防御",
   "passButton": "パス",

--- a/frontend/src/pages/DurakPage.test.tsx
+++ b/frontend/src/pages/DurakPage.test.tsx
@@ -234,6 +234,30 @@ describe('DurakPage', () => {
     await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
   });
 
+  it('marks an undefended attack and pulses when human is defender', async () => {
+    mockExec.mockResolvedValue(defendPhaseState);
+    renderWithProviders(<DurakPage />);
+    await waitFor(() => expect(screen.getByTestId('dk-pair-0')).toBeInTheDocument());
+    const attack = screen.getByTestId('dk-attack-0');
+    expect(attack).toHaveAttribute('data-undefended', 'true');
+    expect(attack.className).toContain('animate-pulse');
+    expect(screen.queryByTestId('dk-defense-0')).not.toBeInTheDocument();
+  });
+
+  it('renders a stacked defense card and no pulse when the pair is defended', async () => {
+    mockExec.mockResolvedValue({
+      ...defendPhaseState,
+      defenderIdx: 1,
+      tablePairs: [{ attack: { design: 'CLOVER', value: 7 }, defense: { design: 'HEART', value: 9 } }],
+    });
+    renderWithProviders(<DurakPage />);
+    await waitFor(() => expect(screen.getByTestId('dk-pair-0')).toBeInTheDocument());
+    expect(screen.getByTestId('dk-defense-0')).toBeInTheDocument();
+    const attack = screen.getByTestId('dk-attack-0');
+    expect(attack).toHaveAttribute('data-undefended', 'false');
+    expect(attack.className).not.toContain('animate-pulse');
+  });
+
   it('shows 次のゲーム at game-end and fires reset directly (no confirm)', async () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<DurakPage />);

--- a/frontend/src/pages/DurakPage.test.tsx
+++ b/frontend/src/pages/DurakPage.test.tsx
@@ -242,6 +242,21 @@ describe('DurakPage', () => {
     expect(attack).toHaveAttribute('data-undefended', 'true');
     expect(attack.className).toContain('animate-pulse');
     expect(screen.queryByTestId('dk-defense-0')).not.toBeInTheDocument();
+    // ARIA label includes suit + rank so screen readers convey "Undefended attack: ♣ 7".
+    expect(screen.getByTestId('dk-pair-0')).toHaveAttribute('aria-label', '未防御の攻撃: ♣ 7');
+  });
+
+  it('does not pulse an undefended attack when the human is not the defender', async () => {
+    // baseState: human is attacker (defenderIdx=1), so undefended attacks should NOT pulse.
+    mockExec.mockResolvedValue({
+      ...baseState,
+      tablePairs: [{ attack: { design: 'CLOVER', value: 7 }, defense: null }],
+    });
+    renderWithProviders(<DurakPage />);
+    await waitFor(() => expect(screen.getByTestId('dk-attack-0')).toBeInTheDocument());
+    const attack = screen.getByTestId('dk-attack-0');
+    expect(attack).toHaveAttribute('data-undefended', 'true');
+    expect(attack.className).not.toContain('animate-pulse');
   });
 
   it('renders a stacked defense card and no pulse when the pair is defended', async () => {
@@ -256,6 +271,8 @@ describe('DurakPage', () => {
     const attack = screen.getByTestId('dk-attack-0');
     expect(attack).toHaveAttribute('data-undefended', 'false');
     expect(attack.className).not.toContain('animate-pulse');
+    // Defended ARIA label names both attack and defense cards.
+    expect(screen.getByTestId('dk-pair-0')).toHaveAttribute('aria-label', '防御済みペア: ♣ 7 を ♥ 9 で防御');
   });
 
   it('shows 次のゲーム at game-end and fires reset directly (no confirm)', async () => {

--- a/frontend/src/pages/DurakPage.tsx
+++ b/frontend/src/pages/DurakPage.tsx
@@ -24,6 +24,7 @@ import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { DurakResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 
@@ -31,6 +32,8 @@ import { playerName } from '../utils/playerUtils';
 const PHASE_ATTACK = 0;
 const PHASE_DEFEND = 1;
 const PHASE_BOUT_END = 2;
+/** Total horizontal/vertical padding on each pair button (p-1 = 4px × 2 sides). */
+const DK_PAIR_PADDING = 8;
 
 const theme = gameTheme.durak;
 
@@ -259,6 +262,12 @@ function DurakPageContent() {
                         const offset = pairCardWidth * 0.3;
                         const undefended = pair.defense === null;
                         const shouldPulse = undefended && isDefender;
+                        const ariaLabel = undefended
+                          ? t('pair.undefendedAria', { card: cardAlt(pair.attack) })
+                          : t('pair.defendedAria', {
+                              attack: cardAlt(pair.attack),
+                              defense: pair.defense ? cardAlt(pair.defense) : '',
+                            });
                         return (
                           <button
                             type="button"
@@ -267,16 +276,12 @@ function DurakPageContent() {
                               selectedAttackIdx === i ? 'ring-2 ring-ds-warning' : ''
                             }`}
                             style={{
-                              width: pairCardWidth + offset + 8,
-                              height: pairCardWidth * 1.4 + offset + 8,
+                              width: pairCardWidth + offset + DK_PAIR_PADDING,
+                              height: pairCardWidth * 1.4 + offset + DK_PAIR_PADDING,
                             }}
                             onClick={() => setSelectedAttackIdx(selectedAttackIdx === i ? null : i)}
                             data-testid={`dk-pair-${i}`}
-                            aria-label={
-                              undefended
-                                ? t('pair.undefendedAria', { rank: pair.attack.value })
-                                : t('pair.defendedAria')
-                            }
+                            aria-label={ariaLabel}
                           >
                             <div
                               className={`absolute top-0 left-0 rounded ${

--- a/frontend/src/pages/DurakPage.tsx
+++ b/frontend/src/pages/DurakPage.tsx
@@ -253,27 +253,52 @@ function DurakPageContent() {
                   {state.tablePairs.length === 0 ? (
                     <div className="text-game-text-muted text-sm">{t('tableEmpty')}</div>
                   ) : (
-                    <div className="flex flex-wrap gap-2">
-                      {state.tablePairs.map((pair, i) => (
-                        <button
-                          type="button"
-                          key={`pair-${pair.attack.design}-${pair.attack.value}-${i}`}
-                          className={`flex flex-col items-center gap-0.5 p-1 rounded cursor-pointer ${
-                            selectedAttackIdx === i ? 'ring-2 ring-ds-warning' : ''
-                          }`}
-                          onClick={() => setSelectedAttackIdx(selectedAttackIdx === i ? null : i)}
-                        >
-                          <AnimatedCard card={pair.attack} width={cardWidth * 0.8} />
-                          {pair.defense ? (
-                            <AnimatedCard card={pair.defense} width={cardWidth * 0.8} />
-                          ) : (
+                    <div className="flex flex-wrap gap-3">
+                      {state.tablePairs.map((pair, i) => {
+                        const pairCardWidth = cardWidth * 0.8;
+                        const offset = pairCardWidth * 0.3;
+                        const undefended = pair.defense === null;
+                        const shouldPulse = undefended && isDefender;
+                        return (
+                          <button
+                            type="button"
+                            key={`pair-${pair.attack.design}-${pair.attack.value}-${i}`}
+                            className={`relative p-1 rounded cursor-pointer ${
+                              selectedAttackIdx === i ? 'ring-2 ring-ds-warning' : ''
+                            }`}
+                            style={{
+                              width: pairCardWidth + offset + 8,
+                              height: pairCardWidth * 1.4 + offset + 8,
+                            }}
+                            onClick={() => setSelectedAttackIdx(selectedAttackIdx === i ? null : i)}
+                            data-testid={`dk-pair-${i}`}
+                            aria-label={
+                              undefended
+                                ? t('pair.undefendedAria', { rank: pair.attack.value })
+                                : t('pair.defendedAria')
+                            }
+                          >
                             <div
-                              className="border border-dashed border-white/30 rounded"
-                              style={{ width: cardWidth * 0.8, height: cardWidth * 0.8 * 1.4 }}
-                            />
-                          )}
-                        </button>
-                      ))}
+                              className={`absolute top-0 left-0 rounded ${
+                                shouldPulse ? 'motion-safe:animate-pulse ring-2 ring-ds-error' : ''
+                              }`}
+                              data-testid={`dk-attack-${i}`}
+                              data-undefended={undefended ? 'true' : 'false'}
+                            >
+                              <AnimatedCard card={pair.attack} width={pairCardWidth} />
+                            </div>
+                            {pair.defense ? (
+                              <div
+                                className="absolute rounded shadow-md"
+                                style={{ top: offset, left: offset }}
+                                data-testid={`dk-defense-${i}`}
+                              >
+                                <AnimatedCard card={pair.defense} width={pairCardWidth} />
+                              </div>
+                            ) : null}
+                          </button>
+                        );
+                      })}
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- Each table pair now renders as an overlapping stack (defense shifted right+down) instead of column layout
- Undefended attack cards pulse with a red ring while the human is the defender
- ARIA labels distinguish defended vs undefended pairs

Closes #1876

## Test plan
- [x] DurakPage test: undefended pair pulses and exposes data-undefended=true
- [x] DurakPage test: defended pair renders the defense card and no pulse
- [x] Existing 21 DurakPage tests still pass