### PR TITLE
feat(callbreak): replace bid input with 1-13 button group

### DIFF
--- a/frontend/src/i18n/locales/en/callbreak.json
+++ b/frontend/src/i18n/locales/en/callbreak.json
@@ -33,6 +33,7 @@
   "scoresRound": "Round",
   "scoresTotal": "Total",
   "bidButton": "Bid",
+  "bidSelectLabel": "Select your bid",
   "playButton": "Play",
   "nextTrick": "Next Trick",
   "nextRound": "Next Round",

--- a/frontend/src/i18n/locales/ja/callbreak.json
+++ b/frontend/src/i18n/locales/ja/callbreak.json
@@ -33,6 +33,7 @@
   "scoresRound": "ラウンド",
   "scoresTotal": "累計",
   "bidButton": "ビッド",
+  "bidSelectLabel": "ビッド数を選択",
   "playButton": "出す",
   "nextTrick": "次のトリック",
   "nextRound": "次のラウンド",

--- a/frontend/src/pages/CallBreakPage.test.tsx
+++ b/frontend/src/pages/CallBreakPage.test.tsx
@@ -83,13 +83,16 @@ describe('CallBreakPage', () => {
     });
   });
 
-  it('renders bid phase with bid button and input', async () => {
+  it('renders bid phase with a 1-13 bid button group', async () => {
     mockExec.mockResolvedValue(bidPhaseState);
     renderWithProviders(<CallBreakPage />);
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'ビッド' })).toBeInTheDocument();
-      expect(screen.getByLabelText('bid-input')).toBeInTheDocument();
     });
+    // 13 selectable bid options, defaulting to 1 pressed.
+    expect(screen.getByTestId('bid-option-1')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('bid-option-13')).toBeInTheDocument();
+    expect(screen.queryByLabelText('bid-input')).not.toBeInTheDocument();
   });
 
   it('shows bid phase instruction when human bid turn', async () => {
@@ -112,8 +115,9 @@ describe('CallBreakPage', () => {
     renderWithProviders(<CallBreakPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ビッド' })).toBeInTheDocument());
 
-    const input = screen.getByLabelText('bid-input');
-    fireEvent.change(input, { target: { value: '5' } });
+    // Select bid 5 from the button group.
+    fireEvent.click(screen.getByTestId('bid-option-5'));
+    expect(screen.getByTestId('bid-option-5')).toHaveAttribute('aria-pressed', 'true');
 
     mockExec.mockClear();
     mockExec.mockResolvedValue(playPhaseState);

--- a/frontend/src/pages/CallBreakPage.tsx
+++ b/frontend/src/pages/CallBreakPage.tsx
@@ -462,20 +462,33 @@ function CallBreakPageContent() {
                 </button>
               )}
               {isHumanBidTurn && (
-                <>
-                  <input
-                    type="number"
-                    min={1}
-                    max={13}
-                    value={bidValue}
-                    onChange={(e) => setBidValue(Number(e.target.value))}
-                    className="w-16 px-2 py-1 rounded bg-white/20 text-ds-text-primary text-center"
-                    aria-label="bid-input"
-                  />
+                <div className="flex flex-col items-center gap-2">
+                  <fieldset
+                    className="grid max-w-[16rem] grid-cols-7 gap-1 border-0 p-0"
+                    aria-label={t('bidSelectLabel')}
+                  >
+                    {Array.from({ length: 13 }, (_, i) => i + 1).map((n) => (
+                      <button
+                        key={n}
+                        type="button"
+                        onClick={() => setBidValue(n)}
+                        disabled={loading}
+                        aria-pressed={bidValue === n}
+                        data-testid={`bid-option-${n}`}
+                        className={`h-9 w-9 rounded-lg font-medium text-sm transition-all ${
+                          bidValue === n
+                            ? 'bg-ds-accent text-white ring-2 ring-ds-accent'
+                            : 'bg-white/20 text-ds-text-primary hover:bg-white/30'
+                        }`}
+                      >
+                        {n}
+                      </button>
+                    ))}
+                  </fieldset>
                   <button type="button" className={btnPrimary} onClick={() => handleBid(bidValue)} disabled={loading}>
                     {t('bidButton')}
                   </button>
-                </>
+                </div>
               )}
               {isHumanTurn && (
                 <button


### PR DESCRIPTION
## 概要

コールブレイクの有効ビッド範囲は常に 1〜13 で固定。`<input type=number>` は操作コストが高くモバイルで不便だったため、1〜13 のボタングループに置き換える。

## 変更内容

- ビッド入力を `<fieldset>` の 7 列グリッド（1〜7 / 8〜13 の2行折り返し）ボタングループに置換
- 選択中ビッドを `aria-pressed` + `ring-2 ring-ds-accent` でハイライト
- 確定は既存「ビッド」ボタン。`type=number` 入力は削除
- `bidSelectLabel` キーを ja / en に追加
- `CallBreakPage.test.tsx` をボタングループ操作に更新

## テスト

- `bun run test -- --run src/pages/CallBreakPage.test.tsx` … 20 passed
- `bun run check` … exit 0（a11y: role=group の div → fieldset 化で解消）/ ja-en パリティ確認済み
- `bun run build`(`tsc -b`) はローカル OOM のため CI ゲート

Closes #2260