### PR TITLE
fix(solitaire): gate give-up behind confirm dialog across remaining pages (#2099)

### DIFF
--- a/frontend/e2e/accordion.spec.ts
+++ b/frontend/e2e/accordion.spec.ts
@@ -27,6 +27,9 @@ test.describe('Accordion E2E', () => {
 
     await page.getByRole('button', { name: 'ギブアップ' }).first().click();
 
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
+
     // After giveup, the action log button should appear (end phase shows "棋譜")
     const logButton = page.getByRole('button', { name: /棋譜|action log|アクション/i });
     await expect(logButton.first()).toBeVisible({ timeout: TIMEOUT_TRANSITION });

--- a/frontend/e2e/acesup.spec.ts
+++ b/frontend/e2e/acesup.spec.ts
@@ -43,6 +43,9 @@ test.describe('Aces Up E2E', () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' });
     await expect(giveUpButton).toBeVisible();
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // After give up, playing buttons should not be visible

--- a/frontend/e2e/bakersdozen.spec.ts
+++ b/frontend/e2e/bakersdozen.spec.ts
@@ -30,6 +30,9 @@ test.describe("Baker's Dozen E2E", () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' });
     await expect(giveUpButton).toBeVisible();
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // After give up, playing buttons should not be visible

--- a/frontend/e2e/beleagueredcastle.spec.ts
+++ b/frontend/e2e/beleagueredcastle.spec.ts
@@ -26,6 +26,9 @@ test.describe('Beleaguered Castle E2E', () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' });
     await expect(giveUpButton).toBeVisible();
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     await expect(page.getByRole('button', { name: 'ヒント' })).not.toBeVisible();

--- a/frontend/e2e/calculation.spec.ts
+++ b/frontend/e2e/calculation.spec.ts
@@ -28,6 +28,9 @@ test.describe('Calculation E2E', () => {
 
     await page.getByRole('button', { name: 'ギブアップ' }).first().click();
 
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
+
     // After giveup, the action log button should appear
     const logButton = page.getByRole('button', { name: /棋譜|action log|アクション/i });
     await expect(logButton.first()).toBeVisible({ timeout: TIMEOUT_TRANSITION });

--- a/frontend/e2e/crescent.spec.ts
+++ b/frontend/e2e/crescent.spec.ts
@@ -35,6 +35,9 @@ test.describe('Crescent Solitaire E2E', () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' });
     await expect(giveUpButton).toBeVisible();
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     await expect(page.getByRole('button', { name: 'ヒント' })).not.toBeVisible();

--- a/frontend/e2e/cruel.spec.ts
+++ b/frontend/e2e/cruel.spec.ts
@@ -33,6 +33,9 @@ test.describe('Cruel E2E', () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' }).first();
     await expect(giveUpButton).toBeVisible({ timeout: TIMEOUT_TRANSITION });
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
     await expect(page.getByText('ゲームオーバー').first()).toBeVisible({ timeout: TIMEOUT_TRANSITION });
   });
 });

--- a/frontend/e2e/easthaven.spec.ts
+++ b/frontend/e2e/easthaven.spec.ts
@@ -30,6 +30,9 @@ test.describe('Easthaven E2E', () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' }).first();
     await expect(giveUpButton).toBeVisible({ timeout: TIMEOUT_TRANSITION });
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
     await expect(page.getByText('ゲームオーバー').first()).toBeVisible({ timeout: TIMEOUT_TRANSITION });
   });
 });

--- a/frontend/e2e/eightoff.spec.ts
+++ b/frontend/e2e/eightoff.spec.ts
@@ -37,6 +37,9 @@ test.describe('Eight Off E2E', () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' });
     await expect(giveUpButton).toBeVisible();
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     await expect(page.getByRole('button', { name: 'ヒント' })).not.toBeVisible();

--- a/frontend/e2e/fortythieves.spec.ts
+++ b/frontend/e2e/fortythieves.spec.ts
@@ -47,6 +47,9 @@ test.describe('Forty Thieves E2E', () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' });
     await expect(giveUpButton).toBeVisible();
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // After give up, playing buttons should not be visible

--- a/frontend/e2e/gaps.spec.ts
+++ b/frontend/e2e/gaps.spec.ts
@@ -38,6 +38,9 @@ test.describe('Gaps E2E', () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' });
     await expect(giveUpButton).toBeVisible();
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
     await expect(page.getByRole('button', { name: 'ヒント' })).not.toBeVisible();
   });

--- a/frontend/e2e/golf.spec.ts
+++ b/frontend/e2e/golf.spec.ts
@@ -47,6 +47,9 @@ test.describe('Golf Solitaire E2E', () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' });
     await expect(giveUpButton).toBeVisible();
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // After give up, playing buttons should not be visible

--- a/frontend/e2e/penguin.spec.ts
+++ b/frontend/e2e/penguin.spec.ts
@@ -37,6 +37,9 @@ test.describe('Penguin E2E', () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' });
     await expect(giveUpButton).toBeVisible();
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     await expect(page.getByRole('button', { name: 'ヒント' })).not.toBeVisible();

--- a/frontend/e2e/pokersquares.spec.ts
+++ b/frontend/e2e/pokersquares.spec.ts
@@ -34,6 +34,9 @@ test.describe('Poker Squares E2E', () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' });
     await expect(giveUpButton).toBeVisible({ timeout: TIMEOUT_TRANSITION });
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // After give up, playing buttons should not be visible

--- a/frontend/e2e/pyramid.spec.ts
+++ b/frontend/e2e/pyramid.spec.ts
@@ -47,6 +47,9 @@ test.describe('Pyramid E2E', () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' });
     await expect(giveUpButton).toBeVisible();
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // After give up, playing buttons should not be visible

--- a/frontend/e2e/russiansolitaire.spec.ts
+++ b/frontend/e2e/russiansolitaire.spec.ts
@@ -22,6 +22,9 @@ test.describe('Russian Solitaire E2E', () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' }).first();
     await expect(giveUpButton).toBeVisible({ timeout: TIMEOUT_TRANSITION });
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
     await expect(page.getByText('ゲームオーバー').first()).toBeVisible({ timeout: TIMEOUT_TRANSITION });
   });
 });

--- a/frontend/e2e/scorpion.spec.ts
+++ b/frontend/e2e/scorpion.spec.ts
@@ -32,6 +32,9 @@ test.describe('Scorpion E2E', () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' }).first();
     await expect(giveUpButton).toBeVisible({ timeout: TIMEOUT_TRANSITION });
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
     await expect(page.getByText('ゲームオーバー').first()).toBeVisible({ timeout: TIMEOUT_TRANSITION });
   });
 });

--- a/frontend/e2e/seahaventowers.spec.ts
+++ b/frontend/e2e/seahaventowers.spec.ts
@@ -38,6 +38,9 @@ test.describe('Seahaven Towers E2E', () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' });
     await expect(giveUpButton).toBeVisible();
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // After give up, playing buttons should not be visible

--- a/frontend/e2e/spider.spec.ts
+++ b/frontend/e2e/spider.spec.ts
@@ -35,6 +35,9 @@ test.describe('Spider E2E', () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' });
     await expect(giveUpButton).toBeVisible();
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // After give up, playing buttons should not be visible

--- a/frontend/e2e/spiderette.spec.ts
+++ b/frontend/e2e/spiderette.spec.ts
@@ -28,6 +28,9 @@ test.describe('Spiderette E2E', () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' });
     await expect(giveUpButton).toBeVisible();
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // After give up, the playing buttons should be gone

--- a/frontend/e2e/tripeaks.spec.ts
+++ b/frontend/e2e/tripeaks.spec.ts
@@ -47,6 +47,9 @@ test.describe('TriPeaks E2E', () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' });
     await expect(giveUpButton).toBeVisible();
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // After give up, playing buttons should not be visible

--- a/frontend/e2e/wasp.spec.ts
+++ b/frontend/e2e/wasp.spec.ts
@@ -32,6 +32,9 @@ test.describe('Wasp E2E', () => {
     const giveUpButton = page.getByRole('button', { name: 'ギブアップ' }).first();
     await expect(giveUpButton).toBeVisible({ timeout: TIMEOUT_TRANSITION });
     await giveUpButton.click();
+
+    // Confirm the give-up in the dialog (#2099).
+    await page.getByRole('button', { name: '確認' }).click();
     await expect(page.getByText('ゲームオーバー').first()).toBeVisible({ timeout: TIMEOUT_TRANSITION });
   });
 });

--- a/frontend/src/pages/AccordionPage.test.tsx
+++ b/frontend/src/pages/AccordionPage.test.tsx
@@ -106,10 +106,14 @@ describe('AccordionPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
   });
 
-  it('giveup button triggers giveup command', async () => {
+  it('giveup button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<AccordionPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    screen.getByRole('button', { name: 'ギブアップ' }).click();
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/AccordionPage.tsx
+++ b/frontend/src/pages/AccordionPage.tsx
@@ -110,8 +110,21 @@ function formatAccordionState(state: AccordionResponse): string {
 export const AccordionPage = withTutorial(AccordionPageContent, 'accordion', AC_TUTORIAL_STEPS);
 /** Inner content of the Accordion page. */
 function AccordionPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('accordion');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('accordion');
   const { playSound } = useSound();
   const {
     state,
@@ -165,6 +178,13 @@ function AccordionPageContent() {
   const handleGiveUp = useCallback(() => {
     void apiCall('giveup');
   }, [apiCall]);
+
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
 
   const handleHint = useCallback(() => {
     void apiCall('hint');
@@ -246,10 +266,10 @@ function AccordionPageContent() {
       { key: '3', action: () => mergeFromSelection(3) },
       { key: 'u', action: handleUndo },
       { key: 'h', action: handleHint },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'Escape', action: () => setSelectedIdx(null) },
     ],
-    [moveSelection, mergeFromSelection, handleUndo, handleHint, handleGiveUp],
+    [moveSelection, mergeFromSelection, handleUndo, handleHint, confirmGiveUpAction],
   );
   useActionKeyboardNav({
     bindings: accordionBindings,
@@ -278,6 +298,9 @@ function AccordionPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -427,7 +450,7 @@ function AccordionPageContent() {
                   >
                     {t('undo')}
                   </button>
-                  <button type="button" className={btnDanger} onClick={handleGiveUp} disabled={loading}>
+                  <button type="button" className={btnDanger} onClick={confirmGiveUpAction} disabled={loading}>
                     {t('giveup')}
                   </button>
                   {state.isStalemate && (

--- a/frontend/src/pages/AcesUpPage.test.tsx
+++ b/frontend/src/pages/AcesUpPage.test.tsx
@@ -161,14 +161,16 @@ describe('AcesUpPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('move', 1));
   });
 
-  it('clicking giveup button dispatches giveup', async () => {
+  it('clicking giveup button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<AcesUpPage />);
     await waitFor(() => expect(screen.getByText(/山札/)).toBeInTheDocument());
 
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
-
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/AcesUpPage.tsx
+++ b/frontend/src/pages/AcesUpPage.tsx
@@ -68,8 +68,21 @@ const COL_COUNT = 4;
 export const AcesUpPage = withTutorial(AcesUpPageContent, 'acesup', ACESUP_TUTORIAL_STEPS);
 /** Inner content of the Aces Up page, wrapped by TutorialProvider. */
 function AcesUpPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('acesup');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('acesup');
   const { playSound } = useSound();
   const {
     state,
@@ -104,21 +117,29 @@ function AcesUpPageContent() {
   const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
   const isPlayingForKbd = state?.phase === AcesUpPhase.PLAYING;
-  const actionBindings = useMemo(
-    () => [
-      { key: 'd', action: handleDraw },
-      { key: 'h', action: handleHint },
-      { key: 'g', action: handleGiveUp },
-      { key: 'z', action: handleUndo },
-    ],
-    [handleDraw, handleHint, handleGiveUp, handleUndo],
-  );
-  useActionKeyboardNav({ bindings: actionBindings, enabled: !!isPlayingForKbd && !loading });
 
   const handleManualReset = useCallback(() => {
     hideActionLog();
     handleReset();
   }, [handleReset, hideActionLog]);
+
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
+  const actionBindings = useMemo(
+    () => [
+      { key: 'd', action: handleDraw },
+      { key: 'h', action: handleHint },
+      { key: 'g', action: confirmGiveUpAction },
+      { key: 'z', action: handleUndo },
+    ],
+    [handleDraw, handleHint, confirmGiveUpAction, handleUndo],
+  );
+  useActionKeyboardNav({ bindings: actionBindings, enabled: !!isPlayingForKbd && !loading });
 
   // Drag a movable top card onto an empty column to move it (the "Move [n]" buttons
   // remain as keyboard/tap-friendly fallbacks; D&D is additive, never required).
@@ -154,6 +175,9 @@ function AcesUpPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -339,7 +363,7 @@ function AcesUpPageContent() {
                   <button type="button" className={btnSuccess} onClick={handleHint} disabled={loading}>
                     {t('hint')}
                   </button>
-                  <button type="button" className={btnDanger} onClick={handleGiveUp} disabled={loading}>
+                  <button type="button" className={btnDanger} onClick={confirmGiveUpAction} disabled={loading}>
                     {t('giveup')}
                   </button>
                 </div>

--- a/frontend/src/pages/BakersDozenPage.test.tsx
+++ b/frontend/src/pages/BakersDozenPage.test.tsx
@@ -137,6 +137,19 @@ describe('BakersDozenPage', () => {
     await waitFor(() => expect(screen.queryByRole('button', { name: 'ギブアップ' })).not.toBeInTheDocument());
   });
 
+  it('giveup button opens a confirm dialog and only dispatches giveup after confirm', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<BakersDozenPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(gameOverState);
+    fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
+  });
+
   it('shows phase name in header for game over', async () => {
     mockExec.mockResolvedValue(gameOverState);
     renderWithProviders(<BakersDozenPage />);

--- a/frontend/src/pages/BakersDozenPage.tsx
+++ b/frontend/src/pages/BakersDozenPage.tsx
@@ -75,8 +75,21 @@ function formatHintZone(t: (key: string, opts?: Record<string, unknown>) => stri
 
 /** Inner content of the Baker's Dozen page, wrapped by TutorialProvider. */
 function BakersDozenPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('bakersdozen');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('bakersdozen');
   const { playSound } = useSound();
   const {
     state,
@@ -167,14 +180,21 @@ function BakersDozenPageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const actionBindings = useMemo(
     () => [
       { key: 'h', action: handleHint },
       { key: 'a', action: handleAutoComplete },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: handleUndo },
     ],
-    [handleHint, handleAutoComplete, handleGiveUp, handleUndo],
+    [handleHint, handleAutoComplete, confirmGiveUpAction, handleUndo],
   );
 
   useActionKeyboardNav({
@@ -208,6 +228,9 @@ function BakersDozenPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span className="text-sm text-ds-text-muted">
@@ -467,7 +490,7 @@ function BakersDozenPageContent() {
                   <button
                     type="button"
                     className={btnDanger}
-                    onClick={handleGiveUp}
+                    onClick={confirmGiveUpAction}
                     disabled={loading || isAutoCompleting}
                   >
                     {t('giveup')}

--- a/frontend/src/pages/BakersGamePage.test.tsx
+++ b/frontend/src/pages/BakersGamePage.test.tsx
@@ -196,14 +196,16 @@ describe('BakersGamePage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
   });
 
-  it('handleGiveUp called on giveup button click', async () => {
+  it('handleGiveUp called on giveup button click after confirm', async () => {
     renderWithProviders(<BakersGamePage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());
 
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
-
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 
@@ -370,13 +372,16 @@ describe('BakersGamePage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
   });
 
-  it('pressing g triggers giveup in PLAYING phase', async () => {
+  it('pressing g opens the give up confirm dialog in PLAYING phase', async () => {
     renderWithProviders(<BakersGamePage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());
 
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.keyDown(document, { key: 'g' });
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/BakersGamePage.tsx
+++ b/frontend/src/pages/BakersGamePage.tsx
@@ -75,8 +75,21 @@ const BG_TUTORIAL_STEPS: TutorialStep[] = [
 export const BakersGamePage = withTutorial(BakersGamePageContent, 'bakersgame', BG_TUTORIAL_STEPS);
 /** Inner content of the Baker's Game page, wrapped by TutorialProvider. */
 function BakersGamePageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('bakersgame');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('bakersgame');
   const { playSound } = useSound();
   const {
     state,
@@ -135,14 +148,21 @@ function BakersGamePageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const actionBindings = useMemo(
     () => [
       { key: 'h', action: handleHint },
       { key: 'a', action: handleAutoComplete },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: handleUndo },
     ],
-    [handleHint, handleAutoComplete, handleGiveUp, handleUndo],
+    [handleHint, handleAutoComplete, confirmGiveUpAction, handleUndo],
   );
 
   useActionKeyboardNav({
@@ -188,6 +208,9 @@ function BakersGamePageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -519,7 +542,7 @@ function BakersGamePageContent() {
                   <button
                     type="button"
                     className={btnDanger}
-                    onClick={handleGiveUp}
+                    onClick={confirmGiveUpAction}
                     disabled={loading || isAutoCompleting}
                   >
                     {t('giveup')}

--- a/frontend/src/pages/BeleagueredCastlePage.test.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.test.tsx
@@ -102,6 +102,19 @@ describe('BeleagueredCastlePage', () => {
     await waitFor(() => expect(screen.queryByRole('button', { name: 'ギブアップ' })).not.toBeInTheDocument());
   });
 
+  it('giveup button opens a confirm dialog and only dispatches giveup after confirm', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<BeleagueredCastlePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(gameOverState);
+    fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
+  });
+
   it('shows phase name in header for game over', async () => {
     mockExec.mockResolvedValue(gameOverState);
     renderWithProviders(<BeleagueredCastlePage />);

--- a/frontend/src/pages/BeleagueredCastlePage.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.tsx
@@ -73,8 +73,21 @@ function formatHintZone(t: (key: string, opts?: Record<string, unknown>) => stri
 }
 
 function BeleagueredCastlePageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('beleagueredcastle');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('beleagueredcastle');
   const { playSound } = useSound();
   const game = useBeleagueredCastleGame();
   const { state, loading, error, retry, hintError, selectedSource, hint, isAutoCompleting } = game;
@@ -136,14 +149,18 @@ function BeleagueredCastlePageContent() {
     game.handleReset();
   }, [game, hideActionLog]);
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(() => requestGiveUpConfirm(game.handleGiveUp), [requestGiveUpConfirm, game]);
+
   const actionBindings = useMemo(
     () => [
       { key: 'h', action: game.handleHint },
       { key: 'a', action: game.handleAutoComplete },
-      { key: 'g', action: game.handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: game.handleUndo },
     ],
-    [game],
+    [game, confirmGiveUpAction],
   );
 
   useActionKeyboardNav({
@@ -255,6 +272,9 @@ function BeleagueredCastlePageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span className="text-sm text-ds-text-muted">
@@ -413,7 +433,7 @@ function BeleagueredCastlePageContent() {
                   <button
                     type="button"
                     className={btnDanger}
-                    onClick={game.handleGiveUp}
+                    onClick={confirmGiveUpAction}
                     disabled={loading || isAutoCompleting}
                   >
                     {t('giveup')}

--- a/frontend/src/pages/BeleagueredCastlePage.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.tsx
@@ -151,7 +151,10 @@ function BeleagueredCastlePageContent() {
 
   // Give-up is irreversible, so route both the button and the `g` key through
   // the confirm dialog — matching reset's guard (issue #2099).
-  const confirmGiveUpAction = useCallback(() => requestGiveUpConfirm(game.handleGiveUp), [requestGiveUpConfirm, game]);
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(game.handleGiveUp),
+    [requestGiveUpConfirm, game.handleGiveUp],
+  );
 
   const actionBindings = useMemo(
     () => [

--- a/frontend/src/pages/BristolPage.test.tsx
+++ b/frontend/src/pages/BristolPage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { bristolApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -147,10 +147,14 @@ describe('BristolPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
   });
 
-  it('giveup button triggers giveup command', async () => {
+  it('giveup button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<BristolPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    screen.getByRole('button', { name: 'ギブアップ' }).click();
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/BristolPage.tsx
+++ b/frontend/src/pages/BristolPage.tsx
@@ -60,8 +60,21 @@ export const BristolPage = withTutorial(BristolPageContent, 'bristol', BR_TUTORI
 
 /** Inner content of the Bristol page. */
 function BristolPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('bristol');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('bristol');
   const { state, loading, error, exec: execApi, retry } = useGameApi(bristolApi.exec);
   const { cardWidth, cardHeight } = useCardDimensions();
   const {
@@ -92,6 +105,13 @@ function BristolPageContent() {
   }, [execApi]);
   const handleDraw = useCallback(() => execApi('draw'), [execApi]);
   const handleGiveUp = useCallback(() => execApi('giveup'), [execApi]);
+
+  // Give-up is irreversible, so route the button through the confirm dialog —
+  // matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
   const handleHint = useCallback(() => execApi('hint'), [execApi]);
   const handleAutoComplete = useCallback(() => execApi('autocomplete'), [execApi]);
   const handleUndo = useCallback(() => execApi('undo'), [execApi]);
@@ -163,6 +183,9 @@ function BristolPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span className="text-sm text-ds-text-muted">
@@ -393,7 +416,7 @@ function BristolPageContent() {
                   <button
                     type="button"
                     className={`${btnDanger} ${focusRingWhite}`}
-                    onClick={handleGiveUp}
+                    onClick={confirmGiveUpAction}
                     disabled={loading}
                   >
                     {t('giveup')}

--- a/frontend/src/pages/CalculationPage.test.tsx
+++ b/frontend/src/pages/CalculationPage.test.tsx
@@ -84,10 +84,16 @@ describe('CalculationPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
   });
 
-  it('giveup button triggers giveup command', async () => {
+  it('giveup button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<CalculationPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    screen.getByRole('button', { name: 'ギブアップ' }).click();
+    mockExec.mockClear();
+    // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
+    fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    // Confirming dispatches giveup.
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/CalculationPage.tsx
+++ b/frontend/src/pages/CalculationPage.tsx
@@ -185,8 +185,21 @@ function formatCalculationState(state: CalculationResponse): string {
 
 export const CalculationPage = withTutorial(CalculationPageContent, 'calculation', CA_TUTORIAL_STEPS);
 function CalculationPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('calculation');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('calculation');
   const { playSound } = useSound();
   const {
     state,
@@ -240,6 +253,13 @@ function CalculationPageContent() {
     void runApi('giveup');
     setSource(null);
   }, [runApi]);
+
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
 
   const handleHint = useCallback(() => {
     void runApi('hint');
@@ -337,6 +357,9 @@ function CalculationPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -587,7 +610,7 @@ function CalculationPageContent() {
                   >
                     {t('autoComplete')}
                   </button>
-                  <button type="button" className={btnDanger} onClick={handleGiveUp} disabled={loading}>
+                  <button type="button" className={btnDanger} onClick={confirmGiveUpAction} disabled={loading}>
                     {t('giveup')}
                   </button>
                   {state.isStalemate && (

--- a/frontend/src/pages/CanfieldPage.test.tsx
+++ b/frontend/src/pages/CanfieldPage.test.tsx
@@ -137,11 +137,16 @@ describe('CanfieldPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
   });
 
-  it('giveup button triggers giveup command', async () => {
+  it('giveup button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<CanfieldPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    const btn = screen.getByRole('button', { name: 'ギブアップ' });
-    btn.click();
+    mockExec.mockClear();
+    // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
+    fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    // Confirming dispatches giveup.
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/CanfieldPage.tsx
+++ b/frontend/src/pages/CanfieldPage.tsx
@@ -66,8 +66,21 @@ const CF_TUTORIAL_STEPS: TutorialStep[] = [
 export const CanfieldPage = withTutorial(CanfieldPageContent, 'canfield', CF_TUTORIAL_STEPS);
 /** Inner content of the Canfield page. */
 function CanfieldPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('canfield');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('canfield');
   const { state, loading, error, exec: execApi, retry } = useGameApi(canfieldApi.exec);
   const { cardWidth, cardHeight } = useCardDimensions();
   const {
@@ -97,6 +110,13 @@ function CanfieldPageContent() {
   const handleReset = useCallback(() => execApi('reset'), [execApi]);
   const handleDraw = useCallback(() => execApi('draw'), [execApi]);
   const handleGiveUp = useCallback(() => execApi('giveup'), [execApi]);
+
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
   const handleHint = useCallback(() => execApi('hint'), [execApi]);
   const handleAutoComplete = useCallback(() => execApi('autocomplete'), [execApi]);
   const handleUndo = useCallback(() => execApi('undo'), [execApi]);
@@ -171,6 +191,9 @@ function CanfieldPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span className="text-sm text-ds-text-muted">
@@ -447,7 +470,7 @@ function CanfieldPageContent() {
                   <button
                     type="button"
                     className={`${btnDanger} ${focusRingWhite}`}
-                    onClick={handleGiveUp}
+                    onClick={confirmGiveUpAction}
                     disabled={loading}
                   >
                     {t('giveup')}

--- a/frontend/src/pages/CrescentPage.test.tsx
+++ b/frontend/src/pages/CrescentPage.test.tsx
@@ -145,12 +145,17 @@ describe('CrescentPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
   });
 
-  it('clicking give up dispatches giveup', async () => {
+  it('give up button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<CrescentPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
+    // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    // Confirming dispatches giveup.
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/CrescentPage.tsx
+++ b/frontend/src/pages/CrescentPage.tsx
@@ -75,8 +75,21 @@ function formatHintZone(t: (key: string, opts?: Record<string, unknown>) => stri
 
 /** Inner content of the Crescent page, wrapped by TutorialProvider. */
 function CrescentPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('crescent');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('crescent');
   const { playSound } = useSound();
   const {
     state,
@@ -143,15 +156,22 @@ function CrescentPageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const actionBindings = useMemo(
     () => [
       { key: 'd', action: handleRedeal },
       { key: 'h', action: handleHint },
       { key: 'a', action: handleAutoComplete },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: handleUndo },
     ],
-    [handleRedeal, handleHint, handleAutoComplete, handleGiveUp, handleUndo],
+    [handleRedeal, handleHint, handleAutoComplete, confirmGiveUpAction, handleUndo],
   );
 
   useActionKeyboardNav({
@@ -186,6 +206,9 @@ function CrescentPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -452,7 +475,7 @@ function CrescentPageContent() {
                   <button
                     type="button"
                     className={btnDanger}
-                    onClick={handleGiveUp}
+                    onClick={confirmGiveUpAction}
                     disabled={loading || isAutoCompleting}
                   >
                     {t('giveup')}

--- a/frontend/src/pages/CruelPage.test.tsx
+++ b/frontend/src/pages/CruelPage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { cruelApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -130,11 +130,16 @@ describe('CruelPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
   });
 
-  it('giveup button fires giveup command', async () => {
+  it('giveup button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<CruelPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    const btn = screen.getByRole('button', { name: 'ギブアップ' });
-    btn.click();
+    mockExec.mockClear();
+    // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
+    fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    // Confirming dispatches giveup.
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/CruelPage.tsx
+++ b/frontend/src/pages/CruelPage.tsx
@@ -151,8 +151,21 @@ function formatCruelState(state: CruelResponse): string {
 export const CruelPage = withTutorial(CruelPageContent, 'cruel', CRUEL_TUTORIAL_STEPS);
 /** Inner content of the Cruel page. */
 function CruelPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('cruel');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('cruel');
   const { playSound } = useSound();
   const {
     state,
@@ -246,6 +259,13 @@ function CruelPageContent() {
     void apiExec('giveup');
   }, [apiExec]);
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const handleHint = useCallback(async () => {
     try {
       const res = await cruelApi.exec('hint');
@@ -299,11 +319,11 @@ function CruelPageContent() {
     () => [
       { key: 'h', action: handleHint },
       { key: 'a', action: handleAutoComplete },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: handleUndo },
       { key: 's', action: handleShift },
     ],
-    [handleHint, handleAutoComplete, handleGiveUp, handleUndo, handleShift],
+    [handleHint, handleAutoComplete, confirmGiveUpAction, handleUndo, handleShift],
   );
 
   useActionKeyboardNav({
@@ -335,6 +355,9 @@ function CruelPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -571,7 +594,7 @@ function CruelPageContent() {
                   >
                     {t('undo')}
                   </button>
-                  <button type="button" className={btnDanger} onClick={handleGiveUp} disabled={loading}>
+                  <button type="button" className={btnDanger} onClick={confirmGiveUpAction} disabled={loading}>
                     {t('giveup')}
                   </button>
                   {state.isStalemate && (

--- a/frontend/src/pages/EasthavenPage.test.tsx
+++ b/frontend/src/pages/EasthavenPage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { easthavenApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -154,10 +154,16 @@ describe('EasthavenPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
   });
 
-  it('giveup button triggers giveup command', async () => {
+  it('giveup button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<EasthavenPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    screen.getByRole('button', { name: 'ギブアップ' }).click();
+    mockExec.mockClear();
+    // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
+    fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    // Confirming dispatches giveup.
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/EasthavenPage.tsx
+++ b/frontend/src/pages/EasthavenPage.tsx
@@ -170,8 +170,21 @@ function formatEasthavenState(state: EasthavenResponse): string {
 export const EasthavenPage = withTutorial(EasthavenPageContent, 'easthaven', EH_TUTORIAL_STEPS);
 /** Inner content of the Easthaven page. */
 function EasthavenPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('easthaven');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('easthaven');
   const { playSound } = useSound();
   const {
     state,
@@ -272,6 +285,13 @@ function EasthavenPageContent() {
     void apiExec('giveup');
   }, [apiExec]);
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const handleHint = useCallback(async () => {
     const res = await easthavenApi.exec('hint');
     setState((prev) => (prev ? { ...prev, hint: res.hint } : prev));
@@ -324,11 +344,11 @@ function EasthavenPageContent() {
     () => [
       { key: 'h', action: handleHint },
       { key: 'a', action: handleAutoComplete },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: handleUndo },
       { key: 'd', action: handleDealGuarded },
     ],
-    [handleHint, handleAutoComplete, handleGiveUp, handleUndo, handleDealGuarded],
+    [handleHint, handleAutoComplete, confirmGiveUpAction, handleUndo, handleDealGuarded],
   );
 
   useActionKeyboardNav({
@@ -364,6 +384,9 @@ function EasthavenPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -632,7 +655,7 @@ function EasthavenPageContent() {
                   >
                     {t('undo')}
                   </button>
-                  <button type="button" className={btnDanger} onClick={handleGiveUp} disabled={loading}>
+                  <button type="button" className={btnDanger} onClick={confirmGiveUpAction} disabled={loading}>
                     {t('giveup')}
                   </button>
                   {state.isStalemate && (

--- a/frontend/src/pages/EightOffPage.test.tsx
+++ b/frontend/src/pages/EightOffPage.test.tsx
@@ -180,14 +180,18 @@ describe('EightOffPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
   });
 
-  it('handleGiveUp called on giveup button click', async () => {
+  it('giveup button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<EightOffPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());
 
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
+    // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
-
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    // Confirming dispatches giveup.
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 
@@ -407,13 +411,16 @@ describe('EightOffPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
   });
 
-  it('pressing g triggers giveup in PLAYING phase', async () => {
+  it('pressing g opens the give up confirm dialog in PLAYING phase', async () => {
     renderWithProviders(<EightOffPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());
 
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.keyDown(document, { key: 'g' });
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/EightOffPage.tsx
+++ b/frontend/src/pages/EightOffPage.tsx
@@ -75,8 +75,21 @@ const EO_TUTORIAL_STEPS: TutorialStep[] = [
 export const EightOffPage = withTutorial(EightOffPageContent, 'eightoff', EO_TUTORIAL_STEPS);
 /** Inner content of the Eight Off page, wrapped by TutorialProvider. */
 function EightOffPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('eightoff');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('eightoff');
   const { playSound } = useSound();
   const {
     state,
@@ -135,14 +148,21 @@ function EightOffPageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const actionBindings = useMemo(
     () => [
       { key: 'h', action: handleHint },
       { key: 'a', action: handleAutoComplete },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: handleUndo },
     ],
-    [handleHint, handleAutoComplete, handleGiveUp, handleUndo],
+    [handleHint, handleAutoComplete, confirmGiveUpAction, handleUndo],
   );
 
   useActionKeyboardNav({
@@ -194,6 +214,9 @@ function EightOffPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -515,7 +538,7 @@ function EightOffPageContent() {
                   <button
                     type="button"
                     className={btnDanger}
-                    onClick={handleGiveUp}
+                    onClick={confirmGiveUpAction}
                     disabled={loading || isAutoCompleting}
                   >
                     {t('giveup')}

--- a/frontend/src/pages/FortyThievesPage.test.tsx
+++ b/frontend/src/pages/FortyThievesPage.test.tsx
@@ -218,14 +218,16 @@ describe('FortyThievesPage', () => {
     expect(screen.getByTestId('autocomplete-button')).toBeDisabled();
   });
 
-  it('clicking give up button dispatches giveup', async () => {
+  it('clicking give up button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<FortyThievesPage />);
     await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
 
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
-
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/FortyThievesPage.tsx
+++ b/frontend/src/pages/FortyThievesPage.tsx
@@ -76,8 +76,21 @@ function formatHintZone(t: (key: string, opts?: Record<string, unknown>) => stri
 
 /** Inner content of the Forty Thieves page, wrapped by TutorialProvider. */
 function FortyThievesPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('fortythieves');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('fortythieves');
   const { playSound } = useSound();
   const {
     state,
@@ -148,15 +161,22 @@ function FortyThievesPageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const actionBindings = useMemo(
     () => [
       { key: 'd', action: handleDraw },
       { key: 'h', action: handleHint },
       { key: 'a', action: handleAutoComplete },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: handleUndo },
     ],
-    [handleDraw, handleHint, handleAutoComplete, handleGiveUp, handleUndo],
+    [handleDraw, handleHint, handleAutoComplete, confirmGiveUpAction, handleUndo],
   );
 
   useActionKeyboardNav({
@@ -194,6 +214,9 @@ function FortyThievesPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -495,7 +518,7 @@ function FortyThievesPageContent() {
                   <button
                     type="button"
                     className={btnDanger}
-                    onClick={handleGiveUp}
+                    onClick={confirmGiveUpAction}
                     disabled={loading || isAutoCompleting}
                   >
                     {t('giveup')}

--- a/frontend/src/pages/GapsPage.test.tsx
+++ b/frontend/src/pages/GapsPage.test.tsx
@@ -116,10 +116,13 @@ describe('GapsPage', () => {
     await waitFor(() => expect(mockedRun).toHaveBeenCalledWith('hint'));
   });
 
-  it('calls run giveup when give up clicked', async () => {
+  it('clicking give up button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<GapsPage />);
     const btn = await screen.findByRole('button', { name: 'ギブアップ' });
     fireEvent.click(btn);
+    expect(mockedRun).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockedRun).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/GapsPage.tsx
+++ b/frontend/src/pages/GapsPage.tsx
@@ -65,8 +65,21 @@ const GAPS_TUTORIAL_STEPS: TutorialStep[] = [
 export const GapsPage = withTutorial(GapsPageContent, 'gaps', GAPS_TUTORIAL_STEPS);
 
 function GapsPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('gaps');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('gaps');
   const apiRun = gapsApi.exec;
   const { state, loading, error, exec: run, retry } = useGameApi(apiRun);
 
@@ -103,6 +116,13 @@ function GapsPageContent() {
     void run('hint');
   }, [run]);
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const dispatchMove = useCallback(
     (source: GapsMoveZone, target: GapsMoveZone) => {
       void run('move', source, target);
@@ -136,6 +156,9 @@ function GapsPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -300,7 +323,7 @@ function GapsPageContent() {
               <button type="button" className={btnSuccess} onClick={handleHint} disabled={loading}>
                 {t('hint')}
               </button>
-              <button type="button" className={btnDanger} onClick={handleGiveUp} disabled={loading}>
+              <button type="button" className={btnDanger} onClick={confirmGiveUpAction} disabled={loading}>
                 {t('giveup')}
               </button>
             </div>

--- a/frontend/src/pages/GolfPage.test.tsx
+++ b/frontend/src/pages/GolfPage.test.tsx
@@ -140,14 +140,16 @@ describe('GolfPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw'));
   });
 
-  it('clicking giveup button dispatches giveup', async () => {
+  it('clicking giveup button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<GolfPage />);
     await waitFor(() => expect(screen.getByText('捨て札')).toBeInTheDocument());
 
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
-
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/GolfPage.tsx
+++ b/frontend/src/pages/GolfPage.tsx
@@ -73,8 +73,21 @@ const GOLF_TUTORIAL_STEPS: TutorialStep[] = [
 export const GolfPage = withTutorial(GolfPageContent, 'golf', GOLF_TUTORIAL_STEPS);
 /** Inner content of the Golf page, wrapped by TutorialProvider. */
 function GolfPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('golf');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('golf');
   const { playSound } = useSound();
   const {
     state,
@@ -114,14 +127,21 @@ function GolfPageContent() {
 
   const isPlayingForKbd = state?.phase === GolfPhase.PLAYING;
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const actionBindings = useMemo(
     () => [
       { key: 'd', action: handleDraw },
       { key: 'h', action: handleHint },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: handleUndo },
     ],
-    [handleDraw, handleHint, handleGiveUp, handleUndo],
+    [handleDraw, handleHint, confirmGiveUpAction, handleUndo],
   );
 
   useActionKeyboardNav({
@@ -173,6 +193,9 @@ function GolfPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -357,7 +380,7 @@ function GolfPageContent() {
                   <button type="button" className={btnSuccess} onClick={handleHint} disabled={loading}>
                     {t('hint')}
                   </button>
-                  <button type="button" className={btnDanger} onClick={handleGiveUp} disabled={loading}>
+                  <button type="button" className={btnDanger} onClick={confirmGiveUpAction} disabled={loading}>
                     {t('giveup')}
                   </button>
                 </div>

--- a/frontend/src/pages/MonteCarloPage.test.tsx
+++ b/frontend/src/pages/MonteCarloPage.test.tsx
@@ -112,11 +112,14 @@ describe('MonteCarloPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('deal'));
   });
 
-  it('giveup button fires giveup command', async () => {
+  it('giveup button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<MonteCarloPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     mockExec.mockClear();
-    screen.getByRole('button', { name: 'ギブアップ' }).click();
+    fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/MonteCarloPage.tsx
+++ b/frontend/src/pages/MonteCarloPage.tsx
@@ -59,8 +59,21 @@ export const MonteCarloPage = withTutorial(MonteCarloPageContent, 'montecarlo', 
 
 /** Inner content of the Monte Carlo Solitaire page. */
 function MonteCarloPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('montecarlo');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('montecarlo');
   const { cardWidth } = useCardDimensions();
   const { playSound } = useSound();
   const { state, loading, error, exec: execApi, retry } = useGameApi(montecarloApi.exec);
@@ -137,6 +150,13 @@ function MonteCarloPageContent() {
     setSelected(null);
   }, [execApi]);
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const handleManualReset = useCallback(() => {
     hideActionLog();
     void execApi('reset');
@@ -159,6 +179,9 @@ function MonteCarloPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         state && (
           <span className="font-mono text-xs">
@@ -325,7 +348,7 @@ function MonteCarloPageContent() {
                   >
                     {t('button.undo')}
                   </button>
-                  <button type="button" className={btnDanger} onClick={handleGiveUp} disabled={loading}>
+                  <button type="button" className={btnDanger} onClick={confirmGiveUpAction} disabled={loading}>
                     {t('button.giveup')}
                   </button>
                 </>

--- a/frontend/src/pages/OsmosisPage.test.tsx
+++ b/frontend/src/pages/OsmosisPage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { osmosisApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -137,10 +137,14 @@ describe('OsmosisPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
   });
 
-  it('giveup button triggers giveup command', async () => {
+  it('giveup button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<OsmosisPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    screen.getByRole('button', { name: 'ギブアップ' }).click();
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/OsmosisPage.tsx
+++ b/frontend/src/pages/OsmosisPage.tsx
@@ -68,8 +68,21 @@ export const OsmosisPage = withTutorial(OsmosisPageContent, 'osmosis', OS_TUTORI
 
 /** Inner content of the Osmosis page. */
 function OsmosisPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('osmosis');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('osmosis');
   const { state, loading, error, exec: execApi, retry } = useGameApi(osmosisApi.exec);
   const { cardWidth, cardHeight } = useCardDimensions();
   const {
@@ -100,6 +113,13 @@ function OsmosisPageContent() {
   }, [execApi]);
   const handleDraw = useCallback(() => execApi('draw'), [execApi]);
   const handleGiveUp = useCallback(() => execApi('giveup'), [execApi]);
+
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
   const handleHint = useCallback(() => execApi('hint'), [execApi]);
   const handleAutoComplete = useCallback(() => execApi('autocomplete'), [execApi]);
   const handleUndo = useCallback(() => execApi('undo'), [execApi]);
@@ -158,6 +178,9 @@ function OsmosisPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span className="text-sm text-ds-text-muted">
@@ -382,7 +405,7 @@ function OsmosisPageContent() {
                   <button
                     type="button"
                     className={`${btnDanger} ${focusRingWhite}`}
-                    onClick={handleGiveUp}
+                    onClick={confirmGiveUpAction}
                     disabled={loading}
                   >
                     {t('giveup')}

--- a/frontend/src/pages/PenguinPage.test.tsx
+++ b/frontend/src/pages/PenguinPage.test.tsx
@@ -165,14 +165,16 @@ describe('PenguinPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
   });
 
-  it('handleGiveUp called on giveup button click', async () => {
+  it('handleGiveUp called on giveup button click via confirm dialog', async () => {
     renderWithProviders(<PenguinPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());
 
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
-
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 
@@ -350,13 +352,16 @@ describe('PenguinPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
   });
 
-  it('pressing g triggers giveup in PLAYING phase', async () => {
+  it('pressing g opens the give up confirm dialog in PLAYING phase', async () => {
     renderWithProviders(<PenguinPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());
 
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.keyDown(document, { key: 'g' });
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/PenguinPage.tsx
+++ b/frontend/src/pages/PenguinPage.tsx
@@ -97,8 +97,21 @@ const PG_TUTORIAL_STEPS: TutorialStep[] = [
 export const PenguinPage = withTutorial(PenguinPageContent, 'penguin', PG_TUTORIAL_STEPS);
 /** Inner content of the Penguin page, wrapped by TutorialProvider. */
 function PenguinPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('penguin');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('penguin');
   const { playSound } = useSound();
   const {
     state,
@@ -157,14 +170,21 @@ function PenguinPageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const actionBindings = useMemo(
     () => [
       { key: 'h', action: handleHint },
       { key: 'a', action: handleAutoComplete },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: handleUndo },
     ],
-    [handleHint, handleAutoComplete, handleGiveUp, handleUndo],
+    [handleHint, handleAutoComplete, confirmGiveUpAction, handleUndo],
   );
 
   useActionKeyboardNav({
@@ -212,6 +232,9 @@ function PenguinPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -535,7 +558,7 @@ function PenguinPageContent() {
                   <button
                     type="button"
                     className={btnDanger}
-                    onClick={handleGiveUp}
+                    onClick={confirmGiveUpAction}
                     disabled={loading || isAutoCompleting}
                   >
                     {t('giveup')}

--- a/frontend/src/pages/PokerSquaresPage.test.tsx
+++ b/frontend/src/pages/PokerSquaresPage.test.tsx
@@ -167,11 +167,15 @@ describe('PokerSquaresPage', () => {
     await waitFor(() => expect(mockApi).toHaveBeenCalledWith('undo'));
   });
 
-  it('calls exec with giveup when give up button clicked', async () => {
+  it('give up button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     mockApi.mockResolvedValue(playingState);
     renderWithProviders(<PokerSquaresPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());
+    mockApi.mockClear();
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockApi).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockApi).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/PokerSquaresPage.tsx
+++ b/frontend/src/pages/PokerSquaresPage.tsx
@@ -54,8 +54,21 @@ const POKERSQUARES_TUTORIAL_STEPS: TutorialStep[] = [
 export const PokerSquaresPage = withTutorial(PokerSquaresPageContent, 'pokersquares', POKERSQUARES_TUTORIAL_STEPS);
 /** Inner content of the Poker Squares page, wrapped by TutorialProvider. */
 function PokerSquaresPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('pokersquares');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('pokersquares');
   const { cardWidth: baseCardWidth, isMobile } = useCardDimensions();
   const windowWidth = useWindowWidth();
   // On mobile the 5-column board plus its row-score column wastes horizontal
@@ -145,8 +158,15 @@ function PokerSquaresPageContent() {
     execApi('place', row, col);
   };
   const handleUndo = () => execApi('undo');
-  const handleGiveUp = () => execApi('giveup');
+  const handleGiveUp = useCallback(() => execApi('giveup'), [execApi]);
   const handleReset = useCallback(() => execApi('reset'), [execApi]);
+
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
   const handleManualReset = useCallback(() => {
     hideActionLog();
     handleReset();
@@ -165,6 +185,9 @@ function PokerSquaresPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           {state && (
@@ -382,7 +405,7 @@ function PokerSquaresPageContent() {
                   >
                     {t('button.undo')}
                   </button>
-                  <button type="button" className={btnDanger} onClick={handleGiveUp} disabled={loading}>
+                  <button type="button" className={btnDanger} onClick={confirmGiveUpAction} disabled={loading}>
                     {t('button.giveup')}
                   </button>
                 </>

--- a/frontend/src/pages/PyramidPage.test.tsx
+++ b/frontend/src/pages/PyramidPage.test.tsx
@@ -190,14 +190,16 @@ describe('PyramidPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
   });
 
-  it('clicking give up button dispatches giveup', async () => {
+  it('give up button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<PyramidPage />);
     await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
 
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
-
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/PyramidPage.tsx
+++ b/frontend/src/pages/PyramidPage.tsx
@@ -72,8 +72,21 @@ const PY_TUTORIAL_STEPS: TutorialStep[] = [
 export const PyramidPage = withTutorial(PyramidPageContent, 'pyramid', PY_TUTORIAL_STEPS);
 /** Inner content of the Pyramid page, wrapped by TutorialProvider. */
 function PyramidPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('pyramid');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('pyramid');
   const { playSound } = useSound();
   const {
     state,
@@ -114,14 +127,21 @@ function PyramidPageContent() {
 
   const isPlayingForKbd = state?.phase === PyramidPhase.PLAYING;
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const actionBindings = useMemo(
     () => [
       { key: 'd', action: handleDraw },
       { key: 'h', action: handleHint },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: handleUndo },
     ],
-    [handleDraw, handleHint, handleGiveUp, handleUndo],
+    [handleDraw, handleHint, confirmGiveUpAction, handleUndo],
   );
 
   useActionKeyboardNav({
@@ -187,6 +207,9 @@ function PyramidPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -400,7 +423,7 @@ function PyramidPageContent() {
                   <button type="button" className={btnSuccess} onClick={handleHint} disabled={loading}>
                     {t('hint')}
                   </button>
-                  <button type="button" className={btnDanger} onClick={handleGiveUp} disabled={loading}>
+                  <button type="button" className={btnDanger} onClick={confirmGiveUpAction} disabled={loading}>
                     {t('giveup')}
                   </button>
                 </div>

--- a/frontend/src/pages/RussianSolitairePage.test.tsx
+++ b/frontend/src/pages/RussianSolitairePage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { russianSolitaireApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -155,11 +155,14 @@ describe('RussianSolitairePage', () => {
     expect(screen.getByTestId('autocomplete-button')).toBeDisabled();
   });
 
-  it('giveup button triggers giveup command', async () => {
+  it('give up button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<RussianSolitairePage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    const btn = screen.getByRole('button', { name: 'ギブアップ' });
-    btn.click();
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/RussianSolitairePage.tsx
+++ b/frontend/src/pages/RussianSolitairePage.tsx
@@ -143,8 +143,21 @@ function formatRussianSolitaireState(state: RussianSolitaireResponse): string {
 export const RussianSolitairePage = withTutorial(RussianSolitairePageContent, 'russiansolitaire', RS_TUTORIAL_STEPS);
 /** Inner content of the Russian Solitaire page. */
 function RussianSolitairePageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('russiansolitaire');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('russiansolitaire');
   const { playSound } = useSound();
   const {
     state,
@@ -234,6 +247,13 @@ function RussianSolitairePageContent() {
     void apiExec('giveup');
   }, [apiExec]);
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const handleHint = useCallback(async () => {
     const res = await russianSolitaireApi.exec('hint');
     setState((prev) => (prev ? { ...prev, hint: res.hint } : prev));
@@ -286,10 +306,10 @@ function RussianSolitairePageContent() {
     () => [
       { key: 'h', action: handleHint },
       { key: 'a', action: handleAutoComplete },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: handleUndo },
     ],
-    [handleHint, handleAutoComplete, handleGiveUp, handleUndo],
+    [handleHint, handleAutoComplete, confirmGiveUpAction, handleUndo],
   );
 
   useActionKeyboardNav({
@@ -332,6 +352,9 @@ function RussianSolitairePageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -576,7 +599,7 @@ function RussianSolitairePageContent() {
                   >
                     {t('undo')}
                   </button>
-                  <button type="button" className={btnDanger} onClick={handleGiveUp} disabled={loading}>
+                  <button type="button" className={btnDanger} onClick={confirmGiveUpAction} disabled={loading}>
                     {t('giveup')}
                   </button>
                   {state.isStalemate && (

--- a/frontend/src/pages/ScorpionPage.test.tsx
+++ b/frontend/src/pages/ScorpionPage.test.tsx
@@ -168,11 +168,14 @@ describe('ScorpionPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
   });
 
-  it('giveup button triggers giveup command', async () => {
+  it('give up button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<ScorpionPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    const btn = screen.getByRole('button', { name: 'ギブアップ' });
-    btn.click();
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 
@@ -300,10 +303,14 @@ describe('ScorpionPage', () => {
     expect(screen.getByRole('button', { name: /棋譜|action log|アクション/i })).toBeInTheDocument();
   });
 
-  it('keyboard shortcut "g" triggers giveup', async () => {
+  it('keyboard shortcut "g" opens the give up confirm dialog in PLAYING phase', async () => {
     renderWithProviders(<ScorpionPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'g' });
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/ScorpionPage.tsx
+++ b/frontend/src/pages/ScorpionPage.tsx
@@ -148,8 +148,21 @@ function formatScorpionState(state: ScorpionResponse): string {
 export const ScorpionPage = withTutorial(ScorpionPageContent, 'scorpion', SC_TUTORIAL_STEPS);
 /** Inner content of the Scorpion page. */
 function ScorpionPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('scorpion');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('scorpion');
   const { playSound } = useSound();
   const {
     state,
@@ -237,6 +250,13 @@ function ScorpionPageContent() {
     void apiCall('giveup');
   }, [apiCall]);
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const handleHint = useCallback(() => {
     void apiCall('hint');
   }, [apiCall]);
@@ -288,11 +308,11 @@ function ScorpionPageContent() {
     () => [
       { key: 'h', action: handleHint },
       { key: 'a', action: handleAutoComplete },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: handleUndo },
       { key: 'd', action: handleDealGuarded },
     ],
-    [handleHint, handleAutoComplete, handleGiveUp, handleUndo, handleDealGuarded],
+    [handleHint, handleAutoComplete, confirmGiveUpAction, handleUndo, handleDealGuarded],
   );
 
   useActionKeyboardNav({
@@ -327,6 +347,9 @@ function ScorpionPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -513,7 +536,7 @@ function ScorpionPageContent() {
                   >
                     {t('undo')}
                   </button>
-                  <button type="button" className={btnDanger} onClick={handleGiveUp} disabled={loading}>
+                  <button type="button" className={btnDanger} onClick={confirmGiveUpAction} disabled={loading}>
                     {t('giveup')}
                   </button>
                   {state.isStalemate && (

--- a/frontend/src/pages/SeahavenTowersPage.test.tsx
+++ b/frontend/src/pages/SeahavenTowersPage.test.tsx
@@ -152,6 +152,18 @@ describe('SeahavenTowersPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
   });
 
+  it('give up button opens a confirm dialog and only dispatches giveup after confirm', async () => {
+    renderWithProviders(<SeahavenTowersPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(gameOverState);
+    fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
+  });
+
   it('renders game-clear state', async () => {
     mockExec.mockResolvedValue(gameClearState);
     renderWithProviders(<SeahavenTowersPage />);

--- a/frontend/src/pages/SeahavenTowersPage.tsx
+++ b/frontend/src/pages/SeahavenTowersPage.tsx
@@ -76,8 +76,21 @@ export const SeahavenTowersPage = withTutorial(SeahavenTowersPageContent, 'seaha
 
 /** Inner content of the Seahaven Towers page, wrapped by TutorialProvider. */
 function SeahavenTowersPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('seahaventowers');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('seahaventowers');
   const { playSound } = useSound();
   const {
     state,
@@ -152,14 +165,21 @@ function SeahavenTowersPageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const actionBindings = useMemo(
     () => [
       { key: 'h', action: handleHint },
       { key: 'a', action: handleAutoComplete },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: handleUndo },
     ],
-    [handleHint, handleAutoComplete, handleGiveUp, handleUndo],
+    [handleHint, handleAutoComplete, confirmGiveUpAction, handleUndo],
   );
 
   useActionKeyboardNav({
@@ -202,6 +222,9 @@ function SeahavenTowersPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -517,7 +540,7 @@ function SeahavenTowersPageContent() {
                   <button
                     type="button"
                     className={btnDanger}
-                    onClick={handleGiveUp}
+                    onClick={confirmGiveUpAction}
                     disabled={loading || isAutoCompleting}
                   >
                     {t('giveup')}

--- a/frontend/src/pages/SpiderPage.test.tsx
+++ b/frontend/src/pages/SpiderPage.test.tsx
@@ -218,14 +218,19 @@ describe('SpiderPage', () => {
     expect(screen.getByTestId('autocomplete-button')).toBeDisabled();
   });
 
-  it('clicking give up button dispatches giveup', async () => {
+  it('give up button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<SpiderPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());
 
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
+    // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
 
+    // Confirming dispatches giveup.
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -82,8 +82,21 @@ const SPD_TUTORIAL_STEPS: TutorialStep[] = [
 export const SpiderPage = withTutorial(SpiderPageContent, 'spider', SPD_TUTORIAL_STEPS);
 /** Inner content of the Spider page, wrapped by TutorialProvider. */
 function SpiderPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('spider');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('spider');
   const { playSound } = useSound();
   const {
     state,
@@ -168,6 +181,13 @@ function SpiderPageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const currentDifficulty = state?.difficulty ?? 1;
 
   const actionBindings = useMemo(
@@ -175,10 +195,10 @@ function SpiderPageContent() {
       { key: 'd', action: handleDealGuarded },
       { key: 'h', action: handleHint },
       { key: 'a', action: handleAutoComplete },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: handleUndo },
     ],
-    [handleDealGuarded, handleHint, handleAutoComplete, handleGiveUp, handleUndo],
+    [handleDealGuarded, handleHint, handleAutoComplete, confirmGiveUpAction, handleUndo],
   );
 
   useActionKeyboardNav({
@@ -215,6 +235,9 @@ function SpiderPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -454,7 +477,7 @@ function SpiderPageContent() {
                   <button
                     type="button"
                     className={btnDanger}
-                    onClick={handleGiveUp}
+                    onClick={confirmGiveUpAction}
                     disabled={loading || isAutoCompleting}
                   >
                     {t('giveup')}

--- a/frontend/src/pages/SpiderettePage.test.tsx
+++ b/frontend/src/pages/SpiderettePage.test.tsx
@@ -115,4 +115,19 @@ describe('SpiderettePage', () => {
     renderWithProviders(<SpiderettePage />);
     await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
   });
+
+  it('give up button opens a confirm dialog and only dispatches giveup after confirm', async () => {
+    renderWithProviders(<SpiderettePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());
+
+    mockSend.mockClear();
+    // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
+    fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockSend).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+
+    // Confirming dispatches giveup.
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    await waitFor(() => expect(mockSend).toHaveBeenCalledWith('giveup'));
+  });
 });

--- a/frontend/src/pages/SpiderettePage.tsx
+++ b/frontend/src/pages/SpiderettePage.tsx
@@ -57,8 +57,21 @@ const TABLEAU_COLS = 7;
 export const SpiderettePage = withTutorial(SpiderettePageContent, 'spiderette', SPDT_TUTORIAL_STEPS);
 
 function SpiderettePageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('spiderette');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('spiderette');
   const { playSound } = useSound();
   const game = useSpideretteGame();
   const {
@@ -114,15 +127,22 @@ function SpiderettePageContent() {
     handleReset();
   }, [handleReset, hideActionLog]);
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const actionBindings = useMemo(
     () => [
       { key: 'd', action: handleDealGuarded },
       { key: 'h', action: handleHint },
       { key: 'a', action: handleAutoComplete },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: handleUndo },
     ],
-    [handleDealGuarded, handleHint, handleAutoComplete, handleGiveUp, handleUndo],
+    [handleDealGuarded, handleHint, handleAutoComplete, confirmGiveUpAction, handleUndo],
   );
 
   useActionKeyboardNav({ bindings: actionBindings, enabled: !!isPlayingForKbd && !loading });
@@ -164,6 +184,9 @@ function SpiderettePageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -357,7 +380,12 @@ function SpiderettePageContent() {
               >
                 {t('autoComplete')}
               </button>
-              <button type="button" className={btnDanger} onClick={handleGiveUp} disabled={loading || isAutoCompleting}>
+              <button
+                type="button"
+                className={btnDanger}
+                onClick={confirmGiveUpAction}
+                disabled={loading || isAutoCompleting}
+              >
                 {t('giveup')}
               </button>
             </div>

--- a/frontend/src/pages/TriPeaksPage.test.tsx
+++ b/frontend/src/pages/TriPeaksPage.test.tsx
@@ -166,14 +166,19 @@ describe('TriPeaksPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw'));
   });
 
-  it('clicking giveup button dispatches giveup', async () => {
+  it('give up button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<TriPeaksPage />);
     await waitFor(() => expect(screen.getByText('捨て札')).toBeInTheDocument());
 
     mockExec.mockClear();
     mockExec.mockResolvedValue(gameOverState);
+    // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
     fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
 
+    // Confirming dispatches giveup.
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/TriPeaksPage.tsx
+++ b/frontend/src/pages/TriPeaksPage.tsx
@@ -82,8 +82,21 @@ const TP_TUTORIAL_STEPS: TutorialStep[] = [
 export const TriPeaksPage = withTutorial(TriPeaksPageContent, 'tripeaks', TP_TUTORIAL_STEPS);
 /** Inner content of the TriPeaks page, wrapped by TutorialProvider. */
 function TriPeaksPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('tripeaks');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('tripeaks');
   const { playSound } = useSound();
   const {
     state,
@@ -123,14 +136,21 @@ function TriPeaksPageContent() {
 
   const isPlayingForKbd = state?.phase === TriPeaksPhase.PLAYING;
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const actionBindings = useMemo(
     () => [
       { key: 'd', action: handleDraw },
       { key: 'h', action: handleHint },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: handleUndo },
     ],
-    [handleDraw, handleHint, handleGiveUp, handleUndo],
+    [handleDraw, handleHint, confirmGiveUpAction, handleUndo],
   );
 
   useActionKeyboardNav({
@@ -179,6 +199,9 @@ function TriPeaksPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -375,7 +398,7 @@ function TriPeaksPageContent() {
                   <button type="button" className={btnSuccess} onClick={handleHint} disabled={loading}>
                     {t('hint')}
                   </button>
-                  <button type="button" className={btnDanger} onClick={handleGiveUp} disabled={loading}>
+                  <button type="button" className={btnDanger} onClick={confirmGiveUpAction} disabled={loading}>
                     {t('giveup')}
                   </button>
                 </div>

--- a/frontend/src/pages/WaspPage.test.tsx
+++ b/frontend/src/pages/WaspPage.test.tsx
@@ -189,11 +189,18 @@ describe('WaspPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
   });
 
-  it('giveup button triggers giveup command', async () => {
+  it('give up button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<WaspPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    const btn = screen.getByRole('button', { name: 'ギブアップ' });
-    btn.click();
+
+    mockExec.mockClear();
+    // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
+    fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+
+    // Confirming dispatches giveup.
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 
@@ -334,10 +341,15 @@ describe('WaspPage', () => {
     expect(screen.getByRole('button', { name: /棋譜|action log|アクション/i })).toBeInTheDocument();
   });
 
-  it('keyboard shortcut "g" triggers giveup', async () => {
+  it('keyboard shortcut "g" opens the give up confirm dialog in PLAYING phase', async () => {
     renderWithProviders(<WaspPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    mockExec.mockClear();
     fireEvent.keyDown(document, { key: 'g' });
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/WaspPage.tsx
+++ b/frontend/src/pages/WaspPage.tsx
@@ -148,8 +148,21 @@ function formatWaspState(state: WaspResponse): string {
 export const WaspPage = withTutorial(WaspPageContent, 'wasp', SC_TUTORIAL_STEPS);
 /** Inner content of the Wasp page. */
 function WaspPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('wasp');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('wasp');
   const { playSound } = useSound();
   const {
     state,
@@ -237,6 +250,13 @@ function WaspPageContent() {
     void apiCall('giveup');
   }, [apiCall]);
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const handleHint = useCallback(() => {
     void apiCall('hint');
   }, [apiCall]);
@@ -288,11 +308,11 @@ function WaspPageContent() {
     () => [
       { key: 'h', action: handleHint },
       { key: 'a', action: handleAutoComplete },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: handleUndo },
       { key: 'd', action: handleDealGuarded },
     ],
-    [handleHint, handleAutoComplete, handleGiveUp, handleUndo, handleDealGuarded],
+    [handleHint, handleAutoComplete, confirmGiveUpAction, handleUndo, handleDealGuarded],
   );
 
   useActionKeyboardNav({
@@ -327,6 +347,9 @@ function WaspPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -521,7 +544,7 @@ function WaspPageContent() {
                   >
                     {t('undo')}
                   </button>
-                  <button type="button" className={btnDanger} onClick={handleGiveUp} disabled={loading}>
+                  <button type="button" className={btnDanger} onClick={confirmGiveUpAction} disabled={loading}>
                     {t('giveup')}
                   </button>
                   {state.isStalemate && (

--- a/frontend/src/pages/YukonPage.test.tsx
+++ b/frontend/src/pages/YukonPage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { yukonApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -155,11 +155,18 @@ describe('YukonPage', () => {
     expect(screen.getByTestId('autocomplete-button')).toBeDisabled();
   });
 
-  it('giveup button triggers giveup command', async () => {
+  it('give up button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<YukonPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    const btn = screen.getByRole('button', { name: 'ギブアップ' });
-    btn.click();
+
+    mockExec.mockClear();
+    // Clicking give-up must NOT dispatch immediately — it opens a confirm dialog (#2099).
+    fireEvent.click(screen.getByRole('button', { name: 'ギブアップ' }));
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+
+    // Confirming dispatches giveup.
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
   });
 

--- a/frontend/src/pages/YukonPage.tsx
+++ b/frontend/src/pages/YukonPage.tsx
@@ -141,8 +141,21 @@ function formatYukonState(state: YukonResponse): string {
 export const YukonPage = withTutorial(YukonPageContent, 'yukon', YK_TUTORIAL_STEPS);
 /** Inner content of the Yukon page. */
 function YukonPageContent() {
-  const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
-    useGamePageSetup('yukon');
+  const {
+    t,
+    tc,
+    actionLog,
+    showActionLog,
+    hideActionLog,
+    confirmOpen,
+    requestConfirm,
+    confirmReset,
+    cancelReset,
+    giveUpConfirmOpen,
+    requestGiveUpConfirm,
+    confirmGiveUp,
+    cancelGiveUp,
+  } = useGamePageSetup('yukon');
   const { playSound } = useSound();
   const {
     state,
@@ -221,6 +234,13 @@ function YukonPageContent() {
     void apiExec('giveup');
   }, [apiExec]);
 
+  // Give-up is irreversible, so route both the button and the `g` key through
+  // the confirm dialog — matching reset's guard (issue #2099).
+  const confirmGiveUpAction = useCallback(
+    () => requestGiveUpConfirm(handleGiveUp),
+    [requestGiveUpConfirm, handleGiveUp],
+  );
+
   const handleHint = useCallback(async () => {
     const res = await yukonApi.exec('hint');
     setState((prev) => (prev ? { ...prev, hint: res.hint } : prev));
@@ -273,10 +293,10 @@ function YukonPageContent() {
     () => [
       { key: 'h', action: handleHint },
       { key: 'a', action: handleAutoComplete },
-      { key: 'g', action: handleGiveUp },
+      { key: 'g', action: confirmGiveUpAction },
       { key: 'z', action: handleUndo },
     ],
-    [handleHint, handleAutoComplete, handleGiveUp, handleUndo],
+    [handleHint, handleAutoComplete, confirmGiveUpAction, handleUndo],
   );
 
   useActionKeyboardNav({
@@ -319,6 +339,9 @@ function YukonPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      giveUpConfirmOpen={giveUpConfirmOpen}
+      confirmGiveUp={confirmGiveUp}
+      cancelGiveUp={cancelGiveUp}
       headerExtra={
         <>
           <span>
@@ -563,7 +586,7 @@ function YukonPageContent() {
                   >
                     {t('undo')}
                   </button>
-                  <button type="button" className={btnDanger} onClick={handleGiveUp} disabled={loading}>
+                  <button type="button" className={btnDanger} onClick={confirmGiveUpAction} disabled={loading}>
                     {t('giveup')}
                   </button>
                   {state.isStalemate && (


### PR DESCRIPTION
## Summary

Completes the rollout of the give-up confirmation dialog (started in PR #2108 for Klondike + FreeCell) to the **remaining 28 solitaire-style pages**.

Give-up is an irreversible destructive operation, but it was wired directly to the button **and** the single `g` key with no confirmation — unlike reset, which is guarded by a confirm dialog on every page. A mis-tapped button (mobile) or a stray `g` keypress during play would silently discard several minutes of in-progress solitaire. This asymmetry violated the existing consistency/error-prevention guard.

## Changes

For each of the 28 pages, both the give-up **button** and the **`g` keybinding** now route through the existing `requestGiveUpConfirm` flow, surfacing the shared `GameGiveUpDialog` via `GamePageShell`'s `giveUpConfirmOpen` / `confirmGiveUp` / `cancelGiveUp` props — exactly mirroring reset's guard and the Klondike/FreeCell reference implementation. No new infrastructure was needed; the dialog, i18n keys (`button.confirmGiveUp*`), hook (`useGamePageSetup`), and shell support already shipped in #2108.

Pages updated: Accordion, AcesUp, BakersDozen, BakersGame, BeleagueredCastle, Bristol, Calculation, Canfield, Crescent, Cruel, Easthaven, EightOff, FortyThieves, Gaps, Golf, MonteCarlo, Osmosis, Penguin, PokerSquares, Pyramid, RussianSolitaire, Scorpion, SeahavenTowers, Spider, Spiderette, TriPeaks, Wasp, Yukon.

## Test plan

- [x] Each page test updated (or added) to assert the gating: clicking give-up (or pressing `g`) does **not** dispatch `giveup` immediately, the `投了確認` dialog appears, and `giveup` is dispatched only after confirming.
- [x] `bun run check` (Biome + design-tokens) — passes
- [x] `bun run test` — all affected page tests green (28 pages)
- [x] `tsc -b` — passes (raised heap locally)
- [x] `bun run build` (vite) — passes

Closes #2099

🤖 Generated with [Claude Code](https://claude.com/claude-code)