### PR TITLE
feat(solowhist): announce the contract when it is decided

### DIFF
--- a/frontend/src/pages/SoloWhistPage.test.tsx
+++ b/frontend/src/pages/SoloWhistPage.test.tsx
@@ -124,6 +124,24 @@ describe('SoloWhistPage', () => {
     await waitFor(() => expect(screen.getByTestId('sw-highest-bid')).toHaveTextContent('まだ入札なし'));
   });
 
+  it('exposes the declarer line as a polite live region', async () => {
+    renderWithProviders(<SoloWhistPage />);
+    const line = await screen.findByTestId('solowhist-declarer');
+    expect(line).toHaveAttribute('role', 'status');
+    expect(line).toHaveAttribute('aria-live', 'polite');
+    expect(line.className).not.toContain('animate-pulse');
+  });
+
+  it('pulses the declarer line when the contract is decided', async () => {
+    // Mount with an undecided contract, then a bid resolves it (declarerIdx -1 → 0).
+    mockExec.mockResolvedValue(makeSoloWhistState({ declarerIdx: -1 }));
+    renderWithProviders(<SoloWhistPage />);
+    const bidSolo = await screen.findByTestId('bid-1');
+    mockExec.mockResolvedValue(makeSoloWhistState({ declarerIdx: 0, contract: 1, isHumanBidTurn: false }));
+    fireEvent.click(bidSolo);
+    await waitFor(() => expect(screen.getByTestId('solowhist-declarer').className).toContain('animate-pulse'));
+  });
+
   it('renders the play phase with the human cards and the declarer badge', async () => {
     mockExec.mockResolvedValue(playPhaseState);
     renderWithProviders(<SoloWhistPage />);

--- a/frontend/src/pages/SoloWhistPage.tsx
+++ b/frontend/src/pages/SoloWhistPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { soloWhistApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -128,6 +128,22 @@ function SoloWhistPageContent() {
   const { cardWidth, isMobile } = useCardDimensions();
   const phaseNames = usePhaseNames('solowhist', SOLO_WHIST_PHASE_KEYS);
 
+  // Transient pulse when the contract is decided (declarerIdx: -1 → a real seat) —
+  // a plan-shaping event (esp. misère) that's otherwise easy to miss in the small text row.
+  const [contractPulse, setContractPulse] = useState(false);
+  const prevDeclarerRef = useRef<number | null>(null);
+  useEffect(() => {
+    const declarer = state?.declarerIdx ?? null;
+    if (declarer == null) return;
+    const prev = prevDeclarerRef.current;
+    prevDeclarerRef.current = declarer;
+    if (prev != null && prev < 0 && declarer >= 0) {
+      setContractPulse(true);
+      const id = setTimeout(() => setContractPulse(false), 2500);
+      return () => clearTimeout(id);
+    }
+  }, [state?.declarerIdx]);
+
   if (!state)
     return <GameSkeleton gameKey="solowhist" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 13 }} />;
 
@@ -223,7 +239,14 @@ function SoloWhistPageContent() {
               <span>{t('target', { points: state.config.targetPoints })}</span>
             </div>
 
-            <div className="text-ds-text-muted text-center mb-2 text-sm">
+            <div
+              className={`text-ds-text-muted text-center mb-2 text-sm${
+                contractPulse ? ' motion-safe:animate-pulse text-ds-accent font-semibold' : ''
+              }`}
+              data-testid="solowhist-declarer"
+              role="status"
+              aria-live="polite"
+            >
               {state.declarerIdx >= 0
                 ? t('declarerLine', {
                     name: playerName(state.declarerIdx, state.players[state.declarerIdx]?.isHuman ?? false),


### PR DESCRIPTION
## 概要

`SoloWhistPage.tsx` の declarerLine（契約者と契約名を示す中央行）は素の div のため、ビッド中に CPU が契約を確定しても支援技術に通知されず、小さな text-sm 表示のみで確定の瞬間が分かりにくかった。契約の種類（特にミゼール）はその後のプレイ方針を左右する重要情報。

declarerLine に `role="status"` ／ `aria-live="polite"` を付与し、`declarerIdx` が -1 から確定値に変わった瞬間に `motion-safe:animate-pulse` で数秒間強調する（`SpoilFivePage` の useRef+useEffect 遷移検知パターン）。

## 変更点

- `SoloWhistPage.tsx`: declarerLine に `data-testid="solowhist-declarer"`／`role="status"`／`aria-live="polite"` を付与。`declarerIdx` の -1→確定遷移を検知して 2.5 秒パルスする effect を追加（`useState`/`useRef`）
- `prefers-reduced-motion` 環境では `motion-safe:` によりアニメーション無効

## 受け入れ条件

- [x] declarerLine に `role=status` / `aria-live=polite` が付与される
- [x] 契約確定時に視覚的な一時強調が表示される
- [x] `prefers-reduced-motion` でアニメーションが無効化される（`motion-safe:`）
- [x] `SoloWhistPage.test.tsx` で検証

## テスト

- `SoloWhistPage.test.tsx`: `role=status`/`aria-live=polite`、初期状態でパルスなし、ビッドで declarerIdx -1→0 に確定した際に `animate-pulse` が付くことを検証（14 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3435