### PR TITLE
feat(fortyfives): localize the contract and highest-bid labels

### DIFF
--- a/frontend/src/pages/FortyFivesPage.test.tsx
+++ b/frontend/src/pages/FortyFivesPage.test.tsx
@@ -135,6 +135,19 @@ describe('FortyFivesPage', () => {
     expect(screen.getByText('落札者')).toBeInTheDocument();
   });
 
+  it('shows the localized bid name (Jink) in the contract line for a 25 contract', async () => {
+    mockExec.mockResolvedValue({ ...playPhaseState, contract: 25 });
+    renderWithProviders(<FortyFivesPage />);
+    // Contract line shows "25 (Jink)", not the bare number.
+    await waitFor(() => expect(screen.getByText(/落札者:.*25 \(Jink\)/)).toBeInTheDocument());
+  });
+
+  it('shows the localized bid name for the current highest bid', async () => {
+    mockExec.mockResolvedValue(makeFortyFivesState({ bids: [25, 0, 0, 0] }));
+    renderWithProviders(<FortyFivesPage />);
+    await waitFor(() => expect(screen.getByText(/現在の最高ビッド: 25 \(Jink\)/)).toBeInTheDocument());
+  });
+
   it('does not show the play button on a CPU turn', async () => {
     mockExec.mockResolvedValue(cpuTurnState);
     renderWithProviders(<FortyFivesPage />);

--- a/frontend/src/pages/FortyFivesPage.tsx
+++ b/frontend/src/pages/FortyFivesPage.tsx
@@ -149,7 +149,13 @@ function FortyFivesPageContent() {
   const highestBidder = highestBid > 0 ? state.players[state.bids.indexOf(highestBid)] : undefined;
   const highestBidderName = highestBidder ? playerName(highestBidder.id, highestBidder.isHuman) : '';
 
-  const contractLabel = state.contract === 0 ? t('contractUndecided') : String(state.contract);
+  // Map a bid value to its localized name (e.g. 25 -> "25 (Jink)"), matching the
+  // CUI's fortyFivesBidName; fall back to the raw number for any unknown value.
+  const bidName = (value: number): string => {
+    const bid = BIDS.find((b) => b.value === value);
+    return bid ? t(bid.key) : String(value);
+  };
+  const contractLabel = state.contract === 0 ? t('contractUndecided') : bidName(state.contract);
 
   const handleManualReset = () => {
     hideActionLog();
@@ -329,7 +335,9 @@ function FortyFivesPageContent() {
                 <>
                   <span className="text-xs text-ds-text-muted self-center mr-1">{t('bidPrompt')}</span>
                   <span className="text-xs text-ds-text-muted self-center mr-1" data-testid="ff-highest-bid">
-                    {highestBid > 0 ? t('bidHighest', { bid: highestBid, player: highestBidderName }) : t('bidNone')}
+                    {highestBid > 0
+                      ? t('bidHighest', { bid: bidName(highestBid), player: highestBidderName })
+                      : t('bidNone')}
                   </span>
                   {BIDS.map((b) => {
                     // Pass (0) is always allowed; a non-pass bid must beat the current highest.


### PR DESCRIPTION
## 概要
`FortyFivesPage.tsx` の `contractLabel` は `String(state.contract)` で生の数値を表示しており、25 の特別名「25 (Jink)」が Web では単なる「25」となり CUI（`fortyFivesBidName`）と不一致だった。

## 変更点
- 既存の `BIDS` キー（bid.fifteen/twenty/twentyfive）を使う `bidName(value)` を追加し、契約行と最高ビッド表示の両方に適用（未知値は数値にフォールバック）
- 新規ロケールキーなし（既存キー再利用）
- `FortyFivesPage.test.tsx`: 25 契約の Jink 表示と最高ビッド名のテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/FortyFivesPage.test.tsx`（14 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）

Closes #3415