### PR TITLE
feat(briscola): localize hand-card aria-labels via cardAlt

### DIFF
--- a/frontend/src/pages/BriscolaPage.test.tsx
+++ b/frontend/src/pages/BriscolaPage.test.tsx
@@ -73,17 +73,17 @@ describe('BriscolaPage', () => {
 
   it('shows human hand as 3 play buttons', async () => {
     renderWithProviders(<BriscolaPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Play SPADE 1' })).toBeInTheDocument());
-    expect(screen.getByRole('button', { name: 'Play HEART 5' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Play DIAMOND 11' })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole('button', { name: '♠ A を出す' })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: '♥ 5 を出す' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '♦ J を出す' })).toBeInTheDocument();
   });
 
   it('fires play with the selected card index when a card is clicked', async () => {
     renderWithProviders(<BriscolaPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Play HEART 5' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '♥ 5 を出す' })).toBeInTheDocument());
 
     mockExec.mockClear();
-    fireEvent.click(screen.getByRole('button', { name: 'Play HEART 5' }));
+    fireEvent.click(screen.getByRole('button', { name: '♥ 5 を出す' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', 1));
   });
 
@@ -155,7 +155,7 @@ describe('BriscolaPage', () => {
     mockExec.mockResolvedValue(makeState({ currentPlayerIdx: 1 }));
     renderWithProviders(<BriscolaPage />);
     await waitFor(() => {
-      const btn = screen.getByRole('button', { name: 'Play SPADE 1' });
+      const btn = screen.getByRole('button', { name: '♠ A を出す' });
       expect(btn).toBeDisabled();
     });
   });

--- a/frontend/src/pages/BriscolaPage.tsx
+++ b/frontend/src/pages/BriscolaPage.tsx
@@ -17,6 +17,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { BriscolaResponse } from '../types/card';
 import { BriscolaPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 
 /** Tutorial steps for the Briscola page. */
 const BRISCOLA_TUTORIAL_STEPS: TutorialStep[] = [
@@ -211,7 +212,7 @@ function BriscolaPageContent() {
                   type="button"
                   onClick={() => handlePlay(idx)}
                   disabled={loading || !isHumanTurn}
-                  aria-label={`Play ${card.design} ${card.value}`}
+                  aria-label={tc('card.play', { card: cardAlt(card) })}
                   className="disabled:opacity-50"
                 >
                   <CardImage card={card} width={cardWidth} />


### PR DESCRIPTION
## Summary
Briscola's hand-card buttons used a raw `aria-label={\`Play ${card.design} ${card.value}\`}` ("Play SPADE 11"). Route it through `cardAlt()` + the shared `common` `card.play` key so screen readers announce localized names (e.g. "♠ A を出す"), matching Truco/Beleaguered Castle/etc.

## Test plan
- [x] `bun run test -- --run src/pages/BriscolaPage.test.tsx` (12 passed)
- [x] `bun run check` (exit 0)

Closes #2630