### PR TITLE
docs: fix stale game-count claims and add CI drift guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ go_trumpcardsが目指す未来は、**あらゆる人がクリエイターと�
 
 ## Features
 
-Go + Clean Architecture で実装した126種類のトランプゲーム。CLI と Web GUI（React + Go REST API）の2つのインターフェースで遊べます。Web GUI は日英多言語対応。
+Go + Clean Architecture で実装した132種類のトランプゲーム。CLI と Web GUI（React + Go REST API）の2つのインターフェースで遊べます。Web GUI は日英多言語対応。
 
 | ゲーム | コマンド | マニュアル |
 |--------|----------|------------|

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -30,7 +30,7 @@ Shared building blocks:
 | `useGameApi(apiFn, opts)` | Server-state management with loading / error / retry |
 | `GamePageShell` | Background + heading + phase indicator + reset dialog wrapper (most pages use this) |
 | `TutorialWrapper` | Tutorial provider + i18n init (always wraps the exported `XPage`) |
-| `useCliMode` + `useCliGame` + `<CliTerminal>` + `<CliToggle>` | CLI fallback mode, available on most pages (~112). Per-game parsing/formatting lives in `src/utils/cli/commands/<game>Commands.ts` + `src/utils/cli/formatters/<game>Formatter.ts` |
+| `useCliMode` + `useCliGame` + `<CliTerminal>` + `<CliToggle>` | CLI fallback mode, available on most pages (~127). Per-game parsing/formatting lives in `src/utils/cli/commands/<game>Commands.ts` + `src/utils/cli/formatters/<game>Formatter.ts` |
 
 ## Package Manager Rule
 
@@ -130,7 +130,7 @@ bun run build && bun run check && bun run test
 | `TutorialProvider` | `src/providers/TutorialProvider.tsx` | Context provider; renders overlay (used internally by TutorialWrapper) |
 | `TutorialOverlay` | `src/components/tutorial/TutorialOverlay.tsx` | Full-screen overlay with SVG mask spotlight |
 | `useTutorial` | `src/hooks/useTutorial.ts` | State management (step progression, localStorage, resume/restart) |
-| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers ~all games, currently 124). The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
+| `useGameHint` | `src/hooks/useGameHint.ts` | Frontend hints; registry-driven via `hintFactories` (covers ~all games, currently 125). The supported set is the `HintGameName` union (`keyof typeof hintFactories`) — add a game by registering its factory there |
 | `TutorialSuggestDialog` | `src/components/tutorial/TutorialSuggestDialog.tsx` | First-visit dialog; controlled by `useFirstVisit` hook |
 | `TutorialProgressPanel` | `src/components/tutorial/TutorialProgressPanel.tsx` | Progress overview in NavBar |
 

