### PR TITLE
fix(catchten): stop double-resolving CPU-completed tricks

### DIFF
--- a/internal/domain/CatchTen.go
+++ b/internal/domain/CatchTen.go
@@ -253,10 +253,7 @@ func (g *CatchTen) ResolveTrick() {
 	g.leadPlayerIdx = winnerIdx
 
 	if g.trickNumber >= CatchTenHandSize {
-		// Last trick of the deal — tally the round (and the game-end check)
-		// now so the round-end score screen reflects the final scores.
 		g.phase = CatchTenPhaseRoundEnd
-		g.ScoreRound()
 	} else {
 		g.phase = CatchTenPhaseTrickEnd
 	}
@@ -451,10 +448,7 @@ func (g *CatchTen) playCard(playerIdx int, card *Card) {
 	g.appendLog(playerIdx, "play", fmt.Sprintf("%s plays %s", g.playerName(playerIdx), cardStr(card)), []*Card{card})
 
 	if len(g.currentTrick) == CatchTenPlayerCnt {
-		// The trick is full — resolve it immediately so it is scored
-		// regardless of whether a human or a CPU played the last card.
 		g.phase = CatchTenPhaseTrickEnd
-		g.ResolveTrick()
 	} else {
 		g.currentPlayerIdx = (g.currentPlayerIdx + 1) % CatchTenPlayerCnt
 	}

--- a/internal/domain/CatchTen_test.go
+++ b/internal/domain/CatchTen_test.go
@@ -302,6 +302,39 @@ func TestCatchTen_ResolveTrick_LastTrick(t *testing.T) {
 	assert.Equal(t, domain.CatchTenPhaseRoundEnd, g.GetPhase())
 }
 
+// TestCatchTen_PlayCardDoesNotAutoResolve is a regression test: playCard must
+// NOT resolve a full trick by itself. The caller resolves it exactly once (the
+// interactor's human path, or the runCpuTurns loop after a CPU play). If
+// playCard auto-resolved, a CPU completing a trick inside the loop — which then
+// also calls ResolveTrick — would double the winner's trick and honour counts.
+func TestCatchTen_PlayCardDoesNotAutoResolve(t *testing.T) {
+	g := newTestCatchTen()
+	g.Reset()
+	g.SetTrumpSuit(domain.CardDesignSpade)
+	setupCatchTenPlayPhase(g, 3, 0, 1) // seat 3 (a CPU) plays the 4th card
+	g.SetCurrentTrick([]*domain.CatchTenTrickCard{
+		{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignHeart, 7, false)},
+		{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignHeart, 13, false)},
+		{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 9, false)},
+	})
+
+	g.CpuPlay() // CPU at seat 3 completes the trick
+
+	assert.Equal(t, domain.CatchTenPhaseTrickEnd, g.GetPhase())
+	tricksBefore := 0
+	for i := 0; i < domain.CatchTenPlayerCnt; i++ {
+		tricksBefore += g.GetPlayer(i).GetTrickCount()
+	}
+	assert.Equal(t, 0, tricksBefore, "playCard must not resolve the trick itself")
+
+	g.ResolveTrick()
+	tricksAfter := 0
+	for i := 0; i < domain.CatchTenPlayerCnt; i++ {
+		tricksAfter += g.GetPlayer(i).GetTrickCount()
+	}
+	assert.Equal(t, 1, tricksAfter, "exactly one trick should be awarded after a single ResolveTrick")
+}
+
 func TestCatchTen_NextTrick(t *testing.T) {
 	g := newTestCatchTen()
 	g.Reset()
@@ -633,9 +666,8 @@ func TestCatchTen_FullGame_AllDifficulties(t *testing.T) {
 			g.Reset()
 
 			for round := 0; round < 50 && !g.GetGameEndFlag(); round++ {
-				// playCatchTenRound drives the deal to RoundEnd; the domain
-				// scores the round automatically when the last trick resolves.
-				playCatchTenRound(t, g)
+				playCatchTenRound(t, g) // drives the deal to RoundEnd
+				g.ScoreRound()
 				if g.GetGameEndFlag() {
 					break
 				}
@@ -665,6 +697,7 @@ func playCatchTenRound(t *testing.T, g *domain.CatchTen) {
 				g.CpuPlay()
 			}
 		case domain.CatchTenPhaseTrickEnd:
+			g.ResolveTrick()
 			g.NextTrick()
 		default: // RoundEnd or GameEnd
 			return

--- a/internal/usecase/CatchTenInteractor.go
+++ b/internal/usecase/CatchTenInteractor.go
@@ -61,8 +61,11 @@ func (ci *CatchTenInteractor) Play(cardIndex int) string {
 	if err != nil {
 		return ci.cp.Output(ci.Game, err)
 	}
-	// Trick/round resolution is handled automatically in the domain when the
-	// trick becomes full (works whether a human or a CPU played the last card).
+	// If the human played the last card of the trick, resolve it here; when a
+	// CPU plays the last card the trick is resolved inside runCpuTurns' loop.
+	if ci.Game.GetPhase() == domain.CatchTenPhaseTrickEnd {
+		ci.Game.ResolveTrick()
+	}
 	ci.runCpuTurns()
 	return ci.cp.Output(ci.Game, nil)
 }
@@ -76,6 +79,7 @@ func (ci *CatchTenInteractor) NextTrick() string {
 
 // NextRound 次のラウンドへ進む (ラウンドのスコアリングはトリック解決時に自動実行済み)
 func (ci *CatchTenInteractor) NextRound() string {
+	ci.Game.ScoreRound()
 	if out, blocked := guardGameEnd(ci.Game, ci.cp); blocked {
 		return out
 	}

--- a/internal/usecase/CatchTenInteractor_test.go
+++ b/internal/usecase/CatchTenInteractor_test.go
@@ -116,9 +116,9 @@ func TestCatchTenInteractor_Play(t *testing.T) {
 		gameMock.AssertNotCalled(t, "PlayerPlay")
 	})
 
-	t.Run("trick resolution handled by domain", func(t *testing.T) {
-		// When a trick completes the domain resolves it inside playCard, so
-		// the interactor must NOT call ResolveTrick itself.
+	t.Run("human completes trick resolves it", func(t *testing.T) {
+		// When the human plays the last card of a trick, the interactor
+		// resolves it (a CPU-completed trick is resolved in runCpuTurns).
 		cpMock := new(presenter.MockCatchTenPresenter)
 		cpMock.On("Output", mock.Anything, mock.Anything).Return(mockOutput)
 		gameMock := new(interfaces.MockCatchTenGame)
@@ -126,10 +126,11 @@ func TestCatchTenInteractor_Play(t *testing.T) {
 		gameMock.On("IsHumanTurn").Return(true)
 		gameMock.On("PlayerPlay", 1).Return(nil)
 		gameMock.On("GetPhase").Return(domain.CatchTenPhaseTrickEnd)
+		gameMock.On("ResolveTrick").Return()
 
 		ci := usecase.NewCatchTenInteractor(gameMock, cpMock)
 		assert.Equal(t, mockOutput, ci.Play(1))
-		gameMock.AssertNotCalled(t, "ResolveTrick")
+		gameMock.AssertCalled(t, "ResolveTrick")
 	})
 }
 
@@ -151,12 +152,11 @@ func TestCatchTenInteractor_NextTrick(t *testing.T) {
 func TestCatchTenInteractor_NextRound(t *testing.T) {
 	mockOutput := `{"phase":0}`
 
-	t.Run("starts next round", func(t *testing.T) {
-		// The round is already scored by the domain when the last trick
-		// resolved, so NextRound only advances the deal.
+	t.Run("scores round then starts next", func(t *testing.T) {
 		cpMock := new(presenter.MockCatchTenPresenter)
 		cpMock.On("Output", mock.Anything, mock.Anything).Return(mockOutput)
 		gameMock := new(interfaces.MockCatchTenGame)
+		gameMock.On("ScoreRound").Return()
 		gameMock.On("GetGameEndFlag").Return(false)
 		gameMock.On("NextRound").Return()
 		gameMock.On("GetPhase").Return(domain.CatchTenPhasePlay)
@@ -164,20 +164,20 @@ func TestCatchTenInteractor_NextRound(t *testing.T) {
 
 		ci := usecase.NewCatchTenInteractor(gameMock, cpMock)
 		assert.Equal(t, mockOutput, ci.NextRound())
+		gameMock.AssertCalled(t, "ScoreRound")
 		gameMock.AssertCalled(t, "NextRound")
-		gameMock.AssertNotCalled(t, "ScoreRound")
 	})
 
-	t.Run("game ended guard blocks next round", func(t *testing.T) {
+	t.Run("game ended after scoring", func(t *testing.T) {
 		cpMock := new(presenter.MockCatchTenPresenter)
 		cpMock.On("Output", mock.Anything, mock.Anything).Return("game ended")
 		gameMock := new(interfaces.MockCatchTenGame)
+		gameMock.On("ScoreRound").Return()
 		gameMock.On("GetGameEndFlag").Return(true)
 
 		ci := usecase.NewCatchTenInteractor(gameMock, cpMock)
 		assert.Equal(t, "game ended", ci.NextRound())
 		gameMock.AssertNotCalled(t, "NextRound")
-		gameMock.AssertNotCalled(t, "ScoreRound")
 	})
 }
 


### PR DESCRIPTION
## Problem

PR #2927 (Catch the Ten) moved trick resolution into `CatchTen.playCard` — calling `ResolveTrick()` as soon as the trick fills — based on a Gemini review comment claiming that a CPU playing the last card of a trick would otherwise never be resolved.

**That premise was incorrect.** The shared `runCpuTurnsLoop` (used by every trick game, including ohhell/whist) *already* calls `ResolveTrick()` after each `CpuPlay`. So a CPU-completed trick was resolved **twice** — once inside `playCard`, then again in the loop (the trick stays full until `NextTrick`, so the guard didn't stop the second call). This **double-counted the winner's tricks and honour points**, and double-ran the final deal's `ScoreRound`.

The existing tests missed it because the domain play-through helper drives tricks directly, not through the interactor's CPU loop where the second resolve happens. Web/E2E don't assert exact scores, so it slipped through.

## Fix

Revert to the established pattern (ohhell / whist):
- `playCard` only marks the trick complete (`phase = TrickEnd`).
- The **caller** resolves exactly once — the interactor's human path in `Play()`, and `runCpuTurnsLoop` for CPU plays.
- The round is scored in `NextRound()` (as before #2927).

## Regression test

`TestCatchTen_PlayCardDoesNotAutoResolve` fills a trick with a **CPU** play and asserts no trick is awarded until a single `ResolveTrick` runs — directly guarding against re-introducing the auto-resolve.

## Verification
- [x] Domain (incl. new regression test), usecase, presenter, controller tests pass
- [x] `golangci-lint` 0 issues (domain, usecase); `goimports` clean