### PR TITLE
fix(cui): run reader cleanup on signal exit instead of bare os.Exit

### DIFF
--- a/internal/infrastructure/ui/DoubtCui.go
+++ b/internal/infrastructure/ui/DoubtCui.go
@@ -72,7 +72,10 @@ func (cui *DoubtCui) drainInput() {
 
 // Exec ゲームメインループ
 func (cui *DoubtCui) Exec() {
-	setupSignalHandler()
+	// The Doubt loop reads plain (cooked) stdin and holds no terminal raw
+	// mode or history file, so there is nothing to clean up on signal — but
+	// it still needs a handler to exit on SIGINT/SIGTERM (issue #2096).
+	defer runSignalWatcher(nil)()
 	go cui.inputReader()
 	fmt.Println(cui.dc.Exec("r"))
 	fmt.Println(i18n.T("typeHelp"))

--- a/internal/infrastructure/ui/cui_runner.go
+++ b/internal/infrastructure/ui/cui_runner.go
@@ -51,7 +51,9 @@ func runSignalWatcher(cleanup func()) (stop func()) {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 	done := make(chan struct{})
+	stopped := make(chan struct{})
 	go func() {
+		defer close(stopped)
 		select {
 		case sig := <-sigCh:
 			signal.Stop(sigCh)
@@ -60,7 +62,10 @@ func runSignalWatcher(cleanup func()) (stop func()) {
 			signal.Stop(sigCh)
 		}
 	}()
-	return func() { close(done) }
+	return func() {
+		close(done)
+		<-stopped
+	}
 }
 
 // CuiExecer CUIコントローラの共通インタフェース

--- a/internal/infrastructure/ui/cui_runner.go
+++ b/internal/infrastructure/ui/cui_runner.go
@@ -6,34 +6,61 @@ import (
 	"os"
 	"os/signal"
 	"strings"
-	"sync"
 	"syscall"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
-var signalHandlerOnce sync.Once
+// signalExitCode prints the goodbye banner, runs cleanup, and returns the
+// POSIX exit code (128 + signal number) for sig.
+//
+// os.Exit does NOT run deferred functions, so a signal handler that simply
+// calls os.Exit would skip the deferred reader.Close() in the CUI loops —
+// losing the command history (never written to ~/.trumpcards_history) and,
+// worse, leaving the terminal stuck in liner's raw mode (requiring `reset` /
+// `stty sane` to recover). To avoid that, the signal watcher runs `cleanup`
+// (which performs exactly what the deferred teardown would: history save +
+// terminal restore) before exiting. Extracted as a pure function so the
+// exit-code mapping and the cleanup invocation are unit-testable without
+// raising a real signal or calling os.Exit. See issue #2096.
+func signalExitCode(sig os.Signal, cleanup func()) int {
+	fmt.Println("\n" + i18n.T("bye"))
+	if cleanup != nil {
+		cleanup()
+	}
+	// POSIX convention: exit code = 128 + signal number (SIGINT=130, SIGTERM=143).
+	exitCode := 128
+	if sigNum, ok := sig.(syscall.Signal); ok {
+		exitCode += int(sigNum)
+	}
+	return exitCode
+}
 
-// setupSignalHandler registers a handler for SIGINT and SIGTERM that prints
-// a goodbye message and exits gracefully. Call this at the start of any CUI loop.
-// It is safe to call multiple times; only the first call has an effect.
-func setupSignalHandler() {
-	signalHandlerOnce.Do(func() {
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
-		go func() {
-			sig := <-sigCh
+// runSignalWatcher installs a SIGINT/SIGTERM handler scoped to a single CUI
+// loop and returns a stop function the loop must defer. On a signal it runs
+// cleanup (see signalExitCode) and exits; on normal loop return the deferred
+// stop() tears the watcher down without touching cleanup, so the loop's own
+// deferred teardown runs exactly once. cleanup may be nil for loops with no
+// resources to release (e.g. the plain-stdin Doubt loop).
+//
+// This replaces the previous package-level os.Exit handler, which bypassed
+// deferred terminal restore and history persistence (issue #2096) — mirroring
+// the local-signal approach already used by RunRealtimeCuiLoop.
+func runSignalWatcher(cleanup func()) (stop func()) {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		select {
+		case sig := <-sigCh:
 			signal.Stop(sigCh)
-			fmt.Println("\n" + i18n.T("bye"))
-			// POSIX convention: exit code = 128 + signal number
-			exitCode := 128
-			if sigNum, ok := sig.(syscall.Signal); ok {
-				exitCode += int(sigNum)
-			}
-			os.Exit(exitCode)
-		}()
-	})
+			os.Exit(signalExitCode(sig, cleanup))
+		case <-done:
+			signal.Stop(sigCh)
+		}
+	}()
+	return func() { close(done) }
 }
 
 // CuiExecer CUIコントローラの共通インタフェース
@@ -148,7 +175,6 @@ func filterByPrefix(candidates []string, token string) []string {
 // error (issue #1839). The manager handles help/? commands internally;
 // other commands are delegated to the current game.
 func RunInteractiveCuiLoop(manager *GameManager) int {
-	setupSignalHandler()
 	initMsg := manager.InitCurrentGame()
 	if initMsg != "" {
 		fmt.Println(initMsg)
@@ -156,6 +182,9 @@ func RunInteractiveCuiLoop(manager *GameManager) int {
 	fmt.Println(i18n.T("typeHelp"))
 	reader := newDefaultLineReader()
 	defer func() { _ = reader.Close() }()
+	// On SIGINT/SIGTERM, close the reader (history save + terminal restore)
+	// before exiting since os.Exit skips the defer above (issue #2096).
+	defer runSignalWatcher(func() { _ = reader.Close() })()
 	// *GameManager statically satisfies commandLister, so no type assertion
 	// is needed here. RunCuiLoop below uses one because its parameter is the
 	// CuiExecer interface and we don't know the concrete type.
@@ -201,11 +230,13 @@ func printResult(res string) {
 // Returns 0 on normal exit (EOF, "quit", QuitSentinel) and 1 when stdin
 // reads fail with a non-EOF I/O error (issue #1839). See issue #1605.
 func RunCuiLoop(gameName string, controller CuiExecer, helpLines []string) int {
-	setupSignalHandler()
 	fmt.Println(controller.Exec("r"))
 	fmt.Println(i18n.T("typeHelp"))
 	reader := newDefaultLineReader()
 	defer func() { _ = reader.Close() }()
+	// On SIGINT/SIGTERM, close the reader (history save + terminal restore)
+	// before exiting since os.Exit skips the defer above (issue #2096).
+	defer runSignalWatcher(func() { _ = reader.Close() })()
 	if lister, ok := controller.(commandLister); ok {
 		installCompleter(reader, lister)
 	} else {

--- a/internal/infrastructure/ui/cui_runner_test.go
+++ b/internal/infrastructure/ui/cui_runner_test.go
@@ -3,7 +3,6 @@ package ui
 import (
 	"syscall"
 	"testing"
-	"time"
 )
 
 // closeSpyReader is a LineReader whose Close records that it ran, so tests can
@@ -55,9 +54,8 @@ func TestRunSignalWatcher_NormalExitDoesNotRunCleanup(t *testing.T) {
 	reader := &closeSpyReader{}
 	stop := runSignalWatcher(func() { _ = reader.Close() })
 	// Simulate a normal loop return: stop the watcher without a signal.
+	// stop() now blocks until the goroutine exits, so no sleep needed.
 	stop()
-	// Give the watcher goroutine a moment to observe the done channel.
-	time.Sleep(20 * time.Millisecond)
 	if reader.closed != 0 {
 		t.Errorf("cleanup ran on normal exit (%d times); it should only run on a signal", reader.closed)
 	}

--- a/internal/infrastructure/ui/cui_runner_test.go
+++ b/internal/infrastructure/ui/cui_runner_test.go
@@ -1,0 +1,64 @@
+package ui
+
+import (
+	"syscall"
+	"testing"
+	"time"
+)
+
+// closeSpyReader is a LineReader whose Close records that it ran, so tests can
+// assert the signal path performs the history-save / terminal-restore cleanup
+// that os.Exit would otherwise skip (issue #2096).
+type closeSpyReader struct {
+	closed int
+}
+
+func (*closeSpyReader) Prompt(string) (string, error)      { return "", nil }
+func (*closeSpyReader) AppendHistory(string)               {}
+func (*closeSpyReader) SetCompleter(func(string) []string) {}
+func (r *closeSpyReader) Close() error                     { r.closed++; return nil }
+
+func TestSignalExitCode_RunsCleanupAndMapsCode(t *testing.T) {
+	tests := []struct {
+		name string
+		sig  syscall.Signal
+		want int
+	}{
+		{name: "SIGINT maps to 130", sig: syscall.SIGINT, want: 130},
+		{name: "SIGTERM maps to 143", sig: syscall.SIGTERM, want: 143},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := &closeSpyReader{}
+			got := signalExitCode(tt.sig, func() { _ = reader.Close() })
+			if got != tt.want {
+				t.Errorf("signalExitCode(%v) exit code = %d, want %d", tt.sig, got, tt.want)
+			}
+			// The cleanup (history save + terminal restore via reader.Close)
+			// must run on the signal path — this is the regression the issue
+			// is about: os.Exit alone would skip it.
+			if reader.closed != 1 {
+				t.Errorf("cleanup ran %d times, want exactly 1", reader.closed)
+			}
+		})
+	}
+}
+
+func TestSignalExitCode_NilCleanupIsSafe(t *testing.T) {
+	// The Doubt loop passes a nil cleanup (no reader/raw mode); it must not panic.
+	if got := signalExitCode(syscall.SIGINT, nil); got != 130 {
+		t.Errorf("signalExitCode with nil cleanup = %d, want 130", got)
+	}
+}
+
+func TestRunSignalWatcher_NormalExitDoesNotRunCleanup(t *testing.T) {
+	reader := &closeSpyReader{}
+	stop := runSignalWatcher(func() { _ = reader.Close() })
+	// Simulate a normal loop return: stop the watcher without a signal.
+	stop()
+	// Give the watcher goroutine a moment to observe the done channel.
+	time.Sleep(20 * time.Millisecond)
+	if reader.closed != 0 {
+		t.Errorf("cleanup ran on normal exit (%d times); it should only run on a signal", reader.closed)
+	}
+}


### PR DESCRIPTION
## Summary

The line-based CUI loops (`RunCuiLoop` / `RunInteractiveCuiLoop`) registered a package-level `setupSignalHandler` whose goroutine called `os.Exit(128+sig)` on SIGINT/SIGTERM. **`os.Exit` does not run deferred functions**, so the `defer reader.Close()` in those loops never fired on a signal. `linerLineReader.Close()` does two things:

1. Writes command history to `~/.trumpcards_history` (`state.WriteHistory`)
2. Restores the terminal out of liner's raw mode (`state.Close`)

Both were skipped on `kill` (SIGTERM) and on SIGINT delivered outside liner's prompt wait — losing history and leaving the user's shell stuck in raw mode (no echo / no line editing, needing `reset` / `stty sane`).

The realtime loop (`RunRealtimeCuiLoop`) already documents and avoids this exact hazard with a local quit channel. This brings the line-based loops in line.

## Change

- Remove the package-level `setupSignalHandler` (+ its `sync.Once`).
- Add `runSignalWatcher(cleanup func()) (stop func())`: a per-loop SIGINT/SIGTERM watcher. On a signal it runs `cleanup` (history save + terminal restore) **before** exiting; on normal loop return the deferred `stop()` tears the watcher down via a `done` channel **without** running cleanup, so the loop's own `defer reader.Close()` still runs exactly once.
- Extract the exit-code mapping + cleanup invocation into the pure, unit-testable `signalExitCode(sig, cleanup) int` (no real signal, no `os.Exit` needed to test it).
- `RunCuiLoop` / `RunInteractiveCuiLoop` pass a reader-closing cleanup; the plain-stdin `DoubtCui.Exec` passes `nil` (cooked stdin — no raw mode or history file to release).
- Exit-code semantics preserved: SIGINT → 130, SIGTERM → 143.

## Test plan
- New `cui_runner_test.go`:
  - `signalExitCode` runs the cleanup (asserts `reader.Close()` invoked exactly once) and maps SIGINT→130 / SIGTERM→143.
  - nil cleanup is panic-safe (Doubt path).
  - `runSignalWatcher` normal-exit (`stop()`) path does **not** run cleanup.
- `go test -tags test ./internal/infrastructure/ui/` ✅
- `golangci-lint run ./internal/infrastructure/ui/` ✅
- `goimports -w` applied.

Closes #2096

🤖 Generated with [Claude Code](https://claude.com/claude-code)