### PR TITLE
feat(beleagueredcastle): pulse the auto-complete button when ready

### DIFF
--- a/frontend/src/i18n/locales/en/beleagueredcastle.json
+++ b/frontend/src/i18n/locales/en/beleagueredcastle.json
@@ -14,6 +14,7 @@
   "landscapeBanner": "Landscape mode recommended",
   "hint": "Hint",
   "autoComplete": "Auto Complete",
+  "autoCompleteNotReady": "Available once a foundation builds past its ace",
   "undo": "Undo",
   "stalemate": "Stalemate",
   "playing": "Move cards to build foundations",

--- a/frontend/src/i18n/locales/ja/beleagueredcastle.json
+++ b/frontend/src/i18n/locales/ja/beleagueredcastle.json
@@ -14,6 +14,7 @@
   "landscapeBanner": "横画面での表示を推奨します",
   "hint": "ヒント",
   "autoComplete": "自動完成",
+  "autoCompleteNotReady": "ファンデーションを2枚目以降まで進めると有効になります",
   "undo": "元に戻す",
   "stalemate": "手詰まりです",
   "playing": "カードを移動してください",

--- a/frontend/src/pages/BeleagueredCastlePage.test.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.test.tsx
@@ -108,10 +108,26 @@ describe('BeleagueredCastlePage', () => {
     await waitFor(() => expect(screen.getAllByText(/ゲームオーバー/).length).toBeGreaterThan(0));
   });
 
-  it('renders auto-complete button enabled while playing', async () => {
-    mockExec.mockResolvedValue(playingState);
+  it('disables the auto-complete button and shows a reason when no foundation has progressed', async () => {
+    mockExec.mockResolvedValue(playingState); // foundations hold only aces
     renderWithProviders(<BeleagueredCastlePage />);
-    await waitFor(() => expect(screen.getByTestId('autocomplete-button')).toBeEnabled());
+    const btn = await screen.findByTestId('autocomplete-button');
+    expect(btn).toBeDisabled();
+    expect(btn.className).not.toContain('animate-pulse');
+    expect(btn).toHaveAttribute('title');
+  });
+
+  it('enables and pulses the auto-complete button once a foundation builds past its ace', async () => {
+    const readyState: BeleagueredCastleResponse = {
+      ...playingState,
+      foundation: [[card('SPADE', 1), card('SPADE', 2)], [card('CLOVER', 1)], [card('HEART', 1)], [card('DIAMOND', 1)]],
+    };
+    mockExec.mockResolvedValue(readyState);
+    renderWithProviders(<BeleagueredCastlePage />);
+    const btn = await screen.findByTestId('autocomplete-button');
+    expect(btn).toBeEnabled();
+    expect(btn.className).toContain('animate-pulse');
+    expect(btn.className).toContain('ring-ds-success');
   });
 
   it('shows StalemateEscapeButton when stalemate flag is set', async () => {

--- a/frontend/src/pages/BeleagueredCastlePage.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.tsx
@@ -157,6 +157,9 @@ function BeleagueredCastlePageContent() {
   const isGameClear = state.phase === BeleagueredCastlePhase.GAME_CLEAR;
   const isGameOver = state.phase === BeleagueredCastlePhase.GAME_OVER;
   const isEnded = isGameClear || isGameOver;
+  // Auto-complete becomes useful once a foundation has built past its ace, so
+  // pulse the button only then (mirrors Crescent / Spiderette).
+  const autoCompleteReady = state.foundation.some((pile) => pile.length > 1);
 
   const isSourceSelected = (zone: string, col?: number, cardIndex?: number) =>
     selectedSource !== null &&
@@ -399,10 +402,11 @@ function BeleagueredCastlePageContent() {
                   </button>
                   <button
                     type="button"
-                    className={btnSuccess}
+                    className={`${btnSuccess}${autoCompleteReady && !loading && !isAutoCompleting ? ' animate-pulse ring-2 ring-ds-success' : ''}`}
                     onClick={game.handleAutoComplete}
-                    disabled={loading || isAutoCompleting}
+                    disabled={loading || isAutoCompleting || !autoCompleteReady}
                     data-testid="autocomplete-button"
+                    title={autoCompleteReady ? undefined : t('autoCompleteNotReady')}
                   >
                     {t('autoComplete')}
                   </button>


### PR DESCRIPTION
## 概要

包囲された城の自動完成ボタンは `btnSuccess` のみで、オートコンプリート可能になったタイミングの視覚フィードバックがなかった。Crescent / Spiderette と同じパターンを踏襲する。

## 変更内容

- `autoCompleteReady`（いずれかのファンデーションがエース以降まで進んだ状態）を算出
- ready 時に `animate-pulse ring-2 ring-ds-success` を付与し、ボタンを有効化
- not-ready 時はボタンを `disabled` にして `title`（`autoCompleteNotReady`）で理由を表示
- `autoCompleteNotReady` キーを ja/en に追加
- `BeleagueredCastlePage.test.tsx` に ready/not-ready のパルス・disabled・title アサーションを追加

## テスト

- `bun run test -- --run src/pages/BeleagueredCastlePage.test.tsx` … 10 passed
- `bun run check` … exit 0 / ja-en パリティ確認済み
- `bun run build`(`tsc -b`) はローカル OOM のため CI ゲート

Closes #2257