### PR TITLE
chore: add game-improve skill for per-game improvement issue batches

### DIFF
--- a/.claude/skills/game-improve/SKILL.md
+++ b/.claude/skills/game-improve/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: game-improve
+version: 1.0.0
+description: Generate ONE high-impact improvement proposal per card game (from real Page.tsx + CuiPresenter code) and open each as a GitHub issue. Use for "各ゲームの改善提案", "全ゲームのissueを作って", per-game UX-assist batches.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - Agent
+  - AskUserQuestion
+triggers:
+  - 各ゲームの改善提案
+  - ゲームの改善提案をissueに
+  - 全ゲームのissue
+  - per-game improvement issues
+  - game improvement batch
+---
+
+# game-improve — per-game improvement proposals → GitHub issues
+
+Codifies the 2026-06-07 batch that produced issues **#2161–#2292** (one
+proposal per game across all 132 games). Reuse it whenever the user wants
+per-game improvement proposals turned into GitHub issues.
+
+## What it produces
+
+For each in-scope game: ONE highest-impact, **code-grounded** improvement
+(named files / phases / components — never generic "add tests"), opened as a
+GitHub issue with the body template:
+
+```
+## 背景・現状
+## 提案
+## 受け入れ条件   (- [ ] checklist)
+## 対象ファイル   (`path` list)
+```
+
+Titles are Japanese with a bracket tag: `[UI/UX]` `[機能]` `[アクセシビリティ]`
+`[CUI]` `[i18n]` + the game's Japanese name in parentheses.
+
+## Decide scope first (AskUserQuestion unless the user already said)
+
+1. **対象範囲** — all games / one category (casino|classic|solo) / explicit list /
+   only games without an existing improvement issue.
+2. **提案数/game** — default 1 (most effective). 2–3 → one issue each.
+3. **作成タイミング** — immediate (`gh issue create` now) vs draft-then-confirm.
+4. (Skip skillify question — this *is* the skill.)
+
+## Workflow
+
+### 1. Canonical game list (SSoT)
+Read `internal/infrastructure/games/registry.go`. Each entry is
+`{Name, Category, Description}`. Name = short slug + URL segment; Description
+carries the Japanese name. There are 132 games as of 2026-06; never hardcode the
+count — derive it from the registry. `go run ./cmd/trumpcards games --short` also
+lists names.
+
+### 2. Dedupe against open issues
+`gh issue list --state open --limit 400 --json number,title`. Skip games that
+already have a comparable open improvement issue. (Most past per-game issues are
+closed/merged, so collisions are rare.)
+
+### 3. Fan out READ-ONLY analysis agents
+Chunk the in-scope games into groups of ~16. Launch one `general-purpose`
+**sonnet** agent per group **in a single message** (parallel). Per-agent prompt
+must enforce:
+
+- **HARD RULE: no build/test/lint/tsc/go test/bun — Read/Grep/Glob only.**
+  Builds OOM this ~2 GB box (see memory `feedback_sequential_tasks`). Reading is
+  light, so parallel read-only agents are RAM-safe.
+- For each game: read `frontend/src/pages/<PascalCase>Page.tsx` and
+  `internal/adapter/presenter/<PascalCase>CuiPresenter.go` (glob for casing);
+  optionally the hook/components or `docs/manual/web/<game>.md`.
+- Output ONE proposal/game (or N if scope said so) to
+  `/tmp/claude-proposals/group-<n>.json` as a JSON array of
+  `{game,title,body}`. Body ~120–220 words, valid JSON (escape newlines).
+- Return only a one-line count; the file is the real payload (keeps the
+  orchestrator's context lean).
+
+Map PascalCase from the slug if needed (e.g. `bigtwo`→`BigTwo`,
+`seahaventowers`→`SeahavenTowers`, `ohhell`→`OhHell`).
+
+### 4. Validate + merge
+```sh
+cd /tmp/claude-proposals
+for f in group-*.json; do jq -e . "$f" >/dev/null && echo "$f OK $(jq length $f)" || echo "$f BAD"; done
+jq -s 'add' group-*.json > all.json
+jq 'length' all.json                                   # == in-scope count
+jq -s 'add|map(select(.game==null or .title==null or .body==null))|length' group-*.json   # == 0
+jq -s 'add|group_by(.game)|map(select(length>1))|map(.[0].game)' group-*.json             # == []
+```
+Spot-check one full body for quality (real file names, concrete phase).
+
+### 5. Create issues (idempotent, rate-limit-safe)
+Use `scripts/create_issues.sh` (in this skill dir). It:
+- creates one issue per `all.json` element via `gh issue create --body-file`,
+- appends a `対象ゲーム` footer,
+- logs `game\turl\ttitle` to `created.log` and **skips already-logged games on
+  rerun** (resumable if it dies mid-batch),
+- `sleep 3` between creates (~20/min) to dodge GitHub's secondary
+  content-creation rate limit. 132 issues ≈ 7 min — run in background.
+
+Verify gh first: `gh auth status`. Repo has **no custom labels** → create without
+`--label` (passing a missing label errors the whole call).
+
+For draft mode: render `all.json` to the user as a table and stop before step 5.
+
+### 6. Verify + report
+```sh
+comm -23 <(jq -r '.[].game' all.json|sort) <(cut -f1 created.log|sort)   # missing games (want empty)
+wc -l created.log ; [ -s errors.log ] && cat errors.log
+```
+Report issue-number range, per-category counts, and the recurring-gap themes.
+Record the batch in project memory (`project_issues_<lo>_<hi>_improvements`) and
+add a one-line MEMORY.md pointer, mirroring `project_issues_2161_2292_improvements`.
+
+## Notes / gotchas
+- Agent tool has **no schema option** (that's Workflow). Enforce JSON shape in the
+  prompt and validate with `jq` after.
+- Do NOT use the Workflow tool here unless the user explicitly opts into
+  multi-agent orchestration ("ultracode" / "use a workflow"). Plain `Agent`
+  fan-out is the default.
+- Frontend page = `frontend/src/pages/`, CUI presenter = `internal/adapter/presenter/`.
+- Body files are reused per-iteration at `/tmp/claude-proposals/body.md`; the
+  script overwrites it each loop — safe because it writes-then-creates serially.

--- a/.claude/skills/game-improve/scripts/create_issues.sh
+++ b/.claude/skills/game-improve/scripts/create_issues.sh
@@ -3,13 +3,14 @@
 # proposals JSON (array of {game,title,body}).
 #
 # Usage:
-#   SRC=/tmp/claude-proposals/all.json REPO_DIR=/home/yuta/work/go_trumpcards \
+#   SRC=/tmp/claude-proposals/all.json REPO_DIR=/path/to/repo \
 #     bash create_issues.sh
 # Run in the background; ~3s/issue. Rerun to resume (skips already-created games).
 set -uo pipefail
 
-REPO_DIR="${REPO_DIR:-/home/yuta/work/go_trumpcards}"
+REPO_DIR="${REPO_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 SRC="${SRC:-/tmp/claude-proposals/all.json}"
+[[ "$SRC" = /* ]] || SRC="$PWD/$SRC"   # absolutize before the cd below
 WORKDIR="$(dirname "$SRC")"
 LOG="$WORKDIR/created.log"
 ERR="$WORKDIR/errors.log"
@@ -20,14 +21,15 @@ cd "$REPO_DIR"
 touch "$LOG" "$ERR"
 
 command -v jq >/dev/null || { echo "jq required" >&2; exit 1; }
+command -v gh >/dev/null || { echo "gh CLI required" >&2; exit 1; }
 gh auth status >/dev/null 2>&1 || { echo "gh not authenticated" >&2; exit 1; }
 jq -e . "$SRC" >/dev/null 2>&1 || { echo "invalid JSON: $SRC" >&2; exit 1; }
 
 n=$(jq 'length' "$SRC")
 echo "Creating $n issues from $SRC (sleep ${SLEEP}s)..."
-for i in $(seq 0 $((n-1))); do
+for ((i=0; i<n; i++)); do
   game=$(jq -r ".[$i].game" "$SRC")
-  if grep -q "^${game}	" "$LOG" 2>/dev/null; then
+  if grep -q "^${game}"$'\t' "$LOG" 2>/dev/null; then
     echo "[$((i+1))/$n] $game — already created, skip"
     continue
   fi

--- a/.claude/skills/game-improve/scripts/create_issues.sh
+++ b/.claude/skills/game-improve/scripts/create_issues.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# game-improve: idempotent, rate-limit-safe GitHub issue creation from a merged
+# proposals JSON (array of {game,title,body}).
+#
+# Usage:
+#   SRC=/tmp/claude-proposals/all.json REPO_DIR=/home/yuta/work/go_trumpcards \
+#     bash create_issues.sh
+# Run in the background; ~3s/issue. Rerun to resume (skips already-created games).
+set -uo pipefail
+
+REPO_DIR="${REPO_DIR:-/home/yuta/work/go_trumpcards}"
+SRC="${SRC:-/tmp/claude-proposals/all.json}"
+WORKDIR="$(dirname "$SRC")"
+LOG="$WORKDIR/created.log"
+ERR="$WORKDIR/errors.log"
+BODY="$WORKDIR/body.md"
+SLEEP="${SLEEP:-3}"          # seconds between creates (secondary-rate-limit safety)
+
+cd "$REPO_DIR"
+touch "$LOG" "$ERR"
+
+command -v jq >/dev/null || { echo "jq required" >&2; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "gh not authenticated" >&2; exit 1; }
+jq -e . "$SRC" >/dev/null 2>&1 || { echo "invalid JSON: $SRC" >&2; exit 1; }
+
+n=$(jq 'length' "$SRC")
+echo "Creating $n issues from $SRC (sleep ${SLEEP}s)..."
+for i in $(seq 0 $((n-1))); do
+  game=$(jq -r ".[$i].game" "$SRC")
+  if grep -q "^${game}	" "$LOG" 2>/dev/null; then
+    echo "[$((i+1))/$n] $game — already created, skip"
+    continue
+  fi
+  title=$(jq -r ".[$i].title" "$SRC")
+  jq -r ".[$i].body" "$SRC" > "$BODY"
+  printf '\n\n---\n_対象ゲーム: `%s`。ゲーム改善提案バッチにより自動起票。_\n' "$game" >> "$BODY"
+  url=$(gh issue create --title "$title" --body-file "$BODY" 2>>"$ERR")
+  if [ -n "$url" ]; then
+    printf '%s\t%s\t%s\n' "$game" "$url" "$title" >> "$LOG"
+    echo "[$((i+1))/$n] $game -> $url"
+  else
+    echo "[$((i+1))/$n] $game -> FAILED (see $ERR)"
+  fi
+  sleep "$SLEEP"
+done
+echo "DONE. created=$(wc -l < "$LOG")"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,3 +244,4 @@ Key routing rules:
 - Architecture review → invoke plan-eng-review
 - Save progress, checkpoint, resume → invoke checkpoint
 - Code quality, health check → invoke health
+- Per-game improvement proposals → GitHub issues ("各ゲームの改善提案", "全ゲームのissueを作って") → invoke game-improve


### PR DESCRIPTION
## 概要

各ゲームの改善提案を GitHub issue として一括起票するワークフローを再利用可能なローカルスキル `game-improve` として追加します。本日 issue #2161–#2292（全132ゲーム × 1提案）を作成した手順をそのまま汎用化したものです。

## 内容
- `.claude/skills/game-improve/SKILL.md` — スコープ確認 → registry SSoT → 既存issue重複排除 → 読み取り専用 sonnet エージェント並列分析（各ゲームの実 `Page.tsx` + `CuiPresenter.go` を読む / ビルド・テスト禁止で OOM 回避）→ jq 検証 → issue 一括作成 → 検証・報告・メモリ記録
- `.claude/skills/game-improve/scripts/create_issues.sh` — 冪等（created.log で再開可能）・GitHub 二次レート制限安全（sleep 3）な `gh issue create` ループ
- `CLAUDE.md` — Skill routing に発見用ポインタを1行追加

## 補足
- このリポジトリ固有（registry.go / frontend 規約に依存）だが、同じリポジトリで作業する他マシン・メンバーが再利用できるためコミット
- 既存の `.claude/skills/*`（gstack のローカル symlink 群）は未追跡のまま。本スキルディレクトリのみ明示的に追跡

## テスト
- `bash -n scripts/create_issues.sh` 構文チェック済み
- 実運用での実証: 本日の #2161–#2292（132件・欠落0・エラー0）がこのフローの出力