### PR TITLE
fix(threecard): lock bet steppers while a request is in-flight

### DIFF
--- a/frontend/src/pages/ThreeCardPage.tsx
+++ b/frontend/src/pages/ThreeCardPage.tsx
@@ -314,7 +314,10 @@ function ThreeCardPageContent() {
                   label={t('label.ante')}
                   value={anteAmount}
                   onChange={setAnteAmount}
+                  min={10}
                   max={state.chips}
+                  step={10}
+                  disabled={loading}
                   showSteppers
                 />
                 <ChipBetInput
@@ -324,6 +327,8 @@ function ThreeCardPageContent() {
                   onChange={setPairPlusAmount}
                   min={0}
                   max={state.chips}
+                  step={10}
+                  disabled={loading}
                   showSteppers
                 />
                 <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading}>


### PR DESCRIPTION
## 概要

#2198 (PR #2444) で導入したスリーカードポーカーのベット入力 `ChipBetInput` に `disabled={loading}` が抜けていたため、ベット送信中（API リクエスト中）もステッパーで金額を変更できてしまう小さな不整合を修正する。`CasinoHoldemPage` 等の他カジノページと揃える。

これは #2445 (Texas Hold'em Bonus) の自動レビューで指摘された同一の must-fix を、先行マージ済みの ThreeCard 側にも反映する一貫性フォローアップ。

## 変更点

- `frontend/src/pages/ThreeCardPage.tsx`: ante / pair plus の `ChipBetInput` に `disabled={loading}` と明示的な `min`/`step` を追加

## テスト計画

- [x] `bun run test -- --run ThreeCardPage` → 37 passed
- [x] `biome check` → clean
- [ ] CI: `bun run build`（tsc）— ローカル OOM のため CI で検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)