### PR TITLE
feat(nertz): announce foundation placements and collisions to screen readers

### DIFF
--- a/frontend/src/i18n/locales/en/nertz.json
+++ b/frontend/src/i18n/locales/en/nertz.json
@@ -54,5 +54,10 @@
     "foundations": "The central foundations are shared. Start with an Ace and build up by suit.",
     "stock": "Draw from the stock to pull more cards through your waste.",
     "resetButton": "Reset to start a new game."
+  },
+  "foundationAnnounce": {
+    "human": "You placed on foundation {{foundation}}",
+    "cpu": "CPU placed on foundation {{foundation}}",
+    "collision": "Move to foundation {{foundation}} rejected"
   }
 }

--- a/frontend/src/i18n/locales/ja/nertz.json
+++ b/frontend/src/i18n/locales/ja/nertz.json
@@ -54,5 +54,10 @@
     "foundations": "中央のファウンデーションは全員共有。Aから同スートで積み上げます。",
     "stock": "ストックを引いてウェイスト経由で使えるカードを増やしましょう。",
     "resetButton": "リセットでもう一度遊べます。"
+  },
+  "foundationAnnounce": {
+    "human": "ファウンデーション{{foundation}}にあなたが配置",
+    "cpu": "ファウンデーション{{foundation}}にCPUが配置",
+    "collision": "ファウンデーション{{foundation}}への移動が失敗"
   }
 }

--- a/frontend/src/pages/NertzPage.test.tsx
+++ b/frontend/src/pages/NertzPage.test.tsx
@@ -267,6 +267,24 @@ describe('NertzPage', () => {
     });
   });
 
