### PR TITLE
feat(contractrummy): real-time slot validation feedback

### DIFF
--- a/frontend/src/pages/ContractRummyPage.test.tsx
+++ b/frontend/src/pages/ContractRummyPage.test.tsx
@@ -238,6 +238,47 @@ describe('ContractRummyPage', () => {
     expect(screen.getByRole('button', { name: /Lay off|レイオフ/ })).toBeInTheDocument();
   });
 
+  it('shows per-slot progress and only enables Submit when both slots satisfy their contract', async () => {
+    mockExec.mockResolvedValue(playState);
+    renderWithProviders(<ContractRummyPage />);
+    await waitFor(() => expect(screen.getByTestId('cr-slot-progress')).toBeInTheDocument());
+    // Both slots start empty.
+    expect(screen.getByTestId('cr-slot-progress-0')).toHaveAttribute('data-state', 'empty');
+    expect(screen.getByTestId('cr-slot-progress-1')).toHaveAttribute('data-state', 'empty');
+    expect(screen.getByTestId('cr-submit-contract')).toBeDisabled();
+
+    // Fill slot 0 with the three 5s — valid set.
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.querySelector('img'));
+    fireEvent.click(cardButtons[0]);
+    fireEvent.click(cardButtons[1]);
+    fireEvent.click(cardButtons[2]);
+    fireEvent.click(screen.getByRole('button', { name: /Add to slot|スロットに追加/ }));
+    await waitFor(() => expect(screen.getByTestId('cr-slot-progress-0')).toHaveAttribute('data-state', 'satisfied'));
+    expect(screen.getByTestId('cr-submit-contract')).toBeDisabled();
+
+    // Fill slot 1 with the three Ks — valid set.
+    fireEvent.click(cardButtons[3]);
+    fireEvent.click(cardButtons[4]);
+    fireEvent.click(cardButtons[5]);
+    fireEvent.click(screen.getByRole('button', { name: /Add to slot|スロットに追加/ }));
+    await waitFor(() => expect(screen.getByTestId('cr-slot-progress-1')).toHaveAttribute('data-state', 'satisfied'));
+    expect(screen.getByTestId('cr-submit-contract')).not.toBeDisabled();
+  });
+
+  it('flags an invalid set as invalid in the slot progress chip', async () => {
+    mockExec.mockResolvedValue(playState);
+    renderWithProviders(<ContractRummyPage />);
+    await waitFor(() => expect(screen.getByTestId('cr-slot-progress-0')).toBeInTheDocument());
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.querySelector('img'));
+    // Three mismatched ranks (5, K, 2) — not a valid set.
+    fireEvent.click(cardButtons[0]);
+    fireEvent.click(cardButtons[3]);
+    fireEvent.click(cardButtons[6]);
+    fireEvent.click(screen.getByRole('button', { name: /Add to slot|スロットに追加/ }));
+    await waitFor(() => expect(screen.getByTestId('cr-slot-progress-0')).toHaveAttribute('data-state', 'invalid'));
+    expect(screen.getByTestId('cr-submit-contract')).toBeDisabled();
+  });
+
   it('shows winner banner at game end', async () => {
     const endState: ContractRummyResponse = {
       ...drawState,

--- a/frontend/src/pages/ContractRummyPage.tsx
+++ b/frontend/src/pages/ContractRummyPage.tsx
@@ -18,6 +18,7 @@ import { btnDanger, btnOutline, btnPrimary, focusRingWhite } from '../styles/but
 import { gameTheme } from '../styles/gameTheme';
 import type { Card, ContractRummyContractSlot, ContractRummyResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
+import { evaluateContractSlot } from '../utils/contractRummyUtils';
 
 /** Phase identifiers for Contract Rummy. */
 const CR_PHASE = {
@@ -167,6 +168,23 @@ function ContractRummyPageContent() {
     return phaseNames[state.phase] ?? '';
   }, [phaseNames, state]);
 
+  // Per-slot evaluation against the required contract — drives the in-progress feedback
+  // (placed / required, color, satisfied?) and gates the submit button so the player
+  // can't fire an obviously invalid request.
+  const slotEvaluations = useMemo(() => {
+    if (!state || !humanPlayer) return [];
+    return state.contractSlots.map((slot, slotIdx) => {
+      const cardIdxs = contractSlots[slotIdx] ?? [];
+      const cards = cardIdxs.map((i) => humanPlayer.cards[i]).filter(Boolean);
+      return evaluateContractSlot(slot, cards);
+    });
+  }, [state, humanPlayer, contractSlots]);
+
+  const allSlotsSatisfied =
+    state !== null &&
+    slotEvaluations.length === state.contractSlots.length &&
+    slotEvaluations.every((ev) => ev.satisfied);
+
   if (!state) {
     return (
       <GameSkeleton
@@ -207,6 +225,31 @@ function ContractRummyPageContent() {
           </span>
         )}
       </section>
+
+      {isPlayPhase && humanPlayer && !humanPlayer.contractMet && state.contractSlots.length > 0 && (
+        <section className="px-4 py-2 flex flex-wrap gap-2 text-sm" data-testid="cr-slot-progress">
+          {state.contractSlots.map((slot, slotIdx) => {
+            const ev = slotEvaluations[slotIdx] ?? { placed: 0, required: slot.size, satisfied: false, invalid: false };
+            const color = ev.satisfied
+              ? 'bg-ds-success/20 border-ds-success text-ds-success'
+              : ev.invalid
+                ? 'bg-ds-error/20 border-ds-error text-ds-error'
+                : ev.placed === 0
+                  ? 'bg-black/20 border-white/30 text-ds-text-muted'
+                  : 'bg-ds-warning/20 border-ds-warning text-ds-warning';
+            return (
+              <span
+                key={`slot-${slotIdx}`}
+                className={`px-2 py-1 rounded border ${color}`}
+                data-testid={`cr-slot-progress-${slotIdx}`}
+                data-state={ev.satisfied ? 'satisfied' : ev.invalid ? 'invalid' : ev.placed === 0 ? 'empty' : 'partial'}
+              >
+                {formatSlot(slot, t)} ({ev.placed}/{ev.required}){ev.satisfied ? ' ✓' : ''}
+              </span>
+            );
+          })}
+        </section>
+      )}
 
       <section className="px-4 py-2 grid gap-2 md:grid-cols-3">
         {state.players.map((p) => (
@@ -315,8 +358,9 @@ function ContractRummyPageContent() {
             <button
               type="button"
               onClick={handleSubmitContract}
-              disabled={contractSlots.length !== state.contractSlots.length}
-              className={btnPrimary}
+              disabled={!allSlotsSatisfied}
+              className={`${btnPrimary} ${allSlotsSatisfied ? 'motion-safe:animate-pulse' : ''}`}
+              data-testid="cr-submit-contract"
             >
               {t('submitContract')}
             </button>

--- a/frontend/src/pages/ContractRummyPage.tsx
+++ b/frontend/src/pages/ContractRummyPage.tsx
@@ -180,10 +180,11 @@ function ContractRummyPageContent() {
     });
   }, [state, humanPlayer, contractSlots]);
 
+  // humanPlayer gates slotEvaluations population, so checking it here keeps the
+  // intent obvious; the length>0 guard prevents `[].every(...)` from vacuously
+  // enabling submit on a contract with zero slots.
   const allSlotsSatisfied =
-    state !== null &&
-    slotEvaluations.length === state.contractSlots.length &&
-    slotEvaluations.every((ev) => ev.satisfied);
+    humanPlayer != null && slotEvaluations.length > 0 && slotEvaluations.every((ev) => ev.satisfied);
 
   if (!state) {
     return (

--- a/frontend/src/utils/contractRummyUtils.test.ts
+++ b/frontend/src/utils/contractRummyUtils.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import {
+  CONTRACT_SLOT_RUN,
+  CONTRACT_SLOT_SET,
+  evaluateContractSlot,
+  isContractRun,
+  isContractSet,
+} from './contractRummyUtils';
+
+const card = (design: string, value: number): Card => ({ design, value }) as Card;
+
+describe('isContractSet', () => {
+  it('returns true when all cards share the same rank', () => {
+    expect(isContractSet([card('SPADE', 7), card('HEART', 7), card('CLOVER', 7)])).toBe(true);
+  });
+
+  it('returns false when ranks differ', () => {
+    expect(isContractSet([card('SPADE', 7), card('HEART', 8)])).toBe(false);
+  });
+
+  it('returns false for a single card', () => {
+    expect(isContractSet([card('SPADE', 7)])).toBe(false);
+  });
+});
+
+describe('isContractRun', () => {
+  it('accepts an ace-low run', () => {
+    expect(isContractRun([card('SPADE', 1), card('SPADE', 2), card('SPADE', 3), card('SPADE', 4)])).toBe(true);
+  });
+
+  it('accepts an ace-high run (J-Q-K-A)', () => {
+    expect(isContractRun([card('SPADE', 11), card('SPADE', 12), card('SPADE', 13), card('SPADE', 1)])).toBe(true);
+  });
+
+  it('rejects mixed suits', () => {
+    expect(isContractRun([card('SPADE', 2), card('HEART', 3), card('SPADE', 4), card('SPADE', 5)])).toBe(false);
+  });
+
+  it('rejects non-consecutive values', () => {
+    expect(isContractRun([card('SPADE', 2), card('SPADE', 3), card('SPADE', 5), card('SPADE', 6)])).toBe(false);
+  });
+
+  it('rejects K-A-2 wrap-around', () => {
+    expect(isContractRun([card('SPADE', 13), card('SPADE', 1), card('SPADE', 2), card('SPADE', 3)])).toBe(false);
+  });
+
+  it('rejects duplicate ranks within the run', () => {
+    expect(isContractRun([card('SPADE', 2), card('SPADE', 3), card('SPADE', 3), card('SPADE', 4)])).toBe(false);
+  });
+});
+
+describe('evaluateContractSlot', () => {
+  it('returns an empty state when no cards have been placed', () => {
+    expect(evaluateContractSlot({ kind: CONTRACT_SLOT_SET, size: 3 }, [])).toEqual({
+      required: 3,
+      placed: 0,
+      satisfied: false,
+      invalid: false,
+    });
+  });
+
+  it('returns in-progress when fewer cards than required', () => {
+    const ev = evaluateContractSlot({ kind: CONTRACT_SLOT_SET, size: 3 }, [card('SPADE', 7)]);
+    expect(ev).toEqual({ required: 3, placed: 1, satisfied: false, invalid: false });
+  });
+
+  it('returns satisfied when a valid set fills the slot', () => {
+    const ev = evaluateContractSlot({ kind: CONTRACT_SLOT_SET, size: 3 }, [
+      card('SPADE', 7),
+      card('HEART', 7),
+      card('CLOVER', 7),
+    ]);
+    expect(ev.satisfied).toBe(true);
+    expect(ev.invalid).toBe(false);
+  });
+
+  it('flags invalid when filled with the wrong combination', () => {
+    const ev = evaluateContractSlot({ kind: CONTRACT_SLOT_SET, size: 3 }, [
+      card('SPADE', 7),
+      card('HEART', 8),
+      card('CLOVER', 7),
+    ]);
+    expect(ev.satisfied).toBe(false);
+    expect(ev.invalid).toBe(true);
+  });
+
+  it('returns satisfied for a valid run', () => {
+    const ev = evaluateContractSlot({ kind: CONTRACT_SLOT_RUN, size: 4 }, [
+      card('SPADE', 4),
+      card('SPADE', 5),
+      card('SPADE', 6),
+      card('SPADE', 7),
+    ]);
+    expect(ev.satisfied).toBe(true);
+  });
+
+  it('flags over-filled slots as invalid', () => {
+    const ev = evaluateContractSlot({ kind: CONTRACT_SLOT_SET, size: 3 }, [
+      card('SPADE', 7),
+      card('HEART', 7),
+      card('CLOVER', 7),
+      card('DIAMOND', 7),
+    ]);
+    expect(ev.invalid).toBe(true);
+    expect(ev.satisfied).toBe(false);
+  });
+});

--- a/frontend/src/utils/contractRummyUtils.test.ts
+++ b/frontend/src/utils/contractRummyUtils.test.ts
@@ -22,6 +22,10 @@ describe('isContractSet', () => {
   it('returns false for a single card', () => {
     expect(isContractSet([card('SPADE', 7)])).toBe(false);
   });
+
+  it('returns false for a 2-card pair (Contract Rummy sets require ≥3)', () => {
+    expect(isContractSet([card('SPADE', 7), card('HEART', 7)])).toBe(false);
+  });
 });
 
 describe('isContractRun', () => {

--- a/frontend/src/utils/contractRummyUtils.ts
+++ b/frontend/src/utils/contractRummyUtils.ts
@@ -1,0 +1,69 @@
+import type { Card, ContractRummyContractSlot } from '../types/card';
+
+/** Contract slot kind enum: 0 = set (same rank), 1 = run (same suit consecutive). */
+export const CONTRACT_SLOT_SET = 0;
+export const CONTRACT_SLOT_RUN = 1;
+
+/** Result of evaluating a single contract slot against the cards the player has placed into it. */
+export interface ContractSlotEvaluation {
+  /** Number of cards required. */
+  required: number;
+  /** Number of cards currently placed. */
+  placed: number;
+  /** True only when the count matches and the cards form a valid set/run. */
+  satisfied: boolean;
+  /** True when the count is correct but the combination is invalid (e.g. 3 cards but not the same rank). */
+  invalid: boolean;
+}
+
+/** Returns true iff every card has the same rank. */
+export function isContractSet(cards: Card[]): boolean {
+  if (cards.length < 2) return false;
+  const first = cards[0].value;
+  return cards.every((c) => c.value === first);
+}
+
+/** Returns true iff cards share a suit and form a consecutive run (Ace may be low or high). */
+export function isContractRun(cards: Card[]): boolean {
+  if (cards.length < 3) return false;
+  const suit = cards[0].design;
+  const values: number[] = [];
+  const seen = new Set<number>();
+  for (const c of cards) {
+    if (c.design !== suit) return false;
+    if (seen.has(c.value)) return false;
+    seen.add(c.value);
+    values.push(c.value);
+  }
+  const sortedLow = [...values].sort((a, b) => a - b);
+  if (isStrictlyConsecutive(sortedLow)) return true;
+  if (sortedLow[0] === 1) {
+    const high = [...sortedLow.slice(1), 14].sort((a, b) => a - b);
+    if (isStrictlyConsecutive(high)) return true;
+  }
+  return false;
+}
+
+function isStrictlyConsecutive(sorted: number[]): boolean {
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i] !== sorted[i - 1] + 1) return false;
+  }
+  return true;
+}
+
+/** Evaluate a single contract slot against the cards the player has placed into it. */
+export function evaluateContractSlot(slot: ContractRummyContractSlot, cards: Card[]): ContractSlotEvaluation {
+  const placed = cards.length;
+  const required = slot.size;
+  if (placed === 0) {
+    return { required, placed: 0, satisfied: false, invalid: false };
+  }
+  if (placed < required) {
+    return { required, placed, satisfied: false, invalid: false };
+  }
+  if (placed > required) {
+    return { required, placed, satisfied: false, invalid: true };
+  }
+  const ok = slot.kind === CONTRACT_SLOT_SET ? isContractSet(cards) : isContractRun(cards);
+  return { required, placed, satisfied: ok, invalid: !ok };
+}

--- a/frontend/src/utils/contractRummyUtils.ts
+++ b/frontend/src/utils/contractRummyUtils.ts
@@ -12,13 +12,13 @@ export interface ContractSlotEvaluation {
   placed: number;
   /** True only when the count matches and the cards form a valid set/run. */
   satisfied: boolean;
-  /** True when the count is correct but the combination is invalid (e.g. 3 cards but not the same rank). */
+  /** True when the cards do not form a valid set/run (wrong combination or too many cards). */
   invalid: boolean;
 }
 
-/** Returns true iff every card has the same rank. */
+/** Returns true iff cards share the same rank. Contract Rummy requires at least 3 cards. */
 export function isContractSet(cards: Card[]): boolean {
-  if (cards.length < 2) return false;
+  if (cards.length < 3) return false;
   const first = cards[0].value;
   return cards.every((c) => c.value === first);
 }
@@ -38,7 +38,9 @@ export function isContractRun(cards: Card[]): boolean {
   const sortedLow = [...values].sort((a, b) => a - b);
   if (isStrictlyConsecutive(sortedLow)) return true;
   if (sortedLow[0] === 1) {
-    const high = [...sortedLow.slice(1), 14].sort((a, b) => a - b);
+    // sortedLow without the leading Ace is already ascending, and 14 is the max possible
+    // value, so concatenating preserves order — no resort needed.
+    const high = [...sortedLow.slice(1), 14];
     if (isStrictlyConsecutive(high)) return true;
   }
   return false;


### PR DESCRIPTION
## Summary
- Per-slot progress chip ("Set of 3 (2/3)") recolors as the player builds each contract slot
- Submit button is gated on a frontend-side validation pass (set / run / ace-low / ace-high)
- New `contractRummyUtils.ts` with `evaluateContractSlot`, `isContractSet`, `isContractRun`

Closes #1879

## Test plan
- [x] 13 cases in contractRummyUtils.test.ts covering set/run/ace-low/ace-high/invalid combinations
- [x] ContractRummyPage test: progress chip transitions empty → satisfied
- [x] ContractRummyPage test: an invalid combination flags the chip and keeps Submit disabled
- [x] Existing 13 ContractRummyPage tests still pass