### PR TITLE
feat(beleagueredcastle): show foundation progress on game over

### DIFF
--- a/frontend/src/i18n/locales/en/beleagueredcastle.json
+++ b/frontend/src/i18n/locales/en/beleagueredcastle.json
@@ -20,6 +20,7 @@
   "playing": "Move cards to build foundations",
   "gameClear": "Game Clear! Moves: {{moveCount}}",
   "gameOver": "Game Over",
+  "gameOverSummary": "Reached {{count}}/52 cards on the foundations ({{percent}}%)",
   "hintAvailable": "Hint available",
   "noHint": "No hint available",
   "tutorial": {

--- a/frontend/src/i18n/locales/ja/beleagueredcastle.json
+++ b/frontend/src/i18n/locales/ja/beleagueredcastle.json
@@ -20,6 +20,7 @@
   "playing": "カードを移動してください",
   "gameClear": "ゲームクリア！ 手数: {{moveCount}}",
   "gameOver": "ゲームオーバー",
+  "gameOverSummary": "ファウンデーション {{count}}/52 枚（{{percent}}%）まで到達",
   "hintAvailable": "ヒントがあります",
   "noHint": "ヒントはありません",
   "tutorial": {

--- a/frontend/src/pages/BeleagueredCastlePage.test.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.test.tsx
@@ -121,6 +121,21 @@ describe('BeleagueredCastlePage', () => {
     await waitFor(() => expect(screen.getAllByText(/ゲームオーバー/).length).toBeGreaterThan(0));
   });
 
+  it('shows the foundation progress summary on game over', async () => {
+    mockExec.mockResolvedValue(gameOverState); // 4 aces on foundations → 4/52 (8%)
+    renderWithProviders(<BeleagueredCastlePage />);
+    const summary = await screen.findByTestId('bc-gameover-summary');
+    expect(summary).toHaveTextContent('4/52');
+    expect(summary).toHaveTextContent('8%');
+  });
+
+  it('does not show the progress summary on game clear', async () => {
+    mockExec.mockResolvedValue(gameClearState);
+    renderWithProviders(<BeleagueredCastlePage />);
+    await waitFor(() => expect(screen.getAllByText(/ゲームクリア/).length).toBeGreaterThan(0));
+    expect(screen.queryByTestId('bc-gameover-summary')).not.toBeInTheDocument();
+  });
+
   it('disables the auto-complete button and shows a reason when no foundation has progressed', async () => {
     mockExec.mockResolvedValue(playingState); // foundations hold only aces
     renderWithProviders(<BeleagueredCastlePage />);

--- a/frontend/src/pages/BeleagueredCastlePage.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.tsx
@@ -177,8 +177,9 @@ function BeleagueredCastlePageContent() {
   const isGameClear = state.phase === BeleagueredCastlePhase.GAME_CLEAR;
   const isGameOver = state.phase === BeleagueredCastlePhase.GAME_OVER;
   const isEnded = isGameClear || isGameOver;
-  // How many of the 52 cards reached a foundation — shown on game over to convey progress.
-  const foundationCount = state.foundation.reduce((sum, pile) => sum + pile.length, 0);
+  // How many of the 52 cards reached a foundation — only needed on game over, so skip the
+  // reduce during normal (frequently re-rendered) play.
+  const foundationCount = isGameOver ? state.foundation.reduce((sum, pile) => sum + pile.length, 0) : 0;
   // Auto-complete becomes useful once a foundation has built past its ace, so
   // pulse the button only then (mirrors Crescent / Spiderette).
   const autoCompleteReady = state.foundation.some((pile) => pile.length > 1);

--- a/frontend/src/pages/BeleagueredCastlePage.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.tsx
@@ -177,6 +177,8 @@ function BeleagueredCastlePageContent() {
   const isGameClear = state.phase === BeleagueredCastlePhase.GAME_CLEAR;
   const isGameOver = state.phase === BeleagueredCastlePhase.GAME_OVER;
   const isEnded = isGameClear || isGameOver;
+  // How many of the 52 cards reached a foundation — shown on game over to convey progress.
+  const foundationCount = state.foundation.reduce((sum, pile) => sum + pile.length, 0);
   // Auto-complete becomes useful once a foundation has built past its ace, so
   // pulse the button only then (mirrors Crescent / Spiderette).
   const autoCompleteReady = state.foundation.some((pile) => pile.length > 1);
@@ -369,6 +371,15 @@ function BeleagueredCastlePageContent() {
               messageCode={state.messageCode}
               messageParams={state.messageParams}
             />
+
+            {isGameOver && (
+              <p data-testid="bc-gameover-summary" className="text-ds-text-muted text-sm text-center mt-1">
+                {t('gameOverSummary', {
+                  count: foundationCount,
+                  percent: Math.round((foundationCount / 52) * 100),
+                })}
+              </p>
+            )}
 
             <ActionLogSection
               isEndPhase={isEnded}


### PR DESCRIPTION
## 概要
Beleaguered Castle は GAME_OVER 時に `phase.gameOver` ラベルが出るだけで、なぜ詰みかも達成度も分からず唐突に終わる印象でした。敗北時に「52枚中いくつ foundation に積めたか」を可視化し、再挑戦の動機付けにします。

## 変更点
- `BeleagueredCastlePage.tsx`: `foundationCount = state.foundation.reduce(...)` を算出し、`isGameOver` 時のみ `GameMessageBox` 直下に `gameOverSummary`（枚数＋割合、`data-testid=bc-gameover-summary`）を表示。GAME_CLEAR 時は非表示（祝福演出で十分）。
- `ja/en beleagueredcastle.json`: `gameOverSummary` キーを追加。
- `BeleagueredCastlePage.test.tsx`: ゲームオーバー時に「4/52」「8%」が出ること、ゲームクリア時は非表示を検証（計13）。

## テスト
- `bun run test -- --run BeleagueredCastlePage` → 13 passed
- `bun run check` → エラーなし

Closes #2624