### PR TITLE
feat(reddog): ghost rank chips visualise winning spread (#1914)

### DIFF
--- a/frontend/src/i18n/locales/en/reddog.json
+++ b/frontend/src/i18n/locales/en/reddog.json
@@ -7,7 +7,8 @@
     "raise": "Raise",
     "spread": "Spread",
     "initial": "Initial",
-    "third": "Third"
+    "third": "Third",
+    "winners": "Winning ranks"
   },
   "button": {
     "bet": "Bet",

--- a/frontend/src/i18n/locales/ja/reddog.json
+++ b/frontend/src/i18n/locales/ja/reddog.json
@@ -7,7 +7,8 @@
     "raise": "レイズ",
     "spread": "スプレッド",
     "initial": "初手",
-    "third": "3枚目"
+    "third": "3枚目",
+    "winners": "当たり"
   },
   "button": {
     "bet": "ベット",

--- a/frontend/src/pages/RedDogPage.test.tsx
+++ b/frontend/src/pages/RedDogPage.test.tsx
@@ -129,4 +129,21 @@ describe('RedDogPage', () => {
     renderWithProviders(<RedDogPage />);
     await waitFor(() => expect(mockUseCliMode).toHaveBeenCalledWith('reddog'));
   });
+
+  it('shows ghost rank chips for winning ranks during spread decision', async () => {
+    mockApi.mockResolvedValue(spreadState);
+    renderWithProviders(<RedDogPage />);
+    await waitFor(() => expect(screen.getByTestId('reddog-ghost-ranks')).toBeInTheDocument());
+    for (const r of [6, 7, 8, 9]) {
+      expect(screen.getByTestId(`reddog-ghost-${r}`)).toBeInTheDocument();
+    }
+  });
+
+  it('marks the hit ghost chip in end phase', async () => {
+    mockApi.mockResolvedValue(winState);
+    renderWithProviders(<RedDogPage />);
+    await waitFor(() => expect(screen.getByTestId('reddog-ghost-7')).toBeInTheDocument());
+    const hitChip = screen.getByTestId('reddog-ghost-7');
+    expect(hitChip.className).toContain('bg-ds-success');
+  });
 });

--- a/frontend/src/pages/RedDogPage.tsx
+++ b/frontend/src/pages/RedDogPage.tsx
@@ -25,12 +25,13 @@ import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { RedDogResponse } from '../types/card';
+import type { Card, RedDogResponse } from '../types/card';
 import { RedDogPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { parseReddogCommand, REDDOG_HELP } from '../utils/cli/commands/reddogCommands';
 import { formatReddogState } from '../utils/cli/formatters/reddogFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { rankLabel, redDogRank, reddogWinningRanks } from '../utils/reddogWinningRanks';
 
 /** Minimum bet amount matching backend RedDogMinBet. */
 const REDDOG_MIN_BET = 10;
@@ -191,9 +192,16 @@ function RedDogPageContent() {
                   ))}
                 </div>
                 {state.spread > 0 && (isSpreadDecision || isEndPhase) && (
-                  <div className="text-ds-text-primary text-center text-sm mt-2">
-                    {t('label.spread')}: {state.spread}
-                  </div>
+                  <>
+                    <div className="text-ds-text-primary text-center text-sm mt-2">
+                      {t('label.spread')}: {state.spread}
+                    </div>
+                    <WinningRankGhosts
+                      initial={state.initialCards}
+                      thirdRank={isEndPhase && state.thirdCard ? redDogRank(state.thirdCard) : null}
+                      label={t('label.winners')}
+                    />
+                  </>
                 )}
               </div>
             )}
@@ -276,5 +284,44 @@ function RedDogPageContent() {
         </>
       )}
     </GamePageShell>
