### PR TITLE
feat(shortdeck): persistent flush>fullhouse reminder badge

### DIFF
--- a/frontend/src/i18n/locales/en/shortdeck.json
+++ b/frontend/src/i18n/locales/en/shortdeck.json
@@ -10,6 +10,7 @@
     "rebuy": "Rebuy/Addon"
   },
   "communityCards": "Community Cards",
+  "rankOverrideReminder": "Short Deck special rule: Flush beats Full House",
   "yourHand": "Your Hand",
   "handNumber": "Hand #{{count}} (Level up: every {{level}} hands)",
   "rebuy": {

--- a/frontend/src/i18n/locales/ja/shortdeck.json
+++ b/frontend/src/i18n/locales/ja/shortdeck.json
@@ -10,6 +10,7 @@
     "rebuy": "リバイ/アドオン"
   },
   "communityCards": "コミュニティカード",
+  "rankOverrideReminder": "ショートデック特殊ルール：フラッシュ > フルハウス",
   "yourHand": "あなたの手札",
   "handNumber": "ハンド#{{count}} (レベルアップ:{{level}}ハンド毎)",
   "rebuy": {

--- a/frontend/src/pages/ShortDeckPage.test.tsx
+++ b/frontend/src/pages/ShortDeckPage.test.tsx
@@ -1120,4 +1120,18 @@ describe('ShortDeckPage', () => {
     const settingsSummary = Array.from(allSummaries).find((s) => s.textContent?.includes('設定'));
     expect(settingsSummary).toBeTruthy();
   });
+
+  it('renders the Flush > Full House rule reminder chip near the community cards', async () => {
+    mockExec.mockResolvedValue(preFlopState);
+    renderWithProviders(<ShortDeckPage />);
+    const chip = await screen.findByTestId('shortdeck-rank-watermark');
+    expect(chip).toBeInTheDocument();
+    expect(chip.textContent).toContain('Flush');
+    expect(chip.textContent).toContain('Full House');
+    // Uses the design-system warning state-badge tokens, not opacity-modified ones.
+    expect(chip.className).toContain('border-ds-warning');
+    expect(chip.className).toContain('text-ds-warning');
+    expect(chip.className).not.toContain('bg-ds-warning/');
+    expect(chip.className).not.toContain('border-ds-warning/');
+  });
 });

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -248,7 +248,16 @@ function ShortDeckPageContent() {
             {(() => {
               const communityCardsContent = (
                 <>
-                  <div className="text-ds-text-primary text-lg mb-1.5">{t('communityCards')}</div>
+                  <div className="text-ds-text-primary text-lg mb-1.5 flex items-center gap-2 flex-wrap">
+                    <span>{t('communityCards')}</span>
+                    <span
+                      data-testid="shortdeck-rank-watermark"
+                      className="px-1.5 py-0.5 rounded text-[10px] uppercase tracking-wider bg-ds-warning/20 text-ds-warning border border-ds-warning/60"
+                      title={t('rankOverrideReminder')}
+                    >
+                      ♣♠♥♦ Flush &gt; Full House
+                    </span>
+                  </div>
                   <div className="flex flex-wrap gap-2">
                     {state?.communityCards?.length
                       ? state.communityCards.map((card) => (

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -32,6 +32,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
+import { badgeWarning } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { placeholderCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
@@ -250,9 +251,13 @@ function ShortDeckPageContent() {
                 <>
                   <div className="text-ds-text-primary text-lg mb-1.5 flex items-center gap-2 flex-wrap">
                     <span>{t('communityCards')}</span>
+                    {/* Use the project's badgeWarning state-token style so the contrast ratios
+                        in DESIGN.md hold on the green poker felt — mixing the warning token with
+                        Tailwind opacity suffixes silently breaks WCAG AA. The size overrides shadow
+                        the default px/py/text-size for a compact in-line chip. */}
                     <span
                       data-testid="shortdeck-rank-watermark"
-                      className="px-1.5 py-0.5 rounded text-[10px] uppercase tracking-wider bg-ds-warning/20 text-ds-warning border border-ds-warning/60"
+                      className={`${badgeWarning} px-2 py-0.5 text-[11px] uppercase tracking-wider`}
                       title={t('rankOverrideReminder')}
                     >
                       ♣♠♥♦ Flush &gt; Full House


### PR DESCRIPTION
## Summary
- Adds a small warning-color chip next to the \"Community Cards\" header that always reads \"♣♠♥♦ Flush > Full House\" — a permanent reminder of Short Deck's hand-rank reversal so players coming from standard Hold'em don't shove a full house against an obvious flush.

## Implementation
- Inline chip + \`title\` tooltip; localized via new \`rankOverrideReminder\` key (ja/en).
- Lives inside the shared \`communityCardsContent\` so both the desktop \`PokerTableLayout\` and the mobile sticky header pick it up.

## Test plan
- [x] \`bun run test -- --run src/pages/ShortDeckPage.test.tsx\`
- [x] \`bun run check\`

Closes #1940