### PR TITLE
feat(baccarat): show win/loss history row in CUI

### DIFF
--- a/internal/adapter/presenter/BaccaratCuiPresenter.go
+++ b/internal/adapter/presenter/BaccaratCuiPresenter.go
@@ -12,6 +12,28 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
+// baccaratHistoryMaxShown caps the trailing run of results rendered in the CUI
+// so a long shoe does not overflow the terminal line.
+const baccaratHistoryMaxShown = 30
+
+// baccaratHistorySymbols maps the big-road history to a P/B/T symbol string.
+func baccaratHistorySymbols(history []int) string {
+	syms := make([]string, len(history))
+	for i, r := range history {
+		switch r {
+		case domain.BaccaratResultPlayer:
+			syms[i] = "P"
+		case domain.BaccaratResultBanker:
+			syms[i] = "B"
+		case domain.BaccaratResultTie:
+			syms[i] = "T"
+		default:
+			syms[i] = "?"
+		}
+	}
+	return strings.Join(syms, " ")
+}
+
 // BaccaratCuiPresenter バカラCUIプレゼンタークラス
 type BaccaratCuiPresenter struct {
 }
@@ -70,6 +92,14 @@ func (bp *BaccaratCuiPresenter) Output(b interfaces.BaccaratGame, lastErr error)
 		}
 		sb.WriteString(i18n.Tf("baccarat.payoutLine", "payout", strconv.Itoa(b.GetPayout())) + "\n")
 		sb.WriteString("----------\n")
+	}
+
+	// Big-road history (also useful while betting); skip when empty.
+	if history := b.GetHistory(); len(history) > 0 {
+		if len(history) > baccaratHistoryMaxShown {
+			history = history[len(history)-baccaratHistoryMaxShown:]
+		}
+		sb.WriteString(i18n.Tf("baccarat.historyHeader", "symbols", baccaratHistorySymbols(history)) + "\n")
 	}
 
 	return sb.String()

--- a/internal/adapter/presenter/BaccaratCuiPresenter_test.go
+++ b/internal/adapter/presenter/BaccaratCuiPresenter_test.go
@@ -23,6 +23,7 @@ func setupBaccaratCuiMockDefaults(m *interfaces.MockBaccaratGame) {
 	m.On("GetResult").Return(domain.GameResult(0)).Maybe()
 	m.On("GetPayout").Return(0).Maybe()
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
+	m.On("GetHistory").Return(([]int)(nil)).Maybe()
 }
 
 func TestBaccaratCuiPresenter_Output_BetPhase(t *testing.T) {
@@ -36,6 +37,38 @@ func TestBaccaratCuiPresenter_Output_BetPhase(t *testing.T) {
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "チップ: 1000")
 	assert.Contains(t, result, "フェーズ: BET")
+}
+
+func TestBaccaratCuiPresenter_Output_History(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+	p := new(BaccaratCuiPresenter)
+
+	t.Run("shows P/B/T history symbols when present", func(t *testing.T) {
+		m := new(interfaces.MockBaccaratGame)
+		m.On("GetChips").Return(1000).Maybe()
+		m.On("GetPhase").Return(domain.BaccaratPhaseBet).Maybe()
+		m.On("GetPlayerHand").Return(([]*domain.Card)(nil)).Maybe()
+		m.On("GetBankerHand").Return(([]*domain.Card)(nil)).Maybe()
+		m.On("GetPlayerHandValue").Return(0).Maybe()
+		m.On("GetBankerHandValue").Return(0).Maybe()
+		m.On("GetGameEndFlag").Return(false).Maybe()
+		m.On("GetHistory").Return([]int{
+			domain.BaccaratResultPlayer,
+			domain.BaccaratResultBanker,
+			domain.BaccaratResultTie,
+		}).Maybe()
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "履歴: P B T")
+	})
+
+	t.Run("omits the history line when empty", func(t *testing.T) {
+		m := new(interfaces.MockBaccaratGame)
+		setupBaccaratCuiMockDefaults(m)
+		result := p.Output(m, nil)
+		assert.NotContains(t, result, "履歴:")
+	})
 }
 
 func TestBaccaratCuiPresenter_Output_EndPhase_PlayerWins(t *testing.T) {
@@ -62,6 +95,7 @@ func TestBaccaratCuiPresenter_Output_EndPhase_PlayerWins(t *testing.T) {
 	m.On("GetResult").Return(domain.GameResultWin).Maybe()
 	m.On("GetPayout").Return(200).Maybe()
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
+	m.On("GetHistory").Return(([]int)(nil)).Maybe()
 
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "フェーズ: END")
@@ -94,6 +128,7 @@ func TestBaccaratCuiPresenter_Output_EndPhase_BankerWins(t *testing.T) {
 	m.On("GetResult").Return(domain.GameResultLose).Maybe()
 	m.On("GetPayout").Return(0).Maybe()
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
+	m.On("GetHistory").Return(([]int)(nil)).Maybe()
 
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "バンカーの勝ち")
@@ -122,6 +157,7 @@ func TestBaccaratCuiPresenter_Output_EndPhase_Tie(t *testing.T) {
 	m.On("GetResult").Return(domain.GameResultDraw).Maybe()
 	m.On("GetPayout").Return(900).Maybe()
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
+	m.On("GetHistory").Return(([]int)(nil)).Maybe()
 
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "タイ")
@@ -172,6 +208,7 @@ func TestBaccaratCuiPresenter_Output_EndPhase_UnknownResult(t *testing.T) {
 	m.On("GetResult").Return(domain.GameResult(99)).Maybe()
 	m.On("GetPayout").Return(0).Maybe()
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
+	m.On("GetHistory").Return(([]int)(nil)).Maybe()
 
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "払戻し: 0")
@@ -199,6 +236,7 @@ func TestBaccaratCuiPresenter_Output_UnknownBetType(t *testing.T) {
 	m.On("GetResult").Return(domain.GameResultWin).Maybe()
 	m.On("GetPayout").Return(200).Maybe()
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
+	m.On("GetHistory").Return(([]int)(nil)).Maybe()
 
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "UNKNOWN")

--- a/internal/adapter/presenter/BaccaratCuiPresenter_test.go
+++ b/internal/adapter/presenter/BaccaratCuiPresenter_test.go
@@ -1,6 +1,7 @@
 package presenter
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -68,6 +69,31 @@ func TestBaccaratCuiPresenter_Output_History(t *testing.T) {
 		setupBaccaratCuiMockDefaults(m)
 		result := p.Output(m, nil)
 		assert.NotContains(t, result, "履歴:")
+	})
+
+	t.Run("renders unknown result values as ? and caps the trailing run", func(t *testing.T) {
+		m := new(interfaces.MockBaccaratGame)
+		m.On("GetChips").Return(1000).Maybe()
+		m.On("GetPhase").Return(domain.BaccaratPhaseBet).Maybe()
+		m.On("GetPlayerHand").Return(([]*domain.Card)(nil)).Maybe()
+		m.On("GetBankerHand").Return(([]*domain.Card)(nil)).Maybe()
+		m.On("GetPlayerHandValue").Return(0).Maybe()
+		m.On("GetBankerHandValue").Return(0).Maybe()
+		m.On("GetGameEndFlag").Return(false).Maybe()
+		// 40 entries (> cap) ending in an unexpected value to hit both branches.
+		history := make([]int, 0, 40)
+		for range 39 {
+			history = append(history, domain.BaccaratResultPlayer)
+		}
+		history = append(history, 99)
+		m.On("GetHistory").Return(history).Maybe()
+		result := p.Output(m, nil)
+		// Unknown value maps to '?'.
+		assert.Contains(t, result, "?")
+		// Only the last baccaratHistoryMaxShown symbols are shown (29 P + 1 ?);
+		// without the cap there would be 39 P. No other P/? appears in the
+		// bet-phase output, so counting the symbol chars verifies truncation.
+		assert.Equal(t, baccaratHistoryMaxShown, strings.Count(result, "P")+strings.Count(result, "?"))
 	})
 }
 

