### PR TITLE
feat(fourcardpoker): replace play-multiplier select with Play 1x/2x/3x buttons

### DIFF
--- a/frontend/e2e/fourcardpoker.spec.ts
+++ b/frontend/e2e/fourcardpoker.spec.ts
@@ -10,7 +10,7 @@ test.describe('Four Card Poker E2E', () => {
     await betButton.click();
     await waitForLoaded(page);
 
-    const playButton = page.getByRole('button', { name: 'プレイ' });
+    const playButton = page.getByRole('button', { name: 'プレイ 1x' });
     await expect(playButton).toBeVisible({ timeout: 10_000 });
     await playButton.click();
     await waitForLoaded(page);

--- a/frontend/src/i18n/locales/en/fourcardpoker.json
+++ b/frontend/src/i18n/locales/en/fourcardpoker.json
@@ -8,12 +8,11 @@
     "ante": "Ante",
     "acesUp": "Aces Up",
     "play": "Play Bet",
-    "playMultiplier": "Play Mul",
     "handRank": "Hand"
   },
   "button": {
     "bet": "Bet",
-    "play": "Play",
+    "playMult": "Play {{mult}}x",
     "fold": "Fold",
     "reset": "Reset"
   },

--- a/frontend/src/i18n/locales/ja/fourcardpoker.json
+++ b/frontend/src/i18n/locales/ja/fourcardpoker.json
@@ -8,12 +8,11 @@
     "ante": "アンテ",
     "acesUp": "エースズアップ",
     "play": "プレイベット",
-    "playMultiplier": "プレイ倍率",
     "handRank": "役"
   },
   "button": {
     "bet": "ベット",
-    "play": "プレイ",
+    "playMult": "プレイ {{mult}}x",
     "fold": "フォールド",
     "reset": "リセット"
   },

--- a/frontend/src/pages/FourCardPokerPage.test.tsx
+++ b/frontend/src/pages/FourCardPokerPage.test.tsx
@@ -169,8 +169,22 @@ describe('FourCardPokerPage', () => {
   it('sends play command with the chosen multiplier button', async () => {
     mockExec.mockResolvedValue(actionPhaseState);
     renderWithProviders(<FourCardPokerPage />);
-    fireEvent.click(await screen.findByTestId('play-3x'));
+    fireEvent.click(await screen.findByTestId('play-1x'));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', undefined, undefined, 1));
+    fireEvent.click(screen.getByTestId('play-2x'));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', undefined, undefined, 2));
+    fireEvent.click(screen.getByTestId('play-3x'));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', undefined, undefined, 3));
+  });
+
+  it('plays via the 1/2/3 keyboard shortcuts', async () => {
+    mockExec.mockResolvedValue(actionPhaseState);
+    renderWithProviders(<FourCardPokerPage />);
+    await screen.findByTestId('play-1x');
+    for (const key of ['1', '2', '3'] as const) {
+      fireEvent.keyDown(document, { key });
+      await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', undefined, undefined, Number(key)));
+    }
   });
 
   it('sends fold command', async () => {

--- a/frontend/src/pages/FourCardPokerPage.test.tsx
+++ b/frontend/src/pages/FourCardPokerPage.test.tsx
@@ -155,20 +155,21 @@ describe('FourCardPokerPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bet', 100, 0));
   });
 
-  it('renders action phase with play and fold buttons', async () => {
+  it('renders action phase with per-multiplier play buttons and fold', async () => {
     mockExec.mockResolvedValue(actionPhaseState);
     renderWithProviders(<FourCardPokerPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'プレイ' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('play-1x')).toBeInTheDocument());
+    expect(screen.getByTestId('play-2x')).toBeInTheDocument();
+    expect(screen.getByTestId('play-3x')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'フォールド' })).toBeInTheDocument();
+    // The select-box multiplier control is gone.
+    expect(screen.queryByLabelText(/プレイ倍率/)).not.toBeInTheDocument();
   });
 
-  it('sends play command with selected multiplier', async () => {
+  it('sends play command with the chosen multiplier button', async () => {
     mockExec.mockResolvedValue(actionPhaseState);
     renderWithProviders(<FourCardPokerPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'プレイ' })).toBeInTheDocument());
-
-    fireEvent.change(screen.getByLabelText(/プレイ倍率/), { target: { value: '3' } });
-    fireEvent.click(screen.getByRole('button', { name: 'プレイ' }));
+    fireEvent.click(await screen.findByTestId('play-3x'));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', undefined, undefined, 3));
   });
 

