### PR TITLE
feat(dragontiger): implement CLI commands and formatter

### DIFF
--- a/frontend/src/pages/DragonTigerPage.tsx
+++ b/frontend/src/pages/DragonTigerPage.tsx
@@ -27,21 +27,11 @@ import { gameTheme } from '../styles/gameTheme';
 import type { DragonTigerResponse } from '../types/card';
 import { DragonTigerBetType, DragonTigerHistoryResult, DragonTigerPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { DRAGONTIGER_CLI_HELP, parseDragonTigerCommand } from '../utils/cli/commands/dragontigerCommands';
+import { formatDragonTigerState } from '../utils/cli/formatters/dragontigerFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 
 const DT_TUTORIAL_STEPS: TutorialStep[] = [];
-
-const DRAGONTIGER_CLI_HELP: string[] = [];
-
-/** Stub CLI parser — Dragon Tiger doesn't ship CLI commands yet (per checklist item 11 minimum). */
-function parseDragonTigerCommand(): { error: string } {
-  return { error: 'CLI commands are not yet implemented for Dragon Tiger.' };
-}
-
-/** Stub formatter — used only when CLI mode is enabled. */
-function formatDragonTigerState(_state: DragonTigerResponse | null): string {
-  return 'CLI mode is not implemented for Dragon Tiger.';
-}
 
 /** Renders the Dragon Tiger game page (#1684). */
 export const DragonTigerPage = withTutorial(DragonTigerPageContent, 'dragontiger', DT_TUTORIAL_STEPS);

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -6321,7 +6321,7 @@ export interface DragonTigerResponse extends BaseGameResponse {
   betAmount: number;
   /** 0=Dragon, 1=Tiger, 2=Tie */
   betType: number;
-  /** Domain GameResult: 1=Win (Dragon), 2=Lose (Tiger), 3=Draw (Tie) */
+  /** Domain GameResult on the wire: 1=Dragon wins, -1=Tiger wins, 0=Tie */
   result: number;
   payout: number;
   /** Big Road history. 0=Dragon, 1=Tiger, 2=Tie. */

--- a/frontend/src/utils/cli/commands/dragontigerCommands.test.ts
+++ b/frontend/src/utils/cli/commands/dragontigerCommands.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { DragonTigerBetType } from '../../../types/phases';
+import { DRAGONTIGER_CLI_HELP, parseDragonTigerCommand } from './dragontigerCommands';
+
+describe('parseDragonTigerCommand', () => {
+  it('parses bet with an explicit target and amount', () => {
+    expect(parseDragonTigerCommand('bet dragon 100')).toEqual({
+      args: ['bet', 100, DragonTigerBetType.DRAGON],
+    });
+    expect(parseDragonTigerCommand('bet tiger 50')).toEqual({
+      args: ['bet', 50, DragonTigerBetType.TIGER],
+    });
+    expect(parseDragonTigerCommand('bet tie 25')).toEqual({
+      args: ['bet', 25, DragonTigerBetType.TIE],
+    });
+  });
+
+  it('parses the d/t/e shortcuts', () => {
+    expect(parseDragonTigerCommand('d 100')).toEqual({ args: ['bet', 100, DragonTigerBetType.DRAGON] });
+    expect(parseDragonTigerCommand('t 100')).toEqual({ args: ['bet', 100, DragonTigerBetType.TIGER] });
+    expect(parseDragonTigerCommand('e 100')).toEqual({ args: ['bet', 100, DragonTigerBetType.TIE] });
+  });
+
+  it('returns error for bet without a valid target', () => {
+    expect('error' in parseDragonTigerCommand('bet 100')).toBe(true);
+    expect('error' in parseDragonTigerCommand('bet sideways 100')).toBe(true);
+  });
+
+  it('returns error for a non-numeric amount', () => {
+    expect('error' in parseDragonTigerCommand('bet dragon abc')).toBe(true);
+    expect('error' in parseDragonTigerCommand('d')).toBe(true);
+  });
+
+  it('parses clear', () => {
+    expect(parseDragonTigerCommand('clear')).toEqual({ args: ['clear'] });
+  });
+
+  it('parses log', () => {
+    expect(parseDragonTigerCommand('log')).toEqual({ args: ['log'] });
+  });
+
+  it('parses reset', () => {
+    expect(parseDragonTigerCommand('r')).toEqual({ args: ['reset'] });
+    expect(parseDragonTigerCommand('reset')).toEqual({ args: ['reset'] });
+  });
+
+  it('suggests a close command for a typo', () => {
+    const result = parseDragonTigerCommand('rese');
+    expect('error' in result && result.error).toContain('reset');
+  });
+
+  it('returns error for an unknown command', () => {
+    expect('error' in parseDragonTigerCommand('xyz')).toBe(true);
+  });
+
+  it('exposes help text', () => {
+    expect(DRAGONTIGER_CLI_HELP.length).toBeGreaterThan(0);
+    expect(DRAGONTIGER_CLI_HELP.some((line) => line.includes('bet'))).toBe(true);
+  });
+});

--- a/frontend/src/utils/cli/commands/dragontigerCommands.ts
+++ b/frontend/src/utils/cli/commands/dragontigerCommands.ts
@@ -1,0 +1,78 @@
+import type { dragontigerApi } from '../../../api/gameApi';
+import { DragonTigerBetType } from '../../../types/phases';
+import { parseIntArg, splitCommand, suggestCommand } from '../commandParserBase';
+import type { CliParseResult } from '../types';
+
+type DragonTigerArgs = Parameters<typeof dragontigerApi.exec>;
+
+const VALID_COMMANDS = ['b', 'bet', 'd', 'dragon', 't', 'tiger', 'e', 'tie', 'clear', 'log', 'r', 'reset', 'help', '?'];
+
+/** Maps a bet-target token to the DragonTigerBetType value, or null if unknown. */
+function parseBetTarget(token: string | undefined): number | null {
+  switch ((token ?? '').toLowerCase()) {
+    case 'd':
+    case 'dragon':
+      return DragonTigerBetType.DRAGON;
+    case 't':
+    case 'tiger':
+      return DragonTigerBetType.TIGER;
+    case 'e':
+    case 'tie':
+      return DragonTigerBetType.TIE;
+    default:
+      return null;
+  }
+}
+
+/** Builds a bet command for the given target and amount argument. */
+function betArgs(betType: number, amountArg: string | undefined): CliParseResult<DragonTigerArgs> {
+  if (amountArg === undefined || amountArg === '') {
+    return { error: 'Usage: bet <dragon|tiger|tie> <amount>' };
+  }
+  const amount = parseIntArg([amountArg], 0);
+  if ('error' in amount) return { error: 'Usage: bet <dragon|tiger|tie> <amount>' };
+  return { args: ['bet', amount.value, betType] };
+}
+
+/** Parse a Dragon Tiger CLI command into API exec arguments. */
+export function parseDragonTigerCommand(input: string): CliParseResult<DragonTigerArgs> {
+  const { cmd, args } = splitCommand(input);
+
+  switch (cmd) {
+    case 'b':
+    case 'bet': {
+      const betType = parseBetTarget(args[0]);
+      if (betType === null) return { error: 'Usage: bet <dragon|tiger|tie> <amount>' };
+      return betArgs(betType, args[1]);
+    }
+    case 'd':
+    case 'dragon':
+      return betArgs(DragonTigerBetType.DRAGON, args[0]);
+    case 't':
+    case 'tiger':
+      return betArgs(DragonTigerBetType.TIGER, args[0]);
+    case 'e':
+    case 'tie':
+      return betArgs(DragonTigerBetType.TIE, args[0]);
+    case 'clear':
+      return { args: ['clear'] };
+    case 'log':
+      return { args: ['log'] };
+    case 'r':
+    case 'reset':
+      return { args: ['reset'] };
+    default: {
+      const suggestion = suggestCommand(cmd, VALID_COMMANDS);
+      if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
+      return { error: `Unknown command: ${cmd}` };
+    }
+  }
+}
+
+/** Help text for Dragon Tiger CLI mode. */
+export const DRAGONTIGER_CLI_HELP: string[] = [
+  'bet <dragon|tiger|tie> <amt> - Place a bet (or shortcuts: d/t/e <amt>)',
+  'clear                        - Clear the current bet',
+  'log                          - Show action log',
+  'r/reset                      - Reset game',
+];

--- a/frontend/src/utils/cli/formatters/dragontigerFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/dragontigerFormatter.test.ts
@@ -43,6 +43,13 @@ describe('formatDragonTigerState', () => {
     expect(out).toContain('result: Dragon  payout: 200');
   });
 
+  it('maps the wire result value (1/-1/0) to Dragon/Tiger/Tie', () => {
+    const end = { ...baseState, phase: DragonTigerPhase.END };
+    expect(formatDragonTigerState({ ...end, result: 1 })).toContain('result: Dragon');
+    expect(formatDragonTigerState({ ...end, result: -1 })).toContain('result: Tiger');
+    expect(formatDragonTigerState({ ...end, result: 0 })).toContain('result: Tie');
+  });
+
   it('renders the big-road history with target names', () => {
     const out = formatDragonTigerState({ ...baseState, history: [0, 1, 2] });
     expect(out).toContain('history: Dragon Tiger Tie');

--- a/frontend/src/utils/cli/formatters/dragontigerFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/dragontigerFormatter.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign, DragonTigerResponse } from '../../../types/card';
+import { DragonTigerBetType, DragonTigerPhase } from '../../../types/phases';
+import { formatDragonTigerState } from './dragontigerFormatter';
+
+const card = (design: CardDesign, value: number): Card => ({ design, value });
+
+const baseState: DragonTigerResponse = {
+  phase: DragonTigerPhase.BET,
+  chips: 1000,
+  betAmount: 0,
+  betType: DragonTigerBetType.DRAGON,
+  result: 0,
+  payout: 0,
+  history: [],
+  message: '',
+};
+
+describe('formatDragonTigerState', () => {
+  it('renders header, chips, and phase', () => {
+    const out = formatDragonTigerState(baseState);
+    expect(out).toContain('Dragon Tiger');
+    expect(out).toContain('chips: 1000');
+    expect(out).toContain('phase: BET');
+  });
+
+  it('shows the active bet target and amount', () => {
+    const out = formatDragonTigerState({ ...baseState, betAmount: 50, betType: DragonTigerBetType.TIGER });
+    expect(out).toContain('bet: 50 on Tiger');
+  });
+
+  it('shows both cards and the result/payout at end', () => {
+    const out = formatDragonTigerState({
+      ...baseState,
+      phase: DragonTigerPhase.END,
+      dragonCard: card('SPADE', 13),
+      tigerCard: card('HEART', 7),
+      result: 1,
+      payout: 200,
+    });
+    expect(out).toContain('Dragon: ♠K');
+    expect(out).toContain('Tiger: ♥7');
+    expect(out).toContain('result: Dragon  payout: 200');
+  });
+
+  it('renders the big-road history with target names', () => {
+    const out = formatDragonTigerState({ ...baseState, history: [0, 1, 2] });
+    expect(out).toContain('history: Dragon Tiger Tie');
+  });
+
+  it('renders UNKNOWN for an unexpected phase', () => {
+    expect(formatDragonTigerState({ ...baseState, phase: 99 })).toContain('phase: UNKNOWN');
+  });
+});

--- a/frontend/src/utils/cli/formatters/dragontigerFormatter.ts
+++ b/frontend/src/utils/cli/formatters/dragontigerFormatter.ts
@@ -13,8 +13,12 @@ const BET_NAMES: Record<number, string> = {
   [DragonTigerBetType.TIE]: 'Tie',
 };
 
-// Domain GameResult: 1=Dragon wins, 2=Tiger wins, 3=Tie.
-const RESULT_NAMES: Record<number, string> = { 1: 'Dragon', 2: 'Tiger', 3: 'Tie' };
+// Domain GameResult on the wire: 1 (Win) = Dragon wins, -1 (Lose) = Tiger wins, 0 (Draw) = Tie.
+function resultName(result: number): string {
+  if (result > 0) return 'Dragon';
+  if (result < 0) return 'Tiger';
+  return 'Tie';
+}
 
 /** Format a Dragon Tiger game state as terminal text. */
 export function formatDragonTigerState(state: DragonTigerResponse): string {
@@ -32,7 +36,7 @@ export function formatDragonTigerState(state: DragonTigerResponse): string {
   }
 
   if (state.phase === DragonTigerPhase.END) {
-    lines.push(`result: ${RESULT_NAMES[state.result] ?? 'UNKNOWN'}  payout: ${state.payout}`);
+    lines.push(`result: ${resultName(state.result)}  payout: ${state.payout}`);
   }
 
   if (state.history.length > 0) {

--- a/frontend/src/utils/cli/formatters/dragontigerFormatter.ts
+++ b/frontend/src/utils/cli/formatters/dragontigerFormatter.ts
@@ -1,0 +1,46 @@
+import type { DragonTigerResponse } from '../../../types/card';
+import { DragonTigerBetType, DragonTigerPhase } from '../../../types/phases';
+import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+
+const PHASE_NAMES: Record<number, string> = {
+  [DragonTigerPhase.BET]: 'BET',
+  [DragonTigerPhase.END]: 'END',
+};
+
+const BET_NAMES: Record<number, string> = {
+  [DragonTigerBetType.DRAGON]: 'Dragon',
+  [DragonTigerBetType.TIGER]: 'Tiger',
+  [DragonTigerBetType.TIE]: 'Tie',
+};
+
+// Domain GameResult: 1=Dragon wins, 2=Tiger wins, 3=Tie.
+const RESULT_NAMES: Record<number, string> = { 1: 'Dragon', 2: 'Tiger', 3: 'Tie' };
+
+/** Format a Dragon Tiger game state as terminal text. */
+export function formatDragonTigerState(state: DragonTigerResponse): string {
+  const lines: string[] = [];
+  lines.push(formatHeader('Dragon Tiger'));
+  lines.push(`chips: ${state.chips}  phase: ${PHASE_NAMES[state.phase] ?? 'UNKNOWN'}`);
+
+  if (state.betAmount > 0) {
+    lines.push(`bet: ${state.betAmount} on ${BET_NAMES[state.betType] ?? '?'}`);
+  }
+
+  if (state.dragonCard || state.tigerCard) {
+    lines.push(`Dragon: ${state.dragonCard ? formatCard(state.dragonCard) : '??'}`);
+    lines.push(`Tiger: ${state.tigerCard ? formatCard(state.tigerCard) : '??'}`);
+  }
+
+  if (state.phase === DragonTigerPhase.END) {
+    lines.push(`result: ${RESULT_NAMES[state.result] ?? 'UNKNOWN'}  payout: ${state.payout}`);
+  }
+
+  if (state.history.length > 0) {
+    lines.push(`history: ${state.history.map((h) => BET_NAMES[h] ?? '?').join(' ')}`);
+  }
+
+  if (state.message) lines.push(state.message);
+
+  lines.push(formatSeparator());
+  return lines.join('\n');
+}


### PR DESCRIPTION
## 概要
Dragon Tiger の CLI はトグル・配線済みなのに `parseDragonTigerCommand`/`formatDragonTigerState` がスタブ（"not yet implemented"）で機能していませんでした（#2613）。実装版を新設してスタブを置換します。

## 変更点
- **`utils/cli/commands/dragontigerCommands.ts`** (新規): `bet <dragon|tiger|tie> <amount>`（d/t/e ショートカット可）/ `clear` / `log` / `r/reset` のパーサ + HELP。exec シグネチャ `(command, amount?, betType?)` と `DragonTigerBetType`(0/1/2) に一致。
- **`utils/cli/formatters/dragontigerFormatter.ts`** (新規): チップ・フェーズ・ベット(対象/額)・Dragon/Tiger カード・結果/払戻し・ビッグロード履歴を整形。
- **`DragonTigerPage.tsx`**: スタブ2関数と空 HELP を削除し、新ファイルから import。

## テスト
- commands 10 + formatter 5 + 既存 page tests、全 28 件 green。biome clean。
- 注: `Number('')===0` のため bet の金額欠落は明示ガードでエラー化。

Closes #2613