### PR TITLE
feat(durak): announce CPU actions in a live region

### DIFF
--- a/frontend/src/pages/DurakPage.test.tsx
+++ b/frontend/src/pages/DurakPage.test.tsx
@@ -89,6 +89,17 @@ describe('DurakPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined, defaultConfig));
   });
 
+  it('announces CPU actions in a polite live region', async () => {
+    mockExec.mockResolvedValue({
+      ...baseState,
+      cpuActions: [{ playerIdx: 1, actionType: 0, card: null, attackIdx: -1 }],
+    });
+    renderWithProviders(<DurakPage />);
+    const log = await screen.findByTestId('durak-cpu-actions');
+    expect(log).toHaveAttribute('aria-live', 'polite');
+    expect(log).toHaveAttribute('role', 'status');
+  });
+
   it('renders CPU player areas', async () => {
     renderWithProviders(<DurakPage />);
     await waitFor(() => {

--- a/frontend/src/pages/DurakPage.tsx
+++ b/frontend/src/pages/DurakPage.tsx
@@ -310,7 +310,12 @@ function DurakPageContent() {
 
                 {/* CPU actions */}
                 {state.cpuActions.length > 0 && (
-                  <div className="bg-black/40 rounded-lg text-game-text-muted py-2 px-3.5 my-2 whitespace-pre-line text-xs">
+                  <div
+                    role="status"
+                    aria-live="polite"
+                    data-testid="durak-cpu-actions"
+                    className="bg-black/40 rounded-lg text-game-text-muted py-2 px-3.5 my-2 whitespace-pre-line text-xs"
+                  >
                     {[
                       tc('label.cpuActions'),
                       ...state.cpuActions.map(


### PR DESCRIPTION
## 概要
`DurakPageContent` の CPU 行動ログは通常の `<div>` で `aria-live` がなく、3人の CPU が攻撃/防御/パス/テイクを進めてもスクリーンリーダーに自動読み上げされなかった（4人プレイで状況把握が遅れる）。

## 変更点
- CPU 行動ログの `<div>` に `role="status"` と `aria-live="polite"` を付与（このブロックは直近の CPU ターンの行動を保持するため、更新時に新しい動きが読み上げられる）
- 視覚的レイアウト・スタイルは不変
- `DurakPage.test.tsx`: ライブリージョン属性のテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/DurakPage.test.tsx`（26 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）

Closes #3126