### PR TITLE
feat(bourre): show pot + bourré-penalty summary in the decide phase

### DIFF
--- a/frontend/src/i18n/locales/en/bourre.json
+++ b/frontend/src/i18n/locales/en/bourre.json
@@ -1,5 +1,6 @@
 {
   "title": "Bourré",
+  "decideSummary": "Pot: {{pot}} chips | Bourré penalty: {{penalty}} chips",
   "label": {
     "pot": "Pot",
     "carry": "Carry",

--- a/frontend/src/i18n/locales/ja/bourre.json
+++ b/frontend/src/i18n/locales/ja/bourre.json
@@ -1,5 +1,6 @@
 {
   "title": "ブーレ",
+  "decideSummary": "ポット: {{pot}}チップ | ブーレ時ペナルティ: {{penalty}}チップ",
   "label": {
     "pot": "ポット",
     "carry": "繰越",

--- a/frontend/src/pages/BourrePage.test.tsx
+++ b/frontend/src/pages/BourrePage.test.tsx
@@ -102,6 +102,21 @@ describe('BourrePage', () => {
     expect(summary).not.toHaveClass('text-ds-warning');
   });
 
+  it('decide phase: penalty includes carryPot', async () => {
+    mockExec.mockResolvedValue(makeState({ pot: 25, carryPot: 5 }));
+    renderWithProviders(<BourrePage />);
+    const summary = await screen.findByTestId('bourre-decide-summary');
+    expect(summary).toHaveTextContent('30'); // penalty = pot + carryPot
+  });
+
+  it('decide phase: carryPot can push a small pot over the warning threshold', async () => {
+    mockExec.mockResolvedValue(makeState({ pot: 5, carryPot: 6 }));
+    renderWithProviders(<BourrePage />);
+    const summary = await screen.findByTestId('bourre-decide-summary');
+    expect(summary).toHaveTextContent('11'); // 5 + 6 >= 10
+    expect(summary).toHaveClass('text-ds-warning');
+  });
+
   it('does not show the decide summary outside the decide phase', async () => {
     mockExec.mockResolvedValue(makeState({ phase: 'play', currentPlayerIdx: 0 }));
     renderWithProviders(<BourrePage />);

--- a/frontend/src/pages/BourrePage.test.tsx
+++ b/frontend/src/pages/BourrePage.test.tsx
@@ -87,6 +87,28 @@ describe('BourrePage', () => {
     });
   });
 
+  it('decide phase: shows the pot/penalty summary, flagged in warning color when the pot is high', async () => {
+    renderWithProviders(<BourrePage />); // default: pot 25, carryPot 0 → penalty 25 (>= threshold)
+    const summary = await screen.findByTestId('bourre-decide-summary');
+    expect(summary).toHaveTextContent('25');
+    expect(summary).toHaveClass('text-ds-warning');
+  });
+
+  it('decide phase: pot/penalty summary uses muted color when the pot is small', async () => {
+    mockExec.mockResolvedValue(makeState({ pot: 3, carryPot: 0 }));
+    renderWithProviders(<BourrePage />);
+    const summary = await screen.findByTestId('bourre-decide-summary');
+    expect(summary).toHaveClass('text-ds-text-muted');
+    expect(summary).not.toHaveClass('text-ds-warning');
+  });
+
+  it('does not show the decide summary outside the decide phase', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: 'play', currentPlayerIdx: 0 }));
+    renderWithProviders(<BourrePage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    expect(screen.queryByTestId('bourre-decide-summary')).not.toBeInTheDocument();
+  });
+
   it('decide phase: play and fold buttons dispatch decide', async () => {
     renderWithProviders(<BourrePage />);
     fireEvent.click(await screen.findByRole('button', { name: '参加（アンティ）' }));

--- a/frontend/src/pages/BourrePage.tsx
+++ b/frontend/src/pages/BourrePage.tsx
@@ -32,6 +32,9 @@ type ApiArgs = {
   config?: { cpuDifficulty?: number };
 };
 
+// At/above this total pot (pot + carryPot) the bourré penalty is flagged in warning color.
+const BOURRE_PENALTY_WARN_THRESHOLD = 10;
+
 const TUTORIAL_STEPS: TutorialStep[] = [
   { target: '[data-tutorial="bourre-hand"]', messageKey: 'tutorial.intro', placement: 'top', advanceOn: 'next' },
   { target: '[data-tutorial="bourre-controls"]', messageKey: 'tutorial.decide', placement: 'top', advanceOn: 'next' },
@@ -309,6 +312,23 @@ function BourrePageContent() {
               </button>
             )}
           </div>
+
+          {phase === 'decide' && isHumanTurn && (
+            <p
+              data-testid="bourre-decide-summary"
+              className={`mt-1 text-center text-xs ${
+                state.pot + state.carryPot >= BOURRE_PENALTY_WARN_THRESHOLD
+                  ? 'text-ds-warning font-medium'
+                  : 'text-ds-text-muted'
+              }`}
+            >
+              {t('decideSummary', {
+                pot: state.pot,
+                penalty: state.pot + state.carryPot,
+                defaultValue: 'Pot: {{pot}} | Bourré penalty: {{penalty}}',
+              })}
+            </p>
+          )}
 
           {/* Human hand */}
           {humanPlayer && !humanPlayer.isFinished && humanPlayer.cards.length > 0 && (

--- a/frontend/src/pages/BourrePage.tsx
+++ b/frontend/src/pages/BourrePage.tsx
@@ -32,7 +32,6 @@ type ApiArgs = {
   config?: { cpuDifficulty?: number };
 };
 
-// At/above this total pot (pot + carryPot) the bourré penalty is flagged in warning color.
 const BOURRE_PENALTY_WARN_THRESHOLD = 10;
 
 const TUTORIAL_STEPS: TutorialStep[] = [
@@ -325,7 +324,7 @@ function BourrePageContent() {
               {t('decideSummary', {
                 pot: state.pot,
                 penalty: state.pot + state.carryPot,
-                defaultValue: 'Pot: {{pot}} | Bourré penalty: {{penalty}}',
+                defaultValue: 'Pot: {{pot}} chips | Bourré penalty: {{penalty}} chips',
               })}
             </p>
           )}


### PR DESCRIPTION
## Summary

Implements #2292. In Bourré's decide phase the player chooses to play (pay the ante) or fold, but the page only showed the raw pot — never the **bourré penalty** (paying the full pot if you play and take zero tricks). Without it, players can't judge the fold decision's expected value.

- During `phase === 'decide'` on the human's turn, render a one-line `Pot: X chips | Bourré penalty: X chips` summary under the Play/Fold buttons.
- The penalty is the total at stake (`pot + carryPot`); the line turns `text-ds-warning` once that total reaches the threshold (10 chips), and stays `text-ds-text-muted` otherwise.
- New `decideSummary` i18n key in both locales (parity preserved).

## Test plan
- [x] `bun run test -- --run src/pages/BourrePage.test.tsx` (16 passed) — summary shows the amount + warning color for a high pot, muted color for a small pot, and is absent outside the decide phase
- [x] `bun run check` (biome + design-tokens OK)
- [ ] CI: build (tsc) + E2E + codecov + i18n parity

Closes #2292