### PR TITLE
feat(doubt): louder visual tell on a suspicious CPU

### DIFF
--- a/frontend/src/components/doubt/DoubtCpuArea.test.tsx
+++ b/frontend/src/components/doubt/DoubtCpuArea.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { DoubtPlayerData } from '../../types/card';
+import { DoubtCpuArea } from './DoubtCpuArea';
+
+const basePlayer: DoubtPlayerData = {
+  id: 1,
+  isHuman: false,
+  cardCount: 5,
+  cards: [],
+  isFinished: false,
+};
+
+describe('DoubtCpuArea', () => {
+  it('does not render the tell indicator when hasTell is false', () => {
+    render(<DoubtCpuArea player={basePlayer} isCurrentTurn={false} hasTell={false} />);
+    expect(screen.queryByTestId('doubt-tell-indicator')).not.toBeInTheDocument();
+  });
+
+  it('renders sweat, eye-dart, and label badge when hasTell is true', () => {
+    render(<DoubtCpuArea player={basePlayer} isCurrentTurn={true} hasTell={true} />);
+    const indicator = screen.getByTestId('doubt-tell-indicator');
+    expect(indicator).toBeInTheDocument();
+    expect(indicator.querySelector('.animate-sweat-drop')).not.toBeNull();
+    expect(indicator.querySelector('.animate-eye-dart')).not.toBeNull();
+    expect(screen.getByText('怪しい')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/doubt/DoubtCpuArea.tsx
+++ b/frontend/src/components/doubt/DoubtCpuArea.tsx
@@ -31,9 +31,22 @@ export function DoubtCpuArea({
     >
       <div className="text-game-text-muted text-xs">{t('cardCount', { count: player.cardCount })}</div>
       {hasTell && (
-        <span className="animate-sweat-drop text-lg" role="img" aria-label={t('tell')}>
-          💧
-        </span>
+        <div
+          className="mt-0.5 flex items-center gap-1"
+          role="img"
+          aria-label={t('tell')}
+          data-testid="doubt-tell-indicator"
+        >
+          <span aria-hidden="true" className="animate-sweat-drop text-lg leading-none">
+            💧
+          </span>
+          <span aria-hidden="true" className="animate-eye-dart text-lg leading-none">
+            👀
+          </span>
+          <span className="rounded-full bg-ds-warning/30 px-1.5 py-0 text-[10px] font-semibold leading-tight text-ds-warning motion-safe:animate-pulse">
+            {t('tellBadge')}
+          </span>
+        </div>
       )}
     </CpuTurnArea>
   );

--- a/frontend/src/i18n/locales/en/doubt.json
+++ b/frontend/src/i18n/locales/en/doubt.json
@@ -31,6 +31,7 @@
   "claimRangeWarning": "Adjusted to range 1-13",
   "playButton": "Play",
   "tell": "Tell",
+  "tellBadge": "Suspicious",
   "settings": {
     "title": "Settings",
     "doubtTime": "Doubt Time:",

--- a/frontend/src/i18n/locales/ja/doubt.json
+++ b/frontend/src/i18n/locales/ja/doubt.json
@@ -31,6 +31,7 @@
   "claimRangeWarning": "1〜13の範囲に調整されました",
   "playButton": "出す",
   "tell": "テル",
+  "tellBadge": "怪しい",
   "settings": {
     "title": "設定",
     "doubtTime": "ダウト時間:",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -268,6 +268,22 @@ input:not([type]):focus-visible {
   animation: sweat-drop 1.5s ease-in-out infinite;
 }
 
+@keyframes eye-dart {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-2px);
+  }
+  75% {
+    transform: translateX(2px);
+  }
+}
+.animate-eye-dart {
+  animation: eye-dart 0.9s ease-in-out infinite;
+}
+
 /* Suit watermark "settle" animation — used by Crazy Eights when chosenSuit
    becomes active. Starts slightly larger and settles to the resting opacity
    so the suit change registers in peripheral vision (#1885). The 100% opacity
@@ -392,6 +408,7 @@ input:not([type]):focus-visible {
   .animate-shake,
   .animate-flipIn,
   .animate-sweat-drop,
+  .animate-eye-dart,
   .animate-card-deal-in {
     animation: none;
   }


### PR DESCRIPTION
## Summary
- Pair the existing 💧 sweat drop with an eye-dart 👀 animation (new \`eye-dart\` keyframe respecting prefers-reduced-motion) and a pulsing \"Suspicious / 怪しい\" badge.
- Tell cluster lives inside DoubtCpuArea so the signal sits next to the avatar and is visible during the doubt-judgement window, not just in log text.

## Test plan
- [x] \`bun run test -- --run src/components/doubt/DoubtCpuArea.test.tsx\` (with/without hasTell)
- [x] \`bun run test -- --run src/pages/DoubtPage.test.tsx\` (104 existing tests still pass)
- [ ] tsc + build verified by CI

Closes #1948