### PR TITLE
feat(tripeaks): ring playable cards adjacent to the waste top

### DIFF
--- a/frontend/src/pages/TriPeaksPage.test.tsx
+++ b/frontend/src/pages/TriPeaksPage.test.tsx
@@ -82,6 +82,29 @@ beforeEach(() => {
 });
 
 describe('TriPeaksPage', () => {
+  it('rings exposed cards adjacent to the waste top during play', async () => {
+    renderWithProviders(<TriPeaksPage />);
+    await waitFor(() => expect(screen.getByLabelText('♠ 5')).toBeInTheDocument());
+    // Waste top is ♣4: the exposed ♠5 is playable, ♥6/♣7 are not, ♦10 is face-down.
+    expect(screen.getByLabelText('♠ 5')).toHaveClass('ring-ds-success/70');
+    expect(screen.getByLabelText('♥ 6')).not.toHaveClass('ring-ds-success/70');
+    expect(screen.getByLabelText('♦ 10')).not.toHaveClass('ring-ds-success/70');
+  });
+
+  it('shows no playable ring when the waste is empty', async () => {
+    mockExec.mockResolvedValue({ ...playingState, waste: [] });
+    renderWithProviders(<TriPeaksPage />);
+    await waitFor(() => expect(screen.getByLabelText('♠ 5')).toBeInTheDocument());
+    expect(screen.getByLabelText('♠ 5')).not.toHaveClass('ring-ds-success/70');
+  });
+
+  it('shows no playable ring after the game ends', async () => {
+    mockExec.mockResolvedValue(gameClearState);
+    renderWithProviders(<TriPeaksPage />);
+    await waitFor(() => expect(screen.getByLabelText('♠ 5')).toBeInTheDocument());
+    expect(screen.getByLabelText('♠ 5')).not.toHaveClass('ring-ds-success/70');
+  });
+
   it('renders skeleton when no state', () => {
     mockExec.mockReturnValue(new Promise(() => undefined));
     renderWithProviders(<TriPeaksPage />);

--- a/frontend/src/pages/TriPeaksPage.test.tsx
+++ b/frontend/src/pages/TriPeaksPage.test.tsx
@@ -91,6 +91,17 @@ describe('TriPeaksPage', () => {
     expect(screen.getByLabelText('♦ 10')).not.toHaveClass('ring-ds-success/70');
   });
 
+  it('prefers the hint ring over the playable ring on the same card', async () => {
+    renderWithProviders(<TriPeaksPage />);
+    await waitFor(() => expect(screen.getByLabelText('♠ 5')).toBeInTheDocument());
+
+    // Server hint targets ♠5 at row 3, col 0 — the same card the playable ring covers.
+    mockExec.mockResolvedValueOnce({ ...playingState, hint: { type: 'remove', row: 3, col: 0 } });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+    await waitFor(() => expect(screen.getByLabelText('♠ 5')).toHaveClass('ring-ds-warning'));
+    expect(screen.getByLabelText('♠ 5')).not.toHaveClass('ring-ds-success/70');
+  });
+
   it('shows no playable ring when the waste is empty', async () => {
     mockExec.mockResolvedValue({ ...playingState, waste: [] });
     renderWithProviders(<TriPeaksPage />);

--- a/frontend/src/pages/TriPeaksPage.tsx
+++ b/frontend/src/pages/TriPeaksPage.tsx
@@ -34,6 +34,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { parseTripeaksCommand, TRIPEAKS_HELP } from '../utils/cli/commands/tripeaksCommands';
 import { formatTripeaksState } from '../utils/cli/formatters/tripeaksFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { isTriPeaksAdjacent } from '../utils/hints/tripeaksHint';
 
 /** Valid column positions per row in the TriPeaks tableau. */
 const VALID_COLS: readonly number[][] = [
@@ -148,6 +149,8 @@ function TriPeaksPageContent() {
     return <GameSkeleton gameKey="tripeaks" layout={{ kind: 'tiered-rows', rows: [3, 6, 9, 10], stockWaste: true }} />;
 
   const isPlaying = state.phase === TriPeaksPhase.PLAYING;
+  // Rank of the waste top, used to ring playable (±1 with K-A wrap) tableau cards.
+  const wasteTopValue = state.waste.length > 0 ? state.waste[state.waste.length - 1].value : undefined;
   const isGameClear = state.phase === TriPeaksPhase.GAME_CLEAR;
   const isGameOver = state.phase === TriPeaksPhase.GAME_OVER;
   const isEnded = isGameClear || isGameOver;
@@ -234,6 +237,11 @@ function TriPeaksPageContent() {
                       if (!tc2.card) return null;
                       const exposed = tc2.exposed;
                       const isHinted = hint?.type === 'remove' && hint.row === rowIdx && hint.col === colIdx;
+                      const isPlayable =
+                        isPlaying &&
+                        exposed &&
+                        wasteTopValue !== undefined &&
+                        isTriPeaksAdjacent(tc2.card.value, wasteTopValue);
                       return (
                         <div key={`tc-${rowIdx.toString()}-${colIdx.toString()}`} className="absolute" style={{ left }}>
                           <button
@@ -245,7 +253,7 @@ function TriPeaksPageContent() {
                             disabled={!isPlaying || loading || !exposed}
                             aria-label={cardAlt(tc2.card)}
                             className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${
-                              isHinted ? 'ring-2 ring-ds-warning' : ''
+                              isHinted ? 'ring-2 ring-ds-warning' : isPlayable ? 'ring-2 ring-ds-success/70' : ''
                             } ${!exposed ? 'opacity-60' : ''}`}
                           >
                             <AnimatedCard card={tc2.card} width={effectiveCardWidth} />

--- a/frontend/src/utils/hints/tripeaksHint.ts
+++ b/frontend/src/utils/hints/tripeaksHint.ts
@@ -47,6 +47,10 @@ function countRemovableCards(state: TriPeaksResponse, wasteValue: number): numbe
 }
 
 /** Check if two values are adjacent (with King-Ace wrap-around). */
+export function isTriPeaksAdjacent(a: number, b: number): boolean {
+  return isAdjacent(a, b);
+}
+
 function isAdjacent(a: number, b: number): boolean {
   const diff = Math.abs(a - b);
   return diff === 1 || diff === MAX_VALUE - 1;


### PR DESCRIPTION
## Summary

Closes #2196

TriPeaks gave no standing indication of which tableau cards are currently playable (waste-top rank ±1) — players had to press the hint button to see a single candidate. This PR:

- Rings exposed tableau cards adjacent to the waste top with `ring-2 ring-ds-success/70` during the PLAY phase, recomputed per render from `state.waste` (no new state, per the issue).
- Reuses the hint engine's adjacency rule by exporting `isTriPeaksAdjacent` (K↔A wrap) from `tripeaksHint.ts` — one source of truth for "playable".
- The hint highlight (`ring-ds-warning`) takes ternary precedence when both apply; empty waste and ended games show no ring (acceptance criteria).
- **Token note:** the issue suggested raw `ring-green-300/400`; used the `ds-success` token instead per DESIGN.md and the design-token checker.

## Test plan

- [x] TDD: 3 new tests (adjacent exposed ♠5 ringed while ♥6 and face-down ♦10 are not; empty waste → no ring; game end → no ring) — positive case confirmed failing first, then 29/29 green
- [x] `frontend/e2e/tripeaks.spec.ts` checked — no card-class dependencies
- [x] `tsc -b`, `bun run build` (vite), `bun run check` (incl. design tokens) all pass
- [x] Full `bun run test`: 9088 passed, 0 failed (known local NavBar fork-kill — CI is the gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)