### PR TITLE
feat(omahahilo): show Hi/Lo pot-split breakdown badges at showdown

### DIFF
--- a/frontend/src/i18n/locales/en/omahahilo.json
+++ b/frontend/src/i18n/locales/en/omahahilo.json
@@ -1,4 +1,10 @@
 {
+  "hiLo": {
+    "title": "Hi/Lo split",
+    "hi": "Hi",
+    "lo": "Lo",
+    "winner": "{{name}} (+{{amount}})"
+  },
   "phase": {
     "preFlop": "Pre-Flop",
     "flop": "Flop",

--- a/frontend/src/i18n/locales/ja/omahahilo.json
+++ b/frontend/src/i18n/locales/ja/omahahilo.json
@@ -1,4 +1,10 @@
 {
+  "hiLo": {
+    "title": "ハイ/ロー内訳",
+    "hi": "ハイ",
+    "lo": "ロー",
+    "winner": "{{name}} (+{{amount}})"
+  },
   "phase": {
     "preFlop": "プリフロップ",
     "flop": "フロップ",

--- a/frontend/src/pages/OmahaHiLoPage.test.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.test.tsx
@@ -366,6 +366,32 @@ describe('OmahaHiLoPage', () => {
     await waitFor(() => expect(screen.getByText('ツーペア')).toBeInTheDocument());
   });
 
+  it('shows green Hi and blue Lo badges when the pot splits', async () => {
+    const splitState: OmahaResponse = {
+      ...showdownState,
+      roundResults: [
+        { ...showdownState.roundResults[0], hiWonAmount: 200, lowWonAmount: 0 },
+        { ...showdownState.roundResults[1], wonAmount: 100, hiWonAmount: 0, lowWonAmount: 100 },
+      ],
+    };
+    mockExec.mockResolvedValue(splitState);
+    renderWithProviders(<OmahaHiLoPage />);
+    await waitFor(() => expect(screen.getByTestId('omahahilo-split')).toBeInTheDocument());
+    expect(screen.getByTestId('omahahilo-hi-badge')).toHaveClass('text-ds-success');
+    expect(screen.getByTestId('omahahilo-lo-badge')).toHaveClass('text-ds-info');
+  });
+
+  it('omits the Lo badge when no low qualifies', async () => {
+    const hiOnlyState: OmahaResponse = {
+      ...showdownState,
+      roundResults: [{ ...showdownState.roundResults[0], hiWonAmount: 200, lowWonAmount: 0 }],
+    };
+    mockExec.mockResolvedValue(hiOnlyState);
+    renderWithProviders(<OmahaHiLoPage />);
+    await waitFor(() => expect(screen.getByTestId('omahahilo-hi-badge')).toBeInTheDocument());
+    expect(screen.queryByTestId('omahahilo-lo-badge')).not.toBeInTheDocument();
+  });
+
   it('does not show CPU hand name badge when CPU is folded in showdown', async () => {
     mockExec.mockResolvedValue(showdownState);
     renderWithProviders(<OmahaHiLoPage />);

--- a/frontend/src/pages/OmahaHiLoPage.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.tsx
@@ -321,38 +321,35 @@ function OmahaHiLoPageContent() {
             {/* Hi/Lo split breakdown: green Hi badges + blue Lo badges (Lo omitted when nobody qualifies) */}
             {isShowdown &&
               (() => {
-                const results = state?.roundResults ?? [];
-                const hiWinners = results.filter((r) => (r.hiWonAmount ?? 0) > 0);
-                const loWinners = results.filter((r) => (r.lowWonAmount ?? 0) > 0);
+                // Narrow each winner to a concrete { name, amount } (no optional fallbacks).
+                // A won amount is non-negative, so a truthy value means "> 0".
+                const hiWinners = state.roundResults.flatMap((r) =>
+                  r.hiWonAmount ? [{ name: findPlayerName(state.players, r.playerIdx), amount: r.hiWonAmount }] : [],
+                );
+                const loWinners = state.roundResults.flatMap((r) =>
+                  r.lowWonAmount ? [{ name: findPlayerName(state.players, r.playerIdx), amount: r.lowWonAmount }] : [],
+                );
                 if (hiWinners.length === 0 && loWinners.length === 0) return null;
                 return (
                   <div className="mb-2 text-center text-sm" data-testid="omahahilo-split">
                     <div className="mb-1 text-ds-text-muted">{t('hiLo.title')}</div>
                     <div className="flex flex-wrap justify-center gap-2">
-                      {hiWinners.map((r) => (
+                      {hiWinners.map((w) => (
                         <span
-                          key={`hi-${r.playerIdx}`}
+                          key={`hi-${w.name}`}
                           data-testid="omahahilo-hi-badge"
                           className="inline-block rounded border border-ds-success bg-ds-surface px-2 py-0.5 text-ds-success"
                         >
-                          {t('hiLo.hi')}:{' '}
-                          {t('hiLo.winner', {
-                            name: findPlayerName(state?.players ?? [], r.playerIdx),
-                            amount: r.hiWonAmount ?? 0,
-                          })}
+                          {t('hiLo.hi')}: {t('hiLo.winner', { name: w.name, amount: w.amount })}
                         </span>
                       ))}
-                      {loWinners.map((r) => (
+                      {loWinners.map((w) => (
                         <span
-                          key={`lo-${r.playerIdx}`}
+                          key={`lo-${w.name}`}
                           data-testid="omahahilo-lo-badge"
                           className="inline-block rounded border border-ds-info bg-ds-surface px-2 py-0.5 text-ds-info"
                         >
-                          {t('hiLo.lo')}:{' '}
-                          {t('hiLo.winner', {
-                            name: findPlayerName(state?.players ?? [], r.playerIdx),
-                            amount: r.lowWonAmount ?? 0,
-                          })}
+                          {t('hiLo.lo')}: {t('hiLo.winner', { name: w.name, amount: w.amount })}
                         </span>
                       ))}
                     </div>

--- a/frontend/src/pages/OmahaHiLoPage.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.tsx
@@ -318,6 +318,48 @@ function OmahaHiLoPageContent() {
             {/* Round results */}
             {isShowdown && <RoundResults results={state?.roundResults} players={state?.players ?? []} />}
 
+            {/* Hi/Lo split breakdown: green Hi badges + blue Lo badges (Lo omitted when nobody qualifies) */}
+            {isShowdown &&
+              (() => {
+                const results = state?.roundResults ?? [];
+                const hiWinners = results.filter((r) => (r.hiWonAmount ?? 0) > 0);
+                const loWinners = results.filter((r) => (r.lowWonAmount ?? 0) > 0);
+                if (hiWinners.length === 0 && loWinners.length === 0) return null;
+                return (
+                  <div className="mb-2 text-center text-sm" data-testid="omahahilo-split">
+                    <div className="mb-1 text-ds-text-muted">{t('hiLo.title')}</div>
+                    <div className="flex flex-wrap justify-center gap-2">
+                      {hiWinners.map((r) => (
+                        <span
+                          key={`hi-${r.playerIdx}`}
+                          data-testid="omahahilo-hi-badge"
+                          className="inline-block rounded border border-ds-success bg-ds-surface px-2 py-0.5 text-ds-success"
+                        >
+                          {t('hiLo.hi')}:{' '}
+                          {t('hiLo.winner', {
+                            name: findPlayerName(state?.players ?? [], r.playerIdx),
+                            amount: r.hiWonAmount ?? 0,
+                          })}
+                        </span>
+                      ))}
+                      {loWinners.map((r) => (
+                        <span
+                          key={`lo-${r.playerIdx}`}
+                          data-testid="omahahilo-lo-badge"
+                          className="inline-block rounded border border-ds-info bg-ds-surface px-2 py-0.5 text-ds-info"
+                        >
+                          {t('hiLo.lo')}:{' '}
+                          {t('hiLo.winner', {
+                            name: findPlayerName(state?.players ?? [], r.playerIdx),
+                            amount: r.lowWonAmount ?? 0,
+                          })}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })()}
+
             {/* Action log */}
             <ActionLogSection
               isEndPhase={!!state?.gameEndFlag}


### PR DESCRIPTION
## 概要

オマハ ハイローのショーダウンで、どのプレイヤーがハイ半分/ロー半分を取ったかがひと目で分からなかった。`roundResults` の `hiWonAmount`/`lowWonAmount`（サーバー提供）から Hi/Lo バッジを色分け表示する。

## 変更点

- `frontend/src/pages/OmahaHiLoPage.tsx`: ショーダウン時、`hiWonAmount>0` のプレイヤーに緑「ハイ」バッジ（border-ds-success/text-ds-success）、`lowWonAmount>0` に青「ロー」バッジ（border-ds-info/text-ds-info）を名前+金額付きで表示。ロー不成立（誰も lowWonAmount>0 でない）なら Lo 行を省略。共有 `RoundResults` は変更せずページ内に追加（他ポーカー系への影響なし）
- `frontend/src/i18n/locales/{ja,en}/omahahilo.json`: `hiLo.title`/`hi`/`lo`/`winner` を追加
- `frontend/src/pages/OmahaHiLoPage.test.tsx`: スプリット時の Hi/Lo バッジ色、ロー不成立時の Lo 省略テストを追加

## 受け入れ条件

- [x] ハイ獲得者に緑「ハイ」、ロー獲得者に青「ロー」バッジ
- [x] ロー不成立の場合はロー表示が省略される
- [x] テストを追加（113 passed）
- [x] `bun run test` + `biome check` 通過。`bun run build`(tsc) はローカル OOM のため CI で検証

Closes #2170