### PR TITLE
feat(doubt): countdown a11y (role=timer + escalating live) + key hints

### DIFF
--- a/frontend/src/components/doubt/CountdownBar.test.tsx
+++ b/frontend/src/components/doubt/CountdownBar.test.tsx
@@ -57,11 +57,17 @@ describe('CountdownBar', () => {
     vi.mocked(useReducedMotion).mockReturnValue(false);
   });
 
-  it('renders label text in aria-live region when provided', () => {
+  it('renders label as a role=timer region, assertive in the final seconds', () => {
     render(<CountdownBar remaining={3} total={10} label="残り 3 秒" />);
     const liveRegion = screen.getByText('残り 3 秒');
-    expect(liveRegion).toHaveAttribute('aria-live', 'assertive');
+    expect(liveRegion).toHaveAttribute('role', 'timer');
+    expect(liveRegion).toHaveAttribute('aria-live', 'assertive'); // ≤3s → urgent
     expect(liveRegion).toHaveAttribute('aria-atomic', 'true');
+  });
+
+  it('announces politely while time remains (above 3s)', () => {
+    render(<CountdownBar remaining={7} total={10} label="残り 7 秒" />);
+    expect(screen.getByText('残り 7 秒')).toHaveAttribute('aria-live', 'polite');
   });
 
   it('applies ds-warning color to label text', () => {

--- a/frontend/src/components/doubt/CountdownBar.tsx
+++ b/frontend/src/components/doubt/CountdownBar.tsx
@@ -45,7 +45,14 @@ export function CountdownBar({ remaining, total, label }: CountdownBarProps) {
         />
       </div>
       {label && (
-        <div className="text-ds-warning text-lg font-bold mt-1" aria-live="assertive" aria-atomic="true">
+        <div
+          className="text-ds-warning text-lg font-bold mt-1"
+          role="timer"
+          // Announce politely most of the time; escalate to assertive in the final
+          // few seconds so the urgency interrupts rather than queues.
+          aria-live={remaining <= 3 ? 'assertive' : 'polite'}
+          aria-atomic="true"
+        >
           {label}
         </div>
       )}

--- a/frontend/src/i18n/locales/en/doubt.json
+++ b/frontend/src/i18n/locales/en/doubt.json
@@ -61,5 +61,6 @@
     "bluffCarefully": "No matching pairs — bluff carefully",
     "doubtTell": "Opponent showed a tell — consider doubting",
     "skipSafe": "No obvious tell — safer to skip"
-  }
+  },
+  "keyHints": "Space: Doubt / Esc: Skip"
 }

--- a/frontend/src/i18n/locales/ja/doubt.json
+++ b/frontend/src/i18n/locales/ja/doubt.json
@@ -61,5 +61,6 @@
     "bluffCarefully": "同じ数字のペアなし — 慎重にブラフ推奨",
     "doubtTell": "相手にテル（癖）が見えます — ダウト推奨",
     "skipSafe": "明確なテルなし — スキップが安全"
-  }
+  },
+  "keyHints": "Space: ダウト ／ Esc: スキップ"
 }

--- a/frontend/src/pages/DoubtPage.test.tsx
+++ b/frontend/src/pages/DoubtPage.test.tsx
@@ -348,6 +348,14 @@ describe('DoubtPage', () => {
     });
   });
 
+  it('shows the keyboard-shortcut hints during the doubt window', async () => {
+    mockExec.mockResolvedValue(doubtPhaseCpuPlayedState);
+    renderWithProviders(<DoubtPage />);
+    await waitFor(() => expect(screen.getByTestId('doubt-key-hints')).toBeInTheDocument());
+    expect(screen.getByTestId('doubt-key-hints')).toHaveTextContent('Space');
+    expect(screen.getByTestId('doubt-key-hints')).toHaveTextContent('Esc');
+  });
+
   it('shows cpu doubters in cpuPlayed doubt phase', async () => {
     const s: DoubtResponse = {
       ...doubtPhaseCpuPlayedState,
@@ -513,12 +521,13 @@ describe('DoubtPage', () => {
       await waitFor(() => expect(screen.getByText(/残り 10 秒/)).toBeInTheDocument());
     });
 
-    it('countdown has aria-live assertive and aria-atomic true', async () => {
+    it('countdown is a polite role=timer region early on (escalates to assertive ≤3s)', async () => {
       mockExec.mockResolvedValue(doubtPhaseCpuPlayedState);
       renderWithProviders(<DoubtPage />);
       await waitFor(() => expect(screen.getByText(/残り 10 秒/)).toBeInTheDocument());
       const countdownEl = screen.getByText(/残り 10 秒/);
-      expect(countdownEl).toHaveAttribute('aria-live', 'assertive');
+      expect(countdownEl).toHaveAttribute('role', 'timer');
+      expect(countdownEl).toHaveAttribute('aria-live', 'polite'); // 10s remaining → not yet urgent
       expect(countdownEl).toHaveAttribute('aria-atomic', 'true');
     });
 

--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -347,6 +347,9 @@ function DoubtPageContent() {
                             {t('skipButton')}
                           </button>
                         </div>
+                        <p className="text-game-text-muted text-xs mt-2" data-testid="doubt-key-hints">
+                          {t('keyHints')}
+                        </p>
                       </>
                     ) : (
                       <>


### PR DESCRIPTION
## Summary
The Doubt decision window's countdown was visual-only-ish (the label was always `aria-live="assertive"`, interrupting every second) and the Space/Esc shortcuts weren't shown on screen. This improves it:

- The countdown label is now a `role="timer"` region that announces **politely** while time remains and **escalates to `assertive` in the final ≤3 s** (urgency interrupts instead of queuing — and stops hammering AT every second early on).
- Added an on-screen "Space: Doubt / Esc: Skip" key-hint line by the doubt/skip buttons (`doubt-key-hints`).
- `keyHints` i18n added (ja/en).

## Test plan
- [x] `bun run test -- --run src/components/doubt/CountdownBar.test.tsx src/pages/DoubtPage.test.tsx` (112 passed) — role=timer, polite>3s/assertive≤3s, key hints shown
- [x] `bun run check` (exit 0)

Closes #2534