### PR TITLE
feat(clocksolitaire): show current card's target clock pile in CUI

### DIFF
--- a/internal/adapter/presenter/ClockSolitaireCuiPresenter.go
+++ b/internal/adapter/presenter/ClockSolitaireCuiPresenter.go
@@ -60,6 +60,14 @@ func (pr *ClockSolitaireCuiPresenter) Output(g interfaces.ClockSolitaireGame, la
 		// Current card (hand)
 		if cc := g.GetCurrentCard(); cc != nil {
 			b.WriteString(i18n.Tf("clocksolitaire.currentCard", "card", cuiCardStr(cc)) + "\n")
+			// Mirror the web's flight-target highlight: A-Q map to their hour pile, K to the center.
+			if g.GetPhase() == domain.ClockSolitairePhasePlaying {
+				if cc.GetValue() == 13 {
+					b.WriteString(i18n.T("clocksolitaire.placementKing") + "\n")
+				} else {
+					b.WriteString(i18n.Tf("clocksolitaire.placementHint", "hour", strconv.Itoa(cc.GetValue())) + "\n")
+				}
+			}
 		}
 
 		cuiErrorBlock(b, lastErr)

--- a/internal/adapter/presenter/ClockSolitaireCuiPresenter_test.go
+++ b/internal/adapter/presenter/ClockSolitaireCuiPresenter_test.go
@@ -20,6 +20,37 @@ func TestClockSolitaireCuiPresenterOutput_Playing(t *testing.T) {
 	result := p.Output(gg, nil)
 	assert.Contains(t, result, "Clock Solitaire")
 	assert.Contains(t, result, "ステップ: 0")
+	// Current card is SPADE 5 → placement hint points to the 5 o'clock pile.
+	assert.Contains(t, result, "5時の山へ")
+}
+
+func TestClockSolitaireCuiPresenterOutput_KingPlacement(t *testing.T) {
+	gg := new(interfaces.MockClockSolitaireGame)
+	setupClockSolitaireWebMockDefaults(gg)
+	gg.ExpectedCalls = nil
+	gg.On("GetPhase").Return(domain.ClockSolitairePhasePlaying)
+	gg.On("GetStepCount").Return(3)
+	gg.On("GetCurrentCard").Return(domain.NewCard(domain.CardDesignHeart, 13, false))
+
+	var piles [domain.ClockSolitairePileCount][]*domain.ClockSolitaireCard
+	var fuc [domain.ClockSolitairePileCount]int
+	for i := range domain.ClockSolitairePileCount {
+		piles[i] = make([]*domain.ClockSolitaireCard, domain.ClockSolitaireCardsPerPile)
+		for j := range domain.ClockSolitaireCardsPerPile {
+			piles[i][j] = &domain.ClockSolitaireCard{
+				Card:   domain.NewCard(domain.CardDesignSpade, i+1, false),
+				FaceUp: true,
+			}
+		}
+		fuc[i] = 4
+	}
+	gg.On("GetPiles").Return(piles)
+	gg.On("GetFaceUpCount").Return(fuc)
+
+	p := &ClockSolitaireCuiPresenter{}
+	result := p.Output(gg, nil)
+	assert.Contains(t, result, "中央(K)の山へ")
+	assert.NotContains(t, result, "時の山へ")
 }
 
 func TestClockSolitaireCuiPresenterOutput_Error(t *testing.T) {

--- a/internal/i18n/locales/en/clocksolitaire.json
+++ b/internal/i18n/locales/en/clocksolitaire.json
@@ -6,6 +6,8 @@
   "centerLabel": "[Center K]",
   "pileFootnote": " ({{up}}/{{total}})",
   "currentCard": "In hand: {{card}}",
+  "placementHint": "  → to the {{hour}} o'clock pile",
+  "placementKing": "  → to the center (K) pile",
   "stepLine": "Steps: {{count}}",
   "gameClearLine": "Game clear! Steps: {{count}}",
   "gameOverLine": "Game over. Steps: {{count}}",

--- a/internal/i18n/locales/ja/clocksolitaire.json
+++ b/internal/i18n/locales/ja/clocksolitaire.json
@@ -6,6 +6,8 @@
   "centerLabel": "[中央K]",
   "pileFootnote": " ({{up}}/{{total}})",
   "currentCard": "手持ち: {{card}}",
+  "placementHint": "  → {{hour}}時の山へ",
+  "placementKing": "  → 中央(K)の山へ",
   "stepLine": "ステップ: {{count}}",
   "gameClearLine": "ゲームクリア！ ステップ数: {{count}}",
   "gameOverLine": "ゲームオーバー ステップ数: {{count}}",


### PR DESCRIPTION
## 概要
`ClockSolitaireCuiPresenter` で、手持ちの現在カードがどの時計位置へ置かれるか（1〜12→対応時、K→中央）を1行で案内します（#2574）。Web は `isFlightTarget` でリング強調していますが、CUI 利用者は値→時刻を毎回暗算する必要がありました。

## 変更点
- 現在カード行の直後に、プレイ中フェーズのみ配置先を表示：値13(K)→`clocksolitaire.placementKing`（中央）、それ以外→`clocksolitaire.placementHint`（{{hour}}時の山）。Web と同じ値→時刻マッピング。
- ゲームクリア/オーバー時は非表示（フェーズガード）。
- i18n `clocksolitaire.placementHint`/`placementKing` を ja/en に追加。

## テスト
- `ClockSolitaireCuiPresenter_test.go`: 現在カード SPADE 5 → 「5時の山へ」、King → 「中央(K)の山へ」かつ「時の山へ」非表示を検証。
- go test / golangci-lint green。

Closes #2574