### PR TITLE
feat(tute): give marriage buttons a spoken suit name and point value

### DIFF
--- a/frontend/src/i18n/locales/en/tute.json
+++ b/frontend/src/i18n/locales/en/tute.json
@@ -30,6 +30,13 @@
   "teamScore": "{{team}}: {{score}} pts",
   "playButton": "Play",
   "declareMarriage": "Marriage {{suit}}",
+  "marriageAria": "Declare {{suit}} marriage ({{points}} points)",
+  "suitName": {
+    "spade": "Spade",
+    "club": "Club",
+    "heart": "Heart",
+    "diamond": "Diamond"
+  },
   "declareTute": "Declare Tute",
   "declarationsLabel": "Available declarations",
   "tuteHelp": "Tute: declare when you hold all four Kings (or all four Queens) for a large bonus.",

--- a/frontend/src/i18n/locales/ja/tute.json
+++ b/frontend/src/i18n/locales/ja/tute.json
@@ -30,6 +30,13 @@
   "teamScore": "{{team}}: {{score}}点",
   "playButton": "出す",
   "declareMarriage": "結婚宣言 {{suit}}",
+  "marriageAria": "{{suit}}のマリッジを宣言（{{points}}点）",
+  "suitName": {
+    "spade": "スペード",
+    "club": "クラブ",
+    "heart": "ハート",
+    "diamond": "ダイヤ"
+  },
   "declareTute": "Tute 宣言",
   "declarationsLabel": "宣言できる役",
   "tuteHelp": "Tute: 4枚の King（または 4枚の Queen）を揃えると宣言でき、大きなボーナス点になります。",

--- a/frontend/src/pages/TutePage.test.tsx
+++ b/frontend/src/pages/TutePage.test.tsx
@@ -74,9 +74,18 @@ describe('TutePage', () => {
   it('shows marriage declaration buttons when allowed and dispatches a suit', async () => {
     mockExec.mockResolvedValue(marriageState);
     renderWithProviders(<TutePage />);
-    const heartBtn = await screen.findByRole('button', { name: '結婚宣言 ♥' });
+    // The button's accessible name is now the spoken aria-label (suit name + points);
+    // heart is not the trump (♦) so the marriage is worth 20.
+    const heartBtn = await screen.findByRole('button', { name: 'ハートのマリッジを宣言（20点）' });
     fireEvent.click(heartBtn);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('marriage', { suit: 3 }));
+  });
+
+  it('labels a trump-suit marriage as worth 40 points', async () => {
+    // Make heart (the human's K+Q suit) the trump so the marriage is worth 40.
+    mockExec.mockResolvedValue(makeTuteState({ canDeclareMarriage: true, trumpSuit: 3 }));
+    renderWithProviders(<TutePage />);
+    expect(await screen.findByRole('button', { name: 'ハートのマリッジを宣言（40点）' })).toBeInTheDocument();
   });
 
   it('shows the Tute declaration button when allowed and dispatches', async () => {

--- a/frontend/src/pages/TutePage.tsx
+++ b/frontend/src/pages/TutePage.tsx
@@ -34,6 +34,8 @@ import { playerName } from '../utils/playerUtils';
 
 /** Suit symbols indexed by suit number (1=♠ 2=♣ 3=♥ 4=♦; index 0 unused). */
 const SUIT_SYMBOLS = ['', '♠', '♣', '♥', '♦'] as const;
+/** Suit id → `suitName.*` i18n key (1=♠ .. 4=♦). */
+const SUIT_KEYS = ['', 'spade', 'club', 'heart', 'diamond'] as const;
 
 /** Tute tutorial step definitions. */
 const TUTE_TUTORIAL_STEPS: TutorialStep[] = [
@@ -343,6 +345,10 @@ function TutePageContent() {
                           className={btnSecondary}
                           onClick={() => handleDeclareMarriage(suit)}
                           disabled={loading}
+                          aria-label={t('marriageAria', {
+                            suit: t(`suitName.${SUIT_KEYS[suit]}`),
+                            points: suit === state.trumpSuit ? 40 : 20,
+                          })}
                         >
                           {t('declareMarriage', { suit: SUIT_SYMBOLS[suit] })}
                         </button>


### PR DESCRIPTION
## 概要

`TutePage.tsx` のマリッジ宣言ボタンはスートを ♠♣♥♦ の記号のみで表現しており、スクリーンリーダーには「どのスートの宣言か」が伝わりにくかった。

各マリッジボタンに `aria-label` を追加し、スート名（スペード/クラブ/ハート/ダイヤ）＋獲得点（トランプなら40点、それ以外20点）を読み上げるようにした。視覚上の記号表示は変更なし。

## 変更点

- `TutePage.tsx`: マリッジ `<button>` に `aria-label={t('marriageAria', { suit, points })}` を付与（`SUIT_KEYS` マップ追加）
- i18n キー `marriageAria` / `suitName.{spade,club,heart,diamond}` を ja / en に追加

## 受け入れ条件

- [x] 全マリッジボタンにスート名と点数を含む aria-label が付与される
- [x] ja/en 両ロケールにスート名キーを追加
- [x] 視覚上の表示（記号）は変更しない
- [x] `TutePage.test.tsx` で aria-label を検証

## テスト

- `TutePage.test.tsx`: ♥（非トランプ）=20点、♥（トランプ時）=40点 の aria-label を検証。既存の記号セレクタも新ラベルへ更新（13 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3411