### PR TITLE
feat(highcardflush): highlight longest-flush cards (#1890)

### DIFF
--- a/frontend/src/pages/HighCardFlushPage.test.tsx
+++ b/frontend/src/pages/HighCardFlushPage.test.tsx
@@ -232,4 +232,35 @@ describe('HighCardFlushPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: 'レイズ x3' })).toBeInTheDocument());
     expect(screen.getByRole('button', { name: 'レイズ x2' })).toBeInTheDocument();
   });
+
+  it('lifts and glows the cards in the longest flush, dims off-suit cards', async () => {
+    mockExec.mockResolvedValueOnce(betPhaseState).mockResolvedValueOnce(actionPhase5Flush);
+    renderWithProviders(<HighCardFlushPage />);
+    await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'レイズ x2' })).toBeInTheDocument());
+    // actionPhase5Flush has 5 SPADE + 1 HEART + 1 CLOVER → SPADE is the longest flush.
+    const flushCards = document.querySelectorAll('[data-flush-card="true"]');
+    const offCards = document.querySelectorAll('[data-flush-card="false"]');
+    expect(flushCards.length).toBe(5);
+    expect(offCards.length).toBe(2);
+    expect((flushCards[0] as HTMLElement).className).toContain('drop-shadow-[0_0_8px_var(--color-ds-warning)]');
+    expect((offCards[0] as HTMLElement).className).toContain('opacity-50');
+  });
+
+  it('does not dim or highlight the dealer hand until end phase (no spoilers)', async () => {
+    mockExec.mockResolvedValueOnce(betPhaseState).mockResolvedValueOnce({
+      ...actionPhase5Flush,
+      dealerHand: [card('SPADE', 2)],
+    });
+    renderWithProviders(<HighCardFlushPage />);
+    await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'レイズ x2' })).toBeInTheDocument());
+    // The dealer's hand wrapper carries data-flush-card="false" but should NOT have the dim/highlight classes during action phase.
+    const dealerSection = document.querySelectorAll('[data-flush-card]');
+    const dealerWrapper = Array.from(dealerSection).find((el) => el.querySelector('img[alt*="2"]'));
+    expect(dealerWrapper?.className).not.toContain('drop-shadow');
+    expect(dealerWrapper?.className).not.toContain('opacity-50');
+  });
 });

--- a/frontend/src/pages/HighCardFlushPage.test.tsx
+++ b/frontend/src/pages/HighCardFlushPage.test.tsx
@@ -257,10 +257,13 @@ describe('HighCardFlushPage', () => {
     await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
     await waitFor(() => expect(screen.getByRole('button', { name: 'レイズ x2' })).toBeInTheDocument());
-    // The dealer's hand wrapper carries data-flush-card="false" but should NOT have the dim/highlight classes during action phase.
-    const dealerSection = document.querySelectorAll('[data-flush-card]');
-    const dealerWrapper = Array.from(dealerSection).find((el) => el.querySelector('img[alt*="2"]'));
-    expect(dealerWrapper?.className).not.toContain('drop-shadow');
-    expect(dealerWrapper?.className).not.toContain('opacity-50');
+    // Scope by data-card-section so we don't rely on alt-text matching (which
+    // would silently start testing the wrong element if AnimatedCard's alt
+    // format ever changes).
+    const dealerWrappers = document.querySelectorAll('[data-card-section="dealer"]');
+    expect(dealerWrappers.length).toBe(1);
+    const dealerWrapper = dealerWrappers[0] as HTMLElement;
+    expect(dealerWrapper.className).not.toContain('drop-shadow');
+    expect(dealerWrapper.className).not.toContain('opacity-50');
   });
 });

