### PR TITLE
feat(twotenjack): add a trump-selection prompt beside the suit buttons

### DIFF
--- a/frontend/src/i18n/locales/en/twotenjack.json
+++ b/frontend/src/i18n/locales/en/twotenjack.json
@@ -30,6 +30,7 @@
   "team0": "Your team (0,2)",
   "team1": "Opponents (1,3)",
   "declarePhase": "Declare the trump suit (♠/♣/♥/♦)",
+  "declarePrompt": "Choose trump →",
   "playButton": "Play",
   "nextTrick": "Next Trick",
   "nextRound": "Next Round",

--- a/frontend/src/i18n/locales/ja/twotenjack.json
+++ b/frontend/src/i18n/locales/ja/twotenjack.json
@@ -30,6 +30,7 @@
   "team0": "あなたのチーム (0,2)",
   "team1": "相手チーム (1,3)",
   "declarePhase": "切り札スートを宣言してください (♠/♣/♥/♦)",
+  "declarePrompt": "切り札を選択 →",
   "playButton": "出す",
   "nextTrick": "次のトリック",
   "nextRound": "次のラウンド",

--- a/frontend/src/pages/TwoTenJackPage.test.tsx
+++ b/frontend/src/pages/TwoTenJackPage.test.tsx
@@ -115,6 +115,19 @@ describe('TwoTenJackPage', () => {
     });
   });
 
+  it('shows a trump-selection prompt beside the suit buttons when the human declares', async () => {
+    mockExec.mockResolvedValue(declarePhaseState);
+    renderWithProviders(<TwoTenJackPage />);
+    await waitFor(() => expect(screen.getByTestId('tt-declare-prompt')).toBeInTheDocument());
+  });
+
+  it('does not show the trump-selection prompt when a CPU declares', async () => {
+    mockExec.mockResolvedValue(declarePhaseCpuState);
+    renderWithProviders(<TwoTenJackPage />);
+    await waitFor(() => expect(screen.queryByTestId('skeleton')).not.toBeInTheDocument());
+    expect(screen.queryByTestId('tt-declare-prompt')).not.toBeInTheDocument();
+  });
+
   it('dispatches declare command when a suit button is clicked', async () => {
     mockExec.mockResolvedValue(declarePhaseState);
     renderWithProviders(<TwoTenJackPage />);

--- a/frontend/src/pages/TwoTenJackPage.tsx
+++ b/frontend/src/pages/TwoTenJackPage.tsx
@@ -410,6 +410,11 @@ function TwoTenJackPageContent() {
             <ErrorAlert message={error} onRetry={retry} />
 
             <div className="flex gap-2 items-center flex-wrap" data-tutorial="tt-play-button">
+              {isHumanDeclarer && (
+                <span data-testid="tt-declare-prompt" className="text-ds-warning text-sm font-medium w-full sm:w-auto">
+                  {t('declarePrompt')}
+                </span>
+              )}
               {isHumanDeclarer &&
                 SUIT_OPTIONS.map((suit) => (
                   <button


### PR DESCRIPTION
## 概要
`TwoTenJackPage.tsx` の DECLARE フェーズは宣言プロンプトを上部に出すだけで、スート選択ボタンはフッターに離れて配置され、初見プレイヤーが何をすべきか分かりにくかった。ボタン近傍に誘導ラベルを追加した。

## 変更点
- `TwoTenJackPage.tsx`: 人間が宣言者のとき、スート選択ボタン群の先頭に `切り札を選択 →` 誘導ラベル (`data-testid=tt-declare-prompt`) を追加。スートボタンの `aria-label` は既存（`suit.*`）
- `i18n/locales/{ja,en}/twotenjack.json`: `declarePrompt` を追加

## テスト計画
- [x] `TwoTenJackPage.test.tsx`: 人間宣言時にプロンプト表示、CPU宣言時は非表示を検証（全26件パス）
- [x] `bun run check` パス (exit 0)、ja/en キー整合

Closes #2578