### PR TITLE
feat(primero): identify player states without relying on colour

### DIFF
--- a/frontend/src/i18n/locales/en/primero.json
+++ b/frontend/src/i18n/locales/en/primero.json
@@ -21,6 +21,7 @@
   "roundBet": "Bet: {{amount}}",
   "handLabel": "Your hand",
   "playersTitle": "Players",
+  "playerRowLabel": "{{name}} — status: {{status}}",
   "bettingNotice": "Your turn — call, raise (vie), or fold.",
   "badge": {
     "active": "In",

--- a/frontend/src/i18n/locales/ja/primero.json
+++ b/frontend/src/i18n/locales/ja/primero.json
@@ -21,6 +21,7 @@
   "roundBet": "賭け: {{amount}}",
   "handLabel": "あなたの手札",
   "playersTitle": "プレイヤー",
+  "playerRowLabel": "{{name}} — 状態: {{status}}",
   "bettingNotice": "あなたの番です — コール・レイズ（ヴィ）・フォールドを選んでください。",
   "badge": {
     "active": "参加中",

--- a/frontend/src/pages/PrimeroPage.test.tsx
+++ b/frontend/src/pages/PrimeroPage.test.tsx
@@ -179,4 +179,17 @@ describe('PrimeroPage', () => {
     renderWithProviders(<PrimeroPage />);
     await waitFor(() => expect(screen.getByText('ゲーム終了！ あなたの勝利です！')).toBeInTheDocument());
   });
+
+  it('marks player states with a colour-independent icon and a status aria-label', async () => {
+    mockExec.mockResolvedValue(resultState);
+    renderWithProviders(<PrimeroPage />);
+    const winner = await screen.findByTestId('primero-player-0');
+    // Winner: crown glyph + status in the row aria-label.
+    expect(winner).toHaveTextContent('👑');
+    expect(winner).toHaveAttribute('aria-label', expect.stringContaining('勝者'));
+    // Folded player: × glyph + status.
+    const folded = screen.getByTestId('primero-player-2');
+    expect(folded).toHaveTextContent('×');
+    expect(folded).toHaveAttribute('aria-label', expect.stringContaining('降りた'));
+  });
 });

--- a/frontend/src/pages/PrimeroPage.tsx
+++ b/frontend/src/pages/PrimeroPage.tsx
@@ -136,6 +136,10 @@ function PrimeroPageContent() {
   const playerBadge = (p: PrimeroResponse['players'][number]): string =>
     p.out ? t('badge.out') : p.isWinner ? t('badge.winner') : p.folded ? t('badge.folded') : t('badge.active');
 
+  /** A colour-independent glyph for each player state (WCAG 1.4.1). */
+  const playerBadgeIcon = (p: PrimeroResponse['players'][number]): string =>
+    p.out ? '—' : p.isWinner ? '👑' : p.folded ? '×' : '●';
+
   const handleManualReset = () => {
     hideActionLog();
     reset();
@@ -229,16 +233,25 @@ function PrimeroPageContent() {
             {/* Players */}
             <div className="mb-2 p-2 rounded bg-black/30" data-tutorial="primero-players">
               <div className="mb-1 text-ds-text-primary text-sm">{t('playersTitle')}</div>
-              {state.players.map((p) => (
-                <div
-                  key={p.id}
-                  className={`text-sm py-0.5 ${p.isWinner ? 'text-ds-success' : 'text-ds-text-muted'} ${p.isHuman ? 'font-semibold' : ''}`}
-                >
-                  {playerLabel(p.id, p.isHuman)} — {t('chips', { amount: p.chips })} ·{' '}
-                  {t('roundBet', { amount: p.roundBet })} · [{playerBadge(p)}]
-                  {p.handName ? ` · ${handName(p.handName)}` : ''}
-                </div>
-              ))}
+              <ul className="list-none">
+                {state.players.map((p) => {
+                  const isCurrentTurn = !isGameEnd && state.currentPlayerIdx === p.id;
+                  return (
+                    <li
+                      key={p.id}
+                      data-testid={`primero-player-${p.id}`}
+                      aria-label={t('playerRowLabel', { name: playerLabel(p.id, p.isHuman), status: playerBadge(p) })}
+                      className={`text-sm py-0.5 ${p.isWinner ? 'text-ds-success' : 'text-ds-text-muted'} ${p.isHuman ? 'font-semibold' : ''} ${
+                        isCurrentTurn ? 'border-l-2 border-ds-accent pl-1' : ''
+                      }`}
+                    >
+                      {playerLabel(p.id, p.isHuman)} — {t('chips', { amount: p.chips })} ·{' '}
+                      {t('roundBet', { amount: p.roundBet })} · <span aria-hidden="true">{playerBadgeIcon(p)} </span>[
+                      {playerBadge(p)}]{p.handName ? ` · ${handName(p.handName)}` : ''}
+                    </li>
+                  );
+                })}
+              </ul>
             </div>
 
             {/* Revealed hands at result */}


### PR DESCRIPTION
## 概要

`PrimeroPage.tsx` の `playerBadge` は out/winner/folded/active を文言で返すが、勝者行は `text-ds-success`、その他は `text-ds-text-muted` の色分けに大きく依存し、色覚特性ユーザーには区別が付きにくかった（Bouillotte/Anaconda と共通の弱点）。

各状態バッジに色以外の識別アイコン（勝者=👑, fold=×, out=—, active=●）を付け、プレイヤー行（意味的に `<li>` 化）に状態を含む `aria-label` を付与、手番プレイヤーには左枠強調を追加する。

## 変更点

- `PrimeroPage.tsx`: `playerBadgeIcon`（`aria-hidden` グリフ）追加、行を `<ul>/<li>` に、各行に `aria-label`（`playerRowLabel`）と手番の `border-l-2 border-ds-accent`
- i18n キー `playerRowLabel` を ja / en に追加

## 受け入れ条件

- [x] 各状態バッジに色以外の識別アイコンが付く
- [x] プレイヤー行に状態を含む `aria-label` が付与される
- [x] 手番プレイヤーが枠でも識別できる
- [x] `PrimeroPage.test.tsx` に aria/アイコンのテストを追加

## テスト

- `PrimeroPage.test.tsx`: 勝者行に 👑＋`aria-label` に「勝者」、フォールド行に ×＋「降りた」を検証（12 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3484