### PR TITLE
feat(tripeaks,golf): combo badge for consecutive removes

### DIFF
--- a/frontend/src/hooks/useChainCombo.test.ts
+++ b/frontend/src/hooks/useChainCombo.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { useChainCombo } from './useChainCombo';
 
@@ -47,9 +47,20 @@ describe('useChainCombo', () => {
     });
     rerender({ m: 1, s: 24 });
     expect(result.current).toBe(1);
-    act(() => {
-      rerender({ m: 1, s: 24 });
+    rerender({ m: 1, s: 24 });
+    expect(result.current).toBe(1);
+  });
+
+  it('resets when moveCount decreases (undo)', () => {
+    const { result, rerender } = renderHook(({ m, s }) => useChainCombo(m, s), {
+      initialProps: { m: 0, s: 24 },
     });
+    rerender({ m: 1, s: 24 });
+    rerender({ m: 2, s: 24 });
+    expect(result.current).toBe(2);
+    rerender({ m: 1, s: 24 }); // undo
+    expect(result.current).toBe(0);
+    rerender({ m: 2, s: 24 }); // redo would otherwise inflate; combo starts fresh
     expect(result.current).toBe(1);
   });
 });

--- a/frontend/src/hooks/useChainCombo.test.ts
+++ b/frontend/src/hooks/useChainCombo.test.ts
@@ -1,0 +1,55 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useChainCombo } from './useChainCombo';
+
+describe('useChainCombo', () => {
+  it('returns 0 when state is not yet loaded', () => {
+    const { result } = renderHook(() => useChainCombo(undefined, undefined));
+    expect(result.current).toBe(0);
+  });
+
+  it('increments while moveCount rises and stockCount holds', () => {
+    const { result, rerender } = renderHook(({ m, s }) => useChainCombo(m, s), {
+      initialProps: { m: 0, s: 24 },
+    });
+    expect(result.current).toBe(0);
+    rerender({ m: 1, s: 24 });
+    expect(result.current).toBe(1);
+    rerender({ m: 2, s: 24 });
+    expect(result.current).toBe(2);
+  });
+
+  it('resets when stockCount changes (player drew from stock)', () => {
+    const { result, rerender } = renderHook(({ m, s }) => useChainCombo(m, s), {
+      initialProps: { m: 0, s: 24 },
+    });
+    rerender({ m: 1, s: 24 });
+    rerender({ m: 2, s: 24 });
+    expect(result.current).toBe(2);
+    rerender({ m: 3, s: 23 }); // drew a card
+    expect(result.current).toBe(0);
+  });
+
+  it('resets when moveCount drops to 0 (game reset)', () => {
+    const { result, rerender } = renderHook(({ m, s }) => useChainCombo(m, s), {
+      initialProps: { m: 0, s: 24 },
+    });
+    rerender({ m: 1, s: 24 });
+    rerender({ m: 2, s: 24 });
+    expect(result.current).toBe(2);
+    rerender({ m: 0, s: 24 }); // reset
+    expect(result.current).toBe(0);
+  });
+
+  it('does not increment if moveCount stays the same', () => {
+    const { result, rerender } = renderHook(({ m, s }) => useChainCombo(m, s), {
+      initialProps: { m: 0, s: 24 },
+    });
+    rerender({ m: 1, s: 24 });
+    expect(result.current).toBe(1);
+    act(() => {
+      rerender({ m: 1, s: 24 });
+    });
+    expect(result.current).toBe(1);
+  });
+});

