### PR TITLE
feat(crazyeights): announce suit changes and label illegal cards for screen readers

### DIFF
--- a/frontend/src/i18n/locales/en/crazyeights.json
+++ b/frontend/src/i18n/locales/en/crazyeights.json
@@ -17,6 +17,13 @@
   "drawPile": "Draw pile: {{count}} cards",
   "discardTop": "Discard",
   "chosenSuit": "Chosen suit",
+  "suitChanged": "Chosen suit changed to {{suit}}",
+  "suitName": {
+    "spade": "Spades",
+    "clover": "Clubs",
+    "heart": "Hearts",
+    "diamond": "Diamonds"
+  },
   "cards": "{{count}} cards",
   "cumulativeScore": "Total: {{score}}",
   "roundScore": "Round: {{score}}",

--- a/frontend/src/i18n/locales/ja/crazyeights.json
+++ b/frontend/src/i18n/locales/ja/crazyeights.json
@@ -17,6 +17,13 @@
   "drawPile": "山札: {{count}}枚",
   "discardTop": "捨て札",
   "chosenSuit": "指定スート",
+  "suitChanged": "スートが {{suit}} に変更されました",
+  "suitName": {
+    "spade": "スペード",
+    "clover": "クローバー",
+    "heart": "ハート",
+    "diamond": "ダイヤ"
+  },
   "cards": "{{count}}枚",
   "cumulativeScore": "累計: {{score}}",
   "roundScore": "ラウンド: {{score}}",

--- a/frontend/src/pages/CrazyEightsPage.test.tsx
+++ b/frontend/src/pages/CrazyEightsPage.test.tsx
@@ -383,6 +383,50 @@ describe('CrazyEightsPage', () => {
     });
   });
 
