### PR TITLE
feat(cribbage): screen-reader-friendly peg board

### DIFF
--- a/frontend/src/i18n/locales/en/cribbage.json
+++ b/frontend/src/i18n/locales/en/cribbage.json
@@ -77,5 +77,7 @@
     "peggingArea": "Take turns playing cards to reach 31.",
     "pegBoard": "Player scores are shown here.",
     "resetButton": "Press the reset button to start a new game."
-  }
+  },
+  "pegBoardAria": "Peg board (scores)",
+  "scoreSummary": "{{name}}: {{score}} of {{limit}} points"
 }

--- a/frontend/src/i18n/locales/ja/cribbage.json
+++ b/frontend/src/i18n/locales/ja/cribbage.json
@@ -77,5 +77,7 @@
     "peggingArea": "交互にカードを出して31を目指します。",
     "pegBoard": "各プレイヤーのスコアが表示されます。",
     "resetButton": "リセットボタンで新しいゲームを始められます。"
-  }
+  },
+  "pegBoardAria": "ペグボード（得点）",
+  "scoreSummary": "{{name}}: {{score}} / {{limit}} 点"
 }

--- a/frontend/src/pages/CribbagePage.test.tsx
+++ b/frontend/src/pages/CribbagePage.test.tsx
@@ -542,11 +542,16 @@ describe('CribbagePage', () => {
     expect(screen.queryByAltText('\u2666 K')).not.toBeInTheDocument();
   });
 
-  it('shows peg board', async () => {
+  it('shows peg board with a localized label and screen-reader score summaries', async () => {
     renderWithProviders(<CribbagePage />);
     await waitFor(() => {
-      expect(screen.getByLabelText('peg-board')).toBeInTheDocument();
+      expect(screen.getByTestId('peg-board')).toBeInTheDocument();
     });
+    // aria-label is localized (no longer the literal "peg-board").
+    expect(screen.getByLabelText('ペグボード（得点）')).toBeInTheDocument();
+    expect(screen.queryByLabelText('peg-board')).not.toBeInTheDocument();
+    // Each player has an sr-only score/goal summary.
+    expect(screen.getByTestId('peg-score-summary-0')).toHaveTextContent('/ 121 点');
   });
 
   it('renders the rear-peg trail after the player score jumps', async () => {

--- a/frontend/src/pages/CribbagePage.tsx
+++ b/frontend/src/pages/CribbagePage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { cribbageApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -92,6 +93,7 @@ function pegCenter(pct: number): string {
 
 /** Inline peg board showing score progress, with front + rear pegs to surface the most recent jump. */
 function PegBoard({ scores, pointLimit }: { scores: { name: string; score: number }[]; pointLimit: number }) {
+  const { t } = useTranslation('cribbage');
   const prevScoresRef = useRef<number[]>(scores.map((s) => s.score));
   // Read the previous score for the rear-peg position before we overwrite the ref.
   const prevScores = prevScoresRef.current;
@@ -108,7 +110,7 @@ function PegBoard({ scores, pointLimit }: { scores: { name: string; score: numbe
     return out;
   }, [pointLimit]);
   return (
-    <section className="my-2 p-2 rounded bg-black/30" aria-label="peg-board" data-testid="peg-board">
+    <section className="my-2 p-2 rounded bg-black/30" aria-label={t('pegBoardAria')} data-testid="peg-board">
       {scores.map((p, idx) => {
         const pct = Math.min((p.score / pointLimit) * 100, 100);
         const prev = prevScores[idx] ?? p.score;
@@ -116,12 +118,17 @@ function PegBoard({ scores, pointLimit }: { scores: { name: string; score: numbe
         const tone = idx === 0 ? 'bg-ds-warning' : 'bg-ds-info';
         return (
           <div key={idx} className="mb-1">
-            <div className="flex justify-between text-ds-text-muted text-xs mb-0.5">
+            {/* Visual score row is decorative; the sr-only summary below carries
+                the same info as a single readable phrase for screen readers. */}
+            <div className="flex justify-between text-ds-text-muted text-xs mb-0.5" aria-hidden="true">
               <span>{p.name}</span>
               <span>
                 {p.score}/{pointLimit}
               </span>
             </div>
+            <span className="sr-only" data-testid={`peg-score-summary-${idx}`}>
+              {t('scoreSummary', { name: p.name, score: p.score, limit: pointLimit })}
+            </span>
             <div className="relative w-full h-3 bg-white/10 rounded-full overflow-visible">
               {ticks.map((v) => (
                 <div


### PR DESCRIPTION
## Summary
Cribbage's peg board exposed only a hard-coded English `aria-label="peg-board"` and kept all score info inside aria-hidden visual elements. This makes it accessible:

- The section `aria-label` is now localized (`pegBoardAria`).
- Each player gets an `sr-only` score/goal summary (`scoreSummary`, e.g. "You: 57 of 121 points", `peg-score-summary-N`).
- The decorative visual score row is marked `aria-hidden`; pegs/ticks stay `aria-hidden` — decoration separated from information (AC3).
- `pegBoardAria` / `scoreSummary` i18n added (ja/en).

## Test plan
- [x] `bun run test -- --run src/pages/CribbagePage.test.tsx` (56 passed) — localized label, no literal "peg-board" label, sr-only summary present
- [x] `bun run check` (exit 0)

Closes #2564