### PR TITLE
feat(durak): add aria-label and aria-pressed to hand card buttons

### DIFF
--- a/frontend/src/pages/DurakPage.test.tsx
+++ b/frontend/src/pages/DurakPage.test.tsx
@@ -111,6 +111,24 @@ describe('DurakPage', () => {
     });
   });
 
+  it('labels hand card buttons with cardAlt and tracks selection via aria-pressed', async () => {
+    renderWithProviders(<DurakPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '♠ A' })).toBeInTheDocument());
+
+    const aceBtn = screen.getByRole('button', { name: '♠ A' });
+    const jackBtn = screen.getByRole('button', { name: '♥ J' });
+    expect(aceBtn).toHaveAttribute('aria-pressed', 'false');
+    expect(jackBtn).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(aceBtn);
+    expect(aceBtn).toHaveAttribute('aria-pressed', 'true');
+    expect(jackBtn).toHaveAttribute('aria-pressed', 'false');
+
+    // Clicking again deselects.
+    fireEvent.click(aceBtn);
+    expect(aceBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+
   it('shows attack button when human is attacker in attack phase', async () => {
     renderWithProviders(<DurakPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '攻撃' })).toBeInTheDocument());

--- a/frontend/src/pages/DurakPage.tsx
+++ b/frontend/src/pages/DurakPage.tsx
@@ -385,6 +385,8 @@ function DurakPageContent() {
                       key={`${card.design}-${card.value}-${i}`}
                       className={`cursor-pointer transition-transform ${selectedCardIdx === i ? '-translate-y-2' : ''}`}
                       onClick={() => setSelectedCardIdx(selectedCardIdx === i ? null : i)}
+                      aria-label={cardAlt(card)}
+                      aria-pressed={selectedCardIdx === i}
                     >
                       <AnimatedCard card={card} width={cardWidth} isSelected={selectedCardIdx === i} />
                     </button>


### PR DESCRIPTION
## Summary

Durak's hand-card buttons wrapped `<AnimatedCard>` with no `aria-label` or `aria-pressed`, so assistive technology had no explicit per-card name or toggle state. They now carry `aria-label={cardAlt(card)}` (♠ A style) and `aria-pressed={selectedCardIdx === i}`, the convention used by Pyramid, Klondike, and the recently fixed Pai Gow (#2418). The visual `-translate-y-2` selection lift is untouched, and `durak.spec.ts` has no attribute-based selectors that this could break (checked after #2418's lesson).

Note on the issue's manual NVDA/VoiceOver acceptance item: not verifiable in this environment — the attributes follow the exact pattern of the pages where it was previously verified.

## Test plan

- [x] TDD Red→Green: new test asserts both buttons are reachable by their cardAlt names with `aria-pressed=false`, that clicking selects exactly one (`true`), and that re-clicking deselects — failed before, passes after
- [x] All 25 DurakPage tests pass locally; Biome clean; local `tsc -b` passes
- [ ] CI: build, frontend tests, E2E, codecov/patch

Closes #2208

🤖 Generated with [Claude Code](https://claude.com/claude-code)