### PR TITLE
feat(klaverjas): announce live Roem changes to assistive tech

### DIFF
--- a/frontend/src/pages/KlaverjasPage.test.tsx
+++ b/frontend/src/pages/KlaverjasPage.test.tsx
@@ -90,6 +90,28 @@ describe('KlaverjasPage', () => {
     expect(roem).toHaveTextContent('20');
   });
 
+  it('exposes the live Roem panel as a polite live region', async () => {
+    mockExec.mockResolvedValue(makeKlaverjasState({ phase: 0, roundRoem: [20, 0] }));
+    renderWithProviders(<KlaverjasPage />);
+    const roem = await screen.findByTestId('klaverjas-roem');
+    expect(roem).toHaveAttribute('role', 'status');
+    expect(roem).toHaveAttribute('aria-live', 'polite');
+    // No pulse highlight before any increase.
+    expect(roem.className).not.toContain('animate-pulse');
+  });
+
+  it('pulses the Roem panel when the combined Roem total increases', async () => {
+    mockExec.mockResolvedValue(makeKlaverjasState({ phase: 0, roundRoem: [20, 0] }));
+    renderWithProviders(<KlaverjasPage />);
+    const card = await screen.findByAltText('♥ Q');
+    fireEvent.click(card);
+    const playBtn = await screen.findByRole('button', { name: '出す' });
+    // The play resolves to a state with higher Roem (20 → 40), triggering the pulse.
+    mockExec.mockResolvedValue(makeKlaverjasState({ phase: 0, roundRoem: [40, 0] }));
+    fireEvent.click(playBtn);
+    await waitFor(() => expect(screen.getByTestId('klaverjas-roem').className).toContain('animate-pulse'));
+  });
+
   it('falls back to 0 Roem when the array is empty', async () => {
     mockExec.mockResolvedValue(makeKlaverjasState({ phase: 0, roundRoem: [] }));
     renderWithProviders(<KlaverjasPage />);

--- a/frontend/src/pages/KlaverjasPage.tsx
+++ b/frontend/src/pages/KlaverjasPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { klaverjasApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -121,6 +121,22 @@ function KlaverjasPageContent() {
   const { cardWidth, isMobile } = useCardDimensions();
   const phaseNames = usePhaseNames('klaverjas', KLAVERJAS_PHASE_KEYS);
 
+  // Transient pulse whenever the combined Roem (bonus) total grows during a hand —
+  // a scoring-relevant event that is otherwise easy to miss both visually and for SR users.
+  const [roemPulse, setRoemPulse] = useState(false);
+  const prevRoemRef = useRef<number | null>(null);
+  useEffect(() => {
+    const roemTotal = state?.roundRoem ? (state.roundRoem[0] ?? 0) + (state.roundRoem[1] ?? 0) : null;
+    if (roemTotal == null) return;
+    const prev = prevRoemRef.current;
+    prevRoemRef.current = roemTotal;
+    if (prev != null && roemTotal > prev) {
+      setRoemPulse(true);
+      const id = setTimeout(() => setRoemPulse(false), 2500);
+      return () => clearTimeout(id);
+    }
+  }, [state?.roundRoem]);
+
   if (!state)
     return <GameSkeleton gameKey="klaverjas" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 8 }} />;
 
@@ -230,7 +246,14 @@ function KlaverjasPageContent() {
                 {/* Live Roem (bonus) per team, shown throughout the hand to match the CUI's
                     Roem readout; the round-result block below repeats it once the round ends. */}
                 {!(isRoundEnd || isGameEnd) && (
-                  <div className="mb-2 p-2 rounded bg-black/30 text-ds-text-muted text-sm" data-testid="klaverjas-roem">
+                  <div
+                    className={`mb-2 p-2 rounded bg-black/30 text-ds-text-muted text-sm${
+                      roemPulse ? ' motion-safe:animate-pulse ring-1 ring-ds-warning' : ''
+                    }`}
+                    data-testid="klaverjas-roem"
+                    role="status"
+                    aria-live="polite"
+                  >
                     <div className="mb-1 text-ds-text-primary">{t('roem.title')}</div>
                     <div>
                       {t('roundResult.roem', { roemA: state.roundRoem[0] ?? 0, roemB: state.roundRoem[1] ?? 0 })}


### PR DESCRIPTION
## 概要

`KlaverjasPage.tsx` のライブ Roem パネル（`klaverjas-roem`）は単なる div だったため、トリック中にマリッジや連続カードで Roem が加算されても支援技術に通知されず、視覚的にも気付きにくかった。

パネルを `role="status"` ＋ `aria-live="polite"` のライブリージョンにし、合算 Roem が増加した瞬間に `motion-safe:animate-pulse` ＋ リングで一時的に強調する（`SpoilFivePage` の potDelta パターンを流用）。

## 変更点

- `KlaverjasPage.tsx`: Roem パネルに `role="status"`／`aria-live="polite"` を付与。`roundRoem[0]+roundRoem[1]` の合計が増加したら 2.5 秒間パルス表示する effect を追加（`useState`/`useRef`）
- `prefers-reduced-motion` 環境では `motion-safe:` によりアニメーション無効

## 受け入れ条件

- [x] Roem パネルに `role=status` / `aria-live=polite` が付与される
- [x] Roem 増加時に一時的な視覚ハイライトが表示される
- [x] `prefers-reduced-motion` 環境ではアニメーションが無効になる（`motion-safe:`）
- [x] `KlaverjasPage.test.tsx` で属性と増加時挙動を検証

## テスト

- `KlaverjasPage.test.tsx`: `role=status`/`aria-live=polite` の検証、初期状態でパルスなし、プレイで Roem 20→40 に増加した際に `animate-pulse` が付くことを検証（13 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3423