### PR TITLE
fix(e2e): repair Klondike give-up + Chinese Poker foul E2E tests

### DIFF
--- a/frontend/e2e/chinesepoker.spec.ts
+++ b/frontend/e2e/chinesepoker.spec.ts
@@ -1,6 +1,130 @@
 import { expect, test } from '@playwright/test';
 import { navigateTo, waitForLoaded } from './helpers';
 
+/** A dealt card with its rank (A=14 high), suit symbol, and 0-based button index. */
+type PCard = { r: number; s: string; i: number };
+
+/** Parse the rank value from a card alt label like "♥ A" or "♦ 10" (Ace high). */
+function parseRank(label: string): number {
+  const token = label.trim().split(/\s+/).pop() ?? '';
+  if (token === 'A') return 14;
+  if (token === 'K') return 13;
+  if (token === 'Q') return 12;
+  if (token === 'J') return 11;
+  return Number.parseInt(token, 10);
+}
+
+/** Parse the suit symbol from a card alt label like "♥ A". */
+function parseSuit(label: string): string {
+  return label.trim().split(/\s+/)[0] ?? '';
+}
+
+/** Ranks ordered by frequency (desc), then by rank (desc) — poker kicker order. */
+function freqOrder(ranks: number[]): number[] {
+  const count = new Map<number, number>();
+  for (const r of ranks) count.set(r, (count.get(r) ?? 0) + 1);
+  return [...ranks].sort((a, b) => {
+    const ca = count.get(a) ?? 0;
+    const cb = count.get(b) ?? 0;
+    return ca !== cb ? cb - ca : b - a;
+  });
+}
+
+/** Distinct count values (desc) for a set of ranks, e.g. a full house → [3, 2]. */
+function countShape(ranks: number[]): number[] {
+  const count = new Map<number, number>();
+  for (const r of ranks) count.set(r, (count.get(r) ?? 0) + 1);
+  return [...count.values()].sort((a, b) => b - a);
+}
+
+/** True when 5 ranks form a straight (Ace high; A-2-3-4-5 wheel allowed). */
+function isStraight(ranks: number[]): boolean {
+  const sorted = [...ranks].sort((a, b) => a - b);
+  if (new Set(sorted).size !== 5) return false;
+  if (sorted[4] - sorted[0] === 4) return true;
+  return sorted.join(',') === '2,3,4,5,14';
+}
+
+/** Score a 5-card hand as [category, ...frequency-ordered ranks]. Higher is stronger. */
+function rank5(cards: PCard[]): number[] {
+  const ranks = cards.map((c) => c.r);
+  const counts = countShape(ranks);
+  const flush = new Set(cards.map((c) => c.s)).size === 1;
+  const straight = isStraight(ranks);
+  let cat: number;
+  if (flush && straight) cat = 8;
+  else if (counts[0] === 4) cat = 7;
+  else if (counts[0] === 3 && counts[1] === 2) cat = 6;
+  else if (flush) cat = 5;
+  else if (straight) cat = 4;
+  else if (counts[0] === 3) cat = 3;
+  else if (counts[0] === 2 && counts[1] === 2) cat = 2;
+  else if (counts[0] === 2) cat = 1;
+  else cat = 0;
+  return [cat, ...freqOrder(ranks)];
+}
+
+/** Score a 3-card front hand (no straights/flushes count): trips=3, pair=1, high=0. */
+function rank3(cards: PCard[]): number[] {
+  const ranks = cards.map((c) => c.r);
+  const counts = countShape(ranks);
+  const cat = counts[0] === 3 ? 3 : counts[0] === 2 ? 1 : 0;
+  return [cat, ...freqOrder(ranks)];
+}
+
+/** Lexicographic compare of two hand scores. >0 if a is stronger than b. */
+function cmp(a: number[], b: number[]): number {
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+/** Generate all k-combinations of arr. */
+function combinations<T>(arr: T[], k: number): T[][] {
+  const res: T[][] = [];
+  const rec = (start: number, combo: T[]) => {
+    if (combo.length === k) {
+      res.push([...combo]);
+      return;
+    }
+    for (let i = start; i < arr.length; i++) {
+      combo.push(arr[i]);
+      rec(i + 1, combo);
+      combo.pop();
+    }
+  };
+  rec(0, []);
+  return res;
+}
+
+/**
+ * Find a legal (non-foul) arrangement: front(3) ≤ middle(5) ≤ back(5) by hand
+ * strength. Brute-forces all 3/5/5 partitions and returns the button indices to
+ * assign to front and middle (the remaining 5 fall to back automatically).
+ * Returns null only if no legal arrangement exists (effectively never for a
+ * random 13-card deal).
+ */
+function legalArrangement(cards: PCard[]): { front: number[]; middle: number[] } | null {
+  const pos = cards.map((_, i) => i);
+  for (const f of combinations(pos, 3)) {
+    const fset = new Set(f);
+    const rem = pos.filter((i) => !fset.has(i));
+    const fScore = rank3(f.map((i) => cards[i]));
+    for (const m of combinations(rem, 5)) {
+      const mScore = rank5(m.map((i) => cards[i]));
+      if (cmp(fScore, mScore) > 0) continue;
+      const mset = new Set(m);
+      const back = rem.filter((i) => !mset.has(i));
+      if (cmp(mScore, rank5(back.map((i) => cards[i]))) <= 0) {
+        return { front: f.map((i) => cards[i].i), middle: m.map((i) => cards[i].i) };
+      }
+    }
+  }
+  return null;
+}
+
 test.describe('Chinese Poker E2E', () => {
   test('plays a round: bet → set hands → result → reset', async ({ page }) => {
     await navigateTo(page, '/chinesepoker');
@@ -11,14 +135,29 @@ test.describe('Chinese Poker E2E', () => {
     await betButton.click();
     await waitForLoaded(page);
 
-    // SET HANDS phase: select 3 front + 5 middle cards then click セット
+    // SET HANDS phase: read the 13 dealt cards and compute a legal arrangement.
+    // A naive "first 3 → front, next 5 → middle" split is almost always a foul
+    // (front ≤ middle ≤ back is violated), which the server rejects — so the
+    // arrangement must be rank-aware to reliably reach the END phase.
     const cards = page.locator('[data-tutorial="cp-set-hands"] button[aria-label^="Card"]');
     await expect(cards.first()).toBeVisible({ timeout: 10_000 });
+    const count = await cards.count();
 
-    // Click 8 cards to assign front (3) + middle (5)
-    for (let i = 0; i < 8; i++) {
-      await cards.nth(i).click();
+    const dealt: PCard[] = [];
+    for (let i = 0; i < count; i++) {
+      const label = (await cards.nth(i).locator('img').first().getAttribute('alt')) ?? '';
+      dealt.push({ r: parseRank(label), s: parseSuit(label), i });
     }
+
+    const arrangement = legalArrangement(dealt);
+    // A legal arrangement effectively always exists for a random 13-card deal;
+    // throwing (rather than asserting) narrows the type for the clicks below.
+    if (!arrangement) throw new Error('no legal (non-foul) arrangement for the dealt hand');
+
+    // Click the 3 front cards first (they fill the front slots), then the 5
+    // middle cards (they fill the middle slots); the remaining 5 fall to back.
+    for (const i of arrangement.front) await cards.nth(i).click();
+    for (const i of arrangement.middle) await cards.nth(i).click();
 
     const setButton = page.getByRole('button', { name: 'セット' });
     await expect(setButton).toBeVisible();

--- a/frontend/e2e/klondike.spec.ts
+++ b/frontend/e2e/klondike.spec.ts
@@ -50,10 +50,13 @@ test.describe('Klondike E2E', () => {
   test('give up ends the game', async ({ page }) => {
     await navigateTo(page, '/klondike');
 
-    // Click give up
+    // Click give up — gated behind a confirm dialog since #2099.
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' });
     await expect(giveUpButton).toBeVisible();
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog.
+    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // After give up, playing buttons should not be visible


### PR DESCRIPTION
## Summary

Two Playwright E2E tests have been failing **deterministically on `develop`** (the E2E job has been red for several commits). Root-caused via the CI Playwright DOM snapshots. Neither is tied to a single feature; this PR fixes both, test-only.

### 1. `klondike.spec.ts:60` — "give up ends the game"

- **Symptom:** `expect(button 'ヒント').not.toBeVisible()` → `Received: visible`.
- **Root cause:** PR #2108 (`b1588072`, #2099) gated give-up behind a **confirm dialog** (`KlondikePage` → `requestGiveUpConfirm(handleGiveUp)` → `GameGiveUpDialog`, confirm label `確認`). The give-up only fires after confirming. The spec was not updated — it clicked ギブアップ and immediately asserted the game ended, so the dialog was still open and the game still live.
- **Fix:** click the `確認` button to confirm the give-up before asserting.

### 2. `chinesepoker.spec.ts:30` — "plays a round"

- **Symptom:** `次のゲーム` (END) never appears; page stuck in `ハンド設定`. The CI snapshot shows the status banner: *"Foul: Back hand must be stronger than or equal to Middle, and Middle must be ≥ Front."*
- **Root cause:** the spec assigned cards by **deal order** (first 3 → front, next 5 → middle), which is a foul on almost every random deal (front ≤ middle ≤ back violated). The server rejects fouls and keeps the game in the set phase. The test only passed on the rare deal whose naive split happened to be legal — flaky by design.
- **Fix:** the spec now reads the 13 dealt cards (rank + suit from the card `alt` labels) and **brute-forces a legal (non-foul) front/middle/back arrangement**, then clicks front-then-middle in that order. Deterministic.

## Test plan

- [x] `bunx biome check` clean on both specs.
- [ ] CI: Playwright E2E — both `klondike` and `chinesepoker` specs pass (verified in CI; the local box lacks RAM to run Playwright).

Found while landing #2109 (2-7 Triple Draw), which inherited these pre-existing `develop` E2E failures. Keeping the fix separate so #2109 stays scoped to the new game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)