### PR TITLE
chore(workers): pilot per-category build tags (#2126)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,14 @@ define build_worker
 	# runCpuTurns → Output on staging, so we bump to 128KB. The flag only
 	# reserves linear memory at runtime (binary stays well under the
 	# Cloudflare Workers free-tier 1MB gzipped limit).
-	$(TINYGO) build -o workers/$(1)/build/app.wasm -target wasm -stack-size=128KB -no-debug -opt=z ./cmd/workers/$(1)
+	# -tags $(1): the worker name doubles as a per-category build tag (casino /
+	# classic / solo). Each game's domain/usecase/adapter files carry a
+	# `//go:build !js || !wasm || <category>` constraint, so a worker only
+	# compiles its own category's games. This stops every game's serialisation
+	# from shipping in every worker and keeps each binary under the 1 MB gzip
+	# free-tier limit (see issue #2126). Non-worker builds (server, CLI, tests)
+	# match `!js || !wasm`, so they still include all games.
+	$(TINYGO) build -tags $(1) -o workers/$(1)/build/app.wasm -target wasm -stack-size=128KB -no-debug -opt=z ./cmd/workers/$(1)
 	$(WASM_OPT) --enable-bulk-memory --enable-nontrapping-float-to-int --enable-sign-ext -Oz workers/$(1)/build/app.wasm -o workers/$(1)/build/app.wasm
 	@RAW=$$(stat -c%s workers/$(1)/build/app.wasm); GZIP=$$(gzip -c workers/$(1)/build/app.wasm | wc -c); \
 	echo "  $(1): $$RAW bytes raw, $$GZIP bytes gzip"

--- a/internal/adapter/controller/AccordionCuiController.go
+++ b/internal/adapter/controller/AccordionCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/AccordionWebController.go
+++ b/internal/adapter/controller/AccordionWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/AcesUpCuiController.go
+++ b/internal/adapter/controller/AcesUpCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/AcesUpWebController.go
+++ b/internal/adapter/controller/AcesUpWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/BakersDozenCuiController.go
+++ b/internal/adapter/controller/BakersDozenCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/BakersDozenWebController.go
+++ b/internal/adapter/controller/BakersDozenWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/BarbuCuiController.go
+++ b/internal/adapter/controller/BarbuCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/BarbuWebController.go
+++ b/internal/adapter/controller/BarbuWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/BeleagueredCastleCuiController.go
+++ b/internal/adapter/controller/BeleagueredCastleCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/BeleagueredCastleWebController.go
+++ b/internal/adapter/controller/BeleagueredCastleWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/BurracoCuiController.go
+++ b/internal/adapter/controller/BurracoCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/BurracoWebController.go
+++ b/internal/adapter/controller/BurracoWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/CalculationCuiController.go
+++ b/internal/adapter/controller/CalculationCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/CalculationWebController.go
+++ b/internal/adapter/controller/CalculationWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/CanastaCuiController.go
+++ b/internal/adapter/controller/CanastaCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/CanastaWebController.go
+++ b/internal/adapter/controller/CanastaWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/CanfieldCuiController.go
+++ b/internal/adapter/controller/CanfieldCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/CanfieldWebController.go
+++ b/internal/adapter/controller/CanfieldWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/ClockSolitaireCuiController.go
+++ b/internal/adapter/controller/ClockSolitaireCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/ClockSolitaireWebController.go
+++ b/internal/adapter/controller/ClockSolitaireWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/ContractRummyCuiController.go
+++ b/internal/adapter/controller/ContractRummyCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/ContractRummyWebController.go
+++ b/internal/adapter/controller/ContractRummyWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/CrescentCuiController.go
+++ b/internal/adapter/controller/CrescentCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/CrescentWebController.go
+++ b/internal/adapter/controller/CrescentWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/CribbageCuiController.go
+++ b/internal/adapter/controller/CribbageCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/CribbageWebController.go
+++ b/internal/adapter/controller/CribbageWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/CruelCuiController.go
+++ b/internal/adapter/controller/CruelCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/CruelWebController.go
+++ b/internal/adapter/controller/CruelWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/EightOffCuiController.go
+++ b/internal/adapter/controller/EightOffCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/EightOffWebController.go
+++ b/internal/adapter/controller/EightOffWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/FiveHundredCuiController.go
+++ b/internal/adapter/controller/FiveHundredCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/FiveHundredWebController.go
+++ b/internal/adapter/controller/FiveHundredWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/FortyThievesCuiController.go
+++ b/internal/adapter/controller/FortyThievesCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/FortyThievesWebController.go
+++ b/internal/adapter/controller/FortyThievesWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/FreeCellCuiController.go
+++ b/internal/adapter/controller/FreeCellCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/FreeCellWebController.go
+++ b/internal/adapter/controller/FreeCellWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/GapsCuiController.go
+++ b/internal/adapter/controller/GapsCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/GapsWebController.go
+++ b/internal/adapter/controller/GapsWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/GinRummyCuiController.go
+++ b/internal/adapter/controller/GinRummyCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/GinRummyWebController.go
+++ b/internal/adapter/controller/GinRummyWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/GolfCuiController.go
+++ b/internal/adapter/controller/GolfCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/GolfWebController.go
+++ b/internal/adapter/controller/GolfWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/KlondikeCuiController.go
+++ b/internal/adapter/controller/KlondikeCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/KlondikeWebController.go
+++ b/internal/adapter/controller/KlondikeWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/MacauCuiController.go
+++ b/internal/adapter/controller/MacauCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/MacauWebController.go
+++ b/internal/adapter/controller/MacauWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/MemoryCuiController.go
+++ b/internal/adapter/controller/MemoryCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/MemoryWebController.go
+++ b/internal/adapter/controller/MemoryWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/MonteCarloCuiController.go
+++ b/internal/adapter/controller/MonteCarloCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/MonteCarloWebController.go
+++ b/internal/adapter/controller/MonteCarloWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/OsmosisCuiController.go
+++ b/internal/adapter/controller/OsmosisCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/OsmosisWebController.go
+++ b/internal/adapter/controller/OsmosisWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/PenguinCuiController.go
+++ b/internal/adapter/controller/PenguinCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/PenguinWebController.go
+++ b/internal/adapter/controller/PenguinWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/PokerSquaresCuiController.go
+++ b/internal/adapter/controller/PokerSquaresCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/PokerSquaresWebController.go
+++ b/internal/adapter/controller/PokerSquaresWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/PyramidCuiController.go
+++ b/internal/adapter/controller/PyramidCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/PyramidWebController.go
+++ b/internal/adapter/controller/PyramidWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/Rummy500CuiController.go
+++ b/internal/adapter/controller/Rummy500CuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/Rummy500WebController.go
+++ b/internal/adapter/controller/Rummy500WebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/RussianSolitaireCuiController.go
+++ b/internal/adapter/controller/RussianSolitaireCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/RussianSolitaireWebController.go
+++ b/internal/adapter/controller/RussianSolitaireWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/SchnapsenCuiController.go
+++ b/internal/adapter/controller/SchnapsenCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/SchnapsenWebController.go
+++ b/internal/adapter/controller/SchnapsenWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/ScorpionCuiController.go
+++ b/internal/adapter/controller/ScorpionCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/ScorpionWebController.go
+++ b/internal/adapter/controller/ScorpionWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/SeahavenTowersCuiController.go
+++ b/internal/adapter/controller/SeahavenTowersCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/SeahavenTowersWebController.go
+++ b/internal/adapter/controller/SeahavenTowersWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/SevenBridgeCuiController.go
+++ b/internal/adapter/controller/SevenBridgeCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/SevenBridgeWebController.go
+++ b/internal/adapter/controller/SevenBridgeWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/SpiderCuiController.go
+++ b/internal/adapter/controller/SpiderCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/SpiderWebController.go
+++ b/internal/adapter/controller/SpiderWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/SpideretteCuiController.go
+++ b/internal/adapter/controller/SpideretteCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/SpideretteWebController.go
+++ b/internal/adapter/controller/SpideretteWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/ThirtyOneCuiController.go
+++ b/internal/adapter/controller/ThirtyOneCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/ThirtyOneWebController.go
+++ b/internal/adapter/controller/ThirtyOneWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/TienLenCuiController.go
+++ b/internal/adapter/controller/TienLenCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/TienLenWebController.go
+++ b/internal/adapter/controller/TienLenWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/TriPeaksCuiController.go
+++ b/internal/adapter/controller/TriPeaksCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/TriPeaksWebController.go
+++ b/internal/adapter/controller/TriPeaksWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/WaspCuiController.go
+++ b/internal/adapter/controller/WaspCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/WaspWebController.go
+++ b/internal/adapter/controller/WaspWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/YukonCuiController.go
+++ b/internal/adapter/controller/YukonCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/controller/YukonWebController.go
+++ b/internal/adapter/controller/YukonWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package controller
 
 import (

--- a/internal/adapter/presenter/AccordionCuiPresenter.go
+++ b/internal/adapter/presenter/AccordionCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/AccordionWebPresenter.go
+++ b/internal/adapter/presenter/AccordionWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/AcesUpCuiPresenter.go
+++ b/internal/adapter/presenter/AcesUpCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/AcesUpWebPresenter.go
+++ b/internal/adapter/presenter/AcesUpWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/BakersDozenCuiPresenter.go
+++ b/internal/adapter/presenter/BakersDozenCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/BakersDozenWebPresenter.go
+++ b/internal/adapter/presenter/BakersDozenWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/BarbuCuiPresenter.go
+++ b/internal/adapter/presenter/BarbuCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/BarbuWebPresenter.go
+++ b/internal/adapter/presenter/BarbuWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/BeleagueredCastleCuiPresenter.go
+++ b/internal/adapter/presenter/BeleagueredCastleCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/BeleagueredCastleWebPresenter.go
+++ b/internal/adapter/presenter/BeleagueredCastleWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/BurracoCuiPresenter.go
+++ b/internal/adapter/presenter/BurracoCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/BurracoWebPresenter.go
+++ b/internal/adapter/presenter/BurracoWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/CalculationCuiPresenter.go
+++ b/internal/adapter/presenter/CalculationCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/CalculationWebPresenter.go
+++ b/internal/adapter/presenter/CalculationWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/CanastaCuiPresenter.go
+++ b/internal/adapter/presenter/CanastaCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/CanastaWebPresenter.go
+++ b/internal/adapter/presenter/CanastaWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/CanfieldCuiPresenter.go
+++ b/internal/adapter/presenter/CanfieldCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/CanfieldWebPresenter.go
+++ b/internal/adapter/presenter/CanfieldWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/ClockSolitaireCuiPresenter.go
+++ b/internal/adapter/presenter/ClockSolitaireCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/ClockSolitaireWebPresenter.go
+++ b/internal/adapter/presenter/ClockSolitaireWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/ContractRummyCuiPresenter.go
+++ b/internal/adapter/presenter/ContractRummyCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/ContractRummyWebPresenter.go
+++ b/internal/adapter/presenter/ContractRummyWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/CrescentCuiPresenter.go
+++ b/internal/adapter/presenter/CrescentCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/CrescentWebPresenter.go
+++ b/internal/adapter/presenter/CrescentWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/CribbageCuiPresenter.go
+++ b/internal/adapter/presenter/CribbageCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/CribbageWebPresenter.go
+++ b/internal/adapter/presenter/CribbageWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/CruelCuiPresenter.go
+++ b/internal/adapter/presenter/CruelCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/CruelWebPresenter.go
+++ b/internal/adapter/presenter/CruelWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/EightOffCuiPresenter.go
+++ b/internal/adapter/presenter/EightOffCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/EightOffWebPresenter.go
+++ b/internal/adapter/presenter/EightOffWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/FiveHundredCuiPresenter.go
+++ b/internal/adapter/presenter/FiveHundredCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/FiveHundredWebPresenter.go
+++ b/internal/adapter/presenter/FiveHundredWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/FortyThievesCuiPresenter.go
+++ b/internal/adapter/presenter/FortyThievesCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/FortyThievesWebPresenter.go
+++ b/internal/adapter/presenter/FortyThievesWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/FreeCellCuiPresenter.go
+++ b/internal/adapter/presenter/FreeCellCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/FreeCellWebPresenter.go
+++ b/internal/adapter/presenter/FreeCellWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/GapsCuiPresenter.go
+++ b/internal/adapter/presenter/GapsCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/GapsWebPresenter.go
+++ b/internal/adapter/presenter/GapsWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/GinRummyCuiPresenter.go
+++ b/internal/adapter/presenter/GinRummyCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/GinRummyWebPresenter.go
+++ b/internal/adapter/presenter/GinRummyWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/GolfCuiPresenter.go
+++ b/internal/adapter/presenter/GolfCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/GolfWebPresenter.go
+++ b/internal/adapter/presenter/GolfWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/KlondikeCuiPresenter.go
+++ b/internal/adapter/presenter/KlondikeCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/KlondikeWebPresenter.go
+++ b/internal/adapter/presenter/KlondikeWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/MacauCuiPresenter.go
+++ b/internal/adapter/presenter/MacauCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/MacauWebPresenter.go
+++ b/internal/adapter/presenter/MacauWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/MemoryCuiPresenter.go
+++ b/internal/adapter/presenter/MemoryCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/MemoryWebPresenter.go
+++ b/internal/adapter/presenter/MemoryWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/MonteCarloCuiPresenter.go
+++ b/internal/adapter/presenter/MonteCarloCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/MonteCarloWebPresenter.go
+++ b/internal/adapter/presenter/MonteCarloWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/OsmosisCuiPresenter.go
+++ b/internal/adapter/presenter/OsmosisCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/OsmosisWebPresenter.go
+++ b/internal/adapter/presenter/OsmosisWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/PenguinCuiPresenter.go
+++ b/internal/adapter/presenter/PenguinCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/PenguinWebPresenter.go
+++ b/internal/adapter/presenter/PenguinWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/PokerSquaresCuiPresenter.go
+++ b/internal/adapter/presenter/PokerSquaresCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/PokerSquaresWebPresenter.go
+++ b/internal/adapter/presenter/PokerSquaresWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/PyramidCuiPresenter.go
+++ b/internal/adapter/presenter/PyramidCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/PyramidWebPresenter.go
+++ b/internal/adapter/presenter/PyramidWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/Rummy500CuiPresenter.go
+++ b/internal/adapter/presenter/Rummy500CuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/Rummy500WebPresenter.go
+++ b/internal/adapter/presenter/Rummy500WebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/RussianSolitaireCuiPresenter.go
+++ b/internal/adapter/presenter/RussianSolitaireCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/RussianSolitaireWebPresenter.go
+++ b/internal/adapter/presenter/RussianSolitaireWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/SchnapsenCuiPresenter.go
+++ b/internal/adapter/presenter/SchnapsenCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/SchnapsenWebPresenter.go
+++ b/internal/adapter/presenter/SchnapsenWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/ScorpionCuiPresenter.go
+++ b/internal/adapter/presenter/ScorpionCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/ScorpionWebPresenter.go
+++ b/internal/adapter/presenter/ScorpionWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/SeahavenTowersCuiPresenter.go
+++ b/internal/adapter/presenter/SeahavenTowersCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/SeahavenTowersWebPresenter.go
+++ b/internal/adapter/presenter/SeahavenTowersWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/SevenBridgeCuiPresenter.go
+++ b/internal/adapter/presenter/SevenBridgeCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/SevenBridgeWebPresenter.go
+++ b/internal/adapter/presenter/SevenBridgeWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/SpiderCuiPresenter.go
+++ b/internal/adapter/presenter/SpiderCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/SpiderWebPresenter.go
+++ b/internal/adapter/presenter/SpiderWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/SpideretteCuiPresenter.go
+++ b/internal/adapter/presenter/SpideretteCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/SpideretteWebPresenter.go
+++ b/internal/adapter/presenter/SpideretteWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/ThirtyOneCuiPresenter.go
+++ b/internal/adapter/presenter/ThirtyOneCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/ThirtyOneWebPresenter.go
+++ b/internal/adapter/presenter/ThirtyOneWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/TienLenCuiPresenter.go
+++ b/internal/adapter/presenter/TienLenCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/TienLenWebPresenter.go
+++ b/internal/adapter/presenter/TienLenWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/TriPeaksCuiPresenter.go
+++ b/internal/adapter/presenter/TriPeaksCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/TriPeaksWebPresenter.go
+++ b/internal/adapter/presenter/TriPeaksWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/WaspCuiPresenter.go
+++ b/internal/adapter/presenter/WaspCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/WaspWebPresenter.go
+++ b/internal/adapter/presenter/WaspWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/YukonCuiPresenter.go
+++ b/internal/adapter/presenter/YukonCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/YukonWebPresenter.go
+++ b/internal/adapter/presenter/YukonWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/solitaire_output_helper.go
+++ b/internal/adapter/presenter/solitaire_output_helper.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"

--- a/internal/domain/Accordion.go
+++ b/internal/domain/Accordion.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/AcesUp.go
+++ b/internal/domain/AcesUp.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/BakersDozen.go
+++ b/internal/domain/BakersDozen.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/Barbu.go
+++ b/internal/domain/Barbu.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 // Package domain バルブ (Barbu) のドメインモデル。
 //
 // Barbu はフランス発祥のコンペンディウム (オムニバス) 型トリックテイキング

--- a/internal/domain/BarbuCPU.go
+++ b/internal/domain/BarbuCPU.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 // BarbuCPU.go は CPU の意思決定 (コントラクト選択 / トリックプレイ / 7 並べ) を担う。

--- a/internal/domain/BarbuConfig.go
+++ b/internal/domain/BarbuConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/BarbuContracts.go
+++ b/internal/domain/BarbuContracts.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 // BarbuContracts.go はコントラクトごとの得点計算 (Strategy パターン) を担う。

--- a/internal/domain/BarbuDominoes.go
+++ b/internal/domain/BarbuDominoes.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "fmt"

--- a/internal/domain/BarbuPlayer.go
+++ b/internal/domain/BarbuPlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/BeleagueredCastle.go
+++ b/internal/domain/BeleagueredCastle.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/Burraco.go
+++ b/internal/domain/Burraco.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 // Burraco (ブラーコ) is implemented as a configured Canasta: the Pozzetto

--- a/internal/domain/Calculation.go
+++ b/internal/domain/Calculation.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/Canasta.go
+++ b/internal/domain/Canasta.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/CanastaConfig.go
+++ b/internal/domain/CanastaConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 // CanastaCpuDifficulty CPU の難易度レベル

--- a/internal/domain/CanastaPlayer.go
+++ b/internal/domain/CanastaPlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/Canfield.go
+++ b/internal/domain/Canfield.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/ClockSolitaire.go
+++ b/internal/domain/ClockSolitaire.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/ContractRummy.go
+++ b/internal/domain/ContractRummy.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/ContractRummyConfig.go
+++ b/internal/domain/ContractRummyConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 // ContractRummyCpuDifficulty CPU の難易度レベル

--- a/internal/domain/ContractRummyPlayer.go
+++ b/internal/domain/ContractRummyPlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/Crescent.go
+++ b/internal/domain/Crescent.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/Cribbage.go
+++ b/internal/domain/Cribbage.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/CribbageConfig.go
+++ b/internal/domain/CribbageConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/CribbagePlayer.go
+++ b/internal/domain/CribbagePlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/Cruel.go
+++ b/internal/domain/Cruel.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/EightOff.go
+++ b/internal/domain/EightOff.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/FiveHundred.go
+++ b/internal/domain/FiveHundred.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/FiveHundredConfig.go
+++ b/internal/domain/FiveHundredConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 // FiveHundredCpuDifficulty CPU の難易度レベル

--- a/internal/domain/FiveHundredPlayer.go
+++ b/internal/domain/FiveHundredPlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/FortyThieves.go
+++ b/internal/domain/FortyThieves.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/FreeCell.go
+++ b/internal/domain/FreeCell.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/Gaps.go
+++ b/internal/domain/Gaps.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/GinRummy.go
+++ b/internal/domain/GinRummy.go
@@ -1,5 +1,3 @@
-//go:build !js || !wasm || solo
-
 package domain
 
 import (

--- a/internal/domain/GinRummy.go
+++ b/internal/domain/GinRummy.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/GinRummyConfig.go
+++ b/internal/domain/GinRummyConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 // GinRummyCpuDifficulty CPU の難易度レベル

--- a/internal/domain/GinRummyConfig.go
+++ b/internal/domain/GinRummyConfig.go
@@ -1,5 +1,3 @@
-//go:build !js || !wasm || solo
-
 package domain
 
 // GinRummyCpuDifficulty CPU の難易度レベル

--- a/internal/domain/GinRummyPlayer.go
+++ b/internal/domain/GinRummyPlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/GinRummyPlayer.go
+++ b/internal/domain/GinRummyPlayer.go
@@ -1,5 +1,3 @@
-//go:build !js || !wasm || solo
-
 package domain
 
 import "encoding/json"

--- a/internal/domain/Golf.go
+++ b/internal/domain/Golf.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/Klondike.go
+++ b/internal/domain/Klondike.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/Macau.go
+++ b/internal/domain/Macau.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/MacauConfig.go
+++ b/internal/domain/MacauConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 // MacauCpuDifficulty CPU の難易度レベル

--- a/internal/domain/MacauPlayer.go
+++ b/internal/domain/MacauPlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/Memory.go
+++ b/internal/domain/Memory.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/MemoryConfig.go
+++ b/internal/domain/MemoryConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 // MemoryCpuDifficulty CPU の難易度レベル

--- a/internal/domain/MemoryPlayer.go
+++ b/internal/domain/MemoryPlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/MonteCarlo.go
+++ b/internal/domain/MonteCarlo.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 // Package domain provides core game domain models.
 package domain
 

--- a/internal/domain/Osmosis.go
+++ b/internal/domain/Osmosis.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/Penguin.go
+++ b/internal/domain/Penguin.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/PokerSquares.go
+++ b/internal/domain/PokerSquares.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 // Package domain provides core game domain models.
 package domain
 

--- a/internal/domain/Pyramid.go
+++ b/internal/domain/Pyramid.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/Rummy500.go
+++ b/internal/domain/Rummy500.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/Rummy500Config.go
+++ b/internal/domain/Rummy500Config.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 // Rummy500CpuDifficulty CPUの難易度レベル

--- a/internal/domain/Rummy500Player.go
+++ b/internal/domain/Rummy500Player.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/RussianSolitaire.go
+++ b/internal/domain/RussianSolitaire.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/Schnapsen.go
+++ b/internal/domain/Schnapsen.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 // Package domain シュナプセン / Sixty-Six (Schnapsen / 66) のドメインモデル。
 //
 // Schnapsen はドイツ・オーストリアで人気の 2 人用トリックテイキングゲーム。

--- a/internal/domain/SchnapsenConfig.go
+++ b/internal/domain/SchnapsenConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 // SchnapsenCpuDifficulty CPU の難易度レベル

--- a/internal/domain/SchnapsenPlayer.go
+++ b/internal/domain/SchnapsenPlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/Scorpion.go
+++ b/internal/domain/Scorpion.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/SeahavenTowers.go
+++ b/internal/domain/SeahavenTowers.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/SevenBridge.go
+++ b/internal/domain/SevenBridge.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/SevenBridgeConfig.go
+++ b/internal/domain/SevenBridgeConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 // SevenBridgeCpuDifficulty CPU の難易度レベル

--- a/internal/domain/SevenBridgePlayer.go
+++ b/internal/domain/SevenBridgePlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/Spider.go
+++ b/internal/domain/Spider.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/SpiderConfig.go
+++ b/internal/domain/SpiderConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 // SpiderDifficulty スパイダーソリティア難易度

--- a/internal/domain/Spiderette.go
+++ b/internal/domain/Spiderette.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/ThirtyOne.go
+++ b/internal/domain/ThirtyOne.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/ThirtyOneConfig.go
+++ b/internal/domain/ThirtyOneConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 // ThirtyOneCpuDifficulty CPU の難易度レベル

--- a/internal/domain/ThirtyOnePlayer.go
+++ b/internal/domain/ThirtyOnePlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/TienLen.go
+++ b/internal/domain/TienLen.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/TienLenCPU.go
+++ b/internal/domain/TienLenCPU.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "sort"

--- a/internal/domain/TienLenConfig.go
+++ b/internal/domain/TienLenConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/TienLenEval.go
+++ b/internal/domain/TienLenEval.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "sort"

--- a/internal/domain/TienLenPlayer.go
+++ b/internal/domain/TienLenPlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/TriPeaks.go
+++ b/internal/domain/TriPeaks.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/Wasp.go
+++ b/internal/domain/Wasp.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/Yukon.go
+++ b/internal/domain/Yukon.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import (

--- a/internal/domain/card_color.go
+++ b/internal/domain/card_color.go
@@ -1,0 +1,17 @@
+package domain
+
+// card_color.go holds card-colour helpers shared across categories. They live
+// in an untagged (core) file — not in a per-category game file — so the
+// per-worker build-tag split (#2126) keeps them available in every Cloudflare
+// Worker. For example Nertz (classic worker) reuses isAlternateColor, which
+// originally lived in freecell_solver.go (solo).
+
+// isBlack reports whether a card belongs to a black suit (spade or club).
+func isBlack(card *Card) bool {
+	return card.GetDesign() == CardDesignSpade || card.GetDesign() == CardDesignClover
+}
+
+// isAlternateColor reports whether two cards are of opposite colours.
+func isAlternateColor(card1, card2 *Card) bool {
+	return isBlack(card1) != isBlack(card2)
+}

--- a/internal/domain/eightoff_solver.go
+++ b/internal/domain/eightoff_solver.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "container/heap"

--- a/internal/domain/freecell_solver.go
+++ b/internal/domain/freecell_solver.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "container/heap"

--- a/internal/domain/freecell_solver.go
+++ b/internal/domain/freecell_solver.go
@@ -275,14 +275,6 @@ func canPlaceOnFoundation(card *Card, fIdx int, foundation [FreeCellFoundationCn
 	return card.GetValue() == count+1
 }
 
-func isAlternateColor(card1, card2 *Card) bool {
-	return isBlack(card1) != isBlack(card2)
-}
-
-func isBlack(card *Card) bool {
-	return card.GetDesign() == CardDesignSpade || card.GetDesign() == CardDesignClover
-}
-
 // stateKey returns the state key for the solver's initial state (used in tests).
 func (s *freeCellSolver) stateKey() [52]uint16 {
 	return stateKeyFromState(s.initialState)

--- a/internal/domain/interfaces/accordion.go
+++ b/internal/domain/interfaces/accordion.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/acesup.go
+++ b/internal/domain/interfaces/acesup.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/bakersdozen.go
+++ b/internal/domain/interfaces/bakersdozen.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/barbu.go
+++ b/internal/domain/interfaces/barbu.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/beleagueredcastle.go
+++ b/internal/domain/interfaces/beleagueredcastle.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/burraco.go
+++ b/internal/domain/interfaces/burraco.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 // BurracoGame はブラーコゲームのインタフェース。Burraco は「ポゼットを有効化した

--- a/internal/domain/interfaces/calculation.go
+++ b/internal/domain/interfaces/calculation.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/canasta.go
+++ b/internal/domain/interfaces/canasta.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/canfield.go
+++ b/internal/domain/interfaces/canfield.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/clocksolitaire.go
+++ b/internal/domain/interfaces/clocksolitaire.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/contractrummy.go
+++ b/internal/domain/interfaces/contractrummy.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/crescent.go
+++ b/internal/domain/interfaces/crescent.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/cribbage.go
+++ b/internal/domain/interfaces/cribbage.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/cruel.go
+++ b/internal/domain/interfaces/cruel.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/eightoff.go
+++ b/internal/domain/interfaces/eightoff.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/fivehundred.go
+++ b/internal/domain/interfaces/fivehundred.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/fortythieves.go
+++ b/internal/domain/interfaces/fortythieves.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/freecell.go
+++ b/internal/domain/interfaces/freecell.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/gaps.go
+++ b/internal/domain/interfaces/gaps.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/ginrummy.go
+++ b/internal/domain/interfaces/ginrummy.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/golf.go
+++ b/internal/domain/interfaces/golf.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/klondike.go
+++ b/internal/domain/interfaces/klondike.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/macau.go
+++ b/internal/domain/interfaces/macau.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/memory.go
+++ b/internal/domain/interfaces/memory.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/monte_carlo.go
+++ b/internal/domain/interfaces/monte_carlo.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/osmosis.go
+++ b/internal/domain/interfaces/osmosis.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/penguin.go
+++ b/internal/domain/interfaces/penguin.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/poker_squares.go
+++ b/internal/domain/interfaces/poker_squares.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/pyramid.go
+++ b/internal/domain/interfaces/pyramid.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/rummy500.go
+++ b/internal/domain/interfaces/rummy500.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/russiansolitaire.go
+++ b/internal/domain/interfaces/russiansolitaire.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/schnapsen.go
+++ b/internal/domain/interfaces/schnapsen.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/scorpion.go
+++ b/internal/domain/interfaces/scorpion.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/seahaventowers.go
+++ b/internal/domain/interfaces/seahaventowers.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/sevenbridge.go
+++ b/internal/domain/interfaces/sevenbridge.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/spider.go
+++ b/internal/domain/interfaces/spider.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/spiderette.go
+++ b/internal/domain/interfaces/spiderette.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/thirtyone.go
+++ b/internal/domain/interfaces/thirtyone.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/tienlen.go
+++ b/internal/domain/interfaces/tienlen.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/tripeaks.go
+++ b/internal/domain/interfaces/tripeaks.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/wasp.go
+++ b/internal/domain/interfaces/wasp.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/yukon.go
+++ b/internal/domain/interfaces/yukon.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/klondike_solver.go
+++ b/internal/domain/klondike_solver.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 // checkKlondikeStalemate checks for immediate deadlock in Klondike.

--- a/internal/domain/penguin_solver.go
+++ b/internal/domain/penguin_solver.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "container/heap"

--- a/internal/domain/seahaventowers_solver.go
+++ b/internal/domain/seahaventowers_solver.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package domain
 
 import "container/heap"

--- a/internal/usecase/AccordionInteractor.go
+++ b/internal/usecase/AccordionInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/AcesUpInteractor.go
+++ b/internal/usecase/AcesUpInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/BakersDozenInteractor.go
+++ b/internal/usecase/BakersDozenInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/BarbuInteractor.go
+++ b/internal/usecase/BarbuInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/BeleagueredCastleInteractor.go
+++ b/internal/usecase/BeleagueredCastleInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/BurracoInteractor.go
+++ b/internal/usecase/BurracoInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/CalculationInteractor.go
+++ b/internal/usecase/CalculationInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/CanastaInteractor.go
+++ b/internal/usecase/CanastaInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/CanfieldInteractor.go
+++ b/internal/usecase/CanfieldInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/ClockSolitaireInteractor.go
+++ b/internal/usecase/ClockSolitaireInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/ContractRummyInteractor.go
+++ b/internal/usecase/ContractRummyInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/CrescentInteractor.go
+++ b/internal/usecase/CrescentInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/CribbageInteractor.go
+++ b/internal/usecase/CribbageInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/CruelInteractor.go
+++ b/internal/usecase/CruelInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/EightOffInteractor.go
+++ b/internal/usecase/EightOffInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/FiveHundredInteractor.go
+++ b/internal/usecase/FiveHundredInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/FortyThievesInteractor.go
+++ b/internal/usecase/FortyThievesInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/FreeCellInteractor.go
+++ b/internal/usecase/FreeCellInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/GapsInteractor.go
+++ b/internal/usecase/GapsInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/GinRummyInteractor.go
+++ b/internal/usecase/GinRummyInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/GolfInteractor.go
+++ b/internal/usecase/GolfInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/KlondikeInteractor.go
+++ b/internal/usecase/KlondikeInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/MacauInteractor.go
+++ b/internal/usecase/MacauInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/MemoryInteractor.go
+++ b/internal/usecase/MemoryInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/MonteCarloInteractor.go
+++ b/internal/usecase/MonteCarloInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/OsmosisInteractor.go
+++ b/internal/usecase/OsmosisInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/PenguinInteractor.go
+++ b/internal/usecase/PenguinInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/PokerSquaresInteractor.go
+++ b/internal/usecase/PokerSquaresInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/PyramidInteractor.go
+++ b/internal/usecase/PyramidInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/Rummy500Interactor.go
+++ b/internal/usecase/Rummy500Interactor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/RussianSolitaireInteractor.go
+++ b/internal/usecase/RussianSolitaireInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/SchnapsenInteractor.go
+++ b/internal/usecase/SchnapsenInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/ScorpionInteractor.go
+++ b/internal/usecase/ScorpionInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/SeahavenTowersInteractor.go
+++ b/internal/usecase/SeahavenTowersInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/SevenBridgeInteractor.go
+++ b/internal/usecase/SevenBridgeInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/SpiderInteractor.go
+++ b/internal/usecase/SpiderInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/SpideretteInteractor.go
+++ b/internal/usecase/SpideretteInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/ThirtyOneInteractor.go
+++ b/internal/usecase/ThirtyOneInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/TienLenInteractor.go
+++ b/internal/usecase/TienLenInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/TriPeaksInteractor.go
+++ b/internal/usecase/TriPeaksInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/WaspInteractor.go
+++ b/internal/usecase/WaspInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/YukonInteractor.go
+++ b/internal/usecase/YukonInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package usecase
 
 import (

--- a/internal/usecase/presenter/AccordionPresenter.go
+++ b/internal/usecase/presenter/AccordionPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/AcesUpPresenter.go
+++ b/internal/usecase/presenter/AcesUpPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/BakersDozenPresenter.go
+++ b/internal/usecase/presenter/BakersDozenPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/BarbuPresenter.go
+++ b/internal/usecase/presenter/BarbuPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/BeleagueredCastlePresenter.go
+++ b/internal/usecase/presenter/BeleagueredCastlePresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/BurracoPresenter.go
+++ b/internal/usecase/presenter/BurracoPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/CalculationPresenter.go
+++ b/internal/usecase/presenter/CalculationPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/CanastaPresenter.go
+++ b/internal/usecase/presenter/CanastaPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/CanfieldPresenter.go
+++ b/internal/usecase/presenter/CanfieldPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/ClockSolitairePresenter.go
+++ b/internal/usecase/presenter/ClockSolitairePresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/ContractRummyPresenter.go
+++ b/internal/usecase/presenter/ContractRummyPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/CrescentPresenter.go
+++ b/internal/usecase/presenter/CrescentPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/CribbagePresenter.go
+++ b/internal/usecase/presenter/CribbagePresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/CruelPresenter.go
+++ b/internal/usecase/presenter/CruelPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/EightOffPresenter.go
+++ b/internal/usecase/presenter/EightOffPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/FiveHundredPresenter.go
+++ b/internal/usecase/presenter/FiveHundredPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/FortyThievesPresenter.go
+++ b/internal/usecase/presenter/FortyThievesPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/FreeCellPresenter.go
+++ b/internal/usecase/presenter/FreeCellPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/GapsPresenter.go
+++ b/internal/usecase/presenter/GapsPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/GinRummyPresenter.go
+++ b/internal/usecase/presenter/GinRummyPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/GolfPresenter.go
+++ b/internal/usecase/presenter/GolfPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/KlondikePresenter.go
+++ b/internal/usecase/presenter/KlondikePresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/MacauPresenter.go
+++ b/internal/usecase/presenter/MacauPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/MemoryPresenter.go
+++ b/internal/usecase/presenter/MemoryPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/MonteCarloPresenter.go
+++ b/internal/usecase/presenter/MonteCarloPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/OsmosisPresenter.go
+++ b/internal/usecase/presenter/OsmosisPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/PenguinPresenter.go
+++ b/internal/usecase/presenter/PenguinPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/PokerSquaresPresenter.go
+++ b/internal/usecase/presenter/PokerSquaresPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/PyramidPresenter.go
+++ b/internal/usecase/presenter/PyramidPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/Rummy500Presenter.go
+++ b/internal/usecase/presenter/Rummy500Presenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/RussianSolitairePresenter.go
+++ b/internal/usecase/presenter/RussianSolitairePresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/SchnapsenPresenter.go
+++ b/internal/usecase/presenter/SchnapsenPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/ScorpionPresenter.go
+++ b/internal/usecase/presenter/ScorpionPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/SeahavenTowersPresenter.go
+++ b/internal/usecase/presenter/SeahavenTowersPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/SevenBridgePresenter.go
+++ b/internal/usecase/presenter/SevenBridgePresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/SpiderPresenter.go
+++ b/internal/usecase/presenter/SpiderPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/SpiderettePresenter.go
+++ b/internal/usecase/presenter/SpiderettePresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/ThirtyOnePresenter.go
+++ b/internal/usecase/presenter/ThirtyOnePresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/TienLenPresenter.go
+++ b/internal/usecase/presenter/TienLenPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/TriPeaksPresenter.go
+++ b/internal/usecase/presenter/TriPeaksPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/WaspPresenter.go
+++ b/internal/usecase/presenter/WaspPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/YukonPresenter.go
+++ b/internal/usecase/presenter/YukonPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || solo
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"


### PR DESCRIPTION
Pilot for #2126 — prove the per-category build-tag split shrinks the classic worker.

- Makefile: TinyGo build now passes `-tags <category>` (the worker name).
- Three **zero-coupling** solo games (Pyramid, TriPeaks, Wasp — nothing references them) carry `//go:build !js || !wasm || solo`, so they compile only in the solo worker + non-worker builds and drop out of classic & casino.

**What to read off CI:** classic gzip should fall ~3 KB/game (~9 KB) below its current ~1,050,200 B; solo/casino/server/test builds unchanged. If validated, extend to the whole solo (then casino) category for the real fix.

Refs #2126