### PR TITLE
feat(irishpoker): select and discard 2 cards at once

### DIFF
--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -644,9 +644,11 @@ export const sevenCardStudApi = createHoldemLikeApi<SevenCardStudResponse, Seven
 /** API client for the Razz /razz/exec endpoint. */
 export const razzApi = createHoldemLikeApi<SevenCardStudResponse, SevenCardStudConfigInput>('razz');
 
-/** Configuration options for Pineapple Poker (extends Hold'em with cardIdx for discard). */
+/** Configuration options for Pineapple Poker (extends Hold'em with cardIdx/cardIdxs for discard). */
 export interface PineappleConfigInput extends HoldemConfigInput {
   cardIdx?: number;
+  /** Multiple discard indices, submitted together (Irish Poker's 2-card discard). */
+  cardIdxs?: number[];
 }
 
 /** API client for the Pineapple Poker /pineapple/exec endpoint. */

--- a/frontend/src/i18n/locales/en/irishpoker.json
+++ b/frontend/src/i18n/locales/en/irishpoker.json
@@ -18,7 +18,8 @@
     "select": "Select a card to discard (2 cards total)",
     "confirm": "Discard {{card}}?",
     "confirmYes": "Confirm",
-    "confirmNo": "Cancel"
+    "confirmNo": "Cancel",
+    "selectedCount": "{{n}}/{{total}} selected"
   },
   "rebuy": {
     "prompt": "Rebuy? ({{chips}} chips, {{used}}/{{max}} used)",

--- a/frontend/src/i18n/locales/ja/irishpoker.json
+++ b/frontend/src/i18n/locales/ja/irishpoker.json
@@ -18,7 +18,8 @@
     "select": "捨てるカードを選択してください（計2枚）",
     "confirm": "{{card}} を捨てますか？",
     "confirmYes": "確定",
-    "confirmNo": "キャンセル"
+    "confirmNo": "キャンセル",
+    "selectedCount": "{{n}}/{{total}} 枚選択済み"
   },
   "rebuy": {
     "prompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済)",

--- a/frontend/src/pages/IrishPokerPage.test.tsx
+++ b/frontend/src/pages/IrishPokerPage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { irishPokerApi, pineappleApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -143,5 +143,39 @@ describe('IrishPokerPage', () => {
     mockIrishExec.mockResolvedValue(discardState);
     renderWithProviders(<IrishPokerPage />);
     await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+  });
+
+  it('requires selecting 2 cards then submits them together as cardIdxs', async () => {
+    mockIrishExec.mockResolvedValue(discardState);
+    renderWithProviders(<IrishPokerPage />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+
+    const discardBtn = screen.getByRole('button', { name: 'カードを捨ててください。' });
+    expect(discardBtn).toBeDisabled(); // 0 selected
+
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.getAttribute('aria-pressed') !== null);
+    fireEvent.click(cardButtons[2]); // 1/2 selected → still disabled, count badge shows
+    expect(screen.getByTestId('discard-count')).toHaveTextContent('1/2');
+    expect(discardBtn).toBeDisabled();
+
+    fireEvent.click(cardButtons[3]); // 2/2 selected → enabled
+    await waitFor(() => expect(discardBtn).not.toBeDisabled());
+
+    fireEvent.click(discardBtn);
+    fireEvent.click(screen.getByRole('button', { name: '確定' }));
+    await waitFor(() => expect(mockIrishExec).toHaveBeenCalledWith('discard', undefined, { cardIdxs: [2, 3] }));
+  });
+
+  it('caps the discard selection at 2 cards', async () => {
+    mockIrishExec.mockResolvedValue(discardState);
+    renderWithProviders(<IrishPokerPage />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.getAttribute('aria-pressed') !== null);
+    fireEvent.click(cardButtons[0]);
+    fireEvent.click(cardButtons[1]);
+    fireEvent.click(cardButtons[2]); // ignored — cap is 2
+    expect(screen.getByTestId('discard-count')).toHaveTextContent('2/2');
+    expect(cardButtons[2]).toHaveAttribute('aria-pressed', 'false');
   });
 });

--- a/frontend/src/pages/PineapplePage.test.tsx
+++ b/frontend/src/pages/PineapplePage.test.tsx
@@ -237,11 +237,11 @@ describe('PineapplePage', () => {
 
     // Pressing discard now opens an inline confirm step rather than committing immediately.
     fireEvent.click(discardBtn);
-    expect(mockExec).not.toHaveBeenCalledWith('discard', undefined, { cardIdx: 0 });
+    expect(mockExec).not.toHaveBeenCalledWith('discard', undefined, { cardIdxs: [0] });
     expect(screen.getByTestId('discard-confirm')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: '確定' }));
