### PR TITLE
feat(fiftyone): guide the next selection while the exchange button is disabled

### DIFF
--- a/frontend/src/i18n/locales/en/fiftyone.json
+++ b/frontend/src/i18n/locales/en/fiftyone.json
@@ -4,6 +4,10 @@
     "exchangeAll": "Exchange All",
     "stop": "Stop"
   },
+  "guide": {
+    "selectHand": "Select a card from your hand",
+    "selectTable": "Select a table card"
+  },
   "phase": {
     "play": "Playing",
     "end": "End"

--- a/frontend/src/i18n/locales/ja/fiftyone.json
+++ b/frontend/src/i18n/locales/ja/fiftyone.json
@@ -4,6 +4,10 @@
     "exchangeAll": "全交換",
     "stop": "ストップ"
   },
+  "guide": {
+    "selectHand": "手札を選択してください",
+    "selectTable": "場札を選択してください"
+  },
   "phase": {
     "play": "プレイ中",
     "end": "終了"

--- a/frontend/src/pages/FiftyOnePage.test.tsx
+++ b/frontend/src/pages/FiftyOnePage.test.tsx
@@ -123,6 +123,33 @@ describe('FiftyOnePage', () => {
     expect(exchangeBtn).toBeDisabled();
   });
 
+  it('guides the next selection while the exchange button is disabled', async () => {
+    const { FiftyOnePage } = await import('./FiftyOnePage');
+    renderWithProviders(<FiftyOnePage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    // Nothing selected → prompt for a hand card.
+    expect(screen.getByText('手札を選択してください')).toBeInTheDocument();
+
+    // Hand selected → prompt for a table card.
+    fireEvent.click(screen.getByRole('button', { name: '♠ A' }));
+    expect(screen.getByText('場札を選択してください')).toBeInTheDocument();
+    expect(screen.queryByText('手札を選択してください')).not.toBeInTheDocument();
+
+    // Both selected → guide disappears, button enabled.
+    fireEvent.click(screen.getByRole('button', { name: '♠ K' }));
+    expect(screen.queryByText(/を選択してください/)).not.toBeInTheDocument();
+    expect(screen.getByTestId('exchange-button')).not.toBeDisabled();
+  });
+
+  it('hides the selection guide when it is not the human turn', async () => {
+    mockExec.mockResolvedValue({ ...baseState, currentTurn: 1 });
+    const { FiftyOnePage } = await import('./FiftyOnePage');
+    renderWithProviders(<FiftyOnePage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(screen.queryByText(/を選択してください/)).not.toBeInTheDocument();
+  });
+
   it('renders suit score badges and highlights the leading suit', async () => {
     const { FiftyOnePage } = await import('./FiftyOnePage');
     renderWithProviders(<FiftyOnePage />);

--- a/frontend/src/pages/FiftyOnePage.tsx
+++ b/frontend/src/pages/FiftyOnePage.tsx
@@ -157,6 +157,13 @@ function FiftyOnePageContent() {
   const human = state.players[0];
   const phaseName = isGameEnd ? t('phase.end') : t('phase.play');
   const canExchange = isHumanTurn && selectedHandIdx !== null && selectedTableIdx !== null;
+  const exchangeGuide = !isHumanTurn
+    ? ''
+    : selectedHandIdx === null
+      ? t('guide.selectHand')
+      : selectedTableIdx === null
+        ? t('guide.selectTable')
+        : '';
 
   return (
     <GamePageShell
@@ -316,6 +323,7 @@ function FiftyOnePageContent() {
                 type="button"
                 onClick={handleExchange}
                 disabled={loading || !canExchange}
+                title={exchangeGuide || undefined}
                 className="px-4 py-2 rounded-lg bg-ds-info hover:bg-ds-info text-white font-medium disabled:opacity-40 disabled:cursor-not-allowed text-sm"
                 data-testid="exchange-button"
               >
@@ -353,6 +361,10 @@ function FiftyOnePageContent() {
                 hideActionLog={hideActionLog}
               />
             </div>
+            {/* Always rendered so the footer height stays stable while selections toggle. */}
+            <p className="text-xs text-ds-text-muted text-center mt-1 mb-0 min-h-4" role="note">
+              {exchangeGuide}
+            </p>
           </GameFooter>
         </>
       )}


### PR DESCRIPTION
## Summary

Fifty-One's 交換 (exchange) button is disabled until both a hand card and a table card are selected, but the UI gave no clue what to pick first. A small muted guide line now appears under the footer buttons (and as the button's `title`), driven by which selection is missing:

- nothing selected → 手札を選択してください / "Select a card from your hand"
- hand selected → 場札を選択してください / "Select a table card"
- both selected (or not the human's turn) → no guide

New `guide.selectHand` / `guide.selectTable` keys in ja+en.

## Test plan

- [x] TDD Red→Green: `guides the next selection while the exchange button is disabled` walks all three states (hand prompt → table prompt → hidden + button enabled) by clicking ♠A then ♠K; `hides the selection guide when it is not the human turn` covers the CPU-turn branch
- [x] All 9 FiftyOnePage tests pass locally; Biome clean; local `tsc -b` passes
- [x] i18n parity checker: ja/en fiftyone.json fully in sync
- [ ] CI: build, frontend tests, E2E, codecov/patch

Closes #2216

🤖 Generated with [Claude Code](https://claude.com/claude-code)