### PR TITLE
feat(mississippistud): show community-card reveal-count status

### DIFF
--- a/frontend/src/i18n/locales/en/mississippistud.json
+++ b/frontend/src/i18n/locales/en/mississippistud.json
@@ -8,6 +8,7 @@
     "totalPayout": "Total Payout",
     "hand": "Hand",
     "community": "Community Cards",
+    "communityStatus": "Revealed: {{revealed}} / {{total}}",
     "street3": "3rd",
     "street4": "4th",
     "street5": "5th"

--- a/frontend/src/i18n/locales/ja/mississippistud.json
+++ b/frontend/src/i18n/locales/ja/mississippistud.json
@@ -8,6 +8,7 @@
     "totalPayout": "合計配当",
     "hand": "ハンド",
     "community": "コミュニティカード",
+    "communityStatus": "開示済み: {{revealed}} / {{total}}",
     "street3": "3rd",
     "street4": "4th",
     "street5": "5th"

--- a/frontend/src/pages/MississippiStudPage.test.tsx
+++ b/frontend/src/pages/MississippiStudPage.test.tsx
@@ -160,6 +160,13 @@ describe('MississippiStudPage', () => {
     expect(screen.getByText('コミュニティカード')).toBeInTheDocument();
   });
 
+  it('shows the community reveal-count status text', async () => {
+    mockApi.mockResolvedValue(fourthStreetState); // communityRevealed [true,false,false]
+    renderWithProviders(<MississippiStudPage />);
+    await waitFor(() => expect(screen.getByTestId('community-status')).toBeInTheDocument());
+    expect(screen.getByTestId('community-status')).toHaveTextContent('開示済み: 1 / 3');
+  });
+
   it('shows bet-status with street multipliers in street phase', async () => {
     mockApi.mockResolvedValue(fourthStreetState);
     renderWithProviders(<MississippiStudPage />);

--- a/frontend/src/pages/MississippiStudPage.tsx
+++ b/frontend/src/pages/MississippiStudPage.tsx
@@ -224,6 +224,7 @@ function MississippiStudPageContent() {
               className="text-ds-text-muted text-xs text-center mt-1"
               data-testid="community-status"
               aria-live="polite"
+              aria-atomic="true"
             >
               {t('label.communityStatus', {
                 revealed: state.communityRevealed.filter(Boolean).length,

--- a/frontend/src/pages/MississippiStudPage.tsx
+++ b/frontend/src/pages/MississippiStudPage.tsx
@@ -220,6 +220,16 @@ function MississippiStudPageContent() {
                 ),
               )}
             </div>
+            <div
+              className="text-ds-text-muted text-xs text-center mt-1"
+              data-testid="community-status"
+              aria-live="polite"
+            >
+              {t('label.communityStatus', {
+                revealed: state.communityRevealed.filter(Boolean).length,
+                total: state.communityRevealed.length,
+              })}
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
## 概要
`MississippiStudPage.tsx` はコミュニティカードを `??` (AnimatedCardBack) / 実カードで表示するが、3枚中何枚が開示済みかを示すテキストが無かった。CUI は `communityRevealed` に同期して状態を出すのに対し Web は分かりにくい。開示枚数の状況テキストを追加した。

## 変更点
- `MississippiStudPage.tsx`: コミュニティカード直下に `data-testid=community-status` の状況テキストを追加。`state.communityRevealed.filter(Boolean).length` / `length` を `t('label.communityStatus', {revealed, total})` に渡す。`aria-live=polite` 付き
- `i18n/locales/{ja,en}/mississippistud.json`: `label.communityStatus` を追加 (ja=「開示済み: {{revealed}} / {{total}}」, en=「Revealed: ...」)

## テスト計画
- [x] `MississippiStudPage.test.tsx`: 4thストリート(communityRevealed [true,false,false])で「開示済み: 1 / 3」が表示されることを検証 (Red→Green)
- [x] `bun run test src/pages/MississippiStudPage.test.tsx` 全20件パス
- [x] `bun run check` パス (exit 0)
- [x] ja/en キー整合

Closes #2619