### PR TITLE
feat(gaps): ghost hint inside empty cells

### DIFF
--- a/frontend/src/pages/GapsPage.tsx
+++ b/frontend/src/pages/GapsPage.tsx
@@ -184,7 +184,7 @@ function GapsPageContent() {
                           <span
                             aria-hidden="true"
                             data-testid={`gaps-ghost-${rIdx}-${cIdx}`}
-                            className={`text-base font-semibold opacity-30 ${RED_DESIGNS.has(ghost.design) ? 'text-red-400' : 'text-white'}`}
+                            className={`text-base font-semibold opacity-30 ${RED_DESIGNS.has(ghost.design) ? 'text-ds-error' : 'text-ds-text-primary'}`}
                           >
                             {SUIT_SYMBOLS[ghost.design]}
                             {valueName(ghost.value)}

--- a/frontend/src/pages/GapsPage.tsx
+++ b/frontend/src/pages/GapsPage.tsx
@@ -22,7 +22,17 @@ import { gameTheme } from '../styles/gameTheme';
 import { GapsPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { valueName } from '../utils/cardUtils';
+import { computeGapsGhostHint } from '../utils/gapsGhostHint';
 import { gapsLockedPrefixLengths } from '../utils/gapsUtils';
+
+const SUIT_SYMBOLS: Record<string, string> = {
+  SPADE: '♠',
+  HEART: '♥',
+  DIAMOND: '♦',
+  CLOVER: '♣',
+};
+const RED_DESIGNS = new Set(['HEART', 'DIAMOND']);
 
 const GAPS_TUTORIAL_STEPS: TutorialStep[] = [
   {
@@ -153,6 +163,7 @@ function GapsPageContent() {
                   const isHintFrom = state.hint && state.hint.fromRow === rIdx && state.hint.fromCol === cIdx;
                   const isHintTo = state.hint && state.hint.toRow === rIdx && state.hint.toCol === cIdx;
                   if (cell === null) {
+                    const ghost = computeGapsGhostHint(row, cIdx);
                     return (
                       <button
                         type="button"
@@ -161,14 +172,43 @@ function GapsPageContent() {
                         onDragLeave={dnd.handleDragLeave}
                         onDrop={dnd.handleDrop(zone)}
                         aria-label={t('gap')}
-                        className={`rounded border-2 ${
+                        className={`relative flex items-center justify-center rounded border-2 ${
                           dnd.isDropTarget(zone)
                             ? 'border-ds-warning bg-ds-warning/20'
                             : 'border-dashed border-white/30'
                         } ${isHintTo ? 'ring-2 ring-ds-warning' : ''} ${focusRingWhite}`}
                         style={{ width: cardWidth, height: cardHeight }}
                         disabled={!isPlaying || loading}
-                      />
+                      >
+                        {ghost?.kind === 'needed' && (
+                          <span
+                            aria-hidden="true"
+                            data-testid={`gaps-ghost-${rIdx}-${cIdx}`}
+                            className={`text-base font-semibold opacity-30 ${RED_DESIGNS.has(ghost.design) ? 'text-red-400' : 'text-white'}`}
+                          >
+                            {SUIT_SYMBOLS[ghost.design]}
+                            {valueName(ghost.value)}
+                          </span>
+                        )}
+                        {ghost?.kind === 'anySuit' && (
+                          <span
+                            aria-hidden="true"
+                            data-testid={`gaps-ghost-${rIdx}-${cIdx}`}
+                            className="text-base font-semibold text-white opacity-30"
+                          >
+                            {valueName(ghost.value)}
+                          </span>
+                        )}
+                        {ghost?.kind === 'blocked' && (
+                          <span
+                            aria-hidden="true"
+                            data-testid={`gaps-ghost-${rIdx}-${cIdx}-blocked`}
+                            className="text-xl opacity-40"
+                          >
+                            🚫
+                          </span>
+                        )}
+                      </button>
                     );
                   }
                   const isLocked = cIdx < lockedCount;

--- a/frontend/src/utils/gapsGhostHint.test.ts
+++ b/frontend/src/utils/gapsGhostHint.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { computeGapsGhostHint } from './gapsGhostHint';
+
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('computeGapsGhostHint', () => {
+  it('returns anySuit/2 for column 0', () => {
+    expect(computeGapsGhostHint([null, c('SPADE', 5)], 0)).toEqual({ kind: 'anySuit', value: 2 });
+  });
+
+  it('returns needed (left.suit, left.value + 1) for a normal gap', () => {
+    expect(computeGapsGhostHint([c('SPADE', 5), null], 1)).toEqual({
+      kind: 'needed',
+      design: 'SPADE',
+      value: 6,
+    });
+  });
+
+  it('returns blocked when the left neighbor is a King', () => {
+    expect(computeGapsGhostHint([c('HEART', 13), null], 1)).toEqual({ kind: 'blocked' });
+  });
+
+  it('returns null when the left neighbor is itself empty (chained gap)', () => {
+    expect(computeGapsGhostHint([null, null, c('CLOVER', 4)], 1)).toBeNull();
+  });
+
+  it('returns Q-then-K = needed K (value 13)', () => {
+    expect(computeGapsGhostHint([c('DIAMOND', 12), null], 1)).toEqual({
+      kind: 'needed',
+      design: 'DIAMOND',
+      value: 13,
+    });
+  });
+});

--- a/frontend/src/utils/gapsGhostHint.ts
+++ b/frontend/src/utils/gapsGhostHint.ts
@@ -1,0 +1,24 @@
+import type { Card, CardDesign } from '../types/card';
+
+/** Outcome of computing what should go into an empty Gaps cell. */
+export type GapsGhostHint =
+  | { kind: 'needed'; design: CardDesign; value: number }
+  | { kind: 'anySuit'; value: number }
+  | { kind: 'blocked' };
+
+/**
+ * Compute the ghost-card hint for an empty Gaps cell.
+ *
+ * Rules:
+ * - Column 0: any "2" of any suit may be placed → `anySuit` (value 2).
+ * - Left neighbor is a King (13): no card may be placed → `blocked`.
+ * - Left neighbor is a `null` (another gap): no determined hint → `null`.
+ * - Otherwise: the cell needs (leftSuit, leftValue + 1) → `needed`.
+ */
+export function computeGapsGhostHint(row: (Card | null)[], col: number): GapsGhostHint | null {
+  if (col === 0) return { kind: 'anySuit', value: 2 };
+  const leftCell = row[col - 1];
+  if (leftCell == null) return null;
+  if (leftCell.value === 13) return { kind: 'blocked' };
+  return { kind: 'needed', design: leftCell.design, value: leftCell.value + 1 };
+}


### PR DESCRIPTION
## Summary
- New \`computeGapsGhostHint(row, col)\` derives what should fill each Gaps empty cell from the row and column index.
- GapsPage paints the result inside each gap: low-opacity suited rank, plain rank-2 for column 0, or 🚫 when the left neighbor is a King.
- Red suits use a red tint to match standard playing-card semantics.

## Test plan
- [x] \`bun run test -- --run src/utils/gapsGhostHint.test.ts\` (5 cases incl. K-blocked + chained gap)
- [x] \`bun run test -- --run src/pages/GapsPage.test.tsx\` (14 existing tests still pass)
- [ ] tsc + build verified by CI

Closes #1946