### PR TITLE
feat(ohhell): make restricted bids focusable with an explanatory label

### DIFF
--- a/frontend/src/i18n/locales/en/ohhell.json
+++ b/frontend/src/i18n/locales/en/ohhell.json
@@ -90,5 +90,6 @@
     "followSuit": "Follow the led suit",
     "trumpWithCard": "Trump with a card",
     "discardLowest": "Discard your lowest card"
-  }
+  },
+  "restrictedBidAria": "Bid {{n}} (unavailable due to the dealer restriction)"
 }

--- a/frontend/src/i18n/locales/ja/ohhell.json
+++ b/frontend/src/i18n/locales/ja/ohhell.json
@@ -90,5 +90,6 @@
     "followSuit": "リードされたスートに従ってプレイ推奨",
     "trumpWithCard": "切り札を使うチャンス",
     "discardLowest": "最も低いカードを捨てることを推奨"
-  }
+  },
+  "restrictedBidAria": "{{n}} をビッド（ディーラー制約により選択できません）"
 }

--- a/frontend/src/pages/OhHellPage.test.tsx
+++ b/frontend/src/pages/OhHellPage.test.tsx
@@ -276,20 +276,30 @@ describe('OhHellPage', () => {
     expect(await screen.findByTestId('bid-total-chip')).toHaveTextContent('(ぴったり)');
   });
 
-  it('disables the restricted bid button and exposes the tooltip', async () => {
+  it('makes the restricted bid focusable via aria-disabled and ignores its click', async () => {
     mockExec.mockResolvedValue(bidPhaseDealerState);
     renderWithProviders(<OhHellPage />);
-    await waitFor(() => {
-      const restricted = screen.getByRole('button', { name: '\u30d3\u30c3\u30c9 3' });
-      expect(restricted).toBeDisabled();
-      expect(restricted).toHaveAttribute(
-        'title',
-        '\u30c7\u30a3\u30fc\u30e9\u30fc\u5236\u7d04\u306e\u305f\u3081\u9078\u629e\u3067\u304d\u307e\u305b\u3093',
-      );
-      // Other choices remain enabled
-      expect(screen.getByRole('button', { name: '\u30d3\u30c3\u30c9 0' })).not.toBeDisabled();
-      expect(screen.getByRole('button', { name: '\u30d3\u30c3\u30c9 5' })).not.toBeDisabled();
-    });
+    const restricted = await screen.findByTestId('ohhell-restricted-bid');
+    // aria-disabled (stays focusable), NOT HTML-disabled; reason in the label.
+    expect(restricted).toHaveAttribute('aria-disabled', 'true');
+    expect(restricted).not.toBeDisabled();
+    expect(restricted).toHaveAttribute(
+      'aria-label',
+      '3 \u3092\u30d3\u30c3\u30c9\uff08\u30c7\u30a3\u30fc\u30e9\u30fc\u5236\u7d04\u306b\u3088\u308a\u9078\u629e\u3067\u304d\u307e\u305b\u3093\uff09',
+    );
+    expect(restricted).toHaveAttribute(
+      'title',
+      '\u30c7\u30a3\u30fc\u30e9\u30fc\u5236\u7d04\u306e\u305f\u3081\u9078\u629e\u3067\u304d\u307e\u305b\u3093',
+    );
+
+    // Clicking the restricted bid dispatches nothing.
+    mockExec.mockClear();
+    fireEvent.click(restricted);
+    expect(mockExec).not.toHaveBeenCalled();
+
+    // Other choices remain enabled and normal.
+    expect(screen.getByRole('button', { name: '\u30d3\u30c3\u30c9 0' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: '\u30d3\u30c3\u30c9 5' })).not.toBeDisabled();
   });
 
   it('shows bid phase instruction when human bid turn', async () => {

--- a/frontend/src/pages/OhHellPage.tsx
+++ b/frontend/src/pages/OhHellPage.tsx
@@ -562,11 +562,19 @@ function OhHellPageContent() {
                       <button
                         key={i}
                         type="button"
-                        className={btnPrimary}
-                        onClick={() => handleBid(i)}
-                        disabled={loading || isRestricted}
+                        // Restricted bids use aria-disabled (not the HTML disabled
+                        // attribute) so they stay focusable and a screen reader can
+                        // read why they can't be chosen; the click is guarded instead.
+                        // Mirrors the Cribbage pegRestricted / Call Break pattern.
+                        className={`${btnPrimary}${isRestricted ? ' opacity-50 cursor-not-allowed' : ''}`}
+                        onClick={() => {
+                          if (!isRestricted) handleBid(i);
+                        }}
+                        disabled={loading}
+                        aria-disabled={isRestricted || undefined}
                         title={isRestricted ? t('restrictedBidTooltip') : undefined}
-                        aria-label={t('bid', { n: i })}
+                        aria-label={isRestricted ? t('restrictedBidAria', { n: i }) : t('bid', { n: i })}
+                        data-testid={isRestricted ? 'ohhell-restricted-bid' : undefined}
                       >
                         {i}
                       </button>

--- a/frontend/src/pages/OhHellPage.tsx
+++ b/frontend/src/pages/OhHellPage.tsx
@@ -566,7 +566,11 @@ function OhHellPageContent() {
                         // attribute) so they stay focusable and a screen reader can
                         // read why they can't be chosen; the click is guarded instead.
                         // Mirrors the Cribbage pegRestricted / Call Break pattern.
-                        className={`${btnPrimary}${isRestricted ? ' opacity-50 cursor-not-allowed' : ''}`}
+                        // Neutralize btnPrimary's interactive feedback (press-scale,
+                        // hover shadow) when restricted so it doesn't feel clickable.
+                        className={`${btnPrimary}${
+                          isRestricted ? ' opacity-50 cursor-not-allowed active:scale-100 hover:shadow-none' : ''
+                        }`}
                         onClick={() => {
                           if (!isRestricted) handleBid(i);
                         }}


### PR DESCRIPTION
## 概要 / Summary

Closes #3095

オー・ヘルのディーラー制約ビッドが HTML `disabled` でフォーカス不能なため、キーボード/スクリーンリーダー利用者が「なぜ押せないか」を知る手段がなかった問題への対応。クリベッジ `pegRestricted` / コールブレイク（#1865）と同じ `aria-disabled` パターンを踏襲。

## 変更内容 / Changes

- **aria-disabled 化**: 禁止ビッドを `disabled`（loading のみ残す）→ `aria-disabled` に変更しフォーカス可能に。`onClick` を `!isRestricted` でガードし API を呼ばない。
- **理由の読み上げ**: `aria-label` に制約理由（「N をビッド（ディーラー制約により選択できません）」）を含める。
- 視覚の減光（opacity-50）は維持。i18n `restrictedBidAria` を ja/en に追加。

## 受け入れ条件 / Acceptance criteria

- [x] 禁止ビッドボタンが Tab フォーカス可能で、クリックしても API が呼ばれない
- [x] aria-label に禁止理由が含まれ ja/en で翻訳される
- [x] 通常ビッドの操作性は不変
- [x] ページテストで aria-disabled とクリック無視を検証

## テスト / Test plan

- `bun run test`（OhHellPage 49 件）— pass
- `bun run build` / `bunx tsc --noEmit` — OK / exit 0
- `bun run check`（フル biome）— clean
- i18n パリティ（ja/en）確認済み