### PR TITLE
feat(cassino): auto-highlight subset-sum take candidates

### DIFF
--- a/frontend/src/pages/CassinoPage.tsx
+++ b/frontend/src/pages/CassinoPage.tsx
@@ -20,6 +20,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { gameTheme } from '../styles/gameTheme';
 import type { CassinoResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
+import { cassinoTakeCandidates } from '../utils/cassinoTakeCandidates';
 import { suggestCassinoAction } from '../utils/cassinoUtils';
 import {
   CASSINO_HELP,
@@ -167,6 +168,10 @@ function CassinoPageContent() {
 
   const isGameEnd = state.gameEndFlag;
   const humanWon = isGameEnd && state.roundWinners.includes(0);
+  const takeCandidateIndices =
+    handIndex !== null && isHumanTurn
+      ? cassinoTakeCandidates(state.tableCards, human.cards[handIndex]?.value ?? 0).indices
+      : new Set<number>();
   const canTake = isHumanTurn && handIndex !== null && (tableIndices.length > 0 || buildIndices.length > 0);
   const canBuild = isHumanTurn && handIndex !== null && tableIndices.length > 0;
   const canTrail = isHumanTurn && handIndex !== null;
@@ -229,20 +234,28 @@ function CassinoPageContent() {
                 {state.tableCards.length === 0 ? (
                   <span className="text-ds-text-muted text-sm self-center">{t('label.tableEmpty')}</span>
                 ) : (
-                  state.tableCards.map((c, i) => (
-                    <button
-                      key={i}
-                      type="button"
-                      onClick={() => isHumanTurn && toggleTable(i)}
-                      disabled={!isHumanTurn}
-                      className={`rounded transition-all ${
-                        tableIndices.includes(i) ? 'ring-2 ring-ds-warning -translate-y-1' : ''
-                      } ${isHumanTurn ? 'cursor-pointer hover:opacity-90' : 'cursor-default'}`}
-                      data-testid={`table-card-${i}`}
-                    >
-                      <AnimatedCard card={c} width={cardWidth * 0.9} />
-                    </button>
-                  ))
+                  state.tableCards.map((c, i) => {
+                    const isCandidate = takeCandidateIndices.has(i);
+                    return (
+                      <button
+                        key={i}
+                        type="button"
+                        onClick={() => isHumanTurn && toggleTable(i)}
+                        disabled={!isHumanTurn}
+                        className={`rounded transition-all ${
+                          tableIndices.includes(i)
+                            ? 'ring-2 ring-ds-warning -translate-y-1'
+                            : isCandidate
+                              ? 'ring-2 ring-ds-success motion-safe:animate-pulse'
+                              : ''
+                        } ${isHumanTurn ? 'cursor-pointer hover:opacity-90' : 'cursor-default'}`}
+                        data-testid={`table-card-${i}`}
+                        data-take-candidate={isCandidate || undefined}
+                      >
+                        <AnimatedCard card={c} width={cardWidth * 0.9} />
+                      </button>
+                    );
+                  })
                 )}
               </div>
             </div>

--- a/frontend/src/utils/cassinoTakeCandidates.test.ts
+++ b/frontend/src/utils/cassinoTakeCandidates.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { cassinoTakeCandidates } from './cassinoTakeCandidates';
+
+const c = (value: number): Card => ({ design: 'SPADE', value });
+
+describe('cassinoTakeCandidates', () => {
+  it('returns empty for empty table', () => {
+    expect(cassinoTakeCandidates([], 9).indices.size).toBe(0);
+  });
+
+  it('matches a single equal-value card', () => {
+    const r = cassinoTakeCandidates([c(2), c(9), c(5)], 9);
+    expect(Array.from(r.indices).sort()).toEqual([1]);
+  });
+
+  it('matches a pair that sums to the target', () => {
+    const r = cassinoTakeCandidates([c(4), c(5), c(2)], 9);
+    expect(Array.from(r.indices).sort()).toEqual([0, 1]);
+  });
+
+  it('returns the union of every matching subset', () => {
+    // table: 2, 3, 5, 9 target 9. Matches: {9}, {4? no}, {2,3,? no}, {2,3, ? }. Actually 2+3+? hmm 2+3=5,+nothing.
+    // Match subsets: {9} → index 3; {4? none}. Try {2,3, 4? none}. Only {9}. But add a pair: 4+5=9.
+    const r = cassinoTakeCandidates([c(2), c(3), c(4), c(5), c(9)], 9);
+    // Matches: {9}(idx4); {4,5}(idx 2,3); {2,3,4}(idx 0,1,2).
+    expect(Array.from(r.indices).sort()).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('restricts to identical-value matches for face cards (J/Q/K)', () => {
+    const r = cassinoTakeCandidates([c(11), c(5), c(6), c(11)], 11);
+    expect(Array.from(r.indices).sort()).toEqual([0, 3]);
+  });
+
+  it('returns empty when no subset sums to target', () => {
+    const r = cassinoTakeCandidates([c(2), c(2), c(3)], 9);
+    expect(r.indices.size).toBe(0);
+  });
+});

--- a/frontend/src/utils/cassinoTakeCandidates.ts
+++ b/frontend/src/utils/cassinoTakeCandidates.ts
@@ -1,0 +1,54 @@
+import type { Card } from '../types/card';
+
+/**
+ * Cards on the Cassino table that participate in at least one subset
+ * whose values sum to the player's selected hand-card value.
+ *
+ * Returns:
+ * - `indices`: a `Set<number>` of table-card indices touched by any matching subset.
+ *   These should be highlighted in the UI as take candidates.
+ *
+ * Rules:
+ * - Face cards (J=11, Q=12, K=13) cannot be combined; they only take by single
+ *   matching face card. So when `targetValue >= 11`, only indices with the same
+ *   exact value are returned.
+ * - For number cards (1..10), all subsets summing to `targetValue` are valid.
+ *   Single-card matches are included (a card equal to `targetValue`).
+ * - Empty table or no matching subset returns an empty Set.
+ *
+ * The search enumerates subsets of up to `MAX_SUBSET_SIZE` table cards to keep
+ * the worst case bounded; Cassino tables rarely exceed ~10 cards so a full
+ * 2^N scan is also fine, but this is defense in depth.
+ */
+const MAX_SUBSET_SIZE = 12;
+
+export function cassinoTakeCandidates(tableCards: readonly Card[], targetValue: number): { indices: Set<number> } {
+  const indices = new Set<number>();
+  if (tableCards.length === 0 || targetValue <= 0) return { indices };
+
+  if (targetValue >= 11) {
+    tableCards.forEach((c, i) => {
+      if (c.value === targetValue) indices.add(i);
+    });
+    return { indices };
+  }
+
+  const n = Math.min(tableCards.length, MAX_SUBSET_SIZE);
+  const total = 1 << n;
+  for (let mask = 1; mask < total; mask += 1) {
+    let sum = 0;
+    for (let bit = 0; bit < n; bit += 1) {
+      if ((mask >>> bit) & 1) {
+        sum += tableCards[bit].value;
+        if (sum > targetValue) break;
+      }
+    }
+    if (sum === targetValue) {
+      for (let bit = 0; bit < n; bit += 1) {
+        if ((mask >>> bit) & 1) indices.add(bit);
+      }
+    }
+  }
+
+  return { indices };
+}


### PR DESCRIPTION
## Summary
- New \`cassinoTakeCandidates\` enumerates table-card subsets that sum to the player's selected hand-card value.
- Cards in any matching subset get a pulsing success ring, so the player can see every legal take at a glance.
- Face cards (J/Q/K) restrict to exact single-card matches, matching the take rules.

## Test plan
- [x] \`bun run test -- --run src/utils/cassinoTakeCandidates.test.ts\` (6 cases incl. faces + unions)
- [x] \`bun run test -- --run src/pages/CassinoPage.test.tsx\` (19 existing tests pass)
- [ ] tsc + build verified by CI

Closes #1956