### PR TITLE
feat(gongzhu): name the exposable cards in the expose hint

### DIFF
--- a/frontend/src/pages/GongZhuPage.test.tsx
+++ b/frontend/src/pages/GongZhuPage.test.tsx
@@ -60,6 +60,16 @@ describe('GongZhuPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: '公開しない' })).toBeInTheDocument());
   });
 
+  it('names the exposable cards (index + card name) in a role=status hint', async () => {
+    mockExec.mockResolvedValue(exposePhaseState); // exposableIndices [0, 1] → ♠ Q, ♦ J
+    const { container } = renderWithProviders(<GongZhuPage />);
+    await waitFor(() => expect(container.querySelector('[data-tutorial="gz-expose-area"]')).not.toBeNull());
+    const hint = container.querySelector('[data-tutorial="gz-expose-area"]') as HTMLElement;
+    expect(hint).toHaveAttribute('role', 'status');
+    expect(hint.textContent).toContain('[0] ♠ Q');
+    expect(hint.textContent).toContain('[1] ♦ J');
+  });
+
   it('shows exposed point cards with localized symbols and an aria-label', async () => {
     mockExec.mockResolvedValue(makeGongZhuState({ exposed: { pig: true, sheep: true, ace: true, doubler: true } }));
     renderWithProviders(<GongZhuPage />);

--- a/frontend/src/pages/GongZhuPage.tsx
+++ b/frontend/src/pages/GongZhuPage.tsx
@@ -29,6 +29,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { GongZhuResponse } from '../types/card';
 import { GongZhuPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import { GONGZHU_HELP, parseGongZhuCommand } from '../utils/cli/commands/gongzhuCommands';
 import { formatGongZhuState } from '../utils/cli/formatters/gongzhuFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -258,9 +259,18 @@ function GongZhuPageContent() {
               <div>
                 {/* Exposure hint (expose phase) */}
                 {isExposePhase && (
-                  <div className="text-ds-warning text-center mb-2" data-tutorial="gz-expose-area">
+                  <div className="text-ds-warning text-center mb-2" data-tutorial="gz-expose-area" role="status">
                     {state.exposableIndices.length > 0
-                      ? t('exposableHint', { indices: state.exposableIndices.map((i) => `[${i}]`).join(', ') })
+                      ? t('exposableHint', {
+                          // Include the card name after each index so SR users and
+                          // beginners know which card [0]/[3]… refers to.
+                          indices: state.exposableIndices
+                            .map((i) => {
+                              const c = humanPlayer?.cards[i];
+                              return c ? `[${i}] ${cardAlt(c)}` : `[${i}]`;
+                            })
+                            .join(', '),
+                        })
                       : t('exposableNone')}
                   </div>
                 )}


### PR DESCRIPTION
## 概要

`GongZhuPage.tsx` の EXPOSE フェーズ案内は `[0], [3]` のようなインデックス列を表示するだけで、どのカード（♠Q/♦J/♥A/♣10）を露出できるのか番号からは分からなかった。

`exposableIndices` に対応する人間手札のカードを `cardAlt` で引き、「[0] ♠ Q, [3] ♣ 10」のようにカード名付きの案内文に変更。案内領域に `role="status"` を付与しフェーズ遷移時に読み上げられるようにした。

## 変更点

- `GongZhuPage.tsx`: 露出案内の `{{indices}}` に各インデックス＋カード名を含める。`gz-expose-area` に `role="status"` を付与（`cardAlt` を import）

## 受け入れ条件

- [x] 露出案内にインデックスとカード名の両方が表示される
- [x] 案内が `role="status"` で支援技術に通知される
- [x] 露出可能カードがない場合の `exposableNone` 表示は従来通り
- [x] `GongZhuPage.test.tsx` にカード名表示のテスト追加

## テスト

- `GongZhuPage.test.tsx`: `[0] ♠ Q` / `[1] ♦ J` を含み role=status であることを検証（15 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3378