### PR TITLE
feat(casinoholdem): unify ante/bonus inputs to ChipBetInput with steppers

### DIFF
--- a/frontend/src/i18n/locales/en/casinoholdem.json
+++ b/frontend/src/i18n/locales/en/casinoholdem.json
@@ -5,6 +5,7 @@
   "board": "Board",
   "dealerQualified": "Dealer qualifies",
   "dealerDoesNotQualify": "Dealer does not qualify",
+  "betError": "Ante must be at least 10, bets in steps of 10, and within your balance",
   "label": {
     "chips": "Chips",
     "ante": "Ante",

--- a/frontend/src/i18n/locales/ja/casinoholdem.json
+++ b/frontend/src/i18n/locales/ja/casinoholdem.json
@@ -5,6 +5,7 @@
   "board": "ボード",
   "dealerQualified": "ディーラークオリファイ",
   "dealerDoesNotQualify": "ディーラーノークオリファイ",
+  "betError": "アンテは10以上、ベットは10単位で、残高以内で指定してください",
   "label": {
     "chips": "チップ",
     "ante": "アンテ",

--- a/frontend/src/pages/CasinoHoldemPage.test.tsx
+++ b/frontend/src/pages/CasinoHoldemPage.test.tsx
@@ -163,6 +163,28 @@ describe('CasinoHoldemPage', () => {
     await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', 200, 10));
   });
 
+  it('shows a validation error and disables Bet for a non-multiple-of-10 ante', async () => {
+    mockApi.mockResolvedValue(betPhaseState);
+    renderWithProviders(<CasinoHoldemPage />);
+    await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText('アンテ'), { target: { value: '15' } });
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'ベット' })).toBeDisabled();
+  });
+
+  it('steps the ante up and down with the stepper buttons', async () => {
+    mockApi.mockResolvedValue(betPhaseState);
+    renderWithProviders(<CasinoHoldemPage />);
+    await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
+
+    const ante = screen.getByLabelText('アンテ') as HTMLInputElement;
+    fireEvent.click(screen.getByRole('button', { name: 'アンテ +10' }));
+    expect(ante.value).toBe('110');
+    fireEvent.click(screen.getByRole('button', { name: 'アンテ −10' }));
+    expect(ante.value).toBe('100');
+  });
+
   it('shows network error', async () => {
     mockApi.mockResolvedValueOnce(betPhaseState).mockRejectedValueOnce(new Error('Network'));
     renderWithProviders(<CasinoHoldemPage />);

--- a/frontend/src/pages/CasinoHoldemPage.tsx
+++ b/frontend/src/pages/CasinoHoldemPage.tsx
@@ -3,6 +3,7 @@ import { casinoholdemApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { ChipBetInput } from '../components/common/ChipBetInput';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
@@ -131,6 +132,12 @@ function CasinoHoldemPageContent() {
   const handleCall = () => execApi('call');
   const handleFold = () => execApi('fold');
   const handleReset = () => execApi('reset');
+
+  // Bet validation: ante must be a positive multiple of 10, bonus a (possibly
+  // zero) multiple of 10, and their sum within the chip balance.
+  const anteInvalid = Number.isNaN(anteAmount) || anteAmount < 10 || anteAmount % 10 !== 0;
+  const bonusInvalid = Number.isNaN(bonusAmount) || bonusAmount < 0 || bonusAmount % 10 !== 0;
+  const betInvalid = anteInvalid || bonusInvalid || anteAmount + bonusAmount > state.chips;
 
   const phaseName = isBetPhase ? t('phase.bet') : isFlopPhase ? t('phase.flop') : t('phase.end');
 
@@ -320,51 +327,38 @@ function CasinoHoldemPageContent() {
             <SettingsPanel title={t('settings.title')} groups={[]} />
             {isBetPhase && (
               <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="ch-bet-controls">
-                <div className="flex items-center gap-2">
-                  <label htmlFor="casinoholdem-ante-amount" className="text-ds-text-primary text-sm">
-                    {t('label.ante')}
-                  </label>
-                  <input
-                    id="casinoholdem-ante-amount"
-                    type="number"
-                    min={10}
-                    max={state.chips}
-                    step={10}
-                    value={anteAmount}
-                    onChange={(e) => setAnteAmount(Number(e.target.value))}
-                    className="w-24 px-2 py-1 rounded text-sm"
-                  />
-                </div>
-                <div className="flex items-center gap-2">
-                  <label htmlFor="casinoholdem-bonus-amount" className="text-ds-text-primary text-sm">
-                    {t('label.bonus')}
-                  </label>
-                  <input
-                    id="casinoholdem-bonus-amount"
-                    type="number"
-                    min={0}
-                    max={state.chips}
-                    step={10}
-                    value={bonusAmount}
-                    onChange={(e) => setBonusAmount(Number(e.target.value))}
-                    className="w-24 px-2 py-1 rounded text-sm"
-                  />
-                </div>
-                <button
-                  type="button"
-                  className={btnPrimary}
-                  onClick={handleBet}
-                  disabled={
-                    loading ||
-                    Number.isNaN(anteAmount) ||
-                    Number.isNaN(bonusAmount) ||
-                    anteAmount < 10 ||
-                    anteAmount % 10 !== 0 ||
-                    (bonusAmount > 0 && bonusAmount < 10) ||
-                    bonusAmount % 10 !== 0 ||
-                    anteAmount + bonusAmount > state.chips
-                  }
-                >
+                <ChipBetInput
+                  id="casinoholdem-ante-amount"
+                  label={t('label.ante')}
+                  value={anteAmount}
+                  onChange={setAnteAmount}
+                  min={10}
+                  max={state.chips}
+                  step={10}
+                  disabled={loading}
+                  showSteppers
+                  invalid={anteInvalid}
+                  describedBy={betInvalid ? 'casinoholdem-bet-error' : undefined}
+                />
+                <ChipBetInput
+                  id="casinoholdem-bonus-amount"
+                  label={t('label.bonus')}
+                  value={bonusAmount}
+                  onChange={setBonusAmount}
+                  min={0}
+                  max={state.chips}
+                  step={10}
+                  disabled={loading}
+                  showSteppers
+                  invalid={bonusInvalid}
+                  describedBy={betInvalid ? 'casinoholdem-bet-error' : undefined}
+                />
+                {betInvalid && (
+                  <p id="casinoholdem-bet-error" role="alert" className="text-ds-error text-xs">
+                    {t('betError')}
+                  </p>
+                )}
+                <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading || betInvalid}>
                   {t('button.bet')}
                 </button>
               </div>


### PR DESCRIPTION
## 概要

カジノホールデムの BET フェーズはアンテ/ボーナスが生 `input[type=number]` で、`% 10` 不正時はボタンが無効化されるだけでエラーが見えなかった。共通 `ChipBetInput`（ステッパー付き）へ統一し、検証メッセージを表示する。

## 変更内容

- アンテ/ボーナス入力を `ChipBetInput`（`showSteppers`）に置換。`−`/`＋` で10単位制約を自然に満たす
- 範囲外（10未満・10単位でない・残高超過）のとき `role="alert"` の `betError` メッセージを表示し、両入力を `invalid` に
- `betError` キーを ja/en に追加
- `CasinoHoldemPage.test.tsx` にエラー表示 + ステッパー操作テストを追加

## テスト

- `bun run test -- --run src/pages/CasinoHoldemPage.test.tsx` … 15 passed
- `bun run check` … exit 0 / ja-en パリティ確認済み
- `bun run build`(`tsc -b`) はローカル OOM のため CI ゲート

Closes #2259