### PR TITLE
feat(chinesepoker): label hand cards by name and assignment, not 'Card N'

### DIFF
--- a/frontend/e2e/chinesepoker.spec.ts
+++ b/frontend/e2e/chinesepoker.spec.ts
@@ -139,7 +139,7 @@ test.describe('Chinese Poker E2E', () => {
     // A naive "first 3 → front, next 5 → middle" split is almost always a foul
     // (front ≤ middle ≤ back is violated), which the server rejects — so the
     // arrangement must be rank-aware to reliably reach the END phase.
-    const cards = page.locator('[data-tutorial="cp-set-hands"] button[aria-label^="Card"]');
+    const cards = page.locator('[data-testid^="cp-hand-card-"]');
     await expect(cards.first()).toBeVisible({ timeout: 10_000 });
     const count = await cards.count();
 

--- a/frontend/src/i18n/locales/en/chinesepoker.json
+++ b/frontend/src/i18n/locales/en/chinesepoker.json
@@ -59,6 +59,7 @@
   "previewFront": "Front",
   "previewMiddle": "Middle",
   "previewBack": "Back",
+  "cardAssignedAria": "{{card}} ({{row}})",
   "foulWarning": "Foul: Hands must be arranged so that Back ≧ Middle ≧ Front",
   "royalty": "Royalty: +{{points}}",
   "tutorial": {

--- a/frontend/src/i18n/locales/ja/chinesepoker.json
+++ b/frontend/src/i18n/locales/ja/chinesepoker.json
@@ -59,6 +59,7 @@
   "previewFront": "フロント",
   "previewMiddle": "ミドル",
   "previewBack": "バック",
+  "cardAssignedAria": "{{card}}（{{row}}）",
   "foulWarning": "ファウル: バック ≧ ミドル ≧ フロント の順になるように配置してください",
   "royalty": "ロイヤリティ: +{{points}}",
   "tutorial": {

--- a/frontend/src/pages/ChinesePokerPage.test.tsx
+++ b/frontend/src/pages/ChinesePokerPage.test.tsx
@@ -97,12 +97,24 @@ describe('ChinesePokerPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bet', 100));
   });
 
-  it('renders set hands phase with 13 cards', async () => {
+  it('renders set hands phase with 13 cards labeled by card name', async () => {
     mockExec.mockResolvedValue(setHandsState);
     renderWithProviders(<ChinesePokerPage />);
     await waitFor(() => expect(screen.getByTestId('set-hands-button')).toBeInTheDocument());
-    const cardButtons = screen.getAllByRole('button', { name: /Card \d+/ });
+    // Hand cards are now named by suit+rank (cardAlt), not the hardcoded "Card N".
+    const cardButtons = screen.getAllByRole('button', { name: /^[♠♥♣♦]/ });
     expect(cardButtons.length).toBe(13);
+    expect(screen.queryByRole('button', { name: /Card \d+/ })).not.toBeInTheDocument();
+  });
+
+  it('includes the assigned row in a hand card aria-label once assigned', async () => {
+    mockExec.mockResolvedValue(setHandsState);
+    renderWithProviders(<ChinesePokerPage />);
+    // First card is ♥ A (design idx 1, value 1).
+    const firstCard = await screen.findByRole('button', { name: '♥ A' });
+    // First tap assigns it to the front row.
+    fireEvent.click(firstCard);
+    await waitFor(() => expect(screen.getByRole('button', { name: '♥ A（フロント）' })).toBeInTheDocument());
   });
 
   it('shows the front/middle/back row preview and updates it on assignment', async () => {
@@ -116,11 +128,11 @@ describe('ChinesePokerPage', () => {
     expect(front()).toHaveLength(0);
     const middle = () => within(screen.getByTestId('cp-row-middle')).queryAllByTestId('animated-card');
     // First click assigns the card to the front row.
-    fireEvent.click(screen.getByRole('button', { name: 'Card 0' }));
+    fireEvent.click(screen.getByTestId('cp-hand-card-0'));
     expect(front()).toHaveLength(1);
     expect(back()).toHaveLength(12);
     // Second click cycles front → middle.
-    fireEvent.click(screen.getByRole('button', { name: 'Card 0' }));
+    fireEvent.click(screen.getByTestId('cp-hand-card-0'));
     expect(front()).toHaveLength(0);
     expect(middle()).toHaveLength(1);
     expect(back()).toHaveLength(12);
@@ -160,7 +172,7 @@ describe('ChinesePokerPage', () => {
   // row, the next 5 the middle row, and the remaining 5 stay in the back row.
   const assignFrontMiddle = (frontMid: number[]) => {
     for (const i of frontMid) {
-      fireEvent.click(screen.getByRole('button', { name: `Card ${i}` }));
+      fireEvent.click(screen.getByTestId(`cp-hand-card-${i}`));
     }
   };
 

--- a/frontend/src/pages/ChinesePokerPage.tsx
+++ b/frontend/src/pages/ChinesePokerPage.tsx
@@ -28,6 +28,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { Card, ChinesePokerResponse } from '../types/card';
 import { ChinesePokerPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import { chinesePokerIsFoul } from '../utils/chinesePokerFoul';
 import { CHINESEPOKER_HELP, parseChinesepokerCommand } from '../utils/cli/commands/chinesepokerCommands';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -259,10 +260,18 @@ function ChinesePokerPageContent() {
                     <button
                       key={`p-${card.design}-${card.value}-${i}`}
                       type="button"
+                      data-testid={`cp-hand-card-${i}`}
                       onClick={() => toggleCard(i)}
                       className={`relative transition-transform ${ringClass(assignments[i])}`}
                       aria-pressed={!!assignments[i]}
-                      aria-label={`Card ${i}`}
+                      aria-label={
+                        assignments[i]
+                          ? t('cardAssignedAria', {
+                              card: cardAlt(card),
+                              row: t(assignments[i] === 'front' ? 'previewFront' : 'previewMiddle'),
+                            })
+                          : cardAlt(card)
+                      }
                     >
                       <AnimatedCard card={card} width={cardWidth} />
                       {assignments[i] && (


### PR DESCRIPTION
## 概要

`ChinesePokerPage.tsx` の SET_HANDS フェーズでは、13枚の手札ボタンに `aria-label={`Card ${i}`}` とハードコードされた英語インデックスラベルが付いており、スクリーンリーダー利用者はどのカードか分からないまま front/middle/back を割り当てていた。また割り当て状態（F/M バッジ）は視覚のみだった。

`aria-label` を `cardAlt(card)` ベースに変更し、割り当て済みなら割り当て先（フロント/ミドル）を含める（例:「♥ A（フロント）」）。

## 変更点

- `ChinesePokerPage.tsx`: 手札ボタンの `aria-label` を `cardAlt(card)`＋割り当て先に変更。テスト安定化のため `data-testid={`cp-hand-card-${i}`}` も付与
- i18n キー `cardAssignedAria` を ja / en に追加（`previewFront`/`previewMiddle` を流用）
- 既存テスト（`Card N` でカードをクリックしていた3件）を testid ベースに更新

## 受け入れ条件

- [x] 手札ボタンの aria-label がカード名になる
- [x] 割り当て済みカードはラベルに割り当て先が含まれる
- [x] ハードコード英語が i18n キー／cardAlt に置き換わる
- [x] `ChinesePokerPage.test.tsx` に aria-label のテストを追加

## テスト

- `ChinesePokerPage.test.tsx`: 13枚がスート+数字ラベル、`Card N` が消滅、割り当てで「♥ A（フロント）」化を検証（11 tests pass）
- `bun run build` / `bunx biome check` / `bunx tsc -b` … OK

Closes #3333