### PR TITLE
feat(daifugo): card-count mismatch warning before play

### DIFF
--- a/frontend/src/i18n/locales/en/daifugo.json
+++ b/frontend/src/i18n/locales/en/daifugo.json
@@ -105,5 +105,6 @@
     "revolutionChance": "You have 4 of a kind — consider a revolution",
     "playStronger": "You can beat the table — play a stronger card",
     "passNoPlay": "No cards strong enough — pass"
-  }
+  },
+  "countMismatch": "Select {{count}} card(s) to match the table"
 }

--- a/frontend/src/i18n/locales/ja/daifugo.json
+++ b/frontend/src/i18n/locales/ja/daifugo.json
@@ -105,5 +105,6 @@
     "revolutionChance": "同じ数字が4枚あります — 革命のチャンス",
     "playStronger": "場より強いカードがあります — プレイ推奨",
     "passNoPlay": "出せるカードなし — パス推奨"
-  }
+  },
+  "countMismatch": "場のカードと同じ {{count}} 枚を選んでください"
 }

--- a/frontend/src/pages/DaifugoPage.test.tsx
+++ b/frontend/src/pages/DaifugoPage.test.tsx
@@ -273,6 +273,53 @@ describe('DaifugoPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', [0]));
   });
 
+  it('warns and disables play when the selection count does not match the table', async () => {
+    mockExec.mockResolvedValue({
+      ...humanTurnState,
+      tableCards: [
+        { design: 'HEART', value: 6 },
+        { design: 'DIAMOND', value: 6 },
+      ],
+    });
+    renderWithProviders(<DaifugoPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ 3')).toBeInTheDocument());
+    fireEvent.click(screen.getByAltText('♠ 3')); // 1 card selected, table needs 2
+    expect(screen.getByTestId('daifugo-count-warning')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '選択して出す' })).toBeDisabled();
+  });
+
+  it('allows play when the selection count matches the table', async () => {
+    mockExec.mockResolvedValue({
+      ...humanTurnState,
+      tableCards: [
+        { design: 'HEART', value: 6 },
+        { design: 'DIAMOND', value: 6 },
+      ],
+    });
+    renderWithProviders(<DaifugoPage />);
+    await waitFor(() => expect(screen.getByAltText('♥ 5')).toBeInTheDocument());
+    fireEvent.click(screen.getByAltText('♥ 5'));
+    fireEvent.click(screen.getByAltText('♦ 5')); // 2 cards = table count
+    expect(screen.queryByTestId('daifugo-count-warning')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '選択して出す' })).not.toBeDisabled();
+  });
+
+  it('does not show the count warning during a pending action', async () => {
+    mockExec.mockResolvedValue({
+      ...humanTurnState,
+      tableCards: [
+        { design: 'HEART', value: 6 },
+        { design: 'DIAMOND', value: 6 },
+      ],
+      pendingAction: 'sevenPass',
+      pendingActionTarget: 1,
+    });
+    renderWithProviders(<DaifugoPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ 3')).toBeInTheDocument());
+    fireEvent.click(screen.getByAltText('♠ 3')); // mismatching count, but pending → gated off
+    expect(screen.queryByTestId('daifugo-count-warning')).not.toBeInTheDocument();
+  });
+
   it('shows human action log after play', async () => {
     mockExec.mockResolvedValue(cpuTurnState);
     renderWithProviders(<DaifugoPage />);

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -200,6 +200,12 @@ function DaifugoPageContent() {
 
   const pendingAction = state.pendingAction ?? 'none';
   const isHumanTurn = !state.gameEndFlag && !!state.players[state.currentTurn]?.isHuman;
+  // When following a non-empty table, a play must match the table combo's card
+  // count — a count mismatch is illegal regardless of rank or revolution/eleven-back
+  // inversion, so we can flag it client-side. Strength is still validated server-side.
+  const tableCount = state.tableCards?.length ?? 0;
+  const countMismatch =
+    pendingAction === 'none' && tableCount > 0 && selectedIndices.length > 0 && selectedIndices.length !== tableCount;
   const cpuPlayers = state.players.filter((p) => !p.isHuman);
   const humanPlayer = state.players.find((p) => p.isHuman);
 
@@ -421,6 +427,11 @@ function DaifugoPageContent() {
             )}
 
             <div className="text-center" data-tutorial="df-play-pass">
+              {countMismatch && (
+                <p className="mb-1.5 text-xs text-ds-error" role="alert" data-testid="daifugo-count-warning">
+                  {t('countMismatch', { count: tableCount })}
+                </p>
+              )}
               <GameResetButton
                 isGameEnd={!!state.gameEndFlag}
                 onReset={handleManualReset}
@@ -445,7 +456,8 @@ function DaifugoPageContent() {
                   !isHumanTurn ||
                   state.gameEndFlag ||
                   selectedIndices.length === 0 ||
-                  pendingAction === 'queenBomber'
+                  pendingAction === 'queenBomber' ||
+                  countMismatch
                 }
                 onClick={() =>
                   exec(


### PR DESCRIPTION
## Summary
Daifugo's play button was only disabled when nothing was selected, so a player could submit a count-mismatched combo (e.g. 1 card against a table pair) and only learn it's illegal from a server error. This adds a safe client-side guard:

- When **following** a non-empty table, a play must match the table combo's **card count**. A count mismatch is illegal regardless of rank or revolution/eleven-back inversion, so it's flagged client-side: an inline `role="alert"` warning + the play button disabled.
- **Gated to `pendingAction === 'none'`** so it never conflicts with the sevenPass / tenDiscard / queenBomber pending states (AC3).
- Inversion-correct by construction — card count is independent of revolution/eleven-back (AC2).
- `countMismatch` i18n added (ja/en).

Scope note: **strength** validation (too-weak same-count plays) is intentionally left to the server — porting Daifugo's full rank/inversion/combo classification client-side risks false "illegal" flags that would block legal plays. This delivers the unambiguous count-mismatch slice; the server still rejects too-weak plays as before.

## Test plan
- [x] `bun run test -- --run src/pages/DaifugoPage.test.tsx` (102 passed) — mismatch warns+disables, matching count allows, pending action gates it off
- [x] `bun run check` (exit 0)
- [x] Local coverage: all changed lines covered

Closes #2531