### PR TITLE
feat: validate web --host as usage error (exit 2) not runtime failure

### DIFF
--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/signal"
 	"slices"
@@ -60,6 +61,62 @@ func isPosixLocalePlaceholder(prefix string) bool {
 // reserved for "let the OS assign an ephemeral port" (POSIX convention).
 func portInRange(port int) bool {
 	return port >= 0 && port <= 65535
+}
+
+// validHost reports whether s is usable as the host portion of a TCP bind
+// address: a literal IP (v4/v6), an empty string (treated as "all interfaces"
+// by net.Listen), or a syntactically valid hostname. We deliberately do NOT
+// resolve DNS here — name-resolution failure at bind time stays a runtime
+// error (exit 1); only syntactically impossible values are rejected as a
+// usage error (exit 2). Whitespace and an embedded ":" (which would corrupt
+// net.JoinHostPort, or smuggle in a port) are rejected up front. See #2150.
+func validHost(s string) bool {
+	if s == "" {
+		return true
+	}
+	if strings.TrimSpace(s) != s || strings.ContainsAny(s, " \t") {
+		return false
+	}
+	if net.ParseIP(s) != nil {
+		return true
+	}
+	// Reject anything that would break net.JoinHostPort / contain a port.
+	if strings.Contains(s, ":") {
+		return false
+	}
+	return isValidHostname(s)
+}
+
+// isValidHostname reports whether s is a syntactically valid RFC 1123 hostname:
+// 1-253 characters total, dot-separated labels of 1-63 characters each, where
+// every label contains only ASCII letters, digits, or hyphens and does not
+// start or end with a hyphen. A single trailing dot (fully-qualified form) is
+// tolerated. This is a syntax check only — it does not attempt resolution.
+func isValidHostname(s string) bool {
+	s = strings.TrimSuffix(s, ".")
+	if s == "" || len(s) > 253 {
+		return false
+	}
+	for _, label := range strings.Split(s, ".") {
+		if len(label) == 0 || len(label) > 63 {
+			return false
+		}
+		if label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+		for i := 0; i < len(label); i++ {
+			c := label[i]
+			switch {
+			case c >= 'a' && c <= 'z':
+			case c >= 'A' && c <= 'Z':
+			case c >= '0' && c <= '9':
+			case c == '-':
+			default:
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // applyColorMode resolves the tristate `--color=auto|always|never` flag (issue
@@ -389,8 +446,18 @@ func run() int {
 			}
 			_ = os.Setenv("PORT", strconv.Itoa(port))
 		}
-		if host != "" {
-			_ = os.Setenv("HOST", host)
+		if flagSetVisited(fs, "host") {
+			if !validHost(host) {
+				// Usage error (malformed bind address), not a runtime
+				// failure — mirrors --port so systemd / CI can branch on
+				// exit 2. DNS-resolvable-but-down names stay exit 1 at bind.
+				fmt.Fprintln(os.Stderr, i18n.Tf("cliInvalidHost", "host", host))
+				fmt.Fprintln(os.Stderr, i18n.Tf("cliTryHelp", "cmd", "web"))
+				return 2
+			}
+			if host != "" {
+				_ = os.Setenv("HOST", host)
+			}
 		}
 		// Default to quiet when stderr is not a TTY (systemd, docker, pipe).
 		// See issue #1452: human-friendly text is noise for log shippers, but

--- a/cmd/trumpcards/main.go
+++ b/cmd/trumpcards/main.go
@@ -64,12 +64,15 @@ func portInRange(port int) bool {
 }
 
 // validHost reports whether s is usable as the host portion of a TCP bind
-// address: a literal IP (v4/v6), an empty string (treated as "all interfaces"
-// by net.Listen), or a syntactically valid hostname. We deliberately do NOT
-// resolve DNS here — name-resolution failure at bind time stays a runtime
-// error (exit 1); only syntactically impossible values are rejected as a
-// usage error (exit 2). Whitespace and an embedded ":" (which would corrupt
-// net.JoinHostPort, or smuggle in a port) are rejected up front. See #2150.
+// address: a literal IP (v4/v6), an empty string, or a syntactically valid
+// hostname. An empty host is accepted but treated by the server as "unset" —
+// getListenAddr falls back to the 127.0.0.1 default, so `--host ""` is
+// equivalent to omitting the flag; pass 0.0.0.0 to expose on all interfaces.
+// We deliberately do NOT resolve DNS here — name-resolution failure at bind
+// time stays a runtime error (exit 1); only syntactically impossible values
+// are rejected as a usage error (exit 2). Whitespace and an embedded ":"
+// (which would corrupt net.JoinHostPort, or smuggle in a port) are rejected
+// up front. See #2150.
 func validHost(s string) bool {
 	if s == "" {
 		return true
@@ -635,7 +638,7 @@ var builtinSubcommandHelp = map[string][]string{
 		"    0  Server exited cleanly without receiving a signal",
 		"    1  Server start failure (includes EADDRINUSE / port already in use —",
 		"       systemd / Docker `restart: on-failure` should retry on this code)",
-		"    2  Usage error (unknown flag, --port out of range)",
+		"    2  Usage error (unknown flag, --port out of range, or invalid --host)",
 		"  130  Graceful shutdown triggered by SIGINT (Ctrl+C)  (128 + 2)",
 		"  143  Graceful shutdown triggered by SIGTERM  (128 + 15)",
 		"",

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -157,6 +157,93 @@ func TestPortInRange(t *testing.T) {
 	}
 }
 
+func TestValidHost(t *testing.T) {
+	tests := []struct {
+		host string
+		want bool
+	}{
+		{"", true},                    // unset -> all interfaces (net.Listen convention)
+		{"0.0.0.0", true},             // expose-all literal
+		{"127.0.0.1", true},           // IPv4 loopback
+		{"::1", true},                 // IPv6 loopback
+		{"2001:db8::1", true},         // IPv6 literal
+		{"localhost", true},           // hostname
+		{"example.com", true},         // dotted hostname
+		{"my-host.local", true},       // hyphen inside label
+		{"nonexistent.invalid", true}, // syntactically valid; DNS failure stays exit 1 at bind
+		{"bad host", false},           // embedded space
+		{" leading", false},           // leading whitespace
+		{"trailing ", false},          // trailing whitespace
+		{"1.2.3.4:5", false},          // smuggled port (would corrupt JoinHostPort)
+		{"-bad.com", false},           // label starts with hyphen
+		{"bad-.com", false},           // label ends with hyphen
+		{"a..b", false},               // empty label
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("host=%q", tt.host), func(t *testing.T) {
+			if got := validHost(tt.host); got != tt.want {
+				t.Errorf("validHost(%q) = %v, want %v", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRunWebRejectsInvalidHost is the --host analogue of
+// TestRunWebRejectsExplicitInvalidPort (#2150): a syntactically malformed
+// --host must exit 2 (usage error) with cliInvalidHost + the help hint and
+// must NOT set the HOST env var, so systemd/CI can distinguish an operator
+// typo from a runtime bind failure (exit 1).
+func TestRunWebRejectsInvalidHost(t *testing.T) {
+	origArgs := os.Args
+	origCmdLine := flag.CommandLine
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	origHostEnv, hostEnvWasSet := os.LookupEnv("HOST")
+	defer func() {
+		os.Args = origArgs
+		flag.CommandLine = origCmdLine
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+		if hostEnvWasSet {
+			_ = os.Setenv("HOST", origHostEnv)
+		} else {
+			_ = os.Unsetenv("HOST")
+		}
+	}()
+	_ = os.Unsetenv("HOST") // baseline
+
+	flag.CommandLine = flag.NewFlagSet("trumpcards", flag.ExitOnError)
+	os.Args = []string{"trumpcards", "web", "--host", "bad host"}
+
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	exitCh := make(chan int, 1)
+	go func() { exitCh <- run() }()
+	exit := <-exitCh
+
+	_ = wOut.Close()
+	_ = wErr.Close()
+	var outBuf, errBuf bytes.Buffer
+	_, _ = outBuf.ReadFrom(rOut)
+	_, _ = errBuf.ReadFrom(rErr)
+
+	if exit != 2 {
+		t.Errorf("exit = %d, want 2 (usage error; stderr=%q)", exit, errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "bad host") {
+		t.Errorf("stderr should mention the offending host; got: %q", errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "help web") {
+		t.Errorf("stderr should include cliTryHelp hint; got: %q", errBuf.String())
+	}
+	if got := os.Getenv("HOST"); got != "" {
+		t.Errorf("HOST should not be set on invalid input; got %q", got)
+	}
+}
+
 func TestFlagSetVisitedDistinguishesExplicitFromDefault(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/cmd/trumpcards/main_test.go
+++ b/cmd/trumpcards/main_test.go
@@ -162,7 +162,7 @@ func TestValidHost(t *testing.T) {
 		host string
 		want bool
 	}{
-		{"", true},                    // unset -> all interfaces (net.Listen convention)
+		{"", true},                    // empty -> server falls back to its 127.0.0.1 default
 		{"0.0.0.0", true},             // expose-all literal
 		{"127.0.0.1", true},           // IPv4 loopback
 		{"::1", true},                 // IPv6 loopback
@@ -172,6 +172,7 @@ func TestValidHost(t *testing.T) {
 		{"my-host.local", true},       // hyphen inside label
 		{"nonexistent.invalid", true}, // syntactically valid; DNS failure stays exit 1 at bind
 		{"bad host", false},           // embedded space
+		{"a\tb", false},               // embedded tab
 		{" leading", false},           // leading whitespace
 		{"trailing ", false},          // trailing whitespace
 		{"1.2.3.4:5", false},          // smuggled port (would corrupt JoinHostPort)

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -40,6 +40,7 @@
   "cliStartupBanner": "trumpcards {{version}} - Interactive Mode",
   "cliStartupGame": "Starting with {{game}}. Type 'switch <game>' to change, 'games' to list all.",
   "cliInvalidPort": "Error: invalid port number {{port}} (must be 0-65535; 0 asks the OS for an ephemeral port)",
+  "cliInvalidHost": "Error: invalid host {{host}} (expected an IP address or hostname; use 0.0.0.0 to expose on all interfaces)",
   "cliExtraArgsWarning": "Warning: extra arguments ignored: {{args}}",
   "cliCompletionUsage": "Usage: trumpcards completion <bash|zsh|fish>",
   "cliCompletionUnsupportedShell": "Error: unsupported shell \"{{shell}}\" (supported: bash, zsh, fish)",

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -40,6 +40,7 @@
   "cliStartupBanner": "trumpcards {{version}} - インタラクティブモード",
   "cliStartupGame": "{{game}} を開始します。'switch <game>' でゲームを切り替え、'games' で一覧を表示できます。",
   "cliInvalidPort": "エラー: 無効なポート番号 {{port}} です (0-65535 の範囲で指定してください。0 はOSに空きポートを割り当てさせます)",
+  "cliInvalidHost": "エラー: 無効なホスト {{host}} です (IP アドレスまたはホスト名を指定してください。全インターフェースに公開するには 0.0.0.0 を使用します)",
   "cliExtraArgsWarning": "警告: 余分な引数は無視されました: {{args}}",
   "cliCompletionUsage": "使い方: trumpcards completion <bash|zsh|fish>",
   "cliCompletionUnsupportedShell": "エラー: サポートされていないシェル \"{{shell}}\" (対応: bash, zsh, fish)",


### PR DESCRIPTION
## Summary

`trumpcards web --port` pre-validates its value and rejects out-of-range input with **exit 2** (usage error) and a localized, actionable message. `--host` had **no validation**: a typo or malformed bind address fell through to `net.Listen` and surfaced as a raw Go runtime error with **exit 1**, breaking the documented exit-code contract (1 = runtime failure / 2 = usage error).

This change mirrors `--port` for `--host`:

- Adds `validHost` / `isValidHostname` helpers (next to `portInRange`).
- Validates `--host` **before** setting the `HOST` env var; rejects syntactically impossible values (whitespace, embedded `:`/port) with exit 2 + new localized `cliInvalidHost` message + the `help web` hint.
- DNS-resolvable-but-down hostnames (e.g. `nonexistent.invalid`) **stay exit 1** at bind time — only clearly malformed input is rejected, avoiding over-validation (pendulum effect).

## Changes

- `cmd/trumpcards/main.go` — `net` import, `validHost`/`isValidHostname` helpers, `--host` pre-validation in the `web` command.
- `internal/i18n/locales/{ja,en}/common.json` — new `cliInvalidHost` key (next to `cliInvalidPort`).
- `cmd/trumpcards/main_test.go` — `TestValidHost` (table) + `TestRunWebRejectsInvalidHost` (exit 2, message, HOST unset).

## Test plan

- [x] `go test -tags test ./cmd/trumpcards/ ./internal/i18n/...` — pass
- [x] `golangci-lint run ./cmd/trumpcards/...` — 0 issues
- [x] `goimports -w` on modified files

Closes #2150