### PR TITLE
feat(cuckoo): add keep/swap/refuse/accept keyboard shortcuts

### DIFF
--- a/frontend/src/pages/CuckooPage.test.tsx
+++ b/frontend/src/pages/CuckooPage.test.tsx
@@ -152,6 +152,35 @@ describe('CuckooPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('accept'));
   });
 
+  it('supports k/s keyboard shortcuts on the human turn', async () => {
+    renderWithProviders(<CuckooPage />);
+    await screen.findByRole('button', { name: 'キープ' });
+    mockExec.mockClear();
+    fireEvent.keyDown(document, { key: 'k' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('keep'));
+    mockExec.mockClear();
+    fireEvent.keyDown(document, { key: 's' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('swap'));
+  });
+
+  it('supports r/a keyboard shortcuts only when targeted for a swap', async () => {
+    mockExec.mockResolvedValue(refuseState);
+    renderWithProviders(<CuckooPage />);
+    await screen.findByRole('button', { name: '受け入れる' });
+    mockExec.mockClear();
+    // keep/swap keys are inactive in the refuse phase.
+    fireEvent.keyDown(document, { key: 'k' });
+    fireEvent.keyDown(document, { key: 'a' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('accept'));
+    expect(mockExec).not.toHaveBeenCalledWith('keep');
+  });
+
+  it('shows keyboard hints on the action buttons', async () => {
+    renderWithProviders(<CuckooPage />);
+    const keep = await screen.findByRole('button', { name: 'キープ' });
+    expect(keep.querySelector('kbd')).toHaveTextContent('K');
+  });
+
   it('shows the round-loser reveal and dispatches nextround', async () => {
     mockExec.mockResolvedValue(roundEndState);
     renderWithProviders(<CuckooPage />);

--- a/frontend/src/pages/CuckooPage.tsx
+++ b/frontend/src/pages/CuckooPage.tsx
@@ -10,8 +10,10 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { KbdBadge } from '../components/KbdBadge';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
+import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
@@ -114,6 +116,21 @@ function CuckooPageContent() {
 
   const { cardWidth } = useCardDimensions();
   const phaseNames = usePhaseNames('cuckoo', CUCKOO_PHASE_KEYS);
+
+  // Keyboard shortcuts: keep/swap on a TURN, refuse/accept when targeted for a swap.
+  // Enabled only on the human's active turn (see the per-binding `enabled` flags).
+  const kbIsHumanTurn = state?.phase === CuckooPhase.TURN && state.currentPlayerIdx === 0 && !state.gameEndFlag;
+  const kbIsRefuseTarget = state?.phase === CuckooPhase.REFUSE && state.pendingSwapTo === 0 && !state.gameEndFlag;
+  const actionBindings = useMemo(
+    () => [
+      { key: 'k', action: () => exec('keep'), enabled: kbIsHumanTurn },
+      { key: 's', action: () => exec('swap'), enabled: kbIsHumanTurn },
+      { key: 'r', action: () => exec('refuse'), enabled: kbIsRefuseTarget },
+      { key: 'a', action: () => exec('accept'), enabled: kbIsRefuseTarget },
+    ],
+    [exec, kbIsHumanTurn, kbIsRefuseTarget],
+  );
+  useActionKeyboardNav({ bindings: actionBindings, enabled: !!state && !loading });
 
   if (!state)
     return <GameSkeleton gameKey="cuckoo" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 1 }} />;
@@ -256,9 +273,11 @@ function CuckooPageContent() {
                 <>
                   <button type="button" className={btnSuccess} onClick={() => exec('keep')} disabled={loading}>
                     {t('keepButton')}
+                    <KbdBadge label="K" />
                   </button>
                   <button type="button" className={btnPrimary} onClick={() => exec('swap')} disabled={loading}>
                     {humanIsDealer ? t('swapDealerButton') : t('swapButton')}
+                    <KbdBadge label="S" />
                   </button>
                 </>
               )}
@@ -267,9 +286,11 @@ function CuckooPageContent() {
                 <>
                   <button type="button" className={btnWarning} onClick={() => exec('refuse')} disabled={loading}>
                     {t('refuseButton')}
+                    <KbdBadge label="R" />
                   </button>
                   <button type="button" className={btnSuccess} onClick={() => exec('accept')} disabled={loading}>
                     {t('acceptButton')}
+                    <KbdBadge label="A" />
                   </button>
                 </>
               )}


### PR DESCRIPTION
## 概要

`CuckooPage.tsx` の操作は keep/swap（TURN）と refuse/accept（REFUSE）の 2 択ボタンのみで、キーボードショートカットが未実装だった。単純な 2 択ゲームこそキーボード完結の恩恵が大きい。

`FiveCardStudPage` と同じ `useActionKeyboardNav` を導入し、k=keep / s=swap / r=refuse / a=accept を各フェーズの有効時のみバインド。各ボタンに `KbdBadge` のキーヒントを添える（`aria-hidden` なのでアクセシブル名は不変）。

## 変更点

- `CuckooPage.tsx`: `useActionKeyboardNav` を導入（per-binding `enabled` で TURN/REFUSE を切替、`enabled: !!state && !loading`）。各アクションボタンに `<KbdBadge>` を追加

## 受け入れ条件

- [x] 人間の手番でキー操作が対応するボタンと同じ動作をする（k/s/r/a）
- [x] フェーズ外・loading 中はキーが効かない（`enabled` フラグ）
- [x] ボタンにキーヒントが表示される（`KbdBadge`）
- [x] キーバインドのテストを追加

## テスト

- `CuckooPage.test.tsx`: TURN で k→keep / s→swap、REFUSE で a→accept かつ k が無効、KbdBadge の 'K' 表示を検証（18 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3558