### PR TITLE
feat(ohhell): show a bid-progress chip in the game header

### DIFF
--- a/frontend/src/i18n/locales/en/ohhell.json
+++ b/frontend/src/i18n/locales/en/ohhell.json
@@ -32,6 +32,7 @@
   "roundScore": "Round: {{score}}",
   "bid": "Bid {{n}}",
   "bidNone": "No bid",
+  "bidProgress": "Bid: {{bid}} / Won: {{won}}",
   "currentTrick": "Current Trick",
   "scores": "Scores",
   "scoresPlayer": "Player",

--- a/frontend/src/i18n/locales/ja/ohhell.json
+++ b/frontend/src/i18n/locales/ja/ohhell.json
@@ -32,6 +32,7 @@
   "roundScore": "ラウンド: {{score}}",
   "bid": "ビッド {{n}}",
   "bidNone": "未ビッド",
+  "bidProgress": "宣言: {{bid}} / 獲得: {{won}}",
   "currentTrick": "現在のトリック",
   "scores": "スコア",
   "scoresPlayer": "プレイヤー",

--- a/frontend/src/pages/OhHellPage.test.tsx
+++ b/frontend/src/pages/OhHellPage.test.tsx
@@ -164,6 +164,78 @@ describe('OhHellPage', () => {
     });
   });
 
