### PR TITLE
feat(barbu): add contract description panel to selection grid

### DIFF
--- a/frontend/src/pages/BarbuPage.test.tsx
+++ b/frontend/src/pages/BarbuPage.test.tsx
@@ -70,6 +70,20 @@ describe('BarbuPage', () => {
     expect(screen.getByTestId('contract-6')).toBeInTheDocument();
   });
 
+  it('shows a contract description panel that updates on focus', async () => {
+    renderWithProviders(<BarbuPage />);
+    const panel = await screen.findByTestId('contract-desc');
+    // Defaults to the first available contract's description.
+    const initial = panel.textContent;
+    expect(initial).toBeTruthy();
+    // Focusing a different contract updates the panel...
+    fireEvent.focus(screen.getByTestId('contract-3'));
+    expect(panel.textContent).not.toBe(initial);
+    // ...and focusing back restores the original description.
+    fireEvent.focus(screen.getByTestId('contract-0'));
+    expect(panel.textContent).toBe(initial);
+  });
+
   it('selects a non-trump contract directly', async () => {
     renderWithProviders(<BarbuPage />);
     await waitFor(() => expect(screen.getByTestId('contract-0')).toBeInTheDocument());

--- a/frontend/src/pages/BarbuPage.test.tsx
+++ b/frontend/src/pages/BarbuPage.test.tsx
@@ -79,8 +79,8 @@ describe('BarbuPage', () => {
     // Focusing a different contract updates the panel...
     fireEvent.focus(screen.getByTestId('contract-3'));
     expect(panel.textContent).not.toBe(initial);
-    // ...and focusing back restores the original description.
-    fireEvent.focus(screen.getByTestId('contract-0'));
+    // ...and blurring it restores the original description.
+    fireEvent.blur(screen.getByTestId('contract-3'));
     expect(panel.textContent).toBe(initial);
   });
 

--- a/frontend/src/pages/BarbuPage.tsx
+++ b/frontend/src/pages/BarbuPage.tsx
@@ -228,7 +228,9 @@ function BarbuPageContent() {
                           type="button"
                           onClick={() => onContractClick(c)}
                           onMouseEnter={() => setHoveredContract(c)}
+                          onMouseLeave={() => setHoveredContract(null)}
                           onFocus={() => setHoveredContract(c)}
+                          onBlur={() => setHoveredContract(null)}
                           disabled={loading || state.usedContracts[c]}
                           className="px-3 py-2 rounded-lg bg-ds-info text-white text-xs font-medium disabled:opacity-30 disabled:line-through"
                           data-testid={`contract-${c}`}

--- a/frontend/src/pages/BarbuPage.tsx
+++ b/frontend/src/pages/BarbuPage.tsx
@@ -108,6 +108,7 @@ function BarbuPageContent() {
   const { handleCommand } = useCliGame(callApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
   const [trumpPickerOpen, setTrumpPickerOpen] = useState(false);
+  const [hoveredContract, setHoveredContract] = useState<number | null>(null);
   const onReset = useCallback(() => handleResetWithConfig(), [handleResetWithConfig]);
 
   const onContractClick = useCallback(
@@ -130,6 +131,13 @@ function BarbuPageContent() {
 
   const human = state && state.players.length >= 1 ? state.players[0] : null;
   const isSelectPhase = !!state && state.phase === 'selectContract';
+  // Default the description panel to the first contract that is still selectable.
+  const firstAvailableContract = state
+    ? Math.max(
+        0,
+        state.usedContracts.findIndex((used) => !used),
+      )
+    : 0;
   const isPlayPhase = !!state && state.phase === 'play';
   const isHumanSelect = isSelectPhase && state.dealerIdx === 0 && !state.gameEndFlag;
   const isHumanPlay = isPlayPhase && state.currentTurn === 0 && !state.gameEndFlag;
@@ -212,21 +220,32 @@ function BarbuPageContent() {
             {isHumanSelect && (
               <div className="py-2 bg-black/20 rounded-lg" data-tutorial="bb-contracts">
                 {!trumpPickerOpen ? (
-                  <div className="flex flex-wrap justify-center gap-2">
-                    {Array.from({ length: CONTRACT_COUNT }, (_, c) => (
-                      <button
-                        key={c}
-                        type="button"
-                        onClick={() => onContractClick(c)}
-                        disabled={loading || state.usedContracts[c]}
-                        className="px-3 py-2 rounded-lg bg-ds-info text-white text-xs font-medium disabled:opacity-30 disabled:line-through"
-                        data-testid={`contract-${c}`}
-                        title={t(`contractDesc.${c}`)}
-                      >
-                        {t(`contract.${c}`)}
-                      </button>
-                    ))}
-                  </div>
+                  <>
+                    <div className="flex flex-wrap justify-center gap-2">
+                      {Array.from({ length: CONTRACT_COUNT }, (_, c) => (
+                        <button
+                          key={c}
+                          type="button"
+                          onClick={() => onContractClick(c)}
+                          onMouseEnter={() => setHoveredContract(c)}
+                          onFocus={() => setHoveredContract(c)}
+                          disabled={loading || state.usedContracts[c]}
+                          className="px-3 py-2 rounded-lg bg-ds-info text-white text-xs font-medium disabled:opacity-30 disabled:line-through"
+                          data-testid={`contract-${c}`}
+                          title={t(`contractDesc.${c}`)}
+                        >
+                          {t(`contract.${c}`)}
+                        </button>
+                      ))}
+                    </div>
+                    <p
+                      role="status"
+                      data-testid="contract-desc"
+                      className="mt-2 min-h-[2rem] px-3 text-center text-ds-text-muted text-xs"
+                    >
+                      {t(`contractDesc.${hoveredContract ?? firstAvailableContract}`)}
+                    </p>
+                  </>
                 ) : (
                   <div className="flex flex-col items-center gap-2">
                     <span className="text-xs text-ds-text-muted">{t('label.selectTrump')}</span>


### PR DESCRIPTION
## 概要

バルブの7契約は特殊ルールを持つが、説明はPCのホバーツールチップ(`title`)でしか見えず、モバイルでは確認手段がなかった。契約ボタングリッド下に説明パネルを追加する。

## 変更内容

- 契約選択フェーズで、ボタングリッド直下に `role="status"` の説明パネル（`data-testid="contract-desc"`）を追加
- ボタンの hover / focus で対応する `contractDesc.<c>` テキストに更新
- デフォルトは「まだ使用していない最初の契約」の説明（`firstAvailableContract`）
- 既存の `title` ツールチップは維持

## テスト

- `bun run test -- --run src/pages/BarbuPage.test.tsx` … 11 passed（新規1件: パネル表示 + focus で説明更新/復帰）
- `bun run check` … exit 0
- `bun run build`(`tsc -b`) はローカル ~2GB RAM で OOM するため CI ゲートで検証

Closes #2276