### PR TITLE
feat(gaps): show locked-card count the redeal will keep

### DIFF
--- a/frontend/src/i18n/locales/en/gaps.json
+++ b/frontend/src/i18n/locales/en/gaps.json
@@ -9,6 +9,7 @@
   "redealsRemaining": "Redeals left",
   "undo": "Undo",
   "redeal": "Redeal",
+  "redealKeepLabel": "Redeal ({{used}}/{{total}}) — keeps {{locked}}",
   "giveup": "Give Up",
   "hint": "Hint",
   "gap": "Gap",

--- a/frontend/src/i18n/locales/ja/gaps.json
+++ b/frontend/src/i18n/locales/ja/gaps.json
@@ -9,6 +9,7 @@
   "redealsRemaining": "再配り残り",
   "undo": "元に戻す",
   "redeal": "再配り",
+  "redealKeepLabel": "再配り ({{used}}/{{total}}) — {{locked}}枚維持",
   "giveup": "ギブアップ",
   "hint": "ヒント",
   "gap": "空き",

--- a/frontend/src/pages/GapsPage.test.tsx
+++ b/frontend/src/pages/GapsPage.test.tsx
@@ -101,6 +101,14 @@ describe('GapsPage', () => {
     await waitFor(() => expect(mockedRun).toHaveBeenCalledWith('redeal'));
   });
 
