### PR TITLE
feat(spoilfive): animate pot increase with transient +NN

### DIFF
--- a/frontend/src/i18n/locales/en/spoilfive.json
+++ b/frontend/src/i18n/locales/en/spoilfive.json
@@ -16,6 +16,7 @@
   "trick": "Trick {{n}}",
   "trump": "Trump {{suit}}",
   "pot": "Pot {{n}}",
+  "potIncrease": "+{{n}}",
   "target": "Target {{n}}",
   "cards": "{{count}} cards",
   "roundTricks": "{{count}} round tricks",

--- a/frontend/src/i18n/locales/ja/spoilfive.json
+++ b/frontend/src/i18n/locales/ja/spoilfive.json
@@ -16,6 +16,7 @@
   "trick": "トリック {{n}}",
   "trump": "切り札 {{suit}}",
   "pot": "ポット {{n}}",
+  "potIncrease": "+{{n}}",
   "target": "目標 {{n}}点",
   "cards": "{{count}}枚",
   "roundTricks": "今ラウンド {{count}}トリック",

--- a/frontend/src/pages/SpoilFivePage.test.tsx
+++ b/frontend/src/pages/SpoilFivePage.test.tsx
@@ -70,6 +70,17 @@ describe('SpoilFivePage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', { cardIndex: 0 }));
   });
 
+  it('shows a transient +NN pot delta when the pot grows', async () => {
+    renderWithProviders(<SpoilFivePage />);
+    const card = await screen.findByAltText('♥ Q');
+    fireEvent.click(card);
+    const playBtn = await screen.findByRole('button', { name: '出す' });
+    mockExec.mockResolvedValue(spoilState); // pot 5 -> 10
+    fireEvent.click(playBtn);
+    const delta = await screen.findByTestId('spoilfive-pot-delta');
+    expect(delta).toHaveTextContent('+5');
+  });
+
   it('renders trick end with the next trick button', async () => {
     mockExec.mockResolvedValue(trickEndState);
     renderWithProviders(<SpoilFivePage />);

--- a/frontend/src/pages/SpoilFivePage.tsx
+++ b/frontend/src/pages/SpoilFivePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { spoilFiveApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -126,6 +126,22 @@ function SpoilFivePageContent() {
   const { cardWidth, isMobile } = useCardDimensions();
   const phaseNames = usePhaseNames('spoilfive', SPOIL_FIVE_PHASE_KEYS);
 
+  // Transient "+NN" feedback whenever the pot grows (e.g. a spoiled round carries
+  // the pot forward). Cleared after a short delay so the pulse is momentary.
+  const [potDelta, setPotDelta] = useState(0);
+  const prevPotRef = useRef<number | null>(null);
+  useEffect(() => {
+    const pot = state?.pot;
+    if (pot == null) return;
+    const prev = prevPotRef.current;
+    prevPotRef.current = pot;
+    if (prev != null && pot > prev) {
+      setPotDelta(pot - prev);
+      const id = setTimeout(() => setPotDelta(0), 2500);
+      return () => clearTimeout(id);
+    }
+  }, [state?.pot]);
+
   if (!state)
     return <GameSkeleton gameKey="spoilfive" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 5 }} />;
 
@@ -219,7 +235,17 @@ function SpoilFivePageContent() {
               <span className="mr-4">{t('round', { n: state.roundNumber })}</span>
               <span className="mr-4">{t('trick', { n: state.trickNumber })}</span>
               <span className="mr-4">{t('trump', { suit: trumpSymbol })}</span>
-              <span>{t('pot', { n: state.pot })}</span>
+              <span className={potDelta > 0 ? 'font-semibold text-ds-warning motion-safe:animate-pulse' : ''}>
+                {t('pot', { n: state.pot })}
+              </span>
+              {potDelta > 0 && (
+                <span
+                  data-testid="spoilfive-pot-delta"
+                  className="ml-1 text-sm font-semibold text-ds-warning motion-safe:animate-pulse"
+                >
+                  {t('potIncrease', { n: potDelta })}
+                </span>
+              )}
             </div>
 
             <div className={lgTwoColGrid}>


### PR DESCRIPTION
## Summary
Spoil Five's pot readout had no feedback when the pot grew (e.g. a spoiled round carries the pot forward). This adds a momentary pulse on the pot value plus a transient `+NN` delta that clears after a short delay.

- `SpoilFivePage.tsx`: track previous pot via `useRef`; on increase, set a `potDelta` state and clear it after 2.5s. Render `+NN` next to the pot with `motion-safe:animate-pulse` (respects reduced-motion).
- `potIncrease` i18n key added to ja/en.
- Unit test: playing a card that returns a higher-pot state surfaces `spoilfive-pot-delta` showing `+5`.

CUI is already covered — `SpoilFiveCuiPresenter.promptSpoil` prints the explicit pot amount, so no Go change is needed.

## Test plan
- [x] `bun run test -- --run SpoilFivePage` (11 passed)
- [x] `bun run check` (exit 0)

Closes #2675