### PR TITLE
feat(nap): show declarer trick progress and unreachable contract

### DIFF
--- a/frontend/src/i18n/locales/en/nap.json
+++ b/frontend/src/i18n/locales/en/nap.json
@@ -31,6 +31,8 @@
   "contract": "Contract: {{contract}}",
   "contractUndecided": "Contract: undecided",
   "declarerLine": "Declarer: {{name}} — {{contract}}",
+  "declarerProgress": "Declarer: {{won}} / {{needed}} tricks (remaining {{remaining}})",
+  "contractUnreachable": "Contract unreachable",
   "bidLabel": "Bid",
   "playButton": "Play",
   "nextTrick": "Next Trick",

--- a/frontend/src/i18n/locales/ja/nap.json
+++ b/frontend/src/i18n/locales/ja/nap.json
@@ -31,6 +31,8 @@
   "contract": "契約: {{contract}}",
   "contractUndecided": "契約: 未決定",
   "declarerLine": "宣言者: {{name}} — {{contract}}",
+  "declarerProgress": "宣言者: {{won}} / {{needed}} トリック（残り{{remaining}}トリック）",
+  "contractUnreachable": "達成不可",
   "bidLabel": "入札",
   "playButton": "出す",
   "nextTrick": "次のトリック",

--- a/frontend/src/pages/NapPage.test.tsx
+++ b/frontend/src/pages/NapPage.test.tsx
@@ -144,6 +144,39 @@ describe('NapPage', () => {
     expect(screen.queryByTestId('bid-0')).not.toBeInTheDocument();
   });
 
