### PR TITLE
feat(egyptianratscrew): announce slap results to screen readers

### DIFF
--- a/frontend/src/i18n/locales/en/egyptianratscrew.json
+++ b/frontend/src/i18n/locales/en/egyptianratscrew.json
@@ -38,6 +38,10 @@
       "pair": "PAIR!",
       "sandwich": "SANDWICH!",
       "miss": "MISS!"
+    },
+    "slapAnnounce": {
+      "correct": "{{player}} slapped correctly ({{reason}})",
+      "wrong": "{{player}} slapped incorrectly"
     }
   },
   "hint": {

--- a/frontend/src/i18n/locales/ja/egyptianratscrew.json
+++ b/frontend/src/i18n/locales/ja/egyptianratscrew.json
@@ -38,6 +38,10 @@
       "pair": "ペア！",
       "sandwich": "サンドイッチ！",
       "miss": "ミス！"
+    },
+    "slapAnnounce": {
+      "correct": "{{player}}がスラップ成功（{{reason}}）",
+      "wrong": "{{player}}がスラップ失敗"
     }
   },
   "hint": {

--- a/frontend/src/pages/EgyptianRatscrewPage.test.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.test.tsx
@@ -4,7 +4,7 @@ import { egyptianRatscrewApi } from '../api/gameApi';
 import { useCliMode } from '../hooks/useCliMode';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { EgyptianRatscrewResponse } from '../types/card';
-import { EgyptianRatscrewPhase, EgyptianRatscrewSlapReason } from '../types/phases';
+import { EgyptianRatscrewEventKind, EgyptianRatscrewPhase, EgyptianRatscrewSlapReason } from '../types/phases';
 import { EgyptianRatscrewPage } from './EgyptianRatscrewPage';
 
 vi.mock('../hooks/useCliMode', () => ({
@@ -120,6 +120,32 @@ describe('EgyptianRatscrewPage', () => {
     await waitFor(() => expect(screen.getByTestId('slap-button')).toBeInTheDocument());
     fireEvent.click(screen.getByTestId('slap-button'));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('slap'));
+  });
+
+  it('announces a correct sandwich slap to screen readers', async () => {
+    mockExec.mockResolvedValue({
+      ...slappableState,
+      lastEventKind: EgyptianRatscrewEventKind.SLAP_CORRECT,
+      lastEventPlayerIdx: 0,
+      lastSlapReason: EgyptianRatscrewSlapReason.SANDWICH,
+    });
+    renderWithProviders(<EgyptianRatscrewPage />);
+    await waitFor(() => {
+      const announce = screen.getByTestId('er-slap-announce');
+      expect(announce).toHaveAttribute('aria-live', 'polite');
+      expect(announce.textContent).toMatch(/スラップ成功/);
+      expect(announce.textContent).toMatch(/サンドイッチ/);
+    });
+  });
+
+  it('announces a wrong slap to screen readers', async () => {
+    mockExec.mockResolvedValue({
+      ...slappableState,
+      lastEventKind: EgyptianRatscrewEventKind.SLAP_WRONG,
+      lastEventPlayerIdx: 1,
+    });
+    renderWithProviders(<EgyptianRatscrewPage />);
+    await waitFor(() => expect(screen.getByTestId('er-slap-announce').textContent).toMatch(/スラップ失敗/));
   });
 
   it('disables slap button when pile is empty', async () => {

--- a/frontend/src/pages/EgyptianRatscrewPage.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.tsx
@@ -87,9 +87,15 @@ function EgyptianRatscrewPageContent() {
     outcome: 'correct',
     label: '',
   });
+  const [slapAnnounce, setSlapAnnounce] = useState('');
   const prevSlapEventRef = useRef<{ kind: number; player: number }>({ kind: -1, player: -1 });
   useEffect(() => {
-    if (!state) return;
+    if (!state) {
+      // A reset blanks `state` momentarily; clear the live region so a fresh
+      // game never surfaces the previous round's stale announcement.
+      setSlapAnnounce('');
+      return;
+    }
     const kind = state.lastEventKind;
     const player = state.lastEventPlayerIdx;
     const prev = prevSlapEventRef.current;
@@ -107,9 +113,19 @@ function EgyptianRatscrewPageContent() {
       // Incrementing counter is more robust than Date.now() for trigger keys:
       // back-to-back events within the same ms still register as distinct.
       setSlapBurst((prevBurst) => ({ key: prevBurst.key + 1, outcome, label }));
+      const slapper = player === 0 ? tc('player.you') : tc('player.cpu', { id: player });
+      if (outcome === 'correct') {
+        const reason =
+          state.lastSlapReason === EgyptianRatscrewSlapReason.SANDWICH
+            ? t('egyptianratscrew.slapReason.sandwich')
+            : t('egyptianratscrew.slapReason.pair');
+        setSlapAnnounce(t('egyptianratscrew.slapAnnounce.correct', { player: slapper, reason }));
+      } else {
+        setSlapAnnounce(t('egyptianratscrew.slapAnnounce.wrong', { player: slapper }));
+      }
       prevSlapEventRef.current = { kind, player };
     }
-  }, [state, t]);
+  }, [state, t, tc]);
 
   useMountReset(execApi);
 
@@ -239,6 +255,16 @@ function EgyptianRatscrewPageContent() {
               data-tutorial="er-arena"
             >
               <SlapBurst triggerKey={slapBurst.key} outcome={slapBurst.outcome} label={slapBurst.label} />
+              {/* Screen-reader announcement for the slap outcome (parity with Slapjack #2607). */}
+              <div
+                className="sr-only"
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+                data-testid="er-slap-announce"
+              >
+                {slapAnnounce}
+              </div>
               <div className="text-center">
                 <div className="text-sm text-ds-text-primary font-semibold">
                   {t('label.pileCount', { count: state.centerPileSize })}


### PR DESCRIPTION
## 概要
Slapjack では #2607 でスラップ成否を通知する sr-only live region が追加されたが、同じ SlapBurst ベースの `EgyptianRatscrewPage.tsx` には相当実装がなく、スラップ結果（ペア/サンドイッチ）が支援技術に伝わらなかった。

## 変更点
- Slapjack の `slapAnnounce` パターンを移植: `SLAP_CORRECT`/`SLAP_WRONG` 検知時に `slapAnnounce` state を設定（correct は成立理由 pair/sandwich も含む）し、視覚非表示（`sr-only`）の `role="status" aria-live="polite" aria-atomic="true"` 領域（`er-slap-announce`）で読み上げ。リセット時（state=null）にクリア
- `egyptianratscrew.json`（ja/en）に `slapAnnounce.correct`/`.wrong` を追加（parity 維持）
- `EgyptianRatscrewPage.test.tsx`: 成功（サンドイッチ）と失敗の両方の通知を検証するテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/EgyptianRatscrewPage.test.tsx`（21 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）
- [x] egyptianratscrew.json ja/en key-for-key parity 確認

Closes #3226