### PR TITLE
feat(scopone): localize CPU difficulty select options

### DIFF
--- a/frontend/src/i18n/locales/en/scopone.json
+++ b/frontend/src/i18n/locales/en/scopone.json
@@ -31,7 +31,10 @@
   "settings": {
     "title": "Settings",
     "cpuDifficulty": "CPU Difficulty",
-    "targetScore": "Target Score"
+    "targetScore": "Target Score",
+    "easy": "Easy",
+    "normal": "Normal",
+    "hard": "Hard"
   },
   "result": {
     "win": "Win",

--- a/frontend/src/i18n/locales/ja/scopone.json
+++ b/frontend/src/i18n/locales/ja/scopone.json
@@ -31,7 +31,10 @@
   "settings": {
     "title": "設定",
     "cpuDifficulty": "CPU難易度",
-    "targetScore": "目標点"
+    "targetScore": "目標点",
+    "easy": "かんたん",
+    "normal": "ふつう",
+    "hard": "むずかしい"
   },
   "result": {
     "win": "勝ち",

--- a/frontend/src/pages/ScoponePage.test.tsx
+++ b/frontend/src/pages/ScoponePage.test.tsx
@@ -28,6 +28,15 @@ describe('ScoponePage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('r'));
   });
 
+  it('renders CPU difficulty options with localized labels', async () => {
+    renderWithProviders(<ScoponePage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    // Difficulty options are localized (ja), not the hardcoded Easy/Normal/Hard.
+    expect(screen.getByRole('option', { name: 'かんたん' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'ふつう' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'むずかしい' })).toBeInTheDocument();
+  });
+
   it('renders the human hand', async () => {
     renderWithProviders(<ScoponePage />);
     await waitFor(() => expect(screen.getByTestId('hand-card-0')).toBeInTheDocument());

--- a/frontend/src/pages/ScoponePage.tsx
+++ b/frontend/src/pages/ScoponePage.tsx
@@ -307,7 +307,10 @@ function ScoponePageContent() {
                     id: 'cpuDifficulty',
                     label: t('settings.cpuDifficulty'),
                     value: String(configInput.cpuDifficulty ?? 1),
-                    options: DIFFICULTY_OPTIONS,
+                    options: DIFFICULTY_OPTIONS.map((o) => ({
+                      value: o.value,
+                      label: t(`settings.${o.label.toLowerCase()}`),
+                    })),
                     onSelect: (v: string) => handleConfigChange('cpuDifficulty', Number.parseInt(v, 10)),
                   },
                   {


### PR DESCRIPTION
## 概要
`ScoponePage.tsx` の `DIFFICULTY_OPTIONS` は英語ラベル（Easy/Normal/Hard）を直書きし `SettingsPanel` にそのまま渡していたため、日本語ロケールでも英語表示だった。

## 変更点
- `scopone.json`（ja/en）の `settings` に `easy`/`normal`/`hard` を追加（parity 維持）
- `ScoponePage.tsx`: `DIFFICULTY_OPTIONS` を `t('settings.${label.toLowerCase()}')` 経由にマップ（value は不変）
- `ScoponePage.test.tsx`: 難易度 option が日本語（かんたん/ふつう/むずかしい）で表示されることを検証するテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/ScoponePage.test.tsx`（16 passed）
- [x] `bun run check`（exit 0）/ `bun run build`（exit 0）/ `npx tsc -b`（exit 0）
- [x] scopone.json ja/en settings キー parity 確認

Closes #3465