### PR TITLE
feat(holdem): glow best-5 + dim kickers at showdown

### DIFF
--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -43,6 +43,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { HOLDEM_HELP, parseHoldemCommand } from '../utils/cli/commands/holdemCommands';
 import { formatHoldemState } from '../utils/cli/formatters/holdemFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { holdemBestFive } from '../utils/holdemBestFive';
 
 /** Texas Hold'em tutorial step definitions. */
 const HE_TUTORIAL_STEPS: TutorialStep[] = [
@@ -163,6 +164,28 @@ function HoldemPageContent() {
   const isActive = phase >= HoldemPhase.PRE_FLOP && phase <= HoldemPhase.RIVER;
   const isShowdown = phase === HoldemPhase.SHOWDOWN || phase === HoldemPhase.END;
   const humanPlayer = state?.players?.find((p) => p.isHuman);
+  // Best-5 highlight at showdown: enumerate hole + community → mark which of
+  // the 7 visible cards contribute to the winning 5-card hand. Indices 0..1
+  // map to the hole cards, 2..6 to the community board.
+  const showdownBest5 = useMemo(() => {
+    if (!isShowdown || !humanPlayer || humanPlayer.folded) {
+      return { holeSet: new Set<number>(), boardSet: new Set<number>() };
+    }
+    const hole = humanPlayer?.cards ?? [];
+    const board = state?.communityCards ?? [];
+    if (hole.length !== 2 || board.length < 5) {
+      return { holeSet: new Set<number>(), boardSet: new Set<number>() };
+    }
+    const combined = [...hole, ...board.slice(0, 5)];
+    const picked = holdemBestFive(combined) ?? [];
+    const holeSet = new Set<number>();
+    const boardSet = new Set<number>();
+    for (const i of picked) {
+      if (i < hole.length) holeSet.add(i);
+      else boardSet.add(i - hole.length);
+    }
+    return { holeSet, boardSet };
+  }, [isShowdown, humanPlayer, state?.communityCards]);
   const humanFolded = humanPlayer?.folded ?? false;
   const humanAllIn = humanPlayer?.allIn ?? false;
   const canAct = isActive && !humanFolded && !humanAllIn && state?.currentTurn === humanPlayer?.id;
@@ -252,14 +275,21 @@ function HoldemPageContent() {
                   <div className="text-ds-text-primary text-lg mb-1.5">{t('communityCards')}</div>
                   <div className="flex flex-wrap gap-2">
                     {state?.communityCards?.length
-                      ? state.communityCards.map((card) => (
-                          <AnimatedCard
-                            key={`${card.design}-${card.value}`}
-                            card={card}
-                            width={cardWidth}
-                            style={placeholderCardStyle}
-                          />
-                        ))
+                      ? state.communityCards.map((card, idx) => {
+                          const inBest = showdownBest5.boardSet.has(idx);
+                          const dim = isShowdown && showdownBest5.boardSet.size > 0 && !inBest;
+                          return (
+                            <div
+                              key={`${card.design}-${card.value}`}
+                              className={`transition-all ${
+                                inBest ? '-translate-y-1 ring-2 ring-ds-success motion-safe:animate-pulse' : ''
+                              } ${dim ? 'opacity-50' : ''}`}
+                              data-best5-board={inBest || undefined}
+                            >
+                              <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
+                            </div>
+                          );
+                        })
                       : Array.from({ length: 5 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                   </div>
                 </>
@@ -353,14 +383,21 @@ function HoldemPageContent() {
                 </div>
                 <div className="flex flex-wrap gap-1.5 mb-2">
                   {humanPlayer.cards?.length
-                    ? humanPlayer.cards.map((card) => (
-                        <AnimatedCard
-                          key={`${card.design}-${card.value}`}
-                          card={card}
-                          width={cardWidth}
-                          style={placeholderCardStyle}
-                        />
-                      ))
+                    ? humanPlayer.cards.map((card, idx) => {
+                        const inBest = showdownBest5.holeSet.has(idx);
+                        const dim = isShowdown && showdownBest5.holeSet.size > 0 && !inBest;
+                        return (
+                          <div
+                            key={`${card.design}-${card.value}`}
+                            className={`transition-all ${
+                              inBest ? '-translate-y-1 ring-2 ring-ds-success motion-safe:animate-pulse' : ''
+                            } ${dim ? 'opacity-50' : ''}`}
+                            data-best5-hole={inBest || undefined}
+                          >
+                            <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
+                          </div>
+                        );
+                      })
                     : !humanPlayer.folded &&
                       Array.from({ length: 2 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                 </div>

--- a/frontend/src/utils/holdemBestFive.test.ts
+++ b/frontend/src/utils/holdemBestFive.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { holdemBestFive } from './holdemBestFive';
+
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('holdemBestFive', () => {
+  it('returns null for fewer than 5 cards', () => {
+    expect(holdemBestFive([c('SPADE', 2), c('CLOVER', 3)])).toBeNull();
+  });
+
+  it('picks a four-of-a-kind over an unrelated flush', () => {
+    const cards = [
+      c('SPADE', 9),
+      c('CLOVER', 9),
+      c('HEART', 9),
+      c('DIAMOND', 9),
+      c('SPADE', 5),
+      c('SPADE', 7),
+      c('SPADE', 3),
+    ];
+    const picked = holdemBestFive(cards)!;
+    const values = picked.map((i) => cards[i].value).sort((a, b) => a - b);
+    // Quad 9s + highest available kicker (7).
+    expect(values).toEqual([7, 9, 9, 9, 9]);
+  });
+
+  it('prefers a flush over two pair', () => {
+    const cards = [
+      c('SPADE', 2),
+      c('SPADE', 4),
+      c('SPADE', 6),
+      c('SPADE', 8),
+      c('SPADE', 10),
+      c('HEART', 4),
+      c('HEART', 6),
+    ];
+    const picked = holdemBestFive(cards)!.map((i) => cards[i]);
+    expect(picked.every((card) => card.design === 'SPADE')).toBe(true);
+  });
+
+  it('recognizes the wheel straight (A-2-3-4-5)', () => {
+    const cards = [
+      c('SPADE', 1),
+      c('CLOVER', 2),
+      c('HEART', 3),
+      c('DIAMOND', 4),
+      c('SPADE', 5),
+      c('HEART', 9),
+      c('CLOVER', 10),
+    ];
+    const picked = holdemBestFive(cards)!
+      .map((i) => cards[i].value)
+      .sort((a, b) => a - b);
+    expect(picked).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('picks the higher kicker on one-pair ties', () => {
+    const cards = [
+      c('SPADE', 10),
+      c('CLOVER', 10),
+      c('HEART', 13), // K
+      c('DIAMOND', 9),
+      c('SPADE', 4),
+      c('CLOVER', 7),
+      c('HEART', 2),
+    ];
+    const picked = holdemBestFive(cards)!
+      .map((i) => cards[i].value)
+      .sort((a, b) => a - b);
+    // Pair of 10s plus K, 9, 7 kickers.
+    expect(picked).toEqual([7, 9, 10, 10, 13]);
+  });
+
+  it('picks 5 community cards when those are better than including hole cards', () => {
+    // Royal flush on the board.
+    const cards = [
+      c('HEART', 2), // hole
+      c('SPADE', 3), // hole
+      c('HEART', 10),
+      c('HEART', 11),
+      c('HEART', 12),
+      c('HEART', 13),
+      c('HEART', 1), // Ace high
+    ];
+    const picked = holdemBestFive(cards)!.map((i) => cards[i]);
+    expect(picked.every((card) => card.design === 'HEART')).toBe(true);
+  });
+});

--- a/frontend/src/utils/holdemBestFive.ts
+++ b/frontend/src/utils/holdemBestFive.ts
@@ -1,0 +1,123 @@
+import type { Card } from '../types/card';
+
+/**
+ * Choose the best 5-card poker hand out of a 7-card set (2 hole + 5 community).
+ * Returns the indices (into the input array) of the 5 cards that comprise the
+ * best hand, or `null` if fewer than 5 cards are supplied.
+ *
+ * The evaluator scores each of the 21 5-card subsets and picks the highest.
+ * Hand ordering uses a lexicographic tuple:
+ *   [category, primary..., kickers...]
+ * with Aces both high (14) and as the low end of A-2-3-4-5 (wheel).
+ */
+export function holdemBestFive(cards: readonly Card[]): number[] | null {
+  if (cards.length < 5) return null;
+
+  let bestScore: number[] = [];
+  let bestIdx: number[] = [];
+  const n = cards.length;
+  for (let a = 0; a < n - 4; a += 1) {
+    for (let b = a + 1; b < n - 3; b += 1) {
+      for (let c = b + 1; c < n - 2; c += 1) {
+        for (let d = c + 1; d < n - 1; d += 1) {
+          for (let e = d + 1; e < n; e += 1) {
+            const idx = [a, b, c, d, e];
+            const score = scoreFive(idx.map((i) => cards[i]));
+            if (compareScores(score, bestScore) > 0) {
+              bestScore = score;
+              bestIdx = idx;
+            }
+          }
+        }
+      }
+    }
+  }
+  return bestIdx;
+}
+
+function compareScores(a: readonly number[], b: readonly number[]): number {
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i += 1) {
+    const av = a[i] ?? 0;
+    const bv = b[i] ?? 0;
+    if (av !== bv) return av - bv;
+  }
+  return 0;
+}
+
+function rankValue(card: Card): number {
+  // Treat Aces as high (14); the straight check handles the wheel separately.
+  return card.value === 1 ? 14 : card.value;
+}
+
+function scoreFive(hand: readonly Card[]): number[] {
+  const ranks = hand.map(rankValue).sort((x, y) => y - x);
+  const suits = hand.map((c) => c.design);
+  const flush = suits.every((s) => s === suits[0]);
+  const uniq = Array.from(new Set(ranks)).sort((x, y) => y - x);
+  const straight = isStraight(uniq);
+
+  // Group by rank, sort by (count desc, rank desc).
+  const counts = new Map<number, number>();
+  for (const r of ranks) counts.set(r, (counts.get(r) ?? 0) + 1);
+  const grouped = Array.from(counts.entries()).sort((a, b) => b[1] - a[1] || b[0] - a[0]);
+
+  if (flush && straight !== null) {
+    if (straight === 14) return [9, 14, 13, 12, 11, 10];
+    return [9, straight];
+  }
+  if (grouped[0][1] === 4) {
+    const four = grouped[0][0];
+    const kicker = grouped[1][0];
+    return [8, four, kicker];
+  }
+  if (grouped[0][1] === 3 && grouped[1] && grouped[1][1] === 2) {
+    return [7, grouped[0][0], grouped[1][0]];
+  }
+  if (flush) {
+    return [6, ...ranks];
+  }
+  if (straight !== null) {
+    return [5, straight];
+  }
+  if (grouped[0][1] === 3) {
+    const three = grouped[0][0];
+    const kickers = grouped.slice(1).map(([r]) => r);
+    return [4, three, ...kickers];
+  }
+  if (grouped[0][1] === 2 && grouped[1] && grouped[1][1] === 2) {
+    const [hi, lo] = grouped[0][0] > grouped[1][0] ? [grouped[0][0], grouped[1][0]] : [grouped[1][0], grouped[0][0]];
+    const kicker = grouped[2]?.[0] ?? 0;
+    return [3, hi, lo, kicker];
+  }
+  if (grouped[0][1] === 2) {
+    const pair = grouped[0][0];
+    const kickers = grouped.slice(1).map(([r]) => r);
+    return [2, pair, ...kickers];
+  }
+  return [1, ...ranks];
+}
+
+/**
+ * Return the high card of a 5-rank straight if present, otherwise null.
+ * Aces as wheel (A-2-3-4-5 = high 5) are handled via the duplicate-low-1 pass.
+ */
+function isStraight(uniqSortedDesc: readonly number[]): number | null {
+  if (uniqSortedDesc.length < 5) return null;
+  // Regular: 5 consecutive.
+  for (let i = 0; i + 4 < uniqSortedDesc.length; i += 1) {
+    if (uniqSortedDesc[i] - uniqSortedDesc[i + 4] === 4) return uniqSortedDesc[i];
+  }
+  // Wheel: A-2-3-4-5 (Aces stored as 14 here).
+  const withWheel = uniqSortedDesc.slice();
+  if (
+    withWheel[0] === 14 &&
+    withWheel.includes(5) &&
+    withWheel.includes(4) &&
+    withWheel.includes(3) &&
+    withWheel.includes(2)
+  ) {
+    return 5;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- New \`holdemBestFive\` evaluator enumerates the 21 5-card subsets of 2 hole + 5 community cards and returns the indices of the strongest hand (handles flushes, full houses, four-of-a-kind, the wheel straight, and high-card tiebreaks).
- At showdown HoldemPage paints contributing cards with a success ring + translate-y-1 and dims kickers/uninvolved cards to opacity-50 so the reason for the win/loss is visible at a glance.

## Test plan
- [x] \`bun run test -- --run src/utils/holdemBestFive.test.ts\` (6 cases incl. wheel, kickers, board-only royal flush)
- [x] \`bun run test -- --run src/pages/HoldemPage.test.tsx\` (113 existing tests still pass)
- [ ] tsc + build verified by CI

Closes #1962