### PR TITLE
feat(texasholdembonus): unify bet inputs to ChipBetInput steppers

### DIFF
--- a/frontend/src/pages/TexasHoldemBonusPage.test.tsx
+++ b/frontend/src/pages/TexasHoldemBonusPage.test.tsx
@@ -214,6 +214,25 @@ describe('TexasHoldemBonusPage', () => {
     await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', 200, 10));
   });
 
+  it('steps the ante and bonus amounts with the chip steppers', async () => {
+    mockApi.mockResolvedValue(betPhaseState);
+    renderWithProviders(<TexasHoldemBonusPage />);
+    await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
+
+    // Default ante 100 → +10 → 110; bonus 0 → +10 → 10.
+    fireEvent.click(screen.getByRole('button', { name: 'アンテ +10' }));
+    fireEvent.click(screen.getByRole('button', { name: 'ボーナス +10' }));
+    fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', 110, 10));
+  });
+
+  it('disables the bonus minus stepper at zero', async () => {
+    mockApi.mockResolvedValue(betPhaseState);
+    renderWithProviders(<TexasHoldemBonusPage />);
+    await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'ボーナス −10' })).toBeDisabled();
+  });
+
   it('shows network error', async () => {
     mockApi.mockResolvedValueOnce(betPhaseState).mockRejectedValueOnce(new Error('Network'));
     renderWithProviders(<TexasHoldemBonusPage />);

--- a/frontend/src/pages/TexasHoldemBonusPage.tsx
+++ b/frontend/src/pages/TexasHoldemBonusPage.tsx
@@ -3,6 +3,7 @@ import { texasholdembonusApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { ChipBetInput } from '../components/common/ChipBetInput';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
@@ -334,36 +335,23 @@ function TexasHoldemBonusPageContent() {
             <SettingsPanel title={t('settings.title')} groups={[]} />
             {isBetPhase && (
               <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="thb-bet-controls">
-                <div className="flex items-center gap-2">
-                  <label htmlFor="texasholdembonus-ante-amount" className="text-ds-text-primary text-sm">
-                    {t('label.ante')}
-                  </label>
-                  <input
-                    id="texasholdembonus-ante-amount"
-                    type="number"
-                    min={10}
-                    max={state.chips}
-                    step={10}
-                    value={anteAmount}
-                    onChange={(e) => setAnteAmount(Number(e.target.value))}
-                    className="w-24 px-2 py-1 rounded text-sm"
-                  />
-                </div>
-                <div className="flex items-center gap-2">
-                  <label htmlFor="texasholdembonus-bonus-amount" className="text-ds-text-primary text-sm">
-                    {t('label.bonus')}
-                  </label>
-                  <input
-                    id="texasholdembonus-bonus-amount"
-                    type="number"
-                    min={0}
-                    max={state.chips}
-                    step={10}
-                    value={bonusAmount}
-                    onChange={(e) => setBonusAmount(Number(e.target.value))}
-                    className="w-24 px-2 py-1 rounded text-sm"
-                  />
-                </div>
+                <ChipBetInput
+                  id="texasholdembonus-ante-amount"
+                  label={t('label.ante')}
+                  value={anteAmount}
+                  onChange={setAnteAmount}
+                  max={state.chips}
+                  showSteppers
+                />
+                <ChipBetInput
+                  id="texasholdembonus-bonus-amount"
+                  label={t('label.bonus')}
+                  value={bonusAmount}
+                  onChange={setBonusAmount}
+                  min={0}
+                  max={state.chips}
+                  showSteppers
+                />
                 <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading}>
                   {t('button.bet')}
                 </button>

--- a/frontend/src/pages/TexasHoldemBonusPage.tsx
+++ b/frontend/src/pages/TexasHoldemBonusPage.tsx
@@ -340,7 +340,10 @@ function TexasHoldemBonusPageContent() {
                   label={t('label.ante')}
                   value={anteAmount}
                   onChange={setAnteAmount}
+                  min={10}
                   max={state.chips}
+                  step={10}
+                  disabled={loading}
                   showSteppers
                 />
                 <ChipBetInput
@@ -350,6 +353,8 @@ function TexasHoldemBonusPageContent() {
                   onChange={setBonusAmount}
                   min={0}
                   max={state.chips}
+                  step={10}
+                  disabled={loading}
                   showSteppers
                 />
                 <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading}>


### PR DESCRIPTION
## 概要

テキサスホールデムボーナスポーカーのベットフェーズの ante / bonus 入力を `<input type="number">` から共通コンポーネント `ChipBetInput`（−/＋ ステッパー付き）に置き換え、Caribbean Stud / Let It Ride と一貫した外観・モバイル操作性に統一する。

## 変更点

- `frontend/src/pages/TexasHoldemBonusPage.tsx`: ante と bonus の数値入力をステッパー付き `ChipBetInput` に置換
  - ante: `min` 10（デフォルト）, step 10, `max` = 手持ちチップ
  - bonus: `min` 0, step 10, `max` = 手持ちチップ（賭けなしを維持）
  - ステッパーは最小値で `−`、最大値（チップ残高）で `＋` が自動的に無効化される
- `frontend/src/pages/TexasHoldemBonusPage.test.tsx`: ステッパークリックで金額が変化し Bet API に反映されるテスト、bonus の `−10` が 0 で無効になるテストを追加

## 受け入れ条件

- [x] アンテ入力が `ChipBetInput` で置き換えられている
- [x] ボーナス入力が `ChipBetInput` で置き換えられている
- [x] `min={0}` のボーナス入力でも減算ボタンが 0 以下にならない（0 で無効化）
- [x] Caribbean Stud / Let It Ride と一貫した外観
- [x] `bun run test` (18 passed) + `biome check` 通過。`bun run build`(tsc) はローカル OOM のため CI で検証

Closes #2213

🤖 Generated with [Claude Code](https://claude.com/claude-code)