### PR TITLE
feat(fivecardstud): highlight each player's newest door card

### DIFF
--- a/frontend/src/pages/FiveCardStudPage.test.tsx
+++ b/frontend/src/pages/FiveCardStudPage.test.tsx
@@ -199,6 +199,20 @@ describe('FiveCardStudPage', () => {
     expect(screen.getAllByText('ホールカード').length).toBeGreaterThanOrEqual(1);
   });
 
+  it('highlights the latest door card for the human and each CPU', async () => {
+    mockExec.mockResolvedValue(secondStreetState);
+    renderWithProviders(<FiveCardStudPage />);
+    // Human's newest door card (last of 4) gets a ring highlight.
+    const humanLatest = await screen.findByTestId('latest-door-human');
+    expect(humanLatest.className).toContain('ring-2');
+    expect(humanLatest.className).toContain('motion-safe:animate-pulse');
+    // The newest door card is the last in the array (♦ 7), not an earlier one.
+    expect(humanLatest.querySelector('img')).toHaveAttribute('alt', '♦ 7');
+    // Each CPU also has exactly one highlighted latest door card.
+    expect(screen.getByTestId('latest-door-cpu-1')).toBeInTheDocument();
+    expect(screen.getByTestId('latest-door-cpu-2')).toBeInTheDocument();
+  });
+
   it('reveals CPU hand name and hole card during showdown and shows round results', async () => {
     mockExec.mockResolvedValue(showdownState);
     renderWithProviders(<FiveCardStudPage />);

--- a/frontend/src/pages/FiveCardStudPage.tsx
+++ b/frontend/src/pages/FiveCardStudPage.tsx
@@ -308,14 +308,24 @@ function FiveCardStudPageContent() {
                   <div className="text-ds-text-muted text-xs mb-0.5">{t('doorCards')}</div>
                   <div className="flex flex-wrap gap-1 mb-1">
                     {p.doorCards?.length
-                      ? p.doorCards.map((card) => (
-                          <AnimatedCard
-                            key={`${card.design}-${card.value}`}
-                            card={card}
-                            width={cardWidth}
-                            style={placeholderCardStyle}
-                          />
-                        ))
+                      ? p.doorCards.map((card, i, arr) =>
+                          i === arr.length - 1 ? (
+                            <span
+                              key={`${card.design}-${card.value}`}
+                              className="inline-block rounded ring-2 ring-ds-accent motion-safe:animate-pulse"
+                              data-testid={`latest-door-cpu-${p.id}`}
+                            >
+                              <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
+                            </span>
+                          ) : (
+                            <AnimatedCard
+                              key={`${card.design}-${card.value}`}
+                              card={card}
+                              width={cardWidth}
+                              style={placeholderCardStyle}
+                            />
+                          ),
+                        )
                       : !p.folded &&
                         Array.from({ length: doorCount }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                   </div>
@@ -397,14 +407,24 @@ function FiveCardStudPageContent() {
                 <div className="text-ds-text-muted text-xs mb-0.5">{t('doorCards')}</div>
                 <div className="flex flex-wrap gap-1.5 mb-1">
                   {humanPlayer.doorCards?.length
-                    ? humanPlayer.doorCards.map((card) => (
-                        <AnimatedCard
-                          key={`${card.design}-${card.value}`}
-                          card={card}
-                          width={cardWidth}
-                          style={placeholderCardStyle}
-                        />
-                      ))
+                    ? humanPlayer.doorCards.map((card, i, arr) =>
+                        i === arr.length - 1 ? (
+                          <span
+                            key={`${card.design}-${card.value}`}
+                            className="inline-block rounded ring-2 ring-ds-accent motion-safe:animate-pulse"
+                            data-testid="latest-door-human"
+                          >
+                            <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
+                          </span>
+                        ) : (
+                          <AnimatedCard
+                            key={`${card.design}-${card.value}`}
+                            card={card}
+                            width={cardWidth}
+                            style={placeholderCardStyle}
+                          />
+                        ),
+                      )
                     : !humanPlayer.folded &&
                       Array.from({ length: doorCount }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                 </div>


### PR DESCRIPTION
## 背景
各ストリートで表向き札（door cards）が1枚ずつ増えますが、新たに配られた札が既存の表向き札と同じ見た目で横並びになるだけで、どれが今ストリートの札か分かりませんでした。スタッドポーカーは公開札の読み合いが肝なのに最新札のハイライトが無い状態でした。

## 変更
- 各プレイヤー（人間・CPU）の `doorCards` の最後の1枚を `ring-2 ring-ds-accent motion-safe:animate-pulse` の span でラップして強調。
- ストリート進行に応じて最後の要素が変わるため強調対象も自動更新。
- リングは常時表示（視認性）、パルスは `motion-safe` で `prefers-reduced-motion` 時に無効化。
- `AnimatedCard` は reduced-motion 時にラッパーを落とすため、専用 span でラップしリングを確実に残す実装。

## テスト
- 人間の最新 door card（配列末尾＝♦7）のリング/パルス、各 CPU の最新札強調を検証する page テストを追加（19 passed）。`bun run check` OK。

Closes #2694