### PR TITLE
feat(accordion): show an end-game score summary banner

### DIFF
--- a/frontend/src/i18n/locales/en/accordion.json
+++ b/frontend/src/i18n/locales/en/accordion.json
@@ -12,6 +12,10 @@
   "undo": "Undo",
   "gameClear": "Game Clear! Moves: {{moveCount}}",
   "gameOver": "Game Over",
+  "result": {
+    "clear": "Cleared! Down to 1 pile in {{moveCount}} moves",
+    "gameOver": "{{pileCount}} piles left / {{moveCount}} moves"
+  },
   "playing": "Playing",
   "noHint": "No hints available",
   "hintAvailable": "Hint available",

--- a/frontend/src/i18n/locales/ja/accordion.json
+++ b/frontend/src/i18n/locales/ja/accordion.json
@@ -12,6 +12,10 @@
   "undo": "元に戻す",
   "gameClear": "ゲームクリア！ 手数: {{moveCount}}",
   "gameOver": "ゲームオーバー",
+  "result": {
+    "clear": "クリア！ {{moveCount}}手で1パイルに収束",
+    "gameOver": "残り{{pileCount}}パイル / {{moveCount}}手"
+  },
   "playing": "プレイ中",
   "noHint": "ヒントはありません",
   "hintAvailable": "ヒントがあります",

--- a/frontend/src/pages/AccordionPage.test.tsx
+++ b/frontend/src/pages/AccordionPage.test.tsx
@@ -81,6 +81,24 @@ describe('AccordionPage', () => {
     await waitFor(() => expect(screen.getAllByText('ゲームオーバー').length).toBeGreaterThan(0));
   });
 
+  it('shows a clear summary banner after game clear', async () => {
+    mockExec.mockResolvedValue(gameClearState);
+    renderWithProviders(<AccordionPage />);
+    await waitFor(() => expect(screen.getByTestId('result-banner')).toHaveTextContent('クリア！ 51手'));
+  });
+
+  it('shows the remaining-piles summary banner after game over', async () => {
+    mockExec.mockResolvedValue(gameOverState);
+    renderWithProviders(<AccordionPage />);
+    await waitFor(() => expect(screen.getByTestId('result-banner')).toHaveTextContent('残り4パイル / 0手'));
+  });
+
+  it('does not show the result banner while playing', async () => {
+    renderWithProviders(<AccordionPage />);
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+    expect(screen.queryByTestId('result-banner')).not.toBeInTheDocument();
+  });
+
   it('hint button triggers hint command', async () => {
     renderWithProviders(<AccordionPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));

--- a/frontend/src/pages/AccordionPage.tsx
+++ b/frontend/src/pages/AccordionPage.tsx
@@ -368,6 +368,23 @@ function AccordionPageContent() {
               messageParams={state.messageParams}
             />
 
+            {isEnded && (
+              <div
+                data-testid="result-banner"
+                role="status"
+                aria-live="polite"
+                className={
+                  isGameClear
+                    ? 'text-sm text-center font-medium rounded px-3 py-1.5 mt-1 border bg-ds-success/20 text-ds-success border-ds-success'
+                    : 'text-sm text-center font-medium rounded px-3 py-1.5 mt-1 border bg-ds-error/20 text-ds-error border-ds-error'
+                }
+              >
+                {isGameClear
+                  ? t('result.clear', { moveCount: state.moveCount })
+                  : t('result.gameOver', { pileCount: state.pileCount, moveCount: state.moveCount })}
+              </div>
+            )}
+
             {state.hint && (
               <div
                 className="text-sm text-ds-accent bg-ds-surface/90 border border-ds-accent rounded px-3 py-1.5 mt-1"


### PR DESCRIPTION
## Summary

Accordion ends (52 piles → goal: 1) with only a phase-name change — no feedback on how close the run got. A summary banner now renders directly under `GameMessageBox` at game end:

- **Clear** (green, `bg-ds-success/20`): クリア！ {{moveCount}}手で1パイルに収束 / "Cleared! Converged to 1 pile in N moves"
- **Game over** (red, `bg-ds-error/20`): 残り{{pileCount}}パイル / {{moveCount}}手 / "N piles left / M moves"

Hidden while `isEnded` is false. Built from existing `state.pileCount`/`state.moveCount` — no API change. New `result.clear`/`result.gameOver` keys in ja+en.

## Test plan

- [x] TDD Red→Green: banner-content tests for clear (クリア！ 51手) and game over (残り4パイル / 0手), plus an absence test while playing — clear/game-over tests failed before, pass after
- [x] All 36 AccordionPage tests pass locally; Biome clean; local `tsc -b` passes
- [x] i18n parity checker: ja/en accordion.json fully in sync (24 keys)
- [ ] CI: build, frontend tests, E2E, codecov/patch

Closes #2229

🤖 Generated with [Claude Code](https://claude.com/claude-code)