### PR TITLE
feat(bristol): give tableau columns contextual labels (web + CUI)

### DIFF
--- a/frontend/src/i18n/locales/en/bristol.json
+++ b/frontend/src/i18n/locales/en/bristol.json
@@ -7,6 +7,8 @@
   "title": "Bristol",
   "stock": "Stock",
   "tableau": "Tableau",
+  "tableauColAria": "Build-down column {{num}} ({{count}} cards)",
+  "tableauRule": "Tableau: {{count}} build-down columns (any suit)",
   "fan": "Fan",
   "foundation": "Foundation",
   "moveCount": "Moves",

--- a/frontend/src/i18n/locales/ja/bristol.json
+++ b/frontend/src/i18n/locales/ja/bristol.json
@@ -7,6 +7,8 @@
   "title": "ブリストル",
   "stock": "山札",
   "tableau": "場札",
+  "tableauColAria": "降順ビルド列 {{num}}（{{count}}枚）",
+  "tableauRule": "場札: {{count}}列の降順ビルド（スート不問）",
   "fan": "ファン",
   "foundation": "組札",
   "moveCount": "手数",

--- a/frontend/src/pages/BristolPage.test.tsx
+++ b/frontend/src/pages/BristolPage.test.tsx
@@ -65,6 +65,15 @@ describe('BristolPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
+  it('gives tableau columns a contextual aria-label (1-based number, role, depth) and a rule header', async () => {
+    renderWithProviders(<BristolPage />);
+    // Column 1 (0-based idx 0) holds 1 card → "降順ビルド列 1（1枚）".
+    await waitFor(() => expect(screen.getByRole('button', { name: '降順ビルド列 1（1枚）' })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: '降順ビルド列 8（1枚）' })).toBeInTheDocument();
+    // The tableau header conveys the build-down rule with the actual column count (8).
+    expect(screen.getByTestId('br-tableau-rule')).toHaveTextContent('8列の降順ビルド');
+  });
+
   it('shows a stacked-count badge on fans with 2+ cards and hides it otherwise', async () => {
     mockExec.mockResolvedValue({
       ...playingState,
@@ -95,11 +104,13 @@ describe('BristolPage', () => {
   it('selects a tableau column then moves it to another tableau column', async () => {
     renderWithProviders(<BristolPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    screen.getByRole('button', { name: '場札 0' }).click();
+    screen.getByRole('button', { name: /降順ビルド列 1/ }).click();
     // Wait for the source selection to render before clicking the destination,
     // so the destination handler reads the updated `selected` state.
-    await waitFor(() => expect(screen.getByRole('button', { name: '場札 0' })).toHaveAttribute('aria-pressed', 'true'));
-    screen.getByRole('button', { name: '場札 1' }).click();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /降順ビルド列 1/ })).toHaveAttribute('aria-pressed', 'true'),
+    );
+    screen.getByRole('button', { name: /降順ビルド列 2/ }).click();
     await waitFor(() =>
       expect(mockExec).toHaveBeenCalledWith('move', { zone: 'tableau', col: 0 }, { zone: 'tableau', col: 1 }),
     );
@@ -108,7 +119,7 @@ describe('BristolPage', () => {
   it('selects a tableau column then moves it to a foundation', async () => {
     renderWithProviders(<BristolPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
-    screen.getByRole('button', { name: '場札 0' }).click();
+    screen.getByRole('button', { name: /降順ビルド列 1/ }).click();
     await waitFor(() => expect(screen.getByRole('button', { name: '組札 0' })).toBeEnabled());
     screen.getByRole('button', { name: '組札 0' }).click();
     await waitFor(() =>

--- a/frontend/src/pages/BristolPage.tsx
+++ b/frontend/src/pages/BristolPage.tsx
@@ -250,18 +250,21 @@ function BristolPageContent() {
             </div>
 
             {/* Tableau */}
+            <div className="mb-0.5 text-center text-xs text-ds-text-muted" data-testid="br-tableau-rule">
+              {t('tableauRule', { count: state.tableau.length })}
+            </div>
             <div className="mb-3 flex gap-1 sm:gap-2" data-tutorial="br-tableau">
               {state.tableau.map((col, colIdx) => {
                 const zone: BristolMoveZone = { zone: 'tableau', col: colIdx };
                 const colHeight = col.length > 0 ? (col.length - 1) * colOffset + cardHeight : cardHeight;
                 return (
                   <div key={`col-${colIdx}`} className="flex flex-1 flex-col items-center gap-1 min-w-0">
-                    <span className="text-xs text-ds-text-muted">#{colIdx}</span>
+                    <span className="text-xs text-ds-text-muted">#{colIdx + 1}</span>
                     <button
                       type="button"
                       onClick={() => handleTableauClick(colIdx)}
                       disabled={!isPlaying || loading || (col.length === 0 && !selected)}
-                      aria-label={`${t('tableau')} ${colIdx}`}
+                      aria-label={t('tableauColAria', { num: colIdx + 1, count: col.length })}
                       aria-pressed={isSelected(zone)}
                       className={
                         isSelected(zone)

--- a/internal/adapter/presenter/BristolCuiPresenter.go
+++ b/internal/adapter/presenter/BristolCuiPresenter.go
@@ -34,6 +34,7 @@ func (p *BristolCuiPresenter) Output(b interfaces.BristolGame, lastErr error) st
 		sb.WriteString("----------\n")
 
 		// Tableau columns
+		sb.WriteString(i18n.Tf("bristol.tableauRule", "count", strconv.Itoa(domain.BristolTableauCnt)) + "\n")
 		tableau := b.GetTableau()
 		for i := range domain.BristolTableauCnt {
 			sb.WriteString(i18n.Tf("bristol.tableauLabel", "idx", strconv.Itoa(i)))

--- a/internal/adapter/presenter/BristolCuiPresenter_test.go
+++ b/internal/adapter/presenter/BristolCuiPresenter_test.go
@@ -44,6 +44,7 @@ func TestBristolCuiPresenter_Output(t *testing.T) {
 		result := p.Output(bg, nil)
 		assert.Contains(t, result, "Bristol")
 		assert.Contains(t, result, "組札0:")
+		assert.Contains(t, result, "降順ビルド") // tableau build-down rule line
 		assert.Contains(t, result, "タブロー0列:")
 		assert.Contains(t, result, "ファン0:")
 		assert.Contains(t, result, "ストック: 28枚")

--- a/internal/i18n/locales/en/bristol.json
+++ b/internal/i18n/locales/en/bristol.json
@@ -21,6 +21,7 @@
   "hintAvailable": "Hint available",
   "noHint": "No hint",
   "foundationLabel": "Foundation {{idx}}:",
+  "tableauRule": "Tableau: {{count}} build-down columns (any suit)",
   "tableauLabel": "Tableau {{idx}}:",
   "fanLabel": "Fan {{idx}}:",
   "pileCount": " ({{count}})",

--- a/internal/i18n/locales/ja/bristol.json
+++ b/internal/i18n/locales/ja/bristol.json
@@ -21,6 +21,7 @@
   "hintAvailable": "ヒントがあります",
   "noHint": "ヒントはありません",
   "foundationLabel": "組札{{idx}}:",
+  "tableauRule": "場札: {{count}}列の降順ビルド（スート不問）",
   "tableauLabel": "タブロー{{idx}}列:",
   "fanLabel": "ファン{{idx}}:",
   "pileCount": " ({{count}}枚)",


### PR DESCRIPTION
## 背景
タブロー列は `#{colIdx}`（0始まり）と `aria-label` `タブロー 0` 止まりで、Bristol が降順ビルド列であるルール文脈を伝えていませんでした。CUI も列インデックスのみ。

## 変更（cross-stack）
**Web (`BristolPage.tsx`)**
- 列ボタンの `aria-label` を `tableauColAria`（「降順ビルド列 {{num}}（{{count}}枚）」, 1始まり番号＋役割＋深さ）に。
- タブロー上部に `tableauRule`（「場札: {{count}}列の降順ビルド（スート不問）」）ヘッダを追加（`br-tableau-rule`）。
- 視覚の列番号も 1 始まりに統一。

**CUI (`BristolCuiPresenter.go`)**
- タブロー列の前に `bristol.tableauRule` の1行説明を出力。

**i18n**: web ja/en + CUI ja/en に `tableauRule`（＋web `tableauColAria`）を追加。

NOTE: 列数は実装上 **8列**（チュートリアル準拠）のため、issue 記載の「7列」ではなく `BristolTableauCnt`／`state.tableau.length` から動的に表示。

## テスト
- Web: aria-label（1始まり番号・枚数）＋ルールヘッダ（8列）を検証。既存の列選択テストは新ラベルへ更新（18 passed）。
- CUI: 降順ビルド行の出力を検証（Go presenter test, ok）。
- `golangci-lint` 0 issues、`bun run check` OK。

Closes #2653