### PR TITLE
feat(kalooki): show opening-threshold hint for unopened player in CUI

### DIFF
--- a/internal/adapter/presenter/KalookiCuiPresenter.go
+++ b/internal/adapter/presenter/KalookiCuiPresenter.go
@@ -86,6 +86,9 @@ func (p *KalookiCuiPresenter) Output(g interfaces.KalookiGame, lastErr error) st
 			currentIdx := g.GetCurrentPlayerIdx()
 			b.WriteString(i18n.Tf("kalooki.promptMeld",
 				"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
+			if cur := g.GetPlayer(currentIdx); cur != nil && !cur.HasOpened() {
+				b.WriteString(i18n.Tf("kalooki.openingHint", "n", strconv.Itoa(g.GetOpeningThreshold())) + "\n")
+			}
 			b.WriteString(i18n.T("kalooki.promptMeldHelpMeld") + "\n")
 			b.WriteString(i18n.T("kalooki.promptMeldHelpLayoff") + "\n")
 			b.WriteString(i18n.T("kalooki.promptMeldHelpDiscard") + "\n")

--- a/internal/adapter/presenter/KalookiCuiPresenter_test.go
+++ b/internal/adapter/presenter/KalookiCuiPresenter_test.go
@@ -53,7 +53,11 @@ func TestKalookiCuiPresenter_Output(t *testing.T) {
 
 	t.Run("meld phase", func(t *testing.T) {
 		m, _ := setupKalookiCuiMock(domain.KalookiPhaseMeld, false)
-		assert.NotEmpty(t, p.Output(m, nil))
+		out := p.Output(m, nil)
+		assert.NotEmpty(t, out)
+		// Current player has not opened → opening-threshold hint is shown.
+		assert.Contains(t, out, "開設には")
+		assert.Contains(t, out, "51")
 	})
 
 	t.Run("round end", func(t *testing.T) {
@@ -79,7 +83,10 @@ func TestKalookiCuiPresenter_Output(t *testing.T) {
 			domain.NewCard(domain.CardDesignHeart, 5, false),
 			domain.NewCard(domain.CardDesignDiamond, 5, false),
 		})
-		assert.NotEmpty(t, p.Output(m, nil))
+		out := p.Output(m, nil)
+		assert.NotEmpty(t, out)
+		// Already opened → no opening-threshold hint.
+		assert.NotContains(t, out, "開設には")
 	})
 }
 

--- a/internal/i18n/locales/en/kalooki.json
+++ b/internal/i18n/locales/en/kalooki.json
@@ -23,6 +23,7 @@
   "promptDrawHelpStock": "ds: draw from stock",
   "promptDrawHelpDiscard": "dd: take the discard top",
   "promptMeld": "{{name}} to act (meld phase)",
+  "openingHint": "Opening requires melds totaling at least {{n}} points",
   "promptMeldHelpMeld": "m <a,b,c> [<d,e,f>]: lay meld(s)",
   "promptMeldHelpLayoff": "lo <pIdx> <mIdx> <cIdx>: add a card to an existing meld",
   "promptMeldHelpDiscard": "d <idx>: discard a card",

--- a/internal/i18n/locales/ja/kalooki.json
+++ b/internal/i18n/locales/ja/kalooki.json
@@ -23,6 +23,7 @@
   "promptDrawHelpStock": "ds・・・山札から引く",
   "promptDrawHelpDiscard": "dd・・・捨て札トップを取る",
   "promptMeld": "手番: {{name}} (メルドフェーズ)",
+  "openingHint": "開設には合計 {{n}} 点以上のメルドが必要です",
   "promptMeldHelpMeld": "m <a,b,c> [<d,e,f>]・・・メルドを場に出す",
   "promptMeldHelpLayoff": "lo <pIdx> <mIdx> <cIdx>・・・既存メルドにカード追加",
   "promptMeldHelpDiscard": "d <idx>・・・カードを捨てる",


### PR DESCRIPTION
## 概要
`KalookiCuiPresenter` の MELD フェーズで、現プレイヤーがまだオープンしていないとき、開設に必要な点数しきい値を表示します（#2686）。Web は `openingHint` でこれを表示しますが、CUI には文脈がなく未オープンのプレイヤーがいつ開設すべきか分かりませんでした。

## 変更点
- MELD フェーズで `!player.HasOpened()` のとき `kalooki.openingHint`（`GetOpeningThreshold()` 点）を表示。オープン済みは従来通り。
- i18n `kalooki.openingHint` を ja/en に追加（Web の openingHint と同等の文言、CUI 変更のため internal/i18n）。
- 注: 受け入れ条件の「現在 X 点」はメルド未配置のため算出不可で、Web も閾値のみ表示のため閾値表示に統一。

## テスト
- `KalookiCuiPresenter_test.go`: 未オープン時に「開設には…51…」表示、オープン済みで非表示を検証。
- go test / golangci-lint green。

Closes #2686