### PR TITLE
feat(contractrummy): clearer layoff-target meld selection

### DIFF
--- a/frontend/src/i18n/locales/en/contractrummy.json
+++ b/frontend/src/i18n/locales/en/contractrummy.json
@@ -23,6 +23,8 @@
   "submitContract": "Submit contract",
   "meldExtra": "Lay extra meld",
   "layoff": "Lay off",
+  "meldAria": "{{player}}'s meld {{meld}}",
+  "layoffTargetSummary": "→ Lay off to: {{player}} meld {{meld}}",
   "discard": "Discard card",
   "nextRound": "Next round",
   "viewLog": "View log",

--- a/frontend/src/i18n/locales/ja/contractrummy.json
+++ b/frontend/src/i18n/locales/ja/contractrummy.json
@@ -23,6 +23,8 @@
   "submitContract": "コントラクトを場に出す",
   "meldExtra": "追加メルド",
   "layoff": "レイオフ",
+  "meldAria": "{{player}}のメルド{{meld}}",
+  "layoffTargetSummary": "→ レイオフ先: {{player}} メルド{{meld}}",
   "discard": "カードを捨てる",
   "nextRound": "次のラウンドへ",
   "viewLog": "棋譜を表示",

--- a/frontend/src/pages/ContractRummyPage.test.tsx
+++ b/frontend/src/pages/ContractRummyPage.test.tsx
@@ -238,6 +238,28 @@ describe('ContractRummyPage', () => {
     expect(screen.getByRole('button', { name: /Lay off|レイオフ/ })).toBeInTheDocument();
   });
 
