### PR TITLE
feat(mighty): trump/partner suit button groups in declaration

### DIFF
--- a/frontend/src/i18n/locales/en/mighty.json
+++ b/frontend/src/i18n/locales/en/mighty.json
@@ -32,6 +32,7 @@
   "noTrumpToggle": "No-Trump",
   "currentTrick": "Current Trick",
   "trumpSuit": "Trump",
+  "partnerSuit": "Partner card suit",
   "noTrump": "No-Trump",
   "partnerCard": "Partner card",
   "partnerNone": "(none)",

--- a/frontend/src/i18n/locales/ja/mighty.json
+++ b/frontend/src/i18n/locales/ja/mighty.json
@@ -32,6 +32,7 @@
   "noTrumpToggle": "ノートランプ",
   "currentTrick": "現在のトリック",
   "trumpSuit": "切り札",
+  "partnerSuit": "パートナーカードのスート",
   "noTrump": "ノートランプ",
   "partnerCard": "パートナー指名カード",
   "partnerNone": "なし",

--- a/frontend/src/pages/MightyPage.test.tsx
+++ b/frontend/src/pages/MightyPage.test.tsx
@@ -372,17 +372,27 @@ describe('MightyPage', () => {
     mockCall.mockResolvedValue(trumpAndFriendState);
     renderWithProviders(<MightyPage />);
     await waitFor(() => {
-      expect(screen.getByLabelText('trump-suit')).toBeInTheDocument();
-      expect(screen.getByLabelText('partner-suit')).toBeInTheDocument();
+      expect(screen.getByTestId('trump-suit--1')).toBeInTheDocument();
+      expect(screen.getByTestId('trump-suit-1')).toBeInTheDocument();
+      expect(screen.getByTestId('partner-suit-0')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: '宣言' })).toBeInTheDocument();
     });
