### PR TITLE
feat(doudizhu): cardAlt aria-labels on hand + CLI hand listing

### DIFF
--- a/frontend/src/pages/DoudizhuPage.test.tsx
+++ b/frontend/src/pages/DoudizhuPage.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { doudizhuApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { DoudizhuResponse } from '../types/card';
-import { DoudizhuPage } from './DoudizhuPage';
+import { DoudizhuPage, formatDDZState } from './DoudizhuPage';
 
 vi.mock('../api/gameApi', () => ({
   doudizhuApi: { exec: vi.fn() },
@@ -122,6 +122,29 @@ describe('DoudizhuPage', () => {
     await waitFor(() => {
       expect(mockExec).toHaveBeenCalledWith(expect.objectContaining({ command: 'bid', bidValue: 0 }));
     });
+  });
+
+  it('formatDDZState lists the human hand with indices for the CLI', () => {
+    const out = formatDDZState({
+      ...defaultState,
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          isFinished: false,
+          isLandlord: true,
+          cardCount: 2,
+          cards: [
+            { design: 'SPADE', value: 5 },
+            { design: 'HEART', value: 13 },
+          ],
+        },
+        { id: 1, isHuman: false, isFinished: false, isLandlord: false, cardCount: 17, cards: [] },
+        { id: 2, isHuman: false, isFinished: false, isLandlord: false, cardCount: 17, cards: [] },
+      ],
+    });
+    expect(out).toContain('[0]♠ 5');
+    expect(out).toContain('[1]♥ K');
   });
 
   it('labels hand cards via cardAlt and reflects selection with aria-pressed', async () => {

--- a/frontend/src/pages/DoudizhuPage.test.tsx
+++ b/frontend/src/pages/DoudizhuPage.test.tsx
@@ -147,6 +147,11 @@ describe('DoudizhuPage', () => {
     expect(out).toContain('[1]♥ K');
   });
 
+  it('formatDDZState omits the hand line when the human has no visible cards', () => {
+    // defaultState's human has cards: [] → no "Your hand" line.
+    expect(formatDDZState(defaultState)).not.toContain('Your hand');
+  });
+
   it('labels hand cards via cardAlt and reflects selection with aria-pressed', async () => {
     mockExec.mockResolvedValue({
       ...defaultState,

--- a/frontend/src/pages/DoudizhuPage.test.tsx
+++ b/frontend/src/pages/DoudizhuPage.test.tsx
@@ -124,6 +124,29 @@ describe('DoudizhuPage', () => {
     });
   });
 
+  it('labels hand cards via cardAlt and reflects selection with aria-pressed', async () => {
+    mockExec.mockResolvedValue({
+      ...defaultState,
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          isFinished: false,
+          isLandlord: true,
+          cardCount: 1,
+          cards: [{ design: 'SPADE', value: 5 }],
+        },
+        { id: 1, isHuman: false, isFinished: false, isLandlord: false, cardCount: 17, cards: [] },
+        { id: 2, isHuman: false, isFinished: false, isLandlord: false, cardCount: 17, cards: [] },
+      ],
+    });
+    renderWithProviders(<DoudizhuPage />);
+    const cardBtn = await screen.findByRole('button', { name: '♠ 5' });
+    expect(cardBtn).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(cardBtn);
+    expect(cardBtn).toHaveAttribute('aria-pressed', 'true');
+  });
+
   it('disables play until a card is selected, then plays on click', async () => {
     mockExec.mockResolvedValue({
       ...defaultState,

--- a/frontend/src/pages/DoudizhuPage.tsx
+++ b/frontend/src/pages/DoudizhuPage.tsx
@@ -71,7 +71,8 @@ function parseDDZCommand(input: string): CliParseResult<[ApiArgs]> {
   }
 }
 
-function formatDDZState(state: DoudizhuResponse): string {
+/** Formats Dou Dizhu state for the CLI terminal, including the human's indexed hand. */
+export function formatDDZState(state: DoudizhuResponse): string {
   const lines: string[] = [`Phase: ${state.phase}`];
   for (const p of state.players) {
     const role = p.isLandlord ? ' [Landlord]' : '';

--- a/frontend/src/pages/DoudizhuPage.tsx
+++ b/frontend/src/pages/DoudizhuPage.tsx
@@ -24,6 +24,7 @@ import { btnPrimary, btnSecondary, btnWarning } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { DoudizhuResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 
 type ApiArgs = {
@@ -79,6 +80,10 @@ function formatDDZState(state: DoudizhuResponse): string {
   }
   if (state.tableCards.length > 0) {
     lines.push(`Table: ${state.tableCombo} (${state.tableCards.length} cards)`);
+  }
+  const human = state.players.find((p) => p.isHuman);
+  if (human?.cards?.length) {
+    lines.push(`Your hand: ${human.cards.map((c, i) => `[${i}]${cardAlt(c)}`).join(' ')}`);
   }
   if (state.message) lines.push(state.message);
   return lines.join('\n');
@@ -285,6 +290,8 @@ function DoudizhuPageContent() {
                         : 'transition-transform'
                     }
                     onClick={() => toggleCard(i)}
+                    aria-label={cardAlt(c)}
+                    aria-pressed={selectedCards.has(i)}
                   >
                     <AnimatedCard card={c} width={cardWidth * 0.9} />
                   </button>


### PR DESCRIPTION
## Summary
Dou Dizhu's hand-card buttons had no `aria-label` (screen readers announced unnamed buttons), and the CLI formatter never listed the hand.

- Hand-card buttons now get `aria-label={cardAlt(card)}` + `aria-pressed` for selection state.
- `formatDDZState` now lists the human's hand indexed (e.g. `Your hand: [0]♠ 5 …`) so the cards are readable in CLI mode.

## Test plan
- [x] `bun run test -- --run src/pages/DoudizhuPage.test.tsx` (14 passed) — card aria-label + aria-pressed toggle
- [x] `bun run check` (exit 0)

Closes #2639