--- a/frontend/src/pages/FourCardPokerPage.tsx
+++ b/frontend/src/pages/FourCardPokerPage.tsx
@@ -66,7 +66,6 @@ function FourCardPokerPageContent() {
 
   const [anteAmount, setAnteAmount] = useState(100);
   const [acesUpAmount, setAcesUpAmount] = useState(0);
-  const [playMultiplier, setPlayMultiplier] = useState(1);
 
   const { cardWidth } = useCardDimensions();
   const { playSound } = useSound();
@@ -85,11 +84,13 @@ function FourCardPokerPageContent() {
         action: () => execApi('bet', anteAmount, acesUpAmount),
         enabled: isBetPhase,
       },
-      { key: 'p', action: () => execApi('play', undefined, undefined, playMultiplier), enabled: isActionPhase },
+      { key: '1', action: () => execApi('play', undefined, undefined, 1), enabled: isActionPhase },
+      { key: '2', action: () => execApi('play', undefined, undefined, 2), enabled: isActionPhase },
+      { key: '3', action: () => execApi('play', undefined, undefined, 3), enabled: isActionPhase },
       { key: 'f', action: () => execApi('fold'), enabled: isActionPhase },
       { key: 'r', action: () => execApi('reset'), enabled: isEndPhase },
     ],
-    [execApi, anteAmount, acesUpAmount, playMultiplier, isBetPhase, isActionPhase, isEndPhase],
+    [execApi, anteAmount, acesUpAmount, isBetPhase, isActionPhase, isEndPhase],
   );
 
   useActionKeyboardNav({
@@ -103,8 +104,8 @@ function FourCardPokerPageContent() {
     execApi('bet', anteAmount, acesUpAmount);
   };
 
-  const handlePlay = () => {
-    execApi('play', undefined, undefined, playMultiplier);
+  const handlePlay = (mult: number) => {
+    execApi('play', undefined, undefined, mult);
   };
 
   const handleFold = () => {
@@ -295,25 +296,19 @@ function FourCardPokerPageContent() {
         )}
         {isActionPhase && (
           <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="fcp-action-buttons">
-            <div className="flex items-center gap-2">
-              <label htmlFor="fcp-play-multiplier" className="text-ds-text-primary text-sm">
-                {t('label.playMultiplier')}
-              </label>
-              <select
-                id="fcp-play-multiplier"
-                value={playMultiplier}
-                onChange={(e) => setPlayMultiplier(Number(e.target.value))}
-                className="px-2 py-1 rounded text-sm"
-              >
-                <option value={1}>1x</option>
-                <option value={2}>2x</option>
-                <option value={3}>3x</option>
-              </select>
-            </div>
-            <div className="flex justify-center gap-2">
-              <button type="button" className={btnSuccess} onClick={handlePlay} disabled={loading}>
-                {t('button.play')}
-              </button>
+            <div className="flex flex-wrap justify-center gap-2">
+              {[1, 2, 3].map((mult) => (
+                <button
+                  key={mult}
+                  type="button"
+                  className={btnSuccess}
+                  onClick={() => handlePlay(mult)}
+                  disabled={loading}
+                  data-testid={`play-${mult}x`}
+                >
+                  {t('button.playMult', { mult })}
+                </button>
+              ))}
               <button type="button" className={btnDanger} onClick={handleFold} disabled={loading}>
                 {t('button.fold')}
               </button>


### PR DESCRIPTION
## 概要

フォーカードポーカーのアクションフェーズは倍率を `<select>` で選んでから「プレイ」を押す2ステップ操作だった。固定3択なので、High Card Flush の raise ボタン群と同じく「Play 1x/2x/3x」ボタンに置き換える。

## 変更内容

- `<select id="fcp-play-multiplier">` + 単一プレイボタンを廃止し、`btnSuccess` の `Play {{mult}}x` ×3 + Fold に置換（`data-testid="play-{1,2,3}x"`）
- `playMultiplier` ローカルステートを削除
- キーボードショートカットを `p` → `1`/`2`/`3` に変更（`f`/`r` は維持）
- 不要になった `button.play` / `label.playMultiplier` キーを ja/en から削除
- `FourCardPokerPage.test.tsx` をボタン操作に更新

## テスト

- `bun run test -- --run src/pages/FourCardPokerPage.test.tsx` … 13 passed
- `bun run check` … exit 0 / ja-en パリティ確認済み
- `bun run build`(`tsc -b`) はローカル OOM のため CI ゲート

Closes #2265