### PR TITLE
feat(thirtyone): add knock countdown banner for the last turn

### DIFF
--- a/frontend/src/i18n/locales/en/thirtyone.json
+++ b/frontend/src/i18n/locales/en/thirtyone.json
@@ -21,7 +21,9 @@
     "knocked": "Knocked!",
     "out": "OUT",
     "suitScores": "Suit totals",
-    "selectCard": "Select a card to discard"
+    "selectCard": "Select a card to discard",
+    "knockBannerLastTurn": "{{knocker}} knocked — this is your last turn",
+    "knockBannerActive": "{{knocker}} knocked"
   },
   "settings": {
     "cpuDifficulty": "CPU Difficulty",

--- a/frontend/src/i18n/locales/ja/thirtyone.json
+++ b/frontend/src/i18n/locales/ja/thirtyone.json
@@ -22,8 +22,8 @@
     "out": "脱落",
     "suitScores": "スート別合計",
     "selectCard": "捨てるカードを選んでください",
-    "knockBannerLastTurn": "{{knocker}} がノック — あなたの最後のターン",
-    "knockBannerActive": "{{knocker}} がノック中"
+    "knockBannerLastTurn": "{{knocker}}がノック — あなたの最後のターン",
+    "knockBannerActive": "{{knocker}}がノック中"
   },
   "settings": {
     "cpuDifficulty": "CPU難易度",

--- a/frontend/src/i18n/locales/ja/thirtyone.json
+++ b/frontend/src/i18n/locales/ja/thirtyone.json
@@ -21,7 +21,9 @@
     "knocked": "ノック!",
     "out": "脱落",
     "suitScores": "スート別合計",
-    "selectCard": "捨てるカードを選んでください"
+    "selectCard": "捨てるカードを選んでください",
+    "knockBannerLastTurn": "{{knocker}} がノック — あなたの最後のターン",
+    "knockBannerActive": "{{knocker}} がノック中"
   },
   "settings": {
     "cpuDifficulty": "CPU難易度",

--- a/frontend/src/pages/ThirtyOnePage.test.tsx
+++ b/frontend/src/pages/ThirtyOnePage.test.tsx
@@ -127,6 +127,14 @@ describe('ThirtyOnePage', () => {
     expect(banner).toHaveTextContent(/最後のターン/);
   });
 
+  it('shows the active knock banner without last-turn text when it is not the human turn', async () => {
+    mockExec.mockResolvedValue(makeState({ knockerIdx: 2, currentPlayerIdx: 1 }));
+    renderWithProviders(<ThirtyOnePage />);
+    const banner = await screen.findByTestId('knock-countdown-banner');
+    expect(banner).toHaveTextContent(/CPU 2/);
+    expect(banner).not.toHaveTextContent(/最後のターン/);
+  });
+
   it('hides the knock countdown banner at round end', async () => {
     mockExec.mockResolvedValue(makeState({ phase: ThirtyOnePhase.ROUND_END, knockerIdx: 1 }));
     renderWithProviders(<ThirtyOnePage />);

--- a/frontend/src/pages/ThirtyOnePage.test.tsx
+++ b/frontend/src/pages/ThirtyOnePage.test.tsx
@@ -119,6 +119,21 @@ describe('ThirtyOnePage', () => {
     expect(await screen.findByTestId('knock-button')).toBeDisabled();
   });
 
+  it('shows the knock countdown banner with the knocker name on the human last turn', async () => {
+    mockExec.mockResolvedValue(makeState({ knockerIdx: 1 }));
+    renderWithProviders(<ThirtyOnePage />);
+    const banner = await screen.findByTestId('knock-countdown-banner');
+    expect(banner).toHaveTextContent(/CPU 1/);
+    expect(banner).toHaveTextContent(/最後のターン/);
+  });
+
+  it('hides the knock countdown banner at round end', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: ThirtyOnePhase.ROUND_END, knockerIdx: 1 }));
+    renderWithProviders(<ThirtyOnePage />);
+    await screen.findByTestId('next-round-button');
+    expect(screen.queryByTestId('knock-countdown-banner')).not.toBeInTheDocument();
+  });
+
   it('highlights the leading suit badge', async () => {
     // Default human hand: SPADE 3, HEART 5, DIAMOND 7 → DIAMOND leads.
     renderWithProviders(<ThirtyOnePage />);

--- a/frontend/src/pages/ThirtyOnePage.test.tsx
+++ b/frontend/src/pages/ThirtyOnePage.test.tsx
@@ -142,6 +142,13 @@ describe('ThirtyOnePage', () => {
     expect(screen.queryByTestId('knock-countdown-banner')).not.toBeInTheDocument();
   });
 
+  it('hides the knock countdown banner at game end', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: ThirtyOnePhase.GAME_END, gameEndFlag: true, knockerIdx: 1 }));
+    renderWithProviders(<ThirtyOnePage />);
+    await waitFor(() => expect(screen.getAllByLabelText(/lives-|out/).length).toBeGreaterThan(0));
+    expect(screen.queryByTestId('knock-countdown-banner')).not.toBeInTheDocument();
+  });
+
   it('highlights the leading suit badge', async () => {
     // Default human hand: SPADE 3, HEART 5, DIAMOND 7 → DIAMOND leads.
     renderWithProviders(<ThirtyOnePage />);

--- a/frontend/src/pages/ThirtyOnePage.test.tsx
+++ b/frontend/src/pages/ThirtyOnePage.test.tsx
@@ -142,6 +142,14 @@ describe('ThirtyOnePage', () => {
     expect(screen.queryByTestId('knock-countdown-banner')).not.toBeInTheDocument();
   });
 
+  it('names the human in the knock banner when the human is the knocker', async () => {
+    mockExec.mockResolvedValue(makeState({ knockerIdx: 0, currentPlayerIdx: 1 }));
+    renderWithProviders(<ThirtyOnePage />);
+    const banner = await screen.findByTestId('knock-countdown-banner');
+    expect(banner).toHaveTextContent(/あなた/);
+    expect(banner).not.toHaveTextContent(/最後のターン/);
+  });
+
   it('hides the knock countdown banner at game end', async () => {
     mockExec.mockResolvedValue(makeState({ phase: ThirtyOnePhase.GAME_END, gameEndFlag: true, knockerIdx: 1 }));
     renderWithProviders(<ThirtyOnePage />);

--- a/frontend/src/pages/ThirtyOnePage.tsx
+++ b/frontend/src/pages/ThirtyOnePage.tsx
@@ -315,6 +315,18 @@ function ThirtyOnePageContent() {
               </div>
             </div>
 
+            {state.knockerIdx >= 0 && !isGameEnd && !isRoundEnd && (
+              <div
+                role="status"
+                data-testid="knock-countdown-banner"
+                className="rounded-lg bg-ds-warning/20 border border-ds-warning px-3 py-1.5 text-center text-ds-warning text-sm font-medium"
+              >
+                {t(isHumanTurn ? 'label.knockBannerLastTurn' : 'label.knockBannerActive', {
+                  knocker: state.knockerIdx === 0 ? tc('player.you') : tc('player.cpu', { id: state.knockerIdx }),
+                })}
+              </div>
+            )}
+
             <GameMessageBox
               message={state.message}
               messageCode={state.messageCode}


### PR DESCRIPTION
## 概要

サーティワンでは誰かがノックすると残り全員に最後の1ターンが与えられるが、従来は knocked バッジが出るだけで「自分のターンが最後の1回」であることが分かりにくかった。ノック中であることと最後のターンであることを伝えるバナーを追加する。

## 変更内容

- `state.knockerIdx >= 0` かつ非ゲームエンド/非ラウンドエンドのとき、メッセージボックス直前に `ds-warning` 色のバナー（`role="status"`, `data-testid="knock-countdown-banner"`）を表示
  - 自分のターン: `{knocker} がノック — あなたの最後のターン`
  - それ以外: `{knocker} がノック中`
  - ノックしたプレイヤー名を含む（`あなた` / `CPU N`）
- `label.knockBannerLastTurn` / `label.knockBannerActive` を ja / en に追加

## テスト

- `bun run test -- --run src/pages/ThirtyOnePage.test.tsx` … 16 passed（新規2件: 最後のターンバナー表示+knocker名 / ラウンドエンドで非表示）
- `bun run check` … exit 0 / ja-en キーパリティ確認済み
- `bun run build`(`tsc -b`) はローカル ~2GB RAM で OOM するため CI ゲートで検証

Closes #2278