### PR TITLE
feat(manille): highlight the human's team in the player list

### DIFF
--- a/frontend/src/pages/ManillePage.test.tsx
+++ b/frontend/src/pages/ManillePage.test.tsx
@@ -10,6 +10,15 @@ vi.mock('../api/gameApi', () => ({
   actionLogApi: { manille: vi.fn() },
 }));
 
+const mobileFlag = vi.hoisted(() => ({ value: false }));
+vi.mock('../hooks/useCardDimensions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../hooks/useCardDimensions')>();
+  return {
+    ...actual,
+    useCardDimensions: () => ({ ...actual.useCardDimensions(), isMobile: mobileFlag.value }),
+  };
+});
+
 const mockExec = vi.mocked(manilleApi.exec);
 
 const playPhaseState = makeManilleState();
@@ -32,6 +41,7 @@ const cpuTurnState = makeManilleState({ currentPlayerIdx: 1, isHumanTurn: false 
 beforeEach(() => {
   mockExec.mockReset();
   mockExec.mockResolvedValue(playPhaseState);
+  mobileFlag.value = false;
 });
 
 describe('ManillePage', () => {
@@ -103,5 +113,15 @@ describe('ManillePage', () => {
     expect(screen.getByTestId('manille-player-2')).toHaveAttribute('data-own-team', 'true');
     expect(screen.getByTestId('manille-player-1')).not.toHaveAttribute('data-own-team');
     expect(screen.getByTestId('manille-player-3')).not.toHaveAttribute('data-own-team');
+  });
+
+  it('applies the same-team highlight in the mobile player list', async () => {
+    mobileFlag.value = true;
+    renderWithProviders(<ManillePage />);
+    // Expand the <details> player list, then check the shared row renderer applied the flag.
+    const summary = await screen.findByText('プレイヤー');
+    fireEvent.click(summary);
+    expect(screen.getByTestId('manille-player-0')).toHaveAttribute('data-own-team', 'true');
+    expect(screen.getByTestId('manille-player-1')).not.toHaveAttribute('data-own-team');
   });
 });

--- a/frontend/src/pages/ManillePage.test.tsx
+++ b/frontend/src/pages/ManillePage.test.tsx
@@ -94,4 +94,14 @@ describe('ManillePage', () => {
     await waitFor(() => expect(screen.getByAltText('♥ Q')).toBeInTheDocument());
     expect(screen.queryByRole('button', { name: '出す' })).not.toBeInTheDocument();
   });
+
+  it('highlights the human player and their partner (same team) in the player list', async () => {
+    renderWithProviders(<ManillePage />);
+    // Human is player 0 → team 0. Even ids (0, 2) are own team; odd ids (1, 3) are opponents.
+    await waitFor(() => expect(screen.getByTestId('manille-player-0')).toBeInTheDocument());
+    expect(screen.getByTestId('manille-player-0')).toHaveAttribute('data-own-team', 'true');
+    expect(screen.getByTestId('manille-player-2')).toHaveAttribute('data-own-team', 'true');
+    expect(screen.getByTestId('manille-player-1')).not.toHaveAttribute('data-own-team');
+    expect(screen.getByTestId('manille-player-3')).not.toHaveAttribute('data-own-team');
+  });
 });

