### PR TITLE
feat(pyramid): highlight exposed sum-13 partners on first selection

### DIFF
--- a/frontend/src/pages/PyramidPage.test.tsx
+++ b/frontend/src/pages/PyramidPage.test.tsx
@@ -227,6 +227,16 @@ describe('PyramidPage', () => {
     );
   });
 
+  it('flags exposed pair candidates after the first selection', async () => {
+    renderWithProviders(<PyramidPage />);
+    await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
+    const card3 = screen.getByAltText('♦ 3').closest('button') as HTMLButtonElement;
+    fireEvent.click(card3);
+    const card10 = screen.getByAltText('♠ 10').closest('button') as HTMLButtonElement;
+    await waitFor(() => expect(card10).toHaveAttribute('data-pair-candidate', 'true'));
+    expect(card3).not.toHaveAttribute('data-pair-candidate');
+  });
+
   it('clicking same card twice deselects it', async () => {
     renderWithProviders(<PyramidPage />);
     await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());

--- a/frontend/src/pages/PyramidPage.test.tsx
+++ b/frontend/src/pages/PyramidPage.test.tsx
@@ -237,6 +237,39 @@ describe('PyramidPage', () => {
     expect(card3).not.toHaveAttribute('data-pair-candidate');
   });
 
+  it('selecting the waste card highlights matching pyramid partners', async () => {
+    // playingState.waste = [♣ 3]; partner value 10 should match the exposed ♠ 10 in the pyramid.
+    renderWithProviders(<PyramidPage />);
+    await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
+    const wasteButton = screen.getByRole('button', { name: '♣ 3' });
+    fireEvent.click(wasteButton);
+    const card10 = screen.getByAltText('♠ 10').closest('button') as HTMLButtonElement;
+    await waitFor(() => expect(card10).toHaveAttribute('data-pair-candidate', 'true'));
+  });
+
+  it('selecting a pyramid card whose partner is the waste top flags the waste card', async () => {
+    // waste top is ♣ 3 (value 3); the exposed ♠ 10 (value 10) is its partner.
+    renderWithProviders(<PyramidPage />);
+    await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
+    const card10 = screen.getByAltText('♠ 10').closest('button') as HTMLButtonElement;
+    fireEvent.click(card10);
+    const wasteButton = screen.getByRole('button', { name: '♣ 3' });
+    await waitFor(() => expect(wasteButton).toHaveAttribute('data-pair-candidate', 'true'));
+  });
+
+  it('selecting a King (value 13) does not flag any pair candidates', async () => {
+    renderWithProviders(<PyramidPage />);
+    await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
+    const kingButton = screen.getByAltText('♥ K').closest('button') as HTMLButtonElement;
+    fireEvent.click(kingButton);
+    // King auto-removes via handleSelectCard, so the API is called immediately.
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith('remove', expect.objectContaining({ zone: 'pyramid', row: 2, col: 2 })),
+    );
+    // No pair-candidate attribute should appear anywhere because partnerValue stays null for Kings.
+    expect(document.querySelectorAll('[data-pair-candidate="true"]')).toHaveLength(0);
+  });
+
   it('clicking same card twice deselects it', async () => {
     renderWithProviders(<PyramidPage />);
     await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());

--- a/frontend/src/pages/PyramidPage.tsx
+++ b/frontend/src/pages/PyramidPage.tsx
@@ -152,10 +152,14 @@ function PyramidPageContent() {
     if (selectedCard.zone === 'waste') {
       return state.waste.length > 0 ? state.waste[state.waste.length - 1].value : null;
     }
-    const pc = state.pyramid[selectedCard.row ?? -1]?.[selectedCard.col ?? -1];
+    if (selectedCard.row === undefined || selectedCard.col === undefined) return null;
+    const pc = state.pyramid[selectedCard.row]?.[selectedCard.col];
     return pc?.card?.value ?? null;
   })();
   const partnerValue = selectedValue !== null && selectedValue < 13 ? 13 - selectedValue : null;
+  const wasteTopCard = state.waste.length > 0 ? state.waste[state.waste.length - 1] : null;
+  const isWastePairCandidate =
+    partnerValue !== null && !isSelected('waste') && wasteTopCard !== null && wasteTopCard.value === partnerValue;
 
   // Calculate pyramid layout dimensions
   const maxCols = 7; // bottom row has 7 cards
