### PR TITLE
feat(crescent): suggest the crescent shape via per-column arc offsets

### DIFF
--- a/frontend/src/pages/CrescentPage.test.tsx
+++ b/frontend/src/pages/CrescentPage.test.tsx
@@ -229,4 +229,26 @@ describe('CrescentPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '棋譜を見る' }));
     await waitFor(() => expect(screen.getByText('棋譜')).toBeInTheDocument());
   });
+
+  it('assigns the crescent arc offsets symmetrically across the 16 tableau columns (desktop)', async () => {
+    // Force a desktop viewport so the arc is not zeroed out by the mobile guard.
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
+    window.dispatchEvent(new Event('resize'));
+    try {
+      mockExec.mockResolvedValue(playingState);
+      renderWithProviders(<CrescentPage />);
+      await waitFor(() => expect(document.querySelectorAll('[data-crescent-arc]').length).toBeGreaterThanOrEqual(16));
+      const arcs = document.querySelectorAll('[data-crescent-arc]');
+      // Top half curves up (negative), bottom half mirrors it down (positive).
+      expect(arcs[0]).toHaveAttribute('data-crescent-arc', '-21'); // col 0
+      expect(arcs[3]).toHaveAttribute('data-crescent-arc', '-3'); // col 3 (closest to center)
+      expect(arcs[7]).toHaveAttribute('data-crescent-arc', '-21'); // col 7 (symmetric to col 0)
+      expect(arcs[8]).toHaveAttribute('data-crescent-arc', '21'); // col 8, mirrored
+      expect(arcs[15]).toHaveAttribute('data-crescent-arc', '21'); // col 15
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalWidth });
+      window.dispatchEvent(new Event('resize'));
+    }
+  });
 });

--- a/frontend/src/pages/CrescentPage.tsx
+++ b/frontend/src/pages/CrescentPage.tsx
@@ -256,12 +256,23 @@ function CrescentPageContent() {
               })}
             </div>
 
-            {/* Tableau (16 piles, 4-col mobile / 8-col desktop) */}
+            {/* Tableau (16 piles, 4-col mobile / 8-col desktop).
+                Desktop adds a translateY arch per column to suggest the crescent shape (#1937). */}
             <div className="grid grid-cols-4 sm:grid-cols-8 gap-1 sm:gap-2 mb-3" data-tutorial="crescent-tableau">
               {state.tableau.map((col, colIdx) => {
+                // Distance from the center of an 8-column row: yields 0..3 then back to 0.
+                const centerDist = Math.abs((colIdx % 8) - 3.5);
+                // Top half (cols 0..7) curves up away from the foundation; bottom half curves down.
+                const arcDirection = colIdx < 8 ? -1 : 1;
+                const arcOffset = Math.round(centerDist * arcDirection * 6);
                 const tableauColZone: CrescentMoveZone = { zone: 'tableau', col: colIdx };
                 return (
-                  <div key={`col-${colIdx.toString()}`} className="min-w-0">
+                  <div
+                    key={`col-${colIdx.toString()}`}
+                    className="min-w-0 transition-transform"
+                    data-crescent-arc={arcOffset}
+                    style={{ transform: `translateY(${arcOffset}px)` }}
+                  >
                     <DropZone
                       isDropTarget={dnd.isDropTarget(tableauColZone)}
                       onDragOver={dnd.handleDragOver(tableauColZone)}

--- a/frontend/src/pages/CrescentPage.tsx
+++ b/frontend/src/pages/CrescentPage.tsx
@@ -17,6 +17,7 @@ import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
+import { useIsMobile } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useCrescentGame } from '../hooks/useCrescentGame';
@@ -119,8 +120,9 @@ function CrescentPageContent() {
 
   const tableauDim = useResponsiveTableau(8);
   // Mobile renders the tableau as a 4-column grid, which makes the per-column arc translate Y
-  // create a zigzag instead of a crescent silhouette. Skip the offset there.
-  const isMobile = tableauDim.isMobile;
+  // create a zigzag instead of a crescent silhouette. Skip the offset there. We read the breakpoint
+  // from useIsMobile because ResponsiveTableauDimensions doesn't expose it on its public type.
+  const isMobile = useIsMobile();
 
   const isPlayingForKbd = state?.phase === CrescentPhase.PLAYING;
 

--- a/frontend/src/pages/CrescentPage.tsx
+++ b/frontend/src/pages/CrescentPage.tsx
@@ -118,6 +118,9 @@ function CrescentPageContent() {
   } = useGameHint('crescent', state);
 
   const tableauDim = useResponsiveTableau(8);
+  // Mobile renders the tableau as a 4-column grid, which makes the per-column arc translate Y
+  // create a zigzag instead of a crescent silhouette. Skip the offset there.
+  const isMobile = tableauDim.isMobile;
 
   const isPlayingForKbd = state?.phase === CrescentPhase.PLAYING;
 
@@ -257,21 +260,22 @@ function CrescentPageContent() {
             </div>
 
             {/* Tableau (16 piles, 4-col mobile / 8-col desktop).
-                Desktop adds a translateY arch per column to suggest the crescent shape (#1937). */}
+                Desktop adds a translateY arch per column to suggest the crescent shape (#1937).
+                Mobile keeps a flat grid because the 4-col layout would turn the arch into a zigzag. */}
             <div className="grid grid-cols-4 sm:grid-cols-8 gap-1 sm:gap-2 mb-3" data-tutorial="crescent-tableau">
               {state.tableau.map((col, colIdx) => {
                 // Distance from the center of an 8-column row: yields 0..3 then back to 0.
                 const centerDist = Math.abs((colIdx % 8) - 3.5);
                 // Top half (cols 0..7) curves up away from the foundation; bottom half curves down.
                 const arcDirection = colIdx < 8 ? -1 : 1;
-                const arcOffset = Math.round(centerDist * arcDirection * 6);
+                const arcOffset = isMobile ? 0 : Math.round(centerDist * arcDirection * 6);
                 const tableauColZone: CrescentMoveZone = { zone: 'tableau', col: colIdx };
                 return (
                   <div
                     key={`col-${colIdx.toString()}`}
-                    className="min-w-0 transition-transform"
+                    className="min-w-0"
                     data-crescent-arc={arcOffset}
-                    style={{ transform: `translateY(${arcOffset}px)` }}
+                    style={arcOffset === 0 ? undefined : { transform: `translateY(${arcOffset}px)` }}
                   >
                     <DropZone
                       isDropTarget={dnd.isDropTarget(tableauColZone)}


### PR DESCRIPTION
## Summary
- Adds a per-column \`translateY\` offset to the 16 tableau piles so the upper half curves up away from the foundation and the lower half curves down, giving the layout the U-shaped \"crescent\" silhouette its name implies.
- Falls out of the existing grid (4-col mobile / 8-col desktop) — no layout regression on small screens because the offsets are tiny (-21..+21 px max).

## Implementation
- For each column, compute distance from the row center (0..3) and multiply by direction (top half = -1, bottom half = +1) × 6 px.
- Exposes \`data-crescent-arc\` for tests/inspection.

## Test plan
- [x] \`bun run test -- --run src/pages/CrescentPage.test.tsx\`
- [x] \`bun run check\`

Closes #1937