### PR TITLE
refactor: consolidate per-game CUI hint-reason wrappers into hintReasonStr

### DIFF
--- a/internal/adapter/presenter/BeloteCuiPresenter.go
+++ b/internal/adapter/presenter/BeloteCuiPresenter.go
@@ -109,7 +109,7 @@ func (p *BeloteCuiPresenter) HintOutput(b interfaces.BeloteGame) string {
 	if hint == nil {
 		return i18n.T("belote.hintNone") + "\n"
 	}
-	reason := beloteHintReasonStr(hint.Reason)
+	reason := hintReasonStr(hint.Reason, nil)
 	if hint.OrderUp != nil {
 		if *hint.OrderUp {
 			return color.Yellow(i18n.Tf("belote.hintOrderUp", "reason", reason)) + "\n"
@@ -130,12 +130,6 @@ func (p *BeloteCuiPresenter) HintOutput(b interfaces.BeloteGame) string {
 		"idx", strconv.Itoa(*hint.CardIndex),
 		"card", cuiCardStr(card),
 		"reason", reason)) + "\n"
-}
-
-// beloteHintReasonStr resolves a Belote-specific reason key, falling back to
-// the shared cui_common layer.
-func beloteHintReasonStr(reason string) string {
-	return lookupHintReason(reason, nil)
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/BridgeCuiPresenter.go
+++ b/internal/adapter/presenter/BridgeCuiPresenter.go
@@ -147,7 +147,7 @@ func (p *BridgeCuiPresenter) HintOutput(b interfaces.BridgeGame) string {
 	if hint == nil {
 		return i18n.T("bridge.hintNone") + "\n"
 	}
-	reason := bridgeHintReasonStr(hint.Reason)
+	reason := hintReasonStr(hint.Reason, bridgeHintReasonKeys)
 	if hint.BidType != nil {
 		bidTypeStr := bridgeBidTypeStr(*hint.BidType)
 		if *hint.BidType == int(domain.BridgeBidNormal) && hint.BidLevel != nil && hint.BidSuit != nil {
@@ -194,15 +194,6 @@ func bridgeBidTypeStr(bidType int) string {
 var bridgeHintReasonKeys = map[string]string{
 	"support_partner": "bridge.hintReasonSupportPartner",
 	"competitive_bid": "bridge.hintReasonCompetitiveBid",
-}
-
-// bridgeHintReasonStr resolves a reason via the per-game map first, then
-// the shared (cui_common) layer.
-func bridgeHintReasonStr(reason string) string {
-	if key, ok := bridgeHintReasonKeys[reason]; ok {
-		return i18n.T(key)
-	}
-	return lookupHintReason(reason, nil)
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/BridgeCuiPresenter.go
+++ b/internal/adapter/presenter/BridgeCuiPresenter.go
@@ -190,7 +190,7 @@ func bridgeBidTypeStr(bidType int) string {
 
 // bridgeHintReasonKeys maps Bridge-specific hint-reason identifiers to
 // their i18n keys. Reasons not in this map fall through to
-// lookupHintReason → cui_common (e.g. strategic_bid).
+// hintReasonStr → cui_common (e.g. strategic_bid).
 var bridgeHintReasonKeys = map[string]string{
 	"support_partner": "bridge.hintReasonSupportPartner",
 	"competitive_bid": "bridge.hintReasonCompetitiveBid",

--- a/internal/adapter/presenter/BriscolaCuiPresenter.go
+++ b/internal/adapter/presenter/BriscolaCuiPresenter.go
@@ -99,7 +99,7 @@ func (p *BriscolaCuiPresenter) HintOutput(b interfaces.BriscolaGame) string {
 	return color.Yellow(i18n.Tf("briscola.hintCard",
 		"idx", strconv.Itoa(*hint.CardIndex),
 		"card", cuiCardStr(card),
-		"reason", briscolaHintReasonStr(hint.Reason))) + "\n"
+		"reason", hintReasonStr(hint.Reason, briscolaHintReasonKeys))) + "\n"
 }
 
 // briscolaHintReasonKeys maps Briscola-specific hint-reason identifiers to their
@@ -112,15 +112,6 @@ var briscolaHintReasonKeys = map[string]string{
 	"follow_cut":  "briscola.hintReasonFollowCut",
 	"follow_win":  "briscola.hintReasonFollowWin",
 	"follow_dump": "briscola.hintReasonFollowDump",
-}
-
-// briscolaHintReasonStr resolves a reason via the per-game map first, then the
-// shared (cui_common) layer.
-func briscolaHintReasonStr(reason string) string {
-	if key, ok := briscolaHintReasonKeys[reason]; ok {
-		return i18n.T(key)
-	}
-	return lookupHintReason(reason, nil)
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/BriscolaCuiPresenter.go
+++ b/internal/adapter/presenter/BriscolaCuiPresenter.go
@@ -104,7 +104,7 @@ func (p *BriscolaCuiPresenter) HintOutput(b interfaces.BriscolaGame) string {
 
 // briscolaHintReasonKeys maps Briscola-specific hint-reason identifiers to their
 // i18n keys. Reasons not listed here fall through to cui_common via
-// lookupHintReason.
+// hintReasonStr.
 var briscolaHintReasonKeys = map[string]string{
 	"lead_trump":  "briscola.hintReasonLeadTrump",
 	"lead_low":    "briscola.hintReasonLeadLow",

--- a/internal/adapter/presenter/CallBreakCuiPresenter.go
+++ b/internal/adapter/presenter/CallBreakCuiPresenter.go
@@ -100,7 +100,7 @@ func (p *CallBreakCuiPresenter) HintOutput(cb interfaces.CallBreakGame) string {
 	if hint == nil {
 		return i18n.T("callbreak.hintNone") + "\n"
 	}
-	reason := callBreakHintReasonStr(hint.Reason)
+	reason := hintReasonStr(hint.Reason, callBreakHintReasonKeys)
 	if hint.Bid != nil {
 		return color.Yellow(i18n.Tf("callbreak.hintBid",
 			"bid", strconv.Itoa(*hint.Bid),
@@ -120,13 +120,6 @@ func (p *CallBreakCuiPresenter) HintOutput(cb interfaces.CallBreakGame) string {
 // their i18n keys. Reasons not in this map fall through to lookupHintReason.
 var callBreakHintReasonKeys = map[string]string{
 	"trump_cut": "callbreak.hintReasonTrumpCut",
-}
-
-func callBreakHintReasonStr(reason string) string {
-	if key, ok := callBreakHintReasonKeys[reason]; ok {
-		return i18n.T(key)
-	}
-	return lookupHintReason(reason, nil)
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/CallBreakCuiPresenter.go
+++ b/internal/adapter/presenter/CallBreakCuiPresenter.go
@@ -117,7 +117,7 @@ func (p *CallBreakCuiPresenter) HintOutput(cb interfaces.CallBreakGame) string {
 }
 
 // callBreakHintReasonKeys maps Call Break-specific hint-reason identifiers to
-// their i18n keys. Reasons not in this map fall through to lookupHintReason.
+// their i18n keys. Reasons not in this map fall through to hintReasonStr.
 var callBreakHintReasonKeys = map[string]string{
 	"trump_cut": "callbreak.hintReasonTrumpCut",
 }

--- a/internal/adapter/presenter/EuchreCuiPresenter.go
+++ b/internal/adapter/presenter/EuchreCuiPresenter.go
@@ -120,7 +120,7 @@ func (p *EuchreCuiPresenter) HintOutput(e interfaces.EuchreGame) string {
 	if hint == nil {
 		return i18n.T("euchre.hintNone") + "\n"
 	}
-	reason := euchreHintReasonStr(hint.Reason)
+	reason := hintReasonStr(hint.Reason, euchreHintReasonKeys)
 	if hint.OrderUp != nil {
 		if *hint.OrderUp {
 			key := "euchre.hintOrderUp"
@@ -156,15 +156,6 @@ func (p *EuchreCuiPresenter) HintOutput(e interfaces.EuchreGame) string {
 // lookupHintReason.
 var euchreHintReasonKeys = map[string]string{
 	"discard_weakest": "euchre.hintReasonDiscardWeakest",
-}
-
-// euchreHintReasonStr resolves a reason via the per-game map first, then the
-// shared (cui_common) layer.
-func euchreHintReasonStr(reason string) string {
-	if key, ok := euchreHintReasonKeys[reason]; ok {
-		return i18n.T(key)
-	}
-	return lookupHintReason(reason, nil)
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/EuchreCuiPresenter.go
+++ b/internal/adapter/presenter/EuchreCuiPresenter.go
@@ -153,7 +153,7 @@ func (p *EuchreCuiPresenter) HintOutput(e interfaces.EuchreGame) string {
 
 // euchreHintReasonKeys maps Euchre-specific hint-reason identifiers to their
 // i18n keys. Reasons not listed here fall through to cui_common via
-// lookupHintReason.
+// hintReasonStr.
 var euchreHintReasonKeys = map[string]string{
 	"discard_weakest": "euchre.hintReasonDiscardWeakest",
 }

--- a/internal/adapter/presenter/GongZhuCuiPresenter.go
+++ b/internal/adapter/presenter/GongZhuCuiPresenter.go
@@ -118,7 +118,7 @@ func (p *GongZhuCuiPresenter) HintOutput(g interfaces.GongZhuGame) string {
 	}
 	return color.Yellow(i18n.Tf("gongzhu.hintCard",
 		"cards", cardsStr,
-		"reason", gongZhuHintReasonStr(hint.Reason))) + "\n"
+		"reason", hintReasonStr(hint.Reason, gongZhuHintReasonKeys))) + "\n"
 }
 
 // gongZhuHintReasonKeys maps Gong Zhu-specific hint-reason identifiers to i18n keys.
@@ -127,14 +127,6 @@ var gongZhuHintReasonKeys = map[string]string{
 	"expose_none":    "gongzhu.hintReasonExposeNone",
 	"discard_pig":    "gongzhu.hintReasonDiscardPig",
 	"discard_hearts": "gongzhu.hintReasonDiscardHearts",
-}
-
-// gongZhuHintReasonStr resolves a reason via the per-game map first, then the shared layer.
-func gongZhuHintReasonStr(reason string) string {
-	if key, ok := gongZhuHintReasonKeys[reason]; ok {
-		return i18n.T(key)
-	}
-	return lookupHintReason(reason, nil)
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/HeartsCuiPresenter.go
+++ b/internal/adapter/presenter/HeartsCuiPresenter.go
@@ -105,7 +105,7 @@ func (p *HeartsCuiPresenter) HintOutput(h interfaces.HeartsGame) string {
 
 // heartsHintReasonKeys maps Hearts-specific hint-reason identifiers to
 // their i18n keys. Reasons not in this map fall through to
-// lookupHintReason → cui_common.
+// hintReasonStr → cui_common.
 var heartsHintReasonKeys = map[string]string{
 	"pass_high_risk_cards": "hearts.hintReasonPassHighRisk",
 	"discard_queen_spades": "hearts.hintReasonDiscardQueenSpades",

--- a/internal/adapter/presenter/HeartsCuiPresenter.go
+++ b/internal/adapter/presenter/HeartsCuiPresenter.go
@@ -100,7 +100,7 @@ func (p *HeartsCuiPresenter) HintOutput(h interfaces.HeartsGame) string {
 	}
 	return color.Yellow(i18n.Tf("hearts.hintCard",
 		"cards", strings.Join(cards, ", "),
-		"reason", heartsHintReasonStr(hint.Reason))) + "\n"
+		"reason", hintReasonStr(hint.Reason, heartsHintReasonKeys))) + "\n"
 }
 
 // heartsHintReasonKeys maps Hearts-specific hint-reason identifiers to
@@ -110,15 +110,6 @@ var heartsHintReasonKeys = map[string]string{
 	"pass_high_risk_cards": "hearts.hintReasonPassHighRisk",
 	"discard_queen_spades": "hearts.hintReasonDiscardQueenSpades",
 	"discard_hearts":       "hearts.hintReasonDiscardHearts",
-}
-
-// heartsHintReasonStr resolves a reason via the per-game map first, then
-// the shared (cui_common) layer.
-func heartsHintReasonStr(reason string) string {
-	if key, ok := heartsHintReasonKeys[reason]; ok {
-		return i18n.T(key)
-	}
-	return lookupHintReason(reason, nil)
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/MightyCuiPresenter.go
+++ b/internal/adapter/presenter/MightyCuiPresenter.go
@@ -162,7 +162,7 @@ func (p *MightyCuiPresenter) HintOutput(m interfaces.MightyGame) string {
 	if hint == nil {
 		return i18n.T("mighty.hintNone") + "\n"
 	}
-	reason := mightyHintReasonStr(hint.Reason)
+	reason := hintReasonStr(hint.Reason, mightyHintReasonKeys)
 	switch {
 	case hint.Bid != nil:
 		tag := ""
@@ -219,14 +219,6 @@ var mightyHintReasonKeys = map[string]string{
 	"play_low":          "mighty.hintReasonPlayLow",
 	"play_trump":        "mighty.hintReasonPlayTrump",
 	"play_follow":       "mighty.hintReasonPlayFollow",
-}
-
-// mightyHintReasonStr resolves a reason to the active locale.
-func mightyHintReasonStr(reason string) string {
-	if key, ok := mightyHintReasonKeys[reason]; ok {
-		return i18n.T(key)
-	}
-	return lookupHintReason(reason, nil)
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/NapoleonCuiPresenter.go
+++ b/internal/adapter/presenter/NapoleonCuiPresenter.go
@@ -160,7 +160,7 @@ func (p *NapoleonCuiPresenter) HintOutput(n interfaces.NapoleonGame) string {
 	if hint == nil {
 		return i18n.T("napoleon.hintNone") + "\n"
 	}
-	reason := napoleonHintReasonStr(hint.Reason)
+	reason := hintReasonStr(hint.Reason, napoleonHintReasonKeys)
 	switch {
 	case hint.Bid != nil:
 		return color.Yellow(i18n.Tf("napoleon.hintBid",
@@ -203,18 +203,6 @@ var napoleonHintReasonKeys = map[string]string{
 	"strategic_discard": "napoleon.hintReasonStrategicDiscard",
 	"play_joker":        "napoleon.hintReasonPlayJoker",
 	"discard_low":       "napoleon.hintReasonDiscardLow",
-}
-
-// napoleonHintReasonStr resolves a reason to the active locale, falling
-// through to the shared (cui_common) reason map and finally to the raw
-// reason key as a debug-friendly fallback.
-func napoleonHintReasonStr(reason string) string {
-	if key, ok := napoleonHintReasonKeys[reason]; ok {
-		return i18n.T(key)
-	}
-	// lookupHintReason already delegates to cui_common via i18n; passing nil
-	// for the per-game map skips the second lookup we just did.
-	return lookupHintReason(reason, nil)
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/NapoleonCuiPresenter_test.go
+++ b/internal/adapter/presenter/NapoleonCuiPresenter_test.go
@@ -514,7 +514,7 @@ func TestNapoleonCuiPresenter_English(t *testing.T) {
 	// strategic_bid is intentionally NOT in napoleonHintReasonKeys — it's
 	// shared with Bridge, Spades, Skat, OhHell and lives in
 	// sharedHintReasonKeys (cui_common). The fallthrough path in
-	// napoleonHintReasonStr (per-game miss → lookupHintReason → cui_common)
+	// hintReasonStr (per-game miss → sharedHintReasonKeys → cui_common)
 	// is what makes it render. This test pins that path under LANG=en.
 	t.Run("strategic_bid falls through to shared key in English", func(t *testing.T) {
 		bid := 14

--- a/internal/adapter/presenter/OhHellCuiPresenter.go
+++ b/internal/adapter/presenter/OhHellCuiPresenter.go
@@ -111,7 +111,7 @@ func (p *OhHellCuiPresenter) HintOutput(o interfaces.OhHellGame) string {
 	if hint == nil {
 		return i18n.T("ohhell.hintNone") + "\n"
 	}
-	reason := ohHellHintReasonStr(hint.Reason)
+	reason := hintReasonStr(hint.Reason, nil)
 	if hint.Bid != nil {
 		return color.Yellow(i18n.Tf("ohhell.hintBid",
 			"bid", strconv.Itoa(*hint.Bid),
@@ -135,12 +135,6 @@ func (p *OhHellCuiPresenter) HintOutput(o interfaces.OhHellGame) string {
 		"idx", strconv.Itoa(*hint.CardIndex),
 		"card", cuiCardStr(card),
 		"reason", reason)) + "\n"
-}
-
-// ohHellHintReasonStr falls through to the cui_common shared keys (Oh Hell
-// has no game-specific hint reasons today).
-func ohHellHintReasonStr(reason string) string {
-	return lookupHintReason(reason, nil)
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/PitchCuiPresenter.go
+++ b/internal/adapter/presenter/PitchCuiPresenter.go
@@ -127,7 +127,7 @@ func (p *PitchCuiPresenter) HintOutput(s interfaces.PitchGame) string {
 	if hint == nil {
 		return i18n.T("pitch.hintNone") + "\n"
 	}
-	reason := pitchHintReasonStr(hint.Reason)
+	reason := hintReasonStr(hint.Reason, pitchHintReasonKeys)
 	if hint.Bid != nil {
 		return color.Yellow(i18n.Tf("pitch.hintBid",
 			"bid", pitchBidStr(*hint.Bid),
@@ -161,15 +161,6 @@ var pitchHintReasonKeys = map[string]string{
 	"trump_cut":      "pitch.hintReasonTrumpCut",
 	"bid_strong":     "pitch.hintReasonBidStrong",
 	"bid_pass":       "pitch.hintReasonBidPass",
-}
-
-// pitchHintReasonStr resolves a reason via the per-game map first, then
-// the shared (cui_common) layer.
-func pitchHintReasonStr(reason string) string {
-	if key, ok := pitchHintReasonKeys[reason]; ok {
-		return i18n.T(key)
-	}
-	return lookupHintReason(reason, nil)
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/PitchCuiPresenter.go
+++ b/internal/adapter/presenter/PitchCuiPresenter.go
@@ -154,7 +154,7 @@ func (p *PitchCuiPresenter) HintOutput(s interfaces.PitchGame) string {
 }
 
 // pitchHintReasonKeys maps Pitch-specific hint-reason identifiers to their
-// i18n keys. Reasons not in this map fall through to lookupHintReason →
+// i18n keys. Reasons not in this map fall through to hintReasonStr →
 // cui_common.
 var pitchHintReasonKeys = map[string]string{
 	"set_trump_lead": "pitch.hintReasonSetTrumpLead",

--- a/internal/adapter/presenter/SchnapsenCuiPresenter.go
+++ b/internal/adapter/presenter/SchnapsenCuiPresenter.go
@@ -146,7 +146,7 @@ func (p *SchnapsenCuiPresenter) HintOutput(s interfaces.SchnapsenGame) string {
 
 // schnapsenHintReasonKeys maps Schnapsen-specific hint-reason identifiers to their
 // i18n keys. Reasons not listed here fall through to cui_common via
-// lookupHintReason.
+// hintReasonStr.
 var schnapsenHintReasonKeys = map[string]string{
 	"lead_trump":  "schnapsen.hintReasonLeadTrump",
 	"lead_low":    "schnapsen.hintReasonLeadLow",

--- a/internal/adapter/presenter/SchnapsenCuiPresenter.go
+++ b/internal/adapter/presenter/SchnapsenCuiPresenter.go
@@ -141,7 +141,7 @@ func (p *SchnapsenCuiPresenter) HintOutput(s interfaces.SchnapsenGame) string {
 	return color.Yellow(i18n.Tf("schnapsen.hintCard",
 		"idx", strconv.Itoa(*hint.CardIndex),
 		"card", cuiCardStr(card),
-		"reason", schnapsenHintReasonStr(hint.Reason))) + "\n"
+		"reason", hintReasonStr(hint.Reason, schnapsenHintReasonKeys))) + "\n"
 }
 
 // schnapsenHintReasonKeys maps Schnapsen-specific hint-reason identifiers to their
@@ -154,15 +154,6 @@ var schnapsenHintReasonKeys = map[string]string{
 	"follow_cut":  "schnapsen.hintReasonFollowCut",
 	"follow_win":  "schnapsen.hintReasonFollowWin",
 	"follow_dump": "schnapsen.hintReasonFollowDump",
-}
-
-// schnapsenHintReasonStr resolves a reason via the per-game map first, then the
-// shared (cui_common) layer.
-func schnapsenHintReasonStr(reason string) string {
-	if key, ok := schnapsenHintReasonKeys[reason]; ok {
-		return i18n.T(key)
-	}
-	return lookupHintReason(reason, nil)
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/SpadesCuiPresenter.go
+++ b/internal/adapter/presenter/SpadesCuiPresenter.go
@@ -100,7 +100,7 @@ func (p *SpadesCuiPresenter) HintOutput(s interfaces.SpadesGame) string {
 	if hint == nil {
 		return i18n.T("spades.hintNone") + "\n"
 	}
-	reason := spadesHintReasonStr(hint.Reason)
+	reason := hintReasonStr(hint.Reason, spadesHintReasonKeys)
 	if hint.Bid != nil {
 		return color.Yellow(i18n.Tf("spades.hintBid",
 			"bid", strconv.Itoa(*hint.Bid),
@@ -121,15 +121,6 @@ func (p *SpadesCuiPresenter) HintOutput(s interfaces.SpadesGame) string {
 // lookupHintReason → cui_common.
 var spadesHintReasonKeys = map[string]string{
 	"trump_cut": "spades.hintReasonTrumpCut",
-}
-
-// spadesHintReasonStr resolves a reason via the per-game map first, then
-// the shared (cui_common) layer.
-func spadesHintReasonStr(reason string) string {
-	if key, ok := spadesHintReasonKeys[reason]; ok {
-		return i18n.T(key)
-	}
-	return lookupHintReason(reason, nil)
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/SpadesCuiPresenter.go
+++ b/internal/adapter/presenter/SpadesCuiPresenter.go
@@ -118,7 +118,7 @@ func (p *SpadesCuiPresenter) HintOutput(s interfaces.SpadesGame) string {
 
 // spadesHintReasonKeys maps Spades-specific hint-reason identifiers to
 // their i18n keys. Reasons not in this map fall through to
-// lookupHintReason → cui_common.
+// hintReasonStr → cui_common.
 var spadesHintReasonKeys = map[string]string{
 	"trump_cut": "spades.hintReasonTrumpCut",
 }

--- a/internal/adapter/presenter/TarneebCuiPresenter.go
+++ b/internal/adapter/presenter/TarneebCuiPresenter.go
@@ -128,7 +128,7 @@ func (p *TarneebCuiPresenter) HintOutput(t interfaces.TarneebGame) string {
 	if hint == nil {
 		return i18n.T("tarneeb.hintNone") + "\n"
 	}
-	reason := tarneebHintReasonStr(hint.Reason)
+	reason := hintReasonStr(hint.Reason, tarneebHintReasonKeys)
 	if hint.Bid != nil {
 		return color.Yellow(i18n.Tf("tarneeb.hintBid",
 			"bid", strconv.Itoa(*hint.Bid),
@@ -155,13 +155,6 @@ var tarneebHintReasonKeys = map[string]string{
 	"bid_estimate":  "tarneeb.hintReasonBidEstimate",
 	"trump_longest": "tarneeb.hintReasonTrumpLongest",
 	"trump_cut":     "tarneeb.hintReasonTrumpCut",
-}
-
-func tarneebHintReasonStr(reason string) string {
-	if key, ok := tarneebHintReasonKeys[reason]; ok {
-		return i18n.T(key)
-	}
-	return lookupHintReason(reason, nil)
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/TressetteCuiPresenter.go
+++ b/internal/adapter/presenter/TressetteCuiPresenter.go
@@ -104,7 +104,7 @@ func (p *TressetteCuiPresenter) HintOutput(g interfaces.TressetteGame) string {
 	}
 	return color.Yellow(i18n.Tf("tressette.hintCard",
 		"cards", strings.Join(cards, ", "),
-		"reason", tressetteHintReasonStr(hint.Reason))) + "\n"
+		"reason", hintReasonStr(hint.Reason, tressetteHintReasonKeys))) + "\n"
 }
 
 // tressetteHintReasonKeys maps Tressette-specific hint-reason identifiers to i18n keys.
@@ -114,14 +114,6 @@ var tressetteHintReasonKeys = map[string]string{
 	"follow_duck":  "tressette.hintReasonFollowDuck",
 	"give_partner": "tressette.hintReasonGivePartner",
 	"discard_low":  "tressette.hintReasonDiscardLow",
-}
-
-// tressetteHintReasonStr resolves a reason via the per-game map first, then the shared layer.
-func tressetteHintReasonStr(reason string) string {
-	if key, ok := tressetteHintReasonKeys[reason]; ok {
-		return i18n.T(key)
-	}
-	return lookupHintReason(reason, nil)
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/TrucoCuiPresenter.go
+++ b/internal/adapter/presenter/TrucoCuiPresenter.go
@@ -129,7 +129,7 @@ func (p *TrucoCuiPresenter) HintOutput(g interfaces.TrucoGame) string {
 		return color.Yellow(i18n.Tf("truco.hintCard",
 			"idx", strconv.Itoa(*hint.CardIndex),
 			"card", cuiCardStr(card),
-			"reason", trucoHintReasonStr(hint.Reason))) + "\n"
+			"reason", hintReasonStr(hint.Reason, trucoHintReasonKeys))) + "\n"
 	}
 }
 
@@ -139,15 +139,6 @@ var trucoHintReasonKeys = map[string]string{
 	"leadLow":    "truco.hintReasonLeadLow",
 	"followWin":  "truco.hintReasonFollowWin",
 	"followDump": "truco.hintReasonFollowDump",
-}
-
-// trucoHintReasonStr resolves a reason via the per-game map first, then the
-// shared (cui_common) layer.
-func trucoHintReasonStr(reason string) string {
-	if key, ok := trucoHintReasonKeys[reason]; ok {
-		return i18n.T(key)
-	}
-	return lookupHintReason(reason, nil)
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/TwoTenJackCuiPresenter.go
+++ b/internal/adapter/presenter/TwoTenJackCuiPresenter.go
@@ -105,7 +105,7 @@ func (p *TwoTenJackCuiPresenter) HintOutput(s interfaces.TwoTenJackGame) string 
 	if hint == nil {
 		return i18n.T("twotenjack.hintNone") + "\n"
 	}
-	reason := twoTenJackHintReasonStr(hint.Reason)
+	reason := hintReasonStr(hint.Reason, twoTenJackHintReasonKeys)
 	if hint.TrumpSuit != nil {
 		return color.Yellow(i18n.Tf("twotenjack.hintTrump",
 			"suit", twoTenJackSuitLabel(*hint.TrumpSuit),
@@ -131,15 +131,6 @@ var twoTenJackHintReasonKeys = map[string]string{
 	"follow_suit":     "twotenjack.hintReasonFollowSuit",
 	"trump_cut":       "twotenjack.hintReasonTrumpCut",
 	"discard":         "twotenjack.hintReasonDiscard",
-}
-
-// twoTenJackHintReasonStr resolves a reason via the per-game map first, then
-// the shared (cui_common) layer.
-func twoTenJackHintReasonStr(reason string) string {
-	if key, ok := twoTenJackHintReasonKeys[reason]; ok {
-		return i18n.T(key)
-	}
-	return lookupHintReason(reason, nil)
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/TwoTenJackCuiPresenter.go
+++ b/internal/adapter/presenter/TwoTenJackCuiPresenter.go
@@ -124,7 +124,7 @@ func (p *TwoTenJackCuiPresenter) HintOutput(s interfaces.TwoTenJackGame) string 
 
 // twoTenJackHintReasonKeys maps Two Ten Jack-specific hint-reason identifiers
 // to their i18n keys. Reasons not listed here fall through to cui_common via
-// lookupHintReason.
+// hintReasonStr.
 var twoTenJackHintReasonKeys = map[string]string{
 	"strategic_trump": "twotenjack.hintReasonStrategicTrump",
 	"lead":            "twotenjack.hintReasonLead",

--- a/internal/adapter/presenter/WhistCuiPresenter.go
+++ b/internal/adapter/presenter/WhistCuiPresenter.go
@@ -92,7 +92,7 @@ func (p *WhistCuiPresenter) HintOutput(w interfaces.WhistGame) string {
 	return color.Yellow(i18n.Tf("whist.hintCard",
 		"idx", strconv.Itoa(*hint.CardIndex),
 		"card", cuiCardStr(card),
-		"reason", whistHintReasonStr(hint.Reason))) + "\n"
+		"reason", hintReasonStr(hint.Reason, whistHintReasonKeys))) + "\n"
 }
 
 // whistHintReasonKeys maps Whist-specific hint-reason identifiers to their
@@ -100,15 +100,6 @@ func (p *WhistCuiPresenter) HintOutput(w interfaces.WhistGame) string {
 // lookupHintReason.
 var whistHintReasonKeys = map[string]string{
 	"trump_cut": "whist.hintReasonTrumpCut",
-}
-
-// whistHintReasonStr resolves a reason via the per-game map first, then the
-// shared (cui_common) layer.
-func whistHintReasonStr(reason string) string {
-	if key, ok := whistHintReasonKeys[reason]; ok {
-		return i18n.T(key)
-	}
-	return lookupHintReason(reason, nil)
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/WhistCuiPresenter.go
+++ b/internal/adapter/presenter/WhistCuiPresenter.go
@@ -97,7 +97,7 @@ func (p *WhistCuiPresenter) HintOutput(w interfaces.WhistGame) string {
 
 // whistHintReasonKeys maps Whist-specific hint-reason identifiers to their
 // i18n keys. Reasons not listed here fall through to cui_common via
-// lookupHintReason.
+// hintReasonStr.
 var whistHintReasonKeys = map[string]string{
 	"trump_cut": "whist.hintReasonTrumpCut",
 }

--- a/internal/adapter/presenter/cui_output_helper.go
+++ b/internal/adapter/presenter/cui_output_helper.go
@@ -63,9 +63,29 @@ var sharedHintReasonKeys = map[string]string{
 }
 
 // lookupHintReason looks up a hint reason string from game-specific map, then shared map.
+// The gameReasons map holds already-resolved display strings (reason → text);
+// values are returned verbatim. For maps that hold i18n keys (reason → key)
+// use hintReasonStr instead, which applies i18n.T.
 func lookupHintReason(reason string, gameReasons map[string]string) string {
 	if s, ok := gameReasons[reason]; ok {
 		return s
+	}
+	if key, ok := sharedHintReasonKeys[reason]; ok {
+		return i18n.T(key)
+	}
+	return reason
+}
+
+// hintReasonStr resolves a hint reason via a game-specific key map first
+// (reason → i18n key, translated through i18n.T), then falls back to the
+// shared sharedHintReasonKeys, and finally returns the raw reason. It is the
+// common implementation behind every per-game *HintReasonStr helper: a game
+// passes its xHintReasonKeys map (or nil when it only needs the shared
+// fallback). Unlike lookupHintReason, the map values are treated as i18n keys,
+// not pre-resolved strings.
+func hintReasonStr(reason string, gameKeys map[string]string) string {
+	if key, ok := gameKeys[reason]; ok {
+		return i18n.T(key)
 	}
 	if key, ok := sharedHintReasonKeys[reason]; ok {
 		return i18n.T(key)


### PR DESCRIPTION
## Summary

The CUI presenter layer had **18 near-identical `xHintReasonStr` wrappers** (one per game) that all did the same thing: look up a game-specific `reason → i18n-key` map, translate via `i18n.T`, and fall back to the shared `cui_common` keys. This is a DRY/YAGNI smell that grew from copying presenters when adding games.

This PR adds one shared helper and deletes the wrappers:

- New `hintReasonStr(reason string, gameKeys map[string]string) string` in `cui_output_helper.go` (translates `gameKeys` values as i18n keys, then falls back to `sharedHintReasonKeys`).
- 16 keyed games call `hintReasonStr(hint.Reason, xHintReasonKeys)` directly; their per-game `xHintReasonKeys` maps stay as the SSoT, so **displayed hint text is unchanged**.
- 2 pure pass-throughs (Belote, Oh Hell) call `hintReasonStr(hint.Reason, nil)`.

### Scope note (deviation from the issue)

The issue classified **Skat** as a third pass-through, but Skat's wrapper is `lookupHintReason(reason, skatHintReasons)` — used at **5 call sites** with a meaningful *literal-string* map. Removing it would repeat `skatHintReasons` 5× and *reduce* DRY-ness, so Skat's wrapper is **kept** (avoiding the over-refactor the issue itself warns about). `lookupHintReason` is retained for that literal-string semantic (also used by BidWhist/FiveHundred and covered by existing tests); its doc comment now spells out how it differs from `hintReasonStr`.

## Changes

- `cui_output_helper.go` — add `hintReasonStr`; clarify `lookupHintReason` doc.
- 18 `*CuiPresenter.go` — delete wrappers, call `hintReasonStr` at the call site.
- `NapoleonCuiPresenter_test.go` — update a stale comment referencing the removed wrapper.

Net: **−181 / +44 lines**.

## Test plan

- [x] `go test -tags test ./internal/adapter/presenter/` — pass (hint output strings unchanged)
- [x] `golangci-lint run ./internal/adapter/presenter/...` — 0 issues
- [x] `go vet` / `goimports -w` clean

Closes #2153