### PR TITLE
feat(reddog): winning ranks & raise/stay guide in spread decision

### DIFF
--- a/frontend/src/pages/RedDogPage.test.tsx
+++ b/frontend/src/pages/RedDogPage.test.tsx
@@ -148,6 +148,8 @@ describe('RedDogPage', () => {
     for (const r of [6, 7, 8, 9]) {
       expect(screen.getByTestId(`reddog-ghost-${r}`)).toBeInTheDocument();
     }
+    // Text summary mirrors the ghost chips for at-a-glance / non-visual reading.
+    expect(screen.getByTestId('reddog-winners-text')).toHaveTextContent('6, 7, 8, 9');
   });
 
   it('marks the hit ghost chip in end phase', async () => {

--- a/frontend/src/pages/RedDogPage.tsx
+++ b/frontend/src/pages/RedDogPage.tsx
@@ -199,6 +199,11 @@ function RedDogPageContent() {
                       thirdRank={isEndPhase && state.thirdCard ? redDogRank(state.thirdCard) : null}
                       label={t('label.winners')}
                     />
+                    {reddogWinningRanks(state.initialCards).length > 0 && (
+                      <div className="text-ds-text-muted text-center text-xs mt-1" data-testid="reddog-winners-text">
+                        {t('label.winners')}: {reddogWinningRanks(state.initialCards).map(rankLabel).join(', ')}
+                      </div>
+                    )}
                   </>
                 )}
               </div>

--- a/internal/adapter/presenter/RedDogCuiPresenter.go
+++ b/internal/adapter/presenter/RedDogCuiPresenter.go
@@ -23,11 +23,11 @@ func redDogRankOf(c *domain.Card) int {
 	return c.GetValue()
 }
 
-// redDogRankLabel renders a Red Dog rank as a short label (A/K/Q/J or number).
+// redDogRankLabel renders a Red Dog rank as a short label (K/Q/J or number).
+// Winning ranks are always strictly below the higher card (max 14), so the
+// highest possible label here is K (13); Ace never appears.
 func redDogRankLabel(rank int) string {
 	switch rank {
-	case 14:
-		return "A"
 	case 13:
 		return "K"
 	case 12:
@@ -53,7 +53,7 @@ func redDogWinningRanksStr(initial []*domain.Card) string {
 	for r := lo + 1; r < hi; r++ {
 		labels = append(labels, redDogRankLabel(r))
 	}
-	return strings.Join(labels, ",")
+	return strings.Join(labels, ", ")
 }
 
 // Output ゲーム状態を出力

--- a/internal/adapter/presenter/RedDogCuiPresenter.go
+++ b/internal/adapter/presenter/RedDogCuiPresenter.go
@@ -15,6 +15,47 @@ import (
 // RedDogCuiPresenter レッドドッグCUIプレゼンタークラス
 type RedDogCuiPresenter struct{}
 
+// redDogRankOf maps a card to Red Dog rank space (Ace high = 14).
+func redDogRankOf(c *domain.Card) int {
+	if c.GetValue() == 1 {
+		return 14
+	}
+	return c.GetValue()
+}
+
+// redDogRankLabel renders a Red Dog rank as a short label (A/K/Q/J or number).
+func redDogRankLabel(rank int) string {
+	switch rank {
+	case 14:
+		return "A"
+	case 13:
+		return "K"
+	case 12:
+		return "Q"
+	case 11:
+		return "J"
+	default:
+		return strconv.Itoa(rank)
+	}
+}
+
+// redDogWinningRanksStr lists the ranks strictly between the two initial cards —
+// the ranks the third card must hit to win.
+func redDogWinningRanksStr(initial []*domain.Card) string {
+	if len(initial) != 2 {
+		return ""
+	}
+	lo, hi := redDogRankOf(initial[0]), redDogRankOf(initial[1])
+	if lo > hi {
+		lo, hi = hi, lo
+	}
+	labels := make([]string, 0, hi-lo)
+	for r := lo + 1; r < hi; r++ {
+		labels = append(labels, redDogRankLabel(r))
+	}
+	return strings.Join(labels, ",")
+}
+
 // Output ゲーム状態を出力
 func (rp *RedDogCuiPresenter) Output(rd interfaces.RedDogGame, lastErr error) string {
 	var sb strings.Builder
@@ -31,6 +72,10 @@ func (rp *RedDogCuiPresenter) Output(rd interfaces.RedDogGame, lastErr error) st
 	}
 	if rd.GetPhase() == domain.RedDogPhaseSpreadDecision || rd.GetPhase() == domain.RedDogPhaseEnd {
 		sb.WriteString(i18n.Tf("reddog.spreadLine", "spread", strconv.Itoa(rd.GetSpread())) + "\n")
+	}
+	if rd.GetPhase() == domain.RedDogPhaseSpreadDecision {
+		sb.WriteString(i18n.Tf("reddog.cuiSpreadGuide",
+			"ranks", redDogWinningRanksStr(rd.GetInitialCards())) + "\n")
 	}
 
 	initial := rd.GetInitialCards()

--- a/internal/adapter/presenter/RedDogCuiPresenter_test.go
+++ b/internal/adapter/presenter/RedDogCuiPresenter_test.go
@@ -65,6 +65,32 @@ func TestRedDogCuiPresenter_Output_SpreadDecision(t *testing.T) {
 	assert.Contains(t, result, "INITIAL")
 	assert.Contains(t, result, "スプレッド: 4")
 	assert.Contains(t, result, "アンテ: 100")
+	// Winning ranks strictly between 5 and 10 are 6,7,8,9, plus the raise/stay guide.
+	assert.Contains(t, result, "勝てるランク: 6,7,8,9")
+	assert.Contains(t, result, "raise")
+}
+
+func TestRedDogCuiPresenter_Output_SpreadGuideFaceCards(t *testing.T) {
+	p := new(RedDogCuiPresenter)
+	m := new(interfaces.MockRedDogGame)
+	cards := []*domain.Card{
+		domain.NewCard(domain.CardDesignSpade, 10, false),
+		domain.NewCard(domain.CardDesignHeart, 1, false), // Ace high (14)
+	}
+	m.On("GetChips").Return(900)
+	m.On("GetPhase").Return(domain.RedDogPhaseSpreadDecision)
+	m.On("GetInitialCards").Return(cards)
+	m.On("GetThirdCard").Return((*domain.Card)(nil))
+	m.On("GetGameEndFlag").Return(false)
+	m.On("GetAnte").Return(100)
+	m.On("GetRaise").Return(0)
+	m.On("GetSpread").Return(3)
+	m.On("GetResult").Return(domain.GameResult(0))
+	m.On("GetTotalPayout").Return(0)
+
+	result := p.Output(m, nil)
+	// Ranks strictly between 10 and Ace(14): J,Q,K.
+	assert.Contains(t, result, "勝てるランク: J,Q,K")
 }
 
 func TestRedDogCuiPresenter_Output_EndWin(t *testing.T) {

--- a/internal/adapter/presenter/RedDogCuiPresenter_test.go
+++ b/internal/adapter/presenter/RedDogCuiPresenter_test.go
@@ -66,7 +66,7 @@ func TestRedDogCuiPresenter_Output_SpreadDecision(t *testing.T) {
 	assert.Contains(t, result, "スプレッド: 4")
 	assert.Contains(t, result, "アンテ: 100")
 	// Winning ranks strictly between 5 and 10 are 6,7,8,9, plus the raise/stay guide.
-	assert.Contains(t, result, "勝てるランク: 6,7,8,9")
+	assert.Contains(t, result, "勝てるランク: 6, 7, 8, 9")
 	assert.Contains(t, result, "raise")
 }
 
@@ -90,7 +90,7 @@ func TestRedDogCuiPresenter_Output_SpreadGuideFaceCards(t *testing.T) {
 
 	result := p.Output(m, nil)
 	// Ranks strictly between 10 and Ace(14): J,Q,K.
-	assert.Contains(t, result, "勝てるランク: J,Q,K")
+	assert.Contains(t, result, "勝てるランク: J, Q, K")
 }
 
 func TestRedDogCuiPresenter_Output_EndWin(t *testing.T) {
@@ -166,6 +166,19 @@ func TestRedDogCuiPresenter_PhaseStr_AllBranches(t *testing.T) {
 	} {
 		assert.Equal(t, expect, p.phaseStr(phase))
 	}
+}
+
+func TestRedDogWinningRanksStr(t *testing.T) {
+	// Higher card first exercises the lo/hi swap.
+	reversed := []*domain.Card{
+		domain.NewCard(domain.CardDesignSpade, 10, false),
+		domain.NewCard(domain.CardDesignHeart, 5, false),
+	}
+	assert.Equal(t, "6, 7, 8, 9", redDogWinningRanksStr(reversed))
+	// A non-pair of two cards always yields a non-empty list at decision time,
+	// but a malformed (non-2) slice is guarded.
+	assert.Equal(t, "", redDogWinningRanksStr(nil))
+	assert.Equal(t, "", redDogWinningRanksStr([]*domain.Card{domain.NewCard(domain.CardDesignSpade, 5, false)}))
 }
 
 func TestRedDogCuiPresenter_ActionLogOutput(t *testing.T) {

--- a/internal/i18n/locales/en/reddog.json
+++ b/internal/i18n/locales/en/reddog.json
@@ -8,6 +8,7 @@
   "anteLine": "ante: {{ante}}",
   "raiseInline": "  raise: {{raise}}",
   "spreadLine": "spread: {{spread}}",
+  "cuiSpreadGuide": "Winning ranks: {{ranks}} | raise <amt> / stay: s",
   "initialHeader": "INITIAL",
   "thirdHeader": "THIRD",
   "phaseBet": "BET",

--- a/internal/i18n/locales/ja/reddog.json
+++ b/internal/i18n/locales/ja/reddog.json
@@ -8,6 +8,7 @@
   "anteLine": "アンテ: {{ante}}",
   "raiseInline": "  レイズ: {{raise}}",
   "spreadLine": "スプレッド: {{spread}}",
+  "cuiSpreadGuide": "勝てるランク: {{ranks}} | レイズ: raise <額> / そのまま: s",
   "initialHeader": "INITIAL",
   "thirdHeader": "THIRD",
   "phaseBet": "BET",


### PR DESCRIPTION
## 概要
Red Dog の SPREAD_DECISION で、勝てるランク一覧とレイズ/ステイの案内を CUI に追加し、フロントにも勝ちランクのテキスト要約を追加します（#2590）。

## 変更点
### CUI (`RedDogCuiPresenter`)
- SPREAD_DECISION フェーズのスプレッド行の後に `reddog.cuiSpreadGuide` を表示：2枚の初期カードの間にあるランク（=勝てるランク）の一覧 + `raise <額>` / `s`(stay) の案内。
- ヘルパー `redDogRankOf`(Ace=14) / `redDogRankLabel`(A/K/Q/J/数字) / `redDogWinningRanksStr` を追加。
- i18n `reddog.cuiSpreadGuide` を ja/en に追加。

### フロント (`RedDogPage`)
- 既存の `WinningRankGhosts`（視覚表示）の下に、既存 util `reddogWinningRanks`+`rankLabel` を使った勝ちランクのテキスト要約（`reddog-winners-text`）を追加。

## テスト
- Go: SpreadDecision で勝ちランク(6,7,8,9)+raise案内、フェイスカード境界(10〜A→J,Q,K)を検証。
- フロント: spread decision でテキスト要約「6, 7, 8, 9」表示を検証。
- go test / golangci-lint / vitest / biome green。

Closes #2590