### PR TITLE
feat(hachihachi): make the round-result table accessible beyond colour

### DIFF
--- a/frontend/src/i18n/locales/en/hachihachi.json
+++ b/frontend/src/i18n/locales/en/hachihachi.json
@@ -32,7 +32,11 @@
     "raw": "Raw",
     "bonus": "Yaku pts",
     "delta": "Delta",
-    "yaku": "Yaku"
+    "yaku": "Yaku",
+    "caption": "Round settlement table (raw, bonus and delta per player)",
+    "bestLabel": "Top score",
+    "deltaGain": "gained {{n}}",
+    "deltaLoss": "lost {{n}}"
   },
   "result": {
     "title": "Final Scores",

--- a/frontend/src/i18n/locales/ja/hachihachi.json
+++ b/frontend/src/i18n/locales/ja/hachihachi.json
@@ -32,7 +32,11 @@
     "raw": "素点",
     "bonus": "役点",
     "delta": "差分",
-    "yaku": "出来役"
+    "yaku": "出来役",
+    "caption": "ラウンド精算表（プレイヤー別の素点・役点・差分）",
+    "bestLabel": "最高得点",
+    "deltaGain": "{{n}}点獲得",
+    "deltaLoss": "{{n}}点失点"
   },
   "result": {
     "title": "最終得点",

--- a/frontend/src/pages/HachiHachiPage.test.tsx
+++ b/frontend/src/pages/HachiHachiPage.test.tsx
@@ -104,6 +104,21 @@ describe('HachiHachiPage', () => {
     expect(screen.getByTestId('hachihachi-score-row-2')).toBeInTheDocument();
   });
 
+  it('conveys the best row and delta signs without relying on colour', async () => {
+    mockExec.mockResolvedValue(roundEndState);
+    renderWithProviders(<HachiHachiPage />);
+    await waitFor(() => expect(screen.getByTestId('hachihachi-round-result')).toBeInTheDocument());
+    // The best row carries a crown glyph and an sr-only "top score" label.
+    const bestRow = screen.getByTestId('hachihachi-score-row-0');
+    expect(bestRow).toHaveTextContent('👑');
+    expect(bestRow).toHaveTextContent('最高得点');
+    // Delta signs read meaningfully: +52 → gained, -8 → lost.
+    expect(bestRow).toHaveTextContent('52点獲得');
+    expect(screen.getByTestId('hachihachi-score-row-1')).toHaveTextContent('8点失点');
+    // The table names itself via a caption.
+    expect(screen.getByText('ラウンド精算表（プレイヤー別の素点・役点・差分）')).toBeInTheDocument();
+  });
+
   it('renders the game-end result with a winner banner', async () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<HachiHachiPage />);

--- a/frontend/src/pages/HachiHachiPage.tsx
+++ b/frontend/src/pages/HachiHachiPage.tsx
@@ -267,6 +267,7 @@ function HachiHachiPageContent() {
                 <div className="mb-1 text-ds-text-primary">{t('roundResult.title')}</div>
                 <div className="overflow-x-auto">
                   <table className="mx-auto text-sm border-collapse">
+                    <caption className="sr-only">{t('roundResult.caption')}</caption>
                     <thead>
                       <tr className="text-ds-text-muted">
                         <th className="px-2 py-1 text-left">{t('roundResult.player')}</th>
@@ -288,10 +289,21 @@ function HachiHachiPageContent() {
                             data-testid={`hachihachi-score-row-${s.playerIdx}`}
                             data-best={best || undefined}
                           >
-                            <td className="px-2 py-1 text-left">{p ? seatName(p) : `P${s.playerIdx}`}</td>
+                            <td className="px-2 py-1 text-left">
+                              {best && <span aria-hidden="true">👑 </span>}
+                              {best && <span className="sr-only">{t('roundResult.bestLabel')} </span>}
+                              {p ? seatName(p) : `P${s.playerIdx}`}
+                            </td>
                             <td className="px-2 py-1 text-right">{s.rawScore}</td>
                             <td className="px-2 py-1 text-right">{s.bonus}</td>
-                            <td className="px-2 py-1 text-right">{sign}</td>
+                            <td className="px-2 py-1 text-right">
+                              <span aria-hidden="true">{sign}</span>
+                              <span className="sr-only">
+                                {s.delta >= 0
+                                  ? t('roundResult.deltaGain', { n: s.delta })
+                                  : t('roundResult.deltaLoss', { n: -s.delta })}
+                              </span>
+                            </td>
                             <td className="px-2 py-1 text-left">{s.yaku.length > 0 ? yakuList(s.yaku) : '—'}</td>
                           </tr>
                         );


### PR DESCRIPTION
## 概要

`HachiHachiPage.tsx` の精算テーブルは、最良プレイヤー行（`s.playerIdx === lastRoundResult.best`）を `text-ds-success font-semibold` の色と太字だけで強調し、delta の +/- 符号もスクリーンリーダーには意味が伝わらなかった。

最良行に王冠グリフ（`aria-hidden`）＋ sr-only「最高得点」ラベルを付け、テーブルに sr-only `<caption>`、delta セルに「N点獲得/失点」の sr-only テキストを追加する。

## 変更点

- `HachiHachiPage.tsx`: 最良行に 👑＋sr-only「最高得点」、テーブルに sr-only caption、delta セルに符号（`aria-hidden`）＋ sr-only「{{n}}点獲得/失点」
- i18n キー `roundResult.{caption,bestLabel,deltaGain,deltaLoss}` を ja / en に追加

## 受け入れ条件

- [x] 最良プレイヤー行に色以外の識別（王冠＋「最高得点」テキスト）が付く
- [x] テーブルに caption が付与される
- [x] delta の符号が読み上げで意味を持つ（「52点獲得」「8点失点」）
- [x] i18n キーを ja/en に追加

## テスト

- `HachiHachiPage.test.tsx`: 最良行の 👑＋「最高得点」＋「52点獲得」、他行の「8点失点」、caption 表示を検証（13 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3523