### PR TITLE
feat(ultimatetexasholdem): unify ante/trips inputs to ChipBetInput with steppers

### DIFF
--- a/frontend/src/pages/UltimateTexasHoldemPage.tsx
+++ b/frontend/src/pages/UltimateTexasHoldemPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { ultimatetexasholdemApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
+import { ChipBetInput } from '../components/common/ChipBetInput';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
@@ -334,36 +335,30 @@ function UltimateTexasHoldemPageContent() {
         {isBetPhase && (
           <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="uth-bet-controls">
             <div className="flex items-center gap-2">
-              <label htmlFor="uth-ante-amount" className="text-ds-text-primary text-sm">
-                {t('label.ante')}
-              </label>
-              <input
+              <ChipBetInput
                 id="uth-ante-amount"
-                type="number"
+                label={t('label.ante')}
+                value={anteAmount}
+                onChange={setAnteAmount}
                 min={10}
                 max={Math.floor(state.chips / 2)}
                 step={10}
-                value={anteAmount}
-                onChange={(e) => setAnteAmount(Number(e.target.value))}
-                className="w-24 px-2 py-1 rounded text-sm"
+                disabled={loading}
+                showSteppers
               />
               <span className="text-ds-text-muted text-xs">×2 ({t('label.blind')})</span>
             </div>
-            <div className="flex items-center gap-2">
-              <label htmlFor="uth-trips-amount" className="text-ds-text-primary text-sm">
-                {t('label.trips')}
-              </label>
-              <input
-                id="uth-trips-amount"
-                type="number"
-                min={0}
-                max={state.chips}
-                step={10}
-                value={tripsAmount}
-                onChange={(e) => setTripsAmount(Number(e.target.value))}
-                className="w-24 px-2 py-1 rounded text-sm"
-              />
-            </div>
+            <ChipBetInput
+              id="uth-trips-amount"
+              label={t('label.trips')}
+              value={tripsAmount}
+              onChange={setTripsAmount}
+              min={0}
+              max={state.chips}
+              step={10}
+              disabled={loading}
+              showSteppers
+            />
             <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading}>
               {t('button.bet')}
             </button>


### PR DESCRIPTION
## 概要

アルティメットテキサスホールデムだけ BET フェーズのアンテ/トリップスが生 `input[type=number]` で、他カジノゲームと一貫性がなかった。共通 `ChipBetInput`（ステッパー付き）へ統一する。

## 変更内容

- アンテ入力を `ChipBetInput`（`min=10`, `max=floor(chips/2)`, `showSteppers`）に置換。`×2 (ブラインド)` ヒントは維持
- トリップス入力を `ChipBetInput`（`min=0`, `showSteppers`）に置換
- チップ単位ボタン（−/＋ 10刻み）で操作

## テスト

- `bun run test -- --run src/pages/UltimateTexasHoldemPage.test.tsx` … 26 passed
- `bun run check` … exit 0
- `bun run build`(`tsc -b`) はローカル OOM のため CI ゲート

Closes #2250