### PR TITLE
feat(macau): add penalty count badge to draw button

### DIFF
--- a/frontend/src/pages/MacauPage.test.tsx
+++ b/frontend/src/pages/MacauPage.test.tsx
@@ -119,6 +119,22 @@ describe('MacauPage', () => {
     expect(screen.getByRole('button', { name: /引き受ける/ })).toBeInTheDocument();
   });
 
+  it('shows a penalty count badge and danger-styled draw button when penalty active', async () => {
+    mockExec.mockResolvedValue(penaltyState);
+    renderWithProviders(<MacauPage />);
+    const badge = await screen.findByTestId('penalty-badge');
+    expect(badge).toHaveTextContent('4');
+    const drawButton = screen.getByRole('button', { name: /引き受ける/ });
+    expect(drawButton.className).toContain('bg-ds-error');
+  });
+
+  it('hides the penalty badge when no penalty is active', async () => {
+    mockExec.mockResolvedValue(playPhaseState);
+    renderWithProviders(<MacauPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '引く' })).toBeInTheDocument());
+    expect(screen.queryByTestId('penalty-badge')).not.toBeInTheDocument();
+  });
+
   it('shows reverse direction indicator', async () => {
     mockExec.mockResolvedValue(reverseState);
     renderWithProviders(<MacauPage />);

--- a/frontend/src/pages/MacauPage.tsx
+++ b/frontend/src/pages/MacauPage.tsx
@@ -382,9 +382,7 @@ function MacauPageContent() {
                     onClick={handleDraw}
                     disabled={loading}
                   >
-                    {hasPenalty
-                      ? t('takePenaltyButton', { count: state.penaltyDrawCount })
-                      : t('drawButton')}
+                    {hasPenalty ? t('takePenaltyButton', { count: state.penaltyDrawCount }) : t('drawButton')}
                     {hasPenalty && (
                       <span
                         data-testid="penalty-badge"

--- a/frontend/src/pages/MacauPage.tsx
+++ b/frontend/src/pages/MacauPage.tsx
@@ -22,7 +22,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useMacauGame } from '../hooks/useMacauGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
-import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
+import { btnDanger, btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -375,11 +375,27 @@ function MacauPageContent() {
                   >
                     {t('playButton')}
                   </button>
-                  <button type="button" className={btnPrimary} onClick={handleDraw} disabled={loading}>
-                    {state.penaltyDrawCount > 0
-                      ? t('takePenaltyButton', { count: state.penaltyDrawCount })
-                      : t('drawButton')}
-                  </button>
+                  <div className="relative inline-flex">
+                    <button
+                      type="button"
+                      className={state.penaltyDrawCount > 0 ? btnDanger : btnPrimary}
+                      onClick={handleDraw}
+                      disabled={loading}
+                    >
+                      {state.penaltyDrawCount > 0
+                        ? t('takePenaltyButton', { count: state.penaltyDrawCount })
+                        : t('drawButton')}
+                    </button>
+                    {state.penaltyDrawCount > 0 && (
+                      <span
+                        data-testid="penalty-badge"
+                        aria-hidden="true"
+                        className="pointer-events-none absolute -top-2 -right-2 flex h-5 min-w-5 items-center justify-center rounded-full bg-ds-error px-1 font-bold text-white text-xs"
+                      >
+                        {state.penaltyDrawCount}
+                      </span>
+                    )}
+                  </div>
                 </div>
               )}
               {isChooseSuit && state.players[state.currentPlayerIdx]?.isHuman && (

--- a/frontend/src/pages/MacauPage.tsx
+++ b/frontend/src/pages/MacauPage.tsx
@@ -171,6 +171,7 @@ function MacauPageContent() {
   const isRoundEnd = state.phase === MacauPhase.ROUND_END;
   const isGameEnd = state.phase === MacauPhase.GAME_END || state.gameEndFlag;
   const isHumanTurn = isPlayPhase && state.players[state.currentPlayerIdx]?.isHuman === true;
+  const hasPenalty = state.penaltyDrawCount > 0;
   const directionLabel = state.direction < 0 ? '←' : '→';
 
   return (
@@ -267,7 +268,7 @@ function MacauPageContent() {
                   </div>
                 )}
 
-                {state.penaltyDrawCount > 0 && (
+                {hasPenalty && (
                   <div
                     className="my-2 p-2 rounded bg-ds-warning/20 text-ds-warning text-sm font-semibold"
                     role="status"
@@ -375,18 +376,16 @@ function MacauPageContent() {
                   >
                     {t('playButton')}
                   </button>
-                  <div className="relative inline-flex">
-                    <button
-                      type="button"
-                      className={state.penaltyDrawCount > 0 ? btnDanger : btnPrimary}
-                      onClick={handleDraw}
-                      disabled={loading}
-                    >
-                      {state.penaltyDrawCount > 0
-                        ? t('takePenaltyButton', { count: state.penaltyDrawCount })
-                        : t('drawButton')}
-                    </button>
-                    {state.penaltyDrawCount > 0 && (
+                  <button
+                    type="button"
+                    className={`${hasPenalty ? btnDanger : btnPrimary} relative`}
+                    onClick={handleDraw}
+                    disabled={loading}
+                  >
+                    {hasPenalty
+                      ? t('takePenaltyButton', { count: state.penaltyDrawCount })
+                      : t('drawButton')}
+                    {hasPenalty && (
                       <span
                         data-testid="penalty-badge"
                         aria-hidden="true"
@@ -395,7 +394,7 @@ function MacauPageContent() {
                         {state.penaltyDrawCount}
                       </span>
                     )}
-                  </div>
+                  </button>
                 </div>
               )}
               {isChooseSuit && state.players[state.currentPlayerIdx]?.isHuman && (


### PR DESCRIPTION
## 概要

マカオでペナルティ蓄積時（`state.penaltyDrawCount > 0`）、ドローボタンのラベルが変わるだけで緊迫感が視覚的に伝わりにくかった。ドローボタンを `btnDanger` 化し、右上に赤い枚数バッジを重ねて表示する。

## 変更内容

- `penaltyDrawCount > 0` のときドローボタンを `btnPrimary` → `btnDanger` に切り替え
- ドローボタン右上に絶対配置の数字バッジ（`bg-ds-error text-white rounded-full`, `data-testid="penalty-badge"`）を追加。`penaltyDrawCount === 0` では非表示
- バッジは `aria-hidden`（ボタンラベル `引き受ける(N)` が既に枚数を読み上げるため二重読み上げを回避）
- 既存 `penaltyBanner` は維持

## テスト

- `bun run test -- --run src/pages/MacauPage.test.tsx` … 24 passed（新規2件: バッジ表示+danger化 / 非ペナルティ時バッジ非表示）
- `bun run check` … exit 0
- `bun run build`(`tsc -b`) はローカル ~2GB RAM で OOM するため CI ゲートで検証

Closes #2277