### PR TITLE
feat(omahahilo): identify low cards without relying on color

### DIFF
--- a/frontend/src/i18n/locales/en/omahahilo.json
+++ b/frontend/src/i18n/locales/en/omahahilo.json
@@ -76,5 +76,7 @@
     "weakHandRank": "Weak hand — fold recommended",
     "scoopChance": "Scoop range (hi + lo) — raise recommended",
     "lowDraw": "Low likely to qualify — call to chase the half"
-  }
+  },
+  "loCardAria": "Low hand card",
+  "loBadge": "LO"
 }

--- a/frontend/src/i18n/locales/ja/omahahilo.json
+++ b/frontend/src/i18n/locales/ja/omahahilo.json
@@ -76,5 +76,7 @@
     "weakHandRank": "弱いハンド — フォールド推奨",
     "scoopChance": "ハイ＋ローのスクープ圏内 — レイズ推奨",
     "lowDraw": "ロー成立濃厚 — 半分狙いでコール推奨"
-  }
+  },
+  "loCardAria": "ロー構成カード",
+  "loBadge": "LO"
 }

--- a/frontend/src/pages/OmahaHiLoPage.test.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.test.tsx
@@ -418,8 +418,14 @@ describe('OmahaHiLoPage', () => {
     renderWithProviders(<OmahaHiLoPage />);
     await waitFor(() => expect(screen.getByTestId('omahahilo-split')).toBeInTheDocument());
     // At least one card (hole and/or board) is ringed as a low card.
-    expect(screen.getAllByTestId('omahahilo-lo-card').length).toBeGreaterThan(0);
-    // The low winner badge lists the qualifying card ranks.
+    const loCards = screen.getAllByTestId('omahahilo-lo-card');
+    expect(loCards.length).toBeGreaterThan(0);
+    // Each low card keeps the blue ring AND gains screen-reader text plus a
+    // color-independent "LO" badge (not just color).
+    expect(loCards[0].className).toContain('ring-ds-info');
+    expect(within(loCards[0]).getByText('ロー構成カード')).toBeInTheDocument();
+    expect(screen.getAllByTestId('omahahilo-lo-card-badge')[0]).toHaveTextContent('LO');
+    // The low winner badge still lists the qualifying card ranks.
     expect(screen.getByTestId('omahahilo-lo-badge')).toHaveTextContent('A 5 8 2 5');
   });
 

--- a/frontend/src/pages/OmahaHiLoPage.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.tsx
@@ -37,7 +37,7 @@ import { placeholderCardStyle } from '../styles/cardStyles';
 import { handNameBadgeClass } from '../styles/gameConstants';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { OmahaResponse } from '../types/card';
+import type { Card, OmahaResponse } from '../types/card';
 import { OmahaPhase, OmahaRebuyPhaseType } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { valueName } from '../utils/cardUtils';
@@ -102,6 +102,42 @@ const OMAHA_PHASE_KEYS: Readonly<Record<number, string>> = {
   [OmahaPhase.END]: 'end',
   [OmahaPhase.REBUY]: 'rebuy',
 };
+
+/** A community or hole card that, when part of the qualifying low hand (`isLo`),
+ * gets the blue ring plus color-independent markers: sr-only text (a plain div
+ * can't carry aria-label) and a visible, aria-hidden "LO" badge. */
+function OmahaLoCard({
+  card,
+  isLo,
+  cardWidth,
+  t,
+}: {
+  card: Card;
+  isLo: boolean;
+  cardWidth: number;
+  t: (key: string) => string;
+}) {
+  return (
+    <div
+      className={isLo ? 'relative rounded-lg ring-2 ring-ds-info motion-safe:animate-pulse' : ''}
+      data-testid={isLo ? 'omahahilo-lo-card' : undefined}
+    >
+      <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
+      {isLo && (
+        <>
+          <span className="sr-only">{t('loCardAria')}</span>
+          <span
+            aria-hidden="true"
+            className="absolute top-0.5 left-0.5 px-1 rounded bg-ds-info text-ds-text-on-accent text-[11px] font-extrabold leading-tight shadow"
+            data-testid="omahahilo-lo-card-badge"
+          >
+            {t('loBadge')}
+          </span>
+        </>
+      )}
+    </div>
+  );
+}
 
 /** Renders the Omaha Hi-Lo (8 or Better) game page with community cards,
  * betting, and split-pot showdown. */
