### PR TITLE
feat(scopa): expose capture candidates and selection to assistive tech

### DIFF
--- a/frontend/src/i18n/locales/en/scopa.json
+++ b/frontend/src/i18n/locales/en/scopa.json
@@ -15,6 +15,10 @@
   "label": {
     "tableCards": "Table",
     "tableEmpty": "No table cards",
+    "selected": "selected",
+    "takeCandidate": "capture candidate",
+    "takeCandidateAnnounce": "{{count}} capture candidate(s) available",
+    "noTakeCandidate": "No capture candidates",
     "yourCaptures": "Captures",
     "cpuStats": "{{cards}} cards / {{score}} pt",
     "humanStats": "Hand {{cards}} / Captured {{captured}} / Scopa {{scopa}} / Total {{score}} pt"

--- a/frontend/src/i18n/locales/ja/scopa.json
+++ b/frontend/src/i18n/locales/ja/scopa.json
@@ -15,6 +15,10 @@
   "label": {
     "tableCards": "場札",
     "tableEmpty": "場札なし",
+    "selected": "選択中",
+    "takeCandidate": "取り札候補",
+    "takeCandidateAnnounce": "{{count}}枚の取り札候補があります",
+    "noTakeCandidate": "取り札候補はありません",
     "yourCaptures": "獲得カード",
     "cpuStats": "{{cards}}枚 / {{score}}pt",
     "humanStats": "手札{{cards}}枚 / 捕獲{{captured}}枚 / スコパ{{scopa}} / 累計{{score}}pt"

--- a/frontend/src/pages/ScopaPage.test.tsx
+++ b/frontend/src/pages/ScopaPage.test.tsx
@@ -70,6 +70,24 @@ describe('ScopaPage', () => {
     expect(screen.getByTestId('table-card-1')).toBeInTheDocument();
   });
 
+  it('exposes capture candidates, selection state, and a candidate-count live region', async () => {
+    mockExec.mockResolvedValue(makeState());
+    renderWithProviders(<ScopaPage />);
+    await waitFor(() => expect(screen.getByTestId('table-card-0')).toBeInTheDocument());
+    // Base state: no hand card selected → plain labels, not pressed, empty live region.
+    expect(screen.getByTestId('table-card-0')).toHaveAttribute('aria-label', '♠ 2');
+    expect(screen.getByTestId('table-card-0')).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByTestId('sc-take-candidate-live')).toHaveTextContent('');
+    // Selecting the ♥5 hand card makes the matching ♥5 table card a capture candidate.
+    fireEvent.click(screen.getByTestId('hand-card-1'));
+    await waitFor(() => expect(screen.getByTestId('table-card-1')).toHaveAttribute('aria-label', '♥ 5 取り札候補'));
+    expect(screen.getByTestId('sc-take-candidate-live')).toHaveTextContent('取り札候補があります');
+    // Selecting that candidate flips its aria-pressed to true and updates the label.
+    fireEvent.click(screen.getByTestId('table-card-1'));
+    await waitFor(() => expect(screen.getByTestId('table-card-1')).toHaveAttribute('aria-pressed', 'true'));
+    expect(screen.getByTestId('table-card-1')).toHaveAttribute('aria-label', '♥ 5 選択中');
+  });
+
   it('renders human stats via i18n (no hardcoded Japanese under en locale)', async () => {
     await i18n.changeLanguage('en');
     renderWithProviders(<ScopaPage />);

--- a/frontend/src/pages/ScopaPage.tsx
+++ b/frontend/src/pages/ScopaPage.tsx
@@ -20,6 +20,7 @@ import { useScopaGame } from '../hooks/useScopaGame';
 import { gameTheme } from '../styles/gameTheme';
 import type { ScopaResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import {
   formatScopaState,
   parseScopaCommand,
@@ -134,6 +135,14 @@ function ScopaPageContent() {
       : new Set<number>();
   const canTake = isHumanTurn && handIndex !== null && tableIndices.length > 0;
   const canLay = isHumanTurn && handIndex !== null && tableIndices.length === 0;
+  // Announce how many table cards the selected hand card could capture, since the
+  // green candidate rings are purely visual.
+  const takeCandidateAnnounce =
+    handIndex !== null && isHumanTurn
+      ? takeCandidateIndices.size > 0
+        ? t('label.takeCandidateAnnounce', { count: takeCandidateIndices.size })
+        : t('label.noTakeCandidate')
+      : '';
   const phaseName = isGameEnd ? t('phase.end') : t(`phase.${state.phase}`, t('phase.play'));
 
   return (
@@ -183,6 +192,9 @@ function ScopaPageContent() {
 
             {/* Table cards */}
             <div className="py-3 bg-black/20 rounded-lg" data-tutorial="sc-table-cards">
+              <div className="sr-only" role="status" aria-live="polite" data-testid="sc-take-candidate-live">
+                {takeCandidateAnnounce}
+              </div>
               <div className="text-center text-xs text-ds-text-muted mb-2">{t('label.tableCards')}</div>
               <div className="flex justify-center gap-2 min-h-[60px] flex-wrap">
                 {state.tableCards.length === 0 ? (
@@ -196,6 +208,14 @@ function ScopaPageContent() {
                         type="button"
                         onClick={() => isHumanTurn && toggleTable(i)}
                         disabled={!isHumanTurn}
+                        aria-pressed={tableIndices.includes(i)}
+                        aria-label={`${cardAlt(c)}${
+                          tableIndices.includes(i)
+                            ? ` ${t('label.selected')}`
+                            : isCandidate
+                              ? ` ${t('label.takeCandidate')}`
+                              : ''
+                        }`}
                         className={`rounded transition-all ${
                           tableIndices.includes(i)
                             ? 'ring-2 ring-ds-warning -translate-y-1'


### PR DESCRIPTION
## 概要

`ScopaPage.tsx` は手札選択時に `scopaTakeCandidates` で取れるテーブルカードを緑リング＋`data-take-candidate` で示すが、完全に視覚的で、テーブルカードボタンに `aria-pressed` が無く、候補・選択状態も読み上げに含まれなかった。

3点を追加:
1. `aria-pressed={tableIndices.includes(i)}`
2. 候補/選択済みの場合に `aria-label` へ「取り札候補」「選択中」を付加
3. 手札選択時に `role="status"` の sr-only リージョンで「◯枚の取り札候補があります」を通知

## 変更点

- `ScopaPage.tsx`: テーブルカードボタンに `aria-pressed`・状態付き `aria-label`（`cardAlt`）、`sc-take-candidate-live` の live リージョンを追加
- i18n キー `label.selected` / `label.takeCandidate` / `label.takeCandidateAnnounce` / `label.noTakeCandidate` を ja / en に追加

## 受け入れ条件

- [x] 取り札候補がスクリーンリーダーで識別できる
- [x] 選択中テーブルカードが aria-pressed で分かる
- [x] 候補数の変化が aria-live で通知される
- [x] `ScopaPage.test.tsx` に aria のテストを追加

## テスト

- `ScopaPage.test.tsx`: 素の label→（♥5手札選択で）取り札候補＋live通知→（クリックで）選択中・aria-pressed を検証（15 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3345