### PR TITLE
feat(sixcardgolf): per-column score breakdown at round over

### DIFF
--- a/frontend/src/i18n/locales/en/sixcardgolf.json
+++ b/frontend/src/i18n/locales/en/sixcardgolf.json
@@ -12,7 +12,8 @@
     "human": "You",
     "cpu": "CPU {{id}}",
     "faceDown": "Face Down",
-    "finalTurn": "Final Turn"
+    "finalTurn": "Final Turn",
+    "columnScore": "{{score}} pt"
   },
   "button": {
     "flipInitial": "Flip",

--- a/frontend/src/i18n/locales/ja/sixcardgolf.json
+++ b/frontend/src/i18n/locales/ja/sixcardgolf.json
@@ -12,7 +12,8 @@
     "human": "あなた",
     "cpu": "CPU{{id}}",
     "faceDown": "伏せ札",
-    "finalTurn": "最終ターン"
+    "finalTurn": "最終ターン",
+    "columnScore": "{{score}}pt"
   },
   "button": {
     "flipInitial": "めくる",

--- a/frontend/src/pages/SixCardGolfPage.test.tsx
+++ b/frontend/src/pages/SixCardGolfPage.test.tsx
@@ -1,0 +1,72 @@
+import { screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { sixcardgolfApi } from '../api/gameApi';
+import { renderWithProviders } from '../test/renderWithProviders';
+import type { Card, SixCardGolfResponse, SixCardGolfSlot } from '../types/card';
+import { SixCardGolfPage } from './SixCardGolfPage';
+
+vi.mock('../api/gameApi', () => ({
+  sixcardgolfApi: { exec: vi.fn() },
+  actionLogApi: { sixcardgolf: vi.fn() },
+}));
+
+const mockExec = vi.mocked(sixcardgolfApi.exec);
+
+const card = (value: number): Card => ({ design: 'SPADE', value }) as unknown as Card;
+const slot = (value: number): SixCardGolfSlot => ({ card: card(value), faceUp: true });
+
+function makeState(overrides: Partial<SixCardGolfResponse> = {}): SixCardGolfResponse {
+  const grid = [slot(5), slot(3), slot(7), slot(5), slot(9), slot(2)];
+  return {
+    players: [
+      { id: 0, isHuman: true, grid, roundScore: 28, cumulativeScore: 28, allFaceUp: true },
+      { id: 1, isHuman: false, grid: [...grid], roundScore: 10, cumulativeScore: 10, allFaceUp: true },
+    ],
+    phase: 3, // SCG_PHASE_ROUND_OVER
+    roundNumber: 1,
+    totalRounds: 9,
+    currentPlayerIdx: 0,
+    discardTop: card(4),
+    drawPileCount: 20,
+    drawnCard: null,
+    drawnFromDiscard: false,
+    canFlip: false,
+    finalTurnTrigger: -1,
+    gameEndFlag: false,
+    winnerIdx: -1,
+    config: { playerCount: 2, cpuDifficulty: 1, rounds: 9 },
+    message: '',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  mockExec.mockReset();
+  mockExec.mockResolvedValue(makeState());
+});
+
+describe('SixCardGolfPage', () => {
+  it('calls reset on mount', async () => {
+    renderWithProviders(<SixCardGolfPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith({ command: 'reset' }));
+  });
+
+  it('shows per-column score badges at round over, marking matched pairs', async () => {
+    renderWithProviders(<SixCardGolfPage />);
+    const breakdown = await screen.findByTestId('scg-column-scores');
+    expect(breakdown).toBeInTheDocument();
+    // Column 0 is a 5-over-5 pair → 0pt with success highlight.
+    const col0 = screen.getByTestId('scg-column-score-0');
+    expect(col0.className).toContain('bg-ds-success');
+    // Column 1 (3 over 9) is not a pair → no success highlight.
+    expect(screen.getByTestId('scg-column-score-1').className).not.toContain('bg-ds-success');
+  });
+
+  it('does not show the column breakdown during active play', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: 1 /* player turn */ }));
+    renderWithProviders(<SixCardGolfPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    await waitFor(() => expect(screen.queryByTestId('scg-column-scores')).not.toBeInTheDocument());
+  });
+});

