### PR TITLE
feat(egyptianratscrew): show why the pile is slappable (pair/sandwich badge)

### DIFF
--- a/frontend/src/pages/EgyptianRatscrewPage.test.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.test.tsx
@@ -4,7 +4,7 @@ import { egyptianRatscrewApi } from '../api/gameApi';
 import { useCliMode } from '../hooks/useCliMode';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { EgyptianRatscrewResponse } from '../types/card';
-import { EgyptianRatscrewPhase } from '../types/phases';
+import { EgyptianRatscrewPhase, EgyptianRatscrewSlapReason } from '../types/phases';
 import { EgyptianRatscrewPage } from './EgyptianRatscrewPage';
 
 vi.mock('../hooks/useCliMode', () => ({
@@ -164,13 +164,13 @@ describe('EgyptianRatscrewPage', () => {
   });
 
   it('shows a pair slap-reason badge while slappable', async () => {
-    mockExec.mockResolvedValueOnce({ ...slappableState, lastSlapReason: 1 }); // 1 = PAIR
+    mockExec.mockResolvedValueOnce({ ...slappableState, lastSlapReason: EgyptianRatscrewSlapReason.PAIR });
     renderWithProviders(<EgyptianRatscrewPage />);
     await waitFor(() => expect(screen.getByTestId('er-slap-reason')).toHaveTextContent('ペア'));
   });
 
   it('labels the slap-reason badge as a sandwich when applicable', async () => {
-    mockExec.mockResolvedValueOnce({ ...slappableState, lastSlapReason: 2 }); // 2 = SANDWICH
+    mockExec.mockResolvedValueOnce({ ...slappableState, lastSlapReason: EgyptianRatscrewSlapReason.SANDWICH });
     renderWithProviders(<EgyptianRatscrewPage />);
     await waitFor(() => expect(screen.getByTestId('er-slap-reason')).toHaveTextContent('サンドイッチ'));
   });

--- a/frontend/src/pages/EgyptianRatscrewPage.test.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.test.tsx
@@ -163,6 +163,25 @@ describe('EgyptianRatscrewPage', () => {
     expect(slap.className).toMatch(/animate-pulse/);
   });
 
+  it('shows a pair slap-reason badge while slappable', async () => {
+    mockExec.mockResolvedValueOnce({ ...slappableState, lastSlapReason: 1 }); // 1 = PAIR
+    renderWithProviders(<EgyptianRatscrewPage />);
+    await waitFor(() => expect(screen.getByTestId('er-slap-reason')).toHaveTextContent('ペア'));
+  });
+
+  it('labels the slap-reason badge as a sandwich when applicable', async () => {
+    mockExec.mockResolvedValueOnce({ ...slappableState, lastSlapReason: 2 }); // 2 = SANDWICH
+    renderWithProviders(<EgyptianRatscrewPage />);
+    await waitFor(() => expect(screen.getByTestId('er-slap-reason')).toHaveTextContent('サンドイッチ'));
+  });
+
+  it('does not show the slap-reason badge when the pile is not slappable', async () => {
+    mockExec.mockResolvedValueOnce(baseState); // isSlappable false, lastSlapReason 0
+    renderWithProviders(<EgyptianRatscrewPage />);
+    await waitFor(() => expect(screen.getByTestId('slap-button')).toBeInTheDocument());
+    expect(screen.queryByTestId('er-slap-reason')).not.toBeInTheDocument();
+  });
+
   it('renders chance remaining indicator on face-card chance battle', async () => {
     mockExec.mockResolvedValueOnce(chanceState);
     renderWithProviders(<EgyptianRatscrewPage />);

--- a/frontend/src/pages/EgyptianRatscrewPage.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.tsx
@@ -263,6 +263,16 @@ function EgyptianRatscrewPageContent() {
                     {t('egyptianratscrew.slappable')}
                   </div>
                 )}
+                {state.isSlappable && state.lastSlapReason !== EgyptianRatscrewSlapReason.NONE && (
+                  <div
+                    data-testid="er-slap-reason"
+                    className="mt-1 inline-flex items-center gap-1 rounded-full bg-ds-warning/20 px-2 py-0.5 text-xs font-medium text-ds-warning"
+                  >
+                    {state.lastSlapReason === EgyptianRatscrewSlapReason.PAIR
+                      ? `👯 ${t('egyptianratscrew.slapReason.pair')}`
+                      : `🥪 ${t('egyptianratscrew.slapReason.sandwich')}`}
+                  </div>
+                )}
               </div>
             </div>
 


### PR DESCRIPTION
## Summary

Implements #2241. Egyptian Rat Screw has **two** slap conditions (pair and sandwich), but the arena only showed a generic "slappable!" callout — beginners (who often forget the sandwich rule) couldn't tell *why* the pile is slappable.

- Added a small badge in the arena (`👯 Pair` / `🥪 Sandwich`) driven by `state.lastSlapReason` (`PAIR=1` / `SANDWICH=2`), shown only while `isSlappable` and `lastSlapReason !== NONE`, so it disappears as soon as the pile stops being slappable.
- Reuses the existing `egyptianratscrew.slapReason.pair`/`.sandwich` i18n keys (already present and in ja/en parity) — no locale changes needed; emoji are added in the component.

## Test plan
- [x] `bun run test -- --run src/pages/EgyptianRatscrewPage.test.tsx` (17 passed) — pair badge, sandwich badge, and absent-when-not-slappable
- [x] `bun run check` (biome + design-tokens OK)
- [ ] CI: build (tsc) + E2E + codecov

Closes #2241