### PR TITLE
feat(russianpoker): localize player-card aria-labels via cardAlt

### DIFF
--- a/frontend/src/pages/RussianPokerPage.test.tsx
+++ b/frontend/src/pages/RussianPokerPage.test.tsx
@@ -52,6 +52,14 @@ describe('RussianPokerPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
+  it('labels player cards with localized names via cardAlt', async () => {
+    renderWithProviders(<RussianPokerPage />);
+    // playerHand[0] is ♠10 → cardAlt label, not the old "Card 1".
+    const firstCard = await screen.findByTestId('player-card-0');
+    expect(firstCard).toHaveAttribute('aria-label', '♠ 10');
+    expect(firstCard.getAttribute('aria-label')).not.toMatch(/Card 1/);
+  });
+
   it('shows the exchange-cost line from the start of the action phase (0 cards = 0 fee)', async () => {
     renderWithProviders(<RussianPokerPage />);
     const line = await screen.findByTestId('russian-exchange-fee-line');

--- a/frontend/src/pages/RussianPokerPage.tsx
+++ b/frontend/src/pages/RussianPokerPage.tsx
@@ -28,6 +28,7 @@ import type { RussianPokerResponse } from '../types/card';
 import { isMaskedCard } from '../types/card';
 import { RussianPokerPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import { parseRussianpokerCommand, RUSSIANPOKER_HELP } from '../utils/cli/commands/russianpokerCommands';
 import { formatRussianpokerState } from '../utils/cli/formatters/russianpokerFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -295,7 +296,7 @@ function RussianPokerPageContent() {
                       <button
                         key={`p-${i}`}
                         type="button"
-                        aria-label={`Card ${i + 1}${selected ? ' (selected)' : ''}`}
+                        aria-label={isMaskedCard(card) ? tc('card.back') : cardAlt(card)}
                         aria-pressed={selectable ? selected : undefined}
                         data-testid={`player-card-${i}`}
                         data-selected={selected ? 'true' : 'false'}

--- a/frontend/src/pages/RussianPokerPage.tsx
+++ b/frontend/src/pages/RussianPokerPage.tsx
@@ -296,7 +296,7 @@ function RussianPokerPageContent() {
                       <button
                         key={`p-${i}`}
                         type="button"
-                        aria-label={isMaskedCard(card) ? tc('card.back') : cardAlt(card)}
+                        aria-label={cardAlt(card)}
                         aria-pressed={selectable ? selected : undefined}
                         data-testid={`player-card-${i}`}
                         data-selected={selected ? 'true' : 'false'}


### PR DESCRIPTION
## Summary
Russian Poker's player-hand buttons used `aria-label="Card N"`, telling screen-reader users nothing about the card. Replace with `cardAlt(card)` (guarding masked cards with the localized card-back label). Selection state is already conveyed by the existing `aria-pressed`, so the redundant "(selected)" suffix is dropped.

## Test plan
- [x] `bun run test -- --run src/pages/RussianPokerPage.test.tsx` (5 passed) — first card labelled "♠ 10", not "Card 1"
- [x] `bun run check` (exit 0)

Closes #2635