### PR TITLE
feat(nap): show the current highest bid in the bid phase

### DIFF
--- a/frontend/src/i18n/locales/en/nap.json
+++ b/frontend/src/i18n/locales/en/nap.json
@@ -37,6 +37,9 @@
   "nextRound": "Next Round",
   "target": "Target: {{points}} chips",
   "bidPrompt": "Place a bid (only a higher bid is allowed):",
+  "bidHighest": "Highest bid: {{bid}} ({{player}})",
+  "bidNone": "No bids yet",
+  "bidTooLow": "Must beat the current highest bid of {{bid}}",
   "bid": {
     "pass": "Pass",
     "two": "Two",

--- a/frontend/src/i18n/locales/ja/nap.json
+++ b/frontend/src/i18n/locales/ja/nap.json
@@ -37,6 +37,9 @@
   "nextRound": "次のラウンド",
   "target": "目標: {{points}}チップ",
   "bidPrompt": "入札してください（上回る入札のみ可）:",
+  "bidHighest": "現在の最高入札: {{bid}}（{{player}}）",
+  "bidNone": "まだ入札なし",
+  "bidTooLow": "現在の最高入札 {{bid}} を上回る必要があります",
   "bid": {
     "pass": "パス",
     "two": "ツー",

--- a/frontend/src/pages/NapPage.test.tsx
+++ b/frontend/src/pages/NapPage.test.tsx
@@ -109,6 +109,23 @@ describe('NapPage', () => {
     expect(screen.getByTestId('bid-0')).toBeEnabled();
   });
 
+  it('shows the current highest bid and a too-low tooltip on disabled bids', async () => {
+    mockExec.mockResolvedValue(makeNapState({ bids: [3, 0, 0, 0] }));
+    renderWithProviders(<NapPage />);
+    const info = await screen.findByTestId('nap-highest-bid');
+    // A real highest bid is shown (not the "no bids yet" placeholder).
+    expect(info).not.toHaveTextContent('まだ入札なし');
+    // Too-low bids carry a tooltip; valid bids do not.
+    expect(screen.getByTestId('bid-2')).toHaveAttribute('title');
+    expect(screen.getByTestId('bid-4')).not.toHaveAttribute('title');
+  });
+
+  it('shows "no bids yet" before anyone has bid', async () => {
+    mockExec.mockResolvedValue(makeNapState({ bids: [0, 0, 0, 0] }));
+    renderWithProviders(<NapPage />);
+    await waitFor(() => expect(screen.getByTestId('nap-highest-bid')).toHaveTextContent('まだ入札なし'));
+  });
+
   it('renders the play phase with the human cards and the declarer badge', async () => {
     mockExec.mockResolvedValue(playPhaseState);
     renderWithProviders(<NapPage />);

--- a/frontend/src/pages/NapPage.tsx
+++ b/frontend/src/pages/NapPage.tsx
@@ -154,6 +154,10 @@ function NapPageContent() {
 
   // The current highest (non-pass) bid; a new non-pass bid must beat it.
   const highestBid = Math.max(0, ...state.bids);
+  const highestBidderIdx = highestBid > 0 ? state.bids.indexOf(highestBid) : -1;
+  const highestBidLabelKey = BIDS.find((b) => b.value === highestBid)?.key;
+  const highestBidderName =
+    highestBidderIdx >= 0 ? playerName(highestBidderIdx, state.players[highestBidderIdx]?.isHuman === true) : '';
 
   const contractName =
     state.declarerIdx >= 0 ? t(`contractName.${CONTRACT_KEYS[state.contract] ?? 'pass'}`) : t('contractUndecided');
@@ -354,9 +358,15 @@ function NapPageContent() {
               {isBidPhase && isHumanBidTurn && (
                 <>
                   <span className="text-xs text-ds-text-muted self-center mr-1">{t('bidPrompt')}</span>
+                  <span className="text-xs text-ds-text-muted self-center mr-1" data-testid="nap-highest-bid">
+                    {highestBid > 0 && highestBidLabelKey
+                      ? t('bidHighest', { bid: t(highestBidLabelKey), player: highestBidderName })
+                      : t('bidNone')}
+                  </span>
                   {BIDS.map((b) => {
                     // Pass (0) is always allowed; a non-pass bid must beat the current highest.
-                    const disabled = loading || (b.value !== NapContract.PASS && b.value <= highestBid);
+                    const tooLow = b.value !== NapContract.PASS && b.value <= highestBid;
+                    const disabled = loading || tooLow;
                     return (
                       <button
                         key={b.value}
@@ -364,6 +374,10 @@ function NapPageContent() {
                         className="px-3 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
                         onClick={() => handleBid(b.value)}
                         disabled={disabled}
+                        aria-disabled={disabled}
+                        title={
+                          tooLow ? t('bidTooLow', { bid: highestBidLabelKey ? t(highestBidLabelKey) : '' }) : undefined
+                        }
                         data-testid={`bid-${b.value}`}
                       >
                         {t(b.key)}

--- a/frontend/src/pages/NapPage.tsx
+++ b/frontend/src/pages/NapPage.tsx
@@ -154,10 +154,9 @@ function NapPageContent() {
 
   // The current highest (non-pass) bid; a new non-pass bid must beat it.
   const highestBid = Math.max(0, ...state.bids);
-  const highestBidderIdx = highestBid > 0 ? state.bids.indexOf(highestBid) : -1;
+  const highestBidder = highestBid > 0 ? state.players[state.bids.indexOf(highestBid)] : undefined;
   const highestBidLabelKey = BIDS.find((b) => b.value === highestBid)?.key;
-  const highestBidderName =
-    highestBidderIdx >= 0 ? playerName(highestBidderIdx, state.players[highestBidderIdx]?.isHuman === true) : '';
+  const highestBidderName = highestBidder ? playerName(highestBidder.id, highestBidder.isHuman) : '';
 
   const contractName =
     state.declarerIdx >= 0 ? t(`contractName.${CONTRACT_KEYS[state.contract] ?? 'pass'}`) : t('contractUndecided');


### PR DESCRIPTION
## 概要
Nap はビッドボタンの活性判定に `highestBid` を使うものの、現在の最高入札自体を表示しておらず、プレイヤーはなぜ低いビッドが無効かを把握できませんでした。最高入札と入札者を表示し、無効ボタンに理由ツールチップを付けます。

## 変更点
- `NapPage.tsx`: 入札フェーズに `bidHighest`（最高入札の契約名＋入札者）/ `bidNone` 表示行（`data-testid=nap-highest-bid`）を追加。無効（too-low）な非パスボタンに `title`=`bidTooLow` と `aria-disabled` を付与。
- `ja/en nap.json`: `bidHighest`/`bidNone`/`bidTooLow` を追加。
- `NapPage.test.tsx`: 最高入札表示・too-low ボタンの tooltip・未入札時の「まだ入札なし」を検証（計12）。

## テスト
- `bun run test -- --run NapPage` → 12 passed
- `bun run check` → エラーなし

Closes #2673