### PR TITLE
feat(crazyeights): chosen-suit watermark behind discard pile (#1885)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -268,6 +268,27 @@ input:not([type]):focus-visible {
   animation: sweat-drop 1.5s ease-in-out infinite;
 }
 
+/* Suit watermark "settle" animation — used by Crazy Eights when chosenSuit
+   becomes active. Starts slightly larger and fades to its resting opacity so
+   the suit change registers in peripheral vision (#1885). */
+@keyframes suit-watermark {
+  0% {
+    opacity: 0;
+    transform: scale(1.6);
+  }
+  60% {
+    opacity: 0.3;
+    transform: scale(1.05);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+.animate-suit-watermark {
+  animation: suit-watermark 0.4s ease-out;
+}
+
 /* Rotate chevron when sidebar category is open */
 .sidebar-category[open] .sidebar-category-chevron {
   transform: rotate(90deg);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -269,19 +269,22 @@ input:not([type]):focus-visible {
 }
 
 /* Suit watermark "settle" animation — used by Crazy Eights when chosenSuit
-   becomes active. Starts slightly larger and fades to its resting opacity so
-   the suit change registers in peripheral vision (#1885). */
+   becomes active. Starts slightly larger and settles to the resting opacity
+   so the suit change registers in peripheral vision (#1885). The 100% opacity
+   must match the element's resting Tailwind opacity (`opacity-15` = 0.15);
+   otherwise the computed value snaps when the animation ends, producing a
+   visible flash. */
 @keyframes suit-watermark {
   0% {
     opacity: 0;
     transform: scale(1.6);
   }
   60% {
-    opacity: 0.3;
+    opacity: 0.08;
     transform: scale(1.05);
   }
   100% {
-    opacity: 1;
+    opacity: 0.15;
     transform: scale(1);
   }
 }

--- a/frontend/src/pages/CrazyEightsPage.test.tsx
+++ b/frontend/src/pages/CrazyEightsPage.test.tsx
@@ -342,7 +342,10 @@ describe('CrazyEightsPage', () => {
       const watermark = screen.getByTestId('chosen-suit-watermark');
       expect(watermark).toBeInTheDocument();
       expect(watermark.textContent).toBe('♠');
-      expect(watermark.className).toContain('animate-suit-watermark');
+      // motion-safe: prefix is load-bearing — it pins the keyframe to users who haven't
+      // enabled prefers-reduced-motion. Substring on 'animate-suit-watermark' alone would
+      // silently pass even if the prefix were dropped.
+      expect(watermark.className).toContain('motion-safe:animate-suit-watermark');
       expect(watermark.className).toContain('opacity-15');
     });
   });

--- a/frontend/src/pages/CrazyEightsPage.test.tsx
+++ b/frontend/src/pages/CrazyEightsPage.test.tsx
@@ -325,7 +325,7 @@ describe('CrazyEightsPage', () => {
     renderWithProviders(<CrazyEightsPage />);
     await waitFor(() => {
       expect(screen.getByText(/指定スート/)).toBeInTheDocument();
-      expect(screen.getByText(/♠/)).toBeInTheDocument();
+      expect(screen.getByText(/指定スート: ♠/)).toBeInTheDocument();
     });
   });
 
@@ -333,6 +333,24 @@ describe('CrazyEightsPage', () => {
     renderWithProviders(<CrazyEightsPage />);
     await waitFor(() => expect(screen.getByText('捨て札')).toBeInTheDocument());
     expect(screen.queryByText('指定スート')).not.toBeInTheDocument();
+  });
+
+  it('renders large suit watermark behind discard pile when chosenSuit > 0', async () => {
+    mockExec.mockResolvedValue(chosenSuitState);
+    renderWithProviders(<CrazyEightsPage />);
+    await waitFor(() => {
+      const watermark = screen.getByTestId('chosen-suit-watermark');
+      expect(watermark).toBeInTheDocument();
+      expect(watermark.textContent).toBe('♠');
+      expect(watermark.className).toContain('animate-suit-watermark');
+      expect(watermark.className).toContain('opacity-15');
+    });
+  });
+
+  it('does not render watermark when chosenSuit is 0', async () => {
+    renderWithProviders(<CrazyEightsPage />);
+    await waitFor(() => expect(screen.getByText('捨て札')).toBeInTheDocument());
+    expect(screen.queryByTestId('chosen-suit-watermark')).not.toBeInTheDocument();
   });
 
   it('shows fallback ? for unknown suit value', async () => {

--- a/frontend/src/pages/CrazyEightsPage.tsx
+++ b/frontend/src/pages/CrazyEightsPage.tsx
@@ -247,7 +247,11 @@ function CrazyEightsPageContent() {
                         {SUIT_SYMBOLS[state.chosenSuit] ?? '?'}
                       </span>
                     )}
-                    <AnimatedCard card={state.discardTop} width={cardWidth} />
+                    {/* Wrap in a positioned div so DOM order — not "positioned beats static" —
+                        decides stacking: the card must paint on top of the absolute watermark span above. */}
+                    <div className="relative">
+                      <AnimatedCard card={state.discardTop} width={cardWidth} />
+                    </div>
                     <div className="text-ds-text-muted text-sm relative">
                       <div>{t('discardTop')}</div>
                       {state.chosenSuit > 0 && (

--- a/frontend/src/pages/CrazyEightsPage.tsx
+++ b/frontend/src/pages/CrazyEightsPage.tsx
@@ -234,9 +234,21 @@ function CrazyEightsPageContent() {
               <div>
                 {/* Discard pile top */}
                 {state.discardTop && (
-                  <div className="my-3 p-3 rounded bg-black/40 flex items-center gap-3" data-tutorial="ce-discard-pile">
+                  <div
+                    className="my-3 p-3 rounded bg-black/40 flex items-center gap-3 relative overflow-hidden"
+                    data-tutorial="ce-discard-pile"
+                  >
+                    {state.chosenSuit > 0 && (
+                      <span
+                        aria-hidden="true"
+                        data-testid="chosen-suit-watermark"
+                        className="pointer-events-none absolute inset-0 flex items-center justify-end pr-4 text-[6rem] leading-none opacity-15 text-ds-warning motion-safe:animate-suit-watermark"
+                      >
+                        {SUIT_SYMBOLS[state.chosenSuit] ?? '?'}
+                      </span>
+                    )}
                     <AnimatedCard card={state.discardTop} width={cardWidth} />
-                    <div className="text-ds-text-muted text-sm">
+                    <div className="text-ds-text-muted text-sm relative">
                       <div>{t('discardTop')}</div>
                       {state.chosenSuit > 0 && (
                         <div className="text-ds-warning">


### PR DESCRIPTION
Closes #1885

## Summary
- Adds a large (6rem) translucent (`opacity-15`) suit glyph behind the discard pile in `CrazyEightsPage.tsx`, visible only while `chosenSuit > 0`.
- Suit settles in via a new `suit-watermark` keyframe (`scale 1.6 → 1`, fade-in) defined in `src/index.css`.
- Text indicator (\`指定スート: ♠\`) stays as the canonical source.
- PageOne has no `chosenSuit` field (its mechanic is "declare Page One"), so the change is scoped to Crazy Eights only.

## Test plan
- [x] `bun run test -- --run CrazyEightsPage` (57 passed, 2 new watermark cases)
- [ ] CI 緑
- [ ] 8 を出してスート選択 → 中央のディスカード周辺に大きな♠/♣/♥/♦が薄く現れること
- [ ] 通常プレイ中（`chosenSuit === 0`）には透かしが出ないこと