### PR TITLE
feat(sevenbridge): implement working CLI mode

### DIFF
--- a/frontend/src/pages/SevenBridgePage.test.tsx
+++ b/frontend/src/pages/SevenBridgePage.test.tsx
@@ -114,4 +114,16 @@ describe('SevenBridgePage', () => {
     fireEvent.click(btn);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('drawstock'));
   });
+
+  it('executes a typed CLI command (no longer a no-op stub)', async () => {
+    localStorage.setItem('cli-mode-sevenbridge', 'true');
+    mockExec.mockResolvedValue(drawState);
+    renderWithProviders(<SevenBridgePage />);
+    const input = await screen.findByRole('textbox');
+    mockExec.mockClear();
+    fireEvent.change(input, { target: { value: 'd' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('drawstock'));
+    localStorage.removeItem('cli-mode-sevenbridge');
+  });
 });

--- a/frontend/src/pages/SevenBridgePage.tsx
+++ b/frontend/src/pages/SevenBridgePage.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import type { sevenBridgeApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
@@ -12,6 +13,7 @@ import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
+import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
@@ -21,9 +23,13 @@ import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
+import type { SevenBridgeResponse } from '../types/card';
 import { SevenBridgePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { parseSevenBridgeCommand, SEVENBRIDGE_HELP } from '../utils/cli/commands/sevenBridgeCommands';
+import { formatSevenBridgeState } from '../utils/cli/formatters/sevenBridgeFormatter';
+import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 
 const SEVENBRIDGE_PHASE_KEYS: Readonly<Record<number, string>> = {
@@ -91,7 +97,17 @@ function SevenBridgePageContent() {
   } = useGameHint('sevenbridge', state);
   const { cardWidth } = useCardDimensions();
   const { playSound } = useSound();
-  const { cliEnabled, toggleCli, logEntries } = useCliMode('sevenbridge');
+  const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('sevenbridge');
+  const cliConfig: CliGameConfig<SevenBridgeResponse, Parameters<typeof sevenBridgeApi.exec>> = useMemo(
+    () => ({
+      gameName: 'sevenbridge',
+      parseCommand: parseSevenBridgeCommand,
+      formatResponse: formatSevenBridgeState,
+      helpText: SEVENBRIDGE_HELP,
+    }),
+    [],
+  );
+  const { handleCommand } = useCliGame(callApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
   const phaseNames = usePhaseNames('sevenbridge', SEVENBRIDGE_PHASE_KEYS);
 
@@ -133,7 +149,7 @@ function SevenBridgePageContent() {
       headerExtra={<CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />}
     >
       {cliEnabled ? (
-        <CliTerminal logEntries={logEntries} onCommand={async () => undefined} disabled={loading} />
+        <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
         <>
           <SettingsPanel

--- a/frontend/src/utils/cli/commands/sevenBridgeCommands.test.ts
+++ b/frontend/src/utils/cli/commands/sevenBridgeCommands.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { parseSevenBridgeCommand, SEVENBRIDGE_HELP } from './sevenBridgeCommands';
+
+describe('parseSevenBridgeCommand', () => {
+  it('parses draw (d / draw)', () => {
+    expect(parseSevenBridgeCommand('d')).toEqual({ args: ['drawstock'] });
+    expect(parseSevenBridgeCommand('draw')).toEqual({ args: ['drawstock'] });
+  });
+
+  it('parses pon with hand indices', () => {
+    expect(parseSevenBridgeCommand('p 0 3')).toEqual({ args: ['pon', undefined, undefined, [0, 3]] });
+    expect(parseSevenBridgeCommand('pon 1 2 5')).toEqual({ args: ['pon', undefined, undefined, [1, 2, 5]] });
+  });
+
+  it('parses chi with hand indices', () => {
+    expect(parseSevenBridgeCommand('c 4 5')).toEqual({ args: ['chi', undefined, undefined, [4, 5]] });
+  });
+
+  it('parses meld with hand indices', () => {
+    expect(parseSevenBridgeCommand('m 0 1 2')).toEqual({ args: ['meld', undefined, undefined, [0, 1, 2]] });
+  });
+
+  it('parses discard (x / discard)', () => {
+    expect(parseSevenBridgeCommand('x 6')).toEqual({ args: ['discard', 6] });
+    expect(parseSevenBridgeCommand('discard 0')).toEqual({ args: ['discard', 0] });
+  });
+
+  it('parses layoff with hand/target/meld indices', () => {
+    expect(parseSevenBridgeCommand('lay 2 1 0')).toEqual({ args: ['layoff', 2, undefined, undefined, 1, 0] });
+  });
+
+  it('parses next round (n / nextround)', () => {
+    expect(parseSevenBridgeCommand('n')).toEqual({ args: ['nextround'] });
+    expect(parseSevenBridgeCommand('nextround')).toEqual({ args: ['nextround'] });
+  });
+
+  it('parses reset and log', () => {
+    expect(parseSevenBridgeCommand('r')).toEqual({ args: ['reset'] });
+    expect(parseSevenBridgeCommand('l')).toEqual({ args: ['log'] });
+  });
+
+  it('returns usage errors for malformed action args', () => {
+    expect(parseSevenBridgeCommand('p')).toEqual({ error: expect.stringContaining('Usage: p') });
+    expect(parseSevenBridgeCommand('x abc')).toEqual({ error: expect.stringContaining('Usage: x') });
+    expect(parseSevenBridgeCommand('lay 1 2')).toEqual({ error: expect.stringContaining('Usage: lay') });
+  });
+
+  it('suggests a close command for typos', () => {
+    const r = parseSevenBridgeCommand('drar');
+    expect(r).toHaveProperty('error');
+    if ('error' in r) expect(r.error).toMatch(/Did you mean: draw/);
+  });
+
+  it('rejects an unknown command', () => {
+    expect(parseSevenBridgeCommand('zzz')).toEqual({ error: 'Unknown command: zzz' });
+  });
+
+  it('exposes help text covering every action', () => {
+    expect(SEVENBRIDGE_HELP.length).toBeGreaterThan(0);
+    const joined = SEVENBRIDGE_HELP.join('\n');
+    for (const verb of ['Draw', 'Pon', 'Chi', 'Meld', 'Discard', 'Reset']) {
+      expect(joined).toContain(verb);
+    }
+  });
+});

--- a/frontend/src/utils/cli/commands/sevenBridgeCommands.ts
+++ b/frontend/src/utils/cli/commands/sevenBridgeCommands.ts
@@ -37,22 +37,25 @@ export function parseSevenBridgeCommand(input: string): CliParseResult<SevenBrid
     case 'p':
     case 'pon': {
       const idx = parseIntSlice(args);
-      if ('error' in idx) return { error: 'Usage: p <i...> (hand indices forming the pon)' };
-      if (idx.values.length === 0) return { error: 'Usage: p <i...> (hand indices forming the pon)' };
+      if ('error' in idx || idx.values.length === 0) {
+        return { error: 'Usage: p <i...> (hand indices forming the pon)' };
+      }
       return { args: ['pon', undefined, undefined, idx.values] };
     }
     case 'c':
     case 'chi': {
       const idx = parseIntSlice(args);
-      if ('error' in idx) return { error: 'Usage: c <i...> (hand indices forming the chi)' };
-      if (idx.values.length === 0) return { error: 'Usage: c <i...> (hand indices forming the chi)' };
+      if ('error' in idx || idx.values.length === 0) {
+        return { error: 'Usage: c <i...> (hand indices forming the chi)' };
+      }
       return { args: ['chi', undefined, undefined, idx.values] };
     }
     case 'm':
     case 'meld': {
       const idx = parseIntSlice(args);
-      if ('error' in idx) return { error: 'Usage: m <i...> (hand indices forming the meld)' };
-      if (idx.values.length === 0) return { error: 'Usage: m <i...> (hand indices forming the meld)' };
+      if ('error' in idx || idx.values.length === 0) {
+        return { error: 'Usage: m <i...> (hand indices forming the meld)' };
+      }
       return { args: ['meld', undefined, undefined, idx.values] };
     }
     case 'x':
@@ -99,5 +102,5 @@ export const SEVENBRIDGE_HELP: string[] = [
   'x <i>                   - Discard hand card i',
   'n                       - Next round',
   'r                       - Reset / new game',
-  'l                       - Action log',
+  'l / log                 - Action log',
 ];

--- a/frontend/src/utils/cli/commands/sevenBridgeCommands.ts
+++ b/frontend/src/utils/cli/commands/sevenBridgeCommands.ts
@@ -1,0 +1,103 @@
+import type { sevenBridgeApi } from '../../../api/gameApi';
+import { parseIntArg, parseIntSlice, splitCommand, suggestCommand } from '../commandParserBase';
+import type { CliParseResult } from '../types';
+
+type SevenBridgeArgs = Parameters<typeof sevenBridgeApi.exec>;
+
+const VALID_COMMANDS = [
+  'd',
+  'draw',
+  'p',
+  'pon',
+  'c',
+  'chi',
+  'm',
+  'meld',
+  'lay',
+  'layoff',
+  'x',
+  'discard',
+  'n',
+  'next',
+  'nextround',
+  'r',
+  'reset',
+  'log',
+  'l',
+];
+
+/** Parse a CLI input string into Seven Bridge API arguments. */
+export function parseSevenBridgeCommand(input: string): CliParseResult<SevenBridgeArgs> {
+  const { cmd, args } = splitCommand(input);
+
+  switch (cmd) {
+    case 'd':
+    case 'draw':
+      return { args: ['drawstock'] };
+    case 'p':
+    case 'pon': {
+      const idx = parseIntSlice(args);
+      if ('error' in idx) return { error: 'Usage: p <i...> (hand indices forming the pon)' };
+      if (idx.values.length === 0) return { error: 'Usage: p <i...> (hand indices forming the pon)' };
+      return { args: ['pon', undefined, undefined, idx.values] };
+    }
+    case 'c':
+    case 'chi': {
+      const idx = parseIntSlice(args);
+      if ('error' in idx) return { error: 'Usage: c <i...> (hand indices forming the chi)' };
+      if (idx.values.length === 0) return { error: 'Usage: c <i...> (hand indices forming the chi)' };
+      return { args: ['chi', undefined, undefined, idx.values] };
+    }
+    case 'm':
+    case 'meld': {
+      const idx = parseIntSlice(args);
+      if ('error' in idx) return { error: 'Usage: m <i...> (hand indices forming the meld)' };
+      if (idx.values.length === 0) return { error: 'Usage: m <i...> (hand indices forming the meld)' };
+      return { args: ['meld', undefined, undefined, idx.values] };
+    }
+    case 'x':
+    case 'discard': {
+      const card = parseIntArg(args, 0);
+      if ('error' in card) return { error: 'Usage: x <i> (hand index to discard)' };
+      return { args: ['discard', card.value] };
+    }
+    case 'lay':
+    case 'layoff': {
+      const card = parseIntArg(args, 0);
+      const target = parseIntArg(args, 1);
+      const meld = parseIntArg(args, 2);
+      if ('error' in card || 'error' in target || 'error' in meld) {
+        return { error: 'Usage: lay <handIdx> <targetPlayer> <meldIdx>' };
+      }
+      return { args: ['layoff', card.value, undefined, undefined, target.value, meld.value] };
+    }
+    case 'n':
+    case 'next':
+    case 'nextround':
+      return { args: ['nextround'] };
+    case 'log':
+    case 'l':
+      return { args: ['log'] };
+    case 'r':
+    case 'reset':
+      return { args: ['reset'] };
+    default: {
+      const suggestion = suggestCommand(cmd, VALID_COMMANDS);
+      if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
+      return { error: `Unknown command: ${cmd}` };
+    }
+  }
+}
+
+/** Help text for Seven Bridge CLI mode. */
+export const SEVENBRIDGE_HELP: string[] = [
+  'd                       - Draw a card from the stock',
+  'p <i...>                - Pon (claim discard with two matching hand cards)',
+  'c <i...>                - Chi (claim discard to complete a run)',
+  'm <i...>                - Meld a set/run from your hand',
+  'lay <i> <pl> <meld>     - Lay off hand card i onto player pl meld',
+  'x <i>                   - Discard hand card i',
+  'n                       - Next round',
+  'r                       - Reset / new game',
+  'l                       - Action log',
+];

--- a/frontend/src/utils/cli/formatters/sevenBridgeFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/sevenBridgeFormatter.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, SevenBridgeResponse } from '../../../types/card';
+import { formatSevenBridgeState } from './sevenBridgeFormatter';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+const baseState: SevenBridgeResponse = {
+  players: [
+    {
+      id: 0,
+      isHuman: true,
+      cardCount: 3,
+      cards: [card('SPADE', 5), card('HEART', 13), card('CLOVER', 1)],
+      melds: [{ cards: [card('DIAMOND', 7), card('DIAMOND', 8), card('DIAMOND', 9)] }],
+      roundScore: 0,
+      cumulativeScore: 10,
+    },
+    {
+      id: 1,
+      isHuman: false,
+      cardCount: 5,
+      cards: [],
+      melds: [],
+      roundScore: 0,
+      cumulativeScore: 20,
+    },
+  ],
+  phase: 1,
+  roundNumber: 2,
+  currentPlayerIdx: 0,
+  discardTop: card('HEART', 10),
+  drawPileCount: 40,
+  gameEndFlag: false,
+  winnerIdx: -1,
+  roundWinnerIdx: -1,
+  config: { cpuDifficulty: 1, pointLimit: 100 },
+  message: '',
+};
+
+describe('formatSevenBridgeState', () => {
+  it('renders the header, round/phase, stock and discard', () => {
+    const out = formatSevenBridgeState(baseState);
+    expect(out).toContain('Seven Bridge');
+    expect(out).toContain('round: 2');
+    expect(out).toContain('phase: PLAY');
+    expect(out).toContain('stock: 40');
+    expect(out).toContain('discard: ♥10');
+  });
+
+  it('shows the human hand with indices and laid melds', () => {
+    const out = formatSevenBridgeState(baseState);
+    expect(out).toContain('[0]♠5');
+    expect(out).toContain('meld[0]:');
+    expect(out).toContain('cards=5'); // CPU hand count shown without revealing cards
+  });
+
+  it('shows the current turn while the game is running', () => {
+    expect(formatSevenBridgeState(baseState)).toContain('turn:');
+  });
+
+  it('renders an empty discard slot when none is present', () => {
+    expect(formatSevenBridgeState({ ...baseState, discardTop: null })).toContain('discard: [  ]');
+  });
+
+  it('announces the winner at game end', () => {
+    const out = formatSevenBridgeState({ ...baseState, gameEndFlag: true, winnerIdx: 1 });
+    expect(out).toContain('Game Over! Winner:');
+    expect(out).not.toContain('turn:');
+  });
+});

--- a/frontend/src/utils/cli/formatters/sevenBridgeFormatter.ts
+++ b/frontend/src/utils/cli/formatters/sevenBridgeFormatter.ts
@@ -1,0 +1,52 @@
+import type { SevenBridgeResponse } from '../../../types/card';
+import {
+  formatCard,
+  formatCardList,
+  formatHeader,
+  formatIndexedCards,
+  formatPlayerName,
+  formatSeparator,
+} from '../formatterBase';
+
+const PHASE_NAMES: Record<number, string> = {
+  0: 'DRAW',
+  1: 'PLAY',
+  2: 'ROUND END',
+  3: 'GAME END',
+};
+
+/** Format a Seven Bridge game state as terminal text. */
+export function formatSevenBridgeState(state: SevenBridgeResponse): string {
+  const lines: string[] = [];
+
+  lines.push(formatHeader('Seven Bridge'));
+  lines.push(`round: ${state.roundNumber}  phase: ${PHASE_NAMES[state.phase] ?? 'UNKNOWN'}`);
+  lines.push(`stock: ${state.drawPileCount} | discard: ${state.discardTop ? formatCard(state.discardTop) : '[  ]'}`);
+  lines.push('');
+
+  for (const p of state.players) {
+    const name = formatPlayerName(p.id, p.isHuman);
+    lines.push(`${name}: total=${p.cumulativeScore} round=${p.roundScore} cards=${p.cardCount}`);
+    if (p.isHuman && p.cards.length > 0) {
+      lines.push(`  ${formatIndexedCards(p.cards)}`);
+    }
+    p.melds.forEach((m, i) => {
+      lines.push(`  meld[${i}]: ${formatCardList(m.cards)}`);
+    });
+  }
+  lines.push('----------');
+
+  if (!state.gameEndFlag) {
+    const current = formatPlayerName(state.currentPlayerIdx, state.players[state.currentPlayerIdx]?.isHuman ?? false);
+    lines.push(`turn: ${current}`);
+  }
+
+  if (state.message) lines.push(state.message);
+  if (state.gameEndFlag) {
+    const winner = formatPlayerName(state.winnerIdx, state.players[state.winnerIdx]?.isHuman ?? false);
+    lines.push(`Game Over! Winner: ${winner}`);
+  }
+
+  lines.push(formatSeparator());
+  return lines.join('\n');
+}


### PR DESCRIPTION
## 概要

セブンブリッジの CLI モードはトグルとターミナルを表示するものの `onCommand={async () => undefined}` の空スタブで、コマンドを入力しても何も起きない見せかけの状態でした。他ゲームと同様に CLI を正しく配線し、全アクションを CLI から実行できるようにします。

## 変更点

- `frontend/src/utils/cli/commands/sevenBridgeCommands.ts` (新規): `draw`/`pon`/`chi`/`meld`/`layoff`/`discard`/`nextround`/`reset`/`log` のパーサ（エイリアス + 近似コマンド提案 + ヘルプ）。返す引数は `Parameters<typeof sevenBridgeApi.exec>` に一致。
- `frontend/src/utils/cli/formatters/sevenBridgeFormatter.ts` (新規): 手札（インデックス付き）・捨て札・各プレイヤーのメルド・スコア・手番・勝者を表示。
- `SevenBridgePage.tsx`: `useCliMode` のログコールバック + `useCliGame` を配線し、`CliTerminal` に `handleCommand` を渡す（スタブ撤去）。ゲームフックの `callApi` を exec として利用。

実装方針: issue の2案（実装 or トグル撤去）のうち**実装**を選択。前回の撤去PR (#2845) はJSXの大幅な再インデントchurnでクローズされたため、churnの無い実装側で対応。

## テスト

- `sevenBridgeCommands.test.ts` (新規): 全コマンド・エイリアス・用法エラー・タイポ提案・ヘルプ網羅。
- `sevenBridgeFormatter.test.ts` (新規): ヘッダ/ラウンド/山札/捨て札/手札インデックス/メルド/手番/勝者/空捨て札スロット。
- `SevenBridgePage.test.tsx`: CLIで `d` を入力 → `drawstock` が実行されることを検証（スタブでない証明）。

## 受け入れ条件

- [x] CLIで全アクションが実行できる
- [x] パーサ/フォーマッタに単体テストを追加
- [x] ヘルプテキストを表示

Closes #2598