### PR TITLE
feat(wasp): highlight legal target columns for the selected card

### DIFF
--- a/frontend/src/pages/WaspPage.tsx
+++ b/frontend/src/pages/WaspPage.tsx
@@ -35,6 +35,7 @@ import { WaspPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import type { CliGameConfig } from '../utils/cli/types';
+import { waspLegalTargets } from '../utils/waspUtils';
 
 const noop = () => {};
 
@@ -235,6 +236,11 @@ function WaspPageContent() {
   // Empty-column deal guard: surfaces a shake animation + tooltip instead of failing silently.
   const [emptyDealAttemptKey, setEmptyDealAttemptKey] = useState(0);
   const hasEmptyColumn = useMemo(() => state?.tableau.some((col) => col.length === 0) ?? false, [state?.tableau]);
+  // Columns the selected card may legally move onto (same suit, one rank higher).
+  const legalTargets = useMemo(
+    () => (selectedSource && state ? waspLegalTargets(state.tableau, selectedSource) : new Set<number>()),
+    [selectedSource, state],
+  );
   const dealBlockedByEmpty = hasEmptyColumn && (state?.stockCount ?? 0) > 0;
   const handleDealGuarded = useCallback(() => {
     if (dealBlockedByEmpty) {
@@ -441,11 +447,14 @@ function WaspPageContent() {
                                   draggable={isPlaying}
                                   onDragStart={dnd.handleDragStart(zone)}
                                   onDragEnd={dnd.handleDragEnd}
+                                  data-testid={isLast && legalTargets.has(colIdx) ? 'wasp-legal-target' : undefined}
                                   className={`${focusRingWhite} rounded-lg transition-all ${
                                     isSelected ? 'ring-2 ring-ds-warning -translate-y-1' : ''
                                   } ${isDragSrc ? 'opacity-50' : ''} ${
                                     hintFrom ? 'ring-2 ring-ds-info animate-pulse' : ''
-                                  } ${hintTo ? 'ring-2 ring-ds-success animate-pulse' : ''}`}
+                                  } ${hintTo ? 'ring-2 ring-ds-success animate-pulse' : ''} ${
+                                    isLast && legalTargets.has(colIdx) ? 'ring-2 ring-ds-success' : ''
+                                  }`}
                                   onClick={() => {
                                     if (selectedSource) {
                                       // Re-clicking the already-selected card deselects it.

--- a/frontend/src/utils/waspUtils.test.ts
+++ b/frontend/src/utils/waspUtils.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, KlondikeTableauCard } from '../types/card';
+import { waspLegalTargets } from './waspUtils';
+
+const up = (design: Card['design'], value: number): KlondikeTableauCard => ({ card: { design, value }, faceUp: true });
+
+describe('waspLegalTargets', () => {
+  it('flags same-suit, one-rank-higher top cards, ignoring wrong suit/rank', () => {
+    const tableau: KlondikeTableauCard[][] = [
+      [up('SPADE', 7)], // source col 0: ♠7
+      [up('SPADE', 8)], // ♠8 → legal
+      [up('HEART', 8)], // wrong suit
+      [up('SPADE', 9)], // two higher
+    ];
+    expect([...waspLegalTargets(tableau, { col: 0, cardIndex: 0 })]).toEqual([1]);
+  });
+
+  it('ignores empty/source columns and undefined source fields', () => {
+    const tableau: KlondikeTableauCard[][] = [[up('CLOVER', 4)], [], [up('CLOVER', 5)]];
+    expect([...waspLegalTargets(tableau, { col: 0, cardIndex: 0 })]).toEqual([2]);
+    expect(waspLegalTargets(tableau, { col: undefined, cardIndex: undefined }).size).toBe(0);
+  });
+});

--- a/frontend/src/utils/waspUtils.ts
+++ b/frontend/src/utils/waspUtils.ts
@@ -1,0 +1,30 @@
+import type { KlondikeTableauCard } from '../types/card';
+
+/**
+ * Columns onto which the selected Wasp card may legally move: a non-empty
+ * column whose face-up top card is the same suit and exactly one rank higher.
+ * The source column is excluded; empty columns accept any card and are handled
+ * by the page's own placement UI.
+ *
+ * @param tableau - All tableau columns.
+ * @param source - The selected card's column and index (either may be undefined).
+ * @returns The set of legal target column indices.
+ */
+export function waspLegalTargets(
+  tableau: KlondikeTableauCard[][],
+  source: { col?: number; cardIndex?: number },
+): Set<number> {
+  const result = new Set<number>();
+  if (source.col === undefined || source.cardIndex === undefined) return result;
+  const srcCol = source.col;
+  const srcCard = tableau[srcCol]?.[source.cardIndex]?.card;
+  if (!srcCard) return result;
+  tableau.forEach((col, idx) => {
+    if (idx === srcCol || col.length === 0) return;
+    const top = col[col.length - 1];
+    if (top?.faceUp && top.card && top.card.design === srcCard.design && top.card.value === srcCard.value + 1) {
+      result.add(idx);
+    }
+  });
+  return result;
+}


### PR DESCRIPTION
## 概要
`WaspPage.tsx` はカード選択中、非空列のどこが合法な移動先（同スート1ランク降順）か分からず、サーバヒント要求時のみリングが付いた。選択中、合法な移動先列の末尾札に緑リングを付与した（#2594 Scorpion と同型）。

## 変更点
- `utils/waspUtils.ts`: 純粋関数 `waspLegalTargets(tableau, source)`（同スート・1つ上のランクの末尾札を持つ非空列、ソース列除外、col/cardIndex optional ガード）+ ユニットテスト
- `WaspPage.tsx`: 選択中 `legalTargets` を算出し、合法列の末尾札に `ring-2 ring-ds-success`（`data-testid=wasp-legal-target`）。空列は任意カード可で既存UIが担当

## テスト計画
- [x] `waspUtils.test.ts`: 同スート+1判定／空列・ソース列除外／undefined ガードを検証
- [x] `WaspPage.test.tsx`: ♥7選択で♥8列のみが合法ターゲットになることを検証（全41件パス）
- [x] `bun run check` パス (exit 0)

Closes #2595