### PR TITLE
feat(penguin): add a base-rank legend near the foundation

### DIFF
--- a/frontend/src/i18n/locales/en/penguin.json
+++ b/frontend/src/i18n/locales/en/penguin.json
@@ -13,6 +13,7 @@
   "undo": "Undo",
   "moveCount": "Moves",
   "baseRank": "Base Rank",
+  "baseRankLegend": "This deal starts at {{rank}}; the rank below it ({{prev}}) comes last (K wraps to A)",
   "empty": "Empty",
   "hintAvailable": "Hint",
   "foundationAriaLabel": "{{suit}} Foundation ({{cardCount}} cards)",

--- a/frontend/src/i18n/locales/ja/penguin.json
+++ b/frontend/src/i18n/locales/ja/penguin.json
@@ -13,6 +13,7 @@
   "undo": "元に戻す",
   "moveCount": "手数",
   "baseRank": "基準ランク",
+  "baseRankLegend": "このディールは {{rank}} から開始。1つ下の {{prev}} が最後（K→A と折り返し）",
   "empty": "空",
   "hintAvailable": "ヒント",
   "foundationAriaLabel": "{{suit}} ファンデーション ({{cardCount}}枚)",

--- a/frontend/src/pages/PenguinPage.test.tsx
+++ b/frontend/src/pages/PenguinPage.test.tsx
@@ -107,6 +107,15 @@ describe('PenguinPage', () => {
     expect(fourElements.length).toBeGreaterThanOrEqual(1);
   });
 
+  it('shows a base-rank legend near the foundation with the wraparound rule', async () => {
+    renderWithProviders(<PenguinPage />);
+    const legend = await screen.findByTestId('pg-base-rank-legend');
+    // baseRank 4 → starts at 4, ends at 3 (rank below).
+    expect(legend).toHaveTextContent('4');
+    expect(legend).toHaveTextContent('3');
+    expect(legend).toHaveTextContent(/折り返し/);
+  });
+
   it('renders foundation with cards', async () => {
     mockExec.mockResolvedValue(withFoundationState);
     renderWithProviders(<PenguinPage />);

--- a/frontend/src/pages/PenguinPage.tsx
+++ b/frontend/src/pages/PenguinPage.tsx
@@ -314,54 +314,65 @@ function PenguinPageContent() {
               <div className="w-4" />
 
               {/* Foundation piles */}
-              <div className="flex gap-2" data-tutorial="pg-foundation">
-                {state.foundation.map((pile: Card[], idx: number) => {
-                  const foundationZone: PenguinMoveZone = { zone: 'foundation', col: idx };
-                  return (
-                    <div key={`f-${idx.toString()}`} className="text-center">
-                      <div className="text-game-text-muted text-xs mb-1">{FOUNDATION_SUITS[idx]}</div>
-                      <DropZone
-                        isDropTarget={dnd.isDropTarget(foundationZone)}
-                        onDragOver={dnd.handleDragOver(foundationZone)}
-                        onDrop={dnd.handleDrop(foundationZone)}
-                        onDragLeave={dnd.handleDragLeave}
-                      >
-                        {pile.length > 0 ? (
-                          <button
-                            type="button"
-                            onClick={() => handleSelectTarget(foundationZone)}
-                            disabled={!isPlaying || loading || isAutoCompleting || !selectedSource}
-                            aria-label={t('foundationAriaLabel', {
-                              suit: FOUNDATION_SUITS[idx],
-                              cardCount: String(pile.length),
-                            })}
-                            data-testid={`pg-foundation-${idx.toString()}`}
-                            className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite}${isHintTarget('foundation', idx) ? ' ring-2 ring-ds-success animate-pulse' : ''}`}
-                          >
-                            <AnimatedCard
-                              card={pile[pile.length - 1]}
-                              width={cardWidth}
-                              draggable={false}
-                              dealDelay={isAutoCompleting ? idx * 0.15 : 0}
-                            />
-                          </button>
-                        ) : (
-                          <button
-                            type="button"
-                            onClick={() => handleSelectTarget(foundationZone)}
-                            disabled={!isPlaying || loading || !selectedSource}
-                            aria-label={t('emptyFoundationAriaLabel', { suit: FOUNDATION_SUITS[idx] })}
-                            data-testid={`pg-foundation-empty-${idx.toString()}`}
-                            style={{ width: cardWidth, height: cardHeight }}
-                            className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}${isHintTarget('foundation', idx) ? ' ring-2 ring-ds-success animate-pulse' : ''}`}
-                          >
-                            {baseRankLabel(state.baseRank)}
-                          </button>
-                        )}
-                      </DropZone>
-                    </div>
-                  );
-                })}
+              <div className="flex flex-col items-center">
+                <div
+                  className="text-game-text-muted text-[10px] mb-1 max-w-[12rem] text-center"
+                  data-testid="pg-base-rank-legend"
+                >
+                  {t('baseRankLegend', {
+                    rank: baseRankLabel(state.baseRank),
+                    prev: prevRankLabel(state.baseRank),
+                  })}
+                </div>
+                <div className="flex gap-2" data-tutorial="pg-foundation">
+                  {state.foundation.map((pile: Card[], idx: number) => {
+                    const foundationZone: PenguinMoveZone = { zone: 'foundation', col: idx };
+                    return (
+                      <div key={`f-${idx.toString()}`} className="text-center">
+                        <div className="text-game-text-muted text-xs mb-1">{FOUNDATION_SUITS[idx]}</div>
+                        <DropZone
+                          isDropTarget={dnd.isDropTarget(foundationZone)}
+                          onDragOver={dnd.handleDragOver(foundationZone)}
+                          onDrop={dnd.handleDrop(foundationZone)}
+                          onDragLeave={dnd.handleDragLeave}
+                        >
+                          {pile.length > 0 ? (
+                            <button
+                              type="button"
+                              onClick={() => handleSelectTarget(foundationZone)}
+                              disabled={!isPlaying || loading || isAutoCompleting || !selectedSource}
+                              aria-label={t('foundationAriaLabel', {
+                                suit: FOUNDATION_SUITS[idx],
+                                cardCount: String(pile.length),
+                              })}
+                              data-testid={`pg-foundation-${idx.toString()}`}
+                              className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite}${isHintTarget('foundation', idx) ? ' ring-2 ring-ds-success animate-pulse' : ''}`}
+                            >
+                              <AnimatedCard
+                                card={pile[pile.length - 1]}
+                                width={cardWidth}
+                                draggable={false}
+                                dealDelay={isAutoCompleting ? idx * 0.15 : 0}
+                              />
+                            </button>
+                          ) : (
+                            <button
+                              type="button"
+                              onClick={() => handleSelectTarget(foundationZone)}
+                              disabled={!isPlaying || loading || !selectedSource}
+                              aria-label={t('emptyFoundationAriaLabel', { suit: FOUNDATION_SUITS[idx] })}
+                              data-testid={`pg-foundation-empty-${idx.toString()}`}
+                              style={{ width: cardWidth, height: cardHeight }}
+                              className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}${isHintTarget('foundation', idx) ? ' ring-2 ring-ds-success animate-pulse' : ''}`}
+                            >
+                              {baseRankLabel(state.baseRank)}
+                            </button>
+                          )}
+                        </DropZone>
+                      </div>
+                    );
+                  })}
+                </div>
               </div>
             </div>
 

