### PR TITLE
fix(sheepshead,doppelkopf): harden trick winner-strength lookup + add Doppelkopf trump-beats-fail test

### DIFF
--- a/internal/domain/Doppelkopf.go
+++ b/internal/domain/Doppelkopf.go
@@ -539,6 +539,16 @@ func (g *Doppelkopf) indexOfPlayerInTrick(playerIdx int) int {
 	return -1
 }
 
+// trickTopStrength 現在のトリック勝者 winnerIdx の札の強さを返す。防御的に、
+// 勝者がトリック内に見つからない場合は極小値を返す (負インデックスでのパニック回避)。
+func (g *Doppelkopf) trickTopStrength(winnerIdx int) int {
+	idx := g.indexOfPlayerInTrick(winnerIdx)
+	if idx < 0 {
+		return -1 << 30
+	}
+	return dkStrength(g.currentTrick[idx].Card)
+}
+
 // findHumanIdx 人間プレイヤーのインデックスを返す (-1=なし)。
 func (g *Doppelkopf) findHumanIdx() int {
 	for i, p := range g.players {
@@ -822,7 +832,7 @@ func (g *Doppelkopf) playHintReason(playerIdx, chosenIdx int) string {
 		return "discard_low"
 	}
 	winnerIdx := g.trickWinner()
-	topStrength := dkStrength(g.currentTrick[g.indexOfPlayerInTrick(winnerIdx)].Card)
+	topStrength := g.trickTopStrength(winnerIdx)
 	if dkStrength(card) > topStrength {
 		return "follow_win"
 	}
@@ -873,7 +883,7 @@ func (g *Doppelkopf) cpuPlaySmart(playerIdx int, valid []int) int {
 
 	leadSuit := dkSuitID(g.currentTrick[0].Card)
 	winnerIdx := g.trickWinner()
-	topStrength := dkStrength(g.currentTrick[g.indexOfPlayerInTrick(winnerIdx)].Card)
+	topStrength := g.trickTopStrength(winnerIdx)
 	partnerWinning := g.reTeam[playerIdx] == g.reTeam[winnerIdx]
 	trickPts := 0
 	for _, tc := range g.currentTrick {

--- a/internal/domain/Doppelkopf_test.go
+++ b/internal/domain/Doppelkopf_test.go
@@ -175,6 +175,20 @@ func TestDoppelkopf_TrumpBeatsFailLead(t *testing.T) {
 	}
 }
 
+func TestDoppelkopf_TrickTopStrengthGuard(t *testing.T) {
+	g := newDKGame(false)
+	g.SetCurrentTrick([]*DoppelkopfTrickCard{
+		{PlayerIdx: 0, Card: dkCard(CardDesignClover, 1)},
+	})
+	// A winner not present in the current trick must yield the sentinel, not panic.
+	if got := g.trickTopStrength(99); got != -1<<30 {
+		t.Errorf("trickTopStrength(absent) = %d, want sentinel", got)
+	}
+	if got := g.trickTopStrength(0); got != dkStrength(dkCard(CardDesignClover, 1)) {
+		t.Errorf("trickTopStrength(0) = %d, want A♣ strength", got)
+	}
+}
+
 func TestDoppelkopf_MustFollowSuit(t *testing.T) {
 	g := newDKGame(true) // human is player 0
 	g.SetPhase(DoppelkopfPhasePlay)

--- a/internal/domain/Doppelkopf_test.go
+++ b/internal/domain/Doppelkopf_test.go
@@ -150,6 +150,31 @@ func TestDoppelkopf_TrickWinnerHighFail(t *testing.T) {
 	}
 }
 
+func TestDoppelkopf_TrumpBeatsFailLead(t *testing.T) {
+	// A fail suit is led; a player void in it overruffs with trump. The trump
+	// must win even though its suit ID (trump) differs from the lead suit.
+	g := newDKGame(false)
+	g.SetCurrentTrick([]*DoppelkopfTrickCard{
+		{PlayerIdx: 0, Card: dkCard(CardDesignClover, 1)},   // A♣ fail lead
+		{PlayerIdx: 1, Card: dkCard(CardDesignDiamond, 13)}, // K♦ trump
+		{PlayerIdx: 2, Card: dkCard(CardDesignClover, 10)},  // 10♣ fail
+		{PlayerIdx: 3, Card: dkCard(CardDesignClover, 9)},   // 9♣ fail
+	})
+	if w := g.trickWinner(); w != 1 {
+		t.Errorf("winner = %d, want 1 (K♦ trump beats the ♣ fail lead)", w)
+	}
+	// And the Dulle (♥10) beats a lower trump played earlier.
+	g.SetCurrentTrick([]*DoppelkopfTrickCard{
+		{PlayerIdx: 0, Card: dkCard(CardDesignClover, 1)},  // A♣ fail lead
+		{PlayerIdx: 1, Card: dkCard(CardDesignDiamond, 1)}, // A♦ trump
+		{PlayerIdx: 2, Card: dkCard(CardDesignHeart, 10)},  // Dulle (top trump)
+		{PlayerIdx: 3, Card: dkCard(CardDesignSpade, 12)},  // Q♠ trump
+	})
+	if w := g.trickWinner(); w != 2 {
+		t.Errorf("winner = %d, want 2 (Dulle is the highest trump)", w)
+	}
+}
+
 func TestDoppelkopf_MustFollowSuit(t *testing.T) {
 	g := newDKGame(true) // human is player 0
 	g.SetPhase(DoppelkopfPhasePlay)

--- a/internal/domain/Sheepshead.go
+++ b/internal/domain/Sheepshead.go
@@ -721,6 +721,16 @@ func (g *Sheepshead) indexOfPlayerInTrick(playerIdx int) int {
 	return -1
 }
 
+// trickTopStrength 現在のトリック勝者 winnerIdx の札の強さを返す。防御的に、
+// 勝者がトリック内に見つからない場合は極小値を返す (パニック回避)。
+func (g *Sheepshead) trickTopStrength(winnerIdx int) int {
+	idx := g.indexOfPlayerInTrick(winnerIdx)
+	if idx < 0 {
+		return -1 << 30
+	}
+	return sheepsheadStrength(g.currentTrick[idx].Card)
+}
+
 // --- Card classification ---
 
 // sheepsheadIsTrump 切り札 (全 Q, 全 J, ダイヤ全札) か。
@@ -1037,7 +1047,7 @@ func (g *Sheepshead) playHintReason(playerIdx, chosenIdx int) string {
 		return "discard_low"
 	}
 	winnerIdx := g.trickWinner()
-	topStrength := sheepsheadStrength(g.currentTrick[g.indexOfPlayerInTrick(winnerIdx)].Card)
+	topStrength := g.trickTopStrength(winnerIdx)
 	if sheepsheadStrength(card) > topStrength {
 		return "follow_win"
 	}
@@ -1136,7 +1146,7 @@ func (g *Sheepshead) cpuPlaySmart(playerIdx int, valid []int) int {
 
 	leadSuit := sheepsheadSuitID(g.currentTrick[0].Card)
 	winnerIdx := g.trickWinner()
-	topStrength := sheepsheadStrength(g.currentTrick[g.indexOfPlayerInTrick(winnerIdx)].Card)
+	topStrength := g.trickTopStrength(winnerIdx)
 	partnerWinning := g.cpuSameTeam(playerIdx, winnerIdx)
 	trickPts := 0
 	for _, tc := range g.currentTrick {

--- a/internal/domain/Sheepshead_test.go
+++ b/internal/domain/Sheepshead_test.go
@@ -312,6 +312,20 @@ func TestSheepshead_MustFollowSuit(t *testing.T) {
 	}
 }
 
+func TestSheepshead_TrickTopStrengthGuard(t *testing.T) {
+	g := newSSGame(false)
+	g.SetCurrentTrick([]*SheepsheadTrickCard{
+		{PlayerIdx: 0, Card: ssCard(CardDesignClover, 1)},
+	})
+	// A winner not present in the current trick yields the sentinel, not a panic.
+	if got := g.trickTopStrength(99); got != -1<<30 {
+		t.Errorf("trickTopStrength(absent) = %d, want sentinel", got)
+	}
+	if got := g.trickTopStrength(0); got != sheepsheadStrength(ssCard(CardDesignClover, 1)) {
+		t.Errorf("trickTopStrength(0) = %d, want A♣ strength", got)
+	}
+}
+
 func TestSheepshead_TrickWinnerTrumpBeatsFail(t *testing.T) {
 	g := newSSGame(false)
 	g.SetPhase(SheepsheadPhaseTrickEnd)


### PR DESCRIPTION
## Summary

Follow-up to the merged #2478 (Sheepshead) and #2479 (Doppelkopf) addressing the remaining review comments that landed after those PRs merged.

- **Defensive guard (both games)**: route the trick winner's card-strength lookup through a `trickTopStrength(winnerIdx)` helper that returns a sentinel when the winner is not found in the current trick, instead of indexing `currentTrick[indexOfPlayerInTrick(...)]` with a possible `-1`. (Gemini WANT on #2479; same pattern existed in Sheepshead.) The index can't actually be negative today since `trickWinner` only returns an in-trick player, so this is pure hardening with no behavior change.
- **Regression test**: add `TestDoppelkopf_TrumpBeatsFailLead`, locking in the trickWinner fix from #2479 (a trump played on a fail lead wins; the Dulle ♥10 is the top trump). The github-actions reviewer flagged this test as missing.

## Notes on review comments intentionally NOT applied
- **CUI `setchips`→`setbasechips`**: skipped. The established code convention across all chip games is `setchips` (10 usages, 0 `setbasechips`); only the newly-written OpenAPI text used `setbasechips`. Renaming the code would diverge from the convention; the short alias `sb` is unchanged regardless.
- Sheepshead frontend config defaults / "Hard" CPU parity / dead "Next Trick" button: low-priority, deferred (intentional-divergence / cosmetic).

## Test plan
- [x] `go build ./...`
- [x] `go test -tags test -run 'TestDoppelkopf' ./internal/domain/` — pass (incl. new TrumpBeatsFailLead)
- [ ] full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)