### PR TITLE
feat(pokersquares): announce cross-highlight score preview in a live region

### DIFF
--- a/frontend/src/i18n/locales/en/pokersquares.json
+++ b/frontend/src/i18n/locales/en/pokersquares.json
@@ -41,5 +41,7 @@
     "fourOfAKind": "Four of a Kind",
     "straightFlush": "Straight Flush",
     "royalFlush": "Royal Flush"
-  }
+  },
+  "previewRowAnnounce": "Row {{row}} completes {{hand}} for {{delta}} points",
+  "previewColAnnounce": "Column {{col}} completes {{hand}} for {{delta}} points"
 }

--- a/frontend/src/i18n/locales/ja/pokersquares.json
+++ b/frontend/src/i18n/locales/ja/pokersquares.json
@@ -41,5 +41,7 @@
     "fourOfAKind": "フォーカード",
     "straightFlush": "ストレートフラッシュ",
     "royalFlush": "ロイヤルフラッシュ"
-  }
+  },
+  "previewRowAnnounce": "{{row}}行目が{{hand}}で完成し、{{delta}}点獲得します",
+  "previewColAnnounce": "{{col}}列目が{{hand}}で完成し、{{delta}}点獲得します"
 }

--- a/frontend/src/pages/PokerSquaresPage.test.tsx
+++ b/frontend/src/pages/PokerSquaresPage.test.tsx
@@ -129,6 +129,64 @@ describe('PokerSquaresPage', () => {
     await waitFor(() => expect(mockApi).toHaveBeenCalledWith('place', 2, 3));
   });
 
