### PR TITLE
feat(clocksolitaire): pulse destination pile while a card waits

### DIFF
--- a/frontend/src/pages/ClockSolitairePage.test.tsx
+++ b/frontend/src/pages/ClockSolitairePage.test.tsx
@@ -157,4 +157,51 @@ describe('ClockSolitairePage', () => {
     });
     expect(screen.queryByText('手持ちカード')).not.toBeInTheDocument();
   });
+
+  // Helper: the CLI-mode test above leaves `mockUseCliMode` returning `cliEnabled: true`
+  // because vi.clearAllMocks() only clears call history, not the implementation. Restore
+  // the default cliEnabled: false at the top of each remaining test so the clock face renders.
+  const restoreCliModeDefault = (): void => {
+    mockUseCliMode.mockReturnValue({
+      cliEnabled: false,
+      toggleCli: vi.fn(),
+      logEntries: [],
+      addInput: vi.fn(),
+      addOutput: vi.fn(),
+      addError: vi.fn(),
+      clearLog: vi.fn(),
+    });
+  };
+
+  it('marks the matching hour pile as the flight target while a 1-12 card is waiting', async () => {
+    restoreCliModeDefault();
+    // playingState already has currentCard = ♠5, so the 5 o'clock pile (index 4) should be the
+    // single flight target. Other piles must not carry the data attribute.
+    renderWithProviders(<ClockSolitairePage />);
+    await waitFor(() => expect(screen.getByText(/ステップ数/)).toBeInTheDocument());
+    const targets = document.querySelectorAll('[data-flight-target="true"]');
+    expect(targets).toHaveLength(1);
+    const target = targets[0] as HTMLElement;
+    expect(target.className).toContain('ring-ds-warning');
+    expect(target.className).toContain('animate-pulse');
+  });
+
+  it('marks the center K pile as the flight target when a King is waiting', async () => {
+    restoreCliModeDefault();
+    mockExec.mockResolvedValue({ ...playingState, currentCard: card('SPADE', 13) });
+    renderWithProviders(<ClockSolitairePage />);
+    await waitFor(() => expect(screen.getByText(/ステップ数/)).toBeInTheDocument());
+    const targets = document.querySelectorAll('[data-flight-target="true"]');
+    // Only the center K pile should match for value=13.
+    expect(targets).toHaveLength(1);
+    expect((targets[0] as HTMLElement).className).toContain('ring-ds-warning');
+  });
+
+  it('renders no flight target when there is no card awaiting placement', async () => {
+    restoreCliModeDefault();
+    mockExec.mockResolvedValue({ ...playingState, currentCard: undefined });
+    renderWithProviders(<ClockSolitairePage />);
+    await waitFor(() => expect(screen.getByText(/ステップ数/)).toBeInTheDocument());
+    expect(document.querySelectorAll('[data-flight-target="true"]')).toHaveLength(0);
+  });
 });

