### PR TITLE
feat(crescent): color-code foundation direction + top card in aria

### DIFF
--- a/frontend/src/i18n/locales/en/crescent.json
+++ b/frontend/src/i18n/locales/en/crescent.json
@@ -12,7 +12,7 @@
   "redealUnavailable": "No redeals remaining",
   "giveup": "Give Up",
   "empty": "Empty",
-  "foundationAriaLabel": "{{direction}} foundation {{suit}} {{count}} cards",
+  "foundationAriaLabel": "{{direction}} foundation {{suit}} {{count}} cards top {{top}}",
   "emptyFoundationAriaLabel": "Empty {{direction}} foundation ({{suit}})",
   "landscapeBanner": "Landscape mode recommended",
   "hint": "Hint",

--- a/frontend/src/i18n/locales/en/crescent.json
+++ b/frontend/src/i18n/locales/en/crescent.json
@@ -14,6 +14,10 @@
   "empty": "Empty",
   "foundationAriaLabel": "{{direction}} foundation {{suit}} {{count}} cards top {{top}}",
   "emptyFoundationAriaLabel": "Empty {{direction}} foundation ({{suit}})",
+  "direction": {
+    "asc": "Ascending",
+    "desc": "Descending"
+  },
   "landscapeBanner": "Landscape mode recommended",
   "hint": "Hint",
   "autoComplete": "Auto Complete",

--- a/frontend/src/i18n/locales/ja/crescent.json
+++ b/frontend/src/i18n/locales/ja/crescent.json
@@ -12,7 +12,7 @@
   "redealUnavailable": "残り再配り回数がありません",
   "giveup": "ギブアップ",
   "empty": "空",
-  "foundationAriaLabel": "{{direction}}ファンデーション {{suit}} 残り{{count}}枚",
+  "foundationAriaLabel": "{{direction}}ファンデーション {{suit}} 残り{{count}}枚 トップ {{top}}",
   "emptyFoundationAriaLabel": "空の{{direction}}ファンデーション ({{suit}})",
   "landscapeBanner": "横向きでのプレイを推奨します",
   "hint": "ヒント",

--- a/frontend/src/i18n/locales/ja/crescent.json
+++ b/frontend/src/i18n/locales/ja/crescent.json
@@ -14,6 +14,10 @@
   "empty": "空",
   "foundationAriaLabel": "{{direction}}ファンデーション {{suit}} 残り{{count}}枚 トップ {{top}}",
   "emptyFoundationAriaLabel": "空の{{direction}}ファンデーション ({{suit}})",
+  "direction": {
+    "asc": "昇順",
+    "desc": "降順"
+  },
   "landscapeBanner": "横向きでのプレイを推奨します",
   "hint": "ヒント",
   "autoComplete": "オートコンプリート",

