### PR TITLE
feat(twentynine): show live round card points during bidding/play

### DIFF
--- a/frontend/src/i18n/locales/en/twentynine.json
+++ b/frontend/src/i18n/locales/en/twentynine.json
@@ -31,6 +31,7 @@
     "b": "Team B"
   },
   "yourTeam": "Your Team",
+  "roundPointsTitle": "Current round points",
   "teamScore": "{{team}}: {{score}} pts",
   "declarerBadge": "Declarer",
   "contractUndecided": "Declarer: undecided",

--- a/frontend/src/i18n/locales/ja/twentynine.json
+++ b/frontend/src/i18n/locales/ja/twentynine.json
@@ -31,6 +31,7 @@
     "b": "チームB"
   },
   "yourTeam": "あなたのチーム",
+  "roundPointsTitle": "現在のラウンド得点",
   "teamScore": "{{team}}: {{score}}点",
   "declarerBadge": "落札者",
   "contractUndecided": "落札者: 未決定",

--- a/frontend/src/pages/TwentyNinePage.test.tsx
+++ b/frontend/src/pages/TwentyNinePage.test.tsx
@@ -126,6 +126,21 @@ describe('TwentyNinePage', () => {
     expect(screen.getByText('落札者')).toBeInTheDocument();
   });
 
+  it('shows live round card points during play', async () => {
+    mockExec.mockResolvedValue(makeTwentyNineState({ phase: 1, isHumanBidTurn: false, roundTeamPoints: [12, 7] }));
+    renderWithProviders(<TwentyNinePage />);
+    const live = await screen.findByTestId('tn29-round-points');
+    expect(live).toHaveTextContent('12');
+    expect(live).toHaveTextContent('7');
+  });
+
+  it('hides the live round-points block at round end (the result block takes over)', async () => {
+    mockExec.mockResolvedValue(roundEndState);
+    renderWithProviders(<TwentyNinePage />);
+    await waitFor(() => expect(screen.getByText('ラウンド結果（カード点）')).toBeInTheDocument());
+    expect(screen.queryByTestId('tn29-round-points')).not.toBeInTheDocument();
+  });
+
   it('does not show the play button on a CPU turn', async () => {
     mockExec.mockResolvedValue(cpuTurnState);
     renderWithProviders(<TwentyNinePage />);

--- a/frontend/src/pages/TwentyNinePage.tsx
+++ b/frontend/src/pages/TwentyNinePage.tsx
@@ -280,8 +280,8 @@ function TwentyNinePageContent() {
                     data-testid="tn29-round-points"
                   >
                     <div className="mb-1 text-ds-text-primary">{t('roundPointsTitle')}</div>
-                    <div>{t('roundResult.teamA', { points: state.roundTeamPoints[0] ?? 0 })}</div>
-                    <div>{t('roundResult.teamB', { points: state.roundTeamPoints[1] ?? 0 })}</div>
+                    <div>{t('roundResult.teamA', { points: state.roundTeamPoints[0] })}</div>
+                    <div>{t('roundResult.teamB', { points: state.roundTeamPoints[1] })}</div>
                   </div>
                 )}
 

--- a/frontend/src/pages/TwentyNinePage.tsx
+++ b/frontend/src/pages/TwentyNinePage.tsx
@@ -272,6 +272,19 @@ function TwentyNinePageContent() {
                   </div>
                 ))}
 
+                {/* Live round card points during bidding/play (matches the CUI's roundPoints
+                    readout); the round-result block below takes over once the round ends. */}
+                {!(isRoundEnd || isGameEnd) && (
+                  <div
+                    className="my-3 p-2 rounded bg-black/30 text-ds-text-muted text-sm"
+                    data-testid="tn29-round-points"
+                  >
+                    <div className="mb-1 text-ds-text-primary">{t('roundPointsTitle')}</div>
+                    <div>{t('roundResult.teamA', { points: state.roundTeamPoints[0] ?? 0 })}</div>
+                    <div>{t('roundResult.teamB', { points: state.roundTeamPoints[1] ?? 0 })}</div>
+                  </div>
+                )}
+
                 {/* Round result: card points per team */}
                 {(isRoundEnd || isGameEnd) && (
                   <div className="my-3 p-2 rounded bg-black/30 text-ds-text-muted text-sm">


### PR DESCRIPTION
## 概要
Twenty-Nine の CUI はラウンドのチームカードポイントを常時表示しますが、Web の情報サイドバーは `isRoundEnd || isGameEnd` のときしかラウンド結果を出さず、BID/PLAY 中に現ラウンドの獲得点が見えませんでした（CUI と情報非対称）。プレイ中も常時表示します。

## 変更点
- `TwentyNinePage.tsx`: `!(isRoundEnd || isGameEnd)` のとき `state.roundTeamPoints` を表示する常時ブロック（`data-testid=tn29-round-points`）を追加。ラウンド終了時は従来の結果ブロックに切り替わり重複しません。
- `ja/en twentynine.json`: `roundPointsTitle` を追加（チーム点ラベルは既存 `roundResult.teamA/teamB` を再利用）。
- `TwentyNinePage.test.tsx`: プレイ中に現ラウンド点が出ること・ラウンド終了時は常時ブロックが消える（結果ブロックに交代）ことを検証（計13）。

## テスト
- `bun run test -- --run TwentyNinePage` → 13 passed
- `bun run check` → エラーなし

Closes #2666