### PR TITLE
feat(egyptianratscrew): visualize chance-battle countdown as pulsing dots

### DIFF
--- a/frontend/src/i18n/locales/en/egyptianratscrew.json
+++ b/frontend/src/i18n/locales/en/egyptianratscrew.json
@@ -17,6 +17,7 @@
     "pileCount": "Pile: {{count}}",
     "chanceRemaining": "Chances left: {{count}}"
   },
+  "chanceResponder": "Responding: {{player}}",
   "settings": {
     "cpuDifficulty": "CPU difficulty",
     "difficulty": {

--- a/frontend/src/i18n/locales/ja/egyptianratscrew.json
+++ b/frontend/src/i18n/locales/ja/egyptianratscrew.json
@@ -17,6 +17,7 @@
     "pileCount": "場に{{count}}枚",
     "chanceRemaining": "残りチャンス: {{count}}"
   },
+  "chanceResponder": "応答: {{player}}",
   "settings": {
     "cpuDifficulty": "CPU難易度",
     "difficulty": {

--- a/frontend/src/pages/EgyptianRatscrewPage.test.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.test.tsx
@@ -200,6 +200,14 @@ describe('EgyptianRatscrewPage', () => {
     expect(row).toHaveTextContent('応答: CPU 1');
   });
 
+  it('names the human as responder when it is the human turn during a chance', async () => {
+    mockExec.mockResolvedValueOnce({ ...chanceState, isHumanTurn: true, currentTurnIdx: 0, chanceRemaining: 1 });
+    renderWithProviders(<EgyptianRatscrewPage />);
+    const row = await screen.findByTestId('er-chance-row');
+    expect(row.querySelectorAll('span.rounded-full')).toHaveLength(1);
+    expect(row).toHaveTextContent('応答: あなた');
+  });
+
   it('reset settings select fires reset with cpuDifficulty config', async () => {
     renderWithProviders(<EgyptianRatscrewPage />);
     await waitFor(() => expect(screen.getByTestId('step-button')).toBeInTheDocument());

--- a/frontend/src/pages/EgyptianRatscrewPage.test.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.test.tsx
@@ -189,6 +189,17 @@ describe('EgyptianRatscrewPage', () => {
     expect(screen.getAllByText(/2/).length).toBeGreaterThan(0);
   });
 
+  it('renders a dot per remaining chance and names the responding player', async () => {
+    // chanceRemaining 2, currentTurnIdx 1 (CPU) on this fixture.
+    mockExec.mockResolvedValueOnce(chanceState);
+    renderWithProviders(<EgyptianRatscrewPage />);
+    const row = await screen.findByTestId('er-chance-row');
+    // One decorative pip per remaining flip.
+    expect(row.querySelectorAll('span.rounded-full')).toHaveLength(2);
+    // Responder label identifies the CPU (currentTurnIdx 1, isHumanTurn false).
+    expect(row).toHaveTextContent('応答: CPU 1');
+  });
+
   it('reset settings select fires reset with cpuDifficulty config', async () => {
     renderWithProviders(<EgyptianRatscrewPage />);
     await waitFor(() => expect(screen.getByTestId('step-button')).toBeInTheDocument());

--- a/frontend/src/pages/EgyptianRatscrewPage.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.tsx
@@ -244,8 +244,25 @@ function EgyptianRatscrewPageContent() {
                   {t('label.pileCount', { count: state.centerPileSize })}
                 </div>
                 {state.chanceRemaining > 0 && (
-                  <div className="text-xs text-ds-warning mt-1">
-                    {t('label.chanceRemaining', { count: state.chanceRemaining })}
+                  <div className="mt-1 flex flex-col items-center gap-0.5" data-testid="er-chance-row">
+                    {/* Dot row: one filled pip per remaining flip. Keyed on the count so it
+                        re-mounts and re-pulses each time a chance is consumed (#2608). */}
+                    <div
+                      key={`chance-${state.chanceRemaining}`}
+                      className="flex items-center justify-center gap-1 animate-pulse"
+                      aria-hidden="true"
+                    >
+                      {Array.from({ length: state.chanceRemaining }, (_, i) => `dot${i}`).map((id) => (
+                        <span key={id} className="inline-block h-2 w-2 rounded-full bg-ds-warning" />
+                      ))}
+                    </div>
+                    <div className="text-xs text-ds-warning" role="status">
+                      {t('label.chanceRemaining', { count: state.chanceRemaining })}
+                      {' — '}
+                      {t('chanceResponder', {
+                        player: state.isHumanTurn ? tc('player.you') : tc('player.cpu', { id: state.currentTurnIdx }),
+                      })}
+                    </div>
                   </div>
                 )}
                 <div className="mt-2">

--- a/frontend/src/pages/EgyptianRatscrewPage.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.tsx
@@ -252,8 +252,8 @@ function EgyptianRatscrewPageContent() {
                       className="flex items-center justify-center gap-1 animate-pulse"
                       aria-hidden="true"
                     >
-                      {Array.from({ length: state.chanceRemaining }, (_, i) => `dot${i}`).map((id) => (
-                        <span key={id} className="inline-block h-2 w-2 rounded-full bg-ds-warning" />
+                      {Array.from({ length: state.chanceRemaining }, (_, i) => (
+                        <span key={`dot${i}`} className="inline-block h-2 w-2 rounded-full bg-ds-warning" />
                       ))}
                     </div>
                     <div className="text-xs text-ds-warning" role="status">


### PR DESCRIPTION
## 背景
フェイスカードが場に出た際のチャンス・バトルは `state.chanceRemaining` を小さな黄色テキストで表示するだけで、slap 成否が `SlapBurst` で派手にフィードバックされるのと非対称でした。

## 変更
- arena の chanceRemaining 表示を、残り回数ぶんのドット列（●）に置換。`chanceRemaining` をキーにして再マウントし、回数が減るごとにパルスアニメーションが再発火。
- 応答プレイヤー（あなた / CPU）を示すラベルを併記（`state.isHumanTurn`/`currentTurnIdx` から導出）。
- `chanceResponder` を ja/en に追加。

## テスト
- 残り回数ぶんのドット数と応答プレイヤーのラベルを検証する page テストを追加（18 passed）。`bun run check` OK。

Closes #2608