### PR TITLE
feat(oasispoker): stage dealer-qualification disclosure

### DIFF
--- a/frontend/src/i18n/locales/en/oasispoker.json
+++ b/frontend/src/i18n/locales/en/oasispoker.json
@@ -81,6 +81,7 @@
   },
   "dealerQualified": "Qualified",
   "dealerNotQualified": "Not qualified",
+  "dealerQualifyPending": "Qualification is revealed at showdown",
   "tutorial": {
     "betControls": "Set your ante and optional jackpot bet, then press Bet.",
     "exchangeControls": "Tap cards to mark them for exchange, then press Exchange or Stand. Each exchanged card costs 1x ante.",

--- a/frontend/src/i18n/locales/ja/oasispoker.json
+++ b/frontend/src/i18n/locales/ja/oasispoker.json
@@ -81,6 +81,7 @@
   },
   "dealerQualified": "クオリファイ",
   "dealerNotQualified": "未クオリファイ",
+  "dealerQualifyPending": "資格（クオリファイ）は結果フェーズで開示されます",
   "tutorial": {
     "betControls": "アンテとオプションのジャックポットを設定し、ベットを押してください。",
     "exchangeControls": "交換したいカードをタップで選択し、交換するかステイするかを選んでください。1枚交換するごとにアンテと同額の手数料が必要です。",

--- a/frontend/src/pages/OasisPokerPage.test.tsx
+++ b/frontend/src/pages/OasisPokerPage.test.tsx
@@ -112,6 +112,19 @@ describe('OasisPokerPage', () => {
     expect(screen.getByTestId('skeleton')).toBeInTheDocument();
   });
 
+  it('shows the dealer-qualification-pending note during the exchange phase', async () => {
+    mockApi.mockResolvedValue(exchangePhaseState);
+    renderWithProviders(<OasisPokerPage />);
+    await waitFor(() => expect(screen.getByTestId('dealer-qualify-pending')).toBeInTheDocument());
+  });
+
+  it('hides the pending note and shows the qualification state at the end phase', async () => {
+    mockApi.mockResolvedValue(endPhasePlayerWins);
+    renderWithProviders(<OasisPokerPage />);
+    await waitFor(() => expect(screen.getByText('クオリファイ')).toBeInTheDocument());
+    expect(screen.queryByTestId('dealer-qualify-pending')).not.toBeInTheDocument();
+  });
+
   it('transitions bet → exchange and shows exchange UI', async () => {
     mockApi.mockResolvedValueOnce(betPhaseState).mockResolvedValueOnce(exchangePhaseState);
     renderWithProviders(<OasisPokerPage />);

--- a/frontend/src/pages/OasisPokerPage.tsx
+++ b/frontend/src/pages/OasisPokerPage.tsx
@@ -331,6 +331,11 @@ function OasisPokerPageContent() {
                     ),
                   )}
                 </div>
+                {!isEndPhase && (
+                  <div className="text-ds-text-muted text-xs text-center mt-1" data-testid="dealer-qualify-pending">
+                    {t('dealerQualifyPending')}
+                  </div>
+                )}
               </div>
             )}
 


### PR DESCRIPTION
## 概要
Closes #2623

`OasisPokerPage` はディーラーの資格（クオリファイ/未クオリファイ）を結果フェーズでのみ表示し、交換フェーズ中はいつ判明するかの手掛かりが無かった。ショーダウン前のフェーズでは伏せたディーラーハンド下に「資格は結果で開示」の注釈を表示する。結果フェーズの資格ラベル表示は従来どおり。

## 変更点
- `OasisPokerPage.tsx`: `!isEndPhase` のときディーラーハンド下に `dealerQualifyPending` 注釈（`data-testid=dealer-qualify-pending`）を追加。
- `i18n/locales/{ja,en}/oasispoker.json`: `dealerQualifyPending` を新設。
- `OasisPokerPage.test.tsx`: 交換フェーズで注釈表示／結果フェーズで注釈非表示＋資格ラベル表示 を検証。

## テスト
- [x] `bun run test -- --run OasisPokerPage` 14件緑
- [x] `bun run check` パス（新規警告なし）