### PR TITLE
feat(hearts): alert when a player appears to be shooting the moon (#1919)

### DIFF
--- a/frontend/src/i18n/locales/en/hearts.json
+++ b/frontend/src/i18n/locales/en/hearts.json
@@ -28,6 +28,7 @@
   "cards": "{{count}} cards",
   "cumulativeScore": "Total: {{score}}",
   "roundScore": "Round: {{score}}",
+  "shootTheMoonAlert": "Shoot-the-Moon alert",
   "currentTrick": "Current Trick",
   "scores": "Scores",
   "scoresPlayer": "Player",

--- a/frontend/src/i18n/locales/ja/hearts.json
+++ b/frontend/src/i18n/locales/ja/hearts.json
@@ -28,6 +28,7 @@
   "cards": "{{count}}枚",
   "cumulativeScore": "累計: {{score}}",
   "roundScore": "ラウンド: {{score}}",
+  "shootTheMoonAlert": "シュート・ザ・ムーン警戒",
   "currentTrick": "現在のトリック",
   "scores": "スコア",
   "scoresPlayer": "プレイヤー",

--- a/frontend/src/pages/HeartsPage.test.tsx
+++ b/frontend/src/pages/HeartsPage.test.tsx
@@ -76,6 +76,46 @@ describe('HeartsPage', () => {
     });
   });
 
+  it('shows shoot-the-moon alert when one CPU monopolises ≥13 round points', async () => {
+    const moonState = makeHeartsState({
+      players: [
+        { id: 0, isHuman: true, cardCount: 13, cards: [], roundScore: 0, cumulativeScore: 0, trickCount: 0 },
+        { id: 1, isHuman: false, cardCount: 13, cards: [], roundScore: 0, cumulativeScore: 0, trickCount: 0 },
+        { id: 2, isHuman: false, cardCount: 13, cards: [], roundScore: 14, cumulativeScore: 14, trickCount: 5 },
+        { id: 3, isHuman: false, cardCount: 13, cards: [], roundScore: 0, cumulativeScore: 0, trickCount: 0 },
+      ],
+    });
+    mockExec.mockResolvedValue(moonState);
+    renderWithProviders(<HeartsPage />);
+    await waitFor(() => expect(screen.getAllByTestId('hearts-shoot-the-moon-badge').length).toBeGreaterThan(0));
+  });
+
+  it('does not show shoot-the-moon alert when points are split between players', async () => {
+    const splitState = makeHeartsState({
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          cardCount: 13,
+          cards: [
+            { design: 'SPADE', value: 1 },
+            { design: 'HEART', value: 11 },
+          ],
+          roundScore: 0,
+          cumulativeScore: 0,
+          trickCount: 0,
+        },
+        { id: 1, isHuman: false, cardCount: 13, cards: [], roundScore: 8, cumulativeScore: 8, trickCount: 3 },
+        { id: 2, isHuman: false, cardCount: 13, cards: [], roundScore: 8, cumulativeScore: 8, trickCount: 3 },
+        { id: 3, isHuman: false, cardCount: 13, cards: [], roundScore: 0, cumulativeScore: 0, trickCount: 0 },
+      ],
+    });
+    mockExec.mockResolvedValue(splitState);
+    renderWithProviders(<HeartsPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+    expect(screen.queryByTestId('hearts-shoot-the-moon-badge')).not.toBeInTheDocument();
+  });
+
   it('renders pass phase with pass button', async () => {
     mockExec.mockResolvedValue(passPhaseState);
     renderWithProviders(<HeartsPage />);

--- a/frontend/src/pages/HeartsPage.tsx
+++ b/frontend/src/pages/HeartsPage.tsx
@@ -32,6 +32,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { HEARTS_HELP, parseHeartsCommand } from '../utils/cli/commands/heartsCommands';
 import { formatHeartsState } from '../utils/cli/formatters/heartsFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { shootTheMoonAlertIdx } from '../utils/heartsShootMoonAlert';
 import { playerName } from '../utils/playerUtils';
 
 /** Hearts tutorial step definitions. */
@@ -174,6 +175,7 @@ function HeartsPageContent() {
     return <GameSkeleton gameKey="hearts" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 5 }} />;
 
   const humanPlayer = state.players.find((p) => p.isHuman);
+  const moonAlertIdx = shootTheMoonAlertIdx(state.players);
   const isPassPhase = state.phase === HeartsPhase.PASS;
   const isPlayPhase = state.phase === HeartsPhase.PLAY;
   const isTrickEnd = state.phase === HeartsPhase.TRICK_END;
@@ -288,6 +290,7 @@ function HeartsPageContent() {
                             {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
                             {t('cumulativeScore', { score: p.cumulativeScore })} |{' '}
                             {t('roundScore', { score: p.roundScore })}
+                            {moonAlertIdx === p.id && <ShootTheMoonBadge label={t('shootTheMoonAlert')} />}
                           </div>
                         ))}
                     </div>
