### PR TITLE
fix(freecell): confirm before giving up

### DIFF
--- a/frontend/e2e/freecell.spec.ts
+++ b/frontend/e2e/freecell.spec.ts
@@ -38,6 +38,9 @@ test.describe('FreeCell E2E', () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' });
     await expect(giveUpButton).toBeVisible();
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog.
+    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // After give up, playing buttons should not be visible

--- a/frontend/src/pages/FreeCellPage.test.tsx
+++ b/frontend/src/pages/FreeCellPage.test.tsx
@@ -180,15 +180,29 @@ describe('FreeCellPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
   });
 
-  it('handleGiveUp called on giveup button click', async () => {
+  it('give up button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<FreeCellPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());
 
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
+    // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2180).
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
 
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
+  });
+
+  it('cancelling the give up dialog does not dispatch giveup', async () => {
+    renderWithProviders(<FreeCellPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());
+
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
   });
 
   it('handleUndo called on undo button click', async () => {
@@ -354,13 +368,16 @@ describe('FreeCellPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
   });
 
-  it('pressing g triggers giveup in PLAYING phase', async () => {
+  it('pressing g opens the give up confirm dialog in PLAYING phase', async () => {
     renderWithProviders(<FreeCellPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());
 
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.keyDown(document, { key: 'g' });
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -75,8 +75,21 @@ const FC_TUTORIAL_STEPS: TutorialStep[] = [
 export const FreeCellPage = withTutorial(FreeCellPageContent, 'freecell', FC_TUTORIAL_STEPS);
 /** Inner content of the FreeCell page, wrapped by TutorialProvider. */
 function FreeCellPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('freecell');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('freecell');
   const { playSound } = useSound();
   const {
     state,
@@ -135,14 +148,19 @@ function FreeCellPageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const actionBindings = useMemo(
     () => [
       { key: 'h', action: handleHint },
       { key: 'a', action: handleAutoComplete },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: handleUndo },
     ],
-    [handleHint, handleAutoComplete, handleGiveUp, handleUndo],
+    [handleHint, handleAutoComplete, confirmGiveUpAction, handleUndo],
   );
 
   useActionKeyboardNav({
@@ -188,6 +206,9 @@ function FreeCellPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -503,7 +524,7 @@ function FreeCellPageContent() {
                   <button
                     type="button"
                     className={btnDanger}
-                    onClick={handleGiveUp}
+                    onClick={confirmGiveUpAction}
                     disabled={loading || isAutoCompleting}
                   >
                     {t('giveup')}


### PR DESCRIPTION
## Summary

Closes #2180

FreeCell's あきらめる (give up) button — and the `g` keyboard shortcut — dispatched `giveup` immediately, ending the game with no confirmation, unlike Klondike which gained a confirm dialog in #2099. This PR ports the exact Klondike pattern:

- `giveUpConfirmOpen` / `requestGiveUpConfirm` / `confirmGiveUp` / `cancelGiveUp` destructured from `useGamePageSetup`.
- Both the button and the `g` key binding route through `confirmGiveUpAction = () => requestGiveUpConfirm(handleGiveUp)`.
- `GamePageShell` receives the three dialog props, rendering the shared `GameGiveUpDialog`.
- No `useFreeCellGame` change was needed (the issue listed it, but `handleGiveUp` is unchanged — only the call sites now go through the confirm flow).

## Test plan

- [x] TDD: converted the two direct-dispatch tests to the dialog contract and added a cancel test — all 3 confirmed failing first (3 failed / 60 passed), then 63/63 green:
  - button click → no dispatch + 投了確認 dialog → 確認 dispatches `giveup`
  - キャンセル → never dispatches
  - `g` key → same confirm flow (acceptance criterion)
- [x] `tsc -b`, `bun run build` (vite), `bun run check` all pass
- [x] Full `bun run test`: 9077 passed, 0 failed (known local NavBar fork-kill, file untouched — CI is the gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)