### PR TITLE
feat(dragontiger): break down the END-phase payout (bet type, odds, profit)

### DIFF
--- a/frontend/src/i18n/locales/en/dragontiger.json
+++ b/frontend/src/i18n/locales/en/dragontiger.json
@@ -32,8 +32,7 @@
     "tie": "Tie",
     "oddsBadge": "{{type}} ×{{odds}}",
     "win": "Win +{{amount}}",
-    "loss": "Loss {{amount}}",
-    "even": "No change"
+    "loss": "Loss -{{amount}}"
   },
   "tutorial": {
     "betButtons": "Pick Dragon, Tiger, or Tie and place your bet",

--- a/frontend/src/i18n/locales/en/dragontiger.json
+++ b/frontend/src/i18n/locales/en/dragontiger.json
@@ -26,7 +26,14 @@
     "tieRefund": "Tie (half bet refunded)"
   },
   "payout": {
-    "total": "Payout"
+    "total": "Payout",
+    "dragon": "Dragon",
+    "tiger": "Tiger",
+    "tie": "Tie",
+    "oddsBadge": "{{type}} ×{{odds}}",
+    "win": "Win +{{amount}}",
+    "loss": "Loss {{amount}}",
+    "even": "No change"
   },
   "tutorial": {
     "betButtons": "Pick Dragon, Tiger, or Tie and place your bet",

--- a/frontend/src/i18n/locales/ja/dragontiger.json
+++ b/frontend/src/i18n/locales/ja/dragontiger.json
@@ -32,8 +32,7 @@
     "tie": "タイ",
     "oddsBadge": "{{type}} ×{{odds}}",
     "win": "勝ち +{{amount}}",
-    "loss": "負け {{amount}}",
-    "even": "増減なし"
+    "loss": "負け -{{amount}}"
   },
   "tutorial": {
     "betButtons": "ドラゴン・タイガー・タイのいずれかを選んでベット",

--- a/frontend/src/i18n/locales/ja/dragontiger.json
+++ b/frontend/src/i18n/locales/ja/dragontiger.json
@@ -26,7 +26,14 @@
     "tieRefund": "タイ (ベット額の半分を返還)"
   },
   "payout": {
-    "total": "払戻し"
+    "total": "払戻し",
+    "dragon": "ドラゴン",
+    "tiger": "タイガー",
+    "tie": "タイ",
+    "oddsBadge": "{{type}} ×{{odds}}",
+    "win": "勝ち +{{amount}}",
+    "loss": "負け {{amount}}",
+    "even": "増減なし"
   },
   "tutorial": {
     "betButtons": "ドラゴン・タイガー・タイのいずれかを選んでベット",

--- a/frontend/src/pages/DragonTigerPage.test.tsx
+++ b/frontend/src/pages/DragonTigerPage.test.tsx
@@ -186,6 +186,17 @@ describe('DragonTigerPage', () => {
     expect(diff).toHaveClass('text-ds-success');
   });
 
+  it('shows the tiger-win result and ×1 badge for a winning Tiger bet', async () => {
+    mockApi.mockResolvedValueOnce(tigerWinOnTigerBetState); // result -1, bet Tiger 100, payout 200
+    renderWithProviders(<DragonTigerPage />);
+    const breakdown = await screen.findByTestId('payout-breakdown');
+    expect(breakdown).toHaveTextContent('タイガーの勝ち');
+    expect(breakdown).toHaveTextContent('タイガー ×1');
+    const diff = screen.getByTestId('payout-diff');
+    expect(diff).toHaveTextContent('+100');
+    expect(diff).toHaveClass('text-ds-success');
+  });
+
   it('shows the ×8 odds badge and a big green profit for a Tie-bet win', async () => {
     mockApi.mockResolvedValueOnce(tieWinOnTieBetState); // bet Tie 100, payout 900
     renderWithProviders(<DragonTigerPage />);

--- a/frontend/src/pages/DragonTigerPage.test.tsx
+++ b/frontend/src/pages/DragonTigerPage.test.tsx
@@ -59,8 +59,8 @@ const tigerWinOnTigerBetState: DragonTigerResponse = {
   chips: 1100,
   betAmount: 100,
   betType: DragonTigerBetType.TIGER,
-  // result===2 (GameResultLose, tiger-side won) but the player took Tiger so they win.
-  result: 2,
+  // GameResult wire value: -1 (GameResultLose = Tiger side won); the player took Tiger so they win.
+  result: -1,
   payout: 200,
   history: [DragonTigerHistoryResult.TIGER],
   message: 'Tiger wins!',
@@ -74,7 +74,7 @@ const tieWinOnTieBetState: DragonTigerResponse = {
   chips: 1800,
   betAmount: 100,
   betType: DragonTigerBetType.TIE,
-  result: 3,
+  result: 0,
   payout: 900,
   history: [DragonTigerHistoryResult.TIE],
   message: 'Tie! You win the tie bet.',
@@ -89,7 +89,7 @@ const tieRefundOnDragonBetState: DragonTigerResponse = {
   betAmount: 100,
   betType: DragonTigerBetType.DRAGON,
   // Tie outcome: half-refund on a Dragon bet means payout < betAmount → no celebration.
-  result: 3,
+  result: 0,
   payout: 50,
   history: [DragonTigerHistoryResult.TIE],
   message: 'Tie. Half of your bet is refunded.',
@@ -173,5 +173,36 @@ describe('DragonTigerPage', () => {
     mockApi.mockResolvedValueOnce(tieRefundOnDragonBetState);
     renderWithProviders(<DragonTigerPage />);
     await waitFor(() => expect(screen.getByText('払戻し: 50')).toBeInTheDocument());
+  });
+
+  it('shows the payout breakdown — result, ×1 odds badge, and a green profit — for a Dragon win', async () => {
+    mockApi.mockResolvedValueOnce(dragonWinState); // bet Dragon 100, payout 200
+    renderWithProviders(<DragonTigerPage />);
+    const breakdown = await screen.findByTestId('payout-breakdown');
+    expect(breakdown).toHaveTextContent('ドラゴンの勝ち');
+    expect(breakdown).toHaveTextContent('ドラゴン ×1');
+    const diff = screen.getByTestId('payout-diff');
+    expect(diff).toHaveTextContent('+100');
+    expect(diff).toHaveClass('text-ds-success');
+  });
+
+  it('shows the ×8 odds badge and a big green profit for a Tie-bet win', async () => {
+    mockApi.mockResolvedValueOnce(tieWinOnTieBetState); // bet Tie 100, payout 900
+    renderWithProviders(<DragonTigerPage />);
+    const breakdown = await screen.findByTestId('payout-breakdown');
+    expect(breakdown).toHaveTextContent('タイ ×8');
+    expect(screen.getByTestId('payout-result')).toHaveTextContent('的中'); // tieWin text
+    const diff = screen.getByTestId('payout-diff');
+    expect(diff).toHaveTextContent('+800');
+    expect(diff).toHaveClass('text-ds-success');
+  });
+
+  it('distinguishes a tie refund with a red loss diff for a Dragon bet', async () => {
+    mockApi.mockResolvedValueOnce(tieRefundOnDragonBetState); // bet Dragon 100, payout 50
+    renderWithProviders(<DragonTigerPage />);
+    const diff = await screen.findByTestId('payout-diff');
+    expect(diff).toHaveTextContent('-50');
+    expect(diff).toHaveClass('text-ds-error');
+    expect(screen.getByTestId('payout-result')).toHaveTextContent('返還'); // tieRefund text
   });
 });

--- a/frontend/src/pages/DragonTigerPage.tsx
+++ b/frontend/src/pages/DragonTigerPage.tsx
@@ -196,13 +196,50 @@ function DragonTigerPageContent() {
               </div>
             )}
 
-            {isEndPhase && (
-              <div className="text-ds-text-primary text-center text-sm mb-2" data-testid="payout-breakdown">
-                <div className="font-bold">
-                  {t('payout.total')}: {state.payout}
-                </div>
-              </div>
-            )}
+            {isEndPhase &&
+              (() => {
+                const odds = state.betType === DragonTigerBetType.TIE ? 8 : 1;
+                const betTypeName =
+                  state.betType === DragonTigerBetType.DRAGON
+                    ? t('payout.dragon')
+                    : state.betType === DragonTigerBetType.TIGER
+                      ? t('payout.tiger')
+                      : t('payout.tie');
+                // GameResult: 1 = Dragon wins, -1 = Tiger wins, 0 = tie.
+                const resultKey =
+                  state.result > 0
+                    ? 'dragonWins'
+                    : state.result < 0
+                      ? 'tigerWins'
+                      : state.betType === DragonTigerBetType.TIE
+                        ? 'tieWin'
+                        : 'tieRefund';
+                const profit = state.payout - state.betAmount;
+                const profitCls = profit > 0 ? 'text-ds-success' : profit < 0 ? 'text-ds-error' : 'text-ds-text-muted';
+                return (
+                  <div
+                    className="text-ds-text-primary text-center text-sm mb-2 space-y-1"
+                    data-testid="payout-breakdown"
+                  >
+                    <div data-testid="payout-result">{t(`result.${resultKey}`)}</div>
+                    <div>
+                      <span className="inline-block rounded-full bg-ds-surface-elevated px-2 py-0.5 text-xs font-medium">
+                        {t('payout.oddsBadge', { type: betTypeName, odds })}
+                      </span>
+                    </div>
+                    <div className={`font-medium ${profitCls}`} data-testid="payout-diff">
+                      {profit > 0
+                        ? t('payout.win', { amount: profit })
+                        : profit < 0
+                          ? t('payout.loss', { amount: profit })
+                          : t('payout.even')}
+                    </div>
+                    <div className="font-bold">
+                      {t('payout.total')}: {state.payout}
+                    </div>
+                  </div>
+                );
+              })()}
 
             {actionLog && <ActionLogPanel entries={actionLog} onClose={hideActionLog} />}
           </div>

--- a/frontend/src/pages/DragonTigerPage.tsx
+++ b/frontend/src/pages/DragonTigerPage.tsx
@@ -97,6 +97,27 @@ function DragonTigerPageContent() {
 
   const phaseName = isBetPhase ? t('phase.bet') : t('phase.end');
 
+  // END-phase payout breakdown (state is non-null past the guard above).
+  const odds = state.betType === DragonTigerBetType.TIE ? 8 : 1;
+  const betTypeName =
+    state.betType === DragonTigerBetType.DRAGON
+      ? t('payout.dragon')
+      : state.betType === DragonTigerBetType.TIGER
+        ? t('payout.tiger')
+        : t('payout.tie');
+  // GameResult wire value: 1 = Dragon wins, -1 = Tiger wins, 0 = tie.
+  const resultKey =
+    state.result > 0
+      ? 'dragonWins'
+      : state.result < 0
+        ? 'tigerWins'
+        : state.betType === DragonTigerBetType.TIE
+          ? 'tieWin'
+          : 'tieRefund';
+  // Payouts are always a loss (< bet) or a win (> bet); a break-even is impossible.
+  const profit = state.payout - state.betAmount;
+  const isProfit = profit >= 0;
+
   return (
     <GamePageShell
       title={tc('nav.dragontiger')}
@@ -196,50 +217,25 @@ function DragonTigerPageContent() {
               </div>
             )}
 
-            {isEndPhase &&
-              (() => {
-                const odds = state.betType === DragonTigerBetType.TIE ? 8 : 1;
-                const betTypeName =
-                  state.betType === DragonTigerBetType.DRAGON
-                    ? t('payout.dragon')
-                    : state.betType === DragonTigerBetType.TIGER
-                      ? t('payout.tiger')
-                      : t('payout.tie');
-                // GameResult: 1 = Dragon wins, -1 = Tiger wins, 0 = tie.
-                const resultKey =
-                  state.result > 0
-                    ? 'dragonWins'
-                    : state.result < 0
-                      ? 'tigerWins'
-                      : state.betType === DragonTigerBetType.TIE
-                        ? 'tieWin'
-                        : 'tieRefund';
-                const profit = state.payout - state.betAmount;
-                const profitCls = profit > 0 ? 'text-ds-success' : profit < 0 ? 'text-ds-error' : 'text-ds-text-muted';
-                return (
-                  <div
-                    className="text-ds-text-primary text-center text-sm mb-2 space-y-1"
-                    data-testid="payout-breakdown"
-                  >
-                    <div data-testid="payout-result">{t(`result.${resultKey}`)}</div>
-                    <div>
-                      <span className="inline-block rounded-full bg-ds-surface-elevated px-2 py-0.5 text-xs font-medium">
-                        {t('payout.oddsBadge', { type: betTypeName, odds })}
-                      </span>
-                    </div>
-                    <div className={`font-medium ${profitCls}`} data-testid="payout-diff">
-                      {profit > 0
-                        ? t('payout.win', { amount: profit })
-                        : profit < 0
-                          ? t('payout.loss', { amount: profit })
-                          : t('payout.even')}
-                    </div>
-                    <div className="font-bold">
-                      {t('payout.total')}: {state.payout}
-                    </div>
-                  </div>
-                );
-              })()}
+            {isEndPhase && (
+              <div className="text-ds-text-primary text-center text-sm mb-2 space-y-1" data-testid="payout-breakdown">
+                <div data-testid="payout-result">{t(`result.${resultKey}`)}</div>
+                <div>
+                  <span className="inline-block rounded-full bg-ds-surface-elevated px-2 py-0.5 text-xs font-medium">
+                    {t('payout.oddsBadge', { type: betTypeName, odds })}
+                  </span>
+                </div>
+                <div
+                  className={`font-medium ${isProfit ? 'text-ds-success' : 'text-ds-error'}`}
+                  data-testid="payout-diff"
+                >
+                  {isProfit ? t('payout.win', { amount: profit }) : t('payout.loss', { amount: Math.abs(profit) })}
+                </div>
+                <div className="font-bold">
+                  {t('payout.total')}: {state.payout}
+                </div>
+              </div>
+            )}
 
             {actionLog && <ActionLogPanel entries={actionLog} onClose={hideActionLog} />}
           </div>

--- a/internal/adapter/presenter/DragonTigerCuiPresenter.go
+++ b/internal/adapter/presenter/DragonTigerCuiPresenter.go
@@ -69,6 +69,18 @@ func (dp *DragonTigerCuiPresenter) Output(dt interfaces.DragonTigerGame, lastErr
 				}
 			default:
 			}
+			// Show the bet type and its odds (Tie pays 8:1, Dragon/Tiger 1:1) so the
+			// payout figure below is self-explanatory.
+			odds := 1
+			betTypeKey := "dragontiger.betTypeDragon"
+			switch betType {
+			case domain.DragonTigerBetTiger:
+				betTypeKey = "dragontiger.betTypeTiger"
+			case domain.DragonTigerBetTie:
+				betTypeKey = "dragontiger.betTypeTie"
+				odds = 8
+			}
+			b.WriteString(i18n.Tf("dragontiger.oddsLine", "type", i18n.T(betTypeKey), "odds", strconv.Itoa(odds)) + "\n")
 			b.WriteString(i18n.Tf("dragontiger.payoutLine", "payout", strconv.Itoa(dt.GetPayout())) + "\n")
 		}
 	})

