### PR TITLE
feat(cuarenta): pop and chime the human's caída/ronda/limpia bonus

### DIFF
--- a/frontend/src/pages/CuarentaPage.test.tsx
+++ b/frontend/src/pages/CuarentaPage.test.tsx
@@ -10,6 +10,14 @@ vi.mock('../api/gameApi', () => ({
   actionLogApi: { cuarenta: vi.fn() },
 }));
 
+const mockPlaySound = vi.fn();
+const mockSoundValue = { playSound: mockPlaySound, muted: false, toggleMute: vi.fn() };
+vi.mock('../providers/SoundProvider', () => ({
+  SoundProvider: ({ children }: { children: React.ReactNode }) => children,
+  useSound: () => mockSoundValue,
+  useOptionalSound: () => mockSoundValue,
+}));
+
 const mockExec = vi.mocked(cuarentaApi.exec);
 
 const card = (design: Card['design'], value: number): Card => ({ design, value });
@@ -76,6 +84,7 @@ const cpuWinState = makeState({
 
 beforeEach(() => {
   mockExec.mockReset();
+  mockPlaySound.mockReset();
   mockExec.mockResolvedValue(playState);
 });
 
@@ -154,6 +163,49 @@ describe('CuarentaPage', () => {
     await waitFor(() => expect(screen.getByText('カイーダ! +2')).toBeInTheDocument());
     expect(screen.getByText('ロンダ! +1')).toBeInTheDocument();
     expect(screen.getByText('リンピア! +1')).toBeInTheDocument();
+    // The human's bonus badges pop (motion-safe) to draw the eye.
+    const popped = screen.getAllByTestId('cuarenta-bonus-pop');
+    expect(popped.length).toBeGreaterThan(0);
+    expect(popped[0].className).toContain('motion-safe:animate-bounce');
+  });
+
+  it('chimes once when a fresh human bonus lands, but not on a plain play', async () => {
+    renderWithProviders(<CuarentaPage />);
+    const cardBtn = await screen.findByTestId('hand-card-1');
+    // A plain capture (no bonus) must not chime.
+    mockExec.mockResolvedValueOnce(
+      makeState({
+        humanAction: {
+          playerIdx: 0,
+          playedCard: card('CLOVER', 7),
+          capturedCards: [card('CLOVER', 7)],
+          isCaida: false,
+          isLimpia: false,
+          rondaBonus: 0,
+        },
+      }),
+    );
+    fireEvent.click(cardBtn);
+    await waitFor(() => expect(screen.getByText('直前のプレイ')).toBeInTheDocument());
+    expect(mockPlaySound).not.toHaveBeenCalled();
+
+    // A subsequent bonus play chimes exactly once.
+    const nextCard = await screen.findByTestId('hand-card-0');
+    mockExec.mockResolvedValueOnce(
+      makeState({
+        humanAction: {
+          playerIdx: 0,
+          playedCard: card('SPADE', 5),
+          capturedCards: [card('SPADE', 5)],
+          isCaida: true,
+          isLimpia: false,
+          rondaBonus: 0,
+        },
+      }),
+    );
+    fireEvent.click(nextCard);
+    await waitFor(() => expect(mockPlaySound).toHaveBeenCalledWith('chipClick', { pitchVariation: 0.1 }));
+    expect(mockPlaySound).toHaveBeenCalledTimes(1);
   });
 
   it('shows the win message when the human team wins', async () => {

--- a/frontend/src/pages/CuarentaPage.tsx
+++ b/frontend/src/pages/CuarentaPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { cuarentaApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CardImage } from '../components/CardImage';
@@ -18,6 +18,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { useSound } from '../providers/SoundProvider';
 import { btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -115,6 +116,30 @@ function CuarentaPageContent() {
   const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
   const { cardWidth } = useCardDimensions();
+  const { playSound } = useSound();
+
+  // Pop + chime the human's caída / ronda / limpia bonus the instant it lands —
+  // these Cuarenta-specific scores were buried as static text in the log (#2693).
+  const [bonusCelebrationKey, setBonusCelebrationKey] = useState(0);
+  const prevHumanActionRef = useRef<string | null>(null);
+  const humanAction = state?.humanAction ?? null;
+  const humanBonus = !!humanAction && (humanAction.isCaida || humanAction.rondaBonus > 0 || humanAction.isLimpia);
+  const humanActionSig = humanAction
+    ? `${humanAction.playedCard?.design ?? ''}${humanAction.playedCard?.value ?? ''}-${humanAction.isCaida}-${humanAction.rondaBonus}-${humanAction.isLimpia}`
+    : '';
+  useEffect(() => {
+    if (prevHumanActionRef.current === null) {
+      prevHumanActionRef.current = humanActionSig;
+      return;
+    }
+    if (humanActionSig !== prevHumanActionRef.current) {
+      prevHumanActionRef.current = humanActionSig;
+      if (humanBonus) {
+        setBonusCelebrationKey((k) => k + 1);
+        playSound('chipClick', { pitchVariation: 0.1 });
+      }
+    }
+  }, [humanActionSig, humanBonus, playSound]);
 
   if (!state)
     return <GameSkeleton gameKey="cuarenta" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 5 }} />;
@@ -132,8 +157,9 @@ function CuarentaPageContent() {
   const teamLabel = (team: number): string => t('team', { name: team === 0 ? 'A' : 'B' });
   const playerLabel = (id: number, isHuman: boolean): string => (isHuman ? t('you') : t('cpu', { id }));
 
-  /** Renders a short capture-result line for a play action, with bonus badges. */
-  const renderAction = (a: CuarentaAction) => {
+  /** Renders a short capture-result line for a play action, with bonus badges.
+   * `celebrate` pops the bonus badges (used for the human's freshest bonus play). */
+  const renderAction = (a: CuarentaAction, celebrate = false) => {
     const badges: string[] = [];
     if (a.isCaida) badges.push(t('caida'));
     if (a.rondaBonus > 0) badges.push(t('ronda', { bonus: a.rondaBonus }));
@@ -145,7 +171,11 @@ function CuarentaPageContent() {
         {a.playedCard && <CardImage card={a.playedCard} width={Math.round(cardWidth * 0.6)} />}
         <span>{captured > 0 ? t('captured', { count: captured }) : t('laidDown')}</span>
         {badges.map((b) => (
-          <span key={b} className="text-ds-accent font-semibold">
+          <span
+            key={b}
+            className={`text-ds-accent font-semibold ${celebrate ? 'motion-safe:animate-bounce' : ''}`}
+            data-testid={celebrate ? 'cuarenta-bonus-pop' : undefined}
+          >
             {b}
           </span>
         ))}
@@ -252,7 +282,9 @@ function CuarentaPageContent() {
             {(state.humanAction || state.cpuActions.length > 0) && (
               <div className="mb-2 p-2 rounded bg-black/20">
                 <div className="mb-1 text-ds-text-muted text-xs">{t('lastPlays')}</div>
-                {state.humanAction && renderAction(state.humanAction)}
+                {state.humanAction && (
+                  <div key={bonusCelebrationKey}>{renderAction(state.humanAction, humanBonus)}</div>
+                )}
                 {state.cpuActions.map((a) => renderAction(a))}
               </div>
             )}


### PR DESCRIPTION
## 背景
caída・ronda・limpia という Cuarenta 特有の重要得点源は、`直前のプレイ` 欄にアクセント色テキストとして並ぶだけで埋もれており、何が起きたか・なぜ点が入ったかが分かりにくく、`useSound` も未使用でした。

## 変更
- 人間のプレイ（`state.humanAction`）で caída/ronda/limpia のいずれかが成立した瞬間を `useEffect`（playedCard+ボーナスのシグネチャ変化）で検知し、該当バッジに `motion-safe:animate-bounce` のポップ演出 + `playSound('chipClick')` を一度だけ発火（連続成立は key で再アニメ）。
- 通常プレイ（ボーナス無し）では鳴らさない。マウント時も鳴らさない（前回値ガード）。
- `prefers-reduced-motion` で bounce 無効（motion-safe）。既存音源のみ使用（SoundProvider 変更なし）。

## テスト
- ボーナスバッジのポップ class、ボーナス成立で1回だけ chime・通常プレイでは鳴らないことを検証する page テストを追加（16 passed）。`bun run check` OK。

Closes #2693