### PR TITLE
feat(solowhist): show current highest bid in the bid phase

### DIFF
--- a/frontend/src/i18n/locales/en/solowhist.json
+++ b/frontend/src/i18n/locales/en/solowhist.json
@@ -37,6 +37,9 @@
   "nextRound": "Next Round",
   "target": "Target: {{points}} pts",
   "bidPrompt": "Place a bid (only a higher bid is allowed):",
+  "bidHighest": "Highest bid: {{bid}} ({{player}})",
+  "bidNone": "No bids yet",
+  "bidTooLow": "Must beat the current highest bid",
   "bid": {
     "pass": "Pass",
     "solo": "Solo",

--- a/frontend/src/i18n/locales/ja/solowhist.json
+++ b/frontend/src/i18n/locales/ja/solowhist.json
@@ -37,6 +37,9 @@
   "nextRound": "次のラウンド",
   "target": "目標: {{points}}点",
   "bidPrompt": "入札してください（上回る入札のみ可）:",
+  "bidHighest": "現在の最高ビッド: {{bid}}（{{player}}）",
+  "bidNone": "まだ入札なし",
+  "bidTooLow": "現在の最高ビッドを上回る必要があります",
   "bid": {
     "pass": "パス",
     "solo": "ソロ",

--- a/frontend/src/pages/SoloWhistPage.test.tsx
+++ b/frontend/src/pages/SoloWhistPage.test.tsx
@@ -107,6 +107,23 @@ describe('SoloWhistPage', () => {
     expect(screen.getByTestId('bid-0')).toBeEnabled();
   });
 
+  it('shows the current highest bid and a reason tooltip on too-low bids', async () => {
+    mockExec.mockResolvedValue(makeSoloWhistState({ bids: [2, 0, 0, 0] }));
+    renderWithProviders(<SoloWhistPage />);
+    const info = await screen.findByTestId('sw-highest-bid');
+    expect(info).not.toHaveTextContent('まだ入札なし');
+    // Too-low bids carry a tooltip on the wrapping span; valid bids do not.
+    expect(screen.getByTestId('bid-wrap-1')).toHaveAttribute('title');
+    expect(screen.getByTestId('bid-1')).toHaveAttribute('aria-label');
+    expect(screen.getByTestId('bid-wrap-3')).not.toHaveAttribute('title');
+  });
+
+  it('shows "no bids yet" before anyone has bid', async () => {
+    mockExec.mockResolvedValue(makeSoloWhistState({ bids: [0, 0, 0, 0] }));
+    renderWithProviders(<SoloWhistPage />);
+    await waitFor(() => expect(screen.getByTestId('sw-highest-bid')).toHaveTextContent('まだ入札なし'));
+  });
+
   it('renders the play phase with the human cards and the declarer badge', async () => {
     mockExec.mockResolvedValue(playPhaseState);
     renderWithProviders(<SoloWhistPage />);

--- a/frontend/src/pages/SoloWhistPage.tsx
+++ b/frontend/src/pages/SoloWhistPage.tsx
@@ -352,8 +352,11 @@ function SoloWhistPageContent() {
                 <>
                   <span className="text-xs text-ds-text-muted self-center mr-1">{t('bidPrompt')}</span>
                   <span className="text-xs text-ds-text-muted self-center mr-1" data-testid="sw-highest-bid">
-                    {highestBid > 0 && highestBidLabelKey
-                      ? t('bidHighest', { bid: t(highestBidLabelKey), player: highestBidderName })
+                    {highestBid > 0
+                      ? t('bidHighest', {
+                          bid: highestBidLabelKey ? t(highestBidLabelKey) : highestBid,
+                          player: highestBidderName,
+                        })
                       : t('bidNone')}
                   </span>
                   {BIDS.map((b) => {

--- a/frontend/src/pages/SoloWhistPage.tsx
+++ b/frontend/src/pages/SoloWhistPage.tsx
@@ -147,6 +147,10 @@ function SoloWhistPageContent() {
 
   // The current highest (non-pass) bid; a new non-pass bid must beat it.
   const highestBid = Math.max(0, ...state.bids);
+  // Resolve the holder via the players array (playerName expects a player id, not an index).
+  const highestBidder = highestBid > 0 ? state.players[state.bids.indexOf(highestBid)] : undefined;
+  const highestBidLabelKey = BIDS.find((b) => b.value === highestBid)?.key;
+  const highestBidderName = highestBidder ? playerName(highestBidder.id, highestBidder.isHuman) : '';
 
   const contractName =
     state.declarerIdx >= 0 ? t(`contractName.${CONTRACT_KEYS[state.contract] ?? 'pass'}`) : t('contractUndecided');
@@ -347,20 +351,32 @@ function SoloWhistPageContent() {
               {isBidPhase && isHumanBidTurn && (
                 <>
                   <span className="text-xs text-ds-text-muted self-center mr-1">{t('bidPrompt')}</span>
+                  <span className="text-xs text-ds-text-muted self-center mr-1" data-testid="sw-highest-bid">
+                    {highestBid > 0 && highestBidLabelKey
+                      ? t('bidHighest', { bid: t(highestBidLabelKey), player: highestBidderName })
+                      : t('bidNone')}
+                  </span>
                   {BIDS.map((b) => {
                     // Pass (0) is always allowed; a non-pass bid must beat the current highest.
-                    const disabled = loading || (b.value !== SoloWhistContract.PASS && b.value <= highestBid);
+                    const tooLow = b.value !== SoloWhistContract.PASS && b.value <= highestBid;
+                    const disabled = loading || tooLow;
+                    const reason = tooLow ? t('bidTooLow') : undefined;
+                    // The title lives on the wrapping span: browsers suppress native tooltips on
+                    // disabled buttons, so hovering the span still surfaces the reason.
                     return (
-                      <button
-                        key={b.value}
-                        type="button"
-                        className="px-3 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
-                        onClick={() => handleBid(b.value)}
-                        disabled={disabled}
-                        data-testid={`bid-${b.value}`}
-                      >
-                        {t(b.key)}
-                      </button>
+                      <span key={b.value} title={reason} data-testid={`bid-wrap-${b.value}`}>
+                        <button
+                          type="button"
+                          className="px-3 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
+                          onClick={() => handleBid(b.value)}
+                          disabled={disabled}
+                          aria-disabled={disabled}
+                          aria-label={reason ? `${t(b.key)} — ${reason}` : undefined}
+                          data-testid={`bid-${b.value}`}
+                        >
+                          {t(b.key)}
+                        </button>
+                      </span>
                     );
                   })}
                 </>


### PR DESCRIPTION
## 概要
Solo Whist の BID フェーズは Pass/Solo/Misère/Abundance を同一ボタンで描画し、現在の最高ビッドや無効理由が見えませんでした。最高ビッドと入札者を表示し、無効ボタンに理由を付けます。

## 変更点
- `SoloWhistPage.tsx`: BID フェーズに `bidHighest`（最高ビッド＋入札者）/ `bidNone` 表示（`data-testid=sw-highest-bid`）。too-low ボタンは wrapping span に `title`=`bidTooLow`（disabled ボタンは native title が出ないため）＋ボタンに `aria-label`/`aria-disabled`。入札者は players 配列経由で解決し `playerName` に正しい player id を渡す。
- `ja/en solowhist.json`: `bidHighest`/`bidNone`/`bidTooLow` を追加。
- `SoloWhistPage.test.tsx`: 最高ビッド表示・tooltip・未入札時の「まだ入札なし」を検証（計12）。

## 補足
- CUI（`SoloWhistCuiPresenter`）の `promptBid` は既に「現在の契約: {{contract}}」を表示し `promptBidHelp` も上回り制約を説明済みのため、CUI 変更は不要でした。

## テスト
- `bun run test -- --run SoloWhistPage` → 12 passed
- `bun run check` → エラーなし

Closes #2671