### PR TITLE
fix(e2e): disable /dev/shm to stop Chromium crashing on CI

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -15,7 +15,16 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          // CI runners give Chromium a tiny /dev/shm; once it fills during the
+          // long single-worker run the browser process crashes mid-test
+          // ("Target page, context or browser has been closed" — see #2369).
+          // Routing shared memory to /tmp instead removes the flaky crash.
+          args: process.env.CI ? ['--disable-dev-shm-usage'] : [],
+        },
+      },
     },
   ],
   webServer: {


### PR DESCRIPTION
## Summary

Fixes #2369. The `poker.spec.ts` full-round E2E intermittently failed with **`Target page, context or browser has been closed`** (timeout waiting for `aria-busy="false"` because the browser had already crashed), forcing repeated E2E reruns on nearly every PR this batch. develop's E2E is green, so it was never a test-logic bug — it's the classic CI symptom of **Chromium exhausting the small `/dev/shm`** on the runner during the long single-worker run (workers are already `1` and retries `2`, so parallelism wasn't the lever).

- Added `launchOptions.args: ['--disable-dev-shm-usage']` (CI only) to the chromium project, so Chromium routes shared memory to `/tmp` instead of the tiny `/dev/shm` and stops crashing mid-run.

## Test plan
- [x] `bun run check` (biome OK)
- [x] `bunx playwright test --list` parses the config cleanly
- [ ] CI: E2E is the real gate — it should run without the browser-crash flake (config-only change; no unit test applies to Playwright config)

Closes #2369