### PR TITLE
feat(holdem): label the winning hand beside the board best-5

### DIFF
--- a/frontend/src/i18n/locales/en/holdem.json
+++ b/frontend/src/i18n/locales/en/holdem.json
@@ -10,6 +10,7 @@
     "rebuy": "Rebuy/Addon"
   },
   "communityCards": "Community Cards",
+  "winningHand": "Hand: {{hand}}",
   "yourHand": "Your Hand",
   "handNumber": "Hand #{{count}} (Level up: every {{level}} hands)",
   "rebuy": {

--- a/frontend/src/i18n/locales/ja/holdem.json
+++ b/frontend/src/i18n/locales/ja/holdem.json
@@ -10,6 +10,7 @@
     "rebuy": "リバイ/アドオン"
   },
   "communityCards": "コミュニティカード",
+  "winningHand": "役: {{hand}}",
   "yourHand": "あなたの手札",
   "handNumber": "ハンド#{{count}} (レベルアップ:{{level}}ハンド毎)",
   "rebuy": {

--- a/frontend/src/pages/HoldemPage.test.tsx
+++ b/frontend/src/pages/HoldemPage.test.tsx
@@ -345,6 +345,27 @@ describe('HoldemPage', () => {
     await waitFor(() => expect(screen.getByText('ツーペア')).toBeInTheDocument());
   });
 
+  it('shows the winning-hand label beside the board best-5 at showdown', async () => {
+    mockExec.mockResolvedValue(showdownState);
+    renderWithProviders(<HoldemPage />);
+    const label = await screen.findByTestId('board-winning-hand');
+    expect(label).toHaveTextContent('ワンペア');
+  });
+
+  it('omits the board winning-hand label when the human has folded', async () => {
+    mockExec.mockResolvedValue({
+      ...showdownState,
+      players: [
+        humanPlayer({ handName: 'ワンペア', folded: true }),
+        showdownState.players[1],
+        showdownState.players[2],
+      ],
+    });
+    renderWithProviders(<HoldemPage />);
+    await waitFor(() => expect(screen.getByText('ツーペア')).toBeInTheDocument());
+    expect(screen.queryByTestId('board-winning-hand')).not.toBeInTheDocument();
+  });
+
   it('does not show CPU hand name badge when CPU is folded in showdown', async () => {
     // CPU 2 is folded in showdownState → no hand name
     mockExec.mockResolvedValue(showdownState);

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -32,9 +32,9 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
+import { badgeSuccessColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { placeholderCardStyle } from '../styles/cardStyles';
-import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { HoldemResponse } from '../types/card';
@@ -273,7 +273,17 @@ function HoldemPageContent() {
             {(() => {
               const communityCardsContent = (
                 <>
-                  <div className="text-ds-text-primary text-lg mb-1.5">{t('communityCards')}</div>
+                  <div className="text-ds-text-primary text-lg mb-1.5">
+                    {t('communityCards')}
+                    {isShowdown && !humanPlayer.folded && humanPlayer.handName && (
+                      <span
+                        className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${badgeSuccessColors}`}
+                        data-testid="board-winning-hand"
+                      >
+                        {t('winningHand', { hand: humanPlayer.handName })}
+                      </span>
+                    )}
+                  </div>
                   <div className="flex flex-wrap gap-2">
                     {state?.communityCards?.length
                       ? state.communityCards.map((card, idx) => {
@@ -377,7 +387,7 @@ function HoldemPageContent() {
                   {humanPlayer.folded && <span className="ml-2 text-ds-error text-xs">[{tc('status.folded')}]</span>}
                   {humanPlayer.allIn && <span className="ml-2 text-ds-warning text-xs">[{tc('status.allIn')}]</span>}
                   {isShowdown && !humanPlayer.folded && humanPlayer.handName && (
-                    <span className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}>
+                    <span className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${badgeSuccessColors}`}>
                       {humanPlayer.handName}
                     </span>
                   )}

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -275,7 +275,7 @@ function HoldemPageContent() {
                 <>
                   <div className="text-ds-text-primary text-lg mb-1.5">
                     {t('communityCards')}
-                    {isShowdown && !humanPlayer.folded && humanPlayer.handName && (
+                    {isShowdown && humanPlayer && !humanPlayer.folded && humanPlayer.handName && (
                       <span
                         className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${badgeSuccessColors}`}
                         data-testid="board-winning-hand"


### PR DESCRIPTION
## 概要
ショーダウンのベスト5強調（`ring-ds-success`）はあるが、役名バッジが手札側にだけ・中立色で表示され、強調5枚と役名の結び付きが弱かった。盤面側に役名ラベルを追加し、色を強調リングに揃えた。

## 変更点
- `HoldemPage.tsx`: コミュニティカード見出し横にショーダウン時の役名ラベル (`data-testid=board-winning-hand`, `badgeSuccessColors`) を追加。手札側の役名バッジも `badgeSuccessColors` に変更し `ring-ds-success` と色対応。未使用化した `handNameBadgeClass` import を削除
- `i18n/locales/{ja,en}/holdem.json`: `winningHand` キーを追加

## 備考
CPUカードのベスト5強調は提案の「可能であれば」項目（受け入れ条件外）かつ共有コンポーネント `CpuPlayerCard` に影響するため本PRでは対象外。フォールド時は従来通り非表示（受け入れ条件3）。

## テスト計画
- [x] `HoldemPage.test.tsx`: ショーダウンで盤面の役名ラベルが表示され、フォールド時は非表示を検証（全116件パス）
- [x] `bun run check` パス (exit 0)、ja/en キー整合

Closes #2535