### PR TITLE
feat(videopoker): bolder HOLD badge + lock-in pulse for held cards

### DIFF
--- a/frontend/src/components/VideoPokerGameContent.test.tsx
+++ b/frontend/src/components/VideoPokerGameContent.test.tsx
@@ -266,6 +266,18 @@ describe('VideoPokerGameContent', () => {
     expect(cardButtons.every((b) => b.getAttribute('aria-pressed') === 'false')).toBe(true);
   });
 
+  it('renders the HOLD badge overlay only on held cards', async () => {
+    mockExec.mockResolvedValue(resultPhaseWin);
+    renderContent();
+    await waitFor(() => expect(screen.getByRole('button', { name: /次のゲーム/ })).toBeInTheDocument());
+    // resultPhaseWin holds card indices 0 and 1; 2-4 are not held.
+    expect(screen.getByTestId('vp-hold-badge-0')).toBeInTheDocument();
+    expect(screen.getByTestId('vp-hold-badge-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('vp-hold-badge-2')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('vp-hold-badge-3')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('vp-hold-badge-4')).not.toBeInTheDocument();
+  });
+
   it('renders accessible h1 heading', async () => {
     mockExec.mockResolvedValue(betPhaseState);
     renderContent();

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -231,13 +231,24 @@ export function VideoPokerGameContent({
                         type="button"
                         onClick={() => toggleHold(i)}
                         disabled={!isDrawPhase}
-                        className={`rounded transition-transform ${displayHeld[i] ? 'ring-2 ring-ds-warning -translate-y-2' : ''}`}
+                        className={`relative rounded transition-transform ${
+                          displayHeld[i] ? 'ring-4 ring-ds-warning -translate-y-2 motion-safe:animate-card-lock' : ''
+                        }`}
                         aria-label={displayHeld[i] ? `${tNs('hold')} ${i}` : tNs('card', { index: i })}
                         aria-pressed={displayHeld[i] ?? false}
+                        data-held={displayHeld[i] ? 'true' : undefined}
                       >
                         <AnimatedCard card={card} width={cardWidth} />
+                        {displayHeld[i] && (
+                          <span
+                            aria-hidden="true"
+                            className="absolute inset-x-0 bottom-1 mx-auto w-fit px-2 py-0.5 rounded bg-ds-warning text-ds-text-on-accent text-[10px] font-extrabold tracking-wider shadow-md pointer-events-none"
+                            data-testid={`vp-hold-badge-${i}`}
+                          >
+                            {tNs('hold')}
+                          </span>
+                        )}
                       </button>
-                      {displayHeld[i] && <span className="text-ds-warning text-xs font-bold mt-1">{tNs('hold')}</span>}
                     </div>
                   ))}
                 </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -230,6 +230,23 @@ input:not([type]):focus-visible {
   animation: flipIn 0.3s ease-out;
 }
 
+/* Brief "lock-in" pulse used when a Video Poker card is held. The scale dip
+   gives the card a tactile "click" the moment the HOLD ring appears. */
+@keyframes card-lock {
+  0% {
+    transform: translateY(-0.5rem) scale(1);
+  }
+  35% {
+    transform: translateY(-0.5rem) scale(0.94);
+  }
+  100% {
+    transform: translateY(-0.5rem) scale(1);
+  }
+}
+.animate-card-lock {
+  animation: card-lock 0.18s ease-out;
+}
+
 @keyframes sweat-drop {
   0% {
     opacity: 0.6;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -231,16 +231,17 @@ input:not([type]):focus-visible {
 }
 
 /* Brief "lock-in" pulse used when a Video Poker card is held. The scale dip
-   gives the card a tactile "click" the moment the HOLD ring appears. */
+   gives the card a tactile "click" the moment the HOLD ring appears.
+   Uses standalone `scale` (not transform: scale()) so the animation is additive:
+   Tailwind's -translate-y-2 transition still slides the card up smoothly while
+   this keyframe only controls the scale dip. */
 @keyframes card-lock {
-  0% {
-    transform: translateY(-0.5rem) scale(1);
+  0%,
+  100% {
+    scale: 1;
   }
   35% {
-    transform: translateY(-0.5rem) scale(0.94);
-  }
-  100% {
-    transform: translateY(-0.5rem) scale(1);
+    scale: 0.94;
   }
 }
 .animate-card-lock {


### PR DESCRIPTION
## Summary
- Replace the post-card "HOLD" caption with an in-card overlay badge (bold, tracking-wide, ds-warning bg)
- Add a 180ms 'card-lock' scale-dip animation that fires when a card becomes held — gives auto-hold a tactile feel
- Single change applies to Video Poker, Deuces Wild, and Joker Poker via the shared VideoPokerGameContent

Closes #1882

## Test plan
- [x] VideoPokerGameContent test: HOLD badges render only on held card indices
- [x] All existing 54 Video Poker family tests still pass