### PR TITLE
feat(ginrummy): show deadwood total & knock-ability in CUI

### DIFF
--- a/internal/adapter/presenter/GinRummyCuiPresenter.go
+++ b/internal/adapter/presenter/GinRummyCuiPresenter.go
@@ -12,6 +12,33 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
+// ginRummyBestDeadwood returns the lowest deadwood value the player can reach by
+// discarding one card — the value that gates knocking (<= GinRummyKnockThreshold).
+func ginRummyBestDeadwood(player *domain.GinRummyPlayer) int {
+	n := player.GetCardsSize()
+	cards := make([]*domain.Card, n)
+	for i := 0; i < n; i++ {
+		cards[i] = player.GetCard(i)
+	}
+	best := -1
+	for skip := 0; skip < n; skip++ {
+		sub := make([]*domain.Card, 0, n-1)
+		for i, c := range cards {
+			if i != skip {
+				sub = append(sub, c)
+			}
+		}
+		_, deadwood := domain.FindBestMelds(sub)
+		if v := domain.CalcDeadwoodValue(deadwood); best < 0 || v < best {
+			best = v
+		}
+	}
+	if best < 0 {
+		best = 0
+	}
+	return best
+}
+
 // ginRummyPlayerStr returns the display string for a single GinRummy player.
 func ginRummyPlayerStr(player *domain.GinRummyPlayer, i int) string {
 	var b strings.Builder
@@ -66,6 +93,13 @@ func (p *GinRummyCuiPresenter) Output(g interfaces.GinRummyGame, lastErr error) 
 			currentIdx := g.GetCurrentPlayerIdx()
 			b.WriteString(i18n.Tf("ginrummy.promptDiscard",
 				"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
+			if cur := g.GetPlayer(currentIdx); cur.GetIsHuman() {
+				best := ginRummyBestDeadwood(cur)
+				b.WriteString(i18n.Tf("ginrummy.deadwoodLine", "value", strconv.Itoa(best)) + "\n")
+				if best <= domain.GinRummyKnockThreshold {
+					b.WriteString(color.Yellow(i18n.T("ginrummy.canKnockNow")) + "\n")
+				}
+			}
 			b.WriteString(i18n.T("ginrummy.promptDiscardHelp") + "\n")
 			b.WriteString(i18n.T("ginrummy.promptKnockHelp") + "\n")
 		case domain.GinRummyPhaseLayoff:

--- a/internal/adapter/presenter/GinRummyCuiPresenter_test.go
+++ b/internal/adapter/presenter/GinRummyCuiPresenter_test.go
@@ -154,6 +154,47 @@ func TestGinRummyCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "k <idx>")
 	})
 
+	t.Run("discard phase shows deadwood and knock-available for a low hand", func(t *testing.T) {
+		m, players := setupGinRummyCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.GinRummyPhaseDiscard)
+		// Two runs + two low strays: discarding one stray leaves deadwood <= 10.
+		for _, v := range []int{1, 2, 3, 4, 5, 6} {
+			players[0].AddCard(domain.NewCard(domain.CardDesignSpade, v, false))
+		}
+		for _, v := range []int{7, 8, 9} {
+			players[0].AddCard(domain.NewCard(domain.CardDesignHeart, v, false))
+		}
+		players[0].AddCard(domain.NewCard(domain.CardDesignDiamond, 2, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignClover, 3, false))
+
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "現在のデッドウッド:")
+		assert.Contains(t, result, "ノック可能")
+	})
+
+	t.Run("discard phase hides knock-available for a high hand", func(t *testing.T) {
+		m, players := setupGinRummyCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.GinRummyPhaseDiscard)
+		// Scattered high cards with no runs or sets: deadwood stays well above 10.
+		highCards := []struct {
+			d, v int
+		}{
+			{domain.CardDesignSpade, 13}, {domain.CardDesignHeart, 12}, {domain.CardDesignClover, 11},
+			{domain.CardDesignDiamond, 10}, {domain.CardDesignSpade, 9}, {domain.CardDesignHeart, 8},
+			{domain.CardDesignClover, 7}, {domain.CardDesignDiamond, 6}, {domain.CardDesignSpade, 4},
+			{domain.CardDesignHeart, 3}, {domain.CardDesignClover, 2},
+		}
+		for _, c := range highCards {
+			players[0].AddCard(domain.NewCard(c.d, c.v, false))
+		}
+
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "現在のデッドウッド:")
+		assert.NotContains(t, result, "ノック可能")
+	})
+
 	t.Run("layoff phase shows commands", func(t *testing.T) {
 		m, _ := setupGinRummyCuiMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")

--- a/internal/adapter/presenter/GinRummyCuiPresenter_test.go
+++ b/internal/adapter/presenter/GinRummyCuiPresenter_test.go
@@ -169,7 +169,7 @@ func TestGinRummyCuiPresenter_Output(t *testing.T) {
 		players[0].AddCard(domain.NewCard(domain.CardDesignClover, 3, false))
 
 		result := p.Output(m, nil)
-		assert.Contains(t, result, "現在のデッドウッド:")
+		assert.Contains(t, result, "最小デッドウッド(1枚捨て後):")
 		assert.Contains(t, result, "ノック可能")
 	})
 
@@ -191,7 +191,7 @@ func TestGinRummyCuiPresenter_Output(t *testing.T) {
 		}
 
 		result := p.Output(m, nil)
-		assert.Contains(t, result, "現在のデッドウッド:")
+		assert.Contains(t, result, "最小デッドウッド(1枚捨て後):")
 		assert.NotContains(t, result, "ノック可能")
 	})
 

