### PR TITLE
feat(blackjack): add quick-bet chip shortcuts in bet phase

### DIFF
--- a/frontend/src/components/blackjack/BjBetPhaseControls.test.tsx
+++ b/frontend/src/components/blackjack/BjBetPhaseControls.test.tsx
@@ -7,6 +7,7 @@ function defaultProps(overrides?: Partial<BjBetPhaseControlsProps>): BjBetPhaseC
   return {
     betAmount: 10,
     onBetAmountChange: vi.fn(),
+    playerChips: 1000,
     deckCount: 1,
     onDeckCountChange: vi.fn(),
     cpuPlayerCount: 0,
@@ -49,6 +50,19 @@ describe('BjBetPhaseControls', () => {
     render(<BjBetPhaseControls {...defaultProps({ onBetAmountChange })} />);
     fireEvent.change(screen.getByLabelText('ベット額:'), { target: { value: '100' } });
     expect(onBetAmountChange).toHaveBeenCalledWith(100);
+  });
+
+  it('renders quick-bet chips and applies chip-derived amounts (clamped to chips)', () => {
+    const onBetAmountChange = vi.fn();
+    render(<BjBetPhaseControls {...defaultProps({ onBetAmountChange, playerChips: 1000 })} />);
+    const row = screen.getByTestId('bj-quick-bet');
+    expect(row).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '最小' }));
+    expect(onBetAmountChange).toHaveBeenLastCalledWith(10);
+    fireEvent.click(screen.getByRole('button', { name: '半額' }));
+    expect(onBetAmountChange).toHaveBeenLastCalledWith(500);
+    fireEvent.click(screen.getByRole('button', { name: '全額' }));
+    expect(onBetAmountChange).toHaveBeenLastCalledWith(1000);
   });
 
   it('renders deck count selector with provided value', () => {

--- a/frontend/src/components/blackjack/BjBetPhaseControls.tsx
+++ b/frontend/src/components/blackjack/BjBetPhaseControls.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { btnPrimary, btnSuccess, btnWarning } from '../../styles/buttonStyles';
+import { type BjQuickBetKind, bjQuickBetAmount } from '../../utils/blackjackBet';
 import { ChipBetInput } from '../common/ChipBetInput';
 import {
   BJ_COUNTING_HILO,
@@ -19,6 +20,8 @@ const VALID_SURRENDER_RULES = [0, 1, 2] as const;
 export interface BjBetPhaseControlsProps {
   betAmount: number;
   onBetAmountChange: (v: number) => void;
+  /** The player's current chip balance, used to derive quick-bet amounts. */
+  playerChips: number;
   deckCount: number;
   onDeckCountChange: (v: number) => void;
   cpuPlayerCount: number;
@@ -54,6 +57,20 @@ export function BjBetPhaseControls(props: BjBetPhaseControlsProps) {
   const { t } = useTranslation('blackjack');
   return (
     <>
+      {/* Quick-bet shortcuts derived from the player's chips */}
+      <div className="flex items-center justify-center gap-2 mb-2" data-testid="bj-quick-bet">
+        {(['min', 'half', 'max'] as BjQuickBetKind[]).map((kind) => (
+          <button
+            key={kind}
+            type="button"
+            className={`${btnPrimary} min-w-[44px] min-h-[44px] px-3 text-sm`}
+            disabled={props.loading}
+            onClick={() => props.onBetAmountChange(bjQuickBetAmount(kind, props.playerChips))}
+          >
+            {t(`betChip.${kind}`)}
+          </button>
+        ))}
+      </div>
       {/* Basic settings: bet amount, hand count */}
       <div className="flex items-center justify-center gap-2 mb-2">
         <ChipBetInput

--- a/frontend/src/i18n/locales/en/blackjack.json
+++ b/frontend/src/i18n/locales/en/blackjack.json
@@ -38,6 +38,9 @@
     "continue": "Continue"
   },
   "betAmount": "Bet Amount:",
+  "betChip.min": "Min",
+  "betChip.half": "Half",
+  "betChip.max": "Max",
   "deckCount": "Decks:",
   "cpuCount": "CPU Players:",
   "cpuUnit": "",

--- a/frontend/src/i18n/locales/ja/blackjack.json
+++ b/frontend/src/i18n/locales/ja/blackjack.json
@@ -37,6 +37,9 @@
     "continue": "続行"
   },
   "betAmount": "ベット額:",
+  "betChip.min": "最小",
+  "betChip.half": "半額",
+  "betChip.max": "全額",
   "deckCount": "デッキ数:",
   "cpuCount": "CPU人数:",
   "cpuUnit": "人",

--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -532,6 +532,7 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
                     <BjBetPhaseControls
                       betAmount={betAmount}
                       onBetAmountChange={setBetAmount}
+                      playerChips={playerChips}
                       deckCount={state?.deckCount ?? 1}
                       onDeckCountChange={(v) => exec('setdeckcount', v)}
                       cpuPlayerCount={cpuPlayerCount}

--- a/frontend/src/utils/blackjackBet.test.ts
+++ b/frontend/src/utils/blackjackBet.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { BJ_MIN_BET, bjQuickBetAmount } from './blackjackBet';
+
+describe('bjQuickBetAmount', () => {
+  it('returns the table minimum for "min"', () => {
+    expect(bjQuickBetAmount('min', 1000)).toBe(BJ_MIN_BET);
+    expect(bjQuickBetAmount('min', 30)).toBe(BJ_MIN_BET);
+  });
+
+  it('returns half the chips rounded down to a 10-multiple for "half"', () => {
+    expect(bjQuickBetAmount('half', 1000)).toBe(500);
+    expect(bjQuickBetAmount('half', 250)).toBe(120); // floor(125/10)*10
+  });
+
+  it('returns all chips rounded down to a 10-multiple for "max"', () => {
+    expect(bjQuickBetAmount('max', 1000)).toBe(1000);
+    expect(bjQuickBetAmount('max', 255)).toBe(250);
+  });
+
+  it('never exceeds the available chips (clamps half/max)', () => {
+    expect(bjQuickBetAmount('half', 15)).toBeLessThanOrEqual(15);
+    expect(bjQuickBetAmount('max', 15)).toBeLessThanOrEqual(15);
+  });
+});

--- a/frontend/src/utils/blackjackBet.test.ts
+++ b/frontend/src/utils/blackjackBet.test.ts
@@ -17,8 +17,10 @@ describe('bjQuickBetAmount', () => {
     expect(bjQuickBetAmount('max', 255)).toBe(250);
   });
 
-  it('never exceeds the available chips (clamps half/max)', () => {
-    expect(bjQuickBetAmount('half', 15)).toBeLessThanOrEqual(15);
-    expect(bjQuickBetAmount('max', 15)).toBeLessThanOrEqual(15);
+  it('never exceeds the available chips, including below the table minimum', () => {
+    for (const kind of ['min', 'half', 'max'] as const) {
+      expect(bjQuickBetAmount(kind, 5)).toBeLessThanOrEqual(5);
+      expect(bjQuickBetAmount(kind, 15)).toBeLessThanOrEqual(15);
+    }
   });
 });

--- a/frontend/src/utils/blackjackBet.ts
+++ b/frontend/src/utils/blackjackBet.ts
@@ -20,10 +20,10 @@ function floorToStep(amount: number): number {
 export function bjQuickBetAmount(kind: BjQuickBetKind, playerChips: number): number {
   switch (kind) {
     case 'min':
-      return BJ_MIN_BET;
+      return Math.min(playerChips, BJ_MIN_BET);
     case 'half':
       return Math.min(playerChips, Math.max(BJ_MIN_BET, floorToStep(playerChips / 2)));
     case 'max':
-      return Math.max(BJ_MIN_BET, floorToStep(playerChips));
+      return Math.min(playerChips, Math.max(BJ_MIN_BET, floorToStep(playerChips)));
   }
 }

--- a/frontend/src/utils/blackjackBet.ts
+++ b/frontend/src/utils/blackjackBet.ts
@@ -1,0 +1,29 @@
+/** Minimum BlackJack table bet (matches the bet input's min/step). */
+export const BJ_MIN_BET = 10;
+
+/** Quick-bet shortcut kinds offered in the bet phase. */
+export type BjQuickBetKind = 'min' | 'half' | 'max';
+
+/** Round a chip amount down to the nearest valid (10-multiple) bet. */
+function floorToStep(amount: number): number {
+  return Math.floor(Math.max(0, amount) / BJ_MIN_BET) * BJ_MIN_BET;
+}
+
+/**
+ * Computes the bet amount for a quick-bet shortcut from the player's chips.
+ * `half` and `max` are rounded down to a 10-multiple and never exceed `playerChips`.
+ *
+ * @param kind - Which shortcut: table minimum, half the chips, or all chips.
+ * @param playerChips - The player's current chip balance.
+ * @returns The bet amount to apply.
+ */
+export function bjQuickBetAmount(kind: BjQuickBetKind, playerChips: number): number {
+  switch (kind) {
+    case 'min':
+      return BJ_MIN_BET;
+    case 'half':
+      return Math.min(playerChips, Math.max(BJ_MIN_BET, floorToStep(playerChips / 2)));
+    case 'max':
+      return Math.max(BJ_MIN_BET, floorToStep(playerChips));
+  }
+}


### PR DESCRIPTION
## 概要
ベットフェーズで毎回ベット額を手入力する必要があり、特にモバイルで煩雑だった。所持チップから算出した「最小 / 半額 / 全額」のワンタップ・クイックベットチップ行を追加した。

## 変更点
- `utils/blackjackBet.ts`: 純粋関数 `bjQuickBetAmount(kind, playerChips)` を新設（10刻みに切り捨て、所持チップにクランプ）+ ユニットテスト
- `BjBetPhaseControls.tsx`: ベット入力の上に `最小/半額/全額` ボタン行 (`data-testid=bj-quick-bet`) を追加。44×44px タップ領域、`playerChips` prop を追加
- `BlackJackPage.tsx`: `playerChips` を渡す
- `i18n/locales/{ja,en}/blackjack.json`: `betChip.min/half/max` を追加

## テスト計画
- [x] `blackjackBet.test.ts`: min/half/max とチップ超過クランプを検証
- [x] `BjBetPhaseControls.test.tsx`: クイックベット行が表示され、各ボタンがチップ連動額(10/500/1000)で `onBetAmountChange` を呼ぶことを検証
- [x] `BlackJackPage.test.tsx` 全131件パス
- [x] `bun run check` パス (exit 0)、ja/en キー整合

Closes #2528