### PR TITLE
feat(speed): localize the hand and center-pile card aria-labels

### DIFF
--- a/frontend/src/i18n/locales/en/speed.json
+++ b/frontend/src/i18n/locales/en/speed.json
@@ -8,7 +8,6 @@
   "yourHand": "Your Hand",
   "cpuHand": "CPU Hand",
   "drawPile": "Draw Pile",
-  "centerPile": "Center Pile",
   "selectCard": "Select a card from your hand",
   "selectPile": "Click a center pile to play",
   "playButton": "Play",
@@ -36,5 +35,6 @@
     "playerHand": "Your hand: tap a card to select, then tap a center pile to play",
     "drawPile": "Draw pile: cards are automatically drawn when you play",
     "flipButton": "Flip button: press when stuck to turn over new center cards"
-  }
+  },
+  "centerPileCard": "Center pile {{n}}: {{card}}"
 }

--- a/frontend/src/i18n/locales/ja/speed.json
+++ b/frontend/src/i18n/locales/ja/speed.json
@@ -8,7 +8,6 @@
   "yourHand": "手札",
   "cpuHand": "CPU手札",
   "drawPile": "山札",
-  "centerPile": "台札",
   "selectCard": "手札からカードを選択",
   "selectPile": "台札をクリックして出す",
   "playButton": "出す",
@@ -36,5 +35,6 @@
     "playerHand": "あなたの手札：タップして台札に出します",
     "drawPile": "山札：カードを出すと自動で補充されます",
     "flipButton": "めくるボタン：膠着時に押してカードをめくります"
-  }
+  },
+  "centerPileCard": "台札{{n}}: {{card}}"
 }

