### PR TITLE
feat(videopoker): expand the payout table on first visit

### DIFF
--- a/frontend/src/components/VideoPokerGameContent.test.tsx
+++ b/frontend/src/components/VideoPokerGameContent.test.tsx
@@ -220,11 +220,12 @@ describe('VideoPokerGameContent', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bet', 5));
   });
 
-  it('renders payout table collapsed by default in draw phase', async () => {
+  it('renders payout table collapsed in draw phase once dismissed', async () => {
+    localStorage.setItem('paytable_open_videopoker', 'false');
     mockExec.mockResolvedValue(drawPhaseState);
     renderContent();
     await waitFor(() => expect(screen.getByText(/配当表/)).toBeInTheDocument());
-    // Payout table should be collapsed (details element should not have open attribute)
+    // Once the player has collapsed the table, it stays collapsed across phases.
     const details = screen.getByText(/配当表/).closest('details');
     expect(details).not.toHaveAttribute('open');
   });
@@ -286,6 +287,33 @@ describe('VideoPokerGameContent', () => {
     mockExec.mockResolvedValue(betPhaseState);
     renderContent();
     await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+  });
+
+  it('expands the payout table on first visit', async () => {
+    mockExec.mockResolvedValue(betPhaseState);
+    renderContent();
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    const details = document.querySelector('details');
+    expect(details).not.toBeNull();
+    expect(details?.open).toBe(true);
+  });
+
+  it('keeps the payout table collapsed once dismissed', async () => {
+    localStorage.setItem('paytable_open_videopoker', 'false');
+    mockExec.mockResolvedValue(betPhaseState);
+    renderContent();
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(document.querySelector('details')?.open).toBe(false);
+  });
+
+  it('persists the collapsed state when the payout table is toggled shut', async () => {
+    mockExec.mockResolvedValue(betPhaseState);
+    renderContent();
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    const details = document.querySelector('details') as HTMLDetailsElement;
+    details.open = false;
+    fireEvent(details, new Event('toggle'));
+    expect(localStorage.getItem('paytable_open_videopoker')).toBe('false');
   });
 
   it('marks twos with a WILD badge in Deuces Wild', async () => {

--- a/frontend/src/components/VideoPokerGameContent.test.tsx
+++ b/frontend/src/components/VideoPokerGameContent.test.tsx
@@ -293,9 +293,8 @@ describe('VideoPokerGameContent', () => {
     mockExec.mockResolvedValue(betPhaseState);
     renderContent();
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    const details = document.querySelector('details');
-    expect(details).not.toBeNull();
-    expect(details?.open).toBe(true);
+    const details = screen.getByText(/配当表/).closest('details') as HTMLDetailsElement;
+    expect(details.open).toBe(true);
   });
 
   it('keeps the payout table collapsed once dismissed', async () => {
@@ -303,14 +302,14 @@ describe('VideoPokerGameContent', () => {
     mockExec.mockResolvedValue(betPhaseState);
     renderContent();
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    expect(document.querySelector('details')?.open).toBe(false);
+    expect((screen.getByText(/配当表/).closest('details') as HTMLDetailsElement).open).toBe(false);
   });
 
   it('persists the collapsed state when the payout table is toggled shut', async () => {
     mockExec.mockResolvedValue(betPhaseState);
     renderContent();
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    const details = document.querySelector('details') as HTMLDetailsElement;
+    const details = screen.getByText(/配当表/).closest('details') as HTMLDetailsElement;
     details.open = false;
     fireEvent(details, new Event('toggle'));
     expect(localStorage.getItem('paytable_open_videopoker')).toBe('false');

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -54,10 +54,12 @@ export interface VideoPokerGameContentProps {
   cliGameConfig: Omit<CliGameConfig<VideoPokerResponse, Parameters<VideoPokerGameContentProps['apiExec']>>, 'gameName'>;
 }
 
-/** Payout table display component (collapsed by default, user can expand on tap). */
-function PayoutTable({ t, rows }: { t: (key: string) => string; rows: string[] }) {
+/** Payout table display component. Expanded on the first visit so new players see
+ * the payouts; once the player collapses it, the choice persists per variant. */
+function PayoutTable({ t, rows, gameName }: { t: (key: string) => string; rows: string[]; gameName: string }) {
+  const [open, setOpen] = useLocalStorageToggle(`paytable_open_${gameName}`, true);
   return (
-    <details className="mb-3 text-center">
+    <details className="mb-3 text-center" open={open} onToggle={(e) => setOpen((e.target as HTMLDetailsElement).open)}>
       <summary className="text-ds-warning text-sm cursor-pointer lg:text-base">{t('payoutTable.title')}</summary>
       <ul className="text-ds-text-muted text-xs mt-1 space-y-0.5 lg:text-sm lg:space-y-1">
         {rows.map((row) => (
@@ -300,7 +302,7 @@ export function VideoPokerGameContent({
               </div>
             )}
 
-            <PayoutTable t={tNs} rows={payoutTableRows} />
+            <PayoutTable t={tNs} rows={payoutTableRows} gameName={gameName} />
 
             {actionLog && <ActionLogPanel entries={actionLog} onClose={hideActionLog} />}
           </div>

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -56,10 +56,18 @@ export interface VideoPokerGameContentProps {
 
 /** Payout table display component. Expanded on the first visit so new players see
  * the payouts; once the player collapses it, the choice persists per variant. */
-function PayoutTable({ t, rows, gameName }: { t: (key: string) => string; rows: string[]; gameName: string }) {
+function PayoutTable({
+  t,
+  rows,
+  gameName,
+}: {
+  t: (key: string) => string;
+  rows: string[];
+  gameName: 'videopoker' | 'deuceswild' | 'jokerpoker';
+}) {
   const [open, setOpen] = useLocalStorageToggle(`paytable_open_${gameName}`, true);
   return (
-    <details className="mb-3 text-center" open={open} onToggle={(e) => setOpen((e.target as HTMLDetailsElement).open)}>
+    <details className="mb-3 text-center" open={open} onToggle={(e) => setOpen(e.currentTarget.open)}>
       <summary className="text-ds-warning text-sm cursor-pointer lg:text-base">{t('payoutTable.title')}</summary>
       <ul className="text-ds-text-muted text-xs mt-1 space-y-0.5 lg:text-sm lg:space-y-1">
         {rows.map((row) => (


### PR DESCRIPTION
## Summary

Closes #2191

The `PayoutTable` `<details>` in the shared `VideoPokerGameContent` was always collapsed by default, so first-time players could miss the payout information entirely. This PR:

- Expands the table on first visit and persists the player's collapse choice via `useLocalStorageToggle('paytable_open_<gameName>', true)` — the same persistence pattern as the existing `auto_hold_<gameName>` toggle, keyed per variant so all three video poker games (videopoker / deuceswild / jokerpoker) remember their own state.
- Syncs state from the native `onToggle` event, so both summary clicks and programmatic changes persist.
- Updates the one pre-existing test that asserted the old collapsed-by-default behavior to instead assert the dismissed-state contract (collapsed stays collapsed across phases after the player closes it).

## Test plan

- [x] TDD: 3 new tests written first, 2 confirmed failing (first-visit expanded; toggle-shut persists), then 22/22 green
- [x] `tsc -b`, `bun run build` (vite), `bun run check` all pass (Biome wanted the `<details>` attributes on one line — fixed)
- [x] Full `bun run test`: 9071 passed, 0 failed (known local NavBar fork-kill, file untouched — CI is the gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)