+  });
+
+  it('highlights the selected trump suit button', async () => {
+    mockCall.mockResolvedValue(trumpAndFriendState);
+    renderWithProviders(<MightyPage />);
+    const heart = await screen.findByTestId('trump-suit-3');
+    fireEvent.click(heart);
+    expect(screen.getByTestId('trump-suit-3')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('trump-suit-1')).toHaveAttribute('aria-pressed', 'false');
   });
 
   it('does not show declaration controls when cpu is declarer', async () => {
     mockCall.mockResolvedValue(trumpAndFriendCpuState);
     renderWithProviders(<MightyPage />);
     await waitFor(() => expect(screen.getByText('スコア')).toBeInTheDocument());
-    expect(screen.queryByLabelText('trump-suit')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('trump-suit--1')).not.toBeInTheDocument();
   });
 
   it('calls trump command when declare button clicked', async () => {
@@ -400,18 +410,18 @@ describe('MightyPage', () => {
   it('hides partner-value when partner-suit is joker (0)', async () => {
     mockCall.mockResolvedValue(trumpAndFriendState);
     renderWithProviders(<MightyPage />);
-    await waitFor(() => expect(screen.getByLabelText('partner-suit')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('partner-suit-0')).toBeInTheDocument());
 
-    fireEvent.change(screen.getByLabelText('partner-suit'), { target: { value: '0' } });
+    fireEvent.click(screen.getByTestId('partner-suit-0'));
     expect(screen.queryByLabelText('partner-value')).not.toBeInTheDocument();
   });
 
   it('sends partner-value 0 when joker partner is chosen', async () => {
     mockCall.mockResolvedValue(trumpAndFriendState);
     renderWithProviders(<MightyPage />);
-    await waitFor(() => expect(screen.getByLabelText('partner-suit')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('partner-suit-0')).toBeInTheDocument());
 
-    fireEvent.change(screen.getByLabelText('partner-suit'), { target: { value: '0' } });
+    fireEvent.click(screen.getByTestId('partner-suit-0'));
 
     mockCall.mockClear();
     mockCall.mockResolvedValue(playPhaseState);
@@ -423,9 +433,9 @@ describe('MightyPage', () => {
   it('supports No-Trump trump declaration (-1)', async () => {
     mockCall.mockResolvedValue(trumpAndFriendState);
     renderWithProviders(<MightyPage />);
-    await waitFor(() => expect(screen.getByLabelText('trump-suit')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('trump-suit--1')).toBeInTheDocument());
 
-    fireEvent.change(screen.getByLabelText('trump-suit'), { target: { value: '-1' } });
+    fireEvent.click(screen.getByTestId('trump-suit--1'));
 
     mockCall.mockClear();
     mockCall.mockResolvedValue(playPhaseState);

--- a/frontend/src/pages/MightyPage.test.tsx
+++ b/frontend/src/pages/MightyPage.test.tsx
@@ -388,6 +388,15 @@ describe('MightyPage', () => {
     expect(screen.getByTestId('trump-suit-1')).toHaveAttribute('aria-pressed', 'false');
   });
 
+  it('highlights the selected partner suit button', async () => {
+    mockCall.mockResolvedValue(trumpAndFriendState);
+    renderWithProviders(<MightyPage />);
+    const club = await screen.findByTestId('partner-suit-2');
+    fireEvent.click(club);
+    expect(screen.getByTestId('partner-suit-2')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('partner-suit-0')).toHaveAttribute('aria-pressed', 'false');
+  });
+
   it('does not show declaration controls when cpu is declarer', async () => {
     mockCall.mockResolvedValue(trumpAndFriendCpuState);
     renderWithProviders(<MightyPage />);

--- a/frontend/src/pages/MightyPage.tsx
+++ b/frontend/src/pages/MightyPage.tsx
@@ -106,6 +106,14 @@ const MIGHTY_PHASE_KEYS: Readonly<Record<number, string>> = {
 };
 
 const SUIT_KEYS: Record<number, string> = { 1: 'spade', 2: 'club', 3: 'heart', 4: 'diamond' };
+const SUIT_SYMBOLS: Record<number, string> = { 1: '♠', 2: '♣', 3: '♥', 4: '♦' };
+
+/** Tailwind classes for a suit/option toggle button (44px tap target, highlighted when selected). */
+function suitToggleClass(selected: boolean): string {
+  return `min-h-[44px] min-w-[44px] rounded px-2 font-bold text-lg ${
+    selected ? 'bg-ds-accent text-white ring-2 ring-ds-accent' : 'bg-white/20 text-ds-text-primary'
+  }`;
+}
 
 /** Renders the Mighty game page with bidding, trump/friend declaration, kitty exchange, trick play, and scoring. */
 export const MightyPage = withTutorial(MightyPageContent, 'mighty', MIGHTY_TUTORIAL_STEPS);
@@ -677,32 +685,58 @@ function MightyPageContent() {
               {/* Trump & Friend declaration controls */}
               {isHumanDeclarer && (
                 <>
-                  <select
-                    value={trumpSuitValue}
-                    onChange={(e) => setTrumpSuitValue(Number(e.target.value))}
-                    className="px-2 py-1 rounded bg-white/20 text-ds-text-primary"
-                    aria-label="trump-suit"
-                  >
-                    <option value={-1}>{t('noTrump')}</option>
+                  <fieldset className="flex flex-wrap gap-1 border-0 p-0" aria-label={t('trumpSuit')}>
+                    <button
+                      type="button"
+                      aria-pressed={trumpSuitValue === -1}
+                      data-testid="trump-suit--1"
+                      onClick={() => setTrumpSuitValue(-1)}
+                      disabled={loading}
+                      className={suitToggleClass(trumpSuitValue === -1)}
+                    >
+                      {t('noTrump')}
+                    </button>
                     {[1, 2, 3, 4].map((s) => (
-                      <option key={s} value={s}>
-                        {t(`suitName.${SUIT_KEYS[s]}`)}
-                      </option>
+                      <button
+                        key={s}
+                        type="button"
+                        aria-pressed={trumpSuitValue === s}
+                        aria-label={t(`suitName.${SUIT_KEYS[s]}`)}
+                        data-testid={`trump-suit-${s}`}
+                        onClick={() => setTrumpSuitValue(s)}
+                        disabled={loading}
+                        className={suitToggleClass(trumpSuitValue === s)}
+                      >
+                        {SUIT_SYMBOLS[s]}
+                      </button>
                     ))}
-                  </select>
-                  <select
-                    value={partnerSuitValue}
-                    onChange={(e) => setPartnerSuitValue(Number(e.target.value))}
-                    className="px-2 py-1 rounded bg-white/20 text-ds-text-primary"
-                    aria-label="partner-suit"
-                  >
-                    <option value={0}>JOKER</option>
+                  </fieldset>
+                  <fieldset className="flex flex-wrap gap-1 border-0 p-0" aria-label={t('partnerSuit')}>
+                    <button
+                      type="button"
+                      aria-pressed={partnerSuitValue === 0}
+                      data-testid="partner-suit-0"
+                      onClick={() => setPartnerSuitValue(0)}
+                      disabled={loading}
+                      className={suitToggleClass(partnerSuitValue === 0)}
+                    >
+                      JOKER
+                    </button>
                     {[1, 2, 3, 4].map((s) => (
-                      <option key={s} value={s}>
-                        {t(`suitName.${SUIT_KEYS[s]}`)}
-                      </option>
+                      <button
+                        key={s}
+                        type="button"
+                        aria-pressed={partnerSuitValue === s}
+                        aria-label={t(`suitName.${SUIT_KEYS[s]}`)}
+                        data-testid={`partner-suit-${s}`}
+                        onClick={() => setPartnerSuitValue(s)}
+                        disabled={loading}
+                        className={suitToggleClass(partnerSuitValue === s)}
+                      >
+                        {SUIT_SYMBOLS[s]}
+                      </button>
                     ))}
-                  </select>
+                  </fieldset>
                   {partnerSuitValue > 0 && (
                     <select
                       value={partnerValueValue}

--- a/frontend/src/pages/MightyPage.tsx
+++ b/frontend/src/pages/MightyPage.tsx
@@ -110,9 +110,9 @@ const SUIT_SYMBOLS: Record<number, string> = { 1: '♠', 2: '♣', 3: '♥', 4: 
 
 /** Tailwind classes for a suit/option toggle button (44px tap target, highlighted when selected). */
 function suitToggleClass(selected: boolean): string {
-  return `min-h-[44px] min-w-[44px] rounded px-2 font-bold text-lg ${
-    selected ? 'bg-ds-accent text-white ring-2 ring-ds-accent' : 'bg-white/20 text-ds-text-primary'
-  }`;
+  return selected
+    ? 'min-h-[44px] min-w-[44px] rounded px-2 font-bold text-lg bg-ds-accent text-white ring-2 ring-ds-accent'
+    : 'min-h-[44px] min-w-[44px] rounded px-2 font-bold text-lg bg-white/20 text-ds-text-primary';
 }
 
 /** Renders the Mighty game page with bidding, trump/friend declaration, kitty exchange, trick play, and scoring. */
@@ -685,7 +685,8 @@ function MightyPageContent() {
               {/* Trump & Friend declaration controls */}
               {isHumanDeclarer && (
                 <>
-                  <fieldset className="flex flex-wrap gap-1 border-0 p-0" aria-label={t('trumpSuit')}>
+                  <fieldset className="flex flex-wrap gap-1 border-0 p-0">
+                    <legend className="sr-only">{t('trumpSuit')}</legend>
                     <button
                       type="button"
                       aria-pressed={trumpSuitValue === -1}
@@ -711,7 +712,8 @@ function MightyPageContent() {
                       </button>
                     ))}
                   </fieldset>
-                  <fieldset className="flex flex-wrap gap-1 border-0 p-0" aria-label={t('partnerSuit')}>
+                  <fieldset className="flex flex-wrap gap-1 border-0 p-0">
+                    <legend className="sr-only">{t('partnerSuit')}</legend>
                     <button
                       type="button"
                       aria-pressed={partnerSuitValue === 0}


### PR DESCRIPTION
## 概要

マイティの TRUMP_AND_FRIEND フェーズは切り札スート・パートナーカードを3つの `<select>` で選んでおり、モバイルで操作性が悪く他ゲーム（Belote 等）と一貫性がなかった。スート選択をボタングループに置き換える。

## 変更内容

- 切り札スート選択を `<fieldset>` ボタングループ化（`No-Trump` + ♠♣♥♦）
- パートナーカードのスート選択も同様（`JOKER` + ♠♣♥♦）
- パートナーカードの値選択は `<select>` のまま維持
- 44×44px タップターゲット、選択中は `bg-ds-accent ring-2 ring-ds-accent` でハイライト（`aria-pressed`)
- `partnerSuit` キーを ja/en に追加。CLI モードは不変

## テスト

- `bun run test -- --run src/pages/MightyPage.test.tsx` … 55 passed（既存の select 操作テストをボタンクリックへ更新 + 選択ハイライトテスト追加）
- `bun run check` … exit 0 / design-tokens OK / ja-en パリティ確認済み
- `bun run build`(`tsc -b`) はローカル OOM のため CI ゲート

Closes #2255