### PR TITLE
feat(skat): show hand-based max bid and warn on overbids

### DIFF
--- a/frontend/src/i18n/locales/en/skat.json
+++ b/frontend/src/i18n/locales/en/skat.json
@@ -31,6 +31,15 @@
   "play": "Play card",
   "nextTrick": "Next trick",
   "nextRound": "Next round",
+  "bidEstimate": "Hand-estimated max: {{value}} ({{type}})",
+  "bidExceedsHand": "Current bid may not be justifiable from this hand",
+  "gameTypeLabel": {
+    "clover": "♣ Clubs",
+    "spade": "♠ Spades",
+    "heart": "♥ Hearts",
+    "diamond": "♦ Diamonds",
+    "grand": "Grand"
+  },
   "phase": {
     "bid": "Bidding",
     "skatPickup": "Skat pickup",

--- a/frontend/src/i18n/locales/ja/skat.json
+++ b/frontend/src/i18n/locales/ja/skat.json
@@ -31,6 +31,15 @@
   "play": "カードを出す",
   "nextTrick": "次のトリック",
   "nextRound": "次のラウンド",
+  "bidEstimate": "手札推定上限: {{value}} ({{type}})",
+  "bidExceedsHand": "現在のビッドは手札では正当化できない可能性があります",
+  "gameTypeLabel": {
+    "clover": "♣ クラブ",
+    "spade": "♠ スペード",
+    "heart": "♥ ハート",
+    "diamond": "♦ ダイヤ",
+    "grand": "グランド"
+  },
   "phase": {
     "bid": "ビッドフェーズ",
     "skatPickup": "スカート拾い",

--- a/frontend/src/pages/SkatPage.test.tsx
+++ b/frontend/src/pages/SkatPage.test.tsx
@@ -499,4 +499,42 @@ describe('SkatPage', () => {
     await waitFor(() => expect(screen.getAllByText(/ラウンド/i).length).toBeGreaterThan(0));
     expect(screen.queryByRole('button', { name: '次のラウンド' })).not.toBeInTheDocument();
   });
+
+  it('renders bid-estimate during bid phase without an exceeds warning when the current bid is 0', async () => {
+    mockExec.mockResolvedValue({
+      ...bidPhaseHumanTurn,
+      players: [
+        {
+          ...basePlayer(0, true),
+          cards: [{ design: 'CLOVER', value: 11 } as Card],
+        },
+        basePlayer(1, false),
+        basePlayer(2, false),
+      ],
+    });
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/skat']}>
+        <SkatPage />
+      </MemoryRouter>,
+    );
+    const estimate = await screen.findByTestId('bid-estimate');
+    expect(estimate).not.toHaveAttribute('data-exceeds');
+    // J♣ alone → Grand "with 1" → value 48; the label should mention that number.
+    expect(estimate.textContent).toContain('48');
+  });
+
+  it('flags the bid-estimate as exceeded when the current bid is above the hand ceiling', async () => {
+    mockExec.mockResolvedValue({
+      ...bidPhaseHumanTurn,
+      currentBid: 999,
+    });
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/skat']}>
+        <SkatPage />
+      </MemoryRouter>,
+    );
+    const estimate = await screen.findByTestId('bid-estimate');
+    expect(estimate).toHaveAttribute('data-exceeds', 'true');
+    expect(estimate.textContent).toContain('⚠️');
+  });
 });

--- a/frontend/src/pages/SkatPage.tsx
+++ b/frontend/src/pages/SkatPage.tsx
@@ -27,6 +27,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { parseSkatCommand, SKAT_HELP } from '../utils/cli/commands/skatCommands';
 import { formatSkatState } from '../utils/cli/formatters/skatFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { skatBestBidEstimate } from '../utils/skatBidEstimate';
 
 /** Suit identifiers matching internal/domain/Card.go (1=Spade, 2=Clover, 3=Heart, 4=Diamond). */
 const SUIT_SPADE = 1;
