### PR TITLE
feat(belote): visual + sound feedback on belote/rebelote confirmation

### DIFF
--- a/frontend/src/i18n/locales/en/belote.json
+++ b/frontend/src/i18n/locales/en/belote.json
@@ -37,7 +37,8 @@
     "dixDeDer": "Last trick +10",
     "beloteKing": "Trump K",
     "beloteQueen": "Trump Q",
-    "beloteBonus": "+20"
+    "beloteBonus": "+20",
+    "beloteConfirmed": "Belote/Rebelote confirmed! +20"
   },
   "orderUpButton": "Take",
   "passButton": "Pass",

--- a/frontend/src/i18n/locales/ja/belote.json
+++ b/frontend/src/i18n/locales/ja/belote.json
@@ -37,7 +37,8 @@
     "dixDeDer": "最終トリック +10",
     "beloteKing": "切り札 K",
     "beloteQueen": "切り札 Q",
-    "beloteBonus": "+20"
+    "beloteBonus": "+20",
+    "beloteConfirmed": "ベロート・ルベロート確定！ +20"
   },
   "orderUpButton": "取る",
   "passButton": "パス",

--- a/frontend/src/i18n/locales/ja/belote.json
+++ b/frontend/src/i18n/locales/ja/belote.json
@@ -38,7 +38,7 @@
     "beloteKing": "切り札 K",
     "beloteQueen": "切り札 Q",
     "beloteBonus": "+20",
-    "beloteConfirmed": "ベロート・ルベロート確定！ +20"
+    "beloteConfirmed": "ベロート・レベロート確定！ +20"
   },
   "orderUpButton": "取る",
   "passButton": "パス",

--- a/frontend/src/pages/BelotePage.test.tsx
+++ b/frontend/src/pages/BelotePage.test.tsx
@@ -11,6 +11,14 @@ vi.mock('../api/gameApi', () => ({
   actionLogApi: { belote: vi.fn() },
 }));
 
+const mockPlaySound = vi.fn();
+const mockSoundValue = { playSound: mockPlaySound, muted: false, toggleMute: vi.fn() };
+vi.mock('../providers/SoundProvider', () => ({
+  SoundProvider: ({ children }: { children: React.ReactNode }) => children,
+  useSound: () => mockSoundValue,
+  useOptionalSound: () => mockSoundValue,
+}));
+
 const mockExec = vi.mocked(beloteApi.exec);
 
 const card = (design: string, value: number): Card => ({ design, value }) as unknown as Card;
@@ -67,6 +75,8 @@ const gameEndState = makeState({
 });
 
 beforeEach(() => {
+  mockExec.mockReset();
+  mockPlaySound.mockClear();
   mockExec.mockResolvedValue(initialState);
 });
 
