### PR TITLE
feat(mao): buzz and flash the rule panel on a hidden-rule penalty

### DIFF
--- a/frontend/src/pages/MaoPage.test.tsx
+++ b/frontend/src/pages/MaoPage.test.tsx
@@ -10,6 +10,14 @@ vi.mock('../api/gameApi', () => ({
   actionLogApi: { mao: vi.fn() },
 }));
 
+const mockPlaySound = vi.fn();
+const mockSoundValue = { playSound: mockPlaySound, muted: false, toggleMute: vi.fn() };
+vi.mock('../providers/SoundProvider', () => ({
+  SoundProvider: ({ children }: { children: React.ReactNode }) => children,
+  useSound: () => mockSoundValue,
+  useOptionalSound: () => mockSoundValue,
+}));
+
 const mockExec = vi.mocked(maoApi.exec);
 
 const playPhaseState: MaoResponse = {
@@ -60,8 +68,11 @@ const gameEndState: MaoResponse = {
   message: 'Game end!',
 };
 const penaltyState: MaoResponse = { ...playPhaseState, penaltyDrawCount: 4 };
+const rulePenaltyState: MaoResponse = { ...playPhaseState, rulePenalty: true };
 
 beforeEach(() => {
+  mockExec.mockReset();
+  mockPlaySound.mockReset();
   mockExec.mockResolvedValue(playPhaseState);
 });
 
@@ -104,6 +115,22 @@ describe('MaoPage', () => {
     mockExec.mockResolvedValue(playPhaseState);
     fireEvent.click(screen.getByRole('button', { name: '引く' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('draw'));
+  });
+
+  it('buzzes and flashes the rule panel when a rule penalty lands', async () => {
+    mockExec.mockResolvedValue(rulePenaltyState);
+    renderWithProviders(<MaoPage />);
+    await waitFor(() => expect(screen.getByTestId('rule-penalty')).toBeInTheDocument());
+    expect(mockPlaySound).toHaveBeenCalledWith('errorBuzz');
+    const panel = screen.getByTestId('mao-rule-panel');
+    expect(panel.className).toContain('motion-safe:animate-pulse');
+    expect(panel.className).toContain('ring-ds-error');
+  });
+
+  it('does not buzz when there is no rule penalty', async () => {
+    renderWithProviders(<MaoPage />);
+    await waitFor(() => expect(screen.getByTestId('mao-rule-panel')).toBeInTheDocument());
+    expect(mockPlaySound).not.toHaveBeenCalledWith('errorBuzz');
   });
 
   it('shows penalty banner and take-penalty draw label when penalty active', async () => {

--- a/frontend/src/pages/MaoPage.tsx
+++ b/frontend/src/pages/MaoPage.tsx
@@ -166,9 +166,7 @@ function MaoPageContent() {
 
   const phaseNames = usePhaseNames('mao', MAO_PHASE_KEYS);
 
-  // Buzz the moment a hidden-rule penalty lands (false→true) so the failure
-  // isn't missed amid fast CPU turns (#2688). The panel's attention pulse is
-  // driven by the `rulePenalty` flag directly (re-fires as the class re-applies).
+  // Buzz once on the false→true edge; fast CPU turns would otherwise swallow the feedback.
   const prevRulePenaltyRef = useRef(false);
   useEffect(() => {
     const penalty = state?.rulePenalty ?? false;

--- a/frontend/src/pages/MaoPage.tsx
+++ b/frontend/src/pages/MaoPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { maoApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -165,6 +165,18 @@ function MaoPageContent() {
   });
 
   const phaseNames = usePhaseNames('mao', MAO_PHASE_KEYS);
+
+  // Buzz the moment a hidden-rule penalty lands (false→true) so the failure
+  // isn't missed amid fast CPU turns (#2688). The panel's attention pulse is
+  // driven by the `rulePenalty` flag directly (re-fires as the class re-applies).
+  const prevRulePenaltyRef = useRef(false);
+  useEffect(() => {
+    const penalty = state?.rulePenalty ?? false;
+    if (penalty && !prevRulePenaltyRef.current) {
+      playSound('errorBuzz');
+    }
+    prevRulePenaltyRef.current = penalty;
+  }, [state?.rulePenalty, playSound]);
 
   if (!state)
     return (
@@ -366,7 +378,9 @@ function MaoPageContent() {
 
             {/* Hidden-rule panel: the player must guess when to speak — the game never reveals the rule. */}
             <div
-              className="my-2 p-2 rounded bg-black/30 flex flex-col gap-2 text-sm"
+              className={`my-2 p-2 rounded bg-black/30 flex flex-col gap-2 text-sm ${
+                state.rulePenalty ? 'ring-2 ring-ds-error motion-safe:animate-pulse' : ''
+              }`}
               data-tutorial="mao-rule-panel"
               data-testid="mao-rule-panel"
             >


### PR DESCRIPTION
## 背景
`MaoPage` は隠しルールを当てるゲームですが、ペナルティ発生時のフィードバックが `rule-penalty` の赤テキストのみで、CPU の速いターン進行の中で見落としやすい状態でした（`useSound` は勝利時しか使われていない）。

## 変更
- `rulePenalty` が false→true に変化したタイミングで既存の `playSound('errorBuzz')`（`error-buzz.ogg`）を一度だけ再生（`useRef` で前回値比較）。
- ルールパネル（`mao-rule-panel`）に `motion-safe:animate-pulse` + `ring-ds-error` の注意喚起アニメーションを付与。`prefers-reduced-motion` で自動無効化。

## テスト
- ペナルティ立ち上がりで errorBuzz が鳴りパネルがフラッシュすること、ペナルティ無しでは鳴らないことを検証する page テストを追加（23 passed）。`bun run check` OK。
- SoundProvider をモックして `playSound` をスパイ。

Closes #2688