### PR TITLE
feat(tichu): mark bomb cards in the hand with a badge and aria-label

### DIFF
--- a/frontend/src/i18n/locales/en/tichu.json
+++ b/frontend/src/i18n/locales/en/tichu.json
@@ -3,6 +3,7 @@
   "settings": {
     "cpuDifficulty": "CPU difficulty"
   },
+  "bombCardAriaLabel": "{{card}} (part of a bomb)",
   "label": {
     "table": "Table",
     "bombs": "Bombs",

--- a/frontend/src/i18n/locales/ja/tichu.json
+++ b/frontend/src/i18n/locales/ja/tichu.json
@@ -3,6 +3,7 @@
   "settings": {
     "cpuDifficulty": "CPUの難易度"
   },
+  "bombCardAriaLabel": "{{card}}（ボム構成カード）",
   "label": {
     "table": "場",
     "bombs": "爆弾",

--- a/frontend/src/pages/TichuPage.test.tsx
+++ b/frontend/src/pages/TichuPage.test.tsx
@@ -198,6 +198,33 @@ describe('TichuPage', () => {
     expect(screen.getByRole('button', { name: '♠ 7（ボム構成カード）' })).toBeInTheDocument();
   });
 
+  it('declare phase: bomb cards are badged in the hand too', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: 'declare',
+        players: [
+          player({
+            id: 0,
+            isHuman: true,
+            team: 0,
+            cardCount: 4,
+            cards: [
+              { design: 'SPADE', value: 7 },
+              { design: 'HEART', value: 7 },
+              { design: 'CLOVER', value: 7 },
+              { design: 'DIAMOND', value: 7 },
+            ],
+          }),
+          player({ id: 1, team: 1 }),
+          player({ id: 2, team: 0 }),
+          player({ id: 3, team: 1 }),
+        ],
+      }),
+    );
+    renderWithProviders(<TichuPage />);
+    await waitFor(() => expect(screen.getByTestId('tichu-bomb-badge-0')).toBeInTheDocument());
+  });
+
   it('end phase: shows team scores, the win banner, and the one-two note', async () => {
     mockExec.mockResolvedValue(makeState({ phase: 'end', gameEndFlag: true, isOneTwo: true, scores: [200, -100] }));
     renderWithProviders(<TichuPage />);

--- a/frontend/src/pages/TichuPage.test.tsx
+++ b/frontend/src/pages/TichuPage.test.tsx
@@ -165,6 +165,39 @@ describe('TichuPage', () => {
     });
   });
 
