### PR TITLE
feat(pinochle): hover-driven meld→hand grouping + non-meld dim

### DIFF
--- a/frontend/src/pages/PinochlePage.tsx
+++ b/frontend/src/pages/PinochlePage.tsx
@@ -326,6 +326,7 @@ function PinochlePageContent() {
 
             {/* Melds */}
             {(phase === PinochlePhase.MELD || phase === PinochlePhase.ROUND_END) && state.playerMelds && (
+              // biome-ignore lint/a11y/noStaticElementInteractions: panel acts as a hover-out reset for the per-badge highlight; not interactive on its own.
               <div
                 className="mb-3 p-2 rounded bg-ds-accent/15"
                 data-tutorial="pn-meld-area"

--- a/frontend/src/pages/PinochlePage.tsx
+++ b/frontend/src/pages/PinochlePage.tsx
@@ -326,7 +326,11 @@ function PinochlePageContent() {
 
             {/* Melds */}
             {(phase === PinochlePhase.MELD || phase === PinochlePhase.ROUND_END) && state.playerMelds && (
-              <div className="mb-3 p-2 rounded bg-ds-accent/15" data-tutorial="pn-meld-area">
+              <div
+                className="mb-3 p-2 rounded bg-ds-accent/15"
+                data-tutorial="pn-meld-area"
+                onMouseLeave={() => setHighlightedMeldIdx(null)}
+              >
                 <div className="text-ds-text-primary font-bold mb-1">{t('meldScore')}:</div>
                 {state.playerMelds.map((melds: PinochleMeldData[], pIdx: number) =>
                   melds.length > 0 ? (
@@ -347,6 +351,8 @@ function PinochlePageContent() {
                             key={mIdx}
                             type="button"
                             onClick={() => setHighlightedMeldIdx((prev) => (prev === mIdx ? null : mIdx))}
+                            onMouseEnter={() => setHighlightedMeldIdx(mIdx)}
+                            onFocus={() => setHighlightedMeldIdx(mIdx)}
                             data-testid={`pn-meld-badge-${mIdx}`}
                             data-active={isActive ? 'true' : undefined}
                             className={`mr-2 inline-block px-2 py-0.5 rounded text-xs ${
@@ -394,6 +400,7 @@ function PinochlePageContent() {
                   const inHighlightedMeld = highlightedCardKeys.has(cardKey);
                   const meldTitle = cardKeyToMeldTitle.get(cardKey);
                   const isInMeld = meldTitle !== undefined;
+                  const dimmedByMeldFocus = highlightedMeldIdx !== null && !inHighlightedMeld;
                   return (
                     <button
                       type="button"
@@ -404,12 +411,12 @@ function PinochlePageContent() {
                       data-meld-highlighted={inHighlightedMeld ? 'true' : undefined}
                       data-in-meld={isInMeld ? 'true' : undefined}
                       title={meldTitle}
-                      className={`relative transition${inHighlightedMeld ? ' ring-4 ring-ds-accent' : ''}`}
+                      className={`relative transition-all${inHighlightedMeld ? ' -translate-y-2 ring-4 ring-ds-accent' : ''}${dimmedByMeldFocus ? ' opacity-40' : ''}`}
                       style={{
                         background: 'none',
                         padding: 0,
                         borderRadius: 8,
-                        opacity: isPlayTurn && !isValid ? 0.5 : 1,
+                        opacity: dimmedByMeldFocus ? undefined : isPlayTurn && !isValid ? 0.5 : 1,
                         boxSizing: 'border-box',
                       }}
                     >


### PR DESCRIPTION
## Summary
- Each human meld badge now triggers the same highlight on hover/focus as it does on click. Cards belonging to the meld lift (translate-y-2) and keep the ring; non-meld cards in the hand dim to opacity-40 so the grouping reads instantly.
- onMouseLeave on the meld panel clears the focus so the hand returns to normal.

## Test plan
- [x] \`bun run test -- --run src/pages/PinochlePage.test.tsx\` (26 existing tests pass)
- [ ] tsc + build verified by CI

Closes #1958