### PR TITLE
feat(bakersgame): show real-time movable-card count badge

### DIFF
--- a/frontend/src/i18n/locales/en/bakersgame.json
+++ b/frontend/src/i18n/locales/en/bakersgame.json
@@ -18,6 +18,7 @@
   "emptyFoundationAriaLabel": "{{suit}} Foundation (empty)",
   "emptyFreecellAriaLabel": "Free Cell {{idx}} (empty)",
   "supermoveLimitTooltip": "Only {{limit}} card(s) can be moved at once",
+  "movableCount": "Movable: {{count}}",
   "tutorial": {
     "freeCells": "Free cells. Four temporary storage slots. More empty cells allow moving more cards at once.",
     "foundation": "Foundation piles. Build each suit from Ace to King.",

--- a/frontend/src/i18n/locales/ja/bakersgame.json
+++ b/frontend/src/i18n/locales/ja/bakersgame.json
@@ -18,6 +18,7 @@
   "emptyFoundationAriaLabel": "{{suit}} ファンデーション (空)",
   "emptyFreecellAriaLabel": "フリーセル {{idx}} (空)",
   "supermoveLimitTooltip": "一度に動かせるのは{{limit}}枚までです",
+  "movableCount": "移動可能: {{count}}枚",
   "tutorial": {
     "freeCells": "フリーセルです。一時的にカードを置ける4つのスペースです。空きセルが多いほど多くのカードを一度に移動できます。",
     "foundation": "ファウンデーションです。各スートをAからKまで順番に積み上げます。",

--- a/frontend/src/pages/BakersGamePage.test.tsx
+++ b/frontend/src/pages/BakersGamePage.test.tsx
@@ -128,6 +128,19 @@ describe('BakersGamePage', () => {
     expect(emptyButtons.length).toBe(4);
   });
 
+  it('shows the movable-count badge during play', async () => {
+    // playingState: 4 empty free cells, 6 empty tableau columns → (1+4)*2^6 = 320.
+    renderWithProviders(<BakersGamePage />);
+    await waitFor(() => expect(screen.getByTestId('bg-movable-count')).toHaveTextContent('320'));
+  });
+
+  it('hides the movable-count badge once the game ends', async () => {
+    mockExec.mockResolvedValue(gameClearState);
+    renderWithProviders(<BakersGamePage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    expect(screen.queryByTestId('bg-movable-count')).not.toBeInTheDocument();
+  });
+
   it('renders freecell with card occupied', async () => {
     mockExec.mockResolvedValue(withFreeCellCardState);
     renderWithProviders(<BakersGamePage />);

--- a/frontend/src/pages/BakersGamePage.test.tsx
+++ b/frontend/src/pages/BakersGamePage.test.tsx
@@ -134,8 +134,11 @@ describe('BakersGamePage', () => {
     await waitFor(() => expect(screen.getByTestId('bg-movable-count')).toHaveTextContent('320'));
   });
 
-  it('hides the movable-count badge once the game ends', async () => {
-    mockExec.mockResolvedValue(gameClearState);
+  it.each([
+    ['game clear', gameClearState],
+    ['game over', gameOverState],
+  ])('hides the movable-count badge once the game ends (%s)', async (_label, endState) => {
+    mockExec.mockResolvedValue(endState);
     renderWithProviders(<BakersGamePage />);
     await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
     expect(screen.queryByTestId('bg-movable-count')).not.toBeInTheDocument();

--- a/frontend/src/pages/BakersGamePage.tsx
+++ b/frontend/src/pages/BakersGamePage.tsx
@@ -477,6 +477,7 @@ function BakersGamePageContent() {
               {isPlaying && (
                 <span
                   data-testid="bg-movable-count"
+                  aria-live="polite"
                   className="text-ds-text-primary text-xs font-medium bg-ds-surface-elevated rounded px-2 py-1"
                 >
                   {t('movableCount', { count: supermoveLimit })}

--- a/frontend/src/pages/BakersGamePage.tsx
+++ b/frontend/src/pages/BakersGamePage.tsx
@@ -475,6 +475,14 @@ function BakersGamePageContent() {
             <ErrorAlert message={error ?? hintError} onRetry={retry} />
             <div className="flex gap-2 items-center flex-wrap">
               {isPlaying && (
+                <span
+                  data-testid="bg-movable-count"
+                  className="text-ds-text-primary text-xs font-medium bg-ds-surface-elevated rounded px-2 py-1"
+                >
+                  {t('movableCount', { count: supermoveLimit })}
+                </span>
+              )}
+              {isPlaying && (
                 <div data-tutorial="fc-controls">
                   <button
                     type="button"


### PR DESCRIPTION
## Summary

Implements #2291. Baker's Game already computes the FreeCell supermove limit (`(1 + freeCells) * 2^emptyCols`) and dims over-limit stacks, but nowhere showed players *how many* cards they can currently move — they had to count free cells and empty columns and do the math.

- Added a **`移動可能: N枚` / `Movable: N`** badge in the footer control row, shown only during play.
- Reuses the already-computed `supermoveLimit`, so it updates live as free cells fill/empty and columns open/close (zero extra computation).
- New `movableCount` i18n key in both locales (parity preserved).

## Test plan
- [x] `bun run test -- --run src/pages/BakersGamePage.test.tsx` (64 passed) — badge shows the computed limit (320 for the default 4 free cells / 6 empty columns) during play and is absent once the game ends
- [x] `bun run check` (biome + design-tokens OK)
- [ ] CI: build (tsc) + E2E + codecov + i18n parity

Closes #2291