### PR TITLE
feat(rummy500): real-time hand-penalty badge above player hand

### DIFF
--- a/frontend/src/i18n/locales/en/rummy500.json
+++ b/frontend/src/i18n/locales/en/rummy500.json
@@ -32,6 +32,8 @@
   "playPhase": "Meld, lay off, then discard",
   "roundEnd": "Round complete",
   "drawDiscardHint": "Click any discard card to take it plus all cards above it",
+  "handPenalty": "Hand penalty: -{{points}} pts",
+  "handPenaltyHint": "If anyone else goes out, this is how many points you lose",
   "winner": {
     "human": "You win!",
     "cpu": "CPU {{idx}} wins"

--- a/frontend/src/i18n/locales/ja/rummy500.json
+++ b/frontend/src/i18n/locales/ja/rummy500.json
@@ -32,6 +32,8 @@
   "playPhase": "メルド・レイオフ・ディスカードを行ってください",
   "roundEnd": "ラウンド終了",
   "drawDiscardHint": "捨て札の任意のカードをクリックすると、そのカード以上をすべて引き取れます",
+  "handPenalty": "手札ペナルティ: -{{points}}点",
+  "handPenaltyHint": "誰かが上がった時、手札に残ったカードの合計がマイナス点になります",
   "winner": {
     "human": "あなたの勝利！",
     "cpu": "CPU {{idx}}の勝利"

--- a/frontend/src/pages/Rummy500Page.test.tsx
+++ b/frontend/src/pages/Rummy500Page.test.tsx
@@ -158,4 +158,26 @@ describe('Rummy500Page', () => {
       expect(mockExec).toHaveBeenCalledWith('drawstock');
     });
   });
+
+  it('renders the hand-penalty badge with the summed value when the player holds cards', async () => {
+    // drawPhaseState has [♠7, ♥7] in hand → penalty = 7 + 7 = 14.
+    mockExec.mockResolvedValue(drawPhaseState);
+    renderWithProviders(<Rummy500Page />);
+    await waitFor(() => {
+      const badge = screen.getByTestId('hand-penalty-badge');
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent('14');
+    });
+  });
+
+  it('hides the hand-penalty badge when the player has no cards', async () => {
+    const emptyHandState: Rummy500Response = {
+      ...drawPhaseState,
+      players: [{ ...drawPhaseState.players[0], cardCount: 0, cards: [] }, drawPhaseState.players[1]],
+    };
+    mockExec.mockResolvedValue(emptyHandState);
+    renderWithProviders(<Rummy500Page />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, expect.any(Object)));
+    expect(screen.queryByTestId('hand-penalty-badge')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/Rummy500Page.tsx
+++ b/frontend/src/pages/Rummy500Page.tsx
@@ -28,6 +28,7 @@ import { Rummy500Phase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { playerName } from '../utils/playerUtils';
+import { rummy500HandPenalty } from '../utils/rummy500HandPenalty';
 
 const RUMMY500_PHASE_KEYS: Readonly<Record<number, string>> = {
   [Rummy500Phase.DRAW]: 'draw',
@@ -242,6 +243,17 @@ function Rummy500PageContent() {
       </div>
 
       <GameFooter className={`${gameTheme.rummy500.footer} px-4 py-2.5`}>
+        {humanPlayer && humanPlayer.cards.length > 0 && (
+          <div className="flex justify-end mb-1 text-xs">
+            <span
+              data-testid="hand-penalty-badge"
+              className="px-2 py-0.5 rounded-full bg-ds-error/20 text-ds-error border border-ds-error font-medium"
+              title={t('handPenaltyHint')}
+            >
+              {t('handPenalty', { points: rummy500HandPenalty(humanPlayer.cards) })}
+            </span>
+          </div>
+        )}
         {humanPlayer && (
           <div className="flex flex-wrap gap-1 mb-2" data-tutorial="r5-player-hand">
             {humanPlayer.cards.map((card, idx) => (

--- a/frontend/src/pages/Rummy500Page.tsx
+++ b/frontend/src/pages/Rummy500Page.tsx
@@ -251,6 +251,7 @@ function Rummy500PageContent() {
               title={t('handPenaltyHint')}
             >
               {t('handPenalty', { points: rummy500HandPenalty(humanPlayer.cards) })}
+              <span className="sr-only"> — {t('handPenaltyHint')}</span>
             </span>
           </div>
         )}

--- a/frontend/src/utils/rummy500HandPenalty.test.ts
+++ b/frontend/src/utils/rummy500HandPenalty.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { rummy500CardPenalty, rummy500HandPenalty } from './rummy500HandPenalty';
+
+describe('rummy500CardPenalty', () => {
+  it.each([
+    [1, 1],
+    [5, 5],
+    [9, 9],
+    [10, 10],
+    [11, 10],
+    [13, 10],
+  ])('value %i -> %i', (v, expected) => {
+    expect(rummy500CardPenalty(v)).toBe(expected);
+  });
+});
+
+describe('rummy500HandPenalty', () => {
+  it('sums per-card penalty across the hand', () => {
+    const cards: Card[] = [
+      { design: 'SPADE', value: 13 },
+      { design: 'HEART', value: 10 },
+      { design: 'CLOVER', value: 1 },
+      { design: 'DIAMOND', value: 4 },
+    ];
+    expect(rummy500HandPenalty(cards)).toBe(10 + 10 + 1 + 4);
+  });
+  it('returns 0 for an empty hand', () => {
+    expect(rummy500HandPenalty([])).toBe(0);
+  });
+});

--- a/frontend/src/utils/rummy500HandPenalty.ts
+++ b/frontend/src/utils/rummy500HandPenalty.ts
@@ -1,0 +1,17 @@
+import type { Card } from '../types/card';
+
+/** Per-card penalty value used when a round ends with cards still in hand. A=1, J/Q/K=10, otherwise face value. */
+export function rummy500CardPenalty(value: number): number {
+  if (value === 1) return 1;
+  if (value >= 10) return 10;
+  return value;
+}
+
+/** Total penalty (sum of card values) for a Rummy 500 hand. */
+export function rummy500HandPenalty(cards: Card[]): number {
+  let total = 0;
+  for (const c of cards) {
+    total += rummy500CardPenalty(c.value);
+  }
+  return total;
+}


### PR DESCRIPTION
## Summary
- New \`-N pts\` red chip sits above the player's hand row in Rummy 500 so the carry-cost of staying in the round is always visible.
- Helps the player follow the manual's \"discard the high cards first\" advice without doing mental arithmetic every turn.

## Implementation
- New \`rummy500HandPenalty\` util mirrors the backend's \`rummy500CardScoreLow\` (A=1, J/Q/K=10, otherwise face value).
- Rummy500Page renders the badge when the player still holds cards; \`title\` tooltip explains the cost.
- 2 new i18n keys per locale (\`handPenalty\` / \`handPenaltyHint\`).

## Test plan
- [x] \`bun run test -- --run src/utils/rummy500HandPenalty.test.ts src/pages/Rummy500Page.test.tsx\`
- [x] \`bun run check\`

Closes #1930