### PR TITLE
feat(scopa): add capture hint to CUI

### DIFF
--- a/internal/adapter/controller/ScopaCuiController.go
+++ b/internal/adapter/controller/ScopaCuiController.go
@@ -32,7 +32,7 @@ func (c *ScopaCuiController) Exec(command string) string {
 			return c.si.ResetWithConfig(cfg)
 		},
 		[]string{
-			"play", "p", "next", "n", "sd", "setdifficulty", "log", "l",
+			"play", "p", "next", "n", "sd", "setdifficulty", "h", "hint", "log", "l",
 		},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
@@ -47,7 +47,7 @@ func (c *ScopaCuiController) Exec(command string) string {
 					return c.si.ResetWithConfig(cfg)
 				})
 			default:
-				return handleCuiLog(cmd, c.si.ActionLog)
+				return handleCuiHintAndLog(cmd, c.si.Hint, c.si.ActionLog)
 			}
 		},
 	)

--- a/internal/adapter/controller/usecase/ScopaInteractor_mock.go
+++ b/internal/adapter/controller/usecase/ScopaInteractor_mock.go
@@ -43,6 +43,12 @@ func (_m *MockScopaInteractor) ResetWithConfig(config domain.ScopaConfig) string
 	return ret.Get(0).(string)
 }
 
+// Hint モック
+func (_m *MockScopaInteractor) Hint() string {
+	ret := _m.Called()
+	return ret.Get(0).(string)
+}
+
 // ActionLog モック
 func (_m *MockScopaInteractor) ActionLog() string {
 	ret := _m.Called()

--- a/internal/adapter/presenter/ScopaCuiPresenter.go
+++ b/internal/adapter/presenter/ScopaCuiPresenter.go
@@ -104,6 +104,51 @@ func scopaCardShort(c *domain.Card) string {
 	return cuiCardSliceStr([]*domain.Card{c})
 }
 
+// HintOutput emits a capture recommendation for the human's turn: the hand
+// card and the table cards it captures (flagging a scopa when it clears the
+// table), reusing the domain's EnumerateScopaCaptures.
+func (p *ScopaCuiPresenter) HintOutput(sg interfaces.ScopaGame) string {
+	if sg.GetPhase() != domain.ScopaPhasePlayerTurn {
+		return i18n.T("scopa.hintNone") + "\n"
+	}
+	turn := sg.GetCurrentTurn()
+	player := sg.GetPlayer(turn)
+	if player == nil || !player.GetIsHuman() {
+		return i18n.T("scopa.hintNone") + "\n"
+	}
+	table := sg.GetTableCards()
+	bestHand := -1
+	var bestCap []int
+	bestScopa := false
+	for i := 0; i < player.GetCardsSize(); i++ {
+		for _, cap := range domain.EnumerateScopaCaptures(player.GetCard(i), table) {
+			isScopa := len(table) > 0 && len(cap) == len(table)
+			switch {
+			case bestHand == -1:
+			case isScopa && !bestScopa:
+			case isScopa == bestScopa && len(cap) > len(bestCap):
+			default:
+				continue
+			}
+			bestHand, bestCap, bestScopa = i, cap, isScopa
+		}
+	}
+	if bestHand == -1 {
+		return color.Yellow(i18n.T("scopa.hintNoCapture")) + "\n"
+	}
+	capCards := make([]*domain.Card, 0, len(bestCap))
+	for _, idx := range bestCap {
+		capCards = append(capCards, table[idx])
+	}
+	key := "scopa.hintCapture"
+	if bestScopa {
+		key = "scopa.hintScopa"
+	}
+	return color.Yellow(i18n.Tf(key,
+		"played", scopaCardShort(player.GetCard(bestHand)),
+		"captured", cuiCardSliceStr(capCards))) + "\n"
+}
+
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ScopaCuiPresenter) ActionLogOutput(sg interfaces.ScopaGame) string {
 	return actionLogOutputText(sg)

--- a/internal/adapter/presenter/ScopaCuiPresenter_test.go
+++ b/internal/adapter/presenter/ScopaCuiPresenter_test.go
@@ -36,6 +36,56 @@ type scopaAssertErr struct{}
 
 func (scopaAssertErr) Error() string { return "boom" }
 
+func TestScopaCuiPresenter_HintOutput(t *testing.T) {
+	p := &presenter.ScopaCuiPresenter{}
+	build := func(handVal, handSuit int, table []*domain.Card) *domain.Scopa {
+		s := domain.ScopaTestNew(domain.DefaultScopaConfig())
+		s.ScopaTestSetPhase(domain.ScopaPhasePlayerTurn)
+		s.ScopaTestSetCurrentTurn(0)
+		s.GetPlayer(0).AddCard(domain.NewCard(handSuit, handVal, false))
+		s.ScopaTestSetTable(table)
+		return s
+	}
+
+	t.Run("scopa sweep", func(t *testing.T) {
+		s := build(7, domain.CardDesignHeart, []*domain.Card{
+			domain.NewCard(domain.CardDesignDiamond, 3, false),
+			domain.NewCard(domain.CardDesignClover, 4, false),
+		})
+		if out := p.HintOutput(s); !strings.Contains(out, "スコパ") {
+			t.Errorf("expected scopa hint, got: %s", out)
+		}
+	})
+
+	t.Run("plain capture", func(t *testing.T) {
+		s := build(7, domain.CardDesignHeart, []*domain.Card{
+			domain.NewCard(domain.CardDesignDiamond, 7, false),
+			domain.NewCard(domain.CardDesignClover, 5, false),
+		})
+		if out := p.HintOutput(s); !strings.Contains(out, "捕獲") {
+			t.Errorf("expected capture hint, got: %s", out)
+		}
+	})
+
+	t.Run("no capture", func(t *testing.T) {
+		s := build(2, domain.CardDesignHeart, []*domain.Card{
+			domain.NewCard(domain.CardDesignDiamond, 7, false),
+			domain.NewCard(domain.CardDesignClover, 5, false),
+		})
+		if out := p.HintOutput(s); !strings.Contains(out, "捕獲できる手はありません") {
+			t.Errorf("expected no-capture hint, got: %s", out)
+		}
+	})
+
+	t.Run("none outside player turn", func(t *testing.T) {
+		s := domain.ScopaTestNew(domain.DefaultScopaConfig())
+		s.ScopaTestSetPhase(domain.ScopaPhaseRoundEnd)
+		if out := p.HintOutput(s); !strings.Contains(out, "ヒントはありません") {
+			t.Errorf("expected none hint, got: %s", out)
+		}
+	})
+}
+
 func TestScopaCuiPresenter_ActionLogOutput(t *testing.T) {
 	p := &presenter.ScopaCuiPresenter{}
 	s := buildPlayedScopa(t)

--- a/internal/adapter/presenter/ScopaWebPresenter.go
+++ b/internal/adapter/presenter/ScopaWebPresenter.go
@@ -135,6 +135,13 @@ func (swp *ScopaWebPresenter) buildResultMessage(sg interfaces.ScopaGame) string
 }
 
 // ActionLogOutput 棋譜を JSON 出力。
+// HintOutput returns the current state as JSON. The Web GUI computes its own
+// hint client-side, so this mirrors Output to satisfy the ScopaPresenter
+// interface shared with the CUI.
+func (swp *ScopaWebPresenter) HintOutput(sg interfaces.ScopaGame) string {
+	return swp.Output(sg, nil)
+}
+
 func (swp *ScopaWebPresenter) ActionLogOutput(sg interfaces.ScopaGame) string {
 	return actionLogOutputJSON(sg)
 }

--- a/internal/adapter/presenter/ScopaWebPresenter_test.go
+++ b/internal/adapter/presenter/ScopaWebPresenter_test.go
@@ -31,6 +31,20 @@ func TestScopaWebPresenter_OutputJSON(t *testing.T) {
 	}
 }
 
