### PR TITLE
chore(workers): split casino category (#2126)

### DIFF
--- a/internal/adapter/controller/BaccaratCuiController.go
+++ b/internal/adapter/controller/BaccaratCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/BaccaratWebController.go
+++ b/internal/adapter/controller/BaccaratWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/BadugiCuiController.go
+++ b/internal/adapter/controller/BadugiCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/BadugiWebController.go
+++ b/internal/adapter/controller/BadugiWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/BlackJackCuiController.go
+++ b/internal/adapter/controller/BlackJackCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/BlackJackSwitchCuiController.go
+++ b/internal/adapter/controller/BlackJackSwitchCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/BlackJackSwitchWebController.go
+++ b/internal/adapter/controller/BlackJackSwitchWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/BlackJackWebController.go
+++ b/internal/adapter/controller/BlackJackWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/CaribbeanStudCuiController.go
+++ b/internal/adapter/controller/CaribbeanStudCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/CaribbeanStudWebController.go
+++ b/internal/adapter/controller/CaribbeanStudWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/CasinoHoldemCuiController.go
+++ b/internal/adapter/controller/CasinoHoldemCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/CasinoHoldemWebController.go
+++ b/internal/adapter/controller/CasinoHoldemWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/CasinoWarCuiController.go
+++ b/internal/adapter/controller/CasinoWarCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/CasinoWarWebController.go
+++ b/internal/adapter/controller/CasinoWarWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/ChinesePokerCuiController.go
+++ b/internal/adapter/controller/ChinesePokerCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/ChinesePokerWebController.go
+++ b/internal/adapter/controller/ChinesePokerWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/DeuceToSevenCuiController.go
+++ b/internal/adapter/controller/DeuceToSevenCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/DeuceToSevenWebController.go
+++ b/internal/adapter/controller/DeuceToSevenWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/DragonTigerCuiController.go
+++ b/internal/adapter/controller/DragonTigerCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/DragonTigerWebController.go
+++ b/internal/adapter/controller/DragonTigerWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/FourCardPokerCuiController.go
+++ b/internal/adapter/controller/FourCardPokerCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/FourCardPokerWebController.go
+++ b/internal/adapter/controller/FourCardPokerWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/HighCardFlushCuiController.go
+++ b/internal/adapter/controller/HighCardFlushCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/HighCardFlushWebController.go
+++ b/internal/adapter/controller/HighCardFlushWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/HoldemCuiController.go
+++ b/internal/adapter/controller/HoldemCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/HoldemWebController.go
+++ b/internal/adapter/controller/HoldemWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/IndianPokerCuiController.go
+++ b/internal/adapter/controller/IndianPokerCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/IndianPokerWebController.go
+++ b/internal/adapter/controller/IndianPokerWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/LetItRideCuiController.go
+++ b/internal/adapter/controller/LetItRideCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/LetItRideWebController.go
+++ b/internal/adapter/controller/LetItRideWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/MississippiStudCuiController.go
+++ b/internal/adapter/controller/MississippiStudCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/MississippiStudWebController.go
+++ b/internal/adapter/controller/MississippiStudWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/OasisPokerCuiController.go
+++ b/internal/adapter/controller/OasisPokerCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/OasisPokerWebController.go
+++ b/internal/adapter/controller/OasisPokerWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/OmahaCuiController.go
+++ b/internal/adapter/controller/OmahaCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/OmahaWebController.go
+++ b/internal/adapter/controller/OmahaWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/PaiGowCuiController.go
+++ b/internal/adapter/controller/PaiGowCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/PaiGowWebController.go
+++ b/internal/adapter/controller/PaiGowWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/PineappleCuiController.go
+++ b/internal/adapter/controller/PineappleCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/PineappleWebController.go
+++ b/internal/adapter/controller/PineappleWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/PokerCuiController.go
+++ b/internal/adapter/controller/PokerCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/PokerWebController.go
+++ b/internal/adapter/controller/PokerWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/RedDogCuiController.go
+++ b/internal/adapter/controller/RedDogCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/RedDogWebController.go
+++ b/internal/adapter/controller/RedDogWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/RussianPokerCuiController.go
+++ b/internal/adapter/controller/RussianPokerCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/RussianPokerWebController.go
+++ b/internal/adapter/controller/RussianPokerWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/ScopaCuiController.go
+++ b/internal/adapter/controller/ScopaCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/ScopaWebController.go
+++ b/internal/adapter/controller/ScopaWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/SevenCardStudCuiController.go
+++ b/internal/adapter/controller/SevenCardStudCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/SevenCardStudWebController.go
+++ b/internal/adapter/controller/SevenCardStudWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/ShortDeckCuiController.go
+++ b/internal/adapter/controller/ShortDeckCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/ShortDeckWebController.go
+++ b/internal/adapter/controller/ShortDeckWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/TexasHoldemBonusCuiController.go
+++ b/internal/adapter/controller/TexasHoldemBonusCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/TexasHoldemBonusWebController.go
+++ b/internal/adapter/controller/TexasHoldemBonusWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/ThreeCardCuiController.go
+++ b/internal/adapter/controller/ThreeCardCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/ThreeCardWebController.go
+++ b/internal/adapter/controller/ThreeCardWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/UltimateTexasHoldemCuiController.go
+++ b/internal/adapter/controller/UltimateTexasHoldemCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/UltimateTexasHoldemWebController.go
+++ b/internal/adapter/controller/UltimateTexasHoldemWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/VideoPokerCuiController.go
+++ b/internal/adapter/controller/VideoPokerCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/VideoPokerWebController.go
+++ b/internal/adapter/controller/VideoPokerWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/config_helpers.go
+++ b/internal/adapter/controller/config_helpers.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/poker_dispatch.go
+++ b/internal/adapter/controller/poker_dispatch.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/poker_input_mixins.go
+++ b/internal/adapter/controller/poker_input_mixins.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 // PokerCommonInput holds the tournament/limit/rebuy/addon/tableSize fields

--- a/internal/adapter/presenter/BaccaratCuiPresenter.go
+++ b/internal/adapter/presenter/BaccaratCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/BaccaratWebPresenter.go
+++ b/internal/adapter/presenter/BaccaratWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/BadugiCuiPresenter.go
+++ b/internal/adapter/presenter/BadugiCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/BadugiWebPresenter.go
+++ b/internal/adapter/presenter/BadugiWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/BlackJackCuiPresenter.go
+++ b/internal/adapter/presenter/BlackJackCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/BlackJackSwitchCuiPresenter.go
+++ b/internal/adapter/presenter/BlackJackSwitchCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/BlackJackSwitchWebPresenter.go
+++ b/internal/adapter/presenter/BlackJackSwitchWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/BlackJackWebPresenter.go
+++ b/internal/adapter/presenter/BlackJackWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/CaribbeanStudCuiPresenter.go
+++ b/internal/adapter/presenter/CaribbeanStudCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/CaribbeanStudWebPresenter.go
+++ b/internal/adapter/presenter/CaribbeanStudWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/CasinoHoldemCuiPresenter.go
+++ b/internal/adapter/presenter/CasinoHoldemCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/CasinoHoldemWebPresenter.go
+++ b/internal/adapter/presenter/CasinoHoldemWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/CasinoWarCuiPresenter.go
+++ b/internal/adapter/presenter/CasinoWarCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/CasinoWarWebPresenter.go
+++ b/internal/adapter/presenter/CasinoWarWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/ChinesePokerCuiPresenter.go
+++ b/internal/adapter/presenter/ChinesePokerCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/ChinesePokerWebPresenter.go
+++ b/internal/adapter/presenter/ChinesePokerWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/DeuceToSevenCuiPresenter.go
+++ b/internal/adapter/presenter/DeuceToSevenCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/DeuceToSevenWebPresenter.go
+++ b/internal/adapter/presenter/DeuceToSevenWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/DragonTigerCuiPresenter.go
+++ b/internal/adapter/presenter/DragonTigerCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/DragonTigerWebPresenter.go
+++ b/internal/adapter/presenter/DragonTigerWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/FourCardPokerCuiPresenter.go
+++ b/internal/adapter/presenter/FourCardPokerCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/FourCardPokerWebPresenter.go
+++ b/internal/adapter/presenter/FourCardPokerWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/HighCardFlushCuiPresenter.go
+++ b/internal/adapter/presenter/HighCardFlushCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/HighCardFlushWebPresenter.go
+++ b/internal/adapter/presenter/HighCardFlushWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/HoldemCuiPresenter.go
+++ b/internal/adapter/presenter/HoldemCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/HoldemWebPresenter.go
+++ b/internal/adapter/presenter/HoldemWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/IndianPokerCuiPresenter.go
+++ b/internal/adapter/presenter/IndianPokerCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/IndianPokerWebPresenter.go
+++ b/internal/adapter/presenter/IndianPokerWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/LetItRideCuiPresenter.go
+++ b/internal/adapter/presenter/LetItRideCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/LetItRideWebPresenter.go
+++ b/internal/adapter/presenter/LetItRideWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/MississippiStudCuiPresenter.go
+++ b/internal/adapter/presenter/MississippiStudCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/MississippiStudWebPresenter.go
+++ b/internal/adapter/presenter/MississippiStudWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/OasisPokerCuiPresenter.go
+++ b/internal/adapter/presenter/OasisPokerCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/OasisPokerWebPresenter.go
+++ b/internal/adapter/presenter/OasisPokerWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/OmahaCuiPresenter.go
+++ b/internal/adapter/presenter/OmahaCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/OmahaWebPresenter.go
+++ b/internal/adapter/presenter/OmahaWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/PaiGowCuiPresenter.go
+++ b/internal/adapter/presenter/PaiGowCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/PaiGowWebPresenter.go
+++ b/internal/adapter/presenter/PaiGowWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/PineappleCuiPresenter.go
+++ b/internal/adapter/presenter/PineappleCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/PineappleWebPresenter.go
+++ b/internal/adapter/presenter/PineappleWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/PokerCuiPresenter.go
+++ b/internal/adapter/presenter/PokerCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/PokerWebPresenter.go
+++ b/internal/adapter/presenter/PokerWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/RedDogCuiPresenter.go
+++ b/internal/adapter/presenter/RedDogCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/RedDogWebPresenter.go
+++ b/internal/adapter/presenter/RedDogWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/RussianPokerCuiPresenter.go
+++ b/internal/adapter/presenter/RussianPokerCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/RussianPokerWebPresenter.go
+++ b/internal/adapter/presenter/RussianPokerWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/ScopaCuiPresenter.go
+++ b/internal/adapter/presenter/ScopaCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/ScopaWebPresenter.go
+++ b/internal/adapter/presenter/ScopaWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/SevenCardStudCuiPresenter.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/SevenCardStudWebPresenter.go
+++ b/internal/adapter/presenter/SevenCardStudWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/ShortDeckCuiPresenter.go
+++ b/internal/adapter/presenter/ShortDeckCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/ShortDeckWebPresenter.go
+++ b/internal/adapter/presenter/ShortDeckWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/TexasHoldemBonusCuiPresenter.go
+++ b/internal/adapter/presenter/TexasHoldemBonusCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/TexasHoldemBonusWebPresenter.go
+++ b/internal/adapter/presenter/TexasHoldemBonusWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/ThreeCardCuiPresenter.go
+++ b/internal/adapter/presenter/ThreeCardCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/ThreeCardWebPresenter.go
+++ b/internal/adapter/presenter/ThreeCardWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/UltimateTexasHoldemCuiPresenter.go
+++ b/internal/adapter/presenter/UltimateTexasHoldemCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/UltimateTexasHoldemWebPresenter.go
+++ b/internal/adapter/presenter/UltimateTexasHoldemWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/VideoPokerCuiPresenter.go
+++ b/internal/adapter/presenter/VideoPokerCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/VideoPokerWebPresenter.go
+++ b/internal/adapter/presenter/VideoPokerWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/cui_betting_action.go
+++ b/internal/adapter/presenter/cui_betting_action.go
@@ -1,0 +1,33 @@
+//go:build !js || !wasm || casino
+
+package presenter
+
+import (
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
+)
+
+// cui_betting_action.go holds the betting-action display helper. It references
+// the casino-only domain.PokerAction* constants and is used only by casino
+// (betting) CUI presenters, so it carries the casino build tag — keeping the
+// shared cui_card_helper.go free of casino dependencies (#2126).
+
+// bettingActionKeys maps betting action constants to i18n keys in
+// cui_common.json. Used by cuiBettingActionName so the displayed action
+// text follows the active locale (issue #1699 Phase 1).
+var bettingActionKeys = map[int]string{
+	domain.PokerActionFold:  "cuiBettingActionFold",
+	domain.PokerActionCheck: "cuiBettingActionCheck",
+	domain.PokerActionCall:  "cuiBettingActionCall",
+	domain.PokerActionBet:   "cuiBettingActionBet",
+	domain.PokerActionRaise: "cuiBettingActionRaise",
+	domain.PokerActionAllIn: "cuiBettingActionAllIn",
+}
+
+// cuiBettingActionName returns the localized name for a betting action.
+func cuiBettingActionName(action int) string {
+	if key, ok := bettingActionKeys[action]; ok {
+		return i18n.T(key)
+	}
+	return i18n.T("cuiBettingActionUnknown")
+}

--- a/internal/adapter/presenter/cui_card_helper.go
+++ b/internal/adapter/presenter/cui_card_helper.go
@@ -62,18 +62,6 @@ type cuiPlayer interface {
 // Index 0 is unused (joker); indices 1–4 correspond to CardDesignSpade–CardDesignDiamond.
 var suitNames = []string{"", "SPADE", "CLOVER", "HEART", "DIAMOND"}
 
-// bettingActionKeys maps betting action constants to i18n keys in
-// cui_common.json. Used by cuiBettingActionName so the displayed action
-// text follows the active locale (issue #1699 Phase 1).
-var bettingActionKeys = map[int]string{
-	domain.PokerActionFold:  "cuiBettingActionFold",
-	domain.PokerActionCheck: "cuiBettingActionCheck",
-	domain.PokerActionCall:  "cuiBettingActionCall",
-	domain.PokerActionBet:   "cuiBettingActionBet",
-	domain.PokerActionRaise: "cuiBettingActionRaise",
-	domain.PokerActionAllIn: "cuiBettingActionAllIn",
-}
-
 // cuiCardStr returns a text-based card string (e.g. "SPADE 5", "JOKER", "??").
 // Used by BlackJack, OldMaid, Daifugo, Sevens, and Doubt CUI presenters.
 func cuiCardStr(card *domain.Card) string {
@@ -151,15 +139,6 @@ func cuiPlayerNameWithStyle[P cuiPlayerWithStyle](player P, idx int) string {
 		name = fmt.Sprintf("%s (%s)", name, player.GetPlayStyleName())
 	}
 	return name
-}
-
-// cuiBettingActionName returns the localized action name for betting
-// actions. Used by Poker and Holdem CUI presenters.
-func cuiBettingActionName(action int) string {
-	if key, ok := bettingActionKeys[action]; ok {
-		return i18n.T(key)
-	}
-	return i18n.T("cuiBettingActionUnknown")
 }
 
 // cuiIndexedCardListStr returns a double-space separated indexed card string.

--- a/internal/adapter/presenter/poker_presenter_common.go
+++ b/internal/adapter/presenter/poker_presenter_common.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/domain/Baccarat.go
+++ b/internal/domain/Baccarat.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/BaccaratSideBet.go
+++ b/internal/domain/BaccaratSideBet.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // バカラサイドベット種類定数

--- a/internal/domain/Badugi.go
+++ b/internal/domain/Badugi.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/BadugiConfig.go
+++ b/internal/domain/BadugiConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // BadugiCpuCountMin / BadugiCpuCountMax are the valid CPU opponent counts.

--- a/internal/domain/BadugiPlayer.go
+++ b/internal/domain/BadugiPlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/BettingHumanProfile.go
+++ b/internal/domain/BettingHumanProfile.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/BigO.go
+++ b/internal/domain/BigO.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // Big O (5 Card Omaha) は通常のオマハ (ホールカード4枚) のホールカードを

--- a/internal/domain/BlackJack.go
+++ b/internal/domain/BlackJack.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/BlackJackBasicStrategy.go
+++ b/internal/domain/BlackJackBasicStrategy.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // BJSuggestedAction ベーシックストラテジー推奨アクション

--- a/internal/domain/BlackJackCPU.go
+++ b/internal/domain/BlackJackCPU.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // initCpuPlayers CPUプレイヤー初期化

--- a/internal/domain/BlackJackConfig.go
+++ b/internal/domain/BlackJackConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "fmt"

--- a/internal/domain/BlackJackCountingStrategy.go
+++ b/internal/domain/BlackJackCountingStrategy.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // countForDecision バランスドシステムならTC、KOならRCを返す

--- a/internal/domain/BlackJackCpuSeat.go
+++ b/internal/domain/BlackJackCpuSeat.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/BlackJackEval.go
+++ b/internal/domain/BlackJackEval.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // dealerPlay ディーラーのカードドロー＆精算

--- a/internal/domain/BlackJackHand.go
+++ b/internal/domain/BlackJackHand.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/BlackJackPlayer.go
+++ b/internal/domain/BlackJackPlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/BlackJackSideBet.go
+++ b/internal/domain/BlackJackSideBet.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "sort"

--- a/internal/domain/BlackJackSwitch.go
+++ b/internal/domain/BlackJackSwitch.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/BlackJackVariant.go
+++ b/internal/domain/BlackJackVariant.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // BlackJackVariantName はブラックジャック系バリアントの識別子

--- a/internal/domain/CaribbeanStud.go
+++ b/internal/domain/CaribbeanStud.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/CasinoHoldem.go
+++ b/internal/domain/CasinoHoldem.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/CasinoWar.go
+++ b/internal/domain/CasinoWar.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/ChinesePoker.go
+++ b/internal/domain/ChinesePoker.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/DeuceToSeven.go
+++ b/internal/domain/DeuceToSeven.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/DeuceToSevenConfig.go
+++ b/internal/domain/DeuceToSevenConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // DeuceToSevenCpuCountMin / DeuceToSevenCpuCountMax are the valid CPU opponent

--- a/internal/domain/DeuceToSevenPlayer.go
+++ b/internal/domain/DeuceToSevenPlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/DragonTiger.go
+++ b/internal/domain/DragonTiger.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/FourCardPoker.go
+++ b/internal/domain/FourCardPoker.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/HighCardFlush.go
+++ b/internal/domain/HighCardFlush.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/Holdem.go
+++ b/internal/domain/Holdem.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/HoldemCPU.go
+++ b/internal/domain/HoldemCPU.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/HoldemConfig.go
+++ b/internal/domain/HoldemConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "fmt"

--- a/internal/domain/HoldemEquity.go
+++ b/internal/domain/HoldemEquity.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/HoldemEval.go
+++ b/internal/domain/HoldemEval.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // trackPreFlopStats プリフロップのHUDスタッツを追跡

--- a/internal/domain/HoldemPlayer.go
+++ b/internal/domain/HoldemPlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/HoldemRebuy.go
+++ b/internal/domain/HoldemRebuy.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // checkAndTransitionAddon はアドオン判定を行い、人間にアドオン決定を促す場合は true を返す。

--- a/internal/domain/IndianPoker.go
+++ b/internal/domain/IndianPoker.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/IndianPokerConfig.go
+++ b/internal/domain/IndianPokerConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // IndianPokerConfig インディアンポーカー設定

--- a/internal/domain/IndianPokerHumanProfile.go
+++ b/internal/domain/IndianPokerHumanProfile.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/IndianPokerPlayer.go
+++ b/internal/domain/IndianPokerPlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/LetItRide.go
+++ b/internal/domain/LetItRide.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/MississippiStud.go
+++ b/internal/domain/MississippiStud.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/OasisPoker.go
+++ b/internal/domain/OasisPoker.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/Omaha.go
+++ b/internal/domain/Omaha.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/OmahaConfig.go
+++ b/internal/domain/OmahaConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // OmahaConfig オマハホールデム設定 (HoldemConfigと同一構造)

--- a/internal/domain/OmahaEquity.go
+++ b/internal/domain/OmahaEquity.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/OmahaPlayer.go
+++ b/internal/domain/OmahaPlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/PaiGow.go
+++ b/internal/domain/PaiGow.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/Pineapple.go
+++ b/internal/domain/Pineapple.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/PineappleCPU.go
+++ b/internal/domain/PineappleCPU.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/PineappleConfig.go
+++ b/internal/domain/PineappleConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // PineappleConfig パイナップルポーカー設定 (HoldemConfigと同一構造)

--- a/internal/domain/PineapplePlayer.go
+++ b/internal/domain/PineapplePlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/Poker.go
+++ b/internal/domain/Poker.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/PokerConfig.go
+++ b/internal/domain/PokerConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // PokerCpuCountMin PokerCpuCountMax CPU プレイヤー数の有効範囲

--- a/internal/domain/PokerOdds.go
+++ b/internal/domain/PokerOdds.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // PokerDrawOdds ドローオッズ (各ハンドランクの確率)

--- a/internal/domain/PokerPlayer.go
+++ b/internal/domain/PokerPlayer.go
@@ -4,36 +4,6 @@ package domain
 
 import "encoding/json"
 
-// ポーカーハンドランク定数
-const (
-	PokerHandHighCard      = 0
-	PokerHandOnePair       = 1
-	PokerHandTwoPair       = 2
-	PokerHandThreeOfAKind  = 3
-	PokerHandStraight      = 4
-	PokerHandFlush         = 5
-	PokerHandFullHouse     = 6
-	PokerHandFourOfAKind   = 7
-	PokerHandStraightFlush = 8
-	PokerHandRoyalFlush    = 9
-	PokerHandFiveOfAKind   = 10
-)
-
-// PokerHandNames ポーカーハンド名
-var PokerHandNames = []string{
-	"High Card",
-	"One Pair",
-	"Two Pair",
-	"Three of a Kind",
-	"Straight",
-	"Flush",
-	"Full House",
-	"Four of a Kind",
-	"Straight Flush",
-	"Royal Flush",
-	"Five of a Kind",
-}
-
 // PokerPlayer ポーカープレイヤークラス
 type PokerPlayer struct {
 	Player                           // 親クラス

--- a/internal/domain/PokerPlayer.go
+++ b/internal/domain/PokerPlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/RedDog.go
+++ b/internal/domain/RedDog.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/RussianPoker.go
+++ b/internal/domain/RussianPoker.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/Scopa.go
+++ b/internal/domain/Scopa.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 // Package domain スコパ (Scopa) のドメインモデル。
 //
 // Scopa はイタリアの国民的フィッシング系カードゲーム。40 枚デッキ

--- a/internal/domain/ScopaCPU.go
+++ b/internal/domain/ScopaCPU.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "math/rand"

--- a/internal/domain/ScopaConfig.go
+++ b/internal/domain/ScopaConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/ScopaEval.go
+++ b/internal/domain/ScopaEval.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // ScopaMaxSubsetCards は scopaSubsetsSummingTo で処理する最大カード枚数。

--- a/internal/domain/ScopaPlayer.go
+++ b/internal/domain/ScopaPlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/SevenCardStud.go
+++ b/internal/domain/SevenCardStud.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/SevenCardStudCPU.go
+++ b/internal/domain/SevenCardStudCPU.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/SevenCardStudConfig.go
+++ b/internal/domain/SevenCardStudConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "fmt"

--- a/internal/domain/SevenCardStudPlayer.go
+++ b/internal/domain/SevenCardStudPlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/SevenCardStudRebuy.go
+++ b/internal/domain/SevenCardStudRebuy.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // checkAndTransitionAddon はアドオン判定を行い、人間にアドオン決定を促す場合は true を返す。

--- a/internal/domain/ShortDeck.go
+++ b/internal/domain/ShortDeck.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/ShortDeckCPU.go
+++ b/internal/domain/ShortDeckCPU.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // shortDeckStyleParamsMap ショートデック用スタイルごとのパラメータ

--- a/internal/domain/ShortDeckConfig.go
+++ b/internal/domain/ShortDeckConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // ShortDeckConfig ショートデックホールデム設定 (HoldemConfigと同一構造)

--- a/internal/domain/ShortDeckEquity.go
+++ b/internal/domain/ShortDeckEquity.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/ShortDeckPlayer.go
+++ b/internal/domain/ShortDeckPlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/TexasHoldemBonus.go
+++ b/internal/domain/TexasHoldemBonus.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/ThreeCard.go
+++ b/internal/domain/ThreeCard.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/TrumpCards.go
+++ b/internal/domain/TrumpCards.go
@@ -239,6 +239,10 @@ func NewTrumpCardsSchnapsen() *TrumpCards {
 	return t
 }
 
+// ShortDeckValues はショートデック(6+)の札値 A,6-K。デッキ構築 (core) と
+// 役判定 (casino) の両方が参照するため、untagged な core ファイルに置く (#2126)。
+var ShortDeckValues = []int{1, 6, 7, 8, 9, 10, 11, 12, 13}
+
 // NewTrumpCardsShortDeck ショートデック(6+)用36枚デッキコンストラクタ
 // A,6,7,8,9,10,J,Q,K (値: 1,6,7,8,9,10,11,12,13) × 4スート = 36枚
 func NewTrumpCardsShortDeck() *TrumpCards {

--- a/internal/domain/UltimateTexasHoldem.go
+++ b/internal/domain/UltimateTexasHoldem.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/VideoPoker.go
+++ b/internal/domain/VideoPoker.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/VideoPokerVariant.go
+++ b/internal/domain/VideoPokerVariant.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // VideoPokerVariantConfig はビデオポーカーのバリアント固有設定を保持する

--- a/internal/domain/badugi_hand_eval.go
+++ b/internal/domain/badugi_hand_eval.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "sort"

--- a/internal/domain/betting.go
+++ b/internal/domain/betting.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "sort"

--- a/internal/domain/community_card_game_base.go
+++ b/internal/domain/community_card_game_base.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 // communityCardBettingBase はコミュニティカード系ポーカー（Holdem, Omaha, ShortDeck, Pineapple）

--- a/internal/domain/deuce_to_seven_hand_eval.go
+++ b/internal/domain/deuce_to_seven_hand_eval.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "sort"

--- a/internal/domain/equity_engine.go
+++ b/internal/domain/equity_engine.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "math/rand"

--- a/internal/domain/interfaces/baccarat.go
+++ b/internal/domain/interfaces/baccarat.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/badugi.go
+++ b/internal/domain/interfaces/badugi.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/black_jack_switch.go
+++ b/internal/domain/interfaces/black_jack_switch.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/blackjack.go
+++ b/internal/domain/interfaces/blackjack.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/caribbean_stud.go
+++ b/internal/domain/interfaces/caribbean_stud.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/casino_war.go
+++ b/internal/domain/interfaces/casino_war.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/casinoholdem.go
+++ b/internal/domain/interfaces/casinoholdem.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/chinesepoker.go
+++ b/internal/domain/interfaces/chinesepoker.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/deuce_to_seven.go
+++ b/internal/domain/interfaces/deuce_to_seven.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/dragon_tiger.go
+++ b/internal/domain/interfaces/dragon_tiger.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/fourcardpoker.go
+++ b/internal/domain/interfaces/fourcardpoker.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/highcardflush.go
+++ b/internal/domain/interfaces/highcardflush.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/holdem.go
+++ b/internal/domain/interfaces/holdem.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/indianpoker.go
+++ b/internal/domain/interfaces/indianpoker.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/let_it_ride.go
+++ b/internal/domain/interfaces/let_it_ride.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/mississippi_stud.go
+++ b/internal/domain/interfaces/mississippi_stud.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/oasis_poker.go
+++ b/internal/domain/interfaces/oasis_poker.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/omaha.go
+++ b/internal/domain/interfaces/omaha.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/paigow.go
+++ b/internal/domain/interfaces/paigow.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/pineapple.go
+++ b/internal/domain/interfaces/pineapple.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/poker.go
+++ b/internal/domain/interfaces/poker.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/red_dog.go
+++ b/internal/domain/interfaces/red_dog.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/russian_poker.go
+++ b/internal/domain/interfaces/russian_poker.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/scopa.go
+++ b/internal/domain/interfaces/scopa.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/sevencardstud.go
+++ b/internal/domain/interfaces/sevencardstud.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/shortdeck.go
+++ b/internal/domain/interfaces/shortdeck.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/texasholdembonus.go
+++ b/internal/domain/interfaces/texasholdembonus.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/threecard.go
+++ b/internal/domain/interfaces/threecard.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/ultimate_texas_holdem.go
+++ b/internal/domain/interfaces/ultimate_texas_holdem.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/interfaces/videopoker.go
+++ b/internal/domain/interfaces/videopoker.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/domain/poker_hand_rank.go
+++ b/internal/domain/poker_hand_rank.go
@@ -1,0 +1,37 @@
+package domain
+
+// poker_hand_rank.go holds the poker hand-rank constants and names. They live
+// in an untagged (core) file — not in a per-category game file — because the
+// core hand evaluators (hand_eval.go, kicker.go) and non-casino games such as
+// PokerSquares (solo worker) depend on them, so they must compile into every
+// Cloudflare Worker (#2126).
+
+// ポーカーハンドランク定数
+const (
+	PokerHandHighCard      = 0
+	PokerHandOnePair       = 1
+	PokerHandTwoPair       = 2
+	PokerHandThreeOfAKind  = 3
+	PokerHandStraight      = 4
+	PokerHandFlush         = 5
+	PokerHandFullHouse     = 6
+	PokerHandFourOfAKind   = 7
+	PokerHandStraightFlush = 8
+	PokerHandRoyalFlush    = 9
+	PokerHandFiveOfAKind   = 10
+)
+
+// PokerHandNames ポーカーハンド名
+var PokerHandNames = []string{
+	"High Card",
+	"One Pair",
+	"Two Pair",
+	"Three of a Kind",
+	"Straight",
+	"Flush",
+	"Full House",
+	"Four of a Kind",
+	"Straight Flush",
+	"Royal Flush",
+	"Five of a Kind",
+}

--- a/internal/domain/shortdeck_hand_eval.go
+++ b/internal/domain/shortdeck_hand_eval.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "sort"

--- a/internal/domain/shortdeck_hand_eval.go
+++ b/internal/domain/shortdeck_hand_eval.go
@@ -33,7 +33,6 @@ var ShortDeckHandNames = []string{
 }
 
 // ShortDeckValues ショートデックで使用するカード値 (A,6,7,8,9,10,J,Q,K)
-var ShortDeckValues = []int{1, 6, 7, 8, 9, 10, 11, 12, 13}
 
 // evalShortDeckFiveCardHand ショートデック用5枚ハンド評価
 // Flush > FullHouse, A-6-7-8-9が最弱ストレート

--- a/internal/usecase/BaccaratInteractor.go
+++ b/internal/usecase/BaccaratInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/BadugiInteractor.go
+++ b/internal/usecase/BadugiInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/BlackJackInteractor.go
+++ b/internal/usecase/BlackJackInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/BlackJackSwitchInteractor.go
+++ b/internal/usecase/BlackJackSwitchInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/CaribbeanStudInteractor.go
+++ b/internal/usecase/CaribbeanStudInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/CasinoHoldemInteractor.go
+++ b/internal/usecase/CasinoHoldemInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/CasinoWarInteractor.go
+++ b/internal/usecase/CasinoWarInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/ChinesePokerInteractor.go
+++ b/internal/usecase/ChinesePokerInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/DeuceToSevenInteractor.go
+++ b/internal/usecase/DeuceToSevenInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/DragonTigerInteractor.go
+++ b/internal/usecase/DragonTigerInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/FourCardPokerInteractor.go
+++ b/internal/usecase/FourCardPokerInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/HighCardFlushInteractor.go
+++ b/internal/usecase/HighCardFlushInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/HoldemInteractor.go
+++ b/internal/usecase/HoldemInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/IndianPokerInteractor.go
+++ b/internal/usecase/IndianPokerInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/LetItRideInteractor.go
+++ b/internal/usecase/LetItRideInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/MississippiStudInteractor.go
+++ b/internal/usecase/MississippiStudInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/OasisPokerInteractor.go
+++ b/internal/usecase/OasisPokerInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/OmahaInteractor.go
+++ b/internal/usecase/OmahaInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/PaiGowInteractor.go
+++ b/internal/usecase/PaiGowInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/PineappleInteractor.go
+++ b/internal/usecase/PineappleInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/PokerInteractor.go
+++ b/internal/usecase/PokerInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/RedDogInteractor.go
+++ b/internal/usecase/RedDogInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/RussianPokerInteractor.go
+++ b/internal/usecase/RussianPokerInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/ScopaInteractor.go
+++ b/internal/usecase/ScopaInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/SevenCardStudInteractor.go
+++ b/internal/usecase/SevenCardStudInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/ShortDeckInteractor.go
+++ b/internal/usecase/ShortDeckInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/TexasHoldemBonusInteractor.go
+++ b/internal/usecase/TexasHoldemBonusInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/ThreeCardInteractor.go
+++ b/internal/usecase/ThreeCardInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/UltimateTexasHoldemInteractor.go
+++ b/internal/usecase/UltimateTexasHoldemInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/VideoPokerInteractor.go
+++ b/internal/usecase/VideoPokerInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/presenter/BaccaratPresenter.go
+++ b/internal/usecase/presenter/BaccaratPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/BadugiPresenter.go
+++ b/internal/usecase/presenter/BadugiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/usecase/presenter/BlackJackPresenter.go
+++ b/internal/usecase/presenter/BlackJackPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/BlackJackSwitchPresenter.go
+++ b/internal/usecase/presenter/BlackJackSwitchPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/CaribbeanStudPresenter.go
+++ b/internal/usecase/presenter/CaribbeanStudPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/CasinoHoldemPresenter.go
+++ b/internal/usecase/presenter/CasinoHoldemPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/CasinoWarPresenter.go
+++ b/internal/usecase/presenter/CasinoWarPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/ChinesePokerPresenter.go
+++ b/internal/usecase/presenter/ChinesePokerPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/DeuceToSevenPresenter.go
+++ b/internal/usecase/presenter/DeuceToSevenPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/usecase/presenter/DragonTigerPresenter.go
+++ b/internal/usecase/presenter/DragonTigerPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/FourCardPokerPresenter.go
+++ b/internal/usecase/presenter/FourCardPokerPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/HighCardFlushPresenter.go
+++ b/internal/usecase/presenter/HighCardFlushPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/HoldemPresenter.go
+++ b/internal/usecase/presenter/HoldemPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/IndianPokerPresenter.go
+++ b/internal/usecase/presenter/IndianPokerPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/LetItRidePresenter.go
+++ b/internal/usecase/presenter/LetItRidePresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/MississippiStudPresenter.go
+++ b/internal/usecase/presenter/MississippiStudPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/OasisPokerPresenter.go
+++ b/internal/usecase/presenter/OasisPokerPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/OmahaPresenter.go
+++ b/internal/usecase/presenter/OmahaPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/PaiGowPresenter.go
+++ b/internal/usecase/presenter/PaiGowPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/PineapplePresenter.go
+++ b/internal/usecase/presenter/PineapplePresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/PokerPresenter.go
+++ b/internal/usecase/presenter/PokerPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/usecase/presenter/RedDogPresenter.go
+++ b/internal/usecase/presenter/RedDogPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/RussianPokerPresenter.go
+++ b/internal/usecase/presenter/RussianPokerPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/ScopaPresenter.go
+++ b/internal/usecase/presenter/ScopaPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/SevenCardStudPresenter.go
+++ b/internal/usecase/presenter/SevenCardStudPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/ShortDeckPresenter.go
+++ b/internal/usecase/presenter/ShortDeckPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/TexasHoldemBonusPresenter.go
+++ b/internal/usecase/presenter/TexasHoldemBonusPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/ThreeCardPresenter.go
+++ b/internal/usecase/presenter/ThreeCardPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/UltimateTexasHoldemPresenter.go
+++ b/internal/usecase/presenter/UltimateTexasHoldemPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"

--- a/internal/usecase/presenter/VideoPokerPresenter.go
+++ b/internal/usecase/presenter/VideoPokerPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"


### PR DESCRIPTION
Extends the merged solo split to the casino category. Tags casino game + betting/poker base files with `//go:build !js || !wasm || casino`. Iterating on cross-category helper coupling via CI.

Refs #2126