### PR TITLE
fix(domain): prevent illegal sub-minimum CPU bets in pot-limit Five Card Stud

### DIFF
--- a/internal/domain/FiveCardStudCPU.go
+++ b/internal/domain/FiveCardStudCPU.go
@@ -74,6 +74,7 @@ func (s *FiveCardStud) cpuDecide(idx int) (int, int) {
 		if maxBetAmount > 0 && amount > maxBetAmount {
 			amount = maxBetAmount
 		}
+		action, amount = s.legalizeClampedAction(action, amount, callAmount)
 		if maxRaises > 0 && s.raiseCount >= maxRaises {
 			if action == FiveCardStudActionRaise || action == FiveCardStudActionBet {
 				if callAmount > 0 {
@@ -120,6 +121,7 @@ func (s *FiveCardStud) cpuDecide(idx int) (int, int) {
 	if maxBetAmount > 0 && amount > maxBetAmount {
 		amount = maxBetAmount
 	}
+	action, amount = s.legalizeClampedAction(action, amount, callAmount)
 	if maxRaises > 0 && s.raiseCount >= maxRaises {
 		if action == FiveCardStudActionRaise || action == FiveCardStudActionBet {
 			if callAmount > 0 {
@@ -129,6 +131,23 @@ func (s *FiveCardStud) cpuDecide(idx int) (int, int) {
 		}
 	}
 	return action, amount
+}
+
+// legalizeClampedAction demotes an aggressive action whose amount was clamped below the
+// legal minimum to a legal alternative. In pot-limit games the pot-size cap
+// (maxBetAmount = pot + lastBet) can fall below the table minimum bet/raise when the pot
+// is small, which would otherwise produce an illegal "bet below the minimum" action. In
+// that case the CPU calls when facing a bet, or checks when opening.
+func (s *FiveCardStud) legalizeClampedAction(action, amount, callAmount int) (int, int) {
+	belowMin := (action == FiveCardStudActionBet && amount < s.currentBetSize()) ||
+		(action == FiveCardStudActionRaise && amount < s.minRaise)
+	if !belowMin {
+		return action, amount
+	}
+	if callAmount > 0 {
+		return FiveCardStudActionCall, 0
+	}
+	return FiveCardStudActionCheck, 0
 }
 
 // evalThirdStreetStrength 開始ストリートのハンド強度評価 (0-100)

--- a/internal/domain/FiveCardStud_test.go
+++ b/internal/domain/FiveCardStud_test.go
@@ -1287,6 +1287,39 @@ func TestFiveCardStud_FullCPUGame_PotLimit(t *testing.T) {
 	}
 }
 
+func TestFiveCardStud_legalizeClampedAction(t *testing.T) {
+	cfg := DefaultFiveCardStudConfig() // SmallBet 5, BigBet 10
+	// Second/third street → the minimum bet is SmallBet (5).
+	s := &FiveCardStud{config: cfg, phase: FiveCardStudPhaseSecondStreet, minRaise: 5}
+
+	// A bet clamped below the minimum (pot-limit small-pot case) becomes a check when opening.
+	action, amount := s.legalizeClampedAction(FiveCardStudActionBet, 3, 0)
+	assert.Equal(t, FiveCardStudActionCheck, action)
+	assert.Equal(t, 0, amount)
+
+	// A bet clamped below the minimum while facing a wager becomes a call.
+	action, _ = s.legalizeClampedAction(FiveCardStudActionBet, 3, 4)
+	assert.Equal(t, FiveCardStudActionCall, action)
+
+	// A legal bet (>= SmallBet) is left untouched.
+	action, amount = s.legalizeClampedAction(FiveCardStudActionBet, 5, 0)
+	assert.Equal(t, FiveCardStudActionBet, action)
+	assert.Equal(t, 5, amount)
+
+	// A raise clamped below the minimum raise becomes a call when facing a wager.
+	action, _ = s.legalizeClampedAction(FiveCardStudActionRaise, 2, 4)
+	assert.Equal(t, FiveCardStudActionCall, action)
+
+	// A legal raise (>= minRaise) is left untouched.
+	action, amount = s.legalizeClampedAction(FiveCardStudActionRaise, 5, 4)
+	assert.Equal(t, FiveCardStudActionRaise, action)
+	assert.Equal(t, 5, amount)
+
+	// Non-aggressive actions pass through unchanged.
+	action, _ = s.legalizeClampedAction(FiveCardStudActionFold, 0, 4)
+	assert.Equal(t, FiveCardStudActionFold, action)
+}
+
 func TestFiveCardStud_FullCPUGame_Tournament(t *testing.T) {
 	cfg := DefaultFiveCardStudConfig()
 	cfg.TableSize = 3


### PR DESCRIPTION
## 概要
長らく CI を断続的に落としていた `TestFiveCardStud_FullCPUGame_PotLimit` フレーク（`CPU player N action 3 failed: Bet must be at least the minimum bet.`）の根本原因を修正します。

## 根本原因
ポットリミットでは `FiveCardStudCPU.go` の `cpuDecide` が CPU のベット/レイズ額を `maxBetAmount = pot + lastBet`（`CalculateBettingLimits`）まで切り下げます。ストリート開始直後などポットが小さいと、切り下げ後の額がテーブル最低ベット（`currentBetSize()` = SmallBet/BigBet）を下回り、`ExecuteBettingAction`（betting.go:129）が「最低ベット未満」として拒否していました。

## 修正
- `legalizeClampedAction(action, amount, callAmount)` を追加し、両方の clamp 箇所の直後で適用。最低額を下回るベット/レイズを、開始時は **チェック**、ベットに直面している場合は **コール** へ降格させます（いずれも常に合法）。
- 影響範囲は `FiveCardStudCPU.go` のみ（共有 `betting.go` は不変）で、他ゲームには影響しません。
- `legalizeClampedAction` の決定的ユニットテストを追加。

## 検証
- 修正前: `go test -run TestFiveCardStud_FullCPUGame_PotLimit -count=80` でローカル再現（断続失敗）。
- 本ボックスはテストバイナリのコンパイルが非常に重いため、フルの `-count` 検証は CI に委ねています（Backend Tests がフレークテストを実行）。
- 追加した `TestFiveCardStud_legalizeClampedAction` で降格ロジックを決定的に検証。

Closes #2443 に類する安定化（独立フレーク）。