### PR TITLE
feat(shortdeck): mark the rank-override rule on the showdown hand badge

### DIFF
--- a/frontend/src/pages/ShortDeckPage.test.tsx
+++ b/frontend/src/pages/ShortDeckPage.test.tsx
@@ -332,6 +332,14 @@ describe('ShortDeckPage', () => {
     await waitFor(() => expect(screen.getByText('ツーペア')).toBeInTheDocument());
   });
 
+  it('appends the Short Deck rank-override marker to the human hand-name badge at showdown', async () => {
+    mockExec.mockResolvedValue(showdownState);
+    renderWithProviders(<ShortDeckPage />);
+    const marker = await screen.findByTestId('shortdeck-handname-rule');
+    expect(marker).toHaveAttribute('title', 'ショートデック特殊ルール：フラッシュ > フルハウス');
+    expect(marker).toHaveAttribute('aria-label', 'ショートデック特殊ルール：フラッシュ > フルハウス');
+  });
+
   it('shows CPU cards face-up during showdown when not folded', async () => {
     mockExec.mockResolvedValue(showdownState);
     renderWithProviders(<ShortDeckPage />);

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -361,8 +361,19 @@ function ShortDeckPageContent() {
                   {humanPlayer.folded && <span className="ml-2 text-ds-error text-xs">[{tc('status.folded')}]</span>}
                   {humanPlayer.allIn && <span className="ml-2 text-ds-warning text-xs">[{tc('status.allIn')}]</span>}
                   {isShowdown && !humanPlayer.folded && humanPlayer.handName && (
-                    <span className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}>
+                    <span
+                      className={`inline-flex items-center gap-1 ml-2 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}
+                    >
                       {humanPlayer.handName}
+                      <span
+                        data-testid="shortdeck-handname-rule"
+                        role="img"
+                        aria-label={t('rankOverrideReminder')}
+                        title={t('rankOverrideReminder')}
+                        className="cursor-help text-ds-warning"
+                      >
+                        ★
+                      </span>
                     </span>
                   )}
                 </div>


### PR DESCRIPTION
## 概要

ショートデックのショーダウン時、人間プレイヤーの手役バッジ（`handNameBadge`）の横に「Flush > Full House」ルール差分の注記マーカー（★）を常時表示する。これまでコミュニティカードエリアの警告バッジ（`shortdeck-rank-watermark`）はスクロールアップしないと見えなかったため、手役確認時に常にルール差分を意識できるようにする。

## 変更点

- `frontend/src/pages/ShortDeckPage.tsx`: ショーダウン時の手役バッジ内に `★` マーカーを追加。`title` / `aria-label` に既存の `rankOverrideReminder` キー（「ショートデック特殊ルール：フラッシュ > フルハウス」/「Short Deck special rule: Flush beats Full House」）を割り当て、`role="img"` でアクセシブルに
- `frontend/src/pages/ShortDeckPage.test.tsx`: マーカーの存在と title/aria-label テキストを検証するテストを追加

## 受け入れ条件

- [x] ショーダウン時の手役バッジ横に Short Deck ルール注記が表示される
- [x] `title` 属性でフルテキストが確認できる（aria-label も同テキスト）
- [x] 既存の `shortdeck-rank-watermark` テストが引き続きパス（84 passed）
- [x] `bun run test` + `biome check` 通過。`bun run build`(tsc) はローカル OOM のため CI で検証

Closes #2173

🤖 Generated with [Claude Code](https://claude.com/claude-code)