### PR TITLE
feat(omaha,omahahilo): always-visible 2-hole + 3-board rule badge

### DIFF
--- a/frontend/src/i18n/locales/en/omaha.json
+++ b/frontend/src/i18n/locales/en/omaha.json
@@ -11,6 +11,8 @@
   },
   "communityCards": "Community Cards",
   "yourHand": "Your Hand",
+  "mandatoryRule": "Rule: 2 hole + 3 board",
+  "mandatoryRuleAria": "Omaha rule: you must use exactly 2 hole cards and exactly 3 board cards",
   "handNumber": "Hand #{{count}} (Level up: every {{level}} hands)",
   "rebuy": {
     "prompt": "Rebuy? ({{chips}} chips, {{used}}/{{max}} used)",

--- a/frontend/src/i18n/locales/en/omahahilo.json
+++ b/frontend/src/i18n/locales/en/omahahilo.json
@@ -11,6 +11,8 @@
   },
   "communityCards": "Community Cards",
   "yourHand": "Your Hand",
+  "mandatoryRule": "Rule: 2 hole + 3 board (Hi/Lo separately)",
+  "mandatoryRuleAria": "Hi-Lo rule: each of high and low uses exactly 2 hole cards and 3 board cards",
   "handNumber": "Hand #{{count}} (Level up: every {{level}} hands)",
   "rebuy": {
     "prompt": "Rebuy? ({{chips}} chips, {{used}}/{{max}} used)",

--- a/frontend/src/i18n/locales/ja/omaha.json
+++ b/frontend/src/i18n/locales/ja/omaha.json
@@ -11,6 +11,8 @@
   },
   "communityCards": "コミュニティカード",
   "yourHand": "あなたの手札",
+  "mandatoryRule": "ルール: 手札から2枚 + 場札から3枚",
+  "mandatoryRuleAria": "オマハのルール: 手札ちょうど2枚と場札ちょうど3枚を使います",
   "handNumber": "ハンド#{{count}} (レベルアップ:{{level}}ハンド毎)",
   "rebuy": {
     "prompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済)",

--- a/frontend/src/i18n/locales/ja/omahahilo.json
+++ b/frontend/src/i18n/locales/ja/omahahilo.json
@@ -11,6 +11,8 @@
   },
   "communityCards": "コミュニティカード",
   "yourHand": "あなたの手札",
+  "mandatoryRule": "ルール: 手札から2枚 + 場札から3枚 (Hi/Lo別に組合せ可)",
+  "mandatoryRuleAria": "Hi-Loルール: ハイとローそれぞれで手札2枚と場札3枚を使います",
   "handNumber": "ハンド#{{count}} (レベルアップ:{{level}}ハンド毎)",
   "rebuy": {
     "prompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済)",

--- a/frontend/src/pages/OmahaHiLoPage.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.tsx
@@ -358,6 +358,14 @@ function OmahaHiLoPageContent() {
                     </span>
                   )}
                 </div>
+                <div
+                  className="mb-1 inline-flex items-center gap-1.5 rounded-full bg-ds-info/20 px-2 py-0.5 text-[11px] font-semibold text-ds-info"
+                  data-testid="omahahilo-rule-badge"
+                  aria-label={t('mandatoryRuleAria')}
+                >
+                  <span aria-hidden="true">🎯</span>
+                  {t('mandatoryRule')}
+                </div>
                 <div className="flex flex-wrap gap-1.5 mb-2" data-tutorial="ohl-combination-rule">
                   {humanPlayer.cards?.length
                     ? humanPlayer.cards.map((card) => (

--- a/frontend/src/pages/OmahaHiLoPage.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.tsx
@@ -361,7 +361,7 @@ function OmahaHiLoPageContent() {
                 <div
                   className="mb-1 inline-flex items-center gap-1.5 rounded-full bg-ds-info/20 px-2 py-0.5 text-[11px] font-semibold text-ds-info"
                   data-testid="omahahilo-rule-badge"
-                  aria-label={t('mandatoryRuleAria')}
+                  title={t('mandatoryRuleAria')}
                 >
                   <span aria-hidden="true">🎯</span>
                   {t('mandatoryRule')}

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -357,6 +357,14 @@ function OmahaPageContent() {
                     </span>
                   )}
                 </div>
+                <div
+                  className="mb-1 inline-flex items-center gap-1.5 rounded-full bg-ds-info/20 px-2 py-0.5 text-[11px] font-semibold text-ds-info"
+                  data-testid="omaha-rule-badge"
+                  aria-label={t('mandatoryRuleAria')}
+                >
+                  <span aria-hidden="true">🎯</span>
+                  {t('mandatoryRule')}
+                </div>
                 <div className="flex flex-wrap gap-1.5 mb-2" data-tutorial="oh-combination-rule">
                   {humanPlayer.cards?.length
                     ? humanPlayer.cards.map((card) => (

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -360,7 +360,7 @@ function OmahaPageContent() {
                 <div
                   className="mb-1 inline-flex items-center gap-1.5 rounded-full bg-ds-info/20 px-2 py-0.5 text-[11px] font-semibold text-ds-info"
                   data-testid="omaha-rule-badge"
-                  aria-label={t('mandatoryRuleAria')}
+                  title={t('mandatoryRuleAria')}
                 >
                   <span aria-hidden="true">🎯</span>
                   {t('mandatoryRule')}


### PR DESCRIPTION
## Summary
- Add a 🎯 info-tinted pill above the human's 4-card hand on both Omaha and Omaha Hi-Lo reminding players the hand uses exactly 2 hole + 3 board.
- Hi-Lo copy notes Hi and Lo are evaluated independently.
- Pure visual nudge — no API changes; tests stay green.

## Test plan
- [x] \`bun run test -- --run src/pages/OmahaPage.test.tsx src/pages/OmahaHiLoPage.test.tsx\` (222 existing tests pass)
- [ ] tsc + build verified by CI

Closes #1955