### PR TITLE
feat(allfours): read out trump/turn-up by name and standardise the hint toggle

### DIFF
--- a/frontend/src/i18n/locales/en/allfours.json
+++ b/frontend/src/i18n/locales/en/allfours.json
@@ -63,5 +63,11 @@
     "playButton": "Select a card, then play it with this button.",
     "scoreTable": "The score table. Compete for High/Low/Jack/Game; first to 7 points wins.",
     "resetButton": "The reset button starts a new game."
+  },
+  "suitName": {
+    "spade": "Spade",
+    "club": "Club",
+    "heart": "Heart",
+    "diamond": "Diamond"
   }
 }

--- a/frontend/src/i18n/locales/ja/allfours.json
+++ b/frontend/src/i18n/locales/ja/allfours.json
@@ -63,5 +63,11 @@
     "playButton": "カードを選んだらこのボタンで出します。",
     "scoreTable": "スコア表です。High/Low/Jack/Game の4ポイントを競い、先に7点で勝利です。",
     "resetButton": "リセットボタンで新しいゲームを始められます。"
+  },
+  "suitName": {
+    "spade": "スペード",
+    "club": "クラブ",
+    "heart": "ハート",
+    "diamond": "ダイヤ"
   }
 }

--- a/frontend/src/pages/AllFoursPage.test.tsx
+++ b/frontend/src/pages/AllFoursPage.test.tsx
@@ -135,6 +135,18 @@ describe('AllFoursPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', undefined, undefined, 0));
   });
 
