### PR TITLE
feat(blackjackswitch): touch + always-on post-switch score preview

### DIFF
--- a/frontend/src/i18n/locales/en/blackjackswitch.json
+++ b/frontend/src/i18n/locales/en/blackjackswitch.json
@@ -5,7 +5,8 @@
     "dealer": "Dealer",
     "hand": "Hand",
     "switched": "switched",
-    "currentHand": "current hand"
+    "currentHand": "current hand",
+    "alwaysPreview": "Always show post-switch scores"
   },
   "phase": {
     "bet": "bet",

--- a/frontend/src/i18n/locales/ja/blackjackswitch.json
+++ b/frontend/src/i18n/locales/ja/blackjackswitch.json
@@ -5,7 +5,8 @@
     "dealer": "ディーラー",
     "hand": "ハンド",
     "switched": "スイッチ実行済み",
-    "currentHand": "現在のハンド"
+    "currentHand": "現在のハンド",
+    "alwaysPreview": "スイッチ後のスコアを常に表示"
   },
   "phase": {
     "bet": "ベット",

--- a/frontend/src/pages/BlackJackSwitchPage.test.tsx
+++ b/frontend/src/pages/BlackJackSwitchPage.test.tsx
@@ -197,7 +197,18 @@ describe('BlackJackSwitchPage', () => {
     expect(screen.queryByTestId('hand-0-preview')).not.toBeInTheDocument();
     fireEvent.touchStart(btn);
     expect(screen.getByTestId('hand-0-preview')).toHaveTextContent('20');
+    expect(screen.getByTestId('hand-1-preview')).toHaveTextContent('11');
     fireEvent.touchEnd(btn);
+    expect(screen.queryByTestId('hand-0-preview')).not.toBeInTheDocument();
+  });
+
+  it('clears the preview when a touch is cancelled by the OS', async () => {
+    mockApi.mockResolvedValue(switchState);
+    renderWithProviders(<BlackJackSwitchPage />);
+    const btn = await screen.findByTestId('switch-button');
+    fireEvent.touchStart(btn);
+    expect(screen.getByTestId('hand-0-preview')).toBeInTheDocument();
+    fireEvent.touchCancel(btn);
     expect(screen.queryByTestId('hand-0-preview')).not.toBeInTheDocument();
   });
 
@@ -206,9 +217,12 @@ describe('BlackJackSwitchPage', () => {
     renderWithProviders(<BlackJackSwitchPage />);
     await screen.findByTestId('switch-button');
     expect(screen.queryByTestId('hand-0-preview')).not.toBeInTheDocument();
+    // Open the collapsed settings <details> first, as a real user would.
+    fireEvent.click(screen.getByText('設定'));
     fireEvent.click(screen.getByLabelText(/常に表示|Always show/));
     // Visible without any hover/focus.
     expect(screen.getByTestId('hand-0-preview')).toHaveTextContent('20');
+    expect(screen.getByTestId('hand-1-preview')).toHaveTextContent('11');
   });
 
   it('focusing Switch shows the preview for keyboard parity', async () => {

--- a/frontend/src/pages/BlackJackSwitchPage.test.tsx
+++ b/frontend/src/pages/BlackJackSwitchPage.test.tsx
@@ -190,6 +190,27 @@ describe('BlackJackSwitchPage', () => {
     expect(screen.queryByTestId('hand-0-preview')).not.toBeInTheDocument();
   });
 
+  it('touching Switch shows then hides the preview for touch devices', async () => {
+    mockApi.mockResolvedValue(switchState);
+    renderWithProviders(<BlackJackSwitchPage />);
+    const btn = await screen.findByTestId('switch-button');
+    expect(screen.queryByTestId('hand-0-preview')).not.toBeInTheDocument();
+    fireEvent.touchStart(btn);
+    expect(screen.getByTestId('hand-0-preview')).toHaveTextContent('20');
+    fireEvent.touchEnd(btn);
+    expect(screen.queryByTestId('hand-0-preview')).not.toBeInTheDocument();
+  });
+
+  it('keeps the preview visible without hover when "always preview" is enabled', async () => {
+    mockApi.mockResolvedValue(switchState);
+    renderWithProviders(<BlackJackSwitchPage />);
+    await screen.findByTestId('switch-button');
+    expect(screen.queryByTestId('hand-0-preview')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText(/常に表示|Always show/));
+    // Visible without any hover/focus.
+    expect(screen.getByTestId('hand-0-preview')).toHaveTextContent('20');
+  });
+
   it('focusing Switch shows the preview for keyboard parity', async () => {
     mockApi.mockResolvedValue(switchState);
     renderWithProviders(<BlackJackSwitchPage />);

--- a/frontend/src/pages/BlackJackSwitchPage.tsx
+++ b/frontend/src/pages/BlackJackSwitchPage.tsx
@@ -277,6 +277,7 @@ function BlackJackSwitchPageContent() {
                   onBlur={() => setSwitchPreview(false)}
                   onTouchStart={() => setSwitchPreview(true)}
                   onTouchEnd={() => setSwitchPreview(false)}
+                  onTouchCancel={() => setSwitchPreview(false)}
                   data-testid="switch-button"
                   disabled={loading}
                 >

--- a/frontend/src/pages/BlackJackSwitchPage.tsx
+++ b/frontend/src/pages/BlackJackSwitchPage.tsx
@@ -53,6 +53,7 @@ function BlackJackSwitchPageContent() {
 
   const [betAmount, setBetAmount] = useState(100);
   const [switchPreview, setSwitchPreview] = useState(false);
+  const [alwaysPreview, setAlwaysPreview] = useState(false);
   const { cardWidth } = useCardDimensions();
   const { playSound } = useSound();
   const { state, loading, error, exec: execApi, retry } = useGameApi(blackjackswitchApi.exec);
@@ -104,7 +105,7 @@ function BlackJackSwitchPageContent() {
   const canDoubleDown = isActionPhase && currentHand && currentHand.cards.length === 2;
 
   const previewScores =
-    isSwitchPhase && switchPreview && state.hands.length >= 2
+    isSwitchPhase && (switchPreview || alwaysPreview) && state.hands.length >= 2
       ? blackjackSwitchPreviewScores(state.hands[0].cards, state.hands[1].cards)
       : null;
 
@@ -234,7 +235,22 @@ function BlackJackSwitchPageContent() {
 
           <GameFooter className={`${gameTheme.blackjackswitch.footer} px-4 pt-3`}>
             <ErrorAlert message={error} onRetry={retry} />
-            <SettingsPanel title={tc('settings.title')} groups={[]} />
+            <SettingsPanel
+              title={tc('settings.title')}
+              groups={[
+                {
+                  items: [
+                    {
+                      type: 'checkbox' as const,
+                      id: 'blackjackswitch-always-preview',
+                      label: t('label.alwaysPreview'),
+                      checked: alwaysPreview,
+                      onToggle: setAlwaysPreview,
+                    },
+                  ],
+                },
+              ]}
+            />
             {isBetPhase && (
               <div className="flex flex-col items-center gap-2 pb-2">
                 <ChipBetInput
@@ -259,6 +275,8 @@ function BlackJackSwitchPageContent() {
                   onMouseLeave={() => setSwitchPreview(false)}
                   onFocus={() => setSwitchPreview(true)}
                   onBlur={() => setSwitchPreview(false)}
+                  onTouchStart={() => setSwitchPreview(true)}
+                  onTouchEnd={() => setSwitchPreview(false)}
                   data-testid="switch-button"
                   disabled={loading}
                 >


### PR DESCRIPTION
## Summary

Implements #2247. In Blackjack Switch's SWITCH phase, the post-swap score preview (the `→ {score}` badges on each hand) was driven only by `onMouseEnter`/`onMouseLeave`/focus — so on touch devices, where hover events never fire, players couldn't preview the outcome before committing to the swap.

- Added `onTouchStart` (preview on) / `onTouchEnd` (preview off) to the Switch button.
- Added an **"always show post-switch scores"** checkbox to the Settings panel (the panel previously had empty groups); when on, the preview stays visible without any hover/focus.
- New `label.alwaysPreview` i18n key in both locales (parity preserved).

## Test plan
- [x] `bun run test -- --run src/pages/BlackJackSwitchPage.test.tsx` (21 passed) — added a touchStart/touchEnd preview test and an always-preview toggle test
- [x] `bun run check` (biome + design-tokens OK)
- [ ] CI: build (tsc) + E2E + codecov + i18n parity

Closes #2247