### PR TITLE
feat(ecarte): name the current exchange negotiation sub-step

### DIFF
--- a/frontend/src/i18n/locales/en/ecarte.json
+++ b/frontend/src/i18n/locales/en/ecarte.json
@@ -20,6 +20,12 @@
   "stock": "Stock: {{count}}",
   "noTrump": "undeclared",
   "exchangeNotice": "Exchange phase — the elder chooses Propose or Stand; if proposed, the dealer Accepts or Refuses. After accepting, choose cards to discard and draw replacements.",
+  "negStepLabel": "Current step: {{step}}",
+  "negStep": {
+    "elderDecide": "Elder's proposal",
+    "dealerRespond": "Dealer's response",
+    "discard": "Card exchange"
+  },
   "currentTrick": "Current Trick",
   "you": "You",
   "cpu": "CPU {{id}}",

--- a/frontend/src/i18n/locales/ja/ecarte.json
+++ b/frontend/src/i18n/locales/ja/ecarte.json
@@ -20,6 +20,12 @@
   "stock": "山札: {{count}}枚",
   "noTrump": "未宣言",
   "exchangeNotice": "交換フェーズ — エルダーは「交換を提案」か「勝負」を選び、提案されたらディーラーが「承諾」か「拒否」を選びます。承諾後は捨て札を選んで引き直します。",
+  "negStepLabel": "現在のステップ: {{step}}",
+  "negStep": {
+    "elderDecide": "エルダーの提案",
+    "dealerRespond": "ディーラーの応答",
+    "discard": "札交換"
+  },
   "currentTrick": "現在のトリック",
   "you": "あなた",
   "cpu": "CPU {{id}}",

--- a/frontend/src/pages/EcartePage.test.tsx
+++ b/frontend/src/pages/EcartePage.test.tsx
@@ -66,6 +66,24 @@ describe('EcartePage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('propose'));
   });
 
+  it('names the negotiation sub-step in the exchange banner', async () => {
+    renderWithProviders(<EcartePage />);
+    // elderDecideState is the beforeEach default → "Elder's proposal".
+    await waitFor(() => expect(screen.getByTestId('ecarte-neg-step')).toHaveTextContent('エルダーの提案'));
+  });
+
+  it('shows the dealer-response sub-step label on a DealerRespond turn', async () => {
+    mockExec.mockResolvedValue(dealerRespondState);
+    renderWithProviders(<EcartePage />);
+    await waitFor(() => expect(screen.getByTestId('ecarte-neg-step')).toHaveTextContent('ディーラーの応答'));
+  });
+
+  it('shows the discard sub-step label on a discard turn', async () => {
+    mockExec.mockResolvedValue(discardState);
+    renderWithProviders(<EcartePage />);
+    await waitFor(() => expect(screen.getByTestId('ecarte-neg-step')).toHaveTextContent('札交換'));
+  });
+
   it('shows accept/refuse buttons on a DealerRespond turn', async () => {
     mockExec.mockResolvedValue(dealerRespondState);
     renderWithProviders(<EcartePage />);

--- a/frontend/src/pages/EcartePage.tsx
+++ b/frontend/src/pages/EcartePage.tsx
@@ -60,6 +60,18 @@ const ECARTE_PHASE_KEYS: Readonly<Record<number, string>> = {
   [EcartePhase.GAME_END]: 'gameEnd',
 };
 
+/**
+ * Exchange-phase negotiation sub-step → i18n key, mirroring the CUI's
+ * `ecarteNegPromptKey` grouping (both discard steps share one label) so the
+ * Web UI names the current sub-step instead of just showing a generic banner (#2678).
+ */
+const ECARTE_NEG_STEP_KEYS: Readonly<Record<number, string>> = {
+  [EcarteNegStep.ELDER_DECIDE]: 'negStep.elderDecide',
+  [EcarteNegStep.DEALER_RESPOND]: 'negStep.dealerRespond',
+  [EcarteNegStep.ELDER_DISCARD]: 'negStep.discard',
+  [EcarteNegStep.DEALER_DISCARD]: 'negStep.discard',
+};
+
 /** Renders the Écarté game page: a 2-player French trick game with an Exchange phase. */
 export const EcartePage = withTutorial(EcartePageContent, 'ecarte', ECARTE_TUTORIAL_STEPS);
 
@@ -210,7 +222,12 @@ function EcartePageContent() {
             </div>
 
             {isExchangePhase && (
-              <div className="text-ds-text-muted text-center mb-2 text-sm font-semibold">{t('exchangeNotice')}</div>
+              <div className="text-center mb-2">
+                <div className="text-ds-text-muted text-sm font-semibold">{t('exchangeNotice')}</div>
+                <div className="text-ds-accent text-xs mt-0.5" data-testid="ecarte-neg-step">
+                  {t('negStepLabel', { step: t(ECARTE_NEG_STEP_KEYS[state.negStep] ?? 'negStep.elderDecide') })}
+                </div>
+              </div>
             )}
 
             <div className={lgTwoColGrid}>

--- a/frontend/src/pages/EcartePage.tsx
+++ b/frontend/src/pages/EcartePage.tsx
@@ -225,7 +225,7 @@ function EcartePageContent() {
               <div className="text-center mb-2">
                 <div className="text-ds-text-muted text-sm font-semibold">{t('exchangeNotice')}</div>
                 <div className="text-ds-accent text-xs mt-0.5" data-testid="ecarte-neg-step">
-                  {t('negStepLabel', { step: t(ECARTE_NEG_STEP_KEYS[state.negStep] ?? 'negStep.elderDecide') })}
+                  {t('negStepLabel', { step: t(ECARTE_NEG_STEP_KEYS[state.negStep]) })}
                 </div>
               </div>
             )}


### PR DESCRIPTION
## 背景
EXCHANGE フェーズでは汎用的な `exchangeNotice` バナーのみで、いま必要な交渉サブステップ（エルダーの提案／ディーラーの応答／札交換）が名指しされず、ユーザはボタンの有無から推測するしかありませんでした。CUI `EcarteCuiPresenter.go` の `ecarteNegPromptKey` はサブステップを明示しています。

## 変更
- `state.negStep`（`EcarteNegStep`）からサブステップ名を導出し、交換バナー直下に表示（`現在のステップ: …`）。
- CUI の `ecarteNegPromptKey` のグルーピング（両 discard を1ラベルに集約）に整合。
- `negStepLabel` + `negStep.{elderDecide,dealerRespond,discard}` を ja/en に追加。

## テスト
- elderDecide / dealerRespond / discard 各サブステップのラベル表示を検証する page テストを3件追加（15 passed）。`bun run check` OK。

Closes #2678