--- a/frontend/src/hooks/useChainCombo.ts
+++ b/frontend/src/hooks/useChainCombo.ts
@@ -1,0 +1,44 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Track a "chain" of consecutive remove actions (no stock draw between them).
+ *
+ * The hook watches `moveCount` and `stockCount` from the server response and
+ * increments an internal counter whenever `moveCount` rises while `stockCount`
+ * stays the same. Any change to `stockCount` (i.e. the player drew from the
+ * stock) resets the chain back to zero.
+ *
+ * Used by TriPeaks and Golf to surface a streak/Combo badge.
+ */
+export function useChainCombo(moveCount: number | undefined, stockCount: number | undefined): number {
+  const [combo, setCombo] = useState(0);
+  const prevMove = useRef<number | undefined>(moveCount);
+  const prevStock = useRef<number | undefined>(stockCount);
+
+  useEffect(() => {
+    if (moveCount === undefined || stockCount === undefined) {
+      setCombo(0);
+      prevMove.current = moveCount;
+      prevStock.current = stockCount;
+      return;
+    }
+    const lastMove = prevMove.current;
+    const lastStock = prevStock.current;
+    if (lastMove === undefined || lastStock === undefined) {
+      prevMove.current = moveCount;
+      prevStock.current = stockCount;
+      return;
+    }
+    if (moveCount === 0) {
+      setCombo(0);
+    } else if (stockCount !== lastStock) {
+      setCombo(0);
+    } else if (moveCount > lastMove) {
+      setCombo((c) => c + 1);
+    }
+    prevMove.current = moveCount;
+    prevStock.current = stockCount;
+  }, [moveCount, stockCount]);
+
+  return combo;
+}

--- a/frontend/src/hooks/useChainCombo.ts
+++ b/frontend/src/hooks/useChainCombo.ts
@@ -5,8 +5,11 @@ import { useEffect, useRef, useState } from 'react';
  *
  * The hook watches `moveCount` and `stockCount` from the server response and
  * increments an internal counter whenever `moveCount` rises while `stockCount`
- * stays the same. Any change to `stockCount` (i.e. the player drew from the
- * stock) resets the chain back to zero.
+ * stays the same. The chain resets to zero on any of:
+ * - the player draws from the stock (`stockCount` changes),
+ * - the player undoes a move (`moveCount` decreases) — otherwise undo + redo
+ *   would inflate the combo,
+ * - the game restarts (`moveCount` returns to zero).
  *
  * Used by TriPeaks and Golf to surface a streak/Combo badge.
  */
