### PR TITLE
feat(whist): add 'n' keyboard shortcut to advance trick/round

### DIFF
--- a/frontend/src/pages/WhistPage.test.tsx
+++ b/frontend/src/pages/WhistPage.test.tsx
@@ -64,6 +64,24 @@ describe('WhistPage', () => {
     );
   });
 
+  it('advances to the next trick when pressing n at trick end', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: 1 }));
+    renderWithProviders(<WhistPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のトリック' })).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: 'n' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('next'));
+  });
+
+  it('advances to the next round when pressing n at round end', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: 2 }));
+    renderWithProviders(<WhistPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のラウンド' })).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: 'n' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('nextround'));
+  });
+
   it('shows mid-game リセット button that opens confirm dialog', async () => {
     renderWithProviders(<WhistPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());

--- a/frontend/src/pages/WhistPage.tsx
+++ b/frontend/src/pages/WhistPage.tsx
@@ -16,6 +16,7 @@ import { ScrollFadeHint } from '../components/ScrollFadeHint';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { TrickDisplay } from '../components/TrickDisplay';
 import { withTutorial } from '../components/tutorial/withTutorial';
+import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useCliGame } from '../hooks/useCliGame';
@@ -143,6 +144,8 @@ function WhistPageContent() {
   const isPlayPhaseForKbd = state?.phase === WhistPhase.PLAY;
   const isHumanTurnForKbd = isPlayPhaseForKbd && state?.players[state.currentPlayerIdx]?.isHuman === true;
   const humanCardCountForKbd = state?.players.find((p) => p.isHuman)?.cards?.length ?? 0;
+  const isTrickEndForKbd = state?.phase === WhistPhase.TRICK_END;
+  const isRoundEndForKbd = state?.phase === WhistPhase.ROUND_END;
 
   const confirmAction = useCallback(() => {
     handlePlay();
@@ -155,6 +158,21 @@ function WhistPageContent() {
     onClear: clearSelection,
     enabled: !!isHumanTurnForKbd && !loading,
   });
+
+  // 'n' advances the game at a trick/round boundary, mirroring the CUI's
+  // next / nextround commands so keyboard users can progress without the mouse.
+  const advanceAction = useCallback(() => {
+    if (isTrickEndForKbd) {
+      handleNextTrick();
+    } else if (isRoundEndForKbd) {
+      handleNextRound();
+    }
+  }, [isTrickEndForKbd, isRoundEndForKbd, handleNextTrick, handleNextRound]);
+  const advanceBindings = useMemo(
+    () => [{ key: 'n', action: advanceAction, enabled: isTrickEndForKbd || isRoundEndForKbd }],
+    [advanceAction, isTrickEndForKbd, isRoundEndForKbd],
+  );
+  useActionKeyboardNav({ bindings: advanceBindings, enabled: !!state && !loading });
 
   const phaseNames = usePhaseNames('whist', WHIST_PHASE_KEYS);
 

--- a/internal/i18n/locales/en/whist.json
+++ b/internal/i18n/locales/en/whist.json
@@ -13,7 +13,7 @@
   "promptCurrentPlayer": "{{name}} to play",
   "promptPlay": "play <idx>: play a card",
   "promptTrickEnd": "Trick complete",
-  "promptTrickEndHelp": "next: advance to next trick",
+  "promptTrickEndHelp": "n / next: advance to next trick",
   "promptRoundEnd": "Round complete",
   "promptRoundEndHelp": "nr / nextround: advance to next round",
   "hintNone": "No hint available.",

--- a/internal/i18n/locales/ja/whist.json
+++ b/internal/i18n/locales/ja/whist.json
@@ -13,7 +13,7 @@
   "promptCurrentPlayer": "手番: {{name}}",
   "promptPlay": "play <idx>・・・カードを出す",
   "promptTrickEnd": "トリック終了",
-  "promptTrickEndHelp": "next・・・次のトリックへ",
+  "promptTrickEndHelp": "n / next・・・次のトリックへ",
   "promptRoundEnd": "ラウンド終了",
   "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
   "hintNone": "ヒントはありません。",


### PR DESCRIPTION
## 概要
Closes #2586

CUI は TRICK_END/ROUND_END で進行コマンド（next / nextround）を既に明示しているが、Web版はボタンのみでキーボード利用者が進められなかった。フロントに `n` キーバインドを追加し、CUI のトリック終了ヘルプも `n / next`（コントローラは両方受理済み）に揃える。

## 変更点
- `WhistPage.tsx`: `useActionKeyboardNav` で `n` を TRICK_END→次トリック / ROUND_END→次ラウンドにバインド（フェーズで分岐する単一バインディング。`useActionKeyboardNav` は最初の一致キーを採用するため同一キー重複は不可）。
- `internal/i18n/locales/{ja,en}/whist.json`: `promptTrickEndHelp` を `n / next` 表記に更新（round-end ヘルプの `nr / nextround` と統一）。
- `WhistPage.test.tsx`: TRICK_END で `n`→`next` / ROUND_END で `n`→`nextround` を検証。

## テスト
- [x] `bun run test -- --run WhistPage` 38件緑
- [x] `bun run check` パス（新規警告なし）

注: CUI 側の進行コマンド明示は既存の `promptTrickEndHelp`/`promptRoundEndHelp` で達成済みのため、冗長な新規キーは追加せず既存ヘルプをキーに合わせて更新。