### PR TITLE
feat(baccarat): collapse side-bet inputs by default

### DIFF
--- a/frontend/src/i18n/locales/en/baccarat.json
+++ b/frontend/src/i18n/locales/en/baccarat.json
@@ -23,6 +23,7 @@
     "end": "Result"
   },
   "sideBet": {
+    "title": "Side bets (optional)",
     "playerPair": "Player Pair",
     "bankerPair": "Banker Pair",
     "pair": "Pair",

--- a/frontend/src/i18n/locales/ja/baccarat.json
+++ b/frontend/src/i18n/locales/ja/baccarat.json
@@ -23,6 +23,7 @@
     "end": "結果"
   },
   "sideBet": {
+    "title": "サイドベット（任意）",
     "playerPair": "プレイヤーペア",
     "bankerPair": "バンカーペア",
     "pair": "ペア",

--- a/frontend/src/pages/BaccaratPage.test.tsx
+++ b/frontend/src/pages/BaccaratPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, baccaratApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
@@ -119,6 +119,18 @@ describe('BaccaratPage', () => {
     renderWithProviders(<BaccaratPage />);
     await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
     expect(screen.getByRole('button', { name: 'ベット' })).toBeInTheDocument();
+  });
+
+  it('renders the side-bet inputs inside a collapsed details section', async () => {
+    mockExec.mockResolvedValue(betPhaseState);
+    renderWithProviders(<BaccaratPage />);
+    await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
+    const details = screen.getByTestId('baccarat-sidebet-details');
+    // Collapsed by default (no `open` attribute) but the inputs still live inside it.
+    expect(details).not.toHaveAttribute('open');
+    expect(within(details).getByText('サイドベット（任意）')).toBeInTheDocument();
+    expect(within(details).getByLabelText('プレイヤーペア')).toBeInTheDocument();
+    expect(within(details).getByLabelText('バンカーペア')).toBeInTheDocument();
   });
 
   it('does not expand card area with flex-1 during bet phase', async () => {

--- a/frontend/src/pages/BaccaratPage.test.tsx
+++ b/frontend/src/pages/BaccaratPage.test.tsx
@@ -133,6 +133,17 @@ describe('BaccaratPage', () => {
     expect(within(details).getByLabelText('バンカーペア')).toBeInTheDocument();
   });
 
+  it('auto-expands the side-bet details once a side bet is non-zero', async () => {
+    mockExec.mockResolvedValue(betPhaseState);
+    renderWithProviders(<BaccaratPage />);
+    await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
+    const details = screen.getByTestId('baccarat-sidebet-details');
+    expect(details).not.toHaveAttribute('open');
+    // Setting a side bet must keep it visible (not hidden behind the collapsed summary).
+    fireEvent.change(screen.getByLabelText('プレイヤーペア'), { target: { value: '10' } });
+    expect(details).toHaveAttribute('open');
+  });
+
   it('does not expand card area with flex-1 during bet phase', async () => {
     mockExec.mockResolvedValue(betPhaseState);
     renderWithProviders(<BaccaratPage />);

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -480,25 +480,32 @@ function BaccaratPageContent() {
                     <option value={BaccaratBetType.TIE}>{t(BET_TYPE_LABELS[BaccaratBetType.TIE])}</option>
                   </select>
                 </div>
-                {/* Side bet inputs */}
-                <ChipBetInput
-                  id="baccarat-pp-bet"
-                  label={t('sideBet.playerPair')}
-                  value={playerPairBet}
-                  onChange={setPlayerPairBet}
-                  max={state.chips}
-                  min={0}
-                  widthClass="w-20"
-                />
-                <ChipBetInput
-                  id="baccarat-bp-bet"
-                  label={t('sideBet.bankerPair')}
-                  value={bankerPairBet}
-                  onChange={setBankerPairBet}
-                  max={state.chips}
-                  min={0}
-                  widthClass="w-20"
-                />
+                {/* Side bet inputs — collapsed by default to reduce clutter for beginners */}
+                <details className="bg-black/30 rounded-lg w-full max-w-sm" data-testid="baccarat-sidebet-details">
+                  <summary className="cursor-pointer select-none px-4 py-2 text-ds-text-primary font-bold text-sm">
+                    {t('sideBet.title')}
+                  </summary>
+                  <div className="flex flex-col items-center gap-2 px-4 pb-3">
+                    <ChipBetInput
+                      id="baccarat-pp-bet"
+                      label={t('sideBet.playerPair')}
+                      value={playerPairBet}
+                      onChange={setPlayerPairBet}
+                      max={state.chips}
+                      min={0}
+                      widthClass="w-20"
+                    />
+                    <ChipBetInput
+                      id="baccarat-bp-bet"
+                      label={t('sideBet.bankerPair')}
+                      value={bankerPairBet}
+                      onChange={setBankerPairBet}
+                      max={state.chips}
+                      min={0}
+                      widthClass="w-20"
+                    />
+                  </div>
+                </details>
                 <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading}>
                   {t('button.bet')}
                 </button>

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -480,8 +480,14 @@ function BaccaratPageContent() {
                     <option value={BaccaratBetType.TIE}>{t(BET_TYPE_LABELS[BaccaratBetType.TIE])}</option>
                   </select>
                 </div>
-                {/* Side bet inputs — collapsed by default to reduce clutter for beginners */}
-                <details className="bg-black/30 rounded-lg w-full max-w-sm" data-testid="baccarat-sidebet-details">
+                {/* Side bet inputs — collapsed by default to reduce clutter for beginners, but
+                    auto-expanded when a side bet carries over from a prior round so a non-zero
+                    wager is never hidden behind the summary (and re-bet unintentionally). */}
+                <details
+                  className="bg-black/30 rounded-lg w-full max-w-sm"
+                  data-testid="baccarat-sidebet-details"
+                  open={playerPairBet > 0 || bankerPairBet > 0 || undefined}
+                >
                   <summary className="cursor-pointer select-none px-4 py-2 text-ds-text-primary font-bold text-sm">
                     {t('sideBet.title')}
                   </summary>


### PR DESCRIPTION
## 概要

バカラのベット期フッターでプレイヤーペア/バンカーペアのサイドベット入力が常時表示され、初心者には情報過多だった。サイドベット入力を既定で折り畳む。

## 変更点

- `frontend/src/pages/BaccaratPage.tsx`: 2 つのサイドベット `ChipBetInput` を `<details>`（既定 closed、`data-testid="baccarat-sidebet-details"`）でラップ。サマリーは `サイドベット（任意）`。ペイアウト参照パネルと同じスタイル
- `frontend/src/i18n/locales/{ja,en}/baccarat.json`: `sideBet.title`（「サイドベット（任意）」/「Side bets (optional)」）を追加
- `frontend/src/pages/BaccaratPage.test.tsx`: 既定折り畳み + 展開時に両入力が見えるテストを追加

## 受け入れ条件

- [x] サイドベット入力が既定で折り畳み状態
- [x] 展開時は従来通り PlayerPair / BankerPair の ChipBetInput が見える
- [x] `<summary>` によるアクセシブルな開閉（キーボード操作対応）
- [x] `bun run test` (44 passed) + `biome check` 通過。`bun run build`(tsc) はローカル OOM のため CI で検証

Closes #2183

🤖 Generated with [Claude Code](https://claude.com/claude-code)