### PR TITLE
feat(schnapsen): localize hand play-button aria-label

### DIFF
--- a/frontend/src/i18n/locales/en/schnapsen.json
+++ b/frontend/src/i18n/locales/en/schnapsen.json
@@ -24,7 +24,8 @@
     "reset": "Reset",
     "marriage": "Marriage",
     "hint": "Hint",
-    "marriageAria": "Declare marriage: K + Q of {{suit}} for {{points}} points"
+    "marriageAria": "Declare marriage: K + Q of {{suit}} for {{points}} points",
+    "playAria": "Play {{card}}"
   },
   "tutorial": {
     "trump": "The trump upcard and stock. The trump suit beats all others in a trick. When the stock runs out, phase 2 begins.",

--- a/frontend/src/i18n/locales/ja/schnapsen.json
+++ b/frontend/src/i18n/locales/ja/schnapsen.json
@@ -24,7 +24,8 @@
     "reset": "リセット",
     "marriage": "マリアージュ宣言",
     "hint": "ヒント",
-    "marriageAria": "マリアージュ宣言: {{suit}} のKとQで{{points}}点"
+    "marriageAria": "マリアージュ宣言: {{suit}} のKとQで{{points}}点",
+    "playAria": "{{card}} を出す"
   },
   "tutorial": {
     "trump": "切り札のアップカードと山札です。切り札のスートが各トリックで最強になります。山札が尽きるとフェーズ2に入ります。",

--- a/frontend/src/pages/SchnapsenPage.test.tsx
+++ b/frontend/src/pages/SchnapsenPage.test.tsx
@@ -72,15 +72,15 @@ describe('SchnapsenPage', () => {
 
   it('shows the human hand as play buttons', async () => {
     renderWithProviders(<SchnapsenPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Play SPADE 1' })).toBeInTheDocument());
-    expect(screen.getByRole('button', { name: 'Play HEART 10' })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole('button', { name: '♠ A を出す' })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: '♥ 10 を出す' })).toBeInTheDocument();
   });
 
   it('fires play with the selected card index when a card is clicked', async () => {
     renderWithProviders(<SchnapsenPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Play HEART 10' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '♥ 10 を出す' })).toBeInTheDocument());
     mockExec.mockClear();
-    fireEvent.click(screen.getByRole('button', { name: 'Play HEART 10' }));
+    fireEvent.click(screen.getByRole('button', { name: '♥ 10 を出す' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', 1));
   });
 
@@ -107,8 +107,8 @@ describe('SchnapsenPage', () => {
     mockExec.mockResolvedValue(makeState({ isEndgame: true, validPlays: [0] }));
     renderWithProviders(<SchnapsenPage />);
     await waitFor(() => expect(screen.getByTestId('schnapsen-phase')).toHaveTextContent(/第2フェーズ/));
-    expect(screen.getByRole('button', { name: 'Play SPADE 1' })).not.toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Play HEART 10' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: '♠ A を出す' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: '♥ 10 を出す' })).toBeDisabled();
   });
 
   it('shows "Next trick" button on trick-end and dispatches next', async () => {
@@ -162,7 +162,7 @@ describe('SchnapsenPage', () => {
     mockExec.mockResolvedValue(makeState({ currentPlayerIdx: 1 }));
     renderWithProviders(<SchnapsenPage />);
     await waitFor(() => {
-      const btn = screen.getByRole('button', { name: 'Play SPADE 1' });
+      const btn = screen.getByRole('button', { name: '♠ A を出す' });
       expect(btn).toBeDisabled();
     });
   });

--- a/frontend/src/pages/SchnapsenPage.tsx
+++ b/frontend/src/pages/SchnapsenPage.tsx
@@ -20,7 +20,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { SchnapsenResponse } from '../types/card';
 import { SchnapsenPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
-import { suitSymbol } from '../utils/cardAlt';
+import { cardAlt, suitSymbol } from '../utils/cardAlt';
 
 /** Card design → Schnapsen trump-suit id (1=♠ 2=♣ 3=♥ 4=♦). */
 const DESIGN_TO_SUIT: Readonly<Record<string, number>> = { SPADE: 1, CLOVER: 2, HEART: 3, DIAMOND: 4 };
@@ -223,7 +223,7 @@ function SchnapsenPageContent() {
                       type="button"
                       onClick={() => handlePlay(idx)}
                       disabled={loading || !playable}
-                      aria-label={`Play ${card.design} ${card.value}`}
+                      aria-label={t('actions.playAria', { card: cardAlt(card) })}
                       className="disabled:opacity-50"
                     >
                       <CardImage card={card} width={cardWidth} />


### PR DESCRIPTION
## 概要
`SchnapsenPage.tsx` の手札プレイボタンは `aria-label={\`Play ${card.design} ${card.value}\`}` と英語＋内部enum名（SPADE/CLOVER）を直書きしており、日本語ロケールでも「Play SPADE 12」のような読み上げになっていた。同ファイルのマリアージュボタンは i18n 済みで不整合だった。

## 変更点
- `SchnapsenPage.tsx`: `aria-label={t('actions.playAria', { card: cardAlt(card) })}` に置換。`cardAlt` でスート記号（♠等）＋ランクの自然な表記にし、enum名の露出を解消
- `schnapsen.json`（ja/en）に `actions.playAria`（ja: `{{card}} を出す` / en: `Play {{card}}`）を追加（parity 維持）
- `SchnapsenPage.test.tsx`: aria-label 参照を新表記（`♠ A を出す` 等）に更新

## テスト計画
- [x] `bun run test -- --run src/pages/SchnapsenPage.test.tsx`（16 passed）
- [x] `bun run check`（exit 0）/ `bun run build`（exit 0）
- [x] schnapsen.json ja/en actions キー parity 確認

Closes #3369