+  it('reads out the trump suit and turn-up by name', async () => {
+    renderWithProviders(<AllFoursPage />); // trumpSuit 3 = ♥, turnUp ♥7
+    expect(await screen.findByRole('img', { name: '切り札: ハート' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'めくり札: ハート7' })).toBeInTheDocument();
+  });
+
+  it('exposes the hint toggle as a labelled checkbox in the settings panel', async () => {
+    renderWithProviders(<AllFoursPage />);
+    const toggle = await screen.findByRole('checkbox', { name: /ヒント/ });
+    expect(toggle).toBeInTheDocument();
+  });
+
   it('shows winner message at game end', async () => {
     mockExec.mockResolvedValueOnce(gameEndState);
     renderWithProviders(<AllFoursPage />);

--- a/frontend/src/pages/AllFoursPage.test.tsx
+++ b/frontend/src/pages/AllFoursPage.test.tsx
@@ -147,6 +147,14 @@ describe('AllFoursPage', () => {
     expect(toggle).toBeInTheDocument();
   });
 
+  it('reads the trump as unset and omits the turn-up before it is decided', async () => {
+    mockExec.mockResolvedValueOnce({ ...baseState, trumpSuit: 0, turnUp: null });
+    renderWithProviders(<AllFoursPage />);
+    expect(await screen.findByRole('img', { name: '切り札: 未確定' })).toBeInTheDocument();
+    // No turn-up card is shown before it is flipped.
+    expect(screen.queryByRole('img', { name: /めくり札/ })).not.toBeInTheDocument();
+  });
+
   it('shows winner message at game end', async () => {
     mockExec.mockResolvedValueOnce(gameEndState);
     renderWithProviders(<AllFoursPage />);

--- a/frontend/src/pages/AllFoursPage.test.tsx
+++ b/frontend/src/pages/AllFoursPage.test.tsx
@@ -141,6 +141,12 @@ describe('AllFoursPage', () => {
     expect(screen.getByRole('img', { name: 'めくり札: ハート7' })).toBeInTheDocument();
   });
 
+  it('spells a face-card turn-up with its letter (♠J → スペードJ)', async () => {
+    mockExec.mockResolvedValueOnce({ ...baseState, trumpSuit: 1, turnUp: { design: 'SPADE', value: 11 } });
+    renderWithProviders(<AllFoursPage />);
+    expect(await screen.findByRole('img', { name: 'めくり札: スペードJ' })).toBeInTheDocument();
+  });
+
   it('exposes the hint toggle as a labelled checkbox in the settings panel', async () => {
     renderWithProviders(<AllFoursPage />);
     const toggle = await screen.findByRole('checkbox', { name: /ヒント/ });

--- a/frontend/src/pages/AllFoursPage.tsx
+++ b/frontend/src/pages/AllFoursPage.tsx
@@ -250,7 +250,7 @@ function AllFoursPageContent() {
                 <span
                   role="img"
                   aria-label={t('turnUp', {
-                    card: `${t(`suitName.${SUIT_NAME_BY_DESIGN[state.turnUp.design] ?? ''}`, state.turnUp.design)}${VALUE_LABELS[state.turnUp.value] ?? state.turnUp.value}`,
+                    card: `${t(`suitName.${SUIT_NAME_BY_DESIGN[state.turnUp.design]}`, state.turnUp.design)}${VALUE_LABELS[state.turnUp.value] ?? state.turnUp.value}`,
                   })}
                 >
                   <span aria-hidden="true">{t('turnUp', { card: cardLabel(state.turnUp) })}</span>

--- a/frontend/src/pages/AllFoursPage.tsx
+++ b/frontend/src/pages/AllFoursPage.tsx
@@ -87,6 +87,22 @@ const SUIT_LABELS: Readonly<Record<number, string>> = {
   4: '♦',
 };
 
+/** Suit-name i18n key suffixes indexed by trump-suit number (1=♠ 2=♣ 3=♥ 4=♦). */
+const SUIT_NAME_KEYS: Readonly<Record<number, string>> = {
+  1: 'spade',
+  2: 'club',
+  3: 'heart',
+  4: 'diamond',
+};
+
+/** Suit-name i18n key suffixes indexed by card design string. */
+const SUIT_NAME_BY_DESIGN: Readonly<Record<string, string>> = {
+  SPADE: 'spade',
+  CLOVER: 'club',
+  HEART: 'heart',
+  DIAMOND: 'diamond',
+};
+
 const SUIT_DESIGNS: Readonly<Record<string, string>> = {
   SPADE: '♠',
   CLOVER: '♣',
@@ -217,18 +233,31 @@ function AllFoursPageContent() {
               <span>{t('round', { n: state.roundNumber })}</span>
               <span>{t('trick', { n: state.trickNumber })}</span>
               <span>{t('dealer', { name: findPlayerName(state.players, state.dealerIdx) })}</span>
-              <span>
-                {t('trumpSuit', {
-                  suit: state.trumpSuit === 0 ? t('trumpUnset') : (SUIT_LABELS[state.trumpSuit] ?? '?'),
+              {/* Trump: symbol shown, suit read out by name to avoid "black spade symbol". */}
+              <span
+                role="img"
+                aria-label={t('trumpSuit', {
+                  suit: state.trumpSuit === 0 ? t('trumpUnset') : t(`suitName.${SUIT_NAME_KEYS[state.trumpSuit]}`, '?'),
                 })}
+              >
+                <span aria-hidden="true">
+                  {t('trumpSuit', {
+                    suit: state.trumpSuit === 0 ? t('trumpUnset') : (SUIT_LABELS[state.trumpSuit] ?? '?'),
+                  })}
+                </span>
               </span>
-              {state.turnUp && <span>{t('turnUp', { card: cardLabel(state.turnUp) })}</span>}
+              {state.turnUp && (
+                <span
+                  role="img"
+                  aria-label={t('turnUp', {
+                    card: `${t(`suitName.${SUIT_NAME_BY_DESIGN[state.turnUp.design] ?? ''}`, state.turnUp.design)}${VALUE_LABELS[state.turnUp.value] ?? state.turnUp.value}`,
+                  })}
+                >
+                  <span aria-hidden="true">{t('turnUp', { card: cardLabel(state.turnUp) })}</span>
+                </span>
+              )}
             </div>
 
-            <label className="flex items-center gap-1 text-ds-text-primary text-xs justify-center mb-2 cursor-pointer">
-              <input type="checkbox" checked={hintEnabled} onChange={(e) => setHintEnabled(e.target.checked)} />
-              {tc('hint.toggle', { ns: 'tutorial' })}
-            </label>
             {hintEnabled && hint && <HintTooltip reason={t(hint.reason)} confidence={hint.confidence} />}
 
             <div data-tutorial="af-score-table" className="overflow-x-auto mb-3">
@@ -335,6 +364,13 @@ function AllFoursPageContent() {
                       value: pointLimit,
                       options: [5, 7, 9, 11, 15, 21].map((v) => ({ value: v, label: String(v) })),
                       onSelect: (v) => handleConfigChange('pointLimit', Number(v)),
+                    },
+                    {
+                      type: 'checkbox',
+                      id: 'frontendHint',
+                      label: tc('hint.toggle', { ns: 'tutorial' }),
+                      checked: hintEnabled,
+                      onToggle: setHintEnabled,
                     },
                   ],
                 },


### PR DESCRIPTION
## 概要

`AllFoursPage.tsx` の情報バーは `SUIT_LABELS`（♠♣♥♦）や `cardLabel()` の記号をそのまま `t('trumpSuit', {...})` に埋め込んでおり、スクリーンリーダーは「ブラックスペード記号」等の不安定な読み上げになっていた。ヒントトグルも素の `<input type="checkbox">` で、共有 `SettingsPanel` に統一されていなかった。

トランプ・ターンアップ表示に `role="img"`＋スート名 aria-label（例:「切り札: スペード」）を付与し記号を `aria-hidden` に、ヒントトグルを `SettingsPanel` の `type: 'checkbox'` item へ移設する。

## 変更点

- `AllFoursPage.tsx`: `SUIT_NAME_KEYS`／`SUIT_NAME_BY_DESIGN` マップ追加。切り札・めくり札を `role="img"`＋スート名 aria-label（記号 aria-hidden）に。ヒントトグルを SettingsPanel の checkbox item へ移設
- i18n キー `suitName.{spade,club,heart,diamond}` を ja / en に追加

## 受け入れ条件

- [x] 切り札・ターンアップがテキストで読み上げ可能（`role=img`＋スート名）
- [x] ヒントトグルが SettingsPanel 内で操作できる
- [x] 手札ボタンの aria-label（cardLabel）が維持される
- [x] 属性検証テストを追加

## テスト

- `AllFoursPage.test.tsx`: 切り札 `role=img`「切り札: ハート」、めくり札「めくり札: ハート7」、ヒント checkbox（`getByRole('checkbox',{name:/ヒント/})`）を検証（9 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3594