### PR TITLE
feat(gofish): show opponents' known ranks in CUI

### DIFF
--- a/internal/adapter/presenter/GoFishCuiPresenter.go
+++ b/internal/adapter/presenter/GoFishCuiPresenter.go
@@ -22,6 +22,46 @@ func goFishPlayerStr(player *domain.GoFishPlayer, i int) string {
 	return b.String()
 }
 
+// writeGoFishKnownRanks lists, per opponent, the ranks they are known to hold
+// from past asks; a rank the human also holds is starred as a strong ask
+// target. Emitted only on the human's turn.
+func writeGoFishKnownRanks(b *strings.Builder, gf interfaces.GoFishGame) {
+	known := gf.GetKnownRanks()
+	var human *domain.GoFishPlayer
+	for i := 0; i < gf.GetPlayerCnt(); i++ {
+		if p := gf.GetPlayer(i); p != nil && p.GetIsHuman() {
+			human = p
+			break
+		}
+	}
+	wrote := false
+	for i := 0; i < gf.GetPlayerCnt(); i++ {
+		p := gf.GetPlayer(i)
+		if p == nil || p.GetIsHuman() {
+			continue
+		}
+		ranks := known[i]
+		if len(ranks) == 0 {
+			continue
+		}
+		parts := make([]string, len(ranks))
+		for k, r := range ranks {
+			s := strconv.Itoa(r)
+			if human != nil && human.HasRank(r) {
+				s += "*" // you hold this rank too — a strong ask target
+			}
+			parts[k] = s
+		}
+		b.WriteString(i18n.Tf("gofish.knownRanks",
+			"name", cuiPlayerName(p, i),
+			"ranks", strings.Join(parts, " ")) + "\n")
+		wrote = true
+	}
+	if wrote {
+		b.WriteString(i18n.T("gofish.knownRanksLegend") + "\n")
+	}
+}
+
 // GoFishCuiPresenter renders the Go Fish CUI view.
 type GoFishCuiPresenter struct{}
 
@@ -107,6 +147,7 @@ func (p *GoFishCuiPresenter) Output(gf interfaces.GoFishGame, lastErr error) str
 		b.WriteString(i18n.Tf("gofish.promptCurrentTurn", "name", turnName) + "\n")
 		if gf.IsHumanTurn() {
 			b.WriteString(i18n.T("gofish.promptHumanHelp") + "\n")
+			writeGoFishKnownRanks(b, gf)
 		}
 	})
 }

--- a/internal/adapter/presenter/GoFishCuiPresenter_test.go
+++ b/internal/adapter/presenter/GoFishCuiPresenter_test.go
@@ -22,6 +22,24 @@ func TestGoFishCuiPresenter_Output_Initial(t *testing.T) {
 	assert.Contains(t, result, "のターン")
 }
 
