### PR TITLE
feat(gaps): convey backend hint via ring highlights only

### DIFF
--- a/frontend/src/i18n/locales/en/gaps.json
+++ b/frontend/src/i18n/locales/en/gaps.json
@@ -19,7 +19,6 @@
   "gameClear": "Game Clear! Moves: {{moveCount}}",
   "gameOver": "Game Over",
   "noHint": "No hint available",
-  "hintAvailable": "Hint available",
   "noRedealsLeft": "No redeals remaining",
   "landscapeBanner": "Rotate to landscape for easier play",
   "tutorial": {

--- a/frontend/src/i18n/locales/ja/gaps.json
+++ b/frontend/src/i18n/locales/ja/gaps.json
@@ -19,7 +19,6 @@
   "gameClear": "ゲームクリア！ 手数: {{moveCount}}",
   "gameOver": "ゲームオーバー",
   "noHint": "ヒントはありません",
-  "hintAvailable": "ヒントがあります",
   "noRedealsLeft": "再配りはもう使えません",
   "landscapeBanner": "横向きにすると操作しやすくなります",
   "tutorial": {

--- a/frontend/src/pages/GapsPage.test.tsx
+++ b/frontend/src/pages/GapsPage.test.tsx
@@ -130,9 +130,9 @@ describe('GapsPage', () => {
     fireEvent.click(btn);
 
     // Target gap cell gets the hint ring.
-    await waitFor(() => expect(screen.getByTestId('gaps-cell-0-12').className).toContain('ring-ds-warning'));
+    await waitFor(() => expect(screen.getByTestId('gaps-cell-0-12')).toHaveClass('ring-ds-warning'));
     // Source card cell gets the hint ring (locked in this fixture; the hint ring wins over the locked ring).
-    expect(screen.getByTestId('gaps-locked-1-0').className).toContain('ring-ds-warning');
+    expect(screen.getByTestId('gaps-locked-1-0')).toHaveClass('ring-ds-warning');
     // The old coordinate text line is gone.
     expect(screen.queryByText(/\(1,0\)/)).not.toBeInTheDocument();
   });

--- a/frontend/src/pages/GapsPage.test.tsx
+++ b/frontend/src/pages/GapsPage.test.tsx
@@ -123,12 +123,18 @@ describe('GapsPage', () => {
     await waitFor(() => expect(mockedRun).toHaveBeenCalledWith('giveup'));
   });
 
-  it('shows hint coordinates when backend hint is present', async () => {
-    mockedRun.mockResolvedValue(withHintState);
+  it('highlights hint source and target cells with rings instead of coordinate text', async () => {
+    mockedRun.mockResolvedValue(withHintState); // from (1,0) card, to (0,12) gap
     renderWithProviders(<GapsPage />);
     const btn = await screen.findByRole('button', { name: 'ヒント' });
     fireEvent.click(btn);
-    await waitFor(() => expect(screen.getByText(/\(1,0\)/)).toBeInTheDocument());
+
+    // Target gap cell gets the hint ring.
+    await waitFor(() => expect(screen.getByTestId('gaps-cell-0-12').className).toContain('ring-ds-warning'));
+    // Source card cell gets the hint ring (locked in this fixture; the hint ring wins over the locked ring).
+    expect(screen.getByTestId('gaps-locked-1-0').className).toContain('ring-ds-warning');
+    // The old coordinate text line is gone.
+    expect(screen.queryByText(/\(1,0\)/)).not.toBeInTheDocument();
   });
 
   it('hides action buttons when game is in game-clear phase', async () => {

--- a/frontend/src/pages/GapsPage.tsx
+++ b/frontend/src/pages/GapsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect } from 'react';
 import { type GapsMoveZone, gapsApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { SettingsPanel } from '../components/common/SettingsPanel';
@@ -48,7 +48,7 @@ const GAPS_TUTORIAL_STEPS: TutorialStep[] = [
     advanceOn: 'next',
   },
   {
-    target: '[data-tutorial="gaps-hint-display"]',
+    target: '[data-tutorial="gaps-grid"]',
     messageKey: 'tutorial.hintDisplay',
     placement: 'bottom',
     advanceOn: 'next',
@@ -69,7 +69,6 @@ function GapsPageContent() {
     useGamePageSetup('gaps');
   const apiRun = gapsApi.exec;
   const { state, loading, error, exec: run, retry } = useGameApi(apiRun);
-  const [hintEnabledByUser, setHintEnabledByUser] = useState(false);
 
   useEffect(() => {
     void run('reset');
@@ -85,7 +84,6 @@ function GapsPageContent() {
 
   const handleReset = useCallback(() => {
     hideActionLog();
-    setHintEnabledByUser(false);
     void run('reset');
   }, [run, hideActionLog]);
 
@@ -102,7 +100,6 @@ function GapsPageContent() {
   }, [run]);
 
   const handleHint = useCallback(() => {
-    setHintEnabledByUser(true);
     void run('hint');
   }, [run]);
 
@@ -172,6 +169,7 @@ function GapsPageContent() {
                         onDragLeave={dnd.handleDragLeave}
                         onDrop={dnd.handleDrop(zone)}
                         aria-label={t('gap')}
+                        data-testid={`gaps-cell-${rIdx.toString()}-${cIdx.toString()}`}
                         className={`relative flex items-center justify-center rounded border-2 ${
                           dnd.isDropTarget(zone)
                             ? 'border-ds-warning bg-ds-warning/20'
@@ -225,7 +223,7 @@ function GapsPageContent() {
                       onDragEnd={dnd.handleDragEnd}
                       aria-label={isLocked ? `${cardAlt(cell)} ${t('lockedAria')}` : cardAlt(cell)}
                       disabled={!isPlaying || loading}
-                      data-testid={isLocked ? `gaps-locked-${rIdx}-${cIdx}` : undefined}
+                      data-testid={isLocked ? `gaps-locked-${rIdx}-${cIdx}` : `gaps-cell-${rIdx}-${cIdx}`}
                       className={`relative p-0 border-0 bg-transparent rounded ${focusRingWhite} ${ringClass} ${dnd.isDragSource(zone) ? 'opacity-50' : ''}`}
                     >
                       <AnimatedCard card={cell} width={cardWidth} />
@@ -244,15 +242,6 @@ function GapsPageContent() {
               </div>
             );
           })}
-        </div>
-
-        <div data-tutorial="gaps-hint-display">
-          {state.hint && hintEnabledByUser && (
-            <div className="text-ds-warning text-sm mb-2 text-center">
-              {t('hintAvailable')}: ({state.hint.fromRow},{state.hint.fromCol}) → ({state.hint.toRow},{state.hint.toCol}
-              )
-            </div>
-          )}
         </div>
 
         {frontendHintEnabled && frontendHint && (

--- a/frontend/src/pages/GapsPage.tsx
+++ b/frontend/src/pages/GapsPage.tsx
@@ -223,7 +223,11 @@ function GapsPageContent() {
                       onDragEnd={dnd.handleDragEnd}
                       aria-label={isLocked ? `${cardAlt(cell)} ${t('lockedAria')}` : cardAlt(cell)}
                       disabled={!isPlaying || loading}
-                      data-testid={isLocked ? `gaps-locked-${rIdx}-${cIdx}` : `gaps-cell-${rIdx}-${cIdx}`}
+                      data-testid={
+                        isLocked
+                          ? `gaps-locked-${rIdx.toString()}-${cIdx.toString()}`
+                          : `gaps-cell-${rIdx.toString()}-${cIdx.toString()}`
+                      }
                       className={`relative p-0 border-0 bg-transparent rounded ${focusRingWhite} ${ringClass} ${dnd.isDragSource(zone) ? 'opacity-50' : ''}`}
                     >
                       <AnimatedCard card={cell} width={cardWidth} />


### PR DESCRIPTION
## Summary

Implements #2264. In **Gaps / Montana**, the backend hint was shown two ways: a coordinate text line (`(fromRow,fromCol) → (toRow,toCol)`) *and* ring highlights on the from/to grid cells. The text line is redundant and less intuitive than the on-grid highlight, so this removes it and keeps the rings as the sole indicator.

- Removed the coordinate text `<div>` and the now-unused `hintEnabledByUser` state (+ its `useState` import).
- Existing behaviour preserved: hint source cell and target gap cell still get `ring-2 ring-ds-warning`.
- Re-pointed the `hintDisplay` tutorial step from the removed text div to the grid (`gaps-grid`), where the rings actually appear, so the tutorial keeps working.
- Added `gaps-cell-<r>-<c>` testid anchors to grid cells (gap + non-locked card) for assertions.
- Dropped the orphaned `hintAvailable` key from `ja/gaps.json` and `en/gaps.json` (parity preserved).
- The frontend `HintTooltip` is unchanged.

## Test plan
- [x] `bun run test -- --run src/pages/GapsPage.test.tsx` (14 passed) — rewrote the hint test to assert the source/target rings and the absence of the coordinate text
- [x] `bun run check` (biome + design-tokens OK)
- [ ] CI: build (tsc) + E2E + codecov

Closes #2264