### PR TITLE
feat(clocksolitaire): announce step results in a live region

### DIFF
--- a/frontend/src/pages/ClockSolitairePage.test.tsx
+++ b/frontend/src/pages/ClockSolitairePage.test.tsx
@@ -114,6 +114,40 @@ describe('ClockSolitairePage', () => {
     await waitFor(() => expect(screen.getByTestId('phase-indicator')).toHaveTextContent('ゲームクリア'));
   });
 
+  it('mirrors the resolved message in a polite live region', async () => {
+    renderWithProviders(<ClockSolitairePage />);
+    const live = await screen.findByTestId('cs-live-region');
+    expect(live).toHaveAttribute('aria-live', 'polite');
+    expect(live).toHaveAttribute('role', 'status');
+    await waitFor(() => expect(live).toHaveTextContent('プレイ中'));
+  });
+
+  it('announces the game-clear result (with step count) in the live region', async () => {
+    mockExec.mockResolvedValue(gameClearState);
+    renderWithProviders(<ClockSolitairePage />);
+    const live = await screen.findByTestId('cs-live-region');
+    await waitFor(() => expect(live).toHaveTextContent('ゲームクリア'));
+    expect(live.textContent).toMatch(/48/);
+  });
+
+  it('falls back to the raw message when there is no messageCode', async () => {
+    mockExec.mockResolvedValue({ ...playingState, messageCode: undefined, message: 'カスタムメッセージ' });
+    renderWithProviders(<ClockSolitairePage />);
+    const live = await screen.findByTestId('cs-live-region');
+    await waitFor(() => expect(live).toHaveTextContent('カスタムメッセージ'));
+  });
+
+  it('falls back to the raw message when the messageCode has no translation', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      messageCode: 'clocksolitaire.unknownCode',
+      message: '生メッセージ',
+    });
+    renderWithProviders(<ClockSolitairePage />);
+    const live = await screen.findByTestId('cs-live-region');
+    await waitFor(() => expect(live).toHaveTextContent('生メッセージ'));
+  });
+
   it('shows game over phase name', async () => {
     mockExec.mockResolvedValue(gameOverState);
     renderWithProviders(<ClockSolitairePage />);

--- a/frontend/src/pages/ClockSolitairePage.tsx
+++ b/frontend/src/pages/ClockSolitairePage.tsx
@@ -142,6 +142,17 @@ function ClockSolitairePageContent() {
 
   const radius = Math.min(cardWidth * 5, 180);
 
+  // Resolve the same text GameMessageBox shows so it can also be announced in a
+  // dedicated live region (the visible box is not guaranteed to be a live region).
+  const liveMessage = (() => {
+    if (state.messageCode) {
+      const key = `messageCode.${state.messageCode}`;
+      const translated = tc(key, state.messageParams ?? {});
+      if (translated !== key) return translated;
+    }
+    return state.message ?? '';
+  })();
+
   return (
     <GamePageShell
       title={tc('nav.clocksolitaire')}
@@ -291,6 +302,10 @@ function ClockSolitairePageContent() {
               messageCode={state.messageCode}
               messageParams={state.messageParams}
             />
+            {/* Announce each step's result (and game clear/over) to screen readers. */}
+            <div className="sr-only" role="status" aria-live="polite" data-testid="cs-live-region">
+              {liveMessage}
+            </div>
 
             <ActionLogSection
               isEndPhase={isEnded}


### PR DESCRIPTION
## 概要
`ClockSolitairePageContent` は配置先パイルの視覚ハイライト（`isFlightTarget`）のみで、スクリーンリーダー向けの `aria-live` 領域がなかった。`GameMessageBox` の `state.message` はライブリージョンである保証がなかった。

## 変更点
- `GameMessageBox` が表示するのと同じ解決済みメッセージを読み上げる、`sr-only` の `role="status" aria-live="polite"` 領域を追加
- 1手ごとの配置結果および `GAME_CLEAR`/`GAME_OVER` を通知
- 既存の視覚ハイライトは不変
- `ClockSolitairePage.test.tsx`: ライブリージョンとゲームクリア通知のテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/ClockSolitairePage.test.tsx`（19 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）

Closes #3123