### PR TITLE
feat(pageone): announce CPU last-card badge via a polite live region

### DIFF
--- a/frontend/src/i18n/locales/en/pageone.json
+++ b/frontend/src/i18n/locales/en/pageone.json
@@ -32,6 +32,7 @@
   "declaredBadge": "PAGE ONE!",
   "lastCardBanner": "⚠ Only 1 card left — don't forget to declare Page One!",
   "cpuLastCardBadge": "⚠ 1 card left",
+  "cpuLastCardAnnounce": "{{name}} has one card left",
   "playPhase": "Play a card or draw from the pile",
   "mustDeclarePhase": "Only 1 card left! Declare Page One!",
   "roundEnd": "Round over",

--- a/frontend/src/i18n/locales/ja/pageone.json
+++ b/frontend/src/i18n/locales/ja/pageone.json
@@ -32,6 +32,7 @@
   "declaredBadge": "PAGE ONE!",
   "lastCardBanner": "⚠ 残り1枚！ページワン宣言を忘れずに",
   "cpuLastCardBadge": "⚠ 残り1枚",
+  "cpuLastCardAnnounce": "{{name}}が残り1枚です",
   "playPhase": "カードを出すか、山札から引いてください",
   "mustDeclarePhase": "手札が残り1枚です！「ページワン！」と宣言してください",
   "roundEnd": "ラウンド終了",

--- a/frontend/src/pages/PageOnePage.test.tsx
+++ b/frontend/src/pages/PageOnePage.test.tsx
@@ -62,6 +62,15 @@ const gameEndState: PageOneResponse = {
 
 const cpuTurnState: PageOneResponse = { ...playPhaseState, currentPlayerIdx: 1 };
 
+const cpuAtOneCardState: PageOneResponse = {
+  ...playPhaseState,
+  players: [
+    playPhaseState.players[0],
+    { ...playPhaseState.players[1], cardCount: 1 },
+    ...playPhaseState.players.slice(2),
+  ],
+};
+
 beforeEach(() => {
   mockExec.mockResolvedValue(playPhaseState);
 });
@@ -81,6 +90,16 @@ describe('PageOnePage', () => {
         pointLimit: 200,
       }),
     );
+  });
+
+  it('exposes the CPU last-card badge to assistive tech via a polite live region', async () => {
+    mockExec.mockResolvedValue(cpuAtOneCardState);
+    renderWithProviders(<PageOnePage />);
+    const badge = await screen.findByTestId('po-cpu-1-last-card-badge');
+    expect(badge).toHaveAttribute('role', 'status');
+    expect(badge).toHaveAttribute('aria-live', 'polite');
+    // The accessible name names the CPU so the announcement has context.
+    expect(badge).toHaveAttribute('aria-label', expect.stringContaining('残り1枚'));
   });
 
   it('renders play and draw buttons when human turn', async () => {

--- a/frontend/src/pages/PageOnePage.tsx
+++ b/frontend/src/pages/PageOnePage.tsx
@@ -270,6 +270,9 @@ function PageOnePageContent() {
                           {cpuAtOne && (
                             <span
                               data-testid={`po-cpu-${p.id}-last-card-badge`}
+                              role="status"
+                              aria-live="polite"
+                              aria-label={t('cpuLastCardAnnounce', { name: playerName(p.id, p.isHuman) })}
                               className={`ml-2 inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-bold ${badgeWarningColors}`}
                             >
                               <span


### PR DESCRIPTION
## 概要

`PageOnePage.tsx` では、自分が残り1枚になった時のバナー（`showLastCardBanner`）には `role="alert" aria-live="assertive"` が付与されスクリーンリーダーに確実に通知されるが、CPUプレイヤーが残り1枚になった際の `po-cpu-${p.id}-last-card-badge`（点滅ドット付き）には `role` や `aria-live` が一切付与されておらず、視覚的アニメーションのみに依存していた。

CPU用の残り1枚バッジに `role="status" aria-live="polite"` を追加し、さらにどのCPUかが分かるよう `aria-label` にプレイヤー名を含めた（自分の `assertive` より控えめだが確実に通知）。視覚表示は変更なし。

## 変更点

- `PageOnePage.tsx`: CPU残り1枚バッジに `role="status"`・`aria-live="polite"`・`aria-label={t('cpuLastCardAnnounce', { name })}` を付与
- i18n キー `cpuLastCardAnnounce` を ja / en に追加

## 受け入れ条件

- [x] CPUが残り1枚になった時、`aria-live` 領域経由で情報が読み上げられる
- [x] 既存の視覚表示（点滅バッジ）は変更しない
- [x] `PageOnePage.test.tsx` に aria-live 属性の検証テストを追加

## テスト

- `PageOnePage.test.tsx`: バッジの `role`/`aria-live`/`aria-label` を検証（18 tests pass）
- `bun run build` / `bun run check` / `bunx tsc -b` … OK

Closes #3171