### PR TITLE
feat(montecarlo): sharpen pair vs adjacent cues + pair-removed toast

### DIFF
--- a/frontend/src/i18n/locales/en/montecarlo.json
+++ b/frontend/src/i18n/locales/en/montecarlo.json
@@ -1,5 +1,6 @@
 {
   "title": "Monte Carlo Solitaire",
+  "pairRemoved": "Pair removed!",
   "phase": {
     "playing": "Playing",
     "gameClear": "Game Clear",

--- a/frontend/src/i18n/locales/ja/montecarlo.json
+++ b/frontend/src/i18n/locales/ja/montecarlo.json
@@ -1,5 +1,6 @@
 {
   "title": "モンテカルロ・ソリティア",
+  "pairRemoved": "ペアを除去しました！",
   "phase": {
     "playing": "プレイ中",
     "gameClear": "ゲームクリア",

--- a/frontend/src/pages/MonteCarloPage.test.tsx
+++ b/frontend/src/pages/MonteCarloPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { montecarloApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -166,7 +166,7 @@ describe('MonteCarloPage', () => {
     expect(partner.className).toContain('animate-pulse');
   });
 
-  it('falls back to warning ring on adjacent cells with a different rank', async () => {
+  it('dims adjacent cells with a different rank instead of ringing them', async () => {
     // Build a board where two adjacent cells (0,0) and (1,0) hold different ranks.
     const board = emptyBoard();
     board[0][0] = { card: card('SPADE', 7) };
@@ -179,7 +179,34 @@ describe('MonteCarloPage', () => {
 
     const neighbor = screen.getByTestId('mc-cell-1-0');
     expect(neighbor).not.toHaveAttribute('data-pair-match');
-    expect(neighbor.className).toContain('ring-ds-warning');
+    expect(neighbor.className).toContain('opacity-60');
     expect(neighbor.className).not.toContain('animate-pulse');
+  });
+
+  it('lifts a matching adjacent pair candidate and shows a transient success toast on removal', async () => {
+    vi.useFakeTimers();
+    try {
+      const board = emptyBoard();
+      board[0][0] = { card: card('SPADE', 7) };
+      board[1][0] = { card: card('HEART', 7) }; // adjacent, same rank
+      mockExec.mockResolvedValue({ ...playingState, board });
+      renderWithProviders(<MonteCarloPage />);
+      await vi.waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+      fireEvent.click(screen.getByTestId('mc-cell-0-0'));
+      const match = screen.getByTestId('mc-cell-1-0');
+      expect(match).toHaveAttribute('data-pair-match', 'true');
+      expect(match.className).toContain('-translate-y-1');
+
+      // Removing the valid pair flashes the toast, which auto-dismisses after 1s.
+      fireEvent.click(match);
+      expect(screen.getByTestId('mc-pair-toast')).toBeInTheDocument();
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(screen.queryByTestId('mc-pair-toast')).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/pages/MonteCarloPage.test.tsx
+++ b/frontend/src/pages/MonteCarloPage.test.tsx
@@ -191,6 +191,8 @@ describe('MonteCarloPage', () => {
       board[1][0] = { card: card('HEART', 7) }; // adjacent, same rank
       mockExec.mockResolvedValue({ ...playingState, board });
       renderWithProviders(<MonteCarloPage />);
+      // Use vi.waitFor (not RTL waitFor) here: RTL's waitFor relies on real timers
+      // and would hang under vi.useFakeTimers().
       await vi.waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
 
       fireEvent.click(screen.getByTestId('mc-cell-0-0'));

--- a/frontend/src/pages/MonteCarloPage.tsx
+++ b/frontend/src/pages/MonteCarloPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { montecarloApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { SettingsPanel } from '../components/common/SettingsPanel';
@@ -74,6 +74,17 @@ function MonteCarloPageContent() {
   const phaseNames = usePhaseNames('montecarlo', MC_PHASE_KEYS);
 
   const [selected, setSelected] = useState<CellPos | null>(null);
+  const [pairRemoved, setPairRemoved] = useState(false);
+  const pairToastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear the success toast timer on unmount to avoid setting state after teardown.
+  useEffect(() => () => clearTimeout(pairToastTimer.current ?? undefined), []);
+
+  const flashPairRemoved = useCallback(() => {
+    setPairRemoved(true);
+    clearTimeout(pairToastTimer.current ?? undefined);
+    pairToastTimer.current = setTimeout(() => setPairRemoved(false), 1000);
+  }, []);
 
   const isPlaying = state?.phase === MonteCarloPhase.PLAYING;
   const isGameClear = state?.phase === MonteCarloPhase.GAME_CLEAR;
@@ -98,11 +109,16 @@ function MonteCarloPageContent() {
         return;
       }
       // Two cells chosen. Send the remove request (server validates adjacency + rank).
+      // Flash the success toast when the chosen pair is locally valid (adjacent + same rank).
+      const firstCard = state.board[selected.row]?.[selected.col]?.card;
+      const isValidPair =
+        firstCard != null && firstCard.value === cell.card.value && isAdjacent(selected, { row, col });
       void execApi('remove', selected.row, selected.col, row, col);
       playSound('cardPlace');
+      if (isValidPair) flashPairRemoved();
       setSelected(null);
     },
-    [execApi, isPlaying, playSound, selected, state],
+    [execApi, flashPairRemoved, isPlaying, playSound, selected, state],
   );
 
   const handleDeal = useCallback(() => {
@@ -227,13 +243,13 @@ function MonteCarloPageContent() {
                           onClick={() => handleCellClick(rowIdx, colIdx)}
                           disabled={!isPlaying || loading || !filled}
                           data-pair-match={isMatchingPair ? 'true' : undefined}
-                          className={`p-0 border-0 bg-transparent rounded ${focusRingWhite} ${
+                          className={`p-0 border-0 bg-transparent rounded transition-transform ${focusRingWhite} ${
                             filled ? 'cursor-pointer' : ''
                           } ${isSelected ? 'ring-2 ring-ds-accent' : ''} ${
                             isMatchingPair
-                              ? 'ring-2 ring-ds-success animate-pulse'
+                              ? 'ring-2 ring-ds-success animate-pulse -translate-y-1'
                               : isAdjOfSelected
-                                ? 'ring-1 ring-ds-warning'
+                                ? 'opacity-60'
                                 : ''
                           } ${isHintTarget ? 'ring-2 ring-ds-warning' : ''}`}
                         >
@@ -257,6 +273,17 @@ function MonteCarloPageContent() {
             <div className="text-center text-ds-text-muted text-sm mb-2" data-testid="mc-prompt">
               {selected === null ? t('label.selectFirst') : t('label.selectSecond')}
             </div>
+
+            {pairRemoved && (
+              <div
+                role="status"
+                aria-live="polite"
+                data-testid="mc-pair-toast"
+                className="mb-2 text-center text-ds-success text-sm font-medium"
+              >
+                {t('pairRemoved')}
+              </div>
+            )}
 
             <GameMessageBox
               message={state.message}


### PR DESCRIPTION
## Summary

Implements #2248. In Monte Carlo Solitaire the matching-pair ring (`ring-ds-success`) and the different-rank adjacent ring (`ring-ds-warning`) looked too similar — hard to tell "can I pair this?" at a glance, especially on mobile or with color-vision deficiency. The persistent pulse also competed with the hint highlight.

- **Matching pair candidate**: now also lifts with `-translate-y-1` (on top of the existing `ring-ds-success animate-pulse`) so it clearly pops.
- **Non-matching adjacent cell**: changed from `ring-1 ring-ds-warning` to `opacity-60` — reads as "not selectable" rather than another colored ring.
- **Pair removed**: a transient success toast (`role=status`, `aria-live=polite`) appears for 1s when a locally-valid pair (adjacent + same rank) is removed; the timer is cleared on unmount.

## Test plan
- [x] `bun run test -- --run src/pages/MonteCarloPage.test.tsx` (16 passed) — adjacent-different-rank dims (no warning ring), matching pair lifts + `data-pair-match`, and the toast appears then auto-dismisses after 1s (fake timers)
- [x] `bun run check` (biome + design-tokens OK)
- [ ] CI: build (tsc) + E2E + codecov + i18n parity

Closes #2248