### PR TITLE
feat(fiftyone): add aria-label and aria-pressed to card buttons

### DIFF
--- a/frontend/src/pages/FiftyOnePage.test.tsx
+++ b/frontend/src/pages/FiftyOnePage.test.tsx
@@ -74,6 +74,25 @@ describe('FiftyOnePage', () => {
     mockExec.mockResolvedValue(baseState);
   });
 
+  it('labels hand and table cards and toggles aria-pressed on selection', async () => {
+    const { FiftyOnePage } = await import('./FiftyOnePage');
+    renderWithProviders(<FiftyOnePage />);
+    // Hand ♠A and table ♠K are distinct, labeled, selectable buttons.
+    const handAce = await screen.findByRole('button', { name: '♠ A' });
+    const tableKing = screen.getByRole('button', { name: '♠ K' });
+    expect(handAce).toHaveAttribute('aria-pressed', 'false');
+    expect(tableKing).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(handAce);
+    expect(handAce).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(tableKing);
+    expect(tableKing).toHaveAttribute('aria-pressed', 'true');
+
+    // Clicking the same hand card again deselects it.
+    fireEvent.click(handAce);
+    expect(handAce).toHaveAttribute('aria-pressed', 'false');
+  });
+
   it('calls reset on mount', async () => {
     const { FiftyOnePage } = await import('./FiftyOnePage');
     renderWithProviders(<FiftyOnePage />);

--- a/frontend/src/pages/FiftyOnePage.tsx
+++ b/frontend/src/pages/FiftyOnePage.tsx
@@ -216,21 +216,24 @@ function FiftyOnePageContent() {
             <div className="py-3 bg-black/20 rounded-lg" data-tutorial="fo-table-cards">
               <div className="text-center text-xs text-ds-text-muted mb-2">{t('label.tableCards')}</div>
               <div className="flex justify-center gap-2">
-                {state.tableCards.map((c, i) => (
-                  <button
-                    key={i}
-                    type="button"
-                    onClick={() => isHumanTurn && setSelectedTableIdx(i === selectedTableIdx ? null : i)}
-                    disabled={!isHumanTurn}
-                    aria-label={cardAlt(c)}
-                    aria-pressed={isHumanTurn ? selectedTableIdx === i : undefined}
-                    className={`rounded transition-all ${
-                      selectedTableIdx === i ? 'ring-2 ring-ds-warning -translate-y-1' : ''
-                    } ${isHumanTurn ? 'cursor-pointer hover:opacity-90' : 'cursor-default'}`}
-                  >
-                    <AnimatedCard card={c} width={cardWidth * 0.9} />
-                  </button>
-                ))}
+                {state.tableCards.map((c, i) => {
+                  const isSelected = selectedTableIdx === i;
+                  return (
+                    <button
+                      key={i}
+                      type="button"
+                      onClick={() => isHumanTurn && setSelectedTableIdx(isSelected ? null : i)}
+                      disabled={!isHumanTurn}
+                      aria-label={cardAlt(c)}
+                      aria-pressed={isHumanTurn ? isSelected : undefined}
+                      className={`rounded transition-all ${
+                        isSelected ? 'ring-2 ring-ds-warning -translate-y-1' : ''
+                      } ${isHumanTurn ? 'cursor-pointer hover:opacity-90' : 'cursor-default'}`}
+                    >
+                      <AnimatedCard card={c} width={cardWidth * 0.9} />
+                    </button>
+                  );
+                })}
               </div>
             </div>
 
@@ -269,21 +272,24 @@ function FiftyOnePageContent() {
                 })}
               </ul>
               <div className="flex justify-center gap-2">
-                {human.cards.map((c, i) => (
-                  <button
-                    key={i}
-                    type="button"
-                    onClick={() => isHumanTurn && setSelectedHandIdx(i === selectedHandIdx ? null : i)}
-                    disabled={!isHumanTurn}
-                    aria-label={cardAlt(c)}
-                    aria-pressed={isHumanTurn ? selectedHandIdx === i : undefined}
-                    className={`rounded transition-all ${
-                      selectedHandIdx === i ? 'ring-2 ring-ds-info -translate-y-2' : ''
-                    } ${isHumanTurn ? 'cursor-pointer hover:opacity-90' : 'cursor-default'}`}
-                  >
-                    <AnimatedCard card={c} width={cardWidth} />
-                  </button>
-                ))}
+                {human.cards.map((c, i) => {
+                  const isSelected = selectedHandIdx === i;
+                  return (
+                    <button
+                      key={i}
+                      type="button"
+                      onClick={() => isHumanTurn && setSelectedHandIdx(isSelected ? null : i)}
+                      disabled={!isHumanTurn}
+                      aria-label={cardAlt(c)}
+                      aria-pressed={isHumanTurn ? isSelected : undefined}
+                      className={`rounded transition-all ${
+                        isSelected ? 'ring-2 ring-ds-info -translate-y-2' : ''
+                      } ${isHumanTurn ? 'cursor-pointer hover:opacity-90' : 'cursor-default'}`}
+                    >
+                      <AnimatedCard card={c} width={cardWidth} />
+                    </button>
+                  );
+                })}
               </div>
             </div>
 

--- a/frontend/src/pages/FiftyOnePage.tsx
+++ b/frontend/src/pages/FiftyOnePage.tsx
@@ -24,6 +24,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { FiftyOneResponse } from '../types/card';
 import { FiftyOnePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { fiftyOneBestSuit, fiftyOneSuitScores } from '../utils/fiftyOneSuitScores';
 
@@ -221,6 +222,8 @@ function FiftyOnePageContent() {
                     type="button"
                     onClick={() => isHumanTurn && setSelectedTableIdx(i === selectedTableIdx ? null : i)}
                     disabled={!isHumanTurn}
+                    aria-label={cardAlt(c)}
+                    aria-pressed={isHumanTurn ? selectedTableIdx === i : undefined}
                     className={`rounded transition-all ${
                       selectedTableIdx === i ? 'ring-2 ring-ds-warning -translate-y-1' : ''
                     } ${isHumanTurn ? 'cursor-pointer hover:opacity-90' : 'cursor-default'}`}
@@ -272,6 +275,8 @@ function FiftyOnePageContent() {
                     type="button"
                     onClick={() => isHumanTurn && setSelectedHandIdx(i === selectedHandIdx ? null : i)}
                     disabled={!isHumanTurn}
+                    aria-label={cardAlt(c)}
+                    aria-pressed={isHumanTurn ? selectedHandIdx === i : undefined}
                     className={`rounded transition-all ${
                       selectedHandIdx === i ? 'ring-2 ring-ds-info -translate-y-2' : ''
                     } ${isHumanTurn ? 'cursor-pointer hover:opacity-90' : 'cursor-default'}`}


### PR DESCRIPTION
## 概要 / Summary

Closes #3150

フィフティワンの場札・手札カードボタンに `aria-label`/`aria-pressed` が無く、スクリーンリーダーではカードの識別・選択状態が伝わらず視覚のリングのみに依存していた問題への対応（PaiGow パターンに合わせる）。

## 変更内容 / Changes

- 場札・手札の各カードボタンに `aria-label={cardAlt(c)}` を付与。
- 選択状態を `aria-pressed`（場札=`selectedTableIdx`／手札=`selectedHandIdx`、人間手番時のみ）で反映。
- 既存の視覚リングハイライトは不変。

## 受け入れ条件 / Acceptance criteria

- [x] 場札カードボタンに `aria-label={cardAlt(c)}` が追加される
- [x] 手札カードボタンに `aria-label={cardAlt(c)}` と `aria-pressed` が追加される
- [x] 選択状態の変化がスクリーンリーダーで伝わる（`aria-pressed` トグルをテスト）
- [x] 既存の視覚的なリングハイライトは変更しない

## テスト / Test plan

- `bun run test`（FiftyOnePage 11 件）— pass
- `bun run build` / `bunx tsc --noEmit` — OK / exit 0
- `bun run check`（フル biome）— clean