### PR TITLE
feat(cribbage): pegboard track with front/rear pegs

### DIFF
--- a/frontend/src/pages/CribbagePage.test.tsx
+++ b/frontend/src/pages/CribbagePage.test.tsx
@@ -549,6 +549,39 @@ describe('CribbagePage', () => {
     });
   });
 
+  it('renders the rear-peg trail after the player score jumps', async () => {
+    const startState: CribbageResponse = {
+      ...discardPhaseState,
+      players: [{ ...discardPhaseState.players[0], cumulativeScore: 10 }, { ...discardPhaseState.players[1] }],
+    };
+    mockExec.mockResolvedValue(startState);
+    renderWithProviders(<CribbagePage />);
+    await waitFor(() => expect(screen.getByTestId('front-peg-0')).toBeInTheDocument());
+    // First render captures 10 into prevScoresRef → no rear peg yet.
+    expect(screen.queryByTestId('rear-peg-0')).not.toBeInTheDocument();
+
+    // Trigger a re-render with a higher score.
+    mockExec.mockResolvedValueOnce({
+      ...startState,
+      players: [{ ...startState.players[0], cumulativeScore: 22 }, { ...startState.players[1] }],
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+
+    await waitFor(() => expect(screen.getByTestId('rear-peg-0')).toBeInTheDocument());
+  });
+
+  it('uses 15-point ticks on a 61-point board', async () => {
+    mockExec.mockResolvedValue({
+      ...discardPhaseState,
+      config: { cpuDifficulty: 1, pointLimit: 61 },
+    });
+    renderWithProviders(<CribbagePage />);
+    await screen.findByTestId('peg-board');
+    // 2 tracks × 4 ticks each (15, 30, 45, 60 — strictly < pointLimit 61) = 8 tick elements.
+    expect(screen.getAllByTestId('peg-tick')).toHaveLength(8);
+  });
+
   it('shows loading state', async () => {
     renderWithProviders(<CribbagePage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).not.toBeDisabled());

--- a/frontend/src/pages/CribbagePage.tsx
+++ b/frontend/src/pages/CribbagePage.tsx
@@ -80,6 +80,16 @@ const CB_TUTORIAL_STEPS: TutorialStep[] = [
 
 /** Renders the Cribbage game page with discard, pegging, show, and round phases. */
 export const CribbagePage = withTutorial(CribbagePageContent, 'cribbage', CB_TUTORIAL_STEPS);
+/**
+ * Front peg's center expressed as a CSS calc that keeps the peg fully inside the
+ * track even at the extremes (0% / 100%). The peg is 12 px wide so we shift its
+ * center inward by 6 px at 0% and -6 px at 100%, blending linearly between.
+ */
+function pegCenter(pct: number): string {
+  const inset = 6 - (pct / 100) * 12;
+  return `calc(${pct}% + ${inset}px)`;
+}
+
 /** Inline peg board showing score progress, with front + rear pegs to surface the most recent jump. */
 function PegBoard({ scores, pointLimit }: { scores: { name: string; score: number }[]; pointLimit: number }) {
   const prevScoresRef = useRef<number[]>(scores.map((s) => s.score));
@@ -88,10 +98,15 @@ function PegBoard({ scores, pointLimit }: { scores: { name: string; score: numbe
   useEffect(() => {
     prevScoresRef.current = scores.map((s) => s.score);
   }, [scores]);
-  // Quarter-board tick marks (every 30 on a 121 board, every 15 on 61).
-  const step = pointLimit >= 100 ? 30 : 15;
-  const ticks: number[] = [];
-  for (let v = step; v < pointLimit; v += step) ticks.push(v);
+  // Quarter-board tick marks (every 30 on a 121 board, every 15 on 61). Memoised so the
+  // array isn't reallocated on each render — pointLimit only changes when the user opens
+  // the settings panel and switches the target score.
+  const ticks = useMemo(() => {
+    const step = pointLimit >= 100 ? 30 : 15;
+    const out: number[] = [];
+    for (let v = step; v < pointLimit; v += step) out.push(v);
+    return out;
+  }, [pointLimit]);
   return (
     <section className="my-2 p-2 rounded bg-black/30" aria-label="peg-board" data-testid="peg-board">
       {scores.map((p, idx) => {
@@ -111,6 +126,7 @@ function PegBoard({ scores, pointLimit }: { scores: { name: string; score: numbe
               {ticks.map((v) => (
                 <div
                   key={v}
+                  data-testid="peg-tick"
                   aria-hidden="true"
                   className="absolute top-0 bottom-0 w-px bg-white/20"
                   style={{ left: `${(v / pointLimit) * 100}%` }}
@@ -125,14 +141,14 @@ function PegBoard({ scores, pointLimit }: { scores: { name: string; score: numbe
                   data-testid={`rear-peg-${idx}`}
                   aria-hidden="true"
                   className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-2 h-2 rounded-full bg-white/50"
-                  style={{ left: `${prevPct}%` }}
+                  style={{ left: pegCenter(prevPct) }}
                 />
               )}
               <div
                 data-testid={`front-peg-${idx}`}
                 aria-hidden="true"
                 className={`absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border border-white/70 transition-all ${tone}`}
-                style={{ left: `${pct}%` }}
+                style={{ left: pegCenter(pct) }}
               />
             </div>
           </div>

--- a/frontend/src/pages/CribbagePage.tsx
+++ b/frontend/src/pages/CribbagePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { cribbageApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -80,12 +80,25 @@ const CB_TUTORIAL_STEPS: TutorialStep[] = [
 
 /** Renders the Cribbage game page with discard, pegging, show, and round phases. */
 export const CribbagePage = withTutorial(CribbagePageContent, 'cribbage', CB_TUTORIAL_STEPS);
-/** Inline peg board showing score progress as a simple bar. */
+/** Inline peg board showing score progress, with front + rear pegs to surface the most recent jump. */
 function PegBoard({ scores, pointLimit }: { scores: { name: string; score: number }[]; pointLimit: number }) {
+  const prevScoresRef = useRef<number[]>(scores.map((s) => s.score));
+  // Read the previous score for the rear-peg position before we overwrite the ref.
+  const prevScores = prevScoresRef.current;
+  useEffect(() => {
+    prevScoresRef.current = scores.map((s) => s.score);
+  }, [scores]);
+  // Quarter-board tick marks (every 30 on a 121 board, every 15 on 61).
+  const step = pointLimit >= 100 ? 30 : 15;
+  const ticks: number[] = [];
+  for (let v = step; v < pointLimit; v += step) ticks.push(v);
   return (
-    <section className="my-2 p-2 rounded bg-black/30" aria-label="peg-board">
+    <section className="my-2 p-2 rounded bg-black/30" aria-label="peg-board" data-testid="peg-board">
       {scores.map((p, idx) => {
         const pct = Math.min((p.score / pointLimit) * 100, 100);
+        const prev = prevScores[idx] ?? p.score;
+        const prevPct = Math.min((prev / pointLimit) * 100, 100);
+        const tone = idx === 0 ? 'bg-ds-warning' : 'bg-ds-info';
         return (
           <div key={idx} className="mb-1">
             <div className="flex justify-between text-ds-text-muted text-xs mb-0.5">
@@ -94,10 +107,32 @@ function PegBoard({ scores, pointLimit }: { scores: { name: string; score: numbe
                 {p.score}/{pointLimit}
               </span>
             </div>
-            <div className="w-full h-3 bg-white/10 rounded-full overflow-hidden">
+            <div className="relative w-full h-3 bg-white/10 rounded-full overflow-visible">
+              {ticks.map((v) => (
+                <div
+                  key={v}
+                  aria-hidden="true"
+                  className="absolute top-0 bottom-0 w-px bg-white/20"
+                  style={{ left: `${(v / pointLimit) * 100}%` }}
+                />
+              ))}
               <div
-                className={`h-full rounded-full transition-all ${idx === 0 ? 'bg-ds-warning' : 'bg-ds-info'}`}
+                className={`absolute inset-y-0 left-0 rounded-full transition-all ${tone}`}
                 style={{ width: `${pct}%` }}
+              />
+              {prev !== p.score && (
+                <div
+                  data-testid={`rear-peg-${idx}`}
+                  aria-hidden="true"
+                  className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-2 h-2 rounded-full bg-white/50"
+                  style={{ left: `${prevPct}%` }}
+                />
+              )}
+              <div
+                data-testid={`front-peg-${idx}`}
+                aria-hidden="true"
+                className={`absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border border-white/70 transition-all ${tone}`}
+                style={{ left: `${pct}%` }}
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Upgrades the Cribbage progress bar into a track that surfaces the most recent score jump: a small rear-peg dot stays at the previous score while the front peg jumps to the new total.
- Adds quarter-board tick marks (every 30 on 121-point boards, every 15 on 61-point boards) so progress reads at a glance.

## Implementation
- Tracks the previous score via \`useRef\` and snaps it on each render with \`useEffect\`.
- Renders pegs/ticks as absolutely positioned dots over the existing fill bar; no API contract changes.

## Test plan
- [x] \`bun run test -- --run src/pages/CribbagePage.test.tsx\`
- [x] \`bun run check\`

Closes #1935