### PR TITLE
feat(pineapple): give feedback when the discard cap is exceeded

### DIFF
--- a/frontend/src/i18n/locales/en/crazypineapple.json
+++ b/frontend/src/i18n/locales/en/crazypineapple.json
@@ -20,7 +20,9 @@
     "confirm": "Discard {{card}}?",
     "confirmYes": "Confirm",
     "confirmNo": "Cancel",
-    "candidateHand": "If discarded"
+    "candidateHand": "If discarded",
+    "limitReached": "You can select up to {{count}} card(s). Deselect one first.",
+    "limitDescription": "You can select at most {{count}} card(s) to discard."
   },
   "rebuy": {
     "prompt": "Rebuy? ({{chips}} chips, {{used}}/{{max}} used)",

--- a/frontend/src/i18n/locales/en/irishpoker.json
+++ b/frontend/src/i18n/locales/en/irishpoker.json
@@ -21,7 +21,9 @@
     "confirmNo": "Cancel",
     "selectedCount": "{{n}}/{{total}} selected",
     "keepLabel": "Keep",
-    "previewHand": "Tentative hand"
+    "previewHand": "Tentative hand",
+    "limitReached": "You can select up to {{count}} card(s). Deselect one first.",
+    "limitDescription": "You can select at most {{count}} card(s) to discard."
   },
   "rebuy": {
     "prompt": "Rebuy? ({{chips}} chips, {{used}}/{{max}} used)",

--- a/frontend/src/i18n/locales/en/pineapple.json
+++ b/frontend/src/i18n/locales/en/pineapple.json
@@ -18,7 +18,9 @@
     "select": "Select a card to discard",
     "confirm": "Discard {{card}}?",
     "confirmYes": "Confirm",
-    "confirmNo": "Cancel"
+    "confirmNo": "Cancel",
+    "limitReached": "You can select up to {{count}} card(s). Deselect one first.",
+    "limitDescription": "You can select at most {{count}} card(s) to discard."
   },
   "rebuy": {
     "prompt": "Rebuy? ({{chips}} chips, {{used}}/{{max}} used)",

--- a/frontend/src/i18n/locales/ja/crazypineapple.json
+++ b/frontend/src/i18n/locales/ja/crazypineapple.json
@@ -20,7 +20,9 @@
     "confirm": "{{card}} を捨てますか？",
     "confirmYes": "確定",
     "confirmNo": "キャンセル",
-    "candidateHand": "捨てると"
+    "candidateHand": "捨てると",
+    "limitReached": "選択できるのは{{count}}枚までです。先に選択を解除してください",
+    "limitDescription": "ディスカードで選択できるのは最大{{count}}枚です"
   },
   "rebuy": {
     "prompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済)",

--- a/frontend/src/i18n/locales/ja/irishpoker.json
+++ b/frontend/src/i18n/locales/ja/irishpoker.json
@@ -21,7 +21,9 @@
     "confirmNo": "キャンセル",
     "selectedCount": "{{n}}/{{total}} 枚選択済み",
     "keepLabel": "残す札",
-    "previewHand": "暫定役"
+    "previewHand": "暫定役",
+    "limitReached": "選択できるのは{{count}}枚までです。先に選択を解除してください",
+    "limitDescription": "ディスカードで選択できるのは最大{{count}}枚です"
   },
   "rebuy": {
     "prompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済)",

--- a/frontend/src/i18n/locales/ja/pineapple.json
+++ b/frontend/src/i18n/locales/ja/pineapple.json
@@ -18,7 +18,9 @@
     "select": "捨てるカードを選択してください",
     "confirm": "{{card}} を捨てますか？",
     "confirmYes": "確定",
-    "confirmNo": "キャンセル"
+    "confirmNo": "キャンセル",
+    "limitReached": "選択できるのは{{count}}枚までです。先に選択を解除してください",
+    "limitDescription": "ディスカードで選択できるのは最大{{count}}枚です"
   },
   "rebuy": {
     "prompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済)",

--- a/frontend/src/pages/PineapplePage.test.tsx
+++ b/frontend/src/pages/PineapplePage.test.tsx
@@ -248,6 +248,40 @@ describe('PineapplePage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('discard', undefined, { cardIdxs: [0] }));
   });
 
