### PR TITLE
feat(sueca): show trump in the sidebar and announce the trick winner

### DIFF
--- a/frontend/src/i18n/locales/en/sueca.json
+++ b/frontend/src/i18n/locales/en/sueca.json
@@ -23,6 +23,7 @@
   "you": "You",
   "cpu": "CPU {{id}}",
   "yourTeam": "Your team",
+  "trickWinner": "{{team}} won the trick",
   "team": {
     "a": "Team A",
     "b": "Team B"

--- a/frontend/src/i18n/locales/ja/sueca.json
+++ b/frontend/src/i18n/locales/ja/sueca.json
@@ -23,6 +23,7 @@
   "you": "あなた",
   "cpu": "CPU {{id}}",
   "yourTeam": "あなたのチーム",
+  "trickWinner": "{{team}} がトリック獲得",
   "team": {
     "a": "チームA",
     "b": "チームB"

--- a/frontend/src/pages/SuecaPage.test.tsx
+++ b/frontend/src/pages/SuecaPage.test.tsx
@@ -75,6 +75,23 @@ describe('SuecaPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: '次のトリック' })).toBeInTheDocument());
   });
 
+  it('shows the trump suit in the always-visible sidebar', async () => {
+    renderWithProviders(<SuecaPage />); // default trump ♦
+    await waitFor(() => expect(screen.getByTestId('sueca-sidebar-trump')).toHaveTextContent('切り札: ♦'));
+  });
+
+  it('announces the trick-winning team at trick end (leadPlayerIdx → team)', async () => {
+    mockExec.mockResolvedValue(trickEndState); // leadPlayerIdx 0 → Team A
+    renderWithProviders(<SuecaPage />);
+    await waitFor(() => expect(screen.getByTestId('sueca-trick-winner')).toHaveTextContent('チームA がトリック獲得'));
+  });
+
+  it('names Team B when an odd seat wins the trick', async () => {
+    mockExec.mockResolvedValue(makeSuecaState({ phase: 1, leadPlayerIdx: 1 }));
+    renderWithProviders(<SuecaPage />);
+    await waitFor(() => expect(screen.getByTestId('sueca-trick-winner')).toHaveTextContent('チームB がトリック獲得'));
+  });
+
   it('renders round end with the next round button and the round result', async () => {
     mockExec.mockResolvedValue(roundEndState);
     renderWithProviders(<SuecaPage />);

--- a/frontend/src/pages/SuecaPage.tsx
+++ b/frontend/src/pages/SuecaPage.tsx
@@ -221,12 +221,10 @@ function SuecaPageContent() {
                 {/* Team game points */}
                 <div className="mb-2 p-2 rounded bg-black/30 text-ds-text-muted text-sm">
                   {/* Trump kept in the always-visible sidebar so it isn't lost off-screen on mobile. */}
-                  <div className="text-ds-text-primary font-semibold" data-testid="sueca-sidebar-trump">
+                  <div className="mb-1 text-ds-text-primary font-semibold" data-testid="sueca-sidebar-trump">
                     {t('trump', { suit: trumpSymbol })}
                   </div>
-                  <div className="mt-1">
-                    {t('teamScore', { team: t('team.a'), score: state.teamGamePoints[0] ?? 0 })}
-                  </div>
+                  <div>{t('teamScore', { team: t('team.a'), score: state.teamGamePoints[0] ?? 0 })}</div>
                   <div>{t('teamScore', { team: t('team.b'), score: state.teamGamePoints[1] ?? 0 })}</div>
                   <div className="mt-1">
                     {t('yourTeam')}: {humanTeam === 0 ? t('team.a') : t('team.b')}

--- a/frontend/src/pages/SuecaPage.tsx
+++ b/frontend/src/pages/SuecaPage.tsx
@@ -220,7 +220,14 @@ function SuecaPageContent() {
               <div data-tutorial="sueca-info">
                 {/* Team game points */}
                 <div className="mb-2 p-2 rounded bg-black/30 text-ds-text-muted text-sm">
-                  <div>{t('teamScore', { team: t('team.a'), score: state.teamGamePoints[0] ?? 0 })}</div>
+                  {/* Trump is the key trick-taking signal; keep it in the always-visible sidebar
+                      so it isn't lost off-screen in the header on mobile. */}
+                  <div className="text-ds-text-primary font-semibold" data-testid="sueca-sidebar-trump">
+                    {t('trump', { suit: trumpSymbol })}
+                  </div>
+                  <div className="mt-1">
+                    {t('teamScore', { team: t('team.a'), score: state.teamGamePoints[0] ?? 0 })}
+                  </div>
                   <div>{t('teamScore', { team: t('team.b'), score: state.teamGamePoints[1] ?? 0 })}</div>
                   <div className="mt-1">
                     {t('yourTeam')}: {humanTeam === 0 ? t('team.a') : t('team.b')}
@@ -261,6 +268,19 @@ function SuecaPageContent() {
                 )}
               </div>
             </div>
+
+            {/* Trick-winner feedback: at TrickEnd the domain sets leadPlayerIdx to the
+                trick winner, so their team is shown immediately (before Next Trick). */}
+            {isTrickEnd && (
+              <div
+                className="my-2 p-2 rounded bg-ds-accent/15 text-center text-sm font-semibold text-ds-accent"
+                role="status"
+                aria-live="polite"
+                data-testid="sueca-trick-winner"
+              >
+                {t('trickWinner', { team: state.leadPlayerIdx % 2 === 0 ? t('team.a') : t('team.b') })}
+              </div>
+            )}
 
             {/* Message */}
             <GameMessageBox

--- a/frontend/src/pages/SuecaPage.tsx
+++ b/frontend/src/pages/SuecaPage.tsx
@@ -220,8 +220,7 @@ function SuecaPageContent() {
               <div data-tutorial="sueca-info">
                 {/* Team game points */}
                 <div className="mb-2 p-2 rounded bg-black/30 text-ds-text-muted text-sm">
-                  {/* Trump is the key trick-taking signal; keep it in the always-visible sidebar
-                      so it isn't lost off-screen in the header on mobile. */}
+                  {/* Trump kept in the always-visible sidebar so it isn't lost off-screen on mobile. */}
                   <div className="text-ds-text-primary font-semibold" data-testid="sueca-sidebar-trump">
                     {t('trump', { suit: trumpSymbol })}
                   </div>
@@ -269,8 +268,7 @@ function SuecaPageContent() {
               </div>
             </div>
 
-            {/* Trick-winner feedback: at TrickEnd the domain sets leadPlayerIdx to the
-                trick winner, so their team is shown immediately (before Next Trick). */}
+            {/* At TrickEnd leadPlayerIdx is the trick winner, so their team shows before Next Trick. */}
             {isTrickEnd && (
               <div
                 className="my-2 p-2 rounded bg-ds-accent/15 text-center text-sm font-semibold text-ds-accent"


### PR DESCRIPTION
## 背景
切り札スートはページヘッダーにしか出ず、カードを選ぶたびに見上げる必要があり（モバイルでは画面外になり得る）、トリック獲得時の即時フィードバック（どちらのチームが勝ったか）も Next Trick を押すまで分かりませんでした。

## 変更（frontend-only）
- 情報サイドバーに**常時表示の切り札スート**を追加（`sueca-sidebar-trump`）。
- TRICK_END 時、トリック勝者チームを示すバナーを `GameMessageBox` 付近へ自動表示（`sueca-trick-winner`, `role=status aria-live=polite`）。勝者はドメインが TrickEnd 時に勝者へ更新する `leadPlayerIdx`（team = idx % 2）から導出 — **バックエンド変更なし**。
- `trickWinner` キーを ja/en に追加。

## テスト
- サイドバー切り札（♦）表示、TRICK_END で チームA（leadPlayerIdx 0）/ チームB（leadPlayerIdx 1）の勝者バナーを検証（11 passed）。`bun run check` OK。

Closes #2664