### PR TITLE
fix(twotenjack): celebrate only when the human team wins

### DIFF
--- a/frontend/src/pages/TwoTenJackPage.test.tsx
+++ b/frontend/src/pages/TwoTenJackPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, twoTenJackApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
@@ -168,6 +168,21 @@ describe('TwoTenJackPage', () => {
     await waitFor(() =>
       expect(screen.getByRole('button', { name: '\u6b21\u306e\u30e9\u30a6\u30f3\u30c9' })).toBeInTheDocument(),
     );
+  });
+
+  it('plays the win celebration when the human team wins', async () => {
+    mockExec.mockResolvedValue(gameEndState); // winnerTeam: 0 = human team
+    renderWithProviders(<TwoTenJackPage />);
+    expect(await screen.findByTestId('win-celebration')).toBeInTheDocument();
+  });
+
+  it('does not celebrate when the CPU team wins', async () => {
+    mockExec.mockResolvedValue({ ...gameEndState, winnerTeam: 1 });
+    renderWithProviders(<TwoTenJackPage />);
+    await waitFor(() => expect(screen.getByText('Game end!')).toBeInTheDocument());
+    // Outwait the celebration's 400ms delay so a wrongly-fired overlay would be visible.
+    await act(() => new Promise((resolve) => setTimeout(resolve, 600)));
+    expect(screen.queryByTestId('win-celebration')).not.toBeInTheDocument();
   });
 
   it('shows game end with action log button', async () => {

--- a/frontend/src/pages/TwoTenJackPage.tsx
+++ b/frontend/src/pages/TwoTenJackPage.tsx
@@ -152,6 +152,11 @@ function TwoTenJackPageContent() {
 
   const phaseNames = usePhaseNames('twotenjack', TWOTENJACK_PHASE_KEYS);
   const { playSound } = useSound();
+  // Memoized so WinCelebration's effect (which depends on onCelebrate) does not
+  // re-arm its timer — and replay the fanfare — on every post-win re-render.
+  const handleCelebrate = useCallback(() => {
+    playSound('winFanfare');
+  }, [playSound]);
 
   const handleManualReset = useCallback(() => {
     hideActionLog();
@@ -191,7 +196,7 @@ function TwoTenJackPageContent() {
       gamePath="/twotenjack"
       gameEndFlag={!!state?.gameEndFlag}
       winShow={humanWon}
-      onCelebrate={() => playSound('winFanfare')}
+      onCelebrate={handleCelebrate}
       loading={loading}
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}

--- a/frontend/src/pages/TwoTenJackPage.tsx
+++ b/frontend/src/pages/TwoTenJackPage.tsx
@@ -24,6 +24,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useTwoTenJackGame } from '../hooks/useTwoTenJackGame';
+import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -150,6 +151,7 @@ function TwoTenJackPageContent() {
   });
 
   const phaseNames = usePhaseNames('twotenjack', TWOTENJACK_PHASE_KEYS);
+  const { playSound } = useSound();
 
   const handleManualReset = useCallback(() => {
     hideActionLog();
@@ -171,6 +173,9 @@ function TwoTenJackPageContent() {
   const isHumanTurn = isPlayPhase && state.players[state.currentPlayerIdx]?.isHuman === true;
   const isHumanDeclarer = isDeclarePhase && state.players[state.declarerIdx]?.isHuman === true;
 
+  // The human sits at seat 0, so team 0 is the human team.
+  const humanWon = isGameEnd && state.winnerTeam === 0;
+
   // Team totals (team 0 = seats 0,2 ; team 1 = seats 1,3).
   const team0Total = (state.players[0]?.cumulativeScore ?? 0) + (state.players[2]?.cumulativeScore ?? 0);
   const team1Total = (state.players[1]?.cumulativeScore ?? 0) + (state.players[3]?.cumulativeScore ?? 0);
@@ -185,6 +190,8 @@ function TwoTenJackPageContent() {
       isHumanTurn={isHumanDeclarer || isHumanTurn}
       gamePath="/twotenjack"
       gameEndFlag={!!state?.gameEndFlag}
+      winShow={humanWon}
+      onCelebrate={() => playSound('winFanfare')}
       loading={loading}
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}


### PR DESCRIPTION
## Summary

Closes #2211

The issue reports that TwoTenJack never plays a win celebration. The actual behavior was subtler — and worse: `TwoTenJackPage` passed no `winShow` to `GamePageShell`, whose fallback is `winShow ?? gameEndFlag`, so the confetti celebration fired on **every** game end including CPU-team wins; meanwhile no fanfare sound played because `onCelebrate` was absent. This PR:

- Adds `humanWon = isGameEnd && state.winnerTeam === 0` (the human always sits at seat 0, so team 0 is the human team) and passes `winShow={humanWon}` — the same pattern as `BidWhistPage` (`winnerTeam === humanTeam`).
- Wires `onCelebrate={() => playSound('winFanfare')}` for the fanfare.

## Test plan

- [x] TDD: the negative test ("does not celebrate when the CPU team wins") needed to outwait `WinCelebration`'s 400 ms delay (`act` + 600 ms sleep) to be a real Red — immediate-assert negative tests (the Durak pattern) pass vacuously against this bug. Confirmed failing before the fix (1 failed / 23 passed), 24/24 after.
- [x] Positive test: human-team win shows the `win-celebration` overlay.
- [x] `tsc -b`, `bun run build` (vite), `bun run check` all pass
- [x] Full `bun run test`: 9065 passed, 0 failed (known local NavBar fork-kill on the 2 GB box — file untouched, CI is the gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)