### PR TITLE
feat(montecarlo): pulse adjacent matching ranks after selection

### DIFF
--- a/frontend/src/pages/MonteCarloPage.test.tsx
+++ b/frontend/src/pages/MonteCarloPage.test.tsx
@@ -152,4 +152,34 @@ describe('MonteCarloPage', () => {
     renderWithProviders(<MonteCarloPage />);
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
   });
+
+  it('flags adjacent same-rank cell with pulsing success ring after selecting', async () => {
+    // boardWithPair: [0][0] = ♠7, [0][1] = ♥7 — clicking [0][0] should mark [0][1] as a pair match.
+    renderWithProviders(<MonteCarloPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    fireEvent.click(screen.getByTestId('mc-cell-0-0'));
+
+    const partner = screen.getByTestId('mc-cell-0-1');
+    expect(partner).toHaveAttribute('data-pair-match', 'true');
+    expect(partner.className).toContain('ring-ds-success');
+    expect(partner.className).toContain('animate-pulse');
+  });
+
+  it('falls back to warning ring on adjacent cells with a different rank', async () => {
+    // Build a board where two adjacent cells (0,0) and (1,0) hold different ranks.
+    const board = emptyBoard();
+    board[0][0] = { card: card('SPADE', 7) };
+    board[1][0] = { card: card('HEART', 9) };
+    mockExec.mockResolvedValue({ ...playingState, board });
+    renderWithProviders(<MonteCarloPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    fireEvent.click(screen.getByTestId('mc-cell-0-0'));
+
+    const neighbor = screen.getByTestId('mc-cell-1-0');
+    expect(neighbor).not.toHaveAttribute('data-pair-match');
+    expect(neighbor.className).toContain('ring-ds-warning');
+    expect(neighbor.className).not.toContain('animate-pulse');
+  });
 });

