### PR TITLE
feat(spider): announce suit completions (aria-live + flash + sound)

### DIFF
--- a/frontend/src/i18n/locales/en/spider.json
+++ b/frontend/src/i18n/locales/en/spider.json
@@ -44,5 +44,6 @@
     "revealFaceDown": "Move cards to reveal face-down cards underneath",
     "useEmptyColumn": "An empty column is available — use it to reorganize",
     "dealFromStock": "No obvious moves — try dealing from the stock"
-  }
+  },
+  "suitCompleted": "Suit complete!"
 }

--- a/frontend/src/i18n/locales/ja/spider.json
+++ b/frontend/src/i18n/locales/ja/spider.json
@@ -44,5 +44,6 @@
     "revealFaceDown": "カードを動かして裏向きのカードをめくりましょう",
     "useEmptyColumn": "空の列があります — 整理に活用しましょう",
     "dealFromStock": "すぐにできる手がありません — 山札から配ってみましょう"
-  }
+  },
+  "suitCompleted": "スート完成！"
 }

--- a/frontend/src/pages/SpiderPage.test.tsx
+++ b/frontend/src/pages/SpiderPage.test.tsx
@@ -136,6 +136,22 @@ describe('SpiderPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('deal'));
   });
 
+  it('announces and flashes when a new suit is completed', async () => {
+    const filled: SpiderResponse = {
+      ...playingState,
+      tableau: makeTableau(Array.from({ length: 10 }, () => [{ card: card('SPADE', 13), faceUp: true }])),
+    };
+    mockExec.mockResolvedValue(filled); // completedSuits 0
+    renderWithProviders(<SpiderPage />);
+    await waitFor(() => expect(screen.getAllByRole('button', { name: '配る' }).length).toBeGreaterThanOrEqual(1));
+    expect(screen.queryByTestId('spd-suit-complete')).not.toBeInTheDocument();
+
+    mockExec.mockResolvedValue({ ...filled, completedSuits: 1 });
+    const dealButtons = screen.getAllByRole('button', { name: '配る' });
+    fireEvent.click(dealButtons[dealButtons.length - 1]);
+    await waitFor(() => expect(screen.getByTestId('spd-suit-complete')).toBeInTheDocument());
+  });
+
   it('clicking deal with empty columns triggers shake on empty placeholders and skips API', async () => {
     // playingState has empty columns 2..9
     renderWithProviders(<SpiderPage />);

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { SpiderMoveZone, spiderApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { AutoCompleteReadyBadge } from '../components/AutoCompleteReadyBadge';
@@ -206,6 +206,23 @@ function SpiderPageContent() {
     enabled: !!isPlayingForKbd && !loading,
   });
 
+  // Announce + sound a fanfare cue whenever a new K→A suit is completed, so the
+  // mid-game progress (not just the final win) gives feedback. The count text is
+  // an aria-live region, so screen readers hear it too.
+  const [suitJustCompleted, setSuitJustCompleted] = useState(false);
+  const prevCompletedRef = useRef<number | null>(null);
+  useEffect(() => {
+    const completed = state?.completedSuits ?? 0;
+    const prev = prevCompletedRef.current;
+    prevCompletedRef.current = completed;
+    if (prev != null && completed > prev) {
+      setSuitJustCompleted(true);
+      playSound('cardPlace');
+      const id = setTimeout(() => setSuitJustCompleted(false), 2500);
+      return () => clearTimeout(id);
+    }
+  }, [state?.completedSuits, playSound]);
+
   if (!state) return <GameSkeleton gameKey="spider" layout={{ kind: 'tableau', topRow: 3, tableau: 10 }} />;
 
   const isPlaying = state.phase === SpiderPhase.PLAYING;
@@ -250,8 +267,13 @@ function SpiderPageContent() {
         </>
       }
       headerEnd={
-        <span className="ml-3" data-tutorial="spd-completed-suits">
+        <span className="ml-3" role="status" aria-live="polite" data-tutorial="spd-completed-suits">
           {t('completed')}: {state.completedSuits}/8
+          {suitJustCompleted && (
+            <span className="ml-1 text-ds-success font-semibold" data-testid="spd-suit-complete">
+              {t('suitCompleted')}
+            </span>
+          )}
         </span>
       }
     >

--- a/frontend/src/pages/SpiderPage.tsx
+++ b/frontend/src/pages/SpiderPage.tsx
@@ -267,14 +267,16 @@ function SpiderPageContent() {
         </>
       }
       headerEnd={
-        <span className="ml-3" role="status" aria-live="polite" data-tutorial="spd-completed-suits">
-          {t('completed')}: {state.completedSuits}/8
-          {suitJustCompleted && (
-            <span className="ml-1 text-ds-success font-semibold" data-testid="spd-suit-complete">
-              {t('suitCompleted')}
-            </span>
-          )}
-        </span>
+        <>
+          <span className="ml-3" role="status" data-tutorial="spd-completed-suits">
+            {t('completed')}: {state.completedSuits}/8
+          </span>
+          {/* Dedicated live region for the completion flash: keeping it separate
+              from the counter means its removal never re-reads the counter text. */}
+          <span className="ml-1 text-ds-success font-semibold" role="status">
+            {suitJustCompleted ? <span data-testid="spd-suit-complete">{t('suitCompleted')}</span> : null}
+          </span>
+        </>
       }
     >
       {cliEnabled ? (


### PR DESCRIPTION
## Summary
Spider's `completed: N/8` counter was plain text with no live-region semantics, so screen readers never announced a completed suit, and the only completion feedback was the final win fanfare. This adds mid-game progress feedback:

- The completed-suits counter is now a `role="status" aria-live="polite"` region.
- When `completedSuits` increases, a "Suit complete!" badge flashes (`spd-suit-complete`, auto-clears after 2.5s) and a `cardPlace` sound plays.
- `suitCompleted` i18n added (ja/en).

## Test plan
- [x] `bun run test -- --run src/pages/SpiderPage.test.tsx` (58 passed) — incl. announcement appears on completedSuits increase
- [x] `bun run check` (exit 0)

Closes #2555