### PR TITLE
feat(hearts): name the pass recipient and show progress from zero

### DIFF
--- a/frontend/src/i18n/locales/en/hearts.json
+++ b/frontend/src/i18n/locales/en/hearts.json
@@ -37,6 +37,7 @@
   "scoresTricks": "Tricks",
   "passButton": "Pass",
   "passProgress": "{{count}}/3 selected",
+  "passTo": "{{direction}} → {{name}}",
   "playButton": "Play",
   "nextTrick": "Next Trick",
   "nextRound": "Next Round",

--- a/frontend/src/i18n/locales/ja/hearts.json
+++ b/frontend/src/i18n/locales/ja/hearts.json
@@ -37,6 +37,7 @@
   "scoresTricks": "トリック",
   "passButton": "パス",
   "passProgress": "{{count}}/3 枚選択済み",
+  "passTo": "{{direction}} → {{name}} へ",
   "playButton": "出す",
   "nextTrick": "次のトリック",
   "nextRound": "次のラウンド",

--- a/frontend/src/pages/HeartsPage.test.tsx
+++ b/frontend/src/pages/HeartsPage.test.tsx
@@ -116,13 +116,21 @@ describe('HeartsPage', () => {
     expect(screen.queryByTestId('hearts-shoot-the-moon-badge')).not.toBeInTheDocument();
   });
 
-  it('renders pass phase with pass button', async () => {
+  it('renders pass phase with pass button and the recipient name', async () => {
     mockExec.mockResolvedValue(passPhaseState);
     renderWithProviders(<HeartsPage />);
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'パス' })).toBeInTheDocument();
-      expect(screen.getByText('パス方向: 左')).toBeInTheDocument();
+      // Left pass from seat 0 goes to seat 1 (CPU 1).
+      expect(screen.getByText('パス方向: 左 → CPU 1 へ')).toBeInTheDocument();
     });
