### PR TITLE
feat(pinochle): render GameSkeleton instead of plain-text loading div

### DIFF
--- a/frontend/src/pages/PinochlePage.test.tsx
+++ b/frontend/src/pages/PinochlePage.test.tsx
@@ -116,10 +116,11 @@ afterEach(() => {
 });
 
 describe('PinochlePage', () => {
-  it('renders loading message when no state', () => {
+  it('renders skeleton before first API response', () => {
     mockExec.mockReturnValue(new Promise(() => undefined));
     renderWithProviders(<PinochlePage />);
-    expect(screen.getByText('考え中...')).toBeInTheDocument();
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    expect(screen.queryByText('考え中...')).not.toBeInTheDocument();
   });
 
   it('calls reset on mount', async () => {

--- a/frontend/src/pages/PinochlePage.tsx
+++ b/frontend/src/pages/PinochlePage.tsx
@@ -11,6 +11,7 @@ import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
+import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
@@ -207,11 +208,7 @@ function PinochlePageContent() {
   }, [state?.players, state?.playerMelds, t]);
 
   if (!state) {
-    return (
-      <div className="p-4 text-center text-ds-text-primary">
-        <p>{tc('status.thinking')}</p>
-      </div>
-    );
+    return <GameSkeleton gameKey="pinochle" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 12 }} />;
   }
 
   const phase = state.phase;


### PR DESCRIPTION
## Summary

`PinochlePage`'s `!state` fallback returned a bare `p-4 text-center` div with 考え中... text — the only game page not using `<GameSkeleton>`, causing layout shift on first load. It now renders the shared skeleton with the `trick-taking` layout (trick area + 12-card footer hand, matching Pinochle's deal), same as HeartsPage.

## Test plan

- [x] TDD Red→Green: replaced the `renders loading message when no state` test with `renders skeleton before first API response` (asserts `getByTestId('skeleton')` and that the 考え中... text is gone) — failed before, passes after
- [x] All 26 PinochlePage tests pass locally; Biome clean; local `tsc -b` passes
- [ ] CI: build, frontend tests, E2E, codecov/patch

Closes #2203

🤖 Generated with [Claude Code](https://claude.com/claude-code)