+  it('shows the bid-progress chip in the header during play', async () => {
+    renderWithProviders(<OhHellPage />);
+    // Human bid 2, won 0, 5 cards left \u2192 still achievable \u2192 neutral info colors.
+    const chip = await screen.findByTestId('bid-progress-chip');
+    expect(chip).toHaveTextContent('\u5ba3\u8a00: 2 / \u7372\u5f97: 0');
+    expect(chip.className).toContain('border-ds-border-subtle');
+  });
+
+  it('colors the progress chip green when tricks match the bid', async () => {
+    mockExec.mockResolvedValue({
+      ...playPhaseState,
+      players: [{ ...playPhaseState.players[0], trickCount: 2 }, ...playPhaseState.players.slice(1)],
+    });
+    renderWithProviders(<OhHellPage />);
+    const chip = await screen.findByTestId('bid-progress-chip');
+    expect(chip).toHaveTextContent('\u5ba3\u8a00: 2 / \u7372\u5f97: 2');
+    expect(chip.className).toContain('border-ds-success');
+  });
+
+  it('colors the progress chip yellow when tricks exceed the bid', async () => {
+    mockExec.mockResolvedValue({
+      ...playPhaseState,
+      players: [{ ...playPhaseState.players[0], trickCount: 3 }, ...playPhaseState.players.slice(1)],
+    });
+    renderWithProviders(<OhHellPage />);
+    const chip = await screen.findByTestId('bid-progress-chip');
+    expect(chip.className).toContain('border-ds-warning');
+  });
+
+  it('colors the progress chip red when the bid is no longer reachable', async () => {
+    mockExec.mockResolvedValue({
+      ...playPhaseState,
+      players: [{ ...playPhaseState.players[0], cardCount: 1 }, ...playPhaseState.players.slice(1)],
+    });
+    renderWithProviders(<OhHellPage />);
+    // Needs 2 more tricks with only 1 card left.
+    const chip = await screen.findByTestId('bid-progress-chip');
+    expect(chip.className).toContain('border-ds-error');
+  });
+
+  it('does not turn red while the human card in the unresolved trick can still win', async () => {
+    // 1 card in hand + 1 card already played into the open trick → 2 winnable tricks, bid 2 reachable.
+    mockExec.mockResolvedValue({
+      ...playPhaseState,
+      currentTrick: [{ playerIdx: 0, card: { design: 'SPADE', value: 9 } }],
+      players: [{ ...playPhaseState.players[0], cardCount: 1 }, ...playPhaseState.players.slice(1)],
+    });
+    renderWithProviders(<OhHellPage />);
+    const chip = await screen.findByTestId('bid-progress-chip');
+    expect(chip.className).toContain('border-ds-border-subtle');
+    expect(chip.className).not.toContain('border-ds-error');
+  });
+
+  it('hides the progress chip during the bid phase and at game end', async () => {
+    mockExec.mockResolvedValue(bidPhaseState);
+    let view = renderWithProviders(<OhHellPage />);
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+    expect(screen.queryByTestId('bid-progress-chip')).not.toBeInTheDocument();
+    view.unmount();
+
+    mockExec.mockResolvedValue(gameEndState);
+    view = renderWithProviders(<OhHellPage />);
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+    expect(screen.queryByTestId('bid-progress-chip')).not.toBeInTheDocument();
+    view.unmount();
+
+    mockExec.mockResolvedValue(gameEndByFlagState);
+    renderWithProviders(<OhHellPage />);
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+    expect(screen.queryByTestId('bid-progress-chip')).not.toBeInTheDocument();
+  });
+
   it('renders bid phase as a button group of bid choices', async () => {
     mockExec.mockResolvedValue(bidPhaseState);
     renderWithProviders(<OhHellPage />);

--- a/frontend/src/pages/OhHellPage.tsx
+++ b/frontend/src/pages/OhHellPage.tsx
@@ -32,6 +32,7 @@ import {
 } from '../hooks/useOhHellGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
+import { badgeErrorColors, badgeInfoColors, badgeSuccessColors, badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
@@ -84,6 +85,13 @@ const OH_TUTORIAL_STEPS: TutorialStep[] = [
     advanceOn: 'next',
   },
 ];
+
+/** Pick the badge color tokens for the bid-progress chip: green on target, yellow overshot, red unreachable. */
+function progressChipColors(bid: number, won: number, remainingTricks: number): string {
+  if (won === bid) return badgeSuccessColors;
+  if (won > bid) return badgeWarningColors;
+  return bid - won > remainingTricks ? badgeErrorColors : badgeInfoColors;
+}
 
 const OH_HELL_PHASE_KEYS: Readonly<Record<number, string>> = {
   [OhHellPhase.BID]: 'bid',
@@ -192,6 +200,12 @@ function OhHellPageContent() {
     state.players[state.dealerIdx]?.isHuman ?? false,
   );
 
+  // A card already played into the unresolved trick still counts as a winnable trick,
+  // even though cardCount has been decremented for it.
+  const humanIdx = state.players.findIndex((p) => p.isHuman);
+  const humanInCurrentTrick = state.currentTrick.some((tc) => tc.playerIdx === humanIdx);
+  const showProgressChip = !isBidPhase && !isGameEnd && humanPlayer !== undefined && humanPlayer.bid >= 0;
+
   return (
     <GamePageShell
       title={tc('nav.ohhell')}
@@ -205,7 +219,23 @@ function OhHellPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
-      headerExtra={<CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />}
+      headerExtra={
+        <>
+          {showProgressChip && (
+            <span
+              data-testid="bid-progress-chip"
+              className={`rounded-full px-2.5 py-1 text-xs font-medium ${progressChipColors(
+                humanPlayer.bid,
+                humanPlayer.trickCount,
+                humanPlayer.cardCount + (humanInCurrentTrick ? 1 : 0),
+              )}`}
+            >
+              {t('bidProgress', { bid: humanPlayer.bid, won: humanPlayer.trickCount })}
+            </span>
+          )}
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </>
+      }
     >
       {cliEnabled ? (
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />


### PR DESCRIPTION
## Summary

Oh Hell's header only held the CLI toggle — checking your own bid vs. tricks won meant scrolling down to the scoreboard after every trick. A compact chip now sits in `headerExtra`: 宣言: X / 獲得: Y ("Bid: X / Won: Y"), using the opaque `badgeStyles` color tokens per the issue's color spec:

- tricks == bid → `badgeSuccessColors` (green, on target)
- tricks > bid → `badgeWarningColors` (overshot)
- bid − tricks > cards remaining → `badgeErrorColors` (mathematically unreachable)
- otherwise → `badgeInfoColors` (neutral, still achievable)

Hidden during the bid phase (bid not yet final) and at game end (scoreboard takes over). New `bidProgress` key in ja+en.

## Test plan

- [x] TDD Red→Green: five tests — chip text + neutral colors during play, green on-target, yellow overshoot, red unreachable (bid 2, 0 won, 1 card left), and hidden in bid phase + game end — four failed before, all pass after
- [x] All 46 OhHellPage tests pass locally; Biome clean; local `tsc -b` passes
- [x] i18n parity checker: ja/en ohhell.json fully in sync (66 keys)
- [ ] CI: build, frontend tests, E2E, codecov/patch

Closes #2199

🤖 Generated with [Claude Code](https://claude.com/claude-code)