### PR TITLE
feat(streetsandalleys): highlight drop-target columns when a source is picked

### DIFF
--- a/frontend/src/pages/StreetsAndAlleysPage.test.tsx
+++ b/frontend/src/pages/StreetsAndAlleysPage.test.tsx
@@ -77,6 +77,32 @@ describe('StreetsAndAlleysPage', () => {
     expect(mockExec.mock.calls[0]?.[0]).toBe('reset');
   });
 
+  it('highlights column tops as drop targets once a source card is selected', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<StreetsAndAlleysPage />);
+    // No source selected yet → no target-candidate highlight.
+    const heart6 = await screen.findByRole('button', { name: '♥ 6' });
+    expect(heart6).not.toHaveAttribute('data-target-candidate');
+    // Select the top of column 0 (♠5) as the move source.
+    fireEvent.click(screen.getByRole('button', { name: '♠ 5' }));
+    // Column 1's top (♥6) is now a drop target with the info ring.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: '♥ 6' })).toHaveAttribute('data-target-candidate', 'true'),
+    );
+    expect(screen.getByRole('button', { name: '♥ 6' }).className).toContain('ring-ds-info');
+    // The selected source card itself is not a target candidate.
+    expect(screen.getByRole('button', { name: '♠ 5' })).not.toHaveAttribute('data-target-candidate');
+  });
+
+  it('dims a tableau card while it is being dragged', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<StreetsAndAlleysPage />);
+    const top = await screen.findByRole('button', { name: '♠ 5' });
+    // jsdom doesn't attach a DataTransfer to synthetic drag events, so provide one.
+    fireEvent.dragStart(top, { dataTransfer: { setData: () => {}, effectAllowed: '' } });
+    await waitFor(() => expect(top.className).toContain('opacity-50'));
+  });
+
   it('renders heading and move count', async () => {
     mockExec.mockResolvedValue(playingState);
     renderWithProviders(<StreetsAndAlleysPage />);

--- a/frontend/src/pages/StreetsAndAlleysPage.tsx
+++ b/frontend/src/pages/StreetsAndAlleysPage.tsx
@@ -220,6 +220,12 @@ function StreetsAndAlleysPageContent() {
                   cardIndex: cardIdx,
                 };
                 const isTop = cardIdx === col.length - 1;
+                const isSelfSource = isSourceSelected('tableau', colIdx, cardIdx);
+                // When a source is picked, each column's top card is a drop
+                // target. Give it a subtle ring so keyboard/Tab users can see
+                // which cards are now selectable as a destination (the disabled
+                // state alone was invisible). Excludes the picked source itself.
+                const isTargetCandidate = !!selectedSource && isTop && !isSelfSource;
                 return (
                   <div
                     key={`tc-${colIdx.toString()}-${cardIdx.toString()}`}
@@ -238,11 +244,12 @@ function StreetsAndAlleysPageContent() {
                         }}
                         disabled={!isPlaying || loading || (!isTop && !selectedSource)}
                         aria-label={cardAlt(tc.card)}
-                        aria-pressed={isSourceSelected('tableau', colIdx, cardIdx)}
+                        aria-pressed={isSelfSource}
+                        data-target-candidate={isTargetCandidate || undefined}
                         draggable={isPlaying && !loading && isTop}
                         onDragStart={dnd.handleDragStart(cardZone)}
                         onDragEnd={dnd.handleDragEnd}
-                        className={`p-0 border-0 bg-transparent w-full rounded ${focusRingWhite} ${isTop ? 'cursor-pointer' : 'cursor-default'} ${isSourceSelected('tableau', colIdx, cardIdx) ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
+                        className={`p-0 border-0 bg-transparent w-full rounded ${focusRingWhite} ${isTop ? 'cursor-pointer' : 'cursor-default'} ${isSelfSource ? 'ring-2 ring-ds-warning' : ''} ${isTargetCandidate ? 'ring-1 ring-ds-info motion-safe:hover:ring-2 focus:ring-2' : ''} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
                       >
                         <AnimatedCard
                           card={tc.card}


### PR DESCRIPTION
## 概要

`StreetsAndAlleysPage.tsx` のタブロー内カードは、`selectedSource` がセットされているときに移動先ターゲットとしてクリック可能になるが、その状態は `disabled` 属性でしか表現されず視覚的な差分クラスが無かったため、キーボードで Tab 移動する利用者は「今このカードが移動先として押せるか」を判別しにくかった。

`selectedSource` がある間、各列の最上段カード（＝ドロップ先）に `ring-1 ring-ds-info`（hover/focus で `ring-2` に強調）と `data-target-candidate` を付与。選択中のソース自身は除外。ヒントはテキスト表示のためリングスタイルの衝突は無い。

## 変更点

- `StreetsAndAlleysPage.tsx`: `isTargetCandidate`（`selectedSource && isTop && !isSelfSource`）を計算し、対象カードに `ring-ds-info` 系クラスと `data-target-candidate` を付与

## 受け入れ条件

- [x] `selectedSource` 有効時、選択可能なカードに視覚的な強調が付く
- [x] キーボードフォーカス時にも同様の強調が確認できる（`focus:ring-2`）
- [x] 既存のヒント表示スタイル（テキスト）と衝突しない
- [x] コンポーネントテストでクラス付与を検証

## テスト

- `StreetsAndAlleysPage.test.tsx`: ソース選択前は無強調、♠5選択後に♥6が `data-target-candidate`＋`ring-ds-info`、ソース自身は非対象、を検証（14 tests pass）
- `bun run build` / `bunx biome check` / `bunx tsc -b` … OK

Closes #3279