### PR TITLE
feat(briscola): cross-stack trump card under the stock deck

### DIFF
--- a/frontend/src/pages/BriscolaPage.tsx
+++ b/frontend/src/pages/BriscolaPage.tsx
@@ -5,6 +5,7 @@ import { CardImage } from '../components/CardImage';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
+import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { TrickDisplay } from '../components/TrickDisplay';
 import { withTutorial } from '../components/tutorial/withTutorial';
@@ -117,11 +118,60 @@ function BriscolaPageContent() {
           <div className="p-2 rounded bg-black/30 text-ds-text-muted text-sm">
             {t('header.cpu')}: {cpu?.cardCount ?? 0} / {t('header.tricks')}: {cpu?.trickCount ?? 0}
           </div>
-          <div className="p-2 rounded bg-black/30 flex items-center gap-2">
+          <div
+            className="flex items-center gap-2 rounded bg-black/30 p-2"
+            data-testid="briscola-stock"
+            aria-label={state.trumpCard ? t('header.trump') : t('header.trumpNone')}
+          >
             <span className="text-ds-text-muted text-sm">
               {state.trumpCard ? t('header.trump') : t('header.trumpNone')}
             </span>
-            {state.trumpCard && <CardImage card={state.trumpCard} width={Math.round(cardWidth * 0.7)} />}
+            {state.trumpCard ? (
+              <div
+                className="relative"
+                style={{
+                  width: Math.round(cardWidth * 1.1),
+                  height: Math.round(cardWidth * 0.95),
+                }}
+              >
+                {/* Face-up trump card rotated 90° — sits at the bottom of the stock,
+                    half visible to the right of the deck. */}
+                <div
+                  className="absolute left-0 top-1/2"
+                  style={{
+                    transform: 'translateY(-50%) rotate(90deg)',
+                    transformOrigin: 'left center',
+                  }}
+                >
+                  <CardImage card={state.trumpCard} width={Math.round(cardWidth * 0.7)} />
+                </div>
+                {/* Card-back stack — width tapers down as cards are drawn so the
+                    physical "thinning deck" reads at a glance. */}
+                {state.stockRemaining > 0 && (
+                  <div
+                    className="absolute left-1/2 top-1/2 -translate-y-1/2"
+                    style={{ transform: 'translate(0,-50%)' }}
+                    data-testid="briscola-stock-deck"
+                    aria-label={t('header.stock')}
+                  >
+                    <div className="relative">
+                      {Array.from({ length: Math.min(state.stockRemaining, 4) }, (_, i) => (
+                        <div
+                          key={`back-${i.toString()}`}
+                          className="absolute"
+                          style={{
+                            top: i * -1.5,
+                            left: i * 1.5,
+                          }}
+                        >
+                          <AnimatedCardBack width={Math.round(cardWidth * 0.7)} />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ) : null}
           </div>
         </div>
 

--- a/frontend/src/pages/BriscolaPage.tsx
+++ b/frontend/src/pages/BriscolaPage.tsx
@@ -118,11 +118,7 @@ function BriscolaPageContent() {
           <div className="p-2 rounded bg-black/30 text-ds-text-muted text-sm">
             {t('header.cpu')}: {cpu?.cardCount ?? 0} / {t('header.tricks')}: {cpu?.trickCount ?? 0}
           </div>
-          <div
-            className="flex items-center gap-2 rounded bg-black/30 p-2"
-            data-testid="briscola-stock"
-            aria-label={state.trumpCard ? t('header.trump') : t('header.trumpNone')}
-          >
+          <div className="flex items-center gap-2 rounded bg-black/30 p-2" data-testid="briscola-stock">
             <span className="text-ds-text-muted text-sm">
               {state.trumpCard ? t('header.trump') : t('header.trumpNone')}
             </span>
@@ -152,7 +148,6 @@ function BriscolaPageContent() {
                     className="absolute left-1/2 top-1/2 -translate-y-1/2"
                     style={{ transform: 'translate(0,-50%)' }}
                     data-testid="briscola-stock-deck"
-                    aria-label={t('header.stock')}
                   >
                     <div className="relative">
                       {Array.from({ length: Math.min(state.stockRemaining, 4) }, (_, i) => (


### PR DESCRIPTION
## Summary
- Render the face-up briscola trump rotated 90° behind a small stack of card-backs.
- The visible thickness of the back-stack tapers to the remaining stock count (capped at 4 layers) so players can see the deck thinning physically as cards are drawn.
- Pure visual — no API or layout changes elsewhere.

## Test plan
- [x] \`bun run test -- --run src/pages/BriscolaPage.test.tsx\` (11 existing tests pass)
- [ ] tsc + build verified by CI

Closes #1959