### PR TITLE
feat(preference): add reason labels to disabled bids and a Misère note

### DIFF
--- a/frontend/src/i18n/locales/en/preference.json
+++ b/frontend/src/i18n/locales/en/preference.json
@@ -72,5 +72,6 @@
   "bidHighest": "Highest bid: {{name}}",
   "bidNone": "none",
   "bidTooLow": "Must exceed the current highest bid",
-  "misereBadge": "Special"
+  "misereBadge": "Special",
+  "misereDesc": "Misère is a special contract aiming to win no tricks; failing it costs heavily."
 }

--- a/frontend/src/i18n/locales/ja/preference.json
+++ b/frontend/src/i18n/locales/ja/preference.json
@@ -72,5 +72,6 @@
   "bidHighest": "現在の最高入札: {{name}}",
   "bidNone": "なし",
   "bidTooLow": "現在の最高入札を上回る必要があります",
-  "misereBadge": "特殊"
+  "misereBadge": "特殊",
+  "misereDesc": "ミゼールは1トリックも取らないことを目指す特殊契約で、失敗すると大きな失点になります。"
 }

--- a/frontend/src/pages/PreferencePage.test.tsx
+++ b/frontend/src/pages/PreferencePage.test.tsx
@@ -121,17 +121,22 @@ describe('PreferencePage', () => {
     expect(banner).toHaveTextContent('ミゼール');
   });
 
-  it('explains via tooltip why a too-low bid is disabled', async () => {
+  it('explains via tooltip and aria-label why a too-low bid is disabled', async () => {
     mockExec.mockResolvedValue(makePreferenceState({ bids: [2, 0, 0] }));
     renderWithProviders(<PreferencePage />);
     const six = await screen.findByTestId('bid-1');
     expect(six.closest('span')).toHaveAttribute('title', '現在の最高入札を上回る必要があります');
+    // The button name itself carries the reason for SR users.
+    expect(six).toHaveAttribute('aria-label', 'シックス — 現在の最高入札を上回る必要があります');
   });
 
-  it('marks the Misère bid as a special contract', async () => {
+  it('marks the Misère bid as a special contract with a described risk', async () => {
     renderWithProviders(<PreferencePage />);
     const misere = await screen.findByTestId('bid-2');
     expect(misere).toHaveTextContent('特殊');
+    // The risk explanation is available to screen readers via aria-describedby.
+    expect(misere).toHaveAttribute('aria-describedby', 'preference-misere-desc');
+    expect(document.getElementById('preference-misere-desc')).toHaveTextContent(/ミゼール/);
   });
 
   it('renders the play phase with the human cards and the declarer badge', async () => {

--- a/frontend/src/pages/PreferencePage.tsx
+++ b/frontend/src/pages/PreferencePage.tsx
@@ -361,9 +361,10 @@ function PreferencePageContent() {
                     const tooLow = b.value !== PreferenceContract.PASS && b.value <= highestBid;
                     const disabled = loading || tooLow;
                     const isMisere = b.value === PreferenceContract.MISERE;
+                    const reason = tooLow ? t('bidTooLow') : undefined;
                     return (
                       // Wrap in a span so the explanatory tooltip still shows on a disabled button.
-                      <span key={b.value} title={tooLow ? t('bidTooLow') : undefined} className="inline-flex">
+                      <span key={b.value} title={reason} className="inline-flex">
                         <button
                           type="button"
                           className={`px-3 py-2 rounded-lg text-white text-sm disabled:opacity-40 ${
@@ -372,11 +373,18 @@ function PreferencePageContent() {
                           onClick={() => handleBid(b.value)}
                           disabled={disabled}
                           aria-disabled={disabled}
+                          aria-label={reason ? `${t(b.key)} — ${reason}` : undefined}
+                          aria-describedby={isMisere ? 'preference-misere-desc' : undefined}
                           data-testid={`bid-${b.value}`}
                         >
                           {t(b.key)}
                           {isMisere && <span className="ml-1 text-[10px] opacity-80">{t('misereBadge')}</span>}
                         </button>
+                        {isMisere && (
+                          <span id="preference-misere-desc" className="sr-only">
+                            {t('misereDesc')}
+                          </span>
+                        )}
                       </span>
                     );
                   })}


### PR DESCRIPTION
## 概要

`PreferencePage.tsx` のビッドボタンは、低すぎるビッドを span の `title` で説明していたが、ボタン自体の `aria-label` に理由が含まれず、ミゼールボタンの危険性も視覚専用バッジのみだった。

`FortyFivesPage` のパターンに合わせ、tooLow のボタンへ理由付き `aria-label`（例:「シックス — 現在の最高入札を上回る必要があります」）を追加し、ミゼールボタンには危険な契約である旨の sr-only `aria-describedby` テキストを付与する。

## 変更点

- `PreferencePage.tsx`: tooLow ボタンに `aria-label={`${t(b.key)} — ${reason}`}`、ミゼールボタンに `aria-describedby="preference-misere-desc"` ＋ sr-only 説明 span
- i18n キー `misereDesc` を ja / en に追加

## 受け入れ条件

- [x] 無効ビッドボタンに理由付き aria-label が付与される
- [x] ミゼールボタンに補足説明が読み上げ可能になる（aria-describedby）
- [x] 視覚表示は変更しない
- [x] `PreferencePage.test.tsx` で属性を検証

## テスト

- `PreferencePage.test.tsx`: too-low bid の `aria-label="シックス — …"`、ミゼールの `aria-describedby` ＋ sr-only 説明文を検証（14 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3443