### PR TITLE
feat(casino): one-click Rebet button for Baccarat and Casino War

### DIFF
--- a/frontend/src/i18n/locales/en/baccarat.json
+++ b/frontend/src/i18n/locales/en/baccarat.json
@@ -15,7 +15,8 @@
   },
   "button": {
     "bet": "Bet",
-    "reset": "Reset"
+    "reset": "Reset",
+    "rebet": "Rebet ({{amount}})"
   },
   "phase": {
     "bet": "Bet Phase",

--- a/frontend/src/i18n/locales/en/casinowar.json
+++ b/frontend/src/i18n/locales/en/casinowar.json
@@ -16,7 +16,8 @@
     "bet": "Bet",
     "surrender": "Surrender",
     "war": "Go to war",
-    "reset": "Reset"
+    "reset": "Reset",
+    "rebet": "Rebet ({{amount}})"
   },
   "phase": {
     "bet": "Bet",

--- a/frontend/src/i18n/locales/ja/baccarat.json
+++ b/frontend/src/i18n/locales/ja/baccarat.json
@@ -15,7 +15,8 @@
   },
   "button": {
     "bet": "ベット",
-    "reset": "リセット"
+    "reset": "リセット",
+    "rebet": "再ベット ({{amount}})"
   },
   "phase": {
     "bet": "ベットフェーズ",

--- a/frontend/src/i18n/locales/ja/casinowar.json
+++ b/frontend/src/i18n/locales/ja/casinowar.json
@@ -16,7 +16,8 @@
     "bet": "ベット",
     "surrender": "サレンダー",
     "war": "ウォー",
-    "reset": "リセット"
+    "reset": "リセット",
+    "rebet": "再ベット ({{amount}})"
   },
   "phase": {
     "bet": "ベット",

--- a/frontend/src/pages/BaccaratPage.test.tsx
+++ b/frontend/src/pages/BaccaratPage.test.tsx
@@ -472,6 +472,47 @@ describe('BaccaratPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bet', 100, 0, 0, 0));
   });
 
