### PR TITLE
feat(gofish): complete a turn with the keyboard

### DIFF
--- a/frontend/src/i18n/locales/en/gofish.json
+++ b/frontend/src/i18n/locales/en/gofish.json
@@ -46,6 +46,6 @@
   "a11y": {
     "targetSelected": "Selected {{name}}",
     "rankSelected": "Selected rank {{rank}}",
-    "kbdHint": "Number keys pick the opponent, arrows change rank, Enter asks"
+    "kbdHint": "Number keys pick the opponent, arrows change rank, a asks"
   }
 }

--- a/frontend/src/i18n/locales/en/gofish.json
+++ b/frontend/src/i18n/locales/en/gofish.json
@@ -42,5 +42,10 @@
   "hint": {
     "askKnownRank": "Ask for the rank an opponent recently took",
     "askMostCopies": "Ask for the rank you hold most copies of"
+  },
+  "a11y": {
+    "targetSelected": "Selected {{name}}",
+    "rankSelected": "Selected rank {{rank}}",
+    "kbdHint": "Number keys pick the opponent, arrows change rank, Enter asks"
   }
 }

--- a/frontend/src/i18n/locales/ja/gofish.json
+++ b/frontend/src/i18n/locales/ja/gofish.json
@@ -42,5 +42,10 @@
   "hint": {
     "askKnownRank": "直前に相手が取ったランクを要求推奨",
     "askMostCopies": "最も多く持っているランクを要求推奨"
+  },
+  "a11y": {
+    "targetSelected": "{{name}} を選択",
+    "rankSelected": "ランク {{rank}} を選択",
+    "kbdHint": "数字キーで相手、←→ でランク、Enter で要求"
   }
 }

--- a/frontend/src/i18n/locales/ja/gofish.json
+++ b/frontend/src/i18n/locales/ja/gofish.json
@@ -46,6 +46,6 @@
   "a11y": {
     "targetSelected": "{{name}} を選択",
     "rankSelected": "ランク {{rank}} を選択",
-    "kbdHint": "数字キーで相手、←→ でランク、Enter で要求"
+    "kbdHint": "数字キーで相手、←→ でランク、a で要求"
   }
 }

--- a/frontend/src/pages/GoFishPage.test.tsx
+++ b/frontend/src/pages/GoFishPage.test.tsx
@@ -141,7 +141,7 @@ describe('GoFishPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('ask', expect.any(Number), 7));
   });
 
