### PR TITLE
feat(pineapple): add keyboard control for the discard phase

### DIFF
--- a/frontend/src/pages/PineapplePage.test.tsx
+++ b/frontend/src/pages/PineapplePage.test.tsx
@@ -248,6 +248,35 @@ describe('PineapplePage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('discard', undefined, { cardIdxs: [0] }));
   });
 
+  it('keyboard: a number key selects a card and Enter steps through confirm to commit', async () => {
+    mockExec.mockResolvedValue(discardState);
+    renderWithProviders(<PineapplePage />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.getAttribute('aria-pressed') !== null);
+    mockExec.mockClear();
+    // "1" selects the first hole card.
+    fireEvent.keyDown(document.body, { key: '1' });
+    await waitFor(() => expect(cardButtons[0]).toHaveAttribute('aria-pressed', 'true'));
+    // First Enter opens the confirm step without committing.
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+    expect(screen.getByTestId('discard-confirm')).toBeInTheDocument();
+    expect(mockExec).not.toHaveBeenCalledWith('discard', undefined, { cardIdxs: [0] });
+    // Second Enter commits the discard.
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('discard', undefined, { cardIdxs: [0] }));
+  });
+
+  it('keyboard: Escape deselects a discard candidate', async () => {
+    mockExec.mockResolvedValue(discardState);
+    renderWithProviders(<PineapplePage />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.getAttribute('aria-pressed') !== null);
+    fireEvent.keyDown(document.body, { key: '1' });
+    await waitFor(() => expect(cardButtons[0]).toHaveAttribute('aria-pressed', 'true'));
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+    await waitFor(() => expect(cardButtons[0]).toHaveAttribute('aria-pressed', 'false'));
+  });
+
   it('previews the kept cards and tentative hand for Irish Poker discard', async () => {
     const irishDiscardState: PineappleResponse = {
       ...discardState,

--- a/frontend/src/pages/PineapplePage.test.tsx
+++ b/frontend/src/pages/PineapplePage.test.tsx
@@ -277,6 +277,47 @@ describe('PineapplePage', () => {
     await waitFor(() => expect(cardButtons[0]).toHaveAttribute('aria-pressed', 'false'));
   });
 
+  it('keyboard: re-pressing deselects, the 1-card cap blocks a second pick, and empty Enter is a no-op', async () => {
+    mockExec.mockResolvedValue(discardState);
+    renderWithProviders(<PineapplePage />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.getAttribute('aria-pressed') !== null);
+    mockExec.mockClear();
+    // Select card 0.
+    fireEvent.keyDown(document.body, { key: '1' });
+    await waitFor(() => expect(cardButtons[0]).toHaveAttribute('aria-pressed', 'true'));
+    // Crazy Pineapple discards exactly 1, so pressing "2" must not also select card 1.
+    fireEvent.keyDown(document.body, { key: '2' });
+    expect(cardButtons[1]).toHaveAttribute('aria-pressed', 'false');
+    // Re-pressing "1" deselects card 0.
+    fireEvent.keyDown(document.body, { key: '1' });
+    await waitFor(() => expect(cardButtons[0]).toHaveAttribute('aria-pressed', 'false'));
+    // With nothing selected, Enter neither opens the confirm step nor commits.
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+    expect(screen.queryByTestId('discard-confirm')).not.toBeInTheDocument();
+    expect(mockExec).not.toHaveBeenCalledWith('discard', undefined, expect.anything());
+  });
+
+  it('keyboard: Escape from the confirm step returns to selection without committing', async () => {
+    mockExec.mockResolvedValue(discardState);
+    renderWithProviders(<PineapplePage />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.getAttribute('aria-pressed') !== null);
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: '1' });
+    await waitFor(() => expect(cardButtons[0]).toHaveAttribute('aria-pressed', 'true'));
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+    expect(screen.getByTestId('discard-confirm')).toBeInTheDocument();
+    // Number keys are inert while confirming — the selection can't be changed.
+    fireEvent.keyDown(document.body, { key: '2' });
+    expect(cardButtons[1]).toHaveAttribute('aria-pressed', 'false');
+    // Escape backs out of the confirm step; the selection is kept.
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByTestId('discard-confirm')).not.toBeInTheDocument());
+    expect(cardButtons[0]).toHaveAttribute('aria-pressed', 'true');
+    expect(mockExec).not.toHaveBeenCalledWith('discard', undefined, expect.anything());
+  });
+
   it('previews the kept cards and tentative hand for Irish Poker discard', async () => {
     const irishDiscardState: PineappleResponse = {
       ...discardState,

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -24,6 +24,7 @@ import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { TutorialWrapper } from '../components/tutorial/TutorialWrapper';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions, useIsMobile } from '../hooks/useCardDimensions';
+import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
@@ -287,6 +288,42 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
   useActionKeyboardNav({
     bindings: actionBindings,
     enabled: canAct && !loading,
+  });
+
+  // Discard phase keyboard control: number keys toggle a hole card, Enter steps
+  // through the two-stage confirm (select -> confirm -> commit), Escape backs out.
+  const discardCardCount = humanPlayer?.cards?.length ?? 0;
+  const discardToggle = useCallback(
+    (idx: number) => {
+      if (!canDiscard || discardConfirming) return;
+      setSelectedDiscards((prev) => {
+        if (prev.includes(idx)) return prev.filter((i) => i !== idx);
+        if (prev.length >= discardCount) return prev; // cap reached
+        return [...prev, idx];
+      });
+    },
+    [canDiscard, discardConfirming, discardCount],
+  );
+  const discardConfirm = useCallback(() => {
+    if (selectedDiscards.length !== discardCount) return;
+    if (discardConfirming) {
+      void apiExec('discard', undefined, { cardIdxs: [...selectedDiscards] });
+      setSelectedDiscards([]);
+      setDiscardConfirming(false);
+    } else {
+      setDiscardConfirming(true);
+    }
+  }, [selectedDiscards, discardCount, discardConfirming, apiExec]);
+  const discardClear = useCallback(() => {
+    if (discardConfirming) setDiscardConfirming(false);
+    else setSelectedDiscards([]);
+  }, [discardConfirming]);
+  useCardKeyboardNav({
+    cardCount: discardCardCount,
+    onToggle: discardToggle,
+    onConfirm: discardConfirm,
+    onClear: discardClear,
+    enabled: canDiscard && !loading,
   });
 
   if (!state)


### PR DESCRIPTION
## 概要
`PineapplePage.tsx`（crazypineapple/irishpoker が共有）の `useActionKeyboardNav` はベッティングのみで `!isDiscardPhase` 条件のため捨て札フェーズでは無効。捨て札選択（`toggleDiscard`）と2段階確定（`discardConfirming`）がマウス/タッチ専用だった。

## 変更点
- 捨て札フェーズ用に `useCardKeyboardNav` を導入：数字キーで捨て札候補をトグル、Enter で2段階確定（選択→確認→確定）、Escape で選択解除／確認ステップから戻る
- 人間の捨て札手番かつ `!loading` のみ有効。ベッティングの `useActionKeyboardNav` は捨て札中は無効なので非衝突
- `PineapplePage.test.tsx`: 選択→確認→確定フロー、Escape 解除のキーボードテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/PineapplePage.test.tsx src/pages/CrazyPineapplePage.test.tsx`（27 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）

Closes #3020