### PR TITLE
feat(tichu): migrate hint toggle + CPU difficulty into SettingsPanel

### DIFF
--- a/frontend/src/i18n/locales/en/tichu.json
+++ b/frontend/src/i18n/locales/en/tichu.json
@@ -1,5 +1,8 @@
 {
   "title": "Tichu",
+  "settings": {
+    "cpuDifficulty": "CPU difficulty"
+  },
   "label": {
     "table": "Table",
     "bombs": "Bombs",

--- a/frontend/src/i18n/locales/ja/tichu.json
+++ b/frontend/src/i18n/locales/ja/tichu.json
@@ -1,5 +1,8 @@
 {
   "title": "ティチュー",
+  "settings": {
+    "cpuDifficulty": "CPUの難易度"
+  },
   "label": {
     "table": "場",
     "bombs": "爆弾",

--- a/frontend/src/pages/TichuPage.test.tsx
+++ b/frontend/src/pages/TichuPage.test.tsx
@@ -72,6 +72,28 @@ describe('TichuPage', () => {
     });
   });
 
+  it('changing CPU difficulty in settings resets with the new config', async () => {
+    renderWithProviders(<TichuPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith(expect.objectContaining({ command: 'reset' })));
+    fireEvent.click(screen.getByText('設定')); // open the collapsed settings panel
+    fireEvent.change(screen.getByLabelText('CPUの難易度'), { target: { value: '2' } });
+    await waitFor(() =>
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'reset', config: { cpuDifficulty: 2 } }),
+      ),
+    );
+  });
+
+  it('toggles the hint setting from the settings panel', async () => {
+    renderWithProviders(<TichuPage />);
+    await screen.findByText('設定');
+    fireEvent.click(screen.getByText('設定'));
+    const hintToggle = screen.getByLabelText('ヒント表示');
+    expect(hintToggle).not.toBeChecked();
+    fireEvent.click(hintToggle);
+    expect(hintToggle).toBeChecked();
+  });
+
   it('renders CPU player areas and declaration labels after load', async () => {
     mockExec.mockResolvedValue(
       makeState({

--- a/frontend/src/pages/TichuPage.tsx
+++ b/frontend/src/pages/TichuPage.tsx
@@ -3,6 +3,7 @@ import { tichuApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
@@ -38,6 +39,13 @@ const TUTORIAL_STEPS: TutorialStep[] = [
   { target: '[data-tutorial="tichu-declare"]', messageKey: 'tutorial.declare', placement: 'bottom', advanceOn: 'next' },
   { target: '[data-tutorial="tichu-table"]', messageKey: 'tutorial.play', placement: 'bottom', advanceOn: 'next' },
   { target: '[data-tutorial="tichu-cpus"]', messageKey: 'tutorial.teams', placement: 'bottom', advanceOn: 'next' },
+];
+
+// Values match the Go domain constants (TichuConfig.go): 0=Normal, 1=Easy, 2=Hard.
+const DIFFICULTY_OPTIONS = [
+  { value: '0', label: 'Normal' },
+  { value: '1', label: 'Easy' },
+  { value: '2', label: 'Hard' },
 ];
 
 function parseTichuCommand(input: string): CliParseResult<[ApiArgs]> {
@@ -120,10 +128,11 @@ function TichuPageContent() {
   const { playSound } = useSound();
 
   const [selectedCards, setSelectedCards] = useState<Set<number>>(new Set());
+  const [cpuDifficulty, setCpuDifficulty] = useState(0);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only reset
   useEffect(() => {
-    void apiCall({ command: 'reset' });
+    void apiCall({ command: 'reset', config: { cpuDifficulty } });
   }, []);
 
   const phase = state?.phase ?? '';
@@ -156,7 +165,18 @@ function TichuPageContent() {
     setSelectedCards(new Set());
   }, [apiCall]);
 
-  const handleReset = useCallback(() => apiCall({ command: 'reset' }), [apiCall]);
+  const handleReset = useCallback(
+    () => apiCall({ command: 'reset', config: { cpuDifficulty } }),
+    [apiCall, cpuDifficulty],
+  );
+
+  const handleDifficultyChange = useCallback(
+    (value: number) => {
+      setCpuDifficulty(value);
+      void apiCall({ command: 'reset', config: { cpuDifficulty: value } });
+    },
+    [apiCall],
+  );
 
   const toggleCard = useCallback((idx: number) => {
     setSelectedCards((prev) => {
@@ -328,6 +348,30 @@ function TichuPageContent() {
           />
         </div>
       )}
+      <SettingsPanel
+        title={tc('settings.title')}
+        groups={[
+          {
+            items: [
+              {
+                type: 'select' as const,
+                id: 'cpuDifficulty',
+                label: t('settings.cpuDifficulty'),
+                value: String(cpuDifficulty),
+                options: DIFFICULTY_OPTIONS,
+                onSelect: (v: string) => handleDifficultyChange(Number.parseInt(v, 10)),
+              },
+              {
+                type: 'checkbox' as const,
+                id: 'frontendHint',
+                label: tc('hint.toggle', { ns: 'tutorial' }),
+                checked: hintEnabled,
+                onToggle: setHintEnabled,
+              },
+            ],
+          },
+        ]}
+      />
       <GameFooter className={gameTheme.tichu.footer}>
         <GameResetButton
           isGameEnd={isGameEnd}
@@ -336,10 +380,6 @@ function TichuPageContent() {
           loading={loading}
           dataTutorial="tichu-reset"
         />
-        <label className="flex items-center gap-1 text-ds-text-primary text-xs">
-          <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
-          {tc('hint')}
-        </label>
       </GameFooter>
     </GamePageShell>
   );


### PR DESCRIPTION
## Summary

Implements #2290. Tichu's `TichuPage.tsx` used a hand-rolled `<label><input type='checkbox'>` in the footer for the hint toggle — diverging from the standard `SettingsPanel` pattern used by 100+ other games — and CPU difficulty could only be set via the `sd [0-2]` CLI command, never from the GUI.

- Replaced the footer checkbox with the standard `SettingsPanel`.
- Added a **CPU difficulty** select (0=Normal / 1=Easy / 2=Hard, matching `TichuConfig.go`), held in React state so it persists across game resets; changing it resets with the new `config.cpuDifficulty`.
- Routed the existing hint toggle (already `useGameHint`-backed) through the panel.
- Mount reset and the reset button now send `config: { cpuDifficulty }`.
- New `settings.cpuDifficulty` i18n key in both locales (parity preserved); reuses the shared `settings.title` / `hint.toggle` keys.

## Test plan
- [x] `bun run test -- --run src/pages/TichuPage.test.tsx` (10 passed) — added tests for the difficulty select dispatching a reset with the new config and for the hint toggle in the panel
- [x] `bun run check` (biome + design-tokens OK)
- [ ] CI: build (tsc) + E2E + codecov + i18n parity

Closes #2290