### PR TITLE
feat(letitride): confirm before pulling a bet, with a risk summary

### DIFF
--- a/frontend/e2e/letitride.spec.ts
+++ b/frontend/e2e/letitride.spec.ts
@@ -41,16 +41,18 @@ test.describe('Let It Ride E2E', () => {
     await betButton.click();
     await waitForLoaded(page);
 
-    // FIRST DECISION: pull
+    // FIRST DECISION: pull (now requires confirming the risk-reduction dialog)
     const pullButton1 = page.getByRole('button', { name: 'プル' });
     await expect(pullButton1).toBeVisible({ timeout: 10_000 });
     await pullButton1.click();
+    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // SECOND DECISION: pull
     const pullButton2 = page.getByRole('button', { name: 'プル' });
     await expect(pullButton2).toBeVisible({ timeout: 10_000 });
     await pullButton2.click();
+    await page.getByRole('button', { name: '確認' }).click();
     await waitForLoaded(page);
 
     // END phase

--- a/frontend/src/i18n/locales/en/letitride.json
+++ b/frontend/src/i18n/locales/en/letitride.json
@@ -1,5 +1,7 @@
 {
   "title": "Let It Ride",
+  "pullConfirmTitle": "Pull this bet?",
+  "pullConfirm": "Pull one bet: {{amount}} is returned and your total risk drops from {{risk}} to {{newRisk}}. This cannot be undone.",
   "player": "Player",
   "label": {
     "chips": "Chips",

--- a/frontend/src/i18n/locales/ja/letitride.json
+++ b/frontend/src/i18n/locales/ja/letitride.json
@@ -1,5 +1,7 @@
 {
   "title": "レットイットライド",
+  "pullConfirmTitle": "ベットを引き下げますか？",
+  "pullConfirm": "ベットを1口引き下げます。{{amount}} が戻り、総リスクは {{risk}} → {{newRisk}} に減ります。この操作は取り消せません。",
   "player": "プレイヤー",
   "label": {
     "chips": "チップ",

--- a/frontend/src/pages/LetItRidePage.test.tsx
+++ b/frontend/src/pages/LetItRidePage.test.tsx
@@ -230,6 +230,8 @@ describe('LetItRidePage', () => {
     // Clicking Pull opens a confirmation (does not immediately call the API).
     fireEvent.click(screen.getByRole('button', { name: 'プル' }));
     expect(screen.getByText('ベットを引き下げますか？')).toBeInTheDocument();
+    // firstDecisionState: betAmount 100, all 3 active → risk 300, newRisk 200.
+    expect(screen.getByText(/100 が戻り、総リスクは 300 → 200/)).toBeInTheDocument();
     expect(mockApi).not.toHaveBeenCalledWith('pull');
 
     mockApi.mockResolvedValue(secondDecisionState);
@@ -244,6 +246,16 @@ describe('LetItRidePage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'プル' }));
     fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
     expect(mockApi).not.toHaveBeenCalledWith('pull');
+  });
+
+  it('disables keyboard shortcuts while the pull confirmation is open', async () => {
+    mockApi.mockResolvedValue(firstDecisionState);
+    renderWithProviders(<LetItRidePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'プル' })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: 'プル' }));
+    // With the dialog open, the 'l' shortcut must not bypass it.
+    fireEvent.keyDown(window, { key: 'l' });
+    expect(mockApi).not.toHaveBeenCalledWith('letitride');
   });
 
   it('calls execApi with letitride when letitride button clicked', async () => {

--- a/frontend/src/pages/LetItRidePage.test.tsx
+++ b/frontend/src/pages/LetItRidePage.test.tsx
@@ -222,14 +222,28 @@ describe('LetItRidePage', () => {
     expect(breakdown).not.toHaveTextContent('ベット3:');
   });
 
-  it('calls execApi with pull when pull button clicked', async () => {
+  it('confirms before pulling, showing the return amount and new risk', async () => {
     mockApi.mockResolvedValue(firstDecisionState);
     renderWithProviders(<LetItRidePage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'プル' })).toBeInTheDocument());
 
-    mockApi.mockResolvedValue(secondDecisionState);
+    // Clicking Pull opens a confirmation (does not immediately call the API).
     fireEvent.click(screen.getByRole('button', { name: 'プル' }));
+    expect(screen.getByText('ベットを引き下げますか？')).toBeInTheDocument();
+    expect(mockApi).not.toHaveBeenCalledWith('pull');
+
+    mockApi.mockResolvedValue(secondDecisionState);
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
     await waitFor(() => expect(mockApi).toHaveBeenCalledWith('pull'));
+  });
+
+  it('does not pull when the confirmation is cancelled', async () => {
+    mockApi.mockResolvedValue(firstDecisionState);
+    renderWithProviders(<LetItRidePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'プル' })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: 'プル' }));
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    expect(mockApi).not.toHaveBeenCalledWith('pull');
   });
 
   it('calls execApi with letitride when letitride button clicked', async () => {

--- a/frontend/src/pages/LetItRidePage.test.tsx
+++ b/frontend/src/pages/LetItRidePage.test.tsx
@@ -248,13 +248,22 @@ describe('LetItRidePage', () => {
     expect(mockApi).not.toHaveBeenCalledWith('pull');
   });
 
+  it('opens the pull confirmation via the "p" keyboard shortcut', async () => {
+    mockApi.mockResolvedValue(firstDecisionState);
+    renderWithProviders(<LetItRidePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'プル' })).toBeInTheDocument());
+    fireEvent.keyDown(document, { key: 'p' });
+    expect(screen.getByText('ベットを引き下げますか？')).toBeInTheDocument();
+    expect(mockApi).not.toHaveBeenCalledWith('pull');
+  });
+
   it('disables keyboard shortcuts while the pull confirmation is open', async () => {
     mockApi.mockResolvedValue(firstDecisionState);
     renderWithProviders(<LetItRidePage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'プル' })).toBeInTheDocument());
     fireEvent.click(screen.getByRole('button', { name: 'プル' }));
     // With the dialog open, the 'l' shortcut must not bypass it.
