### PR TITLE
feat(irishpoker): kept-cards + tentative-hand preview at discard

### DIFF
--- a/frontend/src/i18n/locales/en/irishpoker.json
+++ b/frontend/src/i18n/locales/en/irishpoker.json
@@ -19,7 +19,9 @@
     "confirm": "Discard {{card}}?",
     "confirmYes": "Confirm",
     "confirmNo": "Cancel",
-    "selectedCount": "{{n}}/{{total}} selected"
+    "selectedCount": "{{n}}/{{total}} selected",
+    "keepLabel": "Keep",
+    "previewHand": "Tentative hand"
   },
   "rebuy": {
     "prompt": "Rebuy? ({{chips}} chips, {{used}}/{{max}} used)",
@@ -88,5 +90,17 @@
     "decentHandRank": "Decent hand — call recommended",
     "weakHandRank": "Weak hand — fold recommended",
     "discardWeakest": "Discard the weakest card"
+  },
+  "hand": {
+    "highCard": "High Card",
+    "onePair": "One Pair",
+    "twoPair": "Two Pair",
+    "threeOfAKind": "Three of a Kind",
+    "straight": "Straight",
+    "flush": "Flush",
+    "fullHouse": "Full House",
+    "fourOfAKind": "Four of a Kind",
+    "straightFlush": "Straight Flush",
+    "royalFlush": "Royal Flush"
   }
 }

--- a/frontend/src/i18n/locales/ja/irishpoker.json
+++ b/frontend/src/i18n/locales/ja/irishpoker.json
@@ -19,7 +19,9 @@
     "confirm": "{{card}} を捨てますか？",
     "confirmYes": "確定",
     "confirmNo": "キャンセル",
-    "selectedCount": "{{n}}/{{total}} 枚選択済み"
+    "selectedCount": "{{n}}/{{total}} 枚選択済み",
+    "keepLabel": "残す札",
+    "previewHand": "暫定役"
   },
   "rebuy": {
     "prompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済)",
@@ -88,5 +90,17 @@
     "decentHandRank": "まずまずのハンド — コール推奨",
     "weakHandRank": "弱いハンド — フォールド推奨",
     "discardWeakest": "最も弱いカードを捨てましょう"
+  },
+  "hand": {
+    "highCard": "ハイカード",
+    "onePair": "ワンペア",
+    "twoPair": "ツーペア",
+    "threeOfAKind": "スリーカード",
+    "straight": "ストレート",
+    "flush": "フラッシュ",
+    "fullHouse": "フルハウス",
+    "fourOfAKind": "フォーカード",
+    "straightFlush": "ストレートフラッシュ",
+    "royalFlush": "ロイヤルフラッシュ"
   }
 }

--- a/frontend/src/pages/PineapplePage.test.tsx
+++ b/frontend/src/pages/PineapplePage.test.tsx
@@ -350,6 +350,13 @@ describe('PineapplePage', () => {
     expect(preview).not.toHaveTextContent('暫定役');
   });
 
