### PR TITLE
feat(oichokabu): read out hand ranks by name and announce the result

### DIFF
--- a/frontend/src/i18n/locales/en/oichokabu.json
+++ b/frontend/src/i18n/locales/en/oichokabu.json
@@ -40,5 +40,11 @@
   "hint": {
     "drawLow": "Your kabu is low (0–3) — drawing a third card is favorable",
     "standHigh": "Your kabu is high enough — standing is the basic play"
-  }
+  },
+  "rankName": {
+    "0": "Buta, weakest",
+    "9": "Kabu, strongest"
+  },
+  "rankAriaLabelNamed": "{{hand}} score {{rank}} ({{name}})",
+  "rankAriaLabelPlain": "{{hand}} score {{rank}}"
 }

--- a/frontend/src/i18n/locales/ja/oichokabu.json
+++ b/frontend/src/i18n/locales/ja/oichokabu.json
@@ -40,5 +40,11 @@
   "hint": {
     "drawLow": "カブが低い（0〜3）— 3枚目を引くのが有利",
     "standHigh": "カブが十分高い — このまま勝負するのが基本"
-  }
+  },
+  "rankName": {
+    "0": "ブタ、最弱",
+    "9": "カブ、最強"
+  },
+  "rankAriaLabelNamed": "{{hand}}の目{{rank}}（{{name}}）",
+  "rankAriaLabelPlain": "{{hand}}の目{{rank}}"
 }

--- a/frontend/src/pages/OichoKabuPage.test.tsx
+++ b/frontend/src/pages/OichoKabuPage.test.tsx
@@ -143,6 +143,17 @@ describe('OichoKabuPage', () => {
     expect(screen.getByText(/200/)).toBeInTheDocument();
   });
 
+  it('exposes each hand rank by name and the result as a live region', async () => {
+    mockApi.mockResolvedValue(winState); // playerRank 9 (Kabu), bankerRank 7
+    renderWithProviders(<OichoKabuPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: /次のゲーム/ })).toBeInTheDocument());
+    // Player rank 9 is named (Kabu, strongest); a plain rank (7) is not.
+    expect(screen.getByRole('img', { name: '子（あなた）の目9（カブ、最強）' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: '親の目7' })).toBeInTheDocument();
+    // The payout/result block is announced.
+    expect(screen.getByTestId('payout-breakdown')).toHaveAttribute('role', 'status');
+  });
+
   it('reads from useCliMode', async () => {
     mockApi.mockResolvedValue(betState);
     renderWithProviders(<OichoKabuPage />);

--- a/frontend/src/pages/OichoKabuPage.tsx
+++ b/frontend/src/pages/OichoKabuPage.tsx
@@ -87,6 +87,15 @@ function OichoKabuPageContent() {
   const handleStand = useCallback(() => execApi('stand'), [execApi]);
   const handleReset = useCallback(() => execApi('reset'), [execApi]);
   const canRebet = lastBetAmount !== null && lastBetAmount > 0 && state !== null && lastBetAmount <= state.chips;
+
+  // Spoken label for a hand's Kabu score: the digit alone conveys nothing to a
+  // screen reader, so name the special ranks (9 = Kabu/strongest, 0 = Buta/weakest).
+  const rankAriaLabel = (handKey: string, rank: number): string => {
+    const name = t(`rankName.${rank}`, { defaultValue: '' });
+    return name
+      ? t('rankAriaLabelNamed', { hand: t(handKey), rank, name })
+      : t('rankAriaLabelPlain', { hand: t(handKey), rank });
+  };
   const handleRebet = useCallback(async () => {
     if (lastBetAmount === null) return;
     await execApi('reset');
@@ -170,7 +179,11 @@ function OichoKabuPageContent() {
 
             {state.playerHand.length > 0 && (
               <div className="mb-4" data-tutorial="ok-results">
-                <div className="text-ds-warning font-bold text-center mb-1">
+                <div
+                  className="text-ds-warning font-bold text-center mb-1"
+                  role="img"
+                  aria-label={rankAriaLabel('label.playerHand', state.playerRank)}
+                >
                   {t('label.playerHand')} — {t('label.rank')} {state.playerRank}
                 </div>
                 <div className="flex justify-center gap-2 flex-wrap">
@@ -183,7 +196,11 @@ function OichoKabuPageContent() {
 
             {isEndPhase && state.bankerHand.length > 0 && (
               <div className="mb-4">
-                <div className="text-ds-info font-bold text-center mb-1">
+                <div
+                  className="text-ds-info font-bold text-center mb-1"
+                  role="img"
+                  aria-label={rankAriaLabel('label.bankerHand', state.bankerRank)}
+                >
                   {t('label.bankerHand')} — {t('label.rank')} {state.bankerRank}
                 </div>
                 <div className="flex justify-center gap-2 flex-wrap">
@@ -195,7 +212,11 @@ function OichoKabuPageContent() {
             )}
 
             {isEndPhase && (
-              <div className="text-ds-text-primary text-center text-sm mb-2" data-testid="payout-breakdown">
+              <div
+                className="text-ds-text-primary text-center text-sm mb-2"
+                data-testid="payout-breakdown"
+                role="status"
+              >
                 <div className="font-bold">
                   {t('payout.total')}: {state.totalPayout}
                 </div>


### PR DESCRIPTION
## 概要

`OichoKabuPage.tsx` は子・親の目（9=カブ, 0=ブタ等）を数字と色（緑/赤/黄）だけで表示しており、スクリーンリーダー利用者に役の強弱や勝敗が伝わりにくかった。

各手の見出しに `role="img"`＋`aria-label`（例:「子（あなた）の目9（カブ、最強）」）で役説明を付与し、結果（payout）コンテナに `role="status"` を付ける。目 0/9 の名称を i18n で定義する。

## 変更点

- `OichoKabuPage.tsx`: `rankAriaLabel` ヘルパー追加。子・親見出しに `role="img"`＋aria-label、payout ブロックに `role="status"`
- i18n キー `rankName.{0,9}`／`rankAriaLabelNamed`／`rankAriaLabelPlain` を ja / en に追加

## 受け入れ条件

- [x] 子・親の目に役名を含む aria-label が付く（特殊目のみ名称、他は「目N」）
- [x] 勝敗結果コンテナに `role="status"` を付与
- [x] 目0/9 の名称 i18n キーを ja/en に追加
- [x] 既存の AnimatedCard の描画は変えない

## テスト

- `OichoKabuPage.test.tsx`: playerRank 9 が `role=img`「…の目9（カブ、最強）」、bankerRank 7 が「親の目7」、payout が `role=status` を検証（15 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3510