### PR TITLE
feat(sueca): read out the trump suit by name in header and sidebar

### DIFF
--- a/frontend/src/i18n/locales/en/sueca.json
+++ b/frontend/src/i18n/locales/en/sueca.json
@@ -16,6 +16,12 @@
   "round": "Round {{n}}",
   "trick": "Trick {{n}}",
   "trump": "Trump: {{suit}}",
+  "suitName": {
+    "spade": "Spade",
+    "club": "Club",
+    "heart": "Heart",
+    "diamond": "Diamond"
+  },
   "cards": "{{count}} cards",
   "tricks": "{{count}} tricks",
   "currentTrick": "Current Trick",

--- a/frontend/src/i18n/locales/ja/sueca.json
+++ b/frontend/src/i18n/locales/ja/sueca.json
@@ -16,6 +16,12 @@
   "round": "ラウンド {{n}}",
   "trick": "トリック {{n}}",
   "trump": "切り札: {{suit}}",
+  "suitName": {
+    "spade": "スペード",
+    "club": "クラブ",
+    "heart": "ハート",
+    "diamond": "ダイヤ"
+  },
   "cards": "{{count}}枚",
   "tricks": "{{count}}トリック",
   "currentTrick": "現在のトリック",

--- a/frontend/src/pages/SuecaPage.test.tsx
+++ b/frontend/src/pages/SuecaPage.test.tsx
@@ -41,6 +41,16 @@ describe('SuecaPage', () => {
     expect(screen.getByTestId('skeleton')).toBeInTheDocument();
   });
 
