### PR TITLE
feat(letitride): show bet amounts and total risk in the bet-status panel

### DIFF
--- a/frontend/src/i18n/locales/en/letitride.json
+++ b/frontend/src/i18n/locales/en/letitride.json
@@ -9,6 +9,7 @@
     "bet3": "Bet 3",
     "active": "Active",
     "pulled": "Pulled",
+    "currentRisk": "Current Risk",
     "community": "Community Cards"
   },
   "button": {

--- a/frontend/src/i18n/locales/ja/letitride.json
+++ b/frontend/src/i18n/locales/ja/letitride.json
@@ -9,6 +9,7 @@
     "bet3": "ベット3",
     "active": "有効",
     "pulled": "引き戻し",
+    "currentRisk": "現在のリスク合計",
     "community": "コミュニティカード"
   },
   "button": {

--- a/frontend/src/pages/LetItRidePage.test.tsx
+++ b/frontend/src/pages/LetItRidePage.test.tsx
@@ -165,6 +165,26 @@ describe('LetItRidePage', () => {
     expect(screen.getByTestId('bet-status')).toHaveTextContent('引き戻し');
   });
 
+  it('shows the per-bet amount and total current risk when all bets are live', async () => {
+    mockApi.mockResolvedValue(firstDecisionState);
+    renderWithProviders(<LetItRidePage />);
+    await waitFor(() => expect(screen.getByTestId('bet-status')).toBeInTheDocument());
+    // betAmount 100 in each of the 3 boxes.
+    expect(screen.getByTestId('bet-box-bet1')).toHaveTextContent('100');
+    // All three live → risk 300, and the active box carries the success ring.
+    expect(screen.getByTestId('current-risk')).toHaveTextContent('300');
+    expect(screen.getByTestId('bet-box-bet1').className).toContain('ring-ds-success');
+  });
+
+  it('dims a pulled bet box and lowers the current risk total', async () => {
+    mockApi.mockResolvedValue(secondDecisionState);
+    renderWithProviders(<LetItRidePage />);
+    await waitFor(() => expect(screen.getByTestId('bet-status')).toBeInTheDocument());
+    // bet1 pulled → dimmed, risk drops to 2 × 100 = 200.
+    expect(screen.getByTestId('bet-box-bet1').className).toContain('opacity-40');
+    expect(screen.getByTestId('current-risk')).toHaveTextContent('200');
+  });
+
   it('shows END phase with reset button and payout breakdown on win', async () => {
     mockApi.mockResolvedValue(endPhaseWin);
     renderWithProviders(<LetItRidePage />);

--- a/frontend/src/pages/LetItRidePage.tsx
+++ b/frontend/src/pages/LetItRidePage.tsx
@@ -146,6 +146,10 @@ function LetItRidePageContent() {
     execApi('reset');
   };
 
+  // Bets at risk in the decision/end phases: each live bet stakes `betAmount`.
+  const activeBetCount = [state.bet1Active, state.bet2Active, state.bet3Active].filter(Boolean).length;
+  const currentRisk = state.betAmount * activeBetCount;
+
   const phaseName = isBetPhase
     ? t('phase.bet')
     : isFirstDecision
@@ -272,16 +276,29 @@ function LetItRidePageContent() {
             )}
 
             {!isBetPhase && (
-              <div className="flex justify-center gap-4 text-ds-text-primary text-sm mb-2" data-testid="bet-status">
-                <span>
-                  {t('label.bet1')}: {state.bet1Active ? t('label.active') : t('label.pulled')}
-                </span>
-                <span>
-                  {t('label.bet2')}: {state.bet2Active ? t('label.active') : t('label.pulled')}
-                </span>
-                <span>
-                  {t('label.bet3')}: {state.bet3Active ? t('label.active') : t('label.pulled')}
-                </span>
+              <div className="mb-2" data-testid="bet-status">
+                <div className="flex justify-center gap-3">
+                  {[
+                    { key: 'bet1', label: t('label.bet1'), active: state.bet1Active },
+                    { key: 'bet2', label: t('label.bet2'), active: state.bet2Active },
+                    { key: 'bet3', label: t('label.bet3'), active: state.bet3Active },
+                  ].map((bet) => (
+                    <div
+                      key={bet.key}
+                      data-testid={`bet-box-${bet.key}`}
+                      className={`flex flex-col items-center rounded px-3 py-1 text-ds-text-primary text-sm ${
+                        bet.active ? 'ring-1 ring-ds-success' : 'opacity-40'
+                      }`}
+                    >
+                      <span>{bet.label}</span>
+                      <span className="font-bold">{state.betAmount}</span>
+                      <span className="text-xs">{bet.active ? t('label.active') : t('label.pulled')}</span>
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-1 text-center text-ds-text-primary text-sm" data-testid="current-risk">
+                  {t('label.currentRisk')}: {currentRisk}
+                </div>
               </div>
             )}
 


### PR DESCRIPTION
## 概要

レット・イット・ライドの判断/結果フェーズのベット状態表示を、金額付きの視覚インジケータに拡張する。プレイヤーが「今いくら賭けているか／引けばいくら戻るか」を一目で把握できるようにする。

## 変更点

- `frontend/src/pages/LetItRidePage.tsx`:
  - ベット状態パネルを各ベットのボックス表示に変更。各ボックスに掛け金額（`state.betAmount`）と active/pulled 状態を表示
  - active ベット = `ring-1 ring-ds-success` でハイライト、pulled ベット = `opacity-40` で減光
  - パネル下部に「現在のリスク合計 = `betAmount × アクティブ数`」を追加（`data-testid="current-risk"`）
- `frontend/src/i18n/locales/{ja,en}/letitride.json`: `label.currentRisk`（現在のリスク合計 / Current Risk）を追加

## 受け入れ条件

- [x] 各ベットボックスに掛け金額が表示される
- [x] active ベットが緑リングでハイライトされる
- [x] pulled ベットが暗くなる（opacity-40）
- [x] 「現在リスク」の合計金額が表示される
- [x] 翻訳キーが ja/en 両ロケールに定義されている
- [x] `bun run test` (25 passed) + `biome check` 通過。`bun run build`(tsc) はローカル OOM のため CI で検証

Closes #2220

🤖 Generated with [Claude Code](https://claude.com/claude-code)