### PR TITLE
feat(contractrummy): branch play help on contract-met status in CUI

### DIFF
--- a/internal/adapter/presenter/ContractRummyCuiPresenter.go
+++ b/internal/adapter/presenter/ContractRummyCuiPresenter.go
@@ -103,8 +103,14 @@ func (p *ContractRummyCuiPresenter) Output(g interfaces.ContractRummyGame, lastE
 			currentIdx := g.GetCurrentPlayerIdx()
 			b.WriteString(i18n.Tf("contractrummy.promptPlay",
 				"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
-			b.WriteString(i18n.T("contractrummy.promptPlayHelpMeldContract") + "\n")
-			b.WriteString(i18n.T("contractrummy.promptPlayHelpMeldExtra") + "\n")
+			if cur := g.GetPlayer(currentIdx); cur != nil && cur.IsContractMet() {
+				// Contract already down: extra melds / layoffs are optional, discard ends the turn.
+				b.WriteString(i18n.T("contractrummy.promptPlayHelpAfterContract") + "\n")
+				b.WriteString(i18n.T("contractrummy.promptPlayHelpMeldExtra") + "\n")
+			} else {
+				b.WriteString(i18n.T("contractrummy.promptPlayHelpContractRequired") + "\n")
+				b.WriteString(i18n.T("contractrummy.promptPlayHelpMeldContract") + "\n")
+			}
 			b.WriteString(i18n.T("contractrummy.promptPlayHelpLayoff") + "\n")
 			b.WriteString(i18n.T("contractrummy.promptPlayHelpDiscard") + "\n")
 		case domain.ContractRummyPhaseRoundEnd:

--- a/internal/adapter/presenter/ContractRummyCuiPresenter_test.go
+++ b/internal/adapter/presenter/ContractRummyCuiPresenter_test.go
@@ -55,6 +55,8 @@ func TestContractRummyCuiPresenter_Output(t *testing.T) {
 		m, _ := setupContractRummyCuiMock(domain.ContractRummyPhasePlay, false)
 		out := p.Output(m, nil)
 		assert.NotEmpty(t, out)
+		// Contract not yet met → the help emphasizes meeting it first.
+		assert.Contains(t, out, "コントラクト達成が必須")
 	})
 
 	t.Run("round end", func(t *testing.T) {
@@ -85,6 +87,9 @@ func TestContractRummyCuiPresenter_Output(t *testing.T) {
 		})
 		out := p.Output(m, nil)
 		assert.NotEmpty(t, out)
+		// Contract met → optional extra melds / discard-to-end help, not the required prompt.
+		assert.Contains(t, out, "コントラクト達成済み")
+		assert.NotContains(t, out, "コントラクト達成が必須")
 	})
 }
 

--- a/internal/i18n/locales/en/contractrummy.json
+++ b/internal/i18n/locales/en/contractrummy.json
@@ -23,6 +23,8 @@
   "promptDrawHelpStock": "ds: draw from stock",
   "promptDrawHelpDiscard": "dd: take the discard top",
   "promptPlay": "{{name}} to act (play phase)",
+  "promptPlayHelpContractRequired": "▶ You must meet this round's contract first",
+  "promptPlayHelpAfterContract": "▶ Contract met: extra melds/layoffs are optional, or discard to end",
   "promptPlayHelpMeldContract": "mc <a,b,c> <d,e,f>: meet the round contract",
   "promptPlayHelpMeldExtra": "me <a,b,c>: lay an extra meld (after contract met)",
   "promptPlayHelpLayoff": "lo <pIdx> <mIdx> <cIdx>: add a card to an existing meld",

--- a/internal/i18n/locales/ja/contractrummy.json
+++ b/internal/i18n/locales/ja/contractrummy.json
@@ -23,6 +23,8 @@
   "promptDrawHelpStock": "ds・・・山札から引く",
   "promptDrawHelpDiscard": "dd・・・捨て札トップを取る",
   "promptPlay": "手番: {{name}} (プレイフェーズ)",
+  "promptPlayHelpContractRequired": "▶ まずこのラウンドのコントラクト達成が必須です",
+  "promptPlayHelpAfterContract": "▶ コントラクト達成済み: 追加メルド/レイオフ（任意）または捨て札で終了",
   "promptPlayHelpMeldContract": "mc <a,b,c> <d,e,f>・・・コントラクトを場に出す",
   "promptPlayHelpMeldExtra": "me <a,b,c>・・・追加メルド（コントラクト達成後）",
   "promptPlayHelpLayoff": "lo <pIdx> <mIdx> <cIdx>・・・既存メルドにカード追加",


### PR DESCRIPTION
## 概要
`ContractRummyCuiPresenter` の PLAY フェーズのヘルプを、現プレイヤーの契約達成状況で分岐させます（#2616）。従来は meldContract/meldExtra/layoff/discard の4ヘルプを無条件に列挙しており、達成済みか否かで取るべき行動が変わるのに区別がありませんでした。

## 変更点
- `player.IsContractMet()` で分岐：
  - 未達成 → `promptPlayHelpContractRequired`（達成必須）+ meldContract ヘルプ。
  - 達成済み → `promptPlayHelpAfterContract`（追加メルド/レイオフ任意・捨て札で終了）+ meldExtra ヘルプ。
  - layoff/discard ヘルプは両分岐で維持。
- i18n `promptPlayHelpContractRequired` / `promptPlayHelpAfterContract` を ja/en に追加。

## テスト
- `ContractRummyCuiPresenter_test.go`: 未達成時に「達成が必須」、達成時に「達成済み」表示かつ「必須」非表示を検証。
- go test / golangci-lint green。

Closes #2616