### PR TITLE
feat(pinochle): persistent meld-card badge on hand cards

### DIFF
--- a/frontend/src/pages/PinochlePage.test.tsx
+++ b/frontend/src/pages/PinochlePage.test.tsx
@@ -252,6 +252,46 @@ describe('PinochlePage', () => {
     expect(screen.getByLabelText('♥ K')).not.toHaveAttribute('data-meld-highlighted');
   });
 
+  it('renders a persistent meld-card badge ("M") on every card that scored in a meld', async () => {
+    const meldStateWithHumanMeld: PinochleResponse = {
+      ...meldPhaseState,
+      players: makePlayers([
+        {
+          id: 0,
+          isHuman: true,
+          cardCount: 3,
+          cards: [
+            { design: 'HEART', value: 13 },
+            { design: 'HEART', value: 12 },
+            { design: 'SPADE', value: 1 },
+          ],
+        },
+      ]),
+      playerMelds: [
+        [
+          {
+            type: 1,
+            points: 20,
+            cards: [
+              { design: 'HEART', value: 13 },
+              { design: 'HEART', value: 12 },
+            ],
+          },
+        ],
+        [],
+        [],
+        [],
+      ],
+    };
+    mockExec.mockResolvedValue(meldStateWithHumanMeld);
+    renderWithProviders(<PinochlePage />);
+    await waitFor(() => expect(screen.getByTestId('pn-meld-card-badge-0')).toBeInTheDocument());
+    expect(screen.getByTestId('pn-meld-card-badge-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('pn-meld-card-badge-2')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('♥ K')).toHaveAttribute('data-in-meld', 'true');
+    expect(screen.getByLabelText('♠ A')).not.toHaveAttribute('data-in-meld');
+  });
+
   it('renders play phase with human cards', async () => {
     mockExec.mockResolvedValue(playPhaseState);
     renderWithProviders(<PinochlePage />);

--- a/frontend/src/pages/PinochlePage.test.tsx
+++ b/frontend/src/pages/PinochlePage.test.tsx
@@ -292,6 +292,47 @@ describe('PinochlePage', () => {
     expect(screen.getByLabelText('♠ A')).not.toHaveAttribute('data-in-meld');
   });
 
+  it('keeps the meld-card badge visible in PLAY phase so users do not discard meld components', async () => {
+    const playStateWithHumanMeld: PinochleResponse = {
+      ...playPhaseState,
+      players: makePlayers([
+        {
+          id: 0,
+          isHuman: true,
+          cardCount: 3,
+          cards: [
+            { design: 'HEART', value: 13 },
+            { design: 'HEART', value: 12 },
+            { design: 'SPADE', value: 1 },
+          ],
+        },
+      ]),
+      validPlayIndices: [0, 1, 2],
+      playerMelds: [
+        [
+          {
+            type: 1,
+            points: 20,
+            cards: [
+              { design: 'HEART', value: 13 },
+              { design: 'HEART', value: 12 },
+            ],
+          },
+        ],
+        [],
+        [],
+        [],
+      ],
+    };
+    mockExec.mockResolvedValue(playStateWithHumanMeld);
+    renderWithProviders(<PinochlePage />);
+    await waitFor(() => expect(screen.getByTestId('pn-meld-card-badge-0')).toBeInTheDocument());
+    expect(screen.getByTestId('pn-meld-card-badge-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('pn-meld-card-badge-2')).not.toBeInTheDocument();
+    // Tooltip carries the localized meld type for the components.
+    expect(screen.getByLabelText('♥ K')).toHaveAttribute('title', 'コモンマリッジ');
+  });
+
   it('renders play phase with human cards', async () => {
     mockExec.mockResolvedValue(playPhaseState);
     renderWithProviders(<PinochlePage />);

--- a/frontend/src/pages/PinochlePage.tsx
+++ b/frontend/src/pages/PinochlePage.tsx
@@ -178,6 +178,29 @@ function PinochlePageContent() {
     return new Set<string>(meld.cards.map((c) => `${c.design}-${c.value}`));
   }, [state, highlightedMeldIdx]);
 
+  // Map from card key to the meld type numbers it participates in (for the human player).
+  // Used to render a persistent "M" badge across MELD and PLAY phases so the user remembers
+  // which cards are scored.
+  const cardKeyToMeldTypes = useMemo(() => {
+    const out = new Map<string, number[]>();
+    if (!state) return out;
+    const humanIdxLocal = state.players.findIndex((p) => p.isHuman);
+    const myMelds = humanIdxLocal >= 0 ? state.playerMelds?.[humanIdxLocal] : null;
+    if (!myMelds) return out;
+    for (const m of myMelds) {
+      for (const c of m.cards) {
+        const key = `${c.design}-${c.value}`;
+        const existing = out.get(key);
+        if (existing) {
+          if (!existing.includes(m.type)) existing.push(m.type);
+        } else {
+          out.set(key, [m.type]);
+        }
+      }
+    }
+    return out;
+  }, [state]);
+
   if (!state) {
     return (
       <div className="p-4 text-center text-ds-text-primary">
@@ -362,7 +385,11 @@ function PinochlePageContent() {
               <div className="flex flex-wrap gap-1 mb-2" data-tutorial="pn-player-hand">
                 {humanPlayer.cards.map((card, idx) => {
                   const isValid = state.validPlayIndices?.includes(idx);
-                  const inHighlightedMeld = highlightedCardKeys.has(`${card.design}-${card.value}`);
+                  const cardKey = `${card.design}-${card.value}`;
+                  const inHighlightedMeld = highlightedCardKeys.has(cardKey);
+                  const meldTypes = cardKeyToMeldTypes.get(cardKey);
+                  const isInMeld = meldTypes !== undefined && meldTypes.length > 0;
+                  const meldTitle = isInMeld ? meldTypes.map((mt) => t(`meldTypes.${mt}`)).join(', ') : undefined;
                   return (
                     <button
                       type="button"
@@ -371,7 +398,9 @@ function PinochlePageContent() {
                       disabled={loading || !isPlayTurn || !isValid}
                       aria-label={cardAlt(card)}
                       data-meld-highlighted={inHighlightedMeld ? 'true' : undefined}
-                      className={`transition${inHighlightedMeld ? ' ring-4 ring-ds-accent' : ''}`}
+                      data-in-meld={isInMeld ? 'true' : undefined}
+                      title={meldTitle}
+                      className={`relative transition${inHighlightedMeld ? ' ring-4 ring-ds-accent' : ''}`}
                       style={{
                         background: 'none',
                         padding: 0,
@@ -381,6 +410,15 @@ function PinochlePageContent() {
                       }}
                     >
                       <AnimatedCard card={card} width={cardWidth} />
+                      {isInMeld && (
+                        <span
+                          aria-hidden="true"
+                          className="absolute top-0.5 right-0.5 px-1 rounded-full bg-ds-accent text-ds-text-on-accent text-[10px] font-bold shadow-sm pointer-events-none"
+                          data-testid={`pn-meld-card-badge-${idx}`}
+                        >
+                          M
+                        </span>
+                      )}
                     </button>
                   );
                 })}

--- a/frontend/src/pages/PinochlePage.tsx
+++ b/frontend/src/pages/PinochlePage.tsx
@@ -178,28 +178,33 @@ function PinochlePageContent() {
     return new Set<string>(meld.cards.map((c) => `${c.design}-${c.value}`));
   }, [state, highlightedMeldIdx]);
 
-  // Map from card key to the meld type numbers it participates in (for the human player).
-  // Used to render a persistent "M" badge across MELD and PLAY phases so the user remembers
-  // which cards are scored.
-  const cardKeyToMeldTypes = useMemo(() => {
-    const out = new Map<string, number[]>();
-    if (!state) return out;
-    const humanIdxLocal = state.players.findIndex((p) => p.isHuman);
-    const myMelds = humanIdxLocal >= 0 ? state.playerMelds?.[humanIdxLocal] : null;
+  // Precompute the localized meld-list tooltip per card key so the badge render doesn't
+  // re-translate + join on every parent re-render (e.g., bid-amount edits).
+  const cardKeyToMeldTitle = useMemo(() => {
+    const out = new Map<string, string>();
+    const players = state?.players;
+    const playerMelds = state?.playerMelds;
+    if (!players || !playerMelds) return out;
+    const humanIdxLocal = players.findIndex((p) => p.isHuman);
+    const myMelds = humanIdxLocal >= 0 ? playerMelds[humanIdxLocal] : null;
     if (!myMelds) return out;
+    const cardKeyToTypes = new Map<string, number[]>();
     for (const m of myMelds) {
       for (const c of m.cards) {
         const key = `${c.design}-${c.value}`;
-        const existing = out.get(key);
+        const existing = cardKeyToTypes.get(key);
         if (existing) {
           if (!existing.includes(m.type)) existing.push(m.type);
         } else {
-          out.set(key, [m.type]);
+          cardKeyToTypes.set(key, [m.type]);
         }
       }
     }
+    for (const [key, types] of cardKeyToTypes) {
+      out.set(key, types.map((mt) => t(`meldTypes.${mt}`)).join(', '));
+    }
     return out;
-  }, [state]);
+  }, [state?.players, state?.playerMelds, t]);
 
   if (!state) {
     return (
@@ -387,9 +392,8 @@ function PinochlePageContent() {
                   const isValid = state.validPlayIndices?.includes(idx);
                   const cardKey = `${card.design}-${card.value}`;
                   const inHighlightedMeld = highlightedCardKeys.has(cardKey);
-                  const meldTypes = cardKeyToMeldTypes.get(cardKey);
-                  const isInMeld = meldTypes !== undefined && meldTypes.length > 0;
-                  const meldTitle = isInMeld ? meldTypes.map((mt) => t(`meldTypes.${mt}`)).join(', ') : undefined;
+                  const meldTitle = cardKeyToMeldTitle.get(cardKey);
+                  const isInMeld = meldTitle !== undefined;
                   return (
                     <button
                       type="button"


### PR DESCRIPTION
## Summary
- Every hand card belonging to a human-player meld gets a small "M" badge
- Tooltip on the card lists the localized meld type names (Common Marriage, Pinochle, Run, ...)
- Badge persists from MELD into PLAY/ROUND_END so users don't accidentally discard a meld-component

Closes #1877

## Test plan
- [x] PinochlePage test: meld cards get the M badge, unrelated cards do not
- [x] Existing 24 PinochlePage tests still pass