+  it('does not show the Irish Poker discard preview outside the discard phase', async () => {
+    mockIrishExec.mockResolvedValue({ ...preFlopState, initialDealCount: 4 });
+    renderWithProviders(<PineapplePage variant="irishpoker" />);
+    await waitFor(() => expect(screen.getByText('あなたの手札')).toBeInTheDocument());
+    expect(screen.queryByTestId('irishpoker-discard-preview')).not.toBeInTheDocument();
+  });
+
   it('does not show the Irish Poker discard preview for the Pineapple variant', async () => {
     mockExec.mockResolvedValue(discardState);
     renderWithProviders(<PineapplePage />);

--- a/frontend/src/pages/PineapplePage.test.tsx
+++ b/frontend/src/pages/PineapplePage.test.tsx
@@ -1,16 +1,18 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { pineappleApi } from '../api/gameApi';
+import { irishPokerApi, pineappleApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { PineappleResponse } from '../types/card';
 import { PineapplePage } from './PineapplePage';
 
 vi.mock('../api/gameApi', () => ({
   pineappleApi: { exec: vi.fn() },
-  actionLogApi: { pineapple: vi.fn() },
+  irishPokerApi: { exec: vi.fn() },
+  actionLogApi: { pineapple: vi.fn(), irishpoker: vi.fn() },
 }));
 
 const mockExec = vi.mocked(pineappleApi.exec);
+const mockIrishExec = vi.mocked(irishPokerApi.exec);
 
 /** Helper: base human player */
 const humanPlayer = (overrides: Partial<import('../types/card').HoldemPlayerData> = {}) => ({
@@ -242,6 +244,52 @@ describe('PineapplePage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '確定' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('discard', undefined, { cardIdxs: [0] }));
+  });
+
+  it('previews the kept cards and tentative hand for Irish Poker discard', async () => {
+    const irishDiscardState: PineappleResponse = {
+      ...discardState,
+      initialDealCount: 4,
+      players: [
+        humanPlayer({
+          cards: [
+            { design: 'SPADE', value: 1 },
+            { design: 'HEART', value: 1 },
+            { design: 'DIAMOND', value: 5 },
+            { design: 'CLOVER', value: 8 },
+          ],
+        }),
+        cpuPlayer(1),
+        cpuPlayer(2),
+        cpuPlayer(3),
+      ],
+      communityCards: [
+        { design: 'SPADE', value: 10 },
+        { design: 'HEART', value: 5 },
+        { design: 'DIAMOND', value: 8 },
+      ],
+      discardDone: [false, true, true, true],
+    };
+    mockIrishExec.mockResolvedValue(irishDiscardState);
+    renderWithProviders(<PineapplePage variant="irishpoker" />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+
+    // Discard ♦5 and ♣8, keeping the pair of Aces.
+    fireEvent.click(screen.getByAltText('♦ 5').closest('button') as HTMLButtonElement);
+    fireEvent.click(screen.getByAltText('♣ 8').closest('button') as HTMLButtonElement);
+
+    const preview = await screen.findByTestId('irishpoker-discard-preview');
+    // Kept ♠A ♥A + board makes one pair.
+    expect(preview).toHaveTextContent('ワンペア');
+  });
+
+  it('does not show the Irish Poker discard preview for the Pineapple variant', async () => {
+    mockExec.mockResolvedValue(discardState);
+    renderWithProviders(<PineapplePage />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+    const cardButtons = screen.getAllByRole('button').filter((btn) => btn.getAttribute('aria-pressed') !== null);
+    fireEvent.click(cardButtons[0]);
+    expect(screen.queryByTestId('irishpoker-discard-preview')).not.toBeInTheDocument();
   });
 
   it('cancels the discard confirm step and returns to selection', async () => {

--- a/frontend/src/pages/PineapplePage.test.tsx
+++ b/frontend/src/pages/PineapplePage.test.tsx
@@ -283,6 +283,73 @@ describe('PineapplePage', () => {
     expect(preview).toHaveTextContent('ワンペア');
   });
 
+  it('evaluates the best five when the board has more than three cards', async () => {
+    const irishRiverState: PineappleResponse = {
+      ...discardState,
+      initialDealCount: 4,
+      players: [
+        humanPlayer({
+          cards: [
+            { design: 'SPADE', value: 1 },
+            { design: 'HEART', value: 1 },
+            { design: 'DIAMOND', value: 5 },
+            { design: 'CLOVER', value: 8 },
+          ],
+        }),
+        cpuPlayer(1),
+        cpuPlayer(2),
+        cpuPlayer(3),
+      ],
+      // Five board cards → kept(2) + board(5) = 7, so holdemBestFive picks the best 5.
+      communityCards: [
+        { design: 'SPADE', value: 10 },
+        { design: 'HEART', value: 5 },
+        { design: 'DIAMOND', value: 8 },
+        { design: 'CLOVER', value: 2 },
+        { design: 'HEART', value: 9 },
+      ],
+      discardDone: [false, true, true, true],
+    };
+    mockIrishExec.mockResolvedValue(irishRiverState);
+    renderWithProviders(<PineapplePage variant="irishpoker" />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+    fireEvent.click(screen.getByAltText('♦ 5').closest('button') as HTMLButtonElement);
+    fireEvent.click(screen.getByAltText('♣ 8').closest('button') as HTMLButtonElement);
+    const preview = await screen.findByTestId('irishpoker-discard-preview');
+    expect(preview).toHaveTextContent('ワンペア');
+  });
+
+  it('shows kept cards without a hand badge when the board is too small to evaluate', async () => {
+    const irishNoBoardState: PineappleResponse = {
+      ...discardState,
+      initialDealCount: 4,
+      players: [
+        humanPlayer({
+          cards: [
+            { design: 'SPADE', value: 1 },
+            { design: 'HEART', value: 1 },
+            { design: 'DIAMOND', value: 5 },
+            { design: 'CLOVER', value: 8 },
+          ],
+        }),
+        cpuPlayer(1),
+        cpuPlayer(2),
+        cpuPlayer(3),
+      ],
+      communityCards: [], // fewer than 3 board cards → no hand can be formed
+      discardDone: [false, true, true, true],
+    };
+    mockIrishExec.mockResolvedValue(irishNoBoardState);
+    renderWithProviders(<PineapplePage variant="irishpoker" />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+    fireEvent.click(screen.getByAltText('♦ 5').closest('button') as HTMLButtonElement);
+    fireEvent.click(screen.getByAltText('♣ 8').closest('button') as HTMLButtonElement);
+    const preview = await screen.findByTestId('irishpoker-discard-preview');
+    // Kept cards are shown, but no tentative-hand badge.
+    expect(preview).toHaveTextContent('残す札');
+    expect(preview).not.toHaveTextContent('暫定役');
+  });
+
   it('does not show the Irish Poker discard preview for the Pineapple variant', async () => {
     mockExec.mockResolvedValue(discardState);
     renderWithProviders(<PineapplePage />);

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -46,6 +46,7 @@ import { formatPineappleState } from '../utils/cli/formatters/pineappleFormatter
 import type { CliGameConfig } from '../utils/cli/types';
 import { holdemBestFive } from '../utils/holdemBestFive';
 import { findPlayerName } from '../utils/playerUtils';
+import { evaluateFiveCardHand, pokerHandKey } from '../utils/pokerSquaresUtils';
 
 /** Pineapple Poker tutorial step definitions. */
 const PN_TUTORIAL_STEPS: TutorialStep[] = [
@@ -231,6 +232,22 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
   const canDiscard = isDiscardPhase && !humanDiscardDone;
   // Cards the player must discard down to 2: Pineapple/Crazy = 1, Irish = 2.
   const discardCount = Math.max(1, (state?.initialDealCount ?? 3) - 2);
+  // Irish Poker discards 2 of 4 hole cards; while choosing, preview the 2 cards
+  // that would be kept plus the best hand they make with the current board.
+  const discardPreview = useMemo(() => {
+    if (variant !== 'irishpoker' || !isDiscardPhase) return null;
+    const hole = humanPlayer?.cards ?? [];
+    if (hole.length === 0 || selectedDiscards.length !== discardCount) return null;
+    const kept = hole.filter((_, i) => !selectedDiscards.includes(i));
+    const all = [...kept, ...(state?.communityCards ?? [])];
+    let handKey: string | null = null;
+    if (all.length >= 5) {
+      const five = all.length === 5 ? all : (holdemBestFive(all)?.map((i) => all[i]) ?? null);
+      const rank = five ? evaluateFiveCardHand(five) : null;
+      handKey = rank == null ? null : pokerHandKey(rank);
+    }
+    return { kept, handKey };
+  }, [variant, isDiscardPhase, humanPlayer, state?.communityCards, selectedDiscards, discardCount]);
   const toggleDiscard = (idx: number) => {
     if (!canDiscard) return;
     setSelectedDiscards((prev) => {
@@ -475,6 +492,19 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
             {/* Discard controls */}
             {canDiscard && (
               <div className="mb-2 text-center" data-testid="discard-controls" data-tutorial="pn-discard-controls">
+                {discardPreview && (
+                  <div className="mb-2 text-sm" data-testid="irishpoker-discard-preview">
+                    <span className="text-ds-text-muted">{`${t('discard.keepLabel')}: `}</span>
+                    <span className="text-ds-text-primary font-semibold">
+                      {discardPreview.kept.map((c) => cardAlt(c)).join('  ')}
+                    </span>
+                    {discardPreview.handKey && (
+                      <span className="ml-2 inline-block rounded-full bg-ds-accent/30 px-2 py-0.5 text-ds-text-primary font-semibold">
+                        {`${t('discard.previewHand')}: ${t(`hand.${discardPreview.handKey}`)}`}
+                      </span>
+                    )}
+                  </div>
+                )}
                 {discardConfirming && selectedDiscards.length === discardCount && humanPlayer ? (
                   <div data-testid="discard-confirm">
                     <p className="text-ds-text-primary mb-2">

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -235,18 +235,14 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
   // Irish Poker discards 2 of 4 hole cards; while choosing, preview the 2 cards
   // that would be kept plus the best hand they make with the current board.
   const discardPreview = useMemo(() => {
-    if (variant !== 'irishpoker' || !isDiscardPhase) return null;
-    const hole = humanPlayer?.cards ?? [];
-    if (hole.length === 0 || selectedDiscards.length !== discardCount) return null;
-    const kept = hole.filter((_, i) => !selectedDiscards.includes(i));
+    const isIrishDiscardChoice = variant === 'irishpoker' && isDiscardPhase && selectedDiscards.length === discardCount;
+    if (!isIrishDiscardChoice) return null;
+    const kept = (humanPlayer?.cards ?? []).filter((_, i) => !selectedDiscards.includes(i));
+    // holdemBestFive picks the best 5 of (kept + board); it returns null for <5 cards.
     const all = [...kept, ...(state?.communityCards ?? [])];
-    let handKey: string | null = null;
-    if (all.length >= 5) {
-      const five = all.length === 5 ? all : (holdemBestFive(all)?.map((i) => all[i]) ?? null);
-      const rank = five ? evaluateFiveCardHand(five) : null;
-      handKey = rank == null ? null : pokerHandKey(rank);
-    }
-    return { kept, handKey };
+    const picked = holdemBestFive(all);
+    const rank = picked ? evaluateFiveCardHand(picked.map((i) => all[i])) : null;
+    return { kept, handKey: rank == null ? null : pokerHandKey(rank) };
   }, [variant, isDiscardPhase, humanPlayer, state?.communityCards, selectedDiscards, discardCount]);
   const toggleDiscard = (idx: number) => {
     if (!canDiscard) return;


### PR DESCRIPTION
## Summary
Irish Poker (PineapplePage `irishpoker` variant) discards 2 of 4 hole cards, but the UI only showed an n/total count with no guidance on which pair to keep. This adds a live preview during discard selection:

- When both discards are selected, show the **2 kept cards** plus the **best poker hand** they make with the current board — reusing `holdemBestFive` + `evaluateFiveCardHand` + `pokerHandKey` (no new evaluator).
- Rendered in both the select and confirm steps, gated to the `irishpoker` variant (Pineapple/Crazy Pineapple discard only 1 card → no preview).
- `hand.*` (10 rank names) + `discard.keepLabel` / `discard.previewHand` i18n added to ja/en.

No backend change — purely derived from existing response fields.

## Test plan
- [x] `bun run test -- --run src/pages/PineapplePage.test.tsx` (16 passed) — incl. preview shows pair-of-aces for irishpoker, and absent for pineapple variant
- [x] `bun run check` (exit 0)

Closes #2543