### PR TITLE
feat(blackjackswitch): swap-preview score on Switch hover/focus

### DIFF
--- a/frontend/src/pages/BlackJackSwitchPage.test.tsx
+++ b/frontend/src/pages/BlackJackSwitchPage.test.tsx
@@ -190,6 +190,77 @@ describe('BlackJackSwitchPage', () => {
     expect(screen.queryByTestId('hand-0-preview')).not.toBeInTheDocument();
   });
 
+  it('focusing Switch shows the preview for keyboard parity', async () => {
+    mockApi.mockResolvedValue(switchState);
+    renderWithProviders(<BlackJackSwitchPage />);
+    const btn = await screen.findByTestId('switch-button');
+    fireEvent.focus(btn);
+    expect(screen.getByTestId('hand-0-preview')).toBeInTheDocument();
+    fireEvent.blur(btn);
+    expect(screen.queryByTestId('hand-0-preview')).not.toBeInTheDocument();
+  });
+
+  it('paints the bust path in red when the post-swap score exceeds 21', async () => {
+    // Hand 0 = [S10, D11]=20; Hand 1 = [H10, S10]=20. After swap: hand0 = [S10, S10] = 20; hand1 = [H10, D11] = 20.
+    // Bust requires score > 21. Use [S10, S10] and [H10, S2]: swapped → [S10, S2]=12 and [H10, S10]=20.
+    // For a real bust path: Hand 0 = [S10, D11]=20; Hand 1 = [H10, S5]=15 → swap → hand0 [S10,S5]=15; hand1 [H10,D11]=20.
+    // Use Hand 0 = [S10, S10, S5]=25 (already busts); Hand 1 = [H10, D11]=20 → swap → hand0 [S10,D11,S5]=25 (still bust).
+    const bustState: BlackJackSwitchResponse = {
+      ...switchState,
+      hands: [
+        {
+          ...switchState.hands[0],
+          cards: [
+            { design: 'SPADE', value: 10 },
+            { design: 'SPADE', value: 10 },
+            { design: 'SPADE', value: 5 },
+          ],
+          score: 25,
+        },
+        switchState.hands[1],
+      ],
+    };
+    mockApi.mockResolvedValue(bustState);
+    renderWithProviders(<BlackJackSwitchPage />);
+    const btn = await screen.findByTestId('switch-button');
+    fireEvent.mouseEnter(btn);
+    const preview = screen.getByTestId('hand-0-preview');
+    expect(preview).toHaveTextContent('25');
+    expect(preview.className).toContain('text-ds-error');
+  });
+
+  it('paints the neutral path when the post-swap score is unchanged', async () => {
+    // Symmetric swap: hand0 [S5, C5]=10; hand1 [H5, D5]=10 → swap → hand0 [S5, D5]=10; hand1 [H5, C5]=10.
+    const flatState: BlackJackSwitchResponse = {
+      ...switchState,
+      hands: [
+        {
+          ...switchState.hands[0],
+          cards: [
+            { design: 'SPADE', value: 5 },
+            { design: 'CLOVER', value: 5 },
+          ],
+          score: 10,
+        },
+        {
+          ...switchState.hands[1],
+          cards: [
+            { design: 'HEART', value: 5 },
+            { design: 'DIAMOND', value: 5 },
+          ],
+          score: 10,
+        },
+      ],
+    };
+    mockApi.mockResolvedValue(flatState);
+    renderWithProviders(<BlackJackSwitchPage />);
+    const btn = await screen.findByTestId('switch-button');
+    fireEvent.mouseEnter(btn);
+    const preview = screen.getByTestId('hand-0-preview');
+    expect(preview).toHaveTextContent('10');
+    expect(preview.className).toContain('text-ds-text-muted');
+  });
+
   it('clicks Keep and posts the keep command', async () => {
     mockApi.mockResolvedValue(switchState);
     renderWithProviders(<BlackJackSwitchPage />);

--- a/frontend/src/pages/BlackJackSwitchPage.test.tsx
+++ b/frontend/src/pages/BlackJackSwitchPage.test.tsx
@@ -177,6 +177,19 @@ describe('BlackJackSwitchPage', () => {
     await waitFor(() => expect(mockApi).toHaveBeenCalledWith('switch'));
   });
 
+  it('hovering Switch shows post-swap score previews on each hand', async () => {
+    mockApi.mockResolvedValue(switchState);
+    renderWithProviders(<BlackJackSwitchPage />);
+    const btn = await screen.findByTestId('switch-button');
+    expect(screen.queryByTestId('hand-0-preview')).not.toBeInTheDocument();
+    fireEvent.mouseEnter(btn);
+    // Hand 0 = [S10, C5]=15 -> swap -> [S10, D11]=20; Hand 1 = [H6, D11]=16 -> swap -> [H6, C5]=11
+    expect(screen.getByTestId('hand-0-preview')).toHaveTextContent('20');
+    expect(screen.getByTestId('hand-1-preview')).toHaveTextContent('11');
+    fireEvent.mouseLeave(btn);
+    expect(screen.queryByTestId('hand-0-preview')).not.toBeInTheDocument();
+  });
+
   it('clicks Keep and posts the keep command', async () => {
     mockApi.mockResolvedValue(switchState);
     renderWithProviders(<BlackJackSwitchPage />);

--- a/frontend/src/pages/BlackJackSwitchPage.tsx
+++ b/frontend/src/pages/BlackJackSwitchPage.tsx
@@ -25,6 +25,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { BlackJackSwitchResponse, Card } from '../types/card';
 import { BlackJackSwitchPhase, BlackJackSwitchResult } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { blackjackSwitchPreviewScores } from '../utils/blackjackSwitchPreview';
 import type { CliGameConfig } from '../utils/cli/types';
 
 const BJSWITCH_TUTORIAL_STEPS: TutorialStep[] = [];
@@ -51,6 +52,7 @@ function BlackJackSwitchPageContent() {
     useGamePageSetup('blackjackswitch');
 
   const [betAmount, setBetAmount] = useState(100);
+  const [switchPreview, setSwitchPreview] = useState(false);
   const { cardWidth } = useCardDimensions();
   const { playSound } = useSound();
   const { state, loading, error, exec: execApi, retry } = useGameApi(blackjackswitchApi.exec);
@@ -100,6 +102,11 @@ function BlackJackSwitchPageContent() {
 
   const currentHand = state.hands[state.currentHandIdx];
   const canDoubleDown = isActionPhase && currentHand && currentHand.cards.length === 2;
+
+  const previewScores =
+    isSwitchPhase && switchPreview && state.hands.length >= 2
+      ? blackjackSwitchPreviewScores(state.hands[0].cards, state.hands[1].cards)
+      : null;
 
   return (
     <GamePageShell
@@ -160,6 +167,18 @@ function BlackJackSwitchPageContent() {
                 {state.hands.map((hand, idx) => {
                   const isCurrent = isActionPhase && idx === state.currentHandIdx;
                   const tone = isCurrent ? 'border-ds-accent' : 'border-white/20';
+                  const previewScore = previewScores ? (idx === 0 ? previewScores.a : previewScores.b) : null;
+                  const previewDelta = previewScore !== null ? previewScore - hand.score : 0;
+                  const previewColor =
+                    previewScore === null
+                      ? ''
+                      : previewScore > 21
+                        ? 'text-ds-error'
+                        : previewDelta > 0
+                          ? 'text-ds-success'
+                          : previewDelta < 0
+                            ? 'text-ds-error'
+                            : 'text-ds-text-muted';
                   return (
                     <div
                       key={`hand-${idx}`}
@@ -167,7 +186,13 @@ function BlackJackSwitchPageContent() {
                       className={`border rounded-lg p-2 ${tone} bg-black/20`}
                     >
                       <div className="text-ds-text-primary text-center text-xs font-bold mb-1">
-                        {t('label.hand')} {idx} ({hand.score}) — {t('label.bet')}: {hand.bet}
+                        {t('label.hand')} {idx} ({hand.score}
+                        {previewScore !== null && (
+                          <span data-testid={`hand-${idx}-preview`} className={`ml-1 font-bold ${previewColor}`}>
+                            → {previewScore}
+                          </span>
+                        )}
+                        ) — {t('label.bet')}: {hand.bet}
                         {hand.busted ? ' BUST' : ''}
                         {hand.isBJ ? ' BJ' : ''}
                       </div>
@@ -226,7 +251,17 @@ function BlackJackSwitchPageContent() {
             )}
             {isSwitchPhase && (
               <div className="flex justify-center gap-2 pb-2 flex-wrap">
-                <button type="button" className={btnWarning} onClick={handleSwitch} disabled={loading}>
+                <button
+                  type="button"
+                  className={btnWarning}
+                  onClick={handleSwitch}
+                  onMouseEnter={() => setSwitchPreview(true)}
+                  onMouseLeave={() => setSwitchPreview(false)}
+                  onFocus={() => setSwitchPreview(true)}
+                  onBlur={() => setSwitchPreview(false)}
+                  data-testid="switch-button"
+                  disabled={loading}
+                >
                   {t('button.switch')}
                 </button>
                 <button type="button" className={btnSecondary} onClick={handleKeep} disabled={loading}>

--- a/frontend/src/utils/blackjackSwitchPreview.test.ts
+++ b/frontend/src/utils/blackjackSwitchPreview.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { blackjackScore, blackjackSwitchPreviewScores } from './blackjackSwitchPreview';
+
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('blackjackScore', () => {
+  it('counts face cards as 10 and aces flexibly', () => {
+    expect(blackjackScore([c('SPADE', 1), c('HEART', 13)])).toBe(21);
+    expect(blackjackScore([c('SPADE', 1), c('HEART', 9), c('CLOVER', 5)])).toBe(15); // ace soft 1
+    expect(blackjackScore([c('SPADE', 1), c('HEART', 1)])).toBe(12); // 11+11 -> 12
+    expect(blackjackScore([c('SPADE', 5), c('HEART', 9), c('CLOVER', 8)])).toBe(22); // bust
+  });
+});
+
+describe('blackjackSwitchPreviewScores', () => {
+  it('swaps the second card between two hands', () => {
+    const a: Card[] = [c('SPADE', 10), c('SPADE', 4)];
+    const b: Card[] = [c('HEART', 10), c('HEART', 7)];
+    // Before: a=14, b=17. After swap: a=10+7=17, b=10+4=14
+    expect(blackjackSwitchPreviewScores(a, b)).toEqual({ a: 17, b: 14 });
+  });
+
+  it('returns null when either hand has fewer than 2 cards', () => {
+    expect(blackjackSwitchPreviewScores([c('SPADE', 1)], [c('HEART', 2), c('HEART', 3)])).toBeNull();
+  });
+
+  it('preserves extra cards beyond the second', () => {
+    const a: Card[] = [c('SPADE', 10), c('SPADE', 4), c('SPADE', 2)];
+    const b: Card[] = [c('HEART', 9), c('HEART', 8)];
+    // After swap: a = [S10, H8, S2] = 20; b = [H9, S4] = 13
+    expect(blackjackSwitchPreviewScores(a, b)).toEqual({ a: 20, b: 13 });
+  });
+});

--- a/frontend/src/utils/blackjackSwitchPreview.test.ts
+++ b/frontend/src/utils/blackjackSwitchPreview.test.ts
@@ -11,12 +11,16 @@ describe('blackjackScore', () => {
     expect(blackjackScore([c('SPADE', 1), c('HEART', 1)])).toBe(12); // 11+11 -> 12
     expect(blackjackScore([c('SPADE', 5), c('HEART', 9), c('CLOVER', 8)])).toBe(22); // bust
   });
+
+  it('skips null entries (face-down cards)', () => {
+    expect(blackjackScore([c('SPADE', 10), null, c('HEART', 5)])).toBe(15);
+  });
 });
 
 describe('blackjackSwitchPreviewScores', () => {
   it('swaps the second card between two hands', () => {
-    const a: Card[] = [c('SPADE', 10), c('SPADE', 4)];
-    const b: Card[] = [c('HEART', 10), c('HEART', 7)];
+    const a: Array<Card | null> = [c('SPADE', 10), c('SPADE', 4)];
+    const b: Array<Card | null> = [c('HEART', 10), c('HEART', 7)];
     // Before: a=14, b=17. After swap: a=10+7=17, b=10+4=14
     expect(blackjackSwitchPreviewScores(a, b)).toEqual({ a: 17, b: 14 });
   });
@@ -26,9 +30,14 @@ describe('blackjackSwitchPreviewScores', () => {
   });
 
   it('preserves extra cards beyond the second', () => {
-    const a: Card[] = [c('SPADE', 10), c('SPADE', 4), c('SPADE', 2)];
-    const b: Card[] = [c('HEART', 9), c('HEART', 8)];
+    const a: Array<Card | null> = [c('SPADE', 10), c('SPADE', 4), c('SPADE', 2)];
+    const b: Array<Card | null> = [c('HEART', 9), c('HEART', 8)];
     // After swap: a = [S10, H8, S2] = 20; b = [H9, S4] = 13
     expect(blackjackSwitchPreviewScores(a, b)).toEqual({ a: 20, b: 13 });
+  });
+
+  it('returns null when a card-to-swap is face-down (null)', () => {
+    expect(blackjackSwitchPreviewScores([c('SPADE', 10), null], [c('HEART', 9), c('HEART', 8)])).toBeNull();
+    expect(blackjackSwitchPreviewScores([c('SPADE', 10), c('SPADE', 4)], [c('HEART', 9), null])).toBeNull();
   });
 });

--- a/frontend/src/utils/blackjackSwitchPreview.ts
+++ b/frontend/src/utils/blackjackSwitchPreview.ts
@@ -7,11 +7,15 @@ function bjCardBase(value: number): number {
   return value;
 }
 
-/** Blackjack hand score with the best (highest non-busting) Ace treatment. */
-export function blackjackScore(cards: Card[]): number {
+/**
+ * Blackjack hand score with the best (highest non-busting) Ace treatment. Null entries
+ * (face-down cards in the server's `(Card | null)[]` payload) are skipped.
+ */
+export function blackjackScore(cards: ReadonlyArray<Card | null>): number {
   let total = 0;
   let aces = 0;
   for (const c of cards) {
+    if (c === null) continue;
     total += bjCardBase(c.value);
     if (c.value === 1) aces += 1;
   }
@@ -22,10 +26,19 @@ export function blackjackScore(cards: Card[]): number {
   return total;
 }
 
-/** Preview the two hand totals after swapping the 2nd card between two Blackjack Switch hands. */
-export function blackjackSwitchPreviewScores(handA: Card[], handB: Card[]): { a: number; b: number } | null {
+/**
+ * Preview the two hand totals after swapping the 2nd card between two Blackjack Switch hands.
+ * Returns `null` when either hand has fewer than 2 cards or the swap slot is face-down.
+ */
+export function blackjackSwitchPreviewScores(
+  handA: ReadonlyArray<Card | null>,
+  handB: ReadonlyArray<Card | null>,
+): { a: number; b: number } | null {
   if (handA.length < 2 || handB.length < 2) return null;
-  const swappedA = [handA[0], handB[1], ...handA.slice(2)];
-  const swappedB = [handB[0], handA[1], ...handB.slice(2)];
+  const a1 = handA[1];
+  const b1 = handB[1];
+  if (a1 === null || b1 === null) return null;
+  const swappedA: Array<Card | null> = [handA[0], b1, ...handA.slice(2)];
+  const swappedB: Array<Card | null> = [handB[0], a1, ...handB.slice(2)];
   return { a: blackjackScore(swappedA), b: blackjackScore(swappedB) };
 }

--- a/frontend/src/utils/blackjackSwitchPreview.ts
+++ b/frontend/src/utils/blackjackSwitchPreview.ts
@@ -1,0 +1,31 @@
+import type { Card } from '../types/card';
+
+/** Numeric value contributed by one card in Blackjack scoring. Aces report 11; soft-total adjustment happens in {@link blackjackScore}. */
+function bjCardBase(value: number): number {
+  if (value === 1) return 11;
+  if (value >= 10) return 10;
+  return value;
+}
+
+/** Blackjack hand score with the best (highest non-busting) Ace treatment. */
+export function blackjackScore(cards: Card[]): number {
+  let total = 0;
+  let aces = 0;
+  for (const c of cards) {
+    total += bjCardBase(c.value);
+    if (c.value === 1) aces += 1;
+  }
+  while (total > 21 && aces > 0) {
+    total -= 10;
+    aces -= 1;
+  }
+  return total;
+}
+
+/** Preview the two hand totals after swapping the 2nd card between two Blackjack Switch hands. */
+export function blackjackSwitchPreviewScores(handA: Card[], handB: Card[]): { a: number; b: number } | null {
+  if (handA.length < 2 || handB.length < 2) return null;
+  const swappedA = [handA[0], handB[1], ...handA.slice(2)];
+  const swappedB = [handB[0], handA[1], ...handB.slice(2)];
+  return { a: blackjackScore(swappedA), b: blackjackScore(swappedB) };
+}


### PR DESCRIPTION
## Summary
- Hovering or focusing the Switch button now overlays the post-swap score on each hand panel (e.g. \`(15 → 20)\`), color-coded green for an improvement, red for a worsening / bust.
- Removes the need to mentally simulate \"if I switch the 2nd card, what will each hand total?\".

## Implementation
- New \`blackjackSwitchPreviewScores\` util reproduces BJ scoring (Ace flex, J/Q/K=10) and computes per-hand totals after swapping cards[1] between the two hands.
- BlackJackSwitchPage adds a \`switchPreview\` flag wired to the Switch button's pointer + focus events for keyboard/touch parity.

## Test plan
- [x] \`bun run test -- --run src/utils/blackjackSwitchPreview.test.ts src/pages/BlackJackSwitchPage.test.tsx\`
- [x] \`bun run check\` (no new lints)

Closes #1924