### PR TITLE
feat(highcardflush): stepper buttons for bet inputs via ChipBetInput

### DIFF
--- a/frontend/src/components/common/ChipBetInput.test.tsx
+++ b/frontend/src/components/common/ChipBetInput.test.tsx
@@ -141,4 +141,34 @@ describe('ChipBetInput', () => {
     fireEvent.wheel(input, { deltaY: 100 });
     expect(document.activeElement).not.toBe(input);
   });
+
+  describe('steppers', () => {
+    it('does not render steppers by default', () => {
+      render(<ChipBetInput id="bet" label="Bet" value={50} onChange={() => {}} max={500} />);
+      expect(screen.queryByRole('button', { name: /Bet \+/ })).not.toBeInTheDocument();
+    });
+
+    it('increments and decrements by step, clamped to [min, max]', () => {
+      const onChange = vi.fn();
+      render(
+        <ChipBetInput id="bet" label="Bet" value={50} onChange={onChange} min={10} max={500} step={10} showSteppers />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Bet +10' }));
+      expect(onChange).toHaveBeenLastCalledWith(60);
+      fireEvent.click(screen.getByRole('button', { name: 'Bet −10' }));
+      expect(onChange).toHaveBeenLastCalledWith(40);
+    });
+
+    it('disables the minus button at min and the plus button at max', () => {
+      const { rerender } = render(
+        <ChipBetInput id="bet" label="Bet" value={10} onChange={() => {}} min={10} max={100} step={10} showSteppers />,
+      );
+      expect(screen.getByRole('button', { name: 'Bet −10' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Bet +10' })).toBeEnabled();
+      rerender(
+        <ChipBetInput id="bet" label="Bet" value={100} onChange={() => {}} min={10} max={100} step={10} showSteppers />,
+      );
+      expect(screen.getByRole('button', { name: 'Bet +10' })).toBeDisabled();
+    });
+  });
 });

--- a/frontend/src/components/common/ChipBetInput.tsx
+++ b/frontend/src/components/common/ChipBetInput.tsx
@@ -32,6 +32,12 @@ export interface ChipBetInputProps {
   invalid?: boolean;
   /** Optional id of an element describing the input (typically an error message). */
   describedBy?: string;
+  /**
+   * When true, render −/＋ stepper buttons (of size `step`) on either side of the
+   * input that clamp to [min, max]. Off by default so existing consumers are
+   * unaffected.
+   */
+  showSteppers?: boolean;
 }
 
 /**
@@ -51,16 +57,32 @@ export function ChipBetInput({
   autoClamp = true,
   invalid,
   describedBy,
+  showSteppers = false,
 }: ChipBetInputProps) {
   // Foreground stays text-ds-text-primary (10.1:1 AAA on surface) — pairing
   // text-ds-error with bg-ds-surface only hits ~2.7:1, well below WCAG AA.
   // The error semantic is carried entirely by the coloured border.
   const errorClasses = invalid ? 'bg-ds-surface border-ds-error text-ds-text-primary' : '';
+  const upperBound = max ?? Number.POSITIVE_INFINITY;
+  const stepBy = (delta: number) => onChange(Math.max(min, Math.min(value + delta, upperBound)));
+  const stepperClass =
+    'min-h-[44px] min-w-[44px] rounded bg-ds-surface-elevated px-3 font-bold text-ds-text-primary text-lg disabled:opacity-40 disabled:cursor-not-allowed';
   return (
     <div className="flex items-center gap-2">
       <label htmlFor={id} className="text-ds-text-primary text-sm">
         {label}
       </label>
+      {showSteppers && (
+        <button
+          type="button"
+          aria-label={`${label} −${step}`}
+          className={stepperClass}
+          onClick={() => stepBy(-step)}
+          disabled={disabled || value <= min}
+        >
+          −
+        </button>
+      )}
       <input
         id={id}
         type="text"
@@ -91,6 +113,17 @@ export function ChipBetInput({
         disabled={disabled}
         className={`${widthClass} px-3 py-2 rounded text-base min-h-[44px] ${errorClasses}`}
       />
+      {showSteppers && (
+        <button
+          type="button"
+          aria-label={`${label} +${step}`}
+          className={stepperClass}
+          onClick={() => stepBy(step)}
+          disabled={disabled || (max != null && value >= max)}
+        >
+          ＋
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/HighCardFlushPage.tsx
+++ b/frontend/src/pages/HighCardFlushPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { highcardflushApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
+import { ChipBetInput } from '../components/common/ChipBetInput';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
@@ -319,51 +320,39 @@ function HighCardFlushPageContent() {
         />
         {isBetPhase && (
           <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="hcf-bet-controls">
-            <div className="flex items-center gap-2">
-              <label htmlFor="hcf-ante" className="text-ds-text-primary text-sm">
-                {t('label.ante')}
-              </label>
-              <input
-                id="hcf-ante"
-                type="number"
-                min={10}
-                max={state.chips}
-                step={10}
-                value={anteAmount}
-                onChange={(e) => setAnteAmount(Number(e.target.value))}
-                className="w-24 px-2 py-1 rounded text-sm"
-              />
-            </div>
-            <div className="flex items-center gap-2">
-              <label htmlFor="hcf-flush-bonus" className="text-ds-text-primary text-sm">
-                {t('label.flushBonus')}
-              </label>
-              <input
-                id="hcf-flush-bonus"
-                type="number"
-                min={0}
-                max={state.chips}
-                step={10}
-                value={flushBonusAmount}
-                onChange={(e) => setFlushBonusAmount(Number(e.target.value))}
-                className="w-24 px-2 py-1 rounded text-sm"
-              />
-            </div>
-            <div className="flex items-center gap-2">
-              <label htmlFor="hcf-straight-flush" className="text-ds-text-primary text-sm">
-                {t('label.straightFlush')}
-              </label>
-              <input
-                id="hcf-straight-flush"
-                type="number"
-                min={0}
-                max={state.chips}
-                step={10}
-                value={straightFlushAmount}
-                onChange={(e) => setStraightFlushAmount(Number(e.target.value))}
-                className="w-24 px-2 py-1 rounded text-sm"
-              />
-            </div>
+            <ChipBetInput
+              id="hcf-ante"
+              label={t('label.ante')}
+              value={anteAmount}
+              onChange={setAnteAmount}
+              min={10}
+              max={state.chips}
+              step={10}
+              disabled={loading}
+              showSteppers
+            />
+            <ChipBetInput
+              id="hcf-flush-bonus"
+              label={t('label.flushBonus')}
+              value={flushBonusAmount}
+              onChange={setFlushBonusAmount}
+              min={0}
+              max={state.chips}
+              step={10}
+              disabled={loading}
+              showSteppers
+            />
+            <ChipBetInput
+              id="hcf-straight-flush"
+              label={t('label.straightFlush')}
+              value={straightFlushAmount}
+              onChange={setStraightFlushAmount}
+              min={0}
+              max={state.chips}
+              step={10}
+              disabled={loading}
+              showSteppers
+            />
             <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading}>
               {t('button.bet')}
             </button>


### PR DESCRIPTION
## 概要

ハイカードフラッシュのベットフェーズは Ante / Flush Bonus / Straight Flush の3つをフリーテキスト `type=number` で入力しており、モバイルで操作しづらく超過バリデーションも送信後まで分からなかった。共通 `ChipBetInput` に `-10/+10` ステッパーを追加して置き換える。

## 変更内容

- 共通 `ChipBetInput` にオプトインの `showSteppers` prop を追加（デフォルト off → 既存カジノ消費者は不変）。`−`/`＋` ボタン（`step` 刻み、44px タップターゲット、[min,max] クランプ、境界で `disabled`）
- High Card Flush の3つの生 `input[type=number]` を `ChipBetInput`（`showSteppers`）に置換。即時 `max=chips` クランプ + label 紐付けを獲得
- `ChipBetInput.test.tsx` にステッパーのテストを追加

## テスト

- `bun run test -- --run src/components/common/ChipBetInput.test.tsx src/pages/HighCardFlushPage.test.tsx` … 37 passed
- `bun run check` … exit 0
- `bun run build`(`tsc -b`) はローカル OOM のため CI ゲート

Closes #2262