### PR TITLE
feat(spiteandmalice): i18n Hand heading and CPU goal labels

### DIFF
--- a/frontend/src/i18n/locales/en/spiteandmalice.json
+++ b/frontend/src/i18n/locales/en/spiteandmalice.json
@@ -13,6 +13,9 @@
     "side": "Side",
     "cpuSides": "CPU side piles",
     "hand": "Hand",
+    "hidden": "hidden",
+    "handCount": "hand: {{count}}",
+    "cpuGoal": "CPU goal: {{count}}",
     "foundation": "Foundation",
     "stock": "Stock",
     "completed": "Completed"

--- a/frontend/src/i18n/locales/ja/spiteandmalice.json
+++ b/frontend/src/i18n/locales/ja/spiteandmalice.json
@@ -13,6 +13,9 @@
     "side": "サイド",
     "cpuSides": "CPUのサイドパイル",
     "hand": "手札",
+    "hidden": "非公開",
+    "handCount": "手札: {{count}}",
+    "cpuGoal": "CPUゴール: {{count}}",
     "foundation": "ファウンデーション",
     "stock": "ストック",
     "completed": "完成済み"

--- a/frontend/src/pages/SpiteAndMalicePage.test.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.test.tsx
@@ -88,6 +88,17 @@ describe('SpiteAndMalicePage', () => {
     await waitFor(() => expect(screen.getByText(/手数|Moves/)).toBeInTheDocument());
   });
 
