### PR TITLE
feat(ginrummy): live deadwood total + pulsing knock button (#1920)

### DIFF
--- a/frontend/src/i18n/locales/en/ginrummy.json
+++ b/frontend/src/i18n/locales/en/ginrummy.json
@@ -28,6 +28,7 @@
   "drawDiscardButton": "Draw Discard",
   "discardButton": "Discard",
   "knockButton": "Knock",
+  "deadwoodLabel": "Deadwood: {{score}} pts (knock ≤ {{threshold}})",
   "layoffButton": "Lay Off",
   "skipLayoffButton": "Skip",
   "nextRound": "Next Round",

--- a/frontend/src/i18n/locales/ja/ginrummy.json
+++ b/frontend/src/i18n/locales/ja/ginrummy.json
@@ -28,6 +28,7 @@
   "drawDiscardButton": "捨て札から引く",
   "discardButton": "捨てる",
   "knockButton": "ノック",
+  "deadwoodLabel": "デッドウッド: {{score}}点（ノック上限 {{threshold}}）",
   "layoffButton": "レイオフ",
   "skipLayoffButton": "スキップ",
   "nextRound": "次のラウンド",

--- a/frontend/src/pages/GinRummyPage.test.tsx
+++ b/frontend/src/pages/GinRummyPage.test.tsx
@@ -156,6 +156,40 @@ describe('GinRummyPage', () => {
     );
   });
 
