### PR TITLE
feat(gongzhu): highlight exposable cards in the expose phase

### DIFF
--- a/frontend/src/components/MobileHandGrid.tsx
+++ b/frontend/src/components/MobileHandGrid.tsx
@@ -96,7 +96,7 @@ export function MobileHandGrid({
               const ml = i === 0 ? 0 : isExpanded ? expansionMargin(true, overlap) : overlap;
               const restricted = isRestricted(globalIdx);
               const highlighted = isHighlighted(globalIdx);
-              const dimmed = highlightIndices != null && !highlighted && !isSelected;
+              const dimmed = highlightIndices != null && !highlighted && !isSelected && !restricted;
               return (
                 <button
                   type="button"
@@ -121,7 +121,7 @@ export function MobileHandGrid({
                     ...(isSelected
                       ? selectedCardStyle(true)
                       : highlighted
-                        ? highlightCardStyle(true)
+                        ? highlightCardStyle()
                         : selectedCardStyle(false)),
                     transition: 'transform 0.15s, border 0.15s, box-shadow 0.15s, margin-left 0.15s',
                     boxSizing: 'border-box',

--- a/frontend/src/components/MobileHandGrid.tsx
+++ b/frontend/src/components/MobileHandGrid.tsx
@@ -1,6 +1,6 @@
 import { useWindowWidth } from '../hooks/useCardDimensions';
 import { useReducedMotion } from '../hooks/useReducedMotion';
-import { expansionMargin, focusRingCard, selectedCardStyle } from '../styles/cardStyles';
+import { expansionMargin, focusRingCard, highlightCardStyle, selectedCardStyle } from '../styles/cardStyles';
 import type { Card } from '../types/card';
 import { cardAlt } from '../utils/cardAlt';
 import { CardImage } from './CardImage';
@@ -42,6 +42,11 @@ interface MobileHandGridProps {
   restrictedTooltip?: string;
   /** Optional badge to render in the top-left corner of a card (e.g. game-specific role marker). */
   cardBadgeFor?: (idx: number) => { glyph: string; title: string } | null;
+  /**
+   * Optional indices to highlight as actionable (e.g. exposable cards). Highlighted
+   * cards get a warning border; the rest are dimmed when this list is provided.
+   */
+  highlightIndices?: number[];
 }
 
 /**
@@ -58,11 +63,13 @@ export function MobileHandGrid({
   validIndices,
   restrictedTooltip,
   cardBadgeFor,
+  highlightIndices,
 }: MobileHandGridProps) {
   const viewportWidth = useWindowWidth();
   const reduced = useReducedMotion();
   const buttonWidth = cardWidth + BUTTON_EXTRA;
   const isRestricted = (idx: number): boolean => validIndices != null && !validIndices.includes(idx);
+  const isHighlighted = (idx: number): boolean => highlightIndices?.includes(idx) ?? false;
 
   const useTwoRows = cards.length >= TWO_ROW_THRESHOLD;
   const splitAt = useTwoRows ? Math.ceil(cards.length / 2) : cards.length;
@@ -88,6 +95,8 @@ export function MobileHandGrid({
                 selectedIndices.includes(globalIdx) || (i > 0 && selectedIndices.includes(globalIdx - 1));
               const ml = i === 0 ? 0 : isExpanded ? expansionMargin(true, overlap) : overlap;
               const restricted = isRestricted(globalIdx);
+              const highlighted = isHighlighted(globalIdx);
+              const dimmed = highlightIndices != null && !highlighted && !isSelected;
               return (
                 <button
                   type="button"
@@ -102,13 +111,18 @@ export function MobileHandGrid({
                   // need to reach the tooltip that explains why the card is illegal.
                   aria-disabled={restricted || undefined}
                   title={restricted ? restrictedTooltip : undefined}
-                  className={`${focusRingCard} ${restricted ? 'opacity-50 cursor-not-allowed' : ''}`}
+                  className={`${focusRingCard} ${restricted ? 'opacity-50 cursor-not-allowed' : ''} ${dimmed ? 'opacity-60' : ''}`}
                   style={{
                     background: 'none',
                     padding: 0,
                     borderRadius: 8,
                     position: 'relative',
-                    ...selectedCardStyle(isSelected),
+                    // Selection takes visual priority; otherwise show the highlight border.
+                    ...(isSelected
+                      ? selectedCardStyle(true)
+                      : highlighted
+                        ? highlightCardStyle(true)
+                        : selectedCardStyle(false)),
                     transition: 'transform 0.15s, border 0.15s, box-shadow 0.15s, margin-left 0.15s',
                     boxSizing: 'border-box',
                     marginLeft: ml,

--- a/frontend/src/components/PlayerHandSection.test.tsx
+++ b/frontend/src/components/PlayerHandSection.test.tsx
@@ -126,3 +126,37 @@ describe('PlayerHandSection (validIndices)', () => {
     for (const btn of buttons) expect(btn).not.toHaveAttribute('aria-disabled');
   });
 });
+
+describe('PlayerHandSection (highlightIndices)', () => {
+  // JSDOM drops the CSS var from the `border` shorthand, so assert on the
+  // parseable boxShadow glow, which is distinct per state:
+  //   highlight = rgba(232, 146, 58, …) (warning), selection = rgba(59, 130, 246, …) (blue).
+  it('gives highlighted cards a warning glow and dims the rest on desktop', () => {
+    render(<PlayerHandSection {...baseProps} isMobile={false} highlightIndices={[1, 3]} />);
+    const buttons = screen.getAllByRole('button');
+    expect(buttons[1].style.boxShadow).toContain('rgba(232, 146, 58');
+    expect(buttons[3].style.boxShadow).toContain('rgba(232, 146, 58');
+    expect(buttons[0]).toHaveClass('opacity-60');
+    expect(buttons[1]).not.toHaveClass('opacity-60');
+  });
+
+  it('keeps the selection glow on a card that is both selected and highlighted', () => {
+    render(<PlayerHandSection {...baseProps} isMobile={false} highlightIndices={[0]} selectedCardIndices={[0]} />);
+    const buttons = screen.getAllByRole('button');
+    // Selection wins over highlight, and a selected card is never dimmed.
+    expect(buttons[0].style.boxShadow).toContain('rgba(59, 130, 246');
+    expect(buttons[0]).not.toHaveClass('opacity-60');
+  });
+
+  it('highlights and dims on mobile too', () => {
+    render(<PlayerHandSection {...baseProps} isMobile={true} highlightIndices={[2]} />);
+    const buttons = screen.getAllByRole('button');
+    expect(buttons[2].style.boxShadow).toContain('rgba(232, 146, 58');
+    expect(buttons[0]).toHaveClass('opacity-60');
+  });
+
+  it('applies no highlight or dimming when highlightIndices is undefined', () => {
+    render(<PlayerHandSection {...baseProps} isMobile={false} />);
+    for (const btn of screen.getAllByRole('button')) expect(btn).not.toHaveClass('opacity-60');
+  });
+});

--- a/frontend/src/components/PlayerHandSection.tsx
+++ b/frontend/src/components/PlayerHandSection.tsx
@@ -82,7 +82,8 @@ export function PlayerHandSection({
         const restricted = isRestricted(idx);
         const highlighted = isHighlighted(idx);
         // When a highlight list is active, dim the non-highlighted (and unselected) cards.
-        const dimmed = highlightIndices != null && !highlighted && !isSelected;
+        // Skip already-restricted cards so the two opacity classes never collide.
+        const dimmed = highlightIndices != null && !highlighted && !isSelected && !restricted;
         return (
           <button
             type="button"
@@ -103,11 +104,7 @@ export function PlayerHandSection({
               padding: 0,
               borderRadius: 8,
               // Selection takes visual priority; otherwise show the highlight border.
-              ...(isSelected
-                ? selectedCardStyle(true)
-                : highlighted
-                  ? highlightCardStyle(true)
-                  : selectedCardStyle(false)),
+              ...(isSelected ? selectedCardStyle(true) : highlighted ? highlightCardStyle() : selectedCardStyle(false)),
               boxSizing: 'border-box',
             }}
           >

--- a/frontend/src/components/PlayerHandSection.tsx
+++ b/frontend/src/components/PlayerHandSection.tsx
@@ -1,4 +1,4 @@
-import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
+import { focusRingCard, highlightCardStyle, selectedCardStyle } from '../styles/cardStyles';
 import type { Card } from '../types/card';
 import { cardAlt } from '../utils/cardAlt';
 import { MobileHandGrid } from './MobileHandGrid';
@@ -32,6 +32,12 @@ export interface PlayerHandSectionProps {
   validIndices?: number[];
   /** Tooltip surfaced on cards that are present but disabled by `validIndices`. */
   restrictedTooltip?: string;
+  /**
+   * Optional indices to visually highlight as actionable (e.g. exposable cards).
+   * Highlighted cards get a warning border; when this list is provided, the
+   * remaining (non-highlighted, non-selected) cards are dimmed to draw the eye.
+   */
+  highlightIndices?: number[];
 }
 
 /**
@@ -48,9 +54,11 @@ export function PlayerHandSection({
   dataTutorialPrefix,
   validIndices,
   restrictedTooltip,
+  highlightIndices,
 }: PlayerHandSectionProps) {
   const dataTutorial = `${dataTutorialPrefix}-player-hand`;
   const isRestricted = (idx: number): boolean => validIndices != null && !validIndices.includes(idx);
+  const isHighlighted = (idx: number): boolean => highlightIndices?.includes(idx) ?? false;
 
   if (isMobile) {
     return (
@@ -62,6 +70,7 @@ export function PlayerHandSection({
         dataTutorial={dataTutorial}
         validIndices={validIndices}
         restrictedTooltip={restrictedTooltip}
+        highlightIndices={highlightIndices}
       />
     );
   }
@@ -71,6 +80,9 @@ export function PlayerHandSection({
       {humanPlayer.cards.map((card, idx) => {
         const isSelected = selectedCardIndices.includes(idx);
         const restricted = isRestricted(idx);
+        const highlighted = isHighlighted(idx);
+        // When a highlight list is active, dim the non-highlighted (and unselected) cards.
+        const dimmed = highlightIndices != null && !highlighted && !isSelected;
         return (
           <button
             type="button"
@@ -85,12 +97,17 @@ export function PlayerHandSection({
             // need to reach the tooltip that explains why the card is illegal.
             aria-disabled={restricted || undefined}
             title={restricted ? restrictedTooltip : undefined}
-            className={`transition-transform ${focusRingCard} ${restricted ? 'opacity-50 cursor-not-allowed' : ''}`}
+            className={`transition-transform ${focusRingCard} ${restricted ? 'opacity-50 cursor-not-allowed' : ''} ${dimmed ? 'opacity-60' : ''}`}
             style={{
               background: 'none',
               padding: 0,
               borderRadius: 8,
-              ...selectedCardStyle(isSelected),
+              // Selection takes visual priority; otherwise show the highlight border.
+              ...(isSelected
+                ? selectedCardStyle(true)
+                : highlighted
+                  ? highlightCardStyle(true)
+                  : selectedCardStyle(false)),
               boxSizing: 'border-box',
             }}
           >

--- a/frontend/src/pages/GongZhuPage.test.tsx
+++ b/frontend/src/pages/GongZhuPage.test.tsx
@@ -76,6 +76,17 @@ describe('GongZhuPage', () => {
     expect(cards[1]).toHaveClass('opacity-60');
   });
 
+  it('does not dim any card when there are no exposable cards', async () => {
+    mockExec.mockResolvedValue(makeGongZhuState({ phase: 0, trickNumber: 0, exposableIndices: [] }));
+    const { container } = renderWithProviders(<GongZhuPage />);
+    const hand = await waitFor(() => {
+      const el = container.querySelector('[data-tutorial="gz-player-hand"]');
+      if (!el) throw new Error('hand not rendered yet');
+      return el as HTMLElement;
+    });
+    for (const card of hand.querySelectorAll('button')) expect(card).not.toHaveClass('opacity-60');
+  });
+
   it('expose button dispatches expose with empty selection', async () => {
     mockExec.mockResolvedValue(exposePhaseState);
     renderWithProviders(<GongZhuPage />);

--- a/frontend/src/pages/GongZhuPage.test.tsx
+++ b/frontend/src/pages/GongZhuPage.test.tsx
@@ -60,6 +60,22 @@ describe('GongZhuPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: '公開しない' })).toBeInTheDocument());
   });
 
+  it('highlights the exposable cards during the expose phase', async () => {
+    // Human hand has 2 cards; only index 0 is exposable so index 1 is the dimmed one.
+    mockExec.mockResolvedValue(makeGongZhuState({ phase: 0, trickNumber: 0, exposableIndices: [0] }));
+    const { container } = renderWithProviders(<GongZhuPage />);
+    const hand = await waitFor(() => {
+      const el = container.querySelector('[data-tutorial="gz-player-hand"]');
+      if (!el) throw new Error('hand not rendered yet');
+      return el as HTMLElement;
+    });
+    const cards = hand.querySelectorAll('button');
+    // The exposable card (idx 0) carries the warning glow.
+    expect((cards[0] as HTMLElement).style.boxShadow).toContain('rgba(232, 146, 58');
+    // The non-exposable card (idx 1) is dimmed.
+    expect(cards[1]).toHaveClass('opacity-60');
+  });
+
   it('expose button dispatches expose with empty selection', async () => {
     mockExec.mockResolvedValue(exposePhaseState);
     renderWithProviders(<GongZhuPage />);

--- a/frontend/src/pages/GongZhuPage.tsx
+++ b/frontend/src/pages/GongZhuPage.tsx
@@ -405,6 +405,7 @@ function GongZhuPageContent() {
                 cardWidth={cardWidth}
                 isMobile={isMobile}
                 dataTutorialPrefix="gz"
+                highlightIndices={isExposePhase ? state.exposableIndices : undefined}
               />
             )}
 

--- a/frontend/src/pages/GongZhuPage.tsx
+++ b/frontend/src/pages/GongZhuPage.tsx
@@ -405,7 +405,9 @@ function GongZhuPageContent() {
                 cardWidth={cardWidth}
                 isMobile={isMobile}
                 dataTutorialPrefix="gz"
-                highlightIndices={isExposePhase ? state.exposableIndices : undefined}
+                highlightIndices={
+                  isExposePhase && state.exposableIndices.length > 0 ? state.exposableIndices : undefined
+                }
               />
             )}
 

--- a/frontend/src/styles/cardStyles.ts
+++ b/frontend/src/styles/cardStyles.ts
@@ -42,10 +42,10 @@ export function playableCardStyle(isPlayable: boolean): React.CSSProperties {
  * `ring`) because the selection styles set `boxShadow` inline, which would
  * otherwise override a class-based ring.
  */
-export function highlightCardStyle(isHighlighted: boolean): React.CSSProperties {
+export function highlightCardStyle(): React.CSSProperties {
   return {
-    border: isHighlighted ? '3px solid var(--color-ds-warning)' : '3px solid transparent',
-    boxShadow: isHighlighted ? '0 0 8px rgba(232, 146, 58, 0.45)' : 'none',
+    border: '3px solid var(--color-ds-warning)',
+    boxShadow: '0 0 8px rgba(232, 146, 58, 0.45)',
     transition: 'border 0.15s, box-shadow 0.15s',
   };
 }

--- a/frontend/src/styles/cardStyles.ts
+++ b/frontend/src/styles/cardStyles.ts
@@ -36,6 +36,21 @@ export function playableCardStyle(isPlayable: boolean): React.CSSProperties {
 }
 
 /**
+ * Return inline styles for a card highlighted as an actionable option (e.g. an
+ * exposable card in Gong Zhu). Uses the warning accent so it reads distinctly
+ * from the blue selection border. Applied via inline style (not a Tailwind
+ * `ring`) because the selection styles set `boxShadow` inline, which would
+ * otherwise override a class-based ring.
+ */
+export function highlightCardStyle(isHighlighted: boolean): React.CSSProperties {
+  return {
+    border: isHighlighted ? '3px solid var(--color-ds-warning)' : '3px solid transparent',
+    boxShadow: isHighlighted ? '0 0 8px rgba(232, 146, 58, 0.45)' : 'none',
+    transition: 'border 0.15s, box-shadow 0.15s',
+  };
+}
+
+/**
  * Return adjusted overlap margin for a card that is adjacent to a selected card on mobile.
  * Reduces the negative overlap by EXPANSION_GAP_PX, effectively widening the visible area.
  * Returns the original overlap when the card is not adjacent to a selection.


### PR DESCRIPTION
## Summary

Implements #2285. In Gong Zhu's expose phase, `state.exposableIndices` held which cards could be revealed, but the hand showed no visual cue — players had to read an index-list hint (`indices: [0], [2]…`) to know what was exposable.

- Added an optional `highlightIndices?: number[]` prop to the shared `PlayerHandSection` (and the underlying `MobileHandGrid`). Highlighted cards get a warning border + glow (new `highlightCardStyle` in `cardStyles`); when the prop is set, the remaining non-selected cards dim to `opacity-60`.
- Highlight is applied via inline style (not a Tailwind `ring`) because the selection styles set `boxShadow` inline, which would override a class ring. Selection always wins visually and a selected card is never dimmed.
- `GongZhuPage` passes `highlightIndices={isExposePhase ? state.exposableIndices : undefined}`. The prop is fully backward-compatible — every other game omits it and renders unchanged.

## Test plan
- [x] `bun run test -- --run src/components/PlayerHandSection.test.tsx` (16 passed) — desktop + mobile highlight/dim, selection-priority, undefined no-op
- [x] `bun run test -- --run src/components/MobileHandGrid` (20 passed, no regression)
- [x] `bun run test -- --run src/pages/GongZhuPage.test.tsx` (11 passed) — expose phase highlights the exposable card and dims the rest
- [x] `bun run check` (biome + design-tokens OK)
- [ ] CI: build (tsc) + E2E + codecov

Closes #2285