### PR TITLE
feat(euchre): grey out partner when going alone (#1921)

### DIFF
--- a/frontend/src/i18n/locales/en/euchre.json
+++ b/frontend/src/i18n/locales/en/euchre.json
@@ -27,6 +27,7 @@
   "dealer": "Dealer",
   "maker": "Maker: Team {{team}}",
   "goingAlone": "Going Alone",
+  "sittingOut": "Sitting out",
   "faceUpCard": "Face-up Card",
   "currentTrick": "Current Trick",
   "partnership": "Partner: {{partner}}",

--- a/frontend/src/i18n/locales/ja/euchre.json
+++ b/frontend/src/i18n/locales/ja/euchre.json
@@ -27,6 +27,7 @@
   "dealer": "ディーラー",
   "maker": "メイカー: チーム {{team}}",
   "goingAlone": "一人で勝負中",
+  "sittingOut": "休み",
   "faceUpCard": "めくり札",
   "currentTrick": "現在のトリック",
   "partnership": "パートナー: {{partner}}",

--- a/frontend/src/pages/EuchrePage.test.tsx
+++ b/frontend/src/pages/EuchrePage.test.tsx
@@ -188,6 +188,21 @@ describe('EuchrePage', () => {
     });
   });
 
+  it('greys out the going-alone partner row with a sitting-out badge', async () => {
+    mockExec.mockResolvedValue(goingAloneState);
+    renderWithProviders(<EuchrePage />);
+    const partnerRow = await screen.findByTestId('eu-player-row-2');
+    expect(partnerRow.className).toContain('grayscale');
+    expect(screen.getByTestId('eu-sitting-out-2')).toBeInTheDocument();
+    expect(screen.queryByTestId('eu-sitting-out-1')).not.toBeInTheDocument();
+  });
+
+  it('does not show sitting-out badge when no one is going alone', async () => {
+    renderWithProviders(<EuchrePage />);
+    await waitFor(() => expect(screen.getByAltText('\u2660 A')).toBeInTheDocument());
+    expect(screen.queryByTestId('eu-sitting-out-2')).not.toBeInTheDocument();
+  });
+
   it('renders pick-up phase with order up and pass buttons', async () => {
     mockExec.mockResolvedValue(pickUpPhaseState);
     renderWithProviders(<EuchrePage />);

--- a/frontend/src/pages/EuchrePage.tsx
+++ b/frontend/src/pages/EuchrePage.tsx
@@ -27,7 +27,7 @@ import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { EuchreResponse } from '../types/card';
+import type { EuchrePlayerData, EuchreResponse } from '../types/card';
 import { EuchrePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
@@ -346,14 +346,7 @@ function EuchrePageContent() {
                               data-testid={`eu-player-row-${p.id}`}
                               className={`text-ds-text-muted text-sm py-0.5 ${sittingOut ? 'opacity-40 grayscale' : ''}`}
                             >
-                              {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
-                              {t('team', { n: p.team })} | {t('trickCount', { count: p.trickCount })}
-                              {state.dealerIdx === p.id ? ` | ${t('dealer')}` : ''}
-                              {sittingOut && (
-                                <span data-testid={`eu-sitting-out-${p.id}`} className="ml-2 text-ds-warning">
-                                  💤 {t('sittingOut')}
-                                </span>
-                              )}
+                              <CpuPlayerLine player={p} dealerIdx={state.dealerIdx} sittingOut={sittingOut} t={t} />
                             </div>
                           );
                         })}
@@ -371,14 +364,7 @@ function EuchrePageContent() {
                           className={`mb-2 p-2 rounded bg-black/30 ${sittingOut ? 'opacity-40 grayscale' : ''}`}
                         >
                           <div className="text-ds-text-muted text-sm">
-                            {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
-                            {t('team', { n: p.team })} | {t('trickCount', { count: p.trickCount })}
-                            {state.dealerIdx === p.id ? ` | ${t('dealer')}` : ''}
-                            {sittingOut && (
-                              <span data-testid={`eu-sitting-out-${p.id}`} className="ml-2 text-ds-warning">
-                                💤 {t('sittingOut')}
-                              </span>
-                            )}
+                            <CpuPlayerLine player={p} dealerIdx={state.dealerIdx} sittingOut={sittingOut} t={t} />
                           </div>
                         </div>
                       );
@@ -606,5 +592,32 @@ function EuchrePageContent() {
         </>
       )}
     </GamePageShell>
+  );
+}
+
+/** Translated row line + sitting-out badge for a single CPU player, shared
+ * between the mobile collapsed-details and desktop card layouts. */
+function CpuPlayerLine({
+  player,
+  dealerIdx,
+  sittingOut,
+  t,
+}: {
+  player: EuchrePlayerData;
+  dealerIdx: number;
+  sittingOut: boolean;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+}) {
+  return (
+    <>
+      {playerName(player.id, player.isHuman)}: {t('cards', { count: player.cardCount })} |{' '}
+      {t('team', { n: player.team })} | {t('trickCount', { count: player.trickCount })}
+      {dealerIdx === player.id ? ` | ${t('dealer')}` : ''}
+      {sittingOut && (
+        <span data-testid={`eu-sitting-out-${player.id}`} className="ml-2 text-ds-warning">
+          💤 {t('sittingOut')}
+        </span>
+      )}
+    </>
   );
 }

