### PR TITLE
feat(russianpoker): always show exchange-cost line in action phase

### DIFF
--- a/frontend/src/pages/RussianPokerPage.test.tsx
+++ b/frontend/src/pages/RussianPokerPage.test.tsx
@@ -70,4 +70,18 @@ describe('RussianPokerPage', () => {
     const line = screen.getByTestId('russian-exchange-fee-line');
     expect(line).toHaveTextContent('選択中: 1枚');
   });
+
+  it('shows the high-risk warning and error styling at 4+ selected cards', async () => {
+    renderWithProviders(<RussianPokerPage />);
+    await screen.findByTestId('russian-exchange-fee-line');
+    // Select 4 of the 5 hand cards (11=J, 12=Q via cardAlt).
+    fireEvent.click(screen.getByAltText('♠ 10'));
+    fireEvent.click(screen.getByAltText('♥ J'));
+    fireEvent.click(screen.getByAltText('♦ Q'));
+    fireEvent.click(screen.getByAltText('♣ 3'));
+    const line = screen.getByTestId('russian-exchange-fee-line');
+    expect(line).toHaveTextContent('選択中: 4枚');
+    expect(within(line).getByText(/⚠/)).toBeInTheDocument();
+    expect(line.querySelector('.text-ds-error')).not.toBeNull();
+  });
 });

