### PR TITLE
feat(freecell): localize hint zone names in web hint display

### DIFF
--- a/frontend/src/pages/FreeCellPage.test.tsx
+++ b/frontend/src/pages/FreeCellPage.test.tsx
@@ -361,6 +361,8 @@ describe('FreeCellPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
 
     await waitFor(() => expect(screen.getAllByText(/ヒント/).length).toBeGreaterThanOrEqual(1));
+    // Zone identifiers are localized (ja), not shown as raw English.
+    await waitFor(() => expect(screen.getByText(/フリーセル.*→.*タブロー 3/)).toBeInTheDocument());
   });
 
   it('hint display shows fromCol when fromCol is non-negative', async () => {
@@ -370,7 +372,7 @@ describe('FreeCellPage', () => {
     mockExec.mockResolvedValue(withHintFromColState);
     fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
 
-    await waitFor(() => expect(screen.getByText(/tableau 2/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/タブロー 2/)).toBeInTheDocument());
   });
 
   // --- Keyboard shortcuts ---

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -451,8 +451,10 @@ function FreeCellPageContent() {
             {/* Hint display */}
             {hint && (
               <div className="text-ds-warning text-sm mb-2">
-                {t('hintAvailable')}: {hint.fromZone}
-                {hint.fromCol >= 0 ? ` ${hint.fromCol}` : ''} → {hint.toZone}
+                {/* Zone identifiers (tableau/freecell/foundation) double as i18n
+                    keys, so they localize instead of showing raw English. */}
+                {t('hintAvailable')}: {t(hint.fromZone)}
+                {hint.fromCol >= 0 ? ` ${hint.fromCol}` : ''} → {t(hint.toZone)}
                 {hint.toCol >= 0 ? ` ${hint.toCol}` : ''}
               </div>
             )}


### PR DESCRIPTION
## 概要
`FreeCellPage.tsx` のヒント表示は `{hint.fromZone}` / `{hint.toZone}` を直接描画しており、日本語UIでも API のゾーン識別子（`tableau 3 → freecell 1`）が英語のまま出ていた。CUI 側（`FreeCellCuiPresenter.go` の HintOutput）は i18n 済みで、Web だけ未対応だった。

## 変更点
- `FreeCellPage.tsx`: ヒントのゾーン識別子を `t(hint.fromZone)` / `t(hint.toZone)` 経由で描画。ゾーン識別子（`tableau`/`freecell`/`foundation`）は `freecell.json` に既存キーとして存在するため、新規キー追加は不要（既存の `タブロー`/`フリーセル`/`ファンデーション` を再利用）
- `FreeCellPage.test.tsx`: ヒント表示がローカライズされたゾーン名になることを検証（`タブロー 2`、`フリーセル → タブロー 3`）

## 補足
issue の 対象ファイル には freecell.json へのキー追加が挙がっていたが、該当キーは既存だったため JSON 変更なし。i18n パリティは不変。

## テスト計画
- [x] `bun run test -- --run src/pages/FreeCellPage.test.tsx`（66 passed）
- [x] `bun run check`（exit 0）/ `bun run build`（exit 0）

Closes #3036