### PR TITLE
feat(contractrummy): add aria-label and aria-pressed to hand card buttons

### DIFF
--- a/frontend/src/i18n/locales/en/contractrummy.json
+++ b/frontend/src/i18n/locales/en/contractrummy.json
@@ -24,6 +24,7 @@
   "meldExtra": "Lay extra meld",
   "layoff": "Lay off",
   "meldAria": "{{player}}'s meld {{meld}}",
+  "cardInSlotAria": "in slot",
   "layoffTargetSummary": "→ Lay off to: {{player}} meld {{meld}}",
   "discard": "Discard card",
   "nextRound": "Next round",

--- a/frontend/src/i18n/locales/ja/contractrummy.json
+++ b/frontend/src/i18n/locales/ja/contractrummy.json
@@ -24,6 +24,7 @@
   "meldExtra": "追加メルド",
   "layoff": "レイオフ",
   "meldAria": "{{player}}のメルド{{meld}}",
+  "cardInSlotAria": "スロット配置済み",
   "layoffTargetSummary": "→ レイオフ先: {{player}} メルド{{meld}}",
   "discard": "カードを捨てる",
   "nextRound": "次のラウンドへ",

--- a/frontend/src/pages/ContractRummyPage.test.tsx
+++ b/frontend/src/pages/ContractRummyPage.test.tsx
@@ -128,6 +128,16 @@ describe('ContractRummyPage', () => {
     );
   });
 
+  it('exposes hand cards as accessible buttons with aria-pressed selection state', async () => {
+    mockExec.mockResolvedValue(playState);
+    renderWithProviders(<ContractRummyPage />);
+    // cardAlt('DIAMOND', 5) => "♦ 5"
+    const cardBtn = await screen.findByRole('button', { name: '♦ 5' });
+    expect(cardBtn).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(cardBtn);
+    await waitFor(() => expect(screen.getByRole('button', { name: '♦ 5' })).toHaveAttribute('aria-pressed', 'true'));
+  });
+
   it('shows next-round button at round end', async () => {
     mockExec.mockResolvedValue(roundEndState);
     renderWithProviders(<ContractRummyPage />);

--- a/frontend/src/pages/ContractRummyPage.tsx
+++ b/frontend/src/pages/ContractRummyPage.tsx
@@ -19,6 +19,7 @@ import { btnDanger, btnOutline, btnPrimary, focusRingWhite } from '../styles/but
 import { gameTheme } from '../styles/gameTheme';
 import type { Card, ContractRummyContractSlot, ContractRummyResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import { evaluateContractSlot } from '../utils/contractRummyUtils';
 
 /** Phase identifiers for Contract Rummy. */
@@ -336,6 +337,8 @@ function ContractRummyPageContent() {
                   key={`${idx}-${c.design}-${c.value}`}
                   onClick={() => toggleCard(idx)}
                   disabled={isInSlot}
+                  aria-pressed={isSelected}
+                  aria-label={isInSlot ? `${cardAlt(c)} (${t('cardInSlotAria')})` : cardAlt(c)}
                   className={`${focusRingWhite} ${isSelected ? 'ring-2 ring-ds-warning' : ''} ${
                     isInSlot ? 'opacity-40' : ''
                   }`}


### PR DESCRIPTION
## 概要
`ContractRummyPage.tsx` の手札ボタンは `AnimatedCard` を入れただけで `aria-label`・`aria-pressed` が無く、スクリーンリーダーでカードの判別も選択状態の確認もできなかった（メルドボタンには `meldAria` があるのに手札だけ無名）。

## 変更点
- 手札の各ボタンに `aria-label={cardAlt(c)}`（`cardAlt` で「♦ 5」等）と `aria-pressed={isSelected}` を追加
- スロット投入済みカード（`isInSlot`）には aria-label に「スロット配置済み」補足を付与（新規キー `cardInSlotAria` ja/en）
- `ContractRummyPage.test.tsx`: アクセシブルネームと aria-pressed のトグルを検証するテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/ContractRummyPage.test.tsx`（18 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）
- [x] contractrummy.json ja/en キー parity 確認

Closes #3251