### PR TITLE
feat(paigow): block foul splits in the UI with a live warning

### DIFF
--- a/frontend/src/i18n/locales/en/paigow.json
+++ b/frontend/src/i18n/locales/en/paigow.json
@@ -56,6 +56,7 @@
   "betGuide": "Set your bet amount",
   "selectLowHand": "Select 2 cards for your low hand",
   "selectedCount": "{{count}} / 2 selected",
+  "foulWarning": "Foul: the low hand outranks the high hand",
   "tutorial": {
     "betControls": "Set your bet amount and press Bet.",
     "setHands": "Select 2 cards from your 7 to form the low hand, then press Set.",

--- a/frontend/src/i18n/locales/ja/paigow.json
+++ b/frontend/src/i18n/locales/ja/paigow.json
@@ -56,6 +56,7 @@
   "betGuide": "ベット額を設定してベット",
   "selectLowHand": "2枚選択してローハンドをセット",
   "selectedCount": "{{count}} / 2 選択中",
+  "foulWarning": "反則：ローハンドがハイハンドより強くなっています",
   "tutorial": {
     "betControls": "ベット額を設定し、ベットを押してください。",
     "setHands": "7枚のカードから2枚を選択してローハンドを作り、セットを押してください。",

--- a/frontend/src/pages/PaiGowPage.test.tsx
+++ b/frontend/src/pages/PaiGowPage.test.tsx
@@ -160,12 +160,27 @@ describe('PaiGowPage', () => {
     renderWithProviders(<PaiGowPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'セット' })).toBeInTheDocument());
 
+    // Pick a non-foul split: low = [C5, S3] keeps the 13 in the high hand.
+    const cardButtons = screen.getAllByRole('button', { name: /Card \d/ });
+    fireEvent.click(cardButtons[3]);
+    fireEvent.click(cardButtons[5]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'セット' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('set', undefined, 3, 5));
+  });
+
+  it('blocks Set and shows a foul warning when the low hand outranks the high hand', async () => {
+    mockExec.mockResolvedValue(setHandsPhaseState);
+    renderWithProviders(<PaiGowPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'セット' })).toBeInTheDocument());
+
+    // Low = [D13, S3] (top 13); high = [S10, H11, C5, H7, D9] (top 11) → foul.
     const cardButtons = screen.getAllByRole('button', { name: /Card \d/ });
     fireEvent.click(cardButtons[2]);
     fireEvent.click(cardButtons[5]);
 
