### PR TITLE
feat(deucetoseven): add stand-pat guidance to CLI formatter

### DIFF
--- a/frontend/src/utils/cli/formatters/deuceToSevenFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/deuceToSevenFormatter.test.ts
@@ -121,4 +121,88 @@ describe('formatDeuceToSevenState', () => {
     const result = formatDeuceToSevenState(makeState({ phase: 99 as 0 }));
     expect(result).toContain('UNKNOWN');
   });
+
+  function drawHuman(cards: DeuceToSevenResponse['players'][number]['cards']) {
+    return makeState({
+      phase: 3,
+      currentTurn: 0,
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          cards,
+          chips: 1000,
+          currentBet: 0,
+          folded: false,
+          allIn: false,
+          handRank: 0,
+          handName: '',
+          drawCount: 0,
+          totalDraws: 0,
+          playStyleName: 'tight',
+        },
+      ],
+    });
+  }
+
+  it('flags a made pat low and recommends standing in the draw phase', () => {
+    const result = formatDeuceToSevenState(
+      drawHuman([
+        { design: 'SPADE', value: 7 },
+        { design: 'HEART', value: 5 },
+        { design: 'CLOVER', value: 4 },
+        { design: 'DIAMOND', value: 3 },
+        { design: 'SPADE', value: 2 },
+      ]),
+    );
+    expect(result).toContain('Made low:');
+    expect(result).toContain('stand recommended');
+  });
+
+  it('lists the cards worth keeping when the low is not yet made', () => {
+    const result = formatDeuceToSevenState(
+      drawHuman([
+        { design: 'SPADE', value: 9 },
+        { design: 'HEART', value: 5 },
+        { design: 'CLOVER', value: 4 },
+        { design: 'DIAMOND', value: 3 },
+        { design: 'SPADE', value: 2 },
+      ]),
+    );
+    expect(result).toContain('Best to keep:');
+    expect(result).toContain('draw the rest');
+  });
+
+  it('does not show stand-pat guidance outside the draw phase', () => {
+    const result = formatDeuceToSevenState(
+      makeState({
+        phase: 2,
+        currentTurn: 0,
+        players: [
+          {
+            id: 0,
+            isHuman: true,
+            cards: [
+              { design: 'SPADE', value: 7 },
+              { design: 'HEART', value: 5 },
+              { design: 'CLOVER', value: 4 },
+              { design: 'DIAMOND', value: 3 },
+              { design: 'SPADE', value: 2 },
+            ],
+            chips: 1000,
+            currentBet: 0,
+            folded: false,
+            allIn: false,
+            handRank: 0,
+            handName: '',
+            drawCount: 0,
+            totalDraws: 0,
+            playStyleName: 'tight',
+          },
+        ],
+      }),
+    );
+    expect(result).not.toContain('Made low:');
+    expect(result).not.toContain('Best to keep:');
+  });
 });

--- a/frontend/src/utils/cli/formatters/deuceToSevenFormatter.ts
+++ b/frontend/src/utils/cli/formatters/deuceToSevenFormatter.ts
@@ -1,5 +1,7 @@
 import type { DeuceToSevenResponse } from '../../../types/card';
-import { formatHeader, formatIndexedCards, formatPlayerName, formatSeparator } from '../formatterBase';
+import { DeuceToSevenPhase } from '../../../types/phases';
+import { deuceToSevenBestIndices, isMadePatLow } from '../../deuceToSevenUtils';
+import { formatCardList, formatHeader, formatIndexedCards, formatPlayerName, formatSeparator } from '../formatterBase';
 
 const PHASE_NAMES: Record<number, string> = {
   0: 'INIT',
@@ -30,6 +32,17 @@ export function formatDeuceToSevenState(state: DeuceToSevenResponse): string {
     if (p.handName) lines.push(`  hand: ${p.handName}`);
     if (p.isHuman && p.cards.length > 0) {
       lines.push(`  ${formatIndexedCards(p.cards)}`);
+    }
+  }
+
+  // Draw-phase stand-pat guidance for the human, mirroring the GUI banner.
+  const human = state.players.find((p) => p.isHuman);
+  if (state.phase === DeuceToSevenPhase.DRAW && human && state.currentTurn === human.id && human.cards.length === 5) {
+    if (isMadePatLow(human.cards)) {
+      lines.push(`Made low: ${formatCardList(human.cards)} (stand recommended)`);
+    } else {
+      const keep = deuceToSevenBestIndices(human.cards).map((i) => human.cards[i]);
+      lines.push(`Best to keep: ${formatCardList(keep)} (draw the rest)`);
     }
   }
 


### PR DESCRIPTION
## 概要
Closes #2592

`deuceToSevenFormatter.ts`（CLIモード）は手札・フェーズ・ポットしか出力せず、GUI の最重要支援であるスタンドパット可否情報が得られなかった。GUI と同じ `isMadePatLow` / `deuceToSevenBestIndices` を再利用し、ドローフェーズで自分の番のときにガイダンス行を追加する。

## 変更点
- `deuceToSevenFormatter.ts`: DRAWフェーズかつ人間の手番（5枚所持）のとき、メイドロー成立なら `Made low: <5枚> (stand recommended)`、未成立なら `Best to keep: <キープ札> (draw the rest)` を出力。ロジックは `deuceToSevenUtils` の既存関数を再利用。
- `deuceToSevenFormatter.test.ts`: メイドロー/未成立/ドローフェーズ外非表示 の3ケースを追加（計9件）。

## テスト
- [x] `bun run test -- --run deuceToSevenFormatter` 9件緑
- [x] `bun run check` パス（新規警告なし）