### PR TITLE
feat(fortyfives): show current highest bid in the bid phase

### DIFF
--- a/frontend/src/i18n/locales/en/fortyfives.json
+++ b/frontend/src/i18n/locales/en/fortyfives.json
@@ -39,6 +39,9 @@
   "nextRound": "Next Round",
   "target": "Target: {{points}} pts",
   "bidPrompt": "Place a bid (only a higher bid is allowed):",
+  "bidHighest": "Highest bid: {{bid}} ({{player}})",
+  "bidNone": "No bids yet",
+  "bidDisabledReason": "Must exceed the current highest bid of {{currentBid}}",
   "bid": {
     "pass": "Pass",
     "fifteen": "15",

--- a/frontend/src/i18n/locales/ja/fortyfives.json
+++ b/frontend/src/i18n/locales/ja/fortyfives.json
@@ -39,6 +39,9 @@
   "nextRound": "次のラウンド",
   "target": "目標: {{points}}点",
   "bidPrompt": "入札してください（上回る入札のみ可）:",
+  "bidHighest": "現在の最高ビッド: {{bid}}（{{player}}）",
+  "bidNone": "まだ入札なし",
+  "bidDisabledReason": "現在の最高ビッド {{currentBid}} を超える必要があります",
   "bid": {
     "pass": "パス",
     "fifteen": "15",

--- a/frontend/src/pages/FortyFivesPage.test.tsx
+++ b/frontend/src/pages/FortyFivesPage.test.tsx
@@ -113,8 +113,10 @@ describe('FortyFivesPage', () => {
     const info = await screen.findByTestId('ff-highest-bid');
     expect(info).toHaveTextContent('20');
     expect(info).not.toHaveTextContent('まだ入札なし');
-    expect(screen.getByTestId('bid-15')).toHaveAttribute('title');
-    expect(screen.getByTestId('bid-25')).not.toHaveAttribute('title');
+    // The reason tooltip lives on the wrapping span (disabled buttons suppress native titles).
+    expect(screen.getByTestId('bid-wrap-15')).toHaveAttribute('title');
+    expect(screen.getByTestId('bid-15')).toHaveAttribute('aria-label');
+    expect(screen.getByTestId('bid-wrap-25')).not.toHaveAttribute('title');
   });
 
   it('shows "no bids yet" before anyone has bid', async () => {

--- a/frontend/src/pages/FortyFivesPage.test.tsx
+++ b/frontend/src/pages/FortyFivesPage.test.tsx
@@ -107,6 +107,22 @@ describe('FortyFivesPage', () => {
     expect(screen.getByTestId('bid-0')).toBeEnabled();
   });
 
+  it('shows the current highest bid and a reason tooltip on too-low bids', async () => {
+    mockExec.mockResolvedValue(makeFortyFivesState({ bids: [20, 0, 0, 0] }));
+    renderWithProviders(<FortyFivesPage />);
+    const info = await screen.findByTestId('ff-highest-bid');
+    expect(info).toHaveTextContent('20');
+    expect(info).not.toHaveTextContent('まだ入札なし');
+    expect(screen.getByTestId('bid-15')).toHaveAttribute('title');
+    expect(screen.getByTestId('bid-25')).not.toHaveAttribute('title');
+  });
+
+  it('shows "no bids yet" before anyone has bid', async () => {
+    mockExec.mockResolvedValue(makeFortyFivesState({ bids: [0, 0, 0, 0] }));
+    renderWithProviders(<FortyFivesPage />);
+    await waitFor(() => expect(screen.getByTestId('ff-highest-bid')).toHaveTextContent('まだ入札なし'));
+  });
+
   it('renders the play phase with the human cards and the declarer badge', async () => {
     mockExec.mockResolvedValue(playPhaseState);
     renderWithProviders(<FortyFivesPage />);

--- a/frontend/src/pages/FortyFivesPage.tsx
+++ b/frontend/src/pages/FortyFivesPage.tsx
@@ -335,19 +335,23 @@ function FortyFivesPageContent() {
                     // Pass (0) is always allowed; a non-pass bid must beat the current highest.
                     const tooLow = b.value !== 0 && b.value <= highestBid;
                     const disabled = loading || tooLow;
+                    const reason = tooLow ? t('bidDisabledReason', { currentBid: highestBid }) : undefined;
+                    // The title lives on the wrapping span: browsers suppress native tooltips on
+                    // disabled buttons, so hovering the span still surfaces the reason.
                     return (
-                      <button
-                        key={b.value}
-                        type="button"
-                        className="px-3 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
-                        onClick={() => handleBid(b.value)}
-                        disabled={disabled}
-                        aria-disabled={disabled}
-                        title={tooLow ? t('bidDisabledReason', { currentBid: highestBid }) : undefined}
-                        data-testid={`bid-${b.value}`}
-                      >
-                        {t(b.key)}
-                      </button>
+                      <span key={b.value} title={reason} data-testid={`bid-wrap-${b.value}`}>
+                        <button
+                          type="button"
+                          className="px-3 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
+                          onClick={() => handleBid(b.value)}
+                          disabled={disabled}
+                          aria-disabled={disabled}
+                          aria-label={reason ? `${t(b.key)} — ${reason}` : undefined}
+                          data-testid={`bid-${b.value}`}
+                        >
+                          {t(b.key)}
+                        </button>
+                      </span>
                     );
                   })}
                 </>

--- a/frontend/src/pages/FortyFivesPage.tsx
+++ b/frontend/src/pages/FortyFivesPage.tsx
@@ -145,6 +145,9 @@ function FortyFivesPageContent() {
 
   // The current highest (non-pass) bid; a new non-pass bid must beat it.
   const highestBid = Math.max(0, ...state.bids);
+  // Look up the holder via the players array (playerName expects a player id, not an index).
+  const highestBidder = highestBid > 0 ? state.players[state.bids.indexOf(highestBid)] : undefined;
+  const highestBidderName = highestBidder ? playerName(highestBidder.id, highestBidder.isHuman) : '';
 
   const contractLabel = state.contract === 0 ? t('contractUndecided') : String(state.contract);
 
@@ -325,9 +328,13 @@ function FortyFivesPageContent() {
               {isBidPhase && isHumanBidTurn && (
                 <>
                   <span className="text-xs text-ds-text-muted self-center mr-1">{t('bidPrompt')}</span>
+                  <span className="text-xs text-ds-text-muted self-center mr-1" data-testid="ff-highest-bid">
+                    {highestBid > 0 ? t('bidHighest', { bid: highestBid, player: highestBidderName }) : t('bidNone')}
+                  </span>
                   {BIDS.map((b) => {
                     // Pass (0) is always allowed; a non-pass bid must beat the current highest.
-                    const disabled = loading || (b.value !== 0 && b.value <= highestBid);
+                    const tooLow = b.value !== 0 && b.value <= highestBid;
+                    const disabled = loading || tooLow;
                     return (
                       <button
                         key={b.value}
@@ -335,6 +342,8 @@ function FortyFivesPageContent() {
                         className="px-3 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
                         onClick={() => handleBid(b.value)}
                         disabled={disabled}
+                        aria-disabled={disabled}
+                        title={tooLow ? t('bidDisabledReason', { currentBid: highestBid }) : undefined}
                         data-testid={`bid-${b.value}`}
                       >
                         {t(b.key)}


### PR DESCRIPTION
## 概要
Forty-Fives の BID フェーズは、現在の最高ビッド（`highestBid`）を画面表示しておらず、無効ビッドボタンも `opacity-40` のみで理由が分かりませんでした。最高ビッドと保持者を表示し、無効ボタンに理由を付けます。

## 変更点
- `FortyFivesPage.tsx`: BID フェーズに `bidHighest`（最高ビッド＋保持者）/ `bidNone` 表示（`data-testid=ff-highest-bid`）。無効（too-low）な非パスボタンに `title`=`bidDisabledReason` と `aria-disabled`。保持者は players 配列経由で解決し `playerName` に正しい player id を渡す。
- `ja/en fortyfives.json`: `bidHighest`/`bidNone`/`bidDisabledReason` を追加。
- `FortyFivesPage.test.tsx`: 最高ビッド表示・tooltip・未入札時の「まだ入札なし」を検証（計12）。

## テスト
- `bun run test -- --run FortyFivesPage` → 12 passed
- `bun run check` → エラーなし

Closes #2665