+  it('announces the chosen suit in a polite live region when chosenSuit > 0', async () => {
+    mockExec.mockResolvedValue(chosenSuitState); // chosenSuit: 1 → spade
+    renderWithProviders(<CrazyEightsPage />);
+    const region = await screen.findByTestId('ce-suit-live-region');
+    expect(region).toHaveAttribute('role', 'status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    expect(region).toHaveTextContent('スートが スペード に変更されました');
+  });
+
+  it('keeps the suit live region empty when no suit is chosen', async () => {
+    renderWithProviders(<CrazyEightsPage />);
+    const region = await screen.findByTestId('ce-suit-live-region');
+    expect(region).toHaveTextContent('');
+  });
+
+  it('keeps the suit live region empty for an unknown suit value', async () => {
+    mockExec.mockResolvedValue(unknownSuitState); // chosenSuit: 99
+    renderWithProviders(<CrazyEightsPage />);
+    await waitFor(() => expect(screen.getByText(/指定スート: \?/)).toBeInTheDocument());
+    expect(screen.getByTestId('ce-suit-live-region')).toHaveTextContent('');
+  });
+
+  it('associates the illegal-play reason with illegal cards via aria-describedby', async () => {
+    // Discard top ♥7; ♠A is illegal on the human turn.
+    renderWithProviders(<CrazyEightsPage />);
+    const illegal = await screen.findByLabelText('♠ A');
+    expect(illegal).toHaveAttribute('aria-describedby', 'ce-illegal-reason');
+    const reason = document.getElementById('ce-illegal-reason');
+    expect(reason).toHaveTextContent('このカードは出せません（スート・数字・8 のいずれも不一致）');
+  });
+
+  it('does not set aria-describedby on legal cards', async () => {
+    renderWithProviders(<CrazyEightsPage />);
+    const legal = await screen.findByLabelText('♥ J');
+    expect(legal).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('does not set aria-describedby on cards during a CPU turn', async () => {
+    mockExec.mockResolvedValue(cpuTurnState);
+    renderWithProviders(<CrazyEightsPage />);
+    const card = await screen.findByLabelText('♠ A');
+    expect(card).not.toHaveAttribute('aria-describedby');
+  });
+
   it('card selection toggle via aria-pressed', async () => {
     renderWithProviders(<CrazyEightsPage />);
     await waitFor(() => expect(screen.getByAltText('\u2660 A')).toBeInTheDocument());

--- a/frontend/src/pages/CrazyEightsPage.tsx
+++ b/frontend/src/pages/CrazyEightsPage.tsx
@@ -57,6 +57,17 @@ const SUIT_SYMBOLS: Record<number, string> = {
   [CrazyEightsSuit.DIAMOND]: '♦',
 };
 
+/** Chosen-suit number → i18n key for the spoken suit name (used in the live-region announcement). */
+const SUIT_NAME_KEYS: Record<number, string> = {
+  [CrazyEightsSuit.SPADE]: 'suitName.spade',
+  [CrazyEightsSuit.CLOVER]: 'suitName.clover',
+  [CrazyEightsSuit.HEART]: 'suitName.heart',
+  [CrazyEightsSuit.DIAMOND]: 'suitName.diamond',
+};
+
+/** DOM id linking each illegal card button to the shared screen-reader reason text. */
+const ILLEGAL_REASON_ID = 'ce-illegal-reason';
+
 /** Crazy Eights tutorial step definitions. */
 const CE_TUTORIAL_STEPS: TutorialStep[] = [
   {
@@ -169,6 +180,12 @@ function CrazyEightsPageContent() {
   const isGameEnd = state.phase === CrazyEightsPhase.GAME_END || state.gameEndFlag;
   const isHumanTurn = isPlayPhase && state.players[state.currentPlayerIdx]?.isHuman === true;
 
+  // Announce the active suit whenever an 8 has changed it. The watermark and the
+  // sidebar readout are aria-hidden / static, so this sr-only live region is the
+  // only channel that tells a screen-reader user a suit was chosen (e.g. by a CPU).
+  const suitNameKey = SUIT_NAME_KEYS[state.chosenSuit];
+  const suitAnnouncement = state.chosenSuit > 0 && suitNameKey ? t('suitChanged', { suit: t(suitNameKey) }) : '';
+
   return (
     <GamePageShell
       title={tc('nav.crazyeights')}
@@ -228,6 +245,12 @@ function CrazyEightsPageContent() {
             <div className="text-ds-text-primary text-center mb-2">
               <span className="mr-4">{t('round', { n: state.roundNumber })}</span>
               <span>{t('drawPile', { count: state.drawPileCount })}</span>
+            </div>
+
+            {/* Always-rendered polite live region announcing the active suit after an 8.
+                Empty when no suit is chosen so the announcement fires on the transition. */}
+            <div className="sr-only" role="status" aria-live="polite" data-testid="ce-suit-live-region">
+              {suitAnnouncement}
             </div>
 
             <div className={lgTwoColGrid}>
@@ -324,6 +347,11 @@ function CrazyEightsPageContent() {
           <GameFooter className={`${gameTheme.crazyeights.footer} px-4 py-2.5`}>
             {humanPlayer && (
               <div className="flex flex-wrap gap-1 mb-2" data-tutorial="ce-player-hand">
+                {/* Shared screen-reader reason, referenced by every illegal card via
+                    aria-describedby so the "why" is spoken (title alone is skipped by SRs). */}
+                <span id={ILLEGAL_REASON_ID} className="sr-only">
+                  {t('illegalHint')}
+                </span>
                 {humanPlayer.cards.map((card, idx) => {
                   // On the human's turn, highlight playable cards (matching suit/rank or an 8)
                   // and dim the rest with a reason tooltip, so the rule is visible at a glance.
@@ -336,6 +364,7 @@ function CrazyEightsPageContent() {
                       aria-label={cardAlt(card)}
                       aria-pressed={selectedCardIndices.includes(idx)}
                       title={isHumanTurn && !legal ? t('illegalHint') : undefined}
+                      aria-describedby={isHumanTurn && !legal ? ILLEGAL_REASON_ID : undefined}
                       data-legal={isHumanTurn ? legal : undefined}
                       className={`transition-transform ${focusRingCard} ${
                         isHumanTurn && legal ? 'rounded-lg ring-2 ring-ds-success' : ''


### PR DESCRIPTION
## 概要 / Summary

Closes #3049

Crazy Eights のスート変更と非合法カードをスクリーンリーダーに伝わるようにするアクセシビリティ改善。

- CPU（またはプレイヤー）が 8 を出してスートを変えても、透かし（`aria-hidden`）と静的なサイドバー表示しか手がかりがなく、スクリーンリーダー利用者に変更が通知されていなかった。
- 非合法カードの理由は `title` 属性と `opacity` のみで、支援技術では読まれにくかった。

## 変更内容 / Changes

- **スート変更の aria-live 通知**: 常時マウントされる `sr-only` な `role="status" aria-live="polite"` リージョンを追加。8 でスートが指定されたタイミングでスート名（例: 「スートが スペード に変更されました」）を読み上げる。未指定時は空、不明なスート値は読み上げない。
- **非合法カードの理由関連付け**: 各非合法カードボタンを共有の `sr-only` 理由テキストに `aria-describedby`（`ce-illegal-reason`）で関連付け、「なぜ出せないか」を読み上げ可能にした。
- **視覚表示は不変**: 透かし・リング・ディミングは変更なし（既存の透かしテストもグリーンのまま）。
- **i18n**: `ja`/`en` に `suitChanged` とスート名キーを追加（キー完全一致を確認）。

## 受け入れ条件 / Acceptance criteria

- [x] chosenSuit の変化が aria-live で読み上げられる
- [x] 非合法カードに SR 向けの理由説明が関連付く（`aria-describedby`）
- [x] 視覚上の既存表示（透かし・リング）が変わらない
- [x] `CrazyEightsPage.test.tsx` にライブリージョンのテストを追加

## テスト / Test plan

- `bun run test -- --run CrazyEightsPage` — 65 tests pass（新規 6 件: ライブリージョンの読み上げ/空/不明スート、非合法カードの `aria-describedby`、合法カード・CPU ターンで未設定）
- `bun run build` — OK
- `bunx tsc --noEmit` — exit 0
- `bunx biome check`（変更 4 ファイル）— clean