### PR TITLE
feat(burraco): show a pre-emptive freeze constraint guide in the draw phase

### DIFF
--- a/frontend/src/i18n/locales/en/burraco.json
+++ b/frontend/src/i18n/locales/en/burraco.json
@@ -31,6 +31,7 @@
   "naturalBurraco": "Natural Burraco",
   "mixedBurraco": "Mixed Burraco",
   "drawStockButton": "Draw from stock",
+  "drawFreezeGuide": "Discard pile is frozen: you may take only the top card, and wild cards cannot be used to pick it up.",
   "drawDiscardButton": "Pick up discard",
   "meldButton": "Meld",
   "skipMeldButton": "Skip",

--- a/frontend/src/i18n/locales/ja/burraco.json
+++ b/frontend/src/i18n/locales/ja/burraco.json
@@ -31,6 +31,7 @@
   "naturalBurraco": "ナチュラルブラーコ",
   "mixedBurraco": "ミックスブラーコ",
   "drawStockButton": "山札から引く",
+  "drawFreezeGuide": "捨て札はフリーズ中: 上の1枚しか取れず、ワイルドカードで取り込むことはできません。",
   "drawDiscardButton": "捨て札を取る",
   "meldButton": "メルドする",
   "skipMeldButton": "スキップ",

--- a/frontend/src/pages/BurracoPage.test.tsx
+++ b/frontend/src/pages/BurracoPage.test.tsx
@@ -215,6 +215,8 @@ describe('BurracoPage', () => {
     expect(screen.getByTestId('ca-draw-discard-reason')).toHaveTextContent(
       'フリーズ中はワイルドカードでの代用ができません',
     );
+    // Pre-emptive freeze guide shown at the top of the draw controls.
+    expect(screen.getByTestId('ca-draw-freeze-guide')).toHaveTextContent(/フリーズ中/);
   });
 
   it('switches the reason to selectOneMore once the player selects one card', async () => {

--- a/frontend/src/pages/BurracoPage.tsx
+++ b/frontend/src/pages/BurracoPage.tsx
@@ -445,6 +445,11 @@ function BurracoPageContent() {
             <div className="flex gap-2 items-center flex-wrap" data-tutorial="ca-actions">
               {isDrawPhase && isHumanTurn && (
                 <div className="flex gap-2 flex-col">
+                  {state?.isFrozen && (
+                    <div role="status" data-testid="ca-draw-freeze-guide" className="text-xs text-ds-warning">
+                      {t('drawFreezeGuide')}
+                    </div>
+                  )}
                   <div className="flex gap-2">
                     <button type="button" className={btnPrimary} onClick={handleDrawStock} disabled={loading}>
                       {t('drawStockButton')}

--- a/frontend/src/pages/BurracoPage.tsx
+++ b/frontend/src/pages/BurracoPage.tsx
@@ -445,7 +445,7 @@ function BurracoPageContent() {
             <div className="flex gap-2 items-center flex-wrap" data-tutorial="ca-actions">
               {isDrawPhase && isHumanTurn && (
                 <div className="flex gap-2 flex-col">
-                  {state?.isFrozen && (
+                  {state.isFrozen && (
                     <div role="status" data-testid="ca-draw-freeze-guide" className="text-xs text-ds-warning">
                       {t('drawFreezeGuide')}
                     </div>

--- a/internal/adapter/presenter/BurracoCuiPresenter.go
+++ b/internal/adapter/presenter/BurracoCuiPresenter.go
@@ -105,6 +105,9 @@ func (p *BurracoCuiPresenter) Output(g interfaces.BurracoGame, lastErr error) st
 				"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
 			b.WriteString(i18n.T("burraco.promptDrawHelpStock") + "\n")
 			b.WriteString(i18n.T("burraco.promptDrawHelpDiscard") + "\n")
+			if g.GetIsFrozen() {
+				b.WriteString(i18n.T("burraco.promptDrawFrozen") + "\n")
+			}
 		case domain.BurracoPhaseMeld:
 			currentIdx := g.GetCurrentPlayerIdx()
 			b.WriteString(i18n.Tf("burraco.promptMeld",

--- a/internal/adapter/presenter/BurracoCuiPresenter_test.go
+++ b/internal/adapter/presenter/BurracoCuiPresenter_test.go
@@ -69,6 +69,8 @@ func TestBurracoCuiPresenter_Output(t *testing.T) {
 
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "[フリーズ]")
+		// The draw prompt warns about the freeze constraint (top-only, no wild pickup).
+		assert.Contains(t, result, "フリーズ中: 上の1枚のみ")
 	})
 
 	t.Run("discard top shown", func(t *testing.T) {

--- a/internal/i18n/locales/en/burraco.json
+++ b/internal/i18n/locales/en/burraco.json
@@ -25,6 +25,7 @@
   "promptDraw": "{{name}} to act (draw phase)",
   "promptDrawHelpStock": "ds: draw from stock",
   "promptDrawHelpDiscard": "dd <idx,idx>: take the discard pile (natural pair indices)",
+  "promptDrawFrozen": "Frozen: only the top card, no wild-card pickup",
   "promptMeld": "{{name}} to act (meld phase)",
   "promptMeldHelp": "m <idx,idx,idx;idx,idx,idx>: lay down meld(s) (; separates groups)",
   "promptSkipMeld": "sm: skip melding",

--- a/internal/i18n/locales/ja/burraco.json
+++ b/internal/i18n/locales/ja/burraco.json
@@ -25,6 +25,7 @@
   "promptDraw": "手番: {{name}} (ドローフェーズ)",
   "promptDrawHelpStock": "ds・・・山札から引く",
   "promptDrawHelpDiscard": "dd <idx,idx>・・・捨て札の山を取る (ナチュラルペアのインデックス)",
+  "promptDrawFrozen": "フリーズ中: 上の1枚のみ、ワイルドでの取り込み不可",
   "promptMeld": "手番: {{name}} (メルドフェーズ)",
   "promptMeldHelp": "m <idx,idx,idx;idx,idx,idx>・・・メルドを出す (;でグループ区切り)",
   "promptSkipMeld": "sm・・・メルドせずにスキップ",


### PR DESCRIPTION
## 概要
Burraco の最も複雑な DRAW フェーズのフリーズ／ワイルド制約は、カード選択が失敗した後にしか説明されませんでした。フリーズ中の人間のドローターンで事前ガイドを表示し、CUI の DRAW プロンプトにも制約の一文を追加します。

## 変更点
- `BurracoPage.tsx`: `isDrawPhase && isHumanTurn && state.isFrozen` のとき、ドロー操作群の先頭に `role=status` の `drawFreezeGuide`（`data-testid=ca-draw-freeze-guide`）を表示。
- `BurracoCuiPresenter.go`: DRAW プロンプトで `GetIsFrozen()` のとき `promptDrawFrozen` の一文を追加。
- `frontend/internal ja/en burraco.json`: `drawFreezeGuide` / `promptDrawFrozen` を追加。
- テスト: フロント（フリーズ時に事前ガイド表示、計21）＋ Go プレゼンター（frozen 時に DRAW プロンプトへ制約文）。

## テスト
- `bun run test -- --run BurracoPage` → 21 passed
- `bun run check` → エラーなし

Closes #2650