### PR TITLE
docs: fix documentation drift to match 110-game registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Go implementations of 106 trump card game algorithms (blackjack, poker, hearts, klondike, baccarat, ...). Run `go run ./cmd/trumpcards games --short` for the canonical list. Clean Architecture with CLI and Web GUI (React + Go REST API).
+Go implementations of 110 trump card game algorithms (blackjack, poker, hearts, klondike, baccarat, ...). Run `go run ./cmd/trumpcards games --short` for the canonical list. Clean Architecture with CLI and Web GUI (React + Go REST API).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ go_trumpcardsが目指す未来は、**あらゆる人がクリエイターと�
 
 ## Features
 
-Go + Clean Architecture で実装した106種類のトランプゲーム。CLI と Web GUI（React + Go REST API）の2つのインターフェースで遊べます。Web GUI は日英多言語対応。
+Go + Clean Architecture で実装した110種類のトランプゲーム。CLI と Web GUI（React + Go REST API）の2つのインターフェースで遊べます。Web GUI は日英多言語対応。
 
 | ゲーム | コマンド | マニュアル |
 |--------|----------|------------|
@@ -119,6 +119,7 @@ Go + Clean Architecture で実装した106種類のトランプゲーム。CLI �
 | カジノホールデム (Casino Hold'em) | `casinoholdem` | [CUI](docs/manual/cui/casinoholdem.md) / [Web](docs/manual/web/casinoholdem.md) |
 | コールブレイク (Call Break) | `callbreak` | [CUI](docs/manual/cui/callbreak.md) / [Web](docs/manual/web/callbreak.md) |
 | ターニーブ (Tarneeb) | `tarneeb` | [CUI](docs/manual/cui/tarneeb.md) / [Web](docs/manual/web/tarneeb.md) |
+| ハイカードフラッシュ (High Card Flush) | `highcardflush` | [CUI](docs/manual/cui/highcardflush.md) / [Web](docs/manual/web/highcardflush.md) |
 | ブリスコラ (Briscola) | `briscola` | [CUI](docs/manual/cui/briscola.md) / [Web](docs/manual/web/briscola.md) |
 | ギャップス (Gaps / Montana) | `gaps` | [CUI](docs/manual/cui/gaps.md) / [Web](docs/manual/web/gaps.md) |
 | フォーカードポーカー (Four Card Poker) | `fourcardpoker` | [CUI](docs/manual/cui/fourcardpoker.md) / [Web](docs/manual/web/fourcardpoker.md) |

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -10094,6 +10094,177 @@ paths:
               schema:
                 $ref: '#/components/schemas/HighCardFlushResponse'
 
+  /sixcardgolf/exec:
+    post:
+      tags:
+        - sixcardgolf
+      summary: Execute a Six Card Golf game command
+      description: |
+        Send a command to advance the Six Card Golf (シックスカードゴルフ) game session
+        identified by `sessionId`. Six Card Golf is a multi-player card game (1 human plus
+        CPU opponents) using a standard 52-card deck. Each player owns a 2x3 grid of six
+        cards and aims for the lowest score over a configurable number of rounds. Aces
+        count 1, 2 counts -2, number cards face value, J/Q count 10, K counts 0, and a
+        matched vertical pair cancels to 0.
+
+        The game proceeds through these phases:
+
+        | Phase       | Value | Description |
+        |-------------|-------|-------------|
+        | Setup       | `0`   | Flip two initial cards in your grid |
+        | PlayerTurn  | `1`   | Choose to draw from the stock or the discard pile |
+        | DrawPending | `2`   | Swap the drawn card into the grid or discard it |
+        | RoundOver   | `3`   | Round complete; scores shown |
+        | GameOver    | `4`   | Match complete; final winner decided |
+
+        | Command       | Aliases | Description |
+        |---------------|---------|-------------|
+        | `reset`       | `r`     | Start / restart a game (accepts optional `config`) |
+        | `flipinitial` | `fi`    | Flip one of the two initial cards (requires `position`) |
+        | `drawstock`   | `ds`    | Draw the top card from the stock pile |
+        | `drawdiscard` | `dd`    | Draw the top card from the discard pile |
+        | `swap`        | `sw`    | Swap the drawn card into a grid slot (requires `position`) |
+        | `discard`     | `di`    | Discard the drawn stock card without swapping |
+        | `flip`        | `fl`    | Flip a face-down grid card (requires `position`) |
+        | `skipflip`    | `sf`    | Skip the optional flip |
+        | `nextround`   | `nr`    | Advance to the next round |
+        | `log`         | `l`     | View action log |
+      operationId: sixcardgolfExec
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - command
+                - sessionId
+              properties:
+                command:
+                  type: string
+                  enum: [reset, r, flipinitial, fi, drawstock, ds, drawdiscard, dd, swap, sw, discard, di, flip, fl, skipflip, sf, nextround, nr, log, l]
+                position:
+                  type: integer
+                  description: Grid slot index (0-5) for flipinitial, swap, and flip commands
+                config:
+                  type: object
+                  description: Optional game configuration (used with reset)
+                  properties:
+                    playerCount:
+                      type: integer
+                      description: Number of players (2-4)
+                    cpuDifficulty:
+                      type: integer
+                      description: CPU difficulty (0=Easy, 1=Normal, 2=Hard)
+                    rounds:
+                      type: integer
+                      description: Number of rounds to play (1-18)
+                sessionId:
+                  type: string
+            examples:
+              reset:
+                summary: Start a new game
+                value:
+                  command: reset
+                  sessionId: my-session-001
+              flipinitial:
+                summary: Flip an initial card
+                value:
+                  command: flipinitial
+                  position: 0
+                  sessionId: my-session-001
+              drawstock:
+                summary: Draw from the stock pile
+                value:
+                  command: drawstock
+                  sessionId: my-session-001
+              swap:
+                summary: Swap the drawn card into the grid
+                value:
+                  command: swap
+                  position: 3
+                  sessionId: my-session-001
+      responses:
+        '200':
+          description: Command processed successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  players:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                        isHuman:
+                          type: boolean
+                        grid:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              card:
+                                $ref: '#/components/schemas/Card'
+                              faceUp:
+                                type: boolean
+                        roundScore:
+                          type: integer
+                        cumulativeScore:
+                          type: integer
+                        allFaceUp:
+                          type: boolean
+                  phase:
+                    type: integer
+                  roundNumber:
+                    type: integer
+                  totalRounds:
+                    type: integer
+                  currentPlayerIdx:
+                    type: integer
+                  discardTop:
+                    $ref: '#/components/schemas/Card'
+                  drawPileCount:
+                    type: integer
+                  drawnCard:
+                    $ref: '#/components/schemas/Card'
+                  drawnFromDiscard:
+                    type: boolean
+                  canFlip:
+                    type: boolean
+                  finalTurnTrigger:
+                    type: integer
+                  gameEndFlag:
+                    type: boolean
+                  winnerIdx:
+                    type: integer
+                  config:
+                    type: object
+                    properties:
+                      playerCount:
+                        type: integer
+                      cpuDifficulty:
+                        type: integer
+                      rounds:
+                        type: integer
+                  message:
+                    type: string
+                  messageCode:
+                    type: string
+                  messageParams:
+                    type: object
+        '400':
+          description: Bad request (unsupported command, missing/invalid parameters, or session error)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+
   /doudizhu/exec:
     post:
       tags:

--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -6,7 +6,7 @@
 
 - [1. クラス図](#1-クラス図)
   - [1.1 コアドメイン (カード・プレイヤー)](#11-コアドメイン-カードプレイヤー)
-  - [1.2 ゲームドメイン (全104ゲーム)](#12-ゲームドメイン-全104ゲーム)
+  - [1.2 ゲームドメイン (全110ゲーム)](#12-ゲームドメイン-全110ゲーム)
   - [1.3 ユースケース層 (Interactor・Presenter)](#13-ユースケース層-interactorpresenter)
   - [1.4 アダプタ層 (Controller・Presenter実装)](#14-アダプタ層-controllerpresenter実装)
   - [1.5 インフラストラクチャ層](#15-インフラストラクチャ層)
@@ -151,7 +151,7 @@ classDiagram
     GamePlayer *-- ChipHolder : mixin
 ```
 
-### 1.2 ゲームドメイン (全104ゲーム)
+### 1.2 ゲームドメイン (全110ゲーム)
 
 #### ベッティング系ゲーム
 
@@ -1683,7 +1683,7 @@ classDiagram
     note for GamePresenter "各ゲームの Presenter は\nGamePresenter[G] の型エイリアス\nまたは拡張インターフェース"
 ```
 
-**Interactor パターン (全104ゲーム共通)**
+**Interactor パターン (全110ゲーム共通)**
 
 ```mermaid
 classDiagram
@@ -1755,8 +1755,8 @@ classDiagram
     GameCuiPresenter ..|> GamePresenter : implements
     GameWebPresenter ..|> GamePresenter : implements
 
-    note for GameCuiController "104ゲーム × CUI/Web = 208 Controller\nGameCuiController / GameWebController は\n各ゲーム毎に具体的な実装が存在"
-    note for GameCuiPresenter "104ゲーム × CUI/Web = 208 Presenter 実装"
+    note for GameCuiController "110ゲーム × CUI/Web = 220 Controller\nGameCuiController / GameWebController は\n各ゲーム毎に具体的な実装が存在"
+    note for GameCuiPresenter "110ゲーム × CUI/Web = 220 Presenter 実装"
 ```
 
 ### 1.5 インフラストラクチャ層

--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -436,7 +436,7 @@ classDiagram
         +object messageParams
     }
 
-    note for BlackJackResponse "各ゲームが固有のResponse型を持つ\n(全104ゲーム分存在)\n共通フィールド: message, messageCode, messageParams"
+    note for BlackJackResponse "各ゲームが固有のResponse型を持つ\n(全110ゲーム分存在)\n共通フィールド: message, messageCode, messageParams"
 ```
 
 **フェーズ定数 (全ゲーム)**
@@ -867,7 +867,7 @@ classDiagram
     class actionLogApi {
         +blackjack() Promise~ActionLogResponse~
         +poker() Promise~ActionLogResponse~
-        ...全104ゲーム()
+        ...全110ゲーム()
     }
 
     BlackJackApi --> gameApi : uses postJson/gameExec
@@ -929,7 +929,7 @@ classDiagram
 
     RedDogApi --> gameApi : uses postJson/gameExec
 
-    note for BlackJackApi "全104ゲーム分のAPI Objectが存在\n(blackjack, spanish21, poker, oldmaid, daifugo,\nsevens, doubt, bigtwo, holdem, omaha, omahahilo, shortdeck,\npineapple, crazypineapple, hearts, memory, klondike, freecell,\nseahaventowers, cruel, baccarat, spades, twotenjack, crazyeights,\nginrummy, canasta, spider, spiderette, napoleon, mighty,\nindianpoker, videopoker, deuceswild, jokerpoker, euchre, pyramid, tripeaks,\ncribbage, threecard, caribbeanstud, texasholdembonus,\nultimatetexasholdem, mississippistud, ohhell, bridge, speed,\ngofish, pinochle, golf, pigtail,\nsevencardstud, clocksolitaire, durak,\nfortythieves, paigow, war, canfield, fiftyone, yukon, russiansolitaire, scorpion, accordion, whist,\nletitride, pokersquares, pageone, reddog, razz, badugi, trash,\nsevenbridge, president, cassino, calculation, crescent, spiteandmalice,\nskat, shithead, nertz, slapjack, egyptianratscrew, bakersdozen, tonk,\ncasinowar, pitch, dragontiger, blackjackswitch, montecarlo, contractrummy, belote,\noasispoker, beleagueredcastle, piquet, casinoholdem, callbreak,\nhighcardflush, fourcardpoker, russianpoker, briscola, tarneeb, gaps, rummy500, eightoff, penguin)"
+    note for BlackJackApi "全110ゲーム分のAPI Objectが存在\n(blackjack, spanish21, poker, oldmaid, daifugo,\nsevens, doubt, bigtwo, holdem, omaha, omahahilo, shortdeck,\npineapple, crazypineapple, hearts, memory, klondike, freecell,\nseahaventowers, cruel, baccarat, spades, twotenjack, crazyeights,\nginrummy, canasta, spider, spiderette, napoleon, mighty,\nindianpoker, videopoker, deuceswild, jokerpoker, euchre, pyramid, tripeaks,\ncribbage, threecard, caribbeanstud, texasholdembonus,\nultimatetexasholdem, mississippistud, ohhell, bridge, speed,\ngofish, pinochle, golf, pigtail,\nsevencardstud, clocksolitaire, durak,\nfortythieves, paigow, war, canfield, fiftyone, yukon, russiansolitaire, scorpion, accordion, whist,\nletitride, pokersquares, pageone, reddog, razz, badugi, trash,\nsevenbridge, president, cassino, calculation, crescent, spiteandmalice,\nskat, shithead, nertz, slapjack, egyptianratscrew, bakersdozen, tonk,\ncasinowar, pitch, dragontiger, blackjackswitch, montecarlo, contractrummy, belote,\noasispoker, beleagueredcastle, piquet, casinoholdem, callbreak,\nhighcardflush, fourcardpoker, russianpoker, briscola, tarneeb, gaps, rummy500, eightoff, penguin,\nirishpoker, chinesepoker, sixcardgolf, doudizhu, truco, acesup)"
 ```
 
 ### 1.3 Hook 層 (共通Hook)
@@ -1308,7 +1308,7 @@ classDiagram
 
     useCanastaGame --> useGameApi : uses
 
-    note for useBlackJackGame "全104ゲーム分の固有Hookが存在\n各HookはuseGameApiで統一的にAPI呼出し\n必要に応じてuseCardSelectionを合成"
+    note for useBlackJackGame "全110ゲーム分の固有Hookが存在\n各HookはuseGameApiで統一的にAPI呼出し\n必要に応じてuseCardSelectionを合成"
 ```
 
 ### 1.5 コンポーネント層
@@ -1907,7 +1907,7 @@ classDiagram
     GamePage --> PokerTableLayout : renders (Hold'em/Omaha/ShortDeck/Pineapple/SevenCardStud/Razz)
     PokerTableLayout --> CpuPlayerCard : wraps
 
-    note for GamePage "全104ゲームページが同一パターンで構成\nuseGamePageSetup → ゲーム固有Hook → 描画"
+    note for GamePage "全110ゲームページが同一パターンで構成\nuseGamePageSetup → ゲーム固有Hook → 描画"
 ```
 
 ### 1.7 i18n・プロバイダー・ルーティング
@@ -1930,7 +1930,7 @@ classDiagram
         +HashRouter
         +ErrorBoundary
         +NavBar
-        +Routes (104ゲーム)
+        +Routes (110ゲーム)
     }
 
     class gameCategories {
@@ -1953,11 +1953,11 @@ classDiagram
     App --> i18n : initializes
     App --> gameCategories : routes from
     App --> NavBar : renders
-    App --> GamePage : routes to 104 pages
+    App --> GamePage : routes to 110 pages
     GamePage --> TutorialProvider : wraps (per-game)
     TutorialProvider --> TutorialOverlay : renders when active
 
-    note for i18n "106名前空間: common + 104ゲーム固有 + tutorial\n翻訳ファイル: locales/{ja,en}/game.json"
+    note for i18n "113名前空間: common + 110ゲーム固有 + tutorial + discover\n翻訳ファイル: locales/{ja,en}/game.json"
 ```
 
 ### 1.8 AI Game Concierge (/discover)


### PR DESCRIPTION
## Summary

Ran `/doc-drift-check --fix`. The authoritative game count is **110** (`internal/infrastructure/games/registry.go` / `go run ./cmd/trumpcards games --short`), but several docs were stale. This PR syncs them.

## Changes

| File | Fix |
|------|-----|
| `CLAUDE.md` | header game count 106 → 110 |
| `README.md` | "106種類 → 110種類"; **added missing `highcardflush` table row** (registry order, between `tarneeb` and `briscola`) |
| `api/openapi.yaml` | **added missing `/sixcardgolf/exec` path block** (109 → 110 paths; CRLF preserved, `yaml.safe_load` validates 110 paths) |
| `docs/design/backend.md` | "全104ゲーム → 全110ゲーム" (TOC anchor + §1.2 heading + notes); "208 → 220 Controller/Presenter" |
| `docs/design/frontend.md` | "104 → 110 games/pages"; i18n note "106 → 113名前空間 (+ discover)"; appended `irishpoker, chinesepoker, sixcardgolf, doudizhu, truco, acesup` to `BlackJackApi` note |

## Verified already consistent (no change)

`docs/games.md` (110), CUI/Web manuals (110 each), `docs/architecture.md` ("One hundred ten endpoints"), ADR index (25/25), frontend locales (113 each) + `gameApi.ts` workerUrl (all 110 mapped), version table. `go.mod go 1.25.8` is intentional for TinyGo per ADR — left untouched.

## Test plan

- [x] `yaml.safe_load(api/openapi.yaml)` → 110 paths, `/sixcardgolf/exec` present
- [x] README game table = 110 rows, no games missing vs registry
- [x] No remaining stale `104ゲーム`/`208`/`106名前空間` refs in design docs
- [x] backend.md TOC anchor matches updated §1.2 heading

Docs-only change; no code paths affected.

Closes #2093

🤖 Generated with [Claude Code](https://claude.com/claude-code)