### PR TITLE
feat(paigow): use cardAlt for SET_HANDS card button aria-labels

### DIFF
--- a/frontend/e2e/paigow.spec.ts
+++ b/frontend/e2e/paigow.spec.ts
@@ -12,8 +12,9 @@ test.describe('Pai Gow Poker E2E', () => {
     await waitForLoaded(page);
 
     // SET HANDS phase: select 2 cards and click セット
-    // Cards should be visible; click on the first two to select them for low hand
-    const cards = page.locator('[data-tutorial="pg-set-hands"] button[aria-label^="Card"]');
+    // Cards should be visible; click on the first two to select them for low hand.
+    // Cards are labelled with their suit/rank (cardAlt), so select by the toggle-state attribute.
+    const cards = page.locator('[data-tutorial="pg-set-hands"] button[aria-pressed]');
     await expect(cards.first()).toBeVisible({ timeout: 10_000 });
     await cards.nth(0).click();
     await cards.nth(1).click();

--- a/frontend/src/pages/PaiGowPage.test.tsx
+++ b/frontend/src/pages/PaiGowPage.test.tsx
@@ -4,6 +4,7 @@ import { actionLogApi, paigowApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, PaiGowResponse } from '../types/card';
+import { cardAlt } from '../utils/cardAlt';
 import { PaiGowPage } from './PaiGowPage';
 
 vi.mock('../hooks/useGameHint');
@@ -16,6 +17,10 @@ vi.mock('../api/gameApi', () => ({
 const mockExec = vi.mocked(paigowApi.exec);
 
 const card = (design: CardDesign, value: number): Card => ({ design, value });
+
+/** The 7 SET_HANDS fixture card buttons, in deal order, located by their cardAlt names. */
+const getCardButtons = () =>
+  setHandsPhaseState.playerCards.map((c) => screen.getByRole('button', { name: cardAlt(c) }));
 
 const betPhaseState: PaiGowResponse = {
   playerCards: [],
@@ -137,7 +142,17 @@ describe('PaiGowPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
     await waitFor(() => expect(screen.getByRole('button', { name: 'セット' })).toBeInTheDocument());
     // 7 card buttons should be present
-    expect(screen.getAllByRole('button', { name: /Card \d/ }).length).toBe(7);
+    expect(getCardButtons()).toHaveLength(7);
+  });
+
+  it('labels each card button with its cardAlt name, not a raw index', async () => {
+    mockExec.mockResolvedValue(setHandsPhaseState);
+    renderWithProviders(<PaiGowPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'セット' })).toBeInTheDocument());
+    for (const c of setHandsPhaseState.playerCards) {
+      expect(screen.getByRole('button', { name: cardAlt(c) })).toHaveAttribute('aria-pressed', 'false');
+    }
+    expect(screen.queryByRole('button', { name: /Card \d/ })).not.toBeInTheDocument();
   });
 
   it('set button is disabled until 2 cards are selected', async () => {
@@ -148,7 +163,7 @@ describe('PaiGowPage', () => {
     expect(screen.getByRole('button', { name: 'セット' })).toBeDisabled();
 
     // Select 2 cards
-    const cardButtons = screen.getAllByRole('button', { name: /Card \d/ });
+    const cardButtons = getCardButtons();
     fireEvent.click(cardButtons[0]);
     fireEvent.click(cardButtons[1]);
 
@@ -161,7 +176,7 @@ describe('PaiGowPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: 'セット' })).toBeInTheDocument());
 
     // Pick a non-foul split: low = [C5, S3] keeps the 13 in the high hand.
-    const cardButtons = screen.getAllByRole('button', { name: /Card \d/ });
+    const cardButtons = getCardButtons();
     fireEvent.click(cardButtons[3]);
     fireEvent.click(cardButtons[5]);
 
@@ -175,7 +190,7 @@ describe('PaiGowPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: 'セット' })).toBeInTheDocument());
 
     // Low = [D13, S3] (top 13); high = [S10, H11, C5, H7, D9] (top 11) → foul.
-    const cardButtons = screen.getAllByRole('button', { name: /Card \d/ });
+    const cardButtons = getCardButtons();
     fireEvent.click(cardButtons[2]);
     fireEvent.click(cardButtons[5]);
 
@@ -188,7 +203,7 @@ describe('PaiGowPage', () => {
     renderWithProviders(<PaiGowPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'セット' })).toBeInTheDocument());
 
-    const cardButtons = screen.getAllByRole('button', { name: /Card \d/ });
+    const cardButtons = getCardButtons();
     fireEvent.click(cardButtons[0]);
     fireEvent.click(cardButtons[1]);
     // Deselect first card
@@ -203,7 +218,7 @@ describe('PaiGowPage', () => {
     renderWithProviders(<PaiGowPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'セット' })).toBeInTheDocument());
 
-    const cardButtons = screen.getAllByRole('button', { name: /Card \d/ });
+    const cardButtons = getCardButtons();
     fireEvent.click(cardButtons[0]);
     fireEvent.click(cardButtons[1]);
     fireEvent.click(cardButtons[2]); // should be ignored

--- a/frontend/src/pages/PaiGowPage.tsx
+++ b/frontend/src/pages/PaiGowPage.tsx
@@ -28,6 +28,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { PaiGowResponse } from '../types/card';
 import { PaiGowPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import { PAIGOW_HELP, parsePaigowCommand } from '../utils/cli/commands/paigowCommands';
 import { formatPaigowState } from '../utils/cli/formatters/paigowFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -239,7 +240,7 @@ function PaiGowPageContent() {
                       onClick={() => toggleCardSelection(i)}
                       className={`relative transition-transform ${selectedIndices.includes(i) ? '-translate-y-3 ring-2 ring-ds-warning rounded' : ''}`}
                       aria-pressed={selectedIndices.includes(i)}
-                      aria-label={`Card ${i}`}
+                      aria-label={cardAlt(card)}
                     >
                       <AnimatedCard card={card} width={cardWidth} />
                     </button>


### PR DESCRIPTION
## Summary

Pai Gow's SET_HANDS card buttons had `aria-label={`Card ${i}`}` — a screen-reader user couldn't tell which suit/rank they were splitting into the low hand. The label is now `cardAlt(card)` (♠ 10 style), the shared util used across the other pages. `aria-pressed` selection state is untouched.

## Test plan

- [x] TDD Red→Green: new test asserts every card button is reachable by its `cardAlt` name with `aria-pressed` and that no `Card N` literal remains; the six existing selection tests were converted from `/Card \d/` queries to explicit card-name lookups (deal order preserved) — all 7 failed before the fix, pass after
- [x] All 31 PaiGowPage tests pass locally; Biome clean; local `tsc -b` passes
- [ ] CI: build, frontend tests, E2E, codecov/patch

Closes #2210

🤖 Generated with [Claude Code](https://claude.com/claude-code)