-    fireEvent.keyDown(window, { key: 'l' });
+    fireEvent.keyDown(document, { key: 'l' });
     expect(mockApi).not.toHaveBeenCalledWith('letitride');
   });
 

--- a/frontend/src/pages/LetItRidePage.tsx
+++ b/frontend/src/pages/LetItRidePage.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { letitrideApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
+import { ConfirmDialog } from '../components/ConfirmDialog';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { ChipBetInput } from '../components/common/ChipBetInput';
@@ -19,6 +20,7 @@ import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
+import { useConfirmDialog } from '../hooks/useConfirmDialog';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
@@ -77,6 +79,13 @@ export const LetItRidePage = withTutorial(LetItRidePageContent, 'letitride', LIR
 function LetItRidePageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('letitride');
+  // Separate confirm dialog for the irreversible "pull" action.
+  const {
+    isOpen: pullConfirmOpen,
+    requestConfirm: requestPullConfirm,
+    confirm: confirmPull,
+    cancel: cancelPull,
+  } = useConfirmDialog();
 
   const [betAmount, setBetAmount] = useState(100);
 
@@ -116,11 +125,11 @@ function LetItRidePageContent() {
         action: () => execApi('bet', betAmount),
         enabled: isBetPhase,
       },
-      { key: 'p', action: () => execApi('pull'), enabled: isDecisionPhase },
+      { key: 'p', action: () => requestPullConfirm(() => execApi('pull')), enabled: isDecisionPhase },
       { key: 'l', action: () => execApi('letitride'), enabled: isDecisionPhase },
       { key: 'r', action: () => execApi('reset'), enabled: isEndPhase },
     ],
-    [execApi, betAmount, isBetPhase, isDecisionPhase, isEndPhase],
+    [execApi, betAmount, isBetPhase, isDecisionPhase, isEndPhase, requestPullConfirm],
   );
 
   useActionKeyboardNav({
@@ -135,7 +144,7 @@ function LetItRidePageContent() {
   };
 
   const handlePull = () => {
-    execApi('pull');
+    requestPullConfirm(() => execApi('pull'));
   };
 
   const handleLetItRide = () => {
@@ -371,6 +380,19 @@ function LetItRidePageContent() {
           </GameFooter>
         </>
       )}
+      <ConfirmDialog
+        open={pullConfirmOpen}
+        title={t('pullConfirmTitle')}
+        message={t('pullConfirm', {
+          amount: state.betAmount,
+          risk: currentRisk,
+          newRisk: Math.max(0, currentRisk - state.betAmount),
+        })}
+        confirmLabel={tc('button.confirm')}
+        cancelLabel={tc('button.cancel')}
+        onConfirm={confirmPull}
+        onCancel={cancelPull}
+      />
     </GamePageShell>
   );
 }

--- a/frontend/src/pages/LetItRidePage.tsx
+++ b/frontend/src/pages/LetItRidePage.tsx
@@ -134,7 +134,9 @@ function LetItRidePageContent() {
 
   useActionKeyboardNav({
     bindings: actionBindings,
-    enabled: !!state && !loading,
+    // Disable shortcuts while a confirmation dialog is open so a stray key
+    // (e.g. 'l') can't bypass the confirm.
+    enabled: !!state && !loading && !pullConfirmOpen && !confirmOpen,
   });
 
   if (!state) return <GameSkeleton gameKey="letitride" layout={{ kind: 'casino-table', sections: [3, 2] }} />;


### PR DESCRIPTION
## 概要
`LetItRidePage.tsx` の Pull 操作は不可逆で金額が動くのに、確認もサマリも無く誤操作リスクが高かった。Pull の前に、戻る額と新しい総リスクを示す確認ダイアログを挟んだ。

## 変更点
- `LetItRidePage.tsx`: 専用の `useConfirmDialog` インスタンスを追加し、`handlePull` とキーボード 'p' の両方を `requestPullConfirm(() => execApi('pull'))` 経由に変更。共有 `ConfirmDialog` で「{{amount}} が戻り、総リスク {{risk}} → {{newRisk}}」を表示
- `i18n/locales/{ja,en}/letitride.json`: `pullConfirmTitle`/`pullConfirm` を追加

## テスト計画
- [x] `LetItRidePage.test.tsx`: Pull クリックで確認が出て即時 API を呼ばない／確認で pull 実行／キャンセルで未実行を検証（全26件パス）
- [x] `bun run check` パス (exit 0)、ja/en キー整合

Closes #2587