### PR TITLE
feat(canasta): replace the plain loading text with GameSkeleton

### DIFF
--- a/frontend/src/pages/BurracoPage.test.tsx
+++ b/frontend/src/pages/BurracoPage.test.tsx
@@ -100,6 +100,12 @@ const gameEndState: BurracoResponse = {
 };
 
 describe('BurracoPage', () => {
+  it('renders skeleton before first API response', () => {
+    mockExec.mockReturnValue(new Promise(() => undefined));
+    renderWithProviders(<BurracoPage />);
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockExec.mockResolvedValue(drawPhaseState);

--- a/frontend/src/pages/BurracoPage.test.tsx
+++ b/frontend/src/pages/BurracoPage.test.tsx
@@ -100,15 +100,15 @@ const gameEndState: BurracoResponse = {
 };
 
 describe('BurracoPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExec.mockResolvedValue(drawPhaseState);
+  });
+
   it('renders skeleton before first API response', () => {
     mockExec.mockReturnValue(new Promise(() => undefined));
     renderWithProviders(<BurracoPage />);
     expect(screen.getByTestId('skeleton')).toBeInTheDocument();
-  });
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockExec.mockResolvedValue(drawPhaseState);
   });
 
   it('calls reset on mount', async () => {

--- a/frontend/src/pages/BurracoPage.tsx
+++ b/frontend/src/pages/BurracoPage.tsx
@@ -11,6 +11,7 @@ import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
+import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useBurracoGame } from '../hooks/useBurracoGame';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -189,9 +190,10 @@ function BurracoPageContent() {
 
   if (!state) {
     return (
-      <div className="p-4 text-center text-ds-text-primary">
-        <p>{tc('status.thinking')}</p>
-      </div>
+      <GameSkeleton
+        gameKey="burraco"
+        layout={{ kind: 'trick-taking', opponents: 1, centerCard: true, trickArea: true, footerHandSize: 11 }}
+      />
     );
   }
 

--- a/frontend/src/pages/CanastaPage.test.tsx
+++ b/frontend/src/pages/CanastaPage.test.tsx
@@ -88,15 +88,15 @@ const gameEndState: CanastaResponse = {
 };
 
 describe('CanastaPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExec.mockResolvedValue(drawPhaseState);
+  });
+
   it('renders skeleton before first API response', () => {
     mockExec.mockReturnValue(new Promise(() => undefined));
     renderWithProviders(<CanastaPage />);
     expect(screen.getByTestId('skeleton')).toBeInTheDocument();
-  });
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockExec.mockResolvedValue(drawPhaseState);
   });
 
   it('calls reset on mount', async () => {

--- a/frontend/src/pages/CanastaPage.test.tsx
+++ b/frontend/src/pages/CanastaPage.test.tsx
@@ -88,6 +88,12 @@ const gameEndState: CanastaResponse = {
 };
 
 describe('CanastaPage', () => {
+  it('renders skeleton before first API response', () => {
+    mockExec.mockReturnValue(new Promise(() => undefined));
+    renderWithProviders(<CanastaPage />);
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockExec.mockResolvedValue(drawPhaseState);

--- a/frontend/src/pages/CanastaPage.tsx
+++ b/frontend/src/pages/CanastaPage.tsx
@@ -11,6 +11,7 @@ import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
+import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useCanastaGame } from '../hooks/useCanastaGame';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -148,9 +149,10 @@ function CanastaPageContent() {
 
   if (!state) {
     return (
-      <div className="p-4 text-center text-ds-text-primary">
-        <p>{tc('status.thinking')}</p>
-      </div>
+      <GameSkeleton
+        gameKey="canasta"
+        layout={{ kind: 'trick-taking', opponents: 1, centerCard: true, trickArea: true, footerHandSize: 11 }}
+      />
     );
   }
 


### PR DESCRIPTION
## Summary

Closes #2187

`CanastaPage` rendered a bare `tc('status.thinking')` text div while `state` was null, instead of the `GameSkeleton` every other page uses — causing layout shift (CLS) when the 11-card hand arrives. This PR:

- Replaces the loading branch with `<GameSkeleton gameKey="canasta" layout={{ kind: 'trick-taking', opponents: 1, centerCard: true, trickArea: true, footerHandSize: 11 }} />` — the same layout shape `Rummy500Page` (footerHandSize 13) and `GinRummyPage` (10) use for the 1-CPU rummy family, with `footerHandSize: 11` per the issue.
- Applies the identical fix to **BurracoPage** — Burraco is the aliased Canasta variant (#2000) and had the same bare-div block; same twin-sync precedent as #2426 (BigTwo/TienLen) and #2412 (RussianSolitaire/Yukon).
- Adds a `renders skeleton before first API response` test to both page test files (TDD: confirmed failing first, 2 failed / 37 passed → 39/39 after the swap).

## Test plan

- [x] TDD red→green on the two new skeleton tests (39/39 in both files)
- [x] `tsc -b` passes
- [x] `bun run build` (vite) passes
- [x] `bun run check` (Biome + design tokens) passes
- [x] Full `bun run test`: 9062 passed, 0 failed; `NavBar.test.tsx` fork-worker was killed by the known local 2 GB RAM exhaustion (file untouched by this diff) — CI is the gate, same as #2426

🤖 Generated with [Claude Code](https://claude.com/claude-code)