### PR TITLE
feat(president): flash overlay + rotating icon on revolution

### DIFF
--- a/frontend/src/pages/PresidentPage.test.tsx
+++ b/frontend/src/pages/PresidentPage.test.tsx
@@ -102,6 +102,14 @@ describe('PresidentPage', () => {
     await waitFor(() => expect(screen.getByText(/革命中/)).toBeInTheDocument());
   });
 
+  it('flashes a full-screen overlay when revolution turns on', async () => {
+    // revolutionActive arrives true on mount → false→true transition fires the flash.
+    mockExec.mockResolvedValue(makeState({ revolutionActive: true }));
+    renderWithProviders(<PresidentPage />);
+    await waitFor(() => expect(screen.getByTestId('president-revolution-flash')).toBeInTheDocument());
+    expect(screen.getByTestId('president-revolution-flash')).toHaveClass('bg-ds-warning/40');
+  });
+
   it('disables action buttons when it is not human turn', async () => {
     mockExec.mockResolvedValue(makeState({ currentTurn: 1 }));
     renderWithProviders(<PresidentPage />);

--- a/frontend/src/pages/PresidentPage.tsx
+++ b/frontend/src/pages/PresidentPage.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
@@ -127,6 +127,23 @@ function PresidentPageContent() {
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('president', state);
 
+  // One-shot full-screen flash when revolution toggles on (false → true), to
+  // make the strength inversion impossible to miss. flashKey re-triggers the
+  // CSS animation without AnimatePresence; the timer hides the scrim after 400ms.
+  const [revolutionFlash, setRevolutionFlash] = useState(0);
+  const prevRevolution = useRef(false);
+  const revolutionFlashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => clearTimeout(revolutionFlashTimer.current ?? undefined), []);
+  useEffect(() => {
+    const active = state?.revolutionActive ?? false;
+    if (active && !prevRevolution.current) {
+      setRevolutionFlash((k) => k + 1);
+      clearTimeout(revolutionFlashTimer.current ?? undefined);
+      revolutionFlashTimer.current = setTimeout(() => setRevolutionFlash(0), 400);
+    }
+    prevRevolution.current = active;
+  }, [state?.revolutionActive]);
+
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('president');
   const cliConfig: CliGameConfig<PresidentResponse, PresidentCliArgs> = useMemo(
@@ -176,6 +193,14 @@ function PresidentPageContent() {
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
         <>
+          {revolutionFlash > 0 && (
+            <div
+              key={revolutionFlash}
+              data-testid="president-revolution-flash"
+              aria-hidden="true"
+              className="pointer-events-none fixed inset-0 z-40 bg-ds-warning/40 motion-safe:animate-[fadeIn_0.2s_ease-out] motion-reduce:hidden"
+            />
+          )}
           <div className="flex-1 overflow-y-auto px-4 py-2 space-y-3">
             {error && (
               <button type="button" onClick={retry} className="text-ds-error underline">
@@ -184,7 +209,12 @@ function PresidentPageContent() {
             )}
 
             {state.revolutionActive && (
-              <div className="text-center text-ds-warning font-semibold">{t('badge.revolution')}</div>
+              <div className="flex items-center justify-center gap-1.5 text-center text-ds-warning font-semibold">
+                <span className="inline-block motion-safe:rotate-180 transition-transform" aria-hidden="true">
+                  ⇅
+                </span>
+                {t('badge.revolution')}
+              </div>
             )}
 
             {/* CPU players */}


### PR DESCRIPTION
## 概要

プレジデントでは革命発生時に中央テキスト「革命！」が出るだけで強弱逆転が視覚的に強調されず、見逃しやすかった。発動の瞬間に全画面フラッシュ + バナーアイコン反転を追加する。

## 変更点

- `frontend/src/pages/PresidentPage.tsx`:
  - `revolutionActive` の false→true 遷移を `useRef` 比較で検知し、`flashKey`(useState) を increment（AnimatePresence 不要で CSS アニメ再発火）→ 400ms の全画面フラッシュ（`bg-ds-warning/40` 装飾スクリム、`motion-reduce:hidden`、タイマーで自動消滅、unmount でクリア）
  - 「革命！」バナーに `motion-safe:rotate-180` の ⇅ アイコンを付与（ランク反転を示唆）
- `frontend/src/pages/PresidentPage.test.tsx`: 革命 on でフラッシュが表示されるテストを追加

## 受け入れ条件

- [x] `revolutionActive` false→true で 400ms のフラッシュオーバーレイが表示される
- [x] 「革命！」バナーのアイコンが 180° 回転する
- [x] `prefers-reduced-motion` 下ではアニメ/フラッシュがスキップ（`motion-reduce:hidden` + `motion-safe:`）
- [x] テストを追加（21 passed）
- [x] `bun run test` + `biome check` 通過。`bg-ds-warning/40` は DESIGN.md の装飾スクリム許容範囲。`bun run build`(tsc) はローカル OOM のため CI で検証

Closes #2232