### PR TITLE
feat(truco): add keyboard shortcuts for play, truco, accept/decline, next

### DIFF
--- a/frontend/src/pages/TrucoPage.test.tsx
+++ b/frontend/src/pages/TrucoPage.test.tsx
@@ -62,6 +62,41 @@ describe('TrucoPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 
+  it('plays a card with number keys and declares truco with t during the play turn', async () => {
+    mockExec.mockResolvedValue(makeState()); // PLAY phase, human turn, canDeclareTruco
+    renderWithProviders(<TrucoPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    fireEvent.keyDown(document, { key: '1' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', 0));
+    fireEvent.keyDown(document, { key: 't' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('truco'));
+  });
+
+  it('accepts and declines with a/d during the respond phase', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: 1, responderIdx: 0, trucoCallerIdx: 1 }));
+    renderWithProviders(<TrucoPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    fireEvent.keyDown(document, { key: 'a' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('accept'));
+    fireEvent.keyDown(document, { key: 'd' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('decline'));
+  });
+
+  it('ignores play/respond shortcuts outside their phases', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: 4, gameEndFlag: true })); // GAME_END
+    renderWithProviders(<TrucoPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    mockExec.mockClear();
+    fireEvent.keyDown(document, { key: '1' });
+    fireEvent.keyDown(document, { key: 'a' });
+    fireEvent.keyDown(document, { key: 't' });
+    expect(mockExec).not.toHaveBeenCalledWith('play', 0);
+    expect(mockExec).not.toHaveBeenCalledWith('accept');
+    expect(mockExec).not.toHaveBeenCalledWith('truco');
+  });
+
   it('renders match score and stake header', async () => {
     renderWithProviders(<TrucoPage />);
     await waitFor(() => expect(screen.getByText(/マッチ得点/)).toBeInTheDocument());

--- a/frontend/src/pages/TrucoPage.tsx
+++ b/frontend/src/pages/TrucoPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { trucoApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CardImage } from '../components/CardImage';
@@ -8,6 +8,7 @@ import { GamePageShell } from '../components/GamePageShell';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { TrickDisplay } from '../components/TrickDisplay';
 import { withTutorial } from '../components/tutorial/withTutorial';
+import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
@@ -63,6 +64,39 @@ function TrucoPageContent() {
   const handleAccept = useCallback(() => void dispatch('accept'), [dispatch]);
   const handleDecline = useCallback(() => void dispatch('decline'), [dispatch]);
   const handleNext = useCallback(() => void dispatch('next'), [dispatch]);
+
+  // Keyboard shortcuts (must run before the early return): 1/2/3 play a card,
+  // t declares truco, a/d accept/decline a truco call, n advances at a boundary.
+  const kbHumanIdx = state?.players.findIndex((p) => p.isHuman) ?? -1;
+  const kbHumanCardCount = state?.players[kbHumanIdx]?.cards?.length ?? 0;
+  const kbIsHumanPlayTurn = state?.phase === TrucoPhase.PLAY && state.players[state.currentPlayerIdx]?.isHuman === true;
+  const kbIsHumanRespond = state?.phase === TrucoPhase.RESPOND && state.responderIdx === kbHumanIdx;
+  const kbCanTruco = !!state?.canDeclareTruco;
+  const kbIsBoundary = state?.phase === TrucoPhase.TRICK_END || state?.phase === TrucoPhase.HAND_END;
+  const actionBindings = useMemo(
+    () => [
+      { key: '1', action: () => handlePlay(0), enabled: kbIsHumanPlayTurn && kbHumanCardCount >= 1 },
+      { key: '2', action: () => handlePlay(1), enabled: kbIsHumanPlayTurn && kbHumanCardCount >= 2 },
+      { key: '3', action: () => handlePlay(2), enabled: kbIsHumanPlayTurn && kbHumanCardCount >= 3 },
+      { key: 't', action: handleTruco, enabled: (kbIsHumanPlayTurn || kbIsHumanRespond) && kbCanTruco },
+      { key: 'a', action: handleAccept, enabled: kbIsHumanRespond },
+      { key: 'd', action: handleDecline, enabled: kbIsHumanRespond },
+      { key: 'n', action: handleNext, enabled: kbIsBoundary },
+    ],
+    [
+      handlePlay,
+      handleTruco,
+      handleAccept,
+      handleDecline,
+      handleNext,
+      kbIsHumanPlayTurn,
+      kbHumanCardCount,
+      kbIsHumanRespond,
+      kbCanTruco,
+      kbIsBoundary,
+    ],
+  );
+  useActionKeyboardNav({ bindings: actionBindings, enabled: !!state && !loading });
 
   if (!state) {
     return <GameSkeleton gameKey="truco" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 3 }} />;


### PR DESCRIPTION
## 概要

`TrucoPage.tsx` は `useActionKeyboardNav` を使っておらず、カードプレイ・トゥルコ宣言・受諾・拒否・次へが全てマウス/タップ必須だった。特に RESPOND フェーズは相手のレイズに即応する場面で、キーバインドがあると操作性・アクセシビリティが大きく向上する。

`useActionKeyboardNav` を導入し、フェーズごとにゲート:
- `1`/`2`/`3` = カードプレイ（human play turn、手札枚数に応じて有効）
- `t` = トゥルコ宣言（`canDeclareTruco` 時。play/respond 両フェーズ）
- `a` = accept・`d` = decline（respond フェーズ）
- `n` = next（TRICK_END/HAND_END）
- `enabled` は `!!state && !loading`

## 変更点

- `TrucoPage.tsx`: 早期 return 前に `useActionKeyboardNav` を追加（state-optional なフラグでフェーズ判定）
- （`useActionKeyboardNav.ts` は既にこのパターンを満たすため変更なし）

## 受け入れ条件

- [x] 数字キーで手札が出せる
- [x] RESPOND フェーズで a/d/t キーが機能する
- [x] 無効フェーズではキーが反応しない
- [x] `TrucoPage.test.tsx` にキー操作のテストを追加

## テスト

- `TrucoPage.test.tsx`: play(1/t)・respond(a/d)・GAME_END で無反応、の3ケースを追加（15 tests pass）
- `bun run build` / `bunx biome check` / `bunx tsc -b` … OK

Closes #3342