### PR TITLE
chore: add new-game skill and game-registration-checker agent

### DIFF
--- a/.claude/agents/game-registration-checker.md
+++ b/.claude/agents/game-registration-checker.md
@@ -1,0 +1,88 @@
+---
+name: game-registration-checker
+description: Read-only verifier that a newly added card game is wired into every required backend, frontend, worker, and count-assertion touchpoint, with all four registration points agreeing on name+category. Use before committing a new-game change to catch missing registrations and stale count totals BEFORE the (expensive, OOM-prone) CI round-trip. MUST BE USED after adding or renaming a game.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are a registration-consistency checker for the go_trumpcards repo. You are **read-only**:
+never edit files, never commit. Your job is to verify a game `<name>` (bucket `<category>` ∈
+{casino, classic, solo}) is fully and consistently wired, then report PASS/FAIL with exact
+file:line evidence for every gap.
+
+The caller gives you the game `<name>` and its `<category>`. If `<category>` is not given,
+infer it from `registry.go` and state your inference.
+
+## Checks (run all; do not stop at the first failure)
+
+### 1. Four backend registration points agree on name + category
+Run these and confirm each yields exactly one match for `<name>`:
+```
+grep -n '"<name>"' internal/infrastructure/games/registry.go
+grep -n '"<name>"' internal/infrastructure/games/games_server.go
+grep -rn '"<name>"' internal/infrastructure/games/<category>/
+grep -n '"<name>"' internal/infrastructure/ui/GameManager.go
+grep -n '"<name>"' frontend/src/api/gameApi.ts
+```
+- `registry.go` must have `{Name: "<name>", Category: Category<Cap>, …}`.
+- `games_server.go` must have `BindWebControllerFor("<name>", …)`.
+- The `RegisterKVGame("<name>", …)` call must live in the `<category>` sub-package **and
+  nowhere else** — a call under the wrong sub-package is a FAIL (it breaks the worker size
+  split and `TestWorkerRegistrationsCoverAllGames`).
+- `GameManager.go` `gameRegistry` must have a matching entry.
+- `gameApi.ts` `workerUrl` must map `"<name>": "<category>"` (the bucket string must equal
+  `<category>`). A mismatch here is the most common silent break — verify the value, not
+  just the key's presence.
+
+### 2. Registry ↔ CLI ordering
+`TestRegistryMatchesCLI` requires `gameRegistry` (GameManager.go) order to match `registry`
+(registry.go) order. Confirm the new game appears in the **same relative position** (newest
+games are appended last in both). Report if positions differ.
+
+### 3. Count assertions are bumped consistently
+Read these and report each value:
+- `internal/infrastructure/games/registry_test.go` consts `expectedCasino` / `expectedClassic`
+  / `expectedSolo` (lines ~16–18). The const for `<category>` must equal the number of
+  `RegisterKVGame` calls in `internal/infrastructure/games/<category>/`. Count them:
+  ```
+  grep -rc 'RegisterKVGame' internal/infrastructure/games/<category>/
+  ```
+  If `expected<Category>` ≠ that count → FAIL with both numbers.
+- `frontend/src/hooks/useTutorialProgress.test.ts` — `totalCount).toBe(N)` (~line 12)
+- `frontend/src/components/tutorial/TutorialProgressPanel.test.tsx` — **three** assertions
+  (~lines 22/36/49): `getByText(/N/)`, `links.length`, `incompleteMarkers.length`.
+- All four frontend `N` values AND the global total (sum of the three Go consts) must be
+  equal. Compute the Go total and compare. Any divergence → FAIL listing each file's value.
+- Confirm the `games` array in `frontend/src/api/gameApi.ts` (~line 2237) includes `<name>`.
+
+### 4. Frontend route + concierge profile
+- `frontend/src/constants/gameRoutes.ts` has a `<name>` entry **with a `profile:` field**
+  (tsc fails without it).
+- `frontend/src/App.tsx` has a route for the page.
+- `frontend/src/i18n/locales/{ja,en}/discover.json` both contain `discover.blurb.<kebab>`
+  and `discover.stretch_blurb.<kebab>`.
+
+### 5. Manuals registered
+- `docs/manual/cui/<name>.md` and `docs/manual/web/<name>.md` exist.
+- `frontend/src/constants/manualTexts.ts` imports + route-maps the **Web** manual.
+- `frontend/src/constants/cuiManualTexts.ts` imports + route-maps the **CUI** manual
+  (easy to forget — check explicitly).
+
+### 6. i18n + hint + page wiring
+- `frontend/src/i18n/locales/{ja,en}/<name>.json` both exist.
+- `frontend/src/utils/hints/<name>Hint.ts` exists (real impl or documented `null` stub) and
+  is registered in `frontend/src/hooks/useGameHint.ts` `hintFactories`.
+- `frontend/src/styles/gameTheme.ts` has a unique `GameKey` entry for `<name>`.
+
+## Output format
+
+Report as a checklist. For each of the 6 groups, mark `✅ PASS` or `❌ FAIL`. For every
+FAIL give the exact `file:line` (or "missing: <expected file>") and the concrete fix
+("bump expectedSolo 39→40", "workerUrl maps to 'classic' but Category is solo"). End with:
+
+- **VERDICT: PASS** — all wired and counts consistent, safe to commit, or
+- **VERDICT: FAIL (n issues)** — followed by a numbered fix list ordered by what will break
+  the build first (count/worker mismatches before doc gaps).
+
+Do not run `go test`, `golangci-lint`, or `bun run build` — they OOM on this box; your value
+is catching these statically before CI. Stay read-only.