--- a/frontend/src/hooks/useGameHint.docCount.test.ts
+++ b/frontend/src/hooks/useGameHint.docCount.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Raw-source imports via Vite's `?raw` glob — mirrors the approach in
+ * `src/i18n/namespaceDiscipline.test.ts` to scan source/doc text without
+ * pulling in `node:fs` / `__dirname` (which `tsc` rejects under the current
+ * types config).
+ */
+const hintSource = Object.values(
+  import.meta.glob<string>('./useGameHint.ts', {
+    query: '?raw',
+    import: 'default',
+    eager: true,
+  }),
+)[0];
+
+const claudeDoc = Object.values(
+  import.meta.glob<string>('../../CLAUDE.md', {
+    query: '?raw',
+    import: 'default',
+    eager: true,
+  }),
+)[0];
+
+/**
+ * Count the entries in the `hintFactories` registry object. The block is flat
+ * (one `name: (s) => …,` per line), delimited by `const hintFactories = {`
+ * and `} satisfies Record<string, HintFn>;`.
+ */
+function countHintFactories(src: string): number {
+  const start = src.indexOf('const hintFactories = {');
+  const end = src.indexOf('} satisfies Record<string, HintFn>;', start);
+  if (start === -1 || end === -1) {
+    throw new Error('hintFactories block not found in useGameHint.ts — update useGameHint.docCount.test.ts');
+  }
+  const block = src.slice(start, end);
+  // Each entry begins a line with `  <name>: (` — the start of its arrow fn.
+  const matches = block.match(/^\s+[A-Za-z0-9]+:\s*\(/gm);
+  return matches ? matches.length : 0;
+}
+
+describe('frontend/CLAUDE.md hint-count claim', () => {
+  // The `useGameHint` row in frontend/CLAUDE.md hard-codes the number of
+  // registered hint factories ("currently N"). It drifts whenever a hint is
+  // added (see issue #2474, where it still said 124 after the registry reached
+  // 125). This test fails CI the moment the doc and the registry diverge.
+  it('matches the actual hintFactories entry count', () => {
+    const actual = countHintFactories(hintSource);
+    const m = claudeDoc.match(/hintFactories`[^)]*currently (\d+)\)/);
+    expect(
+      m,
+      'could not find the "currently N" hint count in frontend/CLAUDE.md — update the regex if the wording moved',
+    ).not.toBeNull();
+    const documented = Number(m?.[1]);
+    expect(
+      documented,
+      `frontend/CLAUDE.md says ${documented} hint factories, but useGameHint.ts has ${actual} — update the doc`,
+    ).toBe(actual);
+  });
+});

--- a/internal/infrastructure/games/docs_consistency_test.go
+++ b/internal/infrastructure/games/docs_consistency_test.go
@@ -1,0 +1,102 @@
+package games_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/games"
+)
+
+// repoRoot is the module root relative to this test's working directory
+// (the package dir internal/infrastructure/games).
+const repoRoot = "../../.."
+
+// readDocNumber reads the file at path (relative to repoRoot), applies re —
+// which must capture exactly one numeric group — and returns the captured
+// integer. A missing match fails loudly so a reworded sentence surfaces here
+// (update the regex) rather than silently skipping the assertion.
+func readDocNumber(t *testing.T, path string, re *regexp.Regexp) int {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(repoRoot, path))
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	m := re.FindSubmatch(data)
+	if m == nil {
+		t.Fatalf("%s: pattern %q not found — did the wording change? update the regex in docs_consistency_test.go", path, re)
+	}
+	n, err := strconv.Atoi(string(m[1]))
+	if err != nil {
+		t.Fatalf("%s: matched %q is not an integer: %v", path, m[1], err)
+	}
+	return n
+}
+
+// TestDocGameCountsMatchRegistry guards the hand-maintained game-count numbers
+// in README.md and CLAUDE.md against the registry single source of truth.
+// These prose counts drift on every new game (see issue #2474, where README
+// still said 126 after the registry reached 132); this test fails CI the
+// moment they fall out of sync instead of waiting for a manual drift sweep.
+func TestDocGameCountsMatchRegistry(t *testing.T) {
+	total := len(games.All())
+
+	cases := []struct {
+		name string
+		path string
+		re   *regexp.Regexp
+	}{
+		{"README.md Features prose", "README.md", regexp.MustCompile(`実装した(\d+)種類`)},
+		{"CLAUDE.md intro line", "CLAUDE.md", regexp.MustCompile(`Go implementations of (\d+) trump card game`)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := readDocNumber(t, c.path, c.re); got != total {
+				t.Errorf("%s says %d games, registry has %d — update the doc (or the regex if the wording moved)", c.name, got, total)
+			}
+		})
+	}
+}
+
+// TestPerGameManualsMatchRegistry asserts a strict 1:1 mapping between
+// registered games and the per-game manuals under docs/manual/{cui,web}. It
+// catches both a missing manual for a freshly added game and an orphan manual
+// left behind by a rename or removal. Template files live at
+// docs/manual/{cui,web}_template.md (outside these dirs) and are not counted.
+func TestPerGameManualsMatchRegistry(t *testing.T) {
+	all := games.All()
+	names := make(map[string]bool, len(all))
+	for _, g := range all {
+		names[g.Name] = true
+	}
+
+	for _, dir := range []string{"docs/manual/cui", "docs/manual/web"} {
+		t.Run(dir, func(t *testing.T) {
+			// Every registered game must have a manual in this dir.
+			for _, g := range all {
+				p := filepath.Join(repoRoot, dir, g.Name+".md")
+				if _, err := os.Stat(p); err != nil {
+					t.Errorf("missing manual %s/%s.md for registered game %q", dir, g.Name, g.Name)
+				}
+			}
+			// No orphan manuals: every <name>.md must map to a registered game.
+			entries, err := os.ReadDir(filepath.Join(repoRoot, dir))
+			if err != nil {
+				t.Fatalf("read dir %s: %v", dir, err)
+			}
+			for _, e := range entries {
+				name, ok := strings.CutSuffix(e.Name(), ".md")
+				if !ok {
+					t.Errorf("%s/%s is not a .md manual file", dir, e.Name())
+					continue
+				}
+				if !names[name] {
+					t.Errorf("orphan manual %s/%s.md has no matching game in the registry", dir, name)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to the `/doc-drift-check` sweep in #2474. Fixes the hand-maintained count numbers that had drifted from the registry SSoT (132 games), and adds tests so they can't silently rot again — wired into the **existing** Backend Tests / Frontend Tests jobs (no new workflow steps).

### Doc fixes
- `README.md` — Features intro `126種類` → `132種類` (the game table below it was already correct)
- `frontend/CLAUDE.md` — CLI fallback `(~112)` → `(~127)` pages; `useGameHint` `currently 124` → `125`

### New CI guards
- **`internal/infrastructure/games/docs_consistency_test.go`** (Backend Tests)
  - `TestDocGameCountsMatchRegistry` — README.md / CLAUDE.md prose counts must equal `len(games.All())`
  - `TestPerGameManualsMatchRegistry` — strict 1:1 between registered games and `docs/manual/{cui,web}/<name>.md`; fails on a **missing** manual (new game) or an **orphan** (rename/removal). Templates at `docs/manual/*_template.md` are outside these dirs and not counted.
- **`frontend/src/hooks/useGameHint.docCount.test.ts`** (Frontend Tests)
  - asserts `frontend/CLAUDE.md`'s `hintFactories ... currently N` equals the actual key count parsed from `useGameHint.ts`, using the repo's `import.meta.glob('?raw')` pattern (tsc rejects `node:fs`)

### Deliberately not pinned
The CLI `~127` figure is written as an explicit approximation (`~`, "most pages"), so a hard-equality test would fight the doc's intent. The two precise claims and the game/manual counts — the things that drift on every new game — are now guarded.

## Test plan
- [x] `go test -tags test ./internal/infrastructure/games/...` — all pass (scoped run)
- [x] `cd frontend && bun run test -- --run src/hooks/useGameHint.docCount.test.ts` — pass
- [x] `goimports -l` clean, `golangci-lint run ./internal/infrastructure/games/...` 0 issues
- [x] `biome check` clean on the new frontend test
- [ ] Full CI green

Closes #2474

🤖 Generated with [Claude Code](https://claude.com/claude-code)