### PR TITLE
feat(jokerpoker): highlight wild cards in the VideoPoker CUI output

### DIFF
--- a/internal/adapter/presenter/VideoPokerCuiPresenter.go
+++ b/internal/adapter/presenter/VideoPokerCuiPresenter.go
@@ -31,7 +31,7 @@ func (vpp *VideoPokerCuiPresenter) Output(vp interfaces.VideoPokerGame, lastErr 
 		holdLabel := i18n.T("videopoker.holdLabel")
 		parts := make([]string, len(hand))
 		for i, card := range hand {
-			s := cuiCardStr(card)
+			s := vpp.cardStr(vp, card)
 			if held[i] {
 				s += " " + holdLabel
 			}
@@ -64,6 +64,21 @@ func (vpp *VideoPokerCuiPresenter) Output(vp interfaces.VideoPokerGame, lastErr 
 // ActionLogOutput 棋譜をテキスト出力
 func (vpp *VideoPokerCuiPresenter) ActionLogOutput(vp interfaces.VideoPokerGame) string {
 	return actionLogOutputText(vp)
+}
+
+// cardStr ワイルドカードを強調した手札カード文字列（ジョーカーは太字黄、Deuces Wildの2は黄）
+func (vpp *VideoPokerCuiPresenter) cardStr(vp interfaces.VideoPokerGame, card *domain.Card) string {
+	if card == nil {
+		return cuiCardStr(card)
+	}
+	if card.GetDesign() == domain.CardDesignJoker {
+		return color.BoldYellow("JOKER")
+	}
+	if card.GetValue() == 2 && vp.GetVariantName() == "deuceswild" {
+		// 赤スートの通常色（赤）を上書きしないよう、素のスート名から組み立てる
+		return color.Yellow(cuiSuitName(card.GetDesign()) + " 2")
+	}
+	return cuiCardStr(card)
 }
 
 // phaseStr フェーズ文字列

--- a/internal/adapter/presenter/VideoPokerCuiPresenter_test.go
+++ b/internal/adapter/presenter/VideoPokerCuiPresenter_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 )
@@ -21,6 +22,7 @@ func setupVideoPokerCuiMockDefaults(m *interfaces.MockVideoPokerGame) {
 	m.On("GetHandName").Return("").Maybe()
 	m.On("GetHeldIndices").Return([domain.VideoPokerHandSize]bool{}).Maybe()
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
+	m.On("GetVariantName").Return("videopoker").Maybe()
 }
 
 func TestVideoPokerCuiPresenter_Output_BetPhase(t *testing.T) {
@@ -107,6 +109,7 @@ func TestVideoPokerCuiPresenter_Output_ResultPhase_Lose(t *testing.T) {
 	m.On("GetHandName").Return("").Maybe()
 	m.On("GetHeldIndices").Return([domain.VideoPokerHandSize]bool{}).Maybe()
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
+	m.On("GetVariantName").Return("videopoker").Maybe()
 
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "役なし。")
@@ -136,4 +139,77 @@ func TestVideoPokerCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetGameEndFlag").Return(false)
 	result := p.ActionLogOutput(m)
 	assert.NotEmpty(t, result)
+}
+
+func TestVideoPokerCuiPresenter_Output_JokerHighlighted(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(false)
+	defer color.SetNoColor(origNoColor)
+
+	p := new(VideoPokerCuiPresenter)
+	m := new(interfaces.MockVideoPokerGame)
+	m.On("GetChips").Return(1000).Maybe()
+	m.On("GetPhase").Return(domain.VideoPokerPhaseDraw).Maybe()
+	m.On("GetGameEndFlag").Return(false).Maybe()
+	m.On("GetHeldIndices").Return([domain.VideoPokerHandSize]bool{}).Maybe()
+	m.On("GetVariantName").Return("jokerpoker").Maybe()
+	m.On("GetHand").Return([]*domain.Card{
+		domain.NewCard(domain.CardDesignJoker, 0, false),
+		domain.NewCard(domain.CardDesignSpade, 5, false),
+	}).Maybe()
+
+	result := p.Output(m, nil)
+	assert.Contains(t, result, color.BoldYellow("JOKER"))
+	assert.Contains(t, result, "SPADE 5")
+}
+
+func TestVideoPokerCuiPresenter_Output_DeucesWildTwosHighlighted(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(false)
+	defer color.SetNoColor(origNoColor)
+
+	p := new(VideoPokerCuiPresenter)
+	m := new(interfaces.MockVideoPokerGame)
+	m.On("GetChips").Return(1000).Maybe()
+	m.On("GetPhase").Return(domain.VideoPokerPhaseDraw).Maybe()
+	m.On("GetGameEndFlag").Return(false).Maybe()
+	m.On("GetHeldIndices").Return([domain.VideoPokerHandSize]bool{}).Maybe()
+	m.On("GetVariantName").Return("deuceswild").Maybe()
+	m.On("GetHand").Return([]*domain.Card{
+		domain.NewCard(domain.CardDesignHeart, 2, false),
+		domain.NewCard(domain.CardDesignSpade, 2, false),
+		domain.NewCard(domain.CardDesignSpade, 5, false),
+	}).Maybe()
+
+	result := p.Output(m, nil)
+	assert.Contains(t, result, color.Yellow("HEART 2"))
+	assert.Contains(t, result, color.Yellow("SPADE 2"))
+	assert.NotContains(t, result, color.Yellow("SPADE 5"))
+}
+
+func TestVideoPokerCuiPresenter_Output_PlainVariantTwoNotHighlighted(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(false)
+	defer color.SetNoColor(origNoColor)
+
+	p := new(VideoPokerCuiPresenter)
+	m := new(interfaces.MockVideoPokerGame)
+	m.On("GetChips").Return(1000).Maybe()
+	m.On("GetPhase").Return(domain.VideoPokerPhaseDraw).Maybe()
+	m.On("GetGameEndFlag").Return(false).Maybe()
+	m.On("GetHeldIndices").Return([domain.VideoPokerHandSize]bool{}).Maybe()
+	m.On("GetVariantName").Return("videopoker").Maybe()
+	m.On("GetHand").Return([]*domain.Card{
+		domain.NewCard(domain.CardDesignSpade, 2, false),
+	}).Maybe()
+
+	result := p.Output(m, nil)
+	assert.Contains(t, result, "SPADE 2")
+	assert.NotContains(t, result, color.Yellow("SPADE 2"))
+}
+
+func TestVideoPokerCuiPresenter_cardStr_NilCard(t *testing.T) {
+	p := new(VideoPokerCuiPresenter)
+	m := new(interfaces.MockVideoPokerGame)
+	assert.Equal(t, "??", p.cardStr(m, nil))
 }


### PR DESCRIPTION
## Summary

In the shared VideoPoker CUI presenter (Joker Poker / Deuces Wild / Jacks or Better), wild cards had no visual emphasis: jokers printed as plain `JOKER` and Deuces Wild 2s looked like any other card. A new variant-aware `cardStr` helper now renders:

- **Jokers** in `color.BoldYellow` (any variant — jokers only exist in the Joker Poker deck)
- **2s** in `color.Yellow`, only when `GetVariantName() == "deuceswild"`, built from the bare suit name so the wild tint isn't overridden by the red-suit coloring
- everything else via the unchanged shared `cuiCardStr`

The change is scoped to `VideoPokerCuiPresenter` — the shared `cuiCardStr` helper used by other games' presenters is untouched. The check is lazy (only when a 2 is in hand), so existing call sites without `GetVariantName` expectations keep working.

## Test plan

- [x] TDD Red→Green: three new table tests — joker renders bold-yellow, both deuceswild 2s render yellow while a 5 stays plain, and a 2 in the plain variant is NOT highlighted — failed before, pass after
- [x] Full `internal/adapter/presenter` package passes locally (`-tags test -p 1`); `golangci-lint` on the package: 0 issues; `goimports` applied
- [ ] CI: backend tests, lint, E2E, codecov/patch

Closes #2193

🤖 Generated with [Claude Code](https://claude.com/claude-code)