### PR TITLE
feat(oasispoker): unify ante/jackpot inputs to ChipBetInput with steppers

### DIFF
--- a/frontend/src/pages/OasisPokerPage.tsx
+++ b/frontend/src/pages/OasisPokerPage.tsx
@@ -3,6 +3,7 @@ import { oasispokerApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { ChipBetInput } from '../components/common/ChipBetInput';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
@@ -369,36 +370,28 @@ function OasisPokerPageContent() {
             <SettingsPanel title={t('settings.title')} groups={[]} />
             {isBetPhase && (
               <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="oasis-bet-controls">
-                <div className="flex items-center gap-2">
-                  <label htmlFor="oasispoker-ante-amount" className="text-ds-text-primary text-sm">
-                    {t('label.ante')}
-                  </label>
-                  <input
-                    id="oasispoker-ante-amount"
-                    type="number"
-                    min={10}
-                    max={state.chips}
-                    step={10}
-                    value={anteAmount}
-                    onChange={(e) => setAnteAmount(Number(e.target.value))}
-                    className="w-24 px-2 py-1 rounded text-sm"
-                  />
-                </div>
-                <div className="flex items-center gap-2">
-                  <label htmlFor="oasispoker-jackpot-amount" className="text-ds-text-primary text-sm">
-                    {t('label.jackpot')}
-                  </label>
-                  <input
-                    id="oasispoker-jackpot-amount"
-                    type="number"
-                    min={0}
-                    max={state.chips}
-                    step={10}
-                    value={jackpotAmount}
-                    onChange={(e) => setJackpotAmount(Number(e.target.value))}
-                    className="w-24 px-2 py-1 rounded text-sm"
-                  />
-                </div>
+                <ChipBetInput
+                  id="oasispoker-ante-amount"
+                  label={t('label.ante')}
+                  value={anteAmount}
+                  onChange={setAnteAmount}
+                  min={10}
+                  max={state.chips}
+                  step={10}
+                  disabled={loading}
+                  showSteppers
+                />
+                <ChipBetInput
+                  id="oasispoker-jackpot-amount"
+                  label={t('label.jackpot')}
+                  value={jackpotAmount}
+                  onChange={setJackpotAmount}
+                  min={0}
+                  max={state.chips}
+                  step={10}
+                  disabled={loading}
+                  showSteppers
+                />
                 <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading}>
                   {t('button.bet')}
                 </button>


### PR DESCRIPTION
## 概要

オアシスポーカーの BET フェーズはアンテ/ジャックポットが生 `input[type=number]` で、他カジノゲームと操作感が揃っていなかった。共通 `ChipBetInput`（ステッパー付き）へ統一する。

## 変更内容

- アンテ入力を `ChipBetInput`（`min=10`, `showSteppers`）に置換
- ジャックポット入力を `ChipBetInput`（`min=0`, `showSteppers`）に置換。0 のままでも `bet` は正常送信
- `max={state.chips}` の上限維持

## テスト

- `bun run test -- --run src/pages/OasisPokerPage.test.tsx` … 12 passed（既存テストは label 紐付けで継続動作）
- `bun run check` … exit 0
- `bun run build`(`tsc -b`) はローカル OOM のため CI ゲート

Closes #2256