### PR TITLE
feat(canfield): i18n the tableau move-button labels

### DIFF
--- a/frontend/src/i18n/locales/en/canfield.json
+++ b/frontend/src/i18n/locales/en/canfield.json
@@ -27,6 +27,10 @@
   "moveReserveToTableau": "Reserve → Tableau",
   "moveWasteToFoundation": "Waste → Foundation",
   "moveWasteToTableau": "Waste → Tableau",
+  "moveWasteToCol": "W→{{col}}",
+  "moveReserveToCol": "R→{{col}}",
+  "moveToFoundation": "→F",
+  "moveToCol": "→T{{col}}",
   "moveTableauToFoundation": "Tableau → Foundation",
   "frontendHint": {
     "moveToFoundation": "A card can be moved to the foundation",

--- a/frontend/src/i18n/locales/ja/canfield.json
+++ b/frontend/src/i18n/locales/ja/canfield.json
@@ -27,6 +27,10 @@
   "moveReserveToTableau": "リザーブ→場札",
   "moveWasteToFoundation": "ウェイスト→組札",
   "moveWasteToTableau": "ウェイスト→場札",
+  "moveWasteToCol": "捨→{{col}}",
+  "moveReserveToCol": "予→{{col}}",
+  "moveToFoundation": "→組",
+  "moveToCol": "→{{col}}",
   "moveTableauToFoundation": "場札→組札",
   "frontendHint": {
     "moveToFoundation": "組札へ移動できるカードがあります",

--- a/frontend/src/pages/CanfieldPage.test.tsx
+++ b/frontend/src/pages/CanfieldPage.test.tsx
@@ -187,8 +187,8 @@ describe('CanfieldPage', () => {
   it('tableau-to-tableau button fires move command with correct args', async () => {
     renderWithProviders(<CanfieldPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    // Column 0 → column 1 button (each non-empty column has 3 →Tj buttons)
-    const btn = screen.getAllByRole('button', { name: /→T1/ })[0];
+    // Column 0 → column 1 button (ja moveToCol label is exactly "→1"; each non-empty column renders one per other column)
+    const btn = screen.getAllByRole('button', { name: '→1' })[0];
     btn.click();
     await waitFor(() =>
       expect(mockExec).toHaveBeenCalledWith(

--- a/frontend/src/pages/CanfieldPage.tsx
+++ b/frontend/src/pages/CanfieldPage.tsx
@@ -345,7 +345,7 @@ function CanfieldPageContent() {
                           onClick={() => handleMoveWasteToTableau(i)}
                           disabled={!topWaste || loading}
                         >
-                          W→{i}
+                          {t('moveWasteToCol', { col: i })}
                         </button>
                         <button
                           type="button"
@@ -353,7 +353,7 @@ function CanfieldPageContent() {
                           onClick={() => handleMoveReserveToTableau(i)}
                           disabled={!topReserve || loading}
                         >
-                          R→{i}
+                          {t('moveReserveToCol', { col: i })}
                         </button>
                         <button
                           type="button"
@@ -361,7 +361,7 @@ function CanfieldPageContent() {
                           onClick={() => handleMoveTableauToFoundation(i)}
                           disabled={col.length === 0 || loading}
                         >
-                          →F
+                          {t('moveToFoundation')}
                         </button>
                         {state.tableau.map((_, j) =>
                           j === i ? null : (
@@ -372,7 +372,7 @@ function CanfieldPageContent() {
                               onClick={() => handleMoveTableauToTableau(i, col.length - 1, j)}
                               disabled={col.length === 0 || loading}
                             >
-                              →T{j}
+                              {t('moveToCol', { col: j })}
                             </button>
                           ),
                         )}


### PR DESCRIPTION
## Summary

Implements #2215. Canfield's per-column move buttons (`W→n`, `R→n`, `→F`, `→Tn`) were hardcoded English abbreviations, shown even in the Japanese locale and hard to read in narrow mobile columns.

- Route them through new keys `moveWasteToCol` / `moveReserveToCol` / `moveToFoundation` / `moveToCol` (ja localized e.g. `捨→0` / `予→0` / `→組` / `→1`; en unchanged as `W→0`/`R→0`/`→F`/`→T1`). ja/en parity preserved.

## Test plan
- [x] `bun run test -- --run src/pages/CanfieldPage.test.tsx` (24 passed) — updated the move-button query to the new ja label
- [x] `bun run check`
- [ ] CI

Closes #2215