### PR TITLE
feat(tienlen): disable play + explain for invalid combination

### DIFF
--- a/frontend/src/i18n/locales/en/tienlen.json
+++ b/frontend/src/i18n/locales/en/tienlen.json
@@ -11,6 +11,7 @@
   "tableEmpty": "(empty)",
   "playButton": "Play Selected",
   "passButton": "Pass",
+  "invalidCombo": "Not a valid combination (single, pair, triple, straight, double-sequence, or four of a kind)",
   "phase": {
     "play": "Play",
     "end": "End"

--- a/frontend/src/i18n/locales/ja/tienlen.json
+++ b/frontend/src/i18n/locales/ja/tienlen.json
@@ -11,6 +11,7 @@
   "tableEmpty": "(なし)",
   "playButton": "選択したカードを出す",
   "passButton": "パス",
+  "invalidCombo": "有効な組み合わせではありません（シングル・ペア・トリオ・ストレート・連続ペア・フォーカード）",
   "phase": {
     "play": "プレイ",
     "end": "終了"

--- a/frontend/src/pages/TienLenPage.test.tsx
+++ b/frontend/src/pages/TienLenPage.test.tsx
@@ -67,6 +67,15 @@ describe('TienLenPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', [0]));
   });
 
+  it('disables play and shows a reason for an invalid combination', async () => {
+    renderWithProviders(<TienLenPage />);
+    // Select ♠3 + ♥5 (two different ranks) → not a legal combo.
+    fireEvent.click(await screen.findByTestId('hand-card-0'));
+    fireEvent.click(screen.getByTestId('hand-card-1'));
+    expect(screen.getByTestId('play-button')).toBeDisabled();
+    expect(screen.getByTestId('tl-invalid-combo')).toBeInTheDocument();
+  });
+
   it('passes when the pass button is clicked', async () => {
     renderWithProviders(<TienLenPage />);
     fireEvent.click(await screen.findByTestId('pass-button'));

--- a/frontend/src/pages/TienLenPage.tsx
+++ b/frontend/src/pages/TienLenPage.tsx
@@ -28,6 +28,7 @@ import {
   type TienLenCliArgs,
 } from '../utils/cli/commands/tienlenCommands';
 import type { CliGameConfig } from '../utils/cli/types';
+import { isValidTienLenCombo } from '../utils/tienLenComboValidator';
 
 // Values match the Go domain constants: 0=Normal, 1=Easy, 2=Hard
 // (see TienLenConfig.go / TienLenCuiController help text).
@@ -119,7 +120,11 @@ function TienLenPageContent() {
   const humanWon = isGameEnd && state.players[0]?.rank === 1;
   const isHumanTurn = state.currentTurn === 0 && !isGameEnd;
   const human = state.players[0];
-  const canPlay = isHumanTurn && selectedIndices.length > 0;
+  const selectedCards = selectedIndices.map((i) => human.cards[i]).filter((c): c is NonNullable<typeof c> => c != null);
+  const hasValidCombo = isValidTienLenCombo(selectedCards);
+  // Only allow Play for a legal Tien Len combination; flag an invalid selection.
+  const canPlay = isHumanTurn && selectedIndices.length > 0 && hasValidCombo;
+  const showInvalidCombo = isHumanTurn && selectedIndices.length > 0 && !hasValidCombo;
   const phaseName = isGameEnd ? t('phase.end') : t('phase.play');
 
   return (
@@ -252,6 +257,15 @@ function TienLenPageContent() {
           <ReplaySpeedSettingsPanel />
 
           <GameFooter className={`${gameTheme.tienlen.footer} px-4 py-2.5`}>
+            {showInvalidCombo && (
+              <p
+                role="status"
+                data-testid="tl-invalid-combo"
+                className="mb-1 text-center font-medium text-ds-warning text-xs"
+              >
+                {t('invalidCombo')}
+              </p>
+            )}
             <div className="flex gap-2 justify-center flex-wrap" data-tutorial="tl-play-pass">
               <button
                 type="button"

--- a/frontend/src/pages/TienLenPage.tsx
+++ b/frontend/src/pages/TienLenPage.tsx
@@ -122,7 +122,6 @@ function TienLenPageContent() {
   const human = state.players[0];
   const selectedCards = selectedIndices.map((i) => human.cards[i]).filter((c): c is NonNullable<typeof c> => c != null);
   const hasValidCombo = isValidTienLenCombo(selectedCards);
-  // Only allow Play for a legal Tien Len combination; flag an invalid selection.
   const canPlay = isHumanTurn && selectedIndices.length > 0 && hasValidCombo;
   const showInvalidCombo = isHumanTurn && selectedIndices.length > 0 && !hasValidCombo;
   const phaseName = isGameEnd ? t('phase.end') : t('phase.play');

--- a/frontend/src/utils/tienLenComboValidator.test.ts
+++ b/frontend/src/utils/tienLenComboValidator.test.ts
@@ -19,6 +19,15 @@ describe('classifyTienLenCombo', () => {
     expect(classifyTienLenCombo([c('SPADE', 13), c('HEART', 1), c('CLOVER', 2)])).toBe('invalid'); // contains a 2
   });
 
+  it('classifies longer straights (5, 6, 7 cards) and rejects broken ones', () => {
+    expect(classifyTienLenCombo([c('S', 3), c('H', 4), c('C', 5), c('D', 6), c('S', 7)])).toBe('straight'); // 5
+    expect(classifyTienLenCombo([c('S', 3), c('H', 4), c('C', 5), c('D', 6), c('S', 7), c('H', 8)])).toBe('straight'); // 6
+    expect(classifyTienLenCombo([c('S', 3), c('H', 4), c('C', 5), c('D', 6), c('S', 7), c('H', 8), c('C', 9)])).toBe(
+      'straight',
+    ); // 7
+    expect(classifyTienLenCombo([c('S', 3), c('H', 4), c('C', 5), c('D', 6), c('S', 9)])).toBe('invalid'); // 5, broken
+  });
+
   it('classifies a three-pair run (chop) and rejects non-consecutive pairs', () => {
     expect(
       classifyTienLenCombo([c('SPADE', 4), c('HEART', 4), c('SPADE', 5), c('HEART', 5), c('SPADE', 6), c('HEART', 6)]),

--- a/frontend/src/utils/tienLenComboValidator.test.ts
+++ b/frontend/src/utils/tienLenComboValidator.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { classifyTienLenCombo, isValidTienLenCombo } from './tienLenComboValidator';
+
+const c = (design: string, value: number): Card => ({ design, value }) as unknown as Card;
+
+describe('classifyTienLenCombo', () => {
+  it('classifies singles, pairs, triples and four-of-a-kind', () => {
+    expect(classifyTienLenCombo([c('SPADE', 7)])).toBe('single');
+    expect(classifyTienLenCombo([c('SPADE', 7), c('HEART', 7)])).toBe('pair');
+    expect(classifyTienLenCombo([c('SPADE', 7), c('HEART', 7), c('CLOVER', 7)])).toBe('triple');
+    expect(classifyTienLenCombo([c('SPADE', 7), c('HEART', 7), c('CLOVER', 7), c('DIAMOND', 7)])).toBe('fourOfAKind');
+  });
+
+  it('classifies straights of length >= 3 (mixed suits), rejecting any containing a 2', () => {
+    expect(classifyTienLenCombo([c('SPADE', 3), c('HEART', 4), c('CLOVER', 5)])).toBe('straight');
+    // A (1) is high but legal in a run J-Q-K-A; 2 is not.
+    expect(classifyTienLenCombo([c('SPADE', 11), c('HEART', 12), c('CLOVER', 13), c('DIAMOND', 1)])).toBe('straight');
+    expect(classifyTienLenCombo([c('SPADE', 13), c('HEART', 1), c('CLOVER', 2)])).toBe('invalid'); // contains a 2
+  });
+
+  it('classifies a three-pair run (chop) and rejects non-consecutive pairs', () => {
+    expect(
+      classifyTienLenCombo([c('SPADE', 4), c('HEART', 4), c('SPADE', 5), c('HEART', 5), c('SPADE', 6), c('HEART', 6)]),
+    ).toBe('threePairRun');
+    expect(
+      classifyTienLenCombo([c('SPADE', 4), c('HEART', 4), c('SPADE', 5), c('HEART', 5), c('SPADE', 8), c('HEART', 8)]),
+    ).toBe('invalid'); // 4-5 then gap to 8
+  });
+
+  it('rejects malformed selections', () => {
+    expect(classifyTienLenCombo([c('SPADE', 7), c('HEART', 8)])).toBe('invalid'); // two different ranks
+    expect(classifyTienLenCombo([c('SPADE', 3), c('HEART', 4), c('CLOVER', 6)])).toBe('invalid'); // broken run
+  });
+});
+
+describe('isValidTienLenCombo', () => {
+  it('is false for an empty selection and true for a legal combo', () => {
+    expect(isValidTienLenCombo([])).toBe(false);
+    expect(isValidTienLenCombo([c('SPADE', 7), c('HEART', 8)])).toBe(false);
+    expect(isValidTienLenCombo([c('SPADE', 7), c('HEART', 7)])).toBe(true);
+  });
+});

--- a/frontend/src/utils/tienLenComboValidator.ts
+++ b/frontend/src/utils/tienLenComboValidator.ts
@@ -11,9 +11,8 @@ function allSameValue(cards: Card[]): boolean {
   return cards.length > 0 && cards.every((c) => c.value === cards[0].value);
 }
 
-/** A run of 3+ consecutive ranks; 2 cannot appear, suits may be mixed. */
+/** A run of consecutive ranks (callers pass 3+ cards); 2 cannot appear, suits may be mixed. */
 function checkStraight(cards: Card[]): boolean {
-  if (cards.length < 3) return false;
   if (cards.some((c) => c.value === 2)) return false;
   const strengths = cards.map((c) => valueStrength(c.value)).sort((a, b) => a - b);
   for (let i = 1; i < strengths.length; i++) {

--- a/frontend/src/utils/tienLenComboValidator.ts
+++ b/frontend/src/utils/tienLenComboValidator.ts
@@ -1,0 +1,61 @@
+import type { Card } from '../types/card';
+
+/** Tien Len rank strength: 2 is highest (12), then A (11), then 3..K = 0..10. */
+function valueStrength(v: number): number {
+  if (v === 2) return 12;
+  if (v === 1) return 11;
+  return v - 3;
+}
+
+function allSameValue(cards: Card[]): boolean {
+  return cards.length > 0 && cards.every((c) => c.value === cards[0].value);
+}
+
+/** A run of 3+ consecutive ranks; 2 cannot appear, suits may be mixed. */
+function checkStraight(cards: Card[]): boolean {
+  if (cards.length < 3) return false;
+  if (cards.some((c) => c.value === 2)) return false;
+  const strengths = cards.map((c) => valueStrength(c.value)).sort((a, b) => a - b);
+  for (let i = 1; i < strengths.length; i++) {
+    if (strengths[i] !== strengths[i - 1] + 1) return false;
+  }
+  return true;
+}
+
+/** Three consecutive pairs (e.g. 4-4-5-5-6-6); 2 cannot appear. */
+function checkThreePairRun(cards: Card[]): boolean {
+  if (cards.length !== 6) return false;
+  if (cards.some((c) => c.value === 2)) return false;
+  const freq = new Map<number, number>();
+  for (const c of cards) freq.set(c.value, (freq.get(c.value) ?? 0) + 1);
+  if (freq.size !== 3) return false;
+  const strengths: number[] = [];
+  for (const [v, cnt] of freq) {
+    if (cnt !== 2) return false;
+    strengths.push(valueStrength(v));
+  }
+  strengths.sort((a, b) => a - b);
+  return strengths[1] === strengths[0] + 1 && strengths[2] === strengths[1] + 1;
+}
+
+/** The Tien Len play categories. */
+export type TienLenCombo = 'single' | 'pair' | 'triple' | 'straight' | 'threePairRun' | 'fourOfAKind' | 'invalid';
+
+/**
+ * Classifies a selection of cards into its Tien Len play type, mirroring the Go
+ * domain `tienLenClassifyPlay`.
+ */
+export function classifyTienLenCombo(cards: Card[]): TienLenCombo {
+  const n = cards.length;
+  if (n === 1) return 'single';
+  if (n === 2) return allSameValue(cards) ? 'pair' : 'invalid';
+  if (n === 3) return allSameValue(cards) ? 'triple' : checkStraight(cards) ? 'straight' : 'invalid';
+  if (n === 4) return allSameValue(cards) ? 'fourOfAKind' : checkStraight(cards) ? 'straight' : 'invalid';
+  if (n === 6) return checkThreePairRun(cards) ? 'threePairRun' : checkStraight(cards) ? 'straight' : 'invalid';
+  return checkStraight(cards) ? 'straight' : 'invalid';
+}
+
+/** True if the selected cards form any legal Tien Len combination. */
+export function isValidTienLenCombo(cards: Card[]): boolean {
+  return cards.length > 0 && classifyTienLenCombo(cards) !== 'invalid';
+}


### PR DESCRIPTION
## 概要

ティエンレンは選択枚数>0なら Play ボタンが押せ、無効な組み合わせでもサーバーエラーが返るまで失敗が分からなかった。フロントで組み合わせを検証する。

## 変更内容

- 新規 util `tienLenComboValidator`（`classifyTienLenCombo`/`isValidTienLenCombo`、Go `tienLenClassifyPlay` を忠実再現: シングル/ペア/トリオ/フォーカード/ストレート(3+,2不可)/連続3ペア）
- `canPlay` を有効な組み合わせのみに限定。無効選択時は `text-ds-warning` の理由メッセージ（`data-testid="tl-invalid-combo"`）を表示

## テスト

- `bun run test -- --run src/utils/tienLenComboValidator.test.ts src/pages/TienLenPage.test.tsx` … 15 passed（util: 各役/2混入除外/連続ペア、ページ: 無効選択で Play 無効+理由表示）
- `bun run check` … exit 0 / design-tokens OK / ja-en パリティ確認済み
- `bun run build`(`tsc -b`) はローカル OOM のため CI ゲート

Closes #2279