### PR TITLE
feat(belote): always-visible Dix de Der and Belote/Rebelote trackers

### DIFF
--- a/frontend/src/i18n/locales/en/belote.json
+++ b/frontend/src/i18n/locales/en/belote.json
@@ -33,6 +33,12 @@
   "trickCount": "Tricks: {{count}}",
   "roundPoints": "Round: {{points}} pts",
   "beloteRebelote": "Belote/Rebelote +20",
+  "tracker": {
+    "dixDeDer": "Last trick +10",
+    "beloteKing": "Trump K",
+    "beloteQueen": "Trump Q",
+    "beloteBonus": "+20"
+  },
   "orderUpButton": "Take",
   "passButton": "Pass",
   "callTrumpButton": "Call Trump",

--- a/frontend/src/i18n/locales/ja/belote.json
+++ b/frontend/src/i18n/locales/ja/belote.json
@@ -33,6 +33,12 @@
   "trickCount": "獲得トリック: {{count}}",
   "roundPoints": "ラウンド: {{points}}点",
   "beloteRebelote": "ベロート/レベロート +20",
+  "tracker": {
+    "dixDeDer": "最終トリック +10",
+    "beloteKing": "切り札 K",
+    "beloteQueen": "切り札 Q",
+    "beloteBonus": "+20"
+  },
   "orderUpButton": "取る",
   "passButton": "パス",
   "callTrumpButton": "コール",

--- a/frontend/src/pages/BelotePage.test.tsx
+++ b/frontend/src/pages/BelotePage.test.tsx
@@ -123,6 +123,28 @@ describe('BelotePage', () => {
     expect(screen.getByRole('alertdialog')).toBeInTheDocument();
   });
 
+  it('renders bonus trackers (dim by default) during play after trump is set', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: BelotePhase.PLAY, trumpSuit: 1, trickNumber: 3, makerTeam: 0 }));
+    renderWithProviders(<BelotePage />);
+    await waitFor(() => expect(screen.getByTestId('belote-bonus-trackers')).toBeInTheDocument());
+    expect(screen.getByTestId('dix-de-der-badge')).not.toHaveAttribute('data-active');
+    expect(screen.getByTestId('belote-rebelote-badge')).not.toHaveAttribute('data-active');
+  });
+
+  it('activates the dix-de-der badge on the 8th trick', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: BelotePhase.PLAY, trumpSuit: 1, trickNumber: 8, makerTeam: 0 }));
+    renderWithProviders(<BelotePage />);
+    await waitFor(() => expect(screen.getByTestId('dix-de-der-badge')).toHaveAttribute('data-active', 'true'));
+  });
+
+  it('activates the belote/rebelote badge once the maker team earns the bonus', async () => {
+    mockExec.mockResolvedValue(
+      makeState({ phase: BelotePhase.PLAY, trumpSuit: 1, trickNumber: 5, makerTeam: 0, roundBeloteBonus: [20, 0] }),
+    );
+    renderWithProviders(<BelotePage />);
+    await waitFor(() => expect(screen.getByTestId('belote-rebelote-badge')).toHaveAttribute('data-active', 'true'));
+  });
+
   it('shows 次のゲーム at game end with no confirm', async () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<BelotePage />);

--- a/frontend/src/pages/BelotePage.test.tsx
+++ b/frontend/src/pages/BelotePage.test.tsx
@@ -145,6 +145,15 @@ describe('BelotePage', () => {
     await waitFor(() => expect(screen.getByTestId('belote-rebelote-badge')).toHaveAttribute('data-active', 'true'));
   });
 
+  it('activates the belote/rebelote badge when the defender team earns the bonus too', async () => {
+    // Backend awards the bonus to whichever team plays K+Q of trump, not the maker.
+    mockExec.mockResolvedValue(
+      makeState({ phase: BelotePhase.PLAY, trumpSuit: 1, trickNumber: 5, makerTeam: 0, roundBeloteBonus: [0, 20] }),
+    );
+    renderWithProviders(<BelotePage />);
+    await waitFor(() => expect(screen.getByTestId('belote-rebelote-badge')).toHaveAttribute('data-active', 'true'));
+  });
+
   it('shows 次のゲーム at game end with no confirm', async () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<BelotePage />);

