### PR TITLE
feat(osmosis): annotate CUI hint with target foundation's allowed ranks

### DIFF
--- a/internal/adapter/presenter/OsmosisCuiPresenter.go
+++ b/internal/adapter/presenter/OsmosisCuiPresenter.go
@@ -75,6 +75,71 @@ func (p *OsmosisCuiPresenter) Output(o interfaces.OsmosisGame, lastErr error) st
 	})
 }
 
+// osmosisRanksIn returns the set of card ranks present in a foundation pile.
+func osmosisRanksIn(pile []*domain.Card) map[int]bool {
+	have := make(map[int]bool, len(pile))
+	for _, c := range pile {
+		have[c.GetValue()] = true
+	}
+	return have
+}
+
+// osmosisAllowedRanks mirrors the web rule: which ranks may be placed on
+// foundation row i (base row 0 accepts any rank once seeded; lower rows accept
+// ranks present in the row above that are not yet in the row).
+func osmosisAllowedRanks(foundation [domain.OsmosisFoundationCnt][]*domain.Card, baseRank, i int) []int {
+	pile := foundation[i]
+	if len(pile) == 0 {
+		if i >= 1 && len(foundation[i-1]) == 0 {
+			return nil
+		}
+		return []int{baseRank}
+	}
+	have := osmosisRanksIn(pile)
+	if i == 0 {
+		var all []int
+		for r := 1; r <= 13; r++ {
+			if !have[r] {
+				all = append(all, r)
+			}
+		}
+		return all
+	}
+	above := osmosisRanksIn(foundation[i-1])
+	var out []int
+	for r := 1; r <= 13; r++ {
+		if above[r] && !have[r] {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// osmosisRankLabel renders an Ace-low rank (1=A … 13=K) as a short label.
+func osmosisRankLabel(rank int) string {
+	switch rank {
+	case 1:
+		return "A"
+	case 11:
+		return "J"
+	case 12:
+		return "Q"
+	case 13:
+		return "K"
+	default:
+		return strconv.Itoa(rank)
+	}
+}
+
+// osmosisRankLabels renders ranks as short labels (A/2-10/J/Q/K).
+func osmosisRankLabels(ranks []int) string {
+	labels := make([]string, 0, len(ranks))
+	for _, r := range ranks {
+		labels = append(labels, osmosisRankLabel(r))
+	}
+	return strings.Join(labels, " ")
+}
+
 // HintOutput emits the current Osmosis hint.
 func (p *OsmosisCuiPresenter) HintOutput(o interfaces.OsmosisGame) string {
 	hint := o.GetHint()
@@ -88,7 +153,15 @@ func (p *OsmosisCuiPresenter) HintOutput(o interfaces.OsmosisGame) string {
 		from = i18n.T("osmosis.hintFromWaste")
 	}
 	to := i18n.Tf("osmosis.hintToFoundation", "idx", strconv.Itoa(hint.ToCol))
-	return i18n.Tf("osmosis.hintLine", "from", from, "to", to) + "\n"
+
+	foundation := o.GetFoundation()
+	var allowed string
+	if hint.ToCol == 0 && len(foundation[0]) > 0 {
+		allowed = i18n.T("osmosis.anyRank")
+	} else {
+		allowed = osmosisRankLabels(osmosisAllowedRanks(foundation, o.GetBaseRank(), hint.ToCol))
+	}
+	return i18n.Tf("osmosis.hintLine", "from", from, "to", to, "allowed", allowed) + "\n"
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/OsmosisCuiPresenter_test.go
+++ b/internal/adapter/presenter/OsmosisCuiPresenter_test.go
@@ -133,6 +133,23 @@ func TestOsmosisCuiPresenter_HintOutput(t *testing.T) {
 		assert.Contains(t, result, "配置可能: 7")
 	})
 
+	t.Run("lower row with partial pile lists ranks from the row above", func(t *testing.T) {
+		og := new(interfaces.MockOsmosisGame)
+		og.On("GetHint").Return(&domain.OsmosisHint{FromZone: "reserve", FromCol: 0, ToCol: 1})
+		og.On("GetBaseRank").Return(7)
+		var foundation [domain.OsmosisFoundationCnt][]*domain.Card
+		foundation[0] = []*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 7, false),
+			domain.NewCard(domain.CardDesignSpade, 9, false),
+		}
+		foundation[1] = []*domain.Card{domain.NewCard(domain.CardDesignHeart, 7, false)}
+		og.On("GetFoundation").Return(foundation)
+		p := new(OsmosisCuiPresenter)
+		result := p.HintOutput(og)
+		// Row above has 7 and 9; row 1 already has 7 → only 9 is placeable.
+		assert.Contains(t, result, "配置可能: 9")
+	})
+
 	t.Run("waste to base row shows any rank", func(t *testing.T) {
 		og := new(interfaces.MockOsmosisGame)
 		og.On("GetHint").Return(&domain.OsmosisHint{FromZone: "waste", FromCol: -1, ToCol: 0})
@@ -146,6 +163,46 @@ func TestOsmosisCuiPresenter_HintOutput(t *testing.T) {
 		// Base row already seeded → any rank may be added.
 		assert.Contains(t, result, "任意ランク")
 	})
+}
+
+func TestOsmosisAllowedRanks(t *testing.T) {
+	card := func(v int) *domain.Card { return domain.NewCard(domain.CardDesignSpade, v, false) }
+
+	t.Run("empty row returns the base rank", func(t *testing.T) {
+		var f [domain.OsmosisFoundationCnt][]*domain.Card
+		f[0] = []*domain.Card{card(7)}
+		assert.Equal(t, []int{7}, osmosisAllowedRanks(f, 7, 1))
+	})
+
+	t.Run("empty row with empty row above returns nothing", func(t *testing.T) {
+		var f [domain.OsmosisFoundationCnt][]*domain.Card
+		assert.Nil(t, osmosisAllowedRanks(f, 7, 2))
+	})
+
+	t.Run("base row lists every rank not yet present", func(t *testing.T) {
+		var f [domain.OsmosisFoundationCnt][]*domain.Card
+		f[0] = []*domain.Card{card(7), card(13)}
+		got := osmosisAllowedRanks(f, 7, 0)
+		assert.NotContains(t, got, 7)
+		assert.NotContains(t, got, 13)
+		assert.Contains(t, got, 1)
+		assert.Len(t, got, 11)
+	})
+
+	t.Run("lower row intersects the row above minus its own ranks", func(t *testing.T) {
+		var f [domain.OsmosisFoundationCnt][]*domain.Card
+		f[0] = []*domain.Card{card(7), card(9), card(11)}
+		f[1] = []*domain.Card{card(7)}
+		assert.Equal(t, []int{9, 11}, osmosisAllowedRanks(f, 7, 1))
+	})
+}
+
+func TestOsmosisRankLabel(t *testing.T) {
+	assert.Equal(t, "A", osmosisRankLabel(1))
+	assert.Equal(t, "10", osmosisRankLabel(10))
+	assert.Equal(t, "J", osmosisRankLabel(11))
+	assert.Equal(t, "Q", osmosisRankLabel(12))
+	assert.Equal(t, "K", osmosisRankLabel(13))
 }
 
 func TestOsmosisCuiPresenter_ActionLogOutput(t *testing.T) {

--- a/internal/adapter/presenter/OsmosisCuiPresenter_test.go
+++ b/internal/adapter/presenter/OsmosisCuiPresenter_test.go
@@ -118,21 +118,33 @@ func TestOsmosisCuiPresenter_HintOutput(t *testing.T) {
 		assert.Contains(t, p.HintOutput(og), "ヒントはありません")
 	})
 
-	t.Run("reserve to foundation", func(t *testing.T) {
+	t.Run("reserve to foundation shows allowed ranks", func(t *testing.T) {
 		og := new(interfaces.MockOsmosisGame)
 		og.On("GetHint").Return(&domain.OsmosisHint{FromZone: "reserve", FromCol: 0, ToCol: 1})
+		og.On("GetBaseRank").Return(7)
+		var foundation [domain.OsmosisFoundationCnt][]*domain.Card
+		foundation[0] = []*domain.Card{domain.NewCard(domain.CardDesignSpade, 7, false)}
+		og.On("GetFoundation").Return(foundation)
 		p := new(OsmosisCuiPresenter)
 		result := p.HintOutput(og)
 		assert.Contains(t, result, "リザーブ0列")
 		assert.Contains(t, result, "組札1段")
+		// Row 1 is empty with a seeded base row → only the base rank (7) is placeable.
+		assert.Contains(t, result, "配置可能: 7")
 	})
 
-	t.Run("waste to foundation", func(t *testing.T) {
+	t.Run("waste to base row shows any rank", func(t *testing.T) {
 		og := new(interfaces.MockOsmosisGame)
 		og.On("GetHint").Return(&domain.OsmosisHint{FromZone: "waste", FromCol: -1, ToCol: 0})
+		og.On("GetBaseRank").Return(7)
+		var foundation [domain.OsmosisFoundationCnt][]*domain.Card
+		foundation[0] = []*domain.Card{domain.NewCard(domain.CardDesignSpade, 7, false)}
+		og.On("GetFoundation").Return(foundation)
 		p := new(OsmosisCuiPresenter)
 		result := p.HintOutput(og)
 		assert.Contains(t, result, "ウェイスト")
+		// Base row already seeded → any rank may be added.
+		assert.Contains(t, result, "任意ランク")
 	})
 }
 

--- a/internal/i18n/locales/en/osmosis.json
+++ b/internal/i18n/locales/en/osmosis.json
@@ -27,5 +27,6 @@
   "hintFromReserve": "reserve col {{col}}",
   "hintFromWaste": "waste",
   "hintToFoundation": "foundation {{idx}}",
-  "hintLine": "Hint: {{from}} → {{to}}"
+  "anyRank": "any rank",
+  "hintLine": "Hint: {{from}} → {{to}} (allowed: {{allowed}})"
 }

--- a/internal/i18n/locales/ja/osmosis.json
+++ b/internal/i18n/locales/ja/osmosis.json
@@ -27,5 +27,6 @@
   "hintFromReserve": "リザーブ{{col}}列",
   "hintFromWaste": "ウェイスト",
   "hintToFoundation": "組札{{idx}}段",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "anyRank": "任意ランク",
+  "hintLine": "ヒント: {{from}} → {{to}} (配置可能: {{allowed}})"
 }


### PR DESCRIPTION
## 概要
`OsmosisCuiPresenter.HintOutput` を拡張し、ヒントの移動先ファウンデーションに現在配置可能なランクを併記します（#2647）。Web は各ファウンデーションの許容ランク（基底行は「★ any」）を表示しますが、CUI のヒントは「move <from> to foundation <idx>」のみでした。

## 変更点
- `osmosisAllowedRanks(foundation, baseRank, i)` を Go に移植（frontend `osmosisRules.ts` と同一ロジック：空の段は基底ランク、基底行(0)は手持ち以外の全ランク、下段は上段に存在し当段に無いランク）。`osmosisRankLabel`（Ace-low）併設。
- HintOutput で移動先段の許容ランクを算出し `{{allowed}}` に渡す。基底行が既に置かれている場合は `anyRank`（任意ランク）。
- i18n `osmosis.hintLine` に `{{allowed}}` を追加、`osmosis.anyRank` を ja/en に新設。

## テスト
- `OsmosisCuiPresenter_test.go`: 下段ヒントで許容ランク（7）併記、基底行ヒントで「任意ランク」を検証。
- go test / golangci-lint green。

Closes #2647