### PR TITLE
ci(claude-review): track_progress for reliable auto-review posting

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,22 +30,26 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Consolidate the review into a single, updated-in-place PR comment.
-          use_sticky_comment: true
-          # In automation mode the action does not grant gh/comment tools by
-          # default, so the review could run but not post (permission denials).
-          # Allow it to read the diff and post its review summary + inline notes.
+          # track_progress makes the action create and maintain a tracking
+          # comment, so the review is reliably posted (without it the job ran
+          # but sometimes posted nothing — permission denials / no buffered
+          # comments). This is the official automatic-review mechanism.
+          track_progress: true
+          # Tools the review needs to read the diff and post inline + summary.
           claude_args: |
-            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),mcp__github_inline_comment__create_inline_comment"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
             Review this pull request. Inspect the diff (e.g. `gh pr diff`), then assess:
             - Correctness bugs and missed edge cases
             - Security issues
             - Performance concerns
             - Maintainability and adherence to the project's conventions (see CLAUDE.md)
-            Post your findings as a single PR comment grouped by severity (use
-            `gh pr comment`), and clearly flag anything that must be fixed before
-            merge. If the change looks good, say so briefly.
+            Use inline comments for specific issues and a top-level comment for the
+            overall summary grouped by severity. Clearly flag anything that must be
+            fixed before merge. If the change looks good, say so briefly.
 
   # Interactive response when someone mentions @claude on a PR or issue comment.
   # No prompt here: the action reads the comment as its instruction.


### PR DESCRIPTION
## 背景

#2353 + #2355 で auto-review は起動しツール許可も付与したが、**投稿が不安定**だった。#2356 では投稿されたが #2357 では `permission_denials_count: 3` / `No buffered inline comments` で何も投稿されなかった。

## 原因

automation モードでの投稿は、`use_sticky_comment` + ツール許可だけでは確実に行われない（Claude が要約テキストを出してもアクションが投稿しないケースがある）。

## 修正

公式の `pr-review-comprehensive.yml` 例にならい **`track_progress: true`** を採用:

- アクションがトラッキングコメントを作成・更新し、レビューを**確実に投稿**する（automatic-review の正式な仕組み）
- prompt に `REPO` / `PR NUMBER` コンテキストを追加
- `claude_args --allowedTools` を upstream 例と同順に（inline comment 優先）
- `use_sticky_comment` は track_progress に置き換え（重複回避）

## 確認

- YAML 構文・`track_progress`/`claude_args` 付与を検証済み
- `mention-review`（@claude）ジョブは変更なし

> 注: 本PR自体の auto-review は develop の現行ワークフローで走るため、確実な投稿は **マージ後のPR** から有効になります。