### PR TITLE
feat(bidwhist): add kitty exchange selection progress bar

### DIFF
--- a/frontend/src/i18n/locales/en/bidwhist.json
+++ b/frontend/src/i18n/locales/en/bidwhist.json
@@ -25,6 +25,7 @@
   "passButton": "Pass",
   "declareTrumpPrompt": "Choose a trump suit:",
   "exchangeButton": "Exchange ({{count}}/6)",
+  "kittyProgress": "Selected: {{count}} / 6",
   "playButton": "Play",
   "nextTrickButton": "Next trick",
   "nextRoundButton": "Next round",

--- a/frontend/src/i18n/locales/ja/bidwhist.json
+++ b/frontend/src/i18n/locales/ja/bidwhist.json
@@ -25,6 +25,7 @@
   "passButton": "パス",
   "declareTrumpPrompt": "切り札スートを選択:",
   "exchangeButton": "交換 ({{count}}/6)",
+  "kittyProgress": "選択済み: {{count}} / 6",
   "playButton": "出す",
   "nextTrickButton": "次のトリック",
   "nextRoundButton": "次のラウンド",

--- a/frontend/src/pages/BidWhistPage.test.tsx
+++ b/frontend/src/pages/BidWhistPage.test.tsx
@@ -122,4 +122,38 @@ describe('BidWhistPage', () => {
     fireEvent.click(await screen.findByTestId('play-button'));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', { cardIndex: 0 }));
   });
+
+  it('shows the kitty selection progress and fills the bar at six cards', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: 2,
+        declarerIdx: 0,
+        players: [
+          player(0, true, sixCards, { isDeclarer: true }),
+          player(1, false, []),
+          player(2, false, []),
+          player(3, false, []),
+        ],
+      }),
+    );
+    renderWithProviders(<BidWhistPage />);
+    const progress = await screen.findByTestId('kitty-progress');
+    expect(progress).toHaveTextContent('0 / 6');
+    // Bar is not yet full → info colour, no success colour.
+    expect(progress.querySelector('.bg-ds-success')).toBeNull();
+
+    // Select all six cards → counter reaches 6/6 and the bar turns success.
+    for (let i = 0; i < 6; i++) {
+      fireEvent.click(screen.getByTestId(`hand-card-${i}`));
+    }
+    expect(progress).toHaveTextContent('6 / 6');
+    expect(progress.querySelector('.bg-ds-success')).not.toBeNull();
+  });
+
+  it('hides the kitty progress outside the exchange phase', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: 3, currentPlayerIdx: 0 }));
+    renderWithProviders(<BidWhistPage />);
+    await screen.findByTestId('hand-card-0');
+    expect(screen.queryByTestId('kitty-progress')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/BidWhistPage.tsx
+++ b/frontend/src/pages/BidWhistPage.tsx
@@ -261,9 +261,11 @@ function BidWhistPageContent() {
                 </div>
                 <div className="h-2 overflow-hidden rounded-full bg-ds-surface-elevated">
                   <div
-                    className={`h-full rounded-full transition-all ${
-                      selectedCardIndices.length === 6 ? 'bg-ds-success' : 'bg-ds-info'
-                    }`}
+                    className={
+                      selectedCardIndices.length === 6
+                        ? 'h-full rounded-full transition-all bg-ds-success'
+                        : 'h-full rounded-full transition-all bg-ds-info'
+                    }
                     style={{ width: `${(Math.min(selectedCardIndices.length, 6) * 100) / 6}%` }}
                   />
                 </div>

--- a/frontend/src/pages/BidWhistPage.tsx
+++ b/frontend/src/pages/BidWhistPage.tsx
@@ -253,6 +253,23 @@ function BidWhistPageContent() {
               </div>
             </div>
 
+            {/* Kitty exchange progress */}
+            {isHumanExchange && (
+              <div className="mx-auto mb-2 max-w-xs" data-testid="kitty-progress">
+                <div className="mb-1 text-center text-ds-text-muted text-xs">
+                  {t('kittyProgress', { count: selectedCardIndices.length })}
+                </div>
+                <div className="h-2 overflow-hidden rounded-full bg-ds-surface-elevated">
+                  <div
+                    className={`h-full rounded-full transition-all ${
+                      selectedCardIndices.length === 6 ? 'bg-ds-success' : 'bg-ds-info'
+                    }`}
+                    style={{ width: `${(Math.min(selectedCardIndices.length, 6) * 100) / 6}%` }}
+                  />
+                </div>
+              </div>
+            )}
+
             {/* Human hand */}
             <div className="text-center" data-tutorial="bw-hand">
               <div className="text-xs text-ds-text-muted mb-1">


### PR DESCRIPTION
## 概要

ビッド・ホイストのキティ交換フェーズでは6枚をキティに戻す必要があるが、`exchangeButton` が `length !== 6` で無効化されるだけで「あと何枚」が分からなかった。手札直上にプログレスバー + カウントを追加する。

## 変更内容

- `isHumanExchange` のとき手札エリア直上に `選択済み: n / 6` のプログレスバー（`data-testid="kitty-progress"`）を表示
- 6枚選択でバーが満杯になり `bg-ds-info` → `bg-ds-success` に変化
- 交換フェーズ以外（プレイフェーズ等）では非表示
- `kittyProgress` キーを ja / en に追加

## テスト

- `bun run test -- --run src/pages/BidWhistPage.test.tsx` … 8 passed（新規2件: 0/6→6/6でバー満杯+success化 / 非交換フェーズで非表示）
- `bun run check` … exit 0 / ja-en キーパリティ確認済み
- `bun run build`(`tsc -b`) はローカル ~2GB RAM で OOM するため CI ゲートで検証

Closes #2287