### PR TITLE
feat(cruel): pulse shift button and prompt on stalemate (#1916)

### DIFF
--- a/frontend/src/pages/CruelPage.test.tsx
+++ b/frontend/src/pages/CruelPage.test.tsx
@@ -99,6 +99,22 @@ describe('CruelPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('shift'));
   });
 
+  it('pulses the shift button and shows a banner on stalemate', async () => {
+    mockExec.mockResolvedValue({ ...playingState, isStalemate: true });
+    renderWithProviders(<CruelPage />);
+    const shiftBtn = await screen.findByTestId('shift-button');
+    expect(shiftBtn.className).toContain('animate-pulse');
+    expect(shiftBtn).toHaveAttribute('aria-label', '手詰まりです。シフトで再構築できます');
+    expect(screen.getByTestId('cruel-stalemate-banner')).toBeInTheDocument();
+  });
+
+  it('does not pulse the shift button when not stalemate', async () => {
+    renderWithProviders(<CruelPage />);
+    const shiftBtn = await screen.findByTestId('shift-button');
+    expect(shiftBtn.className).not.toContain('animate-pulse');
+    expect(screen.queryByTestId('cruel-stalemate-banner')).not.toBeInTheDocument();
+  });
+
   it('hint button fires hint command', async () => {
     renderWithProviders(<CruelPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));

--- a/frontend/src/pages/CruelPage.tsx
+++ b/frontend/src/pages/CruelPage.tsx
@@ -494,6 +494,17 @@ function CruelPageContent() {
 
             {error && <ErrorAlert message={error} onRetry={retry} />}
 
+            {isPlaying && state.isStalemate && (
+              <div
+                data-testid="cruel-stalemate-banner"
+                className="text-sm text-ds-warning bg-ds-surface/90 border border-ds-warning rounded px-3 py-1.5 mt-1"
+                role="status"
+                aria-live="polite"
+              >
+                {t('stalemate')}
+              </div>
+            )}
+
             {state.hint && (
               <div
                 className="text-sm text-ds-accent bg-ds-surface/90 border border-ds-accent rounded px-3 py-1.5 mt-1"
@@ -527,11 +538,16 @@ function CruelPageContent() {
                 <>
                   <button
                     type="button"
-                    className={btnPrimary}
+                    className={`${btnPrimary} ${
+                      state.isStalemate
+                        ? 'ring-2 ring-ds-warning ring-offset-1 ring-offset-transparent motion-safe:animate-pulse'
+                        : ''
+                    }`}
                     onClick={handleShift}
                     disabled={loading}
                     data-tutorial="cruel-shift"
                     data-testid="shift-button"
+                    aria-label={state.isStalemate ? t('stalemate') : undefined}
                   >
                     {t('shift')}
                   </button>

--- a/frontend/src/pages/CruelPage.tsx
+++ b/frontend/src/pages/CruelPage.tsx
@@ -538,11 +538,11 @@ function CruelPageContent() {
                 <>
                   <button
                     type="button"
-                    className={`${btnPrimary} ${
+                    className={
                       state.isStalemate
-                        ? 'ring-2 ring-ds-warning ring-offset-1 ring-offset-transparent motion-safe:animate-pulse'
-                        : ''
-                    }`}
+                        ? `${btnPrimary} ring-2 ring-ds-warning ring-offset-1 ring-offset-transparent motion-safe:animate-pulse`
+                        : btnPrimary
+                    }
                     onClick={handleShift}
                     disabled={loading}
                     data-tutorial="cruel-shift"


### PR DESCRIPTION
Closes #1916

## Summary
- Shift button gets a pulsing `ring-ds-warning` outline when
  `state.isStalemate` is true. Aria-label switches to the existing
  `stalemate` localisation so screen readers also get the cue.
- New banner above the controls (role=status, aria-live=polite) shows
  the same prompt visually for sighted players.
- Reuses the existing `stalemate` translation — no new keys.

## Test plan
- [x] `bun run test -- --run CruelPage` (17 passed; 2 new cases)
- [x] `bun run check`
- [ ] CI 緑
- [ ] `/cruel` で手詰まりに到達すると、シフトボタンが脈打ち、上にバナーが出ること
- [ ] 通常時はパルスもバナーも出ないこと