### PR TITLE
feat(cribbage): caption the score tables and label the empty header

### DIFF
--- a/frontend/src/i18n/locales/en/cribbage.json
+++ b/frontend/src/i18n/locales/en/cribbage.json
@@ -49,7 +49,9 @@
     "runs": "Runs",
     "flush": "Flush",
     "nobs": "Nobs",
-    "total": "Total"
+    "total": "Total",
+    "caption": "Show scoring breakdown",
+    "subject": "Subject"
   },
   "handScoreLabels": {
     "you": "Your Hand",
@@ -79,5 +81,6 @@
     "resetButton": "Press the reset button to start a new game."
   },
   "pegBoardAria": "Peg board (scores)",
-  "scoreSummary": "{{name}}: {{score}} of {{limit}} points"
+  "scoreSummary": "{{name}}: {{score}} of {{limit}} points",
+  "scoresCaption": "Score by player"
 }

--- a/frontend/src/i18n/locales/ja/cribbage.json
+++ b/frontend/src/i18n/locales/ja/cribbage.json
@@ -49,7 +49,9 @@
     "runs": "ラン",
     "flush": "フラッシュ",
     "nobs": "ノブ",
-    "total": "合計"
+    "total": "合計",
+    "caption": "ショー得点の内訳",
+    "subject": "対象"
   },
   "handScoreLabels": {
     "you": "あなたのハンド",
@@ -79,5 +81,6 @@
     "resetButton": "リセットボタンで新しいゲームを始められます。"
   },
   "pegBoardAria": "ペグボード（得点）",
-  "scoreSummary": "{{name}}: {{score}} / {{limit}} 点"
+  "scoreSummary": "{{name}}: {{score}} / {{limit}} 点",
+  "scoresCaption": "プレイヤー別スコア"
 }

--- a/frontend/src/pages/CribbagePage.test.tsx
+++ b/frontend/src/pages/CribbagePage.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, cribbageApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
@@ -298,6 +298,17 @@ describe('CribbagePage', () => {
     mockExec.mockResolvedValue(showPhaseState);
     renderWithProviders(<CribbagePage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '次を表示' })).toBeInTheDocument());
+  });
+
+  it('gives the score-breakdown table a caption and a labeled first column header', async () => {
+    mockExec.mockResolvedValue(showPhaseState);
+    renderWithProviders(<CribbagePage />);
+    // The breakdown table is captioned...
+    const table = await screen.findByRole('table', { name: 'ショー得点の内訳' });
+    expect(table).toBeInTheDocument();
+    // ...and its previously-empty first column header now has an accessible name.
+    const headers = within(table).getAllByRole('columnheader');
+    expect(headers[0]).toHaveTextContent('対象');
   });
 
   it('calls shownext when show next button is clicked', async () => {

--- a/frontend/src/pages/CribbagePage.tsx
+++ b/frontend/src/pages/CribbagePage.tsx
@@ -422,9 +422,12 @@ function CribbagePageContent() {
                   <div className="my-3 p-2 rounded bg-black/30">
                     <div className="text-ds-text-muted text-sm mb-1">{t('score')}</div>
                     <table className="w-full text-sm text-ds-text-muted">
+                      <caption className="sr-only">{t('scoreDetail.caption')}</caption>
                       <thead>
                         <tr>
-                          <th scope="col" className="text-left" />
+                          <th scope="col" className="text-left">
+                            <span className="sr-only">{t('scoreDetail.subject')}</span>
+                          </th>
                           <th scope="col">{t('scoreDetail.fifteens')}</th>
                           <th scope="col">{t('scoreDetail.pairs')}</th>
                           <th scope="col">{t('scoreDetail.runs')}</th>
@@ -495,6 +498,7 @@ function CribbagePageContent() {
                 <div className="my-3 p-2 rounded bg-black/30">
                   <div className="text-ds-text-muted text-sm mb-1">{t('scores')}</div>
                   <table className="w-full text-sm text-ds-text-muted">
+                    <caption className="sr-only">{t('scoresCaption')}</caption>
                     <thead>
                       <tr>
                         <th scope="col" className="text-left">


### PR DESCRIPTION
## 概要
`CribbagePage.tsx` のショー得点内訳テーブルは1列目ヘッダーが空要素で、スクリーンリーダーが「あなた/CPU/クリブ」のラベル列を無名で読み上げていた。テーブルに caption もなく、周辺テキストとの関連付けが視覚配置頼みだった。

## 変更点
- 空の `th` に sr-only の「対象」ラベルを付与（視覚レイアウトは不変）
- 得点内訳テーブルとプレイヤー別スコア表の両方に sr-only `<caption>` を追加
- `scoreDetail.caption`/`scoreDetail.subject`/`scoresCaption` を ja/en に追加（parity 維持）
- `CribbagePage.test.tsx`: caption と1列目 columnheader のラベルを検証

## テスト計画
- [x] `bun run test -- --run src/pages/CribbagePage.test.tsx`（57 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）
- [x] cribbage ja↔en キー parity 確認

Closes #3089