### PR TITLE
feat(hearts): pass-direction arrow + remaining-card hint

### DIFF
--- a/frontend/src/i18n/locales/en/hearts.json
+++ b/frontend/src/i18n/locales/en/hearts.json
@@ -37,6 +37,7 @@
   "scoresTricks": "Tricks",
   "passButton": "Pass",
   "passProgress": "{{count}}/3 selected",
+  "passRemaining": "{{count}} more",
   "passTo": "{{direction}} → {{name}}",
   "playButton": "Play",
   "nextTrick": "Next Trick",

--- a/frontend/src/i18n/locales/ja/hearts.json
+++ b/frontend/src/i18n/locales/ja/hearts.json
@@ -37,6 +37,7 @@
   "scoresTricks": "トリック",
   "passButton": "パス",
   "passProgress": "{{count}}/3 枚選択済み",
+  "passRemaining": "あと{{count}}枚",
   "passTo": "{{direction}} → {{name}} へ",
   "playButton": "出す",
   "nextTrick": "次のトリック",

--- a/frontend/src/pages/HeartsPage.test.tsx
+++ b/frontend/src/pages/HeartsPage.test.tsx
@@ -192,6 +192,41 @@ describe('HeartsPage', () => {
     expect(screen.getByTestId('hearts-pass-progress')).toHaveTextContent('2/3');
   });
 
+  it('shows a directional arrow glyph for the pass direction', async () => {
+    mockExec.mockResolvedValue(passPhaseState); // left
+    renderWithProviders(<HeartsPage />);
+    const arrow = await screen.findByTestId('hearts-pass-arrow');
+    expect(arrow).toHaveTextContent('←');
+  });
+
+  it('shows the remaining-card count until 3 are selected', async () => {
+    mockExec.mockResolvedValue({
+      ...passPhaseState,
+      players: [
+        {
+          ...passPhaseState.players[0],
+          cards: [
+            { design: 'SPADE', value: 1 },
+            { design: 'HEART', value: 11 },
+            { design: 'CLOVER', value: 5 },
+          ],
+        },
+        ...passPhaseState.players.slice(1),
+      ],
+    });
+    renderWithProviders(<HeartsPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+
+    const badge = screen.getByTestId('hearts-pass-progress');
+    expect(badge).toHaveTextContent('あと3枚');
+
+    fireEvent.click(screen.getByAltText('♠ A').closest('button') as HTMLButtonElement);
+    fireEvent.click(screen.getByAltText('♥ J').closest('button') as HTMLButtonElement);
+    fireEvent.click(screen.getByAltText('♣ 5').closest('button') as HTMLButtonElement);
+    // All three selected: remaining hint disappears.
+    expect(badge).not.toHaveTextContent('あと');
+  });
+
   it('play button disabled when not 1 card selected', async () => {
     renderWithProviders(<HeartsPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '出す' })).toBeDisabled());

--- a/frontend/src/pages/HeartsPage.tsx
+++ b/frontend/src/pages/HeartsPage.tsx
@@ -93,6 +93,9 @@ const HEARTS_PHASE_KEYS: Readonly<Record<number, string>> = {
 
 const passDirectionKeys = ['left', 'right', 'across', 'none'] as const;
 
+/** Decorative arrow glyph per pass direction (0=left, 1=right, 2=across, 3=none). */
+const PASS_ARROWS = ['←', '→', '↑', ''] as const;
+
 /** Renders the Hearts game page with card passing, trick play, and scoring. */
 export const HeartsPage = withTutorial(HeartsPageContent, 'hearts', HT_TUTORIAL_STEPS);
 /** Inner content of the Hearts page, wrapped by TutorialProvider. */
@@ -262,16 +265,26 @@ function HeartsPageContent() {
               <div>
                 {/* Pass direction (pass phase) */}
                 {isPassPhase && (
-                  <div className="text-ds-warning text-center mb-2" data-tutorial="ht-pass-area">
-                    {(() => {
-                      const direction = t(`passDirection.${passDirectionKeys[state.passDirection]}`);
-                      if (state.passDirection === 3) return direction;
-                      const humanIdx = state.players.findIndex((p) => p.isHuman);
-                      const recipient = state.players[heartsPassTarget(humanIdx, state.passDirection)];
-                      return recipient
-                        ? t('passTo', { direction, name: playerName(recipient.id, recipient.isHuman) })
-                        : direction;
-                    })()}
+                  <div
+                    className="text-ds-warning text-center mb-2 flex items-center justify-center gap-1.5"
+                    data-tutorial="ht-pass-area"
+                  >
+                    {PASS_ARROWS[state.passDirection] && (
+                      <span aria-hidden="true" className="text-lg leading-none" data-testid="hearts-pass-arrow">
+                        {PASS_ARROWS[state.passDirection]}
+                      </span>
+                    )}
+                    <span>
+                      {(() => {
+                        const direction = t(`passDirection.${passDirectionKeys[state.passDirection]}`);
+                        if (state.passDirection === 3) return direction;
+                        const humanIdx = state.players.findIndex((p) => p.isHuman);
+                        const recipient = state.players[heartsPassTarget(humanIdx, state.passDirection)];
+                        return recipient
+                          ? t('passTo', { direction, name: playerName(recipient.id, recipient.isHuman) })
+                          : direction;
+                      })()}
+                    </span>
                   </div>
                 )}
 
@@ -446,6 +459,11 @@ function HeartsPageContent() {
                   className="self-center rounded-full bg-ds-surface border border-ds-accent px-2.5 py-0.5 text-ds-text-primary text-xs"
                 >
                   {t('passProgress', { count: selectedCardIndices.length })}
+                  {selectedCardIndices.length < 3 && (
+                    <span className="ml-1 text-ds-warning">
+                      {`· ${t('passRemaining', { count: 3 - selectedCardIndices.length })}`}
+                    </span>
+                  )}
                 </span>
               )}
               {isPassPhase && (


### PR DESCRIPTION
## Summary
In the Hearts pass phase, the recipient name (`passTo`) and an `N/3` progress badge already existed. This adds the two genuinely-missing pieces from #2544:

- **Directional arrow glyph** (`←`/`→`/`↑`, `aria-hidden`, `data-testid="hearts-pass-arrow"`) next to the pass-direction label so the direction reads at a glance. No arrow for the no-pass round.
- **Explicit remaining-card hint** appended to the progress badge (`· N more`) until 3 cards are selected, satisfying the "あと何枚" acceptance criterion.
- `passRemaining` i18n key added to ja/en.

## Test plan
- [x] `bun run test -- --run HeartsPage` (73 passed) — incl. new arrow + remaining-count tests
- [x] `bun run check` (exit 0)

Closes #2544