### PR TITLE
feat(acesup): drag a movable top card onto an empty column to move it

### DIFF
--- a/frontend/src/pages/AcesUpPage.test.tsx
+++ b/frontend/src/pages/AcesUpPage.test.tsx
@@ -132,6 +132,35 @@ describe('AcesUpPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('move', 1));
   });
 
+  it('dragging a movable top card onto an empty column dispatches move', async () => {
+    const buildDataTransfer = () => {
+      const store: Record<string, string> = {};
+      return {
+        setData: (type: string, val: string) => {
+          store[type] = val;
+        },
+        getData: (type: string) => store[type] ?? '',
+        effectAllowed: '',
+        dropEffect: '',
+      };
+    };
+
+    renderWithProviders(<AcesUpPage />);
+    await waitFor(() => expect(screen.getByTestId('acesup-empty-2')).toBeInTheDocument());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(playingState);
+
+    // Drag col1's movable 9♠ (the only movable top card) onto the empty col2.
+    const dataTransfer = buildDataTransfer();
+    fireEvent.dragStart(screen.getByRole('button', { name: '♠ 9' }), { dataTransfer });
+    const dropZone = screen.getByTestId('acesup-empty-2');
+    fireEvent.dragOver(dropZone, { dataTransfer });
+    fireEvent.drop(dropZone, { dataTransfer });
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('move', 1));
+  });
+
   it('clicking giveup button dispatches giveup', async () => {
     renderWithProviders(<AcesUpPage />);
     await waitFor(() => expect(screen.getByText(/山札/)).toBeInTheDocument());

--- a/frontend/src/pages/AcesUpPage.tsx
+++ b/frontend/src/pages/AcesUpPage.tsx
@@ -179,6 +179,8 @@ function AcesUpPageContent() {
                 const col = state.columns[colIdx] ?? [];
                 const topIdx = col.length - 1;
                 const topCard = col[topIdx];
+                const columnZone = { zone: 'column', col: colIdx };
+                const isDropping = dnd.isDropTarget(columnZone);
                 const isHinted = (hint?.type === 'remove' || hint?.type === 'move') && hint.col === colIdx;
                 const stackHeight =
                   col.length === 0 ? cardHeight : cardHeight + (col.length - 1) * (cardHeight - rowOverlap);
@@ -187,18 +189,16 @@ function AcesUpPageContent() {
                     <div className="relative" style={{ width: cardWidth + cardGap, height: stackHeight }}>
                       {col.length === 0 ? (
                         <DropZone
-                          isDropTarget={dnd.isDropTarget({ zone: 'column', col: colIdx })}
-                          onDragOver={dnd.handleDragOver({ zone: 'column', col: colIdx })}
-                          onDrop={dnd.handleDrop({ zone: 'column', col: colIdx })}
+                          isDropTarget={isDropping}
+                          onDragOver={dnd.handleDragOver(columnZone)}
+                          onDrop={dnd.handleDrop(columnZone)}
                           onDragLeave={dnd.handleDragLeave}
                         >
                           <div
                             data-testid={`acesup-empty-${colIdx.toString()}`}
                             style={{ width: cardWidth, height: cardHeight }}
                             className={`rounded border-2 border-dashed ${
-                              dnd.isDropTarget({ zone: 'column', col: colIdx }) || isHinted
-                                ? 'border-ds-warning'
-                                : 'border-white/30'
+                              isDropping || isHinted ? 'border-ds-warning' : 'border-white/30'
                             } text-game-text-muted text-xs flex items-center justify-center`}
                           >
                             {t('empty')}
@@ -221,12 +221,12 @@ function AcesUpPageContent() {
                                   disabled={!isPlaying || loading || !c.removable}
                                   aria-label={cardAlt(c.card)}
                                   draggable={isPlaying && !loading && c.movable === true}
-                                  onDragStart={dnd.handleDragStart({ zone: 'column', col: colIdx })}
+                                  onDragStart={dnd.handleDragStart(columnZone)}
                                   onDragEnd={dnd.handleDragEnd}
                                   className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${
                                     isHinted ? 'ring-2 ring-ds-warning' : ''
                                   } ${!c.removable ? 'opacity-90' : ''} ${
-                                    dnd.isDragSource({ zone: 'column', col: colIdx }) ? 'opacity-50' : ''
+                                    dnd.isDragSource(columnZone) ? 'opacity-50' : ''
                                   }`}
                                 >
                                   <AnimatedCard card={c.card} width={cardWidth} />

--- a/frontend/src/pages/AcesUpPage.tsx
+++ b/frontend/src/pages/AcesUpPage.tsx
@@ -4,6 +4,7 @@ import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
+import { DropZone } from '../components/DropZone';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
@@ -21,6 +22,7 @@ import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -118,6 +120,15 @@ function AcesUpPageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
+  // Drag a movable top card onto an empty column to move it (the "Move [n]" buttons
+  // remain as keyboard/tap-friendly fallbacks; D&D is additive, never required).
+  // Declared before the early return so the hook order stays stable.
+  const dnd = useSolitaireDragDrop<{ zone: string; col: number }>({
+    onMove: (source) => handleMove(source.col),
+    isPlaying: state?.phase === AcesUpPhase.PLAYING,
+    disabled: loading,
+  });
+
   if (!state)
     return <GameSkeleton gameKey="acesup" layout={{ kind: 'tiered-rows', rows: [4, 4, 4, 4], columns: true }} />;
 
@@ -175,14 +186,24 @@ function AcesUpPageContent() {
                   <div key={`col-${colIdx.toString()}`} className="flex flex-col items-center">
                     <div className="relative" style={{ width: cardWidth + cardGap, height: stackHeight }}>
                       {col.length === 0 ? (
-                        <div
-                          style={{ width: cardWidth, height: cardHeight }}
-                          className={`rounded border-2 border-dashed ${
-                            isHinted ? 'border-ds-warning' : 'border-white/30'
-                          } text-game-text-muted text-xs flex items-center justify-center`}
+                        <DropZone
+                          isDropTarget={dnd.isDropTarget({ zone: 'column', col: colIdx })}
+                          onDragOver={dnd.handleDragOver({ zone: 'column', col: colIdx })}
+                          onDrop={dnd.handleDrop({ zone: 'column', col: colIdx })}
+                          onDragLeave={dnd.handleDragLeave}
                         >
-                          {t('empty')}
-                        </div>
+                          <div
+                            data-testid={`acesup-empty-${colIdx.toString()}`}
+                            style={{ width: cardWidth, height: cardHeight }}
+                            className={`rounded border-2 border-dashed ${
+                              dnd.isDropTarget({ zone: 'column', col: colIdx }) || isHinted
+                                ? 'border-ds-warning'
+                                : 'border-white/30'
+                            } text-game-text-muted text-xs flex items-center justify-center`}
+                          >
+                            {t('empty')}
+                          </div>
+                        </DropZone>
                       ) : (
                         col.map((c, rowIdx) => {
                           const top = rowIdx * (cardHeight - rowOverlap);
@@ -199,9 +220,14 @@ function AcesUpPageContent() {
                                   onClick={() => handleRemove(colIdx)}
                                   disabled={!isPlaying || loading || !c.removable}
                                   aria-label={cardAlt(c.card)}
+                                  draggable={isPlaying && !loading && c.movable === true}
+                                  onDragStart={dnd.handleDragStart({ zone: 'column', col: colIdx })}
+                                  onDragEnd={dnd.handleDragEnd}
                                   className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${
                                     isHinted ? 'ring-2 ring-ds-warning' : ''
-                                  } ${!c.removable ? 'opacity-90' : ''}`}
+                                  } ${!c.removable ? 'opacity-90' : ''} ${
+                                    dnd.isDragSource({ zone: 'column', col: colIdx }) ? 'opacity-50' : ''
+                                  }`}
                                 >
                                   <AnimatedCard card={c.card} width={cardWidth} />
                                 </button>


### PR DESCRIPTION
## Summary

Implements #2275. In Aces Up the per-column "Move [n]" buttons move a column's top card to an empty column, but the button carries no sense of *which* empty column it lands in — confusing when 2+ columns are empty, and inconsistent with the drag interaction other solitaire games offer.

- Wired up `useSolitaireDragDrop`: a **movable** column-top card is now `draggable`, and each **empty** column is a `DropZone` that highlights with `border-ds-warning` while a drag is over it. Dropping dispatches `handleMove(sourceCol)`.
- The existing `Move [n]` buttons are unchanged and remain the keyboard/tap-friendly path — D&D is purely additive and never forced on touch.
- The `dnd` hook is declared before the `!state` early return to keep hook order stable; the `DropZone` wrapper keeps the drop target accessible (no interactive-`div` lint).

## Test plan
- [x] `bun run test -- --run src/pages/AcesUpPage.test.tsx` (19 passed) — dragging the movable 9♠ from col1 onto the empty col2 dispatches `move 1`; existing Move-button test still passes
- [x] `bun run check` (biome + design-tokens OK)
- [ ] CI: build (tsc) + E2E + codecov

Closes #2275