### PR TITLE
feat(bigtwo): replace the plain loading div with GameSkeleton

### DIFF
--- a/frontend/src/pages/BigTwoPage.test.tsx
+++ b/frontend/src/pages/BigTwoPage.test.tsx
@@ -1,25 +1,25 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { tienlenApi } from '../api/gameApi';
+import { bigtwoApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import { renderWithProviders } from '../test/renderWithProviders';
-import type { Card, TienLenResponse } from '../types/card';
-import { TienLenPage } from './TienLenPage';
+import type { BigTwoResponse, Card } from '../types/card';
+import { BigTwoPage } from './BigTwoPage';
 
 vi.mock('../api/gameApi', () => ({
-  tienlenApi: { exec: vi.fn() },
-  actionLogApi: { tienlen: vi.fn() },
+  bigtwoApi: { exec: vi.fn() },
+  actionLogApi: { bigtwo: vi.fn() },
 }));
 
-const mockExec = vi.mocked(tienlenApi.exec);
+const mockExec = vi.mocked(bigtwoApi.exec);
 
 const card = (design: string, value: number): Card => ({ design, value }) as unknown as Card;
 
-function player(id: number, isHuman: boolean, cards: Card[], over: Partial<TienLenResponse['players'][number]> = {}) {
+function player(id: number, isHuman: boolean, cards: Card[], over: Partial<BigTwoResponse['players'][number]> = {}) {
   return { id, isHuman, isFinished: false, rank: 0, cardCount: cards.length, cards, ...over };
 }
 
-function makeState(overrides: Partial<TienLenResponse> = {}): TienLenResponse {
+function makeState(overrides: Partial<BigTwoResponse> = {}): BigTwoResponse {
   return {
     players: [
       player(0, true, [card('SPADE', 3), card('HEART', 5), card('DIAMOND', 7)]),
@@ -46,33 +46,33 @@ beforeEach(() => {
   mockExec.mockResolvedValue(makeState());
 });
 
-describe('TienLenPage', () => {
+describe('BigTwoPage', () => {
   it('renders skeleton before first API response', () => {
     mockExec.mockReturnValue(new Promise(() => undefined));
-    renderWithProviders(<TienLenPage />);
+    renderWithProviders(<BigTwoPage />);
     expect(screen.getByTestId('skeleton')).toBeInTheDocument();
   });
 
   it('renders skeleton when fewer than 4 players are present', async () => {
     mockExec.mockResolvedValue(makeState({ players: [player(0, true, [])] }));
-    renderWithProviders(<TienLenPage />);
+    renderWithProviders(<BigTwoPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     expect(screen.getByTestId('skeleton')).toBeInTheDocument();
   });
 
   it('calls reset on mount', async () => {
-    renderWithProviders(<TienLenPage />);
+    renderWithProviders(<BigTwoPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
   it('shows play and pass buttons on the human turn', async () => {
-    renderWithProviders(<TienLenPage />);
+    renderWithProviders(<BigTwoPage />);
     expect(await screen.findByTestId('pass-button')).toBeEnabled();
     expect(screen.getByTestId('play-button')).toBeDisabled(); // nothing selected yet
   });
 
   it('selecting a card enables play and clicking plays it', async () => {
-    renderWithProviders(<TienLenPage />);
+    renderWithProviders(<BigTwoPage />);
     fireEvent.click(await screen.findByTestId('hand-card-0'));
     const playBtn = screen.getByTestId('play-button');
     expect(playBtn).toBeEnabled();
@@ -80,23 +80,14 @@ describe('TienLenPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', [0]));
   });
 
-  it('disables play and shows a reason for an invalid combination', async () => {
-    renderWithProviders(<TienLenPage />);
-    // Select ♠3 + ♥5 (two different ranks) → not a legal combo.
-    fireEvent.click(await screen.findByTestId('hand-card-0'));
-    fireEvent.click(screen.getByTestId('hand-card-1'));
-    expect(screen.getByTestId('play-button')).toBeDisabled();
-    expect(screen.getByTestId('tl-invalid-combo')).toBeInTheDocument();
-  });
-
   it('passes when the pass button is clicked', async () => {
-    renderWithProviders(<TienLenPage />);
+    renderWithProviders(<BigTwoPage />);
     fireEvent.click(await screen.findByTestId('pass-button'));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', []));
   });
 
   it('toggles card selection on and off', async () => {
-    renderWithProviders(<TienLenPage />);
+    renderWithProviders(<BigTwoPage />);
     const card0 = await screen.findByTestId('hand-card-0');
     fireEvent.click(card0);
     expect(screen.getByTestId('play-button')).toBeEnabled();
@@ -105,14 +96,14 @@ describe('TienLenPage', () => {
   });
 
   it('renders the CLI terminal when CLI mode is enabled', async () => {
-    localStorage.setItem('cli-mode-tienlen', 'true');
-    renderWithProviders(<TienLenPage />);
+    localStorage.setItem('cli-mode-bigtwo', 'true');
+    renderWithProviders(<BigTwoPage />);
     expect(await screen.findByPlaceholderText(/コマンド/)).toBeInTheDocument();
     expect(screen.queryByTestId('play-button')).not.toBeInTheDocument();
   });
 
   it('shows a retry button when an action fails', async () => {
-    renderWithProviders(<TienLenPage />);
+    renderWithProviders(<BigTwoPage />);
     const passBtn = await screen.findByTestId('pass-button');
     mockExec.mockRejectedValueOnce(new Error('boom'));
     fireEvent.click(passBtn);
@@ -120,39 +111,5 @@ describe('TienLenPage', () => {
     mockExec.mockResolvedValue(makeState());
     fireEvent.click(retry);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', []));
-  });
-
-  it('shows a finished CPU rank instead of a card count', async () => {
-    // A CPU has gone out (rank 1) while the round continues — exercises the
-    // `isFinished ? rank : cardCount` branch. Locale is ja in tests, so "1位".
-    mockExec.mockResolvedValue(
-      makeState({
-        players: [
-          player(0, true, [card('SPADE', 3)]),
-          player(1, false, [], { isFinished: true, rank: 1, cardCount: 0 }),
-          player(2, false, [], { cardCount: 5 }),
-          player(3, false, [], { cardCount: 9 }),
-        ],
-      }),
-    );
-    renderWithProviders(<TienLenPage />);
-    await screen.findByTestId('pass-button');
-    expect(screen.getAllByText('1位').length).toBeGreaterThanOrEqual(1);
-  });
-
-  it('shows CPU remaining-card counts during play', async () => {
-    mockExec.mockResolvedValue(
-      makeState({
-        players: [
-          player(0, true, [card('SPADE', 3)]),
-          player(1, false, [], { cardCount: 7 }),
-          player(2, false, [], { cardCount: 5 }),
-          player(3, false, [], { cardCount: 9 }),
-        ],
-      }),
-    );
-    renderWithProviders(<TienLenPage />);
-    await screen.findByTestId('pass-button');
-    expect(screen.getByText('— 7')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/BigTwoPage.tsx
+++ b/frontend/src/pages/BigTwoPage.tsx
@@ -11,6 +11,7 @@ import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
+import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useBigTwoGame } from '../hooks/useBigTwoGame';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -107,9 +108,19 @@ function BigTwoPageContent() {
 
   if (!state || state.players.length < 4) {
     return (
-      <div className={`flex-1 flex items-center justify-center ${gameTheme.bigtwo.bg} text-ds-text-muted`} aria-busy>
-        {tc('skeleton.loading')}
-      </div>
+      <GameSkeleton
+        gameKey="bigtwo"
+        layout={{
+          kind: 'trick-taking',
+          titleBar: false,
+          opponents: 3,
+          opponentStyle: 'hand',
+          opponentHandSize: 4,
+          trickArea: true,
+          footerHandSize: 5,
+          footerButton: 'wide',
+        }}
+      />
     );
   }
 

--- a/frontend/src/pages/TienLenPage.tsx
+++ b/frontend/src/pages/TienLenPage.tsx
@@ -11,6 +11,7 @@ import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
+import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
@@ -110,9 +111,19 @@ function TienLenPageContent() {
 
   if (!state || state.players.length < 4) {
     return (
-      <div className={`flex-1 flex items-center justify-center ${gameTheme.tienlen.bg} text-ds-text-muted`} aria-busy>
-        {tc('skeleton.loading')}
-      </div>
+      <GameSkeleton
+        gameKey="tienlen"
+        layout={{
+          kind: 'trick-taking',
+          titleBar: false,
+          opponents: 3,
+          opponentStyle: 'hand',
+          opponentHandSize: 4,
+          trickArea: true,
+          footerHandSize: 5,
+          footerButton: 'wide',
+        }}
+      />
     );
   }
 


### PR DESCRIPTION
## Summary

Closes #2165

`BigTwoPage` showed a bare `aria-busy` text div during the initial load instead of the `GameSkeleton` component used by nearly every other game page. This PR:

- Replaces the loading branch with `<GameSkeleton gameKey="bigtwo" layout={{ kind: 'trick-taking', titleBar: false, opponents: 3, opponentStyle: 'hand', opponentHandSize: 4, trickArea: true, footerHandSize: 5, footerButton: 'wide' }} />` — the exact layout Daifugo (the closest 4-player shedding sibling) uses, with `trickArea` added vs. the issue's proposal since the page renders table cards mid-screen.
- Applies the identical fix to **TienLenPage** — Tien Len is the Big Two clone and had the same bare-div loading block; this keeps the twins in sync (same precedent as the RussianSolitaire/Yukon alignment in #2412).
- Adds the previously missing `BigTwoPage.test.tsx` unit suite (9 tests, modeled on `TienLenPage.test.tsx`): skeleton-while-pending, skeleton-when-fewer-than-4-players (covers both sides of the guard), reset-on-mount, play/pass flows, selection toggle, CLI mode, retry-on-error.
- Adds the two skeleton tests to `TienLenPage.test.tsx`.

## Test plan

- [x] TDD: skeleton tests written first and confirmed failing (2 failed / 7 passed), then green after the swap (21/21 across both files)
- [x] `tsc -b` passes (raised heap locally)
- [x] `bun run build` (vite) passes
- [x] `bun run check` (Biome + design tokens) passes
- [x] Full `bun run test`: 9058 passed; the only 2 failures were `NavBar.test.tsx` link-active timeouts with a vitest fork-worker kill — local 2 GB RAM exhaustion (box was 2.6 GB into swap), unrelated to this diff (NavBar references pages by route string, not import). CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)