### PR TITLE
feat(casinoholdem): show the player's current hand at the flop

### DIFF
--- a/frontend/src/i18n/locales/en/casinoholdem.json
+++ b/frontend/src/i18n/locales/en/casinoholdem.json
@@ -1,6 +1,7 @@
 {
   "title": "Casino Hold'em",
   "player": "Player",
+  "currentHand": "Current hand",
   "dealer": "Dealer",
   "board": "Board",
   "dealerQualified": "Dealer qualifies",

--- a/frontend/src/i18n/locales/ja/casinoholdem.json
+++ b/frontend/src/i18n/locales/ja/casinoholdem.json
@@ -1,6 +1,7 @@
 {
   "title": "カジノホールデム",
   "player": "プレイヤー",
+  "currentHand": "現在の役",
   "dealer": "ディーラー",
   "board": "ボード",
   "dealerQualified": "ディーラークオリファイ",

--- a/frontend/src/pages/CasinoHoldemPage.test.tsx
+++ b/frontend/src/pages/CasinoHoldemPage.test.tsx
@@ -204,6 +204,22 @@ describe('CasinoHoldemPage', () => {
     expect(screen.getByText('🃏')).toBeInTheDocument();
   });
 
+  it('shows the player current hand at flop (computed client-side)', async () => {
+    // flopState is A-K-Q-J-10 all spades → Royal Flush.
+    mockApi.mockResolvedValue(flopState);
+    renderWithProviders(<CasinoHoldemPage />);
+    const hand = await screen.findByTestId('ch-flop-hand');
+    expect(hand).toHaveTextContent('現在の役');
+    expect(hand).toHaveTextContent('ロイヤルフラッシュ');
+  });
+
+  it('does not show the flop current-hand readout in the bet phase', async () => {
+    mockApi.mockResolvedValue(betPhaseState);
+    renderWithProviders(<CasinoHoldemPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: /ベット/ })).toBeInTheDocument());
+    expect(screen.queryByTestId('ch-flop-hand')).not.toBeInTheDocument();
+  });
+
   it('renders hint toggle checkbox', async () => {
     mockApi.mockResolvedValue(flopState);
     renderWithProviders(<CasinoHoldemPage />);

--- a/frontend/src/pages/CasinoHoldemPage.test.tsx
+++ b/frontend/src/pages/CasinoHoldemPage.test.tsx
@@ -213,6 +213,19 @@ describe('CasinoHoldemPage', () => {
     expect(hand).toHaveTextContent('ロイヤルフラッシュ');
   });
 
+  it('shows a non-royal current hand at flop (one pair)', async () => {
+    // A♠ + 10♣ with board 10♥ 4♦ 2♠ → a pair of tens.
+    const onePairFlop: CasinoHoldemResponse = {
+      ...flopState,
+      playerHand: [card('SPADE', 1), card('CLOVER', 10)],
+      community: [card('HEART', 10), card('DIAMOND', 4), card('SPADE', 2)],
+    };
+    mockApi.mockResolvedValue(onePairFlop);
+    renderWithProviders(<CasinoHoldemPage />);
+    const hand = await screen.findByTestId('ch-flop-hand');
+    expect(hand).toHaveTextContent('ワンペア');
+  });
+
   it('does not show the flop current-hand readout in the bet phase', async () => {
     mockApi.mockResolvedValue(betPhaseState);
     renderWithProviders(<CasinoHoldemPage />);

--- a/frontend/src/pages/CasinoHoldemPage.tsx
+++ b/frontend/src/pages/CasinoHoldemPage.tsx
@@ -34,6 +34,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { CASINOHOLDEM_HELP, parseCasinoholdemCommand } from '../utils/cli/commands/casinoholdemCommands';
 import { formatCasinoholdemState } from '../utils/cli/formatters/casinoholdemFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { evaluateFiveCardHand } from '../utils/pokerSquaresUtils';
 
 /** Casino Hold'em tutorial step definitions. */
 const CH_TUTORIAL_STEPS: TutorialStep[] = [
@@ -140,6 +141,14 @@ function CasinoHoldemPageContent() {
   const betInvalid = anteInvalid || bonusInvalid || anteAmount + bonusAmount > state.chips;
 
   const phaseName = isBetPhase ? t('phase.bet') : isFlopPhase ? t('phase.flop') : t('phase.end');
+
+  // At the flop the player sees 2 hole + 3 community = 5 cards, so the current
+  // hand can be evaluated client-side to aid the Call/Fold call (#2626). The
+  // dealer's hand stays hidden until END.
+  const flopHandRank =
+    isFlopPhase && state.playerHand.length === 2 && state.community.length === 3
+      ? evaluateFiveCardHand([...state.playerHand, ...state.community])
+      : null;
 
   return (
     <GamePageShell
@@ -281,6 +290,11 @@ function CasinoHoldemPageContent() {
                   <span aria-hidden="true">🟡</span> {t('player')}
                   {isEndPhase && (
                     <span className="ml-2 text-sm">({t(HAND_RANK_KEYS[state.playerHandRank] ?? 'handRank.0')})</span>
+                  )}
+                  {flopHandRank !== null && (
+                    <span className="ml-2 text-sm" data-testid="ch-flop-hand">
+                      ({t('currentHand')}: {t(HAND_RANK_KEYS[flopHandRank] ?? 'handRank.0')})
+                    </span>
                   )}
                 </div>
                 <div className="flex justify-center gap-2 flex-wrap">

--- a/frontend/src/pages/CasinoHoldemPage.tsx
+++ b/frontend/src/pages/CasinoHoldemPage.tsx
@@ -143,12 +143,10 @@ function CasinoHoldemPageContent() {
   const phaseName = isBetPhase ? t('phase.bet') : isFlopPhase ? t('phase.flop') : t('phase.end');
 
   // At the flop the player sees 2 hole + 3 community = 5 cards, so the current
-  // hand can be evaluated client-side to aid the Call/Fold call (#2626). The
+  // hand can be evaluated client-side to aid the Call/Fold call. evaluateFiveCardHand
+  // returns null for anything but 5 cards, so the phase guard is enough. The
   // dealer's hand stays hidden until END.
-  const flopHandRank =
-    isFlopPhase && state.playerHand.length === 2 && state.community.length === 3
-      ? evaluateFiveCardHand([...state.playerHand, ...state.community])
-      : null;
+  const flopHandRank = isFlopPhase ? evaluateFiveCardHand([...state.playerHand, ...state.community]) : null;
 
   return (
     <GamePageShell
@@ -293,7 +291,7 @@ function CasinoHoldemPageContent() {
                   )}
                   {flopHandRank !== null && (
                     <span className="ml-2 text-sm" data-testid="ch-flop-hand">
-                      ({t('currentHand')}: {t(HAND_RANK_KEYS[flopHandRank] ?? 'handRank.0')})
+                      ({t('currentHand')}: {t(HAND_RANK_KEYS[flopHandRank])})
                     </span>
                   )}
                 </div>


### PR DESCRIPTION
## 背景
FLOP フェーズでは player の2枚＋community の3枚が見えているのに、現在の役名は END でしか表示されず、初心者は Call/Fold 判断時に自分の役が分からず根拠なく賭けていました。

## 変更
- FLOP 時、`[...playerHand, ...community]`（2+3=5枚）を既存の `evaluateFiveCardHand` で評価し、プレイヤー欄に現在役名を表示（`現在の役: …`、`ch-flop-hand` testid）。
- `PokerHand` のランク値（0–9）はページの `HAND_RANK_KEYS` と一致するため、そのまま `t(HAND_RANK_KEYS[rank])` で表示。
- **ディーラーの役は END まで非表示**のまま（ネタバレ防止）。**バックエンド変更なし**。
- `currentHand` を ja/en に追加。

## テスト
- FLOP で現在役（ロイヤルフラッシュ）が出ること・BET フェーズでは出ないことを検証する page テストを追加（17 passed）。`bun run check` OK。

Closes #2626