### PR TITLE
feat(tripeaks): mark playable and blocked cards in CUI

### DIFF
--- a/internal/adapter/presenter/TriPeaksCuiPresenter.go
+++ b/internal/adapter/presenter/TriPeaksCuiPresenter.go
@@ -12,6 +12,17 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
+// triPeaksAdjacentRank reports whether two ranks differ by one, treating
+// King(13) and Ace(1) as adjacent (mirrors the domain's isAdjacentRank, which
+// is unexported, and the frontend's isTriPeaksAdjacent).
+func triPeaksAdjacentRank(v1, v2 int) bool {
+	diff := v1 - v2
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff == 1 || diff == 12
+}
+
 // TriPeaksCuiPresenter renders the TriPeaks Solitaire CUI view.
 type TriPeaksCuiPresenter struct{}
 
@@ -19,6 +30,13 @@ type TriPeaksCuiPresenter struct{}
 func (pr *TriPeaksCuiPresenter) Output(t interfaces.TriPeaksGame, lastErr error) string {
 	return buildCuiOutput(i18n.T("tripeaks.helpTitle"), func(b *strings.Builder) {
 		layout := t.GetLayout()
+
+		// Waste top drives the ±1 playable check for exposed tableau cards.
+		waste := t.GetWaste()
+		var wasteTop *domain.Card
+		if len(waste) > 0 {
+			wasteTop = waste[len(waste)-1]
+		}
 
 		// Tableau (with row indent)
 		for row := range domain.TriPeaksRowCnt {
@@ -34,9 +52,20 @@ func (pr *TriPeaksCuiPresenter) Output(t interfaces.TriPeaksGame, lastErr error)
 					b.WriteString("  ")
 				}
 				first = false
-				if tc.Removed {
+				switch {
+				case tc.Removed:
 					b.WriteString("    ")
-				} else {
+				case !t.IsExposed(row, col):
+					// Blocked cards hide coordinates: they cannot be taken yet.
+					b.WriteString(i18n.Tf("tripeaks.blockedCard", "card", cuiCardStr(tc.Card)))
+				case wasteTop != nil && triPeaksAdjacentRank(tc.Card.GetValue(), wasteTop.GetValue()):
+					// Exposed and ±1 from the waste top: playable now (trailing *).
+					b.WriteString(i18n.Tf("tripeaks.playableCard",
+						"row", strconv.Itoa(row),
+						"col", strconv.Itoa(col),
+						"card", cuiCardStr(tc.Card)))
+				default:
+					// Exposed but not adjacent: shown with coordinates, no marker.
 					b.WriteString(i18n.Tf("tripeaks.tableauCard",
 						"row", strconv.Itoa(row),
 						"col", strconv.Itoa(col),
@@ -51,7 +80,6 @@ func (pr *TriPeaksCuiPresenter) Output(t interfaces.TriPeaksGame, lastErr error)
 		// Stock + waste
 		b.WriteString(i18n.Tf("tripeaks.stockLine",
 			"count", strconv.Itoa(t.GetStockCount())))
-		waste := t.GetWaste()
 		if len(waste) > 0 {
 			b.WriteString(i18n.Tf("tripeaks.wasteCard",
 				"card", cuiCardStr(waste[len(waste)-1])))

--- a/internal/adapter/presenter/TriPeaksCuiPresenter_test.go
+++ b/internal/adapter/presenter/TriPeaksCuiPresenter_test.go
@@ -26,6 +26,8 @@ func setupTriPeaksCuiMockDefaults(tg *interfaces.MockTriPeaksGame) {
 			Card:    domain.NewCard(domain.CardDesignSpade, c%13+1, false),
 			Removed: false,
 		}
+		// Even columns exposed, odd columns blocked — exercises both formats.
+		tg.On("IsExposed", 3, c).Return(c%2 == 0).Maybe()
 	}
 	tg.On("GetLayout").Return(layout).Maybe()
 }
@@ -39,6 +41,36 @@ func TestTriPeaksCuiPresenterOutput_Playing(t *testing.T) {
 	assert.Contains(t, result, "TriPeaks")
 	assert.Contains(t, result, "Stock: 23枚")
 	assert.Contains(t, result, "手数: 0")
+}
+
+func TestTriPeaksCuiPresenterOutput_PlayableAndBlocked(t *testing.T) {
+	tg := new(interfaces.MockTriPeaksGame)
+	tg.On("GetPhase").Return(domain.TriPeaksPhasePlaying).Maybe()
+	tg.On("GetMoveCount").Return(0).Maybe()
+	tg.On("GetStockCount").Return(10).Maybe()
+	tg.On("IsStalemate").Return(false).Maybe()
+	// Waste top is a 2: adjacent to Ace(1) and 3, with K-A wrap also possible.
+	tg.On("GetWaste").Return([]*domain.Card{domain.NewCard(domain.CardDesignHeart, 2, false)}).Maybe()
+
+	var layout [domain.TriPeaksRowCnt][domain.TriPeaksColCnt]*domain.TriPeaksCard
+	// (3,0)=A exposed & adjacent->playable; (3,1)=5 blocked; (3,2)=9 exposed but not adjacent.
+	layout[3][0] = &domain.TriPeaksCard{Card: domain.NewCard(domain.CardDesignSpade, 1, false)}
+	layout[3][1] = &domain.TriPeaksCard{Card: domain.NewCard(domain.CardDesignSpade, 5, false)}
+	layout[3][2] = &domain.TriPeaksCard{Card: domain.NewCard(domain.CardDesignSpade, 9, false)}
+	tg.On("GetLayout").Return(layout).Maybe()
+	tg.On("IsExposed", 3, 0).Return(true).Maybe()
+	tg.On("IsExposed", 3, 1).Return(false).Maybe()
+	tg.On("IsExposed", 3, 2).Return(true).Maybe()
+
+	p := &TriPeaksCuiPresenter{}
+	result := p.Output(tg, nil)
+	// (3,0) is exposed and ±1 from the waste top -> playable marker.
+	assert.Contains(t, result, "(3,0)")
+	assert.Contains(t, result, "*")
+	// (3,1) is blocked -> coordinates hidden.
+	assert.Contains(t, result, "[--]")
+	// (3,2) is exposed but not adjacent -> plain coordinate format, no marker.
+	assert.Contains(t, result, "(3,2)")
 }
 
 func TestTriPeaksCuiPresenterOutput_Error(t *testing.T) {

--- a/internal/i18n/locales/en/tripeaks.json
+++ b/internal/i18n/locales/en/tripeaks.json
@@ -5,6 +5,8 @@
   "helpGiveUp": "  g                        give up",
   "helpHint": "  h                        hint",
   "tableauCard": "({{row}},{{col}}){{card}}",
+  "playableCard": "({{row}},{{col}}){{card}}*",
+  "blockedCard": "[--]{{card}}",
   "stockLine": "Stock: {{count}}",
   "wasteCard": " | Waste: {{card}}",
   "wasteEmpty": " | Waste: [empty]",

--- a/internal/i18n/locales/ja/tripeaks.json
+++ b/internal/i18n/locales/ja/tripeaks.json
@@ -5,6 +5,8 @@
   "helpGiveUp": "  g                        ギブアップ",
   "helpHint": "  h                        ヒント",
   "tableauCard": "({{row}},{{col}}){{card}}",
+  "playableCard": "({{row}},{{col}}){{card}}*",
+  "blockedCard": "[--]{{card}}",
   "stockLine": "Stock: {{count}}枚",
   "wasteCard": " | Waste: {{card}}",
   "wasteEmpty": " | Waste: [空]",


### PR DESCRIPTION
## 概要
Closes #2563

`TriPeaksCuiPresenter` はタブローの全カードを同じ書式で表示し、各カードが露出済みか、かつ捨て札トップと±1（プレイ可能）かを示さなかった。Web版（`isPlayable` = 露出済み かつ `isTriPeaksAdjacent`）に倣い、CUI でもプレイ可能/ブロックを書式で判別できるようにする。

## 変更点
- `TriPeaksCuiPresenter.go`: 捨て札トップを先頭で取得し、各カードを分岐 — 露出かつ±1（K-Aラップ込み）→ `tripeaks.playableCard`（末尾 `*`）／非露出 → `tripeaks.blockedCard`（`[--]CARD`）／露出だが非隣接 → 既存 `tripeaks.tableauCard`。±1判定はドメインの非公開 `isAdjacentRank` と同じロジックをヘルパーで再現（フロントの `isTriPeaksAdjacent` と同方針）。
- `internal/i18n/locales/{ja,en}/tripeaks.json`: `playableCard`/`blockedCard` を追加。
- `TriPeaksCuiPresenter_test.go`: playable(`*`)/blocked(`[--]`)/露出非隣接 を検証する `PlayableAndBlocked` ケース＋既存モックに `IsExposed` 期待値を追加。

## テスト
- [x] `go test -tags test ./internal/adapter/presenter/ -run TestTriPeaksCuiPresenter` 緑
- [x] `golangci-lint run ./internal/adapter/presenter/` 0 issues