+func TestScopaWebPresenter_HintOutput(t *testing.T) {
+	p := &presenter.ScopaWebPresenter{}
+	s := buildScoredScopa(t)
+	// HintOutput mirrors Output (the GUI computes its own hint client-side).
+	out := p.HintOutput(s)
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("hint output is not valid JSON: %v", err)
+	}
+	if _, ok := parsed["phase"]; !ok {
+		t.Errorf("missing phase key in hint output")
+	}
+}
+
 func TestScopaWebPresenter_OutputError(t *testing.T) {
 	p := &presenter.ScopaWebPresenter{}
 	s := buildScoredScopa(t)

--- a/internal/i18n/locales/en/scopa.json
+++ b/internal/i18n/locales/en/scopa.json
@@ -1,5 +1,9 @@
 {
   "helpTitle": "Scopa",
+  "hintNone": "No hint available",
+  "hintNoCapture": "No capture available; lay your lowest card",
+  "hintCapture": "Recommendation: play {{played}} to capture {{captured}}",
+  "hintScopa": "Recommendation: play {{played}} to sweep {{captured}} (scopa!)",
   "helpPlay": "  p <h> [t...]             play hand h (capture table cards t..., or lay if none given)",
   "helpNext": "  n                        start the next round",
   "helpSetDifficulty": "  sd [0-2]                 CPU difficulty (0=Easy, 1=Normal, 2=Hard)",

--- a/internal/i18n/locales/ja/scopa.json
+++ b/internal/i18n/locales/ja/scopa.json
@@ -1,5 +1,9 @@
 {
   "helpTitle": "Scopa (スコパ)",
+  "hintNone": "ヒントはありません",
+  "hintNoCapture": "捕獲できる手はありません。最小札を場に置きましょう",
+  "hintCapture": "推奨: {{played}} で 場札 {{captured}} を捕獲",
+  "hintScopa": "推奨: {{played}} で 場札 {{captured}} を全取り（スコパ！）",
   "helpPlay": "  p <h> [t...]             手札hを出す (場札t...を捕獲、無指定で場に置く)",
   "helpNext": "  n                        次のラウンドを開始する",
   "helpSetDifficulty": "  sd [0-2]                 CPU難易度 (0=Easy, 1=Normal, 2=Hard)",

--- a/internal/usecase/ScopaInteractor.go
+++ b/internal/usecase/ScopaInteractor.go
@@ -22,6 +22,8 @@ type ScopaInteractorIF interface {
 	ResetWithConfig(config domain.ScopaConfig) string
 	// GetConfig 現在の設定を返す
 	GetConfig() domain.ScopaConfig
+	// Hint ヒントを出力する
+	Hint() string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
 }
@@ -81,6 +83,11 @@ func (si *ScopaInteractor) ResetWithConfig(config domain.ScopaConfig) string {
 // ActionLog 棋譜を出力する。
 func (si *ScopaInteractor) ActionLog() string {
 	return si.sp.ActionLogOutput(si.Game)
+}
+
+// Hint ヒントを出力する。
+func (si *ScopaInteractor) Hint() string {
+	return si.sp.HintOutput(si.Game)
 }
 
 // scopaMaxCpuIterations は runCpuTurns の防御的な反復上限。

--- a/internal/usecase/ScopaInteractor_test.go
+++ b/internal/usecase/ScopaInteractor_test.go
@@ -64,6 +64,15 @@ func TestScopaInteractor_ActionLog(t *testing.T) {
 	spMock.AssertExpectations(t)
 }
 
+func TestScopaInteractor_Hint(t *testing.T) {
+	spMock := new(presenter.MockScopaPresenter)
+	gameMock := new(interfaces.MockScopaGame)
+	spMock.On("HintOutput", gameMock).Return("hint output")
+	si := usecase.NewScopaInteractor(gameMock, spMock)
+	assert.Equal(t, "hint output", si.Hint())
+	spMock.AssertExpectations(t)
+}
+
 func TestScopaInteractor_MockGame(t *testing.T) {
 	mockOutput := `{"players":[]}`
 	spMock := new(presenter.MockScopaPresenter)

--- a/internal/usecase/presenter/ScopaPresenter.go
+++ b/internal/usecase/presenter/ScopaPresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // ScopaPresenter スコパプレゼンターインタフェース。
-type ScopaPresenter = GamePresenter[interfaces.ScopaGame]
+type ScopaPresenter interface {
+	GamePresenter[interfaces.ScopaGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.ScopaGame) string
+}

--- a/internal/usecase/presenter/ScopaPresenter_mock.go
+++ b/internal/usecase/presenter/ScopaPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockScopaPresenter スコパプレゼンターモック。
-type MockScopaPresenter = MockGamePresenter[interfaces.ScopaGame]
+type MockScopaPresenter struct {
+	MockGamePresenter[interfaces.ScopaGame]
+}
+
+// HintOutput モック
+func (_m *MockScopaPresenter) HintOutput(g interfaces.ScopaGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 概要
Closes #2641

`ScopaCuiPresenter` には捕獲判断を助けるヒントが無く、Web版（HintTooltip）と非対称だった。alias→bespoke 配線で HintOutput を通し、人間手番で「どの手札でどの場札を捕獲できるか（場を全取りするスコパも明示）」を出力する。

## 変更点（alias→bespoke パターン）
- `usecase/presenter/ScopaPresenter.go`/`_mock.go`: エイリアス→専用 interface/モック。
- `adapter/presenter/ScopaCuiPresenter.go`: `HintOutput` — playerTurn＋人間手番で各手札に `domain.EnumerateScopaCaptures` を適用し、最良の捕獲（スコパ＞捕獲枚数最大）を `hintCapture`/`hintScopa` で出力。捕獲不可なら `hintNoCapture`。単一一致優先などの捕獲規則はドメイン関数を再利用。
- `adapter/presenter/ScopaWebPresenter.go`: `HintOutput`→`Output` 委譲（GUI はクライアント側ヒント）。
- `usecase/ScopaInteractor.go`: `Hint()`+IF。mock に `Hint()`。
- `adapter/controller/ScopaCuiController.go`: `h`/`hint` 配線。
- `internal/i18n/locales/{ja,en}/scopa.json`: `hintNone`/`hintNoCapture`/`hintCapture`/`hintScopa`。

## テスト
- [x] presenter/usecase/controller の Scopa テスト緑（scopa-sweep / capture / no-capture / 非playerTurn、interactor Hint、web HintOutput）
- [x] `golangci-lint` 0 issues（5パッケージ）