-    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('discard', undefined, { cardIdx: 0 }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('discard', undefined, { cardIdxs: [0] }));
   });
 
   it('cancels the discard confirm step and returns to selection', async () => {
@@ -259,7 +259,7 @@ describe('PineapplePage', () => {
     // Back to selection; nothing discarded.
     expect(screen.queryByTestId('discard-confirm')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: '1枚捨ててください。' })).toBeInTheDocument();
-    expect(mockExec).not.toHaveBeenCalledWith('discard', undefined, { cardIdx: 0 });
+    expect(mockExec).not.toHaveBeenCalledWith('discard', undefined, { cardIdxs: [0] });
   });
 
   it('shows round results during showdown', async () => {

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -137,7 +137,9 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
   const [learningMode, setLearningMode] = useState(false);
   const [cpuMetaAI, setCpuMetaAI] = useState(false);
   const { hint, hintEnabled, setHintEnabled } = useGameHint(variant, state);
-  const [selectedDiscard, setSelectedDiscard] = useState<number | null>(null);
+  // Indices selected for discard. Pineapple/Crazy Pineapple discard 1 (3→2);
+  // Irish Poker discards 2 (4→2). Capped at `discardCount` below.
+  const [selectedDiscards, setSelectedDiscards] = useState<number[]>([]);
   // Two-step discard: pressing "discard" enters a confirm step before committing.
   const [discardConfirming, setDiscardConfirming] = useState(false);
   const turnStartRef = useRef(0);
@@ -178,7 +180,7 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
   // Reset discard selection (and any pending confirm) when leaving discard phase
   useEffect(() => {
     if (!state?.isDiscardPhase) {
-      setSelectedDiscard(null);
+      setSelectedDiscards([]);
       setDiscardConfirming(false);
     }
   }, [state?.isDiscardPhase]);
@@ -208,6 +210,16 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
   const cpuPlayers = useMemo(() => state?.players?.filter((p) => !p.isHuman) ?? [], [state?.players]);
   const humanDiscardDone = state?.discardDone?.[humanIdx] ?? false;
   const canDiscard = isDiscardPhase && !humanDiscardDone;
+  // Cards the player must discard down to 2: Pineapple/Crazy = 1, Irish = 2.
+  const discardCount = Math.max(1, (state?.initialDealCount ?? 3) - 2);
+  const toggleDiscard = (idx: number) => {
+    if (!canDiscard) return;
+    setSelectedDiscards((prev) => {
+      if (prev.includes(idx)) return prev.filter((i) => i !== idx);
+      if (prev.length >= discardCount) return prev; // cap reached
+      return [...prev, idx];
+    });
+  };
 
   const actionBindings = useMemo(
     () => [
@@ -399,19 +411,22 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
                 </div>
                 <div className="flex flex-wrap gap-1.5 mb-2">
                   {humanPlayer.cards?.length
-                    ? humanPlayer.cards.map((card, idx) => (
-                        <button
-                          key={`${card.design}-${card.value}`}
-                          type="button"
-                          onClick={() => canDiscard && setSelectedDiscard(idx)}
-                          aria-pressed={canDiscard ? selectedDiscard === idx : undefined}
-                          className={canDiscard ? 'cursor-pointer' : 'cursor-default'}
-                          disabled={!canDiscard}
-                          style={selectedCardStyle(canDiscard && selectedDiscard === idx)}
-                        >
-                          <AnimatedCard card={card} width={cardWidth} />
-                        </button>
-                      ))
+                    ? humanPlayer.cards.map((card, idx) => {
+                        const isSelected = selectedDiscards.includes(idx);
+                        return (
+                          <button
+                            key={`${card.design}-${card.value}`}
+                            type="button"
+                            onClick={() => toggleDiscard(idx)}
+                            aria-pressed={canDiscard ? isSelected : undefined}
+                            className={canDiscard ? 'cursor-pointer' : 'cursor-default'}
+                            disabled={!canDiscard}
+                            style={selectedCardStyle(canDiscard && isSelected)}
+                          >
+                            <AnimatedCard card={card} width={cardWidth} />
+                          </button>
+                        );
+                      })
                     : !humanPlayer.folded &&
                       Array.from({ length: state?.initialDealCount ?? 3 }).map((_, i) => (
                         <AnimatedCardBack key={i} width={cardWidth} />
@@ -433,10 +448,12 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
             {/* Discard controls */}
             {canDiscard && (
               <div className="mb-2 text-center" data-testid="discard-controls" data-tutorial="pn-discard-controls">
-                {discardConfirming && selectedDiscard !== null && humanPlayer?.cards[selectedDiscard] ? (
+                {discardConfirming && selectedDiscards.length === discardCount ? (
                   <div data-testid="discard-confirm">
                     <p className="text-ds-text-primary mb-2">
-                      {t('discard.confirm', { card: cardAlt(humanPlayer.cards[selectedDiscard]) })}
+                      {t('discard.confirm', {
+                        card: selectedDiscards.map((i) => cardAlt(humanPlayer.cards[i])).join(', '),
+                      })}
                     </p>
                     <div className="flex justify-center gap-2">
                       <button
@@ -444,8 +461,8 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
                         className={`${btnPrimary} min-w-[90px]`}
                         disabled={loading}
                         onClick={() => {
-                          apiExec('discard', undefined, { cardIdx: selectedDiscard });
-                          setSelectedDiscard(null);
+                          apiExec('discard', undefined, { cardIdxs: [...selectedDiscards] });
+                          setSelectedDiscards([]);
                           setDiscardConfirming(false);
                         }}
                       >
@@ -464,10 +481,15 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
                 ) : (
                   <>
                     <p className="text-ds-text-primary mb-2">{t('discard.select')}</p>
+                    {discardCount > 1 && (
+                      <p className="text-ds-text-muted text-xs mb-2" data-testid="discard-count">
+                        {t('discard.selectedCount', { n: selectedDiscards.length, total: discardCount })}
+                      </p>
+                    )}
                     <button
                       type="button"
                       className={`${btnPrimary} min-w-[90px]`}
-                      disabled={loading || selectedDiscard === null}
+                      disabled={loading || selectedDiscards.length !== discardCount}
                       onClick={() => setDiscardConfirming(true)}
                     >
                       {t('discard.prompt')}

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -448,7 +448,7 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
             {/* Discard controls */}
             {canDiscard && (
               <div className="mb-2 text-center" data-testid="discard-controls" data-tutorial="pn-discard-controls">
-                {discardConfirming && selectedDiscards.length === discardCount ? (
+                {discardConfirming && selectedDiscards.length === discardCount && humanPlayer ? (
                   <div data-testid="discard-confirm">
                     <p className="text-ds-text-primary mb-2">
                       {t('discard.confirm', {

--- a/internal/adapter/controller/PineappleWebController.go
+++ b/internal/adapter/controller/PineappleWebController.go
@@ -18,6 +18,7 @@ type PineappleWebInput struct {
 	Amount      int             `json:"amount,omitempty"`
 	HumanPlayMs int             `json:"humanPlayMs,omitempty"`
 	CardIdx     *int            `json:"cardIdx,omitempty"`
+	CardIdxs    []int           `json:"cardIdxs,omitempty"`
 	CpuMetaAI   bool            `json:"cpuMetaAI,omitempty"`
 	Profile     json.RawMessage `json:"profile,omitempty"`
 }
@@ -87,6 +88,11 @@ func pineappleDispatch(bc *baseController, w http.ResponseWriter, pgi usecase.Pi
 		}
 		bc.writePresenterResponse(w, pgi.ResetWithConfig(cfg, param.Profile))
 	case "d", "discard":
+		// 複数枚指定 (Irish Poker の2枚捨て) を優先。なければ単一 cardIdx。
+		if len(param.CardIdxs) > 0 {
+			bc.writePresenterResponse(w, pgi.DiscardMany(param.CardIdxs))
+			return true
+		}
 		if !requireParam(bc, w, newDefault, param.CardIdx == nil, "param error: cardIdx is required for discard") {
 			return true
 		}

--- a/internal/adapter/controller/PineappleWebController_test.go
+++ b/internal/adapter/controller/PineappleWebController_test.go
@@ -134,6 +134,23 @@ func TestPineappleWebController_Discard_ValidCardIdx(t *testing.T) {
 	recorded.CodeIs(200)
 }
 
+func TestPineappleWebController_Discard_MultipleCardIdxs(t *testing.T) {
+	mi := new(mockUsecase.MockPineappleInteractor)
+	pwc := newPineappleTestController(mi)
+	defer pwc.Stop()
+
+	// Irish Poker: cardIdxs takes precedence and routes to DiscardMany.
+	mi.On("DiscardMany", []int{1, 3}).Return(`{"phase":2}`)
+
+	recorded := execRequest(t, pwc.Exec, map[string]interface{}{
+		"command":   "discard",
+		"sessionId": "s1",
+		"cardIdxs":  []int{1, 3},
+	})
+	recorded.CodeIs(200)
+	mi.AssertCalled(t, "DiscardMany", []int{1, 3})
+}
+
 func TestPineappleWebController_Discard_ShortCommand(t *testing.T) {
 	mi := new(mockUsecase.MockPineappleInteractor)
 	pwc := newPineappleTestController(mi)

--- a/internal/adapter/controller/usecase/PineappleInteractor_mock.go
+++ b/internal/adapter/controller/usecase/PineappleInteractor_mock.go
@@ -37,6 +37,12 @@ func (_m *MockPineappleInteractor) Discard(cardIdx int) string {
 	return ret.Get(0).(string)
 }
 
+// DiscardMany モック
+func (_m *MockPineappleInteractor) DiscardMany(cardIdxs []int) string {
+	ret := _m.Called(cardIdxs)
+	return ret.Get(0).(string)
+}
+
 // GetConfig モック
 func (_m *MockPineappleInteractor) GetConfig() domain.PineappleConfig {
 	ret := _m.Called()

--- a/internal/domain/Pineapple.go
+++ b/internal/domain/Pineapple.go
@@ -5,6 +5,7 @@ package domain
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 )
 
 // パイナップルフェーズ定数 (Holdemと共通 + ディスカードフェーズ)
@@ -338,6 +339,14 @@ func (p *Pineapple) PlayerAction(action, amount, humanPlayMs int) error {
 
 // DiscardCard 人間プレイヤーが手札から1枚をディスカードする
 func (p *Pineapple) DiscardCard(cardIdx int) error {
+	return p.DiscardCards([]int{cardIdx})
+}
+
+// DiscardCards 人間プレイヤーが手札から複数枚を一括でディスカードする。
+// Irish Poker は 4 枚から 2 枚を一度に捨てるため複数インデックスを受け取り、
+// 高い順に取り除く (取り除きごとにインデックスがずれないようにするため)。
+// インデックスは 1 枚以上・重複不可・範囲内でなければならない。
+func (p *Pineapple) DiscardCards(cardIdxs []int) error {
 	if p.phase != PineapplePhaseDiscard {
 		return NewDomainError(ErrWrongPhase, "Discard is not allowed now.")
 	}
@@ -358,12 +367,28 @@ func (p *Pineapple) DiscardCard(cardIdx int) error {
 	}
 
 	pl := p.players[humanIdx]
-	if cardIdx < 0 || cardIdx >= pl.GetCardsSize() {
-		return NewDomainError(ErrInvalidCard, "Invalid card index.")
+	if len(cardIdxs) == 0 {
+		return NewDomainError(ErrInvalidCard, "No card index supplied.")
+	}
+	// インデックス検証 (範囲・重複)
+	seen := make(map[int]bool, len(cardIdxs))
+	for _, idx := range cardIdxs {
+		if idx < 0 || idx >= pl.GetCardsSize() {
+			return NewDomainError(ErrInvalidCard, "Invalid card index.")
+		}
+		if seen[idx] {
+			return NewDomainError(ErrInvalidCard, "Duplicate card index.")
+		}
+		seen[idx] = true
 	}
 
-	p.removeCard(humanIdx, cardIdx)
-	p.appendLog(humanIdx, "discard", "discard", nil)
+	// 高い順に取り除く (低インデックスを後回しにしてズレを防ぐ)
+	sorted := append([]int(nil), cardIdxs...)
+	sort.Sort(sort.Reverse(sort.IntSlice(sorted)))
+	for _, idx := range sorted {
+		p.removeCard(humanIdx, idx)
+		p.appendLog(humanIdx, "discard", "discard", nil)
+	}
 
 	if pl.GetCardsSize() <= 2 {
 		p.discardDone[humanIdx] = true

--- a/internal/domain/Pineapple_test.go
+++ b/internal/domain/Pineapple_test.go
@@ -513,3 +513,59 @@ func TestPineapple_ActionLog(t *testing.T) {
 	assert.NotNil(t, p.GetActionLog())
 	assert.Greater(t, len(p.GetActionLog()), 0)
 }
+
+// TestPineapple_DiscardCards はIrish Pokerの2枚一括ディスカードを検証する。
+func TestPineapple_DiscardCards(t *testing.T) {
+	setup := func() *Pineapple {
+		p := newTestPineapple()
+		p.phase = PineapplePhaseDiscard
+		p.discardDone = make([]bool, len(p.players))
+		for i := 1; i < len(p.players); i++ {
+			p.discardDone[i] = true // CPUは済みにして人間のみ精算対象
+		}
+		p.players[0].Reset()
+		p.players[0].AddCard(NewCard(CardDesignSpade, 1, false))  // idx0
+		p.players[0].AddCard(NewCard(CardDesignSpade, 13, false)) // idx1
+		p.players[0].AddCard(NewCard(CardDesignHeart, 2, false))  // idx2
+		p.players[0].AddCard(NewCard(CardDesignClover, 9, false)) // idx3
+		return p
+	}
+
+	t.Run("discards two cards at once down to two", func(t *testing.T) {
+		p := setup()
+		err := p.DiscardCards([]int{2, 3}) // 弱い2枚を捨てる
+		assert.NoError(t, err)
+		assert.Equal(t, 2, p.players[0].GetCardsSize())
+		assert.True(t, p.discardDone[0])
+		// 残りは A♠ と K♠
+		assert.Equal(t, 1, p.players[0].GetCard(0).GetValue())
+		assert.Equal(t, 13, p.players[0].GetCard(1).GetValue())
+	})
+
+	t.Run("rejects duplicate indices", func(t *testing.T) {
+		p := setup()
+		err := p.DiscardCards([]int{2, 2})
+		assert.Error(t, err)
+		assert.Equal(t, 4, p.players[0].GetCardsSize()) // 変化なし
+	})
+
+	t.Run("rejects out-of-range index", func(t *testing.T) {
+		p := setup()
+		err := p.DiscardCards([]int{0, 9})
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects empty index list", func(t *testing.T) {
+		p := setup()
+		err := p.DiscardCards([]int{})
+		assert.Error(t, err)
+	})
+
+	t.Run("DiscardCard delegates to DiscardCards", func(t *testing.T) {
+		p := setup()
+		err := p.DiscardCard(3) // 4→3枚, まだ済みではない
+		assert.NoError(t, err)
+		assert.Equal(t, 3, p.players[0].GetCardsSize())
+		assert.False(t, p.discardDone[0])
+	})
+}

--- a/internal/domain/interfaces/pineapple.go
+++ b/internal/domain/interfaces/pineapple.go
@@ -14,6 +14,8 @@ type PineappleGame interface {
 	PlayerAction(action, amount, humanPlayMs int) error
 	// DiscardCard 人間プレイヤーが手札から1枚をディスカードする
 	DiscardCard(cardIdx int) error
+	// DiscardCards 人間プレイヤーが手札から複数枚を一括でディスカードする
+	DiscardCards(cardIdxs []int) error
 	// IsDiscardPhase ディスカードフェーズかどうか
 	IsDiscardPhase() bool
 	// GetPhase 現在のフェーズを取得する

--- a/internal/domain/interfaces/pineapple_mock.go
+++ b/internal/domain/interfaces/pineapple_mock.go
@@ -31,6 +31,12 @@ func (_m *MockPineappleGame) DiscardCard(cardIdx int) error {
 	return ret.Error(0)
 }
 
+// DiscardCards モック
+func (_m *MockPineappleGame) DiscardCards(cardIdxs []int) error {
+	ret := _m.Called(cardIdxs)
+	return ret.Error(0)
+}
+
 // IsDiscardPhase モック
 func (_m *MockPineappleGame) IsDiscardPhase() bool {
 	ret := _m.Called()

--- a/internal/usecase/PineappleInteractor.go
+++ b/internal/usecase/PineappleInteractor.go
@@ -19,8 +19,10 @@ type PineappleInteractorIF interface {
 	ResetWithConfig(cfg domain.PineappleConfig, profileData []byte) string
 	// Action プレイヤーアクション実行
 	Action(action int, amount int, humanPlayMs int) string
-	// Discard ディスカード実行
+	// Discard ディスカード実行 (1枚)
 	Discard(cardIdx int) string
+	// DiscardMany ディスカード実行 (複数枚を一括: Irish Poker の2枚捨て等)
+	DiscardMany(cardIdxs []int) string
 	// GetConfig 現在の設定を取得
 	GetConfig() domain.PineappleConfig
 	// ActionLog 棋譜を出力する
@@ -74,6 +76,11 @@ func (pi *PineappleInteractor) Action(action int, amount int, humanPlayMs int) s
 // Discard ディスカード実行
 func (pi *PineappleInteractor) Discard(cardIdx int) string {
 	return execAndPresent(pi.Game, pi.pp, func() error { return pi.Game.DiscardCard(cardIdx) })
+}
+
+// DiscardMany ディスカード実行 (複数枚を一括)
+func (pi *PineappleInteractor) DiscardMany(cardIdxs []int) string {
+	return execAndPresent(pi.Game, pi.pp, func() error { return pi.Game.DiscardCards(cardIdxs) })
 }
 
 // GetConfig 現在の設定を取得

--- a/internal/usecase/PineappleInteractor_test.go
+++ b/internal/usecase/PineappleInteractor_test.go
@@ -127,6 +127,19 @@ func TestPineappleInteractor_Discard(t *testing.T) {
 	mg.AssertCalled(t, "DiscardCard", 2)
 }
 
+func TestPineappleInteractor_DiscardMany(t *testing.T) {
+	mg := new(interfaces.MockPineappleGame)
+	mp := new(presenter.MockPineapplePresenter)
+	pi := NewPineappleInteractor(mg, mp)
+
+	mg.On("DiscardCards", []int{1, 3}).Return(nil)
+	mp.On("Output", mg, mock.Anything).Return("discard many output")
+
+	result := pi.DiscardMany([]int{1, 3})
+	assert.Equal(t, "discard many output", result)
+	mg.AssertCalled(t, "DiscardCards", []int{1, 3})
+}
+
 func TestPineappleInteractor_Discard_Error(t *testing.T) {
 	mg := new(interfaces.MockPineappleGame)
 	mp := new(presenter.MockPineapplePresenter)


### PR DESCRIPTION
## 概要

アイリッシュポーカーは 4 枚のホールカードから 2 枚を捨てるが、ディスカード UI が単一選択（`selectedDiscard: number | null`）前提で、2 枚同時選択ができなかった。バックエンドに複数枚一括ディスカードを追加し、フロントを複数選択に対応させる。

## 変更点（バックエンド）

- `internal/domain/Pineapple.go`: `DiscardCards([]int)` を追加（インデックスの範囲・重複検証、高い順に除去してズレ防止、≤2枚で discardDone）。`DiscardCard` は `DiscardCards([]int{idx})` の薄いラッパに
- `internal/usecase/PineappleInteractor.go` (+IF): `DiscardMany([]int) string`
- `internal/domain/interfaces/pineapple.go` (+mock), `internal/adapter/controller/usecase/PineappleInteractor_mock.go`: 新メソッドを追加
- `internal/adapter/controller/PineappleWebController.go`: 入力に `cardIdxs []int` を追加し、存在すれば `DiscardMany`、なければ従来の単一 `Discard`

## 変更点（フロントエンド）

- `frontend/src/pages/PineapplePage.tsx`: `selectedDiscard: number|null` → `selectedDiscards: number[]`。`discardCount = max(1, initialDealCount-2)`（Irish=2, Pineapple/Crazy=1）まで選択可能・キャップ。Irish では `N/2 選択済み` バッジを表示。確定で `{ cardIdxs }` を一括送信。1枚バリアントは従来通り動作
- `frontend/src/i18n/locales/{ja,en}/irishpoker.json`: `discard.selectedCount` を追加

## テスト

- Go: `TestPineapple_DiscardCards`（2枚一括/重複拒否/範囲外拒否/空拒否/DiscardCard委譲）
- Frontend: Irish の2枚選択→一括 `cardIdxs` 送信、2枚キャップ、Pineapple/Crazy の単一動作（pineapple-family 19 passed）

## 受け入れ条件

- [x] `irishpoker` で 2 枚選択が可能
- [x] `pineapple`/`crazypineapple` は従来通り 1 枚選択
- [x] 選択枚数バッジ表示（Irish）
- [x] `IrishPokerPage.test.tsx` にテスト追加
- [x] `bun run test` + `biome check` + `go vet` 通過。`internal/domain` テストはローカル OOM のため CI 検証

Closes #2176