### PR TITLE
feat(oldmaid): aria state for suspect toggle + draw target

### DIFF
--- a/frontend/src/components/oldmaid/OldMaidPlayerArea.test.tsx
+++ b/frontend/src/components/oldmaid/OldMaidPlayerArea.test.tsx
@@ -56,6 +56,32 @@ describe('OldMaidPlayerArea compactNonTarget', () => {
   });
 });
 
+describe('OldMaidPlayerArea suspect/target a11y', () => {
+  it('exposes the suspect toggle state via aria-pressed and a descriptive aria-label', () => {
+    const { rerender } = render(
+      <OldMaidPlayerArea {...defaultProps} player={makeCpuPlayer(5)} onToggleSuspect={vi.fn()} isSuspect={false} />,
+    );
+    const btn = screen.getByRole('button', { name: /容疑者/ });
+    expect(btn).toHaveAttribute('aria-pressed', 'false');
+    expect(btn.getAttribute('aria-label')).toContain('CPU');
+
+    rerender(<OldMaidPlayerArea {...defaultProps} player={makeCpuPlayer(5)} onToggleSuspect={vi.fn()} isSuspect />);
+    expect(screen.getByRole('button', { name: /容疑者/ })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('marks the current draw target with aria-current', () => {
+    const { container } = render(
+      <OldMaidPlayerArea {...defaultProps} player={makeCpuPlayer(5)} isTarget isHumanTurn />,
+    );
+    expect(container.querySelector('#player-area-1')).toHaveAttribute('aria-current', 'true');
+  });
+
+  it('does not set aria-current on a non-target player', () => {
+    const { container } = render(<OldMaidPlayerArea {...defaultProps} player={makeCpuPlayer(5)} />);
+    expect(container.querySelector('#player-area-1')).not.toHaveAttribute('aria-current');
+  });
+});
+
 describe('OldMaidPlayerArea CPU highlight', () => {
   const selectableProps = { ...defaultProps, isTarget: true, isHumanTurn: true };
 

--- a/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
+++ b/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
@@ -143,6 +143,9 @@ export function OldMaidPlayerArea({
   return (
     <div
       id={`player-area-${player.id}`}
+      // Mark the current draw target programmatically so assistive tech announces
+      // it, not just the visual highlight / badge.
+      aria-current={isTarget && !player.isHuman && !player.isFinished && !gameEndFlag ? 'true' : undefined}
       className={`relative ${playerAreaClass}${conditionalClass ? ` ${conditionalClass}` : ''}`}
     >
       {/* Always mount CpuActionBubble so its sr-only live region stays in the
@@ -163,6 +166,10 @@ export function OldMaidPlayerArea({
             type="button"
             className="ml-1 px-1.5 py-0.5 text-xs rounded bg-ds-error hover:bg-ds-error-hover text-white"
             onClick={onToggleSuspect}
+            aria-pressed={isSuspect}
+            aria-label={t(isSuspect ? 'suspect.unpinAria' : 'suspect.pinAria', {
+              name: playerName(player.id, player.isHuman),
+            })}
           >
             {isSuspect ? t('suspect.unpin') : t('suspect.pin')}
           </button>

--- a/frontend/src/i18n/locales/en/oldmaid.json
+++ b/frontend/src/i18n/locales/en/oldmaid.json
@@ -36,7 +36,9 @@
   "suspect": {
     "badge": "Suspect",
     "pin": "Pin Suspect",
-    "unpin": "Unpin"
+    "unpin": "Unpin",
+    "pinAria": "Mark {{name}} as a suspect",
+    "unpinAria": "Remove the suspect mark from {{name}}"
   },
   "button": {
     "settings": "Settings",

--- a/frontend/src/i18n/locales/ja/oldmaid.json
+++ b/frontend/src/i18n/locales/ja/oldmaid.json
@@ -36,7 +36,9 @@
   "suspect": {
     "badge": "容疑者",
     "pin": "容疑者ピン",
-    "unpin": "ピン解除"
+    "unpin": "ピン解除",
+    "pinAria": "{{name}} を容疑者にマーク",
+    "unpinAria": "{{name}} の容疑者マークを外す"
   },
   "button": {
     "settings": "設定",

--- a/frontend/src/pages/OldMaidPage.test.tsx
+++ b/frontend/src/pages/OldMaidPage.test.tsx
@@ -1099,30 +1099,30 @@ describe('OldMaidPage', () => {
 
   it('shows suspect pin button for CPU players', async () => {
     await startGame();
-    const pinButtons = screen.getAllByRole('button', { name: '容疑者ピン' });
+    const pinButtons = screen.getAllByRole('button', { name: /容疑者にマーク/ });
     expect(pinButtons.length).toBeGreaterThan(0);
   });
 
   it('toggles suspect pin on click', async () => {
     await startGame();
-    const pinButton = screen.getAllByRole('button', { name: '容疑者ピン' })[0];
+    const pinButton = screen.getAllByRole('button', { name: /容疑者にマーク/ })[0];
     fireEvent.click(pinButton);
     expect(screen.getByText('容疑者')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'ピン解除' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /マークを外す/ })).toBeInTheDocument();
   });
 
   it('unpins suspect on second click', async () => {
     await startGame();
-    const pinButton = screen.getAllByRole('button', { name: '容疑者ピン' })[0];
+    const pinButton = screen.getAllByRole('button', { name: /容疑者にマーク/ })[0];
     fireEvent.click(pinButton);
     expect(screen.getByText('容疑者')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'ピン解除' }));
+    fireEvent.click(screen.getByRole('button', { name: /マークを外す/ }));
     expect(screen.queryByText('容疑者')).not.toBeInTheDocument();
   });
 
   it('clears suspect pins on reset', async () => {
     await startGame();
-    const pinButton = screen.getAllByRole('button', { name: '容疑者ピン' })[0];
+    const pinButton = screen.getAllByRole('button', { name: /容疑者にマーク/ })[0];
     fireEvent.click(pinButton);
     expect(screen.getByText('容疑者')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
@@ -1132,7 +1132,7 @@ describe('OldMaidPage', () => {
 
   it('clears suspect pins when applying settings', async () => {
     await startGame();
-    const pinButton = screen.getAllByRole('button', { name: '容疑者ピン' })[0];
+    const pinButton = screen.getAllByRole('button', { name: /容疑者にマーク/ })[0];
     fireEvent.click(pinButton);
     expect(screen.getByText('容疑者')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '設定' }));
@@ -1152,14 +1152,14 @@ describe('OldMaidPage', () => {
     mockExec.mockResolvedValue(stateWithFinished);
     await startGame();
     // Only CPU 2 (not finished) should have pin button
-    const pinButtons = screen.getAllByRole('button', { name: '容疑者ピン' });
+    const pinButtons = screen.getAllByRole('button', { name: /容疑者にマーク/ });
     expect(pinButtons).toHaveLength(1);
   });
 
   it('does not show suspect pin button when game has ended', async () => {
     mockExec.mockResolvedValue(gameEndState);
     await startGame();
-    expect(screen.queryByRole('button', { name: '容疑者ピン' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /容疑者にマーク/ })).not.toBeInTheDocument();
   });
 
   it('goes directly to CPU replay when humanAction is null', async () => {


### PR DESCRIPTION
## Summary
Old Maid conveyed two key game states only visually. This adds the assistive-tech state:

- Suspect-pin toggle now has `aria-pressed={isSuspect}` and a descriptive `aria-label` (e.g. "Mark CPU 2 as a suspect" / "Remove the suspect mark from CPU 2").
- The current draw-target player area is marked `aria-current="true"`.
- The "who drew" bubble already exposes an sr-only live region (no change needed).
- `suspect.pinAria` / `suspect.unpinAria` i18n added (ja/en).

## Test plan
- [x] `bun run test -- --run src/components/oldmaid/OldMaidPlayerArea.test.tsx` (32 passed) — aria-pressed toggles, descriptive label, aria-current on/off
- [x] `bun run check` (exit 0)

Closes #2530