--- a/frontend/src/pages/HighCardFlushPage.tsx
+++ b/frontend/src/pages/HighCardFlushPage.tsx
@@ -23,6 +23,7 @@ import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import { HighCardFlushPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { longestFlushSuit } from '../utils/highCardFlushUtils';
 
 /** High Card Flush tutorial step definitions. */
 const HCF_TUTORIAL_STEPS: TutorialStep[] = [
@@ -197,9 +198,23 @@ function HighCardFlushPageContent() {
               )}
             </div>
             <div className="flex justify-center flex-wrap gap-2">
-              {state.playerHand.map((card, i) => (
-                <AnimatedCard key={`p-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
-              ))}
+              {(() => {
+                const flushSuit = longestFlushSuit(state.playerHand);
+                return state.playerHand.map((card, i) => {
+                  const inFlush = card.design === flushSuit;
+                  return (
+                    <div
+                      key={`p-${card.design}-${card.value}-${i}`}
+                      className={`transition-all ${
+                        inFlush ? 'drop-shadow-[0_0_8px_var(--color-ds-warning)] -translate-y-1' : 'opacity-50'
+                      }`}
+                      data-flush-card={inFlush ? 'true' : 'false'}
+                    >
+                      <AnimatedCard card={card} width={cardWidth} />
+                    </div>
+                  );
+                });
+              })()}
             </div>
           </div>
         )}
@@ -219,9 +234,29 @@ function HighCardFlushPageContent() {
               )}
             </div>
             <div className="flex justify-center flex-wrap gap-2">
-              {state.dealerHand.map((card, i) => (
-                <AnimatedCard key={`d-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
-              ))}
+              {(() => {
+                // Only highlight the dealer's flush at end-phase (showdown). Before that
+                // we don't want to spoil any partial dealer information.
+                const flushSuit = isEndPhase ? longestFlushSuit(state.dealerHand) : null;
+                return state.dealerHand.map((card, i) => {
+                  const inFlush = flushSuit !== null && card.design === flushSuit;
+                  return (
+                    <div
+                      key={`d-${card.design}-${card.value}-${i}`}
+                      className={`transition-all ${
+                        flushSuit === null
+                          ? ''
+                          : inFlush
+                            ? 'drop-shadow-[0_0_8px_var(--color-ds-error)] -translate-y-1'
+                            : 'opacity-50'
+                      }`}
+                      data-flush-card={inFlush ? 'true' : 'false'}
+                    >
+                      <AnimatedCard card={card} width={cardWidth} />
+                    </div>
+                  );
+                });
+              })()}
             </div>
           </div>
         )}

--- a/frontend/src/pages/HighCardFlushPage.tsx
+++ b/frontend/src/pages/HighCardFlushPage.tsx
@@ -71,6 +71,15 @@ function HighCardFlushPageContent() {
   const isEndPhase = state?.phase === HighCardFlushPhase.END;
   const maxMultiplier = state?.maxRaiseMultiplier ?? 1;
 
+  // Memoize the longest-flush computation per hand so it doesn't run on every
+  // unrelated re-render (e.g. bet-input changes). Dealer flush also gates on
+  // isEndPhase to avoid spoilers during the action phase.
+  const playerFlushSuit = useMemo(() => longestFlushSuit(state?.playerHand ?? []), [state?.playerHand]);
+  const dealerFlushSuit = useMemo(
+    () => (isEndPhase ? longestFlushSuit(state?.dealerHand ?? []) : null),
+    [isEndPhase, state?.dealerHand],
+  );
+
   const actionBindings = useMemo(
     () => [
       {
@@ -198,23 +207,21 @@ function HighCardFlushPageContent() {
               )}
             </div>
             <div className="flex justify-center flex-wrap gap-2">
-              {(() => {
-                const flushSuit = longestFlushSuit(state.playerHand);
-                return state.playerHand.map((card, i) => {
-                  const inFlush = card.design === flushSuit;
-                  return (
-                    <div
-                      key={`p-${card.design}-${card.value}-${i}`}
-                      className={`transition-all ${
-                        inFlush ? 'drop-shadow-[0_0_8px_var(--color-ds-warning)] -translate-y-1' : 'opacity-50'
-                      }`}
-                      data-flush-card={inFlush ? 'true' : 'false'}
-                    >
-                      <AnimatedCard card={card} width={cardWidth} />
-                    </div>
-                  );
-                });
-              })()}
+              {state.playerHand.map((card, i) => {
+                const inFlush = card.design === playerFlushSuit;
+                return (
+                  <div
+                    key={`p-${card.design}-${card.value}-${i}`}
+                    className={`transition-all ${
+                      inFlush ? 'drop-shadow-[0_0_8px_var(--color-ds-warning)] -translate-y-1' : 'opacity-50'
+                    }`}
+                    data-card-section="player"
+                    data-flush-card={inFlush ? 'true' : 'false'}
+                  >
+                    <AnimatedCard card={card} width={cardWidth} />
+                  </div>
+                );
+              })}
             </div>
           </div>
         )}
@@ -234,29 +241,26 @@ function HighCardFlushPageContent() {
               )}
             </div>
             <div className="flex justify-center flex-wrap gap-2">
