### PR TITLE
feat(freecell,eightoff,seahaven): highlight in-limit supermove block on hover

### DIFF
--- a/frontend/src/pages/EightOffPage.test.tsx
+++ b/frontend/src/pages/EightOffPage.test.tsx
@@ -739,6 +739,34 @@ describe('EightOffPage', () => {
       expect(topButton).toHaveAttribute('data-supermove-blocked', 'true');
     });
 
+    it('highlights the in-limit block under the cursor', async () => {
+      const looseState: EightOffResponse = {
+        ...playingState,
+        tableau: [
+          [card('SPADE', 13), card('HEART', 12), card('CLOVER', 11)],
+          [card('DIAMOND', 1)],
+          [card('SPADE', 2)],
+          [card('HEART', 3)],
+          [card('DIAMOND', 4)],
+          [card('CLOVER', 5)],
+          [card('SPADE', 6)],
+          [card('HEART', 7)],
+        ],
+        freeCells: [card('DIAMOND', 8), card('CLOVER', 9), null, null, null, null, null, null],
+      };
+      mockExec.mockResolvedValue(looseState);
+      renderWithProviders(<EightOffPage />);
+      await waitFor(() => expect(screen.getByAltText('♥ Q')).toBeInTheDocument());
+
+      const middleButton = screen.getByAltText('♥ Q').closest('button') as HTMLButtonElement;
+      const bottomButton = screen.getByAltText('♣ J').closest('button') as HTMLButtonElement;
+      fireEvent.mouseEnter(middleButton);
+      expect(middleButton).toHaveAttribute('data-supermove-block', 'true');
+      expect(bottomButton).toHaveAttribute('data-supermove-block', 'true');
+      fireEvent.mouseLeave(middleButton);
+      expect(middleButton).not.toHaveAttribute('data-supermove-block');
+    });
+
     it('lets the entire stack drag when free cells + empty cols allow it', async () => {
       // 3-card stack, 2 empty free cells, 0 empty cols → limit = (1+2)*2^0 = 3 → all 3 movable.
       const looseState: EightOffResponse = {

--- a/frontend/src/pages/EightOffPage.tsx
+++ b/frontend/src/pages/EightOffPage.tsx
@@ -349,7 +349,6 @@ function EightOffPageContent() {
                                 hoveredStack !== null &&
                                 hoveredStack.col === colIdx &&
                                 cardIdx >= hoveredStack.cardIdx &&
-                                !exceedsSupermove &&
                                 col.length - hoveredStack.cardIdx <= supermoveLimit;
                               return (
                                 <div

--- a/frontend/src/pages/EightOffPage.tsx
+++ b/frontend/src/pages/EightOffPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { EightOffMoveZone, eightoffApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -149,6 +149,8 @@ function EightOffPageContent() {
     bindings: actionBindings,
     enabled: !!isPlayingForKbd && !loading,
   });
+
+  const [hoveredStack, setHoveredStack] = useState<{ col: number; cardIdx: number } | null>(null);
 
   if (!state) return <GameSkeleton gameKey="eightoff" layout={{ kind: 'tableau', topRow: 8, tableau: 8 }} />;
 
@@ -343,6 +345,12 @@ function EightOffPageContent() {
                               };
                               const stackSize = col.length - cardIdx;
                               const exceedsSupermove = stackSize > supermoveLimit;
+                              const isInHoveredBlock =
+                                hoveredStack !== null &&
+                                hoveredStack.col === colIdx &&
+                                cardIdx >= hoveredStack.cardIdx &&
+                                !exceedsSupermove &&
+                                col.length - hoveredStack.cardIdx <= supermoveLimit;
                               return (
                                 <div
                                   key={`tc-${colIdx.toString()}-${cardIdx.toString()}`}
@@ -365,12 +373,17 @@ function EightOffPageContent() {
                                       draggable={isPlaying && !loading && !exceedsSupermove}
                                       onDragStart={dnd.handleDragStart(cardZone)}
                                       onDragEnd={dnd.handleDragEnd}
+                                      onMouseEnter={() => setHoveredStack({ col: colIdx, cardIdx })}
+                                      onMouseLeave={() => setHoveredStack(null)}
+                                      onFocus={() => setHoveredStack({ col: colIdx, cardIdx })}
+                                      onBlur={() => setHoveredStack(null)}
                                       title={
                                         exceedsSupermove
                                           ? t('supermoveLimitTooltip', { limit: supermoveLimit })
                                           : undefined
                                       }
                                       data-supermove-blocked={exceedsSupermove ? 'true' : undefined}
+                                      data-supermove-block={isInHoveredBlock ? 'true' : undefined}
                                       className={[
                                         'p-0 border-0 bg-transparent cursor-pointer w-full rounded',
                                         focusRingWhite,
@@ -378,6 +391,7 @@ function EightOffPageContent() {
                                           'ring-2 ring-ds-warning',
                                         dnd.isDragSource(cardZone) && 'opacity-50',
                                         exceedsSupermove && 'opacity-60 ring-1 ring-ds-error',
+                                        isInHoveredBlock && 'ring-2 ring-ds-success',
                                       ]
                                         .filter(Boolean)
                                         .join(' ')}

--- a/frontend/src/pages/FreeCellPage.test.tsx
+++ b/frontend/src/pages/FreeCellPage.test.tsx
@@ -730,6 +730,34 @@ describe('FreeCellPage', () => {
       expect(topButton).toHaveAttribute('data-supermove-blocked', 'true');
     });
 
+    it('highlights the in-limit block under the cursor', async () => {
+      const looseState: FreeCellResponse = {
+        ...playingState,
+        tableau: [
+          [card('SPADE', 13), card('HEART', 12), card('CLOVER', 11)],
+          [card('DIAMOND', 1)],
+          [card('SPADE', 2)],
+          [card('HEART', 3)],
+          [card('DIAMOND', 4)],
+          [card('CLOVER', 5)],
+          [card('SPADE', 6)],
+          [card('HEART', 7)],
+        ],
+        freeCells: [card('DIAMOND', 8), card('CLOVER', 9), null, null],
+      };
+      mockExec.mockResolvedValue(looseState);
+      renderWithProviders(<FreeCellPage />);
+      await waitFor(() => expect(screen.getByAltText('♥ Q')).toBeInTheDocument());
+
+      const middleButton = screen.getByAltText('♥ Q').closest('button') as HTMLButtonElement;
+      const bottomButton = screen.getByAltText('♣ J').closest('button') as HTMLButtonElement;
+      fireEvent.mouseEnter(middleButton);
+      expect(middleButton).toHaveAttribute('data-supermove-block', 'true');
+      expect(bottomButton).toHaveAttribute('data-supermove-block', 'true');
+      fireEvent.mouseLeave(middleButton);
+      expect(middleButton).not.toHaveAttribute('data-supermove-block');
+    });
+
     it('lets the entire stack drag when free cells + empty cols allow it', async () => {
       // 3-card stack, 2 empty free cells, 0 empty cols → limit = (1+2)*2^0 = 3 → all 3 movable.
       const looseState: FreeCellResponse = {

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -349,7 +349,6 @@ function FreeCellPageContent() {
                                 hoveredStack !== null &&
                                 hoveredStack.col === colIdx &&
                                 cardIdx >= hoveredStack.cardIdx &&
-                                !exceedsSupermove &&
                                 col.length - hoveredStack.cardIdx <= supermoveLimit;
                               return (
                                 <div

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { FreeCellMoveZone, freecellApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -149,6 +149,8 @@ function FreeCellPageContent() {
     bindings: actionBindings,
     enabled: !!isPlayingForKbd && !loading,
   });
+
+  const [hoveredStack, setHoveredStack] = useState<{ col: number; cardIdx: number } | null>(null);
 
   if (!state) return <GameSkeleton gameKey="freecell" layout={{ kind: 'tableau', topRow: 8, tableau: 8 }} />;
 
@@ -343,6 +345,12 @@ function FreeCellPageContent() {
                               };
                               const stackSize = col.length - cardIdx;
                               const exceedsSupermove = stackSize > supermoveLimit;
+                              const isInHoveredBlock =
+                                hoveredStack !== null &&
+                                hoveredStack.col === colIdx &&
+                                cardIdx >= hoveredStack.cardIdx &&
+                                !exceedsSupermove &&
+                                col.length - hoveredStack.cardIdx <= supermoveLimit;
                               return (
                                 <div
                                   key={`tc-${colIdx.toString()}-${cardIdx.toString()}`}
@@ -365,12 +373,17 @@ function FreeCellPageContent() {
                                       draggable={isPlaying && !loading && !exceedsSupermove}
                                       onDragStart={dnd.handleDragStart(cardZone)}
                                       onDragEnd={dnd.handleDragEnd}
+                                      onMouseEnter={() => setHoveredStack({ col: colIdx, cardIdx })}
+                                      onMouseLeave={() => setHoveredStack(null)}
+                                      onFocus={() => setHoveredStack({ col: colIdx, cardIdx })}
+                                      onBlur={() => setHoveredStack(null)}
                                       title={
                                         exceedsSupermove
                                           ? t('supermoveLimitTooltip', { limit: supermoveLimit })
                                           : undefined
                                       }
                                       data-supermove-blocked={exceedsSupermove ? 'true' : undefined}
+                                      data-supermove-block={isInHoveredBlock ? 'true' : undefined}
                                       className={[
                                         'p-0 border-0 bg-transparent cursor-pointer w-full rounded',
                                         focusRingWhite,
@@ -378,6 +391,7 @@ function FreeCellPageContent() {
                                           'ring-2 ring-ds-warning',
                                         dnd.isDragSource(cardZone) && 'opacity-50',
                                         exceedsSupermove && 'opacity-60 ring-1 ring-ds-error',
+                                        isInHoveredBlock && 'ring-2 ring-ds-success',
                                       ]
                                         .filter(Boolean)
                                         .join(' ')}

--- a/frontend/src/pages/SeahavenTowersPage.test.tsx
+++ b/frontend/src/pages/SeahavenTowersPage.test.tsx
@@ -163,4 +163,35 @@ describe('SeahavenTowersPage', () => {
     renderWithProviders(<SeahavenTowersPage />);
     await waitFor(() => expect(screen.getAllByText(/ゲームオーバー/).length).toBeGreaterThan(0));
   });
+
+  it('highlights the in-limit supermove block under the cursor', async () => {
+    // Both reserved cells empty → limit = 1 + 2 = 3, so the bottom 3 cards form the movable block.
+    const looseState: SeahavenTowersResponse = {
+      ...playingState,
+      tableau: [
+        [card('SPADE', 13), card('HEART', 12), card('CLOVER', 11)],
+        [card('DIAMOND', 1)],
+        [card('SPADE', 2)],
+        [card('HEART', 3)],
+        [card('DIAMOND', 4)],
+        [card('CLOVER', 5)],
+        [card('SPADE', 6)],
+        [card('HEART', 7)],
+        [card('CLOVER', 8)],
+        [card('DIAMOND', 9)],
+      ],
+      reservedCells: [null, null],
+    };
+    mockExec.mockResolvedValue(looseState);
+    renderWithProviders(<SeahavenTowersPage />);
+    await waitFor(() => expect(screen.getByAltText('♥ Q')).toBeInTheDocument());
+
+    const middleButton = screen.getByAltText('♥ Q').closest('button') as HTMLButtonElement;
+    const bottomButton = screen.getByAltText('♣ J').closest('button') as HTMLButtonElement;
+    fireEvent.mouseEnter(middleButton);
+    expect(middleButton).toHaveAttribute('data-supermove-block', 'true');
+    expect(bottomButton).toHaveAttribute('data-supermove-block', 'true');
+    fireEvent.mouseLeave(middleButton);
+    expect(middleButton).not.toHaveAttribute('data-supermove-block');
+  });
 });

--- a/frontend/src/pages/SeahavenTowersPage.tsx
+++ b/frontend/src/pages/SeahavenTowersPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { SeahavenTowersMoveZone, seahaventowersApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -166,6 +166,8 @@ function SeahavenTowersPageContent() {
     bindings: actionBindings,
     enabled: !!isPlayingForKbd && !loading,
   });
+
+  const [hoveredStack, setHoveredStack] = useState<{ col: number; cardIdx: number } | null>(null);
 
   if (!state) return <GameSkeleton gameKey="seahaventowers" layout={{ kind: 'tableau', topRow: 10, tableau: 10 }} />;
 
@@ -357,6 +359,12 @@ function SeahavenTowersPageContent() {
                               };
                               const stackSize = col.length - cardIdx;
                               const exceedsSupermove = stackSize > supermoveLimit;
+                              const isInHoveredBlock =
+                                hoveredStack !== null &&
+                                hoveredStack.col === colIdx &&
+                                cardIdx >= hoveredStack.cardIdx &&
+                                !exceedsSupermove &&
+                                col.length - hoveredStack.cardIdx <= supermoveLimit;
                               return (
                                 <div
                                   key={`tc-${colIdx.toString()}-${cardIdx.toString()}`}
@@ -379,12 +387,17 @@ function SeahavenTowersPageContent() {
                                       draggable={isPlaying && !loading && !exceedsSupermove}
                                       onDragStart={dnd.handleDragStart(cardZone)}
                                       onDragEnd={dnd.handleDragEnd}
+                                      onMouseEnter={() => setHoveredStack({ col: colIdx, cardIdx })}
+                                      onMouseLeave={() => setHoveredStack(null)}
+                                      onFocus={() => setHoveredStack({ col: colIdx, cardIdx })}
+                                      onBlur={() => setHoveredStack(null)}
                                       title={
                                         exceedsSupermove
                                           ? t('supermoveLimitTooltip', { limit: supermoveLimit })
                                           : undefined
                                       }
                                       data-supermove-blocked={exceedsSupermove ? 'true' : undefined}
+                                      data-supermove-block={isInHoveredBlock ? 'true' : undefined}
                                       className={[
                                         'p-0 border-0 bg-transparent cursor-pointer w-full rounded',
                                         focusRingWhite,
@@ -392,6 +405,7 @@ function SeahavenTowersPageContent() {
                                           'ring-2 ring-ds-warning',
                                         dnd.isDragSource(cardZone) && 'opacity-50',
                                         exceedsSupermove && 'opacity-60 ring-1 ring-ds-error',
+                                        isInHoveredBlock && 'ring-2 ring-ds-success',
                                       ]
                                         .filter(Boolean)
                                         .join(' ')}

--- a/frontend/src/pages/SeahavenTowersPage.tsx
+++ b/frontend/src/pages/SeahavenTowersPage.tsx
@@ -363,7 +363,6 @@ function SeahavenTowersPageContent() {
                                 hoveredStack !== null &&
                                 hoveredStack.col === colIdx &&
                                 cardIdx >= hoveredStack.cardIdx &&
-                                !exceedsSupermove &&
                                 col.length - hoveredStack.cardIdx <= supermoveLimit;
                               return (
                                 <div


### PR DESCRIPTION
## Summary
- Hovering (or focusing) a tableau card now lights the entire below-stack with a green ring **when** that stack fits inside the current supermove limit, so players can see at a glance how many cards their next drag will actually move.
- Complements the existing red \"exceeds supermove\" affordance — together they form a clear cap line for FreeCell / Eight Off / Seahaven Towers.

## Implementation
- Each page tracks a \`hoveredStack: { col, cardIdx } | null\` state (declared before the early-return to satisfy hooks rules).
- A card is marked \`data-supermove-block=\"true\"\` and \`ring-2 ring-ds-success\` when the hover origin's stack size ≤ supermoveLimit.
- Keyboard parity via \`onFocus\`/\`onBlur\`.

## Test plan
- [x] \`bun run test -- --run src/pages/FreeCellPage.test.tsx src/pages/EightOffPage.test.tsx src/pages/SeahavenTowersPage.test.tsx\` (new hover-block test added on FreeCell)
- [x] \`bun run check\`

Closes #1926