### PR TITLE
feat(holdem): show betting shortcuts and aria-keyshortcuts in BettingControls

### DIFF
--- a/frontend/src/components/BettingControls.test.tsx
+++ b/frontend/src/components/BettingControls.test.tsx
@@ -37,6 +37,21 @@ describe('BettingControls', () => {
     expect(screen.queryByRole('button', { name: 'チェック' })).not.toBeInTheDocument();
   });
 
+  it('renders the key-hint line and per-button aria-keyshortcuts (outstanding bet)', () => {
+    render(<BettingControls {...makeProps({ hasOutstandingBet: true })} />);
+    expect(screen.getByTestId('betting-key-hints')).toHaveTextContent('C: コール');
+    expect(screen.getByRole('button', { name: 'コール' })).toHaveAttribute('aria-keyshortcuts', 'c');
+    expect(screen.getByRole('button', { name: 'レイズ' })).toHaveAttribute('aria-keyshortcuts', 'r');
+    expect(screen.getByRole('button', { name: 'フォールド' })).toHaveAttribute('aria-keyshortcuts', 'f');
+    expect(screen.getByRole('button', { name: 'オールイン' })).toHaveAttribute('aria-keyshortcuts', 'a');
+  });
+
+  it('assigns aria-keyshortcuts to bet/check when there is no outstanding bet', () => {
+    render(<BettingControls {...makeProps()} />);
+    expect(screen.getByRole('button', { name: 'ベット' })).toHaveAttribute('aria-keyshortcuts', 'r');
+    expect(screen.getByRole('button', { name: 'チェック' })).toHaveAttribute('aria-keyshortcuts', 'k');
+  });
+
   it('always renders fold and all-in buttons', () => {
     render(<BettingControls {...makeProps()} />);
     expect(screen.getByRole('button', { name: 'フォールド' })).toBeInTheDocument();

--- a/frontend/src/components/BettingControls.test.tsx
+++ b/frontend/src/components/BettingControls.test.tsx
@@ -37,17 +37,22 @@ describe('BettingControls', () => {
     expect(screen.queryByRole('button', { name: 'チェック' })).not.toBeInTheDocument();
   });
 
-  it('renders the key-hint line and per-button aria-keyshortcuts (outstanding bet)', () => {
+  it('renders the call/raise key-hint line and per-button aria-keyshortcuts (outstanding bet)', () => {
     render(<BettingControls {...makeProps({ hasOutstandingBet: true })} />);
-    expect(screen.getByTestId('betting-key-hints')).toHaveTextContent('C: コール');
+    const hints = screen.getByTestId('betting-key-hints');
+    expect(hints).toHaveTextContent('C: コール');
+    expect(hints).not.toHaveTextContent('K: チェック'); // check isn't available now
     expect(screen.getByRole('button', { name: 'コール' })).toHaveAttribute('aria-keyshortcuts', 'c');
     expect(screen.getByRole('button', { name: 'レイズ' })).toHaveAttribute('aria-keyshortcuts', 'r');
     expect(screen.getByRole('button', { name: 'フォールド' })).toHaveAttribute('aria-keyshortcuts', 'f');
     expect(screen.getByRole('button', { name: 'オールイン' })).toHaveAttribute('aria-keyshortcuts', 'a');
   });
 
-  it('assigns aria-keyshortcuts to bet/check when there is no outstanding bet', () => {
+  it('renders the check/bet key-hint line and aria-keyshortcuts when there is no outstanding bet', () => {
     render(<BettingControls {...makeProps()} />);
+    const hints = screen.getByTestId('betting-key-hints');
+    expect(hints).toHaveTextContent('K: チェック');
+    expect(hints).not.toHaveTextContent('C: コール'); // call isn't available now
     expect(screen.getByRole('button', { name: 'ベット' })).toHaveAttribute('aria-keyshortcuts', 'r');
     expect(screen.getByRole('button', { name: 'チェック' })).toHaveAttribute('aria-keyshortcuts', 'k');
   });

--- a/frontend/src/components/BettingControls.tsx
+++ b/frontend/src/components/BettingControls.tsx
@@ -165,9 +165,11 @@ export function BettingControls({
         {t('action.allIn')}
       </button>
       {/* Keyboard shortcut hint. BettingControls only renders while the human can
-          act, so the shortcuts are always live here — advertising them is safe. */}
+          act, so the shortcuts are always live here. Show only the actions that are
+          actually on screen (call/raise vs check/bet) to avoid advertising the
+          mutually-exclusive one. */}
       <p className="text-game-text-muted text-xs mt-2" data-testid="betting-key-hints">
-        {t('betting.keyHints')}
+        {t(hasOutstandingBet ? 'betting.keyHintsOutstanding' : 'betting.keyHintsNormal')}
       </p>
     </div>
   );

--- a/frontend/src/components/BettingControls.tsx
+++ b/frontend/src/components/BettingControls.tsx
@@ -105,29 +105,70 @@ export function BettingControls({
       </div>
       {hasOutstandingBet ? (
         <>
-          <button type="button" className={`${btnPokerPrimary} min-w-[80px]`} disabled={loading} onClick={onCall}>
+          <button
+            type="button"
+            className={`${btnPokerPrimary} min-w-[80px]`}
+            disabled={loading}
+            onClick={onCall}
+            aria-keyshortcuts="c"
+          >
             {t('action.call')}
           </button>
-          <button type="button" className={`${btnPokerAccent} min-w-[80px]`} disabled={!canBet} onClick={onRaise}>
+          <button
+            type="button"
+            className={`${btnPokerAccent} min-w-[80px]`}
+            disabled={!canBet}
+            onClick={onRaise}
+            aria-keyshortcuts="r"
+          >
             {t('action.raise')}
           </button>
         </>
       ) : (
         <>
-          <button type="button" className={`${btnPokerAccent} min-w-[80px]`} disabled={!canBet} onClick={onBet}>
+          <button
+            type="button"
+            className={`${btnPokerAccent} min-w-[80px]`}
+            disabled={!canBet}
+            onClick={onBet}
+            aria-keyshortcuts="r"
+          >
             {t('action.bet')}
           </button>
-          <button type="button" className={`${btnPokerPrimary} min-w-[80px]`} disabled={loading} onClick={onCheck}>
+          <button
+            type="button"
+            className={`${btnPokerPrimary} min-w-[80px]`}
+            disabled={loading}
+            onClick={onCheck}
+            aria-keyshortcuts="k"
+          >
             {t('action.check')}
           </button>
         </>
       )}
-      <button type="button" className={`${btnPokerMuted} min-w-[80px]`} disabled={loading} onClick={onFold}>
+      <button
+        type="button"
+        className={`${btnPokerMuted} min-w-[80px]`}
+        disabled={loading}
+        onClick={onFold}
+        aria-keyshortcuts="f"
+      >
         {t('action.fold')}
       </button>
-      <button type="button" className={`${btnPokerAllIn} min-w-[80px]`} disabled={loading} onClick={onAllIn}>
+      <button
+        type="button"
+        className={`${btnPokerAllIn} min-w-[80px]`}
+        disabled={loading}
+        onClick={onAllIn}
+        aria-keyshortcuts="a"
+      >
         {t('action.allIn')}
       </button>
+      {/* Keyboard shortcut hint. BettingControls only renders while the human can
+          act, so the shortcuts are always live here — advertising them is safe. */}
+      <p className="text-game-text-muted text-xs mt-2" data-testid="betting-key-hints">
+        {t('betting.keyHints')}
+      </p>
     </div>
   );
 }

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -288,7 +288,8 @@
       "pot": "Pot",
       "max": "Max"
     },
-    "keyHints": "C: Call / R: Bet/Raise / K: Check / F: Fold / A: All-in"
+    "keyHintsOutstanding": "C: Call / R: Raise / F: Fold / A: All-in",
+    "keyHintsNormal": "K: Check / R: Bet / F: Fold / A: All-in"
   },
   "button": {
     "reset": "Reset",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -287,7 +287,8 @@
       "halfPot": "1/2 Pot",
       "pot": "Pot",
       "max": "Max"
-    }
+    },
+    "keyHints": "C: Call / R: Bet/Raise / K: Check / F: Fold / A: All-in"
   },
   "button": {
     "reset": "Reset",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -288,7 +288,8 @@
       "pot": "Pot",
       "max": "Max"
     },
-    "keyHints": "C: コール / R: ベット・レイズ / K: チェック / F: フォールド / A: オールイン"
+    "keyHintsOutstanding": "C: コール / R: レイズ / F: フォールド / A: オールイン",
+    "keyHintsNormal": "K: チェック / R: ベット / F: フォールド / A: オールイン"
   },
   "button": {
     "reset": "リセット",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -287,7 +287,8 @@
       "halfPot": "1/2 Pot",
       "pot": "Pot",
       "max": "Max"
-    }
+    },
+    "keyHints": "C: コール / R: ベット・レイズ / K: チェック / F: フォールド / A: オールイン"
   },
   "button": {
     "reset": "リセット",


### PR DESCRIPTION
## 概要 / Summary

Closes #2998

テキサスホールデムのベット操作ショートカット（c/r/k/f/a）を画面と支援技術に明示。共通の `BettingControls` に実装したため、omaha / shortdeck / pineapple などのポーカー系にも波及する（提案どおり）。

## 変更内容 / Changes

- **aria-keyshortcuts**: 各アクションボタンに小文字キーを付与（コール=c, レイズ/ベット=r, チェック=k, フォールド=f, オールイン=a）。`BettingControls` は `canAct` 時のみ描画されるため、ショートカットは常に有効＝広告して安全（#2983 の「動作しないショートカットを広告しない」教訓に整合）。
- **キーヒント行**: ボタン群の下に「C: コール / R: ベット・レイズ / K: チェック / F: フォールド / A: オールイン」を表示。
- i18n `betting.keyHints` を **common**（`BettingControls` の名前空間）の ja/en に追加。

## 受け入れ条件 / Acceptance criteria

- [x] 手番時にキーヒントが表示される（`BettingControls` は canAct 時のみ描画）
- [x] 各アクションボタンに aria-keyshortcuts が付与される
- [x] ja/en の翻訳キーを追加する
- [x] BettingControls のテストを更新する

## テスト / Test plan

- `bun run test`（BettingControls 43 件 / Holdem・Omaha 系ページ 275 件）— pass
- `bun run build` / `bunx tsc --noEmit` — OK / exit 0
- `bun run check`（フル biome）— clean
- common i18n パリティ（ja/en）確認済み