### PR TITLE
feat(spanish21): make bonus-badge key mapping namespace-agnostic

### DIFF
--- a/frontend/src/pages/BlackJackPage.tsx
+++ b/frontend/src/pages/BlackJackPage.tsx
@@ -61,6 +61,21 @@ const BJ_PHASE_KEYS: Readonly<Record<number, string>> = {
   [BjPhase.EARLY_SURRENDER]: 'earlySurrender',
 };
 
+/**
+ * Strips the i18n namespace segment from a backend bonus key so it can be
+ * resolved by the page's namespaced `t()`. Backend bonus keys are the fully
+ * qualified `<namespace>.<...path>` form (e.g. `spanish21.bonus.777.spade`,
+ * see `BlackJackVariant.go`); `t()` here is already scoped to the variant
+ * namespace, so only the leading namespace segment is removed — the rest of
+ * the dotted path is preserved. Namespace-agnostic (not coupled to the literal
+ * `spanish21.` prefix) so a namespace rename cannot silently drop translation.
+ */
+function bonusBadgeKey(fullKey: string): string {
+  // indexOf('.') is -1 when there is no namespace segment, so slice(0) returns
+  // the key unchanged — no branch needed.
+  return fullKey.slice(fullKey.indexOf('.') + 1);
+}
+
 function useSuggestionLabels(t: (key: string) => string): Record<number, string> {
   return {
     [BJ_SUGGEST_HIT]: t('suggest.hit'),
@@ -514,7 +529,7 @@ function BlackJackPageContent({ variant = 'blackjack' }: BlackJackPageProps) {
                     data-testid="bj-bonus-badge"
                     className="rounded-full border border-ds-warning bg-ds-surface px-3 py-0.5 text-ds-warning text-sm font-bold motion-safe:animate-pulse-once"
                   >
-                    🎉 {t(key.replace(/^spanish21\./, ''))}
+                    🎉 {t(bonusBadgeKey(key))}
                   </span>
                 ))}
               </div>

--- a/frontend/src/pages/Spanish21Page.test.tsx
+++ b/frontend/src/pages/Spanish21Page.test.tsx
@@ -37,6 +37,33 @@ const betPhaseState: BlackJackResponse = {
   surrenderRule: 0,
 };
 
+const endPhaseWithBonus: BlackJackResponse = {
+  ...betPhaseState,
+  dealer: { score: 19, cards: [{ design: 'CLOVER', value: 9 }], chips: 1000 },
+  player: { chips: 1150 },
+  hands: [
+    {
+      score: 21,
+      cards: [
+        { design: 'SPADE', value: 7 },
+        { design: 'SPADE', value: 7 },
+        { design: 'SPADE', value: 7 },
+      ],
+      bet: 100,
+      stood: true,
+      doubled: false,
+      busted: false,
+      isBlackJack: false,
+      canSplit: false,
+      surrendered: false,
+      canSurrender: false,
+    },
+  ],
+  phase: 5,
+  message: 'You are the winner.',
+  bonuses: ['spanish21.bonus.777.spade'],
+};
+
 beforeEach(() => {
   mockExec.mockResolvedValue(betPhaseState);
 });
@@ -46,6 +73,17 @@ describe('Spanish21Page', () => {
     renderWithProviders(<Spanish21Page />);
     await waitFor(() => expect(mockExec).toHaveBeenCalled());
     expect(mockExec.mock.calls[0]?.[0]).toBe('reset');
+  });
+
+  it('renders a bonus badge with the translated label, not the raw key', async () => {
+    mockExec.mockResolvedValue(endPhaseWithBonus);
+    renderWithProviders(<Spanish21Page />);
+    const badge = await screen.findByTestId('bj-bonus-badge');
+    // The fully-qualified backend key `spanish21.bonus.777.spade` resolves to
+    // its ja translation; a broken namespace strip would leave the raw key.
+    expect(badge).toHaveTextContent('7-7-7 (全スペード)');
+    expect(badge).not.toHaveTextContent('spanish21.bonus');
+    expect(badge).not.toHaveTextContent('bonus.777.spade');
   });
 
   it('opens a Spanish 21 specific tutorial step describing the 48-card deck and bonuses', async () => {


### PR DESCRIPTION
## 概要
`BlackJackPage.tsx` のボーナスバッジ表示は `t(key.replace(/^spanish21\./, ''))` と、サーバーの `spanish21.` プレフィックスを正規表現でハードコード除去してから翻訳しており、命名規則が変わると静かに翻訳が外れ生キーが表示されるリスクがあった。

## 変更点
- `BlackJackPage.tsx`: 正規表現を廃止し、ネームスペース非依存の `bonusBadgeKey()` ヘルパー（先頭のネームスペースセグメントのみを除去）に置換。`slice(indexOf('.')+1)` によりドット無しキーも安全に処理（分岐不要）
- `Spanish21Page.test.tsx`: `spanish21.bonus.777.spade` が生キーではなく翻訳済みラベル（`7-7-7 (全スペード)`）で表示されることを検証するテストを追加。キー命名規則や変換が壊れると失敗する

## 挙動
既存のバッジ表示内容は不変（`spanish21.bonus.777.spade` → `bonus.777.spade` → 翻訳、と従来と同一結果）。

## テスト計画
- [x] `bun run test -- --run src/pages/Spanish21Page.test.tsx src/pages/BlackJackPage.test.tsx`（134 passed）
- [x] `bun run check`（exit 0）/ `bun run build`（exit 0）

Closes #3207