### PR TITLE
feat(chinchon): show a per-card deadwood breakdown in the discard phase

### DIFF
--- a/frontend/src/i18n/locales/en/chinchon.json
+++ b/frontend/src/i18n/locales/en/chinchon.json
@@ -31,6 +31,7 @@
   "discardButton": "Discard",
   "knockButton": "Knock",
   "deadwoodLabel": "Deadwood: {{score}} pts (knock ≤ {{threshold}})",
+  "deadwoodBreakdown": "Breakdown: {{breakdown}}",
   "layoffButton": "Lay Off",
   "skipLayoffButton": "Skip",
   "nextRound": "Next Round",

--- a/frontend/src/i18n/locales/ja/chinchon.json
+++ b/frontend/src/i18n/locales/ja/chinchon.json
@@ -31,6 +31,7 @@
   "discardButton": "捨てる",
   "knockButton": "ノック",
   "deadwoodLabel": "デッドウッド: {{score}}点（ノック上限 {{threshold}}）",
+  "deadwoodBreakdown": "内訳: {{breakdown}}",
   "layoffButton": "レイオフ",
   "skipLayoffButton": "スキップ",
   "nextRound": "次のラウンド",

--- a/frontend/src/pages/ChinchonPage.test.tsx
+++ b/frontend/src/pages/ChinchonPage.test.tsx
@@ -125,6 +125,28 @@ describe('ChinchonPage', () => {
     expect(knockBtn.className).toContain('animate-pulse');
   });
 
