### PR TITLE
feat(seahaventowers): localize hint zone names in web hint display

### DIFF
--- a/frontend/src/pages/SeahavenTowersPage.test.tsx
+++ b/frontend/src/pages/SeahavenTowersPage.test.tsx
@@ -150,6 +150,18 @@ describe('SeahavenTowersPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
   });
 
+  it('hint display localizes zone names instead of raw English', async () => {
+    renderWithProviders(<SeahavenTowersPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+    mockExec.mockResolvedValue({
+      ...withHintState,
+      hint: { fromZone: 'reserved', fromCol: 1, cardIndex: -1, toZone: 'foundation', toCol: -1 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+    // Zone identifiers render as localized names (ja), matching the CUI terminology.
+    await waitFor(() => expect(screen.getByText(/リザーブセル 1.*→.*ファンデーション/)).toBeInTheDocument());
+  });
+
   it('autocomplete button triggers autocomplete API call', async () => {
     renderWithProviders(<SeahavenTowersPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'オートコンプリート' })).toBeInTheDocument());

--- a/frontend/src/pages/SeahavenTowersPage.test.tsx
+++ b/frontend/src/pages/SeahavenTowersPage.test.tsx
@@ -162,6 +162,18 @@ describe('SeahavenTowersPage', () => {
     await waitFor(() => expect(screen.getByText(/リザーブセル 1.*→.*ファンデーション/)).toBeInTheDocument());
   });
 
+  it('hint display omits column when col is negative and localizes both zones', async () => {
+    renderWithProviders(<SeahavenTowersPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+    mockExec.mockResolvedValue({
+      ...withHintState,
+      hint: { fromZone: 'foundation', fromCol: -1, cardIndex: -1, toZone: 'tableau', toCol: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+    // fromCol < 0 -> no number after the source zone; toCol >= 0 -> "タブロー 2".
+    await waitFor(() => expect(screen.getByText(/ファンデーション.*→.*タブロー 2/)).toBeInTheDocument());
+  });
+
   it('autocomplete button triggers autocomplete API call', async () => {
     renderWithProviders(<SeahavenTowersPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'オートコンプリート' })).toBeInTheDocument());

--- a/frontend/src/pages/SeahavenTowersPage.tsx
+++ b/frontend/src/pages/SeahavenTowersPage.tsx
@@ -463,8 +463,10 @@ function SeahavenTowersPageContent() {
             {/* Hint display */}
             {hint && (
               <div className="text-ds-warning text-sm mb-2">
-                {t('hintAvailable')}: {hint.fromZone}
-                {hint.fromCol >= 0 ? ` ${hint.fromCol}` : ''} → {hint.toZone}
+                {/* Zone identifiers (tableau/reserved/foundation) double as i18n
+                    keys, matching the CUI HintOutput terminology. */}
+                {t('hintAvailable')}: {t(hint.fromZone)}
+                {hint.fromCol >= 0 ? ` ${hint.fromCol}` : ''} → {t(hint.toZone)}
                 {hint.toCol >= 0 ? ` ${hint.toCol}` : ''}
               </div>
             )}


### PR DESCRIPTION
## 概要
`SeahavenTowersPage.tsx` のヒント表示が `{hint.fromZone}` / `{hint.toZone}` を生描画しており、日本語UIでも `tableau 5 → reserved 1` と英語識別子が露出していた。CUI（`SeahavenTowersCuiPresenter.go`）は `hintFrom*`/`hintTo*` キーで i18n 済みで Web だけ未対応だった。

## 変更点
- `SeahavenTowersPage.tsx`: ゾーン識別子を `t(hint.fromZone)` / `t(hint.toZone)` 経由に。`tableau`/`reserved`/`foundation` は `seahaventowers.json` に既存キーとして存在し（タブロー/リザーブセル/ファンデーション）、CUI用語（`hintFromReserved`=リザーブセル 等）と一致するため新規キー追加は不要
- `SeahavenTowersPage.test.tsx`: `reserved → foundation` ヒントがローカライズ表示されることを検証するテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/SeahavenTowersPage.test.tsx`（17 passed）
- [x] `bun run check`（exit 0）/ `bun run build`（exit 0）

Closes #3038