### PR TITLE
feat(pokersquares): size the board cards responsively on mobile

### DIFF
--- a/frontend/src/pages/PokerSquaresPage.test.tsx
+++ b/frontend/src/pages/PokerSquaresPage.test.tsx
@@ -105,6 +105,20 @@ describe('PokerSquaresPage', () => {
     expect(screen.getByText(/次に置くカード/)).toBeInTheDocument();
   });
 
+  it('grows the card width to fill the viewport on a 375px mobile screen', async () => {
+    const original = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    try {
+      mockApi.mockResolvedValue(playingState);
+      renderWithProviders(<PokerSquaresPage />);
+      const cell = await screen.findByTestId('cell-0-0');
+      // floor((375 - 112) / 5) = 52, clamped to [40, 60] → 52px (> the fixed 40px mobile preset).
+      expect(cell.querySelector('div')).toHaveStyle({ width: '52px' });
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: original });
+    }
+  });
+
   it('calls exec with place when an empty cell is clicked', async () => {
     mockApi.mockResolvedValue(playingState);
     renderWithProviders(<PokerSquaresPage />);

--- a/frontend/src/pages/PokerSquaresPage.tsx
+++ b/frontend/src/pages/PokerSquaresPage.tsx
@@ -12,7 +12,7 @@ import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { withTutorial } from '../components/tutorial/withTutorial';
-import { useCardDimensions } from '../hooks/useCardDimensions';
+import { CARD_DIMENSIONS, useCardDimensions, useWindowWidth } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
@@ -56,7 +56,20 @@ export const PokerSquaresPage = withTutorial(PokerSquaresPageContent, 'pokersqua
 function PokerSquaresPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('pokersquares');
-  const { cardWidth } = useCardDimensions();
+  const { cardWidth: baseCardWidth, isMobile } = useCardDimensions();
+  const windowWidth = useWindowWidth();
+  // On mobile the 5-column board plus its row-score column wastes horizontal
+  // space at the fixed 40px card width. Grow cards to fill the viewport width
+  // (accounting for page padding, inter-card gaps, and the row-score column),
+  // clamped to [baseCardWidth, desktop width] so they never shrink below the
+  // current size or overflow. Desktop keeps the fixed preset.
+  const PS_BOARD_CHROME_PX = 112;
+  const cardWidth = isMobile
+    ? Math.max(
+        baseCardWidth,
+        Math.min(CARD_DIMENSIONS.desktop.cardWidth, Math.floor((windowWidth - PS_BOARD_CHROME_PX) / 5)),
+      )
+    : baseCardWidth;
   const { playSound } = useSound();
   const { state, loading, error, exec: execApi, retry } = useGameApi(pokersquaresApi.exec);
   const {


### PR DESCRIPTION
## 概要

ポーカー・スクエアズの 5×5 ボードがモバイルで固定 40px カード幅のままビューポート幅に対して小さく、横の余白を持て余していた。`useWindowWidth()` を導入し、モバイル時はカード幅をビューポート幅に合わせて拡大する（ページパディング・カード間ギャップ・行スコア列を考慮）。横スクロールは発生させない。

## 変更点

- `frontend/src/pages/PokerSquaresPage.tsx`:
  - `useWindowWidth()` + `useCardDimensions().isMobile` を導入
  - モバイル時 `cardWidth = clamp(baseCardWidth, floor((windowWidth - 112) / 5), desktopWidth)` で動的計算（`112` = ページパディング + ギャップ + 行スコア列の概算チップ幅）
  - デスクトップは従来の固定プリセットを維持
  - 行/列スコアバッジの高さは既に `cardWidth * 1.4` 比例のため自動でリサイズ
- `frontend/src/pages/PokerSquaresPage.test.tsx`: 375px 幅でカード幅が 52px に拡大するテストを追加

## 受け入れ条件

- [x] 375px 幅で 5×5 グリッドが横スクロールなく表示される（カードは 40→52px に拡大）
- [x] スコアバッジがカード高さに合わせてリサイズされる（`height: cardWidth*1.4`）
- [x] デスクトップでは従来の固定幅カードが維持される（`isMobile` 分岐）
- [x] `bun run test` (19 passed) + `biome check` 通過。`bun run build`(tsc) はローカル OOM のため CI で検証

Closes #2221

🤖 Generated with [Claude Code](https://claude.com/claude-code)