### PR TITLE
docs: fix documentation drift — update game counts to 104

### DIFF
--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -6,7 +6,7 @@
 
 - [1. クラス図](#1-クラス図)
   - [1.1 コアドメイン (カード・プレイヤー)](#11-コアドメイン-カードプレイヤー)
-  - [1.2 ゲームドメイン (全101ゲーム)](#12-ゲームドメイン-全101ゲーム)
+  - [1.2 ゲームドメイン (全104ゲーム)](#12-ゲームドメイン-全104ゲーム)
   - [1.3 ユースケース層 (Interactor・Presenter)](#13-ユースケース層-interactorpresenter)
   - [1.4 アダプタ層 (Controller・Presenter実装)](#14-アダプタ層-controllerpresenter実装)
   - [1.5 インフラストラクチャ層](#15-インフラストラクチャ層)
@@ -151,7 +151,7 @@ classDiagram
     GamePlayer *-- ChipHolder : mixin
 ```
 
-### 1.2 ゲームドメイン (全101ゲーム)
+### 1.2 ゲームドメイン (全104ゲーム)
 
 #### ベッティング系ゲーム
 
@@ -405,6 +405,32 @@ classDiagram
 
     CasinoWar --> "1" TrumpCards
     CasinoWar --> "1" ChipHolder
+
+    class RussianPoker {
+        -trumpCards *TrumpCards
+        -chipHolder *ChipHolder
+        -playerHand []*Card
+        -dealerHand []*Card
+        -phase int
+        -anteBet int
+        -playBet int
+        -exchangeCount int
+        -bought6th bool
+        +Reset()
+        +Bet(ante int) error
+        +Exchange(indices []int) error
+        +Buy6th() error
+        +Select(discardIndex int) error
+        +Play() error
+        +Fold() error
+        +ForceExchange() error
+        +Decline() error
+        +GetPhase() int
+        +GetActionLog() []*ActionLogEntry
+    }
+
+    RussianPoker --> "1" TrumpCards
+    RussianPoker --> "1" ChipHolder
 
     note for VideoPokerVariantConfig "DeucesWild・JokerPoker は独立したドメインクラスを持たず\nVideoPokerVariantConfig のファクトリ関数\n(DeucesWildConfig / JokerPokerConfig) として実装"
 ```
@@ -1552,11 +1578,58 @@ classDiagram
         +GetPhase() WhistPhase
     }
 
+    class EightOff {
+        -trumpCards *TrumpCards
+        -tableau [8][]*Card
+        -foundation [4][]*Card
+        -freeCells [8]*Card
+        -phase EightOffPhase
+        -history []*eightOffSnapshot
+        +Reset()
+        +MoveTableauToTableau(fromCol, cardIndex, toCol int) error
+        +MoveTableauToFoundation(col int) error
+        +MoveTableauToFreeCell(col, cell int) error
+        +MoveFreeCellToTableau(cell, col int) error
+        +MoveFreeCellToFoundation(cell int) error
+        +GiveUp()
+        +GetHint() *EightOffHint
+        +AutoComplete() error
+        +Undo() error
+        +UndoN(n int) error
+        +UndoToEscape() int
+        +GetPhase() EightOffPhase
+    }
+
+    class Penguin {
+        -trumpCards *TrumpCards
+        -tableau [7][]*Card
+        -foundation [4][]*Card
+        -freeCells [3]*Card
+        -baseRank int
+        -phase PenguinPhase
+        -history []*penguinSnapshot
+        +Reset()
+        +MoveTableauToTableau(fromCol, cardIndex, toCol int) error
+        +MoveTableauToFoundation(col int) error
+        +MoveTableauToFreeCell(col, cell int) error
+        +MoveFreeCellToTableau(cell, col int) error
+        +MoveFreeCellToFoundation(cell int) error
+        +GiveUp()
+        +GetHint() *PenguinHint
+        +AutoComplete() error
+        +Undo() error
+        +UndoN(n int) error
+        +UndoToEscape() int
+        +GetPhase() PenguinPhase
+    }
+
     Canfield --> "1" TrumpCards
     War --> "1" TrumpCards
     War --> "2" WarPlayer
     Whist --> "1" TrumpCards
     Whist --> "4" WhistPlayer
+    EightOff --> "1" TrumpCards
+    Penguin --> "1" TrumpCards
 ```
 
 ### 1.3 ユースケース層 (Interactor・Presenter)
@@ -1610,7 +1683,7 @@ classDiagram
     note for GamePresenter "各ゲームの Presenter は\nGamePresenter[G] の型エイリアス\nまたは拡張インターフェース"
 ```
 
-**Interactor パターン (全101ゲーム共通)**
+**Interactor パターン (全104ゲーム共通)**
 
 ```mermaid
 classDiagram
@@ -1682,8 +1755,8 @@ classDiagram
     GameCuiPresenter ..|> GamePresenter : implements
     GameWebPresenter ..|> GamePresenter : implements
 
-    note for GameCuiController "101ゲーム × CUI/Web = 202 Controller\nGameCuiController / GameWebController は\n各ゲーム毎に具体的な実装が存在"
-    note for GameCuiPresenter "101ゲーム × CUI/Web = 202 Presenter 実装"
+    note for GameCuiController "104ゲーム × CUI/Web = 208 Controller\nGameCuiController / GameWebController は\n各ゲーム毎に具体的な実装が存在"
+    note for GameCuiPresenter "104ゲーム × CUI/Web = 208 Presenter 実装"
 ```
 
 ### 1.5 インフラストラクチャ層
@@ -3464,5 +3537,49 @@ stateDiagram-v2
 ```
 
 Penguin は FreeCell のバリアントで、最初に配られたカードのランク (baseRank) が組札の開始ランクとなる。baseRank と同じランクの残り3枚は自動的にフリーセルに配置される。EightOff と同様にスーパームーブ `(1 + emptyFreeCells) × 2^(emptyTableauCols)` を使用するが、空列に入れるカードが prevRank(baseRank) に限定される点が異なる。
+
+### 3.53 EightOff フェーズ遷移
+
+```mermaid
+stateDiagram-v2
+    [*] --> Playing : Reset()
+    Playing --> Playing : Move() / Undo() / Hint() / AutoComplete()
+    Playing --> GameClear : 組札4スート全完成
+    Playing --> GameOver : GiveUp()
+    GameClear --> [*]
+    GameOver --> [*]
+
+    note right of Playing : EightOffPhasePlaying = 0\n8列×6枚 + フリーセル8個(4枚初期配置)\n同スート降順のタブロー構築\nスーパームーブ = (1 + emptyFreeCells) × 2^(emptyTableauCols)
+    note right of GameClear : EightOffPhaseGameClear = 1
+    note right of GameOver : EightOffPhaseGameOver = 2
+```
+
+EightOff は FreeCell のバリアントで、8列×6枚(計48枚)のタブローと8個のフリーセル(残り4枚が初期配置)を持つ。タブローは同スート降順で構築し、空列には King のみ配置可能。FreeCell と同じスーパームーブ計算式を使用する。
+
+### 3.54 RussianPoker フェーズ遷移
+
+```mermaid
+stateDiagram-v2
+    [*] --> Bet : Reset()
+    Bet --> Action : Bet(ante)
+    Action --> End : Fold()
+    Action --> End : Play() (ディーラー非クオリファイ or 決着)
+    Action --> ForceQualify : Play() (ディーラー非クオリファイ + プレイヤー勝ち)
+    Action --> PostAction : Exchange(indices)
+    Action --> Select : Buy6th()
+    Select --> PostAction : Select(discardIndex)
+    PostAction --> End : Fold()
+    PostAction --> End : Play()
+    PostAction --> ForceQualify : Play() (ディーラー非クオリファイ + プレイヤー勝ち)
+    ForceQualify --> End : ForceExchange() / Decline()
+    End --> [*]
+
+    note right of Bet : RussianPokerPhaseBet = 1\nアンティベット
+    note right of Action : RussianPokerPhaseAction = 2\nFold / Play / Exchange(最大2回) / Buy6th
+    note right of Select : RussianPokerPhaseSelect = 3\n6枚から5枚を選ぶ
+    note right of PostAction : RussianPokerPhasePostAction = 4\n交換・購入後の Fold / Play 選択
+    note right of ForceQualify : RussianPokerPhaseForceQualify = 5\nアンティ追加でディーラー強制クオリファイ
+    note right of End : RussianPokerPhaseEnd = 6\n配当計算・結果表示
+```
 
 **注:** OldMaid・Daifugo・Sevens・President はターン制で進行する手札削り系のため、明示的なフェーズ定数を持ちません (currentTurn が巡回し、全プレイヤーの手札が 0 枚またはランクが確定するまで進行)。

--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -436,7 +436,7 @@ classDiagram
         +object messageParams
     }
 
-    note for BlackJackResponse "各ゲームが固有のResponse型を持つ\n(全101ゲーム分存在)\n共通フィールド: message, messageCode, messageParams"
+    note for BlackJackResponse "各ゲームが固有のResponse型を持つ\n(全104ゲーム分存在)\n共通フィールド: message, messageCode, messageParams"
 ```
 
 **フェーズ定数 (全ゲーム)**
@@ -867,7 +867,7 @@ classDiagram
     class actionLogApi {
         +blackjack() Promise~ActionLogResponse~
         +poker() Promise~ActionLogResponse~
-        ...全101ゲーム()
+        ...全104ゲーム()
     }
 
     BlackJackApi --> gameApi : uses postJson/gameExec
@@ -929,7 +929,7 @@ classDiagram
 
     RedDogApi --> gameApi : uses postJson/gameExec
 
-    note for BlackJackApi "全102ゲーム分のAPI Objectが存在\n(blackjack, spanish21, poker, oldmaid, daifugo,\nsevens, doubt, holdem, omaha, omahahilo, shortdeck,\npineapple, crazypineapple, hearts, memory, klondike, freecell,\nseahaventowers, cruel, baccarat, spades, twotenjack, crazyeights,\nginrummy, canasta, spider, spiderette, napoleon, mighty,\nindianpoker, videopoker, deuceswild, jokerpoker, euchre, pyramid, tripeaks,\ncribbage, threecard, caribbeanstud, texasholdembonus,\nultimatetexasholdem, mississippistud, ohhell, bridge, speed,\ngofish, pinochle, golf, pigtail,\nsevencardstud, clocksolitaire, durak,\nfortythieves, paigow, war, canfield, fiftyone, yukon, russiansolitaire, scorpion, accordion, whist,\nletitride, pokersquares, pageone, reddog, razz, badugi, trash,\nsevenbridge, president, cassino, calculation, crescent, spiteandmalice,\nskat, shithead, nertz, slapjack, egyptianratscrew, bakersdozen, tonk,\ncasinowar, pitch, dragontiger, blackjackswitch, montecarlo, contractrummy, belote,\noasispoker, beleagueredcastle, piquet, casinoholdem, callbreak,\nhighcardflush, fourcardpoker, briscola, tarneeb, gaps, rummy500, eightoff, penguin)"
+    note for BlackJackApi "全104ゲーム分のAPI Objectが存在\n(blackjack, spanish21, poker, oldmaid, daifugo,\nsevens, doubt, bigtwo, holdem, omaha, omahahilo, shortdeck,\npineapple, crazypineapple, hearts, memory, klondike, freecell,\nseahaventowers, cruel, baccarat, spades, twotenjack, crazyeights,\nginrummy, canasta, spider, spiderette, napoleon, mighty,\nindianpoker, videopoker, deuceswild, jokerpoker, euchre, pyramid, tripeaks,\ncribbage, threecard, caribbeanstud, texasholdembonus,\nultimatetexasholdem, mississippistud, ohhell, bridge, speed,\ngofish, pinochle, golf, pigtail,\nsevencardstud, clocksolitaire, durak,\nfortythieves, paigow, war, canfield, fiftyone, yukon, russiansolitaire, scorpion, accordion, whist,\nletitride, pokersquares, pageone, reddog, razz, badugi, trash,\nsevenbridge, president, cassino, calculation, crescent, spiteandmalice,\nskat, shithead, nertz, slapjack, egyptianratscrew, bakersdozen, tonk,\ncasinowar, pitch, dragontiger, blackjackswitch, montecarlo, contractrummy, belote,\noasispoker, beleagueredcastle, piquet, casinoholdem, callbreak,\nhighcardflush, fourcardpoker, russianpoker, briscola, tarneeb, gaps, rummy500, eightoff, penguin)"
 ```
 
 ### 1.3 Hook 層 (共通Hook)
@@ -1308,7 +1308,7 @@ classDiagram
 
     useCanastaGame --> useGameApi : uses
 
-    note for useBlackJackGame "全101ゲーム分の固有Hookが存在\n各HookはuseGameApiで統一的にAPI呼出し\n必要に応じてuseCardSelectionを合成"
+    note for useBlackJackGame "全104ゲーム分の固有Hookが存在\n各HookはuseGameApiで統一的にAPI呼出し\n必要に応じてuseCardSelectionを合成"
 ```
 
 ### 1.5 コンポーネント層
@@ -1907,7 +1907,7 @@ classDiagram
     GamePage --> PokerTableLayout : renders (Hold'em/Omaha/ShortDeck/Pineapple/SevenCardStud/Razz)
     PokerTableLayout --> CpuPlayerCard : wraps
 
-    note for GamePage "全101ゲームページが同一パターンで構成\nuseGamePageSetup → ゲーム固有Hook → 描画"
+    note for GamePage "全104ゲームページが同一パターンで構成\nuseGamePageSetup → ゲーム固有Hook → 描画"
 ```
 
 ### 1.7 i18n・プロバイダー・ルーティング
@@ -1930,7 +1930,7 @@ classDiagram
         +HashRouter
         +ErrorBoundary
         +NavBar
-        +Routes (101ゲーム)
+        +Routes (104ゲーム)
     }
 
     class gameCategories {
@@ -1953,11 +1953,11 @@ classDiagram
     App --> i18n : initializes
     App --> gameCategories : routes from
     App --> NavBar : renders
-    App --> GamePage : routes to 101 pages
+    App --> GamePage : routes to 104 pages
     GamePage --> TutorialProvider : wraps (per-game)
     TutorialProvider --> TutorialOverlay : renders when active
 
-    note for i18n "103名前空間: common + 101ゲーム固有 + tutorial\n翻訳ファイル: locales/{ja,en}/game.json"
+    note for i18n "106名前空間: common + 104ゲーム固有 + tutorial\n翻訳ファイル: locales/{ja,en}/game.json"
 ```
 
 ### 1.8 AI Game Concierge (/discover)

--- a/internal/infrastructure/games/registry.go
+++ b/internal/infrastructure/games/registry.go
@@ -5,7 +5,7 @@
 // binaries (TinyGo / WASM) stay under the 1 MB gzipped free-tier limit:
 //
 //   - registry.go (this file, no tag)  — types and bare metadata (Name +
-//     Category) for all 96 games. Cheap; no references to game code.
+//     Category) for all 104 games. Cheap; no references to game code.
 //   - games_server.go (!js || !wasm)   — installs Web-server factories for
 //     every game via BindWebController. Imported by TrumpCardsWeb.
 //   - casino/, classic/, solo/ (js && wasm) — per-category worker bindings.


### PR DESCRIPTION
## Summary
- Update stale game counts (96/101/102 → 104) across `registry.go`, `docs/design/backend.md`, and `docs/design/frontend.md`
- Add missing class and state machine diagrams for EightOff, RussianPoker, and Penguin in `backend.md`
- Fix `frontend.md` API note game list (add `russianpoker`, `bigtwo`)

Closes #2084

## Test plan
- [ ] Verify no stale counts remain: `grep -rn '全101\|全96\|96 games\|101ゲーム\|102ゲーム' docs/design/ internal/infrastructure/games/registry.go`
- [ ] Verify Mermaid diagrams render correctly in GitHub