### PR TITLE
feat(sheepshead): add keyboard hand navigation for bury and play

### DIFF
--- a/frontend/src/pages/SheepsheadPage.test.tsx
+++ b/frontend/src/pages/SheepsheadPage.test.tsx
@@ -77,6 +77,39 @@ describe('SheepsheadPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', { cardIndex: 0 }));
   });
 
+  it('play phase: a number key selects a card and Enter plays it', async () => {
+    renderWithProviders(<SheepsheadPage />);
+    await screen.findByAltText('♠ A');
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(playPhaseState);
+    // "1" toggles the first hand card (index 0); Enter confirms the play.
+    fireEvent.keyDown(document.body, { key: '1' });
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', { cardIndex: 0 }));
+  });
+
+  it('bury phase: two number keys select cards and Enter buries them', async () => {
+    mockExec.mockResolvedValue(buryPhaseState);
+    renderWithProviders(<SheepsheadPage />);
+    await screen.findByAltText('♠ A');
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(buryPhaseState);
+    fireEvent.keyDown(document.body, { key: '1' });
+    fireEvent.keyDown(document.body, { key: '2' });
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bury', { buryIndices: [0, 1] }));
+  });
+
+  it('keyboard play is disabled on a CPU turn', async () => {
+    mockExec.mockResolvedValue(cpuTurnState);
+    renderWithProviders(<SheepsheadPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', expect.anything()));
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: '1' });
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+    expect(mockExec).not.toHaveBeenCalledWith('play', expect.anything());
+  });
+
   it('renders pick / pass buttons in the pick phase on the human turn', async () => {
     mockExec.mockResolvedValue(pickPhaseState);
     renderWithProviders(<SheepsheadPage />);

--- a/frontend/src/pages/SheepsheadPage.tsx
+++ b/frontend/src/pages/SheepsheadPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import type { sheepsheadApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -15,6 +15,7 @@ import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { TrickDisplay } from '../components/TrickDisplay';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
+import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
@@ -96,6 +97,7 @@ function SheepsheadPageContent() {
     handleConfigChange,
     selectedCardIndices,
     toggleCard,
+    clearSelection,
     reset,
     handlePick,
     handlePass,
@@ -132,6 +134,25 @@ function SheepsheadPageContent() {
   } = useGameHint('sheepshead', state);
   const { cardWidth, isMobile } = useCardDimensions();
   const phaseNames = usePhaseNames('sheepshead', SHEEPSHEAD_PHASE_KEYS);
+
+  // Keyboard hand navigation (arrow keys move, space toggles, Enter confirms).
+  // BURY needs two cards and PLAY needs one; both handlers self-guard on the
+  // selected count, so confirmAction just routes to the active phase's handler.
+  const humanIdxForKbd = state?.players.findIndex((p) => p.isHuman) ?? -1;
+  const canBuryForKbd = state?.phase === SheepsheadPhase.BURY && state.pickerIdx === humanIdxForKbd;
+  const canPlayForKbd = state?.phase === SheepsheadPhase.PLAY && state.currentPlayerIdx === humanIdxForKbd;
+  const humanCardCountForKbd = state?.players.find((p) => p.isHuman)?.cards?.length ?? 0;
+  const confirmAction = useCallback(() => {
+    if (canBuryForKbd) handleBury();
+    else if (canPlayForKbd) handlePlay();
+  }, [canBuryForKbd, canPlayForKbd, handleBury, handlePlay]);
+  useCardKeyboardNav({
+    cardCount: humanCardCountForKbd,
+    onToggle: toggleCard,
+    onConfirm: confirmAction,
+    onClear: clearSelection,
+    enabled: (canBuryForKbd || canPlayForKbd) && !loading,
+  });
 
   if (!state)
     return <GameSkeleton gameKey="sheepshead" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 6 }} />;

--- a/frontend/src/pages/SheepsheadPage.tsx
+++ b/frontend/src/pages/SheepsheadPage.tsx
@@ -135,9 +135,10 @@ function SheepsheadPageContent() {
   const { cardWidth, isMobile } = useCardDimensions();
   const phaseNames = usePhaseNames('sheepshead', SHEEPSHEAD_PHASE_KEYS);
 
-  // Keyboard hand navigation (arrow keys move, space toggles, Enter confirms).
-  // BURY needs two cards and PLAY needs one; both handlers self-guard on the
-  // selected count, so confirmAction just routes to the active phase's handler.
+  // Keyboard hand navigation: number keys toggle a card, Enter confirms,
+  // Escape clears. BURY needs two cards and PLAY needs one; both handlers
+  // self-guard on the selected count, so confirmAction just routes to the
+  // active phase's handler.
   const humanIdxForKbd = state?.players.findIndex((p) => p.isHuman) ?? -1;
   const canBuryForKbd = state?.phase === SheepsheadPhase.BURY && state.pickerIdx === humanIdxForKbd;
   const canPlayForKbd = state?.phase === SheepsheadPhase.PLAY && state.currentPlayerIdx === humanIdxForKbd;


### PR DESCRIPTION
## 概要
`SheepsheadPage.tsx` は同じ `PlayerHandSection` ベースの gongzhu / tressette / burraco と異なりキーボードによる手札操作がなかった。BURY(2枚選択)と PLAY(1枚選択)がマウス/タップ限定でキーボードのみのユーザーが操作不能だった。

## 変更点
- `useCardKeyboardNav` を導入（数字キーで手札選択、Enter で確定、Escape で選択クリア）
- `confirmAction` で BURY 時は `handleBury`（2枚選択済みのみ）/ PLAY 時は `handlePlay`（1枚選択済みのみ）に振り分け（gongzhu の `confirmAction` パターン踏襲）。両ハンドラは選択枚数を自己ガード
- `enabled` は `(canBuryForKbd || canPlayForKbd) && !loading` — CPU 手番・他フェーズでは無効
- フックは skeleton early-return より前に配置しフック順序を安定化
- `SheepsheadPage.test.tsx`: play/bury/CPU手番 no-op のキーボードテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/SheepsheadPage.test.tsx`（14 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）

Closes #3401