### PR TITLE
feat(doppelkopf): localize round-end Re/Kontra wins outcome in CUI

### DIFF
--- a/internal/adapter/presenter/DoppelkopfCuiPresenter.go
+++ b/internal/adapter/presenter/DoppelkopfCuiPresenter.go
@@ -80,9 +80,9 @@ func (p *DoppelkopfCuiPresenter) Output(g interfaces.DoppelkopfGame, lastErr err
 			b.WriteString(i18n.T("doppelkopf.promptTrickEndHelp") + "\n")
 		case domain.DoppelkopfPhaseRoundEnd:
 			reWon := g.GetRoundReWon()
-			outcome := "Kontra wins"
+			outcome := i18n.T("doppelkopf.outcomeKontraWins")
 			if reWon {
-				outcome = "Re wins"
+				outcome = i18n.T("doppelkopf.outcomeReWins")
 			}
 			b.WriteString(i18n.Tf("doppelkopf.promptRoundEnd",
 				"rePts", strconv.Itoa(g.GetRoundRePoints()),

--- a/internal/adapter/presenter/DoppelkopfCuiPresenter_test.go
+++ b/internal/adapter/presenter/DoppelkopfCuiPresenter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func makeDoppelkopfPlayers() []*domain.DoppelkopfPlayer {
@@ -82,12 +83,25 @@ func TestDoppelkopfCuiPresenter_Output(t *testing.T) {
 		assert.NotEmpty(t, result)
 	})
 
-	t.Run("round end prompt", func(t *testing.T) {
+	t.Run("round end prompt shows localized Kontra-wins outcome", func(t *testing.T) {
 		m, _ := setupDoppelkopfCuiMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
 		m.On("GetPhase").Return(domain.DoppelkopfPhaseRoundEnd)
-		result := p.Output(m, nil)
-		assert.NotEmpty(t, result)
+		// GetRoundReWon defaults to false -> Kontra wins. Default locale is ja.
+		assert.Contains(t, p.Output(m, nil), "Kontra の勝ち")
+
+		i18n.SetLang("en")
+		defer i18n.SetLang("ja")
+		assert.Contains(t, p.Output(m, nil), "Kontra wins")
+	})
+
+	t.Run("round end prompt shows localized Re-wins outcome", func(t *testing.T) {
+		m, _ := setupDoppelkopfCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.DoppelkopfPhaseRoundEnd)
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetRoundReWon")
+		m.On("GetRoundReWon").Return(true)
+		assert.Contains(t, p.Output(m, nil), "Re の勝ち")
 	})
 
 	t.Run("game end banner", func(t *testing.T) {

--- a/internal/i18n/locales/en/doppelkopf.json
+++ b/internal/i18n/locales/en/doppelkopf.json
@@ -15,6 +15,8 @@
   "promptTrickEnd": "Trick complete",
   "promptTrickEndHelp": "n / next ... go to the next trick",
   "promptRoundEnd": "Round complete (Re {{rePts}} pts, {{outcome}}, {{gamePts}} game pts)",
+  "outcomeReWins": "Re wins",
+  "outcomeKontraWins": "Kontra wins",
   "promptRoundEndHelp": "nr / nextround ... go to the next round",
   "hintNone": "No hint available.",
   "hintCard": "[HINT: {{cards}} ({{reason}})]",

--- a/internal/i18n/locales/ja/doppelkopf.json
+++ b/internal/i18n/locales/ja/doppelkopf.json
@@ -15,6 +15,8 @@
   "promptTrickEnd": "トリック終了",
   "promptTrickEndHelp": "n / next・・・次のトリックへ",
   "promptRoundEnd": "ラウンド終了（Re {{rePts}}点, {{outcome}}, {{gamePts}}ゲームポイント）",
+  "outcomeReWins": "Re の勝ち",
+  "outcomeKontraWins": "Kontra の勝ち",
   "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
   "hintNone": "ヒントはありません。",
   "hintCard": "[HINT: {{cards}} ({{reason}})]",


### PR DESCRIPTION
## 概要
`DoppelkopfCuiPresenter.go` の `DoppelkopfPhaseRoundEnd` 分岐で `"Kontra wins"` / `"Re wins"` が英語直書きされ、ローカライズ済みの `doppelkopf.promptRoundEnd` テンプレートの `outcome` に渡されていた。日本語ロケールでもラウンド勝敗だけ英語表示だった。

## 変更点
- `doppelkopf.json`（ja/en）に `outcomeReWins`（ja: `Re の勝ち`）/ `outcomeKontraWins`（ja: `Kontra の勝ち`）を追加（parity 維持）
- `DoppelkopfCuiPresenter.go`: `outcome` を `i18n.T` 経由で解決
- `DoppelkopfCuiPresenter_test.go`: Kontra 勝ち（ja/en）と Re 勝ち（reWon=true）両分岐のロケール検証テストを追加

## テスト計画
- [x] `go test -tags test ./internal/adapter/presenter/ -run TestDoppelkopfCuiPresenter`（pass）
- [x] `go vet` / `golangci-lint run`（0 issues）
- [x] doppelkopf.json ja/en キー parity 確認

Closes #3405