### PR TITLE
feat(yukon): add move-priority label to CUI hint

### DIFF
--- a/internal/adapter/presenter/YukonCuiPresenter.go
+++ b/internal/adapter/presenter/YukonCuiPresenter.go
@@ -78,13 +78,16 @@ func (p *YukonCuiPresenter) HintOutput(y interfaces.YukonGame) string {
 	from := i18n.Tf("yukon.hintFrom",
 		"col", strconv.Itoa(hint.FromCol),
 		"idx", strconv.Itoa(hint.CardIndex))
-	var to string
+	var to, confidence string
 	if hint.ToZone == "foundation" {
+		// Foundation moves never hurt, so they are the highest-priority play.
 		to = i18n.T("yukon.hintToFoundation")
+		confidence = i18n.T("yukon.hintConfidenceFoundation")
 	} else {
 		to = i18n.Tf("yukon.hintToTableau", "col", strconv.Itoa(hint.ToCol))
+		confidence = i18n.T("yukon.hintConfidenceTableau")
 	}
-	return i18n.Tf("yukon.hintLine", "from", from, "to", to) + "\n"
+	return i18n.Tf("yukon.hintLine", "from", from, "to", to, "confidence", confidence) + "\n"
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/YukonCuiPresenter_test.go
+++ b/internal/adapter/presenter/YukonCuiPresenter_test.go
@@ -125,6 +125,8 @@ func TestYukonCuiPresenter_HintOutput(t *testing.T) {
 		result := p.HintOutput(yg)
 		assert.Contains(t, result, "ヒント")
 		assert.Contains(t, result, "ファンデーション")
+		// Foundation moves carry the high-priority confidence label.
+		assert.Contains(t, result, "優先度: 高")
 	})
 
 	t.Run("hint to tableau", func(t *testing.T) {
@@ -139,6 +141,8 @@ func TestYukonCuiPresenter_HintOutput(t *testing.T) {
 		p := new(YukonCuiPresenter)
 		result := p.HintOutput(yg)
 		assert.Contains(t, result, "タブロー列3")
+		// Tableau moves carry the medium-priority confidence label.
+		assert.Contains(t, result, "優先度: 中")
 	})
 
 	t.Run("no hint", func(t *testing.T) {

--- a/internal/i18n/locales/en/yukon.json
+++ b/internal/i18n/locales/en/yukon.json
@@ -21,5 +21,7 @@
   "hintFrom": "tableau column {{col}}[{{idx}}]",
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
-  "hintLine": "Hint: {{from}} → {{to}}"
+  "hintLine": "Hint: {{from}} → {{to}} {{confidence}}",
+  "hintConfidenceFoundation": "(priority: high - safe move to a foundation)",
+  "hintConfidenceTableau": "(priority: medium - tableau reorganization)"
 }

--- a/internal/i18n/locales/ja/yukon.json
+++ b/internal/i18n/locales/ja/yukon.json
@@ -21,5 +21,7 @@
   "hintFrom": "タブロー列{{col}}[{{idx}}]",
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "hintLine": "ヒント: {{from}} → {{to}} {{confidence}}",
+  "hintConfidenceFoundation": "（優先度: 高・基礎へ送れる安全手）",
+  "hintConfidenceTableau": "（優先度: 中・盤面を整える手）"
 }


### PR DESCRIPTION
## 概要
Closes #2584

`YukonCuiPresenter.HintOutput` は from/to の単一手のみ出力し、その手の確信度/優先度が分からなかった。ドメインに confidence フィールドは無いため、ヒントの移動先（`ToZone`）から相対的な優先度ラベルを導出して付与する（基礎へ送る手は常に安全＝優先度高、タブロー手は状況依存＝優先度中）。ドメイン変更なし。

## 変更点
- `YukonCuiPresenter.go`: foundation 行きは `hintConfidenceFoundation`、tableau 行きは `hintConfidenceTableau` を `hintLine` の `{{confidence}}` に付与。
- `internal/i18n/locales/{ja,en}/yukon.json`: `hintLine` に `{{confidence}}` を追加し、`hintConfidenceFoundation`/`hintConfidenceTableau` を新設（CUI ランタイムは internal/i18n 参照）。
- `YukonCuiPresenter_test.go`: foundation→「優先度: 高」/ tableau→「優先度: 中」を検証。`cuiHintNone`（ヒント無し）は従来どおり。

## テスト
- [x] `go test -tags test ./internal/adapter/presenter/ -run TestYukonCuiPresenter` 緑
- [x] `golangci-lint run ./internal/adapter/presenter/` 0 issues