### PR TITLE
docs: refresh frontend CLAUDE.md useGameHint/CLI coverage

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -30,7 +30,7 @@ Shared building blocks:
 | `useGameApi(apiFn, opts)` | Server-state management with loading / error / retry |
 | `GamePageShell` | Background + heading + phase indicator + reset dialog wrapper (most pages use this) |
 | `TutorialWrapper` | Tutorial provider + i18n init (always wraps the exported `XPage`) |
-| `useCliMode` + `useCliGame` + `<CliTerminal>` + `<CliToggle>` | CLI fallback mode (BlackJack / Poker / etc.) |
+| `useCliMode` + `useCliGame` + `<CliTerminal>` + `<CliToggle>` | CLI fallback mode, available on most pages (~112). Per-game parsing/formatting lives in `src/utils/cli/commands/<game>Commands.ts` + `src/utils/cli/formatters/<game>Formatter.ts` |
 
 ## Package Manager Rule
 
@@ -130,7 +130,7 @@ bun run build && bun run check && bun run test
 | `TutorialProvider` | `src/providers/TutorialProvider.tsx` | Context provider; renders overlay (used internally by TutorialWrapper) |
 | `TutorialOverlay` | `src/components/tutorial/TutorialOverlay.tsx` | Full-screen overlay with SVG mask spotlight |
 | `useTutorial` | `src/hooks/useTutorial.ts` | State management (step progression, localStorage, resume/restart) |
-| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints for BlackJack, Poker, Hearts, Spades |
+| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers ~all games, currently 124). The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
 | `TutorialSuggestDialog` | `src/components/tutorial/TutorialSuggestDialog.tsx` | First-visit dialog; controlled by `useFirstVisit` hook |
 | `TutorialProgressPanel` | `src/components/tutorial/TutorialProgressPanel.tsx` | Progress overview in NavBar |
 


### PR DESCRIPTION
## Summary

Refreshes two stale claims in `frontend/CLAUDE.md` found during a CLAUDE.md currency audit. Both descriptions implied a feature covers only 2-4 games when it is actually a registry-driven, near-universal system — which could lead a new-game author to build a one-off path instead of registering in the existing slot.

| Item | Before (stale) | After (verified) |
|------|----------------|------------------|
| `useGameHint` | "Frontend hints for BlackJack, Poker, Hearts, Spades" (4) | Registry-driven via `hintFactories`, covers 124 games; supported set is the `HintGameName` union (`keyof typeof hintFactories`) |
| CLI fallback mode | "(BlackJack / Poker / etc.)" | Available on ~112 pages; per-game files in `src/utils/cli/commands/` + `src/utils/cli/formatters/` |

Both are reworded as **registry-driven** so they don't re-stale as games are added.

## Verification

- `useGameHint` `hintFactories` keys counted: **124** games.
- `useCliMode`/`useCliGame` usage: **112** pages; **85** CLI command parsers.
- Framework reference ("Vite + React + TypeScript", "Vitest") left unchanged — migration issues #809/#810 are open but not yet done, so it is still current.
- Root `CLAUDE.md` and `internal/CLAUDE.md` audited as well — both current (132 games; worker lists casino 50 / classic 33 / solo 49 = 132 exact match), no changes needed.

## Test plan

- [x] Docs-only change (`frontend/CLAUDE.md`, 2 lines); no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
