### PR TITLE
feat(calculation): label the stock button and empty waste piles

### DIFF
--- a/frontend/src/i18n/locales/en/calculation.json
+++ b/frontend/src/i18n/locales/en/calculation.json
@@ -25,6 +25,8 @@
   "nextRankAria": "Next required card {{rank}}",
   "upcomingRanksTooltip": "Upcoming cards: {{sequence}}",
   "wasteRanksTooltip": "Waste {{idx}} (top 3): {{ranks}}",
+  "wasteEmptyAria": "Waste {{idx}}: empty",
+  "stockTopAria": "Stock top: {{card}}",
   "foundationCompleteAria": "Complete",
   "gameClear": "Game Clear! Moves: {{moveCount}}",
   "gameOver": "Game Over",

--- a/frontend/src/i18n/locales/ja/calculation.json
+++ b/frontend/src/i18n/locales/ja/calculation.json
@@ -25,6 +25,8 @@
   "nextRankAria": "次に置くべきカード {{rank}}",
   "upcomingRanksTooltip": "今後の必要カード: {{sequence}}",
   "wasteRanksTooltip": "ウェイスト{{idx}}（上3枚）: {{ranks}}",
+  "wasteEmptyAria": "ウェイスト{{idx}}: 空",
+  "stockTopAria": "山札のトップ: {{card}}",
   "foundationCompleteAria": "完成",
   "gameClear": "ゲームクリア！ 手数: {{moveCount}}",
   "gameOver": "ゲームオーバー",

