### PR TITLE
fix(highcardflush): stop leaking the dealer hand before showdown

### DIFF
--- a/internal/adapter/presenter/HighCardFlushWebPresenter.go
+++ b/internal/adapter/presenter/HighCardFlushWebPresenter.go
@@ -17,7 +17,15 @@ func (hp *HighCardFlushWebPresenter) Output(hcf interfaces.HighCardFlushGame, la
 	resObj := new(controller.HighCardFlushWebOutput)
 
 	resObj.PlayerHand = cardsToOutputOrEmpty(hcf.GetPlayerHand())
-	resObj.DealerHand = cardsToOutputOrEmpty(hcf.GetDealerHand())
+	// The dealer's 7 cards are dealt at the same time as the player's but stay
+	// hidden until showdown. Only expose them at the END phase — otherwise the
+	// web API would leak the dealer's hand (a cheat, and, via the UI, an
+	// accessibility over-share) during betting/action. Mirrors the CUI gate.
+	if hcf.GetPhase() == domain.HighCardFlushPhaseEnd {
+		resObj.DealerHand = cardsToOutputOrEmpty(hcf.GetDealerHand())
+	} else {
+		resObj.DealerHand = cardsToOutputOrEmpty(nil)
+	}
 	resObj.Phase = hcf.GetPhase()
 	resObj.Chips = hcf.GetChips()
 	resObj.AnteBet = hcf.GetAnteBet()

--- a/internal/adapter/presenter/HighCardFlushWebPresenter_test.go
+++ b/internal/adapter/presenter/HighCardFlushWebPresenter_test.go
@@ -92,6 +92,30 @@ func endStateMock(t *testing.T, result domain.GameResult, raise int, qualified b
 	return m
 }
 
+// The dealer's 7 cards are dealt with the player's but must stay hidden until
+// showdown; the web output must not leak them during bet/action (cheat + a11y
+// over-share). Only the END phase reveals them.
+func TestHighCardFlushWebPresenter_Output_HidesDealerHandUntilShowdown(t *testing.T) {
+	dealer := []*domain.Card{domain.NewCard(1, 5, false), domain.NewCard(2, 9, false)}
+	build := func(phase int) *interfaces.MockHighCardFlushGame {
+		m := new(interfaces.MockHighCardFlushGame)
+		// Registered first so these win over the defaults' Bet/nil values.
+		m.On("GetPhase").Return(phase).Maybe()
+		m.On("GetDealerHand").Return(dealer).Maybe()
+		setupHighCardFlushWebMockDefaults(m)
+		return m
+	}
+	p := new(HighCardFlushWebPresenter)
+
+	for _, phase := range []int{domain.HighCardFlushPhaseBet, domain.HighCardFlushPhaseAction} {
+		out := parseHighCardFlushOutput(t, p.Output(build(phase), nil))
+		assert.Empty(t, out.DealerHand, "dealer hand must not leak before showdown (phase %d)", phase)
+	}
+
+	endOut := parseHighCardFlushOutput(t, p.Output(build(domain.HighCardFlushPhaseEnd), nil))
+	assert.Len(t, endOut.DealerHand, 2, "dealer hand is revealed at showdown")
+}
+
 func TestHighCardFlushWebPresenter_Output_PlayerWins(t *testing.T) {
 	p := new(HighCardFlushWebPresenter)
 	m := endStateMock(t, domain.GameResultWin, 100, true)


### PR DESCRIPTION
## 概要

`HighCardFlushWebPresenter` はディーラーの7枚をフェーズに関係なく無条件で出力していた。ディーラーの手札はプレイヤーと同時に配られるが本来は決着（END フェーズ）まで隠されるべきで、ベット/アクションフェーズ中に Web API がディーラーの手札を漏洩していた。これにより DevTools/DOM から覗き見（チート）が可能になり、さらに UI が「空でないディーラー手札」を描画するため、支援技術にも過剰に開示されていた。

CUI プレゼンター（`HighCardFlushCuiPresenter`）と同様に、ディーラー手札の出力を END フェーズに限定した。

## 経緯

PR #3740（High Card Flush のフラッシュ対象 aria-label 追加、マージ済み）に対する Gemini レビューが、ディーラーの裏向きカードの `aria-label` 漏洩（`![MUST]` security-high）を指摘。調査の結果、根本原因は Web プレゼンターがフェーズを問わずディーラー手札を送っていたこと（＝視覚・a11y 両方の漏洩源）と判明したため、ソースで修正する。

## 変更点

- `HighCardFlushWebPresenter.go`: `GetPhase() == HighCardFlushPhaseEnd` のときのみディーラー手札を出力（それ以外は空）
- 対応するプレゼンターテストを追加（bet/action で空、end で公開）

## テスト

- `go test -tags test ./internal/adapter/presenter/` … OK（新規テスト `..._HidesDealerHandUntilShowdown` 含む）
- `golangci-lint run` … 該当ファイルに警告なし

## 影響

フロントの `HighCardFlushPage` はアクション中に `dealerHand` が空になるためディーラーセクションを描画しなくなる（従来の意図通りの挙動に修正）。END フェーズの表示・#3740 のフラッシュ aria-label は不変。