### PR TITLE
feat(pageone): show the play condition under the discard top card

### DIFF
--- a/frontend/src/i18n/locales/en/pageone.json
+++ b/frontend/src/i18n/locales/en/pageone.json
@@ -16,6 +16,7 @@
   "round": "Round {{n}}",
   "drawPile": "Draw pile: {{count}}",
   "discardTop": "Discard",
+  "playCondition": "Playable: {{suit}} or {{rank}}",
   "cards": "{{count}} cards",
   "cumulativeScore": "Total: {{score}}",
   "roundScore": "Round: {{score}}",

--- a/frontend/src/i18n/locales/ja/pageone.json
+++ b/frontend/src/i18n/locales/ja/pageone.json
@@ -16,6 +16,7 @@
   "round": "ラウンド {{n}}",
   "drawPile": "山札: {{count}}枚",
   "discardTop": "捨て札",
+  "playCondition": "出せる条件: {{suit}} または {{rank}}",
   "cards": "{{count}}枚",
   "cumulativeScore": "累計: {{score}}",
   "roundScore": "ラウンド: {{score}}",

--- a/frontend/src/pages/PageOnePage.test.tsx
+++ b/frontend/src/pages/PageOnePage.test.tsx
@@ -91,6 +91,19 @@ describe('PageOnePage', () => {
     });
   });
 
+  it('shows the play-condition badge under the discard top', async () => {
+    renderWithProviders(<PageOnePage />);
+    // discardTop is ♥7 → playable cards are hearts or 7s.
+    await waitFor(() => expect(screen.getByText('出せる条件: ♥ または 7')).toBeInTheDocument());
+  });
+
+  it('hides the play-condition badge when the discard pile is empty', async () => {
+    mockExec.mockResolvedValue({ ...playPhaseState, discardTop: null });
+    renderWithProviders(<PageOnePage />);
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+    expect(screen.queryByText(/出せる条件/)).not.toBeInTheDocument();
+  });
+
   it('does not show play/draw buttons when not human turn', async () => {
     mockExec.mockResolvedValue(cpuTurnState);
     renderWithProviders(<PageOnePage />);

--- a/frontend/src/pages/PageOnePage.tsx
+++ b/frontend/src/pages/PageOnePage.tsx
@@ -30,7 +30,8 @@ import { gameTheme } from '../styles/gameTheme';
 import type { PageOneResponse } from '../types/card';
 import { PageOnePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
-import { cardAlt } from '../utils/cardAlt';
+import { cardAlt, suitSymbol } from '../utils/cardAlt';
+import { valueName } from '../utils/cardUtils';
 import { PAGEONE_HELP, parsePageoneCommand } from '../utils/cli/commands/pageoneCommands';
 import { formatPageoneState } from '../utils/cli/formatters/pageoneFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -224,6 +225,12 @@ function PageOnePageContent() {
                     <AnimatedCard card={state.discardTop} width={cardWidth} />
                     <div className="text-ds-text-muted text-sm">
                       <div>{t('discardTop')}</div>
+                      <div className="text-xs text-ds-accent mt-0.5">
+                        {t('playCondition', {
+                          suit: suitSymbol(state.discardTop.design),
+                          rank: valueName(state.discardTop.value),
+                        })}
+                      </div>
                     </div>
                   </div>
                 )}

--- a/frontend/src/utils/cardAlt.test.ts
+++ b/frontend/src/utils/cardAlt.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import i18n from '../i18n';
 import type { CardDesign } from '../types/card';
-import { cardAlt } from './cardAlt';
+import { cardAlt, suitSymbol } from './cardAlt';
 
 describe('cardAlt', () => {
   it('returns localized joker text for JOKER', () => {
@@ -26,5 +26,20 @@ describe('cardAlt', () => {
 
   it('falls back to raw design for unknown design', () => {
     expect(cardAlt({ design: 'UNKNOWN' as CardDesign, value: 3 })).toBe('UNKNOWN 3');
+  });
+});
+
+describe('suitSymbol', () => {
+  it.each<[CardDesign, string]>([
+    ['SPADE', '♠'],
+    ['HEART', '♥'],
+    ['DIAMOND', '♦'],
+    ['CLOVER', '♣'],
+  ])('maps %s to %s', (design, symbol) => {
+    expect(suitSymbol(design)).toBe(symbol);
+  });
+
+  it('falls back to the raw design for unknown designs', () => {
+    expect(suitSymbol('JOKER')).toBe('JOKER');
   });
 });

--- a/frontend/src/utils/cardAlt.ts
+++ b/frontend/src/utils/cardAlt.ts
@@ -9,9 +9,13 @@ const DESIGN_SYMBOLS: Record<string, string> = {
   CLOVER: '♣',
 };
 
+/** Return the suit symbol for a card design (e.g. SPADE → ♠), or the raw design when unknown. */
+export function suitSymbol(design: Card['design']): string {
+  return DESIGN_SYMBOLS[design] ?? design;
+}
+
 /** Return accessible alt text for a card: localized "Joker" for jokers, "♠ A" style for normal cards. */
 export function cardAlt(card: Card): string {
   if (card.design === 'JOKER') return i18n.t('common:card.joker');
-  const symbol = DESIGN_SYMBOLS[card.design] ?? card.design;
-  return `${symbol} ${valueName(card.value)}`;
+  return `${suitSymbol(card.design)} ${valueName(card.value)}`;
 }


### PR DESCRIPTION
## Summary

Page One's discard area showed only the top card — nothing on screen explained the play rule (same suit or same rank). A small accent badge now sits under the 捨て札 label: 出せる条件: ♥ または 7 / "Playable: ♥ or 7", derived from `discardTop.design`/`value`. Hidden when the discard pile is empty (the whole block already gates on `discardTop`).

Implementation note: the suit-symbol map lived privately inside `cardAlt`; it's now exposed as a `suitSymbol(design)` util (with `cardAlt` refactored to use it) rather than duplicating the map in the page.

## Test plan

- [x] TDD Red→Green: page tests for the badge content (♥7 fixture) and its absence with `discardTop: null`; unit tests for the new `suitSymbol` (4 suits + unknown fallback) — all failed before, pass after
- [x] All 29 affected tests pass locally (PageOnePage + cardAlt); Biome clean; local `tsc -b` passes
- [x] i18n parity checker: ja/en pageone.json fully in sync (43 keys)
- [ ] CI: build, frontend tests, E2E, codecov/patch

Closes #2222

🤖 Generated with [Claude Code](https://claude.com/claude-code)