### PR TITLE
feat(sevencardstud): show betting action prompt with call/raise amounts in CUI

### DIFF
--- a/internal/adapter/presenter/SevenCardStudCuiPresenter.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter.go
@@ -111,6 +111,28 @@ func (p *SevenCardStudCuiPresenter) Output(s interfaces.SevenCardStudGame, lastE
 			}
 		}
 
+		phase := s.GetPhase()
+		isBettingStreet := phase >= domain.SevenCardStudPhaseThirdStreet && phase <= domain.SevenCardStudPhaseSeventhStreet
+		if !s.GetGameEndFlag() && isBettingStreet {
+			turnIdx := s.GetCurrentTurn()
+			cur := s.GetPlayer(turnIdx)
+			if cur != nil && cur.GetIsHuman() && !cur.GetFolded() {
+				toCall := s.GetLastBet() - cur.GetCurrentBet()
+				if toCall < 0 {
+					toCall = 0
+				}
+				b.WriteString("----------\n")
+				if toCall == 0 {
+					b.WriteString(i18n.Tf("sevencardstud.actionPromptCheck",
+						"raise", strconv.Itoa(s.GetMinRaise())) + "\n")
+				} else {
+					b.WriteString(i18n.Tf("sevencardstud.actionPrompt",
+						"call", strconv.Itoa(toCall),
+						"raise", strconv.Itoa(s.GetMinRaise())) + "\n")
+				}
+			}
+		}
+
 		results := s.GetRoundResults()
 		if len(results) > 0 && (s.GetPhase() == domain.SevenCardStudPhaseEnd || s.GetPhase() == domain.SevenCardStudPhaseShowdown) {
 			b.WriteString("==========\n")

--- a/internal/adapter/presenter/SevenCardStudCuiPresenter_test.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter_test.go
@@ -37,6 +37,39 @@ func TestSevenCardStudCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "♣5")
 	})
 
+	t.Run("action prompt shows call amount on human betting turn", func(t *testing.T) {
+		s, players := makeSevenCardStudForPresenter()
+		s.SetPhase(domain.SevenCardStudPhaseThirdStreet)
+		s.SetCurrentTurn(0)
+		s.SetLastBet(5)
+		players[0].SetCurrentBet(0)
+
+		result := p.Output(s, nil)
+		assert.Contains(t, result, "コール 5")
+		assert.Contains(t, result, "最低レイズ")
+	})
+
+	t.Run("action prompt shows check when nothing to call", func(t *testing.T) {
+		s, players := makeSevenCardStudForPresenter()
+		s.SetPhase(domain.SevenCardStudPhaseThirdStreet)
+		s.SetCurrentTurn(0)
+		s.SetLastBet(0)
+		players[0].SetCurrentBet(0)
+
+		result := p.Output(s, nil)
+		assert.Contains(t, result, "チェック可")
+	})
+
+	t.Run("no action prompt on a CPU betting turn", func(t *testing.T) {
+		s := func() *domain.SevenCardStud { s, _ := makeSevenCardStudForPresenter(); return s }()
+		s.SetPhase(domain.SevenCardStudPhaseThirdStreet)
+		s.SetCurrentTurn(1)
+		s.SetLastBet(5)
+
+		result := p.Output(s, nil)
+		assert.NotContains(t, result, "あなたの手番")
+	})
+
 	t.Run("ante and bring-in info displayed", func(t *testing.T) {
 		s, _ := makeSevenCardStudForPresenter()
 		s.SetPhase(domain.SevenCardStudPhaseThirdStreet)

--- a/internal/i18n/locales/en/sevencardstud.json
+++ b/internal/i18n/locales/en/sevencardstud.json
@@ -52,6 +52,8 @@
   "resultKickers": " (kickers: {{kickers}})",
   "wonAmount": " → won {{total}} chips",
   "muckPrompt": "Muck? (m=muck / sh=show)",
+  "actionPrompt": "Your turn: call {{call}} / min raise {{raise}} / fold",
+  "actionPromptCheck": "Your turn: check / min bet {{raise}} / fold",
   "rebuyPrompt": "Rebuy? ({{chips}} chips, used {{used}}/{{max}}) (rb=rebuy / sr=skip)",
   "addonPrompt": "Add-on? ({{chips}} chips) (ad=addon / sa=skip)",
   "gameEnd": "Game over"

--- a/internal/i18n/locales/ja/sevencardstud.json
+++ b/internal/i18n/locales/ja/sevencardstud.json
@@ -52,6 +52,8 @@
   "resultKickers": " (キッカー: {{kickers}})",
   "wonAmount": " → {{total}}チップ獲得",
   "muckPrompt": "マックしますか? (m=マック / sh=ショー)",
+  "actionPrompt": "あなたの手番: コール {{call}} / 最低レイズ {{raise}} / フォールド可",
+  "actionPromptCheck": "あなたの手番: チェック可 / 最低ベット {{raise}} / フォールド可",
   "rebuyPrompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済) (rb=リバイ / sr=スキップ)",
   "addonPrompt": "アドオンしますか? ({{chips}}チップ) (ad=アドオン / sa=スキップ)",
   "gameEnd": "ゲーム終了"


### PR DESCRIPTION
## 概要
`SevenCardStudCuiPresenter` に、人間のベッティング手番でコール額・最低レイズ額・チェック可否を案内する手番プロンプトを追加します（#2573）。マック/リバイには専用プロンプトがあるのに通常ベッティングラウンドの行動指針が欠けており、CUI 利用者は妥当なベット額を逆算する必要がありました。

## 変更点
- ベッティングストリート（Third〜Seventh）かつ現手番が人間（未フォールド）のとき、行動プロンプトを表示。
  - コール額 = `GetLastBet() - player.GetCurrentBet()`。0 なら `actionPromptCheck`（チェック可）、>0 なら `actionPrompt`（コール {{call}}）。最低レイズ = `GetMinRaise()`。
- CPU 手番・終了/ショーダウン・リバイでは非表示。
- i18n `sevencardstud.actionPrompt` / `actionPromptCheck` を ja/en に追加。

## テスト
- `SevenCardStudCuiPresenter_test.go`: コール額表示（call 5）、ベットなし時のチェック表示、CPU 手番での非表示を検証。
- go test / golangci-lint green。

Closes #2573