--- a/.claude/skills/new-game/SKILL.md
+++ b/.claude/skills/new-game/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: new-game
+description: Scaffold and wire a new card game across every backend, frontend, worker, doc, and count-assertion touchpoint. Use when the user wants to add a new game (e.g. "add a new game", "implement <game>", "/new-game <name> <category>"). Drives the full New Game Addition Checklist so no registration point or hardcoded count is missed.
+disable-model-invocation: true
+---
+
+# New Game
+
+Add a new card game end to end without the recurring first-push failures (forgotten count
+assertions, wrong worker bucket, missing registration touchpoint). This skill is the
+*driver*; the authoritative step list lives in
+[`docs/new-game-checklist.md`](../../../docs/new-game-checklist.md) — read it first and treat
+it as the source of truth. This file adds the moving parts that bite most often.
+
+## Inputs
+
+- `<name>` — lowercase game id, no spaces (e.g. `fivehundred`, `sixcardgolf`). Used as the
+  registry key, API route, i18n filename, and worker route. Must be unique.
+- `<category>` — exactly one of `casino` | `classic` | `solo`. **This is a binary-size
+  bucket, not a user-facing taxonomy.** It pins the game to one Cloudflare Worker WASM
+  binary. Pick the category whose worker still has gzip headroom under the 1 MB free-tier
+  limit, *not* the one that "feels" right thematically.
+  - ⚠️ The `classic` worker is historically at/near the 1 MB limit. Recent games
+    (Scopa, Barbu, Macau, Tien Len, Wasp, Thirty-One, Osmosis, Five Hundred) were all
+    bucketed `solo` or `casino` for headroom even when thematically trick-taking. When in
+    doubt, prefer `solo` (most headroom) and confirm with `make build-worker-<category>`.
+- `<issue#>` (optional) — GitHub issue this closes; include `Closes #<n>` in the PR body.
+
+If `<name>` or `<category>` is missing, ask before scaffolding.
+
+## Workflow
+
+1. **Research & reuse first.** Before writing a domain, check whether an existing game is a
+   near-clone. The repo has many derived games (Wasp = Scorpion + empty-column rule;
+   Big O = Omaha with `holeCards=5`; Tien Len = Big Two variant). Cloning an existing
+   domain + adjusting one rule is the dominant successful pattern — search
+   `internal/domain/` for the closest analog and read it before starting net-new code.
+
+2. **TDD per layer (Red → Green → Refactor).** Tests ship in the same commit. Domain →
+   usecase → adapter → frontend, each with its test file. Target **80%+ branch coverage**
+   on every new package (`cmd/` and `internal/infrastructure/` are exempt).
+
+3. **Walk the checklist.** Open [`docs/new-game-checklist.md`](../../../docs/new-game-checklist.md)
+   and complete every item (backend, frontend, docs, verification). Do not skip the
+   self-audit block at the bottom.
+
+4. **Bump ALL count assertions** (the #1 first-push failure). Adding one game changes these
+   hardcoded totals — update every one in the same commit:
+
+   | File | What to bump |
+   |------|--------------|
+   | `internal/infrastructure/games/registry_test.go` | the matching `expectedCasino` / `expectedClassic` / `expectedSolo` const (line 16–18). `expectedTotal` is derived — do not touch it. |
+   | `frontend/src/hooks/useTutorialProgress.test.ts` | `totalCount).toBe(N)` (~line 12) |
+   | `frontend/src/components/tutorial/TutorialProgressPanel.test.tsx` | **three** assertions: `getByText(/N/)`, `links.length === N`, `incompleteMarkers.length === N` (~lines 22, 36, 49) |
+
+   The Go `expected<Category>` const must match the **count of `RegisterKVGame` calls in
+   that category's sub-package**, and `TestWorkerRegistrationsCoverAllGames` parses the
+   sources to enforce registry ↔ worker agreement (ADR-0031). A mismatch fails the build.
+
+5. **Registration ordering gotcha.** `TestRegistryMatchesCLI` requires the order of entries
+   in `internal/infrastructure/ui/GameManager.go` `gameRegistry` to match the order in
+   `internal/infrastructure/games/registry.go`. Append the new game **last in both**.
+
+6. **The four backend registration points must all agree on `<name>` and `<category>`:**
+   - `registry.go` → `{Name, Category, Description}`
+   - `games_server.go` → `BindWebControllerFor("<name>", …)`
+   - `internal/infrastructure/games/<category>/<category>.go` → `RegisterKVGame("<name>", games.Category…, …)`
+   - `frontend/src/api/gameApi.ts` `workerUrl` → `"<name>": "<category>"`
+
+7. **Frontend route requires a `profile`.** Every `gameRoutes.ts` entry needs the
+   `profile: GameProfile` field (4 axes; see `discoverAxes.ts` for option order) or tsc
+   rejects the file. Also add `discover.blurb.<page-kebab>` + `discover.stretch_blurb.<page-kebab>`
+   in both `i18n/locales/{ja,en}/discover.json`.
+
+8. **Verify, respecting this box's memory limits.** Per the project's RAM constraints,
+   **never run heavy builds/tests in parallel** — run one at a time and let CI gate the
+   ones that OOM locally (`internal/domain` test pkg, full `golangci-lint`, `bun run build`
+   tsc, E2E, tinygo worker-size). What *does* run locally: targeted `go test` on the new
+   non-domain packages, `goimports -w`, `biome check`, `vitest`, host `go build ./...`,
+   and `make build-worker-<category>` for the size check.
+
+9. **Run the registration checker before committing.** Invoke the
+   `game-registration-checker` subagent (Agent tool, `subagent_type:
+   "game-registration-checker"`) with the new `<name>` and `<category>`. It greps every
+   touchpoint and diffs the count assertions read-only — catching the exact failures above
+   *before* the expensive CI round-trip. Fix anything it flags, then commit.
+
+10. **Docs in the same commit.** README.md, CLAUDE.md (games list), docs/games.md,
+    docs/architecture.md (+ endpoint count), api/openapi.yaml, and both
+    `docs/manual/{cui,web}/<game>.md` (Mermaid flowchart mandatory; Mermaid state-diagram
+    notes must use `=` not `:`). Register the manuals in `manualTexts.ts` (Web) and
+    `cuiManualTexts.ts` (CUI).
+
+## Commit & PR
+
+- Conventional Commits: `feat(<name>): add <Game Title> game`.
+- Never `git add -A` / `git add .` / `git checkout <branch> -- .` — this worktree has
+  local-only files; stage explicit paths only.
+- Fetch/merge latest `develop` before branching and pushing.
+- PR body must include `Closes #<issue#>` when an issue exists.


### PR DESCRIPTION
## Summary

Adds two Claude Code automations targeting the repo's most frequent task — adding a game — and its recurring first-push failures.

- **`.claude/skills/new-game/SKILL.md`** — user-invocable `/new-game <name> <category>` skill that drives the New Game Addition Checklist. Treats `docs/new-game-checklist.md` as the source of truth and layers on the parts that bite most often: count-assertion bump table (exact files/lines), the category-is-a-binary-size-bucket warning (classic worker is full → prefer solo), the `TestRegistryMatchesCLI` ordering gotcha, the four backend registration points that must agree on name+category, and the OOM-aware local-verify policy.
- **`.claude/agents/game-registration-checker.md`** — read-only subagent (Read/Grep/Glob/Bash) that verifies every backend/frontend/worker registration point and count assertion is wired and consistent **before** the expensive, OOM-prone CI round-trip. Computes the Go category-total and compares it against all four frontend count assertions; reports PASS/FAIL with `file:line` evidence and an ordered fix list.

Both are checked into `.claude/` so the team shares the workflow. No application code touched (188 insertions, two new files).

## Test plan

- [x] Skill relative path to `docs/new-game-checklist.md` resolves
- [x] No `.go`/`.ts` files changed — commit-time lint hooks pass through
- [ ] Agent appears in `subagent_type` list after agents reload (new session / `/reload-plugins`)