### PR TITLE
fix(barbu): harden barbuLegalTrickIndices against nil cards

### DIFF
--- a/internal/adapter/presenter/BarbuCuiPresenter.go
+++ b/internal/adapter/presenter/BarbuCuiPresenter.go
@@ -143,22 +143,35 @@ func barbuTrumpLabel(suit int) string {
 // in a trick contract: cards of the lead suit, or the whole hand when leading
 // or void in the lead suit.
 func barbuLegalTrickIndices(player *domain.BarbuPlayer, trick []*domain.BarbuTrickCard) []int {
-	all := make([]int, 0, player.GetCardsSize())
-	for i := 0; i < player.GetCardsSize(); i++ {
-		all = append(all, i)
-	}
-	if len(trick) == 0 {
+	cardsSize := player.GetCardsSize()
+	makeAll := func() []int {
+		all := make([]int, cardsSize)
+		for i := range all {
+			all[i] = i
+		}
 		return all
 	}
-	leadSuit := trick[0].Card.GetDesign()
-	follow := make([]int, 0, len(all))
-	for _, i := range all {
-		if player.GetCard(i).GetDesign() == leadSuit {
+	// Find the lead card defensively: a malformed/empty trick falls back to
+	// "all cards legal" rather than dereferencing a nil entry.
+	var leadCard *domain.Card
+	for _, tc := range trick {
+		if tc != nil && tc.Card != nil {
+			leadCard = tc.Card
+			break
+		}
+	}
+	if leadCard == nil {
+		return makeAll()
+	}
+	leadSuit := leadCard.GetDesign()
+	follow := make([]int, 0, cardsSize)
+	for i := 0; i < cardsSize; i++ {
+		if c := player.GetCard(i); c != nil && c.GetDesign() == leadSuit {
 			follow = append(follow, i)
 		}
 	}
 	if len(follow) == 0 {
-		return all
+		return makeAll()
 	}
 	return follow
 }

--- a/internal/adapter/presenter/BarbuCuiPresenter_test.go
+++ b/internal/adapter/presenter/BarbuCuiPresenter_test.go
@@ -52,6 +52,36 @@ func TestBarbuCuiPresenter_HintOutput(t *testing.T) {
 		assert.Contains(t, p.HintOutput(b), "合法手")
 	})
 
+	t.Run("trick leading (empty trick): all cards legal", func(t *testing.T) {
+		b := domain.BarbuTestNew(domain.DefaultBarbuConfig())
+		b.BarbuTestSetContract(domain.BarbuContractNoTricks, 0)
+		b.BarbuTestSetPhase(domain.BarbuPhasePlay)
+		b.BarbuTestSetCurrentPlayer(0)
+		b.BarbuTestSetHand(0, []*domain.Card{bcard(domain.CardDesignHeart, 5), bcard(domain.CardDesignSpade, 9)})
+		assert.Contains(t, p.HintOutput(b), "合法手")
+	})
+
+	t.Run("trick void in lead suit: all cards legal", func(t *testing.T) {
+		b := domain.BarbuTestNew(domain.DefaultBarbuConfig())
+		b.BarbuTestSetContract(domain.BarbuContractNoTricks, 0)
+		b.BarbuTestSetPhase(domain.BarbuPhasePlay)
+		b.BarbuTestSetCurrentPlayer(0)
+		// Hand has no hearts, lead is a heart -> void -> every card is legal.
+		b.BarbuTestSetHand(0, []*domain.Card{bcard(domain.CardDesignSpade, 5), bcard(domain.CardDesignClover, 9)})
+		b.BarbuTestSetCurrentTrick([]*domain.BarbuTrickCard{{PlayerIdx: 3, Card: bcard(domain.CardDesignHeart, 9)}})
+		assert.Contains(t, p.HintOutput(b), "合法手")
+	})
+
+	t.Run("trick with a nil lead entry falls back to all legal", func(t *testing.T) {
+		b := domain.BarbuTestNew(domain.DefaultBarbuConfig())
+		b.BarbuTestSetContract(domain.BarbuContractNoTricks, 0)
+		b.BarbuTestSetPhase(domain.BarbuPhasePlay)
+		b.BarbuTestSetCurrentPlayer(0)
+		b.BarbuTestSetHand(0, []*domain.Card{bcard(domain.CardDesignSpade, 5)})
+		b.BarbuTestSetCurrentTrick([]*domain.BarbuTrickCard{{PlayerIdx: 3, Card: nil}})
+		assert.Contains(t, p.HintOutput(b), "合法手")
+	})
+
 	t.Run("none outside the play phase", func(t *testing.T) {
 		b := domain.BarbuTestNew(domain.DefaultBarbuConfig())
 		b.BarbuTestSetPhase(domain.BarbuPhaseSelectContract)


### PR DESCRIPTION
Follow-up to #2864 (gemini MUST). Adds defensive nil-guards to `barbuLegalTrickIndices`: the lead-card lookup skips nil trick entries and the per-card suit check skips nil hand cards, so a malformed trick/hand cannot nil-panic. The full index slice is only materialised when returned. Behaviour is unchanged for valid game state.

## テスト
- [x] `go test -tags test ./internal/adapter/presenter/ -run TestBarbuCuiPresenter` 緑
- [x] `golangci-lint run ./internal/adapter/presenter/` 0 issues