### PR TITLE
feat(war): visual face-down pot stack during a war chain

### DIFF
--- a/frontend/src/pages/WarPage.test.tsx
+++ b/frontend/src/pages/WarPage.test.tsx
@@ -142,4 +142,31 @@ describe('WarPage', () => {
     renderWithProviders(<WarPage />);
     await waitFor(() => expect(screen.queryByTestId('step-button')).not.toBeInTheDocument());
   });
+
+  it('does not render the pot stack when warPotSize is 2 or fewer', async () => {
+    // warPhaseState carries warPotSize: 2 — the visual stack only appears when burial cards push
+    // the pot past the initial tied pair (> 2).
+    mockExec.mockResolvedValueOnce(warPhaseState);
+    renderWithProviders(<WarPage />);
+    await waitFor(() => expect(screen.getByTestId('step-button')).toBeInTheDocument());
+    expect(screen.queryByTestId('war-pot-stack')).not.toBeInTheDocument();
+  });
+
+  it('renders the pot stack with data-pot-size matching warPotSize when > 2', async () => {
+    mockExec.mockResolvedValueOnce({ ...warPhaseState, warPotSize: 4 });
+    renderWithProviders(<WarPage />);
+    const stack = await screen.findByTestId('war-pot-stack');
+    expect(stack).toHaveAttribute('data-pot-size', '4');
+    // 4 cards → 4 face-down placeholders inside the stack.
+    expect(stack.querySelectorAll('[data-testid="animated-card-back"]')).toHaveLength(4);
+  });
+
+  it('caps the visual pot stack at 10 cards even when warPotSize is larger', async () => {
+    mockExec.mockResolvedValueOnce({ ...warPhaseState, warPotSize: 15 });
+    renderWithProviders(<WarPage />);
+    const stack = await screen.findByTestId('war-pot-stack');
+    expect(stack).toHaveAttribute('data-pot-size', '15');
+    // The render cap keeps the layout stable on long war chains.
+    expect(stack.querySelectorAll('[data-testid="animated-card-back"]')).toHaveLength(10);
+  });
 });

--- a/frontend/src/pages/WarPage.tsx
+++ b/frontend/src/pages/WarPage.tsx
@@ -196,6 +196,27 @@ function WarPageContent() {
                 <div className="text-sm text-ds-text-primary font-semibold">
                   {t('label.potCount', { count: state.warPotSize })}
                 </div>
+                {state.warPotSize > 2 && (
+                  <div
+                    className="relative mx-auto mt-1"
+                    data-testid="war-pot-stack"
+                    data-pot-size={state.warPotSize}
+                    style={{
+                      width: cardWidth * 0.6,
+                      height: cardWidth * 0.6 * 1.4 + Math.min(state.warPotSize, 10) * 2,
+                    }}
+                  >
+                    {Array.from({ length: Math.min(state.warPotSize, 10) }, (_, i) => (
+                      <div
+                        key={i}
+                        className="absolute left-0 top-0"
+                        style={{ transform: `translate(${i * 1.5}px, ${i * 2}px)` }}
+                      >
+                        <AnimatedCardBack width={cardWidth * 0.6} />
+                      </div>
+                    ))}
+                  </div>
+                )}
                 <div className="text-xs text-ds-text-muted mt-1">
                   {t('label.rounds')}: {state.roundsPlayed} / {state.config.maxRounds}
                 </div>


### PR DESCRIPTION
## Summary
- When a War triggers (pot > 2 cards), the central arena now renders a stacked offset of face-down cards beneath the pot counter so players feel the thickness of what's being fought over, not just a number.
- Caps the visible stack at 10 cards so the layout stays tidy on long war chains.

## Implementation
- Adds a small absolutely-positioned stack of \`AnimatedCardBack\` next to the existing \`Pot: N\` label.
- Honors \`data-pot-size\` for testing/inspection.

## Test plan
- [x] \`bun run test -- --run src/pages/WarPage.test.tsx\`
- [x] \`bun run check\`

Closes #1941