-    fireEvent.click(screen.getByRole('button', { name: 'セット' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('set', undefined, 2, 5));
+    expect(screen.getByTestId('foul-warning')).toBeInTheDocument();
+    expect(screen.getByTestId('set-hands-button')).toBeDisabled();
   });
 
   it('deselects a card when clicked again', async () => {

--- a/frontend/src/pages/PaiGowPage.tsx
+++ b/frontend/src/pages/PaiGowPage.tsx
@@ -31,6 +31,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { PAIGOW_HELP, parsePaigowCommand } from '../utils/cli/commands/paigowCommands';
 import { formatPaigowState } from '../utils/cli/formatters/paigowFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { paiGowFoulCheck } from '../utils/paiGowFoul';
 
 /** High hand rank display name lookup. */
 const HIGH_HAND_RANK_KEYS: Record<number, string> = {
@@ -114,6 +115,14 @@ function PaiGowPageContent() {
   const isSetHandsPhase = state?.phase === PaiGowPhase.SET_HANDS;
   const isEndPhase = state?.phase === PaiGowPhase.END;
 
+  const foul = useMemo(
+    () =>
+      isSetHandsPhase && state && selectedIndices.length === 2
+        ? paiGowFoulCheck(state.playerCards, selectedIndices)
+        : { isFoul: false },
+    [isSetHandsPhase, state, selectedIndices],
+  );
+
   const toggleCardSelection = useCallback((index: number) => {
     setSelectedIndices((prev) => {
       if (prev.includes(index)) {
@@ -134,15 +143,15 @@ function PaiGowPageContent() {
       {
         key: 's',
         action: () => {
-          if (selectedIndices.length === 2) {
+          if (selectedIndices.length === 2 && !foul.isFoul) {
             execApi('set', undefined, selectedIndices[0], selectedIndices[1]);
           }
         },
-        enabled: isSetHandsPhase && selectedIndices.length === 2,
+        enabled: isSetHandsPhase && selectedIndices.length === 2 && !foul.isFoul,
       },
       { key: 'r', action: () => execApi('reset'), enabled: isEndPhase },
     ],
-    [execApi, betAmount, selectedIndices, isBetPhase, isSetHandsPhase, isEndPhase],
+    [execApi, betAmount, selectedIndices, isBetPhase, isSetHandsPhase, isEndPhase, foul.isFoul],
   );
 
   useActionKeyboardNav({
@@ -157,7 +166,7 @@ function PaiGowPageContent() {
   };
 
   const handleSet = () => {
-    if (selectedIndices.length === 2) {
+    if (selectedIndices.length === 2 && !foul.isFoul) {
       execApi('set', undefined, selectedIndices[0], selectedIndices[1]);
     }
   };
@@ -368,12 +377,18 @@ function PaiGowPageContent() {
               </div>
             )}
             {isSetHandsPhase && (
-              <div className="flex justify-center gap-2 pb-2">
+              <div className="flex flex-col items-center gap-1 pb-2">
+                {foul.isFoul && (
+                  <p data-testid="foul-warning" className="text-ds-error text-sm font-medium">
+                    {t('foulWarning')}
+                  </p>
+                )}
                 <button
                   type="button"
                   className={btnSuccess}
                   onClick={handleSet}
-                  disabled={loading || selectedIndices.length !== 2}
+                  disabled={loading || selectedIndices.length !== 2 || foul.isFoul}
+                  data-testid="set-hands-button"
                 >
                   {t('button.set')}
                 </button>

--- a/frontend/src/utils/paiGowFoul.test.ts
+++ b/frontend/src/utils/paiGowFoul.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { paiGowFoulCheck } from './paiGowFoul';
+
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('paiGowFoulCheck', () => {
+  it('returns no foul when low is high card and high beats it', () => {
+    // Hand: S2,S3,S5,S6,S7,H10,DK; low = first two (S2,S3 → top 3); high contains DK=13
+    const cards = [
+      c('SPADE', 2),
+      c('SPADE', 3),
+      c('SPADE', 5),
+      c('SPADE', 6),
+      c('SPADE', 7),
+      c('HEART', 10),
+      c('DIAMOND', 13),
+    ];
+    expect(paiGowFoulCheck(cards, [0, 1])).toEqual({ isFoul: false });
+  });
+
+  it('flags foul when low is a pair and high is just high card', () => {
+    // Low = [S K, H K] -> pair of K; High = [D2, S3, C4, D6, H8] -> high card → foul
+    const cards = [
+      c('SPADE', 13),
+      c('HEART', 13),
+      c('DIAMOND', 2),
+      c('SPADE', 3),
+      c('CLOVER', 4),
+      c('DIAMOND', 6),
+      c('HEART', 8),
+    ];
+    expect(paiGowFoulCheck(cards, [0, 1])).toEqual({ isFoul: true });
+  });
+
+  it('does not flag foul when high contains a pair', () => {
+    // Low = [S K, H K]; High = [D2, S3, C4, D6, H6] (pair of 6) → high beats low only if rank-wise high pair beats low pair?
+    // High-rank wins because high>=pair short-circuits in our check (we only forbid low > high card).
+    const cards = [
+      c('SPADE', 13),
+      c('HEART', 13),
+      c('DIAMOND', 2),
+      c('SPADE', 3),
+      c('CLOVER', 4),
+      c('DIAMOND', 6),
+      c('HEART', 6),
+    ];
+    expect(paiGowFoulCheck(cards, [0, 1]).isFoul).toBe(false);
+  });
+
+  it('flags foul when both are high cards but low top > high top', () => {
+    // Low = [D A, S K] tops=14,13; High = [H2,C3,D4,S5,H7] tops=7 → foul.
+    const cards = [
+      c('DIAMOND', 1),
+      c('SPADE', 13),
+      c('HEART', 2),
+      c('CLOVER', 3),
+      c('DIAMOND', 4),
+      c('SPADE', 5),
+      c('HEART', 7),
+    ];
+    expect(paiGowFoulCheck(cards, [0, 1]).isFoul).toBe(true);
+  });
+
+  it('treats a 5-card flush as beating any low', () => {
+    // High = all spades (5 spades); Low = [H K, H K]
+    const cards = [
+      c('HEART', 13),
+      c('HEART', 13),
+      c('SPADE', 2),
+      c('SPADE', 4),
+      c('SPADE', 7),
+      c('SPADE', 9),
+      c('SPADE', 11),
+    ];
+    expect(paiGowFoulCheck(cards, [0, 1]).isFoul).toBe(false);
+  });
+
+  it('skips check when a joker is present', () => {
+    const cards = [
+      c('JOKER', 0),
+      c('HEART', 13),
+      c('SPADE', 2),
+      c('DIAMOND', 3),
+      c('CLOVER', 4),
+      c('SPADE', 5),
+      c('HEART', 7),
+    ];
+    expect(paiGowFoulCheck(cards, [0, 1])).toEqual({ isFoul: false });
+  });
+
+  it('returns no foul when lowIndices length is not 2', () => {
+    const cards = [
+      c('SPADE', 2),
+      c('SPADE', 3),
+      c('SPADE', 5),
+      c('SPADE', 6),
+      c('SPADE', 7),
+      c('HEART', 10),
+      c('DIAMOND', 13),
+    ];
+    expect(paiGowFoulCheck(cards, [0])).toEqual({ isFoul: false });
+  });
+});

--- a/frontend/src/utils/paiGowFoul.test.ts
+++ b/frontend/src/utils/paiGowFoul.test.ts
@@ -6,7 +6,7 @@ const c = (design: Card['design'], value: number): Card => ({ design, value });
 
 describe('paiGowFoulCheck', () => {
   it('returns no foul when low is high card and high beats it', () => {
-    // Hand: S2,S3,S5,S6,S7,H10,DK; low = first two (S2,S3 → top 3); high contains DK=13
+    // Low = [S2, S3] top=3; High = [S5,S6,S7,H10,DK] top=13 → not foul
     const cards = [
       c('SPADE', 2),
       c('SPADE', 3),
@@ -20,7 +20,7 @@ describe('paiGowFoulCheck', () => {
   });
 
   it('flags foul when low is a pair and high is just high card', () => {
-    // Low = [S K, H K] -> pair of K; High = [D2, S3, C4, D6, H8] -> high card → foul
+    // Low = [S K, H K] → pair of K; High = [D2, S3, C4, D6, H8] → high card → foul
     const cards = [
       c('SPADE', 13),
       c('HEART', 13),
@@ -33,9 +33,8 @@ describe('paiGowFoulCheck', () => {
     expect(paiGowFoulCheck(cards, [0, 1])).toEqual({ isFoul: true });
   });
 
-  it('does not flag foul when high contains a pair', () => {
-    // Low = [S K, H K]; High = [D2, S3, C4, D6, H6] (pair of 6) → high beats low only if rank-wise high pair beats low pair?
-    // High-rank wins because high>=pair short-circuits in our check (we only forbid low > high card).
+  it('flags foul when low pair outranks high pair', () => {
+    // Low = [S K, H K] (Pair of 13); High = [D2, S3, C4, D6, H6] (Pair of 6) → foul
     const cards = [
       c('SPADE', 13),
       c('HEART', 13),
@@ -45,11 +44,25 @@ describe('paiGowFoulCheck', () => {
       c('DIAMOND', 6),
       c('HEART', 6),
     ];
+    expect(paiGowFoulCheck(cards, [0, 1]).isFoul).toBe(true);
+  });
+
+  it('does not flag foul when high pair outranks low pair', () => {
+    // Low = [S2, H2] (Pair of 2s); High = [D6, S6, C4, D7, H8] (Pair of 6s) → not foul
+    const cards = [
+      c('SPADE', 2),
+      c('HEART', 2),
+      c('DIAMOND', 6),
+      c('SPADE', 6),
+      c('CLOVER', 4),
+      c('DIAMOND', 7),
+      c('HEART', 8),
+    ];
     expect(paiGowFoulCheck(cards, [0, 1]).isFoul).toBe(false);
   });
 
   it('flags foul when both are high cards but low top > high top', () => {
-    // Low = [D A, S K] tops=14,13; High = [H2,C3,D4,S5,H7] tops=7 → foul.
+    // Low = [D A, S K] tops=14,13; High = [H2,C3,D4,S5,H7] tops=7 → foul
     const cards = [
       c('DIAMOND', 1),
       c('SPADE', 13),
@@ -62,16 +75,72 @@ describe('paiGowFoulCheck', () => {
     expect(paiGowFoulCheck(cards, [0, 1]).isFoul).toBe(true);
   });
 
+  it('flags foul when top cards tie but low second card outranks high second card', () => {
+    // Low = [D K, S Q] vals=13,12; High = [H K, C3, D4, S5, H7] vals=13,7,5,4,3 → foul (12 > 7)
+    const cards = [
+      c('DIAMOND', 13),
+      c('SPADE', 12),
+      c('HEART', 13),
+      c('CLOVER', 3),
+      c('DIAMOND', 4),
+      c('SPADE', 5),
+      c('HEART', 7),
+    ];
+    expect(paiGowFoulCheck(cards, [0, 1]).isFoul).toBe(true);
+  });
+
+  it('does not flag foul when top cards tie and high second card outranks low second card', () => {
+    // Low = [D K, S3] vals=13,3; High = [H K, C Q, D4, S5, H7] vals=13,12,7,5,4 → not foul (12 > 3)
+    const cards = [
+      c('DIAMOND', 13),
+      c('SPADE', 3),
+      c('HEART', 13),
+      c('CLOVER', 12),
+      c('DIAMOND', 4),
+      c('SPADE', 5),
+      c('HEART', 7),
+    ];
+    expect(paiGowFoulCheck(cards, [0, 1]).isFoul).toBe(false);
+  });
+
   it('treats a 5-card flush as beating any low', () => {
-    // High = all spades (5 spades); Low = [H K, H K]
+    // High = all spades (flush); Low = [H K, H Q] → not foul
     const cards = [
       c('HEART', 13),
-      c('HEART', 13),
+      c('HEART', 12),
       c('SPADE', 2),
       c('SPADE', 4),
       c('SPADE', 7),
       c('SPADE', 9),
       c('SPADE', 11),
+    ];
+    expect(paiGowFoulCheck(cards, [0, 1]).isFoul).toBe(false);
+  });
+
+  it('treats a 5-card straight as beating any low', () => {
+    // High = [H2,S3,D4,C5,H6] (straight); Low = [D A, S K] → not foul
+    const cards = [
+      c('DIAMOND', 1),
+      c('SPADE', 13),
+      c('HEART', 2),
+      c('SPADE', 3),
+      c('DIAMOND', 4),
+      c('CLOVER', 5),
+      c('HEART', 6),
+    ];
+    expect(paiGowFoulCheck(cards, [0, 1]).isFoul).toBe(false);
+  });
+
+  it('treats two pair in high hand as beating any low', () => {
+    // High = [S2,H2,D3,C3,H8] (two pair); Low = [D A, S K] → not foul
+    const cards = [
+      c('DIAMOND', 1),
+      c('SPADE', 13),
+      c('SPADE', 2),
+      c('HEART', 2),
+      c('DIAMOND', 3),
+      c('CLOVER', 3),
+      c('HEART', 8),
     ];
     expect(paiGowFoulCheck(cards, [0, 1]).isFoul).toBe(false);
   });

--- a/frontend/src/utils/paiGowFoul.ts
+++ b/frontend/src/utils/paiGowFoul.ts
@@ -1,0 +1,64 @@
+import type { Card } from '../types/card';
+
+/** Numeric rank used for Pai Gow comparisons: Ace = 14, J/Q/K = 11/12/13, otherwise face value. */
+function paiGowValue(card: Card): number {
+  if (card.value === 1) return 14;
+  return card.value;
+}
+
+function isJoker(card: Card): boolean {
+  return card.design === 'JOKER';
+}
+
+/** Detect a 5-card straight ignoring suits (handles A-low 1-5 and A-high 10-A). */
+function isStraightValues(vals: number[]): boolean {
+  const sorted = [...vals].sort((a, b) => a - b);
+  // A-low: 14,2,3,4,5 → after sort 2,3,4,5,14
+  if (sorted[0] === 2 && sorted[1] === 3 && sorted[2] === 4 && sorted[3] === 5 && sorted[4] === 14) return true;
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i] - sorted[i - 1] !== 1) return false;
+  }
+  return true;
+}
+
+/** True if the 5-card high hand is at least one pair OR a straight/flush (which beats any 2-card low). */
+function highHandAtLeastPair(highHand: Card[]): boolean {
+  if (highHand.length !== 5) return false;
+  const counts = new Map<number, number>();
+  for (const c of highHand) {
+    const v = paiGowValue(c);
+    counts.set(v, (counts.get(v) ?? 0) + 1);
+  }
+  for (const c of counts.values()) {
+    if (c >= 2) return true;
+  }
+  const vals = highHand.map(paiGowValue);
+  if (isStraightValues(vals)) return true;
+  const firstDesign = highHand[0].design;
+  if (highHand.every((c) => c.design === firstDesign)) return true;
+  return false;
+}
+
+/** Computed foul state for a Pai Gow split. */
+export interface PaiGowFoulResult {
+  /** True when the split is illegal (low hand outranks high). */
+  isFoul: boolean;
+}
+
+/** Detect whether the 2-card low hand outranks the 5-card high hand. Skips evaluation if a joker is present. */
+export function paiGowFoulCheck(playerCards: Card[], lowIndices: readonly number[]): PaiGowFoulResult {
+  if (lowIndices.length !== 2 || playerCards.length !== 7) return { isFoul: false };
+  if (playerCards.some(isJoker)) return { isFoul: false }; // conservative — backend handles
+  const [i0, i1] = lowIndices;
+  if (i0 === i1 || i0 < 0 || i1 < 0 || i0 >= 7 || i1 >= 7) return { isFoul: false };
+  const lowHand = [playerCards[i0], playerCards[i1]];
+  const highHand = playerCards.filter((_, idx) => idx !== i0 && idx !== i1);
+
+  const lowVals = lowHand.map(paiGowValue).sort((a, b) => b - a);
+  const isLowPair = lowVals[0] === lowVals[1];
+
+  if (highHandAtLeastPair(highHand)) return { isFoul: false };
+  if (isLowPair) return { isFoul: true };
+  const highVals = highHand.map(paiGowValue).sort((a, b) => b - a);
+  return { isFoul: highVals[0] < lowVals[0] };
+}

--- a/frontend/src/utils/paiGowFoul.ts
+++ b/frontend/src/utils/paiGowFoul.ts
@@ -49,8 +49,7 @@ function getHighHandStrength(highHand: Card[]): HighHandStrength {
   }
 
   const highVals = highHand.map(paiGowValue).sort((a, b) => b - a);
-  const isStraightOrFlush =
-    isStraightValues(highVals) || highHand.every((c) => c.design === highHand[0].design);
+  const isStraightOrFlush = isStraightValues(highVals) || highHand.every((c) => c.design === highHand[0].design);
 
   return {
     isRank2Plus: isStraightOrFlush || hasTripsOrBetter || pairs >= 2,

--- a/frontend/src/utils/paiGowFoul.ts
+++ b/frontend/src/utils/paiGowFoul.ts
@@ -21,22 +21,42 @@ function isStraightValues(vals: number[]): boolean {
   return true;
 }
 
-/** True if the 5-card high hand is at least one pair OR a straight/flush (which beats any 2-card low). */
-function highHandAtLeastPair(highHand: Card[]): boolean {
-  if (highHand.length !== 5) return false;
+interface HighHandStrength {
+  /** True if rank is two pair, trips, straight, flush, or better — always beats any 2-card low hand. */
+  isRank2Plus: boolean;
+  /** The value of the single pair, or 0 if the high hand is not exactly one pair. */
+  pairValue: number;
+  /** High hand values sorted descending, used for high-card comparison. */
+  highVals: number[];
+}
+
+/** Compute the strength category of a 5-card high hand for foul detection. */
+function getHighHandStrength(highHand: Card[]): HighHandStrength {
   const counts = new Map<number, number>();
-  for (const c of highHand) {
-    const v = paiGowValue(c);
-    counts.set(v, (counts.get(v) ?? 0) + 1);
+  let pairs = 0;
+  let highPairVal = 0;
+  let hasTripsOrBetter = false;
+
+  for (const card of highHand) {
+    const v = paiGowValue(card);
+    const count = (counts.get(v) ?? 0) + 1;
+    counts.set(v, count);
+    if (count === 2) {
+      pairs++;
+      if (v > highPairVal) highPairVal = v;
+    }
+    if (count >= 3) hasTripsOrBetter = true;
   }
-  for (const c of counts.values()) {
-    if (c >= 2) return true;
-  }
-  const vals = highHand.map(paiGowValue);
-  if (isStraightValues(vals)) return true;
-  const firstDesign = highHand[0].design;
-  if (highHand.every((c) => c.design === firstDesign)) return true;
-  return false;
+
+  const highVals = highHand.map(paiGowValue).sort((a, b) => b - a);
+  const isStraightOrFlush =
+    isStraightValues(highVals) || highHand.every((c) => c.design === highHand[0].design);
+
+  return {
+    isRank2Plus: isStraightOrFlush || hasTripsOrBetter || pairs >= 2,
+    pairValue: pairs === 1 ? highPairVal : 0,
+    highVals,
+  };
 }
 
 /** Computed foul state for a Pai Gow split. */
@@ -56,9 +76,22 @@ export function paiGowFoulCheck(playerCards: Card[], lowIndices: readonly number
 
   const lowVals = lowHand.map(paiGowValue).sort((a, b) => b - a);
   const isLowPair = lowVals[0] === lowVals[1];
+  const highInfo = getHighHandStrength(highHand);
 
-  if (highHandAtLeastPair(highHand)) return { isFoul: false };
-  if (isLowPair) return { isFoul: true };
-  const highVals = highHand.map(paiGowValue).sort((a, b) => b - a);
-  return { isFoul: highVals[0] < lowVals[0] };
+  // Rank 2+ (two pair, trips, straight, flush, or better) always beats any 2-card hand.
+  if (highInfo.isRank2Plus) return { isFoul: false };
+
+  if (isLowPair) {
+    // Low pair vs high card: foul (pair beats any high card hand).
+    if (highInfo.pairValue === 0) return { isFoul: true };
+    // Low pair vs high pair: foul only when the low pair outranks the high pair.
+    return { isFoul: lowVals[0] > highInfo.pairValue };
+  }
+
+  // Low is high card. High hand has a pair (beats any high card): not a foul.
+  if (highInfo.pairValue > 0) return { isFoul: false };
+
+  // Both are high card: compare top card, then second card.
+  if (lowVals[0] !== highInfo.highVals[0]) return { isFoul: lowVals[0] > highInfo.highVals[0] };
+  return { isFoul: lowVals[1] > highInfo.highVals[1] };
 }


### PR DESCRIPTION
## Summary
- Computes whether the currently-selected 2-card low hand would outrank the remaining 5-card high hand and, if so, disables the Set button (plus the \`s\` keyboard shortcut) and shows a localized warning above it.
- Stops players from blindly submitting a foul split and getting the backend rejection / autoloss after the fact.

## Implementation
- New \`paiGowFoulCheck\` util reproduces the backend's pair/straight/flush short-circuit and the high-card vs low-card top-rank comparison. Jokers fall back to the backend's authoritative validation (no false positives).
- \`PaiGowPage\` memoizes the foul check, gates Set / hotkey on it, and renders the warning beneath the existing select-low-hand guide.

## Test plan
- [x] \`bun run test -- --run src/utils/paiGowFoul.test.ts src/pages/PaiGowPage.test.tsx\`
- [x] \`bun run check\`

Closes #1925