### PR TITLE
feat(sevenbridge): replace layoff selects with a visual meld grid

### DIFF
--- a/frontend/src/pages/SevenBridgePage.test.tsx
+++ b/frontend/src/pages/SevenBridgePage.test.tsx
@@ -80,6 +80,33 @@ describe('SevenBridgePage', () => {
     expect(screen.getByRole('button', { name: /捨てる|Discard/i })).toBeInTheDocument();
   });
 
+  it('renders layoff target melds as clickable card-row buttons and highlights the selection', async () => {
+    const meldState: SevenBridgeResponse = {
+      ...playState,
+      players: [
+        {
+          ...playState.players[0],
+          melds: [
+            {
+              cards: [
+                { design: 'SPADE', value: 5 },
+                { design: 'HEART', value: 5 },
+                { design: 'DIAMOND', value: 5 },
+              ],
+            },
+          ],
+        },
+        playState.players[1],
+      ],
+    };
+    mockExec.mockResolvedValue(meldState);
+    renderWithProviders(<SevenBridgePage />);
+    const meldBtn = await screen.findByTestId('sb-layoff-meld-0-0');
+    fireEvent.click(meldBtn);
+    expect(meldBtn).toHaveAttribute('aria-pressed', 'true');
+    expect(meldBtn.className).toContain('ring-ds-info');
+  });
+
   it('fires drawstock when clicking stock draw', async () => {
     mockExec.mockResolvedValue(drawState);
     renderWithProviders(<SevenBridgePage />);

--- a/frontend/src/pages/SevenBridgePage.tsx
+++ b/frontend/src/pages/SevenBridgePage.tsx
@@ -350,37 +350,42 @@ function SevenBridgePageContent() {
                   >
                     {t('meldButton')}
                   </button>
-                  <label className="text-ds-text-muted text-xs flex items-center gap-1">
-                    <span>{t('layoffTarget')}:</span>
-                    <select
-                      value={layoffTarget}
-                      onChange={(e) => {
-                        const val = Number(e.target.value);
-                        if (!Number.isNaN(val)) {
-                          setLayoffTarget(val);
-                          setLayoffMeldIdx(0);
-                        }
-                      }}
-                      className="border rounded px-1 text-xs bg-white text-black"
-                    >
-                      {layoffPlayers.map((p) => (
-                        <option key={p.id} value={p.id}>
-                          {playerName(p.id, p.isHuman)}
-                        </option>
-                      ))}
-                    </select>
-                    <select
-                      value={layoffMeldIdx}
-                      onChange={(e) => setLayoffMeldIdx(Number(e.target.value))}
-                      className="border rounded px-1 text-xs bg-white text-black"
-                    >
-                      {layoffMelds.map((_m, mi) => (
-                        <option key={mi} value={mi}>
-                          #{mi + 1}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
+                  {/* Visual meld picker: tap a meld's card row to target it for layoff. */}
+                  <div className="flex w-full flex-col gap-1" data-testid="sb-layoff-melds">
+                    <span className="text-ds-text-muted text-xs">{t('layoffTarget')}:</span>
+                    {layoffPlayers.map((p) =>
+                      p.melds.length > 0 ? (
+                        <div key={p.id} className="flex flex-wrap items-center gap-1">
+                          <span className="text-ds-text-muted text-xs">{playerName(p.id, p.isHuman)}:</span>
+                          {p.melds.map((meld, mi) => {
+                            const selected = layoffTarget === p.id && layoffMeldIdx === mi;
+                            return (
+                              <button
+                                type="button"
+                                key={`${p.id}-${mi}`}
+                                data-testid={`sb-layoff-meld-${p.id}-${mi}`}
+                                aria-pressed={selected}
+                                aria-label={`${playerName(p.id, p.isHuman)} ${t('layoffTarget')} ${mi + 1}`}
+                                onClick={() => {
+                                  setLayoffTarget(p.id);
+                                  setLayoffMeldIdx(mi);
+                                }}
+                                className={`flex gap-0.5 rounded p-0.5 ${focusRingCard} ${selected ? 'ring-2 ring-ds-info' : ''}`}
+                              >
+                                {meld.cards.map((c, ci) => (
+                                  <AnimatedCard
+                                    key={`${c.design}-${c.value}-${ci}`}
+                                    card={c}
+                                    width={Math.round(cardWidth * 0.4)}
+                                  />
+                                ))}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      ) : null,
+                    )}
+                  </div>
                   <button
                     type="button"
                     className={btnPrimary}


### PR DESCRIPTION
## 概要

セブンブリッジのレイオフ操作は `<select>` 二連（プレイヤー + メルド番号）で、モバイルでのタップ精度が悪く、中央のメルド表示と UI が乖離していた。視覚的なメルドカード列ボタンに置き換える。

## 変更点

- `frontend/src/pages/SevenBridgePage.tsx`: 2 つの `<select>` を削除し、各プレイヤーのメルドを `cardWidth*0.4` のカード列ボタン（`data-testid="sb-layoff-meld-<id>-<idx>"`）として表示。タップで `layoffTarget`(=player id) + `layoffMeldIdx` を同時セット、選択中は `ring-2 ring-ds-info` + `aria-pressed`。メルドが無いプレイヤーは省略
- `frontend/src/pages/SevenBridgePage.test.tsx`: メルドボタンの表示・選択ハイライトのテストを追加

## 受け入れ条件

- [x] PLAY フェーズ・自ターン時、レイオフ可能なメルドがカード列ボタンとして表示される
- [x] 選択メルドが `ring-ds-info` でハイライトされる
- [x] 既存の `<select>` は削除
- [x] モバイル幅でも flex-wrap で折り返し表示
- [x] テストを追加（5 passed）
- [x] `bun run test` + `biome check` 通過。`bun run build`(tsc) はローカル OOM のため CI で検証

Closes #2231