### PR TITLE
feat(slapjack): announce slap outcome in a live region

### DIFF
--- a/frontend/src/i18n/locales/en/slapjack.json
+++ b/frontend/src/i18n/locales/en/slapjack.json
@@ -30,6 +30,10 @@
     "burst": {
       "jack": "JACK!",
       "miss": "MISS!"
+    },
+    "slapAnnounce": {
+      "correct": "Slap won by {{player}}",
+      "wrong": "False slap by {{player}}"
     }
   },
   "hint": {

--- a/frontend/src/i18n/locales/ja/slapjack.json
+++ b/frontend/src/i18n/locales/ja/slapjack.json
@@ -30,6 +30,10 @@
     "burst": {
       "jack": "ジャック！",
       "miss": "ミス！"
+    },
+    "slapAnnounce": {
+      "correct": "スラップ成功（{{player}}）",
+      "wrong": "お手つき（{{player}}）"
     }
   },
   "hint": {

--- a/frontend/src/pages/SlapjackPage.test.tsx
+++ b/frontend/src/pages/SlapjackPage.test.tsx
@@ -4,7 +4,7 @@ import { slapjackApi } from '../api/gameApi';
 import { useCliMode } from '../hooks/useCliMode';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { SlapjackResponse } from '../types/card';
-import { SlapjackPhase } from '../types/phases';
+import { SlapjackEventKind, SlapjackPhase } from '../types/phases';
 import { SlapjackPage } from './SlapjackPage';
 
 vi.mock('../hooks/useCliMode', () => ({
@@ -171,7 +171,11 @@ describe('SlapjackPage', () => {
   });
 
   it('announces a correct slap by the human via a polite status live region', async () => {
-    mockExec.mockResolvedValueOnce({ ...baseState, lastEventKind: 2, lastEventPlayerIdx: 0 });
+    mockExec.mockResolvedValueOnce({
+      ...baseState,
+      lastEventKind: SlapjackEventKind.SLAP_CORRECT,
+      lastEventPlayerIdx: 0,
+    });
     renderWithProviders(<SlapjackPage />);
     const announce = await screen.findByTestId('sj-slap-announce');
     expect(announce).toHaveAttribute('role', 'status');
@@ -180,7 +184,11 @@ describe('SlapjackPage', () => {
   });
 
   it('announces a false slap by the CPU naming the offender', async () => {
-    mockExec.mockResolvedValueOnce({ ...baseState, lastEventKind: 3, lastEventPlayerIdx: 1 });
+    mockExec.mockResolvedValueOnce({
+      ...baseState,
+      lastEventKind: SlapjackEventKind.SLAP_WRONG,
+      lastEventPlayerIdx: 1,
+    });
     renderWithProviders(<SlapjackPage />);
     const announce = await screen.findByTestId('sj-slap-announce');
     await waitFor(() => expect(announce).toHaveTextContent('お手つき（CPU 1）'));

--- a/frontend/src/pages/SlapjackPage.test.tsx
+++ b/frontend/src/pages/SlapjackPage.test.tsx
@@ -170,6 +170,22 @@ describe('SlapjackPage', () => {
     expect(announce).toHaveTextContent('');
   });
 
+  it('announces a correct slap by the human via a polite status live region', async () => {
+    mockExec.mockResolvedValueOnce({ ...baseState, lastEventKind: 2, lastEventPlayerIdx: 0 });
+    renderWithProviders(<SlapjackPage />);
+    const announce = await screen.findByTestId('sj-slap-announce');
+    expect(announce).toHaveAttribute('role', 'status');
+    expect(announce).toHaveAttribute('aria-live', 'polite');
+    await waitFor(() => expect(announce).toHaveTextContent('スラップ成功（あなた）'));
+  });
+
+  it('announces a false slap by the CPU naming the offender', async () => {
+    mockExec.mockResolvedValueOnce({ ...baseState, lastEventKind: 3, lastEventPlayerIdx: 1 });
+    renderWithProviders(<SlapjackPage />);
+    const announce = await screen.findByTestId('sj-slap-announce');
+    await waitFor(() => expect(announce).toHaveTextContent('お手つき（CPU 1）'));
+  });
+
   it('renders the game-end state with both buttons disabled when human wins', async () => {
     mockExec.mockResolvedValueOnce(gameEndState);
     renderWithProviders(<SlapjackPage />);

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -81,6 +81,9 @@ function SlapjackPageContent() {
     outcome: 'correct',
     label: '',
   });
+  // Screen-reader announcement for the slap outcome (who slapped + correct/miss).
+  // The visual SlapBurst alone is invisible to assistive tech (#2607).
+  const [slapAnnounce, setSlapAnnounce] = useState('');
   const prevSlapEventRef = useRef<{ kind: number; player: number }>({ kind: -1, player: -1 });
   useEffect(() => {
     if (!state) return;
@@ -96,9 +99,11 @@ function SlapjackPageContent() {
       // Counter (not Date.now()) keeps repeated slap events distinct even
       // when they happen within the same millisecond.
       setSlapBurst((prevBurst) => ({ key: prevBurst.key + 1, outcome, label }));
+      const slapper = player === 0 ? tc('player.you') : tc('player.cpu', { id: player });
+      setSlapAnnounce(t(`slapjack.slapAnnounce.${outcome}`, { player: slapper }));
       prevSlapEventRef.current = { kind, player };
     }
-  }, [state, t]);
+  }, [state, t, tc]);
 
   useMountReset(execApi);
 
@@ -253,6 +258,16 @@ function SlapjackPageContent() {
                 {/* Screen-reader announcement for the flash slap chance. */}
                 <div className="sr-only" aria-live="assertive" aria-atomic="true" data-testid="sj-jack-announce">
                   {state.isTopJack ? t('slapjack.jackAnnounce') : ''}
+                </div>
+                {/* Screen-reader announcement for the slap outcome (#2607). */}
+                <div
+                  className="sr-only"
+                  role="status"
+                  aria-live="polite"
+                  aria-atomic="true"
+                  data-testid="sj-slap-announce"
+                >
+                  {slapAnnounce}
                 </div>
               </div>
             </div>

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -86,7 +86,12 @@ function SlapjackPageContent() {
   const [slapAnnounce, setSlapAnnounce] = useState('');
   const prevSlapEventRef = useRef<{ kind: number; player: number }>({ kind: -1, player: -1 });
   useEffect(() => {
-    if (!state) return;
+    if (!state) {
+      // A reset blanks `state` momentarily; clear the live region so a fresh
+      // game never surfaces the previous round's stale announcement.
+      setSlapAnnounce('');
+      return;
+    }
     const kind = state.lastEventKind;
     const player = state.lastEventPlayerIdx;
     const prev = prevSlapEventRef.current;


### PR DESCRIPTION
## 背景
スラップ判定の結果（`SLAP_CORRECT`/`SLAP_WRONG`）はビジュアル演出 `SlapBurst` のみで提示され、誰がスラップを取ったか・正解だったかがスクリーンリーダー利用者に伝わりませんでした。

## 変更
- スラップイベント検出時（`prevSlapEventRef` 更新箇所）に `role="status" aria-live="polite"` のライブ領域へローカライズ文言を出力（`スラップ成功（あなた）` / `お手つき（CPU 1）` 等、実行者名を含む）。
- 視覚演出 `SlapBurst` は従来どおり（変更なし）。
- `slapjack.slapAnnounce.{correct,wrong}` を ja/en に追加。

## テスト
- 人間の正解スラップ / CPU のお手つきの読み上げを検証する page テストを2件追加（18 passed）。
- `bun run check` OK、i18n ja/en parity 維持。

Closes #2607