### PR TITLE
feat(baccarat): staged third-card reveal animation (#1892)

### DIFF
--- a/frontend/src/pages/BaccaratPage.test.tsx
+++ b/frontend/src/pages/BaccaratPage.test.tsx
@@ -148,7 +148,8 @@ describe('BaccaratPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
     await waitFor(() => expect(screen.getByText('プレイヤーの勝ち！')).toBeInTheDocument());
-    expect(screen.getByText('配当: 200')).toBeInTheDocument();
+    // Payout is gated behind the staged-reveal final step (#1892).
+    await waitFor(() => expect(screen.getByText('配当: 200')).toBeInTheDocument());
     expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument();
   });
 
@@ -168,7 +169,8 @@ describe('BaccaratPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
     await waitFor(() => expect(screen.getByText('引き分け！')).toBeInTheDocument());
-    expect(screen.getByText('配当: 900')).toBeInTheDocument();
+    // Payout is gated behind the staged-reveal final step (#1892).
+    await waitFor(() => expect(screen.getByText('配当: 900')).toBeInTheDocument());
   });
 
   it('can change bet amount and bet type', async () => {
@@ -511,6 +513,56 @@ describe('BaccaratPage', () => {
     fireEvent.keyDown(document, { key: 'e' });
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bet', 100, 0, 0, 0));
+  });
+
+  it('staggers the third-card reveal: 3rd card hidden until its timer fires, payout gated until last step', async () => {
+    vi.useFakeTimers();
+    try {
+      const endWithThirdCards: BaccaratResponse = {
+        ...endPhasePlayerWins,
+        playerHand: [card('SPADE', 9), card('HEART', 3), card('CLOVER', 2)],
+        bankerHand: [card('DIAMOND', 4), card('SPADE', 2), card('HEART', 6)],
+        playerHandValue: 4,
+        bankerHandValue: 2,
+      };
+      mockExec.mockResolvedValue(endWithThirdCards);
+      renderWithProviders(<BaccaratPage />);
+      // Step 1: initial 2 + 2 cards.
+      await vi.waitFor(() => {
+        expect(screen.getByTestId('bac-player-cards').childElementCount).toBe(2);
+      });
+      expect(screen.getByTestId('bac-banker-cards').childElementCount).toBe(2);
+      expect(screen.queryByTestId('bac-payout')).not.toBeInTheDocument();
+      // Step 2: player's third card lands.
+      await vi.advanceTimersByTimeAsync(600);
+      expect(screen.getByTestId('bac-player-cards').childElementCount).toBe(3);
+      expect(screen.getByTestId('bac-banker-cards').childElementCount).toBe(2);
+      // Step 3: banker's third card lands.
+      await vi.advanceTimersByTimeAsync(600);
+      expect(screen.getByTestId('bac-banker-cards').childElementCount).toBe(3);
+      expect(screen.queryByTestId('bac-payout')).not.toBeInTheDocument();
+      // Step 4: payout appears.
+      await vi.advanceTimersByTimeAsync(600);
+      expect(screen.getByTestId('bac-payout')).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('no third-card stagger when both hands stand on 2 cards (skips straight to payout)', async () => {
+    vi.useFakeTimers();
+    try {
+      mockExec.mockResolvedValue(endPhasePlayerWins);
+      renderWithProviders(<BaccaratPage />);
+      await vi.waitFor(() => {
+        expect(screen.getByTestId('bac-player-cards').childElementCount).toBe(2);
+      });
+      // No third-card delays; only the final payout reveal at +600ms.
+      await vi.advanceTimersByTimeAsync(600);
+      expect(screen.getByTestId('bac-payout')).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('payout table is rendered as a collapsible details element in bet phase', async () => {

--- a/frontend/src/pages/BaccaratPage.test.tsx
+++ b/frontend/src/pages/BaccaratPage.test.tsx
@@ -549,6 +549,43 @@ describe('BaccaratPage', () => {
     }
   });
 
+  it('header hand value tracks the visible slice, not the final server value (no spoilers)', async () => {
+    vi.useFakeTimers();
+    try {
+      // Player: [9,3,2] → final 4. Two-card total: 9+3 = 12 % 10 = 2.
+      // Banker: [4,2,6] → final 2. Two-card total: 4+2 = 6.
+      const endWithThirdCards: BaccaratResponse = {
+        ...endPhasePlayerWins,
+        playerHand: [card('SPADE', 9), card('HEART', 3), card('CLOVER', 2)],
+        bankerHand: [card('DIAMOND', 4), card('SPADE', 2), card('HEART', 6)],
+        playerHandValue: 4,
+        bankerHandValue: 2,
+      };
+      mockExec.mockResolvedValue(endWithThirdCards);
+      renderWithProviders(<BaccaratPage />);
+      await vi.waitFor(() => {
+        expect(screen.getByTestId('bac-player-cards').childElementCount).toBe(2);
+      });
+      // Header values are split across sibling text nodes ("プレイヤー" + space + "値: N"),
+      // so query the row by data-testid and assert on its full textContent instead.
+      const playerHeader = screen.getByTestId('bac-player-cards').previousElementSibling as HTMLElement;
+      const bankerHeader = screen.getByTestId('bac-banker-cards').previousElementSibling as HTMLElement;
+      // Step 1: two-card totals (not the final server values 4 / 2).
+      expect(playerHeader.textContent).toContain('値: 2');
+      expect(bankerHeader.textContent).toContain('値: 6');
+      // Step 2: player's third card lands → 9+3+2 = 14 % 10 = 4. Banker still at 6.
+      await vi.advanceTimersByTimeAsync(600);
+      expect(playerHeader.textContent).toContain('値: 4');
+      expect(bankerHeader.textContent).toContain('値: 6');
+      // Step 3: banker's third card lands → 4+2+6 = 12 % 10 = 2. Player stays at 4.
+      await vi.advanceTimersByTimeAsync(600);
+      expect(playerHeader.textContent).toContain('値: 4');
+      expect(bankerHeader.textContent).toContain('値: 2');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('no third-card stagger when both hands stand on 2 cards (skips straight to payout)', async () => {
     vi.useFakeTimers();
     try {

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -26,7 +26,7 @@ import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { BaccaratResponse, BaccaratSideBetResult } from '../types/card';
+import type { BaccaratResponse, BaccaratSideBetResult, Card } from '../types/card';
 import { BaccaratBetType, BaccaratPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { BACCARAT_HELP, parseBaccaratCommand } from '../utils/cli/commands/baccaratCommands';
@@ -70,6 +70,18 @@ const BAC_TUTORIAL_STEPS: TutorialStep[] = [
 const ROAD_PLAYER = 0;
 const ROAD_BANKER = 1;
 const ROAD_MAX_ROWS = 6;
+
+/**
+ * Baccarat hand value for the visible card slice. Aces=1, 2-9=face, 10/J/Q/K=0,
+ * total mod 10. Mirrors the server's scoring rule and lets us paint an
+ * intermediate header total during the staged reveal (#1892) without spoiling
+ * the third card.
+ */
+function baccaratHandValue(cards: readonly Card[]): number {
+  let total = 0;
+  for (const c of cards) total += c.value >= 10 ? 0 : c.value;
+  return total % 10;
+}
 
 function BigRoadGrid({ history }: { history: number[] }) {
   if (history.length === 0) return null;
@@ -226,6 +238,7 @@ function BaccaratPageContent() {
   const bankerHand = state?.bankerHand ?? [];
   const handSignature = isEndPhase ? `${playerHand.length}:${bankerHand.length}:${state?.payout ?? 0}` : 'bet';
   const [revealStep, setRevealStep] = useState(0);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: handSignature already encodes playerHand.length and bankerHand.length — listing them would re-fire the effect for the same hand.
   useEffect(() => {
     if (!isEndPhase) {
       setRevealStep(0);
@@ -236,7 +249,7 @@ function BaccaratPageContent() {
     let delay = 600;
     if (playerHand.length === 3) {
       const d = delay;
-      timers.push(setTimeout(() => setRevealStep(2), d));
+      timers.push(setTimeout(() => setRevealStep((s) => Math.max(s, 2)), d));
       delay += 600;
     }
     if (bankerHand.length === 3) {
@@ -244,16 +257,22 @@ function BaccaratPageContent() {
       timers.push(setTimeout(() => setRevealStep((s) => Math.max(s, 3)), d));
       delay += 600;
     }
-    timers.push(setTimeout(() => setRevealStep(4), delay));
+    timers.push(setTimeout(() => setRevealStep((s) => Math.max(s, 4)), delay));
     return () => {
       for (const timer of timers) clearTimeout(timer);
     };
-    // playerHand/bankerHand are stable for a given handSignature.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isEndPhase, handSignature]);
   const playerCardsShown = revealStep >= 2 ? playerHand.length : Math.min(playerHand.length, 2);
   const bankerCardsShown = revealStep >= 3 ? bankerHand.length : Math.min(bankerHand.length, 2);
-  const showResultDetails = !isEndPhase || revealStep >= 4;
+  // showResultDetails is only consumed under `isEndPhase && ...`, so the !isEndPhase branch
+  // was unreachable; collapse to the meaningful condition.
+  const showResultDetails = revealStep >= 4;
+
+  // Visible baccarat hand value for the currently revealed slice, so the header
+  // total doesn't spoil the third card before it animates in. A=1, 2-9=face,
+  // 10/J/Q/K=0, total mod 10.
+  const visiblePlayerValue = isEndPhase ? baccaratHandValue(playerHand.slice(0, playerCardsShown)) : 0;
+  const visibleBankerValue = isEndPhase ? baccaratHandValue(bankerHand.slice(0, bankerCardsShown)) : 0;
 
   const handleBet = useCallback(() => {
     setLastBet({ amount: betAmount, type: betType, pp: playerPairBet, bp: bankerPairBet });
@@ -348,7 +367,8 @@ function BaccaratPageContent() {
             {state.playerHand.length > 0 && (
               <div className="mb-4" data-tutorial="bac-player-hand">
                 <div className="text-ds-warning font-bold text-center mb-1">
-                  <span aria-hidden="true">🟡</span> {t('player')} {t('label.value', { value: state.playerHandValue })}
+                  <span aria-hidden="true">🟡</span> {t('player')}{' '}
+                  {t('label.value', { value: isEndPhase ? visiblePlayerValue : state.playerHandValue })}
                 </div>
                 <div className="flex justify-center gap-2" data-testid="bac-player-cards">
                   {state.playerHand.slice(0, playerCardsShown).map((card, i) => (
@@ -362,7 +382,8 @@ function BaccaratPageContent() {
             {state.bankerHand.length > 0 && (
               <div className="mb-4" data-tutorial="bac-banker-hand">
                 <div className="text-ds-error font-bold text-center mb-1">
-                  <span aria-hidden="true">🔴</span> {t('banker')} {t('label.value', { value: state.bankerHandValue })}
+                  <span aria-hidden="true">🔴</span> {t('banker')}{' '}
+                  {t('label.value', { value: isEndPhase ? visibleBankerValue : state.bankerHandValue })}
                 </div>
                 <div className="flex justify-center gap-2" data-testid="bac-banker-cards">
                   {state.bankerHand.slice(0, bankerCardsShown).map((card, i) => (

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { baccaratApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -218,6 +218,43 @@ function BaccaratPageContent() {
   const isBetPhase = state?.phase === BaccaratPhase.BET;
   const isEndPhase = state?.phase === BaccaratPhase.END;
 
+  // Staged reveal for the showdown so the third-card rule isn't a black box (#1892).
+  // Steps: 1 = initial 2+2 cards, 2 = player's 3rd, 3 = banker's 3rd, 4 = payout/result.
+  // The hand "signature" string keys the effect so each new round restarts the animation
+  // without flicker mid-render.
+  const playerHand = state?.playerHand ?? [];
+  const bankerHand = state?.bankerHand ?? [];
+  const handSignature = isEndPhase ? `${playerHand.length}:${bankerHand.length}:${state?.payout ?? 0}` : 'bet';
+  const [revealStep, setRevealStep] = useState(0);
+  useEffect(() => {
+    if (!isEndPhase) {
+      setRevealStep(0);
+      return;
+    }
+    setRevealStep(1);
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    let delay = 600;
+    if (playerHand.length === 3) {
+      const d = delay;
+      timers.push(setTimeout(() => setRevealStep(2), d));
+      delay += 600;
+    }
+    if (bankerHand.length === 3) {
+      const d = delay;
+      timers.push(setTimeout(() => setRevealStep((s) => Math.max(s, 3)), d));
+      delay += 600;
+    }
+    timers.push(setTimeout(() => setRevealStep(4), delay));
+    return () => {
+      for (const timer of timers) clearTimeout(timer);
+    };
+    // playerHand/bankerHand are stable for a given handSignature.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isEndPhase, handSignature]);
+  const playerCardsShown = revealStep >= 2 ? playerHand.length : Math.min(playerHand.length, 2);
+  const bankerCardsShown = revealStep >= 3 ? bankerHand.length : Math.min(bankerHand.length, 2);
+  const showResultDetails = !isEndPhase || revealStep >= 4;
+
   const handleBet = useCallback(() => {
     setLastBet({ amount: betAmount, type: betType, pp: playerPairBet, bp: bankerPairBet });
     execApi('bet', betAmount, betType, playerPairBet, bankerPairBet);
@@ -307,43 +344,43 @@ function BaccaratPageContent() {
               messageParams={state.messageParams}
             />
 
-            {/* Player Hand */}
+            {/* Player Hand — staged reveal hides the 3rd card until step 2 */}
             {state.playerHand.length > 0 && (
               <div className="mb-4" data-tutorial="bac-player-hand">
                 <div className="text-ds-warning font-bold text-center mb-1">
                   <span aria-hidden="true">🟡</span> {t('player')} {t('label.value', { value: state.playerHandValue })}
                 </div>
-                <div className="flex justify-center gap-2">
-                  {state.playerHand.map((card, i) => (
+                <div className="flex justify-center gap-2" data-testid="bac-player-cards">
+                  {state.playerHand.slice(0, playerCardsShown).map((card, i) => (
                     <AnimatedCard key={`p-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                   ))}
                 </div>
               </div>
             )}
 
-            {/* Banker Hand */}
+            {/* Banker Hand — staged reveal hides the 3rd card until step 3 */}
             {state.bankerHand.length > 0 && (
               <div className="mb-4" data-tutorial="bac-banker-hand">
                 <div className="text-ds-error font-bold text-center mb-1">
                   <span aria-hidden="true">🔴</span> {t('banker')} {t('label.value', { value: state.bankerHandValue })}
                 </div>
-                <div className="flex justify-center gap-2">
-                  {state.bankerHand.map((card, i) => (
+                <div className="flex justify-center gap-2" data-testid="bac-banker-cards">
+                  {state.bankerHand.slice(0, bankerCardsShown).map((card, i) => (
                     <AnimatedCard key={`b-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                   ))}
                 </div>
               </div>
             )}
 
-            {/* Payout info */}
-            {isEndPhase && (
-              <div className="text-ds-text-primary text-center font-bold mb-2">
+            {/* Payout info — gated behind the final reveal step */}
+            {isEndPhase && showResultDetails && (
+              <div className="text-ds-text-primary text-center font-bold mb-2" data-testid="bac-payout">
                 {t('label.payout', { payout: state.payout })}
               </div>
             )}
 
-            {/* Side bet results */}
-            {isEndPhase && state.sideBetResults.length > 0 && (
+            {/* Side bet results — gated behind the final reveal step */}
+            {isEndPhase && showResultDetails && state.sideBetResults.length > 0 && (
               <SideBetResultsDisplay results={state.sideBetResults} t={t} />
             )}
 


### PR DESCRIPTION
Closes #1892

## Summary
- Adds a `revealStep` state machine in `BaccaratPage`:
  1. Initial 2+2 cards
  2. Player's third card (if drawn) — 600ms later
  3. Banker's third card (if drawn) — another 600ms
  4. Payout banner — final 600ms
- Player/banker hands now render `slice(0, shown)`; payout & side-bet results gate on the final step.
- When neither side draws a third card, only the initial deal + payout fire (no wasted delay on simple hands).
- The hand "signature" string keys the reveal effect so a fresh round restarts the animation cleanly.

## Test plan
- [x] `bun run test -- --run BaccaratPage` (42 passed; 2 new staged-reveal cases)
- [ ] CI 緑
- [ ] `/baccarat` でプレイヤー第3枚が引かれる手を見ると、2枚→2枚→プレイヤー3枚目→バンカー3枚目→配当の順にじわじわ表示されること
- [ ] スタンド (2 vs 2) のときはすぐに配当が出ること