### PR TITLE
feat(deuceswild): mark wild cards with a WILD badge

### DIFF
--- a/frontend/src/components/VideoPokerGameContent.test.tsx
+++ b/frontend/src/components/VideoPokerGameContent.test.tsx
@@ -8,7 +8,11 @@ import { VideoPokerGameContent } from './VideoPokerGameContent';
 
 vi.mock('../api/gameApi', () => ({
   videopokerApi: { exec: vi.fn() },
-  actionLogApi: { videopoker: vi.fn().mockResolvedValue([]) },
+  actionLogApi: {
+    videopoker: vi.fn().mockResolvedValue([]),
+    deuceswild: vi.fn().mockResolvedValue([]),
+    jokerpoker: vi.fn().mockResolvedValue([]),
+  },
 }));
 
 const mockExec = vi.fn();
@@ -81,15 +85,15 @@ const tutorialConfig: TutorialConfig = {
   steps: [],
 };
 
-function renderContent() {
+function renderContent(gameName: 'videopoker' | 'deuceswild' | 'jokerpoker' = 'videopoker') {
   return renderWithProviders(
     <TutorialProvider config={tutorialConfig} translateMessage={(k: string) => k}>
       <VideoPokerGameContent
-        gameName="videopoker"
-        i18nNamespace="videopoker"
+        gameName={gameName}
+        i18nNamespace={gameName}
         apiExec={mockExec}
         payoutTableRows={payoutRows}
-        gamePath="/videopoker"
+        gamePath={`/${gameName}`}
         cliGameConfig={{
           parseCommand: () => ({ args: ['reset'] }),
           formatResponse: () => '',
@@ -282,5 +286,40 @@ describe('VideoPokerGameContent', () => {
     mockExec.mockResolvedValue(betPhaseState);
     renderContent();
     await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+  });
+
+  it('marks twos with a WILD badge in Deuces Wild', async () => {
+    mockExec.mockResolvedValue({
+      ...drawPhaseState,
+      variantName: 'deuceswild',
+      hand: [card('SPADE', 2), card('HEART', 11), card('CLOVER', 2), card('DIAMOND', 8), card('SPADE', 13)],
+    });
+    renderContent('deuceswild');
+    await waitFor(() => expect(screen.getByTestId('vp-wild-badge-0')).toBeInTheDocument());
+    expect(screen.getByTestId('vp-wild-badge-2')).toBeInTheDocument();
+    expect(screen.queryByTestId('vp-wild-badge-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('vp-wild-badge-3')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('vp-wild-badge-4')).not.toBeInTheDocument();
+  });
+
+  it('marks jokers with a WILD badge in Joker Poker', async () => {
+    mockExec.mockResolvedValue({
+      ...drawPhaseState,
+      variantName: 'jokerpoker',
+      hand: [card('JOKER', 0), card('HEART', 11), card('CLOVER', 5), card('DIAMOND', 8), card('SPADE', 13)],
+    });
+    renderContent('jokerpoker');
+    await waitFor(() => expect(screen.getByTestId('vp-wild-badge-0')).toBeInTheDocument());
+    expect(screen.queryByTestId('vp-wild-badge-1')).not.toBeInTheDocument();
+  });
+
+  it('shows no WILD badge in Jacks or Better even on twos', async () => {
+    mockExec.mockResolvedValue({
+      ...drawPhaseState,
+      hand: [card('SPADE', 2), card('HEART', 11), card('CLOVER', 5), card('DIAMOND', 8), card('SPADE', 13)],
+    });
+    renderContent();
+    await waitFor(() => expect(screen.getByRole('button', { name: /ドロー/ })).toBeInTheDocument());
+    expect(screen.queryByTestId('vp-wild-badge-0')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/VideoPokerGameContent.test.tsx
+++ b/frontend/src/components/VideoPokerGameContent.test.tsx
@@ -297,6 +297,8 @@ describe('VideoPokerGameContent', () => {
     renderContent('deuceswild');
     await waitFor(() => expect(screen.getByTestId('vp-wild-badge-0')).toBeInTheDocument());
     expect(screen.getByTestId('vp-wild-badge-2')).toBeInTheDocument();
+    // Wild status is surfaced to screen readers via the button aria-label.
+    expect(screen.getAllByRole('button', { name: /ワイルド/ })).toHaveLength(2);
     expect(screen.queryByTestId('vp-wild-badge-1')).not.toBeInTheDocument();
     expect(screen.queryByTestId('vp-wild-badge-3')).not.toBeInTheDocument();
     expect(screen.queryByTestId('vp-wild-badge-4')).not.toBeInTheDocument();
@@ -311,6 +313,9 @@ describe('VideoPokerGameContent', () => {
     renderContent('jokerpoker');
     await waitFor(() => expect(screen.getByTestId('vp-wild-badge-0')).toBeInTheDocument());
     expect(screen.queryByTestId('vp-wild-badge-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('vp-wild-badge-2')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('vp-wild-badge-3')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('vp-wild-badge-4')).not.toBeInTheDocument();
   });
 
   it('shows no WILD badge in Jacks or Better even on twos', async () => {

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -248,6 +248,15 @@ export function VideoPokerGameContent({
                             {tNs('hold')}
                           </span>
                         )}
+                        {WILD_CARD_PREDICATE[gameName](card) && (
+                          <span
+                            aria-hidden="true"
+                            className="absolute top-1 right-1 px-1.5 py-0.5 rounded bg-ds-info text-ds-text-on-accent text-[9px] font-extrabold tracking-wider shadow-md pointer-events-none"
+                            data-testid={`vp-wild-badge-${i}`}
+                          >
+                            {tNs('wild')}
+                          </span>
+                        )}
                       </button>
                     </div>
                   ))}

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -228,39 +228,39 @@ export function VideoPokerGameContent({
                   {state.hand.map((card, i) => {
                     const isWild = WILD_CARD_PREDICATE[gameName](card);
                     return (
-                    <div key={`vp-${card.design}-${card.value}-${i}`} className="flex flex-col items-center">
-                      <button
-                        type="button"
-                        onClick={() => toggleHold(i)}
-                        disabled={!isDrawPhase}
-                        className={`relative rounded transition-transform ${
-                          displayHeld[i] ? 'ring-4 ring-ds-warning -translate-y-2 motion-safe:animate-card-lock' : ''
-                        }`}
-                        aria-label={`${displayHeld[i] ? `${tNs('hold')} ${i}` : tNs('card', { index: i })}${isWild ? ` ${tNs('wild')}` : ''}`}
-                        aria-pressed={displayHeld[i] ?? false}
-                        data-held={displayHeld[i] ? 'true' : undefined}
-                      >
-                        <AnimatedCard card={card} width={cardWidth} />
-                        {displayHeld[i] && (
-                          <span
-                            aria-hidden="true"
-                            className="absolute inset-x-0 bottom-1 mx-auto w-fit px-2 py-0.5 rounded bg-ds-warning text-ds-text-on-accent text-[10px] font-extrabold tracking-wider shadow-md pointer-events-none"
-                            data-testid={`vp-hold-badge-${i}`}
-                          >
-                            {tNs('hold')}
-                          </span>
-                        )}
-                        {isWild && (
-                          <span
-                            aria-hidden="true"
-                            className="absolute top-1 right-1 px-1.5 py-0.5 rounded bg-ds-info text-ds-text-on-accent text-[9px] font-extrabold tracking-wider shadow-md pointer-events-none"
-                            data-testid={`vp-wild-badge-${i}`}
-                          >
-                            {tNs('wild')}
-                          </span>
-                        )}
-                      </button>
-                    </div>
+                      <div key={`vp-${card.design}-${card.value}-${i}`} className="flex flex-col items-center">
+                        <button
+                          type="button"
+                          onClick={() => toggleHold(i)}
+                          disabled={!isDrawPhase}
+                          className={`relative rounded transition-transform ${
+                            displayHeld[i] ? 'ring-4 ring-ds-warning -translate-y-2 motion-safe:animate-card-lock' : ''
+                          }`}
+                          aria-label={`${displayHeld[i] ? `${tNs('hold')} ${i}` : tNs('card', { index: i })}${isWild ? ` ${tNs('wild')}` : ''}`}
+                          aria-pressed={displayHeld[i] ?? false}
+                          data-held={displayHeld[i] ? 'true' : undefined}
+                        >
+                          <AnimatedCard card={card} width={cardWidth} />
+                          {displayHeld[i] && (
+                            <span
+                              aria-hidden="true"
+                              className="absolute inset-x-0 bottom-1 mx-auto w-fit px-2 py-0.5 rounded bg-ds-warning text-ds-text-on-accent text-[10px] font-extrabold tracking-wider shadow-md pointer-events-none"
+                              data-testid={`vp-hold-badge-${i}`}
+                            >
+                              {tNs('hold')}
+                            </span>
+                          )}
+                          {isWild && (
+                            <span
+                              aria-hidden="true"
+                              className="absolute top-1 right-1 px-1.5 py-0.5 rounded bg-ds-info text-ds-text-on-accent text-[9px] font-extrabold tracking-wider shadow-md pointer-events-none"
+                              data-testid={`vp-wild-badge-${i}`}
+                            >
+                              {tNs('wild')}
+                            </span>
+                          )}
+                        </button>
+                      </div>
                     );
                   })}
                 </div>

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -225,7 +225,9 @@ export function VideoPokerGameContent({
             {state.hand.length > 0 && (
               <div className="mb-4" data-tutorial="vp-hand">
                 <div className="flex justify-center gap-2">
-                  {state.hand.map((card, i) => (
+                  {state.hand.map((card, i) => {
+                    const isWild = WILD_CARD_PREDICATE[gameName](card);
+                    return (
                     <div key={`vp-${card.design}-${card.value}-${i}`} className="flex flex-col items-center">
                       <button
                         type="button"
@@ -234,7 +236,7 @@ export function VideoPokerGameContent({
                         className={`relative rounded transition-transform ${
                           displayHeld[i] ? 'ring-4 ring-ds-warning -translate-y-2 motion-safe:animate-card-lock' : ''
                         }`}
-                        aria-label={displayHeld[i] ? `${tNs('hold')} ${i}` : tNs('card', { index: i })}
+                        aria-label={`${displayHeld[i] ? `${tNs('hold')} ${i}` : tNs('card', { index: i })}${isWild ? ` ${tNs('wild')}` : ''}`}
                         aria-pressed={displayHeld[i] ?? false}
                         data-held={displayHeld[i] ? 'true' : undefined}
                       >
@@ -248,7 +250,7 @@ export function VideoPokerGameContent({
                             {tNs('hold')}
                           </span>
                         )}
-                        {WILD_CARD_PREDICATE[gameName](card) && (
+                        {isWild && (
                           <span
                             aria-hidden="true"
                             className="absolute top-1 right-1 px-1.5 py-0.5 rounded bg-ds-info text-ds-text-on-accent text-[9px] font-extrabold tracking-wider shadow-md pointer-events-none"
@@ -259,7 +261,8 @@ export function VideoPokerGameContent({
                         )}
                       </button>
                     </div>
-                  ))}
+                    );
+                  })}
                 </div>
               </div>
             )}

--- a/frontend/src/i18n/locales/en/deuceswild.json
+++ b/frontend/src/i18n/locales/en/deuceswild.json
@@ -18,6 +18,7 @@
     "result": "Result"
   },
   "hold": "HOLD",
+  "wild": "WILD",
   "result": {
     "win": "{{handName}}! You win {{payout}} coins!",
     "lose": "No winning hand."

--- a/frontend/src/i18n/locales/en/jokerpoker.json
+++ b/frontend/src/i18n/locales/en/jokerpoker.json
@@ -18,6 +18,7 @@
     "result": "Result"
   },
   "hold": "HOLD",
+  "wild": "WILD",
   "result": {
     "win": "{{handName}}! You win {{payout}} coins!",
     "lose": "No winning hand."

--- a/frontend/src/i18n/locales/ja/deuceswild.json
+++ b/frontend/src/i18n/locales/ja/deuceswild.json
@@ -18,6 +18,7 @@
     "result": "結果"
   },
   "hold": "ホールド",
+  "wild": "ワイルド",
   "result": {
     "win": "{{handName}}! {{payout}}コイン獲得!",
     "lose": "役なし。次のハンドで頑張りましょう!"

--- a/frontend/src/i18n/locales/ja/jokerpoker.json
+++ b/frontend/src/i18n/locales/ja/jokerpoker.json
@@ -18,6 +18,7 @@
     "result": "結果"
   },
   "hold": "ホールド",
+  "wild": "ワイルド",
   "result": {
     "win": "{{handName}}! {{payout}}コイン獲得!",
     "lose": "役なし。次のハンドで頑張りましょう!"


### PR DESCRIPTION
## Summary

Closes #2192

Deuces Wild (`value === 2`) and Joker Poker (`design === 'JOKER'`) wild cards had no visual marker in the shared `VideoPokerGameContent` hand display. This PR:

- Adds a small "WILD"/「ワイルド」 badge to wild cards, gated on the existing `WILD_CARD_PREDICATE[gameName](card)` — so Jacks or Better (`videopoker`) never renders it.
- **Placement**: top-right corner (`top-1 right-1`), not the issue's suggested bottom-right. On mobile card widths (~50 px) the bottom-center HOLD badge (「ホールド」 at `px-2`) spans nearly the full card width, so a bottom-right badge would overlap it — and the actual acceptance criterion is "HOLD バッジと WILD バッジが重ならない配置". Top-right guarantees no overlap; styling mirrors the HOLD badge (`bg-ds-info text-ds-text-on-accent`, `text-[9px]`).
- Adds `wild` locale keys to ja/en `deuceswild.json` + `jokerpoker.json` (parity verified).
- Parameterizes the test helper with the variant and extends the `actionLogApi` mock so the shared component can be tested as all three variants.

## Test plan

- [x] TDD: 3 new tests written first; the 2 badge tests confirmed failing (2 failed / 17 passed), then 19/19 green — Deuces Wild twos badged (and non-twos not), Joker Poker joker badged, Jacks or Better twos NOT badged (covers both predicate branches)
- [x] `tsc -b`, `bun run build` (vite), `bun run check` all pass
- [x] Full `bun run test`: 9063 passed, 0 failed (known local NavBar fork-kill on the 2 GB box — file untouched, CI is the gate, same as #2426–#2428)

🤖 Generated with [Claude Code](https://claude.com/claude-code)