### PR TITLE
feat(bigohilo): highlight the qualifying low and distinguish it from the high

### DIFF
--- a/frontend/src/i18n/locales/en/bigohilo.json
+++ b/frontend/src/i18n/locales/en/bigohilo.json
@@ -3,7 +3,8 @@
     "title": "Hi/Lo split",
     "hi": "Hi",
     "lo": "Lo",
-    "winner": "{{name}} (+{{amount}})"
+    "winner": "{{name}} (+{{amount}})",
+    "hiTakesAll": "No qualifying low — Hi scoops the pot"
   },
   "phase": {
     "preFlop": "Pre-Flop",

--- a/frontend/src/i18n/locales/ja/bigohilo.json
+++ b/frontend/src/i18n/locales/ja/bigohilo.json
@@ -3,7 +3,8 @@
     "title": "ハイ/ロー内訳",
     "hi": "ハイ",
     "lo": "ロー",
-    "winner": "{{name}} (+{{amount}})"
+    "winner": "{{name}} (+{{amount}})",
+    "hiTakesAll": "ロー該当者なし — ハイが総取り"
   },
   "phase": {
     "preFlop": "プリフロップ",

--- a/frontend/src/pages/BigOHiLoPage.test.tsx
+++ b/frontend/src/pages/BigOHiLoPage.test.tsx
@@ -389,6 +389,43 @@ describe('BigOHiLoPage', () => {
     expect(screen.getByTestId('bigohilo-lo-badge')).toHaveClass('text-ds-info');
   });
 
+  it('highlights the human qualifying low (blue) and lists the low card ranks', async () => {
+    const lowState: OmahaResponse = {
+      ...showdownState,
+      roundResults: [
+        {
+          ...showdownState.roundResults[0],
+          hiWonAmount: 0,
+          lowWonAmount: 100,
+          lowBestHand: [
+            { design: 'SPADE', value: 1 },
+            { design: 'CLOVER', value: 5 },
+            { design: 'DIAMOND', value: 8 },
+            { design: 'CLOVER', value: 2 },
+            { design: 'HEART', value: 5 },
+          ],
+        },
+        { ...showdownState.roundResults[1], hiWonAmount: 200, lowWonAmount: 0 },
+      ],
+    };
+    mockExec.mockResolvedValue(lowState);
+    renderWithProviders(<BigOHiLoPage />);
+    await waitFor(() => expect(screen.getByTestId('bigohilo-split')).toBeInTheDocument());
+    expect(screen.getAllByTestId('bigohilo-lo-card').length).toBeGreaterThan(0);
+    expect(screen.getByTestId('bigohilo-lo-badge')).toHaveTextContent('A 5 8 2 5');
+  });
+
+  it('states Hi scoops the pot when no low qualifies', async () => {
+    const hiOnlyState: OmahaResponse = {
+      ...showdownState,
+      roundResults: [{ ...showdownState.roundResults[0], hiWonAmount: 200, lowWonAmount: 0 }],
+    };
+    mockExec.mockResolvedValue(hiOnlyState);
+    renderWithProviders(<BigOHiLoPage />);
+    await waitFor(() => expect(screen.getByTestId('bigohilo-hi-badge')).toBeInTheDocument());
+    expect(screen.getByTestId('bigohilo-hi-takes-all')).toBeInTheDocument();
+  });
+
   it('does not show CPU hand name badge when CPU is folded in showdown', async () => {
     mockExec.mockResolvedValue(showdownState);
     renderWithProviders(<BigOHiLoPage />);

--- a/frontend/src/pages/BigOHiLoPage.tsx
+++ b/frontend/src/pages/BigOHiLoPage.tsx
@@ -40,10 +40,12 @@ import { gameTheme } from '../styles/gameTheme';
 import type { OmahaResponse } from '../types/card';
 import { OmahaPhase, OmahaRebuyPhaseType } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { valueName } from '../utils/cardUtils';
 import { OMAHA_HELP, parseOmahaCommand } from '../utils/cli/commands/omahaCommands';
 import { formatOmahaState } from '../utils/cli/formatters/omahaFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { omahaBestFive } from '../utils/omahaBestFive';
+import { lowCardIndexSets } from '../utils/omahaLowCards';
 import { findPlayerName } from '../utils/playerUtils';
 
 /** 5 Card Omaha Hi-Lo (Big O) tutorial step definitions. */
@@ -173,6 +175,12 @@ function BigOHiLoPageContent() {
     if (!best) return empty;
     return { holeSet: new Set(best.holeIdx), boardSet: new Set(best.boardIdx) };
   }, [isShowdown, humanPlayer, state?.communityCards]);
+  // Separately highlight the human's qualifying low cards (blue), distinct from
+  // the Hi best-5 (green) — the Hi and Lo hole cards can differ.
+  const humanLowBestHand = isShowdown
+    ? state?.roundResults?.find((r) => r.playerIdx === humanPlayer?.id)?.lowBestHand
+    : undefined;
+  const lowSets = lowCardIndexSets(humanLowBestHand, humanPlayer?.cards ?? [], state?.communityCards ?? []);
   const humanFolded = humanPlayer?.folded ?? false;
   const humanAllIn = humanPlayer?.allIn ?? false;
   const canAct = isActive && !humanFolded && !humanAllIn && state?.currentTurn === humanPlayer?.id;
@@ -265,14 +273,19 @@ function BigOHiLoPageContent() {
                     {state?.communityCards?.length
                       ? state.communityCards.map((card, idx) => {
                           const inBest = showdownBest5.boardSet.has(idx);
-                          const dim = showdownBest5.boardSet.size > 0 && !inBest;
+                          const inLo = lowSets.loBoardSet.has(idx);
+                          const dim = showdownBest5.boardSet.size > 0 && !inBest && !inLo;
+                          const ring = inLo
+                            ? 'ring-2 ring-ds-info motion-safe:animate-pulse'
+                            : inBest
+                              ? '-translate-y-1 ring-2 ring-ds-success motion-safe:animate-pulse'
+                              : '';
                           return (
                             <div
                               key={`${card.design}-${card.value}`}
-                              className={`transition-all ${
-                                inBest ? '-translate-y-1 ring-2 ring-ds-success motion-safe:animate-pulse' : ''
-                              } ${dim ? 'opacity-50' : ''}`}
+                              className={`transition-all ${ring} ${dim ? 'opacity-50' : ''}`}
                               data-best5-board={inBest || undefined}
+                              data-testid={inLo ? 'bigohilo-lo-card' : undefined}
                             >
                               <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
                             </div>
@@ -343,7 +356,15 @@ function BigOHiLoPageContent() {
                   r.hiWonAmount ? [{ name: findPlayerName(state.players, r.playerIdx), amount: r.hiWonAmount }] : [],
                 );
                 const loWinners = state.roundResults.flatMap((r) =>
-                  r.lowWonAmount ? [{ name: findPlayerName(state.players, r.playerIdx), amount: r.lowWonAmount }] : [],
+                  r.lowWonAmount
+                    ? [
+                        {
+                          name: findPlayerName(state.players, r.playerIdx),
+                          amount: r.lowWonAmount,
+                          cards: (r.lowBestHand ?? []).map((card) => valueName(card.value)).join(' '),
+                        },
+                      ]
+                    : [],
                 );
                 if (hiWinners.length === 0 && loWinners.length === 0) return null;
                 return (
@@ -366,9 +387,15 @@ function BigOHiLoPageContent() {
                           className="inline-block rounded border border-ds-info bg-ds-surface px-2 py-0.5 text-ds-info"
                         >
                           {t('hiLo.lo')}: {t('hiLo.winner', { name: w.name, amount: w.amount })}
+                          {w.cards && ` (${w.cards})`}
                         </span>
                       ))}
                     </div>
+                    {loWinners.length === 0 && hiWinners.length > 0 && (
+                      <div className="mt-1 text-xs text-ds-text-muted" data-testid="bigohilo-hi-takes-all">
+                        {t('hiLo.hiTakesAll')}
+                      </div>
+                    )}
                   </div>
                 );
               })()}
@@ -426,14 +453,19 @@ function BigOHiLoPageContent() {
                   {humanPlayer.cards?.length
                     ? humanPlayer.cards.map((card, idx) => {
                         const inBest = showdownBest5.holeSet.has(idx);
-                        const dim = showdownBest5.holeSet.size > 0 && !inBest;
+                        const inLo = lowSets.loHoleSet.has(idx);
+                        const dim = showdownBest5.holeSet.size > 0 && !inBest && !inLo;
+                        const ring = inLo
+                          ? 'ring-2 ring-ds-info motion-safe:animate-pulse'
+                          : inBest
+                            ? '-translate-y-1 ring-2 ring-ds-success motion-safe:animate-pulse'
+                            : '';
                         return (
                           <div
                             key={`${card.design}-${card.value}`}
-                            className={`transition-all ${
-                              inBest ? '-translate-y-1 ring-2 ring-ds-success motion-safe:animate-pulse' : ''
-                            } ${dim ? 'opacity-50' : ''}`}
+                            className={`transition-all ${ring} ${dim ? 'opacity-50' : ''}`}
                             data-best5-hole={inBest || undefined}
+                            data-testid={inLo ? 'bigohilo-lo-card' : undefined}
                           >
                             <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
                           </div>


### PR DESCRIPTION
## 概要
`BigOHiLoPage.tsx` はハイのベスト5強調と勝者バッジのみで、ロー成立札（ホール2枚含む）の強調が無く、ハイ用とロー用のホール札が異なり得ることが視覚化されていなかった。`omahaLowCards` ユーティリティ（#2537 で新設）を再利用してロー強調を追加した。

## 変更点
- `BigOHiLoPage.tsx`: 人間の `lowBestHand` を `lowCardIndexSets` でホール/ボードのインデックスに対応付け、ロー札を青リング (`ring-ds-info`, `bigohilo-lo-card`) で強調（ハイは緑のまま、色で区別）。非該当札の淡色化条件を `!hi && !lo` に調整。ロー勝者バッジにロー5枚のランクを併記。ロー不成立時に「ハイ総取り」(`bigohilo-hi-takes-all`) を表示
- `i18n/locales/{ja,en}/bigohilo.json`: ネストキー `hiLo.hiTakesAll` を追加

## テスト計画
- [x] `BigOHiLoPage.test.tsx`: ロー青強調・ロー5枚併記・ハイ総取り表示を検証（全115件パス）
- [x] `bun run check` パス (exit 0)、ja/en キー整合

Closes #2539