### PR TITLE
feat(indianpoker): show estimated win equity in CUI

### DIFF
--- a/internal/adapter/presenter/IndianPokerCuiPresenter.go
+++ b/internal/adapter/presenter/IndianPokerCuiPresenter.go
@@ -64,6 +64,13 @@ func (p *IndianPokerCuiPresenter) Output(ip interfaces.IndianPokerGame, lastErr 
 					b.WriteString(i18n.Tf("indianpoker.cardLine", "card", cuiCardStrEmoji(player.GetCard(0))) + "\n")
 				}
 			}
+
+			// During betting, surface the human's estimated win equity (their
+			// own card is hidden), mirroring the web equity meter.
+			if ip.GetPhase() == domain.IndianPokerPhaseBetting && player.GetIsHuman() && !player.GetFolded() {
+				b.WriteString(i18n.Tf("indianpoker.equityLine",
+					"pct", strconv.Itoa(ip.GetEstimatedStrength(i))) + "\n")
+			}
 		}
 
 		cpuActions := ip.GetCpuActions()

--- a/internal/adapter/presenter/IndianPokerCuiPresenter_test.go
+++ b/internal/adapter/presenter/IndianPokerCuiPresenter_test.go
@@ -46,6 +46,27 @@ func TestIndianPokerCuiPresenter_Output(t *testing.T) {
 		assert.NotContains(t, result, "♠10")
 	})
 