+  it('shows a per-card deadwood breakdown during the discard phase', async () => {
+    // No melds possible; best discard drops ♥K, leaving ♠5 + ♣3 = 8 deadwood.
+    const handWithDeadwood: ChinchonResponse = {
+      ...discardPhaseState,
+      players: [
+        {
+          ...discardPhaseState.players[0],
+          cards: [
+            { design: 'SPADE', value: 5 },
+            { design: 'HEART', value: 13 },
+            { design: 'CLOVER', value: 3 },
+          ],
+        },
+        ...discardPhaseState.players.slice(1),
+      ],
+    };
+    mockExec.mockResolvedValue(handWithDeadwood);
+    renderWithProviders(<ChinchonPage />);
+    const bd = await screen.findByTestId('chinchon-deadwood-breakdown');
+    expect(bd).toHaveTextContent('5 + 3 = 8');
+  });
+
   it('renders draw phase with human cards', async () => {
     renderWithProviders(<ChinchonPage />);
     await waitFor(() => {

--- a/frontend/src/pages/ChinchonPage.tsx
+++ b/frontend/src/pages/ChinchonPage.tsx
@@ -33,7 +33,11 @@ import type { ChinchonResponse } from '../types/card';
 import { ChinchonPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
-import { bestChinchonDeadwoodValue, chinchonMeldLabel } from '../utils/chinchonDeadwood';
+import {
+  type ChinchonDeadwoodBreakdown,
+  chinchonDeadwoodBreakdown,
+  chinchonMeldLabel,
+} from '../utils/chinchonDeadwood';
 import { CHINCHON_HELP, parseChinchonCommand } from '../utils/cli/commands/chinchonCommands';
 import { formatChinchonState } from '../utils/cli/formatters/chinchonFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -167,25 +171,26 @@ function ChinchonPageContent() {
   // a card is selected we project that discard; otherwise show the best-case
   // deadwood across all single discards (a knockability hint).
   const knockThreshold = state?.config.knockThreshold ?? chinchonConfig.knockThreshold;
-  const liveDeadwood = useMemo<number | null>(() => {
-    if (!state) return null;
-    if (state.phase !== ChinchonPhase.DISCARD) return null;
+  // Breakdown of the deadwood that would remain after the chosen discard (or the
+  // best discard when 0/2+ cards are selected), used for both the score and the
+  // per-card "5 + 3 + 2 = 10" hint.
+  const liveDeadwoodBreakdown = useMemo<ChinchonDeadwoodBreakdown | null>(() => {
+    if (!state || state.phase !== ChinchonPhase.DISCARD) return null;
     const human = state.players.find((p) => p.isHuman);
-    if (!human) return null;
+    if (!human || human.cards.length === 0) return null;
     const cards = human.cards;
-    if (cards.length === 0) return null;
     if (selectedCardIndices.length === 1) {
-      const drop = selectedCardIndices[0];
-      return bestChinchonDeadwoodValue(cards.filter((_, i) => i !== drop));
+      return chinchonDeadwoodBreakdown(cards.filter((_, i) => i !== selectedCardIndices[0]));
     }
-    let best = Number.POSITIVE_INFINITY;
+    let best: ChinchonDeadwoodBreakdown | null = null;
     for (let i = 0; i < cards.length; i++) {
-      const dv = bestChinchonDeadwoodValue(cards.filter((_, j) => j !== i));
-      if (dv < best) best = dv;
-      if (best === 0) break;
+      const bd = chinchonDeadwoodBreakdown(cards.filter((_, j) => j !== i));
+      if (best === null || bd.total < best.total) best = bd;
+      if (best.total === 0) break;
     }
-    return Number.isFinite(best) ? best : null;
+    return best;
   }, [state, selectedCardIndices]);
+  const liveDeadwood = liveDeadwoodBreakdown?.total ?? null;
   const canKnockNow = liveDeadwood != null && liveDeadwood <= knockThreshold;
 
   if (!state)
@@ -386,6 +391,13 @@ function ChinchonPageContent() {
                 className={`text-xs font-bold mb-1 ${canKnockNow ? 'text-ds-success' : 'text-ds-text-muted'}`}
               >
                 {t('deadwoodLabel', { score: liveDeadwood, threshold: knockThreshold })}
+              </div>
+            )}
+            {liveDeadwoodBreakdown != null && liveDeadwoodBreakdown.cards.length > 0 && (
+              <div data-testid="chinchon-deadwood-breakdown" className="text-[10px] text-ds-text-muted mb-1">
+                {t('deadwoodBreakdown', {
+                  breakdown: `${liveDeadwoodBreakdown.values.join(' + ')} = ${liveDeadwoodBreakdown.total}`,
+                })}
               </div>
             )}
             {humanPlayer && (

--- a/frontend/src/utils/chinchonDeadwood.test.ts
+++ b/frontend/src/utils/chinchonDeadwood.test.ts
@@ -4,6 +4,7 @@ import {
   bestChinchonDeadwoodValue,
   calcChinchonDeadwoodValue,
   chinchonCardValue,
+  chinchonDeadwoodBreakdown,
   chinchonMeldLabel,
   chinchonRankPosition,
 } from './chinchonDeadwood';
@@ -74,5 +75,21 @@ describe('bestChinchonDeadwoodValue', () => {
   it('removes a same-rank set from the deadwood', () => {
     const hand = [c('SPADE', 5), c('HEART', 5), c('CLOVER', 5), c('DIAMOND', 11)];
     expect(bestChinchonDeadwoodValue(hand)).toBe(10);
+  });
+});
+
+describe('chinchonDeadwoodBreakdown', () => {
+  it('lists the leftover deadwood cards and their values after the best meld split', () => {
+    // ♠5-♥5-♣5 set melds away; ♦K(10) and ♥3(3) are deadwood.
+    const hand = [c('SPADE', 5), c('HEART', 5), c('CLOVER', 5), c('DIAMOND', 13), c('HEART', 3)];
+    const bd = chinchonDeadwoodBreakdown(hand);
+    expect(bd.total).toBe(13);
+    expect([...bd.values].sort((a, b) => a - b)).toEqual([3, 10]);
+    expect(bd.cards).toHaveLength(2);
+  });
+
+  it('returns an empty breakdown when every card melds', () => {
+    const hand = [c('SPADE', 5), c('HEART', 5), c('CLOVER', 5)];
+    expect(chinchonDeadwoodBreakdown(hand)).toEqual({ cards: [], values: [], total: 0 });
   });
 });

--- a/frontend/src/utils/chinchonDeadwood.ts
+++ b/frontend/src/utils/chinchonDeadwood.ts
@@ -60,20 +60,37 @@ interface IndexedCard {
  * surfaced back to React is the integer deadwood total. */
 export function bestChinchonDeadwoodValue(hand: readonly Card[]): number {
   if (hand.length === 0) return 0;
-  const indexed: IndexedCard[] = hand.map((card, idx) => ({ idx, card }));
-  return search(indexed);
+  return search(hand.map((card, idx) => ({ idx, card }))).value;
 }
 
-function search(remaining: IndexedCard[]): number {
+/** The deadwood cards (and their values) left over by the best meld split. */
+export interface ChinchonDeadwoodBreakdown {
+  /** Cards not absorbed by any meld in the minimum-deadwood split. */
+  cards: Card[];
+  /** Each card's Chinchón point value, parallel to `cards`. */
+  values: number[];
+  /** Sum of `values` (the deadwood score). */
+  total: number;
+}
+
+/** Breakdown of which cards remain as deadwood in the best meld split, for a
+ * per-card hint like "5 + 3 + 2 = 10". */
+export function chinchonDeadwoodBreakdown(hand: readonly Card[]): ChinchonDeadwoodBreakdown {
+  const deadwood = search(hand.map((card, idx) => ({ idx, card }))).deadwood.map((d) => d.card);
+  const values = deadwood.map(chinchonCardValue);
+  return { cards: deadwood, values, total: values.reduce((a, b) => a + b, 0) };
+}
+
+function search(remaining: IndexedCard[]): { value: number; deadwood: IndexedCard[] } {
   const candidates = enumerateMelds(remaining);
-  let best = calcChinchonDeadwoodValue(remaining.map((r) => r.card));
+  let best = { value: calcChinchonDeadwoodValue(remaining.map((r) => r.card)), deadwood: remaining };
   if (candidates.length === 0) return best;
   for (const meld of candidates) {
     const meldIdx = new Set(meld.map((m) => m.idx));
     const rest = remaining.filter((r) => !meldIdx.has(r.idx));
-    const dv = search(rest);
-    if (dv < best) best = dv;
-    if (best === 0) break;
+    const sub = search(rest);
+    if (sub.value < best.value) best = sub;
+    if (best.value === 0) break;
   }
   return best;
 }

--- a/frontend/src/utils/chinchonDeadwood.ts
+++ b/frontend/src/utils/chinchonDeadwood.ts
@@ -76,9 +76,9 @@ export interface ChinchonDeadwoodBreakdown {
 /** Breakdown of which cards remain as deadwood in the best meld split, for a
  * per-card hint like "5 + 3 + 2 = 10". */
 export function chinchonDeadwoodBreakdown(hand: readonly Card[]): ChinchonDeadwoodBreakdown {
-  const deadwood = search(hand.map((card, idx) => ({ idx, card }))).deadwood.map((d) => d.card);
-  const values = deadwood.map(chinchonCardValue);
-  return { cards: deadwood, values, total: values.reduce((a, b) => a + b, 0) };
+  const best = search(hand.map((card, idx) => ({ idx, card })));
+  const cards = best.deadwood.map((d) => d.card);
+  return { cards, values: cards.map(chinchonCardValue), total: best.value };
 }
 
 function search(remaining: IndexedCard[]): { value: number; deadwood: IndexedCard[] } {


### PR DESCRIPTION
## 概要
Chinchón の `liveDeadwood` は賢く最小デッドウッドを計算しますが結果が数値だけで、どのカード構成でノック可能になるかが分かりませんでした。デッドウッドの内訳（例「5 + 3 = 8」）を表示します。

## 変更点
- `chinchonDeadwood.ts`: 最小デッドウッド探索を `searchBest`（値＋残存デッドウッドカードを返す）に統一し、`bestChinchonDeadwoodValue` はそれに委譲。`chinchonDeadwoodBreakdown(hand)`（残存カード／各点数／合計）を追加。
- `ChinchonPage.tsx`: `liveDeadwood` を `liveDeadwoodBreakdown` から導出（単一計算）。DISCARD フェーズでデッドウッドがあるとき `deadwoodBreakdown` のミュートヒント（`data-testid=chinchon-deadwood-breakdown`）を表示。選択変更に追従。
- `ja/en chinchon.json`: `deadwoodBreakdown` を追加。
- テスト: util（内訳・全メルド時は空）＋ページ（DISCARD で「5 + 3 = 8」表示）。

## テスト
- `bun run test -- --run chinchonDeadwood` → 13 passed
- `bun run test -- --run ChinchonPage` → 28 passed
- `bun run check` → エラーなし

Closes #2685