@@ -260,34 +296,15 @@ function OmahaHiLoPageContent() {
                   <div className="text-ds-text-primary text-lg mb-1.5">{t('communityCards')}</div>
                   <div className="flex flex-wrap gap-2">
                     {state?.communityCards?.length
-                      ? state.communityCards.map((card, idx) => {
-                          const isLo = lowSets.loBoardSet.has(idx);
-                          return (
-                            <div
-                              key={`${card.design}-${card.value}`}
-                              className={
-                                isLo ? 'relative rounded-lg ring-2 ring-ds-info motion-safe:animate-pulse' : ''
-                              }
-                              data-testid={isLo ? 'omahahilo-lo-card' : undefined}
-                            >
-                              <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
-                              {isLo && (
-                                <>
-                                  {/* Screen-reader text (a plain div can't take aria-label). */}
-                                  <span className="sr-only">{t('loCardAria')}</span>
-                                  {/* Visible color-independent marker for sighted (incl. color-blind) users. */}
-                                  <span
-                                    aria-hidden="true"
-                                    className="absolute top-0.5 left-0.5 px-1 rounded bg-ds-info text-ds-text-on-accent text-[9px] font-extrabold leading-tight shadow"
-                                    data-testid="omahahilo-lo-card-badge"
-                                  >
-                                    {t('loBadge')}
-                                  </span>
-                                </>
-                              )}
-                            </div>
-                          );
-                        })
+                      ? state.communityCards.map((card, idx) => (
+                          <OmahaLoCard
+                            key={`${card.design}-${card.value}`}
+                            card={card}
+                            isLo={lowSets.loBoardSet.has(idx)}
+                            cardWidth={cardWidth}
+                            t={t}
+                          />
+                        ))
                       : Array.from({ length: 5 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                   </div>
                 </>
@@ -449,30 +466,15 @@ function OmahaHiLoPageContent() {
                 </div>
                 <div className="flex flex-wrap gap-1.5 mb-2" data-tutorial="ohl-combination-rule">
                   {humanPlayer.cards?.length
-                    ? humanPlayer.cards.map((card, idx) => {
-                        const isLo = lowSets.loHoleSet.has(idx);
-                        return (
-                          <div
-                            key={`${card.design}-${card.value}`}
-                            className={isLo ? 'relative rounded-lg ring-2 ring-ds-info motion-safe:animate-pulse' : ''}
-                            data-testid={isLo ? 'omahahilo-lo-card' : undefined}
-                          >
-                            <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
-                            {isLo && (
-                              <>
-                                <span className="sr-only">{t('loCardAria')}</span>
-                                <span
-                                  aria-hidden="true"
-                                  className="absolute top-0.5 left-0.5 px-1 rounded bg-ds-info text-ds-text-on-accent text-[9px] font-extrabold leading-tight shadow"
-                                  data-testid="omahahilo-lo-card-badge"
-                                >
-                                  {t('loBadge')}
-                                </span>
-                              </>
-                            )}
-                          </div>
-                        );
-                      })
+                    ? humanPlayer.cards.map((card, idx) => (
+                        <OmahaLoCard
+                          key={`${card.design}-${card.value}`}
+                          card={card}
+                          isLo={lowSets.loHoleSet.has(idx)}
+                          cardWidth={cardWidth}
+                          t={t}
+                        />
+                      ))
                     : !humanPlayer.folded &&
                       Array.from({ length: 4 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                 </div>

--- a/frontend/src/pages/OmahaHiLoPage.tsx
+++ b/frontend/src/pages/OmahaHiLoPage.tsx
@@ -260,19 +260,34 @@ function OmahaHiLoPageContent() {
                   <div className="text-ds-text-primary text-lg mb-1.5">{t('communityCards')}</div>
                   <div className="flex flex-wrap gap-2">
                     {state?.communityCards?.length
-                      ? state.communityCards.map((card, idx) => (
-                          <div
-                            key={`${card.design}-${card.value}`}
-                            className={
-                              lowSets.loBoardSet.has(idx)
-                                ? 'rounded-lg ring-2 ring-ds-info motion-safe:animate-pulse'
-                                : ''
-                            }
-                            data-testid={lowSets.loBoardSet.has(idx) ? 'omahahilo-lo-card' : undefined}
-                          >
-                            <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
-                          </div>
-                        ))
+                      ? state.communityCards.map((card, idx) => {
+                          const isLo = lowSets.loBoardSet.has(idx);
+                          return (
+                            <div
+                              key={`${card.design}-${card.value}`}
+                              className={
+                                isLo ? 'relative rounded-lg ring-2 ring-ds-info motion-safe:animate-pulse' : ''
+                              }
+                              data-testid={isLo ? 'omahahilo-lo-card' : undefined}
+                            >
+                              <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
+                              {isLo && (
+                                <>
+                                  {/* Screen-reader text (a plain div can't take aria-label). */}
+                                  <span className="sr-only">{t('loCardAria')}</span>
+                                  {/* Visible color-independent marker for sighted (incl. color-blind) users. */}
+                                  <span
+                                    aria-hidden="true"
+                                    className="absolute top-0.5 left-0.5 px-1 rounded bg-ds-info text-ds-text-on-accent text-[9px] font-extrabold leading-tight shadow"
+                                    data-testid="omahahilo-lo-card-badge"
+                                  >
+                                    {t('loBadge')}
+                                  </span>
+                                </>
+                              )}
+                            </div>
+                          );
+                        })
                       : Array.from({ length: 5 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                   </div>
                 </>
@@ -434,17 +449,30 @@ function OmahaHiLoPageContent() {
                 </div>
                 <div className="flex flex-wrap gap-1.5 mb-2" data-tutorial="ohl-combination-rule">
                   {humanPlayer.cards?.length
-                    ? humanPlayer.cards.map((card, idx) => (
-                        <div
-                          key={`${card.design}-${card.value}`}
-                          className={
-                            lowSets.loHoleSet.has(idx) ? 'rounded-lg ring-2 ring-ds-info motion-safe:animate-pulse' : ''
-                          }
-                          data-testid={lowSets.loHoleSet.has(idx) ? 'omahahilo-lo-card' : undefined}
-                        >
-                          <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
-                        </div>
-                      ))
+                    ? humanPlayer.cards.map((card, idx) => {
+                        const isLo = lowSets.loHoleSet.has(idx);
+                        return (
+                          <div
+                            key={`${card.design}-${card.value}`}
+                            className={isLo ? 'relative rounded-lg ring-2 ring-ds-info motion-safe:animate-pulse' : ''}
+                            data-testid={isLo ? 'omahahilo-lo-card' : undefined}
+                          >
+                            <AnimatedCard card={card} width={cardWidth} style={placeholderCardStyle} />
+                            {isLo && (
+                              <>
+                                <span className="sr-only">{t('loCardAria')}</span>
+                                <span
+                                  aria-hidden="true"
+                                  className="absolute top-0.5 left-0.5 px-1 rounded bg-ds-info text-ds-text-on-accent text-[9px] font-extrabold leading-tight shadow"
+                                  data-testid="omahahilo-lo-card-badge"
+                                >
+                                  {t('loBadge')}
+                                </span>
+                              </>
+                            )}
+                          </div>
+                        );
+                      })
                     : !humanPlayer.folded &&
                       Array.from({ length: 4 }).map((_, i) => <AnimatedCardBack key={i} width={cardWidth} />)}
                 </div>


### PR DESCRIPTION
## 概要 / Summary

Closes #3006

オマハ ハイローのロー該当カードが青リングのみで識別され、色覚特性のあるユーザーやスクリーンリーダーで Hi/Lo を判別できなかった問題への対応。

## 変更内容 / Changes

- **色以外の識別手段**: ロー該当カード（場札・手札）に、視覚的な「LO」バッジ（`aria-hidden`）と、スクリーンリーダー向けの `sr-only` テキスト（「ロー構成カード」）を追加。
- 既存の青リング（`ring-ds-info`）表示は維持。
- **note**: ラッパーは素の `<div>` で `aria-label` を持てない（biome の a11y ルール）ため、`sr-only` テキストで代替。カードバッジは勝者バッジと別 testid（`omahahilo-lo-card-badge`）。
- i18n `loCardAria` / `loBadge` を ja/en に追加。

## 受け入れ条件 / Acceptance criteria

- [x] ロー該当カードが支援技術に識別可能（sr-only テキスト「ロー構成カード」）
- [x] 色以外の視覚ラベル（LO表記）が表示される
- [x] 既存の青リング表示は維持される
- [x] アクセシビリティテストを追加する

## テスト / Test plan

- `bun run test`（OmahaHiLoPage 114 件）— pass
- `bun run build` / `bunx tsc --noEmit` — OK / exit 0
- `bun run check`（フル biome、a11y ルール含む）— clean
- i18n パリティ（ja/en）確認済み