### PR TITLE
fix(texasholdembonus): don't mislabel unevaluated hand ranks as High Card

### DIFF
--- a/frontend/src/pages/CaribbeanStudPage.test.tsx
+++ b/frontend/src/pages/CaribbeanStudPage.test.tsx
@@ -274,6 +274,14 @@ describe('CaribbeanStudPage', () => {
     expect(screen.getByText('🔴')).toBeInTheDocument();
   });
 
+  it('does not label unevaluated hand ranks as High Card', async () => {
+    mockApi.mockResolvedValue({ ...endPhasePlayerWins, playerHandRank: -1, dealerHandRank: -1 });
+    renderWithProviders(<CaribbeanStudPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+    // Ranks of -1 (unevaluated) must not fall back to the "High Card" label.
+    expect(screen.queryByText(/ハイカード/)).not.toBeInTheDocument();
+  });
+
   it('renders 1 face-up and 4 face-down dealer cards in action phase', async () => {
     mockApi.mockResolvedValueOnce(betPhaseState).mockResolvedValueOnce(actionPhaseState);
     renderWithProviders(<CaribbeanStudPage />);

--- a/frontend/src/pages/CaribbeanStudPage.tsx
+++ b/frontend/src/pages/CaribbeanStudPage.tsx
@@ -252,8 +252,8 @@ function CaribbeanStudPageContent() {
               <div className="mb-4" data-tutorial="csp-results">
                 <div className="text-ds-warning font-bold text-center mb-1">
                   <span aria-hidden="true">🟡</span> {t('player')}
-                  {isEndPhase && (
-                    <span className="ml-2 text-sm">({t(HAND_RANK_KEYS[state.playerHandRank] ?? 'handRank.0')})</span>
+                  {isEndPhase && HAND_RANK_KEYS[state.playerHandRank] && (
+                    <span className="ml-2 text-sm">({t(HAND_RANK_KEYS[state.playerHandRank])})</span>
                   )}
                 </div>
                 <div className="flex justify-center gap-2 flex-wrap">
@@ -268,8 +268,8 @@ function CaribbeanStudPageContent() {
               <div className="mb-4">
                 <div className="text-ds-error font-bold text-center mb-1">
                   <span aria-hidden="true">🔴</span> {t('dealer')}
-                  {isEndPhase && (
-                    <span className="ml-2 text-sm">({t(HAND_RANK_KEYS[state.dealerHandRank] ?? 'handRank.0')})</span>
+                  {isEndPhase && HAND_RANK_KEYS[state.dealerHandRank] && (
+                    <span className="ml-2 text-sm">({t(HAND_RANK_KEYS[state.dealerHandRank])})</span>
                   )}
                   {isEndPhase && (
                     <span className="ml-2 text-xs">

--- a/frontend/src/pages/LetItRidePage.test.tsx
+++ b/frontend/src/pages/LetItRidePage.test.tsx
@@ -199,6 +199,14 @@ describe('LetItRidePage', () => {
     await waitFor(() => expect(screen.getByText(/ロイヤルフラッシュ/)).toBeInTheDocument());
   });
 
+  it('does not label an unevaluated hand rank as High Card', async () => {
+    mockApi.mockResolvedValue({ ...endPhaseWin, handRank: -1 });
+    renderWithProviders(<LetItRidePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+    // handRank of -1 (unevaluated) must not fall back to the "High Card" label.
+    expect(screen.queryByText(/ハイカード/)).not.toBeInTheDocument();
+  });
+
   it('shows individual bet payouts when non-zero', async () => {
     mockApi.mockResolvedValue(endPhaseWin);
     renderWithProviders(<LetItRidePage />);

--- a/frontend/src/pages/LetItRidePage.tsx
+++ b/frontend/src/pages/LetItRidePage.tsx
@@ -257,8 +257,8 @@ function LetItRidePageContent() {
               <div className="mb-4" data-tutorial="lir-results">
                 <div className="text-ds-warning font-bold text-center mb-1">
                   <span aria-hidden="true">🟡</span> {t('player')}
-                  {isEndPhase && (
-                    <span className="ml-2 text-sm">({t(HAND_RANK_KEYS[state.handRank] ?? 'handRank.0')})</span>
+                  {isEndPhase && HAND_RANK_KEYS[state.handRank] && (
+                    <span className="ml-2 text-sm">({t(HAND_RANK_KEYS[state.handRank])})</span>
                   )}
                 </div>
                 <div className="flex justify-center gap-2 flex-wrap">

--- a/frontend/src/pages/TexasHoldemBonusPage.test.tsx
+++ b/frontend/src/pages/TexasHoldemBonusPage.test.tsx
@@ -187,6 +187,14 @@ describe('TexasHoldemBonusPage', () => {
     await waitFor(() => expect(screen.getByText('ディーラー勝利！')).toBeInTheDocument());
   });
 
+  it('does not label an unevaluated hand rank as High Card', async () => {
+    mockApi.mockResolvedValue({ ...endPlayerWins, playerHandRank: -1, dealerHandRank: -1 });
+    renderWithProviders(<TexasHoldemBonusPage />);
+    await waitFor(() => expect(screen.getByText('勝利！')).toBeInTheDocument());
+    // Ranks of -1 (unevaluated) must not fall back to the handRank.0 "High Card" label.
+    expect(screen.queryByText(/ハイカード/)).not.toBeInTheDocument();
+  });
+
   it('shows end phase with fold', async () => {
     mockApi.mockResolvedValue(endFold);
     renderWithProviders(<TexasHoldemBonusPage />);

--- a/frontend/src/pages/TexasHoldemBonusPage.tsx
+++ b/frontend/src/pages/TexasHoldemBonusPage.tsx
@@ -275,8 +275,8 @@ function TexasHoldemBonusPageContent() {
               <div className="mb-4">
                 <div className="text-ds-error font-bold text-center mb-1">
                   <span aria-hidden="true">🔴</span> {t('dealer')}
-                  {isEndPhase && (
-                    <span className="ml-2 text-sm">({t(HAND_RANK_KEYS[state.dealerHandRank] ?? 'handRank.0')})</span>
+                  {isEndPhase && HAND_RANK_KEYS[state.dealerHandRank] && (
+                    <span className="ml-2 text-sm">({t(HAND_RANK_KEYS[state.dealerHandRank])})</span>
                   )}
                 </div>
                 <div className="flex justify-center gap-2 flex-wrap">
@@ -295,8 +295,8 @@ function TexasHoldemBonusPageContent() {
               <div className="mb-4" data-tutorial="thb-results">
                 <div className="text-ds-warning font-bold text-center mb-1">
                   <span aria-hidden="true">🟡</span> {t('player')}
-                  {isEndPhase && (
-                    <span className="ml-2 text-sm">({t(HAND_RANK_KEYS[state.playerHandRank] ?? 'handRank.0')})</span>
+                  {isEndPhase && HAND_RANK_KEYS[state.playerHandRank] && (
+                    <span className="ml-2 text-sm">({t(HAND_RANK_KEYS[state.playerHandRank])})</span>
                   )}
                 </div>
                 <div className="flex justify-center gap-2 flex-wrap">


### PR DESCRIPTION
## 概要
`TexasHoldemBonusPage.tsx` の `HAND_RANK_KEYS[state.xxxHandRank] ?? 'handRank.0'` は、ランクが未評価（`-1` など辞書に無い値）の場合に無条件で `handRank.0`（ハイカード）へフォールバックし、フォールドやショーダウン未到達で未確定のハンドが「ハイカード」と誤表示されうる。

## 変更点
- `TexasHoldemBonusPage.tsx`: ランクチップの表示条件を `HAND_RANK_KEYS[rank]` が定義されている場合に限定（未評価時は括弧付きランク表示自体を出さない）
- 同型ロジックを持つ `CaribbeanStudPage.tsx`（player/dealer）・`LetItRidePage.tsx` にも同じガードを適用（issue AC の「同型ロジック点検」に対応）
- 3ページそれぞれに未評価ランク（-1）で「ハイカード」を表示しないことを検証するテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/{TexasHoldemBonus,LetItRide,CaribbeanStud}Page.test.tsx`（70 passed）
- [x] `bun run check`（exit 0）/ `bun run build`（exit 0）

Closes #3141