### PR TITLE
feat(memory): mark previously-seen face-down cells in CUI

### DIFF
--- a/internal/adapter/presenter/MemoryCuiPresenter.go
+++ b/internal/adapter/presenter/MemoryCuiPresenter.go
@@ -21,6 +21,10 @@ func memoryCellStr(bc *domain.MemoryBoardCard, pos int) string {
 	if bc.FaceUp {
 		return fmt.Sprintf("[%2d]%-10s", pos, cuiCardStr(bc.Card))
 	}
+	// Face-down: distinguish previously-seen cells (*?) from unseen ones (??).
+	if bc.Visited {
+		return fmt.Sprintf("[%2d]%-10s", pos, "*?")
+	}
 	return fmt.Sprintf("[%2d]%-10s", pos, "??")
 }
 
@@ -52,6 +56,7 @@ func (p *MemoryCuiPresenter) Output(m interfaces.MemoryGame, lastErr error) stri
 			b.WriteString("\n")
 		}
 
+		b.WriteString(i18n.T("memory.visitedLegend") + "\n")
 		b.WriteString("----------\n")
 
 		cuiErrorBlock(b, lastErr)

--- a/internal/adapter/presenter/MemoryCuiPresenter_test.go
+++ b/internal/adapter/presenter/MemoryCuiPresenter_test.go
@@ -59,6 +59,39 @@ func TestMemoryCuiPresenterOutput(t *testing.T) {
 		assert.Contains(t, result, "f <pos>")
 	})
 
+	t.Run("marks visited face-down cells distinctly with a legend", func(t *testing.T) {
+		mg := newMockMemoryGame()
+		setupMemoryMockDefaults(mg)
+		mg.ExpectedCalls = nil // clear defaults
+		mg.On("GetPlayerCnt").Return(4)
+		mg.On("GetGameEndFlag").Return(false)
+		mg.On("GetPhase").Return(domain.MemoryPhaseFlip1)
+		mg.On("GetCurrentPlayerIdx").Return(0)
+		mg.On("GetLastMatchResult").Return(false)
+		mg.On("GetWinnerIdx").Return(-1)
+
+		var board [domain.MemoryBoardSize]*domain.MemoryBoardCard
+		for i := 0; i < domain.MemoryBoardSize; i++ {
+			board[i] = &domain.MemoryBoardCard{
+				Card:   domain.NewCard(domain.CardDesignSpade, (i%13)+1, false),
+				FaceUp: false,
+				Taken:  false,
+			}
+		}
+		// Position 0 was seen before (face-down but visited).
+		board[0].Visited = true
+		mg.On("GetBoard").Return(board)
+		for i := 0; i < 4; i++ {
+			mg.On("GetPlayer", i).Return(domain.NewMemoryPlayer(i == 0))
+		}
+
+		p := new(MemoryCuiPresenter)
+		result := p.Output(mg, nil)
+		assert.Contains(t, result, "*?") // visited, face-down
+		assert.Contains(t, result, "??") // unvisited cells
+		assert.Contains(t, result, "凡例")
+	})
+
 	t.Run("flip2 phase", func(t *testing.T) {
 		mg := newMockMemoryGame()
 		setupMemoryMockDefaults(mg)

--- a/internal/domain/Memory.go
+++ b/internal/domain/Memory.go
@@ -35,6 +35,9 @@ type MemoryBoardCard struct {
 	Card   *Card `json:"c"`
 	FaceUp bool  `json:"f"`
 	Taken  bool  `json:"t"`
+	// Visited is true once the card has been turned face up at least once,
+	// powering the CUI/Web memory aids for previously-seen face-down cells.
+	Visited bool `json:"v"`
 }
 
 // CPU記憶パラメータ (難易度別)
@@ -309,6 +312,7 @@ func (m *Memory) flip(pos int) error {
 	}
 
 	bc.FaceUp = true
+	bc.Visited = true
 	retentionChance := m.retentionChance()
 
 	// 全CPUプレイヤーに公開されたカードを記憶させる

--- a/internal/i18n/locales/en/memory.json
+++ b/internal/i18n/locales/en/memory.json
@@ -4,6 +4,7 @@
   "helpNext": "  n                    next turn",
   "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
   "playerLine": "{{name}}: {{pairs}} pair(s)",
+  "visitedLegend": "Legend: *? = seen before (flipped once) / ?? = unseen",
   "promptFlip1": "{{name}} — pick the first card",
   "promptFlip2": "{{name}} — pick the second card",
   "promptFlipHelp": "f <pos>: flip a card",

--- a/internal/i18n/locales/ja/memory.json
+++ b/internal/i18n/locales/ja/memory.json
@@ -4,6 +4,7 @@
   "helpNext": "  n                    next turn",
   "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
   "playerLine": "{{name}}: {{pairs}}ペア",
+  "visitedLegend": "凡例: *? = 既出（一度めくられた札） / ?? = 未確認",
   "promptFlip1": "手番: {{name}} — 1枚目を選んでください",
   "promptFlip2": "手番: {{name}} — 2枚目を選んでください",
   "promptFlipHelp": "f <pos>・・・カードをめくる",


### PR DESCRIPTION
## 概要
Closes #2545

CUI版 `MemoryCuiPresenter` は裏向きセルを一律 `??` で描画し、CUIプレイヤーは盤面52マスを完全に暗記するしかなかった（Web版は既出札に目印を表示）。`MemoryBoardCard` に `Visited` フラグを追加し、一度でも表になったセルを記憶補助として描き分ける。

## 変更点
- `internal/domain/Memory.go`: `MemoryBoardCard` に `Visited bool`（json `v`）を追加し、カードを表にする箇所で `Visited = true` をセット。
- `MemoryCuiPresenter.go`: 裏向きセルを訪問済み `*?` / 未訪問 `??` で描き分け、凡例行 `visitedLegend` を出力。
- `internal/i18n/locales/{ja,en}/memory.json`: `visitedLegend` を追加。
- `MemoryCuiPresenter_test.go`: `*?`/`??`/凡例 の描き分けを検証。

## テスト
- [x] `go test -tags test ./internal/adapter/presenter/ -run TestMemoryCuiPresenter` 緑
- [x] ドメイン変更は `Visited` フィールド追加＋フリップ箇所1行のみ（`TestMemorySetBoard` はフリップ無し→`Visited`=false 維持で不変）。Backend Tests/Lint は CI で検証。