### PR TITLE
feat(tute): group declaration buttons in a labelled fieldset

### DIFF
--- a/frontend/src/i18n/locales/en/tute.json
+++ b/frontend/src/i18n/locales/en/tute.json
@@ -31,6 +31,8 @@
   "playButton": "Play",
   "declareMarriage": "Marriage {{suit}}",
   "declareTute": "Declare Tute",
+  "declarationsLabel": "Available declarations",
+  "tuteHelp": "Tute: declare when you hold all four Kings (or all four Queens) for a large bonus.",
   "nextTrick": "Next Trick",
   "nextRound": "Next Round",
   "roundResult": {

--- a/frontend/src/i18n/locales/ja/tute.json
+++ b/frontend/src/i18n/locales/ja/tute.json
@@ -31,6 +31,8 @@
   "playButton": "出す",
   "declareMarriage": "結婚宣言 {{suit}}",
   "declareTute": "Tute 宣言",
+  "declarationsLabel": "宣言できる役",
+  "tuteHelp": "Tute: 4枚の King（または 4枚の Queen）を揃えると宣言でき、大きなボーナス点になります。",
   "nextTrick": "次のトリック",
   "nextRound": "次のラウンド",
   "roundResult": {

--- a/frontend/src/pages/TutePage.test.tsx
+++ b/frontend/src/pages/TutePage.test.tsx
@@ -87,6 +87,17 @@ describe('TutePage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('tute'));
   });
 
+  it('groups declarations in a labelled fieldset and describes the Tute button', async () => {
+    mockExec.mockResolvedValue(tuteDeclState);
+    renderWithProviders(<TutePage />);
+    const group = await screen.findByTestId('tute-declarations');
+    expect(group.tagName).toBe('FIELDSET');
+    expect(group).toHaveAttribute('aria-label', '宣言できる役');
+    const tuteBtn = screen.getByTestId('tute-declare-button');
+    expect(tuteBtn).toHaveAttribute('aria-describedby', 'tute-help-desc');
+    expect(document.getElementById('tute-help-desc')).toHaveTextContent(/Tute/);
+  });
+
   it('does not show declaration buttons when not allowed', async () => {
     renderWithProviders(<TutePage />);
     await waitFor(() => expect(screen.getByAltText('♥ Q')).toBeInTheDocument());

--- a/frontend/src/pages/TutePage.test.tsx
+++ b/frontend/src/pages/TutePage.test.tsx
@@ -92,7 +92,8 @@ describe('TutePage', () => {
     renderWithProviders(<TutePage />);
     const group = await screen.findByTestId('tute-declarations');
     expect(group.tagName).toBe('FIELDSET');
-    expect(group).toHaveAttribute('aria-label', '宣言できる役');
+    // The <legend> names the group (no redundant aria-label).
+    expect(group.querySelector('legend')).toHaveTextContent('宣言できる役');
     const tuteBtn = screen.getByTestId('tute-declare-button');
     expect(tuteBtn).toHaveAttribute('aria-describedby', 'tute-help-desc');
     expect(document.getElementById('tute-help-desc')).toHaveTextContent(/Tute/);

--- a/frontend/src/pages/TutePage.tsx
+++ b/frontend/src/pages/TutePage.tsx
@@ -319,33 +319,54 @@ function TutePageContent() {
                   {t('playButton')}
                 </button>
               )}
-              {canPlay &&
-                state.canDeclareMarriage &&
-                humanPlayer &&
-                ([1, 2, 3, 4] as const)
-                  .filter((suit) => {
-                    // Only offer suits the human actually holds K+Q of and has
-                    // not already declared, so every button is a legal move.
-                    const design = (['', 'SPADE', 'CLOVER', 'HEART', 'DIAMOND'] as const)[suit];
-                    const hasK = humanPlayer.cards.some((c) => c.design === design && c.value === 13);
-                    const hasQ = humanPlayer.cards.some((c) => c.design === design && c.value === 12);
-                    return hasK && hasQ && !state.declaredSuits[suit];
-                  })
-                  .map((suit) => (
-                    <button
-                      key={suit}
-                      type="button"
-                      className={btnSecondary}
-                      onClick={() => handleDeclareMarriage(suit)}
-                      disabled={loading}
-                    >
-                      {t('declareMarriage', { suit: SUIT_SYMBOLS[suit] })}
-                    </button>
-                  ))}
-              {canPlay && state.canDeclareTute && (
-                <button type="button" className={btnSecondary} onClick={handleDeclareTute} disabled={loading}>
-                  {t('declareTute')}
-                </button>
+              {canPlay && (state.canDeclareMarriage || state.canDeclareTute) && (
+                <fieldset
+                  className="flex flex-wrap items-center gap-2 border-0 p-0 m-0"
+                  aria-label={t('declarationsLabel')}
+                  data-testid="tute-declarations"
+                >
+                  <legend className="text-xs text-ds-text-muted mr-1">{t('declarationsLabel')}</legend>
+                  {state.canDeclareMarriage &&
+                    humanPlayer &&
+                    ([1, 2, 3, 4] as const)
+                      .filter((suit) => {
+                        // Only offer suits the human actually holds K+Q of and has
+                        // not already declared, so every button is a legal move.
+                        const design = (['', 'SPADE', 'CLOVER', 'HEART', 'DIAMOND'] as const)[suit];
+                        const hasK = humanPlayer.cards.some((c) => c.design === design && c.value === 13);
+                        const hasQ = humanPlayer.cards.some((c) => c.design === design && c.value === 12);
+                        return hasK && hasQ && !state.declaredSuits[suit];
+                      })
+                      .map((suit) => (
+                        <button
+                          key={suit}
+                          type="button"
+                          className={btnSecondary}
+                          onClick={() => handleDeclareMarriage(suit)}
+                          disabled={loading}
+                        >
+                          {t('declareMarriage', { suit: SUIT_SYMBOLS[suit] })}
+                        </button>
+                      ))}
+                  {state.canDeclareTute && (
+                    <>
+                      <button
+                        type="button"
+                        className={btnSecondary}
+                        onClick={handleDeclareTute}
+                        disabled={loading}
+                        title={t('tuteHelp')}
+                        aria-describedby="tute-help-desc"
+                        data-testid="tute-declare-button"
+                      >
+                        {t('declareTute')}
+                      </button>
+                      <span id="tute-help-desc" className="sr-only">
+                        {t('tuteHelp')}
+                      </span>
+                    </>
+                  )}
+                </fieldset>
               )}
               {isTrickEnd && (
                 <button type="button" className={btnSuccess} onClick={handleNextTrick} disabled={loading}>

--- a/frontend/src/pages/TutePage.tsx
+++ b/frontend/src/pages/TutePage.tsx
@@ -322,7 +322,6 @@ function TutePageContent() {
               {canPlay && (state.canDeclareMarriage || state.canDeclareTute) && (
                 <fieldset
                   className="flex flex-wrap items-center gap-2 border-0 p-0 m-0"
-                  aria-label={t('declarationsLabel')}
                   data-testid="tute-declarations"
                 >
                   <legend className="text-xs text-ds-text-muted mr-1">{t('declarationsLabel')}</legend>


### PR DESCRIPTION
## 概要
Tute の宣言ボタン群（マリッジ用スートボタン＋Tute ボタン）には視覚的グループ・ラベル・role がなく、非晴眼ユーザーには「任意の宣言操作」であることや Tute の成立条件が伝わりませんでした。

## 変更点
- `TutePage.tsx`: マリッジ/Tute ボタンを `<fieldset aria-label={declarationsLabel}>`（`data-testid=tute-declarations`）＋ `<legend>` でグループ化。Tute ボタンに `aria-describedby` で成立条件・ボーナスの説明（`tuteHelp`、`sr-only` + `title`）を紐付け。
- `ja/en tute.json`: `declarationsLabel` / `tuteHelp` を追加。
- `TutePage.test.tsx`: fieldset グループ化・Tute ボタンの aria-describedby と説明テキストを検証（計12）。

## テスト
- `bun run test -- --run TutePage` → 12 passed
- `bun run check` → エラーなし

Closes #2663