### PR TITLE
feat(casinowar): suggest reusing the previous bet in the bet phase

### DIFF
--- a/frontend/src/i18n/locales/en/casinowar.json
+++ b/frontend/src/i18n/locales/en/casinowar.json
@@ -4,6 +4,7 @@
   "tieGuide": "Tie! Surrender (lose half ante) or go to War (match ante and re-draw).",
   "warCost": "War = {{amount}} extra chips",
   "insufficientChips": "Not enough chips",
+  "previousBet": "Use last bet ({{amount}})",
   "label": {
     "chips": "Chips",
     "ante": "Ante",

--- a/frontend/src/i18n/locales/ja/casinowar.json
+++ b/frontend/src/i18n/locales/ja/casinowar.json
@@ -4,6 +4,7 @@
   "tieGuide": "タイ！ サレンダー (アンテ半額没収) かウォー (同額追加ベットで再勝負) を選択",
   "warCost": "ウォー = 追加 {{amount}} チップ",
   "insufficientChips": "チップが足りません",
+  "previousBet": "前回額を使う ({{amount}})",
   "label": {
     "chips": "チップ",
     "ante": "アンテ",

--- a/frontend/src/pages/CasinoWarPage.test.tsx
+++ b/frontend/src/pages/CasinoWarPage.test.tsx
@@ -277,6 +277,8 @@ describe('CasinoWarPage', () => {
 
     fireEvent.click(suggest);
     await waitFor(() => expect(input.value).toBe('300'));
+    // Once the input matches the previous bet, the suggestion is redundant and hides.
+    await waitFor(() => expect(screen.queryByTestId('cw-previous-bet')).not.toBeInTheDocument());
   });
 
   it('does not suggest the previous bet before any bet is placed', async () => {

--- a/frontend/src/pages/CasinoWarPage.test.tsx
+++ b/frontend/src/pages/CasinoWarPage.test.tsx
@@ -259,4 +259,30 @@ describe('CasinoWarPage', () => {
     await waitFor(() => expect(mockApi).toHaveBeenCalledWith('reset'));
     await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', 100));
   });
+
+  it('suggests the previous bet in the bet phase and refills the input when clicked', async () => {
+    mockApi.mockResolvedValue(betState);
+    renderWithProviders(<CasinoWarPage />);
+    const input = (await screen.findByLabelText(/アンテ/)) as HTMLInputElement;
+
+    // Place a non-default bet of 300, then return to the bet phase.
+    fireEvent.change(input, { target: { value: '300' } });
+    fireEvent.click(screen.getByRole('button', { name: /^ベット$/ }));
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bet', 300));
+
+    // Lower the current input below the last bet so the suggestion appears.
+    fireEvent.change(input, { target: { value: '150' } });
+    const suggest = await screen.findByTestId('cw-previous-bet');
+    expect(suggest).toHaveTextContent('300');
+
+    fireEvent.click(suggest);
+    await waitFor(() => expect(input.value).toBe('300'));
+  });
+
+  it('does not suggest the previous bet before any bet is placed', async () => {
+    mockApi.mockResolvedValue(betState);
+    renderWithProviders(<CasinoWarPage />);
+    await screen.findByRole('button', { name: /^ベット$/ });
+    expect(screen.queryByTestId('cw-previous-bet')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/CasinoWarPage.tsx
+++ b/frontend/src/pages/CasinoWarPage.tsx
@@ -251,6 +251,17 @@ function CasinoWarPageContent() {
                   onChange={setBetAmount}
                   max={state.chips}
                 />
+                {canRebet && lastBetAmount !== null && lastBetAmount !== betAmount && (
+                  <button
+                    type="button"
+                    className={btnSecondary}
+                    onClick={() => setBetAmount(lastBetAmount)}
+                    disabled={loading}
+                    data-testid="cw-previous-bet"
+                  >
+                    {t('previousBet', { amount: lastBetAmount })}
+                  </button>
+                )}
                 <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading}>
                   {t('button.bet')}
                 </button>


### PR DESCRIPTION
## 概要
カジノウォーの BET フェーズに、前回のベット額をワンクリックで再利用できるサジェストボタンを追加しました。これまで `lastBetAmount` は END フェーズの「再ベット」でしか使えず、同額連投したいプレイヤーは毎回 ChipBetInput で額を入れ直す必要がありました。

## 変更点
- `CasinoWarPage.tsx`: BET フェーズで `canRebet` かつ現在の入力額と異なる場合、`前回額を使う ({{amount}})` ボタン（`data-testid=cw-previous-bet`）を表示。クリックで `betAmount = lastBetAmount` に更新（自動ベットはしない）
- `ja/en casinowar.json`: `previousBet` キーを追加
- `CasinoWarPage.test.tsx`: サジェスト表示→クリックで入力が前回額に戻ること、未ベット時は非表示であることを検証（計20テスト）

## テスト
- `bun run test -- --run CasinoWarPage` → 20 passed
- `bun run check` → エラーなし

Closes #2611