### PR TITLE
feat(hearts): show an N/3 selection-progress pill during the pass phase

### DIFF
--- a/frontend/src/i18n/locales/en/hearts.json
+++ b/frontend/src/i18n/locales/en/hearts.json
@@ -36,6 +36,7 @@
   "scoresTotal": "Total",
   "scoresTricks": "Tricks",
   "passButton": "Pass",
+  "passProgress": "{{count}}/3 selected",
   "playButton": "Play",
   "nextTrick": "Next Trick",
   "nextRound": "Next Round",

--- a/frontend/src/i18n/locales/ja/hearts.json
+++ b/frontend/src/i18n/locales/ja/hearts.json
@@ -36,6 +36,7 @@
   "scoresTotal": "累計",
   "scoresTricks": "トリック",
   "passButton": "パス",
+  "passProgress": "{{count}}/3 枚選択済み",
   "playButton": "出す",
   "nextTrick": "次のトリック",
   "nextRound": "次のラウンド",

--- a/frontend/src/pages/HeartsPage.test.tsx
+++ b/frontend/src/pages/HeartsPage.test.tsx
@@ -156,6 +156,34 @@ describe('HeartsPage', () => {
     expect(screen.getByRole('button', { name: 'パス' })).not.toBeDisabled();
   });
 
+  it('shows a N/3 selection-progress pill during the pass phase', async () => {
+    mockExec.mockResolvedValue({
+      ...passPhaseState,
+      players: [
+        {
+          ...passPhaseState.players[0],
+          cards: [
+            { design: 'SPADE', value: 1 },
+            { design: 'HEART', value: 11 },
+            { design: 'CLOVER', value: 5 },
+          ],
+        },
+        ...passPhaseState.players.slice(1),
+      ],
+    });
+    renderWithProviders(<HeartsPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+
+    // No pill before any selection.
+    expect(screen.queryByTestId('hearts-pass-progress')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByAltText('♠ A').closest('button') as HTMLButtonElement);
+    expect(screen.getByTestId('hearts-pass-progress')).toHaveTextContent('1/3');
+
+    fireEvent.click(screen.getByAltText('♥ J').closest('button') as HTMLButtonElement);
+    expect(screen.getByTestId('hearts-pass-progress')).toHaveTextContent('2/3');
+  });
+
   it('play button disabled when not 1 card selected', async () => {
     renderWithProviders(<HeartsPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '出す' })).toBeDisabled());

--- a/frontend/src/pages/HeartsPage.tsx
+++ b/frontend/src/pages/HeartsPage.tsx
@@ -431,6 +431,14 @@ function HeartsPageContent() {
                   {tc('button.hint')}
                 </button>
               )}
+              {isPassPhase && selectedCardIndices.length > 0 && (
+                <span
+                  data-testid="hearts-pass-progress"
+                  className="self-center rounded-full bg-ds-surface border border-ds-accent px-2.5 py-0.5 text-ds-text-primary text-xs"
+                >
+                  {t('passProgress', { count: selectedCardIndices.length })}
+                </span>
+              )}
               {isPassPhase && (
                 <button
                   type="button"


### PR DESCRIPTION
## 概要

ハーツのパスフェーズで、3枚選択するまでパスボタンが disabled になるが「あと何枚選べばよいか」の表示がなく、特にモバイルで分かりづらかった。選択進捗ピルを追加する。

## 変更点

- `frontend/src/pages/HeartsPage.tsx`: パスフェーズ中 `selectedCardIndices.length > 0` のとき、パスボタン上部に `N/3 枚選択済み` ピル（`data-testid="hearts-pass-progress"`）を表示。3枚でパス有効になる既存挙動は不変
- `frontend/src/i18n/locales/{ja,en}/hearts.json`: `passProgress`（「{{count}}/3 枚選択済み」/「{{count}}/3 selected」）を追加
- `frontend/src/pages/HeartsPage.test.tsx`: 0枚で非表示、1枚→「1/3」、2枚→「2/3」の進捗テストを追加

## 受け入れ条件

- [x] パスフェーズ中に「N/3 枚選択済み」ピルが表示される
- [x] 3 枚選択でパスボタンが有効になる挙動は不変
- [x] `HeartsPage.test.tsx` にテストを追加（70 passed）
- [x] `bun run test` + `biome check` 通過。`bun run build`(tsc) はローカル OOM のため CI で検証

Closes #2177

🤖 Generated with [Claude Code](https://claude.com/claude-code)