### PR TITLE
feat(barbu): localize CPU difficulty select options

### DIFF
--- a/frontend/src/i18n/locales/en/barbu.json
+++ b/frontend/src/i18n/locales/en/barbu.json
@@ -58,7 +58,10 @@
   },
   "settings": {
     "title": "Settings",
-    "cpuDifficulty": "CPU Difficulty"
+    "cpuDifficulty": "CPU Difficulty",
+    "easy": "Easy",
+    "normal": "Normal",
+    "hard": "Hard"
   },
   "result": {
     "win": "Win",

--- a/frontend/src/i18n/locales/ja/barbu.json
+++ b/frontend/src/i18n/locales/ja/barbu.json
@@ -58,7 +58,10 @@
   },
   "settings": {
     "title": "設定",
-    "cpuDifficulty": "CPU 難易度"
+    "cpuDifficulty": "CPU 難易度",
+    "easy": "かんたん",
+    "normal": "ふつう",
+    "hard": "むずかしい"
   },
   "result": {
     "win": "勝ち",

--- a/frontend/src/pages/BarbuPage.test.tsx
+++ b/frontend/src/pages/BarbuPage.test.tsx
@@ -64,6 +64,15 @@ describe('BarbuPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('r'));
   });
 
+  it('renders CPU difficulty options with localized labels', async () => {
+    renderWithProviders(<BarbuPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('r'));
+    // Difficulty options are localized (ja), not the hardcoded Easy/Normal/Hard.
+    expect(screen.getByRole('option', { name: 'かんたん' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'ふつう' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'むずかしい' })).toBeInTheDocument();
+  });
+
   it('renders contract buttons in the select phase', async () => {
     renderWithProviders(<BarbuPage />);
     await waitFor(() => expect(screen.getByTestId('contract-0')).toBeInTheDocument());

--- a/frontend/src/pages/BarbuPage.tsx
+++ b/frontend/src/pages/BarbuPage.tsx
@@ -349,7 +349,10 @@ function BarbuPageContent() {
                     id: 'cpuDifficulty',
                     label: t('settings.cpuDifficulty'),
                     value: String(configInput.cpuDifficulty ?? 1),
-                    options: DIFFICULTY_OPTIONS,
+                    options: DIFFICULTY_OPTIONS.map((o) => ({
+                      value: o.value,
+                      label: t(`settings.${o.label.toLowerCase()}`),
+                    })),
                     onSelect: (v: string) => handleConfigChange('cpuDifficulty', Number.parseInt(v, 10)),
                   },
                   {


### PR DESCRIPTION
## 概要
`BarbuPage.tsx` の `DIFFICULTY_OPTIONS` は `label: 'Easy'/'Normal'/'Hard'` とハードコードされ `SettingsPanel` にそのまま渡されており、日本語ロケールでも難易度が英語表示だった（`MacauPage` は `t('settings.${label.toLowerCase()}')` で翻訳済み）。

## 変更点
- `barbu.json`（ja/en）の `settings` に `easy`/`normal`/`hard` を追加（parity 維持）
- `BarbuPage.tsx`: `DIFFICULTY_OPTIONS` を `t()` 経由にマップしてから `SettingsPanel` へ（`value` '0'/'1'/'2' は不変）
- `BarbuPage.test.tsx`: 難易度 option が日本語（かんたん/ふつう/むずかしい）で表示されることを検証するテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/BarbuPage.test.tsx`（12 passed）
- [x] `bun run check`（exit 0）/ `bun run build`（exit 0）
- [x] barbu.json ja/en settings キー parity 確認

Closes #3351