### PR TITLE
feat(cassino): label table/build buttons with content and selection state

### DIFF
--- a/frontend/src/i18n/locales/en/cassino.json
+++ b/frontend/src/i18n/locales/en/cassino.json
@@ -13,6 +13,8 @@
   "button.reset": "Reset",
   "label.tableCards": "Table",
   "label.tableEmpty": "Empty",
+  "label.selected": "selected",
+  "label.takeCandidate": "take candidate",
   "label.builds": "Builds",
   "build.label": "Value {{value}} ({{kind}}) / owner: {{owner}}",
   "build.single": "single",

--- a/frontend/src/i18n/locales/ja/cassino.json
+++ b/frontend/src/i18n/locales/ja/cassino.json
@@ -13,6 +13,8 @@
   "button.reset": "リセット",
   "label.tableCards": "場",
   "label.tableEmpty": "なし",
+  "label.selected": "選択中",
+  "label.takeCandidate": "テイク候補",
   "label.builds": "ビルド",
   "build.label": "値{{value}} ({{kind}}) / 所有:{{owner}}",
   "build.single": "単一",

--- a/frontend/src/pages/CassinoPage.test.tsx
+++ b/frontend/src/pages/CassinoPage.test.tsx
@@ -87,6 +87,21 @@ describe('CassinoPage', () => {
     expect(screen.getByTestId('table-card-1')).toBeInTheDocument();
   });
 
+  it('labels table cards with content, take-candidate, and selected state', async () => {
+    renderWithProviders(<CassinoPage />);
+    await waitFor(() => expect(screen.getByTestId('table-card-0')).toBeInTheDocument());
+    // Base label = card content only.
+    expect(screen.getByTestId('table-card-0')).toHaveAttribute('aria-label', '♠ 2');
+    // Selecting the ♥5 hand card makes the matching ♥5 table card a take candidate.
+    fireEvent.click(screen.getByTestId('hand-card-1'));
+    await waitFor(() => expect(screen.getByTestId('table-card-1')).toHaveAttribute('aria-label', '♥ 5 テイク候補'));
+    // The non-matching ♠2 keeps its plain label.
+    expect(screen.getByTestId('table-card-0')).toHaveAttribute('aria-label', '♠ 2');
+    // Selecting the candidate flips its label to "selected".
+    fireEvent.click(screen.getByTestId('table-card-1'));
+    await waitFor(() => expect(screen.getByTestId('table-card-1')).toHaveAttribute('aria-label', '♥ 5 選択中'));
+  });
+
   it('take button is disabled until both hand and table are selected', async () => {
     renderWithProviders(<CassinoPage />);
     await waitFor(() => expect(screen.getByTestId('take-button')).toBeInTheDocument());

--- a/frontend/src/pages/CassinoPage.tsx
+++ b/frontend/src/pages/CassinoPage.tsx
@@ -20,6 +20,7 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { gameTheme } from '../styles/gameTheme';
 import type { CassinoResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import { cassinoTakeCandidates } from '../utils/cassinoTakeCandidates';
 import { suggestCassinoAction } from '../utils/cassinoUtils';
 import {
@@ -252,6 +253,13 @@ function CassinoPageContent() {
                         } ${isHumanTurn ? 'cursor-pointer hover:opacity-90' : 'cursor-default'}`}
                         data-testid={`table-card-${i}`}
                         data-take-candidate={isCandidate || undefined}
+                        aria-label={`${cardAlt(c)}${
+                          tableIndices.includes(i)
+                            ? ` ${t('label.selected')}`
+                            : isCandidate
+                              ? ` ${t('label.takeCandidate')}`
+                              : ''
+                        }`}
                       >
                         <AnimatedCard card={c} width={cardWidth * 0.9} />
                       </button>
@@ -282,6 +290,7 @@ function CassinoPageContent() {
                           buildIndices.includes(i) ? 'ring-2 ring-ds-info bg-ds-info/20' : 'border-white/20 bg-black/20'
                         } ${isHumanTurn ? 'cursor-pointer' : ''}`}
                         data-testid={`build-${i}`}
+                        aria-label={`${buildLabel}${buildIndices.includes(i) ? ` ${t('label.selected')}` : ''}`}
                       >
                         {buildLabel}
                       </button>


### PR DESCRIPTION
## 概要

`CassinoPage.tsx` の場札ボタン（`table-card-${i}`）は `<AnimatedCard>` のみを子に持ち `aria-label` が無く、テイク候補（`isCandidate`）かどうかはリング色や `data-take-candidate` でしか判別できなかった。スクリーンリーダー利用者はカード内容もテイク候補かも読み上げで確認できなかった。

場札ボタンにカード内容＋状態（選択中／テイク候補）を含む `aria-label` を付与。ビルドボタンにも選択状態を追加。視覚表示は変更なし。

## 変更点

- `CassinoPage.tsx`: 場札ボタンに `aria-label={cardAlt(c) + 状態}` を付与（選択中 / テイク候補 / 素）。ビルドボタンの accessible name に選択状態を追加
- i18n キー `label.selected` / `label.takeCandidate` を ja / en に追加

## 受け入れ条件

- [x] 場札ボタンにカード内容を説明する aria-label が付与される
- [x] テイク候補の場合はその旨が aria-label に含まれる
- [x] `CassinoPage.test.tsx` に aria-label 検証テストを追加

## テスト

- `CassinoPage.test.tsx`: 素の label →（♥5手札選択で）テイク候補 →（クリックで）選択中 の遷移を検証（22 tests pass）
- `bun run build` / `bunx biome check` / `bunx tsc -b` … OK

Closes #3204