### PR TITLE
feat(accordion): hover-highlight legal -1/-3 merge targets (#1887)

### DIFF
--- a/frontend/src/pages/AccordionPage.test.tsx
+++ b/frontend/src/pages/AccordionPage.test.tsx
@@ -131,6 +131,47 @@ describe('AccordionPage', () => {
     expect(screen.getByRole('button', { name: /2:/ }).dataset.hoverTarget).toBe('false');
   });
 
+  it('hover ring is suppressed on hintFrom pile even when it is a legal target', async () => {
+    // pile 0 (SPADE 7) is both hintFrom AND a legal hover-target for pile 3 (SPADE 9, same suit)
+    const hintFromHoverState: AccordionResponse = {
+      ...playingState,
+      piles: [
+        { cards: [card('SPADE', 7)], size: 1 },
+        { cards: [card('HEART', 2)], size: 1 },
+        { cards: [card('CLOVER', 3)], size: 1 },
+        { cards: [card('SPADE', 9)], size: 1 },
+      ],
+      pileCount: 4,
+      hint: { fromIdx: 0, toIdx: 3 },
+    };
+    mockExec.mockResolvedValue(hintFromHoverState);
+    renderWithProviders(<AccordionPage />);
+    const pile3 = await screen.findByRole('button', { name: /3:/ });
+    fireEvent.mouseEnter(pile3);
+    const pile0 = screen.getByRole('button', { name: /0:/ });
+    // pile 0 is a legal target (SPADE match) but hintFrom wins; no success ring
+    expect(pile0.className).not.toContain('ring-ds-success');
+    // hintFrom ring is still present
+    expect(pile0.className).toContain('ring-ds-info');
+  });
+
+  it('hover does not highlight targets when game is over', async () => {
+    const twoSpadePiles = {
+      ...gameOverState,
+      piles: [
+        { cards: [card('SPADE', 7)], size: 1 },
+        { cards: [card('SPADE', 9)], size: 1 },
+      ],
+      pileCount: 2,
+    };
+    mockExec.mockResolvedValue(twoSpadePiles);
+    renderWithProviders(<AccordionPage />);
+    const pile1 = await screen.findByRole('button', { name: /1:/ });
+    fireEvent.mouseEnter(pile1);
+    // pile 0 shares suit but isPlaying=false → no hover targets
+    expect(screen.getByRole('button', { name: /0:/ }).dataset.hoverTarget).toBe('false');
+  });
+
   it('mouseleave clears the hover highlight', async () => {
     const hoverState: AccordionResponse = {
       ...playingState,

--- a/frontend/src/pages/AccordionPage.test.tsx
+++ b/frontend/src/pages/AccordionPage.test.tsx
@@ -109,6 +109,47 @@ describe('AccordionPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo'));
   });
 
+  it('hovering a pile lights up legal -1/-3 merge targets', async () => {
+    const hoverState: AccordionResponse = {
+      ...playingState,
+      piles: [
+        { cards: [card('SPADE', 7)], size: 1 },
+        { cards: [card('HEART', 2)], size: 1 },
+        { cards: [card('CLOVER', 3)], size: 1 },
+        { cards: [card('SPADE', 9)], size: 1 },
+      ],
+      pileCount: 4,
+    };
+    mockExec.mockResolvedValue(hoverState);
+    renderWithProviders(<AccordionPage />);
+    const pile3 = await screen.findByRole('button', { name: /3:/ });
+    fireEvent.mouseEnter(pile3);
+    const pile0 = screen.getByRole('button', { name: /0:/ });
+    expect(pile0.dataset.hoverTarget).toBe('true');
+    expect(pile0.className).toContain('ring-ds-success');
+    // Adjacent pile (index 2) shares neither suit nor rank with SPADE 9.
+    expect(screen.getByRole('button', { name: /2:/ }).dataset.hoverTarget).toBe('false');
+  });
+
+  it('mouseleave clears the hover highlight', async () => {
+    const hoverState: AccordionResponse = {
+      ...playingState,
+      piles: [
+        { cards: [card('SPADE', 7)], size: 1 },
+        { cards: [card('HEART', 2)], size: 1 },
+        { cards: [card('CLOVER', 3)], size: 1 },
+        { cards: [card('SPADE', 9)], size: 1 },
+      ],
+      pileCount: 4,
+    };
+    mockExec.mockResolvedValue(hoverState);
+    renderWithProviders(<AccordionPage />);
+    const pile3 = await screen.findByRole('button', { name: /3:/ });
+    fireEvent.mouseEnter(pile3);
+    fireEvent.mouseLeave(pile3);
+    expect(screen.getByRole('button', { name: /0:/ }).dataset.hoverTarget).toBe('false');
+  });
+
   it('shows error alert when API fails on mount', async () => {
     mockExec.mockRejectedValue(new Error('network error'));
     renderWithProviders(<AccordionPage />);

--- a/frontend/src/pages/AccordionPage.tsx
+++ b/frontend/src/pages/AccordionPage.tsx
@@ -335,11 +335,11 @@ function AccordionPageContent() {
                         isSelected ? 'ring-2 ring-ds-warning -translate-y-1' : ''
                       } ${hintFrom ? 'ring-2 ring-ds-info animate-pulse' : ''} ${
                         hintTo ? 'ring-2 ring-ds-success animate-pulse' : ''
-                      } ${isHoverTarget && !isSelected && !hintTo ? 'ring-2 ring-ds-success' : ''}`}
+                      } ${isHoverTarget && !isSelected && !hintTo && !hintFrom ? 'ring-2 ring-ds-success' : ''}`}
                       onClick={() => handlePileClick(idx)}
-                      onMouseEnter={() => setHoveredIdx(idx)}
+                      onMouseEnter={isPlaying ? () => setHoveredIdx(idx) : undefined}
                       onMouseLeave={() => setHoveredIdx((cur) => (cur === idx ? null : cur))}
-                      onFocus={() => setHoveredIdx(idx)}
+                      onFocus={isPlaying ? () => setHoveredIdx(idx) : undefined}
                       onBlur={() => setHoveredIdx((cur) => (cur === idx ? null : cur))}
                       disabled={!isPlaying}
                       data-hover-target={isHoverTarget ? 'true' : 'false'}

--- a/frontend/src/pages/AccordionPage.tsx
+++ b/frontend/src/pages/AccordionPage.tsx
@@ -29,6 +29,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { AccordionResponse } from '../types/card';
 import { AccordionPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { accordionLegalTargets } from '../utils/accordionUtils';
 import { cardAlt } from '../utils/cardAlt';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 
@@ -123,6 +124,10 @@ function AccordionPageContent() {
   useMountReset(apiCall);
 
   const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
+  // Tracks the pile under cursor/focus so we can paint legal -1/-3 targets
+  // (same suit OR same rank) without waiting for click. Reset by mouseleave/blur
+  // and on every state change (handled implicitly because piles re-key on size).
+  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
 
   const {
     hint: frontendHint,
@@ -309,40 +314,50 @@ function AccordionPageContent() {
 
           <div className="flex-1 overflow-y-auto pt-3 px-2 sm:px-4 lg:px-8">
             <div className="flex flex-wrap gap-1 sm:gap-2 justify-center" data-tutorial="ac-piles">
-              {state.piles.map((pile, idx) => {
-                const top = pile.cards[0];
-                const isSelected = selectedIdx === idx;
-                const hintFrom = state.hint?.fromIdx === idx;
-                const hintTo = state.hint?.toIdx === idx;
-                // Keying by the top card's identity lets React preserve
-                // per-pile state (ring/selection class transitions, AnimatedCard
-                // instances) when piles shift left after a merge.
-                const pileKey = top ? `${top.design}-${top.value}-${pile.size}` : `empty-${idx}`;
-                return (
-                  <button
-                    key={pileKey}
-                    type="button"
-                    className={`relative ${focusRingWhite} rounded-lg transition-transform ${
-                      isSelected ? 'ring-2 ring-ds-warning -translate-y-1' : ''
-                    } ${hintFrom ? 'ring-2 ring-ds-info animate-pulse' : ''} ${
-                      hintTo ? 'ring-2 ring-ds-success animate-pulse' : ''
-                    }`}
-                    onClick={() => handlePileClick(idx)}
-                    disabled={!isPlaying}
-                    aria-label={top ? `${idx}: ${cardAlt(top)}` : `${idx}: empty`}
-                  >
-                    {top && <AnimatedCard card={top} width={cardWidth} />}
-                    <span className="absolute top-0 left-0 text-[10px] bg-black/40 text-ds-text-primary rounded-br px-1">
-                      {idx}
-                    </span>
-                    {pile.size > 1 && (
-                      <span className="absolute bottom-0 right-0 text-[10px] bg-black/60 text-ds-text-primary rounded-tl px-1">
-                        +{pile.size - 1}
+              {(() => {
+                const hoverTargets =
+                  isPlaying && hoveredIdx !== null ? new Set(accordionLegalTargets(state.piles, hoveredIdx)) : null;
+                return state.piles.map((pile, idx) => {
+                  const top = pile.cards[0];
+                  const isSelected = selectedIdx === idx;
+                  const hintFrom = state.hint?.fromIdx === idx;
+                  const hintTo = state.hint?.toIdx === idx;
+                  const isHoverTarget = hoverTargets?.has(idx) ?? false;
+                  // Keying by the top card's identity lets React preserve
+                  // per-pile state (ring/selection class transitions, AnimatedCard
+                  // instances) when piles shift left after a merge.
+                  const pileKey = top ? `${top.design}-${top.value}-${pile.size}` : `empty-${idx}`;
+                  return (
+                    <button
+                      key={pileKey}
+                      type="button"
+                      className={`relative ${focusRingWhite} rounded-lg transition-transform ${
+                        isSelected ? 'ring-2 ring-ds-warning -translate-y-1' : ''
+                      } ${hintFrom ? 'ring-2 ring-ds-info animate-pulse' : ''} ${
+                        hintTo ? 'ring-2 ring-ds-success animate-pulse' : ''
+                      } ${isHoverTarget && !isSelected && !hintTo ? 'ring-2 ring-ds-success' : ''}`}
+                      onClick={() => handlePileClick(idx)}
+                      onMouseEnter={() => setHoveredIdx(idx)}
+                      onMouseLeave={() => setHoveredIdx((cur) => (cur === idx ? null : cur))}
+                      onFocus={() => setHoveredIdx(idx)}
+                      onBlur={() => setHoveredIdx((cur) => (cur === idx ? null : cur))}
+                      disabled={!isPlaying}
+                      data-hover-target={isHoverTarget ? 'true' : 'false'}
+                      aria-label={top ? `${idx}: ${cardAlt(top)}` : `${idx}: empty`}
+                    >
+                      {top && <AnimatedCard card={top} width={cardWidth} />}
+                      <span className="absolute top-0 left-0 text-[10px] bg-black/40 text-ds-text-primary rounded-br px-1">
+                        {idx}
                       </span>
-                    )}
-                  </button>
-                );
-              })}
+                      {pile.size > 1 && (
+                        <span className="absolute bottom-0 right-0 text-[10px] bg-black/60 text-ds-text-primary rounded-tl px-1">
+                          +{pile.size - 1}
+                        </span>
+                      )}
+                    </button>
+                  );
+                });
+              })()}
             </div>
           </div>
 

--- a/frontend/src/utils/accordionUtils.test.ts
+++ b/frontend/src/utils/accordionUtils.test.ts
@@ -38,4 +38,9 @@ describe('accordionLegalTargets', () => {
     const piles = [pile(card('SPADE', 2)), pile(card('HEART', 9))];
     expect(accordionLegalTargets(piles, 1)).toEqual([]);
   });
+
+  it('skips empty target pile at valid offset', () => {
+    // fromIdx=1 (SPADE 9), toIdx=0 exists but is empty → no match
+    expect(accordionLegalTargets([pile(undefined), pile(card('SPADE', 9))], 1)).toEqual([]);
+  });
 });

--- a/frontend/src/utils/accordionUtils.test.ts
+++ b/frontend/src/utils/accordionUtils.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import type { AccordionPile, Card, CardDesign } from '../types/card';
+import { accordionLegalTargets } from './accordionUtils';
+
+const card = (design: CardDesign, value: number): Card => ({ design, value });
+const pile = (top: Card | undefined): AccordionPile => ({ cards: top ? [top] : [], size: top ? 1 : 0 });
+
+describe('accordionLegalTargets', () => {
+  it('returns no targets when fromIdx is empty', () => {
+    expect(accordionLegalTargets([pile(card('SPADE', 5)), pile(undefined)], 1)).toEqual([]);
+  });
+
+  it('returns no targets when fromIdx is 0', () => {
+    expect(accordionLegalTargets([pile(card('SPADE', 5))], 0)).toEqual([]);
+  });
+
+  it('matches by suit at offset 1', () => {
+    const piles = [pile(card('SPADE', 2)), pile(card('SPADE', 9))];
+    expect(accordionLegalTargets(piles, 1)).toEqual([0]);
+  });
+
+  it('matches by rank at offset 3', () => {
+    const piles = [pile(card('SPADE', 7)), pile(card('HEART', 2)), pile(card('CLOVER', 3)), pile(card('DIAMOND', 7))];
+    expect(accordionLegalTargets(piles, 3)).toEqual([0]);
+  });
+
+  it('returns both offsets when both match', () => {
+    const piles = [pile(card('SPADE', 7)), pile(card('HEART', 7)), pile(card('CLOVER', 7)), pile(card('DIAMOND', 7))];
+    expect(accordionLegalTargets(piles, 3)).toEqual([2, 0]);
+  });
+
+  it('skips offset 3 when it would be negative', () => {
+    const piles = [pile(card('SPADE', 2)), pile(card('SPADE', 9))];
+    expect(accordionLegalTargets(piles, 1)).toEqual([0]);
+  });
+
+  it('returns nothing when neither suit nor rank matches', () => {
+    const piles = [pile(card('SPADE', 2)), pile(card('HEART', 9))];
+    expect(accordionLegalTargets(piles, 1)).toEqual([]);
+  });
+});

--- a/frontend/src/utils/accordionUtils.ts
+++ b/frontend/src/utils/accordionUtils.ts
@@ -1,0 +1,25 @@
+import type { AccordionPile } from '../types/card';
+
+/** The two legal merge offsets in Accordion: pile-1 (adjacent) and pile-3 (three-back). */
+const ACCORDION_OFFSETS: readonly number[] = [1, 3] as const;
+
+/**
+ * Returns the indices of piles to the left of `fromIdx` (at offsets 1 and 3)
+ * whose top card matches `fromIdx`'s top by suit OR rank — i.e. legal merge
+ * targets in Accordion. Used by the hover affordance (#1887).
+ */
+export function accordionLegalTargets(piles: readonly AccordionPile[], fromIdx: number): number[] {
+  const from = piles[fromIdx]?.cards[0];
+  if (!from) return [];
+  const targets: number[] = [];
+  for (const offset of ACCORDION_OFFSETS) {
+    const toIdx = fromIdx - offset;
+    if (toIdx < 0) continue;
+    const to = piles[toIdx]?.cards[0];
+    if (!to) continue;
+    if (to.design === from.design || to.value === from.value) {
+      targets.push(toIdx);
+    }
+  }
+  return targets;
+}


### PR DESCRIPTION
Closes #1887

## Summary
- New util `accordionLegalTargets(piles, fromIdx)` — returns indices at offset -1 / -3 whose top matches by suit OR rank.
- `AccordionPage` tracks `hoveredIdx` (mouseenter/leave + focus/blur), passes legal targets through a Set, and rings the matched piles with `ring-ds-success`.
- Selection and backend-hint rings still win when present, so the new affordance is additive, not noisy.

## Test plan
- [x] `bun run test -- --run accordionUtils AccordionPage` (38 passed; 6 util + 2 page-level hover tests)
- [ ] CI 緑
- [ ] `/accordion` でパイル上にマウスを乗せると -1/-3 に位置するスート/ランク一致パイルが緑枠になること、離すと消えること