-  it('keyboard: number key selects an opponent and arrows cycle the rank, then Enter asks', async () => {
+  it('keyboard: number key selects an opponent and arrows cycle the rank, then "a" asks', async () => {
     renderWithProviders(<GoFishPage />);
     await waitFor(() => expect(screen.getByText(/CPU 2/)).toBeInTheDocument());
     // "1" picks the first opponent (CPU 1) and announces it.
@@ -155,8 +155,8 @@ describe('GoFishPage', () => {
     await waitFor(() => expect(screen.getByTestId('gf-kbd-announce').textContent).toMatch(/7/));
     mockExec.mockClear();
     mockExec.mockResolvedValue(baseState);
-    // Enter asks the selected opponent for the selected rank.
-    fireEvent.keyDown(document.body, { key: 'Enter' });
+    // "a" asks the selected opponent for the selected rank.
+    fireEvent.keyDown(document.body, { key: 'a' });
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('ask', 1, 7));
   });
 
@@ -178,7 +178,7 @@ describe('GoFishPage', () => {
     mockExec.mockClear();
     fireEvent.keyDown(document.body, { key: '1' });
     fireEvent.keyDown(document.body, { key: 'ArrowRight' });
-    fireEvent.keyDown(document.body, { key: 'Enter' });
+    fireEvent.keyDown(document.body, { key: 'a' });
     expect(mockExec).not.toHaveBeenCalledWith('ask', expect.anything(), expect.anything());
     expect(screen.getByTestId('gf-kbd-announce').textContent).toBe('');
   });

--- a/frontend/src/pages/GoFishPage.test.tsx
+++ b/frontend/src/pages/GoFishPage.test.tsx
@@ -141,6 +141,48 @@ describe('GoFishPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('ask', expect.any(Number), 7));
   });
 
+  it('keyboard: number key selects an opponent and arrows cycle the rank, then Enter asks', async () => {
+    renderWithProviders(<GoFishPage />);
+    await waitFor(() => expect(screen.getByText(/CPU 2/)).toBeInTheDocument());
+    // "1" picks the first opponent (CPU 1) and announces it.
+    fireEvent.keyDown(document.body, { key: '1' });
+    await waitFor(() => expect(screen.getByTestId('gf-kbd-announce').textContent).toMatch(/CPU 1/));
+    // ArrowRight cycles to the first hand rank (3) and announces it.
+    fireEvent.keyDown(document.body, { key: 'ArrowRight' });
+    await waitFor(() => expect(screen.getByTestId('gf-kbd-announce').textContent).toMatch(/3/));
+    // A second ArrowRight advances from the current rank to the next one (7).
+    fireEvent.keyDown(document.body, { key: 'ArrowRight' });
+    await waitFor(() => expect(screen.getByTestId('gf-kbd-announce').textContent).toMatch(/7/));
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(baseState);
+    // Enter asks the selected opponent for the selected rank.
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('ask', 1, 7));
+  });
+
+  it('keyboard: "a" also asks once a target and rank are chosen', async () => {
+    renderWithProviders(<GoFishPage />);
+    await waitFor(() => expect(screen.getByText(/CPU 2/)).toBeInTheDocument());
+    fireEvent.keyDown(document.body, { key: '2' }); // CPU 2
+    fireEvent.keyDown(document.body, { key: 'ArrowLeft' }); // wraps to the last rank (7)
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(baseState);
+    fireEvent.keyDown(document.body, { key: 'a' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('ask', 2, 7));
+  });
+
+  it('keyboard: bindings are inert on a CPU turn', async () => {
+    mockExec.mockResolvedValue(cpuTurnState);
+    renderWithProviders(<GoFishPage />);
+    await waitFor(() => expect(screen.getByText(/CPU 2/)).toBeInTheDocument());
+    mockExec.mockClear();
+    fireEvent.keyDown(document.body, { key: '1' });
+    fireEvent.keyDown(document.body, { key: 'ArrowRight' });
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+    expect(mockExec).not.toHaveBeenCalledWith('ask', expect.anything(), expect.anything());
+    expect(screen.getByTestId('gf-kbd-announce').textContent).toBe('');
+  });
+
   it('rank buttons appear on human turn', async () => {
     renderWithProviders(<GoFishPage />);
     await waitFor(() => expect(screen.getByText('7')).toBeInTheDocument());

--- a/frontend/src/pages/GoFishPage.tsx
+++ b/frontend/src/pages/GoFishPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { goFishApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -15,6 +15,7 @@ import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
+import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
@@ -36,6 +37,7 @@ import { valueName } from '../utils/cardUtils';
 import { GOFISH_HELP, parseGofishCommand } from '../utils/cli/commands/gofishCommands';
 import { formatGofishState } from '../utils/cli/formatters/gofishFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { playerName } from '../utils/playerUtils';
 
 /** CPU difficulty options for Go Fish. */
 const CPU_DIFFICULTY_OPTIONS = [
@@ -127,6 +129,51 @@ function GoFishPageContent() {
 
   const knownRanks = useGoFishKnownRanks(state);
 
+  // Keyboard: number keys pick the opponent, arrows cycle the rank, Enter/a asks.
+  // Selection changes are announced via an aria-live region (below), on top of
+  // the per-button aria-pressed state.
+  const [kbdAnnounce, setKbdAnnounce] = useState('');
+  const kbdCpuPlayers = useMemo(() => state?.players.filter((p) => !p.isHuman) ?? [], [state?.players]);
+  const kbdHumanRanks = useMemo(() => {
+    const human = state?.players.find((p) => p.isHuman);
+    return human ? [...new Set(human.cards.map((c) => c.value))].sort((a, b) => a - b) : [];
+  }, [state?.players]);
+  const kbdIsHumanTurn =
+    state?.phase === GoFishPhase.PLAY && state.players[state.currentTurn]?.isHuman === true && !loading;
+  const kbdCanAsk = kbdIsHumanTurn && selectedTarget !== null && selectedRank !== null;
+  const cycleRank = useCallback(
+    (dir: 1 | -1) => {
+      if (kbdHumanRanks.length === 0) return;
+      const cur = selectedRank === null ? -1 : kbdHumanRanks.indexOf(selectedRank);
+      const next =
+        cur === -1
+          ? dir === 1
+            ? 0
+            : kbdHumanRanks.length - 1
+          : (cur + dir + kbdHumanRanks.length) % kbdHumanRanks.length;
+      const rank = kbdHumanRanks[next];
+      handleSelectRank(rank);
+      setKbdAnnounce(t('a11y.rankSelected', { rank: valueName(rank) }));
+    },
+    [kbdHumanRanks, selectedRank, handleSelectRank, t],
+  );
+  const askBindings = useMemo(() => {
+    const bindings = kbdCpuPlayers.map((p, i) => ({
+      key: String(i + 1),
+      action: () => {
+        handleSelectTarget(p.id);
+        setKbdAnnounce(t('a11y.targetSelected', { name: playerName(p.id, false) }));
+      },
+      enabled: kbdIsHumanTurn,
+    }));
+    bindings.push({ key: 'ArrowRight', action: () => cycleRank(1), enabled: kbdIsHumanTurn });
+    bindings.push({ key: 'ArrowLeft', action: () => cycleRank(-1), enabled: kbdIsHumanTurn });
+    bindings.push({ key: 'a', action: handleAsk, enabled: kbdCanAsk });
+    bindings.push({ key: 'Enter', action: handleAsk, enabled: kbdCanAsk });
+    return bindings;
+  }, [kbdCpuPlayers, handleSelectTarget, cycleRank, handleAsk, kbdIsHumanTurn, kbdCanAsk, t]);
+  useActionKeyboardNav({ bindings: askBindings, enabled: !!kbdIsHumanTurn });
+
   if (!state) return <GameSkeleton gameKey="gofish" layout={{ kind: 'trick-taking', footerHandSize: 5 }} />;
 
   const humanPlayer = state.players.find((p) => p.isHuman);
@@ -194,6 +241,10 @@ function GoFishPageContent() {
             {/* Turn & deck info */}
             <div className="text-ds-text-primary text-center mb-2 flex items-center justify-center gap-4">
               <span>{t('deck', { count: state.deckRemaining })}</span>
+            </div>
+
+            <div className="sr-only" role="status" aria-live="polite" data-testid="gf-kbd-announce">
+              {kbdAnnounce}
             </div>
 
             {/* CPU player areas */}
@@ -313,9 +364,12 @@ function GoFishPageContent() {
 
             <div className="flex gap-2 items-center" data-tutorial="gf-ask-button">
               {isHumanTurn && (
-                <button type="button" className={btnPrimary} onClick={handleAsk} disabled={!canAsk}>
-                  {t('button.ask')}
-                </button>
+                <>
+                  <button type="button" className={btnPrimary} onClick={handleAsk} disabled={!canAsk}>
+                    {t('button.ask')}
+                  </button>
+                  <span className="text-ds-text-muted text-xs hidden sm:inline">{t('a11y.kbdHint')}</span>
+                </>
               )}
               <GameResetButton
                 isGameEnd={!!isGameEnd}

--- a/frontend/src/pages/GoFishPage.tsx
+++ b/frontend/src/pages/GoFishPage.tsx
@@ -168,8 +168,11 @@ function GoFishPageContent() {
     }));
     bindings.push({ key: 'ArrowRight', action: () => cycleRank(1), enabled: kbdIsHumanTurn });
     bindings.push({ key: 'ArrowLeft', action: () => cycleRank(-1), enabled: kbdIsHumanTurn });
+    // Ask key is the letter "a" only. Enter is deliberately not bound: the hook
+    // listens at the document level and does not exclude BUTTON, so an Enter
+    // binding would double-fire (native button activation + this handler) and
+    // send a duplicate ask when a button is focused.
     bindings.push({ key: 'a', action: handleAsk, enabled: kbdCanAsk });
-    bindings.push({ key: 'Enter', action: handleAsk, enabled: kbdCanAsk });
     return bindings;
   }, [kbdCpuPlayers, handleSelectTarget, cycleRank, handleAsk, kbdIsHumanTurn, kbdCanAsk, t]);
   useActionKeyboardNav({ bindings: askBindings, enabled: !!kbdIsHumanTurn });


### PR DESCRIPTION
## 概要
`GoFishPage.tsx` はターン操作（相手選択→ランク選択→Ask）がすべてポインタ前提で、キーボード/スイッチデバイス利用者は毎ターン Tab で3段階辿る必要があった。

## 変更点
- `useActionKeyboardNav` を導入：数字キーで相手 CPU 選択、`←/→` で手札のランクを巡回選択（ラップ）、`Enter` または `a` で Ask（`canAsk` 成立時のみ）
- 選択状態の変化を `role="status" aria-live="polite"` の sr-only リージョンで通知（既存の `aria-pressed` に加えて）。ショートカット説明のヒント行も追加
- 人間の PLAY 手番のみ有効。既存のクリック操作は不変
- `a11y.*`(ja/en, parity) を追加
- `GoFishPage.test.tsx`: Ask 全フロー、`a` エイリアス、ランクのラップ、CPU手番 no-op のキーボードテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/GoFishPage.test.tsx`（27 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）/ patch coverage OK
- [x] gofish ja↔en キー parity 確認

Closes #3107