### PR TITLE
feat(speed): use design-system button token for the hint button

### DIFF
--- a/frontend/src/pages/SpeedPage.test.tsx
+++ b/frontend/src/pages/SpeedPage.test.tsx
@@ -214,6 +214,15 @@ describe('SpeedPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
   });
 
+  it('uses the design-system button token (not Bootstrap classes) for the hint button', async () => {
+    renderWithProviders(<SpeedPage />);
+    const hint = await screen.findByRole('button', { name: 'ヒント' });
+    // btnOutline token applied; legacy Bootstrap classes gone.
+    expect(hint.className).toContain('border');
+    expect(hint.className).not.toContain('btn-outline');
+    expect(hint.className).not.toMatch(/\bbtn\b/);
+  });
+
   it('shows phase as stuck when phase is 1', async () => {
     mockExec.mockResolvedValue(stuckState);
     renderWithProviders(<SpeedPage />);

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -22,6 +22,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { AUTO_FLIP_DELAY_MS, CPU_DIFFICULTY_OPTIONS, useSpeedGame } from '../hooks/useSpeedGame';
 import { useSound } from '../providers/SoundProvider';
+import { btnOutline } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import type { SpeedResponse } from '../types/card';
 import { SpeedPhase } from '../types/phases';
@@ -341,7 +342,7 @@ function SpeedPageContent() {
               type="button"
               onClick={handleHint}
               disabled={loading || !isPlayPhase}
-              className="btn btn-sm btn-outline"
+              className={`${btnOutline} text-sm`}
             >
               {tc('button.hint')}
             </button>

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -338,12 +338,7 @@ function SpeedPageContent() {
             ]}
           />
           <GameFooter>
-            <button
-              type="button"
-              onClick={handleHint}
-              disabled={loading || !isPlayPhase}
-              className={`${btnOutline} text-sm`}
-            >
+            <button type="button" onClick={handleHint} disabled={loading || !isPlayPhase} className={btnOutline}>
               {tc('button.hint')}
             </button>
             <ActionLogSection


### PR DESCRIPTION
## Summary

Implements #2201. Speed's hint button used Bootstrap-style classes (`btn btn-sm btn-outline`) — the only page not using the project's `buttonStyles` design tokens, so theme/design updates would skip it.

- Swap to the standard `btnOutline` token (+ `text-sm`); the Bootstrap class string is gone.

## Test plan
- [x] `bun run test -- --run src/pages/SpeedPage.test.tsx` (45 passed) — added a test asserting the hint button uses the token (`border`, no `btn`/`btn-outline`)
- [x] `bun run check`
- [ ] CI

Closes #2201