### PR TITLE
feat(scorpion): include selected state in tableau card aria-labels

### DIFF
--- a/frontend/src/i18n/locales/en/scorpion.json
+++ b/frontend/src/i18n/locales/en/scorpion.json
@@ -15,6 +15,7 @@
   "autoComplete": "Auto Complete",
   "undo": "Undo",
   "empty": "Empty",
+  "cardSelected": "selected",
   "gameClear": "Game Clear! Moves: {{moveCount}}",
   "gameOver": "Game Over",
   "playing": "Playing",

--- a/frontend/src/i18n/locales/ja/scorpion.json
+++ b/frontend/src/i18n/locales/ja/scorpion.json
@@ -15,6 +15,7 @@
   "autoComplete": "自動完成",
   "undo": "元に戻す",
   "empty": "空",
+  "cardSelected": "選択中",
   "gameClear": "ゲームクリア！ 手数: {{moveCount}}",
   "gameOver": "ゲームオーバー",
   "playing": "プレイ中",

--- a/frontend/src/pages/ScorpionPage.test.tsx
+++ b/frontend/src/pages/ScorpionPage.test.tsx
@@ -73,10 +73,35 @@ describe('ScorpionPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
+  it("adds a 'selected' hint to the aria-label of the picked source card", async () => {
+    renderWithProviders(<ScorpionPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    // Base labels carry no selection hint.
+    expect(screen.getByRole('button', { name: '♠ K' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /選択中/ })).not.toBeInTheDocument();
+    // Selecting the top card of a column marks it selected in its label.
+    fireEvent.click(screen.getByRole('button', { name: '♠ K' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: '♠ K 選択中' })).toBeInTheDocument());
+    // Other cards keep their plain, hint-free label.
+    expect(screen.getByRole('button', { name: '♥ 8' })).toBeInTheDocument();
+  });
+
   it('shows move count and stock', async () => {
     renderWithProviders(<ScorpionPage />);
     await waitFor(() => expect(screen.getByText(/手数/)).toBeInTheDocument());
     expect(screen.getByText(/Stock|ストック/)).toBeInTheDocument();
+  });
+
+  it('renders a face-up slot without a card as an empty-labelled button (defensive guard)', async () => {
+    // A face-up card with no card object should not crash; the aria-label guard
+    // falls back to an empty string.
+    mockExec.mockResolvedValue({
+      ...playingState,
+      tableau: [[{ card: null, faceUp: true }], [], [], [], [], [], []],
+    });
+    const { container } = renderWithProviders(<ScorpionPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(container.querySelector('button[aria-label=""]')).toBeInTheDocument();
   });
 
   it('shows game clear phase', async () => {

--- a/frontend/src/pages/ScorpionPage.tsx
+++ b/frontend/src/pages/ScorpionPage.tsx
@@ -464,7 +464,9 @@ function ScorpionPageContent() {
                                     }
                                   }}
                                   disabled={!isPlaying}
-                                  aria-label={tc.card ? cardAlt(tc.card) : ''}
+                                  aria-label={
+                                    tc.card ? `${cardAlt(tc.card)}${isSelected ? ` ${t('cardSelected')}` : ''}` : ''
+                                  }
                                 >
                                   {tc.card && <AnimatedCard card={tc.card} width={sc.cw} />}
                                 </button>


### PR DESCRIPTION
## 概要

`ScorpionPage.tsx` のタブローカードボタンは `ring-2 ring-ds-warning -translate-y-1` で選択状態を視覚的に示すが、`aria-label={tc.card ? cardAlt(tc.card) : ''}` はカード内容のみを返し、選択状態を含んでいなかった。`BadugiPage.tsx` など同コードベースの他ページは `${cardAlt(card)}${isSelected ? ' 選択済み' : ''}` のように選択状態を含めており、スコーピオンだけこのパターンから外れていた。

`isSelected` が真の場合に `aria-label` へローカライズされた「選択中」を追加。視覚表示は変更なし。

## 変更点

- `ScorpionPage.tsx`: 移動元として選択中のカードの `aria-label` に `t('cardSelected')` を付与
- i18n キー `cardSelected` を ja / en に追加

## 受け入れ条件

- [x] 選択中のカードの aria-label に選択状態が含まれる
- [x] 選択解除時は aria-label が元に戻る（`isSelected` 条件による）
- [x] `ScorpionPage.test.tsx` に aria-label 内容の検証テストを追加

## テスト

- `ScorpionPage.test.tsx`: 選択で `♠ K 選択中` になり、他カードは素の label のままを検証（39 tests pass）
- `bun run build` / `bun run check` / `bunx tsc -b` … OK

Closes #3184