### PR TITLE
feat(escoba): add capture hint to CUI

### DIFF
--- a/internal/adapter/controller/EscobaCuiController.go
+++ b/internal/adapter/controller/EscobaCuiController.go
@@ -34,7 +34,7 @@ func (c *EscobaCuiController) Exec(command string) string {
 		},
 		[]string{
 			"play", "p", "next", "n", "nextround",
-			"sd", "setdifficulty", "st", "settarget", "log", "l",
+			"sd", "setdifficulty", "st", "settarget", "h", "hint", "log", "l",
 		},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
@@ -55,7 +55,7 @@ func (c *EscobaCuiController) Exec(command string) string {
 					return c.ei.ResetWithConfig(cfg)
 				})
 			default:
-				return handleCuiLog(cmd, c.ei.ActionLog)
+				return handleCuiHintAndLog(cmd, c.ei.Hint, c.ei.ActionLog)
 			}
 		},
 	)

--- a/internal/adapter/controller/usecase/EscobaInteractor_mock.go
+++ b/internal/adapter/controller/usecase/EscobaInteractor_mock.go
@@ -43,6 +43,12 @@ func (_m *MockEscobaInteractor) ResetWithConfig(config domain.EscobaConfig) stri
 	return ret.Get(0).(string)
 }
 
