### PR TITLE
feat(pigtail): recent-center tail history strip

### DIFF
--- a/frontend/src/i18n/locales/en/pigtail.json
+++ b/frontend/src/i18n/locales/en/pigtail.json
@@ -16,7 +16,8 @@
     "center": "Center",
     "cards": "cards",
     "penalty": "PENALTY!",
-    "safe": "SAFE"
+    "safe": "SAFE",
+    "recentCenter": "Recent tail"
   },
   "tutorial": {
     "circleArea": "This is the circle pile. Cards are placed face down in a circle.",

--- a/frontend/src/i18n/locales/ja/pigtail.json
+++ b/frontend/src/i18n/locales/ja/pigtail.json
@@ -16,7 +16,8 @@
     "center": "場札",
     "cards": "枚",
     "penalty": "ペナルティ！",
-    "safe": "セーフ"
+    "safe": "セーフ",
+    "recentCenter": "直近のしっぽ"
   },
   "tutorial": {
     "circleArea": "これが山札です。カードが裏向きで円状に並んでいます。",

--- a/frontend/src/pages/PigsTailPage.test.tsx
+++ b/frontend/src/pages/PigsTailPage.test.tsx
@@ -147,6 +147,31 @@ describe('PigsTailPage', () => {
     expect(screen.getByTestId('pt-center-history')).toHaveTextContent('♠A');
   });
 
+  it('does not duplicate the center history when the top card is unchanged', async () => {
+    mockExec.mockResolvedValue({
+      ...baseState,
+      centerTop: { design: 'SPADE', value: 1 },
+      centerCount: 3,
+      circleCount: 52,
+    });
+    renderWithProviders(<PigsTailPage />);
+    const strip = await screen.findByTestId('pt-center-history');
+    expect(strip.children).toHaveLength(1);
+
+    // A fresh draw signature (circleCount changed) but the same center top must
+    // not append a duplicate entry.
+    mockExec.mockResolvedValue({
+      ...baseState,
+      centerTop: { design: 'SPADE', value: 1 },
+      centerCount: 3,
+      circleCount: 51,
+    });
+    fireEvent.click(screen.getByRole('button', { name: '山札から引く' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw'));
+    await waitFor(() => expect(screen.getByText((_, el) => el?.textContent === '山札: 51')).toBeInTheDocument());
+    expect(screen.getByTestId('pt-center-history').children).toHaveLength(1);
+  });
+
   it('clears the center history when the pile is collected (centerCount 0)', async () => {
     mockExec.mockResolvedValue({ ...baseState, centerTop: { design: 'SPADE', value: 1 }, centerCount: 3 });
     renderWithProviders(<PigsTailPage />);

--- a/frontend/src/pages/PigsTailPage.test.tsx
+++ b/frontend/src/pages/PigsTailPage.test.tsx
@@ -134,6 +134,29 @@ describe('PigsTailPage', () => {
     expect(center).toHaveTextContent('?');
   });
 
+  it('accumulates a recent-center history strip across draws', async () => {
+    mockExec.mockResolvedValue({ ...baseState, centerTop: { design: 'SPADE', value: 1 }, centerCount: 3 });
+    renderWithProviders(<PigsTailPage />);
+    const strip = await screen.findByTestId('pt-center-history');
+    expect(strip).toHaveTextContent('♠A');
+
+    mockExec.mockResolvedValue({ ...baseState, centerTop: { design: 'HEART', value: 3 }, centerCount: 4 });
+    fireEvent.click(screen.getByRole('button', { name: '山札から引く' }));
+    await waitFor(() => expect(screen.getByTestId('pt-center-history')).toHaveTextContent('♥3'));
+    // The earlier center top is still part of the tail.
+    expect(screen.getByTestId('pt-center-history')).toHaveTextContent('♠A');
+  });
+
+  it('clears the center history when the pile is collected (centerCount 0)', async () => {
+    mockExec.mockResolvedValue({ ...baseState, centerTop: { design: 'SPADE', value: 1 }, centerCount: 3 });
+    renderWithProviders(<PigsTailPage />);
+    await screen.findByTestId('pt-center-history');
+
+    mockExec.mockResolvedValue({ ...baseState, centerTop: null, centerCount: 0 });
+    fireEvent.click(screen.getByRole('button', { name: '山札から引く' }));
+    await waitFor(() => expect(screen.queryByTestId('pt-center-history')).not.toBeInTheDocument());
+  });
+
   it('draw button is disabled on game end', async () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<PigsTailPage />);

--- a/frontend/src/pages/PigsTailPage.tsx
+++ b/frontend/src/pages/PigsTailPage.tsx
@@ -37,6 +37,9 @@ function centerCardLabel(card: Card): string {
   return `${SUIT_SYMBOLS[card.design] ?? '?'}${valueName(card.value)}`;
 }
 
+/** Max number of recent center-pile tops kept in the client-side tail strip. */
+const CENTER_HISTORY_MAX = 6;
+
 const PT_TUTORIAL_STEPS: TutorialStep[] = [
   {
     target: '[data-tutorial="pt-circle-area"]',
@@ -124,12 +127,25 @@ function PigsTailPageContent() {
   // new lastDrawCard. We key on centerCount+circleCount to detect fresh draws,
   // not just spurious re-renders.
   const [penaltyFlash, setPenaltyFlash] = useState(0);
+  // Best-effort recent-center strip: the API exposes no history, so we
+  // accumulate each new center top as it appears and reset when the pile is
+  // collected (centerCount drops to 0, e.g. after a penalty).
+  const [centerHistory, setCenterHistory] = useState<Card[]>([]);
   const prevDrawSigRef = useRef<string>('');
   useEffect(() => {
     if (!state) return;
     const sig = `${state.circleCount}-${state.centerCount}-${state.lastDrawCard ? `${state.lastDrawCard.design}${state.lastDrawCard.value}` : 'none'}`;
-    if (sig !== prevDrawSigRef.current && state.lastPenalty) {
-      setPenaltyFlash(Date.now());
+    if (sig !== prevDrawSigRef.current) {
+      if (state.lastPenalty) {
+        setPenaltyFlash(Date.now());
+      }
+      const top = state.centerTop;
+      setCenterHistory((prev) => {
+        if (state.centerCount === 0 || !top) return [];
+        const last = prev[prev.length - 1];
+        if (last && last.design === top.design && last.value === top.value) return prev;
+        return [...prev, top].slice(-CENTER_HISTORY_MAX);
+      });
     }
     prevDrawSigRef.current = sig;
   }, [state]);
@@ -196,6 +212,25 @@ function PigsTailPageContent() {
                 >
                   {state.centerTop ? centerCardLabel(state.centerTop) : '-'}
                 </div>
+                {centerHistory.length > 0 && (
+                  <div className="mt-1.5">
+                    <div className="text-[10px] text-ds-text-muted mb-0.5">{t('label.recentCenter')}</div>
+                    <div className="flex items-center justify-center gap-1" data-testid="pt-center-history">
+                      {centerHistory.map((c, i) => (
+                        <span
+                          key={`${c.design}-${c.value}-${i}`}
+                          className={`px-1 py-0.5 rounded text-xs font-semibold ${
+                            i === centerHistory.length - 1
+                              ? 'bg-ds-warning/50 text-white'
+                              : 'bg-black/20 text-ds-text-muted'
+                          }`}
+                        >
+                          {centerCardLabel(c)}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
Pig's Tail's center top already shows rank+suit (`centerCardLabel`, #2572's AC1 was already satisfied by a prior change). This delivers the missing AC2 — a recent center-tail history so players can read the suit-chain ("tail") that drives penalties:

- Since `PigsTailResponse` exposes no history array, the page accumulates each new center top client-side as it appears (deduped against the current top, capped at 6) and resets the strip when the pile is collected (`centerCount` drops to 0, e.g. after a penalty).
- Renders a small strip (`pt-center-history`) below the center pile with the latest card highlighted. Existing penalty screen-flash is untouched.
- `label.recentCenter` i18n added to ja/en.

Note: this is a best-effort reconstruction of observed center tops — the backend exposes no authoritative history. The CUI presenter already prints the full top card, so no Go change is needed.

## Test plan
- [x] `bun run test -- --run src/pages/PigsTailPage.test.tsx` (17 passed) — accumulation across draws + reset-on-collect
- [x] `bun run check` (exit 0)

Closes #2572