### PR TITLE
feat(fiftyone): localize CPU difficulty select options

### DIFF
--- a/frontend/src/i18n/locales/en/fiftyone.json
+++ b/frontend/src/i18n/locales/en/fiftyone.json
@@ -23,7 +23,10 @@
     "suitScores": "Suit totals"
   },
   "settings": {
-    "cpuDifficulty": "CPU Difficulty"
+    "cpuDifficulty": "CPU Difficulty",
+    "difficultyEasy": "Easy",
+    "difficultyNormal": "Normal",
+    "difficultyHard": "Hard"
   },
   "hint": {
     "exchangeStrong": "A card exchange can greatly improve your score",

--- a/frontend/src/i18n/locales/ja/fiftyone.json
+++ b/frontend/src/i18n/locales/ja/fiftyone.json
@@ -23,7 +23,10 @@
     "suitScores": "スート別合計"
   },
   "settings": {
-    "cpuDifficulty": "CPU難易度"
+    "cpuDifficulty": "CPU難易度",
+    "difficultyEasy": "簡単",
+    "difficultyNormal": "普通",
+    "difficultyHard": "難しい"
   },
   "hint": {
     "exchangeStrong": "スコアを大幅に改善できる交換があります",

--- a/frontend/src/pages/FiftyOnePage.test.tsx
+++ b/frontend/src/pages/FiftyOnePage.test.tsx
@@ -86,6 +86,16 @@ describe('FiftyOnePage', () => {
     await waitFor(() => expect(screen.getByText(/スコア: 21/)).toBeInTheDocument());
   });
 
+  it('renders CPU difficulty options with localized labels', async () => {
+    const { FiftyOnePage } = await import('./FiftyOnePage');
+    renderWithProviders(<FiftyOnePage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    // Difficulty options are localized (ja), not the hardcoded Easy/Normal/Hard.
+    expect(screen.getByRole('option', { name: '簡単' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: '普通' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: '難しい' })).toBeInTheDocument();
+  });
+
   it('exchange all button calls exchangeall', async () => {
     const { FiftyOnePage } = await import('./FiftyOnePage');
     renderWithProviders(<FiftyOnePage />);

--- a/frontend/src/pages/FiftyOnePage.tsx
+++ b/frontend/src/pages/FiftyOnePage.tsx
@@ -30,9 +30,9 @@ import { fiftyOneBestSuit, fiftyOneSuitScores } from '../utils/fiftyOneSuitScore
 type FiftyOneArgs = Parameters<typeof fiftyoneApi.exec>;
 
 const DIFFICULTY_OPTIONS = [
-  { value: '0', label: 'Easy' },
-  { value: '1', label: 'Normal' },
-  { value: '2', label: 'Hard' },
+  { value: '0', labelKey: 'settings.difficultyEasy' },
+  { value: '1', labelKey: 'settings.difficultyNormal' },
+  { value: '2', labelKey: 'settings.difficultyHard' },
 ];
 
 /** Tutorial steps for the Fifty-one game. */
@@ -302,7 +302,7 @@ function FiftyOnePageContent() {
                     id: 'cpuDifficulty',
                     label: t('settings.cpuDifficulty'),
                     value: String(cpuDifficulty),
-                    options: DIFFICULTY_OPTIONS,
+                    options: DIFFICULTY_OPTIONS.map((opt) => ({ value: opt.value, label: t(opt.labelKey) })),
                     onSelect: (v: string) => setCpuDifficulty(Number.parseInt(v, 10)),
                   },
                   {


### PR DESCRIPTION
## 概要
`FiftyOnePage.tsx` の `DIFFICULTY_OPTIONS` は `label: 'Easy'/'Normal'/'Hard'` とハードコードされ `SettingsPanel` にそのまま渡されており、日本語ロケールでも難易度選択が常に英語表示だった（`DurakPage`/`TwoTenJackPage` は `t('settings.difficulty...')` 経由で翻訳済み）。

## 変更点
- `fiftyone.json`（ja/en）の `settings` に `difficultyEasy`/`difficultyNormal`/`difficultyHard` を追加（parity 維持）
- `FiftyOnePage.tsx`: `DIFFICULTY_OPTIONS` のラベルを翻訳キー参照に変更し、使用箇所で `t()` 経由にマップ（`value` '0'/'1'/'2' は不変）
- `FiftyOnePage.test.tsx`: 難易度 option が日本語表示になることを検証するテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/FiftyOnePage.test.tsx`（10 passed）
- [x] `bun run check`（exit 0）/ `bun run build`（exit 0）
- [x] fiftyone.json ja/en settings キー parity 確認

Closes #3148