### PR TITLE
feat(burraco): announce pozzetto pickup + pulse changed round scores

### DIFF
--- a/frontend/src/i18n/locales/en/burraco.json
+++ b/frontend/src/i18n/locales/en/burraco.json
@@ -24,6 +24,7 @@
   "discardPile": "Discard: {{count}} cards",
   "pozzetto": "Pozzetti: {{count}} left",
   "tookPozzetto": "Pozzetto taken",
+  "pozzettoTakenBanner": "{{player}} took the pozzetto!",
   "frozen": "Frozen",
   "melds": "Melds",
   "red3s": "Red 3s",

--- a/frontend/src/i18n/locales/ja/burraco.json
+++ b/frontend/src/i18n/locales/ja/burraco.json
@@ -24,6 +24,7 @@
   "discardPile": "捨て札: {{count}}枚",
   "pozzetto": "ポゼット: 残り{{count}}山",
   "tookPozzetto": "ポゼット獲得済",
+  "pozzettoTakenBanner": "{{player}} がポゼットを獲得！",
   "frozen": "フリーズ中",
   "melds": "メルド",
   "red3s": "赤3",

--- a/frontend/src/pages/BurracoPage.test.tsx
+++ b/frontend/src/pages/BurracoPage.test.tsx
@@ -268,6 +268,21 @@ describe('BurracoPage', () => {
     expect(playSoundMock).toHaveBeenCalledWith('chipClick');
   });
 
