### PR TITLE
feat(fiftyone): per-suit score badges with leading-suit highlight

### DIFF
--- a/frontend/src/i18n/locales/en/fiftyone.json
+++ b/frontend/src/i18n/locales/en/fiftyone.json
@@ -15,7 +15,8 @@
     "selectCard": "Select a card",
     "stopCalled": "Stop called",
     "yourTurn": "Your turn",
-    "cpuTurn": "CPU {{id}}'s turn"
+    "cpuTurn": "CPU {{id}}'s turn",
+    "suitScores": "Suit totals"
   },
   "settings": {
     "cpuDifficulty": "CPU Difficulty"

--- a/frontend/src/i18n/locales/ja/fiftyone.json
+++ b/frontend/src/i18n/locales/ja/fiftyone.json
@@ -15,7 +15,8 @@
     "selectCard": "カードを選択",
     "stopCalled": "ストップ宣言済み",
     "yourTurn": "あなたのターン",
-    "cpuTurn": "CPU{{id}}のターン"
+    "cpuTurn": "CPU{{id}}のターン",
+    "suitScores": "スート別合計"
   },
   "settings": {
     "cpuDifficulty": "CPU難易度"

--- a/frontend/src/pages/FiftyOnePage.test.tsx
+++ b/frontend/src/pages/FiftyOnePage.test.tsx
@@ -83,7 +83,7 @@ describe('FiftyOnePage', () => {
   it('renders player score after load', async () => {
     const { FiftyOnePage } = await import('./FiftyOnePage');
     renderWithProviders(<FiftyOnePage />);
-    await waitFor(() => expect(screen.getByText(/21/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/スコア: 21/)).toBeInTheDocument());
   });
 
   it('exchange all button calls exchangeall', async () => {
@@ -121,5 +121,18 @@ describe('FiftyOnePage', () => {
 
     const exchangeBtn = screen.getByTestId('exchange-button');
     expect(exchangeBtn).toBeDisabled();
+  });
+
+  it('renders suit score badges and highlights the leading suit', async () => {
+    const { FiftyOnePage } = await import('./FiftyOnePage');
+    renderWithProviders(<FiftyOnePage />);
+    await waitFor(() => expect(screen.getByTestId('suit-score-badges')).toBeInTheDocument());
+    // SPADE=11+10=21, CLOVER=2, HEART=5, DIAMOND=3 → SPADE leads.
+    const spade = screen.getByTestId('suit-badge-SPADE');
+    expect(spade).toHaveTextContent('21');
+    expect(spade.className).toContain('bg-ds-accent');
+    const heart = screen.getByTestId('suit-badge-HEART');
+    expect(heart).toHaveTextContent('5');
+    expect(heart.className).not.toContain('bg-ds-accent');
   });
 });

--- a/frontend/src/pages/FiftyOnePage.tsx
+++ b/frontend/src/pages/FiftyOnePage.tsx
@@ -25,6 +25,7 @@ import type { FiftyOneResponse } from '../types/card';
 import { FiftyOnePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
+import { fiftyOneBestSuit, fiftyOneSuitScores } from '../utils/fiftyOneSuitScores';
 
 type FiftyOneArgs = Parameters<typeof fiftyoneApi.exec>;
 
@@ -143,6 +144,10 @@ function FiftyOnePageContent() {
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
+  const humanCards = state?.players[0]?.cards;
+  const suitTotals = useMemo(() => fiftyOneSuitScores(humanCards ?? []), [humanCards]);
+  const bestSuit = useMemo(() => fiftyOneBestSuit(suitTotals), [suitTotals]);
+
   if (!state || state.players.length < 4)
     return <GameSkeleton gameKey="fiftyone" layout={{ kind: 'centered', rows: [5, 5] }} />;
 
@@ -229,6 +234,30 @@ function FiftyOnePageContent() {
               <div className="text-xs text-ds-text-muted mb-1">
                 {tc('player.you')} — {t('label.score')}: {human.score}
               </div>
+              <ul
+                className="flex justify-center gap-1.5 mb-1.5 text-xs flex-wrap list-none p-0 m-0"
+                aria-label={t('label.suitScores')}
+                data-testid="suit-score-badges"
+              >
+                {(['SPADE', 'CLOVER', 'HEART', 'DIAMOND'] as const).map((d) => {
+                  const isLeader = d === bestSuit && suitTotals[d] > 0;
+                  const symbol = d === 'SPADE' ? '♠' : d === 'CLOVER' ? '♣' : d === 'HEART' ? '♥' : '♦';
+                  const isRed = d === 'HEART' || d === 'DIAMOND';
+                  const classes = isLeader
+                    ? 'bg-ds-accent text-ds-text-on-accent border-ds-accent'
+                    : 'bg-ds-surface text-ds-text border-ds-border';
+                  return (
+                    <li
+                      key={d}
+                      data-testid={`suit-badge-${d}`}
+                      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full border font-medium ${classes}`}
+                    >
+                      <span className={isLeader ? '' : isRed ? 'text-ds-error' : ''}>{symbol}</span>
+                      <span className="tabular-nums">{suitTotals[d]}</span>
+                    </li>
+                  );
+                })}
+              </ul>
               <div className="flex justify-center gap-2">
                 {human.cards.map((c, i) => (
                   <button

--- a/frontend/src/utils/fiftyOneSuitScores.test.ts
+++ b/frontend/src/utils/fiftyOneSuitScores.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { fiftyOneBestSuit, fiftyOneCardScore, fiftyOneSuitScores } from './fiftyOneSuitScores';
+
+describe('fiftyOneCardScore', () => {
+  it.each([
+    [1, 11],
+    [2, 2],
+    [10, 10],
+    [11, 10],
+    [12, 10],
+    [13, 10],
+  ])('value %i -> %i', (v, expected) => {
+    expect(fiftyOneCardScore(v)).toBe(expected);
+  });
+});
+
+describe('fiftyOneSuitScores', () => {
+  it('aggregates per-suit totals and skips jokers', () => {
+    const cards: Card[] = [
+      { design: 'SPADE', value: 1 }, // 11
+      { design: 'SPADE', value: 10 }, // 10
+      { design: 'HEART', value: 5 }, // 5
+      { design: 'DIAMOND', value: 13 }, // 10
+      { design: 'JOKER', value: 0 },
+    ];
+    expect(fiftyOneSuitScores(cards)).toEqual({ SPADE: 21, CLOVER: 0, HEART: 5, DIAMOND: 10 });
+  });
+
+  it('returns zeros for empty hand', () => {
+    expect(fiftyOneSuitScores([])).toEqual({ SPADE: 0, CLOVER: 0, HEART: 0, DIAMOND: 0 });
+  });
+});
+
+describe('fiftyOneBestSuit', () => {
+  it('returns the suit with the highest total', () => {
+    expect(fiftyOneBestSuit({ SPADE: 5, CLOVER: 0, HEART: 30, DIAMOND: 10 })).toBe('HEART');
+  });
+
+  it('breaks ties in S/C/H/D order', () => {
+    expect(fiftyOneBestSuit({ SPADE: 10, CLOVER: 10, HEART: 10, DIAMOND: 10 })).toBe('SPADE');
+  });
+});

--- a/frontend/src/utils/fiftyOneSuitScores.ts
+++ b/frontend/src/utils/fiftyOneSuitScores.ts
@@ -1,0 +1,35 @@
+import type { Card, CardDesign } from '../types/card';
+
+/** Numeric score a single card contributes in Fifty-One: A=11, J/Q/K=10, 2-10=face value. */
+export function fiftyOneCardScore(value: number): number {
+  if (value === 1) return 11;
+  if (value >= 11) return 10;
+  return value;
+}
+
+/** Per-suit total scores for a Fifty-One hand. Joker cards are ignored. */
+export type FiftyOneSuitScoreMap = Record<Exclude<CardDesign, 'JOKER'>, number>;
+
+/** Aggregate per-suit totals for a hand. */
+export function fiftyOneSuitScores(cards: Card[]): FiftyOneSuitScoreMap {
+  const scores: FiftyOneSuitScoreMap = { SPADE: 0, CLOVER: 0, HEART: 0, DIAMOND: 0 };
+  for (const c of cards) {
+    if (c.design === 'JOKER') continue;
+    scores[c.design] += fiftyOneCardScore(c.value);
+  }
+  return scores;
+}
+
+/** Suit (excluding JOKER) with the highest total, breaking ties in fixed order S/C/H/D. */
+export function fiftyOneBestSuit(scores: FiftyOneSuitScoreMap): Exclude<CardDesign, 'JOKER'> {
+  const order: Array<Exclude<CardDesign, 'JOKER'>> = ['SPADE', 'CLOVER', 'HEART', 'DIAMOND'];
+  let best: Exclude<CardDesign, 'JOKER'> = 'SPADE';
+  let bestScore = -1;
+  for (const d of order) {
+    if (scores[d] > bestScore) {
+      best = d;
+      bestScore = scores[d];
+    }
+  }
+  return best;
+}


### PR DESCRIPTION
## Summary
- Adds a per-suit total bar above the player's hand on the Fifty-One page so users no longer have to mentally re-add S/C/H/D scores after every card swap.
- Pulls the leading suit into accent color so the current 51-target suit is obvious at a glance.

## Implementation
- New \`fiftyOneSuitScores\` util mirrors the backend scoring (A=11, J/Q/K=10) and returns the leading suit with the same tiebreak order as the Go domain (\`SPADE → CLOVER → HEART → DIAMOND\`).
- FiftyOnePage renders the four badges as a list directly above the player hand; leading suit gets \`bg-ds-accent\`, others stay on \`bg-ds-surface\`.
- Existing tests touched only to disambiguate the score text now that \`21\` appears in both the player line and the SPADE badge.

## Test plan
- [x] \`bun run test -- --run src/utils/fiftyOneSuitScores.test.ts src/pages/FiftyOnePage.test.tsx\`
- [x] \`bun run check\`

Closes #1923