+  });
+
+  it('shows the pass-progress badge from zero cards selected', async () => {
+    mockExec.mockResolvedValue(passPhaseState);
+    renderWithProviders(<HeartsPage />);
+    const badge = await screen.findByTestId('hearts-pass-progress');
+    expect(badge).toHaveTextContent('0/3');
   });
 
   it('pass button disabled when not 3 cards selected', async () => {
@@ -174,8 +182,8 @@ describe('HeartsPage', () => {
     renderWithProviders(<HeartsPage />);
     await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
 
-    // No pill before any selection.
-    expect(screen.queryByTestId('hearts-pass-progress')).not.toBeInTheDocument();
+    // Pill shows 0/3 before any selection, then updates as cards are picked.
+    expect(screen.getByTestId('hearts-pass-progress')).toHaveTextContent('0/3');
 
     fireEvent.click(screen.getByAltText('♠ A').closest('button') as HTMLButtonElement);
     expect(screen.getByTestId('hearts-pass-progress')).toHaveTextContent('1/3');
@@ -497,13 +505,13 @@ describe('HeartsPage', () => {
   it('shows pass direction right', async () => {
     mockExec.mockResolvedValue({ ...passPhaseState, passDirection: 1 });
     renderWithProviders(<HeartsPage />);
-    await waitFor(() => expect(screen.getByText('パス方向: 右')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('パス方向: 右 → CPU 3 へ')).toBeInTheDocument());
   });
 
   it('shows pass direction across', async () => {
     mockExec.mockResolvedValue({ ...passPhaseState, passDirection: 2 });
     renderWithProviders(<HeartsPage />);
-    await waitFor(() => expect(screen.getByText('パス方向: 対面')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('パス方向: 対面 → CPU 2 へ')).toBeInTheDocument());
   });
 
   it('shows pass direction none', async () => {

--- a/frontend/src/pages/HeartsPage.tsx
+++ b/frontend/src/pages/HeartsPage.tsx
@@ -33,6 +33,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { HEARTS_HELP, parseHeartsCommand } from '../utils/cli/commands/heartsCommands';
 import { formatHeartsState } from '../utils/cli/formatters/heartsFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { heartsPassTarget } from '../utils/heartsPass';
 import { shootTheMoonAlertIdx } from '../utils/heartsShootMoonAlert';
 import { playerName } from '../utils/playerUtils';
 
@@ -262,7 +263,15 @@ function HeartsPageContent() {
                 {/* Pass direction (pass phase) */}
                 {isPassPhase && (
                   <div className="text-ds-warning text-center mb-2" data-tutorial="ht-pass-area">
-                    {t(`passDirection.${passDirectionKeys[state.passDirection]}`)}
+                    {(() => {
+                      const direction = t(`passDirection.${passDirectionKeys[state.passDirection]}`);
+                      if (state.passDirection === 3) return direction;
+                      const humanIdx = state.players.findIndex((p) => p.isHuman);
+                      const recipient = state.players[heartsPassTarget(humanIdx, state.passDirection)];
+                      return recipient
+                        ? t('passTo', { direction, name: playerName(recipient.id, recipient.isHuman) })
+                        : direction;
+                    })()}
                   </div>
                 )}
 
@@ -431,7 +440,7 @@ function HeartsPageContent() {
                   {tc('button.hint')}
                 </button>
               )}
-              {isPassPhase && selectedCardIndices.length > 0 && (
+              {isPassPhase && (
                 <span
                   data-testid="hearts-pass-progress"
                   className="self-center rounded-full bg-ds-surface border border-ds-accent px-2.5 py-0.5 text-ds-text-primary text-xs"

--- a/frontend/src/utils/heartsPass.test.ts
+++ b/frontend/src/utils/heartsPass.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { heartsPassTarget } from './heartsPass';
+
+describe('heartsPassTarget', () => {
+  it('passes left to the next seat', () => {
+    expect(heartsPassTarget(0, 0)).toBe(1);
+    expect(heartsPassTarget(3, 0)).toBe(0);
+  });
+
+  it('passes right to the previous seat', () => {
+    expect(heartsPassTarget(0, 1)).toBe(3);
+    expect(heartsPassTarget(2, 1)).toBe(1);
+  });
+
+  it('passes across to the opposite seat', () => {
+    expect(heartsPassTarget(0, 2)).toBe(2);
+    expect(heartsPassTarget(3, 2)).toBe(1);
+  });
+
+  it('returns the same seat for the no-pass round', () => {
+    expect(heartsPassTarget(2, 3)).toBe(2);
+  });
+});

--- a/frontend/src/utils/heartsPass.ts
+++ b/frontend/src/utils/heartsPass.ts
@@ -1,0 +1,24 @@
+/** Number of seats in Hearts. */
+const HEARTS_PLAYER_COUNT = 4;
+
+/**
+ * Computes the seat index a player passes to, mirroring the backend
+ * `passTarget` logic: left = next seat, right = previous, across = opposite,
+ * and the no-pass round returns the same seat.
+ *
+ * @param fromIdx - The passing player's seat index (0-3).
+ * @param direction - Pass direction: 0=left, 1=right, 2=across, 3=none.
+ * @returns The recipient's seat index.
+ */
+export function heartsPassTarget(fromIdx: number, direction: number): number {
+  switch (direction) {
+    case 0: // left
+      return (fromIdx + 1) % HEARTS_PLAYER_COUNT;
+    case 1: // right
+      return (fromIdx + HEARTS_PLAYER_COUNT - 1) % HEARTS_PLAYER_COUNT;
+    case 2: // across
+      return (fromIdx + 2) % HEARTS_PLAYER_COUNT;
+    default: // none
+      return fromIdx;
+  }
+}


### PR DESCRIPTION
## 概要
パスフェーズは方向名（左/右/対面）だけを表示し、渡し先CPUは各自が暗算する必要があった。また選択進捗バッジは1枚目を選ぶまで出なかった。渡し先プレイヤー名の併記と0枚からの進捗表示を追加した。

## 変更点
- `utils/heartsPass.ts`: バックエンドの `passTarget` を踏襲した純粋関数 `heartsPassTarget(fromIdx, direction)`（left=+1/right=+3/across=+2/none=self, 4人）+ ユニットテスト
- `HeartsPage.tsx`: パス方向ラベルに渡し先名を併記（`passTo`、例「パス方向: 左 → CPU 1 へ」）。`hearts-pass-progress` バッジをパスフェーズ中は常時表示（0/3 から）
- `i18n/locales/{ja,en}/hearts.json`: `passTo` キーを追加

## テスト計画
- [x] `heartsPass.test.ts`: left/right/across/none の渡し先を検証
- [x] `HeartsPage.test.tsx`: 渡し先名つきラベル（左→CPU1/右→CPU3/対面→CPU2）と 0/3 バッジを検証（全71件パス）
- [x] `bun run check` パス (exit 0)、ja/en キー整合

Closes #2544