### PR TITLE
feat(pitch): add keyboard navigation for hand, bids, and trick advance

### DIFF
--- a/frontend/src/i18n/locales/en/pitch.json
+++ b/frontend/src/i18n/locales/en/pitch.json
@@ -78,5 +78,13 @@
     "scoreTable": "Score table — High / Low / Jack / Game make 4 points per round.",
     "scoringInfo": "Make your bid: +points won. Miss it: -bid value (set back).",
     "resetButton": "Use this button to start a new game."
+  },
+  "kbd": {
+    "pass": "P",
+    "bid2": "2",
+    "bid3": "3",
+    "bid4": "4",
+    "play": "↵",
+    "next": "N"
   }
 }

--- a/frontend/src/i18n/locales/ja/pitch.json
+++ b/frontend/src/i18n/locales/ja/pitch.json
@@ -78,5 +78,13 @@
     "scoreTable": "スコア表です。High/Low/Jack/Game の4ポイントを競います。",
     "scoringInfo": "ビッド達成で +ポイント獲得、未達なら -ビッド数 (set back) になります。",
     "resetButton": "リセットボタンで新しいゲームを始められます。"
+  },
+  "kbd": {
+    "pass": "P",
+    "bid2": "2",
+    "bid3": "3",
+    "bid4": "4",
+    "play": "↵",
+    "next": "N"
   }
 }

--- a/frontend/src/pages/PitchPage.test.tsx
+++ b/frontend/src/pages/PitchPage.test.tsx
@@ -112,6 +112,49 @@ describe('PitchPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: /出す/ })).toBeInTheDocument());
   });
 
