### PR TITLE
feat(kemps): announce signal cues and selection to screen readers

### DIFF
--- a/frontend/src/i18n/locales/en/kemps.json
+++ b/frontend/src/i18n/locales/en/kemps.json
@@ -14,6 +14,7 @@
   "swapButton": "Swap with this card",
   "passButton": "Pass (no swap)",
   "signalLabel": "Your secret signal:",
+  "signalSent": "Signal set: {{signal}}",
   "signal": {
     "sound": "Sound (cough)",
     "blink": "Blink"

--- a/frontend/src/i18n/locales/ja/kemps.json
+++ b/frontend/src/i18n/locales/ja/kemps.json
@@ -14,6 +14,7 @@
   "swapButton": "このカードと交換",
   "passButton": "パス（交換しない）",
   "signalLabel": "あなたの秘密のシグナル:",
+  "signalSent": "シグナル設定: {{signal}}",
   "signal": {
     "sound": "音（咳払い）",
     "blink": "瞬き"

--- a/frontend/src/pages/KempsPage.test.tsx
+++ b/frontend/src/pages/KempsPage.test.tsx
@@ -146,16 +146,29 @@ describe('KempsPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('counter', { targetSeat: 1 }));
   });
 
-  it('shows the partner signaling cue in the declare window', async () => {
+  it('shows the partner signaling cue in the declare window as a live region', async () => {
     mockExec.mockResolvedValue(makeState({ phase: 1, isHumanTurn: false, partnerSignaling: true, fourHolderIdx: 2 }));
     renderWithProviders(<KempsPage />);
-    await waitFor(() => expect(screen.getByText(/パートナーが合図/)).toBeInTheDocument());
+    const cue = await screen.findByTestId('kemps-partner-signaling');
+    expect(cue).toHaveAttribute('role', 'status');
+    expect(cue).toHaveAttribute('aria-live', 'polite');
+    expect(cue).toHaveTextContent(/パートナーが合図/);
   });
 
-  it('shows the opponent signaling cue in the declare window', async () => {
+  it('shows the opponent signaling cue in the declare window as a live region', async () => {
     mockExec.mockResolvedValue(makeState({ phase: 1, isHumanTurn: false, opponentSignaling: true, fourHolderIdx: 1 }));
     renderWithProviders(<KempsPage />);
-    await waitFor(() => expect(screen.getByText(/合図しているかもしれません/)).toBeInTheDocument());
+    const cue = await screen.findByTestId('kemps-opponent-signaling');
+    expect(cue).toHaveAttribute('role', 'status');
+    expect(cue).toHaveTextContent(/合図しているかもしれません/);
+  });
+
+  it('announces the chosen secret signal in a live region', async () => {
+    mockExec.mockResolvedValue(makeState({ signalType: 1 })); // blink
+    renderWithProviders(<KempsPage />);
+    const sent = await screen.findByTestId('kemps-signal-sent');
+    expect(sent).toHaveAttribute('role', 'status');
+    expect(sent).toHaveTextContent('シグナル設定: 瞬き');
   });
 
   it('shows the next round button at round end and dispatches next', async () => {

--- a/frontend/src/pages/KempsPage.tsx
+++ b/frontend/src/pages/KempsPage.tsx
@@ -260,12 +260,24 @@ function KempsPageContent() {
 
             {/* Signal cues (human only) */}
             {isDeclare && state.partnerSignaling && (
-              <div className="my-2 p-2 rounded bg-ds-success/20 text-ds-success text-sm font-semibold">
+              <div
+                className="my-2 p-2 rounded bg-ds-success/20 text-ds-success text-sm font-semibold"
+                role="status"
+                aria-live="polite"
+                data-testid="kemps-partner-signaling"
+              >
                 {t('partnerSignaling')}
               </div>
             )}
             {isDeclare && state.opponentSignaling && (
-              <div className="my-2 p-2 rounded bg-ds-warning/20 text-ds-warning text-sm">{t('opponentSignaling')}</div>
+              <div
+                className="my-2 p-2 rounded bg-ds-warning/20 text-ds-warning text-sm"
+                role="status"
+                aria-live="polite"
+                data-testid="kemps-opponent-signaling"
+              >
+                {t('opponentSignaling')}
+              </div>
             )}
 
             <GameMessageBox
@@ -335,6 +347,12 @@ function KempsPageContent() {
                   {t(`signal.${o.label}`)}
                 </button>
               ))}
+              {/* Announce the chosen signal — the visual selection is colour-only otherwise (#2690). */}
+              <span className="sr-only" role="status" aria-live="polite" data-testid="kemps-signal-sent">
+                {t('signalSent', {
+                  signal: t(`signal.${SIGNAL_OPTIONS.find((o) => o.value === state.signalType)?.label ?? 'sound'}`),
+                })}
+              </span>
             </div>
 
             <div className="flex flex-wrap gap-2 items-center" data-tutorial="kemps-declare">

--- a/frontend/src/pages/KempsPage.tsx
+++ b/frontend/src/pages/KempsPage.tsx
@@ -41,6 +41,12 @@ const SIGNAL_OPTIONS = [
   { value: KempsSignal.BLINK, label: 'blink' },
 ];
 
+/** Signal-type → i18n label key, for the screen-reader "signal set" announcement. */
+const SIGNAL_LABEL_BY_TYPE: Readonly<Record<number, string>> = {
+  [KempsSignal.SOUND]: 'sound',
+  [KempsSignal.BLINK]: 'blink',
+};
+
 /** Kemps tutorial step definitions. */
 const KEMPS_TUTORIAL_STEPS: TutorialStep[] = [
   {
@@ -349,9 +355,7 @@ function KempsPageContent() {
               ))}
               {/* Announce the chosen signal — the visual selection is colour-only otherwise (#2690). */}
               <span className="sr-only" role="status" aria-live="polite" data-testid="kemps-signal-sent">
-                {t('signalSent', {
-                  signal: t(`signal.${SIGNAL_OPTIONS.find((o) => o.value === state.signalType)?.label ?? 'sound'}`),
-                })}
+                {t('signalSent', { signal: t(`signal.${SIGNAL_LABEL_BY_TYPE[state.signalType]}`) })}
               </span>
             </div>
 


### PR DESCRIPTION
## 背景
シグナル送信結果（`partnerSignaling`/`opponentSignaling`）の通知が `role` 無しの `<div>` で、相棒が反応したか・相手に読まれたかという最重要情報がスクリーンリーダーに伝わりませんでした。選択中シグナルも色だけに依存。

## 変更
- 両シグナルキュー `<div>` に `role="status" aria-live="polite"` + testid を付与。
- シグナルセレクタに選択中シグナルを読み上げる sr-only ライブ領域（`signalSent`）を追加。
- 既存の `signalType` ボタンの `aria-pressed` は維持。
- `signalSent` を ja/en に追加。

## テスト
- 両キューのライブ領域属性 + シグナル選択読み上げを検証する page テストを追加/更新（16 passed）。`bun run check` OK。

Closes #2690