### PR TITLE
feat(bidwhist): localize CPU difficulty select options

### DIFF
--- a/frontend/src/i18n/locales/en/bidwhist.json
+++ b/frontend/src/i18n/locales/en/bidwhist.json
@@ -32,7 +32,10 @@
   "nextRoundButton": "Next round",
   "settings": {
     "cpuDifficulty": "CPU difficulty",
-    "targetScore": "Target score"
+    "targetScore": "Target score",
+    "easy": "Easy",
+    "normal": "Normal",
+    "hard": "Hard"
   },
   "tutorial": {
     "info": "Round, contract, and team scores appear here. The first team to 7 points wins.",

--- a/frontend/src/i18n/locales/ja/bidwhist.json
+++ b/frontend/src/i18n/locales/ja/bidwhist.json
@@ -32,7 +32,10 @@
   "nextRoundButton": "次のラウンド",
   "settings": {
     "cpuDifficulty": "CPU難易度",
-    "targetScore": "目標スコア"
+    "targetScore": "目標スコア",
+    "easy": "かんたん",
+    "normal": "ふつう",
+    "hard": "むずかしい"
   },
   "tutorial": {
     "info": "ここにラウンド・契約・チームスコアが表示されます。先に7点に到達したチームの勝ちです。",

--- a/frontend/src/pages/BidWhistPage.test.tsx
+++ b/frontend/src/pages/BidWhistPage.test.tsx
@@ -78,6 +78,15 @@ describe('BidWhistPage', () => {
     );
   });
 
+  it('renders CPU difficulty options with localized labels', async () => {
+    renderWithProviders(<BidWhistPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    // Difficulty options are localized (ja), not the hardcoded Easy/Normal/Hard.
+    expect(screen.getByRole('option', { name: 'かんたん' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'ふつう' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'むずかしい' })).toBeInTheDocument();
+  });
+
   it('shows bid controls on the human bid turn', async () => {
     renderWithProviders(<BidWhistPage />);
     expect(await screen.findByTestId('pass-button')).toBeEnabled();

--- a/frontend/src/pages/BidWhistPage.tsx
+++ b/frontend/src/pages/BidWhistPage.tsx
@@ -325,7 +325,10 @@ function BidWhistPageContent() {
                     id: 'cpuDifficulty',
                     label: t('settings.cpuDifficulty'),
                     value: String(config.cpuDifficulty ?? 1),
-                    options: CPU_DIFFICULTY_SELECT,
+                    options: CPU_DIFFICULTY_SELECT.map((o) => ({
+                      value: o.value,
+                      label: t(`settings.${o.label.toLowerCase()}`),
+                    })),
                     onSelect: (v: string) => handleConfigChange('cpuDifficulty', v),
                   },
                   {


### PR DESCRIPTION
## 概要
`BidWhistPage.tsx` の `CPU_DIFFICULTY_SELECT` は英語ラベル（Easy/Normal/Hard）を直書きし `SettingsPanel` にそのまま渡していたため、日本語ロケールでも英語表示だった。方向ボタン等は i18n 済みで設定パネルだけ取り残されていた。

## 変更点
- `bidwhist.json`（ja/en）の `settings` に `easy`/`normal`/`hard` を追加（parity 維持、fivehundred とキー命名統一）
- `BidWhistPage.tsx`: `CPU_DIFFICULTY_SELECT` を `t('settings.${label.toLowerCase()}')` 経由にマップ（value は不変、`TARGET_SCORE_SELECT` は対象外）
- `BidWhistPage.test.tsx`: 難易度 option が日本語（かんたん/ふつう/むずかしい）で表示されることを検証するテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/BidWhistPage.test.tsx`（10 passed）
- [x] `bun run check`（exit 0）/ `bun run build`（exit 0）
- [x] bidwhist.json ja/en settings キー parity 確認

Closes #3384