### PR TITLE
feat(videopoker): Bet Max button (Video Poker / Deuces Wild / Joker Poker)

### DIFF
--- a/frontend/src/components/VideoPokerGameContent.test.tsx
+++ b/frontend/src/components/VideoPokerGameContent.test.tsx
@@ -120,6 +120,15 @@ describe('VideoPokerGameContent', () => {
     expect(screen.getByRole('button', { name: /ディール/ })).toBeInTheDocument();
   });
 
+  it('bets the maximum (5) and deals when Bet Max is clicked', async () => {
+    mockExec.mockResolvedValue(betPhaseState);
+    renderContent();
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '最大ベット' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bet', 5));
+  });
+
   it('renders draw phase with hold toggles', async () => {
     mockExec.mockResolvedValueOnce(betPhaseState).mockResolvedValueOnce(drawPhaseState);
     renderContent();

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -161,6 +161,12 @@ export function VideoPokerGameContent({
   const handleDeal = useCallback(() => {
     execApi('bet', betAmount);
   }, [execApi, betAmount]);
+  // Bet the table maximum (5) and deal in one action. Pass 5 explicitly rather
+  // than relying on the async setBetAmount so the deal never uses a stale value.
+  const handleBetMax = useCallback(() => {
+    setBetAmount(5);
+    execApi('bet', 5);
+  }, [execApi]);
 
   const handleDraw = useCallback(() => {
     const indices = heldCards.reduce<number[]>((acc, held, i) => {
@@ -303,9 +309,14 @@ export function VideoPokerGameContent({
                     ))}
                   </select>
                 </div>
-                <button type="button" className={`${btnPrimary} mt-2`} onClick={handleDeal} disabled={loading}>
-                  {t('button.deal')}
-                </button>
+                <div className="mt-2 flex gap-2">
+                  <button type="button" className={btnPrimary} onClick={handleDeal} disabled={loading}>
+                    {t('button.deal')}
+                  </button>
+                  <button type="button" className={btnPrimary} onClick={handleBetMax} disabled={loading}>
+                    {t('label.betMax')}
+                  </button>
+                </div>
                 <p className="text-ds-text-muted text-xs mt-2">{tNs('dealGuide')}</p>
               </div>
             )}

--- a/frontend/src/i18n/locales/en/deuceswild.json
+++ b/frontend/src/i18n/locales/en/deuceswild.json
@@ -5,7 +5,8 @@
     "bet": "Bet: {{bet}} coin(s)",
     "payout": "Payout: {{payout}}",
     "betAmount": "Coins",
-    "autoHold": "Auto-hold"
+    "autoHold": "Auto-hold",
+    "betMax": "Bet Max"
   },
   "button": {
     "deal": "Deal",

--- a/frontend/src/i18n/locales/en/jokerpoker.json
+++ b/frontend/src/i18n/locales/en/jokerpoker.json
@@ -5,7 +5,8 @@
     "bet": "Bet: {{bet}} coin(s)",
     "payout": "Payout: {{payout}}",
     "betAmount": "Coins",
-    "autoHold": "Auto-hold"
+    "autoHold": "Auto-hold",
+    "betMax": "Bet Max"
   },
   "button": {
     "deal": "Deal",

--- a/frontend/src/i18n/locales/en/videopoker.json
+++ b/frontend/src/i18n/locales/en/videopoker.json
@@ -5,7 +5,8 @@
     "bet": "Bet: {{bet}} coin(s)",
     "payout": "Payout: {{payout}}",
     "betAmount": "Coins",
-    "autoHold": "Auto-hold"
+    "autoHold": "Auto-hold",
+    "betMax": "Bet Max"
   },
   "button": {
     "deal": "Deal",

--- a/frontend/src/i18n/locales/ja/deuceswild.json
+++ b/frontend/src/i18n/locales/ja/deuceswild.json
@@ -5,7 +5,8 @@
     "bet": "ベット: {{bet}}コイン",
     "payout": "配当: {{payout}}",
     "betAmount": "コイン数",
-    "autoHold": "自動ホールド"
+    "autoHold": "自動ホールド",
+    "betMax": "最大ベット"
   },
   "button": {
     "deal": "ディール",

--- a/frontend/src/i18n/locales/ja/jokerpoker.json
+++ b/frontend/src/i18n/locales/ja/jokerpoker.json
@@ -5,7 +5,8 @@
     "bet": "ベット: {{bet}}コイン",
     "payout": "配当: {{payout}}",
     "betAmount": "コイン数",
-    "autoHold": "自動ホールド"
+    "autoHold": "自動ホールド",
+    "betMax": "最大ベット"
   },
   "button": {
     "deal": "ディール",

--- a/frontend/src/i18n/locales/ja/videopoker.json
+++ b/frontend/src/i18n/locales/ja/videopoker.json
@@ -5,7 +5,8 @@
     "bet": "ベット: {{bet}}コイン",
     "payout": "配当: {{payout}}",
     "betAmount": "コイン数",
-    "autoHold": "自動ホールド"
+    "autoHold": "自動ホールド",
+    "betMax": "最大ベット"
   },
   "button": {
     "deal": "ディール",


### PR DESCRIPTION
## Summary
The video-poker bet phase only had a 1–5 `<select>`; the standard "Bet Max" shortcut was missing. This adds a **Bet Max** button beside Deal in the shared `VideoPokerGameContent`, so it benefits all three variants (Video Poker, Deuces Wild, Joker Poker — the issue is filed under Joker Poker).

- `handleBetMax` sets the bet to 5 and deals in one action, passing 5 explicitly to the API so the deal never uses a stale `betAmount`.
- `label.betMax` i18n added to all three namespaces (ja/en).

Scope note: AC2 (per-bet payout-column highlight) is deferred — `PayoutTable` rows are pre-formatted localized strings, so highlighting one bet column would need the payout data restructured into per-bet numbers (a larger refactor). This PR delivers the Bet Max shortcut (AC1/AC3/AC4).

## Test plan
- [x] `bun run test -- --run src/components/VideoPokerGameContent.test.tsx` (23 passed) — incl. Bet Max → `exec('bet', 5)`
- [x] `bun run check` (exit 0)

Closes #2560