### PR TITLE
feat(threecard): replace bet number inputs with chip steppers

### DIFF
--- a/frontend/src/pages/ThreeCardPage.test.tsx
+++ b/frontend/src/pages/ThreeCardPage.test.tsx
@@ -233,6 +233,25 @@ describe('ThreeCardPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bet', 200, 50));
   });
 
+  it('steps the ante and pair plus amounts with the chip steppers', async () => {
+    mockExec.mockResolvedValue(betPhaseState);
+    renderWithProviders(<ThreeCardPage />);
+    await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
+
+    // Default ante 100 → +10 → 110; pair plus 0 → +10 → 10.
+    fireEvent.click(screen.getByRole('button', { name: 'アンテ +10' }));
+    fireEvent.click(screen.getByRole('button', { name: 'ペアプラス +10' }));
+    fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bet', 110, 10));
+  });
+
+  it('disables the pair plus minus stepper at zero', async () => {
+    mockExec.mockResolvedValue(betPhaseState);
+    renderWithProviders(<ThreeCardPage />);
+    await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'ペアプラス −10' })).toBeDisabled();
+  });
+
   it('resets after end phase', async () => {
     mockExec
       .mockResolvedValueOnce(betPhaseState)

--- a/frontend/src/pages/ThreeCardPage.tsx
+++ b/frontend/src/pages/ThreeCardPage.tsx
@@ -3,6 +3,7 @@ import { threecardApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { ChipBetInput } from '../components/common/ChipBetInput';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
@@ -308,36 +309,23 @@ function ThreeCardPageContent() {
             />
             {isBetPhase && (
               <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="tc-bet-controls">
-                <div className="flex items-center gap-2">
-                  <label htmlFor="threecard-ante-amount" className="text-ds-text-primary text-sm">
-                    {t('label.ante')}
-                  </label>
-                  <input
-                    id="threecard-ante-amount"
-                    type="number"
-                    min={10}
-                    max={state.chips}
-                    step={10}
-                    value={anteAmount}
-                    onChange={(e) => setAnteAmount(Number(e.target.value))}
-                    className="w-24 px-2 py-1 rounded text-sm"
-                  />
-                </div>
-                <div className="flex items-center gap-2">
-                  <label htmlFor="threecard-pairplus-amount" className="text-ds-text-primary text-sm">
-                    {t('label.pairPlus')}
-                  </label>
-                  <input
-                    id="threecard-pairplus-amount"
-                    type="number"
-                    min={0}
-                    max={state.chips}
-                    step={10}
-                    value={pairPlusAmount}
-                    onChange={(e) => setPairPlusAmount(Number(e.target.value))}
-                    className="w-24 px-2 py-1 rounded text-sm"
-                  />
-                </div>
+                <ChipBetInput
+                  id="threecard-ante-amount"
+                  label={t('label.ante')}
+                  value={anteAmount}
+                  onChange={setAnteAmount}
+                  max={state.chips}
+                  showSteppers
+                />
+                <ChipBetInput
+                  id="threecard-pairplus-amount"
+                  label={t('label.pairPlus')}
+                  value={pairPlusAmount}
+                  onChange={setPairPlusAmount}
+                  min={0}
+                  max={state.chips}
+                  showSteppers
+                />
                 <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading}>
                   {t('button.bet')}
                 </button>


### PR DESCRIPTION
## 概要

スリーカードポーカーのベットフェーズの ante / pair plus 入力を `<input type="number">` から `ChipBetInput`（−/＋ ステッパー付き）に置き換え、モバイルでの操作性を改善する。

## 変更点

- `frontend/src/pages/ThreeCardPage.tsx`: ante と pair plus の数値入力を、ステッパー付き `ChipBetInput`（既存共通コンポーネント）に置換
  - ante: `min` 10, step 10
  - pair plus: `min` 0, step 10（賭けなしを許容）
- ステッパーは最小値で `−`、最大値（手持ちチップ）で `＋` が自動的に無効化される
- `frontend/src/pages/ThreeCardPage.test.tsx`: ステッパークリックで金額が変化し Bet API に反映されるテスト、および pair plus の `−10` が 0 で無効になるテストを追加

## テスト計画

- [x] `bun run test -- --run ThreeCardPage` → 37 passed
- [x] `biome check` (modified files) → clean
- [ ] CI: `bun run build`（tsc）— ローカルは OOM のため CI で検証

Closes #2198

🤖 Generated with [Claude Code](https://claude.com/claude-code)