### PR TITLE
feat(macau): add a must-declare context banner for screen readers

### DIFF
--- a/frontend/src/i18n/locales/en/macau.json
+++ b/frontend/src/i18n/locales/en/macau.json
@@ -37,6 +37,7 @@
   "suitHeart": "♥ Heart",
   "suitDiamond": "♦ Diamond",
   "penaltyBanner": "Draw penalty: {{count}}! Stack a 2 or take them",
+  "mustDeclareBanner": "You have one card left. Declare 'Macau!'? If you don't, you may be penalized.",
   "playPhase": "Play a card or draw from the stock",
   "chooseSuitPhase": "Choose a suit",
   "mustDeclarePhase": "One card left! Declare \"Macau!\"",

--- a/frontend/src/i18n/locales/ja/macau.json
+++ b/frontend/src/i18n/locales/ja/macau.json
@@ -37,6 +37,7 @@
   "suitHeart": "♥ ハート",
   "suitDiamond": "♦ ダイヤ",
   "penaltyBanner": "ドローペナルティ {{count}}枚！ 2を重ねるか引き受けてください",
+  "mustDeclareBanner": "残り1枚です。『マカオ！』を宣言しますか？宣言しないとペナルティの可能性があります",
   "playPhase": "カードを出すか、山札から引いてください",
   "chooseSuitPhase": "スートを選択してください",
   "mustDeclarePhase": "手札が残り1枚！「マカオ！」と宣言してください",

--- a/frontend/src/pages/MacauPage.test.tsx
+++ b/frontend/src/pages/MacauPage.test.tsx
@@ -70,6 +70,21 @@ describe('MacauPage', () => {
     expect(screen.getByTestId('skeleton')).toBeInTheDocument();
   });
 
+  it('shows a role=status must-declare banner on the human MUST_DECLARE turn', async () => {
+    mockExec.mockResolvedValue(mustDeclareState); // phase 2, human's turn
+    renderWithProviders(<MacauPage />);
+    const banner = await screen.findByTestId('macau-must-declare-banner');
+    expect(banner).toHaveAttribute('role', 'status');
+    expect(banner).toHaveTextContent('マカオ');
+  });
+
+  it('does not show the must-declare banner on a CPU turn', async () => {
+    mockExec.mockResolvedValue({ ...mustDeclareState, currentPlayerIdx: 1 });
+    renderWithProviders(<MacauPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined, expect.any(Object)));
+    expect(screen.queryByTestId('macau-must-declare-banner')).not.toBeInTheDocument();
+  });
+
   it('calls reset on mount', async () => {
     renderWithProviders(<MacauPage />);
     await waitFor(() =>

--- a/frontend/src/pages/MacauPage.tsx
+++ b/frontend/src/pages/MacauPage.tsx
@@ -277,6 +277,16 @@ function MacauPageContent() {
                   </div>
                 )}
 
+                {isMustDeclare && state.players[state.currentPlayerIdx]?.isHuman && (
+                  <div
+                    className="my-2 p-2 rounded bg-ds-info/20 text-ds-info text-sm font-semibold"
+                    role="status"
+                    data-testid="macau-must-declare-banner"
+                  >
+                    {t('mustDeclareBanner')}
+                  </div>
+                )}
+
                 <GameMessageBox
                   message={state.message}
                   messageCode={state.messageCode}


### PR DESCRIPTION
## 概要

`MacauPage.tsx` の MUST_DECLARE フェーズでは宣言/スキップの2ボタンが突然フッターに現れるだけで、「残り1枚になったのでマカオ宣言が必要（怠るとペナルティ）」という文脈説明が画面に無かった。ペナルティ発生時は `penaltyBanner`（`role="status"`）が出るのと対照的だった。

MUST_DECLARE で人間の番のとき、`penaltyBanner` と同様の `role="status"` バナーを表示し、スクリーンリーダーにフェーズ遷移を通知する。

## 変更点

- `MacauPage.tsx`: `isMustDeclare && 人間の番` のとき `role="status"` の `macau-must-declare-banner` を表示（penaltyBanner と同じ位置・スタイル系）
- i18n キー `mustDeclareBanner` を ja / en に追加（CUI の `promptMustDeclare` に対応）

## 受け入れ条件

- [x] MUST_DECLARE フェーズで説明バナーが表示される
- [x] バナーが role=status で読み上げ通知される
- [x] ja/en 両ロケールで翻訳
- [x] `MacauPage.test.tsx` にバナーのテストを追加（人間の番で表示、CPU の番で非表示）

## テスト

- `MacauPage.test.tsx`: 26 tests pass
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3353