### PR TITLE
feat(badugi): visualize the current best subset in the player's hand

### DIFF
--- a/frontend/src/pages/BadugiPage.test.tsx
+++ b/frontend/src/pages/BadugiPage.test.tsx
@@ -235,4 +235,65 @@ describe('BadugiPage', () => {
     fireEvent.click(cardButtons[0]);
     await waitFor(() => expect(cardButtons[0]).toHaveAttribute('aria-pressed', 'true'));
   });
+
+  it('marks every card with data-badugi-subset during the draw phase when the hand is a perfect Badugi', async () => {
+    mockExec.mockResolvedValue(baseState({ phase: BadugiPhase.DRAW, drawIndex: 1, currentTurn: 0 }));
+    renderWithProviders(<BadugiPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '交換' })).toBeInTheDocument());
+
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.getAttribute('aria-pressed') !== null);
+    expect(cardButtons.length).toBe(4);
+    for (const btn of cardButtons) {
+      expect(btn).toHaveAttribute('data-badugi-subset', 'true');
+      expect(btn.className).toContain('-translate-y-1');
+      expect(btn.className).not.toContain('opacity-50');
+    }
+  });
+
+  it('dims duplicate-suit cards in the draw phase and omits data-badugi-subset on them', async () => {
+    // Force a duplicate suit so one card falls out of the best subset (lowball: keep the lower ♠).
+    mockExec.mockResolvedValue(
+      baseState({
+        phase: BadugiPhase.DRAW,
+        drawIndex: 1,
+        currentTurn: 0,
+        players: [
+          humanPlayer({
+            cards: [
+              { design: 'SPADE', value: 1 },
+              { design: 'SPADE', value: 9 },
+              { design: 'HEART', value: 3 },
+              { design: 'DIAMOND', value: 6 },
+            ],
+          }),
+          cpuPlayer(1),
+          cpuPlayer(2),
+          cpuPlayer(3),
+        ],
+      }),
+    );
+    renderWithProviders(<BadugiPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '交換' })).toBeInTheDocument());
+
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.getAttribute('aria-pressed') !== null);
+    // Subset = {SPADE 1, HEART 3, DIAMOND 6} = indices [0, 2, 3]; duplicate SPADE 9 = index 1.
+    expect(cardButtons[0]).toHaveAttribute('data-badugi-subset', 'true');
+    expect(cardButtons[1]).not.toHaveAttribute('data-badugi-subset');
+    expect(cardButtons[1].className).toContain('opacity-50');
+    expect(cardButtons[2]).toHaveAttribute('data-badugi-subset', 'true');
+    expect(cardButtons[3]).toHaveAttribute('data-badugi-subset', 'true');
+  });
+
+  it('does not annotate subset cards outside the draw phase', async () => {
+    // BET phase: subset hint should not appear (player cannot act on the dim/lift cue here).
+    mockExec.mockResolvedValue(baseState({ phase: BadugiPhase.BET, currentTurn: 0, lastBet: 20 }));
+    renderWithProviders(<BadugiPage />);
+    await waitFor(() => expect(screen.getAllByText(/ベット/).length).toBeGreaterThan(0));
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.getAttribute('aria-pressed') !== null);
+    for (const btn of cardButtons) {
+      expect(btn).not.toHaveAttribute('data-badugi-subset');
+      expect(btn.className).not.toContain('opacity-50');
+      expect(btn.className).not.toContain('-translate-y-1');
+    }
+  });
 });