--- a/frontend/src/pages/CrescentPage.test.tsx
+++ b/frontend/src/pages/CrescentPage.test.tsx
@@ -110,8 +110,8 @@ describe('CrescentPage', () => {
     expect(asc.className).toContain('text-ds-success');
     const desc = screen.getByTestId('foundation-dir-4'); // row 1 = descending
     expect(desc.className).toContain('text-ds-warning');
-    // Ascending ♠ pile tops out at A → aria-label mentions the top card.
-    expect(screen.getByLabelText(/トップ ♠ A/)).toBeInTheDocument();
+    // Ascending ♠ pile tops out at A → aria-label is localized and names the top card.
+    expect(screen.getByLabelText(/昇順ファンデーション ♠ 残り1枚 トップ ♠ A/)).toBeInTheDocument();
   });
 
   it('redeal button shows remaining count', async () => {

--- a/frontend/src/pages/CrescentPage.test.tsx
+++ b/frontend/src/pages/CrescentPage.test.tsx
@@ -104,6 +104,16 @@ describe('CrescentPage', () => {
     expect(screen.getAllByText(/♠ ↓/).length).toBeGreaterThanOrEqual(1);
   });
 
+  it('color-codes the foundation direction badges and names the top card', async () => {
+    renderWithProviders(<CrescentPage />);
+    const asc = await screen.findByTestId('foundation-dir-0'); // row 0 = ascending
+    expect(asc.className).toContain('text-ds-success');
+    const desc = screen.getByTestId('foundation-dir-4'); // row 1 = descending
+    expect(desc.className).toContain('text-ds-warning');
+    // Ascending ♠ pile tops out at A → aria-label mentions the top card.
+    expect(screen.getByLabelText(/トップ ♠ A/)).toBeInTheDocument();
+  });
+
   it('redeal button shows remaining count', async () => {
     renderWithProviders(<CrescentPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: /再配り/ })).toBeInTheDocument());

--- a/frontend/src/pages/CrescentPage.tsx
+++ b/frontend/src/pages/CrescentPage.tsx
@@ -221,7 +221,9 @@ function CrescentPageContent() {
                             <span
                               data-testid={`foundation-dir-${idx}`}
                               className={`inline-block rounded px-1 font-bold ${
-                                directionKey === 'asc' ? 'text-ds-success' : 'text-ds-warning'
+                                directionKey === 'asc'
+                                  ? 'bg-ds-success/20 text-ds-success'
+                                  : 'bg-ds-warning/20 text-ds-warning'
                               }`}
                             >
                               {suit} {directionKey === 'asc' ? '↑' : '↓'}
@@ -240,7 +242,7 @@ function CrescentPageContent() {
                                 disabled={!isPlaying || loading || isAutoCompleting || !selectedSource}
                                 aria-label={t('foundationAriaLabel', {
                                   suit,
-                                  direction: directionKey,
+                                  direction: t(`direction.${directionKey}`),
                                   count: pile.length,
                                   top: cardAlt(pile[pile.length - 1]),
                                 })}

--- a/frontend/src/pages/CrescentPage.tsx
+++ b/frontend/src/pages/CrescentPage.tsx
@@ -217,8 +217,15 @@ function CrescentPageContent() {
                       const suit = FOUNDATION_SUITS[col];
                       return (
                         <div key={`f-${idx}`} className="text-center">
-                          <div className="text-game-text-muted text-xs mb-1">
-                            {suit} {directionKey === 'asc' ? '↑' : '↓'}
+                          <div className="text-xs mb-1">
+                            <span
+                              data-testid={`foundation-dir-${idx}`}
+                              className={`inline-block rounded px-1 font-bold ${
+                                directionKey === 'asc' ? 'text-ds-success' : 'text-ds-warning'
+                              }`}
+                            >
+                              {suit} {directionKey === 'asc' ? '↑' : '↓'}
+                            </span>
                           </div>
                           <DropZone
                             isDropTarget={dnd.isDropTarget(foundationZone)}
@@ -235,6 +242,7 @@ function CrescentPageContent() {
                                   suit,
                                   direction: directionKey,
                                   count: pile.length,
+                                  top: cardAlt(pile[pile.length - 1]),
                                 })}
                                 className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite}`}
                               >


### PR DESCRIPTION
## 概要

クレセント・ソリティアの8つの基礎スタックは `↑`/`↓` のテキストのみで方向を示しており、色覚や初見では昇順/降順が直感的に分かりにくかった。また aria-label にトップカード情報が無かった。

## 変更内容

- 各基礎ヘッダーに色付き方向バッジを追加（昇順=`text-ds-success`、降順=`text-ds-warning`、`data-testid="foundation-dir-<idx>"`)
- `foundationAriaLabel` に現在のトップカード（`cardAlt`）を追加（ja/en）
- `CrescentPage.test.tsx` にバッジ色 + トップカード aria のテストを追加

## テスト

- `bun run test -- --run src/pages/CrescentPage.test.tsx` … 18 passed
- `bun run check` … exit 0 / ja-en パリティ確認済み
- `bun run build`(`tsc -b`) はローカル OOM のため CI ゲート

Closes #2251