### PR TITLE
feat(bakersdozen): warn before emptying a tableau column (#1922)

### DIFF
--- a/frontend/src/i18n/locales/en/bakersdozen.json
+++ b/frontend/src/i18n/locales/en/bakersdozen.json
@@ -9,6 +9,7 @@
   "moveCount": "Moves",
   "giveup": "Give Up",
   "empty": "Empty",
+  "lastCardWarning": "This column will be lost for good",
   "foundationAriaLabel": "{{suit}} foundation {{count}} cards",
   "emptyFoundationAriaLabel": "Empty foundation ({{suit}})",
   "landscapeBanner": "Landscape mode recommended",

--- a/frontend/src/i18n/locales/ja/bakersdozen.json
+++ b/frontend/src/i18n/locales/ja/bakersdozen.json
@@ -9,6 +9,7 @@
   "moveCount": "手数",
   "giveup": "ギブアップ",
   "empty": "空",
+  "lastCardWarning": "この列は二度と使えなくなります",
   "foundationAriaLabel": "{{suit}} 組札 {{count}}枚",
   "emptyFoundationAriaLabel": "空の組札 ({{suit}})",
   "landscapeBanner": "横画面での表示を推奨します",

--- a/frontend/src/pages/BakersDozenPage.test.tsx
+++ b/frontend/src/pages/BakersDozenPage.test.tsx
@@ -82,6 +82,36 @@ describe('BakersDozenPage', () => {
     expect(mockExec.mock.calls[0]?.[0]).toBe('reset');
   });
 
+  it('marks the last card in a column with a dashed warning ring', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<BakersDozenPage />);
+    const lastCardBtn = await screen.findByTestId('bd-last-card-1');
+    expect(lastCardBtn.className).toContain('ring-dashed');
+    // Column 0 has 2 cards so it's NOT the last-card scenario
+    expect(screen.queryByTestId('bd-last-card-0')).not.toBeInTheDocument();
+  });
+
+  it('does not flag any card on a fresh deal with multi-card columns only', async () => {
+    const fullState: BakersDozenResponse = {
+      ...playingState,
+      tableau: makeTableau([
+        [
+          { card: card('SPADE', 13), faceUp: true },
+          { card: card('SPADE', 5), faceUp: true },
+        ],
+        [
+          { card: card('HEART', 6), faceUp: true },
+          { card: card('HEART', 7), faceUp: true },
+        ],
+      ]),
+    };
+    mockExec.mockResolvedValue(fullState);
+    renderWithProviders(<BakersDozenPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ 5')).toBeInTheDocument());
+    expect(screen.queryByTestId('bd-last-card-0')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('bd-last-card-1')).not.toBeInTheDocument();
+  });
+
   it('renders heading and move count', async () => {
     mockExec.mockResolvedValue(playingState);
     renderWithProviders(<BakersDozenPage />);

--- a/frontend/src/pages/BakersDozenPage.tsx
+++ b/frontend/src/pages/BakersDozenPage.tsx
@@ -291,7 +291,15 @@ function BakersDozenPageContent() {
                             };
                             const isTop = cardIdx === col.length - 1;
                             const isLastInCol = isTop && col.length === 1;
-                            const lastWarnSelected = isLastInCol && isSourceSelected('tableau', colIdx, cardIdx);
+                            const isSelected = isSourceSelected('tableau', colIdx, cardIdx);
+                            const showEmptyColumnWarning = isLastInCol && isSelected;
+                            // Selection ring wins over the dashed empty-column ring when both
+                            // would apply — avoids stacking two rings that look like a bug.
+                            const ringClass = isSelected
+                              ? 'ring-2 ring-ds-warning'
+                              : isLastInCol
+                                ? 'ring-2 ring-ds-warning/60 ring-dashed'
+                                : '';
                             return (
                               <div
                                 key={`tc-${colIdx.toString()}-${cardIdx.toString()}`}
@@ -311,11 +319,11 @@ function BakersDozenPageContent() {
                                     }}
                                     disabled={!isPlaying || loading || (!isTop && !selectedSource)}
                                     aria-label={cardAlt(tc.card)}
-                                    aria-pressed={isSourceSelected('tableau', colIdx, cardIdx)}
+                                    aria-pressed={isSelected}
                                     draggable={isPlaying && !loading && isTop}
                                     onDragStart={dnd.handleDragStart(cardZone)}
                                     onDragEnd={dnd.handleDragEnd}
-                                    className={`p-0 border-0 bg-transparent w-full rounded ${focusRingWhite} ${isTop ? 'cursor-pointer' : 'cursor-default'} ${isSourceSelected('tableau', colIdx, cardIdx) ? 'ring-2 ring-ds-warning' : ''} ${isLastInCol ? 'ring-2 ring-ds-warning/60 ring-offset-0 ring-dashed' : ''} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
+                                    className={`p-0 border-0 bg-transparent w-full rounded ${focusRingWhite} ${isTop ? 'cursor-pointer' : 'cursor-default'} ${ringClass} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
                                     title={isLastInCol ? t('lastCardWarning') : undefined}
                                   >
                                     <AnimatedCard
@@ -327,7 +335,7 @@ function BakersDozenPageContent() {
                                     />
                                   </button>
                                 ) : null}
-                                {lastWarnSelected && (
+                                {showEmptyColumnWarning && (
                                   <div
                                     data-testid={`bd-empty-column-warn-${colIdx}`}
                                     role="alert"

--- a/frontend/src/pages/BakersDozenPage.tsx
+++ b/frontend/src/pages/BakersDozenPage.tsx
@@ -290,6 +290,8 @@ function BakersDozenPageContent() {
                               cardIndex: cardIdx,
                             };
                             const isTop = cardIdx === col.length - 1;
+                            const isLastInCol = isTop && col.length === 1;
+                            const lastWarnSelected = isLastInCol && isSourceSelected('tableau', colIdx, cardIdx);
                             return (
                               <div
                                 key={`tc-${colIdx.toString()}-${cardIdx.toString()}`}
@@ -299,6 +301,7 @@ function BakersDozenPageContent() {
                                 {tc.card ? (
                                   <button
                                     type="button"
+                                    data-testid={isLastInCol ? `bd-last-card-${colIdx}` : undefined}
                                     onClick={() => {
                                       if (selectedSource) {
                                         handleSelectTarget(tableauColZone);
@@ -312,7 +315,8 @@ function BakersDozenPageContent() {
                                     draggable={isPlaying && !loading && isTop}
                                     onDragStart={dnd.handleDragStart(cardZone)}
                                     onDragEnd={dnd.handleDragEnd}
-                                    className={`p-0 border-0 bg-transparent w-full rounded ${focusRingWhite} ${isTop ? 'cursor-pointer' : 'cursor-default'} ${isSourceSelected('tableau', colIdx, cardIdx) ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
+                                    className={`p-0 border-0 bg-transparent w-full rounded ${focusRingWhite} ${isTop ? 'cursor-pointer' : 'cursor-default'} ${isSourceSelected('tableau', colIdx, cardIdx) ? 'ring-2 ring-ds-warning' : ''} ${isLastInCol ? 'ring-2 ring-ds-warning/60 ring-offset-0 ring-dashed' : ''} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
+                                    title={isLastInCol ? t('lastCardWarning') : undefined}
                                   >
                                     <AnimatedCard
                                       card={tc.card}
@@ -323,6 +327,15 @@ function BakersDozenPageContent() {
                                     />
                                   </button>
                                 ) : null}
+                                {lastWarnSelected && (
+                                  <div
+                                    data-testid={`bd-empty-column-warn-${colIdx}`}
+                                    role="alert"
+                                    className="absolute inset-0 flex items-center justify-center pointer-events-none text-xs text-ds-error font-bold text-center px-1 motion-safe:animate-pulse"
+                                  >
+                                    🚫 {t('lastCardWarning')}
+                                  </div>
+                                )}
                               </div>
                             );
                           })


### PR DESCRIPTION
Closes #1922

## Summary
- Every \"last card in column\" gets a dashed `ring-ds-warning/60`
  outline so players spot the columns that are about to disappear.
- While that card is selected, a pulsing 🚫 banner (role=alert) using
  the new `lastCardWarning` i18n key floats over its slot — the empty
  column rule (no refill allowed in Baker's Dozen) is now surfaced
  the moment it matters.
- Pure UX change; no backend or game-rule edits.

## Test plan
- [x] `bun run test -- --run BakersDozenPage` (14 passed; 2 new cases)
- [x] `bun run check`
- [ ] CI 緑
- [ ] `/bakersdozen` で列に残り1枚のカードはオレンジ点線で枠取られること
- [ ] そのカードを選択中に「この列は二度と使えなくなります」が出ること