### PR TITLE
feat(eightoff): explain supermove limit with empty cell/column counts

### DIFF
--- a/frontend/src/i18n/locales/en/eightoff.json
+++ b/frontend/src/i18n/locales/en/eightoff.json
@@ -17,7 +17,7 @@
   "foundationAriaLabel": "{{suit}} Foundation ({{cardCount}} cards)",
   "emptyFoundationAriaLabel": "{{suit}} Foundation (empty)",
   "emptyFreecellAriaLabel": "Free Cell {{idx}} (empty)",
-  "supermoveLimitTooltip": "Only {{limit}} card(s) can be moved at once",
+  "supermoveLimitTooltip": "Only {{limit}} card(s) can be moved at once ({{cells}} free cell(s), {{cols}} empty column(s))",
   "tutorial": {
     "freeCells": "Eight free cells. Four are pre-filled with initial cards. More empty cells allow moving more cards at once.",
     "foundation": "Foundation piles. Build each suit from Ace to King.",

--- a/frontend/src/i18n/locales/ja/eightoff.json
+++ b/frontend/src/i18n/locales/ja/eightoff.json
@@ -17,7 +17,7 @@
   "foundationAriaLabel": "{{suit}} ファンデーション ({{cardCount}}枚)",
   "emptyFoundationAriaLabel": "{{suit}} ファンデーション (空)",
   "emptyFreecellAriaLabel": "フリーセル {{idx}} (空)",
-  "supermoveLimitTooltip": "一度に動かせるのは{{limit}}枚までです",
+  "supermoveLimitTooltip": "一度に動かせるのは{{limit}}枚まで（空きフリーセル{{cells}}・空き列{{cols}}）",
   "tutorial": {
     "freeCells": "8つのフリーセルです。一時的にカードを置けるスペースで、4つには既に初期カードが配られています。空きセルが多いほど多くのカードを一度に移動できます。",
     "foundation": "ファンデーションです。各スートをAからKまで順番に積み上げます。",

--- a/frontend/src/pages/EightOffPage.test.tsx
+++ b/frontend/src/pages/EightOffPage.test.tsx
@@ -66,6 +66,32 @@ const withFreeCellCardState: EightOffResponse = {
   freeCells: [card('DIAMOND', 7), null, null, null, null, null, null, null],
 };
 
+// All free cells occupied and every tableau column non-empty → supermoveLimit = 1,
+// so the deeper card of a 2-card column exceeds the limit and gets the blocked tooltip.
+const supermoveBlockedState: EightOffResponse = {
+  ...playingState,
+  tableau: [
+    [card('SPADE', 13), card('HEART', 12)],
+    [card('CLOVER', 13)],
+    [card('DIAMOND', 13)],
+    [card('SPADE', 11)],
+    [card('HEART', 11)],
+    [card('CLOVER', 11)],
+    [card('DIAMOND', 11)],
+    [card('SPADE', 10)],
+  ],
+  freeCells: [
+    card('SPADE', 2),
+    card('SPADE', 3),
+    card('SPADE', 4),
+    card('SPADE', 5),
+    card('HEART', 6),
+    card('HEART', 7),
+    card('HEART', 8),
+    card('HEART', 9),
+  ],
+};
+
 beforeEach(() => {
   mockExec.mockResolvedValue(playingState);
   vi.mocked(useGameHint).mockReturnValue({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() });
@@ -85,6 +111,17 @@ describe('EightOffPage', () => {
   it('renders tableau without index headers', async () => {
     renderWithProviders(<EightOffPage />);
     await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+  });
+
+  it('shows supermove limit tooltip with empty free-cell and column counts', async () => {
+    mockExec.mockResolvedValue(supermoveBlockedState);
+    renderWithProviders(<EightOffPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    const blocked = document.querySelector('[data-supermove-blocked="true"]');
+    expect(blocked).not.toBeNull();
+    const title = blocked?.getAttribute('title') ?? '';
+    expect(title).toMatch(/空きフリーセル0/);
+    expect(title).toMatch(/空き列0/);
   });
 
   it('renders empty tableau columns with K placeholder', async () => {

--- a/frontend/src/pages/EightOffPage.test.tsx
+++ b/frontend/src/pages/EightOffPage.test.tsx
@@ -117,9 +117,9 @@ describe('EightOffPage', () => {
     mockExec.mockResolvedValue(supermoveBlockedState);
     renderWithProviders(<EightOffPage />);
     await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
-    const blocked = document.querySelector('[data-supermove-blocked="true"]');
-    expect(blocked).not.toBeNull();
-    const title = blocked?.getAttribute('title') ?? '';
+    const blocked = screen.getByTestId('eo-tableau-0-0');
+    expect(blocked).toHaveAttribute('data-supermove-blocked', 'true');
+    const title = blocked.getAttribute('title') ?? '';
     expect(title).toMatch(/空きフリーセル0/);
     expect(title).toMatch(/空き列0/);
   });

--- a/frontend/src/pages/EightOffPage.tsx
+++ b/frontend/src/pages/EightOffPage.tsx
@@ -416,7 +416,11 @@ function EightOffPageContent() {
                                       onBlur={() => setHoveredStack(null)}
                                       title={
                                         exceedsSupermove
-                                          ? t('supermoveLimitTooltip', { limit: supermoveLimit })
+                                          ? t('supermoveLimitTooltip', {
+                                              limit: supermoveLimit,
+                                              cells: emptyFreeCells,
+                                              cols: emptyTableauCols,
+                                            })
                                           : undefined
                                       }
                                       data-supermove-blocked={exceedsSupermove ? 'true' : undefined}


### PR DESCRIPTION
## 概要
Eight Off のスーパームーブ上限ツールチップに、上限を決める「空きフリーセル数」と「空き列数」を併記しました。これまでは上限枚数のみ表示で、なぜその枚数なのか（=フリーセルや列を空ければ増える）が伝わりませんでした。

## 変更点
- `EightOffPage.tsx`: `supermoveLimitTooltip` に `cells`(emptyFreeCells) / `cols`(emptyTableauCols) を渡す
- `ja/en eightoff.json`: ツールチップ文言を引数付きに更新（例「一度に動かせるのは N 枚まで（空きフリーセル C・空き列 K）」）
- `EightOffPage.test.tsx`: 全フリーセル占有＋全列非空（上限1）の状態でブロック対象カードの `title` に空き数が含まれることを検証

## テスト
- `bun run test -- --run EightOffPage` → 67 passed
- `bun run check` → エラーなし

Closes #2634