### PR TITLE
feat(bakersdozen): advertise keyboard shortcuts on control buttons

### DIFF
--- a/frontend/src/i18n/locales/en/bakersdozen.json
+++ b/frontend/src/i18n/locales/en/bakersdozen.json
@@ -35,5 +35,11 @@
   "hintReason": {
     "toFoundation": "Send this card to the foundation to free up the column.",
     "toTableau": "Apply the suggested tableau move to unlock buried cards."
+  },
+  "kbd": {
+    "undo": "Z",
+    "hint": "H",
+    "autoComplete": "A",
+    "giveUp": "G"
   }
 }

--- a/frontend/src/i18n/locales/ja/bakersdozen.json
+++ b/frontend/src/i18n/locales/ja/bakersdozen.json
@@ -35,5 +35,11 @@
   "hintReason": {
     "toFoundation": "このカードを組札に上げると後の展開が楽になります",
     "toTableau": "示唆された場札への移動でロックされたカードを動かしましょう"
+  },
+  "kbd": {
+    "undo": "Z",
+    "hint": "H",
+    "autoComplete": "A",
+    "giveUp": "G"
   }
 }

--- a/frontend/src/pages/BakersDozenPage.test.tsx
+++ b/frontend/src/pages/BakersDozenPage.test.tsx
@@ -144,6 +144,17 @@ describe('BakersDozenPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());
   });
 
+  it('advertises the keyboard shortcuts on the control buttons', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<BakersDozenPage />);
+    const giveUp = await screen.findByRole('button', { name: 'ギブアップ' });
+    expect(giveUp).toHaveAttribute('aria-keyshortcuts', 'g');
+    expect(giveUp.querySelector('kbd')?.textContent).toBe('G');
+    // The KbdBadge text is aria-hidden, so the hint button's accessible name stays clean.
+    const hint = screen.getByRole('button', { name: 'ヒント' });
+    expect(hint).toHaveAttribute('aria-keyshortcuts', 'h');
+  });
+
   it('hides giveup button when game cleared', async () => {
     mockExec.mockResolvedValue(gameClearState);
     renderWithProviders(<BakersDozenPage />);

--- a/frontend/src/pages/BakersDozenPage.tsx
+++ b/frontend/src/pages/BakersDozenPage.tsx
@@ -11,6 +11,7 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
+import { KbdBadge } from '../components/KbdBadge';
 import { LandscapeBanner } from '../components/LandscapeBanner';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
@@ -467,8 +468,10 @@ function BakersDozenPageContent() {
                     className={btnPrimary}
                     onClick={handleUndo}
                     disabled={loading || isAutoCompleting || !state.canUndo}
+                    aria-keyshortcuts="z"
                   >
                     {t('undo')}
+                    <KbdBadge label={t('kbd.undo')} />
                   </button>
                   {state.isStalemate && (
                     <StalemateEscapeButton
@@ -482,8 +485,10 @@ function BakersDozenPageContent() {
                     className={btnSuccess}
                     onClick={handleHint}
                     disabled={loading || isAutoCompleting}
+                    aria-keyshortcuts="h"
                   >
                     {t('hint')}
+                    <KbdBadge label={t('kbd.hint')} />
                   </button>
                   <button
                     type="button"
@@ -491,16 +496,20 @@ function BakersDozenPageContent() {
                     onClick={handleAutoComplete}
                     disabled={loading || isAutoCompleting}
                     data-testid="autocomplete-button"
+                    aria-keyshortcuts="a"
                   >
                     {t('autoComplete')}
+                    <KbdBadge label={t('kbd.autoComplete')} />
                   </button>
                   <button
                     type="button"
                     className={btnDanger}
                     onClick={confirmGiveUpAction}
                     disabled={loading || isAutoCompleting}
+                    aria-keyshortcuts="g"
                   >
                     {t('giveup')}
+                    <KbdBadge label={t('kbd.giveUp')} />
                   </button>
                 </div>
               )}


### PR DESCRIPTION
## 概要
`BakersDozenPage.tsx` は `h`（ヒント）/`a`（自動完了）/`g`（ギブアップ）/`z`（アンドゥ）のショートカットを実装済みだが画面表示がなく、発見できなかった。

## 変更点
- Undo/Hint/AutoComplete/GiveUp の各ボタンに `KbdBadge` チップ（新規 `kbd.*` キー Z/H/A/G）と `aria-keyshortcuts` 属性を追加
- `bakersdozen.json`（ja/en）に `kbd.undo`/`.hint`/`.autoComplete`/`.giveUp` を追加（parity 維持）
- `BakersDozenPage.test.tsx`: ギブアップ/ヒントボタンの `aria-keyshortcuts` と KbdBadge 表示を検証

## テスト計画
- [x] `bun run test -- --run src/pages/BakersDozenPage.test.tsx`（19 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）
- [x] bakersdozen.json ja/en key-for-key parity 確認

Closes #3230