### PR TITLE
feat(openfacechinese): read out rows, pending card, and foul state

### DIFF
--- a/frontend/src/i18n/locales/en/openfacechinese.json
+++ b/frontend/src/i18n/locales/en/openfacechinese.json
@@ -39,5 +39,8 @@
     "rows": "Place each dealt card into one of three rows (Top 3, Middle 5, Bottom 5).",
     "place": "Pick the row to place the dealt card. Once placed, a card cannot be moved.",
     "resetButton": "Press this button to restart the game from the beginning."
-  }
+  },
+  "rowAriaEmpty": "{{label}} {{count}} cards",
+  "rowAriaFilled": "{{label}} {{count}} cards: {{cards}}",
+  "pendingAnnounce": "To place: {{card}}"
 }

--- a/frontend/src/i18n/locales/ja/openfacechinese.json
+++ b/frontend/src/i18n/locales/ja/openfacechinese.json
@@ -39,5 +39,8 @@
     "rows": "配られたカードを3段（トップ3枚・ミドル5枚・ボトム5枚）に置いていきます。",
     "place": "配られたカードを置く段を選びましょう。一度置いたカードは動かせません。",
     "resetButton": "ゲームを最初からやり直すにはこのボタンを押します。"
-  }
+  },
+  "rowAriaEmpty": "{{label}} {{count}}枚",
+  "rowAriaFilled": "{{label}} {{count}}枚: {{cards}}",
+  "pendingAnnounce": "配置待ち: {{card}}"
 }

--- a/frontend/src/pages/OpenFaceChinesePage.test.tsx
+++ b/frontend/src/pages/OpenFaceChinesePage.test.tsx
@@ -117,6 +117,24 @@ describe('OpenFaceChinesePage', () => {
     expect(screen.getByTestId('place-back')).toBeInTheDocument();
   });
 
