### PR TITLE
feat(thirtyone): show best-suit total & knock notice in CUI

### DIFF
--- a/internal/adapter/presenter/ThirtyOneCuiPresenter.go
+++ b/internal/adapter/presenter/ThirtyOneCuiPresenter.go
@@ -63,6 +63,19 @@ func (p *ThirtyOneCuiPresenter) Output(g interfaces.ThirtyOneGame, lastErr error
 			return
 		}
 
+		// The best-suit total is the win condition (31), so surface the human's
+		// running total and announce a knock (which makes the round's last turn).
+		for i := 0; i < g.GetPlayerCnt(); i++ {
+			if hp := g.GetPlayer(i); hp.GetIsHuman() {
+				b.WriteString(i18n.Tf("thirtyone.yourBestSuit", "score", strconv.Itoa(hp.BestSuitScore())) + "\n")
+				break
+			}
+		}
+		if knocker := g.GetKnockerIdx(); knocker >= 0 {
+			b.WriteString(color.Yellow(i18n.Tf("thirtyone.knockNotice",
+				"name", cuiPlayerName(g.GetPlayer(knocker), knocker))) + "\n")
+		}
+
 		switch g.GetPhase() {
 		case domain.ThirtyOnePhaseDraw:
 			idx := g.GetCurrentPlayerIdx()

--- a/internal/adapter/presenter/ThirtyOneCuiPresenter_test.go
+++ b/internal/adapter/presenter/ThirtyOneCuiPresenter_test.go
@@ -57,6 +57,24 @@ func TestThirtyOneCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "k:") // knock help shown when no knocker
 	})
 
+	t.Run("human best-suit total shown in prompt", func(t *testing.T) {
+		m, players := setupThirtyOneCuiMock()
+		players[0].AddCard(domain.NewCard(domain.CardDesignClover, 10, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignClover, 7, false))
+		assert.Contains(t, p.Output(m, nil), "あなたのベストスート合計:")
+	})
+
+	t.Run("knock notice shown when someone has knocked", func(t *testing.T) {
+		m, _ := setupThirtyOneCuiMock()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetKnockerIdx")
+		m.On("GetKnockerIdx").Return(1)
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "CPU 1")
+		assert.Contains(t, result, "最終ターン")
+		// Knock help is no longer offered once a knock is in progress.
+		assert.NotContains(t, result, "k:")
+	})
+
 	t.Run("discard top shown", func(t *testing.T) {
 		m, _ := setupThirtyOneCuiMock()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetDiscardTop")

--- a/internal/i18n/locales/en/thirtyone.json
+++ b/internal/i18n/locales/en/thirtyone.json
@@ -15,6 +15,8 @@
   "promptDrawHelpStock": "ds: draw from stock",
   "promptDrawHelpDiscard": "dd: draw from discard",
   "promptKnockHelp": "k: knock (stand on your hand)",
+  "yourBestSuit": "Your best-suit total: {{score}} (31 to win)",
+  "knockNotice": "{{name}} knocked — this is the last turn",
   "promptDiscard": "{{name}} to act (discard phase)",
   "promptDiscardHelp": "d <idx>: discard a card",
   "promptThirtyOne": "{{name}} hit 31!",

--- a/internal/i18n/locales/ja/thirtyone.json
+++ b/internal/i18n/locales/ja/thirtyone.json
@@ -15,6 +15,8 @@
   "promptDrawHelpStock": "ds: 山札から引く",
   "promptDrawHelpDiscard": "dd: 捨て札から引く",
   "promptKnockHelp": "k: ノック (引かずに勝負)",
+  "yourBestSuit": "あなたのベストスート合計: {{score}} (31で勝利)",
+  "knockNotice": "{{name}} がノック — これが最終ターンです",
   "promptDiscard": "{{name}} の番です (ディスカードフェーズ)",
   "promptDiscardHelp": "d <idx>: カードを捨てる",
   "promptThirtyOne": "{{name}} が31を達成!",


### PR DESCRIPTION
## 概要
`ThirtyOneCuiPresenter` に、勝利条件であるベストスート合計（人間プレイヤー）と、ノック発生時の「{name} がノック — 最終ターン」通知を追加します（#2645）。Web 側にあるスートスコア表示とノックバナーに相当する情報が CUI に無く、CLI プレイヤーは手札を手集計する必要がありました。

## 変更点
- アクティブプレイのプロンプト先頭に `thirtyone.yourBestSuit`（人間の `BestSuitScore()`）を表示。
- `GetKnockerIdx() >= 0` のとき `thirtyone.knockNotice` を黄色で表示（最終ターン明示）。
- i18n `thirtyone.yourBestSuit` / `thirtyone.knockNotice` を ja/en（`internal/i18n`）に追加。CUI 変更のため i18n は internal 側（issue 記載の frontend パスは誤り）。

## テスト
- `ThirtyOneCuiPresenter_test.go`: ベストスート合計行の表示、ノック時の通知（CPU 1 / 最終ターン）と knock-help 非表示を検証。
- go test / golangci-lint green。

Closes #2645