### PR TITLE
refactor(spiderette,bakersdozen): unify ActionLogOutput on shared helper

### DIFF
--- a/internal/adapter/presenter/BakersDozenCuiPresenter.go
+++ b/internal/adapter/presenter/BakersDozenCuiPresenter.go
@@ -99,8 +99,5 @@ func (p *BakersDozenCuiPresenter) HintOutput(bd interfaces.BakersDozenGame) stri
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BakersDozenCuiPresenter) ActionLogOutput(bd interfaces.BakersDozenGame) string {
-	if bd.GetPhase() == domain.BakersDozenPhasePlaying {
-		return actionLogToText(nil)
-	}
-	return actionLogToText(bd.GetActionLog())
+	return actionLogOutputText(bd)
 }

--- a/internal/adapter/presenter/BakersDozenCuiPresenter_test.go
+++ b/internal/adapter/presenter/BakersDozenCuiPresenter_test.go
@@ -164,7 +164,7 @@ func TestBakersDozenCuiPresenter_HintOutput(t *testing.T) {
 func TestBakersDozenCuiPresenter_ActionLogOutput(t *testing.T) {
 	t.Run("playing phase returns empty", func(t *testing.T) {
 		bg := new(interfaces.MockBakersDozenGame)
-		bg.On("GetPhase").Return(domain.BakersDozenPhasePlaying)
+		bg.On("GetGameEndFlag").Return(false)
 
 		p := new(BakersDozenCuiPresenter)
 		result := p.ActionLogOutput(bg)
@@ -173,7 +173,7 @@ func TestBakersDozenCuiPresenter_ActionLogOutput(t *testing.T) {
 
 	t.Run("game over returns log", func(t *testing.T) {
 		bg := new(interfaces.MockBakersDozenGame)
-		bg.On("GetPhase").Return(domain.BakersDozenPhaseGameOver)
+		bg.On("GetGameEndFlag").Return(true)
 		bg.On("GetActionLog").Return([]*domain.ActionLogEntry{
 			{TurnNumber: 1, ActionType: "move", Detail: "test"},
 		})

--- a/internal/adapter/presenter/SpideretteCuiPresenter.go
+++ b/internal/adapter/presenter/SpideretteCuiPresenter.go
@@ -86,8 +86,5 @@ func (p *SpideretteCuiPresenter) HintOutput(s interfaces.SpideretteGame) string 
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SpideretteCuiPresenter) ActionLogOutput(s interfaces.SpideretteGame) string {
-	if s.GetPhase() == domain.SpiderettePhasePlaying {
-		return actionLogToText(nil)
-	}
-	return actionLogToText(s.GetActionLog())
+	return actionLogOutputText(s)
 }

--- a/internal/adapter/presenter/SpideretteCuiPresenter_test.go
+++ b/internal/adapter/presenter/SpideretteCuiPresenter_test.go
@@ -147,7 +147,7 @@ func TestSpideretteCuiPresenter_ActionLogOutput(t *testing.T) {
 
 	t.Run("during game", func(t *testing.T) {
 		sg := new(interfaces.MockSpideretteGame)
-		sg.On("GetPhase").Return(domain.SpiderettePhasePlaying)
+		sg.On("GetGameEndFlag").Return(false)
 
 		p := new(SpideretteCuiPresenter)
 		result := p.ActionLogOutput(sg)
@@ -156,7 +156,7 @@ func TestSpideretteCuiPresenter_ActionLogOutput(t *testing.T) {
 
 	t.Run("after game clear", func(t *testing.T) {
 		sg := new(interfaces.MockSpideretteGame)
-		sg.On("GetPhase").Return(domain.SpiderettePhaseGameClear)
+		sg.On("GetGameEndFlag").Return(true)
 		sg.On("GetActionLog").Return([]*domain.ActionLogEntry{
 			{TurnNumber: 1, PlayerIdx: 0, ActionType: "move", Detail: "test", Cards: nil},
 		})
@@ -169,7 +169,7 @@ func TestSpideretteCuiPresenter_ActionLogOutput(t *testing.T) {
 
 	t.Run("after game over", func(t *testing.T) {
 		sg := new(interfaces.MockSpideretteGame)
-		sg.On("GetPhase").Return(domain.SpiderettePhaseGameOver)
+		sg.On("GetGameEndFlag").Return(true)
 		sg.On("GetActionLog").Return([]*domain.ActionLogEntry{})
 
 		p := new(SpideretteCuiPresenter)


### PR DESCRIPTION
## 概要
Closes #2621

`SpideretteCuiPresenter` / `BakersDozenCuiPresenter` の `ActionLogOutput` は共通ヘルパー `actionLogOutputText` を使わず、`phase == Playing ? 空 : ログ` をインラインで実装しており、他プレゼンター（Belote/Mighty/Golf 等）と不統一だった。`GetGameEndFlag()` は『プレイ中フェーズを抜けたか』を返す（＝`phase != Playing`）ため、インラインの phase 判定と等価。両者を `actionLogOutputText` に統一して重複を解消する。

## 変更点
- `SpideretteCuiPresenter.go` / `BakersDozenCuiPresenter.go`: `ActionLogOutput` を `actionLogOutputText(g)` に統一（挙動は不変）。
- 各 `*_test.go`: モックを `GetPhase` → `GetGameEndFlag` に更新（新パスが参照するメソッドに合わせる）。

## テスト
- [x] `go test -tags test ./internal/adapter/presenter/ -run 'TestSpideretteCuiPresenter|TestBakersDozenCuiPresenter'` 緑
- [x] `golangci-lint run ./internal/adapter/presenter/` 0 issues