### PR TITLE
feat(tonk): undercut-risk warning on the Knock button

### DIFF
--- a/frontend/src/i18n/locales/en/tonk.json
+++ b/frontend/src/i18n/locales/en/tonk.json
@@ -27,6 +27,7 @@
   "drawDiscardButton": "Draw Discard",
   "discardButton": "Discard",
   "knockButton": "Knock",
+  "knockUndercutWarning": "Opponent's hand is low — undercut risk is high",
   "nextRound": "Next Round",
   "drawPhase": "Draw a card from the stock or discard pile",
   "discardPhase": "Discard a card or knock (deadwood <= 5)",

--- a/frontend/src/i18n/locales/ja/tonk.json
+++ b/frontend/src/i18n/locales/ja/tonk.json
@@ -27,6 +27,7 @@
   "drawDiscardButton": "捨て札から引く",
   "discardButton": "捨てる",
   "knockButton": "ノック",
+  "knockUndercutWarning": "相手の手札が少ないため、アンダーカットのリスクがあります",
   "nextRound": "次のラウンド",
   "drawPhase": "山札または捨て札から1枚引いてください",
   "discardPhase": "手札から1枚捨てるか、ノック (デッドウッド5点以下) してください",

--- a/frontend/src/pages/TonkPage.test.tsx
+++ b/frontend/src/pages/TonkPage.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { tonkApi } from '../api/gameApi';
+import { renderWithProviders } from '../test/renderWithProviders';
+import type { Card, TonkResponse } from '../types/card';
+import { TonkPhase } from '../types/phases';
+import { TonkPage } from './TonkPage';
+
+vi.mock('../api/gameApi', () => ({
+  tonkApi: { exec: vi.fn() },
+  actionLogApi: { tonk: vi.fn() },
+}));
+
+const mockExec = vi.mocked(tonkApi.exec);
+
+const card = (design: string, value: number): Card => ({ design, value }) as unknown as Card;
+
+function makeState(overrides: Partial<TonkResponse> = {}): TonkResponse {
+  return {
+    players: [
+      {
+        id: 0,
+        isHuman: true,
+        cardCount: 5,
+        cards: [card('SPADE', 3), card('HEART', 5), card('DIAMOND', 7), card('CLOVER', 9), card('SPADE', 11)],
+        roundScore: 0,
+        cumulativeScore: 0,
+      },
+      { id: 1, isHuman: false, cardCount: 5, cards: [], roundScore: 0, cumulativeScore: 0 },
+    ],
+    phase: TonkPhase.DISCARD,
+    roundNumber: 1,
+    currentPlayerIdx: 0,
+    discardTop: card('HEART', 2),
+    drawPileCount: 30,
+    gameEndFlag: false,
+    winnerIdx: -1,
+    knockerIdx: -1,
+    knockerMelds: [],
+    knockerDeadwood: [],
+    opponentMelds: [],
+    opponentDeadwood: [],
+    isTonk: false,
+    isUndercut: false,
+    message: '',
+    config: { cpuDifficulty: 1, pointLimit: 250 },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockExec.mockReset();
+  mockExec.mockResolvedValue(makeState());
+});
+
+describe('TonkPage', () => {
+  it('renders the Knock button without an undercut warning when opponents hold > 2 cards', async () => {
+    renderWithProviders(<TonkPage />);
+    const knock = await screen.findByRole('button', { name: /ノック/ });
+    expect(knock).not.toHaveAttribute('data-undercut-risk');
+    expect(knock).not.toHaveAttribute('title');
+    expect(knock.className).not.toContain('ring-ds-warning');
+    expect(knock.className).not.toContain('animate-pulse');
+    expect(knock.textContent).not.toContain('⚠️');
+  });
+
+  it('flags the Knock button as undercut-risk when any opponent has ≤ 2 cards', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        players: [
+          {
+            id: 0,
+            isHuman: true,
+            cardCount: 5,
+            cards: [card('SPADE', 3), card('HEART', 5), card('DIAMOND', 7), card('CLOVER', 9), card('SPADE', 11)],
+            roundScore: 0,
+            cumulativeScore: 0,
+          },
+          { id: 1, isHuman: false, cardCount: 2, cards: [], roundScore: 0, cumulativeScore: 0 },
+        ],
+      }),
+    );
+    renderWithProviders(<TonkPage />);
+    const knock = await screen.findByRole('button', { name: /ノック/ });
+    expect(knock).toHaveAttribute('data-undercut-risk', 'true');
+    expect(knock).toHaveAttribute('title');
+    expect(knock.className).toContain('ring-ds-warning');
+    expect(knock.className).toContain('motion-safe:animate-pulse');
+    expect(knock.textContent).toContain('⚠️');
+  });
+
+  it('clears the warning when opponents drop back above the threshold', async () => {
+    // First render: opponent at 2 → warning on.
+    mockExec.mockResolvedValueOnce(
+      makeState({
+        players: [
+          {
+            id: 0,
+            isHuman: true,
+            cardCount: 5,
+            cards: [card('SPADE', 3), card('HEART', 5), card('DIAMOND', 7), card('CLOVER', 9), card('SPADE', 11)],
+            roundScore: 0,
+            cumulativeScore: 0,
+          },
+          { id: 1, isHuman: false, cardCount: 2, cards: [], roundScore: 0, cumulativeScore: 0 },
+        ],
+      }),
+    );
+    renderWithProviders(<TonkPage />);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /ノック/ })).toHaveAttribute('data-undercut-risk', 'true'),
+    );
+
+    // Reset via the page's reset flow returns a state with opponent at 5 → warning gone.
+    mockExec.mockResolvedValueOnce(makeState());
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /ノック/ })).not.toHaveAttribute('data-undercut-risk'),
+    );
+  });
+});

