### PR TITLE
feat(clocksolitaire): render GameSkeleton while loading and move hint toggle to SettingsPanel

### DIFF
--- a/frontend/src/pages/ClockSolitairePage.test.tsx
+++ b/frontend/src/pages/ClockSolitairePage.test.tsx
@@ -96,6 +96,18 @@ describe('ClockSolitairePage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
+  it('renders skeleton before first API response', () => {
+    mockExec.mockReturnValue(new Promise(() => undefined));
+    renderWithProviders(<ClockSolitairePage />);
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+  });
+
+  it('renders the hint toggle inside the settings panel', async () => {
+    renderWithProviders(<ClockSolitairePage />);
+    await waitFor(() => expect(screen.getByText('設定')).toBeInTheDocument());
+    expect(screen.getByLabelText('ヒント表示')).toBeInTheDocument();
+  });
+
   it('shows game clear phase name', async () => {
     mockExec.mockResolvedValue(gameClearState);
     renderWithProviders(<ClockSolitairePage />);

--- a/frontend/src/pages/ClockSolitairePage.tsx
+++ b/frontend/src/pages/ClockSolitairePage.tsx
@@ -3,6 +3,7 @@ import { clocksolitaireApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
@@ -12,6 +13,7 @@ import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
+import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
@@ -136,7 +138,7 @@ function ClockSolitairePageContent() {
       : t('phase.playing');
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
-  if (!state) return null;
+  if (!state) return <GameSkeleton gameKey="clocksolitaire" layout={{ kind: 'centered', rows: [4, 5, 4] }} />;
 
   const radius = Math.min(cardWidth * 5, 180);
 
@@ -300,17 +302,26 @@ function ClockSolitairePageContent() {
 
           {hintEnabled && hint && <HintTooltip reason={t(hint.reason)} confidence={hint.confidence} />}
 
+          {/* Settings */}
+          <SettingsPanel
+            title={tc('settings.title')}
+            groups={[
+              {
+                items: [
+                  {
+                    type: 'checkbox' as const,
+                    id: 'frontendHint',
+                    label: tc('hint.toggle', { ns: 'tutorial' }),
+                    checked: hintEnabled,
+                    onToggle: setHintEnabled,
+                  },
+                ],
+              },
+            ]}
+          />
+
           <GameFooter className={`${theme.footer} px-4 py-2.5`}>
             <div className="flex flex-wrap items-center gap-2">
-              <label className="flex items-center gap-1 text-ds-text-primary text-xs">
-                <input
-                  type="checkbox"
-                  checked={hintEnabled}
-                  onChange={(e) => setHintEnabled(e.target.checked)}
-                  aria-label={tc('hint.toggle', { ns: 'tutorial' })}
-                />
-                {tc('hint.toggle', { ns: 'tutorial' })}
-              </label>
               {isPlaying && (
                 <div data-tutorial="clock-controls" className="flex gap-2">
                   <button


### PR DESCRIPTION
## Summary

`ClockSolitairePage` was the only game page that returned `null` while `state` was unloaded, producing a completely blank screen on first render (layout shift). It now renders the shared `<GameSkeleton>` (`centered` layout, rows 4/5/4 approximating the 13-pile clock face), like every other game page.

Per the issue proposal, the hint toggle also moves from an inline `GameFooter` checkbox into the standard `<SettingsPanel>` (the Klondike pattern), unifying the settings UI with the other solitaire games.

The `<ErrorAlert>` branch is untouched.

## Test plan

- [x] TDD Red→Green: new tests `renders skeleton before first API response` (getByTestId('skeleton')) and `renders the hint toggle inside the settings panel` (設定 summary + ヒント表示 checkbox) failed before the change, pass after
- [x] All 17 ClockSolitairePage tests pass locally; Biome clean; local `tsc -b` passes
- [ ] CI: build, frontend tests, E2E, codecov/patch

Closes #2207

🤖 Generated with [Claude Code](https://claude.com/claude-code)