### PR TITLE
feat(canasta): show initial-meld minimum and selected card points

### DIFF
--- a/frontend/src/i18n/locales/en/canasta.json
+++ b/frontend/src/i18n/locales/en/canasta.json
@@ -30,6 +30,10 @@
   "drawStockButton": "Draw from stock",
   "drawDiscardButton": "Pick up discard",
   "meldButton": "Meld",
+  "meldPoints": {
+    "initial": "Min initial meld: {{min}} / selected: {{points}}",
+    "selected": "Selected: {{points}}"
+  },
   "skipMeldButton": "Skip",
   "discardButton": "Discard",
   "goOutButton": "Go out",

--- a/frontend/src/i18n/locales/ja/canasta.json
+++ b/frontend/src/i18n/locales/ja/canasta.json
@@ -30,6 +30,10 @@
   "drawStockButton": "山札から引く",
   "drawDiscardButton": "捨て札を取る",
   "meldButton": "メルドする",
+  "meldPoints": {
+    "initial": "初回メルド最低点: {{min}} / 選択合計: {{points}}",
+    "selected": "選択合計: {{points}}"
+  },
   "skipMeldButton": "スキップ",
   "discardButton": "捨てる",
   "goOutButton": "上がる",

--- a/frontend/src/pages/CanastaPage.test.tsx
+++ b/frontend/src/pages/CanastaPage.test.tsx
@@ -131,6 +131,25 @@ describe('CanastaPage', () => {
     expect(screen.getByRole('button', { name: 'スキップ' })).toBeInTheDocument();
   });
 
