### PR TITLE
feat(cassino): i18n the human/CPU stat lines

### DIFF
--- a/frontend/src/i18n/locales/en/cassino.json
+++ b/frontend/src/i18n/locales/en/cassino.json
@@ -20,6 +20,8 @@
   "label.sweep": "Sweeps",
   "label.buildValue": "Build Value",
   "label.remainingDeck": "Deck",
+  "label.cpuStats": "{{cards}} cards / {{score}} pt",
+  "label.humanStats": "Hand {{hand}} / Captured {{captured}} / Sweeps {{sweep}} / Total {{score}} pt",
   "settings.cpuDifficulty": "CPU Difficulty",
   "settings.targetScore": "Target Score",
   "settings.multiBuild": "Multi-Builds",

--- a/frontend/src/i18n/locales/ja/cassino.json
+++ b/frontend/src/i18n/locales/ja/cassino.json
@@ -20,6 +20,8 @@
   "label.sweep": "スイープ",
   "label.buildValue": "宣言値",
   "label.remainingDeck": "山札残",
+  "label.cpuStats": "{{cards}}枚 / {{score}}pt",
+  "label.humanStats": "手札{{hand}}枚 / 捕獲{{captured}}枚 / スイープ{{sweep}} / 累計{{score}}pt",
   "settings.cpuDifficulty": "CPU難易度",
   "settings.targetScore": "目標点",
   "settings.multiBuild": "複合ビルド",

--- a/frontend/src/pages/CassinoPage.test.tsx
+++ b/frontend/src/pages/CassinoPage.test.tsx
@@ -66,6 +66,21 @@ describe('CassinoPage', () => {
     expect(screen.getByTestId('hand-card-2')).toBeInTheDocument();
   });
 
+  it('renders the human and CPU stat lines via i18n (no hardcoded 枚/pt)', async () => {
+    const players = [
+      { id: 0, isHuman: true, cardCount: 3, cards: [], capturedCount: 5, sweepCount: 2, totalScore: 7 },
+      { id: 1, isHuman: false, cardCount: 4, cards: [], capturedCount: 0, sweepCount: 0, totalScore: 3 },
+      { id: 2, isHuman: false, cardCount: 4, cards: [], capturedCount: 0, sweepCount: 0, totalScore: 0 },
+      { id: 3, isHuman: false, cardCount: 4, cards: [], capturedCount: 0, sweepCount: 0, totalScore: 0 },
+    ];
+    mockExec.mockResolvedValue(makeState({ players }));
+    renderWithProviders(<CassinoPage />);
+    // ja label.humanStats: "手札3枚 / 捕獲5枚 / スイープ2 / 累計7pt"
+    await waitFor(() => expect(screen.getByText(/手札3枚.*捕獲5枚.*スイープ2.*累計7pt/)).toBeInTheDocument());
+    // ja label.cpuStats for CPU 1: "4枚 / 3pt"
+    expect(screen.getByText(/4枚 \/ 3pt/)).toBeInTheDocument();
+  });
+
   it('renders table cards', async () => {
     renderWithProviders(<CassinoPage />);
     await waitFor(() => expect(screen.getByTestId('table-card-0')).toBeInTheDocument());

--- a/frontend/src/pages/CassinoPage.tsx
+++ b/frontend/src/pages/CassinoPage.tsx
@@ -216,7 +216,8 @@ function CassinoPageContent() {
                 .map((p) => (
                   <div key={p.id} className="text-center">
                     <div className="text-xs text-ds-text-muted mb-1">
-                      {tc('player.cpu', { id: p.id })} — {p.cardCount}枚 / {p.totalScore}pt
+                      {tc('player.cpu', { id: p.id })} —{' '}
+                      {t('label.cpuStats', { cards: p.cardCount, score: p.totalScore })}
                     </div>
                     <div className="flex gap-0.5 justify-center">
                       {Array.from({ length: Math.min(p.cardCount, 8) }, (_, i) => (
@@ -288,9 +289,13 @@ function CassinoPageContent() {
             {/* Human hand */}
             <div className="text-center" data-tutorial="cs-player-hand">
               <div className="text-xs text-ds-text-muted mb-1">
-                {tc('player.you')} — 手札{human.cardCount}枚 / 捕獲{human.capturedCount}枚 / スイープ{human.sweepCount}{' '}
-                / 累計
-                {human.totalScore}pt
+                {tc('player.you')} —{' '}
+                {t('label.humanStats', {
+                  hand: human.cardCount,
+                  captured: human.capturedCount,
+                  sweep: human.sweepCount,
+                  score: human.totalScore,
+                })}
               </div>
               <div className="flex flex-wrap justify-center gap-2">
                 {human.cards.map((c, i) => (


### PR DESCRIPTION
## Summary

Implements #2233. The Cassino player rows hardcoded Japanese units and labels (`{cardCount}枚 / {totalScore}pt`, `手札X枚 / 捕獲X枚 / スイープX / 累計Xpt`), so the English locale read unnaturally.

- Route both the CPU row and the human row through new interpolated keys `label.cpuStats` / `label.humanStats` in `cassino.json` (ja/en parity).

## Test plan
- [x] `bun run test -- --run src/pages/CassinoPage.test.tsx` (20 passed) — added a test asserting the stat lines render via i18n (no hardcoded 枚/pt)
- [x] `bun run check`
- [ ] CI

Closes #2233