+  it('warns via a live region when clicking past the discard cap', async () => {
+    mockExec.mockResolvedValue(discardState);
+    renderWithProviders(<PineapplePage />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.getAttribute('aria-pressed') !== null);
+
+    // Cap is 1 (3 dealt → discard 1). Selecting card 0 reaches the cap; no warning yet.
+    fireEvent.click(cardButtons[0]);
+    expect(screen.queryByTestId('pn-discard-limit-announce')).not.toBeInTheDocument();
+
+    // Clicking a second, unselected card is over the cap → the warning appears.
+    fireEvent.click(cardButtons[1]);
+    const announce = await screen.findByTestId('pn-discard-limit-announce');
+    expect(announce).toHaveAttribute('role', 'status');
+    expect(announce).toHaveAttribute('aria-live', 'polite');
+    expect(announce).toHaveTextContent('選択できるのは1枚まで');
+  });
+
+  it('describes the discard cap on the hand group and does not warn on normal deselect', async () => {
+    mockExec.mockResolvedValue(discardState);
+    renderWithProviders(<PineapplePage />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+    const cardButtons = screen.getAllByRole('button').filter((b) => b.getAttribute('aria-pressed') !== null);
+
+    const group = cardButtons[0].closest('[aria-describedby]');
+    expect(group).toHaveAttribute('aria-describedby', 'pn-discard-limit-desc');
+    expect(document.getElementById('pn-discard-limit-desc')).toHaveTextContent('最大1枚');
+
+    // Selecting then deselecting the same card is normal — no warning.
+    fireEvent.click(cardButtons[0]);
+    fireEvent.click(cardButtons[0]);
+    expect(screen.queryByTestId('pn-discard-limit-announce')).not.toBeInTheDocument();
+  });
+
   it('a card click is inert once the confirm step has started', async () => {
     mockExec.mockResolvedValue(discardState);
     renderWithProviders(<PineapplePage />);

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -145,6 +145,11 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
   const [selectedDiscards, setSelectedDiscards] = useState<number[]>([]);
   // Two-step discard: pressing "discard" enters a confirm step before committing.
   const [discardConfirming, setDiscardConfirming] = useState(false);
+  // Feedback when a click is ignored because the discard cap is already reached:
+  // a message for the live region and a nonce that re-fires it (and the shake)
+  // on every repeated over-limit attempt, even with identical text.
+  const [limitAnnounce, setLimitAnnounce] = useState('');
+  const [limitNonce, setLimitNonce] = useState(0);
   const turnStartRef = useRef(0);
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode(variant);
@@ -291,13 +296,18 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
   const toggleDiscard = useCallback(
     (idx: number) => {
       if (!canDiscard || discardConfirming) return;
-      setSelectedDiscards((prev) => {
-        if (prev.includes(idx)) return prev.filter((i) => i !== idx);
-        if (prev.length >= discardCount) return prev; // cap reached
-        return [...prev, idx];
-      });
+      const isSelected = selectedDiscards.includes(idx);
+      // Selecting a new card while already at the cap is ignored — but tell the
+      // user why (live region + shake) instead of silently swallowing the click.
+      if (!isSelected && selectedDiscards.length >= discardCount) {
+        setLimitAnnounce(t('discard.limitReached', { count: discardCount }));
+        setLimitNonce((n) => n + 1);
+        return;
+      }
+      setLimitAnnounce('');
+      setSelectedDiscards((prev) => (prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx]));
     },
-    [canDiscard, discardConfirming, discardCount],
+    [canDiscard, discardConfirming, discardCount, selectedDiscards, t],
   );
   const discardConfirm = useCallback(() => {
     if (selectedDiscards.length !== discardCount) return;
@@ -492,7 +502,17 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
                     </span>
                   )}
                 </div>
-                <div className="flex flex-wrap gap-1.5 mb-2">
+                {/* Screen-reader description of the discard cap, associated with the
+                    hand group so AT conveys the limit up front. */}
+                {canDiscard && (
+                  <span id="pn-discard-limit-desc" className="sr-only">
+                    {t('discard.limitDescription', { count: discardCount })}
+                  </span>
+                )}
+                <div
+                  className="flex flex-wrap gap-1.5 mb-2"
+                  aria-describedby={canDiscard ? 'pn-discard-limit-desc' : undefined}
+                >
                   {humanPlayer.cards?.length
                     ? humanPlayer.cards.map((card, idx) => {
                         const isSelected = selectedDiscards.includes(idx);
@@ -528,6 +548,20 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
                         <AnimatedCardBack key={i} width={cardWidth} />
                       ))}
                 </div>
+                {/* Over-limit feedback: visible (color-blind-safe) + announced to AT.
+                    Keyed on the nonce so a repeated over-limit click re-fires the
+                    announcement and restarts the shake even with identical text. */}
+                {limitAnnounce && (
+                  <div
+                    key={limitNonce}
+                    role="status"
+                    aria-live="polite"
+                    data-testid="pn-discard-limit-announce"
+                    className="text-center text-ds-warning text-xs mb-2 motion-safe:animate-shake"
+                  >
+                    {limitAnnounce}
+                  </div>
+                )}
               </div>
             )}
 

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -150,6 +150,11 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
   // on every repeated over-limit attempt, even with identical text.
   const [limitAnnounce, setLimitAnnounce] = useState('');
   const [limitNonce, setLimitNonce] = useState(0);