+// Hint モック
+func (_m *MockEscobaInteractor) Hint() string {
+	ret := _m.Called()
+	return ret.Get(0).(string)
+}
+
 // ActionLog モック
 func (_m *MockEscobaInteractor) ActionLog() string {
 	ret := _m.Called()

--- a/internal/adapter/presenter/EscobaCuiPresenter.go
+++ b/internal/adapter/presenter/EscobaCuiPresenter.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
@@ -90,6 +91,51 @@ func escobaScoreDetailStr(b *strings.Builder, det *domain.EscobaScoreDetail) {
 	b.WriteString(i18n.Tf("escoba.specialLine",
 		"ace", strconv.Itoa(det.AceEsp),
 		"sete", strconv.Itoa(det.SeteEsp)) + "\n")
+}
+
+// HintOutput emits a capture recommendation for the human's turn: the hand
+// card and the table cards summing to 15 it captures (flagging an escoba when
+// it clears the table), reusing the domain's GetValidCaptures.
+func (p *EscobaCuiPresenter) HintOutput(eg interfaces.EscobaGame) string {
+	if eg.GetPhase() != domain.EscobaPhasePlayerTurn {
+		return i18n.T("escoba.hintNone") + "\n"
+	}
+	turn := eg.GetCurrentTurn()
+	player := eg.GetPlayer(turn)
+	if player == nil || !player.GetIsHuman() {
+		return i18n.T("escoba.hintNone") + "\n"
+	}
+	table := eg.GetTableCards()
+	bestHand := -1
+	var bestCap []int
+	bestEscoba := false
+	for i := 0; i < player.GetCardsSize(); i++ {
+		for _, cap := range eg.GetValidCaptures(i) {
+			isEscoba := len(table) > 0 && len(cap) == len(table)
+			switch {
+			case bestHand == -1:
+			case isEscoba && !bestEscoba:
+			case isEscoba == bestEscoba && len(cap) > len(bestCap):
+			default:
+				continue
+			}
+			bestHand, bestCap, bestEscoba = i, cap, isEscoba
+		}
+	}
+	if bestHand == -1 {
+		return color.Yellow(i18n.T("escoba.hintNoCapture")) + "\n"
+	}
+	capCards := make([]*domain.Card, 0, len(bestCap))
+	for _, idx := range bestCap {
+		capCards = append(capCards, table[idx])
+	}
+	key := "escoba.hintCapture"
+	if bestEscoba {
+		key = "escoba.hintEscoba"
+	}
+	return color.Yellow(i18n.Tf(key,
+		"played", cuiCardSliceStr([]*domain.Card{player.GetCard(bestHand)}),
+		"captured", cuiCardSliceStr(capCards))) + "\n"
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/EscobaCuiPresenter_test.go
+++ b/internal/adapter/presenter/EscobaCuiPresenter_test.go
@@ -15,6 +15,60 @@ func escobaBuildCuiGame(t *testing.T) *domain.Escoba {
 	return e
 }
 
+func TestEscobaCuiPresenter_HintOutput(t *testing.T) {
+	p := &presenter.EscobaCuiPresenter{}
+	build := func(handVal, handSuit int, table []*domain.Card) *domain.Escoba {
+		e := domain.NewDefaultEscoba()
+		e.SetPhase(domain.EscobaPhasePlayerTurn)
+		e.SetCurrentTurn(0)
+		e.GetPlayer(0).AddCard(domain.NewCard(handSuit, handVal, false))
+		e.SetTableCards(table)
+		return e
+	}
+
+	t.Run("escoba sweep", func(t *testing.T) {
+		// played 5 (target 10) + table 3+7 = 10, clears the table.
+		e := build(5, domain.CardDesignHeart, []*domain.Card{
+			domain.NewCard(domain.CardDesignDiamond, 3, false),
+			domain.NewCard(domain.CardDesignClover, 7, false),
+		})
+		if out := p.HintOutput(e); !strings.Contains(out, "エスコバ") {
+			t.Errorf("expected escoba hint, got: %s", out)
+		}
+	})
+
+	t.Run("plain capture", func(t *testing.T) {
+		// played 5 (target 10) + table 3+7 = 10, but a 9 remains on the table.
+		e := build(5, domain.CardDesignHeart, []*domain.Card{
+			domain.NewCard(domain.CardDesignDiamond, 3, false),
+			domain.NewCard(domain.CardDesignClover, 7, false),
+			domain.NewCard(domain.CardDesignSpade, 9, false),
+		})
+		if out := p.HintOutput(e); !strings.Contains(out, "捕獲") {
+			t.Errorf("expected capture hint, got: %s", out)
+		}
+	})
+
+	t.Run("no capture", func(t *testing.T) {
+		// played 2 (target 13); no subset of {3,7} sums to 13.
+		e := build(2, domain.CardDesignHeart, []*domain.Card{
+			domain.NewCard(domain.CardDesignDiamond, 3, false),
+			domain.NewCard(domain.CardDesignClover, 7, false),
+		})
+		if out := p.HintOutput(e); !strings.Contains(out, "捕獲できる手はありません") {
+			t.Errorf("expected no-capture hint, got: %s", out)
+		}
+	})
+
+	t.Run("none outside player turn", func(t *testing.T) {
+		e := domain.NewDefaultEscoba()
+		e.SetPhase(domain.EscobaPhaseRoundEnd)
+		if out := p.HintOutput(e); !strings.Contains(out, "ヒントはありません") {
+			t.Errorf("expected none hint, got: %s", out)
+		}
+	})
+}
+
 func TestEscobaCuiPresenter_Output(t *testing.T) {
 	p := &presenter.EscobaCuiPresenter{}
 	e := escobaBuildCuiGame(t)

--- a/internal/adapter/presenter/EscobaWebPresenter.go
+++ b/internal/adapter/presenter/EscobaWebPresenter.go
@@ -108,6 +108,13 @@ func (ewp *EscobaWebPresenter) buildResultMessage(eg interfaces.EscobaGame) stri
 }
 
 // ActionLogOutput 棋譜を JSON 出力。
+// HintOutput returns the current state as JSON. The Web GUI computes its own
+// hint client-side, so this mirrors Output to satisfy the EscobaPresenter
+// interface shared with the CUI.
+func (ewp *EscobaWebPresenter) HintOutput(eg interfaces.EscobaGame) string {
+	return ewp.Output(eg, nil)
+}
+
 func (ewp *EscobaWebPresenter) ActionLogOutput(eg interfaces.EscobaGame) string {
 	return actionLogOutputJSON(eg)
 }

--- a/internal/adapter/presenter/EscobaWebPresenter_test.go
+++ b/internal/adapter/presenter/EscobaWebPresenter_test.go
@@ -16,6 +16,19 @@ func escobaBuildGame(t *testing.T) *domain.Escoba {
 	return e
 }
 
+func TestEscobaWebPresenter_HintOutput(t *testing.T) {
+	p := &presenter.EscobaWebPresenter{}
+	e := escobaBuildGame(t)
+	// HintOutput mirrors Output (the GUI computes its own hint client-side).
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(p.HintOutput(e)), &parsed); err != nil {
+		t.Fatalf("hint output is not valid JSON: %v", err)
+	}
+	if _, ok := parsed["phase"]; !ok {
+		t.Errorf("missing phase key in hint output")
+	}
+}
+
 func TestEscobaWebPresenter_OutputJSON(t *testing.T) {
 	p := &presenter.EscobaWebPresenter{}
 	e := escobaBuildGame(t)

--- a/internal/i18n/locales/en/escoba.json
+++ b/internal/i18n/locales/en/escoba.json
@@ -1,5 +1,9 @@
 {
   "helpTitle": "Escoba",
+  "hintNone": "No hint available",
+  "hintNoCapture": "No capture summing to 15; lay your lowest card",
+  "hintCapture": "Recommendation: play {{played}} to capture {{captured}} (sum 15)",
+  "hintEscoba": "Recommendation: play {{played}} to sweep {{captured}} (escoba!)",
   "helpPlay": "  p <h> [t...]             play hand h (capture table cards t..., or lay if none given)",
   "helpNext": "  n                        start the next round",
   "helpSetDifficulty": "  sd [0-2]                 CPU difficulty (0=Easy, 1=Normal, 2=Hard)",

--- a/internal/i18n/locales/ja/escoba.json
+++ b/internal/i18n/locales/ja/escoba.json
@@ -1,5 +1,9 @@
 {
   "helpTitle": "Escoba (エスコバ)",
+  "hintNone": "ヒントはありません",
+  "hintNoCapture": "合計15で捕獲できる手はありません。最小札を場に置きましょう",
+  "hintCapture": "推奨: {{played}} で 場札 {{captured}} を捕獲（合計15）",
+  "hintEscoba": "推奨: {{played}} で 場札 {{captured}} を全取り（エスコバ！）",
   "helpPlay": "  p <h> [t...]             手札hを出す (場札t...を捕獲、無指定で場に置く)",
   "helpNext": "  n                        次のラウンドを開始する",
   "helpSetDifficulty": "  sd [0-2]                 CPU難易度 (0=Easy, 1=Normal, 2=Hard)",

--- a/internal/usecase/EscobaInteractor.go
+++ b/internal/usecase/EscobaInteractor.go
@@ -22,6 +22,8 @@ type EscobaInteractorIF interface {
 	ResetWithConfig(config domain.EscobaConfig) string
 	// GetConfig 現在の設定を返す
 	GetConfig() domain.EscobaConfig
+	// Hint ヒントを出力する
+	Hint() string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
 }
@@ -81,6 +83,11 @@ func (ei *EscobaInteractor) ResetWithConfig(config domain.EscobaConfig) string {
 // ActionLog 棋譜を出力する。
 func (ei *EscobaInteractor) ActionLog() string {
 	return ei.sp.ActionLogOutput(ei.Game)
+}
+
+// Hint ヒントを出力する。
+func (ei *EscobaInteractor) Hint() string {
+	return ei.sp.HintOutput(ei.Game)
 }
 
 // escobaMaxCpuIterations は runCpuTurns の防御的な反復上限。

--- a/internal/usecase/EscobaInteractor_test.go
+++ b/internal/usecase/EscobaInteractor_test.go
@@ -64,6 +64,15 @@ func TestEscobaInteractor_ActionLog(t *testing.T) {
 	spMock.AssertExpectations(t)
 }
 
+func TestEscobaInteractor_Hint(t *testing.T) {
+	spMock := new(presenter.MockEscobaPresenter)
+	gameMock := new(interfaces.MockEscobaGame)
+	spMock.On("HintOutput", gameMock).Return("hint output")
+	ei := usecase.NewEscobaInteractor(gameMock, spMock)
+	assert.Equal(t, "hint output", ei.Hint())
+	spMock.AssertExpectations(t)
+}
+
 func TestEscobaInteractor_MockGame(t *testing.T) {
 	mockOutput := `{"players":[]}`
 	spMock := new(presenter.MockEscobaPresenter)

--- a/internal/usecase/presenter/EscobaPresenter.go
+++ b/internal/usecase/presenter/EscobaPresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // EscobaPresenter エスコバプレゼンターインタフェース。
-type EscobaPresenter = GamePresenter[interfaces.EscobaGame]
+type EscobaPresenter interface {
+	GamePresenter[interfaces.EscobaGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.EscobaGame) string
+}

--- a/internal/usecase/presenter/EscobaPresenter_mock.go
+++ b/internal/usecase/presenter/EscobaPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockEscobaPresenter エスコバプレゼンターモック。
-type MockEscobaPresenter = MockGamePresenter[interfaces.EscobaGame]
+type MockEscobaPresenter struct {
+	MockGamePresenter[interfaces.EscobaGame]
+}
+
+// HintOutput モック
+func (_m *MockEscobaPresenter) HintOutput(g interfaces.EscobaGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 概要
Closes #2682

`EscobaCuiPresenter` には合計15の捕獲候補を助けるヒントが無かった。alias→bespoke 配線で HintOutput を通し、人間手番で「どの手札でどの場札（合計15）を捕獲できるか（場を全取りするエスコバも明示）」を出力する。

## 変更点（alias→bespoke パターン）
- `usecase/presenter/EscobaPresenter.go`/`_mock.go`: エイリアス→専用 interface/モック。
- `adapter/presenter/EscobaCuiPresenter.go`: `HintOutput` — playerTurn＋人間手番で各手札に `eg.GetValidCaptures(i)`（ドメインの合計15判定）を適用、最良（エスコバ＞捕獲枚数最大）を `hintCapture`/`hintEscoba` で出力。捕獲不可なら `hintNoCapture`。
- `adapter/presenter/EscobaWebPresenter.go`: `HintOutput`→`Output` 委譲。
- `usecase/EscobaInteractor.go`: `Hint()`+IF。mock に `Hint()`。
- `adapter/controller/EscobaCuiController.go`: `h`/`hint` 配線。
- `internal/i18n/locales/{ja,en}/escoba.json`: `hintNone`/`hintNoCapture`/`hintCapture`/`hintEscoba`。

## テスト
- [x] presenter/usecase/controller の Escoba テスト緑（escoba-sweep / capture / no-capture / 非playerTurn、interactor Hint、web HintOutput）
- [x] `golangci-lint` 0 issues（5パッケージ）