### PR TITLE
feat(yaniv): visual feedback as hand total nears Yaniv threshold

### DIFF
--- a/frontend/src/pages/YanivPage.test.tsx
+++ b/frontend/src/pages/YanivPage.test.tsx
@@ -75,6 +75,50 @@ describe('YanivPage', () => {
     expect(screen.getByTestId('discard-button')).toBeDisabled();
   });
 
+  it('highlights the hand-total badge in success color and pulses the Yaniv button when total <= 5', async () => {
+    renderWithProviders(<YanivPage />);
+    const badge = await screen.findByTestId('hand-total-badge');
+    expect(badge.className).toContain('bg-ds-success');
+    const yanivBtn = screen.getByTestId('yaniv-button');
+    expect(yanivBtn.className).toContain('ring-ds-success');
+    expect(yanivBtn.className).toContain('animate-pulse');
+  });
+
+  it('soft-highlights the hand-total badge in warning color when total is 6-10', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        players: [
+          player(0, true, [card('SPADE', 8)], { handTotal: 8 }),
+          player(1, false, []),
+          player(2, false, []),
+          player(3, false, []),
+        ],
+      }),
+    );
+    renderWithProviders(<YanivPage />);
+    const badge = await screen.findByTestId('hand-total-badge');
+    expect(badge.className).toContain('bg-ds-warning');
+    expect(badge.className).not.toContain('bg-ds-success');
+    expect(screen.getByTestId('yaniv-button').className).not.toContain('ring-ds-success');
+  });
+
+  it('leaves the hand-total badge unstyled when total exceeds 10', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        players: [
+          player(0, true, [card('SPADE', 13)], { handTotal: 15 }),
+          player(1, false, []),
+          player(2, false, []),
+          player(3, false, []),
+        ],
+      }),
+    );
+    renderWithProviders(<YanivPage />);
+    const badge = await screen.findByTestId('hand-total-badge');
+    expect(badge.className).not.toContain('bg-ds-success');
+    expect(badge.className).not.toContain('bg-ds-warning');
+  });
+
   it('declares Yaniv when the hand total is low enough', async () => {
     renderWithProviders(<YanivPage />);
     const yanivBtn = await screen.findByTestId('yaniv-button');

--- a/frontend/src/pages/YanivPage.tsx
+++ b/frontend/src/pages/YanivPage.tsx
@@ -274,9 +274,13 @@ function YanivPageContent() {
                 {tc('player.you')} · {t('label.score')}: {human.score} · {t('label.hand')}:{' '}
                 <span
                   data-testid="hand-total-badge"
-                  className={`inline-block rounded px-1.5 font-bold ${
-                    human.handTotal <= 5 ? 'bg-ds-success text-white' : human.handTotal <= 10 ? 'bg-ds-warning/40' : ''
-                  }`}
+                  className={
+                    human.handTotal <= 5
+                      ? 'inline-block rounded px-1.5 font-bold bg-ds-success text-white'
+                      : human.handTotal <= 10
+                        ? 'inline-block rounded px-1.5 font-bold bg-ds-warning/40'
+                        : 'inline-block rounded px-1.5 font-bold'
+                  }
                 >
                   {human.handTotal}
                 </span>
@@ -364,9 +368,11 @@ function YanivPageContent() {
                 type="button"
                 onClick={handleYaniv}
                 disabled={loading || !canYaniv}
-                className={`px-4 py-2 rounded-lg bg-ds-warning text-white font-medium disabled:opacity-40 disabled:cursor-not-allowed text-sm ${
-                  canYaniv ? 'motion-safe:animate-pulse ring-2 ring-ds-success' : ''
-                }`}
+                className={
+                  canYaniv
+                    ? 'px-4 py-2 rounded-lg bg-ds-warning text-white font-medium disabled:opacity-40 disabled:cursor-not-allowed text-sm motion-safe:animate-pulse ring-2 ring-ds-success'
+                    : 'px-4 py-2 rounded-lg bg-ds-warning text-white font-medium disabled:opacity-40 disabled:cursor-not-allowed text-sm'
+                }
                 data-testid="yaniv-button"
               >
                 {t('button.yaniv')}

--- a/frontend/src/pages/YanivPage.tsx
+++ b/frontend/src/pages/YanivPage.tsx
@@ -271,7 +271,15 @@ function YanivPageContent() {
             {/* Human hand */}
             <div className="text-center" data-tutorial="y-player-hand">
               <div className="text-xs text-ds-text-muted mb-1">
-                {tc('player.you')} · {t('label.score')}: {human.score} · {t('label.hand')}: {human.handTotal}
+                {tc('player.you')} · {t('label.score')}: {human.score} · {t('label.hand')}:{' '}
+                <span
+                  data-testid="hand-total-badge"
+                  className={`inline-block rounded px-1.5 font-bold ${
+                    human.handTotal <= 5 ? 'bg-ds-success text-white' : human.handTotal <= 10 ? 'bg-ds-warning/40' : ''
+                  }`}
+                >
+                  {human.handTotal}
+                </span>
               </div>
               {isDiscard && isHumanTurn && (
                 <div className="text-xs text-ds-text-muted mb-1">{t('label.selectCard')}</div>
@@ -356,7 +364,9 @@ function YanivPageContent() {
                 type="button"
                 onClick={handleYaniv}
                 disabled={loading || !canYaniv}
-                className="px-4 py-2 rounded-lg bg-ds-warning text-white font-medium disabled:opacity-40 disabled:cursor-not-allowed text-sm"
+                className={`px-4 py-2 rounded-lg bg-ds-warning text-white font-medium disabled:opacity-40 disabled:cursor-not-allowed text-sm ${
+                  canYaniv ? 'motion-safe:animate-pulse ring-2 ring-ds-success' : ''
+                }`}
                 data-testid="yaniv-button"
               >
                 {t('button.yaniv')}


### PR DESCRIPTION
## 概要

ヤニブは手札合計が5点以下で「ヤニブ！」を宣言する。従来は宣言可能でないとボタンが灰色のままで、初心者はいつ宣言できるか手動計算が必要だった。手札合計バッジとヤニブボタンに視覚的フィードバックを追加する。

## 変更内容

- 手札合計を `data-testid="hand-total-badge"` のバッジ化:
  - `handTotal <= 5` → `bg-ds-success text-white`（宣言可能）
  - `handTotal` 6〜10 → `bg-ds-warning/40`（もうすぐ宣言可能）
  - 11以上 → 強調なし
- `canYaniv` が true のときヤニブボタンに `motion-safe:animate-pulse ring-2 ring-ds-success` を付与（`motion-safe:` はプロジェクトのモーション規約に準拠）

## テスト

- `bun run test -- --run src/pages/YanivPage.test.tsx` … 13 passed（新規3件: ≤5成功色+パルス / 6-10警告色 / >10強調なし）
- `bun run check` … exit 0
- `bun run build`(`tsc -b`) はローカル ~2GB RAM で OOM するため CI ゲートで検証（スタイル変更のみで型リスクなし）

Closes #2284