### PR TITLE
feat(yukon): announce foundations with localized suit names

### DIFF
--- a/frontend/src/i18n/locales/en/yukon.json
+++ b/frontend/src/i18n/locales/en/yukon.json
@@ -24,6 +24,12 @@
   "hintAnnouncement": "Hint: move {{card}} to {{dest}}",
   "foundationAriaLabel": "{{suit}} foundation {{count}} cards",
   "emptyFoundationAriaLabel": "Empty foundation ({{suit}})",
+  "suitNames": {
+    "spade": "Spades",
+    "club": "Clubs",
+    "heart": "Hearts",
+    "diamond": "Diamonds"
+  },
   "stalemate": "Stalemate",
   "frontendHint": {
     "moveToFoundation": "A card can be moved to the foundation",

--- a/frontend/src/i18n/locales/ja/yukon.json
+++ b/frontend/src/i18n/locales/ja/yukon.json
@@ -24,6 +24,12 @@
   "hintAnnouncement": "ヒント: {{card}}を{{dest}}へ移動",
   "foundationAriaLabel": "{{suit}} 組札 {{count}}枚",
   "emptyFoundationAriaLabel": "空の組札 ({{suit}})",
+  "suitNames": {
+    "spade": "スペード",
+    "club": "クラブ",
+    "heart": "ハート",
+    "diamond": "ダイヤ"
+  },
   "stalemate": "手詰まりです",
   "frontendHint": {
     "moveToFoundation": "組札へ移動できるカードがあります",

--- a/frontend/src/pages/YukonPage.test.tsx
+++ b/frontend/src/pages/YukonPage.test.tsx
@@ -220,4 +220,19 @@ describe('YukonPage', () => {
     expect(screen.getByText('♥')).toBeInTheDocument();
     expect(screen.getByText('♦')).toBeInTheDocument();
   });
+
+  it('announces foundations with localized suit names, not bare glyphs', async () => {
+    // Fill the spade foundation so the filled-foundation label path is exercised too.
+    mockExec.mockResolvedValue({
+      ...playingState,
+      foundation: [[card('SPADE', 1)], [], [], []],
+    });
+    renderWithProviders(<YukonPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    // Filled spade foundation reads "スペード 組札 1枚"; empty ones read "空の組札 (<name>)".
+    expect(screen.getByRole('button', { name: 'スペード 組札 1枚' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '空の組札 (クラブ)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '空の組札 (ハート)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '空の組札 (ダイヤ)' })).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/YukonPage.tsx
+++ b/frontend/src/pages/YukonPage.tsx
@@ -37,6 +37,9 @@ import type { CliGameConfig } from '../utils/cli/types';
 import { isTableauAllFaceUp } from '../utils/solitaireUtils';
 
 const FOUNDATION_SUITS = ['♠', '♣', '♥', '♦'] as const;
+// Localized suit-name keys parallel to FOUNDATION_SUITS, used for aria-labels so
+// screen readers announce "スペード / Spades" rather than the bare "♠" glyph (#3153).
+const FOUNDATION_SUIT_KEYS = ['spade', 'club', 'heart', 'diamond'] as const;
 const noop = () => {};
 
 /** Yukon tutorial step definitions. */
@@ -397,11 +400,11 @@ function YukonPageContent() {
                       aria-label={
                         topCard
                           ? t('foundationAriaLabel', {
-                              suit: FOUNDATION_SUITS[i],
+                              suit: t(`suitNames.${FOUNDATION_SUIT_KEYS[i]}`),
                               count: pile.length,
                             })
                           : t('emptyFoundationAriaLabel', {
-                              suit: FOUNDATION_SUITS[i],
+                              suit: t(`suitNames.${FOUNDATION_SUIT_KEYS[i]}`),
                             })
                       }
                       style={{ width: yk.cw, height: yk.ch }}


### PR DESCRIPTION
## 概要

ユーコンのファウンデーションの `aria-label` は、スート記号そのもの（`♠ ♣ ♥ ♦`）を補間して生成していました。スクリーンリーダーによってはこれらの記号を読み飛ばしたり、意味不明な記号として読み上げたりするため、「スペードのファウンデーション」のような自然な名称で伝わらないリスクがありました。

## 変更内容

- `suitNames` マップ（`spade`/`club`/`heart`/`diamond`）を ja/en 双方の `yukon.json` に追加
- `FOUNDATION_SUIT_KEYS` を追加し、`foundationAriaLabel` / `emptyFoundationAriaLabel` の `suit` にはローカライズ済みスート名を補間するよう変更
- **視覚表示（`FOUNDATION_SUITS` の記号）は変更なし** — 記号の見た目はそのまま
- ローカライズされたスート名で読み上げられることを検証するテストを追加（充填/空の両パス）

## 受け入れ条件

- [x] `aria-label` 生成に記号ではなく localized なスート名を使用する
- [x] 視覚表示（`FOUNDATION_SUITS` の記号）は変更しない
- [x] ja/en それぞれのロケールでスート名が正しく読み上げられることを確認する
- [ ] `RussianSolitairePage.tsx` の同型実装は別issue（#3154）で対応

## テスト

- `bun run test -- --run YukonPage.test` — 18 passed
- `bun run check` / `bunx tsc --noEmit` / `bun run build` — pass

Closes #3153