### PR TITLE
feat(highcardflush): label flush vs non-flush cards with text

### DIFF
--- a/frontend/src/i18n/locales/en/highcardflush.json
+++ b/frontend/src/i18n/locales/en/highcardflush.json
@@ -71,6 +71,8 @@
   "dealerQualified": "Qualified",
   "dealerNotQualified": "Not Qualified",
   "flushLine": "{{count}}-card flush",
+  "flushCardAria": "in flush",
+  "nonFlushCardAria": "not in flush",
   "tutorial": {
     "betControls": "Set the ante and optional side bets, then press Bet.",
     "actionButtons": "Raise up to the multiplier allowed by your flush length, or Fold to forfeit the ante.",

--- a/frontend/src/i18n/locales/ja/highcardflush.json
+++ b/frontend/src/i18n/locales/ja/highcardflush.json
@@ -71,6 +71,8 @@
   "dealerQualified": "クオリファイ",
   "dealerNotQualified": "未クオリファイ",
   "flushLine": "{{count}}枚フラッシュ",
+  "flushCardAria": "フラッシュ対象",
+  "nonFlushCardAria": "フラッシュ対象外",
   "tutorial": {
     "betControls": "アンテと任意のサイドベットを設定し、ベットを押してください。",
     "actionButtons": "プレイヤーのフラッシュ枚数で許される最大倍率まで「レイズ」できます。「フォールド」でアンテを放棄します。",

--- a/frontend/src/pages/HighCardFlushPage.test.tsx
+++ b/frontend/src/pages/HighCardFlushPage.test.tsx
@@ -123,6 +123,22 @@ describe('HighCardFlushPage', () => {
     expect(screen.getByRole('button', { name: 'ベット' })).toBeInTheDocument();
   });
 
+  it('labels player flush vs non-flush cards with text, not just glow/opacity', async () => {
+    mockExec.mockResolvedValue(actionPhase5Flush);
+    renderWithProviders(<HighCardFlushPage />);
+    // ♠ cards form the flush; the ♥ is not part of it.
+    await waitFor(() => expect(screen.getByRole('img', { name: '♠ 5 フラッシュ対象' })).toBeInTheDocument());
+    expect(screen.getByRole('img', { name: '♥ 9 フラッシュ対象外' })).toBeInTheDocument();
+  });
+
+  it('labels the dealer flush cards at showdown', async () => {
+    mockExec.mockResolvedValue(endPhasePlayerWins);
+    renderWithProviders(<HighCardFlushPage />);
+    // Dealer's ♣ cards form its 3-card flush; the ♥ is not in it.
+    await waitFor(() => expect(screen.getByRole('img', { name: '♣ 4 フラッシュ対象' })).toBeInTheDocument());
+    expect(screen.getByRole('img', { name: '♥ 8 フラッシュ対象外' })).toBeInTheDocument();
+  });
+
   it('shows action phase with raise/fold buttons matching multiplier cap', async () => {
     mockExec.mockResolvedValueOnce(betPhaseState).mockResolvedValueOnce(actionPhase5Flush);
     renderWithProviders(<HighCardFlushPage />);

--- a/frontend/src/pages/HighCardFlushPage.tsx
+++ b/frontend/src/pages/HighCardFlushPage.tsx
@@ -29,6 +29,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { HighCardFlushResponse } from '../types/card';
 import { HighCardFlushPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import { HIGHCARDFLUSH_HELP, parseHighcardflushCommand } from '../utils/cli/commands/highcardflushCommands';
 import { formatHighcardflushState } from '../utils/cli/formatters/highcardflushFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -243,6 +244,8 @@ function HighCardFlushPageContent() {
                     return (
                       <div
                         key={`p-${card.design}-${card.value}-${i}`}
+                        role="img"
+                        aria-label={`${cardAlt(card)} ${inFlush ? t('flushCardAria') : t('nonFlushCardAria')}`}
                         className={`transition-all ${
                           inFlush ? 'drop-shadow-[0_0_8px_var(--color-ds-warning)] -translate-y-1' : 'opacity-50'
                         }`}
@@ -278,6 +281,14 @@ function HighCardFlushPageContent() {
                     return (
                       <div
                         key={`d-${card.design}-${card.value}-${i}`}
+                        role="img"
+                        // Only announce flush status once the dealer's flush is
+                        // revealed (end phase); during the action phase it's hidden.
+                        aria-label={
+                          dealerFlushSuit === null
+                            ? cardAlt(card)
+                            : `${cardAlt(card)} ${inFlush ? t('flushCardAria') : t('nonFlushCardAria')}`
+                        }
                         className={`transition-all ${
                           dealerFlushSuit === null
                             ? ''


### PR DESCRIPTION
## 概要

`HighCardFlushPage.tsx` では、フラッシュを構成するカード（`inFlush`）はグロー＋浮き上がり、それ以外は不透明度低下のみで区別され、`aria-label` に「フラッシュ対象」であることを示すテキストが無かった。色覚・視覚に障害のあるユーザーやスクリーンリーダー利用者は、どのカードがフラッシュに寄与しているか判別できなかった。

各カードを `role="img"` でラップし、`aria-label` にカード名＋「フラッシュ対象/対象外」テキストを付与。プレイヤー・ディーラー両手札に適用（ディーラーはフラッシュが公開される終了フェーズのみ状態を付与）。既存のグロー/不透明度演出は維持。

## 変更点

- `HighCardFlushPage.tsx`: プレイヤー・ディーラーの各カードラッパー `<div>` に `role="img"` と `aria-label={cardAlt(card) + flush状態}` を付与
- i18n キー `flushCardAria` / `nonFlushCardAria` を ja / en に追加

## 受け入れ条件

- [x] フラッシュ対象カードにテキストで区別可能な aria-label が付与される
- [x] 既存の視覚演出（グロー/不透明度）は維持
- [x] ディーラー側の同様の表示にも適用
- [x] コンポーネントテストで aria-label 内容を検証

## テスト

- `HighCardFlushPage.test.tsx`: プレイヤーの♠=対象/♥=対象外、ディーラー終了時の♣=対象/♥=対象外 を検証（20 tests pass）
- `bun run build` / `bunx biome check` / `bunx tsc -b` … OK

Closes #3307