### PR TITLE
feat(napoleon): show Napoleon-side face-card progress vs the bid

### DIFF
--- a/frontend/src/i18n/locales/en/napoleon.json
+++ b/frontend/src/i18n/locales/en/napoleon.json
@@ -29,6 +29,7 @@
   "bidPass": "Pass",
   "currentTrick": "Current Trick",
   "trumpSuit": "Trump",
+  "faceProgress": "Face cards {{collected}}/{{bid}}",
   "adjutantCard": "Adjutant Card",
   "adjutantNone": "None",
   "role": {

--- a/frontend/src/i18n/locales/ja/napoleon.json
+++ b/frontend/src/i18n/locales/ja/napoleon.json
@@ -29,6 +29,7 @@
   "bidPass": "パス",
   "currentTrick": "現在のトリック",
   "trumpSuit": "切り札",
+  "faceProgress": "絵札 {{collected}}/{{bid}} 枚",
   "adjutantCard": "副官カード",
   "adjutantNone": "なし",
   "role": {

--- a/frontend/src/pages/NapoleonPage.test.tsx
+++ b/frontend/src/pages/NapoleonPage.test.tsx
@@ -283,6 +283,20 @@ describe('NapoleonPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', 0));
   });
 
+  it('shows Napoleon-side face-card progress (adjutant excluded until revealed)', async () => {
+    mockExec.mockResolvedValue(playPhaseState); // napoleon 2 pics, bid 13, adjutant hidden
+    renderWithProviders(<NapoleonPage />);
+    const badge = await screen.findByTestId('np-face-progress');
+    expect(badge).toHaveTextContent('絵札 2/13 枚');
+  });
+
+  it('includes the adjutant haul in the progress once revealed', async () => {
+    mockExec.mockResolvedValue({ ...playPhaseState, adjutantRevealed: true });
+    renderWithProviders(<NapoleonPage />);
+    const badge = await screen.findByTestId('np-face-progress');
+    expect(badge).toHaveTextContent('絵札 3/13 枚');
+  });
+
   it('shows trump declaration controls when human is napoleon', async () => {
     mockExec.mockResolvedValue(trumpDeclarationState);
     renderWithProviders(<NapoleonPage />);

--- a/frontend/src/pages/NapoleonPage.tsx
+++ b/frontend/src/pages/NapoleonPage.tsx
@@ -32,6 +32,7 @@ import {
 } from '../hooks/useNapoleonGame';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { useSound } from '../providers/SoundProvider';
+import { badgeInfo, badgeSuccess } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
@@ -211,6 +212,19 @@ function NapoleonPageContent() {
   const isHumanBidTurn = isBidPhase && state.players[state.bidPlayerIdx]?.isHuman === true;
   const isHumanNapoleon = isTrumpDeclaration && state.players[state.napoleonIdx]?.isHuman === true;
   const isHumanExchange = isKittyExchange && state.players[state.napoleonIdx]?.isHuman === true;
+  // Napoleon-side face-card progress toward the bid (target). The adjutant's
+  // haul is only counted once revealed, to avoid leaking their identity.
+  const napoleonFaceProgress = (() => {
+    if (!isPlayPhase || state.napoleonIdx < 0) return null;
+    const napoleon = state.players[state.napoleonIdx];
+    if (!napoleon) return null;
+    const adjutant =
+      state.adjutantRevealed && state.adjutantIdx >= 0 && state.adjutantIdx !== state.napoleonIdx
+        ? state.players[state.adjutantIdx]
+        : undefined;
+    const collected = napoleon.pictureCards + (adjutant?.pictureCards ?? 0);
+    return { collected, bid: state.highestBid, achieved: collected >= state.highestBid };
+  })();
 
   const roleBadge = (p: { isNapoleon: boolean; isAdjutant: boolean; adjutantRevealed: boolean }) => {
     if (p.isNapoleon) return ` [${t('role.napoleon')}]`;
@@ -305,6 +319,20 @@ function NapoleonPageContent() {
                 </span>
               )}
             </div>
+
+            {napoleonFaceProgress && (
+              <div className="text-center mb-2">
+                <span
+                  data-testid="np-face-progress"
+                  className={napoleonFaceProgress.achieved ? badgeSuccess : badgeInfo}
+                >
+                  {t('faceProgress', {
+                    collected: napoleonFaceProgress.collected,
+                    bid: napoleonFaceProgress.bid,
+                  })}
+                </span>
+              </div>
+            )}
 
             <div className={lgTwoColGrid}>
               {/* Left: game play area */}


### PR DESCRIPTION
## 概要
ナポレオン側の勝敗は絵札獲得数がビッドに届くかで決まるが、プレイ中に「目標に対し今何枚集めたか」を示す指標が無かった。trick info 付近に進捗バッジを追加した。

## 変更点
- `NapoleonPage.tsx`: プレイフェーズで `絵札 {collected}/{bid} 枚` バッジ (`data-testid=np-face-progress`) を表示。ナポレオンの `pictureCards` ＋（公開済みなら）副官の `pictureCards` を集計し、達成/未達で色分け（`badgeSuccess`/`badgeInfo`）。副官未公開時は正体を漏らさないよう副官分を除外
- `i18n/locales/{ja,en}/napoleon.json`: `faceProgress` キーを追加

## テスト計画
- [x] `NapoleonPage.test.tsx`: 副官未公開時(2/13)・公開時(3/13)の進捗を検証（全91件パス）
- [x] `bun run check` パス (exit 0)、ja/en キー整合

Closes #2556