### PR TITLE
feat(pageone): show play condition & urgent declare prompt in CUI

### DIFF
--- a/internal/adapter/presenter/PageOneCuiPresenter.go
+++ b/internal/adapter/presenter/PageOneCuiPresenter.go
@@ -71,9 +71,13 @@ func (p *PageOneCuiPresenter) Output(g interfaces.PageOneGame, lastErr error) st
 				currentIdx := g.GetCurrentPlayerIdx()
 				player := g.GetPlayer(currentIdx)
 				fmt.Fprintf(b, "%s\n", i18n.Tf("pageone.turnLine", "name", cuiPlayerName(player, currentIdx)))
+				if top := g.GetDiscardTop(); top != nil {
+					b.WriteString(i18n.Tf("pageone.cuiPlayCondition", "card", cuiCardStr(top)) + "\n")
+				}
 				b.WriteString(i18n.T("pageone.cmdPlay") + "\n")
 				b.WriteString(i18n.T("pageone.cmdDraw") + "\n")
 			case domain.PageOnePhaseMustDeclare:
+				b.WriteString(color.Yellow(i18n.T("pageone.cuiMustDeclare")) + "\n")
 				b.WriteString(i18n.T("pageone.declarePhase") + "\n")
 				b.WriteString(i18n.T("pageone.cmdDeclare") + "\n")
 				b.WriteString(i18n.T("pageone.cmdSkip") + "\n")

--- a/internal/adapter/presenter/PageOneCuiPresenter_test.go
+++ b/internal/adapter/presenter/PageOneCuiPresenter_test.go
@@ -74,6 +74,8 @@ func TestPageOneCuiPresenter_Output(t *testing.T) {
 
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "捨て札: HEART 7")
+		// Play condition references the matchable discard top during the play phase.
+		assert.Contains(t, result, "出せる条件: HEART 7")
 	})
 
 	t.Run("must declare phase", func(t *testing.T) {
@@ -82,6 +84,7 @@ func TestPageOneCuiPresenter_Output(t *testing.T) {
 		m.On("GetPhase").Return(domain.PageOnePhaseMustDeclare)
 
 		result := p.Output(m, nil)
+		assert.Contains(t, result, "今すぐ「ページワン」を宣言")
 		assert.Contains(t, result, "宣言フェーズ")
 		assert.Contains(t, result, "declare")
 		assert.Contains(t, result, "skip")

--- a/internal/i18n/locales/en/pageone.json
+++ b/internal/i18n/locales/en/pageone.json
@@ -14,6 +14,8 @@
   "turnLine": "Turn: {{name}}",
   "cmdPlay": "play <idx>  ... play a card",
   "cmdDraw": "draw        ... draw a card",
+  "cuiPlayCondition": "Play condition: same suit or rank as {{card}}",
+  "cuiMustDeclare": "⚠ Declare \"Page One\" now!",
   "declarePhase": "Declaration phase: only 1 card left!",
   "cmdDeclare": "declare     ... declare Page One!",
   "cmdSkip": "skip        ... skip declaration (penalty: draw 2)",

--- a/internal/i18n/locales/ja/pageone.json
+++ b/internal/i18n/locales/ja/pageone.json
@@ -14,6 +14,8 @@
   "turnLine": "手番: {{name}}",
   "cmdPlay": "play <idx>・・・カードを出す",
   "cmdDraw": "draw・・・カードを引く",
+  "cuiPlayCondition": "出せる条件: {{card}} と同じスートまたはランク",
+  "cuiMustDeclare": "⚠ 今すぐ「ページワン」を宣言してください！",
   "declarePhase": "宣言フェーズ: 手札が残り1枚です！",
   "cmdDeclare": "declare・・・「ページワン！」と宣言する",
   "cmdSkip": "skip・・・宣言をスキップ（ペナルティ: 2枚引く）",


### PR DESCRIPTION
## 概要
`PageOneCuiPresenter` に、PLAY フェーズの出せる条件（捨て札トップと同じスート/ランク）と、MUST_DECLARE フェーズの強調された宣言プロンプトを追加します（#2589）。

## 変更点
- PLAY フェーズ: ターン行の後に `pageone.cuiPlayCondition`（`{{card}} と同じスートまたはランク`）を表示。プレイ判定は `card.GetDesign()==top.GetDesign() || card.GetValue()==top.GetValue()`（PageOne.go L409）に一致。
- MUST_DECLARE フェーズ: `color.Yellow` で `pageone.cuiMustDeclare`（「今すぐ宣言してください！」）を強調表示。
- i18n `pageone.cuiPlayCondition` / `pageone.cuiMustDeclare` を ja/en に追加。

## テスト
- `PageOneCuiPresenter_test.go`: PLAY フェーズの条件行表示、MUST_DECLARE の強調プロンプト表示を検証。
- go test / golangci-lint green。

Closes #2589