--- a/frontend/src/pages/CalculationPage.test.tsx
+++ b/frontend/src/pages/CalculationPage.test.tsx
@@ -60,6 +60,23 @@ describe('CalculationPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
+  it('labels the stock button with its top card and empty waste piles explicitly', async () => {
+    renderWithProviders(<CalculationPage />);
+    const stock = await screen.findByTestId('calc-stock-button');
+    expect(stock).toHaveAttribute('aria-label', '山札のトップ: ♠ 7');
+    // Empty waste piles now carry an explicit name (previously undefined).
+    expect(screen.getByTestId('calc-waste-button-0')).toHaveAttribute('aria-label', 'ウェイスト0: 空');
+    expect(screen.getByTestId('calc-waste-button-3')).toHaveAttribute('aria-label', 'ウェイスト3: 空');
+  });
+
+  it('labels a non-empty waste pile with its top ranks, not the empty text', async () => {
+    mockExec.mockResolvedValue({ ...playingState, wastes: [[card('HEART', 9)], [], [], []] });
+    renderWithProviders(<CalculationPage />);
+    const waste0 = await screen.findByTestId('calc-waste-button-0');
+    await waitFor(() => expect(waste0.getAttribute('aria-label')).toContain('ウェイスト0'));
+    expect(waste0).not.toHaveAttribute('aria-label', 'ウェイスト0: 空');
+  });
+
   it('shows move count', async () => {
     renderWithProviders(<CalculationPage />);
     await waitFor(() => expect(screen.getByText(/手数/)).toBeInTheDocument());
@@ -150,12 +167,14 @@ describe('CalculationPage', () => {
     expect(btn).toHaveAttribute('aria-label', 'ウェイスト0（上3枚）: 5・K・A');
   });
 
-  it('omits the rank tooltip on an empty waste pile', async () => {
+  it('omits the rank tooltip on an empty waste pile but still names it for SR users', async () => {
     mockExec.mockResolvedValue(playingState);
     renderWithProviders(<CalculationPage />);
     const btn = await screen.findByTestId('calc-waste-button-0');
+    // No hover tooltip when empty…
     expect(btn).not.toHaveAttribute('title');
-    expect(btn).not.toHaveAttribute('aria-label');
+    // …but an explicit spoken name so the empty pile isn't anonymous.
+    expect(btn).toHaveAttribute('aria-label', 'ウェイスト0: 空');
   });
 
   it('clicking foundation without a source has no effect', async () => {

--- a/frontend/src/pages/CalculationPage.tsx
+++ b/frontend/src/pages/CalculationPage.tsx
@@ -29,6 +29,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { CalculationResponse } from '../types/card';
 import { CalculationPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import { valueName } from '../utils/cardUtils';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 
@@ -466,6 +467,7 @@ function CalculationPageContent() {
                     onClick={handleSelectStock}
                     disabled={!isPlaying || loading}
                     aria-pressed={sourceIsStock}
+                    aria-label={t('stockTopAria', { card: cardAlt(state.stockTop) })}
                     data-testid="calc-stock-button"
                     className={`p-0 border-0 bg-transparent rounded ${focusRingWhite} ${sourceIsStock ? 'ring-2 ring-ds-warning' : ''} ${hintStock ? 'ring-2 ring-ds-success animate-pulse' : ''}`}
                   >
@@ -499,7 +501,12 @@ function CalculationPageContent() {
                   .slice(-3)
                   .map((c) => valueName(c.value))
                   .join('・');
-                const wasteLabel = pile.length > 0 ? t('wasteRanksTooltip', { idx, ranks: wasteRanks }) : undefined;
+                // Non-empty piles get the top-ranks tooltip; empty piles still
+                // need a spoken name so SR users can tell them apart (they were
+                // previously unlabeled, unlike the always-labeled foundations).
+                const wasteRanksLabel =
+                  pile.length > 0 ? t('wasteRanksTooltip', { idx, ranks: wasteRanks }) : undefined;
+                const wasteAriaLabel = wasteRanksLabel ?? t('wasteEmptyAria', { idx });
                 return (
                   <div key={`w-${idx.toString()}`} className="flex flex-col items-center">
                     <div className="text-[11px] mb-0.5 text-ds-text-muted">
@@ -516,8 +523,8 @@ function CalculationPageContent() {
                       }}
                       disabled={!isPlaying || loading || (!top && !canAcceptStock)}
                       aria-pressed={selected}
-                      title={wasteLabel}
-                      aria-label={wasteLabel}
+                      title={wasteRanksLabel}
+                      aria-label={wasteAriaLabel}
                       data-testid={`calc-waste-button-${idx.toString()}`}
                       className={`p-0 border-0 bg-transparent rounded ${focusRingWhite} ${selected ? 'ring-2 ring-ds-warning' : ''} ${isHintSource ? 'ring-2 ring-ds-success animate-pulse' : ''} ${canAcceptStock ? 'ring-2 ring-ds-info/70' : ''}`}
                     >


### PR DESCRIPTION
## 概要

`CalculationPage.tsx` の基礎パイル（foundation）ボタンは常に `aria-label` を持つが、山札（stock）ボタンは `aria-label` が無く、空のウェイスト（waste）パイルは `aria-label` が `undefined` のままで、基礎パイルの一貫した命名パターンから逸脱していた。

山札ボタンにトップカードを説明する `aria-label` を追加し、空のウェイストパイルにも「空」を示す `aria-label` を明示的に設定した（ランクツールチップ/`title` は非空パイルのみ維持）。視覚表示は変更なし。

## 変更点

- `CalculationPage.tsx`:
  - 山札ボタンに `aria-label={t('stockTopAria', { card: cardAlt(stockTop) })}` を追加
  - 空のウェイストパイルに `t('wasteEmptyAria', { idx })` を設定（`title` は非空時のみ）
- i18n キー `stockTopAria` / `wasteEmptyAria` を ja / en に追加

## 受け入れ条件

- [x] 山札ボタンに常に aria-label が設定される
- [x] 空のウェイストパイルにも「空」を示す aria-label が設定される
- [x] `CalculationPage.test.tsx` に aria-label 検証テストを追加（既存の「空パイルは無ラベル」テストも新仕様に更新）

## テスト

- `CalculationPage.test.tsx`: 山札トップの aria-label、空/非空ウェイストの aria-label を検証（34 tests pass）
- `bun run build` / `bunx biome check` / `bunx tsc -b` … OK

Closes #3208