### PR TITLE
feat(handandfoot): pulse the draw-from-discard button when frozen

### DIFF
--- a/frontend/src/pages/HandAndFootPage.test.tsx
+++ b/frontend/src/pages/HandAndFootPage.test.tsx
@@ -117,12 +117,19 @@ describe('HandAndFootPage', () => {
     expect(screen.getByRole('button', { name: '捨て札を取る' })).toBeInTheDocument();
   });
 
-  it('pulses the draw-from-discard button when the discard pile is frozen', async () => {
+  it('pulses the draw-from-discard button only when frozen and two cards are selected', async () => {
     mockExec.mockResolvedValue({ ...drawPhaseState, isFrozen: true });
     renderWithProviders(<HandAndFootPage />);
     const btn = await screen.findByRole('button', { name: '捨て札を取る' });
-    expect(btn).toHaveAttribute('data-frozen', 'true');
-    expect(btn.className).toMatch(/animate-pulse/);
+    // Disabled (no selection) → no misleading pulse yet.
+    expect(btn).not.toHaveAttribute('data-frozen');
+    // Select two hand cards to enable the action; the pulse then warns about the freeze.
+    const handCards = screen.getAllByRole('button', { pressed: false }).filter((b) => b.hasAttribute('aria-pressed'));
+    fireEvent.click(handCards[0]);
+    fireEvent.click(handCards[1]);
+    const enabled = screen.getByRole('button', { name: '捨て札を取る' });
+    expect(enabled).toHaveAttribute('data-frozen', 'true');
+    expect(enabled.className).toMatch(/animate-pulse/);
   });
 
   it('does not pulse the draw-from-discard button when not frozen', async () => {

--- a/frontend/src/pages/HandAndFootPage.test.tsx
+++ b/frontend/src/pages/HandAndFootPage.test.tsx
@@ -117,6 +117,21 @@ describe('HandAndFootPage', () => {
     expect(screen.getByRole('button', { name: '捨て札を取る' })).toBeInTheDocument();
   });
 
+  it('pulses the draw-from-discard button when the discard pile is frozen', async () => {
+    mockExec.mockResolvedValue({ ...drawPhaseState, isFrozen: true });
+    renderWithProviders(<HandAndFootPage />);
+    const btn = await screen.findByRole('button', { name: '捨て札を取る' });
+    expect(btn).toHaveAttribute('data-frozen', 'true');
+    expect(btn.className).toMatch(/animate-pulse/);
+  });
+
+  it('does not pulse the draw-from-discard button when not frozen', async () => {
+    renderWithProviders(<HandAndFootPage />);
+    const btn = await screen.findByRole('button', { name: '捨て札を取る' });
+    expect(btn).not.toHaveAttribute('data-frozen');
+    expect(btn.className).not.toMatch(/animate-pulse/);
+  });
+
   it('calls drawstock command when button clicked', async () => {
     renderWithProviders(<HandAndFootPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '山札から引く' })).toBeInTheDocument());

--- a/frontend/src/pages/HandAndFootPage.tsx
+++ b/frontend/src/pages/HandAndFootPage.tsx
@@ -375,7 +375,8 @@ function HandAndFootPageContent() {
                     </button>
                     <button
                       type="button"
-                      className={btnPrimary}
+                      className={`${btnPrimary} ${state.isFrozen ? 'motion-safe:animate-pulse ring-2 ring-ds-info' : ''}`}
+                      data-frozen={state.isFrozen || undefined}
                       onClick={handleDrawDiscard}
                       disabled={loading || selectedCardIndices.length !== 2}
                       title={drawDiscardReason || undefined}

--- a/frontend/src/pages/HandAndFootPage.tsx
+++ b/frontend/src/pages/HandAndFootPage.tsx
@@ -375,8 +375,12 @@ function HandAndFootPageContent() {
                     </button>
                     <button
                       type="button"
-                      className={`${btnPrimary} ${state.isFrozen ? 'motion-safe:animate-pulse ring-2 ring-ds-info' : ''}`}
-                      data-frozen={state.isFrozen || undefined}
+                      className={`${btnPrimary} ${
+                        state.isFrozen && selectedCardIndices.length === 2 && !loading
+                          ? 'motion-safe:animate-pulse ring-2 ring-ds-info'
+                          : ''
+                      }`}
+                      data-frozen={state.isFrozen && selectedCardIndices.length === 2 && !loading ? 'true' : undefined}
                       onClick={handleDrawDiscard}
                       disabled={loading || selectedCardIndices.length !== 2}
                       title={drawDiscardReason || undefined}


### PR DESCRIPTION
## 概要
Hand and Foot の DRAW フェーズでは、凍結状態は `drawDiscardReason` の小さな灰色テキストでしか伝わらない一方、捨て札コンテナ自体は凍結時に青のリング＋背景で強調され、視覚的重みがボタンとカード表示で不一致でした。

## 変更点
- `HandAndFootPage.tsx`: `state.isFrozen` のとき「捨て札を取る」ボタンに `motion-safe:animate-pulse ring-2 ring-ds-info` を付与（`prefers-reduced-motion` 尊重）。`data-frozen` を付与。Chinchón のノックボタン強調に準じる。既存の `drawDiscardReason` テキストは維持。
- `HandAndFootPage.test.tsx`: 凍結時に pulse/ring・非凍結時に非付与を検証（計17）。

## 補足
- 既存の Tailwind ユーティリティで実現したため `buttonStyles.ts` の変更は不要でした。

## テスト
- `bun run test -- --run HandAndFootPage` → 17 passed
- `bun run check` → エラーなし

Closes #2684