--- a/internal/adapter/presenter/DragonTigerCuiPresenter_test.go
+++ b/internal/adapter/presenter/DragonTigerCuiPresenter_test.go
@@ -53,6 +53,8 @@ func TestDragonTigerCuiPresenter_Output_DragonWins(t *testing.T) {
 	assert.Contains(t, result, "タイガー")
 	assert.Contains(t, result, "ドラゴンの勝ち")
 	assert.Contains(t, result, "払戻し: 200")
+	// Dragon pays 1:1, so the odds line reads ×1.
+	assert.Contains(t, result, "DRAGON ×1")
 }
 
 func TestDragonTigerCuiPresenter_Output_TigerWins(t *testing.T) {
@@ -156,6 +158,8 @@ func TestDragonTigerCuiPresenter_Output_Tie_TieBetWins(t *testing.T) {
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "タイベット的中")
 	assert.Contains(t, result, "払戻し: 900")
+	// Tie pays 8:1, so the odds line reads ×8.
+	assert.Contains(t, result, "TIE ×8")
 }
 
 func TestDragonTigerCuiPresenter_Output_Error(t *testing.T) {

--- a/internal/adapter/presenter/DragonTigerCuiPresenter_test.go
+++ b/internal/adapter/presenter/DragonTigerCuiPresenter_test.go
@@ -73,6 +73,8 @@ func TestDragonTigerCuiPresenter_Output_TigerWins(t *testing.T) {
 
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "タイガーの勝ち")
+	// Player bet Dragon (×1) here, so the odds line reads ×1.
+	assert.Contains(t, result, "DRAGON ×1")
 }
 
 // Regression coverage for the gemini/Claude review: the result message color

