### PR TITLE
feat(caribbeanstud): unify bet inputs to ChipBetInput steppers

### DIFF
--- a/frontend/src/pages/CaribbeanStudPage.test.tsx
+++ b/frontend/src/pages/CaribbeanStudPage.test.tsx
@@ -218,6 +218,25 @@ describe('CaribbeanStudPage', () => {
     await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', 200, 10));
   });
 
+  it('steps the ante and jackpot amounts with the chip steppers', async () => {
+    mockApi.mockResolvedValue(betPhaseState);
+    renderWithProviders(<CaribbeanStudPage />);
+    await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
+
+    // Default ante 100 → +10 → 110; jackpot 0 → +10 → 10.
+    fireEvent.click(screen.getByRole('button', { name: 'アンテ +10' }));
+    fireEvent.click(screen.getByRole('button', { name: 'ジャックポット +10' }));
+    fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', 110, 10));
+  });
+
+  it('disables the jackpot minus stepper at zero', async () => {
+    mockApi.mockResolvedValue(betPhaseState);
+    renderWithProviders(<CaribbeanStudPage />);
+    await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'ジャックポット −10' })).toBeDisabled();
+  });
+
   it('next game button executes reset without confirm dialog', async () => {
     mockApi.mockResolvedValue(endPhasePlayerWins);
     renderWithProviders(<CaribbeanStudPage />);

--- a/frontend/src/pages/CaribbeanStudPage.tsx
+++ b/frontend/src/pages/CaribbeanStudPage.tsx
@@ -3,6 +3,7 @@ import { caribbeanstudApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { ChipBetInput } from '../components/common/ChipBetInput';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
@@ -319,36 +320,28 @@ function CaribbeanStudPageContent() {
             <SettingsPanel title={t('settings.title')} groups={[]} />
             {isBetPhase && (
               <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="csp-bet-controls">
-                <div className="flex items-center gap-2">
-                  <label htmlFor="caribbeanstud-ante-amount" className="text-ds-text-primary text-sm">
-                    {t('label.ante')}
-                  </label>
-                  <input
-                    id="caribbeanstud-ante-amount"
-                    type="number"
-                    min={10}
-                    max={state.chips}
-                    step={10}
-                    value={anteAmount}
-                    onChange={(e) => setAnteAmount(Number(e.target.value))}
-                    className="w-24 px-2 py-1 rounded text-sm"
-                  />
-                </div>
-                <div className="flex items-center gap-2">
-                  <label htmlFor="caribbeanstud-jackpot-amount" className="text-ds-text-primary text-sm">
-                    {t('label.jackpot')}
-                  </label>
-                  <input
-                    id="caribbeanstud-jackpot-amount"
-                    type="number"
-                    min={0}
-                    max={state.chips}
-                    step={10}
-                    value={jackpotAmount}
-                    onChange={(e) => setJackpotAmount(Number(e.target.value))}
-                    className="w-24 px-2 py-1 rounded text-sm"
-                  />
-                </div>
+                <ChipBetInput
+                  id="caribbeanstud-ante-amount"
+                  label={t('label.ante')}
+                  value={anteAmount}
+                  onChange={setAnteAmount}
+                  min={10}
+                  max={state.chips}
+                  step={10}
+                  disabled={loading}
+                  showSteppers
+                />
+                <ChipBetInput
+                  id="caribbeanstud-jackpot-amount"
+                  label={t('label.jackpot')}
+                  value={jackpotAmount}
+                  onChange={setJackpotAmount}
+                  min={0}
+                  max={state.chips}
+                  step={10}
+                  disabled={loading}
+                  showSteppers
+                />
                 <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading}>
                   {t('button.bet')}
                 </button>


### PR DESCRIPTION
## 概要

カリビアンスタッドポーカーのアンテ・ジャックポット入力を `<input type="number">` から共通コンポーネント `ChipBetInput`（−/＋ ステッパー付き）に置き換え、`LetItRidePage` と一貫した外観・モバイル操作性に統一する。

## 変更点

- `frontend/src/pages/CaribbeanStudPage.tsx`: ante / jackpot の数値入力をステッパー付き `ChipBetInput` に置換（`min`/`max`/`step`/`disabled={loading}` を CasinoHoldemPage と同じ完全なプロップセットで指定）
  - ante: min 10, step 10, max = 手持ちチップ
  - jackpot: min 0, step 10, max = 手持ちチップ（賭けなしを維持、−ステッパーは 0 で無効化）
- `frontend/src/pages/CaribbeanStudPage.test.tsx`: ステッパークリックで金額が変化し Bet API に反映されるテスト、jackpot の `−10` が 0 で無効になるテストを追加

## 受け入れ条件

- [x] アンテ入力が `ChipBetInput` で置き換えられている
- [x] ジャックポット入力が `ChipBetInput` で置き換えられている
- [x] `LetItRidePage` の `ChipBetInput` 使用例と UI 統一
- [x] `bun run test` (19 passed) + `biome check` 通過。`bun run build`(tsc) はローカル OOM のため CI で検証

Closes #2212

🤖 Generated with [Claude Code](https://claude.com/claude-code)