### PR TITLE
feat(bezique): show trick/meld score breakdown

### DIFF
--- a/frontend/src/i18n/locales/en/bezique.json
+++ b/frontend/src/i18n/locales/en/bezique.json
@@ -25,6 +25,7 @@
   "cpu": "CPU {{id}}",
   "matchScoreTitle": "Score",
   "scoreLine": "{{name}}: match {{match}} / deal {{deal}} / {{tricks}} tricks",
+  "dealBreakdown": "Breakdown: trick {{trick}} + meld {{meld}} = {{total}}",
   "playButton": "Play",
   "skipMeld": "Skip meld",
   "nextRound": "Next Deal",

--- a/frontend/src/i18n/locales/ja/bezique.json
+++ b/frontend/src/i18n/locales/ja/bezique.json
@@ -25,6 +25,7 @@
   "cpu": "CPU {{id}}",
   "matchScoreTitle": "スコア",
   "scoreLine": "{{name}}: マッチ {{match}} / ディール {{deal}} / {{tricks}}トリック",
+  "dealBreakdown": "内訳: トリック{{trick}} + メルド{{meld}} = {{total}}",
   "playButton": "出す",
   "skipMeld": "メルドしない",
   "nextRound": "次のディール",

--- a/frontend/src/pages/BeziquePage.test.tsx
+++ b/frontend/src/pages/BeziquePage.test.tsx
@@ -58,6 +58,17 @@ describe('BeziquePage', () => {
     );
   });
 
