### PR TITLE
feat(pineapple): add an inline confirm step before discarding

### DIFF
--- a/frontend/src/i18n/locales/en/crazypineapple.json
+++ b/frontend/src/i18n/locales/en/crazypineapple.json
@@ -16,7 +16,10 @@
   "handNumber": "Hand #{{count}} (Level up: every {{level}} hands)",
   "discard": {
     "prompt": "Discard one card.",
-    "select": "Select a card to discard"
+    "select": "Select a card to discard",
+    "confirm": "Discard {{card}}?",
+    "confirmYes": "Confirm",
+    "confirmNo": "Cancel"
   },
   "rebuy": {
     "prompt": "Rebuy? ({{chips}} chips, {{used}}/{{max}} used)",

--- a/frontend/src/i18n/locales/en/irishpoker.json
+++ b/frontend/src/i18n/locales/en/irishpoker.json
@@ -15,7 +15,10 @@
   "handNumber": "Hand #{{count}} (Level up: every {{level}} hands)",
   "discard": {
     "prompt": "Discard a card.",
-    "select": "Select a card to discard (2 cards total)"
+    "select": "Select a card to discard (2 cards total)",
+    "confirm": "Discard {{card}}?",
+    "confirmYes": "Confirm",
+    "confirmNo": "Cancel"
   },
   "rebuy": {
     "prompt": "Rebuy? ({{chips}} chips, {{used}}/{{max}} used)",

--- a/frontend/src/i18n/locales/en/pineapple.json
+++ b/frontend/src/i18n/locales/en/pineapple.json
@@ -15,7 +15,10 @@
   "handNumber": "Hand #{{count}} (Level up: every {{level}} hands)",
   "discard": {
     "prompt": "Discard one card.",
-    "select": "Select a card to discard"
+    "select": "Select a card to discard",
+    "confirm": "Discard {{card}}?",
+    "confirmYes": "Confirm",
+    "confirmNo": "Cancel"
   },
   "rebuy": {
     "prompt": "Rebuy? ({{chips}} chips, {{used}}/{{max}} used)",

--- a/frontend/src/i18n/locales/ja/crazypineapple.json
+++ b/frontend/src/i18n/locales/ja/crazypineapple.json
@@ -16,7 +16,10 @@
   "handNumber": "ハンド#{{count}} (レベルアップ:{{level}}ハンド毎)",
   "discard": {
     "prompt": "1枚捨ててください。",
-    "select": "捨てるカードを選択してください"
+    "select": "捨てるカードを選択してください",
+    "confirm": "{{card}} を捨てますか？",
+    "confirmYes": "確定",
+    "confirmNo": "キャンセル"
   },
   "rebuy": {
     "prompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済)",

--- a/frontend/src/i18n/locales/ja/irishpoker.json
+++ b/frontend/src/i18n/locales/ja/irishpoker.json
@@ -15,7 +15,10 @@
   "handNumber": "ハンド#{{count}} (レベルアップ:{{level}}ハンド毎)",
   "discard": {
     "prompt": "カードを捨ててください。",
-    "select": "捨てるカードを選択してください（計2枚）"
+    "select": "捨てるカードを選択してください（計2枚）",
+    "confirm": "{{card}} を捨てますか？",
+    "confirmYes": "確定",
+    "confirmNo": "キャンセル"
   },
   "rebuy": {
     "prompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済)",

--- a/frontend/src/i18n/locales/ja/pineapple.json
+++ b/frontend/src/i18n/locales/ja/pineapple.json
@@ -15,7 +15,10 @@
   "handNumber": "ハンド#{{count}} (レベルアップ:{{level}}ハンド毎)",
   "discard": {
     "prompt": "1枚捨ててください。",
-    "select": "捨てるカードを選択してください"
+    "select": "捨てるカードを選択してください",
+    "confirm": "{{card}} を捨てますか？",
+    "confirmYes": "確定",
+    "confirmNo": "キャンセル"
   },
   "rebuy": {
     "prompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済)",

--- a/frontend/src/pages/PineapplePage.test.tsx
+++ b/frontend/src/pages/PineapplePage.test.tsx
@@ -235,8 +235,31 @@ describe('PineapplePage', () => {
     // Now discard button should be enabled
     await waitFor(() => expect(discardBtn).not.toBeDisabled());
 
+    // Pressing discard now opens an inline confirm step rather than committing immediately.
     fireEvent.click(discardBtn);
+    expect(mockExec).not.toHaveBeenCalledWith('discard', undefined, { cardIdx: 0 });
+    expect(screen.getByTestId('discard-confirm')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '確定' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('discard', undefined, { cardIdx: 0 }));
+  });
+
+  it('cancels the discard confirm step and returns to selection', async () => {
+    mockExec.mockResolvedValue(discardState);
+    renderWithProviders(<PineapplePage />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+    mockExec.mockClear(); // isolate from prior tests' discard calls (beforeEach doesn't clear history)
+
+    const cardButtons = screen.getAllByRole('button').filter((btn) => btn.getAttribute('aria-pressed') !== null);
+    fireEvent.click(cardButtons[0]);
+    fireEvent.click(screen.getByRole('button', { name: '1枚捨ててください。' }));
+    expect(screen.getByTestId('discard-confirm')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    // Back to selection; nothing discarded.
+    expect(screen.queryByTestId('discard-confirm')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '1枚捨ててください。' })).toBeInTheDocument();
+    expect(mockExec).not.toHaveBeenCalledWith('discard', undefined, { cardIdx: 0 });
   });
 
   it('shows round results during showdown', async () => {

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -40,6 +40,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { PineappleResponse } from '../types/card';
 import { HoldemRebuyPhaseType, PineapplePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import { PINEAPPLE_HELP, parsePineappleCommand } from '../utils/cli/commands/pineappleCommands';
 import { formatPineappleState } from '../utils/cli/formatters/pineappleFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -137,6 +138,8 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
   const [cpuMetaAI, setCpuMetaAI] = useState(false);
   const { hint, hintEnabled, setHintEnabled } = useGameHint(variant, state);
   const [selectedDiscard, setSelectedDiscard] = useState<number | null>(null);
+  // Two-step discard: pressing "discard" enters a confirm step before committing.
+  const [discardConfirming, setDiscardConfirming] = useState(false);
   const turnStartRef = useRef(0);
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode(variant);
@@ -172,10 +175,11 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
     }
   }, [state]);
 
-  // Reset discard selection when leaving discard phase
+  // Reset discard selection (and any pending confirm) when leaving discard phase
   useEffect(() => {
     if (!state?.isDiscardPhase) {
       setSelectedDiscard(null);
+      setDiscardConfirming(false);
     }
   }, [state?.isDiscardPhase]);
 
@@ -429,20 +433,47 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
             {/* Discard controls */}
             {canDiscard && (
               <div className="mb-2 text-center" data-testid="discard-controls" data-tutorial="pn-discard-controls">
-                <p className="text-ds-text-primary mb-2">{t('discard.select')}</p>
-                <button
-                  type="button"
-                  className={`${btnPrimary} min-w-[90px]`}
-                  disabled={loading || selectedDiscard === null}
-                  onClick={() => {
-                    if (selectedDiscard !== null) {
-                      apiExec('discard', undefined, { cardIdx: selectedDiscard });
-                      setSelectedDiscard(null);
-                    }
-                  }}
-                >
-                  {t('discard.prompt')}
-                </button>
+                {discardConfirming && selectedDiscard !== null && humanPlayer?.cards[selectedDiscard] ? (
+                  <div data-testid="discard-confirm">
+                    <p className="text-ds-text-primary mb-2">
+                      {t('discard.confirm', { card: cardAlt(humanPlayer.cards[selectedDiscard]) })}
+                    </p>
+                    <div className="flex justify-center gap-2">
+                      <button
+                        type="button"
+                        className={`${btnPrimary} min-w-[90px]`}
+                        disabled={loading}
+                        onClick={() => {
+                          apiExec('discard', undefined, { cardIdx: selectedDiscard });
+                          setSelectedDiscard(null);
+                          setDiscardConfirming(false);
+                        }}
+                      >
+                        {t('discard.confirmYes')}
+                      </button>
+                      <button
+                        type="button"
+                        className={`${btnSecondary} min-w-[90px]`}
+                        disabled={loading}
+                        onClick={() => setDiscardConfirming(false)}
+                      >
+                        {t('discard.confirmNo')}
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <p className="text-ds-text-primary mb-2">{t('discard.select')}</p>
+                    <button
+                      type="button"
+                      className={`${btnPrimary} min-w-[90px]`}
+                      disabled={loading || selectedDiscard === null}
+                      onClick={() => setDiscardConfirming(true)}
+                    >
+                      {t('discard.prompt')}
+                    </button>
+                  </>
+                )}
               </div>
             )}
 


### PR DESCRIPTION
## 概要

パイナイップル系のディスカードフェーズは「捨てる」ボタン押下で即座に廃棄が実行され、誤タップによる誤廃棄リスクがあった（特に Irish Poker は2枚捨て）。押下後にインライン確認ステップを挟む。

## 変更点

- `frontend/src/pages/PineapplePage.tsx`: `discardConfirming` state を追加。「捨てる」押下で即実行せず確認ステップ（選択カード名 + 確定/キャンセル）を表示。確定で `discard` 実行、キャンセルで選択に戻る。フェーズ離脱時に確認状態もリセット。モーダルではなくフッター内インライン
- `frontend/src/i18n/locales/{ja,en}/{pineapple,crazypineapple,irishpoker}.json`: `discard.confirm`（「{{card}} を捨てますか？」/「Discard {{card}}?」）/ `confirmYes` / `confirmNo` を3名前空間に追加
- `frontend/src/pages/PineapplePage.test.tsx`: 確認ステップ表示→確定で discard 実行、キャンセルで選択に戻るテストを追加

## 受け入れ条件

- [x] ディスカードボタン押下後に確認 UI が表示される
- [x] 「確定」で捨て操作が実行され、「キャンセル」で選択に戻る
- [x] `pineapple` / `crazypineapple` / `irishpoker` の3バリアントで動作（共有 PineapplePage、各名前空間にキー追加、3ページのテスト green）
- [x] テストを追加（pineapple-family 計17 passed）
- [x] `bun run test` + `biome check` 通過。`discard-controls` testid は保持（E2E 影響なし）。`bun run build`(tsc) はローカル OOM のため CI で検証

Closes #2174

🤖 Generated with [Claude Code](https://claude.com/claude-code)