### PR TITLE
feat(spiderette): announce hint and empty-column deal guard via aria-live

### DIFF
--- a/frontend/src/pages/SpiderettePage.test.tsx
+++ b/frontend/src/pages/SpiderettePage.test.tsx
@@ -92,6 +92,22 @@ describe('SpiderettePage', () => {
     expect(screen.getByTestId('spdt-col-0').className).toContain('ring-ds-success');
     // A non-target column is not highlighted.
     expect(screen.getByTestId('spdt-col-2').className).not.toContain('ring-ds-success');
+    // The hint text is exposed to screen readers via an aria-live status region.
+    const status = screen.getByRole('status');
+    expect(status).toHaveAttribute('aria-live', 'polite');
+    expect(status.textContent).toContain('場札');
+  });
+
+  it('announces the empty-column deal guard to screen readers', async () => {
+    renderWithProviders(<SpiderettePage />);
+    // playingState has empty columns and stock remaining, so a deal is guarded.
+    const dealBtn = (await screen.findAllByRole('button', { name: '配る' }))[0];
+    fireEvent.click(dealBtn);
+    await waitFor(() => {
+      const warn = screen.getByText('空の列をすべて埋めないと配れません');
+      expect(warn).toHaveAttribute('role', 'status');
+      expect(warn).toHaveAttribute('aria-live', 'assertive');
+    });
   });
 
   it('renders stock count', async () => {

--- a/frontend/src/pages/SpiderettePage.tsx
+++ b/frontend/src/pages/SpiderettePage.tsx
@@ -321,8 +321,22 @@ function SpiderettePageContent() {
         </div>
 
         {hint && (
-          <div className="text-ds-warning text-sm mb-2">
+          <div className="text-ds-warning text-sm mb-2" role="status" aria-live="polite">
             {t('hintAvailable')}: {t('tableau')} {hint.fromCol} [{hint.cardIndex}] → {t('tableau')} {hint.toCol}
+          </div>
+        )}
+
+        {/* Announce the empty-column deal guard for screen readers; the key
+            forces a remount on each blocked attempt so it re-announces, mirroring
+            the visual shake animation. */}
+        {emptyDealAttemptKey > 0 && (
+          <div
+            key={`deal-warn-${emptyDealAttemptKey.toString()}`}
+            className="sr-only"
+            role="status"
+            aria-live="assertive"
+          >
+            {t('cannotDealEmptyColExists')}
           </div>
         )}
 


### PR DESCRIPTION
## 概要
`SpiderettePage.tsx` のヒント表示行と空列時の再配札ガード（`animate-shake` の視覚アニメーションのみ）に `aria-live` / `role="status"` が無く、スクリーンリーダー利用者に状態変化が伝わらなかった。

## 変更点
- ヒント表示 `<div>` に `role="status" aria-live="polite"` を付与
- 空列ガード発火時（`emptyDealAttemptKey > 0`）に、視覚非表示（`sr-only`）の `role="status" aria-live="assertive"` 領域で `cannotDealEmptyColExists` を通知。`key` を毎回変えて再マウントし、シェイクアニメーション同様に毎回読み上げ
- 既存の視覚スタイルは不変
- ヒント／配札ガード両方の aria 属性を検証するテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/SpiderettePage.test.tsx`（8 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）

Closes #3267