-              {(() => {
-                // Only highlight the dealer's flush at end-phase (showdown). Before that
-                // we don't want to spoil any partial dealer information.
-                const flushSuit = isEndPhase ? longestFlushSuit(state.dealerHand) : null;
-                return state.dealerHand.map((card, i) => {
-                  const inFlush = flushSuit !== null && card.design === flushSuit;
-                  return (
-                    <div
-                      key={`d-${card.design}-${card.value}-${i}`}
-                      className={`transition-all ${
-                        flushSuit === null
-                          ? ''
-                          : inFlush
-                            ? 'drop-shadow-[0_0_8px_var(--color-ds-error)] -translate-y-1'
-                            : 'opacity-50'
-                      }`}
-                      data-flush-card={inFlush ? 'true' : 'false'}
-                    >
-                      <AnimatedCard card={card} width={cardWidth} />
-                    </div>
-                  );
-                });
-              })()}
+              {state.dealerHand.map((card, i) => {
+                // dealerFlushSuit is null during the action phase (no spoilers).
+                const inFlush = dealerFlushSuit !== null && card.design === dealerFlushSuit;
+                return (
+                  <div
+                    key={`d-${card.design}-${card.value}-${i}`}
+                    className={`transition-all ${
+                      dealerFlushSuit === null
+                        ? ''
+                        : inFlush
+                          ? 'drop-shadow-[0_0_8px_var(--color-ds-error)] -translate-y-1'
+                          : 'opacity-50'
+                    }`}
+                    data-card-section="dealer"
+                    data-flush-card={inFlush ? 'true' : 'false'}
+                  >
+                    <AnimatedCard card={card} width={cardWidth} />
+                  </div>
+                );
+              })}
             </div>
           </div>
         )}

--- a/frontend/src/utils/highCardFlushUtils.test.ts
+++ b/frontend/src/utils/highCardFlushUtils.test.ts
@@ -31,6 +31,17 @@ describe('longestFlushSuit', () => {
     expect(longestFlushSuit([card('SPADE', 1), card('SPADE', 5), card('HEART', 13), card('HEART', 9)])).toBe('HEART');
   });
 
