### PR TITLE
feat(sevens): prompt to pass when no card is playable

### DIFF
--- a/frontend/src/components/sevens/SevensHumanArea.test.tsx
+++ b/frontend/src/components/sevens/SevensHumanArea.test.tsx
@@ -57,6 +57,13 @@ describe('SevensHumanArea', () => {
     expect(screen.queryByText('出せるカードをクリック')).not.toBeInTheDocument();
   });
 
+  it('shows a must-pass hint when no card is playable on the human turn', () => {
+    // Only 7s are on the table; a lone 3 is not adjacent and there is no joker.
+    render(<SevensHumanArea {...defaultProps} player={makePlayer({ cards: [heart3], cardCount: 1 })} />);
+    expect(screen.getByTestId('sv-must-pass')).toBeInTheDocument();
+    expect(screen.queryByText('出せるカードをクリック')).not.toBeInTheDocument();
+  });
+
   it('renders card buttons with focus-visible ring class', () => {
     render(<SevensHumanArea {...defaultProps} />);
     const buttons = screen.getAllByRole('button');

--- a/frontend/src/components/sevens/SevensHumanArea.tsx
+++ b/frontend/src/components/sevens/SevensHumanArea.tsx
@@ -36,6 +36,23 @@ function HumanArea({
 }: HumanAreaProps) {
   const { t } = useTranslation('sevens');
   const { cardWidth } = useCardDimensions();
+  // Whether the human has at least one legal move this turn (cards or a joker placement).
+  const anyPlayable =
+    isCurrentTurn &&
+    !loading &&
+    (player.cards ?? []).some((card) =>
+      isCardPlayable(
+        card,
+        tablePlaced,
+        tunnelEnabled,
+        noJokerFinish,
+        player.cards,
+        endStopEnabled,
+        jokerConsecutiveBanned,
+        player.lastPlayedJoker,
+        tunnelSkipWidth,
+      ),
+    );
   const conditionalClass = player.isFinished
     ? 'opacity-50'
     : isCurrentTurn
@@ -55,7 +72,14 @@ function HumanArea({
             used: player.passesUsed,
             max: player.maxPasses === 0 ? t('passUnlimited') : player.maxPasses,
           })}
-          {isCurrentTurn && <span className="ml-2 text-game-text-highlight">{t('clickPlayable')}</span>}
+          {isCurrentTurn &&
+            (anyPlayable ? (
+              <span className="ml-2 text-game-text-highlight">{t('clickPlayable')}</span>
+            ) : (
+              <span className="ml-2 text-ds-warning" data-testid="sv-must-pass">
+                {t('mustPass')}
+              </span>
+            ))}
         </div>
       )}
       <div className="flex flex-wrap gap-1">

--- a/frontend/src/i18n/locales/en/sevens.json
+++ b/frontend/src/i18n/locales/en/sevens.json
@@ -7,6 +7,7 @@
   "passCount": "Pass: {{used}}/{{max}}",
   "passUnlimited": "∞",
   "clickPlayable": "Click a playable card",
+  "mustPass": "No playable cards — please pass",
   "playTitle": "Play: {{design}} {{value}}",
   "rankLabel": "#{{rank}}",
   "placeAriaLabel": "Place at {{suit}} {{value}}",

--- a/frontend/src/i18n/locales/ja/sevens.json
+++ b/frontend/src/i18n/locales/ja/sevens.json
@@ -7,6 +7,7 @@
   "passCount": "パス: {{used}}/{{max}}",
   "passUnlimited": "∞",
   "clickPlayable": "出せるカードをクリック",
+  "mustPass": "出せるカードがありません — パスしてください",
   "playTitle": "出す: {{design}} {{value}}",
   "rankLabel": "{{rank}}位",
   "placeAriaLabel": "{{suit}} {{value}} に配置",


### PR DESCRIPTION
## 概要
`SevensHumanArea` は既に `isCardPlayable` で出せる手札をリング強調・出せない札を淡色化しているが（既存実装）、合法手が1枚も無いときも「出せるカードをクリック」と表示され、パスすべき状況が伝わらなかった。合法手ゼロ時にパスを促すヒントを追加した。

## 変更点
- `SevensHumanArea.tsx`: `anyPlayable`（手札＋ジョーカー配置を `isCardPlayable` で判定）を算出し、現在ターンで合法手が無いとき `clickPlayable` の代わりに警告色の `mustPass` ヒント (`data-testid=sv-must-pass`) を表示
- `i18n/locales/{ja,en}/sevens.json`: `mustPass` キーを追加

## 備考
ハイライト/淡色化（受け入れ条件1・2）と tunnel/endStop/jokerConsecutiveBanned 判定は既存実装で満たされていたため、本PRは未実装だった「合法手ゼロ時のパス誘導」（受け入れ条件3）に絞って追加した。

## テスト計画
- [x] `SevensHumanArea.test.tsx`: 合法手ゼロの手札で `sv-must-pass` が表示され clickPlayable が出ないことを検証（全19件パス）
- [x] `bun run check` パス (exit 0)、ja/en キー整合

Closes #2533