### PR TITLE
feat(pitch): Game-pip total badge w/ tooltip breakdown (#1891)

### DIFF
--- a/frontend/src/i18n/locales/en/pitch.json
+++ b/frontend/src/i18n/locales/en/pitch.json
@@ -22,6 +22,8 @@
   "trumpSuit": "Trump: {{suit}}",
   "trumpUnset": "(not set)",
   "cards": "{{count}}",
+  "gamePips": "Game pips: {{pips}}",
+  "gamePipsTooltip": "10=10, A=4, K=3, Q=2, J=1. Whoever captures the most pips wins the Game point.",
   "cumulativeScore": "Total: {{score}}",
   "roundScore": "Round: {{score}}",
   "bid": "Bid {{n}}",

--- a/frontend/src/i18n/locales/ja/pitch.json
+++ b/frontend/src/i18n/locales/ja/pitch.json
@@ -22,6 +22,8 @@
   "trumpSuit": "切り札: {{suit}}",
   "trumpUnset": "未確定",
   "cards": "{{count}}枚",
+  "gamePips": "Game値: {{pips}}",
+  "gamePipsTooltip": "10=10, A=4, K=3, Q=2, J=1。獲得カードのピップ合計が最も多い側がGameポイントを取ります。",
   "cumulativeScore": "累計: {{score}}",
   "roundScore": "ラウンド: {{score}}",
   "bid": "ビッド {{n}}",

--- a/frontend/src/pages/PitchPage.test.tsx
+++ b/frontend/src/pages/PitchPage.test.tsx
@@ -124,4 +124,42 @@ describe('PitchPage', () => {
     renderWithProviders(<PitchPage />);
     await waitFor(() => expect(screen.getByText(/あなたの勝利/)).toBeInTheDocument());
   });
+
+  it('renders the Game-pip badge with the human hand total', async () => {
+    // SPADE 5 (0 pips) + HEART 9 (0 pips) = 0
+    mockApi.mockResolvedValue(bidState);
+    renderWithProviders(<PitchPage />);
+    const badge = await screen.findByTestId('pitch-game-pips-badge');
+    expect(badge.textContent).toMatch(/Game値: 0/);
+  });
+
+  it('Game-pip badge sums A, K, Q, J, 10 correctly', async () => {
+    const pipHand: PitchResponse = {
+      ...bidState,
+      players: [
+        {
+          ...bidState.players[0],
+          // A(4) + 10(10) + J(1) + K(3) + Q(2) + 7(0) = 20
+          cards: [
+            makeCard('SPADE', 1),
+            makeCard('SPADE', 10),
+            makeCard('SPADE', 11),
+            makeCard('SPADE', 13),
+            makeCard('SPADE', 12),
+            makeCard('HEART', 7),
+          ],
+          cardCount: 6,
+        },
+        ...bidState.players.slice(1),
+      ],
+    };
+    mockApi.mockResolvedValue(pipHand);
+    renderWithProviders(<PitchPage />);
+    const badge = await screen.findByTestId('pitch-game-pips-badge');
+    expect(badge.textContent).toMatch(/Game値: 20/);
+    // Tooltip contains the breakdown of contributing cards only.
+    expect(badge.getAttribute('title')).toContain('A(4)');
+    expect(badge.getAttribute('title')).toContain('10(10)');
+    expect(badge.getAttribute('title')).not.toContain('7(');
+  });
 });

--- a/frontend/src/pages/PitchPage.test.tsx
+++ b/frontend/src/pages/PitchPage.test.tsx
@@ -133,6 +133,16 @@ describe('PitchPage', () => {
     expect(badge.textContent).toMatch(/Game値: 0/);
   });
 
