### PR TITLE
feat(slap): comic-style burst overlay on slap events

### DIFF
--- a/frontend/src/components/SlapBurst.test.tsx
+++ b/frontend/src/components/SlapBurst.test.tsx
@@ -1,0 +1,54 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SlapBurst } from './SlapBurst';
+
+describe('SlapBurst', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders nothing when triggerKey is 0', () => {
+    render(<SlapBurst triggerKey={0} outcome="correct" label="PAIR!" />);
+    expect(screen.queryByTestId('slap-burst')).not.toBeInTheDocument();
+  });
+
+  it('fires on first non-zero trigger and shows the label', () => {
+    render(<SlapBurst triggerKey={1} outcome="correct" label="PAIR!" />);
+    const burst = screen.getByTestId('slap-burst');
+    expect(burst).toBeInTheDocument();
+    expect(burst.getAttribute('data-outcome')).toBe('correct');
+    expect(screen.getByText('PAIR!')).toBeInTheDocument();
+  });
+
+  it('auto-dismisses after the burst timeout', () => {
+    render(<SlapBurst triggerKey={1} outcome="correct" label="PAIR!" />);
+    expect(screen.getByTestId('slap-burst')).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(screen.queryByTestId('slap-burst')).not.toBeInTheDocument();
+  });
+
+  it('re-fires when triggerKey changes to a new non-zero value', () => {
+    const { rerender } = render(<SlapBurst triggerKey={1} outcome="wrong" label="MISS!" />);
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(screen.queryByTestId('slap-burst')).not.toBeInTheDocument();
+
+    rerender(<SlapBurst triggerKey={2} outcome="wrong" label="MISS!" />);
+    expect(screen.getByTestId('slap-burst')).toBeInTheDocument();
+  });
+
+  it('does not refire when triggerKey stays the same on rerender', () => {
+    const { rerender } = render(<SlapBurst triggerKey={1} outcome="correct" label="PAIR!" />);
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    rerender(<SlapBurst triggerKey={1} outcome="correct" label="PAIR!" />);
+    expect(screen.queryByTestId('slap-burst')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/SlapBurst.tsx
+++ b/frontend/src/components/SlapBurst.tsx
@@ -7,8 +7,9 @@ export type SlapOutcome = 'correct' | 'wrong';
 export interface SlapBurstProps {
   /**
    * Monotonically-increasing trigger key. Whenever this value changes (and is
-   * non-zero), the burst re-fires. Pass `Date.now()` from the parent when a
-   * new SLAP event is detected.
+   * non-zero), the burst re-fires. Pass an incrementing counter from the
+   * parent: counters survive back-to-back events within a single
+   * millisecond, which `Date.now()` does not.
    */
   triggerKey: number;
   /** Slap outcome — drives the badge tint. */

--- a/frontend/src/components/SlapBurst.tsx
+++ b/frontend/src/components/SlapBurst.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from 'react';
+
+/** Outcome of the slap that triggered the burst. */
+export type SlapOutcome = 'correct' | 'wrong';
+
+/** Props for the SlapBurst component. */
+export interface SlapBurstProps {
+  /**
+   * Monotonically-increasing trigger key. Whenever this value changes (and is
+   * non-zero), the burst re-fires. Pass `Date.now()` from the parent when a
+   * new SLAP event is detected.
+   */
+  triggerKey: number;
+  /** Slap outcome — drives the badge tint. */
+  outcome: SlapOutcome;
+  /** Human-readable label rendered inside the burst (e.g. PAIR! / SANDWICH!). */
+  label: string;
+  /** Test id forwarded to the rendered root. */
+  testId?: string;
+}
+
+const BURST_MS = 1200;
+
+/**
+ * Comic-style burst overlay shown on top of the center pile when a slap fires.
+ * Auto-dismisses after BURST_MS milliseconds. The component is purely visual;
+ * the underlying slap result is owned by the game state.
+ */
+export function SlapBurst({ triggerKey, outcome, label, testId }: SlapBurstProps) {
+  const [visible, setVisible] = useState(false);
+  const prevKey = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    if (triggerKey === 0 || triggerKey === prevKey.current) return;
+    prevKey.current = triggerKey;
+    setVisible(true);
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setVisible(false), BURST_MS);
+    return () => clearTimeout(timerRef.current);
+  }, [triggerKey]);
+
+  if (!visible) return null;
+
+  const colorClass = outcome === 'correct' ? 'bg-ds-success text-ds-text-on-accent' : 'bg-ds-error text-white';
+
+  return (
+    <div
+      role="status"
+      aria-live="assertive"
+      data-testid={testId ?? 'slap-burst'}
+      data-outcome={outcome}
+      className="pointer-events-none absolute inset-0 flex items-center justify-center"
+    >
+      <div
+        className={`-rotate-6 transform rounded-md px-4 py-2 text-2xl font-extrabold tracking-wider shadow-2xl ring-4 ring-white/40 motion-safe:animate-[pulse-once_0.6s_ease-out] ${colorClass}`}
+      >
+        <span aria-hidden="true" className="mr-1">
+          💥
+        </span>
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/i18n/locales/en/egyptianratscrew.json
+++ b/frontend/src/i18n/locales/en/egyptianratscrew.json
@@ -32,6 +32,11 @@
     "slapReason": {
       "pair": "Pair",
       "sandwich": "Sandwich"
+    },
+    "burst": {
+      "pair": "PAIR!",
+      "sandwich": "SANDWICH!",
+      "miss": "MISS!"
     }
   },
   "hint": {

--- a/frontend/src/i18n/locales/en/slapjack.json
+++ b/frontend/src/i18n/locales/en/slapjack.json
@@ -25,7 +25,11 @@
   },
   "slapjack": {
     "slap": "Slap!",
-    "jackOnTop": "JACK! Slap fast!"
+    "jackOnTop": "JACK! Slap fast!",
+    "burst": {
+      "jack": "JACK!",
+      "miss": "MISS!"
+    }
   },
   "hint": {
     "flipCard": "Your turn. Press s to flip the next card",

--- a/frontend/src/i18n/locales/ja/egyptianratscrew.json
+++ b/frontend/src/i18n/locales/ja/egyptianratscrew.json
@@ -32,6 +32,11 @@
     "slapReason": {
       "pair": "ペア",
       "sandwich": "サンドイッチ"
+    },
+    "burst": {
+      "pair": "ペア！",
+      "sandwich": "サンドイッチ！",
+      "miss": "ミス！"
     }
   },
   "hint": {

--- a/frontend/src/i18n/locales/ja/slapjack.json
+++ b/frontend/src/i18n/locales/ja/slapjack.json
@@ -25,7 +25,11 @@
   },
   "slapjack": {
     "slap": "スラップ！",
-    "jackOnTop": "Jだ！叩け！"
+    "jackOnTop": "Jだ！叩け！",
+    "burst": {
+      "jack": "ジャック！",
+      "miss": "ミス！"
+    }
   },
   "hint": {
     "flipCard": "あなたのターンです。s でカードをめくりましょう",

--- a/frontend/src/pages/EgyptianRatscrewPage.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { egyptianRatscrewApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -12,6 +12,7 @@ import { HintTooltip } from '../components/hint/HintTooltip';
 import { KbdBadge } from '../components/KbdBadge';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
+import { SlapBurst, type SlapOutcome } from '../components/SlapBurst';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
@@ -74,6 +75,34 @@ function EgyptianRatscrewPageContent() {
   const handleStep = useCallback(() => execApi('step'), [execApi]);
   const handleSlap = useCallback(() => execApi('slap'), [execApi]);
   const handleReset = useCallback(() => execApi('reset'), [execApi]);
+
+  // SlapBurst trigger: refire whenever a new SLAP_CORRECT or SLAP_WRONG event arrives.
+  const [slapBurst, setSlapBurst] = useState<{ key: number; outcome: SlapOutcome; label: string }>({
+    key: 0,
+    outcome: 'correct',
+    label: '',
+  });
+  const prevSlapEventRef = useRef<{ kind: number; player: number }>({ kind: -1, player: -1 });
+  useEffect(() => {
+    if (!state) return;
+    const kind = state.lastEventKind;
+    const player = state.lastEventPlayerIdx;
+    const prev = prevSlapEventRef.current;
+    if (
+      (kind === EgyptianRatscrewEventKind.SLAP_CORRECT || kind === EgyptianRatscrewEventKind.SLAP_WRONG) &&
+      (kind !== prev.kind || player !== prev.player)
+    ) {
+      const outcome: SlapOutcome = kind === EgyptianRatscrewEventKind.SLAP_CORRECT ? 'correct' : 'wrong';
+      const label =
+        outcome === 'wrong'
+          ? 'MISS!'
+          : state.lastSlapReason === 2 // SANDWICH
+            ? 'SANDWICH!'
+            : 'PAIR!';
+      setSlapBurst({ key: Date.now(), outcome, label });
+      prevSlapEventRef.current = { kind, player };
+    }
+  }, [state]);
 
   useMountReset(execApi);
 
@@ -197,11 +226,12 @@ function EgyptianRatscrewPageContent() {
 
             {/* Center pile / arena */}
             <div
-              className={`flex items-center justify-center gap-8 py-3 rounded-lg transition-colors ${
+              className={`relative flex items-center justify-center gap-8 py-3 rounded-lg transition-colors ${
                 state.isSlappable ? 'bg-ds-warning/30' : 'bg-black/20'
               } ${lastEvent === EgyptianRatscrewEventKind.SLAP_WRONG ? 'ring-2 ring-ds-error' : ''}`}
               data-tutorial="er-arena"
             >
+              <SlapBurst triggerKey={slapBurst.key} outcome={slapBurst.outcome} label={slapBurst.label} />
               <div className="text-center">
                 <div className="text-sm text-ds-text-primary font-semibold">
                   {t('label.pileCount', { count: state.centerPileSize })}

--- a/frontend/src/pages/EgyptianRatscrewPage.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.tsx
@@ -24,7 +24,12 @@ import { useMountReset } from '../hooks/useMountReset';
 import { useReflexShortcuts } from '../hooks/useReflexShortcuts';
 import { gameTheme } from '../styles/gameTheme';
 import type { EgyptianRatscrewResponse } from '../types/card';
-import { EgyptianRatscrewEventKind, EgyptianRatscrewPendingKind, EgyptianRatscrewPhase } from '../types/phases';
+import {
+  EgyptianRatscrewEventKind,
+  EgyptianRatscrewPendingKind,
+  EgyptianRatscrewPhase,
+  EgyptianRatscrewSlapReason,
+} from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { formatEgyptianRatscrewState } from '../utils/cli/formatters/egyptianratscrewFormatter';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
@@ -95,14 +100,16 @@ function EgyptianRatscrewPageContent() {
       const outcome: SlapOutcome = kind === EgyptianRatscrewEventKind.SLAP_CORRECT ? 'correct' : 'wrong';
       const label =
         outcome === 'wrong'
-          ? 'MISS!'
-          : state.lastSlapReason === 2 // SANDWICH
-            ? 'SANDWICH!'
-            : 'PAIR!';
-      setSlapBurst({ key: Date.now(), outcome, label });
+          ? t('egyptianratscrew.burst.miss')
+          : state.lastSlapReason === EgyptianRatscrewSlapReason.SANDWICH
+            ? t('egyptianratscrew.burst.sandwich')
+            : t('egyptianratscrew.burst.pair');
+      // Incrementing counter is more robust than Date.now() for trigger keys:
+      // back-to-back events within the same ms still register as distinct.
+      setSlapBurst((prevBurst) => ({ key: prevBurst.key + 1, outcome, label }));
       prevSlapEventRef.current = { kind, player };
     }
-  }, [state]);
+  }, [state, t]);
 
   useMountReset(execApi);
 

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -92,10 +92,13 @@ function SlapjackPageContent() {
       (kind !== prev.kind || player !== prev.player)
     ) {
       const outcome: SlapOutcome = kind === SlapjackEventKind.SLAP_CORRECT ? 'correct' : 'wrong';
-      setSlapBurst({ key: Date.now(), outcome, label: outcome === 'wrong' ? 'MISS!' : 'JACK!' });
+      const label = outcome === 'wrong' ? t('slapjack.burst.miss') : t('slapjack.burst.jack');
+      // Counter (not Date.now()) keeps repeated slap events distinct even
+      // when they happen within the same millisecond.
+      setSlapBurst((prevBurst) => ({ key: prevBurst.key + 1, outcome, label }));
       prevSlapEventRef.current = { kind, player };
     }
-  }, [state]);
+  }, [state, t]);
 
   useMountReset(execApi);
 

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { slapjackApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -12,6 +12,7 @@ import { HintTooltip } from '../components/hint/HintTooltip';
 import { KbdBadge } from '../components/KbdBadge';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
+import { SlapBurst, type SlapOutcome } from '../components/SlapBurst';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
@@ -73,6 +74,28 @@ function SlapjackPageContent() {
   const handleStep = useCallback(() => execApi('step'), [execApi]);
   const handleSlap = useCallback(() => execApi('slap'), [execApi]);
   const handleReset = useCallback(() => execApi('reset'), [execApi]);
+
+  // SlapBurst trigger: refire whenever a new SLAP_CORRECT or SLAP_WRONG event arrives.
+  const [slapBurst, setSlapBurst] = useState<{ key: number; outcome: SlapOutcome; label: string }>({
+    key: 0,
+    outcome: 'correct',
+    label: '',
+  });
+  const prevSlapEventRef = useRef<{ kind: number; player: number }>({ kind: -1, player: -1 });
+  useEffect(() => {
+    if (!state) return;
+    const kind = state.lastEventKind;
+    const player = state.lastEventPlayerIdx;
+    const prev = prevSlapEventRef.current;
+    if (
+      (kind === SlapjackEventKind.SLAP_CORRECT || kind === SlapjackEventKind.SLAP_WRONG) &&
+      (kind !== prev.kind || player !== prev.player)
+    ) {
+      const outcome: SlapOutcome = kind === SlapjackEventKind.SLAP_CORRECT ? 'correct' : 'wrong';
+      setSlapBurst({ key: Date.now(), outcome, label: outcome === 'wrong' ? 'MISS!' : 'JACK!' });
+      prevSlapEventRef.current = { kind, player };
+    }
+  }, [state]);
 
   useMountReset(execApi);
 
@@ -199,11 +222,12 @@ function SlapjackPageContent() {
 
             {/* Center pile / arena */}
             <div
-              className={`flex items-center justify-center gap-8 py-3 rounded-lg transition-colors ${
+              className={`relative flex items-center justify-center gap-8 py-3 rounded-lg transition-colors ${
                 state.isTopJack ? 'bg-ds-warning/30' : 'bg-black/20'
               } ${lastEvent === SlapjackEventKind.SLAP_WRONG ? 'ring-2 ring-ds-error' : ''}`}
               data-tutorial="sj-arena"
             >
+              <SlapBurst triggerKey={slapBurst.key} outcome={slapBurst.outcome} label={slapBurst.label} />
               <div className="text-center">
                 <div className="text-sm text-ds-text-primary font-semibold">
                   {t('label.pileCount', { count: state.centerPileSize })}


### PR DESCRIPTION
## Summary
- New \`SlapBurst\` component overlays a rotated comic-style badge in the center pile when a SLAP_CORRECT / SLAP_WRONG event arrives.
- Egyptian Ratscrew picks the label from \`lastSlapReason\` (PAIR! / SANDWICH!); Slapjack uses JACK!; both share MISS! on a wrong slap.
- Auto-dismisses after 1.2s and uses an aria-live=\"assertive\" status for screen readers.

## Test plan
- [x] \`bun run test -- --run src/components/SlapBurst.test.tsx\` (mount, trigger, refire)
- [x] \`bun run test -- --run src/pages/EgyptianRatscrewPage.test.tsx src/pages/SlapjackPage.test.tsx\` (28 existing tests pass)
- [ ] tsc + build verified by CI

Closes #1952