--- a/frontend/src/pages/BadugiPage.tsx
+++ b/frontend/src/pages/BadugiPage.tsx
@@ -34,6 +34,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { BadugiResponse } from '../types/card';
 import { BadugiPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { badugiBestSubsetIndices } from '../utils/badugiBestSubset';
 import { isCompleteBadugiHand } from '../utils/badugiUtils';
 import { cardAlt } from '../utils/cardAlt';
 import { BADUGI_HELP, parseBadugiCommand } from '../utils/cli/commands/badugiCommands';
@@ -294,29 +295,37 @@ function BadugiPageContent() {
                 </div>
                 {canExchange && <div className="text-game-text-highlight text-xs mb-1">{t('exchangeInstruction')}</div>}
                 <div className="flex flex-wrap gap-1.5 mb-2">
-                  {humanPlayer.cards?.map((card, i) => {
-                    const isSelected = selected.includes(i);
-                    return (
-                      <button
-                        key={`${card.design}-${card.value}`}
-                        type="button"
-                        aria-label={`${cardAlt(card)}${isSelected ? ` ${t('cardSelected')}` : ''}`}
-                        aria-pressed={isSelected}
-                        onClick={() => toggleCard(i)}
-                        className={`${focusRingAccent} rounded`}
-                        style={{
-                          background: 'none',
-                          padding: 0,
-                          cursor: canExchange ? 'pointer' : 'default',
-                          borderRadius: 8,
-                          ...selectedCardStyle(isSelected),
-                          boxSizing: 'border-box',
-                        }}
-                      >
-                        <AnimatedCard card={card} width={cardWidth} />
-                      </button>
-                    );
-                  })}
+                  {(() => {
+                    const cards = humanPlayer.cards ?? [];
+                    const subset = new Set(badugiBestSubsetIndices(cards));
+                    return cards.map((card, i) => {
+                      const isSelected = selected.includes(i);
+                      const inSubset = subset.has(i);
+                      return (
+                        <button
+                          key={`${card.design}-${card.value}`}
+                          type="button"
+                          aria-label={`${cardAlt(card)}${isSelected ? ` ${t('cardSelected')}` : ''}`}
+                          aria-pressed={isSelected}
+                          onClick={() => toggleCard(i)}
+                          data-badugi-subset={inSubset ? 'true' : undefined}
+                          className={`${focusRingAccent} rounded transition-transform ${
+                            inSubset ? '-translate-y-1' : 'opacity-50'
+                          }`}
+                          style={{
+                            background: 'none',
+                            padding: 0,
+                            cursor: canExchange ? 'pointer' : 'default',
+                            borderRadius: 8,
+                            ...selectedCardStyle(isSelected),
+                            boxSizing: 'border-box',
+                          }}
+                        >
+                          <AnimatedCard card={card} width={cardWidth} />
+                        </button>
+                      );
+                    });
+                  })()}
                 </div>
               </div>
             )}

--- a/frontend/src/pages/BadugiPage.tsx
+++ b/frontend/src/pages/BadugiPage.tsx
@@ -164,6 +164,14 @@ function BadugiPageContent() {
     [canExchange, humanPlayer?.cards],
   );
 