+  it('shows the initial-meld minimum and selected total in the meld phase', async () => {
+    mockExec.mockResolvedValue(meldPhaseState); // score 0 → min 50; hasInitMeld false
+    renderWithProviders(<CanastaPage />);
+    const info = await screen.findByTestId('ca-meld-points');
+    expect(info).toHaveTextContent('初回メルド最低点: 50');
+    expect(info).toHaveTextContent('選択合計: 0');
+  });
+
+  it('shows only the selected total once the initial meld is made', async () => {
+    mockExec.mockResolvedValue({
+      ...meldPhaseState,
+      players: [{ ...basePlayers[0], hasInitMeld: true }, basePlayers[1]],
+    });
+    renderWithProviders(<CanastaPage />);
+    const info = await screen.findByTestId('ca-meld-points');
+    expect(info).toHaveTextContent('選択合計: 0');
+    expect(info).not.toHaveTextContent('初回メルド最低点');
+  });
+
   it('calls skipmeld command when skip button clicked', async () => {
     mockExec.mockResolvedValue(meldPhaseState);
     renderWithProviders(<CanastaPage />);

--- a/frontend/src/pages/CanastaPage.tsx
+++ b/frontend/src/pages/CanastaPage.tsx
@@ -26,9 +26,10 @@ import { btnOutline, btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { CanastaResponse } from '../types/card';
+import type { CanastaResponse, Card } from '../types/card';
 import { CanastaPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { canastaMinMeld, canastaSelectionPoints } from '../utils/canastaScore';
 import { cardAlt } from '../utils/cardAlt';
 import { CANASTA_HELP, parseCanastaCommand } from '../utils/cli/commands/canastaCommands';
 import { formatCanastaState } from '../utils/cli/formatters/canastaFormatter';
@@ -123,6 +124,17 @@ function CanastaPageContent() {
     if (n === 1) return t('drawDiscardReason.selectOneMore');
     return t('drawDiscardReason.selectTwo');
   }, [isDrawPhase, selectedCardIndices.length, state?.isFrozen, t]);
+
+  // Meld phase: surface the initial-meld minimum (by score band) and the
+  // selected cards' running point total so the player can tell if they qualify.
+  const meldPointInfo = useMemo(() => {
+    if (!isMeldPhase || !humanPlayer) return null;
+    const selectedCards = selectedCardIndices.map((i) => humanPlayer.cards[i]).filter((c): c is Card => Boolean(c));
+    const selectedPoints = canastaSelectionPoints(selectedCards);
+    const needInitial = !humanPlayer.hasInitMeld;
+    const minMeld = canastaMinMeld(humanPlayer.cumulativeScore);
+    return { selectedPoints, needInitial, minMeld, below: needInitial && selectedPoints < minMeld };
+  }, [isMeldPhase, humanPlayer, selectedCardIndices]);
 
   const handleManualReset = useCallback(() => {
     hideActionLog();
@@ -414,11 +426,26 @@ function CanastaPageContent() {
               )}
               {isMeldPhase && isHumanTurn && (
                 <>
+                  {meldPointInfo && (
+                    <div
+                      id="ca-meld-points"
+                      data-testid="ca-meld-points"
+                      className={`w-full text-xs ${meldPointInfo.below ? 'text-ds-warning' : 'text-ds-text-muted'}`}
+                    >
+                      {meldPointInfo.needInitial
+                        ? t('meldPoints.initial', {
+                            min: meldPointInfo.minMeld,
+                            points: meldPointInfo.selectedPoints,
+                          })
+                        : t('meldPoints.selected', { points: meldPointInfo.selectedPoints })}
+                    </div>
+                  )}
                   <button
                     type="button"
                     className={btnPrimary}
                     onClick={handleMeldSelected}
                     disabled={loading || selectedCardIndices.length < 3}
+                    aria-describedby={meldPointInfo?.below ? 'ca-meld-points' : undefined}
                   >
                     {t('meldButton')}
                   </button>

--- a/frontend/src/utils/canastaScore.test.ts
+++ b/frontend/src/utils/canastaScore.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { canastaCardValue, canastaMinMeld, canastaSelectionPoints } from './canastaScore';
+
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('canastaMinMeld', () => {
+  it('returns the threshold for each cumulative-score band', () => {
+    expect(canastaMinMeld(-50)).toBe(15);
+    expect(canastaMinMeld(0)).toBe(50);
+    expect(canastaMinMeld(1499)).toBe(50);
+    expect(canastaMinMeld(1500)).toBe(90);
+    expect(canastaMinMeld(2999)).toBe(90);
+    expect(canastaMinMeld(3000)).toBe(120);
+  });
+});
+
+describe('canastaCardValue', () => {
+  it('scores jokers, wild 2s, aces, black 3s, high and low cards', () => {
+    expect(canastaCardValue(c('JOKER', 0))).toBe(50);
+    expect(canastaCardValue(c('SPADE', 2))).toBe(20);
+    expect(canastaCardValue(c('HEART', 1))).toBe(20);
+    expect(canastaCardValue(c('SPADE', 3))).toBe(5); // black 3
+    expect(canastaCardValue(c('HEART', 8))).toBe(10);
+    expect(canastaCardValue(c('CLOVER', 13))).toBe(10);
+    expect(canastaCardValue(c('DIAMOND', 5))).toBe(5);
+  });
+});
+
+describe('canastaSelectionPoints', () => {
+  it('sums the card values', () => {
+    expect(canastaSelectionPoints([c('JOKER', 0), c('SPADE', 1), c('HEART', 8)])).toBe(80);
+    expect(canastaSelectionPoints([])).toBe(0);
+  });
+});

--- a/frontend/src/utils/canastaScore.ts
+++ b/frontend/src/utils/canastaScore.ts
@@ -1,0 +1,39 @@
+import type { Card } from '../types/card';
+
+/**
+ * Minimum initial-meld value required at the player's cumulative score,
+ * mirroring the backend `minimumMeldValue` bands.
+ *
+ * @param cumulativeScore - The player's cumulative score.
+ * @returns The minimum points the first meld must total (15/50/90/120).
+ */
+export function canastaMinMeld(cumulativeScore: number): number {
+  if (cumulativeScore < 0) return 15;
+  if (cumulativeScore < 1500) return 50;
+  if (cumulativeScore < 3000) return 90;
+  return 120;
+}
+
+/**
+ * Point value of a single card, mirroring the backend `CanastaCardValue`.
+ *
+ * @param card - The card to score.
+ * @returns Its Canasta point value.
+ */
+export function canastaCardValue(card: Card): number {
+  if (card.design === 'JOKER') return 50;
+  if (card.value === 2 || card.value === 1) return 20;
+  if (card.value === 3 && (card.design === 'SPADE' || card.design === 'CLOVER')) return 5;
+  if (card.value >= 8) return 10;
+  return 5;
+}
+
+/**
+ * Total point value of a set of selected cards.
+ *
+ * @param cards - The selected cards.
+ * @returns The summed Canasta point value.
+ */
+export function canastaSelectionPoints(cards: Card[]): number {
+  return cards.reduce((sum, card) => sum + canastaCardValue(card), 0);
+}


### PR DESCRIPTION
## 概要
`CanastaPage.tsx` のメルドフェーズは3枚以上で活性化するだけで、カナスタの肝である「初回メルド最低点（累積得点帯で15/50/90/120）」と「選択中カードの合計点」が表示されず、メルド失敗エラーになりやすかった。ドローフェーズの `drawDiscardReason` に倣ってヘルパー行を追加した。

## 変更点
- `utils/canastaScore.ts`: バックエンド（`minimumMeldValue`/`CanastaCardValue`）を踏襲した純粋関数 `canastaMinMeld`/`canastaCardValue`/`canastaSelectionPoints` + ユニットテスト
- `CanastaPage.tsx`: メルドフェーズに `ca-meld-points` ヘルパー行（初回最低点＋選択合計）を追加。未達時は警告色＋ `meldButton` に `aria-describedby` で紐付け。`hasInitMeld` 済みなら選択合計のみ
- `i18n/locales/{ja,en}/canasta.json`: ネストキー `meldPoints.*` を追加

## テスト計画
- [x] `canastaScore.test.ts`: 得点帯/カード点/合計を検証
- [x] `CanastaPage.test.tsx`: 初回最低点＋選択合計の表示、初回メルド済み時は合計のみを検証（全20件パス）
- [x] `bun run check` パス (exit 0)、ja/en キー整合

Closes #2554