### PR TITLE
feat(sedma): colour-code the player list by 2-vs-2 team

### DIFF
--- a/frontend/src/pages/SedmaPage.test.tsx
+++ b/frontend/src/pages/SedmaPage.test.tsx
@@ -94,4 +94,16 @@ describe('SedmaPage', () => {
     await waitFor(() => expect(screen.getByAltText('♥ Q')).toBeInTheDocument());
     expect(screen.queryByRole('button', { name: '出す' })).not.toBeInTheDocument();
   });
+
+  it('colour-codes the player list by 2-vs-2 team', async () => {
+    renderWithProviders(<SedmaPage />);
+    await waitFor(() => expect(screen.getByTestId('sedma-player-0')).toBeInTheDocument());
+    // Even ids → team A (blue), odd ids → team B (red).
+    expect(screen.getByTestId('sedma-player-0')).toHaveAttribute('data-team', '0');
+    expect(screen.getByTestId('sedma-player-0').className).toContain('border-ds-info');
+    expect(screen.getByTestId('sedma-player-2')).toHaveAttribute('data-team', '0');
+    expect(screen.getByTestId('sedma-player-1')).toHaveAttribute('data-team', '1');
+    expect(screen.getByTestId('sedma-player-1').className).toContain('border-ds-error');
+    expect(screen.getByTestId('sedma-player-3')).toHaveAttribute('data-team', '1');
+  });
 });

--- a/frontend/src/pages/SedmaPage.test.tsx
+++ b/frontend/src/pages/SedmaPage.test.tsx
@@ -100,10 +100,10 @@ describe('SedmaPage', () => {
     await waitFor(() => expect(screen.getByTestId('sedma-player-0')).toBeInTheDocument());
     // Even ids → team A (blue), odd ids → team B (red).
     expect(screen.getByTestId('sedma-player-0')).toHaveAttribute('data-team', '0');
-    expect(screen.getByTestId('sedma-player-0').className).toContain('border-ds-info');
+    expect(screen.getByTestId('sedma-player-0')).toHaveClass('border-ds-info');
     expect(screen.getByTestId('sedma-player-2')).toHaveAttribute('data-team', '0');
     expect(screen.getByTestId('sedma-player-1')).toHaveAttribute('data-team', '1');
-    expect(screen.getByTestId('sedma-player-1').className).toContain('border-ds-error');
+    expect(screen.getByTestId('sedma-player-1')).toHaveClass('border-ds-error');
     expect(screen.getByTestId('sedma-player-3')).toHaveAttribute('data-team', '1');
   });
 });

--- a/frontend/src/pages/SedmaPage.tsx
+++ b/frontend/src/pages/SedmaPage.tsx
@@ -133,6 +133,25 @@ function SedmaPageContent() {
   const canPlay = isPlayPhase && isHumanTurn;
   const humanTeam = humanIdx % 2;
 
+  // One info-sidebar row per player, colour-coded by team (A = even ids = blue,
+  // B = odd ids = red), matching the trick display's ally/opponent relationship.
+  // Shared by the mobile (<details>) and desktop layouts.
+  const renderPlayerRow = (p: (typeof state.players)[number]) => {
+    const team = p.id % 2;
+    return (
+      <div
+        key={p.id}
+        data-testid={`sedma-player-${p.id}`}
+        data-team={team}
+        className={`text-ds-text-muted text-sm py-0.5 border-l-2 pl-1 ${
+          team === 0 ? 'border-ds-info' : 'border-ds-error'
+        }`}
+      >
+        {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} | {t('tricks', { count: p.trickCount })}
+      </div>
+    );
+  };
+
   const handleManualReset = () => {
     hideActionLog();
     reset();
@@ -222,28 +241,15 @@ function SedmaPageContent() {
                   </div>
                 </div>
 
-                {/* Players: cards / tricks */}
+                {/* Players: cards / tricks, colour-coded by 2-vs-2 team. Shared renderer for
+                    both layouts so the team-colour logic lives in one place. */}
                 {isMobile ? (
                   <details className="mb-2 p-2 rounded bg-black/30">
                     <summary className="cursor-pointer select-none text-ds-text-muted text-sm">{t('players')}</summary>
-                    <div className="mt-1">
-                      {state.players.map((p) => (
-                        <div key={p.id} className="text-ds-text-muted text-sm py-0.5">
-                          {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
-                          {t('tricks', { count: p.trickCount })}
-                        </div>
-                      ))}
-                    </div>
+                    <div className="mt-1">{state.players.map(renderPlayerRow)}</div>
                   </details>
                 ) : (
-                  <div className="mb-2 p-2 rounded bg-black/30">
-                    {state.players.map((p) => (
-                      <div key={p.id} className="text-ds-text-muted text-sm py-0.5">
-                        {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
-                        {t('tricks', { count: p.trickCount })}
-                      </div>
-                    ))}
-                  </div>
+                  <div className="mb-2 p-2 rounded bg-black/30">{state.players.map(renderPlayerRow)}</div>
                 )}
 
                 {/* Round result */}


### PR DESCRIPTION
## 概要
Sedma は4人2対2のチーム戦ですが、サイドバーのプレイヤー一覧はインデックス順に並ぶだけでチームの視覚的グルーピングがなく、誰が味方で誰が敵か直感的に把握できませんでした。プレイヤー一覧をチーム色で色分けします。

## 変更点
- `SedmaPage.tsx`: 共有の `renderPlayerRow` を導入し、各行に `p.id % 2` で導出したチーム色の左ボーダーを付与（チームA/偶数=青 `border-ds-info`、チームB/奇数=赤 `border-ds-error`）。モバイル/デスクトップ両レイアウトで共通。`data-testid=sedma-player-{id}`、`data-team`。色分けはトリック表示の味方/敵関係（`humanTeam = humanIdx % 2`）と一致。
- `SedmaPage.test.tsx`: 偶数idがteam0(青)・奇数idがteam1(赤)で色分けされることを検証（計9）。

## 補足
- チームスコアの読み上げは可視テキストがそのままアクセシブルネームになるため、`aria-label` の追加（bare div では Biome `useAriaPropsSupportedByRole` 違反）は行いませんでした。

## テスト
- `bun run test -- --run SedmaPage` → 9 passed
- `bun run check` → エラーなし

Closes #2670