### PR TITLE
feat(fiftyone): add colored stop-declared alert to CUI

### DIFF
--- a/internal/adapter/presenter/FiftyOneCuiPresenter.go
+++ b/internal/adapter/presenter/FiftyOneCuiPresenter.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
@@ -55,6 +56,14 @@ func (p *FiftyOneCuiPresenter) Output(fo interfaces.FiftyOneGame, lastErr error)
 		}
 
 		b.WriteString("----------\n")
+
+		// Prominent colored alert whenever a stop has been declared, shown in
+		// every phase right before the prompt so CUI players know the game is in
+		// its final round (mirrors Yukon's color.Red stalemate notice).
+		if fo.GetStopCallerIdx() >= 0 {
+			callerName := cuiPlayerName(fo.GetPlayer(fo.GetStopCallerIdx()), fo.GetStopCallerIdx())
+			b.WriteString(color.Red(i18n.Tf("fiftyone.cuiStopCalled", "name", callerName)) + "\n")
+		}
 
 		cuiErrorBlock(b, lastErr)
 

--- a/internal/adapter/presenter/FiftyOneCuiPresenter.go
+++ b/internal/adapter/presenter/FiftyOneCuiPresenter.go
@@ -49,20 +49,14 @@ func (p *FiftyOneCuiPresenter) Output(fo interfaces.FiftyOneGame, lastErr error)
 		}
 		b.WriteString("\n")
 
-		// Stop state
-		if fo.GetStopCallerIdx() >= 0 {
-			callerName := cuiPlayerName(fo.GetPlayer(fo.GetStopCallerIdx()), fo.GetStopCallerIdx())
-			b.WriteString(i18n.Tf("fiftyone.stopCalled", "name", callerName) + "\n")
-		}
-
 		b.WriteString("----------\n")
 
-		// Prominent colored alert whenever a stop has been declared, shown in
-		// every phase right before the prompt so CUI players know the game is in
-		// its final round (mirrors Yukon's color.Red stalemate notice).
-		if fo.GetStopCallerIdx() >= 0 {
-			callerName := cuiPlayerName(fo.GetPlayer(fo.GetStopCallerIdx()), fo.GetStopCallerIdx())
-			b.WriteString(color.Red(i18n.Tf("fiftyone.cuiStopCalled", "name", callerName)) + "\n")
+		// Colored so CUI players notice the final round is in effect (every phase).
+		if idx := fo.GetStopCallerIdx(); idx >= 0 {
+			if caller := fo.GetPlayer(idx); caller != nil {
+				name := cuiPlayerName(caller, idx)
+				b.WriteString(color.Red(i18n.Tf("fiftyone.cuiStopCalled", "name", name)) + "\n")
+			}
 		}
 
 		cuiErrorBlock(b, lastErr)

--- a/internal/adapter/presenter/FiftyOneCuiPresenter_test.go
+++ b/internal/adapter/presenter/FiftyOneCuiPresenter_test.go
@@ -116,6 +116,16 @@ func TestFiftyOneCuiPresenter_Output_StopCalled(t *testing.T) {
 
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "ストップ宣言")
+	// The prominent colored alert is shown before the prompt in every phase.
+	assert.Contains(t, result, "最終ラウンド")
+}
+
+func TestFiftyOneCuiPresenter_Output_NoStopAlertWhenNoStop(t *testing.T) {
+	p := new(presenter.FiftyOneCuiPresenter)
+	m := setupFiftyOneMock()
+	// setupFiftyOneMock leaves GetStopCallerIdx() == -1 (no stop declared).
+	result := p.Output(m, nil)
+	assert.NotContains(t, result, "最終ラウンド")
 }
 
 func TestFiftyOneCuiPresenter_ActionLogOutput(t *testing.T) {

--- a/internal/i18n/locales/en/fiftyone.json
+++ b/internal/i18n/locales/en/fiftyone.json
@@ -13,6 +13,7 @@
   "tableHeader": "Table: ",
   "tableCard": "[{{idx}}]{{card}}",
   "stopCalled": "⚠ {{name}} called stop!",
+  "cuiStopCalled": "⚠ Stop is in effect ({{name}}) — this is the final round",
   "gameEndHeader": "=== Game over ===",
   "scoreEntry": "  {{name}}: {{score}}",
   "winHuman": "You win!",

--- a/internal/i18n/locales/en/fiftyone.json
+++ b/internal/i18n/locales/en/fiftyone.json
@@ -12,7 +12,6 @@
   "scoreUnknown": "?",
   "tableHeader": "Table: ",
   "tableCard": "[{{idx}}]{{card}}",
-  "stopCalled": "⚠ {{name}} called stop!",
   "cuiStopCalled": "⚠ Stop is in effect ({{name}}) — this is the final round",
   "gameEndHeader": "=== Game over ===",
   "scoreEntry": "  {{name}}: {{score}}",

--- a/internal/i18n/locales/ja/fiftyone.json
+++ b/internal/i18n/locales/ja/fiftyone.json
@@ -13,6 +13,7 @@
   "tableHeader": "場札: ",
   "tableCard": "[{{idx}}]{{card}}",
   "stopCalled": "⚠ {{name}} がストップ宣言！",
+  "cuiStopCalled": "⚠ ストップ宣言中（{{name}}）— 残り1巡が最終ラウンドです",
   "gameEndHeader": "=== ゲーム終了 ===",
   "scoreEntry": "  {{name}}: {{score}}点",
   "winHuman": "あなたの勝ち！",

--- a/internal/i18n/locales/ja/fiftyone.json
+++ b/internal/i18n/locales/ja/fiftyone.json
@@ -12,7 +12,6 @@
   "scoreUnknown": "?",
   "tableHeader": "場札: ",
   "tableCard": "[{{idx}}]{{card}}",
-  "stopCalled": "⚠ {{name}} がストップ宣言！",
   "cuiStopCalled": "⚠ ストップ宣言中（{{name}}）— 残り1巡が最終ラウンドです",
   "gameEndHeader": "=== ゲーム終了 ===",
   "scoreEntry": "  {{name}}: {{score}}点",


### PR DESCRIPTION
## 概要
Closes #2583

`FiftyOneCuiPresenter` はストップ状態をテーブル行にインライン埋め込みするだけで、独立した強調表示がなかった。Yukon の `color.Red` stalemate 通知に倣い、ストップ宣言時はプロンプト直前に色付きアラート行を全フェーズで表示する。

## 変更点
- `FiftyOneCuiPresenter.go`: `GetStopCallerIdx() >= 0` のとき `color.Red(fiftyone.cuiStopCalled)` を区切り線の後・プロンプト前に出力（全該当フェーズ）。
- `internal/i18n/locales/{ja,en}/fiftyone.json`: `cuiStopCalled` キーを追加（CUI ランタイムは internal/i18n を参照）。
- `FiftyOneCuiPresenter_test.go`: 宣言時に表示・未宣言時に非表示の検証を追加。

## テスト
- [x] `go test -tags test ./internal/adapter/presenter/ -run TestFiftyOneCuiPresenter` 緑
- [x] `golangci-lint run ./internal/adapter/presenter/` 0 issues