+  // Set of card indices belonging to the current best Badugi subset. Only computed during the draw
+  // phase — outside of that window the lift / dim visuals would distract more than help, since the
+  // player can't act on "dead weight" until the next exchange opens.
+  const subsetIndices = useMemo(
+    () => (canExchange ? new Set(badugiBestSubsetIndices(humanPlayer?.cards ?? [])) : null),
+    [canExchange, humanPlayer?.cards],
+  );
+
   useCardKeyboardNav({
     cardCount,
     onToggle: toggleCard,
@@ -295,37 +303,39 @@ function BadugiPageContent() {
                 </div>
                 {canExchange && <div className="text-game-text-highlight text-xs mb-1">{t('exchangeInstruction')}</div>}
                 <div className="flex flex-wrap gap-1.5 mb-2">
-                  {(() => {
-                    const cards = humanPlayer.cards ?? [];
-                    const subset = new Set(badugiBestSubsetIndices(cards));
-                    return cards.map((card, i) => {
-                      const isSelected = selected.includes(i);
-                      const inSubset = subset.has(i);
-                      return (
-                        <button
-                          key={`${card.design}-${card.value}`}
-                          type="button"
-                          aria-label={`${cardAlt(card)}${isSelected ? ` ${t('cardSelected')}` : ''}`}
-                          aria-pressed={isSelected}
-                          onClick={() => toggleCard(i)}
-                          data-badugi-subset={inSubset ? 'true' : undefined}
-                          className={`${focusRingAccent} rounded transition-transform ${
-                            inSubset ? '-translate-y-1' : 'opacity-50'
-                          }`}
-                          style={{
-                            background: 'none',
-                            padding: 0,
-                            cursor: canExchange ? 'pointer' : 'default',
-                            borderRadius: 8,
-                            ...selectedCardStyle(isSelected),
-                            boxSizing: 'border-box',
-                          }}
-                        >
-                          <AnimatedCard card={card} width={cardWidth} />
-                        </button>
-                      );
-                    });
-                  })()}
+                  {(humanPlayer.cards ?? []).map((card, i) => {
+                    const isSelected = selected.includes(i);
+                    // Only annotate cards during the draw phase; outside of it we don't want to
+                    // distract the player with a "dead weight" hint they can't act on.
+                    const inSubset = subsetIndices?.has(i) ?? false;
+                    const showSubsetHint = subsetIndices !== null;
+                    let liftOrDim = '';
+                    if (showSubsetHint) {
+                      if (inSubset) liftOrDim = '-translate-y-1';
+                      else if (!isSelected) liftOrDim = 'opacity-50';
+                    }
+                    return (
+                      <button
+                        key={`${card.design}-${card.value}`}
+                        type="button"
+                        aria-label={`${cardAlt(card)}${isSelected ? ` ${t('cardSelected')}` : ''}`}
+                        aria-pressed={isSelected}
+                        onClick={() => toggleCard(i)}
+                        data-badugi-subset={showSubsetHint && inSubset ? 'true' : undefined}
+                        className={`${focusRingAccent} rounded transition-transform ${liftOrDim}`}
+                        style={{
+                          background: 'none',
+                          padding: 0,
+                          cursor: canExchange ? 'pointer' : 'default',
+                          borderRadius: 8,
+                          ...selectedCardStyle(isSelected),
+                          boxSizing: 'border-box',
+                        }}
+                      >
+                        <AnimatedCard card={card} width={cardWidth} />
+                      </button>
+                    );
+                  })}
                 </div>
               </div>
             )}

--- a/frontend/src/utils/badugiBestSubset.test.ts
+++ b/frontend/src/utils/badugiBestSubset.test.ts
@@ -24,4 +24,13 @@ describe('badugiBestSubsetIndices', () => {
   it('returns empty for empty hand', () => {
     expect(badugiBestSubsetIndices([])).toEqual([]);
   });
+
+  it('breaks ties on lowest rank sum (lowball)', () => {
+    // Two valid 3-card subsets are possible:
+    //   {0,1,2} = A♠, 2♥, 3♦ → ranks {1,2,3}, suits {S,H,D}, sum 6
+    //   {0,1,3} = A♠, 2♥, 10♦ → ranks {1,2,10}, suits {S,H,D}, sum 13
+    // Lowball: the lower-sum subset must win.
+    const hand: Card[] = [c('SPADE', 1), c('HEART', 2), c('DIAMOND', 3), c('DIAMOND', 10)];
+    expect(badugiBestSubsetIndices(hand).sort()).toEqual([0, 1, 2]);
+  });
 });

--- a/frontend/src/utils/badugiBestSubset.test.ts
+++ b/frontend/src/utils/badugiBestSubset.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { badugiBestSubsetIndices } from './badugiBestSubset';
+
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('badugiBestSubsetIndices', () => {
+  it('returns all four indices when the hand is already a Badugi', () => {
+    const hand: Card[] = [c('SPADE', 1), c('HEART', 4), c('DIAMOND', 7), c('CLOVER', 11)];
+    expect(badugiBestSubsetIndices(hand)).toEqual([0, 1, 2, 3]);
+  });
+
+  it('drops one duplicate suit to leave the lowest 3-card Badugi', () => {
+    // Two spades — keep the lower one.
+    const hand: Card[] = [c('SPADE', 1), c('SPADE', 9), c('HEART', 3), c('DIAMOND', 6)];
+    expect(badugiBestSubsetIndices(hand).sort()).toEqual([0, 2, 3]);
+  });
+
+  it('drops a duplicate rank', () => {
+    const hand: Card[] = [c('SPADE', 5), c('HEART', 5), c('DIAMOND', 7), c('CLOVER', 10)];
+    expect(badugiBestSubsetIndices(hand).sort()).toEqual([0, 2, 3]);
+  });
+
+  it('returns empty for empty hand', () => {
+    expect(badugiBestSubsetIndices([])).toEqual([]);
+  });
+});

--- a/frontend/src/utils/badugiBestSubset.ts
+++ b/frontend/src/utils/badugiBestSubset.ts
@@ -1,0 +1,43 @@
+import type { Card } from '../types/card';
+
+/** Numeric Badugi rank used for lowball comparison (A=1, then 2..K). */
+function badugiRank(value: number): number {
+  if (value === 1) return 1;
+  return value;
+}
+
+/** Indices of the cards in the best Badugi subset (largest size, then lowest sum). */
+export function badugiBestSubsetIndices(cards: Card[]): number[] {
+  if (cards.length === 0) return [];
+  const n = cards.length;
+  let bestSize = 0;
+  let bestSum = Number.POSITIVE_INFINITY;
+  let best: number[] = [];
+  for (let mask = 1; mask < 1 << n; mask++) {
+    const ranks = new Set<number>();
+    const suits = new Set<string>();
+    const idxs: number[] = [];
+    let sum = 0;
+    let ok = true;
+    for (let i = 0; i < n; i++) {
+      if (!(mask & (1 << i))) continue;
+      const c = cards[i];
+      const r = badugiRank(c.value);
+      if (ranks.has(r) || suits.has(c.design)) {
+        ok = false;
+        break;
+      }
+      ranks.add(r);
+      suits.add(c.design);
+      idxs.push(i);
+      sum += r;
+    }
+    if (!ok) continue;
+    if (idxs.length > bestSize || (idxs.length === bestSize && sum < bestSum)) {
+      bestSize = idxs.length;
+      bestSum = sum;
+      best = idxs;
+    }
+  }
+  return best;
+}

--- a/frontend/src/utils/badugiBestSubset.ts
+++ b/frontend/src/utils/badugiBestSubset.ts
@@ -1,12 +1,9 @@
 import type { Card } from '../types/card';
 
-/** Numeric Badugi rank used for lowball comparison (A=1, then 2..K). */
-function badugiRank(value: number): number {
-  if (value === 1) return 1;
-  return value;
-}
-
-/** Indices of the cards in the best Badugi subset (largest size, then lowest sum). */
+/**
+ * Indices of the cards in the best Badugi subset: largest size first, ties broken by lowest rank
+ * sum (lowball). Ace is encoded as `value === 1` in the project's deck and stays as 1 here.
+ */
 export function badugiBestSubsetIndices(cards: Card[]): number[] {
   if (cards.length === 0) return [];
   const n = cards.length;
@@ -22,15 +19,14 @@ export function badugiBestSubsetIndices(cards: Card[]): number[] {
     for (let i = 0; i < n; i++) {
       if (!(mask & (1 << i))) continue;
       const c = cards[i];
-      const r = badugiRank(c.value);
-      if (ranks.has(r) || suits.has(c.design)) {
+      if (ranks.has(c.value) || suits.has(c.design)) {
         ok = false;
         break;
       }
-      ranks.add(r);
+      ranks.add(c.value);
       suits.add(c.design);
       idxs.push(i);
-      sum += r;
+      sum += c.value;
     }
     if (!ok) continue;
     if (idxs.length > bestSize || (idxs.length === bestSize && sum < bestSum)) {


### PR DESCRIPTION
## Summary
- Computes the largest subset of the player's hand where every card has a distinct rank and suit (the current Badugi qualifying hand) and lifts those cards by 4px while dimming the rest.
- Lets new players see exactly which cards are \"dead weight\" they should exchange in the draw phase.

## Implementation
- New \`badugiBestSubsetIndices\` util enumerates all 16 subsets, picks the largest valid one, and breaks ties on lowest rank sum (lowball).
- BadugiPage applies a \`-translate-y-1\` lift + \`data-badugi-subset=\"true\"\` to subset cards; non-subset cards get \`opacity-50\`.

## Test plan
- [x] \`bun run test -- --run src/utils/badugiBestSubset.test.ts src/pages/BadugiPage.test.tsx\`
- [x] \`bun run check\`

Closes #1933