### PR TITLE
feat(tressette): explain thirds scoring/reset rule in CUI

### DIFF
--- a/internal/adapter/presenter/TressetteCuiPresenter.go
+++ b/internal/adapter/presenter/TressetteCuiPresenter.go
@@ -53,6 +53,7 @@ func (p *TressetteCuiPresenter) Output(g interfaces.TressetteGame, lastErr error
 			"athird", strconv.Itoa(thirds[0]),
 			"b", strconv.Itoa(scores[1]),
 			"bthird", strconv.Itoa(thirds[1])) + "\n")
+		b.WriteString(i18n.T("tressette.thirdsRule") + "\n")
 
 		for i := 0; i < g.GetPlayerCnt(); i++ {
 			if player := g.GetPlayer(i); player != nil {

--- a/internal/adapter/presenter/TressetteCuiPresenter_test.go
+++ b/internal/adapter/presenter/TressetteCuiPresenter_test.go
@@ -51,6 +51,8 @@ func TestTressetteCuiPresenter_Output(t *testing.T) {
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "Tressette")
 		assert.NotEmpty(t, result)
+		// The thirds-conversion rule is explained alongside the score line.
+		assert.Contains(t, result, "サード: 3トリック")
 	})
 
 	t.Run("trick end prompt", func(t *testing.T) {

--- a/internal/i18n/locales/en/tressette.json
+++ b/internal/i18n/locales/en/tressette.json
@@ -7,6 +7,7 @@
   "helpSetTarget": "  st <n>               target points (default 21)",
   "round": "Round: {{round}}  Trick: {{trick}}",
   "teamScores": "Team A: {{a}} pts (this round {{athird}}/3)   Team B: {{b}} pts (this round {{bthird}}/3)",
+  "thirdsRule": "Thirds: every 3 tricks won convert to 1 point, then the counter resets",
   "playerLine": "{{name}} [Team {{team}}]: {{cards}} cards, {{tricks}} tricks",
   "gameEnd": "Game over! Team {{team}} wins!",
   "promptPlay": "Turn: {{name}}",

--- a/internal/i18n/locales/ja/tressette.json
+++ b/internal/i18n/locales/ja/tressette.json
@@ -7,6 +7,7 @@
   "helpSetTarget": "  st <n>               目標点設定 (既定21)",
   "round": "ラウンド: {{round}}  トリック: {{trick}}",
   "teamScores": "チームA: {{a}}点 (今R {{athird}}/3)   チームB: {{b}}点 (今R {{bthird}}/3)",
+  "thirdsRule": "サード: 3トリック獲得ごとに1点に換算され、カウンタはリセットされます",
   "playerLine": "{{name}} [チーム{{team}}]: {{cards}}枚 {{tricks}}トリック",
   "gameEnd": "ゲーム終了！ チーム{{team}}の勝利です！",
   "promptPlay": "手番: {{name}}",


### PR DESCRIPTION
## 概要
`TressetteCuiPresenter` のスコア行の後に、サード（thirds）の得点換算・リセットルールを説明する行を追加します（#2655）。従来は「{{athird}}/3」と生数値のみで、CUI プレイヤーは「3トリックごとに1点となりカウンタがリセットされる」ルールを推測するしかありませんでした（Web は thirdsTooltip で補足済み）。

## 変更点
- スコア行直後に `tressette.thirdsRule` を出力。
- i18n `tressette.thirdsRule` を ja/en に追加（CUI 変更のため internal/i18n）。

## テスト
- `TressetteCuiPresenter_test.go`: play フェーズ出力にサード説明が含まれることを検証。
- go test / golangci-lint green。

Closes #2655