### PR TITLE
feat(penguin): give empty tableau columns a descriptive aria-label

### DIFF
--- a/frontend/src/i18n/locales/en/eightoff.json
+++ b/frontend/src/i18n/locales/en/eightoff.json
@@ -17,6 +17,7 @@
   "foundationAriaLabel": "{{suit}} Foundation ({{cardCount}} cards)",
   "emptyFoundationAriaLabel": "{{suit}} Foundation (empty)",
   "emptyFreecellAriaLabel": "Free Cell {{idx}} (empty)",
+  "emptyColumnAriaLabel": "Empty column (only {{rank}} may be placed)",
   "supermoveLimitTooltip": "Only {{limit}} card(s) can be moved at once ({{cells}} free cell(s), {{cols}} empty column(s))",
   "tutorial": {
     "freeCells": "Eight free cells. Four are pre-filled with initial cards. More empty cells allow moving more cards at once.",

--- a/frontend/src/i18n/locales/en/penguin.json
+++ b/frontend/src/i18n/locales/en/penguin.json
@@ -19,6 +19,7 @@
   "foundationAriaLabel": "{{suit}} Foundation ({{cardCount}} cards)",
   "emptyFoundationAriaLabel": "{{suit}} Foundation (empty)",
   "emptyFreecellAriaLabel": "Free Cell {{idx}} (empty)",
+  "emptyColumnAriaLabel": "Empty column (only {{rank}} may be placed)",
   "supermoveLimitTooltip": "Only {{limit}} card(s) can be moved at once",
   "tutorial": {
     "freeCells": "Seven free cells. Three start occupied after the deal. More empty cells allow moving more cards at once.",

--- a/frontend/src/i18n/locales/ja/eightoff.json
+++ b/frontend/src/i18n/locales/ja/eightoff.json
@@ -17,6 +17,7 @@
   "foundationAriaLabel": "{{suit}} ファンデーション ({{cardCount}}枚)",
   "emptyFoundationAriaLabel": "{{suit}} ファンデーション (空)",
   "emptyFreecellAriaLabel": "フリーセル {{idx}} (空)",
+  "emptyColumnAriaLabel": "空き列（{{rank}} のみ置けます）",
   "supermoveLimitTooltip": "一度に動かせるのは{{limit}}枚まで（空きフリーセル{{cells}}・空き列{{cols}}）",
   "tutorial": {
     "freeCells": "8つのフリーセルです。一時的にカードを置けるスペースで、4つには既に初期カードが配られています。空きセルが多いほど多くのカードを一度に移動できます。",

--- a/frontend/src/i18n/locales/ja/penguin.json
+++ b/frontend/src/i18n/locales/ja/penguin.json
@@ -19,6 +19,7 @@
   "foundationAriaLabel": "{{suit}} ファンデーション ({{cardCount}}枚)",
   "emptyFoundationAriaLabel": "{{suit}} ファンデーション (空)",
   "emptyFreecellAriaLabel": "フリーセル {{idx}} (空)",
+  "emptyColumnAriaLabel": "空き列（{{rank}} のみ置けます）",
   "supermoveLimitTooltip": "一度に動かせるのは{{limit}}枚までです",
   "tutorial": {
     "freeCells": "7つのフリーセルです。初期配置で3セルが使用済みの状態からスタートします。空きセルが多いほど多くのカードを一度に移動できます。",

--- a/frontend/src/pages/EightOffPage.tsx
+++ b/frontend/src/pages/EightOffPage.tsx
@@ -403,6 +403,7 @@ function EightOffPageContent() {
                               type="button"
                               onClick={() => handleSelectTarget(tableauColZone)}
                               disabled={!isPlaying || loading || !selectedSource}
+                              aria-label={t('emptyColumnAriaLabel', { rank: 'K' })}
                               style={{ height: cardHeight }}
                               className={`w-full rounded border-2 border-dashed border-white/20 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}`}
                             >

--- a/frontend/src/pages/PenguinPage.test.tsx
+++ b/frontend/src/pages/PenguinPage.test.tsx
@@ -90,6 +90,21 @@ describe('PenguinPage', () => {
     expect(threeElements.length).toBeGreaterThanOrEqual(1);
   });
 
+  it('gives empty tableau columns a descriptive aria-label whose rank follows baseRank', async () => {
+    renderWithProviders(<PenguinPage />);
+    // baseRank 4 → only the rank one below (3) may be placed on an empty column.
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: '空き列（3 のみ置けます）' }).length).toBeGreaterThanOrEqual(1),
+    );
+
+    // Changing the base rank moves the placeable rank (baseRank 1 → K).
+    mockExec.mockResolvedValue({ ...playingState, baseRank: 1 });
+    renderWithProviders(<PenguinPage />);
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: '空き列（K のみ置けます）' }).length).toBeGreaterThanOrEqual(1),
+    );
+  });
+
   // --- Foundation ---
 
   it('renders foundation piles with suit symbols', async () => {

--- a/frontend/src/pages/PenguinPage.tsx
+++ b/frontend/src/pages/PenguinPage.tsx
@@ -400,6 +400,7 @@ function PenguinPageContent() {
                               type="button"
                               onClick={() => handleSelectTarget(tableauColZone)}
                               disabled={!isPlaying || loading || !selectedSource}
+                              aria-label={t('emptyColumnAriaLabel', { rank: emptyColPlaceholder })}
                               style={{ height: cardHeight }}
                               className={`w-full rounded border-2 border-dashed border-white/20 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}`}
                             >


### PR DESCRIPTION
## 概要

`PenguinPage.tsx` の空きタブロー列ボタンはアクセシブルネームが `prevRankLabel(baseRank)` の1文字（例:「Q」）だけで、スクリーンリーダーには「Q」としか読み上げられなかった。空きフリーセル・空きファウンデーションには説明的な aria-label が既にあるのに、タブロー列だけ欠けていた。Penguin は「ベースランクの1つ下のカードのみ空き列に置ける」特殊ルールのため、この情報欠落は致命的。

空き列ボタンに `aria-label={t('emptyColumnAriaLabel', { rank })}`（例:「空き列（Q のみ置けます）」）を追加。`EightOffPage.tsx` の空き列（固定「K」）にも横展開。

## 変更点

- `PenguinPage.tsx`: 空き列 `<button>` に `aria-label`（`emptyColPlaceholder` = prevRank を埋め込み）
- `EightOffPage.tsx`: 空き列 `<button>` に `aria-label`（`rank: 'K'`）
- i18n キー `emptyColumnAriaLabel` を penguin / eightoff の ja / en に追加

## 受け入れ条件

- [x] 空きタブロー列に説明的な aria-label が付く
- [x] ベースランク変更でラベル中のランクが追随する
- [x] ja/en 両ロケールに翻訳キーが追加
- [x] `PenguinPage.test.tsx` に aria-label のテストを追加（baseRank 4→「3」、1→「K」）

## テスト

- `PenguinPage.test.tsx` / `EightOffPage.test.tsx`: 117 tests pass
- `bun run build` / `bunx biome check` / `bunx tsc -b` … OK

Closes #3330