--- a/frontend/src/pages/PenguinPage.tsx
+++ b/frontend/src/pages/PenguinPage.tsx
@@ -315,15 +315,6 @@ function PenguinPageContent() {
 
               {/* Foundation piles */}
               <div className="flex flex-col items-center">
-                <div
-                  className="text-game-text-muted text-[10px] mb-1 max-w-[12rem] text-center"
-                  data-testid="pg-base-rank-legend"
-                >
-                  {t('baseRankLegend', {
-                    rank: baseRankLabel(state.baseRank),
-                    prev: prevRankLabel(state.baseRank),
-                  })}
-                </div>
                 <div className="flex gap-2" data-tutorial="pg-foundation">
                   {state.foundation.map((pile: Card[], idx: number) => {
                     const foundationZone: PenguinMoveZone = { zone: 'foundation', col: idx };
@@ -371,6 +362,15 @@ function PenguinPageContent() {
                         </DropZone>
                       </div>
                     );
+                  })}
+                </div>
+                <div
+                  className="text-game-text-muted text-[10px] mt-1 max-w-[12rem] text-center"
+                  data-testid="pg-base-rank-legend"
+                >
+                  {t('baseRankLegend', {
+                    rank: baseRankLabel(state.baseRank),
+                    prev: prevRankLabel(state.baseRank),
                   })}
                 </div>
               </div>


### PR DESCRIPTION
## 概要
Penguin はランクが折り返す（K の次が A）特殊ルールで、ベースランク（このディールの開始ランク）はヘッダーの小さな数値でしか示されず初見では分かりづらい状態でした。foundation 行の上に凡例を追加し、ルールを明示します。

## 変更点
- `PenguinPage.tsx`: foundation 列を縦コンテナで包み、その上に `baseRankLegend`（`data-testid=pg-base-rank-legend`）を表示。引数は既算出の `baseRankLabel(state.baseRank)` と `prevRankLabel(state.baseRank)`。
- `ja/en penguin.json`: `baseRankLegend` キーを追加。
- `PenguinPage.test.tsx`: baseRank=4 のとき凡例に「4」「3」「折り返し」が含まれることを検証（計42）。

## テスト
- `bun run test -- --run PenguinPage` → 42 passed
- `bun run check` → エラーなし

Closes #2636