### PR TITLE
feat(bidwhist): add a visible label for the trick-count selector

### DIFF
--- a/frontend/src/i18n/locales/en/bidwhist.json
+++ b/frontend/src/i18n/locales/en/bidwhist.json
@@ -19,6 +19,7 @@
   "currentTrick": "Current trick",
   "trickEmpty": "(no cards yet)",
   "tricksLabel": "Target tricks",
+  "selectTricks": "Select tricks (1-7):",
   "dirUptown": "Uptown",
   "dirDowntown": "Downtown",
   "dirNoTrump": "No Trump",

--- a/frontend/src/i18n/locales/ja/bidwhist.json
+++ b/frontend/src/i18n/locales/ja/bidwhist.json
@@ -19,6 +19,7 @@
   "currentTrick": "現在のトリック",
   "trickEmpty": "(まだカードがありません)",
   "tricksLabel": "目標トリック数",
+  "selectTricks": "トリック数を選択 (1-7):",
   "dirUptown": "アップタウン",
   "dirDowntown": "ダウンタウン",
   "dirNoTrump": "ノートランプ",

--- a/frontend/src/pages/BidWhistPage.test.tsx
+++ b/frontend/src/pages/BidWhistPage.test.tsx
@@ -83,6 +83,12 @@ describe('BidWhistPage', () => {
     expect(await screen.findByTestId('pass-button')).toBeEnabled();
   });
 
+  it('shows a visible label for the trick-count selector', async () => {
+    renderWithProviders(<BidWhistPage />);
+    const label = await screen.findByTestId('bw-tricks-label');
+    expect(label).toHaveTextContent('トリック数を選択');
+  });
+
   it('bids a direction when a direction button is clicked', async () => {
     renderWithProviders(<BidWhistPage />);
     const uptown = await screen.findByRole('button', { name: 'アップタウン' });

--- a/frontend/src/pages/BidWhistPage.tsx
+++ b/frontend/src/pages/BidWhistPage.tsx
@@ -352,6 +352,9 @@ function BidWhistPageContent() {
             <div className="flex gap-2 justify-center flex-wrap items-center" data-tutorial="bw-actions">
               {isHumanBidTurn && (
                 <>
+                  <span className="text-xs text-ds-text-muted self-center" data-testid="bw-tricks-label">
+                    {t('selectTricks')}
+                  </span>
                   <select
                     aria-label={t('tricksLabel')}
                     value={bidTricks}

--- a/frontend/src/pages/BidWhistPage.tsx
+++ b/frontend/src/pages/BidWhistPage.tsx
@@ -352,11 +352,15 @@ function BidWhistPageContent() {
             <div className="flex gap-2 justify-center flex-wrap items-center" data-tutorial="bw-actions">
               {isHumanBidTurn && (
                 <>
-                  <span className="text-xs text-ds-text-muted self-center" data-testid="bw-tricks-label">
+                  <label
+                    htmlFor="bw-bid-tricks"
+                    className="text-xs text-ds-text-muted self-center"
+                    data-testid="bw-tricks-label"
+                  >
                     {t('selectTricks')}
-                  </span>
+                  </label>
                   <select
-                    aria-label={t('tricksLabel')}
+                    id="bw-bid-tricks"
                     value={bidTricks}
                     onChange={(e) => setBidTricks(Number.parseInt(e.target.value, 10))}
                     className="rounded px-2 py-2 text-sm text-ds-text bg-ds-surface"

--- a/internal/i18n/locales/en/bidwhist.json
+++ b/internal/i18n/locales/en/bidwhist.json
@@ -24,7 +24,7 @@
   "dirDowntown": "Downtown",
   "dirNoTrump": "No Trump",
   "promptBid": "{{name}}'s bid",
-  "promptBidHelp": "b <tricks> <dir> to bid / pa to pass",
+  "promptBidHelp": "b <tricks> <dir> to bid (tricks 1-7) / pa to pass",
   "promptTrump": "Declare a trump suit",
   "promptTrumpHelp": "t <suit> (1=S 2=C 3=H 4=D)",
   "promptKittyExchange": "The kitty has been added to your hand. Discard six cards",

--- a/internal/i18n/locales/ja/bidwhist.json
+++ b/internal/i18n/locales/ja/bidwhist.json
@@ -24,7 +24,7 @@
   "dirDowntown": "ダウンタウン",
   "dirNoTrump": "ノートランプ",
   "promptBid": "{{name}} のビッドです",
-  "promptBidHelp": "b <tricks> <dir> でビッド / pa でパス",
+  "promptBidHelp": "b <tricks> <dir> でビッド (tricks は 1-7) / pa でパス",
   "promptTrump": "切り札スートを宣言してください",
   "promptTrumpHelp": "t <suit> (1=S 2=C 3=H 4=D)",
   "promptKittyExchange": "キティを手札に加えました。6枚捨ててください",


### PR DESCRIPTION
## 概要
Bid Whist の BID フェーズのトリック数 `<select>` は `aria-label` のみで可視ラベルがなく、晴眼ユーザーにはドロップダウンが何を選ぶものか不明でした。可視ラベルを追加し、CUI ビッドヘルプにも有効範囲を明示します。

## 変更点
- `BidWhistPage.tsx`: セレクタ前に可視ラベル `selectTricks`（`data-testid=bw-tricks-label`）を追加。
- `frontend ja/en bidwhist.json`: `selectTricks`（「トリック数を選択 (1-7):」）を追加。
- `internal ja/en bidwhist.json`: `promptBidHelp` に有効範囲「tricks 1-7」を明示（Go コード変更なし）。
- `BidWhistPage.test.tsx`: 可視ラベル表示を検証（計9）。

## テスト
- `bun run test -- --run BidWhistPage` → 9 passed
- `bun run check` → エラーなし

Closes #2654