+  it('play phase: marks the cards that form a bomb with a badge and aria-label', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        players: [
+          player({
+            id: 0,
+            isHuman: true,
+            team: 0,
+            cardCount: 5,
+            // Four sevens (a four-of-a-kind bomb) + a lone nine.
+            cards: [
+              { design: 'SPADE', value: 7 },
+              { design: 'HEART', value: 7 },
+              { design: 'CLOVER', value: 7 },
+              { design: 'DIAMOND', value: 7 },
+              { design: 'SPADE', value: 9 },
+            ],
+          }),
+          player({ id: 1, team: 1 }),
+          player({ id: 2, team: 0 }),
+          player({ id: 3, team: 1 }),
+        ],
+      }),
+    );
+    renderWithProviders(<TichuPage />);
+    await waitFor(() => expect(screen.getByTestId('tichu-bomb-badge-0')).toBeInTheDocument());
+    // All four sevens are badged; the nine is not.
+    expect(screen.getByTestId('tichu-bomb-badge-3')).toBeInTheDocument();
+    expect(screen.queryByTestId('tichu-bomb-badge-4')).not.toBeInTheDocument();
+    // A bomb card's accessible name flags the bomb.
+    expect(screen.getByRole('button', { name: '♠ 7（ボム構成カード）' })).toBeInTheDocument();
+  });
+
   it('end phase: shows team scores, the win banner, and the one-two note', async () => {
     mockExec.mockResolvedValue(makeState({ phase: 'end', gameEndFlag: true, isOneTwo: true, scores: [200, -100] }));
     renderWithProviders(<TichuPage />);

--- a/frontend/src/pages/TichuPage.tsx
+++ b/frontend/src/pages/TichuPage.tsx
@@ -25,7 +25,9 @@ import { btnPrimary, btnSecondary, btnWarning } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { TichuResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
+import { tichuBombIndices } from '../utils/tichuBomb';
 
 type ApiArgs = {
   command: string;
@@ -141,6 +143,9 @@ function TichuPageContent() {
   const isHumanTurn = state ? state.currentTurn === humanIdx : false;
   const humanPlayer = state?.players?.[humanIdx];
   const humanTeam = humanPlayer?.team ?? 0;
+  // Hand indices that form a bomb (4-of-a-kind / straight flush) — the strongest
+  // play, which was previously indistinguishable in the hand (#2657).
+  const bombIndices = useMemo(() => tichuBombIndices(humanPlayer?.cards ?? []), [humanPlayer?.cards]);
   const humanWon = isGameEnd && !!state && state.scores[humanTeam] > state.scores[1 - humanTeam];
 
   useEffect(() => {
@@ -289,21 +294,36 @@ function TichuPageContent() {
           {humanPlayer && (phase === 'play' || phase === 'declare') && (
             <div data-tutorial="tichu-hand">
               <div className="flex flex-wrap justify-center gap-1">
-                {humanPlayer.cards.map((c, i) => (
-                  <button
-                    key={`hand-${c.design}-${c.value}-${i}`}
-                    type="button"
-                    className={
-                      selectedCards.has(i)
-                        ? 'transition-transform -translate-y-2 ring-2 ring-ds-warning rounded'
-                        : 'transition-transform'
-                    }
-                    onClick={() => toggleCard(i)}
-                    disabled={phase !== 'play'}
-                  >
-                    <AnimatedCard card={c} width={cardWidth * 0.9} />
-                  </button>
-                ))}
+                {humanPlayer.cards.map((c, i) => {
+                  const isBomb = bombIndices.has(i);
+                  return (
+                    <button
+                      key={`hand-${c.design}-${c.value}-${i}`}
+                      type="button"
+                      className={`relative ${
+                        selectedCards.has(i)
+                          ? 'transition-transform -translate-y-2 ring-2 ring-ds-warning rounded'
+                          : isBomb
+                            ? 'transition-transform ring-2 ring-ds-error rounded'
+                            : 'transition-transform'
+                      }`}
+                      onClick={() => toggleCard(i)}
+                      disabled={phase !== 'play'}
+                      aria-label={isBomb ? t('bombCardAriaLabel', { card: cardAlt(c) }) : cardAlt(c)}
+                    >
+                      <AnimatedCard card={c} width={cardWidth * 0.9} />
+                      {isBomb && (
+                        <span
+                          className="absolute -top-1 -right-1 text-[10px] rounded-full bg-ds-error px-1 text-ds-text-on-accent"
+                          aria-hidden="true"
+                          data-testid={`tichu-bomb-badge-${i}`}
+                        >
+                          💣
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
               </div>
               {phase === 'play' && isHumanTurn && (
                 <div className="flex justify-center gap-2 mt-2">

--- a/frontend/src/pages/TichuPage.tsx
+++ b/frontend/src/pages/TichuPage.tsx
@@ -143,8 +143,6 @@ function TichuPageContent() {
   const isHumanTurn = state ? state.currentTurn === humanIdx : false;
   const humanPlayer = state?.players?.[humanIdx];
   const humanTeam = humanPlayer?.team ?? 0;
-  // Hand indices that form a bomb (4-of-a-kind / straight flush) — the strongest
-  // play, which was previously indistinguishable in the hand (#2657).
   const bombIndices = useMemo(() => tichuBombIndices(humanPlayer?.cards ?? []), [humanPlayer?.cards]);
   const humanWon = isGameEnd && !!state && state.scores[humanTeam] > state.scores[1 - humanTeam];
 

--- a/frontend/src/utils/tichuBomb.test.ts
+++ b/frontend/src/utils/tichuBomb.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { tichuBombIndices } from './tichuBomb';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('tichuBombIndices', () => {
+  it('flags a four-of-a-kind', () => {
+    const hand = [card('SPADE', 7), card('HEART', 7), card('CLOVER', 7), card('DIAMOND', 7), card('SPADE', 9)];
+    expect([...tichuBombIndices(hand)].sort((a, b) => a - b)).toEqual([0, 1, 2, 3]);
+  });
+
+  it('flags a five-card straight flush', () => {
+    const hand = [
+      card('SPADE', 5),
+      card('SPADE', 6),
+      card('SPADE', 7),
+      card('SPADE', 8),
+      card('SPADE', 9),
+      card('HEART', 2),
+    ];
+    expect([...tichuBombIndices(hand)].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('treats the Ace as high (10-J-Q-K-A is a straight flush, A-2-3-4-5 is not)', () => {
+    const highRun = [
+      card('HEART', 10),
+      card('HEART', 11),
+      card('HEART', 12),
+      card('HEART', 13),
+      card('HEART', 1), // Ace
+    ];
+    expect(tichuBombIndices(highRun).size).toBe(5);
+
+    const wheel = [card('HEART', 1), card('HEART', 2), card('HEART', 3), card('HEART', 4), card('HEART', 5)];
+    expect(tichuBombIndices(wheel).size).toBe(0); // Ace is high only — no wheel bomb
+  });
+
+  it('does not flag a four-card straight or a mixed-suit run', () => {
+    const shortRun = [card('SPADE', 5), card('SPADE', 6), card('SPADE', 7), card('SPADE', 8)];
+    expect(tichuBombIndices(shortRun).size).toBe(0);
+    const mixed = [card('SPADE', 5), card('HEART', 6), card('SPADE', 7), card('SPADE', 8), card('SPADE', 9)];
+    expect(tichuBombIndices(mixed).size).toBe(0);
+  });
+
+  it('ignores special (JOKER) cards', () => {
+    // Three sevens + two JOKER specials must not be mistaken for a bomb.
+    const hand = [card('SPADE', 7), card('HEART', 7), card('CLOVER', 7), card('JOKER', 4), card('JOKER', 3)];
+    expect(tichuBombIndices(hand).size).toBe(0);
+  });
+
+  it('returns an empty set for a bombless hand', () => {
+    const hand = [card('SPADE', 2), card('HEART', 5), card('CLOVER', 9), card('DIAMOND', 13)];
+    expect(tichuBombIndices(hand).size).toBe(0);
+  });
+});

--- a/frontend/src/utils/tichuBomb.ts
+++ b/frontend/src/utils/tichuBomb.ts
@@ -23,15 +23,16 @@ function tichuRank(card: Card): number {
 export function tichuBombIndices(cards: readonly Card[]): Set<number> {
   const bomb = new Set<number>();
 
-  // Four-of-a-kind: group the natural cards by value (a single deck holds ≤4 of each).
-  const byValue = new Map<number, number[]>();
+  // Four-of-a-kind: group the natural cards by rank (a single deck holds ≤4 of each).
+  const byRank = new Map<number, number[]>();
   cards.forEach((c, i) => {
     if (!STANDARD_SUITS.has(c.design)) return;
-    const arr = byValue.get(c.value) ?? [];
+    const r = tichuRank(c);
+    const arr = byRank.get(r) ?? [];
     arr.push(i);
-    byValue.set(c.value, arr);
+    byRank.set(r, arr);
   });
-  for (const idxs of byValue.values()) {
+  for (const idxs of byRank.values()) {
     if (idxs.length >= 4) for (const i of idxs) bomb.add(i);
   }
 

--- a/frontend/src/utils/tichuBomb.ts
+++ b/frontend/src/utils/tichuBomb.ts
@@ -1,0 +1,64 @@
+import type { Card } from '../types/card';
+
+/** The four natural suits; Tichu specials (Dragon/Phoenix/Mahjong/Dog) use the JOKER design. */
+const STANDARD_SUITS: ReadonlySet<string> = new Set(['SPADE', 'CLOVER', 'HEART', 'DIAMOND']);
+
+/** Minimum length of a straight-flush bomb in Tichu. */
+const STRAIGHT_FLUSH_MIN = 5;
+
+/**
+ * Tichu rank of a natural card. Ace (value 1) is high (14); 2..K map to 2..13.
+ * Mirrors `tichuRank` in `internal/domain/TichuEval.go` (Ace high, no A-2-3-4-5 wheel).
+ */
+function tichuRank(card: Card): number {
+  return card.value === 1 ? 14 : card.value;
+}
+
+/**
+ * Returns the set of hand indices that form a **bomb** — a four-of-a-kind (four
+ * cards of the same rank) or a straight flush (five or more same-suit cards with
+ * consecutive ranks). Special cards (JOKER design: Dragon/Phoenix/Mahjong/Dog)
+ * never participate, matching the domain's `tichuTryBomb4` / `tichuTryStraightFlush`.
+ */
+export function tichuBombIndices(cards: readonly Card[]): Set<number> {
+  const bomb = new Set<number>();
+
+  // Four-of-a-kind: group the natural cards by value (a single deck holds ≤4 of each).
+  const byValue = new Map<number, number[]>();
+  cards.forEach((c, i) => {
+    if (!STANDARD_SUITS.has(c.design)) return;
+    const arr = byValue.get(c.value) ?? [];
+    arr.push(i);
+    byValue.set(c.value, arr);
+  });
+  for (const idxs of byValue.values()) {
+    if (idxs.length >= 4) for (const i of idxs) bomb.add(i);
+  }
+
+  // Straight flush: within each suit, find runs of ≥5 consecutive ranks.
+  const bySuit = new Map<string, { rank: number; idx: number }[]>();
+  cards.forEach((c, i) => {
+    if (!STANDARD_SUITS.has(c.design)) return;
+    const arr = bySuit.get(c.design) ?? [];
+    arr.push({ rank: tichuRank(c), idx: i });
+    bySuit.set(c.design, arr);
+  });
+  for (const arr of bySuit.values()) {
+    arr.sort((a, b) => a.rank - b.rank);
+    let run: { rank: number; idx: number }[] = [];
+    const flush = () => {
+      if (run.length >= STRAIGHT_FLUSH_MIN) for (const r of run) bomb.add(r.idx);
+    };
+    for (const entry of arr) {
+      if (run.length === 0 || entry.rank === run[run.length - 1].rank + 1) {
+        run.push(entry);
+      } else {
+        flush();
+        run = [entry];
+      }
+    }
+    flush();
+  }
+
+  return bomb;
+}


### PR DESCRIPTION
## 背景
`TichuPage` の play フェーズ手札は、どのカードがボム（任意のコンビを破壊できる最強カード）を構成するか視覚的区別が一切なく、`aria-label` も `cardAlt` のみでした。

## 変更
- 新ユーティリティ `tichuBombIndices` を追加：手札からボム構成カードのインデックスを算出。
  - **4枚同ランク**（フォーオブアカインド）／**同スート5枚以上の連続**（ストレートフラッシュ）。
  - エースは高（rank 14、A-2-3-4-5 wrap なし）、特殊カード（JOKER design）は除外 — ドメインの `tichuTryBomb4`/`tichuTryStraightFlush` に準拠。
- 該当カードに `ring-ds-error` 枠 + 💣 バッジを表示し、`aria-label` を `bombCardAriaLabel`（「{{card}}（ボム構成カード）」）に切替。
- `bombCardAriaLabel` を ja/en に追加。**バックエンド変更なし**（クライアント側で判定）。

## テスト
- util: 4カード/ストレートフラッシュ/エース高/4枚連続は非ボム/特殊除外/ボム無し（6 ケース）。
- page: 4枚同ランクのバッジ＋ aria-label、非ボムカードは非バッジ（11 passed）。`bun run check` OK。

Closes #2657