### PR TITLE
feat(bristol): overlay a stacked-count badge on multi-card fans

### DIFF
--- a/frontend/src/pages/BristolPage.test.tsx
+++ b/frontend/src/pages/BristolPage.test.tsx
@@ -65,6 +65,18 @@ describe('BristolPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
+  it('shows a stacked-count badge on fans with 2+ cards and hides it otherwise', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      fan: [[card('HEART', 4), card('SPADE', 5), card('CLOVER', 6)], [card('DIAMOND', 9)], []],
+    });
+    renderWithProviders(<BristolPage />);
+    // Fan 0 has 3 cards → badge shows the count.
+    await waitFor(() => expect(screen.getByTestId('br-fan-count-0')).toHaveTextContent('3'));
+    // Fan 1 has a single card → no badge.
+    expect(screen.queryByTestId('br-fan-count-1')).not.toBeInTheDocument();
+  });
+
   it('clicks stock to fire draw command', async () => {
     renderWithProviders(<BristolPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));

--- a/frontend/src/pages/BristolPage.test.tsx
+++ b/frontend/src/pages/BristolPage.test.tsx
@@ -68,13 +68,21 @@ describe('BristolPage', () => {
   it('shows a stacked-count badge on fans with 2+ cards and hides it otherwise', async () => {
     mockExec.mockResolvedValue({
       ...playingState,
-      fan: [[card('HEART', 4), card('SPADE', 5), card('CLOVER', 6)], [card('DIAMOND', 9)], []],
+      fan: [[card('HEART', 4), card('SPADE', 5), card('CLOVER', 6)], [card('DIAMOND', 9), card('SPADE', 2)], []],
     });
     renderWithProviders(<BristolPage />);
     // Fan 0 has 3 cards → badge shows the count.
     await waitFor(() => expect(screen.getByTestId('br-fan-count-0')).toHaveTextContent('3'));
-    // Fan 1 has a single card → no badge.
-    expect(screen.queryByTestId('br-fan-count-1')).not.toBeInTheDocument();
+    // Fan 1 has exactly 2 cards → boundary case, badge shows.
+    expect(screen.getByTestId('br-fan-count-1')).toHaveTextContent('2');
+  });
+
+  it('hides the fan count badge for single-card fans', async () => {
+    mockExec.mockResolvedValue({ ...playingState, fan: [[card('HEART', 4)], [], []] });
+    renderWithProviders(<BristolPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    // Single-card fan → no badge.
+    expect(screen.queryByTestId('br-fan-count-0')).not.toBeInTheDocument();
   });
 
   it('clicks stock to fire draw command', async () => {

--- a/frontend/src/pages/BristolPage.tsx
+++ b/frontend/src/pages/BristolPage.tsx
@@ -289,11 +289,9 @@ function BristolPageContent() {
                           disabled={!isPlaying || loading}
                           aria-label={`${t('fan')} ${i}`}
                           aria-pressed={isSelected(zone)}
-                          className={
-                            isSelected(zone)
-                              ? `relative rounded border-2 bg-transparent p-0 ${focusRingWhite} border-ds-info`
-                              : `relative rounded border-2 bg-transparent p-0 ${focusRingWhite} border-transparent`
-                          }
+                          className={`relative rounded border-2 bg-transparent p-0 ${focusRingWhite} ${
+                            isSelected(zone) ? 'border-ds-info' : 'border-transparent'
+                          }`}
                         >
                           <AnimatedCard card={top} width={cardWidth} draggable={false} />
                           {pile.length >= 2 ? (

--- a/frontend/src/pages/BristolPage.tsx
+++ b/frontend/src/pages/BristolPage.tsx
@@ -291,11 +291,20 @@ function BristolPageContent() {
                           aria-pressed={isSelected(zone)}
                           className={
                             isSelected(zone)
-                              ? `rounded border-2 bg-transparent p-0 ${focusRingWhite} border-ds-info`
-                              : `rounded border-2 bg-transparent p-0 ${focusRingWhite} border-transparent`
+                              ? `relative rounded border-2 bg-transparent p-0 ${focusRingWhite} border-ds-info`
+                              : `relative rounded border-2 bg-transparent p-0 ${focusRingWhite} border-transparent`
                           }
                         >
                           <AnimatedCard card={top} width={cardWidth} draggable={false} />
+                          {pile.length >= 2 ? (
+                            <span
+                              aria-hidden="true"
+                              data-testid={`br-fan-count-${i.toString()}`}
+                              className="absolute bottom-0.5 right-0.5 px-1 rounded bg-ds-accent text-ds-text-on-accent text-[10px] font-bold shadow-sm pointer-events-none"
+                            >
+                              {pile.length}
+                            </span>
+                          ) : null}
                         </button>
                       ) : (
                         <div


### PR DESCRIPTION
## Summary

Implements #2286. In **Bristol**, each of the 3 fans renders only its top card plus a tiny `( n )` text line below, so the hidden depth is easy to miss — especially on mobile where the cards shrink. This overlays a small count badge on the fan's top card.

- Badge appears on the fan top-card button when `pile.length >= 2`; hidden for empty/single-card fans.
- Shows `pile.length`; positioned bottom-right, `pointer-events-none` so it never intercepts clicks.
- Uses the existing accent badge token pattern (`bg-ds-accent` / `text-ds-text-on-accent`) — no raw palette.
- The button gains `relative` so the absolute badge anchors correctly; the existing `( n )` text line is kept.

## Test plan
- [x] `bun run test -- --run src/pages/BristolPage.test.tsx` (16 passed) — added a test asserting the badge shows `3` for a 3-card fan and is absent for a single-card fan
- [x] `bun run check` (biome + design-tokens OK)
- [ ] CI: build (tsc) + E2E + codecov

Closes #2286