### PR TITLE
feat(russiansolitaire): give face-down cards concise positional aria-labels

### DIFF
--- a/frontend/src/i18n/locales/en/russiansolitaire.json
+++ b/frontend/src/i18n/locales/en/russiansolitaire.json
@@ -38,5 +38,6 @@
   "nav": {
     "russiansolitaire": "Russian Solitaire"
   },
-  "faceDownRule": "Face-down cards can't be moved — only face-up cards are playable"
+  "faceDownRule": "Face-down cards can't be moved — only face-up cards are playable",
+  "faceDownCardLabel": "Column {{col}}, card {{pos}} from top, face down"
 }

--- a/frontend/src/i18n/locales/ja/russiansolitaire.json
+++ b/frontend/src/i18n/locales/ja/russiansolitaire.json
@@ -38,5 +38,6 @@
   "nav": {
     "russiansolitaire": "ロシアンソリティア"
   },
-  "faceDownRule": "裏向きのカードは移動できません（表向きのカードのみ操作可能）"
+  "faceDownRule": "裏向きのカードは移動できません（表向きのカードのみ操作可能）",
+  "faceDownCardLabel": "列{{col}}、上から{{pos}}枚目、裏向き"
 }

--- a/frontend/src/pages/RussianSolitairePage.test.tsx
+++ b/frontend/src/pages/RussianSolitairePage.test.tsx
@@ -75,11 +75,17 @@ describe('RussianSolitairePage', () => {
     await waitFor(() => expect(screen.getByText(/手数/)).toBeInTheDocument());
   });
 
-  it('shows the face-down rule note and labels face-down cards', async () => {
+  it('shows the face-down rule note and gives face-down cards concise positional labels', async () => {
     renderWithProviders(<RussianSolitairePage />);
     await waitFor(() => expect(screen.getByTestId('rs-facedown-rule')).toBeInTheDocument());
-    // The playing state has face-down cards; each exposes the rule as its label.
-    expect(screen.getAllByLabelText(/移動できません/).length).toBeGreaterThan(0);
+    // The rule text lives only in the note, not repeated on every card label.
+    expect(screen.queryByLabelText(/移動できません/)).not.toBeInTheDocument();
+    // Each face-down card exposes a short label with its column and position.
+    // Columns use the same 0-based index shown in the visible column header:
+    // column 1 has one face-down card at the top; column 2 has two.
+    expect(screen.getByLabelText('列1、上から1枚目、裏向き')).toBeInTheDocument();
+    expect(screen.getByLabelText('列2、上から1枚目、裏向き')).toBeInTheDocument();
+    expect(screen.getByLabelText('列2、上から2枚目、裏向き')).toBeInTheDocument();
   });
 
   it('shows game clear phase', async () => {

--- a/frontend/src/pages/RussianSolitairePage.tsx
+++ b/frontend/src/pages/RussianSolitairePage.tsx
@@ -530,7 +530,11 @@ function RussianSolitairePageContent() {
                                   );
                                 })()
                               ) : (
-                                <div role="img" aria-label={t('faceDownRule')} title={t('faceDownRule')}>
+                                <div
+                                  role="img"
+                                  aria-label={t('faceDownCardLabel', { col: colIdx, pos: cardIdx + 1 })}
+                                  title={t('faceDownRule')}
+                                >
                                   <AnimatedCardBack width={rs.cw} />
                                 </div>
                               )}


### PR DESCRIPTION
## 概要

ロシアンソリティアの伏せカードは、すべてが同じ長いルール説明文 (`faceDownRule`) を `aria-label` として持っていた。スクリーンリーダー利用者は列やカード位置を区別できないまま、同じ長文を伏せカードの枚数分だけ繰り返し聞かされていた。

各伏せカードに、列と位置を示す簡潔なラベル (`faceDownCardLabel` 例:「列3、上から2枚目、裏向き」) を付与し、ルール説明文はページ上部の `rs-facedown-rule` ノートと `title`（ツールチップ）にのみ残すよう変更した。

## 変更点

- `RussianSolitairePage.tsx`: 伏せカードの `aria-label` を `faceDownRule` から `faceDownCardLabel`（列・位置を含む）に変更。`title` はルール説明のまま維持
- 新規 i18n キー `faceDownCardLabel` を ja / en 両方に追加
- 視覚的な表示 (`AnimatedCardBack`) は変更なし

## 受け入れ条件

- [x] 伏せカードの `aria-label` が列・位置を含む簡潔な内容に変更される
- [x] ルール説明文はページ上部の `rs-facedown-rule` にのみ残す（および `title`）
- [x] 新規 i18n キー `faceDownCardLabel` が ja/en 両方に追加される
- [x] 視覚的な表示 (`AnimatedCardBack`) は変更しない

## テスト

- `bun run test -- --run RussianSolitairePage` … 18 passed（既存テストを新ラベル前提に更新）
- `bun run build` / `bun run check` / `bunx tsc -b` … OK

Closes #3154