### PR TITLE
feat(badugi): expose best-subset / exchange hints in card aria-labels

### DIFF
--- a/frontend/src/i18n/locales/en/badugi.json
+++ b/frontend/src/i18n/locales/en/badugi.json
@@ -18,6 +18,8 @@
   "cpuExchangeEntry": "Player {{idx}} (draw {{draw}}): exchanged {{count}}",
   "exchangeCount": "Drew: {{count}}",
   "cardSelected": "(selected to exchange)",
+  "subsetBest": "part of best hand",
+  "subsetExchange": "exchange candidate",
   "settings": {
     "title": "Settings",
     "cpuMetaAI": "Meta-AI (CPUs learn your style)"

--- a/frontend/src/i18n/locales/ja/badugi.json
+++ b/frontend/src/i18n/locales/ja/badugi.json
@@ -18,6 +18,8 @@
   "cpuExchangeEntry": "Player {{idx}} (draw {{draw}}): {{count}}枚交換",
   "exchangeCount": "交換: {{count}}枚",
   "cardSelected": "(交換選択中)",
+  "subsetBest": "ベストハンドの一部",
+  "subsetExchange": "交換候補",
   "settings": {
     "title": "設定",
     "cpuMetaAI": "メタAI（CPUがプレイスタイルを学習）"

--- a/frontend/src/pages/BadugiPage.test.tsx
+++ b/frontend/src/pages/BadugiPage.test.tsx
@@ -106,6 +106,33 @@ describe('BadugiPage', () => {
     await waitFor(() => expect(screen.getAllByText('ドロー 2/3').length).toBeGreaterThan(0));
   });
 
+  it('annotates card aria-labels with best-subset / exchange-candidate hints during the draw phase', async () => {
+    // S1,H2,D3 form the best 3-card subset (lowest sum); the duplicate-suit S5
+    // is the exchange candidate.
+    mockExec.mockResolvedValue(
+      baseState({
+        phase: BadugiPhase.DRAW,
+        currentTurn: 0,
+        players: [
+          humanPlayer({
+            cards: [
+              { design: 'SPADE', value: 1 },
+              { design: 'HEART', value: 2 },
+              { design: 'DIAMOND', value: 3 },
+              { design: 'SPADE', value: 5 },
+            ],
+          }),
+          cpuPlayer(1),
+          cpuPlayer(2),
+          cpuPlayer(3),
+        ],
+      }),
+    );
+    renderWithProviders(<BadugiPage />);
+    await waitFor(() => expect(screen.getAllByRole('button', { name: /ベストハンドの一部/ }).length).toBe(3));
+    expect(screen.getAllByRole('button', { name: /交換候補/ })).toHaveLength(1);
+  });
+
   it('shows the end message at showdown', async () => {
     mockExec.mockResolvedValue(
       baseState({

--- a/frontend/src/pages/BadugiPage.tsx
+++ b/frontend/src/pages/BadugiPage.tsx
@@ -315,11 +315,15 @@ function BadugiPageContent() {
                       if (inSubset) liftOrDim = '-translate-y-1';
                       else if (!isSelected) liftOrDim = 'opacity-50';
                     }
+                    // During the draw phase, mirror the visual lift/dim cue into the
+                    // aria-label so screen readers learn which cards form the current
+                    // best hand and which are exchange candidates.
+                    const subsetHint = showSubsetHint ? ` ${inSubset ? t('subsetBest') : t('subsetExchange')}` : '';
                     return (
                       <button
                         key={`${card.design}-${card.value}`}
                         type="button"
-                        aria-label={`${cardAlt(card)}${isSelected ? ` ${t('cardSelected')}` : ''}`}
+                        aria-label={`${cardAlt(card)}${isSelected ? ` ${t('cardSelected')}` : ''}${subsetHint}`}
                         aria-pressed={isSelected}
                         onClick={() => toggleCard(i)}
                         data-badugi-subset={showSubsetHint && inSubset ? 'true' : undefined}


### PR DESCRIPTION
## 概要

`BadugiPage.tsx` の交換フェーズでは `badugiBestSubsetIndices` により現在の最良4枚を計算し、`-translate-y-1`（浮き上がり）や `opacity-50`（減光）で視覚的に示しているが、各カードボタンの `aria-label` は `${cardAlt(card)}${isSelected ? ' 選択済み' : ''}` のみで、「ベストハンドの一部」かどうかの情報を含んでいなかった。スクリーンリーダー利用者は視覚的な強調情報を得られなかった。

`aria-label` に、`inSubset` が真なら「ベストハンドの一部」、偽なら「交換候補」を追加（ドローヒント表示中のみ）。視覚表示は変更なし。

## 変更点

- `BadugiPage.tsx`: `showSubsetHint` 時に `subsetBest` / `subsetExchange` を `aria-label` に付与
- i18n キー `subsetBest`・`subsetExchange` を ja / en に追加

## 受け入れ条件

- [x] ベストサブセットに含まれるカードの aria-label にその旨が追加される
- [x] 含まれないカードには「交換候補」を追加
- [x] `BadugiPage.test.tsx` に aria-label 内容の検証テストを追加

## テスト

- `BadugiPage.test.tsx`: サブセット3枚が「ベストハンドの一部」、非サブセット1枚が「交換候補」になることを検証（18 tests pass）
- `bun run build` / `bun run check` / `bunx tsc -b` … OK

Closes #3176