### PR TITLE
feat(chinesepoker): warn on foul before Set

### DIFF
--- a/frontend/src/pages/ChinesePokerPage.test.tsx
+++ b/frontend/src/pages/ChinesePokerPage.test.tsx
@@ -155,4 +155,63 @@ describe('ChinesePokerPage', () => {
     fireEvent.keyDown(document, { key: 'b' });
     expect(mockExec).toHaveBeenCalledWith('bet', 100);
   });
+
+  // Assign the cards at the given indices in order: the first 3 become the front
+  // row, the next 5 the middle row, and the remaining 5 stay in the back row.
+  const assignFrontMiddle = (frontMid: number[]) => {
+    for (const i of frontMid) {
+      fireEvent.click(screen.getByRole('button', { name: `Card ${i}` }));
+    }
+  };
+
+  it('shows a foul warning when the staged arrangement violates back >= middle >= front', async () => {
+    // Front = trips 9s (idx 0-2), Middle = pair 6s (idx 3-7), Back = quads 8s.
+    // Front (trips) outranks Middle (pair) → foul.
+    const foulCards: Card[] = [
+      card(0, 9),
+      card(1, 9),
+      card(2, 9), // front: trips
+      card(0, 6),
+      card(1, 6),
+      card(2, 2),
+      card(3, 3),
+      card(0, 4), // middle: pair of 6s
+      card(0, 8),
+      card(1, 8),
+      card(2, 8),
+      card(3, 8),
+      card(0, 5), // back: quads of 8s
+    ];
+    mockExec.mockResolvedValue({ ...setHandsState, playerCards: foulCards });
+    renderWithProviders(<ChinesePokerPage />);
+    await screen.findByTestId('cp-row-preview');
+    assignFrontMiddle([0, 1, 2, 3, 4, 5, 6, 7]);
+    expect(screen.getByTestId('cp-foul-warning')).toBeInTheDocument();
+  });
+
+  it('does not show a foul warning for a legal arrangement', async () => {
+    // Front = high card (idx 0-2), Middle = pair 6s (idx 3-7), Back = trips 8s.
+    const legalCards: Card[] = [
+      card(0, 2),
+      card(1, 3),
+      card(3, 5), // front: high card
+      card(0, 6),
+      card(1, 6),
+      card(2, 10),
+      card(3, 11),
+      card(0, 12), // middle: pair of 6s
+      card(0, 8),
+      card(1, 8),
+      card(2, 8),
+      card(3, 2),
+      card(0, 4), // back: trips 8s
+    ];
+    mockExec.mockResolvedValue({ ...setHandsState, playerCards: legalCards });
+    renderWithProviders(<ChinesePokerPage />);
+    await screen.findByTestId('cp-row-preview');
+    // No assignment yet → incomplete → no warning.
+    expect(screen.queryByTestId('cp-foul-warning')).not.toBeInTheDocument();
+    assignFrontMiddle([0, 1, 2, 3, 4, 5, 6, 7]);
+    expect(screen.queryByTestId('cp-foul-warning')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/ChinesePokerPage.tsx
+++ b/frontend/src/pages/ChinesePokerPage.tsx
@@ -28,6 +28,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { Card, ChinesePokerResponse } from '../types/card';
 import { ChinesePokerPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { chinesePokerIsFoul } from '../utils/chinesePokerFoul';
 import { CHINESEPOKER_HELP, parseChinesepokerCommand } from '../utils/cli/commands/chinesepokerCommands';
 import type { CliGameConfig } from '../utils/cli/types';
 
@@ -134,6 +135,15 @@ function ChinesePokerPageContent() {
     [state?.playerCards, assignments],
   );
   const canSet = frontIndices.length === 3 && middleIndices.length === 5;
+
+  // When a full arrangement is staged, warn (advisory) if it fouls back >= middle >= front.
+  // The check mirrors the server's cpValidateHands, so it agrees with the eventual result.
+  const isFoul = useMemo(() => {
+    if (!canSet) return false;
+    const cards = state?.playerCards ?? [];
+    const pick = (indices: number[]) => indices.map((i) => cards[i]).filter((c): c is Card => !!c);
+    return chinesePokerIsFoul(pick(frontIndices), pick(middleIndices), pick(backIndices));
+  }, [canSet, state?.playerCards, frontIndices, middleIndices, backIndices]);
 
   const toggleCard = useCallback((index: number) => {
     setAssignments((prev) => {
@@ -295,6 +305,15 @@ function ChinesePokerPageContent() {
                     </div>
                   ))}
                 </div>
+                {isFoul && (
+                  <div
+                    className="mt-2 rounded border border-ds-danger/60 bg-ds-danger/10 px-2 py-1 text-ds-danger text-xs"
+                    role="alert"
+                    data-testid="cp-foul-warning"
+                  >
+                    {t('foulWarning')}
+                  </div>
+                )}
               </div>
             )}
 

--- a/frontend/src/utils/chinesePokerFoul.test.ts
+++ b/frontend/src/utils/chinesePokerFoul.test.ts
@@ -22,6 +22,15 @@ describe('cpEvalFiveCardHand', () => {
   it('detects a wheel straight (A-2-3-4-5)', () => {
     expect(cpEvalFiveCardHand([c(S, 1), c(H, 2), c(D, 3), c(C, 4), c(S, 5)])).toBe(4);
   });
+  it('detects a broadway straight (A-10-J-Q-K)', () => {
+    expect(cpEvalFiveCardHand([c(S, 1), c(H, 10), c(D, 11), c(C, 12), c(S, 13)])).toBe(4);
+  });
+  it('detects a straight flush', () => {
+    expect(cpEvalFiveCardHand([c(S, 2), c(S, 3), c(S, 4), c(S, 5), c(S, 6)])).toBe(8);
+  });
+  it('detects a royal flush', () => {
+    expect(cpEvalFiveCardHand([c(S, 1), c(S, 10), c(S, 11), c(S, 12), c(S, 13)])).toBe(9);
+  });
   it('returns high card for a non-5-card hand', () => {
     expect(cpEvalFiveCardHand([c(S, 2), c(H, 3)])).toBe(0);
   });
@@ -68,6 +77,24 @@ describe('chinesePokerIsFoul', () => {
     const middle = [c(S, 6), c(H, 6), c(D, 2), c(C, 10), c(S, 12)]; // one pair
     const back = [c(S, 8), c(H, 8), c(D, 8), c(C, 8), c(S, 4)]; // quads
     expect(chinesePokerIsFoul(strongFront, middle, back)).toBe(true);
+  });
+
+  it('returns true when front ties middle on rank but wins the kicker comparison', () => {
+    // Front pair of Kings vs middle pair of Queens: same mapped rank (one pair),
+    // front's higher kicker makes it stronger than middle → foul.
+    const frontPairK = [c(S, 13), c(H, 13), c(S, 2)];
+    const middle = [c(S, 12), c(H, 12), c(C, 5), c(D, 4), c(C, 3)]; // pair of Queens
+    const back = [c(S, 8), c(H, 8), c(C, 8), c(D, 7), c(S, 6)]; // trips
+    expect(chinesePokerIsFoul(frontPairK, middle, back)).toBe(true);
+  });
+
+  it('returns false when front ties middle on rank but loses the kicker comparison', () => {
+    // Front pair of 3s vs middle pair of Queens: same mapped rank, front's lower
+    // kicker keeps it weaker than middle → legal.
+    const frontPair3 = [c(S, 3), c(H, 3), c(D, 2)];
+    const middle = [c(S, 12), c(H, 12), c(C, 5), c(D, 4), c(C, 3)]; // pair of Queens
+    const back = [c(S, 8), c(H, 8), c(C, 8), c(D, 7), c(S, 6)]; // trips
+    expect(chinesePokerIsFoul(frontPair3, middle, back)).toBe(false);
   });
 
   it('returns false for incomplete (wrong-length) rows', () => {

--- a/frontend/src/utils/chinesePokerFoul.test.ts
+++ b/frontend/src/utils/chinesePokerFoul.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign } from '../types/card';
+import { chinesePokerIsFoul, cpEvalFiveCardHand, cpEvalThreeCardHand } from './chinesePokerFoul';
+
+const S = 'SPADE';
+const H = 'HEART';
+const D = 'DIAMOND';
+const C = 'CLOVER';
+
+/** Build a card. */
+function c(design: CardDesign, value: number): Card {
+  return { design, value };
+}
+
+describe('cpEvalFiveCardHand', () => {
+  it('detects a flush', () => {
+    expect(cpEvalFiveCardHand([c(S, 2), c(S, 5), c(S, 8), c(S, 11), c(S, 13)])).toBe(5);
+  });
+  it('detects a full house', () => {
+    expect(cpEvalFiveCardHand([c(S, 7), c(H, 7), c(D, 7), c(C, 4), c(S, 4)])).toBe(6);
+  });
+  it('detects a wheel straight (A-2-3-4-5)', () => {
+    expect(cpEvalFiveCardHand([c(S, 1), c(H, 2), c(D, 3), c(C, 4), c(S, 5)])).toBe(4);
+  });
+  it('returns high card for a non-5-card hand', () => {
+    expect(cpEvalFiveCardHand([c(S, 2), c(H, 3)])).toBe(0);
+  });
+});
+
+describe('cpEvalThreeCardHand', () => {
+  it('ranks trips above straight', () => {
+    expect(cpEvalThreeCardHand([c(S, 9), c(H, 9), c(D, 9)])).toBe(5);
+  });
+  it('detects a 3-card straight', () => {
+    expect(cpEvalThreeCardHand([c(S, 5), c(H, 6), c(D, 7)])).toBe(4);
+  });
+  it('detects a pair', () => {
+    expect(cpEvalThreeCardHand([c(S, 5), c(H, 5), c(D, 9)])).toBe(2);
+  });
+  it('returns high card for a non-3-card hand', () => {
+    expect(cpEvalThreeCardHand([c(S, 2)])).toBe(1);
+  });
+});
+
+describe('chinesePokerIsFoul', () => {
+  const front = [c(S, 2), c(H, 3), c(D, 5)]; // high card (5 high)
+
+  it('returns false for a legal arrangement (back >= middle >= front)', () => {
+    const middle = [c(S, 6), c(H, 6), c(D, 9), c(C, 10), c(S, 12)]; // one pair
+    const back = [c(S, 8), c(H, 8), c(D, 8), c(C, 2), c(S, 4)]; // trips
+    expect(chinesePokerIsFoul(front, middle, back)).toBe(false);
+  });
+
+  it('returns true when back is weaker than middle (category)', () => {
+    const middle = [c(S, 8), c(H, 8), c(D, 8), c(C, 2), c(S, 4)]; // trips
+    const back = [c(S, 6), c(H, 6), c(D, 9), c(C, 10), c(S, 12)]; // one pair
+    expect(chinesePokerIsFoul(front, middle, back)).toBe(true);
+  });
+
+  it('returns true when back ties middle on category but loses the high-card tiebreak', () => {
+    const middle = [c(S, 13), c(H, 13), c(D, 9), c(C, 10), c(S, 12)]; // pair of Kings
+    const back = [c(S, 6), c(H, 6), c(D, 9), c(C, 10), c(S, 12)]; // pair of 6s
+    expect(chinesePokerIsFoul(front, middle, back)).toBe(true);
+  });
+
+  it('returns true when front is stronger than middle', () => {
+    const strongFront = [c(S, 9), c(H, 9), c(D, 9)]; // trips
+    const middle = [c(S, 6), c(H, 6), c(D, 2), c(C, 10), c(S, 12)]; // one pair
+    const back = [c(S, 8), c(H, 8), c(D, 8), c(C, 8), c(S, 4)]; // quads
+    expect(chinesePokerIsFoul(strongFront, middle, back)).toBe(true);
+  });
+
+  it('returns false for incomplete (wrong-length) rows', () => {
+    expect(chinesePokerIsFoul([c(S, 2)], [], [])).toBe(false);
+  });
+});

--- a/frontend/src/utils/chinesePokerFoul.test.ts
+++ b/frontend/src/utils/chinesePokerFoul.test.ts
@@ -31,6 +31,24 @@ describe('cpEvalFiveCardHand', () => {
   it('detects a royal flush', () => {
     expect(cpEvalFiveCardHand([c(S, 1), c(S, 10), c(S, 11), c(S, 12), c(S, 13)])).toBe(9);
   });
+  it('detects four of a kind', () => {
+    expect(cpEvalFiveCardHand([c(S, 7), c(H, 7), c(D, 7), c(C, 7), c(S, 4)])).toBe(7);
+  });
+  it('detects three of a kind', () => {
+    expect(cpEvalFiveCardHand([c(S, 7), c(H, 7), c(D, 7), c(C, 4), c(S, 9)])).toBe(3);
+  });
+  it('detects two pair', () => {
+    expect(cpEvalFiveCardHand([c(S, 7), c(H, 7), c(D, 4), c(C, 4), c(S, 9)])).toBe(2);
+  });
+  it('detects one pair', () => {
+    expect(cpEvalFiveCardHand([c(S, 7), c(H, 7), c(D, 4), c(C, 9), c(S, 11)])).toBe(1);
+  });
+  it('detects a normal (loop-path) straight', () => {
+    expect(cpEvalFiveCardHand([c(S, 5), c(H, 6), c(D, 7), c(C, 8), c(S, 9)])).toBe(4);
+  });
+  it('detects a plain high card', () => {
+    expect(cpEvalFiveCardHand([c(S, 2), c(H, 5), c(D, 7), c(C, 9), c(S, 11)])).toBe(0);
+  });
   it('returns high card for a non-5-card hand', () => {
     expect(cpEvalFiveCardHand([c(S, 2), c(H, 3)])).toBe(0);
   });
@@ -45,6 +63,21 @@ describe('cpEvalThreeCardHand', () => {
   });
   it('detects a pair', () => {
     expect(cpEvalThreeCardHand([c(S, 5), c(H, 5), c(D, 9)])).toBe(2);
+  });
+  it('detects a 3-card straight flush', () => {
+    expect(cpEvalThreeCardHand([c(S, 5), c(S, 6), c(S, 7)])).toBe(6);
+  });
+  it('detects a 3-card flush', () => {
+    expect(cpEvalThreeCardHand([c(S, 5), c(S, 9), c(S, 13)])).toBe(3);
+  });
+  it('detects an A-2-3 wrap straight', () => {
+    expect(cpEvalThreeCardHand([c(S, 1), c(H, 2), c(D, 3)])).toBe(4);
+  });
+  it('detects a Q-K-A wrap straight', () => {
+    expect(cpEvalThreeCardHand([c(S, 1), c(H, 12), c(D, 13)])).toBe(4);
+  });
+  it('detects a plain 3-card high card', () => {
+    expect(cpEvalThreeCardHand([c(S, 2), c(H, 7), c(D, 11)])).toBe(1);
   });
   it('returns high card for a non-3-card hand', () => {
     expect(cpEvalThreeCardHand([c(S, 2)])).toBe(1);
@@ -95,6 +128,33 @@ describe('chinesePokerIsFoul', () => {
     const middle = [c(S, 12), c(H, 12), c(C, 5), c(D, 4), c(C, 3)]; // pair of Queens
     const back = [c(S, 8), c(H, 8), c(C, 8), c(D, 7), c(S, 6)]; // trips
     expect(chinesePokerIsFoul(frontPair3, middle, back)).toBe(false);
+  });
+
+  it('returns false when back beats middle on the high-card tiebreak (same rank)', () => {
+    const middle = [c(S, 6), c(H, 6), c(D, 9), c(C, 10), c(S, 12)]; // pair of 6s
+    const back = [c(S, 13), c(H, 13), c(D, 9), c(C, 10), c(S, 12)]; // pair of Kings (stronger)
+    expect(chinesePokerIsFoul(front, middle, back)).toBe(false);
+  });
+
+  it('returns false when back exactly ties middle (identical ranks/values)', () => {
+    const middle = [c(S, 6), c(H, 6), c(D, 9), c(C, 10), c(S, 12)]; // pair of 6s
+    const back = [c(D, 6), c(C, 6), c(S, 9), c(H, 10), c(D, 12)]; // pair of 6s, same values
+    expect(chinesePokerIsFoul(front, middle, back)).toBe(false);
+  });
+
+  it('handles a wheel back-row stronger than a wheel-vs-straight tiebreak', () => {
+    // Back 2-3-4-5-6 straight vs middle A-2-3-4-5 wheel: both straights; back wins
+    // the tiebreak (exercises the wheel-detection branch). Legal.
+    const middle = [c(S, 1), c(H, 2), c(D, 3), c(C, 4), c(S, 5)]; // wheel straight
+    const back = [c(S, 2), c(H, 3), c(D, 4), c(C, 5), c(S, 6)]; // 6-high straight
+    expect(chinesePokerIsFoul(front, middle, back)).toBe(false);
+  });
+
+  it('flags a foul when a wheel back-row loses the straight tiebreak to middle', () => {
+    // Back A-2-3-4-5 wheel vs middle 2-3-4-5-6 straight: back is weaker → foul.
+    const middle = [c(S, 2), c(H, 3), c(D, 4), c(C, 5), c(S, 6)]; // 6-high straight
+    const back = [c(S, 1), c(H, 2), c(D, 3), c(C, 4), c(S, 5)]; // wheel straight
+    expect(chinesePokerIsFoul(front, middle, back)).toBe(true);
   });
 
   it('returns false for incomplete (wrong-length) rows', () => {

--- a/frontend/src/utils/chinesePokerFoul.ts
+++ b/frontend/src/utils/chinesePokerFoul.ts
@@ -1,0 +1,214 @@
+import type { Card } from '../types/card';
+
+/**
+ * Chinese Poker foul detection, ported 1:1 from the Go domain so the client-side
+ * SET_HANDS warning agrees with the server's authoritative `cpValidateHands`.
+ *
+ * A "foul" is any arrangement that violates back >= middle >= front. The server
+ * evaluates the two 5-card rows (middle, back) with a category-only ranker plus a
+ * high-card tiebreak, and the 3-card front row with a dedicated 3-card ranker that
+ * is mapped onto the 5-card rank space before comparison. This module mirrors each
+ * of those helpers exactly (`internal/domain/hand_eval.go`,
+ * `internal/domain/ChinesePoker.go`, `internal/domain/HoldemPlayer.go`).
+ */
+
+// 5-card poker hand rank constants (mirror internal/domain/poker_hand_rank.go).
+const POKER_HIGH_CARD = 0;
+const POKER_ONE_PAIR = 1;
+const POKER_TWO_PAIR = 2;
+const POKER_THREE_OF_A_KIND = 3;
+const POKER_STRAIGHT = 4;
+const POKER_FLUSH = 5;
+const POKER_FULL_HOUSE = 6;
+const POKER_FOUR_OF_A_KIND = 7;
+const POKER_STRAIGHT_FLUSH = 8;
+const POKER_ROYAL_FLUSH = 9;
+
+// 3-card poker hand rank constants (mirror internal/domain/hand_eval.go).
+// Note: in 3-card poker, Three of a Kind ranks ABOVE Straight.
+const THREE_HIGH_CARD = 1;
+const THREE_PAIR = 2;
+const THREE_FLUSH = 3;
+const THREE_STRAIGHT = 4;
+const THREE_OF_A_KIND = 5;
+const THREE_STRAIGHT_FLUSH = 6;
+
+function sortedValuesAsc(cards: readonly Card[]): number[] {
+  return cards.map((c) => c.value).sort((a, b) => a - b);
+}
+
+/** Mirror of `checkStraightValues` (sorted ascending; wheel and broadway count). */
+function checkStraightValues(sorted: readonly number[]): boolean {
+  if (sorted[0] === 1 && sorted[1] === 2 && sorted[2] === 3 && sorted[3] === 4 && sorted[4] === 5) {
+    return true;
+  }
+  if (sorted[0] === 1 && sorted[1] === 10 && sorted[2] === 11 && sorted[3] === 12 && sorted[4] === 13) {
+    return true;
+  }
+  for (let i = 1; i < sorted.length; i += 1) {
+    if (sorted[i] !== sorted[i - 1] + 1) return false;
+  }
+  return true;
+}
+
+function checkRoyalStraightValues(sorted: readonly number[]): boolean {
+  return (
+    sorted.length === 5 &&
+    sorted[0] === 1 &&
+    sorted[1] === 10 &&
+    sorted[2] === 11 &&
+    sorted[3] === 12 &&
+    sorted[4] === 13
+  );
+}
+
+/** Mirror of `evalFiveCardHand`: returns a POKER_* category (no joker/five-of-a-kind). */
+export function cpEvalFiveCardHand(cards: readonly Card[]): number {
+  if (cards.length !== 5) return POKER_HIGH_CARD;
+  const values = sortedValuesAsc(cards);
+  const designs = cards.map((c) => c.design);
+
+  const isFlush = designs.every((d) => d === designs[0]);
+  const isStraight = checkStraightValues(values);
+
+  const valueCounts = new Map<number, number>();
+  for (const v of values) valueCounts.set(v, (valueCounts.get(v) ?? 0) + 1);
+  const counts = Array.from(valueCounts.values()).sort((a, b) => b - a);
+
+  if (isFlush && isStraight) {
+    return checkRoyalStraightValues(values) ? POKER_ROYAL_FLUSH : POKER_STRAIGHT_FLUSH;
+  }
+  if (counts[0] === 4) return POKER_FOUR_OF_A_KIND;
+  if (counts.length >= 2 && counts[0] === 3 && counts[1] === 2) return POKER_FULL_HOUSE;
+  if (isFlush) return POKER_FLUSH;
+  if (isStraight) return POKER_STRAIGHT;
+  if (counts[0] === 3) return POKER_THREE_OF_A_KIND;
+  if (counts.length >= 2 && counts[0] === 2 && counts[1] === 2) return POKER_TWO_PAIR;
+  if (counts[0] === 2) return POKER_ONE_PAIR;
+  return POKER_HIGH_CARD;
+}
+
+/** Mirror of `checkThreeCardStraight` (A-2-3 and Q-K-A wrap, plus normal runs). */
+function checkThreeCardStraight(sorted: readonly number[]): boolean {
+  if (sorted.length !== 3) return false;
+  if (sorted[0] === 1 && sorted[1] === 2 && sorted[2] === 3) return true;
+  if (sorted[0] === 1 && sorted[1] === 12 && sorted[2] === 13) return true;
+  return sorted[1] === sorted[0] + 1 && sorted[2] === sorted[1] + 1;
+}
+
+/** Mirror of `evalThreeCardHand`: returns a THREE_* rank. */
+export function cpEvalThreeCardHand(cards: readonly Card[]): number {
+  if (cards.length !== 3) return THREE_HIGH_CARD;
+  const values = sortedValuesAsc(cards);
+  const designs = cards.map((c) => c.design);
+
+  const isFlush = designs[0] === designs[1] && designs[1] === designs[2];
+  const isStraight = checkThreeCardStraight(values);
+
+  const valueCounts = new Map<number, number>();
+  for (const v of values) valueCounts.set(v, (valueCounts.get(v) ?? 0) + 1);
+
+  if (isFlush && isStraight) return THREE_STRAIGHT_FLUSH;
+  for (const cnt of valueCounts.values()) {
+    if (cnt === 3) return THREE_OF_A_KIND;
+  }
+  if (isStraight) return THREE_STRAIGHT;
+  if (isFlush) return THREE_FLUSH;
+  for (const cnt of valueCounts.values()) {
+    if (cnt === 2) return THREE_PAIR;
+  }
+  return THREE_HIGH_CARD;
+}
+
+/** Mirror of `threeCardHandHighValues` / `cpFiveCardHighValues`: raw values, Ace=14, desc. */
+function highValuesDesc(cards: readonly Card[]): number[] {
+  return cards.map((c) => (c.value === 1 ? 14 : c.value)).sort((a, b) => b - a);
+}
+
+/** Mirror of `isWheelHand`: 5-card A-2-3-4-5. */
+function isWheelHand(cards: readonly Card[]): boolean {
+  if (cards.length !== 5) return false;
+  const v = sortedValuesAsc(cards);
+  return v[0] === 1 && v[1] === 2 && v[2] === 3 && v[3] === 4 && v[4] === 5;
+}
+
+/** Mirror of `tieBreakValues`: unique values sorted by (frequency desc, value desc). */
+function tieBreakValues(vals: readonly number[]): number[] {
+  const freq = new Map<number, number>();
+  for (const v of vals) freq.set(v, (freq.get(v) ?? 0) + 1);
+  const unique = Array.from(freq.keys());
+  unique.sort((a, b) => {
+    const fa = freq.get(a) ?? 0;
+    const fb = freq.get(b) ?? 0;
+    if (fa !== fb) return fb - fa;
+    return b - a;
+  });
+  return unique;
+}
+
+/** Mirror of `compareHighCardsSlice`: a>b → 1, a<b → -1, equal → 0. */
+function compareHighCardsSlice(a: readonly Card[], b: readonly Card[]): number {
+  if (a.length === 0 || b.length === 0) return 0;
+  const aWheel = isWheelHand(a);
+  const bWheel = isWheelHand(b);
+  const aVals = a.map((c) => (c.value === 1 && !aWheel ? 14 : c.value));
+  const bVals = b.map((c) => (c.value === 1 && !bWheel ? 14 : c.value));
+  const aTB = tieBreakValues(aVals);
+  const bTB = tieBreakValues(bVals);
+  for (let i = 0; i < aTB.length && i < bTB.length; i += 1) {
+    if (aTB[i] > bTB[i]) return 1;
+    if (aTB[i] < bTB[i]) return -1;
+  }
+  return 0;
+}
+
+/** Mirror of `cpMapThreeCardToFiveCardRank`. */
+function mapThreeCardToFiveCardRank(threeCardRank: number): number {
+  switch (threeCardRank) {
+    case THREE_HIGH_CARD:
+      return POKER_HIGH_CARD;
+    case THREE_PAIR:
+      return POKER_ONE_PAIR;
+    case THREE_FLUSH:
+      return POKER_TWO_PAIR;
+    case THREE_STRAIGHT:
+      return POKER_TWO_PAIR;
+    case THREE_OF_A_KIND:
+      return POKER_THREE_OF_A_KIND;
+    case THREE_STRAIGHT_FLUSH:
+      return POKER_STRAIGHT;
+    default:
+      return POKER_HIGH_CARD;
+  }
+}
+
+/** Mirror of `cpFrontNotStrongerThanMiddle`: true when front does NOT beat middle. */
+function frontNotStrongerThanMiddle(front: readonly Card[], middleRank: number, middle: readonly Card[]): boolean {
+  const cpFront = mapThreeCardToFiveCardRank(cpEvalThreeCardHand(front));
+  if (cpFront < middleRank) return true;
+  if (cpFront > middleRank) return false;
+  const frontVals = highValuesDesc(front);
+  const middleVals = highValuesDesc(middle);
+  for (let i = 0; i < frontVals.length && i < middleVals.length; i += 1) {
+    if (frontVals[i] > middleVals[i]) return false;
+    if (frontVals[i] < middleVals[i]) return true;
+  }
+  return true;
+}
+
+/**
+ * Returns `true` when the given arrangement is a foul (violates back >= middle >= front).
+ * Mirrors the server's `cpValidateHands` (negated). Rows of the wrong length are
+ * treated as non-foul (incomplete) so the warning only fires on a complete layout.
+ */
+export function chinesePokerIsFoul(front: readonly Card[], middle: readonly Card[], back: readonly Card[]): boolean {
+  if (front.length !== 3 || middle.length !== 5 || back.length !== 5) return false;
+
+  const middleRank = cpEvalFiveCardHand(middle);
+  const backRank = cpEvalFiveCardHand(back);
+
+  if (backRank < middleRank) return true;
+  if (backRank === middleRank && compareHighCardsSlice(back, middle) < 0) return true;
+
+  return !frontNotStrongerThanMiddle(front, middleRank, middle);
+}


### PR DESCRIPTION
## 概要

Chinese Poker の SET_HANDS フェーズで、配置が `back ≥ middle ≥ front` を満たさない（=ファウル）状態になったとき、Set ボタンを押す前にリアルタイム警告を表示します。これまではプレイヤーは Set 後に初めてファウル（全段敗北）を知る厳しい UX でした。

## 変更点

- `frontend/src/utils/chinesePokerFoul.ts` (新規): サーバの `cpValidateHands`（`internal/domain/ChinesePoker.go` + `hand_eval.go` + `HoldemPlayer.go`）を **1:1 で TS 移植**したファウル判定。3枚役の評価・5枚役の評価・ハイカードのタイブレーク・front→middle ランクマッピングまで忠実に再現し、サーバ結果と一致させてドリフトを防止。
- `frontend/src/pages/ChinesePokerPage.tsx`: フル配置（front 3 + middle 5 + back 5）が揃った時点でファウル判定し、プレビュー直下に `role="alert"` の警告を表示。**警告中も Set 自体は可能**（ルール上許容）。
- 翻訳キー `foulWarning` は ja/en に既に存在（本PRで初めて使用）。

## テスト

- `chinesePokerFoul.test.ts` (新規, 13 件): 5枚/3枚役評価 + カテゴリ違反 / タイブレーク違反 / front>middle / 未完成（非ファウル）の各ケース。
- `ChinesePokerPage.test.tsx`: フォール配置で警告表示・合法配置/未完成で非表示の 2 ケースを追加。

## 受け入れ条件

- [x] Set 可能時に各段の暫定役強度を評価する
- [x] 強度順序違反時にファウル警告を表示する
- [x] 警告表示中も Set 自体は可能
- [x] `foulWarning` 翻訳キーを ja/en に追加（既存・本PRで使用開始）

Closes #2637