### PR TITLE
feat(labellelucie): recommend a redeal when stuck

### DIFF
--- a/frontend/src/i18n/locales/en/labellelucie.json
+++ b/frontend/src/i18n/locales/en/labellelucie.json
@@ -8,6 +8,8 @@
   "foundation": "Foundation",
   "fan": "Fan",
   "redealsLeft": "Redeals left: {{count}}",
+  "stuckRedeal": "Stuck — redeal recommended",
+  "redealsLeftBadge": "{{count}} left",
   "moveCount": "Moves: {{count}}",
   "redeal": "Gather & redeal",
   "giveup": "Give up",

--- a/frontend/src/i18n/locales/ja/labellelucie.json
+++ b/frontend/src/i18n/locales/ja/labellelucie.json
@@ -8,6 +8,8 @@
   "foundation": "組札",
   "fan": "扇",
   "redealsLeft": "残りシャッフル: {{count}}",
+  "stuckRedeal": "手詰まり: 再ディール推奨",
+  "redealsLeftBadge": "残り{{count}}回",
   "moveCount": "手数: {{count}}",
   "redeal": "集めて配り直す",
   "giveup": "ギブアップ",

--- a/frontend/src/pages/LaBelleLuciePage.test.tsx
+++ b/frontend/src/pages/LaBelleLuciePage.test.tsx
@@ -44,6 +44,25 @@ describe('LaBelleLuciePage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
+  it('shows the stuck redeal banner when no legal move remains', async () => {
+    // No Aces, no foundation builds, no same-suit stacks -> stuck.
+    mockExec.mockResolvedValue(
+      makeState({
+        fans: [[card('SPADE', 5)], [card('HEART', 9)], [card('CLOVER', 2)]],
+        foundation: [[], [], [], []],
+        redealsLeft: 3,
+      }),
+    );
+    renderWithProviders(<LaBelleLuciePage />);
+    await waitFor(() => expect(screen.getByTestId('ll-stuck-banner')).toBeInTheDocument());
+  });
+
+  it('hides the stuck banner when a legal move exists', async () => {
+    renderWithProviders(<LaBelleLuciePage />);
+    await waitFor(() => expect(screen.getByTestId('fan-0')).toBeInTheDocument());
+    expect(screen.queryByTestId('ll-stuck-banner')).not.toBeInTheDocument();
+  });
+
   it('renders fans and foundations', async () => {
     renderWithProviders(<LaBelleLuciePage />);
     await waitFor(() => expect(screen.getByTestId('fan-0')).toBeInTheDocument());

--- a/frontend/src/pages/LaBelleLuciePage.tsx
+++ b/frontend/src/pages/LaBelleLuciePage.tsx
@@ -18,6 +18,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { Card } from '../types/card';
 import { LaBelleLuciePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { labelleLucieHasLegalMove } from '../utils/labelleLucieLegalMove';
 
 /** La Belle Lucie tutorial step definitions. */
 const LL_TUTORIAL_STEPS: TutorialStep[] = [
@@ -76,6 +77,9 @@ function LaBelleLuciePageContent() {
   const isOver = state.phase === LaBelleLuciePhase.GAME_OVER;
   const isEnd = isClear || isOver;
   const canAct = !isEnd;
+  // No legal move left but redeals remain: recommend a redeal before the
+  // player wastes time hunting for a move that does not exist.
+  const stuck = canAct && state.redealsLeft > 0 && !labelleLucieHasLegalMove(state.fans, state.foundation);
   const phaseName = phaseNames[state.phase] ?? '';
 
   const handleReset = () => {
@@ -180,6 +184,18 @@ function LaBelleLuciePageContent() {
         <div className="mt-2 text-ds-text-muted text-xs">
           {t('redealsLeft', { count: state.redealsLeft })} · {t('moveCount', { count: state.moveCount })}
         </div>
+        {stuck && (
+          <div
+            className="mt-1 flex items-center gap-2 text-ds-warning text-sm font-medium"
+            role="status"
+            data-testid="ll-stuck-banner"
+          >
+            <span>{t('stuckRedeal')}</span>
+            <span className="rounded-full bg-ds-warning/20 px-2 py-0.5 text-xs font-bold tabular-nums">
+              {t('redealsLeftBadge', { count: state.redealsLeft })}
+            </span>
+          </div>
+        )}
         {canAct && (
           <div className="mt-1 text-ds-text-primary text-xs">
             {selected === null ? t('selectSource') : t('selectDestination')}
@@ -201,7 +217,7 @@ function LaBelleLuciePageContent() {
           {canAct && (
             <button
               type="button"
-              className={btnWarning}
+              className={`${btnWarning}${stuck ? ' motion-safe:animate-pulse' : ''}`}
               onClick={() => exec('rd')}
               disabled={loading || state.redealsLeft <= 0}
               data-tutorial="ll-redeal"

--- a/frontend/src/utils/labelleLucieLegalMove.test.ts
+++ b/frontend/src/utils/labelleLucieLegalMove.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { labelleLucieHasLegalMove } from './labelleLucieLegalMove';
+
+const c = (design: string, value: number): Card => ({ design, value }) as Card;
+
+describe('labelleLucieHasLegalMove', () => {
+  it('returns true when a fan top can go to an empty foundation (Ace)', () => {
+    const fans = [[c('SPADE', 5), c('SPADE', 1)]]; // top is ♠A
+    const foundation = [[], [], [], []];
+    expect(labelleLucieHasLegalMove(fans, foundation)).toBe(true);
+  });
+
+  it('returns true when a fan top builds up a foundation', () => {
+    const fans = [[c('HEART', 6)]]; // top ♥6
+    const foundation = [[c('HEART', 5)], [], [], []]; // ♥5 on top -> ♥6 fits
+    expect(labelleLucieHasLegalMove(fans, foundation)).toBe(true);
+  });
+
+  it('returns true when a fan top can stack on another fan (same suit, one lower)', () => {
+    const fans = [[c('CLOVER', 7)], [c('CLOVER', 8)]]; // ♣7 onto ♣8
+    const foundation = [[], [], [], []];
+    expect(labelleLucieHasLegalMove(fans, foundation)).toBe(true);
+  });
+
+  it('returns false when no fan top has any move', () => {
+    const fans = [[c('SPADE', 5)], [c('HEART', 9)], [c('CLOVER', 2)]];
+    const foundation = [[], [], [], []]; // no Aces, no builds, no same-suit stacks
+    expect(labelleLucieHasLegalMove(fans, foundation)).toBe(false);
+  });
+
+  it('ignores empty fans', () => {
+    const fans = [[], [c('DIAMOND', 9)]];
+    const foundation = [[], [], [], []];
+    expect(labelleLucieHasLegalMove(fans, foundation)).toBe(false);
+  });
+});

--- a/frontend/src/utils/labelleLucieLegalMove.ts
+++ b/frontend/src/utils/labelleLucieLegalMove.ts
@@ -1,0 +1,43 @@
+import type { Card } from '../types/card';
+
+/** Top (movable) card of a fan, or undefined when the fan is empty. */
+function fanTop(fan: Card[]): Card | undefined {
+  return fan.length > 0 ? fan[fan.length - 1] : undefined;
+}
+
+/** Whether the card can move to any foundation: an empty pile takes an Ace,
+ * otherwise it builds up in the same suit (value + 1). */
+function fitsFoundation(card: Card, foundation: Card[][]): boolean {
+  for (const pile of foundation) {
+    if (pile.length === 0) {
+      if (card.value === 1) return true;
+      continue;
+    }
+    const top = pile[pile.length - 1];
+    if (card.design === top.design && card.value === top.value + 1) return true;
+  }
+  return false;
+}
+
+/** Whether the card can stack on a fan top: same suit, one rank lower. */
+function canStack(card: Card, dstTop: Card | undefined): boolean {
+  if (!dstTop) return false;
+  return card.design === dstTop.design && card.value === dstTop.value - 1;
+}
+
+/**
+ * Reports whether any legal move exists in La Belle Lucie — a fan top that can
+ * go to a foundation or stack onto another fan's top. Mirrors the domain's
+ * hasAnyLegalMove so the UI can recommend a redeal before the player is stuck.
+ */
+export function labelleLucieHasLegalMove(fans: Card[][], foundation: Card[][]): boolean {
+  for (let i = 0; i < fans.length; i++) {
+    const card = fanTop(fans[i]);
+    if (!card) continue;
+    if (fitsFoundation(card, foundation)) return true;
+    for (let j = 0; j < fans.length; j++) {
+      if (i !== j && canStack(card, fanTop(fans[j]))) return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## 概要
Closes #2698

`redealsLeft` は小さな muted 行で、再ディールボタンも常時同じ見た目だったため「手詰まり＝今が再ディール時」が分からなかった。合法手の有無をクライアント側で判定し（新ユーティリティ `labelleLucieHasLegalMove`、ドメインの `hasAnyLegalMove` を踏襲）、再ディール残があるのに合法手が無いとき手詰まり推奨バナー＋残回数バッジを表示し、再ディールボタンを pulse 強調する。

## 変更点
- `frontend/src/utils/labelleLucieLegalMove.ts`(+test): fan トップの ファウンデーション手（空→A / 同スート昇順）と 他 fan への積み（同スート降順）を判定。
- `LaBelleLuciePage.tsx`: `stuck = canAct && redealsLeft>0 && !hasLegalMove` で role=status バナー（`ll-stuck-banner`）＋ `redealsLeftBadge`、再ディールボタンに `motion-safe:animate-pulse`。
- `i18n/locales/{ja,en}/labellelucie.json`: `stuckRedeal`/`redealsLeftBadge`。
- `LaBelleLuciePage.test.tsx`: 手詰まり時バナー表示／合法手ありで非表示。

## テスト
- [x] `bun run test -- --run labelleLucie` 15件緑
- [x] `bun run check` パス