### PR TITLE
fix(russiansolitaire): name the hinted card in the sr-only live region

### DIFF
--- a/frontend/src/i18n/locales/en/russiansolitaire.json
+++ b/frontend/src/i18n/locales/en/russiansolitaire.json
@@ -21,6 +21,7 @@
   "hintAvailable": "Hint available",
   "hintFromAria": "Hint: move this card to {{dest}}",
   "hintToAria": "Hint: destination for the hinted card",
+  "hintAnnouncement": "Hint: move {{card}} to {{dest}}",
   "foundationAriaLabel": "{{suit}} foundation {{count}} cards",
   "emptyFoundationAriaLabel": "Empty foundation ({{suit}})",
   "stalemate": "Stalemate",

--- a/frontend/src/i18n/locales/ja/russiansolitaire.json
+++ b/frontend/src/i18n/locales/ja/russiansolitaire.json
@@ -21,6 +21,7 @@
   "hintAvailable": "ヒントがあります",
   "hintFromAria": "ヒント: このカードを{{dest}}へ移動",
   "hintToAria": "ヒント: 移動先",
+  "hintAnnouncement": "ヒント: {{card}}を{{dest}}へ移動",
   "foundationAriaLabel": "{{suit}} 組札 {{count}}枚",
   "emptyFoundationAriaLabel": "空の組札 ({{suit}})",
   "stalemate": "手詰まりです",

--- a/frontend/src/pages/RussianSolitairePage.test.tsx
+++ b/frontend/src/pages/RussianSolitairePage.test.tsx
@@ -108,8 +108,11 @@ describe('RussianSolitairePage', () => {
     );
     expect(screen.getByRole('button', { name: /ヒント: 移動先/ })).toBeInTheDocument();
     // The hint live region survives for screen readers but is visually hidden,
-    // so it no longer squeezes the footer on mobile.
-    expect(screen.getByRole('status')).toHaveClass('sr-only');
+    // so it no longer squeezes the footer on mobile. It names the card since
+    // "this card" is ambiguous when announced without focus context.
+    const liveRegion = screen.getByRole('status');
+    expect(liveRegion).toHaveClass('sr-only');
+    expect(liveRegion).toHaveTextContent('♥ 8');
   });
 
   it('labels the hint source with the foundation destination', async () => {

--- a/frontend/src/pages/RussianSolitairePage.tsx
+++ b/frontend/src/pages/RussianSolitairePage.tsx
@@ -311,6 +311,8 @@ function RussianSolitairePageContent() {
       ? t('foundation')
       : `${t('tableau')} ${state.hint.toCol}`
     : '';
+  const hintCard = state.hint ? state.tableau[state.hint.fromCol]?.[state.hint.cardIndex]?.card : null;
+  const hintCardName = hintCard ? cardAlt(hintCard) : '';
 
   const isSourceSelected = (zone: string, col?: number, cardIndex?: number) =>
     selectedSource !== null &&
@@ -528,7 +530,7 @@ function RussianSolitairePageContent() {
             {/* Visually hidden so the hint costs no footer space, but still announced to AT. */}
             {state.hint && (
               <div className="sr-only" role="status" aria-live="polite">
-                {t('hintFromAria', { dest: hintDest })}
+                {t('hintAnnouncement', { card: hintCardName, dest: hintDest })}
               </div>
             )}
             {frontendHintEnabled && frontendHint && (


### PR DESCRIPTION
## Summary

Follow-up promised on #2411: Gemini's review there pointed out that the sr-only live region's "このカード" (this card) is ambiguous when announced without focus context, and the Yukon page shipped with a card-naming `hintAnnouncement` key. This aligns the Russian Solitaire twin (merged earlier in #2410 with the older wording) to the same pattern: the live region now reads e.g. ヒント: ♥ 8を場札 4へ移動 via hoisted `hintCard`/`hintCardName` consts and `hintAnnouncement` keys (ja+en).

## Test plan

- [x] Live-region test now asserts the card name (♥ 8) appears in the `sr-only` status region — mirrors the Yukon test
- [x] All 17 RussianSolitairePage tests pass locally; Biome clean; local `tsc -b` passes
- [ ] CI: build, frontend tests, E2E, codecov/patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)