### PR TITLE
feat(klaverjas): show live Roem bonus during play

### DIFF
--- a/frontend/src/i18n/locales/en/klaverjas.json
+++ b/frontend/src/i18n/locales/en/klaverjas.json
@@ -23,6 +23,7 @@
   "you": "You",
   "cpu": "CPU {{id}}",
   "yourTeam": "Your Team",
+  "roem": { "title": "Roem (bonus)" },
   "team": {
     "a": "Team A",
     "b": "Team B"

--- a/frontend/src/i18n/locales/ja/klaverjas.json
+++ b/frontend/src/i18n/locales/ja/klaverjas.json
@@ -23,6 +23,7 @@
   "you": "あなた",
   "cpu": "CPU {{id}}",
   "yourTeam": "あなたのチーム",
+  "roem": { "title": "Roem(ボーナス)" },
   "team": {
     "a": "チームA",
     "b": "チームB"

--- a/frontend/src/pages/KlaverjasPage.test.tsx
+++ b/frontend/src/pages/KlaverjasPage.test.tsx
@@ -82,6 +82,21 @@ describe('KlaverjasPage', () => {
     expect(screen.getByText('ラウンド結果')).toBeInTheDocument();
   });
 
+  it('shows live Roem during play', async () => {
+    mockExec.mockResolvedValue(makeKlaverjasState({ phase: 0, roundRoem: [40, 20] }));
+    renderWithProviders(<KlaverjasPage />);
+    const roem = await screen.findByTestId('klaverjas-roem');
+    expect(roem).toHaveTextContent('40');
+    expect(roem).toHaveTextContent('20');
+  });
+
+  it('hides the live Roem block at round end (the round result repeats it)', async () => {
+    mockExec.mockResolvedValue(roundEndState);
+    renderWithProviders(<KlaverjasPage />);
+    await waitFor(() => expect(screen.getByText('ラウンド結果')).toBeInTheDocument());
+    expect(screen.queryByTestId('klaverjas-roem')).not.toBeInTheDocument();
+  });
+
   it('renders the game end message', async () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<KlaverjasPage />);

--- a/frontend/src/pages/KlaverjasPage.test.tsx
+++ b/frontend/src/pages/KlaverjasPage.test.tsx
@@ -90,6 +90,14 @@ describe('KlaverjasPage', () => {
     expect(roem).toHaveTextContent('20');
   });
 
+  it('falls back to 0 Roem when the array is empty', async () => {
+    mockExec.mockResolvedValue(makeKlaverjasState({ phase: 0, roundRoem: [] }));
+    renderWithProviders(<KlaverjasPage />);
+    const roem = await screen.findByTestId('klaverjas-roem');
+    expect(roem).toHaveTextContent('A=0');
+    expect(roem).toHaveTextContent('B=0');
+  });
+
   it('hides the live Roem block at round end (the round result repeats it)', async () => {
     mockExec.mockResolvedValue(roundEndState);
     renderWithProviders(<KlaverjasPage />);

--- a/frontend/src/pages/KlaverjasPage.tsx
+++ b/frontend/src/pages/KlaverjasPage.tsx
@@ -227,6 +227,15 @@ function KlaverjasPageContent() {
                   </div>
                 </div>
 
+                {/* Live Roem (bonus) per team, shown throughout the hand to match the CUI's
+                    Roem readout; the round-result block below repeats it once the round ends. */}
+                {!(isRoundEnd || isGameEnd) && (
+                  <div className="mb-2 p-2 rounded bg-black/30 text-ds-text-muted text-sm" data-testid="klaverjas-roem">
+                    <div className="mb-1 text-ds-text-primary">{t('roem.title')}</div>
+                    <div>{t('roundResult.roem', { roemA: state.roundRoem[0], roemB: state.roundRoem[1] })}</div>
+                  </div>
+                )}
+
                 {/* Players: cards / tricks */}
                 {isMobile ? (
                   <details className="mb-2 p-2 rounded bg-black/30">

--- a/frontend/src/pages/KlaverjasPage.tsx
+++ b/frontend/src/pages/KlaverjasPage.tsx
@@ -232,7 +232,9 @@ function KlaverjasPageContent() {
                 {!(isRoundEnd || isGameEnd) && (
                   <div className="mb-2 p-2 rounded bg-black/30 text-ds-text-muted text-sm" data-testid="klaverjas-roem">
                     <div className="mb-1 text-ds-text-primary">{t('roem.title')}</div>
-                    <div>{t('roundResult.roem', { roemA: state.roundRoem[0], roemB: state.roundRoem[1] })}</div>
+                    <div>
+                      {t('roundResult.roem', { roemA: state.roundRoem[0] ?? 0, roemB: state.roundRoem[1] ?? 0 })}
+                    </div>
                   </div>
                 )}
 


### PR DESCRIPTION
## 概要
Klaverjas の CUI はラウンドの Roem（ボーナス）得点をプレイ中も表示しますが、Web のサイドバーは ROUND_END でしか出さず、PLAY/TRICK_END 中に各チームの Roem が見えませんでした（CUI と情報非対称）。プレイ中も常時表示します。

## 変更点
- `KlaverjasPage.tsx`: チームスコアブロック直後に、`!(isRoundEnd || isGameEnd)` のとき `state.roundRoem` を表示する常設ブロック（`data-testid=klaverjas-roem`）を追加。ラウンド終了時は従来の結果ブロックが Roem を表示するため重複しません。
- `ja/en klaverjas.json`: `roem.title` を追加（Roem 行ラベルは既存 `roundResult.roem` を再利用）。
- `KlaverjasPage.test.tsx`: プレイ中の Roem 表示・ラウンド終了時に常設ブロックが消えることを検証（計10）。

## テスト
- `bun run test -- --run KlaverjasPage` → 10 passed
- `bun run check` → エラーなし

Closes #2667