### PR TITLE
feat(deucetoseven): localize the poker hand-name badge

### DIFF
--- a/frontend/src/i18n/locales/en/deucetoseven.json
+++ b/frontend/src/i18n/locales/en/deucetoseven.json
@@ -42,5 +42,17 @@
     "lose": "You lose.",
     "folded": "You folded.",
     "gameOver": "Game over."
+  },
+  "hand": {
+    "highCard": "High Card",
+    "onePair": "One Pair",
+    "twoPair": "Two Pair",
+    "threeOfAKind": "Three of a Kind",
+    "straight": "Straight",
+    "flush": "Flush",
+    "fullHouse": "Full House",
+    "fourOfAKind": "Four of a Kind",
+    "straightFlush": "Straight Flush",
+    "royalFlush": "Royal Flush"
   }
 }

--- a/frontend/src/i18n/locales/ja/deucetoseven.json
+++ b/frontend/src/i18n/locales/ja/deucetoseven.json
@@ -42,5 +42,17 @@
     "lose": "あなたの負けです。",
     "folded": "あなたはフォールドしました。",
     "gameOver": "ゲーム終了"
+  },
+  "hand": {
+    "highCard": "ハイカード",
+    "onePair": "ワンペア",
+    "twoPair": "ツーペア",
+    "threeOfAKind": "スリーカード",
+    "straight": "ストレート",
+    "flush": "フラッシュ",
+    "fullHouse": "フルハウス",
+    "fourOfAKind": "フォーカード",
+    "straightFlush": "ストレートフラッシュ",
+    "royalFlush": "ロイヤルフラッシュ"
   }
 }

--- a/frontend/src/pages/DeuceToSevenPage.test.tsx
+++ b/frontend/src/pages/DeuceToSevenPage.test.tsx
@@ -119,6 +119,42 @@ describe('DeuceToSevenPage', () => {
     await waitFor(() => expect(screen.getByText('あなたの勝ちです。')).toBeInTheDocument());
   });
 
+  it('renders the human hand name translated for the current locale', async () => {
+    mockExec.mockResolvedValue(
+      baseState({
+        phase: DeuceToSevenPhase.END,
+        gameEndFlag: true,
+        // Backend sends the English category; the badge should show the ja label.
+        players: [
+          humanPlayer({ handRank: 1, handName: 'One Pair', folded: false }),
+          cpuPlayer(1),
+          cpuPlayer(2),
+          cpuPlayer(3),
+        ],
+      }),
+    );
+    renderWithProviders(<DeuceToSevenPage />);
+    await waitFor(() => expect(screen.getByText('ワンペア')).toBeInTheDocument());
+    expect(screen.queryByText('One Pair')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the server hand name when the rank is out of range', async () => {
+    mockExec.mockResolvedValue(
+      baseState({
+        phase: DeuceToSevenPhase.END,
+        gameEndFlag: true,
+        players: [
+          humanPlayer({ handRank: 99, handName: 'Mystery Hand', folded: false }),
+          cpuPlayer(1),
+          cpuPlayer(2),
+          cpuPlayer(3),
+        ],
+      }),
+    );
+    renderWithProviders(<DeuceToSevenPage />);
+    await waitFor(() => expect(screen.getByText('Mystery Hand')).toBeInTheDocument());
+  });
+
   it('wires betting buttons during the human turn', async () => {
     mockExec.mockResolvedValue(baseState({ phase: DeuceToSevenPhase.DEAL, currentTurn: 0 }));
     renderWithProviders(<DeuceToSevenPage />);

--- a/frontend/src/pages/DeuceToSevenPage.tsx
+++ b/frontend/src/pages/DeuceToSevenPage.tsx
@@ -40,6 +40,7 @@ import { formatDeuceToSevenState } from '../utils/cli/formatters/deuceToSevenFor
 import type { CliGameConfig } from '../utils/cli/types';
 import { deuceToSevenBestIndices, isMadePatLow } from '../utils/deuceToSevenUtils';
 import { findPlayerName } from '../utils/playerUtils';
+import { type PokerHandRank, pokerHandKey } from '../utils/pokerSquaresUtils';
 
 /** 2-7 Triple Draw tutorial step definitions. */
 const D7_TUTORIAL_STEPS: TutorialStep[] = [
@@ -84,6 +85,10 @@ function DeuceToSevenPageContent() {
   const { cardWidth } = useCardDimensions();
   const { playSound } = useSound();
   const isMobile = useIsMobile();
+  // Translate the poker category via its stable rank so the badge follows the
+  // UI locale; fall back to the server's string if the rank is out of range.
+  const handLabel = (handRank: number, handName: string): string =>
+    t(`hand.${pokerHandKey(handRank as PokerHandRank)}`, { defaultValue: handName });
   const gameHook = useDeuceToSevenGame();
   const { state, loading, error, retry, selected, toggleCard, clearSelection, canExchange } = gameHook;
   const execAction = gameHook.exec;
@@ -240,7 +245,7 @@ function DeuceToSevenPageContent() {
                     currentBet: p.currentBet,
                     folded: p.folded,
                     allIn: p.allIn,
-                    handName: p.handName,
+                    handName: handLabel(p.handRank, p.handName),
                     cards: p.cards,
                   }}
                   showCards={isEnd}
@@ -292,7 +297,7 @@ function DeuceToSevenPageContent() {
                   {humanPlayer.allIn && <span className="ml-2 text-ds-warning text-xs">[{tc('status.allIn')}]</span>}
                   {isEnd && !humanPlayer.folded && humanPlayer.handName && (
                     <span className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}>
-                      {humanPlayer.handName}
+                      {handLabel(humanPlayer.handRank, humanPlayer.handName)}
                     </span>
                   )}
                 </div>


### PR DESCRIPTION
## 概要
`DeuceToSevenPage.tsx` は `humanPlayer.handName` や CPU の役名をサーバー文字列のまま表示しており、日本語UIに英語の役名が混在していた。

## 変更点
- 役名を安定した `handRank`（0=High Card…9=Royal Flush）から `pokerHandKey` → `t('hand.*')` で翻訳表示。範囲外の rank はサーバー文字列にフォールバック
- PokerSquares が使う正準の役名キーを再利用し、deucetoseven の ja/en に追加（parity 維持）
- CPU カードの役名表示（`CpuPlayerCard` へ渡す `handName`）も翻訳済み文字列に
- `DeuceToSevenPage.test.tsx`: 翻訳表示（ワンペア）とフォールバックのテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/DeuceToSevenPage.test.tsx`（17 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）
- [x] deucetoseven ja↔en キー parity 確認

Closes #3179