### PR TITLE
feat(freecell): auto-complete-ready badge + pulse

### DIFF
--- a/frontend/src/pages/FreeCellPage.test.tsx
+++ b/frontend/src/pages/FreeCellPage.test.tsx
@@ -187,6 +187,26 @@ describe('FreeCellPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
   });
 
+  it('shows the auto-complete-ready badge and pulses the button when the board is solvable', async () => {
+    // Single-card columns are trivially descending → deterministically winnable.
+    renderWithProviders(<FreeCellPage />);
+    const btn = await screen.findByRole('button', { name: 'オートコンプリート' });
+    expect(btn.className).toContain('animate-pulse');
+    expect(screen.getByTestId('freecell-autocomplete-ready-badge')).toBeInTheDocument();
+  });
+
+  it('does not pulse or show the badge when a column blocks auto-complete', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      // A higher rank stacked on a lower one cannot be auto-collected.
+      tableau: [[card('SPADE', 2), card('HEART', 5)], [], [], [], [], [], [], []],
+    });
+    renderWithProviders(<FreeCellPage />);
+    const btn = await screen.findByRole('button', { name: 'オートコンプリート' });
+    expect(btn.className).not.toContain('animate-pulse');
+    expect(screen.queryByTestId('freecell-autocomplete-ready-badge')).not.toBeInTheDocument();
+  });
+
   it('give up button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<FreeCellPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import type { FreeCellMoveZone, freecellApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
+import { AutoCompleteReadyBadge } from '../components/AutoCompleteReadyBadge';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
@@ -34,6 +35,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { FREECELL_HELP, parseFreecellCommand } from '../utils/cli/commands/freecellCommands';
 import { formatFreecellState } from '../utils/cli/formatters/freecellFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { freeCellAutoCompleteReady } from '../utils/freeCellAutoComplete';
 
 const FOUNDATION_SUITS = ['♠', '♣', '♥', '♦'] as const;
 
@@ -185,6 +187,8 @@ function FreeCellPageContent() {
   const emptyFreeCells = state.freeCells.filter((c) => c === null).length;
   const emptyTableauCols = state.tableau.filter((col: (Card | null)[]) => col.length === 0).length;
   const supermoveLimit = (1 + emptyFreeCells) * 2 ** emptyTableauCols;
+  // Auto-complete will deterministically win once every column is descending.
+  const autoCompleteReady = freeCellAutoCompleteReady(state.tableau);
 
   const isSourceSelected = (zone: string, col?: number, cell?: number, cardIndex?: number) =>
     selectedSource !== null &&
@@ -520,12 +524,15 @@ function FreeCellPageContent() {
                   </button>
                   <button
                     type="button"
-                    className={btnSuccess}
+                    className={`${btnSuccess}${
+                      autoCompleteReady && !loading && !isAutoCompleting ? ' animate-pulse ring-2 ring-ds-success' : ''
+                    }`}
                     onClick={handleAutoComplete}
                     disabled={loading || isAutoCompleting}
                   >
                     {t('autoComplete')}
                   </button>
+                  <AutoCompleteReadyBadge ready={autoCompleteReady} testId="freecell-autocomplete-ready-badge" />
                   <button
                     type="button"
                     className={btnDanger}

--- a/frontend/src/utils/freeCellAutoComplete.test.ts
+++ b/frontend/src/utils/freeCellAutoComplete.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { freeCellAutoCompleteReady } from './freeCellAutoComplete';
+
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('freeCellAutoCompleteReady', () => {
+  it('is ready for an empty board', () => {
+    expect(freeCellAutoCompleteReady([[], [], []])).toBe(true);
+  });
+
+  it('is ready when every column is strictly descending bottom-to-top', () => {
+    const tableau = [
+      [c('SPADE', 5), c('HEART', 3), c('CLOVER', 2)],
+      [c('DIAMOND', 13), c('SPADE', 1)],
+      [c('HEART', 7)],
+    ];
+    expect(freeCellAutoCompleteReady(tableau)).toBe(true);
+  });
+
+  it('is not ready when a column has a larger rank stacked on a smaller one', () => {
+    const tableau = [[c('SPADE', 2), c('HEART', 5)]]; // 5 on top of 2 — blocks
+    expect(freeCellAutoCompleteReady(tableau)).toBe(false);
+  });
+
+  it('is not ready on equal ranks (conservative)', () => {
+    const tableau = [[c('SPADE', 4), c('HEART', 4)]];
+    expect(freeCellAutoCompleteReady(tableau)).toBe(false);
+  });
+
+  it('ignores null slots when evaluating order', () => {
+    const tableau = [[c('SPADE', 9), null, c('HEART', 4), null]];
+    expect(freeCellAutoCompleteReady(tableau)).toBe(true);
+  });
+});

--- a/frontend/src/utils/freeCellAutoComplete.ts
+++ b/frontend/src/utils/freeCellAutoComplete.ts
@@ -1,0 +1,30 @@
+import type { Card } from '../types/card';
+
+/**
+ * Whether FreeCell's auto-complete is guaranteed to clear the entire board.
+ *
+ * The server's `AutoComplete` repeatedly sends any exposed (top-of-column or
+ * free-cell) card to its foundation until nothing more can move. That process
+ * fully clears the board exactly when every tableau column is **strictly
+ * descending in rank from bottom to top**: then the globally smallest unplayed
+ * card is always an exposed top card and is immediately playable, so the
+ * collect can never stall. Free cells hold single exposed cards and never
+ * block, so they don't affect the result.
+ *
+ * The check is intentionally conservative — equal ranks stacked across suits
+ * are technically clearable but report `false`, so the badge never promises a
+ * mop-up that could stall.
+ *
+ * @param tableau - The tableau columns (bottom card first; `null` slots ignored).
+ * @returns `true` when auto-complete will deterministically win the game.
+ */
+export function freeCellAutoCompleteReady(tableau: readonly (Card | null)[][]): boolean {
+  for (const col of tableau) {
+    const cards = col.filter((c): c is Card => c !== null);
+    for (let i = 0; i < cards.length - 1; i++) {
+      // cards[i] sits below cards[i + 1]; the lower card must rank higher.
+      if (cards[i].value <= cards[i + 1].value) return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
FreeCell's auto-complete button lacked the ready-affordance that Klondike/Spider have, and #2547's other ask (showing the supermove cap) was already implemented (`fc-supermove-limit` / `supermoveLimitLabel`). This delivers the missing piece:

- New pure util `freeCellAutoCompleteReady(tableau)`: returns `true` when the board is deterministically winnable — every tableau column strictly descending bottom-to-top, so the server's repeated foundation auto-collect can never stall (the globally-smallest unplayed card is always an exposed top). Conservative on equal ranks.
- `FreeCellPage`: pulses the auto-complete button (`animate-pulse ring-2 ring-ds-success`) and shows the shared `AutoCompleteReadyBadge` (`freecell-autocomplete-ready-badge`, `aria-live="polite"`, auto-dismiss) when ready. The button stays enabled regardless, since partial auto-collect is always valid.
- Badge reuses the existing `common:button.autoCompleteReady` key (no new strings needed); supermove label already localized.

## Test plan
- [x] `bun run test -- --run src/utils/freeCellAutoComplete.test.ts src/pages/FreeCellPage.test.tsx` (71 passed) — util truth table + ready/not-ready page tests
- [x] `bun run check` (exit 0)

Closes #2547