### PR TITLE
feat(bakersdozen): horizontally scroll the 13-column tableau on mobile

### DIFF
--- a/frontend/src/pages/BakersDozenPage.test.tsx
+++ b/frontend/src/pages/BakersDozenPage.test.tsx
@@ -202,6 +202,24 @@ describe('BakersDozenPage', () => {
     await waitFor(() => expect(sourceBtn).toHaveAttribute('aria-pressed', 'true'));
   });
 
+  it('makes the tableau horizontally scrollable so 13 columns stay legible', async () => {
+    mockExec.mockResolvedValue(playingState);
+    const { container } = renderWithProviders(<BakersDozenPage />);
+    await waitFor(() => expect(container.querySelector('[data-tutorial="bd-tableau"]')).toBeInTheDocument());
+    expect(container.querySelector('[data-tutorial="bd-tableau"]')).toHaveClass('overflow-x-auto');
+  });
+
+  it('scrolls the selected tableau column into view', async () => {
+    const scrollIntoView = vi.fn();
+    // jsdom does not implement scrollIntoView; provide a spy for this test.
+    Element.prototype.scrollIntoView = scrollIntoView;
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<BakersDozenPage />);
+    const sourceBtn = await screen.findByRole('button', { name: '♠ 5' });
+    fireEvent.click(sourceBtn);
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
+  });
+
   it('forwards reset commands to the API on initial load', async () => {
     mockExec.mockResolvedValue(playingState);
     renderWithProviders(<BakersDozenPage />);

--- a/frontend/src/pages/BakersDozenPage.test.tsx
+++ b/frontend/src/pages/BakersDozenPage.test.tsx
@@ -209,15 +209,25 @@ describe('BakersDozenPage', () => {
     expect(container.querySelector('[data-tutorial="bd-tableau"]')).toHaveClass('overflow-x-auto');
   });
 
-  it('scrolls the selected tableau column into view', async () => {
+  it('centers the selected tableau column in view on mobile', async () => {
+    const originalScrollIntoView = Element.prototype.scrollIntoView;
+    const originalWidth = window.innerWidth;
     const scrollIntoView = vi.fn();
-    // jsdom does not implement scrollIntoView; provide a spy for this test.
+    // jsdom lacks scrollIntoView; spy on it and force a mobile viewport so the effect runs.
     Element.prototype.scrollIntoView = scrollIntoView;
-    mockExec.mockResolvedValue(playingState);
-    renderWithProviders(<BakersDozenPage />);
-    const sourceBtn = await screen.findByRole('button', { name: '♠ 5' });
-    fireEvent.click(sourceBtn);
-    await waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
+    window.innerWidth = 375;
+    window.dispatchEvent(new Event('resize'));
+    try {
+      mockExec.mockResolvedValue(playingState);
+      renderWithProviders(<BakersDozenPage />);
+      const sourceBtn = await screen.findByRole('button', { name: '♠ 5' });
+      fireEvent.click(sourceBtn);
+      await waitFor(() => expect(scrollIntoView).toHaveBeenCalledWith(expect.objectContaining({ inline: 'center' })));
+    } finally {
+      Element.prototype.scrollIntoView = originalScrollIntoView;
+      window.innerWidth = originalWidth;
+      window.dispatchEvent(new Event('resize'));
+    }
   });
 
   it('forwards reset commands to the API on initial load', async () => {

--- a/frontend/src/pages/BakersDozenPage.tsx
+++ b/frontend/src/pages/BakersDozenPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { BakersDozenMoveZone, bakersDozenApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -129,11 +129,23 @@ function BakersDozenPageContent() {
     const gapPx = 4;
     const cols = 13;
     const colW = Math.floor((windowWidth - padX - (cols - 1) * gapPx) / cols);
-    const cw = Math.min(Math.max(colW, 22), cardWidth);
+    // Floor at 32px so suits/ranks stay legible; the tableau scrolls horizontally
+    // when 13 columns no longer fit (e.g. a 375px portrait phone).
+    const cw = Math.min(Math.max(colW, 32), cardWidth);
     const ch = Math.round(cw * 1.5);
     const co = Math.round(cw * 0.48);
     return { cw, ch, co };
   }, [isMobile, windowWidth, cardWidth, cardHeight, cardOverlap]);
+
+  // Keep the selected tableau column centred in the horizontally-scrolling mobile layout.
+  // Declared before any early return so hook order stays stable.
+  const selectedColRef = useRef<HTMLDivElement | null>(null);
+  const selectedTableauCol = selectedSource?.zone === 'tableau' ? selectedSource.col : undefined;
+  useEffect(() => {
+    if (selectedTableauCol == null) return;
+    // Optional-call: scrollIntoView is unavailable in jsdom.
+    selectedColRef.current?.scrollIntoView?.({ inline: 'center', block: 'nearest', behavior: 'smooth' });
+  }, [selectedTableauCol]);
 
   const isPlayingForKbd = state?.phase === BakersDozenPhase.PLAYING;
 
@@ -262,11 +274,19 @@ function BakersDozenPageContent() {
             </div>
 
             {/* Tableau */}
-            <div className="flex gap-1 sm:gap-2 mb-3" data-tutorial="bd-tableau">
+            <div className="flex gap-1 sm:gap-2 mb-3 overflow-x-auto" data-tutorial="bd-tableau">
               {state.tableau.map((col, colIdx) => {
                 const tableauColZone: BakersDozenMoveZone = { zone: 'tableau', col: colIdx };
+                const isColumnSelected = selectedTableauCol === colIdx;
                 return (
-                  <div key={`col-${colIdx.toString()}`} className="flex-1 min-w-0">
+                  <div
+                    key={`col-${colIdx.toString()}`}
+                    ref={isColumnSelected ? selectedColRef : null}
+                    // On mobile keep each column at its computed width and let the row scroll;
+                    // on desktop the columns flex to fill the available width as before.
+                    className={isMobile ? 'shrink-0' : 'flex-1 min-w-0'}
+                    style={isMobile ? { width: bd.cw } : undefined}
+                  >
                     <DropZone
                       isDropTarget={dnd.isDropTarget(tableauColZone)}
                       onDragOver={dnd.handleDragOver(tableauColZone)}

--- a/frontend/src/pages/BakersDozenPage.tsx
+++ b/frontend/src/pages/BakersDozenPage.tsx
@@ -142,10 +142,11 @@ function BakersDozenPageContent() {
   const selectedColRef = useRef<HTMLDivElement | null>(null);
   const selectedTableauCol = selectedSource?.zone === 'tableau' ? selectedSource.col : undefined;
   useEffect(() => {
-    if (selectedTableauCol == null) return;
+    // Only relevant on the horizontally-scrolling mobile layout; a no-op on desktop.
+    if (selectedTableauCol == null || !isMobile) return;
     // Optional-call: scrollIntoView is unavailable in jsdom.
     selectedColRef.current?.scrollIntoView?.({ inline: 'center', block: 'nearest', behavior: 'smooth' });
-  }, [selectedTableauCol]);
+  }, [selectedTableauCol, isMobile]);
 
   const isPlayingForKbd = state?.phase === BakersDozenPhase.PLAYING;
 


### PR DESCRIPTION
## Summary

Implements #2242. Baker's Dozen has 13 tableau columns; to fit them on a 375px portrait phone the card width shrank to ~22px, leaving suits and ranks unreadable.

- Floor the mobile card width at **32px** (was 22px).
- Each column now keeps that width (`shrink-0`) inside an **`overflow-x-auto`** tableau row, so the columns stay legible and the row scrolls horizontally when they don't all fit. `useSolitaireDragDrop` already works inside a scroll container.
- The selected tableau column is `scrollIntoView`-centered (optional-called since jsdom lacks it).
- Desktop/landscape keep the existing `flex-1` fill-the-width layout unchanged.

## Test plan
- [x] `bun run test -- --run src/pages/BakersDozenPage.test.tsx` (16 passed) — tableau row has `overflow-x-auto`; selecting a column triggers `scrollIntoView`
- [x] `bun run check` (biome + design-tokens OK)
- [ ] CI: build (tsc) + E2E + codecov

Closes #2242