### PR TITLE
feat(shithead): render hand and discard cards as real card images

### DIFF
--- a/frontend/src/pages/ShitheadPage.test.tsx
+++ b/frontend/src/pages/ShitheadPage.test.tsx
@@ -298,8 +298,8 @@ describe('ShitheadPage', () => {
         <ShitheadPage />
       </MemoryRouter>,
     );
-    // The discard top is now a card image; the joker carries an accessible 'ジョーカー' label.
-    await waitFor(() => expect(screen.getAllByText('ジョーカー').length).toBeGreaterThan(0));
+    // The discard top is now a card image; the joker img carries an accessible 'ジョーカー' alt.
+    await waitFor(() => expect(screen.getAllByAltText('ジョーカー').length).toBeGreaterThan(0));
     expect(screen.queryByText(/\?0/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/ShitheadPage.test.tsx
+++ b/frontend/src/pages/ShitheadPage.test.tsx
@@ -131,8 +131,8 @@ describe('ShitheadPage', () => {
       </MemoryRouter>,
     );
     await waitFor(() => expect(screen.getByRole('button', { name: /出す/ })).toBeInTheDocument());
-    // Click the first hand card (button labelled with suit + value)
-    const cardButtons = screen.getAllByRole('button').filter((b) => /^♠|♥|♦|♣/.test(b.textContent ?? ''));
+    // Selectable hand cards are the buttons that expose aria-pressed.
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.hasAttribute('aria-pressed'));
     expect(cardButtons.length).toBeGreaterThan(0);
     fireEvent.click(cardButtons[0]);
     mockExec.mockClear();
@@ -248,7 +248,7 @@ describe('ShitheadPage', () => {
         <ShitheadPage />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(screen.getByText('5')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: /出す/ })).toBeInTheDocument());
     expect(screen.queryByTestId('sh-magic-badge-2-2')).not.toBeInTheDocument();
   });
 
@@ -288,7 +288,7 @@ describe('ShitheadPage', () => {
     expect(screen.getByText('リセット: 次のプレイヤーは何でも出せます')).toBeInTheDocument();
   });
 