+  it('shows how many locked cards a redeal will keep', async () => {
+    // makeGrid: 4 rows each a full 2..13 run → 4 × 12 = 48 locked cards.
+    renderWithProviders(<GapsPage />);
+    const btn = await screen.findByTestId('gaps-redeal-button');
+    expect(btn).toHaveTextContent('(0/3)');
+    expect(btn).toHaveTextContent('48');
+  });
+
   it('calls run undo when undo clicked', async () => {
     mockedRun.mockResolvedValue({ ...playingState, canUndo: true });
     renderWithProviders(<GapsPage />);

--- a/frontend/src/pages/GapsPage.tsx
+++ b/frontend/src/pages/GapsPage.tsx
@@ -24,7 +24,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { valueName } from '../utils/cardUtils';
 import { computeGapsGhostHint } from '../utils/gapsGhostHint';
-import { gapsLockedPrefixLengths, gapsLockedTotal } from '../utils/gapsUtils';
+import { gapsLockedPrefixLengths } from '../utils/gapsUtils';
 
 const SUIT_SYMBOLS: Record<string, string> = {
   SPADE: '♠',
@@ -143,7 +143,8 @@ function GapsPageContent() {
   const isGameOver = state.phase === GapsPhase.GAME_OVER;
   const isEnded = isGameClear || isGameOver;
   const lockedPrefixLengths = gapsLockedPrefixLengths(state.grid);
-  const lockedTotal = gapsLockedTotal(state.grid);
+  // Derive the total from the already-computed per-row lengths to avoid a second board pass.
+  const lockedTotal = lockedPrefixLengths.reduce((sum, n) => sum + n, 0);
 
   return (
     <GamePageShell

--- a/frontend/src/pages/GapsPage.tsx
+++ b/frontend/src/pages/GapsPage.tsx
@@ -24,7 +24,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { valueName } from '../utils/cardUtils';
 import { computeGapsGhostHint } from '../utils/gapsGhostHint';
-import { gapsLockedPrefixLengths } from '../utils/gapsUtils';
+import { gapsLockedPrefixLengths, gapsLockedTotal } from '../utils/gapsUtils';
 
 const SUIT_SYMBOLS: Record<string, string> = {
   SPADE: '♠',
@@ -143,6 +143,7 @@ function GapsPageContent() {
   const isGameOver = state.phase === GapsPhase.GAME_OVER;
   const isEnded = isGameClear || isGameOver;
   const lockedPrefixLengths = gapsLockedPrefixLengths(state.grid);
+  const lockedTotal = gapsLockedTotal(state.grid);
 
   return (
     <GamePageShell
@@ -317,8 +318,13 @@ function GapsPageContent() {
                 className={btnPrimary}
                 onClick={handleRedeal}
                 disabled={loading || state.redealsRemaining <= 0}
+                data-testid="gaps-redeal-button"
               >
-                {t('redeal')} ({state.redealsUsed}/{state.redealsUsed + state.redealsRemaining})
+                {t('redealKeepLabel', {
+                  used: state.redealsUsed,
+                  total: state.redealsUsed + state.redealsRemaining,
+                  locked: lockedTotal,
+                })}
               </button>
               <button type="button" className={btnSuccess} onClick={handleHint} disabled={loading}>
                 {t('hint')}

--- a/frontend/src/utils/gapsUtils.test.ts
+++ b/frontend/src/utils/gapsUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Card, CardDesign } from '../types/card';
-import { gapsLockedPrefixLengths } from './gapsUtils';
+import { gapsLockedPrefixLengths, gapsLockedTotal } from './gapsUtils';
 
 const card = (design: CardDesign, value: number): Card => ({ design, value });
 
@@ -38,5 +38,16 @@ describe('gapsLockedPrefixLengths', () => {
   it('computes a value per row independently', () => {
     const grid = [[card('SPADE', 2), card('SPADE', 3)], [card('HEART', 5)], [], [card('CLOVER', 2)]];
     expect(gapsLockedPrefixLengths(grid)).toEqual([2, 0, 0, 1]);
+  });
+});
+
+describe('gapsLockedTotal', () => {
+  it('sums the locked prefix lengths across all rows', () => {
+    const grid = [[card('SPADE', 2), card('SPADE', 3)], [card('HEART', 5)], [], [card('CLOVER', 2)]];
+    expect(gapsLockedTotal(grid)).toBe(3);
+  });
+
+  it('returns 0 when no row starts with a 2', () => {
+    expect(gapsLockedTotal([[card('HEART', 5)], [card('SPADE', 7)]])).toBe(0);
   });
 });

--- a/frontend/src/utils/gapsUtils.ts
+++ b/frontend/src/utils/gapsUtils.ts
@@ -19,6 +19,18 @@ export function gapsLockedPrefixLengths(grid: readonly (readonly (Card | null)[]
   return grid.map((row) => lockedPrefixLengthForRow(row));
 }
 
+/**
+ * Total number of locked (redeal-surviving) cards across the whole board — the
+ * sum of every row's locked prefix length. Used to tell the player how many
+ * cards a redeal will preserve before they spend one.
+ *
+ * @param grid - The Gaps board.
+ * @returns The total locked-card count.
+ */
+export function gapsLockedTotal(grid: readonly (readonly (Card | null)[])[]): number {
+  return gapsLockedPrefixLengths(grid).reduce((sum, n) => sum + n, 0);
+}
+
 function lockedPrefixLengthForRow(row: readonly (Card | null)[]): number {
   let locked = 0;
   for (let c = 0; c < row.length; c++) {


### PR DESCRIPTION
## 概要
Gaps の redeal はギャップ以外を再シャッフルする不可逆操作ですが、押す前に「いくつのカードが確定（ロック）済みでリディール後も残るか」が見えませんでした。redeal ボタンに維持されるロック枚数を表示し、戦略判断を支援します。

## 変更点
- `gapsUtils.ts`: `gapsLockedTotal(grid)`（各行のロック長合計）を追加。
- `GapsPage.tsx`: redeal ボタンのラベルを `redealKeepLabel`（`再配り ({{used}}/{{total}}) — {{locked}}枚維持`、`data-testid=gaps-redeal-button`）に変更。
- `ja/en gaps.json`: `redealKeepLabel` キーを追加。
- テスト: `gapsLockedTotal` の合計/ゼロケース、ページで「(0/3)」「48」表示を検証（util+page 計24）。

## テスト
- `bun run test -- --run gapsUtils GapsPage` → 24 passed
- `bun run check` → エラーなし

Closes #2631