### PR TITLE
fix(pigtail): move ActionLogSection inside the scrollable area

### DIFF
--- a/frontend/src/pages/PigsTailPage.test.tsx
+++ b/frontend/src/pages/PigsTailPage.test.tsx
@@ -199,4 +199,18 @@ describe('PigsTailPage', () => {
     fireEvent.click(screen.getByTestId('circular-deck-card-0'));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw'));
   });
+
+  it('places the action log section inside the scrollable area before the footer', async () => {
+    mockExec.mockResolvedValue(gameEndState);
+    renderWithProviders(<PigsTailPage />);
+    const buttons = await screen.findAllByRole('button', { name: '棋譜を見る' });
+    const footer = document.querySelector('footer');
+    expect(footer).not.toBeNull();
+    // At least one action-log view button (the ActionLogSection one) must
+    // precede the footer in document order — i.e. live in the scroll area.
+    const precedesFooter = buttons.some(
+      (b) => footer && (footer.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_PRECEDING) !== 0,
+    );
+    expect(precedesFooter).toBe(true);
+  });
 });

--- a/frontend/src/pages/PigsTailPage.test.tsx
+++ b/frontend/src/pages/PigsTailPage.test.tsx
@@ -204,12 +204,11 @@ describe('PigsTailPage', () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<PigsTailPage />);
     const buttons = await screen.findAllByRole('button', { name: '棋譜を見る' });
-    const footer = document.querySelector('footer');
-    expect(footer).not.toBeNull();
+    const footer = screen.getByRole('contentinfo');
     // At least one action-log view button (the ActionLogSection one) must
     // precede the footer in document order — i.e. live in the scroll area.
     const precedesFooter = buttons.some(
-      (b) => footer && (footer.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_PRECEDING) !== 0,
+      (b) => (footer.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_PRECEDING) !== 0,
     );
     expect(precedesFooter).toBe(true);
   });

--- a/frontend/src/pages/PigsTailPage.tsx
+++ b/frontend/src/pages/PigsTailPage.tsx
@@ -246,6 +246,14 @@ function PigsTailPageContent() {
                 messageParams={state.messageParams}
               />
             )}
+
+            {/* Action log */}
+            <ActionLogSection
+              isEndPhase={isGameEnd}
+              actionLog={actionLog}
+              showActionLog={showActionLog}
+              hideActionLog={hideActionLog}
+            />
           </div>
 
           {hintEnabled && hint && <HintTooltip reason={t(hint.reason)} confidence={hint.confidence} />}
@@ -285,13 +293,6 @@ function PigsTailPageContent() {
               </button>
             </div>
           </GameFooter>
-
-          <ActionLogSection
-            isEndPhase={isGameEnd}
-            actionLog={actionLog}
-            showActionLog={showActionLog}
-            hideActionLog={hideActionLog}
-          />
         </>
       )}
     </GamePageShell>


### PR DESCRIPTION
## Summary

Closes #2205

`PigsTailPage` rendered `<ActionLogSection>` **after** `</GameFooter>` — outside the scrollable content area, unlike every other game page. The log panel could sit below/behind the sticky footer and extend the page in unexpected ways on mobile. This PR moves it inside the scroll container as the last child before the footer, matching the `HeartsPage` placement.

## Test plan

- [x] TDD: new DOM-order test ("places the action log section inside the scrollable area before the footer") asserts via `compareDocumentPosition` that an action-log view button precedes the `<footer>` element at game end — confirmed failing before the move (1 failed / 12 passed), 13/13 after.
- [x] `tsc -b`, `bun run build` (vite), `bun run check` all pass
- [x] Full `bun run test`: 9067 passed, 0 failed (known local NavBar fork-kill, file untouched — CI is the gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)