### PR TITLE
feat(pigtail): show the center card's rank, not just its suit

### DIFF
--- a/frontend/src/pages/PigsTailPage.test.tsx
+++ b/frontend/src/pages/PigsTailPage.test.tsx
@@ -111,6 +111,18 @@ describe('PigsTailPage', () => {
     });
   });
 
+  it('shows the center top card rank and suit (not just the suit symbol)', async () => {
+    mockExec.mockResolvedValue({
+      ...baseState,
+      centerTop: { design: 'SPADE', value: 1 },
+      centerCount: 3,
+    });
+    renderWithProviders(<PigsTailPage />);
+    const center = await screen.findByTestId('pt-center-top');
+    // Rank (A) must be visible alongside the suit symbol.
+    expect(center).toHaveTextContent('♠A');
+  });
+
   it('draw button is disabled on game end', async () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<PigsTailPage />);

--- a/frontend/src/pages/PigsTailPage.test.tsx
+++ b/frontend/src/pages/PigsTailPage.test.tsx
@@ -123,6 +123,17 @@ describe('PigsTailPage', () => {
     expect(center).toHaveTextContent('♠A');
   });
 
+  it('falls back to "?" for a card whose design has no suit symbol', async () => {
+    mockExec.mockResolvedValue({
+      ...baseState,
+      centerTop: { design: 'JOKER', value: 0 },
+      centerCount: 1,
+    });
+    renderWithProviders(<PigsTailPage />);
+    const center = await screen.findByTestId('pt-center-top');
+    expect(center).toHaveTextContent('?');
+  });
+
   it('draw button is disabled on game end', async () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<PigsTailPage />);

--- a/frontend/src/pages/PigsTailPage.tsx
+++ b/frontend/src/pages/PigsTailPage.tsx
@@ -20,8 +20,9 @@ import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { badgeErrorColors } from '../styles/badgeStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { PigsTailResponse } from '../types/card';
+import type { Card, PigsTailResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
+import { valueName } from '../utils/cardUtils';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 
 const SUIT_SYMBOLS: Record<string, string> = {
@@ -30,6 +31,11 @@ const SUIT_SYMBOLS: Record<string, string> = {
   DIAMOND: '♦',
   CLOVER: '♣',
 };
+
+/** Render a center-pile card as suit symbol + rank (e.g. "♠A"), so the rank is visible. */
+function centerCardLabel(card: Card): string {
+  return `${SUIT_SYMBOLS[card.design] ?? '?'}${valueName(card.value)}`;
+}
 
 const PT_TUTORIAL_STEPS: TutorialStep[] = [
   {
@@ -184,8 +190,11 @@ function PigsTailPageContent() {
                 <div className="text-xs text-ds-text-muted mb-1">
                   {t('label.center')} ({state.centerCount})
                 </div>
-                <div className="w-16 h-16 rounded-lg bg-ds-warning/60 border-2 border-ds-warning/40 flex items-center justify-center text-xl font-bold text-white">
-                  {state.centerTop ? (SUIT_SYMBOLS[state.centerTop.design] ?? '?') : '-'}
+                <div
+                  className="w-16 h-16 rounded-lg bg-ds-warning/60 border-2 border-ds-warning/40 flex items-center justify-center text-lg font-bold text-white"
+                  data-testid="pt-center-top"
+                >
+                  {state.centerTop ? centerCardLabel(state.centerTop) : '-'}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## 概要
`PigsTailPage.tsx` の中央パイルはスート記号のみ大きく表示し、ランク（数字/絵札）が見えなかった。CUI は `pigtail.topCardLine` でカード全体を出すのに Web の方が情報量が少ない逆転状態だった。ペナルティはしっぽ（スート/ランクの並び）で決まるため、ランクを表示するよう修正した。

## 変更点
- `PigsTailPage.tsx`: `centerCardLabel(card)` ヘルパーを追加し、中央最上段を「スート記号＋ランク」（例 ♠A、`data-testid=pt-center-top`）で表示

## 備考
受け入れ条件2（直近の中央カード履歴）は、`PigsTailResponse` に中央パイルの履歴フィールドが無く（`centerTop` と `centerCount` のみ）、クライアント側蓄積はリロードで消える不安定な実装になるため本PRでは見送り（サーバ側に履歴フィールドが必要）。退行防止のためスート記号表示は維持。

## テスト計画
- [x] `PigsTailPage.test.tsx`: 中央最上段がランク+スート（♠A）で表示されることを検証（全14件パス）
- [x] `bun run check` パス (exit 0)

Closes #2572