### PR TITLE
feat(ginrummy): badge each knocker meld with its set/run type

### DIFF
--- a/frontend/src/pages/GinRummyPage.test.tsx
+++ b/frontend/src/pages/GinRummyPage.test.tsx
@@ -338,6 +338,13 @@ describe('GinRummyPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: 'レイオフ' })).toBeDisabled());
   });
 
+  it('shows a type badge on each knocker meld during layoff', async () => {
+    mockExec.mockResolvedValue(layoffPhaseState);
+    renderWithProviders(<GinRummyPage />);
+    // The fixture meld is a set of three 3s → rank badge "3".
+    await waitFor(() => expect(screen.getByTestId('gr-meld-badge-0')).toHaveTextContent('3'));
+  });
+
   it('calls layoff command when layoff button is clicked', async () => {
     mockExec.mockResolvedValue(layoffPhaseState);
     renderWithProviders(<GinRummyPage />);

--- a/frontend/src/pages/GinRummyPage.tsx
+++ b/frontend/src/pages/GinRummyPage.tsx
@@ -33,7 +33,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { GINRUMMY_HELP, parseGinrummyCommand } from '../utils/cli/commands/ginrummyCommands';
 import { formatGinrummyState } from '../utils/cli/formatters/ginrummyFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
-import { bestDeadwoodValue, GIN_RUMMY_KNOCK_THRESHOLD } from '../utils/ginRummyDeadwood';
+import { bestDeadwoodValue, GIN_RUMMY_KNOCK_THRESHOLD, ginRummyMeldLabel } from '../utils/ginRummyDeadwood';
 import { playerName } from '../utils/playerUtils';
 
 const GINRUMMY_PHASE_KEYS: Readonly<Record<number, string>> = {
@@ -276,14 +276,22 @@ function GinRummyPageContent() {
                   <div className="my-3 p-2 rounded bg-black/30">
                     <div className="text-ds-text-muted text-sm mb-1">{t('knockerMelds')}</div>
                     {state.knockerMelds.map((meld, meldIdx) => (
-                      <div key={`meld-${meldIdx}`} className="flex flex-wrap gap-1 mb-1">
-                        {meld.cards.map((card, cardIdx) => (
-                          <AnimatedCard
-                            key={`meld-${meldIdx}-${card.design}-${card.value}-${cardIdx}`}
-                            card={card}
-                            width={cardWidth * 0.7}
-                          />
-                        ))}
+                      <div key={`meld-${meldIdx}`} className="mb-1">
+                        <span
+                          data-testid={`gr-meld-badge-${meldIdx}`}
+                          className="inline-block rounded border border-ds-secondary px-1.5 py-0.5 text-ds-text-primary text-xs mb-0.5"
+                        >
+                          {ginRummyMeldLabel(meld.cards)}
+                        </span>
+                        <div className="flex flex-wrap gap-1">
+                          {meld.cards.map((card, cardIdx) => (
+                            <AnimatedCard
+                              key={`meld-${meldIdx}-${card.design}-${card.value}-${cardIdx}`}
+                              card={card}
+                              width={cardWidth * 0.7}
+                            />
+                          ))}
+                        </div>
                       </div>
                     ))}
                   </div>

--- a/frontend/src/utils/ginRummyDeadwood.test.ts
+++ b/frontend/src/utils/ginRummyDeadwood.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Card } from '../types/card';
-import { bestDeadwoodValue, calcDeadwoodValue, ginRummyCardValue } from './ginRummyDeadwood';
+import { bestDeadwoodValue, calcDeadwoodValue, ginRummyCardValue, ginRummyMeldLabel } from './ginRummyDeadwood';
 
 const c = (design: Card['design'], value: number): Card => ({ design, value });
 
@@ -57,5 +57,22 @@ describe('bestDeadwoodValue', () => {
       c('DIAMOND', 9),
     ];
     expect(bestDeadwoodValue(hand)).toBe(0);
+  });
+});
+
+describe('ginRummyMeldLabel', () => {
+  it('labels a same-rank set with the rank name', () => {
+    expect(ginRummyMeldLabel([c('SPADE', 3), c('HEART', 3), c('DIAMOND', 3)])).toBe('3');
+    expect(ginRummyMeldLabel([c('SPADE', 13), c('HEART', 13), c('CLOVER', 13)])).toBe('K');
+    expect(ginRummyMeldLabel([c('SPADE', 1), c('HEART', 1), c('CLOVER', 1)])).toBe('A');
+  });
+
+  it('labels a same-suit run with the suit symbol and low-high range', () => {
+    expect(ginRummyMeldLabel([c('SPADE', 5), c('SPADE', 3), c('SPADE', 4)])).toBe('♠ 3-5');
+    expect(ginRummyMeldLabel([c('HEART', 1), c('HEART', 2), c('HEART', 3)])).toBe('♥ A-3');
+  });
+
+  it('returns an empty string for an empty meld', () => {
+    expect(ginRummyMeldLabel([])).toBe('');
   });
 });