+  it('Game-pip badge tooltip has no trailing newline when pips = 0', async () => {
+    // SPADE 5 (0) + HEART 9 (0) → no breakdown line should be appended
+    mockApi.mockResolvedValue(bidState);
+    renderWithProviders(<PitchPage />);
+    const badge = await screen.findByTestId('pitch-game-pips-badge');
+    const title = badge.getAttribute('title') ?? '';
+    expect(title).not.toMatch(/\n$/);
+    expect(title).not.toContain('\n');
+  });
+
   it('Game-pip badge sums A, K, Q, J, 10 correctly', async () => {
     const pipHand: PitchResponse = {
       ...bidState,

--- a/frontend/src/pages/PitchPage.tsx
+++ b/frontend/src/pages/PitchPage.tsx
@@ -29,6 +29,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { PITCH_HELP, parsePitchCommand } from '../utils/cli/commands/pitchCommands';
 import { formatPitchState } from '../utils/cli/formatters/pitchFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { pitchHandPipBreakdown, pitchHandPips } from '../utils/pitchUtils';
 import { findPlayerName, playerName } from '../utils/playerUtils';
 
 const PT_TUTORIAL_STEPS: TutorialStep[] = [
@@ -103,6 +104,10 @@ const VALUE_LABELS: Readonly<Record<number, string>> = {
 function cardLabel(c: { design: string; value: number }): string {
   const v = VALUE_LABELS[c.value] ?? String(c.value);
   return `${SUIT_DESIGNS[c.design] ?? c.design}${v}`;
+}
+
+function valueLabel(value: number): string {
+  return VALUE_LABELS[value] ?? String(value);
 }
 
 /** Pitch (Setback) game page. */
@@ -286,8 +291,20 @@ function PitchPageContent() {
             {/* Player hand (always visible) */}
             {human && human.cards.length > 0 && (
               <div data-tutorial="pt-player-hand" className="flex flex-col gap-2 mb-3 text-ds-text-primary">
-                <div className="text-xs uppercase opacity-60">
-                  {findPlayerName(state.players, humanIdx)} ({t('cards', { count: human.cards.length })})
+                <div className="text-xs uppercase opacity-60 flex items-center gap-2 flex-wrap">
+                  <span>
+                    {findPlayerName(state.players, humanIdx)} ({t('cards', { count: human.cards.length })})
+                  </span>
+                  <span
+                    data-testid="pitch-game-pips-badge"
+                    className="normal-case inline-flex items-center rounded-full bg-ds-accent/20 text-ds-accent px-2 py-0.5 text-[11px] font-bold cursor-help"
+                    title={`${t('gamePipsTooltip')}\n${pitchHandPipBreakdown(human.cards)
+                      .filter((b) => b.pips > 0)
+                      .map((b) => `${valueLabel(b.value)}(${b.pips})`)
+                      .join(' + ')}`}
+                  >
+                    {t('gamePips', { pips: pitchHandPips(human.cards) })}
+                  </span>
                 </div>
                 <div className="flex flex-wrap gap-2">
                   {human.cards.map((c, idx) => {

--- a/frontend/src/pages/PitchPage.tsx
+++ b/frontend/src/pages/PitchPage.tsx
@@ -298,10 +298,16 @@ function PitchPageContent() {
                   <span
                     data-testid="pitch-game-pips-badge"
                     className="normal-case inline-flex items-center rounded-full bg-ds-accent/20 text-ds-accent px-2 py-0.5 text-[11px] font-bold cursor-help"
-                    title={`${t('gamePipsTooltip')}\n${pitchHandPipBreakdown(human.cards)
-                      .filter((b) => b.pips > 0)
-                      .map((b) => `${valueLabel(b.value)}(${b.pips})`)
-                      .join(' + ')}`}
+                    title={
+                      t('gamePipsTooltip') +
+                      (pitchHandPips(human.cards) > 0
+                        ? '\n' +
+                          pitchHandPipBreakdown(human.cards)
+                            .filter((b) => b.pips > 0)
+                            .map((b) => `${valueLabel(b.value)}(${b.pips})`)
+                            .join(' + ')
+                        : '')
+                    }
                   >
                     {t('gamePips', { pips: pitchHandPips(human.cards) })}
                   </span>

--- a/frontend/src/utils/pitchUtils.test.ts
+++ b/frontend/src/utils/pitchUtils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { pitchHandPipBreakdown, pitchHandPips, pitchPipValue } from './pitchUtils';
+
+const c = (value: number, design: Card['design'] = 'SPADE'): Card => ({ design, value });
+
+describe('pitchPipValue', () => {
+  it.each([
+    [1, 4],
+    [10, 10],
+    [11, 1],
+    [12, 2],
+    [13, 3],
+  ])('value %i scores %i pip(s)', (value, expected) => {
+    expect(pitchPipValue(value)).toBe(expected);
+  });
+
+  it.each([2, 3, 4, 5, 6, 7, 8, 9])('value %i scores 0 pips', (value) => {
+    expect(pitchPipValue(value)).toBe(0);
+  });
+});
+
+describe('pitchHandPips', () => {
+  it('returns 0 for an empty hand', () => {
+    expect(pitchHandPips([])).toBe(0);
+  });
+
+  it('sums pip values across the hand', () => {
+    // A(4) + 10(10) + J(1) + 7(0) = 15
+    expect(pitchHandPips([c(1), c(10), c(11), c(7)])).toBe(15);
+  });
+
+  it('includes K and Q in the total', () => {
+    // K(3) + Q(2) + 5(0) = 5
+    expect(pitchHandPips([c(13), c(12), c(5)])).toBe(5);
+  });
+});
+
+describe('pitchHandPipBreakdown', () => {
+  it('returns the per-card breakdown in hand order', () => {
+    expect(pitchHandPipBreakdown([c(1), c(10), c(7)])).toEqual([
+      { value: 1, pips: 4 },
+      { value: 10, pips: 10 },
+      { value: 7, pips: 0 },
+    ]);
+  });
+});

--- a/frontend/src/utils/pitchUtils.ts
+++ b/frontend/src/utils/pitchUtils.ts
@@ -1,0 +1,33 @@
+import type { Card } from '../types/card';
+
+/**
+ * Pitch "Game" point pip values. Only A, K, Q, J, and 10 contribute; all other
+ * cards score 0. The "Game" point at end-of-hand goes to whoever captured the
+ * most pips.
+ */
+const PIP_VALUE: Readonly<Record<number, number>> = {
+  1: 4, // Ace
+  10: 10,
+  11: 1, // Jack
+  12: 2, // Queen
+  13: 3, // King
+};
+
+/** Returns the Pitch Game-point pip value for a single card (0 for 2..9). */
+export function pitchPipValue(value: number): number {
+  return PIP_VALUE[value] ?? 0;
+}
+
+/**
+ * Returns the total Pitch Game-point pip value across a hand. Used by the
+ * UI assist badge (#1891) so players don't have to mentally sum their hand
+ * every bid.
+ */
+export function pitchHandPips(hand: readonly Card[]): number {
+  return hand.reduce((sum, c) => sum + pitchPipValue(c.value), 0);
+}
+
+/** Returns the per-card breakdown for the hand, in input order. */
+export function pitchHandPipBreakdown(hand: readonly Card[]): { value: number; pips: number }[] {
+  return hand.map((c) => ({ value: c.value, pips: pitchPipValue(c.value) }));
+}


### PR DESCRIPTION
Closes #1891

## Summary
- New util `pitchHandPips(hand)` / `pitchHandPipBreakdown(hand)`.
- Adds a "Game値: N" badge next to the player-hand label on `PitchPage`. Title tooltip lists the contributing cards (`A(4) + 10(10) + J(1)`).
- ja + en i18n strings added (`pitch.gamePips`, `pitch.gamePipsTooltip`).

## Test plan
- [x] `bun run test -- --run pitchUtils PitchPage` (24 passed)
- [ ] CI 緑
- [ ] `/pitch` で手札に A/10/J/Q/K がある状態を見ると、合計ピップが正しく表示されること
- [ ] バッジをホバーすると内訳がツールチップで見えること