@@ -32,6 +35,9 @@ export function useChainCombo(moveCount: number | undefined, stockCount: number 
     if (moveCount === 0) {
       setCombo(0);
     } else if (stockCount !== lastStock) {
+      setCombo(0);
+    } else if (moveCount < lastMove) {
+      // Undo breaks the streak — otherwise an undo + redo would fake a longer combo.
       setCombo(0);
     } else if (moveCount > lastMove) {
       setCombo((c) => c + 1);

--- a/frontend/src/i18n/locales/en/golf.json
+++ b/frontend/src/i18n/locales/en/golf.json
@@ -8,6 +8,7 @@
   "stock": "Stock",
   "waste": "Waste",
   "moveCount": "Moves",
+  "combo": "Combo ×{{count}}",
   "draw": "Draw",
   "giveup": "Give Up",
   "hint": "Hint",

--- a/frontend/src/i18n/locales/en/tripeaks.json
+++ b/frontend/src/i18n/locales/en/tripeaks.json
@@ -8,6 +8,7 @@
   "stock": "Stock",
   "waste": "Waste",
   "moveCount": "Moves",
+  "combo": "Combo ×{{count}}",
   "draw": "Draw",
   "giveup": "Give Up",
   "hint": "Hint",

--- a/frontend/src/i18n/locales/ja/golf.json
+++ b/frontend/src/i18n/locales/ja/golf.json
@@ -8,6 +8,7 @@
   "stock": "山札",
   "waste": "捨て札",
   "moveCount": "手数",
+  "combo": "コンボ ×{{count}}",
   "draw": "引く",
   "giveup": "ギブアップ",
   "hint": "ヒント",

--- a/frontend/src/i18n/locales/ja/tripeaks.json
+++ b/frontend/src/i18n/locales/ja/tripeaks.json
@@ -8,6 +8,7 @@
   "stock": "山札",
   "waste": "捨て札",
   "moveCount": "手数",
+  "combo": "コンボ ×{{count}}",
   "draw": "引く",
   "giveup": "ギブアップ",
   "hint": "ヒント",

--- a/frontend/src/pages/GolfPage.test.tsx
+++ b/frontend/src/pages/GolfPage.test.tsx
@@ -10,7 +10,14 @@ vi.mock('../api/gameApi', () => ({
   actionLogApi: { golf: vi.fn() },
 }));
 
+vi.mock('../hooks/useChainCombo', () => ({
+  useChainCombo: vi.fn().mockReturnValue(0),
+}));
+
+import { useChainCombo } from '../hooks/useChainCombo';
+
 const mockExec = vi.mocked(golfApi.exec);
+const mockCombo = vi.mocked(useChainCombo);
 
 const card = (design: CardDesign, value: number): Card => ({ design, value });
 
@@ -63,6 +70,7 @@ const gameOverState: GolfResponse = {
 
 beforeEach(() => {
   mockExec.mockResolvedValue(playingState);
+  mockCombo.mockReturnValue(0);
 });
 
 describe('GolfPage', () => {
@@ -244,5 +252,33 @@ describe('GolfPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     expect(screen.queryByRole('button', { name: '確認' })).not.toBeInTheDocument();
+  });
+
+  it('does not render the combo badge when combo < 2', async () => {
+    mockCombo.mockReturnValue(1);
+    renderWithProviders(<GolfPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    expect(screen.queryByTestId('combo-badge')).not.toBeInTheDocument();
+  });
+
+  it('renders the combo badge with blue styling when combo is 2', async () => {
+    mockCombo.mockReturnValue(2);
+    renderWithProviders(<GolfPage />);
+    const badge = await screen.findByTestId('combo-badge');
+    expect(badge.className).toContain('bg-ds-info');
+  });
+
+  it('renders the combo badge with warning styling when combo is between 3 and 4', async () => {
+    mockCombo.mockReturnValue(3);
+    renderWithProviders(<GolfPage />);
+    const badge = await screen.findByTestId('combo-badge');
+    expect(badge.className).toContain('bg-ds-warning');
+  });
+
+  it('renders the combo badge with error styling when combo >= 5', async () => {
+    mockCombo.mockReturnValue(5);
+    renderWithProviders(<GolfPage />);
+    const badge = await screen.findByTestId('combo-badge');
+    expect(badge.className).toContain('bg-ds-error');
   });
 });

--- a/frontend/src/pages/GolfPage.tsx
+++ b/frontend/src/pages/GolfPage.tsx
@@ -17,6 +17,7 @@ import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions, useWindowWidth } from '../hooks/useCardDimensions';
+import { useChainCombo } from '../hooks/useChainCombo';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
@@ -126,6 +127,8 @@ function GolfPageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
+  const combo = useChainCombo(state?.moveCount, state?.stockCount);
+
   if (!state)
     return (
       <GameSkeleton
@@ -168,6 +171,20 @@ function GolfPageContent() {
           <span>
             {t('moveCount')}: {state.moveCount}
           </span>
+          {combo >= 2 && (
+            <span
+              data-testid="combo-badge"
+              className={`px-2 py-0.5 rounded-full text-xs font-bold ${
+                combo >= 5
+                  ? 'bg-ds-error text-ds-text-on-accent'
+                  : combo >= 3
+                    ? 'bg-ds-warning text-ds-text-on-accent'
+                    : 'bg-ds-info text-ds-text-on-accent'
+              }`}
+            >
+              {t('combo', { count: combo })}
+            </span>
+          )}
           <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
         </>
       }

--- a/frontend/src/pages/TriPeaksPage.test.tsx
+++ b/frontend/src/pages/TriPeaksPage.test.tsx
@@ -15,7 +15,14 @@ vi.mock('../hooks/useGameHint', () => ({
   useGameHint: vi.fn(() => ({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() })),
 }));
 
+vi.mock('../hooks/useChainCombo', () => ({
+  useChainCombo: vi.fn().mockReturnValue(0),
+}));
+
+import { useChainCombo } from '../hooks/useChainCombo';
+
 const mockExec = vi.mocked(tripeaksApi.exec);
+const mockCombo = vi.mocked(useChainCombo);
 
 const card = (design: CardDesign, value: number): Card => ({ design, value });
 
@@ -71,6 +78,7 @@ const gameOverState: TriPeaksResponse = {
 beforeEach(() => {
   mockExec.mockResolvedValue(playingState);
   vi.mocked(useGameHint).mockReturnValue({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() });
+  mockCombo.mockReturnValue(0);
 });
 
 describe('TriPeaksPage', () => {
@@ -250,5 +258,33 @@ describe('TriPeaksPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     expect(screen.queryByRole('button', { name: '確認' })).not.toBeInTheDocument();
+  });
+
+  it('does not render the combo badge when combo < 2', async () => {
+    mockCombo.mockReturnValue(1);
+    renderWithProviders(<TriPeaksPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    expect(screen.queryByTestId('combo-badge')).not.toBeInTheDocument();
+  });
+
+  it('renders the combo badge with blue styling when combo is 2', async () => {
+    mockCombo.mockReturnValue(2);
+    renderWithProviders(<TriPeaksPage />);
+    const badge = await screen.findByTestId('combo-badge');
+    expect(badge.className).toContain('bg-ds-info');
+  });
+
+  it('renders the combo badge with warning styling when combo is between 3 and 4', async () => {
+    mockCombo.mockReturnValue(3);
+    renderWithProviders(<TriPeaksPage />);
+    const badge = await screen.findByTestId('combo-badge');
+    expect(badge.className).toContain('bg-ds-warning');
+  });
+
+  it('renders the combo badge with error styling when combo >= 5', async () => {
+    mockCombo.mockReturnValue(5);
+    renderWithProviders(<TriPeaksPage />);
+    const badge = await screen.findByTestId('combo-badge');
+    expect(badge.className).toContain('bg-ds-error');
   });
 });

--- a/frontend/src/pages/TriPeaksPage.tsx
+++ b/frontend/src/pages/TriPeaksPage.tsx
@@ -18,6 +18,7 @@ import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions, useWindowWidth } from '../hooks/useCardDimensions';
+import { useChainCombo } from '../hooks/useChainCombo';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
@@ -141,6 +142,8 @@ function TriPeaksPageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
+  const combo = useChainCombo(state?.moveCount, state?.stockCount);
+
   if (!state)
     return <GameSkeleton gameKey="tripeaks" layout={{ kind: 'tiered-rows', rows: [3, 6, 9, 10], stockWaste: true }} />;
 
@@ -178,6 +181,20 @@ function TriPeaksPageContent() {
           <span>
             {t('moveCount')}: {state.moveCount}
           </span>
+          {combo >= 2 && (
+            <span
+              data-testid="combo-badge"
+              className={`px-2 py-0.5 rounded-full text-xs font-bold ${
+                combo >= 5
+                  ? 'bg-ds-error text-ds-text-on-accent'
+                  : combo >= 3
+                    ? 'bg-ds-warning text-ds-text-on-accent'
+                    : 'bg-ds-info text-ds-text-on-accent'
+              }`}
+            >
+              {t('combo', { count: combo })}
+            </span>
+          )}
           <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
         </>
       }


### PR DESCRIPTION
## Summary
- New \`Combo ×N\` chip appears in the TriPeaks / Golf header whenever the player removes two or more cards in a row without drawing from the stock; the chip color escalates blue → orange → red at chains of 2 / 3 / 5+.
- The chip resets the moment the player draws a card or restarts the game.

## Implementation
- New \`useChainCombo(moveCount, stockCount)\` hook tracks the streak by watching whether \`moveCount\` ticks while \`stockCount\` stays put.
- TriPeaks and Golf pages both consume the hook and render the badge inside \`headerExtra\` (after \`Moves: N\`), with \`combo\` / \`コンボ ×N\` translations added to both i18n bundles.

## Test plan
- [x] \`bun run test -- --run src/hooks/useChainCombo.test.ts src/pages/TriPeaksPage.test.tsx src/pages/GolfPage.test.tsx\`
- [x] \`bun run check\`

Closes #1927