### PR TITLE
refactor: centralize CLI SUIT_MAP and fix club alias drift

### DIFF
--- a/frontend/src/utils/cli/commands/bridgeCommands.test.ts
+++ b/frontend/src/utils/cli/commands/bridgeCommands.test.ts
@@ -26,6 +26,15 @@ describe('parseBridgeCommand', () => {
     expect(parseBridgeCommand('bid 3 nt')).toEqual({ args: ['bid', undefined, 3, 3, 5] });
   });
 
+  // #2152 review: the shared BRIDGE_SUIT_MAP also accepts singular forms and
+  // the `clover` club alias, matching the other games.
+  it('parses bid with singular and clover suit aliases', () => {
+    expect(parseBridgeCommand('bid 1 club')).toEqual(parseBridgeCommand('bid 1 clubs'));
+    expect(parseBridgeCommand('bid 1 clover')).toEqual({ args: ['bid', undefined, 3, 1, 1] });
+    expect(parseBridgeCommand('bid 2 heart')).toEqual({ args: ['bid', undefined, 3, 2, 3] });
+    expect(parseBridgeCommand('bid 4 spade')).toEqual({ args: ['bid', undefined, 3, 4, 4] });
+  });
+
   it('returns error for bid without enough args', () => {
     const result = parseBridgeCommand('bid');
     expect('error' in result).toBe(true);

--- a/frontend/src/utils/cli/commands/bridgeCommands.ts
+++ b/frontend/src/utils/cli/commands/bridgeCommands.ts
@@ -1,22 +1,10 @@
 import type { bridgeApi } from '../../../api/gameApi';
 import { parseIntArg } from '../commandParserBase';
+import { BRIDGE_SUIT_MAP as SUIT_MAP } from '../suitMaps';
 import type { CliParseResult } from '../types';
 import { parseTrickCommand, TRICK_HELP } from './sharedTrickCommands';
 
 type BridgeArgs = Parameters<typeof bridgeApi.exec>;
-
-const SUIT_MAP: Record<string, number> = {
-  clubs: 1,
-  c: 1,
-  diamonds: 2,
-  d: 2,
-  hearts: 3,
-  h: 3,
-  spades: 4,
-  s: 4,
-  notrump: 5,
-  nt: 5,
-};
 
 const EXTRA_COMMANDS = ['bid', 'pass', 'double', 'dbl', 'redouble', 'rdbl', 'log'];
 

--- a/frontend/src/utils/cli/commands/crazyeightsCommands.ts
+++ b/frontend/src/utils/cli/commands/crazyeightsCommands.ts
@@ -1,23 +1,9 @@
 import type { crazyeightsApi } from '../../../api/gameApi';
 import { parseIntArg, splitCommand, suggestCommand } from '../commandParserBase';
+import { STANDARD_SUIT_MAP as SUIT_MAP } from '../suitMaps';
 import type { CliParseResult } from '../types';
 
 type CrazyEightsArgs = Parameters<typeof crazyeightsApi.exec>;
-
-const SUIT_MAP: Record<string, number> = {
-  spade: 1,
-  spades: 1,
-  s: 1,
-  clover: 2,
-  clubs: 2,
-  c: 2,
-  heart: 3,
-  hearts: 3,
-  h: 3,
-  diamond: 4,
-  diamonds: 4,
-  d: 4,
-};
 
 const VALID_COMMANDS = ['p', 'play', 'd', 'draw', 'suit', 'nr', 'nextround', 'r', 'reset', 'help', '?'];
 

--- a/frontend/src/utils/cli/commands/euchreCommands.ts
+++ b/frontend/src/utils/cli/commands/euchreCommands.ts
@@ -1,24 +1,10 @@
 import type { euchreApi } from '../../../api/gameApi';
 import { parseIntArg } from '../commandParserBase';
+import { STANDARD_SUIT_MAP as SUIT_MAP } from '../suitMaps';
 import type { CliParseResult } from '../types';
 import { parseTrickCommand, TRICK_HELP } from './sharedTrickCommands';
 
 type EuchreArgs = Parameters<typeof euchreApi.exec>;
-
-const SUIT_MAP: Record<string, number> = {
-  spade: 1,
-  spades: 1,
-  s: 1,
-  clover: 2,
-  clubs: 2,
-  c: 2,
-  heart: 3,
-  hearts: 3,
-  h: 3,
-  diamond: 4,
-  diamonds: 4,
-  d: 4,
-};
 
 const EXTRA_COMMANDS = ['ou', 'orderup', 'pass', 'ct', 'calltrump', 'dis', 'discard', 'alone'];
 

--- a/frontend/src/utils/cli/commands/macauCommands.ts
+++ b/frontend/src/utils/cli/commands/macauCommands.ts
@@ -1,23 +1,9 @@
 import type { macauApi } from '../../../api/gameApi';
 import { parseIntArg, splitCommand, suggestCommand } from '../commandParserBase';
+import { STANDARD_SUIT_MAP as SUIT_MAP } from '../suitMaps';
 import type { CliParseResult } from '../types';
 
 type MacauArgs = Parameters<typeof macauApi.exec>;
-
-const SUIT_MAP: Record<string, number> = {
-  spade: 1,
-  spades: 1,
-  s: 1,
-  clover: 2,
-  clubs: 2,
-  c: 2,
-  heart: 3,
-  hearts: 3,
-  h: 3,
-  diamond: 4,
-  diamonds: 4,
-  d: 4,
-};
 
 const VALID_COMMANDS = [
   'p',

--- a/frontend/src/utils/cli/commands/mightyCommands.ts
+++ b/frontend/src/utils/cli/commands/mightyCommands.ts
@@ -1,24 +1,15 @@
 import type { mightyApi } from '../../../api/gameApi';
 import { parseIntArg } from '../commandParserBase';
+import { STANDARD_SUIT_MAP } from '../suitMaps';
 import type { CliParseResult } from '../types';
 import { parseTrickCommand, TRICK_HELP } from './sharedTrickCommands';
 
 type MightyArgs = Parameters<typeof mightyApi.exec>;
 
+// Mighty also accepts the joker and a no-trump declaration, layered on the
+// shared standard suit aliases.
 const SUIT_MAP: Record<string, number> = {
-  spade: 1,
-  spades: 1,
-  s: 1,
-  clover: 2,
-  club: 2,
-  clubs: 2,
-  c: 2,
-  heart: 3,
-  hearts: 3,
-  h: 3,
-  diamond: 4,
-  diamonds: 4,
-  d: 4,
+  ...STANDARD_SUIT_MAP,
   joker: 0,
   j: 0,
   notrump: -1,

--- a/frontend/src/utils/cli/commands/napoleonCommands.ts
+++ b/frontend/src/utils/cli/commands/napoleonCommands.ts
@@ -1,24 +1,10 @@
 import type { napoleonApi } from '../../../api/gameApi';
 import { parseIntArg } from '../commandParserBase';
+import { STANDARD_SUIT_MAP as SUIT_MAP } from '../suitMaps';
 import type { CliParseResult } from '../types';
 import { parseTrickCommand, TRICK_HELP } from './sharedTrickCommands';
 
 type NapoleonArgs = Parameters<typeof napoleonApi.exec>;
-
-const SUIT_MAP: Record<string, number> = {
-  spade: 1,
-  spades: 1,
-  s: 1,
-  clover: 2,
-  clubs: 2,
-  c: 2,
-  heart: 3,
-  hearts: 3,
-  h: 3,
-  diamond: 4,
-  diamonds: 4,
-  d: 4,
-};
 
 const EXTRA_COMMANDS = ['bid', 'pass', 'trump', 'adj', 'adjutant', 'ex', 'exchange', 'log'];
 

--- a/frontend/src/utils/cli/commands/pinochleCommands.ts
+++ b/frontend/src/utils/cli/commands/pinochleCommands.ts
@@ -1,24 +1,10 @@
 import type { pinochleApi } from '../../../api/gameApi';
 import { parseIntArg } from '../commandParserBase';
+import { STANDARD_SUIT_MAP as SUIT_MAP } from '../suitMaps';
 import type { CliParseResult } from '../types';
 import { parseTrickCommand, TRICK_HELP } from './sharedTrickCommands';
 
 type PinochleArgs = Parameters<typeof pinochleApi.exec>;
-
-const SUIT_MAP: Record<string, number> = {
-  spade: 1,
-  spades: 1,
-  s: 1,
-  clover: 2,
-  clubs: 2,
-  c: 2,
-  heart: 3,
-  hearts: 3,
-  h: 3,
-  diamond: 4,
-  diamonds: 4,
-  d: 4,
-};
 
 const EXTRA_COMMANDS = ['bid', 'pass', 'trump', 'meld', 'log'];
 

--- a/frontend/src/utils/cli/commands/sevensCommands.test.ts
+++ b/frontend/src/utils/cli/commands/sevensCommands.test.ts
@@ -29,6 +29,13 @@ describe('parseSevensCommand', () => {
     expect('error' in result2).toBe(true);
   });
 
+  // Regression for #2152: `club` (singular) must be accepted, matching Mighty.
+  it('accepts club, clubs, and clover for the joker suit', () => {
+    expect(parseSevensCommand('j club 6')).toEqual({ args: ['joker', -1, 2, 6] });
+    expect(parseSevensCommand('j clubs 6')).toEqual({ args: ['joker', -1, 2, 6] });
+    expect(parseSevensCommand('j clover 6')).toEqual({ args: ['joker', -1, 2, 6] });
+  });
+
   it('returns error for joker with invalid suit', () => {
     const result = parseSevensCommand('j invalid 5');
     expect('error' in result).toBe(true);

--- a/frontend/src/utils/cli/commands/sevensCommands.ts
+++ b/frontend/src/utils/cli/commands/sevensCommands.ts
@@ -1,23 +1,9 @@
 import type { sevensApi } from '../../../api/gameApi';
 import { parseIntArg, splitCommand, suggestCommand } from '../commandParserBase';
+import { STANDARD_SUIT_MAP as SUIT_MAP } from '../suitMaps';
 import type { CliParseResult } from '../types';
 
 type SevensArgs = Parameters<typeof sevensApi.exec>;
-
-const SUIT_MAP: Record<string, number> = {
-  spade: 1,
-  spades: 1,
-  s: 1,
-  clover: 2,
-  clubs: 2,
-  c: 2,
-  heart: 3,
-  hearts: 3,
-  h: 3,
-  diamond: 4,
-  diamonds: 4,
-  d: 4,
-};
 
 const VALID_COMMANDS = ['p', 'play', 'j', 'joker', 'pass', 'r', 'reset', 'help', '?'];
 

--- a/frontend/src/utils/cli/suitMaps.test.ts
+++ b/frontend/src/utils/cli/suitMaps.test.ts
@@ -7,7 +7,11 @@ describe('STANDARD_SUIT_MAP', () => {
     expect(STANDARD_SUIT_MAP.spades).toBe(1);
     expect(STANDARD_SUIT_MAP.s).toBe(1);
     expect(STANDARD_SUIT_MAP.heart).toBe(3);
+    expect(STANDARD_SUIT_MAP.hearts).toBe(3);
+    expect(STANDARD_SUIT_MAP.h).toBe(3);
     expect(STANDARD_SUIT_MAP.diamond).toBe(4);
+    expect(STANDARD_SUIT_MAP.diamonds).toBe(4);
+    expect(STANDARD_SUIT_MAP.d).toBe(4);
   });
 
   // Regression for #2152: `club` (singular) used to be accepted only by Mighty
@@ -33,5 +37,25 @@ describe('BRIDGE_SUIT_MAP', () => {
     expect(BRIDGE_SUIT_MAP.spade).toBe(4);
     expect(BRIDGE_SUIT_MAP.notrump).toBe(5);
     expect(BRIDGE_SUIT_MAP.nt).toBe(5);
+  });
+
+  // #2152 review: every suit must accept its plural form and single-letter
+  // abbreviation, so the alias set matches STANDARD_SUIT_MAP everywhere.
+  it('accepts plural and abbreviated aliases for each suit', () => {
+    expect(BRIDGE_SUIT_MAP.clubs).toBe(1);
+    expect(BRIDGE_SUIT_MAP.c).toBe(1);
+    expect(BRIDGE_SUIT_MAP.diamonds).toBe(2);
+    expect(BRIDGE_SUIT_MAP.d).toBe(2);
+    expect(BRIDGE_SUIT_MAP.hearts).toBe(3);
+    expect(BRIDGE_SUIT_MAP.h).toBe(3);
+    expect(BRIDGE_SUIT_MAP.spades).toBe(4);
+    expect(BRIDGE_SUIT_MAP.s).toBe(4);
+  });
+
+  // #2152 review: `clover` (the JP-localized club alias) must also resolve in
+  // Bridge, matching STANDARD_SUIT_MAP — otherwise the PR would re-introduce
+  // the cross-game inconsistency it set out to remove.
+  it('accepts clover as a club alias', () => {
+    expect(BRIDGE_SUIT_MAP.clover).toBe(1);
   });
 });

--- a/frontend/src/utils/cli/suitMaps.test.ts
+++ b/frontend/src/utils/cli/suitMaps.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { BRIDGE_SUIT_MAP, STANDARD_SUIT_MAP } from './suitMaps';
+
+describe('STANDARD_SUIT_MAP', () => {
+  it('maps every alias of each suit to the same number', () => {
+    expect(STANDARD_SUIT_MAP.spade).toBe(1);
+    expect(STANDARD_SUIT_MAP.spades).toBe(1);
+    expect(STANDARD_SUIT_MAP.s).toBe(1);
+    expect(STANDARD_SUIT_MAP.heart).toBe(3);
+    expect(STANDARD_SUIT_MAP.diamond).toBe(4);
+  });
+
+  // Regression for #2152: `club` (singular) used to be accepted only by Mighty
+  // and rejected by the other standard-suit games, an inconsistent UX bug. The
+  // shared map now accepts club / clubs / clover uniformly.
+  it('accepts club, clubs, and clover as the same suit', () => {
+    expect(STANDARD_SUIT_MAP.club).toBe(2);
+    expect(STANDARD_SUIT_MAP.clubs).toBe(2);
+    expect(STANDARD_SUIT_MAP.clover).toBe(2);
+    expect(STANDARD_SUIT_MAP.c).toBe(2);
+  });
+
+  it('returns undefined for unknown tokens', () => {
+    expect(STANDARD_SUIT_MAP.bogus).toBeUndefined();
+  });
+});
+
+describe('BRIDGE_SUIT_MAP', () => {
+  it('uses bridge-specific ranking with no-trump highest', () => {
+    expect(BRIDGE_SUIT_MAP.club).toBe(1);
+    expect(BRIDGE_SUIT_MAP.diamond).toBe(2);
+    expect(BRIDGE_SUIT_MAP.heart).toBe(3);
+    expect(BRIDGE_SUIT_MAP.spade).toBe(4);
+    expect(BRIDGE_SUIT_MAP.notrump).toBe(5);
+    expect(BRIDGE_SUIT_MAP.nt).toBe(5);
+  });
+});

--- a/frontend/src/utils/cli/suitMaps.ts
+++ b/frontend/src/utils/cli/suitMaps.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared suit name/abbreviation → internal suit number maps for CLI command
+ * parsers.
+ *
+ * Historically each `*Commands.ts` parser declared its own local `SUIT_MAP`,
+ * which drifted: most games omitted the singular `club` alias that Mighty
+ * accepted, so `club` worked in one game but was rejected as an invalid
+ * command in others. Centralizing the canonical map here removes that
+ * inconsistency and gives a single place to add future aliases.
+ */
+
+/**
+ * Standard four-suit map (Spade=1, Club=2, Heart=3, Diamond=4).
+ *
+ * Accepts both `club` (singular) and `clubs`/`clover` so the alias set is
+ * uniform across every game that uses standard suit ordering.
+ */
+export const STANDARD_SUIT_MAP: Readonly<Record<string, number>> = {
+  spade: 1,
+  spades: 1,
+  s: 1,
+  club: 2,
+  clubs: 2,
+  clover: 2,
+  c: 2,
+  heart: 3,
+  hearts: 3,
+  h: 3,
+  diamond: 4,
+  diamonds: 4,
+  d: 4,
+} as const;
+
+/**
+ * Bridge-specific suit ranking (Club=1, Diamond=2, Heart=3, Spade=4, NT=5).
+ * This ordering is intentional and must not be merged with the standard map.
+ */
+export const BRIDGE_SUIT_MAP: Readonly<Record<string, number>> = {
+  club: 1,
+  clubs: 1,
+  c: 1,
+  diamond: 2,
+  diamonds: 2,
+  d: 2,
+  heart: 3,
+  hearts: 3,
+  h: 3,
+  spade: 4,
+  spades: 4,
+  s: 4,
+  notrump: 5,
+  nt: 5,
+} as const;

--- a/frontend/src/utils/cli/suitMaps.ts
+++ b/frontend/src/utils/cli/suitMaps.ts
@@ -38,6 +38,7 @@ export const STANDARD_SUIT_MAP: Readonly<Record<string, number>> = {
 export const BRIDGE_SUIT_MAP: Readonly<Record<string, number>> = {
   club: 1,
   clubs: 1,
+  clover: 1,
   c: 1,
   diamond: 2,
   diamonds: 2,


### PR DESCRIPTION
## Summary

Six CLI command parsers (`crazyeights`, `sevens`, `napoleon`, `euchre`, `macau`, `pinochle`) each carried a **byte-identical local `SUIT_MAP`** (DRY violation), and Mighty's copy had **drifted** to also accept the singular `club` alias. The result was a real, user-facing inconsistency: typing `club` parsed correctly in Mighty but was rejected as an invalid command in the other six games.

This PR extracts the shared map to a single SSoT and fixes the drift:

- New `frontend/src/utils/cli/suitMaps.ts`:
  - `STANDARD_SUIT_MAP` — now accepts `club` / `clubs` / `clover` **uniformly** (Spade=1, Club=2, Heart=3, Diamond=4).
  - `BRIDGE_SUIT_MAP` — Bridge's intentional ranking (Club=1…Spade=4, NT=5); kept separate, not force-merged.
- The 6 standard parsers + Bridge import from it; their local maps are deleted.
- **Mighty** keeps a local map that *layers* `joker` + no-trump on top of `STANDARD_SUIT_MAP` via spread (game-specific, single-use), so the four suit aliases are no longer duplicated.

### Scope note

Mighty's wrapper is genuinely game-specific (joker + NT) and single-use, so it stays local rather than getting a misnamed shared export — keeping `suitMaps.ts` to the maps that are actually shared.

## Test plan

- [x] `bun run check` — pass (biome + design tokens)
- [x] `bun run test` (affected parsers + new `suitMaps.test.ts`) — 100 tests pass, incl. new `club`/`clubs`/`clover` regression
- [ ] tsc build — gated by CI (tsc OOMs in this local environment; change has no type-surface impact)

Closes #2152