### PR TITLE
feat(pishti): celebrate a Pişti capture with a badge and sound

### DIFF
--- a/frontend/src/i18n/locales/en/pishti.json
+++ b/frontend/src/i18n/locales/en/pishti.json
@@ -5,6 +5,8 @@
   "playersTitle": "Players",
   "captured": "captured {{count}}",
   "pisti": "Pişti {{count}}",
+  "pistiCelebration": "PİŞTİ +10!",
+  "pistiCelebrationJack": "PİŞTİ +20! (J)",
   "finalScore": "{{score}} pts",
   "pile": "Pile",
   "pileTop": "Pile top",

--- a/frontend/src/i18n/locales/ja/pishti.json
+++ b/frontend/src/i18n/locales/ja/pishti.json
@@ -5,6 +5,8 @@
   "playersTitle": "プレイヤー",
   "captured": "捕獲 {{count}}枚",
   "pisti": "Pişti {{count}}点",
+  "pistiCelebration": "PİŞTİ +10!",
+  "pistiCelebrationJack": "PİŞTİ +20! (J)",
   "finalScore": "{{score}}点",
   "pile": "場",
   "pileTop": "場の一番上",

--- a/frontend/src/pages/PishtiPage.test.tsx
+++ b/frontend/src/pages/PishtiPage.test.tsx
@@ -129,12 +129,46 @@ describe('PishtiPage', () => {
   it('marks a Jack Pişti as +20', async () => {
     renderWithProviders(<PishtiPage />);
     const cardBtn = await screen.findByTestId('hand-card-1');
+    expect(screen.queryByTestId('pishti-celebration')).not.toBeInTheDocument();
     mockExec.mockResolvedValueOnce(
       makeState({ players: [makePlayer({ id: 0, isHuman: true, pistiBonus: 20 }), ...playState.players.slice(1)] }),
     );
     fireEvent.click(cardBtn);
     const badge = await screen.findByTestId('pishti-celebration');
     expect(badge).toHaveTextContent('+20');
+  });
+
+  it('does not fake a +20 Jack when two players each score +10 in one response', async () => {
+    renderWithProviders(<PishtiPage />);
+    const cardBtn = await screen.findByTestId('hand-card-1');
+    // Human +10 and a CPU +10 land in the same response → aggregate 20, but neither is a Jack.
+    mockExec.mockResolvedValueOnce(
+      makeState({
+        players: [
+          makePlayer({ id: 0, isHuman: true, pistiBonus: 10 }),
+          makePlayer({ id: 1, pistiBonus: 10 }),
+          makePlayer({ id: 2 }),
+          makePlayer({ id: 3 }),
+        ],
+      }),
+    );
+    fireEvent.click(cardBtn);
+    const badge = await screen.findByTestId('pishti-celebration');
+    expect(badge).toHaveTextContent('+10');
+    expect(badge).not.toHaveTextContent('+20');
+  });
+
+  it('clears the celebration badge when a new game resets the bonuses', async () => {
+    renderWithProviders(<PishtiPage />);
+    const cardBtn = await screen.findByTestId('hand-card-1');
+    mockExec.mockResolvedValueOnce(
+      makeState({ players: [makePlayer({ id: 0, isHuman: true, pistiBonus: 10 }), ...playState.players.slice(1)] }),
+    );
+    fireEvent.click(cardBtn);
+    await screen.findByTestId('pishti-celebration');
+    // A reset (via settings change) resolves a fresh game with bonuses back to 0.
+    fireEvent.change(screen.getByLabelText('CPU難易度'), { target: { value: '2' } });
+    await waitFor(() => expect(screen.queryByTestId('pishti-celebration')).not.toBeInTheDocument());
   });
 
   it('shows the empty-pile label when the pile is empty', async () => {

--- a/frontend/src/pages/PishtiPage.test.tsx
+++ b/frontend/src/pages/PishtiPage.test.tsx
@@ -113,6 +113,30 @@ describe('PishtiPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', { handIndex: 1 }));
   });
 
+  it('celebrates a Pişti when the bonus total rises (+10)', async () => {
+    renderWithProviders(<PishtiPage />);
+    const cardBtn = await screen.findByTestId('hand-card-1');
+    expect(screen.queryByTestId('pishti-celebration')).not.toBeInTheDocument();
+    // The play resolves a state where the human just scored a +10 Pişti.
+    mockExec.mockResolvedValueOnce(
+      makeState({ players: [makePlayer({ id: 0, isHuman: true, pistiBonus: 10 }), ...playState.players.slice(1)] }),
+    );
+    fireEvent.click(cardBtn);
+    const badge = await screen.findByTestId('pishti-celebration');
+    expect(badge).toHaveTextContent('+10');
+  });
+
+  it('marks a Jack Pişti as +20', async () => {
+    renderWithProviders(<PishtiPage />);
+    const cardBtn = await screen.findByTestId('hand-card-1');
+    mockExec.mockResolvedValueOnce(
+      makeState({ players: [makePlayer({ id: 0, isHuman: true, pistiBonus: 20 }), ...playState.players.slice(1)] }),
+    );
+    fireEvent.click(cardBtn);
+    const badge = await screen.findByTestId('pishti-celebration');
+    expect(badge).toHaveTextContent('+20');
+  });
+
   it('shows the empty-pile label when the pile is empty', async () => {
     mockExec.mockResolvedValue(emptyPileState);
     renderWithProviders(<PishtiPage />);

--- a/frontend/src/pages/PishtiPage.tsx
+++ b/frontend/src/pages/PishtiPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { pishtiApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CardImage } from '../components/CardImage';
@@ -17,6 +17,7 @@ import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useSound } from '../providers/SoundProvider';
 import { btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -121,6 +122,26 @@ function PishtiPageContent() {
   const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
   const { cardWidth } = useCardDimensions();
+  const { playSound } = useSound();
+
+  // Celebrate a Pişti the instant the total bonus rises — the +10/+20 capture is
+  // the game's highlight but was easy to miss amid fast CPU turns (#2692).
+  const [pistiCelebration, setPistiCelebration] = useState<{ key: number; jack: boolean } | null>(null);
+  const prevPistiTotalRef = useRef<number | null>(null);
+  const pistiTotal = state ? state.players.reduce((sum, p) => sum + p.pistiBonus, 0) : 0;
+  useEffect(() => {
+    if (prevPistiTotalRef.current === null) {
+      prevPistiTotalRef.current = pistiTotal;
+      return;
+    }
+    const delta = pistiTotal - prevPistiTotalRef.current;
+    prevPistiTotalRef.current = pistiTotal;
+    if (delta > 0) {
+      // A Jack Pişti scores 20, a normal one 10.
+      setPistiCelebration((prev) => ({ key: (prev?.key ?? 0) + 1, jack: delta >= 20 }));
+      playSound('chipClick', { pitchVariation: 0.1 });
+    }
+  }, [pistiTotal, playSound]);
 
   if (!state)
     return <GameSkeleton gameKey="pishti" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 4 }} />;
@@ -213,7 +234,19 @@ function PishtiPageContent() {
             </div>
 
             {/* Center pile */}
-            <div className="mb-2 p-3 rounded bg-black/20 text-center" data-tutorial="pishti-pile">
+            <div className="relative mb-2 p-3 rounded bg-black/20 text-center" data-tutorial="pishti-pile">
+              {pistiCelebration && (
+                <div
+                  key={pistiCelebration.key}
+                  className="absolute inset-x-0 -top-2 z-10 flex justify-center motion-safe:animate-bounce pointer-events-none"
+                  role="status"
+                  data-testid="pishti-celebration"
+                >
+                  <span className="rounded-full bg-ds-accent px-3 py-0.5 text-sm font-bold text-ds-text-on-accent shadow-lg">
+                    {pistiCelebration.jack ? t('pistiCelebrationJack') : t('pistiCelebration')}
+                  </span>
+                </div>
+              )}
               <div className="text-ds-text-muted text-xs mb-1">
                 {t('pile')} — {t('pileCount', { count: state.pileCount })}
               </div>

--- a/frontend/src/pages/PishtiPage.tsx
+++ b/frontend/src/pages/PishtiPage.tsx
@@ -124,24 +124,36 @@ function PishtiPageContent() {
   const { cardWidth } = useCardDimensions();
   const { playSound } = useSound();
 
-  // Celebrate a Pişti the instant the total bonus rises — the +10/+20 capture is
-  // the game's highlight but was easy to miss amid fast CPU turns (#2692).
+  // Celebrate a Pişti the instant a player's bonus rises — the +10/+20 capture is
+  // the game's highlight but was easy to miss amid fast CPU turns (#2692). Tracked
+  // per-player (not aggregate) so two CPU +10s in one response can't fake a +20 Jack.
   const [pistiCelebration, setPistiCelebration] = useState<{ key: number; jack: boolean } | null>(null);
-  const prevPistiTotalRef = useRef<number | null>(null);
-  const pistiTotal = state ? state.players.reduce((sum, p) => sum + p.pistiBonus, 0) : 0;
+  const prevBonusesRef = useRef<number[] | null>(null);
   useEffect(() => {
-    if (prevPistiTotalRef.current === null) {
-      prevPistiTotalRef.current = pistiTotal;
-      return;
+    if (!state) return;
+    const current = state.players.map((p) => p.pistiBonus);
+    const prev = prevBonusesRef.current;
+    prevBonusesRef.current = current;
+    if (prev === null) return;
+    let anyGain = false;
+    let jack = false;
+    if (prev.length === current.length) {
+      for (let i = 0; i < current.length; i++) {
+        const delta = current[i] - prev[i];
+        if (delta > 0) {
+          anyGain = true;
+          if (delta >= 20) jack = true; // a single +20 rise is a Jack Pişti
+        }
+      }
     }
-    const delta = pistiTotal - prevPistiTotalRef.current;
-    prevPistiTotalRef.current = pistiTotal;
-    if (delta > 0) {
-      // A Jack Pişti scores 20, a normal one 10.
-      setPistiCelebration((prev) => ({ key: (prev?.key ?? 0) + 1, jack: delta >= 20 }));
+    if (anyGain) {
+      setPistiCelebration((c) => ({ key: (c?.key ?? 0) + 1, jack }));
       playSound('chipClick', { pitchVariation: 0.1 });
+    } else if (prev.length !== current.length || current.some((v, i) => v < prev[i])) {
+      // A reset / next game / player-count change drops bonuses; clear the stale badge.
+      setPistiCelebration(null);
     }
-  }, [pistiTotal, playSound]);
+  }, [state, playSound]);
 
   if (!state)
     return <GameSkeleton gameKey="pishti" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 4 }} />;


### PR DESCRIPTION
## 背景
ゲーム名にもなっている「Pişti（場札1枚を捕獲＝+10、Jで+20）」が最大の見せ場ですが、演出は `players` 行内のアクセント色テキスト1つだけで、CPU の高速進行下では達成に気づけませんでした。

## 変更
- 全プレイヤーの `pistiBonus` 合計を `useEffect` で前回値と比較し、増加した瞬間に中央パイル（`pishti-pile`）上へ `motion-safe:animate-bounce` の祝福バッジ（`PİŞTİ +10!` / J は `+20!`）をフェード表示。
- `playSound('chipClick')` で短い効果音（既存音源）。delta>=20 で J の +20 を区別。
- `prefers-reduced-motion` で bounce は無効化（motion-safe）。
- `pistiCelebration`/`pistiCelebrationJack` を ja/en に追加。

## テスト
- +10 / +20（J）でバッジが出ること、初期表示では出ないことを検証する page テストを追加（16 passed）。`bun run check` OK。

Closes #2692