### PR TITLE
feat(daifugo): expose the active sort mode to assistive tech

### DIFF
--- a/frontend/src/i18n/locales/en/daifugo.json
+++ b/frontend/src/i18n/locales/en/daifugo.json
@@ -48,7 +48,8 @@
   "sort": {
     "strength": "By Strength",
     "suit": "By Suit",
-    "number": "By Number"
+    "number": "By Number",
+    "label": "Sort hand"
   },
   "phase": {
     "play": "Play",

--- a/frontend/src/i18n/locales/ja/daifugo.json
+++ b/frontend/src/i18n/locales/ja/daifugo.json
@@ -48,7 +48,8 @@
   "sort": {
     "strength": "強さ順",
     "suit": "スート順",
-    "number": "数字順"
+    "number": "数字順",
+    "label": "手札の並べ替え"
   },
   "phase": {
     "play": "プレイ",

--- a/frontend/src/pages/DaifugoPage.test.tsx
+++ b/frontend/src/pages/DaifugoPage.test.tsx
@@ -119,6 +119,17 @@ describe('DaifugoPage', () => {
     expect(screen.getByTestId('skeleton')).toBeInTheDocument();
   });
 
+  it('marks the active sort button with aria-pressed under an sr-only legend', async () => {
+    // humanTurnState has sortMode 0 (strength).
+    renderWithProviders(<DaifugoPage />);
+    const strength = await screen.findByTestId('df-sort-0');
+    expect(strength).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('df-sort-1')).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByTestId('df-sort-2')).toHaveAttribute('aria-pressed', 'false');
+    // The three buttons are grouped with an accessible legend.
+    expect(screen.getByRole('group', { name: '手札の並べ替え' })).toBeInTheDocument();
+  });
+
   it('shows phase indicator with プレイ during gameplay', async () => {
     renderWithProviders(<DaifugoPage />);
     await waitFor(() => {

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -393,19 +393,22 @@ function DaifugoPageContent() {
           </div>
 
           <GameFooter className={`${footerClass} px-4 py-2.5 motion-safe:transition-colors motion-safe:duration-500`}>
-            <div className="text-center mb-1" data-tutorial="df-sort-buttons">
+            <fieldset className="text-center mb-1 border-0 p-0 m-0" data-tutorial="df-sort-buttons">
+              <legend className="sr-only">{t('sort.label')}</legend>
               {sortModes.map(({ mode, label }) => (
                 <button
                   key={mode}
                   type="button"
                   className={state.sortMode === mode ? `${btnPrimary} min-w-[70px]` : `${btnSecondary} min-w-[70px]`}
                   disabled={loading}
+                  aria-pressed={state.sortMode === mode}
+                  data-testid={`df-sort-${mode}`}
                   onClick={() => exec('sort', undefined, undefined, mode)}
                 >
                   {label}
                 </button>
               ))}
-            </div>
+            </fieldset>
 
             {humanPlayer && (
               <div className="mb-2" data-tutorial="df-player-hand">


### PR DESCRIPTION
## 概要
`DaifugoPage.tsx` の3つのソートボタン（強さ/スート/数字順）は選択状態を `btnPrimary`/`btnSecondary` の見た目のみで表現し、`aria-pressed` がなくスクリーンリーダーで選択中が判別できなかった。

## 変更点
- 各ソートボタンに `aria-pressed={state.sortMode === mode}` を付与
- 3ボタンを `<fieldset>` + `sr-only` の `<legend>` で括る（BigTwo のソート制御と同水準）
- 見た目のスタイル切替は現状維持
- `sort.label` を ja/en に追加（parity 維持）
- `DaifugoPage.test.tsx`: aria-pressed 状態とグループ名のテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/DaifugoPage.test.tsx`（103 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）
- [x] daifugo ja↔en キー parity 確認

Closes #2988