### PR TITLE
feat(scopone): add capture hint to CUI

### DIFF
--- a/internal/adapter/controller/ScoponeCuiController.go
+++ b/internal/adapter/controller/ScoponeCuiController.go
@@ -34,7 +34,7 @@ func (c *ScoponeCuiController) Exec(command string) string {
 		},
 		[]string{
 			"play", "p", "next", "n", "nextround",
-			"sd", "setdifficulty", "st", "settarget", "log", "l",
+			"sd", "setdifficulty", "st", "settarget", "h", "hint", "log", "l",
 		},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
@@ -55,7 +55,7 @@ func (c *ScoponeCuiController) Exec(command string) string {
 					return c.si.ResetWithConfig(cfg)
 				})
 			default:
-				return handleCuiLog(cmd, c.si.ActionLog)
+				return handleCuiHintAndLog(cmd, c.si.Hint, c.si.ActionLog)
 			}
 		},
 	)

--- a/internal/adapter/controller/usecase/ScoponeInteractor_mock.go
+++ b/internal/adapter/controller/usecase/ScoponeInteractor_mock.go
@@ -43,6 +43,12 @@ func (_m *MockScoponeInteractor) ResetWithConfig(config domain.ScoponeConfig) st
 	return ret.Get(0).(string)
 }
 
+// Hint モック
+func (_m *MockScoponeInteractor) Hint() string {
+	ret := _m.Called()
+	return ret.Get(0).(string)
+}
+
 // ActionLog モック
 func (_m *MockScoponeInteractor) ActionLog() string {
 	ret := _m.Called()

--- a/internal/adapter/presenter/ScoponeCuiPresenter.go
+++ b/internal/adapter/presenter/ScoponeCuiPresenter.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
@@ -89,6 +90,51 @@ func scoponeScoreDetailStr(b *strings.Builder, det *domain.ScoponeScoreDetail) {
 			"scopas", strconv.Itoa(det.Scopas[t]),
 			"gained", strconv.Itoa(det.Gained[t])) + "\n")
 	}
