### PR TITLE
fix(scopa): replace hardcoded Japanese stats with i18n keys

### DIFF
--- a/frontend/src/i18n/locales/en/scopa.json
+++ b/frontend/src/i18n/locales/en/scopa.json
@@ -15,7 +15,9 @@
   "label": {
     "tableCards": "Table",
     "tableEmpty": "No table cards",
-    "yourCaptures": "Captures"
+    "yourCaptures": "Captures",
+    "cpuStats": "{{cards}} cards / {{score}} pt",
+    "humanStats": "Hand {{cards}} / Captured {{captured}} / Scopa {{scopa}} / Total {{score}} pt"
   },
   "button": {
     "take": "Take",

--- a/frontend/src/i18n/locales/ja/scopa.json
+++ b/frontend/src/i18n/locales/ja/scopa.json
@@ -15,7 +15,9 @@
   "label": {
     "tableCards": "場札",
     "tableEmpty": "場札なし",
-    "yourCaptures": "獲得カード"
+    "yourCaptures": "獲得カード",
+    "cpuStats": "{{cards}}枚 / {{score}}pt",
+    "humanStats": "手札{{cards}}枚 / 捕獲{{captured}}枚 / スコパ{{scopa}} / 累計{{score}}pt"
   },
   "button": {
     "take": "取る",

--- a/frontend/src/pages/ScopaPage.test.tsx
+++ b/frontend/src/pages/ScopaPage.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from 'i18next';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { scopaApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, ScopaResponse } from '../types/card';
@@ -67,6 +68,19 @@ describe('ScopaPage', () => {
     renderWithProviders(<ScopaPage />);
     await waitFor(() => expect(screen.getByTestId('table-card-0')).toBeInTheDocument());
     expect(screen.getByTestId('table-card-1')).toBeInTheDocument();
+  });
+
+  it('renders human stats via i18n (no hardcoded Japanese under en locale)', async () => {
+    await i18n.changeLanguage('en');
+    renderWithProviders(<ScopaPage />);
+    await waitFor(() => expect(screen.getByTestId('hand-card-0')).toBeInTheDocument());
+    // English locale must show English stat labels, never the Japanese "枚" unit.
+    expect(screen.getByText(/Hand 3 \/ Captured 0 \/ Scopa 0 \/ Total 0 pt/)).toBeInTheDocument();
+    expect(screen.queryByText(/枚/)).not.toBeInTheDocument();
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('ja');
   });
 
   it('take button is disabled until both hand and table are selected', async () => {

--- a/frontend/src/pages/ScopaPage.tsx
+++ b/frontend/src/pages/ScopaPage.tsx
@@ -169,7 +169,8 @@ function ScopaPageContent() {
                 .map((p) => (
                   <div key={p.id} className="text-center">
                     <div className="text-xs text-ds-text-muted mb-1">
-                      {tc('player.cpu', { id: p.id })} — {p.cardCount}枚 / {p.totalScore}pt
+                      {tc('player.cpu', { id: p.id })} —{' '}
+                      {t('label.cpuStats', { cards: p.cardCount, score: p.totalScore })}
                     </div>
                     <div className="flex gap-0.5 justify-center">
                       {Array.from({ length: Math.min(p.cardCount, 8) }, (_, i) => (
@@ -216,9 +217,13 @@ function ScopaPageContent() {
             {/* Human hand */}
             <div className="text-center" data-tutorial="sc-player-hand">
               <div className="text-xs text-ds-text-muted mb-1">
-                {tc('player.you')} — 手札{human.cardCount}枚 / 捕獲{human.capturedCount}枚 / スコパ{human.scopaCount} /
-                累計
-                {human.totalScore}pt
+                {tc('player.you')} —{' '}
+                {t('label.humanStats', {
+                  cards: human.cardCount,
+                  captured: human.capturedCount,
+                  scopa: human.scopaCount,
+                  score: human.totalScore,
+                })}
               </div>
               <div className="flex flex-wrap justify-center gap-2">
                 {human.cards.map((c, i) => (


### PR DESCRIPTION
## 概要

スコパの `ScopaPage.tsx` で、CPU・人間プレイヤーのステータス行（`手札N枚 / 捕獲N枚 / スコパN / 累計Npt`）が日本語ハードコードになっており、英語ロケールで遊ぶと日本語が混在していた。これを i18n キー経由に置き換える。

## 変更内容

- `label.cpuStats` / `label.humanStats` キーを `ja/scopa.json`・`en/scopa.json` に追加（補間: cards/captured/scopa/score）
- `ScopaPage.tsx` の CPU 行と人間行のハードコード文字列を `t()` 呼び出しに置換
- `ScopaPage.test.tsx` に英語ロケールでステータスが英語表示され `枚` が出ないことを検証するテストを追加

## テスト

- `bun run test -- --run src/pages/ScopaPage.test.tsx` … 14 passed（新規1件含む）
- `bun run check` … exit 0
- ja/en キーのパリティ確認済み
- `bun run build`（`tsc -b`）はローカル ~2GB RAM で OOM するため CI ゲートで検証（変更は `t()` 補間のみで型リスクなし）

Closes #2274