--- a/frontend/src/pages/BelotePage.tsx
+++ b/frontend/src/pages/BelotePage.tsx
@@ -217,6 +217,42 @@ function BelotePageContent() {
             {state.trumpSuit > 0 ? t('trumpSuit', { suit: t(SUIT_LABEL_KEYS[state.trumpSuit]) }) : t('noTrump')}
           </span>
         </div>
+        {/* Bonus trackers — Dix de Der lights up on trick 8; Belote/Rebelote
+            lights up after K & Q of trump are played by the maker team. */}
+        {state.trumpSuit > 0 && (
+          <div
+            className="text-center mb-2 flex justify-center gap-2 flex-wrap text-xs"
+            data-testid="belote-bonus-trackers"
+          >
+            {state.config.dixDeDer > 0 && (
+              <span
+                data-testid="dix-de-der-badge"
+                data-active={state.trickNumber === 8 ? 'true' : undefined}
+                className={`px-2 py-0.5 rounded-full font-medium border ${
+                  state.trickNumber === 8
+                    ? 'bg-ds-accent text-ds-text-on-accent border-ds-accent animate-pulse'
+                    : 'bg-ds-surface text-ds-text-muted border-ds-border'
+                }`}
+              >
+                👑 {t('tracker.dixDeDer')}
+              </span>
+            )}
+            {state.config.enableBeloteRebelote && (
+              <span
+                data-testid="belote-rebelote-badge"
+                data-active={state.roundBeloteBonus[state.makerTeam] > 0 ? 'true' : undefined}
+                className={`px-2 py-0.5 rounded-full font-medium border ${
+                  state.roundBeloteBonus[state.makerTeam] > 0
+                    ? 'bg-ds-success text-ds-text-on-accent border-ds-success'
+                    : 'bg-ds-surface text-ds-text-muted border-ds-border'
+                }`}
+              >
+                {t('tracker.beloteKing')} · {t('tracker.beloteQueen')}{' '}
+                {state.roundBeloteBonus[state.makerTeam] > 0 ? t('tracker.beloteBonus') : ''}
+              </span>
+            )}
+          </div>
+        )}
 
         {/* Face-up card (during bidding) */}
         {state.faceUpCard && (isBidPickUp || isBidCallTrump) && (

--- a/frontend/src/pages/BelotePage.tsx
+++ b/frontend/src/pages/BelotePage.tsx
@@ -218,41 +218,48 @@ function BelotePageContent() {
           </span>
         </div>
         {/* Bonus trackers — Dix de Der lights up on trick 8; Belote/Rebelote
-            lights up after K & Q of trump are played by the maker team. */}
-        {state.trumpSuit > 0 && (
-          <div
-            className="text-center mb-2 flex justify-center gap-2 flex-wrap text-xs"
-            data-testid="belote-bonus-trackers"
-          >
-            {state.config.dixDeDer > 0 && (
-              <span
-                data-testid="dix-de-der-badge"
-                data-active={state.trickNumber === 8 ? 'true' : undefined}
-                className={`px-2 py-0.5 rounded-full font-medium border ${
-                  state.trickNumber === 8
-                    ? 'bg-ds-accent text-ds-text-on-accent border-ds-accent animate-pulse'
-                    : 'bg-ds-surface text-ds-text-muted border-ds-border'
-                }`}
+            lights up as soon as ANY team finishes playing K + Q of trump
+            (the bonus is awarded to whichever team holds those cards, not
+            specifically the maker — see internal/domain/Belote.go #864). */}
+        {state.trumpSuit > 0 &&
+          (() => {
+            const isLastTrick = state.trickNumber === 8;
+            const hasBeloteBonus = state.roundBeloteBonus.some((b) => b > 0);
+            return (
+              <div
+                className="text-center mb-2 flex justify-center gap-2 flex-wrap text-xs"
+                data-testid="belote-bonus-trackers"
               >
-                👑 {t('tracker.dixDeDer')}
-              </span>
-            )}
-            {state.config.enableBeloteRebelote && (
-              <span
-                data-testid="belote-rebelote-badge"
-                data-active={state.roundBeloteBonus[state.makerTeam] > 0 ? 'true' : undefined}
-                className={`px-2 py-0.5 rounded-full font-medium border ${
-                  state.roundBeloteBonus[state.makerTeam] > 0
-                    ? 'bg-ds-success text-ds-text-on-accent border-ds-success'
-                    : 'bg-ds-surface text-ds-text-muted border-ds-border'
-                }`}
-              >
-                {t('tracker.beloteKing')} · {t('tracker.beloteQueen')}{' '}
-                {state.roundBeloteBonus[state.makerTeam] > 0 ? t('tracker.beloteBonus') : ''}
-              </span>
-            )}
-          </div>
-        )}
+                {state.config.dixDeDer > 0 && (
+                  <span
+                    data-testid="dix-de-der-badge"
+                    data-active={isLastTrick ? 'true' : undefined}
+                    className={
+                      isLastTrick
+                        ? 'px-2 py-0.5 rounded-full font-medium border bg-ds-accent text-ds-text-on-accent border-ds-accent animate-pulse'
+                        : 'px-2 py-0.5 rounded-full font-medium border bg-ds-surface text-ds-text-muted border-ds-border'
+                    }
+                  >
+                    👑 {t('tracker.dixDeDer')}
+                  </span>
+                )}
+                {state.config.enableBeloteRebelote && (
+                  <span
+                    data-testid="belote-rebelote-badge"
+                    data-active={hasBeloteBonus ? 'true' : undefined}
+                    className={
+                      hasBeloteBonus
+                        ? 'px-2 py-0.5 rounded-full font-medium border bg-ds-success text-ds-text-on-accent border-ds-success'
+                        : 'px-2 py-0.5 rounded-full font-medium border bg-ds-surface text-ds-text-muted border-ds-border'
+                    }
+                  >
+                    {t('tracker.beloteKing')} · {t('tracker.beloteQueen')}
+                    {hasBeloteBonus ? ` ${t('tracker.beloteBonus')}` : ''}
+                  </span>
+                )}
+              </div>
+            );
+          })()}
 
         {/* Face-up card (during bidding) */}
         {state.faceUpCard && (isBidPickUp || isBidCallTrump) && (


### PR DESCRIPTION
## Summary
- Adds a small chip strip under the Round/Trick/Trump header that always shows the two Belote-specific bonuses:
  - **👑 Dix de Der +10** — dim by default, glows on trick 8 so the final-trick stakes are obvious.
  - **K · Q Belote/Rebelote** — dim by default, turns green and adds \`+20\` once the maker team earns the bonus.
- Both chips respect the existing config toggles (\`dixDeDer\` > 0 and \`enableBeloteRebelote\`).

## Implementation
- New chips rendered inside the existing card-area header; gated on \`trumpSuit > 0\` so they appear only after bidding.
- Active state derives from \`trickNumber === 8\` and \`roundBeloteBonus[makerTeam] > 0\`.
- 4 new i18n keys per locale under \`tracker.*\`.

## Test plan
- [x] \`bun run test -- --run src/pages/BelotePage.test.tsx\` (3 new assertions for dim / dix-active / belote-active)
- [x] \`bun run check\`

Closes #1929