### PR TITLE
feat(osmosis): allowed-rank guide per foundation row

### DIFF
--- a/frontend/src/i18n/locales/en/osmosis.json
+++ b/frontend/src/i18n/locales/en/osmosis.json
@@ -9,6 +9,8 @@
   "waste": "Waste",
   "reserve": "Reserve",
   "foundation": "Foundation",
+  "anyRank": "any",
+  "cannotPlaceHere": "Can't place here",
   "baseRank": "Base rank",
   "moveCount": "Moves",
   "draw": "Draw",

--- a/frontend/src/i18n/locales/ja/osmosis.json
+++ b/frontend/src/i18n/locales/ja/osmosis.json
@@ -9,6 +9,8 @@
   "waste": "ウェイスト",
   "reserve": "リザーブ",
   "foundation": "組札",
+  "anyRank": "任意",
+  "cannotPlaceHere": "この段には置けません",
   "baseRank": "ベースランク",
   "moveCount": "手数",
   "draw": "引く",

--- a/frontend/src/pages/OsmosisPage.test.tsx
+++ b/frontend/src/pages/OsmosisPage.test.tsx
@@ -105,6 +105,18 @@ describe('OsmosisPage', () => {
     );
   });
 
+  it('flags foundation rows the selected card cannot be placed on', async () => {
+    renderWithProviders(<OsmosisPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    // ♥9 (reserve col 1): wrong suit for the ♠ base row and not the base rank
+    // for the empty rows → cannot be placed anywhere.
+    screen.getByRole('button', { name: 'リザーブ 1' }).click();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: '組札 0' })).toHaveAttribute('title', 'この段には置けません'),
+    );
+    expect(screen.getByRole('button', { name: '組札 0' }).className).toContain('border-ds-error');
+  });
+
   it('foundation rows are disabled until a source is selected', async () => {
     renderWithProviders(<OsmosisPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));

--- a/frontend/src/pages/OsmosisPage.test.tsx
+++ b/frontend/src/pages/OsmosisPage.test.tsx
@@ -62,6 +62,19 @@ describe('OsmosisPage', () => {
     await waitFor(() => expect(screen.getByText(/ベースランク/)).toBeInTheDocument());
   });
 
+  it('shows the allowed-rank guide per foundation row', async () => {
+    // foundation [[♠5],[],[],[]], baseRank 5.
+    renderWithProviders(<OsmosisPage />);
+    await waitFor(() => expect(screen.getByTestId('os-allowed-0')).toBeInTheDocument());
+    // Row 0 is the base row (★) with a fixed suit → any rank.
+    expect(screen.getByTestId('os-allowed-0')).toHaveTextContent('★');
+    expect(screen.getByTestId('os-allowed-0')).toHaveTextContent('任意');
+    // Row 1 (empty, row 0 non-empty) accepts the base rank 5.
+    expect(screen.getByTestId('os-allowed-1')).toHaveTextContent('5');
+    // Row 2 (empty, row 1 empty) accepts nothing yet.
+    expect(screen.getByTestId('os-allowed-2')).toHaveTextContent('—');
+  });
+
   it('clicks stock to fire draw command', async () => {
     renderWithProviders(<OsmosisPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));

--- a/frontend/src/pages/OsmosisPage.tsx
+++ b/frontend/src/pages/OsmosisPage.tsx
@@ -23,12 +23,16 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { btnDanger, btnOutline, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { OsmosisResponse } from '../types/card';
+import type { Card, OsmosisResponse } from '../types/card';
 import { OsmosisPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { OSMOSIS_HELP, parseOsmosisCommand } from '../utils/cli/commands/osmosisCommands';
 import { formatOsmosisState } from '../utils/cli/formatters/osmosisFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { osmosisAllowedRanks, osmosisCanPlace } from '../utils/osmosisRules';
+
+/** Card rank value (1–13) → short display label. */
+const RANK_LABELS = ['', 'A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
 
 /** Tutorial steps for the Osmosis solitaire game. */
 const OS_TUTORIAL_STEPS: TutorialStep[] = [
@@ -132,6 +136,14 @@ function OsmosisPageContent() {
   const topWaste = state.waste.length > 0 ? state.waste[state.waste.length - 1] : null;
   const isSelected = (zone: OsmosisMoveZone) => !!selected && selected.zone === zone.zone && selected.col === zone.col;
 
+  // The actual card currently selected (waste top or a reserve-column top), used
+  // to flag foundation rows the card cannot be placed on.
+  const selectedCard: Card | null = !selected
+    ? null
+    : selected.zone === 'waste'
+      ? topWaste
+      : (state.reserve[selected.col]?.[state.reserve[selected.col].length - 1] ?? null);
+
   return (
     <GamePageShell
       title={tc('nav.osmosis')}
@@ -183,32 +195,43 @@ function OsmosisPageContent() {
             {/* Foundation rows */}
             <div className="mb-3 flex flex-col gap-2" data-tutorial="os-foundation">
               <span className="text-xs text-ds-text-muted">{t('foundation')}</span>
-              {state.foundation.map((pile, i) => (
-                <button
-                  key={`f-${i}`}
-                  type="button"
-                  onClick={() => handleFoundationClick(i)}
-                  disabled={!isPlaying || !selected || loading}
-                  aria-label={`${t('foundation')} ${i}`}
-                  className={
-                    selected
-                      ? `flex items-center gap-2 rounded border p-1 text-left ${focusRingWhite} border-ds-info`
-                      : `flex items-center gap-2 rounded border p-1 text-left ${focusRingWhite} border-white/30`
-                  }
-                >
-                  <span className="w-5 text-xs text-ds-text-muted">#{i}</span>
-                  <div className="relative" style={{ width: cardWidth, height: cardHeight }}>
-                    {pile.length > 0 ? (
-                      <AnimatedCard card={pile[pile.length - 1]} width={cardWidth} />
-                    ) : (
-                      <span className="absolute inset-0 flex items-center justify-center text-xs text-ds-text-muted/80">
-                        {t('foundation')}
-                      </span>
-                    )}
-                  </div>
-                  <span className="text-xs text-ds-text-muted">({pile.length})</span>
-                </button>
-              ))}
+              {state.foundation.map((pile, i) => {
+                const allowed = osmosisAllowedRanks(state.foundation, state.baseRank, i);
+                const blocked =
+                  selectedCard != null && !osmosisCanPlace(state.foundation, state.baseRank, i, selectedCard);
+                const borderColor = blocked ? 'border-ds-error' : selected ? 'border-ds-info' : 'border-white/30';
+                return (
+                  <button
+                    key={`f-${i}`}
+                    type="button"
+                    onClick={() => handleFoundationClick(i)}
+                    disabled={!isPlaying || !selected || loading}
+                    aria-label={`${t('foundation')} ${i}`}
+                    title={blocked ? t('cannotPlaceHere') : undefined}
+                    className={`flex items-center gap-2 rounded border p-1 text-left ${focusRingWhite} ${borderColor}`}
+                  >
+                    <span className="w-5 text-xs text-ds-text-muted">#{i}</span>
+                    <div className="relative" style={{ width: cardWidth, height: cardHeight }}>
+                      {pile.length > 0 ? (
+                        <AnimatedCard card={pile[pile.length - 1]} width={cardWidth} />
+                      ) : (
+                        <span className="absolute inset-0 flex items-center justify-center text-xs text-ds-text-muted/80">
+                          {t('foundation')}
+                        </span>
+                      )}
+                    </div>
+                    <span className="text-xs text-ds-text-muted">({pile.length})</span>
+                    <span className="text-xs text-ds-text-muted" data-testid={`os-allowed-${i}`}>
+                      {i === 0 && <span className="text-ds-warning">★ </span>}
+                      {allowed.length === 0
+                        ? '—'
+                        : i === 0 && pile.length > 0
+                          ? t('anyRank')
+                          : allowed.map((r) => RANK_LABELS[r]).join(' ')}
+                    </span>
+                  </button>
+                );
+              })}
             </div>
 
             {/* Reserve columns */}

--- a/frontend/src/pages/OsmosisPage.tsx
+++ b/frontend/src/pages/OsmosisPage.tsx
@@ -201,7 +201,6 @@ function OsmosisPageContent() {
                 const allowed = osmosisAllowedRanks(state.foundation, state.baseRank, i);
                 const blocked =
                   selectedCard != null && !osmosisCanPlace(state.foundation, state.baseRank, i, selectedCard);
-                const borderColor = blocked ? 'border-ds-error' : selected ? 'border-ds-info' : 'border-white/30';
                 return (
                   <button
                     key={`f-${i}`}
@@ -210,7 +209,13 @@ function OsmosisPageContent() {
                     disabled={!isPlaying || !selected || loading}
                     aria-label={`${t('foundation')} ${i}`}
                     title={blocked ? t('cannotPlaceHere') : undefined}
-                    className={`flex items-center gap-2 rounded border p-1 text-left ${focusRingWhite} ${borderColor}`}
+                    className={
+                      blocked
+                        ? `flex items-center gap-2 rounded border p-1 text-left ${focusRingWhite} border-ds-error`
+                        : selected
+                          ? `flex items-center gap-2 rounded border p-1 text-left ${focusRingWhite} border-ds-info`
+                          : `flex items-center gap-2 rounded border p-1 text-left ${focusRingWhite} border-white/30`
+                    }
                   >
                     <span className="w-5 text-xs text-ds-text-muted">#{i}</span>
                     <div className="relative" style={{ width: cardWidth, height: cardHeight }}>

--- a/frontend/src/pages/OsmosisPage.tsx
+++ b/frontend/src/pages/OsmosisPage.tsx
@@ -138,11 +138,13 @@ function OsmosisPageContent() {
 
   // The actual card currently selected (waste top or a reserve-column top), used
   // to flag foundation rows the card cannot be placed on.
-  const selectedCard: Card | null = !selected
-    ? null
-    : selected.zone === 'waste'
-      ? topWaste
-      : (state.reserve[selected.col]?.[state.reserve[selected.col].length - 1] ?? null);
+  let selectedCard: Card | null = null;
+  if (selected?.zone === 'waste') {
+    selectedCard = topWaste;
+  } else if (selected?.zone === 'reserve' && selected.col != null) {
+    const col = state.reserve[selected.col] ?? [];
+    selectedCard = col.length > 0 ? col[col.length - 1] : null;
+  }
 
   return (
     <GamePageShell

--- a/frontend/src/utils/osmosisRules.test.ts
+++ b/frontend/src/utils/osmosisRules.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { osmosisAllowedRanks, osmosisCanPlace } from './osmosisRules';
+
+const c = (design: string, value: number): Card => ({ design, value }) as unknown as Card;
+
+describe('osmosisAllowedRanks', () => {
+  it('an empty base row (0) accepts only the base rank', () => {
+    expect(osmosisAllowedRanks([[], [], [], []], 5, 0)).toEqual([5]);
+  });
+
+  it('an empty row >=1 accepts the base rank only when the row above is non-empty', () => {
+    expect(osmosisAllowedRanks([[], [], [], []], 5, 1)).toEqual([]);
+    expect(osmosisAllowedRanks([[c('SPADE', 5)], [], [], []], 5, 1)).toEqual([5]);
+  });
+
+  it('the base row with a fixed suit accepts any not-yet-placed rank', () => {
+    const allowed = osmosisAllowedRanks([[c('SPADE', 5), c('SPADE', 6)], [], [], []], 5, 0);
+    expect(allowed).not.toContain(5);
+    expect(allowed).not.toContain(6);
+    expect(allowed).toContain(1);
+    expect(allowed).toContain(13);
+    expect(allowed).toHaveLength(11);
+  });
+
+  it('row >=1 accepts only ranks present in the row above, minus those already placed', () => {
+    const foundation = [
+      [c('SPADE', 5), c('SPADE', 6), c('SPADE', 7)], // base row has 5,6,7
+      [c('HEART', 5)], // row 1 already has 5
+      [],
+      [],
+    ];
+    // Row 1 can still add 6 and 7 (present above, not yet in row 1).
+    expect(osmosisAllowedRanks(foundation, 5, 1)).toEqual([6, 7]);
+  });
+});
+
+describe('osmosisCanPlace', () => {
+  const foundation = [[c('SPADE', 5), c('SPADE', 6)], [c('HEART', 5)], [], []];
+
+  it('base row accepts any rank of its fixed suit', () => {
+    expect(osmosisCanPlace(foundation, 5, 0, c('SPADE', 9))).toBe(true);
+    expect(osmosisCanPlace(foundation, 5, 0, c('HEART', 9))).toBe(false); // wrong suit
+  });
+
+  it('row >=1 accepts a matching-suit card whose rank is in the row above', () => {
+    expect(osmosisCanPlace(foundation, 5, 1, c('HEART', 6))).toBe(true); // 6 is in base row
+    expect(osmosisCanPlace(foundation, 5, 1, c('HEART', 9))).toBe(false); // 9 not above
+    expect(osmosisCanPlace(foundation, 5, 1, c('SPADE', 6))).toBe(false); // wrong suit for row 1
+  });
+
+  it('an empty row accepts only the base rank and a fresh suit', () => {
+    expect(osmosisCanPlace(foundation, 5, 2, c('CLOVER', 5))).toBe(true); // base rank, new suit, row 1 non-empty
+    expect(osmosisCanPlace(foundation, 5, 2, c('CLOVER', 6))).toBe(false); // not base rank
+    expect(osmosisCanPlace(foundation, 5, 2, c('SPADE', 5))).toBe(false); // suit already assigned (row 0)
+  });
+});

--- a/frontend/src/utils/osmosisRules.ts
+++ b/frontend/src/utils/osmosisRules.ts
@@ -1,0 +1,48 @@
+import type { Card } from '../types/card';
+
+/** The set of rank values (1–13) present in a foundation pile. */
+function ranksIn(pile: Card[]): Set<number> {
+  return new Set(pile.map((c) => c.value));
+}
+
+/** True if suit `s` is already the assigned suit of a foundation row other than `except`. */
+function suitAssigned(foundation: Card[][], s: string, except: number): boolean {
+  return foundation.some((pile, i) => i !== except && pile.length > 0 && pile[0]?.design === s);
+}
+
+/**
+ * Ranks that can currently be added to foundation row `i`, mirroring the Osmosis
+ * domain rule (`Osmosis.canPlaceOnFoundation`): an empty row accepts only the base
+ * rank (rows ≥1 also need the row above to be non-empty); the base row (0) with a
+ * fixed suit accepts any not-yet-placed rank; row i≥1 accepts only ranks already
+ * present in the row above and not yet in the row itself.
+ */
+export function osmosisAllowedRanks(foundation: Card[][], baseRank: number, i: number): number[] {
+  const pile = foundation[i] ?? [];
+  if (pile.length === 0) {
+    if (i >= 1 && (foundation[i - 1]?.length ?? 0) === 0) return [];
+    return [baseRank];
+  }
+  const have = ranksIn(pile);
+  if (i === 0) {
+    const all: number[] = [];
+    for (let r = 1; r <= 13; r++) if (!have.has(r)) all.push(r);
+    return all;
+  }
+  const above = ranksIn(foundation[i - 1] ?? []);
+  return [...above].filter((r) => !have.has(r)).sort((a, b) => a - b);
+}
+
+/** Mirrors `Osmosis.canPlaceOnFoundation` for a specific candidate card. */
+export function osmosisCanPlace(foundation: Card[][], baseRank: number, i: number, card: Card): boolean {
+  const pile = foundation[i] ?? [];
+  if (pile.length === 0) {
+    if (card.value !== baseRank) return false;
+    if (suitAssigned(foundation, card.design, i)) return false;
+    if (i === 0) return true;
+    return (foundation[i - 1]?.length ?? 0) > 0;
+  }
+  if (pile[0]?.design !== card.design) return false;
+  if (i === 0) return true;
+  return ranksIn(foundation[i - 1] ?? []).has(card.value);
+}

--- a/frontend/src/utils/osmosisRules.ts
+++ b/frontend/src/utils/osmosisRules.ts
@@ -7,7 +7,7 @@ function ranksIn(pile: Card[]): Set<number> {
 
 /** True if suit `s` is already the assigned suit of a foundation row other than `except`. */
 function suitAssigned(foundation: Card[][], s: string, except: number): boolean {
-  return foundation.some((pile, i) => i !== except && pile.length > 0 && pile[0]?.design === s);
+  return foundation.some((pile, i) => i !== except && pile.length > 0 && pile[0].design === s);
 }
 
 /**
@@ -18,9 +18,9 @@ function suitAssigned(foundation: Card[][], s: string, except: number): boolean 
  * present in the row above and not yet in the row itself.
  */
 export function osmosisAllowedRanks(foundation: Card[][], baseRank: number, i: number): number[] {
-  const pile = foundation[i] ?? [];
+  const pile = foundation[i];
   if (pile.length === 0) {
-    if (i >= 1 && (foundation[i - 1]?.length ?? 0) === 0) return [];
+    if (i >= 1 && foundation[i - 1].length === 0) return [];
     return [baseRank];
   }
   const have = ranksIn(pile);
@@ -29,20 +29,20 @@ export function osmosisAllowedRanks(foundation: Card[][], baseRank: number, i: n
     for (let r = 1; r <= 13; r++) if (!have.has(r)) all.push(r);
     return all;
   }
-  const above = ranksIn(foundation[i - 1] ?? []);
+  const above = ranksIn(foundation[i - 1]);
   return [...above].filter((r) => !have.has(r)).sort((a, b) => a - b);
 }
 
 /** Mirrors `Osmosis.canPlaceOnFoundation` for a specific candidate card. */
 export function osmosisCanPlace(foundation: Card[][], baseRank: number, i: number, card: Card): boolean {
-  const pile = foundation[i] ?? [];
+  const pile = foundation[i];
   if (pile.length === 0) {
     if (card.value !== baseRank) return false;
     if (suitAssigned(foundation, card.design, i)) return false;
     if (i === 0) return true;
-    return (foundation[i - 1]?.length ?? 0) > 0;
+    return foundation[i - 1].length > 0;
   }
-  if (pile[0]?.design !== card.design) return false;
+  if (pile[0].design !== card.design) return false;
   if (i === 0) return true;
-  return ranksIn(foundation[i - 1] ?? []).has(card.value);
+  return ranksIn(foundation[i - 1]).has(card.value);
 }


### PR DESCRIPTION
## 概要

オズモシスは「下段は直上の段にあるランクのみ置ける」という独特ルールで、`OsmosisPage` はランクのヒントが無く初見では試行錯誤が必要だった。各段に置けるランクの視覚ガイドを追加する。

## 変更内容

- 新規 util `osmosisRules`（`osmosisAllowedRanks` / `osmosisCanPlace`、Go ドメインの `canPlaceOnFoundation` を忠実に再現）
- 各組札段に許容ランクバッジ（`data-testid="os-allowed-<i>"`)。ベース段(0)は `★ 任意`、下段は置けるランク列（無ければ `—`）を表示
- カード選択中、その段に置けない場合は `border-ds-error` + `cannotPlaceHere` tooltip
- `anyRank` / `cannotPlaceHere` キーを ja/en に追加

## テスト

- `bun run test -- --run src/utils/osmosisRules.test.ts src/pages/OsmosisPage.test.tsx` … 24 passed（util 7件: 空段/ベース段/上段依存/canPlace 各分岐 + ページ: 段別ガイド表示）
- `bun run check` … exit 0 / ja-en パリティ確認済み
- `bun run build`(`tsc -b`) はローカル OOM のため CI ゲート

Closes #2280