### PR TITLE
feat(trash): show the CPU open-slot count badge

### DIFF
--- a/frontend/src/i18n/locales/en/trash.json
+++ b/frontend/src/i18n/locales/en/trash.json
@@ -19,6 +19,7 @@
   "label.pending": "Hand",
   "label.you": "You",
   "label.cpu": "CPU",
+  "label.cpuOpen": "{{open}}/{{total}} open",
   "cli.help": "Commands:\n  d, draw             Draw the top stock card\n  p, place <pos>      Place the wild at <pos> (1-10)\n  cpu                 Advance the CPU turn\n  r, reset            Restart the game\n  log, l              Show action log",
   "cli.errInvalidPosition": "Position must be an integer between 1 and 10",
   "cli.errUnknown": "Unknown command: {{cmd}}",

--- a/frontend/src/i18n/locales/ja/trash.json
+++ b/frontend/src/i18n/locales/ja/trash.json
@@ -19,6 +19,7 @@
   "label.pending": "手札",
   "label.you": "あなた",
   "label.cpu": "CPU",
+  "label.cpuOpen": "{{open}}/{{total}} 枚オープン",
   "cli.help": "使えるコマンド:\n  d, draw             山札から1枚引く\n  p, place <pos>      ワイルドを位置 <pos> に配置 (1〜10)\n  cpu                 CPUのターンを進める\n  r, reset            ゲームをやり直す\n  log, l              棋譜を表示",
   "cli.errInvalidPosition": "位置は 1〜10 の整数を指定してください",
   "cli.errUnknown": "未知のコマンド: {{cmd}}",

--- a/frontend/src/pages/TrashPage.test.tsx
+++ b/frontend/src/pages/TrashPage.test.tsx
@@ -81,6 +81,8 @@ describe('TrashPage', () => {
     });
     renderWithProviders(<TrashPage />);
     expect(await screen.findByText('3/10 枚オープン')).toBeInTheDocument();
+    // Exactly one badge: the human row never receives the badge prop.
+    expect(screen.getAllByText(/枚オープン/)).toHaveLength(1);
   });
 
   it('renders the page heading', async () => {

--- a/frontend/src/pages/TrashPage.test.tsx
+++ b/frontend/src/pages/TrashPage.test.tsx
@@ -71,6 +71,18 @@ beforeEach(() => {
 });
 
 describe('TrashPage', () => {
+  it('shows the CPU open-slot count indicator', async () => {
+    const mixedSlots = Array.from({ length: 10 }, (_, i) =>
+      i < 3 ? { faceUp: true, card: card('HEART', i + 1) } : { faceUp: false },
+    );
+    mockExec.mockResolvedValue({
+      ...playerTurnState,
+      players: [playerTurnState.players[0], { slots: mixedSlots, isCpu: true }],
+    });
+    renderWithProviders(<TrashPage />);
+    expect(await screen.findByText('3/10 枚オープン')).toBeInTheDocument();
+  });
+
   it('renders the page heading', async () => {
     renderWithProviders(<TrashPage />);
     await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -228,6 +228,10 @@ function TrashPageContent() {
           <div className="flex-1 overflow-y-auto pt-3 px-2 sm:px-4 lg:px-8 space-y-4">
             <PlayerRow
               label={t('label.cpu')}
+              badge={t('label.cpuOpen', {
+                open: state.players[1].slots.filter((s) => s.faceUp).length,
+                total: state.players[1].slots.length,
+              })}
               slots={state.players[1].slots}
               cardWidth={cardWidth}
               highlightFaceDown={false}
@@ -310,6 +314,7 @@ function TrashPageContent() {
 
 function PlayerRow({
   label,
+  badge,
   slots,
   cardWidth,
   highlightFaceDown,
@@ -318,6 +323,8 @@ function PlayerRow({
   pendingTargetIdx,
 }: {
   label: string;
+  /** Optional progress indicator rendered next to the label (e.g. "3/10 枚オープン"). */
+  badge?: string;
   slots: TrashSlot[];
   cardWidth: number;
   highlightFaceDown: boolean;
@@ -328,7 +335,12 @@ function PlayerRow({
 }) {
   return (
     <div className="flex flex-col items-center" data-tutorial={dataTutorial}>
-      <span className="text-sm text-ds-secondary mb-1">{label}</span>
+      <span className="text-sm text-ds-secondary mb-1">
+        {label}
+        {badge !== undefined && (
+          <span className="ml-2 px-1.5 py-0.5 rounded bg-ds-surface/70 text-xs text-ds-secondary">{badge}</span>
+        )}
+      </span>
       <div className="grid grid-cols-5 gap-1 sm:gap-2">
         {slots.map((slot, idx) => {
           const key = `${idx}-${slot.faceUp ? `${slot.card?.design}-${slot.card?.value}` : 'face-down'}`;

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -337,8 +337,10 @@ function PlayerRow({
     <div className="flex flex-col items-center" data-tutorial={dataTutorial}>
       <span className="text-sm text-ds-secondary mb-1">
         {label}
-        {badge !== undefined && (
-          <span className="ml-2 px-1.5 py-0.5 rounded bg-ds-surface/70 text-xs text-ds-secondary">{badge}</span>
+        {badge && (
+          <span className="ml-2 px-1.5 py-0.5 rounded bg-ds-surface/70 text-xs text-ds-secondary whitespace-nowrap">
+            {badge}
+          </span>
         )}
       </span>
       <div className="grid grid-cols-5 gap-1 sm:gap-2">


### PR DESCRIPTION
## Summary

Closes #2230

The CPU row in Trash rendered face-down slots as plain placeholders with no progress indication. This PR adds an open-slot count badge (e.g. 「3/10 枚オープン」/ "3/10 open") next to the CPU label:

- Count computed inline from the existing `slots` array (`filter(s => s.faceUp).length`); the total uses `slots.length` rather than a hardcoded 10 because Trash slot counts shrink in later rounds.
- `PlayerRow` gains an optional `badge?: string` prop rendered next to the label as a small `bg-ds-surface/70` chip (`text-xs`, fits 375 px width); the human row passes none, so both branches of the `badge !== undefined` guard are exercised by tests.
- The badge stays visible after game over, showing the final state (allowed by the acceptance criteria, and avoids an extra conditional branch).
- New `label.cpuOpen` key in ja/en `trash.json` (parity verified).

## Test plan

- [x] TDD: badge test written first and confirmed failing (1 failed / 21 passed), then green (22/22)
- [x] `tsc -b`, `bun run build` (vite), `bun run check` all pass
- [x] Full `bun run test`: 9061 passed, 0 failed (`NavBar.test.tsx` fork-worker killed by the known local 2 GB RAM exhaustion — file untouched, CI is the gate, same as #2426/#2427)

🤖 Generated with [Claude Code](https://claude.com/claude-code)