### PR TITLE
feat(callbreak): aria-live announcement of selected bid

### DIFF
--- a/frontend/src/i18n/locales/en/callbreak.json
+++ b/frontend/src/i18n/locales/en/callbreak.json
@@ -75,5 +75,6 @@
     "followSuit": "Follow the led suit",
     "mustTrumpWithSpade": "Void: must trump with a spade",
     "discardLowest": "Discard your lowest card"
-  }
+  },
+  "bidSelected": "Selected bid: {{n}}"
 }

--- a/frontend/src/i18n/locales/ja/callbreak.json
+++ b/frontend/src/i18n/locales/ja/callbreak.json
@@ -75,5 +75,6 @@
     "followSuit": "リードされたスートに従ってプレイ推奨",
     "mustTrumpWithSpade": "ボイドなのでスペードで切らなければなりません",
     "discardLowest": "最も低いカードを捨てることを推奨"
-  }
+  },
+  "bidSelected": "選択中のビッド: {{n}}"
 }

--- a/frontend/src/pages/CallBreakPage.test.tsx
+++ b/frontend/src/pages/CallBreakPage.test.tsx
@@ -118,6 +118,8 @@ describe('CallBreakPage', () => {
     // Select bid 5 from the button group.
     fireEvent.click(screen.getByTestId('bid-option-5'));
     expect(screen.getByTestId('bid-option-5')).toHaveAttribute('aria-pressed', 'true');
+    // The live region reflects the current selection for screen readers.
+    expect(screen.getByTestId('cb-bid-selected')).toHaveTextContent('5');
 
     mockExec.mockClear();
     mockExec.mockResolvedValue(playPhaseState);

--- a/frontend/src/pages/CallBreakPage.tsx
+++ b/frontend/src/pages/CallBreakPage.tsx
@@ -485,6 +485,11 @@ function CallBreakPageContent() {
                       </button>
                     ))}
                   </fieldset>
+                  {/* Announce the current bid selection to screen readers, since the
+                      grid's aria-pressed alone isn't read back as a running value. */}
+                  <span className="sr-only" role="status" aria-live="polite" data-testid="cb-bid-selected">
+                    {t('bidSelected', { n: bidValue })}
+                  </span>
                   <button type="button" className={btnPrimary} onClick={() => handleBid(bidValue)} disabled={loading}>
                     {t('bidButton')}
                   </button>


### PR DESCRIPTION
## Summary
Call Break's 1–13 bid grid set `aria-pressed` per button but never announced the running selection, so screen-reader users got no feedback when changing the value. This adds an `aria-live="polite"` sr-only region (`cb-bid-selected`) that reflects the current `bidValue`. `bidSelected` i18n added (ja/en).

## Test plan
- [x] `bun run test -- --run src/pages/CallBreakPage.test.tsx` (20 passed) — live region reflects the selected value
- [x] `bun run check` (exit 0)

Closes #2627