### PR TITLE
feat(pitch): make the Game-pips breakdown tap-to-open

### DIFF
--- a/frontend/src/i18n/locales/en/pitch.json
+++ b/frontend/src/i18n/locales/en/pitch.json
@@ -24,6 +24,7 @@
   "cards": "{{count}}",
   "gamePips": "Game pips: {{pips}}",
   "gamePipsTooltip": "10=10, A=4, K=3, Q=2, J=1. Whoever captures the most pips wins the Game point.",
+  "gamePipsTotal": "Total",
   "cumulativeScore": "Total: {{score}}",
   "roundScore": "Round: {{score}}",
   "bid": "Bid {{n}}",

--- a/frontend/src/i18n/locales/ja/pitch.json
+++ b/frontend/src/i18n/locales/ja/pitch.json
@@ -24,6 +24,7 @@
   "cards": "{{count}}枚",
   "gamePips": "Game値: {{pips}}",
   "gamePipsTooltip": "10=10, A=4, K=3, Q=2, J=1。獲得カードのピップ合計が最も多い側がGameポイントを取ります。",
+  "gamePipsTotal": "合計",
   "cumulativeScore": "累計: {{score}}",
   "roundScore": "ラウンド: {{score}}",
   "bid": "ビッド {{n}}",

--- a/frontend/src/pages/PitchPage.test.tsx
+++ b/frontend/src/pages/PitchPage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { pitchApi } from '../api/gameApi';
 import { useCliMode } from '../hooks/useCliMode';
@@ -167,9 +167,25 @@ describe('PitchPage', () => {
     renderWithProviders(<PitchPage />);
     const badge = await screen.findByTestId('pitch-game-pips-badge');
     expect(badge.textContent).toMatch(/Game値: 20/);
-    // Tooltip contains the breakdown of contributing cards only.
-    expect(badge.getAttribute('title')).toContain('A(4)');
-    expect(badge.getAttribute('title')).toContain('10(10)');
-    expect(badge.getAttribute('title')).not.toContain('7(');
+    // Tapping opens a breakdown popover (reachable on touch, unlike the title tooltip).
+    expect(screen.queryByTestId('pitch-game-pips-popover')).not.toBeInTheDocument();
+    fireEvent.click(badge);
+    const popover = screen.getByTestId('pitch-game-pips-popover');
+    // Breakdown lists only contributing cards plus the total; the zero-pip 7 is excluded.
+    expect(popover.textContent).toContain('+4'); // A
+    expect(popover.textContent).toContain('+10'); // 10
+    expect(popover).toHaveTextContent('合計');
+    expect(popover.textContent).toMatch(/20/);
+    // Tapping again closes it.
+    fireEvent.click(badge);
+    expect(screen.queryByTestId('pitch-game-pips-popover')).not.toBeInTheDocument();
+  });
+
+  it('Game-pip badge meets the 44px tap-target minimum', async () => {
+    mockApi.mockResolvedValue(bidState);
+    renderWithProviders(<PitchPage />);
+    const badge = await screen.findByTestId('pitch-game-pips-badge');
+    expect(badge.className).toContain('min-h-[44px]');
+    expect(badge.className).toContain('min-w-[44px]');
   });
 });

--- a/frontend/src/pages/PitchPage.test.tsx
+++ b/frontend/src/pages/PitchPage.test.tsx
@@ -188,4 +188,27 @@ describe('PitchPage', () => {
     expect(badge.className).toContain('min-h-[44px]');
     expect(badge.className).toContain('min-w-[44px]');
   });
