### PR TITLE
feat(memory): mark previously-seen cards with eye overlay (#1915)

### DIFF
--- a/frontend/src/i18n/locales/en/memory.json
+++ b/frontend/src/i18n/locales/en/memory.json
@@ -20,6 +20,7 @@
   },
   "scores": "Scores",
   "cardFaceDown": "Card {{position}} (face down)",
+  "visitedMark": "Already seen",
   "scoreLine": "{{name}}: {{count}}",
   "nextButton": "Next",
   "flipPrompt1": "Flip the first card",

--- a/frontend/src/i18n/locales/ja/memory.json
+++ b/frontend/src/i18n/locales/ja/memory.json
@@ -20,6 +20,7 @@
   },
   "scores": "スコア",
   "cardFaceDown": "{{position}}枚目のカード（裏向き）",
+  "visitedMark": "一度めくったカード",
   "scoreLine": "{{name}}: {{count}}",
   "nextButton": "次へ",
   "flipPrompt1": "1枚目をめくってください",

--- a/frontend/src/pages/MemoryPage.test.tsx
+++ b/frontend/src/pages/MemoryPage.test.tsx
@@ -211,6 +211,33 @@ describe('MemoryPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, { cpuDifficulty: 1 }));
   });
 
+  it('does not show visited badge on a freshly dealt board', async () => {
+    renderWithProviders(<MemoryPage />);
+    await waitFor(() => expect(screen.getByText(/あなた: 0/)).toBeInTheDocument());
+    expect(screen.queryByTestId('board-visited-5')).not.toBeInTheDocument();
+  });
+
+  it('marks a previously face-up card with the visited overlay after it turns down', async () => {
+    // Start with a RESULT-phase state showing card 5 face-up: visited set records 5.
+    const seenState: MemoryResponse = {
+      ...flip1State,
+      phase: 2,
+      firstFlipPos: 5,
+      secondFlipPos: 10,
+      board: makeBoard({
+        5: { faceUp: true, card: { design: 'SPADE' as const, value: 3 } },
+        10: { faceUp: true, card: { design: 'HEART' as const, value: 7 } },
+      }),
+    };
+    mockExec.mockResolvedValueOnce(seenState);
+    renderWithProviders(<MemoryPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ 3')).toBeInTheDocument());
+    // After Next the board flips face-down; the visited overlay should appear.
+    mockExec.mockResolvedValue(flip1State);
+    fireEvent.click(screen.getByRole('button', { name: '次へ' }));
+    await waitFor(() => expect(screen.getByTestId('board-visited-5')).toBeInTheDocument());
+  });
+
   it('face-down cards show card back image instead of position number', async () => {
     renderWithProviders(<MemoryPage />);
     await waitFor(() => expect(screen.getByText(/あなた: 0/)).toBeInTheDocument());

--- a/frontend/src/pages/MemoryPage.test.tsx
+++ b/frontend/src/pages/MemoryPage.test.tsx
@@ -218,7 +218,11 @@ describe('MemoryPage', () => {
   });
 
   it('marks a previously face-up card with the visited overlay after it turns down', async () => {
-    // Start with a RESULT-phase state showing card 5 face-up: visited set records 5.
+    // Regression: an early version reset `visited` whenever the board was
+    // fully face-down + nothing-taken, which is the normal between-turn
+    // state before the first pair is taken. After Next, the board flips
+    // face-down with no `taken` cards — the badge for the previously
+    // face-up positions must still appear.
     const seenState: MemoryResponse = {
       ...flip1State,
       phase: 2,
@@ -232,10 +236,10 @@ describe('MemoryPage', () => {
     mockExec.mockResolvedValueOnce(seenState);
     renderWithProviders(<MemoryPage />);
     await waitFor(() => expect(screen.getByAltText('♠ 3')).toBeInTheDocument());
-    // After Next the board flips face-down; the visited overlay should appear.
     mockExec.mockResolvedValue(flip1State);
     fireEvent.click(screen.getByRole('button', { name: '次へ' }));
     await waitFor(() => expect(screen.getByTestId('board-visited-5')).toBeInTheDocument());
+    expect(screen.getByTestId('board-visited-10')).toBeInTheDocument();
   });
 
   it('face-down cards show card back image instead of position number', async () => {

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -126,11 +126,6 @@ function MemoryPageContent() {
 
   useEffect(() => {
     if (!state) return;
-    const freshBoard = state.board.length > 0 && state.board.every((bc) => !bc.faceUp && !bc.taken);
-    if (freshBoard) {
-      setVisited((prev) => (prev.size === 0 ? prev : new Set()));
-      return;
-    }
     setVisited((prev) => {
       let changed = false;
       const next = new Set(prev);
@@ -267,7 +262,13 @@ function MemoryPageContent() {
                       type="button"
                       key={`board-${idx.toString()}`}
                       data-testid={`board-${idx.toString()}`}
-                      aria-label={bc.faceUp && bc.card ? cardAlt(bc.card) : t('cardFaceDown', { position: idx + 1 })}
+                      aria-label={
+                        bc.faceUp && bc.card
+                          ? cardAlt(bc.card)
+                          : wasVisited
+                            ? `${t('cardFaceDown', { position: idx + 1 })} (${t('visitedMark')})`
+                            : t('cardFaceDown', { position: idx + 1 })
+                      }
                       disabled={loading || !isHumanTurn || bc.taken || bc.faceUp}
                       onClick={() => handleFlip(idx)}
                       className={`memory-card relative aspect-[2/3] min-h-[44px] min-w-[44px] lg:aspect-auto rounded ${focusRingWhite} ${

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { memoryApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -122,8 +122,31 @@ function MemoryPageContent() {
 
   const phaseNames = usePhaseNames('memory', MEMORY_PHASE_KEYS);
 
+  const [visited, setVisited] = useState<Set<number>>(() => new Set());
+
+  useEffect(() => {
+    if (!state) return;
+    const freshBoard = state.board.length > 0 && state.board.every((bc) => !bc.faceUp && !bc.taken);
+    if (freshBoard) {
+      setVisited((prev) => (prev.size === 0 ? prev : new Set()));
+      return;
+    }
+    setVisited((prev) => {
+      let changed = false;
+      const next = new Set(prev);
+      state.board.forEach((bc, idx) => {
+        if (bc.faceUp && !next.has(idx)) {
+          next.add(idx);
+          changed = true;
+        }
+      });
+      return changed ? next : prev;
+    });
+  }, [state]);
+
   const handleManualReset = useCallback(() => {
     hideActionLog();
+    setVisited(new Set());
     void exec('reset', undefined, { cpuDifficulty: memoryConfig.cpuDifficulty });
   }, [exec, hideActionLog, memoryConfig.cpuDifficulty]);
 
@@ -237,32 +260,46 @@ function MemoryPageContent() {
               data-tutorial="mem-board"
             >
               <div className="grid grid-cols-7 gap-0.5 sm:gap-1 sm:grid-cols-8 md:grid-cols-10 lg:grid-cols-13 lg:grid-rows-4 lg:h-full">
-                {state.board.map((bc, idx) => (
-                  <button
-                    type="button"
-                    key={`board-${idx.toString()}`}
-                    data-testid={`board-${idx.toString()}`}
-                    aria-label={bc.faceUp && bc.card ? cardAlt(bc.card) : t('cardFaceDown', { position: idx + 1 })}
-                    disabled={loading || !isHumanTurn || bc.taken || bc.faceUp}
-                    onClick={() => handleFlip(idx)}
-                    className={`memory-card relative aspect-[2/3] min-h-[44px] min-w-[44px] lg:aspect-auto rounded ${focusRingWhite} ${
-                      bc.taken
-                        ? 'hidden'
-                        : bc.faceUp
-                          ? 'bg-white ring-2 ring-ds-warning shadow-lg shadow-ds-warning/30'
-                          : 'bg-ds-info border border-white/10 hover:ring-1 hover:ring-ds-warning'
-                    } transition-all`}
-                  >
-                    <div className={`memory-card-inner${bc.faceUp ? ' flipped' : ''}`}>
-                      <div className="memory-card-back">
-                        <img src="/images/z01.png" alt="" className="w-full h-full object-contain rounded" />
+                {state.board.map((bc, idx) => {
+                  const wasVisited = !bc.faceUp && !bc.taken && visited.has(idx);
+                  return (
+                    <button
+                      type="button"
+                      key={`board-${idx.toString()}`}
+                      data-testid={`board-${idx.toString()}`}
+                      aria-label={bc.faceUp && bc.card ? cardAlt(bc.card) : t('cardFaceDown', { position: idx + 1 })}
+                      disabled={loading || !isHumanTurn || bc.taken || bc.faceUp}
+                      onClick={() => handleFlip(idx)}
+                      className={`memory-card relative aspect-[2/3] min-h-[44px] min-w-[44px] lg:aspect-auto rounded ${focusRingWhite} ${
+                        bc.taken
+                          ? 'hidden'
+                          : bc.faceUp
+                            ? 'bg-white ring-2 ring-ds-warning shadow-lg shadow-ds-warning/30'
+                            : 'bg-ds-info border border-white/10 hover:ring-1 hover:ring-ds-warning'
+                      } transition-all`}
+                    >
+                      <div className={`memory-card-inner${bc.faceUp ? ' flipped' : ''}`}>
+                        <div className="memory-card-back">
+                          <img src="/images/z01.png" alt="" className="w-full h-full object-contain rounded" />
+                          {wasVisited && (
+                            <span
+                              data-testid={`board-visited-${idx.toString()}`}
+                              aria-hidden="true"
+                              className="absolute inset-0 rounded bg-black/25 pointer-events-none flex items-start justify-end p-0.5"
+                            >
+                              <span className="text-[10px] leading-none" title={t('visitedMark')}>
+                                {'\u{1F441}'}
+                              </span>
+                            </span>
+                          )}
+                        </div>
+                        <div className="memory-card-front">
+                          {bc.card && <AnimatedCard card={bc.card} width={cardWidth} />}
+                        </div>
                       </div>
-                      <div className="memory-card-front">
-                        {bc.card && <AnimatedCard card={bc.card} width={cardWidth} />}
-                      </div>
-                    </div>
-                  </button>
-                ))}
+                    </button>
+                  );
+                })}
               </div>
             </div>
 


### PR DESCRIPTION
Closes #1915

## Summary
- Tracks a `Set<number>` of board indices that have ever been face-up
  during the round. A face-down card whose index is in the set gets a
  translucent black overlay with a small 👁 glyph at the top-right.
- Set resets on manual reset and when the board snapshot is fresh
  (every card face-down + not-taken).
- Aria-hidden overlay; tooltip via the localised `visitedMark` key.

## Test plan
- [x] `bun run test -- --run MemoryPage` (47 passed; 2 new cases)
- [x] `bun run check`
- [ ] CI 緑
- [ ] `/memory` で2枚めくって不一致→「次へ」のあと、もう一度同じカード位置を見ると 👁 マークが出ていること
- [ ] リセット直後はマークが消えていること