+  it('selecting an opponent meld highlights it and shows the layoff target in the footer', async () => {
+    const metState: ContractRummyResponse = {
+      ...playState,
+      players: [
+        { ...playState.players[0], contractMet: true },
+        {
+          ...playState.players[1],
+          contractMet: true,
+          melds: [{ cards: [card('SPADE', 5), card('HEART', 5), card('DIAMOND', 5)] }],
+        },
+        playState.players[2],
+      ],
+    };
+    mockExec.mockResolvedValue(metState);
+    renderWithProviders(<ContractRummyPage />);
+    const meldButton = await screen.findByRole('button', { name: /メルド1/ });
+    fireEvent.click(meldButton);
+    expect(meldButton).toHaveAttribute('aria-pressed', 'true');
+    expect(meldButton.className).toContain('bg-ds-warning/20');
+    expect(screen.getByTestId('cr-layoff-target')).toBeInTheDocument();
+  });
+
   it('shows per-slot progress and only enables Submit when both slots satisfy their contract', async () => {
     mockExec.mockResolvedValue(playState);
     renderWithProviders(<ContractRummyPage />);

--- a/frontend/src/pages/ContractRummyPage.test.tsx
+++ b/frontend/src/pages/ContractRummyPage.test.tsx
@@ -260,6 +260,29 @@ describe('ContractRummyPage', () => {
     expect(screen.getByTestId('cr-layoff-target')).toBeInTheDocument();
   });
 
+  it('does not let you target an opponent meld before your own contract is met', async () => {
+    const notMetState: ContractRummyResponse = {
+      ...playState,
+      players: [
+        { ...playState.players[0], contractMet: false }, // human has NOT met their contract
+        {
+          ...playState.players[1],
+          contractMet: true,
+          melds: [{ cards: [card('SPADE', 5), card('HEART', 5), card('DIAMOND', 5)] }],
+        },
+        playState.players[2],
+      ],
+    };
+    mockExec.mockResolvedValue(notMetState);
+    renderWithProviders(<ContractRummyPage />);
+    const meldButton = await screen.findByRole('button', { name: /メルド1/ });
+    // Not actionable yet: no toggle semantics and clicking does nothing.
+    expect(meldButton).not.toHaveAttribute('aria-pressed');
+    fireEvent.click(meldButton);
+    expect(meldButton).not.toHaveClass('bg-ds-warning/20');
+    expect(screen.queryByTestId('cr-layoff-target')).not.toBeInTheDocument();
+  });
+
   it('shows per-slot progress and only enables Submit when both slots satisfy their contract', async () => {
     mockExec.mockResolvedValue(playState);
     renderWithProviders(<ContractRummyPage />);

--- a/frontend/src/pages/ContractRummyPage.test.tsx
+++ b/frontend/src/pages/ContractRummyPage.test.tsx
@@ -256,7 +256,7 @@ describe('ContractRummyPage', () => {
     const meldButton = await screen.findByRole('button', { name: /メルド1/ });
     fireEvent.click(meldButton);
     expect(meldButton).toHaveAttribute('aria-pressed', 'true');
-    expect(meldButton.className).toContain('bg-ds-warning/20');
+    expect(meldButton).toHaveClass('bg-ds-warning/20');
     expect(screen.getByTestId('cr-layoff-target')).toBeInTheDocument();
   });
 

--- a/frontend/src/pages/ContractRummyPage.tsx
+++ b/frontend/src/pages/ContractRummyPage.tsx
@@ -286,17 +286,20 @@ function ContractRummyPageContent() {
                 {p.melds.map((m, mi) => {
                   const isLayoffTarget = layoffTarget?.playerIdx === p.id && layoffTarget?.meldIdx === mi;
                   const playerLabel = p.isHuman ? tc('player.you') : tc('player.cpu', { id: p.id });
+                  // The meld is only a selectable layoff target once both contracts are met.
+                  const canLayoff = humanPlayer?.contractMet === true && p.contractMet;
                   return (
                     <button
                       type="button"
                       key={`${p.id}-${mi}`}
                       onClick={() => {
-                        if (humanPlayer?.contractMet && p.contractMet) {
+                        if (canLayoff) {
                           setLayoffTarget({ playerIdx: p.id, meldIdx: mi });
                         }
                       }}
                       aria-label={t('meldAria', { player: playerLabel, meld: mi + 1 })}
-                      aria-pressed={isLayoffTarget}
+                      // Only expose the toggle semantics when the meld is actually actionable.
+                      aria-pressed={canLayoff ? isLayoffTarget : undefined}
                       className={`flex flex-wrap gap-1 mb-1 px-1 rounded ${focusRingWhite} ${
                         isLayoffTarget ? 'ring-2 ring-ds-warning bg-ds-warning/20' : ''
                       }`}

--- a/frontend/src/pages/ContractRummyPage.tsx
+++ b/frontend/src/pages/ContractRummyPage.tsx
@@ -96,6 +96,14 @@ function ContractRummyPageContent() {
   const isPlayPhase = isHumanTurn && state?.phase === CR_PHASE.PLAY;
   const isRoundEnd = state?.phase === CR_PHASE.ROUND_END;
 
+  // Human-readable label for the currently selected layoff target meld, if any.
+  const layoffTargetPlayer = layoffTarget ? state?.players.find((p) => p.id === layoffTarget.playerIdx) : undefined;
+  const layoffTargetLabel = layoffTargetPlayer
+    ? layoffTargetPlayer.isHuman
+      ? tc('player.you')
+      : tc('player.cpu', { id: layoffTargetPlayer.id })
+    : null;
+
   const toggleCard = useCallback((idx: number) => {
     setSelectedCards((prev) => (prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx]));
   }, []);
@@ -275,24 +283,30 @@ function ContractRummyPageContent() {
             </div>
             {p.melds.length > 0 && (
               <div className="mt-2">
-                {p.melds.map((m, mi) => (
-                  <button
-                    type="button"
-                    key={`${p.id}-${mi}`}
-                    onClick={() => {
-                      if (humanPlayer?.contractMet && p.contractMet) {
-                        setLayoffTarget({ playerIdx: p.id, meldIdx: mi });
-                      }
-                    }}
-                    className={`flex flex-wrap gap-1 mb-1 px-1 rounded ${focusRingWhite} ${
-                      layoffTarget?.playerIdx === p.id && layoffTarget?.meldIdx === mi ? 'ring-2 ring-ds-warning' : ''
-                    }`}
-                  >
-                    {m.cards.map((c, ci) => (
-                      <AnimatedCard key={`${p.id}-${mi}-${ci}`} card={c} width={cardWidth * 0.6} />
-                    ))}
-                  </button>
-                ))}
+                {p.melds.map((m, mi) => {
+                  const isLayoffTarget = layoffTarget?.playerIdx === p.id && layoffTarget?.meldIdx === mi;
+                  const playerLabel = p.isHuman ? tc('player.you') : tc('player.cpu', { id: p.id });
+                  return (
+                    <button
+                      type="button"
+                      key={`${p.id}-${mi}`}
+                      onClick={() => {
+                        if (humanPlayer?.contractMet && p.contractMet) {
+                          setLayoffTarget({ playerIdx: p.id, meldIdx: mi });
+                        }
+                      }}
+                      aria-label={t('meldAria', { player: playerLabel, meld: mi + 1 })}
+                      aria-pressed={isLayoffTarget}
+                      className={`flex flex-wrap gap-1 mb-1 px-1 rounded ${focusRingWhite} ${
+                        isLayoffTarget ? 'ring-2 ring-ds-warning bg-ds-warning/20' : ''
+                      }`}
+                    >
+                      {m.cards.map((c, ci) => (
+                        <AnimatedCard key={`${p.id}-${mi}-${ci}`} card={c} width={cardWidth * 0.6} />
+                      ))}
+                    </button>
+                  );
+                })}
               </div>
             )}
           </div>
@@ -412,6 +426,11 @@ function ContractRummyPageContent() {
             requestConfirm={requestConfirm}
             loading={loading}
           />
+          {layoffTarget && layoffTargetLabel && (
+            <span data-testid="cr-layoff-target" className="text-xs text-ds-warning font-medium">
+              {t('layoffTargetSummary', { player: layoffTargetLabel, meld: layoffTarget.meldIdx + 1 })}
+            </span>
+          )}
         </div>
       </GameFooter>
     </GamePageShell>


### PR DESCRIPTION
## Summary

Implements #2249. Laying off onto another player's meld required clicking a meld button that had **no `aria-label`** and only a thin `ring-2 ring-ds-warning` when selected — easy to mis-tap on mobile and invisible to screen readers, with no confirmation of which target was chosen.

- Meld buttons now have a descriptive `aria-label` (`<player>'s meld N`) and an `aria-pressed` state.
- The selected layoff-target meld gains a `bg-ds-warning/20` fill on top of the ring.
- The footer shows a live `→ Lay off to: <player> meld N` summary while a target is selected.
- New `meldAria` / `layoffTargetSummary` i18n keys in both locales (parity preserved).

## Test plan
- [x] `bun run test -- --run src/pages/ContractRummyPage.test.tsx` (16 passed) — selecting an opponent meld sets `aria-pressed`, adds the `bg-ds-warning/20` fill, and renders the footer target summary
- [x] `bun run check` (biome + design-tokens OK)
- [ ] CI: build (tsc) + E2E + codecov + i18n parity

Closes #2249