### PR TITLE
feat(easthaven): flag empty stock + columns hiding face-down cards

### DIFF
--- a/frontend/src/pages/EasthavenPage.test.tsx
+++ b/frontend/src/pages/EasthavenPage.test.tsx
@@ -88,6 +88,24 @@ describe('EasthavenPage', () => {
     expect(screen.getByRole('button', { name: '配る' })).toBeDisabled();
   });
 
+  it('warns on empty stock and flags columns that still hide a face-down card', async () => {
+    // stock 0, column 0 still has a face-down card, columns 1+ are all face up.
+    mockExec.mockResolvedValue({ ...playingState, stockCount: 0 });
+    renderWithProviders(<EasthavenPage />);
+    await waitFor(() => expect(screen.getByTestId('eh-stock')).toBeInTheDocument());
+    expect(screen.getByTestId('eh-stock').className).toContain('text-ds-warning');
+    expect(screen.getByTestId('eh-col-header-0').className).toContain('bg-ds-warning');
+    expect(screen.getByTestId('eh-col-header-1').className).not.toContain('bg-ds-warning');
+  });
+
+  it('does not flag stock or columns while the stock still has cards', async () => {
+    mockExec.mockResolvedValue(playingState); // stockCount 31
+    renderWithProviders(<EasthavenPage />);
+    await waitFor(() => expect(screen.getByTestId('eh-stock')).toBeInTheDocument());
+    expect(screen.getByTestId('eh-stock').className).not.toContain('text-ds-warning');
+    expect(screen.getByTestId('eh-col-header-0').className).not.toContain('bg-ds-warning');
+  });
+
   it('shows game clear phase', async () => {
     mockExec.mockResolvedValue(gameClearState);
     renderWithProviders(<EasthavenPage />);

--- a/frontend/src/pages/EasthavenPage.tsx
+++ b/frontend/src/pages/EasthavenPage.tsx
@@ -369,7 +369,11 @@ function EasthavenPageContent() {
           <span>
             {t('moveCount')}: {state.moveCount}
           </span>
-          <span data-tutorial="eh-stock">
+          <span
+            data-tutorial="eh-stock"
+            data-testid="eh-stock"
+            className={state.stockCount === 0 ? 'font-bold text-ds-warning' : undefined}
+          >
             {t('stock')}: {state.stockCount}
           </span>
           <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
@@ -448,7 +452,17 @@ function EasthavenPageContent() {
             <div className="flex gap-1 sm:gap-2 justify-center" data-tutorial="eh-tableau">
               {state.tableau.map((col, colIdx) => (
                 <div key={colIdx} className="flex flex-col items-center" style={{ width: eh.cw }}>
-                  <div className="text-game-text-muted text-xs mb-1">{colIdx}</div>
+                  {/* Once the stock is empty, flag columns still hiding a face-down card. */}
+                  <div
+                    data-testid={`eh-col-header-${colIdx}`}
+                    className={`mb-1 rounded px-1 text-game-text-muted text-xs ${
+                      state.stockCount === 0 && !autoCompleteReady && col.some((c) => !c.faceUp)
+                        ? 'bg-ds-warning/20'
+                        : ''
+                    }`}
+                  >
+                    {colIdx}
+                  </div>
                   {col.length === 0 ? (
                     <DropZone
                       onDrop={dnd.handleDrop({ zone: 'tableau', col: colIdx })}


### PR DESCRIPTION
## 概要

イーストヘイブンは全カード表向き+ストック0で自動完成ボタンがパルスするが、その達成を阻む「ストック切れなのに裏向きカードが残っている」状態のフィードバックが無かった。

## 変更内容

- `stockCount === 0` のとき、ヘッダーの `stock: 0` 表示を `font-bold text-ds-warning` で強調（`data-testid="eh-stock"`)
- ストック0かつ未達成（`!autoCompleteReady`）のとき、裏向きカードが残る列の列番号ヘッダーに `bg-ds-warning/20` を付与（`data-testid="eh-col-header-<idx>"`)
- `autoCompleteReady` 達成で列ハイライトは消え、ボタンのパルスのみ残る

## テスト

- `bun run test -- --run src/pages/EasthavenPage.test.tsx` … 23 passed（新規2件: ストック0+裏向き残存の強調 / ストックあり時は非強調）
- `bun run check` … exit 0
- スタイルのみで i18n 追加なし
- `bun run build`(`tsc -b`) はローカル OOM のため CI ゲート

Closes #2289