### PR TITLE
feat(blackjack): show a restart button when chips run out

### DIFF
--- a/frontend/src/i18n/locales/en/blackjack.json
+++ b/frontend/src/i18n/locales/en/blackjack.json
@@ -74,6 +74,7 @@
   "handCount": "Hands:",
   "handCountUnit": "",
   "autoAdvance": "Auto Advance:",
+  "outOfChips": "Out of chips — restart",
   "autoAdvanceSec": "{{sec}}s",
   "sideBet": {
     "perfectPairs": "Perfect Pairs",

--- a/frontend/src/i18n/locales/en/spanish21.json
+++ b/frontend/src/i18n/locales/en/spanish21.json
@@ -73,6 +73,7 @@
   "handCount": "Hands:",
   "handCountUnit": "",
   "autoAdvance": "Auto Advance:",
+  "outOfChips": "Out of chips — restart",
   "autoAdvanceSec": "{{sec}}s",
   "sideBet": {
     "perfectPairs": "Perfect Pairs",

--- a/frontend/src/i18n/locales/ja/blackjack.json
+++ b/frontend/src/i18n/locales/ja/blackjack.json
@@ -73,6 +73,7 @@
   "handCount": "ハンド数:",
   "handCountUnit": "ハンド",
   "autoAdvance": "自動進行:",
+  "outOfChips": "チップ不足 — リスタートする",
   "autoAdvanceSec": "{{sec}}秒",
   "sideBet": {
     "perfectPairs": "Perfect Pairs",

--- a/frontend/src/i18n/locales/ja/spanish21.json
+++ b/frontend/src/i18n/locales/ja/spanish21.json
@@ -73,6 +73,7 @@
   "handCount": "ハンド数:",
   "handCountUnit": "ハンド",
   "autoAdvance": "自動進行:",
+  "outOfChips": "チップ不足 — リスタートする",
   "autoAdvanceSec": "{{sec}}秒",
   "sideBet": {
     "perfectPairs": "Perfect Pairs",

--- a/frontend/src/pages/BlackJackPage.test.tsx
+++ b/frontend/src/pages/BlackJackPage.test.tsx
@@ -161,6 +161,16 @@ beforeEach(() => {
 });
 
 describe('BlackJackPage', () => {
+  it('shows the out-of-chips restart button instead of bet controls at zero chips', async () => {
+    mockExec.mockResolvedValue({ ...betPhaseState, player: { chips: 0 } });
+    renderWithProviders(<BlackJackPage />);
+    const restart = await screen.findByRole('button', { name: /チップ不足/ });
+    expect(screen.queryByRole('button', { name: 'ベット' })).not.toBeInTheDocument();
+    mockExec.mockClear();
+    fireEvent.click(restart);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, expect.anything()));
+  });
+
   it('renders skeleton before first API response', () => {
     mockExec.mockReturnValue(new Promise(() => undefined));
     renderWithProviders(<BlackJackPage />);

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -41,6 +41,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
+import { btnDanger } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { BlackJackResponse } from '../types/card';
@@ -504,7 +505,12 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
 
             {/* Phase-based buttons */}
             <div className="text-center">
-              {phase === BjPhase.BET && (
+              {phase === BjPhase.BET && playerChips === 0 && (
+                <button type="button" className={btnDanger} onClick={handleReset} disabled={loading}>
+                  {t('outOfChips')}
+                </button>
+              )}
+              {phase === BjPhase.BET && playerChips > 0 && (
                 <>
                   <div data-tutorial="bj-bet-controls">
                     <BjBetPhaseControls

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -505,7 +505,7 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
 
             {/* Phase-based buttons */}
             <div className="text-center">
-              {phase === BjPhase.BET && playerChips === 0 && (
+              {phase === BjPhase.BET && playerChips <= 0 && (
                 <button type="button" className={btnDanger} onClick={handleReset} disabled={loading}>
                   {t('outOfChips')}
                 </button>


### PR DESCRIPTION
## Summary

Closes #2161

When the player's chips hit 0, the bet phase left them stranded — bet controls present but unusable, with no signposted way to start over. This PR:

- Shows a `btnDanger` 「チップ不足 — リスタートする」/ "Out of chips — restart" button **instead of** the bet controls when `phase === BjPhase.BET && playerChips === 0` (exclusive display per the acceptance criteria).
- The button calls the existing `handleReset` directly — no confirmation dialog, per the issue (zero chips = nothing to lose), and it preserves the player's rule configuration (deck count, soft-17, DAS, counting, etc.) like every other reset path.
- Adds the `outOfChips` key to **both** `blackjack.json` and `spanish21.json` (ja/en): `BlackJackPage` is shared by the Spanish 21 variant and `t` resolves against the variant namespace, so the blackjack-only key suggested by the issue would have rendered as a raw key on `/spanish21`.

## Test plan

- [x] TDD: new test (restart button shown at 0 chips, bet button absent, click sends `reset` with config) confirmed failing first (1 failed / 128 passed), then 129/129 green; existing bet-phase tests (chips > 0) cover the other branch
- [x] `tsc -b`, `bun run build` (vite), `bun run check` all pass; en/ja locale parity verified for both variants
- [x] Full `bun run test`: 9074 passed, 0 failed (known local NavBar fork-kill, file untouched — CI is the gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)