+  it('shows the declarer trick progress toward the contract during play', async () => {
+    // contract 3, declarer won 0, all 5 tricks still to play.
+    mockExec.mockResolvedValue(playPhaseState);
+    renderWithProviders(<NapPage />);
+    const progress = await screen.findByTestId('nap-declarer-progress');
+    expect(progress).toHaveTextContent('宣言者: 0 / 3 トリック（残り5トリック）');
+    expect(progress).toHaveAttribute('role', 'status');
+    expect(progress).not.toHaveTextContent('達成不可');
+    expect(progress.className).not.toContain('text-ds-error');
+  });
+
+  it('marks the contract as unreachable once too few tricks remain', async () => {
+    // contract 4, declarer has 0 tricks, opponents have taken 2 → only 3 remain, so 4 is impossible.
+    const unreachableState = makeNapState({
+      phase: 1,
+      declarerIdx: 0,
+      contract: 4,
+      isHumanBidTurn: false,
+      isHumanTurn: true,
+      players: [
+        { id: 0, isHuman: true, cardCount: 3, cards: [], trickCount: 0, score: 0, isDeclarer: true },
+        { id: 1, isHuman: false, cardCount: 3, cards: [], trickCount: 1, score: 0, isDeclarer: false },
+        { id: 2, isHuman: false, cardCount: 3, cards: [], trickCount: 1, score: 0, isDeclarer: false },
+        { id: 3, isHuman: false, cardCount: 3, cards: [], trickCount: 0, score: 0, isDeclarer: false },
+      ],
+    });
+    mockExec.mockResolvedValue(unreachableState);
+    renderWithProviders(<NapPage />);
+    const progress = await screen.findByTestId('nap-declarer-progress');
+    expect(progress).toHaveTextContent('達成不可');
+    expect(progress.className).toContain('text-ds-error');
+  });
+
   it('renders trick end with the next trick button', async () => {
     mockExec.mockResolvedValue(trickEndState);
     renderWithProviders(<NapPage />);

--- a/frontend/src/pages/NapPage.tsx
+++ b/frontend/src/pages/NapPage.tsx
@@ -35,6 +35,9 @@ import { playerName } from '../utils/playerUtils';
 /** Suit symbols indexed by suit number (1=♠ 2=♣ 3=♥ 4=♦; index 0 = no trump). */
 const SUIT_SYMBOLS = ['', '♠', '♣', '♥', '♦'] as const;
 
+/** Total tricks in a Nap round (5 cards dealt to each player). */
+const NAP_TOTAL_TRICKS = 5;
+
 /** Maps a Nap contract/bid value (0/2/3/4/5) to its i18n key suffix. */
 const CONTRACT_KEYS: Readonly<Record<number, string>> = {
   [NapContract.PASS]: 'pass',
@@ -161,6 +164,17 @@ function NapPageContent() {
   const contractName =
     state.declarerIdx >= 0 ? t(`contractName.${CONTRACT_KEYS[state.contract] ?? 'pass'}`) : t('contractUndecided');
 
+  // Declarer progress toward the contract. In Nap a round is 5 tricks and the
+  // contract value (2/3/4/5) is exactly the number of tricks the declarer must
+  // win, so we can show won/needed and whether it's still reachable.
+  const declarer = state.declarerIdx >= 0 ? state.players[state.declarerIdx] : undefined;
+  const tricksPlayed = state.players.reduce((sum, p) => sum + p.trickCount, 0);
+  const tricksRemaining = NAP_TOTAL_TRICKS - tricksPlayed;
+  const declarerWon = declarer?.trickCount ?? 0;
+  const tricksStillNeeded = state.contract - declarerWon;
+  const contractUnreachable = tricksStillNeeded > tricksRemaining;
+  const showDeclarerProgress = (isPlayPhase || isTrickEnd) && state.declarerIdx >= 0;
+
   const handleManualReset = () => {
     hideActionLog();
     reset();
@@ -237,6 +251,22 @@ function NapPageContent() {
                   })
                 : t('contractUndecided')}
             </div>
+
+            {showDeclarerProgress && (
+              <div
+                className={`text-center mb-2 text-sm ${contractUnreachable ? 'text-ds-error font-semibold' : 'text-ds-text-muted'}`}
+                data-testid="nap-declarer-progress"
+                role="status"
+                aria-live="polite"
+              >
+                {t('declarerProgress', {
+                  won: declarerWon,
+                  needed: state.contract,
+                  remaining: tricksRemaining,
+                })}
+                {contractUnreachable && <span className="ml-2">{t('contractUnreachable')}</span>}
+              </div>
+            )}
 
             <div className={lgTwoColGrid}>
               {/* Left: play area */}


### PR DESCRIPTION
## 概要

`NapPage.tsx` は契約名と各プレイヤーの獲得トリック数を表示するが、5 トリック制の Nap で宣言者が契約達成まであと何トリック必要か、残りトリックで達成可能かを示す UI がなかった。NapContract の値（2/3/4/5）はそのまま必要トリック数であり、`trickCount` と組み合わせれば達成可否も判定できる。

declarerLine の下に「宣言者: 獲得 / 必要 トリック（残りNトリック）」の進捗行（`role="status"`／`aria-live="polite"`）を追加。必要残数 > 残りトリック数になった時点で「達成不可」を error 色で表示する。

## 変更点

- `NapPage.tsx`: `NAP_TOTAL_TRICKS=5` を追加。宣言者の獲得トリック・残りトリック・達成可否を計算し、PLAY/TRICK_END フェーズかつ契約確定時に進捗行を表示（達成不可時は `text-ds-error` ＋「達成不可」）
- i18n キー `declarerProgress`／`contractUnreachable` を ja / en に追加

## 受け入れ条件

- [x] 宣言者の獲得トリック数と契約必要数が表示される
- [x] 達成不可能になった時点で明示される（error 色）
- [x] ja/en 両ロケールに文言を追加
- [x] `NapPage.test.tsx` に達成可否のテストを追加

## テスト

- `NapPage.test.tsx`: 進捗行が「宣言者: 0 / 3 トリック（残り5トリック）」を表示、達成不可状態（契約4・残り3）で「達成不可」＋`text-ds-error` を検証（14 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3441