### PR TITLE
feat(twentynine): explain why a disabled bid can't be chosen

### DIFF
--- a/frontend/src/i18n/locales/en/twentynine.json
+++ b/frontend/src/i18n/locales/en/twentynine.json
@@ -41,6 +41,7 @@
   "nextRound": "Next Round",
   "target": "Target: {{points}} game pts",
   "bidPrompt": "Place a bid (only a higher bid is allowed):",
+  "bidDisabledReason": "Must exceed the current highest bid of {{currentBid}}",
   "bid": {
     "pass": "Pass",
     "sixteen": "16",

--- a/frontend/src/i18n/locales/ja/twentynine.json
+++ b/frontend/src/i18n/locales/ja/twentynine.json
@@ -41,6 +41,7 @@
   "nextRound": "次のラウンド",
   "target": "目標: {{points}}ゲーム点",
   "bidPrompt": "入札してください（上回る入札のみ可）:",
+  "bidDisabledReason": "現在の最高ビッド {{currentBid}} を超える必要があります",
   "bid": {
     "pass": "パス",
     "sixteen": "16",

--- a/frontend/src/pages/TwentyNinePage.test.tsx
+++ b/frontend/src/pages/TwentyNinePage.test.tsx
@@ -110,6 +110,21 @@ describe('TwentyNinePage', () => {
     expect(screen.getByTestId('bid-0')).toBeEnabled();
   });
 
+  it('explains why a disabled bid cannot be chosen via title and aria-label', async () => {
+    mockExec.mockResolvedValue(makeTwentyNineState({ bids: [20, 0, 0, 0] }));
+    renderWithProviders(<TwentyNinePage />);
+    const bid16 = await screen.findByTestId('bid-16');
+    const reason = '現在の最高ビッド 20 を超える必要があります';
+    // aria-disabled + reason-bearing aria-label on the button.
+    expect(bid16).toHaveAttribute('aria-disabled', 'true');
+    expect(bid16).toHaveAttribute('aria-label', `16 — ${reason}`);
+    // The hover tooltip lives on the wrapping span (browsers suppress it on disabled buttons).
+    expect(screen.getByTestId('bid-wrap-16')).toHaveAttribute('title', reason);
+    // An enabled bid gets neither a reason label nor a title.
+    expect(screen.getByTestId('bid-24')).not.toHaveAttribute('aria-label');
+    expect(screen.getByTestId('bid-wrap-24')).not.toHaveAttribute('title');
+  });
+
   it('hides the trump suit until it is revealed', async () => {
     // Bid-phase fixture has trumpRevealed false; the trump should read "非公開" (hidden).
     renderWithProviders(<TwentyNinePage />);

--- a/frontend/src/pages/TwentyNinePage.tsx
+++ b/frontend/src/pages/TwentyNinePage.tsx
@@ -346,18 +346,25 @@ function TwentyNinePageContent() {
                   <span className="text-xs text-ds-text-muted self-center mr-1">{t('bidPrompt')}</span>
                   {BIDS.map((b) => {
                     // Pass (0) is always allowed; a non-pass bid must beat the current highest.
-                    const disabled = loading || (b.value !== 0 && b.value <= highestBid);
+                    const tooLow = b.value !== 0 && b.value <= highestBid;
+                    const disabled = loading || tooLow;
+                    const reason = tooLow ? t('bidDisabledReason', { currentBid: highestBid }) : undefined;
+                    // The title lives on the wrapping span: browsers suppress native tooltips on
+                    // disabled buttons, so hovering the span still surfaces the reason.
                     return (
-                      <button
-                        key={b.value}
-                        type="button"
-                        className="px-3 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
-                        onClick={() => handleBid(b.value)}
-                        disabled={disabled}
-                        data-testid={`bid-${b.value}`}
-                      >
-                        {t(b.key)}
-                      </button>
+                      <span key={b.value} title={reason} data-testid={`bid-wrap-${b.value}`}>
+                        <button
+                          type="button"
+                          className="px-3 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
+                          onClick={() => handleBid(b.value)}
+                          disabled={disabled}
+                          aria-disabled={disabled}
+                          aria-label={reason ? `${t(b.key)} — ${reason}` : undefined}
+                          data-testid={`bid-${b.value}`}
+                        >
+                          {t(b.key)}
+                        </button>
+                      </span>
                     );
                   })}
                 </>


### PR DESCRIPTION
## 概要

`TwentyNinePage.tsx` のビッドボタンは `disabled` 属性と `opacity-40` だけで無効化されており、なぜ 16/20 が選べないのか（現在の最高ビッド以下）がスクリーンリーダー／ホバー利用者に伝わらなかった。`FortyFivesPage.tsx` で実装済みの bid-wrap パターンを移植する。

## 変更点

- `TwentyNinePage.tsx`: 各ビッドボタンを `title` 付き span でラップ（ブラウザは disabled ボタン上のネイティブツールチップを抑制するため）、ボタンに `aria-disabled` と理由入り `aria-label`（例:「16 — 現在の最高ビッド 20 を超える必要があります」）を付与
- i18n キー `bidDisabledReason` を ja / en に追加

## 受け入れ条件

- [x] 無効ボタンにホバーで理由ツールチップが表示される（wrap span の `title`）
- [x] `aria-disabled` と理由付き `aria-label` が付与される
- [x] 有効なボタンの挙動は変わらない（`aria-label`/`title` なし）
- [x] `TwentyNinePage.test.tsx` で属性を検証

## テスト

- `TwentyNinePage.test.tsx`: 最高ビッド20時に bid-16 が `aria-disabled=true`＋`aria-label="16 — …"`、wrap span が `title`、有効な bid-24 には付与なしを検証（14 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3420