### PR TITLE
feat(mississippistud): show added bet amount on street buttons

### DIFF
--- a/frontend/src/i18n/locales/en/mississippistud.json
+++ b/frontend/src/i18n/locales/en/mississippistud.json
@@ -14,9 +14,7 @@
   },
   "button": {
     "bet": "Ante",
-    "play1x": "1x",
-    "play2x": "2x",
-    "play3x": "3x",
+    "playMult": "{{mult}}x +{{amount}}",
     "fold": "Fold",
     "reset": "Reset"
   },

--- a/frontend/src/i18n/locales/ja/mississippistud.json
+++ b/frontend/src/i18n/locales/ja/mississippistud.json
@@ -14,9 +14,7 @@
   },
   "button": {
     "bet": "アンティ",
-    "play1x": "1倍",
-    "play2x": "2倍",
-    "play3x": "3倍",
+    "playMult": "{{mult}}倍 +{{amount}}",
     "fold": "フォールド",
     "reset": "リセット"
   },

--- a/frontend/src/pages/MississippiStudPage.test.tsx
+++ b/frontend/src/pages/MississippiStudPage.test.tsx
@@ -143,12 +143,13 @@ describe('MississippiStudPage', () => {
     await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', 100));
   });
 
-  it('shows street phase with 1x / 2x / 3x / fold buttons', async () => {
-    mockApi.mockResolvedValue(thirdStreetState);
+  it('shows street buttons with the additional bet amount per multiplier (ante 100)', async () => {
+    mockApi.mockResolvedValue(thirdStreetState); // anteAmount 100
     renderWithProviders(<MississippiStudPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: '1倍' })).toBeInTheDocument());
-    expect(screen.getByRole('button', { name: '2倍' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '3倍' })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId('ms-play-1x')).toBeInTheDocument());
+    expect(screen.getByTestId('ms-play-1x')).toHaveTextContent('+100');
+    expect(screen.getByTestId('ms-play-2x')).toHaveTextContent('+200');
+    expect(screen.getByTestId('ms-play-3x')).toHaveTextContent('+300');
     expect(screen.getByRole('button', { name: 'フォールド' })).toBeInTheDocument();
   });
 
@@ -173,10 +174,10 @@ describe('MississippiStudPage', () => {
   it('calls execApi with play and multiplier=3 when 3倍 clicked', async () => {
     mockApi.mockResolvedValue(thirdStreetState);
     renderWithProviders(<MississippiStudPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: '3倍' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('ms-play-3x')).toBeInTheDocument());
 
     mockApi.mockResolvedValue(fourthStreetState);
-    fireEvent.click(screen.getByRole('button', { name: '3倍' }));
+    fireEvent.click(screen.getByTestId('ms-play-3x'));
     await waitFor(() => expect(mockApi).toHaveBeenCalledWith('play', undefined, 3));
   });
 
@@ -235,7 +236,7 @@ describe('MississippiStudPage', () => {
   it('renders hint toggle checkbox', async () => {
     mockApi.mockResolvedValue(thirdStreetState);
     renderWithProviders(<MississippiStudPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: '1倍' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('ms-play-1x')).toBeInTheDocument());
     expect(screen.getByRole('checkbox')).toBeInTheDocument();
   });
 

--- a/frontend/src/pages/MississippiStudPage.tsx
+++ b/frontend/src/pages/MississippiStudPage.tsx
@@ -270,16 +270,25 @@ function MississippiStudPageContent() {
         )}
         {isStreetPhase && (
           <div className="flex justify-center gap-2 pb-2 flex-wrap" data-tutorial="ms-street-buttons">
-            <button type="button" className={btnSecondary} onClick={() => handlePlay(1)} disabled={loading}>
-              {t('button.play1x')}
-            </button>
-            <button type="button" className={btnPrimary} onClick={() => handlePlay(2)} disabled={loading}>
-              {t('button.play2x')}
-            </button>
-            <button type="button" className={btnSuccess} onClick={() => handlePlay(3)} disabled={loading}>
-              {t('button.play3x')}
-            </button>
-            <button type="button" className={btnDanger} onClick={handleFold} disabled={loading}>
+            {(
+              [
+                { m: 1, cls: btnSecondary },
+                { m: 2, cls: btnPrimary },
+                { m: 3, cls: btnSuccess },
+              ] as const
+            ).map(({ m, cls }) => (
+              <button
+                key={m}
+                type="button"
+                className={`${cls} min-h-[44px]`}
+                onClick={() => handlePlay(m)}
+                disabled={loading}
+                data-testid={`ms-play-${m}x`}
+              >
+                {t('button.playMult', { mult: m, amount: state.anteAmount * m })}
+              </button>
+            ))}
+            <button type="button" className={`${btnDanger} min-h-[44px]`} onClick={handleFold} disabled={loading}>
               {t('button.fold')}
             </button>
           </div>


### PR DESCRIPTION
## 概要

ミシシッピ・スタッドの 1x/2x/3x ストリートボタンは倍率のみ表示で、現在のアンテに対する追加ベット額が分からず暗算が必要だった。

## 変更内容

- 各ボタンを `{mult}x +{ante×mult}` 表示に（`state.anteAmount` から動的算出）。`[{m,cls}]` 配列で描画し 44px タップターゲット維持（`data-testid="ms-play-{1,2,3}x"`)
- `button.play1x/2x/3x` を単一 `button.playMult`（`{{mult}}`/`{{amount}}`）に置換（ja/en）

## テスト

- `bun run test -- --run src/pages/MississippiStudPage.test.tsx` … 19 passed（新規: アンテ100で +100/+200/+300 サブラベル検証）
- `bun run check` … exit 0 / ja-en パリティ確認済み
- `bun run build`(`tsc -b`) はローカル OOM のため CI ゲート

Closes #2252