+  it('announces the row score preview in a live region on focus and clears it on blur', async () => {
+    const b = emptyBoard();
+    b[0][1] = { card: card('HEART', 2) };
+    b[0][2] = { card: card('HEART', 3) };
+    b[0][3] = { card: card('HEART', 4) };
+    b[0][4] = { card: card('HEART', 5) };
+    // Placing HEART 6 at (0,0) completes row 0 as a straight flush; column 0 is
+    // still empty so only the row preview is announced.
+    mockApi.mockResolvedValue({
+      ...playingState,
+      board: b,
+      currentCard: card('HEART', 6),
+      placedCount: 4,
+    });
+    renderWithProviders(<PokerSquaresPage />);
+    await waitFor(() => expect(screen.getByTestId('cell-0-0')).toBeInTheDocument());
+    const live = screen.getByTestId('ps-preview-live');
+    expect(live).toHaveTextContent('');
+    fireEvent.focus(screen.getByTestId('cell-0-0'));
+    await waitFor(() => expect(live).toHaveTextContent(/1行目.*完成.*点/));
+    fireEvent.blur(screen.getByTestId('cell-0-0'));
+    await waitFor(() => expect(live).toHaveTextContent(''));
+  });
+
+  it('announces the column score preview when focusing a cell that completes a column', async () => {
+    const b = emptyBoard();
+    b[1][0] = { card: card('HEART', 2) };
+    b[2][0] = { card: card('HEART', 3) };
+    b[3][0] = { card: card('HEART', 4) };
+    b[4][0] = { card: card('HEART', 5) };
+    // Placing HEART 6 at (0,0) completes column 0; row 0 is otherwise empty so
+    // only the column preview is announced.
+    mockApi.mockResolvedValue({
+      ...playingState,
+      board: b,
+      currentCard: card('HEART', 6),
+      placedCount: 4,
+    });
+    renderWithProviders(<PokerSquaresPage />);
+    await waitFor(() => expect(screen.getByTestId('cell-0-0')).toBeInTheDocument());
+    const live = screen.getByTestId('ps-preview-live');
+    fireEvent.focus(screen.getByTestId('cell-0-0'));
+    await waitFor(() => expect(live).toHaveTextContent(/1列目.*完成.*点/));
+  });
+
+  it('does not announce a preview when the focused cell completes no line', async () => {
+    // Only two cards in row 0 — focusing (0,0) completes nothing.
+    const b = emptyBoard();
+    b[0][1] = { card: card('HEART', 2) };
+    b[0][2] = { card: card('HEART', 3) };
+    mockApi.mockResolvedValue({ ...playingState, board: b, currentCard: card('SPADE', 9), placedCount: 2 });
+    renderWithProviders(<PokerSquaresPage />);
+    await waitFor(() => expect(screen.getByTestId('cell-0-0')).toBeInTheDocument());
+    fireEvent.focus(screen.getByTestId('cell-0-0'));
+    // No completed line -> live region stays empty.
+    expect(screen.getByTestId('ps-preview-live')).toHaveTextContent('');
+  });
+
   it('does not call place when a filled cell is clicked (button is disabled)', async () => {
     const filledState: PokerSquaresResponse = {
       ...playingState,

--- a/frontend/src/pages/PokerSquaresPage.tsx
+++ b/frontend/src/pages/PokerSquaresPage.tsx
@@ -154,6 +154,40 @@ function PokerSquaresPageContent() {
     };
   }, [state, crossHover]);
 
+  // Mirror the visual `+N / hand` score preview into a polite live region so
+  // keyboard users hear how the focused cell would change the row/column score.
+  // Stays empty when the placement completes nothing (or scores 0), so screen
+  // readers aren't spammed while tabbing across cells.
+  const previewAnnouncement = useMemo(() => {
+    if (!state || !crossHover || !preview) return '';
+    const parts: string[] = [];
+    if (preview.row) {
+      const delta = preview.row.score - state.rowScores[crossHover.row];
+      if (delta !== 0) {
+        parts.push(
+          t('previewRowAnnounce', {
+            row: crossHover.row + 1,
+            hand: t(`hand.${pokerHandKey(preview.row.rank)}`),
+            delta,
+          }),
+        );
+      }
+    }
+    if (preview.col) {
+      const delta = preview.col.score - state.colScores[crossHover.col];
+      if (delta !== 0) {
+        parts.push(
+          t('previewColAnnounce', {
+            col: crossHover.col + 1,
+            hand: t(`hand.${pokerHandKey(preview.col.rank)}`),
+            delta,
+          }),
+        );
+      }
+    }
+    return parts.join(' ');
+  }, [state, crossHover, preview, t]);
+
   const handlePlace = (row: number, col: number) => {
     execApi('place', row, col);
   };
@@ -203,6 +237,9 @@ function PokerSquaresPageContent() {
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
         <>
+          <div className="sr-only" role="status" aria-live="polite" data-testid="ps-preview-live">
+            {previewAnnouncement}
+          </div>
           <SettingsPanel
             title={t('settings.title')}
             groups={[


### PR DESCRIPTION
## 概要

`PokerSquaresPageContent` の `crossHover`（`onPointerEnter`/`onFocus` で設定）は対象の行・列をハイライトし、完成見込みなら `+N` とハンド名を視覚表示するが、すべて視覚要素のみで `aria-live` 領域が存在しなかった。キーボードで空セルにフォーカスした際（`onFocus` は発火する）でも、スコアの変化が音声で伝わらなかった。

フォーカス/ホバー時のスコアプレビューを `aria-live="polite"` の `sr-only` 領域で通知するようにした。

## 変更点

- `PokerSquaresPage.tsx`: 既存の `preview`（行/列の完成見込み）から読み上げ文を組み立てる `previewAnnouncement` を追加し、`sr-only` の `role="status" aria-live="polite"` 領域に描画
- 完成しない（またはスコア差0の）場合は空文字のままにして過剰読み上げを防止。`onBlur`/`clearCrossHover` で `crossHover` が null になると領域も自動でクリア
- i18n キー `previewRowAnnounce` / `previewColAnnounce` を ja / en に追加

## 受け入れ条件

- [x] セルにフォーカスした際、行/列の完成プレビュー情報が読み上げられる
- [x] プレビューが無い（完成しない）場合は過剰な読み上げをしない
- [x] 既存の視覚的ハイライトは変更しない
- [x] `crossHover` のクリア時（`onBlur`/`clearCrossHover`）も適切に領域をクリアする

## テスト

- `PokerSquaresPage.test.tsx`: フォーカスで行プレビューを読み上げ→blurでクリア、完成しないセルでは無音、の2ケースを追加
- `bun run build` / `bun run check` / `bunx tsc -b` … OK

Closes #3168