### PR TITLE
feat(ecarte): show the discard limit in the CUI exchange prompt

### DIFF
--- a/internal/adapter/presenter/EcarteCuiPresenter.go
+++ b/internal/adapter/presenter/EcarteCuiPresenter.go
@@ -110,7 +110,20 @@ func ecarteWritePrompt(sb *strings.Builder, b interfaces.EcarteGame) {
 	case domain.EcartePhaseExchange:
 		sb.WriteString(i18n.Tf("ecarte.promptCurrentPlayer",
 			"name", cuiPlayerName(b.GetPlayer(currentIdx), currentIdx)) + "\n")
-		sb.WriteString(i18n.T(ecarteNegPromptKey(b.GetNegStep())) + "\n")
+		step := b.GetNegStep()
+		sb.WriteString(i18n.T(ecarteNegPromptKey(step)) + "\n")
+		// On a discard step, spell out the upper bound (you cannot discard more
+		// cards than the stock can replace) so the player need not compute it.
+		if step == domain.EcarteNegElderDiscard || step == domain.EcarteNegDealerDiscard {
+			stock := b.GetStockRemaining()
+			maxDiscard := stock
+			if player := b.GetPlayer(currentIdx); player != nil && player.GetCardsSize() < maxDiscard {
+				maxDiscard = player.GetCardsSize()
+			}
+			sb.WriteString(i18n.Tf("ecarte.promptDiscardLimit",
+				"max", strconv.Itoa(maxDiscard),
+				"stock", strconv.Itoa(stock)) + "\n")
+		}
 	case domain.EcartePhasePlay:
 		sb.WriteString(i18n.Tf("ecarte.promptCurrentPlayer",
 			"name", cuiPlayerName(b.GetPlayer(currentIdx), currentIdx)) + "\n")

--- a/internal/adapter/presenter/EcarteCuiPresenter_test.go
+++ b/internal/adapter/presenter/EcarteCuiPresenter_test.go
@@ -93,16 +93,40 @@ func TestEcarteCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, out, "拒否")
 	})
 
-	t.Run("exchange phase discard prompt", func(t *testing.T) {
+	t.Run("exchange phase discard prompt shows the limit (hand < stock)", func(t *testing.T) {
 		trump := domain.NewCard(domain.CardDesignSpade, 13, false)
-		m, _ := setupEcarteCuiMockWithPlayers(trump)
+		m, players := setupEcarteCuiMockWithPlayers(trump)
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
 		m.On("GetPhase").Return(domain.EcartePhaseExchange)
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetNegStep")
 		m.On("GetNegStep").Return(domain.EcarteNegElderDiscard)
+		// Elder (seat 0) holds 5 cards; stock is 21 → the hand caps the discard at 5.
+		for range 5 {
+			players[0].AddCard(domain.NewCard(domain.CardDesignClover, 7, false))
+		}
 
 		out := p.Output(m, nil)
 		assert.Contains(t, out, "discard <idx")
+		assert.Contains(t, out, "最大5枚")
+		assert.Contains(t, out, "山札残21")
+	})
+
+	t.Run("exchange phase discard limit is capped by the stock (stock < hand)", func(t *testing.T) {
+		trump := domain.NewCard(domain.CardDesignSpade, 13, false)
+		m, players := setupEcarteCuiMockWithPlayers(trump)
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.EcartePhaseExchange)
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetNegStep")
+		m.On("GetNegStep").Return(domain.EcarteNegDealerDiscard)
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetStockRemaining")
+		m.On("GetStockRemaining").Return(2)
+		for range 5 {
+			players[0].AddCard(domain.NewCard(domain.CardDesignClover, 7, false))
+		}
+
+		out := p.Output(m, nil)
+		assert.Contains(t, out, "最大2枚") // stock (2) < hand (5)
+		assert.Contains(t, out, "山札残2")
 	})
 
 	t.Run("trump-none line when stock exhausted", func(t *testing.T) {

--- a/internal/i18n/locales/en/ecarte.json
+++ b/internal/i18n/locales/en/ecarte.json
@@ -16,6 +16,7 @@
   "promptElderDecide": "propose... propose exchange / stand... play it out",
   "promptDealerRespond": "accept... accept the proposal / refuse... refuse the proposal",
   "promptDiscard": "discard <idx...>... choose cards to exchange",
+  "promptDiscardLimit": "You may discard up to {{max}} card(s) (stock: {{stock}})",
   "promptPlay": "play <idx>... play a card",
   "promptRoundEnd": "Deal complete",
   "promptRoundEndHelp": "next... go to the next deal",

--- a/internal/i18n/locales/ja/ecarte.json
+++ b/internal/i18n/locales/ja/ecarte.json
@@ -16,6 +16,7 @@
   "promptElderDecide": "propose・・・交換を提案 / stand・・・勝負する",
   "promptDealerRespond": "accept・・・提案を承諾 / refuse・・・提案を拒否",
   "promptDiscard": "discard <idx...>・・・捨て札を選んで引き直す",
+  "promptDiscardLimit": "捨てる枚数は最大{{max}}枚です (山札残{{stock}})",
   "promptPlay": "play <idx>・・・カードを出す",
   "promptRoundEnd": "ディール終了",
   "promptRoundEndHelp": "next・・・次のディールへ",


### PR DESCRIPTION
## 概要

`EcarteCuiPresenter.go` の `ecarteWritePrompt` は交換フェーズの Discard ステップで共通の `promptDiscard` 1 行を出すだけで、何枚まで捨てられるか（山札残数による上限）を明示していなかった。プレイヤーが対応関係を自分で計算する必要があった。

Discard ステップ（elder/dealer）で、上限枚数（手札枚数と山札残数の小さい方）とその根拠の山札残数を案内する行を追加する。

## 変更点

- `EcarteCuiPresenter.go`: Exchange フェーズの discard ステップ時に `promptDiscardLimit`（`max` = min(手札, 山札残), `stock` = 山札残）を追加出力
- i18n キー `promptDiscardLimit` を ja / en に追加

## 受け入れ条件

- [x] Discard プロンプトに捨て札可能な上限枚数が表示される
- [x] 山札残数が根拠として併記される
- [x] ja/en 両ロケールにキーを追加
- [x] `EcarteCuiPresenter_test.go` にテストを追加（手札 < 山札 / 山札 < 手札 の両ケース）

## テスト

- `EcarteCuiPresenter_test.go`: 手札5・山札21→「最大5枚/山札残21」、山札2・手札5→「最大2枚/山札残2」を検証。`ecarteWritePrompt` 100% coverage / `golangci-lint` 0 issues

Closes #3456