--- a/frontend/src/pages/EuchrePage.tsx
+++ b/frontend/src/pages/EuchrePage.tsx
@@ -34,6 +34,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { EUCHRE_HELP, parseEuchreCommand } from '../utils/cli/commands/euchreCommands';
 import { formatEuchreState } from '../utils/cli/formatters/euchreFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { euchreSittingOutIdx } from '../utils/euchreSittingOut';
 import { playerName } from '../utils/playerUtils';
 
 const SUIT_NAMES: Readonly<Record<number, string>> = {
@@ -187,6 +188,7 @@ function EuchrePageContent() {
 
   const humanPlayer = state.players.find((p) => p.isHuman);
   const humanTeam = humanPlayer?.team ?? 0;
+  const sittingOutIdx = euchreSittingOutIdx(state);
   const isPickUpPhase = state.phase === EuchrePhase.PICK_UP;
   const isCallTrumpPhase = state.phase === EuchrePhase.CALL_TRUMP;
   const isDiscardPhase = state.phase === EuchrePhase.DISCARD;
@@ -336,27 +338,51 @@ function EuchrePageContent() {
                     <div className="mt-1">
                       {state.players
                         .filter((p) => !p.isHuman)
-                        .map((p) => (
-                          <div key={p.id} className="text-ds-text-muted text-sm py-0.5">
-                            {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
-                            {t('team', { n: p.team })} | {t('trickCount', { count: p.trickCount })}
-                            {state.dealerIdx === p.id ? ` | ${t('dealer')}` : ''}
-                          </div>
-                        ))}
+                        .map((p) => {
+                          const sittingOut = sittingOutIdx === p.id;
+                          return (
+                            <div
+                              key={p.id}
+                              data-testid={`eu-player-row-${p.id}`}
+                              className={`text-ds-text-muted text-sm py-0.5 ${sittingOut ? 'opacity-40 grayscale' : ''}`}
+                            >
+                              {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
+                              {t('team', { n: p.team })} | {t('trickCount', { count: p.trickCount })}
+                              {state.dealerIdx === p.id ? ` | ${t('dealer')}` : ''}
+                              {sittingOut && (
+                                <span data-testid={`eu-sitting-out-${p.id}`} className="ml-2 text-ds-warning">
+                                  💤 {t('sittingOut')}
+                                </span>
+                              )}
+                            </div>
+                          );
+                        })}
                     </div>
                   </details>
                 ) : (
                   state.players
                     .filter((p) => !p.isHuman)
-                    .map((p) => (
-                      <div key={p.id} className="mb-2 p-2 rounded bg-black/30">
-                        <div className="text-ds-text-muted text-sm">
-                          {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
-                          {t('team', { n: p.team })} | {t('trickCount', { count: p.trickCount })}
-                          {state.dealerIdx === p.id ? ` | ${t('dealer')}` : ''}
+                    .map((p) => {
+                      const sittingOut = sittingOutIdx === p.id;
+                      return (
+                        <div
+                          key={p.id}
+                          data-testid={`eu-player-row-${p.id}`}
+                          className={`mb-2 p-2 rounded bg-black/30 ${sittingOut ? 'opacity-40 grayscale' : ''}`}
+                        >
+                          <div className="text-ds-text-muted text-sm">
+                            {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
+                            {t('team', { n: p.team })} | {t('trickCount', { count: p.trickCount })}
+                            {state.dealerIdx === p.id ? ` | ${t('dealer')}` : ''}
+                            {sittingOut && (
+                              <span data-testid={`eu-sitting-out-${p.id}`} className="ml-2 text-ds-warning">
+                                💤 {t('sittingOut')}
+                              </span>
+                            )}
+                          </div>
                         </div>
-                      </div>
-                    ))
+                      );
+                    })
                 )}
 
                 {/* Team scores */}

--- a/frontend/src/utils/euchreSittingOut.test.ts
+++ b/frontend/src/utils/euchreSittingOut.test.ts
@@ -6,7 +6,9 @@ function p(id: number, team: number): EuchrePlayerData {
   return { id, isHuman: id === 0, cardCount: 5, cards: [], team, trickCount: 0 };
 }
 
-function s(overrides: Partial<EuchreResponse> = {}): Pick<EuchreResponse, 'players' | 'goingAlone' | 'goingAlonePlayerIdx'> {
+function s(
+  overrides: Partial<EuchreResponse> = {},
+): Pick<EuchreResponse, 'players' | 'goingAlone' | 'goingAlonePlayerIdx'> {
   return {
     players: [p(0, 0), p(1, 1), p(2, 0), p(3, 1)],
     goingAlone: false,

--- a/frontend/src/utils/euchreSittingOut.test.ts
+++ b/frontend/src/utils/euchreSittingOut.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import type { EuchrePlayerData, EuchreResponse } from '../types/card';
+import { euchreSittingOutIdx } from './euchreSittingOut';
+
+function p(id: number, team: number): EuchrePlayerData {
+  return { id, isHuman: id === 0, cardCount: 5, cards: [], team, trickCount: 0 };
+}
+
+function s(overrides: Partial<EuchreResponse> = {}): Pick<EuchreResponse, 'players' | 'goingAlone' | 'goingAlonePlayerIdx'> {
+  return {
+    players: [p(0, 0), p(1, 1), p(2, 0), p(3, 1)],
+    goingAlone: false,
+    goingAlonePlayerIdx: -1,
+    ...overrides,
+  };
+}
+
+describe('euchreSittingOutIdx', () => {
+  it('returns null when no one is going alone', () => {
+    expect(euchreSittingOutIdx(s())).toBeNull();
+  });
+
+  it('returns the teammate of the going-alone player', () => {
+    expect(euchreSittingOutIdx(s({ goingAlone: true, goingAlonePlayerIdx: 0 }))).toBe(2);
+    expect(euchreSittingOutIdx(s({ goingAlone: true, goingAlonePlayerIdx: 1 }))).toBe(3);
+  });
+
+  it('returns null when goingAlonePlayerIdx is not in players', () => {
+    expect(euchreSittingOutIdx(s({ goingAlone: true, goingAlonePlayerIdx: 99 }))).toBeNull();
+  });
+
+  it('returns null when goingAlone but team has no partner (edge case)', () => {
+    expect(
+      euchreSittingOutIdx({
+        players: [p(0, 0), p(1, 1), p(2, 1), p(3, 1)],
+        goingAlone: true,
+        goingAlonePlayerIdx: 0,
+      }),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/utils/euchreSittingOut.ts
+++ b/frontend/src/utils/euchreSittingOut.ts
@@ -1,0 +1,12 @@
+import type { EuchreResponse } from '../types/card';
+
+/** Returns the index of the player who is sitting out the current round,
+ * or `null` if no one is. In Euchre, when a player declares "Going Alone",
+ * their teammate (same `team`, different `id`) skips the round. */
+export function euchreSittingOutIdx(state: Pick<EuchreResponse, 'players' | 'goingAlone' | 'goingAlonePlayerIdx'>): number | null {
+  if (!state.goingAlone) return null;
+  const goer = state.players.find((p) => p.id === state.goingAlonePlayerIdx);
+  if (!goer) return null;
+  const partner = state.players.find((p) => p.team === goer.team && p.id !== goer.id);
+  return partner ? partner.id : null;
+}

--- a/frontend/src/utils/euchreSittingOut.ts
+++ b/frontend/src/utils/euchreSittingOut.ts
@@ -3,7 +3,9 @@ import type { EuchreResponse } from '../types/card';
 /** Returns the index of the player who is sitting out the current round,
  * or `null` if no one is. In Euchre, when a player declares "Going Alone",
  * their teammate (same `team`, different `id`) skips the round. */
-export function euchreSittingOutIdx(state: Pick<EuchreResponse, 'players' | 'goingAlone' | 'goingAlonePlayerIdx'>): number | null {
+export function euchreSittingOutIdx(
+  state: Pick<EuchreResponse, 'players' | 'goingAlone' | 'goingAlonePlayerIdx'>,
+): number | null {
   if (!state.goingAlone) return null;
   const goer = state.players.find((p) => p.id === state.goingAlonePlayerIdx);
   if (!goer) return null;


### PR DESCRIPTION
Closes #1921

## Summary
- New `euchreSittingOutIdx` util resolves the teammate of the
  going-alone player from `state.players`/`state.goingAlonePlayerIdx`.
- EuchrePage applies `opacity-40 grayscale` to that CPU's row and
  renders a 💤 `sittingOut` badge in both the inline desktop layout
  and the mobile `<details>` panel.
- Returns null safely when the going-alone player has no teammate
  on their team (edge case).

## Test plan
- [x] `bun run test -- --run euchreSittingOut` (4 passed)
- [x] `bun run test -- --run EuchrePage` (65 passed; 2 new cases)
- [x] `bun run check`
- [ ] CI 緑
- [ ] `/euchre` で「一人で勝負」を選んだとき、パートナーの行がグレーアウト＋💤バッジになること
- [ ] 通常ラウンドでは普通に表示されること