### PR TITLE
feat(nertz): render foundation/pile/tableau cards as real card images

### DIFF
--- a/frontend/src/pages/NertzPage.test.tsx
+++ b/frontend/src/pages/NertzPage.test.tsx
@@ -112,7 +112,7 @@ describe('NertzPage', () => {
         <NertzPage />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(screen.getByText(/♥7/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByAltText('♥ 7')).toBeInTheDocument());
     expect(screen.getByRole('button', { name: '35' })).toBeInTheDocument();
   });
 
@@ -198,9 +198,9 @@ describe('NertzPage', () => {
         <NertzPage />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(screen.getByText(/♥7/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByAltText('♥ 7')).toBeInTheDocument());
     // Select nertz pile
-    const nertzBtn = screen.getByText('♥7').closest('button');
+    const nertzBtn = screen.getByAltText('♥ 7').closest('button');
     expect(nertzBtn).not.toBeNull();
     fireEvent.click(nertzBtn as HTMLElement);
     mockExec.mockClear();
@@ -242,7 +242,7 @@ describe('NertzPage', () => {
         <NertzPage />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(screen.getByText(/♥7/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByAltText('♥ 7')).toBeInTheDocument());
     mockExec.mockClear();
     mockExec.mockResolvedValue(playingState);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('tick'), { timeout: 2000 });
@@ -255,7 +255,7 @@ describe('NertzPage', () => {
         <NertzPage />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(screen.getByText(/♥7/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByAltText('♥ 7')).toBeInTheDocument());
 
     mockExec.mockClear();
     mockExec.mockResolvedValue(playingState);
@@ -270,7 +270,7 @@ describe('NertzPage', () => {
         <NertzPage />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(screen.getByText(/♥7/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByAltText('♥ 7')).toBeInTheDocument());
 
     // Pick the Nertz pile via 'n' first, then ask for foundation 0.
     fireEvent.keyDown(document, { key: 'n' });
@@ -292,8 +292,8 @@ describe('NertzPage', () => {
         <NertzPage />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(screen.getByText(/♥7/)).toBeInTheDocument());
-    fireEvent.click(screen.getByText('♥7').closest('button') as HTMLElement);
+    await waitFor(() => expect(screen.getByAltText('♥ 7')).toBeInTheDocument());
+    fireEvent.click(screen.getByAltText('♥ 7').closest('button') as HTMLElement);
 
     // Reject the next move (simulates CPU getting there first).
     mockExec.mockRejectedValueOnce(new Error('collision'));
@@ -308,8 +308,8 @@ describe('NertzPage', () => {
         <NertzPage />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(screen.getByText(/♥7/)).toBeInTheDocument());
-    fireEvent.click(screen.getByText('♥7').closest('button') as HTMLElement);
+    await waitFor(() => expect(screen.getByAltText('♥ 7')).toBeInTheDocument());
+    fireEvent.click(screen.getByAltText('♥ 7').closest('button') as HTMLElement);
 
     mockExec.mockRejectedValueOnce(new Error('boom'));
     fireEvent.click(screen.getByTestId('nertz-foundation-1'));
@@ -327,8 +327,8 @@ describe('NertzPage', () => {
         <NertzPage />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(screen.getByText(/♥7/)).toBeInTheDocument());
-    fireEvent.click(screen.getByText('♥7').closest('button') as HTMLElement);
+    await waitFor(() => expect(screen.getByAltText('♥ 7')).toBeInTheDocument());
+    fireEvent.click(screen.getByAltText('♥ 7').closest('button') as HTMLElement);
 
     // Successful foundation move → state updates → pending ref must be cleared.
     fireEvent.click(screen.getByTestId('nertz-foundation-2'));
@@ -336,7 +336,7 @@ describe('NertzPage', () => {
 
     // Now a different action fails — must NOT light up foundation 2.
     mockExec.mockRejectedValueOnce(new Error('tick boom'));
-    fireEvent.click(screen.getByText('♥7').closest('button') as HTMLElement); // re-select
+    fireEvent.click(screen.getByAltText('♥ 7').closest('button') as HTMLElement); // re-select
     fireEvent.click(screen.getByTestId('nertz-foundation-3')); // dispatch to a different cell
     // Only foundation 3 (the new target) should be marked, not foundation 2.
     await waitFor(() => expect(screen.getByTestId('nertz-foundation-3')).toHaveAttribute('data-collided', 'true'));

--- a/frontend/src/pages/NertzPage.test.tsx
+++ b/frontend/src/pages/NertzPage.test.tsx
@@ -117,9 +117,9 @@ describe('NertzPage', () => {
   });
 
   it('selects a tableau card on click and renders empty columns as placeholders', async () => {
-    const foundations = Array.from({ length: 8 }, () => ({ suit: -1, size: 0, top: null }));
+    const foundations: NertzResponse['foundations'] = Array.from({ length: 8 }, () => ({ suit: -1, size: 0 }));
     // One foundation carries a top card (covers the foundation card-image branch).
-    foundations[0] = { suit: 3, size: 1, top: { design: 'HEART', value: 1 } } as (typeof foundations)[number];
+    foundations[0] = { suit: 3, size: 1, top: { design: 'HEART', value: 1 } };
     const withEmptyCol = {
       ...playingState,
       foundations,

--- a/frontend/src/pages/NertzPage.test.tsx
+++ b/frontend/src/pages/NertzPage.test.tsx
@@ -116,6 +116,41 @@ describe('NertzPage', () => {
     expect(screen.getByRole('button', { name: '35' })).toBeInTheDocument();
   });
 
+  it('selects a tableau card on click and renders empty columns as placeholders', async () => {
+    const foundations = Array.from({ length: 8 }, () => ({ suit: -1, size: 0, top: null }));
+    // One foundation carries a top card (covers the foundation card-image branch).
+    foundations[0] = { suit: 3, size: 1, top: { design: 'HEART', value: 1 } } as (typeof foundations)[number];
+    const withEmptyCol = {
+      ...playingState,
+      foundations,
+      players: [
+        {
+          ...playingState.players[0],
+          // A selectable card, an empty column, and a face-down (null) cell.
+          tableau: [
+            [{ card: { design: 'SPADE' as const, value: 5 }, faceUp: true }],
+            [],
+            [{ card: null, faceUp: false }],
+            [],
+          ],
+        },
+        playingState.players[1],
+      ],
+    };
+    mockExec.mockResolvedValue(withEmptyCol);
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/nertz']}>
+        <NertzPage />
+      </MemoryRouter>,
+    );
+    const card = await screen.findByAltText('♠ 5');
+    // Clicking selects the card (re-renders the AnimatedCard with isSelected=true).
+    fireEvent.click(card);
+    expect(screen.getByAltText('♠ 5')).toBeInTheDocument();
+    // The foundation with a top card shows its image (♥ A).
+    expect(screen.getByAltText('♥ A')).toBeInTheDocument();
+  });
+
   it('renders per-player score progress bars scaled to the target score', async () => {
     mockExec.mockResolvedValue({
       ...playingState,

--- a/frontend/src/pages/NertzPage.tsx
+++ b/frontend/src/pages/NertzPage.tsx
@@ -9,8 +9,10 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
+import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
+import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
@@ -553,9 +555,8 @@ function FoundationCell({
   placedBy = null,
   placedFlashKey = 0,
 }: FoundationCellProps) {
-  const cls = disabled
-    ? 'bg-ds-surface text-ds-text-muted border-ds-border-subtle'
-    : 'bg-ds-surface-elevated text-ds-text-primary border-ds-border-subtle hover:bg-ds-surface-elevated-hover';
+  const { cardWidth } = useCardDimensions();
+  const w = Math.round(cardWidth * 0.6);
   const collisionCls = collided ? 'animate-shake ring-2 ring-ds-error' : '';
   // The placement flash is a sibling overlay so we can remount *it* (via key)
   // to re-fire animate-pulse-once on back-to-back placements without
@@ -572,15 +573,22 @@ function FoundationCell({
         type="button"
         onClick={onClick}
         disabled={disabled}
-        className={`min-w-[3rem] rounded border px-2 py-2 text-sm ${cls} ${collisionCls}`}
+        className={`flex flex-col items-center rounded p-0.5 text-xs text-ds-text-muted ${collisionCls}`}
         aria-label={ariaLabel}
         data-testid={`nertz-foundation-${idx}`}
         data-collided={collided || undefined}
         data-placed-by={placedBy ?? undefined}
       >
-        <span className="block text-xs leading-none">F{idx}</span>
-        <span className="block text-base font-bold">{top ? `${suitSymbol(top.design)}${top.value}` : '—'}</span>
-        <span className="block text-xs">({size})</span>
+        <span className="block leading-none">F{idx}</span>
+        {top ? (
+          <AnimatedCard card={top} width={w} />
+        ) : (
+          <span
+            className="block rounded border border-dashed border-white/30"
+            style={{ width: w, height: Math.round(w * 1.4) }}
+          />
+        )}
+        <span className="block">({size})</span>
       </button>
       {flashOverlayClass && (
         // Remount the overlay (via key) on each new placement so the
@@ -605,20 +613,24 @@ interface CardButtonProps {
 }
 
 function CardButton({ card, label, selected, disabled, onClick }: CardButtonProps) {
-  const cls = selected
-    ? 'bg-ds-warning text-ds-text-on-accent border-ds-warning'
-    : disabled
-      ? 'bg-ds-surface text-ds-text-muted border-ds-border-subtle'
-      : 'bg-ds-surface-elevated text-ds-text-primary border-ds-border-subtle hover:bg-ds-surface-elevated-hover';
+  const { cardWidth } = useCardDimensions();
+  const w = Math.round(cardWidth * 0.6);
   return (
     <button
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className={`min-w-[3rem] px-2 py-2 rounded border text-sm ${cls}`}
+      className="flex flex-col items-center rounded p-0.5 text-xs text-ds-text-muted"
     >
-      <span className="block text-base font-bold">{card ? `${suitSymbol(card.design)}${card.value}` : '—'}</span>
-      <span className="block text-xs">{label}</span>
+      {card ? (
+        <AnimatedCard card={card} width={w} isSelected={selected} />
+      ) : (
+        <span
+          className="block rounded border border-dashed border-white/30"
+          style={{ width: w, height: Math.round(w * 1.4) }}
+        />
+      )}
+      <span className="block">{label}</span>
     </button>
   );
 }
@@ -633,6 +645,8 @@ interface TableauColumnProps {
 }
 
 function TableauColumn({ col, colIdx, selection, onSelectCard, onTarget, disabled }: TableauColumnProps) {
+  const { cardWidth } = useCardDimensions();
+  const w = Math.round(cardWidth * 0.6);
   if (col.length === 0) {
     return (
       <button
@@ -640,6 +654,7 @@ function TableauColumn({ col, colIdx, selection, onSelectCard, onTarget, disable
         onClick={onTarget}
         disabled={disabled}
         className="min-h-[4rem] rounded border border-dashed border-white/30 text-ds-text-muted text-xs"
+        style={{ width: w }}
       >
         —
       </button>
@@ -650,11 +665,6 @@ function TableauColumn({ col, colIdx, selection, onSelectCard, onTarget, disable
       {col.map((tc, i) => {
         const isSelected = selection?.kind === 'tableau' && selection.col === colIdx && selection.cardIndex === i;
         const isLast = i === col.length - 1;
-        const cls = isSelected
-          ? 'bg-ds-warning text-ds-text-on-accent border-ds-warning'
-          : disabled
-            ? 'bg-ds-surface text-ds-text-muted border-ds-border-subtle'
-            : 'bg-ds-surface-elevated text-ds-text-primary border-ds-border-subtle hover:bg-ds-surface-elevated-hover';
         // Dual-purpose click: the bottom card acts as a drop target when a
         // source is already selected (saves the user a second tap on an
         // empty drop zone), otherwise tapping any card selects it as the
@@ -665,29 +675,21 @@ function TableauColumn({ col, colIdx, selection, onSelectCard, onTarget, disable
             type="button"
             onClick={() => (isLast && selection && !isSelected ? onTarget() : onSelectCard(colIdx, i))}
             disabled={disabled || !tc.card}
-            className={`px-2 py-1 rounded border text-sm ${cls}`}
+            className="rounded"
           >
-            {tc.card ? `${suitSymbol(tc.card.design)}${tc.card.value}` : '?'}
+            {tc.card ? (
+              <AnimatedCard card={tc.card} width={w} isSelected={isSelected} />
+            ) : (
+              <span
+                className="block rounded border border-dashed border-white/30"
+                style={{ width: w, height: Math.round(w * 1.4) }}
+              />
+            )}
           </button>
         );
       })}
     </div>
   );
-}
-
-function suitSymbol(design: string): string {
-  switch (design) {
-    case 'SPADE':
-      return '♠';
-    case 'CLOVER':
-      return '♣';
-    case 'HEART':
-      return '♥';
-    case 'DIAMOND':
-      return '♦';
-    default:
-      return '?';
-  }
 }
 
 export type _NertzPagePlayerSnapshot = NertzPlayerData;

--- a/frontend/src/pages/NertzPage.tsx
+++ b/frontend/src/pages/NertzPage.tsx
@@ -556,7 +556,7 @@ function FoundationCell({
   placedFlashKey = 0,
 }: FoundationCellProps) {
   const { cardWidth } = useCardDimensions();
-  const w = Math.round(cardWidth * 0.6);
+  const w = Math.max(44, Math.round(cardWidth * 0.6));
   const collisionCls = collided ? 'animate-shake ring-2 ring-ds-error' : '';
   // The placement flash is a sibling overlay so we can remount *it* (via key)
   // to re-fire animate-pulse-once on back-to-back placements without
@@ -573,7 +573,7 @@ function FoundationCell({
         type="button"
         onClick={onClick}
         disabled={disabled}
-        className={`flex flex-col items-center rounded p-0.5 text-xs text-ds-text-muted ${collisionCls}`}
+        className={`flex flex-col items-center rounded p-0.5 text-xs text-ds-text-muted disabled:opacity-50 ${collisionCls}`}
         aria-label={ariaLabel}
         data-testid={`nertz-foundation-${idx}`}
         data-collided={collided || undefined}
@@ -614,13 +614,13 @@ interface CardButtonProps {
 
 function CardButton({ card, label, selected, disabled, onClick }: CardButtonProps) {
   const { cardWidth } = useCardDimensions();
-  const w = Math.round(cardWidth * 0.6);
+  const w = Math.max(44, Math.round(cardWidth * 0.6));
   return (
     <button
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="flex flex-col items-center rounded p-0.5 text-xs text-ds-text-muted"
+      className="flex flex-col items-center rounded p-0.5 text-xs text-ds-text-muted disabled:opacity-50"
     >
       {card ? (
         <AnimatedCard card={card} width={w} isSelected={selected} />
@@ -646,7 +646,7 @@ interface TableauColumnProps {
 
 function TableauColumn({ col, colIdx, selection, onSelectCard, onTarget, disabled }: TableauColumnProps) {
   const { cardWidth } = useCardDimensions();
-  const w = Math.round(cardWidth * 0.6);
+  const w = Math.max(44, Math.round(cardWidth * 0.6));
   if (col.length === 0) {
     return (
       <button
@@ -675,7 +675,7 @@ function TableauColumn({ col, colIdx, selection, onSelectCard, onTarget, disable
             type="button"
             onClick={() => (isLast && selection && !isSelected ? onTarget() : onSelectCard(colIdx, i))}
             disabled={disabled || !tc.card}
-            className="rounded"
+            className="rounded disabled:opacity-50"
           >
             {tc.card ? (
               <AnimatedCard card={tc.card} width={w} isSelected={isSelected} />


### PR DESCRIPTION
## 概要
Nertz はファウンデーション・ナーツ/ウェイスト・タブローのすべてを `♠7` 形式のテキストボタンで描画しており、他ゲームの実カード画像と乖離。スピード勝負ゆえテキストは色・ランクの瞬時判別が困難でした。

## 変更点
- `NertzPage.tsx`: `FoundationCell`/`CardButton`/`TableauColumn` のカード本体を `AnimatedCard`（`useCardDimensions` の `cardWidth`×0.6）に置換。
  - 選択は `AnimatedCard` の `isSelected`（lift/glow）。衝突シェイク（`animate-shake ring-ds-error`）と配置フラッシュ（sibling overlay）は従来どおり維持。F番号/ラベル/枚数テキストも維持。空スロットは破線プレースホルダ。
  - 未使用化した `suitSymbol` ヘルパーを削除（`AnimatedCard`→`CardImage` の `cardAlt` がアクセシブルラベルを提供）。
- `NertzPage.test.tsx`: テキスト依存のクエリをカード画像（`getByAltText('♥ 7')`）に更新（計17）。

## テスト
- `bun run test -- --run NertzPage` → 17 passed
- `bun run check` → エラーなし

Closes #2606