### PR TITLE
feat(blackhole): highlight playable fans on hint request

### DIFF
--- a/frontend/src/pages/BlackHolePage.test.tsx
+++ b/frontend/src/pages/BlackHolePage.test.tsx
@@ -108,6 +108,19 @@ describe('BlackHolePage', () => {
     expect(otherTop).not.toHaveAttribute('data-hinted-legal');
   });
 
+  it('clears the hint highlight on reset even though moveCount stays 0', async () => {
+    const adj = makeState({ blackHole: [card('SPADE', 7)] });
+    mockExec.mockResolvedValue(adj);
+    renderWithProviders(<BlackHolePage />);
+    await screen.findByTestId('hint-button');
+    fireEvent.click(screen.getByTestId('hint-button'));
+    await waitFor(() => expect(screen.getByTestId('card-0-1')).toHaveAttribute('data-hinted-legal', 'true'));
+    // Reset (with confirm) — moveCount stays 0, so the highlight must be cleared explicitly.
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    await waitFor(() => expect(screen.getByTestId('card-0-1')).not.toHaveAttribute('data-hinted-legal'));
+  });
+
   it('does not ring an A-K wrap (no wrap in Black Hole)', async () => {
     // Hole top A(1): only rank 2 is adjacent — K(13) must NOT highlight.
     const wrap = makeState({ blackHole: [card('SPADE', 1)] });

--- a/frontend/src/pages/BlackHolePage.test.tsx
+++ b/frontend/src/pages/BlackHolePage.test.tsx
@@ -90,4 +90,34 @@ describe('BlackHolePage', () => {
     await waitFor(() => expect(screen.getByTestId('fan-0')).toBeInTheDocument());
     expect(screen.queryByTestId('hint-button')).not.toBeInTheDocument();
   });
+
+  it('rings the ±1 fan tops on hint, leaving non-adjacent fans unmarked', async () => {
+    // Hole top is 7 → fan0 top (CLOVER 6) is adjacent; fan1 top (DIAMOND 10) is not.
+    const adj = makeState({ blackHole: [card('SPADE', 7)] });
+    mockExec.mockResolvedValue(adj);
+    renderWithProviders(<BlackHolePage />);
+    const legalTop = await screen.findByTestId('card-0-1');
+    const otherTop = screen.getByTestId('card-1-0');
+    // No highlight until the hint is requested.
+    expect(legalTop).not.toHaveAttribute('data-hinted-legal');
+
+    fireEvent.click(screen.getByTestId('hint-button'));
+    await waitFor(() => expect(screen.getByTestId('card-0-1')).toHaveAttribute('data-hinted-legal', 'true'));
+    expect(screen.getByTestId('card-0-1').className).toContain('ring-ds-success');
+    // The non-adjacent fan top is never marked.
+    expect(otherTop).not.toHaveAttribute('data-hinted-legal');
+  });
+
+  it('does not ring an A-K wrap (no wrap in Black Hole)', async () => {
+    // Hole top A(1): only rank 2 is adjacent — K(13) must NOT highlight.
+    const wrap = makeState({ blackHole: [card('SPADE', 1)] });
+    wrap.fans[0] = [card('HEART', 13)]; // King
+    wrap.fans[1] = [card('CLOVER', 2)]; // Two — the only legal move
+    mockExec.mockResolvedValue(wrap);
+    renderWithProviders(<BlackHolePage />);
+    await screen.findByTestId('hint-button');
+    fireEvent.click(screen.getByTestId('hint-button'));
+    await waitFor(() => expect(screen.getByTestId('card-1-0')).toHaveAttribute('data-hinted-legal', 'true'));
+    expect(screen.getByTestId('card-0-0')).not.toHaveAttribute('data-hinted-legal');
+  });
 });

