### PR TITLE
feat(agnes): add keyboard shortcuts for the primary actions

### DIFF
--- a/frontend/src/i18n/locales/en/agnes.json
+++ b/frontend/src/i18n/locales/en/agnes.json
@@ -34,5 +34,11 @@
     "actionButtons": "Action buttons: deal, hint, undo, give up.",
     "resetButton": "Start a new game."
   },
-  "columnActions": "Actions"
+  "columnActions": "Actions",
+  "kbd": {
+    "deal": "D",
+    "hint": "H",
+    "undo": "Z",
+    "giveup": "G"
+  }
 }

--- a/frontend/src/i18n/locales/ja/agnes.json
+++ b/frontend/src/i18n/locales/ja/agnes.json
@@ -34,5 +34,11 @@
     "actionButtons": "配る・ヒント・元に戻す・ギブアップなどの操作ボタンです。",
     "resetButton": "新しいゲームを始めるボタンです。"
   },
-  "columnActions": "操作"
+  "columnActions": "操作",
+  "kbd": {
+    "deal": "D",
+    "hint": "H",
+    "undo": "Z",
+    "giveup": "G"
+  }
 }

--- a/frontend/src/pages/AgnesPage.test.tsx
+++ b/frontend/src/pages/AgnesPage.test.tsx
@@ -112,6 +112,55 @@ describe('AgnesPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
   });
 
+  it('keyboard: "d" deals and "h" hints', async () => {
+    renderWithProviders(<AgnesPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: 'd' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('deal'));
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: 'h' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
+  });
+
+  it('keyboard: "z" undoes only when canUndo is true', async () => {
+    mockExec.mockResolvedValue({ ...playingState, canUndo: true });
+    renderWithProviders(<AgnesPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '元に戻す' })).toBeEnabled());
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: 'z' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('undo'));
+  });
+
+  it('keyboard: "z" is a no-op when canUndo is false', async () => {
+    mockExec.mockResolvedValue(playingState); // canUndo: false
+    renderWithProviders(<AgnesPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: 'z' });
+    expect(mockExec).not.toHaveBeenCalledWith('undo');
+  });
+
+  it('keyboard: "g" opens the give-up confirm and only gives up after confirming', async () => {
+    renderWithProviders(<AgnesPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: 'g' });
+    expect(mockExec).not.toHaveBeenCalledWith('giveup');
+    expect(screen.getByText('投了確認')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('giveup'));
+  });
+
+  it('advertises the keyboard shortcuts on the action buttons', async () => {
+    renderWithProviders(<AgnesPage />);
+    const deal = await screen.findByRole('button', { name: '配る' });
+    expect(deal).toHaveAttribute('aria-keyshortcuts', 'd');
+    expect(deal.querySelector('kbd')?.textContent).toBe('D');
+    expect(screen.getByRole('button', { name: 'ヒント' })).toHaveAttribute('aria-keyshortcuts', 'h');
+    expect(screen.getByRole('button', { name: 'ギブアップ' })).toHaveAttribute('aria-keyshortcuts', 'g');
+  });
+
   it('giveup button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<AgnesPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));

--- a/frontend/src/pages/AgnesPage.tsx
+++ b/frontend/src/pages/AgnesPage.tsx
@@ -11,10 +11,12 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
+import { KbdBadge } from '../components/KbdBadge';
 import { LandscapeBanner } from '../components/LandscapeBanner';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { withTutorial } from '../components/tutorial/withTutorial';
+import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
@@ -149,6 +151,20 @@ function AgnesPageContent() {
     : phase === AgnesPhase.GAME_OVER
       ? t('phase.gameOver')
       : t('phase.playing');
+
+  // Keyboard shortcuts for the primary actions, matching other solitaire pages.
+  // Give-up (g) is routed through its confirm dialog since it is irreversible.
+  const canPlayForKbd = isPlaying && !loading;
+  const agnesBindings = useMemo(
+    () => [
+      { key: 'd', action: handleDeal, enabled: canPlayForKbd && (state?.stockCount ?? 0) > 0 },
+      { key: 'h', action: handleHint, enabled: canPlayForKbd },
+      { key: 'z', action: handleUndo, enabled: canPlayForKbd && (state?.canUndo ?? false) },
+      { key: 'g', action: confirmGiveUpAction, enabled: canPlayForKbd },
+    ],
+    [handleDeal, handleHint, handleUndo, confirmGiveUpAction, canPlayForKbd, state?.stockCount, state?.canUndo],
+  );
+  useActionKeyboardNav({ bindings: agnesBindings, enabled: canPlayForKbd });
 
   if (error) return <ErrorAlert message={error} onRetry={retry} />;
   if (!state) return null;
@@ -374,32 +390,40 @@ function AgnesPageContent() {
                     className={`${btnPrimary} ${focusRingWhite}`}
                     onClick={handleDeal}
                     disabled={loading || state.stockCount === 0}
+                    aria-keyshortcuts="d"
                   >
                     {t('deal')}
+                    <KbdBadge label={t('kbd.deal')} />
                   </button>
                   <button
                     type="button"
                     className={`${btnSuccess} ${focusRingWhite}`}
                     onClick={handleHint}
                     disabled={loading}
+                    aria-keyshortcuts="h"
                   >
                     {t('hint')}
+                    <KbdBadge label={t('kbd.hint')} />
                   </button>
                   <button
                     type="button"
                     className={`${btnOutline} ${focusRingWhite}`}
                     onClick={handleUndo}
                     disabled={!state.canUndo || loading}
+                    aria-keyshortcuts="z"
                   >
                     {t('undo')}
+                    <KbdBadge label={t('kbd.undo')} />
                   </button>
                   <button
                     type="button"
                     className={`${btnDanger} ${focusRingWhite}`}
                     onClick={confirmGiveUpAction}
                     disabled={loading}
+                    aria-keyshortcuts="g"
                   >
                     {t('giveup')}
+                    <KbdBadge label={t('kbd.giveup')} />
                   </button>
                 </>
               )}


### PR DESCRIPTION
## 概要
`AgnesPage.tsx` はキーボードフック未登録で、他の全ソリティアページが備える deal/hint/undo/giveup のショートカットが使えなかった（ポインタ/Tab のみ）。

## 変更点
- `useActionKeyboardNav` を導入：`d`(配る・stock 残あり時) / `h`(ヒント) / `z`(元に戻す・canUndo 時) / `g`(ギブアップ)
- ギブアップは不可逆のため既存の確認ダイアログ経由（reset のガードと同様）
- プレイ中のみ有効。各ボタンに `aria-keyshortcuts` と `KbdBadge` を付与。マウス/ドラッグ操作は不変
- `kbd.*`(ja/en, parity) を追加
- `AgnesPage.test.tsx`: deal/hint、undo の有効ゲート、giveup 確認フロー、ボタンのキーヒントのテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/AgnesPage.test.tsx`（25 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）
- [x] agnes ja↔en キー parity 確認

Closes #3291