### PR TITLE
feat(blackhole): read out cards and hints on non-visual channels

### DIFF
--- a/frontend/src/i18n/locales/en/blackhole.json
+++ b/frontend/src/i18n/locales/en/blackhole.json
@@ -1,5 +1,9 @@
 {
-  "phase": { "playing": "Playing", "gameClear": "Game Clear", "gameOver": "Game Over" },
+  "phase": {
+    "playing": "Playing",
+    "gameClear": "Game Clear",
+    "gameOver": "Game Over"
+  },
   "title": "Black Hole",
   "blackHole": "Black Hole",
   "fan": "Fan",
@@ -19,5 +23,11 @@
     "rules": "A fan top can be absorbed when its rank is one away from the black hole top (any suit, no King-Ace wrap). Absorb all 52 cards to win.",
     "actionButtons": "Buttons for hint, undo, give up and more.",
     "resetButton": "Start a new game."
-  }
+  },
+  "fanCardAria": "{{card}} (fan {{fan}})",
+  "holeAria": "Black hole: {{card}}",
+  "holeEmptyAria": "Black hole: empty",
+  "hintPlayable": "playable",
+  "hintLegalFans": "Playable: {{list}}",
+  "hintNoLegal": "No playable card"
 }

--- a/frontend/src/i18n/locales/ja/blackhole.json
+++ b/frontend/src/i18n/locales/ja/blackhole.json
@@ -1,5 +1,9 @@
 {
-  "phase": { "playing": "プレイ中", "gameClear": "ゲームクリア", "gameOver": "ゲームオーバー" },
+  "phase": {
+    "playing": "プレイ中",
+    "gameClear": "ゲームクリア",
+    "gameOver": "ゲームオーバー"
+  },
   "title": "ブラックホール",
   "blackHole": "ブラックホール",
   "fan": "扇",
@@ -19,5 +23,11 @@
     "rules": "扇の最上位が、ブラックホール最上位と±1ランク（スート不問・K-Aのつながりなし）なら吸い込めます。全52枚を吸い込むとクリアです。",
     "actionButtons": "ヒント・元に戻す・ギブアップなどの操作ボタンです。",
     "resetButton": "新しいゲームを始めるボタンです。"
-  }
+  },
+  "fanCardAria": "{{card}}（ファン{{fan}}）",
+  "holeAria": "ブラックホール: {{card}}",
+  "holeEmptyAria": "ブラックホール: 空",
+  "hintPlayable": "置けます",
+  "hintLegalFans": "置けるカード: {{list}}",
+  "hintNoLegal": "置けるカードがありません"
 }