--- a/frontend/src/pages/SpeedPage.test.tsx
+++ b/frontend/src/pages/SpeedPage.test.tsx
@@ -164,8 +164,9 @@ describe('SpeedPage', () => {
     mockExec.mockResolvedValue(stuckState);
     renderWithProviders(<SpeedPage />);
     await waitFor(() => expect(screen.getByText('めくる')).toBeInTheDocument());
-    // Card buttons should be disabled in stuck phase
-    const cardButtons = screen.queryAllByRole('button', { name: /SPADE|HEART|CLOVER|DIAMOND/ });
+    // Card buttons (cardAlt labels use suit symbols) should be disabled in stuck phase.
+    const cardButtons = screen.queryAllByRole('button', { name: /[♠♥♣♦]/ });
+    expect(cardButtons.length).toBeGreaterThan(0);
     for (const btn of cardButtons) {
       expect(btn).toBeDisabled();
     }
@@ -181,18 +182,26 @@ describe('SpeedPage', () => {
     renderWithProviders(<SpeedPage />);
     await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
     // DIAMOND 2 is not adjacent to either center pile (5 or 9), so it toggles normally
-    const cardBtn = screen.getByRole('button', { name: 'DIAMOND 2' });
+    const cardBtn = screen.getByRole('button', { name: '♦ 2' });
     fireEvent.click(cardBtn);
     expect(cardBtn).toHaveAttribute('aria-pressed', 'true');
     fireEvent.click(cardBtn);
     expect(cardBtn).toHaveAttribute('aria-pressed', 'false');
   });
 
+  it('includes the localized top-card name in the center pile aria-labels', async () => {
+    renderWithProviders(<SpeedPage />);
+    await screen.findByText('手札');
+    // Center piles top with ♦5 and ♠9 → the labels name the card to play onto.
+    expect(screen.getByRole('button', { name: '台札1: ♦ 5' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '台札2: ♠ 9' })).toBeInTheDocument();
+  });
+
   it('auto-plays a card via smart-click when only one valid pile exists', async () => {
     renderWithProviders(<SpeedPage />);
     await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
     // SPADE 4 is adjacent to pile 0 (value 5) only → smart-click auto-plays
-    fireEvent.click(screen.getByRole('button', { name: 'SPADE 4' }));
+    fireEvent.click(screen.getByRole('button', { name: '♠ 4' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', 0, 0));
   });
 
@@ -200,7 +209,7 @@ describe('SpeedPage', () => {
     renderWithProviders(<SpeedPage />);
     await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
     // DIAMOND 2 has no valid piles, so it toggles selection first
-    fireEvent.click(screen.getByRole('button', { name: 'DIAMOND 2' }));
+    fireEvent.click(screen.getByRole('button', { name: '♦ 2' }));
     // Then click first center pile manually
     const pileBtns = screen.getAllByRole('button', { name: /台札/ });
     fireEvent.click(pileBtns[0]);
@@ -306,7 +315,7 @@ describe('SpeedPage', () => {
     renderWithProviders(<SpeedPage />);
     await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
     // Select a card with no auto-pile so it stays selected
-    fireEvent.click(screen.getByRole('button', { name: 'DIAMOND 2' }));
+    fireEvent.click(screen.getByRole('button', { name: '♦ 2' }));
     fireEvent.keyDown(window, { key: 'ArrowRight' });
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', 3, 1));
   });
@@ -314,7 +323,7 @@ describe('SpeedPage', () => {
   it('keyboard shortcut: ArrowLeft plays the selected card to left pile', async () => {
     renderWithProviders(<SpeedPage />);
     await waitFor(() => expect(screen.getByText('手札')).toBeInTheDocument());
-    fireEvent.click(screen.getByRole('button', { name: 'DIAMOND 2' }));
+    fireEvent.click(screen.getByRole('button', { name: '♦ 2' }));
     fireEvent.keyDown(window, { key: 'ArrowLeft' });
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', 3, 0));
   });

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -27,6 +27,7 @@ import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import type { SpeedResponse } from '../types/card';
 import { SpeedPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import { parseSpeedCommand, SPEED_HELP } from '../utils/cli/commands/speedCommands';
 import { formatSpeedState } from '../utils/cli/formatters/speedFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -198,7 +199,11 @@ function SpeedPageContent() {
                   onClick={isStuck ? handleFlip : () => handlePlay(pi)}
                   disabled={isStuck ? loading : !isPlayPhase || selectedCardIndices.length !== 1 || loading}
                   className={`transition-transform hover:scale-105 disabled:opacity-50 ${focusRingCard}${isStuck && !loading ? ' animate-pulse cursor-pointer' : ''}`}
-                  aria-label={isStuck ? t('flipCenterPile', { n: pi + 1 }) : `${t('centerPile')} ${pi}`}
+                  aria-label={
+                    isStuck
+                      ? t('flipCenterPile', { n: pi + 1 })
+                      : t('centerPileCard', { n: pi + 1, card: cardAlt(card) })
+                  }
                 >
                   {card && <AnimatedCard card={card} width={cardWidth * 1.2} />}
                 </button>
@@ -238,7 +243,7 @@ function SpeedPageContent() {
                     key={`${card.design}-${card.value}-${idx}`}
                     onClick={() => handleSmartClick(idx, humanPlayer.cards, state.centerPiles)}
                     disabled={!isPlayPhase || loading}
-                    aria-label={`${card.design} ${card.value}`}
+                    aria-label={cardAlt(card)}
                     aria-pressed={selectedCardIndices.includes(idx)}
                     className={`transition-transform ${focusRingCard}`}
                     style={selectedCardStyle(selectedCardIndices.includes(idx))}


### PR DESCRIPTION
## 概要
`SpeedPage.tsx` の手札ボタンは `aria-label={`${card.design} ${card.value}`}` と生の英語 enum（例「SPADE 13」）を読み上げ、他ページの `cardAlt(card)` 規約から外れていた。中央の台札ボタンはカード名を含まず「何の上に出すか」が伝わらなかった。

## 変更点
- 手札の `aria-label` を `cardAlt(card)` に変更（ロケール対応・K/Q/J/A 変換）
- 台札ボタンにトップカード名を含む `aria-label`（`centerPileCard`＝「台札1: ♥ 7」）を付与
- 新規キー `centerPileCard` を ja/en に追加（parity 維持）
- `SpeedPage.test.tsx`: role 名ベースのクエリを cardAlt 表記に更新＋台札ラベルのテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/SpeedPage.test.tsx`（46 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）
- [x] speed ja↔en キー parity 確認

Closes #3104