### PR TITLE
feat(letitride): announce the current risk total via aria-live

### DIFF
--- a/frontend/src/pages/LetItRidePage.test.tsx
+++ b/frontend/src/pages/LetItRidePage.test.tsx
@@ -185,6 +185,15 @@ describe('LetItRidePage', () => {
     expect(screen.getByTestId('current-risk')).toHaveTextContent('200');
   });
 
+  it('exposes the current risk total as a polite live region so pulls are announced', async () => {
+    mockApi.mockResolvedValue(firstDecisionState);
+    renderWithProviders(<LetItRidePage />);
+    await waitFor(() => expect(screen.getByTestId('bet-status')).toBeInTheDocument());
+    const risk = screen.getByTestId('current-risk');
+    expect(risk).toHaveAttribute('role', 'status');
+    expect(risk).toHaveAttribute('aria-live', 'polite');
+  });
+
   it('shows END phase with reset button and payout breakdown on win', async () => {
     mockApi.mockResolvedValue(endPhaseWin);
     renderWithProviders(<LetItRidePage />);

--- a/frontend/src/pages/LetItRidePage.tsx
+++ b/frontend/src/pages/LetItRidePage.tsx
@@ -307,7 +307,14 @@ function LetItRidePageContent() {
                     </div>
                   ))}
                 </div>
-                <div className="mt-1 text-center text-ds-text-primary text-sm" data-testid="current-risk">
+                {/* aria-live so each pull (which lowers the total at risk) is announced
+                    to screen-reader users as the amount changes. Layout is unchanged. */}
+                <div
+                  className="mt-1 text-center text-ds-text-primary text-sm"
+                  data-testid="current-risk"
+                  role="status"
+                  aria-live="polite"
+                >
                   {t('label.currentRisk')}: {currentRisk}
                 </div>
               </div>


### PR DESCRIPTION
## 概要 / Summary

Closes #3165

レット・イット・ライドの「現在のリスク総額」表示（`current-risk`）に `aria-live` を付与し、プル操作で総額が変わるたびにスクリーンリーダーへ通知するアクセシビリティ改善。

`currentRisk`（`betAmount × アクティブなベット数`）は `handlePull` のたびに減少する重要情報だが、通常の `<div>` のため変化が読み上げられなかった。

## 変更内容 / Changes

- `current-risk` 要素に `role="status" aria-live="polite"` を付与。プルによる総リスク額の変化を即時通知。
- 視覚的レイアウトは不変。金額はプル確認ダイアログ（`risk` / `newRisk` を同じ `currentRisk` から算出）と整合。

## 受け入れ条件 / Acceptance criteria

- [x] `current-risk` 要素に `aria-live="polite"` が追加される
- [x] `handlePull` によるベット引き下げ後、変化した金額が読み上げられる
- [x] `ConfirmDialog`（`pullConfirmOpen`）のメッセージ内の金額表示との整合を確認
- [x] 視覚的なレイアウトは変更しない

## テスト / Test plan

- `bun run test`（LetItRidePage 30 件）— pass（`role="status"`/`aria-live="polite"` の付与を検証）
- `bun run build` / `bunx tsc --noEmit` — OK / exit 0
- `bun run check`（フルの biome）— clean