### PR TITLE
feat(baccarat,dragontiger): trend bar + streak badge above Big Road

### DIFF
--- a/frontend/src/components/RoadmapTrendBar.test.tsx
+++ b/frontend/src/components/RoadmapTrendBar.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { RoadmapTrendBar } from './RoadmapTrendBar';
+
+const baseProps = {
+  leftCode: 1,
+  rightCode: 2,
+  leftLabel: 'P',
+  rightLabel: 'B',
+};
+
+describe('RoadmapTrendBar', () => {
+  it('returns null for empty history', () => {
+    const { container } = render(<RoadmapTrendBar history={[]} {...baseProps} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows a streak badge with fire when 3+ in a row', () => {
+    render(<RoadmapTrendBar history={[2, 1, 1, 1]} {...baseProps} />);
+    expect(screen.getByTestId('roadmap-trend-streak')).toBeInTheDocument();
+  });
+
+  it('does not show fire badge when streak is < 3', () => {
+    render(<RoadmapTrendBar history={[1, 2, 2]} {...baseProps} />);
+    expect(screen.queryByTestId('roadmap-trend-streak')).not.toBeInTheDocument();
+  });
+
+  it('ignores neutral outcomes when computing streaks', () => {
+    // Ties (code 0) shouldn't break the run of 1s.
+    render(<RoadmapTrendBar history={[1, 0, 1, 0, 1]} {...baseProps} />);
+    expect(screen.getByTestId('roadmap-trend-streak')).toBeInTheDocument();
+  });
+
+  it('renders percentage labels for both sides', () => {
+    render(<RoadmapTrendBar history={[1, 1, 2, 2]} {...baseProps} />);
+    expect(screen.getByText('P 50%')).toBeInTheDocument();
+    expect(screen.getByText('50% B')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/RoadmapTrendBar.tsx
+++ b/frontend/src/components/RoadmapTrendBar.tsx
@@ -61,7 +61,6 @@ export function RoadmapTrendBar({
   }
   const sideOnly = recent.length;
   const leftWins = recent.filter((r) => r === leftCode).length;
-  const rightWins = sideOnly - leftWins;
   const leftPct = sideOnly === 0 ? 50 : Math.round((leftWins / sideOnly) * 100);
   const rightPct = 100 - leftPct;
   const streakLabel = streakSide === leftCode ? leftLabel : streakSide === rightCode ? rightLabel : null;

--- a/frontend/src/components/RoadmapTrendBar.tsx
+++ b/frontend/src/components/RoadmapTrendBar.tsx
@@ -1,0 +1,98 @@
+import { useTranslation } from 'react-i18next';
+
+/** Props for the RoadmapTrendBar component. */
+export interface RoadmapTrendBarProps {
+  /**
+   * Outcome history. Each element must be a numeric side code. Any value not
+   * matching `leftCode` or `rightCode` is treated as neutral (e.g. Tie) and
+   * does not break the streak.
+   */
+  history: readonly number[];
+  /** Numeric code for the "left" side (e.g. Player / Dragon). */
+  leftCode: number;
+  /** Numeric code for the "right" side (e.g. Banker / Tiger). */
+  rightCode: number;
+  /** Localized labels for the two sides. */
+  leftLabel: string;
+  rightLabel: string;
+  /** How many recent outcomes to include in the win-rate split. Default 12. */
+  lookback?: number;
+  /** Test id for the root element. */
+  testId?: string;
+}
+
+/**
+ * Renders a horizontal split bar showing each side's win share over the last
+ * `lookback` non-neutral outcomes, plus a streak badge (with a 🔥 indicator
+ * when the streak reaches 3+). Returns null when the history is empty.
+ */
+export function RoadmapTrendBar({
+  history,
+  leftCode,
+  rightCode,
+  leftLabel,
+  rightLabel,
+  lookback = 12,
+  testId,
+}: RoadmapTrendBarProps) {
+  const { t } = useTranslation('common');
+  if (history.length === 0) return null;
+
+  // Streak: trailing run of equal sides (ignoring neutral outcomes).
+  let streakSide: number | null = null;
+  let streakCount = 0;
+  for (let i = history.length - 1; i >= 0; i -= 1) {
+    const r = history[i];
+    if (r !== leftCode && r !== rightCode) continue;
+    if (streakSide === null) {
+      streakSide = r;
+      streakCount = 1;
+    } else if (r === streakSide) {
+      streakCount += 1;
+    } else {
+      break;
+    }
+  }
+
+  const recent: number[] = [];
+  for (let i = history.length - 1; i >= 0 && recent.length < lookback; i -= 1) {
+    const r = history[i];
+    if (r === leftCode || r === rightCode) recent.push(r);
+  }
+  const sideOnly = recent.length;
+  const leftWins = recent.filter((r) => r === leftCode).length;
+  const rightWins = sideOnly - leftWins;
+  const leftPct = sideOnly === 0 ? 50 : Math.round((leftWins / sideOnly) * 100);
+  const rightPct = 100 - leftPct;
+  const streakLabel = streakSide === leftCode ? leftLabel : streakSide === rightCode ? rightLabel : null;
+  const showFire = streakCount >= 3 && streakLabel !== null;
+
+  return (
+    <div className="mb-2" data-testid={testId ?? 'roadmap-trend-bar'}>
+      <div className="mb-1 flex items-center justify-between text-[10px] text-ds-text-muted">
+        <span>
+          {leftLabel} {leftPct}%
+        </span>
+        {showFire && streakLabel ? (
+          <span className="font-bold text-ds-warning" data-testid="roadmap-trend-streak">
+            🔥 {streakLabel} {t('roadmapTrend.streak', { count: streakCount, defaultValue: '{{count}} in a row' })}
+          </span>
+        ) : (
+          <span>
+            {t('roadmapTrend.lookback', {
+              count: sideOnly,
+              defaultValue: 'Last {{count}}',
+            })}
+          </span>
+        )}
+        <span>
+          {rightPct}% {rightLabel}
+        </span>
+      </div>
+      <div className="flex h-1.5 overflow-hidden rounded bg-black/30">
+        <div className="bg-ds-info" style={{ width: `${leftPct}%` }} aria-hidden="true" />
+        <div className="bg-ds-error" style={{ width: `${rightPct}%` }} aria-hidden="true" />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -546,5 +546,9 @@
     "requestedPath": "Requested path",
     "actionDiscover": "Find a game",
     "actionHome": "Back to home"
+  },
+  "roadmapTrend": {
+    "streak": "{{count}} in a row",
+    "lookback": "Last {{count}}"
   }
 }

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -546,5 +546,9 @@
     "requestedPath": "要求されたパス",
     "actionDiscover": "おすすめを探す",
     "actionHome": "ホームに戻る"
+  },
+  "roadmapTrend": {
+    "streak": "{{count}}連勝中",
+    "lookback": "直近 {{count}} 戦"
   }
 }

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -12,6 +12,7 @@ import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
+import { RoadmapTrendBar } from '../components/RoadmapTrendBar';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
@@ -410,6 +411,14 @@ function BaccaratPageContent() {
               {state.history.length > 0 && (
                 <div className="text-ds-text-primary text-sm font-bold mb-1">{t('road.title')}</div>
               )}
+              <RoadmapTrendBar
+                history={state.history}
+                leftCode={ROAD_PLAYER}
+                rightCode={ROAD_BANKER}
+                leftLabel={t('betType.player')}
+                rightLabel={t('betType.banker')}
+                testId="baccarat-trend-bar"
+              />
               <BigRoadGrid history={state.history} />
               {state.history.length > 0 && (
                 <button

--- a/frontend/src/pages/DragonTigerPage.tsx
+++ b/frontend/src/pages/DragonTigerPage.tsx
@@ -11,6 +11,7 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
+import { RoadmapTrendBar } from '../components/RoadmapTrendBar';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -162,6 +163,16 @@ function DragonTigerPageContent() {
             {state.history.length > 0 && (
               <div className="mb-4" data-testid="bigroad">
                 <div className="text-ds-text-primary text-center text-sm font-bold mb-1">{t('label.bigRoad')}</div>
+                <div className="mx-auto max-w-3xl">
+                  <RoadmapTrendBar
+                    history={state.history}
+                    leftCode={DragonTigerHistoryResult.DRAGON}
+                    rightCode={DragonTigerHistoryResult.TIGER}
+                    leftLabel={t('label.dragon')}
+                    rightLabel={t('label.tiger')}
+                    testId="dragontiger-trend-bar"
+                  />
+                </div>
                 <div className="flex justify-center gap-1 flex-wrap max-w-3xl mx-auto">
                   {state.history.map((r, i) => {
                     const label =


### PR DESCRIPTION
## Summary
- New \`RoadmapTrendBar\` component computes the trailing-streak length and recent win share (last ~12 non-neutral outcomes) for two sides.
- Renders a horizontal split bar (info vs. error tint) with each side's % share and a 🔥 streak badge when 3+ in a row.
- Wired above the existing Big Road grid on Baccarat (Player/Banker) and Dragon Tiger (Dragon/Tiger).

## Test plan
- [x] \`bun run test -- --run src/components/RoadmapTrendBar.test.tsx\` (5 cases incl. tie-skip + percentage rendering)
- [x] \`bun run test -- --run src/pages/BaccaratPage.test.tsx src/pages/DragonTigerPage.test.tsx\` (existing tests still pass)
- [ ] tsc + build verified by CI

Closes #1960