### PR TITLE
feat(tressette): show round thirds as a 3-dot progress indicator

### DIFF
--- a/frontend/src/i18n/locales/en/tressette.json
+++ b/frontend/src/i18n/locales/en/tressette.json
@@ -25,6 +25,8 @@
   "scoresTeam": "Team",
   "scoresPoints": "Points",
   "scoresThirds": "This round (1/3)",
+  "thirdsTooltip": "{{n}} more third(s) to score this round",
+  "thirdsAria": "{{filled}} of 3 thirds this round",
   "scoresTricks": "Tricks",
   "playButton": "Play",
   "nextTrick": "Next Trick",

--- a/frontend/src/i18n/locales/en/tressette.json
+++ b/frontend/src/i18n/locales/en/tressette.json
@@ -24,7 +24,7 @@
   "scores": "Scores",
   "scoresTeam": "Team",
   "scoresPoints": "Points",
-  "scoresThirds": "This round (1/3)",
+  "scoresThirds": "This round (thirds)",
   "thirdsTooltip": "{{n}} more third(s) to score this round",
   "thirdsAria": "{{filled}} of 3 thirds this round",
   "scoresTricks": "Tricks",

--- a/frontend/src/i18n/locales/ja/tressette.json
+++ b/frontend/src/i18n/locales/ja/tressette.json
@@ -25,6 +25,8 @@
   "scoresTeam": "チーム",
   "scoresPoints": "得点",
   "scoresThirds": "今ラウンド(1/3点)",
+  "thirdsTooltip": "ラウンド得点まであと{{n}}サーズ",
+  "thirdsAria": "今ラウンド {{filled}}/3 サーズ",
   "scoresTricks": "トリック",
   "playButton": "出す",
   "nextTrick": "次のトリック",

--- a/frontend/src/i18n/locales/ja/tressette.json
+++ b/frontend/src/i18n/locales/ja/tressette.json
@@ -24,7 +24,7 @@
   "scores": "スコア",
   "scoresTeam": "チーム",
   "scoresPoints": "得点",
-  "scoresThirds": "今ラウンド(1/3点)",
+  "scoresThirds": "今ラウンド(サーズ)",
   "thirdsTooltip": "ラウンド得点まであと{{n}}サーズ",
   "thirdsAria": "今ラウンド {{filled}}/3 サーズ",
   "scoresTricks": "トリック",

--- a/frontend/src/pages/TressettePage.test.tsx
+++ b/frontend/src/pages/TressettePage.test.tsx
@@ -104,7 +104,7 @@ describe('TressettePage', () => {
     expect(dots0).toHaveLength(3);
     expect(team0.querySelectorAll('.bg-ds-accent')).toHaveLength(2);
     // Tooltip shows the remaining thirds (3 - 2 = 1) and sr-only text the filled count.
-    expect(team0).toHaveAttribute('title', expect.stringContaining('1'));
+    expect(team0).toHaveAttribute('title', 'ラウンド得点まであと1サーズ');
     expect(team0).toHaveTextContent('2/3');
 
     // Team 1 has 0 thirds → no filled dots.

--- a/frontend/src/pages/TressettePage.test.tsx
+++ b/frontend/src/pages/TressettePage.test.tsx
@@ -93,4 +93,22 @@ describe('TressettePage', () => {
     await waitFor(() => expect(screen.getByAltText('♠ 3')).toBeInTheDocument());
     expect(screen.queryByRole('button', { name: '出す' })).not.toBeInTheDocument();
   });
+
+  it('renders a three-dot thirds indicator with the filled count and remaining tooltip', async () => {
+    mockExec.mockResolvedValue(makeTressetteState({ teamRoundThirds: [2, 0] }));
+    renderWithProviders(<TressettePage />);
+
+    const team0 = await screen.findByTestId('tr-thirds-0');
+    // 3 dots rendered; 2 filled (bg-ds-accent), 1 empty (border).
+    const dots0 = team0.querySelectorAll('span[aria-hidden="true"]');
+    expect(dots0).toHaveLength(3);
+    expect(team0.querySelectorAll('.bg-ds-accent')).toHaveLength(2);
+    // Tooltip shows the remaining thirds (3 - 2 = 1) and sr-only text the filled count.
+    expect(team0).toHaveAttribute('title', expect.stringContaining('1'));
+    expect(team0).toHaveTextContent('2/3');
+
+    // Team 1 has 0 thirds → no filled dots.
+    const team1 = screen.getByTestId('tr-thirds-1');
+    expect(team1.querySelectorAll('.bg-ds-accent')).toHaveLength(0);
+  });
 });

