### PR TITLE
feat(mighty): badge Mighty/JokerCall/Joker/Partner cards in hand (#1917)

### DIFF
--- a/frontend/src/components/CardRoleBadge.tsx
+++ b/frontend/src/components/CardRoleBadge.tsx
@@ -1,0 +1,24 @@
+/** Props for {@link CardRoleBadge}. */
+export interface CardRoleBadgeProps {
+  /** Card index in the surrounding hand — feeds the `data-testid`. */
+  idx: number;
+  /** Short visual glyph rendered inside the badge (emoji or letter). */
+  glyph: string;
+  /** Tooltip text (also exposed via `title`). */
+  title: string;
+}
+
+/** Small top-left corner badge identifying a card's special role within a
+ * game (e.g. Mighty's 👑 marker on ♠A). Shared between MobileHandGrid and
+ * any desktop hand renderer so both layouts get the same overlay. */
+export function CardRoleBadge({ idx, glyph, title }: CardRoleBadgeProps) {
+  return (
+    <span
+      data-testid={`card-role-badge-${idx}`}
+      title={title}
+      className="absolute top-0 left-0 bg-black/70 text-white rounded-br rounded-tl px-1 text-[10px] leading-tight pointer-events-none"
+    >
+      {glyph}
+    </span>
+  );
+}

--- a/frontend/src/components/MobileHandGrid.tsx
+++ b/frontend/src/components/MobileHandGrid.tsx
@@ -39,6 +39,8 @@ interface MobileHandGridProps {
   validIndices?: number[];
   /** Tooltip surfaced on cards that are present but disabled by `validIndices`. */
   restrictedTooltip?: string;
+  /** Optional badge to render in the top-left corner of a card (e.g. game-specific role marker). */
+  cardBadgeFor?: (idx: number) => { glyph: string; title: string } | null;
 }
 
 /**
@@ -54,6 +56,7 @@ export function MobileHandGrid({
   dataTutorial,
   validIndices,
   restrictedTooltip,
+  cardBadgeFor,
 }: MobileHandGridProps) {
   const viewportWidth = useWindowWidth();
   const reduced = useReducedMotion();
@@ -126,6 +129,19 @@ export function MobileHandGrid({
                       ✓
                     </span>
                   )}
+                  {(() => {
+                    const badge = cardBadgeFor?.(globalIdx);
+                    if (!badge) return null;
+                    return (
+                      <span
+                        data-testid={`card-role-badge-${globalIdx}`}
+                        title={badge.title}
+                        className="absolute top-0 left-0 bg-black/70 text-white rounded-br rounded-tl px-1 text-[10px] leading-tight pointer-events-none"
+                      >
+                        {badge.glyph}
+                      </span>
+                    );
+                  })()}
                 </button>
               );
             })}

--- a/frontend/src/components/MobileHandGrid.tsx
+++ b/frontend/src/components/MobileHandGrid.tsx
@@ -4,6 +4,7 @@ import { expansionMargin, focusRingCard, selectedCardStyle } from '../styles/car
 import type { Card } from '../types/card';
 import { cardAlt } from '../utils/cardAlt';
 import { CardImage } from './CardImage';
+import { CardRoleBadge } from './CardRoleBadge';
 
 /** Minimum number of cards before splitting into 2 rows. */
 const TWO_ROW_THRESHOLD = 4;
@@ -131,16 +132,7 @@ export function MobileHandGrid({
                   )}
                   {(() => {
                     const badge = cardBadgeFor?.(globalIdx);
-                    if (!badge) return null;
-                    return (
-                      <span
-                        data-testid={`card-role-badge-${globalIdx}`}
-                        title={badge.title}
-                        className="absolute top-0 left-0 bg-black/70 text-white rounded-br rounded-tl px-1 text-[10px] leading-tight pointer-events-none"
-                      >
-                        {badge.glyph}
-                      </span>
-                    );
+                    return badge ? <CardRoleBadge idx={globalIdx} glyph={badge.glyph} title={badge.title} /> : null;
                   })()}
                 </button>
               );

--- a/frontend/src/i18n/locales/en/mighty.json
+++ b/frontend/src/i18n/locales/en/mighty.json
@@ -48,6 +48,12 @@
     "heart": "Heart",
     "diamond": "Diamond"
   },
+  "specialRole": {
+    "mighty": "Mighty (strongest card)",
+    "jokerCall": "Joker Call",
+    "joker": "Joker",
+    "partner": "Partner card"
+  },
   "scores": "Score",
   "scoresPlayer": "Player",
   "scoresBid": "Bid",

