### PR TITLE
feat(poker-cui): localize poker hand names in UTH and Mississippi Stud CUI

### DIFF
--- a/internal/adapter/presenter/MississippiStudCuiPresenter.go
+++ b/internal/adapter/presenter/MississippiStudCuiPresenter.go
@@ -62,7 +62,7 @@ func (mp *MississippiStudCuiPresenter) Output(g interfaces.MississippiStudGame, 
 
 		if g.GetGameEndFlag() {
 			if rank := g.GetHandRank(); rank >= 0 && rank < len(domain.PokerHandNames) && !g.GetFolded() {
-				fmt.Fprintf(b, "%s\n", i18n.Tf("mississippistud.handLine", "hand", domain.PokerHandNames[rank]))
+				fmt.Fprintf(b, "%s\n", i18n.Tf("mississippistud.handLine", "hand", cuiPokerHandName(rank)))
 			}
 			switch g.GetResult() {
 			case domain.GameResultWin:

--- a/internal/adapter/presenter/MississippiStudCuiPresenter_test.go
+++ b/internal/adapter/presenter/MississippiStudCuiPresenter_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupMississippiStudCuiMockDefaults(m *interfaces.MockMississippiStudGame) {
@@ -115,8 +116,13 @@ func TestMississippiStudCuiPresenter_Output_Win(t *testing.T) {
 	m.On("GetTotalPayout").Return(1200)
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "One Pair")
+	// The One Pair rank is localized (ja by default), not raw English.
+	assert.Contains(t, result, "ワンペア")
 	assert.Contains(t, result, "1200")
+
+	i18n.SetLang("en")
+	defer i18n.SetLang("ja")
+	assert.Contains(t, p.Output(m, nil), "One Pair")
 }
 
 func TestMississippiStudCuiPresenter_Output_Push(t *testing.T) {

--- a/internal/adapter/presenter/UltimateTexasHoldemCuiPresenter.go
+++ b/internal/adapter/presenter/UltimateTexasHoldemCuiPresenter.go
@@ -39,7 +39,7 @@ func (up *UltimateTexasHoldemCuiPresenter) Output(g interfaces.UltimateTexasHold
 		if g.GetPhase() == domain.UltimateTexasHoldemPhaseEnd {
 			rank := g.GetPlayerHandRank()
 			if rank >= 0 && rank < len(domain.PokerHandNames) {
-				fmt.Fprintf(&sb, "%s\n", i18n.Tf("ultimatetexasholdem.handLine", "hand", domain.PokerHandNames[rank]))
+				fmt.Fprintf(&sb, "%s\n", i18n.Tf("ultimatetexasholdem.handLine", "hand", cuiPokerHandName(rank)))
 			}
 		}
 		parts := make([]string, len(playerHand))
@@ -55,7 +55,7 @@ func (up *UltimateTexasHoldemCuiPresenter) Output(g interfaces.UltimateTexasHold
 		if g.GetPhase() == domain.UltimateTexasHoldemPhaseEnd {
 			rank := g.GetDealerHandRank()
 			if rank >= 0 && rank < len(domain.PokerHandNames) {
-				fmt.Fprintf(&sb, "%s\n", i18n.Tf("ultimatetexasholdem.handLine", "hand", domain.PokerHandNames[rank]))
+				fmt.Fprintf(&sb, "%s\n", i18n.Tf("ultimatetexasholdem.handLine", "hand", cuiPokerHandName(rank)))
 			}
 			parts := make([]string, len(dealerHand))
 			for i, card := range dealerHand {

--- a/internal/adapter/presenter/UltimateTexasHoldemCuiPresenter_test.go
+++ b/internal/adapter/presenter/UltimateTexasHoldemCuiPresenter_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupUltimateTexasHoldemCuiMockDefaults(m *interfaces.MockUltimateTexasHoldemGame) {
@@ -120,6 +121,13 @@ func TestUltimateTexasHoldemCuiPresenter_Output_EndPhase_PlayerWins(t *testing.T
 
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "1100")
+	// The player's One Pair rank is localized (ja by default), not raw English.
+	assert.Contains(t, result, "ワンペア")
+	assert.NotContains(t, result, "One Pair")
+
+	i18n.SetLang("en")
+	defer i18n.SetLang("ja")
+	assert.Contains(t, p.Output(m, nil), "One Pair")
 }
 
 func TestUltimateTexasHoldemCuiPresenter_Output_EndPhase_Folded(t *testing.T) {

--- a/internal/adapter/presenter/cui_card_helper.go
+++ b/internal/adapter/presenter/cui_card_helper.go
@@ -109,6 +109,18 @@ func cuiSuitName(suit int) string {
 	return "UNKNOWN"
 }
 
+// cuiPokerHandName returns the localized display name for a poker hand rank
+// (0=High Card .. 10=Five of a Kind), resolved via the shared pokerHandRank*
+// keys in cui_common. Out-of-range ranks fall back to the raw English
+// domain.PokerHandNames entry (or "" when the index is invalid). Used by the
+// UltimateTexasHoldem and MississippiStud CUI presenters.
+func cuiPokerHandName(rank int) string {
+	if rank < 0 || rank >= len(domain.PokerHandNames) {
+		return ""
+	}
+	return i18n.T("pokerHandRank" + strconv.Itoa(rank))
+}
+
 // cuiPlayerName returns the human-friendly display name for a player:
 // "You" / "あなた" for the human, "CPU N" for CPU opponents, or
 // "UNKNOWN" if the player is nil/zero. Locale-aware via i18n.T (issue

--- a/internal/adapter/presenter/cui_card_helper_test.go
+++ b/internal/adapter/presenter/cui_card_helper_test.go
@@ -82,6 +82,22 @@ func TestCuiSuitName(t *testing.T) {
 	}
 }
 
+func TestCuiPokerHandName(t *testing.T) {
+	orig := i18n.Lang()
+	i18n.SetLang("ja")
+	defer i18n.SetLang(orig)
+
+	assert.Equal(t, "ハイカード", cuiPokerHandName(0))
+	assert.Equal(t, "ロイヤルフラッシュ", cuiPokerHandName(9))
+	assert.Equal(t, "ファイブカード", cuiPokerHandName(10))
+	// Out-of-range ranks fall back to an empty string.
+	assert.Equal(t, "", cuiPokerHandName(-1))
+	assert.Equal(t, "", cuiPokerHandName(999))
+
+	i18n.SetLang("en")
+	assert.Equal(t, "Royal Flush", cuiPokerHandName(9))
+}
+
 // mockCuiPlayer implements the cuiPlayer interface for testing.
 type mockCuiPlayer struct {
 	isHuman bool

--- a/internal/i18n/locales/en/cui_common.json
+++ b/internal/i18n/locales/en/cui_common.json
@@ -24,5 +24,16 @@
   "cuiSolitaireGameClear": "Game clear!",
   "cuiSolitaireGameOver": "Game over",
   "cuiSolitaireMoves": "Moves: {{count}}",
-  "cuiEmptyCol": "[empty]"
+  "cuiEmptyCol": "[empty]",
+  "pokerHandRank0": "High Card",
+  "pokerHandRank1": "One Pair",
+  "pokerHandRank2": "Two Pair",
+  "pokerHandRank3": "Three of a Kind",
+  "pokerHandRank4": "Straight",
+  "pokerHandRank5": "Flush",
+  "pokerHandRank6": "Full House",
+  "pokerHandRank7": "Four of a Kind",
+  "pokerHandRank8": "Straight Flush",
+  "pokerHandRank9": "Royal Flush",
+  "pokerHandRank10": "Five of a Kind"
 }

--- a/internal/i18n/locales/ja/cui_common.json
+++ b/internal/i18n/locales/ja/cui_common.json
@@ -24,5 +24,16 @@
   "cuiSolitaireGameClear": "ゲームクリア！",
   "cuiSolitaireGameOver": "ゲームオーバー",
   "cuiSolitaireMoves": "手数: {{count}}",
-  "cuiEmptyCol": "[空]"
+  "cuiEmptyCol": "[空]",
+  "pokerHandRank0": "ハイカード",
+  "pokerHandRank1": "ワンペア",
+  "pokerHandRank2": "ツーペア",
+  "pokerHandRank3": "スリーカード",
+  "pokerHandRank4": "ストレート",
+  "pokerHandRank5": "フラッシュ",
+  "pokerHandRank6": "フルハウス",
+  "pokerHandRank7": "フォーカード",
+  "pokerHandRank8": "ストレートフラッシュ",
+  "pokerHandRank9": "ロイヤルフラッシュ",
+  "pokerHandRank10": "ファイブカード"
 }


### PR DESCRIPTION
## 概要
`UltimateTexasHoldemCuiPresenter.go` と `MississippiStudCuiPresenter.go` は終局時の役表示で `domain.PokerHandNames[rank]` を直接埋め込んでおり、日本語ロケールでも「Royal Flush」等の英語役名が出ていた。Web 版は `handRank.*` で i18n 済みで CUI だけ英語固定だった。

## 変更点
- `cui_common.json`（ja/en）に共通キー `pokerHandRank0`〜`pokerHandRank10`（0=ハイカード〜10=ファイブカード）を追加
- `cui_card_helper.go` に共通ヘルパー `cuiPokerHandName(rank)` を追加（範囲外は空文字フォールバック）
- 両プレゼンターを `cuiPokerHandName(rank)` 経由に統一（ポーカー系 CUI の役名解決を共通化）
- 両プレゼンターのテストに ja/en ロケール別の役名検証を追加

## テスト計画
- [x] `go test -tags test ./internal/adapter/presenter/ -run 'TestUltimateTexasHoldemCuiPresenter|TestMississippiStudCuiPresenter'`（pass）
- [x] `go vet` / `golangci-lint run`（0 issues）
- [x] cui_common.json ja/en キー parity 確認

Closes #3255