### PR TITLE
feat(napoleon,mighty): partner-reveal flash overlay

### DIFF
--- a/frontend/src/components/PartnerRevealFlash.test.tsx
+++ b/frontend/src/components/PartnerRevealFlash.test.tsx
@@ -1,0 +1,48 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PartnerRevealFlash } from './PartnerRevealFlash';
+
+describe('PartnerRevealFlash', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders nothing when revealed is false', () => {
+    render(<PartnerRevealFlash revealed={false} partnerName="P2" headline="Adjutant!" />);
+    expect(screen.queryByTestId('partner-reveal-flash')).not.toBeInTheDocument();
+  });
+
+  it('appears when revealed transitions from false to true', () => {
+    const { rerender } = render(<PartnerRevealFlash revealed={false} partnerName="P2" headline="Adjutant!" />);
+    rerender(<PartnerRevealFlash revealed={true} partnerName="P2" headline="Adjutant!" />);
+    expect(screen.getByTestId('partner-reveal-flash')).toBeInTheDocument();
+    expect(screen.getByText('P2')).toBeInTheDocument();
+    expect(screen.getByText('Adjutant!')).toBeInTheDocument();
+  });
+
+  it('auto-dismisses after the flash timeout', () => {
+    const { rerender } = render(<PartnerRevealFlash revealed={false} partnerName="P2" headline="Adjutant!" />);
+    rerender(<PartnerRevealFlash revealed={true} partnerName="P2" headline="Adjutant!" />);
+    expect(screen.getByTestId('partner-reveal-flash')).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(screen.queryByTestId('partner-reveal-flash')).not.toBeInTheDocument();
+  });
+
+  it('re-arms when revealed flips back to false', () => {
+    const { rerender } = render(<PartnerRevealFlash revealed={false} partnerName="P2" headline="Adjutant!" />);
+    rerender(<PartnerRevealFlash revealed={true} partnerName="P2" headline="Adjutant!" />);
+    expect(screen.getByTestId('partner-reveal-flash')).toBeInTheDocument();
+
+    rerender(<PartnerRevealFlash revealed={false} partnerName="P2" headline="Adjutant!" />);
+    expect(screen.queryByTestId('partner-reveal-flash')).not.toBeInTheDocument();
+
+    rerender(<PartnerRevealFlash revealed={true} partnerName="P2" headline="Adjutant!" />);
+    expect(screen.getByTestId('partner-reveal-flash')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/PartnerRevealFlash.tsx
+++ b/frontend/src/components/PartnerRevealFlash.tsx
@@ -50,12 +50,12 @@ export function PartnerRevealFlash({ revealed, partnerName, headline, testId }: 
       data-testid={testId ?? 'partner-reveal-flash'}
       className="pointer-events-none fixed inset-0 z-50 flex items-center justify-center bg-black/55 motion-safe:animate-[fadeIn_0.2s_ease-out]"
     >
-      <div className="rounded-lg border-2 border-yellow-300 bg-yellow-500/20 px-6 py-4 text-center shadow-2xl motion-safe:animate-pulse">
+      <div className="rounded-lg border-2 border-ds-accent bg-ds-accent/20 px-6 py-4 text-center shadow-2xl motion-safe:animate-pulse">
         <div className="mb-1 text-2xl" aria-hidden="true">
           🛡️
         </div>
-        <div className="text-sm font-semibold text-yellow-100">{headline}</div>
-        <div className="mt-1 text-xl font-bold text-yellow-50">{partnerName}</div>
+        <div className="text-sm font-semibold text-ds-text-primary">{headline}</div>
+        <div className="mt-1 text-xl font-bold text-ds-accent">{partnerName}</div>
       </div>
     </div>
   );

--- a/frontend/src/components/PartnerRevealFlash.tsx
+++ b/frontend/src/components/PartnerRevealFlash.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from 'react';
+
+/** Props for the PartnerRevealFlash component. */
+export interface PartnerRevealFlashProps {
+  /**
+   * Whether the partner/adjutant has been revealed in the current round.
+   * The flash fires when this transitions from false to true; resetting back
+   * to false (e.g., next round) re-arms the trigger.
+   */
+  revealed: boolean;
+  /** Display name of the revealed partner. Used inside the announcement text. */
+  partnerName: string;
+  /** i18n-localized headline shown above the partner's name. */
+  headline: string;
+  /** Test id forwarded to the root element. */
+  testId?: string;
+}
+
+const FLASH_MS = 1800;
+
+/**
+ * Renders a one-shot full-screen flash + centered name plate when a hidden
+ * partner role is revealed (Napoleon's adjutant, Mighty's partner). Auto-
+ * dismisses after FLASH_MS milliseconds.
+ */
+export function PartnerRevealFlash({ revealed, partnerName, headline, testId }: PartnerRevealFlashProps) {
+  const [visible, setVisible] = useState(false);
+  const prevRevealed = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    if (revealed && !prevRevealed.current) {
+      setVisible(true);
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setVisible(false), FLASH_MS);
+    } else if (!revealed) {
+      setVisible(false);
+      clearTimeout(timerRef.current);
+    }
+    prevRevealed.current = revealed;
+    return () => clearTimeout(timerRef.current);
+  }, [revealed]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="assertive"
+      data-testid={testId ?? 'partner-reveal-flash'}
+      className="pointer-events-none fixed inset-0 z-50 flex items-center justify-center bg-black/55 motion-safe:animate-[fadeIn_0.2s_ease-out]"
+    >
+      <div className="rounded-lg border-2 border-yellow-300 bg-yellow-500/20 px-6 py-4 text-center shadow-2xl motion-safe:animate-pulse">
+        <div className="mb-1 text-2xl" aria-hidden="true">
+          🛡️
+        </div>
+        <div className="text-sm font-semibold text-yellow-100">{headline}</div>
+        <div className="mt-1 text-xl font-bold text-yellow-50">{partnerName}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/i18n/locales/en/mighty.json
+++ b/frontend/src/i18n/locales/en/mighty.json
@@ -40,7 +40,8 @@
   "role": {
     "declarer": "declarer",
     "partner": "partner",
-    "opposition": "opposition"
+    "opposition": "opposition",
+    "partnerRevealed": "Partner Revealed!"
   },
   "suitName": {
     "spade": "Spade",

--- a/frontend/src/i18n/locales/en/napoleon.json
+++ b/frontend/src/i18n/locales/en/napoleon.json
@@ -33,7 +33,8 @@
   "adjutantNone": "None",
   "role": {
     "napoleon": "Napoleon",
-    "adjutant": "Adjutant"
+    "adjutant": "Adjutant",
+    "adjutantRevealed": "Adjutant Revealed!"
   },
   "suitName": {
     "spade": "Spades",

--- a/frontend/src/i18n/locales/ja/mighty.json
+++ b/frontend/src/i18n/locales/ja/mighty.json
@@ -40,7 +40,8 @@
   "role": {
     "declarer": "宣言者",
     "partner": "パートナー",
-    "opposition": "野党"
+    "opposition": "野党",
+    "partnerRevealed": "パートナー判明！"
   },
   "suitName": {
     "spade": "スペード",

--- a/frontend/src/i18n/locales/ja/napoleon.json
+++ b/frontend/src/i18n/locales/ja/napoleon.json
@@ -33,7 +33,8 @@
   "adjutantNone": "なし",
   "role": {
     "napoleon": "ナポレオン",
-    "adjutant": "副官"
+    "adjutant": "副官",
+    "adjutantRevealed": "副官判明！"
   },
   "suitName": {
     "spade": "スペード",

--- a/frontend/src/pages/MightyPage.tsx
+++ b/frontend/src/pages/MightyPage.tsx
@@ -13,6 +13,7 @@ import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { MobileHandGrid } from '../components/MobileHandGrid';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
+import { PartnerRevealFlash } from '../components/PartnerRevealFlash';
 import { RoundScoreAnnouncement } from '../components/RoundScoreAnnouncement';
 import { ScrollFadeHint } from '../components/ScrollFadeHint';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
@@ -266,6 +267,15 @@ function MightyPageContent() {
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
         <>
+          <PartnerRevealFlash
+            revealed={state.partnerRevealed}
+            partnerName={
+              state.partnerIdx >= 0 && state.players[state.partnerIdx]
+                ? playerName(state.partnerIdx, state.players[state.partnerIdx].isHuman)
+                : ''
+            }
+            headline={t('role.partnerRevealed')}
+          />
           {/* Settings */}
           <SettingsPanel
             title={t('settings.title')}

--- a/frontend/src/pages/NapoleonPage.tsx
+++ b/frontend/src/pages/NapoleonPage.tsx
@@ -12,6 +12,7 @@ import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { MobileHandGrid } from '../components/MobileHandGrid';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
+import { PartnerRevealFlash } from '../components/PartnerRevealFlash';
 import { RoundScoreAnnouncement } from '../components/RoundScoreAnnouncement';
 import { ScrollFadeHint } from '../components/ScrollFadeHint';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
@@ -238,6 +239,15 @@ function NapoleonPageContent() {
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
         <>
+          <PartnerRevealFlash
+            revealed={state.adjutantRevealed}
+            partnerName={
+              state.adjutantIdx >= 0 && state.players[state.adjutantIdx]
+                ? playerName(state.adjutantIdx, state.players[state.adjutantIdx].isHuman)
+                : ''
+            }
+            headline={t('role.adjutantRevealed')}
+          />
           {/* Settings */}
           <SettingsPanel
             title={t('settings.title')}


### PR DESCRIPTION
## Summary
- New \`PartnerRevealFlash\` component pops a centered 🛡️ overlay with the partner's name when the hidden ally role transitions from concealed to revealed.
- Wired into NapoleonPage (\`adjutantRevealed\`) and MightyPage (\`partnerRevealed\`).
- Auto-dismisses after ~1.8s; re-arms when the flag flips back between rounds.

## Test plan
- [x] \`bun run test -- --run src/components/PartnerRevealFlash.test.tsx\` (mount, transition, auto-dismiss, re-arm)
- [x] \`bun run test -- --run src/pages/NapoleonPage.test.tsx src/pages/MightyPage.test.tsx\` (143 existing tests pass)
- [ ] tsc + build verified by CI

Closes #1945