### PR TITLE
ci(claude-review): let the auto-review job actually post its review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,15 +30,22 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Consolidate the review into a single, updated-in-place PR comment.
+          use_sticky_comment: true
+          # In automation mode the action does not grant gh/comment tools by
+          # default, so the review could run but not post (permission denials).
+          # Allow it to read the diff and post its review summary + inline notes.
+          claude_args: |
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),mcp__github_inline_comment__create_inline_comment"
           prompt: |
             Review this pull request. Inspect the diff (e.g. `gh pr diff`), then assess:
             - Correctness bugs and missed edge cases
             - Security issues
             - Performance concerns
             - Maintainability and adherence to the project's conventions (see CLAUDE.md)
-            Post your findings as a single PR review comment grouped by severity, and
-            clearly flag anything that must be fixed before merge. If the change looks
-            good, say so briefly.
+            Post your findings as a single PR comment grouped by severity (use
+            `gh pr comment`), and clearly flag anything that must be fixed before
+            merge. If the change looks good, say so briefly.
 
   # Interactive response when someone mentions @claude on a PR or issue comment.
   # No prompt here: the action reads the comment as its instruction.


### PR DESCRIPTION
## 背景

#2353 で PR open 時に `auto-review` ジョブが起動するようになったが、[実行ログ](https://github.com/yuta-yoshinaga/go_trumpcards/actions/runs/27096086965/job/79968406122) を見ると **ジョブは success だが何も投稿されていない**（`permission_denials_count: 5`, `No buffered inline comments`）。

## 原因

`claude-code-action@v1` の automation モードは、デフォルトでは `gh` コマンドやコメント投稿ツールを許可しない。そのため prompt の「`gh pr diff` で差分を見て `gh pr comment` で投稿」が全て denial になり、レビューが走っても結果を投稿できなかった。

## 修正

`auto-review` ジョブに以下を追加:

- `claude_args: --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),mcp__github_inline_comment__create_inline_comment"` — 差分閲覧 + レビュー投稿（要約コメント + インラインコメント）を許可
- `use_sticky_comment: true` — レビューを1つの sticky コメントに集約（reopen/再実行でも同じコメントを更新）

prompt も `gh pr comment` で投稿するよう明示。

## 確認

- YAML 構文・`claude_args`/`use_sticky_comment` の付与を検証済み
- `mention-review`（@claude）ジョブは従来どおり変更なし