### PR TITLE
feat(callbreak): segmented bid-progress bar per player

### DIFF
--- a/frontend/src/components/BidProgressBar.test.tsx
+++ b/frontend/src/components/BidProgressBar.test.tsx
@@ -35,6 +35,10 @@ describe('BidProgressBar', () => {
     expect(segments.length).toBe(1);
     expect(segments[0].className).toContain('bg-ds-error');
     expect(screen.queryByText(/^\+/)).not.toBeInTheDocument();
+    // aria-valuenow must match the visually-full red bar so screen readers
+    // don't report 0/1 while the eye sees a complete bar.
+    expect(bar).toHaveAttribute('aria-valuemax', '1');
+    expect(bar).toHaveAttribute('aria-valuenow', '1');
   });
 
   it('renders a blank single segment for an unbroken nil bid', () => {

--- a/frontend/src/components/BidProgressBar.test.tsx
+++ b/frontend/src/components/BidProgressBar.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { BidProgressBar } from './BidProgressBar';
+
+describe('BidProgressBar', () => {
+  it('renders nothing for unset (negative) bid', () => {
+    const { container } = render(<BidProgressBar bid={-1} tricksWon={0} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders one segment per bid', () => {
+    render(<BidProgressBar bid={4} tricksWon={1} testId="b" />);
+    const bar = screen.getByTestId('b');
+    expect(bar.querySelectorAll('[class*="rounded-sm"]').length).toBe(4);
+    expect(bar).toHaveAttribute('aria-valuemax', '4');
+    expect(bar).toHaveAttribute('aria-valuenow', '1');
+  });
+
+  it('fills all segments and tints success when bid is exactly met', () => {
+    render(<BidProgressBar bid={3} tricksWon={3} testId="b" />);
+    const bar = screen.getByTestId('b');
+    const segments = Array.from(bar.querySelectorAll('[class*="rounded-sm"]'));
+    expect(segments.every((s) => s.className.includes('bg-ds-success'))).toBe(true);
+  });
+
+  it('shows overtricks pill when tricksWon exceeds bid', () => {
+    render(<BidProgressBar bid={3} tricksWon={5} />);
+    expect(screen.getByText('+2')).toBeInTheDocument();
+  });
+
+  it('renders an error-tinted single segment for nil bid that has been broken', () => {
+    render(<BidProgressBar bid={0} tricksWon={1} testId="b" />);
+    const bar = screen.getByTestId('b');
+    const segments = Array.from(bar.querySelectorAll('[class*="rounded-sm"]'));
+    expect(segments.length).toBe(1);
+    expect(segments[0].className).toContain('bg-ds-error');
+    expect(screen.queryByText(/^\+/)).not.toBeInTheDocument();
+  });
+
+  it('renders a blank single segment for an unbroken nil bid', () => {
+    render(<BidProgressBar bid={0} tricksWon={0} testId="b" />);
+    const bar = screen.getByTestId('b');
+    const segments = Array.from(bar.querySelectorAll('[class*="rounded-sm"]'));
+    expect(segments.length).toBe(1);
+    expect(segments[0].className).not.toContain('bg-ds-error');
+  });
+});

--- a/frontend/src/components/BidProgressBar.tsx
+++ b/frontend/src/components/BidProgressBar.tsx
@@ -1,0 +1,59 @@
+/** Props for the BidProgressBar component. */
+export interface BidProgressBarProps {
+  /** Bid amount declared by the player. Negative values render nothing. */
+  bid: number;
+  /** Tricks the player has actually won so far this round. */
+  tricksWon: number;
+  /** Test id for the outer container. */
+  testId?: string;
+  /** ARIA label for the progress bar. */
+  ariaLabel?: string;
+}
+
+/**
+ * Visualizes Call Break bid progress as a segmented bar. Each segment
+ * corresponds to one trick toward the bid. State tinting:
+ * - Yellow while under bid (working toward target),
+ * - Green when bid is exactly met,
+ * - Green + blue "+N" pill when over bid (overtricks add fractional score),
+ * - Red when bid is 0 and any trick is taken (auto-fail).
+ *
+ * Returns null for negative/unset bids.
+ */
+export function BidProgressBar({ bid, tricksWon, testId, ariaLabel }: BidProgressBarProps) {
+  if (bid < 0) return null;
+
+  const isNil = bid === 0;
+  const nilBroken = isNil && tricksWon > 0;
+  const filledSegments = isNil ? 0 : Math.min(bid, tricksWon);
+  const totalSegments = isNil ? 1 : bid;
+  const overTricks = isNil ? tricksWon : Math.max(0, tricksWon - bid);
+  const isMet = !isNil && tricksWon >= bid;
+  const segmentClass = nilBroken ? 'bg-ds-error' : isMet ? 'bg-ds-success motion-safe:animate-pulse' : 'bg-ds-warning';
+
+  return (
+    <div
+      data-testid={testId ?? 'bid-progress-bar'}
+      className="mt-0.5 flex items-center gap-1"
+      role="progressbar"
+      aria-label={ariaLabel}
+      aria-valuemin={0}
+      aria-valuemax={bid > 0 ? bid : 1}
+      aria-valuenow={Math.min(filledSegments, bid > 0 ? bid : 1)}
+    >
+      <div className="flex flex-1 gap-0.5">
+        {Array.from({ length: totalSegments }, (_, idx) => (
+          <div
+            key={`bid-seg-${idx.toString()}`}
+            className={`h-1.5 flex-1 rounded-sm ${idx < filledSegments || nilBroken ? segmentClass : 'bg-white/15'}`}
+          />
+        ))}
+      </div>
+      {overTricks > 0 && !nilBroken && (
+        <span className="rounded-full bg-ds-info/30 px-1.5 py-0 text-[10px] font-semibold leading-tight text-ds-info">
+          +{overTricks}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/BidProgressBar.tsx
+++ b/frontend/src/components/BidProgressBar.tsx
@@ -29,7 +29,21 @@ export function BidProgressBar({ bid, tricksWon, testId, ariaLabel }: BidProgres
   const totalSegments = isNil ? 1 : bid;
   const overTricks = isNil ? tricksWon : Math.max(0, tricksWon - bid);
   const isMet = !isNil && tricksWon >= bid;
-  const segmentClass = nilBroken ? 'bg-ds-error' : isMet ? 'bg-ds-success motion-safe:animate-pulse' : 'bg-ds-warning';
+  // aria-valuenow tracks the *broken* nil-bid bar (which fills its single
+  // segment red) as fully advanced — otherwise screen readers would read 0/1
+  // while the eye sees a full red bar.
+  const ariaValueMax = bid > 0 ? bid : 1;
+  const ariaValueNow = nilBroken ? 1 : Math.min(filledSegments, ariaValueMax);
+
+  // Conditional segment color: full class strings per branch to keep Tailwind
+  // class-string parsers happy and the per-state classes greppable.
+  const getSegmentClass = (idx: number): string => {
+    const filled = idx < filledSegments || nilBroken;
+    if (!filled) return 'h-1.5 flex-1 rounded-sm bg-white/15';
+    if (nilBroken) return 'h-1.5 flex-1 rounded-sm bg-ds-error';
+    if (isMet) return 'h-1.5 flex-1 rounded-sm bg-ds-success motion-safe:animate-pulse';
+    return 'h-1.5 flex-1 rounded-sm bg-ds-warning';
+  };
 
   return (
     <div
@@ -38,15 +52,12 @@ export function BidProgressBar({ bid, tricksWon, testId, ariaLabel }: BidProgres
       role="progressbar"
       aria-label={ariaLabel}
       aria-valuemin={0}
-      aria-valuemax={bid > 0 ? bid : 1}
-      aria-valuenow={Math.min(filledSegments, bid > 0 ? bid : 1)}
+      aria-valuemax={ariaValueMax}
+      aria-valuenow={ariaValueNow}
     >
       <div className="flex flex-1 gap-0.5">
         {Array.from({ length: totalSegments }, (_, idx) => (
-          <div
-            key={`bid-seg-${idx.toString()}`}
-            className={`h-1.5 flex-1 rounded-sm ${idx < filledSegments || nilBroken ? segmentClass : 'bg-white/15'}`}
-          />
+          <div key={`bid-seg-${idx.toString()}`} className={getSegmentClass(idx)} />
         ))}
       </div>
       {overTricks > 0 && !nilBroken && (

--- a/frontend/src/i18n/locales/en/callbreak.json
+++ b/frontend/src/i18n/locales/en/callbreak.json
@@ -23,6 +23,8 @@
   "roundScore": "Round: {{score}}",
   "bid": "Bid {{n}}",
   "bidNone": "No bid",
+  "tricksWon": "Won {{n}}",
+  "bidProgressAria": "{{name}}'s bid progress",
   "currentTrick": "Current Trick",
   "scores": "Scores",
   "scoresPlayer": "Player",

--- a/frontend/src/i18n/locales/ja/callbreak.json
+++ b/frontend/src/i18n/locales/ja/callbreak.json
@@ -23,6 +23,8 @@
   "roundScore": "ラウンド: {{score}}",
   "bid": "ビッド {{n}}",
   "bidNone": "未ビッド",
+  "tricksWon": "獲得 {{n}}",
+  "bidProgressAria": "{{name}} のビッド達成状況",
   "currentTrick": "現在のトリック",
   "scores": "スコア",
   "scoresPlayer": "プレイヤー",

--- a/frontend/src/pages/CallBreakPage.tsx
+++ b/frontend/src/pages/CallBreakPage.tsx
@@ -283,7 +283,9 @@ function CallBreakPageContent() {
                               {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
                               {t('cumulativeScore', { score: fmtScore(p.cumulativeScore) })} |{' '}
                               {t('roundScore', { score: fmtScore(p.roundScore) })} |{' '}
-                              {p.bid >= 0 ? t('bid', { n: p.bid }) : t('bidNone')}
+                              {p.bid >= 0
+                                ? `${t('bid', { n: p.bid })} / ${t('tricksWon', { n: p.trickCount })}`
+                                : t('bidNone')}
                             </div>
                             <BidProgressBar
                               bid={p.bid}
@@ -304,7 +306,9 @@ function CallBreakPageContent() {
                           {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
                           {t('cumulativeScore', { score: fmtScore(p.cumulativeScore) })} |{' '}
                           {t('roundScore', { score: fmtScore(p.roundScore) })} |{' '}
-                          {p.bid >= 0 ? t('bid', { n: p.bid }) : t('bidNone')}
+                          {p.bid >= 0
+                            ? `${t('bid', { n: p.bid })} / ${t('tricksWon', { n: p.trickCount })}`
+                            : t('bidNone')}
                         </div>
                         <BidProgressBar
                           bid={p.bid}

--- a/frontend/src/pages/CallBreakPage.tsx
+++ b/frontend/src/pages/CallBreakPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import type { callBreakApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
+import { BidProgressBar } from '../components/BidProgressBar';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
@@ -277,11 +278,19 @@ function CallBreakPageContent() {
                       {state.players
                         .filter((p) => !p.isHuman)
                         .map((p) => (
-                          <div key={p.id} className="text-ds-text-muted text-sm py-0.5">
-                            {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
-                            {t('cumulativeScore', { score: fmtScore(p.cumulativeScore) })} |{' '}
-                            {t('roundScore', { score: fmtScore(p.roundScore) })} |{' '}
-                            {p.bid >= 0 ? t('bid', { n: p.bid }) : t('bidNone')}
+                          <div key={p.id} className="py-0.5 text-ds-text-muted text-sm">
+                            <div>
+                              {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
+                              {t('cumulativeScore', { score: fmtScore(p.cumulativeScore) })} |{' '}
+                              {t('roundScore', { score: fmtScore(p.roundScore) })} |{' '}
+                              {p.bid >= 0 ? t('bid', { n: p.bid }) : t('bidNone')}
+                            </div>
+                            <BidProgressBar
+                              bid={p.bid}
+                              tricksWon={p.trickCount}
+                              ariaLabel={t('bidProgressAria', { name: playerName(p.id, p.isHuman) })}
+                              testId={`bid-progress-${p.id.toString()}`}
+                            />
                           </div>
                         ))}
                     </div>
@@ -297,6 +306,12 @@ function CallBreakPageContent() {
                           {t('roundScore', { score: fmtScore(p.roundScore) })} |{' '}
                           {p.bid >= 0 ? t('bid', { n: p.bid }) : t('bidNone')}
                         </div>
+                        <BidProgressBar
+                          bid={p.bid}
+                          tricksWon={p.trickCount}
+                          ariaLabel={t('bidProgressAria', { name: playerName(p.id, p.isHuman) })}
+                          testId={`bid-progress-${p.id.toString()}`}
+                        />
                       </div>
                     ))
                 )}
@@ -396,16 +411,31 @@ function CallBreakPageContent() {
 
           <GameFooter className={`${gameTheme.callbreak.footer} px-4 py-2.5`}>
             {humanPlayer && (
-              <PlayerHandSection
-                humanPlayer={humanPlayer}
-                selectedCardIndices={selectedCardIndices}
-                toggleCard={toggleCard}
-                cardWidth={cardWidth}
-                isMobile={isMobile}
-                dataTutorialPrefix="cb"
-                validIndices={isHumanTurn ? state.validPlayIndices : undefined}
-                restrictedTooltip={t('mustTrumpSpadeTooltip')}
-              />
+              <>
+                {humanPlayer.bid >= 0 && (
+                  <div className="mb-1 text-ds-text-muted text-xs">
+                    <div>
+                      {t('bid', { n: humanPlayer.bid })} / {t('tricksWon', { n: humanPlayer.trickCount })}
+                    </div>
+                    <BidProgressBar
+                      bid={humanPlayer.bid}
+                      tricksWon={humanPlayer.trickCount}
+                      ariaLabel={t('bidProgressAria', { name: playerName(humanPlayer.id, true) })}
+                      testId={`bid-progress-${humanPlayer.id.toString()}`}
+                    />
+                  </div>
+                )}
+                <PlayerHandSection
+                  humanPlayer={humanPlayer}
+                  selectedCardIndices={selectedCardIndices}
+                  toggleCard={toggleCard}
+                  cardWidth={cardWidth}
+                  isMobile={isMobile}
+                  dataTutorialPrefix="cb"
+                  validIndices={isHumanTurn ? state.validPlayIndices : undefined}
+                  restrictedTooltip={t('mustTrumpSpadeTooltip')}
+                />
+              </>
             )}
 
             <ErrorAlert message={error ?? hintError} onRetry={retry} />


### PR DESCRIPTION
## Summary
- New \`BidProgressBar\` segments each player's progress toward their declared bid (one segment per trick).
- Warning tint while under, success tint when met, info \"+N\" pill for overtricks (matching Call Break's +0.1 score-per-overtrick rule), error tint for a broken nil bid.
- Rendered under both human-footer and CPU rows so every seat communicates pressure at a glance.

## Test plan
- [x] \`bun run test -- --run src/components/BidProgressBar.test.tsx\` (6 cases incl. nil broken, overtricks)
- [x] \`bun run test -- --run src/pages/CallBreakPage.test.tsx\` (20 existing tests still pass)
- [ ] tsc + build verified by CI

Closes #1947