### PR TITLE
feat(eightoff,penguin): highlight hint source/target with rings

### DIFF
--- a/frontend/src/pages/EightOffPage.test.tsx
+++ b/frontend/src/pages/EightOffPage.test.tsx
@@ -333,6 +333,58 @@ describe('EightOffPage', () => {
     await waitFor(() => expect(screen.getByTestId('eo-tableau-0-0').className).toContain('ring-ds-info'));
   });
 
+  it('highlights a free-cell hint source with an info ring', async () => {
+    mockExec.mockResolvedValue({
+      ...withFreeCellCardState,
+      hint: { fromZone: 'freecell', fromCol: 0, cardIndex: -1, toZone: 'tableau', toCol: -1 },
+    });
+    renderWithProviders(<EightOffPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    await waitFor(() => expect(screen.getByTestId('eo-freecell-0').className).toContain('ring-ds-info'));
+  });
+
+  it('highlights an empty free-cell hint target with a success ring', async () => {
+    renderWithProviders(<EightOffPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    mockExec.mockResolvedValue({
+      ...playingState,
+      hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 0, toZone: 'freecell', toCol: 1 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    await waitFor(() => expect(screen.getByTestId('eo-freecell-empty-1').className).toContain('ring-ds-success'));
+  });
+
+  it('highlights an empty foundation hint target with a success ring', async () => {
+    renderWithProviders(<EightOffPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    mockExec.mockResolvedValue({
+      ...playingState,
+      hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 0, toZone: 'foundation', toCol: 0 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    await waitFor(() => expect(screen.getByTestId('eo-foundation-empty-0').className).toContain('ring-ds-success'));
+  });
+
+  it('highlights a filled foundation hint target with a success ring', async () => {
+    mockExec.mockResolvedValue({
+      ...withFoundationState, // foundation[0] has SPADE A
+      hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 0, toZone: 'foundation', toCol: 0 },
+    });
+    renderWithProviders(<EightOffPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    await waitFor(() => expect(screen.getByTestId('eo-foundation-0').className).toContain('ring-ds-success'));
+  });
+
   // --- Keyboard shortcuts ---
 
   it('pressing h triggers hint in PLAYING phase', async () => {

--- a/frontend/src/pages/EightOffPage.test.tsx
+++ b/frontend/src/pages/EightOffPage.test.tsx
@@ -58,7 +58,7 @@ const withHintState: EightOffResponse = {
 
 const withHintFromColState: EightOffResponse = {
   ...playingState,
-  hint: { fromZone: 'tableau', fromCol: 2, cardIndex: 0, toZone: 'foundation', toCol: -1 },
+  hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 0, toZone: 'foundation', toCol: -1 },
 };
 
 const withFreeCellCardState: EightOffResponse = {
@@ -312,24 +312,25 @@ describe('EightOffPage', () => {
 
   // --- Hint display ---
 
-  it('hint display when hint is set', async () => {
+  it('highlights the hint target column (success ring) when a hint is set', async () => {
     renderWithProviders(<EightOffPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
 
-    mockExec.mockResolvedValue(withHintState);
+    mockExec.mockResolvedValue(withHintState); // toZone tableau, toCol 3
     fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
 
-    await waitFor(() => expect(screen.getAllByText(/ヒント/).length).toBeGreaterThanOrEqual(1));
+    await waitFor(() => expect(screen.getByTestId('eo-col-3').className).toContain('ring-ds-success'));
+    expect(screen.getByTestId('eo-col-0').className).not.toContain('ring-ds-success');
   });
 
-  it('hint display shows fromCol when fromCol is non-negative', async () => {
+  it('highlights the hint source card with an info ring when fromZone is tableau', async () => {
     renderWithProviders(<EightOffPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
 
-    mockExec.mockResolvedValue(withHintFromColState);
+    mockExec.mockResolvedValue(withHintFromColState); // fromZone tableau, fromCol 0, cardIndex 0
     fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
 
-    await waitFor(() => expect(screen.getByText(/tableau 2/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('eo-tableau-0-0').className).toContain('ring-ds-info'));
   });
 
   // --- Keyboard shortcuts ---

--- a/frontend/src/pages/EightOffPage.tsx
+++ b/frontend/src/pages/EightOffPage.tsx
@@ -240,6 +240,7 @@ function EightOffPageContent() {
                             disabled={!isPlaying || loading}
                             aria-label={cardAlt(card)}
                             aria-pressed={isSourceSelected('freecell', undefined, idx)}
+                            data-testid={`eo-freecell-${idx.toString()}`}
                             draggable={isPlaying && !loading}
                             onDragStart={dnd.handleDragStart(freeCellZone)}
                             onDragEnd={dnd.handleDragEnd}
@@ -253,6 +254,7 @@ function EightOffPageContent() {
                             onClick={() => handleSelectTarget(freeCellZone)}
                             disabled={!isPlaying || loading || !selectedSource}
                             aria-label={t('emptyFreecellAriaLabel', { idx: String(idx) })}
+                            data-testid={`eo-freecell-empty-${idx.toString()}`}
                             style={{ width: cardWidth, height: cardHeight }}
                             className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}${isHintTarget('freecell', idx) ? ' ring-2 ring-ds-success animate-pulse' : ''}`}
                           >
@@ -289,6 +291,7 @@ function EightOffPageContent() {
                               suit: FOUNDATION_SUITS[idx],
                               cardCount: String(pile.length),
                             })}
+                            data-testid={`eo-foundation-${idx.toString()}`}
                             className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite}${isHintTarget('foundation', idx) ? ' ring-2 ring-ds-success animate-pulse' : ''}`}
                           >
                             <AnimatedCard
@@ -304,6 +307,7 @@ function EightOffPageContent() {
                             onClick={() => handleSelectTarget(foundationZone)}
                             disabled={!isPlaying || loading || !selectedSource}
                             aria-label={t('emptyFoundationAriaLabel', { suit: FOUNDATION_SUITS[idx] })}
+                            data-testid={`eo-foundation-empty-${idx.toString()}`}
                             style={{ width: cardWidth, height: cardHeight }}
                             className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}${isHintTarget('foundation', idx) ? ' ring-2 ring-ds-success animate-pulse' : ''}`}
                           >

--- a/frontend/src/pages/EightOffPage.tsx
+++ b/frontend/src/pages/EightOffPage.tsx
@@ -244,7 +244,7 @@ function EightOffPageContent() {
                             draggable={isPlaying && !loading}
                             onDragStart={dnd.handleDragStart(freeCellZone)}
                             onDragEnd={dnd.handleDragEnd}
-                            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${isSourceSelected('freecell', undefined, idx) ? 'ring-2 ring-ds-warning' : isHintSourceFreecell(idx) ? 'ring-2 ring-ds-info animate-pulse' : ''} ${dnd.isDragSource(freeCellZone) ? 'opacity-50' : ''}`}
+                            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${isSourceSelected('freecell', undefined, idx) ? 'ring-2 ring-ds-warning' : isHintSourceFreecell(idx) ? 'ring-2 ring-ds-info animate-pulse' : focusRingWhite} ${dnd.isDragSource(freeCellZone) ? 'opacity-50' : ''}`}
                           >
                             <AnimatedCard card={card} width={cardWidth} draggable={false} />
                           </button>
@@ -400,15 +400,16 @@ function EightOffPageContent() {
                                       data-supermove-block={isInHoveredBlock ? 'true' : undefined}
                                       className={[
                                         'p-0 border-0 bg-transparent cursor-pointer w-full rounded',
-                                        focusRingWhite,
-                                        isSourceSelected('tableau', colIdx, undefined, cardIdx) &&
-                                          'ring-2 ring-ds-warning',
-                                        !isSourceSelected('tableau', colIdx, undefined, cardIdx) &&
-                                          isHintSourceTableau(colIdx, cardIdx) &&
-                                          'ring-2 ring-ds-info animate-pulse',
+                                        isSourceSelected('tableau', colIdx, undefined, cardIdx)
+                                          ? 'ring-2 ring-ds-warning'
+                                          : isHintSourceTableau(colIdx, cardIdx)
+                                            ? 'ring-2 ring-ds-info animate-pulse'
+                                            : exceedsSupermove
+                                              ? 'opacity-60 ring-1 ring-ds-error'
+                                              : isInHoveredBlock
+                                                ? 'ring-2 ring-ds-success'
+                                                : focusRingWhite,
                                         dnd.isDragSource(cardZone) && 'opacity-50',
-                                        exceedsSupermove && 'opacity-60 ring-1 ring-ds-error',
-                                        isInHoveredBlock && 'ring-2 ring-ds-success',
                                       ]
                                         .filter(Boolean)
                                         .join(' ')}

--- a/frontend/src/pages/EightOffPage.tsx
+++ b/frontend/src/pages/EightOffPage.tsx
@@ -175,6 +175,12 @@ function EightOffPageContent() {
     selectedSource.cell === cell &&
     selectedSource.cardIndex === cardIndex;
 
+  // Visual hint: ring the suggested source card (info) and target zone (success).
+  const isHintSourceTableau = (colIdx: number, cardIdx: number) =>
+    hint != null && hint.fromZone === 'tableau' && hint.fromCol === colIdx && hint.cardIndex === cardIdx;
+  const isHintSourceFreecell = (cell: number) => hint != null && hint.fromZone === 'freecell' && hint.fromCol === cell;
+  const isHintTarget = (zone: string, col: number) => hint != null && hint.toZone === zone && hint.toCol === col;
+
   return (
     <GamePageShell
       title={tc('nav.eightoff')}
@@ -237,7 +243,7 @@ function EightOffPageContent() {
                             draggable={isPlaying && !loading}
                             onDragStart={dnd.handleDragStart(freeCellZone)}
                             onDragEnd={dnd.handleDragEnd}
-                            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${isSourceSelected('freecell', undefined, idx) ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(freeCellZone) ? 'opacity-50' : ''}`}
+                            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${isSourceSelected('freecell', undefined, idx) ? 'ring-2 ring-ds-warning' : isHintSourceFreecell(idx) ? 'ring-2 ring-ds-info animate-pulse' : ''} ${dnd.isDragSource(freeCellZone) ? 'opacity-50' : ''}`}
                           >
                             <AnimatedCard card={card} width={cardWidth} draggable={false} />
                           </button>
@@ -248,7 +254,7 @@ function EightOffPageContent() {
                             disabled={!isPlaying || loading || !selectedSource}
                             aria-label={t('emptyFreecellAriaLabel', { idx: String(idx) })}
                             style={{ width: cardWidth, height: cardHeight }}
-                            className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}`}
+                            className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}${isHintTarget('freecell', idx) ? ' ring-2 ring-ds-success animate-pulse' : ''}`}
                           >
                             {t('empty')}
                           </button>
@@ -283,7 +289,7 @@ function EightOffPageContent() {
                               suit: FOUNDATION_SUITS[idx],
                               cardCount: String(pile.length),
                             })}
-                            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite}`}
+                            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite}${isHintTarget('foundation', idx) ? ' ring-2 ring-ds-success animate-pulse' : ''}`}
                           >
                             <AnimatedCard
                               card={pile[pile.length - 1]}
@@ -299,7 +305,7 @@ function EightOffPageContent() {
                             disabled={!isPlaying || loading || !selectedSource}
                             aria-label={t('emptyFoundationAriaLabel', { suit: FOUNDATION_SUITS[idx] })}
                             style={{ width: cardWidth, height: cardHeight }}
-                            className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}`}
+                            className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}${isHintTarget('foundation', idx) ? ' ring-2 ring-ds-success animate-pulse' : ''}`}
                           >
                             A
                           </button>
@@ -317,7 +323,11 @@ function EightOffPageContent() {
                 {state.tableau.map((col: (Card | null)[], colIdx: number) => {
                   const tableauColZone: EightOffMoveZone = { zone: 'tableau', col: colIdx };
                   return (
-                    <div key={`col-${colIdx.toString()}`} className="flex-1 min-w-0">
+                    <div
+                      key={`col-${colIdx.toString()}`}
+                      data-testid={`eo-col-${colIdx.toString()}`}
+                      className={`flex-1 min-w-0${isHintTarget('tableau', colIdx) ? ' rounded ring-2 ring-ds-success animate-pulse' : ''}`}
+                    >
                       <DropZone
                         isDropTarget={dnd.isDropTarget(tableauColZone)}
                         onDragOver={dnd.handleDragOver(tableauColZone)}
@@ -368,6 +378,7 @@ function EightOffPageContent() {
                                       }}
                                       disabled={!isPlaying || loading}
                                       aria-label={cardAlt(card)}
+                                      data-testid={`eo-tableau-${colIdx.toString()}-${cardIdx.toString()}`}
                                       aria-pressed={isSourceSelected('tableau', colIdx, undefined, cardIdx)}
                                       draggable={isPlaying && !loading && !exceedsSupermove}
                                       onDragStart={dnd.handleDragStart(cardZone)}
@@ -388,6 +399,9 @@ function EightOffPageContent() {
                                         focusRingWhite,
                                         isSourceSelected('tableau', colIdx, undefined, cardIdx) &&
                                           'ring-2 ring-ds-warning',
+                                        !isSourceSelected('tableau', colIdx, undefined, cardIdx) &&
+                                          isHintSourceTableau(colIdx, cardIdx) &&
+                                          'ring-2 ring-ds-info animate-pulse',
                                         dnd.isDragSource(cardZone) && 'opacity-50',
                                         exceedsSupermove && 'opacity-60 ring-1 ring-ds-error',
                                         isInHoveredBlock && 'ring-2 ring-ds-success',
@@ -418,14 +432,7 @@ function EightOffPageContent() {
               </div>
             </div>
 
-            {/* Hint display */}
-            {hint && (
-              <div className="text-ds-warning text-sm mb-2">
-                {t('hintAvailable')}: {hint.fromZone}
-                {hint.fromCol >= 0 ? ` ${hint.fromCol}` : ''} → {hint.toZone}
-                {hint.toCol >= 0 ? ` ${hint.toCol}` : ''}
-              </div>
-            )}
+            {/* Hint is shown via ring highlights on the suggested source card and target zone. */}
             {frontendHintEnabled && frontendHint && (
               <div className="flex justify-center">
                 <HintTooltip reason={t(frontendHint.reason)} confidence={frontendHint.confidence} />

--- a/frontend/src/pages/PenguinPage.test.tsx
+++ b/frontend/src/pages/PenguinPage.test.tsx
@@ -276,6 +276,58 @@ describe('PenguinPage', () => {
     await waitFor(() => expect(screen.getByTestId('pg-tableau-0-0').className).toContain('ring-ds-info'));
   });
 
+  it('highlights a free-cell hint source with an info ring', async () => {
+    renderWithProviders(<PenguinPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    mockExec.mockResolvedValue({
+      ...playingState, // freeCells[0] has DIAMOND 3
+      hint: { fromZone: 'freecell', fromCol: 0, cardIndex: -1, toZone: 'tableau', toCol: -1 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    await waitFor(() => expect(screen.getByTestId('pg-freecell-0').className).toContain('ring-ds-info'));
+  });
+
+  it('highlights an empty free-cell hint target with a success ring', async () => {
+    renderWithProviders(<PenguinPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    mockExec.mockResolvedValue({
+      ...playingState, // freeCells[3] is null
+      hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 0, toZone: 'freecell', toCol: 3 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    await waitFor(() => expect(screen.getByTestId('pg-freecell-empty-3').className).toContain('ring-ds-success'));
+  });
+
+  it('highlights an empty foundation hint target with a success ring', async () => {
+    renderWithProviders(<PenguinPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    mockExec.mockResolvedValue({
+      ...playingState,
+      hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 0, toZone: 'foundation', toCol: 0 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    await waitFor(() => expect(screen.getByTestId('pg-foundation-empty-0').className).toContain('ring-ds-success'));
+  });
+
+  it('highlights a filled foundation hint target with a success ring', async () => {
+    mockExec.mockResolvedValue({
+      ...withFoundationState, // foundation[0] has SPADE 4
+      hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 0, toZone: 'foundation', toCol: 0 },
+    });
+    renderWithProviders(<PenguinPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    await waitFor(() => expect(screen.getByTestId('pg-foundation-0').className).toContain('ring-ds-success'));
+  });
+
   // --- Keyboard shortcuts ---
 
   it('pressing h triggers hint in PLAYING phase', async () => {

--- a/frontend/src/pages/PenguinPage.test.tsx
+++ b/frontend/src/pages/PenguinPage.test.tsx
@@ -59,7 +59,7 @@ const withHintState: PenguinResponse = {
 
 const withHintFromColState: PenguinResponse = {
   ...playingState,
-  hint: { fromZone: 'tableau', fromCol: 2, cardIndex: 0, toZone: 'foundation', toCol: -1 },
+  hint: { fromZone: 'tableau', fromCol: 0, cardIndex: 0, toZone: 'foundation', toCol: -1 },
 };
 
 beforeEach(() => {
@@ -255,24 +255,25 @@ describe('PenguinPage', () => {
 
   // --- Hint display ---
 
-  it('hint display when hint is set', async () => {
+  it('highlights the hint target column (success ring) when a hint is set', async () => {
     renderWithProviders(<PenguinPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
 
-    mockExec.mockResolvedValue(withHintState);
+    mockExec.mockResolvedValue(withHintState); // toZone tableau, toCol 3
     fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
 
-    await waitFor(() => expect(screen.getAllByText(/ヒント/).length).toBeGreaterThanOrEqual(1));
+    await waitFor(() => expect(screen.getByTestId('pg-col-3').className).toContain('ring-ds-success'));
+    expect(screen.getByTestId('pg-col-0').className).not.toContain('ring-ds-success');
   });
 
-  it('hint display shows fromCol when fromCol is non-negative', async () => {
+  it('highlights the hint source card with an info ring when fromZone is tableau', async () => {
     renderWithProviders(<PenguinPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
 
-    mockExec.mockResolvedValue(withHintFromColState);
+    mockExec.mockResolvedValue(withHintFromColState); // fromZone tableau, fromCol 0, cardIndex 0
     fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
 
-    await waitFor(() => expect(screen.getByText(/tableau 2/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('pg-tableau-0-0').className).toContain('ring-ds-info'));
   });
 
   // --- Keyboard shortcuts ---

--- a/frontend/src/pages/PenguinPage.tsx
+++ b/frontend/src/pages/PenguinPage.tsx
@@ -194,6 +194,11 @@ function PenguinPageContent() {
     selectedSource.cell === cell &&
     selectedSource.cardIndex === cardIndex;
 
+  const isHintSourceTableau = (colIdx: number, cardIdx: number) =>
+    hint != null && hint.fromZone === 'tableau' && hint.fromCol === colIdx && hint.cardIndex === cardIdx;
+  const isHintSourceFreecell = (cell: number) => hint != null && hint.fromZone === 'freecell' && hint.fromCol === cell;
+  const isHintTarget = (zone: string, col: number) => hint != null && hint.toZone === zone && hint.toCol === col;
+
   return (
     <GamePageShell
       title={tc('nav.penguin')}
@@ -256,10 +261,11 @@ function PenguinPageContent() {
                             disabled={!isPlaying || loading}
                             aria-label={cardAlt(card)}
                             aria-pressed={isSourceSelected('freecell', undefined, idx)}
+                            data-testid={`pg-freecell-${idx.toString()}`}
                             draggable={isPlaying && !loading}
                             onDragStart={dnd.handleDragStart(freeCellZone)}
                             onDragEnd={dnd.handleDragEnd}
-                            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${isSourceSelected('freecell', undefined, idx) ? 'ring-2 ring-ds-warning' : focusRingWhite} ${dnd.isDragSource(freeCellZone) ? 'opacity-50' : ''}`}
+                            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${isSourceSelected('freecell', undefined, idx) ? 'ring-2 ring-ds-warning' : isHintSourceFreecell(idx) ? 'ring-2 ring-ds-info animate-pulse' : focusRingWhite} ${dnd.isDragSource(freeCellZone) ? 'opacity-50' : ''}`}
                           >
                             <AnimatedCard card={card} width={cardWidth} draggable={false} />
                           </button>
@@ -270,7 +276,7 @@ function PenguinPageContent() {
                             disabled={!isPlaying || loading || !selectedSource}
                             aria-label={t('emptyFreecellAriaLabel', { idx: String(idx) })}
                             style={{ width: cardWidth, height: cardHeight }}
-                            className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}`}
+                            className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}${isHintTarget('freecell', idx) ? ' ring-2 ring-ds-success animate-pulse' : ''}`}
                           >
                             {t('empty')}
                           </button>
@@ -305,7 +311,7 @@ function PenguinPageContent() {
                               suit: FOUNDATION_SUITS[idx],
                               cardCount: String(pile.length),
                             })}
-                            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite}`}
+                            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite}${isHintTarget('foundation', idx) ? ' ring-2 ring-ds-success animate-pulse' : ''}`}
                           >
                             <AnimatedCard
                               card={pile[pile.length - 1]}
@@ -321,7 +327,7 @@ function PenguinPageContent() {
                             disabled={!isPlaying || loading || !selectedSource}
                             aria-label={t('emptyFoundationAriaLabel', { suit: FOUNDATION_SUITS[idx] })}
                             style={{ width: cardWidth, height: cardHeight }}
-                            className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}`}
+                            className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}${isHintTarget('foundation', idx) ? ' ring-2 ring-ds-success animate-pulse' : ''}`}
                           >
                             {baseRankLabel(state.baseRank)}
                           </button>
@@ -339,7 +345,11 @@ function PenguinPageContent() {
                 {state.tableau.map((col: (Card | null)[], colIdx: number) => {
                   const tableauColZone: PenguinMoveZone = { zone: 'tableau', col: colIdx };
                   return (
-                    <div key={`col-${colIdx.toString()}`} className="flex-1 min-w-0">
+                    <div
+                      key={`col-${colIdx.toString()}`}
+                      data-testid={`pg-col-${colIdx.toString()}`}
+                      className={`flex-1 min-w-0${isHintTarget('tableau', colIdx) ? ' rounded ring-2 ring-ds-success animate-pulse' : ''}`}
+                    >
                       <DropZone
                         isDropTarget={dnd.isDropTarget(tableauColZone)}
                         onDragOver={dnd.handleDragOver(tableauColZone)}
@@ -391,6 +401,7 @@ function PenguinPageContent() {
                                       disabled={!isPlaying || loading}
                                       aria-label={cardAlt(card)}
                                       aria-pressed={isSourceSelected('tableau', colIdx, undefined, cardIdx)}
+                                      data-testid={`pg-tableau-${colIdx.toString()}-${cardIdx.toString()}`}
                                       draggable={isPlaying && !loading && !exceedsSupermove}
                                       onDragStart={dnd.handleDragStart(cardZone)}
                                       onDragEnd={dnd.handleDragEnd}
@@ -409,11 +420,13 @@ function PenguinPageContent() {
                                         'p-0 border-0 bg-transparent cursor-pointer w-full rounded',
                                         isSourceSelected('tableau', colIdx, undefined, cardIdx)
                                           ? 'ring-2 ring-ds-warning'
-                                          : exceedsSupermove
-                                            ? 'opacity-60 ring-1 ring-ds-error'
-                                            : isInHoveredBlock
-                                              ? 'ring-2 ring-ds-success'
-                                              : focusRingWhite,
+                                          : isHintSourceTableau(colIdx, cardIdx)
+                                            ? 'ring-2 ring-ds-info animate-pulse'
+                                            : exceedsSupermove
+                                              ? 'opacity-60 ring-1 ring-ds-error'
+                                              : isInHoveredBlock
+                                                ? 'ring-2 ring-ds-success'
+                                                : focusRingWhite,
                                         dnd.isDragSource(cardZone) && 'opacity-50',
                                       ]
                                         .filter(Boolean)
@@ -442,14 +455,6 @@ function PenguinPageContent() {
               </div>
             </div>
 
-            {/* Hint display */}
-            {hint && (
-              <div className="text-ds-warning text-sm mb-2">
-                {t('hintAvailable')}: {hint.fromZone}
-                {hint.fromCol >= 0 ? ` ${hint.fromCol}` : ''} → {hint.toZone}
-                {hint.toCol >= 0 ? ` ${hint.toCol}` : ''}
-              </div>
-            )}
             {frontendHintEnabled && frontendHint && (
               <div className="flex justify-center">
                 <HintTooltip reason={t(frontendHint.reason)} confidence={frontendHint.confidence} />

--- a/frontend/src/pages/PenguinPage.tsx
+++ b/frontend/src/pages/PenguinPage.tsx
@@ -275,6 +275,7 @@ function PenguinPageContent() {
                             onClick={() => handleSelectTarget(freeCellZone)}
                             disabled={!isPlaying || loading || !selectedSource}
                             aria-label={t('emptyFreecellAriaLabel', { idx: String(idx) })}
+                            data-testid={`pg-freecell-empty-${idx.toString()}`}
                             style={{ width: cardWidth, height: cardHeight }}
                             className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}${isHintTarget('freecell', idx) ? ' ring-2 ring-ds-success animate-pulse' : ''}`}
                           >
@@ -311,6 +312,7 @@ function PenguinPageContent() {
                               suit: FOUNDATION_SUITS[idx],
                               cardCount: String(pile.length),
                             })}
+                            data-testid={`pg-foundation-${idx.toString()}`}
                             className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite}${isHintTarget('foundation', idx) ? ' ring-2 ring-ds-success animate-pulse' : ''}`}
                           >
                             <AnimatedCard
@@ -326,6 +328,7 @@ function PenguinPageContent() {
                             onClick={() => handleSelectTarget(foundationZone)}
                             disabled={!isPlaying || loading || !selectedSource}
                             aria-label={t('emptyFoundationAriaLabel', { suit: FOUNDATION_SUITS[idx] })}
+                            data-testid={`pg-foundation-empty-${idx.toString()}`}
                             style={{ width: cardWidth, height: cardHeight }}
                             className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}${isHintTarget('foundation', idx) ? ' ring-2 ring-ds-success animate-pulse' : ''}`}
                           >


