### PR TITLE
feat(trash): pulse rank-matching slot on pending draw (#1888)

### DIFF
--- a/frontend/src/pages/TrashPage.test.tsx
+++ b/frontend/src/pages/TrashPage.test.tsx
@@ -212,6 +212,24 @@ describe('TrashPage', () => {
     expect(slot4s[0].dataset.pendingTarget).toBe('false');
   });
 
+  it('highlights slot 0 (Ace boundary) when pending value is 1', async () => {
+    const pendingAce: TrashResponse = { ...playerTurnState, pending: card('SPADE', 1) };
+    mockExec.mockResolvedValue(pendingAce);
+    renderWithProviders(<TrashPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    const slot1s = screen.getAllByRole('button', { name: '1: face-down' });
+    expect(slot1s[1].dataset.pendingTarget).toBe('true');
+  });
+
+  it('highlights slot 9 (10 boundary) when pending value is 10', async () => {
+    const pendingTen: TrashResponse = { ...playerTurnState, pending: card('SPADE', 10) };
+    mockExec.mockResolvedValue(pendingTen);
+    renderWithProviders(<TrashPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    const slot10s = screen.getAllByRole('button', { name: '10: face-down' });
+    expect(slot10s[1].dataset.pendingTarget).toBe('true');
+  });
+
   it('does not highlight when pending card value is outside 1..10 (wild flow handles K/Joker separately)', async () => {
     // K (13) drawn but still in play phase (not yet AWAIT_WILD) — no pending highlight.
     const pendingK: TrashResponse = { ...playerTurnState, pending: card('DIAMOND', 13) };

--- a/frontend/src/pages/TrashPage.test.tsx
+++ b/frontend/src/pages/TrashPage.test.tsx
@@ -196,6 +196,44 @@ describe('TrashPage', () => {
     });
   });
 
+  it('highlights the rank-matching slot when a normal pending card is held', async () => {
+    // Drew the 4 of HEART → slot index 3 should pulse-warn on the human row.
+    // CPU row is rendered first, so the player's slot is the second match.
+    const pendingFour: TrashResponse = { ...playerTurnState, pending: card('HEART', 4) };
+    mockExec.mockResolvedValue(pendingFour);
+    renderWithProviders(<TrashPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    const slot4s = screen.getAllByRole('button', { name: '4: face-down' });
+    const playerSlot4 = slot4s[1];
+    expect(playerSlot4.dataset.pendingTarget).toBe('true');
+    expect(playerSlot4.className).toContain('ring-ds-warning');
+    expect(playerSlot4.className).toContain('motion-safe:animate-pulse');
+    // CPU row never highlights.
+    expect(slot4s[0].dataset.pendingTarget).toBe('false');
+  });
+
+  it('does not highlight when pending card value is outside 1..10 (wild flow handles K/Joker separately)', async () => {
+    // K (13) drawn but still in play phase (not yet AWAIT_WILD) — no pending highlight.
+    const pendingK: TrashResponse = { ...playerTurnState, pending: card('DIAMOND', 13) };
+    mockExec.mockResolvedValue(pendingK);
+    renderWithProviders(<TrashPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    const allSlots = screen.getAllByRole('button', { name: /face-down/ });
+    for (const slot of allSlots) {
+      expect(slot.dataset.pendingTarget).toBe('false');
+    }
+  });
+
+  it('does not highlight on CPU turn', async () => {
+    const cpuPending: TrashResponse = { ...cpuTurnState, pending: card('HEART', 4) };
+    mockExec.mockImplementation(async () => cpuPending);
+    renderWithProviders(<TrashPage />);
+    await waitFor(() => expect(screen.getAllByText(/CPUのターン/).length).toBeGreaterThan(0));
+    for (const slot of screen.getAllByRole('button', { name: /face-down/ })) {
+      expect(slot.dataset.pendingTarget).toBe('false');
+    }
+  });
+
   it('surfaces an error alert when the API fails on mount', async () => {
     mockExec.mockRejectedValue(new Error('network error'));
     renderWithProviders(<TrashPage />);

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -190,6 +190,14 @@ function TrashPageContent() {
         ? t('phase.awaitWild')
         : t('phase.playerTurn');
 
+  // Slot index where the pending non-wild card should land. Wild cards (K/Joker)
+  // route through AWAIT_WILD's existing highlightFaceDown path, so this stays
+  // null whenever isAwaitWild is true or the value is outside 1..10.
+  const pendingTargetIdx =
+    isHumanTurn && !isAwaitWild && state.pending && state.pending.value >= 1 && state.pending.value <= 10
+      ? state.pending.value - 1
+      : null;
+
   return (
     <GamePageShell
       title={tc('nav.trash')}
@@ -255,11 +263,7 @@ function TrashPageContent() {
               highlightFaceDown={isAwaitWild && isHumanTurn}
               onSlotClick={isAwaitWild && isHumanTurn ? handleSlotClick : undefined}
               dataTutorial="tr-player"
-              pendingTargetIdx={
-                isHumanTurn && !isAwaitWild && state.pending && state.pending.value >= 1 && state.pending.value <= 10
-                  ? state.pending.value - 1
-                  : null
-              }
+              pendingTargetIdx={pendingTargetIdx}
             />
           </div>
 

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -225,6 +225,7 @@ function TrashPageContent() {
               highlightFaceDown={false}
               onSlotClick={undefined}
               dataTutorial="tr-opponent"
+              pendingTargetIdx={null}
             />
 
             <div className="flex items-center justify-center gap-6" data-tutorial="tr-stock">
@@ -254,6 +255,11 @@ function TrashPageContent() {
               highlightFaceDown={isAwaitWild && isHumanTurn}
               onSlotClick={isAwaitWild && isHumanTurn ? handleSlotClick : undefined}
               dataTutorial="tr-player"
+              pendingTargetIdx={
+                isHumanTurn && !isAwaitWild && state.pending && state.pending.value >= 1 && state.pending.value <= 10
+                  ? state.pending.value - 1
+                  : null
+              }
             />
           </div>
 
@@ -305,6 +311,7 @@ function PlayerRow({
   highlightFaceDown,
   onSlotClick,
   dataTutorial,
+  pendingTargetIdx,
 }: {
   label: string;
   slots: TrashSlot[];
@@ -312,6 +319,8 @@ function PlayerRow({
   highlightFaceDown: boolean;
   onSlotClick: ((idx: number) => void) | undefined;
   dataTutorial: string;
+  /** Slot index (0..9) where a freshly drawn non-wild card should land, or null. */
+  pendingTargetIdx: number | null;
 }) {
   return (
     <div className="flex flex-col items-center" data-tutorial={dataTutorial}>
@@ -320,15 +329,25 @@ function PlayerRow({
         {slots.map((slot, idx) => {
           const key = `${idx}-${slot.faceUp ? `${slot.card?.design}-${slot.card?.value}` : 'face-down'}`;
           const interactive = !slot.faceUp && onSlotClick !== undefined;
+          const wildHighlight = highlightFaceDown && !slot.faceUp;
+          const pendingHighlight = pendingTargetIdx === idx && !slot.faceUp;
+          // Wild highlight (info ring on every face-down slot) wins over the
+          // single-slot pending highlight so the broader affordance reads first.
+          const ringClass = wildHighlight
+            ? 'ring-2 ring-ds-info hover:-translate-y-0.5'
+            : pendingHighlight
+              ? 'ring-2 ring-ds-warning motion-safe:animate-pulse'
+              : '';
           return (
             <button
               key={key}
               type="button"
-              className={`relative ${focusRingWhite} rounded-lg transition-transform ${
-                highlightFaceDown && !slot.faceUp ? 'ring-2 ring-ds-info hover:-translate-y-0.5' : ''
-              } ${interactive ? 'cursor-pointer' : 'cursor-default'}`}
+              className={`relative ${focusRingWhite} rounded-lg transition-transform ${ringClass} ${
+                interactive ? 'cursor-pointer' : 'cursor-default'
+              }`}
               onClick={() => onSlotClick?.(idx)}
               disabled={!interactive}
+              data-pending-target={pendingHighlight ? 'true' : 'false'}
               aria-label={slot.faceUp && slot.card ? `${idx + 1}: ${cardAlt(slot.card)}` : `${idx + 1}: face-down`}
             >
               {slot.faceUp && slot.card ? (


### PR DESCRIPTION
Closes #1888

## Summary
- `PlayerRow` gains a `pendingTargetIdx: number | null` prop.
- `TrashPage` computes `pending.value - 1` for human-turn draws of A–10 (and leaves it null for K/Joker since `AWAIT_WILD` already highlights every face-down slot via `highlightFaceDown`).
- The matched face-down slot pulses with `ring-ds-warning` + `motion-safe:animate-pulse`. Wild-flow `ring-ds-info` still wins when both apply.
- CPU row always receives `null` (no spoilers).

## Test plan
- [x] `bun run test -- --run TrashPage` (19 passed, 3 new pending-slot cases)
- [ ] CI 緑
- [ ] `/trash` で A〜10 を引いたとき、対応するインデックスのスロットが脈動すること
- [ ] K/Joker を引いたときは既存どおり全 face-down スロットがハイライトされること