### PR TITLE
feat(doubleklondike): render face-down cards as a card-back image

### DIFF
--- a/frontend/src/pages/DoubleKlondikePage.test.tsx
+++ b/frontend/src/pages/DoubleKlondikePage.test.tsx
@@ -59,6 +59,14 @@ describe('DoubleKlondikePage', () => {
     expect(screen.getByTestId('foundation-7')).toBeInTheDocument();
   });
 
+  it('renders face-down tableau cards as a card-back image, not "##"', async () => {
+    renderWithProviders(<DoubleKlondikePage />);
+    // makeState seeds a face-down card at tableau[1][0].
+    await waitFor(() => expect(screen.getByTestId('column-1')).toBeInTheDocument());
+    expect(screen.getAllByAltText('カード裏面').length).toBeGreaterThan(0);
+    expect(screen.queryByText('##')).not.toBeInTheDocument();
+  });
+
   it('draws from the stock', async () => {
     renderWithProviders(<DoubleKlondikePage />);
     const stock = await screen.findByTestId('stock');

--- a/frontend/src/pages/DoubleKlondikePage.test.tsx
+++ b/frontend/src/pages/DoubleKlondikePage.test.tsx
@@ -63,7 +63,9 @@ describe('DoubleKlondikePage', () => {
     renderWithProviders(<DoubleKlondikePage />);
     // makeState seeds a face-down card at tableau[1][0].
     await waitFor(() => expect(screen.getByTestId('column-1')).toBeInTheDocument());
-    expect(screen.getAllByAltText('カード裏面').length).toBeGreaterThan(0);
+    // Assert by the locale-independent card-back image src.
+    const cardBacks = screen.queryAllByRole('img').filter((img) => img.getAttribute('src') === '/images/z01.png');
+    expect(cardBacks.length).toBeGreaterThan(0);
     expect(screen.queryByText('##')).not.toBeInTheDocument();
   });
 

--- a/frontend/src/pages/DoubleKlondikePage.tsx
+++ b/frontend/src/pages/DoubleKlondikePage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { doubleklondikeApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
-import { CardImage } from '../components/CardImage';
+import { CardBack, CardImage } from '../components/CardImage';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
@@ -161,17 +161,7 @@ function DoubleKlondikePageContent() {
             disabled={!canAct || !tc2.faceUp}
             data-testid={`card-${col}-${i}`}
           >
-            {tc2.faceUp && tc2.card ? (
-              <CardImage card={tc2.card} width={w} />
-            ) : (
-              <div
-                className="rounded bg-ds-accent/70 border border-white/30 flex items-center justify-center text-ds-text-muted text-xs"
-                style={{ width: w, height: cardH }}
-                title={t('faceDown')}
-              >
-                ##
-              </div>
-            )}
+            {tc2.faceUp && tc2.card ? <CardImage card={tc2.card} width={w} /> : <CardBack width={w} />}
           </button>
         ))
       )}


### PR DESCRIPTION
## 概要
Double Klondike (ガルガンチュア) の裏向きタブロー札は `##` というテキストで描画されており、他ゲームのカード裏面画像と不揃いでした。共通 `CardBack` コンポーネントに置き換えます。

## 変更点
- `DoubleKlondikePage.tsx`: 裏向き札の `##` プレースホルダ div を `<CardBack width={w} />`（`/images/z01.png`、alt「カード裏面」）に置換。
- `DoubleKlondikePage.test.tsx`: 裏向き札がカード裏面画像で描画され `##` が出ないことを検証（計12）。

## テスト
- `bun run test -- --run DoubleKlondikePage` → 12 passed
- `bun run check` → エラーなし

Closes #2700