### PR TITLE
feat(bakersgame): localize hint zone names in web hint display

### DIFF
--- a/frontend/src/pages/BakersGamePage.test.tsx
+++ b/frontend/src/pages/BakersGamePage.test.tsx
@@ -344,6 +344,8 @@ describe('BakersGamePage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
 
     await waitFor(() => expect(screen.getAllByText(/ヒント/).length).toBeGreaterThanOrEqual(1));
+    // Zone identifiers are localized (ja), not shown as raw English.
+    await waitFor(() => expect(screen.getByText(/フリーセル.*→.*タブロー 3/)).toBeInTheDocument());
   });
 
   it('hint display shows fromCol when fromCol is non-negative', async () => {
@@ -353,7 +355,7 @@ describe('BakersGamePage', () => {
     mockExec.mockResolvedValue(withHintFromColState);
     fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
 
-    await waitFor(() => expect(screen.getByText(/tableau 2/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/タブロー 2/)).toBeInTheDocument());
   });
 
   // --- Keyboard shortcuts ---

--- a/frontend/src/pages/BakersGamePage.tsx
+++ b/frontend/src/pages/BakersGamePage.tsx
@@ -452,8 +452,10 @@ function BakersGamePageContent() {
             {/* Hint display */}
             {hint && (
               <div className="text-ds-warning text-sm mb-2">
-                {t('hintAvailable')}: {hint.fromZone}
-                {hint.fromCol >= 0 ? ` ${hint.fromCol}` : ''} → {hint.toZone}
+                {/* Zone identifiers (tableau/freecell/foundation) double as i18n
+                    keys, so they localize instead of showing raw English. */}
+                {t('hintAvailable')}: {t(hint.fromZone)}
+                {hint.fromCol >= 0 ? ` ${hint.fromCol}` : ''} → {t(hint.toZone)}
                 {hint.toCol >= 0 ? ` ${hint.toCol}` : ''}
               </div>
             )}


### PR DESCRIPTION
## 概要
`BakersGamePage.tsx` のヒント表示が `{hint.fromZone}` / `{hint.toZone}` を生描画しており、日本語UIでも `tableau 3 → foundation` と英語識別子が露出していた。CUI（`BakersGameCuiPresenter.go`）は i18n 済みで Web だけ未対応だった。

## 変更点
- `BakersGamePage.tsx`: ゾーン識別子を `t(hint.fromZone)` / `t(hint.toZone)` 経由に。`tableau`/`freecell`/`foundation` は `bakersgame.json` に既存キーとして存在（タブロー/フリーセル/ファンデーション）するため新規キー追加は不要
- `BakersGamePage.test.tsx`: ヒント表示がローカライズされたゾーン名（`フリーセル → タブロー 3`、`タブロー 2`）になることを検証するよう更新

## テスト計画
- [x] `bun run test -- --run src/pages/BakersGamePage.test.tsx`（66 passed）
- [x] `bun run check`（exit 0）/ `bun run build`（exit 0）

Closes #3396