### PR TITLE
feat(russian,yukon): hover-glow the movable block

### DIFF
--- a/frontend/src/pages/RussianSolitairePage.tsx
+++ b/frontend/src/pages/RussianSolitairePage.tsx
@@ -160,6 +160,13 @@ function RussianSolitairePageContent() {
   useMountReset(apiExec);
 
   const [selectedSource, setSelectedSource] = useState<RussianSolitaireMoveZone | null>(null);
+  /**
+   * The tableau coordinate the mouse is currently over. Russian Solitaire
+   * lets a player grab any face-up card AND drag every card above it as a
+   * loose block, so on hover we glow every card from `cardIdx` to the column's
+   * tail to make the moving block visually unambiguous.
+   */
+  const [hoveredBlock, setHoveredBlock] = useState<{ col: number; cardIdx: number } | null>(null);
 
   const {
     hint: frontendHint,
@@ -446,32 +453,44 @@ function RussianSolitairePageContent() {
                               isDropTarget={isLast && dnd.isDropTarget({ zone: 'tableau', col: colIdx })}
                             >
                               {tc.faceUp ? (
-                                <button
-                                  type="button"
-                                  draggable={isPlaying}
-                                  onDragStart={dnd.handleDragStart(zone)}
-                                  onDragEnd={dnd.handleDragEnd}
-                                  className={`${focusRingWhite} rounded-lg transition-all ${
-                                    isSelected ? 'ring-2 ring-ds-warning -translate-y-1' : ''
-                                  } ${isDragSrc ? 'opacity-50' : ''} ${
-                                    hintFrom ? 'ring-2 ring-ds-info motion-safe:animate-pulse' : ''
-                                  } ${hintTo ? 'ring-2 ring-ds-success motion-safe:animate-pulse' : ''}`}
-                                  onClick={() => {
-                                    if (selectedSource) {
-                                      if (isLast) {
-                                        handleSelectTarget('tableau', colIdx);
-                                      } else {
-                                        handleSelectSource('tableau', colIdx, cardIdx);
-                                      }
-                                    } else {
-                                      handleSelectSource('tableau', colIdx, cardIdx);
-                                    }
-                                  }}
-                                  disabled={!isPlaying}
-                                  aria-label={tc.card ? cardAlt(tc.card) : ''}
-                                >
-                                  {tc.card && <AnimatedCard card={tc.card} width={rs.cw} />}
-                                </button>
+                                (() => {
+                                  const inHoverBlock = hoveredBlock?.col === colIdx && cardIdx >= hoveredBlock.cardIdx;
+                                  return (
+                                    <button
+                                      type="button"
+                                      draggable={isPlaying}
+                                      onDragStart={dnd.handleDragStart(zone)}
+                                      onDragEnd={dnd.handleDragEnd}
+                                      onMouseEnter={() => setHoveredBlock({ col: colIdx, cardIdx })}
+                                      onMouseLeave={() => setHoveredBlock(null)}
+                                      onFocus={() => setHoveredBlock({ col: colIdx, cardIdx })}
+                                      onBlur={() => setHoveredBlock(null)}
+                                      data-block-member={inHoverBlock || undefined}
+                                      className={`${focusRingWhite} rounded-lg transition-all ${
+                                        isSelected ? 'ring-2 ring-ds-warning -translate-y-1' : ''
+                                      } ${isDragSrc ? 'opacity-50' : ''} ${
+                                        hintFrom ? 'ring-2 ring-ds-info motion-safe:animate-pulse' : ''
+                                      } ${hintTo ? 'ring-2 ring-ds-success motion-safe:animate-pulse' : ''} ${
+                                        inHoverBlock && !isSelected ? 'ring-2 ring-ds-accent/70' : ''
+                                      }`}
+                                      onClick={() => {
+                                        if (selectedSource) {
+                                          if (isLast) {
+                                            handleSelectTarget('tableau', colIdx);
+                                          } else {
+                                            handleSelectSource('tableau', colIdx, cardIdx);
+                                          }
+                                        } else {
+                                          handleSelectSource('tableau', colIdx, cardIdx);
+                                        }
+                                      }}
+                                      disabled={!isPlaying}
+                                      aria-label={tc.card ? cardAlt(tc.card) : ''}
+                                    >
+                                      {tc.card && <AnimatedCard card={tc.card} width={rs.cw} />}
+                                    </button>
+                                  );
+                                })()
                               ) : (
                                 <AnimatedCardBack width={rs.cw} />
                               )}

--- a/frontend/src/pages/YukonPage.tsx
+++ b/frontend/src/pages/YukonPage.tsx
@@ -156,6 +156,12 @@ function YukonPageContent() {
   useMountReset(apiExec);
 
   const [selectedSource, setSelectedSource] = useState<YukonMoveZone | null>(null);
+  /**
+   * Yukon allows grabbing any face-up card and dragging it together with every
+   * card sitting above it (regardless of suit/rank order). On hover we glow
+   * the entire moving block so the player can see what they're about to lift.
+   */
+  const [hoveredBlock, setHoveredBlock] = useState<{ col: number; cardIdx: number } | null>(null);
 
   const {
     hint: frontendHint,
@@ -434,32 +440,44 @@ function YukonPageContent() {
                               isDropTarget={isLast && dnd.isDropTarget({ zone: 'tableau', col: colIdx })}
                             >
                               {tc.faceUp ? (
-                                <button
-                                  type="button"
-                                  draggable={isPlaying}
-                                  onDragStart={dnd.handleDragStart(zone)}
-                                  onDragEnd={dnd.handleDragEnd}
-                                  className={`${focusRingWhite} rounded-lg transition-all ${
-                                    isSelected ? 'ring-2 ring-ds-warning -translate-y-1' : ''
-                                  } ${isDragSrc ? 'opacity-50' : ''} ${
-                                    hintFrom ? 'ring-2 ring-ds-info motion-safe:animate-pulse' : ''
-                                  } ${hintTo ? 'ring-2 ring-ds-success motion-safe:animate-pulse' : ''}`}
-                                  onClick={() => {
-                                    if (selectedSource) {
-                                      if (isLast) {
-                                        handleSelectTarget('tableau', colIdx);
-                                      } else {
-                                        handleSelectSource('tableau', colIdx, cardIdx);
-                                      }
-                                    } else {
-                                      handleSelectSource('tableau', colIdx, cardIdx);
-                                    }
-                                  }}
-                                  disabled={!isPlaying}
-                                  aria-label={tc.card ? cardAlt(tc.card) : ''}
-                                >
-                                  {tc.card && <AnimatedCard card={tc.card} width={yk.cw} />}
-                                </button>
+                                (() => {
+                                  const inHoverBlock = hoveredBlock?.col === colIdx && cardIdx >= hoveredBlock.cardIdx;
+                                  return (
+                                    <button
+                                      type="button"
+                                      draggable={isPlaying}
+                                      onDragStart={dnd.handleDragStart(zone)}
+                                      onDragEnd={dnd.handleDragEnd}
+                                      onMouseEnter={() => setHoveredBlock({ col: colIdx, cardIdx })}
+                                      onMouseLeave={() => setHoveredBlock(null)}
+                                      onFocus={() => setHoveredBlock({ col: colIdx, cardIdx })}
+                                      onBlur={() => setHoveredBlock(null)}
+                                      data-block-member={inHoverBlock || undefined}
+                                      className={`${focusRingWhite} rounded-lg transition-all ${
+                                        isSelected ? 'ring-2 ring-ds-warning -translate-y-1' : ''
+                                      } ${isDragSrc ? 'opacity-50' : ''} ${
+                                        hintFrom ? 'ring-2 ring-ds-info motion-safe:animate-pulse' : ''
+                                      } ${hintTo ? 'ring-2 ring-ds-success motion-safe:animate-pulse' : ''} ${
+                                        inHoverBlock && !isSelected ? 'ring-2 ring-ds-accent/70' : ''
+                                      }`}
+                                      onClick={() => {
+                                        if (selectedSource) {
+                                          if (isLast) {
+                                            handleSelectTarget('tableau', colIdx);
+                                          } else {
+                                            handleSelectSource('tableau', colIdx, cardIdx);
+                                          }
+                                        } else {
+                                          handleSelectSource('tableau', colIdx, cardIdx);
+                                        }
+                                      }}
+                                      disabled={!isPlaying}
+                                      aria-label={tc.card ? cardAlt(tc.card) : ''}
+                                    >
+                                      {tc.card && <AnimatedCard card={tc.card} width={yk.cw} />}
+                                    </button>
+                                  );
+                                })()
                               ) : (
                                 <AnimatedCardBack width={yk.cw} />
                               )}


### PR DESCRIPTION
## Summary
- Track a \`hoveredBlock\` coordinate and paint every face-up tableau card from \`cardIdx\` to the column tail with an accent ring on hover/focus.
- Both Russian Solitaire and Yukon allow grabbing a face-up card with every card above it regardless of order; the new highlight makes that ruleset visible before the drag commits.

## Test plan
- [x] \`bun run test -- --run src/pages/RussianSolitairePage.test.tsx src/pages/YukonPage.test.tsx\` (30 existing tests pass)
- [ ] tsc + build verified by CI

Closes #1963