### PR TITLE
feat(jass): translate hint reason instead of showing raw identifier

### DIFF
--- a/frontend/src/i18n/locales/en/jass.json
+++ b/frontend/src/i18n/locales/en/jass.json
@@ -71,7 +71,8 @@
     "lead_strong": "Lead with a strong card",
     "follow_suit": "Follow the led suit",
     "trump_cut": "Cut with trump",
-    "discard_weak": "Discard the lowest-value card"
+    "discard_weak": "Discard the lowest-value card",
+    "fallback": "Best play"
   },
   "tutorial": {
     "bidControls": "In the trump-bid phase, choose a trump suit or pass the bid (Schieben) to your partner.",

--- a/frontend/src/i18n/locales/ja/jass.json
+++ b/frontend/src/i18n/locales/ja/jass.json
@@ -71,7 +71,8 @@
     "lead_strong": "強いカードでリード",
     "follow_suit": "リードスートに従う",
     "trump_cut": "切り札でカット",
-    "discard_weak": "最低点のカードを捨てる"
+    "discard_weak": "最低点のカードを捨てる",
+    "fallback": "最善手"
   },
   "tutorial": {
     "bidControls": "切り札ビッド: 切り札スートを選ぶか、シーバーでパートナーに委ねます。",

--- a/frontend/src/pages/JassPage.test.tsx
+++ b/frontend/src/pages/JassPage.test.tsx
@@ -144,6 +144,28 @@ describe('JassPage', () => {
     await waitFor(() => expect(screen.getByText('チームスコア')).toBeInTheDocument());
   });
 
+  it('translates a known hint reason', async () => {
+    const playState = makeState({ phase: JassPhase.PLAY, trumpSuit: 1, currentPlayerIdx: 0 });
+    mockExec.mockResolvedValue(playState);
+    renderWithProviders(<JassPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+    mockExec.mockResolvedValueOnce({ ...playState, hint: { cardIndex: 0, reason: 'trump_cut' } });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+    await waitFor(() => expect(screen.getByText(/切り札でカット/)).toBeInTheDocument());
+  });
+
+  it('falls back to a generic label for an unknown hint reason', async () => {
+    const playState = makeState({ phase: JassPhase.PLAY, trumpSuit: 1, currentPlayerIdx: 0 });
+    mockExec.mockResolvedValue(playState);
+    renderWithProviders(<JassPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+    // Omit cardIndex to also exercise the `?? '-'` fallback for a missing index.
+    mockExec.mockResolvedValueOnce({ ...playState, hint: { reason: 'brand_new_reason' } });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+    await waitFor(() => expect(screen.getByText(/最善手/)).toBeInTheDocument());
+    expect(screen.queryByText(/brand_new_reason/)).not.toBeInTheDocument();
+  });
+
   it('shows reset button mid-game and opens confirm dialog', async () => {
     renderWithProviders(<JassPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument());

--- a/frontend/src/pages/JassPage.tsx
+++ b/frontend/src/pages/JassPage.tsx
@@ -317,7 +317,11 @@ function JassPageContent() {
 
         {hint && (
           <div className="text-ds-warning text-sm mb-2">
-            {`${t('hintPlay')}: [${hint.cardIndex ?? '-'}] (${hint.reason})`}
+            {/* hint.reason is a raw backend identifier; translate via hintReason.*,
+                falling back to a generic label for any unknown reason. */}
+            {`${t('hintPlay')}: [${hint.cardIndex ?? '-'}] (${t(`hintReason.${hint.reason}`, {
+              defaultValue: t('hintReason.fallback'),
+            })})`}
           </div>
         )}
 


### PR DESCRIPTION
## 概要
`JassPage.tsx` のヒント表示は `(${hint.reason})` とバックエンドの生識別子（例: `lead_strong`）をそのまま出しており、日本語 UI に英語スネークケースが混ざる唯一の箇所だった。CUI（`JassCuiPresenter.go`）は `hintReasonStr` で翻訳済みだった。

## 変更点
- `jass.json`（ja/en）: 既に全 reason（schieben_recommended/strategic_trump/lead_trump/lead_strong/follow_suit/trump_cut/discard_weak）のキーは存在していたため、未知 reason 用の `fallback` キーのみ追加
- `JassPage.tsx`: 表示を `t(\`hintReason.${hint.reason}\`, { defaultValue: t('hintReason.fallback') })` に変更
- `JassPage.test.tsx`: 既知 reason（`trump_cut`→切り札でカット）と未知 reason（→最善手フォールバック）のテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/JassPage.test.tsx`（11 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）
- [x] jass.json ja/en hintReason キー parity 確認

Closes #3598