@@ -301,6 +304,7 @@ function HeartsPageContent() {
                           {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
                           {t('cumulativeScore', { score: p.cumulativeScore })} |{' '}
                           {t('roundScore', { score: p.roundScore })}
+                          {moonAlertIdx === p.id && <ShootTheMoonBadge label={t('shootTheMoonAlert')} />}
                         </div>
                       </div>
                     ))
@@ -467,5 +471,20 @@ function HeartsPageContent() {
         </>
       )}
     </GamePageShell>
+  );
+}
+
+/** Small pulsing badge indicating a player appears to be shooting the moon. */
+function ShootTheMoonBadge({ label }: { label: string }) {
+  return (
+    <span
+      data-testid="hearts-shoot-the-moon-badge"
+      role="status"
+      aria-live="polite"
+      className="ml-2 inline-flex items-center gap-1 rounded-full bg-ds-error/30 px-2 py-0.5 text-xs font-bold text-ds-error motion-safe:animate-pulse"
+    >
+      <span aria-hidden="true">🌕</span>
+      {label}
+    </span>
   );
 }

--- a/frontend/src/pages/HeartsPage.tsx
+++ b/frontend/src/pages/HeartsPage.tsx
@@ -171,11 +171,12 @@ function HeartsPageContent() {
     });
   }, [exec, hideActionLog, heartsConfig.cpuDifficulty, heartsConfig.pointLimit, heartsConfig.omnibusJD]);
 
+  const moonAlertIdx = useMemo(() => (state ? shootTheMoonAlertIdx(state.players) : null), [state]);
+
   if (!state)
     return <GameSkeleton gameKey="hearts" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 5 }} />;
 
   const humanPlayer = state.players.find((p) => p.isHuman);
-  const moonAlertIdx = shootTheMoonAlertIdx(state.players);
   const isPassPhase = state.phase === HeartsPhase.PASS;
   const isPlayPhase = state.phase === HeartsPhase.PLAY;
   const isTrickEnd = state.phase === HeartsPhase.TRICK_END;

--- a/frontend/src/utils/heartsShootMoonAlert.test.ts
+++ b/frontend/src/utils/heartsShootMoonAlert.test.ts
@@ -32,4 +32,11 @@ describe('shootTheMoonAlertIdx', () => {
   it('returns the leader index in extreme scenarios (Q♠ + many hearts)', () => {
     expect(shootTheMoonAlertIdx([player(0, 0), player(1, 0), player(2, 20), player(3, 0)])).toBe(2);
   });
+
+  it('returns null when any player has a negative round score (Omnibus J♦)', () => {
+    // Omnibus: a player with J♦ (-10) + 1 heart = -9. Even if another
+    // player appears to hold all positive points, we cannot tell from
+    // roundScore alone whether penalty cards are split, so we bail.
+    expect(shootTheMoonAlertIdx([player(0, -9), player(1, 18), player(2, 0), player(3, 0)])).toBeNull();
+  });
 });

