### PR TITLE
feat(cuckoo): expose remaining lives and round losses to screen readers

### DIFF
--- a/frontend/src/i18n/locales/en/cuckoo.json
+++ b/frontend/src/i18n/locales/en/cuckoo.json
@@ -6,6 +6,7 @@
   "stock": "Stock: {{count}}",
   "playersTitle": "Players",
   "lives": "Lives",
+  "livesCount": "Lives {{count}}",
   "eliminated": "Out",
   "kingRevealed": "King revealed",
   "yourCard": "Your card",

--- a/frontend/src/i18n/locales/ja/cuckoo.json
+++ b/frontend/src/i18n/locales/ja/cuckoo.json
@@ -6,6 +6,7 @@
   "stock": "山札: {{count}}枚",
   "playersTitle": "プレイヤー",
   "lives": "ライフ",
+  "livesCount": "ライフ {{count}}",
   "eliminated": "脱落",
   "kingRevealed": "キング公開",
   "yourCard": "あなたのカード",

--- a/frontend/src/pages/CuckooPage.test.tsx
+++ b/frontend/src/pages/CuckooPage.test.tsx
@@ -88,11 +88,28 @@ describe('CuckooPage', () => {
     expect(screen.getByText(/山札: 47枚/)).toBeInTheDocument();
   });
 
-  it('renders the players list with lives', async () => {
+  it('renders the players list with lives, exposing the remaining count to screen readers', async () => {
     renderWithProviders(<CuckooPage />);
     await waitFor(() => expect(screen.getByText(/プレイヤー/)).toBeInTheDocument());
-    const lives = screen.getAllByLabelText('ライフ');
+    // Each life row's aria-label includes the remaining count (e.g. "ライフ 3"), not just "ライフ".
+    const lives = screen.getAllByLabelText('ライフ 3');
     expect(lives.length).toBe(4);
+    expect(screen.queryByLabelText('ライフ')).not.toBeInTheDocument();
+  });
+
+  it('labels an eliminated player with the out label instead of a life count', async () => {
+    mockExec.mockResolvedValue(gameEndState); // seats 1-3 eliminated (lives 0)
+    renderWithProviders(<CuckooPage />);
+    await waitFor(() => expect(screen.getByText(/プレイヤー/)).toBeInTheDocument());
+    expect(screen.getAllByLabelText('脱落').length).toBe(3);
+  });
+
+  it('announces round losers via a polite live region', async () => {
+    mockExec.mockResolvedValue(roundEndState);
+    renderWithProviders(<CuckooPage />);
+    const losers = await screen.findByTestId('cuckoo-losers');
+    expect(losers).toHaveAttribute('role', 'status');
+    expect(losers).toHaveAttribute('aria-live', 'polite');
   });
 
   it('dispatches keep on the human turn', async () => {

--- a/frontend/src/pages/CuckooPage.tsx
+++ b/frontend/src/pages/CuckooPage.tsx
@@ -196,7 +196,7 @@ function CuckooPageContent() {
                   } ${p.isHuman ? 'font-semibold' : ''} ${p.isEliminated ? 'opacity-50' : ''}`}
                 >
                   <span>{playerLabel(p.id, p.isHuman)}</span>
-                  <span role="img" aria-label={t('lives')}>
+                  <span role="img" aria-label={p.lives > 0 ? t('livesCount', { count: p.lives }) : t('eliminated')}>
                     {p.lives > 0 ? '♥'.repeat(p.lives) : `(${t('eliminated')})`}
                   </span>
                   {p.kingRevealed && <span className="text-ds-accent">[{t('kingRevealed')}]</span>}
@@ -207,7 +207,13 @@ function CuckooPageContent() {
 
             {/* Round losers */}
             {(isRoundEnd || isGameEnd) && state.roundLosers.length > 0 && (
-              <div className="mb-2 p-2 rounded bg-ds-warning/20 text-ds-warning text-sm" data-tutorial="cuckoo-losers">
+              <div
+                className="mb-2 p-2 rounded bg-ds-warning/20 text-ds-warning text-sm"
+                data-tutorial="cuckoo-losers"
+                data-testid="cuckoo-losers"
+                role="status"
+                aria-live="polite"
+              >
                 <div className="mb-1">{t('roundLosersTitle')}</div>
                 {state.roundLosers.map((idx) => (
                   <div key={`loser-${idx}`}>{t('roundLoser', { name: playerLabel(idx, idx === 0) })}</div>


### PR DESCRIPTION
## 背景
プレイヤーのライフは `'♥'.repeat(p.lives)` で描画され、`aria-label` は `ライフ` のみ。スクリーンリーダーは残り本数（3/2/1）を読み上げられず、ライフ喪失が勝敗を直接決めるゲームなのに視覚（ハート数）依存でした。脱落も `opacity-50` の視覚差のみ。

## 変更
- ハート列の `aria-label` を残ライフ数入り（`livesCount` = 「ライフ {{count}}」）に変更。ライフ0は `eliminated` ラベル。
- ラウンド敗者パネル（`cuckoo-losers`）を `role="status" aria-live="polite"` 化し、ライフ喪失を読み上げ。
- `livesCount` を ja/en に追加。

## テスト
- 残ライフ数入り aria-label・脱落ラベル・敗者パネルのライブ領域属性を検証する page テストを追加/更新（15 passed）。`bun run check` OK。

Closes #2691