### PR TITLE
feat(poker): disable the exchange button until a card is selected

### DIFF
--- a/frontend/src/pages/PokerPage.test.tsx
+++ b/frontend/src/pages/PokerPage.test.tsx
@@ -1352,6 +1352,19 @@ describe('PokerPage', () => {
       await waitFor(() => expect(mockExec).toHaveBeenCalledWith('exchange', [0]));
     });
 
+    it('Enter key does nothing when no cards are selected', async () => {
+      mockExec.mockResolvedValue(exchangeState);
+      renderWithProviders(<PokerPage />);
+      await waitFor(() => expect(screen.getByText('交換するカードを選んでください')).toBeInTheDocument());
+      mockExec.mockClear();
+
+      await act(async () => {
+        fireEvent.keyDown(document, { key: 'Enter' });
+      });
+
+      expect(mockExec).not.toHaveBeenCalled();
+    });
+
     it('Escape key clears selection', async () => {
       mockExec.mockResolvedValue(exchangeState);
       renderWithProviders(<PokerPage />);

--- a/frontend/src/pages/PokerPage.test.tsx
+++ b/frontend/src/pages/PokerPage.test.tsx
@@ -589,6 +589,17 @@ describe('PokerPage', () => {
     expect(screen.queryByRole('button', { name: 'スタンド' })).not.toBeInTheDocument();
   });
 
+  it('disables the exchange button until a card is selected', async () => {
+    mockExec.mockResolvedValue(exchangeState);
+    renderWithProviders(<PokerPage />);
+    const exchangeBtn = await screen.findByRole('button', { name: '交換' });
+    // Nothing selected yet: stand is the only enabled action.
+    expect(exchangeBtn).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'スタンド' })).toBeEnabled();
+    fireEvent.click(screen.getByAltText('♠ A'));
+    expect(exchangeBtn).toBeEnabled();
+  });
+
   it('calls exchange with selected indices', async () => {
     mockExec.mockResolvedValue(exchangeState);
     renderWithProviders(<PokerPage />);

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -408,7 +408,7 @@ function PokerPageContent() {
                 <button
                   type="button"
                   className={`${btnWarning} min-w-[90px]`}
-                  disabled={loading}
+                  disabled={loading || selected.length === 0}
                   onClick={() => exec('exchange', selected)}
                 >
                   {t('exchangeLabel')}

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -170,7 +170,7 @@ function PokerPageContent() {
     cardCount,
     onToggle: toggleCard,
     onConfirm: useCallback(() => {
-      if (canExchange && !loading) exec('exchange', selected);
+      if (canExchange && !loading && selected.length > 0) exec('exchange', selected);
     }, [canExchange, loading, exec, selected]),
     onClear: clearSelection,
     enabled: canExchange,


### PR DESCRIPTION
## Summary

Closes #2162

Most of the issue's proposal was already implemented — the 交換 (exchange) and スタンド (stand) buttons render side by side whenever `canExchange` is true. The one unmet acceptance criterion was the disabled state: 交換 was clickable with zero cards selected, which sent a redundant 0-card `exchange` request semantically identical to `stand`. This PR disables 交換 until at least one card is selected (`disabled={loading || selected.length === 0}`), making スタンド read as the explicit "no exchange" choice.

## Test plan

- [x] TDD: new test (交換 disabled with nothing selected / スタンド enabled / selecting a card enables 交換) confirmed failing first (1 failed / 111 passed), then 112/112 green
- [x] Verified `frontend/e2e/poker.spec.ts` is unaffected (it clicks スタンド, never an unselected 交換)
- [x] `tsc -b`, `bun run build` (vite), `bun run check` all pass
- [x] Full `bun run test`: 9075 passed, 0 failed (known local NavBar fork-kill, file untouched — CI is the gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)