### PR TITLE
feat(tarneeb): replace bid number input with a discrete button group

### DIFF
--- a/frontend/src/i18n/locales/en/tarneeb.json
+++ b/frontend/src/i18n/locales/en/tarneeb.json
@@ -33,6 +33,7 @@
   "opponentTeam": "Opponents",
   "bidButton": "Bid",
   "passButton": "Pass",
+  "bidSelectLabel": "Select your bid",
   "playButton": "Play",
   "nextTrick": "Next trick",
   "nextRound": "Next round",

--- a/frontend/src/i18n/locales/ja/tarneeb.json
+++ b/frontend/src/i18n/locales/ja/tarneeb.json
@@ -33,6 +33,7 @@
   "opponentTeam": "相手チーム",
   "bidButton": "ビッド",
   "passButton": "パス",
+  "bidSelectLabel": "ビッド数を選択",
   "playButton": "出す",
   "nextTrick": "次のトリック",
   "nextRound": "次のラウンド",

--- a/frontend/src/pages/TarneebPage.test.tsx
+++ b/frontend/src/pages/TarneebPage.test.tsx
@@ -92,12 +92,21 @@ describe('TarneebPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', 9));
   });
 
-  it('disables bid buttons that do not beat the current highest bid', async () => {
+  it('disables bid buttons that do not beat the current highest bid and pre-selects the lowest legal bid', async () => {
     mockExec.mockResolvedValue(makeState({ highestBid: 9 }));
     renderWithProviders(<TarneebPage />);
     await waitFor(() => expect(screen.getByTestId('bid-option-9')).toBeDisabled());
     expect(screen.getByTestId('bid-option-7')).toBeDisabled();
     expect(screen.getByTestId('bid-option-10')).toBeEnabled();
+    // The effect snaps the selection to the lowest legal value (highestBid + 1 = 10).
+    expect(screen.getByTestId('bid-option-10')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('shows no bid controls outside the human bid turn', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: 3 })); // PLAY phase
+    renderWithProviders(<TarneebPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined, expect.any(Object)));
+    expect(screen.queryByTestId('bid-option-7')).not.toBeInTheDocument();
   });
 
   it('passes by bidding 0', async () => {

--- a/frontend/src/pages/TarneebPage.test.tsx
+++ b/frontend/src/pages/TarneebPage.test.tsx
@@ -1,4 +1,4 @@
-import { waitFor, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { tarneebApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -75,5 +75,36 @@ describe('TarneebPage', () => {
     const oppRow = within(table).getByText('相手チーム').closest('tr') as HTMLTableRowElement;
     expect(within(oppRow).getByText('2')).toBeInTheDocument();
     expect(within(oppRow).getByText('5')).toBeInTheDocument();
+  });
+
+  it('renders a bid button group from minBid to 13 and bids the selected value', async () => {
+    renderWithProviders(<TarneebPage />);
+    // minBid 7 → buttons 7..13, none below 7.
+    const bid9 = await screen.findByTestId('bid-option-9');
+    expect(screen.queryByTestId('bid-option-6')).not.toBeInTheDocument();
+    expect(screen.getByTestId('bid-option-13')).toBeInTheDocument();
+
+    fireEvent.click(bid9);
+    expect(bid9).toHaveAttribute('aria-pressed', 'true');
+
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'ビッド' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', 9));
+  });
+
+  it('disables bid buttons that do not beat the current highest bid', async () => {
+    mockExec.mockResolvedValue(makeState({ highestBid: 9 }));
+    renderWithProviders(<TarneebPage />);
+    await waitFor(() => expect(screen.getByTestId('bid-option-9')).toBeDisabled());
+    expect(screen.getByTestId('bid-option-7')).toBeDisabled();
+    expect(screen.getByTestId('bid-option-10')).toBeEnabled();
+  });
+
+  it('passes by bidding 0', async () => {
+    renderWithProviders(<TarneebPage />);
+    await screen.findByTestId('bid-option-7');
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'パス' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', 0));
   });
 });

--- a/frontend/src/pages/TarneebPage.tsx
+++ b/frontend/src/pages/TarneebPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { tarneebApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -138,6 +138,15 @@ function TarneebPageContent() {
   } = useGameHint('tarneeb', state);
   const { cardWidth, isMobile } = useCardDimensions();
   const [bidValue, setBidValue] = useState(7);
+  // When the human's bid turn begins, snap the pre-selected bid to the lowest legal
+  // value (minBid, but above any standing bid) so a stale selection from a prior round
+  // is never left highlighted on a now-disabled button.
+  useEffect(() => {
+    if (!state) return;
+    const biddingNow = state.phase === TarneebPhase.BID && state.players[state.bidPlayerIdx]?.isHuman === true;
+    if (!biddingNow) return;
+    setBidValue(Math.max(state.config.minBid, state.highestBid + 1));
+  }, [state]);
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('tarneeb');
   const cliConfig: CliGameConfig<TarneebResponse, Parameters<typeof tarneebApi.exec>> = useMemo(
     () => ({

--- a/frontend/src/pages/TarneebPage.tsx
+++ b/frontend/src/pages/TarneebPage.tsx
@@ -404,36 +404,50 @@ function TarneebPageContent() {
                 </button>
               )}
               {isHumanBidTurn && (
-                <>
+                <div className="flex flex-col items-center gap-2">
                   {/*
-                    Valid Tarneeb bids are 0 (pass) or 7-13. The pass case is exposed via a
-                    dedicated button below, so the input range is restricted to 7-13. Out-of-range
-                    values are clamped on Bid-button click to avoid noisy backend errors.
+                    Valid Tarneeb bids are 0 (pass) or minBid..13 and must beat the current
+                    highest bid. A discrete button group (mirroring CallBreak) replaces the raw
+                    number input: out-of-range / already-beaten values are simply disabled, so no
+                    client-side clamping is needed.
                   */}
-                  <input
-                    type="number"
-                    min={state.config.minBid}
-                    max={13}
-                    value={bidValue}
-                    onChange={(e) => setBidValue(Number(e.target.value))}
-                    className="w-16 px-2 py-1 rounded bg-white/20 text-ds-text-primary text-center"
-                    aria-label="bid-input"
-                  />
-                  <button
-                    type="button"
-                    className={btnPrimary}
-                    onClick={() => {
-                      const clamped = Math.min(13, Math.max(state.config.minBid, bidValue));
-                      handleBid(clamped);
-                    }}
-                    disabled={loading || bidValue < state.config.minBid || bidValue > 13}
-                  >
-                    {t('bidButton')}
-                  </button>
-                  <button type="button" className={btnSuccess} onClick={() => handleBid(0)} disabled={loading}>
-                    {t('passButton')}
-                  </button>
-                </>
+                  <fieldset className="grid grid-cols-7 gap-1 border-0 p-0" aria-label={t('bidSelectLabel')}>
+                    {Array.from({ length: 13 - state.config.minBid + 1 }, (_, i) => i + state.config.minBid).map(
+                      (n) => (
+                        <button
+                          key={n}
+                          type="button"
+                          onClick={() => setBidValue(n)}
+                          disabled={loading || n <= state.highestBid}
+                          aria-pressed={bidValue === n}
+                          data-testid={`bid-option-${n}`}
+                          className={`h-9 w-9 rounded-lg font-medium text-sm transition-all disabled:cursor-not-allowed disabled:opacity-40 ${
+                            bidValue === n
+                              ? 'bg-ds-accent text-white ring-2 ring-ds-accent'
+                              : 'bg-white/20 text-ds-text-primary hover:bg-white/30'
+                          }`}
+                        >
+                          {n}
+                        </button>
+                      ),
+                    )}
+                  </fieldset>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      className={btnPrimary}
+                      onClick={() => handleBid(bidValue)}
+                      disabled={
+                        loading || bidValue < state.config.minBid || bidValue > 13 || bidValue <= state.highestBid
+                      }
+                    >
+                      {t('bidButton')}
+                    </button>
+                    <button type="button" className={btnSuccess} onClick={() => handleBid(0)} disabled={loading}>
+                      {t('passButton')}
+                    </button>
+                  </div>
+                </div>
               )}
               {isHumanTrumpTurn && (
                 <div className="flex gap-1">


### PR DESCRIPTION
## 概要
Tarneeb のビッド入力を、姉妹ゲーム CallBreak と同じ離散数値ボタングループに刷新しました。これまでは生の `<input type=number>` ＋クリック時クランプという場当たり的な作りで、タップ精度・モバイル操作性・有効値の明示に欠けていました。

## 変更点
- `TarneebPage.tsx`: `minBid..13` のボタン群（`bid-option-{n}`、`aria-pressed`）＋独立した Pass ボタンに置換。`<input type=number>` と `Math.min/Math.max` クランプを削除。
- 無効化ルール: `minBid` 未満（範囲外＝描画しない）に加え、**現在の最高ビッド以下のボタンも無効化**（バックエンドの `bid > highestBid` 制約に合わせ、無効なビッド送信を未然に防止）。
- `ja/en tarneeb.json`: `bidSelectLabel` キーを追加（fieldset の aria-label）。
- `TarneebPage.test.tsx`: ボタン群の描画範囲・選択→ビッド送信・最高ビッド以下の無効化・パス(0) を検証（計5テスト）。

## 補足
- 有効ビッドはバックエンド (`Tarneeb.go` PlayerBid) で `[config.MinBid, 13]` かつ `> highestBid`。`MinBid` は設定で 5〜8。よって固定 7〜13 ではなく `minBid..13` を描画。

## テスト
- `bun run test -- --run TarneebPage` → 5 passed
- `bun run check` → エラーなし

Closes #2628