--- a/frontend/src/pages/TressettePage.tsx
+++ b/frontend/src/pages/TressettePage.tsx
@@ -280,7 +280,9 @@ function TressettePageContent() {
                     </thead>
                     <tbody>
                       {teamLabels.map((label, idx) => {
-                        const thirds = state.teamRoundThirds[idx] ?? 0;
+                        // Thirds reset to 0 once they reach 3 (converted to a point),
+                        // but clamp defensively so the 3-dot indicator never overflows.
+                        const filled = Math.min(Math.max(state.teamRoundThirds[idx] ?? 0, 0), 3);
                         return (
                           <tr key={label} className={humanPlayer && humanPlayer.teamId === idx ? 'text-ds-accent' : ''}>
                             <td>{t('teamLabel', { team: label })}</td>
@@ -288,7 +290,7 @@ function TressettePageContent() {
                             <td className="text-center">
                               <span
                                 className="inline-flex gap-0.5 align-middle"
-                                title={t('thirdsTooltip', { n: Math.max(0, 3 - thirds) })}
+                                title={t('thirdsTooltip', { n: 3 - filled })}
                                 data-testid={`tr-thirds-${idx.toString()}`}
                               >
                                 {[0, 1, 2].map((d) => (
@@ -296,11 +298,11 @@ function TressettePageContent() {
                                     key={`tr-dot-${idx.toString()}-${d.toString()}`}
                                     aria-hidden="true"
                                     className={`inline-block w-2 h-2 rounded-full ${
-                                      d < thirds ? 'bg-ds-accent' : 'border border-ds-border-subtle'
+                                      d < filled ? 'bg-ds-accent' : 'border border-ds-border-subtle'
                                     }`}
                                   />
                                 ))}
-                                <span className="sr-only">{t('thirdsAria', { filled: thirds })}</span>
+                                <span className="sr-only">{t('thirdsAria', { filled })}</span>
                               </span>
                             </td>
                           </tr>

--- a/frontend/src/pages/TressettePage.tsx
+++ b/frontend/src/pages/TressettePage.tsx
@@ -80,6 +80,15 @@ const TRESSETTE_PHASE_KEYS: Readonly<Record<number, string>> = {
   [TressettePhase.GAME_END]: 'gameEnd',
 };
 
+/**
+ * Clamps a team's round-thirds count to the [0, 3] range used by the 3-dot
+ * indicator. Thirds reset to 0 once they reach 3 (converted to a point), but
+ * this guards defensively against any out-of-range value.
+ */
+function thirdsFilled(thirds: number): number {
+  return Math.min(Math.max(thirds, 0), 3);
+}
+
 /** Renders the Tressette game page: no-trump must-follow trick play with team scoring. */
 export const TressettePage = withTutorial(TressettePageContent, 'tressette', TR_TUTORIAL_STEPS);
 
@@ -279,35 +288,34 @@ function TressettePageContent() {
                       </tr>
                     </thead>
                     <tbody>
-                      {teamLabels.map((label, idx) => {
-                        // Thirds reset to 0 once they reach 3 (converted to a point),
-                        // but clamp defensively so the 3-dot indicator never overflows.
-                        const filled = Math.min(Math.max(state.teamRoundThirds[idx] ?? 0, 0), 3);
-                        return (
-                          <tr key={label} className={humanPlayer && humanPlayer.teamId === idx ? 'text-ds-accent' : ''}>
-                            <td>{t('teamLabel', { team: label })}</td>
-                            <td className="text-center">{state.teamScores[idx] ?? 0}</td>
-                            <td className="text-center">
-                              <span
-                                className="inline-flex gap-0.5 align-middle"
-                                title={t('thirdsTooltip', { n: 3 - filled })}
-                                data-testid={`tr-thirds-${idx.toString()}`}
-                              >
-                                {[0, 1, 2].map((d) => (
-                                  <span
-                                    key={`tr-dot-${idx.toString()}-${d.toString()}`}
-                                    aria-hidden="true"
-                                    className={`inline-block w-2 h-2 rounded-full ${
-                                      d < filled ? 'bg-ds-accent' : 'border border-ds-border-subtle'
-                                    }`}
-                                  />
-                                ))}
-                                <span className="sr-only">{t('thirdsAria', { filled })}</span>
+                      {teamLabels.map((label, idx) => (
+                        <tr key={label} className={humanPlayer && humanPlayer.teamId === idx ? 'text-ds-accent' : ''}>
+                          <td>{t('teamLabel', { team: label })}</td>
+                          <td className="text-center">{state.teamScores[idx] ?? 0}</td>
+                          <td className="text-center">
+                            <span
+                              className="inline-flex gap-0.5 align-middle"
+                              title={t('thirdsTooltip', { n: 3 - thirdsFilled(state.teamRoundThirds[idx]) })}
+                              data-testid={`tr-thirds-${idx.toString()}`}
+                            >
+                              {[0, 1, 2].map((d) => (
+                                <span
+                                  key={`tr-dot-${idx.toString()}-${d.toString()}`}
+                                  aria-hidden="true"
+                                  className={`inline-block w-2 h-2 rounded-full ${
+                                    d < thirdsFilled(state.teamRoundThirds[idx])
+                                      ? 'bg-ds-accent'
+                                      : 'border border-ds-border-subtle'
+                                  }`}
+                                />
+                              ))}
+                              <span className="sr-only">
+                                {t('thirdsAria', { filled: thirdsFilled(state.teamRoundThirds[idx]) })}
                               </span>
-                            </td>
-                          </tr>
-                        );
-                      })}
+                            </span>
+                          </td>
+                        </tr>
+                      ))}
                     </tbody>
                   </table>
                 </div>

--- a/frontend/src/pages/TressettePage.tsx
+++ b/frontend/src/pages/TressettePage.tsx
@@ -279,13 +279,33 @@ function TressettePageContent() {
                       </tr>
                     </thead>
                     <tbody>
-                      {teamLabels.map((label, idx) => (
-                        <tr key={label} className={humanPlayer && humanPlayer.teamId === idx ? 'text-ds-accent' : ''}>
-                          <td>{t('teamLabel', { team: label })}</td>
-                          <td className="text-center">{state.teamScores[idx] ?? 0}</td>
-                          <td className="text-center">{state.teamRoundThirds[idx] ?? 0}/3</td>
-                        </tr>
-                      ))}
+                      {teamLabels.map((label, idx) => {
+                        const thirds = state.teamRoundThirds[idx] ?? 0;
+                        return (
+                          <tr key={label} className={humanPlayer && humanPlayer.teamId === idx ? 'text-ds-accent' : ''}>
+                            <td>{t('teamLabel', { team: label })}</td>
+                            <td className="text-center">{state.teamScores[idx] ?? 0}</td>
+                            <td className="text-center">
+                              <span
+                                className="inline-flex gap-0.5 align-middle"
+                                title={t('thirdsTooltip', { n: Math.max(0, 3 - thirds) })}
+                                data-testid={`tr-thirds-${idx.toString()}`}
+                              >
+                                {[0, 1, 2].map((d) => (
+                                  <span
+                                    key={`tr-dot-${idx.toString()}-${d.toString()}`}
+                                    aria-hidden="true"
+                                    className={`inline-block w-2 h-2 rounded-full ${
+                                      d < thirds ? 'bg-ds-accent' : 'border border-ds-border-subtle'
+                                    }`}
+                                  />
+                                ))}
+                                <span className="sr-only">{t('thirdsAria', { filled: thirds })}</span>
+                              </span>
+                            </td>
+                          </tr>
+                        );
+                      })}
                     </tbody>
                   </table>
                 </div>


### PR DESCRIPTION
## Summary

Implements #2288. Tressette scores in thirds (`サーズ`), and the score table showed round progress only as a bare `n/3` number — fine for reading a value, but no at-a-glance sense of "how close is this team to scoring the round." This renders the round-thirds cell as a 3-dot indicator.

- Three small dots per team; `teamRoundThirds[idx]` of them filled (`bg-ds-accent`), the rest outlined (`border-ds-border-subtle`).
- Hover `title` tooltip shows the remaining thirds (`3 − thirds`).
- An `sr-only` span keeps the `filled/3` count available to assistive tech (the dots themselves are `aria-hidden`).
- New i18n keys `thirdsTooltip` / `thirdsAria` in both locales (parity preserved).

## Test plan
- [x] `bun run test -- --run src/pages/TressettePage.test.tsx` (9 passed) — added a test asserting 3 dots, the filled count (2 for `teamRoundThirds:[2,0]`), the remaining-thirds tooltip, and the sr-only `2/3` text
- [x] `bun run check` (biome + design-tokens OK)
- [ ] CI: build (tsc) + E2E + codecov + i18n parity

Closes #2288