### PR TITLE
feat(calculation): localize backend hint zone symbols

### DIFF
--- a/frontend/src/pages/CalculationPage.test.tsx
+++ b/frontend/src/pages/CalculationPage.test.tsx
@@ -255,6 +255,8 @@ describe('CalculationPage', () => {
     renderWithProviders(<CalculationPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     expect(screen.getByText(/ヒントがあります/)).toBeInTheDocument();
+    // Hint uses localized zone names + index, not raw F/W symbols.
+    expect(screen.getByText(/ストック → ファンデーション 2/)).toBeInTheDocument();
   });
 
   it('renders the backend hint banner when state.hint is a waste hint', async () => {
@@ -265,7 +267,7 @@ describe('CalculationPage', () => {
     });
     renderWithProviders(<CalculationPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    expect(screen.getByText(/W0 → F1/)).toBeInTheDocument();
+    expect(screen.getByText(/ウェイスト 0 → ファンデーション 1/)).toBeInTheDocument();
   });
 
   it('renders a stalemate escape button when the game is stalled', async () => {

--- a/frontend/src/pages/CalculationPage.tsx
+++ b/frontend/src/pages/CalculationPage.tsx
@@ -552,8 +552,8 @@ function CalculationPageContent() {
                 >
                   {t('hintAvailable')}:{' '}
                   {state.hint.fromZone === 'stock'
-                    ? `${t('stock')} → F${state.hint.foundationIdx}`
-                    : `W${state.hint.wasteIdx} → F${state.hint.foundationIdx}`}
+                    ? `${t('stock')} → ${t('foundation')} ${state.hint.foundationIdx.toString()}`
+                    : `${t('waste')} ${state.hint.wasteIdx.toString()} → ${t('foundation')} ${state.hint.foundationIdx.toString()}`}
                 </div>
               )}
               {frontendHintEnabled && frontendHint && (


### PR DESCRIPTION
## 概要
`CalculationPage.tsx` のサーバヒント表示が未翻訳の生記号 (`F0..F3` / `W0..W3`) を出していた。他所で使われている `t('stock')`/`t('waste')`/`t('foundation')` を使ってローカライズ語+番号に統一した。

## 変更点
- `CalculationPage.tsx`: ヒント行を `${t('stock')} → ${t('foundation')} {idx}` / `${t('waste')} {wIdx} → ${t('foundation')} {fIdx}` に変更 (新規キーなし、既存キー再利用)

## テスト計画
- [x] `CalculationPage.test.tsx`: stock/waste 両ヒントがローカライズ語(ストック/ウェイスト/ファンデーション)+番号で表示されることを検証 (Red→Green)
- [x] `bun run test src/pages/CalculationPage.test.tsx` 全32件パス
- [x] `bun run check` パス (exit 0)

Closes #2602