### PR TITLE
feat(jokerpoker): announce the draw result via an aria-live region

### DIFF
--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -140,6 +140,14 @@ export function VideoPokerGameContent({
   // Screen-reader announcement for a hold toggle (aria-pressed alone is not
   // reliably re-announced by every AT when toggled via the keyboard).
   const [holdAnnounce, setHoldAnnounce] = useState('');
+  // Screen-reader announcement summarising the draw result (winning hand +
+  // payout, or the loss message). The payout text and the payout-table row
+  // highlight are static, so this sr-only live region is the only channel
+  // that tells a non-visual user the outcome. `resultNonce` is an invisible
+  // counter that forces re-announcement even when two consecutive hands
+  // produce identical text.
+  const [resultAnnounce, setResultAnnounce] = useState('');
+  const [resultNonce, setResultNonce] = useState(0);
 
   const { cardWidth } = useCardDimensions();
   const { state, loading, error, exec: execApi, retry } = useGameApi(apiExec);
@@ -167,6 +175,25 @@ export function VideoPokerGameContent({
   const isBetPhase = state?.phase === VideoPokerPhase.BET;
   const isDrawPhase = state?.phase === VideoPokerPhase.DRAW;
   const isResultPhase = state?.phase === VideoPokerPhase.RESULT;
+
+  // Announce the draw outcome once per hand. Keying on the state reference (a
+  // fresh object on every API result) re-fires the effect even for an identical
+  // hand, so a repeated result is read aloud again.
+  useEffect(() => {
+    if (!isResultPhase || !state) {
+      return;
+    }
+    const rowKey = videoPokerHandNameToRowKey(state.handName);
+    const msg =
+      state.payout > 0
+        ? tNs('resultAnnounce.win', {
+            handName: rowKey ? tNs(`payoutTable.name.${rowKey}`) : state.handName,
+            payout: state.payout,
+          })
+        : tNs('resultAnnounce.lose');
+    setResultAnnounce(msg);
+    setResultNonce((n) => n + 1);
+  }, [isResultPhase, state, tNs]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-apply auto-hold only on the phase transition into DRAW (a fresh hand). Adding autoHoldEnabled / state / gameName to the deps would overwrite the player's manual hold edits whenever any of those change mid-draw.
   useEffect(() => {
@@ -297,6 +324,15 @@ export function VideoPokerGameContent({
 
             <div className="sr-only" role="status" aria-live="polite" data-testid="vp-hold-announce">
               {holdAnnounce}
+            </div>
+
+            <div className="sr-only" role="status" aria-live="polite" data-testid="vp-result-announce">
+              {resultAnnounce}
+              {/* Invisible incrementing nonce so assistive tech re-announces even
+                  two identical consecutive results; aria-hidden keeps it silent. */}
+              <span aria-hidden="true" data-testid="vp-result-nonce">
+                {resultNonce}
+              </span>
             </div>
 
             {state.hand.length > 0 && (

--- a/frontend/src/components/VideoPokerGameContent.tsx
+++ b/frontend/src/components/VideoPokerGameContent.tsx
@@ -326,13 +326,19 @@ export function VideoPokerGameContent({
               {holdAnnounce}
             </div>
 
-            <div className="sr-only" role="status" aria-live="polite" data-testid="vp-result-announce">
+            {/* Keying the live region on resultNonce remounts it on each result, so
+                assistive tech re-announces even two identical consecutive hands (an
+                aria-hidden counter would be invisible to the accessibility tree and
+                never trigger a re-read). data-nonce exposes the counter to tests. */}
+            <div
+              key={resultNonce}
+              className="sr-only"
+              role="status"
+              aria-live="polite"
+              data-testid="vp-result-announce"
+              data-nonce={resultNonce}
+            >
               {resultAnnounce}
-              {/* Invisible incrementing nonce so assistive tech re-announces even
-                  two identical consecutive results; aria-hidden keeps it silent. */}
-              <span aria-hidden="true" data-testid="vp-result-nonce">
-                {resultNonce}
-              </span>
             </div>
 
             {state.hand.length > 0 && (

--- a/frontend/src/i18n/locales/en/deuceswild.json
+++ b/frontend/src/i18n/locales/en/deuceswild.json
@@ -24,6 +24,10 @@
     "win": "{{handName}}! You win {{payout}} coins!",
     "lose": "No winning hand."
   },
+  "resultAnnounce": {
+    "win": "Hand: {{handName}}, payout {{payout}} coins",
+    "lose": "No winning hand, bet forfeited"
+  },
   "payoutTable": {
     "title": "Payout Table",
     "hand": "Hand",

--- a/frontend/src/i18n/locales/en/jokerpoker.json
+++ b/frontend/src/i18n/locales/en/jokerpoker.json
@@ -24,6 +24,10 @@
     "win": "{{handName}}! You win {{payout}} coins!",
     "lose": "No winning hand."
   },
+  "resultAnnounce": {
+    "win": "Hand: {{handName}}, payout {{payout}} coins",
+    "lose": "No winning hand, bet forfeited"
+  },
   "payoutTable": {
     "title": "Payout Table",
     "hand": "Hand",

--- a/frontend/src/i18n/locales/en/videopoker.json
+++ b/frontend/src/i18n/locales/en/videopoker.json
@@ -23,6 +23,10 @@
     "win": "{{handName}}! You win {{payout}} coins!",
     "lose": "No winning hand."
   },
+  "resultAnnounce": {
+    "win": "Hand: {{handName}}, payout {{payout}} coins",
+    "lose": "No winning hand, bet forfeited"
+  },
   "payoutTable": {
     "title": "Payout Table",
     "hand": "Hand",

--- a/frontend/src/i18n/locales/ja/deuceswild.json
+++ b/frontend/src/i18n/locales/ja/deuceswild.json
@@ -24,6 +24,10 @@
     "win": "{{handName}}! {{payout}}コイン獲得!",
     "lose": "役なし。次のハンドで頑張りましょう!"
   },
+  "resultAnnounce": {
+    "win": "役: {{handName}}、配当 {{payout}} 枚",
+    "lose": "役なし、ベット没収"
+  },
   "payoutTable": {
     "title": "配当表",
     "hand": "役",

--- a/frontend/src/i18n/locales/ja/jokerpoker.json
+++ b/frontend/src/i18n/locales/ja/jokerpoker.json
@@ -24,6 +24,10 @@
     "win": "{{handName}}! {{payout}}コイン獲得!",
     "lose": "役なし。次のハンドで頑張りましょう!"
   },
+  "resultAnnounce": {
+    "win": "役: {{handName}}、配当 {{payout}} 枚",
+    "lose": "役なし、ベット没収"
+  },
   "payoutTable": {
     "title": "配当表",
     "hand": "役",

--- a/frontend/src/i18n/locales/ja/videopoker.json
+++ b/frontend/src/i18n/locales/ja/videopoker.json
@@ -23,6 +23,10 @@
     "win": "{{handName}}! {{payout}}コイン獲得!",
     "lose": "役なし。次のハンドで頑張りましょう!"
   },
+  "resultAnnounce": {
+    "win": "役: {{handName}}、配当 {{payout}} 枚",
+    "lose": "役なし、ベット没収"
+  },
   "payoutTable": {
     "title": "配当表",
     "hand": "役",

--- a/frontend/src/pages/JokerPokerPage.test.tsx
+++ b/frontend/src/pages/JokerPokerPage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { jokerpokerApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -11,6 +11,14 @@ vi.mock('../api/gameApi', () => ({
 }));
 
 const mockExec = vi.mocked(jokerpokerApi.exec);
+
+const HAND: VideoPokerResponse['hand'] = [
+  { design: 'HEART', value: 10 },
+  { design: 'HEART', value: 10 },
+  { design: 'SPADE', value: 10 },
+  { design: 'CLOVER', value: 5 },
+  { design: 'DIAMOND', value: 5 },
+];
 
 const betPhaseState: VideoPokerResponse = {
   hand: [],
@@ -25,6 +33,50 @@ const betPhaseState: VideoPokerResponse = {
   variantName: 'jokerpoker',
   message: '',
 };
+
+const drawPhaseState: VideoPokerResponse = {
+  ...betPhaseState,
+  hand: HAND,
+  phase: 2,
+  betAmount: 1,
+  heldIndices: [false, false, false, false, false],
+};
+
+const winResultState: VideoPokerResponse = {
+  ...betPhaseState,
+  hand: HAND,
+  phase: 3,
+  betAmount: 1,
+  result: 1,
+  payout: 40,
+  handName: 'Full House',
+  heldIndices: [true, true, true, true, true],
+};
+
+const loseResultState: VideoPokerResponse = {
+  ...betPhaseState,
+  hand: HAND,
+  phase: 3,
+  betAmount: 1,
+  result: 0,
+  payout: 0,
+  handName: '',
+  heldIndices: [false, false, false, false, false],
+};
+
+/** Drive the page from mount through deal + draw to a RESULT-phase state. */
+async function playToResult(result: VideoPokerResponse) {
+  mockExec.mockResolvedValueOnce(betPhaseState); // mount reset
+  renderWithProviders(<JokerPokerPage />);
+  await waitFor(() => expect(screen.getByRole('button', { name: /ディール/ })).toBeInTheDocument());
+
+  mockExec.mockResolvedValueOnce(drawPhaseState);
+  fireEvent.click(screen.getByRole('button', { name: /ディール/ }));
+  await waitFor(() => expect(screen.getByRole('button', { name: /ドロー/ })).toBeInTheDocument());
+
+  mockExec.mockResolvedValueOnce(result);
+  fireEvent.click(screen.getByRole('button', { name: /ドロー/ }));
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -43,5 +95,40 @@ describe('JokerPokerPage', () => {
     mockExec.mockResolvedValue(betPhaseState);
     renderWithProviders(<JokerPokerPage />);
     await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
+  });
+
+  it('announces the winning hand and payout in a polite live region on result', async () => {
+    await playToResult(winResultState);
+    const region = await screen.findByTestId('vp-result-announce');
+    expect(region).toHaveAttribute('role', 'status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    await waitFor(() => expect(region).toHaveTextContent('役: フルハウス、配当 40 枚'));
+  });
+
+  it('announces the loss message when the payout is zero', async () => {
+    await playToResult(loseResultState);
+    const region = await screen.findByTestId('vp-result-announce');
+    await waitFor(() => expect(region).toHaveTextContent('役なし、ベット没収'));
+  });
+
+  it('re-announces (nonce advances) even when two consecutive results are identical', async () => {
+    await playToResult(winResultState);
+    await waitFor(() => expect(screen.getByTestId('vp-result-announce')).toHaveTextContent('役: フルハウス'));
+    const firstNonce = screen.getByTestId('vp-result-nonce').textContent;
+
+    // Next hand: reset → deal → draw → an identical winning result.
+    mockExec.mockResolvedValueOnce(betPhaseState);
+    fireEvent.click(screen.getByRole('button', { name: '次のゲーム' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: /ディール/ })).toBeInTheDocument());
+
+    mockExec.mockResolvedValueOnce(drawPhaseState);
+    fireEvent.click(screen.getByRole('button', { name: /ディール/ }));
+    await waitFor(() => expect(screen.getByRole('button', { name: /ドロー/ })).toBeInTheDocument());
+
+    mockExec.mockResolvedValueOnce(winResultState);
+    fireEvent.click(screen.getByRole('button', { name: /ドロー/ }));
+    await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
+
+    expect(screen.getByTestId('vp-result-nonce').textContent).not.toBe(firstNonce);
   });
 });

--- a/frontend/src/pages/JokerPokerPage.test.tsx
+++ b/frontend/src/pages/JokerPokerPage.test.tsx
@@ -99,22 +99,25 @@ describe('JokerPokerPage', () => {
 
   it('announces the winning hand and payout in a polite live region on result', async () => {
     await playToResult(winResultState);
-    const region = await screen.findByTestId('vp-result-announce');
+    // The region remounts (key={resultNonce}) on each result, so query it fresh
+    // after the announcement lands rather than holding a stale node reference.
+    await waitFor(() =>
+      expect(screen.getByTestId('vp-result-announce')).toHaveTextContent('役: フルハウス、配当 40 枚'),
+    );
+    const region = screen.getByTestId('vp-result-announce');
     expect(region).toHaveAttribute('role', 'status');
     expect(region).toHaveAttribute('aria-live', 'polite');
-    await waitFor(() => expect(region).toHaveTextContent('役: フルハウス、配当 40 枚'));
   });
 
   it('announces the loss message when the payout is zero', async () => {
     await playToResult(loseResultState);
-    const region = await screen.findByTestId('vp-result-announce');
-    await waitFor(() => expect(region).toHaveTextContent('役なし、ベット没収'));
+    await waitFor(() => expect(screen.getByTestId('vp-result-announce')).toHaveTextContent('役なし、ベット没収'));
   });
 
   it('re-announces (nonce advances) even when two consecutive results are identical', async () => {
     await playToResult(winResultState);
     await waitFor(() => expect(screen.getByTestId('vp-result-announce')).toHaveTextContent('役: フルハウス'));
-    const firstNonce = screen.getByTestId('vp-result-nonce').textContent;
+    const firstNonce = screen.getByTestId('vp-result-announce').getAttribute('data-nonce');
 
     // Next hand: reset → deal → draw → an identical winning result.
     mockExec.mockResolvedValueOnce(betPhaseState);
@@ -129,6 +132,6 @@ describe('JokerPokerPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /ドロー/ }));
     await waitFor(() => expect(screen.getByRole('button', { name: '次のゲーム' })).toBeInTheDocument());
 
-    expect(screen.getByTestId('vp-result-nonce').textContent).not.toBe(firstNonce);
+    expect(screen.getByTestId('vp-result-announce').getAttribute('data-nonce')).not.toBe(firstNonce);
   });
 });


### PR DESCRIPTION
## 概要 / Summary

Closes #3078

ジョーカーポーカーの RESULT フェーズで、成立役と配当をスクリーンリーダーに読み上げるアクセシビリティ改善。

配当は静的な `label.payout` テキストと配当表の行ハイライト（`aria-current`）でしか示されず、ホールド/ワイルドバッジは `aria-hidden` のため、視覚に頼らないユーザーはドロー結果を把握できなかった。

## 変更内容 / Changes

- **結果の aria-live 通知**: RESULT 遷移時に `role="status" aria-live="polite"` の `sr-only` リージョンへ「役: フルハウス、配当 40 枚」（payout > 0）または「役なし、ベット没収」（payout 0）を出力。
- **同一文言でも再通知**: 不可視のインクリメントする nonce（`aria-hidden`）を併記し、連続する 2 ハンドが同一文言でも支援技術が毎回読み上げるようにした。役名は `payoutTable.name.*` のローカライズ名を使用。
- **共有コンポーネント対応**: 変更は `VideoPokerGameContent`（jokerpoker / deuceswild / videopoker 共通）にあるため、`resultAnnounce` キーを 3 名前空間（ja + en 計 6 ファイル）に追加し、他 2 ゲームで生キーが表示されないようにした。

## 受け入れ条件 / Acceptance criteria

- [x] RESULT 遷移時に成立役と配当が aria-live リージョンに出力される
- [x] 役なし（payout 0）の場合も敗北メッセージが通知される
- [x] 連続プレイで毎回新しい通知が発火する（同一文言でも再通知 — nonce で担保）
- [x] Testing Library で `role="status"` の内容を検証するテストを追加

## テスト / Test plan

- `bun run test`（JokerPokerPage 5 件 / DeucesWild・VideoPoker・VideoPokerGameContent 35 件）— pass
- `bun run build` / `bunx tsc --noEmit` — OK / exit 0
- `bunx biome check`（変更 8 ファイル）— clean
- i18n パリティ（3 変種 × ja/en）確認済み