--- a/frontend/src/i18n/locales/ja/mighty.json
+++ b/frontend/src/i18n/locales/ja/mighty.json
@@ -48,6 +48,12 @@
     "heart": "ハート",
     "diamond": "ダイヤ"
   },
+  "specialRole": {
+    "mighty": "マイティ (最強カード)",
+    "jokerCall": "ジョーカーコール",
+    "joker": "ジョーカー",
+    "partner": "副官カード"
+  },
   "scores": "スコア",
   "scoresPlayer": "プレイヤー",
   "scoresBid": "ビッド",

--- a/frontend/src/pages/MightyPage.test.tsx
+++ b/frontend/src/pages/MightyPage.test.tsx
@@ -266,6 +266,32 @@ describe('MightyPage', () => {
     });
   });
 
+  it('badges Mighty and partner cards in the human hand', async () => {
+    // With trumpSuit=3 (HEART) the Mighty card is ♠A.
+    const heartTrump: MightyResponse = {
+      ...playPhaseState,
+      trumpSuit: 3,
+      partnerCard: { design: 'HEART', value: 11 },
+      players: playPhaseState.players.map((p, i) =>
+        i === 0
+          ? {
+              ...p,
+              cards: [
+                { design: 'SPADE', value: 1 },
+                { design: 'HEART', value: 11 },
+                { design: 'DIAMOND', value: 8 },
+              ],
+            }
+          : p,
+      ),
+    };
+    mockCall.mockResolvedValue(heartTrump);
+    renderWithProviders(<MightyPage />);
+    await waitFor(() => expect(screen.getByTestId('card-role-badge-0')).toBeInTheDocument());
+    expect(screen.getByTestId('card-role-badge-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('card-role-badge-2')).not.toBeInTheDocument();
+  });
+
   it('renders bid phase with bid button and input', async () => {
     mockCall.mockResolvedValue(bidPhaseState);
     renderWithProviders(<MightyPage />);

--- a/frontend/src/pages/MightyPage.tsx
+++ b/frontend/src/pages/MightyPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import type { mightyApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
+import { CardRoleBadge } from '../components/CardRoleBadge';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
@@ -208,6 +209,15 @@ function MightyPageContent() {
     );
 
   const humanPlayer = state.players.find((p) => p.isHuman);
+  const partnerCard = state.partnerCard ?? null;
+  const trumpSuit = state.trumpSuit;
+  /** Returns the role badge for the human hand card at `idx`, or null. */
+  const roleBadgeFor = (idx: number): { glyph: string; title: string } | null => {
+    const card = humanPlayer?.cards[idx];
+    if (!card) return null;
+    const role = mightySpecialRole(card, trumpSuit, partnerCard);
+    return role ? { glyph: mightyRoleGlyph(role), title: t(`specialRole.${role}`) } : null;
+  };
   const isBidPhase = state.phase === MightyPhase.BID;
   const isTrumpAndFriend = state.phase === MightyPhase.TRUMP_AND_FRIEND;
   const isKittyExchange = state.phase === MightyPhase.KITTY_EXCHANGE;
@@ -532,60 +542,42 @@ function MightyPageContent() {
           <GameFooter className={`${gameTheme.mighty.footer} px-4 py-2.5`}>
             {/* Human cards */}
             {humanPlayer &&
-              (() => {
-                const partnerCard = state.partnerCard ?? null;
-                const roleBadgeFor = (idx: number) => {
-                  const card = humanPlayer.cards[idx];
-                  if (!card) return null;
-                  const role = mightySpecialRole(card, state.trumpSuit, partnerCard);
-                  if (!role) return null;
-                  return { glyph: mightyRoleGlyph(role), title: t(`specialRole.${role}`) };
-                };
-                return isMobile ? (
-                  <MobileHandGrid
-                    cards={humanPlayer.cards}
-                    selectedIndices={selectedCardIndices}
-                    onToggle={toggleCard}
-                    cardWidth={cardWidth}
-                    dataTutorial="mighty-player-hand"
-                    cardBadgeFor={roleBadgeFor}
-                  />
-                ) : (
-                  <div className="flex flex-wrap gap-1 mb-2" data-tutorial="mighty-player-hand">
-                    {humanPlayer.cards.map((card, idx) => {
-                      const badge = roleBadgeFor(idx);
-                      return (
-                        <button
-                          type="button"
-                          key={`${card.design}-${card.value}-${idx}`}
-                          onClick={() => toggleCard(idx)}
-                          aria-label={cardAlt(card)}
-                          aria-pressed={selectedCardIndices.includes(idx)}
-                          className={`transition-transform ${focusRingCard} relative`}
-                          style={{
-                            background: 'none',
-                            padding: 0,
-                            borderRadius: 8,
-                            ...selectedCardStyle(selectedCardIndices.includes(idx)),
-                            boxSizing: 'border-box',
-                          }}
-                        >
-                          <AnimatedCard card={card} width={cardWidth} />
-                          {badge && (
-                            <span
-                              data-testid={`card-role-badge-${idx}`}
-                              title={badge.title}
-                              className="absolute top-0 left-0 bg-black/70 text-white rounded-br rounded-tl px-1 text-[10px] leading-tight pointer-events-none"
-                            >
-                              {badge.glyph}
-                            </span>
-                          )}
-                        </button>
-                      );
-                    })}
-                  </div>
-                );
-              })()}
+              (isMobile ? (
+                <MobileHandGrid
+                  cards={humanPlayer.cards}
+                  selectedIndices={selectedCardIndices}
+                  onToggle={toggleCard}
+                  cardWidth={cardWidth}
+                  dataTutorial="mighty-player-hand"
+                  cardBadgeFor={roleBadgeFor}
+                />
+              ) : (
+                <div className="flex flex-wrap gap-1 mb-2" data-tutorial="mighty-player-hand">
+                  {humanPlayer.cards.map((card, idx) => {
+                    const badge = roleBadgeFor(idx);
+                    return (
+                      <button
+                        type="button"
+                        key={`${card.design}-${card.value}-${idx}`}
+                        onClick={() => toggleCard(idx)}
+                        aria-label={cardAlt(card)}
+                        aria-pressed={selectedCardIndices.includes(idx)}
+                        className={`transition-transform ${focusRingCard} relative`}
+                        style={{
+                          background: 'none',
+                          padding: 0,
+                          borderRadius: 8,
+                          ...selectedCardStyle(selectedCardIndices.includes(idx)),
+                          boxSizing: 'border-box',
+                        }}
+                      >
+                        <AnimatedCard card={card} width={cardWidth} />
+                        {badge && <CardRoleBadge idx={idx} glyph={badge.glyph} title={badge.title} />}
+                      </button>
+                    );
+                  })}
+                </div>
+              ))}
 
             <ErrorAlert message={error ?? hintError} onRetry={retry} />
 

--- a/frontend/src/pages/MightyPage.tsx
+++ b/frontend/src/pages/MightyPage.tsx
@@ -38,6 +38,7 @@ import { valueName } from '../utils/cardUtils';
 import { MIGHTY_HELP, parseMightyCommand } from '../utils/cli/commands/mightyCommands';
 import { formatMightyState } from '../utils/cli/formatters/mightyFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { mightyRoleGlyph, mightySpecialRole } from '../utils/mightySpecialRole';
 import { playerName } from '../utils/playerUtils';
 
 /** Mighty tutorial step definitions. */
@@ -531,37 +532,60 @@ function MightyPageContent() {
           <GameFooter className={`${gameTheme.mighty.footer} px-4 py-2.5`}>
             {/* Human cards */}
             {humanPlayer &&
-              (isMobile ? (
-                <MobileHandGrid
-                  cards={humanPlayer.cards}
-                  selectedIndices={selectedCardIndices}
-                  onToggle={toggleCard}
-                  cardWidth={cardWidth}
-                  dataTutorial="mighty-player-hand"
-                />
-              ) : (
-                <div className="flex flex-wrap gap-1 mb-2" data-tutorial="mighty-player-hand">
-                  {humanPlayer.cards.map((card, idx) => (
-                    <button
-                      type="button"
-                      key={`${card.design}-${card.value}-${idx}`}
-                      onClick={() => toggleCard(idx)}
-                      aria-label={cardAlt(card)}
-                      aria-pressed={selectedCardIndices.includes(idx)}
-                      className={`transition-transform ${focusRingCard}`}
-                      style={{
-                        background: 'none',
-                        padding: 0,
-                        borderRadius: 8,
-                        ...selectedCardStyle(selectedCardIndices.includes(idx)),
-                        boxSizing: 'border-box',
-                      }}
-                    >
-                      <AnimatedCard card={card} width={cardWidth} />
-                    </button>
-                  ))}
-                </div>
-              ))}
+              (() => {
+                const partnerCard = state.partnerCard ?? null;
+                const roleBadgeFor = (idx: number) => {
+                  const card = humanPlayer.cards[idx];
+                  if (!card) return null;
+                  const role = mightySpecialRole(card, state.trumpSuit, partnerCard);
+                  if (!role) return null;
+                  return { glyph: mightyRoleGlyph(role), title: t(`specialRole.${role}`) };
+                };
+                return isMobile ? (
+                  <MobileHandGrid
+                    cards={humanPlayer.cards}
+                    selectedIndices={selectedCardIndices}
+                    onToggle={toggleCard}
+                    cardWidth={cardWidth}
+                    dataTutorial="mighty-player-hand"
+                    cardBadgeFor={roleBadgeFor}
+                  />
+                ) : (
+                  <div className="flex flex-wrap gap-1 mb-2" data-tutorial="mighty-player-hand">
+                    {humanPlayer.cards.map((card, idx) => {
+                      const badge = roleBadgeFor(idx);
+                      return (
+                        <button
+                          type="button"
+                          key={`${card.design}-${card.value}-${idx}`}
+                          onClick={() => toggleCard(idx)}
+                          aria-label={cardAlt(card)}
+                          aria-pressed={selectedCardIndices.includes(idx)}
+                          className={`transition-transform ${focusRingCard} relative`}
+                          style={{
+                            background: 'none',
+                            padding: 0,
+                            borderRadius: 8,
+                            ...selectedCardStyle(selectedCardIndices.includes(idx)),
+                            boxSizing: 'border-box',
+                          }}
+                        >
+                          <AnimatedCard card={card} width={cardWidth} />
+                          {badge && (
+                            <span
+                              data-testid={`card-role-badge-${idx}`}
+                              title={badge.title}
+                              className="absolute top-0 left-0 bg-black/70 text-white rounded-br rounded-tl px-1 text-[10px] leading-tight pointer-events-none"
+                            >
+                              {badge.glyph}
+                            </span>
+                          )}
+                        </button>
+                      );
+                    })}
+                  </div>
+                );
+              })()}
 
             <ErrorAlert message={error ?? hintError} onRetry={retry} />
 

--- a/frontend/src/utils/mightySpecialRole.test.ts
+++ b/frontend/src/utils/mightySpecialRole.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { MIGHTY_SUIT, mightyRoleGlyph, mightySpecialRole } from './mightySpecialRole';
+
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('mightySpecialRole', () => {
+  it('returns "mighty" for ♠A when trump is not Spade', () => {
+    expect(mightySpecialRole(c('SPADE', 1), MIGHTY_SUIT.HEART, null)).toBe('mighty');
+    expect(mightySpecialRole(c('SPADE', 1), -1, null)).toBe('mighty');
+  });
+
+  it('returns "mighty" for ♦A when trump is Spade', () => {
+    expect(mightySpecialRole(c('DIAMOND', 1), MIGHTY_SUIT.SPADE, null)).toBe('mighty');
+    expect(mightySpecialRole(c('SPADE', 1), MIGHTY_SUIT.SPADE, null)).not.toBe('mighty');
+  });
+
+  it('returns "jokerCall" for ♣3 when trump is not Clover', () => {
+    expect(mightySpecialRole(c('CLOVER', 3), MIGHTY_SUIT.HEART, null)).toBe('jokerCall');
+  });
+
+  it('returns "jokerCall" for ♠3 when trump is Clover', () => {
+    expect(mightySpecialRole(c('SPADE', 3), MIGHTY_SUIT.CLOVER, null)).toBe('jokerCall');
+    expect(mightySpecialRole(c('CLOVER', 3), MIGHTY_SUIT.CLOVER, null)).not.toBe('jokerCall');
+  });
+
+  it('returns "joker" for any JOKER-design card', () => {
+    expect(mightySpecialRole(c('JOKER', 0), MIGHTY_SUIT.HEART, null)).toBe('joker');
+  });
+
+  it('returns "partner" when card matches partnerCard', () => {
+    const partner = c('HEART', 12);
+    expect(mightySpecialRole(c('HEART', 12), MIGHTY_SUIT.HEART, partner)).toBe('partner');
+    expect(mightySpecialRole(c('HEART', 11), MIGHTY_SUIT.HEART, partner)).toBeNull();
+  });
+
+  it('returns null for ordinary cards', () => {
+    expect(mightySpecialRole(c('DIAMOND', 7), MIGHTY_SUIT.HEART, null)).toBeNull();
+  });
+
+  it('prioritises joker before partner check', () => {
+    const partner = c('JOKER', 0);
+    expect(mightySpecialRole(c('JOKER', 0), MIGHTY_SUIT.HEART, partner)).toBe('joker');
+  });
+});
+
+describe('mightyRoleGlyph', () => {
+  it('returns distinct glyphs per role', () => {
+    const glyphs = new Set(['mighty', 'jokerCall', 'joker', 'partner'].map((r) => mightyRoleGlyph(r as never)));
+    expect(glyphs.size).toBe(4);
+  });
+});

--- a/frontend/src/utils/mightySpecialRole.ts
+++ b/frontend/src/utils/mightySpecialRole.ts
@@ -1,0 +1,64 @@
+import type { Card } from '../types/card';
+
+/** Backend Mighty suit ints (matches CardDesignSpade…Diamond in Go domain). */
+const SPADE = 1;
+const CLOVER = 2;
+const DIAMOND = 4;
+
+/** Visual role a card plays in the current Mighty round. */
+export type MightySpecialRole = 'mighty' | 'jokerCall' | 'joker' | 'partner';
+
+/** Lookup card → role using the current `trumpSuit` and `partnerCard` from
+ * the backend state. Returns `null` for ordinary cards.
+ *
+ * Mirrors the backend rules:
+ *   - Mighty: ♦A when trumpSuit is ♠, otherwise ♠A.
+ *   - JokerCall: ♠3 when trumpSuit is ♣, otherwise ♣3.
+ *   - Joker: any card with design `JOKER`.
+ *   - Partner: equals `partnerCard` by suit + value.
+ */
+export function mightySpecialRole(
+  card: Card,
+  trumpSuit: number,
+  partnerCard: Card | null | undefined,
+): MightySpecialRole | null {
+  if (card.design === 'JOKER') return 'joker';
+  if (isMighty(card, trumpSuit)) return 'mighty';
+  if (isJokerCall(card, trumpSuit)) return 'jokerCall';
+  if (partnerCard && card.design === partnerCard.design && card.value === partnerCard.value) return 'partner';
+  return null;
+}
+
+function isMighty(card: Card, trumpSuit: number): boolean {
+  if (card.value !== 1) return false;
+  if (trumpSuit === SPADE) return card.design === 'DIAMOND';
+  return card.design === 'SPADE';
+}
+
+function isJokerCall(card: Card, trumpSuit: number): boolean {
+  if (card.value !== 3) return false;
+  if (trumpSuit === CLOVER) return card.design === 'SPADE';
+  return card.design === 'CLOVER';
+}
+
+/** Convert role into a short emoji glyph for the badge. */
+export function mightyRoleGlyph(role: MightySpecialRole): string {
+  switch (role) {
+    case 'mighty':
+      return '\u{1F451}'; // 👑
+    case 'jokerCall':
+      return '\u{1F3AF}'; // 🎯
+    case 'joker':
+      return '\u{1F0CF}'; // 🃏
+    case 'partner':
+      return '\u{1F91D}'; // 🤝
+  }
+}
+
+// Re-export for tests / fixture authors that already work in backend suit ints.
+export const MIGHTY_SUIT = {
+  SPADE,
+  CLOVER,
+  HEART: 3,
+  DIAMOND,
+} as const;


### PR DESCRIPTION
Closes #1917

## Summary
- Adds glyph badges (👑/🎯/🃏/🤝) to special-role cards in the
  human player's hand. Rule set mirrors the backend domain:
  Mighty=♠A (or ♦A when trump=♠), JokerCall=♣3 (or ♠3 when
  trump=♣), Joker=any JOKER, Partner=matches `state.partnerCard`.
- Logic lives in a new pure `mightySpecialRole` util with unit
  coverage of every branch.
- `MobileHandGrid` gains an optional `cardBadgeFor` prop so the
  overlay reuses the existing badge slot for both render paths.

## Test plan
- [x] `bun run test -- --run mightySpecialRole` (9 passed)
- [x] `bun run test -- --run MightyPage` (54 passed; new badge case)
- [x] `bun run test -- --run MobileHandGrid` (20 passed; no regression)
- [x] `bun run check`
- [ ] CI 緑
- [ ] `/mighty` で切り札スペードのラウンドでは ♦A に 👑、それ以外では ♠A に 👑 が出ること
- [ ] 切り札クラブでは ♠3 に 🎯、それ以外では ♣3 に 🎯 が出ること
- [ ] 自分が副官カードを持っているとき 🤝 が出ること