### PR TITLE
feat(fivehundred): add a visible label for the bid trick-count selector

### DIFF
--- a/frontend/src/i18n/locales/en/fivehundred.json
+++ b/frontend/src/i18n/locales/en/fivehundred.json
@@ -18,6 +18,7 @@
   "currentTrick": "Current trick",
   "trickEmpty": "(no cards yet)",
   "tricksLabel": "Tricks",
+  "selectTricks": "Select tricks (6-10):",
   "misereButton": "Misere",
   "openMisereButton": "Open Misere",
   "bidValueLabel": "{{value}} pts",

--- a/frontend/src/i18n/locales/ja/fivehundred.json
+++ b/frontend/src/i18n/locales/ja/fivehundred.json
@@ -18,6 +18,7 @@
   "currentTrick": "現在のトリック",
   "trickEmpty": "(まだカードがありません)",
   "tricksLabel": "トリック数",
+  "selectTricks": "トリック数を選択 (6-10):",
   "misereButton": "ミゼール",
   "openMisereButton": "オープンミゼール",
   "bidValueLabel": "{{value}}点",

--- a/frontend/src/pages/FiveHundredPage.test.tsx
+++ b/frontend/src/pages/FiveHundredPage.test.tsx
@@ -93,6 +93,13 @@ describe('FiveHundredPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bid', { bidKind: 1, bidTricks: 6, bidSuit: 1 }));
   });
 
+  it('shows a visible label associated with the trick-count selector', async () => {
+    renderWithProviders(<FiveHundredPage />);
+    const label = await screen.findByTestId('fh-tricks-label');
+    expect(label).toHaveTextContent('トリック数を選択');
+    expect(label).toHaveAttribute('for', 'fh-bid-tricks');
+  });
+
   it('shows the Avondale score under each bid button (6 = ♠40 / ♥100 / NT120)', async () => {
     renderWithProviders(<FiveHundredPage />);
     expect(await screen.findByTestId('fh-bid-suit-1')).toHaveTextContent('40'); // 6♠
@@ -105,7 +112,7 @@ describe('FiveHundredPage', () => {
   it('updates suit/NT scores live when the trick count changes (7♠=140, 7NT=220)', async () => {
     renderWithProviders(<FiveHundredPage />);
     await screen.findByTestId('fh-bid-suit-1');
-    fireEvent.change(screen.getByLabelText('トリック数'), { target: { value: '7' } });
+    fireEvent.change(screen.getByLabelText(/トリック数を選択/), { target: { value: '7' } });
     expect(screen.getByTestId('fh-bid-suit-1')).toHaveTextContent('140'); // 7♠
     expect(screen.getByTestId('fh-bid-nt')).toHaveTextContent('220'); // 7NT
   });

--- a/frontend/src/pages/FiveHundredPage.tsx
+++ b/frontend/src/pages/FiveHundredPage.tsx
@@ -339,8 +339,15 @@ function FiveHundredPageContent() {
             <div className="flex gap-2 justify-center flex-wrap items-center" data-tutorial="fh-actions">
               {isHumanBidTurn && (
                 <>
+                  <label
+                    htmlFor="fh-bid-tricks"
+                    className="text-xs text-ds-text-muted self-center"
+                    data-testid="fh-tricks-label"
+                  >
+                    {t('selectTricks')}
+                  </label>
                   <select
-                    aria-label={t('tricksLabel')}
+                    id="fh-bid-tricks"
                     value={bidTricks}
                     onChange={(e) => setBidTricks(Number.parseInt(e.target.value, 10))}
                     className="rounded px-2 py-2 text-sm text-ds-text bg-ds-surface"

--- a/internal/i18n/locales/en/fivehundred.json
+++ b/internal/i18n/locales/en/fivehundred.json
@@ -25,7 +25,7 @@
   "bidMisere": "Misere ({{value}})",
   "bidOpenMisere": "Open Misere ({{value}})",
   "promptBid": "{{name}} to bid",
-  "promptBidHelp": "b <tricks> <suit> / bnt <tricks> / m / om / pa",
+  "promptBidHelp": "b <tricks> <suit> / bnt <tricks> / m / om / pa (tricks 6-10)",
   "promptKittyExchange": "Kitty added to your hand. Discard 3 cards.",
   "promptKittyExchangeHelp": "e <i> <j> <k>",
   "promptCurrentPlayer": "{{name}}'s turn",

--- a/internal/i18n/locales/ja/fivehundred.json
+++ b/internal/i18n/locales/ja/fivehundred.json
@@ -25,7 +25,7 @@
   "bidMisere": "ミゼール ({{value}})",
   "bidOpenMisere": "オープンミゼール ({{value}})",
   "promptBid": "{{name}} のビッドです",
-  "promptBidHelp": "b <tricks> <suit> / bnt <tricks> / m / om / pa",
+  "promptBidHelp": "b <tricks> <suit> / bnt <tricks> / m / om / pa (tricks は 6-10)",
   "promptKittyExchange": "キティを手札に加えました。3枚捨ててください",
   "promptKittyExchangeHelp": "e <i> <j> <k>",
   "promptCurrentPlayer": "{{name}} の番です",


### PR DESCRIPTION
## 概要
500 の BID フェーズのトリック数 `<select>` は説明ラベルがなく、500未経験者には選びにくいものでした。可視ラベルを追加します。各スートボタンは既に `fivehundredBidValue(bidTricks, suit)` で選択中トリック数に対応する得点を表示しているため、点数表示（受け入れ条件2）は対応済みです。

## 変更点
- `FiveHundredPage.tsx`: トリック数セレクタに `<label htmlFor="fh-bid-tricks">`（`selectTricks`、`data-testid=fh-tricks-label`）を追加し select と関連付け（旧 aria-label を置換）。
- `frontend ja/en fivehundred.json`: `selectTricks`（「トリック数を選択 (6-10):」）を追加。
- `internal ja/en fivehundred.json`: `promptBidHelp` に有効範囲「tricks 6-10」を明示（Go コード変更なし）。
- `FiveHundredPage.test.tsx`: 可視ラベルと select との関連付けを検証、既存のライブ得点テストのラベル参照を更新（計13）。

## テスト
- `bun run test -- --run FiveHundredPage` → 13 passed
- `bun run check` → エラーなし

Closes #2648