--- a/frontend/src/utils/heartsShootMoonAlert.test.ts
+++ b/frontend/src/utils/heartsShootMoonAlert.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import type { HeartsPlayerData } from '../types/card';
+import { shootTheMoonAlertIdx } from './heartsShootMoonAlert';
+
+const player = (id: number, roundScore: number): HeartsPlayerData => ({
+  id,
+  isHuman: id === 0,
+  cardCount: 0,
+  cards: [],
+  roundScore,
+  cumulativeScore: 0,
+  trickCount: 0,
+});
+
+describe('shootTheMoonAlertIdx', () => {
+  it('returns null when no one has points yet', () => {
+    expect(shootTheMoonAlertIdx([player(0, 0), player(1, 0), player(2, 0), player(3, 0)])).toBeNull();
+  });
+
+  it('returns null when the total is below the threshold', () => {
+    expect(shootTheMoonAlertIdx([player(0, 0), player(1, 0), player(2, 0), player(3, 5)])).toBeNull();
+  });
+
+  it('returns the leader index when one player holds all 13+ points', () => {
+    expect(shootTheMoonAlertIdx([player(0, 0), player(1, 0), player(2, 13), player(3, 0)])).toBe(2);
+  });
+
+  it('returns null when the points are split between two players', () => {
+    expect(shootTheMoonAlertIdx([player(0, 0), player(1, 7), player(2, 7), player(3, 0)])).toBeNull();
+  });
+
+  it('returns the leader index in extreme scenarios (Q♠ + many hearts)', () => {
+    expect(shootTheMoonAlertIdx([player(0, 0), player(1, 0), player(2, 20), player(3, 0)])).toBe(2);
+  });
+});

--- a/frontend/src/utils/heartsShootMoonAlert.ts
+++ b/frontend/src/utils/heartsShootMoonAlert.ts
@@ -7,13 +7,20 @@ const SHOOT_THE_MOON_ALERT_THRESHOLD = 13;
 /** Returns the player index that appears to be shooting the moon, or `null`
  * if no one is dominating yet. The criterion is: the total round points
  * distributed so far is at least the threshold AND a single player holds
- * all of them. */
+ * all of them.
+ *
+ * Limitation: `roundScore` collapses penalty count + Omnibus J♦ bonus
+ * (-10) into a single number, so we can't reliably tell whether a
+ * negative score hides penalty cards. When any player has a negative
+ * round score (only happens with the Omnibus variant) we conservatively
+ * skip the alert rather than risk a false positive. */
 export function shootTheMoonAlertIdx(players: readonly HeartsPlayerData[]): number | null {
   let total = 0;
   let leaderIdx: number | null = null;
   let leaderScore = 0;
   for (const p of players) {
-    if (p.roundScore <= 0) continue;
+    if (p.roundScore < 0) return null;
+    if (p.roundScore === 0) continue;
     total += p.roundScore;
     if (p.roundScore > leaderScore) {
       leaderScore = p.roundScore;

--- a/frontend/src/utils/heartsShootMoonAlert.ts
+++ b/frontend/src/utils/heartsShootMoonAlert.ts
@@ -1,0 +1,27 @@
+import type { HeartsPlayerData } from '../types/card';
+
+/** Round-points threshold above which a single-player monopoly counts as
+ * "shooting the moon in progress" (♥×13 + ♠Q=13 → up to 26 total). */
+const SHOOT_THE_MOON_ALERT_THRESHOLD = 13;
+
+/** Returns the player index that appears to be shooting the moon, or `null`
+ * if no one is dominating yet. The criterion is: the total round points
+ * distributed so far is at least the threshold AND a single player holds
+ * all of them. */
+export function shootTheMoonAlertIdx(players: readonly HeartsPlayerData[]): number | null {
+  let total = 0;
+  let leaderIdx: number | null = null;
+  let leaderScore = 0;
+  for (const p of players) {
+    if (p.roundScore <= 0) continue;
+    total += p.roundScore;
+    if (p.roundScore > leaderScore) {
+      leaderScore = p.roundScore;
+      leaderIdx = p.id;
+    }
+  }
+  if (leaderIdx == null) return null;
+  if (total < SHOOT_THE_MOON_ALERT_THRESHOLD) return null;
+  if (leaderScore < total) return null;
+  return leaderIdx;
+}


### PR DESCRIPTION
Closes #1919

## Summary
- New `shootTheMoonAlertIdx` util scans `state.players` and returns
  the index of a player who holds all round points so far, once the
  total reaches 13 (♥×13 + ♠Q monopoly).
- HeartsPage renders a pulsing 🌕 + "Shoot-the-Moon alert" badge next
  to that CPU's roundScore line (both desktop and mobile layouts).
- `role=status` / `aria-live=polite` for screen readers.

## Test plan
- [x] `bun run test -- --run heartsShootMoonAlert` (5 passed)
- [x] `bun run test -- --run HeartsPage` (69 passed; 2 new cases)
- [x] `bun run check`
- [ ] CI 緑
- [ ] `/hearts` で CPU が ♥や♠Q を 13点以上独占したラウンドで 🌕 警告が点滅すること
- [ ] 点数が複数 CPU に分散しているときは警告が出ないこと