### PR TITLE
feat(tarneeb): translate the trump-declaration button aria-labels

### DIFF
--- a/frontend/src/i18n/locales/en/tarneeb.json
+++ b/frontend/src/i18n/locales/en/tarneeb.json
@@ -20,6 +20,12 @@
   "trick": "Trick {{n}}",
   "trump": "Trump",
   "trumpUndeclared": "not yet declared",
+  "suitName": {
+    "spade": "Spade",
+    "club": "Club",
+    "heart": "Heart",
+    "diamond": "Diamond"
+  },
   "highestBid": "Current high bid",
   "cards": "{{count}} cards",
   "bid": "bid {{n}}",

--- a/frontend/src/i18n/locales/ja/tarneeb.json
+++ b/frontend/src/i18n/locales/ja/tarneeb.json
@@ -20,6 +20,12 @@
   "trick": "トリック {{n}}",
   "trump": "トランプ",
   "trumpUndeclared": "未宣言",
+  "suitName": {
+    "spade": "スペード",
+    "club": "クラブ",
+    "heart": "ハート",
+    "diamond": "ダイヤ"
+  },
   "highestBid": "現在の最高ビッド",
   "cards": "{{count}}枚",
   "bid": "ビッド {{n}}",

--- a/frontend/src/pages/TarneebPage.test.tsx
+++ b/frontend/src/pages/TarneebPage.test.tsx
@@ -63,6 +63,18 @@ describe('TarneebPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined, expect.any(Object)));
   });
 
+  it('labels the trump-declaration buttons with translated suit names', async () => {
+    // Trump-declaration phase with the human (player 0) as bid winner.
+    mockExec.mockResolvedValue(makeState({ phase: 1, bidWinnerIdx: 0, highestBid: 8 }));
+    renderWithProviders(<TarneebPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'スペード' })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'クラブ' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'ハート' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'ダイヤ' })).toBeInTheDocument();
+    // The old untranslated "trump-N" label is gone.
+    expect(screen.queryByRole('button', { name: 'trump-1' })).not.toBeInTheDocument();
+  });
+
   it('labels the human team and opponents and shows round tricks + total per team', async () => {
     const { container } = renderWithProviders(<TarneebPage />);
     await waitFor(() => expect(container.querySelector('[data-tutorial="tn-score-table"] table')).not.toBeNull());

--- a/frontend/src/pages/TarneebPage.tsx
+++ b/frontend/src/pages/TarneebPage.tsx
@@ -103,6 +103,9 @@ const TRUMP_LABELS: Record<number, string> = {
   4: '♦',
 };
 
+/** Maps a trump suit value to its `suitName.*` i18n key (mirrors MightyPage). */
+const SUIT_KEYS: Record<number, string> = { 1: 'spade', 2: 'club', 3: 'heart', 4: 'diamond' };
+
 /** Render the Tarneeb game page (partnership trick-taking with chosen trump). */
 export const TarneebPage = withTutorial(TarneebPageContent, 'tarneeb', TARNEEB_TUTORIAL_STEPS);
 
@@ -467,7 +470,7 @@ function TarneebPageContent() {
                       className={btnPrimary}
                       onClick={() => handleDeclareTrump(suit)}
                       disabled={loading}
-                      aria-label={`trump-${suit}`}
+                      aria-label={t(`suitName.${SUIT_KEYS[suit]}`)}
                     >
                       {TRUMP_LABELS[suit]}
                     </button>


### PR DESCRIPTION
## 概要

`TarneebPage.tsx` のトランプスート宣言ボタンは `aria-label={`trump-${suit}`}` という未翻訳・番号のみのラベルを持ち、スクリーンリーダーには「trump-1」のような意味不明な読み上げになっていた。同種のボタンを持つ `MightyPage.tsx` は `t('suitName.${SUIT_KEYS[s]}')` で翻訳済みラベル（例:「スペード」）を使っている。

Mighty と同じパターンを Tarneeb に適用し、翻訳済みスート名を aria-label に使うようにした。視覚表示（記号）や `data-testid` は変更なし。

## 変更点

- `TarneebPage.tsx`: `SUIT_KEYS` マップを追加し、宣言ボタンの `aria-label` を `t('suitName.${SUIT_KEYS[suit]}')` に変更
- i18n キー `suitName.{spade,club,heart,diamond}` を ja / en に追加（Mighty と同じ文言）
- （`MightyPage.tsx` は既に正しいパターンのため変更なし＝参照元）

## 受け入れ条件

- [x] トランプ宣言ボタンの aria-label が翻訳済みスート名になる
- [x] 既存の視覚表示（記号）は変更しない
- [x] 日英両ロケールで自然な読み上げ
- [x] コンポーネントテストで aria-label 内容を検証

## テスト

- `TarneebPage.test.tsx`: 宣言フェーズで4ボタンが「スペード/クラブ/ハート/ダイヤ」ラベルを持ち、旧「trump-1」が消えたことを検証（7 tests pass）
- `bun run build` / `bunx biome check` / `bunx tsc -b` … OK

Closes #3304