### PR TITLE
feat(fivehundred): label hand cards and expose selection via aria-pressed

### DIFF
--- a/frontend/src/pages/FiveHundredPage.test.tsx
+++ b/frontend/src/pages/FiveHundredPage.test.tsx
@@ -81,6 +81,25 @@ describe('FiveHundredPage', () => {
     );
   });
 
+  it('labels hand cards with cardAlt and reflects selection via aria-pressed during play', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: 2, currentPlayerIdx: 0 })); // PLAY, human turn
+    renderWithProviders(<FiveHundredPage />);
+    const card0 = await screen.findByTestId('hand-card-0');
+    expect(card0).toHaveAttribute('aria-label', '♠ 5');
+    expect(card0).toHaveAttribute('aria-pressed', 'false');
+    expect(card0).not.toBeDisabled();
+    fireEvent.click(card0);
+    await waitFor(() => expect(screen.getByTestId('hand-card-0')).toHaveAttribute('aria-pressed', 'true'));
+  });
+
+  it('keeps hand cards labeled but disabled in a non-selectable phase (bid)', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: 0 })); // BID
+    renderWithProviders(<FiveHundredPage />);
+    const card0 = await screen.findByTestId('hand-card-0');
+    expect(card0).toHaveAttribute('aria-label', '♠ 5');
+    expect(card0).toBeDisabled();
+  });
+
   it('renders CPU difficulty options with localized labels', async () => {
     renderWithProviders(<FiveHundredPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalled());

--- a/frontend/src/pages/FiveHundredPage.tsx
+++ b/frontend/src/pages/FiveHundredPage.tsx
@@ -21,6 +21,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { FiveHundredResponse } from '../types/card';
 import { FiveHundredContract, FiveHundredPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import {
   FIVE_HUNDRED_HELP,
   type FiveHundredCliArgs,
@@ -282,6 +283,8 @@ function FiveHundredPageContent() {
                       type="button"
                       onClick={() => selectable && toggleCard(i)}
                       disabled={!selectable}
+                      aria-label={cardAlt(c)}
+                      aria-pressed={selected}
                       className={cardClass}
                       data-testid={`hand-card-${i}`}
                     >


### PR DESCRIPTION
## 概要

`FiveHundredPage.tsx` の手札ボタンには `aria-label` が無く（中身は `AnimatedCard` 画像のみ）、選択状態（ring + lift）も aria に反映されていなかった。burraco 等は `aria-label={cardAlt(card)}` + `aria-pressed` を付けている。

手札ボタンに `aria-label={cardAlt(c)}` と `aria-pressed={selected}` を付与。特にキティ交換フェーズでは「交換対象として選択中」が伝わる。

## 変更点

- `FiveHundredPage.tsx`: 手札 `<button>` に `aria-label`・`aria-pressed` を付与（`cardAlt` を import）

## 受け入れ条件

- [x] 手札各ボタンに `cardAlt` によるカード名の aria-label が付く
- [x] 選択中カードは `aria-pressed="true"` になる
- [x] BID / TRICK_END など選択不可フェーズでは disabled が維持される
- [x] `FiveHundredPage.test.tsx` に aria 属性のアサーションを追加

## テスト

- `FiveHundredPage.test.tsx`: PLAY で label＋選択で aria-pressed=true、BID で label＋disabled を検証（16 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3366