### PR TITLE
feat(conquian): warn about forced-use of taken discard in CUI

### DIFF
--- a/internal/adapter/presenter/ConquianCuiPresenter.go
+++ b/internal/adapter/presenter/ConquianCuiPresenter.go
@@ -74,6 +74,9 @@ func (p *ConquianCuiPresenter) Output(g interfaces.ConquianGame, lastErr error) 
 			currentIdx := g.GetCurrentPlayerIdx()
 			b.WriteString(i18n.Tf("conquian.promptMeld",
 				"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
+			if g.GetTookDiscard() {
+				b.WriteString(color.Yellow(i18n.T("conquian.forcedUse")) + "\n")
+			}
 			b.WriteString(i18n.T("conquian.promptMeldHelp") + "\n")
 			b.WriteString(i18n.T("conquian.promptDiscardHelp") + "\n")
 		case domain.ConquianPhaseRoundEnd:

--- a/internal/adapter/presenter/ConquianCuiPresenter_test.go
+++ b/internal/adapter/presenter/ConquianCuiPresenter_test.go
@@ -32,6 +32,7 @@ func setupConquianCuiMock(phase domain.ConquianPhase, ended bool, winner int) (*
 	m.On("GetCurrentPlayerIdx").Return(0)
 	m.On("GetWinnerIdx").Return(winner)
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	m.On("GetTookDiscard").Return(false)
 	m.On("GetPlayerCnt").Return(2)
 	m.On("GetPlayer", 0).Return(players[0])
 	m.On("GetPlayer", 1).Return(players[1])
@@ -63,6 +64,17 @@ func TestConquianCuiPresenter_Output(t *testing.T) {
 		})
 		result := p.Output(m, nil)
 		assert.NotEmpty(t, result)
+		// No discard taken → no forced-use warning.
+		assert.NotContains(t, result, "必ず")
+	})
+
+	t.Run("forced-use warning shown after taking a discard", func(t *testing.T) {
+		m, _ := setupConquianCuiMock(domain.ConquianPhaseMeld, false, -1)
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetTookDiscard")
+		m.On("GetTookDiscard").Return(true)
+
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "必ず")
 	})
 
 	t.Run("discard top is displayed", func(t *testing.T) {

--- a/internal/i18n/locales/en/conquian.json
+++ b/internal/i18n/locales/en/conquian.json
@@ -21,6 +21,7 @@
   "promptDrawHelpStock": "ds: draw from stock",
   "promptDrawHelpDiscard": "dd: draw from discard (must be melded)",
   "promptMeld": "{{name}} to act (meld phase)",
+  "forcedUse": "⚠ A card taken from the discard pile must be used in a meld this turn",
   "promptMeldHelp": "m <idx,idx,..>;<idx>: lay or extend melds (groups split by ;)",
   "promptDiscardHelp": "d <idx>: discard a card to end your turn",
   "promptRoundEnd": "Round complete",

--- a/internal/i18n/locales/ja/conquian.json
+++ b/internal/i18n/locales/ja/conquian.json
@@ -21,6 +21,7 @@
   "promptDrawHelpStock": "ds・・・山札から引く",
   "promptDrawHelpDiscard": "dd・・・捨て札から引く (必ずメルドに使う)",
   "promptMeld": "手番: {{name}} (メルドフェーズ)",
+  "forcedUse": "⚠ 捨て札から引いたカードは必ずこのターンにメルドで使う必要があります",
   "promptMeldHelp": "m <idx,idx,..>;<idx>・・・メルドを並べる/付ける (グループは;区切り)",
   "promptDiscardHelp": "d <idx>・・・カードを捨ててターン終了",
   "promptRoundEnd": "ラウンド終了",


### PR DESCRIPTION
## 概要
`ConquianCuiPresenter` の MELD フェーズで、捨て札から引いた直後（`tookDiscard`）に「その札を必ずメルドで使う」強制使用義務を警告します（#2683）。Web は `forcedUse` バナーで表示済みですが、CUI には制約の案内がありませんでした。

## 変更点
- MELD フェーズで `g.GetTookDiscard()` のとき `color.Yellow` で `conquian.forcedUse` を表示。
- i18n `conquian.forcedUse` を ja/en に追加（Web の forcedUse と同等の文言、CUI 変更のため internal/i18n）。
- 注: 該当カードの明示は taken-card の getter が無く Web も汎用文言のため、Web と同じく汎用警告に統一。

## テスト
- `ConquianCuiPresenter_test.go`: tookDiscard=true で警告表示、false で非表示を検証。
- go test / golangci-lint green。

Closes #2683