### PR TITLE
feat(threecardbrag): give the raise steppers meaningful labels

### DIFF
--- a/frontend/src/i18n/locales/en/threecardbrag.json
+++ b/frontend/src/i18n/locales/en/threecardbrag.json
@@ -43,6 +43,8 @@
   "betButton": "Bet ({{amount}})",
   "raiseButton": "Raise ({{amount}})",
   "raisePrompt": "Raise to:",
+  "raiseDecrease": "Decrease raise amount",
+  "raiseIncrease": "Increase raise amount",
   "foldButton": "Fold",
   "showButton": "Show",
   "nextRound": "Next Deal",

--- a/frontend/src/i18n/locales/ja/threecardbrag.json
+++ b/frontend/src/i18n/locales/ja/threecardbrag.json
@@ -43,6 +43,8 @@
   "betButton": "ベット ({{amount}})",
   "raiseButton": "レイズ ({{amount}})",
   "raisePrompt": "レイズ額:",
+  "raiseDecrease": "レイズ額を減らす",
+  "raiseIncrease": "レイズ額を増やす",
   "foldButton": "フォールド",
   "showButton": "ショー",
   "nextRound": "次のディール",

--- a/frontend/src/pages/ThreeCardBragPage.test.tsx
+++ b/frontend/src/pages/ThreeCardBragPage.test.tsx
@@ -69,6 +69,19 @@ describe('ThreeCardBragPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bet'));
   });
 
+  it('labels the raise steppers and announces the amount', async () => {
+    renderWithProviders(<ThreeCardBragPage />);
+    const inc = await screen.findByRole('button', { name: 'レイズ額を増やす' });
+    const dec = screen.getByRole('button', { name: 'レイズ額を減らす' });
+    const amount = screen.getByTestId('tcb-raise-amount');
+    expect(amount).toHaveAttribute('aria-live', 'polite');
+    const before = amount.textContent;
+    fireEvent.click(inc);
+    expect(amount.textContent).not.toBe(before);
+    // The decrease button exists and is operable.
+    expect(dec).toBeEnabled();
+  });
+
   it('dispatches fold when the Fold button is clicked', async () => {
     renderWithProviders(<ThreeCardBragPage />);
     const btn = await screen.findByRole('button', { name: 'フォールド' });

--- a/frontend/src/pages/ThreeCardBragPage.tsx
+++ b/frontend/src/pages/ThreeCardBragPage.tsx
@@ -346,11 +346,15 @@ function ThreeCardBragPageContent() {
                       className={btnSecondary}
                       onClick={() => setRaiseStake((a) => Math.max(state.stake + 1, a - 1))}
                       disabled={loading}
-                      aria-label="-"
+                      aria-label={t('raiseDecrease')}
                     >
                       −
                     </button>
-                    <span className="text-ds-text-primary text-sm min-w-[4rem] text-center">
+                    <span
+                      className="text-ds-text-primary text-sm min-w-[4rem] text-center"
+                      aria-live="polite"
+                      data-testid="tcb-raise-amount"
+                    >
                       {t('raisePrompt')} {raiseStake}
                     </span>
                     <button
@@ -358,7 +362,7 @@ function ThreeCardBragPageContent() {
                       className={btnSecondary}
                       onClick={() => setRaiseStake((a) => a + 1)}
                       disabled={loading}
-                      aria-label="+"
+                      aria-label={t('raiseIncrease')}
                     >
                       ＋
                     </button>


### PR DESCRIPTION
## 概要

`ThreeCardBragPage.tsx` のレイズ額増減ボタンは `aria-label="-"` / `aria-label="+"` で、スクリーンリーダーには記号 1 文字が読まれるだけだった。また金額表示 span が更新通知されなかった。

− / ＋ ボタンの aria-label を「レイズ額を減らす」「レイズ額を増やす」の i18n キーに置き換え、金額表示に `aria-live="polite"` を付与して増減結果が即時に読み上げられるようにする。

## 変更点

- `ThreeCardBragPage.tsx`: − / ＋ ボタンに `aria-label={t('raiseDecrease')}`／`{t('raiseIncrease')}`、金額 span に `aria-live="polite"`＋`data-testid="tcb-raise-amount"`
- i18n キー `raiseDecrease`／`raiseIncrease` を ja / en に追加

## 受け入れ条件

- [x] − / ＋ ボタンに意味のある aria-label（ja/en）が付く
- [x] 金額表示が `aria-live="polite"` で更新通知される
- [x] `getByRole('button', { name: ... })` でテスト可能
- [x] `bun run check` / `test` が green

## テスト

- `ThreeCardBragPage.test.tsx`: 「レイズ額を増やす/減らす」ボタンを role で取得、金額 span の `aria-live=polite`、＋で金額が変わることを検証（11 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3459