### PR TITLE
feat(president): give display-only table cards an accessible name

### DIFF
--- a/frontend/src/pages/PresidentPage.test.tsx
+++ b/frontend/src/pages/PresidentPage.test.tsx
@@ -66,6 +66,16 @@ describe('PresidentPage', () => {
     expect(screen.getByTestId('hand-card-2')).toBeInTheDocument();
   });
 
+  it('gives each display-only table card an accessible name', async () => {
+    // Table cards not present in the human hand (S3/H5/D7) so the labels are unambiguous.
+    mockExec.mockResolvedValue(makeState({ tableCards: [card('SPADE', 12), card('CLOVER', 1)], lastPlayPlayerIdx: 1 }));
+    renderWithProviders(<PresidentPage />);
+    // aria-label on the role="img" wrapper (getByLabelText matches aria-label, not the inner <img alt>).
+    await waitFor(() => expect(screen.getByLabelText('♠ Q')).toBeInTheDocument());
+    expect(screen.getByLabelText('♣ A')).toBeInTheDocument();
+    expect(screen.getByLabelText('♠ Q')).toHaveAttribute('role', 'img');
+  });
+
   it('enables Play button when a card is selected', async () => {
     renderWithProviders(<PresidentPage />);
     await waitFor(() => expect(screen.getByTestId('hand-card-0')).toBeInTheDocument());

--- a/frontend/src/pages/PresidentPage.tsx
+++ b/frontend/src/pages/PresidentPage.tsx
@@ -22,6 +22,7 @@ import { usePresidentGame } from '../hooks/usePresidentGame';
 import { gameTheme } from '../styles/gameTheme';
 import type { PresidentResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import {
   formatPresidentState,
   PRESIDENT_HELP,
@@ -241,7 +242,14 @@ function PresidentPageContent() {
                 {state.tableCards.length === 0 ? (
                   <span className="text-ds-text-muted text-sm self-center">{t('label.tableEmpty')}</span>
                 ) : (
-                  state.tableCards.map((c, i) => <AnimatedCard key={i} card={c} width={cardWidth * 0.9} />)
+                  state.tableCards.map((c, i) => (
+                    // Wrap each display-only table card in a role="img" group so
+                    // screen readers announce it as a single named unit (the card),
+                    // independent of the inner <img alt>. Visuals are unchanged.
+                    <span key={i} role="img" aria-label={cardAlt(c)}>
+                      <AnimatedCard card={c} width={cardWidth * 0.9} />
+                    </span>
+                  ))
                 )}
               </div>
             </div>


### PR DESCRIPTION
## 概要

`PresidentPage.tsx` の場札は `state.tableCards.map((c, i) => <AnimatedCard ... />)` で描画されるだけで、`role` や `aria-label` のラッパーがなく、スクリーンリーダー利用者は現在場に出ているカードを確実に把握する手段がなかった。

各場札を `role="img"` + 明示的な `aria-label`（`cardAlt`）でラップし、1枚のカードとして読み上げられるようにした（Russian Solitaire 等と同じパターン）。表示専用・見た目は変更なし。

## 変更点

- `PresidentPage.tsx`: 場札の各 `<AnimatedCard>` を `<span role="img" aria-label={cardAlt(c)}>` でラップ

## 受け入れ条件

- [x] 場札の各カードにアクセシブルな名前が付与される
- [x] 既存の見た目（表示専用カード）は変更しない
- [x] `PresidentPage.test.tsx` に場札の aria-label 検証テストを追加

## テスト

- `PresidentPage.test.tsx`: 場札 2 枚が `role="img"` + 対応する aria-label を持つことを検証（23 tests pass）
- `bun run build` / `bunx biome check` / `bunx tsc -b` … OK

Closes #3201