### PR TITLE
feat(marias): announce the marriage banner with spoken suit names

### DIFF
--- a/frontend/src/i18n/locales/en/marias.json
+++ b/frontend/src/i18n/locales/en/marias.json
@@ -17,6 +17,12 @@
   "trick": "Trick {{n}}",
   "trump": "Trump: {{suit}}",
   "marriageAvailable": "Marriage available: {{list}}",
+  "suitName": {
+    "spade": "Spade",
+    "club": "Club",
+    "heart": "Heart",
+    "diamond": "Diamond"
+  },
   "cards": "{{count}} cards",
   "tricks": "{{count}} tricks",
   "currentTrick": "Current Trick",

--- a/frontend/src/i18n/locales/ja/marias.json
+++ b/frontend/src/i18n/locales/ja/marias.json
@@ -17,6 +17,12 @@
   "trick": "トリック {{n}}",
   "trump": "切り札: {{suit}}",
   "marriageAvailable": "マリッジ可能: {{list}}",
+  "suitName": {
+    "spade": "スペード",
+    "club": "クラブ",
+    "heart": "ハート",
+    "diamond": "ダイヤ"
+  },
   "cards": "{{count}}枚",
   "tricks": "{{count}}トリック",
   "currentTrick": "現在のトリック",

--- a/frontend/src/pages/MariasPage.test.tsx
+++ b/frontend/src/pages/MariasPage.test.tsx
@@ -78,6 +78,15 @@ describe('MariasPage', () => {
     await waitFor(() => expect(screen.getByTestId('marias-marriage')).toHaveTextContent('♥ K-Q (+20)'));
   });
 
+  it('announces the marriage banner with a spoken suit name (symbol hidden from SR)', async () => {
+    // Default hand: ♥K + ♥Q with trump ♥ → +40. SR reads the suit name, not the glyph.
+    renderWithProviders(<MariasPage />);
+    const banner = await screen.findByTestId('marias-marriage');
+    expect(banner).toHaveAttribute('role', 'status');
+    expect(banner).toHaveAttribute('aria-live', 'polite');
+    expect(banner).toHaveAttribute('aria-label', 'マリッジ可能: ハート K-Q +40');
+  });
+
   it('shows no marriage banner when the hand has no K-Q pair', async () => {
     mockExec.mockResolvedValue(
       makeMariasState({

--- a/frontend/src/pages/MariasPage.tsx
+++ b/frontend/src/pages/MariasPage.tsx
@@ -35,6 +35,9 @@ import { playerName } from '../utils/playerUtils';
 /** Suit symbols indexed by suit number (1=♠ 2=♣ 3=♥ 4=♦; index 0 unused). */
 const SUIT_SYMBOLS = ['', '♠', '♣', '♥', '♦'] as const;
 
+/** Suit-name i18n keys indexed by suit number (1=♠ 2=♣ 3=♥ 4=♦; index 0 unused). */
+const SUIT_KEYS = ['', 'spade', 'club', 'heart', 'diamond'] as const;
+
 /** Card design string → suit number (1=♠ 2=♣ 3=♥ 4=♦), to align with SUIT_SYMBOLS / trumpSuit. */
 const DESIGN_TO_SUIT: Readonly<Record<string, number>> = { SPADE: 1, CLOVER: 2, HEART: 3, DIAMOND: 4 };
 
@@ -150,7 +153,11 @@ function MariasPageContent() {
           const hasQ = cards.some((c) => DESIGN_TO_SUIT[c.design] === suit && c.value === 12);
           return hasK && hasQ;
         })
-        .map((suit) => ({ symbol: SUIT_SYMBOLS[suit] ?? '?', points: suit === state.trumpSuit ? 40 : 20 }))
+        .map((suit) => ({
+          symbol: SUIT_SYMBOLS[suit] ?? '?',
+          suitKey: SUIT_KEYS[suit],
+          points: suit === state.trumpSuit ? 40 : 20,
+        }))
     : [];
 
   const handleManualReset = () => {
@@ -320,10 +327,22 @@ function MariasPageContent() {
           {/* Footer */}
           <GameFooter className={`${gameTheme.marias.footer} px-4 py-2.5`}>
             {marriages.length > 0 && (
-              <div className="mb-1 text-center text-sm text-ds-accent font-semibold" data-testid="marias-marriage">
-                {t('marriageAvailable', {
-                  list: marriages.map((m) => `${m.symbol} K-Q (+${m.points})`).join('  '),
+              <div
+                className="mb-1 text-center text-sm text-ds-accent font-semibold"
+                data-testid="marias-marriage"
+                role="status"
+                aria-live="polite"
+                aria-label={t('marriageAvailable', {
+                  list: marriages
+                    .map((m) => `${m.suitKey ? t(`suitName.${m.suitKey}`) : m.symbol} K-Q +${m.points}`)
+                    .join('、'),
                 })}
+              >
+                <span aria-hidden="true">
+                  {t('marriageAvailable', {
+                    list: marriages.map((m) => `${m.symbol} K-Q (+${m.points})`).join('  '),
+                  })}
+                </span>
               </div>
             )}
             {humanPlayer && (

--- a/frontend/src/pages/MariasPage.tsx
+++ b/frontend/src/pages/MariasPage.tsx
@@ -333,9 +333,7 @@ function MariasPageContent() {
                 role="status"
                 aria-live="polite"
                 aria-label={t('marriageAvailable', {
-                  list: marriages
-                    .map((m) => `${m.suitKey ? t(`suitName.${m.suitKey}`) : m.symbol} K-Q +${m.points}`)
-                    .join('、'),
+                  list: marriages.map((m) => `${t(`suitName.${m.suitKey}`)} K-Q +${m.points}`).join('、'),
                 })}
               >
                 <span aria-hidden="true">


### PR DESCRIPTION
## 概要

`MariasPage.tsx` のマリッジバナー（`marias-marriage`、PLAY 中に K+Q 保持スートを「♠ K-Q (+40)」形式で表示）は単なる div かつスート記号のみのため、支援技術に通知されず、どのスートのマリッジかも読み上げられなかった。

バナーを `role="status"` ＋ `aria-live="polite"` のライブリージョンにし、`aria-label` にスート名を含む読み上げ用テキスト（例:「マリッジ可能: ハート K-Q +40」）を設定。可視の記号＋点数表示は `aria-hidden` にして維持する。

## 変更点

- `MariasPage.tsx`: バナーに `role="status"`／`aria-live="polite"`、スート名入り `aria-label` を付与。記号テキストは `aria-hidden` の span に。`SUIT_KEYS` マップ追加、`marriages` に `suitKey` を保持
- i18n キー `suitName.{spade,club,heart,diamond}` を ja / en に追加

## 受け入れ条件

- [x] マリッジバナーに `role=status` / `aria-live=polite` が付与される
- [x] スート名が読み上げ可能なテキストで提供される（`aria-label`）
- [x] 視覚表示（記号+点数）は維持される
- [x] `MariasPage.test.tsx` で属性を検証

## テスト

- `MariasPage.test.tsx`: バナーの `role=status`/`aria-live=polite`/`aria-label="マリッジ可能: ハート K-Q +40"` を検証（12 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3429