### PR TITLE
feat(spiderette): highlight hint source card + target column

### DIFF
--- a/frontend/src/pages/SpiderettePage.test.tsx
+++ b/frontend/src/pages/SpiderettePage.test.tsx
@@ -86,7 +86,9 @@ describe('SpiderettePage', () => {
     // The Hint button fetches a hint: move HEART 5 (col 1, idx 1) onto column 0.
     mockSend.mockResolvedValue({ ...playingState, hint: { fromCol: 1, cardIndex: 1, toCol: 0 } });
     fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
-    await waitFor(() => expect(screen.getByTestId('spdt-card-1-1').className).toContain('ring-ds-warning'));
+    // Hint-suggested source uses ring-ds-info (distinct from user-selected ring-ds-warning).
+    await waitFor(() => expect(screen.getByTestId('spdt-card-1-1').className).toContain('ring-ds-info'));
+    expect(screen.getByTestId('spdt-card-1-1').className).not.toContain('ring-ds-warning');
     expect(screen.getByTestId('spdt-col-0').className).toContain('ring-ds-success');
     // A non-target column is not highlighted.
     expect(screen.getByTestId('spdt-col-2').className).not.toContain('ring-ds-success');

--- a/frontend/src/pages/SpiderettePage.test.tsx
+++ b/frontend/src/pages/SpiderettePage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { spideretteApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
@@ -78,6 +78,18 @@ describe('SpiderettePage', () => {
     mockSend.mockReturnValue(new Promise(() => undefined));
     renderWithProviders(<SpiderettePage />);
     expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+  });
+
+  it('highlights the hint source card and target column after requesting a hint', async () => {
+    renderWithProviders(<SpiderettePage />);
+    await screen.findByTestId('spdt-card-1-1');
+    // The Hint button fetches a hint: move HEART 5 (col 1, idx 1) onto column 0.
+    mockSend.mockResolvedValue({ ...playingState, hint: { fromCol: 1, cardIndex: 1, toCol: 0 } });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+    await waitFor(() => expect(screen.getByTestId('spdt-card-1-1').className).toContain('ring-ds-warning'));
+    expect(screen.getByTestId('spdt-col-0').className).toContain('ring-ds-success');
+    // A non-target column is not highlighted.
+    expect(screen.getByTestId('spdt-col-2').className).not.toContain('ring-ds-success');
   });
 
   it('renders stock count', async () => {

--- a/frontend/src/pages/SpiderettePage.tsx
+++ b/frontend/src/pages/SpiderettePage.tsx
@@ -141,6 +141,11 @@ function SpiderettePageContent() {
     selectedSource.col === col &&
     selectedSource.cardIndex === cardIndex;
 
+  // Visual hint highlighting: ring the suggested source card and target column.
+  const isHintSource = (col: number, cardIndex: number) =>
+    hint != null && hint.fromCol === col && hint.cardIndex === cardIndex;
+  const isHintTargetCol = (col: number) => hint != null && hint.toCol === col;
+
   // A partial final deal (1–6 cards) still counts as one deal opportunity,
   // so round up rather than down (#1676 review).
   const dealsRemaining = Math.ceil(state.stockCount / TABLEAU_COLS);
@@ -208,7 +213,11 @@ function SpiderettePageContent() {
             {state.tableau.map((col, colIdx) => {
               const tableauColZone: SpideretteMoveZone = { zone: 'tableau', col: colIdx };
               return (
-                <div key={`col-${colIdx.toString()}`} className="flex-1 min-w-0">
+                <div
+                  key={`col-${colIdx.toString()}`}
+                  data-testid={`spdt-col-${colIdx.toString()}`}
+                  className={`flex-1 min-w-0${isHintTargetCol(colIdx) ? ' rounded ring-1 ring-ds-success' : ''}`}
+                >
                   <DropZone
                     isDropTarget={dnd.isDropTarget(tableauColZone)}
                     onDragOver={dnd.handleDragOver(tableauColZone)}
@@ -258,7 +267,8 @@ function SpiderettePageContent() {
                                   draggable={isPlaying && !loading}
                                   onDragStart={dnd.handleDragStart(cardZone)}
                                   onDragEnd={dnd.handleDragEnd}
-                                  className={`p-0 border-0 bg-transparent cursor-pointer w-full rounded ${focusRingWhite} ${isSourceSelected(colIdx, cardIdx) ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
+                                  data-testid={`spdt-card-${colIdx.toString()}-${cardIdx.toString()}`}
+                                  className={`p-0 border-0 bg-transparent cursor-pointer w-full rounded ${focusRingWhite} ${isSourceSelected(colIdx, cardIdx) || isHintSource(colIdx, cardIdx) ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
                                 >
                                   <AnimatedCard
                                     card={tc.card}

--- a/frontend/src/pages/SpiderettePage.tsx
+++ b/frontend/src/pages/SpiderettePage.tsx
@@ -216,7 +216,11 @@ function SpiderettePageContent() {
                 <div
                   key={`col-${colIdx.toString()}`}
                   data-testid={`spdt-col-${colIdx.toString()}`}
-                  className={`flex-1 min-w-0${isHintTargetCol(colIdx) ? ' rounded ring-1 ring-ds-success' : ''}`}
+                  className={
+                    isHintTargetCol(colIdx)
+                      ? 'flex-1 min-w-0 rounded ring-1 ring-ds-success animate-pulse'
+                      : 'flex-1 min-w-0'
+                  }
                 >
                   <DropZone
                     isDropTarget={dnd.isDropTarget(tableauColZone)}
@@ -268,7 +272,7 @@ function SpiderettePageContent() {
                                   onDragStart={dnd.handleDragStart(cardZone)}
                                   onDragEnd={dnd.handleDragEnd}
                                   data-testid={`spdt-card-${colIdx.toString()}-${cardIdx.toString()}`}
-                                  className={`p-0 border-0 bg-transparent cursor-pointer w-full rounded ${focusRingWhite} ${isSourceSelected(colIdx, cardIdx) || isHintSource(colIdx, cardIdx) ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
+                                  className={`p-0 border-0 bg-transparent cursor-pointer w-full rounded ${focusRingWhite} ${isSourceSelected(colIdx, cardIdx) ? 'ring-2 ring-ds-warning' : isHintSource(colIdx, cardIdx) ? 'ring-2 ring-ds-info animate-pulse' : ''} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
                                 >
                                   <AnimatedCard
                                     card={tc.card}


### PR DESCRIPTION
## 概要

スパイダレットのヒントは列番号テキストのみで、画面上の対象を探す手間があった。他ソリティア（Crescent/包囲された城）同様に視覚ハイライトを追加する。

## 変更内容

- ヒント取得後、移動元カードに `ring-2 ring-ds-warning`、移動先列に `ring-1 ring-ds-success` を付与（`isHintSource`/`isHintTargetCol` ヘルパー）
- `data-testid="spdt-card-<c>-<i>"` / `spdt-col-<c>` を追加
- テキストヒントは補足として維持。次の移動で state 更新によりハイライトはクリア

## テスト

- `bun run test -- --run src/pages/SpiderettePage.test.tsx` … 6 passed（新規: ヒント要求後に移動元カード/移動先列がハイライト、非対象列は非ハイライト）
- `bun run check` … exit 0（i18n 追加なし）
- `bun run build`(`tsc -b`) はローカル OOM のため CI ゲート

Closes #2254