### PR TITLE
feat(shortdeck): add a hand-ranking reference

### DIFF
--- a/frontend/src/i18n/locales/en/shortdeck.json
+++ b/frontend/src/i18n/locales/en/shortdeck.json
@@ -1,4 +1,17 @@
 {
+  "handRank": {
+    "title": "Hand ranking (Short Deck)",
+    "straightFlush": "Straight flush",
+    "fourOfAKind": "Four of a kind",
+    "flush": "Flush",
+    "fullHouse": "Full house",
+    "straight": "Straight",
+    "threeOfAKind": "Three of a kind",
+    "twoPair": "Two pair",
+    "onePair": "One pair",
+    "highCard": "High card",
+    "note": "Unlike standard poker, a flush beats a full house. The Ace also plays low in the 6-7-8-9-A straight."
+  },
   "phase": {
     "preFlop": "Pre-Flop",
     "flop": "Flop",

--- a/frontend/src/i18n/locales/ja/shortdeck.json
+++ b/frontend/src/i18n/locales/ja/shortdeck.json
@@ -1,4 +1,17 @@
 {
+  "handRank": {
+    "title": "役の強さ（ショートデッキ）",
+    "straightFlush": "ストレートフラッシュ",
+    "fourOfAKind": "フォーカード",
+    "flush": "フラッシュ",
+    "fullHouse": "フルハウス",
+    "straight": "ストレート",
+    "threeOfAKind": "スリーカード",
+    "twoPair": "ツーペア",
+    "onePair": "ワンペア",
+    "highCard": "ハイカード",
+    "note": "通常ポーカーと違い、フラッシュがフルハウスより強い。A は 6-7-8-9-A の低位ストレートにも使えます。"
+  },
   "phase": {
     "preFlop": "プリフロップ",
     "flop": "フロップ",

--- a/frontend/src/pages/ShortDeckPage.test.tsx
+++ b/frontend/src/pages/ShortDeckPage.test.tsx
@@ -329,7 +329,8 @@ describe('ShortDeckPage', () => {
   it('shows CPU hand name badge during showdown when not folded', async () => {
     mockExec.mockResolvedValue(showdownState);
     renderWithProviders(<ShortDeckPage />);
-    await waitFor(() => expect(screen.getByText('ツーペア')).toBeInTheDocument());
+    // 'ツーペア' appears in the CPU badge and also in the always-present hand-rank reference.
+    await waitFor(() => expect(screen.getAllByText('ツーペア').length).toBeGreaterThanOrEqual(2));
   });
 
   it('appends the Short Deck rank-override marker to the human hand-name badge at showdown', async () => {
@@ -436,7 +437,18 @@ describe('ShortDeckPage', () => {
   it('shows human hand name badge during showdown when not folded', async () => {
     mockExec.mockResolvedValue(showdownState);
     renderWithProviders(<ShortDeckPage />);
-    await waitFor(() => expect(screen.getByText('ワンペア')).toBeInTheDocument());
+    // 'ワンペア' appears in the human badge and also in the always-present hand-rank reference.
+    await waitFor(() => expect(screen.getAllByText('ワンペア').length).toBeGreaterThanOrEqual(2));
+  });
+
+  it('shows the Short Deck hand-ranking reference with the flush>full-house note', async () => {
+    mockExec.mockResolvedValue(showdownState);
+    renderWithProviders(<ShortDeckPage />);
+    const ref = await screen.findByTestId('sd-handrank-reference');
+    expect(ref).toHaveTextContent('役の強さ');
+    expect(ref).toHaveTextContent('フラッシュ');
+    expect(ref).toHaveTextContent('フルハウス');
+    expect(ref).toHaveTextContent('6-7-8-9-A');
   });
 
   // ---- message ----

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -534,6 +534,23 @@ function ShortDeckPageContent() {
                 </div>
               </div>
             </details>
+            <details className="mb-1" data-testid="sd-handrank-reference">
+              <summary className="cursor-pointer select-none text-ds-text-primary text-sm font-bold py-1">
+                {t('handRank.title')}
+              </summary>
+              <ol className="list-decimal list-inside text-ds-text-muted text-xs py-1 space-y-0.5">
+                <li>{t('handRank.straightFlush')}</li>
+                <li>{t('handRank.fourOfAKind')}</li>
+                <li className="text-ds-text-primary font-semibold">{t('handRank.flush')}</li>
+                <li className="text-ds-text-primary font-semibold">{t('handRank.fullHouse')}</li>
+                <li>{t('handRank.straight')}</li>
+                <li>{t('handRank.threeOfAKind')}</li>
+                <li>{t('handRank.twoPair')}</li>
+                <li>{t('handRank.onePair')}</li>
+                <li>{t('handRank.highCard')}</li>
+              </ol>
+              <p className="text-ds-info text-xs pt-1">{t('handRank.note')}</p>
+            </details>
             <GameResetButton
               isGameEnd={phase === HoldemPhase.SHOWDOWN || phase === HoldemPhase.END}
               onReset={handleManualReset}


### PR DESCRIPTION
## 概要
ショートデッキ（36枚 6+ Hold'em）はランキングが特殊（フラッシュ＞フルハウス、A は 6-7-8-9-A の低位ストレート）で通常ポーカーと取り違えやすいが、その役順がどこにも明示されていなかった。折りたたみの役順リファレンスを追加した。

## 変更点
- `ShortDeckPage.tsx`: 設定の下に折りたたみ役順リファレンス (`data-testid=sd-handrank-reference`) を追加。フラッシュ/フルハウスを強調表示し、低位ストレートの注記を併記
- `i18n/locales/{ja,en}/shortdeck.json`: ネストキー `handRank.*` を追加

## 備考
受け入れ条件1（ベスト5強調）は見送り。`holdemBestFive` は標準ランキング（A2345 低位ストレート、フルハウス＞フラッシュ）前提で、ショートデッキ（A6789 低位、フラッシュ＞フルハウス）では誤った5枚を選びうる。正しいベスト5にはショートデッキ専用評価器（またはサーバ提供のbest-5インデックス）が必要なため、本PRは正確かつ高価値な役順リファレンス（受け入れ条件2・3の周知）に限定。

## テスト計画
- [x] `ShortDeckPage.test.tsx`: 役順リファレンスの表示（役の強さ/フラッシュ/フルハウス/6-7-8-9-A）を検証（全85件パス）
- [x] `bun run check` パス (exit 0)、ja/en キー整合

Closes #2540