### PR TITLE
feat(rook): identify trump colours without relying on hue

### DIFF
--- a/frontend/src/pages/RookPage.test.tsx
+++ b/frontend/src/pages/RookPage.test.tsx
@@ -129,6 +129,9 @@ describe('RookPage', () => {
     renderWithProviders(<RookPage />);
     for (let i = 0; i < 5; i++) fireEvent.click(await screen.findByTestId(`hand-card-${i}`));
     const exchangeBtn = screen.getByTestId('exchange-button');
+    // Each colour button carries a letter cue in addition to the colour name.
+    expect(screen.getByTestId('trump-choice-1')).toHaveTextContent('R');
+    expect(screen.getByTestId('trump-choice-3')).toHaveTextContent('G');
     // still disabled until a trump color is chosen
     expect(exchangeBtn).toBeDisabled();
     fireEvent.click(screen.getByTestId('trump-choice-3'));
@@ -149,11 +152,15 @@ describe('RookPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', { cardIndex: 0 }));
   });
 
-  it('shows the trump color swatch once declared', async () => {
+  it('shows the trump color swatch once declared, named for screen readers', async () => {
     mockExec.mockResolvedValue(makeState({ phase: 2, currentPlayerIdx: 0, contractBid: 75, trumpColor: 1 }));
     renderWithProviders(<RookPage />);
-    expect(await screen.findByTestId('trump-swatch')).toBeInTheDocument();
-    expect(screen.getByTestId('trump-name')).toBeInTheDocument();
+    const swatch = await screen.findByTestId('trump-swatch');
+    // The colour dot itself is named (not colour-only) for SR.
+    expect(swatch).toHaveAttribute('role', 'img');
+    expect(swatch).toHaveAttribute('aria-label', '赤');
+    // The visible label carries the letter cue and is hidden from SR to avoid a repeat.
+    expect(screen.getByTestId('trump-name')).toHaveTextContent('R 赤');
   });
 
   it('advances to the next trick', async () => {

--- a/frontend/src/pages/RookPage.tsx
+++ b/frontend/src/pages/RookPage.tsx
@@ -48,11 +48,14 @@ const ROOK_DISCARD_COUNT = 5;
  * 4=black). The `ink` hex mirrors `CardFace`'s INK_COLORS so the swatch reads
  * the same as the drawn cards, never a French suit symbol.
  */
-const TRUMP_COLORS: { id: number; nameKey: string; ink: string }[] = [
-  { id: 1, nameKey: 'color.red', ink: '#B83A3A' },
-  { id: 2, nameKey: 'color.gold', ink: '#B8892E' },
-  { id: 3, nameKey: 'color.green', ink: '#2E7D46' },
-  { id: 4, nameKey: 'color.black', ink: '#1A1A1A' },
+// Rook cards have no French suit, so colour is the only identifier — carry a
+// language-neutral letter (R/Y/G/B) alongside the colour so it isn't conveyed
+// by hue alone (WCAG 1.4.1).
+const TRUMP_COLORS: { id: number; nameKey: string; ink: string; sym: string }[] = [
+  { id: 1, nameKey: 'color.red', ink: '#B83A3A', sym: 'R' },
+  { id: 2, nameKey: 'color.gold', ink: '#B8892E', sym: 'Y' },
+  { id: 3, nameKey: 'color.green', ink: '#2E7D46', sym: 'G' },
+  { id: 4, nameKey: 'color.black', ink: '#1A1A1A', sym: 'B' },
 ];
 
 /** Tutorial steps for Rook. */
@@ -147,11 +150,10 @@ function RookPageContent() {
             ? t('phase.roundEnd')
             : t('phase.play');
 
-  const trumpName =
-    state.trumpColor >= 1
-      ? t(TRUMP_COLORS.find((c) => c.id === state.trumpColor)?.nameKey ?? '')
-      : t('trumpUndeclared');
-  const trumpInk = TRUMP_COLORS.find((c) => c.id === state.trumpColor)?.ink;
+  const trumpMeta = TRUMP_COLORS.find((c) => c.id === state.trumpColor);
+  const trumpName = state.trumpColor >= 1 ? t(trumpMeta?.nameKey ?? '') : t('trumpUndeclared');
+  const trumpInk = trumpMeta?.ink;
+  const trumpSym = trumpMeta?.sym ?? '';
 
   // Bid options: strictly above the current highest bid, within [70, 120] step 5.
   const minSelectableBid = Math.max(
@@ -210,12 +212,17 @@ function RookPageContent() {
                   <>
                     <span>{t('contractLine', { value: state.contractBid })}</span>
                     <span
-                      aria-hidden
+                      role="img"
+                      aria-label={trumpName}
                       className="inline-block h-3 w-3 rounded-full border border-white/40"
                       style={{ backgroundColor: trumpInk }}
                       data-testid="trump-swatch"
                     />
-                    <span data-testid="trump-name">{trumpName}</span>
+                    {/* Visible letter + name (aria-hidden — the swatch already names the colour). */}
+                    <span data-testid="trump-name" aria-hidden="true">
+                      {trumpSym ? `${trumpSym} ` : ''}
+                      {trumpName}
+                    </span>
                   </>
                 ) : state.highestBid > 0 ? (
                   <span>{t('highestBid', { value: state.highestBid })}</span>
@@ -401,6 +408,9 @@ function RookPageContent() {
                       }`}
                       style={{ backgroundColor: c.ink }}
                     >
+                      <span aria-hidden="true" className="font-bold">
+                        {c.sym}
+                      </span>
                       {t(c.nameKey)}
                     </button>
                   ))}


### PR DESCRIPTION
## 概要

`RookPage.tsx` はトランプ色を `trump-swatch`（色のみ、`aria-hidden`）と `trump-choice-{id}` ボタン（地色＋色名）で表示するが、Rook 札は仏スートを持たず色が唯一の識別子のため、赤/金/緑/黒の判別が地色頼みになり色覚特性ユーザーに影響が大きかった。

各トランプ色に言語非依存の略号（R/Y/G/B）を併記し、契約スウォッチには `role="img"`＋色名 `aria-label` を付与する。略号は `TRUMP_COLORS` に単一定義。

## 変更点

- `RookPage.tsx`: `TRUMP_COLORS` に `sym`（R/Y/G/B）追加。色選択ボタンに略号（`aria-hidden`）を併記、契約スウォッチを `role="img"`＋`aria-label={色名}` に（`trump-name` は略号＋色名を表示し `aria-hidden`）

## 受け入れ条件

- [x] 各トランプ色ボタンに色名以外の識別子（略号 R/Y/G/B）が付く
- [x] 契約表示のスウォッチに色名 aria-label が付く
- [x] 4色すべてで判別可能（略号＋色名）
- [x] i18n の色名キーを再利用（新規キーなし）

## テスト

- `RookPage.test.tsx`: スウォッチが `role=img`＋`aria-label="赤"`、`trump-name` が「R 赤」、色ボタンが略号 R/G を含むことを検証（11 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3514