### PR TITLE
feat(openfacechinese): add CLI mode (CliToggle/CliTerminal)

### DIFF
--- a/frontend/src/pages/OpenFaceChinesePage.test.tsx
+++ b/frontend/src/pages/OpenFaceChinesePage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { openfacechineseApi } from '../api/gameApi';
+import { useCliMode } from '../hooks/useCliMode';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, OpenFaceChinesePlayer, OpenFaceChineseResponse } from '../types/card';
 import { OpenFaceChinesePage } from './OpenFaceChinesePage';
@@ -9,6 +10,17 @@ vi.mock('../api/gameApi', () => ({
   openfacechineseApi: { exec: vi.fn() },
   actionLogApi: { openfacechinese: vi.fn() },
 }));
+
+const cliModeDisabled = {
+  cliEnabled: false,
+  toggleCli: vi.fn(),
+  logEntries: [],
+  addInput: vi.fn(),
+  addOutput: vi.fn(),
+  addError: vi.fn(),
+  clearLog: vi.fn(),
+};
+vi.mock('../hooks/useCliMode', () => ({ useCliMode: vi.fn() }));
 
 const mockExec = vi.mocked(openfacechineseApi.exec);
 
@@ -76,6 +88,7 @@ const gameEndState = makeState({
 beforeEach(() => {
   mockExec.mockReset();
   mockExec.mockResolvedValue(placingState);
+  vi.mocked(useCliMode).mockReturnValue(cliModeDisabled);
 });
 
 describe('OpenFaceChinesePage', () => {
@@ -152,5 +165,13 @@ describe('OpenFaceChinesePage', () => {
     renderWithProviders(<OpenFaceChinesePage />);
     await waitFor(() => expect(screen.getAllByText('ゲーム終了').length).toBeGreaterThan(0));
     expect(screen.queryByTestId('next-button')).not.toBeInTheDocument();
+  });
+
+  it('renders the CLI terminal and hides the board when CLI mode is enabled', async () => {
+    vi.mocked(useCliMode).mockReturnValue({ ...cliModeDisabled, cliEnabled: true });
+    mockExec.mockResolvedValue(placingState);
+    renderWithProviders(<OpenFaceChinesePage />);
+    await waitFor(() => expect(screen.getByRole('log')).toBeInTheDocument());
+    expect(screen.queryByTestId('place-front')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/OpenFaceChinesePage.tsx
+++ b/frontend/src/pages/OpenFaceChinesePage.tsx
@@ -1,7 +1,9 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { openfacechineseApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CardImage } from '../components/CardImage';
+import { CliTerminal } from '../components/cli/CliTerminal';
+import { CliToggle } from '../components/cli/CliToggle';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
@@ -10,14 +12,19 @@ import { GameResetButton } from '../components/GameResetButton';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
+import { useCliGame } from '../hooks/useCliGame';
+import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { btnSuccess } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { Card, OpenFaceChinesePlayer } from '../types/card';
+import type { Card, OpenFaceChinesePlayer, OpenFaceChineseResponse } from '../types/card';
 import { OpenFaceChinesePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { OPENFACECHINESE_HELP, parseOpenfacechineseCommand } from '../utils/cli/commands/openfacechineseCommands';
+import { formatOpenfacechineseState } from '../utils/cli/formatters/openfacechineseFormatter';
+import type { CliGameConfig } from '../utils/cli/types';
 
 /** Row indices accepted by the backend `place` command. */
 const ROW_FRONT = 0;
@@ -67,6 +74,17 @@ function OpenFaceChinesePageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('openfacechinese');
   const { state, loading, error, exec, retry } = useGameApi(openfacechineseApi.exec);
+  const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('openfacechinese');
+  const cliConfig: CliGameConfig<OpenFaceChineseResponse, Parameters<typeof openfacechineseApi.exec>> = useMemo(
+    () => ({
+      gameName: 'openfacechinese',
+      parseCommand: parseOpenfacechineseCommand,
+      formatResponse: formatOpenfacechineseState,
+      helpText: OPENFACECHINESE_HELP,
+    }),
+    [],
+  );
+  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
   // Fetch a fresh game on mount.
   // biome-ignore lint/correctness/useExhaustiveDependencies: run once on mount.
@@ -133,132 +151,143 @@ function OpenFaceChinesePageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      headerExtra={<CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />}
     >
-      <div className="flex-1 overflow-y-auto pt-3 px-4 lg:px-8">
-        {/* Round info */}
-        <div
-          className="mb-3 p-2 rounded bg-black/30 flex flex-wrap justify-center gap-x-6 gap-y-1 text-sm"
-          data-tutorial="ofc-info"
-        >
-          <span className="font-semibold text-ds-warning">{t('round', { round: state.roundNumber })}</span>
-          {human && <span className="text-ds-text-muted">{t('totalScore', { score: human.totalScore })}</span>}
-        </div>
-
-        {/* Pending card to place */}
-        {canPlace && state.currentCard && (
-          <div
-            className="mb-3 p-3 rounded bg-black/30 text-center flex flex-col items-center gap-2"
-            data-tutorial="ofc-place"
-          >
-            <span className="text-ds-text-muted text-xs">{t('pendingTitle')}</span>
-            <CardImage card={state.currentCard} width={cardWidth} />
-            <span className="text-ds-text-primary text-sm">{t('placePrompt')}</span>
-            <div className="flex flex-wrap justify-center gap-2 mt-1">
-              <button
-                type="button"
-                className={btnSuccess}
-                onClick={() => handlePlace(ROW_FRONT)}
-                disabled={loading}
-                data-testid="place-front"
-              >
-                {t('place.front')}
-              </button>
-              <button
-                type="button"
-                className={btnSuccess}
-                onClick={() => handlePlace(ROW_MIDDLE)}
-                disabled={loading}
-                data-testid="place-middle"
-              >
-                {t('place.middle')}
-              </button>
-              <button
-                type="button"
-                className={btnSuccess}
-                onClick={() => handlePlace(ROW_BACK)}
-                disabled={loading}
-                data-testid="place-back"
-              >
-                {t('place.back')}
-              </button>
-            </div>
-          </div>
-        )}
-
-        {/* Player boards */}
-        <div className="grid gap-3 sm:grid-cols-2" data-tutorial="ofc-rows">
-          {state.players.map((p) => (
+      {cliEnabled ? (
+        <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
+      ) : (
+        <>
+          <div className="flex-1 overflow-y-auto pt-3 px-4 lg:px-8">
+            {/* Round info */}
             <div
-              key={`player-${p.id}`}
-              className={`p-3 rounded bg-black/20 ${p.id === state.currentPlayerIdx && isPlacing ? 'ring-1 ring-ds-warning' : ''}`}
-              data-testid={`player-${p.id}`}
+              className="mb-3 p-2 rounded bg-black/30 flex flex-wrap justify-center gap-x-6 gap-y-1 text-sm"
+              data-tutorial="ofc-info"
             >
-              <div className="flex items-center justify-between mb-2">
-                <span className="text-ds-text-primary text-sm font-semibold">{playerName(p)}</span>
-                <div className="flex items-center gap-2 text-xs">
-                  {p.fouled && <span className="text-ds-error font-semibold">{t('fouled')}</span>}
-                  {p.fantasyland && <span className="text-ds-accent font-semibold">{t('fantasyland')}</span>}
-                </div>
-              </div>
-              <div className="flex flex-col gap-2">
-                {renderRow(t('rows.front'), p.front, 3, `front-${p.id}`)}
-                {renderRow(t('rows.middle'), p.middle, 5, `middle-${p.id}`)}
-                {renderRow(t('rows.back'), p.back, 5, `back-${p.id}`)}
-              </div>
-              {isRoundEnd && (
-                <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs">
-                  <span className="text-ds-text-primary" data-testid={`round-score-${p.id}`}>
-                    {t('roundScore', { score: p.roundScore })}
-                  </span>
-                  {p.royalty > 0 && <span className="text-ds-success">{t('royalty', { points: p.royalty })}</span>}
-                  <span className="text-ds-text-muted">{t('totalScore', { score: p.totalScore })}</span>
-                </div>
-              )}
+              <span className="font-semibold text-ds-warning">{t('round', { round: state.roundNumber })}</span>
+              {human && <span className="text-ds-text-muted">{t('totalScore', { score: human.totalScore })}</span>}
             </div>
-          ))}
-        </div>
 
-        {isRoundEnd && (
-          <div className="mt-3 text-center text-ds-text-primary text-sm font-semibold">{t('roundEndTitle')}</div>
-        )}
+            {/* Pending card to place */}
+            {canPlace && state.currentCard && (
+              <div
+                className="mb-3 p-3 rounded bg-black/30 text-center flex flex-col items-center gap-2"
+                data-tutorial="ofc-place"
+              >
+                <span className="text-ds-text-muted text-xs">{t('pendingTitle')}</span>
+                <CardImage card={state.currentCard} width={cardWidth} />
+                <span className="text-ds-text-primary text-sm">{t('placePrompt')}</span>
+                <div className="flex flex-wrap justify-center gap-2 mt-1">
+                  <button
+                    type="button"
+                    className={btnSuccess}
+                    onClick={() => handlePlace(ROW_FRONT)}
+                    disabled={loading}
+                    data-testid="place-front"
+                  >
+                    {t('place.front')}
+                  </button>
+                  <button
+                    type="button"
+                    className={btnSuccess}
+                    onClick={() => handlePlace(ROW_MIDDLE)}
+                    disabled={loading}
+                    data-testid="place-middle"
+                  >
+                    {t('place.middle')}
+                  </button>
+                  <button
+                    type="button"
+                    className={btnSuccess}
+                    onClick={() => handlePlace(ROW_BACK)}
+                    disabled={loading}
+                    data-testid="place-back"
+                  >
+                    {t('place.back')}
+                  </button>
+                </div>
+              </div>
+            )}
 
-        <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
+            {/* Player boards */}
+            <div className="grid gap-3 sm:grid-cols-2" data-tutorial="ofc-rows">
+              {state.players.map((p) => (
+                <div
+                  key={`player-${p.id}`}
+                  className={`p-3 rounded bg-black/20 ${p.id === state.currentPlayerIdx && isPlacing ? 'ring-1 ring-ds-warning' : ''}`}
+                  data-testid={`player-${p.id}`}
+                >
+                  <div className="flex items-center justify-between mb-2">
+                    <span className="text-ds-text-primary text-sm font-semibold">{playerName(p)}</span>
+                    <div className="flex items-center gap-2 text-xs">
+                      {p.fouled && <span className="text-ds-error font-semibold">{t('fouled')}</span>}
+                      {p.fantasyland && <span className="text-ds-accent font-semibold">{t('fantasyland')}</span>}
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    {renderRow(t('rows.front'), p.front, 3, `front-${p.id}`)}
+                    {renderRow(t('rows.middle'), p.middle, 5, `middle-${p.id}`)}
+                    {renderRow(t('rows.back'), p.back, 5, `back-${p.id}`)}
+                  </div>
+                  {isRoundEnd && (
+                    <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs">
+                      <span className="text-ds-text-primary" data-testid={`round-score-${p.id}`}>
+                        {t('roundScore', { score: p.roundScore })}
+                      </span>
+                      {p.royalty > 0 && <span className="text-ds-success">{t('royalty', { points: p.royalty })}</span>}
+                      <span className="text-ds-text-muted">{t('totalScore', { score: p.totalScore })}</span>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
 
-        <ActionLogSection
-          isEndPhase={isGameEnd}
-          actionLog={actionLog}
-          showActionLog={showActionLog}
-          hideActionLog={hideActionLog}
-        />
-      </div>
+            {isRoundEnd && (
+              <div className="mt-3 text-center text-ds-text-primary text-sm font-semibold">{t('roundEndTitle')}</div>
+            )}
 
-      {/* Footer: next round / reset */}
-      <GameFooter className={`${gameTheme.openfacechinese.footer} px-4 py-2.5`}>
-        <ErrorAlert message={error} onRetry={retry} />
-        <div className="flex flex-wrap gap-2 items-center">
-          {isGameEnd && <span className="text-ds-text-primary text-sm font-semibold mr-1">{t('gameEnd')}</span>}
+            <GameMessageBox
+              message={state.message}
+              messageCode={state.messageCode}
+              messageParams={state.messageParams}
+            />
 
-          {isRoundEnd && (
-            <button
-              type="button"
-              className={btnSuccess}
-              onClick={handleNext}
-              disabled={loading}
-              data-testid="next-button"
-            >
-              {t('next')}
-            </button>
-          )}
+            <ActionLogSection
+              isEndPhase={isGameEnd}
+              actionLog={actionLog}
+              showActionLog={showActionLog}
+              hideActionLog={hideActionLog}
+            />
+          </div>
 
-          <GameResetButton
-            isGameEnd={isGameEnd}
-            onReset={handleReset}
-            requestConfirm={requestConfirm}
-            loading={loading}
-            dataTutorial="ofc-reset-button"
-          />
-        </div>
-      </GameFooter>
+          {/* Footer: next round / reset */}
+          <GameFooter className={`${gameTheme.openfacechinese.footer} px-4 py-2.5`}>
+            <ErrorAlert message={error} onRetry={retry} />
+            <div className="flex flex-wrap gap-2 items-center">
+              {isGameEnd && <span className="text-ds-text-primary text-sm font-semibold mr-1">{t('gameEnd')}</span>}
+
+              {isRoundEnd && (
+                <button
+                  type="button"
+                  className={btnSuccess}
+                  onClick={handleNext}
+                  disabled={loading}
+                  data-testid="next-button"
+                >
+                  {t('next')}
+                </button>
+              )}
+
+              <GameResetButton
+                isGameEnd={isGameEnd}
+                onReset={handleReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="ofc-reset-button"
+              />
+            </div>
+          </GameFooter>
+        </>
+      )}
     </GamePageShell>
   );
 }

--- a/frontend/src/utils/cli/commands/openfacechineseCommands.test.ts
+++ b/frontend/src/utils/cli/commands/openfacechineseCommands.test.ts
@@ -11,7 +11,10 @@ describe('parseOpenfacechineseCommand', () => {
   it('parses place with row initials and indices', () => {
     expect(parseOpenfacechineseCommand('p f')).toEqual({ args: ['place', { row: 0 }] });
     expect(parseOpenfacechineseCommand('p m')).toEqual({ args: ['place', { row: 1 }] });
+    expect(parseOpenfacechineseCommand('p mid')).toEqual({ args: ['place', { row: 1 }] });
     expect(parseOpenfacechineseCommand('p b')).toEqual({ args: ['place', { row: 2 }] });
+    expect(parseOpenfacechineseCommand('p 0')).toEqual({ args: ['place', { row: 0 }] });
+    expect(parseOpenfacechineseCommand('p 1')).toEqual({ args: ['place', { row: 1 }] });
     expect(parseOpenfacechineseCommand('p 2')).toEqual({ args: ['place', { row: 2 }] });
   });
 

--- a/frontend/src/utils/cli/commands/openfacechineseCommands.test.ts
+++ b/frontend/src/utils/cli/commands/openfacechineseCommands.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { OPENFACECHINESE_HELP, parseOpenfacechineseCommand } from './openfacechineseCommands';
+
+describe('parseOpenfacechineseCommand', () => {
+  it('parses place with a row name', () => {
+    expect(parseOpenfacechineseCommand('place front')).toEqual({ args: ['place', { row: 0 }] });
+    expect(parseOpenfacechineseCommand('place middle')).toEqual({ args: ['place', { row: 1 }] });
+    expect(parseOpenfacechineseCommand('place back')).toEqual({ args: ['place', { row: 2 }] });
+  });
+
+  it('parses place with row initials and indices', () => {
+    expect(parseOpenfacechineseCommand('p f')).toEqual({ args: ['place', { row: 0 }] });
+    expect(parseOpenfacechineseCommand('p m')).toEqual({ args: ['place', { row: 1 }] });
+    expect(parseOpenfacechineseCommand('p b')).toEqual({ args: ['place', { row: 2 }] });
+    expect(parseOpenfacechineseCommand('p 2')).toEqual({ args: ['place', { row: 2 }] });
+  });
+
+  it('returns error for place without a valid row', () => {
+    expect('error' in parseOpenfacechineseCommand('place')).toBe(true);
+    expect('error' in parseOpenfacechineseCommand('place sideways')).toBe(true);
+  });
+
+  it('parses next (and aliases)', () => {
+    expect(parseOpenfacechineseCommand('n')).toEqual({ args: ['nextround'] });
+    expect(parseOpenfacechineseCommand('next')).toEqual({ args: ['nextround'] });
+    expect(parseOpenfacechineseCommand('nextround')).toEqual({ args: ['nextround'] });
+  });
+
+  it('parses log', () => {
+    expect(parseOpenfacechineseCommand('log')).toEqual({ args: ['log'] });
+  });
+
+  it('parses reset', () => {
+    expect(parseOpenfacechineseCommand('r')).toEqual({ args: ['reset'] });
+    expect(parseOpenfacechineseCommand('reset')).toEqual({ args: ['reset'] });
+  });
+
+  it('suggests a close command for a typo', () => {
+    const result = parseOpenfacechineseCommand('rese');
+    expect('error' in result && result.error).toContain('reset');
+  });
+
+  it('returns error for unknown command', () => {
+    expect('error' in parseOpenfacechineseCommand('xyz')).toBe(true);
+  });
+
+  it('exposes help text', () => {
+    expect(OPENFACECHINESE_HELP.length).toBeGreaterThan(0);
+    expect(OPENFACECHINESE_HELP.some((line) => line.includes('place'))).toBe(true);
+  });
+});

--- a/frontend/src/utils/cli/commands/openfacechineseCommands.ts
+++ b/frontend/src/utils/cli/commands/openfacechineseCommands.ts
@@ -1,0 +1,64 @@
+import type { openfacechineseApi } from '../../../api/gameApi';
+import { splitCommand, suggestCommand } from '../commandParserBase';
+import type { CliParseResult } from '../types';
+
+type OpenFaceChineseArgs = Parameters<typeof openfacechineseApi.exec>;
+
+const VALID_COMMANDS = ['p', 'place', 'n', 'next', 'nextround', 'log', 'r', 'reset', 'help', '?'];
+
+/** Maps a row token (name / initial / index) to the backend row index, or null if invalid. */
+function parseRow(token: string | undefined): number | null {
+  switch ((token ?? '').toLowerCase()) {
+    case 'front':
+    case 'f':
+    case '0':
+      return 0;
+    case 'middle':
+    case 'mid':
+    case 'm':
+    case '1':
+      return 1;
+    case 'back':
+    case 'b':
+    case '2':
+      return 2;
+    default:
+      return null;
+  }
+}
+
+/** Parse an Open Face Chinese Poker CLI command into API exec arguments. */
+export function parseOpenfacechineseCommand(input: string): CliParseResult<OpenFaceChineseArgs> {
+  const { cmd, args } = splitCommand(input);
+
+  switch (cmd) {
+    case 'p':
+    case 'place': {
+      const row = parseRow(args[0]);
+      if (row === null) return { error: 'Usage: place <front|middle|back>' };
+      return { args: ['place', { row }] };
+    }
+    case 'n':
+    case 'next':
+    case 'nextround':
+      return { args: ['nextround'] };
+    case 'log':
+      return { args: ['log'] };
+    case 'r':
+    case 'reset':
+      return { args: ['reset'] };
+    default: {
+      const suggestion = suggestCommand(cmd, VALID_COMMANDS);
+      if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
+      return { error: `Unknown command: ${cmd}` };
+    }
+  }
+}
+
+/** Help text for Open Face Chinese Poker CLI mode. */
+export const OPENFACECHINESE_HELP: string[] = [
+  'place <f|m|b>  - Place the pending card in the front / middle / back row',
+  'n/next         - Deal the next round',
+  'log            - Show action log',
+  'r/reset        - Reset game',
+];

--- a/frontend/src/utils/cli/commands/openfacechineseCommands.ts
+++ b/frontend/src/utils/cli/commands/openfacechineseCommands.ts
@@ -57,8 +57,8 @@ export function parseOpenfacechineseCommand(input: string): CliParseResult<OpenF
 
 /** Help text for Open Face Chinese Poker CLI mode. */
 export const OPENFACECHINESE_HELP: string[] = [
-  'place <f|m|b>  - Place the pending card in the front / middle / back row',
-  'n/next         - Deal the next round',
-  'log            - Show action log',
-  'r/reset        - Reset game',
+  'p/place <f|m|b> - Place the pending card in the front / middle / back row',
+  'n/next          - Deal the next round',
+  'log             - Show action log',
+  'r/reset         - Reset game',
 ];

--- a/frontend/src/utils/cli/formatters/openfacechineseFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/openfacechineseFormatter.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign, OpenFaceChinesePlayer, OpenFaceChineseResponse } from '../../../types/card';
+import { OpenFaceChinesePhase } from '../../../types/phases';
+import { formatOpenfacechineseState } from './openfacechineseFormatter';
+
+const card = (design: CardDesign, value: number): Card => ({ design, value });
+
+const player = (overrides: Partial<OpenFaceChinesePlayer> = {}): OpenFaceChinesePlayer => ({
+  id: 0,
+  isHuman: true,
+  front: [],
+  middle: [],
+  back: [],
+  pending: [],
+  roundScore: 0,
+  royalty: 0,
+  fouled: false,
+  fantasyland: false,
+  totalScore: 0,
+  ...overrides,
+});
+
+const baseState: OpenFaceChineseResponse = {
+  phase: OpenFaceChinesePhase.PLACING,
+  roundNumber: 1,
+  currentPlayerIdx: 0,
+  dealerIdx: 1,
+  currentCard: card('SPADE', 14),
+  gameEndFlag: false,
+  winnerIdx: -1,
+  isHumanTurn: true,
+  players: [player({ id: 0, isHuman: true, front: [card('HEART', 5)] }), player({ id: 1, isHuman: false })],
+  config: { cpuDifficulty: 1, playerCount: 2, targetRounds: 1 },
+  message: '',
+};
+
+describe('formatOpenfacechineseState', () => {
+  it('renders the header, round, and phase', () => {
+    const out = formatOpenfacechineseState(baseState);
+    expect(out).toContain('Open Face Chinese Poker');
+    expect(out).toContain('round: 1');
+    expect(out).toContain('phase: PLACING');
+  });
+
+  it('prompts to place the pending card on the human turn', () => {
+    const out = formatOpenfacechineseState(baseState);
+    expect(out).toContain('Place this card');
+    expect(out).toContain('You');
+    expect(out).toContain('CPU 1');
+  });
+
+  it('hides round scores during placing', () => {
+    const out = formatOpenfacechineseState(baseState);
+    expect(out).not.toContain('total:');
+  });
+
+  it('shows scores, royalty, foul, and fantasyland at round end', () => {
+    const out = formatOpenfacechineseState({
+      ...baseState,
+      phase: OpenFaceChinesePhase.ROUND_END,
+      isHumanTurn: false,
+      currentCard: undefined,
+      players: [
+        player({ id: 0, isHuman: true, roundScore: 6, royalty: 4, totalScore: 6, fantasyland: true }),
+        player({ id: 1, isHuman: false, roundScore: -6, totalScore: -6, fouled: true }),
+      ],
+    });
+    expect(out).toContain('total: 6');
+    expect(out).toContain('royalty +4');
+    expect(out).toContain('FANTASYLAND');
+    expect(out).toContain('FOULED');
+    expect(out).not.toContain('Place this card');
+  });
+
+  it('renders UNKNOWN for an unexpected phase', () => {
+    expect(formatOpenfacechineseState({ ...baseState, phase: 99 })).toContain('phase: UNKNOWN');
+  });
+});

--- a/frontend/src/utils/cli/formatters/openfacechineseFormatter.ts
+++ b/frontend/src/utils/cli/formatters/openfacechineseFormatter.ts
@@ -1,0 +1,49 @@
+import type { OpenFaceChinesePlayer, OpenFaceChineseResponse } from '../../../types/card';
+import { OpenFaceChinesePhase } from '../../../types/phases';
+import { formatCard, formatCardList, formatHeader, formatSeparator } from '../formatterBase';
+
+const PHASE_NAMES: Record<number, string> = {
+  [OpenFaceChinesePhase.PLACING]: 'PLACING',
+  [OpenFaceChinesePhase.ROUND_END]: 'ROUND END',
+  [OpenFaceChinesePhase.GAME_END]: 'GAME END',
+};
+
+/** Format one player's three rows plus any round-end scoring. */
+function formatPlayer(p: OpenFaceChinesePlayer, showScores: boolean): string[] {
+  const lines: string[] = [];
+  const name = p.isHuman ? 'You' : `CPU ${p.id}`;
+  const tags = [p.fouled ? 'FOULED' : '', p.fantasyland ? 'FANTASYLAND' : ''].filter(Boolean).join(' ');
+  lines.push(`${name}${tags ? ` (${tags})` : ''}`);
+  lines.push(`  front:  ${formatCardList(p.front) || '-'}`);
+  lines.push(`  middle: ${formatCardList(p.middle) || '-'}`);
+  lines.push(`  back:   ${formatCardList(p.back) || '-'}`);
+  if (showScores) {
+    const royalty = p.royalty > 0 ? ` (royalty +${p.royalty})` : '';
+    lines.push(`  round: ${p.roundScore}${royalty}  total: ${p.totalScore}`);
+  }
+  return lines;
+}
+
+/** Format an Open Face Chinese Poker game state as terminal text. */
+export function formatOpenfacechineseState(state: OpenFaceChineseResponse): string {
+  const lines: string[] = [];
+
+  lines.push(formatHeader('Open Face Chinese Poker'));
+  lines.push(`round: ${state.roundNumber}  phase: ${PHASE_NAMES[state.phase] ?? 'UNKNOWN'}`);
+
+  if (state.currentCard && state.isHumanTurn) {
+    lines.push(`Place this card: ${formatCard(state.currentCard)} (front/middle/back)`);
+  }
+  lines.push('');
+
+  const showScores = state.phase !== OpenFaceChinesePhase.PLACING;
+  for (const p of state.players) {
+    lines.push(...formatPlayer(p, showScores));
+    lines.push('');
+  }
+
+  if (state.message) lines.push(state.message);
+
+  lines.push(formatSeparator());
+  return lines.join('\n');
+}


### PR DESCRIPTION
## 概要
Open Face Chinese Poker (OFC) に CLI モード（`useCliMode`/`useCliGame`/`CliToggle`/`CliTerminal`）を追加し、他の対人カジノ系ゲームと機能パリティを揃えます（#2696）。

## 変更点
- **`utils/cli/commands/openfacechineseCommands.ts`** (新規) — `place <front|middle|back>`（`f/m/b`・`0/1/2` も可）/ `n/next` / `log` / `r/reset` のパーサ + HELP。exec シグネチャ `(command, { row })` に合わせた引数を返す。
- **`utils/cli/formatters/openfacechineseFormatter.ts`** (新規) — ラウンド・フェーズ・各プレイヤーの front/middle/back 3 段・配置待ちカード・ファウル/ファンタジーランド・ラウンド終了時の得点/ロイヤリティ/合計を整形。
- **`pages/OpenFaceChinesePage.tsx`** — `headerExtra` に `CliToggle`、本文を `cliEnabled` 分岐で `CliTerminal` に切替。

## テスト
- commands 9 + formatter 5 + page 1（CLI 端末表示・盤面非表示）。commands/formatter 14 + page 11 全 green。biome clean。

Closes #2696