### PR TITLE
feat(solitaire): announce auto-complete ready transition on Klondike/Spider

### DIFF
--- a/frontend/src/components/AutoCompleteReadyBadge.test.tsx
+++ b/frontend/src/components/AutoCompleteReadyBadge.test.tsx
@@ -1,0 +1,58 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AutoCompleteReadyBadge } from './AutoCompleteReadyBadge';
+
+describe('AutoCompleteReadyBadge', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders nothing when ready is false', () => {
+    render(<AutoCompleteReadyBadge ready={false} />);
+    expect(screen.queryByTestId('autocomplete-ready-badge')).not.toBeInTheDocument();
+  });
+
+  it('appears on initial mount when ready=true (e.g., resuming a ready game)', () => {
+    render(<AutoCompleteReadyBadge ready={true} />);
+    expect(screen.getByTestId('autocomplete-ready-badge')).toBeInTheDocument();
+  });
+
+  it('appears when ready transitions from false to true', () => {
+    const { rerender } = render(<AutoCompleteReadyBadge ready={false} />);
+    expect(screen.queryByTestId('autocomplete-ready-badge')).not.toBeInTheDocument();
+
+    rerender(<AutoCompleteReadyBadge ready={true} />);
+    expect(screen.getByTestId('autocomplete-ready-badge')).toBeInTheDocument();
+    expect(screen.getByTestId('autocomplete-ready-badge')).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('auto-dismisses after the show timeout', () => {
+    const { rerender } = render(<AutoCompleteReadyBadge ready={false} />);
+    rerender(<AutoCompleteReadyBadge ready={true} />);
+    expect(screen.getByTestId('autocomplete-ready-badge')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.queryByTestId('autocomplete-ready-badge')).not.toBeInTheDocument();
+  });
+
+  it('hides immediately when ready becomes false again', () => {
+    const { rerender } = render(<AutoCompleteReadyBadge ready={false} />);
+    rerender(<AutoCompleteReadyBadge ready={true} />);
+    expect(screen.getByTestId('autocomplete-ready-badge')).toBeInTheDocument();
+
+    rerender(<AutoCompleteReadyBadge ready={false} />);
+    expect(screen.queryByTestId('autocomplete-ready-badge')).not.toBeInTheDocument();
+  });
+
+  it('honors a custom testId', () => {
+    const { rerender } = render(<AutoCompleteReadyBadge ready={false} testId="custom-id" />);
+    rerender(<AutoCompleteReadyBadge ready={true} testId="custom-id" />);
+    expect(screen.getByTestId('custom-id')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/AutoCompleteReadyBadge.tsx
+++ b/frontend/src/components/AutoCompleteReadyBadge.tsx
@@ -39,7 +39,6 @@ export function AutoCompleteReadyBadge({ ready, testId }: AutoCompleteReadyBadge
 
   return (
     <output
-      role="status"
       aria-live="polite"
       data-testid={testId ?? 'autocomplete-ready-badge'}
       className="inline-flex items-center gap-1 rounded-full bg-ds-success/20 px-2 py-0.5 text-xs font-semibold text-ds-success animate-pulse"

--- a/frontend/src/components/AutoCompleteReadyBadge.tsx
+++ b/frontend/src/components/AutoCompleteReadyBadge.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+/** Props for the AutoCompleteReadyBadge component. */
+export interface AutoCompleteReadyBadgeProps {
+  /** Whether the auto-complete action is currently available. */
+  ready: boolean;
+  /** Optional test id forwarded to the rendered badge. */
+  testId?: string;
+}
+
+const SHOW_MS = 4000;
+
+/**
+ * Small badge that briefly appears when an auto-complete action becomes available.
+ * Renders an aria-live="polite" status so screen readers announce the transition,
+ * and auto-dismisses after a few seconds.
+ */
+export function AutoCompleteReadyBadge({ ready, testId }: AutoCompleteReadyBadgeProps) {
+  const { t } = useTranslation('common');
+  const [visible, setVisible] = useState(false);
+  const prevReady = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    if (ready && !prevReady.current) {
+      setVisible(true);
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setVisible(false), SHOW_MS);
+    } else if (!ready) {
+      setVisible(false);
+      clearTimeout(timerRef.current);
+    }
+    prevReady.current = ready;
+    return () => clearTimeout(timerRef.current);
+  }, [ready]);
+
+  if (!visible) return null;
+
+  return (
+    <output
+      role="status"
+      aria-live="polite"
+      data-testid={testId ?? 'autocomplete-ready-badge'}
+      className="inline-flex items-center gap-1 rounded-full bg-ds-success/20 px-2 py-0.5 text-xs font-semibold text-ds-success animate-pulse"
+    >
+      <span aria-hidden="true">✨</span>
+      {t('button.autoCompleteReady')}
+    </output>
+  );
+}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -183,7 +183,8 @@
     "hint": "Hint",
     "retry": "Retry",
     "dismiss": "Dismiss",
-    "score": "Score"
+    "score": "Score",
+    "autoCompleteReady": "Auto-complete ready!"
   },
   "roundScoreAnnouncement": {
     "message": "Round complete. {{details}}",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -183,7 +183,8 @@
     "hint": "ヒント",
     "retry": "再試行",
     "dismiss": "閉じる",
-    "score": "スコア"
+    "score": "スコア",
+    "autoCompleteReady": "オートコンプリート可能！"
   },
   "roundScoreAnnouncement": {
     "message": "ラウンド終了。{{details}}",

--- a/frontend/src/pages/KlondikePage.tsx
+++ b/frontend/src/pages/KlondikePage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import type { KlondikeMoveZone, klondikeApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
+import { AutoCompleteReadyBadge } from '../components/AutoCompleteReadyBadge';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
@@ -570,6 +571,7 @@ function KlondikePageContent() {
                   >
                     {t('autoComplete')}
                   </button>
+                  <AutoCompleteReadyBadge ready={autoCompleteReady} />
                   <button
                     type="button"
                     className={btnDanger}

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import type { SpiderMoveZone, spiderApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
+import { AutoCompleteReadyBadge } from '../components/AutoCompleteReadyBadge';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
@@ -449,6 +450,7 @@ function SpiderPageContent() {
                   >
                     {t('autoComplete')}
                   </button>
+                  <AutoCompleteReadyBadge ready={autoCompleteReady} />
                   <button
                     type="button"
                     className={btnDanger}


### PR DESCRIPTION
## Summary
- New \`AutoCompleteReadyBadge\` component pops a one-shot \`aria-live=\"polite\"\` status + visible sparkle pill when \`canAutoComplete\` transitions from false to true.
- Wired into \`KlondikePage\` and \`SpiderPage\` alongside the existing pulsing button so the affordance is both audible (SR) and visible (eye nudge).
- Auto-dismisses after 4s; hides immediately if the ready state flips back to false.

## Implementation
- \`useEffect\` on \`ready\` prop drives a one-shot reveal via \`setVisible(true)\` + \`setTimeout\`.
- New i18n key \`button.autoCompleteReady\` (ja/en) under common namespace.

## Test plan
- [x] \`bun run test -- --run src/components/AutoCompleteReadyBadge.test.tsx\` (6 cases: mount, transition, auto-dismiss, hide-on-reset, testId)
- [x] \`bun run test -- --run src/pages/KlondikePage.test.tsx src/pages/SpiderPage.test.tsx\` (136 existing tests still pass)
- [ ] tsc / build verified by CI (local OOMs on 2 GB RAM box)

Closes #1943