### PR TITLE
chore(workers): rebucket Mighty classic->casino for headroom (#2126)

### DIFF
--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -248,7 +248,7 @@ const workerUrl: Record<string, string> = {
   mississippistud: WORKER_CASINO,
   belote: WORKER_CLASSIC,
   spiderette: WORKER_SOLO,
-  mighty: WORKER_CLASSIC,
+  mighty: WORKER_CASINO,
   oasispoker: WORKER_CASINO,
   russianpoker: WORKER_CASINO,
   beleagueredcastle: WORKER_SOLO,

--- a/internal/adapter/controller/MightyCuiController.go
+++ b/internal/adapter/controller/MightyCuiController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/controller/MightyWebController.go
+++ b/internal/adapter/controller/MightyWebController.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package controller
 
 import (

--- a/internal/adapter/presenter/MightyCuiPresenter.go
+++ b/internal/adapter/presenter/MightyCuiPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/adapter/presenter/MightyWebPresenter.go
+++ b/internal/adapter/presenter/MightyWebPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import (

--- a/internal/domain/Mighty.go
+++ b/internal/domain/Mighty.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import (

--- a/internal/domain/MightyConfig.go
+++ b/internal/domain/MightyConfig.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/MightyPlayer.go
+++ b/internal/domain/MightyPlayer.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package domain
 
 import "encoding/json"

--- a/internal/domain/interfaces/mighty.go
+++ b/internal/domain/interfaces/mighty.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package interfaces
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"

--- a/internal/infrastructure/games/casino/casino.go
+++ b/internal/infrastructure/games/casino/casino.go
@@ -329,4 +329,13 @@ func init() {
 			return usecase.RestoreScopaInteractor(data, new(presenter.ScopaWebPresenter))
 		},
 		controller.NewScopaWebControllerWithProvider)
+	games.RegisterKVGame("mighty", games.CategoryCasino,
+		func() usecase.MightyInteractorIF {
+			return usecase.NewMightyInteractor(domain.NewDefaultMighty(), new(presenter.MightyWebPresenter))
+		},
+		func(data []byte) (usecase.MightyInteractorIF, error) {
+			return usecase.RestoreMightyInteractor(data, new(presenter.MightyWebPresenter))
+		},
+		controller.NewMightyWebControllerWithProvider)
+
 }

--- a/internal/infrastructure/games/classic/classic.go
+++ b/internal/infrastructure/games/classic/classic.go
@@ -287,14 +287,6 @@ func init() {
 			return usecase.RestoreBeloteInteractor(data, new(presenter.BeloteWebPresenter))
 		},
 		controller.NewBeloteWebControllerWithProvider)
-	games.RegisterKVGame("mighty", games.CategoryClassic,
-		func() usecase.MightyInteractorIF {
-			return usecase.NewMightyInteractor(domain.NewDefaultMighty(), new(presenter.MightyWebPresenter))
-		},
-		func(data []byte) (usecase.MightyInteractorIF, error) {
-			return usecase.RestoreMightyInteractor(data, new(presenter.MightyWebPresenter))
-		},
-		controller.NewMightyWebControllerWithProvider)
 	games.RegisterKVGame("piquet", games.CategoryClassic,
 		func() usecase.PiquetInteractorIF {
 			return usecase.NewPiquetInteractor(domain.NewDefaultPiquet(), new(presenter.PiquetWebPresenter))

--- a/internal/infrastructure/games/registry.go
+++ b/internal/infrastructure/games/registry.go
@@ -180,7 +180,11 @@ var registry = []*Game{
 	{Name: "mississippistud", Category: CategoryCasino, Description: "Mississippi Stud (ミシシッピ・スタッド)"},
 	{Name: "belote", Category: CategoryClassic, Description: "Belote (ベロート)"},
 	{Name: "spiderette", Category: CategorySolo, Description: "Spiderette (スパイダレット)"},
-	{Name: "mighty", Category: CategoryClassic, Description: "Mighty (マイティ)"},
+	// Mighty is a trick-taking game, but it is bucketed into the casino worker
+	// purely for binary-size balancing (#2126): it is one of the heaviest games
+	// and the classic worker is at the 1 MB gzip limit. Category is only a
+	// per-worker size bucket with no user-facing meaning.
+	{Name: "mighty", Category: CategoryCasino, Description: "Mighty (マイティ)"},
 	{Name: "oasispoker", Category: CategoryCasino, Description: "Oasis Poker (オアシスポーカー)"},
 	{Name: "beleagueredcastle", Category: CategorySolo, Description: "Beleaguered Castle (包囲された城)"},
 	{Name: "piquet", Category: CategoryClassic, Description: "Piquet (ピケ)"},

--- a/internal/infrastructure/games/registry_test.go
+++ b/internal/infrastructure/games/registry_test.go
@@ -13,8 +13,8 @@ import (
 // here indicates that a game's Category is wrong (and would route to the
 // wrong worker in production).
 const (
-	expectedCasino  = 39
-	expectedClassic = 42
+	expectedCasino  = 40
+	expectedClassic = 41
 	expectedSolo    = 42
 	expectedTotal   = expectedCasino + expectedClassic + expectedSolo
 )

--- a/internal/usecase/MightyInteractor.go
+++ b/internal/usecase/MightyInteractor.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package usecase
 
 import (

--- a/internal/usecase/presenter/MightyPresenter.go
+++ b/internal/usecase/presenter/MightyPresenter.go
@@ -1,3 +1,5 @@
+//go:build !js || !wasm || casino
+
 package presenter
 
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"


### PR DESCRIPTION
Rebuckets the heaviest game (Mighty, ~4.5k LOC, a leaf) from the classic worker to casino. Unlike the JSON-residual category split, this removes Mighty's **full logic** from the classic worker — a much larger reclaim. Casino has ~280 KB headroom.

Watch: classic gzip should drop several KB below its current ~1,045,078 B; casino gains Mighty but stays well under 1 MB.

Refs #2126