### PR TITLE
feat(spiteandmalice): pulse goal pile when its top is playable (#1886)

### DIFF
--- a/frontend/src/pages/SpiteAndMalicePage.test.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.test.tsx
@@ -163,6 +163,22 @@ describe('SpiteAndMalicePage', () => {
     expect(goalBtn.dataset.goalPlayable).toBe('false');
   });
 
+  it('does not pulse the goal pile at game over even if goalTop is playable', async () => {
+    // winState has phase=GAME_OVER but current=0 (still the human's turn),
+    // so a winning hand with a playable goalTop must not keep pulsing on the
+    // game-over screen.
+    const gameOverPlayable: SpiteAndMaliceResponse = {
+      ...winState,
+      players: [{ ...winState.players[0], goalTop: card('SPADE', 1) }, winState.players[1]],
+      foundationTops: [0, 0, 0, 0],
+    };
+    mockExec.mockResolvedValue(gameOverPlayable);
+    renderWithProviders(<SpiteAndMalicePage />);
+    const goalBtn = await screen.findByRole('button', { name: /ゴール|Goal/ });
+    expect(goalBtn.dataset.goalPlayable).toBe('false');
+    expect(goalBtn.className).not.toContain('ring-ds-warning');
+  });
+
   it('hides the autocomplete button on CPU turn and at game over', async () => {
     mockExec.mockResolvedValue(cpuTurnState);
     const { unmount } = renderWithProviders(<SpiteAndMalicePage />);

--- a/frontend/src/pages/SpiteAndMalicePage.test.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.test.tsx
@@ -126,6 +126,43 @@ describe('SpiteAndMalicePage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
   });
 
+  it('marks the human goal pile as playable when goalTop fits a foundation', async () => {
+    const playableGoalState: SpiteAndMaliceResponse = {
+      ...baseState,
+      players: [{ ...baseState.players[0], goalTop: card('SPADE', 1) }, baseState.players[1]],
+    };
+    mockExec.mockResolvedValue(playableGoalState);
+    renderWithProviders(<SpiteAndMalicePage />);
+    const goalBtn = await screen.findByRole('button', { name: /ゴール|Goal/ });
+    expect(goalBtn.dataset.goalPlayable).toBe('true');
+    expect(goalBtn.className).toContain('ring-ds-warning');
+    expect(goalBtn.className).toContain('motion-safe:animate-pulse');
+  });
+
+  it('does not pulse the goal pile when goalTop cannot be played', async () => {
+    const idleGoalState: SpiteAndMaliceResponse = {
+      ...baseState,
+      players: [{ ...baseState.players[0], goalTop: card('SPADE', 5) }, baseState.players[1]],
+      foundationTops: [0, 0, 0, 0],
+    };
+    mockExec.mockResolvedValue(idleGoalState);
+    renderWithProviders(<SpiteAndMalicePage />);
+    const goalBtn = await screen.findByRole('button', { name: /ゴール|Goal/ });
+    expect(goalBtn.dataset.goalPlayable).toBe('false');
+    expect(goalBtn.className).not.toContain('ring-ds-warning');
+  });
+
+  it('does not pulse the goal pile on CPU turn even if it would be playable', async () => {
+    const playableButCpu: SpiteAndMaliceResponse = {
+      ...cpuTurnState,
+      players: [{ ...cpuTurnState.players[0], goalTop: card('SPADE', 1) }, cpuTurnState.players[1]],
+    };
+    mockExec.mockResolvedValue(playableButCpu);
+    renderWithProviders(<SpiteAndMalicePage />);
+    const goalBtn = await screen.findByRole('button', { name: /ゴール|Goal/ });
+    expect(goalBtn.dataset.goalPlayable).toBe('false');
+  });
+
   it('hides the autocomplete button on CPU turn and at game over', async () => {
     mockExec.mockResolvedValue(cpuTurnState);
     const { unmount } = renderWithProviders(<SpiteAndMalicePage />);

--- a/frontend/src/pages/SpiteAndMalicePage.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.tsx
@@ -28,6 +28,7 @@ import { SpiteAndMalicePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
+import { isGoalTopPlayableToFoundation } from '../utils/spiteAndMaliceUtils';
 
 const samRunner = spiteAndMaliceApi;
 
@@ -312,6 +313,7 @@ function SpiteAndMalicePageContent() {
                 selected={selection?.kind === 'goal'}
                 onClick={handleSelectGoal}
                 label={t('label.goal')}
+                playable={isHumanTurn && isGoalTopPlayableToFoundation(human.goalTop, state.foundationTops)}
               />
             </div>
 
@@ -470,6 +472,7 @@ function GoalPile({
   selected,
   onClick,
   label,
+  playable,
 }: {
   top?: Card;
   size: number;
@@ -477,12 +480,22 @@ function GoalPile({
   selected: boolean;
   onClick: () => void;
   label: string;
+  playable: boolean;
 }) {
+  // Selection ring wins (the user explicitly chose this pile); otherwise the
+  // playable affordance pulses a warning-colored glow so the strategically
+  // most important pile attracts the eye first (#1886).
+  const accentClass = selected
+    ? 'ring-2 ring-ds-accent -translate-y-0.5'
+    : playable
+      ? 'ring-2 ring-ds-warning shadow-[0_0_15px_var(--color-ds-warning)] motion-safe:animate-pulse'
+      : '';
   return (
     <button
       type="button"
       data-hint-action="goal-to-f0"
-      className={`${focusRingWhite} flex flex-col items-center rounded-lg transition-transform ${selected ? 'ring-2 ring-ds-accent -translate-y-0.5' : ''}`}
+      data-goal-playable={playable ? 'true' : 'false'}
+      className={`${focusRingWhite} flex flex-col items-center rounded-lg transition-transform ${accentClass}`}
       onClick={onClick}
       disabled={size === 0}
       aria-label={top ? `${label} top: ${cardAlt(top)} (${size} left)` : `${label}: empty`}

--- a/frontend/src/pages/SpiteAndMalicePage.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.tsx
@@ -313,7 +313,9 @@ function SpiteAndMalicePageContent() {
                 selected={selection?.kind === 'goal'}
                 onClick={handleSelectGoal}
                 label={t('label.goal')}
-                playable={isHumanTurn && isGoalTopPlayableToFoundation(human.goalTop, state.foundationTops)}
+                playable={
+                  isHumanTurn && !isGameOver && isGoalTopPlayableToFoundation(human.goalTop, state.foundationTops)
+                }
               />
             </div>
 

--- a/frontend/src/utils/spiteAndMaliceUtils.test.ts
+++ b/frontend/src/utils/spiteAndMaliceUtils.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { isGoalTopPlayableToFoundation } from './spiteAndMaliceUtils';
+
+const card = (value: number, design: Card['design'] = 'SPADE'): Card => ({ design, value });
+
+describe('isGoalTopPlayableToFoundation', () => {
+  it('returns false when goalTop is undefined', () => {
+    expect(isGoalTopPlayableToFoundation(undefined, [0, 0, 0, 0])).toBe(false);
+  });
+
+  it('plays an A onto an empty (top=0) foundation', () => {
+    expect(isGoalTopPlayableToFoundation(card(1), [0, 0, 0, 0])).toBe(true);
+  });
+
+  it('plays a 5 only when a foundation top is 4', () => {
+    expect(isGoalTopPlayableToFoundation(card(5), [3, 4, 7, 0])).toBe(true);
+    expect(isGoalTopPlayableToFoundation(card(5), [3, 6, 7, 0])).toBe(false);
+  });
+
+  it('K is wild: playable on any foundation not yet at Q', () => {
+    expect(isGoalTopPlayableToFoundation(card(13), [0, 0, 0, 0])).toBe(true);
+    expect(isGoalTopPlayableToFoundation(card(13), [5, 11, 7, 3])).toBe(true);
+  });
+
+  it('K is not playable when every foundation is already at Q (12)', () => {
+    expect(isGoalTopPlayableToFoundation(card(13), [12, 12, 12, 12])).toBe(false);
+  });
+
+  it('non-K cannot exceed +1 of any foundation top', () => {
+    expect(isGoalTopPlayableToFoundation(card(7), [4, 4, 4, 4])).toBe(false);
+  });
+});

--- a/frontend/src/utils/spiteAndMaliceUtils.ts
+++ b/frontend/src/utils/spiteAndMaliceUtils.ts
@@ -1,0 +1,22 @@
+import type { Card } from '../types/card';
+
+/** Spite & Malice: K (13) acts as a wild that fills any foundation slot. */
+const KING_VALUE = 13;
+/** Spite & Malice: a foundation completes at Q (12) — the next card cannot stack on a full foundation. */
+const FOUNDATION_TOP_COMPLETE = 12;
+
+/**
+ * Returns true when the goal pile's top card can legally be played onto at
+ * least one foundation. K is wild (always playable on any non-complete
+ * foundation); otherwise the card's value must equal `foundationTop + 1`.
+ *
+ * Used by the goal-pile affordance (#1886) so the UI nudges the player to
+ * spend the goal pile — the actual win condition — whenever it is legal.
+ */
+export function isGoalTopPlayableToFoundation(top: Card | undefined, foundationTops: readonly number[]): boolean {
+  if (!top) return false;
+  if (top.value === KING_VALUE) {
+    return foundationTops.some((t) => t < FOUNDATION_TOP_COMPLETE);
+  }
+  return foundationTops.some((t) => top.value === t + 1);
+}


### PR DESCRIPTION
Closes #1886

## Summary
- New `isGoalTopPlayableToFoundation(top, foundationTops)` util (with tests) — handles K-wild and "+1" rules.
- `GoalPile` gains a `playable` prop; the page passes `isHumanTurn && playable`.
- When playable and not currently selected, the goal pile gets `ring-ds-warning`, a `shadow-[0_0_15px_var(--color-ds-warning)]` glow, and `motion-safe:animate-pulse` — drawing the eye to the highest-priority move.
- Selection ring (accent) still wins so click feedback isn't lost.

## Test plan
- [x] `bun run test -- --run spiteAndMaliceUtils SpiteAndMalicePage` (18 passed)
- [ ] CI 緑
- [ ] `/spiteandmalice` で goalTop=A の状態に持ち込んで warning リングが脈動すること、CPU ターン中は脈動しないこと