### PR TITLE
feat(nertz): show per-player score as progress bars toward the target

### DIFF
--- a/frontend/src/i18n/locales/en/nertz.json
+++ b/frontend/src/i18n/locales/en/nertz.json
@@ -4,6 +4,7 @@
     "round": "Round",
     "moveCount": "Moves",
     "score": "Score",
+    "scoreBarAria": "{{player}}: {{score}} of {{target}}",
     "you": "You",
     "cpu": "CPU",
     "nertz": "Nertz pile",

--- a/frontend/src/i18n/locales/ja/nertz.json
+++ b/frontend/src/i18n/locales/ja/nertz.json
@@ -4,6 +4,7 @@
     "round": "ラウンド",
     "moveCount": "手数",
     "score": "スコア",
+    "scoreBarAria": "{{player}}: {{score}} / {{target}}点",
     "you": "あなた",
     "cpu": "CPU",
     "nertz": "ナッツ",

--- a/frontend/src/pages/NertzPage.test.tsx
+++ b/frontend/src/pages/NertzPage.test.tsx
@@ -152,6 +152,20 @@ describe('NertzPage', () => {
     expect(await screen.findByTestId('nertz-scorebar-0')).toHaveStyle({ width: '0%' });
   });
 
+  it('renders a 0% bar when targetScore is not positive', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      targetScore: 0, // guard against divide-by-zero → 0% width
+      players: [{ ...playingState.players[0], score: 10 }, playingState.players[1]],
+    });
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/nertz']}>
+        <NertzPage />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByTestId('nertz-scorebar-0')).toHaveStyle({ width: '0%' });
+  });
+
   it('caps the score bar at 100% when the score exceeds the target', async () => {
     mockExec.mockResolvedValue({
       ...playingState,

--- a/frontend/src/pages/NertzPage.test.tsx
+++ b/frontend/src/pages/NertzPage.test.tsx
@@ -152,6 +152,19 @@ describe('NertzPage', () => {
     expect(await screen.findByTestId('nertz-scorebar-0')).toHaveStyle({ width: '0%' });
   });
 
+  it('caps the score bar at 100% when the score exceeds the target', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      players: [{ ...playingState.players[0], score: 150 }, playingState.players[1]], // > targetScore 100
+    });
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/nertz']}>
+        <NertzPage />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByTestId('nertz-scorebar-0')).toHaveStyle({ width: '100%' });
+  });
+
   it('clicking the stock dispatches a draw command', async () => {
     renderWithProviders(
       <MemoryRouter initialEntries={['/nertz']}>

--- a/frontend/src/pages/NertzPage.test.tsx
+++ b/frontend/src/pages/NertzPage.test.tsx
@@ -116,6 +116,42 @@ describe('NertzPage', () => {
     expect(screen.getByRole('button', { name: '35' })).toBeInTheDocument();
   });
 
+  it('renders per-player score progress bars scaled to the target score', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      players: [
+        { ...playingState.players[0], score: 50 }, // 50 / 100 = 50%
+        { ...playingState.players[1], score: 25 }, // 25 / 100 = 25%
+      ],
+    });
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/nertz']}>
+        <NertzPage />
+      </MemoryRouter>,
+    );
+    const humanBar = await screen.findByTestId('nertz-scorebar-0');
+    const cpuBar = screen.getByTestId('nertz-scorebar-1');
+    expect(humanBar).toHaveStyle({ width: '50%' });
+    expect(cpuBar).toHaveStyle({ width: '25%' });
+    // Human bar is green, CPU bar is the warning accent; both animate only when motion is allowed.
+    expect(humanBar.className).toContain('bg-ds-success');
+    expect(cpuBar.className).toContain('bg-ds-warning');
+    expect(humanBar.className).toContain('motion-safe:transition-[width]');
+  });
+
+  it('clamps the score bar to 0% for negative scores', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      players: [{ ...playingState.players[0], score: -20 }, playingState.players[1]],
+    });
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/nertz']}>
+        <NertzPage />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByTestId('nertz-scorebar-0')).toHaveStyle({ width: '0%' });
+  });
+
   it('clicking the stock dispatches a draw command', async () => {
     renderWithProviders(
       <MemoryRouter initialEntries={['/nertz']}>

--- a/frontend/src/pages/NertzPage.tsx
+++ b/frontend/src/pages/NertzPage.tsx
@@ -353,7 +353,9 @@ function NertzPageContent() {
                         role="progressbar"
                         aria-valuemin={0}
                         aria-valuemax={state.targetScore}
-                        aria-valuenow={p.score}
+                        // WAI-ARIA requires aria-valuenow within [min, max]; clamp it
+                        // (the raw score is still shown in the numeric label).
+                        aria-valuenow={Math.max(0, Math.min(p.score, state.targetScore))}
                         aria-label={t('labels.scoreBarAria', {
                           player: label,
                           score: p.score,

--- a/frontend/src/pages/NertzPage.tsx
+++ b/frontend/src/pages/NertzPage.tsx
@@ -331,18 +331,48 @@ function NertzPageContent() {
       ) : (
         <>
           <div className="flex-1 overflow-y-auto px-3 py-2 space-y-4">
-            <div className="bg-black/30 text-ds-text-primary p-3 rounded text-sm flex flex-wrap gap-x-4 gap-y-1">
-              <span>
-                {t('labels.round')}: {state.roundNumber}
-              </span>
-              <span>
-                {t('labels.moveCount')}: {state.moveCount}
-              </span>
-              {state.players.map((p, i) => (
-                <span key={`scoreline-${i}`}>
-                  {p.isHuman ? t('labels.you') : `${t('labels.cpu')}${i}`}: {p.score} ({p.nertzSize})
+            <div className="bg-black/30 text-ds-text-primary p-3 rounded text-sm">
+              <div className="flex flex-wrap gap-x-4 gap-y-1">
+                <span>
+                  {t('labels.round')}: {state.roundNumber}
                 </span>
-              ))}
+                <span>
+                  {t('labels.moveCount')}: {state.moveCount}
+                </span>
+              </div>
+              <div className="mt-2 space-y-1">
+                {state.players.map((p, i) => {
+                  const label = p.isHuman ? t('labels.you') : `${t('labels.cpu')}${i}`;
+                  const pct =
+                    state.targetScore > 0 ? Math.max(0, Math.min(100, (p.score / state.targetScore) * 100)) : 0;
+                  return (
+                    <div key={`scorebar-${i}`} className="flex items-center gap-2 text-xs">
+                      <span className="w-14 shrink-0">{label}</span>
+                      <div
+                        className="relative h-3 flex-1 overflow-hidden rounded bg-black/40"
+                        role="progressbar"
+                        aria-valuemin={0}
+                        aria-valuemax={state.targetScore}
+                        aria-valuenow={p.score}
+                        aria-label={t('labels.scoreBarAria', {
+                          player: label,
+                          score: p.score,
+                          target: state.targetScore,
+                        })}
+                      >
+                        <div
+                          data-testid={`nertz-scorebar-${i.toString()}`}
+                          className={`h-full ${p.isHuman ? 'bg-ds-success' : 'bg-ds-warning'} motion-safe:transition-[width] motion-safe:duration-300`}
+                          style={{ width: `${pct.toString()}%` }}
+                        />
+                      </div>
+                      <span className="w-12 shrink-0 text-right tabular-nums">
+                        {p.score} ({p.nertzSize})
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
             </div>
 
             <GameMessageBox


### PR DESCRIPTION
## Summary

Implements #2239. Nerts is a real-time race where everyone plays onto shared foundations, but scores were shown as a single text line (`You: X (Y)`), giving no visual sense of who's ahead.

- Replaced the per-player score spans with horizontal **progress bars**: width = `score / targetScore`, **human = green** (`bg-ds-success`), **CPU = orange** (`bg-ds-warning`), with the numeric score kept to the right.
- Bars animate on change via `motion-safe:transition-[width]` (instant under `prefers-reduced-motion`).
- Each bar is a `role=progressbar` with `aria-valuenow`/`aria-valuemax` and an `aria-label` so screen readers get the value.
- Negative scores clamp to 0%.
- New `labels.scoreBarAria` i18n key in both locales (parity preserved).

## Test plan
- [x] `bun run test -- --run src/pages/NertzPage.test.tsx` (15 passed) — bars scale to 50%/25% for scores 50/25 with the right colors + motion-safe class; negative scores clamp to 0%
- [x] `bun run check` (biome + design-tokens OK)
- [ ] CI: build (tsc) + E2E + codecov + i18n parity

Closes #2239