+}
+
+// HintOutput emits a capture recommendation for the human's turn: the hand
+// card and the table cards it captures (flagging a scopa when it clears the
+// table), reusing the domain's GetValidCaptures.
+func (p *ScoponeCuiPresenter) HintOutput(sg interfaces.ScoponeGame) string {
+	if sg.GetPhase() != domain.ScoponePhasePlayerTurn {
+		return i18n.T("scopone.hintNone") + "\n"
+	}
+	turn := sg.GetCurrentTurn()
+	player := sg.GetPlayer(turn)
+	if player == nil || !player.GetIsHuman() {
+		return i18n.T("scopone.hintNone") + "\n"
+	}
+	table := sg.GetTableCards()
+	bestHand := -1
+	var bestCap []int
+	bestScopa := false
+	for i := 0; i < player.GetCardsSize(); i++ {
+		for _, cap := range sg.GetValidCaptures(i) {
+			isScopa := len(table) > 0 && len(cap) == len(table)
+			switch {
+			case bestHand == -1:
+			case isScopa && !bestScopa:
+			case isScopa == bestScopa && len(cap) > len(bestCap):
+			default:
+				continue
+			}
+			bestHand, bestCap, bestScopa = i, cap, isScopa
+		}
+	}
+	if bestHand == -1 {
+		return color.Yellow(i18n.T("scopone.hintNoCapture")) + "\n"
+	}
+	capCards := make([]*domain.Card, 0, len(bestCap))
+	for _, idx := range bestCap {
+		capCards = append(capCards, table[idx])
+	}
+	key := "scopone.hintCapture"
+	if bestScopa {
+		key = "scopone.hintScopa"
+	}
+	return color.Yellow(i18n.Tf(key,
+		"played", cuiCardSliceStr([]*domain.Card{player.GetCard(bestHand)}),
+		"captured", cuiCardSliceStr(capCards))) + "\n"
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/ScoponeCuiPresenter_test.go
+++ b/internal/adapter/presenter/ScoponeCuiPresenter_test.go
@@ -15,6 +15,56 @@ func spBuildPlayedScopone(t *testing.T) *domain.Scopone {
 	return s
 }
 
+func TestScoponeCuiPresenter_HintOutput(t *testing.T) {
+	p := &presenter.ScoponeCuiPresenter{}
+	build := func(handVal, handSuit int, table []*domain.Card) *domain.Scopone {
+		s := domain.NewDefaultScopone()
+		s.SetPhase(domain.ScoponePhasePlayerTurn)
+		s.SetCurrentTurn(0)
+		s.GetPlayer(0).AddCard(domain.NewCard(handSuit, handVal, false))
+		s.SetTableCards(table)
+		return s
+	}
+
+	t.Run("scopa sweep", func(t *testing.T) {
+		s := build(7, domain.CardDesignHeart, []*domain.Card{
+			domain.NewCard(domain.CardDesignDiamond, 3, false),
+			domain.NewCard(domain.CardDesignClover, 4, false),
+		})
+		if out := p.HintOutput(s); !strings.Contains(out, "スコパ") {
+			t.Errorf("expected scopa hint, got: %s", out)
+		}
+	})
+
+	t.Run("plain capture", func(t *testing.T) {
+		s := build(7, domain.CardDesignHeart, []*domain.Card{
+			domain.NewCard(domain.CardDesignDiamond, 7, false),
+			domain.NewCard(domain.CardDesignClover, 5, false),
+		})
+		if out := p.HintOutput(s); !strings.Contains(out, "捕獲") {
+			t.Errorf("expected capture hint, got: %s", out)
+		}
+	})
+
+	t.Run("no capture", func(t *testing.T) {
+		s := build(2, domain.CardDesignHeart, []*domain.Card{
+			domain.NewCard(domain.CardDesignDiamond, 7, false),
+			domain.NewCard(domain.CardDesignClover, 5, false),
+		})
+		if out := p.HintOutput(s); !strings.Contains(out, "捕獲できる手はありません") {
+			t.Errorf("expected no-capture hint, got: %s", out)
+		}
+	})
+
+	t.Run("none outside player turn", func(t *testing.T) {
+		s := domain.NewDefaultScopone()
+		s.SetPhase(domain.ScoponePhaseRoundEnd)
+		if out := p.HintOutput(s); !strings.Contains(out, "ヒントはありません") {
+			t.Errorf("expected none hint, got: %s", out)
+		}
+	})
+}
+
 func TestScoponeCuiPresenter_Output(t *testing.T) {
 	p := &presenter.ScoponeCuiPresenter{}
 	s := spBuildPlayedScopone(t)

--- a/internal/adapter/presenter/ScoponeWebPresenter.go
+++ b/internal/adapter/presenter/ScoponeWebPresenter.go
@@ -119,6 +119,13 @@ func (swp *ScoponeWebPresenter) buildResultMessage(sg interfaces.ScoponeGame) st
 }
 
 // ActionLogOutput 棋譜を JSON 出力。
+// HintOutput returns the current state as JSON. The Web GUI computes its own
+// hint client-side, so this mirrors Output to satisfy the ScoponePresenter
+// interface shared with the CUI.
+func (swp *ScoponeWebPresenter) HintOutput(sg interfaces.ScoponeGame) string {
+	return swp.Output(sg, nil)
+}
+
 func (swp *ScoponeWebPresenter) ActionLogOutput(sg interfaces.ScoponeGame) string {
 	return actionLogOutputJSON(sg)
 }

--- a/internal/adapter/presenter/ScoponeWebPresenter_test.go
+++ b/internal/adapter/presenter/ScoponeWebPresenter_test.go
@@ -16,6 +16,19 @@ func spBuildScoredScopone(t *testing.T) *domain.Scopone {
 	return s
 }
 
+func TestScoponeWebPresenter_HintOutput(t *testing.T) {
+	p := &presenter.ScoponeWebPresenter{}
+	s := spBuildScoredScopone(t)
+	// HintOutput mirrors Output (the GUI computes its own hint client-side).
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(p.HintOutput(s)), &parsed); err != nil {
+		t.Fatalf("hint output is not valid JSON: %v", err)
+	}
+	if _, ok := parsed["phase"]; !ok {
+		t.Errorf("missing phase key in hint output")
+	}
+}
+
 func TestScoponeWebPresenter_OutputJSON(t *testing.T) {
 	p := &presenter.ScoponeWebPresenter{}
 	s := spBuildScoredScopone(t)

--- a/internal/i18n/locales/en/scopone.json
+++ b/internal/i18n/locales/en/scopone.json
@@ -1,5 +1,9 @@
 {
   "helpTitle": "Scopone",
+  "hintNone": "No hint available",
+  "hintNoCapture": "No capture available; lay your lowest card",
+  "hintCapture": "Recommendation: play {{played}} to capture {{captured}}",
+  "hintScopa": "Recommendation: play {{played}} to sweep {{captured}} (scopa!)",
   "helpPlay": "  p <h> [t...]             play hand h (capture table cards t..., or lay if none given)",
   "helpNext": "  n                        start the next round",
   "helpSetDifficulty": "  sd [0-2]                 CPU difficulty (0=Easy, 1=Normal, 2=Hard)",

--- a/internal/i18n/locales/ja/scopone.json
+++ b/internal/i18n/locales/ja/scopone.json
@@ -1,5 +1,9 @@
 {
   "helpTitle": "Scopone (スコポーネ)",
+  "hintNone": "ヒントはありません",
+  "hintNoCapture": "捕獲できる手はありません。最小札を場に置きましょう",
+  "hintCapture": "推奨: {{played}} で 場札 {{captured}} を捕獲",
+  "hintScopa": "推奨: {{played}} で 場札 {{captured}} を全取り（スコパ！）",
   "helpPlay": "  p <h> [t...]             手札hを出す (場札t...を捕獲、無指定で場に置く)",
   "helpNext": "  n                        次のラウンドを開始する",
   "helpSetDifficulty": "  sd [0-2]                 CPU難易度 (0=Easy, 1=Normal, 2=Hard)",

--- a/internal/usecase/ScoponeInteractor.go
+++ b/internal/usecase/ScoponeInteractor.go
@@ -22,6 +22,8 @@ type ScoponeInteractorIF interface {
 	ResetWithConfig(config domain.ScoponeConfig) string
 	// GetConfig 現在の設定を返す
 	GetConfig() domain.ScoponeConfig
+	// Hint ヒントを出力する
+	Hint() string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
 }
@@ -81,6 +83,11 @@ func (si *ScoponeInteractor) ResetWithConfig(config domain.ScoponeConfig) string
 // ActionLog 棋譜を出力する。
 func (si *ScoponeInteractor) ActionLog() string {
 	return si.sp.ActionLogOutput(si.Game)
+}
+
+// Hint ヒントを出力する。
+func (si *ScoponeInteractor) Hint() string {
+	return si.sp.HintOutput(si.Game)
 }
 
 // scoponeMaxCpuIterations は runCpuTurns の防御的な反復上限。

--- a/internal/usecase/ScoponeInteractor_test.go
+++ b/internal/usecase/ScoponeInteractor_test.go
@@ -64,6 +64,15 @@ func TestScoponeInteractor_ActionLog(t *testing.T) {
 	spMock.AssertExpectations(t)
 }
 
+func TestScoponeInteractor_Hint(t *testing.T) {
+	spMock := new(presenter.MockScoponePresenter)
+	gameMock := new(interfaces.MockScoponeGame)
+	spMock.On("HintOutput", gameMock).Return("hint output")
+	si := usecase.NewScoponeInteractor(gameMock, spMock)
+	assert.Equal(t, "hint output", si.Hint())
+	spMock.AssertExpectations(t)
+}
+
 func TestScoponeInteractor_MockGame(t *testing.T) {
 	mockOutput := `{"players":[]}`
 	spMock := new(presenter.MockScoponePresenter)

--- a/internal/usecase/presenter/ScoponePresenter.go
+++ b/internal/usecase/presenter/ScoponePresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // ScoponePresenter スコポーネプレゼンターインタフェース。
-type ScoponePresenter = GamePresenter[interfaces.ScoponeGame]
+type ScoponePresenter interface {
+	GamePresenter[interfaces.ScoponeGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.ScoponeGame) string
+}

--- a/internal/usecase/presenter/ScoponePresenter_mock.go
+++ b/internal/usecase/presenter/ScoponePresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockScoponePresenter スコポーネプレゼンターモック。
-type MockScoponePresenter = MockGamePresenter[interfaces.ScoponeGame]
+type MockScoponePresenter struct {
+	MockGamePresenter[interfaces.ScoponeGame]
+}
+
+// HintOutput モック
+func (_m *MockScoponePresenter) HintOutput(g interfaces.ScoponeGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 概要
Closes #2681

`ScoponeCuiPresenter` には捕獲判断を助けるヒントが無かった。alias→bespoke 配線で HintOutput を通し、人間手番で「どの手札でどの場札を捕獲できるか（場を全取りするスコパも明示）」を出力する（Scopa と捕獲規則を共有）。

## 変更点（alias→bespoke パターン）
- `usecase/presenter/ScoponePresenter.go`/`_mock.go`: エイリアス→専用 interface/モック。
- `adapter/presenter/ScoponeCuiPresenter.go`: `HintOutput` — playerTurn＋人間手番で各手札に `sg.GetValidCaptures(i)` を適用、最良（スコパ＞捕獲枚数最大）を出力。
- `adapter/presenter/ScoponeWebPresenter.go`: `HintOutput`→`Output` 委譲。
- `usecase/ScoponeInteractor.go`: `Hint()`+IF。mock に `Hint()`。
- `adapter/controller/ScoponeCuiController.go`: `h`/`hint` 配線。
- `internal/i18n/locales/{ja,en}/scopone.json`: `hintNone`/`hintNoCapture`/`hintCapture`/`hintScopa`。

## テスト
- [x] presenter/usecase/controller の Scopone テスト緑（scopa-sweep / capture / no-capture / 非playerTurn、interactor Hint、web HintOutput）
- [x] `golangci-lint` 0 issues（5パッケージ）