+  it('exposes the trump suit by name in the header and sidebar (symbol hidden from SR)', async () => {
+    mockExec.mockResolvedValue(playPhaseState); // trumpSuit 4 = ♦ → ダイヤ
+    renderWithProviders(<SuecaPage />);
+    const sidebar = await screen.findByTestId('sueca-sidebar-trump');
+    expect(sidebar).toHaveAttribute('role', 'img');
+    expect(sidebar).toHaveAttribute('aria-label', '切り札: ダイヤ');
+    // Header + sidebar both expose a named trump element (glyph is aria-hidden).
+    expect(screen.getAllByRole('img', { name: '切り札: ダイヤ' }).length).toBeGreaterThanOrEqual(2);
+  });
+
   it('calls reset on mount with the default config', async () => {
     renderWithProviders(<SuecaPage />);
     await waitFor(() =>

--- a/frontend/src/pages/SuecaPage.test.tsx
+++ b/frontend/src/pages/SuecaPage.test.tsx
@@ -51,6 +51,15 @@ describe('SuecaPage', () => {
     expect(screen.getAllByRole('img', { name: '切り札: ダイヤ' }).length).toBeGreaterThanOrEqual(2);
   });
 
+  it('falls back to the raw symbol when the trump suit is unset', async () => {
+    // trumpSuit 0 has no suit-name key → the label falls back to the symbol string.
+    mockExec.mockResolvedValue(makeSuecaState({ trumpSuit: 0 }));
+    renderWithProviders(<SuecaPage />);
+    const sidebar = await screen.findByTestId('sueca-sidebar-trump');
+    expect(sidebar).toHaveAttribute('role', 'img');
+    expect(sidebar).toHaveAttribute('aria-label', '切り札: ');
+  });
+
   it('calls reset on mount with the default config', async () => {
     renderWithProviders(<SuecaPage />);
     await waitFor(() =>

--- a/frontend/src/pages/SuecaPage.tsx
+++ b/frontend/src/pages/SuecaPage.tsx
@@ -34,6 +34,8 @@ import { playerName } from '../utils/playerUtils';
 
 /** Suit symbols indexed by suit number (1=♠ 2=♣ 3=♥ 4=♦; index 0 unused). */
 const SUIT_SYMBOLS = ['', '♠', '♣', '♥', '♦'] as const;
+/** Suit id → `suitName.*` i18n key (1=♠ .. 4=♦). */
+const SUIT_KEYS = ['', 'spade', 'club', 'heart', 'diamond'] as const;
 
 /** Sueca tutorial step definitions. */
 const SUECA_TUTORIAL_STEPS: TutorialStep[] = [
@@ -136,6 +138,9 @@ function SuecaPageContent() {
   const canPlay = isPlayPhase && isHumanTurn;
   const humanTeam = humanIdx % 2;
   const trumpSymbol = SUIT_SYMBOLS[state.trumpSuit] ?? '?';
+  // Spoken trump: the suit name (not the ♠♣♥♦ glyph, which SRs read poorly).
+  const trumpSuitName = SUIT_KEYS[state.trumpSuit] ? t(`suitName.${SUIT_KEYS[state.trumpSuit]}`) : trumpSymbol;
+  const trumpAriaLabel = t('trump', { suit: trumpSuitName });
 
   const handleManualReset = () => {
     hideActionLog();
@@ -201,7 +206,9 @@ function SuecaPageContent() {
             <div className="text-ds-text-primary text-center mb-2">
               <span className="mr-4">{t('round', { n: state.roundNumber })}</span>
               <span className="mr-4">{t('trick', { n: state.trickNumber })}</span>
-              <span>{t('trump', { suit: trumpSymbol })}</span>
+              <span role="img" aria-label={trumpAriaLabel}>
+                <span aria-hidden="true">{t('trump', { suit: trumpSymbol })}</span>
+              </span>
             </div>
 
             <div className={lgTwoColGrid}>
@@ -221,8 +228,13 @@ function SuecaPageContent() {
                 {/* Team game points */}
                 <div className="mb-2 p-2 rounded bg-black/30 text-ds-text-muted text-sm">
                   {/* Trump kept in the always-visible sidebar so it isn't lost off-screen on mobile. */}
-                  <div className="mb-1 text-ds-text-primary font-semibold" data-testid="sueca-sidebar-trump">
-                    {t('trump', { suit: trumpSymbol })}
+                  <div
+                    className="mb-1 text-ds-text-primary font-semibold"
+                    data-testid="sueca-sidebar-trump"
+                    role="img"
+                    aria-label={trumpAriaLabel}
+                  >
+                    <span aria-hidden="true">{t('trump', { suit: trumpSymbol })}</span>
                   </div>
                   <div>{t('teamScore', { team: t('team.a'), score: state.teamGamePoints[0] ?? 0 })}</div>
                   <div>{t('teamScore', { team: t('team.b'), score: state.teamGamePoints[1] ?? 0 })}</div>


### PR DESCRIPTION
## 概要

`SuecaPage.tsx` は切り札を ♠♣♥♦ の記号のみでヘッダーとサイドバー（`sueca-sidebar-trump`）の2箇所に表示しており、スクリーンリーダー利用者には切り札スートが伝わらず、赤/黒スートの区別も色・形状のみだった。

両方の切り札表示を `role="img"` ＋ `aria-label`（例:「切り札: ダイヤ」）でラップし、記号ノードは `aria-hidden` にして二重読み上げを防止。

## 変更点

- `SuecaPage.tsx`: ヘッダー・サイドバーの切り札表示に `role="img"` ＋ `aria-label`（`t('trump', { suit: スート名 })`）を付与、記号 span を `aria-hidden`（`SUIT_KEYS` マップ追加）
- i18n キー `suitName.{spade,club,heart,diamond}` を ja / en に追加

## 受け入れ条件

- [x] ヘッダーとサイドバーの切り札表示に aria-label が付与される
- [x] 記号ノードが aria-hidden となり二重読み上げされない
- [x] ja/en 両ロケールにスート名キーを追加
- [x] `SuecaPage.test.tsx` で aria-label を検証

## テスト

- `SuecaPage.test.tsx`: サイドバー切り札が `role=img`＋`aria-label="切り札: ダイヤ"`、ヘッダー＋サイドバーで2要素以上を検証（12 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3414