### PR TITLE
fix(pineapple): make discard selection inert during the confirm step

### DIFF
--- a/frontend/src/pages/PineapplePage.test.tsx
+++ b/frontend/src/pages/PineapplePage.test.tsx
@@ -248,6 +248,24 @@ describe('PineapplePage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('discard', undefined, { cardIdxs: [0] }));
   });
 
+  it('a card click is inert once the confirm step has started', async () => {
+    mockExec.mockResolvedValue(discardState);
+    renderWithProviders(<PineapplePage />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.getAttribute('aria-pressed') !== null);
+    // Select the first card and open the confirm step.
+    fireEvent.click(cardButtons[0]);
+    const discardBtn = screen.getByRole('button', { name: '1枚捨ててください。' });
+    await waitFor(() => expect(discardBtn).not.toBeDisabled());
+    fireEvent.click(discardBtn);
+    expect(screen.getByTestId('discard-confirm')).toBeInTheDocument();
+    // Clicking another card during confirm must not change the selection or
+    // dismiss the dialog (consistent with the keyboard behavior).
+    fireEvent.click(cardButtons[1]);
+    expect(cardButtons[1]).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByTestId('discard-confirm')).toBeInTheDocument();
+  });
+
   it('keyboard: a number key selects a card and Enter steps through confirm to commit', async () => {
     mockExec.mockResolvedValue(discardState);
     renderWithProviders(<PineapplePage />);

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -259,14 +259,6 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
       return rank == null ? null : pokerHandKey(rank);
     });
   }, [variant, isDiscardPhase, humanPlayer, state?.communityCards]);
-  const toggleDiscard = (idx: number) => {
-    if (!canDiscard) return;
-    setSelectedDiscards((prev) => {
-      if (prev.includes(idx)) return prev.filter((i) => i !== idx);
-      if (prev.length >= discardCount) return prev; // cap reached
-      return [...prev, idx];
-    });
-  };
 
   const actionBindings = useMemo(
     () => [
@@ -290,10 +282,13 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
     enabled: canAct && !loading,
   });
 
-  // Discard phase keyboard control: number keys toggle a hole card, Enter steps
-  // through the two-stage confirm (select -> confirm -> commit), Escape backs out.
+  // Discard phase control shared by mouse and keyboard: toggle a hole card into
+  // the discard selection. Guarded so nothing changes once the two-stage confirm
+  // has started (the player must commit or cancel), keeping both input methods
+  // consistent. Keyboard: number keys toggle, Enter steps select -> confirm ->
+  // commit, Escape backs out.
   const discardCardCount = humanPlayer?.cards?.length ?? 0;
-  const discardToggle = useCallback(
+  const toggleDiscard = useCallback(
     (idx: number) => {
       if (!canDiscard || discardConfirming) return;
       setSelectedDiscards((prev) => {
@@ -320,7 +315,7 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
   }, [discardConfirming]);
   useCardKeyboardNav({
     cardCount: discardCardCount,
-    onToggle: discardToggle,
+    onToggle: toggleDiscard,
     onConfirm: discardConfirm,
     onClear: discardClear,
     enabled: canDiscard && !loading,


### PR DESCRIPTION
## 概要
#3676 のレビュー指摘（non-blocking）への対応。捨て札カードは確認ステップ中も `disabled={!canDiscard}` のままクリック可能で、マウス/タッチ利用者は確認中でも選択を変更でき、確認ダイアログを誤って解除できてしまう非対称があった（キーボードは `discardConfirming` ガードで no-op）。

## 変更点
- 2 つに分かれていたトグルコールバック（旧 `toggleDiscard` とキーボード用 `discardToggle`）を、`discardConfirming` 中は no-op となる 1 つの memoized `toggleDiscard` に統合し、`onClick` と `useCardKeyboardNav` の両方で共有。マウス/キーボードの挙動が一致し、確認中は選択が変わらない
- `PineapplePage.test.tsx`: 確認ステップ中のカードクリックが無反応であることを検証するテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/PineapplePage.test.tsx src/pages/CrazyPineapplePage.test.tsx`（27 + 2 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）