### PR TITLE
feat(fortythieves): add move-command syntax hint to CUI

### DIFF
--- a/internal/adapter/presenter/FortyThievesCuiPresenter.go
+++ b/internal/adapter/presenter/FortyThievesCuiPresenter.go
@@ -80,6 +80,7 @@ func (p *FortyThievesCuiPresenter) Output(ft interfaces.FortyThievesGame, lastEr
 			if ft.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
 			}
+			b.WriteString(i18n.T("fortythieves.cuiCommandHint") + "\n")
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(ft.GetMoveCount())) + "\n")
 		case domain.FortyThievesPhaseGameClear:

--- a/internal/adapter/presenter/FortyThievesCuiPresenter_test.go
+++ b/internal/adapter/presenter/FortyThievesCuiPresenter_test.go
@@ -53,6 +53,7 @@ func TestFortyThievesCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "Waste: [空]")
 		assert.Contains(t, result, "列0:")
 		assert.Contains(t, result, "手数: 0")
+		assert.Contains(t, result, "操作: m で移動")
 	})
 
 	t.Run("with waste card", func(t *testing.T) {
@@ -85,6 +86,7 @@ func TestFortyThievesCuiPresenter_Output(t *testing.T) {
 		p := new(FortyThievesCuiPresenter)
 		result := p.Output(fg, nil)
 		assert.Contains(t, result, "ゲームクリア")
+		assert.NotContains(t, result, "操作: m で移動")
 	})
 
 	t.Run("game over", func(t *testing.T) {
@@ -96,6 +98,7 @@ func TestFortyThievesCuiPresenter_Output(t *testing.T) {
 		p := new(FortyThievesCuiPresenter)
 		result := p.Output(fg, nil)
 		assert.Contains(t, result, "ゲームオーバー")
+		assert.NotContains(t, result, "操作: m で移動")
 	})
 
 	t.Run("stalemate", func(t *testing.T) {

--- a/internal/i18n/locales/en/fortythieves.json
+++ b/internal/i18n/locales/en/fortythieves.json
@@ -5,6 +5,7 @@
   "helpMoveWF": "  m w f                move waste to foundation",
   "helpMoveTF": "  m t <col> f          move tableau to foundation",
   "helpMoveTT": "  m t <col> <idx> t <col>  move tableau to tableau",
+  "cuiCommandHint": "Commands: m to move (e.g. m w f / m t0 f / m t0 t3), d=draw, u=undo, h=hint",
   "helpGiveUp": "  g                    give up",
   "helpHint": "  h                    hint",
   "helpAutoComplete": "  ac                   auto-complete",

--- a/internal/i18n/locales/en/fortythieves.json
+++ b/internal/i18n/locales/en/fortythieves.json
@@ -5,7 +5,7 @@
   "helpMoveWF": "  m w f                move waste to foundation",
   "helpMoveTF": "  m t <col> f          move tableau to foundation",
   "helpMoveTT": "  m t <col> <idx> t <col>  move tableau to tableau",
-  "cuiCommandHint": "Commands: m to move (e.g. m w f / m t0 f / m t0 t3), d=draw, u=undo, h=hint",
+  "cuiCommandHint": "Commands: m to move (e.g. m w f / m t 0 f), d=draw, u=undo, h=hint",
   "helpGiveUp": "  g                    give up",
   "helpHint": "  h                    hint",
   "helpAutoComplete": "  ac                   auto-complete",

--- a/internal/i18n/locales/ja/fortythieves.json
+++ b/internal/i18n/locales/ja/fortythieves.json
@@ -5,7 +5,7 @@
   "helpMoveWF": "  m w f                move waste to foundation",
   "helpMoveTF": "  m t <col> f          move tableau to foundation",
   "helpMoveTT": "  m t <col> <idx> t <col>  move tableau to tableau",
-  "cuiCommandHint": "操作: m で移動 (例 m w f / m t0 f / m t0 t3), d=ドロー, u=アンドゥ, h=ヒント",
+  "cuiCommandHint": "操作: m で移動 (例 m w f / m t 0 f), d=ドロー, u=アンドゥ, h=ヒント",
   "helpGiveUp": "  g                    give up",
   "helpHint": "  h                    hint",
   "helpAutoComplete": "  ac                   auto-complete",

--- a/internal/i18n/locales/ja/fortythieves.json
+++ b/internal/i18n/locales/ja/fortythieves.json
@@ -5,6 +5,7 @@
   "helpMoveWF": "  m w f                move waste to foundation",
   "helpMoveTF": "  m t <col> f          move tableau to foundation",
   "helpMoveTT": "  m t <col> <idx> t <col>  move tableau to tableau",
+  "cuiCommandHint": "操作: m で移動 (例 m w f / m t0 f / m t0 t3), d=ドロー, u=アンドゥ, h=ヒント",
   "helpGiveUp": "  g                    give up",
   "helpHint": "  h                    hint",
   "helpAutoComplete": "  ac                   auto-complete",


### PR DESCRIPTION
## 概要
`FortyThievesCuiPresenter` の PLAYING フェーズ出力に、カード移動コマンドの構文ヒントを1行追加します（#2576）。従来は盤面と手数のみで、CUI 利用者は `m`/`d`/`u`/`h` の構文を推測するしかありませんでした。

## 変更点
- PLAYING フェーズで `cuiSolitaireMoves`（手数）の直前に `fortythieves.cuiCommandHint` を表示。実際のコントローラ文法（`m w f` / `m t0 f` / `m t0 t3`、`d`=draw / `u`=undo / `h`=hint）に一致。
- GAME_CLEAR / GAME_OVER フェーズでは非表示。
- i18n `fortythieves.cuiCommandHint` を ja/en に追加（CUI 変更のため internal/i18n）。

## テスト
- `FortyThievesCuiPresenter_test.go`: PLAYING でヒント表示、GAME_CLEAR / GAME_OVER で非表示を検証。
- go test / golangci-lint green。

Closes #2576