### PR TITLE
fix(spider): confirm before a mid-game difficulty change resets

### DIFF
--- a/frontend/src/pages/SpiderPage.test.tsx
+++ b/frontend/src/pages/SpiderPage.test.tsx
@@ -294,14 +294,38 @@ describe('SpiderPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
-  it('changing difficulty resets game with config', async () => {
+  it('changing difficulty mid-game asks for confirmation before resetting', async () => {
     renderWithProviders(<SpiderPage />);
     await waitFor(() => expect(screen.getByLabelText('難易度')).toBeInTheDocument());
 
     mockExec.mockClear();
     mockExec.mockResolvedValue({ ...playingState, difficulty: 2 });
     fireEvent.change(screen.getByLabelText('難易度'), { target: { value: '2' } });
+    // Mid-game: no reset until the dialog is confirmed (#2188).
+    expect(mockExec).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
 
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined, { difficulty: 2 }));
+  });
+
+  it('cancelling the difficulty change does not reset', async () => {
+    renderWithProviders(<SpiderPage />);
+    await waitFor(() => expect(screen.getByLabelText('難易度')).toBeInTheDocument());
+
+    mockExec.mockClear();
+    fireEvent.change(screen.getByLabelText('難易度'), { target: { value: '4' } });
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('changing difficulty after game end resets without confirmation', async () => {
+    mockExec.mockResolvedValue(gameOverState);
+    renderWithProviders(<SpiderPage />);
+    await waitFor(() => expect(screen.getByLabelText('難易度')).toBeInTheDocument());
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue({ ...playingState, difficulty: 2 });
+    fireEvent.change(screen.getByLabelText('難易度'), { target: { value: '2' } });
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined, { difficulty: 2 }));
   });
 

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -466,7 +466,14 @@ function SpiderPageContent() {
                 <select
                   value={currentDifficulty}
                   onChange={(e) => {
-                    handleResetWithConfig({ difficulty: Number(e.target.value) });
+                    const difficulty = Number(e.target.value);
+                    // Mid-game the change discards progress, so confirm first (#2188);
+                    // after the game ends there is nothing to lose.
+                    if (isEnded) {
+                      handleResetWithConfig({ difficulty });
+                    } else {
+                      requestConfirm(() => handleResetWithConfig({ difficulty }));
+                    }
                   }}
                   className="bg-ds-surface-elevated text-ds-text-primary text-sm rounded px-2 py-1"
                   aria-label={t('difficulty')}


### PR DESCRIPTION
## Summary

Closes #2188

Spider's 1/2/4-suit difficulty select called `handleResetWithConfig` directly in `onChange`, so switching difficulty mid-game silently discarded all progress. This PR:

- Routes mid-game changes through the existing `requestConfirm` mechanism (the same dialog `GameResetButton` uses), so the player confirms before the reset fires.
- Keeps the direct path when `isEnded` — no progress to lose, no dialog (acceptance criterion).
- Cancelling needs no extra handling: the `<select>` is controlled by `state.difficulty`, so React keeps it on the current value.
- No `useSpiderGame` change was needed (the issue listed it; only the call site changed).

## Test plan

- [x] TDD: converted the direct-reset test to the dialog contract and added cancel + post-game-direct tests — 2 confirmed failing first (2 failed / 55 passed), then 57/57 green
- [x] `frontend/e2e/spider.spec.ts` checked **before** push — it never interacts with the difficulty select
- [x] `tsc -b`, `bun run build` (vite), `bun run check` all pass
- [x] Full `bun run test`: 9079 passed, 0 failed (known local NavBar fork-kill — CI is the gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)