### PR TITLE
feat(truco): localize hand-card aria-labels via cardAlt

### DIFF
--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -299,7 +299,8 @@
   },
   "card": {
     "back": "Card back",
-    "joker": "Joker"
+    "joker": "Joker",
+    "play": "Play {{card}}"
   },
   "label": {
     "result": "Result:",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -299,7 +299,8 @@
   },
   "card": {
     "back": "カード裏面",
-    "joker": "ジョーカー"
+    "joker": "ジョーカー",
+    "play": "{{card}} を出す"
   },
   "label": {
     "result": "結果:",

--- a/frontend/src/pages/TrucoPage.test.tsx
+++ b/frontend/src/pages/TrucoPage.test.tsx
@@ -81,17 +81,17 @@ describe('TrucoPage', () => {
 
   it('shows human hand as 3 play buttons', async () => {
     renderWithProviders(<TrucoPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Play SPADE 1' })).toBeInTheDocument());
-    expect(screen.getByRole('button', { name: 'Play HEART 5' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Play DIAMOND 11' })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole('button', { name: '♠ A を出す' })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: '♥ 5 を出す' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '♦ J を出す' })).toBeInTheDocument();
   });
 
   it('fires play with the selected card index when a card is clicked', async () => {
     renderWithProviders(<TrucoPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Play HEART 5' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '♥ 5 を出す' })).toBeInTheDocument());
 
     mockExec.mockClear();
-    fireEvent.click(screen.getByRole('button', { name: 'Play HEART 5' }));
+    fireEvent.click(screen.getByRole('button', { name: '♥ 5 を出す' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', 1));
   });
 
@@ -140,7 +140,7 @@ describe('TrucoPage', () => {
   it('disables play buttons when it is not the human turn', async () => {
     mockExec.mockResolvedValue(makeState({ currentPlayerIdx: 1, canDeclareTruco: false }));
     renderWithProviders(<TrucoPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Play SPADE 1' })).toBeDisabled());
+    await waitFor(() => expect(screen.getByRole('button', { name: '♠ A を出す' })).toBeDisabled());
   });
 
   it('shows confirm dialog on reset click and runs reset on accept', async () => {

--- a/frontend/src/pages/TrucoPage.tsx
+++ b/frontend/src/pages/TrucoPage.tsx
@@ -16,6 +16,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { TrucoResponse } from '../types/card';
 import { TrucoPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 
 /** Tutorial steps for the Truco page. */
 const TRUCO_TUTORIAL_STEPS: TutorialStep[] = [
@@ -173,7 +174,7 @@ function TrucoPageContent() {
                   type="button"
                   onClick={() => handlePlay(idx)}
                   disabled={loading || !isHumanPlayTurn}
-                  aria-label={`Play ${card.design} ${card.value}`}
+                  aria-label={tc('card.play', { card: cardAlt(card) })}
                   className="disabled:opacity-50"
                 >
                   <CardImage card={card} width={cardWidth} />


### PR DESCRIPTION
## Summary
Truco's play-card buttons used a raw English `aria-label={\`Play ${card.design} ${card.value}\`}` (e.g. "Play SPADE 1"), so a Japanese screen reader announced meaningless enum text while the rest of the page was localized.

- Route the label through the shared `cardAlt()` util plus a new `common` key `card.play` ("{{card}} を出す" / "Play {{card}}"), so it reads e.g. "♠ A を出す" — matching how every other game labels cards.
- Updated the existing TrucoPage tests that queried the old "Play …" names.

## Test plan
- [x] `bun run test -- --run src/pages/TrucoPage.test.tsx` (12 passed)
- [x] `bun run check` (exit 0)

Closes #2640