### PR TITLE
feat(sultan): announce empty divan slots with their slot number

### DIFF
--- a/frontend/src/i18n/locales/en/sultan.json
+++ b/frontend/src/i18n/locales/en/sultan.json
@@ -13,6 +13,7 @@
   "redeal": "Redeal",
   "giveup": "Give Up",
   "empty": "Empty",
+  "emptyDivanSlot": "Empty divan slot {{idx}}",
   "landscapeBanner": "Landscape mode recommended",
   "hint": "Hint",
   "autoComplete": "Auto Complete",

--- a/frontend/src/i18n/locales/ja/sultan.json
+++ b/frontend/src/i18n/locales/ja/sultan.json
@@ -13,6 +13,7 @@
   "redeal": "リディール",
   "giveup": "ギブアップ",
   "empty": "空",
+  "emptyDivanSlot": "空のディヴァン枠 {{idx}}",
   "landscapeBanner": "横向き表示推奨",
   "hint": "ヒント",
   "autoComplete": "自動完成",

--- a/frontend/src/pages/SultanPage.test.tsx
+++ b/frontend/src/pages/SultanPage.test.tsx
@@ -90,6 +90,17 @@ describe('SultanPage', () => {
     expect(screen.getByTestId('skeleton')).toBeInTheDocument();
   });
 
+  it('gives each empty divan slot a role=img with a numbered aria-label', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<SultanPage />);
+    // Empty divan slots (idx 1, 3..7) are now announced with their slot number,
+    // matching the visible 0-based header.
+    await waitFor(() => expect(screen.getByRole('img', { name: '空のディヴァン枠 1' })).toBeInTheDocument());
+    expect(screen.getByRole('img', { name: '空のディヴァン枠 7' })).toBeInTheDocument();
+    // Slots 0 and 2 hold cards (buttons), so they are not empty-slot images.
+    expect(screen.queryByRole('img', { name: '空のディヴァン枠 0' })).not.toBeInTheDocument();
+  });
+
   it('renders stock count', async () => {
     renderWithProviders(<SultanPage />);
     await waitFor(() => expect(screen.getByText(/山札/)).toBeInTheDocument());

--- a/frontend/src/pages/SultanPage.tsx
+++ b/frontend/src/pages/SultanPage.tsx
@@ -294,6 +294,8 @@ function SultanPageContent() {
                     </button>
                   ) : (
                     <div
+                      role="img"
+                      aria-label={t('emptyDivanSlot', { idx })}
                       style={{ width: sultan.cw, height: sultan.ch }}
                       className="rounded border border-white/20 flex items-center justify-center text-game-text-muted text-xs"
                     >


### PR DESCRIPTION
## 概要

`SultanPage.tsx` の8枠のディヴァン（リザーブ）は、`dcard` が null（プレイ済み）の場合 `aria-label` も `role` も持たない `<div>` を描画していた。カードありスロットは `aria-label={cardAlt(dcard)}` を持つのに対し、空スロットはスクリーンリーダー利用者にとって存在自体が消えていた。

空ディヴァンスロットに `role="img"` と枠番号入りの `aria-label`（`emptyDivanSlot`）を付与。番号は視覚的な0始まりのスロットヘッダーと一致させた。視覚デザインは維持。

## 変更点

- `SultanPage.tsx`: 空ディヴァン `<div>` に `role="img"` と `aria-label={t('emptyDivanSlot', { idx })}` を付与
- i18n キー `emptyDivanSlot` を ja / en に追加

## 受け入れ条件

- [x] 空ディヴァンスロットに aria-label が付与される
- [x] スロット番号が読み上げ内容に含まれる（視覚ヘッダーと同じ0始まり）
- [x] 既存の視覚デザインは維持
- [x] コンポーネントテストで aria 属性を検証

## テスト

- `SultanPage.test.tsx`: 空枠1・7が `role=img`＋番号ラベルを持ち、カードのある枠0は空スロット画像でないことを検証（28 tests pass）
- `bun run build` / `bunx biome check` / `bunx tsc -b` … OK

Closes #3292