### PR TITLE
feat(durak): highlight trump cards in the human hand (CUI)

### DIFF
--- a/internal/adapter/presenter/DurakCuiPresenter.go
+++ b/internal/adapter/presenter/DurakCuiPresenter.go
@@ -1,6 +1,7 @@
 package presenter
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -10,8 +11,23 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
+// durakHandStr renders the human's indexed hand, emphasizing trump cards so the
+// player can spot which cards beat any non-trump in attack and defense.
+func durakHandStr(player *domain.DurakPlayer, trumpSuit int) string {
+	parts := make([]string, player.GetCardsSize())
+	for i := range parts {
+		card := player.GetCard(i)
+		s := fmt.Sprintf("[%d]%s", i, cuiCardStr(card))
+		if card != nil && card.GetDesign() == trumpSuit {
+			s = color.BoldYellow(s)
+		}
+		parts[i] = s
+	}
+	return strings.Join(parts, "  ")
+}
+
 // durakPlayerStr returns the display string for a single Durak player.
-func durakPlayerStr(player *domain.DurakPlayer, i int, isAttacker, isDefender bool) string {
+func durakPlayerStr(player *domain.DurakPlayer, i int, isAttacker, isDefender bool, trumpSuit int) string {
 	var b strings.Builder
 	b.WriteString(cuiPlayerName(player, i))
 	if isAttacker {
@@ -27,7 +43,7 @@ func durakPlayerStr(player *domain.DurakPlayer, i int, isAttacker, isDefender bo
 	b.WriteString(i18n.Tf("durak.playerHand",
 		"count", strconv.Itoa(player.GetCardsSize())) + "\n")
 	if player.GetIsHuman() {
-		b.WriteString(cuiIndexedCardListStr(player) + "\n")
+		b.WriteString(durakHandStr(player, trumpSuit) + "\n")
 	}
 	return b.String()
 }
@@ -53,7 +69,7 @@ func (p *DurakCuiPresenter) Output(dg interfaces.DurakGame, lastErr error) strin
 		// Players
 		for i := 0; i < dg.GetPlayerCnt(); i++ {
 			b.WriteString(durakPlayerStr(dg.GetPlayer(i), i,
-				i == dg.GetAttackerIdx(), i == dg.GetDefenderIdx()))
+				i == dg.GetAttackerIdx(), i == dg.GetDefenderIdx(), dg.GetTrumpSuit()))
 		}
 
 		b.WriteString("----------\n")

--- a/internal/adapter/presenter/DurakCuiPresenter_test.go
+++ b/internal/adapter/presenter/DurakCuiPresenter_test.go
@@ -3,11 +3,13 @@
 package presenter_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 )
@@ -95,6 +97,27 @@ func TestDurakCuiPresenter_Output(t *testing.T) {
 		result := p.Output(d, nil)
 		assert.Contains(t, result, "SPADE 7")
 		assert.Contains(t, result, "SPADE 8")
+	})
+
+	t.Run("trump cards highlighted in human hand", func(t *testing.T) {
+		origNoColor := color.NoColor()
+		color.SetNoColor(false)
+		defer color.SetNoColor(origNoColor)
+
+		d := setupGame()
+		d.SetTrumpSuit(domain.CardDesignHeart)
+		human := d.GetPlayer(0)
+		human.Reset()
+		human.AddCard(domain.NewCard(domain.CardDesignHeart, 9, false)) // trump
+		human.AddCard(domain.NewCard(domain.CardDesignSpade, 7, false)) // non-trump
+
+		result := p.Output(d, nil)
+		// The card text itself carries a suit color, so assert on the bold-yellow
+		// opening code that wraps the trump card's index marker.
+		boldStart := strings.Split(color.BoldYellow("X"), "X")[0]
+		assert.Contains(t, result, boldStart+"[0]")    // trump card highlighted
+		assert.NotContains(t, result, boldStart+"[1]") // non-trump left plain
+		assert.Contains(t, result, "SPADE 7")
 	})
 
 	t.Run("finished player rendered", func(t *testing.T) {


### PR DESCRIPTION
## 概要
`DurakCuiPresenter` の人間の手札一覧で、トランプ（切り札）スートのカードを `color.BoldYellow` で強調表示します（#2575）。Durak はトランプの温存が肝で、攻撃/防御の両局面でトランプ識別が重要ですが、従来は無強調でした（攻撃者/防御者ラベルは強調済みなのに不整合）。

## 変更点
- `durakHandStr(player, trumpSuit)` ヘルパーを新設：各カードを `[i]<card>` 形式で出し、`card.GetDesign() == trumpSuit` のものを `color.BoldYellow` で強調。共有の `cuiIndexedCardListStr` は変更せず Durak ローカルに留める。
- `durakPlayerStr` に `trumpSuit` 引数を追加し、人間の手札描画を `durakHandStr` に切替。呼び出し側で `dg.GetTrumpSuit()` を渡す。
- 表示専用ロジックのみ（ゲーム状態は不変）。

## テスト
- `DurakCuiPresenter_test.go`: 既知の手札（トランプ Heart9 / 非トランプ Spade7）と `SetTrumpSuit` を用い、色付き時にトランプ札のインデックスマーカーが bold-yellow で包まれ、非トランプは包まれないことを検証。
- go test / golangci-lint green。

Closes #2575