+
+  it('closes the pips popover on Escape and on an outside click', async () => {
+    const pipHand: PitchResponse = {
+      ...bidState,
+      players: [
+        { ...bidState.players[0], cards: [makeCard('SPADE', 1), makeCard('SPADE', 10)], cardCount: 2 },
+        ...bidState.players.slice(1),
+      ],
+    };
+    mockApi.mockResolvedValue(pipHand);
+    renderWithProviders(<PitchPage />);
+    const badge = await screen.findByTestId('pitch-game-pips-badge');
+
+    fireEvent.click(badge);
+    expect(screen.getByTestId('pitch-game-pips-popover')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByTestId('pitch-game-pips-popover')).not.toBeInTheDocument();
+
+    fireEvent.click(badge);
+    expect(screen.getByTestId('pitch-game-pips-popover')).toBeInTheDocument();
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByTestId('pitch-game-pips-popover')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/PitchPage.tsx
+++ b/frontend/src/pages/PitchPage.tsx
@@ -121,6 +121,8 @@ function PitchPageContent() {
   const { state, loading, error, exec: execApi, retry } = useGameApi(pitchApi.exec);
   const { hint, hintEnabled, setHintEnabled } = useGameHint('pitch', state);
   const [selectedCardIdx, setSelectedCardIdx] = useState<number | null>(null);
+  // Game-pips breakdown popover: title-tooltips are unreachable on touch (#2612).
+  const [pipsOpen, setPipsOpen] = useState(false);
   const { cardWidth } = useCardDimensions();
 
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('pitch');
@@ -295,21 +297,41 @@ function PitchPageContent() {
                   <span>
                     {findPlayerName(state.players, humanIdx)} ({t('cards', { count: human.cards.length })})
                   </span>
-                  <span
-                    data-testid="pitch-game-pips-badge"
-                    className="normal-case inline-flex items-center rounded-full bg-ds-accent/20 text-ds-accent px-2 py-0.5 text-[11px] font-bold cursor-help"
-                    title={
-                      t('gamePipsTooltip') +
-                      (pitchHandPips(human.cards) > 0
-                        ? '\n' +
-                          pitchHandPipBreakdown(human.cards)
+                  <span className="relative inline-flex">
+                    <button
+                      type="button"
+                      data-testid="pitch-game-pips-badge"
+                      className="normal-case inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded-full bg-ds-accent/20 text-ds-accent px-2 py-0.5 text-[11px] font-bold"
+                      aria-expanded={pipsOpen}
+                      onClick={() => setPipsOpen((o) => !o)}
+                      title={t('gamePipsTooltip')}
+                    >
+                      {t('gamePips', { pips: pitchHandPips(human.cards) })}
+                    </button>
+                    {pipsOpen && (
+                      <div
+                        data-testid="pitch-game-pips-popover"
+                        role="dialog"
+                        aria-label={t('gamePipsTooltip')}
+                        className="absolute top-full left-0 z-10 mt-1 w-max max-w-[16rem] rounded-lg bg-ds-surface border border-ds-accent/40 p-2 text-[11px] text-ds-text-primary shadow-lg"
+                      >
+                        <div className="font-bold mb-1">{t('gamePipsTooltip')}</div>
+                        <ul className="space-y-0.5">
+                          {pitchHandPipBreakdown(human.cards)
                             .filter((b) => b.pips > 0)
-                            .map((b) => `${valueLabel(b.value)}(${b.pips})`)
-                            .join(' + ')
-                        : '')
-                    }
-                  >
-                    {t('gamePips', { pips: pitchHandPips(human.cards) })}
+                            .map((b) => (
+                              <li key={`pip-${b.value}`} className="flex justify-between gap-3">
+                                <span>{valueLabel(b.value)}</span>
+                                <span className="font-mono">+{b.pips}</span>
+                              </li>
+                            ))}
+                        </ul>
+                        <div className="mt-1 border-t border-ds-accent/30 pt-1 flex justify-between gap-3 font-bold">
+                          <span>{t('gamePipsTotal')}</span>
+                          <span className="font-mono">{pitchHandPips(human.cards)}</span>
+                        </div>
+                      </div>
+                    )}
                   </span>
                 </div>
                 <div className="flex flex-wrap gap-2">

--- a/frontend/src/pages/PitchPage.tsx
+++ b/frontend/src/pages/PitchPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { pitchApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
@@ -123,7 +123,25 @@ function PitchPageContent() {
   const [selectedCardIdx, setSelectedCardIdx] = useState<number | null>(null);
   // Game-pips breakdown popover: title-tooltips are unreachable on touch (#2612).
   const [pipsOpen, setPipsOpen] = useState(false);
+  const pipsRef = useRef<HTMLSpanElement>(null);
   const { cardWidth } = useCardDimensions();
+
+  // Dismiss the pips popover on Escape or a click/tap outside its wrapper.
+  useEffect(() => {
+    if (!pipsOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setPipsOpen(false);
+    };
+    const onPointer = (e: MouseEvent) => {
+      if (pipsRef.current && !pipsRef.current.contains(e.target as Node)) setPipsOpen(false);
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('mousedown', onPointer);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('mousedown', onPointer);
+    };
+  }, [pipsOpen]);
 
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('pitch');
   const cliConfig: CliGameConfig<PitchResponse, Parameters<typeof pitchApi.exec>> = useMemo(
@@ -297,21 +315,21 @@ function PitchPageContent() {
                   <span>
                     {findPlayerName(state.players, humanIdx)} ({t('cards', { count: human.cards.length })})
                   </span>
-                  <span className="relative inline-flex">
+                  <span className="relative inline-flex" ref={pipsRef}>
                     <button
                       type="button"
                       data-testid="pitch-game-pips-badge"
                       className="normal-case inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded-full bg-ds-accent/20 text-ds-accent px-2 py-0.5 text-[11px] font-bold"
                       aria-expanded={pipsOpen}
+                      aria-haspopup="true"
                       onClick={() => setPipsOpen((o) => !o)}
                       title={t('gamePipsTooltip')}
                     >
                       {t('gamePips', { pips: pitchHandPips(human.cards) })}
                     </button>
                     {pipsOpen && (
-                      <div
+                      <section
                         data-testid="pitch-game-pips-popover"
-                        role="dialog"
                         aria-label={t('gamePipsTooltip')}
                         className="absolute top-full left-0 z-10 mt-1 w-max max-w-[16rem] rounded-lg bg-ds-surface border border-ds-accent/40 p-2 text-[11px] text-ds-text-primary shadow-lg"
                       >
@@ -330,7 +348,7 @@ function PitchPageContent() {
                           <span>{t('gamePipsTotal')}</span>
                           <span className="font-mono">{pitchHandPips(human.cards)}</span>
                         </div>
-                      </div>
+                      </section>
                     )}
                   </span>
                 </div>


### PR DESCRIPTION
## 背景
Game Pips バッジ（`pitch-game-pips-badge`）は `title` 属性の hover ツールチップで内訳を出すだけで、モバイル/タッチ環境では内訳（10=10, A=4, K=3, Q=2, J=1）を確認できませんでした。

## 変更
- バッジを `<button>`（44×44px タップターゲット、`aria-expanded`）化し、タップ/クリックで内訳ポップオーバー（`role=dialog`）を開閉。
- ポップオーバーは寄与カードごとの pip と合計を表示（既存の `pitchHandPipBreakdown`/`pitchHandPips` を流用）。
- desktop 向けに `title` ツールチップは維持。
- `gamePipsTotal` を ja/en に追加。

## テスト
- ポップオーバーのタップ開閉・内訳・合計、44px タップターゲットを検証する page テストを追加/更新（9 passed）。`bun run check` OK。

Closes #2612