### PR TITLE
feat(teenpatti): show the raise range in the CUI betting prompt

### DIFF
--- a/internal/adapter/presenter/TeenPattiCuiPresenter.go
+++ b/internal/adapter/presenter/TeenPattiCuiPresenter.go
@@ -69,6 +69,29 @@ func teenPattiPlayerNameAt(g interfaces.TeenPattiGame, idx int) string {
 	return cuiPlayerName(player, idx)
 }
 
+// teenPattiRaiseRangeStr returns the betting-phase raise guidance line for a
+// human turn: the affordable min..max, or an "unavailable" notice when the
+// player is too short on chips. Empty on a CPU turn (mirrors Three Card Brag).
+func teenPattiRaiseRangeStr(g interfaces.TeenPattiGame) string {
+	player := g.GetPlayer(g.GetCurrentPlayerIdx())
+	if player == nil || !player.GetIsHuman() {
+		return ""
+	}
+	minRaise := g.GetStake() + 1
+	maxRaise := player.GetChips()
+	if player.GetSeen() {
+		// Seen players pay double the stake to call/raise, halving the affordable ceiling.
+		maxRaise = player.GetChips() / 2
+	}
+	if maxRaise < minRaise {
+		return i18n.T("teenpatti.promptRaiseUnavailable") + "\n"
+	}
+	return i18n.Tf("teenpatti.promptRaiseRange",
+		"min", strconv.Itoa(minRaise),
+		"max", strconv.Itoa(maxRaise),
+	) + "\n"
+}
+
 // TeenPattiCuiPresenter renders the Teen Patti CUI view.
 type TeenPattiCuiPresenter struct{}
 
@@ -99,6 +122,7 @@ func (p *TeenPattiCuiPresenter) Output(g interfaces.TeenPattiGame, lastErr error
 		case domain.TeenPattiPhaseBetting:
 			b.WriteString(i18n.T("teenpatti.promptBetting") + "\n")
 			b.WriteString(i18n.T("teenpatti.promptBettingHelp") + "\n")
+			b.WriteString(teenPattiRaiseRangeStr(g))
 		case domain.TeenPattiPhaseSideShow:
 			targetIdx := g.GetSideShowTarget()
 			b.WriteString(i18n.Tf("teenpatti.promptSideShow",

--- a/internal/adapter/presenter/TeenPattiCuiPresenter_test.go
+++ b/internal/adapter/presenter/TeenPattiCuiPresenter_test.go
@@ -69,6 +69,44 @@ func TestTeenPattiCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "SPADE")
 	})
 
+	t.Run("betting raise range: blind human sees full-chip ceiling", func(t *testing.T) {
+		m, players := tpSetupMockWithPlayers()
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 1, false))
+		// Blind, 30 chips, stake 1 → min 2, max 30.
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "レイズ可能額: 2〜30")
+	})
+
+	t.Run("betting raise range: seen human ceiling is halved", func(t *testing.T) {
+		m, players := tpSetupMockWithPlayers()
+		players[0].SetSeen(true)
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 1, false))
+		// Seen pays double, so 30 chips → max 15.
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "レイズ可能額: 2〜15")
+	})
+
+	t.Run("betting raise range: unavailable when chips are too low", func(t *testing.T) {
+		m := tpSetupBaseMock()
+		poor := domain.NewTeenPattiPlayer(true, 1) // 1 chip, stake 1 → min 2 > max 1
+		players := []*domain.TeenPattiPlayer{poor, tpMakePlayers()[1], tpMakePlayers()[2], tpMakePlayers()[3]}
+		m.On("GetPlayerCnt").Return(domain.TeenPattiPlayerCnt)
+		for i, pl := range players {
+			m.On("GetPlayer", i).Return(pl)
+		}
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "チップ不足のためレイズできません")
+	})
+
+	t.Run("betting raise range is omitted on a CPU turn", func(t *testing.T) {
+		m, _ := tpSetupMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentPlayerIdx")
+		m.On("GetCurrentPlayerIdx").Return(1) // a CPU seat
+		result := p.Output(m, nil)
+		assert.NotContains(t, result, "レイズ可能額")
+		assert.NotContains(t, result, "チップ不足")
+	})
+
 	t.Run("side show phase shows player names, not raw indices", func(t *testing.T) {
 		i18n.SetLang("en")
 		defer i18n.SetLang("ja")

--- a/internal/i18n/locales/en/teenpatti.json
+++ b/internal/i18n/locales/en/teenpatti.json
@@ -10,6 +10,8 @@
   "gameEnd": "Game over! Player {{player}} wins the match!",
   "promptBetting": "Betting phase: your turn.",
   "promptBettingHelp": "s=see  b=call  rs <n>=raise  f=fold  sh=show  ss=side show",
+  "promptRaiseRange": "Raise range: {{min}}-{{max}} (use rs <n>)",
+  "promptRaiseUnavailable": "Not enough chips to raise.",
   "promptSideShow": "{{requester}} requests a side show with {{target}}.",
   "promptSideShowYou": "You are being challenged — accept or decline.",
   "promptSideShowHelp": "ac=accept  dc=decline",

--- a/internal/i18n/locales/ja/teenpatti.json
+++ b/internal/i18n/locales/ja/teenpatti.json
@@ -10,6 +10,8 @@
   "gameEnd": "ゲーム終了！ プレイヤー{{player}} の優勝です！",
   "promptBetting": "ベッティングフェーズ: あなたの手番です。",
   "promptBettingHelp": "s=見る  b=コール  rs <n>=レイズ  f=降りる  sh=ショー  ss=サイドショー申請",
+  "promptRaiseRange": "レイズ可能額: {{min}}〜{{max}} (rs <n> で指定)",
+  "promptRaiseUnavailable": "チップ不足のためレイズできません。",
   "promptSideShow": "{{requester}} が {{target}} にサイドショーを要求しました。",
   "promptSideShowYou": "あなたが要求されています。受諾するか辞退してください。",
   "promptSideShowHelp": "ac=受諾  dc=辞退",


### PR DESCRIPTION
## 概要

`TeenPattiCuiPresenter.go` の `TeenPattiPhaseBetting` 分岐は `promptBetting` / `promptBettingHelp` の定型 2 行のみで、いくらまでレイズできるかを CUI から知る手段がなかった。姉妹ゲーム `ThreeCardBragCuiPresenter.go` の `threeCardBragRaiseRangeStr` と同等のロジックを移植する。

## 変更点

- `TeenPattiCuiPresenter.go`: `teenPattiRaiseRangeStr` を追加。人間の手番のとき、許容レイズ範囲（min=stake+1、max=chips、seen は chips/2）を promptBetting 直後に出力。チップ不足時は不可メッセージ、CPU 手番では何も出さない
- i18n キー `promptRaiseRange`／`promptRaiseUnavailable` を ja / en に追加

## 受け入れ条件

- [x] 人間の手番でレイズ範囲行が出力される
- [x] CPU 手番では出力されない
- [x] chips 不足時に不可メッセージが出る
- [x] presenter テストで seen/blind/不足の 3 分岐（＋CPU 手番）を検証

## テスト

- `TeenPattiCuiPresenter_test.go`: blind(2〜30)／seen(2〜15)／不足(不可)／CPU手番(出力なし) を検証。`teenPattiRaiseRangeStr` 100% coverage / `golangci-lint` 0 issues

Closes #3462