### PR TITLE
feat(whist): fall back to generic text for unknown hint reasons

### DIFF
--- a/frontend/src/i18n/locales/en/whist.json
+++ b/frontend/src/i18n/locales/en/whist.json
@@ -42,7 +42,8 @@
     "lead_strong": "Lead with a strong card",
     "follow_suit": "Follow the lead suit",
     "trump_cut": "Cut with trump",
-    "discard_high": "Discard a high card"
+    "discard_high": "Discard a high card",
+    "fallback": "Best play"
   },
   "suitNames": {
     "1": "♠ Spades",

--- a/frontend/src/i18n/locales/ja/whist.json
+++ b/frontend/src/i18n/locales/ja/whist.json
@@ -42,7 +42,8 @@
     "lead_strong": "強いカードでリード",
     "follow_suit": "リードスートに追随",
     "trump_cut": "トランプでカット",
-    "discard_high": "高いカードを捨てる"
+    "discard_high": "高いカードを捨てる",
+    "fallback": "最善手"
   },
   "suitNames": {
     "1": "♠ スペード",

--- a/frontend/src/pages/WhistPage.test.tsx
+++ b/frontend/src/pages/WhistPage.test.tsx
@@ -64,6 +64,24 @@ describe('WhistPage', () => {
     );
   });
 
+  it('shows a known hint reason translated', async () => {
+    renderWithProviders(<WhistPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+    mockExec.mockResolvedValueOnce(makeState({ hint: { cardIndex: 0, reason: 'trump_cut' } }));
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+    await waitFor(() => expect(screen.getByText(/トランプでカット/)).toBeInTheDocument());
+  });
+
+  it('falls back to generic text for an unknown hint reason', async () => {
+    renderWithProviders(<WhistPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+    mockExec.mockResolvedValueOnce(makeState({ hint: { cardIndex: 1, reason: 'brand_new_reason' } }));
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+    // Unknown reason -> hintReason.fallback, not the raw "brand_new_reason" key.
+    await waitFor(() => expect(screen.getByText(/最善手/)).toBeInTheDocument());
+    expect(screen.queryByText(/brand_new_reason/)).not.toBeInTheDocument();
+  });
+
   it('advances to the next trick when pressing n at trick end', async () => {
     mockExec.mockResolvedValue(makeState({ phase: 1 }));
     renderWithProviders(<WhistPage />);

--- a/frontend/src/pages/WhistPage.tsx
+++ b/frontend/src/pages/WhistPage.tsx
@@ -444,7 +444,13 @@ function WhistPageContent() {
 
             {hint && (
               <div className="text-ds-warning text-sm mb-2">
-                {`${t('hintPlay')}: [${hint.cardIndex}] (${t(`hintReason.${hint.reason}`)})`}
+                {/* hint.reason is a raw backend identifier; when a new reason is
+                    added, add its key under hintReason in whist.json (ja/en).
+                    Unknown reasons fall back to hintReason.fallback instead of
+                    showing the raw key. */}
+                {`${t('hintPlay')}: [${hint.cardIndex}] (${t(`hintReason.${hint.reason}`, {
+                  defaultValue: t('hintReason.fallback'),
+                })})`}
               </div>
             )}
 


### PR DESCRIPTION
## 概要
`WhistPage` は `t(\`hintReason.${hint.reason}\`)` とバックエンドの生 `reason` 文字列を翻訳キーに直接組み立てており、未定義の reason に対するフォールバックが無かった。新しい reason 文字列が追加されると翻訳キー未定義のまま生キーが画面表示されるおそれがあった。

## 変更点
- `whist.json`（ja/en）の `hintReason` に `fallback` キーを追加（`最善手` / `Best play`）
- `WhistPage.tsx`: `t()` に `defaultValue: t('hintReason.fallback')` を渡し、未知の reason で生キーではなく汎用テキストを表示。新 reason 追加時に i18n を更新する旨のコメントを明示
- `WhistPage.test.tsx`: 既知 reason（`trump_cut`→トランプでカット）と未知 reason（→最善手フォールバック）の両経路をテスト

## スコープ
CUI 側（`WhistCuiPresenter.go`）は共通ヘルパー `hintReasonStr` が未知 reason を素通しする共有挙動で、whist 固有の変更ではないため対象外（別途 CUI 共通改善で扱うのが適切）。本 PR はタイトル通りフロントエンドのフォールバック欠如を解消する。

## テスト計画
- [x] `bun run test -- --run src/pages/WhistPage.test.tsx`（10 passed）
- [x] `bun run check`（exit 0）/ `bun run build`（exit 0）
- [x] whist.json ja/en hintReason キー parity 確認

Closes #3158