### PR TITLE
feat(caribbeanstud): label the masked dealer cards for assistive tech

### DIFF
--- a/frontend/src/i18n/locales/en/caribbeanstud.json
+++ b/frontend/src/i18n/locales/en/caribbeanstud.json
@@ -81,5 +81,6 @@
     "pairOrBetter": "Pair or better — call recommended",
     "aceKingHigh": "Ace-King high — call recommended",
     "weakHand": "Weak hand — fold recommended"
-  }
+  },
+  "hiddenCard": "Hidden card"
 }

--- a/frontend/src/i18n/locales/ja/caribbeanstud.json
+++ b/frontend/src/i18n/locales/ja/caribbeanstud.json
@@ -81,5 +81,6 @@
     "pairOrBetter": "ペア以上 — コール推奨",
     "aceKingHigh": "A-K ハイ — コール推奨",
     "weakHand": "弱い手札 — フォールド推奨"
-  }
+  },
+  "hiddenCard": "非公開のカード"
 }

--- a/frontend/src/pages/CaribbeanStudPage.test.tsx
+++ b/frontend/src/pages/CaribbeanStudPage.test.tsx
@@ -290,9 +290,8 @@ describe('CaribbeanStudPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'ベット' }));
     await waitFor(() => expect(screen.getByRole('button', { name: 'コール' })).toBeInTheDocument());
 
-    // 5 player face-up + 1 dealer face-up + 4 dealer face-down (CardBack images) = 10 imgs
-    const imgs = screen.getAllByRole('img');
-    expect(imgs.length).toBe(10);
+    // The 4 masked dealer cards are each announced as "hidden card".
+    expect(screen.getAllByRole('img', { name: '非公開のカード' })).toHaveLength(4);
     // Dealer section is shown
     expect(screen.getByText('🔴')).toBeInTheDocument();
   });

--- a/frontend/src/pages/CaribbeanStudPage.tsx
+++ b/frontend/src/pages/CaribbeanStudPage.tsx
@@ -280,7 +280,11 @@ function CaribbeanStudPageContent() {
                 <div className="flex justify-center gap-2 flex-wrap">
                   {state.dealerHand.map((card, i) =>
                     isMaskedCard(card) ? (
-                      <AnimatedCardBack key={`d-back-${i}`} width={cardWidth} />
+                      // role="img" + aria-label makes AT announce "hidden card"
+                      // instead of the generic card-back alt on the inner image.
+                      <span key={`d-back-${i}`} role="img" aria-label={t('hiddenCard')} className="inline-flex">
+                        <AnimatedCardBack width={cardWidth} />
+                      </span>
                     ) : (
                       <AnimatedCard key={`d-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                     ),


### PR DESCRIPTION
## 概要
`CaribbeanStudPage.tsx` の伏せられたディーラーカードは `AnimatedCardBack` の内部画像が汎用の「裏向き」alt を持つのみで、スクリーンリーダー利用者にはディーラーの非公開手札だと分からなかった。

## 変更点
- `isMaskedCard` 分岐の各カードを `role="img"` + `aria-label={t('hiddenCard')}` の span で括る（内部画像は presentational 化）
- 新規キー `hiddenCard` を ja/en に追加（parity 維持）
- 表向きカードの `cardAlt` 表記と区別が明確に
- `CaribbeanStudPage.test.tsx`: 4枚の hiddenCard ラベルを検証

## テスト計画
- [x] `bun run test -- --run src/pages/CaribbeanStudPage.test.tsx`（21 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）
- [x] caribbeanstud ja↔en キー parity 確認

_関連: #3140（テキサスホールデムボーナス/レットイットライドの同様箇所）は別issue。_

Closes #3137