### PR TITLE
feat(machiavelli): make table melds and layoff accessible

### DIFF
--- a/frontend/src/i18n/locales/en/machiavelli.json
+++ b/frontend/src/i18n/locales/en/machiavelli.json
@@ -49,5 +49,9 @@
     "newMeldButton": "Select 3 or more hand cards to lay a new meld on the table.",
     "scoreTable": "Player scores are shown here. Lowest cumulative total wins.",
     "resetButton": "Press the reset button to start a new game."
+  },
+  "a11y": {
+    "meldLabel": "{{kind}}, {{count}} cards, {{rank}}",
+    "layoffTo": "Lay off onto {{meld}}"
   }
 }

--- a/frontend/src/i18n/locales/ja/machiavelli.json
+++ b/frontend/src/i18n/locales/ja/machiavelli.json
@@ -49,5 +49,9 @@
     "newMeldButton": "手札を3枚以上選んで、新しいメルドを場に出します。",
     "scoreTable": "各プレイヤーのスコアが表示されます。累計最少が勝利です。",
     "resetButton": "リセットボタンで新しいゲームを始められます。"
+  },
+  "a11y": {
+    "meldLabel": "{{kind}} {{count}}枚 {{rank}}",
+    "layoffTo": "{{meld}} にレイオフ"
   }
 }

