### PR TITLE
feat(pokersquares): add place-command syntax hint to CUI

### DIFF
--- a/internal/adapter/presenter/PokerSquaresCuiPresenter.go
+++ b/internal/adapter/presenter/PokerSquaresCuiPresenter.go
@@ -57,6 +57,10 @@ func (pr *PokerSquaresCuiPresenter) Output(p interfaces.PokerSquaresGame, lastEr
 			"total", strconv.Itoa(domain.PokerSquaresTotalCells),
 			"score", strconv.Itoa(p.TotalScore())) + "\n")
 
+		if p.GetPhase() != domain.PokerSquaresPhaseComplete {
+			b.WriteString(i18n.T("pokersquares.cuiPlaceHint") + "\n")
+		}
+
 		cuiErrorBlock(b, lastErr)
 
 		if p.GetPhase() == domain.PokerSquaresPhaseComplete {

--- a/internal/adapter/presenter/PokerSquaresCuiPresenter_test.go
+++ b/internal/adapter/presenter/PokerSquaresCuiPresenter_test.go
@@ -33,6 +33,7 @@ func TestPokerSquaresCuiPresenter_Output_Playing(t *testing.T) {
 	assert.Contains(t, out, "Poker Squares")
 	assert.Contains(t, out, "手持ちカード:")
 	assert.Contains(t, out, "配置済み: 0/25")
+	assert.Contains(t, out, "カードを置く: p")
 }
 
 func TestPokerSquaresCuiPresenter_Output_Complete(t *testing.T) {
@@ -57,6 +58,7 @@ func TestPokerSquaresCuiPresenter_Output_Complete(t *testing.T) {
 	out := p.Output(pg, nil)
 	assert.Contains(t, out, "ゲーム終了")
 	assert.Contains(t, out, "20")
+	assert.NotContains(t, out, "カードを置く: p")
 }
 
 func TestPokerSquaresCuiPresenter_ActionLog_Playing(t *testing.T) {

--- a/internal/i18n/locales/en/pokersquares.json
+++ b/internal/i18n/locales/en/pokersquares.json
@@ -7,5 +7,6 @@
   "currentCard": "Current card: {{card}}",
   "currentCardNone": "Current card: (none)",
   "placedLine": "Placed: {{placed}}/{{total}}  Total score: {{score}}",
+  "cuiPlaceHint": "Place a card: p <row> <col> or place <row> <col> (0-based, e.g. p 2 3)",
   "gameComplete": "Game complete! Total score: {{score}}"
 }

--- a/internal/i18n/locales/ja/pokersquares.json
+++ b/internal/i18n/locales/ja/pokersquares.json
@@ -7,5 +7,6 @@
   "currentCard": "手持ちカード: {{card}}",
   "currentCardNone": "手持ちカード: (なし)",
   "placedLine": "配置済み: {{placed}}/{{total}}  合計得点: {{score}}",
+  "cuiPlaceHint": "カードを置く: p <行> <列> または place <行> <列> (0始まり, 例 p 2 3)",
   "gameComplete": "ゲーム終了 合計得点: {{score}}"
 }


### PR DESCRIPTION
## 概要
`PokerSquaresCuiPresenter` のグリッド出力後に、カード配置コマンドの構文と座標形式を1行で案内します（#2588）。従来は座標付きグリッドのみで、CUI 利用者は配置コマンド（`p`/`place`）と 0 始まり座標を推測するしかありませんでした。

## 変更点
- 非 Complete フェーズで `placedLine` の後に `pokersquares.cuiPlaceHint` を表示（コントローラ文法 `p <row> <col>` / `place`、0 始まり、例 `p 2 3`）。
- Complete フェーズでは非表示。
- i18n `pokersquares.cuiPlaceHint` を ja/en に追加（CUI 変更のため internal/i18n）。

## テスト
- `PokerSquaresCuiPresenter_test.go`: Playing でヒント表示、Complete で非表示を検証。
- go test / golangci-lint green。

Closes #2588