### PR TITLE
feat(highcardflush): add CLI mode (CliToggle/CliTerminal)

### DIFF
--- a/frontend/src/pages/HighCardFlushPage.test.tsx
+++ b/frontend/src/pages/HighCardFlushPage.test.tsx
@@ -1,12 +1,24 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, highcardflushApi } from '../api/gameApi';
+import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, HighCardFlushResponse } from '../types/card';
 import { HighCardFlushPage } from './HighCardFlushPage';
 
 vi.mock('../hooks/useGameHint');
+
+const cliModeDisabled = {
+  cliEnabled: false,
+  toggleCli: vi.fn(),
+  logEntries: [],
+  addInput: vi.fn(),
+  addOutput: vi.fn(),
+  addError: vi.fn(),
+  clearLog: vi.fn(),
+};
+vi.mock('../hooks/useCliMode', () => ({ useCliMode: vi.fn() }));
 
 vi.mock('../api/gameApi', () => ({
   highcardflushApi: { exec: vi.fn() },
@@ -94,6 +106,7 @@ const endPhaseFold: HighCardFlushResponse = {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(useGameHint).mockReturnValue({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() });
+  vi.mocked(useCliMode).mockReturnValue(cliModeDisabled);
 });
 
 describe('HighCardFlushPage', () => {
@@ -265,5 +278,13 @@ describe('HighCardFlushPage', () => {
     const dealerWrapper = dealerWrappers[0] as HTMLElement;
     expect(dealerWrapper.className).not.toContain('drop-shadow');
     expect(dealerWrapper.className).not.toContain('opacity-50');
+  });
+
+  it('renders the CLI terminal and hides the betting UI when CLI mode is enabled', async () => {
+    vi.mocked(useCliMode).mockReturnValue({ ...cliModeDisabled, cliEnabled: true });
+    mockExec.mockResolvedValue(betPhaseState);
+    renderWithProviders(<HighCardFlushPage />);
+    await waitFor(() => expect(screen.getByRole('log')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'ベット' })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/HighCardFlushPage.tsx
+++ b/frontend/src/pages/HighCardFlushPage.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react';
 import { highcardflushApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
+import { CliTerminal } from '../components/cli/CliTerminal';
+import { CliToggle } from '../components/cli/CliToggle';
 import { ChipBetInput } from '../components/common/ChipBetInput';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
@@ -14,6 +16,8 @@ import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
+import { useCliGame } from '../hooks/useCliGame';
+import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
@@ -22,8 +26,12 @@ import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
+import type { HighCardFlushResponse } from '../types/card';
 import { HighCardFlushPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { HIGHCARDFLUSH_HELP, parseHighcardflushCommand } from '../utils/cli/commands/highcardflushCommands';
+import { formatHighcardflushState } from '../utils/cli/formatters/highcardflushFormatter';
+import type { CliGameConfig } from '../utils/cli/types';
 import { longestFlushSuit } from '../utils/highCardFlushUtils';
 
 /** High Card Flush tutorial step definitions. */
@@ -64,6 +72,17 @@ function HighCardFlushPageContent() {
   const { playSound } = useSound();
   const { state, loading, error, exec: execApi, retry } = useGameApi(highcardflushApi.exec);
   const { hint, hintEnabled, setHintEnabled } = useGameHint('highcardflush', state);
+  const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('highcardflush');
+  const cliConfig: CliGameConfig<HighCardFlushResponse, Parameters<typeof highcardflushApi.exec>> = useMemo(
+    () => ({
+      gameName: 'highcardflush',
+      parseCommand: parseHighcardflushCommand,
+      formatResponse: formatHighcardflushState,
+      helpText: HIGHCARDFLUSH_HELP,
+    }),
+    [],
+  );
+  const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
   useMountReset(execApi);
 
@@ -138,267 +157,280 @@ function HighCardFlushPageContent() {
       confirmReset={confirmReset}
       cancelReset={cancelReset}
       headerExtra={
-        <span>
-          {t('label.chips')}: {state.chips}
-        </span>
+        <>
+          <span>
+            {t('label.chips')}: {state.chips}
+          </span>
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </>
       }
     >
-      <div
-        data-testid="card-area"
-        className={[`overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`, !isBetPhase && 'flex-1']
-          .filter(Boolean)
-          .join(' ')}
-      >
-        <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
+      {cliEnabled ? (
+        <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
+      ) : (
+        <>
+          <div
+            data-testid="card-area"
+            className={[`overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`, !isBetPhase && 'flex-1']
+              .filter(Boolean)
+              .join(' ')}
+          >
+            <GameMessageBox
+              message={state.message}
+              messageCode={state.messageCode}
+              messageParams={state.messageParams}
+            />
 
-        {/* Payout reference during bet phase */}
-        {isBetPhase && (
-          <div className="flex flex-col items-center justify-center py-4 gap-4">
-            <p className="text-ds-text-muted text-lg">{t('betGuide')}</p>
-            <details className="bg-black/30 rounded-lg w-full max-w-sm">
-              <summary className="cursor-pointer select-none px-4 py-2 text-ds-text-primary font-bold text-sm">
-                {t('payoutRef.title')}
-              </summary>
-              <div className="px-4 pb-3 text-ds-text-muted text-sm space-y-2">
-                <div>
-                  <div className="font-bold text-ds-text-primary mb-1">{t('payoutRef.flushBonusHeader')}</div>
-                  <ul className="space-y-0.5">
-                    {(['flushBonus4', 'flushBonus5', 'flushBonus6', 'flushBonus7'] as const).map((key) => (
-                      <li key={key}>{t(`payoutRef.${key}`)}</li>
-                    ))}
-                  </ul>
-                </div>
-                <div>
-                  <div className="font-bold text-ds-text-primary mb-1">{t('payoutRef.straightFlushHeader')}</div>
-                  <ul className="space-y-0.5">
-                    {(
-                      [
-                        'straightFlush3',
-                        'straightFlush4',
-                        'straightFlush5',
-                        'straightFlush6',
-                        'straightFlush7',
-                      ] as const
-                    ).map((key) => (
-                      <li key={key}>{t(`payoutRef.${key}`)}</li>
-                    ))}
-                  </ul>
-                </div>
-                <div>
-                  <div className="font-bold text-ds-text-primary mb-1">{t('payoutRef.raiseRulesHeader')}</div>
-                  <ul className="space-y-0.5">
-                    {(['raise24', 'raise5', 'raise67'] as const).map((key) => (
-                      <li key={key}>{t(`payoutRef.${key}`)}</li>
-                    ))}
-                  </ul>
-                  <div className="mt-1">{t('payoutRef.dealerQualify')}</div>
-                </div>
-              </div>
-            </details>
-          </div>
-        )}
-
-        {/* Player Hand */}
-        {state.playerHand.length > 0 && (
-          <div className="mb-4" data-tutorial="hcf-results">
-            <div className="text-ds-warning font-bold text-center mb-1">
-              <span aria-hidden="true">🟡</span> {t('player')}
-              {state.playerFlushLen > 0 && (
-                <span className="ml-2 text-sm">({t('flushLine', { count: state.playerFlushLen })})</span>
-              )}
-            </div>
-            <div className="flex justify-center flex-wrap gap-2">
-              {state.playerHand.map((card, i) => {
-                const inFlush = card.design === playerFlushSuit;
-                return (
-                  <div
-                    key={`p-${card.design}-${card.value}-${i}`}
-                    className={`transition-all ${
-                      inFlush ? 'drop-shadow-[0_0_8px_var(--color-ds-warning)] -translate-y-1' : 'opacity-50'
-                    }`}
-                    data-card-section="player"
-                    data-flush-card={inFlush ? 'true' : 'false'}
-                  >
-                    <AnimatedCard card={card} width={cardWidth} />
+            {/* Payout reference during bet phase */}
+            {isBetPhase && (
+              <div className="flex flex-col items-center justify-center py-4 gap-4">
+                <p className="text-ds-text-muted text-lg">{t('betGuide')}</p>
+                <details className="bg-black/30 rounded-lg w-full max-w-sm">
+                  <summary className="cursor-pointer select-none px-4 py-2 text-ds-text-primary font-bold text-sm">
+                    {t('payoutRef.title')}
+                  </summary>
+                  <div className="px-4 pb-3 text-ds-text-muted text-sm space-y-2">
+                    <div>
+                      <div className="font-bold text-ds-text-primary mb-1">{t('payoutRef.flushBonusHeader')}</div>
+                      <ul className="space-y-0.5">
+                        {(['flushBonus4', 'flushBonus5', 'flushBonus6', 'flushBonus7'] as const).map((key) => (
+                          <li key={key}>{t(`payoutRef.${key}`)}</li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div>
+                      <div className="font-bold text-ds-text-primary mb-1">{t('payoutRef.straightFlushHeader')}</div>
+                      <ul className="space-y-0.5">
+                        {(
+                          [
+                            'straightFlush3',
+                            'straightFlush4',
+                            'straightFlush5',
+                            'straightFlush6',
+                            'straightFlush7',
+                          ] as const
+                        ).map((key) => (
+                          <li key={key}>{t(`payoutRef.${key}`)}</li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div>
+                      <div className="font-bold text-ds-text-primary mb-1">{t('payoutRef.raiseRulesHeader')}</div>
+                      <ul className="space-y-0.5">
+                        {(['raise24', 'raise5', 'raise67'] as const).map((key) => (
+                          <li key={key}>{t(`payoutRef.${key}`)}</li>
+                        ))}
+                      </ul>
+                      <div className="mt-1">{t('payoutRef.dealerQualify')}</div>
+                    </div>
                   </div>
-                );
-              })}
-            </div>
-          </div>
-        )}
+                </details>
+              </div>
+            )}
 
-        {/* Dealer Hand */}
-        {state.dealerHand.length > 0 && (
-          <div className="mb-4">
-            <div className="text-ds-error font-bold text-center mb-1">
-              <span aria-hidden="true">🔴</span> {t('dealer')}
-              {isEndPhase && state.dealerFlushLen > 0 && (
-                <span className="ml-2 text-sm">({t('flushLine', { count: state.dealerFlushLen })})</span>
-              )}
-              {isEndPhase && (
-                <span className="ml-2 text-xs">
-                  {state.dealerQualified ? t('dealerQualified') : t('dealerNotQualified')}
-                </span>
-              )}
-            </div>
-            <div className="flex justify-center flex-wrap gap-2">
-              {state.dealerHand.map((card, i) => {
-                // dealerFlushSuit is null during the action phase (no spoilers).
-                const inFlush = dealerFlushSuit !== null && card.design === dealerFlushSuit;
-                return (
-                  <div
-                    key={`d-${card.design}-${card.value}-${i}`}
-                    className={`transition-all ${
-                      dealerFlushSuit === null
-                        ? ''
-                        : inFlush
-                          ? 'drop-shadow-[0_0_8px_var(--color-ds-error)] -translate-y-1'
-                          : 'opacity-50'
-                    }`}
-                    data-card-section="dealer"
-                    data-flush-card={inFlush ? 'true' : 'false'}
-                  >
-                    <AnimatedCard card={card} width={cardWidth} />
+            {/* Player Hand */}
+            {state.playerHand.length > 0 && (
+              <div className="mb-4" data-tutorial="hcf-results">
+                <div className="text-ds-warning font-bold text-center mb-1">
+                  <span aria-hidden="true">🟡</span> {t('player')}
+                  {state.playerFlushLen > 0 && (
+                    <span className="ml-2 text-sm">({t('flushLine', { count: state.playerFlushLen })})</span>
+                  )}
+                </div>
+                <div className="flex justify-center flex-wrap gap-2">
+                  {state.playerHand.map((card, i) => {
+                    const inFlush = card.design === playerFlushSuit;
+                    return (
+                      <div
+                        key={`p-${card.design}-${card.value}-${i}`}
+                        className={`transition-all ${
+                          inFlush ? 'drop-shadow-[0_0_8px_var(--color-ds-warning)] -translate-y-1' : 'opacity-50'
+                        }`}
+                        data-card-section="player"
+                        data-flush-card={inFlush ? 'true' : 'false'}
+                      >
+                        <AnimatedCard card={card} width={cardWidth} />
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* Dealer Hand */}
+            {state.dealerHand.length > 0 && (
+              <div className="mb-4">
+                <div className="text-ds-error font-bold text-center mb-1">
+                  <span aria-hidden="true">🔴</span> {t('dealer')}
+                  {isEndPhase && state.dealerFlushLen > 0 && (
+                    <span className="ml-2 text-sm">({t('flushLine', { count: state.dealerFlushLen })})</span>
+                  )}
+                  {isEndPhase && (
+                    <span className="ml-2 text-xs">
+                      {state.dealerQualified ? t('dealerQualified') : t('dealerNotQualified')}
+                    </span>
+                  )}
+                </div>
+                <div className="flex justify-center flex-wrap gap-2">
+                  {state.dealerHand.map((card, i) => {
+                    // dealerFlushSuit is null during the action phase (no spoilers).
+                    const inFlush = dealerFlushSuit !== null && card.design === dealerFlushSuit;
+                    return (
+                      <div
+                        key={`d-${card.design}-${card.value}-${i}`}
+                        className={`transition-all ${
+                          dealerFlushSuit === null
+                            ? ''
+                            : inFlush
+                              ? 'drop-shadow-[0_0_8px_var(--color-ds-error)] -translate-y-1'
+                              : 'opacity-50'
+                        }`}
+                        data-card-section="dealer"
+                        data-flush-card={inFlush ? 'true' : 'false'}
+                      >
+                        <AnimatedCard card={card} width={cardWidth} />
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* Payout breakdown */}
+            {isEndPhase && (
+              <div className="text-ds-text-primary text-center text-sm mb-2" data-testid="payout-breakdown">
+                {state.antePayout !== 0 && (
+                  <div>
+                    {t('payout.ante')}: {state.antePayout}
                   </div>
-                );
-              })}
-            </div>
+                )}
+                {state.raisePayout !== 0 && (
+                  <div>
+                    {t('payout.raise')}: {state.raisePayout}
+                  </div>
+                )}
+                {state.flushBonusPayout !== 0 && (
+                  <div>
+                    {t('payout.flushBonus')}: {state.flushBonusPayout}
+                  </div>
+                )}
+                {state.straightFlushPayout !== 0 && (
+                  <div>
+                    {t('payout.straightFlush')}: {state.straightFlushPayout}
+                  </div>
+                )}
+                <div className="font-bold mt-1">
+                  {t('payout.total')}: {state.totalPayout}
+                </div>
+              </div>
+            )}
+
+            {/* Action Log */}
+            {actionLog && <ActionLogPanel entries={actionLog} onClose={hideActionLog} />}
           </div>
-        )}
 
-        {/* Payout breakdown */}
-        {isEndPhase && (
-          <div className="text-ds-text-primary text-center text-sm mb-2" data-testid="payout-breakdown">
-            {state.antePayout !== 0 && (
-              <div>
-                {t('payout.ante')}: {state.antePayout}
-              </div>
-            )}
-            {state.raisePayout !== 0 && (
-              <div>
-                {t('payout.raise')}: {state.raisePayout}
-              </div>
-            )}
-            {state.flushBonusPayout !== 0 && (
-              <div>
-                {t('payout.flushBonus')}: {state.flushBonusPayout}
-              </div>
-            )}
-            {state.straightFlushPayout !== 0 && (
-              <div>
-                {t('payout.straightFlush')}: {state.straightFlushPayout}
-              </div>
-            )}
-            <div className="font-bold mt-1">
-              {t('payout.total')}: {state.totalPayout}
-            </div>
-          </div>
-        )}
-
-        {/* Action Log */}
-        {actionLog && <ActionLogPanel entries={actionLog} onClose={hideActionLog} />}
-      </div>
-
-      <GameFooter className={`${gameTheme.highcardflush.footer} px-4 pt-3`}>
-        <ErrorAlert message={error} onRetry={retry} />
-        {hintEnabled && hint && <HintTooltip reason={t(hint.reason)} confidence={hint.confidence} />}
-        <SettingsPanel
-          title={t('settings.title')}
-          groups={[
-            {
-              items: [
+          <GameFooter className={`${gameTheme.highcardflush.footer} px-4 pt-3`}>
+            <ErrorAlert message={error} onRetry={retry} />
+            {hintEnabled && hint && <HintTooltip reason={t(hint.reason)} confidence={hint.confidence} />}
+            <SettingsPanel
+              title={t('settings.title')}
+              groups={[
                 {
-                  type: 'checkbox',
-                  id: 'highcardflush-hint',
-                  label: tc('hint.toggle', { ns: 'tutorial' }),
-                  checked: hintEnabled,
-                  onToggle: setHintEnabled,
+                  items: [
+                    {
+                      type: 'checkbox',
+                      id: 'highcardflush-hint',
+                      label: tc('hint.toggle', { ns: 'tutorial' }),
+                      checked: hintEnabled,
+                      onToggle: setHintEnabled,
+                    },
+                  ],
                 },
-              ],
-            },
-          ]}
-        />
-        {isBetPhase && (
-          <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="hcf-bet-controls">
-            <ChipBetInput
-              id="hcf-ante"
-              label={t('label.ante')}
-              value={anteAmount}
-              onChange={setAnteAmount}
-              min={10}
-              max={state.chips}
-              step={10}
-              disabled={loading}
-              showSteppers
+              ]}
             />
-            <ChipBetInput
-              id="hcf-flush-bonus"
-              label={t('label.flushBonus')}
-              value={flushBonusAmount}
-              onChange={setFlushBonusAmount}
-              min={0}
-              max={state.chips}
-              step={10}
-              disabled={loading}
-              showSteppers
-            />
-            <ChipBetInput
-              id="hcf-straight-flush"
-              label={t('label.straightFlush')}
-              value={straightFlushAmount}
-              onChange={setStraightFlushAmount}
-              min={0}
-              max={state.chips}
-              step={10}
-              disabled={loading}
-              showSteppers
-            />
-            <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading}>
-              {t('button.bet')}
-            </button>
-          </div>
-        )}
-        {isActionPhase && (
-          <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="hcf-action-buttons">
-            <div className="text-ds-text-muted text-xs">
-              {t('label.flushLen')}: {state.playerFlushLen} · {t('label.multiplier')} ≤ {maxMultiplier}
-            </div>
-            <div className="flex flex-wrap justify-center gap-2">
-              {maxMultiplier >= 1 && (
-                <button type="button" className={btnSuccess} onClick={raise(1)} disabled={loading}>
-                  {t('button.raise1x')}
+            {isBetPhase && (
+              <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="hcf-bet-controls">
+                <ChipBetInput
+                  id="hcf-ante"
+                  label={t('label.ante')}
+                  value={anteAmount}
+                  onChange={setAnteAmount}
+                  min={10}
+                  max={state.chips}
+                  step={10}
+                  disabled={loading}
+                  showSteppers
+                />
+                <ChipBetInput
+                  id="hcf-flush-bonus"
+                  label={t('label.flushBonus')}
+                  value={flushBonusAmount}
+                  onChange={setFlushBonusAmount}
+                  min={0}
+                  max={state.chips}
+                  step={10}
+                  disabled={loading}
+                  showSteppers
+                />
+                <ChipBetInput
+                  id="hcf-straight-flush"
+                  label={t('label.straightFlush')}
+                  value={straightFlushAmount}
+                  onChange={setStraightFlushAmount}
+                  min={0}
+                  max={state.chips}
+                  step={10}
+                  disabled={loading}
+                  showSteppers
+                />
+                <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading}>
+                  {t('button.bet')}
                 </button>
-              )}
-              {maxMultiplier >= 2 && (
-                <button type="button" className={btnSuccess} onClick={raise(2)} disabled={loading}>
-                  {t('button.raise2x')}
+              </div>
+            )}
+            {isActionPhase && (
+              <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="hcf-action-buttons">
+                <div className="text-ds-text-muted text-xs">
+                  {t('label.flushLen')}: {state.playerFlushLen} · {t('label.multiplier')} ≤ {maxMultiplier}
+                </div>
+                <div className="flex flex-wrap justify-center gap-2">
+                  {maxMultiplier >= 1 && (
+                    <button type="button" className={btnSuccess} onClick={raise(1)} disabled={loading}>
+                      {t('button.raise1x')}
+                    </button>
+                  )}
+                  {maxMultiplier >= 2 && (
+                    <button type="button" className={btnSuccess} onClick={raise(2)} disabled={loading}>
+                      {t('button.raise2x')}
+                    </button>
+                  )}
+                  {maxMultiplier >= 3 && (
+                    <button type="button" className={btnSuccess} onClick={raise(3)} disabled={loading}>
+                      {t('button.raise3x')}
+                    </button>
+                  )}
+                  <button type="button" className={btnDanger} onClick={handleFold} disabled={loading}>
+                    {t('button.fold')}
+                  </button>
+                </div>
+              </div>
+            )}
+            {isEndPhase && (
+              <div className="flex justify-center gap-2 pb-2">
+                <GameResetButton
+                  isGameEnd={isEndPhase}
+                  onReset={handleReset}
+                  requestConfirm={requestConfirm}
+                  loading={loading}
+                />
+                <button type="button" className={btnSecondary} onClick={showActionLog} disabled={loading}>
+                  {tc('actionLog.view')}
                 </button>
-              )}
-              {maxMultiplier >= 3 && (
-                <button type="button" className={btnSuccess} onClick={raise(3)} disabled={loading}>
-                  {t('button.raise3x')}
-                </button>
-              )}
-              <button type="button" className={btnDanger} onClick={handleFold} disabled={loading}>
-                {t('button.fold')}
-              </button>
-            </div>
-          </div>
-        )}
-        {isEndPhase && (
-          <div className="flex justify-center gap-2 pb-2">
-            <GameResetButton
-              isGameEnd={isEndPhase}
-              onReset={handleReset}
-              requestConfirm={requestConfirm}
-              loading={loading}
-            />
-            <button type="button" className={btnSecondary} onClick={showActionLog} disabled={loading}>
-              {tc('actionLog.view')}
-            </button>
-          </div>
-        )}
-      </GameFooter>
+              </div>
+            )}
+          </GameFooter>
+        </>
+      )}
     </GamePageShell>
   );
 }

--- a/frontend/src/utils/cli/commands/highcardflushCommands.test.ts
+++ b/frontend/src/utils/cli/commands/highcardflushCommands.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { HIGHCARDFLUSH_HELP, parseHighcardflushCommand } from './highcardflushCommands';
+
+describe('parseHighcardflushCommand', () => {
+  it('parses bet with ante only', () => {
+    expect(parseHighcardflushCommand('b 100')).toEqual({ args: ['bet', 100] });
+    expect(parseHighcardflushCommand('bet 50')).toEqual({ args: ['bet', 50] });
+  });
+
+  it('parses bet with ante and flush bonus side bet', () => {
+    expect(parseHighcardflushCommand('b 100 10')).toEqual({ args: ['bet', 100, 10] });
+  });
+
+  it('parses bet with ante, flush bonus, and straight flush side bets', () => {
+    expect(parseHighcardflushCommand('b 100 10 5')).toEqual({ args: ['bet', 100, 10, 5] });
+  });
+
+  it('returns error for bet without amount', () => {
+    expect('error' in parseHighcardflushCommand('b')).toBe(true);
+    expect('error' in parseHighcardflushCommand('bet')).toBe(true);
+  });
+
+  it('returns error for non-numeric ante', () => {
+    expect('error' in parseHighcardflushCommand('b abc')).toBe(true);
+  });
+
+  it('returns error for non-numeric side bet', () => {
+    expect('error' in parseHighcardflushCommand('b 100 xyz')).toBe(true);
+    expect('error' in parseHighcardflushCommand('b 100 10 xyz')).toBe(true);
+  });
+
+  it('parses numeric raise shortcuts 1/2/3', () => {
+    expect(parseHighcardflushCommand('1')).toEqual({ args: ['raise', undefined, undefined, undefined, 1] });
+    expect(parseHighcardflushCommand('2')).toEqual({ args: ['raise', undefined, undefined, undefined, 2] });
+    expect(parseHighcardflushCommand('3')).toEqual({ args: ['raise', undefined, undefined, undefined, 3] });
+  });
+
+  it('parses raise <multiplier>', () => {
+    expect(parseHighcardflushCommand('ra 2')).toEqual({ args: ['raise', undefined, undefined, undefined, 2] });
+    expect(parseHighcardflushCommand('raise 3')).toEqual({ args: ['raise', undefined, undefined, undefined, 3] });
+  });
+
+  it('returns error for out-of-range raise multiplier', () => {
+    expect('error' in parseHighcardflushCommand('raise 4')).toBe(true);
+    expect('error' in parseHighcardflushCommand('raise 0')).toBe(true);
+  });
+
+  it('returns error for raise without a multiplier', () => {
+    expect('error' in parseHighcardflushCommand('raise')).toBe(true);
+  });
+
+  it('parses fold', () => {
+    expect(parseHighcardflushCommand('f')).toEqual({ args: ['fold'] });
+    expect(parseHighcardflushCommand('fold')).toEqual({ args: ['fold'] });
+  });
+
+  it('parses log', () => {
+    expect(parseHighcardflushCommand('log')).toEqual({ args: ['log'] });
+  });
+
+  it('parses reset', () => {
+    expect(parseHighcardflushCommand('r')).toEqual({ args: ['reset'] });
+    expect(parseHighcardflushCommand('reset')).toEqual({ args: ['reset'] });
+  });
+
+  it('suggests a close command for a typo', () => {
+    const result = parseHighcardflushCommand('fol');
+    expect('error' in result && result.error).toContain('fold');
+  });
+
+  it('returns error for unknown command', () => {
+    expect('error' in parseHighcardflushCommand('xyz')).toBe(true);
+  });
+
+  it('exposes help text', () => {
+    expect(HIGHCARDFLUSH_HELP.length).toBeGreaterThan(0);
+    expect(HIGHCARDFLUSH_HELP.some((line) => line.includes('fold'))).toBe(true);
+  });
+});

--- a/frontend/src/utils/cli/commands/highcardflushCommands.ts
+++ b/frontend/src/utils/cli/commands/highcardflushCommands.ts
@@ -1,0 +1,74 @@
+import type { highcardflushApi } from '../../../api/gameApi';
+import { parseIntArg, splitCommand, suggestCommand } from '../commandParserBase';
+import type { CliParseResult } from '../types';
+
+type HighCardFlushArgs = Parameters<typeof highcardflushApi.exec>;
+
+const VALID_COMMANDS = ['b', 'bet', 'ra', 'raise', '1', '2', '3', 'f', 'fold', 'log', 'r', 'reset', 'help', '?'];
+
+/** Parse a raise multiplier (1-3) into the API exec arguments. */
+function raiseArgs(multiplier: number): CliParseResult<HighCardFlushArgs> {
+  if (multiplier < 1 || multiplier > 3) return { error: 'Usage: raise <1|2|3>' };
+  return { args: ['raise', undefined, undefined, undefined, multiplier] };
+}
+
+/** Parse a High Card Flush CLI command into API exec arguments. */
+export function parseHighcardflushCommand(input: string): CliParseResult<HighCardFlushArgs> {
+  const { cmd, args } = splitCommand(input);
+
+  switch (cmd) {
+    case 'b':
+    case 'bet': {
+      const usage = 'Usage: b <ante> [flushBonus] [straightFlush]';
+      const ante = parseIntArg(args, 0);
+      if ('error' in ante) return { error: usage };
+      if (args.length >= 3) {
+        const flushBonus = parseIntArg(args, 1);
+        const straightFlush = parseIntArg(args, 2);
+        if ('error' in flushBonus || 'error' in straightFlush) return { error: usage };
+        return { args: ['bet', ante.value, flushBonus.value, straightFlush.value] };
+      }
+      if (args.length >= 2) {
+        const flushBonus = parseIntArg(args, 1);
+        if ('error' in flushBonus) return { error: usage };
+        return { args: ['bet', ante.value, flushBonus.value] };
+      }
+      return { args: ['bet', ante.value] };
+    }
+    case '1':
+      return raiseArgs(1);
+    case '2':
+      return raiseArgs(2);
+    case '3':
+      return raiseArgs(3);
+    case 'ra':
+    case 'raise': {
+      const multiplier = parseIntArg(args, 0);
+      if ('error' in multiplier) return { error: 'Usage: raise <1|2|3>' };
+      return raiseArgs(multiplier.value);
+    }
+    case 'f':
+    case 'fold':
+      return { args: ['fold'] };
+    case 'log':
+      return { args: ['log'] };
+    case 'r':
+    case 'reset':
+      return { args: ['reset'] };
+    default: {
+      const suggestion = suggestCommand(cmd, VALID_COMMANDS);
+      if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
+      return { error: `Unknown command: ${cmd}` };
+    }
+  }
+}
+
+/** Help text for High Card Flush CLI mode. */
+export const HIGHCARDFLUSH_HELP: string[] = [
+  'b <ante> [fb] [sf] - Ante bet (optional Flush Bonus / Straight Flush side bets)',
+  '1 / 2 / 3          - Raise 1x / 2x / 3x the ante',
+  'ra/raise <1|2|3>   - Raise by multiplier',
+  'f/fold             - Fold',
+  'log                - Show action log',
+  'r/reset            - Reset game',
+];

--- a/frontend/src/utils/cli/formatters/highcardflushFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/highcardflushFormatter.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign, HighCardFlushResponse } from '../../../types/card';
+import { HighCardFlushPhase } from '../../../types/phases';
+import { formatHighcardflushState } from './highcardflushFormatter';
+
+const card = (design: CardDesign, value: number): Card => ({ design, value });
+
+const baseState: HighCardFlushResponse = {
+  playerHand: [],
+  dealerHand: [],
+  phase: HighCardFlushPhase.BET,
+  chips: 1000,
+  anteBet: 0,
+  flushBonusBet: 0,
+  straightFlushBet: 0,
+  raiseBet: 0,
+  result: 0,
+  antePayout: 0,
+  raisePayout: 0,
+  flushBonusPayout: 0,
+  straightFlushPayout: 0,
+  totalPayout: 0,
+  dealerQualified: false,
+  playerFlushLen: 0,
+  dealerFlushLen: 0,
+  playerStraightFlushLen: 0,
+  maxRaiseMultiplier: 3,
+  message: '',
+};
+
+const actionState: HighCardFlushResponse = {
+  ...baseState,
+  phase: HighCardFlushPhase.ACTION,
+  playerHand: [card('SPADE', 12), card('SPADE', 9), card('SPADE', 4), card('HEART', 7), card('CLOVER', 2)],
+  dealerHand: [card('DIAMOND', 13), card('DIAMOND', 8), card('DIAMOND', 3), card('HEART', 5), card('CLOVER', 9)],
+  anteBet: 100,
+  flushBonusBet: 10,
+  playerFlushLen: 3,
+  chips: 890,
+};
+
+const endState: HighCardFlushResponse = {
+  ...actionState,
+  phase: HighCardFlushPhase.END,
+  raiseBet: 200,
+  dealerFlushLen: 3,
+  dealerQualified: true,
+  result: 1,
+  antePayout: 100,
+  raisePayout: 200,
+  flushBonusPayout: 20,
+  totalPayout: 320,
+};
+
+describe('formatHighcardflushState', () => {
+  it('renders the header, chips, and phase', () => {
+    const out = formatHighcardflushState(baseState);
+    expect(out).toContain('High Card Flush');
+    expect(out).toContain('chips: 1000');
+    expect(out).toContain('phase: BET');
+  });
+
+  it('hides the dealer hand during the action phase', () => {
+    const out = formatHighcardflushState(actionState);
+    expect(out).toContain('Dealer: (hidden)');
+    expect(out).toContain('Your longest flush: 3');
+    expect(out).not.toContain('♦');
+  });
+
+  it('reveals the dealer hand and payouts at end', () => {
+    const out = formatHighcardflushState(endState);
+    expect(out).toContain('Dealer:');
+    expect(out).toContain('Dealer longest flush: 3');
+    expect(out).toContain('raise=200');
+    expect(out).toContain('total: 320');
+  });
+
+  it('marks an unqualified dealer at end', () => {
+    const out = formatHighcardflushState({ ...endState, dealerQualified: false });
+    expect(out).toContain('not qualified');
+  });
+
+  it('renders UNKNOWN for an unexpected phase', () => {
+    const out = formatHighcardflushState({ ...baseState, phase: 99 });
+    expect(out).toContain('phase: UNKNOWN');
+  });
+});

--- a/frontend/src/utils/cli/formatters/highcardflushFormatter.ts
+++ b/frontend/src/utils/cli/formatters/highcardflushFormatter.ts
@@ -1,0 +1,51 @@
+import type { HighCardFlushResponse } from '../../../types/card';
+import { HighCardFlushPhase } from '../../../types/phases';
+import { formatCardList, formatHeader, formatIndexedCards, formatSeparator } from '../formatterBase';
+
+const PHASE_NAMES: Record<number, string> = {
+  [HighCardFlushPhase.BET]: 'BET',
+  [HighCardFlushPhase.ACTION]: 'ACTION',
+  [HighCardFlushPhase.END]: 'END',
+};
+
+/** Format a High Card Flush game state as terminal text. */
+export function formatHighcardflushState(state: HighCardFlushResponse): string {
+  const lines: string[] = [];
+
+  lines.push(formatHeader('High Card Flush'));
+  lines.push(`chips: ${state.chips}  phase: ${PHASE_NAMES[state.phase] ?? 'UNKNOWN'}`);
+  lines.push('');
+
+  if (state.playerHand.length > 0) {
+    lines.push(`Your hand: ${formatIndexedCards(state.playerHand)}`);
+    lines.push(`Your longest flush: ${state.playerFlushLen}`);
+  }
+
+  if (state.dealerHand.length > 0) {
+    if (state.phase === HighCardFlushPhase.END) {
+      lines.push(`Dealer: ${formatCardList(state.dealerHand)}`);
+      lines.push(`Dealer longest flush: ${state.dealerFlushLen}${state.dealerQualified ? '' : ' (not qualified)'}`);
+    } else {
+      lines.push('Dealer: (hidden)');
+    }
+  }
+
+  lines.push('----------');
+  if (state.anteBet > 0) lines.push(`ante: ${state.anteBet}`);
+  if (state.raiseBet > 0) lines.push(`raise: ${state.raiseBet}`);
+  if (state.flushBonusBet > 0) lines.push(`flush bonus bet: ${state.flushBonusBet}`);
+  if (state.straightFlushBet > 0) lines.push(`straight flush bet: ${state.straightFlushBet}`);
+
+  if (state.phase === HighCardFlushPhase.END) {
+    lines.push(
+      `payout: ante=${state.antePayout} raise=${state.raisePayout} ` +
+        `fb=${state.flushBonusPayout} sf=${state.straightFlushPayout}`,
+    );
+    lines.push(`total: ${state.totalPayout}`);
+  }
+
+  if (state.message) lines.push(state.message);
+
+  lines.push(formatSeparator());
+  return lines.join('\n');
+}


### PR DESCRIPTION
## 概要
High Card Flush に CLI モード（`useCliMode`/`useCliGame`/`CliToggle`/`CliTerminal`）を追加し、他カジノ系ゲーム（CasinoHoldem・TexasHoldemBonus・CaribbeanStud 等）と機能パリティを揃えます（#2629）。

## 変更点
- **`utils/cli/commands/highcardflushCommands.ts`** (新規) — `b/bet <ante> [flushBonus] [straightFlush]` / `1``2``3` および `ra/raise <1|2|3>` / `f/fold` / `log` / `r/reset` のパーサ + HELP。既存キーボード割り当て（b/1/2/3/f/r）と整合。
- **`utils/cli/formatters/highcardflushFormatter.ts`** (新規) — 手札・最長フラッシュ長・チップ・各ベット・払戻しを整形。ディーラー手札は END まで非表示（スポイラー回避、ページの spoiler ガードと同様）。
- **`pages/HighCardFlushPage.tsx`** — `headerExtra` に `CliToggle`、本文に `cliEnabled` 分岐で `CliTerminal` を追加。

## テスト
- commands: 15 ケース（bet 1〜3 引数、raise ショートカット/範囲外、fold/log/reset、typo サジェスト、unknown）
- formatter: 5 ケース（ヘッダ/フェーズ、ACTION 中はディーラー非表示、END で開示+払戻し、未クオリファイ、未知フェーズ）
- page: CLI モードで terminal(role=log) 表示・ベット UI 非表示

commands/formatter 21 + page 18 全 green。biome clean。

Closes #2629