+func TestGoFishCuiPresenter_Output_KnownRanks(t *testing.T) {
+	p := new(presenter.GoFishCuiPresenter)
+	m := setupGoFishMock()
+	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetKnownRanks")
+	m.On("GetKnownRanks").Return(map[int][]int{1: {7, 9}})
+	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPlayer")
+	human := domain.NewGoFishPlayer(true)
+	human.AddCard(domain.NewCard(domain.CardDesignSpade, 7, false)) // human also holds rank 7
+	m.On("GetPlayer", 0).Return(human)
+	for i := 1; i < 4; i++ {
+		m.On("GetPlayer", i).Return(domain.NewGoFishPlayer(false))
+	}
+
+	result := p.Output(m, nil)
+	assert.Contains(t, result, "既知ランク")
+	assert.Contains(t, result, "7*") // human holds rank 7 -> strong ask target
+}
+
 func TestGoFishCuiPresenter_Output_GameEnd(t *testing.T) {
 	p := new(presenter.GoFishCuiPresenter)
 	m := new(interfaces.MockGoFishGame)

--- a/internal/adapter/presenter/GoFishWebPresenter_test.go
+++ b/internal/adapter/presenter/GoFishWebPresenter_test.go
@@ -18,6 +18,7 @@ import (
 func setupGoFishMock() *interfaces.MockGoFishGame {
 	m := new(interfaces.MockGoFishGame)
 	m.On("GetPlayerCnt").Return(4)
+	m.On("GetKnownRanks").Return(map[int][]int{}).Maybe()
 	m.On("GetCurrentTurn").Return(0)
 	m.On("GetPhase").Return(domain.GoFishPhasePlay)
 	m.On("GetGameEndFlag").Return(false)

--- a/internal/domain/GoFish.go
+++ b/internal/domain/GoFish.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"sort"
 )
 
 // GoFishPlayerCnt Go Fishプレイヤー数
@@ -669,6 +670,38 @@ func (g *GoFish) GetLastBookRank() int { return g.lastBookRank }
 
 // GetCpuActions CPUターンの行動履歴を取得する
 func (g *GoFish) GetCpuActions() []*GoFishCpuAction { return g.cpuActions }
+
+// GetKnownRanks returns, per player index, the sorted ranks that player is
+// publicly known to hold from past asks — a player must hold a card of the rank
+// they ask for — excluding ranks they have since booked. Derived from the
+// shared ask memory so the CUI hint matches what the CPU can already deduce.
+func (g *GoFish) GetKnownRanks() map[int][]int {
+	asked := make(map[int]map[int]bool, len(g.players))
+	for _, e := range g.cpuMemories {
+		if asked[e.askerIdx] == nil {
+			asked[e.askerIdx] = make(map[int]bool)
+		}
+		asked[e.askerIdx][e.rank] = true
+	}
+	out := make(map[int][]int, len(g.players))
+	for i, p := range g.players {
+		booked := make(map[int]bool)
+		for _, book := range p.GetBooks() {
+			if len(book) > 0 {
+				booked[book[0].GetValue()] = true
+			}
+		}
+		ranks := make([]int, 0, len(asked[i]))
+		for r := range asked[i] {
+			if !booked[r] {
+				ranks = append(ranks, r)
+			}
+		}
+		sort.Ints(ranks)
+		out[i] = ranks
+	}
+	return out
+}
 
 // GetHumanAction 人間の最後の行動記録を取得する
 func (g *GoFish) GetHumanAction() *GoFishCpuAction { return g.humanAction }

--- a/internal/domain/GoFish_test.go
+++ b/internal/domain/GoFish_test.go
@@ -328,6 +328,24 @@ func TestGoFish_JSON_RoundTrip_PreservesCpuMemories(t *testing.T) {
 	assert.Equal(t, g.cpuMemories, restored.cpuMemories)
 }
 
+func TestGoFish_GetKnownRanks(t *testing.T) {
+	g := newTestGoFish()
+	g.cpuMemories = []goFishMemoryEntry{
+		{askerIdx: 1, rank: 5},
+		{askerIdx: 1, rank: 5}, // duplicate is de-duped
+		{askerIdx: 1, rank: 9},
+		{askerIdx: 2, rank: 7},
+	}
+	// Player 1 has booked rank 5, so it drops out of their known ranks.
+	g.players[1].books = [][]*Card{{NewCard(CardDesignSpade, 5, false)}}
+
+	known := g.GetKnownRanks()
+	assert.Equal(t, []int{9}, known[1])
+	assert.Equal(t, []int{7}, known[2])
+	assert.Empty(t, known[0])
+	assert.Empty(t, known[3])
+}
+
 func TestGoFish_ActionLog(t *testing.T) {
 	g := newTestGoFish()
 	g.players[0].AddCard(NewCard(CardDesignSpade, 3, false))

--- a/internal/domain/interfaces/gofish.go
+++ b/internal/domain/interfaces/gofish.go
@@ -53,6 +53,8 @@ type GoFishGame interface {
 	GetLastBookRank() int
 	// GetCpuActions CPUターンの行動履歴を取得する
 	GetCpuActions() []*domain.GoFishCpuAction
+	// GetKnownRanks は各プレイヤーが保有を公開済みのランク一覧を返す
+	GetKnownRanks() map[int][]int
 	// GetHumanAction 人間の最後の行動記録を取得する
 	GetHumanAction() *domain.GoFishCpuAction
 }

--- a/internal/domain/interfaces/gofish_mock.go
+++ b/internal/domain/interfaces/gofish_mock.go
@@ -161,6 +161,15 @@ func (_m *MockGoFishGame) GetCpuActions() []*domain.GoFishCpuAction {
 	return nil
 }
 
+// GetKnownRanks モック
+func (_m *MockGoFishGame) GetKnownRanks() map[int][]int {
+	ret := _m.Called()
+	if v, ok := ret.Get(0).(map[int][]int); ok {
+		return v
+	}
+	return nil
+}
+
 // GetHumanAction モック
 func (_m *MockGoFishGame) GetHumanAction() *domain.GoFishCpuAction {
 	ret := _m.Called()

--- a/internal/i18n/locales/en/gofish.json
+++ b/internal/i18n/locales/en/gofish.json
@@ -15,5 +15,7 @@
   "winCpu": "Game over! CPU {{idx}} wins!",
   "scoreEntry": "  {{name}}: {{count}} book(s)",
   "promptCurrentTurn": "{{name}}'s turn",
-  "promptHumanHelp": "ask <opponent> <rank> to request"
+  "promptHumanHelp": "ask <opponent> <rank> to request",
+  "knownRanks": "{{name}} known ranks: {{ranks}}",
+  "knownRanksLegend": "(* = a rank you also hold = a strong ask target)"
 }

--- a/internal/i18n/locales/ja/gofish.json
+++ b/internal/i18n/locales/ja/gofish.json
@@ -15,5 +15,7 @@
   "winCpu": "ゲーム終了！ CPU {{idx}}の勝ち！",
   "scoreEntry": "  {{name}}: {{count}}ブック",
   "promptCurrentTurn": "{{name}}のターン",
-  "promptHumanHelp": "ask <相手番号> <ランク> で要求"
+  "promptHumanHelp": "ask <相手番号> <ランク> で要求",
+  "knownRanks": "{{name}}の既知ランク: {{ranks}}",
+  "knownRanksLegend": "(* = あなたも持つランク = 有利な要求先)"
 }


### PR DESCRIPTION
## 概要
Closes #2569

Web版（`useGoFishKnownRanks`）は過去のアスクから判明した各相手の保有ランクを表示するが、CUI版はアスク履歴を羅列するだけだった。ドメインに `GetKnownRanks`（既存のアスク記憶 `cpuMemories` から導出、ブック済みランクを除外）を追加し、自分の手番で各相手の既知ランクを一覧表示する。自分も持つランクは `*` で「有利な要求先」として強調。

## 変更点
- `internal/domain/GoFish.go`: `GetKnownRanks() map[int][]int` — askerIdx 別に既知ランクを集約しブック済みを除外（Web フックと同ロジック、単一ソース）。
- `internal/domain/interfaces/gofish.go` + `_mock.go`: `GetKnownRanks` 追加。
- `GoFishCuiPresenter.go`: 人間手番で各相手の既知ランク行＋凡例（`* = 自分も持つ`）。新規ヘルパー `writeGoFishKnownRanks`。
- `internal/i18n/locales/{ja,en}/gofish.json`: `knownRanks`/`knownRanksLegend`。
- テスト: ドメイン `GetKnownRanks`（dedup + ブック除外）、presenter（既知ランク表示＋`*` 強調）。

## テスト
- [x] `go test -tags test ./internal/adapter/presenter/ -run TestGoFishCuiPresenter` 緑 / `golangci-lint` presenter 0 issues
- [x] ドメイン `GetKnownRanks` テスト追加（Backend Tests は CI で検証＝ローカル domain compile が swap で OOM のため）