### PR TITLE
feat(shortdeck): localize rank-override watermark text

### DIFF
--- a/frontend/src/i18n/locales/en/shortdeck.json
+++ b/frontend/src/i18n/locales/en/shortdeck.json
@@ -24,6 +24,7 @@
   },
   "communityCards": "Community Cards",
   "rankOverrideReminder": "Short Deck special rule: Flush beats Full House",
+  "rankWatermark": "♣♠♥♦ Flush > Full House",
   "yourHand": "Your Hand",
   "handNumber": "Hand #{{count}} (Level up: every {{level}} hands)",
   "rebuy": {

--- a/frontend/src/i18n/locales/ja/shortdeck.json
+++ b/frontend/src/i18n/locales/ja/shortdeck.json
@@ -24,6 +24,7 @@
   },
   "communityCards": "コミュニティカード",
   "rankOverrideReminder": "ショートデック特殊ルール：フラッシュ > フルハウス",
+  "rankWatermark": "♣♠♥♦ フラッシュ ＞ フルハウス",
   "yourHand": "あなたの手札",
   "handNumber": "ハンド#{{count}} (レベルアップ:{{level}}ハンド毎)",
   "rebuy": {

--- a/frontend/src/pages/ShortDeckPage.test.tsx
+++ b/frontend/src/pages/ShortDeckPage.test.tsx
@@ -1149,8 +1149,11 @@ describe('ShortDeckPage', () => {
     renderWithProviders(<ShortDeckPage />);
     const chip = await screen.findByTestId('shortdeck-rank-watermark');
     expect(chip).toBeInTheDocument();
-    expect(chip.textContent).toContain('Flush');
-    expect(chip.textContent).toContain('Full House');
+    // Visible text now comes from the i18n key (ja locale in tests); suit
+    // symbols stay locale-independent.
+    expect(chip.textContent).toContain('フラッシュ');
+    expect(chip.textContent).toContain('フルハウス');
+    expect(chip.textContent).toContain('♣♠♥♦');
     // Uses the design-system warning state-badge tokens, not opacity-modified ones.
     expect(chip.className).toContain('border-ds-warning');
     expect(chip.className).toContain('text-ds-warning');

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -261,7 +261,7 @@ function ShortDeckPageContent() {
                       className={`${badgeWarning} px-2 py-0.5 text-[11px] uppercase tracking-wider`}
                       title={t('rankOverrideReminder')}
                     >
-                      ♣♠♥♦ Flush &gt; Full House
+                      {t('rankWatermark')}
                     </span>
                   </div>
                   <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## 概要
コミュニティカード横のランク優先バッジ（`data-testid="shortdeck-rank-watermark"`）は `title` を `t('rankOverrideReminder')` でローカライズしていたが、可視テキスト `♣♠♥♦ Flush > Full House` がJSXに直書きで、日本語UIでもこの部分だけ英語固定だった。

## 変更点
- `shortdeck.json`（ja/en）に `rankWatermark` キーを追加（ja: `♣♠♥♦ フラッシュ ＞ フルハウス` / en: `♣♠♥♦ Flush > Full House`）。スート記号はロケール非依存のため保持
- `ShortDeckPage.tsx`: 直書きテキストを `{t('rankWatermark')}` に置換（`badgeWarning` スタイルは維持）
- `ShortDeckPage.test.tsx`: ローカライズ後の文言（ja）を検証するよう更新

## テスト計画
- [x] `bun run test -- --run src/pages/ShortDeckPage.test.tsx`（85 passed）
- [x] `bun run check`（exit 0）/ `bun run build`（exit 0）
- [x] shortdeck.json ja/en キー parity 確認

Closes #3013