### PR TITLE
feat(watten): show Schlag rank as a card-face label in CUI

### DIFF
--- a/internal/adapter/presenter/WattenCuiPresenter.go
+++ b/internal/adapter/presenter/WattenCuiPresenter.go
@@ -43,7 +43,7 @@ func (p *WattenCuiPresenter) Output(g interfaces.WattenGame, lastErr error) stri
 
 		if g.GetCriticalSuit() > 0 {
 			out.WriteString(i18n.Tf("watten.declaredLine",
-				"rank", strconv.Itoa(g.GetSchlagRank()),
+				"rank", cuiRankLabel(g.GetSchlagRank()),
 				"suit", cuiSuitName(g.GetCriticalSuit())) + "\n")
 		} else {
 			out.WriteString(i18n.T("watten.undeclared") + "\n")
@@ -119,7 +119,7 @@ func (p *WattenCuiPresenter) HintOutput(g interfaces.WattenGame) string {
 			suit = *hint.Suit
 		}
 		return color.Yellow(i18n.Tf("watten.hintDeclare",
-			"rank", strconv.Itoa(rank),
+			"rank", cuiRankLabel(rank),
 			"suit", cuiSuitName(suit),
 			"reason", reason)) + "\n"
 	case "raise":

--- a/internal/adapter/presenter/WattenCuiPresenter_test.go
+++ b/internal/adapter/presenter/WattenCuiPresenter_test.go
@@ -74,6 +74,17 @@ func TestWattenCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "ステーク: 2")
 	})
 
+	t.Run("declared schlag rank shows a card-face label", func(t *testing.T) {
+		m, _ := setupWattenCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetSchlagRank")
+		m.On("GetSchlagRank").Return(11)
+
+		result := p.Output(m, nil)
+		// Rank 11 is shown as "J", not the raw number.
+		assert.Contains(t, result, "Schlag=J")
+		assert.NotContains(t, result, "Schlag=11")
+	})
+
 	t.Run("undeclared", func(t *testing.T) {
 		m, _ := setupWattenCuiMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCriticalSuit")

--- a/internal/adapter/presenter/cui_card_helper.go
+++ b/internal/adapter/presenter/cui_card_helper.go
@@ -109,6 +109,25 @@ func cuiSuitName(suit int) string {
 	return "UNKNOWN"
 }
 
+// cuiRankLabel returns the card-face label for a rank value: A for 1, J/Q/K for
+// 11/12/13, and the plain number otherwise (7–10). Locale-independent — matches
+// the card-face notation used elsewhere in the UI. Used by the Watten CUI
+// presenter for Schlag-rank display.
+func cuiRankLabel(rank int) string {
+	switch rank {
+	case 1:
+		return "A"
+	case 11:
+		return "J"
+	case 12:
+		return "Q"
+	case 13:
+		return "K"
+	default:
+		return strconv.Itoa(rank)
+	}
+}
+
 // cuiPokerHandName returns the localized display name for a poker hand rank
 // (0=High Card .. 10=Five of a Kind), resolved via the shared pokerHandRank*
 // keys in cui_common. Out-of-range ranks fall back to the raw English

--- a/internal/adapter/presenter/cui_card_helper_test.go
+++ b/internal/adapter/presenter/cui_card_helper_test.go
@@ -82,6 +82,23 @@ func TestCuiSuitName(t *testing.T) {
 	}
 }
 
+func TestCuiRankLabel(t *testing.T) {
+	tests := []struct {
+		rank     int
+		expected string
+	}{
+		{1, "A"},
+		{7, "7"},
+		{10, "10"},
+		{11, "J"},
+		{12, "Q"},
+		{13, "K"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, cuiRankLabel(tt.rank))
+	}
+}
+
 func TestCuiPokerHandName(t *testing.T) {
 	orig := i18n.Lang()
 	i18n.SetLang("ja")


### PR DESCRIPTION
## 概要
`WattenCuiPresenter.go` の `declaredLine` と `hintDeclare` は Schlag ランクを `strconv.Itoa` で生数値（例: J のはずが「11」）として出しており、Web 版（J/Q/K/A ラベル）やカード表記と乖離していた。

## 変更点
- `cui_card_helper.go` に共通ヘルパー `cuiRankLabel(rank)`（1→A、11→J、12→Q、13→K、7-10→数値）を追加
- `WattenCuiPresenter.go`: `declaredLine`（宣言済み行）と `hintDeclare`（ヒント行）両方のランク出力を `cuiRankLabel` 経由に。スートは既存 `cuiSuitName` を継続利用
- `cui_card_helper_test.go` に `TestCuiRankLabel`、`WattenCuiPresenter_test.go` にランク11→「Schlag=J」表示の検証を追加

## 補足
ラベル（A/J/Q/K）はロケール非依存のため `watten.json` の変更は不要（`{{rank}}` プレースホルダが数値の代わりにラベルを受け取るのみ）。

## テスト計画
- [x] `go test -tags test ./internal/adapter/presenter/ -run 'TestWattenCuiPresenter|TestCuiRankLabel'`（pass）
- [x] `go vet` / `golangci-lint run`（0 issues）

Closes #3491