### PR TITLE
feat(conquian): add keyboard shortcuts for the draw phase

### DIFF
--- a/frontend/src/i18n/locales/en/conquian.json
+++ b/frontend/src/i18n/locales/en/conquian.json
@@ -43,5 +43,9 @@
     "discardButton": "After melding, discard one card from your hand.",
     "scoreTable": "Each player's rounds won are shown here.",
     "resetButton": "Press the reset button to start a new game."
+  },
+  "kbd": {
+    "stock": "S",
+    "discard": "D"
   }
 }

--- a/frontend/src/i18n/locales/ja/conquian.json
+++ b/frontend/src/i18n/locales/ja/conquian.json
@@ -43,5 +43,9 @@
     "discardButton": "メルドしたら不要なカードを1枚捨てます。",
     "scoreTable": "各プレイヤーの勝利数が表示されます。",
     "resetButton": "リセットボタンで新しいゲームを始められます。"
+  },
+  "kbd": {
+    "stock": "S",
+    "discard": "D"
   }
 }

--- a/frontend/src/pages/ConquianPage.test.tsx
+++ b/frontend/src/pages/ConquianPage.test.tsx
@@ -159,6 +159,53 @@ describe('ConquianPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('drawdiscard'));
   });
 
+  it('keyboard: "s" draws from the stock and "d" takes the discard', async () => {
+    const { unmount } = renderWithProviders(<ConquianPage />);
+    await screen.findByRole('button', { name: '山札から引く' });
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(meldPhaseState);
+    fireEvent.keyDown(document.body, { key: 's' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('drawstock'));
+    unmount();
+
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(drawPhaseState);
+    renderWithProviders(<ConquianPage />);
+    await screen.findByRole('button', { name: '捨て札から引く' });
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(meldPhaseTookDiscard);
+    fireEvent.keyDown(document.body, { key: 'd' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('drawdiscard'));
+  });
+
+  it('keyboard: "d" does nothing when there is no discard top', async () => {
+    mockExec.mockResolvedValue(noDiscardState);
+    renderWithProviders(<ConquianPage />);
+    await screen.findByRole('button', { name: '捨て札から引く' });
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: 'd' });
+    expect(mockExec).not.toHaveBeenCalledWith('drawdiscard');
+  });
+
+  it('keyboard: draw keys are disabled on a CPU turn', async () => {
+    mockExec.mockResolvedValue(cpuTurnState);
+    renderWithProviders(<ConquianPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, expect.anything()));
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: 's' });
+    fireEvent.keyDown(document.body, { key: 'd' });
+    expect(mockExec).not.toHaveBeenCalledWith('drawstock');
+    expect(mockExec).not.toHaveBeenCalledWith('drawdiscard');
+  });
+
+  it('advertises the draw keyboard shortcuts on the buttons', async () => {
+    renderWithProviders(<ConquianPage />);
+    const stockBtn = await screen.findByRole('button', { name: '山札から引く' });
+    expect(stockBtn).toHaveAttribute('aria-keyshortcuts', 's');
+    expect(stockBtn.querySelector('kbd')?.textContent).toBe('S');
+    expect(screen.getByRole('button', { name: '捨て札から引く' })).toHaveAttribute('aria-keyshortcuts', 'd');
+  });
+
   it('renders meld and discard buttons during meld phase', async () => {
     mockExec.mockResolvedValue(meldPhaseState);
     renderWithProviders(<ConquianPage />);

--- a/frontend/src/pages/ConquianPage.tsx
+++ b/frontend/src/pages/ConquianPage.tsx
@@ -9,9 +9,11 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { KbdBadge } from '../components/KbdBadge';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
+import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useCliGame } from '../hooks/useCliGame';
@@ -143,6 +145,19 @@ function ConquianPageContent() {
     onClear: clearSelection,
     enabled: !!isHumanTurn && !loading,
   });
+
+  // DRAW phase: s draws from the stock, d takes the discard top. Number keys
+  // and Enter/Escape are handled by useCardKeyboardNav; these letter keys don't
+  // collide with it.
+  const canDrawForKbd = isDrawPhase && !!isHumanTurn && !loading;
+  const drawBindings = useMemo(
+    () => [
+      { key: 's', action: handleDrawStock, enabled: canDrawForKbd },
+      { key: 'd', action: handleDrawDiscard, enabled: canDrawForKbd && !!state?.discardTop },
+    ],
+    [handleDrawStock, handleDrawDiscard, canDrawForKbd, state?.discardTop],
+  );
+  useActionKeyboardNav({ bindings: drawBindings, enabled: canDrawForKbd });
 
   if (!state) {
     return (
@@ -341,16 +356,25 @@ function ConquianPageContent() {
             <div className="flex gap-2 items-center flex-wrap">
               {isDrawPhase && isHumanTurn && (
                 <div className="flex gap-2">
-                  <button type="button" className={btnPrimary} onClick={handleDrawStock} disabled={loading}>
+                  <button
+                    type="button"
+                    className={btnPrimary}
+                    onClick={handleDrawStock}
+                    disabled={loading}
+                    aria-keyshortcuts="s"
+                  >
                     {t('drawStockButton')}
+                    <KbdBadge label={t('kbd.stock')} />
                   </button>
                   <button
                     type="button"
                     className={btnPrimary}
                     onClick={handleDrawDiscard}
                     disabled={loading || !state.discardTop}
+                    aria-keyshortcuts="d"
                   >
                     {t('drawDiscardButton')}
+                    <KbdBadge label={t('kbd.discard')} />
                   </button>
                 </div>
               )}


### PR DESCRIPTION
## 概要
`ConquianPage.tsx` は MELD 選択に `useCardKeyboardNav` を導入済みだが、DRAW フェーズの `handleDrawStock`/`handleDrawDiscard` はマウスクリック限定で、カード選択はキーボード完結なのにターン開始のドローだけ非対称だった。

## 変更点
- `useActionKeyboardNav` で `s`(山札) / `d`(捨て札) を DRAW フェーズにバインド（人間手番・`!loading`、`d` は `discardTop` 存在時のみ）。letter キーは `useCardKeyboardNav` の数字/Enter と非衝突
- 両ボタンに `aria-keyshortcuts` と `KbdBadge` を付与、`kbd.*`(ja/en, parity) を追加
- `ConquianPage.test.tsx`: s/d ドロー、discard なし時の d 無効、CPU手番 no-op、ボタンのキーヒントのテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/ConquianPage.test.tsx`（28 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）
- [x] conquian ja↔en キー parity 確認

Closes #3474