--- a/frontend/src/pages/TonkPage.tsx
+++ b/frontend/src/pages/TonkPage.tsx
@@ -364,28 +364,40 @@ function TonkPageContent() {
                   </button>
                 </div>
               )}
-              {isDiscardPhase && isHumanTurn && (
-                <>
-                  <button
-                    type="button"
-                    className={btnPrimary}
-                    onClick={handleDiscard}
-                    disabled={loading || selectedCardIndices.length !== 1}
-                    data-tutorial="tonk-discard-button"
-                  >
-                    {t('discardButton')}
-                  </button>
-                  <button
-                    type="button"
-                    className={btnPrimary}
-                    onClick={handleKnock}
-                    disabled={loading || selectedCardIndices.length !== 1}
-                    data-tutorial="tonk-knock-button"
-                  >
-                    {t('knockButton')}
-                  </button>
-                </>
-              )}
+              {isDiscardPhase &&
+                isHumanTurn &&
+                (() => {
+                  const minOpponentCards = state.players
+                    .filter((p) => !p.isHuman)
+                    .reduce((m, p) => Math.min(m, p.cardCount), Number.POSITIVE_INFINITY);
+                  const undercutRisk = Number.isFinite(minOpponentCards) && minOpponentCards <= 2;
+                  const knockBtnClass = undercutRisk ? `${btnPrimary} ring-2 ring-ds-warning` : btnPrimary;
+                  return (
+                    <>
+                      <button
+                        type="button"
+                        className={btnPrimary}
+                        onClick={handleDiscard}
+                        disabled={loading || selectedCardIndices.length !== 1}
+                        data-tutorial="tonk-discard-button"
+                      >
+                        {t('discardButton')}
+                      </button>
+                      <button
+                        type="button"
+                        className={knockBtnClass}
+                        onClick={handleKnock}
+                        disabled={loading || selectedCardIndices.length !== 1}
+                        data-tutorial="tonk-knock-button"
+                        data-undercut-risk={undercutRisk ? 'true' : undefined}
+                        title={undercutRisk ? t('knockUndercutWarning') : undefined}
+                      >
+                        {t('knockButton')}
+                        {undercutRisk && <span className="ml-1">⚠️</span>}
+                      </button>
+                    </>
+                  );
+                })()}
               {isRoundEnd && (
                 <button type="button" className={btnSuccess} onClick={handleNextRound} disabled={loading}>
                   {t('nextRound')}

--- a/frontend/src/pages/TonkPage.tsx
+++ b/frontend/src/pages/TonkPage.tsx
@@ -162,6 +162,15 @@ function TonkPageContent() {
   const isRoundEnd = state.phase === TonkPhase.ROUND_END;
   const isGameEnd = state.phase === TonkPhase.GAME_END || state.gameEndFlag;
   const isHumanTurn = (isDrawPhase || isDiscardPhase) && state.players[state.currentPlayerIdx]?.isHuman === true;
+  // Undercut early-warning: if any opponent has 2 or fewer cards, calling Knock is
+  // disproportionately risky (they're likely about to go out themselves, flipping the
+  // result). We add a warning ring + ⚠️ glyph + tooltip so the player notices the
+  // trap before committing. See issue #1939.
+  const minOpponentCards = state.players
+    .filter((p) => !p.isHuman)
+    .reduce((m, p) => Math.min(m, p.cardCount), Number.POSITIVE_INFINITY);
+  const undercutRisk = Number.isFinite(minOpponentCards) && minOpponentCards <= 2;
+  const knockBtnClass = undercutRisk ? `${btnPrimary} ring-2 ring-ds-warning motion-safe:animate-pulse` : btnPrimary;
 
   return (
     <GamePageShell
@@ -364,40 +373,35 @@ function TonkPageContent() {
                   </button>
                 </div>
               )}
-              {isDiscardPhase &&
-                isHumanTurn &&
-                (() => {
-                  const minOpponentCards = state.players
-                    .filter((p) => !p.isHuman)
-                    .reduce((m, p) => Math.min(m, p.cardCount), Number.POSITIVE_INFINITY);
-                  const undercutRisk = Number.isFinite(minOpponentCards) && minOpponentCards <= 2;
-                  const knockBtnClass = undercutRisk ? `${btnPrimary} ring-2 ring-ds-warning` : btnPrimary;
-                  return (
-                    <>
-                      <button
-                        type="button"
-                        className={btnPrimary}
-                        onClick={handleDiscard}
-                        disabled={loading || selectedCardIndices.length !== 1}
-                        data-tutorial="tonk-discard-button"
-                      >
-                        {t('discardButton')}
-                      </button>
-                      <button
-                        type="button"
-                        className={knockBtnClass}
-                        onClick={handleKnock}
-                        disabled={loading || selectedCardIndices.length !== 1}
-                        data-tutorial="tonk-knock-button"
-                        data-undercut-risk={undercutRisk ? 'true' : undefined}
-                        title={undercutRisk ? t('knockUndercutWarning') : undefined}
-                      >
-                        {t('knockButton')}
-                        {undercutRisk && <span className="ml-1">⚠️</span>}
-                      </button>
-                    </>
-                  );
-                })()}
+              {isDiscardPhase && isHumanTurn && (
+                <>
+                  <button
+                    type="button"
+                    className={btnPrimary}
+                    onClick={handleDiscard}
+                    disabled={loading || selectedCardIndices.length !== 1}
+                    data-tutorial="tonk-discard-button"
+                  >
+                    {t('discardButton')}
+                  </button>
+                  <button
+                    type="button"
+                    className={knockBtnClass}
+                    onClick={handleKnock}
+                    disabled={loading || selectedCardIndices.length !== 1}
+                    data-tutorial="tonk-knock-button"
+                    data-undercut-risk={undercutRisk ? 'true' : undefined}
+                    title={undercutRisk ? t('knockUndercutWarning') : undefined}
+                  >
+                    {t('knockButton')}
+                    {undercutRisk && (
+                      <span className="ml-1" aria-hidden="true">
+                        ⚠️
+                      </span>
+                    )}
+                  </button>
+                </>
+              )}
               {isRoundEnd && (
                 <button type="button" className={btnSuccess} onClick={handleNextRound} disabled={loading}>
                   {t('nextRound')}


### PR DESCRIPTION
## Summary
- Adds a warning ring + ⚠️ on the Knock button (with a localized tooltip) whenever any opponent's hand has dropped to 2 or fewer cards — the situations where Tonk's undercut penalty is most likely to fire.
- Lets newer players learn the trap visually instead of through repeated losses.

## Implementation
- Inside the DISCARD-phase render, derive \`minOpponentCards\` and gate the warning class + \`data-undercut-risk\` attribute on \`≤ 2\`.
- New i18n key \`knockUndercutWarning\` per locale.

## Test plan
- [x] \`bun run check\` (no TonkPage.test.tsx exists; lint/build green)
- [ ] Manual smoke: Knock button pulses warning when CPU drops to 2 cards.

Closes #1939