### PR TITLE
feat(indianpoker): show dealer name via playerName, not raw index

### DIFF
--- a/frontend/src/pages/IndianPokerPage.test.tsx
+++ b/frontend/src/pages/IndianPokerPage.test.tsx
@@ -172,11 +172,23 @@ describe('IndianPokerPage', () => {
   });
 
   // ---- info bar ----
-  it('shows pot and dealer index', async () => {
-    mockExec.mockResolvedValue(bettingState);
+  it('shows pot and the dealer name via playerName (CPU dealer)', async () => {
+    mockExec.mockResolvedValue(bettingState); // dealerIdx 3 → CPU
     renderWithProviders(<IndianPokerPage />);
     await waitFor(() => expect(screen.getByText(/ポット:/)).toBeInTheDocument());
     expect(screen.getByText(/ディーラー:/)).toBeInTheDocument();
+    // Dealer renders via playerName (CPU 3), not the raw "Player 3" index.
+    expect(screen.getAllByText('CPU 3').length).toBeGreaterThan(0);
+    expect(screen.queryByText(/Player 3/)).not.toBeInTheDocument();
+  });
+
+  it('shows あなた as the dealer name when the human is the dealer', async () => {
+    mockExec.mockResolvedValue({ ...bettingState, dealerIdx: 0 }); // player 0 is the human
+    renderWithProviders(<IndianPokerPage />);
+    await waitFor(() => expect(screen.getByText(/ディーラー:/)).toBeInTheDocument());
+    // The dealer <strong> renders the human label, not "Player 0".
+    expect(screen.queryByText(/Player 0/)).not.toBeInTheDocument();
+    expect(screen.getAllByText('あなた').length).toBeGreaterThan(0);
   });
 
   it('shows ante in info bar', async () => {

--- a/frontend/src/pages/IndianPokerPage.tsx
+++ b/frontend/src/pages/IndianPokerPage.tsx
@@ -38,6 +38,7 @@ import { INDIANPOKER_HELP, parseIndianpokerCommand } from '../utils/cli/commands
 import { formatIndianpokerState } from '../utils/cli/formatters/indianpokerFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { computeIndianPokerEquity } from '../utils/indianPokerEquity';
+import { findPlayerName } from '../utils/playerUtils';
 
 /** Indian Poker tutorial step definitions. */
 const IP_TUTORIAL_STEPS: TutorialStep[] = [
@@ -214,7 +215,7 @@ function IndianPokerPageContent() {
       }
       headerEnd={
         <span>
-          {tc('label.dealer')} <strong>Player {state.dealerIdx ?? 0}</strong>
+          {tc('label.dealer')} <strong>{findPlayerName(state.players, state.dealerIdx)}</strong>
         </span>
       }
     >


### PR DESCRIPTION
## Summary

Implements #2190. The Indian Poker header showed `Player {state.dealerIdx}` — a raw 0-based index, bypassing the shared `playerName` util and not i18n'd.

- Route the dealer through `playerName(dealerIdx, players[dealerIdx]?.isHuman)`, so a human dealer shows あなた/You and CPU dealers show the translated CPU label.

## Test plan
- [x] `bun run test -- --run src/pages/IndianPokerPage.test.tsx` (67 passed) — CPU dealer renders `CPU 3` (not `Player 3`); human dealer renders あなた
- [x] `bun run check`
- [ ] CI

Closes #2190