--- a/frontend/src/pages/SixCardGolfPage.tsx
+++ b/frontend/src/pages/SixCardGolfPage.tsx
@@ -26,6 +26,7 @@ import type { SixCardGolfResponse, SixCardGolfSlot } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
+import { sixCardGolfColumnScores } from '../utils/sixCardGolfColumnScores';
 
 const runner = sixcardgolfApi;
 
@@ -264,6 +265,21 @@ function SixCardGolfPageContent() {
                   />
                 ))}
               </div>
+              {player.isHuman && (phase === SCG_PHASE_ROUND_OVER || isGameEnd) && (
+                <div className="mt-1 grid grid-cols-3 gap-1" data-testid="scg-column-scores">
+                  {sixCardGolfColumnScores(player.grid).map((col, cIdx) => (
+                    <span
+                      key={cIdx}
+                      data-testid={`scg-column-score-${cIdx}`}
+                      className={`rounded px-1 py-0.5 text-center font-medium text-xs ${
+                        col.isPair ? 'bg-ds-success text-white' : 'bg-ds-surface-elevated text-ds-text-muted'
+                      }`}
+                    >
+                      {t('label.columnScore', { score: col.score })}
+                    </span>
+                  ))}
+                </div>
+              )}
             </div>
           ))}
 

--- a/frontend/src/utils/sixCardGolfColumnScores.test.ts
+++ b/frontend/src/utils/sixCardGolfColumnScores.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, SixCardGolfSlot } from '../types/card';
+import { sixCardGolfCardScore, sixCardGolfColumnScores } from './sixCardGolfColumnScores';
+
+const card = (value: number): Card => ({ design: 'SPADE', value }) as unknown as Card;
+const slot = (value: number | null, faceUp = true): SixCardGolfSlot => ({
+  card: value === null ? null : card(value),
+  faceUp,
+});
+
+describe('sixCardGolfCardScore', () => {
+  it('scores K as 0, A as 1, J/Q as 10, and others at face value', () => {
+    expect(sixCardGolfCardScore(card(13))).toBe(0);
+    expect(sixCardGolfCardScore(card(1))).toBe(1);
+    expect(sixCardGolfCardScore(card(11))).toBe(10);
+    expect(sixCardGolfCardScore(card(12))).toBe(10);
+    expect(sixCardGolfCardScore(card(7))).toBe(7);
+    expect(sixCardGolfCardScore(null)).toBe(0);
+  });
+});
+
+describe('sixCardGolfColumnScores', () => {
+  it('returns one score per column', () => {
+    const grid = [slot(3), slot(5), slot(7), slot(4), slot(6), slot(8)];
+    const cols = sixCardGolfColumnScores(grid);
+    expect(cols).toHaveLength(3);
+    expect(cols.map((c) => c.score)).toEqual([7, 11, 15]);
+    expect(cols.every((c) => !c.isPair)).toBe(true);
+  });
+
+  it('cancels a matched column to zero', () => {
+    // Column 0 is a pair (5 over 5) → 0; column 1 is K over K → pair 0.
+    const grid = [slot(5), slot(13), slot(2), slot(5), slot(13), slot(9)];
+    const cols = sixCardGolfColumnScores(grid);
+    expect(cols[0]).toEqual({ score: 0, isPair: true });
+    expect(cols[1]).toEqual({ score: 0, isPair: true });
+    expect(cols[2]).toEqual({ score: 11, isPair: false });
+  });
+
+  it('ignores face-down cards in the total', () => {
+    const grid = [slot(8), slot(4), slot(2), slot(6, false), slot(4, false), slot(2)];
+    const cols = sixCardGolfColumnScores(grid);
+    // col0: 8 + (face-down) = 8; col1: 4 + (face-down) = 4 (no pair, bottom hidden); col2: 2+2 pair → 0
+    expect(cols[0]).toEqual({ score: 8, isPair: false });
+    expect(cols[1]).toEqual({ score: 4, isPair: false });
+    expect(cols[2]).toEqual({ score: 0, isPair: true });
+  });
+});

