### PR TITLE
feat(omaha): highlight the best-5 hole+board cards at showdown

### DIFF
--- a/frontend/src/pages/OmahaPage.test.tsx
+++ b/frontend/src/pages/OmahaPage.test.tsx
@@ -366,6 +366,15 @@ describe('OmahaPage', () => {
     await waitFor(() => expect(screen.getByText('ツーペア')).toBeInTheDocument());
   });
 
+  it('highlights exactly 2 hole + 3 board cards as the best-5 at showdown', async () => {
+    mockExec.mockResolvedValue(showdownState);
+    const { container } = renderWithProviders(<OmahaPage />);
+    await waitFor(() => expect(screen.getByText('ツーペア')).toBeInTheDocument());
+    // Omaha must-use-2 rule → exactly 2 hole and 3 board cards highlighted.
+    expect(container.querySelectorAll('[data-best5-hole]')).toHaveLength(2);
+    expect(container.querySelectorAll('[data-best5-board]')).toHaveLength(3);
+  });
+
   it('does not show CPU hand name badge when CPU is folded in showdown', async () => {
     mockExec.mockResolvedValue(showdownState);
     renderWithProviders(<OmahaPage />);

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -43,6 +43,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { OMAHA_HELP, parseOmahaCommand } from '../utils/cli/commands/omahaCommands';
 import { formatOmahaState } from '../utils/cli/formatters/omahaFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { omahaBestFive } from '../utils/omahaBestFive';
 import { findPlayerName } from '../utils/playerUtils';
 
 /** Omaha Hold'em tutorial step definitions. */
@@ -162,6 +163,17 @@ function OmahaPageContent() {
   const isActive = phase >= OmahaPhase.PRE_FLOP && phase <= OmahaPhase.RIVER;
   const isShowdown = phase === OmahaPhase.SHOWDOWN || phase === OmahaPhase.END;
   const humanPlayer = state?.players?.find((p) => p.isHuman);
+  // At showdown, highlight the human's winning 5 cards under Omaha's
+  // must-use-exactly-2-hole + 3-board rule (dim the rest).
+  const showdownBest5 = useMemo(() => {
+    const empty = { holeSet: new Set<number>(), boardSet: new Set<number>() };
+    if (!isShowdown || !humanPlayer || humanPlayer.folded) return empty;
+    const hole = humanPlayer.cards ?? [];
+    const board = state?.communityCards ?? [];
+    const best = omahaBestFive(hole, board);
+    if (!best) return empty;
+    return { holeSet: new Set(best.holeIdx), boardSet: new Set(best.boardIdx) };
+  }, [isShowdown, humanPlayer, state?.communityCards]);
   const humanFolded = humanPlayer?.folded ?? false;
   const humanAllIn = humanPlayer?.allIn ?? false;
   const canAct = isActive && !humanFolded && !humanAllIn && state?.currentTurn === humanPlayer?.id;
@@ -252,14 +264,21 @@ function OmahaPageContent() {
                   <div className="text-ds-text-primary text-lg mb-1.5">{t('communityCards')}</div>
                   <div className="flex flex-wrap gap-2">
                     {state?.communityCards?.length
-                      ? state.communityCards.map((card) => (
-                          <AnimatedCard
-                            key={`${card.design}-${card.value}`}
-                            card={card}
-                            width={cardWidth}
-                            style={placeholderCardStyle}
-                          />
-                        ))
+                      ? state.communityCards.map((card, idx) => {
+                          const inBest = showdownBest5.boardSet.has(idx);
+                          const dim = showdownBest5.boardSet.size > 0 && !inBest;
+                          return (
+                            <div
+                              key={`${card.design}-${card.value}`}
+                              className={`transition-all ${
+                                inBest ? '-translate-y-1 ring-2 ring-ds-success motion-safe:animate-pulse' : ''
+                              } ${dim ? 'opacity-50' : ''}`}
+                              data-best5-board={inBest || undefined}
+                            >
+                              <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
+                            </div>
+                          );
+                        })
                       : Array.from({ length: 5 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                   </div>
                 </>
@@ -368,14 +387,21 @@ function OmahaPageContent() {
                 </div>
                 <div className="flex flex-wrap gap-1.5 mb-2" data-tutorial="oh-combination-rule">
                   {humanPlayer.cards?.length
-                    ? humanPlayer.cards.map((card) => (
-                        <AnimatedCard
-                          key={`${card.design}-${card.value}`}
-                          card={card}
-                          width={cardWidth}
-                          style={placeholderCardStyle}
-                        />
-                      ))
+                    ? humanPlayer.cards.map((card, idx) => {
+                        const inBest = showdownBest5.holeSet.has(idx);
+                        const dim = showdownBest5.holeSet.size > 0 && !inBest;
+                        return (
+                          <div
+                            key={`${card.design}-${card.value}`}
+                            className={`transition-all ${
+                              inBest ? '-translate-y-1 ring-2 ring-ds-success motion-safe:animate-pulse' : ''
+                            } ${dim ? 'opacity-50' : ''}`}
+                            data-best5-hole={inBest || undefined}
+                          >
+                            <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
+                          </div>
+                        );
+                      })
                     : !humanPlayer.folded &&
                       Array.from({ length: 4 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                 </div>

--- a/frontend/src/utils/holdemBestFive.ts
+++ b/frontend/src/utils/holdemBestFive.ts
@@ -35,7 +35,12 @@ export function holdemBestFive(cards: readonly Card[]): number[] | null {
   return bestIdx;
 }
 
-function compareScores(a: readonly number[], b: readonly number[]): number {
+/**
+ * Compare two lexicographic hand-score tuples (as produced by {@link scoreFive}).
+ * Returns >0 when `a` is stronger, <0 when `b` is, 0 when equal. Exported for
+ * reuse by other poker variants (e.g. Omaha's must-use-2 evaluator).
+ */
+export function compareScores(a: readonly number[], b: readonly number[]): number {
   const len = Math.max(a.length, b.length);
   for (let i = 0; i < len; i += 1) {
     const av = a[i] ?? 0;
@@ -50,7 +55,11 @@ function rankValue(card: Card): number {
   return card.value === 1 ? 14 : card.value;
 }
 
-function scoreFive(hand: readonly Card[]): number[] {
+/**
+ * Score a 5-card hand as a lexicographic tuple `[category, primary..., kickers...]`
+ * (higher is stronger). Exported for reuse by other poker variants.
+ */
+export function scoreFive(hand: readonly Card[]): number[] {
   const ranks = hand.map(rankValue).sort((x, y) => y - x);
   const suits = hand.map((c) => c.design);
   const flush = suits.every((s) => s === suits[0]);

--- a/frontend/src/utils/omahaBestFive.test.ts
+++ b/frontend/src/utils/omahaBestFive.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { omahaBestFive } from './omahaBestFive';
+
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('omahaBestFive', () => {
+  it('returns null without enough cards', () => {
+    expect(omahaBestFive([c('SPADE', 1)], [c('HEART', 2), c('HEART', 3), c('HEART', 4)])).toBeNull();
+    expect(omahaBestFive([c('SPADE', 1), c('SPADE', 2)], [c('HEART', 3), c('HEART', 4)])).toBeNull();
+  });
+
+  it('always picks exactly 2 hole + 3 board indices', () => {
+    const best = omahaBestFive(
+      [c('SPADE', 1), c('HEART', 13), c('DIAMOND', 7), c('CLOVER', 2)],
+      [c('SPADE', 10), c('HEART', 11), c('DIAMOND', 12), c('CLOVER', 3), c('SPADE', 5)],
+    );
+    expect(best).not.toBeNull();
+    expect(best?.holeIdx).toHaveLength(2);
+    expect(best?.boardIdx).toHaveLength(3);
+  });
+
+  it('uses the two hole cards that complete a flush under the must-use-2 rule', () => {
+    // Hole has two spades (idx 0,1); board has three spades (idx 0,1,2) → spade flush.
+    const best = omahaBestFive(
+      [c('SPADE', 9), c('SPADE', 4), c('HEART', 2), c('DIAMOND', 6)],
+      [c('SPADE', 13), c('SPADE', 11), c('SPADE', 7), c('CLOVER', 3), c('DIAMOND', 8)],
+    );
+    expect(best?.holeIdx).toEqual([0, 1]); // the two spades
+    expect(best?.boardIdx).toEqual([0, 1, 2]); // the three board spades
+  });
+
+  it('cannot use 3+ hole cards even when they would form a better hand', () => {
+    // Three hole spades + two board spades would be a flush if 3 hole were allowed;
+    // under Omaha only 2 hole count, so a board-heavy pair beats the illegal flush.
+    const best = omahaBestFive(
+      [c('SPADE', 2), c('SPADE', 3), c('SPADE', 4), c('HEART', 9)],
+      [c('SPADE', 5), c('SPADE', 6), c('HEART', 9), c('DIAMOND', 9), c('CLOVER', 12)],
+    );
+    // Best legal hand uses the H9 hole + the three nines on board → trip nines.
+    expect(best?.holeIdx).toContain(3); // the H9 hole card
+    expect(best?.holeIdx).toHaveLength(2);
+    expect(best?.boardIdx).toHaveLength(3);
+  });
+
+  it('works with a 5-card (Big O) hole', () => {
+    const best = omahaBestFive(
+      [c('SPADE', 1), c('SPADE', 13), c('HEART', 2), c('DIAMOND', 6), c('CLOVER', 9)],
+      [c('SPADE', 10), c('SPADE', 11), c('SPADE', 12), c('CLOVER', 3), c('DIAMOND', 8)],
+    );
+    // Royal-ish spade flush: A,K hole + 10,J,Q board spades.
+    expect(best?.holeIdx).toEqual([0, 1]);
+    expect(best?.boardIdx).toEqual([0, 1, 2]);
+  });
+});

--- a/frontend/src/utils/omahaBestFive.ts
+++ b/frontend/src/utils/omahaBestFive.ts
@@ -1,0 +1,44 @@
+import type { Card } from '../types/card';
+import { compareScores, scoreFive } from './holdemBestFive';
+
+/** The hole and board indices that make up an Omaha best-five hand. */
+export interface OmahaBestFive {
+  /** Indices into the hole-card array of the (exactly 2) cards used. */
+  holeIdx: number[];
+  /** Indices into the board array of the (exactly 3) cards used. */
+  boardIdx: number[];
+}
+
+/**
+ * Choose the best Omaha-style five-card hand under the "must use exactly two
+ * hole cards and exactly three board cards" rule. Enumerates every 2-of-hole ×
+ * 3-of-board combination, scores each via the shared {@link scoreFive}
+ * evaluator, and returns the indices of the winning combination — or `null`
+ * when there are fewer than 2 hole cards or 3 board cards.
+ *
+ * Works for any hole-card count (Omaha = 4, Big O = 5), so it is reused across
+ * the Omaha-family pages.
+ */
+export function omahaBestFive(hole: readonly Card[], board: readonly Card[]): OmahaBestFive | null {
+  if (hole.length < 2 || board.length < 3) return null;
+  let bestScore: number[] = [];
+  let best: OmahaBestFive | null = null;
+  const h = hole.length;
+  const b = board.length;
+  for (let h1 = 0; h1 < h - 1; h1 += 1) {
+    for (let h2 = h1 + 1; h2 < h; h2 += 1) {
+      for (let b1 = 0; b1 < b - 2; b1 += 1) {
+        for (let b2 = b1 + 1; b2 < b - 1; b2 += 1) {
+          for (let b3 = b2 + 1; b3 < b; b3 += 1) {
+            const score = scoreFive([hole[h1], hole[h2], board[b1], board[b2], board[b3]]);
+            if (best === null || compareScores(score, bestScore) > 0) {
+              bestScore = score;
+              best = { holeIdx: [h1, h2], boardIdx: [b1, b2, b3] };
+            }
+          }
+        }
+      }
+    }
+  }
+  return best;
+}


### PR DESCRIPTION
## 概要

オマハはショーダウン時に「ホール2枚+ボード3枚を必ず使う」制約ルールがあるが、どの組み合わせで勝ったかを示す UI がなかった（Hold'em の `holdemBestFive` 相当が未実装）。勝利構成5枚をハイライトする。

## 変更点

- `frontend/src/utils/holdemBestFive.ts`: 内部の `scoreFive` / `compareScores` を `export`（挙動変更なし、Hold'em は不変）
- 新規 `frontend/src/utils/omahaBestFive.ts`: must-use-2 ルール下で 2-of-N hole × 3-of-5 board の全組合せを共有 `scoreFive` で評価し、勝利構成の hole/board インデックスを返す。hole 枚数非依存（Omaha=4, Big O=5 両対応）
- `frontend/src/pages/OmahaPage.tsx`: ショーダウン時に勝利構成のホール2枚+ボード3枚へ `ring-2 ring-ds-success`（+ `-translate-y-1`）、非該当カードは `opacity-50`。`data-best5-hole`/`data-best5-board` 属性付与
- テスト: `omahaBestFive.test.ts`（null/常に2+3/フラッシュ/3枚ホール不可/Big O）、`OmahaPage.test.tsx`（ショーダウンでホール2+ボード3がハイライト）

## 受け入れ条件

- [x] ショーダウン時に勝利構成5枚（ホール2+ボード3）がハイライトされる
- [x] 非該当カードは `opacity-50` で減光される
- [x] テストを追加（util 11 + page 112 passed）
- [x] `bun run test` + `biome check` 通過。`bun run build`(tsc) はローカル OOM のため CI で検証

Closes #2169

🤖 Generated with [Claude Code](https://claude.com/claude-code)