### PR TITLE
feat(war): highlight the round winner card and dim the loser

### DIFF
--- a/frontend/src/pages/WarPage.test.tsx
+++ b/frontend/src/pages/WarPage.test.tsx
@@ -110,6 +110,57 @@ describe('WarPage', () => {
     expect(screen.getAllByText(/2/).length).toBeGreaterThan(0);
   });
 
+  it('highlights the winner card and dims the loser when the player wins a round', async () => {
+    mockExec.mockResolvedValueOnce({
+      ...baseState,
+      phase: WarPhase.RESOLVED,
+      playerRevealed: { design: 'SPADE', value: 13 },
+      cpuRevealed: { design: 'HEART', value: 5 },
+      lastWinnerIdx: 0,
+    });
+    renderWithProviders(<WarPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ K')).toBeInTheDocument());
+    expect(screen.getByAltText('♠ K')).toHaveClass('ring-ds-success');
+    expect(screen.getByAltText('♥ 5')).toHaveClass('opacity-60');
+  });
+
+  it('highlights the CPU card when the CPU wins a round', async () => {
+    mockExec.mockResolvedValueOnce({
+      ...baseState,
+      phase: WarPhase.RESOLVED,
+      playerRevealed: { design: 'SPADE', value: 3 },
+      cpuRevealed: { design: 'HEART', value: 9 },
+      lastWinnerIdx: 1,
+    });
+    renderWithProviders(<WarPage />);
+    await waitFor(() => expect(screen.getByAltText('♥ 9')).toBeInTheDocument());
+    expect(screen.getByAltText('♥ 9')).toHaveClass('ring-ds-success');
+    expect(screen.getByAltText('♠ 3')).toHaveClass('opacity-60');
+  });
+
+  it('marks both cards with a warning ring during a war', async () => {
+    mockExec.mockResolvedValueOnce(warPhaseState);
+    renderWithProviders(<WarPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ 7')).toBeInTheDocument());
+    expect(screen.getByAltText('♠ 7')).toHaveClass('ring-ds-warning');
+    expect(screen.getByAltText('♥ 7')).toHaveClass('ring-ds-warning');
+  });
+
+  it('shows no emphasis during the reveal phase', async () => {
+    mockExec.mockResolvedValueOnce({
+      ...baseState,
+      playerRevealed: { design: 'SPADE', value: 4 },
+      cpuRevealed: { design: 'HEART', value: 8 },
+    });
+    renderWithProviders(<WarPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ 4')).toBeInTheDocument());
+    for (const alt of ['♠ 4', '♥ 8']) {
+      expect(screen.getByAltText(alt)).not.toHaveClass('ring-ds-success');
+      expect(screen.getByAltText(alt)).not.toHaveClass('ring-ds-warning');
+      expect(screen.getByAltText(alt)).not.toHaveClass('opacity-60');
+    }
+  });
+
   it('disables step button on game end', async () => {
     mockExec.mockResolvedValueOnce(gameEndState);
     renderWithProviders(<WarPage />);

--- a/frontend/src/pages/WarPage.tsx
+++ b/frontend/src/pages/WarPage.tsx
@@ -60,6 +60,21 @@ const WR_TUTORIAL_STEPS: TutorialStep[] = [
   },
 ];
 
+/**
+ * Pick the emphasis classes for a revealed card: green ring for the round winner
+ * and a dimmed loser when resolved, yellow rings on both cards during a war.
+ */
+function revealedCardEmphasis(phase: number, lastWinnerIdx: number, isPlayer: boolean): string {
+  if (phase === WarPhase.RESOLVED) {
+    const won = isPlayer ? lastWinnerIdx === 0 : lastWinnerIdx === 1;
+    return won ? 'ring-2 ring-ds-success' : 'opacity-60';
+  }
+  if (phase === WarPhase.WAR_BURY) {
+    return 'ring-2 ring-ds-warning';
+  }
+  return '';
+}
+
 /** Renders the War (戦争) game page. */
 export const WarPage = withTutorial(WarPageContent, 'war', WR_TUTORIAL_STEPS);
 /** Inner content of the War page. */
@@ -184,7 +199,11 @@ function WarPageContent() {
               <div className="text-center">
                 <div className="text-xs text-ds-text-muted mb-1">CPU</div>
                 {state.cpuRevealed ? (
-                  <AnimatedCard card={state.cpuRevealed} width={cardWidth * 1.1} />
+                  <AnimatedCard
+                    card={state.cpuRevealed}
+                    width={cardWidth * 1.1}
+                    className={revealedCardEmphasis(state.phase, state.lastWinnerIdx, false)}
+                  />
                 ) : (
                   <div
                     className="rounded border border-dashed border-white/30"
@@ -224,7 +243,11 @@ function WarPageContent() {
               <div className="text-center">
                 <div className="text-xs text-ds-text-muted mb-1">{tc('player.you')}</div>
                 {state.playerRevealed ? (
-                  <AnimatedCard card={state.playerRevealed} width={cardWidth * 1.1} />
+                  <AnimatedCard
+                    card={state.playerRevealed}
+                    width={cardWidth * 1.1}
+                    className={revealedCardEmphasis(state.phase, state.lastWinnerIdx, true)}
+                  />
                 ) : (
                   <div
                     className="rounded border border-dashed border-white/30"


### PR DESCRIPTION
## Summary

War's RESOLVED phase told you who won a round only via the message text. The revealed cards now show it directly, per the issue spec:

- **RESOLVED**: winner card gets `ring-2 ring-ds-success`, loser gets `opacity-60` (driven by `lastWinnerIdx`: 0 = player, 1 = CPU, verified against `domain/War.go`)
- **WAR_BURY**: both cards get `ring-2 ring-ds-warning`
- **REVEAL / reset**: no emphasis

The branching lives in a pure module-level `revealedCardEmphasis(phase, lastWinnerIdx, isPlayer)` helper; the classes ride `AnimatedCard`'s `className` passthrough (ClockSolitaire precedent).

## Test plan

- [x] TDD Red→Green: four tests — player-wins (green ring + dimmed CPU card), CPU-wins (reverse), war phase (both yellow), and reveal phase (no emphasis classes) — three failed before, all pass after
- [x] All 15 WarPage tests pass locally; Biome clean; local `tsc -b` passes
- [ ] CI: build, frontend tests, E2E, codecov/patch

Closes #2214

🤖 Generated with [Claude Code](https://claude.com/claude-code)