### PR TITLE
feat(paigow): announce foul status in an assertive live region

### DIFF
--- a/frontend/src/pages/PaiGowPage.test.tsx
+++ b/frontend/src/pages/PaiGowPage.test.tsx
@@ -201,13 +201,23 @@ describe('PaiGowPage', () => {
     renderWithProviders(<PaiGowPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'セット' })).toBeInTheDocument());
 
+    // Before selecting, the assertive live region is present but empty (so a
+    // later foul — and its clearing — are both announced).
+    const foulRegion = screen.getByTestId('foul-warning');
+    expect(foulRegion).toHaveAttribute('aria-live', 'assertive');
+    expect(foulRegion).toHaveTextContent('');
+
     // Low = [D13, S3] (top 13); high = [S10, H11, C5, H7, D9] (top 11) → foul.
     const cardButtons = getCardButtons();
     fireEvent.click(cardButtons[2]);
     fireEvent.click(cardButtons[5]);
 
-    expect(screen.getByTestId('foul-warning')).toBeInTheDocument();
+    expect(foulRegion).not.toHaveTextContent('');
     expect(screen.getByTestId('set-hands-button')).toBeDisabled();
+
+    // Deselecting a card clears the foul → the region empties (announcing the change).
+    fireEvent.click(cardButtons[5]);
+    await waitFor(() => expect(screen.getByTestId('foul-warning')).toHaveTextContent(''));
   });
 
   it('deselects a card when clicked again', async () => {

--- a/frontend/src/pages/PaiGowPage.tsx
+++ b/frontend/src/pages/PaiGowPage.tsx
@@ -379,11 +379,12 @@ function PaiGowPageContent() {
             )}
             {isSetHandsPhase && (
               <div className="flex flex-col items-center gap-1 pb-2">
-                {foul.isFoul && (
-                  <p data-testid="foul-warning" className="text-ds-error text-sm font-medium">
-                    {t('foulWarning')}
-                  </p>
-                )}
+                {/* Always-rendered assertive live region so both the onset and the
+                    clearing of a foul are announced (an unmounted region can't
+                    announce its own removal). Empty <p> collapses to no height. */}
+                <p data-testid="foul-warning" aria-live="assertive" className="text-ds-error text-sm font-medium">
+                  {foul.isFoul ? t('foulWarning') : ''}
+                </p>
                 <details data-testid="foul-rule-help" className="text-xs text-ds-text-muted max-w-sm text-center">
                   <summary className="cursor-pointer text-ds-info">{t('foulRuleHelpTitle')}</summary>
                   <p className="pt-1">{t('foulRuleHelp')}</p>


### PR DESCRIPTION
## 概要
`PaiGowPage.tsx` のファウル警告は条件付きマウントで色＋テキストのみだったため、カード選択でファウルになった瞬間（および別選択で解消した瞬間）がスクリーンリーダーに伝わらなかった。

## 変更点
- 常時レンダリングされる `aria-live="assertive"` 領域に変更（正常時は空、ファウル時に警告文）。ファウルの発生と解消の両方が通知される。空の `<p>` は高さ0に潰れ、視覚レイアウトは不変
- `PaiGowPage.test.tsx`: aria-live 属性とファウル解消（テキストが空に戻る）のテストを追加

## テスト計画
- [x] `bun run test -- --run src/pages/PaiGowPage.test.tsx`（32 passed）
- [x] `bun run check`（exit 0）/ `npx tsc -b`（exit 0）

Closes #3132