### PR TITLE
feat(pinochle): show legal play indices in CUI on human turn

### DIFF
--- a/internal/adapter/presenter/PinochleCuiPresenter.go
+++ b/internal/adapter/presenter/PinochleCuiPresenter.go
@@ -42,7 +42,9 @@ func pinochleMeldName(t domain.PinochleMeldType) string {
 }
 
 // pinochlePlayerStr returns the display string for a single Pinochle player.
-func pinochlePlayerStr(player *domain.PinochlePlayer, i int) string {
+// legalIndices, when non-nil, lists the hand positions the human may legally
+// play this turn and is rendered as a follow-rule legend below their hand.
+func pinochlePlayerStr(player *domain.PinochlePlayer, i int, legalIndices []int) string {
 	var b strings.Builder
 	name := cuiPlayerName(player, i)
 	b.WriteString(i18n.Tf("pinochle.playerLine",
@@ -58,6 +60,14 @@ func pinochlePlayerStr(player *domain.PinochlePlayer, i int) string {
 	if player.GetIsHuman() && player.GetCardsSize() > 0 {
 		b.WriteString(cuiIndexedCardListStr(player))
 		b.WriteString("\n")
+		if legalIndices != nil {
+			parts := make([]string, len(legalIndices))
+			for k, idx := range legalIndices {
+				parts[k] = "[" + strconv.Itoa(idx) + "]"
+			}
+			b.WriteString(i18n.Tf("pinochle.legalPlayLegend",
+				"indices", strings.Join(parts, " ")) + "\n")
+		}
 	}
 	return b.String()
 }
@@ -99,9 +109,14 @@ func (p *PinochleCuiPresenter) Output(g interfaces.PinochleGame, lastErr error) 
 			"a", strconv.Itoa(g.GetTeamScore(0)),
 			"b", strconv.Itoa(g.GetTeamScore(1))))
 
-		// Player rows
+		// Player rows. On the human's play turn, surface the legal follow plays.
 		for i := 0; i < g.GetPlayerCnt(); i++ {
-			b.WriteString(pinochlePlayerStr(g.GetPlayer(i), i))
+			var legalIndices []int
+			if g.GetPhase() == domain.PinochlePhasePlay &&
+				i == g.GetCurrentPlayerIdx() && g.GetPlayer(i).GetIsHuman() {
+				legalIndices = g.GetValidPlayIndices(i)
+			}
+			b.WriteString(pinochlePlayerStr(g.GetPlayer(i), i, legalIndices))
 		}
 
 		// Meld details (only during meld + round-end phases)

--- a/internal/adapter/presenter/PinochleCuiPresenter.go
+++ b/internal/adapter/presenter/PinochleCuiPresenter.go
@@ -60,7 +60,7 @@ func pinochlePlayerStr(player *domain.PinochlePlayer, i int, legalIndices []int)
 	if player.GetIsHuman() && player.GetCardsSize() > 0 {
 		b.WriteString(cuiIndexedCardListStr(player))
 		b.WriteString("\n")
-		if legalIndices != nil {
+		if len(legalIndices) > 0 {
 			parts := make([]string, len(legalIndices))
 			for k, idx := range legalIndices {
 				parts[k] = "[" + strconv.Itoa(idx) + "]"

--- a/internal/adapter/presenter/PinochleCuiPresenter_test.go
+++ b/internal/adapter/presenter/PinochleCuiPresenter_test.go
@@ -110,6 +110,23 @@ func TestPinochleCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "[0]SPADE 1")
 	})
 
+	t.Run("shows legal-play legend on human play turn", func(t *testing.T) {
+		m, players := setupPinochleCuiMockWithPlayers()
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 1, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 10, false))
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "合法手: [0] [1]")
+	})
+
+	t.Run("hides legal-play legend outside the play phase", func(t *testing.T) {
+		m, players := setupPinochleCuiMockWithPlayers()
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 1, false))
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.PinochlePhaseMeld)
+		result := p.Output(m, nil)
+		assert.NotContains(t, result, "合法手:")
+	})
+
 	t.Run("shows current trick on table", func(t *testing.T) {
 		m, _ := setupPinochleCuiMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentTrick")

--- a/internal/i18n/locales/en/pinochle.json
+++ b/internal/i18n/locales/en/pinochle.json
@@ -49,6 +49,7 @@
   "promptTrump": "{{name}}, choose the trump suit. (trump <1-4>)",
   "promptMeld": "Meld phase. (use 'meld' to confirm and continue)",
   "promptPlay": "{{name}} to play. (play <i>)",
+  "legalPlayLegend": "Legal plays: {{indices}}",
   "promptTrickEnd": "Trick ended. (use 'next' to advance)",
   "promptRoundEnd": "Round ended. (use 'nextround' to advance)"
 }

--- a/internal/i18n/locales/ja/pinochle.json
+++ b/internal/i18n/locales/ja/pinochle.json
@@ -49,6 +49,7 @@
   "promptTrump": "{{name}}がトランプスートを選んでください。(trump <1-4>)",
   "promptMeld": "メルドフェーズです。(meld で確認して次に進む)",
   "promptPlay": "{{name}}の番です。(play <i>)",
+  "legalPlayLegend": "合法手: {{indices}}",
   "promptTrickEnd": "トリック終了。(next で次のトリックへ)",
   "promptRoundEnd": "ラウンド終了。(nextround で次のラウンドへ)"
 }


### PR DESCRIPTION
## 概要
Closes #2570

Pinochle は厳格なフォロー義務（同スート→トランプ→ビート）があるが、`PinochleCuiPresenter` は人間の手札を並べるだけで合法手を示さず、CUI利用者はトライ&エラーで探すしかなかった。Web版（`state.validPlayIndices` で非合法カードを無効化）と同じ情報源を使い、プレイフェーズの人間の手番で合法手インデックスの凡例を表示する。

## 変更点
- `PinochleCuiPresenter.go`: プレイフェーズかつ現在の手番が人間のとき、`GetValidPlayIndices(idx)`（インターフェース既存・Web も使用）の結果を手札の下に `pinochle.legalPlayLegend` 凡例（`合法手: [0] [1]`）として表示。他フェーズは従来どおり。
- `internal/i18n/locales/{ja,en}/pinochle.json`: `legalPlayLegend` を追加。
- `PinochleCuiPresenter_test.go`: プレイ手番で凡例表示／メルドフェーズで非表示 の検証ケースを追加。

## テスト
- [x] `go test -tags test ./internal/adapter/presenter/ -run TestPinochleCuiPresenter` 緑
- [x] `golangci-lint run ./internal/adapter/presenter/` 0 issues