--- a/frontend/src/pages/ClockSolitairePage.tsx
+++ b/frontend/src/pages/ClockSolitairePage.tsx
@@ -174,58 +174,63 @@ function ClockSolitairePageContent() {
               className="relative mx-auto"
               style={{ width: radius * 2 + cardWidth + 16, height: radius * 2 + cardHeight + 16 }}
             >
-              {/* 12 clock positions */}
-              {CLOCK_POSITIONS.map((pos, i) => {
-                const pile = state.piles[i];
-                const faceUpCount = state.faceUpCount[i];
-                const isComplete = faceUpCount >= 4;
-                const topCard = pile?.[pile.length - 1]?.card ?? null;
-                const cx = radius + cardWidth / 2 + 8 + pos.x * radius;
-                const cy = radius + cardHeight / 2 + 8 + pos.y * radius;
+              {/* Map the waiting card to its destination pile index once per render:
+                  values 1..12 land on the matching hour (index 0..11) and a King (13) lands
+                  on the center pile (index 12). When no card is waiting we use -1 so no pile
+                  matches. */}
+              {(() => {
                 const currentValue = state.currentCard?.value ?? 0;
                 const targetIdx =
                   currentValue >= 1 && currentValue <= 12 ? currentValue - 1 : currentValue === 13 ? 12 : -1;
-                const isFlightTarget = targetIdx === i;
+                return CLOCK_POSITIONS.map((pos, i) => {
+                  const pile = state.piles[i];
+                  const faceUpCount = state.faceUpCount[i];
+                  const isComplete = faceUpCount >= 4;
+                  const topCard = pile?.[pile.length - 1]?.card ?? null;
+                  const cx = radius + cardWidth / 2 + 8 + pos.x * radius;
+                  const cy = radius + cardHeight / 2 + 8 + pos.y * radius;
+                  const isFlightTarget = targetIdx === i;
 
-                return (
-                  <div
-                    key={i}
-                    className="absolute flex flex-col items-center"
-                    style={{
-                      left: cx - cardWidth / 2,
-                      top: cy - cardHeight / 2,
-                      width: cardWidth,
-                    }}
-                  >
-                    <span className="mb-0.5 text-xs font-bold text-ds-text-muted">{CLOCK_LABELS[i]}</span>
-                    {pile && pile.length > 0 ? (
-                      <div
-                        className={`relative rounded ${isFlightTarget ? 'ring-2 ring-ds-warning animate-pulse' : ''}`}
-                        data-flight-target={isFlightTarget ? 'true' : undefined}
-                        style={{ width: cardWidth }}
-                      >
-                        {isComplete && topCard ? (
-                          <AnimatedCard
-                            card={topCard}
-                            width={cardWidth}
-                            className="rounded border-2 border-ds-success"
-                          />
-                        ) : (
-                          <AnimatedCardBack width={cardWidth} />
-                        )}
-                        <span className="absolute -bottom-4 left-1/2 -translate-x-1/2 text-[10px] text-ds-text-muted">
-                          {faceUpCount}/4
-                        </span>
-                      </div>
-                    ) : (
-                      <div
-                        className="rounded border border-dashed border-white/30"
-                        style={{ width: cardWidth, height: cardHeight }}
-                      />
-                    )}
-                  </div>
-                );
-              })}
+                  return (
+                    <div
+                      key={i}
+                      className="absolute flex flex-col items-center"
+                      style={{
+                        left: cx - cardWidth / 2,
+                        top: cy - cardHeight / 2,
+                        width: cardWidth,
+                      }}
+                    >
+                      <span className="mb-0.5 text-xs font-bold text-ds-text-muted">{CLOCK_LABELS[i]}</span>
+                      {pile && pile.length > 0 ? (
+                        <div
+                          className={`relative rounded ${isFlightTarget ? 'ring-2 ring-ds-warning animate-pulse' : ''}`}
+                          data-flight-target={isFlightTarget ? 'true' : undefined}
+                          style={{ width: cardWidth }}
+                        >
+                          {isComplete && topCard ? (
+                            <AnimatedCard
+                              card={topCard}
+                              width={cardWidth}
+                              className="rounded border-2 border-ds-success"
+                            />
+                          ) : (
+                            <AnimatedCardBack width={cardWidth} />
+                          )}
+                          <span className="absolute -bottom-4 left-1/2 -translate-x-1/2 text-[10px] text-ds-text-muted">
+                            {faceUpCount}/4
+                          </span>
+                        </div>
+                      ) : (
+                        <div
+                          className="rounded border border-dashed border-white/30"
+                          style={{ width: cardWidth, height: cardHeight }}
+                        />
+                      )}
+                    </div>
+                  );
+                });
+              })()}
 
               {/* Center pile (K) */}
               <div

--- a/frontend/src/pages/ClockSolitairePage.tsx
+++ b/frontend/src/pages/ClockSolitairePage.tsx
@@ -182,6 +182,10 @@ function ClockSolitairePageContent() {
                 const topCard = pile?.[pile.length - 1]?.card ?? null;
                 const cx = radius + cardWidth / 2 + 8 + pos.x * radius;
                 const cy = radius + cardHeight / 2 + 8 + pos.y * radius;
+                const currentValue = state.currentCard?.value ?? 0;
+                const targetIdx =
+                  currentValue >= 1 && currentValue <= 12 ? currentValue - 1 : currentValue === 13 ? 12 : -1;
+                const isFlightTarget = targetIdx === i;
 
                 return (
                   <div
@@ -195,7 +199,11 @@ function ClockSolitairePageContent() {
                   >
                     <span className="mb-0.5 text-xs font-bold text-ds-text-muted">{CLOCK_LABELS[i]}</span>
                     {pile && pile.length > 0 ? (
-                      <div className="relative" style={{ width: cardWidth }}>
+                      <div
+                        className={`relative rounded ${isFlightTarget ? 'ring-2 ring-ds-warning animate-pulse' : ''}`}
+                        data-flight-target={isFlightTarget ? 'true' : undefined}
+                        style={{ width: cardWidth }}
+                      >
                         {isComplete && topCard ? (
                           <AnimatedCard
                             card={topCard}
@@ -233,8 +241,13 @@ function ClockSolitairePageContent() {
                 {(() => {
                   const centerPile = state.piles[12];
                   const centerTopCard = centerPile?.[centerPile.length - 1]?.card ?? null;
+                  const isCenterFlightTarget = state.currentCard?.value === 13;
                   return centerPile && centerPile.length > 0 ? (
-                    <div className="relative" style={{ width: cardWidth }}>
+                    <div
+                      className={`relative rounded ${isCenterFlightTarget ? 'ring-2 ring-ds-warning animate-pulse' : ''}`}
+                      data-flight-target={isCenterFlightTarget ? 'true' : undefined}
+                      style={{ width: cardWidth }}
+                    >
                       {state.faceUpCount[12] >= 4 && centerTopCard ? (
                         <AnimatedCard
                           card={centerTopCard}


### PR DESCRIPTION
## Summary
- Whenever \`currentCard\` is set (a card is awaiting its hour), the matching clock pile pulses with a warning ring so the player sees where the next Step will land.
- The center K pile gets the same affordance when the awaiting card is a King.

## Implementation
- Map \`currentCard.value\` → pile index (1..12 → outer pos, 13 → center).
- Apply \`ring-2 ring-ds-warning animate-pulse\` + \`data-flight-target\` to the matching pile container.

## Test plan
- [x] \`bun run test -- --run src/pages/ClockSolitairePage.test.tsx\`
- [x] \`bun run check\`

Closes #1942