### PR TITLE
feat(mighty): show no-trump bonus explanation on bid screen

### DIFF
--- a/frontend/src/i18n/locales/en/mighty.json
+++ b/frontend/src/i18n/locales/en/mighty.json
@@ -14,6 +14,7 @@
     "pointLimit": "Target Score",
     "minBid": "Min Bid",
     "noTrumpExtra": "No-Trump Extra",
+    "noTrumpExtraExplain": "No-trump bonus: +{{points}} (added to the minimum bid when declaring no-trump)",
     "easy": "Easy",
     "normal": "Normal",
     "hard": "Hard"

--- a/frontend/src/i18n/locales/ja/mighty.json
+++ b/frontend/src/i18n/locales/ja/mighty.json
@@ -14,6 +14,7 @@
     "pointLimit": "目標スコア",
     "minBid": "最低ビッド",
     "noTrumpExtra": "ノートランプ加算",
+    "noTrumpExtraExplain": "ノートランプ加算: +{{points}}点（宣言時は最低ビッドに上乗せ）",
     "easy": "Easy",
     "normal": "Normal",
     "hard": "Hard"

--- a/frontend/src/pages/MightyPage.test.tsx
+++ b/frontend/src/pages/MightyPage.test.tsx
@@ -309,6 +309,21 @@ describe('MightyPage', () => {
     });
   });
 
+  it('shows no-trump extra explanation during human bid turn', async () => {
+    mockCall.mockResolvedValue(bidPhaseState);
+    renderWithProviders(<MightyPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId('mighty-notrump-explain')).toHaveTextContent(/ノートランプ加算/);
+    });
+  });
+
+  it('does not show no-trump extra explanation when cpu bid turn', async () => {
+    mockCall.mockResolvedValue(bidPhaseCpuTurnState);
+    renderWithProviders(<MightyPage />);
+    await waitFor(() => expect(screen.getByText('スコア')).toBeInTheDocument());
+    expect(screen.queryByTestId('mighty-notrump-explain')).not.toBeInTheDocument();
+  });
+
   it('does not show bid instruction when cpu bid turn', async () => {
     mockCall.mockResolvedValue(bidPhaseCpuTurnState);
     renderWithProviders(<MightyPage />);

--- a/frontend/src/pages/MightyPage.tsx
+++ b/frontend/src/pages/MightyPage.tsx
@@ -365,8 +365,11 @@ function MightyPageContent() {
 
                 {/* Bid phase instruction */}
                 {isHumanBidTurn && (
-                  <div className="text-ds-warning text-center mb-2" data-tutorial="mighty-bid-controls">
-                    {t('bidPhase', { min: mightyConfig.minBid })}
+                  <div className="text-center mb-2" data-tutorial="mighty-bid-controls">
+                    <div className="text-ds-warning">{t('bidPhase', { min: mightyConfig.minBid })}</div>
+                    <div className="text-ds-text-muted text-sm" data-testid="mighty-notrump-explain">
+                      {t('settings.noTrumpExtraExplain', { points: mightyConfig.noTrumpExtra })}
+                    </div>
                   </div>
                 )}
 

--- a/frontend/src/pages/MightyPage.tsx
+++ b/frontend/src/pages/MightyPage.tsx
@@ -366,9 +366,9 @@ function MightyPageContent() {
                 {/* Bid phase instruction */}
                 {isHumanBidTurn && (
                   <div className="text-center mb-2" data-tutorial="mighty-bid-controls">
-                    <div className="text-ds-warning">{t('bidPhase', { min: mightyConfig.minBid })}</div>
+                    <div className="text-ds-warning">{t('bidPhase', { min: state.config.minBid })}</div>
                     <div className="text-ds-text-muted text-sm" data-testid="mighty-notrump-explain">
-                      {t('settings.noTrumpExtraExplain', { points: mightyConfig.noTrumpExtra })}
+                      {t('settings.noTrumpExtraExplain', { points: state.config.noTrumpExtra })}
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
## 概要
マイティのビッド画面に、ノートランプ宣言時のボーナス加点 (`noTrumpExtra`) を説明する一文を追加しました。これまで設定値が UI に出ておらず、ノートランプ宣言の損得が判断しづらい状態でした。

## 変更点
- `MightyPage.tsx`: ビッド指示テキストの下に `settings.noTrumpExtraExplain` を表示 (`data-testid=mighty-notrump-explain`、`points` に現在の `noTrumpExtra` を補間)
- `ja/en mighty.json`: `settings.noTrumpExtraExplain` キーを追加
- `MightyPage.test.tsx`: 人間ビッドターンで表示・CPU ターンで非表示の2テストを追加

## テスト
- `bun run test -- --run MightyPage` → 58 passed
- `bun run check` → エラーなし

Closes #2622