@@ -285,34 +289,19 @@ function PyramidPageContent() {
               {/* Waste */}
               <div className="text-center">
                 <div className="text-game-text-muted text-xs mb-1">{t('waste')}</div>
-                {state.waste.length > 0 ? (
+                {wasteTopCard ? (
                   <button
                     type="button"
-                    onClick={() => {
-                      const topCard = state.waste[state.waste.length - 1];
-                      handleSelectCard({ zone: 'waste' }, topCard.value);
-                    }}
+                    onClick={() => handleSelectCard({ zone: 'waste' }, wasteTopCard.value)}
                     disabled={!isPlaying || loading}
-                    aria-label={cardAlt(state.waste[state.waste.length - 1])}
+                    aria-label={cardAlt(wasteTopCard)}
                     aria-pressed={isSelected('waste')}
-                    data-pair-candidate={
-                      partnerValue !== null &&
-                      !isSelected('waste') &&
-                      state.waste[state.waste.length - 1].value === partnerValue
-                        ? 'true'
-                        : undefined
-                    }
+                    data-pair-candidate={isWastePairCandidate ? 'true' : undefined}
                     className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${
                       isSelected('waste') ? 'ring-2 ring-ds-warning' : ''
-                    } ${
-                      partnerValue !== null &&
-                      !isSelected('waste') &&
-                      state.waste[state.waste.length - 1].value === partnerValue
-                        ? 'ring-2 ring-ds-success animate-pulse'
-                        : ''
-                    }`}
+                    } ${isWastePairCandidate ? 'ring-2 ring-ds-success animate-pulse' : ''}`}
                   >
-                    <AnimatedCard card={state.waste[state.waste.length - 1]} width={effectiveCardWidth} />
+                    <AnimatedCard card={wasteTopCard} width={effectiveCardWidth} />
                   </button>
                 ) : (
                   <div

--- a/frontend/src/pages/PyramidPage.tsx
+++ b/frontend/src/pages/PyramidPage.tsx
@@ -145,6 +145,18 @@ function PyramidPageContent() {
   const isSelected = (zone: 'pyramid' | 'waste', row?: number, col?: number) =>
     selectedCard !== null && selectedCard.zone === zone && selectedCard.row === row && selectedCard.col === col;
 
+  // When the player has selected the first card, compute the partner value (13 - value).
+  // Kings (13) need no partner; ace (1) wants Q (12), etc.
+  const selectedValue = (() => {
+    if (!selectedCard) return null;
+    if (selectedCard.zone === 'waste') {
+      return state.waste.length > 0 ? state.waste[state.waste.length - 1].value : null;
+    }
+    const pc = state.pyramid[selectedCard.row ?? -1]?.[selectedCard.col ?? -1];
+    return pc?.card?.value ?? null;
+  })();
+  const partnerValue = selectedValue !== null && selectedValue < 13 ? 13 - selectedValue : null;
+
   // Calculate pyramid layout dimensions
   const maxCols = 7; // bottom row has 7 cards
   const cardGap = 4;
@@ -216,6 +228,11 @@ function PyramidPageContent() {
                       }
                       if (!pc.card) return null;
                       const exposed = pc.exposed;
+                      const isPairCandidate =
+                        partnerValue !== null &&
+                        exposed &&
+                        pc.card.value === partnerValue &&
+                        !isSelected('pyramid', rowIdx, colIdx);
                       return (
                         <div key={`pc-${rowIdx.toString()}-${colIdx.toString()}`} className="absolute" style={{ left }}>
                           <button
@@ -227,9 +244,10 @@ function PyramidPageContent() {
                             disabled={!isPlaying || loading || !exposed}
                             aria-label={cardAlt(pc.card)}
                             aria-pressed={isSelected('pyramid', rowIdx, colIdx)}
+                            data-pair-candidate={isPairCandidate ? 'true' : undefined}
                             className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${
                               isSelected('pyramid', rowIdx, colIdx) ? 'ring-2 ring-ds-warning' : ''
-                            } ${!exposed ? 'opacity-60' : ''}`}
+                            } ${isPairCandidate ? 'ring-2 ring-ds-success animate-pulse' : ''} ${!exposed ? 'opacity-60' : ''}`}
                           >
                             <AnimatedCard card={pc.card} width={effectiveCardWidth} />
                           </button>
@@ -277,8 +295,21 @@ function PyramidPageContent() {
                     disabled={!isPlaying || loading}
                     aria-label={cardAlt(state.waste[state.waste.length - 1])}
                     aria-pressed={isSelected('waste')}
+                    data-pair-candidate={
+                      partnerValue !== null &&
+                      !isSelected('waste') &&
+                      state.waste[state.waste.length - 1].value === partnerValue
+                        ? 'true'
+                        : undefined
+                    }
                     className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${
                       isSelected('waste') ? 'ring-2 ring-ds-warning' : ''
+                    } ${
+                      partnerValue !== null &&
+                      !isSelected('waste') &&
+                      state.waste[state.waste.length - 1].value === partnerValue
+                        ? 'ring-2 ring-ds-success animate-pulse'
+                        : ''
                     }`}
                   >
                     <AnimatedCard card={state.waste[state.waste.length - 1]} width={effectiveCardWidth} />


### PR DESCRIPTION
## Summary
- After the player picks the first card, every exposed pyramid (or waste-top) card whose value adds with the selection to 13 gets a pulsing green ring — no more scanning the pyramid for partners.
- Kings (value 13) need no partner, so the highlight only kicks in for cards 1-12.

## Implementation
- PyramidPage derives the selected card's value from \`state.pyramid[row][col]\` or the waste top.
- Adds \`data-pair-candidate=\"true\"\` and \`ring-2 ring-ds-success animate-pulse\` to matching exposed buttons.

## Test plan
- [x] \`bun run test -- --run src/pages/PyramidPage.test.tsx\` (1 new assertion: pair candidate flag)
- [x] \`bun run check\`

Closes #1931