### PR TITLE
chore: add propose-games skill for new-game candidate issue batches

### DIFF
--- a/.claude/skills/game-improve/scripts/create_issues.sh
+++ b/.claude/skills/game-improve/scripts/create_issues.sh
@@ -18,6 +18,7 @@ BODY="$WORKDIR/body.md"
 SLEEP="${SLEEP:-3}"          # seconds between creates (secondary-rate-limit safety)
 
 cd "$REPO_DIR"
+mkdir -p "$WORKDIR"
 touch "$LOG" "$ERR"
 
 command -v jq >/dev/null || { echo "jq required" >&2; exit 1; }
@@ -34,10 +35,9 @@ for ((i=0; i<n; i++)); do
     continue
   fi
   title=$(jq -r ".[$i].title" "$SRC")
-  jq -r ".[$i].body" "$SRC" > "$BODY"
+  jq -r ".[$i].body" "$SRC" > "$BODY" || { echo "[$((i+1))/$n] $game -> jq extract failed, skip" >&2; continue; }
   printf '\n\n---\n_対象ゲーム: `%s`。ゲーム改善提案バッチにより自動起票。_\n' "$game" >> "$BODY"
-  url=$(gh issue create --title "$title" --body-file "$BODY" 2>>"$ERR")
-  if [ -n "$url" ]; then
+  if url=$(gh issue create --title "$title" --body-file "$BODY" 2>>"$ERR"); then
     printf '%s\t%s\t%s\n' "$game" "$url" "$title" >> "$LOG"
     echo "[$((i+1))/$n] $game -> $url"
   else

--- a/.claude/skills/propose-games/SKILL.md
+++ b/.claude/skills/propose-games/SKILL.md
@@ -48,6 +48,7 @@ example):
 
 ### 1. Enumerate existing games (dedup source of truth)
 ```sh
+mkdir -p /tmp/newgames
 grep -oE '\{Name: "[^"]+"' internal/infrastructure/games/registry.go \
   | sed -E 's/.*"([^"]+)"/\1/' | sort > /tmp/newgames/existing.txt
 ```