--- a/frontend/src/pages/RussianPokerPage.test.tsx
+++ b/frontend/src/pages/RussianPokerPage.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { russianpokerApi } from '../api/gameApi';
+import { renderWithProviders } from '../test/renderWithProviders';
+import type { Card, RussianPokerResponse } from '../types/card';
+import { RussianPokerPhase } from '../types/phases';
+import { RussianPokerPage } from './RussianPokerPage';
+
+vi.mock('../api/gameApi', () => ({
+  russianpokerApi: { exec: vi.fn() },
+  actionLogApi: { russianpoker: vi.fn() },
+}));
+
+const mockExec = vi.mocked(russianpokerApi.exec);
+
+const card = (design: string, value: number): Card => ({ design, value }) as unknown as Card;
+
+function makeState(overrides: Partial<RussianPokerResponse> = {}): RussianPokerResponse {
+  return {
+    playerHand: [card('SPADE', 10), card('HEART', 11), card('DIAMOND', 12), card('CLOVER', 3), card('SPADE', 5)],
+    dealerHand: [{ design: '', value: 0 }] as RussianPokerResponse['dealerHand'],
+    phase: RussianPokerPhase.ACTION,
+    chips: 900,
+    anteBet: 100,
+    exchangeCount: 0,
+    exchangeFee: 0,
+    bought6th: false,
+    buy6thFee: 0,
+    forceExchanged: false,
+    forceExchangeFee: 0,
+    playBet: 0,
+    result: 0,
+    antePayout: 0,
+    playPayout: 0,
+    totalPayout: 0,
+    dealerQualified: false,
+    playerHandRank: 0,
+    dealerHandRank: 0,
+    message: '',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockExec.mockReset();
+  mockExec.mockResolvedValue(makeState());
+});
+
+describe('RussianPokerPage', () => {
+  it('resets on mount', async () => {
+    renderWithProviders(<RussianPokerPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+  });
+
+  it('shows the exchange-cost line from the start of the action phase (0 cards = 0 fee)', async () => {
+    renderWithProviders(<RussianPokerPage />);
+    const line = await screen.findByTestId('russian-exchange-fee-line');
+    // Visible with zero selection: count 0 and fee 0 (ante 100).
+    expect(line).toHaveTextContent('0');
+    expect(line).toHaveTextContent('100');
+    // High-risk warning is absent at 0 selected.
+    expect(within(line).queryByText(/⚠/)).not.toBeInTheDocument();
+  });
+
+  it('updates the exchange fee as cards are selected', async () => {
+    renderWithProviders(<RussianPokerPage />);
+    await screen.findByTestId('russian-exchange-fee-line');
+    // Select a card from the hand → fee becomes ante*1 = 100.
+    fireEvent.click(screen.getByAltText('♠ 10'));
+    const line = screen.getByTestId('russian-exchange-fee-line');
+    expect(line).toHaveTextContent('選択中: 1枚');
+  });
+});

--- a/frontend/src/pages/RussianPokerPage.test.tsx
+++ b/frontend/src/pages/RussianPokerPage.test.tsx
@@ -56,8 +56,8 @@ describe('RussianPokerPage', () => {
     renderWithProviders(<RussianPokerPage />);
     const line = await screen.findByTestId('russian-exchange-fee-line');
     // Visible with zero selection: count 0 and fee 0 (ante 100).
-    expect(line).toHaveTextContent('0');
-    expect(line).toHaveTextContent('100');
+    expect(line).toHaveTextContent('選択中: 0枚');
+    expect(line).toHaveTextContent('× 100 = 0');
     // High-risk warning is absent at 0 selected.
     expect(within(line).queryByText(/⚠/)).not.toBeInTheDocument();
   });

--- a/frontend/src/pages/RussianPokerPage.tsx
+++ b/frontend/src/pages/RussianPokerPage.tsx
@@ -405,7 +405,6 @@ function RussianPokerPageContent() {
             )}
             {isActionPhase && (
               <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="russian-action-buttons">
-                {/* Always show the exchange-cost line in the action phase (0 cards = 0 chips). */}
                 <div
                   className="text-ds-text-primary text-sm text-center"
                   data-tutorial="russian-exchange-controls"

--- a/frontend/src/pages/RussianPokerPage.tsx
+++ b/frontend/src/pages/RussianPokerPage.tsx
@@ -405,32 +405,31 @@ function RussianPokerPageContent() {
             )}
             {isActionPhase && (
               <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="russian-action-buttons">
-                {isExchangeSelecting && (
-                  <div
-                    className="text-ds-text-primary text-sm text-center"
-                    data-tutorial="russian-exchange-controls"
-                    data-testid="russian-exchange-fee-line"
+                {/* Always show the exchange-cost line in the action phase (0 cards = 0 chips). */}
+                <div
+                  className="text-ds-text-primary text-sm text-center"
+                  data-tutorial="russian-exchange-controls"
+                  data-testid="russian-exchange-fee-line"
+                >
+                  <p>{t('exchangeGuide')}</p>
+                  <p
+                    className={
+                      selectedIndices.length >= 4
+                        ? 'font-semibold text-ds-error'
+                        : selectedIndices.length >= 2
+                          ? 'font-semibold text-ds-warning'
+                          : 'text-ds-text-primary'
+                    }
                   >
-                    <p>{t('exchangeGuide')}</p>
-                    <p
-                      className={
-                        selectedIndices.length >= 4
-                          ? 'font-semibold text-ds-error'
-                          : selectedIndices.length >= 2
-                            ? 'font-semibold text-ds-warning'
-                            : 'text-ds-text-primary'
-                      }
-                    >
-                      {t('exchangeSelected', { count: selectedIndices.length })} —{' '}
-                      {t('exchangeFeeInfo', { ante: state.anteBet, fee: exchangePreviewFee })}
-                      {selectedIndices.length >= 4 && (
-                        <span className="ml-2 inline-block rounded-full bg-ds-error/30 px-2 py-0.5 text-xs font-bold">
-                          <span aria-hidden="true">⚠</span> {t('exchangeFeeHighRisk')}
-                        </span>
-                      )}
-                    </p>
-                  </div>
-                )}
+                    {t('exchangeSelected', { count: selectedIndices.length })} —{' '}
+                    {t('exchangeFeeInfo', { ante: state.anteBet, fee: exchangePreviewFee })}
+                    {selectedIndices.length >= 4 && (
+                      <span className="ml-2 inline-block rounded-full bg-ds-error/30 px-2 py-0.5 text-xs font-bold">
+                        <span aria-hidden="true">⚠</span> {t('exchangeFeeHighRisk')}
+                      </span>
+                    )}
+                  </p>
+                </div>
                 <p className="text-ds-text-muted text-sm">{t('actionGuide')}</p>
                 <div className="flex gap-2 flex-wrap justify-center">
                   <button type="button" className={btnSuccess} onClick={handlePlay} disabled={loading}>


### PR DESCRIPTION
## 概要

ロシアンポーカーの交換費用表示は1枚以上選択するまで現れず、操作開始前にコストが分からなかった。アクションフェーズ開始時から常時表示する。

## 変更内容

- 交換費用ライン（`data-testid="russian-exchange-fee-line"`）の `isExchangeSelecting` ガードを外し、アクションフェーズ中は常時表示（0枚 = 0チップ）
- 選択に応じて即時更新。`exchangePreviewFee` 変数はそのまま。4枚以上の `⚠` 高リスク警告は維持。Exchange ボタンは従来どおり1枚以上で有効
- `RussianPokerPage.test.tsx` を新規追加（従来テストなし）

## テスト

- `bun run test -- --run src/pages/RussianPokerPage.test.tsx` … 3 passed（新規: 0枚時に費用ライン表示・警告なし / 選択で更新）
- `bun run check` … exit 0（i18n 追加なし）
- `bun run build`(`tsc -b`) はローカル OOM のため CI ゲート

Closes #2268