--- a/frontend/src/pages/BlackHolePage.tsx
+++ b/frontend/src/pages/BlackHolePage.tsx
@@ -82,6 +82,10 @@ function BlackHolePageContent() {
 
   const handleReset = () => {
     hideActionLog();
+    // A reset keeps moveCount at 0, so the moveCount effect won't fire — clear
+    // the stale hint highlight (and its pending timer) here.
+    setShowLegalHint(false);
+    window.clearTimeout(hintTimerRef.current ?? undefined);
     exec('reset');
   };
 

--- a/frontend/src/pages/BlackHolePage.tsx
+++ b/frontend/src/pages/BlackHolePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { blackholeApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CardImage } from '../components/CardImage';
@@ -61,6 +61,18 @@ function BlackHolePageContent() {
   const { cardWidth } = useCardDimensions();
   const w = Math.round(cardWidth * 0.5);
 
+  // On a hint request, ring the fans whose top card is ±1 the black hole's top
+  // rank (Black Hole accepts only adjacent ranks, no A-K wrap). The highlight
+  // auto-clears after a few seconds or on the next move (moveCount change).
+  const [showLegalHint, setShowLegalHint] = useState(false);
+  const hintTimerRef = useRef<number | null>(null);
+  const moveCount = state?.moveCount ?? 0;
+  // biome-ignore lint/correctness/useExhaustiveDependencies: moveCount is the trigger — clear the highlight whenever a move changes the board.
+  useEffect(() => {
+    setShowLegalHint(false);
+  }, [moveCount]);
+  useEffect(() => () => window.clearTimeout(hintTimerRef.current ?? undefined), []);
+
   if (!state) return <GameSkeleton gameKey="blackhole" layout={{ kind: 'tableau', topRow: 1, tableau: 9 }} />;
 
   const isClear = state.phase === BlackHolePhase.GAME_CLEAR;
@@ -78,8 +90,26 @@ function BlackHolePageContent() {
     exec('mb', { fan });
   };
 
+  const handleHint = () => {
+    exec('hint');
+    setShowLegalHint(true);
+    window.clearTimeout(hintTimerRef.current ?? undefined);
+    hintTimerRef.current = window.setTimeout(() => setShowLegalHint(false), 4000);
+  };
+
   const cardH = Math.round(w * 1.4);
   const holeTop = state.blackHole.length > 0 ? state.blackHole[state.blackHole.length - 1] : null;
+
+  // A fan's top card is playable when its rank is exactly one away from the hole's
+  // top rank (no A↔K wrap, so plain numeric ±1 is correct).
+  const legalFans = new Set<number>(
+    holeTop
+      ? state.fans
+          .map((fan, idx) => ({ idx, top: fan[fan.length - 1] }))
+          .filter(({ top }) => top && Math.abs(top.value - holeTop.value) === 1)
+          .map(({ idx }) => idx)
+      : [],
+  );
 
   const renderFan = (fan: (typeof state.fans)[number], idx: number) => (
     <div
@@ -97,15 +127,17 @@ function BlackHolePageContent() {
       ) : (
         fan.map((c, i) => {
           const isTop = i === fan.length - 1;
+          const isHintedLegal = showLegalHint && isTop && legalFans.has(idx);
           return (
             <button
               type="button"
               key={`fan-${idx}-${i}`}
-              className="rounded"
+              className={`rounded ${isHintedLegal ? 'ring-2 ring-ds-success motion-safe:animate-pulse' : ''}`}
               style={{ marginTop: i === 0 ? 0 : -Math.round(w * 1.05) }}
               onClick={canAct && isTop ? () => playFan(idx) : undefined}
               disabled={!canAct || !isTop}
               data-testid={`card-${idx}-${i}`}
+              data-hinted-legal={isHintedLegal ? 'true' : undefined}
             >
               <CardImage card={c} width={w} />
             </button>
@@ -173,7 +205,7 @@ function BlackHolePageContent() {
             <button
               type="button"
               className={btnPrimary}
-              onClick={() => exec('hint')}
+              onClick={handleHint}
               disabled={loading}
               data-testid="hint-button"
             >


### PR DESCRIPTION
## 背景
`hint-button` はメッセージ欄にヒント文を出すだけで、17 個ある扇のどれが吸い込み可能かを盤面上で示さず、6×3 グリッドから手作業で探す負荷が高い状態でした。

## 変更
- ヒント要求時、中央ブラックホールの最上札ランクと **±1（A↔K wrap なし）** の最上札を持つ扇を算出し、当該カードに `ring-2 ring-ds-success motion-safe:animate-pulse` を付与。
- 強調は **約4秒後** または **次手（moveCount 変化）** で自動解除。
- 合法判定はクライアント側で完結（`state.fans` の各最上札 vs `blackHole` 最上札）、**バックエンド変更なし**。
- `prefers-reduced-motion` で pulse 無効（motion-safe）。

## テスト
- 隣接ランクの扇のみ強調・非隣接は非強調、A↔K wrap しない（A の隣は 2 のみ、K は非強調）、ヒント前は非強調を検証する page テストを追加（9 passed）。`bun run check` OK。

Closes #2701