### PR TITLE
feat(bigohilo): best-5 highlight + Hi/Lo split badges at showdown

### DIFF
--- a/frontend/src/i18n/locales/en/bigohilo.json
+++ b/frontend/src/i18n/locales/en/bigohilo.json
@@ -1,4 +1,10 @@
 {
+  "hiLo": {
+    "title": "Hi/Lo split",
+    "hi": "Hi",
+    "lo": "Lo",
+    "winner": "{{name}} (+{{amount}})"
+  },
   "phase": {
     "preFlop": "Pre-Flop",
     "flop": "Flop",

--- a/frontend/src/i18n/locales/ja/bigohilo.json
+++ b/frontend/src/i18n/locales/ja/bigohilo.json
@@ -1,4 +1,10 @@
 {
+  "hiLo": {
+    "title": "ハイ/ロー内訳",
+    "hi": "ハイ",
+    "lo": "ロー",
+    "winner": "{{name}} (+{{amount}})"
+  },
   "phase": {
     "preFlop": "プリフロップ",
     "flop": "フロップ",

--- a/frontend/src/pages/BigOHiLoPage.test.tsx
+++ b/frontend/src/pages/BigOHiLoPage.test.tsx
@@ -366,6 +366,29 @@ describe('BigOHiLoPage', () => {
     await waitFor(() => expect(screen.getByText('ツーペア')).toBeInTheDocument());
   });
 
+  it('highlights exactly 2 hole + 3 board cards as the best-5 at showdown', async () => {
+    mockExec.mockResolvedValue(showdownState);
+    const { container } = renderWithProviders(<BigOHiLoPage />);
+    await waitFor(() => expect(screen.getByText('ツーペア')).toBeInTheDocument());
+    expect(container.querySelectorAll('[data-best5-hole]')).toHaveLength(2);
+    expect(container.querySelectorAll('[data-best5-board]')).toHaveLength(3);
+  });
+
+  it('shows green Hi and blue Lo split badges (Lo omitted when none qualifies)', async () => {
+    const splitState: OmahaResponse = {
+      ...showdownState,
+      roundResults: [
+        { ...showdownState.roundResults[0], hiWonAmount: 200, lowWonAmount: 0 },
+        { ...showdownState.roundResults[1], wonAmount: 100, hiWonAmount: 0, lowWonAmount: 100 },
+      ],
+    };
+    mockExec.mockResolvedValue(splitState);
+    renderWithProviders(<BigOHiLoPage />);
+    await waitFor(() => expect(screen.getByTestId('bigohilo-split')).toBeInTheDocument());
+    expect(screen.getByTestId('bigohilo-hi-badge')).toHaveClass('text-ds-success');
+    expect(screen.getByTestId('bigohilo-lo-badge')).toHaveClass('text-ds-info');
+  });
+
   it('does not show CPU hand name badge when CPU is folded in showdown', async () => {
     mockExec.mockResolvedValue(showdownState);
     renderWithProviders(<BigOHiLoPage />);

--- a/frontend/src/pages/BigOHiLoPage.tsx
+++ b/frontend/src/pages/BigOHiLoPage.tsx
@@ -43,6 +43,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { OMAHA_HELP, parseOmahaCommand } from '../utils/cli/commands/omahaCommands';
 import { formatOmahaState } from '../utils/cli/formatters/omahaFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { omahaBestFive } from '../utils/omahaBestFive';
 import { findPlayerName } from '../utils/playerUtils';
 
 /** 5 Card Omaha Hi-Lo (Big O) tutorial step definitions. */
@@ -164,6 +165,14 @@ function BigOHiLoPageContent() {
   const isActive = phase >= OmahaPhase.PRE_FLOP && phase <= OmahaPhase.RIVER;
   const isShowdown = phase === OmahaPhase.SHOWDOWN || phase === OmahaPhase.END;
   const humanPlayer = state?.players?.find((p) => p.isHuman);
+  // At showdown, highlight the human's winning 5 cards under the must-use-2 rule.
+  const showdownBest5 = useMemo(() => {
+    const empty = { holeSet: new Set<number>(), boardSet: new Set<number>() };
+    if (!isShowdown || !humanPlayer || humanPlayer.folded) return empty;
+    const best = omahaBestFive(humanPlayer.cards ?? [], state?.communityCards ?? []);
+    if (!best) return empty;
+    return { holeSet: new Set(best.holeIdx), boardSet: new Set(best.boardIdx) };
+  }, [isShowdown, humanPlayer, state?.communityCards]);
   const humanFolded = humanPlayer?.folded ?? false;
   const humanAllIn = humanPlayer?.allIn ?? false;
   const canAct = isActive && !humanFolded && !humanAllIn && state?.currentTurn === humanPlayer?.id;
@@ -254,14 +263,21 @@ function BigOHiLoPageContent() {
                   <div className="text-ds-text-primary text-lg mb-1.5">{t('communityCards')}</div>
                   <div className="flex flex-wrap gap-2">
                     {state?.communityCards?.length
-                      ? state.communityCards.map((card) => (
-                          <AnimatedCard
-                            key={`${card.design}-${card.value}`}
-                            card={card}
-                            width={cardWidth}
-                            style={placeholderCardStyle}
-                          />
-                        ))
+                      ? state.communityCards.map((card, idx) => {
+                          const inBest = showdownBest5.boardSet.has(idx);
+                          const dim = showdownBest5.boardSet.size > 0 && !inBest;
+                          return (
+                            <div
+                              key={`${card.design}-${card.value}`}
+                              className={`transition-all ${
+                                inBest ? '-translate-y-1 ring-2 ring-ds-success motion-safe:animate-pulse' : ''
+                              } ${dim ? 'opacity-50' : ''}`}
+                              data-best5-board={inBest || undefined}
+                            >
+                              <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
+                            </div>
+                          );
+                        })
                       : Array.from({ length: 5 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                   </div>
                 </>
@@ -319,6 +335,44 @@ function BigOHiLoPageContent() {
             {/* Round results */}
             {isShowdown && <RoundResults results={state?.roundResults} players={state?.players ?? []} />}
 
+            {/* Hi/Lo split breakdown: green Hi badges + blue Lo badges (Lo omitted when nobody qualifies) */}
+            {isShowdown &&
+              (() => {
+                // A won amount is non-negative, so a truthy value means "> 0".
+                const hiWinners = state.roundResults.flatMap((r) =>
+                  r.hiWonAmount ? [{ name: findPlayerName(state.players, r.playerIdx), amount: r.hiWonAmount }] : [],
+                );
+                const loWinners = state.roundResults.flatMap((r) =>
+                  r.lowWonAmount ? [{ name: findPlayerName(state.players, r.playerIdx), amount: r.lowWonAmount }] : [],
+                );
+                if (hiWinners.length === 0 && loWinners.length === 0) return null;
+                return (
+                  <div className="mb-2 text-center text-sm" data-testid="bigohilo-split">
+                    <div className="mb-1 text-ds-text-muted">{t('hiLo.title')}</div>
+                    <div className="flex flex-wrap justify-center gap-2">
+                      {hiWinners.map((w) => (
+                        <span
+                          key={`hi-${w.name}`}
+                          data-testid="bigohilo-hi-badge"
+                          className="inline-block rounded border border-ds-success bg-ds-surface px-2 py-0.5 text-ds-success"
+                        >
+                          {t('hiLo.hi')}: {t('hiLo.winner', { name: w.name, amount: w.amount })}
+                        </span>
+                      ))}
+                      {loWinners.map((w) => (
+                        <span
+                          key={`lo-${w.name}`}
+                          data-testid="bigohilo-lo-badge"
+                          className="inline-block rounded border border-ds-info bg-ds-surface px-2 py-0.5 text-ds-info"
+                        >
+                          {t('hiLo.lo')}: {t('hiLo.winner', { name: w.name, amount: w.amount })}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })()}
+
             {/* Action log */}
             <ActionLogSection
               isEndPhase={!!state?.gameEndFlag}
@@ -370,14 +424,21 @@ function BigOHiLoPageContent() {
                 </div>
                 <div className="flex flex-wrap gap-1.5 mb-2" data-tutorial="bohl-combination-rule">
                   {humanPlayer.cards?.length
-                    ? humanPlayer.cards.map((card) => (
-                        <AnimatedCard
-                          key={`${card.design}-${card.value}`}
-                          card={card}
-                          width={cardWidth}
-                          style={placeholderCardStyle}
-                        />
-                      ))
+                    ? humanPlayer.cards.map((card, idx) => {
+                        const inBest = showdownBest5.holeSet.has(idx);
+                        const dim = showdownBest5.holeSet.size > 0 && !inBest;
+                        return (
+                          <div
+                            key={`${card.design}-${card.value}`}
+                            className={`transition-all ${
+                              inBest ? '-translate-y-1 ring-2 ring-ds-success motion-safe:animate-pulse' : ''
+                            } ${dim ? 'opacity-50' : ''}`}
+                            data-best5-hole={inBest || undefined}
+                          >
+                            <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
+                          </div>
+                        );
+                      })
                     : !humanPlayer.folded &&
                       Array.from({ length: 5 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                 </div>


### PR DESCRIPTION
## 概要

Big O Hi-Lo は `OmahaHiLoPage` と同一構造だが、ショーダウン時のハイ/ロー内訳の色分けもホール使用2枚のハイライトも未実装だった。#2169/#2171（best-5 ハイライト）と #2170（Hi/Lo バッジ）の両アプローチを適用する。

## 変更点

- `frontend/src/pages/BigOHiLoPage.tsx`:
  - `omahaBestFive`（must-use-2）でショーダウン時に勝利構成のホール2枚+ボード3枚を `ring-2 ring-ds-success`（+ `-translate-y-1`）、非該当を `opacity-50`。`data-best5-hole`/`data-best5-board`
  - `hiWonAmount`/`lowWonAmount` から緑「ハイ」/青「ロー」バッジを表示（ロー不成立時は Lo 省略）。non-null `state` + flatMap でコードカバレッジの partial を回避
- `frontend/src/i18n/locales/{ja,en}/bigohilo.json`: `hiLo.*` を追加
- `frontend/src/pages/BigOHiLoPage.test.tsx`: best-5 ハイライト（ホール2+ボード3）と Hi/Lo バッジのテストを追加

## 受け入れ条件

- [x] ハイ獲得者に緑「ハイ」、ロー獲得者に青「ロー」バッジ
- [x] ホールカード5枚中、使用2枚がハイライトされる
- [x] テストを追加（113 passed）
- [x] `bun run test` + `biome check` 通過。`bun run build`(tsc) はローカル OOM のため CI で検証

Closes #2172