--- a/frontend/src/pages/MachiavelliPage.test.tsx
+++ b/frontend/src/pages/MachiavelliPage.test.tsx
@@ -170,13 +170,33 @@ describe('MachiavelliPage', () => {
     renderWithProviders(<MachiavelliPage />);
     await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
     // Layoff button disabled with no selection.
-    expect(screen.getByRole('button', { name: 'レイオフ' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /レイオフ/ })).toBeDisabled();
     fireEvent.click(screen.getByAltText('♠ A').closest('button') as HTMLButtonElement);
-    expect(screen.getByRole('button', { name: 'レイオフ' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: /レイオフ/ })).not.toBeDisabled();
     mockExec.mockClear();
     mockExec.mockResolvedValue(turnState);
-    fireEvent.click(screen.getByRole('button', { name: 'レイオフ' }));
+    fireEvent.click(screen.getByRole('button', { name: /レイオフ/ }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('layoff', { meldIdx: 0, handIndex: 0 }));
+  });
+
+  it('labels each table meld and its layoff button for assistive tech', async () => {
+    renderWithProviders(<MachiavelliPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ 3')).toBeInTheDocument());
+    // The meld row is a labelled group describing kind + size + rank range.
+    const meldGroup = screen.getByRole('group', { name: /3枚/ });
+    expect(meldGroup).toBeInTheDocument();
+    // The layoff button's accessible name includes the target meld description.
+    const layoff = screen.getByRole('button', { name: /にレイオフ/ });
+    expect(layoff.getAttribute('aria-label')).toMatch(/3枚/);
+  });
+
+  it('highlights table melds as drop targets when exactly one card is selected', async () => {
+    renderWithProviders(<MachiavelliPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+    const meldGroup = screen.getByRole('group', { name: /3枚/ });
+    expect(meldGroup.className).not.toContain('ring-2');
+    fireEvent.click(screen.getByAltText('♠ A').closest('button') as HTMLButtonElement);
+    await waitFor(() => expect(meldGroup.className).toContain('ring-2'));
   });
 
   it('shows the table-empty placeholder when there are no melds', async () => {
@@ -191,7 +211,7 @@ describe('MachiavelliPage', () => {
     await waitFor(() => expect(screen.getByText('スコア')).toBeInTheDocument());
     expect(screen.queryByRole('button', { name: '山札から引く' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'メルドを出す' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'レイオフ' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /レイオフ/ })).not.toBeInTheDocument();
   });
 
   it('shows next round button on round end and calls nextround', async () => {

--- a/frontend/src/pages/MachiavelliPage.test.tsx
+++ b/frontend/src/pages/MachiavelliPage.test.tsx
@@ -190,6 +190,25 @@ describe('MachiavelliPage', () => {
     expect(layoff.getAttribute('aria-label')).toMatch(/3枚/);
   });
 
+  it('labels a set meld with its shared rank', async () => {
+    // kind 0 = set (three 9s): the aria-label uses the single shared rank.
+    const setMeld: MachiavelliMeld = {
+      kind: 0,
+      cards: [
+        { design: 'SPADE', value: 9 },
+        { design: 'HEART', value: 9 },
+        { design: 'CLOVER', value: 9 },
+      ],
+    };
+    mockExec.mockResolvedValue({ ...turnState, table: [setMeld] });
+    renderWithProviders(<MachiavelliPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ 9')).toBeInTheDocument());
+    const meldGroup = screen.getByRole('group', { name: /3枚/ });
+    // The label carries "9" and, unlike a run, no en-dash range.
+    expect(meldGroup.getAttribute('aria-label')).toMatch(/9/);
+    expect(meldGroup.getAttribute('aria-label')).not.toContain('–');
+  });
+
   it('highlights table melds as drop targets when exactly one card is selected', async () => {
     renderWithProviders(<MachiavelliPage />);
     await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());

--- a/frontend/src/pages/MachiavelliPage.tsx
+++ b/frontend/src/pages/MachiavelliPage.tsx
@@ -35,6 +35,7 @@ import type { MachiavelliResponse } from '../types/card';
 import { MachiavelliPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { valueName } from '../utils/cardUtils';
 import { MACHIAVELLI_HELP, parseMachiavelliCommand } from '../utils/cli/commands/machiavelliCommands';
 import { formatMachiavelliState } from '../utils/cli/formatters/machiavelliFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -170,6 +171,19 @@ function MachiavelliPageContent() {
   const isGameEnd = state.phase === MachiavelliPhase.GAME_END || state.gameEndFlag;
   const revealCpu = isRoundEnd || isGameEnd;
   const isHumanTurn = isTurnPhase && state.players[state.currentPlayerIdx]?.isHuman === true;
+  // When exactly one hand card is selected it can be laid off onto any table
+  // meld, so highlight the melds as drop targets and describe the layoff.
+  const canLayoff = isHumanTurn && selectedCardIndices.length === 1;
+
+  /** Describes a table meld for assistive tech: kind, size, and rank(s). */
+  const meldAria = (meld: { kind: number; cards: { design: string; value: number }[] }): string => {
+    const kind = meld.kind === 0 ? t('meldKindSet') : t('meldKindRun');
+    const rank =
+      meld.kind === 0
+        ? valueName(meld.cards[0]?.value ?? 0)
+        : `${valueName(meld.cards[0]?.value ?? 0)}–${valueName(meld.cards[meld.cards.length - 1]?.value ?? 0)}`;
+    return t('a11y.meldLabel', { kind, count: meld.cards.length, rank });
+  };
 
   return (
     <GamePageShell
@@ -250,9 +264,14 @@ function MachiavelliPageContent() {
                   ) : (
                     <div className="flex flex-col gap-2">
                       {state.table.map((meld, meldIdx) => (
+                        // biome-ignore lint/a11y/useSemanticElements: a labelled group of cards forming one meld; <fieldset> would be semantically wrong here
                         <div
                           key={`meld-${meldIdx}-${meld.kind}-${meld.cards.map((c) => `${c.design}${c.value}`).join('')}`}
-                          className="flex items-center gap-2 flex-wrap"
+                          role="group"
+                          aria-label={meldAria(meld)}
+                          className={`flex items-center gap-2 flex-wrap rounded transition-colors ${
+                            canLayoff ? 'ring-2 ring-ds-accent/70 p-1' : ''
+                          }`}
                         >
                           <span className="text-ds-text-muted text-xs w-14">
                             {meld.kind === 0 ? t('meldKindSet') : t('meldKindRun')}
@@ -272,6 +291,7 @@ function MachiavelliPageContent() {
                               className={btnPrimary}
                               onClick={() => handleLayoff(meldIdx)}
                               disabled={loading || selectedCardIndices.length !== 1}
+                              aria-label={t('a11y.layoffTo', { meld: meldAria(meld) })}
                             >
                               {t('layoffButton')}
                             </button>

--- a/frontend/src/pages/MachiavelliPage.tsx
+++ b/frontend/src/pages/MachiavelliPage.tsx
@@ -178,10 +178,9 @@ function MachiavelliPageContent() {
   /** Describes a table meld for assistive tech: kind, size, and rank(s). */
   const meldAria = (meld: { kind: number; cards: { design: string; value: number }[] }): string => {
     const kind = meld.kind === 0 ? t('meldKindSet') : t('meldKindRun');
-    const rank =
-      meld.kind === 0
-        ? valueName(meld.cards[0]?.value ?? 0)
-        : `${valueName(meld.cards[0]?.value ?? 0)}–${valueName(meld.cards[meld.cards.length - 1]?.value ?? 0)}`;
+    // A set shares one rank; a run spans a range from its first to last card.
+    const first = valueName(meld.cards[0].value);
+    const rank = meld.kind === 0 ? first : `${first}–${valueName(meld.cards[meld.cards.length - 1].value)}`;
     return t('a11y.meldLabel', { kind, count: meld.cards.length, rank });
   };
 


### PR DESCRIPTION
## 概要
`MachiavelliPage.tsx` のテーブルメルドは `<div>` で `aria-label` がなく、どのメルドがどの種類/枚数か支援技術に伝わらなかった。layoff ボタンも対象メルドを説明していなかった。

## 変更点
- 各メルド行を `role="group"` + `aria-label`（種類・枚数・代表ランク/レンジ）で説明
- 各 layoff ボタンに対象メルドを含む `aria-label` を付与（可視ラベル「レイオフ」を含む＝WCAG 2.5.3 準拠）
- 手札を1枚選択中は、レイオフ可能なメルド行を枠強調（ring）
- `a11y.*`(ja/en, parity) を追加
- `MachiavelliPage.test.tsx`: メルド/ボタンの aria ラベル、選択時ハイライトのテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/MachiavelliPage.test.tsx`（35 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）
- [x] machiavelli ja↔en キー parity 確認

Closes #3502