### PR TITLE
feat(crescent): show tableau column-number badges

### DIFF
--- a/frontend/src/pages/CrescentPage.test.tsx
+++ b/frontend/src/pages/CrescentPage.test.tsx
@@ -266,4 +266,14 @@ describe('CrescentPage', () => {
       window.dispatchEvent(new Event('resize'));
     }
   });
+
+  it('renders a [0]..[15] column-number badge above each tableau pile', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<CrescentPage />);
+    await waitFor(() => expect(screen.getByTestId('crescent-col-badge-0')).toBeInTheDocument());
+    expect(screen.getByTestId('crescent-col-badge-0')).toHaveTextContent('[0]');
+    expect(screen.getByTestId('crescent-col-badge-15')).toHaveTextContent('[15]');
+    // The badge is decorative — it must not add to the SR card label noise.
+    expect(screen.getByTestId('crescent-col-badge-7')).toHaveAttribute('aria-hidden', 'true');
+  });
 });

--- a/frontend/src/pages/CrescentPage.tsx
+++ b/frontend/src/pages/CrescentPage.tsx
@@ -312,6 +312,15 @@ function CrescentPageContent() {
                     data-crescent-arc={arcOffset}
                     style={arcOffset === 0 ? undefined : { transform: `translateY(${arcOffset}px)` }}
                   >
+                    {/* Column-number badge mirrors the CUI "タブロー列{{col}}" labelling so hints
+                        and logs that reference a column index map to a visible marker (#2618). */}
+                    <div
+                      className="mx-auto mb-0.5 w-fit rounded-full bg-black/20 px-1.5 text-[10px] leading-tight text-ds-text-muted select-none"
+                      aria-hidden="true"
+                      data-testid={`crescent-col-badge-${colIdx.toString()}`}
+                    >
+                      {`[${colIdx.toString()}]`}
+                    </div>
                     <DropZone
                       isDropTarget={dnd.isDropTarget(tableauColZone)}
                       onDragOver={dnd.handleDragOver(tableauColZone)}


### PR DESCRIPTION
## 背景
CrescentPage のタブローは16列の視覚的な列番号が無く、CUI（`タブロー列{{col}}`）と非対称でした。ヒント/ログの列参照が Web UI 上でどの列か特定しづらい状態でした。

## 変更
- 各タブロー列の上部に `[0]`〜`[15]` の控えめなバッジを追加（`bg-black/20 rounded-full text-[10px] text-ds-text-muted`）。
- モバイル（4列）/デスクトップ（8列）両グリッドで `colIdx` ベースに正確番号付け。
- バッジは `aria-hidden` で既存 `cardAlt` の aria-label と重複しない。

## テスト
- `[0]`/`[15]` バッジ表示と `aria-hidden` を検証する page テストを追加（19 passed）。
- `bun run check` OK。

Closes #2618