+  it('announces the pending card and labels rows for screen readers', async () => {
+    renderWithProviders(<OpenFaceChinesePage />); // currentCard ♠A, human placing
+    const announce = await screen.findByTestId('ofc-pending-announce');
+    expect(announce).toHaveAttribute('role', 'status');
+    expect(announce).toHaveAttribute('aria-live', 'polite');
+    expect(announce).toHaveTextContent('配置待ち: ♠ A');
+    // Each row is a named group; both players' empty top rows report their count.
+    expect(screen.getAllByRole('group', { name: /トップ（3枚） 0枚/ }).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('names a filled row with its card contents', async () => {
+    mockExec.mockResolvedValue(roundEndState); // human top row = ♠2 ♥3 ♣4
+    renderWithProviders(<OpenFaceChinesePage />);
+    await waitFor(() =>
+      expect(screen.getByRole('group', { name: 'トップ（3枚） 3枚: ♠ 2, ♥ 3, ♣ 4' })).toBeInTheDocument(),
+    );
+  });
+
   it('places into the top row', async () => {
     renderWithProviders(<OpenFaceChinesePage />);
     const btn = await screen.findByTestId('place-front');

--- a/frontend/src/pages/OpenFaceChinesePage.tsx
+++ b/frontend/src/pages/OpenFaceChinesePage.tsx
@@ -22,6 +22,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { Card, OpenFaceChinesePlayer, OpenFaceChineseResponse } from '../types/card';
 import { OpenFaceChinesePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import { OPENFACECHINESE_HELP, parseOpenfacechineseCommand } from '../utils/cli/commands/openfacechineseCommands';
 import { formatOpenfacechineseState } from '../utils/cli/formatters/openfacechineseFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -120,24 +121,35 @@ function OpenFaceChinesePageContent() {
   const playerName = (player: OpenFaceChinesePlayer) => (player.isHuman ? t('you') : t('cpu', { n: player.id }));
 
   /** Renders a single row of a player's board, padding empty slots up to `capacity`. */
-  const renderRow = (label: string, cards: Card[], capacity: number, keyPrefix: string) => (
-    <div className="flex flex-col gap-1">
-      <span className="text-ds-text-muted text-[11px]">{label}</span>
-      <div className="flex gap-1 flex-wrap">
-        {cards.map((c, i) => (
-          <CardImage key={`${keyPrefix}-${i}`} card={c} width={Math.round(cardWidth * 0.62)} />
-        ))}
-        {Array.from({ length: Math.max(0, capacity - cards.length) }).map((_, i) => (
-          <div
-            key={`${keyPrefix}-empty-${i}`}
-            className="rounded border border-dashed border-white/20 bg-black/20"
-            style={{ width: Math.round(cardWidth * 0.62), height: Math.round(cardWidth * 0.62 * 1.4) }}
-            aria-hidden="true"
-          />
-        ))}
-      </div>
-    </div>
-  );
+  const renderRow = (label: string, cards: Card[], capacity: number, keyPrefix: string) => {
+    // A fieldset+legend names the whole row for SR (count + card contents), since
+    // the empty slots are decorative and biome forbids role="group" on a div.
+    const cardNames = cards.map(cardAlt).join(', ');
+    const rowAria = cardNames
+      ? t('rowAriaFilled', { label, count: cards.length, cards: cardNames })
+      : t('rowAriaEmpty', { label, count: cards.length });
+    return (
+      <fieldset className="flex flex-col gap-1 border-0 p-0 m-0" data-testid={`ofc-row-${keyPrefix}`}>
+        <legend className="sr-only">{rowAria}</legend>
+        <span className="text-ds-text-muted text-[11px]" aria-hidden="true">
+          {label}
+        </span>
+        <div className="flex gap-1 flex-wrap">
+          {cards.map((c, i) => (
+            <CardImage key={`${keyPrefix}-${i}`} card={c} width={Math.round(cardWidth * 0.62)} />
+          ))}
+          {Array.from({ length: Math.max(0, capacity - cards.length) }).map((_, i) => (
+            <div
+              key={`${keyPrefix}-empty-${i}`}
+              className="rounded border border-dashed border-white/20 bg-black/20"
+              style={{ width: Math.round(cardWidth * 0.62), height: Math.round(cardWidth * 0.62 * 1.4) }}
+              aria-hidden="true"
+            />
+          ))}
+        </div>
+      </fieldset>
+    );
+  };
 
   return (
     <GamePageShell
@@ -166,6 +178,11 @@ function OpenFaceChinesePageContent() {
               <span className="font-semibold text-ds-warning">{t('round', { round: state.roundNumber })}</span>
               {human && <span className="text-ds-text-muted">{t('totalScore', { score: human.totalScore })}</span>}
             </div>
+
+            {/* Announce the pending card by name whenever it changes (persistent region). */}
+            <span className="sr-only" role="status" aria-live="polite" data-testid="ofc-pending-announce">
+              {canPlace && state.currentCard ? t('pendingAnnounce', { card: cardAlt(state.currentCard) }) : ''}
+            </span>
 
             {/* Pending card to place */}
             {canPlace && state.currentCard && (
@@ -219,8 +236,16 @@ function OpenFaceChinesePageContent() {
                   <div className="flex items-center justify-between mb-2">
                     <span className="text-ds-text-primary text-sm font-semibold">{playerName(p)}</span>
                     <div className="flex items-center gap-2 text-xs">
-                      {p.fouled && <span className="text-ds-error font-semibold">{t('fouled')}</span>}
-                      {p.fantasyland && <span className="text-ds-accent font-semibold">{t('fantasyland')}</span>}
+                      {p.fouled && (
+                        <span className="text-ds-error font-semibold" role="status">
+                          {t('fouled')}
+                        </span>
+                      )}
+                      {p.fantasyland && (
+                        <span className="text-ds-accent font-semibold" role="status">
+                          {t('fantasyland')}
+                        </span>
+                      )}
                     </div>
                   </div>
                   <div className="flex flex-col gap-2">


### PR DESCRIPTION
## 概要

`OpenFaceChinesePage.tsx` の `renderRow` は空スロットを `aria-hidden` の装飾 div とし、ロー全体にラベルもなく、スクリーンリーダーには front/middle/back に何が何枚あるか伝わらなかった。配置待ちカード（`currentCard`）の切り替わりや FOULED/FANTASYLAND も未通知だった。

各ローを `<fieldset>`＋sr-only `<legend>`（枚数＋内容を `cardAlt` で合成）で名前付けし、配置待ちカードを持続的な `aria-live="polite"` リージョンで読み上げ、FOULED/FANTASYLAND バッジに `role="status"` を付与する。（biome は div の `role="group"` を禁じるため fieldset を採用）

## 変更点

- `OpenFaceChinesePage.tsx`: `renderRow` を fieldset 化（legend にロー名＋枚数＋カード名）、`ofc-pending-announce` の sr-only ライブリージョン、fouled/fantasyland に `role="status"`
- i18n キー `rowAriaEmpty`／`rowAriaFilled`／`pendingAnnounce` を ja / en に追加

## 受け入れ条件

- [x] 各ローに枚数と内容を含む aria-label（legend）が付与される
- [x] 配置待ちカードの変化が `aria-live` で通知される
- [x] ファウル表示が SR で検知できる（`role="status"`）
- [x] 既存テスト green＋アクセシビリティ属性テスト追加

## テスト

- `OpenFaceChinesePage.test.tsx`: pending-announce の `role=status`/`aria-live`＋「配置待ち: ♠ A」、空ローの group 名、埋まったローの「トップ（3枚） 3枚: ♠ 2, ♥ 3, ♣ 4」を検証（13 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3573