### PR TITLE
feat(war): hide the decorative pot stack from assistive tech

### DIFF
--- a/frontend/src/pages/WarPage.test.tsx
+++ b/frontend/src/pages/WarPage.test.tsx
@@ -220,6 +220,15 @@ describe('WarPage', () => {
     expect(stack.querySelectorAll('[data-testid="animated-card-back"]')).toHaveLength(4);
   });
 
+  it('hides the decorative pot stack from AT while keeping the count text readable', async () => {
+    mockExec.mockResolvedValueOnce({ ...warPhaseState, warPotSize: 4 });
+    renderWithProviders(<WarPage />);
+    const stack = await screen.findByTestId('war-pot-stack');
+    expect(stack).toHaveAttribute('aria-hidden', 'true');
+    // The count is still conveyed by the adjacent text (not hidden).
+    expect(screen.getByText(/4/)).toBeInTheDocument();
+  });
+
   it('caps the visual pot stack at 10 cards even when warPotSize is larger', async () => {
     mockExec.mockResolvedValueOnce({ ...warPhaseState, warPotSize: 15 });
     renderWithProviders(<WarPage />);

--- a/frontend/src/pages/WarPage.tsx
+++ b/frontend/src/pages/WarPage.tsx
@@ -217,6 +217,9 @@ function WarPageContent() {
                 </div>
                 {state.warPotSize > 2 && (
                   <div
+                    // Purely decorative stacked card backs; the count is already
+                    // conveyed by the adjacent label.potCount text, so hide from AT.
+                    aria-hidden="true"
                     className="relative mx-auto mt-1"
                     data-testid="war-pot-stack"
                     data-pot-size={state.warPotSize}


### PR DESCRIPTION
## 概要 / Summary

Closes #3144

戦争（War）の `war-pot-stack` は最大10枚の装飾用カード裏面を重ねるだけの演出だが `aria-hidden` が無く、ポット枚数は隣接テキスト（`label.potCount`）で既に伝わっているため、装飾要素がスクリーンリーダーに冗長に読み上げられ得た。

## 変更内容 / Changes

- `war-pot-stack` コンテナに `aria-hidden="true"` を付与（装飾のため AT から隠す）。
- 視覚・レイアウト・`data-pot-size`（E2E 用）は不変。ポット枚数テキストは引き続き読み上げ可能。

## 受け入れ条件 / Acceptance criteria

- [x] `war-pot-stack` コンテナに `aria-hidden="true"` が付与される
- [x] `label.potCount` のテキストは引き続きスクリーンリーダーで読み上げられる
- [x] 視覚的な見た目は変更しない
- [x] 既存の `data-pot-size` E2E に影響しない

## テスト / Test plan

- `bun run test`（WarPage 38 件）— pass
- `bun run build` / `bunx tsc --noEmit` — OK / exit 0
- `bun run check`（フル biome）— clean