+  it('compares second card when count and highest card both tie (showdown rule)', () => {
+    // SPADE: [K, 2], HEART: [K, 5] → same count, same top, HEART wins on 2nd card.
+    expect(longestFlushSuit([card('SPADE', 13), card('SPADE', 2), card('HEART', 13), card('HEART', 5)])).toBe('HEART');
+  });
+
+  it('stays deterministic when every position ties — first-inserted suit wins', () => {
+    // Identical [K, 5] for both suits: the first inserted (SPADE) wins, not a
+    // random Map iteration. Documents the deterministic fall-through.
+    expect(longestFlushSuit([card('SPADE', 13), card('SPADE', 5), card('HEART', 13), card('HEART', 5)])).toBe('SPADE');
+  });
+
   it('handles a 7-card hand with a 4-card flush', () => {
     const hand = [
       card('SPADE', 14),

--- a/frontend/src/utils/highCardFlushUtils.test.ts
+++ b/frontend/src/utils/highCardFlushUtils.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign } from '../types/card';
+import { longestFlushSuit } from './highCardFlushUtils';
+
+const card = (design: CardDesign, value: number): Card => ({ design, value });
+
+describe('longestFlushSuit', () => {
+  it('returns null for an empty hand', () => {
+    expect(longestFlushSuit([])).toBeNull();
+  });
+
+  it('returns the only suit when hand is uniform', () => {
+    expect(longestFlushSuit([card('SPADE', 1), card('SPADE', 7), card('SPADE', 13)])).toBe('SPADE');
+  });
+
+  it('returns the suit with the highest count', () => {
+    expect(
+      longestFlushSuit([
+        card('SPADE', 1),
+        card('HEART', 2),
+        card('HEART', 5),
+        card('HEART', 9),
+        card('CLOVER', 4),
+        card('DIAMOND', 11),
+        card('DIAMOND', 12),
+      ]),
+    ).toBe('HEART');
+  });
+
+  it('uses the highest single card as a tiebreaker when counts tie', () => {
+    expect(longestFlushSuit([card('SPADE', 1), card('SPADE', 5), card('HEART', 13), card('HEART', 9)])).toBe('HEART');
+  });
+
+  it('handles a 7-card hand with a 4-card flush', () => {
+    const hand = [
+      card('SPADE', 14),
+      card('SPADE', 13),
+      card('SPADE', 11),
+      card('SPADE', 5),
+      card('HEART', 7),
+      card('CLOVER', 8),
+      card('DIAMOND', 9),
+    ];
+    expect(longestFlushSuit(hand)).toBe('SPADE');
+  });
+});

--- a/frontend/src/utils/highCardFlushUtils.ts
+++ b/frontend/src/utils/highCardFlushUtils.ts
@@ -1,29 +1,51 @@
 import type { Card, CardDesign } from '../types/card';
 
 /**
+ * Lexicographic compare of two descending-sorted card-value arrays.
+ * Returns >0 if `a` ranks higher, <0 if `b` does, 0 if every position ties.
+ * Used as High Card Flush's own showdown tiebreaker (compare 1st card, then
+ * 2nd, then 3rd…).
+ */
+function compareDescendingValues(a: readonly number[], b: readonly number[]): number {
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+/**
  * Returns the suit (design) that forms the longest flush in a High Card Flush
- * hand, or null when the hand is empty. Tie-breaker: when two suits have the
- * same count, prefers the one containing the highest single card — matching
- * High Card Flush's own "high card wins" tiebreaker so the highlighted set
- * matches the suit the dealer would compare against.
+ * hand, or null when the hand is empty. Tie-breaker matches the game's own
+ * showdown rule: when two suits share the same count, the suit whose
+ * descending-sorted values beat the other one lexicographically wins (compare
+ * top card, then 2nd, then 3rd…). This stays deterministic even when the top
+ * cards also tie — Map iteration order is never relied on.
  */
 export function longestFlushSuit(hand: readonly Card[]): CardDesign | null {
   if (hand.length === 0) return null;
-  const counts = new Map<CardDesign, { count: number; highest: number }>();
+  const groups = new Map<CardDesign, number[]>();
   for (const c of hand) {
-    const cur = counts.get(c.design);
-    if (cur === undefined) {
-      counts.set(c.design, { count: 1, highest: c.value });
+    const arr = groups.get(c.design);
+    if (arr === undefined) {
+      groups.set(c.design, [c.value]);
     } else {
-      cur.count += 1;
-      if (c.value > cur.highest) cur.highest = c.value;
+      arr.push(c.value);
     }
   }
-  let best: { suit: CardDesign; count: number; highest: number } | null = null;
-  for (const [suit, info] of counts) {
-    if (best === null || info.count > best.count || (info.count === best.count && info.highest > best.highest)) {
-      best = { suit, count: info.count, highest: info.highest };
+  let bestSuit: CardDesign | null = null;
+  let bestVals: number[] = [];
+  for (const [suit, vals] of groups) {
+    vals.sort((a, b) => b - a);
+    if (bestSuit === null || vals.length > bestVals.length) {
+      bestSuit = suit;
+      bestVals = vals;
+      continue;
+    }
+    if (vals.length === bestVals.length && compareDescendingValues(vals, bestVals) > 0) {
+      bestSuit = suit;
+      bestVals = vals;
     }
   }
-  return best?.suit ?? null;
+  return bestSuit;
 }

--- a/frontend/src/utils/highCardFlushUtils.ts
+++ b/frontend/src/utils/highCardFlushUtils.ts
@@ -1,0 +1,29 @@
+import type { Card, CardDesign } from '../types/card';
+
+/**
+ * Returns the suit (design) that forms the longest flush in a High Card Flush
+ * hand, or null when the hand is empty. Tie-breaker: when two suits have the
+ * same count, prefers the one containing the highest single card — matching
+ * High Card Flush's own "high card wins" tiebreaker so the highlighted set
+ * matches the suit the dealer would compare against.
+ */
+export function longestFlushSuit(hand: readonly Card[]): CardDesign | null {
+  if (hand.length === 0) return null;
+  const counts = new Map<CardDesign, { count: number; highest: number }>();
+  for (const c of hand) {
+    const cur = counts.get(c.design);
+    if (cur === undefined) {
+      counts.set(c.design, { count: 1, highest: c.value });
+    } else {
+      cur.count += 1;
+      if (c.value > cur.highest) cur.highest = c.value;
+    }
+  }
+  let best: { suit: CardDesign; count: number; highest: number } | null = null;
+  for (const [suit, info] of counts) {
+    if (best === null || info.count > best.count || (info.count === best.count && info.highest > best.highest)) {
+      best = { suit, count: info.count, highest: info.highest };
+    }
+  }
+  return best?.suit ?? null;
+}


### PR DESCRIPTION
Closes #1890

## Summary
- New util `longestFlushSuit(hand)` — most-common suit, ties broken by highest card.
- Player cards in the longest flush lift (`-translate-y-1`) and glow (`drop-shadow-[0_0_8px_var(--color-ds-warning)]`). Off-suit cards dim to `opacity-50`.
- Dealer hand gets the same treatment in error hue, but only at end phase to avoid spoiling action-phase decisions.

## Test plan
- [x] `bun run test -- --run highCardFlushUtils HighCardFlushPage` (22 passed)
- [ ] CI 緑
- [ ] `/highcardflush` で 5枚以上のフラッシュが出たとき、その5枚が浮き上がって光り、他の2枚が薄暗くなること
- [ ] アクションフェーズ中はディーラーカードがハイライトされないこと（END フェーズで初めて赤光する）