### PR TITLE
feat(slapjack): 44px tap targets + assertive slap-chance announcement

### DIFF
--- a/frontend/src/i18n/locales/en/slapjack.json
+++ b/frontend/src/i18n/locales/en/slapjack.json
@@ -26,6 +26,7 @@
   "slapjack": {
     "slap": "Slap!",
     "jackOnTop": "JACK! Slap fast!",
+    "jackAnnounce": "A Jack is up! Slap chance!",
     "burst": {
       "jack": "JACK!",
       "miss": "MISS!"

--- a/frontend/src/i18n/locales/ja/slapjack.json
+++ b/frontend/src/i18n/locales/ja/slapjack.json
@@ -26,6 +26,7 @@
   "slapjack": {
     "slap": "スラップ！",
     "jackOnTop": "Jだ！叩け！",
+    "jackAnnounce": "ジャックが出ました！スラップチャンス！",
     "burst": {
       "jack": "ジャック！",
       "miss": "ミス！"

--- a/frontend/src/pages/SlapjackPage.test.tsx
+++ b/frontend/src/pages/SlapjackPage.test.tsx
@@ -146,6 +146,24 @@ describe('SlapjackPage', () => {
     const slap = screen.getByTestId('slap-button');
     expect(slap).not.toBeDisabled();
     expect(slap.className).toMatch(/animate-pulse/);
+    // Buttons meet the 44px tap-target minimum.
+    expect(slap.className).toContain('min-h-[44px]');
+    expect(screen.getByTestId('step-button').className).toContain('min-h-[44px]');
+  });
+
+  it('announces the slap chance via an assertive live region when a Jack is on top', async () => {
+    mockExec.mockResolvedValueOnce(jackOnTopState);
+    renderWithProviders(<SlapjackPage />);
+    const announce = await screen.findByTestId('sj-jack-announce');
+    expect(announce).toHaveAttribute('aria-live', 'assertive');
+    expect(announce).toHaveTextContent('ジャックが出ました');
+  });
+
+  it('keeps the live region empty when no Jack is on top', async () => {
+    mockExec.mockResolvedValueOnce(baseState);
+    renderWithProviders(<SlapjackPage />);
+    const announce = await screen.findByTestId('sj-jack-announce');
+    expect(announce).toHaveTextContent('');
   });
 
   it('renders the game-end state with both buttons disabled when human wins', async () => {

--- a/frontend/src/pages/SlapjackPage.test.tsx
+++ b/frontend/src/pages/SlapjackPage.test.tsx
@@ -146,16 +146,20 @@ describe('SlapjackPage', () => {
     const slap = screen.getByTestId('slap-button');
     expect(slap).not.toBeDisabled();
     expect(slap.className).toMatch(/animate-pulse/);
-    // Buttons meet the 44px tap-target minimum.
+    // Buttons meet the full WCAG 2.5.5 44x44px tap-target minimum.
     expect(slap.className).toContain('min-h-[44px]');
-    expect(screen.getByTestId('step-button').className).toContain('min-h-[44px]');
+    expect(slap.className).toContain('min-w-[44px]');
+    const step = screen.getByTestId('step-button');
+    expect(step.className).toContain('min-h-[44px]');
+    expect(step.className).toContain('min-w-[44px]');
   });
 
-  it('announces the slap chance via an assertive live region when a Jack is on top', async () => {
+  it('announces the slap chance via an atomic assertive live region when a Jack is on top', async () => {
     mockExec.mockResolvedValueOnce(jackOnTopState);
     renderWithProviders(<SlapjackPage />);
     const announce = await screen.findByTestId('sj-jack-announce');
     expect(announce).toHaveAttribute('aria-live', 'assertive');
+    expect(announce).toHaveAttribute('aria-atomic', 'true');
     expect(announce).toHaveTextContent('ジャックが出ました');
   });
 

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -251,7 +251,7 @@ function SlapjackPageContent() {
                   </div>
                 )}
                 {/* Screen-reader announcement for the flash slap chance. */}
-                <div className="sr-only" aria-live="assertive" data-testid="sj-jack-announce">
+                <div className="sr-only" aria-live="assertive" aria-atomic="true" data-testid="sj-jack-announce">
                   {state.isTopJack ? t('slapjack.jackAnnounce') : ''}
                 </div>
               </div>

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -250,6 +250,10 @@ function SlapjackPageContent() {
                     {t('slapjack.jackOnTop')}
                   </div>
                 )}
+                {/* Screen-reader announcement for the flash slap chance. */}
+                <div className="sr-only" aria-live="assertive" data-testid="sj-jack-announce">
+                  {state.isTopJack ? t('slapjack.jackAnnounce') : ''}
+                </div>
               </div>
             </div>
 
@@ -315,7 +319,7 @@ function SlapjackPageContent() {
                 type="button"
                 onClick={handleStep}
                 disabled={loading || isGameEnd || !state.isHumanTurn}
-                className="px-6 py-2 rounded-lg bg-ds-info hover:bg-ds-info text-white font-medium disabled:opacity-40 disabled:cursor-not-allowed"
+                className="min-h-[44px] min-w-[44px] px-6 py-2 rounded-lg bg-ds-info hover:bg-ds-info text-white font-medium disabled:opacity-40 disabled:cursor-not-allowed"
                 data-testid="step-button"
                 data-tutorial="sj-step-button"
               >
@@ -326,7 +330,7 @@ function SlapjackPageContent() {
                 type="button"
                 onClick={handleSlap}
                 disabled={loading || isGameEnd || state.centerPileSize === 0}
-                className={`px-6 py-2 rounded-lg text-white font-bold disabled:opacity-40 disabled:cursor-not-allowed ${
+                className={`min-h-[44px] min-w-[44px] px-6 py-2 rounded-lg text-white font-bold disabled:opacity-40 disabled:cursor-not-allowed ${
                   state.isTopJack
                     ? 'bg-ds-warning hover:bg-ds-warning-hover animate-pulse'
                     : 'bg-ds-error hover:bg-ds-error'


### PR DESCRIPTION
## 概要

スラップジャックのスラップ/ステップボタンが WCAG 2.5.5 AAA の 44×44px タップターゲットを満たさない可能性があり、Jack 登場のフラッシュ的スラップチャンスが視覚表示のみでスクリーンリーダーに伝わっていなかった。

## 変更内容

- スラップ/ステップ両ボタンに `min-h-[44px] min-w-[44px]` を付与
- `isTopJack` が true のとき `aria-live="assertive"` の sr-only リージョンで「ジャックが出ました！スラップチャンス！」をアナウンス（`data-testid="sj-jack-announce"`)
- `jackAnnounce` キーを ja/en に追加

## テスト

- `bun run test -- --run src/pages/SlapjackPage.test.tsx` … 16 passed（新規: 44px 検証 / Jack時アナウンス発火 / 非Jack時は空）
- `bun run check` … exit 0 / ja-en パリティ確認済み
- `bun run build`(`tsc -b`) はローカル OOM のため CI ゲート

Closes #2240