### PR TITLE
feat(tonk): highlight formed melds before knocking

### DIFF
--- a/frontend/src/pages/TonkPage.test.tsx
+++ b/frontend/src/pages/TonkPage.test.tsx
@@ -130,6 +130,40 @@ describe('TonkPage', () => {
     expect(screen.getByTestId('tonk-hand-2')).not.toHaveAttribute('data-meld');
   });
 
+  it('highlights a run and loses it when a middle card is discarded', async () => {
+    const runHand = () =>
+      makeState({
+        players: [
+          {
+            id: 0,
+            isHuman: true,
+            cardCount: 5,
+            // A 4-card spade run plus one off card.
+            cards: [card('SPADE', 5), card('SPADE', 6), card('SPADE', 7), card('SPADE', 8), card('HEART', 2)],
+            roundScore: 0,
+            cumulativeScore: 0,
+          },
+          { id: 1, isHuman: false, cardCount: 5, cards: [], roundScore: 0, cumulativeScore: 0 },
+        ],
+      });
+
+    // Discard the off card (index 4) → the 5-6-7-8 run stays intact and lights up.
+    mockExec.mockResolvedValue(runHand());
+    const { unmount } = renderWithProviders(<TonkPage />);
+    fireEvent.click(await screen.findByTestId('tonk-hand-4'));
+    await waitFor(() => expect(screen.getByTestId('tonk-hand-0')).toHaveAttribute('data-meld', 'true'));
+    expect(screen.getByTestId('tonk-hand-3')).toHaveAttribute('data-meld', 'true');
+    unmount();
+
+    // Discard a middle card (index 1, the 6) → remaining 5,7,8 is not a run → no highlight.
+    mockExec.mockResolvedValue(runHand());
+    renderWithProviders(<TonkPage />);
+    fireEvent.click(await screen.findByTestId('tonk-hand-1'));
+    await waitFor(() => expect(screen.getByTestId('tonk-hand-1')).toHaveAttribute('aria-pressed', 'true'));
+    expect(screen.getByTestId('tonk-hand-0')).not.toHaveAttribute('data-meld');
+    expect(screen.getByTestId('tonk-hand-2')).not.toHaveAttribute('data-meld');
+  });
+
   it('clears the warning when opponents drop back above the threshold', async () => {
     // First render: opponent at 2 → warning on.
     mockExec.mockResolvedValueOnce(

--- a/frontend/src/pages/TonkPage.test.tsx
+++ b/frontend/src/pages/TonkPage.test.tsx
@@ -89,6 +89,47 @@ describe('TonkPage', () => {
     expect(knock.textContent).toContain('⚠️');
   });
 
+  const meldHandState = () =>
+    makeState({
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          cardCount: 5,
+          // Three 7s (a set) plus two unrelated cards.
+          cards: [card('SPADE', 7), card('HEART', 7), card('CLOVER', 7), card('DIAMOND', 4), card('HEART', 9)],
+          roundScore: 0,
+          cumulativeScore: 0,
+        },
+        { id: 1, isHuman: false, cardCount: 5, cards: [], roundScore: 0, cumulativeScore: 0 },
+      ],
+    });
+
+  it('highlights cards that form a meld once a discard candidate is selected', async () => {
+    mockExec.mockResolvedValue(meldHandState());
+    renderWithProviders(<TonkPage />);
+    // No highlight before a discard is chosen.
+    await waitFor(() => expect(screen.getByTestId('tonk-hand-0')).toBeInTheDocument());
+    expect(screen.getByTestId('tonk-hand-0')).not.toHaveAttribute('data-meld');
+
+    // Select the non-meld card (index 4) as the discard → the three 7s light up.
+    fireEvent.click(screen.getByTestId('tonk-hand-4'));
+    await waitFor(() => expect(screen.getByTestId('tonk-hand-0')).toHaveAttribute('data-meld', 'true'));
+    expect(screen.getByTestId('tonk-hand-1')).toHaveAttribute('data-meld', 'true');
+    expect(screen.getByTestId('tonk-hand-2')).toHaveAttribute('data-meld', 'true');
+    expect(screen.getByTestId('tonk-hand-3')).not.toHaveAttribute('data-meld');
+  });
+
+  it('shows no meld highlight when discarding a meld card breaks the set', async () => {
+    mockExec.mockResolvedValue(meldHandState());
+    renderWithProviders(<TonkPage />);
+    // Discard one of the 7s → only two 7s remain among the other four → no meld.
+    fireEvent.click(await screen.findByTestId('tonk-hand-0'));
+    await waitFor(() => expect(screen.getByTestId('tonk-hand-0')).toHaveAttribute('aria-pressed', 'true'));
+    expect(screen.getByTestId('tonk-hand-1')).not.toHaveAttribute('data-meld');
+    expect(screen.getByTestId('tonk-hand-2')).not.toHaveAttribute('data-meld');
+  });
+
   it('clears the warning when opponents drop back above the threshold', async () => {
     // First render: opponent at 2 → warning on.
     mockExec.mockResolvedValueOnce(

--- a/frontend/src/pages/TonkPage.tsx
+++ b/frontend/src/pages/TonkPage.tsx
@@ -24,7 +24,7 @@ import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useTonkGame } from '../hooks/useTonkGame';
 import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
-import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
+import { focusRingCard, playableCardStyle, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { TonkResponse } from '../types/card';
@@ -35,6 +35,7 @@ import { parseTonkCommand, TONK_HELP } from '../utils/cli/commands/tonkCommands'
 import { formatTonkState } from '../utils/cli/formatters/tonkFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
+import { tonkMeldIndices } from '../utils/tonkMeldIndices';
 
 const TONK_PHASE_KEYS: Readonly<Record<number, string>> = {
   [TonkPhase.DRAW]: 'draw',
@@ -162,6 +163,20 @@ function TonkPageContent() {
   const isRoundEnd = state.phase === TonkPhase.ROUND_END;
   const isGameEnd = state.phase === TonkPhase.GAME_END || state.gameEndFlag;
   const isHumanTurn = (isDrawPhase || isDiscardPhase) && state.players[state.currentPlayerIdx]?.isHuman === true;
+
+  // When exactly one card is selected to discard, highlight which of the remaining
+  // four cards already form a meld (set or run) so the player can knock with confidence.
+  const meldHighlight = (() => {
+    if (!humanPlayer || !isDiscardPhase || !isHumanTurn || selectedCardIndices.length !== 1) {
+      return new Set<number>();
+    }
+    const discardIdx = selectedCardIndices[0];
+    const remaining = humanPlayer.cards.map((card, idx) => ({ card, idx })).filter((x) => x.idx !== discardIdx);
+    const meldedPositions = tonkMeldIndices(remaining.map((x) => x.card));
+    const result = new Set<number>();
+    for (const pos of meldedPositions) result.add(remaining[pos].idx);
+    return result;
+  })();
   // Undercut early-warning: if any opponent has 2 or fewer cards, calling Knock is
   // disproportionately risky (they're likely about to go out themselves, flipping the
   // result). We add a warning ring + ⚠️ glyph + tooltip so the player notices the
@@ -329,25 +344,36 @@ function TonkPageContent() {
           <GameFooter className={`${gameTheme.tonk.footer} px-4 py-2.5`}>
             {humanPlayer && (
               <div className="flex flex-wrap gap-1 mb-2" data-tutorial="tonk-player-hand">
-                {humanPlayer.cards.map((card, idx) => (
-                  <button
-                    type="button"
-                    key={`${card.design}-${card.value}-${idx}`}
-                    onClick={() => toggleCard(idx)}
-                    aria-label={cardAlt(card)}
-                    aria-pressed={selectedCardIndices.includes(idx)}
-                    className={`transition-transform ${focusRingCard}`}
-                    style={{
-                      background: 'none',
-                      padding: 0,
-                      borderRadius: 8,
-                      ...selectedCardStyle(selectedCardIndices.includes(idx)),
-                      boxSizing: 'border-box',
-                    }}
-                  >
-                    <AnimatedCard card={card} width={cardWidth} />
-                  </button>
-                ))}
+                {humanPlayer.cards.map((card, idx) => {
+                  const isCardSelected = selectedCardIndices.includes(idx);
+                  const isMeldCard = !isCardSelected && meldHighlight.has(idx);
+                  return (
+                    <button
+                      type="button"
+                      key={`${card.design}-${card.value}-${idx}`}
+                      onClick={() => toggleCard(idx)}
+                      aria-label={cardAlt(card)}
+                      aria-pressed={isCardSelected}
+                      data-meld={isMeldCard ? 'true' : undefined}
+                      data-testid={`tonk-hand-${idx.toString()}`}
+                      className={`transition-transform ${focusRingCard}`}
+                      style={{
+                        background: 'none',
+                        padding: 0,
+                        borderRadius: 8,
+                        // Selection wins; otherwise green-highlight cards that already form a meld.
+                        ...(isCardSelected
+                          ? selectedCardStyle(true)
+                          : isMeldCard
+                            ? playableCardStyle(true)
+                            : selectedCardStyle(false)),
+                        boxSizing: 'border-box',
+                      }}
+                    >
+                      <AnimatedCard card={card} width={cardWidth} />
+                    </button>
+                  );
+                })}
               </div>
             )}
 

--- a/frontend/src/utils/tonkMeldIndices.test.ts
+++ b/frontend/src/utils/tonkMeldIndices.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { tonkMeldIndices } from './tonkMeldIndices';
+
+const c = (design: string, value: number): Card => ({ design, value }) as unknown as Card;
+
+describe('tonkMeldIndices', () => {
+  it('detects a set of three of a kind', () => {
+    const cards = [c('SPADE', 7), c('HEART', 7), c('CLOVER', 7), c('DIAMOND', 2)];
+    expect(tonkMeldIndices(cards)).toEqual(new Set([0, 1, 2]));
+  });
+
+  it('detects a four-of-a-kind set', () => {
+    const cards = [c('SPADE', 7), c('HEART', 7), c('CLOVER', 7), c('DIAMOND', 7)];
+    expect(tonkMeldIndices(cards)).toEqual(new Set([0, 1, 2, 3]));
+  });
+
+  it('detects a same-suit run of three regardless of input order', () => {
+    const cards = [c('SPADE', 6), c('SPADE', 4), c('SPADE', 5), c('HEART', 10)];
+    expect(tonkMeldIndices(cards)).toEqual(new Set([0, 1, 2]));
+  });
+
+  it('does not meld a pair or a two-card partial run', () => {
+    expect(tonkMeldIndices([c('SPADE', 7), c('HEART', 7), c('CLOVER', 2)])).toEqual(new Set());
+    expect(tonkMeldIndices([c('SPADE', 4), c('SPADE', 5), c('HEART', 9)])).toEqual(new Set());
+  });
+
+  it('does not connect a run across different suits', () => {
+    expect(tonkMeldIndices([c('SPADE', 4), c('HEART', 5), c('SPADE', 6)])).toEqual(new Set());
+  });
+
+  it('detects both a set and a run in the same hand', () => {
+    const cards = [c('SPADE', 7), c('HEART', 7), c('CLOVER', 7), c('DIAMOND', 4), c('DIAMOND', 5), c('DIAMOND', 6)];
+    expect(tonkMeldIndices(cards)).toEqual(new Set([0, 1, 2, 3, 4, 5]));
+  });
+
+  it('returns an empty set for fewer than three cards', () => {
+    expect(tonkMeldIndices([c('SPADE', 7), c('HEART', 7)])).toEqual(new Set());
+  });
+});

--- a/frontend/src/utils/tonkMeldIndices.ts
+++ b/frontend/src/utils/tonkMeldIndices.ts
@@ -1,0 +1,56 @@
+import type { Card } from '../types/card';
+
+/**
+ * Returns the set of indices (into the given `cards` array) that participate in
+ * at least one valid Tonk meld:
+ *
+ * - **Set**: three or four cards of the same rank.
+ * - **Run**: three or more consecutive cards of the same suit.
+ *
+ * This mirrors the meld shapes recognised by the Go domain's `findAllPossibleMelds`
+ * (used by `FindBestMelds`). It is intentionally a "does this card belong to any
+ * meld" check for UI highlighting, not an optimal hand partition.
+ */
+export function tonkMeldIndices(cards: Card[]): Set<number> {
+  const melded = new Set<number>();
+
+  // Sets: group indices by rank; a rank with 3+ cards forms a set.
+  const byRank = new Map<number, number[]>();
+  for (let i = 0; i < cards.length; i++) {
+    const v = cards[i].value;
+    const group = byRank.get(v);
+    if (group) group.push(i);
+    else byRank.set(v, [i]);
+  }
+  for (const group of byRank.values()) {
+    if (group.length >= 3) for (const i of group) melded.add(i);
+  }
+
+  // Runs: group indices by suit, sort by rank, collect consecutive runs of 3+.
+  const bySuit = new Map<string, number[]>();
+  for (let i = 0; i < cards.length; i++) {
+    const d = cards[i].design;
+    const group = bySuit.get(d);
+    if (group) group.push(i);
+    else bySuit.set(d, [i]);
+  }
+  for (const group of bySuit.values()) {
+    if (group.length < 3) continue;
+    const sorted = [...group].sort((a, b) => cards[a].value - cards[b].value);
+    let run: number[] = [sorted[0]];
+    const flush = () => {
+      if (run.length >= 3) for (const i of run) melded.add(i);
+    };
+    for (let k = 1; k < sorted.length; k++) {
+      if (cards[sorted[k]].value === cards[run[run.length - 1]].value + 1) {
+        run.push(sorted[k]);
+      } else {
+        flush();
+        run = [sorted[k]];
+      }
+    }
+    flush();
+  }
+
+  return melded;
+}


### PR DESCRIPTION
## Summary

Implements #2243. In Tonk's discard phase you select one card and press Knock, but there was no way to see whether your **remaining** four cards actually form melds — so you couldn't tell if knocking would win.

- New pure util **`tonkMeldIndices(cards)`** returns the indices that belong to any valid meld — a **set** (3-4 same rank) or a **run** (3+ consecutive same-suit), mirroring the shapes in the Go domain's `findAllPossibleMelds`/`FindBestMelds`.
- In the discard phase, when exactly one card is selected (the discard candidate), the remaining four are evaluated and any meld cards get a green `playableCardStyle` highlight (`--color-ds-success`). Selection styling always wins; the highlight clears on discard/knock.

## Test plan
- [x] `bun run test -- --run src/utils/tonkMeldIndices.test.ts` (7 passed) — sets, 4-of-a-kind, out-of-order runs, suit breaks, pairs/partial runs rejected
- [x] `bun run test -- --run src/pages/TonkPage.test.tsx` (5 passed) — meld cards light up after selecting a discard; highlight disappears when discarding a card that breaks the set
- [x] `bun run check` (biome + design-tokens OK)
- [ ] CI: build (tsc) + E2E + codecov

Closes #2243