### PR TITLE
refactor(controller): extract requireParam helper for dispatch nil checks

### DIFF
--- a/internal/adapter/controller/AccordionWebController.go
+++ b/internal/adapter/controller/AccordionWebController.go
@@ -67,8 +67,7 @@ func accordionDispatch(bc *baseController, w http.ResponseWriter, ai usecase.Acc
 	case "u", "undo":
 		bc.writePresenterResponse(w, ai.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ai.UndoN(*param.N))
@@ -79,16 +78,13 @@ func accordionDispatch(bc *baseController, w http.ResponseWriter, ai usecase.Acc
 }
 
 func accordionMoveDispatch(bc *baseController, w http.ResponseWriter, ai usecase.AccordionInteractorIF, param AccordionWebInput, newDefault func(string) *AccordionWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
-	if param.From.Zone != "pile" || param.To.Zone != "pile" {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: invalid move zones. Only pile to pile is supported."))
+	if !requireParam(bc, w, newDefault, param.From.Zone != "pile" || param.To.Zone != "pile", "param error: invalid move zones. Only pile to pile is supported.") {
 		return true
 	}
-	if param.From.Index == nil || param.To.Index == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.index and to.index are required."))
+	if !requireParam(bc, w, newDefault, param.From.Index == nil || param.To.Index == nil, "param error: from.index and to.index are required.") {
 		return true
 	}
 	bc.writePresenterResponse(w, ai.Move(*param.From.Index, *param.To.Index))

--- a/internal/adapter/controller/AcesUpWebController.go
+++ b/internal/adapter/controller/AcesUpWebController.go
@@ -57,14 +57,12 @@ func acesUpDispatch(bc *baseController, w http.ResponseWriter, ai usecase.AcesUp
 	case "d", "draw":
 		bc.writePresenterResponse(w, ai.Draw())
 	case "rm", "remove":
-		if param.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: col is required."))
+		if !requireParam(bc, w, newDefault, param.Col == nil, "param error: col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ai.Remove(*param.Col))
 	case "mv", "move":
-		if param.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: col is required."))
+		if !requireParam(bc, w, newDefault, param.Col == nil, "param error: col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ai.Move(*param.Col))
@@ -73,8 +71,7 @@ func acesUpDispatch(bc *baseController, w http.ResponseWriter, ai usecase.AcesUp
 	case "u", "undo":
 		bc.writePresenterResponse(w, ai.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ai.UndoN(*param.N))

--- a/internal/adapter/controller/BakersDozenWebController.go
+++ b/internal/adapter/controller/BakersDozenWebController.go
@@ -71,8 +71,7 @@ func bakersDozenDispatch(bc *baseController, w http.ResponseWriter, bi usecase.B
 	case "u", "undo":
 		bc.writePresenterResponse(w, bi.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, bi.UndoN(*param.N))
@@ -83,8 +82,7 @@ func bakersDozenDispatch(bc *baseController, w http.ResponseWriter, bi usecase.B
 }
 
 func bakersDozenMoveDispatch(bc *baseController, w http.ResponseWriter, bi usecase.BakersDozenInteractorIF, param BakersDozenWebInput, newDefault func(string) *BakersDozenWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
 	fromZone := param.From.Zone
@@ -92,8 +90,7 @@ func bakersDozenMoveDispatch(bc *baseController, w http.ResponseWriter, bi useca
 
 	switch {
 	case fromZone == "tableau" && toZone == "tableau":
-		if param.From.Col == nil || param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col and to.col are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.To.Col == nil, "param error: from.col and to.col are required.") {
 			return true
 		}
 		// Pass -1 so the domain resolves the index from its own state — Baker's
@@ -101,8 +98,7 @@ func bakersDozenMoveDispatch(bc *baseController, w http.ResponseWriter, bi useca
 		// adds nothing and gives the server one less untrusted input.
 		bc.writePresenterResponse(w, bi.MoveTableauToTableau(*param.From.Col, -1, *param.To.Col))
 	case fromZone == "tableau" && toZone == "foundation":
-		if param.From.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col is required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil, "param error: from.col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, bi.MoveTableauToFoundation(*param.From.Col))

--- a/internal/adapter/controller/BeleagueredCastleWebController.go
+++ b/internal/adapter/controller/BeleagueredCastleWebController.go
@@ -71,8 +71,7 @@ func beleagueredCastleDispatch(bc *baseController, w http.ResponseWriter, bi use
 	case "u", "undo":
 		bc.writePresenterResponse(w, bi.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, bi.UndoN(*param.N))
@@ -83,8 +82,7 @@ func beleagueredCastleDispatch(bc *baseController, w http.ResponseWriter, bi use
 }
 
 func beleagueredCastleMoveDispatch(bc *baseController, w http.ResponseWriter, bi usecase.BeleagueredCastleInteractorIF, param BeleagueredCastleWebInput, newDefault func(string) *BeleagueredCastleWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
 	fromZone := param.From.Zone
@@ -92,16 +90,14 @@ func beleagueredCastleMoveDispatch(bc *baseController, w http.ResponseWriter, bi
 
 	switch {
 	case fromZone == "tableau" && toZone == "tableau":
-		if param.From.Col == nil || param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col and to.col are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.To.Col == nil, "param error: from.col and to.col are required.") {
 			return true
 		}
 		// Beleaguered Castle only ever moves the top card; pass -1 so the
 		// domain resolves the index from its own state.
 		bc.writePresenterResponse(w, bi.MoveTableauToTableau(*param.From.Col, -1, *param.To.Col))
 	case fromZone == "tableau" && toZone == "foundation":
-		if param.From.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col is required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil, "param error: from.col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, bi.MoveTableauToFoundation(*param.From.Col))

--- a/internal/adapter/controller/BeloteWebController.go
+++ b/internal/adapter/controller/BeloteWebController.go
@@ -124,16 +124,14 @@ func beloteDispatch(bc *baseController, w http.ResponseWriter, bi usecase.Belote
 	case "o", "orderup":
 		bc.writePresenterResponse(w, bi.PickUp(true))
 	case "c", "calltrump":
-		if param.Suit == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: suit is required."))
+		if !requireParam(bc, w, newDefault, param.Suit == nil, "param error: suit is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, bi.CallTrump(*param.Suit))
 	case "pa", "pass":
 		bc.writePresenterResponse(w, bi.Pass())
 	case "p", "play":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, bi.Play(*param.CardIndex))

--- a/internal/adapter/controller/BridgeWebController.go
+++ b/internal/adapter/controller/BridgeWebController.go
@@ -145,8 +145,7 @@ func bridgeDispatch(bc *baseController, w http.ResponseWriter, bi usecase.Bridge
 		}
 		bc.writePresenterResponse(w, bi.Bid(bidType, bidLevel, bidSuit))
 	case "p", "play":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, bi.Play(*param.CardIndex))

--- a/internal/adapter/controller/BriscolaWebController.go
+++ b/internal/adapter/controller/BriscolaWebController.go
@@ -103,8 +103,7 @@ func briscolaDispatch(bc *baseController, w http.ResponseWriter, bi usecase.Bris
 	case "r", "reset":
 		bc.writePresenterResponse(w, bi.ResetWithConfig(param.ToConfig()))
 	case "p", "play":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, bi.Play(*param.CardIndex))

--- a/internal/adapter/controller/CalculationWebController.go
+++ b/internal/adapter/controller/CalculationWebController.go
@@ -65,8 +65,7 @@ func calculationDispatch(bc *baseController, w http.ResponseWriter, ci usecase.C
 	case "u", "undo":
 		bc.writePresenterResponse(w, ci.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.UndoN(*param.N))
@@ -77,8 +76,7 @@ func calculationDispatch(bc *baseController, w http.ResponseWriter, ci usecase.C
 }
 
 func calculationMoveDispatch(bc *baseController, w http.ResponseWriter, ci usecase.CalculationInteractorIF, param CalculationWebInput, newDefault func(string) *CalculationWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
 	fromZone := param.From.Zone
@@ -86,20 +84,17 @@ func calculationMoveDispatch(bc *baseController, w http.ResponseWriter, ci useca
 
 	switch {
 	case fromZone == "stock" && toZone == "foundation":
-		if param.To.Idx == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: to.idx is required."))
+		if !requireParam(bc, w, newDefault, param.To.Idx == nil, "param error: to.idx is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.PlayStockToFoundation(*param.To.Idx))
 	case fromZone == "stock" && toZone == "waste":
-		if param.To.Idx == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: to.idx is required."))
+		if !requireParam(bc, w, newDefault, param.To.Idx == nil, "param error: to.idx is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.PlayStockToWaste(*param.To.Idx))
 	case fromZone == "waste" && toZone == "foundation":
-		if param.From.Idx == nil || param.To.Idx == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.idx and to.idx are required."))
+		if !requireParam(bc, w, newDefault, param.From.Idx == nil || param.To.Idx == nil, "param error: from.idx and to.idx are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.PlayWasteToFoundation(*param.From.Idx, *param.To.Idx))

--- a/internal/adapter/controller/CallBreakWebController.go
+++ b/internal/adapter/controller/CallBreakWebController.go
@@ -112,14 +112,12 @@ func callBreakDispatch(bc *baseController, w http.ResponseWriter, ci usecase.Cal
 	case "r", "reset":
 		bc.writePresenterResponse(w, ci.ResetWithConfig(param.ToConfig()))
 	case "b", "bid":
-		if param.Bid == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: bid is required."))
+		if !requireParam(bc, w, newDefault, param.Bid == nil, "param error: bid is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.Bid(*param.Bid))
 	case "p", "play":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.Play(*param.CardIndex))

--- a/internal/adapter/controller/CanastaWebController.go
+++ b/internal/adapter/controller/CanastaWebController.go
@@ -111,8 +111,7 @@ func canastaDispatch(bc *baseController, w http.ResponseWriter, ci usecase.Canas
 	case "sm", "skipmeld":
 		bc.writePresenterResponse(w, ci.SkipMeld())
 	case "d", "discard":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.Discard(*param.CardIndex))

--- a/internal/adapter/controller/CanfieldWebController.go
+++ b/internal/adapter/controller/CanfieldWebController.go
@@ -81,8 +81,7 @@ func canfieldDispatch(bc *baseController, w http.ResponseWriter, ci usecase.Canf
 	case "u", "undo":
 		bc.writePresenterResponse(w, ci.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.UndoN(*param.N))
@@ -93,8 +92,7 @@ func canfieldDispatch(bc *baseController, w http.ResponseWriter, ci usecase.Canf
 }
 
 func canfieldMoveDispatch(bc *baseController, w http.ResponseWriter, ci usecase.CanfieldInteractorIF, param CanfieldWebInput, newDefault func(string) *CanfieldWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
 	fromZone := param.From.Zone
@@ -102,30 +100,26 @@ func canfieldMoveDispatch(bc *baseController, w http.ResponseWriter, ci usecase.
 
 	switch {
 	case fromZone == "waste" && toZone == "tableau":
-		if param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: to.col is required."))
+		if !requireParam(bc, w, newDefault, param.To.Col == nil, "param error: to.col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.MoveWasteToTableau(*param.To.Col))
 	case fromZone == "waste" && toZone == "foundation":
 		bc.writePresenterResponse(w, ci.MoveWasteToFoundation())
 	case fromZone == "reserve" && toZone == "tableau":
-		if param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: to.col is required."))
+		if !requireParam(bc, w, newDefault, param.To.Col == nil, "param error: to.col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.MoveReserveToTableau(*param.To.Col))
 	case fromZone == "reserve" && toZone == "foundation":
 		bc.writePresenterResponse(w, ci.MoveReserveToFoundation())
 	case fromZone == "tableau" && toZone == "tableau":
-		if param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col, from.cardIndex, to.col are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil, "param error: from.col, from.cardIndex, to.col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.MoveTableauToTableau(*param.From.Col, *param.From.CardIndex, *param.To.Col))
 	case fromZone == "tableau" && toZone == "foundation":
-		if param.From.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col is required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil, "param error: from.col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.MoveTableauToFoundation(*param.From.Col))

--- a/internal/adapter/controller/ContractRummyWebController.go
+++ b/internal/adapter/controller/ContractRummyWebController.go
@@ -120,14 +120,12 @@ func contractRummyDispatch(bc *baseController, w http.ResponseWriter, ci usecase
 	case "me", "meldextra":
 		bc.writePresenterResponse(w, ci.MeldExtra(param.CardIndices))
 	case "lo", "layoff":
-		if param.TargetPlayerIdx == nil || param.MeldIdx == nil || param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: targetPlayerIdx, meldIdx, cardIndex are required."))
+		if !requireParam(bc, w, newDefault, param.TargetPlayerIdx == nil || param.MeldIdx == nil || param.CardIndex == nil, "param error: targetPlayerIdx, meldIdx, cardIndex are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.Layoff(*param.TargetPlayerIdx, *param.MeldIdx, *param.CardIndex))
 	case "d", "discard":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.Discard(*param.CardIndex))

--- a/internal/adapter/controller/CrazyEightsWebController.go
+++ b/internal/adapter/controller/CrazyEightsWebController.go
@@ -88,16 +88,14 @@ func crazyEightsDispatch(bc *baseController, w http.ResponseWriter, ci usecase.C
 	case "r", "reset":
 		bc.writePresenterResponse(w, ci.ResetWithConfig(param.ToConfig()))
 	case "p", "play":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.Play(*param.CardIndex))
 	case "d", "draw":
 		bc.writePresenterResponse(w, ci.Draw())
 	case "s", "suit":
-		if param.Suit == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: suit is required."))
+		if !requireParam(bc, w, newDefault, param.Suit == nil, "param error: suit is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.ChooseSuit(*param.Suit))

--- a/internal/adapter/controller/CrescentWebController.go
+++ b/internal/adapter/controller/CrescentWebController.go
@@ -75,8 +75,7 @@ func crescentDispatch(bc *baseController, w http.ResponseWriter, ci usecase.Cres
 	case "u", "undo":
 		bc.writePresenterResponse(w, ci.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.UndoN(*param.N))
@@ -87,8 +86,7 @@ func crescentDispatch(bc *baseController, w http.ResponseWriter, ci usecase.Cres
 }
 
 func crescentMoveDispatch(bc *baseController, w http.ResponseWriter, ci usecase.CrescentInteractorIF, param CrescentWebInput, newDefault func(string) *CrescentWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
 	fromZone := param.From.Zone
@@ -96,14 +94,12 @@ func crescentMoveDispatch(bc *baseController, w http.ResponseWriter, ci usecase.
 
 	switch {
 	case fromZone == "tableau" && toZone == "tableau":
-		if param.From.Col == nil || param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col and to.col are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.To.Col == nil, "param error: from.col and to.col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.MoveTableauToTableau(*param.From.Col, *param.To.Col))
 	case fromZone == "tableau" && toZone == "foundation":
-		if param.From.Col == nil || param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col and to.col are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.To.Col == nil, "param error: from.col and to.col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.MoveTableauToFoundation(*param.From.Col, *param.To.Col))

--- a/internal/adapter/controller/CribbageWebController.go
+++ b/internal/adapter/controller/CribbageWebController.go
@@ -106,8 +106,7 @@ func cribbageDispatch(bc *baseController, w http.ResponseWriter, ci usecase.Crib
 	case "d", "discard":
 		bc.writePresenterResponse(w, ci.Discard(param.CardIndices))
 	case "p", "peg":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.Peg(*param.CardIndex))

--- a/internal/adapter/controller/CruelWebController.go
+++ b/internal/adapter/controller/CruelWebController.go
@@ -66,8 +66,7 @@ func cruelDispatch(bc *baseController, w http.ResponseWriter, ci usecase.CruelIn
 	case "u", "undo":
 		bc.writePresenterResponse(w, ci.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.UndoN(*param.N))
@@ -78,8 +77,7 @@ func cruelDispatch(bc *baseController, w http.ResponseWriter, ci usecase.CruelIn
 }
 
 func cruelMoveDispatch(bc *baseController, w http.ResponseWriter, ci usecase.CruelInteractorIF, param CruelWebInput, newDefault func(string) *CruelWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
 	fromZone := param.From.Zone
@@ -87,14 +85,12 @@ func cruelMoveDispatch(bc *baseController, w http.ResponseWriter, ci usecase.Cru
 
 	switch {
 	case fromZone == "tableau" && toZone == "tableau":
-		if param.From.Col == nil || param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col and to.col are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.To.Col == nil, "param error: from.col and to.col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.MoveTableauToTableau(*param.From.Col, *param.To.Col))
 	case fromZone == "tableau" && toZone == "foundation":
-		if param.From.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col is required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil, "param error: from.col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.MoveTableauToFoundation(*param.From.Col))

--- a/internal/adapter/controller/EightOffWebController.go
+++ b/internal/adapter/controller/EightOffWebController.go
@@ -69,8 +69,7 @@ func eightOffDispatch(bc *baseController, w http.ResponseWriter, ei usecase.Eigh
 	case "u", "undo":
 		bc.writePresenterResponse(w, ei.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ei.UndoN(*param.N))
@@ -81,8 +80,7 @@ func eightOffDispatch(bc *baseController, w http.ResponseWriter, ei usecase.Eigh
 }
 
 func eightOffMoveDispatch(bc *baseController, w http.ResponseWriter, ei usecase.EightOffInteractorIF, param EightOffWebInput, newDefault func(string) *EightOffWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
 	fromZone := param.From.Zone
@@ -90,32 +88,27 @@ func eightOffMoveDispatch(bc *baseController, w http.ResponseWriter, ei usecase.
 
 	switch {
 	case fromZone == "tableau" && toZone == "tableau":
-		if param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col, from.cardIndex, to.col are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil, "param error: from.col, from.cardIndex, to.col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ei.MoveTableauToTableau(*param.From.Col, *param.From.CardIndex, *param.To.Col))
 	case fromZone == "tableau" && toZone == "foundation":
-		if param.From.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col is required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil, "param error: from.col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ei.MoveTableauToFoundation(*param.From.Col))
 	case fromZone == "tableau" && toZone == "freecell":
-		if param.From.Col == nil || param.To.Cell == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col and to.cell are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.To.Cell == nil, "param error: from.col and to.cell are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ei.MoveTableauToFreeCell(*param.From.Col, *param.To.Cell))
 	case fromZone == "freecell" && toZone == "tableau":
-		if param.From.Cell == nil || param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.cell and to.col are required."))
+		if !requireParam(bc, w, newDefault, param.From.Cell == nil || param.To.Col == nil, "param error: from.cell and to.col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ei.MoveFreeCellToTableau(*param.From.Cell, *param.To.Col))
 	case fromZone == "freecell" && toZone == "foundation":
-		if param.From.Cell == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.cell is required."))
+		if !requireParam(bc, w, newDefault, param.From.Cell == nil, "param error: from.cell is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ei.MoveFreeCellToFoundation(*param.From.Cell))

--- a/internal/adapter/controller/EuchreWebController.go
+++ b/internal/adapter/controller/EuchreWebController.go
@@ -118,8 +118,7 @@ func euchreDispatch(bc *baseController, w http.ResponseWriter, ei usecase.Euchre
 		goAlone := param.GoAlone != nil && *param.GoAlone
 		bc.writePresenterResponse(w, ei.PickUp(true, goAlone))
 	case "c", "calltrump":
-		if param.Suit == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: suit is required."))
+		if !requireParam(bc, w, newDefault, param.Suit == nil, "param error: suit is required.") {
 			return true
 		}
 		goAlone := param.GoAlone != nil && *param.GoAlone
@@ -127,14 +126,12 @@ func euchreDispatch(bc *baseController, w http.ResponseWriter, ei usecase.Euchre
 	case "pa", "pass":
 		bc.writePresenterResponse(w, ei.Pass())
 	case "d", "discard":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ei.Discard(*param.CardIndex))
 	case "p", "play":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ei.Play(*param.CardIndex))

--- a/internal/adapter/controller/FiftyOneWebController.go
+++ b/internal/adapter/controller/FiftyOneWebController.go
@@ -76,8 +76,7 @@ func fiftyOneDispatch(bc *baseController, w http.ResponseWriter, fi usecase.Fift
 		cfg := buildFiftyOneConfig(fi.GetConfig(), param.Config)
 		bc.writePresenterResponse(w, fi.Reset(cfg))
 	case "play":
-		if param.HandIdx == nil || param.TableIdx == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: handIdx and tableIdx are required."))
+		if !requireParam(bc, w, newDefault, param.HandIdx == nil || param.TableIdx == nil, "param error: handIdx and tableIdx are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, fi.ExchangeOne(*param.HandIdx, *param.TableIdx))

--- a/internal/adapter/controller/FortyThievesWebController.go
+++ b/internal/adapter/controller/FortyThievesWebController.go
@@ -77,8 +77,7 @@ func fortyThievesDispatch(bc *baseController, w http.ResponseWriter, fi usecase.
 	case "u", "undo":
 		bc.writePresenterResponse(w, fi.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, fi.UndoN(*param.N))
@@ -89,8 +88,7 @@ func fortyThievesDispatch(bc *baseController, w http.ResponseWriter, fi usecase.
 }
 
 func fortyThievesMoveDispatch(bc *baseController, w http.ResponseWriter, fi usecase.FortyThievesInteractorIF, param FortyThievesWebInput, newDefault func(string) *FortyThievesWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
 	fromZone := param.From.Zone
@@ -98,22 +96,19 @@ func fortyThievesMoveDispatch(bc *baseController, w http.ResponseWriter, fi usec
 
 	switch {
 	case fromZone == "waste" && toZone == "tableau":
-		if param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: to.col is required."))
+		if !requireParam(bc, w, newDefault, param.To.Col == nil, "param error: to.col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, fi.MoveWasteToTableau(*param.To.Col))
 	case fromZone == "waste" && toZone == "foundation":
 		bc.writePresenterResponse(w, fi.MoveWasteToFoundation())
 	case fromZone == "tableau" && toZone == "tableau":
-		if param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col, from.cardIndex, to.col are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil, "param error: from.col, from.cardIndex, to.col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, fi.MoveTableauToTableau(*param.From.Col, *param.From.CardIndex, *param.To.Col))
 	case fromZone == "tableau" && toZone == "foundation":
-		if param.From.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col is required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil, "param error: from.col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, fi.MoveTableauToFoundation(*param.From.Col))

--- a/internal/adapter/controller/FreeCellWebController.go
+++ b/internal/adapter/controller/FreeCellWebController.go
@@ -69,8 +69,7 @@ func freeCellDispatch(bc *baseController, w http.ResponseWriter, fi usecase.Free
 	case "u", "undo":
 		bc.writePresenterResponse(w, fi.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, fi.UndoN(*param.N))
@@ -81,8 +80,7 @@ func freeCellDispatch(bc *baseController, w http.ResponseWriter, fi usecase.Free
 }
 
 func freeCellMoveDispatch(bc *baseController, w http.ResponseWriter, fi usecase.FreeCellInteractorIF, param FreeCellWebInput, newDefault func(string) *FreeCellWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
 	fromZone := param.From.Zone
@@ -90,32 +88,27 @@ func freeCellMoveDispatch(bc *baseController, w http.ResponseWriter, fi usecase.
 
 	switch {
 	case fromZone == "tableau" && toZone == "tableau":
-		if param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col, from.cardIndex, to.col are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil, "param error: from.col, from.cardIndex, to.col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, fi.MoveTableauToTableau(*param.From.Col, *param.From.CardIndex, *param.To.Col))
 	case fromZone == "tableau" && toZone == "foundation":
-		if param.From.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col is required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil, "param error: from.col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, fi.MoveTableauToFoundation(*param.From.Col))
 	case fromZone == "tableau" && toZone == "freecell":
-		if param.From.Col == nil || param.To.Cell == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col and to.cell are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.To.Cell == nil, "param error: from.col and to.cell are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, fi.MoveTableauToFreeCell(*param.From.Col, *param.To.Cell))
 	case fromZone == "freecell" && toZone == "tableau":
-		if param.From.Cell == nil || param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.cell and to.col are required."))
+		if !requireParam(bc, w, newDefault, param.From.Cell == nil || param.To.Col == nil, "param error: from.cell and to.col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, fi.MoveFreeCellToTableau(*param.From.Cell, *param.To.Col))
 	case fromZone == "freecell" && toZone == "foundation":
-		if param.From.Cell == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.cell is required."))
+		if !requireParam(bc, w, newDefault, param.From.Cell == nil, "param error: from.cell is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, fi.MoveFreeCellToFoundation(*param.From.Cell))

--- a/internal/adapter/controller/GapsWebController.go
+++ b/internal/adapter/controller/GapsWebController.go
@@ -65,8 +65,7 @@ func gapsDispatch(bc *baseController, w http.ResponseWriter, gi usecase.GapsInte
 	case "u", "undo":
 		bc.writePresenterResponse(w, gi.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, gi.UndoN(*param.N))
@@ -77,12 +76,10 @@ func gapsDispatch(bc *baseController, w http.ResponseWriter, gi usecase.GapsInte
 }
 
 func gapsMoveDispatch(bc *baseController, w http.ResponseWriter, gi usecase.GapsInteractorIF, param GapsWebInput, newDefault func(string) *GapsWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
-	if param.From.Row == nil || param.From.Col == nil || param.To.Row == nil || param.To.Col == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: row and col are required."))
+	if !requireParam(bc, w, newDefault, param.From.Row == nil || param.From.Col == nil || param.To.Row == nil || param.To.Col == nil, "param error: row and col are required.") {
 		return true
 	}
 	bc.writePresenterResponse(w, gi.Move(*param.From.Row, *param.From.Col, *param.To.Row, *param.To.Col))

--- a/internal/adapter/controller/GinRummyWebController.go
+++ b/internal/adapter/controller/GinRummyWebController.go
@@ -103,14 +103,12 @@ func ginRummyDispatch(bc *baseController, w http.ResponseWriter, ci usecase.GinR
 	case "dd", "drawdiscard":
 		bc.writePresenterResponse(w, ci.DrawFromDiscard())
 	case "d", "discard":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.Discard(*param.CardIndex))
 	case "k", "knock":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.Knock(*param.CardIndex))

--- a/internal/adapter/controller/GoFishWebController.go
+++ b/internal/adapter/controller/GoFishWebController.go
@@ -105,8 +105,7 @@ func goFishDispatch(bc *baseController, w http.ResponseWriter, gi usecase.GoFish
 		cfg := buildGoFishConfig(gi.GetConfig(), param.Config)
 		bc.writePresenterResponse(w, gi.Reset(cfg))
 	case "ask":
-		if param.TargetIdx == nil || param.Rank == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: targetIdx and rank are required."))
+		if !requireParam(bc, w, newDefault, param.TargetIdx == nil || param.Rank == nil, "param error: targetIdx and rank are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, gi.Ask(*param.TargetIdx, *param.Rank))

--- a/internal/adapter/controller/GolfWebController.go
+++ b/internal/adapter/controller/GolfWebController.go
@@ -57,8 +57,7 @@ func golfDispatch(bc *baseController, w http.ResponseWriter, gi usecase.GolfInte
 	case "d", "draw":
 		bc.writePresenterResponse(w, gi.Draw())
 	case "rm", "remove":
-		if param.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: col is required."))
+		if !requireParam(bc, w, newDefault, param.Col == nil, "param error: col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, gi.Remove(*param.Col))
@@ -67,8 +66,7 @@ func golfDispatch(bc *baseController, w http.ResponseWriter, gi usecase.GolfInte
 	case "u", "undo":
 		bc.writePresenterResponse(w, gi.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, gi.UndoN(*param.N))

--- a/internal/adapter/controller/HeartsWebController.go
+++ b/internal/adapter/controller/HeartsWebController.go
@@ -108,14 +108,12 @@ func heartsDispatch(bc *baseController, w http.ResponseWriter, hi usecase.Hearts
 	case "r", "reset":
 		bc.writePresenterResponse(w, hi.ResetWithConfig(param.ToConfig()))
 	case "pass":
-		if len(param.CardIndices) != 3 {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: pass requires exactly 3 card indices."))
+		if !requireParam(bc, w, newDefault, len(param.CardIndices) != 3, "param error: pass requires exactly 3 card indices.") {
 			return true
 		}
 		bc.writePresenterResponse(w, hi.Pass(param.CardIndices))
 	case "p", "play":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, hi.Play(*param.CardIndex))

--- a/internal/adapter/controller/KlondikeWebController.go
+++ b/internal/adapter/controller/KlondikeWebController.go
@@ -101,8 +101,7 @@ func klondikeDispatch(bc *baseController, w http.ResponseWriter, ki usecase.Klon
 	case "u", "undo":
 		bc.writePresenterResponse(w, ki.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ki.UndoN(*param.N))
@@ -113,8 +112,7 @@ func klondikeDispatch(bc *baseController, w http.ResponseWriter, ki usecase.Klon
 }
 
 func klondikeMoveDispatch(bc *baseController, w http.ResponseWriter, ki usecase.KlondikeInteractorIF, param KlondikeWebInput, newDefault func(string) *KlondikeWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
 	fromZone := param.From.Zone
@@ -122,22 +120,19 @@ func klondikeMoveDispatch(bc *baseController, w http.ResponseWriter, ki usecase.
 
 	switch {
 	case fromZone == "waste" && toZone == "tableau":
-		if param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: to.col is required."))
+		if !requireParam(bc, w, newDefault, param.To.Col == nil, "param error: to.col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ki.MoveWasteToTableau(*param.To.Col))
 	case fromZone == "waste" && toZone == "foundation":
 		bc.writePresenterResponse(w, ki.MoveWasteToFoundation())
 	case fromZone == "tableau" && toZone == "tableau":
-		if param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col, from.cardIndex, to.col are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil, "param error: from.col, from.cardIndex, to.col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ki.MoveTableauToTableau(*param.From.Col, *param.From.CardIndex, *param.To.Col))
 	case fromZone == "tableau" && toZone == "foundation":
-		if param.From.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col is required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil, "param error: from.col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ki.MoveTableauToFoundation(*param.From.Col))

--- a/internal/adapter/controller/MemoryWebController.go
+++ b/internal/adapter/controller/MemoryWebController.go
@@ -90,8 +90,7 @@ func memoryDispatch(bc *baseController, w http.ResponseWriter, mi usecase.Memory
 	case "r", "reset":
 		bc.writePresenterResponse(w, mi.ResetWithConfig(param.ToConfig()))
 	case "f", "flip":
-		if param.Position == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: position is required."))
+		if !requireParam(bc, w, newDefault, param.Position == nil, "param error: position is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, mi.Flip(*param.Position))

--- a/internal/adapter/controller/MightyWebController.go
+++ b/internal/adapter/controller/MightyWebController.go
@@ -143,33 +143,28 @@ func mightyDispatch(bc *baseController, w http.ResponseWriter, mi usecase.Mighty
 	case "r", "reset":
 		bc.writePresenterResponse(w, mi.ResetWithConfig(param.ToConfig()))
 	case "b", "bid":
-		if param.Bid == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: bid is required."))
+		if !requireParam(bc, w, newDefault, param.Bid == nil, "param error: bid is required.") {
 			return true
 		}
 		noTrump := param.NoTrump != nil && *param.NoTrump
 		bc.writePresenterResponse(w, mi.Bid(*param.Bid, noTrump))
 	case "t", "trump":
-		if param.TrumpSuit == nil || param.PartnerSuit == nil || param.PartnerValue == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: trumpSuit, partnerSuit, partnerValue are required."))
+		if !requireParam(bc, w, newDefault, param.TrumpSuit == nil || param.PartnerSuit == nil || param.PartnerValue == nil, "param error: trumpSuit, partnerSuit, partnerValue are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, mi.DeclareTrumpAndFriend(*param.TrumpSuit, *param.PartnerSuit, *param.PartnerValue))
 	case "e", "exchange":
-		if len(param.DiscardIndices) == 0 {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: discardIndices are required."))
+		if !requireParam(bc, w, newDefault, len(param.DiscardIndices) == 0, "param error: discardIndices are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, mi.ExchangeKitty(param.DiscardIndices))
 	case "p", "play":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, mi.Play(*param.CardIndex))
 	case "jl", "jokerlead":
-		if param.CardIndex == nil || param.JokerLeadSuit == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex and jokerLeadSuit are required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil || param.JokerLeadSuit == nil, "param error: cardIndex and jokerLeadSuit are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, mi.PlayJokerLead(*param.CardIndex, *param.JokerLeadSuit))

--- a/internal/adapter/controller/MonteCarloWebController.go
+++ b/internal/adapter/controller/MonteCarloWebController.go
@@ -61,8 +61,7 @@ func newMonteCarloDefaultOutput(msg string) *MonteCarloWebOutput {
 func monteCarloDispatch(bc *baseController, w http.ResponseWriter, mi usecase.MonteCarloInteractorIF, param MonteCarloWebInput, newDefault func(string) *MonteCarloWebOutput) bool {
 	switch param.Command {
 	case "m", "move", "remove":
-		if param.FromR == nil || param.FromC == nil || param.ToR == nil || param.ToC == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: fromR, fromC, toR, toC are required."))
+		if !requireParam(bc, w, newDefault, param.FromR == nil || param.FromC == nil || param.ToR == nil || param.ToC == nil, "param error: fromR, fromC, toR, toC are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, mi.Remove(*param.FromR, *param.FromC, *param.ToR, *param.ToC))

--- a/internal/adapter/controller/NapoleonWebController.go
+++ b/internal/adapter/controller/NapoleonWebController.go
@@ -132,26 +132,22 @@ func napoleonDispatch(bc *baseController, w http.ResponseWriter, ni usecase.Napo
 	case "r", "reset":
 		bc.writePresenterResponse(w, ni.ResetWithConfig(param.ToConfig()))
 	case "b", "bid":
-		if param.Bid == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: bid is required."))
+		if !requireParam(bc, w, newDefault, param.Bid == nil, "param error: bid is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ni.Bid(*param.Bid))
 	case "t", "trump":
-		if param.TrumpSuit == nil || param.AdjutantSuit == nil || param.AdjutantValue == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: trumpSuit, adjutantSuit, adjutantValue are required."))
+		if !requireParam(bc, w, newDefault, param.TrumpSuit == nil || param.AdjutantSuit == nil || param.AdjutantValue == nil, "param error: trumpSuit, adjutantSuit, adjutantValue are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ni.DeclareTrump(*param.TrumpSuit, *param.AdjutantSuit, *param.AdjutantValue))
 	case "e", "exchange":
-		if param.DiscardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: discardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.DiscardIndex == nil, "param error: discardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ni.ExchangeKitty(*param.DiscardIndex))
 	case "p", "play":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ni.Play(*param.CardIndex))

--- a/internal/adapter/controller/NertzWebController.go
+++ b/internal/adapter/controller/NertzWebController.go
@@ -158,45 +158,38 @@ func nertzConfigFromInput(current domain.NertzConfig, in *NertzWebConfig) domain
 }
 
 func nertzMoveDispatch(bc *baseController, w http.ResponseWriter, ni usecase.NertzInteractorIF, param NertzWebInput, newDefault func(string) *NertzWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
 	playerIdx := derefDefault(param.PlayerIdx, 0)
 	switch {
 	case param.From.Zone == "nertz" && param.To.Zone == "foundation":
-		if param.To.Idx == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: to.idx is required."))
+		if !requireParam(bc, w, newDefault, param.To.Idx == nil, "param error: to.idx is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ni.MoveNertzToFoundation(playerIdx, *param.To.Idx))
 	case param.From.Zone == "nertz" && param.To.Zone == "tableau":
-		if param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: to.col is required."))
+		if !requireParam(bc, w, newDefault, param.To.Col == nil, "param error: to.col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ni.MoveNertzToTableau(playerIdx, *param.To.Col))
 	case param.From.Zone == "waste" && param.To.Zone == "foundation":
-		if param.To.Idx == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: to.idx is required."))
+		if !requireParam(bc, w, newDefault, param.To.Idx == nil, "param error: to.idx is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ni.MoveWasteToFoundation(playerIdx, *param.To.Idx))
 	case param.From.Zone == "waste" && param.To.Zone == "tableau":
-		if param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: to.col is required."))
+		if !requireParam(bc, w, newDefault, param.To.Col == nil, "param error: to.col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ni.MoveWasteToTableau(playerIdx, *param.To.Col))
 	case param.From.Zone == "tableau" && param.To.Zone == "foundation":
-		if param.From.Col == nil || param.To.Idx == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col and to.idx are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.To.Idx == nil, "param error: from.col and to.idx are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ni.MoveTableauToFoundation(playerIdx, *param.From.Col, *param.To.Idx))
 	case param.From.Zone == "tableau" && param.To.Zone == "tableau":
-		if param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col, from.cardIndex, to.col are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil, "param error: from.col, from.cardIndex, to.col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ni.MoveTableauToTableau(playerIdx, *param.From.Col, *param.From.CardIndex, *param.To.Col))

--- a/internal/adapter/controller/OhHellWebController.go
+++ b/internal/adapter/controller/OhHellWebController.go
@@ -120,14 +120,12 @@ func ohHellDispatch(bc *baseController, w http.ResponseWriter, oi usecase.OhHell
 	case "r", "reset":
 		bc.writePresenterResponse(w, oi.ResetWithConfig(param.ToConfig()))
 	case "b", "bid":
-		if param.Bid == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: bid is required."))
+		if !requireParam(bc, w, newDefault, param.Bid == nil, "param error: bid is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, oi.Bid(*param.Bid))
 	case "p", "play":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, oi.Play(*param.CardIndex))

--- a/internal/adapter/controller/OldMaidWebController.go
+++ b/internal/adapter/controller/OldMaidWebController.go
@@ -132,8 +132,7 @@ func oldMaidDispatch(bc *baseController, w http.ResponseWriter, omi usecase.OldM
 	case "s", "shuffle":
 		bc.writePresenterResponse(w, omi.Shuffle())
 	case "reorder":
-		if param.ReorderIndices == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: reorderIndices is required."))
+		if !requireParam(bc, w, newDefault, param.ReorderIndices == nil, "param error: reorderIndices is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, omi.Reorder(param.ReorderIndices))

--- a/internal/adapter/controller/PageOneWebController.go
+++ b/internal/adapter/controller/PageOneWebController.go
@@ -87,8 +87,7 @@ func pageOneDispatch(bc *baseController, w http.ResponseWriter, ci usecase.PageO
 	case "r", "reset":
 		bc.writePresenterResponse(w, ci.ResetWithConfig(param.ToConfig()))
 	case "p", "play":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.Play(*param.CardIndex))

--- a/internal/adapter/controller/PenguinWebController.go
+++ b/internal/adapter/controller/PenguinWebController.go
@@ -70,8 +70,7 @@ func penguinDispatch(bc *baseController, w http.ResponseWriter, pi usecase.Pengu
 	case "u", "undo":
 		bc.writePresenterResponse(w, pi.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, pi.UndoN(*param.N))
@@ -82,8 +81,7 @@ func penguinDispatch(bc *baseController, w http.ResponseWriter, pi usecase.Pengu
 }
 
 func penguinMoveDispatch(bc *baseController, w http.ResponseWriter, pi usecase.PenguinInteractorIF, param PenguinWebInput, newDefault func(string) *PenguinWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
 	fromZone := param.From.Zone
@@ -91,32 +89,27 @@ func penguinMoveDispatch(bc *baseController, w http.ResponseWriter, pi usecase.P
 
 	switch {
 	case fromZone == "tableau" && toZone == "tableau":
-		if param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col, from.cardIndex, to.col are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil, "param error: from.col, from.cardIndex, to.col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, pi.MoveTableauToTableau(*param.From.Col, *param.From.CardIndex, *param.To.Col))
 	case fromZone == "tableau" && toZone == "foundation":
-		if param.From.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col is required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil, "param error: from.col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, pi.MoveTableauToFoundation(*param.From.Col))
 	case fromZone == "tableau" && toZone == "freecell":
-		if param.From.Col == nil || param.To.Cell == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col and to.cell are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.To.Cell == nil, "param error: from.col and to.cell are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, pi.MoveTableauToFreeCell(*param.From.Col, *param.To.Cell))
 	case fromZone == "freecell" && toZone == "tableau":
-		if param.From.Cell == nil || param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.cell and to.col are required."))
+		if !requireParam(bc, w, newDefault, param.From.Cell == nil || param.To.Col == nil, "param error: from.cell and to.col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, pi.MoveFreeCellToTableau(*param.From.Cell, *param.To.Col))
 	case fromZone == "freecell" && toZone == "foundation":
-		if param.From.Cell == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.cell is required."))
+		if !requireParam(bc, w, newDefault, param.From.Cell == nil, "param error: from.cell is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, pi.MoveFreeCellToFoundation(*param.From.Cell))

--- a/internal/adapter/controller/PineappleWebController.go
+++ b/internal/adapter/controller/PineappleWebController.go
@@ -85,8 +85,7 @@ func pineappleDispatch(bc *baseController, w http.ResponseWriter, pgi usecase.Pi
 		}
 		bc.writePresenterResponse(w, pgi.ResetWithConfig(cfg, param.Profile))
 	case "d", "discard":
-		if param.CardIdx == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIdx is required for discard"))
+		if !requireParam(bc, w, newDefault, param.CardIdx == nil, "param error: cardIdx is required for discard") {
 			return true
 		}
 		bc.writePresenterResponse(w, pgi.Discard(*param.CardIdx))

--- a/internal/adapter/controller/PinochleWebController.go
+++ b/internal/adapter/controller/PinochleWebController.go
@@ -125,24 +125,21 @@ func pinochleDispatch(bc *baseController, w http.ResponseWriter, pi usecase.Pino
 	case "r", "reset":
 		bc.writePresenterResponse(w, pi.ResetWithConfig(param.ToConfig()))
 	case "b", "bid":
-		if param.BidAmount == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: bidAmount is required."))
+		if !requireParam(bc, w, newDefault, param.BidAmount == nil, "param error: bidAmount is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, pi.Bid(*param.BidAmount))
 	case "pa", "pass":
 		bc.writePresenterResponse(w, pi.Pass())
 	case "t", "trump":
-		if param.Suit == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: suit is required."))
+		if !requireParam(bc, w, newDefault, param.Suit == nil, "param error: suit is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, pi.CallTrump(*param.Suit))
 	case "m", "meld":
 		bc.writePresenterResponse(w, pi.ConfirmMelds())
 	case "p", "play":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, pi.Play(*param.CardIndex))

--- a/internal/adapter/controller/PiquetWebController.go
+++ b/internal/adapter/controller/PiquetWebController.go
@@ -147,22 +147,19 @@ func piquetDispatch(bc *baseController, w http.ResponseWriter, pi usecase.Piquet
 	case "r", "reset":
 		bc.writePresenterResponse(w, pi.ResetWithConfig(param.ToConfig()))
 	case "e", "elder":
-		if param.DiscardIndices == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: discardIndices is required."))
+		if !requireParam(bc, w, newDefault, param.DiscardIndices == nil, "param error: discardIndices is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, pi.ExchangeElder(param.DiscardIndices))
 	case "y", "younger":
-		if param.DiscardIndices == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: discardIndices is required."))
+		if !requireParam(bc, w, newDefault, param.DiscardIndices == nil, "param error: discardIndices is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, pi.ExchangeYounger(param.DiscardIndices))
 	case "d", "declare":
 		bc.writePresenterResponse(w, pi.ResolveDeclaration())
 	case "p", "play":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, pi.Play(*param.CardIndex))

--- a/internal/adapter/controller/PitchWebController.go
+++ b/internal/adapter/controller/PitchWebController.go
@@ -112,14 +112,12 @@ func pitchDispatch(bc *baseController, w http.ResponseWriter, pi usecase.PitchIn
 	case "r", "reset":
 		bc.writePresenterResponse(w, pi.ResetWithConfig(param.ToConfig()))
 	case "b", "bid":
-		if param.Bid == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: bid is required."))
+		if !requireParam(bc, w, newDefault, param.Bid == nil, "param error: bid is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, pi.Bid(*param.Bid))
 	case "p", "play":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, pi.Play(*param.CardIndex))

--- a/internal/adapter/controller/PokerSquaresWebController.go
+++ b/internal/adapter/controller/PokerSquaresWebController.go
@@ -52,8 +52,7 @@ func newPokerSquaresDefaultOutput(msg string) *PokerSquaresWebOutput {
 func pokerSquaresDispatch(bc *baseController, w http.ResponseWriter, pi usecase.PokerSquaresInteractorIF, param PokerSquaresWebInput, newDefault func(string) *PokerSquaresWebOutput) bool {
 	switch param.Command {
 	case "p", "place":
-		if param.Row == nil || param.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: row and col are required."))
+		if !requireParam(bc, w, newDefault, param.Row == nil || param.Col == nil, "param error: row and col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, pi.Place(*param.Row, *param.Col))

--- a/internal/adapter/controller/PyramidWebController.go
+++ b/internal/adapter/controller/PyramidWebController.go
@@ -74,8 +74,7 @@ func pyramidDispatch(bc *baseController, w http.ResponseWriter, pi usecase.Pyram
 	case "u", "undo":
 		bc.writePresenterResponse(w, pi.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, pi.UndoN(*param.N))
@@ -86,8 +85,7 @@ func pyramidDispatch(bc *baseController, w http.ResponseWriter, pi usecase.Pyram
 }
 
 func pyramidRemoveDispatch(bc *baseController, w http.ResponseWriter, pi usecase.PyramidInteractorIF, param PyramidWebInput, newDefault func(string) *PyramidWebOutput) bool {
-	if param.Card1 == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: card1 is required."))
+	if !requireParam(bc, w, newDefault, param.Card1 == nil, "param error: card1 is required.") {
 		return true
 	}
 
@@ -97,29 +95,25 @@ func pyramidRemoveDispatch(bc *baseController, w http.ResponseWriter, pi usecase
 	switch {
 	case c1.Zone == "pyramid" && c2 != nil && c2.Zone == "pyramid":
 		// ピラミッド同士のペア除去
-		if c1.Row == nil || c1.Col == nil || c2.Row == nil || c2.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: row and col are required for pyramid cards."))
+		if !requireParam(bc, w, newDefault, c1.Row == nil || c1.Col == nil || c2.Row == nil || c2.Col == nil, "param error: row and col are required for pyramid cards.") {
 			return true
 		}
 		bc.writePresenterResponse(w, pi.RemovePair(*c1.Row, *c1.Col, *c2.Row, *c2.Col))
 	case c1.Zone == "pyramid" && c2 == nil:
 		// ピラミッドのキング除去
-		if c1.Row == nil || c1.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: row and col are required."))
+		if !requireParam(bc, w, newDefault, c1.Row == nil || c1.Col == nil, "param error: row and col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, pi.RemoveKing(*c1.Row, *c1.Col))
 	case c1.Zone == "waste" && c2 != nil && c2.Zone == "pyramid":
 		// ウェイスト+ピラミッドのペア除去
-		if c2.Row == nil || c2.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: row and col are required for pyramid card."))
+		if !requireParam(bc, w, newDefault, c2.Row == nil || c2.Col == nil, "param error: row and col are required for pyramid card.") {
 			return true
 		}
 		bc.writePresenterResponse(w, pi.RemoveWithWaste(*c2.Row, *c2.Col))
 	case c1.Zone == "pyramid" && c2 != nil && c2.Zone == "waste":
 		// ピラミッド+ウェイストのペア除去 (逆順もサポート)
-		if c1.Row == nil || c1.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: row and col are required for pyramid card."))
+		if !requireParam(bc, w, newDefault, c1.Row == nil || c1.Col == nil, "param error: row and col are required for pyramid card.") {
 			return true
 		}
 		bc.writePresenterResponse(w, pi.RemoveWithWaste(*c1.Row, *c1.Col))

--- a/internal/adapter/controller/Rummy500WebController.go
+++ b/internal/adapter/controller/Rummy500WebController.go
@@ -109,14 +109,12 @@ func rummy500Dispatch(bc *baseController, w http.ResponseWriter, ci usecase.Rumm
 	case "m", "meld":
 		bc.writePresenterResponse(w, ci.Meld(param.CardIndices))
 	case "lo", "layoff":
-		if param.MeldOwner == nil || param.MeldIdx == nil || param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: meldOwner, meldIdx and cardIndex are required."))
+		if !requireParam(bc, w, newDefault, param.MeldOwner == nil || param.MeldIdx == nil || param.CardIndex == nil, "param error: meldOwner, meldIdx and cardIndex are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.Layoff(*param.MeldOwner, *param.MeldIdx, *param.CardIndex))
 	case "d", "discard":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.Discard(*param.CardIndex))

--- a/internal/adapter/controller/RussianSolitaireWebController.go
+++ b/internal/adapter/controller/RussianSolitaireWebController.go
@@ -65,8 +65,7 @@ func russianSolitaireDispatch(bc *baseController, w http.ResponseWriter, ri usec
 	case "u", "undo":
 		bc.writePresenterResponse(w, ri.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ri.UndoN(*param.N))
@@ -77,8 +76,7 @@ func russianSolitaireDispatch(bc *baseController, w http.ResponseWriter, ri usec
 }
 
 func russianSolitaireMoveDispatch(bc *baseController, w http.ResponseWriter, ri usecase.RussianSolitaireInteractorIF, param RussianSolitaireWebInput, newDefault func(string) *RussianSolitaireWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
 	fromZone := param.From.Zone
@@ -86,14 +84,12 @@ func russianSolitaireMoveDispatch(bc *baseController, w http.ResponseWriter, ri 
 
 	switch {
 	case fromZone == "tableau" && toZone == "tableau":
-		if param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col, from.cardIndex, to.col are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil, "param error: from.col, from.cardIndex, to.col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ri.MoveTableauToTableau(*param.From.Col, *param.From.CardIndex, *param.To.Col))
 	case fromZone == "tableau" && toZone == "foundation":
-		if param.From.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col is required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil, "param error: from.col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ri.MoveTableauToFoundation(*param.From.Col))

--- a/internal/adapter/controller/ScorpionWebController.go
+++ b/internal/adapter/controller/ScorpionWebController.go
@@ -66,8 +66,7 @@ func scorpionDispatch(bc *baseController, w http.ResponseWriter, si usecase.Scor
 	case "u", "undo":
 		bc.writePresenterResponse(w, si.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, si.UndoN(*param.N))
@@ -78,16 +77,13 @@ func scorpionDispatch(bc *baseController, w http.ResponseWriter, si usecase.Scor
 }
 
 func scorpionMoveDispatch(bc *baseController, w http.ResponseWriter, si usecase.ScorpionInteractorIF, param ScorpionWebInput, newDefault func(string) *ScorpionWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
-	if param.From.Zone != "tableau" || param.To.Zone != "tableau" {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: invalid move zones. Only tableau to tableau is supported."))
+	if !requireParam(bc, w, newDefault, param.From.Zone != "tableau" || param.To.Zone != "tableau", "param error: invalid move zones. Only tableau to tableau is supported.") {
 		return true
 	}
-	if param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col, from.cardIndex, to.col are required."))
+	if !requireParam(bc, w, newDefault, param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil, "param error: from.col, from.cardIndex, to.col are required.") {
 		return true
 	}
 	bc.writePresenterResponse(w, si.MoveTableauToTableau(*param.From.Col, *param.From.CardIndex, *param.To.Col))

--- a/internal/adapter/controller/SeahavenTowersWebController.go
+++ b/internal/adapter/controller/SeahavenTowersWebController.go
@@ -69,8 +69,7 @@ func seahavenTowersDispatch(bc *baseController, w http.ResponseWriter, si usecas
 	case "u", "undo":
 		bc.writePresenterResponse(w, si.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, si.UndoN(*param.N))
@@ -81,8 +80,7 @@ func seahavenTowersDispatch(bc *baseController, w http.ResponseWriter, si usecas
 }
 
 func seahavenTowersMoveDispatch(bc *baseController, w http.ResponseWriter, si usecase.SeahavenTowersInteractorIF, param SeahavenTowersWebInput, newDefault func(string) *SeahavenTowersWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
 	fromZone := param.From.Zone
@@ -90,32 +88,27 @@ func seahavenTowersMoveDispatch(bc *baseController, w http.ResponseWriter, si us
 
 	switch {
 	case fromZone == "tableau" && toZone == "tableau":
-		if param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col, from.cardIndex, to.col are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil, "param error: from.col, from.cardIndex, to.col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, si.MoveTableauToTableau(*param.From.Col, *param.From.CardIndex, *param.To.Col))
 	case fromZone == "tableau" && toZone == "foundation":
-		if param.From.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col is required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil, "param error: from.col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, si.MoveTableauToFoundation(*param.From.Col))
 	case fromZone == "tableau" && toZone == "reserved":
-		if param.From.Col == nil || param.To.Cell == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col and to.cell are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.To.Cell == nil, "param error: from.col and to.cell are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, si.MoveTableauToFreeCell(*param.From.Col, *param.To.Cell))
 	case fromZone == "reserved" && toZone == "tableau":
-		if param.From.Cell == nil || param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.cell and to.col are required."))
+		if !requireParam(bc, w, newDefault, param.From.Cell == nil || param.To.Col == nil, "param error: from.cell and to.col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, si.MoveFreeCellToTableau(*param.From.Cell, *param.To.Col))
 	case fromZone == "reserved" && toZone == "foundation":
-		if param.From.Cell == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.cell is required."))
+		if !requireParam(bc, w, newDefault, param.From.Cell == nil, "param error: from.cell is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, si.MoveFreeCellToFoundation(*param.From.Cell))

--- a/internal/adapter/controller/SevenBridgeWebController.go
+++ b/internal/adapter/controller/SevenBridgeWebController.go
@@ -104,14 +104,12 @@ func sevenBridgeDispatch(bc *baseController, w http.ResponseWriter, ci usecase.S
 	case "m", "meld":
 		bc.writePresenterResponse(w, ci.Meld(param.CardIndices))
 	case "lo", "layoff":
-		if param.TargetPlayerIdx == nil || param.MeldIdx == nil || param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: targetPlayerIdx, meldIdx, cardIndex are required."))
+		if !requireParam(bc, w, newDefault, param.TargetPlayerIdx == nil || param.MeldIdx == nil || param.CardIndex == nil, "param error: targetPlayerIdx, meldIdx, cardIndex are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.Layoff(*param.TargetPlayerIdx, *param.MeldIdx, *param.CardIndex))
 	case "d", "discard":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.Discard(*param.CardIndex))

--- a/internal/adapter/controller/SixCardGolfWebController.go
+++ b/internal/adapter/controller/SixCardGolfWebController.go
@@ -101,8 +101,7 @@ func sixCardGolfDispatch(bc *baseController, w http.ResponseWriter, ci usecase.S
 	case "r", "reset":
 		bc.writePresenterResponse(w, ci.ResetWithConfig(param.ToConfig()))
 	case "fi", "flipinitial":
-		if param.Position == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: position is required."))
+		if !requireParam(bc, w, newDefault, param.Position == nil, "param error: position is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.FlipInitial(*param.Position))
@@ -111,16 +110,14 @@ func sixCardGolfDispatch(bc *baseController, w http.ResponseWriter, ci usecase.S
 	case "dd", "drawdiscard":
 		bc.writePresenterResponse(w, ci.DrawDiscard())
 	case "sw", "swap":
-		if param.Position == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: position is required."))
+		if !requireParam(bc, w, newDefault, param.Position == nil, "param error: position is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.SwapCard(*param.Position))
 	case "di", "discard":
 		bc.writePresenterResponse(w, ci.DiscardDrawn())
 	case "fl", "flip":
-		if param.Position == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: position is required."))
+		if !requireParam(bc, w, newDefault, param.Position == nil, "param error: position is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.FlipCard(*param.Position))

--- a/internal/adapter/controller/SkatWebController.go
+++ b/internal/adapter/controller/SkatWebController.go
@@ -139,26 +139,22 @@ func skatDispatch(bc *baseController, w http.ResponseWriter, si usecase.SkatInte
 	case "r", "reset":
 		bc.writePresenterResponse(w, si.ResetWithConfig(param.ToConfig()))
 	case "b", "bid":
-		if param.Accept == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: accept is required."))
+		if !requireParam(bc, w, newDefault, param.Accept == nil, "param error: accept is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, si.Bid(*param.Accept))
 	case "ps", "pickskat":
-		if param.Pickup == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: pickup is required."))
+		if !requireParam(bc, w, newDefault, param.Pickup == nil, "param error: pickup is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, si.PickSkat(*param.Pickup))
 	case "d", "discard":
-		if param.DiscardA == nil || param.DiscardB == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: discardA and discardB are required."))
+		if !requireParam(bc, w, newDefault, param.DiscardA == nil || param.DiscardB == nil, "param error: discardA and discardB are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, si.Discard(*param.DiscardA, *param.DiscardB))
 	case "g", "game":
-		if param.GameType == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: gameType is required."))
+		if !requireParam(bc, w, newDefault, param.GameType == nil, "param error: gameType is required.") {
 			return true
 		}
 		trump := 0
@@ -167,8 +163,7 @@ func skatDispatch(bc *baseController, w http.ResponseWriter, si usecase.SkatInte
 		}
 		bc.writePresenterResponse(w, si.DeclareGame(domain.SkatGameType(*param.GameType), trump))
 	case "p", "play":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, si.Play(*param.CardIndex))

--- a/internal/adapter/controller/SpadesWebController.go
+++ b/internal/adapter/controller/SpadesWebController.go
@@ -114,14 +114,12 @@ func spadesDispatch(bc *baseController, w http.ResponseWriter, si usecase.Spades
 	case "r", "reset":
 		bc.writePresenterResponse(w, si.ResetWithConfig(param.ToConfig()))
 	case "b", "bid":
-		if param.Bid == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: bid is required."))
+		if !requireParam(bc, w, newDefault, param.Bid == nil, "param error: bid is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, si.Bid(*param.Bid))
 	case "p", "play":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, si.Play(*param.CardIndex))

--- a/internal/adapter/controller/SpiderWebController.go
+++ b/internal/adapter/controller/SpiderWebController.go
@@ -91,8 +91,7 @@ func spiderDispatch(bc *baseController, w http.ResponseWriter, si usecase.Spider
 	case "u", "undo":
 		bc.writePresenterResponse(w, si.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, si.UndoN(*param.N))
@@ -103,16 +102,14 @@ func spiderDispatch(bc *baseController, w http.ResponseWriter, si usecase.Spider
 }
 
 func spiderMoveDispatch(bc *baseController, w http.ResponseWriter, si usecase.SpiderInteractorIF, param SpiderWebInput, newDefault func(string) *SpiderWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
 	fromZone := param.From.Zone
 	toZone := param.To.Zone
 
 	if fromZone == "tableau" && toZone == "tableau" {
-		if param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col, from.cardIndex, to.col are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil, "param error: from.col, from.cardIndex, to.col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, si.MoveTableauToTableau(*param.From.Col, *param.From.CardIndex, *param.To.Col))

--- a/internal/adapter/controller/SpideretteWebController.go
+++ b/internal/adapter/controller/SpideretteWebController.go
@@ -75,8 +75,7 @@ func spideretteDispatch(bc *baseController, w http.ResponseWriter, si usecase.Sp
 	case "u", "undo":
 		bc.writePresenterResponse(w, si.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, si.UndoN(*param.N))
@@ -87,16 +86,13 @@ func spideretteDispatch(bc *baseController, w http.ResponseWriter, si usecase.Sp
 }
 
 func spideretteMoveDispatch(bc *baseController, w http.ResponseWriter, si usecase.SpideretteInteractorIF, param SpideretteWebInput, newDefault func(string) *SpideretteWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
-	if param.From.Zone != "tableau" || param.To.Zone != "tableau" {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: invalid move zones. Only tableau to tableau is supported."))
+	if !requireParam(bc, w, newDefault, param.From.Zone != "tableau" || param.To.Zone != "tableau", "param error: invalid move zones. Only tableau to tableau is supported.") {
 		return true
 	}
-	if param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col, from.cardIndex, to.col are required."))
+	if !requireParam(bc, w, newDefault, param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil, "param error: from.col, from.cardIndex, to.col are required.") {
 		return true
 	}
 	bc.writePresenterResponse(w, si.MoveTableauToTableau(*param.From.Col, *param.From.CardIndex, *param.To.Col))

--- a/internal/adapter/controller/SpiteAndMaliceWebController.go
+++ b/internal/adapter/controller/SpiteAndMaliceWebController.go
@@ -89,26 +89,22 @@ func spiteAndMaliceDispatch(bc *baseController, w http.ResponseWriter, si usecas
 }
 
 func spiteAndMaliceMoveDispatch(bc *baseController, w http.ResponseWriter, si usecase.SpiteAndMaliceInteractorIF, param SpiteAndMaliceWebInput, newDefault func(string) *SpiteAndMaliceWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
-	if param.To.Zone != "foundation" || param.To.Idx == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: to.zone must be 'foundation' with idx."))
+	if !requireParam(bc, w, newDefault, param.To.Zone != "foundation" || param.To.Idx == nil, "param error: to.zone must be 'foundation' with idx.") {
 		return true
 	}
 	switch param.From.Zone {
 	case "hand":
-		if param.From.Idx == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.idx is required."))
+		if !requireParam(bc, w, newDefault, param.From.Idx == nil, "param error: from.idx is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, si.PlayFromHand(*param.From.Idx, *param.To.Idx))
 	case "goal":
 		bc.writePresenterResponse(w, si.PlayFromGoal(*param.To.Idx))
 	case "side":
-		if param.From.Idx == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.idx is required."))
+		if !requireParam(bc, w, newDefault, param.From.Idx == nil, "param error: from.idx is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, si.PlayFromSide(*param.From.Idx, *param.To.Idx))
@@ -119,16 +115,13 @@ func spiteAndMaliceMoveDispatch(bc *baseController, w http.ResponseWriter, si us
 }
 
 func spiteAndMaliceDiscardDispatch(bc *baseController, w http.ResponseWriter, si usecase.SpiteAndMaliceInteractorIF, param SpiteAndMaliceWebInput, newDefault func(string) *SpiteAndMaliceWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
-	if param.From.Zone != "hand" || param.From.Idx == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from must be hand with idx."))
+	if !requireParam(bc, w, newDefault, param.From.Zone != "hand" || param.From.Idx == nil, "param error: from must be hand with idx.") {
 		return true
 	}
-	if param.To.Zone != "side" || param.To.Idx == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: to must be side with idx."))
+	if !requireParam(bc, w, newDefault, param.To.Zone != "side" || param.To.Idx == nil, "param error: to must be side with idx.") {
 		return true
 	}
 	bc.writePresenterResponse(w, si.Discard(*param.From.Idx, *param.To.Idx))

--- a/internal/adapter/controller/TarneebWebController.go
+++ b/internal/adapter/controller/TarneebWebController.go
@@ -120,20 +120,17 @@ func tarneebDispatch(bc *baseController, w http.ResponseWriter, ti usecase.Tarne
 	case "r", "reset":
 		bc.writePresenterResponse(w, ti.ResetWithConfig(param.ToConfig()))
 	case "b", "bid":
-		if param.Bid == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: bid is required."))
+		if !requireParam(bc, w, newDefault, param.Bid == nil, "param error: bid is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ti.Bid(*param.Bid))
 	case "t", "trump":
-		if param.TrumpSuit == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: trumpSuit is required."))
+		if !requireParam(bc, w, newDefault, param.TrumpSuit == nil, "param error: trumpSuit is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ti.DeclareTrump(*param.TrumpSuit))
 	case "p", "play":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ti.Play(*param.CardIndex))

--- a/internal/adapter/controller/TonkWebController.go
+++ b/internal/adapter/controller/TonkWebController.go
@@ -107,14 +107,12 @@ func tonkDispatch(bc *baseController, w http.ResponseWriter, ci usecase.TonkInte
 	case "dd", "drawdiscard":
 		bc.writePresenterResponse(w, ci.DrawFromDiscard())
 	case "d", "discard":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.Discard(*param.CardIndex))
 	case "k", "knock":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ci.Knock(*param.CardIndex))

--- a/internal/adapter/controller/TrashWebController.go
+++ b/internal/adapter/controller/TrashWebController.go
@@ -60,8 +60,7 @@ func trashDispatch(bc *baseController, w http.ResponseWriter, ti usecase.TrashIn
 	case "d", "draw":
 		bc.writePresenterResponse(w, ti.Draw())
 	case "p", "place", "placeWild":
-		if param.Position == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: position is required."))
+		if !requireParam(bc, w, newDefault, param.Position == nil, "param error: position is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ti.PlaceWild(*param.Position))

--- a/internal/adapter/controller/TriPeaksWebController.go
+++ b/internal/adapter/controller/TriPeaksWebController.go
@@ -59,8 +59,7 @@ func triPeaksDispatch(bc *baseController, w http.ResponseWriter, ti usecase.TriP
 	case "d", "draw":
 		bc.writePresenterResponse(w, ti.Draw())
 	case "rm", "remove":
-		if param.Row == nil || param.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: row and col are required."))
+		if !requireParam(bc, w, newDefault, param.Row == nil || param.Col == nil, "param error: row and col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ti.Remove(*param.Row, *param.Col))
@@ -69,8 +68,7 @@ func triPeaksDispatch(bc *baseController, w http.ResponseWriter, ti usecase.TriP
 	case "u", "undo":
 		bc.writePresenterResponse(w, ti.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ti.UndoN(*param.N))

--- a/internal/adapter/controller/TrucoWebController.go
+++ b/internal/adapter/controller/TrucoWebController.go
@@ -119,8 +119,7 @@ func trucoDispatch(bc *baseController, w http.ResponseWriter, ti usecase.TrucoIn
 	case "r", "reset":
 		bc.writePresenterResponse(w, ti.ResetWithConfig(param.ToConfig()))
 	case "p", "play":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ti.Play(*param.CardIndex))

--- a/internal/adapter/controller/TwoTenJackWebController.go
+++ b/internal/adapter/controller/TwoTenJackWebController.go
@@ -107,14 +107,12 @@ func twoTenJackDispatch(bc *baseController, w http.ResponseWriter, ti usecase.Tw
 	case "r", "reset":
 		bc.writePresenterResponse(w, ti.ResetWithConfig(param.ToConfig()))
 	case "d", "declare":
-		if param.TrumpSuit == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: trumpSuit is required."))
+		if !requireParam(bc, w, newDefault, param.TrumpSuit == nil, "param error: trumpSuit is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ti.DeclareTrump(*param.TrumpSuit))
 	case "p", "play":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, ti.Play(*param.CardIndex))

--- a/internal/adapter/controller/WhistWebController.go
+++ b/internal/adapter/controller/WhistWebController.go
@@ -106,8 +106,7 @@ func whistDispatch(bc *baseController, w http.ResponseWriter, wi usecase.WhistIn
 	case "r", "reset":
 		bc.writePresenterResponse(w, wi.ResetWithConfig(param.ToConfig()))
 	case "p", "play":
-		if param.CardIndex == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: cardIndex is required."))
+		if !requireParam(bc, w, newDefault, param.CardIndex == nil, "param error: cardIndex is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, wi.Play(*param.CardIndex))

--- a/internal/adapter/controller/YukonWebController.go
+++ b/internal/adapter/controller/YukonWebController.go
@@ -65,8 +65,7 @@ func yukonDispatch(bc *baseController, w http.ResponseWriter, yi usecase.YukonIn
 	case "u", "undo":
 		bc.writePresenterResponse(w, yi.Undo())
 	case "undo_n":
-		if param.N == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: n is required."))
+		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, yi.UndoN(*param.N))
@@ -77,8 +76,7 @@ func yukonDispatch(bc *baseController, w http.ResponseWriter, yi usecase.YukonIn
 }
 
 func yukonMoveDispatch(bc *baseController, w http.ResponseWriter, yi usecase.YukonInteractorIF, param YukonWebInput, newDefault func(string) *YukonWebOutput) bool {
-	if param.From == nil || param.To == nil {
-		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from and to are required."))
+	if !requireParam(bc, w, newDefault, param.From == nil || param.To == nil, "param error: from and to are required.") {
 		return true
 	}
 	fromZone := param.From.Zone
@@ -86,14 +84,12 @@ func yukonMoveDispatch(bc *baseController, w http.ResponseWriter, yi usecase.Yuk
 
 	switch {
 	case fromZone == "tableau" && toZone == "tableau":
-		if param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col, from.cardIndex, to.col are required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil || param.From.CardIndex == nil || param.To.Col == nil, "param error: from.col, from.cardIndex, to.col are required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, yi.MoveTableauToTableau(*param.From.Col, *param.From.CardIndex, *param.To.Col))
 	case fromZone == "tableau" && toZone == "foundation":
-		if param.From.Col == nil {
-			bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: from.col is required."))
+		if !requireParam(bc, w, newDefault, param.From.Col == nil, "param error: from.col is required.") {
 			return true
 		}
 		bc.writePresenterResponse(w, yi.MoveTableauToFoundation(*param.From.Col))

--- a/internal/adapter/controller/base_controller.go
+++ b/internal/adapter/controller/base_controller.go
@@ -61,6 +61,32 @@ func (bc *baseController) writeJsonResponse(w http.ResponseWriter, status int, b
 	}
 }
 
+// requireParam guards a dispatch case against a missing required parameter.
+// When missing is true it writes a 400 Bad Request carrying msg (built via the
+// game-specific newDefault so the response keeps that game's output shape) and
+// returns false; otherwise it returns true and the caller proceeds.
+//
+// This collapses the "if param.X == nil { writeJsonResponse(400, newDefault(
+// msg)); return true }" block that was duplicated across ~240 dispatch cases in
+// 64 *WebController.go files (issue #2102). The condition is passed verbatim as
+// `missing` (no negation at the call site), so multi-field checks like
+// `param.From == nil || param.To == nil` carry over unchanged. The generic O
+// absorbs each game's distinct *WebOutput type. Canonical usage:
+//
+//	if !requireParam(bc, w, newDefault, param.Col == nil, msgColRequired) {
+//		return true
+//	}
+//
+// Returning true from the dispatch case (command was recognized but invalid)
+// matches the previous behavior: the 400 has already been written here.
+func requireParam[O any](bc *baseController, w http.ResponseWriter, newDefault func(string) O, missing bool, msg string) bool {
+	if missing {
+		bc.writeJsonResponse(w, http.StatusBadRequest, newDefault(msg))
+		return false
+	}
+	return true
+}
+
 // execWithSession handles common web controller boilerplate.
 // handler returns true if command was recognized, false for unsupported.
 func execWithSession[P WebInput, T any](

--- a/internal/adapter/controller/require_param_test.go
+++ b/internal/adapter/controller/require_param_test.go
@@ -1,0 +1,59 @@
+package controller
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// reqParamTestOutput is a minimal *WebOutput stand-in for exercising
+// requireParam: it just needs a JSON-decodable message field so the test can
+// confirm the supplied param-error message is propagated (issue #2102).
+type reqParamTestOutput struct {
+	Message string `json:"message"`
+}
+
+func newReqParamTestOutput(msg string) *reqParamTestOutput {
+	return &reqParamTestOutput{Message: msg}
+}
+
+// TestRequireParam_MissingWrites400 verifies the helper writes a 400 carrying
+// the supplied message (built via newDefault) and returns false when the
+// required parameter is missing.
+func TestRequireParam_MissingWrites400(t *testing.T) {
+	bc := &baseController{}
+	w := httptest.NewRecorder()
+
+	ok := requireParam(bc, w, newReqParamTestOutput, true, "param error: col is required.")
+
+	if ok {
+		t.Fatal("requireParam returned true for a missing param; want false")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	var got reqParamTestOutput
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got.Message != "param error: col is required." {
+		t.Errorf("message = %q, want the supplied param-error message", got.Message)
+	}
+}
+
+// TestRequireParam_PresentDoesNothing verifies the helper returns true and
+// writes no response when the required parameter is present.
+func TestRequireParam_PresentDoesNothing(t *testing.T) {
+	bc := &baseController{}
+	w := httptest.NewRecorder()
+
+	ok := requireParam(bc, w, newReqParamTestOutput, false, "param error: col is required.")
+
+	if !ok {
+		t.Fatal("requireParam returned false for a present param; want true")
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("body = %q, want empty (helper must not write when param present)", w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

Every `*WebController.go` dispatch case guarded its required parameters with the same four-line block:

```go
if param.X == nil {
    bc.writeJsonResponse(w, http.StatusBadRequest, newDefault("param error: ..."))
    return true
}
```

This was duplicated across **243 cases in 64 controllers** (issue #2102) — the only common dispatch helper that hadn't been extracted yet (`dispatchResetHintAndLog` etc. already exist).

This adds a generic `requireParam[O]` helper on `baseController` and collapses each block to a single guard:

```go
if !requireParam(bc, w, newDefault, param.X == nil, "param error: ...") {
    return true
}
```

### Design notes
- The condition is passed **verbatim** as the `missing` argument (no negation at the call site), so multi-field guards like `param.From == nil || param.To == nil` carry over unchanged.
- The generic `O` absorbs each game's distinct `*WebOutput` type via the existing `newDefault func(string) O`.
- Behavior is byte-for-byte identical: same `400` status, same message, same "recognized-but-invalid → return true" semantics (the 400 is already written).
- The mechanical conversion was applied by script and then verified by the compiler + full test suite (a missed/garbled site would not build).
- **Scope note:** message literals are kept verbatim here. Promoting the repeated ones (e.g. `"cardIndex is required."` appears 30×) to shared constants + i18n `messageCode`s is left as a focused follow-up so this PR stays a pure, reviewable control-flow extraction.

## Test plan
- New `require_param_test.go`: missing param → `400` + supplied message; present param → no write, returns true.
- `go build ./...` ✅
- `go test -tags test ./...` ✅ (171 ok, 0 fail)
- `golangci-lint run ./internal/adapter/controller/` ✅ (0 issues)
- `goimports -w` applied.

Closes #2102

🤖 Generated with [Claude Code](https://claude.com/claude-code)