### PR TITLE
feat(tonk): make the undercut warning touch- and screen-reader-accessible

### DIFF
--- a/frontend/src/pages/TonkPage.test.tsx
+++ b/frontend/src/pages/TonkPage.test.tsx
@@ -87,6 +87,12 @@ describe('TonkPage', () => {
     expect(knock.className).toContain('ring-ds-warning');
     expect(knock.className).toContain('motion-safe:animate-pulse');
     expect(knock.textContent).toContain('⚠️');
+    // A visible, screen-reader-announced warning accompanies the button (not just the hover title).
+    const warning = screen.getByTestId('tonk-undercut-warning');
+    expect(warning).toHaveAttribute('role', 'status');
+    const title = knock.getAttribute('title');
+    expect(title).toBeTruthy();
+    expect(warning.textContent).toContain(title as string);
   });
 
   const meldHandState = () =>
@@ -193,5 +199,6 @@ describe('TonkPage', () => {
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /ノック/ })).not.toHaveAttribute('data-undercut-risk'),
     );
+    expect(screen.queryByTestId('tonk-undercut-warning')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/TonkPage.tsx
+++ b/frontend/src/pages/TonkPage.tsx
@@ -426,6 +426,16 @@ function TonkPageContent() {
                       </span>
                     )}
                   </button>
+                  {undercutRisk && (
+                    <div
+                      className="text-ds-warning text-xs w-full text-center"
+                      role="status"
+                      data-testid="tonk-undercut-warning"
+                    >
+                      <span aria-hidden="true">⚠️ </span>
+                      {t('knockUndercutWarning')}
+                    </div>
+                  )}
                 </>
               )}
               {isRoundEnd && (


### PR DESCRIPTION
## 概要
`TonkPage.tsx` の Knock ボタンのアンダーカット警告は `title` ツールチップ（タッチデバイスで非表示）＋ `aria-hidden` の ⚠️ のみで、警告理由がマウスホバーでしか確認できなかった。

## 変更点
- Knock ボタンの直後に、可視の `role="status"` 警告テキスト行（`tonk-undercut-warning`、`t('knockUndercutWarning')`）を追加。タッチでも文言が見え、スクリーンリーダーでも読み上げられる
- 既存の `title` 属性・`data-undercut-risk` 属性・ボタン内 ⚠️ は維持（後方互換）
- `TonkPage.test.tsx`: 可視警告の表示（role=status・文言一致）とリセット後の消去を検証

## 補足
i18n キー `knockUndercutWarning` は既存のものを再利用（json 変更なし）。

## テスト計画
- [x] `bun run test -- --run src/pages/TonkPage.test.tsx`（6 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）

Closes #3234