### PR TITLE
feat(bigtwo): hand sort buttons + table play-type label

### DIFF
--- a/frontend/src/i18n/locales/en/bigtwo.json
+++ b/frontend/src/i18n/locales/en/bigtwo.json
@@ -46,5 +46,12 @@
     "fullHouse": "Full House",
     "fourOfAKind": "Four of a Kind",
     "straightFlush": "Straight Flush"
-  }
+  },
+  "sort": {
+    "strength": "Strength",
+    "suit": "Suit",
+    "number": "Rank",
+    "label": "Sort hand"
+  },
+  "tablePlayLabel": "Play"
 }

--- a/frontend/src/i18n/locales/ja/bigtwo.json
+++ b/frontend/src/i18n/locales/ja/bigtwo.json
@@ -46,5 +46,12 @@
     "fullHouse": "フルハウス",
     "fourOfAKind": "フォーカード",
     "straightFlush": "ストレートフラッシュ"
-  }
+  },
+  "sort": {
+    "strength": "強さ順",
+    "suit": "スート順",
+    "number": "数字順",
+    "label": "手札の並べ替え"
+  },
+  "tablePlayLabel": "場の役"
 }

--- a/frontend/src/pages/BigTwoPage.test.tsx
+++ b/frontend/src/pages/BigTwoPage.test.tsx
@@ -112,4 +112,34 @@ describe('BigTwoPage', () => {
     fireEvent.click(retry);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', []));
   });
+
+  it('renders the hand sort buttons', async () => {
+    renderWithProviders(<BigTwoPage />);
+    expect(await screen.findByTestId('bt-sort-strength')).toBeInTheDocument();
+    expect(screen.getByTestId('bt-sort-suit')).toBeInTheDocument();
+    expect(screen.getByTestId('bt-sort-number')).toBeInTheDocument();
+  });
+
+  it('keeps the selected card index stable across hand sorting', async () => {
+    renderWithProviders(<BigTwoPage />);
+    // Select ♦7 (original index 2), then re-sort by suit (which moves ♦ to the front).
+    fireEvent.click(await screen.findByTestId('hand-card-2'));
+    fireEvent.click(screen.getByTestId('bt-sort-suit'));
+    // The play command still references the original dealt index.
+    fireEvent.click(screen.getByTestId('play-button'));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', [2]));
+  });
+
+  it('shows the table play-type label for the cards in play', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        tableCards: [card('SPADE', 3), card('SPADE', 5), card('SPADE', 7), card('SPADE', 9), card('SPADE', 11)],
+        tablePlayType: 5, // flush
+        currentTurn: 1,
+      }),
+    );
+    renderWithProviders(<BigTwoPage />);
+    const label = await screen.findByTestId('bt-table-playtype');
+    expect(label).toHaveTextContent('フラッシュ');
+  });
 });

