### PR TITLE
feat(zheng): announce turn arrival, lead-can't-pass, and finishing

### DIFF
--- a/frontend/src/i18n/locales/en/zheng.json
+++ b/frontend/src/i18n/locales/en/zheng.json
@@ -46,5 +46,10 @@
     "pairRun": "Pair Run",
     "bomb": "Bomb",
     "jokerBomb": "Joker Bomb"
+  },
+  "announce": {
+    "yourTurn": "It's your turn",
+    "yourTurnLead": "It's your turn. You're leading, so you can't pass.",
+    "finished": "You finished ({{rank}})"
   }
 }

--- a/frontend/src/i18n/locales/ja/zheng.json
+++ b/frontend/src/i18n/locales/ja/zheng.json
@@ -46,5 +46,10 @@
     "pairRun": "連続ペア",
     "bomb": "爆弾",
     "jokerBomb": "ジョーカーボム"
+  },
+  "announce": {
+    "yourTurn": "あなたの手番です",
+    "yourTurnLead": "あなたの手番です。リードなのでパスできません。",
+    "finished": "あがりました（{{rank}}）"
   }
 }

--- a/frontend/src/pages/ZhengPage.test.tsx
+++ b/frontend/src/pages/ZhengPage.test.tsx
@@ -96,6 +96,34 @@ describe('ZhengPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', [0]));
   });
 
+  it('exposes a polite turn/finish live region', async () => {
+    renderWithProviders(<ZhengPage />);
+    const announce = await screen.findByTestId('zheng-turn-announce');
+    expect(announce).toHaveAttribute('role', 'status');
+    expect(announce).toHaveAttribute('aria-live', 'polite');
+    // No transition has occurred on first render, so it starts empty.
+    expect(announce).toHaveTextContent('');
+  });
+
+  it('announces when the human finishes (rank named)', async () => {
+    renderWithProviders(<ZhengPage />);
+    fireEvent.click(await screen.findByTestId('hand-card-0'));
+    // The play resolves to a state where the human has gone out first (rank 1).
+    mockExec.mockResolvedValue(
+      makeState({
+        currentTurn: 1,
+        players: [
+          player(0, true, [], { isFinished: true, rank: 1 }),
+          player(1, false, []),
+          player(2, false, []),
+          player(3, false, []),
+        ],
+      }),
+    );
+    fireEvent.click(screen.getByTestId('play-button'));
+    await waitFor(() => expect(screen.getByTestId('zheng-turn-announce')).toHaveTextContent('あがりました'));
+  });
+
   it('disables play and shows a reason for an invalid combination', async () => {
     renderWithProviders(<ZhengPage />);
     // Select ♠3 + ♥5 (two different ranks) → not a legal combo.

--- a/frontend/src/pages/ZhengPage.tsx
+++ b/frontend/src/pages/ZhengPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
@@ -90,6 +90,25 @@ function ZhengPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('zheng', state);
+
+  // Announce turn arrival, the lead-can't-pass rule, and the human's own finish —
+  // CPU turns advance silently otherwise, leaving SR users unaware their turn came.
+  const [liveMsg, setLiveMsg] = useState('');
+  const prevAnnounceRef = useRef<{ turn: boolean; finished: boolean } | null>(null);
+  useEffect(() => {
+    if (!state || state.players.length < 4) return;
+    const turn = state.currentTurn === 0 && !state.gameEndFlag;
+    const finished = state.players[0]?.isFinished ?? false;
+    const lead = state.tableCards.length === 0;
+    const prev = prevAnnounceRef.current;
+    prevAnnounceRef.current = { turn, finished };
+    if (!prev) return;
+    if (finished && !prev.finished) {
+      setLiveMsg(t('announce.finished', { rank: t(`rank.${state.players[0]?.rank}`) }));
+    } else if (turn && !prev.turn) {
+      setLiveMsg(lead ? t('announce.yourTurnLead') : t('announce.yourTurn'));
+    }
+  }, [state, t]);
 
   // Values match the Go domain constants: 0=Normal, 1=Easy, 2=Hard (ZhengConfig.go).
   const difficultyOptions = useMemo(
@@ -275,6 +294,10 @@ function ZhengPageContent() {
           <ReplaySpeedSettingsPanel />
 
           <GameFooter className={`${gameTheme.zheng.footer} px-4 py-2.5`}>
+            {/* Polite live region for turn/pass/finish transitions. */}
+            <span className="sr-only" role="status" aria-live="polite" data-testid="zheng-turn-announce">
+              {liveMsg}
+            </span>
             {showInvalidCombo && (
               <p
                 role="status"


### PR DESCRIPTION
## 概要

`ZhengPage.tsx` は手番遷移（自分の手番になった／リードなのでパス不可／自分が上がった）をスクリーンリーダーに能動的に通知していなかった（`zheng-invalid-combo` のみ `role="status"`）。CPU 手番の進行や自分の手番到来は無音だった。

手番到来・リードでパス不可・上がり確定を伝える sr-only の `aria-live="polite"` ライブリージョンを追加する（`useRef` で遷移検知）。共有コンポーネント `GameMessageBox` は変更しない。

## 変更点

- `ZhengPage.tsx`: `currentTurn`/`isFinished` の遷移を検知して通知文を設定する effect と、sr-only ライブリージョン `zheng-turn-announce` を追加
- i18n キー `announce.{yourTurn,yourTurnLead,finished}` を ja / en に追加

## 受け入れ条件

- [x] 自分の手番到来が読み上げられる（`announce.yourTurn`）
- [x] リードでパス不可の状況が伝わる（`announce.yourTurnLead`）
- [x] 自分の上がり確定が通知される（`announce.finished`、順位付き）
- [x] 視覚表示は現状を維持

## テスト

- `ZhengPage.test.tsx`: ライブリージョンの `role=status`/`aria-live=polite`＋初期空、プレイ→上がり時に「あがりました」告知を検証（16 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3539