### PR TITLE
feat(crazypineapple): keep-hand preview per discard candidate

### DIFF
--- a/frontend/src/i18n/locales/en/crazypineapple.json
+++ b/frontend/src/i18n/locales/en/crazypineapple.json
@@ -19,7 +19,8 @@
     "select": "Select a card to discard",
     "confirm": "Discard {{card}}?",
     "confirmYes": "Confirm",
-    "confirmNo": "Cancel"
+    "confirmNo": "Cancel",
+    "candidateHand": "If discarded"
   },
   "rebuy": {
     "prompt": "Rebuy? ({{chips}} chips, {{used}}/{{max}} used)",
@@ -88,5 +89,17 @@
     "decentHandRank": "Decent hand — call recommended",
     "weakHandRank": "Weak hand — fold recommended",
     "discardWeakest": "Discard the weakest card"
+  },
+  "hand": {
+    "highCard": "High Card",
+    "onePair": "One Pair",
+    "twoPair": "Two Pair",
+    "threeOfAKind": "Three of a Kind",
+    "straight": "Straight",
+    "flush": "Flush",
+    "fullHouse": "Full House",
+    "fourOfAKind": "Four of a Kind",
+    "straightFlush": "Straight Flush",
+    "royalFlush": "Royal Flush"
   }
 }

--- a/frontend/src/i18n/locales/ja/crazypineapple.json
+++ b/frontend/src/i18n/locales/ja/crazypineapple.json
@@ -19,7 +19,8 @@
     "select": "捨てるカードを選択してください",
     "confirm": "{{card}} を捨てますか？",
     "confirmYes": "確定",
-    "confirmNo": "キャンセル"
+    "confirmNo": "キャンセル",
+    "candidateHand": "捨てると"
   },
   "rebuy": {
     "prompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済)",
@@ -88,5 +89,17 @@
     "decentHandRank": "まずまずのハンド — コール推奨",
     "weakHandRank": "弱いハンド — フォールド推奨",
     "discardWeakest": "最も弱いカードを捨てましょう"
+  },
+  "hand": {
+    "highCard": "ハイカード",
+    "onePair": "ワンペア",
+    "twoPair": "ツーペア",
+    "threeOfAKind": "スリーカード",
+    "straight": "ストレート",
+    "flush": "フラッシュ",
+    "fullHouse": "フルハウス",
+    "fourOfAKind": "フォーカード",
+    "straightFlush": "ストレートフラッシュ",
+    "royalFlush": "ロイヤルフラッシュ"
   }
 }

--- a/frontend/src/pages/PineapplePage.test.tsx
+++ b/frontend/src/pages/PineapplePage.test.tsx
@@ -391,6 +391,31 @@ describe('PineapplePage', () => {
     expect(labels[0]).toHaveTextContent('ワンペア');
   });
 
