### PR TITLE
feat(omahahilo): visualize the qualifying low at showdown

### DIFF
--- a/frontend/src/i18n/locales/en/omahahilo.json
+++ b/frontend/src/i18n/locales/en/omahahilo.json
@@ -3,7 +3,8 @@
     "title": "Hi/Lo split",
     "hi": "Hi",
     "lo": "Lo",
-    "winner": "{{name}} (+{{amount}})"
+    "winner": "{{name}} (+{{amount}})",
+    "hiTakesAll": "No qualifying low — Hi scoops the pot"
   },
   "phase": {
     "preFlop": "Pre-Flop",

--- a/frontend/src/i18n/locales/ja/omahahilo.json
+++ b/frontend/src/i18n/locales/ja/omahahilo.json
@@ -3,7 +3,8 @@
     "title": "ハイ/ロー内訳",
     "hi": "ハイ",
     "lo": "ロー",
-    "winner": "{{name}} (+{{amount}})"
+    "winner": "{{name}} (+{{amount}})",
+    "hiTakesAll": "ロー該当者なし — ハイが総取り"
   },
   "phase": {
     "preFlop": "プリフロップ",

--- a/frontend/src/pages/OmahaHiLoPage.test.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.test.tsx
@@ -390,6 +390,37 @@ describe('OmahaHiLoPage', () => {
     renderWithProviders(<OmahaHiLoPage />);
     await waitFor(() => expect(screen.getByTestId('omahahilo-hi-badge')).toBeInTheDocument());
     expect(screen.queryByTestId('omahahilo-lo-badge')).not.toBeInTheDocument();
+    // With no qualifying low, the breakdown states that Hi scoops the pot.
+    expect(screen.getByTestId('omahahilo-hi-takes-all')).toBeInTheDocument();
+  });
+
+  it('highlights the human qualifying low and lists the low cards', async () => {
+    // Human hole A♠,K♥,10♦,5♣; board 10♠,5♥,8♦,2♣,9♥.
+    const lowState: OmahaResponse = {
+      ...showdownState,
+      roundResults: [
+        {
+          ...showdownState.roundResults[0],
+          hiWonAmount: 0,
+          lowWonAmount: 100,
+          lowBestHand: [
+            { design: 'SPADE', value: 1 },
+            { design: 'CLOVER', value: 5 },
+            { design: 'DIAMOND', value: 8 },
+            { design: 'CLOVER', value: 2 },
+            { design: 'HEART', value: 5 },
+          ],
+        },
+        { ...showdownState.roundResults[1], hiWonAmount: 200, lowWonAmount: 0 },
+      ],
+    };
+    mockExec.mockResolvedValue(lowState);
+    renderWithProviders(<OmahaHiLoPage />);
+    await waitFor(() => expect(screen.getByTestId('omahahilo-split')).toBeInTheDocument());
+    // At least one card (hole and/or board) is ringed as a low card.
+    expect(screen.getAllByTestId('omahahilo-lo-card').length).toBeGreaterThan(0);
+    // The low winner badge lists the qualifying card ranks.
+    expect(screen.getByTestId('omahahilo-lo-badge')).toHaveTextContent('A 5 8 2 5');
   });
 
   it('does not show CPU hand name badge when CPU is folded in showdown', async () => {

--- a/frontend/src/pages/OmahaHiLoPage.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.tsx
@@ -40,9 +40,11 @@ import { gameTheme } from '../styles/gameTheme';
 import type { OmahaResponse } from '../types/card';
 import { OmahaPhase, OmahaRebuyPhaseType } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { valueName } from '../utils/cardUtils';
 import { OMAHA_HELP, parseOmahaCommand } from '../utils/cli/commands/omahaCommands';
 import { formatOmahaState } from '../utils/cli/formatters/omahaFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { lowCardIndexSets } from '../utils/omahaLowCards';
 import { findPlayerName } from '../utils/playerUtils';
 
 /** Omaha Hi-Lo (8 or Better) tutorial step definitions. */
@@ -167,6 +169,11 @@ function OmahaHiLoPageContent() {
   const humanAllIn = humanPlayer?.allIn ?? false;
   const canAct = isActive && !humanFolded && !humanAllIn && state?.currentTurn === humanPlayer?.id;
   const hasOutstandingBet = (state?.lastBet ?? 0) > (humanPlayer?.currentBet ?? 0);
+  // At showdown, highlight the human's qualifying low cards (hole + board), if any.
+  const humanLowBestHand = isShowdown
+    ? state?.roundResults?.find((r) => r.playerIdx === humanPlayer?.id)?.lowBestHand
+    : undefined;
+  const lowSets = lowCardIndexSets(humanLowBestHand, humanPlayer?.cards ?? [], state?.communityCards ?? []);
   const minRaise = state?.minRaise ?? 0;
   const isMuckPhase = phase === OmahaPhase.SHOWDOWN && state?.muckAvailable === true;
   const isRebuyPhase = phase === OmahaPhase.REBUY && state?.rebuyPhaseType === OmahaRebuyPhaseType.REBUY;
@@ -253,13 +260,18 @@ function OmahaHiLoPageContent() {
                   <div className="text-ds-text-primary text-lg mb-1.5">{t('communityCards')}</div>
                   <div className="flex flex-wrap gap-2">
                     {state?.communityCards?.length
-                      ? state.communityCards.map((card) => (
-                          <AnimatedCard
+                      ? state.communityCards.map((card, idx) => (
+                          <div
                             key={`${card.design}-${card.value}`}
-                            card={card}
-                            width={cardWidth}
-                            style={placeholderCardStyle}
-                          />
+                            className={
+                              lowSets.loBoardSet.has(idx)
+                                ? 'rounded-lg ring-2 ring-ds-info motion-safe:animate-pulse'
+                                : ''
+                            }
+                            data-testid={lowSets.loBoardSet.has(idx) ? 'omahahilo-lo-card' : undefined}
+                          >
+                            <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
+                          </div>
                         ))
                       : Array.from({ length: 5 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                   </div>
@@ -327,7 +339,15 @@ function OmahaHiLoPageContent() {
                   r.hiWonAmount ? [{ name: findPlayerName(state.players, r.playerIdx), amount: r.hiWonAmount }] : [],
                 );
                 const loWinners = state.roundResults.flatMap((r) =>
-                  r.lowWonAmount ? [{ name: findPlayerName(state.players, r.playerIdx), amount: r.lowWonAmount }] : [],
+                  r.lowWonAmount
+                    ? [
+                        {
+                          name: findPlayerName(state.players, r.playerIdx),
+                          amount: r.lowWonAmount,
+                          cards: (r.lowBestHand ?? []).map((card) => valueName(card.value)).join(' '),
+                        },
+                      ]
+                    : [],
                 );
                 if (hiWinners.length === 0 && loWinners.length === 0) return null;
                 return (
@@ -350,9 +370,15 @@ function OmahaHiLoPageContent() {
                           className="inline-block rounded border border-ds-info bg-ds-surface px-2 py-0.5 text-ds-info"
                         >
                           {t('hiLo.lo')}: {t('hiLo.winner', { name: w.name, amount: w.amount })}
+                          {w.cards && ` (${w.cards})`}
                         </span>
                       ))}
                     </div>
+                    {loWinners.length === 0 && hiWinners.length > 0 && (
+                      <div className="mt-1 text-xs text-ds-text-muted" data-testid="omahahilo-hi-takes-all">
+                        {t('hiLo.hiTakesAll')}
+                      </div>
+                    )}
                   </div>
                 );
               })()}
@@ -408,13 +434,16 @@ function OmahaHiLoPageContent() {
                 </div>
                 <div className="flex flex-wrap gap-1.5 mb-2" data-tutorial="ohl-combination-rule">
                   {humanPlayer.cards?.length
-                    ? humanPlayer.cards.map((card) => (
-                        <AnimatedCard
+                    ? humanPlayer.cards.map((card, idx) => (
+                        <div
                           key={`${card.design}-${card.value}`}
-                          card={card}
-                          width={cardWidth}
-                          style={placeholderCardStyle}
-                        />
+                          className={
+                            lowSets.loHoleSet.has(idx) ? 'rounded-lg ring-2 ring-ds-info motion-safe:animate-pulse' : ''
+                          }
+                          data-testid={lowSets.loHoleSet.has(idx) ? 'omahahilo-lo-card' : undefined}
+                        >
+                          <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
+                        </div>
                       ))
                     : !humanPlayer.folded &&
                       Array.from({ length: 4 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}

--- a/frontend/src/utils/omahaLowCards.test.ts
+++ b/frontend/src/utils/omahaLowCards.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { lowCardIndexSets } from './omahaLowCards';
+
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('lowCardIndexSets', () => {
+  const hole = [c('SPADE', 1), c('HEART', 2), c('DIAMOND', 13), c('CLOVER', 12)];
+  const board = [c('SPADE', 3), c('HEART', 4), c('DIAMOND', 7), c('CLOVER', 10), c('SPADE', 9)];
+
+  it('maps a qualifying low hand to hole and board indices', () => {
+    // Low hand A,2 (hole 0,1) + 3,4,7 (board 0,1,2)
+    const low = [c('SPADE', 1), c('HEART', 2), c('SPADE', 3), c('HEART', 4), c('DIAMOND', 7)];
+    const { loHoleSet, loBoardSet } = lowCardIndexSets(low, hole, board);
+    expect([...loHoleSet].sort()).toEqual([0, 1]);
+    expect([...loBoardSet].sort()).toEqual([0, 1, 2]);
+  });
+
+  it('returns empty sets when there is no qualifying low', () => {
+    const { loHoleSet, loBoardSet } = lowCardIndexSets(undefined, hole, board);
+    expect(loHoleSet.size).toBe(0);
+    expect(loBoardSet.size).toBe(0);
+  });
+
+  it('ignores cards not present in the hole or board', () => {
+    const low = [c('SPADE', 5)]; // not in hole/board
+    const { loHoleSet, loBoardSet } = lowCardIndexSets(low, hole, board);
+    expect(loHoleSet.size).toBe(0);
+    expect(loBoardSet.size).toBe(0);
+  });
+});

--- a/frontend/src/utils/omahaLowCards.ts
+++ b/frontend/src/utils/omahaLowCards.ts
@@ -1,0 +1,43 @@
+import type { Card } from '../types/card';
+
+/** Index sets identifying a player's qualifying low cards within their hole and the board. */
+export interface LowCardIndexSets {
+  loHoleSet: Set<number>;
+  loBoardSet: Set<number>;
+}
+
+/** Match two cards by design and value (single deck → unique). */
+function sameCard(a: Card, b: Card): boolean {
+  return a.design === b.design && a.value === b.value;
+}
+
+/**
+ * Maps an Omaha Hi-Lo qualifying low hand to the indices of the matching cards
+ * in the player's hole and the community board, so they can be highlighted.
+ *
+ * @param lowBestHand - The five cards forming the qualifying low (or undefined if none).
+ * @param holeCards - The player's hole cards.
+ * @param communityCards - The shared board cards.
+ * @returns Sets of hole and board indices that belong to the low hand.
+ */
+export function lowCardIndexSets(
+  lowBestHand: Card[] | undefined,
+  holeCards: Card[],
+  communityCards: Card[],
+): LowCardIndexSets {
+  const loHoleSet = new Set<number>();
+  const loBoardSet = new Set<number>();
+  if (!lowBestHand || lowBestHand.length === 0) {
+    return { loHoleSet, loBoardSet };
+  }
+  for (const low of lowBestHand) {
+    const h = holeCards.findIndex((card) => sameCard(card, low));
+    if (h >= 0) {
+      loHoleSet.add(h);
+      continue;
+    }
+    const b = communityCards.findIndex((card) => sameCard(card, low));
+    if (b >= 0) loBoardSet.add(b);
+  }
+  return { loHoleSet, loBoardSet };
+}


### PR DESCRIPTION
## 概要
ハイ/ロー内訳は勝者の名前・配当のみで、ローがどのカードでなぜ成立/不成立したかがカードでも文章でも見えなかった。ショーダウン時にロー成立札を可視化した。

## 変更点
- `utils/omahaLowCards.ts`: 純粋関数 `lowCardIndexSets(lowBestHand, hole, community)` を新設（design+value一致でホール/ボードのインデックス集合を算出）+ ユニットテスト
- `OmahaHiLoPage.tsx`: ショーダウンで人間の `lowBestHand`（`roundResults`）に対応するホール/ボード札を青リング (`ring-ds-info`, `data-testid=omahahilo-lo-card`) で強調。ロー勝者バッジにロー5枚のランク (`valueName`) を併記。ロー該当者なし時に「ハイが総取り」メッセージ (`omahahilo-hi-takes-all`) を表示
- `i18n/locales/{ja,en}/omahahilo.json`: ネストキー `hiLo.hiTakesAll` を追加

## 備考
当ページには元々ベスト5のカード強調が無く（ハイ含め）、ロー強調が初の強調表示。ハイ強調が無いため「別色」競合は発生しない。CPU札は共有 `CpuPlayerCard` のため対象外（人間の成立ロー中心）。

## テスト計画
- [x] `omahaLowCards.test.ts`: インデックス対応/非成立/不一致を検証
- [x] `OmahaHiLoPage.test.tsx`: ロー強調カード表示・ロー5枚併記・ハイ総取りメッセージを検証（全114件パス）
- [x] `bun run check` パス (exit 0)、ja/en キー整合

Closes #2537