### PR TITLE
feat(euchre): explain the excluded suit in the call-trump phase

### DIFF
--- a/frontend/e2e/euchre.spec.ts
+++ b/frontend/e2e/euchre.spec.ts
@@ -65,8 +65,9 @@ test.describe('Euchre E2E', () => {
       // Pass (call trump phase)
       if (passVisible && !playVisible && !discardVisible) {
         interactions++;
-        // Try to select a suit button if visible, otherwise pass
-        const suitButton = page.getByRole('button', { name: /♠|♣|♥|♦/ }).first();
+        // Try to select an enabled suit button if visible, otherwise pass
+        // (the turned-down card's suit renders as a disabled button).
+        const suitButton = page.getByRole('button', { name: /♠|♣|♥|♦/, disabled: false }).first();
         const suitVisible = await suitButton.isVisible();
         if (suitVisible) {
           await suitButton.click();

--- a/frontend/src/i18n/locales/en/euchre.json
+++ b/frontend/src/i18n/locales/en/euchre.json
@@ -44,6 +44,7 @@
   "pickUpPhase": "Order up the face-up card to the dealer?",
   "callTrumpPhase": "Choose a trump suit (other than the face-up card's suit)",
   "discardPhase": "Select a card to discard",
+  "turnedDownSuit": "This suit cannot be called (it was the turned-down card)",
   "suitSpade": "♠ Spades",
   "suitClover": "♣ Clubs",
   "suitHeart": "♥ Hearts",

--- a/frontend/src/i18n/locales/ja/euchre.json
+++ b/frontend/src/i18n/locales/ja/euchre.json
@@ -44,6 +44,7 @@
   "pickUpPhase": "ディーラーにめくり札をオーダーアップしますか？",
   "callTrumpPhase": "切り札スートを選んでください（めくり札のスート以外）",
   "discardPhase": "1枚捨てるカードを選んでください",
+  "turnedDownSuit": "このスートは選択できません（めくり札のスート）",
   "suitSpade": "♠ スペード",
   "suitClover": "♣ クラブ",
   "suitHeart": "♥ ハート",

--- a/frontend/src/pages/EuchrePage.test.tsx
+++ b/frontend/src/pages/EuchrePage.test.tsx
@@ -299,6 +299,15 @@ describe('EuchrePage', () => {
     });
   });
 
+  it('shows the turned-down suit as a disabled, explained button', async () => {
+    mockExec.mockResolvedValue(callTrumpPhaseState); // faceUpCard is HEART
+    renderWithProviders(<EuchrePage />);
+    const heart = await screen.findByRole('button', { name: '♥ ハート' });
+    expect(heart).toBeDisabled();
+    expect(heart).toHaveAttribute('title', 'このスートは選択できません（めくり札のスート）');
+    expect(screen.getByRole('button', { name: '♠ スペード' })).toBeEnabled();
+  });
+
   it('renders discard phase with discard button', async () => {
     mockExec.mockResolvedValue(discardPhaseState);
     renderWithProviders(<EuchrePage />);

--- a/frontend/src/pages/EuchrePage.tsx
+++ b/frontend/src/pages/EuchrePage.tsx
@@ -44,6 +44,9 @@ const SUIT_NAMES: Readonly<Record<number, string>> = {
   4: 'suitDiamond',
 };
 
+/** Card design string → suit number used by the call-trump buttons. */
+const DESIGN_TO_SUIT: Readonly<Record<string, number>> = { SPADE: 1, CLOVER: 2, HEART: 3, DIAMOND: 4, JOKER: 0 };
+
 /** Euchre tutorial step definitions. */
 const EU_TUTORIAL_STEPS: TutorialStep[] = [
   {
@@ -514,12 +517,7 @@ function EuchrePageContent() {
                   {[1, 2, 3, 4].map((s) => {
                     // The turned-down card's suit cannot be called; keep its button
                     // visible but disabled so the rule is discoverable.
-                    const isTurnedDownSuit =
-                      state.faceUpCard != null &&
-                      s ===
-                        ({ SPADE: 1, CLOVER: 2, HEART: 3, DIAMOND: 4, JOKER: 0 } as Record<string, number>)[
-                          state.faceUpCard.design
-                        ];
+                    const isTurnedDownSuit = state.faceUpCard != null && s === DESIGN_TO_SUIT[state.faceUpCard.design];
                     return (
                       <button
                         key={s}

--- a/frontend/src/pages/EuchrePage.tsx
+++ b/frontend/src/pages/EuchrePage.tsx
@@ -511,26 +511,28 @@ function EuchrePageContent() {
               {/* Call trump phase controls */}
               {isHumanBidTurn && isCallTrumpPhase && (
                 <>
-                  {[1, 2, 3, 4]
-                    .filter(
-                      (s) =>
-                        state.faceUpCard == null ||
-                        s !==
-                          ({ SPADE: 1, CLOVER: 2, HEART: 3, DIAMOND: 4, JOKER: 0 } as Record<string, number>)[
-                            state.faceUpCard.design
-                          ],
-                    )
-                    .map((s) => (
+                  {[1, 2, 3, 4].map((s) => {
+                    // The turned-down card's suit cannot be called; keep its button
+                    // visible but disabled so the rule is discoverable.
+                    const isTurnedDownSuit =
+                      state.faceUpCard != null &&
+                      s ===
+                        ({ SPADE: 1, CLOVER: 2, HEART: 3, DIAMOND: 4, JOKER: 0 } as Record<string, number>)[
+                          state.faceUpCard.design
+                        ];
+                    return (
                       <button
                         key={s}
                         type="button"
                         className={btnPrimary}
                         onClick={() => handleCallTrump(s, goAlone)}
-                        disabled={loading}
+                        disabled={loading || isTurnedDownSuit}
+                        title={isTurnedDownSuit ? t('turnedDownSuit') : undefined}
                       >
                         {t(SUIT_NAMES[s])}
                       </button>
-                    ))}
+                    );
+                  })}
                   <label className="text-ds-text-primary text-sm flex items-center gap-1">
                     <input type="checkbox" checked={goAlone} onChange={(e) => setGoAlone(e.target.checked)} />
                     {t('goAloneCheck')}


### PR DESCRIPTION
## Summary

Closes #2194

In Euchre's call-trump phase the turned-down card's suit was silently `.filter()`ed out of the suit buttons — first-time players had no way to learn the "can't call the turned-down suit" rule. This PR implements the issue's preferred option:

- All four suits render; the turned-down suit's button is `disabled` (the shared button base already greys it out) with a `title` tooltip — new `turnedDownSuit` key in ja/en (「このスートは選択できません（めくり札のスート）」).
- The design→suit-number map moves into an `isTurnedDownSuit` predicate per button; no behavior change for the other three suits.
- **E2E hazard fixed in the same change:** `euchre.spec.ts` clicks the *first* button matching a suit symbol — after this change that can be the disabled button, which would hang Playwright's actionability wait (~1-in-4 per call-trump round). The locator now passes `disabled: false`.

## Test plan

- [x] TDD: new test (HEART face-up → ♥ ハート button disabled with the tooltip; ♠ スペード enabled) confirmed failing first, then 66/66 green
- [x] ja/en parity verified
- [x] `tsc -b`, `bun run build` (vite), `bun run check` all pass
- [x] Full `bun run test`: 9092 passed; the single reported failure was `DesktopSidebar.test.tsx` timing out under full-suite memory pressure on the 2 GB box (passes 37/37 in isolation; same environmental class as the documented NavBar fork-kill — CI is the gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)