### PR TITLE
chore: add commit-time game-count assertion guard hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,6 +24,12 @@
             "command": "jq -r '.tool_input.command' | { read -r cmd; case \"$cmd\" in git\\ commit*) echo '{\"hookSpecificInstructions\": \"This is a git commit. Check for documentation drift: run git diff --cached --name-only to see staged files, then verify: (1) game domain/interactor/controller/presenter changes have README.md, CLAUDE.md Commands, docs/games.md, docs/manual/ updates; (2) Web API route changes have docs/architecture.md, api/openapi.yaml updates; (3) frontend page/component changes have frontend/CLAUDE.md i18n list updates; (4) new ADR files have docs/adr/README.md index updates; (5) controller schema changes have api/openapi.yaml updates. Block if required docs are missing from staged files.\"}' ;; *) echo '{}' ;; esac; }",
             "timeout": 10,
             "statusMessage": "Checking for documentation drift..."
+          },
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.command' | { read -r cmd; case \"$cmd\" in git\\ commit*) script=.claude/skills/new-game/scripts/count-audit.sh; if [ -f \"$script\" ] && git diff --cached --name-only | grep -qE 'internal/infrastructure/games/(registry(_test)?\\.go|casino/|classic/|solo/)|frontend/src/(hooks/useTutorialProgress\\.test\\.ts|components/tutorial/TutorialProgressPanel\\.test\\.tsx)'; then output=$(bash \"$script\" 2>&1); if [ $? -ne 0 ]; then jq -nc --arg msg \"$output\" '{continue: false, stopReason: (\"game-count assertions are inconsistent \\u2014 bump them in the same commit before committing:\\n\" + $msg)}'; else echo '{}'; fi; else echo '{}'; fi ;; *) echo '{}' ;; esac; }",
+            "timeout": 30,
+            "statusMessage": "Auditing game-count assertions..."
           }
         ]
       }

