### PR TITLE
feat(easthaven): move-target aria-label on empty columns

### DIFF
--- a/frontend/src/i18n/locales/en/easthaven.json
+++ b/frontend/src/i18n/locales/en/easthaven.json
@@ -39,5 +39,6 @@
   },
   "nav": {
     "easthaven": "Easthaven"
-  }
+  },
+  "moveHereAriaLabel": "Empty tableau column {{col}} (move here)"
 }

--- a/frontend/src/i18n/locales/ja/easthaven.json
+++ b/frontend/src/i18n/locales/ja/easthaven.json
@@ -39,5 +39,6 @@
   },
   "nav": {
     "easthaven": "イーストヘイブン"
-  }
+  },
+  "moveHereAriaLabel": "空のタブロー列 {{col}}（ここに移動）"
 }

--- a/frontend/src/pages/EasthavenPage.test.tsx
+++ b/frontend/src/pages/EasthavenPage.test.tsx
@@ -224,6 +224,30 @@ describe('EasthavenPage', () => {
     );
   });
 
+  it('toggles the empty-column aria-label when a source is selected', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      tableau: [
+        [{ card: card('SPADE', 13), faceUp: true }],
+        [{ card: card('HEART', 8), faceUp: true }],
+        [{ card: card('CLOVER', 5), faceUp: true }],
+        [{ card: card('DIAMOND', 10), faceUp: true }],
+        [{ card: card('SPADE', 3), faceUp: true }],
+        [{ card: card('HEART', 7), faceUp: true }],
+        [], // empty column 6
+      ],
+    });
+    renderWithProviders(<EasthavenPage />);
+    const emptyCol = await screen.findByTestId('eh-empty-col-6');
+    // No source selected → plain "empty" label.
+    expect(emptyCol.getAttribute('aria-label')).not.toContain('ここに移動');
+    // Selecting a source switches it to a "move here" prompt.
+    screen.getByRole('button', { name: '♠ K' }).click();
+    await waitFor(() =>
+      expect(screen.getByTestId('eh-empty-col-6').getAttribute('aria-label')).toContain('ここに移動'),
+    );
+  });
+
   it('selecting a card then a foundation fires a foundation move', async () => {
     renderWithProviders(<EasthavenPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));

--- a/frontend/src/pages/EasthavenPage.tsx
+++ b/frontend/src/pages/EasthavenPage.tsx
@@ -502,7 +502,11 @@ function EasthavenPageContent() {
                         style={{ width: eh.cw, height: eh.ch }}
                         onClick={() => selectedSource && handleSelectTarget('tableau', colIdx)}
                         disabled={!isPlaying || !selectedSource}
-                        aria-label={`${t('empty')} ${t('tableau')} ${colIdx}`}
+                        aria-label={
+                          selectedSource
+                            ? t('moveHereAriaLabel', { col: colIdx })
+                            : `${t('empty')} ${t('tableau')} ${colIdx}`
+                        }
                         data-testid={`eh-empty-col-${colIdx.toString()}`}
                       >
                         {t('empty')}


### PR DESCRIPTION
## Summary
Easthaven's empty tableau-column buttons used a static concatenated label and didn't tell screen-reader users they were a valid drop target once a card was selected (the cue was visual-only `hover:ring`). Now the label switches to `moveHereAriaLabel` ("…move here") when `selectedSource` is set, matching the foundation slots.

## Test plan
- [x] `bun run test -- --run src/pages/EasthavenPage.test.tsx` (24 passed) — label toggles base ↔ move-here on source selection
- [x] `bun run check` (exit 0)

Closes #2656