### PR TITLE
feat(sevens): surface the number-key play shortcut on screen and to AT

### DIFF
--- a/frontend/src/components/sevens/SevensHumanArea.tsx
+++ b/frontend/src/components/sevens/SevensHumanArea.tsx
@@ -106,9 +106,10 @@ function HumanArea({
               disabled={!playable}
               onClick={() => onPlay(i)}
               title={playable ? t('playTitle', { design: card.design, value: valueName(card.value) }) : undefined}
-              // Number keys 1-9 directly play the matching card (useCardKeyboardNav);
-              // advertise the shortcut only where it is a legal move this turn.
-              aria-keyshortcuts={playable && i < 9 ? String(i + 1) : undefined}
+              // Number keys 1-9 (and 0 for the 10th card) directly play the matching
+              // card (useCardKeyboardNav maps digit 0 → index 9); advertise the
+              // shortcut only where it is a legal move this turn.
+              aria-keyshortcuts={playable && i <= 9 ? String((i + 1) % 10) : undefined}
               data-testid={playable ? 'playable-card' : undefined}
               style={{
                 background: 'none',

--- a/frontend/src/components/sevens/SevensHumanArea.tsx
+++ b/frontend/src/components/sevens/SevensHumanArea.tsx
@@ -106,6 +106,9 @@ function HumanArea({
               disabled={!playable}
               onClick={() => onPlay(i)}
               title={playable ? t('playTitle', { design: card.design, value: valueName(card.value) }) : undefined}
+              // Number keys 1-9 directly play the matching card (useCardKeyboardNav);
+              // advertise the shortcut only where it is a legal move this turn.
+              aria-keyshortcuts={playable && i < 9 ? String(i + 1) : undefined}
               data-testid={playable ? 'playable-card' : undefined}
               style={{
                 background: 'none',

--- a/frontend/src/i18n/locales/en/sevens.json
+++ b/frontend/src/i18n/locales/en/sevens.json
@@ -68,5 +68,6 @@
     "playExtend": "You have a playable card — extend the range",
     "passAvailable": "No playable cards — pass",
     "passLimitWarning": "Almost out of passes — be careful"
-  }
+  },
+  "keyHints": "Number keys: play the matching card"
 }

--- a/frontend/src/i18n/locales/ja/sevens.json
+++ b/frontend/src/i18n/locales/ja/sevens.json
@@ -68,5 +68,6 @@
     "playExtend": "出せるカードがあります — 範囲を広げましょう",
     "passAvailable": "出せるカードなし — パス",
     "passLimitWarning": "パス残り回数わずか — 慎重に"
-  }
+  },
+  "keyHints": "数字キー: 対応する手札をプレイ"
 }

--- a/frontend/src/pages/SevensPage.test.tsx
+++ b/frontend/src/pages/SevensPage.test.tsx
@@ -197,6 +197,30 @@ describe('SevensPage', () => {
     });
   });
 
+  it('shows the number-key hint and per-card aria-keyshortcuts on the human turn', async () => {
+    renderWithProviders(<SevensPage />);
+    await waitFor(() => expect(screen.getByTestId('sevens-key-hints')).toBeInTheDocument());
+    expect(screen.getByTestId('sevens-key-hints')).toHaveTextContent('数字キー: 対応する手札をプレイ');
+    // ♠6 is hand index 0 → key "1"; ♣8 is index 2 → key "3" (♥5 at index 1 is not playable).
+    expect(screen.getByAltText('♠ 6').closest('button')).toHaveAttribute('aria-keyshortcuts', '1');
+    expect(screen.getByAltText('♣ 8').closest('button')).toHaveAttribute('aria-keyshortcuts', '3');
+    expect(screen.getByAltText('♥ 5').closest('button')).not.toHaveAttribute('aria-keyshortcuts');
+  });
+
+  it('hides the number-key hint when it is not the human turn', async () => {
+    mockExec.mockResolvedValue(cpuTurnState);
+    renderWithProviders(<SevensPage />);
+    await waitFor(() => expect(screen.getByText('CPU 1')).toBeInTheDocument());
+    expect(screen.queryByTestId('sevens-key-hints')).not.toBeInTheDocument();
+  });
+
+  it('hides the number-key hint at game end', async () => {
+    mockExec.mockResolvedValue(gameEndState);
+    renderWithProviders(<SevensPage />);
+    await waitFor(() => expect(screen.getByText('あなた')).toBeInTheDocument());
+    expect(screen.queryByTestId('sevens-key-hints')).not.toBeInTheDocument();
+  });
+
   it('pass button is enabled on human turn with passes remaining', async () => {
     renderWithProviders(<SevensPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'パス' })).not.toBeDisabled());

--- a/frontend/src/pages/SevensPage.tsx
+++ b/frontend/src/pages/SevensPage.tsx
@@ -424,6 +424,13 @@ function SevensPageContent() {
                   loading={loading}
                   onPlay={handleCardPlay}
                 />
+                {/* Number-key shortcut hint, shown while the human's card bindings are
+                    active (matches useCardKeyboardNav onDirectPlay above). */}
+                {isHumanTurn && (
+                  <p className="text-center text-game-text-muted text-xs mt-1" data-testid="sevens-key-hints">
+                    {t('keyHints')}
+                  </p>
+                )}
               </div>
             )}
 


### PR DESCRIPTION
## 概要 / Summary

Closes #2993

七並べ（Sevens）の数字キー直接プレイ（`useCardKeyboardNav` の `onDirectPlay`）を画面と支援技術に明示するアクセシビリティ改善。案内が無く、キーボード利用者が機能に気づけなかった。`DoubtPage` の keyHints 先例に倣う。

## 変更内容 / Changes

- **キーヒント表示**: 人間の手番時にフッターへ「数字キー: 対応する手札をプレイ」を表示（`data-testid="sevens-key-hints"`）。
- **aria-keyshortcuts**: `SevensHumanArea` の各手札ボタンに 1 始まりのインデックス（先頭 9 枚まで、かつ合法手のときのみ）を付与。Escape は本ゲームでは no-op のため広告しない（大文字回避＋動作しないショートカットを出さない #2983 の教訓を踏襲）。
- i18n `keyHints` を ja/en に追加。

## 受け入れ条件 / Acceptance criteria

- [x] 手番時にキーヒントが表示される
- [x] 手番以外・ゲーム終了時は表示されない
- [x] ja/en の翻訳キーを追加する
- [x] 表示のユニットテストを追加する

## テスト / Test plan

- `bun run test`（SevensPage 109 件）— pass（手番表示 / CPU・終了時非表示 / 各カードの aria-keyshortcuts）
- `bun run build` / `bunx tsc --noEmit` — OK / exit 0
- `bun run check`（フル biome）— clean
- i18n パリティ（ja/en）確認済み