### PR TITLE
feat(faro): visually distinguish copper (bet-to-lose) wagers

### DIFF
--- a/frontend/src/i18n/locales/en/faro.json
+++ b/frontend/src/i18n/locales/en/faro.json
@@ -10,6 +10,7 @@
   "copperOff": "Copper: off",
   "betAmountLabel": "Bet amount",
   "copperTag": "copper",
+  "copperModeHint": "Copper mode: your next bet wagers that rank to LOSE",
   "betsTitle": "Current bets",
   "noBets": "No bets placed yet.",
   "betLine": "Rank {{rank}}: {{amount}}",

--- a/frontend/src/i18n/locales/ja/faro.json
+++ b/frontend/src/i18n/locales/ja/faro.json
@@ -10,6 +10,7 @@
   "copperOff": "カッパー: オフ",
   "betAmountLabel": "ベット額",
   "copperTag": "カッパー",
+  "copperModeHint": "カッパーモード: 次の賭けはそのランクが「負ける」方に賭けます",
   "betsTitle": "現在のベット",
   "noBets": "まだベットがありません。",
   "betLine": "ランク {{rank}}: {{amount}}",

--- a/frontend/src/pages/FaroPage.test.tsx
+++ b/frontend/src/pages/FaroPage.test.tsx
@@ -113,6 +113,24 @@ describe('FaroPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bet', { rank: 7, amount: 10, copper: true }));
   });
 
+  it('shows the copper-mode hint on the layout when the copper toggle is on', async () => {
+    renderWithProviders(<FaroPage />);
+    await screen.findByTestId('rank-7');
+    expect(screen.queryByTestId('faro-copper-mode')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('copper-toggle'));
+    expect(screen.getByTestId('faro-copper-mode')).toBeInTheDocument();
+  });
+
+  it('distinguishes a copper bet with accent styling and a coin marker', async () => {
+    mockExec.mockResolvedValue(makeState({ bets: [{ rank: 7, amount: 100, copper: true }] }));
+    renderWithProviders(<FaroPage />);
+    const rankBtn = await screen.findByTestId('rank-7');
+    expect(rankBtn.className).toContain('border-ds-accent');
+    expect(rankBtn.textContent).toContain('🪙');
+    // A normal (non-copper) rank stays on the warning palette.
+    expect(screen.getByTestId('rank-8').className).not.toContain('border-ds-accent');
+  });
+
   it('shows the no-bets message when no chips are placed', async () => {
     renderWithProviders(<FaroPage />);
     await waitFor(() => expect(screen.getByText('まだベットがありません。')).toBeInTheDocument());

--- a/frontend/src/pages/FaroPage.tsx
+++ b/frontend/src/pages/FaroPage.tsx
@@ -204,6 +204,14 @@ function FaroPageContent() {
             {/* 13-rank betting layout */}
             <div className="mb-3 p-3 rounded bg-black/20" data-tutorial="faro-layout">
               <div className="text-ds-text-muted text-xs mb-2 text-center">{t('layoutTitle')}</div>
+              {isBetting && copper && (
+                <div
+                  className="mb-2 text-center text-xs font-semibold text-ds-accent rounded bg-ds-accent/15 py-1"
+                  data-testid="faro-copper-mode"
+                >
+                  🪙 {t('copperModeHint')}
+                </div>
+              )}
               <div className="grid grid-cols-7 gap-2 justify-items-center">
                 {RANKS.map((rank) => {
                   const bet = betFor(rank);
@@ -214,13 +222,22 @@ function FaroPageContent() {
                       onClick={() => isBetting && exec('bet', { rank, amount: chipAmount, copper })}
                       disabled={!isBetting || loading}
                       className={`relative w-12 h-14 rounded border text-lg font-bold transition-all ${
-                        bet
-                          ? 'border-ds-warning bg-ds-warning/20 text-ds-warning'
-                          : 'border-white/30 bg-black/30 text-ds-text-primary'
+                        bet?.copper
+                          ? 'border-ds-accent bg-ds-accent/20 text-ds-accent'
+                          : bet
+                            ? 'border-ds-warning bg-ds-warning/20 text-ds-warning'
+                            : 'border-white/30 bg-black/30 text-ds-text-primary'
                       } ${isBetting ? 'cursor-pointer hover:border-ds-warning hover:-translate-y-0.5' : 'cursor-default opacity-80'}`}
                       data-testid={`rank-${rank}`}
-                      aria-label={`${t('rankName')} ${rankLabel(rank)}`}
+                      aria-label={`${t('rankName')} ${rankLabel(rank)}${bet?.copper ? ` (${t('copperTag')})` : ''}`}
                     >
+                      {/* Copper bets (betting on the rank to lose) are marked with a coin icon + accent
+                          colour so they read differently from normal win bets at a glance (#2695). */}
+                      {bet?.copper && (
+                        <span className="absolute -top-1 -right-1 text-[10px]" aria-hidden="true">
+                          🪙
+                        </span>
+                      )}
                       {rankLabel(rank)}
                       {bet && (
                         <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 text-[10px] whitespace-nowrap">


### PR DESCRIPTION
## 背景
「カッパー（そのランクが負ける方に賭ける）」は初心者に分かりにくい中核ルールですが、通常賭けとカッパー賭けが同じ黄色で、小さな `copperTag` 文字でしか区別されませんでした。フッターの copper トグルも文字のみで盤面と結びついていませんでした。

## 変更
- カッパー賭け（`bet.copper === true`）のランクボタンをアクセント配色（`border-ds-accent bg-ds-accent/20`）＋コインアイコン🪙＋ aria-label に「(カッパー)」付与で区別。
- copper トグル ON 時、レイアウト上部に「次の賭けはカッパー」モード提示（`copperModeHint`）を表示。
- 既存 `rank-*` / `copper-toggle` testid は維持。
- `copperModeHint` を ja/en に追加。

## テスト
- copper モードヒントの表示/非表示、カッパー賭けのアクセント配色＋コイン、通常賭けとの区別を検証する page テストを追加（18 passed）。`bun run check` OK。

Closes #2695