### PR TITLE
feat(piquet): i18n PlayerCard / DeclarationList / TrickView labels

### DIFF
--- a/frontend/src/i18n/locales/en/piquet.json
+++ b/frontend/src/i18n/locales/en/piquet.json
@@ -20,6 +20,12 @@
   "nextDeal": "Next deal",
   "partieWinner": "★ Partie winner: player {{idx}}",
   "partieDraw": "Partie ended in a draw",
+  "carteBlanche": "★ carte blanche",
+  "playerStats": "Hand: {{hand}} | Tricks: {{tricks}} | Round: {{round}} | Match: {{match}}",
+  "declarationsList": "Declarations",
+  "declTied": "tied",
+  "declScored": "{{player}} +{{score}}",
+  "trickHeader": "Trick",
   "tutorial": {
     "hand": "Your hand. Click to select for exchange, or click to play during the play phase.",
     "controls": "Action buttons (exchange, declaration advance, next deal) appear here."

--- a/frontend/src/i18n/locales/ja/piquet.json
+++ b/frontend/src/i18n/locales/ja/piquet.json
@@ -20,6 +20,12 @@
   "nextDeal": "次のディールへ",
   "partieWinner": "★ パルティ勝者: プレイヤー {{idx}}",
   "partieDraw": "パルティは引き分けです",
+  "carteBlanche": "★ カルトブランシュ",
+  "playerStats": "手札: {{hand}} | トリック: {{tricks}} | ラウンド: {{round}} | マッチ: {{match}}",
+  "declarationsList": "宣言結果",
+  "declTied": "引き分け",
+  "declScored": "{{player}} +{{score}}",
+  "trickHeader": "トリック",
   "tutorial": {
     "hand": "あなたの手札です。交換フェーズではクリックで選択し、プレイフェーズではクリックでプレイします。",
     "controls": "交換確定・宣言進行・次ディールなどのアクションがここに出ます。"

--- a/frontend/src/pages/PiquetPage.test.tsx
+++ b/frontend/src/pages/PiquetPage.test.tsx
@@ -188,7 +188,9 @@ describe('PiquetPage', () => {
       }),
     );
     renderWithProviders(<PiquetPage />);
-    await waitFor(() => expect(screen.getByText(/P0:/)).toBeInTheDocument()); // TrickView entry
+    // Exact match isolates the TrickView header from the "トリック: 0" stats line.
+    await waitFor(() => expect(screen.getByText('トリック')).toBeInTheDocument()); // trickHeader
+    expect(screen.getByText(/P0:/)).toBeInTheDocument(); // TrickView entry
   });
 
   it('shows the meld badge in the lost palette when the opponent scores', async () => {

--- a/frontend/src/pages/PiquetPage.test.tsx
+++ b/frontend/src/pages/PiquetPage.test.tsx
@@ -142,6 +142,55 @@ describe('PiquetPage', () => {
     expect(wonBadge).toHaveClass('text-ds-success', 'border-ds-success');
   });
 
+  it('renders the translated per-player stats line', async () => {
+    mockExec.mockResolvedValue(makeState());
+    renderWithProviders(<PiquetPage />);
+    // ja: "手札: 12 | トリック: 0 | ラウンド: 0 | マッチ: 0" (PlayerCard.playerStats)
+    await waitFor(() => expect(screen.getAllByText(/手札: 12/).length).toBeGreaterThan(0));
+  });
+
+  it('renders the declaration list with translated tied and fallback-scorer labels', async () => {
+    const claim = { length: 0, topRank: 0, pipTotal: 0, suit: 0, cards: [] };
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: PiquetPhase.DECLARATION,
+        declStage: PiquetDeclarationKind.SET,
+        declResults: [
+          {
+            kind: PiquetDeclarationKind.POINT,
+            elderClaim: claim,
+            youngerClaim: claim,
+            winner: -1,
+            scoredBy: -1,
+            score: 0,
+          },
+          {
+            kind: PiquetDeclarationKind.SEQUENCE,
+            elderClaim: claim,
+            youngerClaim: claim,
+            winner: -1,
+            scoredBy: 5, // neither elder (0) nor younger (1) → "?" fallback label
+            score: 3,
+          },
+        ],
+      }),
+    );
+    renderWithProviders(<PiquetPage />);
+    await waitFor(() => expect(screen.getByText(/引き分け/)).toBeInTheDocument()); // declTied
+    expect(screen.getByText(/\? \+3/)).toBeInTheDocument(); // declScored with "?" scorer
+  });
+
+  it('renders the translated trick header during the play phase', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: PiquetPhase.PLAY,
+        currentTrick: [{ playerIdx: 0, card: { design: 'SPADE', value: 13 } }],
+      }),
+    );
+    renderWithProviders(<PiquetPage />);
+    await waitFor(() => expect(screen.getByText(/P0:/)).toBeInTheDocument()); // TrickView entry
+  });
+
   it('shows the meld badge in the lost palette when the opponent scores', async () => {
     mockExec.mockResolvedValue(
       makeState({

--- a/frontend/src/pages/PiquetPage.tsx
+++ b/frontend/src/pages/PiquetPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
@@ -291,41 +292,51 @@ interface PlayerCardProps {
 }
 
 function PlayerCard({ label, player, carteBlanche }: PlayerCardProps) {
+  const { t } = useTranslation('piquet');
   if (!player) return null;
   return (
     <div className="rounded border border-white/20 p-2 mx-2 text-sm">
       <div className="flex items-center justify-between">
         <span className="font-bold">{label}</span>
-        {carteBlanche ? <span className="text-ds-warning">★ carte blanche</span> : null}
+        {carteBlanche ? <span className="text-ds-warning">{t('carteBlanche')}</span> : null}
       </div>
       <div className="text-xs opacity-80">
-        hand: {player.cardCount} | tricks: {player.trickCount} | round: {player.roundScore} | match: {player.matchScore}
+        {t('playerStats', {
+          hand: player.cardCount,
+          tricks: player.trickCount,
+          round: player.roundScore,
+          match: player.matchScore,
+        })}
       </div>
     </div>
   );
 }
 
 function DeclarationList({ results, elderIdx }: { results: PiquetDeclaration[]; elderIdx: number }) {
+  const { t } = useTranslation('piquet');
   const youngerIdx = elderIdx === 0 ? 1 : 0;
   return (
     <div className="rounded border border-white/20 p-2 mx-2 text-sm">
-      <div className="mb-1 font-bold">Declarations</div>
-      {results.map((r) => (
-        <div key={`decl-${r.kind}-${r.winner}-${r.score}`} className="text-xs">
-          {declKindLabel(r.kind)}:{' '}
-          {r.score === 0
-            ? 'tied'
-            : `player ${r.scoredBy === elderIdx ? 'E' : r.scoredBy === youngerIdx ? 'Y' : '?'} +${r.score}`}
-        </div>
-      ))}
+      <div className="mb-1 font-bold">{t('declarationsList')}</div>
+      {results.map((r) => {
+        const playerLabel =
+          r.scoredBy === elderIdx ? t('roleElder') : r.scoredBy === youngerIdx ? t('roleYounger') : '?';
+        return (
+          <div key={`decl-${r.kind}-${r.winner}-${r.score}`} className="text-xs">
+            {declKindLabel(r.kind)}:{' '}
+            {r.score === 0 ? t('declTied') : t('declScored', { player: playerLabel, score: r.score })}
+          </div>
+        );
+      })}
     </div>
   );
 }
 
 function TrickView({ trick }: { trick: PiquetResponse['currentTrick'] }) {
+  const { t } = useTranslation('piquet');
   return (
     <div className="rounded border border-white/20 p-2 mx-2 text-sm">
-      <div className="mb-1 font-bold">Trick</div>
+      <div className="mb-1 font-bold">{t('trickHeader')}</div>
       <div className="flex gap-2">
         {trick.map((tc, i) => (
           <div


### PR DESCRIPTION
## Summary

Implements #2258. The `PlayerCard`, `DeclarationList`, and `TrickView` subcomponents in `PiquetPage.tsx` rendered hardcoded English labels, so Piquet showed English UI even in the Japanese locale — inconsistent with every other game. This routes them through `t()`.

- `PlayerCard`: stats line (`hand/tricks/round/match`) → `playerStats` interpolated key; `★ carte blanche` → `carteBlanche`.
- `DeclarationList`: header `Declarations` → `declarationsList`; `tied` → `declTied`; the `player E/Y +score` row → `declScored` interpolation, reusing the existing `roleElder`/`roleYounger` labels instead of the cryptic `E`/`Y` codes.
- `TrickView`: header `Trick` → `trickHeader`.
- Each subcomponent now pulls `t` via `useTranslation('piquet')`.
- Added the new keys to `ja/piquet.json` and `en/piquet.json` (parity preserved).

`declKindLabel` (Point/Sequence/Set) is left as-is — those are standard Piquet declaration proper-nouns already used verbatim in the existing `meldPoint/meldSequence/meldSet` keys.

## Test plan
- [x] `bun run test -- --run src/pages/PiquetPage.test.tsx` (10 passed) — added tests for the stats line, the declaration list (tied + fallback scorer), and the trick header
- [x] `bun run check` (biome + design-tokens OK)
- [ ] CI: build (tsc) + E2E + codecov + i18n parity

Closes #2258