### PR TITLE
feat(fivehundred): show Avondale bid score under each bid button

### DIFF
--- a/frontend/src/i18n/locales/en/fivehundred.json
+++ b/frontend/src/i18n/locales/en/fivehundred.json
@@ -20,6 +20,7 @@
   "tricksLabel": "Tricks",
   "misereButton": "Misere",
   "openMisereButton": "Open Misere",
+  "bidValueLabel": "{{value}} pts",
   "passButton": "Pass",
   "exchangeButton": "Exchange ({{count}}/3)",
   "nominateSuit": "Suit to call with the joker:",

--- a/frontend/src/i18n/locales/ja/fivehundred.json
+++ b/frontend/src/i18n/locales/ja/fivehundred.json
@@ -20,6 +20,7 @@
   "tricksLabel": "トリック数",
   "misereButton": "ミゼール",
   "openMisereButton": "オープンミゼール",
+  "bidValueLabel": "{{value}}点",
   "passButton": "パス",
   "exchangeButton": "交換 ({{count}}/3)",
   "nominateSuit": "ジョーカーで指名するスート:",

--- a/frontend/src/pages/FiveHundredPage.test.tsx
+++ b/frontend/src/pages/FiveHundredPage.test.tsx
@@ -88,9 +88,16 @@ describe('FiveHundredPage', () => {
 
   it('bids a suit when a suit button is clicked', async () => {
     renderWithProviders(<FiveHundredPage />);
-    const spade = await screen.findByRole('button', { name: '♠' });
+    const spade = await screen.findByTestId('fh-bid-suit-1');
     fireEvent.click(spade);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', { bidKind: 1, bidTricks: 6, bidSuit: 1 }));
+  });
+
+  it('shows the Avondale score under each bid button (6 = ♠40 / ♥100 / NT120)', async () => {
+    renderWithProviders(<FiveHundredPage />);
+    expect(await screen.findByTestId('fh-bid-suit-1')).toHaveTextContent('40'); // 6♠
+    expect(screen.getByTestId('fh-bid-suit-3')).toHaveTextContent('100'); // 6♥
+    expect(screen.getByTestId('fh-bid-nt')).toHaveTextContent('120'); // 6NT
   });
 
   it('passes when pass is clicked', async () => {
@@ -101,11 +108,11 @@ describe('FiveHundredPage', () => {
 
   it('bids no-trump, misere and open misere', async () => {
     renderWithProviders(<FiveHundredPage />);
-    fireEvent.click(await screen.findByRole('button', { name: 'NT' }));
+    fireEvent.click(await screen.findByTestId('fh-bid-nt'));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', { bidKind: 2, bidTricks: 6 }));
-    fireEvent.click(screen.getByRole('button', { name: 'ミゼール' }));
+    fireEvent.click(screen.getByRole('button', { name: /ミゼール 250/ }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', { bidKind: 3 }));
-    fireEvent.click(screen.getByRole('button', { name: 'オープンミゼール' }));
+    fireEvent.click(screen.getByRole('button', { name: /オープンミゼール 520/ }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', { bidKind: 4 }));
   });
 

--- a/frontend/src/pages/FiveHundredPage.test.tsx
+++ b/frontend/src/pages/FiveHundredPage.test.tsx
@@ -98,6 +98,16 @@ describe('FiveHundredPage', () => {
     expect(await screen.findByTestId('fh-bid-suit-1')).toHaveTextContent('40'); // 6♠
     expect(screen.getByTestId('fh-bid-suit-3')).toHaveTextContent('100'); // 6♥
     expect(screen.getByTestId('fh-bid-nt')).toHaveTextContent('120'); // 6NT
+    expect(screen.getByTestId('fh-bid-misere')).toHaveTextContent('250');
+    expect(screen.getByTestId('fh-bid-open-misere')).toHaveTextContent('520');
+  });
+
+  it('updates suit/NT scores live when the trick count changes (7♠=140, 7NT=220)', async () => {
+    renderWithProviders(<FiveHundredPage />);
+    await screen.findByTestId('fh-bid-suit-1');
+    fireEvent.change(screen.getByLabelText('トリック数'), { target: { value: '7' } });
+    expect(screen.getByTestId('fh-bid-suit-1')).toHaveTextContent('140'); // 7♠
+    expect(screen.getByTestId('fh-bid-nt')).toHaveTextContent('220'); // 7NT
   });
 
   it('passes when pass is clicked', async () => {
@@ -110,9 +120,9 @@ describe('FiveHundredPage', () => {
     renderWithProviders(<FiveHundredPage />);
     fireEvent.click(await screen.findByTestId('fh-bid-nt'));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', { bidKind: 2, bidTricks: 6 }));
-    fireEvent.click(screen.getByRole('button', { name: /ミゼール 250/ }));
+    fireEvent.click(screen.getByTestId('fh-bid-misere'));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', { bidKind: 3 }));
-    fireEvent.click(screen.getByRole('button', { name: /オープンミゼール 520/ }));
+    fireEvent.click(screen.getByTestId('fh-bid-open-misere'));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', { bidKind: 4 }));
   });
 

--- a/frontend/src/pages/FiveHundredPage.tsx
+++ b/frontend/src/pages/FiveHundredPage.tsx
@@ -28,6 +28,11 @@ import {
   parseFiveHundredCommand,
 } from '../utils/cli/commands/fivehundredCommands';
 import type { CliGameConfig } from '../utils/cli/types';
+import {
+  FIVEHUNDRED_MISERE_VALUE,
+  FIVEHUNDRED_OPEN_MISERE_VALUE,
+  fivehundredBidValue,
+} from '../utils/fivehundredBidValue';
 
 const CPU_DIFFICULTY_SELECT = [
   { value: '0', label: 'Easy' },
@@ -352,34 +357,48 @@ function FiveHundredPageContent() {
                       type="button"
                       onClick={() => bidSuit(bidTricks, s.id)}
                       disabled={loading}
-                      className="px-3 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
+                      data-testid={`fh-bid-suit-${s.id}`}
+                      className="flex flex-col items-center rounded-lg bg-ds-info px-3 py-1.5 text-sm text-white disabled:opacity-40"
                     >
-                      {s.glyph}
+                      <span>{s.glyph}</span>
+                      <span className="text-[10px] text-white">
+                        {t('bidValueLabel', { value: fivehundredBidValue(bidTricks, s.id) })}
+                      </span>
                     </button>
                   ))}
                   <button
                     type="button"
                     onClick={() => bidNoTrump(bidTricks)}
                     disabled={loading}
-                    className="px-3 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
+                    data-testid="fh-bid-nt"
+                    className="flex flex-col items-center rounded-lg bg-ds-info px-3 py-1.5 text-sm text-white disabled:opacity-40"
                   >
-                    NT
+                    <span>NT</span>
+                    <span className="text-[10px] text-white">
+                      {t('bidValueLabel', { value: fivehundredBidValue(bidTricks, -1) })}
+                    </span>
                   </button>
                   <button
                     type="button"
                     onClick={bidMisere}
                     disabled={loading}
-                    className="px-3 py-2 rounded-lg bg-ds-surface text-ds-text text-sm disabled:opacity-40"
+                    className="flex flex-col items-center rounded-lg bg-ds-surface px-3 py-1.5 text-sm text-ds-text disabled:opacity-40"
                   >
-                    {t('misereButton')}
+                    <span>{t('misereButton')}</span>
+                    <span className="text-[10px] text-ds-text-muted">
+                      {t('bidValueLabel', { value: FIVEHUNDRED_MISERE_VALUE })}
+                    </span>
                   </button>
                   <button
                     type="button"
                     onClick={bidOpenMisere}
                     disabled={loading}
-                    className="px-3 py-2 rounded-lg bg-ds-surface text-ds-text text-sm disabled:opacity-40"
+                    className="flex flex-col items-center rounded-lg bg-ds-surface px-3 py-1.5 text-sm text-ds-text disabled:opacity-40"
                   >
-                    {t('openMisereButton')}
+                    <span>{t('openMisereButton')}</span>
+                    <span className="text-[10px] text-ds-text-muted">
+                      {t('bidValueLabel', { value: FIVEHUNDRED_OPEN_MISERE_VALUE })}
+                    </span>
                   </button>
                   <button
                     type="button"

--- a/frontend/src/pages/FiveHundredPage.tsx
+++ b/frontend/src/pages/FiveHundredPage.tsx
@@ -382,6 +382,7 @@ function FiveHundredPageContent() {
                     type="button"
                     onClick={bidMisere}
                     disabled={loading}
+                    data-testid="fh-bid-misere"
                     className="flex flex-col items-center rounded-lg bg-ds-surface px-3 py-1.5 text-sm text-ds-text disabled:opacity-40"
                   >
                     <span>{t('misereButton')}</span>
@@ -393,6 +394,7 @@ function FiveHundredPageContent() {
                     type="button"
                     onClick={bidOpenMisere}
                     disabled={loading}
+                    data-testid="fh-bid-open-misere"
                     className="flex flex-col items-center rounded-lg bg-ds-surface px-3 py-1.5 text-sm text-ds-text disabled:opacity-40"
                   >
                     <span>{t('openMisereButton')}</span>

--- a/frontend/src/utils/fivehundredBidValue.test.ts
+++ b/frontend/src/utils/fivehundredBidValue.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { FIVEHUNDRED_MISERE_VALUE, FIVEHUNDRED_OPEN_MISERE_VALUE, fivehundredBidValue } from './fivehundredBidValue';
+
+describe('fivehundredBidValue (Avondale schedule)', () => {
+  it('scores suit bids by base + 100 per trick above 6', () => {
+    // ♠=40, ♣=60, ♦=80, ♥=100 base; +100 per extra trick.
+    expect(fivehundredBidValue(6, 1)).toBe(40); // 6♠
+    expect(fivehundredBidValue(7, 1)).toBe(140); // 7♠
+    expect(fivehundredBidValue(10, 1)).toBe(440); // 10♠
+    expect(fivehundredBidValue(6, 2)).toBe(60); // 6♣
+    expect(fivehundredBidValue(6, 4)).toBe(80); // 6♦
+    expect(fivehundredBidValue(6, 3)).toBe(100); // 6♥
+    expect(fivehundredBidValue(10, 3)).toBe(500); // 10♥
+  });
+
+  it('scores no-trump (suit -1) from base 120', () => {
+    expect(fivehundredBidValue(6, -1)).toBe(120); // 6NT
+    expect(fivehundredBidValue(10, -1)).toBe(520); // 10NT
+  });
+
+  it('exposes the fixed Misère and Open Misère values', () => {
+    expect(FIVEHUNDRED_MISERE_VALUE).toBe(250);
+    expect(FIVEHUNDRED_OPEN_MISERE_VALUE).toBe(520);
+  });
+});

--- a/frontend/src/utils/fivehundredBidValue.ts
+++ b/frontend/src/utils/fivehundredBidValue.ts
@@ -1,0 +1,18 @@
+/** Avondale base score for a 6-trick suit contract, keyed by suit id (1=♠,2=♣,3=♥,4=♦). */
+const SUIT_BASE: Record<number, number> = { 1: 40, 2: 60, 3: 100, 4: 80 };
+
+/** Fixed score for a Misère contract (declarer takes 0 tricks). */
+export const FIVEHUNDRED_MISERE_VALUE = 250;
+/** Fixed score for an Open Misère contract (hand revealed). */
+export const FIVEHUNDRED_OPEN_MISERE_VALUE = 520;
+
+/**
+ * Avondale schedule score for a 500 suit/no-trump bid, mirroring the Go domain
+ * (`FiveHundredBid.Value`): suit base + 100 per trick above 6; pass `suit = -1`
+ * for No Trump (base 120). Misère / Open Misère are fixed
+ * ({@link FIVEHUNDRED_MISERE_VALUE} / {@link FIVEHUNDRED_OPEN_MISERE_VALUE}).
+ */
+export function fivehundredBidValue(tricks: number, suit: number): number {
+  const base = suit === -1 ? 120 : (SUIT_BASE[suit] ?? 0);
+  return base + (tricks - 6) * 100;
+}


### PR DESCRIPTION
## 概要

500 のビッドフェーズは各入札のスコア価値（6♠=40, 10NT=520, Misère=250 等）が表示されず、初心者にはどの入札が高得点か分からなかった。

## 変更内容

- 新規 util `fivehundredBidValue(tricks, suit)`（Avondale: ♠40/♣60/♦80/♥100 +100/トリック、NT は `suit=-1` で base 120。Misère 250 / Open Misère 520 は定数）— Go ドメイン `FiveHundredBid.Value` を忠実再現
- 各スート/NTボタン下にスコアを表示（トリック数セレクトでリアルタイム更新、`data-testid="fh-bid-suit-<id>"`/`fh-bid-nt`）。Misère/Open Misère は固定値
- `bidValueLabel` キーを ja/en に追加

## テスト

- `bun run test -- --run src/utils/fivehundredBidValue.test.ts src/pages/FiveHundredPage.test.tsx` … 14 passed（util: 各スート/NT/定数、ページ: 6♠40/6♥100/6NT120 表示）
- `bun run check` … exit 0 / design-tokens OK / ja-en パリティ確認済み
- `bun run build`(`tsc -b`) はローカル OOM のため CI ゲート

Closes #2281