### PR TITLE
feat(solitaire): require confirmation before give-up (infra + Klondike)

### DIFF
--- a/frontend/src/components/GameGiveUpDialog.test.tsx
+++ b/frontend/src/components/GameGiveUpDialog.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { GameGiveUpDialog } from './GameGiveUpDialog';
+
+describe('GameGiveUpDialog', () => {
+  it('renders nothing when closed', () => {
+    render(<GameGiveUpDialog giveUpConfirmOpen={false} confirmGiveUp={vi.fn()} cancelGiveUp={vi.fn()} />);
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+
+  it('renders give-up-specific copy (not reset copy) when open', () => {
+    render(<GameGiveUpDialog giveUpConfirmOpen={true} confirmGiveUp={vi.fn()} cancelGiveUp={vi.fn()} />);
+    // ja translations are loaded in test/setup.ts.
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    expect(screen.getByText('投了すると現在のゲームは終了します。よろしいですか？')).toBeInTheDocument();
+  });
+
+  it('fires confirmGiveUp on confirm click', () => {
+    const confirmGiveUp = vi.fn();
+    render(<GameGiveUpDialog giveUpConfirmOpen={true} confirmGiveUp={confirmGiveUp} cancelGiveUp={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    expect(confirmGiveUp).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires cancelGiveUp on cancel click', () => {
+    const cancelGiveUp = vi.fn();
+    render(<GameGiveUpDialog giveUpConfirmOpen={true} confirmGiveUp={vi.fn()} cancelGiveUp={cancelGiveUp} />);
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    expect(cancelGiveUp).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/GameGiveUpDialog.tsx
+++ b/frontend/src/components/GameGiveUpDialog.tsx
@@ -1,0 +1,30 @@
+import { useTranslation } from 'react-i18next';
+import { ConfirmDialog } from './ConfirmDialog';
+
+/** Props for the GameGiveUpDialog component. */
+export interface GameGiveUpDialogProps {
+  giveUpConfirmOpen: boolean;
+  confirmGiveUp: () => void;
+  cancelGiveUp: () => void;
+}
+
+/**
+ * Renders a give-up confirmation dialog using common translation keys.
+ * Mirrors {@link GameResetDialog} but with give-up-specific copy, since
+ * give-up is an irreversible destructive action that deserves the same
+ * "are you sure?" guard as reset (issue #2099).
+ */
+export function GameGiveUpDialog({ giveUpConfirmOpen, confirmGiveUp, cancelGiveUp }: GameGiveUpDialogProps) {
+  const { t: tc } = useTranslation('common');
+  return (
+    <ConfirmDialog
+      open={giveUpConfirmOpen}
+      title={tc('button.confirmGiveUp')}
+      message={tc('button.confirmGiveUpMessage')}
+      confirmLabel={tc('button.confirm')}
+      cancelLabel={tc('button.cancel')}
+      onConfirm={confirmGiveUp}
+      onCancel={cancelGiveUp}
+    />
+  );
+}

--- a/frontend/src/components/GamePageShell.tsx
+++ b/frontend/src/components/GamePageShell.tsx
@@ -65,6 +65,27 @@ interface GamePageShellBaseProps {
 }
 
 /**
+ * Give-up confirmation props. Modeled as a discriminated union so the three
+ * fields are all-or-nothing: a page either opts out entirely (most non-solitaire
+ * games) or supplies the open flag *and* both callbacks. This makes incomplete
+ * wiring a compile error rather than a silently no-op dialog (issue #2099,
+ * PR #2108 review).
+ */
+type GiveUpConfirmProps =
+  | { giveUpConfirmOpen?: undefined; confirmGiveUp?: undefined; cancelGiveUp?: undefined }
+  | {
+      /** Whether the give-up confirmation dialog is open. */
+      giveUpConfirmOpen: boolean;
+      /** Callback to confirm the give-up action. */
+      confirmGiveUp: () => void;
+      /** Callback to cancel the give-up action. */
+      cancelGiveUp: () => void;
+    };
+
+/** Props for the GamePageShell component. */
+export type GamePageShellProps = GamePageShellBaseProps & GiveUpConfirmProps;
+
+/**
  * Renders the shared outer shell of a game page.
  * Includes the background container, visually-hidden heading, PhaseIndicator with
  * TutorialButton and ManualButton, and end-game overlays (WinCelebration, GameResetDialog).

--- a/frontend/src/components/GamePageShell.tsx
+++ b/frontend/src/components/GamePageShell.tsx
@@ -8,8 +8,8 @@ import { WinCelebration } from './motion/WinCelebration';
 import { PhaseIndicator } from './PhaseIndicator';
 import { TutorialButton } from './tutorial/TutorialButton';
 
-/** Props for the GamePageShell component. */
-export interface GamePageShellProps {
+/** Base props for the GamePageShell component (everything except the give-up trio). */
+interface GamePageShellBaseProps {
   /** Page title rendered as a visually-hidden h1 heading. */
   title: string;
   /** Tailwind background class for the outer container (e.g., gameTheme.hearts.bg). */
@@ -42,17 +42,6 @@ export interface GamePageShellProps {
   confirmReset: () => void;
   /** Callback to cancel the reset action. */
   cancelReset: () => void;
-  /**
-   * Whether the give-up confirmation dialog is open. Optional — pages without
-   * a give-up action (most non-solitaire games) omit it and no dialog renders.
-   * Solitaire pages pass this (plus confirmGiveUp/cancelGiveUp) so give-up gets
-   * the same confirm guard as reset (issue #2099).
-   */
-  giveUpConfirmOpen?: boolean;
-  /** Callback to confirm the give-up action. Required when giveUpConfirmOpen is set. */
-  confirmGiveUp?: () => void;
-  /** Callback to cancel the give-up action. Required when giveUpConfirmOpen is set. */
-  cancelGiveUp?: () => void;
   /**
    * Optional `key` applied to the outer container. Use for animations that must
    * restart on demand by remounting the subtree (e.g., Old Maid's shake-key

--- a/frontend/src/components/GamePageShell.tsx
+++ b/frontend/src/components/GamePageShell.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { useGameRoundGuard } from '../hooks/useGameRoundGuard';
+import { GameGiveUpDialog } from './GameGiveUpDialog';
 import { GamePageHeading } from './GamePageHeading';
 import { GameResetDialog } from './GameResetDialog';
 import { ManualButton } from './ManualButton';
@@ -42,6 +43,17 @@ export interface GamePageShellProps {
   /** Callback to cancel the reset action. */
   cancelReset: () => void;
   /**
+   * Whether the give-up confirmation dialog is open. Optional — pages without
+   * a give-up action (most non-solitaire games) omit it and no dialog renders.
+   * Solitaire pages pass this (plus confirmGiveUp/cancelGiveUp) so give-up gets
+   * the same confirm guard as reset (issue #2099).
+   */
+  giveUpConfirmOpen?: boolean;
+  /** Callback to confirm the give-up action. Required when giveUpConfirmOpen is set. */
+  confirmGiveUp?: () => void;
+  /** Callback to cancel the give-up action. Required when giveUpConfirmOpen is set. */
+  cancelGiveUp?: () => void;
+  /**
    * Optional `key` applied to the outer container. Use for animations that must
    * restart on demand by remounting the subtree (e.g., Old Maid's shake-key
    * pattern, where the wrapper needs to re-mount every time an invalid action
@@ -82,6 +94,9 @@ export function GamePageShell({
   confirmOpen,
   confirmReset,
   cancelReset,
+  giveUpConfirmOpen,
+  confirmGiveUp,
+  cancelGiveUp,
   outerKey,
   headerExtra,
   headerEnd,
@@ -101,6 +116,13 @@ export function GamePageShell({
       {children}
       <WinCelebration show={winShow ?? gameEndFlag} onCelebrate={onCelebrate} />
       <GameResetDialog confirmOpen={confirmOpen} confirmReset={confirmReset} cancelReset={cancelReset} />
+      {giveUpConfirmOpen !== undefined && confirmGiveUp && cancelGiveUp && (
+        <GameGiveUpDialog
+          giveUpConfirmOpen={giveUpConfirmOpen}
+          confirmGiveUp={confirmGiveUp}
+          cancelGiveUp={cancelGiveUp}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/hooks/useGamePageSetup.ts
+++ b/frontend/src/hooks/useGamePageSetup.ts
@@ -5,12 +5,21 @@ import { SITE_NAME } from '../constants/site';
 import { useActionLog } from './useActionLog';
 import { useConfirmDialog } from './useConfirmDialog';
 
-/** Hook that provides common page setup: translations, action log, confirm dialog, and document title. */
+/** Hook that provides common page setup: translations, action log, confirm dialogs, and document title. */
 export function useGamePageSetup(gameName: keyof typeof actionLogApi) {
   const { t } = useTranslation(gameName);
   const { t: tc } = useTranslation('common');
   const { actionLog, showActionLog, hideActionLog } = useActionLog(gameName);
   const { isOpen: confirmOpen, requestConfirm, confirm: confirmReset, cancel: cancelReset } = useConfirmDialog();
+  // Separate confirm instance for give-up so its dialog state never collides
+  // with reset's. Give-up abandons an in-progress game and is irreversible,
+  // so — like reset — it must be confirmed before firing (issue #2099).
+  const {
+    isOpen: giveUpConfirmOpen,
+    requestConfirm: requestGiveUpConfirm,
+    confirm: confirmGiveUp,
+    cancel: cancelGiveUp,
+  } = useConfirmDialog();
 
   const pageTitle = tc(`nav.${gameName}`);
   useEffect(() => {
@@ -20,5 +29,19 @@ export function useGamePageSetup(gameName: keyof typeof actionLogApi) {
     };
   }, [pageTitle]);
 
-  return { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset };
+  return {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  };
 }

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -187,6 +187,8 @@
     "cancel": "Cancel",
     "confirmReset": "Confirm Reset",
     "confirmResetMessage": "Are you sure you want to reset the game?",
+    "confirmGiveUp": "Confirm Give Up",
+    "confirmGiveUpMessage": "Giving up will end the current game. Are you sure?",
     "confirmLeaveRoundMessage": "Leaving this page will discard the current round. Continue?",
     "confirm": "Confirm",
     "hint": "Hint",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -187,6 +187,8 @@
     "cancel": "キャンセル",
     "confirmReset": "リセット確認",
     "confirmResetMessage": "本当にゲームをリセットしますか？",
+    "confirmGiveUp": "投了確認",
+    "confirmGiveUpMessage": "投了すると現在のゲームは終了します。よろしいですか？",
     "confirmLeaveRoundMessage": "ページを離れると現在のラウンドが破棄されます。続けますか？",
     "confirm": "確認",
     "hint": "ヒント",

--- a/frontend/src/pages/KlondikePage.test.tsx
+++ b/frontend/src/pages/KlondikePage.test.tsx
@@ -285,15 +285,30 @@ describe('KlondikePage', () => {
     expect(btn.className).toContain('animate-pulse');
   });
 
-  it('clicking give up button dispatches giveup', async () => {
+  it('give up button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<KlondikePage />);
     await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
 
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
+    // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
 
+    // Confirming dispatches giveup.
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
+  });
+
+  it('cancelling the give up dialog does not dispatch giveup', async () => {
+    renderWithProviders(<KlondikePage />);
+    await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
+
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
   });
 
   it('clicking reset button dispatches reset', async () => {

--- a/frontend/src/pages/KlondikePage.tsx
+++ b/frontend/src/pages/KlondikePage.tsx
@@ -85,8 +85,21 @@ const KL_TUTORIAL_STEPS: TutorialStep[] = [
 export const KlondikePage = withTutorial(KlondikePageContent, 'klondike', KL_TUTORIAL_STEPS);
 /** Inner content of the Klondike page, wrapped by TutorialProvider. */
 function KlondikePageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('klondike');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('klondike');
   const { playSound } = useSound();
   const {
     state,
@@ -172,15 +185,22 @@ function KlondikePageContent() {
     handleReset();
   }, [handleReset, hideActionLog, resetTimer]);
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const actionBindings = useMemo(
     () => [
       { key: 'd', action: handleDraw },
       { key: 'h', action: handleHint },
       { key: 'a', action: handleAutoComplete },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: handleUndo },
     ],
-    [handleDraw, handleHint, handleAutoComplete, handleGiveUp, handleUndo],
+    [handleDraw, handleHint, handleAutoComplete, confirmGiveUpAction, handleUndo],
   );
 
   useActionKeyboardNav({
@@ -227,6 +247,9 @@ function KlondikePageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -575,7 +598,7 @@ function KlondikePageContent() {
                   <button
                     type="button"
                     className={btnDanger}
-                    onClick={handleGiveUp}
+                    onClick={confirmGiveUpAction}
                     disabled={loading || isAutoCompleting}
                   >
                     {t('giveup')}

--- a/frontend/src/pages/KlondikePage.tsx
+++ b/frontend/src/pages/KlondikePage.tsx
@@ -205,7 +205,9 @@ function KlondikePageContent() {
 
   useActionKeyboardNav({
     bindings: actionBindings,
-    enabled: !!isPlayingForKbd && !loading,
+    // Mirror the give-up button's disabled condition (loading || isAutoCompleting):
+    // a `g` keypress mid-auto-complete must not open the confirm dialog (#2099 review).
+    enabled: !!isPlayingForKbd && !loading && !isAutoCompleting,
   });
 
   if (!state) return <GameSkeleton gameKey="klondike" layout={{ kind: 'tableau', topRow: 6, tableau: 7 }} />;


### PR DESCRIPTION
## Summary

Give-up abandons an in-progress solitaire game and is **irreversible**, yet — unlike reset — it fires immediately from both the give-up button **and** the single `g` key. A mis-tap or stray keypress throws away minutes of progress with no guard (issue #2099). Reset already routes through a confirm dialog; this brings give-up to parity.

This PR lands the **shared infrastructure + the Klondike reference implementation**. The remaining solitaire pages are a mechanical follow-up (see below).

## What's in this PR

- **i18n** (`common.json` ja+en): `button.confirmGiveUp` / `confirmGiveUpMessage` — give-up-specific copy, **not** reused reset copy (投了確認 / "Confirm Give Up").
- **`useGamePageSetup`**: a second, independent `useConfirmDialog` instance exposed as `giveUpConfirmOpen` / `requestGiveUpConfirm` / `confirmGiveUp` / `cancelGiveUp`, so give-up and reset dialog states never collide.
- **`GameGiveUpDialog`**: mirrors `GameResetDialog` with the give-up keys.
- **`GamePageShell`**: optional `giveUpConfirmOpen`/`confirmGiveUp`/`cancelGiveUp` props; renders the dialog only when provided, so non-solitaire pages are untouched.
- **KlondikePage** (reference wiring): `confirmGiveUpAction = () => requestGiveUpConfirm(handleGiveUp)` now backs both the button `onClick` and the `g` keybinding; the shell receives the give-up props. Confirm dispatches `giveup`; cancel does nothing.

## Follow-up (intentionally not in this PR)

The other ~24 solitaire pages need the same 5-line wiring. I attempted a scripted bulk rollout but it produced non-trivial per-page issues (use-before-declaration on pages that define `handleGiveUp` locally, hook dep-array updates, and three pages — Spiderette/SeahavenTowers/BeleagueredCastle — that render two `GamePageShell` instances and so double-mount the dialog). Rather than land churn I couldn't fully verify in this session, I'm shipping the verified vertical slice and will wire the rest page-by-page in a follow-up. Tracked on #2099.

## Test plan
- `GameGiveUpDialog` test: renders give-up copy; confirm/cancel callbacks fire.
- `useGamePageSetup` test: give-up dialog state is independent of reset; cancel runs no action.
- `KlondikePage` test: give-up does **not** dispatch before confirm; confirm dispatches `giveup`; cancel dispatches nothing.
- `bun run test -- --run KlondikePage GameGiveUpDialog useGamePageSetup GamePageShell GameResetDialog` ✅ 5 files / 119 tests.
- `bunx biome check` on all 9 changed files ✅.
- tsc type-check runs in CI.

Refs #2099 (infra + Klondike; remaining pages follow up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)