### PR TITLE
feat(belote): render face-up bidding card as a card image

### DIFF
--- a/frontend/src/pages/BelotePage.test.tsx
+++ b/frontend/src/pages/BelotePage.test.tsx
@@ -89,6 +89,14 @@ describe('BelotePage', () => {
     expect(screen.getByRole('button', { name: 'パス' })).toBeInTheDocument();
   });
 
+  it('renders the face-up card as a card image (not text) during bidding', async () => {
+    renderWithProviders(<BelotePage />);
+    // faceUpCard is J♥ → AnimatedCard/CardImage exposes it via alt text.
+    expect(await screen.findByAltText('♥ J')).toBeInTheDocument();
+    // The old plain-text "HEART 11" rendering is gone.
+    expect(screen.queryByText(/HEART 11/)).not.toBeInTheDocument();
+  });
+
   it('dispatches orderup when "取る" is clicked', async () => {
     renderWithProviders(<BelotePage />);
     await waitFor(() => screen.getByRole('button', { name: '取る' }));

--- a/frontend/src/pages/BelotePage.tsx
+++ b/frontend/src/pages/BelotePage.tsx
@@ -7,6 +7,7 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
+import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { PlayerHandSection } from '../components/PlayerHandSection';
 import { RoundScoreAnnouncement } from '../components/RoundScoreAnnouncement';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
@@ -263,8 +264,9 @@ function BelotePageContent() {
 
         {/* Face-up card (during bidding) */}
         {state.faceUpCard && (isBidPickUp || isBidCallTrump) && (
-          <div className="text-center mb-3 text-ds-text-muted">
-            {t('faceUpCard')}: {state.faceUpCard.design} {state.faceUpCard.value}
+          <div className="mb-3 flex flex-col items-center gap-1 text-ds-text-muted">
+            <span className="text-xs">{t('faceUpCard')}</span>
+            <AnimatedCard card={state.faceUpCard} width={cardWidth * 0.8} />
           </div>
         )}
 


### PR DESCRIPTION
## 概要

ベロートの入札フェーズのフェースアップカードが `{design} {value}` のテキスト表示のみで、他のトリックテイキングゲーム（カード画像表示）と一貫性がなかった。

## 変更内容

- フェースアップカード表示を `AnimatedCard`（`cardWidth * 0.8`）に置き換え、ラベル下に中央表示
- モバイルでは `cardWidth` 由来で適切に縮小

## テスト

- `bun run test -- --run src/pages/BelotePage.test.tsx` … 12 passed（新規: 入札中にカード画像 `alt="♥ J"` が表示され、旧テキストが消えていることを検証）
- `bun run check` … exit 0（新規 i18n キーなし）
- `bun run build`(`tsc -b`) はローカル OOM のため CI ゲート

Closes #2253