### PR TITLE
feat(razz): replace raw details/summary settings with SettingsPanel

### DIFF
--- a/frontend/src/pages/RazzPage.test.tsx
+++ b/frontend/src/pages/RazzPage.test.tsx
@@ -746,6 +746,17 @@ describe('RazzPage', () => {
     expect(settingsSummary).toBeTruthy();
   });
 
+  it('renders settings via the standard SettingsPanel component', async () => {
+    mockExec.mockResolvedValue(initState);
+    const { container } = renderWithProviders(<RazzPage />);
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+    // SettingsPanel items carry stable ids (the raw <details> checkboxes had none).
+    expect(container.querySelector('#frontendHint')).toBeInTheDocument();
+    expect(container.querySelector('#cpuMetaAI')).toBeInTheDocument();
+    expect(screen.getByLabelText('ヒント表示')).toBeInTheDocument();
+    expect(screen.getByLabelText('メタAI（CPUがプレイスタイルを学習）')).toBeInTheDocument();
+  });
+
   // ---- CLI mode ----
   it('renders CliTerminal when CLI mode is enabled', async () => {
     mockUseCliMode.mockReturnValue({

--- a/frontend/src/pages/RazzPage.tsx
+++ b/frontend/src/pages/RazzPage.tsx
@@ -7,6 +7,7 @@ import { CpuActionLog } from '../components/CpuActionLog';
 import { CpuActionToast } from '../components/CpuActionToast';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
@@ -356,6 +357,31 @@ function RazzPageContent() {
             />
           </div>
 
+          {/* Settings */}
+          <SettingsPanel
+            title={tc('settings.title')}
+            groups={[
+              {
+                items: [
+                  {
+                    type: 'checkbox' as const,
+                    id: 'frontendHint',
+                    label: tc('hint.toggle', { ns: 'tutorial' }),
+                    checked: hintEnabled,
+                    onToggle: setHintEnabled,
+                  },
+                  {
+                    type: 'checkbox' as const,
+                    id: 'cpuMetaAI',
+                    label: t('settings.cpuMetaAI'),
+                    checked: cpuMetaAI,
+                    onToggle: setCpuMetaAI,
+                  },
+                ],
+              },
+            ]}
+          />
+
           {/* Sticky footer: player hand + buttons */}
           <GameFooter className={`${gameTheme.razz.footer} px-5 py-3`}>
             {/* Human player */}
@@ -521,22 +547,6 @@ function RazzPageContent() {
               </div>
             )}
 
-            {/* Settings + Reset */}
-            <details className="mb-1">
-              <summary className="cursor-pointer select-none text-ds-text-primary text-sm font-bold py-1">
-                {tc('settings.title')}
-              </summary>
-              <div className="flex items-center gap-3 py-1">
-                <label className="text-ds-text-primary text-sm flex items-center gap-1">
-                  <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
-                  {tc('hint.toggle', { ns: 'tutorial' })}
-                </label>
-                <label className="text-ds-text-primary text-sm flex items-center gap-1">
-                  <input type="checkbox" checked={cpuMetaAI} onChange={(e) => setCpuMetaAI(e.target.checked)} />
-                  {t('settings.cpuMetaAI')}
-                </label>
-              </div>
-            </details>
             <GameResetButton
               isGameEnd={phase === SevenCardStudPhase.SHOWDOWN || phase === SevenCardStudPhase.END}
               onReset={handleManualReset}


### PR DESCRIPTION
## Summary

The exact twin of #2407 (Seven Card Stud) applied to `RazzPage` (an SCS clone): the hand-rolled `<details>/<summary>` settings block inside the footer is replaced with the shared `<SettingsPanel>` placed above `GameFooter`, carrying the hint toggle and the CPU meta-AI toggle. Keyboard open/close keeps working via the component's native `<details>`.

## Test plan

- [x] TDD Red→Green: new test `renders settings via the standard SettingsPanel component` asserts the stable item ids (`#frontendHint`, `#cpuMetaAI`) and both labelled checkboxes — failed before, passes after
- [x] Pre-existing tests pass unchanged: `toggles cpuMetaAI checkbox and sends reset with metaAI flag` (settings still reach reset) and `wraps settings in collapsible details element`
- [x] All 59 RazzPage tests pass locally; Biome clean; local `tsc -b` passes
- [ ] CI: build, frontend tests, E2E, codecov/patch

Closes #2226

🤖 Generated with [Claude Code](https://claude.com/claude-code)