### PR TITLE
feat(spoons): cue the grab window with a chime and pulsing button

### DIFF
--- a/frontend/src/pages/SpoonsPage.test.tsx
+++ b/frontend/src/pages/SpoonsPage.test.tsx
@@ -152,6 +152,19 @@ describe('SpoonsPage', () => {
     expect(screen.queryByRole('button', { name: 'スプーンを取る！' })).not.toBeInTheDocument();
   });
 
+  it('does not re-chime while the grab window stays open across updates', async () => {
+    renderWithProviders(<SpoonsPage />);
+    const buttons = await screen.findAllByRole('button', { name: '渡す' });
+    mockExec.mockResolvedValueOnce(grabState);
+    fireEvent.click(buttons[0]);
+    await waitFor(() => expect(mockPlaySound).toHaveBeenCalledTimes(1));
+    // A later update that keeps the window open must not chime again.
+    mockExec.mockResolvedValueOnce(makeState({ phase: 1, grabWindowOpen: true, drawPileSize: 35 }));
+    fireEvent.click(screen.getByRole('button', { name: 'スプーンを取る！' }));
+    await waitFor(() => expect(screen.getByText(/山札: 35/)).toBeInTheDocument());
+    expect(mockPlaySound).toHaveBeenCalledTimes(1);
+  });
+
   it('shows the next round button at round end and dispatches next', async () => {
     mockExec.mockResolvedValue(roundEndState);
     renderWithProviders(<SpoonsPage />);

--- a/frontend/src/pages/SpoonsPage.test.tsx
+++ b/frontend/src/pages/SpoonsPage.test.tsx
@@ -10,6 +10,14 @@ vi.mock('../api/gameApi', () => ({
   actionLogApi: { spoons: vi.fn() },
 }));
 
+const mockPlaySound = vi.fn();
+const mockSoundValue = { playSound: mockPlaySound, muted: false, toggleMute: vi.fn() };
+vi.mock('../providers/SoundProvider', () => ({
+  SoundProvider: ({ children }: { children: React.ReactNode }) => children,
+  useSound: () => mockSoundValue,
+  useOptionalSound: () => mockSoundValue,
+}));
+
 const mockExec = vi.mocked(spoonsApi.exec);
 
 function makePlayer(overrides: Partial<SpoonsPlayer> = {}): SpoonsPlayer {
@@ -67,6 +75,7 @@ const gameEndState = makeState({ phase: 3, gameEndFlag: true, winnerIdx: 0, isHu
 
 beforeEach(() => {
   mockExec.mockReset();
+  mockPlaySound.mockReset();
   mockExec.mockResolvedValue(passState);
 });
 
@@ -116,6 +125,25 @@ describe('SpoonsPage', () => {
     mockExec.mockClear();
     fireEvent.click(btn);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('grab'));
+  });
+
+  it('pulses the grab button while the window is open', async () => {
+    mockExec.mockResolvedValue(grabState);
+    renderWithProviders(<SpoonsPage />);
+    const btn = await screen.findByTestId('spoons-grab-button');
+    expect(btn.className).toContain('motion-safe:animate-pulse');
+  });
+
+  it('chimes once when the grab window opens (false→true)', async () => {
+    // Mount in the pass phase (window closed) → no chime yet.
+    renderWithProviders(<SpoonsPage />);
+    const buttons = await screen.findAllByRole('button', { name: '渡す' });
+    expect(mockPlaySound).not.toHaveBeenCalled();
+    // Passing a card opens the grab window in the response → chime fires once.
+    mockExec.mockResolvedValueOnce(grabState);
+    fireEvent.click(buttons[0]);
+    await waitFor(() => expect(mockPlaySound).toHaveBeenCalledWith('turnTick', { pitchVariation: 0.1 }));
+    expect(mockPlaySound).toHaveBeenCalledTimes(1);
   });
 
   it('hides the grab button when the grab window is closed', async () => {

--- a/frontend/src/pages/SpoonsPage.tsx
+++ b/frontend/src/pages/SpoonsPage.tsx
@@ -127,8 +127,8 @@ function SpoonsPageContent() {
   const { playSound } = useSound();
   const phaseNames = usePhaseNames('spoons', SPOONS_PHASE_KEYS);
 
-  // Chime the instant the grab window opens (false→true) — this speed game gave
-  // only a static "grab now!" text, so the window was easy to miss (#2689).
+  // Chime the instant the grab window opens (false→true) — a static "grab now!"
+  // text alone was easy to miss in this reflex game.
   const prevGrabOpenRef = useRef(false);
   useEffect(() => {
     const open = state?.grabWindowOpen ?? false;

--- a/frontend/src/pages/SpoonsPage.tsx
+++ b/frontend/src/pages/SpoonsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { spoonsApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CardImage } from '../components/CardImage';
@@ -18,6 +18,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { useSound } from '../providers/SoundProvider';
 import { btnSuccess, btnWarning } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -123,7 +124,19 @@ function SpoonsPageContent() {
   const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
   const { cardWidth } = useCardDimensions();
+  const { playSound } = useSound();
   const phaseNames = usePhaseNames('spoons', SPOONS_PHASE_KEYS);
+
+  // Chime the instant the grab window opens (false→true) — this speed game gave
+  // only a static "grab now!" text, so the window was easy to miss (#2689).
+  const prevGrabOpenRef = useRef(false);
+  useEffect(() => {
+    const open = state?.grabWindowOpen ?? false;
+    if (open && !prevGrabOpenRef.current) {
+      playSound('turnTick', { pitchVariation: 0.1 });
+    }
+    prevGrabOpenRef.current = open;
+  }, [state?.grabWindowOpen, playSound]);
 
   if (!state)
     return <GameSkeleton gameKey="spoons" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 4 }} />;
@@ -276,7 +289,13 @@ function SpoonsPageContent() {
               {state.grabWindowOpen && !isGameEnd && (
                 <>
                   <span className="text-ds-warning text-sm font-semibold mr-1">{t('grabNotice')}</span>
-                  <button type="button" className={btnWarning} onClick={() => exec('grab')} disabled={loading}>
+                  <button
+                    type="button"
+                    className={`${btnWarning} motion-safe:animate-pulse`}
+                    onClick={() => exec('grab')}
+                    disabled={loading}
+                    data-testid="spoons-grab-button"
+                  >
                     {t('grabButton')}
                   </button>
                 </>


### PR DESCRIPTION
## 背景
反射神経が肝のゲームなのに、`grabWindowOpen` が開いた瞬間の合図が `grabNotice` の警告テキストと `grabButton` の出現のみで、ユーザーが窓の開放に気づくのが遅れていました（`useSound` 未使用）。

## 変更
- `grabWindowOpen` が false→true に変わった瞬間に `playSound('turnTick')`（既存音源）を一度だけ再生（`useRef` で前回値比較）。
- グラブボタンに `motion-safe:animate-pulse` の脈動演出 + `spoons-grab-button` testid。
- `prefers-reduced-motion` で pulse 無効（motion-safe）。SoundProvider 変更なし（turnTick 既存）。

## テスト
- グラブボタンの pulse class、窓開放（false→true）で turnTick が1回だけ鳴り・閉状態では鳴らないことを検証する page テストを追加（16 passed）。`bun run check` OK。

Closes #2689