### PR TITLE
feat(sedma): mark teams with a colour-independent label

### DIFF
--- a/frontend/src/pages/SedmaPage.test.tsx
+++ b/frontend/src/pages/SedmaPage.test.tsx
@@ -106,4 +106,17 @@ describe('SedmaPage', () => {
     expect(screen.getByTestId('sedma-player-1')).toHaveClass('border-ds-error');
     expect(screen.getByTestId('sedma-player-3')).toHaveAttribute('data-team', '1');
   });
+
+  it('marks each team with a colour-independent label (badge + sr-only name)', async () => {
+    renderWithProviders(<SedmaPage />);
+    await waitFor(() => expect(screen.getByTestId('sedma-player-0')).toBeInTheDocument());
+    // Team A (even id): visible 'A' badge + sr-only 'チームA'.
+    const teamA = screen.getByTestId('sedma-player-0');
+    expect(teamA).toHaveTextContent('A');
+    expect(teamA).toHaveTextContent('チームA');
+    // Team B (odd id): visible 'B' badge + sr-only 'チームB'.
+    const teamB = screen.getByTestId('sedma-player-1');
+    expect(teamB).toHaveTextContent('B');
+    expect(teamB).toHaveTextContent('チームB');
+  });
 });

--- a/frontend/src/pages/SedmaPage.tsx
+++ b/frontend/src/pages/SedmaPage.tsx
@@ -138,6 +138,7 @@ function SedmaPageContent() {
   // Shared by the mobile (<details>) and desktop layouts.
   const renderPlayerRow = (p: (typeof state.players)[number]) => {
     const team = p.id % 2;
+    const teamName = team === 0 ? t('team.a') : t('team.b');
     return (
       <div
         key={p.id}
@@ -147,6 +148,17 @@ function SedmaPageContent() {
           team === 0 ? 'border-ds-info' : 'border-ds-error'
         }`}
       >
+        {/* Colour-independent team marker (WCAG 1.4.1): a visible A/B badge plus an
+            sr-only full team name, so team membership isn't conveyed by colour alone. */}
+        <span
+          className={`inline-block mr-1 px-1 rounded text-xs font-bold text-white ${
+            team === 0 ? 'bg-ds-info' : 'bg-ds-error'
+          }`}
+          aria-hidden="true"
+        >
+          {team === 0 ? 'A' : 'B'}
+        </span>
+        <span className="sr-only">{teamName}: </span>
         {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} | {t('tricks', { count: p.trickCount })}
       </div>
     );


### PR DESCRIPTION
## 概要

`SedmaPage.tsx` の `renderPlayerRow` はチーム A/B を左ボーダーの色（青/赤）だけで区別しており、WCAG 1.4.1（色だけに依存しない）に反していた。色覚特性のあるユーザーや支援技術にはチーム所属が伝わらない。

各プレイヤー行に、可視の A/B バッジ（色付き）と sr-only のチーム名（`team.a`/`team.b`）を追加。既存の色ボーダーは維持する。

## 変更点

- `SedmaPage.tsx`: 各行に `aria-hidden` の A/B バッジ ＋ `sr-only` のチーム名（例:「チームA: 」）を追加

## 受け入れ条件

- [x] プレイヤー行に色以外のチーム識別（テキスト/バッジ）が追加される
- [x] スクリーンリーダーでチーム所属が読み上げられる（sr-only テキスト）
- [x] 既存の色ボーダーは維持される
- [x] `SedmaPage.test.tsx` でラベルを検証

## テスト

- `SedmaPage.test.tsx`: team-0 行が 'A'＋'チームA'、team-1 行が 'B'＋'チームB' を含むことを検証（10 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3432