--- a/frontend/src/utils/sixCardGolfColumnScores.ts
+++ b/frontend/src/utils/sixCardGolfColumnScores.ts
@@ -1,0 +1,53 @@
+import type { Card, SixCardGolfSlot } from '../types/card';
+
+/** Number of card columns in a Six Card Golf grid (2 rows × 3 columns). */
+export const SIX_CARD_GOLF_COLUMNS = 3;
+
+/** Score of a single Six Card Golf card: K=0, A=1, J/Q=10, otherwise face value. */
+export function sixCardGolfCardScore(card: Card | null): number {
+  if (!card) return 0;
+  switch (card.value) {
+    case 13:
+      return 0;
+    case 1:
+      return 1;
+    case 11:
+    case 12:
+      return 10;
+    default:
+      return card.value;
+  }
+}
+
+/** Score contribution of one column, mirroring the backend ScorePlayer rule. */
+export interface SixCardGolfColumnScore {
+  /** Combined points the column contributes (a matched pair contributes 0). */
+  score: number;
+  /** True when both cards are face up and share the same value (cancels to 0). */
+  isPair: boolean;
+}
+
+/**
+ * Computes the per-column score breakdown for a Six Card Golf grid.
+ *
+ * Columns are the vertical pairs (top index `c`, bottom index `c + 3`). A column
+ * whose two face-up cards share a value cancels to 0; otherwise each face-up
+ * card adds its {@link sixCardGolfCardScore}. Face-down cards score nothing.
+ */
+export function sixCardGolfColumnScores(grid: SixCardGolfSlot[]): SixCardGolfColumnScore[] {
+  const result: SixCardGolfColumnScore[] = [];
+  for (let col = 0; col < SIX_CARD_GOLF_COLUMNS; col++) {
+    const top = grid[col];
+    const bot = grid[col + SIX_CARD_GOLF_COLUMNS];
+    const isPair =
+      !!top?.faceUp && !!bot?.faceUp && top.card != null && bot.card != null && top.card.value === bot.card.value;
+    if (isPair) {
+      result.push({ score: 0, isPair: true });
+      continue;
+    }
+    const topScore = top?.faceUp ? sixCardGolfCardScore(top.card) : 0;
+    const botScore = bot?.faceUp ? sixCardGolfCardScore(bot.card) : 0;
+    result.push({ score: topScore + botScore, isPair: false });
+  }
+  return result;
+}


### PR DESCRIPTION
## 概要

シックスカードゴルフのスコアボードは累計/ラウンドスコアのみで、各列ペアの点数貢献（ペア=0点など）が分からなかった。ラウンド終了/ゲーム終了時に人間プレイヤーのグリッド下へ列ペアのスコア内訳バッジを表示する。

## 変更内容

- 新規 util `sixCardGolfColumnScores`（バックエンド `ScorePlayer` と同一ルール: 列ペア一致=0、K=0/A=1/J,Q=10/その他=数値、伏せ札=0）
- `SixCardGolfPage` で `phase === ROUND_OVER || isGameEnd` のとき各列バッジ（`scg-column-score-<c>`）を表示。ペア列は `bg-ds-success` の `0pt` ハイライト
- `label.columnScore` を ja / en に追加
- `SixCardGolfPage.test.tsx` を新規追加（従来テストなし）

## テスト

- `bun run test -- --run src/utils/sixCardGolfColumnScores.test.ts` … 4 passed
- `bun run test -- --run src/pages/SixCardGolfPage.test.tsx` … 3 passed
- `bun run check` … exit 0 / ja-en パリティ確認済み
- `bun run build`(`tsc -b`) はローカル ~2GB RAM で OOM するため CI ゲートで検証

Closes #2271