### PR TITLE
feat(texasholdembonus): label the masked dealer cards for assistive tech

### DIFF
--- a/frontend/src/i18n/locales/en/texasholdembonus.json
+++ b/frontend/src/i18n/locales/en/texasholdembonus.json
@@ -87,5 +87,6 @@
     "broadwayCards": "Broadway cards — play recommended",
     "pairOrBetter": "Pair or better — raise recommended",
     "weakHand": "Weak hand"
-  }
+  },
+  "hiddenCard": "Hidden card"
 }

--- a/frontend/src/i18n/locales/ja/texasholdembonus.json
+++ b/frontend/src/i18n/locales/ja/texasholdembonus.json
@@ -87,5 +87,6 @@
     "broadwayCards": "ブロードウェイ — プレイ推奨",
     "pairOrBetter": "ペア以上 — レイズ推奨",
     "weakHand": "弱い手札"
-  }
+  },
+  "hiddenCard": "非公開のカード"
 }

--- a/frontend/src/pages/TexasHoldemBonusPage.test.tsx
+++ b/frontend/src/pages/TexasHoldemBonusPage.test.tsx
@@ -260,8 +260,8 @@ describe('TexasHoldemBonusPage', () => {
   it('renders board and player cards in flop phase', async () => {
     mockApi.mockResolvedValue(flopState);
     renderWithProviders(<TexasHoldemBonusPage />);
-    // 2 player face-up + 3 community face-up + 2 dealer face-down = 7 imgs
-    await waitFor(() => expect(screen.getAllByRole('img').length).toBe(7));
+    // 2 dealer face-down cards are each announced as "hidden card".
+    await waitFor(() => expect(screen.getAllByRole('img', { name: '非公開のカード' })).toHaveLength(2));
     expect(screen.getByText('🟡')).toBeInTheDocument();
     expect(screen.getByText('🔴')).toBeInTheDocument();
     expect(screen.getByText('🃏')).toBeInTheDocument();

--- a/frontend/src/pages/TexasHoldemBonusPage.tsx
+++ b/frontend/src/pages/TexasHoldemBonusPage.tsx
@@ -282,7 +282,11 @@ function TexasHoldemBonusPageContent() {
                 <div className="flex justify-center gap-2 flex-wrap">
                   {state.dealerHand.map((card, i) =>
                     isMaskedCard(card) ? (
-                      <AnimatedCardBack key={`d-back-${i}`} width={cardWidth} />
+                      // role="img" + aria-label makes AT announce "hidden card"
+                      // instead of the generic card-back alt on the inner image.
+                      <span key={`d-back-${i}`} role="img" aria-label={t('hiddenCard')} className="inline-flex">
+                        <AnimatedCardBack width={cardWidth} />
+                      </span>
                     ) : (
                       <AnimatedCard key={`d-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
                     ),


### PR DESCRIPTION
## 概要
`TexasHoldemBonusPage.tsx` のプリフロップ〜ターンで伏せられたディーラーカードは `AnimatedCardBack` の内部画像が汎用「裏向き」alt を持つのみで、スクリーンリーダー利用者に非公開手札の状態が伝わらなかった。

## 変更点
- `isMaskedCard` 分岐の各カードを `role="img"` + `aria-label={t('hiddenCard')}` の span で括る（内部画像は presentational 化）。Caribbean Stud (#3137) と同一手法
- 新規キー `hiddenCard` を ja/en に追加（parity 維持）
- END フェーズで表向きになると通常の `cardAlt` ラベルに戻る
- `TexasHoldemBonusPage.test.tsx`: フロップ時の hiddenCard ラベルを検証

## テスト計画
- [x] `bun run test -- --run src/pages/TexasHoldemBonusPage.test.tsx`（20 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）
- [x] texasholdembonus ja↔en キー parity 確認

Closes #3140