### PR TITLE
feat(spiteandmalice): show the CPU side piles in the opponent summary

### DIFF
--- a/frontend/src/i18n/locales/en/spiteandmalice.json
+++ b/frontend/src/i18n/locales/en/spiteandmalice.json
@@ -11,6 +11,7 @@
     "cpu": "CPU",
     "goal": "Goal",
     "side": "Side",
+    "cpuSides": "CPU side piles",
     "hand": "Hand",
     "foundation": "Foundation",
     "stock": "Stock",

--- a/frontend/src/i18n/locales/ja/spiteandmalice.json
+++ b/frontend/src/i18n/locales/ja/spiteandmalice.json
@@ -11,6 +11,7 @@
     "cpu": "CPU",
     "goal": "ゴール",
     "side": "サイド",
+    "cpuSides": "CPUのサイドパイル",
     "hand": "手札",
     "foundation": "ファウンデーション",
     "stock": "ストック",

--- a/frontend/src/pages/SpiteAndMalicePage.test.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { spiteAndMaliceApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -86,6 +86,22 @@ describe('SpiteAndMalicePage', () => {
   it('shows move count label', async () => {
     renderWithProviders(<SpiteAndMalicePage />);
     await waitFor(() => expect(screen.getByText(/手数|Moves/)).toBeInTheDocument());
+  });
+
+  it('renders the CPU side piles with a count badge on non-empty piles', async () => {
+    mockExec.mockResolvedValue({
+      ...baseState,
+      players: [
+        baseState.players[0],
+        { ...baseState.players[1], sides: [[card('SPADE', 4), card('HEART', 3)], [], [], []] },
+      ],
+    });
+    renderWithProviders(<SpiteAndMalicePage />);
+    await waitFor(() => expect(screen.getByTestId('sam-cpu-sides')).toBeInTheDocument());
+    // Pile 0 has 2 cards → top card image + count badge "2".
+    expect(within(screen.getByTestId('sam-cpu-side-0')).getByText('2')).toBeInTheDocument();
+    // The other three piles render an empty dashed placeholder (no count badge).
+    expect(within(screen.getByTestId('sam-cpu-side-1')).queryByText(/\d/)).not.toBeInTheDocument();
   });
 
   it('drives CPU turn automatically', async () => {

--- a/frontend/src/pages/SpiteAndMalicePage.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.tsx
@@ -283,7 +283,13 @@ function SpiteAndMalicePageContent() {
           <LandscapeBanner message={t('landscapeBanner', { defaultValue: '' })} />
 
           <div className="flex-1 overflow-y-auto pt-3 px-2 sm:px-4 lg:px-8 space-y-4">
-            <PlayerSummary label={t('label.cpu')} player={opponent} cardWidth={cardWidth} dataTutorial="sam-opponent" />
+            <PlayerSummary
+              label={t('label.cpu')}
+              sidesLabel={t('label.cpuSides')}
+              player={opponent}
+              cardWidth={cardWidth}
+              dataTutorial="sam-opponent"
+            />
 
             <div className="flex items-center justify-center gap-2 sm:gap-4" data-tutorial="sam-foundations">
               {state.foundations.map((pile, idx) => (
@@ -387,21 +393,25 @@ function SpiteAndMalicePageContent() {
 
 function PlayerSummary({
   label,
+  sidesLabel,
   player,
   cardWidth,
   dataTutorial,
 }: {
   label: string;
+  sidesLabel: string;
   player: SpiteAndMaliceResponse['players'][number];
   cardWidth: number;
   dataTutorial: string;
 }) {
+  // Side piles render at half scale to keep the opponent strip compact on mobile.
+  const sideWidth = Math.round(cardWidth * 0.5);
   return (
     <div className="flex flex-col items-center" data-tutorial={dataTutorial}>
       <span className="text-sm text-ds-secondary mb-1">
         {label} (hand: {player.hand.length})
       </span>
-      <div className="flex gap-2">
+      <div className="flex gap-2 items-end">
         {player.goalTop ? (
           <div className="flex flex-col items-center">
             <span className="text-xs text-ds-secondary">CPU goal x{player.goalSize}</span>
@@ -410,6 +420,36 @@ function PlayerSummary({
         ) : (
           <span className="text-xs text-ds-secondary">CPU goal: 0</span>
         )}
+        <div className="flex flex-col items-center" data-testid="sam-cpu-sides">
+          <span className="text-xs text-ds-secondary">{sidesLabel}</span>
+          <div className="flex gap-1">
+            {player.sides.map((pile, i) => {
+              const top = pile.length > 0 ? pile[pile.length - 1] : undefined;
+              return (
+                <div
+                  // Fixed-length 4-pile array; index is a stable key.
+                  key={`cpu-side-${i}`}
+                  data-testid={`sam-cpu-side-${i}`}
+                  className="relative flex items-center justify-center"
+                >
+                  {top ? (
+                    <AnimatedCard card={top} width={sideWidth} />
+                  ) : (
+                    <div
+                      style={{ width: sideWidth, height: Math.round(sideWidth * 1.4) }}
+                      className="rounded border border-dashed border-game-border"
+                    />
+                  )}
+                  {pile.length > 0 && (
+                    <span className="absolute -top-1 -right-1 rounded bg-ds-surface px-1 text-[9px] text-ds-text-primary leading-tight">
+                      {pile.length}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要

スパイト・アンド・マリスの相手（CPU）サマリは `goalTop` のみ表示し、CPU のサイドパイル（後でファウンデーションに出せる重要情報）が一切見えなかった。CPU の 4 サイドパイルを `PlayerSummary` に追加表示する。

## 変更点

- `frontend/src/pages/SpiteAndMalicePage.tsx`: `PlayerSummary` に CPU の `player.sides`（4 パイル）を半サイズ（`cardWidth*0.5`）で横並び表示。各パイルはトップカード画像＋枚数バッジ、空パイルは点線ボーダーのプレースホルダー
- `frontend/src/i18n/locales/{ja,en}/spiteandmalice.json`: `label.cpuSides`（「CPUのサイドパイル」/「CPU side piles」）を追加
- `frontend/src/pages/SpiteAndMalicePage.test.tsx`: 非空パイルの枚数バッジと空パイルの検証テストを追加

## 受け入れ条件

- [x] CPU のサイドパイルのトップカード（＋枚数バッジ）が画面上部に表示される
- [x] 空のサイドパイルは点線ボーダーのプレースホルダーで表示される
- [x] モバイル(375px)でも崩れない（半サイズ + items-end の横並び）
- [x] ja/en 翻訳ラベルを追加
- [x] `bun run test` (14 passed) + `biome check` 通過。`bun run build`(tsc) はローカル OOM のため CI で検証

Closes #2236

🤖 Generated with [Claude Code](https://claude.com/claude-code)