+  it('shows the deal-points trick/meld breakdown in the score sidebar', async () => {
+    mockExec.mockResolvedValue(
+      makeBeziqueState({ phase: 0, currentPlayerIdx: 0, dealPoints: [10, 0], dealMeldPoints: [4, 0] }),
+    );
+    renderWithProviders(<BeziquePage />);
+    const breakdown = await screen.findByTestId('bezique-deal-breakdown-0');
+    // trick = deal(10) - meld(4) = 6
+    expect(breakdown).toHaveTextContent('6');
+    expect(breakdown).toHaveTextContent('4');
+  });
+
   it('renders the play phase with the human cards and the play button', async () => {
     renderWithProviders(<BeziquePage />);
     await waitFor(() => {

--- a/frontend/src/pages/BeziquePage.tsx
+++ b/frontend/src/pages/BeziquePage.tsx
@@ -247,9 +247,9 @@ function BeziquePageContent() {
                       </div>
                       <div className="text-ds-text-muted text-xs" data-testid={`bezique-deal-breakdown-${p.id}`}>
                         {t('dealBreakdown', {
-                          trick: (state.dealPoints[p.id] ?? 0) - (state.dealMeldPoints[p.id] ?? 0),
-                          meld: state.dealMeldPoints[p.id] ?? 0,
-                          total: state.dealPoints[p.id] ?? 0,
+                          trick: state.dealPoints[p.id] - state.dealMeldPoints[p.id],
+                          meld: state.dealMeldPoints[p.id],
+                          total: state.dealPoints[p.id],
                         })}
                       </div>
                     </div>

--- a/frontend/src/pages/BeziquePage.tsx
+++ b/frontend/src/pages/BeziquePage.tsx
@@ -237,12 +237,21 @@ function BeziquePageContent() {
                   <div className="mb-1 text-ds-text-primary text-xs">{t('matchScoreTitle')}</div>
                   {state.players.map((p) => (
                     <div key={p.id} className={p.isHuman ? 'text-ds-text-primary' : ''}>
-                      {t('scoreLine', {
-                        name: p.isHuman ? t('you') : t('cpu', { id: p.id }),
-                        match: state.matchScore[p.id] ?? 0,
-                        deal: state.dealPoints[p.id] ?? 0,
-                        tricks: p.trickCount,
-                      })}
+                      <div>
+                        {t('scoreLine', {
+                          name: p.isHuman ? t('you') : t('cpu', { id: p.id }),
+                          match: state.matchScore[p.id] ?? 0,
+                          deal: state.dealPoints[p.id] ?? 0,
+                          tricks: p.trickCount,
+                        })}
+                      </div>
+                      <div className="text-ds-text-muted text-xs" data-testid={`bezique-deal-breakdown-${p.id}`}>
+                        {t('dealBreakdown', {
+                          trick: (state.dealPoints[p.id] ?? 0) - (state.dealMeldPoints[p.id] ?? 0),
+                          meld: state.dealMeldPoints[p.id] ?? 0,
+                          total: state.dealPoints[p.id] ?? 0,
+                        })}
+                      </div>
                     </div>
                   ))}
                 </div>

--- a/frontend/src/test/stateFactories.ts
+++ b/frontend/src/test/stateFactories.ts
@@ -1200,6 +1200,7 @@ const baseBeziqueState: BeziqueResponse = {
     { id: 1, isHuman: false, cardCount: 9, cards: [], roundScore: 0, cumulativeScore: 0, trickCount: 0 },
   ],
   dealPoints: [0, 0],
+  dealMeldPoints: [0, 0],
   matchScore: [0, 0],
   phase: 0,
   roundNumber: 1,

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -2186,6 +2186,8 @@ export interface BeziqueResponse extends BaseGameResponse {
   players: BeziquePlayer[];
   /** Points scored in the current deal, indexed by seat. */
   dealPoints: number[];
+  /** Of the deal points, the portion from melds (trick portion = dealPoints - dealMeldPoints). */
+  dealMeldPoints: number[];
   /** Cumulative match score, indexed by seat. */
   matchScore: number[];
   phase: BeziquePhaseValue;

--- a/internal/adapter/controller/BeziqueWebController.go
+++ b/internal/adapter/controller/BeziqueWebController.go
@@ -59,6 +59,7 @@ type BeziqueWebOutputHint struct {
 type BeziqueWebOutput struct {
 	Players          []*BeziqueWebOutputPlayer    `json:"players"`
 	DealPoints       []int                        `json:"dealPoints"`
+	DealMeldPoints   []int                        `json:"dealMeldPoints"`
 	MatchScore       []int                        `json:"matchScore"`
 	Phase            int                          `json:"phase"`
 	RoundNumber      int                          `json:"roundNumber"`
@@ -113,6 +114,7 @@ func newBeziqueDefaultOutput(msg string) *BeziqueWebOutput {
 	return &BeziqueWebOutput{
 		Players:        make([]*BeziqueWebOutputPlayer, 0),
 		DealPoints:     make([]int, 0),
+		DealMeldPoints: make([]int, 0),
 		MatchScore:     make([]int, 0),
 		CurrentTrick:   make([]*BeziqueWebOutputTrickCard, 0),
 		AvailableMelds: make([]*BeziqueWebOutputMeld, 0),

--- a/internal/adapter/controller/BeziqueWebController_test.go
+++ b/internal/adapter/controller/BeziqueWebController_test.go
@@ -21,6 +21,7 @@ func mustBeziqueOutputJSON(msg string) string {
 	out := &controller.BeziqueWebOutput{
 		Players:        []*controller.BeziqueWebOutputPlayer{},
 		DealPoints:     []int{},
+		DealMeldPoints: []int{},
 		MatchScore:     []int{},
 		CurrentTrick:   []*controller.BeziqueWebOutputTrickCard{},
 		AvailableMelds: []*controller.BeziqueWebOutputMeld{},

--- a/internal/adapter/presenter/BeziqueCuiPresenter.go
+++ b/internal/adapter/presenter/BeziqueCuiPresenter.go
@@ -58,6 +58,17 @@ func (p *BeziqueCuiPresenter) Output(b interfaces.BeziqueGame, lastErr error) st
 			sb.WriteString(beziquePlayerStr(b.GetPlayer(i), i, b.GetDealPoints(i), b.GetMatchScore(i)))
 		}
 
+		// Deal-points breakdown so players see trick vs meld contribution.
+		for i := 0; i < b.GetPlayerCnt(); i++ {
+			deal := b.GetDealPoints(i)
+			meld := b.GetDealMeldPoints(i)
+			sb.WriteString(i18n.Tf("bezique.dealBreakdown",
+				"name", cuiPlayerName(b.GetPlayer(i), i),
+				"trick", strconv.Itoa(deal-meld),
+				"meld", strconv.Itoa(meld),
+				"total", strconv.Itoa(deal)) + "\n")
+		}
+
 		sb.WriteString("----------\n")
 
 		trick := b.GetCurrentTrick()

--- a/internal/adapter/presenter/BeziqueCuiPresenter_test.go
+++ b/internal/adapter/presenter/BeziqueCuiPresenter_test.go
@@ -41,6 +41,8 @@ func setupBeziqueCuiMockWithPlayers(trumpCard *domain.Card) (*interfaces.MockBez
 	m.On("GetPlayer", 1).Return(players[1])
 	m.On("GetDealPoints", 0).Return(18)
 	m.On("GetDealPoints", 1).Return(5)
+	m.On("GetDealMeldPoints", 0).Return(8)
+	m.On("GetDealMeldPoints", 1).Return(0)
 	m.On("GetMatchScore", 0).Return(118)
 	m.On("GetMatchScore", 1).Return(45)
 	return m, players

--- a/internal/adapter/presenter/BeziqueWebPresenter.go
+++ b/internal/adapter/presenter/BeziqueWebPresenter.go
@@ -46,9 +46,11 @@ func (p *BeziqueWebPresenter) buildBase(b interfaces.BeziqueGame) *controller.Be
 
 	cnt := b.GetPlayerCnt()
 	resObj.DealPoints = make([]int, cnt)
+	resObj.DealMeldPoints = make([]int, cnt)
 	resObj.MatchScore = make([]int, cnt)
 	for i := 0; i < cnt; i++ {
 		resObj.DealPoints[i] = b.GetDealPoints(i)
+		resObj.DealMeldPoints[i] = b.GetDealMeldPoints(i)
 		resObj.MatchScore[i] = b.GetMatchScore(i)
 	}
 

--- a/internal/adapter/presenter/BeziqueWebPresenter_test.go
+++ b/internal/adapter/presenter/BeziqueWebPresenter_test.go
@@ -47,6 +47,8 @@ func setupBeziqueWebMockWithPlayers(trumpCard *domain.Card) (*interfaces.MockBez
 	m.On("GetPlayer", 1).Return(players[1])
 	m.On("GetDealPoints", 0).Return(18)
 	m.On("GetDealPoints", 1).Return(5)
+	m.On("GetDealMeldPoints", 0).Return(8)
+	m.On("GetDealMeldPoints", 1).Return(0)
 	m.On("GetMatchScore", 0).Return(118)
 	m.On("GetMatchScore", 1).Return(45)
 	return m, players
@@ -124,6 +126,8 @@ func TestBeziqueWebPresenter_Output_GameEnd(t *testing.T) {
 	m.On("GetPlayer", 1).Return(domain.NewBeziquePlayer(false))
 	m.On("GetDealPoints", 0).Return(0)
 	m.On("GetDealPoints", 1).Return(0)
+	m.On("GetDealMeldPoints", 0).Return(0)
+	m.On("GetDealMeldPoints", 1).Return(0)
 	m.On("GetMatchScore", 0).Return(1010)
 	m.On("GetMatchScore", 1).Return(800)
 	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetGameEndFlag")

--- a/internal/domain/Bezique.go
+++ b/internal/domain/Bezique.go
@@ -173,6 +173,7 @@ type Bezique struct {
 	leadPlayerIdx    int
 	dealerIdx        int
 	dealPoints       []int // 当ディールの得点
+	dealMeldPoints   []int // 当ディールのうちメルド由来の得点 (内訳表示用; トリック由来 = dealPoints - dealMeldPoints)
 	matchScore       []int // 試合累積得点
 	meldsDeclared    []int // プレイヤー毎の宣言済みメルドビットマスク
 	gameEndFlag      bool
@@ -183,13 +184,14 @@ type Bezique struct {
 // NewBezique コンストラクタ
 func NewBezique(trumpCards *TrumpCards, players []*BeziquePlayer, config BeziqueConfig) *Bezique {
 	return &Bezique{
-		trumpCards:    trumpCards,
-		players:       players,
-		config:        config,
-		winnerIdx:     -1,
-		dealPoints:    make([]int, len(players)),
-		matchScore:    make([]int, len(players)),
-		meldsDeclared: make([]int, len(players)),
+		trumpCards:     trumpCards,
+		players:        players,
+		config:         config,
+		winnerIdx:      -1,
+		dealPoints:     make([]int, len(players)),
+		dealMeldPoints: make([]int, len(players)),
+		matchScore:     make([]int, len(players)),
+		meldsDeclared:  make([]int, len(players)),
 	}
 }
 
@@ -227,6 +229,7 @@ func (b *Bezique) NextRound() {
 // startDeal 1 ディールを開始する: シャッフル・8枚配り・切り札表示。
 func (b *Bezique) startDeal() {
 	b.dealPoints = make([]int, len(b.players))
+	b.dealMeldPoints = make([]int, len(b.players))
 	b.meldsDeclared = make([]int, len(b.players))
 	b.currentTrick = nil
 	b.trumpCard = nil
@@ -424,6 +427,15 @@ func (b *Bezique) GetDealPoints(i int) int {
 		return 0
 	}
 	return b.dealPoints[i]
+}
+
+// GetDealMeldPoints はプレイヤーの当ディール得点のうちメルド由来分を返す。
+// トリック由来の得点は GetDealPoints - GetDealMeldPoints で求められる。
+func (b *Bezique) GetDealMeldPoints(i int) int {
+	if i < 0 || i >= len(b.dealMeldPoints) {
+		return 0
+	}
+	return b.dealMeldPoints[i]
 }
 
 // SetDealPoints プレイヤーの当ディール得点設定 (テスト用)
@@ -827,6 +839,7 @@ func (b *Bezique) applyMeld(playerIdx int, m BeziqueMeld) {
 	bit := beziqueMeldBit(m)
 	b.meldsDeclared[playerIdx] |= 1 << bit
 	b.dealPoints[playerIdx] += m.Points
+	b.dealMeldPoints[playerIdx] += m.Points
 	b.appendLog(playerIdx, "meld",
 		fmt.Sprintf("%s declares %s (+%d)", b.playerName(playerIdx), beziqueMeldName(m), m.Points), nil)
 }
@@ -1080,6 +1093,7 @@ type beziqueJSON struct {
 	LeadPlayerIdx    int                 `json:"li"`
 	DealerIdx        int                 `json:"di"`
 	DealPoints       []int               `json:"dp"`
+	DealMeldPoints   []int               `json:"dmp"`
 	MatchScore       []int               `json:"ms"`
 	MeldsDeclared    []int               `json:"me"`
 	GameEndFlag      bool                `json:"ge"`
@@ -1103,6 +1117,7 @@ func (b *Bezique) MarshalJSON() ([]byte, error) {
 		LeadPlayerIdx:    b.leadPlayerIdx,
 		DealerIdx:        b.dealerIdx,
 		DealPoints:       b.dealPoints,
+		DealMeldPoints:   b.dealMeldPoints,
 		MatchScore:       b.matchScore,
 		MeldsDeclared:    b.meldsDeclared,
 		GameEndFlag:      b.gameEndFlag,
@@ -1174,6 +1189,7 @@ func (b *Bezique) UnmarshalJSON(data []byte) error {
 	b.leadPlayerIdx = j.LeadPlayerIdx
 	b.dealerIdx = j.DealerIdx
 	b.dealPoints = beziqueEnsureLen(j.DealPoints)
+	b.dealMeldPoints = beziqueEnsureLen(j.DealMeldPoints)
 	b.matchScore = beziqueEnsureLen(j.MatchScore)
 	b.meldsDeclared = beziqueEnsureLen(j.MeldsDeclared)
 	b.gameEndFlag = j.GameEndFlag

--- a/internal/domain/Bezique_test.go
+++ b/internal/domain/Bezique_test.go
@@ -148,8 +148,11 @@ func TestBezique_FourAcesMeld(t *testing.T) {
 	assert.Equal(t, domain.BeziqueFourAcesPoints, melds[0].Points)
 
 	startDeal := b.GetDealPoints(0)
+	startMeld := b.GetDealMeldPoints(0)
 	require.NoError(t, b.PlayerDeclareMeld(0))
 	assert.Equal(t, startDeal+domain.BeziqueFourAcesPoints, b.GetDealPoints(0))
+	// The meld points are also tracked separately for the score breakdown.
+	assert.Equal(t, startMeld+domain.BeziqueFourAcesPoints, b.GetDealMeldPoints(0))
 	// Same meld cannot be declared twice.
 	b.SetPhase(domain.BeziquePhaseMeld)
 	b.SetCurrentPlayerIdx(0)

--- a/internal/domain/interfaces/bezique.go
+++ b/internal/domain/interfaces/bezique.go
@@ -53,6 +53,8 @@ type BeziqueGame interface {
 	GetDealerIdx() int
 	// GetDealPoints プレイヤーの当ディール得点を取得する
 	GetDealPoints(i int) int
+	// GetDealMeldPoints プレイヤーの当ディール得点のうちメルド由来分を取得する
+	GetDealMeldPoints(i int) int
 	// GetMatchScore プレイヤーの試合累積得点を取得する
 	GetMatchScore(i int) int
 	// GetWinnerIdx 勝者プレイヤーインデックスを取得する (-1: 未確定)

--- a/internal/domain/interfaces/bezique_mock.go
+++ b/internal/domain/interfaces/bezique_mock.go
@@ -124,6 +124,12 @@ func (m *MockBeziqueGame) GetDealPoints(i int) int {
 	return args.Int(0)
 }
 
+// GetDealMeldPoints モック
+func (m *MockBeziqueGame) GetDealMeldPoints(i int) int {
+	args := m.Called(i)
+	return args.Int(0)
+}
+
 func (m *MockBeziqueGame) GetMatchScore(i int) int {
 	args := m.Called(i)
 	return args.Int(0)

--- a/internal/i18n/locales/en/bezique.json
+++ b/internal/i18n/locales/en/bezique.json
@@ -6,6 +6,7 @@
   "trumpLine": "Trump upcard: {{card}}",
   "trumpLineNone": "Trump: {{suit}} (stock exhausted)",
   "scoreLine": "Match score: You={{p0}}  CPU={{p1}}",
+  "dealBreakdown": "{{name}} deal points: trick {{trick}} + meld {{meld}} = {{total}}",
   "playerLine": "{{name}}: {{tricks}} tricks  deal {{deal}} pts  match {{match}} pts  {{cards}} cards",
   "gameEndP0": "Game over! You win ({{p0}}-{{p1}})!",
   "gameEndP1": "Game over! CPU wins ({{p0}}-{{p1}}).",

--- a/internal/i18n/locales/ja/bezique.json
+++ b/internal/i18n/locales/ja/bezique.json
@@ -6,6 +6,7 @@
   "trumpLine": "切り札表示カード: {{card}}",
   "trumpLineNone": "切り札: {{suit}} (山札なし)",
   "scoreLine": "累積得点: あなた={{p0}}  CPU={{p1}}",
+  "dealBreakdown": "{{name}} ディール得点: トリック{{trick}} + メルド{{meld}} = {{total}}",
   "playerLine": "{{name}}: 獲得{{tricks}}トリック ディール{{deal}}点 累積{{match}}点 {{cards}}枚",
   "gameEndP0": "ゲーム終了！ あなたの勝利です ({{p0}}-{{p1}})！",
   "gameEndP1": "ゲーム終了！ CPUの勝利です ({{p0}}-{{p1}})。",


### PR DESCRIPTION
## 概要
Closes #2677

ディール得点はトリック由来とメルド由来が合算されており、Web サイドバーも CUI も内訳が分からなかった。メルド由来分を `dealMeldPoints`（永続化）として別途集計し（トリック由来 = 合計 − メルド）、Web スコアサイドバーと CUI に「トリックX + メルドY = 合計Z」を両プレイヤー分表示する。

## 変更点
- `internal/domain/Bezique.go`: `dealMeldPoints` フィールド（init/startDeal リセット、`applyMeld` で加算）、`GetDealMeldPoints`、JSON 永続化（`dmp`）。
- `interfaces/bezique.go`+mock: `GetDealMeldPoints`。
- `BeziqueCuiPresenter`: プレイヤー毎に `dealBreakdown` 行。
- `BeziqueWebPresenter` + `BeziqueWebController`(出力構造体): `dealMeldPoints` を送出。
- frontend: `BeziqueResponse.dealMeldPoints`、サイドバーに内訳行（`bezique-deal-breakdown-N`）、i18n `dealBreakdown`、stateFactory 更新。

## テスト
- [x] Go presenter（CUI/Web）+ 内訳モック、domain `FourAcesMeld` に `GetDealMeldPoints` 検証追加（Backend は CI 検証＝ローカル domain compile が OOM）
- [x] frontend `BeziquePage` 内訳表示テスト（12件緑）、`bun run check` パス
- [x] `golangci-lint` presenter+controller 0 issues