### PR TITLE
feat(montecarlo): dim non-removable cards after selecting a card

### DIFF
--- a/frontend/src/pages/MonteCarloPage.test.tsx
+++ b/frontend/src/pages/MonteCarloPage.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { montecarloApi } from '../api/gameApi';
+import { useGameHint } from '../hooks/useGameHint';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, MonteCarloBoardCell, MonteCarloResponse } from '../types/card';
 import { MonteCarloPage } from './MonteCarloPage';
@@ -8,6 +9,10 @@ import { MonteCarloPage } from './MonteCarloPage';
 vi.mock('../api/gameApi', () => ({
   montecarloApi: { exec: vi.fn() },
   actionLogApi: { montecarlo: vi.fn() },
+}));
+
+vi.mock('../hooks/useGameHint', () => ({
+  useGameHint: vi.fn(() => ({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() })),
 }));
 
 const mockExec = vi.mocked(montecarloApi.exec);
@@ -205,6 +210,20 @@ describe('MonteCarloPage', () => {
     expect(screen.getByTestId('mc-cell-0-1')).not.toHaveAttribute('data-dimmed');
     // Empty cells are never dimmed (the `filled` guard short-circuits).
     expect(screen.getByTestId('mc-cell-4-4')).not.toHaveAttribute('data-dimmed');
+  });
+
+  it('rings the hint-suggested cells with the warning color when a hint is active', async () => {
+    // boardWithPair: ♠7 at (0,0), ♥7 at (0,1) — the removable pair the hint points at.
+    vi.mocked(useGameHint).mockReturnValue({
+      hint: { targetAction: 'remove-0-0-0-1' },
+      hintEnabled: true,
+      setHintEnabled: vi.fn(),
+    } as unknown as ReturnType<typeof useGameHint>);
+    renderWithProviders(<MonteCarloPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    expect(screen.getByTestId('mc-cell-0-0').className).toContain('ring-ds-warning');
+    expect(screen.getByTestId('mc-cell-0-1').className).toContain('ring-ds-warning');
   });
 
   it('lifts a matching adjacent pair candidate and shows a transient success toast on removal', async () => {

--- a/frontend/src/pages/MonteCarloPage.test.tsx
+++ b/frontend/src/pages/MonteCarloPage.test.tsx
@@ -203,6 +203,8 @@ describe('MonteCarloPage', () => {
     // The selected card and the matching pair are not dimmed.
     expect(screen.getByTestId('mc-cell-0-0')).not.toHaveAttribute('data-dimmed');
     expect(screen.getByTestId('mc-cell-0-1')).not.toHaveAttribute('data-dimmed');
+    // Empty cells are never dimmed (the `filled` guard short-circuits).
+    expect(screen.getByTestId('mc-cell-4-4')).not.toHaveAttribute('data-dimmed');
   });
 
   it('lifts a matching adjacent pair candidate and shows a transient success toast on removal', async () => {

--- a/frontend/src/pages/MonteCarloPage.test.tsx
+++ b/frontend/src/pages/MonteCarloPage.test.tsx
@@ -182,8 +182,27 @@ describe('MonteCarloPage', () => {
 
     const neighbor = screen.getByTestId('mc-cell-1-0');
     expect(neighbor).not.toHaveAttribute('data-pair-match');
-    expect(neighbor.className).toContain('opacity-60');
+    expect(neighbor).toHaveAttribute('data-dimmed', 'true');
+    expect(neighbor.className).toContain('opacity-40');
     expect(neighbor.className).not.toContain('animate-pulse');
+  });
+
+  it('dims non-adjacent filled cells once a first card is selected, leaving the selection lit', async () => {
+    // boardWithPair has ♠7 at (0,0), ♥7 at (0,1) (a match) and ♣5 at (2,2) (far away).
+    renderWithProviders(<MonteCarloPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    // Nothing dimmed before a selection.
+    expect(screen.getByTestId('mc-cell-2-2')).not.toHaveAttribute('data-dimmed');
+
+    fireEvent.click(screen.getByTestId('mc-cell-0-0'));
+
+    const far = screen.getByTestId('mc-cell-2-2');
+    expect(far).toHaveAttribute('data-dimmed', 'true');
+    expect(far.className).toContain('opacity-40');
+    // The selected card and the matching pair are not dimmed.
+    expect(screen.getByTestId('mc-cell-0-0')).not.toHaveAttribute('data-dimmed');
+    expect(screen.getByTestId('mc-cell-0-1')).not.toHaveAttribute('data-dimmed');
   });
 
   it('lifts a matching adjacent pair candidate and shows a transient success toast on removal', async () => {

--- a/frontend/src/pages/MonteCarloPage.tsx
+++ b/frontend/src/pages/MonteCarloPage.tsx
@@ -271,7 +271,7 @@ function MonteCarloPageContent() {
                           disabled={!isPlaying || loading || !filled}
                           data-pair-match={isMatchingPair ? 'true' : undefined}
                           data-dimmed={dimmed ? 'true' : undefined}
-                          className={`p-0 border-0 bg-transparent rounded transition-transform ${focusRingWhite} ${
+                          className={`p-0 border-0 bg-transparent rounded transition ${focusRingWhite} ${
                             filled ? 'cursor-pointer' : ''
                           } ${isSelected ? 'ring-2 ring-ds-accent' : ''} ${
                             isMatchingPair ? 'ring-2 ring-ds-success animate-pulse -translate-y-1' : ''

--- a/frontend/src/pages/MonteCarloPage.tsx
+++ b/frontend/src/pages/MonteCarloPage.tsx
@@ -241,6 +241,10 @@ function MonteCarloPageContent() {
                       // `isAdjOfSelected` already requires `filled`, so `cell.card` is non-null here.
                       const isMatchingPair =
                         isAdjOfSelected && selectedValue !== undefined && cell.card?.value === selectedValue;
+                      // Once a first card is picked, dim every filled card that is neither the
+                      // selection itself nor a legal (adjacent + same-rank) target, so the
+                      // removable pairs stand out.
+                      const dimmed = selected !== null && filled && !isSelected && !isMatchingPair;
                       const cellAction = `remove-${selected?.row ?? -1}-${selected?.col ?? -1}-${rowIdx}-${colIdx}`;
                       const isHintTarget =
                         frontendHintEnabled &&
@@ -266,15 +270,12 @@ function MonteCarloPageContent() {
                           onClick={() => handleCellClick(rowIdx, colIdx)}
                           disabled={!isPlaying || loading || !filled}
                           data-pair-match={isMatchingPair ? 'true' : undefined}
+                          data-dimmed={dimmed ? 'true' : undefined}
                           className={`p-0 border-0 bg-transparent rounded transition-transform ${focusRingWhite} ${
                             filled ? 'cursor-pointer' : ''
                           } ${isSelected ? 'ring-2 ring-ds-accent' : ''} ${
-                            isMatchingPair
-                              ? 'ring-2 ring-ds-success animate-pulse -translate-y-1'
-                              : isAdjOfSelected
-                                ? 'opacity-60'
-                                : ''
-                          } ${isHintTarget ? 'ring-2 ring-ds-warning' : ''}`}
+                            isMatchingPair ? 'ring-2 ring-ds-success animate-pulse -translate-y-1' : ''
+                          } ${dimmed ? 'opacity-40' : ''} ${isHintTarget ? 'ring-2 ring-ds-warning' : ''}`}
                         >
                           {cell.card ? (
                             <AnimatedCard card={cell.card} width={cardWidth} />


### PR DESCRIPTION
## 概要
モンテカルロ・ソリティアで1枚目を選択した後、取り除けない（選択中でも隣接同ランクのペアでもない）すべてのカードを `opacity-40` で暗転させ、除去可能なペアが視覚的に際立つようにしました。

## 現状との差分
- 既に隣接・同ランクのセルは `ring-ds-success` + pulse で強調済み（AC: 「隣接同ランクを強調」は実装済み）。
- これまで暗転していたのは「隣接・異ランク」のみ（`opacity-60`）で、非隣接の埋まったカードは暗転しませんでした。本PRで **非隣接を含む全ての非ペアカード**を `opacity-40` に暗転（AC: 「隣接でも異ランク/非隣接のセルは opacity-40 以下に暗転」を達成）。
- 選択中のカードと一致ペアは暗転しません。

## 変更点
- `MonteCarloPage.tsx`: `dimmed = selected !== null && filled && !isSelected && !isMatchingPair` を追加し `opacity-40` + `data-dimmed` を付与。旧 `isAdjOfSelected ? opacity-60` 分岐を置換。
- `MonteCarloPage.test.tsx`: 既存の暗転テストを opacity-40 / data-dimmed に更新し、非隣接カードの暗転＋選択/ペアは非暗転を検証するテストを追加（計17）。

## テスト
- `bun run test -- --run MonteCarloPage` → 17 passed
- `bun run check` → エラーなし

Closes #2615