### PR TITLE
feat(marias): surface available marriages during play (web + CUI)

### DIFF
--- a/frontend/src/i18n/locales/en/marias.json
+++ b/frontend/src/i18n/locales/en/marias.json
@@ -16,6 +16,7 @@
   "round": "Round {{n}}",
   "trick": "Trick {{n}}",
   "trump": "Trump: {{suit}}",
+  "marriageAvailable": "Marriage available: {{list}}",
   "cards": "{{count}} cards",
   "tricks": "{{count}} tricks",
   "currentTrick": "Current Trick",

--- a/frontend/src/i18n/locales/ja/marias.json
+++ b/frontend/src/i18n/locales/ja/marias.json
@@ -16,6 +16,7 @@
   "round": "ラウンド {{n}}",
   "trick": "トリック {{n}}",
   "trump": "切り札: {{suit}}",
+  "marriageAvailable": "マリッジ可能: {{list}}",
   "cards": "{{count}}枚",
   "tricks": "{{count}}トリック",
   "currentTrick": "現在のトリック",

--- a/frontend/src/pages/MariasPage.test.tsx
+++ b/frontend/src/pages/MariasPage.test.tsx
@@ -64,6 +64,46 @@ describe('MariasPage', () => {
     expect(screen.getByText('ソリスト')).toBeInTheDocument();
   });
 
