### PR TITLE
feat(memory): make the visited-card marker visible at small sizes

### DIFF
--- a/frontend/src/pages/MemoryPage.test.tsx
+++ b/frontend/src/pages/MemoryPage.test.tsx
@@ -259,9 +259,9 @@ describe('MemoryPage', () => {
     mockExec.mockResolvedValue(flip1State);
     fireEvent.click(screen.getByRole('button', { name: '次へ' }));
     await waitFor(() => expect(screen.getByTestId('board-visited-5')).toBeInTheDocument());
-    expect(screen.getByTestId('board-5').className).toContain('ring-ds-accent');
+    expect(screen.getByTestId('board-5')).toHaveClass('ring-ds-accent');
     // Unvisited face-down cards keep the plain back (no persistent ring).
-    expect(screen.getByTestId('board-0').className).not.toContain('ring-ds-accent');
+    expect(screen.getByTestId('board-0')).not.toHaveClass('ring-ds-accent');
   });
 
   it('face-down cards show card back image instead of position number', async () => {

--- a/frontend/src/pages/MemoryPage.test.tsx
+++ b/frontend/src/pages/MemoryPage.test.tsx
@@ -242,6 +242,28 @@ describe('MemoryPage', () => {
     expect(screen.getByTestId('board-visited-10')).toBeInTheDocument();
   });
 
+  it('gives a visited card a contrasting ring readable at small card sizes', async () => {
+    const seenState: MemoryResponse = {
+      ...flip1State,
+      phase: 2,
+      firstFlipPos: 5,
+      secondFlipPos: 10,
+      board: makeBoard({
+        5: { faceUp: true, card: { design: 'SPADE' as const, value: 3 } },
+        10: { faceUp: true, card: { design: 'HEART' as const, value: 7 } },
+      }),
+    };
+    mockExec.mockResolvedValueOnce(seenState);
+    renderWithProviders(<MemoryPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ 3')).toBeInTheDocument());
+    mockExec.mockResolvedValue(flip1State);
+    fireEvent.click(screen.getByRole('button', { name: '次へ' }));
+    await waitFor(() => expect(screen.getByTestId('board-visited-5')).toBeInTheDocument());
+    expect(screen.getByTestId('board-5').className).toContain('ring-ds-accent');
+    // Unvisited face-down cards keep the plain back (no persistent ring).
+    expect(screen.getByTestId('board-0').className).not.toContain('ring-ds-accent');
+  });
+
   it('face-down cards show card back image instead of position number', async () => {
     renderWithProviders(<MemoryPage />);
     await waitFor(() => expect(screen.getByText(/あなた: 0/)).toBeInTheDocument());

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -276,7 +276,9 @@ function MemoryPageContent() {
                           ? 'hidden'
                           : bc.faceUp
                             ? 'bg-white ring-2 ring-ds-warning shadow-lg shadow-ds-warning/30'
-                            : 'bg-ds-info border border-white/10 hover:ring-1 hover:ring-ds-warning'
+                            : wasVisited
+                              ? 'bg-ds-info border border-white/10 ring-1 ring-ds-accent hover:ring-ds-warning'
+                              : 'bg-ds-info border border-white/10 hover:ring-1 hover:ring-ds-warning'
                       } transition-all`}
                     >
                       <div className={`memory-card-inner${bc.faceUp ? ' flipped' : ''}`}>
@@ -288,7 +290,7 @@ function MemoryPageContent() {
                               aria-hidden="true"
                               className="absolute inset-0 rounded bg-black/25 pointer-events-none flex items-start justify-end p-0.5"
                             >
-                              <span className="text-[10px] leading-none" title={t('visitedMark')}>
+                              <span className="text-[14px] leading-none" title={t('visitedMark')}>
                                 {'\u{1F441}'}
                               </span>
                             </span>

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -290,7 +290,7 @@ function MemoryPageContent() {
                               aria-hidden="true"
                               className="absolute inset-0 rounded bg-black/25 pointer-events-none flex items-start justify-end p-0.5"
                             >
-                              <span className="text-[14px] leading-none" title={t('visitedMark')}>
+                              <span className="text-sm leading-none" title={t('visitedMark')}>
                                 {'\u{1F441}'}
                               </span>
                             </span>


### PR DESCRIPTION
## Summary

Closes #2178

The "already seen" marker on Memory's face-down cards was a 10 px 👁 emoji over a `bg-black/25` overlay — effectively invisible at the ~28 px card width on 375 px screens. This PR:

- Adds a persistent `ring-1 ring-ds-accent` to visited face-down cards, so the state is readable from the frame color alone at minimum card size. **Token note:** the issue suggested `ring-ds-info`, but the face-down card back is itself `bg-ds-info` — that ring would be invisible. `ds-accent` (antique gold, per DESIGN.md) contrasts with both the blue back and the orange `ring-ds-warning` used for face-up cards. Hover still upgrades to `ring-ds-warning`.
- Bumps the 👁 emoji to `text-[14px]` and keeps the `bg-black/25` dimming, per the issue.
- `aria-label` already contained `visitedMark` — unchanged. No locale changes needed (purely visual).

## Test plan

- [x] TDD: new test asserts the visited button carries `ring-ds-accent` while an unvisited one doesn't (covers both branches of the new ternary) — confirmed failing first (1 failed / 47 passed), then 48/48
- [x] `tsc -b`, `bun run build` (vite), `bun run check` all pass
- [x] Full `bun run test`: 9070 passed, 0 failed (known local NavBar fork-kill, file untouched — CI is the gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)