### PR TITLE
feat(piquet): render hand and trick cards as real card images

### DIFF
--- a/frontend/src/pages/PiquetPage.test.tsx
+++ b/frontend/src/pages/PiquetPage.test.tsx
@@ -100,8 +100,9 @@ describe('PiquetPage', () => {
   it('shows the human hand cards', async () => {
     mockExec.mockResolvedValue(makeState());
     renderWithProviders(<PiquetPage />);
-    await waitFor(() => expect(screen.getByText('K♠')).toBeInTheDocument());
-    expect(screen.getByText('A♥')).toBeInTheDocument();
+    // Cards now render as real images with localized alt text (suit + rank).
+    await waitFor(() => expect(screen.getByAltText('♠ K')).toBeInTheDocument());
+    expect(screen.getByAltText('♥ A')).toBeInTheDocument();
   });
 
   it('renders reset button', async () => {
@@ -190,7 +191,7 @@ describe('PiquetPage', () => {
     renderWithProviders(<PiquetPage />);
     // Exact match isolates the TrickView header from the "トリック: 0" stats line.
     await waitFor(() => expect(screen.getByText('トリック')).toBeInTheDocument()); // trickHeader
-    expect(screen.getByText(/P0:/)).toBeInTheDocument(); // TrickView entry
+    expect(screen.getByText('P0')).toBeInTheDocument(); // TrickView player label (cards now render as images)
   });
 
   it('shows the meld badge in the lost palette when the opponent scores', async () => {

--- a/frontend/src/pages/PiquetPage.tsx
+++ b/frontend/src/pages/PiquetPage.tsx
@@ -4,14 +4,16 @@ import { ErrorAlert } from '../components/ErrorAlert';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
+import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePiquetGame } from '../hooks/usePiquetGame';
 import { badgeErrorColors, badgeSuccessColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { Card, PiquetDeclaration, PiquetPlayerData, PiquetResponse } from '../types/card';
+import type { PiquetDeclaration, PiquetPlayerData, PiquetResponse } from '../types/card';
 import { PiquetDeclarationKind, PiquetExchangeTurn, PiquetPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { type DeclarationHighlight, declarationHighlight } from '../utils/piquetDeclarationHighlight';
@@ -33,37 +35,6 @@ const PIQUET_TUTORIAL_STEPS: TutorialStep[] = [
   },
 ];
 
-const SUIT_GLYPH: Record<string, string> = {
-  SPADE: '♠',
-  CLOVER: '♣',
-  HEART: '♥',
-  DIAMOND: '♦',
-  JOKER: 'Jk',
-};
-
-/** Format a single card into a short string like "K♠". */
-function formatCard(card: Card): string {
-  const v = card.value;
-  let rank: string;
-  switch (v) {
-    case 1:
-      rank = 'A';
-      break;
-    case 11:
-      rank = 'J';
-      break;
-    case 12:
-      rank = 'Q';
-      break;
-    case 13:
-      rank = 'K';
-      break;
-    default:
-      rank = String(v);
-  }
-  return `${rank}${SUIT_GLYPH[card.design] ?? '?'}`;
-}
-
 function declKindLabel(kind: number): string {
   switch (kind) {
     case PiquetDeclarationKind.POINT:
@@ -84,6 +55,7 @@ function PiquetPageContent() {
   const { t, tc, confirmOpen, requestConfirm, confirmReset, cancelReset } = useGamePageSetup('piquet');
   const game = usePiquetGame();
   const { state, loading, error, retry } = game;
+  const { cardWidth } = useCardDimensions();
   const [selectedDiscards, setSelectedDiscards] = useState<number[]>([]);
   const [activeHighlight, setActiveHighlight] = useState<DeclarationHighlight | null>(null);
   const prevDeclLenRef = useRef(0);
@@ -202,13 +174,12 @@ function PiquetPageContent() {
                 <button
                   key={`hand-${i}-${c.design}-${c.value}`}
                   type="button"
-                  className={`rounded border px-2 py-1 text-sm font-mono min-h-[44px] min-w-[44px] transition-transform ${
-                    selected ? 'bg-ds-warning/40 border-ds-warning' : 'bg-white/10 border-white/30'
-                  } ${ringClass}`}
+                  aria-pressed={humanCanExchange ? selected : undefined}
+                  className={`rounded transition-transform ${selected ? 'ring-2 ring-ds-warning -translate-y-1' : ''} ${ringClass}`}
                   onClick={handleClick}
                   disabled={handleClick == null}
                 >
-                  {formatCard(c)}
+                  <AnimatedCard card={c} width={cardWidth} />
                 </button>
               );
             })}
@@ -334,6 +305,7 @@ function DeclarationList({ results, elderIdx }: { results: PiquetDeclaration[]; 
 
 function TrickView({ trick }: { trick: PiquetResponse['currentTrick'] }) {
   const { t } = useTranslation('piquet');
+  const { cardWidth } = useCardDimensions();
   return (
     <div className="rounded border border-white/20 p-2 mx-2 text-sm">
       <div className="mb-1 font-bold">{t('trickHeader')}</div>
@@ -341,9 +313,10 @@ function TrickView({ trick }: { trick: PiquetResponse['currentTrick'] }) {
         {trick.map((tc, i) => (
           <div
             key={`trick-${i}-${tc.playerIdx}-${tc.card.design}-${tc.card.value}`}
-            className="rounded bg-white/10 px-2 py-1 font-mono"
+            className="flex flex-col items-center gap-0.5"
           >
-            P{tc.playerIdx}: {formatCard(tc.card)}
+            <span className="text-xs text-ds-text-muted">P{tc.playerIdx}</span>
+            <AnimatedCard card={tc.card} width={cardWidth} />
           </div>
         ))}
       </div>

--- a/frontend/src/pages/PiquetPage.tsx
+++ b/frontend/src/pages/PiquetPage.tsx
@@ -163,9 +163,11 @@ function PiquetPageContent() {
             {human.cards.map((c, i) => {
               const selected = selectedDiscards.includes(i);
               const highlighted = activeHighlight?.cardIndices.includes(i) ?? false;
+              // Highlight ring lives on the AnimatedCard wrapper so it tracks the lift; the
+              // selection lift/glow is driven by AnimatedCard's isSelected (Framer Motion).
               const ringClass = highlighted
                 ? activeHighlight?.won
-                  ? 'ring-2 ring-ds-success -translate-y-1'
+                  ? 'ring-2 ring-ds-success'
                   : 'ring-2 ring-ds-error'
                 : '';
               const handlePlay = () => game.handlePlay(i);
@@ -175,11 +177,11 @@ function PiquetPageContent() {
                   key={`hand-${i}-${c.design}-${c.value}`}
                   type="button"
                   aria-pressed={humanCanExchange ? selected : undefined}
-                  className={`rounded transition-transform ${selected ? 'ring-2 ring-ds-warning -translate-y-1' : ''} ${ringClass}`}
+                  className="rounded"
                   onClick={handleClick}
                   disabled={handleClick == null}
                 >
-                  <AnimatedCard card={c} width={cardWidth} />
+                  <AnimatedCard card={c} width={cardWidth} isSelected={selected} wrapperClassName={ringClass} />
                 </button>
               );
             })}

--- a/frontend/src/pages/SkatPage.test.tsx
+++ b/frontend/src/pages/SkatPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { skatApi } from '../api/gameApi';
@@ -487,6 +487,10 @@ describe('SkatPage', () => {
       </MemoryRouter>,
     );
     await waitFor(() => expect(screen.getByText(/スカート \(場札\)/)).toBeInTheDocument());
+    // The two skat cards now render as real card images, not raw "DIAMOND 7" text.
+    const reveal = screen.getByTestId('skat-reveal');
+    expect(within(reveal).getAllByRole('img')).toHaveLength(2);
+    expect(reveal).not.toHaveTextContent('DIAMOND');
   });
 
   it('hides next-round button when game has ended', async () => {

--- a/frontend/src/pages/SkatPage.tsx
+++ b/frontend/src/pages/SkatPage.tsx
@@ -9,6 +9,7 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
+import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { PlayerHandSection } from '../components/PlayerHandSection';
 import { TrickDisplay } from '../components/TrickDisplay';
 import { withTutorial } from '../components/tutorial/withTutorial';
@@ -221,11 +222,9 @@ function SkatPageContent() {
             {state.originalSkat && state.originalSkat.length > 0 && (
               <div className="bg-black/30 text-ds-text-primary p-3 rounded">
                 <div className="text-sm mb-1">{t('skatLabel')}:</div>
-                <div className="flex gap-2">
+                <div className="flex gap-2" data-testid="skat-reveal">
                   {state.originalSkat.map((c, i) => (
-                    <span key={`skat-${i}`} className="bg-white text-black px-2 py-1 rounded">
-                      {c.design} {c.value}
-                    </span>
+                    <AnimatedCard key={`skat-${i}`} card={c} width={cardWidth} />
                   ))}
                 </div>
               </div>


### PR DESCRIPTION
## 概要
Piquet は手札・トリックを `K♠` 形式のテキストボタン（`font-mono`）で描画しており、他のトリックテイキング系（Briscola/CallBreak/Tarneeb）の実カード画像と乖離して視認性・没入感が劣っていました。

## 変更点
- `PiquetPage.tsx`: 手札（`human.cards.map`）と `TrickView` を `AnimatedCard`（`useCardDimensions` の `cardWidth`）に置換。交換選択（`selectedDiscards`）と meld ハイライト（`activeHighlight`）のリングはカード画像上のオーバーレイとして維持（`aria-pressed` で選択状態）。`TrickView` は「P{idx}」ラベル＋カード画像。未使用化した `formatCard`/`SUIT_GLYPH` を削除（`AnimatedCard`→`CardImage` の `cardAlt` がアクセシブルラベルを提供）。
- `PiquetPage.test.tsx`: テキスト依存のクエリをカード画像（`getByAltText`）／`P0` ラベルベースに更新（計10）。

## テスト
- `bun run test -- --run PiquetPage` → 10 passed
- `bun run check` → エラーなし

Closes #2625