-  it('shows ? for joker design in discard pile description', async () => {
+  it('renders a joker discard top as a card image with an accessible label', async () => {
     mockExec.mockResolvedValue({
       ...humanTurnState,
       discardPile: [{ design: 'JOKER', value: 0 }],
@@ -298,9 +298,8 @@ describe('ShitheadPage', () => {
         <ShitheadPage />
       </MemoryRouter>,
     );
-    await waitFor(() => {
-      const matches = screen.getAllByText(/\?0/);
-      expect(matches.length).toBeGreaterThan(0);
-    });
+    // The discard top is now a card image; the joker carries an accessible 'ジョーカー' label.
+    await waitFor(() => expect(screen.getAllByText('ジョーカー').length).toBeGreaterThan(0));
+    expect(screen.queryByText(/\?0/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/ShitheadPage.tsx
+++ b/frontend/src/pages/ShitheadPage.tsx
@@ -9,6 +9,7 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
+import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
@@ -19,8 +20,9 @@ import { useShitheadGame } from '../hooks/useShitheadGame';
 import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { Card, CardDesign, ShitheadConfig, ShitheadResponse } from '../types/card';
+import type { Card, ShitheadConfig, ShitheadResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import { parseShitheadCommand, SHITHEAD_HELP } from '../utils/cli/commands/shitheadCommands';
 import { formatShitheadState } from '../utils/cli/formatters/shitheadFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -60,7 +62,7 @@ function ShitheadPageContent() {
     useGamePageSetup('shithead');
   const { state, loading, error, selectedCardIndices, toggleCard, handlePlay, handlePickup, retry, dispatch } =
     useShitheadGame();
-  const { isMobile: _isMobile } = useCardDimensions();
+  const { cardWidth } = useCardDimensions();
   const { hint, hintEnabled, setHintEnabled } = useGameHint('shithead', state);
   const cliMode = useCliMode('shithead');
   const cliConfig: CliGameConfig<ShitheadResponse, Parameters<typeof shitheadApi.exec>> = useMemo(
@@ -169,7 +171,11 @@ function ShitheadPageContent() {
                     '—'
                   ) : (
                     <>
-                      <span>{describeTopCard(state.discardPile)}</span>
+                      <AnimatedCard
+                        card={state.discardPile[state.discardPile.length - 1]}
+                        width={Math.round(cardWidth * 0.7)}
+                      />
+                      <span className="sr-only">{cardAlt(state.discardPile[state.discardPile.length - 1])}</span>
                       {(() => {
                         const topValue = state.discardPile[state.discardPile.length - 1]?.value ?? 0;
                         const badge = magicLookup.badgeFor(topValue);
@@ -291,29 +297,6 @@ function ShitheadPageContent() {
   );
 }
 
-/** Returns a textual description of the top discard card. */
-function describeTopCard(pile: Card[]): string {
-  const top = pile[pile.length - 1];
-  if (!top) return '—';
-  return `${suitSymbol(top.design)}${top.value}`;
-}
-
-/** Returns a Unicode suit symbol for the given suit identifier. */
-function suitSymbol(design: CardDesign): string {
-  switch (design) {
-    case 'SPADE':
-      return '♠';
-    case 'CLOVER':
-      return '♣';
-    case 'HEART':
-      return '♥';
-    case 'DIAMOND':
-      return '♦';
-    default:
-      return '?';
-  }
-}
-
 interface CardRowProps {
   label: string;
   cards: Card[];
@@ -353,19 +336,15 @@ function buildMagicLookup(config: ShitheadConfig, t: (key: string) => string): M
   };
 }
 
-/** Row of selectable cards with index labels. */
+/** Row of selectable cards rendered as real card images. */
 function CardRow({ label, cards, selectable, selected, onToggle, magic, rowKey }: CardRowProps) {
+  const { cardWidth } = useCardDimensions();
   return (
     <div className="space-y-1">
       <div className="text-xs uppercase tracking-wide text-ds-text-muted">{label}</div>
       <div className="flex flex-wrap gap-2">
         {cards.map((c, i) => {
           const isSelected = selected.includes(i);
-          const cls = isSelected
-            ? 'bg-ds-warning text-ds-text-on-accent border-ds-warning'
-            : selectable
-              ? 'bg-ds-surface-elevated text-ds-text-primary border-ds-border-subtle hover:bg-ds-surface-elevated-hover'
-              : 'bg-ds-surface text-ds-text-muted border-ds-border-subtle';
           const badge = magic.badgeFor(c.value);
           const title = magic.titleFor(c.value);
           return (
@@ -375,11 +354,14 @@ function CardRow({ label, cards, selectable, selected, onToggle, magic, rowKey }
               disabled={!selectable}
               onClick={() => onToggle(i)}
               title={title || undefined}
+              aria-label={cardAlt(c)}
+              aria-pressed={selectable ? isSelected : undefined}
               data-magic-rank={badge ? c.value : undefined}
-              className={`relative min-w-[3rem] px-2 py-2 rounded border text-sm ${cls}`}
+              className={`relative rounded transition-transform ${
+                isSelected ? 'ring-2 ring-ds-warning -translate-y-1' : ''
+              } ${selectable ? 'cursor-pointer' : 'cursor-default'}`}
             >
-              <span className="block leading-none">{suitSymbol(c.design)}</span>
-              <span className="block text-base font-bold">{c.value}</span>
+              <AnimatedCard card={c} width={cardWidth} />
               {badge && (
                 <>
                   <span

--- a/frontend/src/pages/ShitheadPage.tsx
+++ b/frontend/src/pages/ShitheadPage.tsx
@@ -19,10 +19,10 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useShitheadGame } from '../hooks/useShitheadGame';
 import { badgeWarningColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { focusRingCard } from '../styles/cardStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { Card, ShitheadConfig, ShitheadResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
-import { cardAlt } from '../utils/cardAlt';
 import { parseShitheadCommand, SHITHEAD_HELP } from '../utils/cli/commands/shitheadCommands';
 import { formatShitheadState } from '../utils/cli/formatters/shitheadFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -175,7 +175,6 @@ function ShitheadPageContent() {
                         card={state.discardPile[state.discardPile.length - 1]}
                         width={Math.round(cardWidth * 0.7)}
                       />
-                      <span className="sr-only">{cardAlt(state.discardPile[state.discardPile.length - 1])}</span>
                       {(() => {
                         const topValue = state.discardPile[state.discardPile.length - 1]?.value ?? 0;
                         const badge = magicLookup.badgeFor(topValue);
@@ -354,10 +353,9 @@ function CardRow({ label, cards, selectable, selected, onToggle, magic, rowKey }
               disabled={!selectable}
               onClick={() => onToggle(i)}
               title={title || undefined}
-              aria-label={cardAlt(c)}
               aria-pressed={selectable ? isSelected : undefined}
               data-magic-rank={badge ? c.value : undefined}
-              className={`relative rounded transition-transform ${
+              className={`relative rounded transition-transform ${focusRingCard} ${
                 isSelected ? 'ring-2 ring-ds-warning -translate-y-1' : ''
               } ${selectable ? 'cursor-pointer' : 'cursor-default'}`}
             >


### PR DESCRIPTION
## 概要
Shithead は手札・フェイスアップ札・捨て札を `♠7` のようなテキストボタンで描画しており、他ゲームの実カード画像（`AnimatedCard`）と不揃いで、スート色も一目で分かりにくいものでした。

## 変更点
- `ShitheadPage.tsx`: `CardRow` のカード描画と捨て札トップを `AnimatedCard` に置換。選択は `ring-ds-warning`、マジックカードバッジは維持、`cardAlt` による `aria-label`/`aria-pressed` を付与。不要になった `describeTopCard`/`suitSymbol` ヘルパーを削除。
- `ShitheadPage.test.tsx`: テキスト依存のクエリを `aria-pressed`／カード画像（`cardAlt`）ベースに更新（計18）。

## テスト
- `bun run test -- --run ShitheadPage` → 18 passed
- `bun run check` → エラーなし

Closes #2605