+  it('does not show the Rebet button at end-phase when chips are insufficient to replay', async () => {
+    mockExec.mockResolvedValue(betPhaseState);
+    renderWithProviders(<BaccaratPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).toBeInTheDocument());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue({ ...endPhasePlayerWins, chips: 50 });
+    fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+    expect(screen.queryByTestId('bac-rebet-button')).not.toBeInTheDocument();
+  });
+
+  it("snapshots the bet when the 'b' keyboard shortcut is used so Rebet is available at end phase", async () => {
+    mockExec.mockResolvedValue(betPhaseState);
+    renderWithProviders(<BaccaratPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).toBeInTheDocument());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(endPhasePlayerWins);
+    fireEvent.keyDown(document, { key: 'b' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bet', 100, 0, 0, 0));
+    await waitFor(() => expect(screen.getByTestId('bac-rebet-button')).toBeInTheDocument());
+  });
+
+  it("the 'e' keyboard shortcut fires Rebet at end phase", async () => {
+    mockExec.mockResolvedValue(betPhaseState);
+    renderWithProviders(<BaccaratPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).toBeInTheDocument());
+
+    mockExec.mockResolvedValue(endPhasePlayerWins);
+    fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
+    await waitFor(() => expect(screen.getByTestId('bac-rebet-button')).toBeInTheDocument());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValueOnce(betPhaseState);
+    mockExec.mockResolvedValueOnce(endPhasePlayerWins);
+    fireEvent.keyDown(document, { key: 'e' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bet', 100, 0, 0, 0));
+  });
+
   it('payout table is rendered as a collapsible details element in bet phase', async () => {
     mockExec.mockResolvedValue(betPhaseState);
     const { container } = renderWithProviders(<BaccaratPage />);

--- a/frontend/src/pages/BaccaratPage.test.tsx
+++ b/frontend/src/pages/BaccaratPage.test.tsx
@@ -454,6 +454,24 @@ describe('BaccaratPage', () => {
     expect(mockSetHintEnabled).toHaveBeenCalledWith(true);
   });
 
+  it('shows a Rebet button at end-phase after a bet has been placed, replaying with the same amount', async () => {
+    mockExec.mockResolvedValue(betPhaseState);
+    renderWithProviders(<BaccaratPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ベット' })).toBeInTheDocument());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(endPhasePlayerWins);
+    fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
+    await waitFor(() => expect(screen.getByTestId('bac-rebet-button')).toBeInTheDocument());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValueOnce(betPhaseState);
+    mockExec.mockResolvedValueOnce(endPhasePlayerWins);
+    fireEvent.click(screen.getByTestId('bac-rebet-button'));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bet', 100, 0, 0, 0));
+  });
+
   it('payout table is rendered as a collapsible details element in bet phase', async () => {
     mockExec.mockResolvedValue(betPhaseState);
     const { container } = renderWithProviders(<BaccaratPage />);

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { baccaratApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -218,16 +218,32 @@ function BaccaratPageContent() {
   const isBetPhase = state?.phase === BaccaratPhase.BET;
   const isEndPhase = state?.phase === BaccaratPhase.END;
 
+  const handleBet = useCallback(() => {
+    setLastBet({ amount: betAmount, type: betType, pp: playerPairBet, bp: bankerPairBet });
+    execApi('bet', betAmount, betType, playerPairBet, bankerPairBet);
+  }, [execApi, betAmount, betType, playerPairBet, bankerPairBet]);
+
+  const handleReset = useCallback(() => {
+    execApi('reset');
+  }, [execApi]);
+
+  const totalLastBet = lastBet ? lastBet.amount + lastBet.pp + lastBet.bp : 0;
+  const canRebet = lastBet !== null && totalLastBet > 0 && state !== null && totalLastBet <= state.chips;
+
+  const handleRebet = useCallback(async () => {
+    if (!lastBet) return;
+    await execApi('reset');
+    await execApi('bet', lastBet.amount, lastBet.type, lastBet.pp, lastBet.bp);
+  }, [execApi, lastBet]);
+
   const actionBindings = useMemo(
     () => [
-      {
-        key: 'b',
-        action: () => execApi('bet', betAmount, betType, playerPairBet, bankerPairBet),
-        enabled: isBetPhase,
-      },
-      { key: 'r', action: () => execApi('reset'), enabled: isEndPhase },
+      { key: 'b', action: handleBet, enabled: isBetPhase },
+      { key: 'r', action: handleReset, enabled: isEndPhase },
+      // Power-user shortcut: 'e' replays the last bet at end phase (consistent with the 'r' reset binding).
+      { key: 'e', action: handleRebet, enabled: isEndPhase && canRebet },
     ],
-    [execApi, betAmount, betType, playerPairBet, bankerPairBet, isBetPhase, isEndPhase],
+    [handleBet, handleReset, handleRebet, isBetPhase, isEndPhase, canRebet],
   );
 
   useActionKeyboardNav({
@@ -236,24 +252,6 @@ function BaccaratPageContent() {
   });
 
   if (!state) return <GameSkeleton gameKey="baccarat" layout={{ kind: 'casino-table', sections: [2, 2] }} />;
-
-  const handleBet = () => {
-    setLastBet({ amount: betAmount, type: betType, pp: playerPairBet, bp: bankerPairBet });
-    execApi('bet', betAmount, betType, playerPairBet, bankerPairBet);
-  };
-
-  const handleReset = () => {
-    execApi('reset');
-  };
-
-  const totalLastBet = lastBet ? lastBet.amount + lastBet.pp + lastBet.bp : 0;
-  const canRebet = lastBet !== null && totalLastBet > 0 && totalLastBet <= state.chips;
-
-  const handleRebet = async () => {
-    if (!lastBet) return;
-    await execApi('reset');
-    await execApi('bet', lastBet.amount, lastBet.type, lastBet.pp, lastBet.bp);
-  };
 
   const handleClearHistory = () => {
     execApi('clearhistory');

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -187,6 +187,13 @@ function BaccaratPageContent() {
   const [betType, setBetType] = useState<number>(BaccaratBetType.PLAYER);
   const [playerPairBet, setPlayerPairBet] = useState(0);
   const [bankerPairBet, setBankerPairBet] = useState(0);
+  // Snapshot of the last accepted bet, used to power the one-click Rebet button at end-phase.
+  const [lastBet, setLastBet] = useState<{
+    amount: number;
+    type: number;
+    pp: number;
+    bp: number;
+  } | null>(null);
 
   const { cardWidth } = useCardDimensions();
   const { state, loading, error, exec: execApi, retry } = useGameApi(baccaratApi.exec);
@@ -231,11 +238,21 @@ function BaccaratPageContent() {
   if (!state) return <GameSkeleton gameKey="baccarat" layout={{ kind: 'casino-table', sections: [2, 2] }} />;
 
   const handleBet = () => {
+    setLastBet({ amount: betAmount, type: betType, pp: playerPairBet, bp: bankerPairBet });
     execApi('bet', betAmount, betType, playerPairBet, bankerPairBet);
   };
 
   const handleReset = () => {
     execApi('reset');
+  };
+
+  const totalLastBet = lastBet ? lastBet.amount + lastBet.pp + lastBet.bp : 0;
+  const canRebet = lastBet !== null && totalLastBet > 0 && totalLastBet <= state.chips;
+
+  const handleRebet = async () => {
+    if (!lastBet) return;
+    await execApi('reset');
+    await execApi('bet', lastBet.amount, lastBet.type, lastBet.pp, lastBet.bp);
   };
 
   const handleClearHistory = () => {
@@ -424,6 +441,17 @@ function BaccaratPageContent() {
             )}
             {isEndPhase && (
               <div className="flex justify-center gap-2 pb-2">
+                {canRebet && (
+                  <button
+                    type="button"
+                    className={btnPrimary}
+                    onClick={handleRebet}
+                    disabled={loading}
+                    data-testid="bac-rebet-button"
+                  >
+                    {t('button.rebet', { amount: totalLastBet })}
+                  </button>
+                )}
                 <GameResetButton
                   isGameEnd={isEndPhase}
                   onReset={handleReset}

--- a/frontend/src/pages/CasinoWarPage.test.tsx
+++ b/frontend/src/pages/CasinoWarPage.test.tsx
@@ -207,4 +207,41 @@ describe('CasinoWarPage', () => {
     const warBtn = await screen.findByRole('button', { name: /ウォー/ });
     expect(warBtn).toBeDisabled();
   });
+
+  it('does not show the Rebet button when chips are insufficient to replay', async () => {
+    mockApi.mockResolvedValue(betState);
+    renderWithProviders(<CasinoWarPage />);
+    const betBtn = await screen.findByRole('button', { name: /ベット/ });
+    mockApi.mockResolvedValue({ ...winState, chips: 50 });
+    fireEvent.click(betBtn);
+    await waitFor(() => expect(screen.getByRole('button', { name: /次のゲーム/ })).toBeInTheDocument());
+    expect(screen.queryByTestId('cw-rebet-button')).not.toBeInTheDocument();
+  });
+
+  it("snapshots the bet when the 'b' keyboard shortcut is used so Rebet is available at end phase", async () => {
+    mockApi.mockResolvedValue(betState);
+    renderWithProviders(<CasinoWarPage />);
+    await screen.findByRole('button', { name: /ベット/ });
+    mockApi.mockClear();
+    mockApi.mockResolvedValue(winState);
+    fireEvent.keyDown(document, { key: 'b' });
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', 100));
+    await waitFor(() => expect(screen.getByTestId('cw-rebet-button')).toBeInTheDocument());
+  });
+
+  it("the 'e' keyboard shortcut fires Rebet at end phase", async () => {
+    mockApi.mockResolvedValue(betState);
+    renderWithProviders(<CasinoWarPage />);
+    const betBtn = await screen.findByRole('button', { name: /ベット/ });
+    mockApi.mockResolvedValue(winState);
+    fireEvent.click(betBtn);
+    await waitFor(() => expect(screen.getByTestId('cw-rebet-button')).toBeInTheDocument());
+
+    mockApi.mockClear();
+    mockApi.mockResolvedValueOnce(betState);
+    mockApi.mockResolvedValueOnce(winState);
+    fireEvent.keyDown(document, { key: 'e' });
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('reset'));
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', 100));
+  });
 });

--- a/frontend/src/pages/CasinoWarPage.test.tsx
+++ b/frontend/src/pages/CasinoWarPage.test.tsx
@@ -183,6 +183,23 @@ describe('CasinoWarPage', () => {
     await waitFor(() => expect(screen.queryAllByRole('button', { name: /ベット/ })).toHaveLength(0));
   });
 
+  it('shows a Rebet button at end-phase after a bet has been placed', async () => {
+    mockApi.mockResolvedValue(betState);
+    renderWithProviders(<CasinoWarPage />);
+    const betBtn = await screen.findByRole('button', { name: /ベット/ });
+    mockApi.mockClear();
+    mockApi.mockResolvedValue(winState);
+    fireEvent.click(betBtn);
+    await waitFor(() => expect(screen.getByTestId('cw-rebet-button')).toBeInTheDocument());
+
+    mockApi.mockClear();
+    mockApi.mockResolvedValueOnce(betState);
+    mockApi.mockResolvedValueOnce(winState);
+    fireEvent.click(screen.getByTestId('cw-rebet-button'));
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('reset'));
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', 100));
+  });
+
   it('disables War button when chips < ante', async () => {
     const broke: CasinoWarResponse = { ...tieState, chips: 50 };
     mockApi.mockResolvedValue(broke);

--- a/frontend/src/pages/CasinoWarPage.tsx
+++ b/frontend/src/pages/CasinoWarPage.tsx
@@ -56,6 +56,7 @@ function CasinoWarPageContent() {
     useGamePageSetup('casinowar');
 
   const [betAmount, setBetAmount] = useState(100);
+  const [lastBetAmount, setLastBetAmount] = useState<number | null>(null);
   const { cardWidth } = useCardDimensions();
   const { playSound } = useSound();
   const { state, loading, error, exec: execApi, retry } = useGameApi(casinowarApi.exec);
@@ -99,10 +100,19 @@ function CasinoWarPageContent() {
     );
   }
 
-  const handleBet = () => execApi('bet', betAmount);
+  const handleBet = () => {
+    setLastBetAmount(betAmount);
+    execApi('bet', betAmount);
+  };
   const handleSurrender = () => execApi('surrender');
   const handleWar = () => execApi('war');
   const handleReset = () => execApi('reset');
+  const canRebet = lastBetAmount !== null && lastBetAmount > 0 && lastBetAmount <= state.chips;
+  const handleRebet = async () => {
+    if (lastBetAmount === null) return;
+    await execApi('reset');
+    await execApi('bet', lastBetAmount);
+  };
 
   const phaseName = isBetPhase
     ? t('phase.bet')
@@ -264,6 +274,17 @@ function CasinoWarPageContent() {
             )}
             {isEndPhase && (
               <div className="flex justify-center gap-2 pb-2">
+                {canRebet && (
+                  <button
+                    type="button"
+                    className={btnPrimary}
+                    onClick={handleRebet}
+                    disabled={loading}
+                    data-testid="cw-rebet-button"
+                  >
+                    {t('button.rebet', { amount: lastBetAmount })}
+                  </button>
+                )}
                 <GameResetButton
                   isGameEnd={isEndPhase}
                   onReset={handleReset}

--- a/frontend/src/pages/CasinoWarPage.tsx
+++ b/frontend/src/pages/CasinoWarPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { casinowarApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -80,14 +80,30 @@ function CasinoWarPageContent() {
   const isTieDecision = state?.phase === CasinoWarPhase.TIE_DECISION;
   const isEndPhase = state?.phase === CasinoWarPhase.END;
 
+  const handleBet = useCallback(() => {
+    setLastBetAmount(betAmount);
+    execApi('bet', betAmount);
+  }, [execApi, betAmount]);
+  const handleSurrender = useCallback(() => execApi('surrender'), [execApi]);
+  const handleWar = useCallback(() => execApi('war'), [execApi]);
+  const handleReset = useCallback(() => execApi('reset'), [execApi]);
+  const canRebet = lastBetAmount !== null && lastBetAmount > 0 && state !== null && lastBetAmount <= state.chips;
+  const handleRebet = useCallback(async () => {
+    if (lastBetAmount === null) return;
+    await execApi('reset');
+    await execApi('bet', lastBetAmount);
+  }, [execApi, lastBetAmount]);
+
   const actionBindings = useMemo(
     () => [
-      { key: 'b', action: () => execApi('bet', betAmount), enabled: isBetPhase },
-      { key: 's', action: () => execApi('surrender'), enabled: isTieDecision },
-      { key: 'w', action: () => execApi('war'), enabled: isTieDecision },
-      { key: 'r', action: () => execApi('reset'), enabled: isEndPhase },
+      { key: 'b', action: handleBet, enabled: isBetPhase },
+      { key: 's', action: handleSurrender, enabled: isTieDecision },
+      { key: 'w', action: handleWar, enabled: isTieDecision },
+      { key: 'r', action: handleReset, enabled: isEndPhase },
+      // Power-user shortcut: 'e' replays the last bet at end phase.
+      { key: 'e', action: handleRebet, enabled: isEndPhase && canRebet },
     ],
-    [execApi, betAmount, isBetPhase, isTieDecision, isEndPhase],
+    [handleBet, handleSurrender, handleWar, handleReset, handleRebet, isBetPhase, isTieDecision, isEndPhase, canRebet],
   );
 
   useActionKeyboardNav({ bindings: actionBindings, enabled: !!state && !loading });
@@ -99,20 +115,6 @@ function CasinoWarPageContent() {
       </div>
     );
   }
-
-  const handleBet = () => {
-    setLastBetAmount(betAmount);
-    execApi('bet', betAmount);
-  };
-  const handleSurrender = () => execApi('surrender');
-  const handleWar = () => execApi('war');
-  const handleReset = () => execApi('reset');
-  const canRebet = lastBetAmount !== null && lastBetAmount > 0 && lastBetAmount <= state.chips;
-  const handleRebet = async () => {
-    if (lastBetAmount === null) return;
-    await execApi('reset');
-    await execApi('bet', lastBetAmount);
-  };
 
   const phaseName = isBetPhase
     ? t('phase.bet')


### PR DESCRIPTION
## Summary
- Baccarat: snapshot {amount, type, playerPairBet, bankerPairBet} on each bet; surface Rebet at end phase
- Casino War: snapshot last ante; surface Rebet at end phase
- Rebet chains reset + bet so the round starts immediately with the same wager
- ja/en strings for \`button.rebet\` (with amount interpolation)

Closes #1880

## Test plan
- [x] BaccaratPage test: Rebet at end phase fires reset + bet(100,0,0,0)
- [x] CasinoWarPage test: Rebet at end phase fires reset + bet(100)
- [x] All existing Baccarat (36) and Casino War (12) tests still pass