### PR TITLE
ci(claude-review): auto-review on PR open, not only on @claude

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,31 +2,60 @@ name: Claude Code PR Review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, reopened]
     branches-ignore:
       - master
   issue_comment:
     types: [created]
 
 jobs:
-  claude-review:
+  # Automatic review fired by simply opening (or reopening) a PR.
+  # claude-code-action only reviews autonomously when given a `prompt`; without
+  # one it stays in mention mode and does nothing on a pull_request event.
+  auto-review:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    if: >
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
-
     permissions:
       contents: write
       pull-requests: write
       issues: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Run Claude Code Action
+      - name: Run Claude Code Action (auto review)
+        uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review this pull request. Inspect the diff (e.g. `gh pr diff`), then assess:
+            - Correctness bugs and missed edge cases
+            - Security issues
+            - Performance concerns
+            - Maintainability and adherence to the project's conventions (see CLAUDE.md)
+            Post your findings as a single PR review comment grouped by severity, and
+            clearly flag anything that must be fixed before merge. If the change looks
+            good, say so briefly.
+
+  # Interactive response when someone mentions @claude on a PR or issue comment.
+  # No prompt here: the action reads the comment as its instruction.
+  mention-review:
+    if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code Action (mention)
         uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 背景

`claude-review.yml` は `pull_request: [opened]` を購読しているのに、PR を作っただけではレビューが走らず、`@claude` コメント時しか発火していなかった。

## 原因

`anthropics/claude-code-action@v1` は **`prompt` を渡したときだけ自律レビュー（automation mode）** を行う。`prompt` が無いと「メンション応答モード」のままで、`pull_request` イベントでは何もしない（[公式ドキュメント](https://github.com/anthropics/claude-code-action) 確認済み）。

## 修正

ワークフローをイベント別の2ジョブに分割:

- **auto-review** (`pull_request` opened / reopened): レビュー用 `prompt` を付与して自動レビューを実行
- **mention-review** (`issue_comment` の `@claude`): 従来どおり `prompt` なしのインタラクティブ応答

`reopened` も購読対象に追加（bot コミット後の close/reopen 再トリガーでも新規レビューが走るように）。

## 確認

- YAML 構文・ジョブ/トリガー構造を検証済み
- 既存の `@claude` メンション経路は `mention-review` ジョブで維持

注: develop にマージ後の PR から自動レビューが有効になります（`pull_request` はベースブランチのワークフロー定義で動作するため、本 PR 自体はまだ自動発火しません）。