### PR TITLE
feat(wasp): include selected state in tableau card aria-labels

### DIFF
--- a/frontend/src/i18n/locales/en/wasp.json
+++ b/frontend/src/i18n/locales/en/wasp.json
@@ -15,6 +15,7 @@
   "autoComplete": "Auto Complete",
   "undo": "Undo",
   "empty": "Empty",
+  "cardSelected": "selected",
   "anyCard": "Any card",
   "gameClear": "Game Clear! Moves: {{moveCount}}",
   "gameOver": "Game Over",

--- a/frontend/src/i18n/locales/ja/wasp.json
+++ b/frontend/src/i18n/locales/ja/wasp.json
@@ -15,6 +15,7 @@
   "autoComplete": "自動完成",
   "undo": "元に戻す",
   "empty": "空",
+  "cardSelected": "選択中",
   "anyCard": "任意カード可",
   "gameClear": "ゲームクリア！ 手数: {{moveCount}}",
   "gameOver": "ゲームオーバー",

--- a/frontend/src/pages/WaspPage.test.tsx
+++ b/frontend/src/pages/WaspPage.test.tsx
@@ -80,6 +80,31 @@ describe('WaspPage', () => {
     expect(screen.getByText(/Stock|ストック/)).toBeInTheDocument();
   });
 
+  it('renders a face-up slot without a card as an empty-labelled button (defensive guard)', async () => {
+    // A face-up card with no card object should not crash; the aria-label guard
+    // falls back to an empty string.
+    mockExec.mockResolvedValue({
+      ...playingState,
+      tableau: [[{ card: null, faceUp: true }], [], [], [], [], [], []],
+    });
+    const { container } = renderWithProviders(<WaspPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(container.querySelector('button[aria-label=""]')).toBeInTheDocument();
+  });
+
+  it("adds a 'selected' hint to the aria-label of the picked card and removes it on deselect", async () => {
+    renderWithProviders(<WaspPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(screen.queryByRole('button', { name: /選択中/ })).not.toBeInTheDocument();
+    // Select the top card of a column.
+    fireEvent.click(screen.getByRole('button', { name: '♠ K' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: '♠ K 選択中' })).toBeInTheDocument());
+    // Re-clicking deselects and restores the plain label.
+    fireEvent.click(screen.getByRole('button', { name: '♠ K 選択中' }));
+    await waitFor(() => expect(screen.queryByRole('button', { name: /選択中/ })).not.toBeInTheDocument());
+    expect(screen.getByRole('button', { name: '♠ K' })).toBeInTheDocument();
+  });
+
   it('shows game clear phase', async () => {
     mockExec.mockResolvedValue(gameClearState);
     renderWithProviders(<WaspPage />);

--- a/frontend/src/pages/WaspPage.tsx
+++ b/frontend/src/pages/WaspPage.tsx
@@ -472,7 +472,9 @@ function WaspPageContent() {
                                     }
                                   }}
                                   disabled={!isPlaying}
-                                  aria-label={tc.card ? cardAlt(tc.card) : ''}
+                                  aria-label={
+                                    tc.card ? `${cardAlt(tc.card)}${isSelected ? ` ${t('cardSelected')}` : ''}` : ''
+                                  }
                                 >
                                   {tc.card && <AnimatedCard card={tc.card} width={sc.cw} />}
                                 </button>


### PR DESCRIPTION
## 概要

`WaspPage.tsx` のタブローカードボタンは `ring-2 ring-ds-warning -translate-y-1` で選択状態を視覚表示するが、`aria-label={tc.card ? cardAlt(tc.card) : ''}` はカード内容のみを返し選択状態を含んでいなかった（姉妹ゲーム Scorpion と同じコピペ由来の欠落）。

`isSelected` が真の場合、`aria-label` にローカライズされた「選択中」を追加。空列ボタンの既存 aria-label は変更なし。

## 変更点

- `WaspPage.tsx`: 移動元として選択中のカードの `aria-label` に `t('cardSelected')` を付与
- i18n キー `cardSelected` を ja / en に追加

## 受け入れ条件

- [x] 選択中カードの aria-label に選択状態が含まれる
- [x] 空列ボタンの既存 aria-label は維持
- [x] `WaspPage.test.tsx` に aria-label 検証テストを追加（選択→解除の往復）

## テスト

- `WaspPage.test.tsx`: `♠ K` 選択で `♠ K 選択中`、再クリックで素の label に戻ることを検証（41 tests pass）
- `bun run build` / `bun run check` / `bunx tsc -b` … OK

Closes #3187