--- a/frontend/src/pages/BlackHolePage.test.tsx
+++ b/frontend/src/pages/BlackHolePage.test.tsx
@@ -106,6 +106,17 @@ describe('BlackHolePage', () => {
     expect(screen.getByTestId('card-0-1').className).toContain('ring-ds-success');
     // The non-adjacent fan top is never marked.
     expect(otherTop).not.toHaveAttribute('data-hinted-legal');
+    // Non-visual channels: aria-label gains "置けます" and the live region lists it.
+    expect(screen.getByTestId('card-0-1')).toHaveAttribute('aria-label', '♣ 6（ファン1） · 置けます');
+    expect(screen.getByTestId('bh-hint-announce')).toHaveTextContent('置けるカード: ♣ 6（ファン1）');
+  });
+
+  it('labels fan cards and the black hole for screen readers', async () => {
+    mockExec.mockResolvedValue(makeState({ blackHole: [card('DIAMOND', 6)] }));
+    renderWithProviders(<BlackHolePage />);
+    // fan0 top ♣6, hole ♦6.
+    expect(await screen.findByRole('button', { name: '♣ 6（ファン1）' })).toBeInTheDocument();
+    expect(screen.getByTestId('bh-hole-top')).toHaveAttribute('aria-label', 'ブラックホール: ♦ 6');
   });
 
   it('clears the hint highlight on reset even though moveCount stays 0', async () => {

--- a/frontend/src/pages/BlackHolePage.tsx
+++ b/frontend/src/pages/BlackHolePage.tsx
@@ -17,6 +17,7 @@ import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import { BlackHolePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 
 /** Black Hole tutorial step definitions. */
 const BH_TUTORIAL_STEPS: TutorialStep[] = [
@@ -115,6 +116,22 @@ function BlackHolePageContent() {
       : [],
   );
 
+  // Spoken hint result: list the playable fan-top cards (or "none"), shown only
+  // while the visual highlight is active.
+  const hintAnnounce = !showLegalHint
+    ? ''
+    : legalFans.size > 0
+      ? t('hintLegalFans', {
+          list: [...legalFans]
+            .map((idx) => {
+              const top = state.fans[idx][state.fans[idx].length - 1];
+              return top ? t('fanCardAria', { card: cardAlt(top), fan: idx + 1 }) : '';
+            })
+            .filter(Boolean)
+            .join('、'),
+        })
+      : t('hintNoLegal');
+
   const renderFan = (fan: (typeof state.fans)[number], idx: number) => (
     <div
       key={`fan-${idx}`}
@@ -132,18 +149,29 @@ function BlackHolePageContent() {
         fan.map((c, i) => {
           const isTop = i === fan.length - 1;
           const isHintedLegal = showLegalHint && isTop && legalFans.has(idx);
+          const cardLabel = t('fanCardAria', { card: cardAlt(c), fan: idx + 1 });
           return (
             <button
               type="button"
               key={`fan-${idx}-${i}`}
-              className={`rounded ${isHintedLegal ? 'ring-2 ring-ds-success motion-safe:animate-pulse' : ''}`}
+              className={`relative rounded ${isHintedLegal ? 'ring-2 ring-ds-success motion-safe:animate-pulse' : ''}`}
               style={{ marginTop: i === 0 ? 0 : -Math.round(w * 1.05) }}
               onClick={canAct && isTop ? () => playFan(idx) : undefined}
               disabled={!canAct || !isTop}
               data-testid={`card-${idx}-${i}`}
               data-hinted-legal={isHintedLegal ? 'true' : undefined}
+              aria-label={isHintedLegal ? `${cardLabel} · ${t('hintPlayable')}` : cardLabel}
             >
               <CardImage card={c} width={w} />
+              {/* Colour-independent hint marker (a ✓ badge) alongside the ring. */}
+              {isHintedLegal && (
+                <span
+                  aria-hidden="true"
+                  className="absolute -top-1 -right-1 rounded-full bg-ds-success text-white text-[10px] leading-none px-1 py-0.5"
+                >
+                  ✓
+                </span>
+              )}
             </button>
           );
         })
@@ -171,11 +199,19 @@ function BlackHolePageContent() {
           <div
             className="rounded-full bg-black/60 border-2 border-ds-accent flex items-center justify-center"
             style={{ width: cardH, height: cardH }}
+            role="img"
+            aria-label={holeTop ? t('holeAria', { card: cardAlt(holeTop) }) : t('holeEmptyAria')}
+            data-testid="bh-hole-top"
           >
             {holeTop ? <CardImage card={holeTop} width={w} /> : null}
           </div>
           <div className="text-ds-text-muted text-xs">{t('moveCount', { count: state.moveCount })}</div>
         </div>
+
+        {/* Hint result also spoken (colour/animation is not enough). */}
+        <span className="sr-only" role="status" aria-live="polite" data-testid="bh-hint-announce">
+          {hintAnnounce}
+        </span>
 
         <div className="grid grid-cols-6 sm:grid-cols-9 gap-1 items-start" data-tutorial="bh-fans">
           {state.fans.map((fan, i) => renderFan(fan, i))}


### PR DESCRIPTION
## 概要

`BlackHolePage.tsx` のヒントは `ring-2 ring-ds-success motion-safe:animate-pulse` の色＋アニメーションに完全依存し、ファンカードやホールにも `aria-label` がなく、スクリーンリーダーでは盤面もヒント結果も把握できなかった。

`cardAlt` で全ファンカードに aria-label を付与、ホールに `role="img"`＋「ブラックホール: ♦ 6」ラベルを追加。ヒント実行時は色以外に ✓ バッジ、aria-label に「置けます」、`role="status"` ライブリージョンで置けるカードを読み上げる。

## 変更点

- `BlackHolePage.tsx`: ファンカードに `aria-label`（`fanCardAria`、ヒント時「置けます」付与）＋ ✓ バッジ、ホールに `role="img"`＋`aria-label`（`bh-hole-top`）、`bh-hint-announce` の live region
- i18n キー `fanCardAria`／`holeAria`／`holeEmptyAria`／`hintPlayable`／`hintLegalFans`／`hintNoLegal` を ja / en に追加

## 受け入れ条件

- [x] 全ファンカードとホールに aria-label が付く
- [x] ヒント結果が aria-live テキストでも通知される
- [x] 色以外（✓ バッジ＋テキスト）でもヒント対象が判別できる
- [x] 属性・live region のテストを追加

## テスト

- `BlackHolePage.test.tsx`: ヒント時 card-0-1 の `aria-label="♣ 6（ファン1） · 置けます"`＋live region「置けるカード: ♣ 6（ファン1）」、ホールの `aria-label="ブラックホール: ♦ 6"` を検証（11 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3588