### PR TITLE
chore: add improve-issue skill for end-to-end single-issue work

### DIFF
--- a/.claude/skills/improve-issue/SKILL.md
+++ b/.claude/skills/improve-issue/SKILL.md
@@ -10,14 +10,7 @@ allowed-tools:
   - Grep
   - Glob
   - AskUserQuestion
-triggers:
-  - issueに着手
-  - issueを対応
-  - issueをやって
-  - issueをマージまで
-  - 改善issueの実装
-  - implement issue
-  - work the issue
+# Explicit-invocation only (it commits and opens PRs); run it with `/improve-issue <#>`.
 disable-model-invocation: true
 ---
 
@@ -61,8 +54,9 @@ the lowest-effort still-open issue from the batch the user names.
    cd frontend && bun run test -- --run src/pages/<X>Page.test.tsx
    cd frontend && bun run check          # biome + design-tokens (NOT tsc — see gotchas)
    ```
-   For Go changes also: `goimports -w <file>` (at `/home/yuta/go/bin/goimports`),
-   `go vet -tags test ./internal/adapter/presenter/` and run the focused package
+   For Go changes also: `goimports -w <file>` (install with
+   `go install golang.org/x/tools/cmd/goimports@latest`; ensure `$(go env GOPATH)/bin`
+   is on `PATH`), `go vet -tags test ./internal/adapter/presenter/` and run the focused package
    test (`internal/domain` OOMs locally — CI-gate it; `adapter/presenter` is fine).
 
 5. **Commit (Conventional Commits), push, open the PR.**

--- a/.claude/skills/improve-issue/SKILL.md
+++ b/.claude/skills/improve-issue/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: improve-issue
+version: 1.0.0
+description: Implement ONE improvement/UX GitHub issue end-to-end — branch, TDD, PR (Closes #N), watch CI, read the FULL auto-review, address every finding, squash-merge, sync. Use for "issueに着手して", "#NNNN を対応して", "issueをやってマージまで", per-issue improvement work.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+triggers:
+  - issueに着手
+  - issueを対応
+  - issueをやって
+  - issueをマージまで
+  - 改善issueの実装
+  - implement issue
+  - work the issue
+disable-model-invocation: true
+---
+
+# improve-issue — one issue, branch → merge
+
+Codifies the loop used to clear the **#2238–#2292** per-game improvement batch
+(20 PRs #2376–#2395, all merged green). Reuse it to take a single
+improvement/UX/a11y issue from open → merged with reviews addressed.
+
+**Input:** an issue number (e.g. `/improve-issue 2248`). If none is given, pick
+the lowest-effort still-open issue from the batch the user names.
+
+> This is the *driver*. The repo rules in [`CLAUDE.md`](../../../CLAUDE.md),
+> [`frontend/CLAUDE.md`](../../../frontend/CLAUDE.md) and the user's git/PR
+> feedback memories are authoritative — this skill encodes the *sequence* and
+> the *gotchas* that aren't obvious from those docs alone.
+
+## The loop (do these in order)
+
+1. **Read the issue & reality-check it.**
+   `gh issue view <#> --json title,body`. Then **verify the premise against the
+   actual code** before writing anything. The propose-batch occasionally
+   misreads code → the work is already done or impossible. If so, **do not
+   fabricate** — comment with evidence (cite files/lines) and
+   `gh issue close <#> --reason "not planned"`. (Precedents: #2269, #2245, #2272.)
+
+2. **Branch from fresh develop — BEFORE editing.**
+   ```sh
+   git checkout develop && git pull origin develop
+   git checkout -b feat/<#>-<slug>   # ALWAYS branch before the first edit
+   ```
+   Never edit on `develop`. Never `git add -A` / `git add .` (the worktree has
+   local-only files: untracked skills, node_modules cache, build binaries) —
+   `git add` only the exact files you changed.
+
+3. **Implement with TDD** (Red → Green → Refactor). Match the surrounding code.
+   See **Patterns** below. Always ship the test in the same commit.
+
+4. **Local gates** (frontend):
+   ```sh
+   cd frontend && bun run test -- --run src/pages/<X>Page.test.tsx
+   cd frontend && bun run check          # biome + design-tokens (NOT tsc — see gotchas)
+   ```
+   For Go changes also: `goimports -w <file>` (at `/home/yuta/go/bin/goimports`),
+   `go vet -tags test ./internal/adapter/presenter/` and run the focused package
+   test (`internal/domain` OOMs locally — CI-gate it; `adapter/presenter` is fine).
+
+5. **Commit (Conventional Commits), push, open the PR.**
+   ```sh
+   git add <exact files>; git commit -m "feat(<game>): <imperative>\n\n<body>"
+   git push -u origin feat/<#>-<slug>
+   gh pr create --base develop --title "..." --body "...Closes #<#>"
+   ```
+   PR body **must** close the issue (`Closes #<#>`) and include a test plan.
+
+6. **Watch CI** (`gh pr checks <pr> --watch --interval 30`, run in background).
+   Triage failures — see **CI triage** below.
+
+7. **Read the FULL auto-review before merging — not just the verdict.**
+   `gh pr view <pr> --json comments` + inline:
+   `gh api repos/<owner>/<repo>/pulls/<pr>/comments`. Cover **every** section
+   (all severities + Gemini). Fix every 🔴 Must-Fix and 🟡 Should-Fix, plus any
+   codecov gap; apply cheap nits too. Push fixups (they re-run CI).
+   Note: auto-review fires on PR **open only** (not on later pushes), so the
+   first review is the one to satisfy.
+
+8. **Merge when fully green, then sync.**
+   ```sh
+   gh pr merge <pr> --squash --delete-branch
+   git checkout develop && git pull origin develop && git branch -D feat/<#>-<slug>
+   ```
+
+9. **Record progress** in the running memory tally
+   (`memory/project_issues_*.md` + `MEMORY.md`) so the next run has context.
+
+## CI triage (read the log — don't guess)
+
+- **Fast E2E failure (<~1 min)** = a **tsc build error**, not a flake (the E2E
+  job builds first). `gh run view --job <id> --log-failed`. Common tsc-only
+  errors `bun run check` misses: optional-index (`obj[maybeUndef]`), a
+  `HintResult` test mock missing `targetAction`, missing union members.
+- **Long E2E failure (~15–20 min) with `Target page, context or browser has
+  been closed`** = the recurring **runner-crash flake** (e.g. poker.spec /
+  paigow). `231 passed, 1 failed` confirms it. `gh run rerun <run> --failed`;
+  if it recurs, full `gh run rerun <run>` for a fresh runner. develop's E2E is
+  green, so it is never your PR.
+- **golangci-lint binary download HTTP 504** = infra; rerun.
+- **codecov/patch < 80%** = a new branch is untested. codecov counts **each
+  ternary/`&&` branch and each `?.`/`??`** separately → add a test per branch
+  (the eligible **and** the ineligible path, empty-array edges, clamp limits).
+  Prefer extracting a pure util (testable in isolation) and removing dead
+  defensive guards over leaving partial branches.
+
+## Patterns that work (pick by issue)
+
+- **Single-page frontend UX**: edit `src/pages/<X>Page.tsx` + its `.test.tsx` +
+  `i18n/locales/{ja,en}/<x>.json` (keep **key-for-key parity** — the parity
+  checker runs in CI). TDD the page test.
+- **"validate selection / derive value"**: extract a pure util in
+  `src/utils/<x>.ts` mirroring the Go domain logic (verify field names against
+  the Go source), with its own `.test.ts`. Keeps codecov happy and logic
+  verifiable. (e.g. `tonkMeldIndices`, `osmosisRules`, `fivehundredBidValue`.)
+- **Shared hand/board highlight**: `PlayerHandSection`/`MobileHandGrid` take an
+  optional `highlightIndices?` prop (backward-compatible). Card buttons set
+  `boxShadow` **inline**, so a Tailwind `ring-*` is overridden → highlight via
+  an inline style helper (`highlightCardStyle`/`playableCardStyle`), not a ring.
+- **Transient feedback / live value**: `useState` + `useRef` timer cleared in a
+  `useEffect(() => () => clearTimeout(...), [])`; track previous value in a ref
+  to fire only on a real transition. Add `aria-live="polite"` to live readouts;
+  clamp `aria-valuenow` into `[min,max]`. Test timers with `vi.useFakeTimers()`
+  + `vi.waitFor` (NOT RTL `waitFor`) and wrap `vi.advanceTimersByTime` in `act`.
+- **Hooks before early return**: declare every hook (incl. `useGameHint`,
+  `useSolitaireDragDrop`, refs/effects) **above** any `if (!state) return` —
+  biome `useHookAtTopLevel` fails otherwise.
+- **CUI / Go presenter**: mirror an existing `HintOutput` (Truco/Briscola); add
+  i18n keys to BOTH `internal/i18n/locales/{ja,en}/<game>.json`; assert output
+  with `assert.Contains`.
+
+## Conventions baked in
+
+- Design tokens only (`text-ds-*`, `bg-ds-*`); raw palette and `text-white/N`
+  opacity variants are rejected by `check-design-tokens.mjs`.
+- biome requires `${n.toString()}` in template literals (numbers); `clearTimeout`
+  needs `?? undefined` (rejects `null`) — both are real tsc/biome constraints
+  reviewers may wrongly call redundant.
+- Drop comments that merely echo a constant name; remove dead branches; align
+  i18n `defaultValue` strings with the locale files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,3 +246,4 @@ Key routing rules:
 - Code quality, health check → invoke health
 - Per-game improvement proposals → GitHub issues ("各ゲームの改善提案", "全ゲームのissueを作って") → invoke game-improve
 - New-game candidates → GitHub issues ("追加した方が良いゲームを提案", "新規ゲーム候補をissueに") → invoke propose-games
+- Implement a single GitHub issue end-to-end ("issueに着手して", "#NNNN を対応して", "implement issue #N") → invoke improve-issue (explicit `/improve-issue <#>`)


### PR DESCRIPTION
## Summary

Makes the issue-handling loop I used to clear the **#2238–#2292** improvement batch (20 merged PRs, #2376–#2395) reproducible as a committed skill: `/improve-issue <#>`.

`.claude/skills/improve-issue/SKILL.md` codifies the full sequence — **reality-check the issue → branch from fresh develop → TDD → local gates → PR with `Closes #N` → watch CI → read the FULL auto-review → fix every finding + codecov gap → squash-merge → sync → record progress** — plus the non-obvious gotchas that caused the most rework this batch:

- **CI triage**: a fast (<1 min) "E2E fail" is actually a tsc build error (read the log), vs a ~15–20 min `Target page … closed` runner-crash flake (rerun `--failed`).
- **codecov/patch**: counts each ternary / `&&` / `?.` branch separately → add a test per branch; prefer pure utils + removing dead guards.
- **tsc/biome-only constraints** that `bun run check` misses (optional-index, `HintResult` mocks needing `targetAction`, `toString()` in template literals, `clearTimeout(... ?? undefined)`).
- **Reusable patterns**: single-page UX (page + test + ja/en i18n parity), pure util mirroring the Go domain, shared `highlightIndices` prop (inline-style highlight, not a ring), transient-feedback timers + fake-timer testing, hooks-before-early-return, CUI/Go presenter.
- **False-positive handling**: close with evidence instead of fabricating (e.g. #2272 had no hint engine).

Follows the existing committed-skill convention (`game-improve`, `propose-games`, `new-game`); `disable-model-invocation: true` so it runs only when explicitly invoked.

## Test plan
- [x] Frontmatter mirrors existing skills; file is git-trackable (not ignored)
- [x] Docs-only change — no code/CI impact
