### PR TITLE
fix: replace opacity-suffixed tokens on state badges with opaque surfaces

### DIFF
--- a/frontend/src/components/AutoCompleteReadyBadge.tsx
+++ b/frontend/src/components/AutoCompleteReadyBadge.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { badgeSuccessColors } from '../styles/badgeStyles';
 
 /** Props for the AutoCompleteReadyBadge component. */
 export interface AutoCompleteReadyBadgeProps {
@@ -41,7 +42,7 @@ export function AutoCompleteReadyBadge({ ready, testId }: AutoCompleteReadyBadge
     <output
       aria-live="polite"
       data-testid={testId ?? 'autocomplete-ready-badge'}
-      className="inline-flex items-center gap-1 rounded-full bg-ds-success/20 px-2 py-0.5 text-xs font-semibold text-ds-success animate-pulse"
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold animate-pulse ${badgeSuccessColors}`}
     >
       <span aria-hidden="true">✨</span>
       {t('button.autoCompleteReady')}

--- a/frontend/src/components/BidProgressBar.tsx
+++ b/frontend/src/components/BidProgressBar.tsx
@@ -1,3 +1,5 @@
+import { badgeInfoColors } from '../styles/badgeStyles';
+
 /** Props for the BidProgressBar component. */
 export interface BidProgressBarProps {
   /** Bid amount declared by the player. Negative values render nothing. */
@@ -61,7 +63,7 @@ export function BidProgressBar({ bid, tricksWon, testId, ariaLabel }: BidProgres
         ))}
       </div>
       {overTricks > 0 && !nilBroken && (
-        <span className="rounded-full bg-ds-info/30 px-1.5 py-0 text-[10px] font-semibold leading-tight text-ds-info">
+        <span className={`rounded-full px-1.5 py-0 text-[10px] font-semibold leading-tight ${badgeInfoColors}`}>
           +{overTricks}
         </span>
       )}

--- a/frontend/src/components/PhaseIndicator.test.tsx
+++ b/frontend/src/components/PhaseIndicator.test.tsx
@@ -17,7 +17,7 @@ describe('PhaseIndicator', () => {
       'motion-safe:animate-pulse',
       'font-bold',
       'text-base',
-      'bg-ds-success/20',
+      'bg-ds-surface',
       'ring-2',
       'ring-ds-success/40',
       'px-2',

--- a/frontend/src/components/PhaseIndicator.tsx
+++ b/frontend/src/components/PhaseIndicator.tsx
@@ -29,7 +29,7 @@ export function PhaseIndicator({ phaseName, isHumanTurn, children }: PhaseIndica
         <span
           className={
             isHumanTurn
-              ? 'text-ds-success motion-safe:animate-pulse font-bold text-base bg-ds-success/20 ring-2 ring-ds-success/40 px-2 py-0.5 rounded-full'
+              ? 'text-ds-success motion-safe:animate-pulse font-bold text-base bg-ds-surface ring-2 ring-ds-success/40 px-2 py-0.5 rounded-full'
               : 'text-game-text-muted'
           }
         >

--- a/frontend/src/components/doubt/DoubtCpuArea.tsx
+++ b/frontend/src/components/doubt/DoubtCpuArea.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { badgeWarningColors } from '../../styles/badgeStyles';
 import { playerAreaBase } from '../../styles/gameStyles';
 import type { DoubtPlayerData } from '../../types/card';
 import { CpuTurnArea } from '../CpuTurnArea';
@@ -43,7 +44,9 @@ export function DoubtCpuArea({
           <span aria-hidden="true" className="animate-eye-dart text-lg leading-none">
             👀
           </span>
-          <span className="rounded-full bg-ds-warning/30 px-1.5 py-0 text-[10px] font-semibold leading-tight text-ds-warning motion-safe:animate-pulse">
+          <span
+            className={`rounded-full px-1.5 py-0 text-[10px] font-semibold leading-tight motion-safe:animate-pulse ${badgeWarningColors}`}
+          >
             {t('tellBadge')}
           </span>
         </div>

--- a/frontend/src/pages/ContractRummyPage.tsx
+++ b/frontend/src/pages/ContractRummyPage.tsx
@@ -242,7 +242,7 @@ function ContractRummyPageContent() {
             return (
               <span
                 key={`slot-${slotIdx}`}
-                className={`px-2 py-1 rounded border ${color}`}
+                className={`px-2 py-1 rounded ${color}`}
                 data-testid={`cr-slot-progress-${slotIdx}`}
                 data-state={ev.satisfied ? 'satisfied' : ev.invalid ? 'invalid' : ev.placed === 0 ? 'empty' : 'partial'}
               >

--- a/frontend/src/pages/ContractRummyPage.tsx
+++ b/frontend/src/pages/ContractRummyPage.tsx
@@ -14,6 +14,7 @@ import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { badgeErrorColors, badgeSuccessColors, badgeWarningColors } from '../styles/badgeStyles';
 import { btnDanger, btnOutline, btnPrimary, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { Card, ContractRummyContractSlot, ContractRummyResponse } from '../types/card';
@@ -232,12 +233,12 @@ function ContractRummyPageContent() {
           {state.contractSlots.map((slot, slotIdx) => {
             const ev = slotEvaluations[slotIdx] ?? { placed: 0, required: slot.size, satisfied: false, invalid: false };
             const color = ev.satisfied
-              ? 'bg-ds-success/20 border-ds-success text-ds-success'
+              ? badgeSuccessColors
               : ev.invalid
-                ? 'bg-ds-error/20 border-ds-error text-ds-error'
+                ? badgeErrorColors
                 : ev.placed === 0
-                  ? 'bg-black/20 border-white/30 text-ds-text-muted'
-                  : 'bg-ds-warning/20 border-ds-warning text-ds-warning';
+                  ? 'bg-black/20 border border-white/30 text-ds-text-muted'
+                  : badgeWarningColors;
             return (
               <span
                 key={`slot-${slotIdx}`}

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -29,6 +29,7 @@ import { useDaifugoGame } from '../hooks/useDaifugoGame';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSound } from '../providers/SoundProvider';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -289,7 +290,7 @@ function DaifugoPageContent() {
 
             {pendingBanner && (
               <div
-                className="bg-ds-warning/80 rounded-[10px] text-white text-center py-2 px-4 text-sm font-bold my-2"
+                className={`${badgeWarningColors} rounded-[10px] text-center py-2 px-4 text-sm font-bold my-2`}
                 data-tutorial="df-special-actions"
               >
                 {pendingBanner}

--- a/frontend/src/pages/HeartsPage.tsx
+++ b/frontend/src/pages/HeartsPage.tsx
@@ -23,6 +23,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useHeartsGame } from '../hooks/useHeartsGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { badgeErrorColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -482,7 +483,7 @@ function ShootTheMoonBadge({ label }: { label: string }) {
       data-testid="hearts-shoot-the-moon-badge"
       role="status"
       aria-live="polite"
-      className="ml-2 inline-flex items-center gap-1 rounded-full bg-ds-error/30 px-2 py-0.5 text-xs font-bold text-ds-error motion-safe:animate-pulse"
+      className={`ml-2 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-bold motion-safe:animate-pulse ${badgeErrorColors}`}
     >
       <span aria-hidden="true">🌕</span>
       {label}

--- a/frontend/src/pages/PageOnePage.tsx
+++ b/frontend/src/pages/PageOnePage.tsx
@@ -22,6 +22,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, usePageOneGame } from '../hooks/usePageOneGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess, btnWarning } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
@@ -262,7 +263,7 @@ function PageOnePageContent() {
                           {cpuAtOne && (
                             <span
                               data-testid={`po-cpu-${p.id}-last-card-badge`}
-                              className="ml-2 inline-flex items-center gap-1 px-2 py-0.5 rounded bg-ds-warning/30 text-ds-warning text-xs font-bold"
+                              className={`ml-2 inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-bold ${badgeWarningColors}`}
                             >
                               <span
                                 aria-hidden="true"
@@ -309,7 +310,7 @@ function PageOnePageContent() {
                 role="alert"
                 aria-live="assertive"
                 data-testid="po-last-card-banner"
-                className="mb-2 px-3 py-2 rounded bg-ds-warning/20 border-2 border-ds-warning text-ds-warning text-sm font-bold flex items-center gap-2"
+                className="mb-2 px-3 py-2 rounded bg-ds-surface border-2 border-ds-warning text-ds-warning text-sm font-bold flex items-center gap-2"
               >
                 <span aria-hidden="true" className="inline-block w-2 h-2 rounded-full bg-ds-warning animate-pulse" />
                 {t('lastCardBanner')}

--- a/frontend/src/pages/PigsTailPage.tsx
+++ b/frontend/src/pages/PigsTailPage.tsx
@@ -18,6 +18,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { badgeErrorColors } from '../styles/badgeStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { PigsTailResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
@@ -204,7 +205,7 @@ function PigsTailPageContent() {
                 {state.cpuActions.map((action, i) => (
                   <div
                     key={i}
-                    className={`text-xs px-2 py-1 rounded ${action.penaltyFlag ? 'bg-ds-error/40 text-ds-error/80' : 'bg-black/30 text-ds-text-muted'}`}
+                    className={`text-xs px-2 py-1 rounded ${action.penaltyFlag ? badgeErrorColors : 'bg-black/30 text-ds-text-muted'}`}
                   >
                     CPU {action.drawPlayerIdx}:{' '}
                     {action.drawnCard ? (SUIT_SYMBOLS[action.drawnCard.design] ?? '?') + action.drawnCard.value : '?'}

--- a/frontend/src/pages/PiquetPage.test.tsx
+++ b/frontend/src/pages/PiquetPage.test.tsx
@@ -137,6 +137,40 @@ describe('PiquetPage', () => {
       }),
     );
     renderWithProviders(<PiquetPage />);
-    await waitFor(() => expect(screen.getByTestId('piquet-meld-badge')).toBeInTheDocument());
+    const wonBadge = await screen.findByTestId('piquet-meld-badge');
+    // Human (elder, idx 0) was scoredBy:0 above → won → success palette.
+    expect(wonBadge).toHaveClass('text-ds-success', 'border-ds-success');
+  });
+
+  it('shows the meld badge in the lost palette when the opponent scores', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: PiquetPhase.DECLARATION,
+        declStage: PiquetDeclarationKind.SEQUENCE,
+        declResults: [
+          {
+            kind: PiquetDeclarationKind.POINT,
+            elderClaim: {
+              length: 2,
+              topRank: 13,
+              pipTotal: 21,
+              suit: 0,
+              cards: [
+                { design: 'SPADE', value: 13 },
+                { design: 'HEART', value: 1 },
+              ],
+            },
+            youngerClaim: { length: 0, topRank: 0, pipTotal: 0, suit: 0, cards: [] },
+            winner: 1,
+            scoredBy: 1,
+            score: 2,
+          },
+        ],
+      }),
+    );
+    renderWithProviders(<PiquetPage />);
+    const lostBadge = await screen.findByTestId('piquet-meld-badge');
+    // scoredBy:1 (younger) → human lost → error palette (border signal, readable text).
+    expect(lostBadge).toHaveClass('text-ds-text-primary', 'border-ds-error');
   });
 });

--- a/frontend/src/pages/PiquetPage.tsx
+++ b/frontend/src/pages/PiquetPage.tsx
@@ -7,6 +7,7 @@ import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePiquetGame } from '../hooks/usePiquetGame';
+import { badgeErrorColors, badgeSuccessColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { Card, PiquetDeclaration, PiquetPlayerData, PiquetResponse } from '../types/card';
@@ -176,7 +177,7 @@ function PiquetPageContent() {
               <span
                 data-testid="piquet-meld-badge"
                 className={`rounded px-2 py-0.5 text-xs font-bold ${
-                  activeHighlight.won ? 'bg-ds-success/30 text-ds-success' : 'bg-ds-error/30 text-ds-error'
+                  activeHighlight.won ? badgeSuccessColors : badgeErrorColors
                 }`}
               >
                 {t(activeHighlight.won ? 'meldWonBadge' : 'meldLostBadge', {

--- a/frontend/src/pages/ShitheadPage.tsx
+++ b/frontend/src/pages/ShitheadPage.tsx
@@ -16,6 +16,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useShitheadGame } from '../hooks/useShitheadGame';
+import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { Card, CardDesign, ShitheadConfig, ShitheadResponse } from '../types/card';
@@ -168,7 +169,7 @@ function ShitheadPageContent() {
                             data-testid="sh-discard-magic-badge"
                             data-magic-rank={topValue}
                             title={title || undefined}
-                            className="inline-flex items-center rounded-full bg-ds-warning/30 px-1.5 py-0 text-xs leading-tight text-ds-warning motion-safe:animate-pulse"
+                            className={`inline-flex items-center rounded-full px-1.5 py-0 text-xs leading-tight motion-safe:animate-pulse ${badgeWarningColors}`}
                           >
                             {badge}
                           </span>

--- a/frontend/src/styles/badgeStyles.ts
+++ b/frontend/src/styles/badgeStyles.ts
@@ -16,40 +16,68 @@
  * pulses) remain allowed; this file is specifically for state badges.
  */
 
-const BADGE_BASE = 'rounded-lg py-2 px-3.5 text-xs border';
+const BADGE_SIZE = 'rounded-lg py-2 px-3.5 text-xs';
 
 /**
- * Neutral info badge — surface bg, primary text, subtle border.
+ * Opaque color tokens (1px border + surface bg + token foreground + token
+ * border) for an **info** state badge that needs custom sizing.
+ *
+ * Combine with your own `rounded-*` / padding / `text-*` classes for compact
+ * inline pills, where the full {@link badgeInfo} (which forces `rounded-lg
+ * py-2 px-3.5`) would be too large. The contrast guarantees are identical.
  *
  * Intentionally uses `text-ds-text-primary` (10.1:1 AAA on surface) rather
  * than `text-ds-info`: the info token (#5B8FB9) hits only ~4.5:1 on the
- * surface background, right at the AA boundary, so we lean on the
- * border-coloured `border-ds-info` would have given for semantic signal
- * is replaced by `border-ds-border-subtle` — info badges read as quiet
- * notifications, not warnings.
+ * surface background, right at the AA boundary, so the semantic signal comes
+ * from the subtle border while the text stays fully readable.
  */
-export const badgeInfo = `${BADGE_BASE} bg-ds-surface text-ds-text-primary border-ds-border-subtle`;
+export const badgeInfoColors = 'border bg-ds-surface text-ds-text-primary border-ds-border-subtle';
 
 /**
- * Success badge — surface bg, success text (5.8:1 AA on surface) + matching
- * border. Use for "round won", "auto-go", or other positive confirmations.
+ * Opaque color tokens for a **success** state badge that needs custom sizing.
+ * Success text is 5.8:1 (AA) on the surface background. See
+ * {@link badgeInfoColors} for usage.
  */
-export const badgeSuccess = `${BADGE_BASE} bg-ds-surface text-ds-success border-ds-success`;
+export const badgeSuccessColors = 'border bg-ds-surface text-ds-success border-ds-success';
 
 /**
- * Warning badge — surface bg, warning text (6.3:1 AA on surface) + matching
- * border. Use for "forced", "involuntary", or "restricted" states.
+ * Opaque color tokens for a **warning** state badge that needs custom sizing.
+ * Warning text is 6.3:1 (AA) on the surface background. See
+ * {@link badgeInfoColors} for usage.
  */
-export const badgeWarning = `${BADGE_BASE} bg-ds-surface text-ds-warning border-ds-warning`;
+export const badgeWarningColors = 'border bg-ds-surface text-ds-warning border-ds-warning';
 
 /**
- * Error badge — surface bg, primary text (10.1:1 AAA on surface) + error
- * border. Use for "fold", "out", "bust", or error notifications.
+ * Opaque color tokens for an **error** state badge that needs custom sizing.
  *
- * Foreground is intentionally `text-ds-text-primary` rather than
- * `text-ds-error`: the error token (#B83A3A) only hits ~2.7:1 on the
- * surface background — well below WCAG AA — so the semantic signal
- * comes entirely from the coloured border while the message stays
- * fully readable.
+ * Foreground is intentionally `text-ds-text-primary` (10.1:1 AAA on surface)
+ * rather than `text-ds-error`: the error token (#B83A3A) only hits ~2.7:1 on
+ * the surface background — well below WCAG AA — so the semantic signal comes
+ * entirely from the coloured border while the message stays fully readable.
+ * See {@link badgeInfoColors} for usage.
  */
-export const badgeError = `${BADGE_BASE} bg-ds-surface text-ds-text-primary border-ds-error`;
+export const badgeErrorColors = 'border bg-ds-surface text-ds-text-primary border-ds-error';
+
+/**
+ * Neutral info badge — surface bg, primary text, subtle border. Use for quiet
+ * notifications. For compact inline pills use {@link badgeInfoColors}.
+ */
+export const badgeInfo = `${BADGE_SIZE} ${badgeInfoColors}`;
+
+/**
+ * Success badge — surface bg, success text + matching border. Use for "round
+ * won", "auto-go", or other positive confirmations.
+ */
+export const badgeSuccess = `${BADGE_SIZE} ${badgeSuccessColors}`;
+
+/**
+ * Warning badge — surface bg, warning text + matching border. Use for
+ * "forced", "involuntary", or "restricted" states.
+ */
+export const badgeWarning = `${BADGE_SIZE} ${badgeWarningColors}`;
+
+/**
+ * Error badge — surface bg, primary text + error border. Use for "fold",
+ * "out", "bust", or error notifications.
+ */
+export const badgeError = `${BADGE_SIZE} ${badgeErrorColors}`;


### PR DESCRIPTION
## Summary

Several state badges mixed Tailwind opacity suffixes with design tokens (`bg-ds-{state}/NN` + `text-ds-{state}`). On the game-table felt backgrounds the effective color depends on whatever sits beneath, dropping these badges below WCAG AA contrast — the exact pattern DESIGN.md's **Opacity rule** forbids and `badgeStyles.ts` already exists to prevent. (The automated `check-design-tokens` script only flags raw Tailwind palette, not `bg-ds-*/NN`, so these slipped through.)

## Changes

**`badgeStyles.ts`** — add color-only token constants `badge{Info,Success,Warning,Error}Colors` (opaque `bg-ds-surface` + token foreground + token border, no sizing) so compact inline pills can adopt the safe combo without inheriting the full helper's fixed `rounded-lg py-2 px-3.5` sizing. The existing `badge*` helpers now compose from them (no behavior change).

**Converted meaningful state badges/banners** (from the issue's confirmed list):
- `PigsTailPage` — penalty badge (was the worst case: opacity on the text token itself, `text-ds-error/80`)
- `ContractRummyPage` — won/invalid/waiting slot states
- `BidProgressBar` — overtrick `+N` pill
- `DoubtCpuArea` — CPU tell badge
- `PhaseIndicator` — "your turn" indicator (meaningful bg → `bg-ds-surface`; decorative pulse ring kept)
- `AutoCompleteReadyBadge` — `aria-live` ready badge
- `PiquetPage` — meld won/lost highlight
- `PageOnePage` — last-card badge **and** the sibling `role="alert"` banner
- `ShitheadPage` — pass-wait badge
- `HeartsPage` — shoot-the-moon `role="status"` badge
- `DaifugoPage` — pending-action banner (explicitly called out in the issue)

**Left unchanged (decorative, per DESIGN.md and the issue's pendulum-effect caveat):** turn-emphasis rings/pulses, the full-screen penalty flash, player-row/selection tints, and glassmorphism.

## Test plan

- [x] `bun run check` — pass (biome + design-token policy)
- [x] `bun run test` for all touched components/pages — pass (incl. updated `PhaseIndicator` class assertion)
- [ ] tsc build — gated by CI (tsc OOMs in this local environment; changes are className-only with no type-surface impact)

Closes #2151