### PR TITLE
feat(speed): show flip-command help when stuck in CUI

### DIFF
--- a/internal/adapter/presenter/SpeedCuiPresenter.go
+++ b/internal/adapter/presenter/SpeedCuiPresenter.go
@@ -55,6 +55,7 @@ func (p *SpeedCuiPresenter) Output(s interfaces.SpeedGame, lastErr error) string
 		switch s.GetPhase() {
 		case domain.SpeedPhaseStuck:
 			b.WriteString(color.Yellow(i18n.T("speed.promptStuck")) + "\n")
+			b.WriteString(i18n.T("speed.promptStuckHelp") + "\n")
 		}
 
 		// Outcome

--- a/internal/adapter/presenter/SpeedCuiPresenter_test.go
+++ b/internal/adapter/presenter/SpeedCuiPresenter_test.go
@@ -84,6 +84,14 @@ func TestSpeedCuiPresenter_Output(t *testing.T) {
 
 		result := p.Output(s, nil)
 		assert.Contains(t, result, "膠着状態")
+		// The flip-command help line accompanies the stuck message.
+		assert.Contains(t, result, "f / flip")
+	})
+
+	t.Run("does not show stuck help during normal play", func(t *testing.T) {
+		s := setupSpeedWebTest()
+		result := p.Output(s, nil)
+		assert.NotContains(t, result, "f / flip")
 	})
 }
 

--- a/internal/i18n/locales/en/speed.json
+++ b/internal/i18n/locales/en/speed.json
@@ -10,6 +10,7 @@
   "centerCard": "[{{idx}}] {{card}} ",
   "hintLine": "[Hint] play card [{{ci}}] on center pile [{{pi}}]",
   "promptStuck": "Stuck. Use flip to flip the center cards.",
+  "promptStuckHelp": "Command: f / flip — both players flip a new card to break the deadlock",
   "winHuman": "You win!",
   "winCpu": "CPU wins..."
 }

--- a/internal/i18n/locales/ja/speed.json
+++ b/internal/i18n/locales/ja/speed.json
@@ -10,6 +10,7 @@
   "centerCard": "[{{idx}}] {{card}} ",
   "hintLine": "[ヒント] カード[{{ci}}]を台札[{{pi}}]に出せます",
   "promptStuck": "膠着状態です。flip コマンドでカードをめくってください。",
+  "promptStuckHelp": "操作: f / flip → お互いが山札から新しいカードをめくり、膠着を解消します",
   "winHuman": "あなたの勝ちです！",
   "winCpu": "CPUの勝ちです..."
 }


### PR DESCRIPTION
## 概要
`SpeedCuiPresenter` のスタック（`SpeedPhaseStuck`）表示の直後に、デッドロックを解消するフリップ操作の案内行を追加します（#2568）。既存の `promptStuck` は "flip" に言及しますが `f` ショートカットや手順は示しておらず、初見のターミナル利用者が手詰まりで止まりがちでした。

## 変更点
- スタック時のみ `speed.promptStuckHelp` を表示（コントローラの受理コマンド `f` / `flip` に一致 — SpeedCuiController L46）。
- i18n `speed.promptStuckHelp` を ja/en に追加。

## テスト
- `SpeedCuiPresenter_test.go`: スタック時に "f / flip" 案内が表示され、通常プレイ時には表示されないことを検証。
- go test / golangci-lint green。

Closes #2568