--- a/.claude/skills/propose-games/SKILL.md
+++ b/.claude/skills/propose-games/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: propose-games
+version: 1.0.0
+description: Propose NEW card games worth adding to go_trumpcards (deduped against the registry) and open each as a "<Game> の追加" GitHub issue. Use for "追加した方が良いゲームを提案", "新規ゲーム候補をissueに".
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - Agent
+  - AskUserQuestion
+triggers:
+  - 追加した方が良いゲーム
+  - 新規ゲームを提案
+  - 追加候補のゲーム
+  - propose new games
+  - new game candidates
+---
+
+# propose-games — new-game candidates → GitHub issues
+
+Sibling of [[game-improve]]. game-improve improves the 132 existing games;
+**propose-games proposes games that are NOT yet implemented** and opens one
+new-game issue per candidate. Codifies the 2026-06-07 batch (45 candidates).
+
+## Output shape
+
+One issue per candidate, titled `<English name> (<日本語名>) の追加`, body in the
+repo's established new-game format (see issue #2013 Bourré as the canonical
+example):
+
+```
+## 概要 (Overview)
+## 背景と追加のメリット (Context & Why add this?)   (bullets: distinct mechanic / region / feasibility)
+## 仕様案 (Requirements)                          (カテゴリ(バケット) / 人数 / デッキ / 主要ルール 4-6 steps)
+## 実装のポイント (Implementation Details)          (reuse hint + new domain + checklist reminder)
+```
+
+## Decide scope first (AskUserQuestion unless already stated)
+
+1. **候補数** — ~15 (curated) / ~25 / 40+ / 任せる.
+2. **デッキ範囲** — standard decks only (52/54, Latin 40, pinochle 48) **or**
+   special decks allowed (78-card tarot, 48-card hanafuda, etc.).
+
+## Workflow
+
+### 1. Enumerate existing games (dedup source of truth)
+```sh
+grep -oE '\{Name: "[^"]+"' internal/infrastructure/games/registry.go \
+  | sed -E 's/.*"([^"]+)"/\1/' | sort > /tmp/newgames/existing.txt
+```
+This is the **only** authoritative dedup list — never propose a slug already in it.
+
+### 2. Curate candidates (do this yourself — it's the value)
+Pick real, notable card games across diverse buckets so the batch isn't lopsided:
+trick-taking (regional: German Sheepshead/Doppelkopf, Spanish Mus/Tute, Italian
+Scopone, Czech Mariáš…), rummy/melding (Hand and Foot, Conquian, Chinchón),
+shedding/reflex (Mao, Spoons, Kemps), fishing (Pişti, Cuarenta), casino/vying
+(Three Card Brag, Teen Patti, Five Card Stud, Faro, OFC), solitaire (Russian Bank,
+La Belle Lucie, Simple Simon, Double Klondike, Black Hole), and — if special decks
+are in scope — French Tarot, Koi-Koi, Go-Stop. Watch near-duplicates: `threecard`
+= Three Card *Poker* (≠ Three Card Brag); `chinesepoker` = closed (≠ OFC); `scopa`
+(≠ Scopone); `cassino` (≠ Pişti); `klondike` (≠ Double Klondike).
+
+Write a seed JSON `/tmp/newgames/seeds.json` — array of
+`{slug, jp, en, origin, deck, players, mechanic, reuse, bucket}`. `reuse` =
+the existing game/component to model after (this is what makes proposals
+implementable, not hand-wavy). `bucket` recommendation: **classic worker is at
+the 1 MB gzip limit (#2126) → route new games to `casino` or `solo` only.**
+
+Then verify zero collisions:
+```sh
+comm -12 <(jq -r '.[].slug' /tmp/newgames/seeds.json|sort -u) /tmp/newgames/existing.txt   # must be empty
+```
+
+### 3. Fan out body-writer agents (READ-ONLY)
+Split seeds into groups of ~9; launch one `general-purpose` **sonnet** agent per
+group in a single message. Each reads its `seedgroup-<n>.json`, expands every seed
+into `{game,title,body}` following the template above, writes
+`/tmp/newgames/group-<n>.json`. Enforce: **no build/test/lint/go/bun** (Read/Grep
+/Glob only — OOM safety, see memory `feedback_sequential_tasks`); rules-accurate;
+~180–280 word bodies; special decks (tarot/hanafuda) must call out a NEW non-52
+Card/Deck domain type; social/real-time games (Mao/Spoons/Kemps) must describe a
+concrete 1-human-vs-CPU adaptation.
+
+### 4. Validate + merge
+```sh
+cd /tmp/newgames
+jq -s 'add' group-*.json > all.json
+jq 'length' all.json                                                       # == candidate count
+jq -s 'add|map(select(.game==null or .title==null or .body==null))|length' group-*.json   # == 0
+jq -s 'add|group_by(.game)|map(select(length>1))|length' group-*.json      # == 0
+comm -12 <(jq -r '.[].game' all.json|sort) /tmp/newgames/existing.txt      # == empty (re-check dedup)
+```
+Spot-check one body for rule accuracy + the special-deck/social callouts.
+
+### 5. Create issues
+`FOOTER='...' SRC=/tmp/newgames/all.json bash scripts/create_issues.sh` (in this
+skill dir). Idempotent (skips games already in `created.log`), `sleep 3` between
+creates (GitHub secondary-rate-limit safety), `--body-file`, no `--label` (repo
+has none). Run in background; ~3s/issue. For draft mode, render `all.json` as a
+table and stop.
+
+### 6. Verify + report + remember
+```sh
+comm -23 <(jq -r '.[].game' all.json|sort) <(cut -f1 created.log|sort)   # missing (want empty)
+[ -s errors.log ] && cat errors.log
+```
+Report the issue-number range, per-bucket counts, and category spread. Record the
+batch in project memory and add a MEMORY.md pointer.
+
+## Notes
+- Agent tool has no schema option (that's Workflow) — enforce JSON in the prompt,
+  validate with jq.
+- Do NOT use the Workflow tool unless the user explicitly opts into multi-agent
+  orchestration ("ultracode" / "use a workflow").
+- The hanafuda/tarot games imply a new deck abstraction — flag in the issue that
+  they are larger efforts than a 52-card clone.

--- a/.claude/skills/propose-games/scripts/create_issues.sh
+++ b/.claude/skills/propose-games/scripts/create_issues.sh
@@ -19,6 +19,7 @@ ERR="$WORKDIR/errors.log"
 BODY="$WORKDIR/body.md"
 
 cd "$REPO_DIR"
+mkdir -p "$WORKDIR"
 touch "$LOG" "$ERR"
 
 command -v jq >/dev/null || { echo "jq required" >&2; exit 1; }
@@ -35,10 +36,9 @@ for ((i=0; i<n; i++)); do
     continue
   fi
   title=$(jq -r ".[$i].title" "$SRC")
-  jq -r ".[$i].body" "$SRC" > "$BODY"
+  jq -r ".[$i].body" "$SRC" > "$BODY" || { echo "[$((i+1))/$n] $game -> jq extract failed, skip" >&2; continue; }
   printf '\n\n---\n_%s（スラッグ案: `%s`）_\n' "$FOOTER" "$game" >> "$BODY"
-  url=$(gh issue create --title "$title" --body-file "$BODY" 2>>"$ERR")
-  if [ -n "$url" ]; then
+  if url=$(gh issue create --title "$title" --body-file "$BODY" 2>>"$ERR"); then
     printf '%s\t%s\t%s\n' "$game" "$url" "$title" >> "$LOG"
     echo "[$((i+1))/$n] $game -> $url"
   else

--- a/.claude/skills/propose-games/scripts/create_issues.sh
+++ b/.claude/skills/propose-games/scripts/create_issues.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# propose-games: idempotent, rate-limit-safe GitHub issue creation from a merged
+# proposals JSON (array of {game,title,body}).
+#
+# Usage:
+#   SRC=/tmp/newgames/all.json FOOTER='新規ゲーム追加提案バッチにより自動起票。' \
+#     bash create_issues.sh
+# Run in the background; ~3s/issue. Rerun to resume (skips already-created games).
+set -uo pipefail
+
+REPO_DIR="${REPO_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+SRC="${SRC:-/tmp/newgames/all.json}"
+[[ "$SRC" = /* ]] || SRC="$PWD/$SRC"   # absolutize before the cd below
+FOOTER="${FOOTER:-自動起票。実装時は docs/new-game-checklist.md に従うこと。}"
+SLEEP="${SLEEP:-3}"                    # seconds between creates (rate-limit safety)
+WORKDIR="$(dirname "$SRC")"
+LOG="$WORKDIR/created.log"
+ERR="$WORKDIR/errors.log"
+BODY="$WORKDIR/body.md"
+
+cd "$REPO_DIR"
+touch "$LOG" "$ERR"
+
+command -v jq >/dev/null || { echo "jq required" >&2; exit 1; }
+command -v gh >/dev/null || { echo "gh CLI required" >&2; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "gh not authenticated" >&2; exit 1; }
+jq -e . "$SRC" >/dev/null 2>&1 || { echo "invalid JSON: $SRC" >&2; exit 1; }
+
+n=$(jq 'length' "$SRC")
+echo "Creating $n issues from $SRC (sleep ${SLEEP}s)..."
+for ((i=0; i<n; i++)); do
+  game=$(jq -r ".[$i].game" "$SRC")
+  if grep -q "^${game}"$'\t' "$LOG" 2>/dev/null; then
+    echo "[$((i+1))/$n] $game — already created, skip"
+    continue
+  fi
+  title=$(jq -r ".[$i].title" "$SRC")
+  jq -r ".[$i].body" "$SRC" > "$BODY"
+  printf '\n\n---\n_%s（スラッグ案: `%s`）_\n' "$FOOTER" "$game" >> "$BODY"
+  url=$(gh issue create --title "$title" --body-file "$BODY" 2>>"$ERR")
+  if [ -n "$url" ]; then
+    printf '%s\t%s\t%s\n' "$game" "$url" "$title" >> "$LOG"
+    echo "[$((i+1))/$n] $game -> $url"
+  else
+    echo "[$((i+1))/$n] $game -> FAILED (see $ERR)"
+  fi
+  sleep "$SLEEP"
+done
+echo "DONE. created=$(wc -l < "$LOG")"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,3 +245,4 @@ Key routing rules:
 - Save progress, checkpoint, resume → invoke checkpoint
 - Code quality, health check → invoke health
 - Per-game improvement proposals → GitHub issues ("各ゲームの改善提案", "全ゲームのissueを作って") → invoke game-improve
+- New-game candidates → GitHub issues ("追加した方が良いゲームを提案", "新規ゲーム候補をissueに") → invoke propose-games


### PR DESCRIPTION
## 概要

リポジトリに未実装のトランプゲームを精査して提案し、GitHub issue として一括起票するワークフローを再利用可能なローカルスキル `propose-games` として追加します。`game-improve`（既存132ゲームの改善提案、PR #2293 でマージ済み）の姉妹スキルです。

本日この手順で **45件の新規ゲーム候補 issue #2294–#2338** を起票しました（特殊デッキのタロット/花札ゲーム含む、registry との重複0件）。

## 内容
- `.claude/skills/propose-games/SKILL.md` — registry.go から既存スラッグを列挙→重複排除→候補キュレーション→読み取り専用 sonnet エージェント並列で新規ゲームissue本文（概要/背景/仕様案/実装ポイント、#2013 形式）を生成→jq検証→issue一括作成
- `.claude/skills/propose-games/scripts/create_issues.sh` — `game-improve` の作成スクリプトを汎用化（`FOOTER` 環境変数でフッター差し替え可、冪等・レート制限安全）
- `CLAUDE.md` — Skill routing に発見用ポインタを1行追加

## 設計ポイント
- **classic worker は1MB gzip上限（#2126）→ 新規ゲームは casino/solo バケットに誘導**することを明記
- 特殊デッキ（タロット78枚・花札48枚）は52枚 Card/Deck を流用不可＝新規デッキドメインが必要、と本文で明示
- Mao/Spoons/Kemps 等のリアルタイム/秘密合図系は 1人対CPU 向けの具体的アダプテーションを記述

## テスト
- `bash -n scripts/create_issues.sh` 構文チェック済み
- 実運用での実証: #2294–#2338（45件・欠落0・エラー0）がこのフローの出力