### PR TITLE
feat(belote): translate hint reason instead of showing raw identifier

### DIFF
--- a/frontend/src/i18n/locales/en/belote.json
+++ b/frontend/src/i18n/locales/en/belote.json
@@ -73,7 +73,8 @@
     "lead_strong": "Lead with a strong card",
     "follow_suit": "Follow the led suit",
     "trump_cut": "Cut with trump",
-    "discard_weak": "Discard the lowest-value card"
+    "discard_weak": "Discard the lowest-value card",
+    "fallback": "Best play"
   },
   "tutorial": {
     "bidControls": "In the pick-up phase, decide whether to take the face-up card's suit as trump.",

--- a/frontend/src/i18n/locales/ja/belote.json
+++ b/frontend/src/i18n/locales/ja/belote.json
@@ -73,7 +73,8 @@
     "lead_strong": "強いカードでリード",
     "follow_suit": "リードスートに従う",
     "trump_cut": "切り札でカット",
-    "discard_weak": "最低点のカードを捨てる"
+    "discard_weak": "最低点のカードを捨てる",
+    "fallback": "最善手"
   },
   "tutorial": {
     "bidControls": "ピックアップ: 表向きカードのスートを切り札にするか決めます。",

--- a/frontend/src/pages/BelotePage.test.tsx
+++ b/frontend/src/pages/BelotePage.test.tsx
@@ -210,7 +210,8 @@ describe('BelotePage', () => {
     mockExec.mockResolvedValue(playState);
     renderWithProviders(<BelotePage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
-    mockExec.mockResolvedValueOnce({ ...playState, hint: { cardIndex: 1, reason: 'brand_new_reason' } });
+    // Omit cardIndex to also exercise the `?? '-'` fallback for a missing index.
+    mockExec.mockResolvedValueOnce({ ...playState, hint: { reason: 'brand_new_reason' } });
     fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
     // Unknown reason -> hintReason.fallback, not the raw identifier.
     await waitFor(() => expect(screen.getByText(/最善手/)).toBeInTheDocument());

--- a/frontend/src/pages/BelotePage.test.tsx
+++ b/frontend/src/pages/BelotePage.test.tsx
@@ -195,6 +195,28 @@ describe('BelotePage', () => {
     expect(mockPlaySound).toHaveBeenCalledWith('winFanfare');
   });
 
+  it('translates a known hint reason', async () => {
+    const playState = makeState({ phase: BelotePhase.PLAY, trumpSuit: 1, currentPlayerIdx: 0, makerTeam: 0 });
+    mockExec.mockResolvedValue(playState);
+    renderWithProviders(<BelotePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+    mockExec.mockResolvedValueOnce({ ...playState, hint: { cardIndex: 0, reason: 'trump_cut' } });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+    await waitFor(() => expect(screen.getByText(/切り札でカット/)).toBeInTheDocument());
+  });
+
+  it('falls back to a generic label for an unknown hint reason', async () => {
+    const playState = makeState({ phase: BelotePhase.PLAY, trumpSuit: 1, currentPlayerIdx: 0, makerTeam: 0 });
+    mockExec.mockResolvedValue(playState);
+    renderWithProviders(<BelotePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+    mockExec.mockResolvedValueOnce({ ...playState, hint: { cardIndex: 1, reason: 'brand_new_reason' } });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+    // Unknown reason -> hintReason.fallback, not the raw identifier.
+    await waitFor(() => expect(screen.getByText(/最善手/)).toBeInTheDocument());
+    expect(screen.queryByText(/brand_new_reason/)).not.toBeInTheDocument();
+  });
+
   it('auto-hides the confirmation banner after the display window closes', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     try {

--- a/frontend/src/pages/BelotePage.tsx
+++ b/frontend/src/pages/BelotePage.tsx
@@ -403,7 +403,11 @@ function BelotePageContent() {
 
         {hint && (
           <div className="text-ds-warning text-sm mb-2">
-            {`${t('hintPlay')}: [${hint.cardIndex ?? '-'}] (${hint.reason})`}
+            {/* hint.reason is a raw backend identifier; translate via hintReason.*,
+                falling back to a generic label for any unknown reason. */}
+            {`${t('hintPlay')}: [${hint.cardIndex ?? '-'}] (${t(`hintReason.${hint.reason}`, {
+              defaultValue: t('hintReason.fallback'),
+            })})`}
           </div>
         )}
 


### PR DESCRIPTION
## 概要
`BelotePage.tsx` のヒント表示は `(${hint.reason})` とバックエンドの生識別子（例: `follow_suit`）をそのまま出しており、日本語/英語ロケールでも内部キーが露出していた。CUI（`BeloteCuiPresenter.go`）は `hintReasonStr` で i18n 解決済みだった。

## 変更点
- `belote.json`（ja/en）: 既に全 reason（strategic_pickup/pass_recommended/strategic_call/lead_trump/lead_strong/follow_suit/trump_cut/discard_weak）のキーは存在していたため、未知 reason 用の `fallback` キーのみ追加
- `BelotePage.tsx`: 表示を `t(\`hintReason.${hint.reason}\`, { defaultValue: t('hintReason.fallback') })` に変更
- `BelotePage.test.tsx`: 既知 reason（`trump_cut`→切り札でカット）と未知 reason（→最善手フォールバック）のテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/BelotePage.test.tsx`（18 passed）
- [x] `bun run check`（exit 0）/ `bun run build`（exit 0）
- [x] belote.json ja/en hintReason キー parity 確認

Closes #3264