### PR TITLE
feat(razz): show the current best low during play

### DIFF
--- a/frontend/src/i18n/locales/en/razz.json
+++ b/frontend/src/i18n/locales/en/razz.json
@@ -13,6 +13,8 @@
   "doorCards": "Door Cards",
   "holeCards": "Hole Cards",
   "yourHand": "Your Hand",
+  "currentLow": "Current low: {{low}}",
+  "currentLowIncomplete": "Low incomplete (fewer than 5 ranks)",
   "anteBringIn": "Ante/Bring-in",
   "handNumber": "Hand {{count}} / Lv.{{level}}",
   "rebuy": {

--- a/frontend/src/i18n/locales/ja/razz.json
+++ b/frontend/src/i18n/locales/ja/razz.json
@@ -13,6 +13,8 @@
   "doorCards": "ドアカード",
   "holeCards": "ホールカード",
   "yourHand": "あなたの手札",
+  "currentLow": "現在のロー: {{low}}",
+  "currentLowIncomplete": "ロー未完成（5枚揃わず）",
   "anteBringIn": "アンティ/ブリングイン",
   "handNumber": "ハンド#{{count}} (レベルアップ:{{level}}ハンド毎)",
   "rebuy": {

--- a/frontend/src/pages/RazzPage.test.tsx
+++ b/frontend/src/pages/RazzPage.test.tsx
@@ -206,6 +206,29 @@ describe('RazzPage', () => {
     await waitFor(() => expect(screen.getByText('サードストリート')).toBeInTheDocument());
   });
 
+  it('shows the current best low for the human from 3rd street', async () => {
+    // Human cards A,K,10 + 5,8,3,7 → five lowest distinct = A,3,5,7,8.
+    mockExec.mockResolvedValue(thirdStreetState);
+    renderWithProviders(<RazzPage />);
+    const low = await screen.findByTestId('razz-best-low');
+    expect(low).toHaveTextContent('現在のロー: 8-7-5-3-A');
+  });
+
+  it('marks the low as incomplete when fewer than five distinct ranks are known', async () => {
+    mockExec.mockResolvedValue({
+      ...thirdStreetState,
+      players: [
+        humanPlayer({ holeCards: [{ design: 'SPADE', value: 2 }], doorCards: [{ design: 'HEART', value: 2 }] }),
+        thirdStreetState.players[1],
+        thirdStreetState.players[2],
+        thirdStreetState.players[3],
+      ],
+    });
+    renderWithProviders(<RazzPage />);
+    const low = await screen.findByTestId('razz-best-low');
+    expect(low).toHaveTextContent('未完成');
+  });
+
   // ---- info bar ----
   it('shows pot and the dealer name via playerName (CPU dealer)', async () => {
     mockExec.mockResolvedValue(thirdStreetState);

--- a/frontend/src/pages/RazzPage.tsx
+++ b/frontend/src/pages/RazzPage.tsx
@@ -39,6 +39,7 @@ import { SevenCardStudPhase, SevenCardStudRebuyPhaseType } from '../types/phases
 import type { TutorialStep } from '../types/tutorial';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { findPlayerName } from '../utils/playerUtils';
+import { formatRazzLow, razzBestLow } from '../utils/razzLow';
 
 /** Razz tutorial step definitions. */
 const RAZZ_TUTORIAL_STEPS: TutorialStep[] = [
@@ -203,6 +204,11 @@ function RazzPageContent() {
   const humanAllIn = humanPlayer?.allIn ?? false;
   const canAct = isActive && !humanFolded && !humanAllIn && state?.currentTurn === humanPlayer?.id;
   const hasOutstandingBet = (state?.lastBet ?? 0) > (humanPlayer?.currentBet ?? 0);
+  // Current best Razz low from the human's known cards (door + hole), shown from 3rd street.
+  const razzLow =
+    isActive && humanPlayer && !humanPlayer.folded
+      ? razzBestLow([...(humanPlayer.doorCards ?? []), ...(humanPlayer.holeCards ?? [])])
+      : null;
   const minRaise = state?.minRaise ?? 0;
   const isMuckPhase = phase === SevenCardStudPhase.SHOWDOWN && state?.muckAvailable === true;
   const isRebuyPhase =
@@ -399,6 +405,14 @@ function RazzPageContent() {
                   )}
                   {humanPlayer.folded && <span className="ml-2 text-ds-error text-xs">[{tc('status.folded')}]</span>}
                   {humanPlayer.allIn && <span className="ml-2 text-ds-warning text-xs">[{tc('status.allIn')}]</span>}
+                  {razzLow && (
+                    <span
+                      data-testid="razz-best-low"
+                      className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}
+                    >
+                      {razzLow.complete ? t('currentLow', { low: formatRazzLow(razzLow) }) : t('currentLowIncomplete')}
+                    </span>
+                  )}
                   {isShowdown && !humanPlayer.folded && humanPlayer.handName && (
                     <span className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}>
                       {humanPlayer.handName}

--- a/frontend/src/utils/razzLow.test.ts
+++ b/frontend/src/utils/razzLow.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { formatRazzLow, razzBestLow } from './razzLow';
+
+const c = (value: number): Card => ({ design: 'SPADE', value });
+
+describe('razzBestLow', () => {
+  it('picks the five lowest distinct ranks (Ace low) and formats high-to-low', () => {
+    const low = razzBestLow([c(8), c(6), c(4), c(3), c(1), c(13)]);
+    expect(low.complete).toBe(true);
+    expect(low.ranks).toEqual([1, 3, 4, 6, 8]);
+    expect(formatRazzLow(low)).toBe('8-6-4-3-A');
+  });
+
+  it('ignores pairs (duplicate ranks do not help)', () => {
+    const low = razzBestLow([c(2), c(2), c(5), c(5), c(9)]);
+    expect(low.ranks).toEqual([2, 5, 9]);
+    expect(low.complete).toBe(false);
+  });
+
+  it('marks an incomplete low when fewer than five distinct ranks are available', () => {
+    expect(razzBestLow([c(3), c(7), c(10)]).complete).toBe(false);
+  });
+});

--- a/frontend/src/utils/razzLow.ts
+++ b/frontend/src/utils/razzLow.ts
@@ -1,0 +1,32 @@
+import type { Card } from '../types/card';
+import { valueName } from './cardUtils';
+
+/** The current best Razz low from a set of cards. */
+export interface RazzLow {
+  /** The chosen card ranks, lowest first (Ace = 1, the lowest). */
+  ranks: number[];
+  /** True when five distinct ranks are available (a complete low). */
+  complete: boolean;
+}
+
+/**
+ * Computes the best Razz low: the five lowest distinct ranks (Ace plays low).
+ * Pairs don't help, so duplicate ranks are ignored; fewer than five distinct
+ * ranks means the low is not yet complete.
+ *
+ * @param cards - The player's known cards (door + hole).
+ * @returns The chosen ranks (lowest first) and whether the low is complete.
+ */
+export function razzBestLow(cards: Card[]): RazzLow {
+  const distinct = [...new Set(cards.map((c) => c.value))].sort((a, b) => a - b);
+  const ranks = distinct.slice(0, 5);
+  return { ranks, complete: ranks.length === 5 };
+}
+
+/** Formats a Razz low as a high-to-low rank string, e.g. "8-6-4-3-A". */
+export function formatRazzLow(low: RazzLow): string {
+  return [...low.ranks]
+    .sort((a, b) => b - a)
+    .map((v) => valueName(v))
+    .join('-');
+}


### PR DESCRIPTION
## 概要
`RazzPage.tsx` はロー狙いのゲームなのに、各ストリートで自分のローの強さを示すバッジが無く、ショーダウン時のみ `handName` が出ていた。3rd street 以降、現在の最良ローを常時表示した。

## 変更点
- `utils/razzLow.ts`: 純粋関数 `razzBestLow(cards)`（最小5つの異なるランク、A=ロー）+ `formatRazzLow`（高→低で結合）+ ユニットテスト
- `RazzPage.tsx`: 3rd street 以降、人間の door+hole から最良ローを算出し `yourHand` 見出しにバッジ (`data-testid=razz-best-low`) で表示。5枚揃わない（ペア等）場合は「未完成」表示
- `i18n/locales/{ja,en}/razz.json`: `currentLow` / `currentLowIncomplete` を追加

## テスト計画
- [x] `razzLow.test.ts`: 最良ロー算出・ペア無視・未完成を検証
- [x] `RazzPage.test.tsx`: 3rd street で「現在のロー: 8-7-5-3-A」表示、ペア時「未完成」を検証（全61件パス）
- [x] `bun run check` パス (exit 0)、ja/en キー整合

Closes #2593