### PR TITLE
feat(golf): add the standard frontend hint (useGameHint + SettingsPanel toggle)

### DIFF
--- a/frontend/src/hooks/useGameHint.ts
+++ b/frontend/src/hooks/useGameHint.ts
@@ -42,6 +42,7 @@ import type {
   GapsResponse,
   GinRummyResponse,
   GoFishResponse,
+  GolfResponse,
   GongZhuResponse,
   HeartsResponse,
   HighCardFlushResponse,
@@ -154,6 +155,7 @@ import { getFreeCellHint } from '../utils/hints/freecellHint';
 import { getGapsHint } from '../utils/hints/gapsHint';
 import { getGinRummyHint } from '../utils/hints/ginrummyHint';
 import { getGoFishHint } from '../utils/hints/gofishHint';
+import { getGolfHint } from '../utils/hints/golfHint';
 import { getGongZhuHint } from '../utils/hints/gongzhuHint';
 import { getHeartsHint } from '../utils/hints/heartsHint';
 import { getHighCardFlushHint } from '../utils/hints/highcardflushHint';
@@ -286,6 +288,7 @@ const hintFactories = {
   ginrummy: (s) => getGinRummyHint(s as GinRummyResponse),
   cribbage: (s) => getCribbageHint(s as CribbageResponse),
   gofish: (s) => getGoFishHint(s as GoFishResponse),
+  golf: (s) => getGolfHint(s as GolfResponse),
   caribbeanstud: (s) => getCaribbeanStudHint(s as CaribbeanStudResponse),
   casinoholdem: (s) => getCasinoHoldemHint(s as CasinoHoldemResponse),
   texasholdembonus: (s) => getTexasHoldemBonusHint(s as TexasHoldemBonusResponse),

--- a/frontend/src/pages/GolfPage.test.tsx
+++ b/frontend/src/pages/GolfPage.test.tsx
@@ -69,6 +69,7 @@ const gameOverState: GolfResponse = {
 };
 
 beforeEach(() => {
+  localStorage.clear();
   mockExec.mockResolvedValue(playingState);
   mockCombo.mockReturnValue(0);
 });
@@ -79,6 +80,21 @@ describe('GolfPage', () => {
     renderWithProviders(<GolfPage />);
     const pulseElements = document.querySelectorAll('.animate-pulse');
     expect(pulseElements.length).toBeGreaterThan(0);
+  });
+
+  it('offers the frontend hint toggle in the settings panel', async () => {
+    renderWithProviders(<GolfPage />);
+    await waitFor(() => expect(screen.getByText('捨て札')).toBeInTheDocument());
+    const toggle = screen.getByLabelText('ヒント表示');
+    expect(toggle).not.toBeChecked();
+    expect(screen.queryByTestId('hint-tooltip')).not.toBeInTheDocument();
+  });
+
+  it('shows the frontend hint tooltip when the toggle is enabled', async () => {
+    localStorage.setItem('hint_enabled_golf', 'true');
+    renderWithProviders(<GolfPage />);
+    // playingState's waste top (♣4) has adjacent exposed cards → the removable suggestion appears.
+    await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
   });
 
   it('renders stock count', async () => {

--- a/frontend/src/pages/GolfPage.tsx
+++ b/frontend/src/pages/GolfPage.tsx
@@ -9,6 +9,7 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
@@ -20,6 +21,7 @@ import { useCardDimensions, useWindowWidth } from '../hooks/useCardDimensions';
 import { useChainCombo } from '../hooks/useChainCombo';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
+import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useGolfGame } from '../hooks/useGolfGame';
 import { useSound } from '../providers/SoundProvider';
@@ -90,6 +92,11 @@ function GolfPageContent() {
     handleUndoEscape,
     handleSelectCard,
   } = useGolfGame();
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('golf', state);
   const { cardHeight, cardWidth, isMobile } = useCardDimensions();
   const windowWidth = useWindowWidth();
   // CLI mode
@@ -302,8 +309,27 @@ function GolfPageContent() {
             />
           </div>
 
+          {frontendHintEnabled && frontendHint && (
+            <HintTooltip reason={t(frontendHint.reason)} confidence={frontendHint.confidence} />
+          )}
+
           {/* Settings */}
-          <SettingsPanel title={tc('settings.title')} groups={[]} />
+          <SettingsPanel
+            title={tc('settings.title')}
+            groups={[
+              {
+                items: [
+                  {
+                    type: 'checkbox' as const,
+                    id: 'frontendHint',
+                    label: tc('hint.toggle', { ns: 'tutorial' }),
+                    checked: frontendHintEnabled,
+                    onToggle: setFrontendHintEnabled,
+                  },
+                ],
+              },
+            ]}
+          />
 
           <GameFooter className={`${gameTheme.golf.footer} px-4 py-2.5`}>
             <ErrorAlert message={error ?? hintError} onRetry={retry} />

--- a/frontend/src/utils/hints/golfHint.test.ts
+++ b/frontend/src/utils/hints/golfHint.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, GolfCard, GolfResponse } from '../../types/card';
+import { GolfPhase } from '../../types/phases';
+import { getGolfHint } from './golfHint';
+
+const card = (value: number): Card => ({ design: 'SPADE', value });
+const exposed = (value: number): GolfCard => ({ card: card(value), removed: false, exposed: true });
+const buried = (value: number): GolfCard => ({ card: card(value), removed: false, exposed: false });
+
+const baseState = (overrides: Partial<GolfResponse> = {}): GolfResponse => ({
+  layout: [[buried(9), exposed(5)], [exposed(11)]],
+  stockCount: 10,
+  waste: [card(2), card(7)],
+  phase: GolfPhase.PLAYING,
+  moveCount: 0,
+  canUndo: false,
+  isStalemate: false,
+  message: '',
+  ...overrides,
+});
+
+describe('getGolfHint', () => {
+  it('recommends removing when one exposed card is adjacent to the waste top', () => {
+    // Waste top 7; col 1's exposed 6 is adjacent.
+    const hint = getGolfHint(baseState({ layout: [[buried(9), exposed(5)], [exposed(6)]] }));
+    expect(hint).toEqual({ targetAction: 'remove', reason: 'frontendHint.canRemove', confidence: 'strong' });
+  });
+
+  it('points out chain opportunities when several columns are removable', () => {
+    // Waste top 7; exposed 6 and exposed 8 are both adjacent.
+    const hint = getGolfHint(baseState({ layout: [[exposed(8)], [exposed(6)]] }));
+    expect(hint).toEqual({ targetAction: 'remove', reason: 'frontendHint.multipleRemovable', confidence: 'strong' });
+  });
+
+  it('treats K and A as adjacent (wraparound)', () => {
+    const hint = getGolfHint(baseState({ waste: [card(13)], layout: [[exposed(1)]] }));
+    expect(hint?.targetAction).toBe('remove');
+  });
+
+  it('ignores buried and removed cards when scanning for removable columns', () => {
+    const removable: GolfCard = { card: card(6), removed: true, exposed: true };
+    const hint = getGolfHint(baseState({ layout: [[buried(6)], [removable]] }));
+    expect(hint).toEqual({ targetAction: 'draw', reason: 'frontendHint.drawFromStock', confidence: 'moderate' });
+  });
+
+  it('recommends drawing when nothing is removable and stock remains', () => {
+    const hint = getGolfHint(baseState());
+    expect(hint).toEqual({ targetAction: 'draw', reason: 'frontendHint.drawFromStock', confidence: 'moderate' });
+  });
+
+  it('returns null when nothing is removable and the stock is empty', () => {
+    expect(getGolfHint(baseState({ stockCount: 0 }))).toBeNull();
+  });
+
+  it('recommends drawing when the waste is empty but stock remains', () => {
+    expect(getGolfHint(baseState({ waste: [] }))?.targetAction).toBe('draw');
+  });
+
+  it('returns null outside the playing phase', () => {
+    expect(getGolfHint(baseState({ phase: GolfPhase.GAME_CLEAR }))).toBeNull();
+    expect(getGolfHint(baseState({ phase: GolfPhase.GAME_OVER }))).toBeNull();
+  });
+});

--- a/frontend/src/utils/hints/golfHint.ts
+++ b/frontend/src/utils/hints/golfHint.ts
@@ -1,0 +1,36 @@
+import type { GolfResponse } from '../../types/card';
+import type { HintResult } from '../../types/hint';
+import { GolfPhase } from '../../types/phases';
+
+/** True when two Golf card values are adjacent (±1, with K-A wraparound). */
+function isAdjacentRank(v1: number, v2: number): boolean {
+  const diff = Math.abs(v1 - v2);
+  return diff === 1 || diff === 12;
+}
+
+/** Returns a frontend HintResult for Golf Solitaire, or null when nothing is suggestable. */
+export function getGolfHint(state: GolfResponse): HintResult | null {
+  if (state.phase !== GolfPhase.PLAYING) return null;
+
+  const wasteTop = state.waste.at(-1);
+  let removable = 0;
+  if (wasteTop) {
+    for (const column of state.layout) {
+      const top = column.find((c) => c.exposed && !c.removed && c.card !== null);
+      if (top?.card && isAdjacentRank(top.card.value, wasteTop.value)) {
+        removable++;
+      }
+    }
+  }
+
+  if (removable > 1) {
+    return { targetAction: 'remove', reason: 'frontendHint.multipleRemovable', confidence: 'strong' };
+  }
+  if (removable === 1) {
+    return { targetAction: 'remove', reason: 'frontendHint.canRemove', confidence: 'strong' };
+  }
+  if (state.stockCount > 0) {
+    return { targetAction: 'draw', reason: 'frontendHint.drawFromStock', confidence: 'moderate' };
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Golf was the only solitaire page with no standard frontend auto-hint: nothing registered in `hintFactories` and a `SettingsPanel` with empty `groups` — even though `frontendHint.*` locale keys were already staged in both golf.json files (and are now actually used). This PR:

- adds `utils/hints/golfHint.ts`: recommends removal when an exposed column card is adjacent to the waste top (±1 with K–A wraparound, matching `domain/Golf.go`'s `isAdjacentRank`), distinguishes single (`canRemove`) vs multiple (`multipleRemovable`, chain opportunity) removable columns, else suggests drawing while stock remains; null when stuck or out of the playing phase
- registers `golf` in the `useGameHint` factory map
- wires GolfPage: the standard hint toggle in `SettingsPanel` (Klondike pattern) and `HintTooltip` when enabled

**Scope note vs the issue text:** the issue claims "ヒントが機能していない", but the server hint (button + ring highlight) already works and is untouched. Also, the issue's "off の場合はヒントボタンを非表示" is not applied: `useGameHint` defaults to off, so gating the existing server hint button on it would make the button vanish for every player by default (a regression, and it would break an existing test). The toggle controls the frontend auto-hint tooltip, the same semantics as every other game page.

## Test plan

- [x] TDD Red→Green: 8 golfHint unit tests (single/multiple removable, K-A wrap, buried/removed cards ignored, draw fallback, empty stock → null, empty waste, non-playing phases) and 2 page tests (toggle present + tooltip renders when enabled via localStorage) — all failed before, pass after
- [x] All 34 affected tests pass locally (GolfPage 26 + golfHint 8); Biome clean across 7 touched files; local `tsc -b` passes
- [x] i18n parity checker: ja/en golf.json fully in sync (30 keys, no duplicates); locale files needed no diff — the keys were pre-staged
- [ ] CI: build, frontend tests, E2E, codecov/patch

Closes #2204

🤖 Generated with [Claude Code](https://claude.com/claude-code)