### PR TITLE
feat(simplesimon): label cards by name+position and expose selection

### DIFF
--- a/frontend/src/i18n/locales/en/simplesimon.json
+++ b/frontend/src/i18n/locales/en/simplesimon.json
@@ -1,5 +1,9 @@
 {
-  "phase": { "playing": "Playing", "gameClear": "Game Clear", "gameOver": "Game Over" },
+  "phase": {
+    "playing": "Playing",
+    "gameClear": "Game Clear",
+    "gameOver": "Game Over"
+  },
   "title": "Simple Simon",
   "completedSuits": "Completed suits: {{count}} / 4",
   "moveCount": "Moves: {{count}}",
@@ -19,5 +23,7 @@
     "rules": "A complete King-to-Ace same-suit run is removed automatically. Clear all four suits to win. There is no stock.",
     "actionButtons": "Hint, undo and give-up controls.",
     "resetButton": "Start a new game."
-  }
+  },
+  "cardPosAria": "{{card}} (column {{col}}, position {{pos}})",
+  "emptyColAria": "column {{col}} (empty)"
 }

--- a/frontend/src/i18n/locales/ja/simplesimon.json
+++ b/frontend/src/i18n/locales/ja/simplesimon.json
@@ -1,5 +1,9 @@
 {
-  "phase": { "playing": "プレイ中", "gameClear": "ゲームクリア", "gameOver": "ゲームオーバー" },
+  "phase": {
+    "playing": "プレイ中",
+    "gameClear": "ゲームクリア",
+    "gameOver": "ゲームオーバー"
+  },
   "title": "シンプル・サイモン",
   "completedSuits": "完成スート: {{count}} / 4",
   "moveCount": "手数: {{count}}",
@@ -19,5 +23,7 @@
     "rules": "同スートでK〜Aの完全な降順列が揃うと自動的に除去されます。4スート全て除去でクリアです。ストックはありません。",
     "actionButtons": "ヒント・元に戻す・ギブアップなどの操作ボタンです。",
     "resetButton": "新しいゲームを始めるボタンです。"
-  }
+  },
+  "cardPosAria": "{{card}}（列{{col}}・上から{{pos}}枚目）",
+  "emptyColAria": "列{{col}}（空）"
 }

--- a/frontend/src/pages/SimpleSimonPage.test.tsx
+++ b/frontend/src/pages/SimpleSimonPage.test.tsx
@@ -62,6 +62,20 @@ describe('SimpleSimonPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('m', { fromCol: 1, cardIndex: 0, toCol: 0 }));
   });
 
+  it('labels cards with name+position and reflects selection with aria-pressed', async () => {
+    renderWithProviders(<SimpleSimonPage />);
+    // column[1] is ♠8 at the top → "♠ 8（列2・上から1枚目）".
+    const src = await screen.findByTestId('card-1-0');
+    expect(src).toHaveAttribute('aria-label', '♠ 8（列2・上から1枚目）');
+    expect(src).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(src);
+    expect(screen.getByTestId('card-1-0')).toHaveAttribute('aria-pressed', 'true');
+    // Empty column drop targets are named too.
+    expect(screen.getByTestId('column-2-drop')).toHaveAttribute('aria-label', '列3（空）');
+    // The selection guidance is a live region.
+    expect(screen.getByTestId('ss-guidance')).toHaveAttribute('role', 'status');
+  });
+
   it('moves onto an empty column', async () => {
     renderWithProviders(<SimpleSimonPage />);
     const srcCard = await screen.findByTestId('card-0-0');

--- a/frontend/src/pages/SimpleSimonPage.tsx
+++ b/frontend/src/pages/SimpleSimonPage.tsx
@@ -18,6 +18,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { Card } from '../types/card';
 import { SimpleSimonPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 
 /** Simple Simon tutorial step definitions. */
 const SS_TUTORIAL_STEPS: TutorialStep[] = [
@@ -121,22 +122,28 @@ function SimpleSimonPageContent() {
           onClick={canAct ? () => clickColumn(col) : undefined}
           disabled={!canAct}
           title={t('empty')}
+          aria-label={t('emptyColAria', { col: col + 1 })}
           data-testid={`column-${col}-drop`}
         />
       ) : (
-        column.map((c, i) => (
-          <button
-            type="button"
-            key={`col-${col}-${i}`}
-            className={`rounded ${selected && selected.col === col && i >= selected.idx ? 'ring-2 ring-ds-warning' : ''}`}
-            style={{ marginTop: i === 0 ? 0 : -Math.round(w * 1.05) }}
-            onClick={canAct ? () => clickCard(col, i) : undefined}
-            disabled={!canAct}
-            data-testid={`card-${col}-${i}`}
-          >
-            <CardImage card={c} width={w} />
-          </button>
-        ))
+        column.map((c, i) => {
+          const inSelectedRun = Boolean(selected && selected.col === col && i >= selected.idx);
+          return (
+            <button
+              type="button"
+              key={`col-${col}-${i}`}
+              className={`rounded ${inSelectedRun ? 'ring-2 ring-ds-warning' : ''}`}
+              style={{ marginTop: i === 0 ? 0 : -Math.round(w * 1.05) }}
+              onClick={canAct ? () => clickCard(col, i) : undefined}
+              disabled={!canAct}
+              data-testid={`card-${col}-${i}`}
+              aria-label={t('cardPosAria', { card: cardAlt(c), col: col + 1, pos: i + 1 })}
+              aria-pressed={inSelectedRun}
+            >
+              <CardImage card={c} width={w} />
+            </button>
+          );
+        })
       )}
     </div>
   );
@@ -162,7 +169,7 @@ function SimpleSimonPageContent() {
           {state.columns.map((column, i) => renderColumn(column, i))}
         </div>
         {canAct && (
-          <div className="mt-2 text-ds-text-primary text-xs">
+          <div className="mt-2 text-ds-text-primary text-xs" role="status" data-testid="ss-guidance">
             {selected === null ? t('selectSource') : t('selectDestination')}
           </div>
         )}


### PR DESCRIPTION
## 概要

`SimpleSimonPage.tsx` の各カードボタンは `aria-label` がなく、スクリーンリーダーには内容不明のボタンが最大52個並ぶ。空列ドロップ先も `title` のみ、選択状態はリング色だけだった。

`cardAlt` で「♠ 10（列3・上から5枚目）」形式の `aria-label` を全カードボタンに付与し、選択中の範囲に `aria-pressed` を設定。空列ボタンに `aria-label`、選択ガイダンス行に `role="status"` を付ける。

## 変更点

- `SimpleSimonPage.tsx`: カードボタンに `aria-label`（`cardPosAria`）＋`aria-pressed`（選択 run）、空列 drop に `aria-label`（`emptyColAria`）、ガイダンス div に `role="status"`／`data-testid="ss-guidance"`
- i18n キー `cardPosAria`／`emptyColAria` を ja / en に追加

## 受け入れ条件

- [x] 全カードボタンにカード名と位置を含む aria-label が付く
- [x] 選択中カードが `aria-pressed` で判別できる
- [x] 選択ガイダンスが `role="status"` で通知される
- [x] 属性検証テストを追加

## テスト

- `SimpleSimonPage.test.tsx`: card-1-0 の `aria-label="♠ 8（列2・上から1枚目）"`＋`aria-pressed` false→true、空列 `列3（空）`、guidance の `role=status` を検証（8 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3582