### PR TITLE
feat(crescent): announce stalemate and redeal count to screen readers

### DIFF
--- a/frontend/src/i18n/locales/en/crescent.json
+++ b/frontend/src/i18n/locales/en/crescent.json
@@ -24,6 +24,7 @@
   "autoCompleteNotReady": "Available when all tops can reach the foundations",
   "undo": "Undo",
   "stalemate": "Stalemate",
+  "stalemateAlert": "Stalemate. Undo {{count}} time(s) to escape.",
   "playing": "Build the eight foundations: 4 ascending from A and 4 descending from K, all by suit",
   "gameClear": "Game Clear! Moves: {{moveCount}}",
   "gameOver": "Game Over",

--- a/frontend/src/i18n/locales/ja/crescent.json
+++ b/frontend/src/i18n/locales/ja/crescent.json
@@ -24,6 +24,7 @@
   "autoCompleteNotReady": "すべての山がファンデーションに移動可能になると有効になります",
   "undo": "戻す",
   "stalemate": "手詰まり",
+  "stalemateAlert": "手詰まりです。アンドゥ {{count}} 回で脱出できます",
   "playing": "8 つのファンデーション (A から昇順 4 + K から降順 4) を同じスートで完成させましょう",
   "gameClear": "ゲームクリア！ 手数: {{moveCount}}",
   "gameOver": "ゲームオーバー",

--- a/frontend/src/pages/CrescentPage.test.tsx
+++ b/frontend/src/pages/CrescentPage.test.tsx
@@ -134,6 +134,14 @@ describe('CrescentPage', () => {
     expect(alert.textContent).toMatch(/2/);
   });
 
+  it('defaults the escape count to 0 when undoToEscape is absent', async () => {
+    mockExec.mockResolvedValue({ ...playingState, isStalemate: true, undoToEscape: undefined });
+    renderWithProviders(<CrescentPage />);
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/手詰まり/);
+    expect(alert.textContent).toMatch(/0/);
+  });
+
   it('clicking redeal dispatches redeal', async () => {
     renderWithProviders(<CrescentPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: /再配り \(3\)/ })).toBeInTheDocument());

--- a/frontend/src/pages/CrescentPage.test.tsx
+++ b/frontend/src/pages/CrescentPage.test.tsx
@@ -120,6 +120,20 @@ describe('CrescentPage', () => {
     expect(screen.getByRole('button', { name: /再配り \(3\)/ })).toBeInTheDocument();
   });
 
+  it('exposes the redeal count via an aria-live status region', async () => {
+    renderWithProviders(<CrescentPage />);
+    const status = await screen.findByText(/残り再配り回数/);
+    expect(status).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('announces a stalemate via a role=alert region', async () => {
+    mockExec.mockResolvedValue({ ...playingState, isStalemate: true, undoToEscape: 2 });
+    renderWithProviders(<CrescentPage />);
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/手詰まり/);
+    expect(alert.textContent).toMatch(/2/);
+  });
+
   it('clicking redeal dispatches redeal', async () => {
     renderWithProviders(<CrescentPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: /再配り \(3\)/ })).toBeInTheDocument());

--- a/frontend/src/pages/CrescentPage.tsx
+++ b/frontend/src/pages/CrescentPage.tsx
@@ -214,7 +214,9 @@ function CrescentPageContent() {
           <span>
             {t('moveCount')}: {state.moveCount}
           </span>
-          <span>{t('redealsLeft', { count: state.redealsRemaining })}</span>
+          <span role="status" aria-live="polite">
+            {t('redealsLeft', { count: state.redealsRemaining })}
+          </span>
           <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
         </>
       }
@@ -457,11 +459,17 @@ function CrescentPageContent() {
                     {t('undo')}
                   </button>
                   {state.isStalemate && (
-                    <StalemateEscapeButton
-                      undoToEscape={state.undoToEscape ?? 0}
-                      onEscape={handleUndoEscape}
-                      disabled={loading || isAutoCompleting}
-                    />
+                    <>
+                      {/* role=alert announces the stalemate the moment it appears. */}
+                      <div className="sr-only" role="alert">
+                        {t('stalemateAlert', { count: state.undoToEscape ?? 0 })}
+                      </div>
+                      <StalemateEscapeButton
+                        undoToEscape={state.undoToEscape ?? 0}
+                        onEscape={handleUndoEscape}
+                        disabled={loading || isAutoCompleting}
+                      />
+                    </>
                   )}
                   <button
                     type="button"


### PR DESCRIPTION
## 概要
`CrescentPage.tsx` は `isStalemate` 時に `StalemateEscapeButton` を出すだけで live region が無く、スクリーンリーダー利用者は手詰まりに気付けなかった。redeal 残数の変化も無通知だった。

## 変更点
- 手詰まり時に視覚非表示（`sr-only`）の `role="alert"` 領域で「手詰まりです。アンドゥ N 回で脱出できます」を通知（新規キー `stalemateAlert` ja/en）。`role=alert` は挿入時に読み上げられる
- redeal 残数ヘッダーの span に `role="status" aria-live="polite"` を付与し、残数変化を通知
- `CrescentPage.test.tsx`: 手詰まり alert と redeal aria-live の両方を検証するテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/CrescentPage.test.tsx`（21 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）
- [x] crescent.json ja/en キー parity 確認

Closes #3258