### PR TITLE
feat(eightoff): announce the hint move via an aria-live region

### DIFF
--- a/frontend/src/hooks/useEightOffGame.ts
+++ b/frontend/src/hooks/useEightOffGame.ts
@@ -22,6 +22,16 @@ export function useEightOffGame() {
     [base.runAction],
   );
 
+  // Bumped every time a hint is requested so the page can announce the result
+  // (a move, or "no moves available") even when two requests yield the same
+  // hint value — a null hint after a request is indistinguishable from the
+  // initial null without this signal.
+  const [hintNonce, setHintNonce] = useState(0);
+  const handleHint = useCallback(async () => {
+    await base.handleHint();
+    setHintNonce((n) => n + 1);
+  }, [base]);
+
   const handleSelectSource = useCallback((zone: EightOffMoveZone) => {
     setSelectedSource((prev) => {
       if (
@@ -55,9 +65,10 @@ export function useEightOffGame() {
     exec: base.apiCall,
     selectedSource,
     hint: base.hint,
+    hintNonce,
     handleReset: base.handleReset,
     handleGiveUp: base.handleGiveUp,
-    handleHint: base.handleHint,
+    handleHint,
     handleAutoComplete: base.handleAutoComplete,
     handleUndo: base.handleUndo,
     handleUndoEscape,

--- a/frontend/src/hooks/useEightOffGame.ts
+++ b/frontend/src/hooks/useEightOffGame.ts
@@ -27,10 +27,13 @@ export function useEightOffGame() {
   // hint value — a null hint after a request is indistinguishable from the
   // initial null without this signal.
   const [hintNonce, setHintNonce] = useState(0);
+  // Depend on the stable base.handleHint reference, not the whole `base` object
+  // (which is re-created whenever state/loading change), so this callback stays stable.
+  const baseHandleHint = base.handleHint;
   const handleHint = useCallback(async () => {
-    await base.handleHint();
+    await baseHandleHint();
     setHintNonce((n) => n + 1);
-  }, [base]);
+  }, [baseHandleHint]);
 
   const handleSelectSource = useCallback((zone: EightOffMoveZone) => {
     setSelectedSource((prev) => {

--- a/frontend/src/i18n/locales/en/eightoff.json
+++ b/frontend/src/i18n/locales/en/eightoff.json
@@ -32,5 +32,7 @@
     "freeCellsFilling": "Free cells are almost full — try to clear some",
     "useEmptyColumnKing": "An empty column is available — move a King to use it",
     "useFreeCells": "Consider moving a card to a free cell to open up moves"
-  }
+  },
+  "hintAnnouncement": "Hint: move {{card}} from {{from}} to {{to}}",
+  "hintNoMoves": "No moves available"
 }

--- a/frontend/src/i18n/locales/ja/eightoff.json
+++ b/frontend/src/i18n/locales/ja/eightoff.json
@@ -32,5 +32,7 @@
     "freeCellsFilling": "フリーセルがほぼ満杯です — 空けることを検討しましょう",
     "useEmptyColumnKing": "空の列があります — Kを移動して整理に活用しましょう",
     "useFreeCells": "フリーセルにカードを移動して手を広げましょう"
-  }
+  },
+  "hintAnnouncement": "ヒント: {{card}} を {{from}} から {{to}} へ移動",
+  "hintNoMoves": "移動可能な手がありません"
 }

--- a/frontend/src/pages/EightOffPage.test.tsx
+++ b/frontend/src/pages/EightOffPage.test.tsx
@@ -206,6 +206,82 @@ describe('EightOffPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
   });
 
+  it('announces the hinted move (tableau source) in a polite live region', async () => {
+    renderWithProviders(<EightOffPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    // playingState.tableau[0][0] is ♠ K; hint moves it to a foundation.
+    mockExec.mockResolvedValue(withHintFromColState);
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    const region = await screen.findByTestId('eo-hint-announce');
+    expect(region).toHaveAttribute('role', 'status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    await waitFor(() => expect(region).toHaveTextContent('ヒント: ♠ K を タブロー 1 から ファンデーション へ移動'));
+  });
+
+  it('announces a free-cell source hint by resolving the free-cell card', async () => {
+    // Mount with a free cell occupied so state.freeCells[0] stays ♦ 7 (handleHint
+    // updates only the hint, not state).
+    mockExec.mockResolvedValue(withFreeCellCardState);
+    renderWithProviders(<EightOffPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    mockExec.mockResolvedValue({
+      ...withFreeCellCardState,
+      hint: { fromZone: 'freecell', fromCol: 0, cardIndex: -1, toZone: 'tableau', toCol: 3 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    const region = await screen.findByTestId('eo-hint-announce');
+    await waitFor(() => expect(region).toHaveTextContent('ヒント: ♦ 7 を フリーセル 1 から タブロー 4 へ移動'));
+  });
+
+  it('announces that no moves are available when the hint request yields none', async () => {
+    renderWithProviders(<EightOffPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    mockExec.mockResolvedValue({ ...playingState, hint: undefined });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    const region = await screen.findByTestId('eo-hint-announce');
+    await waitFor(() => expect(region).toHaveTextContent('移動可能な手がありません'));
+  });
+
+  it('keeps the hint live region empty before any hint is requested', async () => {
+    renderWithProviders(<EightOffPage />);
+    const region = await screen.findByTestId('eo-hint-announce');
+    expect(region).toHaveTextContent('');
+  });
+
+  it('announces an empty card name when a free-cell hint points at an empty cell', async () => {
+    renderWithProviders(<EightOffPage />); // playingState: all free cells null
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    mockExec.mockResolvedValue({
+      ...playingState,
+      hint: { fromZone: 'freecell', fromCol: 0, cardIndex: -1, toZone: 'tableau', toCol: 3 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    const region = await screen.findByTestId('eo-hint-announce');
+    await waitFor(() => expect(region).toHaveTextContent('ヒント: を フリーセル 1 から タブロー 4 へ移動'));
+  });
+
+  it('announces an empty card name when a tableau hint points at a missing card', async () => {
+    renderWithProviders(<EightOffPage />); // playingState.tableau[2] is empty
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    mockExec.mockResolvedValue({
+      ...playingState,
+      hint: { fromZone: 'tableau', fromCol: 2, cardIndex: 0, toZone: 'foundation', toCol: -1 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    const region = await screen.findByTestId('eo-hint-announce');
+    await waitFor(() => expect(region).toHaveTextContent('ヒント: を タブロー 3 から ファンデーション へ移動'));
+  });
+
   it('handleAutoComplete called on autocomplete button click', async () => {
     renderWithProviders(<EightOffPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'オートコンプリート' })).toBeInTheDocument());

--- a/frontend/src/pages/EightOffPage.test.tsx
+++ b/frontend/src/pages/EightOffPage.test.tsx
@@ -254,6 +254,20 @@ describe('EightOffPage', () => {
     expect(region).toHaveTextContent('');
   });
 
+  it('does not announce "no moves" when the hint request fails', async () => {
+    renderWithProviders(<EightOffPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    // hint fetch rejects → hintError is set, hint stays null; the region must stay
+    // empty rather than falsely announcing "移動可能な手がありません".
+    mockExec.mockRejectedValueOnce(new Error('network error'));
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
+    const region = screen.getByTestId('eo-hint-announce');
+    expect(region).toHaveTextContent('');
+  });
+
   it('announces an empty card name when a free-cell hint points at an empty cell', async () => {
     renderWithProviders(<EightOffPage />); // playingState: all free cells null
     await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());

--- a/frontend/src/pages/EightOffPage.tsx
+++ b/frontend/src/pages/EightOffPage.tsx
@@ -129,7 +129,9 @@ function EightOffPageContent() {
   const [hintAnnounce, setHintAnnounce] = useState('');
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally react only to a new hint request (hintNonce); adding hint/state/t would re-run on unrelated updates and re-announce.
   useEffect(() => {
-    if (hintNonce === 0 || !state) return;
+    // Skip on a failed hint fetch (hintError set, hint left null) so we don't
+    // wrongly announce "no moves" alongside the network-error banner.
+    if (hintNonce === 0 || !state || hintError) return;
     if (!hint) {
       setHintAnnounce(t('hintNoMoves'));
       return;

--- a/frontend/src/pages/EightOffPage.tsx
+++ b/frontend/src/pages/EightOffPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { EightOffMoveZone, eightoffApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -27,7 +27,7 @@ import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { Card, EightOffResponse } from '../types/card';
+import type { Card, EightOffHint, EightOffResponse } from '../types/card';
 import { EightOffPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
@@ -36,6 +36,18 @@ import { formatEightoffState } from '../utils/cli/formatters/eightoffFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 
 const FOUNDATION_SUITS = ['♠', '♣', '♥', '♦'] as const;
+
+/** Localized "<zone> <n>" label for a hint move endpoint (n omitted when col < 0, e.g. any-foundation). */
+function eightOffZoneLabel(t: (key: string) => string, zone: string, col: number): string {
+  const base = zone === 'freecell' ? t('freecell') : zone === 'foundation' ? t('foundation') : t('tableau');
+  return col >= 0 ? `${base} ${col + 1}` : base;
+}
+
+/** The card a hint suggests moving: the free-cell card, or the tableau card at [fromCol][cardIndex]. */
+function eightOffHintCard(state: EightOffResponse, hint: EightOffHint): Card | null {
+  if (hint.fromZone === 'freecell') return state.freeCells[hint.fromCol] ?? null;
+  return state.tableau[hint.fromCol]?.[hint.cardIndex] ?? null;
+}
 
 /** Eight Off tutorial step definitions. */
 const EO_TUTORIAL_STEPS: TutorialStep[] = [
@@ -100,6 +112,7 @@ function EightOffPageContent() {
     hintError,
     selectedSource,
     hint,
+    hintNonce,
     handleReset,
     handleGiveUp,
     handleHint,
@@ -110,6 +123,26 @@ function EightOffPageContent() {
     handleSelectTarget,
     isAutoCompleting,
   } = useEightOffGame();
+  // Screen-reader announcement for the hint (visually it is only ring highlights).
+  // Driven off hintNonce so it fires once per hint request, reading the current
+  // hint/state snapshot; a null hint after a request means no legal move exists.
+  const [hintAnnounce, setHintAnnounce] = useState('');
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally react only to a new hint request (hintNonce); adding hint/state/t would re-run on unrelated updates and re-announce.
+  useEffect(() => {
+    if (hintNonce === 0 || !state) return;
+    if (!hint) {
+      setHintAnnounce(t('hintNoMoves'));
+      return;
+    }
+    const card = eightOffHintCard(state, hint);
+    setHintAnnounce(
+      t('hintAnnouncement', {
+        card: card ? cardAlt(card) : '',
+        from: eightOffZoneLabel(t, hint.fromZone, hint.fromCol),
+        to: eightOffZoneLabel(t, hint.toZone, hint.toCol),
+      }),
+    );
+  }, [hintNonce]);
   const {
     hint: frontendHint,
     hintEnabled: frontendHintEnabled,
@@ -464,7 +497,12 @@ function EightOffPageContent() {
               </div>
             </div>
 
-            {/* Hint is shown via ring highlights on the suggested source card and target zone. */}
+            {/* Hint is shown visually via ring highlights on the suggested source card
+                and target zone; this sr-only live region conveys the same move (or the
+                no-move result) to screen readers. */}
+            <div className="sr-only" role="status" aria-live="polite" data-testid="eo-hint-announce">
+              {hintAnnounce}
+            </div>
             {frontendHintEnabled && frontendHint && (
               <div className="flex justify-center">
                 <HintTooltip reason={t(frontendHint.reason)} confidence={frontendHint.confidence} />


### PR DESCRIPTION
## 概要 / Summary

Closes #3323

Eight Off のヒントは移動元/移動先のリングハイライトのみで表現され（`isHintSourceTableau`/`isHintTarget`）、スクリーンリーダー利用者にはヒントボタンを押しても何も伝わらなかった。CUI の `HintOutput` 相当のテキストを sr-only ライブリージョンへ出力する。

## 変更内容 / Changes

- **ヒントの aria-live 通知**: `sr-only role="status" aria-live="polite"` 領域に「ヒント: {card} を {from} から {to} へ移動」を出力（`hint.fromZone/fromCol/cardIndex/toZone/toCol` から合成）。移動元カードはフリーセル／タブローから解決。
- **手が無い場合**: ヒント要求で move が返らない場合は「移動可能な手がありません」を通知。
- **hintNonce**: フックにヒント要求ごとに増える nonce を追加し、「no-move」を初期状態の null と区別できるようにした。
- 視覚（リングハイライト）は不変。i18n `hintAnnouncement`/`hintNoMoves` を ja/en に追加。

## 受け入れ条件 / Acceptance criteria

- [x] ヒント実行時に移動元→移動先が読み上げテキストとして出力される
- [x] リージョンは sr-only で視覚レイアウトを変えない
- [x] ヒントが無い場合も「移動可能な手がありません」を通知する
- [x] `EightOffPage.test.tsx` に status テキストのテストを追加

## テスト / Test plan

- `bun run test`（EightOffPage 73 件）— pass（tableau/freecell 源, no-move, 空, null-card 分岐）
- `bun run build` / `bunx tsc --noEmit` — OK / exit 0
- `bun run check`（フル biome）— clean
- i18n パリティ（ja/en）確認済み