+  it("announces the human's own foundation placement", async () => {
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/nertz']}>
+        <NertzPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByAltText('♥ 7')).toBeInTheDocument());
+    fireEvent.click(screen.getByAltText('♥ 7').closest('button') as HTMLElement);
+    // The move to foundation 0 succeeds and grows it, so pendingFoundationRef → 0
+    // makes the growth attribute to the human.
+    const grown: NertzResponse['foundations'] = Array.from({ length: 8 }, () => ({ suit: -1, size: 0 }));
+    grown[0] = { suit: 3, size: 1, top: { design: 'HEART', value: 1 } };
+    mockExec.mockClear();
+    mockExec.mockResolvedValue({ ...playingState, foundations: grown });
+    fireEvent.click(screen.getByLabelText(/ファウンデーション0|Foundation 0/));
+    await waitFor(() => expect(screen.getByTestId('nertz-announce').textContent).toMatch(/あなたが配置/));
+  });
+
   it('announces a collision when a foundation move is rejected', async () => {
     renderWithProviders(
       <MemoryRouter initialEntries={['/nertz']}>

--- a/frontend/src/pages/NertzPage.test.tsx
+++ b/frontend/src/pages/NertzPage.test.tsx
@@ -251,6 +251,36 @@ describe('NertzPage', () => {
     );
   });
 
+  it('announces a foundation placement to screen readers', async () => {
+    const foundations: NertzResponse['foundations'] = Array.from({ length: 8 }, () => ({ suit: -1, size: 0 }));
+    foundations[2] = { suit: 3, size: 1, top: { design: 'HEART', value: 1 } };
+    mockExec.mockResolvedValue({ ...playingState, foundations });
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/nertz']}>
+        <NertzPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      const announce = screen.getByTestId('nertz-announce');
+      expect(announce).toHaveAttribute('aria-live', 'polite');
+      expect(announce.textContent).toMatch(/ファウンデーション3/);
+    });
+  });
+
+  it('announces a collision when a foundation move is rejected', async () => {
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/nertz']}>
+        <NertzPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByAltText('♥ 7')).toBeInTheDocument());
+    fireEvent.click(screen.getByAltText('♥ 7').closest('button') as HTMLElement);
+    mockExec.mockClear();
+    mockExec.mockRejectedValue(new Error('invalid move'));
+    fireEvent.click(screen.getByLabelText(/ファウンデーション0|Foundation 0/));
+    await waitFor(() => expect(screen.getByTestId('nertz-announce').textContent).toMatch(/移動が失敗/));
+  });
+
   it('shows the next-round button at round end', async () => {
     mockExec.mockResolvedValue(roundEndState);
     renderWithProviders(

--- a/frontend/src/pages/NertzPage.tsx
+++ b/frontend/src/pages/NertzPage.tsx
@@ -140,6 +140,7 @@ function NertzPageContent() {
   );
 
   const [collidedFoundationIdx, setCollidedFoundationIdx] = useState<number | null>(null);
+  const [foundationAnnounce, setFoundationAnnounce] = useState('');
   const [collisionTick, setCollisionTick] = useState(0);
   /**
    * Map of foundation index → active placement flash. Multiple CPUs (or a CPU
@@ -190,6 +191,10 @@ function NertzPageContent() {
         }
         return next;
       });
+      const lastIdx = grown[grown.length - 1];
+      setFoundationAnnounce(
+        t(humanIdx === lastIdx ? 'foundationAnnounce.human' : 'foundationAnnounce.cpu', { foundation: lastIdx + 1 }),
+      );
       // Schedule a removal for each idx independently so the visible flash
       // duration is constant regardless of when sibling flashes start.
       for (const idx of grown) {
@@ -205,14 +210,16 @@ function NertzPageContent() {
     }
     prevFoundationSizesRef.current = state.foundations.map((f) => f.size);
     pendingFoundationRef.current = null;
-  }, [state]);
+  }, [state, t]);
 
   useEffect(() => {
     if (error && error !== prevErrorRef.current) {
       if (pendingFoundationRef.current !== null) {
-        setCollidedFoundationIdx(pendingFoundationRef.current);
+        const collidedIdx = pendingFoundationRef.current;
+        setCollidedFoundationIdx(collidedIdx);
         setCollisionTick((n) => n + 1);
         setIsCollisionError(true);
+        setFoundationAnnounce(t('foundationAnnounce.collision', { foundation: collidedIdx + 1 }));
         pendingFoundationRef.current = null;
       } else {
         setIsCollisionError(false);
@@ -221,7 +228,7 @@ function NertzPageContent() {
       setIsCollisionError(false);
     }
     prevErrorRef.current = error;
-  }, [error]);
+  }, [error, t]);
 
   useEffect(() => {
     // `collisionTick` ensures repeated collisions on the same foundation reset the timer.
@@ -333,6 +340,9 @@ function NertzPageContent() {
       ) : (
         <>
           <div className="flex-1 overflow-y-auto px-3 py-2 space-y-4">
+            <div className="sr-only" role="status" aria-live="polite" aria-atomic="true" data-testid="nertz-announce">
+              {foundationAnnounce}
+            </div>
             <div className="bg-black/30 text-ds-text-primary p-3 rounded text-sm">
               <div className="flex flex-wrap gap-x-4 gap-y-1">
                 <span>

--- a/frontend/src/pages/NertzPage.tsx
+++ b/frontend/src/pages/NertzPage.tsx
@@ -191,9 +191,13 @@ function NertzPageContent() {
         }
         return next;
       });
-      const lastIdx = grown[grown.length - 1];
+      // Prefer announcing the human's own placement when it grew this tick, so a
+      // simultaneous CPU growth never drowns out the player's own action.
+      const announceIdx = humanIdx !== null && grown.includes(humanIdx) ? humanIdx : grown[grown.length - 1];
       setFoundationAnnounce(
-        t(humanIdx === lastIdx ? 'foundationAnnounce.human' : 'foundationAnnounce.cpu', { foundation: lastIdx + 1 }),
+        t(announceIdx === humanIdx ? 'foundationAnnounce.human' : 'foundationAnnounce.cpu', {
+          foundation: announceIdx + 1,
+        }),
       );
       // Schedule a removal for each idx independently so the visible flash
       // duration is constant regardless of when sibling flashes start.


### PR DESCRIPTION
## 概要
`NertzPage.tsx` のファウンデーション成功フラッシュと衝突フィードバックは視覚のみで、リアルタイムに変化する盤面イベントが支援技術に伝わらなかった（Slapjack #2607 と同種の問題）。

## 変更点
- 視覚非表示（`sr-only`）の `role="status" aria-live="polite" aria-atomic="true"` 領域（`nertz-announce`）を追加
- ファウンデーション成長検知の useEffect で「ファウンデーションNにあなた/CPUが配置」、衝突 useEffect で「ファウンデーションNへの移動が失敗」を `t()` 経由でセット
- `nertz.json`（ja/en）に `foundationAnnounce.human`/`.cpu`/`.collision` を追加（parity 維持）
- `NertzPage.test.tsx`: 配置通知と衝突通知の両方を検証するテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/NertzPage.test.tsx`（20 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）
- [x] nertz.json ja/en key-for-key parity 確認

Closes #3222