### PR TITLE
feat(oasispoker): tinted exchange-fee warning by selection size

### DIFF
--- a/frontend/src/i18n/locales/en/oasispoker.json
+++ b/frontend/src/i18n/locales/en/oasispoker.json
@@ -56,6 +56,7 @@
   "betGuide": "Place an Ante and an optional Jackpot side bet",
   "exchangeGuide": "Tap cards to select them, then press Exchange or Stand",
   "exchangeFeeInfo": "Fee: ante × {{ante}} per card = {{fee}}",
+  "exchangeFeeHighRisk": "High-cost warning",
   "exchangeSelected": "Selected: {{count}}",
   "payoutRef": {
     "title": "Payouts",

--- a/frontend/src/i18n/locales/ja/oasispoker.json
+++ b/frontend/src/i18n/locales/ja/oasispoker.json
@@ -56,6 +56,7 @@
   "betGuide": "アンテと任意のジャックポットを設定してベット",
   "exchangeGuide": "交換したいカードをタップで選択し、「交換」または「ステイ」を押してください",
   "exchangeFeeInfo": "手数料: 1枚あたりアンテ × {{ante}} = {{fee}}",
+  "exchangeFeeHighRisk": "高コスト警告",
   "exchangeSelected": "選択中: {{count}}枚",
   "payoutRef": {
     "title": "配当表",

--- a/frontend/src/pages/OasisPokerPage.tsx
+++ b/frontend/src/pages/OasisPokerPage.tsx
@@ -424,7 +424,7 @@ function OasisPokerPageContent() {
                   {t('exchangeFeeInfo', { ante: state.anteBet, fee: exchangePreviewFee })}
                   {selectedIndices.length >= 4 && (
                     <span className="ml-2 inline-block rounded-full bg-ds-error/30 px-2 py-0.5 text-xs font-bold">
-                      ⚠ {t('exchangeFeeHighRisk')}
+                      <span aria-hidden="true">⚠</span> {t('exchangeFeeHighRisk')}
                     </span>
                   )}
                 </p>

--- a/frontend/src/pages/OasisPokerPage.tsx
+++ b/frontend/src/pages/OasisPokerPage.tsx
@@ -410,9 +410,23 @@ function OasisPokerPageContent() {
                 data-tutorial="oasis-exchange-controls"
               >
                 <p>{t('exchangeGuide')}</p>
-                <p>
+                <p
+                  data-testid="oasis-exchange-fee-line"
+                  className={
+                    selectedIndices.length >= 4
+                      ? 'font-semibold text-ds-error'
+                      : selectedIndices.length >= 2
+                        ? 'font-semibold text-ds-warning'
+                        : 'text-ds-text-primary'
+                  }
+                >
                   {t('exchangeSelected', { count: selectedIndices.length })} —{' '}
                   {t('exchangeFeeInfo', { ante: state.anteBet, fee: exchangePreviewFee })}
+                  {selectedIndices.length >= 4 && (
+                    <span className="ml-2 inline-block rounded-full bg-ds-error/30 px-2 py-0.5 text-xs font-bold">
+                      ⚠ {t('exchangeFeeHighRisk')}
+                    </span>
+                  )}
                 </p>
                 <div className="flex gap-2">
                   <button


### PR DESCRIPTION
## Summary
- Color the exchange-fee summary based on selection size (0-1: primary, 2-3: warning, 4-5: error).
- Add a pill badge at 4+ selected cards calling out the high cost, since the fee is rarely justified by the equity gain at that scale.

## Test plan
- [x] \`bun run test -- --run src/pages/OasisPokerPage.test.tsx\` (12 existing tests pass)
- [ ] tsc + build verified by CI

Closes #1954