### PR TITLE
feat(casinoholdem): add a focus ring to the hint-toggle checkbox

### DIFF
--- a/frontend/src/pages/CasinoHoldemPage.test.tsx
+++ b/frontend/src/pages/CasinoHoldemPage.test.tsx
@@ -112,6 +112,14 @@ describe('CasinoHoldemPage', () => {
     expect(screen.getByTestId('skeleton')).toBeInTheDocument();
   });
 
+  it('gives the hint-toggle checkbox a keyboard focus ring', async () => {
+    mockApi.mockResolvedValue(betPhaseState);
+    renderWithProviders(<CasinoHoldemPage />);
+    const checkbox = await screen.findByRole('checkbox', { name: 'ヒント表示' });
+    // Matches the focus-ring style used by the page's other interactive controls.
+    expect(checkbox.className).toContain('focus-visible:ring');
+  });
+
   it('shows flop with call and fold buttons', async () => {
     mockApi.mockResolvedValueOnce(betPhaseState).mockResolvedValueOnce(flopState);
     renderWithProviders(<CasinoHoldemPage />);

--- a/frontend/src/pages/CasinoHoldemPage.tsx
+++ b/frontend/src/pages/CasinoHoldemPage.tsx
@@ -24,7 +24,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { useSound } from '../providers/SoundProvider';
-import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
+import { btnDanger, btnPrimary, btnSecondary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { CasinoHoldemResponse } from '../types/card';
@@ -191,6 +191,7 @@ function CasinoHoldemPageContent() {
                 type="checkbox"
                 checked={frontendHintEnabled}
                 onChange={(e) => setFrontendHintEnabled(e.target.checked)}
+                className={`${focusRingWhite} rounded cursor-pointer`}
               />
               {tc('hint.toggle', { ns: 'tutorial' })}
             </label>


### PR DESCRIPTION
## 概要

`CasinoHoldemPage.tsx` のヒントトグルの `<input type="checkbox">` にはフォーカス可視化用クラスが無く、キーボードで Tab フォーカスが当たっても視覚的にどこにあるか分かりにくかった。同ページのベット/コール/フォールドボタンは共通スタイルによりフォーカスリングが確保されている。

チェックボックスに共通の `focusRingWhite`（＋`rounded cursor-pointer`）を適用し、他コントロールと一貫したフォーカス可視性を持たせた。

## 変更点

- `CasinoHoldemPage.tsx`: ヒントトグル `<input>` に `focusRingWhite rounded cursor-pointer` を付与

## 受け入れ条件

- [x] キーボードフォーカス時に視覚的なフォーカスリングが表示される（`focus-visible:ring-2`）
- [x] 既存のチェックボックス機能に影響しない
- [x] 他ゲームのフォーカススタイル（`focusRingWhite`）と一貫
- [x] コンポーネントテストでフォーカス用クラス付与を検証

## テスト

- `CasinoHoldemPage.test.tsx`: ヒントトグルが `focus-visible:ring` を含むことを検証（19 tests pass）
- `bun run build` / `bunx biome check` / `bunx tsc -b` … OK

Closes #3299