### PR TITLE
test(speed): fix flaky stuck-help negative test (force play phase)

### DIFF
--- a/internal/adapter/presenter/SpeedCuiPresenter_test.go
+++ b/internal/adapter/presenter/SpeedCuiPresenter_test.go
@@ -90,6 +90,15 @@ func TestSpeedCuiPresenter_Output(t *testing.T) {
 
 	t.Run("does not show stuck help during normal play", func(t *testing.T) {
 		s := setupSpeedWebTest()
+		// Force the play phase: a freshly-dealt board can occasionally be stuck,
+		// which would non-deterministically surface the stuck help.
+		data, _ := json.Marshal(s)
+		var raw map[string]json.RawMessage
+		_ = json.Unmarshal(data, &raw)
+		raw["ph"], _ = json.Marshal(domain.SpeedPhasePlay)
+		newData, _ := json.Marshal(raw)
+		_ = json.Unmarshal(newData, s)
+
 		result := p.Output(s, nil)
 		assert.NotContains(t, result, "f / flip")
 	})


### PR DESCRIPTION
## 概要
`TestSpeedCuiPresenter_Output/does_not_show_stuck_help_during_normal_play`（#2568 で追加）が断続的に失敗し、無関係な PR のバックエンド CI をブロックしていました。

## 原因
`setupSpeedWebTest()` は `s.Reset()`（シャッフル＋配り直し）を行うため、初期盤面がまれに膠着（`SpeedPhaseStuck`）になることがあり、その場合スタックヘルプ `f / flip` が表示され、`NotContains('f / flip')` の否定アサーションが落ちます（NewTrumpCards はランダムシード）。

## 修正
他の "shows stuck message" テストと同じ JSON ラウンドトリップ手法でフェーズを `SpeedPhasePlay` に確定させ、決定的に。

## 確認
- `go test -count=1` を 5 回連続 green、プレゼンター全体 green、golangci-lint clean。