### PR TITLE
ci: prebuild e2e server binary + raise playwright webServer timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,8 +126,13 @@ jobs:
         working-directory: frontend
         run: bunx playwright install --with-deps chromium
 
+      - name: Build server binary
+        run: go build -o /tmp/trumpcards-server ./cmd/server
+
       - name: Run E2E tests
         working-directory: frontend
+        env:
+          E2E_SERVER_BIN: /tmp/trumpcards-server
         run: bunx playwright test
 
       - name: Upload Playwright report

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,5 +1,12 @@
 import { defineConfig, devices } from '@playwright/test';
 
+// In CI we pre-build the server binary so the cold `go build` happens outside
+// the webServer startup window; locally we fall back to `go run`. Either way
+// the server must run from the repo root so it can serve the `public` dir.
+const serverCommand = process.env.E2E_SERVER_BIN
+  ? `cd .. && PORT=8080 ${process.env.E2E_SERVER_BIN}`
+  : 'cd .. && PORT=8080 go run ./cmd/server';
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
@@ -28,9 +35,12 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'cd .. && PORT=8080 go run ./cmd/server',
+    command: serverCommand,
     url: 'http://localhost:8080',
     reuseExistingServer: !process.env.CI,
-    timeout: 30_000,
+    // A cold `go run` compiles the whole backend (174 games) and can exceed a
+    // tight window on slow runners; 120s absorbs that even without the prebuilt
+    // binary, eliminating the chronic "Timed out waiting from webServer" flake.
+    timeout: 120_000,
   },
 });


### PR DESCRIPTION
## 背景
E2E (Playwright) が `Timed out waiting 30000ms from config.webServer` で恒常的に失敗する（直近 #2823 で 9×、develop でも頻発）。原因は webServer 起動コマンドが `go run ./cmd/server` で、コールドな CI ランナーでは全バックエンド（174ゲーム）のコンパイルに 30 秒超かかり、Playwright の 30s タイムアウトを超えるため。サーバ自体は正常に `listening` するが、間に合わない。

## 変更
- **CI**: Playwright 実行前にサーババイナリを事前ビルドする専用ステップを追加（コールドコンパイルを起動ウィンドウの外へ）。`E2E_SERVER_BIN` 経由で webServer から起動。
- **playwright.config.ts**: `E2E_SERVER_BIN` が設定されていればそのバイナリを、なければ従来どおり `go run` を使用。`webServer.timeout` を 30s→120s に引き上げ（ローカル `go run` 経路の安全マージン）。

挙動は従来と同一（cwd=リポジトリルートで `public` を配信）で、コールドビルドを起動待ちから外しただけ。develop 全体の E2E flake を解消する。

## テスト計画
- [ ] この PR の E2E がグリーン（事前ビルドバイナリで webServer が即起動）
- [ ] Build server binary ステップが成功