+  it('names the CPU in the banner when a CPU takes the pozzetto', async () => {
+    mockExec.mockResolvedValue(drawPhaseState);
+    renderWithProviders(<BurracoPage />);
+    await waitFor(() => expect(screen.getByTestId('bu-pozzetto-count')).toBeInTheDocument());
+
+    mockExec.mockResolvedValue({
+      ...meldPhaseState,
+      players: [basePlayers[0], { ...basePlayers[1], tookPozzetto: true }],
+    });
+    fireEvent.click(screen.getByRole('button', { name: '山札から引く' }));
+    // ja CPU label is "CPU 1" → banner interpolates the CPU name, not "あなた".
+    await waitFor(() => expect(screen.getByTestId('bu-pozzetto-banner')).toHaveTextContent('CPU 1'));
+    expect(playSoundMock).toHaveBeenCalledWith('chipClick');
+  });
+
   it('pulses a round-score cell when that score changes', async () => {
     mockExec.mockResolvedValue(drawPhaseState); // roundScore 0
     renderWithProviders(<BurracoPage />);

--- a/frontend/src/pages/BurracoPage.test.tsx
+++ b/frontend/src/pages/BurracoPage.test.tsx
@@ -11,6 +11,15 @@ vi.mock('../api/gameApi', () => ({
 }));
 const mockExec = vi.mocked(burracoApi.exec);
 
+const playSoundMock = vi.fn();
+vi.mock('../providers/SoundProvider', async () => {
+  const actual = await vi.importActual<typeof import('../providers/SoundProvider')>('../providers/SoundProvider');
+  return {
+    ...actual,
+    useSound: () => ({ playSound: playSoundMock, muted: false, toggleMute: vi.fn() }),
+  };
+});
+
 const basePlayers: BurracoPlayerData[] = [
   {
     id: 0,
@@ -241,6 +250,36 @@ describe('BurracoPage', () => {
     expect(screen.getByTestId('ca-draw-discard-reason')).toHaveTextContent(
       'フリーズ中はワイルドカードでの代用ができません',
     );
+  });
+
+  it('shows a banner and plays a sound when a player takes the pozzetto', async () => {
+    mockExec.mockResolvedValue(drawPhaseState); // tookPozzetto false for everyone
+    renderWithProviders(<BurracoPage />);
+    await waitFor(() => expect(screen.getByTestId('bu-pozzetto-count')).toBeInTheDocument());
+    expect(screen.queryByTestId('bu-pozzetto-banner')).not.toBeInTheDocument();
+
+    // The next fetch reports the human took the pozzetto (false → true).
+    mockExec.mockResolvedValue({
+      ...meldPhaseState,
+      players: [{ ...basePlayers[0], tookPozzetto: true }, basePlayers[1]],
+    });
+    fireEvent.click(screen.getByRole('button', { name: '山札から引く' }));
+    await waitFor(() => expect(screen.getByTestId('bu-pozzetto-banner')).toBeInTheDocument());
+    expect(playSoundMock).toHaveBeenCalledWith('chipClick');
+  });
+
+  it('pulses a round-score cell when that score changes', async () => {
+    mockExec.mockResolvedValue(drawPhaseState); // roundScore 0
+    renderWithProviders(<BurracoPage />);
+    await waitFor(() => expect(screen.getByTestId('bu-round-score-0')).toBeInTheDocument());
+    expect(screen.getByTestId('bu-round-score-0')).not.toHaveClass('motion-safe:animate-pulse');
+
+    mockExec.mockResolvedValue({
+      ...roundEndState,
+      players: [{ ...basePlayers[0], roundScore: 120 }, basePlayers[1]],
+    });
+    fireEvent.click(screen.getByRole('button', { name: '山札から引く' }));
+    await waitFor(() => expect(screen.getByTestId('bu-round-score-0')).toHaveClass('motion-safe:animate-pulse'));
   });
 
   afterEach(() => {

--- a/frontend/src/pages/BurracoPage.tsx
+++ b/frontend/src/pages/BurracoPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { burracoApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -133,6 +133,47 @@ function BurracoPageContent() {
   const isHumanTurn =
     (isDrawPhase || isMeldPhase || isDiscardPhase) && state?.players[state.currentPlayerIdx]?.isHuman === true;
 
+  // Transient feedback when a player grabs the pozzetto (a pivotal Burraco moment)
+  // and a one-shot pulse on round-score cells that just changed.
+  const [pozzettoBanner, setPozzettoBanner] = useState<string | null>(null);
+  const [pulsingScoreIds, setPulsingScoreIds] = useState<Set<number>>(new Set());
+  const prevPozzettoRef = useRef<boolean[]>([]);
+  const prevScoresRef = useRef<number[]>([]);
+  const bannerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pulseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      clearTimeout(bannerTimerRef.current ?? undefined);
+      clearTimeout(pulseTimerRef.current ?? undefined);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!state) return;
+    const prevPozzetto = prevPozzettoRef.current;
+    const prevScores = prevScoresRef.current;
+    const taker = state.players.find((p, i) => p.tookPozzetto && prevPozzetto[i] === false);
+    const changedScoreIds = state.players
+      .filter((p, i) => prevScores[i] !== undefined && prevScores[i] !== p.roundScore)
+      .map((p) => p.id);
+    prevPozzettoRef.current = state.players.map((p) => p.tookPozzetto);
+    prevScoresRef.current = state.players.map((p) => p.roundScore);
+
+    if (taker) {
+      setPozzettoBanner(taker.isHuman ? tc('player.you') : tc('player.cpu', { id: taker.id }));
+      playSound('chipClick');
+      clearTimeout(bannerTimerRef.current ?? undefined);
+      bannerTimerRef.current = setTimeout(() => setPozzettoBanner(null), 2000);
+    }
+    if (changedScoreIds.length > 0) {
+      setPulsingScoreIds(new Set(changedScoreIds));
+      clearTimeout(pulseTimerRef.current ?? undefined);
+      pulseTimerRef.current = setTimeout(() => setPulsingScoreIds(new Set()), 1000);
+    }
+  }, [state, tc, playSound]);
+
   const kbdConfirmAction = useCallback(() => {
     if (isDiscardPhase) handleDiscard();
     else if (isMeldPhase) handleMeldSelected();
@@ -210,6 +251,16 @@ function BurracoPageContent() {
           />
 
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>
+            {pozzettoBanner && (
+              <div
+                role="status"
+                aria-live="polite"
+                data-testid="bu-pozzetto-banner"
+                className="mb-2 text-center text-ds-info font-bold motion-safe:animate-pulse"
+              >
+                {t('pozzettoTakenBanner', { player: pozzettoBanner })}
+              </div>
+            )}
             <div className="text-ds-text-primary text-center mb-2">
               <span className="mr-4">{t('round', { n: state.roundNumber })}</span>
               <span>
@@ -307,7 +358,12 @@ function BurracoPageContent() {
                       {state.players.map((p) => (
                         <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
                           <td>{playerName(p.id, p.isHuman)}</td>
-                          <td className="text-center">{p.roundScore}</td>
+                          <td
+                            className={`text-center ${pulsingScoreIds.has(p.id) ? 'motion-safe:animate-pulse text-ds-info' : ''}`}
+                            data-testid={`bu-round-score-${p.id.toString()}`}
+                          >
+                            {p.roundScore}
+                          </td>
                           <td className="text-center">{p.cumulativeScore}</td>
                         </tr>
                       ))}

--- a/frontend/src/pages/BurracoPage.tsx
+++ b/frontend/src/pages/BurracoPage.tsx
@@ -254,7 +254,6 @@ function BurracoPageContent() {
             {pozzettoBanner && (
               <div
                 role="status"
-                aria-live="polite"
                 data-testid="bu-pozzetto-banner"
                 className="mb-2 text-center text-ds-info font-bold motion-safe:animate-pulse"
               >


### PR DESCRIPTION
## Summary

Implements #2283. Grabbing the pozzetto (reserve pile) is one of the most decisive moments in Burraco, but `BurracoPage` only showed a static `[Pozzetto taken]` badge with no moment-of-pickup feedback, and round-score changes in the always-on table were easy to miss.

- A `useEffect` detects any player's `tookPozzetto` flipping **false → true** and shows a 2-second `role=status` banner ("<player> took the pozzetto!") plus `playSound('chipClick')`.
- Round-score cells `motion-safe:animate-pulse` for 1 second whenever their value changes.
- Both timers are cleared on unmount; refs track the previous per-player pozzetto/score so the first render never false-fires.
- New `pozzettoTakenBanner` i18n key in both locales (parity preserved).

## Test plan
- [x] `bun run test -- --run src/pages/BurracoPage.test.tsx` (19 passed) — banner appears + `chipClick` fires on a false→true transition; a round-score cell gains the pulse class when its score changes
- [x] `bun run check` (biome + design-tokens OK)
- [ ] CI: build (tsc) + E2E + codecov + i18n parity

Closes #2283