### PR TITLE
feat(beleagueredcastle): label empty tableau columns with their column number

### DIFF
--- a/frontend/src/i18n/locales/en/beleagueredcastle.json
+++ b/frontend/src/i18n/locales/en/beleagueredcastle.json
@@ -11,6 +11,7 @@
   "empty": "Empty",
   "foundationAriaLabel": "{{suit}} foundation {{count}} cards",
   "emptyFoundationAriaLabel": "Empty foundation ({{suit}})",
+  "emptyColumnAriaLabel": "Empty tableau column {{col}}",
   "landscapeBanner": "Landscape mode recommended",
   "hint": "Hint",
   "autoComplete": "Auto Complete",

--- a/frontend/src/i18n/locales/ja/beleagueredcastle.json
+++ b/frontend/src/i18n/locales/ja/beleagueredcastle.json
@@ -11,6 +11,7 @@
   "empty": "空",
   "foundationAriaLabel": "{{suit}} 組札 {{count}}枚",
   "emptyFoundationAriaLabel": "空の組札 ({{suit}})",
+  "emptyColumnAriaLabel": "空のタブロー列 {{col}}",
   "landscapeBanner": "横画面での表示を推奨します",
   "hint": "ヒント",
   "autoComplete": "自動完成",

--- a/frontend/src/pages/BeleagueredCastlePage.test.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.test.tsx
@@ -90,6 +90,17 @@ describe('BeleagueredCastlePage', () => {
     await waitFor(() => expect(screen.getAllByLabelText(/組札 1枚/).length).toBe(4));
   });
 
+  it('gives each empty tableau column a distinct column-numbered aria-label', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<BeleagueredCastlePage />);
+    // Columns 3 and 8 (1-based) are empty and each reads distinctly, unlike the
+    // previous shared "empty" text.
+    await waitFor(() => expect(screen.getByRole('button', { name: '空のタブロー列 3' })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: '空のタブロー列 8' })).toBeInTheDocument();
+    // The two filled columns (1, 2) are not rendered as empty-column buttons.
+    expect(screen.queryByRole('button', { name: '空のタブロー列 1' })).not.toBeInTheDocument();
+  });
+
   it('renders giveup button when playing', async () => {
     mockExec.mockResolvedValue(playingState);
     renderWithProviders(<BeleagueredCastlePage />);

--- a/frontend/src/pages/BeleagueredCastlePage.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.tsx
@@ -208,6 +208,7 @@ function BeleagueredCastlePageContent() {
                 type="button"
                 onClick={() => game.handleSelectTarget(tableauColZone)}
                 disabled={!isPlaying || loading || !selectedSource}
+                aria-label={t('emptyColumnAriaLabel', { col: colIdx + 1 })}
                 style={{ height: dims.ch }}
                 className={`w-full rounded border-2 border-dashed border-white/20 text-game-text-muted text-xs flex items-center justify-center bg-transparent ${focusRingWhite}`}
               >


### PR DESCRIPTION
## 概要

`BeleagueredCastlePage.tsx` の空タブロー列ボタンは固定テキスト `{t('empty')}` のみで `aria-label` が無く、8列すべてが同一の「空」としか読み上げられず、スクリーンリーダー利用者はどの列か区別できなかった（foundation の空スロットはスート付きでラベル化されているのに対して非対称）。

空タブロー列ボタンに列番号（1始まり）入りの `aria-label`（`emptyColumnAriaLabel`）を追加し、foundation の命名規則と揃えた。クリック/ドラッグ操作は変更なし。

## 変更点

- `BeleagueredCastlePage.tsx`: 空タブロー列 `<button>` に `aria-label={t('emptyColumnAriaLabel', { col: colIdx + 1 })}` を付与
- i18n キー `emptyColumnAriaLabel` を ja / en に追加（foundation と同じ命名パターン）

## 受け入れ条件

- [x] 空タブロー列ボタンに列番号入り aria-label が付与される
- [x] foundation の命名規則と一貫した i18n キー設計
- [x] 既存のクリック/ドラッグ操作に影響しない
- [x] コンポーネントテストで aria-label の内容を検証

## テスト

- `BeleagueredCastlePage.test.tsx`: 空列3・8が個別ラベルを持ち、埋まった列1は空列ボタンでないことを検証（14 tests pass）
- `bun run build` / `bunx biome check` / `bunx tsc -b` … OK

Closes #3276