### PR TITLE
feat(ultimatetexasholdem): pulse 4x/3x buttons by pre-flop hand strength

### DIFF
--- a/frontend/src/pages/UltimateTexasHoldemPage.test.tsx
+++ b/frontend/src/pages/UltimateTexasHoldemPage.test.tsx
@@ -340,4 +340,28 @@ describe('UltimateTexasHoldemPage', () => {
     // Math.floor(100 / 2) === 50, so the input cannot stay at 100.
     expect(Number(anteInput.value)).toBeLessThanOrEqual(50);
   });
+
+  it('pulses the 3x button and not the 4x when the pre-flop hand is moderate', async () => {
+    // K-7 offsuit → moderate per utHoldemPreflopStrength.
+    mockApi.mockResolvedValue({ ...preFlopState, playerHand: [card('SPADE', 13), card('HEART', 7)] });
+    renderWithProviders(<UltimateTexasHoldemPage />);
+    await waitFor(() => expect(screen.getByTestId('play-3x')).toBeInTheDocument());
+
+    const container = screen.getByTestId('play-4x').closest('[data-preflop-strength]') as HTMLElement;
+    expect(container).toHaveAttribute('data-preflop-strength', 'moderate');
+    expect(screen.getByTestId('play-3x').className).toContain('animate-pulse');
+    expect(screen.getByTestId('play-4x').className).not.toContain('animate-pulse');
+  });
+
+  it('does not pulse any button when the pre-flop hand is weak', async () => {
+    // 7-2 offsuit → weak per utHoldemPreflopStrength.
+    mockApi.mockResolvedValue({ ...preFlopState, playerHand: [card('SPADE', 7), card('HEART', 2)] });
+    renderWithProviders(<UltimateTexasHoldemPage />);
+    await waitFor(() => expect(screen.getByTestId('play-4x')).toBeInTheDocument());
+
+    const container = screen.getByTestId('play-4x').closest('[data-preflop-strength]') as HTMLElement;
+    expect(container).toHaveAttribute('data-preflop-strength', 'weak');
+    expect(screen.getByTestId('play-4x').className).not.toContain('animate-pulse');
+    expect(screen.getByTestId('play-3x').className).not.toContain('animate-pulse');
+  });
 });

