### PR TITLE
feat(accordion): announce a selected pile's legal merges to screen readers

### DIFF
--- a/frontend/src/i18n/locales/en/accordion.json
+++ b/frontend/src/i18n/locales/en/accordion.json
@@ -21,6 +21,10 @@
   "hintAvailable": "Hint available",
   "stalemate": "No moves available",
   "hintMove": "Pile {{from}} → Pile {{to}}",
+  "mergeOffsetAvailable": "can merge {{offset}} to the left",
+  "noMergeAvailable": "no merge available",
+  "selectionMoves": "Pile {{idx}} selected. {{count}} merge(s) available",
+  "selectionNoMoves": "Pile {{idx}} selected. No merge available",
   "landscapeBanner": "Landscape orientation recommended",
   "frontendHint": {
     "accordionOffset1": "You can merge with the adjacent pile to the left",

--- a/frontend/src/i18n/locales/en/accordion.json
+++ b/frontend/src/i18n/locales/en/accordion.json
@@ -21,6 +21,7 @@
   "hintAvailable": "Hint available",
   "stalemate": "No moves available",
   "hintMove": "Pile {{from}} → Pile {{to}}",
+  "listSeparator": ", ",
   "mergeOffsetAvailable": "can merge {{offset}} to the left",
   "noMergeAvailable": "no merge available",
   "selectionMoves": "Pile {{idx}} selected. {{count}} merge(s) available",

--- a/frontend/src/i18n/locales/ja/accordion.json
+++ b/frontend/src/i18n/locales/ja/accordion.json
@@ -21,6 +21,7 @@
   "hintAvailable": "ヒントがあります",
   "stalemate": "手詰まりです",
   "hintMove": "パイル{{from}} → パイル{{to}}",
+  "listSeparator": "、",
   "mergeOffsetAvailable": "左{{offset}}へマージ可",
   "noMergeAvailable": "マージ可能な手なし",
   "selectionMoves": "パイル{{idx}}を選択中。マージ可能な手が{{count}}通り",

--- a/frontend/src/i18n/locales/ja/accordion.json
+++ b/frontend/src/i18n/locales/ja/accordion.json
@@ -21,6 +21,10 @@
   "hintAvailable": "ヒントがあります",
   "stalemate": "手詰まりです",
   "hintMove": "パイル{{from}} → パイル{{to}}",
+  "mergeOffsetAvailable": "左{{offset}}へマージ可",
+  "noMergeAvailable": "マージ可能な手なし",
+  "selectionMoves": "パイル{{idx}}を選択中。マージ可能な手が{{count}}通り",
+  "selectionNoMoves": "パイル{{idx}}を選択中。マージ可能な手なし",
   "landscapeBanner": "横向き画面推奨",
   "frontendHint": {
     "accordionOffset1": "左隣のカードと合流できます",

--- a/frontend/src/pages/AccordionPage.test.tsx
+++ b/frontend/src/pages/AccordionPage.test.tsx
@@ -292,7 +292,7 @@ describe('AccordionPage', () => {
     });
     renderWithProviders(<AccordionPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    const hintBox = screen.getByRole('status');
+    const hintBox = await screen.findByText(/パイル3 → パイル0/);
     expect(hintBox.textContent).toMatch(/3/);
     expect(hintBox.textContent).toMatch(/0/);
   });
@@ -349,6 +349,45 @@ describe('AccordionPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     // Empty pile still renders a button with 0: empty aria-label
     expect(screen.getByRole('button', { name: /^0: empty$/ })).toBeInTheDocument();
+  });
+
+  it('reflects a selected pile’s legal merge offsets in its aria-label and live region', async () => {
+    // pile 3 (SPADE 9) can merge onto pile 0 (SPADE 7) at offset 3 (suit match).
+    mockExec.mockResolvedValue({
+      ...playingState,
+      piles: [
+        { cards: [card('SPADE', 7)], size: 1 },
+        { cards: [card('HEART', 2)], size: 1 },
+        { cards: [card('CLOVER', 3)], size: 1 },
+        { cards: [card('SPADE', 9)], size: 1 },
+      ],
+    });
+    renderWithProviders(<AccordionPage />);
+    const pile3 = await screen.findByRole('button', { name: /^3: ♠ 9/ });
+    fireEvent.click(pile3);
+    await waitFor(() => expect(screen.getByRole('button', { name: /3: ♠ 9 — 左3へマージ可/ })).toBeInTheDocument());
+    const status = screen.getByTestId('ac-selection-status');
+    expect(status).toHaveAttribute('role', 'status');
+    expect(status).toHaveTextContent('パイル3を選択中。マージ可能な手が1通り');
+  });
+
+  it('announces when a selected pile has no legal merge', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      piles: [
+        { cards: [card('SPADE', 7)], size: 1 },
+        { cards: [card('HEART', 2)], size: 1 },
+        { cards: [card('CLOVER', 3)], size: 1 },
+        { cards: [card('SPADE', 9)], size: 1 },
+      ],
+    });
+    renderWithProviders(<AccordionPage />);
+    const pile1 = await screen.findByRole('button', { name: /^1: ♥ 2/ });
+    fireEvent.click(pile1);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /1: ♥ 2 — マージ可能な手なし/ })).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('ac-selection-status')).toHaveTextContent('パイル1を選択中。マージ可能な手なし');
   });
 
   it('renders multi-card pile size badge', async () => {

--- a/frontend/src/pages/AccordionPage.test.tsx
+++ b/frontend/src/pages/AccordionPage.test.tsx
@@ -371,6 +371,26 @@ describe('AccordionPage', () => {
     expect(status).toHaveTextContent('パイル3を選択中。マージ可能な手が1通り');
   });
 
+  it('lists both merge offsets joined by the localized separator when both are legal', async () => {
+    // pile 3 (SPADE 9): offset 1 → pile 2 (SPADE 3, suit) AND offset 3 → pile 0 (SPADE 7, suit).
+    mockExec.mockResolvedValue({
+      ...playingState,
+      piles: [
+        { cards: [card('SPADE', 7)], size: 1 },
+        { cards: [card('HEART', 2)], size: 1 },
+        { cards: [card('SPADE', 3)], size: 1 },
+        { cards: [card('SPADE', 9)], size: 1 },
+      ],
+    });
+    renderWithProviders(<AccordionPage />);
+    const pile3 = await screen.findByRole('button', { name: /^3: ♠ 9/ });
+    fireEvent.click(pile3);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /3: ♠ 9 — 左1へマージ可、左3へマージ可/ })).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('ac-selection-status')).toHaveTextContent('パイル3を選択中。マージ可能な手が2通り');
+  });
+
   it('announces when a selected pile has no legal merge', async () => {
     mockExec.mockResolvedValue({
       ...playingState,

--- a/frontend/src/pages/AccordionPage.tsx
+++ b/frontend/src/pages/AccordionPage.tsx
@@ -29,7 +29,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { AccordionResponse } from '../types/card';
 import { AccordionPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
-import { accordionLegalTargets } from '../utils/accordionUtils';
+import { accordionLegalOffsets, accordionLegalTargets } from '../utils/accordionUtils';
 import { cardAlt } from '../utils/cardAlt';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 
@@ -346,6 +346,18 @@ function AccordionPageContent() {
                   const hintFrom = state.hint?.fromIdx === idx;
                   const hintTo = state.hint?.toIdx === idx;
                   const isHoverTarget = hoverTargets?.has(idx) ?? false;
+                  // When a pile is selected, spell out its legal merge offsets (1/3)
+                  // in the aria-label so screen-reader users learn where it can go (#2596).
+                  const mergeSuffix =
+                    isSelected && top
+                      ? (() => {
+                          const offsets = accordionLegalOffsets(state.piles, idx);
+                          return offsets.length > 0
+                            ? ` — ${offsets.map((o) => t('mergeOffsetAvailable', { offset: o })).join('、')}`
+                            : ` — ${t('noMergeAvailable')}`;
+                        })()
+                      : '';
+                  const baseLabel = top ? `${idx}: ${cardAlt(top)}` : `${idx}: empty`;
                   // Keying by the top card's identity lets React preserve
                   // per-pile state (ring/selection class transitions, AnimatedCard
                   // instances) when piles shift left after a merge.
@@ -366,7 +378,7 @@ function AccordionPageContent() {
                       onBlur={() => setHoveredIdx((cur) => (cur === idx ? null : cur))}
                       disabled={!isPlaying}
                       data-hover-target={isHoverTarget ? 'true' : 'false'}
-                      aria-label={top ? `${idx}: ${cardAlt(top)}` : `${idx}: empty`}
+                      aria-label={`${baseLabel}${mergeSuffix}`}
                     >
                       {top && <AnimatedCard card={top} width={cardWidth} />}
                       <span className="absolute top-0 left-0 text-[10px] bg-black/40 text-ds-text-primary rounded-br px-1">
@@ -382,6 +394,18 @@ function AccordionPageContent() {
                 });
               })()}
             </div>
+          </div>
+
+          {/* SR-only live region announcing the selected pile's available merges (#2596). */}
+          <div className="sr-only" role="status" aria-live="polite" data-testid="ac-selection-status">
+            {isPlaying && selectedIdx !== null
+              ? (() => {
+                  const count = accordionLegalOffsets(state.piles, selectedIdx).length;
+                  return count > 0
+                    ? t('selectionMoves', { idx: selectedIdx, count })
+                    : t('selectionNoMoves', { idx: selectedIdx });
+                })()
+              : ''}
           </div>
 
           <div data-tutorial="ac-controls">

--- a/frontend/src/pages/AccordionPage.tsx
+++ b/frontend/src/pages/AccordionPage.tsx
@@ -353,7 +353,7 @@ function AccordionPageContent() {
                       ? (() => {
                           const offsets = accordionLegalOffsets(state.piles, idx);
                           return offsets.length > 0
-                            ? ` — ${offsets.map((o) => t('mergeOffsetAvailable', { offset: o })).join('、')}`
+                            ? ` — ${offsets.map((o) => t('mergeOffsetAvailable', { offset: o })).join(t('listSeparator'))}`
                             : ` — ${t('noMergeAvailable')}`;
                         })()
                       : '';

--- a/frontend/src/utils/accordionUtils.test.ts
+++ b/frontend/src/utils/accordionUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AccordionPile, Card, CardDesign } from '../types/card';
-import { accordionLegalTargets } from './accordionUtils';
+import { accordionLegalOffsets, accordionLegalTargets } from './accordionUtils';
 
 const card = (design: CardDesign, value: number): Card => ({ design, value });
 const pile = (top: Card | undefined): AccordionPile => ({ cards: top ? [top] : [], size: top ? 1 : 0 });
@@ -42,5 +42,17 @@ describe('accordionLegalTargets', () => {
   it('skips empty target pile at valid offset', () => {
     // fromIdx=1 (SPADE 9), toIdx=0 exists but is empty → no match
     expect(accordionLegalTargets([pile(undefined), pile(card('SPADE', 9))], 1)).toEqual([]);
+  });
+});
+
+describe('accordionLegalOffsets', () => {
+  it('maps legal targets back to their offsets (1 and/or 3)', () => {
+    const piles = [pile(card('SPADE', 7)), pile(card('HEART', 7)), pile(card('CLOVER', 7)), pile(card('DIAMOND', 7))];
+    // targets [2, 0] from idx 3 → offsets [1, 3]
+    expect(accordionLegalOffsets(piles, 3)).toEqual([1, 3]);
+  });
+
+  it('returns an empty array when no merge is legal', () => {
+    expect(accordionLegalOffsets([pile(card('SPADE', 2)), pile(card('HEART', 9))], 1)).toEqual([]);
   });
 });

--- a/frontend/src/utils/accordionUtils.ts
+++ b/frontend/src/utils/accordionUtils.ts
@@ -23,3 +23,12 @@ export function accordionLegalTargets(piles: readonly AccordionPile[], fromIdx: 
   }
   return targets;
 }
+
+/**
+ * Returns the legal merge *offsets* (a subset of {@link ACCORDION_OFFSETS}, i.e.
+ * `1` and/or `3`) available from `fromIdx`, derived from {@link accordionLegalTargets}.
+ * Used to describe a selected pile's moves to assistive tech (#2596).
+ */
+export function accordionLegalOffsets(piles: readonly AccordionPile[], fromIdx: number): number[] {
+  return accordionLegalTargets(piles, fromIdx).map((toIdx) => fromIdx - toIdx);
+}


### PR DESCRIPTION
## 背景
`AccordionPage` の合法移動先ハイライト（`accordionLegalTargets` による `ring-ds-success`）はホバー/フォーカス由来の色のみで、矢印キーで選択中の山について「どこへマージ可能か（1/3キー）」が支援技術に伝わりませんでした。

## 変更
- 選択中（`selectedIdx`）の山ボタンの `aria-label` に合法マージオフセット（`左1へマージ可`/`左3へマージ可`、無ければ `マージ可能な手なし`）を付与。
- 選択中の山の手数を読み上げる `role="status" aria-live="polite"` のSR専用ライブ領域を追加。
- `accordionLegalOffsets` ヘルパーを `accordionUtils.ts` に追加（`accordionLegalTargets` からオフセット導出）。
- ja/en `accordion.json` に `mergeOffsetAvailable`/`noMergeAvailable`/`selectionMoves`/`selectionNoMoves` を追加。

## テスト
- util: `accordionLegalOffsets` の2ケース。
- page: 選択時の aria-label + ライブ領域（マージ可 / 手なし）を検証する2ケース。48 passed、`bun run check` OK。

Closes #2596