--- a/frontend/src/pages/MonteCarloPage.tsx
+++ b/frontend/src/pages/MonteCarloPage.tsx
@@ -196,6 +196,12 @@ function MonteCarloPageContent() {
                     const isSelected = selected?.row === rowIdx && selected?.col === colIdx;
                     const isAdjOfSelected =
                       filled && selected !== null && isAdjacent(selected, { row: rowIdx, col: colIdx });
+                    const selectedValue = selected ? state.board[selected.row]?.[selected.col]?.card?.value : undefined;
+                    const isMatchingPair =
+                      isAdjOfSelected &&
+                      cell.card !== null &&
+                      selectedValue !== undefined &&
+                      cell.card.value === selectedValue;
                     const cellAction = `remove-${selected?.row ?? -1}-${selected?.col ?? -1}-${rowIdx}-${colIdx}`;
                     const isHintTarget =
                       frontendHintEnabled &&
@@ -220,10 +226,15 @@ function MonteCarloPageContent() {
                         }
                         onClick={() => handleCellClick(rowIdx, colIdx)}
                         disabled={!isPlaying || loading || !filled}
+                        data-pair-match={isMatchingPair ? 'true' : undefined}
                         className={`p-0 border-0 bg-transparent rounded ${focusRingWhite} ${
                           filled ? 'cursor-pointer' : ''
                         } ${isSelected ? 'ring-2 ring-ds-accent' : ''} ${
-                          isAdjOfSelected ? 'ring-1 ring-ds-warning' : ''
+                          isMatchingPair
+                            ? 'ring-2 ring-ds-success animate-pulse'
+                            : isAdjOfSelected
+                              ? 'ring-1 ring-ds-warning'
+                              : ''
                         } ${isHintTarget ? 'ring-2 ring-ds-warning' : ''}`}
                       >
                         {cell.card ? (

--- a/frontend/src/pages/MonteCarloPage.tsx
+++ b/frontend/src/pages/MonteCarloPage.tsx
@@ -190,66 +190,67 @@ function MonteCarloPageContent() {
                 style={{ gridTemplateColumns: `repeat(${SIZE}, minmax(0, 1fr))` }}
                 data-testid="mc-board"
               >
-                {state.board.map((row, rowIdx) =>
-                  row.map((cell, colIdx) => {
-                    const filled = !!cell.card;
-                    const isSelected = selected?.row === rowIdx && selected?.col === colIdx;
-                    const isAdjOfSelected =
-                      filled && selected !== null && isAdjacent(selected, { row: rowIdx, col: colIdx });
-                    const selectedValue = selected ? state.board[selected.row]?.[selected.col]?.card?.value : undefined;
-                    const isMatchingPair =
-                      isAdjOfSelected &&
-                      cell.card !== null &&
-                      selectedValue !== undefined &&
-                      cell.card.value === selectedValue;
-                    const cellAction = `remove-${selected?.row ?? -1}-${selected?.col ?? -1}-${rowIdx}-${colIdx}`;
-                    const isHintTarget =
-                      frontendHintEnabled &&
-                      frontendHint?.targetAction.startsWith('remove-') &&
-                      (frontendHint.targetAction === cellAction ||
-                        frontendHint.targetAction ===
-                          `remove-${rowIdx}-${colIdx}-${selected?.row ?? -1}-${selected?.col ?? -1}` ||
-                        // Highlight the suggested first cell when nothing is selected yet.
-                        (selected === null &&
-                          (frontendHint.targetAction.split('-').slice(1, 3).join('-') === `${rowIdx}-${colIdx}` ||
-                            frontendHint.targetAction.split('-').slice(3, 5).join('-') === `${rowIdx}-${colIdx}`)));
-                    return (
-                      <button
-                        type="button"
-                        key={`mc-${rowIdx}-${colIdx}`}
-                        data-testid={`mc-cell-${rowIdx}-${colIdx}`}
-                        data-hint-action={`mc-cell-${rowIdx}-${colIdx}`}
-                        aria-label={
-                          cell.card
-                            ? cardAlt(cell.card)
-                            : `${t('label.empty', { ns: 'common' })} ${rowIdx + 1}-${colIdx + 1}`
-                        }
-                        onClick={() => handleCellClick(rowIdx, colIdx)}
-                        disabled={!isPlaying || loading || !filled}
-                        data-pair-match={isMatchingPair ? 'true' : undefined}
-                        className={`p-0 border-0 bg-transparent rounded ${focusRingWhite} ${
-                          filled ? 'cursor-pointer' : ''
-                        } ${isSelected ? 'ring-2 ring-ds-accent' : ''} ${
-                          isMatchingPair
-                            ? 'ring-2 ring-ds-success animate-pulse'
-                            : isAdjOfSelected
-                              ? 'ring-1 ring-ds-warning'
-                              : ''
-                        } ${isHintTarget ? 'ring-2 ring-ds-warning' : ''}`}
-                      >
-                        {cell.card ? (
-                          <AnimatedCard card={cell.card} width={cardWidth} />
-                        ) : (
-                          <div
-                            style={{ width: cardWidth, height: Math.round(cardWidth * 1.4) }}
-                            className="rounded border-2 border-dashed border-white/30"
-                            aria-hidden="true"
-                          />
-                        )}
-                      </button>
-                    );
-                  }),
-                )}
+                {(() => {
+                  // Compute once per render — depends only on `selected`, not on (rowIdx, colIdx).
+                  const selectedValue = selected ? state.board[selected.row]?.[selected.col]?.card?.value : undefined;
+                  return state.board.map((row, rowIdx) =>
+                    row.map((cell, colIdx) => {
+                      const filled = !!cell.card;
+                      const isSelected = selected?.row === rowIdx && selected?.col === colIdx;
+                      const isAdjOfSelected =
+                        filled && selected !== null && isAdjacent(selected, { row: rowIdx, col: colIdx });
+                      // `isAdjOfSelected` already requires `filled`, so `cell.card` is non-null here.
+                      const isMatchingPair =
+                        isAdjOfSelected && selectedValue !== undefined && cell.card?.value === selectedValue;
+                      const cellAction = `remove-${selected?.row ?? -1}-${selected?.col ?? -1}-${rowIdx}-${colIdx}`;
+                      const isHintTarget =
+                        frontendHintEnabled &&
+                        frontendHint?.targetAction.startsWith('remove-') &&
+                        (frontendHint.targetAction === cellAction ||
+                          frontendHint.targetAction ===
+                            `remove-${rowIdx}-${colIdx}-${selected?.row ?? -1}-${selected?.col ?? -1}` ||
+                          // Highlight the suggested first cell when nothing is selected yet.
+                          (selected === null &&
+                            (frontendHint.targetAction.split('-').slice(1, 3).join('-') === `${rowIdx}-${colIdx}` ||
+                              frontendHint.targetAction.split('-').slice(3, 5).join('-') === `${rowIdx}-${colIdx}`)));
+                      return (
+                        <button
+                          type="button"
+                          key={`mc-${rowIdx}-${colIdx}`}
+                          data-testid={`mc-cell-${rowIdx}-${colIdx}`}
+                          data-hint-action={`mc-cell-${rowIdx}-${colIdx}`}
+                          aria-label={
+                            cell.card
+                              ? cardAlt(cell.card)
+                              : `${t('label.empty', { ns: 'common' })} ${rowIdx + 1}-${colIdx + 1}`
+                          }
+                          onClick={() => handleCellClick(rowIdx, colIdx)}
+                          disabled={!isPlaying || loading || !filled}
+                          data-pair-match={isMatchingPair ? 'true' : undefined}
+                          className={`p-0 border-0 bg-transparent rounded ${focusRingWhite} ${
+                            filled ? 'cursor-pointer' : ''
+                          } ${isSelected ? 'ring-2 ring-ds-accent' : ''} ${
+                            isMatchingPair
+                              ? 'ring-2 ring-ds-success animate-pulse'
+                              : isAdjOfSelected
+                                ? 'ring-1 ring-ds-warning'
+                                : ''
+                          } ${isHintTarget ? 'ring-2 ring-ds-warning' : ''}`}
+                        >
+                          {cell.card ? (
+                            <AnimatedCard card={cell.card} width={cardWidth} />
+                          ) : (
+                            <div
+                              style={{ width: cardWidth, height: Math.round(cardWidth * 1.4) }}
+                              className="rounded border-2 border-dashed border-white/30"
+                              aria-hidden="true"
+                            />
+                          )}
+                        </button>
+                      );
+                    }),
+                  );
+                })()}
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- When the player selects a cell, the existing 8-direction adjacency hint now gets a stronger pulsing green ring on cells that are **also the same rank** — making diagonal matches as obvious as horizontal/vertical ones.

## Implementation
- MonteCarloPage now derives \`selectedValue\` from the selected cell and exposes \`isMatchingPair\` per board cell, then applies \`ring-2 ring-ds-success animate-pulse\` (or falls back to the existing warning ring otherwise).

## Test plan
- [x] \`bun run test -- --run src/pages/MonteCarloPage.test.tsx\`
- [x] \`bun run check\`

Closes #1932