@@ -168,6 +169,22 @@ function SkatPageContent() {
                 {t('round')}: {state.roundNumber} | {t('dealer')}: CPU {state.dealerIdx} | {t('currentBid')}:{' '}
                 {state.currentBid}
               </div>
+              {isBid &&
+                humanPlayer &&
+                (() => {
+                  const est = skatBestBidEstimate(humanPlayer.cards ?? []);
+                  const exceeds = state.currentBid > est.value;
+                  return (
+                    <div
+                      data-testid="bid-estimate"
+                      data-exceeds={exceeds ? 'true' : undefined}
+                      className={`text-xs ${exceeds ? 'text-ds-error' : 'text-ds-text-muted'}`}
+                    >
+                      {t('bidEstimate', { value: est.value, type: t(`gameTypeLabel.${est.gameType.toLowerCase()}`) })}
+                      {exceeds && <span className="ml-2">⚠️ {t('bidExceedsHand')}</span>}
+                    </div>
+                  );
+                })()}
               {state.declarerIdx >= 0 && (
                 <div data-tutorial="sk-declarer-info">
                   {t('declarer')}: {state.players[state.declarerIdx]?.isHuman ? t('you') : `CPU ${state.declarerIdx}`}

--- a/frontend/src/utils/skatBidEstimate.test.ts
+++ b/frontend/src/utils/skatBidEstimate.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { skatBestBidEstimate, skatBidEstimates } from './skatBidEstimate';
+
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('skatBidEstimates', () => {
+  it('returns base value for an empty hand (without ∞ jacks, but capped by run)', () => {
+    const estimates = skatBidEstimates([]);
+    // Empty hand → "without" run = full set of top trumps. For Grand without 4 jacks = matadors 4, multiplier 5, value 120.
+    const grand = estimates.find((e) => e.gameType === 'GRAND');
+    if (!grand) throw new Error('expected GRAND estimate');
+    expect(grand.matadors).toBe(4);
+    expect(grand.value).toBe(5 * 24);
+  });
+
+  it('handles a single J♣ as "with 1" for clubs and grand', () => {
+    const hand: Card[] = [c('CLOVER', 11)];
+    const estimates = skatBidEstimates(hand);
+    const grand = estimates.find((e) => e.gameType === 'GRAND');
+    if (!grand) throw new Error('expected GRAND estimate');
+    expect(grand.matadors).toBe(1);
+    expect(grand.value).toBe(2 * 24);
+  });
+
+  it('skatBestBidEstimate picks the highest game value', () => {
+    const hand: Card[] = [c('CLOVER', 11), c('SPADE', 11)];
+    const best = skatBestBidEstimate(hand);
+    // With 2 jacks, Grand = 3 × 24 = 72; Clubs suit = 3 × 12 = 36. Grand wins.
+    expect(best.gameType).toBe('GRAND');
+    expect(best.value).toBe(72);
+  });
+});

--- a/frontend/src/utils/skatBidEstimate.test.ts
+++ b/frontend/src/utils/skatBidEstimate.test.ts
@@ -30,4 +30,56 @@ describe('skatBidEstimates', () => {
     expect(best.gameType).toBe('GRAND');
     expect(best.value).toBe(72);
   });
+
+  it('extends the "with" run into trump-suit cards when the jack run continues unbroken', () => {
+    // Top of clubs is [J♣, J♠, J♥, J♦, A♣, ...]. Holding J♣+J♠+J♥+J♦+A♣ keeps the run
+    // unbroken through 5 top trumps → matadors 5, multiplier 6, value 72.
+    const hand: Card[] = [c('CLOVER', 11), c('SPADE', 11), c('HEART', 11), c('DIAMOND', 11), c('CLOVER', 1)];
+    const estimates = skatBidEstimates(hand);
+    const clubs = estimates.find((e) => e.gameType === 'CLOVER');
+    if (!clubs) throw new Error('expected CLOVER estimate');
+    expect(clubs.matadors).toBe(5);
+    expect(clubs.value).toBe(6 * 12);
+  });
+
+  it('breaks the "with" run at the first missing top trump', () => {
+    // J♣ alone for a clubs game: top[0] = J♣ ✓, top[1] = J♠ ✗ → with 1.
+    // A♣ and 10♣ are further down the run but the break at J♠ stops counting.
+    const hand: Card[] = [c('CLOVER', 11), c('CLOVER', 1), c('CLOVER', 10)];
+    const clubs = skatBidEstimates(hand).find((e) => e.gameType === 'CLOVER');
+    if (!clubs) throw new Error('expected CLOVER estimate');
+    expect(clubs.matadors).toBe(1);
+    expect(clubs.value).toBe(2 * 12);
+  });
+
+  it('lets a deep clubs run beat Grand', () => {
+    // All 4 jacks + 7 trump clubs (A,10,K,Q,9,8,7) = "with 11" for clubs → 12 × 12 = 144.
+    // Grand sees "with 4" jacks → 5 × 24 = 120. Clubs should win.
+    const hand: Card[] = [
+      c('CLOVER', 11),
+      c('SPADE', 11),
+      c('HEART', 11),
+      c('DIAMOND', 11),
+      c('CLOVER', 1),
+      c('CLOVER', 10),
+      c('CLOVER', 13),
+      c('CLOVER', 12),
+      c('CLOVER', 9),
+      c('CLOVER', 8),
+      c('CLOVER', 7),
+    ];
+    const best = skatBestBidEstimate(hand);
+    expect(best.gameType).toBe('CLOVER');
+    expect(best.value).toBe(12 * 12);
+  });
+
+  it('stops the "without" run at the first held trump (J♠ only ⇒ without 1)', () => {
+    // Hand has J♠ but not J♣ → Grand "without 1" (run breaks at J♠), not "without 4".
+    const hand: Card[] = [c('SPADE', 11)];
+    const estimates = skatBidEstimates(hand);
+    const grand = estimates.find((e) => e.gameType === 'GRAND');
+    if (!grand) throw new Error('expected GRAND estimate');
+    expect(grand.matadors).toBe(1);
+    expect(grand.value).toBe(2 * 24);
+  });
 });

--- a/frontend/src/utils/skatBidEstimate.ts
+++ b/frontend/src/utils/skatBidEstimate.ts
@@ -1,0 +1,87 @@
+import type { Card } from '../types/card';
+
+/** Skat base values per game type. */
+const BASE = { CLOVER: 12, SPADE: 11, HEART: 10, DIAMOND: 9, GRAND: 24 } as const;
+
+type SuitKey = 'CLOVER' | 'SPADE' | 'HEART' | 'DIAMOND';
+
+/** Jack rank = value 11 in our deck encoding. */
+function isJack(card: Card): boolean {
+  return card.value === 11;
+}
+
+/** Compute matadors ("with N" or "without N") for the player's hand for a given trump suit (or Grand). */
+function matadors(hand: Card[], trump: SuitKey | 'GRAND'): { with: number; without: number } {
+  // Trump order for ranking: J♣, J♠, J♥, J♦, then if trump = suit add the suit cards A,10,K,Q,9,8,7.
+  const heldJacks = new Set<string>();
+  for (const c of hand) if (isJack(c)) heldJacks.add(c.design);
+  // Build the "top of trumps" ordered list of {suit,value} from most-significant down.
+  const top: { design: string; value: number }[] = [
+    { design: 'CLOVER', value: 11 },
+    { design: 'SPADE', value: 11 },
+    { design: 'HEART', value: 11 },
+    { design: 'DIAMOND', value: 11 },
+  ];
+  if (trump !== 'GRAND') {
+    // After jacks, trump suit's A, 10, K, Q, 9, 8, 7
+    for (const v of [1, 10, 13, 12, 9, 8, 7]) {
+      top.push({ design: trump, value: v });
+    }
+  }
+  const held = new Set(hand.map((c) => `${c.design}:${c.value}`));
+  // "With N": held has top[0], top[1], ..., top[N-1].
+  let withN = 0;
+  for (const t of top) {
+    if (held.has(`${t.design}:${t.value}`)) withN += 1;
+    else break;
+  }
+  // "Without N": player is missing top[0..N-1].
+  let withoutN = 0;
+  for (const t of top) {
+    if (!held.has(`${t.design}:${t.value}`)) withoutN += 1;
+    else break;
+  }
+  return { with: withN, without: withoutN };
+}
+
+/** Per-game-type estimate of the cheapest game value the hand can justify. */
+export interface SkatGameValueEstimate {
+  gameType: 'CLOVER' | 'SPADE' | 'HEART' | 'DIAMOND' | 'GRAND';
+  base: number;
+  matadors: number;
+  multiplier: number;
+  /** Minimum game value: (matadors + 1 game) × base. */
+  value: number;
+}
+
+/**
+ * Compute the minimum game value the player can justify for each game type using just the matador run
+ * (with/without — whichever is larger) plus the +1 multiplier the "game" itself always adds.
+ */
+export function skatBidEstimates(hand: Card[]): SkatGameValueEstimate[] {
+  const types: Array<'CLOVER' | 'SPADE' | 'HEART' | 'DIAMOND' | 'GRAND'> = [
+    'CLOVER',
+    'SPADE',
+    'HEART',
+    'DIAMOND',
+    'GRAND',
+  ];
+  return types.map((t) => {
+    const m = matadors(hand, t);
+    const matadorCount = Math.max(m.with, m.without);
+    const multiplier = matadorCount + 1; // +1 for "game"
+    return {
+      gameType: t,
+      base: BASE[t],
+      matadors: matadorCount,
+      multiplier,
+      value: multiplier * BASE[t],
+    };
+  });
+}
+
+/** The single best (highest game value) estimate among all game types. */
+export function skatBestBidEstimate(hand: Card[]): SkatGameValueEstimate {
+  const estimates = skatBidEstimates(hand);
+  return estimates.reduce((best, e) => (e.value > best.value ? e : best));
+}

--- a/frontend/src/utils/skatBidEstimate.ts
+++ b/frontend/src/utils/skatBidEstimate.ts
@@ -1,6 +1,10 @@
 import type { Card } from '../types/card';
 
-/** Skat base values per game type. */
+/**
+ * Skat base values per game type. Null games (base 23) are intentionally omitted: their value is
+ * fixed by the contract type alone and does not scale with the matador run, so they don't belong
+ * in a matador-based hand estimate.
+ */
 const BASE = { CLOVER: 12, SPADE: 11, HEART: 10, DIAMOND: 9, GRAND: 24 } as const;
 
 type SuitKey = 'CLOVER' | 'SPADE' | 'HEART' | 'DIAMOND';
@@ -44,19 +48,25 @@ function matadors(hand: Card[], trump: SuitKey | 'GRAND'): { with: number; witho
   return { with: withN, without: withoutN };
 }
 
-/** Per-game-type estimate of the cheapest game value the hand can justify. */
+/** Per-game-type estimate of the hand value reachable from the matador run alone. */
 export interface SkatGameValueEstimate {
   gameType: 'CLOVER' | 'SPADE' | 'HEART' | 'DIAMOND' | 'GRAND';
   base: number;
   matadors: number;
   multiplier: number;
-  /** Minimum game value: (matadors + 1 game) × base. */
+  /**
+   * Highest bid the hand can safely accept without announcing extra multipliers
+   * (no Hand / Schneider / Schwarz / Ouvert). Equals `(matadors + 1 game) × base`.
+   * Accepting a bid above this risks an over-bid loss.
+   */
   value: number;
 }
 
 /**
- * Compute the minimum game value the player can justify for each game type using just the matador run
- * (with/without — whichever is larger) plus the +1 multiplier the "game" itself always adds.
+ * Compute the safe-bid ceiling per game type using just the matador run (with/without —
+ * whichever is larger) plus the +1 multiplier the "game" itself always adds. The returned
+ * value is the highest bid the hand can justify without invoking the optional Hand /
+ * Schneider / Schwarz / Ouvert multipliers.
  */
 export function skatBidEstimates(hand: Card[]): SkatGameValueEstimate[] {
   const types: Array<'CLOVER' | 'SPADE' | 'HEART' | 'DIAMOND' | 'GRAND'> = [


### PR DESCRIPTION
## Summary
- Adds a small caption under \"Current bid\" during the bidding phase that previews the highest game value the player's hand can support — e.g. \"Hand-estimated max: 36 (♣ Clubs)\".
- When the current bid exceeds that estimate, the line turns red and adds a ⚠️ warning so the player knows accepting could result in an overbid loss.

## Implementation
- New \`skatBidEstimate\` util computes \"with/without N matadors\" per game type (Suit ×4 + Grand) and returns the highest \`base × (matadors + 1)\` value.
- SkatPage renders the estimate inline during the bid phase only when the player has a hand to evaluate.
- New i18n keys: \`bidEstimate\`, \`bidExceedsHand\`, \`gameTypeLabel.*\` per locale.

## Test plan
- [x] \`bun run test -- --run src/utils/skatBidEstimate.test.ts src/pages/SkatPage.test.tsx\`
- [x] \`bun run check\`

Closes #1934