### PR TITLE
feat(pigtail): red screen-flash on penalty draws

### DIFF
--- a/frontend/src/pages/PigsTailPage.tsx
+++ b/frontend/src/pages/PigsTailPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { pigtailApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CircularDeck } from '../components/CircularDeck';
@@ -113,6 +113,25 @@ function PigsTailPageContent() {
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
+  // Penalty screen-flash: fire whenever lastPenalty transitions to true on a
+  // new lastDrawCard. We key on centerCount+circleCount to detect fresh draws,
+  // not just spurious re-renders.
+  const [penaltyFlash, setPenaltyFlash] = useState(0);
+  const prevDrawSigRef = useRef<string>('');
+  useEffect(() => {
+    if (!state) return;
+    const sig = `${state.circleCount}-${state.centerCount}-${state.lastDrawCard ? `${state.lastDrawCard.design}${state.lastDrawCard.value}` : 'none'}`;
+    if (sig !== prevDrawSigRef.current && state.lastPenalty) {
+      setPenaltyFlash(Date.now());
+    }
+    prevDrawSigRef.current = sig;
+  }, [state]);
+  useEffect(() => {
+    if (penaltyFlash === 0) return;
+    const id = window.setTimeout(() => setPenaltyFlash(0), 600);
+    return () => window.clearTimeout(id);
+  }, [penaltyFlash]);
+
   if (!state)
     return <GameSkeleton gameKey="pigtail" layout={{ kind: 'centered', rows: [2], shape: 'circle', bars: 4 }} />;
 
@@ -139,6 +158,13 @@ function PigsTailPageContent() {
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
         <>
+          {penaltyFlash > 0 && (
+            <div
+              aria-hidden="true"
+              data-testid="pigtail-penalty-flash"
+              className="pointer-events-none fixed inset-0 z-40 bg-ds-error/40 motion-safe:animate-[pulse-once_0.6s_ease-out]"
+            />
+          )}
           <div className="flex-1 overflow-y-auto px-4 py-2 space-y-3">
             {/* Circle & Center area */}
             <div className="flex flex-col items-center gap-3" data-tutorial="pt-circle-area">


### PR DESCRIPTION
## Summary
- Detect each fresh draw via a circleCount+centerCount+card signature and, when the resulting draw is a penalty, briefly flash the screen with an error-tinted overlay (motion-safe, 600ms).
- The existing CircularDeck already provides the analog ring vibe; this adds the missing kinetic \"penalty!\" feedback the issue called for.

## Test plan
- [x] \`bun run test -- --run src/pages/PigsTailPage.test.tsx\` (12 existing tests pass)
- [ ] tsc + build verified by CI

Closes #1957