### PR TITLE
feat(skat): i18n the CUI hint output (was English-only)

### DIFF
--- a/internal/adapter/presenter/SkatCuiPresenter.go
+++ b/internal/adapter/presenter/SkatCuiPresenter.go
@@ -4,6 +4,7 @@ package presenter
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -119,26 +120,27 @@ func (p *SkatCuiPresenter) Output(s interfaces.SkatGame, lastErr error) string {
 func (p *SkatCuiPresenter) HintOutput(s interfaces.SkatGame) string {
 	hint := s.GetHint()
 	if hint == nil {
-		return "No hint available.\n"
+		return i18n.T("skat.hintNone") + "\n"
 	}
+	reason := hintReasonStr(hint.Reason, skatHintReasonKeys)
 	if hint.Bid != nil {
-		choice := "pass"
+		choice := i18n.T("skat.choiceBidPass")
 		if *hint.Bid == 1 {
-			choice = "accept"
+			choice = i18n.T("skat.choiceBidAccept")
 		}
-		return fmt.Sprintf("%s\n", color.Yellow(fmt.Sprintf("[HINT: %s (%s)]", choice, skatHintReasonStr(hint.Reason))))
+		return color.Yellow(i18n.Tf("skat.hintBid", "choice", choice, "reason", reason)) + "\n"
 	}
 	if hint.PickSkat != nil {
-		choice := "decline"
+		choice := i18n.T("skat.choiceSkatDecline")
 		if *hint.PickSkat {
-			choice = "pick up"
+			choice = i18n.T("skat.choiceSkatPickUp")
 		}
-		return fmt.Sprintf("%s\n", color.Yellow(fmt.Sprintf("[HINT: %s the skat (%s)]", choice, skatHintReasonStr(hint.Reason))))
+		return color.Yellow(i18n.Tf("skat.hintPickSkat", "choice", choice, "reason", reason)) + "\n"
 	}
 	if hint.DiscardIndex != nil {
-		player := s.GetPlayer(0)
-		card := player.GetCard(*hint.DiscardIndex)
-		return fmt.Sprintf("%s\n", color.Yellow(fmt.Sprintf("[HINT: discard [%d]%s (%s)]", *hint.DiscardIndex, cuiCardStr(card), skatHintReasonStr(hint.Reason))))
+		card := s.GetPlayer(0).GetCard(*hint.DiscardIndex)
+		return color.Yellow(i18n.Tf("skat.hintDiscard",
+			"idx", strconv.Itoa(*hint.DiscardIndex), "card", cuiCardStr(card), "reason", reason)) + "\n"
 	}
 	if hint.GameType != nil {
 		gt := domain.SkatGameType(*hint.GameType)
@@ -146,14 +148,14 @@ func (p *SkatCuiPresenter) HintOutput(s interfaces.SkatGame) string {
 		if gt == domain.SkatGameSuit && hint.TrumpSuit != nil {
 			s2 = fmt.Sprintf("%s %s", s2, skatSuitSymbol(*hint.TrumpSuit))
 		}
-		return fmt.Sprintf("%s\n", color.Yellow(fmt.Sprintf("[HINT: declare %s (%s)]", s2, skatHintReasonStr(hint.Reason))))
+		return color.Yellow(i18n.Tf("skat.hintDeclare", "game", s2, "reason", reason)) + "\n"
 	}
 	if hint.CardIndex != nil {
-		player := s.GetPlayer(0)
-		card := player.GetCard(*hint.CardIndex)
-		return fmt.Sprintf("%s\n", color.Yellow(fmt.Sprintf("[HINT: play [%d]%s (%s)]", *hint.CardIndex, cuiCardStr(card), skatHintReasonStr(hint.Reason))))
+		card := s.GetPlayer(0).GetCard(*hint.CardIndex)
+		return color.Yellow(i18n.Tf("skat.hintPlay",
+			"idx", strconv.Itoa(*hint.CardIndex), "card", cuiCardStr(card), "reason", reason)) + "\n"
 	}
-	return "No hint available.\n"
+	return i18n.T("skat.hintNone") + "\n"
 }
 
 // ActionLogOutput returns the round's action log as text.
@@ -189,16 +191,11 @@ func skatSuitSymbol(suit int) string {
 	return "?"
 }
 
-// skatHintReasons localised reason strings.
-var skatHintReasons = map[string]string{
-	"strategic_bid": "strategic bid",
-	"skat_pickup":   "skat pickup",
-	"discard_low":   "discard low cards",
-	"game_choice":   "best game choice",
-	"best_play":     "best play",
-}
-
-// skatHintReasonStr translates a hint reason key.
-func skatHintReasonStr(reason string) string {
-	return lookupHintReason(reason, skatHintReasons)
+// skatHintReasonKeys maps Skat-specific hint-reason identifiers to i18n keys.
+var skatHintReasonKeys = map[string]string{
+	"strategic_bid": "skat.hintReasonStrategicBid",
+	"skat_pickup":   "skat.hintReasonSkatPickup",
+	"discard_low":   "skat.hintReasonDiscardLow",
+	"game_choice":   "skat.hintReasonGameChoice",
+	"best_play":     "skat.hintReasonBestPlay",
 }

--- a/internal/adapter/presenter/SkatCuiPresenter_test.go
+++ b/internal/adapter/presenter/SkatCuiPresenter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupSkatCuiMock() *interfaces.MockSkatGame {
@@ -95,6 +96,8 @@ func TestSkatCuiPresenter_HintOutput(t *testing.T) {
 	orig := color.NoColor()
 	color.SetNoColor(true)
 	defer color.SetNoColor(orig)
+	i18n.SetLang("en")
+	defer i18n.SetLang("ja")
 	p := new(presenter.SkatCuiPresenter)
 
 	t.Run("no hint", func(t *testing.T) {
@@ -252,6 +255,8 @@ func TestSkatCuiPresenter_HintOutputAllBranches(t *testing.T) {
 	orig := color.NoColor()
 	color.SetNoColor(true)
 	defer color.SetNoColor(orig)
+	i18n.SetLang("en")
+	defer i18n.SetLang("ja")
 	p := new(presenter.SkatCuiPresenter)
 
 	t.Run("discard hint", func(t *testing.T) {
@@ -308,4 +313,42 @@ func TestSkatCuiPresenter_HintOutputAllBranches(t *testing.T) {
 		m.On("GetHint").Return(&domain.SkatHint{Reason: "best_play"})
 		assert.Contains(t, p.HintOutput(m), "No hint")
 	})
+}
+
+func TestSkatCuiPresenter_HintOutput_Localized(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(orig)
+	p := new(presenter.SkatCuiPresenter)
+
+	t.Run("ja renders Japanese hint + reason", func(t *testing.T) {
+		i18n.SetLang("ja")
+		m := setupSkatCuiMock()
+		val := 1
+		m.On("GetHint").Return(&domain.SkatHint{Bid: &val, Reason: "strategic_bid"})
+		out := p.HintOutput(m)
+		assert.Contains(t, out, "アクセプト")   // choiceBidAccept
+		assert.Contains(t, out, "戦略的なビッド") // hintReasonStrategicBid
+		assert.NotContains(t, out, "strategic bid")
+	})
+
+	t.Run("ja renders Japanese no-hint", func(t *testing.T) {
+		i18n.SetLang("ja")
+		m := setupSkatCuiMock()
+		m.On("GetHint").Return((*domain.SkatHint)(nil))
+		assert.Contains(t, p.HintOutput(m), "ヒントはありません")
+	})
+
+	t.Run("en renders English hint + reason", func(t *testing.T) {
+		i18n.SetLang("en")
+		defer i18n.SetLang("ja")
+		m := setupSkatCuiMock()
+		val := 1
+		m.On("GetHint").Return(&domain.SkatHint{Bid: &val, Reason: "strategic_bid"})
+		out := p.HintOutput(m)
+		assert.Contains(t, out, "accept")
+		assert.Contains(t, out, "strategic bid")
+	})
+
+	i18n.SetLang("ja")
 }

--- a/internal/i18n/locales/en/skat.json
+++ b/internal/i18n/locales/en/skat.json
@@ -8,5 +8,20 @@
   "helpNext": "  n                    next trick",
   "helpNextRound": "  nr                   next round",
   "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
-  "helpSetTarget": "  sl <n>               game-end target score"
+  "helpSetTarget": "  sl <n>               game-end target score",
+  "hintNone": "No hint available.",
+  "hintBid": "[HINT: {{choice}} ({{reason}})]",
+  "hintPickSkat": "[HINT: {{choice}} the skat ({{reason}})]",
+  "hintDiscard": "[HINT: discard [{{idx}}]{{card}} ({{reason}})]",
+  "hintDeclare": "[HINT: declare {{game}} ({{reason}})]",
+  "hintPlay": "[HINT: play [{{idx}}]{{card}} ({{reason}})]",
+  "choiceBidPass": "pass",
+  "choiceBidAccept": "accept",
+  "choiceSkatDecline": "decline",
+  "choiceSkatPickUp": "pick up",
+  "hintReasonStrategicBid": "strategic bid",
+  "hintReasonSkatPickup": "skat pickup",
+  "hintReasonDiscardLow": "discard low cards",
+  "hintReasonGameChoice": "best game choice",
+  "hintReasonBestPlay": "best play"
 }

--- a/internal/i18n/locales/ja/skat.json
+++ b/internal/i18n/locales/ja/skat.json
@@ -8,5 +8,20 @@
   "helpNext": "  n                    next trick",
   "helpNextRound": "  nr                   next round",
   "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
-  "helpSetTarget": "  sl <n>               game-end target score"
+  "helpSetTarget": "  sl <n>               game-end target score",
+  "hintNone": "ヒントはありません。",
+  "hintBid": "[ヒント: {{choice}} ({{reason}})]",
+  "hintPickSkat": "[ヒント: スカートを{{choice}} ({{reason}})]",
+  "hintDiscard": "[ヒント: [{{idx}}]{{card}} を捨てる ({{reason}})]",
+  "hintDeclare": "[ヒント: {{game}} を宣言 ({{reason}})]",
+  "hintPlay": "[ヒント: [{{idx}}]{{card}} をプレイ ({{reason}})]",
+  "choiceBidPass": "パス",
+  "choiceBidAccept": "アクセプト",
+  "choiceSkatDecline": "見送る",
+  "choiceSkatPickUp": "取得する",
+  "hintReasonStrategicBid": "戦略的なビッド",
+  "hintReasonSkatPickup": "スカート取得",
+  "hintReasonDiscardLow": "低いカードを捨てる",
+  "hintReasonGameChoice": "最適なゲーム選択",
+  "hintReasonBestPlay": "最善手"
 }


### PR DESCRIPTION
## Summary

Implements #2237. `SkatCuiPresenter.HintOutput` hardcoded English templates (`[HINT: ...]`, `pass`/`accept`/`pick up`/`discard`/`play`) and reason strings, so Skat showed English hints even under `--lang ja`.

- Route reasons through `hintReasonStr(hint.Reason, skatHintReasonKeys)` (i18n keys) like the other games, replacing the English-valued `skatHintReasons` map.
- Route the 5 hint templates + choice words + no-hint through `i18n.T`/`i18n.Tf`.
- Added `hint*` / `choice*` / `hintReason*` keys to `internal/i18n/locales/{ja,en}/skat.json` (parity).
- (Suit/Grand/Null game-type labels left as-is — standard Skat proper nouns also used outside HintOutput.)

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/ -run TestSkatCuiPresenter` (pass) — existing English tests wrapped in `SetLang("en")`; new `*_Localized` test asserts ja (アクセプト / 戦略的なビッド / ヒントはありません) vs en
- [x] `goimports` + `go vet` clean; `lookupHintReason` still used by BidWhist/FiveHundred (not orphaned)
- [ ] CI: full Go suite + golangci-lint + build + E2E

Closes #2237