### PR TITLE
feat(briscola): add keyboard hand selection and play

### DIFF
--- a/frontend/src/pages/BriscolaPage.test.tsx
+++ b/frontend/src/pages/BriscolaPage.test.tsx
@@ -87,6 +87,42 @@ describe('BriscolaPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', 1));
   });
 
+  it('keyboard: a number key highlights a card and Enter plays it', async () => {
+    renderWithProviders(<BriscolaPage />);
+    const secondCard = await screen.findByRole('button', { name: '♥ 5 を出す' });
+    mockExec.mockClear();
+    // "2" highlights the second hand card (index 1) without playing it.
+    fireEvent.keyDown(document.body, { key: '2' });
+    await waitFor(() => expect(secondCard).toHaveAttribute('aria-pressed', 'true'));
+    expect(mockExec).not.toHaveBeenCalled();
+    // Enter plays the highlighted card.
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', 1));
+  });
+
+  it('keyboard: Escape clears the highlight and Enter then plays nothing', async () => {
+    renderWithProviders(<BriscolaPage />);
+    const firstCard = await screen.findByRole('button', { name: '♠ A を出す' });
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: '1' });
+    await waitFor(() => expect(firstCard).toHaveAttribute('aria-pressed', 'true'));
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+    await waitFor(() => expect(firstCard).toHaveAttribute('aria-pressed', 'false'));
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+    expect(mockExec).not.toHaveBeenCalledWith('play', expect.anything());
+  });
+
+  it('keyboard: number keys do nothing on a CPU turn', async () => {
+    mockExec.mockResolvedValue(makeState({ currentPlayerIdx: 1 }));
+    renderWithProviders(<BriscolaPage />);
+    const firstCard = await screen.findByRole('button', { name: '♠ A を出す' });
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: '1' });
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+    expect(firstCard).toHaveAttribute('aria-pressed', 'false');
+    expect(mockExec).not.toHaveBeenCalledWith('play', expect.anything());
+  });
+
   it('shows "Next trick" button on trick-end and dispatches next', async () => {
     mockExec.mockResolvedValue(makeState({ phase: 1 }));
     renderWithProviders(<BriscolaPage />);

--- a/frontend/src/pages/BriscolaPage.tsx
+++ b/frontend/src/pages/BriscolaPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { briscolaApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CardImage } from '../components/CardImage';
@@ -10,6 +10,7 @@ import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { TrickDisplay } from '../components/TrickDisplay';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
+import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
@@ -68,6 +69,35 @@ function BriscolaPageContent() {
   const handleNext = useCallback(() => {
     void dispatch('next');
   }, [dispatch]);
+
+  // Keyboard hand selection: number keys highlight a card, Enter plays it,
+  // Escape clears. Mouse/touch still plays a card directly on click.
+  const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
+  const isHumanTurnForKbd =
+    state?.phase === BriscolaPhase.PLAY && state.players[state.currentPlayerIdx]?.isHuman === true;
+  const humanCardCountForKbd = state?.players.find((p) => p.isHuman)?.cards?.length ?? 0;
+  // Drop any stale highlight when the turn or trick moves on.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset the highlight whenever the turn/phase changes.
+  useEffect(() => {
+    setSelectedIdx(null);
+  }, [state?.currentPlayerIdx, state?.phase]);
+  const toggleSelect = useCallback((idx: number) => {
+    setSelectedIdx((prev) => (prev === idx ? null : idx));
+  }, []);
+  const clearSelect = useCallback(() => setSelectedIdx(null), []);
+  const confirmPlay = useCallback(() => {
+    if (selectedIdx !== null) {
+      handlePlay(selectedIdx);
+      setSelectedIdx(null);
+    }
+  }, [selectedIdx, handlePlay]);
+  useCardKeyboardNav({
+    cardCount: humanCardCountForKbd,
+    onToggle: toggleSelect,
+    onConfirm: confirmPlay,
+    onClear: clearSelect,
+    enabled: !!isHumanTurnForKbd && !loading,
+  });
 
   if (!state) {
     return <GameSkeleton gameKey="briscola" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 3 }} />;
@@ -213,7 +243,10 @@ function BriscolaPageContent() {
                   onClick={() => handlePlay(idx)}
                   disabled={loading || !isHumanTurn}
                   aria-label={tc('card.play', { card: cardAlt(card) })}
-                  className="disabled:opacity-50"
+                  aria-pressed={selectedIdx === idx}
+                  className={`rounded disabled:opacity-50 ${
+                    selectedIdx === idx ? 'ring-2 ring-ds-accent -translate-y-1 transition-transform' : ''
+                  }`}
                 >
                   <CardImage card={card} width={cardWidth} />
                 </button>


### PR DESCRIPTION
## 概要
`BriscolaPage.tsx` は `useActionKeyboardNav`/`useCardKeyboardNav` のいずれも未登録で、他のトリックテイキングゲーム（CallBreak/Tarneeb）が持つキーボード手札操作が使えなかった。手札プレイはマウス/タッチクリック限定だった。

## 変更点
- `useCardKeyboardNav` を導入（数字キーで手札カードをハイライト選択、Enter でプレイ、Escape で選択解除）
- マウス/タッチは従来どおりクリックで即プレイ（既存操作に影響なし）
- 選択中カードは ring 表示 + `aria-pressed` を付与。手番/フェーズが変わると選択をリセット
- フックは skeleton early-return より前に配置、`enabled` は人間の PLAY 手番かつ `!loading` のみ
- `BriscolaPage.test.tsx`: 選択+プレイ / Escape 解除 / CPU手番 no-op のキーボードテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/BriscolaPage.test.tsx`（15 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）

Closes #3312