### PR TITLE
fix(gofish): guard GetKnownRanks against a nil player slot

### DIFF
--- a/internal/domain/GoFish.go
+++ b/internal/domain/GoFish.go
@@ -685,6 +685,10 @@ func (g *GoFish) GetKnownRanks() map[int][]int {
 	}
 	out := make(map[int][]int, len(g.players))
 	for i, p := range g.players {
+		if p == nil {
+			out[i] = nil
+			continue
+		}
 		booked := make(map[int]bool)
 		for _, book := range p.GetBooks() {
 			if len(book) > 0 {

--- a/internal/domain/GoFish_test.go
+++ b/internal/domain/GoFish_test.go
@@ -339,6 +339,9 @@ func TestGoFish_GetKnownRanks(t *testing.T) {
 	// Player 1 has booked rank 5, so it drops out of their known ranks.
 	g.players[1].books = [][]*Card{{NewCard(CardDesignSpade, 5, false)}}
 
+	// A nil player slot is skipped defensively rather than panicking.
+	g.players[3] = nil
+
 	known := g.GetKnownRanks()
 	assert.Equal(t, []int{9}, known[1])
 	assert.Equal(t, []int{7}, known[2])


### PR DESCRIPTION
Follow-up to #2869 (gemini MUST). `GetKnownRanks` now skips a nil `players[i]` (`out[i]=nil; continue`) instead of dereferencing it via `GetBooks()`. Players are never nil in normal flow, but this hardens the loop; the GetKnownRanks test sets a nil slot to cover the branch.

## テスト
- [x] domain GetKnownRanks test extended (nil slot) — Backend Tests verified in CI