### PR TITLE
feat(crazypineapple): forewarn the upcoming discard during flop betting

### DIFF
--- a/frontend/src/i18n/locales/en/crazypineapple.json
+++ b/frontend/src/i18n/locales/en/crazypineapple.json
@@ -12,6 +12,7 @@
   },
   "communityCards": "Community Cards",
   "yourHand": "Your Hand",
+  "discardUpcoming": "You will discard one card after the flop betting round",
   "handNumber": "Hand #{{count}} (Level up: every {{level}} hands)",
   "discard": {
     "prompt": "Discard one card.",

--- a/frontend/src/i18n/locales/ja/crazypineapple.json
+++ b/frontend/src/i18n/locales/ja/crazypineapple.json
@@ -12,6 +12,7 @@
   },
   "communityCards": "コミュニティカード",
   "yourHand": "あなたの手札",
+  "discardUpcoming": "フロップベット終了後にカードを1枚捨てます",
   "handNumber": "ハンド#{{count}} (レベルアップ:{{level}}ハンド毎)",
   "discard": {
     "prompt": "1枚捨ててください。",

--- a/frontend/src/pages/CrazyPineapplePage.test.tsx
+++ b/frontend/src/pages/CrazyPineapplePage.test.tsx
@@ -146,4 +146,26 @@ describe('CrazyPineapplePage', () => {
     // through useGamePageSetup → useTranslation('crazypineapple').
     expect(screen.getByText('捨てるカードを選択してください')).toBeInTheDocument();
   });
+
+  it('forewarns the upcoming discard with a banner during the flop betting round', async () => {
+    const flopState: PineappleResponse = {
+      ...initState,
+      players: [humanPlayer(), cpuPlayer(1), cpuPlayer(2), cpuPlayer(3)],
+      pot: 60,
+      currentTurn: 0,
+      phase: 2, // PineapplePhase.FLOP
+      communityCards: [
+        { design: 'SPADE', value: 10 },
+        { design: 'HEART', value: 5 },
+        { design: 'DIAMOND', value: 8 },
+      ],
+      handCount: 1,
+    };
+    mockCrazyExec.mockResolvedValue(flopState);
+    renderWithProviders(<CrazyPineapplePage />);
+    await waitFor(() => expect(screen.getByTestId('cp-discard-upcoming-banner')).toBeInTheDocument());
+    expect(screen.getByTestId('cp-discard-upcoming-banner')).toHaveTextContent(
+      'フロップベット終了後にカードを1枚捨てます',
+    );
+  });
 });

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -353,6 +353,16 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
 
           {/* Sticky footer: player hand + buttons */}
           <GameFooter className={`${gameTheme[variant].footer} px-5 py-3`}>
+            {/* Crazy Pineapple discards after the flop betting round (unlike plain
+                Pineapple's immediate discard) — forewarn the player during the flop bet. */}
+            {variant === 'crazypineapple' && phase === PineapplePhase.FLOP && (
+              <div
+                data-testid="cp-discard-upcoming-banner"
+                className="mb-2 rounded border border-ds-info bg-ds-surface px-3 py-1.5 text-center text-ds-info text-sm"
+              >
+                {t('discardUpcoming')}
+              </div>
+            )}
             {/* Human player */}
             {humanPlayer && (
               <div className="mb-2" data-tutorial="pn-player-hand">


### PR DESCRIPTION
## 概要

クレイジーパイナップルはフロップベット後にディスカードが発生する（通常パイナップルは即座）が、このタイミングの違いがゲーム中に明示されていなかった。フロップベット中に予告バナーを表示する。

## 変更点

- `frontend/src/pages/PineapplePage.tsx`: `variant === 'crazypineapple'` かつ `phase === PineapplePhase.FLOP` のとき、手牌エリア上部にインフォバナー（`data-testid="cp-discard-upcoming-banner"`）を表示。DESIGN.md のため `bg-ds-surface` + `border-ds-info`（不透明度フィルは不使用）
- `frontend/src/i18n/locales/{ja,en}/crazypineapple.json`: `discardUpcoming`（「フロップベット終了後にカードを1枚捨てます」/「You will discard one card after the flop betting round」）を追加
- `frontend/src/pages/CrazyPineapplePage.test.tsx`: FLOP フェーズでバナーが表示されるテストを追加

## 受け入れ条件

- [x] `crazypineapple` の FLOP フェーズ中にインフォバナーが表示される
- [x] 他バリアント（`pineapple`/`irishpoker`）には表示されない（`variant` ガード；両ページのテストも green）
- [x] `CrazyPineapplePage.test.tsx` にテストを追加（pineapple-family 計16 passed）
- [x] `bun run test` + `biome check` 通過。`bun run build`(tsc) はローカル OOM のため CI で検証

Closes #2175

🤖 Generated with [Claude Code](https://claude.com/claude-code)