### PR TITLE
feat(omaha): surface the 2-hole+3-board rule at showdown and in learning mode

### DIFF
--- a/frontend/src/i18n/locales/en/omaha.json
+++ b/frontend/src/i18n/locales/en/omaha.json
@@ -10,6 +10,9 @@
     "rebuy": "Rebuy/Addon"
   },
   "communityCards": "Community Cards",
+  "rule": {
+    "use2of4": "Use exactly 2 hole + 3 board cards"
+  },
   "yourHand": "Your Hand",
   "mandatoryRule": "Rule: 2 hole + 3 board",
   "mandatoryRuleAria": "Omaha rule: you must use exactly 2 hole cards and exactly 3 board cards",

--- a/frontend/src/i18n/locales/ja/omaha.json
+++ b/frontend/src/i18n/locales/ja/omaha.json
@@ -10,6 +10,9 @@
     "rebuy": "リバイ/アドオン"
   },
   "communityCards": "コミュニティカード",
+  "rule": {
+    "use2of4": "ホール2枚＋ボード3枚で構成"
+  },
   "yourHand": "あなたの手札",
   "mandatoryRule": "ルール: 手札から2枚 + 場札から3枚",
   "mandatoryRuleAria": "オマハのルール: 手札ちょうど2枚と場札ちょうど3枚を使います",

--- a/frontend/src/pages/OmahaPage.test.tsx
+++ b/frontend/src/pages/OmahaPage.test.tsx
@@ -366,6 +366,21 @@ describe('OmahaPage', () => {
     await waitFor(() => expect(screen.getByText('ツーペア')).toBeInTheDocument());
   });
 
+  it('shows the 2-hole+3-board constraint note by the board at showdown', async () => {
+    mockExec.mockResolvedValue(showdownState);
+    renderWithProviders(<OmahaPage />);
+    expect(await screen.findByTestId('omaha-rule-note')).toBeInTheDocument();
+  });
+
+  it('shows the use-2-of-4 rule hint only when learning mode is enabled', async () => {
+    mockExec.mockResolvedValue(preFlopState);
+    renderWithProviders(<OmahaPage />);
+    await waitFor(() => expect(screen.getByText('ラーニングモード')).toBeInTheDocument());
+    expect(screen.queryByTestId('omaha-rule-hint')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('ラーニングモード'));
+    expect(screen.getByTestId('omaha-rule-hint')).toBeInTheDocument();
+  });
+
   it('highlights exactly 2 hole + 3 board cards as the best-5 at showdown', async () => {
     mockExec.mockResolvedValue(showdownState);
     const { container } = renderWithProviders(<OmahaPage />);

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -32,6 +32,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
+import { badgeInfoColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { placeholderCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
@@ -261,7 +262,17 @@ function OmahaPageContent() {
             {(() => {
               const communityCardsContent = (
                 <>
-                  <div className="text-ds-text-primary text-lg mb-1.5">{t('communityCards')}</div>
+                  <div className="text-ds-text-primary text-lg mb-1.5">
+                    {t('communityCards')}
+                    {isShowdown && humanPlayer && !humanPlayer.folded && humanPlayer.handName && (
+                      <span
+                        className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${badgeInfoColors}`}
+                        data-testid="omaha-rule-note"
+                      >
+                        {t('rule.use2of4')}
+                      </span>
+                    )}
+                  </div>
                   <div className="flex flex-wrap gap-2">
                     {state?.communityCards?.length
                       ? state.communityCards.map((card, idx) => {
@@ -534,6 +545,11 @@ function OmahaPageContent() {
                     onChange={(e) => setLearningMode(e.target.checked)}
                   />
                 </div>
+                {learningMode && (
+                  <p className="text-ds-text-muted text-xs mb-1" data-testid="omaha-rule-hint">
+                    {t('rule.use2of4')}
+                  </p>
+                )}
                 {learningMode && state?.equity && state.potOdds != null && (
                   <EquityDisplay equity={state.equity} potOdds={state.potOdds} />
                 )}


### PR DESCRIPTION
## 概要
オマハ特有の「必ずホール2枚＋ボード3枚を使う」ルールが文章で説明されておらず、ベスト5強調を見ても初心者がホールデムと混同しやすかった。ショーダウン時の注記とラーニングモードのルールヒントを追加した。

## 変更点
- `OmahaPage.tsx`: コミュニティ見出し横にショーダウン時の制約注記 (`data-testid=omaha-rule-note`, `badgeInfoColors`、`humanPlayer &&` ガード付き) を追加。`learningMode` 有効時にルールヒント (`data-testid=omaha-rule-hint`) を表示
- `i18n/locales/{ja,en}/omaha.json`: ネストキー `rule.use2of4` を追加

## テスト計画
- [x] `OmahaPage.test.tsx`: ショーダウンで注記表示、ラーニングモード切替でヒント表示/非表示を検証（全114件パス）
- [x] `bun run check` パス (exit 0)、ja/en キー整合

Closes #2536