### PR TITLE
feat(omaha): route header SB/BB label through i18n

### DIFF
--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -354,6 +354,7 @@
     "cpuActions": "[CPU Actions]",
     "cpuOpponents": "CPU Opponents ({{count}})",
     "pot": "Pot:",
+    "blinds": "SB/BB:",
     "dealer": "Dealer:",
     "networkError": "A network error occurred. Please try again.",
     "chipsWon": "+{{amount}} chips",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -354,6 +354,7 @@
     "cpuActions": "[CPUの行動]",
     "cpuOpponents": "CPU対戦相手 ({{count}})",
     "pot": "ポット:",
+    "blinds": "SB/BB:",
     "dealer": "ディーラー:",
     "networkError": "通信エラーが発生しました。もう一度お試しください。",
     "chipsWon": "+{{amount}}チップ",

--- a/frontend/src/pages/OmahaPage.tsx
+++ b/frontend/src/pages/OmahaPage.tsx
@@ -236,7 +236,7 @@ function OmahaPageContent() {
             {tc('label.pot')} <strong>{state?.pot ?? 0}</strong>
           </span>
           <span>
-            SB/BB:{' '}
+            {tc('label.blinds')}{' '}
             <strong>
               {state?.smallBlind ?? 0}/{state?.bigBlind ?? 0}
             </strong>


### PR DESCRIPTION
## 概要
`OmahaPage.tsx` のヘッダーで `SB/BB:` がJSXに直書きされており、他のヘッダー項目（`tc('label.pot')` / `tc('label.dealer')`）と一貫していなかった。共通ネームスペースに再利用可能な `label.blinds` キーを追加し、`tc('label.blinds')` 経由に置き換えた。

## 変更点
- `frontend/src/i18n/locales/{ja,en}/common.json`: `label.blinds`（"SB/BB:"）を追加（ja/en parity 維持）
- `frontend/src/pages/OmahaPage.tsx`: 直書き `SB/BB:` を `{tc('label.blinds')}` に置換

共通キーのため Holdem/ShortDeck/Pineapple 等からも再利用可能（本issueはオマハのみ対象、他ゲームは別issue）。

## 挙動
キー値は ja/en とも "SB/BB:" のままで表示は不変。既存の「shows SB/BB in info bar」テストがそのまま新しいi18n経路を検証する。

## テスト計画
- [x] `bun run test -- --run src/pages/OmahaPage.test.tsx`（112 passed）
- [x] `bun run check`（exit 0）
- [x] `bun run build`（tsc gate, exit 0）
- [x] common.json ja/en `label` キー parity 確認

Closes #3002