### PR TITLE
feat(spanish21): surface variant bonus achievements as showdown badges

### DIFF
--- a/frontend/src/pages/BlackJackPage.test.tsx
+++ b/frontend/src/pages/BlackJackPage.test.tsx
@@ -270,6 +270,20 @@ describe('BlackJackPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
   });
 
+  it('shows variant bonus badges at end phase when bonuses are present', async () => {
+    mockExec.mockResolvedValue({ ...endPhaseState, bonuses: ['spanish21.bonus.777.spade'] });
+    renderWithProviders(<BlackJackPage />);
+    await waitFor(() => expect(screen.getByTestId('bj-bonus-badges')).toBeInTheDocument());
+    expect(screen.getAllByTestId('bj-bonus-badge')).toHaveLength(1);
+  });
+
+  it('shows no bonus badges at end phase without bonuses', async () => {
+    mockExec.mockResolvedValue(endPhaseState);
+    renderWithProviders(<BlackJackPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+    expect(screen.queryByTestId('bj-bonus-badges')).not.toBeInTheDocument();
+  });
+
   it('shows message overlay when message is non-empty', async () => {
     mockExec.mockResolvedValue(endPhaseState);
     renderWithProviders(<BlackJackPage />);

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -473,6 +473,21 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
               </div>
             )}
 
+            {/* Variant bonus badges (Spanish 21): 7-7-7 / 6-7-8 / 5+card 21 achievements. */}
+            {phase === BjPhase.END && (state?.bonuses?.length ?? 0) > 0 && (
+              <div className="mb-2 flex flex-wrap justify-center gap-1" data-testid="bj-bonus-badges">
+                {state?.bonuses?.map((key) => (
+                  <span
+                    key={key}
+                    data-testid="bj-bonus-badge"
+                    className="rounded-full border border-ds-warning bg-ds-surface px-3 py-0.5 text-ds-warning text-sm font-bold motion-safe:animate-pulse-once"
+                  >
+                    🎉 {t(key.replace(/^spanish21\./, ''))}
+                  </span>
+                ))}
+              </div>
+            )}
+
             {/* Hint banner */}
             {hintEnabled && suggestedAction !== BJ_SUGGEST_NONE && (
               <div className="mb-2">

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -476,9 +476,10 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
             {/* Variant bonus badges (Spanish 21): 7-7-7 / 6-7-8 / 5+card 21 achievements. */}
             {phase === BjPhase.END && (state?.bonuses?.length ?? 0) > 0 && (
               <div className="mb-2 flex flex-wrap justify-center gap-1" data-testid="bj-bonus-badges">
-                {state?.bonuses?.map((key) => (
+                {state?.bonuses?.map((key, i) => (
                   <span
-                    key={key}
+                    // Multi-hand rounds can repeat the same bonus key, so include the index.
+                    key={`${key}-${i}`}
                     data-testid="bj-bonus-badge"
                     className="rounded-full border border-ds-warning bg-ds-surface px-3 py-0.5 text-ds-warning text-sm font-bold motion-safe:animate-pulse-once"
                   >

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -184,6 +184,8 @@ export interface BlackJackResponse extends BaseGameResponse {
   perfectPairsBet: number;
   twentyOnePlus3Bet: number;
   sideBetResults?: BlackJackSideBetResult[];
+  /** i18n keys of variant bonuses achieved this round (Spanish 21, e.g. `spanish21.bonus.777.spade`). */
+  bonuses?: string[];
   doubleAfterSplit: boolean;
   countingSystem: number;
   deckPenetration: number;

--- a/internal/adapter/controller/BlackJackWebController.go
+++ b/internal/adapter/controller/BlackJackWebController.go
@@ -83,6 +83,7 @@ type BlackJackWebOutput struct {
 	PerfectPairsBet    int                                `json:"perfectPairsBet"`
 	TwentyOnePlus3Bet  int                                `json:"twentyOnePlus3Bet"`
 	SideBetResults     []*BlackJackWebOutputSideBetResult `json:"sideBetResults,omitempty"`
+	Bonuses            []string                           `json:"bonuses,omitempty"`
 	DoubleAfterSplit   bool                               `json:"doubleAfterSplit"`
 	CountingSystem     int                                `json:"countingSystem"`
 	DeckPenetration    int                                `json:"deckPenetration"`

--- a/internal/adapter/presenter/BlackJackWebPresenter.go
+++ b/internal/adapter/presenter/BlackJackWebPresenter.go
@@ -47,6 +47,7 @@ func (bjp *BlackJackWebPresenter) Output(bj interfaces.BlackJackGame, lastErr er
 
 	resObj.PerfectPairsBet = bj.GetPerfectPairsBet()
 	resObj.TwentyOnePlus3Bet = bj.Get21Plus3Bet()
+	resObj.Bonuses = bj.GetBonusKeys()
 
 	resObj.Message, resObj.MessageCode, resObj.MessageParams = bjp.buildMessage(bj, lastErr)
 

--- a/internal/domain/BlackJack.go
+++ b/internal/domain/BlackJack.go
@@ -74,6 +74,7 @@ type BlackJack struct {
 	sideBetResults     []*BJSideBetResult      // サイドベット結果
 	multiHandCount     int                     // マルチハンド数（0=デフォルト1）
 	actionLog          []*ActionLogEntry       // 棋譜
+	bonusKeys          []string                // 当ラウンドで成立したバリアントボーナスのi18nキー (Spanish 21 等)
 }
 
 // NewDefaultBlackJack デフォルト設定のブラックジャックを生成するファクトリ関数
@@ -126,6 +127,7 @@ func (b *BlackJack) Reset() {
 	b.perfectPairsBet = 0
 	b.twentyOnePlus3Bet = 0
 	b.sideBetResults = nil
+	b.bonusKeys = nil
 	b.multiHandCount = 0
 	b.actionLog = nil
 	// チップが最低ベット額未満ならデフォルト値にリセット
@@ -656,6 +658,12 @@ func (b *BlackJack) GetMultiHandCount() int {
 		return 1
 	}
 	return b.multiHandCount
+}
+
+// GetBonusKeys 当ラウンドで成立したバリアントボーナスのi18nキー一覧を返す
+// (Spanish 21 の 7-7-7 / 6-7-8 / 5枚以上21 等)。ボーナスなしの場合は空。
+func (b *BlackJack) GetBonusKeys() []string {
+	return b.bonusKeys
 }
 
 // SetMultiHandCount マルチハンド数設定（テスト用）

--- a/internal/domain/BlackJackEval.go
+++ b/internal/domain/BlackJackEval.go
@@ -193,6 +193,7 @@ func (b *BlackJack) GameJudgmentForHand(handIdx int) GameResult {
 
 // resolvePayouts 全ハンドの精算
 func (b *BlackJack) resolvePayouts() {
+	b.bonusKeys = nil // 当ラウンド分のボーナスを再集計
 	dealerScore := b.dealer.GetScore()
 	dealerBJ := b.dealer.GetCardsSize() == 2 && dealerScore == 21
 
@@ -214,6 +215,7 @@ func (b *BlackJack) resolvePayouts() {
 		bonus := b.payoutHandWithVariant(b.player, hand, hand.IsFromSplit(), result)
 		if bonus != nil {
 			b.appendLog(i, "bonus", bonus.NameKey, nil)
+			b.bonusKeys = append(b.bonusKeys, bonus.NameKey)
 		}
 	}
 }

--- a/internal/domain/BlackJackSpanish21_test.go
+++ b/internal/domain/BlackJackSpanish21_test.go
@@ -233,3 +233,34 @@ func TestSpanish21SetConfigSwitchesVariant(t *testing.T) {
 	assert.Equal(t, BJVariantSpanish21, v.Name)
 	assert.True(t, bj.deckCountChanged, "variant change should trigger deck rebuild")
 }
+
+// TestSpanish21BonusKeysCapturedOnResolve は resolvePayouts がボーナス成立時に
+// GetBonusKeys へキーを記録すること、およびボーナスなしの再精算でクリアされることを検証する。
+func TestSpanish21BonusKeysCapturedOnResolve(t *testing.T) {
+	bj := NewSpanish21BlackJack()
+
+	// 5-card 21 (2+3+4+5+7) で勝利 → fivecard21 ボーナス成立
+	hand := NewBlackJackHand()
+	hand.AddCard(NewCard(CardDesignSpade, 2, false))
+	hand.AddCard(NewCard(CardDesignClover, 3, false))
+	hand.AddCard(NewCard(CardDesignHeart, 4, false))
+	hand.AddCard(NewCard(CardDesignDiamond, 5, false))
+	hand.AddCard(NewCard(CardDesignSpade, 7, false))
+	hand.SetBet(100)
+	bj.playerHands = []*BlackJackHand{hand}
+	// ディーラーは 17 (10+7): プレイヤー21 が勝つが BJ ではない
+	bj.dealer.AddCard(NewCard(CardDesignClover, 10, false))
+	bj.dealer.AddCard(NewCard(CardDesignDiamond, 7, false))
+
+	bj.resolvePayouts()
+	assert.Equal(t, []string{"spanish21.bonus.fivecard21"}, bj.GetBonusKeys())
+
+	// ボーナスなしの通常ハンドで再精算 → クリアされる
+	plain := NewBlackJackHand()
+	plain.AddCard(NewCard(CardDesignSpade, 10, false))
+	plain.AddCard(NewCard(CardDesignClover, 9, false)) // 19, 勝ち, ボーナスなし
+	plain.SetBet(100)
+	bj.playerHands = []*BlackJackHand{plain}
+	bj.resolvePayouts()
+	assert.Empty(t, bj.GetBonusKeys())
+}

--- a/internal/domain/interfaces/blackjack.go
+++ b/internal/domain/interfaces/blackjack.go
@@ -82,6 +82,8 @@ type BlackJackGame interface {
 	GetDeckPenetration() int
 	// GetMultiHandCount マルチハンド数を取得する
 	GetMultiHandCount() int
+	// GetBonusKeys 当ラウンドで成立したバリアントボーナスのi18nキー一覧を取得する
+	GetBonusKeys() []string
 	// CanSurrenderHand 指定ハンドのサレンダー可否を返す
 	CanSurrenderHand(handIdx int) bool
 	// CanSurrenderCpuHand CPUハンドのサレンダー可否を返す

--- a/internal/domain/interfaces/blackjack_mock.go
+++ b/internal/domain/interfaces/blackjack_mock.go
@@ -248,6 +248,15 @@ func (_m *MockBlackJackGame) GetMultiHandCount() int {
 	return ret.Int(0)
 }
 
+// GetBonusKeys モック
+func (_m *MockBlackJackGame) GetBonusKeys() []string {
+	ret := _m.Called()
+	if v, ok := ret.Get(0).([]string); ok {
+		return v
+	}
+	return nil
+}
+
 // CanSurrenderHand モック
 func (_m *MockBlackJackGame) CanSurrenderHand(handIdx int) bool {
 	ret := _m.Called(handIdx)


### PR DESCRIPTION
## 概要

スパニッシュ21の「777」「6-7-8」「5枚以上21」等の特殊ボーナスは内部で配当計算されるだけで Web に伝わっておらず、達成を強調する UI がなかった。バックエンドにボーナス成立キーを公開し、フロントでバッジ表示する。

## 変更点（バックエンド）

- `internal/domain/BlackJack.go`: `bonusKeys []string` フィールド追加、`Reset()` でクリア、`GetBonusKeys()` ゲッター追加
- `internal/domain/BlackJackEval.go`: `resolvePayouts` 冒頭で `bonusKeys` をクリアし、ボーナス成立時に `NameKey` を追記（当ラウンド分のみ集計）
- `internal/domain/interfaces/blackjack.go` (+ mock): `GetBonusKeys() []string` を追加
- `internal/adapter/controller/BlackJackWebController.go`: 出力 DTO に `Bonuses []string \`json:"bonuses,omitempty"\``
- `internal/adapter/presenter/BlackJackWebPresenter.go`: `resObj.Bonuses = bj.GetBonusKeys()`

## 変更点（フロントエンド）

- `frontend/src/types/card.ts`: `BlackJackResponse.bonuses?: string[]`
- `frontend/src/pages/BlackJackPage.tsx`: END フェーズで `bonuses` があれば 🎉 スタンプバッジ（`motion-safe:animate-pulse-once`、`border-ds-warning`）を表示。通常勝利では非表示。NameKey は `spanish21.` プレフィックスを剥がして `t()`

## テスト

- Go: `TestSpanish21BonusKeysCapturedOnResolve`（resolvePayouts がボーナスキーを記録し、ボーナスなし再精算でクリア）。presenter パッケージテスト緑（ローカル）。`internal/domain` テストはローカル OOM のため CI 検証
- Frontend: ボーナスあり→バッジ表示 / なし→非表示（BlackJackPage 131 passed）+ biome 通過

## 受け入れ条件

- [x] 777・6-7-8 等のボーナス手成立時に「特別ボーナス！」バッジが stamp アニメで表示される
- [x] バッジはボーナスなし（通常勝利）時には表示されない
- [x] `prefers-reduced-motion` 配慮（`motion-safe:`）
- [x] ja/en 翻訳キーは既存の `spanish21.bonus.*` を流用
- [x] `BlackJackPage.test.tsx` にテスト追加

Closes #2234