### PR TITLE
feat(calculation): preview waste-pile upper ranks in a tooltip

### DIFF
--- a/frontend/src/i18n/locales/en/calculation.json
+++ b/frontend/src/i18n/locales/en/calculation.json
@@ -24,6 +24,7 @@
   "nextRankBadge": "Next: {{rank}}",
   "nextRankAria": "Next required card {{rank}}",
   "upcomingRanksTooltip": "Upcoming cards: {{sequence}}",
+  "wasteRanksTooltip": "Waste {{idx}} (top 3): {{ranks}}",
   "foundationCompleteAria": "Complete",
   "gameClear": "Game Clear! Moves: {{moveCount}}",
   "gameOver": "Game Over",

--- a/frontend/src/i18n/locales/ja/calculation.json
+++ b/frontend/src/i18n/locales/ja/calculation.json
@@ -24,6 +24,7 @@
   "nextRankBadge": "次:{{rank}}",
   "nextRankAria": "次に置くべきカード {{rank}}",
   "upcomingRanksTooltip": "今後の必要カード: {{sequence}}",
+  "wasteRanksTooltip": "ウェイスト{{idx}}（上3枚）: {{ranks}}",
   "foundationCompleteAria": "完成",
   "gameClear": "ゲームクリア！ 手数: {{moveCount}}",
   "gameOver": "ゲームオーバー",

--- a/frontend/src/pages/CalculationPage.test.tsx
+++ b/frontend/src/pages/CalculationPage.test.tsx
@@ -132,6 +132,26 @@ describe('CalculationPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
   });
 
+  it('shows the bottom-up rank preview as a tooltip/aria-label on a non-empty waste pile', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      // Array order is bottom→top; the last <=3 (5, K, A) render in order.
+      wastes: [[card('SPADE', 2), card('HEART', 5), card('DIAMOND', 13), card('CLOVER', 1)], [], [], []],
+    });
+    renderWithProviders(<CalculationPage />);
+    const btn = await screen.findByTestId('calc-waste-button-0');
+    expect(btn).toHaveAttribute('title', 'ウェイスト0（上3枚）: 5・K・A');
+    expect(btn).toHaveAttribute('aria-label', 'ウェイスト0（上3枚）: 5・K・A');
+  });
+
+  it('omits the rank tooltip on an empty waste pile', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<CalculationPage />);
+    const btn = await screen.findByTestId('calc-waste-button-0');
+    expect(btn).not.toHaveAttribute('title');
+    expect(btn).not.toHaveAttribute('aria-label');
+  });
+
   it('clicking foundation without a source has no effect', async () => {
     renderWithProviders(<CalculationPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));

--- a/frontend/src/pages/CalculationPage.tsx
+++ b/frontend/src/pages/CalculationPage.tsx
@@ -469,6 +469,14 @@ function CalculationPageContent() {
                 const selected = isWasteSelected(idx);
                 const isHintSource = hintWaste === idx;
                 const canAcceptStock = sourceIsStock && isPlaying && !loading;
+                // Compact preview of the pile's upper cards (last <=3 array
+                // elements, ending at the playable top) for the hover/focus
+                // tooltip and screen-reader label.
+                const wasteRanks = pile
+                  .slice(-3)
+                  .map((c) => valueName(c.value))
+                  .join('・');
+                const wasteLabel = pile.length > 0 ? t('wasteRanksTooltip', { idx, ranks: wasteRanks }) : undefined;
                 return (
                   <div key={`w-${idx.toString()}`} className="flex flex-col items-center">
                     <div className="text-[11px] mb-0.5 text-ds-text-muted">
@@ -485,6 +493,8 @@ function CalculationPageContent() {
                       }}
                       disabled={!isPlaying || loading || (!top && !canAcceptStock)}
                       aria-pressed={selected}
+                      title={wasteLabel}
+                      aria-label={wasteLabel}
                       data-testid={`calc-waste-button-${idx.toString()}`}
                       className={`p-0 border-0 bg-transparent rounded ${focusRingWhite} ${selected ? 'ring-2 ring-ds-warning' : ''} ${isHintSource ? 'ring-2 ring-ds-success animate-pulse' : ''} ${canAcceptStock ? 'ring-2 ring-ds-info/70' : ''}`}
                     >


### PR DESCRIPTION
## 概要

カルキュレーションの各 Waste ボタンにホバー/フォーカス時のツールチップと `aria-label` を追加し、パイル上部（末尾 ≤3 枚、トップで終わる）のカードランクを「5・K・A」のようにコンパクト表示する。積み上がった廃棄山で「次に何が使えるか」を埋もれたカードを確認せず判断できるようにする。

## 変更点

- `frontend/src/pages/CalculationPage.tsx`: Waste ボタンに `title` / `aria-label` を追加（`pile.slice(-3)` を `valueName` で整形）。空パイルでは付与しない
- `frontend/src/i18n/locales/{ja,en}/calculation.json`: `wasteRanksTooltip`（「ウェイスト{{idx}}（上3枚）: {{ranks}}」/「Waste {{idx}} (top 3): {{ranks}}」）を追加
- `frontend/src/pages/CalculationPage.test.tsx`: 非空パイルの tooltip/aria-label と空パイルでの非表示を検証

## 受け入れ条件

- [x] Waste ボタンにホバー/フォーカスで上から最大 3 枚のランクが tooltip 表示される
- [x] トップが 1 枚のみの場合は 1 枚だけ表示（`slice(-3)` が 1 要素を返す）
- [x] 空パイルでは tooltip を表示しない
- [x] 既存の `CalculationPage.test.tsx` が通過（32 passed）
- [x] `aria-label` でスクリーンリーダーでも読み上げ可能
- [x] `bun run test` + `biome check` 通過。`bun run build`(tsc) はローカル OOM のため CI で検証

Closes #2235

🤖 Generated with [Claude Code](https://claude.com/claude-code)