### PR TITLE
feat(samba): announce discard-pile freeze/thaw to assistive tech

### DIFF
--- a/frontend/src/i18n/locales/en/samba.json
+++ b/frontend/src/i18n/locales/en/samba.json
@@ -50,6 +50,8 @@
     "tooMany": "Select at most 2 cards"
   },
   "frozenIndicator": "❄️ Frozen",
+  "frozenAnnounceOn": "The discard pile is frozen. Taking it now needs two matching natural cards.",
+  "frozenAnnounceOff": "The discard pile is no longer frozen.",
   "selectMeld": "Select cards to meld",
   "result": {
     "humanWin": "Your team wins!",

--- a/frontend/src/i18n/locales/ja/samba.json
+++ b/frontend/src/i18n/locales/ja/samba.json
@@ -50,6 +50,8 @@
     "tooMany": "選択は2枚までです"
   },
   "frozenIndicator": "❄️ フリーズ",
+  "frozenAnnounceOn": "捨札が凍結されました。取得には同種の条件札2枚が必要です。",
+  "frozenAnnounceOff": "捨札の凍結が解除されました。",
   "selectMeld": "メルドするカードを選択してください",
   "result": {
     "humanWin": "あなたのチームの勝利！",

--- a/frontend/src/pages/SambaPage.test.tsx
+++ b/frontend/src/pages/SambaPage.test.tsx
@@ -49,6 +49,18 @@ describe('SambaPage', () => {
     expect(screen.getByTestId('sa-team-scores')).toBeInTheDocument();
   });
 
+  it('announces when the discard pile becomes frozen', async () => {
+    renderWithProviders(<SambaPage />);
+    const announce = await screen.findByTestId('sa-frozen-announce');
+    expect(announce).toHaveAttribute('role', 'status');
+    expect(announce).toHaveAttribute('aria-live', 'polite');
+    expect(announce).toHaveTextContent(''); // no transition yet
+    // A draw resolves to a frozen state → isFrozen false→true triggers the announcement.
+    mockExec.mockResolvedValue(makeSambaState({ isFrozen: true }));
+    fireEvent.click(screen.getByRole('button', { name: '山札から引く' }));
+    await waitFor(() => expect(screen.getByTestId('sa-frozen-announce')).toHaveTextContent('捨札が凍結されました'));
+  });
+
   it('calls drawstock command when button clicked', async () => {
     renderWithProviders(<SambaPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '山札から引く' })).toBeInTheDocument());

--- a/frontend/src/pages/SambaPage.tsx
+++ b/frontend/src/pages/SambaPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { sambaApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -159,6 +159,23 @@ function SambaPageContent() {
     enabled: !!isHumanTurn && !loading,
   });
 
+  // Announce freeze/thaw transitions: freezing changes the draw rules (you now
+  // need two matching cards to take the discard pile), so it must reach SR users
+  // beyond the colour/badge cue.
+  const [frozenMsg, setFrozenMsg] = useState('');
+  const prevFrozenRef = useRef<boolean | null>(null);
+  useEffect(() => {
+    const frozen = state?.isFrozen;
+    if (frozen == null) return;
+    const prev = prevFrozenRef.current;
+    prevFrozenRef.current = frozen;
+    if (prev != null && prev !== frozen) {
+      setFrozenMsg(frozen ? t('frozenAnnounceOn') : t('frozenAnnounceOff'));
+      const id = setTimeout(() => setFrozenMsg(''), 3000);
+      return () => clearTimeout(id);
+    }
+  }, [state?.isFrozen, t]);
+
   if (!state) {
     return (
       <GameSkeleton
@@ -230,6 +247,10 @@ function SambaPageContent() {
                 {t('drawPile', { count: state.drawPileCount })} / {t('discardPile', { count: state.discardPileCount })}
               </span>
               {state.isFrozen && <span className="ml-2 text-ds-info font-bold">[{t('frozen')}]</span>}
+              {/* Self-contained live region announcing freeze/thaw transitions. */}
+              <span className="sr-only" role="status" aria-live="polite" data-testid="sa-frozen-announce">
+                {frozenMsg}
+              </span>
             </div>
             <div className="text-ds-text-muted text-center mb-2 text-sm" data-testid="sa-team-scores">
               {t('teamScores', { a: state.teamScores[0] ?? 0, b: state.teamScores[1] ?? 0 })}


### PR DESCRIPTION
## 概要

`SambaPage.tsx` は捨札凍結を `isFrozen` で色/バッジ（`sa-frozen-badge`）中心に表示するが、凍結は「捨札取得に同種の条件札2枚が必要」という重要ルール変化なのに、状態変化がライブ告知されなかった。

凍結状態の変化を sr-only の `role="status"`／`aria-live="polite"` リージョンで告知する（`useRef` で遷移検知）。凍結中の取得条件テキスト（`sa-draw-discard-reason`）は既存のまま維持。

## 変更点

- `SambaPage.tsx`: `isFrozen` の遷移を検知して 3 秒間メッセージを出す effect と、sr-only ライブリージョン `sa-frozen-announce` を追加
- i18n キー `frozenAnnounceOn`／`frozenAnnounceOff` を ja / en に追加

## 受け入れ条件

- [x] 凍結状態変化が aria-live で告知される
- [x] 凍結中の取得条件が常時テキスト表示される（既存 `sa-draw-discard-reason` を維持）
- [x] 既存 `sa-frozen-badge` と重複せず整理される（バッジは視覚、告知は sr-only で役割分担）
- [x] `SambaPage.test.tsx` に aria-live 告知テストを追加

## テスト

- `SambaPage.test.tsx`: `sa-frozen-announce` が `role=status`/`aria-live=polite`、初期は空、ドローで isFrozen false→true 時に「捨札が凍結されました」を告知（17 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3496