### PR TITLE
feat(badugi): add best-subset draw hint to CUI

### DIFF
--- a/internal/adapter/controller/BadugiCuiController.go
+++ b/internal/adapter/controller/BadugiCuiController.go
@@ -44,7 +44,7 @@ func (bcc *BadugiCuiController) Exec(command string) string {
 			"e", "exchange", "s", "stand", "b", "bet", "c", "call", "ra", "raise",
 			"f", "fold", "ck", "check", "a", "allin",
 			"bl", "bettinglimit", "scc", "setcpucount", "mai", "metaai",
-			"log", "l",
+			"h", "hint", "log", "l",
 		},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
@@ -91,7 +91,7 @@ func (bcc *BadugiCuiController) Exec(command string) string {
 				cfg.CpuMetaAI = v == 1
 				return bcc.bi.ResetWithConfig(cfg, nil), true
 			default:
-				return handleCuiLog(cmd, bcc.bi.ActionLog)
+				return handleCuiHintAndLog(cmd, bcc.bi.Hint, bcc.bi.ActionLog)
 			}
 		},
 	)

--- a/internal/adapter/controller/usecase/BadugiInteractor_mock.go
+++ b/internal/adapter/controller/usecase/BadugiInteractor_mock.go
@@ -50,6 +50,11 @@ func (m *MockBadugiInteractor) Stand() string {
 }
 
 // ActionLog mock.
+func (m *MockBadugiInteractor) Hint() string {
+	ret := m.Called()
+	return ret.Get(0).(string)
+}
+
 func (m *MockBadugiInteractor) ActionLog() string {
 	ret := m.Called()
 	return ret.Get(0).(string)

--- a/internal/adapter/presenter/BadugiCuiPresenter.go
+++ b/internal/adapter/presenter/BadugiCuiPresenter.go
@@ -131,3 +131,45 @@ func (bcp *BadugiCuiPresenter) Output(g interfaces.BadugiGame, lastErr error) st
 func (bcp *BadugiCuiPresenter) ActionLogOutput(g interfaces.BadugiGame) string {
 	return actionLogOutputText(g)
 }
+
+// HintOutput emits a draw-phase recommendation: which cards form the current
+// best Badugi subset (keep) and which to exchange. Mirrors the CPU's
+// best-subset discard logic so the human gets the same guidance.
+func (bcp *BadugiCuiPresenter) HintOutput(g interfaces.BadugiGame) string {
+	if g.GetPhase() != domain.BadugiPhaseDraw {
+		return i18n.T("badugi.hintNone") + "\n"
+	}
+	turn := g.GetCurrentTurn()
+	players := g.GetPlayers()
+	if turn < 0 || turn >= len(players) {
+		return i18n.T("badugi.hintNone") + "\n"
+	}
+	pl := players[turn]
+	if !pl.GetIsHuman() {
+		return i18n.T("badugi.hintNone") + "\n"
+	}
+	// EvalHand idempotently recomputes the cached best subset from the current
+	// cards; the draw phase does not otherwise refresh it for the human.
+	pl.EvalHand()
+	best := pl.GetBestHand()
+	kept := make(map[*domain.Card]bool, len(best.Cards))
+	for _, c := range best.Cards {
+		kept[c] = true
+	}
+	keep := make([]string, 0, best.Size)
+	discard := make([]string, 0, pl.GetCardsSize())
+	for i := 0; i < pl.GetCardsSize(); i++ {
+		if kept[pl.GetCard(i)] {
+			keep = append(keep, strconv.Itoa(i))
+		} else {
+			discard = append(discard, strconv.Itoa(i))
+		}
+	}
+	if len(discard) == 0 {
+		return color.Yellow(i18n.Tf("badugi.hintStandPat", "size", strconv.Itoa(best.Size))) + "\n"
+	}
+	return color.Yellow(i18n.Tf("badugi.hintExchange",
+		"keep", strings.Join(keep, ","),
+		"discard", strings.Join(discard, ","),
+		"size", strconv.Itoa(best.Size))) + "\n"
+}

--- a/internal/adapter/presenter/BadugiCuiPresenter_test.go
+++ b/internal/adapter/presenter/BadugiCuiPresenter_test.go
@@ -52,6 +52,45 @@ func TestBadugiCuiPresenter_Output_ShowsHumanHand(t *testing.T) {
 	}
 }
 
