### PR TITLE
feat(callbreak): render score with the locale's decimal separator

### DIFF
--- a/frontend/src/pages/CallBreakPage.test.tsx
+++ b/frontend/src/pages/CallBreakPage.test.tsx
@@ -4,7 +4,7 @@ import { callBreakApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import { renderWithProviders } from '../test/renderWithProviders';
 import { makeCallBreakState } from '../test/stateFactories';
-import { CallBreakPage } from './CallBreakPage';
+import { CallBreakPage, fmtScore } from './CallBreakPage';
 
 vi.mock('../api/gameApi', () => ({
   callBreakApi: { exec: vi.fn() },
@@ -56,6 +56,21 @@ const cpuTurnState = makeCallBreakState({ currentPlayerIdx: 1 });
 
 beforeEach(() => {
   mockExec.mockResolvedValue(playPhaseState);
+});
+
+describe('fmtScore', () => {
+  it('formats int×10 scores as X.Y for en/ja locales (period separator)', () => {
+    expect(fmtScore(41, 'en')).toBe('4.1');
+    expect(fmtScore(40, 'en')).toBe('4.0');
+    expect(fmtScore(5, 'en')).toBe('0.5');
+    expect(fmtScore(-41, 'en')).toBe('-4.1');
+    expect(fmtScore(105, 'ja')).toBe('10.5');
+  });
+
+  it('uses the locale decimal separator for comma-decimal locales', () => {
+    expect(fmtScore(41, 'de-DE')).toBe('4,1');
+    expect(fmtScore(-5, 'de-DE')).toBe('-0,5');
+  });
 });
 
 describe('CallBreakPage', () => {

--- a/frontend/src/pages/CallBreakPage.tsx
+++ b/frontend/src/pages/CallBreakPage.tsx
@@ -29,6 +29,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import i18n from '../i18n';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -41,14 +42,18 @@ import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 
 /**
- * Render a Call Break int×10 score (e.g. 41) as "X.Y" / "-X.Y" for the UI.
- * Mirrors `FormatCallBreakScore` in the Go backend so the wire integer round-trips
- * to the same display string on both sides.
+ * Render a Call Break int×10 score (e.g. 41) as "X.Y" for the UI, using the
+ * active locale's decimal separator. Mirrors `FormatCallBreakScore` in the Go
+ * backend for ja/en (both use "."), while a locale that formats decimals with a
+ * comma (e.g. "de-DE") renders "X,Y" instead of a hardcoded period. The `locale`
+ * parameter defaults to the active i18n language and is injectable for testing.
  */
-function fmtScore(internal: number): string {
-  const sign = internal < 0 ? '-' : '';
-  const n = Math.abs(internal);
-  return `${sign}${Math.trunc(n / 10)}.${n % 10}`;
+export function fmtScore(internal: number, locale: string = i18n.language): string {
+  return new Intl.NumberFormat(locale, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+    useGrouping: false,
+  }).format(internal / 10);
 }
 
 /** Call Break tutorial step definitions. */


### PR DESCRIPTION
## 概要
`CallBreakPage.tsx` の `fmtScore` は `${sign}${Math.trunc(n/10)}.${n%10}` と小数点をピリオド固定で手書き連結しており、int×10 スコア表示がロケールの数値規約を無視していた。

## 変更点
- `fmtScore` を `Intl.NumberFormat(locale, { minimumFractionDigits: 1, maximumFractionDigits: 1, useGrouping: false })` ベースに変更。`locale` 引数は `i18n.language` をデフォルトにし、テスト用に注入可能
- ja/en は従来通り `"4.1"`（ピリオド）で後方互換、カンマ小数ロケール（例: de-DE）では `"4,1"` になる
- `fmtScore` を export し、ピリオド/カンマ両ロケールの単体テストを追加

## 互換性
`FormatCallBreakScore`（Go）と ja/en で同一のフォーマット。旧実装と全値域で一致することを確認済み（0/1/5/10/41/-41/105/125 等）。

## テスト計画
- [x] `bun run test -- --run src/pages/CallBreakPage.test.tsx`（22 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）

Closes #3302