--- a/internal/i18n/locales/en/dragontiger.json
+++ b/internal/i18n/locales/en/dragontiger.json
@@ -19,5 +19,6 @@
   "tigerWins": "Tiger wins!",
   "tieWin": "Tie! You win the tie bet.",
   "tieRefund": "Tie. Half of your bet is refunded.",
+  "oddsLine": "Bet: {{type}} ×{{odds}}",
   "payoutLine": "payout: {{payout}}"
 }

--- a/internal/i18n/locales/ja/dragontiger.json
+++ b/internal/i18n/locales/ja/dragontiger.json
@@ -19,5 +19,6 @@
   "tigerWins": "タイガーの勝ち！",
   "tieWin": "タイ！タイベット的中！",
   "tieRefund": "タイ。ベット額の半分を返還します。",
+  "oddsLine": "ベット: {{type}} ×{{odds}}",
   "payoutLine": "払戻し: {{payout}}"
 }


### PR DESCRIPTION
## Summary

Implements #2246. Dragon Tiger's END phase showed only `Payout: N` — players couldn't tell *why* they got that amount (Tie pays 8:1, Dragon/Tiger 1:1), nor a tie **win** from a half-bet **refund**.

**Frontend (`DragonTigerPage`):** the END breakdown now shows
- the round-result text (`result.dragonWins`/`tigerWins`/`tieWin`/`tieRefund`, derived from the wire `result`: `1`=Dragon, `-1`=Tiger, `0`=tie),
- a **bet-type × odds** badge (Tie ×8, Dragon/Tiger ×1), and
- a colored **profit/loss diff** (`payout − betAmount`): green win, red loss, neutral even — so a tie win (+800 on 100) reads differently from a half refund (−50).
- Also corrected two test fixtures whose `result` used the old mis-documented `2`/`3` encoding to the real GameResult wire values (`-1`/`0`).

**CUI (`DragonTigerCuiPresenter.go`):** adds a `Bet: <type> ×<odds>` line before the payout line, with new `oddsLine` Go i18n keys.

## Test plan
- [x] `bun run test -- --run src/pages/DragonTigerPage.test.tsx` (12 passed) — result text, ×1/×8 badge, +/- colored diff, tie-win vs refund
- [x] `go test -tags test ./internal/adapter/presenter/ -run TestDragonTigerCuiPresenter` (pass) — asserts `DRAGON ×1` and `TIE ×8` lines
- [x] `go vet` + `goimports` on the presenter; `bun run check`
- [ ] CI: full Go suite + build + E2E + codecov + i18n parity

Closes #2246