### PR TITLE
feat(barbu): add play hint to CUI

### DIFF
--- a/internal/adapter/controller/BarbuCuiController.go
+++ b/internal/adapter/controller/BarbuCuiController.go
@@ -33,7 +33,7 @@ func (c *BarbuCuiController) Exec(command string) string {
 			return c.bi.ResetWithConfig(cfg)
 		},
 		[]string{
-			"contract", "c", "play", "p", "next", "n", "sd", "setdifficulty", "log", "l",
+			"contract", "c", "play", "p", "next", "n", "sd", "setdifficulty", "h", "hint", "log", "l",
 		},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
@@ -50,7 +50,7 @@ func (c *BarbuCuiController) Exec(command string) string {
 					return c.bi.ResetWithConfig(cfg)
 				})
 			default:
-				return handleCuiLog(cmd, c.bi.ActionLog)
+				return handleCuiHintAndLog(cmd, c.bi.Hint, c.bi.ActionLog)
 			}
 		},
 	)

--- a/internal/adapter/controller/usecase/BarbuInteractor_mock.go
+++ b/internal/adapter/controller/usecase/BarbuInteractor_mock.go
@@ -49,6 +49,12 @@ func (_m *MockBarbuInteractor) ResetWithConfig(config domain.BarbuConfig) string
 	return ret.Get(0).(string)
 }
 
