### PR TITLE
feat(betting): show per-button key hints on the betting controls (desktop)

### DIFF
--- a/frontend/src/components/BettingControls.test.tsx
+++ b/frontend/src/components/BettingControls.test.tsx
@@ -46,6 +46,9 @@ describe('BettingControls', () => {
     expect(screen.getByRole('button', { name: 'レイズ' })).toHaveAttribute('aria-keyshortcuts', 'r');
     expect(screen.getByRole('button', { name: 'フォールド' })).toHaveAttribute('aria-keyshortcuts', 'f');
     expect(screen.getByRole('button', { name: 'オールイン' })).toHaveAttribute('aria-keyshortcuts', 'a');
+    // Desktop: each button also carries a visible <kbd> key chip (aria-hidden, so the name is unchanged).
+    expect(screen.getByRole('button', { name: 'コール' }).querySelector('kbd')).toHaveTextContent('C');
+    expect(screen.getByRole('button', { name: 'フォールド' }).querySelector('kbd')).toHaveTextContent('F');
   });
 
   it('renders the check/bet key-hint line and aria-keyshortcuts when there is no outstanding bet', () => {

--- a/frontend/src/components/BettingControls.tsx
+++ b/frontend/src/components/BettingControls.tsx
@@ -1,6 +1,8 @@
 import { useTranslation } from 'react-i18next';
+import { useIsMobile } from '../hooks/useCardDimensions';
 import { btnPokerAccent, btnPokerAllIn, btnPokerMuted, btnPokerPrimary } from '../styles/buttonStyles';
 import { ChipBetInput } from './common/ChipBetInput';
+import { KbdBadge } from './KbdBadge';
 
 interface BettingControlsProps {
   inputId: string;
@@ -38,6 +40,9 @@ export function BettingControls({
   onAllIn,
 }: BettingControlsProps) {
   const { t } = useTranslation('common');
+  // Per-button key hints are a desktop affordance; on touch there's no keyboard.
+  const isMobile = useIsMobile();
+  const kbd = (label: string) => (isMobile ? null : <KbdBadge label={label} />);
   const max = maxBetAmount ?? 0;
   const hasMax = max > 0;
   const isOutOfRange = Number.isNaN(betAmount) || betAmount < minRaise || (hasMax && betAmount > max);
@@ -113,6 +118,7 @@ export function BettingControls({
             aria-keyshortcuts="c"
           >
             {t('action.call')}
+            {kbd('C')}
           </button>
           <button
             type="button"
@@ -122,6 +128,7 @@ export function BettingControls({
             aria-keyshortcuts="r"
           >
             {t('action.raise')}
+            {kbd('R')}
           </button>
         </>
       ) : (
@@ -134,6 +141,7 @@ export function BettingControls({
             aria-keyshortcuts="r"
           >
             {t('action.bet')}
+            {kbd('R')}
           </button>
           <button
             type="button"
@@ -143,6 +151,7 @@ export function BettingControls({
             aria-keyshortcuts="k"
           >
             {t('action.check')}
+            {kbd('K')}
           </button>
         </>
       )}
@@ -154,6 +163,7 @@ export function BettingControls({
         aria-keyshortcuts="f"
       >
         {t('action.fold')}
+        {kbd('F')}
       </button>
       <button
         type="button"
@@ -163,6 +173,7 @@ export function BettingControls({
         aria-keyshortcuts="a"
       >
         {t('action.allIn')}
+        {kbd('A')}
       </button>
       {/* Keyboard shortcut hint. BettingControls only renders while the human can
           act, so the shortcuts are always live here. Show only the actions that are


### PR DESCRIPTION
## 概要

`FiveCardStudPage` 等が使う `BettingControls` は `useActionKeyboardNav` で c/r/k/f/a を実装済み（`aria-keyshortcuts` とサマリーのキーヒント行もあり）だが、各ボタン自体にはキー表記がなく機能の存在に気づきにくかった。

各アクションボタン（コール/レイズ/ベット/チェック/フォールド/オールイン）に `KbdBadge` のキーヒントチップを追加。デスクトップのみ表示（`useIsMobile` でモバイルは省略）。チップは `aria-hidden` なのでアクセシブル名は不変で、共有コンポーネントを使う全ポーカー系ゲームのテストに影響しない。

## 変更点

- `BettingControls.tsx`: 各アクションボタンに `<KbdBadge>`（`useIsMobile` で非モバイル時のみ）。`aria-keyshortcuts` は既存のまま

## 受け入れ条件

- [x] 各操作ボタンにキーヒントが表示される（`KbdBadge`）
- [x] `aria-keyshortcuts` が設定される（既存）
- [x] モバイル表示ではヒントが出ない（`useIsMobile`）
- [x] `BettingControls` のテストを更新

## テスト

- `BettingControls.test.tsx`: コール/フォールドボタンの `<kbd>` が 'C'/'F' を含み、`aria-keyshortcuts` が維持されることを検証（43 tests pass）
- 共有コンポーネント：KbdBadge は aria-hidden ゆえアクセシブル名不変 → 全ポーカー系ページテストに影響なし
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3567