### PR TITLE
feat(scorpion,wasp): show completed-suit progress as filled suit glyphs

### DIFF
--- a/frontend/src/components/common/SuitProgressBadge.test.tsx
+++ b/frontend/src/components/common/SuitProgressBadge.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { SuitProgressBadge } from './SuitProgressBadge';
+
+describe('SuitProgressBadge', () => {
+  it('renders four suit glyphs', () => {
+    render(<SuitProgressBadge completed={0} />);
+    expect(screen.getAllByTestId('suit-todo')).toHaveLength(4);
+    expect(screen.queryAllByTestId('suit-done')).toHaveLength(0);
+  });
+
+  it('fills the first N glyphs as completed', () => {
+    render(<SuitProgressBadge completed={2} />);
+    const done = screen.getAllByTestId('suit-done');
+    const todo = screen.getAllByTestId('suit-todo');
+    expect(done).toHaveLength(2);
+    expect(todo).toHaveLength(2);
+    expect(done[0]).toHaveClass('text-ds-success');
+    expect(todo[0]).toHaveClass('text-ds-text-muted');
+  });
+
+  it('fills every glyph when all suits are complete', () => {
+    render(<SuitProgressBadge completed={4} />);
+    expect(screen.getAllByTestId('suit-done')).toHaveLength(4);
+    expect(screen.getByTestId('suit-progress')).toHaveAttribute('aria-label', '4/4');
+  });
+
+  it('clamps out-of-range counts to [0, 4]', () => {
+    const { rerender } = render(<SuitProgressBadge completed={9} />);
+    expect(screen.getAllByTestId('suit-done')).toHaveLength(4);
+    rerender(<SuitProgressBadge completed={-3} />);
+    expect(screen.getAllByTestId('suit-todo')).toHaveLength(4);
+  });
+
+  it('renders an optional label', () => {
+    render(<SuitProgressBadge completed={1} label="完成" />);
+    expect(screen.getByText('完成:')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/common/SuitProgressBadge.tsx
+++ b/frontend/src/components/common/SuitProgressBadge.tsx
@@ -1,0 +1,47 @@
+/** The four card suits, drawn in canonical order to mark foundation progress. */
+const SUIT_GLYPHS = ['♠', '♣', '♥', '♦'] as const;
+
+/** Total number of suits a player must complete. */
+const TOTAL_SUITS = SUIT_GLYPHS.length;
+
+/** Props for {@link SuitProgressBadge}. */
+export interface SuitProgressBadgeProps {
+  /**
+   * Number of completed suits (0–4). The first `completed` glyphs are filled
+   * (`text-ds-success`); the rest are shown muted. The count is suit-agnostic —
+   * games such as Scorpion/Wasp expose only a tally, so glyphs fill in canonical
+   * ♠♣♥♦ order rather than by which specific suits finished.
+   */
+  completed: number;
+  /** Optional label rendered before the glyphs (e.g. "Completed"). */
+  label?: string;
+}
+
+/**
+ * Renders four suit glyphs that fill as foundations complete, giving solitaire
+ * games (Scorpion, Wasp) a visual "N of 4 suits done" progress indicator in
+ * place of plain `N/4` text.
+ */
+export function SuitProgressBadge({ completed, label }: SuitProgressBadgeProps) {
+  const filled = Math.max(0, Math.min(completed, TOTAL_SUITS));
+  return (
+    <span
+      className="inline-flex items-center gap-1"
+      data-testid="suit-progress"
+      role="img"
+      aria-label={`${filled}/${TOTAL_SUITS}`}
+    >
+      {label && <span className="text-ds-text-primary">{label}:</span>}
+      {SUIT_GLYPHS.map((glyph, i) => (
+        <span
+          // Fixed-length canonical list; index is a stable key.
+          key={glyph}
+          data-testid={i < filled ? 'suit-done' : 'suit-todo'}
+          className={i < filled ? 'text-ds-success' : 'text-ds-text-muted'}
+        >
+          {glyph}
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/frontend/src/pages/ScorpionPage.tsx
+++ b/frontend/src/pages/ScorpionPage.tsx
@@ -4,6 +4,7 @@ import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
+import { SuitProgressBadge } from '../components/common/SuitProgressBadge';
 import { DropZone } from '../components/DropZone';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
@@ -331,8 +332,9 @@ function ScorpionPageContent() {
           <span>
             {t('moveCount')}: {state.moveCount}
           </span>
-          <span data-tutorial="sc-stock">
-            {t('stock')}: {state.stockCount} / {t('completed')}: {state.completedSuits}/4
+          <span data-tutorial="sc-stock" className="inline-flex items-center gap-2">
+            {t('stock')}: {state.stockCount}
+            <SuitProgressBadge completed={state.completedSuits} label={t('completed')} />
           </span>
           <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
         </>

--- a/frontend/src/pages/WaspPage.tsx
+++ b/frontend/src/pages/WaspPage.tsx
@@ -4,6 +4,7 @@ import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
+import { SuitProgressBadge } from '../components/common/SuitProgressBadge';
 import { DropZone } from '../components/DropZone';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
@@ -331,8 +332,9 @@ function WaspPageContent() {
           <span>
             {t('moveCount')}: {state.moveCount}
           </span>
-          <span data-tutorial="sc-stock">
-            {t('stock')}: {state.stockCount} / {t('completed')}: {state.completedSuits}/4
+          <span data-tutorial="sc-stock" className="inline-flex items-center gap-2">
+            {t('stock')}: {state.stockCount}
+            <SuitProgressBadge completed={state.completedSuits} label={t('completed')} />
           </span>
           <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
         </>


### PR DESCRIPTION
## 概要

スコーピオン / ワスプのヘッダーにある「completed: N/4」テキストを、4 つのスート glyph（♠♣♥♦）による進捗インジケータに置き換える。完成スート数を視覚的に表示し、ゴールへの達成感を演出する。

## 変更点

- 新規共通コンポーネント `frontend/src/components/common/SuitProgressBadge.tsx`: `completed`(0–4) を受け取り、先頭 N 個の glyph を `text-ds-success` で塗りつぶし、残りを `text-ds-text-muted` で表示。`role="img"` + `aria-label="N/4"` でアクセシブル
  - 注: Scorpion/Wasp の `completedSuits` はカウントのみ（どのスートが完成したかは持たない）ため、canonical な ♠♣♥♦ 順に N 個を塗りつぶす（suit-agnostic）
- `frontend/src/pages/ScorpionPage.tsx` / `WaspPage.tsx`: ヘッダーの完成数テキストを `SuitProgressBadge` に置換
- `frontend/src/components/common/SuitProgressBadge.test.tsx`: 0/2/4/範囲外/ラベルの各ケースをカバー

## 受け入れ条件

- [x] 4 つのスートアイコンが完成状態に応じて色分け表示される
- [x] 完成スートが `text-ds-success` でハイライトされる
- [x] 未完成スートが `text-ds-text-muted` で表示される
- [x] `WaspPage.tsx` も同じ `SuitProgressBadge` を使う
- [x] `bun run test` (component 5 + Scorpion + Wasp) + `biome check` 通過。`bun run build`(tsc) はローカル OOM のため CI で検証

Closes #2227

🤖 Generated with [Claude Code](https://claude.com/claude-code)