### PR TITLE
feat(deucetoseven): lift best-low cards and dim draw candidates

### DIFF
--- a/frontend/src/pages/DeuceToSevenPage.test.tsx
+++ b/frontend/src/pages/DeuceToSevenPage.test.tsx
@@ -224,6 +224,37 @@ describe('DeuceToSevenPage', () => {
     expect(screen.getByTestId('d7-stand-btn').className).not.toContain('animate-pulse');
   });
 
+  it('lifts the best-low core cards and dims the draw candidates', async () => {
+    // Hand 2-2-4-6-8: the duplicate 2 is a draw candidate; the rest are kept.
+    mockExec.mockResolvedValue(
+      baseState({
+        phase: DeuceToSevenPhase.DRAW,
+        drawIndex: 1,
+        currentTurn: 0,
+        players: [
+          humanPlayer({
+            cards: [
+              { design: 'SPADE', value: 2 },
+              { design: 'HEART', value: 2 },
+              { design: 'DIAMOND', value: 4 },
+              { design: 'CLOVER', value: 6 },
+              { design: 'SPADE', value: 8 },
+            ],
+          }),
+          cpuPlayer(1),
+          cpuPlayer(2),
+          cpuPlayer(3),
+        ],
+      }),
+    );
+    renderWithProviders(<DeuceToSevenPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '交換' })).toBeInTheDocument());
+
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.getAttribute('aria-pressed') !== null);
+    expect(cardButtons[0].className).toContain('-translate-y-1'); // kept 2
+    expect(cardButtons[1].className).toContain('opacity-50'); // duplicate 2 → draw candidate
+  });
+
   it('marks a selected card as pressed in draw phase', async () => {
     mockExec.mockResolvedValue(baseState({ phase: DeuceToSevenPhase.DRAW, drawIndex: 1, currentTurn: 0 }));
     renderWithProviders(<DeuceToSevenPage />);

--- a/frontend/src/pages/DeuceToSevenPage.tsx
+++ b/frontend/src/pages/DeuceToSevenPage.tsx
@@ -38,7 +38,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { DEUCE_TO_SEVEN_HELP, parseDeuceToSevenCommand } from '../utils/cli/commands/deuceToSevenCommands';
 import { formatDeuceToSevenState } from '../utils/cli/formatters/deuceToSevenFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
-import { isMadePatLow } from '../utils/deuceToSevenUtils';
+import { deuceToSevenBestIndices, isMadePatLow } from '../utils/deuceToSevenUtils';
 import { findPlayerName } from '../utils/playerUtils';
 
 /** 2-7 Triple Draw tutorial step definitions. */
@@ -158,6 +158,12 @@ function DeuceToSevenPageContent() {
   // low (no pair / straight / flush). Drawing from this state can only weaken it.
   const humanHasMadeLow = useMemo(
     () => (canExchange ? isMadePatLow(humanPlayer?.cards ?? []) : false),
+    [canExchange, humanPlayer?.cards],
+  );
+
+  // During the draw, lift the best-low core cards and dim the draw candidates.
+  const bestSubset = useMemo(
+    () => (canExchange ? new Set(deuceToSevenBestIndices(humanPlayer?.cards ?? [])) : null),
     [canExchange, humanPlayer?.cards],
   );
 
@@ -294,6 +300,11 @@ function DeuceToSevenPageContent() {
                 <div className="flex flex-wrap gap-1.5 mb-2">
                   {(humanPlayer.cards ?? []).map((card, i) => {
                     const isSelected = selected.includes(i);
+                    let liftOrDim = '';
+                    if (bestSubset) {
+                      if (bestSubset.has(i)) liftOrDim = '-translate-y-1';
+                      else if (!isSelected) liftOrDim = 'opacity-50';
+                    }
                     return (
                       <button
                         key={`${card.design}-${card.value}`}
@@ -301,7 +312,7 @@ function DeuceToSevenPageContent() {
                         aria-label={`${cardAlt(card)}${isSelected ? ` ${t('cardSelected')}` : ''}`}
                         aria-pressed={isSelected}
                         onClick={() => toggleCard(i)}
-                        className={`${focusRingAccent} rounded transition-transform`}
+                        className={`${focusRingAccent} rounded transition-transform ${liftOrDim}`}
                         style={{
                           background: 'none',
                           padding: 0,

--- a/frontend/src/utils/deuceToSevenUtils.test.ts
+++ b/frontend/src/utils/deuceToSevenUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Card, CardDesign } from '../types/card';
-import { isMadePatLow } from './deuceToSevenUtils';
+import { deuceToSevenBestIndices, isMadePatLow } from './deuceToSevenUtils';
 
 const card = (design: CardDesign, value: number): Card => ({ design, value });
 
@@ -55,5 +55,32 @@ describe('isMadePatLow', () => {
     expect(
       isMadePatLow([card('JOKER', 0), card('HEART', 5), card('DIAMOND', 4), card('CLOVER', 3), card('SPADE', 2)]),
     ).toBe(false);
+  });
+});
+
+describe('deuceToSevenBestIndices', () => {
+  it('keeps every index for a made pat low', () => {
+    const hand = [card('SPADE', 7), card('HEART', 5), card('DIAMOND', 4), card('CLOVER', 3), card('SPADE', 2)];
+    expect(deuceToSevenBestIndices(hand)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('drops high cards (9+) and the Ace as draw candidates', () => {
+    // 2 (idx0), 4 (idx2), 5 (idx3) are low keepers; K (idx1) and A (idx4) are high → dropped.
+    const hand = [card('SPADE', 2), card('HEART', 13), card('DIAMOND', 4), card('CLOVER', 5), card('SPADE', 1)];
+    expect(deuceToSevenBestIndices(hand)).toEqual([0, 2, 3]);
+  });
+
+  it('keeps only one card of a low pair', () => {
+    // Two 4s (idx1, idx3): keep exactly one; 2 and 8 also kept.
+    const hand = [card('SPADE', 2), card('HEART', 4), card('DIAMOND', 8), card('CLOVER', 4), card('SPADE', 10)];
+    const out = deuceToSevenBestIndices(hand);
+    expect(out).toContain(0); // 2
+    expect(out).toContain(2); // 8
+    expect(out).not.toContain(4); // 10 is high → dropped
+    expect([out.includes(1), out.includes(3)].filter(Boolean)).toHaveLength(1);
+  });
+
+  it('returns an empty array for an empty hand', () => {
+    expect(deuceToSevenBestIndices([])).toEqual([]);
   });
 });

--- a/frontend/src/utils/deuceToSevenUtils.ts
+++ b/frontend/src/utils/deuceToSevenUtils.ts
@@ -39,3 +39,28 @@ export function isMadePatLow(cards: ReadonlyArray<Card>): boolean {
   if (isDeuceStraight(highs)) return false; // straight
   return highs[highs.length - 1] <= 8; // 8-or-better high card
 }
+
+/**
+ * Indices of the cards worth keeping toward the best 2-7 low draw. A completed
+ * pat low (see {@link isMadePatLow}) keeps all five cards. Otherwise the "core"
+ * is the set of distinct 8-or-better ranks (the low targets): a pair's higher
+ * duplicate and any 9-or-higher card are treated as draw candidates and left
+ * out. Used to lift the keepers / dim the discards during the draw phase.
+ */
+export function deuceToSevenBestIndices(cards: ReadonlyArray<Card>): number[] {
+  if (cards.length === 0) return [];
+  // A made low can only be weakened by drawing — keep everything.
+  if (isMadePatLow(cards)) return cards.map((_, i) => i);
+  // Visit lowest-first so the kept copy of a pair is its (equal) lowest card.
+  const order = cards
+    .map((c, i) => ({ i, hv: highValue(c), rank: c.value, joker: c.design === 'JOKER' }))
+    .sort((a, b) => a.hv - b.hv);
+  const seenRank = new Set<number>();
+  const keep: number[] = [];
+  for (const { i, hv, rank, joker } of order) {
+    if (joker || hv > 8 || seenRank.has(rank)) continue; // high card / pair dup → draw candidate
+    seenRank.add(rank);
+    keep.push(i);
+  }
+  return keep.sort((a, b) => a - b);
+}


### PR DESCRIPTION
## 概要

デューストゥセブンのドローフェーズで、Badugi と同様にどのカードが「ロー完成の核」かを視覚化する。残すべきカードをリフト、捨て候補をディムし、初心者の判断を助ける。

## 変更点

- `frontend/src/utils/deuceToSevenUtils.ts`: `deuceToSevenBestIndices` を追加（メイドパットロー → 全カード保持；それ以外は distinct な 8-or-better の低ランク核を返し、ペアの重複・9以上の高カードは捨て候補として除外）
- `frontend/src/pages/DeuceToSevenPage.tsx`: ドロー中、核カードを `-translate-y-1` でリフト、未選択の捨て候補を `opacity-50` でディム
- `frontend/src/utils/deuceToSevenUtils.test.ts`: `deuceToSevenBestIndices` のユニットテストを追加（メイドロー全保持／高カード&Ace除外／ペア重複1枚保持／空配列）
- `frontend/src/pages/DeuceToSevenPage.test.tsx`: リフト/ディムのレンダリングテストを追加

## 受け入れ条件

- [x] ドローフェーズ中に最良ロー構成カードが `-translate-y-1` でリフトされる
- [x] 不要カードが `opacity-50` で暗くなる
- [x] `isMadePatLow` が true の場合は全カードがリフトされる（`deuceToSevenBestIndices` が全index返却）
- [x] `deuceToSevenBestIndices` のユニットテストを追加
- [x] `bun run test` (util + page 計 27/15) + `biome check` 通過。`bun run build`(tsc) はローカル OOM のため CI で検証

Closes #2225

🤖 Generated with [Claude Code](https://claude.com/claude-code)