### PR TITLE
feat(courtpiece): show undeclared-trump status and label suit buttons

### DIFF
--- a/frontend/src/i18n/locales/en/courtpiece.json
+++ b/frontend/src/i18n/locales/en/courtpiece.json
@@ -39,6 +39,8 @@
   "nextRound": "Next Round",
   "target": "Target: {{points}} pts",
   "trumpPrompt": "Declare a trump suit:",
+  "trumpUndeclared": "Trump not yet declared",
+  "declareTrumpAria": "Declare {{suit}} as trump",
   "suit": {
     "spade": "♠ Spades",
     "club": "♣ Clubs",

--- a/frontend/src/i18n/locales/ja/courtpiece.json
+++ b/frontend/src/i18n/locales/ja/courtpiece.json
@@ -39,6 +39,8 @@
   "nextRound": "次のラウンド",
   "target": "目標: {{points}}ポイント",
   "trumpPrompt": "切り札スートを宣言してください:",
+  "trumpUndeclared": "切り札未宣言",
+  "declareTrumpAria": "{{suit}}を切り札に宣言",
   "suit": {
     "spade": "♠ スペード",
     "club": "♣ クラブ",

--- a/frontend/src/pages/CourtPiecePage.test.tsx
+++ b/frontend/src/pages/CourtPiecePage.test.tsx
@@ -88,6 +88,14 @@ describe('CourtPiecePage', () => {
     expect(screen.getByTestId('trump-4')).toBeInTheDocument();
   });
 
+  it('shows the undeclared status and accessible labels on suit buttons during declaration', async () => {
+    renderWithProviders(<CourtPiecePage />);
+    await waitFor(() => expect(screen.getByTestId('cp-trump-status')).toBeInTheDocument());
+    expect(screen.getByTestId('cp-trump-status')).toHaveTextContent('未宣言');
+    // Each suit button carries a declare aria-label.
+    expect(screen.getByTestId('trump-1')).toHaveAttribute('aria-label');
+  });
+
   it('dispatches a trump declaration when a suit button is clicked', async () => {
     renderWithProviders(<CourtPiecePage />);
     const trump3 = await screen.findByTestId('trump-3');

--- a/frontend/src/pages/CourtPiecePage.test.tsx
+++ b/frontend/src/pages/CourtPiecePage.test.tsx
@@ -91,9 +91,16 @@ describe('CourtPiecePage', () => {
   it('shows the undeclared status and accessible labels on suit buttons during declaration', async () => {
     renderWithProviders(<CourtPiecePage />);
     await waitFor(() => expect(screen.getByTestId('cp-trump-status')).toBeInTheDocument());
-    expect(screen.getByTestId('cp-trump-status')).toHaveTextContent('未宣言');
-    // Each suit button carries a declare aria-label.
-    expect(screen.getByTestId('trump-1')).toHaveAttribute('aria-label');
+    expect(screen.getByTestId('cp-trump-status')).toHaveTextContent('切り札未宣言');
+    // Each suit button carries a declare aria-label with the interpolated suit name.
+    for (const [testId, label] of [
+      ['trump-1', '♠ スペードを切り札に宣言'],
+      ['trump-2', '♣ クラブを切り札に宣言'],
+      ['trump-3', '♥ ハートを切り札に宣言'],
+      ['trump-4', '♦ ダイヤを切り札に宣言'],
+    ] as const) {
+      expect(screen.getByTestId(testId)).toHaveAttribute('aria-label', label);
+    }
   });
 
   it('dispatches a trump declaration when a suit button is clicked', async () => {

--- a/frontend/src/pages/CourtPiecePage.tsx
+++ b/frontend/src/pages/CourtPiecePage.tsx
@@ -318,6 +318,9 @@ function CourtPiecePageContent() {
             <div className="flex flex-wrap gap-2 items-center" data-tutorial="courtpiece-action-buttons">
               {isTrumpPhase && isHumanTrumpTurn && (
                 <>
+                  <span className="text-xs font-bold text-ds-warning self-center mr-1" data-testid="cp-trump-status">
+                    {t('trumpUndeclared')}
+                  </span>
                   <span className="text-xs text-ds-text-muted self-center mr-1">{t('trumpPrompt')}</span>
                   {TRUMP_SUIT_OPTIONS.map((s) => (
                     <button
@@ -326,6 +329,7 @@ function CourtPiecePageContent() {
                       className="px-3 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
                       onClick={() => handleDeclareTrump(s.value)}
                       disabled={loading}
+                      aria-label={t('declareTrumpAria', { suit: t(s.key) })}
                       data-testid={`trump-${s.value}`}
                     >
                       {t(s.key)}


### PR DESCRIPTION
## 概要
Court Piece (Rang) の切り札宣言フェーズは、Web に「まだ切り札が宣言されていない」状態を示すラベルがなく制約が暗黙的でした。未宣言ラベルとスートボタンのアクセシブルラベルを追加します。

## 変更点
- `CourtPiecePage.tsx`: 宣言フェーズに `trumpUndeclared` ステータス（`data-testid=cp-trump-status`）を表示。4つのスートボタンに `declareTrumpAria`（例「♠を切り札に宣言」）の `aria-label` を付与。
- `ja/en courtpiece.json`: `trumpUndeclared` / `declareTrumpAria` を追加。
- `CourtPiecePage.test.tsx`: 未宣言ステータス表示・ボタンの aria-label を検証（計10）。

## テスト
- `bun run test -- --run CourtPiecePage` → 10 passed
- `bun run check` → エラーなし

Closes #2676