### PR TITLE
feat(bezique): add spoken labels and a group for meld buttons

### DIFF
--- a/frontend/src/i18n/locales/en/bezique.json
+++ b/frontend/src/i18n/locales/en/bezique.json
@@ -31,6 +31,14 @@
   "nextRound": "Next Deal",
   "target": "Target: {{points}} pts",
   "meldPrompt": "Choose a meld to declare:",
+  "meldMarriageName": "{{suit}} {{name}}",
+  "meldDeclareLabel": "Declare {{name}} +{{points}} pts",
+  "suitName": {
+    "spade": "Spade",
+    "club": "Club",
+    "heart": "Heart",
+    "diamond": "Diamond"
+  },
   "meldShort": "meld",
   "meldName": {
     "marriage": "Marriage (K+Q)",

--- a/frontend/src/i18n/locales/ja/bezique.json
+++ b/frontend/src/i18n/locales/ja/bezique.json
@@ -31,6 +31,14 @@
   "nextRound": "次のディール",
   "target": "目標: {{points}}点",
   "meldPrompt": "宣言するメルドを選んでください:",
+  "meldMarriageName": "{{suit}}の{{name}}",
+  "meldDeclareLabel": "{{name}}を宣言 +{{points}}点",
+  "suitName": {
+    "spade": "スペード",
+    "club": "クラブ",
+    "heart": "ハート",
+    "diamond": "ダイヤ"
+  },
   "meldShort": "メルド",
   "meldName": {
     "marriage": "結婚 (K+Q)",

--- a/frontend/src/pages/BeziquePage.test.tsx
+++ b/frontend/src/pages/BeziquePage.test.tsx
@@ -103,6 +103,20 @@ describe('BeziquePage', () => {
     expect(screen.getByTestId('meld-skip')).toBeInTheDocument();
   });
 
+  it('gives each meld button a suit-named aria-label inside a labelled group', async () => {
+    mockExec.mockResolvedValue(meldPhaseState);
+    renderWithProviders(<BeziquePage />);
+    // Marriage of ♠ (type 0, suit 1) reads the suit by name, not the glyph.
+    const marriage = await screen.findByTestId('meld-0');
+    expect(marriage).toHaveAttribute('aria-label', 'スペードの結婚 (K+Q)を宣言 +20点');
+    // A non-suited meld (bezique) omits the suit.
+    expect(screen.getByTestId('meld-1')).toHaveAttribute('aria-label', 'ベジーク (♠Q+♦J)を宣言 +40点');
+    // The melds are bundled in a labelled group.
+    const group = screen.getByRole('group', { name: '宣言するメルドを選んでください:' });
+    expect(group).toBeInTheDocument();
+    expect(group).toContainElement(marriage);
+  });
+
   it('dispatches a meld declaration when a meld button is clicked', async () => {
     mockExec.mockResolvedValue(meldPhaseState);
     renderWithProviders(<BeziquePage />);

--- a/frontend/src/pages/BeziquePage.tsx
+++ b/frontend/src/pages/BeziquePage.tsx
@@ -35,6 +35,9 @@ import type { CliGameConfig } from '../utils/cli/types';
 /** Suit symbols indexed by suit number (1=♠ 2=♣ 3=♥ 4=♦; index 0 = undeclared). */
 const SUIT_SYMBOLS = ['', '♠', '♣', '♥', '♦'] as const;
 
+/** Suit-name i18n key suffixes indexed by suit number (1=♠ 2=♣ 3=♥ 4=♦; index 0 unused). */
+const SUIT_KEYS = ['', 'spade', 'club', 'heart', 'diamond'] as const;
+
 /** Meld-name i18n key suffixes indexed by meld type (0=marriage … 5=four jacks). */
 const MELD_NAME_KEYS = ['marriage', 'bezique', 'fourAces', 'fourKings', 'fourQueens', 'fourJacks'] as const;
 
@@ -139,6 +142,16 @@ function BeziquePageContent() {
     const name = t(`meldName.${MELD_NAME_KEYS[m.type] ?? 'marriage'}`);
     const suit = m.type === 0 && m.suit >= 1 && m.suit <= 4 ? ` ${SUIT_SYMBOLS[m.suit]}` : '';
     return `${name}${suit} (+${m.points})`;
+  };
+
+  /** Builds a screen-reader label naming the suit (a marriage is suit-specific) and points. */
+  const meldAriaLabel = (m: BeziqueMeld): string => {
+    const name = t(`meldName.${MELD_NAME_KEYS[m.type] ?? 'marriage'}`);
+    const fullName =
+      m.type === 0 && m.suit >= 1 && m.suit <= 4
+        ? t('meldMarriageName', { suit: t(`suitName.${SUIT_KEYS[m.suit]}`), name })
+        : name;
+    return t('meldDeclareLabel', { name: fullName, points: m.points });
   };
 
   const handleManualReset = () => {
@@ -329,19 +342,27 @@ function BeziquePageContent() {
               )}
               {isHumanMeldTurn && (
                 <>
-                  <span className="text-xs text-ds-text-muted self-center mr-1">{t('meldPrompt')}</span>
-                  {state.availableMelds.map((m, i) => (
-                    <button
-                      key={`${m.type}-${m.suit}`}
-                      type="button"
-                      className="px-3 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
-                      onClick={() => handleMeld(i)}
-                      disabled={loading}
-                      data-testid={`meld-${i}`}
-                    >
-                      {meldLabel(m)}
-                    </button>
-                  ))}
+                  {/* Fieldset groups the meld buttons; the sr-only legend names the group
+                      (the visible prompt is aria-hidden to avoid a duplicate announcement). */}
+                  <fieldset className="contents">
+                    <legend className="sr-only">{t('meldPrompt')}</legend>
+                    <span aria-hidden="true" className="text-xs text-ds-text-muted self-center mr-1">
+                      {t('meldPrompt')}
+                    </span>
+                    {state.availableMelds.map((m, i) => (
+                      <button
+                        key={`${m.type}-${m.suit}`}
+                        type="button"
+                        className="px-3 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
+                        onClick={() => handleMeld(i)}
+                        disabled={loading}
+                        data-testid={`meld-${i}`}
+                        aria-label={meldAriaLabel(m)}
+                      >
+                        {meldLabel(m)}
+                      </button>
+                    ))}
+                  </fieldset>
                   <button
                     type="button"
                     className={btnSuccess}


### PR DESCRIPTION
## 概要

`BeziquePage.tsx` のメルドボタンはスートを SUIT_SYMBOLS の記号のみで表示していたため、スクリーンリーダーではどのスートのマリッジか判別できず、メルドボタン群のグループ文脈も伝わらなかった。

各メルドボタンにスート名入りの `aria-label`（例:「スペードの結婚 (K+Q)を宣言 +20点」）を付与し、ボタン群を `<fieldset>`（sr-only の `<legend>` がグループ名）で構造化する。

## 変更点

- `BeziquePage.tsx`: `meldAriaLabel` を追加（マリッジはスート名を含む）。メルドボタンを `fieldset` ＋ sr-only `legend`（`meldPrompt`）で包み、可視プロンプト span は `aria-hidden`。`SUIT_KEYS` 追加
- i18n キー `meldMarriageName`／`meldDeclareLabel`／`suitName.*` を ja / en に追加

## 受け入れ条件

- [x] 全メルドボタンにスート名入りの aria-label が付与される
- [x] メルドボタン群がグループ（fieldset/legend）として構造化される
- [x] 視覚表示は変更しない
- [x] `BeziquePage.test.tsx` で aria-label を検証

## テスト

- `BeziquePage.test.tsx`: ♠マリッジが `aria-label="スペードの結婚 (K+Q)を宣言 +20点"`、非スートメルドが suit なし、`role=group`（fieldset/legend）に内包されることを検証（13 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3453