### PR TITLE
feat(sevencardstud): replace raw details/summary settings with SettingsPanel

### DIFF
--- a/frontend/src/pages/SevenCardStudPage.test.tsx
+++ b/frontend/src/pages/SevenCardStudPage.test.tsx
@@ -731,4 +731,15 @@ describe('SevenCardStudPage', () => {
     const settingsSummary = Array.from(allSummaries).find((s) => s.textContent?.includes('設定'));
     expect(settingsSummary).toBeTruthy();
   });
+
+  it('renders settings via the standard SettingsPanel component', async () => {
+    mockExec.mockResolvedValue(initState);
+    const { container } = renderWithProviders(<SevenCardStudPage />);
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+    // SettingsPanel items carry stable ids (the raw <details> checkboxes had none).
+    expect(container.querySelector('#frontendHint')).toBeInTheDocument();
+    expect(container.querySelector('#cpuMetaAI')).toBeInTheDocument();
+    expect(screen.getByLabelText('ヒント表示')).toBeInTheDocument();
+    expect(screen.getByLabelText('メタAI（CPUがプレイスタイルを学習）')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/SevenCardStudPage.tsx
+++ b/frontend/src/pages/SevenCardStudPage.tsx
@@ -7,6 +7,7 @@ import { CpuActionLog } from '../components/CpuActionLog';
 import { CpuActionToast } from '../components/CpuActionToast';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
@@ -357,6 +358,31 @@ function SevenCardStudPageContent() {
             />
           </div>
 
+          {/* Settings */}
+          <SettingsPanel
+            title={tc('settings.title')}
+            groups={[
+              {
+                items: [
+                  {
+                    type: 'checkbox' as const,
+                    id: 'frontendHint',
+                    label: tc('hint.toggle', { ns: 'tutorial' }),
+                    checked: hintEnabled,
+                    onToggle: setHintEnabled,
+                  },
+                  {
+                    type: 'checkbox' as const,
+                    id: 'cpuMetaAI',
+                    label: t('settings.cpuMetaAI'),
+                    checked: cpuMetaAI,
+                    onToggle: setCpuMetaAI,
+                  },
+                ],
+              },
+            ]}
+          />
+
           {/* Sticky footer: player hand + buttons */}
           <GameFooter className={`${gameTheme.sevencardstud.footer} px-5 py-3`}>
             {/* Human player */}
@@ -522,22 +548,6 @@ function SevenCardStudPageContent() {
               </div>
             )}
 
-            {/* Settings + Reset */}
-            <details className="mb-1">
-              <summary className="cursor-pointer select-none text-ds-text-primary text-sm font-bold py-1">
-                {tc('settings.title')}
-              </summary>
-              <div className="flex items-center gap-3 py-1">
-                <label className="text-ds-text-primary text-sm flex items-center gap-1">
-                  <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
-                  {tc('hint.toggle', { ns: 'tutorial' })}
-                </label>
-                <label className="text-ds-text-primary text-sm flex items-center gap-1">
-                  <input type="checkbox" checked={cpuMetaAI} onChange={(e) => setCpuMetaAI(e.target.checked)} />
-                  {t('settings.cpuMetaAI')}
-                </label>
-              </div>
-            </details>
             <GameResetButton
               isGameEnd={phase === SevenCardStudPhase.SHOWDOWN || phase === SevenCardStudPhase.END}
               onReset={handleManualReset}


### PR DESCRIPTION
## Summary

`SevenCardStudPage`'s settings area was a hand-rolled `<details>/<summary>` block inside the footer — no design tokens, no gear icon, no 44px tap targets. The hint toggle and CPU meta-AI toggle now live in the shared `<SettingsPanel>` (placed above `GameFooter`, the Klondike/ClockSolitaire pattern). The component keeps the native `<details>` element, so keyboard open/close (Enter/Space) works as before.

Note: the issue body mentions a difficulty selector, but the page has none — the actual `<details>` contents were the two checkboxes (hint, cpuMetaAI), both migrated.

## Test plan

- [x] TDD Red→Green: new test `renders settings via the standard SettingsPanel component` asserts the panel's stable item ids (`#frontendHint`, `#cpuMetaAI`) and both labelled checkboxes — failed before, passes after
- [x] Pre-existing tests pass unchanged, proving behavior preservation: `toggles cpuMetaAI checkbox and sends reset with metaAI flag` (settings still reach game logic) and `wraps settings in collapsible details element` (keyboard-collapsible)
- [x] All 52 SevenCardStudPage tests pass locally; Biome clean; local `tsc -b` passes
- [ ] CI: build, frontend tests, E2E, codecov/patch

Closes #2206

🤖 Generated with [Claude Code](https://claude.com/claude-code)