+	t.Run("betting phase shows human estimated equity", func(t *testing.T) {
+		ip, players := makeIndianPokerForPresenter()
+		ip.SetPhase(domain.IndianPokerPhaseBetting)
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 10, false))
+		// A low visible opponent card leaves most ranks above it.
+		players[1].AddCard(domain.NewCard(domain.CardDesignClover, 2, false))
+
+		result := p.Output(ip, nil)
+		assert.Contains(t, result, "推定勝率:")
+	})
+
+	t.Run("showdown phase hides equity", func(t *testing.T) {
+		ip, players := makeIndianPokerForPresenter()
+		ip.SetPhase(domain.IndianPokerPhaseShowdown)
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 10, false))
+		players[1].AddCard(domain.NewCard(domain.CardDesignClover, 2, false))
+
+		result := p.Output(ip, nil)
+		assert.NotContains(t, result, "推定勝率:")
+	})
+
 	t.Run("showdown phase human card visible", func(t *testing.T) {
 		ip, players := makeIndianPokerForPresenter()
 		ip.SetPhase(domain.IndianPokerPhaseShowdown)

--- a/internal/domain/IndianPoker.go
+++ b/internal/domain/IndianPoker.go
@@ -647,6 +647,11 @@ func (ip *IndianPoker) cpuPotBet(potPct int) int {
 // GetPhase フェーズ取得
 func (ip *IndianPoker) GetPhase() int { return ip.phase }
 
+// GetEstimatedStrength は player idx の推定勝率 (0-100) を返す。自分のカードが
+// 見えないインディアンポーカーで、見えている相手札から算出した勝率であり、CUI
+// のエクイティ表示と CPU 判断で共有する単一ロジック。
+func (ip *IndianPoker) GetEstimatedStrength(idx int) int { return ip.estimateOwnStrength(idx) }
+
 // GetPlayers プレイヤー一覧取得
 func (ip *IndianPoker) GetPlayers() []*IndianPokerPlayer { return ip.players }
 

--- a/internal/domain/IndianPoker_test.go
+++ b/internal/domain/IndianPoker_test.go
@@ -37,6 +37,20 @@ func defaultTestConfig() IndianPokerConfig {
 
 // --- Phase and Action constants ---
 
+func TestIndianPoker_GetEstimatedStrength(t *testing.T) {
+	ip, players := newIndianPokerTestGame(defaultTestConfig())
+	// Opponents all show low cards, so player 0's hidden card very likely wins.
+	players[1].AddCard(NewCard(CardDesignClover, 2, false))
+	players[2].AddCard(NewCard(CardDesignHeart, 3, false))
+	players[3].AddCard(NewCard(CardDesignSpade, 4, false))
+
+	s := ip.GetEstimatedStrength(0)
+	assert.GreaterOrEqual(t, s, 0)
+	assert.LessOrEqual(t, s, 100)
+	// Max visible rank is 4, so most remaining ranks beat it -> high equity.
+	assert.GreaterOrEqual(t, s, 50)
+}
+
 func TestIndianPokerPhaseConstants(t *testing.T) {
 	assert.Equal(t, 0, IndianPokerPhaseInit)
 	assert.Equal(t, 1, IndianPokerPhaseAnte)

--- a/internal/domain/interfaces/indianpoker.go
+++ b/internal/domain/interfaces/indianpoker.go
@@ -14,6 +14,8 @@ type IndianPokerGame interface {
 	PlayerAction(action, amount, humanPlayMs int) error
 	// GetPhase 現在のフェーズを取得する
 	GetPhase() int
+	// GetEstimatedStrength は player idx の推定勝率 (0-100) を返す
+	GetEstimatedStrength(idx int) int
 	// GetPlayers プレイヤー一覧を取得する
 	GetPlayers() []*domain.IndianPokerPlayer
 	// GetPlayer 指定インデックスのプレイヤーを取得する

--- a/internal/domain/interfaces/indianpoker_mock.go
+++ b/internal/domain/interfaces/indianpoker_mock.go
@@ -31,6 +31,12 @@ func (_m *MockIndianPokerGame) GetPhase() int {
 	return ret.Int(0)
 }
 
+// GetEstimatedStrength モック
+func (_m *MockIndianPokerGame) GetEstimatedStrength(idx int) int {
+	ret := _m.Called(idx)
+	return ret.Int(0)
+}
+
 // GetPlayers モック
 func (_m *MockIndianPokerGame) GetPlayers() []*domain.IndianPokerPlayer {
 	ret := _m.Called()

--- a/internal/i18n/locales/en/indianpoker.json
+++ b/internal/i18n/locales/en/indianpoker.json
@@ -26,6 +26,7 @@
   "playerBet": " bet:{{bet}}",
   "cardLine": "  card: {{card}}",
   "cardHidden": "  card: ??",
+  "equityLine": "  est. win: {{pct}}%",
   "cpuActionsHeader": "[CPU actions]",
   "cpuActionLine": "  Player {{idx}}: {{action}}",
   "cpuActionAmount": " ({{amount}})",

--- a/internal/i18n/locales/ja/indianpoker.json
+++ b/internal/i18n/locales/ja/indianpoker.json
@@ -26,6 +26,7 @@
   "playerBet": " ベット:{{bet}}",
   "cardLine": "  カード: {{card}}",
   "cardHidden": "  カード: ??",
+  "equityLine": "  推定勝率: {{pct}}%",
   "cpuActionsHeader": "[CPU行動]",
   "cpuActionLine": "  Player {{idx}}: {{action}}",
   "cpuActionAmount": " ({{amount}})",


### PR DESCRIPTION
## 概要
Closes #2557

Web版（`computeIndianPokerEquity` + equity meter）は見えている相手札から自分の勝率を表示するが、CUI版は勝率を一切算出しなかった。ドメインの `estimateOwnStrength`（CPU 判断と同じ勝率推定ロジック）を `GetEstimatedStrength` として公開し、ベッティング中の人間プレイヤー行に「推定勝率: NN%」を表示する。

## 変更点
- `internal/domain/IndianPoker.go`: `GetEstimatedStrength(idx) int` 公開ラッパー（= `estimateOwnStrength`、CUI と CPU で単一ロジック共有）。
- `internal/domain/interfaces/indianpoker.go` + `_mock.go`: インターフェースに `GetEstimatedStrength` 追加。
- `IndianPokerCuiPresenter.go`: ベッティングフェーズ＋人間＋非フォールドのとき `indianpoker.equityLine` を出力。ショーダウン/フォールドでは非表示。
- `internal/i18n/locales/{ja,en}/indianpoker.json`: `equityLine`。
- `IndianPokerCuiPresenter_test.go`: ベッティングで勝率表示／ショーダウンで非表示 を検証。

## テスト
- [x] `go test -tags test ./internal/adapter/presenter/ -run TestIndianPokerCuiPresenter` 緑
- [x] ドメイン変更は公開ラッパー1行のみ（既存挙動不変）。Backend Tests/Lint は CI で検証（ローカルは domain パッケージの compile が swap で OOM するため）。