+  it('localizes the hand heading, card aria-labels, and CPU goal (no raw English)', async () => {
+    renderWithProviders(<SpiteAndMalicePage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    // Hand card aria-labels are localized ("手札 N: ..."), not "Hand N: ...".
+    expect(screen.getByLabelText(/^手札 1:/)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Hand 1:/)).not.toBeInTheDocument();
+    // CPU goal count is localized, not the hardcoded "CPU goal x20".
+    expect(screen.getByText(/CPUゴール: 20/)).toBeInTheDocument();
+    expect(screen.queryByText(/CPU goal/)).not.toBeInTheDocument();
+  });
+
   it('renders the CPU side piles with a count badge on non-empty piles', async () => {
     mockExec.mockResolvedValue({
       ...baseState,

--- a/frontend/src/pages/SpiteAndMalicePage.test.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.test.tsx
@@ -103,7 +103,7 @@ describe('SpiteAndMalicePage', () => {
     mockExec.mockResolvedValue({
       ...baseState,
       players: [
-        { ...baseState.players[0], hand: [card('SPADE', 5), null] },
+        { ...baseState.players[0], hand: [card('SPADE', 5), undefined] },
         { ...baseState.players[1], goalTop: null, goalSize: 0 },
       ],
     });

--- a/frontend/src/pages/SpiteAndMalicePage.test.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.test.tsx
@@ -99,6 +99,22 @@ describe('SpiteAndMalicePage', () => {
     expect(screen.queryByText(/CPU goal/)).not.toBeInTheDocument();
   });
 
+  it('localizes a hidden (face-down) hand card and a zero CPU goal', async () => {
+    mockExec.mockResolvedValue({
+      ...baseState,
+      players: [
+        { ...baseState.players[0], hand: [card('SPADE', 5), null] },
+        { ...baseState.players[1], goalTop: null, goalSize: 0 },
+      ],
+    });
+    renderWithProviders(<SpiteAndMalicePage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    // Null hand card uses the localized hidden label.
+    expect(screen.getByLabelText(/手札 2: 非公開/)).toBeInTheDocument();
+    // Empty goal pile renders the localized zero-count label.
+    expect(screen.getByText(/CPUゴール: 0/)).toBeInTheDocument();
+  });
+
   it('renders the CPU side piles with a count badge on non-empty piles', async () => {
     mockExec.mockResolvedValue({
       ...baseState,

--- a/frontend/src/pages/SpiteAndMalicePage.test.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.test.tsx
@@ -103,8 +103,8 @@ describe('SpiteAndMalicePage', () => {
     mockExec.mockResolvedValue({
       ...baseState,
       players: [
-        { ...baseState.players[0], hand: [card('SPADE', 5), undefined] },
-        { ...baseState.players[1], goalTop: null, goalSize: 0 },
+        { ...baseState.players[0], hand: [card('SPADE', 5), null] },
+        { ...baseState.players[1], goalTop: undefined, goalSize: 0 },
       ],
     });
     renderWithProviders(<SpiteAndMalicePage />);

--- a/frontend/src/pages/SpiteAndMalicePage.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.tsx
@@ -289,6 +289,8 @@ function SpiteAndMalicePageContent() {
               player={opponent}
               cardWidth={cardWidth}
               dataTutorial="sam-opponent"
+              handCountLabel={(count) => t('label.handCount', { count })}
+              goalLabel={(count) => t('label.cpuGoal', { count })}
             />
 
             <div className="flex items-center justify-center gap-2 sm:gap-4" data-tutorial="sam-foundations">
@@ -333,6 +335,9 @@ function SpiteAndMalicePageContent() {
               dataTutorial="sam-hand"
               hintEnabled={hintEnabled}
               currentHint={currentHint}
+              label={t('label.hand')}
+              emptyLabel={t('empty')}
+              hiddenLabel={t('label.hidden')}
             />
 
             <SideRow
@@ -397,28 +402,32 @@ function PlayerSummary({
   player,
   cardWidth,
   dataTutorial,
+  handCountLabel,
+  goalLabel,
 }: {
   label: string;
   sidesLabel: string;
   player: SpiteAndMaliceResponse['players'][number];
   cardWidth: number;
   dataTutorial: string;
+  handCountLabel: (count: number) => string;
+  goalLabel: (count: number) => string;
 }) {
   // Side piles render at half scale to keep the opponent strip compact on mobile.
   const sideWidth = Math.round(cardWidth * 0.5);
   return (
     <div className="flex flex-col items-center" data-tutorial={dataTutorial}>
       <span className="text-sm text-ds-secondary mb-1">
-        {label} (hand: {player.hand.length})
+        {label} ({handCountLabel(player.hand.length)})
       </span>
       <div className="flex gap-2 items-end">
         {player.goalTop ? (
           <div className="flex flex-col items-center">
-            <span className="text-xs text-ds-secondary">CPU goal x{player.goalSize}</span>
+            <span className="text-xs text-ds-secondary">{goalLabel(player.goalSize)}</span>
             <AnimatedCard card={player.goalTop} width={cardWidth} />
           </div>
         ) : (
-          <span className="text-xs text-ds-secondary">CPU goal: 0</span>
+          <span className="text-xs text-ds-secondary">{goalLabel(0)}</span>
         )}
         <div className="flex flex-col items-center" data-testid="sam-cpu-sides">
           <span className="text-xs text-ds-secondary">{sidesLabel}</span>
@@ -558,6 +567,9 @@ function HandRow({
   dataTutorial,
   hintEnabled,
   currentHint,
+  label,
+  emptyLabel,
+  hiddenLabel,
 }: {
   hand: (Card | null)[];
   cardWidth: number;
@@ -566,13 +578,16 @@ function HandRow({
   dataTutorial: string;
   hintEnabled: boolean;
   currentHint: { targetAction: string } | null;
+  label: string;
+  emptyLabel: string;
+  hiddenLabel: string;
 }) {
   return (
     <div className="flex flex-col items-center" data-tutorial={dataTutorial}>
-      <span className="text-sm text-ds-secondary mb-1">Hand</span>
+      <span className="text-sm text-ds-secondary mb-1">{label}</span>
       <div className="flex gap-2 flex-wrap justify-center">
         {hand.length === 0 ? (
-          <span className="text-xs text-ds-secondary">(empty)</span>
+          <span className="text-xs text-ds-secondary">{emptyLabel}</span>
         ) : (
           hand.map((card, idx) => {
             const selected = selectedIdx === idx;
@@ -586,7 +601,7 @@ function HandRow({
                 className={`${focusRingWhite} relative rounded-lg transition-transform ${ring}`}
                 onClick={() => onSelect(idx)}
                 disabled={card === null}
-                aria-label={card ? `Hand ${idx + 1}: ${cardAlt(card)}` : `Hand ${idx + 1}: hidden`}
+                aria-label={`${label} ${(idx + 1).toString()}: ${card ? cardAlt(card) : hiddenLabel}`}
               >
                 {card ? <AnimatedCard card={card} width={cardWidth} /> : <FaceDownSlot label="?" width={cardWidth} />}
               </button>


### PR DESCRIPTION
## 概要
`SpiteAndMalicePage.tsx` のサブコンポーネントに英語リテラルが散在していた。`HandRow` の見出し `Hand`・空表示 `(empty)`・カードの `aria-label` (`Hand N: ...`)、`PlayerSummary` の `(hand: N)`・`CPU goal x{size}`/`CPU goal: 0` をローカライズした。

## 変更点
- `HandRow`: `label`/`emptyLabel`/`hiddenLabel` を props で受け取り、見出し・空表示・カード aria-label に使用
- `PlayerSummary`: `handCountLabel`/`goalLabel` フォーマッタ props を受け取り、手札枚数・CPUゴール枚数をローカライズ
- 呼び出し側で `t('label.hand')`/`t('empty')`/`t('label.hidden')`、`t('label.handCount',{count})`/`t('label.cpuGoal',{count})` を渡す
- `i18n/locales/{ja,en}/spiteandmalice.json`: `label.hidden`/`label.handCount`/`label.cpuGoal` を追加
- CLIフォーマッタの `Foundations tops`/`CPU`/`YOU` (L106-111) はCLI出力のため対象外

## テスト計画
- [x] `SpiteAndMalicePage.test.tsx`: 手札 aria-label (手札 N) と CPUゴール (CPUゴール: 20) がローカライズされ、英語(Hand/CPU goal)を含まないことを検証 (Red→Green)
- [x] `bun run test src/pages/SpiteAndMalicePage.test.tsx` 全15件パス
- [x] `bun run check` パス (exit 0)
- [x] ja/en キー整合

Closes #2603