### PR TITLE
feat(trickdisplay): color partner-team cards by ally vs foe

### DIFF
--- a/frontend/src/components/TrickDisplay.test.tsx
+++ b/frontend/src/components/TrickDisplay.test.tsx
@@ -58,4 +58,33 @@ describe('TrickDisplay', () => {
     render(<TrickDisplay currentTrick={trick} players={players} cardWidth={40} label="label" />);
     expect(screen.getAllByTestId('animated-card')).toHaveLength(2);
   });
+
+  it('marks ally vs foe when partner-team data is supplied', () => {
+    const teamedPlayers: TrickDisplayPlayer[] = [
+      { id: 0, isHuman: true, team: 0 },
+      { id: 1, isHuman: false, team: 1 },
+      { id: 2, isHuman: false, team: 0 },
+      { id: 3, isHuman: false, team: 1 },
+    ];
+    const teamedTrick: TrickDisplayCard[] = [
+      { playerIdx: 0, card }, // human, team 0 → ally
+      { playerIdx: 1, card: { design: 'HEART', value: 10 } }, // CPU 1, team 1 → foe
+      { playerIdx: 2, card: { design: 'CLOVER', value: 7 } }, // partner, team 0 → ally
+    ];
+    const { container } = render(
+      <TrickDisplay currentTrick={teamedTrick} players={teamedPlayers} cardWidth={40} label="現在のトリック" />,
+    );
+    const allies = container.querySelectorAll('[data-team-role="ally"]');
+    const foes = container.querySelectorAll('[data-team-role="foe"]');
+    expect(allies).toHaveLength(2);
+    expect(foes).toHaveLength(1);
+  });
+
+  it('omits team coloring when only one team appears in the players list', () => {
+    const singleTeamPlayers: TrickDisplayPlayer[] = players.map((p) => ({ ...p, team: 0 }));
+    const { container } = render(
+      <TrickDisplay currentTrick={trick} players={singleTeamPlayers} cardWidth={40} label="label" />,
+    );
+    expect(container.querySelector('[data-team-role]')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/TrickDisplay.tsx
+++ b/frontend/src/components/TrickDisplay.tsx
@@ -12,6 +12,8 @@ export interface TrickDisplayCard {
 export interface TrickDisplayPlayer {
   id: number;
   isHuman: boolean;
+  /** Team identifier (0/1) for partner-based games. Omitted for free-for-all games. */
+  team?: number;
 }
 
 /** Props for {@link TrickDisplay}. */
@@ -33,26 +35,52 @@ export interface TrickDisplayProps {
  * Napoleon, OhHell, TwoTenJack, Whist). Renders each played card with the player's
  * name underneath, or nothing when the trick is empty. AnimatedCard plays the
  * default deal SFX itself, so callers no longer need to thread a sound callback.
+ *
+ * Partner-aware games (Bridge, Euchre, Whist, Tarneeb, ...) pass a `team` field
+ * on each TrickDisplayPlayer and the card is bordered + labeled in the human
+ * team's color (blue) or the opposing team's color (red) to make ally/opponent
+ * relationships scannable at a glance.
  */
 export function TrickDisplay({ currentTrick, players, cardWidth, label, dataTutorial }: TrickDisplayProps) {
   if (currentTrick.length === 0) {
     return null;
   }
+
+  const human = players.find((p) => p.isHuman);
+  const humanTeam = human?.team;
+  const hasTeams = humanTeam !== undefined && players.some((p) => p.team !== undefined && p.team !== humanTeam);
+
   return (
     <div className="my-3 p-3 rounded bg-black/40" data-tutorial={dataTutorial}>
       <div className="text-ds-text-muted text-sm mb-1">{label}</div>
       <div className="flex gap-2">
-        {currentTrick.map((trickCard) => (
-          <div key={`trick-${trickCard.playerIdx}`} className="text-center">
-            <AnimatedCard card={trickCard.card} width={cardWidth} />
-            <div className="text-game-text-muted text-xs mt-1">
-              {playerName(
-                players[trickCard.playerIdx]?.id ?? trickCard.playerIdx,
-                players[trickCard.playerIdx]?.isHuman ?? false,
-              )}
+        {currentTrick.map((trickCard) => {
+          const player = players[trickCard.playerIdx];
+          const team = player?.team;
+          const isAlly = hasTeams && team !== undefined && team === humanTeam;
+          const isFoe = hasTeams && team !== undefined && team !== humanTeam;
+          const wrapperClass = isAlly ? 'ring-2 ring-ds-info rounded' : isFoe ? 'ring-2 ring-ds-error rounded' : '';
+          const labelClass = isAlly
+            ? 'text-ds-info font-semibold'
+            : isFoe
+              ? 'text-ds-error font-semibold'
+              : 'text-game-text-muted';
+          return (
+            <div
+              key={`trick-${trickCard.playerIdx}`}
+              className="text-center"
+              data-team={team ?? undefined}
+              data-team-role={isAlly ? 'ally' : isFoe ? 'foe' : undefined}
+            >
+              <div className={wrapperClass}>
+                <AnimatedCard card={trickCard.card} width={cardWidth} />
+              </div>
+              <div className={`text-xs mt-1 ${labelClass}`}>
+                {playerName(player?.id ?? trickCard.playerIdx, player?.isHuman ?? false)}
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/frontend/src/components/TrickDisplay.tsx
+++ b/frontend/src/components/TrickDisplay.tsx
@@ -72,9 +72,7 @@ export function TrickDisplay({ currentTrick, players, cardWidth, label, dataTuto
               data-team={team ?? undefined}
               data-team-role={isAlly ? 'ally' : isFoe ? 'foe' : undefined}
             >
-              <div className={wrapperClass}>
-                <AnimatedCard card={trickCard.card} width={cardWidth} />
-              </div>
+              <AnimatedCard card={trickCard.card} width={cardWidth} wrapperClassName={wrapperClass || undefined} />
               <div className={`text-xs mt-1 ${labelClass}`}>
                 {playerName(player?.id ?? trickCard.playerIdx, player?.isHuman ?? false)}
               </div>


### PR DESCRIPTION
## Summary
- Optional \`team\` field on TrickDisplayPlayer (backward compatible)
- TrickDisplay highlights ally cards in ds-info blue and foe cards in ds-error red when player data carries team info
- data-team-role / data-team attributes for tests
- Opt-in: callers in Bridge/Euchre/Whist/Tarneeb/OhHell/Belote already pass full state.players, which carry team — no caller-side changes needed

Closes #1883

## Test plan
- [x] TrickDisplay test: ally + foe data-team-role attributes
- [x] TrickDisplay test: same-team-only players skip the coloring
- [x] All 6 existing TrickDisplay tests still pass
- [x] BridgePage (36) and EuchrePage (63) tests still pass