### PR TITLE
feat(oldmaid): surface the d/s keyboard shortcuts on screen and to AT

### DIFF
--- a/frontend/src/i18n/locales/en/oldmaid.json
+++ b/frontend/src/i18n/locales/en/oldmaid.json
@@ -67,5 +67,6 @@
   "bubble": {
     "drewFrom": "← from {{from}}",
     "drewAndPaired": "← from {{from}} (paired)"
-  }
+  },
+  "keyHints": "D: Draw / S: Shuffle"
 }

--- a/frontend/src/i18n/locales/ja/oldmaid.json
+++ b/frontend/src/i18n/locales/ja/oldmaid.json
@@ -67,5 +67,6 @@
   "bubble": {
     "drewFrom": "← {{from}} から",
     "drewAndPaired": "← {{from}} から (ペア成立)"
-  }
+  },
+  "keyHints": "D: 引く / S: シャッフル"
 }

--- a/frontend/src/pages/OldMaidPage.test.tsx
+++ b/frontend/src/pages/OldMaidPage.test.tsx
@@ -83,18 +83,22 @@ describe('OldMaidPage', () => {
     );
   });
 
-  it('shows keyboard shortcut hints and aria-keyshortcuts on the human turn', async () => {
+  it('shows keyboard shortcut hints and lowercase aria-keyshortcuts on the human turn', async () => {
     await startGame();
     expect(screen.getByTestId('oldmaid-key-hints')).toHaveTextContent('D: 引く / S: シャッフル');
-    expect(screen.getByRole('button', { name: 'ランダムに引く' })).toHaveAttribute('aria-keyshortcuts', 'D');
-    expect(screen.getByRole('button', { name: 'シャッフル' })).toHaveAttribute('aria-keyshortcuts', 'S');
+    // Lowercase: an unmodified key (uppercase would imply Shift+D per WAI-ARIA).
+    expect(screen.getByRole('button', { name: 'ランダムに引く' })).toHaveAttribute('aria-keyshortcuts', 'd');
+    expect(screen.getByRole('button', { name: 'シャッフル' })).toHaveAttribute('aria-keyshortcuts', 's');
   });
 
-  it('hides the key hints on a CPU turn', async () => {
+  it('hides the key hints and drops aria-keyshortcuts on a CPU turn (bindings inactive)', async () => {
     mockExec.mockResolvedValue(cpuTurnState);
     renderWithProviders(<OldMaidPage />);
     await waitFor(() => expect(screen.getAllByText('あなた').length).toBeGreaterThan(0));
     expect(screen.queryByTestId('oldmaid-key-hints')).not.toBeInTheDocument();
+    // The shuffle button stays clickable on a CPU turn, but the `s` key binding is
+    // inactive, so it must not advertise a shortcut that does nothing.
+    expect(screen.getByRole('button', { name: 'シャッフル' })).not.toHaveAttribute('aria-keyshortcuts');
   });
 
   it('renders skeleton while API call is pending on mount', () => {

--- a/frontend/src/pages/OldMaidPage.test.tsx
+++ b/frontend/src/pages/OldMaidPage.test.tsx
@@ -83,6 +83,20 @@ describe('OldMaidPage', () => {
     );
   });
 
+  it('shows keyboard shortcut hints and aria-keyshortcuts on the human turn', async () => {
+    await startGame();
+    expect(screen.getByTestId('oldmaid-key-hints')).toHaveTextContent('D: 引く / S: シャッフル');
+    expect(screen.getByRole('button', { name: 'ランダムに引く' })).toHaveAttribute('aria-keyshortcuts', 'D');
+    expect(screen.getByRole('button', { name: 'シャッフル' })).toHaveAttribute('aria-keyshortcuts', 'S');
+  });
+
+  it('hides the key hints on a CPU turn', async () => {
+    mockExec.mockResolvedValue(cpuTurnState);
+    renderWithProviders(<OldMaidPage />);
+    await waitFor(() => expect(screen.getAllByText('あなた').length).toBeGreaterThan(0));
+    expect(screen.queryByTestId('oldmaid-key-hints')).not.toBeInTheDocument();
+  });
+
   it('renders skeleton while API call is pending on mount', () => {
     mockExec.mockReturnValue(new Promise(() => undefined));
     renderWithProviders(<OldMaidPage />);

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -405,7 +405,9 @@ function OldMaidPageContent() {
                   className={`${btnPrimary} min-w-[110px]`}
                   disabled={loading || !isHumanTurn || state.gameEndFlag}
                   onClick={() => gameExec('draw')}
-                  aria-keyshortcuts="D"
+                  // Lowercase to mean the unmodified key; only advertised while the
+                  // keyboard bindings are actually active (the human's turn).
+                  aria-keyshortcuts={isHumanTurn ? 'd' : undefined}
                 >
                   {t('button.drawRandom')}
                 </button>
@@ -415,7 +417,7 @@ function OldMaidPageContent() {
                 className={`${btnSecondary} min-w-[110px]`}
                 disabled={loading || state.gameEndFlag}
                 onClick={() => gameExec('shuffle')}
-                aria-keyshortcuts="S"
+                aria-keyshortcuts={isHumanTurn ? 's' : undefined}
               >
                 {t('button.shuffle')}
               </button>

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -405,6 +405,7 @@ function OldMaidPageContent() {
                   className={`${btnPrimary} min-w-[110px]`}
                   disabled={loading || !isHumanTurn || state.gameEndFlag}
                   onClick={() => gameExec('draw')}
+                  aria-keyshortcuts="D"
                 >
                   {t('button.drawRandom')}
                 </button>
@@ -414,10 +415,19 @@ function OldMaidPageContent() {
                 className={`${btnSecondary} min-w-[110px]`}
                 disabled={loading || state.gameEndFlag}
                 onClick={() => gameExec('shuffle')}
+                aria-keyshortcuts="S"
               >
                 {t('button.shuffle')}
               </button>
             </div>
+
+            {/* Keyboard shortcut hints, shown on the human's turn (matches the d/s
+                bindings in useActionKeyboardNav above). */}
+            {isHumanTurn && (
+              <p className="text-center text-game-text-muted text-xs mt-2" data-testid="oldmaid-key-hints">
+                {t('keyHints')}
+              </p>
+            )}
           </GameFooter>
         </>
       )}


### PR DESCRIPTION
## 概要 / Summary

Closes #2983

ババ抜き（Old Maid）のキーボードショートカット（d=引く / s=シャッフル）を画面と支援技術に明示するアクセシビリティ改善。`useActionKeyboardNav` でバインド済みだが画面表示が無く、発見できなかった。`DoubtPage` の `keyHints` 先例に倣う。

## 変更内容 / Changes

- **キーヒント表示**: フッターのボタン下に「D: 引く / S: シャッフル」を人間の手番時に表示（`data-testid="oldmaid-key-hints"`）。
- **aria-keyshortcuts**: 「ランダムに引く」ボタンに `aria-keyshortcuts="D"`、「シャッフル」ボタンに `="S"` を付与。
- i18n `keyHints` を ja/en に追加。

## 受け入れ条件 / Acceptance criteria

- [x] 人間の手番時にキーヒントが表示される
- [x] draw/shuffle ボタンに aria-keyshortcuts が付与される
- [x] ja/en の翻訳キーを追加する
- [x] 表示のユニットテストを追加する

## テスト / Test plan

- `bun run test`（OldMaidPage 100 件）— pass（手番時表示 / CPU 手番非表示 / aria 属性）
- `bun run build` / `bunx tsc --noEmit` — OK / exit 0
- `bun run check`（フル biome）— clean
- i18n パリティ（ja/en）確認済み