### PR TITLE
feat(kingalbert): announce empty reserve slots with their slot number

### DIFF
--- a/frontend/src/i18n/locales/en/kingalbert.json
+++ b/frontend/src/i18n/locales/en/kingalbert.json
@@ -10,6 +10,7 @@
   "moveCount": "Moves",
   "giveup": "Give Up",
   "empty": "Empty",
+  "emptyReserveSlot": "Empty reserve slot {{idx}}",
   "foundationAriaLabel": "{{suit}} foundation {{count}} cards",
   "emptyFoundationAriaLabel": "Empty foundation ({{suit}})",
   "landscapeBanner": "Landscape mode recommended",

--- a/frontend/src/i18n/locales/ja/kingalbert.json
+++ b/frontend/src/i18n/locales/ja/kingalbert.json
@@ -10,6 +10,7 @@
   "moveCount": "手数",
   "giveup": "ギブアップ",
   "empty": "空",
+  "emptyReserveSlot": "空のリザーブ枠 {{idx}}",
   "foundationAriaLabel": "{{suit}} 組札 {{count}}枚",
   "emptyFoundationAriaLabel": "空の組札 ({{suit}})",
   "landscapeBanner": "横画面での表示を推奨します",

--- a/frontend/src/pages/KingAlbertPage.test.tsx
+++ b/frontend/src/pages/KingAlbertPage.test.tsx
@@ -91,6 +91,17 @@ describe('KingAlbertPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: '♦ 7' })).toBeInTheDocument());
   });
 
+  it('gives each empty reserve slot a role=img with a numbered aria-label', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<KingAlbertPage />);
+    // Reserve slots 2..7 (1-based) are empty and each is now an announced,
+    // numbered slot instead of an anonymous div.
+    await waitFor(() => expect(screen.getByRole('img', { name: '空のリザーブ枠 2' })).toBeInTheDocument());
+    expect(screen.getByRole('img', { name: '空のリザーブ枠 7' })).toBeInTheDocument();
+    // Slot 1 holds ♦7 (a button), so it is not an empty-slot image.
+    expect(screen.queryByRole('img', { name: '空のリザーブ枠 1' })).not.toBeInTheDocument();
+  });
+
   it('selecting a reserve card marks it as selected', async () => {
     mockExec.mockResolvedValue(playingState);
     renderWithProviders(<KingAlbertPage />);

--- a/frontend/src/pages/KingAlbertPage.tsx
+++ b/frontend/src/pages/KingAlbertPage.tsx
@@ -278,6 +278,8 @@ function KingAlbertPageContent() {
       return (
         <div
           key={`r-${cellIdx.toString()}`}
+          role="img"
+          aria-label={t('emptyReserveSlot', { idx: cellIdx + 1 })}
           className="rounded border border-dashed border-white/10"
           style={{ width: dims.cw, height: dims.ch }}
         />


### PR DESCRIPTION
## 概要

`KingAlbertPage.tsx` の `renderReserveCell` は、リザーブが空の場合 `aria-label` も `role` も持たないただの `<div>` を返していた。KingAlbert の7枠リザーブは一度使うと二度と埋まらない仕様で空スロットが頻発するが、その存在自体がスクリーンリーダー利用者に伝わらなかった（タブロー空列は最低限テキスト付きボタンなのに対して非対称）。

空リザーブスロットに `role="img"` と枠番号入りの `aria-label`（`emptyReserveSlot`）を付与し、タブロー空列と同等のアクセシビリティを確保した。点線ボーダーの視覚デザインは維持。

## 変更点

- `KingAlbertPage.tsx`: 空リザーブ `<div>` に `role="img"` と `aria-label={t('emptyReserveSlot', { idx: cellIdx + 1 })}` を付与
- i18n キー `emptyReserveSlot` を ja / en に追加

## 受け入れ条件

- [x] 空リザーブスロットに aria-label が付与される
- [x] リザーブ枠番号が読み上げ内容に含まれる
- [x] 既存の視覚デザイン（点線ボーダー）は維持
- [x] コンポーネントテストで aria 属性を検証

## テスト

- `KingAlbertPage.test.tsx`: 空枠2・7が `role=img`＋番号ラベルを持ち、カードのある枠1は空スロット画像でないことを検証（12 tests pass）
- `bun run build` / `bunx biome check` / `bunx tsc -b` … OK

Closes #3280