### PR TITLE
feat(spoilfive): announce pot changes to screen readers

### DIFF
--- a/frontend/src/i18n/locales/en/spoilfive.json
+++ b/frontend/src/i18n/locales/en/spoilfive.json
@@ -17,6 +17,7 @@
   "trump": "Trump {{suit}}",
   "pot": "Pot {{n}}",
   "potIncrease": "+{{n}}",
+  "potIncreaseAnnounce": "Pot +{{delta}} (total {{total}})",
   "target": "Target {{n}}",
   "cards": "{{count}} cards",
   "roundTricks": "{{count}} round tricks",

--- a/frontend/src/i18n/locales/ja/spoilfive.json
+++ b/frontend/src/i18n/locales/ja/spoilfive.json
@@ -17,6 +17,7 @@
   "trump": "切り札 {{suit}}",
   "pot": "ポット {{n}}",
   "potIncrease": "+{{n}}",
+  "potIncreaseAnnounce": "ポット +{{delta}}（合計 {{total}}）",
   "target": "目標 {{n}}点",
   "cards": "{{count}}枚",
   "roundTricks": "今ラウンド {{count}}トリック",

--- a/frontend/src/pages/SpoilFivePage.test.tsx
+++ b/frontend/src/pages/SpoilFivePage.test.tsx
@@ -79,6 +79,23 @@ describe('SpoilFivePage', () => {
     fireEvent.click(playBtn);
     const delta = await screen.findByTestId('spoilfive-pot-delta');
     expect(delta).toHaveTextContent('+5');
+    // The visible pulse is decorative (colour-only, transient) → hidden from SR.
+    expect(delta).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('announces the pot change to screen readers with delta and total', async () => {
+    renderWithProviders(<SpoilFivePage />);
+    const card = await screen.findByAltText('♥ Q');
+    const announce = screen.getByTestId('spoilfive-pot-announce');
+    expect(announce).toHaveAttribute('role', 'status');
+    expect(announce).toHaveAttribute('aria-live', 'polite');
+    // Empty until the pot grows.
+    expect(announce).toHaveTextContent('');
+    fireEvent.click(card);
+    const playBtn = await screen.findByRole('button', { name: '出す' });
+    mockExec.mockResolvedValue(spoilState); // pot 5 -> 10
+    fireEvent.click(playBtn);
+    await waitFor(() => expect(screen.getByTestId('spoilfive-pot-announce')).toHaveTextContent('ポット +5（合計 10）'));
   });
 
   it('renders trick end with the next trick button', async () => {

--- a/frontend/src/pages/SpoilFivePage.tsx
+++ b/frontend/src/pages/SpoilFivePage.tsx
@@ -242,10 +242,17 @@ function SpoilFivePageContent() {
                 <span
                   data-testid="spoilfive-pot-delta"
                   className="ml-1 text-sm font-semibold text-ds-warning motion-safe:animate-pulse"
+                  aria-hidden="true"
                 >
                   {t('potIncrease', { n: potDelta })}
                 </span>
               )}
+              {/* Screen-reader announcement of the pot change: a self-contained live
+                  region so a spoiled round carrying the pot forward is spoken even
+                  though the visual "+NN" pulse is transient and colour-only. */}
+              <span className="sr-only" role="status" aria-live="polite" data-testid="spoilfive-pot-announce">
+                {potDelta > 0 ? t('potIncreaseAnnounce', { delta: potDelta, total: state.pot }) : ''}
+              </span>
             </div>
 
             <div className={lgTwoColGrid}>


### PR DESCRIPTION
## 概要

`SpoilFivePage.tsx` の potDelta span（`spoilfive-pot-delta`）は `motion-safe:animate-pulse` の視覚配慮はあるが `role`／`aria-live` がなく、スクリーンリーダー利用者はスポイル（流局）でポットが持ち越された事実を知る手段がなかった。

potDelta 表示とは別に、`sr-only` の `role="status"`／`aria-live="polite"` ライブリージョンを追加し、「ポット +15（合計 45）」のような完結した読み上げテキストを提供。可視のパルス span は装飾（色・一時表示のみ）なので `aria-hidden` にする。

## 変更点

- `SpoilFivePage.tsx`: `spoilfive-pot-announce` の sr-only ライブリージョン（増分＋合計）を追加。可視 potDelta span を `aria-hidden`
- i18n キー `potIncreaseAnnounce` を ja / en に追加

## 受け入れ条件

- [x] ポット増加時にスクリーンリーダーへ通知される（role=status/aria-live=polite）
- [x] 読み上げテキストに増分と合計が含まれる
- [x] 既存のアニメーション表示は維持される
- [x] `SpoilFivePage.test.tsx` で属性を検証

## テスト

- `SpoilFivePage.test.tsx`: 可視 delta が `aria-hidden`、announce 領域が `role=status`/`aria-live=polite`＋初期空、ポット 5→10 で「ポット +5（合計 10）」を検証（12 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3447