### PR TITLE
feat(spiteandmalice): explain disabled discard buttons via aria-describedby

### DIFF
--- a/frontend/src/i18n/locales/en/spiteandmalice.json
+++ b/frontend/src/i18n/locales/en/spiteandmalice.json
@@ -23,6 +23,8 @@
   "moveCount": "Moves",
   "endTurn": "End turn",
   "discard": "Discard",
+  "discardNeedHand": "Select a hand card first",
+  "discardReady": "Hand card selected — ready to discard",
   "autoComplete": "Auto Complete",
   "selectSource": "Select a card to play",
   "selectFoundation": "Select a foundation",

--- a/frontend/src/i18n/locales/ja/spiteandmalice.json
+++ b/frontend/src/i18n/locales/ja/spiteandmalice.json
@@ -23,6 +23,8 @@
   "moveCount": "手数",
   "endTurn": "ターン終了",
   "discard": "ディスカード",
+  "discardNeedHand": "先に手札のカードを選択してください",
+  "discardReady": "手札を選択済みです。ディスカードできます",
   "autoComplete": "自動完成",
   "selectSource": "出すカードを選んでください",
   "selectFoundation": "出すファウンデーションを選んでください",

--- a/frontend/src/pages/SpiteAndMalicePage.test.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.test.tsx
@@ -88,6 +88,20 @@ describe('SpiteAndMalicePage', () => {
     await waitFor(() => expect(screen.getByText(/手数|Moves/)).toBeInTheDocument());
   });
 
+  it('explains why discard is disabled until a hand card is selected', async () => {
+    mockExec.mockResolvedValue(baseState);
+    renderWithProviders(<SpiteAndMalicePage />);
+    const discardBtns = await screen.findAllByRole('button', { name: 'ディスカード' });
+    expect(discardBtns[0]).toHaveAttribute('aria-describedby', 'sam-discard-hint');
+    // Nothing selected → the shared hint states the requirement and discard is disabled.
+    expect(discardBtns[0]).toBeDisabled();
+    expect(screen.getByTestId('sam-discard-hint')).toHaveTextContent('先に手札');
+    // Selecting a hand card (♠5) flips the hint to "ready" and enables discard.
+    fireEvent.click(screen.getByRole('button', { name: /♠ 5/ }));
+    await waitFor(() => expect(screen.getByTestId('sam-discard-hint')).toHaveTextContent('ディスカードできます'));
+    expect(screen.getAllByRole('button', { name: 'ディスカード' })[0]).not.toBeDisabled();
+  });
+
   it('localizes the hand heading, card aria-labels, and CPU goal (no raw English)', async () => {
     renderWithProviders(<SpiteAndMalicePage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));

--- a/frontend/src/pages/SpiteAndMalicePage.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.tsx
@@ -351,6 +351,7 @@ function SpiteAndMalicePageContent() {
               label={t('label.side')}
               discardLabel={t('discard')}
               discardEnabled={selectionIsHand}
+              discardHint={selectionIsHand ? t('discardReady') : t('discardNeedHand')}
             />
           </div>
 
@@ -624,6 +625,7 @@ function SideRow({
   label,
   discardLabel,
   discardEnabled,
+  discardHint,
 }: {
   sides: [Card[], Card[], Card[], Card[]];
   cardWidth: number;
@@ -635,10 +637,16 @@ function SideRow({
   label: string;
   discardLabel: string;
   discardEnabled: boolean;
+  discardHint: string;
 }) {
   return (
     <div className="flex flex-col items-center gap-2" data-tutorial={dataTutorial}>
       <span className="text-sm text-ds-secondary">{cpuLabel ? `CPU ${label}` : label}</span>
+      {/* Shared reason for the discard buttons' disabled state (they all gate on
+          a selected hand card), announced via aria-describedby below. */}
+      <span id="sam-discard-hint" className="sr-only" data-testid="sam-discard-hint">
+        {discardHint}
+      </span>
       <div className="grid grid-cols-4 gap-2">
         {sides.map((pile, idx) => {
           const top = pile.length > 0 ? pile[pile.length - 1] : undefined;
@@ -671,6 +679,7 @@ function SideRow({
                 className={`${btnPrimary} text-xs px-2 py-1`}
                 onClick={() => onDiscard(idx)}
                 disabled={!discardEnabled}
+                aria-describedby="sam-discard-hint"
               >
                 {discardLabel}
               </button>


### PR DESCRIPTION
## 概要

`SpiteAndMalicePage.tsx` の `SideRow` 内の各捨て札ボタン（`discard-${idx}`）は手札のカードが選択されるまで無効化されるが、`aria-describedby` や `title` による理由説明が無く、手札を選択せずにフォーカスしたユーザーはなぜ押せないのか分からなかった。

全捨て札ボタンから参照する共有の sr-only ヒントを追加し、`aria-describedby` で関連付け。無効時は「先に手札のカードを選択してください」、手札選択後は「ディスカードできます」に切り替わる。視覚表示は変更なし。

## 変更点

- `SpiteAndMalicePage.tsx`: `SideRow` に共有ヒント `#sam-discard-hint`（sr-only）を追加し、各捨て札ボタンに `aria-describedby` を付与。ヒント文言は親から `discardHint` prop で渡す（選択状態に応じて切替）
- i18n キー `discardNeedHand` / `discardReady` を ja / en に追加

## 受け入れ条件

- [x] 捨て札ボタン無効時に理由が aria 属性で提供される
- [x] 手札選択後は説明が「実行可能」相当に変わる
- [x] `SpiteAndMalicePage.test.tsx` に aria-describedby 検証テストを追加

## テスト

- `SpiteAndMalicePage.test.tsx`: describedby 関連付け、無効時の理由、手札選択で「できます」化＋活性化を検証（17 tests pass）
- `bun run build` / `bunx biome check` / `bunx tsc -b` … OK

Closes #3213