+func TestBadugiCuiPresenter_HintOutput_StandPat(t *testing.T) {
+	pres := new(presenter.BadugiCuiPresenter)
+	bd, players := makeBadugiForPresenter()
+	bd.SetPhase(domain.BadugiPhaseDraw)
+	bd.SetCurrentTurn(0)
+	// A complete 4-card Badugi (all ranks and suits distinct).
+	players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 1, false))
+	players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 2, false))
+	players[0].AddCard(domain.NewCard(domain.CardDesignDiamond, 3, false))
+	players[0].AddCard(domain.NewCard(domain.CardDesignClover, 4, false))
+
+	out := pres.HintOutput(bd)
+	assert.Contains(t, out, "スタンドパット")
+}
+
+func TestBadugiCuiPresenter_HintOutput_Exchange(t *testing.T) {
+	pres := new(presenter.BadugiCuiPresenter)
+	bd, players := makeBadugiForPresenter()
+	bd.SetPhase(domain.BadugiPhaseDraw)
+	bd.SetCurrentTurn(0)
+	// Two spades + two hearts: best Badugi subset is only 2 cards, so the
+	// other two should be flagged for exchange.
+	players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 1, false))
+	players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
+	players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 3, false))
+	players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 4, false))
+
+	out := pres.HintOutput(bd)
+	assert.Contains(t, out, "交換")
+}
+
+func TestBadugiCuiPresenter_HintOutput_NoneOutsideDraw(t *testing.T) {
+	pres := new(presenter.BadugiCuiPresenter)
+	bd, _ := makeBadugiForPresenter()
+	bd.SetPhase(domain.BadugiPhaseDeal)
+
+	assert.Contains(t, pres.HintOutput(bd), "ヒントはありません")
+}
+
 func TestBadugiCuiPresenter_Output_ShowsFoldedBadge(t *testing.T) {
 	pres := new(presenter.BadugiCuiPresenter)
 	bd, players := makeBadugiForPresenter()

--- a/internal/adapter/presenter/BadugiWebPresenter.go
+++ b/internal/adapter/presenter/BadugiWebPresenter.go
@@ -17,6 +17,13 @@ func (bwp *BadugiWebPresenter) Output(g interfaces.BadugiGame, lastErr error) st
 }
 
 // ActionLogOutput marshals the action log to JSON.
+// HintOutput returns the current state as JSON. The Web GUI computes its own
+// draw hint client-side, so this mirrors Output to satisfy the BadugiPresenter
+// interface shared with the CUI.
+func (bwp *BadugiWebPresenter) HintOutput(g interfaces.BadugiGame) string {
+	return bwp.Output(g, nil)
+}
+
 func (bwp *BadugiWebPresenter) ActionLogOutput(g interfaces.BadugiGame) string {
 	return actionLogOutputJSON(g)
 }

--- a/internal/adapter/presenter/BadugiWebPresenter_test.go
+++ b/internal/adapter/presenter/BadugiWebPresenter_test.go
@@ -24,6 +24,18 @@ func makeBadugiForPresenter() (*domain.Badugi, []*domain.BadugiPlayer) {
 	return domain.NewBadugi(tc, players, domain.DefaultBadugiConfig()), players
 }
 
