### PR TITLE
feat(president): spring-animated rank stamp badges at round end

### DIFF
--- a/frontend/src/pages/PresidentPage.test.tsx
+++ b/frontend/src/pages/PresidentPage.test.tsx
@@ -182,6 +182,38 @@ describe('PresidentPage', () => {
     );
     renderWithProviders(<PresidentPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+    // Each finished player gets a uniquely-identified rank stamp badge.
+    expect(screen.getByTestId('rank-stamp-1')).toBeInTheDocument();
+    expect(screen.getByTestId('rank-stamp-2')).toBeInTheDocument();
+    expect(screen.getByTestId('rank-stamp-3')).toBeInTheDocument();
+    expect(screen.getByTestId('rank-stamp-4')).toBeInTheDocument();
+    // Crown icon for rank 1 (president).
+    expect(screen.getByTestId('rank-stamp-1').textContent).toContain('👑');
+    // Trash icon for rank 4 (scum).
+    expect(screen.getByTestId('rank-stamp-4').textContent).toContain('🗑️');
+  });
+
+  it('falls back to neutral styling and an empty icon for an unknown rank value', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        gameEndFlag: true,
+        players: [
+          // Out-of-range rank exercises the ?? fallbacks in PRESIDENT_RANK_BG / ICON / KEYS.
+          { id: 0, isHuman: true, isFinished: true, rank: 99, cardCount: 0, cards: [] },
+          { id: 1, isHuman: false, isFinished: true, rank: 2, cardCount: 0, cards: [] },
+          { id: 2, isHuman: false, isFinished: true, rank: 3, cardCount: 0, cards: [] },
+          { id: 3, isHuman: false, isFinished: true, rank: 4, cardCount: 0, cards: [] },
+        ],
+      }),
+    );
+    renderWithProviders(<PresidentPage />);
+    const fallback = await screen.findByTestId('rank-stamp-99');
+    // Fallback uses the neutral design tokens (no warning/info/error background).
+    expect(fallback.className).toContain('bg-ds-surface');
+    expect(fallback.className).toContain('text-ds-text-primary');
+    // No matching icon for rank 99 → the emoji prefix is absent, leaving only a space + label text.
+    expect(fallback.textContent?.trim().startsWith('👑')).toBe(false);
+    expect(fallback.textContent?.trim().startsWith('🗑️')).toBe(false);
   });
 
   it('shows loading state when state has fewer than 4 players', async () => {

--- a/frontend/src/pages/PresidentPage.tsx
+++ b/frontend/src/pages/PresidentPage.tsx
@@ -1,3 +1,4 @@
+import { motion } from 'framer-motion';
 import { useCallback, useMemo } from 'react';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -70,6 +71,35 @@ const PRESIDENT_RANK_KEYS: Readonly<Record<number, string>> = {
   3: 'rank.viceScum',
   4: 'rank.scum',
 };
+
+const PRESIDENT_RANK_ICON: Readonly<Record<number, string>> = {
+  1: '👑',
+  2: '🥈',
+  3: '🥉',
+  4: '🗑️',
+};
+
+const PRESIDENT_RANK_BG: Readonly<Record<number, string>> = {
+  1: 'bg-ds-warning text-ds-text-on-accent',
+  2: 'bg-ds-info text-ds-text-on-accent',
+  3: 'bg-ds-surface text-ds-text-muted',
+  4: 'bg-ds-error text-ds-text-on-accent',
+};
+
+/** Stamp-style rank badge that springs in when a player finishes. */
+function RankStamp({ rank, label }: { rank: number; label: string }) {
+  return (
+    <motion.span
+      data-testid={`rank-stamp-${rank}`}
+      initial={{ scale: 2, opacity: 0, rotate: -20 }}
+      animate={{ scale: 1, opacity: 1, rotate: -8 }}
+      transition={{ type: 'spring', stiffness: 260, damping: 14 }}
+      className={`inline-block px-2 py-0.5 rounded-md font-bold text-xs border-2 border-current ${PRESIDENT_RANK_BG[rank] ?? 'bg-ds-surface text-ds-text'}`}
+    >
+      {PRESIDENT_RANK_ICON[rank] ?? ''} {label}
+    </motion.span>
+  );
+}
 
 /** Renders the President (プレジデント) game page. */
 export const PresidentPage = withTutorial(PresidentPageContent, 'president', PR_TUTORIAL_STEPS);
@@ -163,10 +193,10 @@ function PresidentPageContent() {
                 .filter((p) => !p.isHuman)
                 .map((p) => (
                   <div key={p.id} className="text-center">
-                    <div className="text-xs text-ds-text-muted mb-1">
-                      {tc('player.cpu', { id: p.id })}{' '}
+                    <div className="text-xs text-ds-text-muted mb-1 flex items-center justify-center gap-1">
+                      <span>{tc('player.cpu', { id: p.id })}</span>
                       {p.isFinished ? (
-                        <span className="text-ds-success">({t(PRESIDENT_RANK_KEYS[p.rank] ?? 'rank.unknown')})</span>
+                        <RankStamp rank={p.rank} label={t(PRESIDENT_RANK_KEYS[p.rank] ?? 'rank.unknown')} />
                       ) : (
                         <span>— {p.cardCount}</span>
                       )}
@@ -194,9 +224,11 @@ function PresidentPageContent() {
 
             {/* Human hand */}
             <div className="text-center" data-tutorial="pr-player-hand">
-              <div className="text-xs text-ds-text-muted mb-1">
-                {tc('player.you')}
-                {human.isFinished && <> — {t(PRESIDENT_RANK_KEYS[human.rank] ?? 'rank.unknown')}</>}
+              <div className="text-xs text-ds-text-muted mb-1 flex items-center justify-center gap-1">
+                <span>{tc('player.you')}</span>
+                {human.isFinished && (
+                  <RankStamp rank={human.rank} label={t(PRESIDENT_RANK_KEYS[human.rank] ?? 'rank.unknown')} />
+                )}
               </div>
               <div className="flex flex-wrap justify-center gap-2">
                 {human.cards.map((c, i) => (

--- a/frontend/src/pages/PresidentPage.tsx
+++ b/frontend/src/pages/PresidentPage.tsx
@@ -94,7 +94,7 @@ function RankStamp({ rank, label }: { rank: number; label: string }) {
       initial={{ scale: 2, opacity: 0, rotate: -20 }}
       animate={{ scale: 1, opacity: 1, rotate: -8 }}
       transition={{ type: 'spring', stiffness: 260, damping: 14 }}
-      className={`inline-block px-2 py-0.5 rounded-md font-bold text-xs border-2 border-current ${PRESIDENT_RANK_BG[rank] ?? 'bg-ds-surface text-ds-text'}`}
+      className={`inline-block px-2 py-0.5 rounded-md font-bold text-xs border-2 border-current ${PRESIDENT_RANK_BG[rank] ?? 'bg-ds-surface text-ds-text-primary'}`}
     >
       {PRESIDENT_RANK_ICON[rank] ?? ''} {label}
     </motion.span>


### PR DESCRIPTION
## Summary
- When a player finishes a round in President, their plain text rank label is replaced by a stamp-style badge that springs in with rotation + scale, color-coded by rank (gold 👑 President, silver 🥈 VP, beige 🥉 vice-scum, red 🗑️ Scum).
- Sharpens the \"social mobility\" feel of the game without changing the underlying gameplay or layout.

## Implementation
- Inline \`RankStamp\` component uses Framer Motion (already a project dep) with a \`spring\` transition for the entrance.
- CPU and human rank readouts both consume \`RankStamp\` so the badge keeps re-mounting on each round.

## Test plan
- [x] \`bun run test -- --run src/pages/PresidentPage.test.tsx\`
- [x] \`bun run check\`

Closes #1938