### PR TITLE
feat(rummy500): click a laid meld to pick the lay-off target

### DIFF
--- a/frontend/src/i18n/locales/en/rummy500.json
+++ b/frontend/src/i18n/locales/en/rummy500.json
@@ -25,6 +25,7 @@
   "meldButton": "Meld",
   "layoffOwner": "Owner",
   "layoffMeld": "Meld#",
+  "layoffMeldTarget": "Select {{owner}}'s meld {{idx}} as lay-off target",
   "layoffButton": "Lay off",
   "discardButton": "Discard",
   "nextRound": "Next round",

--- a/frontend/src/i18n/locales/ja/rummy500.json
+++ b/frontend/src/i18n/locales/ja/rummy500.json
@@ -25,6 +25,7 @@
   "meldButton": "メルドする",
   "layoffOwner": "所有者",
   "layoffMeld": "メルド#",
+  "layoffMeldTarget": "{{owner}} のメルド {{idx}} をレイオフ先に選択",
   "layoffButton": "レイオフ",
   "discardButton": "捨てる",
   "nextRound": "次のラウンド",

--- a/frontend/src/pages/Rummy500Page.test.tsx
+++ b/frontend/src/pages/Rummy500Page.test.tsx
@@ -121,6 +121,33 @@ describe('Rummy500Page', () => {
     expect(screen.getByRole('button', { name: /^捨てる$/ })).toBeInTheDocument();
   });
 
+  it('selects a lay-off target by clicking a laid meld', async () => {
+    const withMeld: Rummy500Response = {
+      ...playPhaseState,
+      players: [
+        playPhaseState.players[0],
+        {
+          ...playPhaseState.players[1],
+          laidMelds: [
+            {
+              cards: [
+                { design: 'DIAMOND', value: 4 },
+                { design: 'DIAMOND', value: 5 },
+                { design: 'DIAMOND', value: 6 },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    mockExec.mockResolvedValue(withMeld);
+    renderWithProviders(<Rummy500Page />);
+    const meldBtn = await screen.findByTestId('layoff-meld-1-0');
+    expect(meldBtn).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(meldBtn);
+    await waitFor(() => expect(screen.getByTestId('layoff-meld-1-0')).toHaveAttribute('aria-pressed', 'true'));
+  });
+
   it('shows next round button in RoundEnd phase', async () => {
     mockExec.mockResolvedValue(roundEndState);
     renderWithProviders(<Rummy500Page />);

--- a/frontend/src/pages/Rummy500Page.tsx
+++ b/frontend/src/pages/Rummy500Page.tsx
@@ -213,18 +213,34 @@ function Rummy500PageContent() {
                 {p.laidMelds.length > 0 && (
                   <div className="mt-1">
                     <div className="text-ds-text-muted text-xs mb-1">{t('laidMelds')}</div>
-                    {p.laidMelds.map((meld, mIdx) => (
-                      <div key={`meld-${p.id}-${mIdx}`} className="flex flex-wrap gap-1 mb-1">
-                        <span className="text-xs text-ds-text-muted self-center">[{mIdx}]</span>
-                        {meld.cards.map((card, ci) => (
-                          <AnimatedCard
-                            key={`meld-${p.id}-${mIdx}-${card.design}-${card.value}-${ci}`}
-                            card={card}
-                            width={cardWidth * 0.6}
-                          />
-                        ))}
-                      </div>
-                    ))}
+                    {p.laidMelds.map((meld, mIdx) => {
+                      const isLayoffTarget = layoffOwner === p.id && layoffMeldIdx === mIdx;
+                      return (
+                        <button
+                          type="button"
+                          key={`meld-${p.id}-${mIdx}`}
+                          onClick={() => {
+                            setLayoffOwner(p.id);
+                            setLayoffMeldIdx(mIdx);
+                          }}
+                          aria-pressed={isLayoffTarget}
+                          aria-label={t('layoffMeldTarget', { owner: playerName(p.id, p.isHuman), idx: mIdx })}
+                          data-testid={`layoff-meld-${p.id}-${mIdx}`}
+                          className={`flex flex-wrap gap-1 mb-1 w-full rounded p-1 text-left transition-all ${
+                            isLayoffTarget ? 'ring-2 ring-ds-info' : 'hover:bg-white/5'
+                          }`}
+                        >
+                          <span className="text-xs text-ds-text-muted self-center">[{mIdx}]</span>
+                          {meld.cards.map((card, ci) => (
+                            <AnimatedCard
+                              key={`meld-${p.id}-${mIdx}-${card.design}-${card.value}-${ci}`}
+                              card={card}
+                              width={cardWidth * 0.6}
+                            />
+                          ))}
+                        </button>
+                      );
+                    })}
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## 概要

ラミー500 のレイオフは、メルドがカード画像で表示されているのに「インデックス番号」を数値入力する必要があり一貫性がなかった。表示中のメルド行をクリックで選べるようにする。

## 変更内容

- 各 `laidMelds` 行を `<button>` 化。クリックで `layoffOwner` / `layoffMeldIdx` を自動設定
- 選択中メルドを `ring-2 ring-ds-info` でハイライト（`aria-pressed`)
- `aria-label`（`layoffMeldTarget`）+ `data-testid="layoff-meld-<owner>-<idx>"` でキーボード/テスト対応
- 既存の owner `<select>` / index `<input>` はフォールバックとして残置（レイオフボタンの有効化挙動は不変）

## テスト

- `bun run test -- --run src/pages/Rummy500Page.test.tsx` … 11 passed（新規: メルドクリックで aria-pressed が true に）
- `bun run check` … exit 0 / ja-en パリティ確認済み
- `bun run build`(`tsc -b`) はローカル OOM のため CI ゲート

Closes #2266