### PR TITLE
feat(daifugo): recolor background while card-strength is inverted

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -37,6 +37,8 @@
   --color-game-bg-casino-dark: #0a3a10;
   --color-game-bg-blue: #1a2c5c;
   --color-game-bg-blue-dark: #101c3a;
+  --color-game-bg-revolution: #5a1717;
+  --color-game-bg-revolution-dark: #3c0f0f;
   /* Design system colors (from DESIGN.md) */
   --color-ds-bg: #0f1419;
   --color-ds-surface: #1a2332;

--- a/frontend/src/pages/DaifugoPage.test.tsx
+++ b/frontend/src/pages/DaifugoPage.test.tsx
@@ -423,6 +423,21 @@ describe('DaifugoPage', () => {
     await waitFor(() => expect(screen.getByText('11バック', { selector: 'button' })).toBeInTheDocument());
   });
 
+  it('switches the page background to the revolution palette when revolution is active', async () => {
+    mockExec.mockResolvedValue({ ...humanTurnState, revolutionActive: true });
+    const { container } = renderWithProviders(<DaifugoPage />);
+    await waitFor(() => expect(screen.getByText('革命中')).toBeInTheDocument());
+    expect(container.querySelector('.bg-game-bg-revolution')).toBeInTheDocument();
+    expect(container.querySelector('.bg-game-bg-green')).not.toBeInTheDocument();
+  });
+
+  it('keeps the default green background when neither inversion is active', async () => {
+    mockExec.mockResolvedValue(humanTurnState);
+    const { container } = renderWithProviders(<DaifugoPage />);
+    await waitFor(() => expect(container.querySelector('.bg-game-bg-green')).toBeInTheDocument());
+    expect(container.querySelector('.bg-game-bg-revolution')).not.toBeInTheDocument();
+  });
+
   it('shows suit lock badge when suitLocked is true', async () => {
     const suitLockedState: DaifugoResponse = {
       ...humanTurnState,

--- a/frontend/src/pages/DaifugoPage.test.tsx
+++ b/frontend/src/pages/DaifugoPage.test.tsx
@@ -429,6 +429,16 @@ describe('DaifugoPage', () => {
     await waitFor(() => expect(screen.getByText('革命中')).toBeInTheDocument());
     expect(container.querySelector('.bg-game-bg-revolution')).toBeInTheDocument();
     expect(container.querySelector('.bg-game-bg-green')).not.toBeInTheDocument();
+    // The footer should track the body palette so the page doesn't read as a green/crimson split.
+    expect(container.querySelector('.bg-game-bg-revolution-dark')).toBeInTheDocument();
+  });
+
+  it('switches the page background to the revolution palette when 11-back is active', async () => {
+    mockExec.mockResolvedValue({ ...humanTurnState, elevenBackActive: true });
+    const { container } = renderWithProviders(<DaifugoPage />);
+    await waitFor(() => expect(container.querySelector('.bg-game-bg-revolution')).toBeInTheDocument());
+    expect(container.querySelector('.bg-game-bg-revolution-dark')).toBeInTheDocument();
+    expect(container.querySelector('.bg-game-bg-green')).not.toBeInTheDocument();
   });
 
   it('keeps the default green background when neither inversion is active', async () => {
@@ -436,6 +446,7 @@ describe('DaifugoPage', () => {
     const { container } = renderWithProviders(<DaifugoPage />);
     await waitFor(() => expect(container.querySelector('.bg-game-bg-green')).toBeInTheDocument());
     expect(container.querySelector('.bg-game-bg-revolution')).not.toBeInTheDocument();
+    expect(container.querySelector('.bg-game-bg-revolution-dark')).not.toBeInTheDocument();
   });
 
   it('shows suit lock badge when suitLocked is true', async () => {

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -183,6 +183,11 @@ function DaifugoPageContent() {
   const cpuPlayers = state.players.filter((p) => !p.isHuman);
   const humanPlayer = state.players.find((p) => p.isHuman);
 
+  // When the strength order is inverted (revolution or eleven-back), recolor the page
+  // background so the player sees the rule change at a glance instead of reading the badge.
+  const inversionActive = state.revolutionActive || state.elevenBackActive;
+  const bgClass = inversionActive ? 'bg-game-bg-revolution' : gameTheme.daifugo.bg;
+
   let playButtonLabel = t('playButton');
   let pendingBanner: string | null = null;
   if (pendingAction === 'sevenPass') {
@@ -213,7 +218,7 @@ function DaifugoPageContent() {
   return (
     <GamePageShell
       title={tc('nav.daifugo')}
-      gameThemeBg={gameTheme.daifugo.bg}
+      gameThemeBg={`${bgClass} motion-safe:transition-colors motion-safe:duration-500`}
       phaseName={state.gameEndFlag ? t('phase.end') : t('phase.play')}
       isHumanTurn={isHumanTurn}
       gamePath="/daifugo"

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -187,6 +187,7 @@ function DaifugoPageContent() {
   // background so the player sees the rule change at a glance instead of reading the badge.
   const inversionActive = state.revolutionActive || state.elevenBackActive;
   const bgClass = inversionActive ? 'bg-game-bg-revolution' : gameTheme.daifugo.bg;
+  const footerClass = inversionActive ? 'bg-game-bg-revolution-dark border-white/20' : gameTheme.daifugo.footer;
 
   let playButtonLabel = t('playButton');
   let pendingBanner: string | null = null;
@@ -355,7 +356,7 @@ function DaifugoPageContent() {
             />
           </div>
 
-          <GameFooter className={`${gameTheme.daifugo.footer} px-4 py-2.5`}>
+          <GameFooter className={`${footerClass} px-4 py-2.5 motion-safe:transition-colors motion-safe:duration-500`}>
             <div className="text-center mb-1" data-tutorial="df-sort-buttons">
               {sortModes.map(({ mode, label }) => (
                 <button


### PR DESCRIPTION
## Summary
- Adds \`--color-game-bg-revolution\` (dark crimson) design token
- DaifugoPage swaps to that background when revolutionActive or elevenBackActive is true
- Smooth 500ms color transition signals the rule change at a glance

Closes #1881

## Test plan
- [x] DaifugoPage test: revolution swaps to bg-game-bg-revolution
- [x] DaifugoPage test: default green palette while neither inversion is active
- [x] Existing 93 DaifugoPage tests still pass