### PR TITLE
feat(bigtwo): localize CUI CPU names via cuiPlayerName

### DIFF
--- a/internal/adapter/presenter/BigTwoCuiPresenter.go
+++ b/internal/adapter/presenter/BigTwoCuiPresenter.go
@@ -48,12 +48,7 @@ func (p *BigTwoCuiPresenter) Output(bg interfaces.BigTwoGame, lastErr error) str
 			for i := 0; i < bg.GetPlayerCnt(); i++ {
 				player := bg.GetPlayer(i)
 				if player.GetRank() >= 1 {
-					var name string
-					if player.GetIsHuman() {
-						name = i18n.T("bigtwo.playerYou")
-					} else {
-						name = fmt.Sprintf("CPU %d", i)
-					}
+					name := cuiPlayerName(player, i)
 					fmt.Fprintf(b, "  %s: %s\n", name, i18n.Tf("bigtwo.rankN", "rank", strconv.Itoa(player.GetRank())))
 				}
 			}
@@ -65,7 +60,7 @@ func (p *BigTwoCuiPresenter) Output(bg interfaces.BigTwoGame, lastErr error) str
 				} else {
 					actionStr = cuiCardSliceStr(action.PlayedCards)
 				}
-				fmt.Fprintf(b, "CPU %d: %s\n", action.PlayerIdx, actionStr)
+				fmt.Fprintf(b, "%s: %s\n", cuiPlayerName(bg.GetPlayer(action.PlayerIdx), action.PlayerIdx), actionStr)
 			}
 			if bg.IsHumanTurn() {
 				b.WriteString(i18n.T("bigtwo.yourTurn") + "\n")

--- a/internal/adapter/presenter/BigTwoCuiPresenter_test.go
+++ b/internal/adapter/presenter/BigTwoCuiPresenter_test.go
@@ -1,0 +1,88 @@
+//go:build test
+
+package presenter_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+)
+
+func makeBigTwoPlayers() []*domain.BigTwoPlayer {
+	return []*domain.BigTwoPlayer{
+		domain.NewBigTwoPlayer(true),
+		domain.NewBigTwoPlayer(false),
+		domain.NewBigTwoPlayer(false),
+		domain.NewBigTwoPlayer(false),
+	}
+}
+
+func setupBigTwoCuiMock() (*interfaces.MockBigTwoGame, []*domain.BigTwoPlayer) {
+	m := new(interfaces.MockBigTwoGame)
+	players := makeBigTwoPlayers()
+	m.On("GetGameEndFlag").Return(false)
+	m.On("GetTableCards").Return(([]*domain.Card)(nil))
+	m.On("GetCpuActions").Return(([]*domain.BigTwoAction)(nil))
+	m.On("IsHumanTurn").Return(true)
+	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	m.On("GetPlayerCnt").Return(4)
+	for i := 0; i < 4; i++ {
+		m.On("GetPlayer", i).Return(players[i])
+	}
+	return m, players
+}
+
+func TestBigTwoCuiPresenter_Output(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+	p := new(presenter.BigTwoCuiPresenter)
+
+	t.Run("initial empty table shows title and human turn", func(t *testing.T) {
+		m, players := setupBigTwoCuiMock()
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 3, false))
+
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "Big Two")
+		assert.Contains(t, result, "自由に出せます")
+		assert.Contains(t, result, "あなたのターン")
+	})
+
+	t.Run("cpu action line uses localized CPU name, not hardcoded", func(t *testing.T) {
+		m, _ := setupBigTwoCuiMock()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCpuActions")
+		m.On("GetCpuActions").Return([]*domain.BigTwoAction{
+			{PlayerIdx: 1, PlayedCards: nil},
+			{PlayerIdx: 2, PlayedCards: []*domain.Card{domain.NewCard(domain.CardDesignHeart, 4, false)}},
+		})
+		result := p.Output(m, nil)
+		// cuiPlayerName renders "CPU 1"/"CPU 2" via the shared cuiPlayerCpu key.
+		assert.Contains(t, result, "CPU 1")
+		assert.Contains(t, result, "CPU 2")
+	})
+
+	t.Run("game ended rankings use localized player names", func(t *testing.T) {
+		m, players := setupBigTwoCuiMock()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetGameEndFlag")
+		m.On("GetGameEndFlag").Return(true)
+		players[0].SetRank(1)
+		players[1].SetRank(2)
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "ゲーム終了")
+		// Human -> "あなた", CPU -> "CPU 1" (both via cuiPlayerName).
+		assert.Contains(t, result, "あなた")
+		assert.Contains(t, result, "CPU 1")
+		assert.Contains(t, result, "1位")
+	})
+
+	t.Run("error is shown", func(t *testing.T) {
+		m, _ := setupBigTwoCuiMock()
+		assert.Contains(t, p.Output(m, errors.New("invalid play")), "invalid play")
+	})
+}

--- a/internal/i18n/locales/en/bigtwo.json
+++ b/internal/i18n/locales/en/bigtwo.json
@@ -8,7 +8,6 @@
   "tableEmpty": "Table: empty (free lead)",
   "gameEnd": "Game Over!",
   "rankN": "Rank {{rank}}",
-  "playerYou": "You",
   "yourTurn": "Your turn",
   "actionPass": "pass"
 }

--- a/internal/i18n/locales/ja/bigtwo.json
+++ b/internal/i18n/locales/ja/bigtwo.json
@@ -8,7 +8,6 @@
   "tableEmpty": "場: なし (自由に出せます)",
   "gameEnd": "ゲーム終了！",
   "rankN": "{{rank}}位",
-  "playerYou": "あなた",
   "yourTurn": "あなたのターンです",
   "actionPass": "パス"
 }


### PR DESCRIPTION
## 概要
`BigTwoCuiPresenter` はゲーム終了時の順位表示とCPUアクション行で `fmt.Sprintf("CPU %d", ...)` とCPU名を英語ハードコードしており、日本語ロケールでも他ゲームと表記が混在していた。両箇所を共通ヘルパー `cuiPlayerName` 経由に統一し、ロケール対応した名前（`あなた` / `CPU N`）を出力するようにした。

## 変更点
- `BigTwoCuiPresenter.go`: 終了時順位表示とCPUアクション行を `cuiPlayerName(bg.GetPlayer(idx), idx)` に置き換え
- 未使用になった `bigtwo.playerYou` キーを ja/en 双方から削除（デッドコード整理、キー parity 維持）
- `BigTwoCuiPresenter_test.go` を新規追加（従来テスト無し）: 順位表示・CPUアクション行がローカライズされたCPU名になることを検証

## スコープ外
`BigTwoWebPresenter.buildResultMessage` も `CPU %d` を持つが、これは frontend が `MessageCode`/`MessageParams` 経由で描画するサーバー側フォールバック文字列であり、`cuiPlayerName`（ANSI装飾を含む）を注入するとJSONが壊れるため対象外とした。Web結果メッセージのi18nは別issueで扱うのが適切。

## テスト計画
- [x] `go test -tags test ./internal/adapter/presenter/ -run TestBigTwoCuiPresenter`
- [x] `go vet` / `golangci-lint run`（0 issues）
- [x] ja/en bigtwo.json キー parity 確認

Closes #2991