### PR TITLE
feat(bigo): label used vs unused hole cards at showdown

### DIFF
--- a/frontend/src/i18n/locales/en/bigo.json
+++ b/frontend/src/i18n/locales/en/bigo.json
@@ -13,6 +13,8 @@
   "yourHand": "Your Hand",
   "mandatoryRule": "Rule: 2 hole + 3 board",
   "mandatoryRuleAria": "Big O rule: you must use exactly 2 hole cards and exactly 3 board cards",
+  "cardUsed": "Used",
+  "cardUnused": "Unused",
   "handNumber": "Hand #{{count}} (Level up: every {{level}} hands)",
   "rebuy": {
     "prompt": "Rebuy? ({{chips}} chips, {{used}}/{{max}} used)",

--- a/frontend/src/i18n/locales/ja/bigo.json
+++ b/frontend/src/i18n/locales/ja/bigo.json
@@ -13,6 +13,8 @@
   "yourHand": "あなたの手札",
   "mandatoryRule": "ルール: 手札から2枚 + 場札から3枚",
   "mandatoryRuleAria": "Big Oのルール: 手札ちょうど2枚と場札ちょうど3枚を使います",
+  "cardUsed": "使用",
+  "cardUnused": "未使用",
   "handNumber": "ハンド#{{count}} (レベルアップ:{{level}}ハンド毎)",
   "rebuy": {
     "prompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済)",

--- a/frontend/src/pages/BigOPage.test.tsx
+++ b/frontend/src/pages/BigOPage.test.tsx
@@ -366,6 +366,29 @@ describe('BigOPage', () => {
     await waitFor(() => expect(screen.getByText('ツーペア')).toBeInTheDocument());
   });
 
+  it('labels the used hole cards (2) and the unused ones at showdown', async () => {
+    mockExec.mockResolvedValue(showdownState);
+    renderWithProviders(<BigOPage />);
+    await waitFor(() => expect(screen.getByText('ツーペア')).toBeInTheDocument());
+    // Omaha-style: exactly 2 hole cards are used; the rest are labeled unused.
+    expect(screen.getAllByTestId('bigo-hole-used').length).toBe(2);
+    expect(screen.getAllByTestId('bigo-hole-unused').length).toBeGreaterThan(0);
+  });
+
+  it('omits used/unused labels when the human has folded', async () => {
+    mockExec.mockResolvedValue({
+      ...showdownState,
+      players: [
+        humanPlayer({ handName: 'ワンペア', folded: true }),
+        showdownState.players[1],
+        showdownState.players[2],
+      ],
+    });
+    renderWithProviders(<BigOPage />);
+    await waitFor(() => expect(screen.getByText('ツーペア')).toBeInTheDocument());
+    expect(screen.queryByTestId('bigo-hole-used')).not.toBeInTheDocument();
+  });
+
   it('highlights exactly 2 hole + 3 board cards as the best-5 at showdown', async () => {
     mockExec.mockResolvedValue(showdownState);
     const { container } = renderWithProviders(<BigOPage />);

--- a/frontend/src/pages/BigOPage.tsx
+++ b/frontend/src/pages/BigOPage.tsx
@@ -388,16 +388,26 @@ function BigOPageContent() {
                   {humanPlayer.cards?.length
                     ? humanPlayer.cards.map((card, idx) => {
                         const inBest = showdownBest5.holeSet.has(idx);
-                        const dim = showdownBest5.holeSet.size > 0 && !inBest;
+                        const showUsage = showdownBest5.holeSet.size > 0;
+                        const dim = showUsage && !inBest;
                         return (
-                          <div
-                            key={`${card.design}-${card.value}`}
-                            className={`transition-all ${
-                              inBest ? '-translate-y-1 ring-2 ring-ds-success motion-safe:animate-pulse' : ''
-                            } ${dim ? 'opacity-50' : ''}`}
-                            data-best5-hole={inBest || undefined}
-                          >
-                            <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
+                          <div key={`${card.design}-${card.value}`} className="flex flex-col items-center">
+                            <div
+                              className={`transition-all ${
+                                inBest ? '-translate-y-1 ring-2 ring-ds-success motion-safe:animate-pulse' : ''
+                              } ${dim ? 'opacity-50' : ''}`}
+                              data-best5-hole={inBest || undefined}
+                            >
+                              <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
+                            </div>
+                            {showUsage && (
+                              <span
+                                className={`mt-0.5 text-[10px] font-semibold ${inBest ? 'text-ds-success' : 'text-ds-text-muted'}`}
+                                data-testid={inBest ? 'bigo-hole-used' : 'bigo-hole-unused'}
+                              >
+                                {inBest ? t('cardUsed') : t('cardUnused')}
+                              </span>
+                            )}
                           </div>
                         );
                       })


### PR DESCRIPTION
## 概要
Big O はホール5枚から必ず2枚だけ使う制約がオマハ以上に直感に反する。ベスト5の ring/dim による視覚区別と `mandatoryRule` バッジは既存だが、どの2枚が「使用」でどの3枚が「未使用」かの明示テキストが無かった。各ホール札に使用/未使用ラベルを追加した。

## 変更点
- `BigOPage.tsx`: ショーダウン時（`showdownBest5.holeSet.size > 0`）に各ホール札の下へ「使用」(`bigo-hole-used`, 緑) /「未使用」(`bigo-hole-unused`, ミュート) ラベルを表示
- `i18n/locales/{ja,en}/bigo.json`: `cardUsed`/`cardUnused` を追加

## 備考
受け入れ条件2（2枚使用の注記）は既存の `bigo-rule-badge`（`mandatoryRule`）で既に満たされ、ベスト5強調（ring/dim）も既存。本PRは未対応だった「使用/未使用の明示ラベル付け」に絞った。

## テスト計画
- [x] `BigOPage.test.tsx`: 使用2枚・未使用ラベル表示、フォールド時は非表示を検証（全114件パス）
- [x] `bun run check` パス (exit 0)、ja/en キー整合

Closes #2538