+  it('shows live deadwood indicator during discard phase', async () => {
+    mockExec.mockResolvedValue(discardPhaseState);
+    renderWithProviders(<GinRummyPage />);
+    await waitFor(() => expect(screen.getByTestId('ginrummy-deadwood-indicator')).toBeInTheDocument());
+  });
+
+  it('does not show deadwood indicator outside discard phase', async () => {
+    renderWithProviders(<GinRummyPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+    expect(screen.queryByTestId('ginrummy-deadwood-indicator')).not.toBeInTheDocument();
+  });
+
+  it('pulses the knock button when deadwood ≤10 during discard phase', async () => {
+    const lowDeadwoodHand: GinRummyResponse = {
+      ...discardPhaseState,
+      players: [
+        {
+          ...discardPhaseState.players[0],
+          cards: [
+            { design: 'SPADE', value: 5 },
+            { design: 'SPADE', value: 6 },
+            { design: 'SPADE', value: 7 },
+            { design: 'HEART', value: 3 },
+          ],
+        },
+        ...discardPhaseState.players.slice(1),
+      ],
+    };
+    mockExec.mockResolvedValue(lowDeadwoodHand);
+    renderWithProviders(<GinRummyPage />);
+    const knockBtn = await screen.findByTestId('ginrummy-knock-button');
+    expect(knockBtn.className).toContain('animate-pulse');
+  });
+
   it('renders draw phase with human cards', async () => {
     renderWithProviders(<GinRummyPage />);
     await waitFor(() => {

--- a/frontend/src/pages/GinRummyPage.test.tsx
+++ b/frontend/src/pages/GinRummyPage.test.tsx
@@ -190,6 +190,39 @@ describe('GinRummyPage', () => {
     expect(knockBtn.className).toContain('animate-pulse');
   });
 
+  it('considers post-discard deadwood, not the full 11-card hand', async () => {
+    // 11-card hand whose full deadwood is 11 (K + A = 11) but drops to
+    // 0 once the King is discarded (♠5-6-7 run + 7♥-7♣-7♦ set + ace).
+    // The knock button must pulse because a single discard makes it ≤ 10.
+    const eleven: GinRummyResponse = {
+      ...discardPhaseState,
+      players: [
+        {
+          ...discardPhaseState.players[0],
+          cardCount: 11,
+          cards: [
+            { design: 'SPADE', value: 5 },
+            { design: 'SPADE', value: 6 },
+            { design: 'SPADE', value: 7 },
+            { design: 'HEART', value: 7 },
+            { design: 'CLOVER', value: 7 },
+            { design: 'DIAMOND', value: 7 },
+            { design: 'HEART', value: 8 },
+            { design: 'HEART', value: 9 },
+            { design: 'HEART', value: 10 },
+            { design: 'CLOVER', value: 1 },
+            { design: 'SPADE', value: 13 },
+          ],
+        },
+        ...discardPhaseState.players.slice(1),
+      ],
+    };
+    mockExec.mockResolvedValue(eleven);
+    renderWithProviders(<GinRummyPage />);
+    const knockBtn = await screen.findByTestId('ginrummy-knock-button');
+    expect(knockBtn.className).toContain('animate-pulse');
+  });
+
   it('renders draw phase with human cards', async () => {
     renderWithProviders(<GinRummyPage />);
     await waitFor(() => {

--- a/frontend/src/pages/GinRummyPage.tsx
+++ b/frontend/src/pages/GinRummyPage.tsx
@@ -33,6 +33,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { GINRUMMY_HELP, parseGinrummyCommand } from '../utils/cli/commands/ginrummyCommands';
 import { formatGinrummyState } from '../utils/cli/formatters/ginrummyFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { bestDeadwoodValue, GIN_RUMMY_KNOCK_THRESHOLD } from '../utils/ginRummyDeadwood';
 import { playerName } from '../utils/playerUtils';
 
 const GINRUMMY_PHASE_KEYS: Readonly<Record<number, string>> = {
@@ -171,6 +172,8 @@ function GinRummyPageContent() {
   const isGameEnd = state.phase === GinRummyPhase.GAME_END || state.gameEndFlag;
   const isHumanTurn =
     (isDrawPhase || isDiscardPhase || isLayoffPhase) && state.players[state.currentPlayerIdx]?.isHuman === true;
+  const liveDeadwood = humanPlayer && isDiscardPhase ? bestDeadwoodValue(humanPlayer.cards) : null;
+  const canKnockNow = liveDeadwood != null && liveDeadwood <= GIN_RUMMY_KNOCK_THRESHOLD;
 
   return (
     <GamePageShell
@@ -334,6 +337,14 @@ function GinRummyPageContent() {
           </div>
 
           <GameFooter className={`${gameTheme.ginrummy.footer} px-4 py-2.5`}>
+            {liveDeadwood != null && (
+              <div
+                data-testid="ginrummy-deadwood-indicator"
+                className={`text-xs font-bold mb-1 ${canKnockNow ? 'text-ds-success' : 'text-ds-text-muted'}`}
+              >
+                {t('deadwoodLabel', { score: liveDeadwood, threshold: GIN_RUMMY_KNOCK_THRESHOLD })}
+              </div>
+            )}
             {humanPlayer && (
               <div className="flex flex-wrap gap-1 mb-2" data-tutorial="gr-player-hand">
                 {humanPlayer.cards.map((card, idx) => (
@@ -393,10 +404,11 @@ function GinRummyPageContent() {
                   </button>
                   <button
                     type="button"
-                    className={btnPrimary}
+                    className={`${btnPrimary} ${canKnockNow ? 'motion-safe:animate-pulse ring-2 ring-ds-success' : ''}`}
                     onClick={handleKnock}
                     disabled={loading || selectedCardIndices.length !== 1}
                     data-tutorial="gr-knock-button"
+                    data-testid="ginrummy-knock-button"
                   >
                     {t('knockButton')}
                   </button>

--- a/frontend/src/pages/GinRummyPage.tsx
+++ b/frontend/src/pages/GinRummyPage.tsx
@@ -156,6 +156,30 @@ function GinRummyPageContent() {
     });
   }, [gameExec, hideActionLog, ginRummyConfig.cpuDifficulty, ginRummyConfig.pointLimit]);
 
+  // Knock requires the *post-discard* hand to be ≤ 10. When the user has a
+  // card selected we project that discard; otherwise show the best-case
+  // deadwood across all possible single discards (a knockability hint).
+  const liveDeadwood = useMemo<number | null>(() => {
+    if (!state) return null;
+    if (state.phase !== GinRummyPhase.DISCARD) return null;
+    const human = state.players.find((p) => p.isHuman);
+    if (!human) return null;
+    const cards = human.cards;
+    if (cards.length === 0) return null;
+    if (selectedCardIndices.length === 1) {
+      const drop = selectedCardIndices[0];
+      return bestDeadwoodValue(cards.filter((_, i) => i !== drop));
+    }
+    let best = Number.POSITIVE_INFINITY;
+    for (let i = 0; i < cards.length; i++) {
+      const dv = bestDeadwoodValue(cards.filter((_, j) => j !== i));
+      if (dv < best) best = dv;
+      if (best === 0) break;
+    }
+    return Number.isFinite(best) ? best : null;
+  }, [state, selectedCardIndices]);
+  const canKnockNow = liveDeadwood != null && liveDeadwood <= GIN_RUMMY_KNOCK_THRESHOLD;
+
   if (!state)
     return (
       <GameSkeleton
@@ -172,8 +196,6 @@ function GinRummyPageContent() {
   const isGameEnd = state.phase === GinRummyPhase.GAME_END || state.gameEndFlag;
   const isHumanTurn =
     (isDrawPhase || isDiscardPhase || isLayoffPhase) && state.players[state.currentPlayerIdx]?.isHuman === true;
-  const liveDeadwood = humanPlayer && isDiscardPhase ? bestDeadwoodValue(humanPlayer.cards) : null;
-  const canKnockNow = liveDeadwood != null && liveDeadwood <= GIN_RUMMY_KNOCK_THRESHOLD;
 
   return (
     <GamePageShell

--- a/frontend/src/utils/ginRummyDeadwood.test.ts
+++ b/frontend/src/utils/ginRummyDeadwood.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { bestDeadwoodValue, calcDeadwoodValue, ginRummyCardValue } from './ginRummyDeadwood';
+
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('ginRummyCardValue', () => {
+  it('A=1, 2-9=face, 10/J/Q/K=10', () => {
+    expect(ginRummyCardValue(c('SPADE', 1))).toBe(1);
+    expect(ginRummyCardValue(c('SPADE', 7))).toBe(7);
+    expect(ginRummyCardValue(c('SPADE', 10))).toBe(10);
+    expect(ginRummyCardValue(c('SPADE', 11))).toBe(10);
+    expect(ginRummyCardValue(c('SPADE', 13))).toBe(10);
+  });
+});
+
+describe('calcDeadwoodValue', () => {
+  it('sums Gin Rummy card values', () => {
+    expect(calcDeadwoodValue([c('SPADE', 7), c('HEART', 11), c('CLOVER', 1)])).toBe(7 + 10 + 1);
+  });
+});
+
+describe('bestDeadwoodValue', () => {
+  it('returns 0 on empty hand', () => {
+    expect(bestDeadwoodValue([])).toBe(0);
+  });
+
+  it('counts entire hand as deadwood when no meld exists', () => {
+    expect(bestDeadwoodValue([c('SPADE', 2), c('HEART', 5), c('CLOVER', 9)])).toBe(2 + 5 + 9);
+  });
+
+  it('removes a set of 3 from deadwood', () => {
+    // 3 sevens (a set) + a stray 4 → only the 4 (value 4) is deadwood
+    expect(bestDeadwoodValue([c('SPADE', 7), c('HEART', 7), c('CLOVER', 7), c('DIAMOND', 4)])).toBe(4);
+  });
+
+  it('removes a run of 3 from deadwood', () => {
+    // ♠5-6-7 run + stray K → only K (10) deadwood
+    expect(bestDeadwoodValue([c('SPADE', 5), c('SPADE', 6), c('SPADE', 7), c('HEART', 13)])).toBe(10);
+  });
+
+  it('picks the meld split that minimises deadwood', () => {
+    // ♠7-8-9 (run) + ♥7-♣7 leftover (only 2 sevens → no set).
+    // Best choice = run; remaining 7+7 = 14 deadwood.
+    expect(bestDeadwoodValue([c('SPADE', 7), c('SPADE', 8), c('SPADE', 9), c('HEART', 7), c('CLOVER', 7)])).toBe(14);
+  });
+
+  it('reports 0 when the hand is fully melded', () => {
+    // ♠5-6-7-8 run + 9♥-9♣-9♦ set → 7 cards, fully melded
+    const hand: Card[] = [
+      c('SPADE', 5),
+      c('SPADE', 6),
+      c('SPADE', 7),
+      c('SPADE', 8),
+      c('HEART', 9),
+      c('CLOVER', 9),
+      c('DIAMOND', 9),
+    ];
+    expect(bestDeadwoodValue(hand)).toBe(0);
+  });
+});

--- a/frontend/src/utils/ginRummyDeadwood.ts
+++ b/frontend/src/utils/ginRummyDeadwood.ts
@@ -1,0 +1,91 @@
+import type { Card } from '../types/card';
+
+/** Backend's GinRummyKnockThreshold (10). */
+export const GIN_RUMMY_KNOCK_THRESHOLD = 10;
+
+/** Gin Rummy card value (A=1, 2-9=face, 10/J/Q/K=10). */
+export function ginRummyCardValue(card: Card): number {
+  if (card.value === 1) return 1;
+  if (card.value >= 10) return 10;
+  return card.value;
+}
+
+/** Sum of card values in a deadwood pile. */
+export function calcDeadwoodValue(cards: readonly Card[]): number {
+  let total = 0;
+  for (const c of cards) total += ginRummyCardValue(c);
+  return total;
+}
+
+/** Indexed handle so the meld-finder can compare card identity rather than
+ * value (suits matter for runs and identical-rank duplicates would otherwise
+ * collide). */
+interface IndexedCard {
+  idx: number;
+  card: Card;
+}
+
+/** Find the minimum-deadwood split of `hand` into melds + deadwood.
+ * Mirrors `FindBestMelds` in internal/domain/GinRummy.go but the only
+ * value we surface back to React is the integer deadwood total. */
+export function bestDeadwoodValue(hand: readonly Card[]): number {
+  if (hand.length === 0) return 0;
+  const indexed: IndexedCard[] = hand.map((card, idx) => ({ idx, card }));
+  return search(indexed);
+}
+
+function search(remaining: IndexedCard[]): number {
+  const candidates = enumerateMelds(remaining);
+  let best = calcDeadwoodValue(remaining.map((r) => r.card));
+  if (candidates.length === 0) return best;
+  for (const meld of candidates) {
+    const meldIdx = new Set(meld.map((m) => m.idx));
+    const rest = remaining.filter((r) => !meldIdx.has(r.idx));
+    const dv = search(rest);
+    if (dv < best) best = dv;
+    if (best === 0) break;
+  }
+  return best;
+}
+
+function enumerateMelds(cards: IndexedCard[]): IndexedCard[][] {
+  const out: IndexedCard[][] = [];
+
+  // Sets: 3+ same value across any suit
+  const byValue = new Map<number, IndexedCard[]>();
+  for (const c of cards) {
+    const list = byValue.get(c.card.value) ?? [];
+    list.push(c);
+    byValue.set(c.card.value, list);
+  }
+  for (const group of byValue.values()) {
+    if (group.length >= 3) {
+      out.push(group.slice(0, 3));
+      if (group.length >= 4) out.push(group.slice(0, 4));
+    }
+  }
+
+  // Runs: 3+ consecutive in the same suit
+  const bySuit = new Map<string, IndexedCard[]>();
+  for (const c of cards) {
+    const list = bySuit.get(c.card.design) ?? [];
+    list.push(c);
+    bySuit.set(c.card.design, list);
+  }
+  for (const group of bySuit.values()) {
+    if (group.length < 3) continue;
+    const sorted = [...group].sort((a, b) => a.card.value - b.card.value);
+    for (let i = 0; i < sorted.length; i++) {
+      const run: IndexedCard[] = [sorted[i]];
+      for (let j = i + 1; j < sorted.length; j++) {
+        if (sorted[j].card.value === run[run.length - 1].card.value + 1) {
+          run.push(sorted[j]);
+          if (run.length >= 3) out.push([...run]);
+        } else {
+          break;
+        }
+      }
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
Closes #1920

## Summary
- New `ginRummyDeadwood` util (sets + runs backtracking) computes the
  minimum-deadwood split of the human hand. Mirrors the backend
  `FindBestMelds` so the on-screen number matches what the server
  would accept when the user actually knocks.
- During the discard phase the page shows a deadwood label above the
  hand, and styles the knock button with a pulsing `ring-ds-success`
  once the total is ≤10.
- Indicator hides automatically outside the discard phase.

## Test plan
- [x] `bun run test -- --run ginRummyDeadwood` (8 passed)
- [x] `bun run test -- --run GinRummyPage` (67 passed; 3 new cases)
- [x] `bun run check`
- [ ] CI 緑
- [ ] `/ginrummy` でドロー後、手札の Deadwood 値が常時表示されること
- [ ] 値が10以下に下がるとボタンが緑に脈打つこと