--- a/frontend/src/pages/ManillePage.tsx
+++ b/frontend/src/pages/ManillePage.tsx
@@ -137,6 +137,24 @@ function ManillePageContent() {
   const humanTeam = humanIdx % 2;
   const trumpSymbol = SUIT_SYMBOLS[state.trumpSuit] ?? '?';
 
+  // One info-sidebar row per player; same-team members are emphasised. Shared by the
+  // mobile (<details>) and desktop layouts so the highlight logic lives in one place.
+  const renderPlayerRow = (p: (typeof state.players)[number]) => {
+    const isMyTeam = p.id % 2 === humanTeam;
+    return (
+      <div
+        key={p.id}
+        data-testid={`manille-player-${p.id}`}
+        data-own-team={isMyTeam ? 'true' : undefined}
+        className={`text-sm py-0.5 ${
+          isMyTeam ? 'font-bold text-ds-text-primary border-l-2 border-ds-accent pl-1' : 'text-ds-text-muted'
+        }`}
+      >
+        {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} | {t('tricks', { count: p.trickCount })}
+      </div>
+    );
+  };
+
   const handleManualReset = () => {
     hideActionLog();
     reset();
@@ -227,52 +245,15 @@ function ManillePageContent() {
                   </div>
                 </div>
 
-                {/* Players: cards / tricks */}
+                {/* Players: cards / tricks. Same-team members (p.id % 2 === humanTeam) are
+                    emphasised so the 2-vs-2 partnership is visible. Shared by both layouts. */}
                 {isMobile ? (
                   <details className="mb-2 p-2 rounded bg-black/30">
                     <summary className="cursor-pointer select-none text-ds-text-muted text-sm">{t('players')}</summary>
-                    <div className="mt-1">
-                      {state.players.map((p) => {
-                        const isMyTeam = p.id % 2 === humanTeam;
-                        return (
-                          <div
-                            key={p.id}
-                            data-testid={`manille-player-${p.id}`}
-                            data-own-team={isMyTeam ? 'true' : undefined}
-                            className={`text-sm py-0.5 ${
-                              isMyTeam
-                                ? 'font-bold text-ds-text-primary border-l-2 border-ds-accent pl-1'
-                                : 'text-ds-text-muted'
-                            }`}
-                          >
-                            {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
-                            {t('tricks', { count: p.trickCount })}
-                          </div>
-                        );
-                      })}
-                    </div>
+                    <div className="mt-1">{state.players.map(renderPlayerRow)}</div>
                   </details>
                 ) : (
-                  <div className="mb-2 p-2 rounded bg-black/30">
-                    {state.players.map((p) => {
-                      const isMyTeam = p.id % 2 === humanTeam;
-                      return (
-                        <div
-                          key={p.id}
-                          data-testid={`manille-player-${p.id}`}
-                          data-own-team={isMyTeam ? 'true' : undefined}
-                          className={`text-sm py-0.5 ${
-                            isMyTeam
-                              ? 'font-bold text-ds-text-primary border-l-2 border-ds-accent pl-1'
-                              : 'text-ds-text-muted'
-                          }`}
-                        >
-                          {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
-                          {t('tricks', { count: p.trickCount })}
-                        </div>
-                      );
-                    })}
-                  </div>
+                  <div className="mb-2 p-2 rounded bg-black/30">{state.players.map(renderPlayerRow)}</div>
                 )}
 
                 {/* Round result */}

--- a/frontend/src/pages/ManillePage.tsx
+++ b/frontend/src/pages/ManillePage.tsx
@@ -232,22 +232,46 @@ function ManillePageContent() {
                   <details className="mb-2 p-2 rounded bg-black/30">
                     <summary className="cursor-pointer select-none text-ds-text-muted text-sm">{t('players')}</summary>
                     <div className="mt-1">
-                      {state.players.map((p) => (
-                        <div key={p.id} className="text-ds-text-muted text-sm py-0.5">
-                          {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
-                          {t('tricks', { count: p.trickCount })}
-                        </div>
-                      ))}
+                      {state.players.map((p) => {
+                        const isMyTeam = p.id % 2 === humanTeam;
+                        return (
+                          <div
+                            key={p.id}
+                            data-testid={`manille-player-${p.id}`}
+                            data-own-team={isMyTeam ? 'true' : undefined}
+                            className={`text-sm py-0.5 ${
+                              isMyTeam
+                                ? 'font-bold text-ds-text-primary border-l-2 border-ds-accent pl-1'
+                                : 'text-ds-text-muted'
+                            }`}
+                          >
+                            {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
+                            {t('tricks', { count: p.trickCount })}
+                          </div>
+                        );
+                      })}
                     </div>
                   </details>
                 ) : (
                   <div className="mb-2 p-2 rounded bg-black/30">
-                    {state.players.map((p) => (
-                      <div key={p.id} className="text-ds-text-muted text-sm py-0.5">
-                        {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
-                        {t('tricks', { count: p.trickCount })}
-                      </div>
-                    ))}
+                    {state.players.map((p) => {
+                      const isMyTeam = p.id % 2 === humanTeam;
+                      return (
+                        <div
+                          key={p.id}
+                          data-testid={`manille-player-${p.id}`}
+                          data-own-team={isMyTeam ? 'true' : undefined}
+                          className={`text-sm py-0.5 ${
+                            isMyTeam
+                              ? 'font-bold text-ds-text-primary border-l-2 border-ds-accent pl-1'
+                              : 'text-ds-text-muted'
+                          }`}
+                        >
+                          {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
+                          {t('tricks', { count: p.trickCount })}
+                        </div>
+                      );
+                    })}
                   </div>
                 )}
 


### PR DESCRIPTION
## 概要
Manille は2対2のパートナーシップ制ですが、サイドバーのプレイヤー一覧では自チームのメンバーが視覚的に区別されず、スコア欄の「自チーム」ラベルと整合していませんでした。一覧で自チーム（人間と同チーム）を強調します。

## 変更点
- `ManillePage.tsx`: モバイル/デスクトップ両方のプレイヤー一覧で、`p.id % 2 === humanTeam` のメンバーに太字＋アクセント左ボーダーを付与（`data-testid=manille-player-{id}`、`data-own-team`）。チーム判定はトリック表示（`humanTeam = humanIdx % 2`）と一致。
- `ManillePage.test.tsx`: 人間(0)とパートナー(2)が own-team、相手(1,3)は非強調を検証（計9）。

## 補足
- 既存の DS トークン（`ds-accent` 等）を使用したため `gameTheme.ts` の変更は不要でした。

## テスト
- `bun run test -- --run ManillePage` → 9 passed
- `bun run check` → エラーなし

Closes #2668