+  // Mirror the selection in a ref so toggleDiscard can read it without listing
+  // selectedDiscards as a dependency — otherwise the callback (and the global
+  // keydown listener in useCardKeyboardNav) would be re-created on every toggle.
+  const selectedDiscardsRef = useRef<number[]>(selectedDiscards);
+  selectedDiscardsRef.current = selectedDiscards;
   const turnStartRef = useRef(0);
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode(variant);
@@ -185,11 +190,13 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
     }
   }, [state]);
 
-  // Reset discard selection (and any pending confirm) when leaving discard phase
+  // Reset discard selection (and any pending confirm / limit banner) when leaving
+  // the discard phase, so a stale over-limit warning can't outlive it.
   useEffect(() => {
     if (!state?.isDiscardPhase) {
       setSelectedDiscards([]);
       setDiscardConfirming(false);
+      setLimitAnnounce('');
     }
   }, [state?.isDiscardPhase]);
 
@@ -296,10 +303,11 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
   const toggleDiscard = useCallback(
     (idx: number) => {
       if (!canDiscard || discardConfirming) return;
-      const isSelected = selectedDiscards.includes(idx);
+      const current = selectedDiscardsRef.current;
+      const isSelected = current.includes(idx);
       // Selecting a new card while already at the cap is ignored — but tell the
       // user why (live region + shake) instead of silently swallowing the click.
-      if (!isSelected && selectedDiscards.length >= discardCount) {
+      if (!isSelected && current.length >= discardCount) {
         setLimitAnnounce(t('discard.limitReached', { count: discardCount }));
         setLimitNonce((n) => n + 1);
         return;
@@ -307,7 +315,7 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
       setLimitAnnounce('');
       setSelectedDiscards((prev) => (prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx]));
     },
-    [canDiscard, discardConfirming, discardCount, selectedDiscards, t],
+    [canDiscard, discardConfirming, discardCount, t],
   );
   const discardConfirm = useCallback(() => {
     if (selectedDiscards.length !== discardCount) return;


### PR DESCRIPTION
## 概要 / Summary

Closes #3018

パイナップルポーカーで、ディスカード上限到達後のカードクリックが黙って無視され、なぜ選択できないか分からなかった問題への対応。

## 変更内容 / Changes

- **上限超過フィードバック**: 上限到達状態で未選択カードを押すと、`role="status" aria-live="polite"` のライブリージョンで「選択できるのは N 枚までです。先に選択を解除してください」を通知。視覚的にも表示（色覚非依存）＋軽いシェイク。nonce を key にして連続超過クリックでも毎回再通知。
- **aria-describedby**: 手札グループに上限説明（`sr-only`）を関連付け、支援技術へ上限を伝達。
- 通常の選択/解除は不変。
- **共有コンポーネント対応**: `PineapplePage` は pineapple / crazypineapple / irishpoker で共有のため、`discard.limitReached` / `limitDescription` を 3 名前空間（ja+en 計6ファイル）に追加。

## 受け入れ条件 / Acceptance criteria

- [x] 上限超過クリックでライブリージョン通知が出る
- [x] aria-describedby で上限がスクリーンリーダーに伝わる
- [x] 通常の選択/解除動作は変更しない
- [x] ユニットテストを追加する

## テスト / Test plan

- `bun run test`（PineapplePage/CrazyPineapple/IrishPoker 系）— pass
- `bun run build` / `bunx tsc --noEmit` — OK / exit 0
- `bun run check`（フル biome）— clean
- i18n パリティ（3 変種 × ja/en）確認済み