### PR TITLE
feat(bridge): use MobileHandGrid for the human hand on mobile

### DIFF
--- a/frontend/src/pages/BridgePage.test.tsx
+++ b/frontend/src/pages/BridgePage.test.tsx
@@ -223,6 +223,20 @@ describe('BridgePage', () => {
     });
   });
 
+  it('renders the human hand via MobileHandGrid on a narrow mobile viewport', async () => {
+    const original = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    try {
+      mockExec.mockResolvedValue(playPhaseState);
+      renderWithProviders(<BridgePage />);
+      // MobileHandGrid lays the hand out in fanned rows instead of a scrolling strip.
+      await waitFor(() => expect(screen.getAllByTestId('hand-row').length).toBeGreaterThan(0));
+      expect(screen.getByAltText('\u2660 A')).toBeInTheDocument();
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: original });
+    }
+  });
+
   it('play button disabled when not 1 card selected', async () => {
     mockExec.mockResolvedValue(playPhaseState);
     renderWithProviders(<BridgePage />);

--- a/frontend/src/pages/BridgePage.tsx
+++ b/frontend/src/pages/BridgePage.tsx
@@ -9,6 +9,7 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { MobileHandGrid } from '../components/MobileHandGrid';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { TrickDisplay } from '../components/TrickDisplay';
@@ -139,7 +140,7 @@ function BridgePageContent() {
     hintLoading,
     handleHint,
   } = useBridgeGame();
-  const { cardWidth, isMobile, solitaireMinColWidth } = useCardDimensions();
+  const { cardWidth, isMobile } = useCardDimensions();
   const [bidLevel, setBidLevel] = useState(1);
   const [bidSuit, setBidSuit] = useState(5);
   // CLI mode
@@ -500,33 +501,38 @@ function BridgePageContent() {
           {/* Footer */}
           <GameFooter className={`${gameTheme.bridge.footer} px-4 py-2.5`}>
             {/* Human cards */}
-            {humanPlayer && (
-              <div
-                className={isMobile ? 'flex gap-1 overflow-x-auto mb-2' : 'flex flex-wrap gap-1 mb-2'}
-                data-tutorial="br-player-hand"
-              >
-                {humanPlayer.cards.map((card, idx) => (
-                  <button
-                    type="button"
-                    key={`${card.design}-${card.value}-${idx}`}
-                    onClick={() => toggleCard(idx)}
-                    aria-label={cardAlt(card)}
-                    aria-pressed={selectedCardIndices.includes(idx)}
-                    className={`transition-transform ${focusRingCard}`}
-                    style={{
-                      background: 'none',
-                      padding: 0,
-                      borderRadius: 8,
-                      ...selectedCardStyle(selectedCardIndices.includes(idx)),
-                      boxSizing: 'border-box',
-                      ...(isMobile ? { minWidth: solitaireMinColWidth, flexShrink: 0 } : {}),
-                    }}
-                  >
-                    <AnimatedCard card={card} width={cardWidth} />
-                  </button>
-                ))}
-              </div>
-            )}
+            {humanPlayer &&
+              (isMobile ? (
+                <MobileHandGrid
+                  cards={humanPlayer.cards}
+                  selectedIndices={selectedCardIndices}
+                  onToggle={toggleCard}
+                  cardWidth={cardWidth}
+                  dataTutorial="br-player-hand"
+                />
+              ) : (
+                <div className="flex flex-wrap gap-1 mb-2" data-tutorial="br-player-hand">
+                  {humanPlayer.cards.map((card, idx) => (
+                    <button
+                      type="button"
+                      key={`${card.design}-${card.value}-${idx}`}
+                      onClick={() => toggleCard(idx)}
+                      aria-label={cardAlt(card)}
+                      aria-pressed={selectedCardIndices.includes(idx)}
+                      className={`transition-transform ${focusRingCard}`}
+                      style={{
+                        background: 'none',
+                        padding: 0,
+                        borderRadius: 8,
+                        ...selectedCardStyle(selectedCardIndices.includes(idx)),
+                        boxSizing: 'border-box',
+                      }}
+                    >
+                      <AnimatedCard card={card} width={cardWidth} />
+                    </button>
+                  ))}
+                </div>
+              ))}
 
             <ErrorAlert message={error ?? hintError} onRetry={retry} />
 


### PR DESCRIPTION
## 概要

ブリッジの手牌（13枚）はモバイルで水平スクロールのストリップ表示になっており操作しづらかった。Hearts/Napoleon 等と同じ共通 `MobileHandGrid`（扇状・オーバーラップ対応の段組み）に置き換える。

## 変更点

- `frontend/src/pages/BridgePage.tsx`: モバイル時の人間手牌を `MobileHandGrid` でレンダリング（デスクトップは従来の flex-wrap を維持）。未使用になった `solitaireMinColWidth` 取得を削除
- `frontend/src/pages/BridgePage.test.tsx`: 375px 幅で `MobileHandGrid`（hand-row）が描画されるテストを追加

## 受け入れ条件

- [x] モバイルで手牌が水平スクロールではなく MobileHandGrid 表示になる
- [x] デスクトップは従来表示を維持
- [x] `bun run test` (37 passed) + `biome check` 通過。`bun run build`(tsc) はローカル OOM のため CI で検証

Closes #2200

🤖 Generated with [Claude Code](https://claude.com/claude-code)