+func TestBadugiWebPresenter_HintOutput(t *testing.T) {
+	pres := new(presenter.BadugiWebPresenter)
+	bd, _ := makeBadugiForPresenter()
+	bd.SetPhase(domain.BadugiPhaseDeal)
+
+	// HintOutput mirrors Output (the GUI computes its own hint client-side).
+	var out controller.BadugiWebOutput
+	require.NoError(t, json.Unmarshal([]byte(pres.HintOutput(bd)), &out))
+	assert.Equal(t, domain.BadugiPhaseDeal, out.Phase)
+	assert.Equal(t, 4, len(out.Players))
+}
+
 func TestBadugiWebPresenter_Output_Initial(t *testing.T) {
 	pres := new(presenter.BadugiWebPresenter)
 	bd, players := makeBadugiForPresenter()

--- a/internal/i18n/locales/en/badugi.json
+++ b/internal/i18n/locales/en/badugi.json
@@ -1,5 +1,8 @@
 {
   "helpTitle": "Badugi",
+  "hintNone": "No hint available",
+  "hintStandPat": "Recommendation: stand pat (a {{size}}-card Badugi is complete)",
+  "hintExchange": "Recommendation: keep [{{keep}}], exchange [{{discard}}] (best subset {{size}})",
   "helpBet": "  b [amount]           bet (e.g. b 20)",
   "helpCall": "  c                    call",
   "helpRaise": "  ra [amount]          raise (e.g. ra 30)",

--- a/internal/i18n/locales/ja/badugi.json
+++ b/internal/i18n/locales/ja/badugi.json
@@ -1,5 +1,8 @@
 {
   "helpTitle": "Badugi (バドゥーギ)",
+  "hintNone": "ヒントはありません",
+  "hintStandPat": "推奨: スタンドパット（現在 {{size}} 枚のバドゥーギが完成）",
+  "hintExchange": "推奨: [{{keep}}] を残し [{{discard}}] を交換（最善サブセット {{size}} 枚）",
   "helpBet": "  b [amount]           ベット (例: b 20)",
   "helpCall": "  c                    コール",
   "helpRaise": "  ra [amount]          レイズ (例: ra 30)",

--- a/internal/usecase/BadugiInteractor.go
+++ b/internal/usecase/BadugiInteractor.go
@@ -27,6 +27,8 @@ type BadugiInteractorIF interface {
 	Exchange(indices []int) string
 	// Stand passes on the current draw.
 	Stand() string
+	// Hint returns the hint output for the current hand.
+	Hint() string
 	// ActionLog returns the log output for the current hand.
 	ActionLog() string
 }
@@ -93,6 +95,11 @@ func (bi *BadugiInteractor) Stand() string {
 // ActionLog returns the log output for the current hand.
 func (bi *BadugiInteractor) ActionLog() string {
 	return bi.pp.ActionLogOutput(bi.Game)
+}
+
+// Hint returns the hint output for the current hand.
+func (bi *BadugiInteractor) Hint() string {
+	return bi.pp.HintOutput(bi.Game)
 }
 
 // RestoreBadugiInteractor deserialises JSON into a BadugiInteractor. Used by

--- a/internal/usecase/BadugiInteractor_test.go
+++ b/internal/usecase/BadugiInteractor_test.go
@@ -178,6 +178,15 @@ func TestBadugiInteractor_ActionLog(t *testing.T) {
 	mp.AssertExpectations(t)
 }
 
+func TestBadugiInteractor_Hint(t *testing.T) {
+	mg, mp := newBadugiMocks()
+	mp.On("HintOutput", mg).Return("hint output")
+	bi := usecase.NewBadugiInteractor(mg, mp)
+
+	assert.Equal(t, "hint output", bi.Hint())
+	mp.AssertExpectations(t)
+}
+
 func TestBadugiInteractor_Snapshot(t *testing.T) {
 	g := domain.NewDefaultBadugi()
 	bi := usecase.NewBadugiInteractor(g, new(presenter.MockBadugiPresenter))

--- a/internal/usecase/presenter/BadugiPresenter.go
+++ b/internal/usecase/presenter/BadugiPresenter.go
@@ -9,4 +9,8 @@ import (
 // BadugiPresenter is the Badugi-specific presenter alias over the generic
 // GamePresenter. Adapter-side implementations satisfy this via Output +
 // ActionLogOutput.
-type BadugiPresenter = GamePresenter[interfaces.BadugiGame]
+type BadugiPresenter interface {
+	GamePresenter[interfaces.BadugiGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.BadugiGame) string
+}

--- a/internal/usecase/presenter/BadugiPresenter_mock.go
+++ b/internal/usecase/presenter/BadugiPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockBadugiPresenter is the testify/mock presenter for Badugi.
-type MockBadugiPresenter = MockGamePresenter[interfaces.BadugiGame]
+type MockBadugiPresenter struct {
+	MockGamePresenter[interfaces.BadugiGame]
+}
+
+// HintOutput モック
+func (_m *MockBadugiPresenter) HintOutput(g interfaces.BadugiGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 概要
Closes #2591

`BadugiCuiPresenter` にはドローフェーズのヒントが無く、Web版と機能格差があった。#2565 と同じ alias→bespoke 配線で HintOutput を通し、ドローフェーズの人間手番で「最善サブセット（残す札）と交換すべき札」を提示する（4枚バドゥーギ完成時はスタンドパット推奨）。

## 変更点（alias→bespoke パターン）
- `usecase/presenter/BadugiPresenter.go` / `_mock.go`: エイリアス→専用 interface/モック（HintOutput 付き）。
- `adapter/presenter/BadugiCuiPresenter.go`: `HintOutput` — ドローフェーズ＋人間手番で `pl.EvalHand()`（最善サブセットの冪等な再計算）→ `GetBestHand()` の Cards をポインタ一致で keep/discard に振り分け、`hintStandPat`/`hintExchange` を出力。CPU の best-subset 破棄ロジックと同方針。
- `adapter/presenter/BadugiWebPresenter.go`: 共有 interface 充足のため `HintOutput`→`Output` 委譲（GUI はクライアント側ヒント）。
- `usecase/BadugiInteractor.go`: `Hint()` + IF。controller mock に `Hint()`。
- `adapter/controller/BadugiCuiController.go`: `h`/`hint` コマンド配線。
- `internal/i18n/locales/{ja,en}/badugi.json`: `hintNone`/`hintStandPat`/`hintExchange`。

## テスト
- [x] presenter/usecase/controller の Badugi テスト緑（stand-pat / exchange / 非ドロー、interactor Hint、web HintOutput）
- [x] `golangci-lint` 0 issues（5パッケージ）