### PR DESCRIPTION
## Summary

Implements #2267. Replaces the plain-text hint line in **Eight Off** and **Penguin** (`tableau N → foundation`) with on-board visual ring highlights, matching the hint convention already used by Spiderette and the other solitaire pages.

- **Hint source card** → `ring-ds-info animate-pulse` (freecell or tableau card)
- **Hint target slot/column** → `ring-ds-success animate-pulse` (empty freecell, foundation pile, tableau column)
- Selection ring (`ring-ds-warning`) keeps priority over the hint ring; the existing supermove rings (error / hovered-success) fall below the hint ring in the tableau priority chain.

The issue explicitly asked for the same change in Penguin, so both pages are updated identically.

## Changes
- `EightOffPage.tsx` / `PenguinPage.tsx`: add `isHintSourceTableau` / `isHintSourceFreecell` / `isHintTarget` helpers, wire rings into freecell/foundation/tableau elements, add `data-testid` anchors (`eo-`/`pg-` col + tableau + freecell), remove the text hint block.
- Rewrote the two hint tests on each page to assert the rings instead of the removed text.

## Test plan
- [x] `bun run test -- --run src/pages/EightOffPage.test.tsx` (62 passed)
- [x] `bun run test -- --run src/pages/PenguinPage.test.tsx` (37 passed)
- [x] `bun run check` (biome + design-tokens OK)
- [ ] CI: build (tsc) + E2E + codecov

Closes #2267