### PR TITLE
feat(chinesepoker): front/middle/back row preview in set-hands

### DIFF
--- a/frontend/src/i18n/locales/en/chinesepoker.json
+++ b/frontend/src/i18n/locales/en/chinesepoker.json
@@ -56,6 +56,9 @@
   "selectCards": "Select 3 cards for Front and 5 cards for Middle",
   "selectedFront": "Front: {{count}} / 3",
   "selectedMiddle": "Middle: {{count}} / 5",
+  "previewFront": "Front",
+  "previewMiddle": "Middle",
+  "previewBack": "Back",
   "foulWarning": "Foul: Hands must be arranged so that Back ≧ Middle ≧ Front",
   "royalty": "Royalty: +{{points}}",
   "tutorial": {

--- a/frontend/src/i18n/locales/ja/chinesepoker.json
+++ b/frontend/src/i18n/locales/ja/chinesepoker.json
@@ -56,6 +56,9 @@
   "selectCards": "フロント3枚とミドル5枚を選んでください",
   "selectedFront": "フロント: {{count}} / 3",
   "selectedMiddle": "ミドル: {{count}} / 5",
+  "previewFront": "フロント",
+  "previewMiddle": "ミドル",
+  "previewBack": "バック",
   "foulWarning": "ファウル: バック ≧ ミドル ≧ フロント の順になるように配置してください",
   "royalty": "ロイヤリティ: +{{points}}",
   "tutorial": {

--- a/frontend/src/pages/ChinesePokerPage.test.tsx
+++ b/frontend/src/pages/ChinesePokerPage.test.tsx
@@ -114,9 +114,15 @@ describe('ChinesePokerPage', () => {
     // Initially everything is unassigned → all 13 cards sit in the back row.
     expect(back()).toHaveLength(13);
     expect(front()).toHaveLength(0);
+    const middle = () => within(screen.getByTestId('cp-row-middle')).queryAllByTestId('animated-card');
     // First click assigns the card to the front row.
     fireEvent.click(screen.getByRole('button', { name: 'Card 0' }));
     expect(front()).toHaveLength(1);
+    expect(back()).toHaveLength(12);
+    // Second click cycles front → middle.
+    fireEvent.click(screen.getByRole('button', { name: 'Card 0' }));
+    expect(front()).toHaveLength(0);
+    expect(middle()).toHaveLength(1);
     expect(back()).toHaveLength(12);
   });
 

--- a/frontend/src/pages/ChinesePokerPage.test.tsx
+++ b/frontend/src/pages/ChinesePokerPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, ChinesePokerResponse } from '../types/card';
@@ -103,6 +103,21 @@ describe('ChinesePokerPage', () => {
     await waitFor(() => expect(screen.getByTestId('set-hands-button')).toBeInTheDocument());
     const cardButtons = screen.getAllByRole('button', { name: /Card \d+/ });
     expect(cardButtons.length).toBe(13);
+  });
+
+  it('shows the front/middle/back row preview and updates it on assignment', async () => {
+    mockExec.mockResolvedValue(setHandsState);
+    renderWithProviders(<ChinesePokerPage />);
+    await screen.findByTestId('cp-row-preview');
+    const back = () => within(screen.getByTestId('cp-row-back')).queryAllByTestId('animated-card');
+    const front = () => within(screen.getByTestId('cp-row-front')).queryAllByTestId('animated-card');
+    // Initially everything is unassigned → all 13 cards sit in the back row.
+    expect(back()).toHaveLength(13);
+    expect(front()).toHaveLength(0);
+    // First click assigns the card to the front row.
+    fireEvent.click(screen.getByRole('button', { name: 'Card 0' }));
+    expect(front()).toHaveLength(1);
+    expect(back()).toHaveLength(12);
   });
 
   it('set button disabled when not enough cards selected', async () => {

--- a/frontend/src/pages/ChinesePokerPage.tsx
+++ b/frontend/src/pages/ChinesePokerPage.tsx
@@ -128,6 +128,11 @@ function ChinesePokerPageContent() {
     () => assignments.map((a, i) => (a === 'middle' ? i : -1)).filter((i) => i >= 0),
     [assignments],
   );
+  // Cards not assigned to front/middle implicitly form the back (bottom) row.
+  const backIndices = useMemo(
+    () => (state?.playerCards ?? []).map((_, i) => i).filter((i) => !assignments[i]),
+    [state?.playerCards, assignments],
+  );
   const canSet = frontIndices.length === 3 && middleIndices.length === 5;
 
   const toggleCard = useCallback((index: number) => {
@@ -260,6 +265,28 @@ function ChinesePokerPageContent() {
                         </span>
                       )}
                     </button>
+                  ))}
+                </div>
+
+                {/* Front / middle / back row preview */}
+                <div className="mt-3 space-y-1" data-testid="cp-row-preview">
+                  {(
+                    [
+                      { key: 'front', label: t('previewFront'), indices: frontIndices, need: 3 },
+                      { key: 'middle', label: t('previewMiddle'), indices: middleIndices, need: 5 },
+                      { key: 'back', label: t('previewBack'), indices: backIndices, need: 5 },
+                    ] as const
+                  ).map((row) => (
+                    <div key={row.key} className="flex items-center gap-2">
+                      <span className="w-24 shrink-0 text-ds-text-muted text-xs">
+                        {row.label} ({row.indices.length}/{row.need})
+                      </span>
+                      <div className="flex flex-wrap gap-0.5" data-testid={`cp-row-${row.key}`}>
+                        {row.indices.map((idx) => (
+                          <AnimatedCard key={idx} card={state.playerCards[idx]} width={cardWidth * 0.6} />
+                        ))}
+                      </div>
+                    </div>
                   ))}
                 </div>
               </div>

--- a/frontend/src/pages/ChinesePokerPage.tsx
+++ b/frontend/src/pages/ChinesePokerPage.tsx
@@ -274,17 +274,23 @@ function ChinesePokerPageContent() {
                     [
                       { key: 'front', label: t('previewFront'), indices: frontIndices, need: 3 },
                       { key: 'middle', label: t('previewMiddle'), indices: middleIndices, need: 5 },
-                      { key: 'back', label: t('previewBack'), indices: backIndices, need: 5 },
+                      // Back drains toward 5 rather than filling up, so show a plain
+                      // count (no denominator) to avoid a confusing "13/5" reading.
+                      { key: 'back', label: t('previewBack'), indices: backIndices, need: undefined },
                     ] as const
                   ).map((row) => (
                     <div key={row.key} className="flex items-center gap-2">
                       <span className="w-24 shrink-0 text-ds-text-muted text-xs">
-                        {row.label} ({row.indices.length}/{row.need})
+                        {row.label} ({row.indices.length}
+                        {row.need != null ? `/${row.need}` : ''})
                       </span>
                       <div className="flex flex-wrap gap-0.5" data-testid={`cp-row-${row.key}`}>
-                        {row.indices.map((idx) => (
-                          <AnimatedCard key={idx} card={state.playerCards[idx]} width={cardWidth * 0.6} />
-                        ))}
+                        {row.indices.map((idx) => {
+                          const previewCard = state.playerCards[idx];
+                          return previewCard ? (
+                            <AnimatedCard key={idx} card={previewCard} width={cardWidth * 0.6} />
+                          ) : null;
+                        })}
                       </div>
                     </div>
                   ))}


### PR DESCRIPTION
## 概要

チャイニーズポーカーのセット手フェーズは F/M バッジのみで、バック行が暗黙的でユーザーが組み合わせを暗算する必要があった。3行プレビューを追加する。

## 変更内容

- カードグリッド下に「フロント(3)/ミドル(5)/バック(残り)」の3行インラインプレビュー（`cardWidth*0.6` 縮小、`data-testid="cp-row-{front,middle,back}"`)
- `backIndices` = 未割り当てカードから自動算出。割り当て変更で即時更新
- `previewFront`/`previewMiddle`/`previewBack` キーを ja/en に追加。`canSet` 条件は不変

## テスト

- `bun run test -- --run src/pages/ChinesePokerPage.test.tsx` … 8 passed（新規: 初期は全13枚がバック、Card 0 クリックでフロント1/バック12に更新）
- `bun run check` … exit 0 / ja-en パリティ確認済み
- `bun run build`(`tsc -b`) はローカル OOM のため CI ゲート

Closes #2270