@@ -160,6 +170,55 @@ describe('BelotePage', () => {
     );
     renderWithProviders(<BelotePage />);
     await waitFor(() => expect(screen.getByTestId('belote-rebelote-badge')).toHaveAttribute('data-active', 'true'));
+  });
+
+  it('chimes and shows a confirmation banner when the belote bonus is freshly earned', async () => {
+    mockExec.mockResolvedValue(
+      makeState({ phase: BelotePhase.PLAY, trumpSuit: 1, trickNumber: 3, currentPlayerIdx: 0, makerTeam: 0 }),
+    );
+    renderWithProviders(<BelotePage />);
+    const cardBtn = await screen.findByRole('button', { name: '♠ J' });
+    fireEvent.click(cardBtn);
+    // The play that lands the K+Q-of-trump bonus.
+    mockExec.mockResolvedValueOnce(
+      makeState({
+        phase: BelotePhase.PLAY,
+        trumpSuit: 1,
+        trickNumber: 3,
+        currentPlayerIdx: 1,
+        makerTeam: 0,
+        roundBeloteBonus: [20, 0],
+      }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: '出す' }));
+    await waitFor(() => expect(screen.getByTestId('belote-bonus-confirmed')).toBeInTheDocument());
+    expect(mockPlaySound).toHaveBeenCalledWith('winFanfare');
+  });
+
+  it('does not chime on a plain play that earns no new bonus', async () => {
+    mockExec.mockResolvedValue(
+      makeState({ phase: BelotePhase.PLAY, trumpSuit: 1, trickNumber: 3, currentPlayerIdx: 0, makerTeam: 0 }),
+    );
+    renderWithProviders(<BelotePage />);
+    const cardBtn = await screen.findByRole('button', { name: '♠ J' });
+    fireEvent.click(cardBtn);
+    mockExec.mockResolvedValueOnce(
+      makeState({ phase: BelotePhase.PLAY, trumpSuit: 1, trickNumber: 4, currentPlayerIdx: 1, makerTeam: 0 }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: '出す' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', undefined, 0));
+    expect(mockPlaySound).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('belote-bonus-confirmed')).not.toBeInTheDocument();
+  });
+
+  it('does not chime when loaded into a round that already has the bonus', async () => {
+    mockExec.mockResolvedValue(
+      makeState({ phase: BelotePhase.PLAY, trumpSuit: 1, trickNumber: 5, makerTeam: 0, roundBeloteBonus: [20, 0] }),
+    );
+    renderWithProviders(<BelotePage />);
+    await waitFor(() => expect(screen.getByTestId('belote-rebelote-badge')).toHaveAttribute('data-active', 'true'));
+    expect(mockPlaySound).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('belote-bonus-confirmed')).not.toBeInTheDocument();
   });
 
   it('shows 次のゲーム at game end with no confirm', async () => {

--- a/frontend/src/pages/BelotePage.test.tsx
+++ b/frontend/src/pages/BelotePage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { beloteApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -195,6 +195,36 @@ describe('BelotePage', () => {
     expect(mockPlaySound).toHaveBeenCalledWith('winFanfare');
   });
 
+  it('auto-hides the confirmation banner after the display window closes', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      mockExec.mockResolvedValue(
+        makeState({ phase: BelotePhase.PLAY, trumpSuit: 1, trickNumber: 3, currentPlayerIdx: 0, makerTeam: 0 }),
+      );
+      renderWithProviders(<BelotePage />);
+      const cardBtn = await screen.findByRole('button', { name: '♠ J' });
+      fireEvent.click(cardBtn);
+      mockExec.mockResolvedValueOnce(
+        makeState({
+          phase: BelotePhase.PLAY,
+          trumpSuit: 1,
+          trickNumber: 3,
+          currentPlayerIdx: 1,
+          makerTeam: 0,
+          roundBeloteBonus: [20, 0],
+        }),
+      );
+      fireEvent.click(screen.getByRole('button', { name: '出す' }));
+      await waitFor(() => expect(screen.getByTestId('belote-bonus-confirmed')).toBeInTheDocument());
+      await act(async () => {
+        vi.advanceTimersByTime(2600);
+      });
+      await waitFor(() => expect(screen.queryByTestId('belote-bonus-confirmed')).not.toBeInTheDocument());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not chime on a plain play that earns no new bonus', async () => {
     mockExec.mockResolvedValue(
       makeState({ phase: BelotePhase.PLAY, trumpSuit: 1, trickNumber: 3, currentPlayerIdx: 0, makerTeam: 0 }),
@@ -207,8 +237,8 @@ describe('BelotePage', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: '出す' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', undefined, 0));
+    await waitFor(() => expect(screen.queryByTestId('belote-bonus-confirmed')).not.toBeInTheDocument());
     expect(mockPlaySound).not.toHaveBeenCalled();
-    expect(screen.queryByTestId('belote-bonus-confirmed')).not.toBeInTheDocument();
   });
 
   it('does not chime when loaded into a round that already has the bonus', async () => {

--- a/frontend/src/pages/BelotePage.tsx
+++ b/frontend/src/pages/BelotePage.tsx
@@ -133,12 +133,16 @@ function BelotePageContent() {
     if (beloteTotal > prevBeloteTotalRef.current) {
       setBeloteJustConfirmed(true);
       playSound('winFanfare');
-      prevBeloteTotalRef.current = beloteTotal;
-      const id = setTimeout(() => setBeloteJustConfirmed(false), 2500);
-      return () => clearTimeout(id);
     }
     prevBeloteTotalRef.current = beloteTotal;
   }, [beloteTotal, playSound, state]);
+
+  // Clear timer keyed only on the flag so an unrelated state update mid-window can't cancel it.
+  useEffect(() => {
+    if (!beloteJustConfirmed) return;
+    const id = setTimeout(() => setBeloteJustConfirmed(false), 2500);
+    return () => clearTimeout(id);
+  }, [beloteJustConfirmed]);
 
   const handleManualReset = useCallback(() => {
     hideActionLog();

--- a/frontend/src/pages/BelotePage.tsx
+++ b/frontend/src/pages/BelotePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
@@ -18,6 +18,7 @@ import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -118,6 +119,26 @@ function BelotePageContent() {
   const { cardWidth, isMobile } = useCardDimensions();
 
   const phaseNames = usePhaseNames('belote', BELOTE_PHASE_KEYS);
+
+  const { playSound } = useSound();
+  const beloteTotal = state ? state.roundBeloteBonus[0] + state.roundBeloteBonus[1] : 0;
+  const prevBeloteTotalRef = useRef<number | null>(null);
+  const [beloteJustConfirmed, setBeloteJustConfirmed] = useState(false);
+  useEffect(() => {
+    if (!state) return;
+    if (prevBeloteTotalRef.current === null) {
+      prevBeloteTotalRef.current = beloteTotal;
+      return;
+    }
+    if (beloteTotal > prevBeloteTotalRef.current) {
+      setBeloteJustConfirmed(true);
+      playSound('winFanfare');
+      prevBeloteTotalRef.current = beloteTotal;
+      const id = setTimeout(() => setBeloteJustConfirmed(false), 2500);
+      return () => clearTimeout(id);
+    }
+    prevBeloteTotalRef.current = beloteTotal;
+  }, [beloteTotal, playSound, state]);
 
   const handleManualReset = useCallback(() => {
     hideActionLog();
@@ -248,11 +269,11 @@ function BelotePageContent() {
                   <span
                     data-testid="belote-rebelote-badge"
                     data-active={hasBeloteBonus ? 'true' : undefined}
-                    className={
+                    className={`${
                       hasBeloteBonus
                         ? 'px-2 py-0.5 rounded-full font-medium border bg-ds-success text-ds-text-on-accent border-ds-success'
                         : 'px-2 py-0.5 rounded-full font-medium border bg-ds-surface text-ds-text-muted border-ds-border'
-                    }
+                    }${beloteJustConfirmed ? ' ring-2 ring-ds-success motion-safe:animate-pulse' : ''}`}
                   >
                     {t('tracker.beloteKing')} · {t('tracker.beloteQueen')}
                     {hasBeloteBonus ? ` ${t('tracker.beloteBonus')}` : ''}
@@ -261,6 +282,17 @@ function BelotePageContent() {
               </div>
             );
           })()}
+
+        {beloteJustConfirmed && (
+          <div
+            role="status"
+            aria-live="polite"
+            data-testid="belote-bonus-confirmed"
+            className="text-center mb-2 text-sm font-semibold text-ds-success motion-safe:animate-pulse"
+          >
+            {t('tracker.beloteConfirmed')}
+          </div>
+        )}
 
         {/* Face-up card (during bidding) */}
         {state.faceUpCard && (isBidPickUp || isBidCallTrump) && (


### PR DESCRIPTION
## 概要
Belote/Rebelote ボーナス（切り札 K+Q プレイで +20）が確定した瞬間に、視覚・音のフィードバックを追加します（#2620）。

これまで BelotePage は `roundBeloteBonus` をチェックしてバッジを点灯するだけで、いつ確定したかが曖昧でした。

## 変更点（BelotePage のみ — 共有 TrickDisplay は触れていません）
- `roundBeloteBonus` の合計が上昇した瞬間を検出（`useRef` で前回値を保持、初回ロード時はシードのみで発火しない）
- 確定時に `winFanfare` サウンドを 1 回再生
- belote/rebelote バッジに一時的な `ring + motion-safe:animate-pulse` を付与
- 確定メッセージのバナー（`role=status` `aria-live=polite`、`belote-bonus-confirmed`）を ~2.5 秒表示
- i18n キー `tracker.beloteConfirmed` を ja/en に追加

## テスト
- ボーナス確定時にチャイム＋バナー表示
- ボーナスが増えない通常プレイではチャイムなし
- 既にボーナスがあるラウンドにロードした場合はチャイムなし（マウントガード）

全 15 件 green。

Closes #2620