--- a/.claude/skills/new-game/SKILL.md
+++ b/.claude/skills/new-game/SKILL.md
@@ -45,7 +45,15 @@ If `<name>` or `<category>` is missing, ask before scaffolding.
    self-audit block at the bottom.
 
 4. **Bump ALL count assertions** (the #1 first-push failure). Adding one game changes these
-   hardcoded totals — update every one in the same commit:
+   hardcoded totals. Run the bundled audit to see, in one shot, the source-of-truth count
+   (`RegisterKVGame` calls per category) against every assertion and exactly which are stale:
+
+   ```sh
+   bash .claude/skills/new-game/scripts/count-audit.sh
+   ```
+
+   It is read-only (edits nothing) and exits non-zero on any mismatch. Bump every ❌ line to
+   the source-of-truth value, then re-run until it prints all ✅. The assertions it covers:
 
    | File | What to bump |
    |------|--------------|
@@ -53,9 +61,11 @@ If `<name>` or `<category>` is missing, ask before scaffolding.
    | `frontend/src/hooks/useTutorialProgress.test.ts` | `totalCount).toBe(N)` (~line 12) |
    | `frontend/src/components/tutorial/TutorialProgressPanel.test.tsx` | **three** assertions: `getByText(/N/)`, `links.length === N`, `incompleteMarkers.length === N` (~lines 22, 36, 49) |
 
-   The Go `expected<Category>` const must match the **count of `RegisterKVGame` calls in
-   that category's sub-package**, and `TestWorkerRegistrationsCoverAllGames` parses the
-   sources to enforce registry ↔ worker agreement (ADR-0031). A mismatch fails the build.
+   The three frontend assertions are **tsc-only** — `bun run check` (biome) does not catch a
+   stale count, so without this audit they slip through to a failed CI run. The Go
+   `expected<Category>` const must match the **count of `RegisterKVGame` calls in that
+   category's sub-package**, and `TestWorkerRegistrationsCoverAllGames` parses the sources to
+   enforce registry ↔ worker agreement (ADR-0031). A mismatch fails the build.
 
 5. **Registration ordering gotcha.** `TestRegistryMatchesCLI` requires the order of entries
    in `internal/infrastructure/ui/GameManager.go` `gameRegistry` to match the order in
@@ -79,11 +89,12 @@ If `<name>` or `<category>` is missing, ask before scaffolding.
    non-domain packages, `goimports -w`, `biome check`, `vitest`, host `go build ./...`,
    and `make build-worker-<category>` for the size check.
 
-9. **Run the registration checker before committing.** Invoke the
-   `game-registration-checker` subagent (Agent tool, `subagent_type:
-   "game-registration-checker"`) with the new `<name>` and `<category>`. It greps every
-   touchpoint and diffs the count assertions read-only — catching the exact failures above
-   *before* the expensive CI round-trip. Fix anything it flags, then commit.
+9. **Gate before committing.** First re-run `bash .claude/skills/new-game/scripts/count-audit.sh`
+   — it must print all ✅. Then invoke the `game-registration-checker` subagent (Agent tool,
+   `subagent_type: "game-registration-checker"`) with the new `<name>` and `<category>`. It
+   greps every touchpoint and diffs the count assertions read-only — catching the exact
+   failures above *before* the expensive, OOM-prone CI round-trip. Fix anything either flags,
+   then commit.
 
 10. **Docs in the same commit.** README.md, CLAUDE.md (games list), docs/games.md,
     docs/architecture.md (+ endpoint count), api/openapi.yaml, and both

--- a/.claude/skills/new-game/scripts/count-audit.sh
+++ b/.claude/skills/new-game/scripts/count-audit.sh
@@ -36,7 +36,10 @@ check() { # label  actual  expected
   fi
 }
 
-grepval() { grep -nE "$2" "$1" 2>/dev/null | head -1 | grep -oE '[0-9]+' | tail -1; }
+# Extract the numeric value from the first line matching ERE $2 in file $1.
+# Strip // comments first so an inline trailing number (e.g. "= 47 // up from 45")
+# can't be mistaken for the value; take the last remaining digit run on the line.
+grepval() { grep -E "$2" "$1" 2>/dev/null | head -1 | sed 's|//.*||' | grep -oE '[0-9]+' | tail -1; }
 
 echo "── Go: $REG_TEST ───────────"
 check "expectedCasino"  "$(grepval "$REG_TEST" 'expectedCasino[[:space:]]*=')"  "$cas"
@@ -46,10 +49,13 @@ echo
 
 echo "── Frontend (tsc-only — NOT caught by 'bun run check') ─────────"
 check "useTutorialProgress.test.ts totalCount" "$(grepval "$TUT_HOOK" 'totalCount\).toBe\(')" "$total"
-# TutorialProgressPanel.test.tsx has three total assertions on separate lines:
-panel_text=$(grep -nE 'getByText\(/[0-9]+/\)' "$TUT_PANEL" 2>/dev/null | grep -oE '/[0-9]+/' | tr -d '/' | sort -rn | head -1)
-panel_links=$(grep -nE 'links\.length\)\.toBe\(' "$TUT_PANEL" 2>/dev/null | grep -oE '[0-9]+' | tail -1)
-panel_incomplete=$(grep -nE 'incompleteMarkers\.length\)\.toBe\(' "$TUT_PANEL" 2>/dev/null | grep -oE '[0-9]+' | tail -1)
+# TutorialProgressPanel.test.tsx has three total assertions on separate lines.
+# getByText(/N/) has no unique anchor token, so we take the largest of the
+# getByText(/…/) numbers (the file also asserts /0/ and /3/); this assumes the
+# total is the largest such literal in the file — true today (124 > 3 > 0).
+panel_text=$(grep -E 'getByText\(/[0-9]+/\)' "$TUT_PANEL" 2>/dev/null | sed 's|//.*||' | grep -oE '/[0-9]+/' | tr -d '/' | sort -rn | head -1)
+panel_links=$(grepval "$TUT_PANEL" 'links\.length\)\.toBe\(')
+panel_incomplete=$(grepval "$TUT_PANEL" 'incompleteMarkers\.length\)\.toBe\(')
 check "TutorialProgressPanel getByText(/N/)"   "$panel_text"       "$total"
 check "TutorialProgressPanel links.length"     "$panel_links"      "$total"
 check "TutorialProgressPanel incompleteMarkers" "$panel_incomplete" "$total"

--- a/.claude/skills/new-game/scripts/count-audit.sh
+++ b/.claude/skills/new-game/scripts/count-audit.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# count-audit.sh — read-only audit of the game-count assertions that a new game must bump.
+#
+# Prints the source-of-truth count (RegisterKVGame calls per category) alongside every
+# hardcoded assertion, and flags any mismatch. Run from the repo root. Safe to run anytime;
+# it edits nothing. Exit code 0 = all consistent, 1 = at least one mismatch.
+#
+# The #1 recurring new-game miss is forgetting one of these assertions: tsc only runs in CI
+# (`bun run check` is biome-only), so a stale frontend count slips past local checks and
+# fails the expensive, OOM-prone CI round-trip. Run this before committing instead.
+set -u
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" || exit 2
+
+REG_TEST=internal/infrastructure/games/registry_test.go
+TUT_HOOK=frontend/src/hooks/useTutorialProgress.test.ts
+TUT_PANEL=frontend/src/components/tutorial/TutorialProgressPanel.test.tsx
+
+fail=0
+
+# --- source of truth: RegisterKVGame calls per category sub-package ---
+cas=$(grep -rc 'RegisterKVGame' internal/infrastructure/games/casino/  2>/dev/null | awk -F: '{s+=$2} END{print s+0}')
+cla=$(grep -rc 'RegisterKVGame' internal/infrastructure/games/classic/ 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')
+sol=$(grep -rc 'RegisterKVGame' internal/infrastructure/games/solo/    2>/dev/null | awk -F: '{s+=$2} END{print s+0}')
+total=$((cas + cla + sol))
+
+echo "── Source of truth (RegisterKVGame calls) ──────────────────────"
+printf '  casino=%s  classic=%s  solo=%s  TOTAL=%s\n\n' "$cas" "$cla" "$sol" "$total"
+
+check() { # label  actual  expected
+  if [ "$2" = "$3" ]; then
+    printf '  ✅ %-52s %s\n' "$1" "$2"
+  else
+    printf '  ❌ %-52s %s (expected %s)\n' "$1" "$2" "$3"
+    fail=1
+  fi
+}
+
+grepval() { grep -nE "$2" "$1" 2>/dev/null | head -1 | grep -oE '[0-9]+' | tail -1; }
+
+echo "── Go: $REG_TEST ───────────"
+check "expectedCasino"  "$(grepval "$REG_TEST" 'expectedCasino[[:space:]]*=')"  "$cas"
+check "expectedClassic" "$(grepval "$REG_TEST" 'expectedClassic[[:space:]]*=')" "$cla"
+check "expectedSolo"    "$(grepval "$REG_TEST" 'expectedSolo[[:space:]]*=')"    "$sol"
+echo
+
+echo "── Frontend (tsc-only — NOT caught by 'bun run check') ─────────"
+check "useTutorialProgress.test.ts totalCount" "$(grepval "$TUT_HOOK" 'totalCount\).toBe\(')" "$total"
+# TutorialProgressPanel.test.tsx has three total assertions on separate lines:
+panel_text=$(grep -nE 'getByText\(/[0-9]+/\)' "$TUT_PANEL" 2>/dev/null | grep -oE '/[0-9]+/' | tr -d '/' | sort -rn | head -1)
+panel_links=$(grep -nE 'links\.length\)\.toBe\(' "$TUT_PANEL" 2>/dev/null | grep -oE '[0-9]+' | tail -1)
+panel_incomplete=$(grep -nE 'incompleteMarkers\.length\)\.toBe\(' "$TUT_PANEL" 2>/dev/null | grep -oE '[0-9]+' | tail -1)
+check "TutorialProgressPanel getByText(/N/)"   "$panel_text"       "$total"
+check "TutorialProgressPanel links.length"     "$panel_links"      "$total"
+check "TutorialProgressPanel incompleteMarkers" "$panel_incomplete" "$total"
+echo
+
+if [ "$fail" -eq 0 ]; then
+  echo "VERDICT: ✅ all count assertions consistent ($total games)"
+else
+  echo "VERDICT: ❌ mismatch — bump the ❌ lines to match the source-of-truth column above"
+fi
+exit "$fail"


### PR DESCRIPTION
## Summary

Adds a guard against the single most-recurring new-game first-push failure: a stale hardcoded game-count assertion that slips past local checks and only fails in the expensive, OOM-prone CI round-trip.

Two commits:

1. **`settings.json` PreToolUse hook** — on `git commit`, when staged files touch count-affecting paths (`registry.go`, `registry_test.go`, the `casino/classic/solo` worker sub-packages, or the tutorial-progress assertion tests), it runs the count-audit and **blocks the commit** if the assertions disagree with the `RegisterKVGame` source of truth. Has an existence guard so it degrades to a no-op where the script is absent.
2. **`scripts/count-audit.sh` + SKILL.md wiring** — a read-only audit comparing the per-category `RegisterKVGame` count against every hardcoded assertion: the Go consts in `registry_test.go` **and** the three frontend assertions that are **tsc-only** (`bun run check` / biome does not catch a stale count). Exits non-zero on mismatch. Wired into the `new-game` skill as both the count-bump driver and a pre-commit gate.

## Why these files live under `.claude/`

This is agent tooling. `new-game/SKILL.md` was already tracked; the script and the hook are committed alongside it so the protection travels with the repo rather than relying on a local-only file.

## Test plan

- [x] Hook no-op paths return `{}` (non-commit; commit with nothing relevant staged; commit with count file staged + counts consistent)
- [x] Hook blocking path: staged `registry_test.go` with `expectedSolo 44→45` mismatch → `continue: false` with the exact stale-assertion line; valid JSON output (emoji/newlines escaped via `jq -n`)
- [x] `count-audit.sh` reports all ✅ against current repo (124 games = 47 casino + 33 classic + 44 solo)
- [x] Temporary test mismatch fully reverted; no source files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)