+  it('shows a marriage banner during play (trump-suit K-Q scores +40)', async () => {
+    // Default hand: ♥K + ♥Q with trump ♥ → a +40 marriage.
+    renderWithProviders(<MariasPage />);
+    const banner = await screen.findByTestId('marias-marriage');
+    expect(banner).toHaveTextContent('マリッジ可能');
+    expect(banner).toHaveTextContent('♥ K-Q (+40)');
+  });
+
+  it('labels a non-trump marriage as +20', async () => {
+    mockExec.mockResolvedValue(makeMariasState({ trumpSuit: 1 })); // trump ♠, ♥ K-Q now +20
+    renderWithProviders(<MariasPage />);
+    await waitFor(() => expect(screen.getByTestId('marias-marriage')).toHaveTextContent('♥ K-Q (+20)'));
+  });
+
+  it('shows no marriage banner when the hand has no K-Q pair', async () => {
+    mockExec.mockResolvedValue(
+      makeMariasState({
+        players: [
+          {
+            id: 0,
+            isHuman: true,
+            cardCount: 2,
+            cards: [
+              { design: 'HEART', value: 13 },
+              { design: 'SPADE', value: 12 },
+            ],
+            trickCount: 0,
+            score: 0,
+            isSoloist: true,
+          },
+          { id: 1, isHuman: false, cardCount: 10, cards: [], trickCount: 0, score: 0, isSoloist: false },
+          { id: 2, isHuman: false, cardCount: 10, cards: [], trickCount: 0, score: 0, isSoloist: false },
+        ],
+      }),
+    );
+    renderWithProviders(<MariasPage />);
+    await waitFor(() => expect(screen.getByAltText('♥ K')).toBeInTheDocument());
+    expect(screen.queryByTestId('marias-marriage')).not.toBeInTheDocument();
+  });
+
   it('selecting a card then playing dispatches play', async () => {
     renderWithProviders(<MariasPage />);
     const card = await screen.findByAltText('♥ Q');

--- a/frontend/src/pages/MariasPage.tsx
+++ b/frontend/src/pages/MariasPage.tsx
@@ -35,6 +35,9 @@ import { playerName } from '../utils/playerUtils';
 /** Suit symbols indexed by suit number (1=♠ 2=♣ 3=♥ 4=♦; index 0 unused). */
 const SUIT_SYMBOLS = ['', '♠', '♣', '♥', '♦'] as const;
 
+/** Card design string → suit number (1=♠ 2=♣ 3=♥ 4=♦), to align with SUIT_SYMBOLS / trumpSuit. */
+const DESIGN_TO_SUIT: Readonly<Record<string, number>> = { SPADE: 1, CLOVER: 2, HEART: 3, DIAMOND: 4 };
+
 /** Mariáš tutorial step definitions. */
 const MARIAS_TUTORIAL_STEPS: TutorialStep[] = [
   {
@@ -135,6 +138,20 @@ function MariasPageContent() {
 
   const canPlay = isPlayPhase && isHumanTurn;
   const trumpSymbol = SUIT_SYMBOLS[state.trumpSuit] ?? '?';
+
+  // Suits where the human holds both K (13) and Q (12) — a marriage worth 40 in
+  // the trump suit, otherwise 20. Surfaced as a banner during play so the bonus
+  // (otherwise only shown at round end) is visible while it can still be earned.
+  const marriages = isPlayPhase
+    ? [1, 2, 3, 4]
+        .filter((suit) => {
+          const cards = humanPlayer?.cards ?? [];
+          const hasK = cards.some((c) => DESIGN_TO_SUIT[c.design] === suit && c.value === 13);
+          const hasQ = cards.some((c) => DESIGN_TO_SUIT[c.design] === suit && c.value === 12);
+          return hasK && hasQ;
+        })
+        .map((suit) => ({ symbol: SUIT_SYMBOLS[suit] ?? '?', points: suit === state.trumpSuit ? 40 : 20 }))
+    : [];
 
   const handleManualReset = () => {
     hideActionLog();
@@ -302,6 +319,13 @@ function MariasPageContent() {
 
           {/* Footer */}
           <GameFooter className={`${gameTheme.marias.footer} px-4 py-2.5`}>
+            {marriages.length > 0 && (
+              <div className="mb-1 text-center text-sm text-ds-accent font-semibold" data-testid="marias-marriage">
+                {t('marriageAvailable', {
+                  list: marriages.map((m) => `${m.symbol} K-Q (+${m.points})`).join('  '),
+                })}
+              </div>
+            )}
             {humanPlayer && (
               <PlayerHandSection
                 humanPlayer={humanPlayer}

--- a/internal/adapter/presenter/MariasCuiPresenter.go
+++ b/internal/adapter/presenter/MariasCuiPresenter.go
@@ -89,6 +89,7 @@ func (p *MariasCuiPresenter) Output(g interfaces.MariasGame, lastErr error) stri
 			b.WriteString(i18n.Tf("marias.promptPlay",
 				"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
 			b.WriteString(i18n.T("marias.promptPlayHelp") + "\n")
+			b.WriteString(i18n.T("marias.promptMarriageHelp") + "\n")
 		case domain.MariasPhaseTrickEnd:
 			b.WriteString(i18n.T("marias.promptTrickEnd") + "\n")
 			b.WriteString(i18n.T("marias.promptTrickEndHelp") + "\n")

--- a/internal/adapter/presenter/MariasCuiPresenter_test.go
+++ b/internal/adapter/presenter/MariasCuiPresenter_test.go
@@ -60,6 +60,7 @@ func TestMariasCuiPresenter_Output(t *testing.T) {
 		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 13, false))
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "Mariáš")
+		assert.Contains(t, result, "マリッジ") // play-phase help explains the marriage bonus
 		assert.NotEmpty(t, result)
 	})
 

--- a/internal/i18n/locales/en/marias.json
+++ b/internal/i18n/locales/en/marias.json
@@ -11,6 +11,7 @@
   "gameEnd": "Game over! {{name}} wins the match!",
   "promptPlay": "Turn: {{name}}",
   "promptPlayHelp": "play <idx> ... play a card (A>10>K>Q>J>9>8>7; must follow suit, then must trump if void)",
+  "promptMarriageHelp": "Marriage: leading the K or Q from a same-suit K+Q in hand scores +20 (+40 in the trump suit)",
   "promptTrickEnd": "Trick complete",
   "promptTrickEndHelp": "n / next ... go to the next trick",
   "promptRoundEnd": "Round complete (Soloist {{soloist}}: {{pts}} card pts)",

--- a/internal/i18n/locales/ja/marias.json
+++ b/internal/i18n/locales/ja/marias.json
@@ -11,6 +11,7 @@
   "gameEnd": "ゲーム終了！{{name}}がマッチ勝利！",
   "promptPlay": "手番: {{name}}",
   "promptPlayHelp": "play <idx>・・・カードを出す（強さ A>10>K>Q>J>9>8>7／マストフォロー、ボイド時は切り札強制）",
+  "promptMarriageHelp": "マリッジ: 同スートの K と Q を持つ手札からどちらかをリードすると +20（切り札スートは +40）",
   "promptTrickEnd": "トリック終了",
   "promptTrickEndHelp": "n / next・・・次のトリックへ",
   "promptRoundEnd": "ラウンド終了（ソリスト {{soloist}}: {{pts}}点）",


### PR DESCRIPTION
## 背景
マリッジ（同スートの K・Q、切り札スートは +40 / それ以外 +20）はラウンド終了サイドバーでしか可視化されず、PLAY 中に成立可能なことの手掛かりがありませんでした。CUI の play ヘルプにも説明がありませんでした。

## 変更（cross-stack）
**Web (`MariasPage.tsx`)**: 人間の手札から「K と Q を両方持つスート」をクライアント側で検出し、PLAY フェーズ中に手札上部へバナー表示（`マリッジ可能: ♥ K-Q (+40)` 等、切り札は +40・他は +20）。`marias-marriage` testid。
**CUI (`MariasCuiPresenter.go`)**: play フェーズの help にマリッジ説明行（`promptMarriageHelp`）を追加。
**i18n**: web ja/en に `marriageAvailable`、CUI ja/en に `promptMarriageHelp`。

## テスト
- Web: 切り札マリッジ(+40)・非切り札(+20)・K-Q 無しでバナー非表示（11 passed）。
- CUI: play 出力にマリッジ説明が出ることを検証（Go presenter test ok）。
- `golangci-lint` 0 issues、`bun run check` OK。

Closes #2669