### PR TITLE
feat(bridge): DUMMY watermark + active glow on the dummy area

### DIFF
--- a/frontend/src/i18n/locales/en/bridge.json
+++ b/frontend/src/i18n/locales/en/bridge.json
@@ -46,6 +46,7 @@
   "bidLevel": "Level",
   "bidSuit": "Suit",
   "dummyHand": "Dummy's Hand",
+  "yourTurnDummy": "Your move — playing dummy",
   "gamesWon": "Games Won",
   "belowLine": "Below the Line",
   "suitSpade": "♠",

--- a/frontend/src/i18n/locales/ja/bridge.json
+++ b/frontend/src/i18n/locales/ja/bridge.json
@@ -46,6 +46,7 @@
   "bidLevel": "レベル",
   "bidSuit": "スート",
   "dummyHand": "ダミーの手札",
+  "yourTurnDummy": "あなたが操作する番です",
   "gamesWon": "ゲーム勝利数",
   "belowLine": "ビロウ・ザ・ライン",
   "suitSpade": "♠",

--- a/frontend/src/pages/BridgePage.tsx
+++ b/frontend/src/pages/BridgePage.tsx
@@ -348,7 +348,7 @@ function BridgePageContent() {
                   >
                     <span
                       aria-hidden="true"
-                      className="pointer-events-none absolute inset-0 flex items-center justify-center select-none text-5xl font-extrabold tracking-widest text-white/5"
+                      className="pointer-events-none absolute inset-0 flex items-center justify-center select-none text-5xl font-extrabold tracking-widest text-ds-text-muted opacity-10"
                     >
                       DUMMY
                     </span>

--- a/frontend/src/pages/BridgePage.tsx
+++ b/frontend/src/pages/BridgePage.tsx
@@ -332,13 +332,37 @@ function BridgePageContent() {
 
                 {/* Dummy hand */}
                 {state.openingLeadDone && state.dummyHand && state.dummyHand.length > 0 && (
-                  <div className="my-3 p-3 rounded bg-black/40" data-tutorial="br-dummy-hand">
+                  <div
+                    className={`relative my-3 overflow-hidden rounded p-3 bg-black/40 transition-shadow ${
+                      humanPlayer?.id === state.declarerIdx && state.currentPlayerIdx === state.dummyIdx
+                        ? 'ring-2 ring-ds-info shadow-[0_0_18px_rgba(91,143,185,0.55)] motion-safe:animate-pulse'
+                        : ''
+                    }`}
+                    data-tutorial="br-dummy-hand"
+                    data-testid="bridge-dummy-area"
+                    data-dummy-active={
+                      humanPlayer?.id === state.declarerIdx && state.currentPlayerIdx === state.dummyIdx
+                        ? 'true'
+                        : undefined
+                    }
+                  >
+                    <span
+                      aria-hidden="true"
+                      className="pointer-events-none absolute inset-0 flex items-center justify-center select-none text-5xl font-extrabold tracking-widest text-white/5"
+                    >
+                      DUMMY
+                    </span>
                     <div className="text-ds-text-muted text-sm mb-1">{t('dummyHand')}</div>
                     <div className="flex gap-1 flex-wrap">
                       {state.dummyHand.map((card, idx) => (
                         <AnimatedCard key={`dummy-${card.design}-${card.value}-${idx}`} card={card} width={cardWidth} />
                       ))}
                     </div>
+                    {humanPlayer?.id === state.declarerIdx && state.currentPlayerIdx === state.dummyIdx && (
+                      <div className="relative mt-1 text-center text-xs font-semibold text-ds-info">
+                        {t('yourTurnDummy')}
+                      </div>
+                    )}
                   </div>
                 )}
 


### PR DESCRIPTION
## Summary
- Render a low-opacity \"DUMMY\" watermark behind the dummy hand to communicate the role at a glance.
- When the human is the declarer and the dummy's turn arrives, the dummy area gains an info-tinted ring, outer shadow glow, and a \"Your move — playing dummy\" caption so the player knows to operate those cards.

## Test plan
- [x] \`bun run test -- --run src/pages/BridgePage.test.tsx\` (32 existing tests still pass)
- [ ] tsc + build verified by CI

Closes #1951