--- a/internal/i18n/locales/en/baccarat.json
+++ b/internal/i18n/locales/en/baccarat.json
@@ -2,6 +2,7 @@
   "helpTitle": "Baccarat",
   "helpBet": "  b <amount> <type>    bet (type: 0=Player, 1=Banker, 2=Tie)",
   "chipsLine": "chips: {{chips}}",
+  "historyHeader": "History: {{symbols}}",
   "phaseLine": "phase: {{phase}}",
   "valueLine": "value: {{value}}",
   "playerHeader": "PLAYER",

--- a/internal/i18n/locales/ja/baccarat.json
+++ b/internal/i18n/locales/ja/baccarat.json
@@ -2,6 +2,7 @@
   "helpTitle": "Baccarat (バカラ)",
   "helpBet": "  b <amount> <type>    bet (type: 0=Player, 1=Banker, 2=Tie)",
   "chipsLine": "チップ: {{chips}}",
+  "historyHeader": "履歴: {{symbols}}",
   "phaseLine": "フェーズ: {{phase}}",
   "valueLine": "値: {{value}}",
   "playerHeader": "PLAYER",


### PR DESCRIPTION
## 概要
Closes #2550

Web版（`BigRoadGrid`/`RoadmapTrendBar`）はバカラ戦略の核となる出目トレンドを可視化するが、`BaccaratCuiPresenter` はチップ・両者の手・配当しか出さず履歴を一切表示しなかった。`GetHistory()` を使い、直近の勝敗履歴を P/B/T 記号の1行で表示する。

## 変更点
- `BaccaratCuiPresenter.go`: 出力末尾に `baccarat.historyHeader` 行（直近30件の P/B/T 記号、履歴が空なら非表示）。ベットフェーズ含む全フェーズで表示。
- `internal/i18n/locales/{ja,en}/baccarat.json`: `historyHeader` を追加。
- `BaccaratCuiPresenter_test.go`: 記号列表示／空時非表示 の検証＋既存モックに `GetHistory` 期待値を追加。

## テスト
- [x] `go test -tags test ./internal/adapter/presenter/ -run TestBaccaratCuiPresenter` 緑
- [x] `golangci-lint run ./internal/adapter/presenter/` 0 issues