--- a/internal/i18n/locales/en/ginrummy.json
+++ b/internal/i18n/locales/en/ginrummy.json
@@ -16,6 +16,8 @@
   "promptDrawHelpStock": "ds: draw from stock",
   "promptDrawHelpDiscard": "dd: draw from discard",
   "promptDiscard": "{{name}} to act (discard phase)",
+  "deadwoodLine": "Current deadwood: {{value}}",
+  "canKnockNow": "Can knock now (deadwood ≤ 10)",
   "promptDiscardHelp": "d <idx>: discard a card",
   "promptKnockHelp": "k <idx>: knock (discard + knock)",
   "promptLayoff": "Layoff phase",

--- a/internal/i18n/locales/en/ginrummy.json
+++ b/internal/i18n/locales/en/ginrummy.json
@@ -16,7 +16,7 @@
   "promptDrawHelpStock": "ds: draw from stock",
   "promptDrawHelpDiscard": "dd: draw from discard",
   "promptDiscard": "{{name}} to act (discard phase)",
-  "deadwoodLine": "Current deadwood: {{value}}",
+  "deadwoodLine": "Best deadwood after discard: {{value}}",
   "canKnockNow": "Can knock now (deadwood ≤ 10)",
   "promptDiscardHelp": "d <idx>: discard a card",
   "promptKnockHelp": "k <idx>: knock (discard + knock)",

--- a/internal/i18n/locales/ja/ginrummy.json
+++ b/internal/i18n/locales/ja/ginrummy.json
@@ -16,6 +16,8 @@
   "promptDrawHelpStock": "ds・・・山札から引く",
   "promptDrawHelpDiscard": "dd・・・捨て札から引く",
   "promptDiscard": "手番: {{name}} (ディスカードフェーズ)",
+  "deadwoodLine": "現在のデッドウッド: {{value}}点",
+  "canKnockNow": "ノック可能 (デッドウッド10点以下)",
   "promptDiscardHelp": "d <idx>・・・カードを捨てる",
   "promptKnockHelp": "k <idx>・・・ノック (カードを捨ててノック)",
   "promptLayoff": "レイオフフェーズ",

--- a/internal/i18n/locales/ja/ginrummy.json
+++ b/internal/i18n/locales/ja/ginrummy.json
@@ -16,7 +16,7 @@
   "promptDrawHelpStock": "ds・・・山札から引く",
   "promptDrawHelpDiscard": "dd・・・捨て札から引く",
   "promptDiscard": "手番: {{name}} (ディスカードフェーズ)",
-  "deadwoodLine": "現在のデッドウッド: {{value}}点",
+  "deadwoodLine": "最小デッドウッド(1枚捨て後): {{value}}点",
   "canKnockNow": "ノック可能 (デッドウッド10点以下)",
   "promptDiscardHelp": "d <idx>・・・カードを捨てる",
   "promptKnockHelp": "k <idx>・・・ノック (カードを捨ててノック)",


### PR DESCRIPTION
## 概要
`GinRummyCuiPresenter` のディスカードフェーズで、人間プレイヤーの現在のデッドウッド点と「ノック可能(≤10)」かどうかを手札行の後に表示します（#2553）。Web 版はこれを常時表示していますが、CUI は素のインデックス列のみで、CLI プレイヤーは手作業で点数計算が必要でした。

## 変更点
- `ginRummyBestDeadwood(player)` ヘルパーを追加：1枚捨てた後に到達できる最小デッドウッド（=ノック判定値）を、エクスポート済みの `domain.FindBestMelds`/`CalcDeadwoodValue` で全捨て札候補をループして算出（`cpuDiscardOrKnock` と同じロジック）。
- ディスカードフェーズで現在の手番が人間のとき `ginrummy.deadwoodLine` を表示、`<= GinRummyKnockThreshold(10)` なら `ginrummy.canKnockNow` を黄色で表示。
- i18n `ginrummy.deadwoodLine` / `ginrummy.canKnockNow` を ja/en に追加。

## テスト
- `GinRummyCuiPresenter_test.go`: 低デッドウッド手札（2ラン+低い余り）で「現在のデッドウッド:」+「ノック可能」表示、高デッドウッド手札（メルド無しの高札散在）で「ノック可能」非表示を検証。
- go test / golangci-lint green。

Closes #2553