+  );
+}
+
+interface WinningRankGhostsProps {
+  initial: Card[];
+  thirdRank: number | null;
+  label: string;
+}
+
+/** Translucent rank chips shown between the two initial cards: each chip is
+ * a rank the third card needs to hit to win. On END phase the matching chip
+ * is filled green (hit) and others fade to muted (miss). */
+function WinningRankGhosts({ initial, thirdRank, label }: WinningRankGhostsProps) {
+  const ranks = reddogWinningRanks(initial);
+  if (ranks.length === 0) return null;
+  return (
+    <div className="mt-2 flex flex-col items-center gap-1" data-testid="reddog-ghost-ranks">
+      <div className="text-ds-text-muted text-xs">{label}</div>
+      <div className="flex flex-wrap justify-center gap-1">
+        {ranks.map((r) => {
+          const isHit = thirdRank === r;
+          const isResolved = thirdRank != null;
+          const cls = isHit
+            ? 'bg-ds-success/70 text-white border-ds-success'
+            : isResolved
+              ? 'bg-white/5 text-ds-text-muted border-white/10 opacity-50'
+              : 'bg-white/15 text-ds-text-primary border-white/30';
+          return (
+            <span
+              key={`ghost-${r}`}
+              data-testid={`reddog-ghost-${r}`}
+              className={`rounded border px-2 py-0.5 text-xs font-mono ${cls}`}
+            >
+              {rankLabel(r)}
+            </span>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/frontend/src/pages/RedDogPage.tsx
+++ b/frontend/src/pages/RedDogPage.tsx
@@ -297,7 +297,7 @@ interface WinningRankGhostsProps {
  * a rank the third card needs to hit to win. On END phase the matching chip
  * is filled green (hit) and others fade to muted (miss). */
 function WinningRankGhosts({ initial, thirdRank, label }: WinningRankGhostsProps) {
-  const ranks = reddogWinningRanks(initial);
+  const ranks = useMemo(() => reddogWinningRanks(initial), [initial]);
   if (ranks.length === 0) return null;
   return (
     <div className="mt-2 flex flex-col items-center gap-1" data-testid="reddog-ghost-ranks">

--- a/frontend/src/utils/reddogWinningRanks.test.ts
+++ b/frontend/src/utils/reddogWinningRanks.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { rankLabel, redDogRank, reddogWinningRanks } from './reddogWinningRanks';
+
+const c = (value: number): Card => ({ design: 'SPADE', value });
+
+describe('reddogWinningRanks', () => {
+  it('returns the ranks strictly between the two initial cards', () => {
+    expect(reddogWinningRanks([c(4), c(9)])).toEqual([5, 6, 7, 8]);
+  });
+
+  it('treats ace as the high rank (14)', () => {
+    expect(reddogWinningRanks([c(11), c(1)])).toEqual([12, 13]);
+  });
+
+  it('returns [] on pair', () => {
+    expect(reddogWinningRanks([c(7), c(7)])).toEqual([]);
+  });
+
+  it('returns [] on consecutive ranks', () => {
+    expect(reddogWinningRanks([c(7), c(8)])).toEqual([]);
+  });
+
+  it('returns [] when initial does not have exactly 2 cards', () => {
+    expect(reddogWinningRanks([])).toEqual([]);
+    expect(reddogWinningRanks([c(5)])).toEqual([]);
+  });
+
+  it('is unaffected by input order', () => {
+    expect(reddogWinningRanks([c(10), c(3)])).toEqual([4, 5, 6, 7, 8, 9]);
+  });
+});
+
+describe('redDogRank', () => {
+  it('promotes ace to 14', () => {
+    expect(redDogRank(c(1))).toBe(14);
+  });
+  it('returns the value as-is for 2..K', () => {
+    expect(redDogRank(c(2))).toBe(2);
+    expect(redDogRank(c(13))).toBe(13);
+  });
+});
+
+describe('rankLabel', () => {
+  it('formats face cards', () => {
+    expect(rankLabel(14)).toBe('A');
+    expect(rankLabel(13)).toBe('K');
+    expect(rankLabel(12)).toBe('Q');
+    expect(rankLabel(11)).toBe('J');
+  });
+  it('formats number cards', () => {
+    expect(rankLabel(7)).toBe('7');
+  });
+});

--- a/frontend/src/utils/reddogWinningRanks.ts
+++ b/frontend/src/utils/reddogWinningRanks.ts
@@ -1,0 +1,36 @@
+import type { Card } from '../types/card';
+
+/** Returns the ranks (Red Dog rank space — A=14) that the third card must
+ * hit for the player to win, given the two initial cards. Returns an empty
+ * array on pair or consecutive (no in-between ranks). */
+export function reddogWinningRanks(initial: Card[]): number[] {
+  if (initial.length !== 2) return [];
+  const r1 = redDogRank(initial[0]);
+  const r2 = redDogRank(initial[1]);
+  const lo = Math.min(r1, r2);
+  const hi = Math.max(r1, r2);
+  const out: number[] = [];
+  for (let r = lo + 1; r < hi; r++) out.push(r);
+  return out;
+}
+
+/** Maps a card value to Red Dog rank space (A=14, K=13, … 2=2). */
+export function redDogRank(c: Card): number {
+  return c.value === 1 ? 14 : c.value;
+}
+
+/** Short rank label suitable for chip display. */
+export function rankLabel(rank: number): string {
+  switch (rank) {
+    case 14:
+      return 'A';
+    case 13:
+      return 'K';
+    case 12:
+      return 'Q';
+    case 11:
+      return 'J';
+    default:
+      return String(rank);
+  }
+}

--- a/frontend/src/utils/reddogWinningRanks.ts
+++ b/frontend/src/utils/reddogWinningRanks.ts
@@ -9,9 +9,7 @@ export function reddogWinningRanks(initial: Card[]): number[] {
   const r2 = redDogRank(initial[1]);
   const lo = Math.min(r1, r2);
   const hi = Math.max(r1, r2);
-  const out: number[] = [];
-  for (let r = lo + 1; r < hi; r++) out.push(r);
-  return out;
+  return Array.from({ length: Math.max(0, hi - lo - 1) }, (_, i) => lo + 1 + i);
 }
 
 /** Maps a card value to Red Dog rank space (A=14, K=13, … 2=2). */


### PR DESCRIPTION
Closes #1914

## Summary
- New `reddogWinningRanks` util computes the inclusive in-between rank
  list using the same A=14 rank mapping as the backend `rankOf`.
- `RedDogPage` renders a `WinningRankGhosts` row under the spread label:
  one chip per winning rank during SPREAD_DECISION, and on END the
  matching chip fills green while the misses fade to muted.
- No change for pair/consecutive — the util returns `[]` and the row
  doesn't render.

## Test plan
- [x] `bun run test -- --run reddog` (47 passed; new util + page cases)
- [x] `bun run check` (clean)
- [ ] CI 緑
- [ ] `/reddog` で 4 と 9 の初手だと 5/6/7/8 の薄いチップが表示されること
- [ ] 3 枚目が 7 のとき 7 だけ緑で光り、他は薄く落ちること
- [ ] ペア手や連続手ではゴーストが出ないこと