--- a/frontend/src/pages/BigTwoPage.tsx
+++ b/frontend/src/pages/BigTwoPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
@@ -19,9 +19,11 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { BigTwoResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
+import { type BigTwoSortMode, bigTwoPlayTypeKey, sortedBigTwoHand } from '../utils/bigTwoSort';
 import {
   BIGTWO_HELP,
   type BigTwoCliArgs,
@@ -29,6 +31,13 @@ import {
   parseBigTwoCommand,
 } from '../utils/cli/commands/bigtwoCommands';
 import type { CliGameConfig } from '../utils/cli/types';
+
+/** Hand sort options for the Big Two footer. */
+const BIGTWO_SORT_MODES: { mode: BigTwoSortMode; labelKey: string }[] = [
+  { mode: 'strength', labelKey: 'sort.strength' },
+  { mode: 'suit', labelKey: 'sort.suit' },
+  { mode: 'number', labelKey: 'sort.number' },
+];
 
 const DIFFICULTY_OPTIONS = [
   { value: '0', label: 'Easy' },
@@ -85,6 +94,7 @@ function BigTwoPageContent() {
     retry,
   } = useBigTwoGame();
   const { cardWidth } = useCardDimensions();
+  const [sortMode, setSortMode] = useState<BigTwoSortMode>('strength');
   const {
     hint: frontendHint,
     hintEnabled: frontendHintEnabled,
@@ -182,7 +192,20 @@ function BigTwoPageContent() {
 
             {/* Table cards */}
             <div className="py-3 bg-black/20 rounded-lg" data-tutorial="bt-table-cards">
-              <div className="text-center text-xs text-ds-text-muted mb-2">{t('tableCards')}</div>
+              <div className="text-center text-xs text-ds-text-muted mb-2 flex items-center justify-center gap-2">
+                <span>{t('tableCards')}</span>
+                {(() => {
+                  const key = bigTwoPlayTypeKey(state.tablePlayType);
+                  return key && state.tableCards.length > 0 ? (
+                    <span
+                      data-testid="bt-table-playtype"
+                      className="rounded-full bg-ds-accent/30 px-2 py-0.5 text-ds-text-primary font-semibold"
+                    >
+                      {`${t('tablePlayLabel')}: ${t(`playType.${key}`)}`}
+                    </span>
+                  ) : null;
+                })()}
+              </div>
               <div className="flex justify-center gap-2 min-h-[60px]">
                 {state.tableCards.length === 0 ? (
                   <span className="text-ds-text-muted text-sm self-center">{t('tableEmpty')}</span>
@@ -198,19 +221,35 @@ function BigTwoPageContent() {
                 <span>{tc('player.you')}</span>
                 {human.isFinished && <span className="font-bold">{t(`rank.${human.rank}`)}</span>}
               </div>
+              {human.cards.length > 0 && (
+                <fieldset className="flex justify-center gap-1.5 mb-2 border-0 p-0 m-0">
+                  <legend className="sr-only">{t('sort.label')}</legend>
+                  {BIGTWO_SORT_MODES.map(({ mode, labelKey }) => (
+                    <button
+                      key={mode}
+                      type="button"
+                      onClick={() => setSortMode(mode)}
+                      className={sortMode === mode ? `${btnPrimary} min-w-[64px]` : `${btnSecondary} min-w-[64px]`}
+                      data-testid={`bt-sort-${mode}`}
+                    >
+                      {t(labelKey)}
+                    </button>
+                  ))}
+                </fieldset>
+              )}
               <div className="flex flex-wrap justify-center gap-2">
-                {human.cards.map((c, i) => (
+                {sortedBigTwoHand(human.cards, sortMode).map(({ card, index }) => (
                   <button
-                    key={i}
+                    key={index}
                     type="button"
-                    onClick={() => isHumanTurn && toggleCardSelection(i)}
+                    onClick={() => isHumanTurn && toggleCardSelection(index)}
                     disabled={!isHumanTurn}
                     className={`rounded transition-all ${
-                      selectedIndices.includes(i) ? 'ring-2 ring-ds-info -translate-y-2' : ''
+                      selectedIndices.includes(index) ? 'ring-2 ring-ds-info -translate-y-2' : ''
                     } ${isHumanTurn ? 'cursor-pointer hover:opacity-90' : 'cursor-default'}`}
-                    data-testid={`hand-card-${i}`}
+                    data-testid={`hand-card-${index}`}
                   >
-                    <AnimatedCard card={c} width={cardWidth} />
+                    <AnimatedCard card={card} width={cardWidth} />
                   </button>
                 ))}
               </div>

--- a/frontend/src/utils/bigTwoSort.test.ts
+++ b/frontend/src/utils/bigTwoSort.test.ts
@@ -49,10 +49,17 @@ describe('sortedBigTwoHand', () => {
 });
 
 describe('bigTwoPlayTypeKey', () => {
-  it('maps play types 1-8 to keys', () => {
-    expect(bigTwoPlayTypeKey(1)).toBe('single');
-    expect(bigTwoPlayTypeKey(6)).toBe('fullHouse');
-    expect(bigTwoPlayTypeKey(8)).toBe('straightFlush');
+  it('maps every play type 1-8 to its key', () => {
+    expect([1, 2, 3, 4, 5, 6, 7, 8].map(bigTwoPlayTypeKey)).toEqual([
+      'single',
+      'pair',
+      'triple',
+      'straight',
+      'flush',
+      'fullHouse',
+      'fourOfAKind',
+      'straightFlush',
+    ]);
   });
 
   it('returns null for invalid/empty (0)', () => {

--- a/frontend/src/utils/bigTwoSort.test.ts
+++ b/frontend/src/utils/bigTwoSort.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { bigTwoCardStrength, bigTwoPlayTypeKey, bigTwoValueStrength, sortedBigTwoHand } from './bigTwoSort';
+
+const c = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('bigTwoValueStrength', () => {
+  it('ranks 2 highest, then A, then 3..K ascending', () => {
+    expect(bigTwoValueStrength(2)).toBe(12);
+    expect(bigTwoValueStrength(1)).toBe(11);
+    expect(bigTwoValueStrength(3)).toBe(0);
+    expect(bigTwoValueStrength(13)).toBe(10);
+  });
+});
+
+describe('bigTwoCardStrength', () => {
+  it('orders by value first then suit (♦<♣<♥<♠)', () => {
+    expect(bigTwoCardStrength(c('SPADE', 2))).toBeGreaterThan(bigTwoCardStrength(c('DIAMOND', 2)));
+    expect(bigTwoCardStrength(c('DIAMOND', 2))).toBeGreaterThan(bigTwoCardStrength(c('SPADE', 1)));
+  });
+});
+
+describe('sortedBigTwoHand', () => {
+  const hand = [c('SPADE', 3), c('DIAMOND', 2), c('HEART', 1), c('CLOVER', 3)];
+
+  it('keeps each card paired with its original index', () => {
+    const out = sortedBigTwoHand(hand, 'strength');
+    for (const { card, index } of out) {
+      expect(hand[index]).toBe(card);
+    }
+  });
+
+  it('strength mode puts the 2 last and the lowest 3 first', () => {
+    const out = sortedBigTwoHand(hand, 'strength');
+    expect(out[0].card.value).toBe(3);
+    expect(out[out.length - 1].card).toEqual(c('DIAMOND', 2));
+  });
+
+  it('suit mode groups by suit ♦♣♥♠', () => {
+    const out = sortedBigTwoHand(hand, 'suit');
+    expect(out.map((o) => o.card.design)).toEqual(['DIAMOND', 'CLOVER', 'HEART', 'SPADE']);
+  });
+
+  it('number mode uses natural rank (A first, 2 second)', () => {
+    const out = sortedBigTwoHand(hand, 'number');
+    expect(out[0].card.value).toBe(1); // Ace
+    expect(out[1].card.value).toBe(2);
+  });
+});
+
+describe('bigTwoPlayTypeKey', () => {
+  it('maps play types 1-8 to keys', () => {
+    expect(bigTwoPlayTypeKey(1)).toBe('single');
+    expect(bigTwoPlayTypeKey(6)).toBe('fullHouse');
+    expect(bigTwoPlayTypeKey(8)).toBe('straightFlush');
+  });
+
+  it('returns null for invalid/empty (0)', () => {
+    expect(bigTwoPlayTypeKey(0)).toBeNull();
+    expect(bigTwoPlayTypeKey(99)).toBeNull();
+  });
+});

--- a/frontend/src/utils/bigTwoSort.ts
+++ b/frontend/src/utils/bigTwoSort.ts
@@ -1,0 +1,67 @@
+import type { Card } from '../types/card';
+
+/**
+ * Big Two value strength (2 is highest, then A, K…3). Mirrors
+ * `bigTwoValueStrength` in internal/domain/BigTwoEval.go: 2→12, A→11, else value-3.
+ */
+export function bigTwoValueStrength(value: number): number {
+  if (value === 2) return 12;
+  if (value === 1) return 11; // Ace
+  return value - 3;
+}
+
+/** Suit strength ♦<♣<♥<♠ (0-3), mirroring `bigTwoSuitStrength`. */
+const SUIT_STRENGTH: Record<string, number> = { DIAMOND: 0, CLOVER: 1, HEART: 2, SPADE: 3 };
+
+/** Combined Big Two card strength = valueStrength*4 + suitStrength (matches `BigTwoCardStrength`). */
+export function bigTwoCardStrength(card: Card): number {
+  return bigTwoValueStrength(card.value) * 4 + (SUIT_STRENGTH[card.design] ?? 0);
+}
+
+/** Hand sort modes offered in the UI. */
+export type BigTwoSortMode = 'strength' | 'suit' | 'number';
+
+/**
+ * Returns the hand reordered for display under `mode`, each entry carrying its
+ * **original** index so selection/play commands keep referencing the
+ * server-dealt position (sorting never invalidates the selected indices).
+ *
+ * - `strength`: Big Two play strength (2 high), suit as tiebreak.
+ * - `suit`: grouped by suit (♦♣♥♠), strength within each suit.
+ * - `number`: natural rank order (A,2,3…K), suit as tiebreak.
+ */
+export function sortedBigTwoHand(cards: readonly Card[], mode: BigTwoSortMode): { card: Card; index: number }[] {
+  const items = cards.map((card, index) => ({ card, index }));
+  const suit = (c: Card) => SUIT_STRENGTH[c.design] ?? 0;
+  const comparators: Record<BigTwoSortMode, (a: Card, b: Card) => number> = {
+    strength: (a, b) => bigTwoCardStrength(a) - bigTwoCardStrength(b),
+    suit: (a, b) => suit(a) - suit(b) || bigTwoValueStrength(a.value) - bigTwoValueStrength(b.value),
+    number: (a, b) => a.value - b.value || suit(a) - suit(b),
+  };
+  const cmp = comparators[mode];
+  return [...items].sort((a, b) => cmp(a.card, b.card));
+}
+
+/** i18n key suffix for a Big Two table play type (1-8), or `null` when none is on the table. */
+export function bigTwoPlayTypeKey(playType: number): string | null {
+  switch (playType) {
+    case 1:
+      return 'single';
+    case 2:
+      return 'pair';
+    case 3:
+      return 'triple';
+    case 4:
+      return 'straight';
+    case 5:
+      return 'flush';
+    case 6:
+      return 'fullHouse';
+    case 7:
+      return 'fourOfAKind';
+    case 8:
+      return 'straightFlush';
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## Summary
Big Two's 13-card hand was shown in dealt order with no way to sort (unlike Daifugo), and the table cards carried no play-type label. This adds both, frontend-only:

- **Hand sort** — strength / suit / rank buttons above the hand. Sorting is client-side: it renders a reordered view whose entries keep their **original dealt index**, so `toggleCardSelection`/`play` always reference the server's positions and the selected indices never break across re-sorts (covered by a test).
- **Table play-type label** — the table-cards block now shows e.g. "場の役: フラッシュ" derived from the existing `tablePlayType` response field (no backend change).
- New `bigTwoSort` util mirrors `BigTwoEval` ordering (2 highest, suits ♦♣♥♠) + `bigTwoPlayTypeKey`, with unit tests.
- `sort.*` / `tablePlayLabel` i18n added (ja/en); reuses the existing `playType.*` keys.

Note: Daifugo's sort is server-side (`sortMode`); Big Two has no such command, so this is intentionally a client-side display sort — chosen so no backend change is needed.

## Test plan
- [x] `bun run test -- --run src/utils/bigTwoSort.test.ts src/pages/BigTwoPage.test.tsx` (20 passed)
- [x] `bun run check` (exit 0)

Closes #2532