+// Hint モック
+func (_m *MockBarbuInteractor) Hint() string {
+	ret := _m.Called()
+	return ret.Get(0).(string)
+}
+
 // ActionLog モック
 func (_m *MockBarbuInteractor) ActionLog() string {
 	ret := _m.Called()

--- a/internal/adapter/presenter/BarbuCuiPresenter.go
+++ b/internal/adapter/presenter/BarbuCuiPresenter.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
@@ -136,6 +137,60 @@ func barbuTrumpLabel(suit int) string {
 		return "-"
 	}
 	return suitNames[suit]
+}
+
+// barbuLegalTrickIndices returns the hand positions the player may legally play
+// in a trick contract: cards of the lead suit, or the whole hand when leading
+// or void in the lead suit.
+func barbuLegalTrickIndices(player *domain.BarbuPlayer, trick []*domain.BarbuTrickCard) []int {
+	all := make([]int, 0, player.GetCardsSize())
+	for i := 0; i < player.GetCardsSize(); i++ {
+		all = append(all, i)
+	}
+	if len(trick) == 0 {
+		return all
+	}
+	leadSuit := trick[0].Card.GetDesign()
+	follow := make([]int, 0, len(all))
+	for _, i := range all {
+		if player.GetCard(i).GetDesign() == leadSuit {
+			follow = append(follow, i)
+		}
+	}
+	if len(follow) == 0 {
+		return all
+	}
+	return follow
+}
+
+// HintOutput emits a play recommendation for the human's turn: the playable
+// hand positions for the Dominoes contract (via GetDominoPlayableIndices) or
+// the legal follow-suit plays for a trick contract.
+func (p *BarbuCuiPresenter) HintOutput(bg interfaces.BarbuGame) string {
+	if bg.GetPhase() != domain.BarbuPhasePlay {
+		return i18n.T("barbu.hintNone") + "\n"
+	}
+	turn := bg.GetCurrentTurn()
+	player := bg.GetPlayer(turn)
+	if player == nil || !player.GetIsHuman() {
+		return i18n.T("barbu.hintNone") + "\n"
+	}
+	idxStr := func(idxs []int) string {
+		parts := make([]string, len(idxs))
+		for i, idx := range idxs {
+			parts[i] = "[" + strconv.Itoa(idx) + "]"
+		}
+		return strings.Join(parts, " ")
+	}
+	if bg.GetCurrentContract() == domain.BarbuContractDominoes {
+		playable := bg.GetDominoPlayableIndices(turn)
+		if len(playable) == 0 {
+			return color.Yellow(i18n.T("barbu.hintDominoPass")) + "\n"
+		}
+		return color.Yellow(i18n.Tf("barbu.hintDomino", "cards", idxStr(playable))) + "\n"
+	}
+	legal := barbuLegalTrickIndices(player, bg.GetCurrentTrick())
+	return color.Yellow(i18n.Tf("barbu.hintLegal", "cards", idxStr(legal))) + "\n"
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/BarbuCuiPresenter_test.go
+++ b/internal/adapter/presenter/BarbuCuiPresenter_test.go
@@ -20,6 +20,45 @@ func TestBarbuCuiPresenter_Output(t *testing.T) {
 	assert.Contains(t, out, "[0]")  // human indexed hand
 }
 
+func TestBarbuCuiPresenter_HintOutput(t *testing.T) {
+	p := new(presenter.BarbuCuiPresenter)
+
+	t.Run("dominoes playable", func(t *testing.T) {
+		b := domain.BarbuTestNew(domain.DefaultBarbuConfig())
+		b.BarbuTestSetContract(domain.BarbuContractDominoes, -1)
+		b.BarbuTestSetPhase(domain.BarbuPhasePlay)
+		b.BarbuTestSetCurrentPlayer(0)
+		b.BarbuTestSetHand(0, []*domain.Card{bcard(domain.CardDesignSpade, 7)})
+		assert.Contains(t, p.HintOutput(b), "置けるカード")
+	})
+
+	t.Run("dominoes pass when nothing playable", func(t *testing.T) {
+		b := domain.BarbuTestNew(domain.DefaultBarbuConfig())
+		b.BarbuTestSetContract(domain.BarbuContractDominoes, -1)
+		b.BarbuTestSetPhase(domain.BarbuPhasePlay)
+		b.BarbuTestSetCurrentPlayer(0)
+		// No 7 and an empty table: nothing can be placed.
+		b.BarbuTestSetHand(0, []*domain.Card{bcard(domain.CardDesignSpade, 5)})
+		assert.Contains(t, p.HintOutput(b), "パス")
+	})
+
+	t.Run("trick legal follow", func(t *testing.T) {
+		b := domain.BarbuTestNew(domain.DefaultBarbuConfig())
+		b.BarbuTestSetContract(domain.BarbuContractNoTricks, 0)
+		b.BarbuTestSetPhase(domain.BarbuPhasePlay)
+		b.BarbuTestSetCurrentPlayer(0)
+		b.BarbuTestSetHand(0, []*domain.Card{bcard(domain.CardDesignHeart, 5), bcard(domain.CardDesignSpade, 9)})
+		b.BarbuTestSetCurrentTrick([]*domain.BarbuTrickCard{{PlayerIdx: 3, Card: bcard(domain.CardDesignHeart, 9)}})
+		assert.Contains(t, p.HintOutput(b), "合法手")
+	})
+
+	t.Run("none outside the play phase", func(t *testing.T) {
+		b := domain.BarbuTestNew(domain.DefaultBarbuConfig())
+		b.BarbuTestSetPhase(domain.BarbuPhaseSelectContract)
+		assert.Contains(t, p.HintOutput(b), "ヒントはありません")
+	})
+}
+
 func TestBarbuCuiPresenter_ContractAndTrick(t *testing.T) {
 	b := domain.BarbuTestNew(domain.DefaultBarbuConfig())
 	b.BarbuTestSetContract(domain.BarbuContractTrumps, domain.CardDesignSpade)

--- a/internal/adapter/presenter/BarbuWebPresenter.go
+++ b/internal/adapter/presenter/BarbuWebPresenter.go
@@ -154,6 +154,13 @@ func (bwp *BarbuWebPresenter) buildResultMessage(bg interfaces.BarbuGame) string
 }
 
 // ActionLogOutput は棋譜を JSON 出力する。
+// HintOutput returns the current state as JSON. The Web GUI computes its own
+// hint client-side, so this mirrors Output to satisfy the BarbuPresenter
+// interface shared with the CUI.
+func (bwp *BarbuWebPresenter) HintOutput(bg interfaces.BarbuGame) string {
+	return bwp.Output(bg, nil)
+}
+
 func (bwp *BarbuWebPresenter) ActionLogOutput(bg interfaces.BarbuGame) string {
 	return actionLogOutputJSON(bg)
 }

--- a/internal/adapter/presenter/BarbuWebPresenter_test.go
+++ b/internal/adapter/presenter/BarbuWebPresenter_test.go
@@ -15,6 +15,16 @@ import (
 
 func bcard(design, value int) *domain.Card { return domain.NewCard(design, value, false) }
 
+func TestBarbuWebPresenter_HintOutput(t *testing.T) {
+	b := domain.NewDefaultBarbu()
+	b.Reset()
+	p := new(presenter.BarbuWebPresenter)
+	// HintOutput mirrors Output (the GUI computes its own hint client-side).
+	var out controller.BarbuWebOutput
+	require.NoError(t, json.Unmarshal([]byte(p.HintOutput(b)), &out))
+	assert.Equal(t, domain.BarbuPhaseSelectContract, out.Phase)
+}
+
 func TestBarbuWebPresenter_Output(t *testing.T) {
 	b := domain.NewDefaultBarbu()
 	b.Reset()

--- a/internal/i18n/locales/en/barbu.json
+++ b/internal/i18n/locales/en/barbu.json
@@ -1,5 +1,9 @@
 {
   "helpTitle": "Barbu",
+  "hintNone": "No hint available",
+  "hintDomino": "Recommendation: playable cards {{cards}}",
+  "hintDominoPass": "No playable card; you must pass",
+  "hintLegal": "Legal plays: {{cards}}",
   "helpContract": "  c <0-6> [trump 1-4]      pick a contract (trump suit only for Trumps=5)",
   "helpPlay": "  p <h>                    play hand h (-1 to pass in Dominoes)",
   "helpNext": "  n                        start the next deal",

--- a/internal/i18n/locales/ja/barbu.json
+++ b/internal/i18n/locales/ja/barbu.json
@@ -1,5 +1,9 @@
 {
   "helpTitle": "バルブ",
+  "hintNone": "ヒントはありません",
+  "hintDomino": "推奨: 置けるカード {{cards}}",
+  "hintDominoPass": "置けるカードがありません。パスします",
+  "hintLegal": "合法手: {{cards}}",
   "helpContract": "  c <0-6> [切札 1-4]       コントラクトを選ぶ (切札は Trumps=5 のみ)",
   "helpPlay": "  p <h>                    手札 h を出す (Dominoes では -1 でパス)",
   "helpNext": "  n                        次のディールを開始",

--- a/internal/usecase/BarbuInteractor.go
+++ b/internal/usecase/BarbuInteractor.go
@@ -24,6 +24,8 @@ type BarbuInteractorIF interface {
 	ResetWithConfig(config domain.BarbuConfig) string
 	// GetConfig 現在の設定を返す
 	GetConfig() domain.BarbuConfig
+	// Hint ヒントを出力する
+	Hint() string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
 }
@@ -95,6 +97,11 @@ func (bi *BarbuInteractor) ResetWithConfig(config domain.BarbuConfig) string {
 // ActionLog 棋譜を出力する。
 func (bi *BarbuInteractor) ActionLog() string {
 	return bi.bp.ActionLogOutput(bi.Game)
+}
+
+// Hint ヒントを出力する。
+func (bi *BarbuInteractor) Hint() string {
+	return bi.bp.HintOutput(bi.Game)
 }
 
 // barbuMaxCpuIterations は runCpuTurns の防御的な反復上限。

--- a/internal/usecase/BarbuInteractor_test.go
+++ b/internal/usecase/BarbuInteractor_test.go
@@ -69,6 +69,15 @@ func TestBarbuInteractor_ActionLog(t *testing.T) {
 	bpMock.AssertExpectations(t)
 }
 
+func TestBarbuInteractor_Hint(t *testing.T) {
+	bpMock := new(presenter.MockBarbuPresenter)
+	gameMock := new(interfaces.MockBarbuGame)
+	bpMock.On("HintOutput", gameMock).Return("hint output")
+	bi := usecase.NewBarbuInteractor(gameMock, bpMock)
+	assert.Equal(t, "hint output", bi.Hint())
+	bpMock.AssertExpectations(t)
+}
+
 func TestBarbuInteractor_GuardsWhenGameEnded(t *testing.T) {
 	mockOutput := `{"end":1}`
 	bpMock := new(presenter.MockBarbuPresenter)

--- a/internal/usecase/presenter/BarbuPresenter.go
+++ b/internal/usecase/presenter/BarbuPresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // BarbuPresenter はバルブプレゼンターインタフェース。
-type BarbuPresenter = GamePresenter[interfaces.BarbuGame]
+type BarbuPresenter interface {
+	GamePresenter[interfaces.BarbuGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.BarbuGame) string
+}

--- a/internal/usecase/presenter/BarbuPresenter_mock.go
+++ b/internal/usecase/presenter/BarbuPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockBarbuPresenter はバルブプレゼンターモック。
-type MockBarbuPresenter = MockGamePresenter[interfaces.BarbuGame]
+type MockBarbuPresenter struct {
+	MockGamePresenter[interfaces.BarbuGame]
+}
+
+// HintOutput モック
+func (_m *MockBarbuPresenter) HintOutput(g interfaces.BarbuGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 概要
Closes #2643

`BarbuCuiPresenter` には手番のヒントが無く、Web版（HintTooltip）と非対称だった。alias→bespoke 配線で HintOutput を通し、人間手番で推奨手を出力する。

## 変更点（alias→bespoke パターン）
- `usecase/presenter/BarbuPresenter.go`/`_mock.go`: エイリアス→専用 interface/モック。
- `adapter/presenter/BarbuCuiPresenter.go`: `HintOutput` — Dominoes 契約は `bg.GetDominoPlayableIndices(turn)` で置けるカード（無ければパス）、トリック契約は must-follow の合法手インデックスを算出して出力。
- `adapter/presenter/BarbuWebPresenter.go`: `HintOutput`→`Output` 委譲。
- `usecase/BarbuInteractor.go`: `Hint()`+IF。mock に `Hint()`。
- `adapter/controller/BarbuCuiController.go`: `h`/`hint` 配線。
- `internal/i18n/locales/{ja,en}/barbu.json`: `hintNone`/`hintDomino`/`hintDominoPass`/`hintLegal`。

## テスト
- [x] presenter/usecase/controller の Barbu テスト緑（dominoes-playable / dominoes-pass / trick-legal / 非play、interactor Hint、web HintOutput）
- [x] `golangci-lint` 0 issues（5パッケージ）