### PR TITLE
fix(mighty): nil-pointer panic in CpuPlay with an empty hand

### DIFF
--- a/internal/domain/Mighty.go
+++ b/internal/domain/Mighty.go
@@ -1011,11 +1011,6 @@ func (m *Mighty) startPlayPhase() {
 
 // playCard カードをプレイする共通処理
 func (m *Mighty) playCard(playerIdx int, card *Card, isJokerLead bool, demandSuit int) {
-	// Defense in depth: a nil card (e.g. RemoveCard on an out-of-range/empty index)
-	// must never reach card.GetDesign() below and panic the HTTP handler (issue #2527).
-	if card == nil {
-		return
-	}
 	m.round.currentTrick = append(m.round.currentTrick, &MightyTrickCard{
 		PlayerIdx:      playerIdx,
 		Card:           card,

--- a/internal/domain/Mighty.go
+++ b/internal/domain/Mighty.go
@@ -427,6 +427,15 @@ func (m *Mighty) CpuPlay() {
 
 	player := m.players[m.round.currentPlayerIdx]
 
+	// Safety net: never ask an empty-handed player to play. If we somehow reach
+	// the play phase with no cards (a hand-desync bug), end the round instead of
+	// dereferencing a nil card. RoundEnd is a terminal phase for the CPU loop, so
+	// this also avoids an infinite no-op loop (issue #2527).
+	if player.GetCardsSize() == 0 {
+		m.round.phase = MightyPhaseRoundEnd
+		return
+	}
+
 	// ジョーカーリードの判断: リード時かつジョーカー所有時のみ検討
 	if len(m.round.currentTrick) == 0 {
 		jokerIdx := m.findJokerIndex(player)
@@ -470,7 +479,11 @@ func (m *Mighty) ResolveTrick() {
 
 	m.round.leadPlayerIdx = winnerIdx
 
-	if m.round.trickNumber >= MightyTricksPerRound {
+	// The winner leads the next trick; if their hand is empty the round is over.
+	// Guarding on an empty hand (not just the trick cap) prevents NextTrick from
+	// re-entering the play phase with an empty-handed leader, which would make
+	// CpuPlay try to play a card it does not have (issue #2527).
+	if m.round.trickNumber >= MightyTricksPerRound || m.players[winnerIdx].GetCardsSize() == 0 {
 		m.round.phase = MightyPhaseRoundEnd
 	} else {
 		m.round.phase = MightyPhaseTrickEnd
@@ -998,6 +1011,11 @@ func (m *Mighty) startPlayPhase() {
 
 // playCard カードをプレイする共通処理
 func (m *Mighty) playCard(playerIdx int, card *Card, isJokerLead bool, demandSuit int) {
+	// Defense in depth: a nil card (e.g. RemoveCard on an out-of-range/empty index)
+	// must never reach card.GetDesign() below and panic the HTTP handler (issue #2527).
+	if card == nil {
+		return
+	}
 	m.round.currentTrick = append(m.round.currentTrick, &MightyTrickCard{
 		PlayerIdx:      playerIdx,
 		Card:           card,

--- a/internal/domain/Mighty_test.go
+++ b/internal/domain/Mighty_test.go
@@ -1473,3 +1473,33 @@ func TestMighty_TrickCard_JSONRoundTrip(t *testing.T) {
 	assert.Equal(t, tc.Card.GetDesign(), out.Card.GetDesign())
 	assert.Equal(t, tc.Card.GetValue(), out.Card.GetValue())
 }
+
+// --- issue #2527: empty-hand nil-panic in CpuPlay ---
+
+func TestMighty_CpuPlayDoesNotPanicOnEmptyHand(t *testing.T) {
+	m := newTestMighty()
+	m.SetPhase(domain.MightyPhasePlay)
+	m.SetCurrentPlayerIdx(1) // a CPU whose hand is empty (no cards dealt)
+	require.NotPanics(t, func() { m.CpuPlay() })
+	// The invalid empty-hand-in-play state is converted to RoundEnd, which is a
+	// terminal phase for the CPU loop (no panic, no infinite no-op loop).
+	assert.Equal(t, domain.MightyPhaseRoundEnd, m.GetPhase())
+}
+
+func TestMighty_ResolveTrickEndsRoundWhenWinnerOutOfCards(t *testing.T) {
+	m := newTestMighty()
+	m.SetTrumpSuit(domain.CardDesignSpade)
+	m.SetPhase(domain.MightyPhaseTrickEnd)
+	m.SetTrickNumber(3) // well before the 10-trick cap
+	// A complete 5-card trick while every hand is already empty.
+	m.SetCurrentTrick([]*domain.MightyTrickCard{
+		{PlayerIdx: 0, Card: mightyCard(domain.CardDesignSpade, 5)},
+		{PlayerIdx: 1, Card: mightyCard(domain.CardDesignSpade, 9)},
+		{PlayerIdx: 2, Card: mightyCard(domain.CardDesignHeart, 3)},
+		{PlayerIdx: 3, Card: mightyCard(domain.CardDesignClover, 7)},
+		{PlayerIdx: 4, Card: mightyCard(domain.CardDesignDiamond, 2)},
+	})
+	m.ResolveTrick()
+	// Winner is out of cards, so the round ends instead of starting another trick.
+	assert.Equal(t, domain.MightyPhaseRoundEnd, m.GetPhase())
+}


### PR DESCRIPTION
## 概要

マイティで CPU プレイ中に nil ポインタ参照でサーバが HTTP 500 (`http: panic serving`) を起こす潜在バグ (#2527) を修正します。手札枚数のずれにより、プレイフェーズ中に手札が空のプレイヤーへ手番が回ると `CpuPlay` が `RemoveCard` で範囲外インデックスを引いて nil カードを取得し、`playCard` の `card.GetDesign()` で panic していました。

## 根本原因

`cpuSelectPlayCard` は手札が空でも index 0 を返し、`RemoveCard(0)` が nil を返し、`playCard` が無防備に `card.GetDesign()` を参照していました (`Mighty.go:1019`)。通常は全員10枚で10トリック後に `trickNumber>=10` で RoundEnd になりますが、手札がずれて早期に空になるとこの不変条件が崩れ、`ResolveTrick → TrickEnd → NextTrick → Play` で空手札のリーダーに手番が回ってしまいます。

## 修正 (多層防御)

1. **`ResolveTrick`**: トリック勝者 (=次リーダー) の手札が空ならラウンド終了にする。`NextTrick` が空手札でプレイフェーズへ戻るのを防ぐ。
2. **`CpuPlay`**: 手番プレイヤーの手札が空なら、カードを出さず RoundEnd へ遷移。RoundEnd は CPU ループの終端なので panic も無限 no-op ループも起きない。
3. **`playCard`**: nil カードを受け取ったら早期 return。範囲外インデックス由来の nil が二度とハンドラを panic させない。

## テスト

- `TestMighty_CpuPlayDoesNotPanicOnEmptyHand`: 空手札の CPU に手番がある状態で `CpuPlay` が panic せず RoundEnd になることを検証。
- `TestMighty_ResolveTrickEndsRoundWhenWinnerOutOfCards`: トリック上限前でも勝者が手札切れなら RoundEnd になることを検証。
- Go 変更のため Backend Tests/Lint (CI) が権威。

## 受け入れ条件

- [x] 空手札のプレイヤーにプレイを要求しない (CpuPlay ガード)
- [x] `playCard` を nil カードに対して防御的にする
- [x] 決定的な回帰テストを追加

Closes #2527