+  it('omits Crazy Pineapple candidate labels when the board is too small to evaluate', async () => {
+    const crazyNoBoardState: PineappleResponse = {
+      ...discardState,
+      initialDealCount: 3,
+      players: [
+        humanPlayer({
+          cards: [
+            { design: 'SPADE', value: 1 },
+            { design: 'HEART', value: 1 },
+            { design: 'DIAMOND', value: 5 },
+          ],
+        }),
+        cpuPlayer(1),
+        cpuPlayer(2),
+        cpuPlayer(3),
+      ],
+      communityCards: [], // keep(2) + board(0) < 5 → no hand can be evaluated
+      discardDone: [false, true, true, true],
+    };
+    mockCrazyExec.mockResolvedValue(crazyNoBoardState);
+    renderWithProviders(<PineapplePage variant="crazypineapple" />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+    expect(screen.queryByTestId('cp-discard-candidate')).not.toBeInTheDocument();
+  });
+
   it('does not show Crazy Pineapple candidate labels outside the discard phase', async () => {
     mockCrazyExec.mockResolvedValue({ ...preFlopState, initialDealCount: 3 });
     renderWithProviders(<PineapplePage variant="crazypineapple" />);

--- a/frontend/src/pages/PineapplePage.test.tsx
+++ b/frontend/src/pages/PineapplePage.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { irishPokerApi, pineappleApi } from '../api/gameApi';
+import { crazyPineappleApi, irishPokerApi, pineappleApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { PineappleResponse } from '../types/card';
 import { PineapplePage } from './PineapplePage';
@@ -8,11 +8,13 @@ import { PineapplePage } from './PineapplePage';
 vi.mock('../api/gameApi', () => ({
   pineappleApi: { exec: vi.fn() },
   irishPokerApi: { exec: vi.fn() },
-  actionLogApi: { pineapple: vi.fn(), irishpoker: vi.fn() },
+  crazyPineappleApi: { exec: vi.fn() },
+  actionLogApi: { pineapple: vi.fn(), irishpoker: vi.fn(), crazypineapple: vi.fn() },
 }));
 
 const mockExec = vi.mocked(pineappleApi.exec);
 const mockIrishExec = vi.mocked(irishPokerApi.exec);
+const mockCrazyExec = vi.mocked(crazyPineappleApi.exec);
 
 /** Helper: base human player */
 const humanPlayer = (overrides: Partial<import('../types/card').HoldemPlayerData> = {}) => ({
@@ -355,6 +357,45 @@ describe('PineapplePage', () => {
     renderWithProviders(<PineapplePage variant="irishpoker" />);
     await waitFor(() => expect(screen.getByText('あなたの手札')).toBeInTheDocument());
     expect(screen.queryByTestId('irishpoker-discard-preview')).not.toBeInTheDocument();
+  });
+
+  it('annotates each Crazy Pineapple hole card with the keep-hand if discarded', async () => {
+    const crazyDiscardState: PineappleResponse = {
+      ...discardState,
+      initialDealCount: 3,
+      players: [
+        humanPlayer({
+          cards: [
+            { design: 'SPADE', value: 1 },
+            { design: 'HEART', value: 1 },
+            { design: 'DIAMOND', value: 5 },
+          ],
+        }),
+        cpuPlayer(1),
+        cpuPlayer(2),
+        cpuPlayer(3),
+      ],
+      communityCards: [
+        { design: 'SPADE', value: 10 },
+        { design: 'HEART', value: 5 },
+        { design: 'DIAMOND', value: 8 },
+      ],
+      discardDone: [false, true, true, true],
+    };
+    mockCrazyExec.mockResolvedValue(crazyDiscardState);
+    renderWithProviders(<PineapplePage variant="crazypineapple" />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+    const labels = screen.getAllByTestId('cp-discard-candidate');
+    expect(labels).toHaveLength(3); // one per hole card
+    // Each keep makes at least a pair (Aces or fives), so a hand name is shown.
+    expect(labels[0]).toHaveTextContent('ワンペア');
+  });
+
+  it('does not show Crazy Pineapple candidate labels outside the discard phase', async () => {
+    mockCrazyExec.mockResolvedValue({ ...preFlopState, initialDealCount: 3 });
+    renderWithProviders(<PineapplePage variant="crazypineapple" />);
+    await waitFor(() => expect(screen.getByText('あなたの手札')).toBeInTheDocument());
+    expect(screen.queryByTestId('cp-discard-candidate')).not.toBeInTheDocument();
   });
 
   it('does not show the Irish Poker discard preview for the Pineapple variant', async () => {

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -244,6 +244,20 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
     const rank = picked ? evaluateFiveCardHand(picked.map((i) => all[i])) : null;
     return { kept, handKey: rank == null ? null : pokerHandKey(rank) };
   }, [variant, isDiscardPhase, humanPlayer, state?.communityCards, selectedDiscards, discardCount]);
+  // Crazy Pineapple discards 1 of 3 after the flop; annotate each hole card with
+  // the best hand the OTHER two would make with the board if that card is the
+  // one discarded, so the player can compare keeps before committing.
+  const candidatePreviews = useMemo<(string | null)[] | null>(() => {
+    if (variant !== 'crazypineapple' || !isDiscardPhase) return null;
+    const hole = humanPlayer?.cards ?? [];
+    const board = state?.communityCards ?? [];
+    return hole.map((_, discardIdx) => {
+      const all = [...hole.filter((_, i) => i !== discardIdx), ...board];
+      const picked = holdemBestFive(all);
+      const rank = picked ? evaluateFiveCardHand(picked.map((i) => all[i])) : null;
+      return rank == null ? null : pokerHandKey(rank);
+    });
+  }, [variant, isDiscardPhase, humanPlayer, state?.communityCards]);
   const toggleDiscard = (idx: number) => {
     if (!canDiscard) return;
     setSelectedDiscards((prev) => {
@@ -452,19 +466,29 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
                         const isSelected = selectedDiscards.includes(idx);
                         const inBest = showdownBest5.holeSet.has(idx);
                         const dim = showdownBest5.holeSet.size > 0 && !inBest;
+                        const candKey = candidatePreviews?.[idx] ?? null;
                         return (
-                          <button
-                            key={`${card.design}-${card.value}`}
-                            type="button"
-                            onClick={() => toggleDiscard(idx)}
-                            aria-pressed={canDiscard ? isSelected : undefined}
-                            className={`${canDiscard ? 'cursor-pointer' : 'cursor-default'} ${inBest ? 'rounded-lg ring-2 ring-ds-success motion-safe:animate-pulse' : ''} ${dim ? 'opacity-50' : ''}`}
-                            disabled={!canDiscard}
-                            style={selectedCardStyle(canDiscard && isSelected)}
-                            data-testid={inBest ? 'pn-best5-card' : undefined}
-                          >
-                            <AnimatedCard card={card} width={cardWidth} />
-                          </button>
+                          <div key={`${card.design}-${card.value}`} className="flex flex-col items-center">
+                            <button
+                              type="button"
+                              onClick={() => toggleDiscard(idx)}
+                              aria-pressed={canDiscard ? isSelected : undefined}
+                              className={`${canDiscard ? 'cursor-pointer' : 'cursor-default'} ${inBest ? 'rounded-lg ring-2 ring-ds-success motion-safe:animate-pulse' : ''} ${dim ? 'opacity-50' : ''}`}
+                              disabled={!canDiscard}
+                              style={selectedCardStyle(canDiscard && isSelected)}
+                              data-testid={inBest ? 'pn-best5-card' : undefined}
+                            >
+                              <AnimatedCard card={card} width={cardWidth} />
+                            </button>
+                            {candKey && (
+                              <span
+                                className="mt-0.5 text-[10px] text-ds-text-muted"
+                                data-testid="cp-discard-candidate"
+                              >
+                                {`${t('discard.candidateHand')}: ${t(`hand.${candKey}`)}`}
+                              </span>
+                            )}
+                          </div>
                         );
                       })
                     : !humanPlayer.folded &&


### PR DESCRIPTION
## Summary
Crazy Pineapple discards 1 of 3 hole cards *after* seeing the flop, but the discard UI gave no hint about which keep is strongest. This annotates each hole card with the best poker hand the **other two** would make with the current board if that card were the one discarded.

- New `candidatePreviews` memo (crazypineapple + discard phase): for each hole index, evaluates `holdemBestFive(otherTwo + board)` → `evaluateFiveCardHand` → `pokerHandKey`. Reuses existing utils, no new evaluator.
- Each hole card shows a small "If discarded: <hand>" label (`cp-discard-candidate`). Gated to the crazypineapple variant.
- `hand.*` (10 rank names) + `discard.candidateHand` i18n added to ja/en.

No backend change — derived from existing response fields. Mirrors the Irish Poker discard preview (#2543).

## Test plan
- [x] `bun run test -- --run src/pages/PineapplePage.test.tsx` (21 passed) — incl. 3 per-card labels for crazypineapple, none outside discard / for other variants
- [x] `bun run check` (exit 0)
- [x] Local coverage: all changed lines covered

Closes #2542