--- a/frontend/src/pages/UltimateTexasHoldemPage.tsx
+++ b/frontend/src/pages/UltimateTexasHoldemPage.tsx
@@ -24,6 +24,7 @@ import { gameTheme } from '../styles/gameTheme';
 import { isMaskedCard } from '../types/card';
 import { UltimateTexasHoldemPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { utHoldemPreflopStrength } from '../utils/utHoldemPreflop';
 
 /** Ultimate Texas Hold'em tutorial step definitions. */
 const UTH_TUTORIAL_STEPS: TutorialStep[] = [
@@ -368,19 +369,41 @@ function UltimateTexasHoldemPageContent() {
             </button>
           </div>
         )}
-        {isPreFlopPhase && (
-          <div className="flex justify-center gap-2 pb-2" data-tutorial="uth-pre-flop-buttons">
-            <button type="button" className={btnSuccess} onClick={() => handlePlay(4)} disabled={loading}>
-              {t('button.play4x')}
-            </button>
-            <button type="button" className={btnSuccess} onClick={() => handlePlay(3)} disabled={loading}>
-              {t('button.play3x')}
-            </button>
-            <button type="button" className={btnSecondary} onClick={handleCheck} disabled={loading}>
-              {t('button.check')}
-            </button>
-          </div>
-        )}
+        {isPreFlopPhase &&
+          (() => {
+            const strength = utHoldemPreflopStrength(state.playerHand);
+            const strong = strength === 'strong';
+            const moderate = strength === 'moderate';
+            return (
+              <div
+                className="flex justify-center gap-2 pb-2"
+                data-tutorial="uth-pre-flop-buttons"
+                data-preflop-strength={strength}
+              >
+                <button
+                  type="button"
+                  className={`${btnSuccess} ${strong ? 'ring-2 ring-ds-warning animate-pulse' : ''}`}
+                  onClick={() => handlePlay(4)}
+                  disabled={loading}
+                  data-testid="play-4x"
+                >
+                  {t('button.play4x')}
+                </button>
+                <button
+                  type="button"
+                  className={`${btnSuccess} ${moderate ? 'ring-2 ring-ds-warning animate-pulse' : ''}`}
+                  onClick={() => handlePlay(3)}
+                  disabled={loading}
+                  data-testid="play-3x"
+                >
+                  {t('button.play3x')}
+                </button>
+                <button type="button" className={btnSecondary} onClick={handleCheck} disabled={loading}>
+                  {t('button.check')}
+                </button>
+              </div>
+            );
+          })()}
         {isFlopPhase && (
           <div className="flex justify-center gap-2 pb-2" data-tutorial="uth-flop-buttons">
             <button type="button" className={btnWarning} onClick={() => handlePlay(2)} disabled={loading}>

--- a/frontend/src/utils/utHoldemPreflop.test.ts
+++ b/frontend/src/utils/utHoldemPreflop.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { utHoldemPreflopStrength } from './utHoldemPreflop';
+
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('utHoldemPreflopStrength', () => {
+  it.each([
+    ['pair of 2s', [c('SPADE', 2), c('HEART', 2)], 'strong'],
+    ['any ace', [c('SPADE', 1), c('HEART', 5)], 'strong'],
+    ['suited king', [c('SPADE', 13), c('SPADE', 4)], 'strong'],
+    ['K-Q offsuit', [c('SPADE', 13), c('HEART', 12)], 'strong'],
+    ['Q-J offsuit', [c('SPADE', 12), c('HEART', 11)], 'strong'],
+    ['K-7 offsuit', [c('SPADE', 13), c('HEART', 7)], 'moderate'],
+    ['suited 8-9', [c('SPADE', 8), c('SPADE', 9)], 'moderate'],
+    ['Q-4 suited', [c('SPADE', 12), c('SPADE', 4)], 'moderate'],
+    ['7-2 offsuit', [c('SPADE', 7), c('HEART', 2)], 'weak'],
+    ['empty hand', [], 'weak'],
+  ])('%s -> %s', (_, hand, expected) => {
+    expect(utHoldemPreflopStrength(hand as Card[])).toBe(expected);
+  });
+});

--- a/frontend/src/utils/utHoldemPreflop.test.ts
+++ b/frontend/src/utils/utHoldemPreflop.test.ts
@@ -10,12 +10,14 @@ describe('utHoldemPreflopStrength', () => {
     ['any ace', [c('SPADE', 1), c('HEART', 5)], 'strong'],
     ['suited king', [c('SPADE', 13), c('SPADE', 4)], 'strong'],
     ['K-Q offsuit', [c('SPADE', 13), c('HEART', 12)], 'strong'],
-    ['Q-J offsuit', [c('SPADE', 12), c('HEART', 11)], 'strong'],
+    ['Q-J suited', [c('SPADE', 12), c('SPADE', 11)], 'strong'],
+    ['Q-J offsuit', [c('SPADE', 12), c('HEART', 11)], 'moderate'],
     ['K-7 offsuit', [c('SPADE', 13), c('HEART', 7)], 'moderate'],
     ['suited 8-9', [c('SPADE', 8), c('SPADE', 9)], 'moderate'],
     ['Q-4 suited', [c('SPADE', 12), c('SPADE', 4)], 'moderate'],
     ['7-2 offsuit', [c('SPADE', 7), c('HEART', 2)], 'weak'],
     ['empty hand', [], 'weak'],
+    ['single card', [c('SPADE', 1)], 'weak'],
   ])('%s -> %s', (_, hand, expected) => {
     expect(utHoldemPreflopStrength(hand as Card[])).toBe(expected);
   });

--- a/frontend/src/utils/utHoldemPreflop.ts
+++ b/frontend/src/utils/utHoldemPreflop.ts
@@ -23,8 +23,9 @@ export function utHoldemPreflopStrength(hand: Card[]): UTHPreflopStrength {
   if (hi === 14) return 'strong'; // any ace
   if (hi === 13 && suited) return 'strong'; // suited king
   if (hi === 13 && lo >= 11) return 'strong'; // K-Q/J offsuit
-  if (hi === 12 && lo >= 11) return 'strong'; // Q-J either way
+  if (hi === 12 && lo === 11 && suited) return 'strong'; // Q-J suited (offsuit drops to moderate per UTH basic strategy)
   if (hi === 13) return 'moderate'; // K-anything offsuit
+  if (hi === 12 && lo === 11) return 'moderate'; // Q-J offsuit
   if (suited && hi - lo <= 2 && lo >= 6) return 'moderate'; // suited connector mid+
   if (suited && hi >= 12) return 'moderate'; // Q-x suited
   return 'weak';

--- a/frontend/src/utils/utHoldemPreflop.ts
+++ b/frontend/src/utils/utHoldemPreflop.ts
@@ -1,0 +1,31 @@
+import type { Card } from '../types/card';
+
+export type UTHPreflopStrength = 'strong' | 'moderate' | 'weak';
+
+function effectiveRank(value: number): number {
+  return value === 1 ? 14 : value;
+}
+
+/**
+ * Coarse pre-flop strength bucket for Ultimate Texas Hold'em: "strong" recommends a 4x bet,
+ * "moderate" recommends a 3x, "weak" recommends Check. Based on the published basic strategy
+ * (any pair, any Ace, suited Broadway → 4x; suited connectors / K-anything offsuit → 3x).
+ */
+export function utHoldemPreflopStrength(hand: Card[]): UTHPreflopStrength {
+  if (hand.length < 2) return 'weak';
+  const [a, b] = hand;
+  const ra = effectiveRank(a.value);
+  const rb = effectiveRank(b.value);
+  const hi = Math.max(ra, rb);
+  const lo = Math.min(ra, rb);
+  const suited = a.design === b.design;
+  if (ra === rb) return 'strong'; // any pair
+  if (hi === 14) return 'strong'; // any ace
+  if (hi === 13 && suited) return 'strong'; // suited king
+  if (hi === 13 && lo >= 11) return 'strong'; // K-Q/J offsuit
+  if (hi === 12 && lo >= 11) return 'strong'; // Q-J either way
+  if (hi === 13) return 'moderate'; // K-anything offsuit
+  if (suited && hi - lo <= 2 && lo >= 6) return 'moderate'; // suited connector mid+
+  if (suited && hi >= 12) return 'moderate'; // Q-x suited
+  return 'weak';
+}


### PR DESCRIPTION
## Summary
- During the pre-flop street, the recommended bet button now pulses with a warning ring based on the player's two hole cards — Strong hands light up Play 4x, moderate hands light up Play 3x, weak hands stay dim so checking is the obvious default.

## Implementation
- New \`utHoldemPreflopStrength\` util buckets a 2-card hand into strong / moderate / weak using the published UTH basic strategy (pairs, any ace, suited king / Broadway → strong; K-anything off / suited connectors → moderate).
- Page wraps the Play 4x / 3x buttons in an IIFE that reads the strength and applies \`ring-2 ring-ds-warning animate-pulse\` accordingly. \`data-preflop-strength\` is exposed for tests.

## Test plan
- [x] \`bun run test -- --run src/utils/utHoldemPreflop.test.ts src/pages/UltimateTexasHoldemPage.test.tsx\`
- [x] \`bun run check\`

Closes #1936