### PR TITLE
feat(golf): ring exposed cards playable on the waste top

### DIFF
--- a/frontend/src/pages/GolfPage.test.tsx
+++ b/frontend/src/pages/GolfPage.test.tsx
@@ -82,6 +82,13 @@ describe('GolfPage', () => {
     expect(pulseElements.length).toBeGreaterThan(0);
   });
 
+  it('rings exposed cards that are playable (±1 of the waste top)', async () => {
+    // Waste top 4; exposed bottom-row values are 1..7, so only 3 and 5 are playable.
+    renderWithProviders(<GolfPage />);
+    await waitFor(() => expect(screen.getByText('捨て札')).toBeInTheDocument());
+    expect(screen.getAllByTestId('golf-playable')).toHaveLength(2);
+  });
+
   it('offers the frontend hint toggle in the settings panel', async () => {
     renderWithProviders(<GolfPage />);
     await waitFor(() => expect(screen.getByText('捨て札')).toBeInTheDocument());

--- a/frontend/src/pages/GolfPage.tsx
+++ b/frontend/src/pages/GolfPage.tsx
@@ -34,6 +34,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { GOLF_HELP, parseGolfCommand } from '../utils/cli/commands/golfCommands';
 import { formatGolfState } from '../utils/cli/formatters/golfFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { isGolfAdjacent } from '../utils/hints/golfHint';
 
 /** Golf Solitaire tutorial step definitions. */
 const GOLF_TUTORIAL_STEPS: TutorialStep[] = [
@@ -166,6 +167,8 @@ function GolfPageContent() {
 
   const isPlaying = state.phase === GolfPhase.PLAYING;
   const isGameClear = state.phase === GolfPhase.GAME_CLEAR;
+  // Waste-top value drives which exposed tableau cards are playable (±1, K-A wrap).
+  const wasteTopValue = isPlaying ? state.waste.at(-1)?.value : undefined;
   const isGameOver = state.phase === GolfPhase.GAME_OVER;
   const isEnded = isGameClear || isGameOver;
 
@@ -252,6 +255,8 @@ function GolfPageContent() {
                     if (!gc.card) return null;
                     const exposed = gc.exposed;
                     const isHinted = hint?.type === 'remove' && hint.col === colIdx;
+                    const isPlayable =
+                      exposed && wasteTopValue !== undefined && isGolfAdjacent(gc.card.value, wasteTopValue);
                     return (
                       <div key={`gc-${colIdx.toString()}-${rowIdx.toString()}`} className="absolute" style={{ top }}>
                         <button
@@ -259,8 +264,9 @@ function GolfPageContent() {
                           onClick={() => handleSelectCard(colIdx)}
                           disabled={!isPlaying || loading || !exposed}
                           aria-label={cardAlt(gc.card)}
+                          data-testid={isPlayable ? 'golf-playable' : undefined}
                           className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${
-                            isHinted && exposed ? 'ring-2 ring-ds-warning' : ''
+                            isHinted && exposed ? 'ring-2 ring-ds-warning' : isPlayable ? 'ring-2 ring-ds-success' : ''
                           } ${!exposed ? 'opacity-60' : ''}`}
                         >
                           <AnimatedCard card={gc.card} width={effectiveCardWidth} />

--- a/frontend/src/utils/hints/golfHint.ts
+++ b/frontend/src/utils/hints/golfHint.ts
@@ -3,7 +3,7 @@ import type { HintResult } from '../../types/hint';
 import { GolfPhase } from '../../types/phases';
 
 /** True when two Golf card values are adjacent (±1, with K-A wraparound). */
-function isAdjacentRank(v1: number, v2: number): boolean {
+export function isGolfAdjacent(v1: number, v2: number): boolean {
   const diff = Math.abs(v1 - v2);
   return diff === 1 || diff === 12;
 }
@@ -17,7 +17,7 @@ export function getGolfHint(state: GolfResponse): HintResult | null {
   if (wasteTop) {
     for (const column of state.layout) {
       const top = column.find((c) => c.exposed && !c.removed && c.card !== null);
-      if (top?.card && isAdjacentRank(top.card.value, wasteTop.value)) {
+      if (top?.card && isGolfAdjacent(top.card.value, wasteTop.value)) {
         removable++;
       }
     }


### PR DESCRIPTION
## 概要
`GolfPage.tsx` はサーバヒントのカードにのみリングが付き、露出済みでプレイ可能（捨て札トップと±1）なカードを強調していなかった（姉妹実装の TriPeaks は緑リングで常時可視化済み）。プレイ可能カードを緑リングで強調した。

## 変更点
- `utils/hints/golfHint.ts`: 既存の内部関数 `isAdjacentRank` を `isGolfAdjacent` として export（±1・K-Aラップ、バックエンド `isAdjacentRank` と一致）
- `GolfPage.tsx`: 露出済みかつ `isGolfAdjacent(card.value, wasteTop.value)` のカードを緑リング (`ring-ds-success`, `data-testid=golf-playable`) で強調。サーバヒント（`ring-ds-warning`）が優先、それ以外のプレイ可能札は緑で両立。ブロック中（非露出）は強調しない

## テスト計画
- [x] `GolfPage.test.tsx`: 捨て札トップ4に対し露出値1-7のうち3・5の2枚が強調されることを検証（全27件パス）
- [x] `golfHint.test.ts` 緑（export改名後も）パス
- [x] `bun run check` パス (exit 0)

Closes #2571