--- a/frontend/src/utils/ginRummyDeadwood.ts
+++ b/frontend/src/utils/ginRummyDeadwood.ts
@@ -1,7 +1,24 @@
 import type { Card } from '../types/card';
+import { suitSymbol } from './cardAlt';
+import { valueName } from './cardUtils';
 
 /** Backend's GinRummyKnockThreshold (10). */
 export const GIN_RUMMY_KNOCK_THRESHOLD = 10;
+
+/**
+ * Short type label for a Gin Rummy meld, derived from its cards (no API change):
+ * a same-rank set yields the rank (e.g. `7`, `K`); a same-suit run yields the
+ * suit symbol with its low–high range (e.g. `♠ 3-5`). Returns `''` for an empty
+ * meld. Used as a header badge so players can spot layoff targets quickly.
+ */
+export function ginRummyMeldLabel(cards: readonly Card[]): string {
+  if (cards.length === 0) return '';
+  const first = cards[0];
+  const sameRank = cards.every((c) => c.value === first.value);
+  if (sameRank) return valueName(first.value); // set
+  const sorted = cards.map((c) => c.value).sort((a, b) => a - b); // run
+  return `${suitSymbol(first.design)} ${valueName(sorted[0])}-${valueName(sorted[sorted.length - 1])}`;
+}
 
 /** Gin Rummy card value (A=1, 2-9=face, 10/J/Q/K=10). */
 export function ginRummyCardValue(card: Card): number {


### PR DESCRIPTION
## 概要

ジンラミーのレイオフフェーズで、ノッカーのメルドが「ランクセット / スートラン」のどちらか視覚的に分からず、どのカードに乗せられるか判断しづらかった。各メルドに種別バッジを追加する。

## 変更点

- `frontend/src/utils/ginRummyDeadwood.ts`: `ginRummyMeldLabel(cards)` を追加（同ランクのセット → ランク名 `7`/`K`/`A`；同スートのラン → スート記号＋low-high範囲 `♠ 3-5`）。メルドのカード配列から自動算出、API 変更不要
- `frontend/src/pages/GinRummyPage.tsx`: 各ノッカーメルドのヘッダーに種別バッジ（`gr-meld-badge-N`）を表示
- `frontend/src/utils/ginRummyDeadwood.test.ts`: `ginRummyMeldLabel` のユニットテスト（セット/ラン/空）
- `frontend/src/pages/GinRummyPage.test.tsx`: レイオフ時にバッジが表示されるテスト

## 受け入れ条件

- [x] レイオフフェーズでノッカーの各メルドにランク/スート種別バッジが表示される
- [x] バッジはメルドのカード配列から自動算出（API 変更不要）
- [x] 既存の Vitest テストが pass（util + page 計 80）+ `biome check` 通過。`bun run build`(tsc) はローカル OOM のため CI で検証

Closes #2186

🤖 Generated with [Claude Code](https://claude.com/claude-code)