### PR TITLE
feat(cruel): show the hint's source column in the hint band

### DIFF
--- a/frontend/src/i18n/locales/en/cruel.json
+++ b/frontend/src/i18n/locales/en/cruel.json
@@ -7,6 +7,7 @@
   "title": "Cruel",
   "foundation": "Foundation",
   "tableau": "Tableau",
+  "hintMove": "{{from}} → {{to}}",
   "moveCount": "Moves",
   "shift": "Shift",
   "giveup": "Give up",

--- a/frontend/src/i18n/locales/ja/cruel.json
+++ b/frontend/src/i18n/locales/ja/cruel.json
@@ -7,6 +7,7 @@
   "title": "クルーエル",
   "foundation": "組札",
   "tableau": "場札",
+  "hintMove": "{{from}} → {{to}}",
   "moveCount": "手数",
   "shift": "シフト",
   "giveup": "ギブアップ",

--- a/frontend/src/pages/CruelPage.test.tsx
+++ b/frontend/src/pages/CruelPage.test.tsx
@@ -123,6 +123,26 @@ describe('CruelPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
   });
 
+  it('shows the hint source and destination columns (tableau → foundation)', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      hint: { fromCol: 3, cardIndex: 0, toZone: 'foundation', toCol: -1 },
+    });
+    renderWithProviders(<CruelPage />);
+    const hint = await screen.findByTestId('cruel-hint');
+    expect(hint).toHaveTextContent('場札 3 → 組札');
+  });
+
+  it('shows the hint source and destination columns (tableau → tableau)', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      hint: { fromCol: 3, cardIndex: 0, toZone: 'tableau', toCol: 5 },
+    });
+    renderWithProviders(<CruelPage />);
+    const hint = await screen.findByTestId('cruel-hint');
+    expect(hint).toHaveTextContent('場札 3 → 場札 5');
+  });
+
   it('autocomplete button fires autocomplete command', async () => {
     renderWithProviders(<CruelPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));

--- a/frontend/src/pages/CruelPage.tsx
+++ b/frontend/src/pages/CruelPage.tsx
@@ -533,8 +533,15 @@ function CruelPageContent() {
                 className="text-sm text-ds-accent bg-ds-surface/90 border border-ds-accent rounded px-3 py-1.5 mt-1"
                 role="status"
                 aria-live="polite"
+                data-testid="cruel-hint"
               >
-                {state.hint.toZone === 'foundation' ? t('foundation') : `${t('tableau')} ${state.hint.toCol}`}
+                {t('hintMove', {
+                  from: `${t('tableau')} ${state.hint.fromCol.toString()}`,
+                  to:
+                    state.hint.toZone === 'foundation'
+                      ? t('foundation')
+                      : `${t('tableau')} ${state.hint.toCol.toString()}`,
+                })}
               </div>
             )}
             {frontendHintEnabled && frontendHint && (


### PR DESCRIPTION
## 概要
`CruelPage.tsx` のヒント帯は移動「先」だけを表示し、移動「元」列（`hint.fromCol`）を出していなかった。12列の盤面では from 列を目視で探す必要があり、CUI（両端を表示）より情報が欠落していた。「元 → 先」表記に変更した。

## 変更点
- `CruelPage.tsx`: ヒント帯を `t('hintMove', {from, to})` で「場札 N → 組札/場札 M」表記に変更（`data-testid=cruel-hint`）
- `i18n/locales/{ja,en}/cruel.json`: `hintMove` キーを追加

## テスト計画
- [x] `CruelPage.test.tsx`: tableau→foundation / tableau→tableau のヒント帯表記を検証（全19件パス）
- [x] `bun run check` パス (exit 0)、ja/en キー整合

Closes #2549