### PR TITLE
feat(calculation): upcoming-rank preview under each foundation

### DIFF
--- a/frontend/src/i18n/locales/en/calculation.json
+++ b/frontend/src/i18n/locales/en/calculation.json
@@ -23,6 +23,7 @@
   "empty": "Empty",
   "nextRankBadge": "Next: {{rank}}",
   "nextRankAria": "Next required card {{rank}}",
+  "upcomingRanksTooltip": "Upcoming cards: {{sequence}}",
   "foundationCompleteAria": "Complete",
   "gameClear": "Game Clear! Moves: {{moveCount}}",
   "gameOver": "Game Over",

--- a/frontend/src/i18n/locales/ja/calculation.json
+++ b/frontend/src/i18n/locales/ja/calculation.json
@@ -23,6 +23,7 @@
   "empty": "空",
   "nextRankBadge": "次:{{rank}}",
   "nextRankAria": "次に置くべきカード {{rank}}",
+  "upcomingRanksTooltip": "今後の必要カード: {{sequence}}",
   "foundationCompleteAria": "完成",
   "gameClear": "ゲームクリア！ 手数: {{moveCount}}",
   "gameOver": "ゲームオーバー",

--- a/frontend/src/pages/CalculationPage.tsx
+++ b/frontend/src/pages/CalculationPage.tsx
@@ -55,6 +55,30 @@ export function calculationNextRank(
   return next > FOUNDATION_PILE_FULL ? next - FOUNDATION_PILE_FULL : next;
 }
 
+/**
+ * Return the upcoming ranks for the given foundation, starting from the next
+ * required rank and including up to `maxLookAhead` (or until the pile would
+ * be complete). Used for the "next cards" preview tooltip.
+ */
+export function calculationUpcomingRanks(
+  foundationIdx: number,
+  topValue: number | undefined,
+  pileLength: number,
+  maxLookAhead = 6,
+): number[] {
+  const out: number[] = [];
+  let v = topValue;
+  let len = pileLength;
+  for (let i = 0; i < maxLookAhead; i += 1) {
+    const next = calculationNextRank(foundationIdx, v, len);
+    if (next === null) break;
+    out.push(next);
+    v = next;
+    len += 1;
+  }
+  return out;
+}
+
 const CA_TUTORIAL_STEPS: TutorialStep[] = [
   {
     target: '[data-tutorial="ca-foundations"]',
@@ -353,6 +377,8 @@ function CalculationPageContent() {
                 const isHint = hintFoundation === idx;
                 const nextRank = calculationNextRank(idx, top?.value, pile.length);
                 const nextRankLabel = nextRank !== null ? valueName(nextRank) : null;
+                const upcomingRanks = calculationUpcomingRanks(idx, top?.value, pile.length);
+                const upcomingLabel = upcomingRanks.map(valueName).join(' → ');
                 return (
                   <button
                     key={`f-${idx.toString()}`}
@@ -360,6 +386,7 @@ function CalculationPageContent() {
                     className={`flex flex-col items-center p-1 rounded ${focusRingWhite} ${isHint ? 'ring-2 ring-ds-success animate-pulse' : ''} ${source ? 'cursor-pointer' : 'cursor-default'}`}
                     onClick={() => playToFoundation(idx)}
                     disabled={!isPlaying || loading || source === null}
+                    title={upcomingLabel ? t('upcomingRanksTooltip', { sequence: upcomingLabel }) : undefined}
                     aria-label={
                       nextRankLabel
                         ? `${t('foundation')} ${idx} ${STEP_LABELS[idx]} ${t('nextRankAria', { rank: nextRankLabel })}`
@@ -391,6 +418,15 @@ function CalculationPageContent() {
                       )}
                     </div>
                     <span className="text-[11px] text-ds-text-muted mt-0.5">{pile.length}/13</span>
+                    {upcomingRanks.length > 1 && (
+                      <span
+                        data-testid={`calc-foundation-upcoming-${idx}`}
+                        aria-hidden="true"
+                        className="mt-0.5 text-[10px] leading-none text-ds-text-muted opacity-60"
+                      >
+                        {upcomingRanks.slice(1, 5).map(valueName).join('·')}
+                      </span>
+                    )}
                   </button>
                 );
               })}


### PR DESCRIPTION
## Summary
- New \`calculationUpcomingRanks\` walks the +1/+2/+3/+4 sequence forward from the foundation top.
- Page renders ranks 2..5 as a low-opacity dot-separated preview under each foundation, and shows the full sequence in the title-tooltip so players can plan ahead without mental arithmetic.
- Reuses the existing rank-name formatter; complete piles emit no preview.

## Test plan
- [x] \`bun run test -- --run src/pages/CalculationPage.test.tsx\` (30 existing tests pass)
- [ ] tsc + build verified by CI

Closes #1953