### PR TITLE
feat(bakersgame): aria-label for empty tableau columns

### DIFF
--- a/frontend/src/i18n/locales/en/bakersgame.json
+++ b/frontend/src/i18n/locales/en/bakersgame.json
@@ -33,5 +33,6 @@
     "freeCellsFilling": "Free cells are almost full — try to clear some",
     "useEmptyColumn": "An empty column is available — use it for reorganization",
     "useFreeCells": "Consider moving a card to a free cell to open up moves"
-  }
+  },
+  "emptyTableauColumnAriaLabel": "Empty tableau column {{idx}} (move target)"
 }

--- a/frontend/src/i18n/locales/ja/bakersgame.json
+++ b/frontend/src/i18n/locales/ja/bakersgame.json
@@ -33,5 +33,6 @@
     "freeCellsFilling": "フリーセルがほぼ満杯です — 空けることを検討しましょう",
     "useEmptyColumn": "空の列があります — 整理に活用しましょう",
     "useFreeCells": "フリーセルにカードを移動して手を広げましょう"
-  }
+  },
+  "emptyTableauColumnAriaLabel": "空のタブロー列 {{idx}}（カードの移動先）"
 }

--- a/frontend/src/pages/BakersGamePage.test.tsx
+++ b/frontend/src/pages/BakersGamePage.test.tsx
@@ -94,6 +94,12 @@ describe('BakersGamePage', () => {
     expect(kElements.length).toBeGreaterThanOrEqual(1);
   });
 
+  it('labels empty tableau columns for screen readers', async () => {
+    renderWithProviders(<BakersGamePage />);
+    // playingState columns 2-7 are empty → each empty-column button is labelled.
+    await waitFor(() => expect(screen.getByLabelText('空のタブロー列 2（カードの移動先）')).toBeInTheDocument());
+  });
+
   // --- Foundation ---
 
   it('renders foundation piles with suit symbols', async () => {

--- a/frontend/src/pages/BakersGamePage.tsx
+++ b/frontend/src/pages/BakersGamePage.tsx
@@ -363,6 +363,7 @@ function BakersGamePageContent() {
                               disabled={!isPlaying || loading || !selectedSource}
                               style={{ height: cardHeight }}
                               className={`w-full rounded border-2 border-dashed border-white/20 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}`}
+                              aria-label={t('emptyTableauColumnAriaLabel', { idx: String(colIdx) })}
                             >
                               K
                             </button>


### PR DESCRIPTION
## Summary
Baker's Game labelled empty free-cell and foundation slots for screen readers, but the empty **tableau** column buttons had only a hardcoded "K" text node. This adds a parallel `emptyTableauColumnAriaLabel` (indexed) so AT users can tell which empty column they're moving a card to.

## Test plan
- [x] `bun run test -- --run src/pages/BakersGamePage.test.tsx` (66 passed) — empty column button labelled
- [x] `bun run check` (exit 0)

Closes #2658