### PR TITLE
fix(oldmaid): darken draw-history chip palette to meet WCAG AA contrast

### DIFF
--- a/frontend/src/components/oldmaid/OldMaidDrawHistory.test.tsx
+++ b/frontend/src/components/oldmaid/OldMaidDrawHistory.test.tsx
@@ -3,13 +3,18 @@ import { describe, expect, it } from 'vitest';
 import type { DrawHistoryEntry, OldMaidPlayerData } from '../../types/card';
 import { OldMaidDrawHistory, PLAYER_PALETTE } from './OldMaidDrawHistory';
 
+/** Linearizes one `rr`/`gg`/`bb` hex channel per the WCAG 2.1 sRGB formula. */
+function parseChannel(hex: string): number {
+  const c = Number.parseInt(hex, 16) / 255;
+  return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+}
+
 /** sRGB relative luminance of a `#rrggbb` color (WCAG 2.1 formula). */
 function relativeLuminance(hex: string): number {
-  const channels = [hex.slice(1, 3), hex.slice(3, 5), hex.slice(5, 7)].map((h) => {
-    const c = Number.parseInt(h, 16) / 255;
-    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
-  });
-  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+  const r = parseChannel(hex.slice(1, 3));
+  const g = parseChannel(hex.slice(3, 5));
+  const b = parseChannel(hex.slice(5, 7));
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
 }
 
 /** Contrast ratio between a `#rrggbb` color and pure white (`#ffffff`). */
@@ -98,7 +103,8 @@ describe('OldMaidDrawHistory (graphical timeline)', () => {
 
   it('every chip palette color meets WCAG AA contrast (>=4.5:1) against white text', () => {
     for (const color of PLAYER_PALETTE) {
-      expect(contrastWithWhite(color)).toBeGreaterThanOrEqual(4.5);
+      // Pass the color as the assertion message so a future failure names the offending hex.
+      expect(contrastWithWhite(color), color).toBeGreaterThanOrEqual(4.5);
     }
   });
 });

--- a/frontend/src/components/oldmaid/OldMaidDrawHistory.test.tsx
+++ b/frontend/src/components/oldmaid/OldMaidDrawHistory.test.tsx
@@ -1,7 +1,21 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import type { DrawHistoryEntry, OldMaidPlayerData } from '../../types/card';
-import { OldMaidDrawHistory } from './OldMaidDrawHistory';
+import { OldMaidDrawHistory, PLAYER_PALETTE } from './OldMaidDrawHistory';
+
+/** sRGB relative luminance of a `#rrggbb` color (WCAG 2.1 formula). */
+function relativeLuminance(hex: string): number {
+  const channels = [hex.slice(1, 3), hex.slice(3, 5), hex.slice(5, 7)].map((h) => {
+    const c = Number.parseInt(h, 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+/** Contrast ratio between a `#rrggbb` color and pure white (`#ffffff`). */
+function contrastWithWhite(hex: string): number {
+  return 1.05 / (relativeLuminance(hex) + 0.05);
+}
 
 const players: OldMaidPlayerData[] = [
   { id: 0, isHuman: true, isFinished: false, cardCount: 5, cards: [] },
@@ -80,5 +94,11 @@ describe('OldMaidDrawHistory (graphical timeline)', () => {
     );
     expect(screen.getByText(/あなた.*上がり/)).toBeInTheDocument();
     expect(screen.getByText(/CPU\s?1.*上がり/)).toBeInTheDocument();
+  });
+
+  it('every chip palette color meets WCAG AA contrast (>=4.5:1) against white text', () => {
+    for (const color of PLAYER_PALETTE) {
+      expect(contrastWithWhite(color)).toBeGreaterThanOrEqual(4.5);
+    }
   });
 });

--- a/frontend/src/components/oldmaid/OldMaidDrawHistory.tsx
+++ b/frontend/src/components/oldmaid/OldMaidDrawHistory.tsx
@@ -7,7 +7,11 @@ import { findPlayerName } from '../../utils/playerUtils';
 // is satisfied — the design system has no per-player token, and inline style
 // values are static so the JIT/AOT pass doesn't need to see class names.
 // Hoisted to module scope so the array is not re-allocated on every chip render.
-const PLAYER_PALETTE = ['#2563eb', '#059669', '#d97706', '#9333ea', '#db2777', '#0891b2'] as const;
+// Every color meets WCAG 2.1 AA contrast (>=4.5:1) against the white chip text:
+// the emerald/amber/cyan entries use the Tailwind -700 shades (the -600 shades
+// previously used fell to 3.2–3.8:1, below AA); blue/purple/pink already passed
+// and are unchanged. See #2097.
+export const PLAYER_PALETTE = ['#2563eb', '#047857', '#b45309', '#9333ea', '#db2777', '#0e7490'] as const;
 
 /** Colored chip used as a player icon in the timeline. Deterministic by index. */
 function PlayerChip({ name, idx }: { name: string; idx: number }) {


### PR DESCRIPTION
## Summary

The Old Maid draw-history timeline (#1889) renders player names as **white, 10px, bold** text on per-player categorical background colors. Three of the six palette colors (emerald `#059669`, amber `#d97706`, cyan `#0891b2` — Tailwind -600 shades) only reached **3.2–3.8:1** contrast against white, below WCAG 2.1 AA (1.4.3, 4.5:1 for small text).

This swaps those three to the matching **-700** shades, keeping categorical (per-player) distinctiveness while bringing every color to **≥5:1**:

| Before | After | Contrast vs white |
|--------|-------|-------------------|
| `#059669` emerald-600 | `#047857` emerald-700 | 5.50:1 ✅ |
| `#d97706` amber-600 | `#b45309` amber-700 | 5.01:1 ✅ |
| `#0891b2` cyan-600 | `#0e7490` cyan-700 | 5.37:1 ✅ |

Blue / purple / pink already passed and are unchanged.

## Test plan
- `PLAYER_PALETTE` is now exported; added a contrast regression test computing the WCAG relative-luminance contrast of white vs every palette entry, asserting ≥4.5:1.
- `bun run test -- --run OldMaidDrawHistory` ✅ (11 tests)
- `bunx biome check` on changed files ✅
- tsc type-check runs in CI.

Closes #2097

🤖 Generated with [Claude Code](https://claude.com/claude-code)