+  it('bid phase: pressing "p" passes and "2" bids two', async () => {
+    mockApi.mockResolvedValue(bidState);
+    renderWithProviders(<PitchPage />);
+    await screen.findByRole('button', { name: /パス/ });
+    mockApi.mockClear();
+    fireEvent.keyDown(document.body, { key: 'p' });
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bid', 0));
+    mockApi.mockClear();
+    fireEvent.keyDown(document.body, { key: '2' });
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('bid', 2));
+  });
+
+  it('play phase: a number key selects a valid card and Enter plays it', async () => {
+    mockApi.mockResolvedValue(playState);
+    renderWithProviders(<PitchPage />);
+    await screen.findByRole('button', { name: /出す/ });
+    mockApi.mockClear();
+    // "1" → hand index 0 (a valid play index); Enter confirms.
+    fireEvent.keyDown(document.body, { key: '1' });
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('play', undefined, 0));
+  });
+
+  it('play phase: an invalid card cannot be selected or played', async () => {
+    // Only index 0 is a legal play; pressing "2" (index 1) must not select.
+    mockApi.mockResolvedValue({ ...playState, validPlayIndices: [0] });
+    renderWithProviders(<PitchPage />);
+    await screen.findByRole('button', { name: /出す/ });
+    mockApi.mockClear();
+    fireEvent.keyDown(document.body, { key: '2' });
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+    // No selection means handlePlay early-returns; no play command is sent.
+    await waitFor(() => expect(mockApi).not.toHaveBeenCalled());
+  });
+
+  it('advertises the bid keyboard shortcut on the pass button', async () => {
+    mockApi.mockResolvedValue(bidState);
+    renderWithProviders(<PitchPage />);
+    const pass = await screen.findByRole('button', { name: /パス/ });
+    expect(pass).toHaveAttribute('aria-keyshortcuts', 'p');
+    expect(pass.querySelector('kbd')?.textContent).toBe('P');
+  });
+
   it('shows score table with players', async () => {
     mockApi.mockResolvedValue(bidState);
     renderWithProviders(<PitchPage />);

--- a/frontend/src/pages/PitchPage.tsx
+++ b/frontend/src/pages/PitchPage.tsx
@@ -12,8 +12,11 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
+import { KbdBadge } from '../components/KbdBadge';
 import { withTutorial } from '../components/tutorial/withTutorial';
+import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
+import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
@@ -197,6 +200,43 @@ function PitchPageContent() {
     },
     [execApi, cpuDifficulty, pointLimit],
   );
+
+  // Keyboard: number keys select a hand card, Enter plays it (play phase only,
+  // and only cards in validPlayIndices are selectable).
+  const selectValidCard = useCallback(
+    (idx: number) => {
+      if (state?.validPlayIndices.includes(idx)) setSelectedCardIdx(idx);
+    },
+    [state?.validPlayIndices],
+  );
+  const clearSelection = useCallback(() => setSelectedCardIdx(null), []);
+  useCardKeyboardNav({
+    cardCount: human?.cards.length ?? 0,
+    onToggle: selectValidCard,
+    onConfirm: handlePlay,
+    onClear: clearSelection,
+    enabled: isHumanPlayTurn && !loading,
+  });
+
+  // Keyboard: bid keys (p / 2 / 3 / 4) in the bid phase, n to advance a
+  // finished trick or round.
+  const handleNext = useCallback(() => {
+    if (isTrickEnd) handleNextTrick();
+    else if (isRoundEnd && !isGameEnd) handleNextRound();
+  }, [isTrickEnd, isRoundEnd, isGameEnd, handleNextTrick, handleNextRound]);
+  const currentBid = state?.currentBid ?? 0;
+  const canBid = isHumanBidTurn && !loading;
+  const actionBindings = useMemo(
+    () => [
+      { key: 'p', action: () => handleBid(0), enabled: canBid },
+      { key: '2', action: () => handleBid(2), enabled: canBid && 2 > currentBid },
+      { key: '3', action: () => handleBid(3), enabled: canBid && 3 > currentBid },
+      { key: '4', action: () => handleBid(4), enabled: canBid && 4 > currentBid },
+      { key: 'n', action: handleNext, enabled: (isTrickEnd || (isRoundEnd && !isGameEnd)) && !loading },
+    ],
+    [handleBid, handleNext, canBid, currentBid, isTrickEnd, isRoundEnd, isGameEnd, loading],
+  );
+  useActionKeyboardNav({ bindings: actionBindings, enabled: !!state });
 
   if (!state) {
     return (
@@ -420,8 +460,10 @@ function PitchPageContent() {
                   className={btnSecondary}
                   disabled={!isHumanBidTurn || loading}
                   onClick={() => handleBid(0)}
+                  aria-keyshortcuts="p"
                 >
                   {t('passButton')}
+                  <KbdBadge label={t('kbd.pass')} />
                 </button>
                 {[2, 3, 4].map((n) => (
                   <button
@@ -430,8 +472,10 @@ function PitchPageContent() {
                     className={btnPrimary}
                     disabled={!isHumanBidTurn || loading || n <= state.currentBid}
                     onClick={() => handleBid(n)}
+                    aria-keyshortcuts={String(n)}
                   >
                     {t('bid', { n })}
+                    <KbdBadge label={t(`kbd.bid${n}`)} />
                   </button>
                 ))}
               </div>
@@ -445,24 +489,40 @@ function PitchPageContent() {
                   className={btnSuccess}
                   onClick={handlePlay}
                   disabled={selectedCardIdx === null || loading}
+                  aria-keyshortcuts="Enter"
                 >
                   {t('playButton')}
+                  <KbdBadge label={t('kbd.play')} />
                 </button>
               </div>
             )}
 
             {isTrickEnd && (
               <div className="flex justify-center pb-2">
-                <button type="button" className={btnPrimary} onClick={handleNextTrick} disabled={loading}>
+                <button
+                  type="button"
+                  className={btnPrimary}
+                  onClick={handleNextTrick}
+                  disabled={loading}
+                  aria-keyshortcuts="n"
+                >
                   {t('nextTrick')}
+                  <KbdBadge label={t('kbd.next')} />
                 </button>
               </div>
             )}
 
             {isRoundEnd && !isGameEnd && (
               <div className="flex justify-center pb-2">
-                <button type="button" className={btnPrimary} onClick={handleNextRound} disabled={loading}>
+                <button
+                  type="button"
+                  className={btnPrimary}
+                  onClick={handleNextRound}
+                  disabled={loading}
+                  aria-keyshortcuts="n"
+                >
                   {t('nextRound')}
+                  <KbdBadge label={t('kbd.next')} />
                 </button>
               </div>
             )}


### PR DESCRIPTION
## 概要
`PitchPage.tsx` はキーボード操作の仕組みが皆無で、手札選択・ビッド・トリック/ラウンド送りが全てマウス/タップ必須だった（Tonk/CasinoWar 等は既存フックで対応済み）。

## 変更点
- **プレイフェーズ**: `useCardKeyboardNav` を導入。数字キーで手札選択、Enter でプレイ確定。`validPlayIndices` 外のカードは選択・確定不可
- **ビッドフェーズ**: `useActionKeyboardNav` で `p`(パス) / `2` / `3` / `4`(各ビッド、現在ビッド超のみ有効) をバインド
- **トリック/ラウンド送り**: `n` キーで `next` / `nextround`（フェーズに応じて分岐）
- 両フック群を loading early-return より前に配置しフック順序を安定化
- bid/play/next ボタンに `aria-keyshortcuts` と `KbdBadge` を付与、`kbd.*`(ja/en) を追加（parity 維持）
- `PitchPage.test.tsx`: パス/ビッド/有効カードプレイ/無効カードガードのキーボードテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/PitchPage.test.tsx`（14 passed）
- [x] `bun run check`（exit 0, PitchPage 警告なし）/ `npx tsc -b`（exit 0）
- [x] pitch.json ja/en kbd キー parity 確認

Closes #3239