### PR TITLE
feat(fivehundred): localize CPU difficulty select options

### DIFF
--- a/frontend/src/i18n/locales/en/fivehundred.json
+++ b/frontend/src/i18n/locales/en/fivehundred.json
@@ -30,7 +30,10 @@
   "nextRoundButton": "Next round",
   "settings": {
     "cpuDifficulty": "CPU difficulty",
-    "targetScore": "Target score"
+    "targetScore": "Target score",
+    "easy": "Easy",
+    "normal": "Normal",
+    "hard": "Hard"
   },
   "tutorial": {
     "info": "Round, contract, and team scores show here. The first team to reach 500 points wins.",

--- a/frontend/src/i18n/locales/ja/fivehundred.json
+++ b/frontend/src/i18n/locales/ja/fivehundred.json
@@ -30,7 +30,10 @@
   "nextRoundButton": "次のラウンド",
   "settings": {
     "cpuDifficulty": "CPU難易度",
-    "targetScore": "目標スコア"
+    "targetScore": "目標スコア",
+    "easy": "かんたん",
+    "normal": "ふつう",
+    "hard": "むずかしい"
   },
   "tutorial": {
     "info": "ここにラウンド・契約・チームスコアが表示されます。先に500点に到達したチームの勝ちです。",

--- a/frontend/src/pages/FiveHundredPage.test.tsx
+++ b/frontend/src/pages/FiveHundredPage.test.tsx
@@ -81,6 +81,15 @@ describe('FiveHundredPage', () => {
     );
   });
 
+  it('renders CPU difficulty options with localized labels', async () => {
+    renderWithProviders(<FiveHundredPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    // Difficulty options are localized (ja), not the hardcoded Easy/Normal/Hard.
+    expect(screen.getByRole('option', { name: 'かんたん' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'ふつう' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'むずかしい' })).toBeInTheDocument();
+  });
+
   it('shows bid controls on the human bid turn', async () => {
     renderWithProviders(<FiveHundredPage />);
     expect(await screen.findByTestId('pass-button')).toBeEnabled();

--- a/frontend/src/pages/FiveHundredPage.tsx
+++ b/frontend/src/pages/FiveHundredPage.tsx
@@ -312,7 +312,10 @@ function FiveHundredPageContent() {
                     id: 'cpuDifficulty',
                     label: t('settings.cpuDifficulty'),
                     value: String(config.cpuDifficulty ?? 1),
-                    options: CPU_DIFFICULTY_SELECT,
+                    options: CPU_DIFFICULTY_SELECT.map((o) => ({
+                      value: o.value,
+                      label: t(`settings.${o.label.toLowerCase()}`),
+                    })),
                     onSelect: (v: string) => handleConfigChange('cpuDifficulty', v),
                   },
                   {


### PR DESCRIPTION
## 概要
`FiveHundredPage.tsx` の `CPU_DIFFICULTY_SELECT` は英語ラベル（Easy/Normal/Hard）を直書きし `SettingsPanel` にそのまま渡していたため、日本語ロケールでも英語表示だった。

## 変更点
- `fivehundred.json`（ja/en）の `settings` に `easy`/`normal`/`hard` を追加（parity 維持）
- `FiveHundredPage.tsx`: `CPU_DIFFICULTY_SELECT` を `t('settings.${label.toLowerCase()}')` 経由にマップ（value は不変、`TARGET_SCORE_SELECT` は対象外）
- `FiveHundredPage.test.tsx`: 難易度 option が日本語（かんたん/ふつう/むずかしい）で表示されることを検証するテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/FiveHundredPage.test.tsx`（14 passed）
- [x] `bun run check`（exit 0）/ `bun run build`（exit 0）
- [x] fivehundred.json ja/en settings キー parity 確認

Closes #3365