### PR TITLE
feat(trenteetquarante): clarify the selected bet and always show its meaning

### DIFF
--- a/frontend/src/pages/TrenteEtQuarantePage.test.tsx
+++ b/frontend/src/pages/TrenteEtQuarantePage.test.tsx
@@ -83,6 +83,21 @@ describe('TrenteEtQuarantePage', () => {
     expect(screen.getByTestId(`teq-bet-${TrenteEtQuaranteBetType.INVERSE}`)).toBeInTheDocument();
   });
 
+  it('highlights the selected bet with a check mark and always shows the descriptions', async () => {
+    mockApi.mockResolvedValue(betState);
+    renderWithProviders(<TrenteEtQuarantePage />);
+    // Couleur/Inverse meanings are shown as static text (not only tooltips).
+    await waitFor(() => expect(screen.getByText('最初のカードの色が勝ち色と一致')).toBeInTheDocument());
+    expect(screen.getByText('最初のカードの色が勝ち色と不一致')).toBeInTheDocument();
+    // Selecting Rouge marks it pressed with a ✓; the previously selected Noir is not.
+    fireEvent.click(screen.getByTestId(`teq-bet-${TrenteEtQuaranteBetType.ROUGE}`));
+    const rouge = screen.getByTestId(`teq-bet-${TrenteEtQuaranteBetType.ROUGE}`);
+    expect(rouge).toHaveAttribute('aria-pressed', 'true');
+    expect(rouge).toHaveTextContent('✓');
+    expect(rouge.className).toContain('ring-2');
+    expect(screen.getByTestId(`teq-bet-${TrenteEtQuaranteBetType.NOIR}`)).toHaveAttribute('aria-pressed', 'false');
+  });
+
   it('deals with the selected bet type and stake', async () => {
     mockApi.mockResolvedValue(betState);
     renderWithProviders(<TrenteEtQuarantePage />);

--- a/frontend/src/pages/TrenteEtQuarantePage.tsx
+++ b/frontend/src/pages/TrenteEtQuarantePage.tsx
@@ -215,21 +215,35 @@ function TrenteEtQuarantePageContent() {
             {isBetPhase && (
               <div className="flex flex-col items-center gap-3 pb-2" data-tutorial="teq-bet-controls">
                 {/* biome-ignore lint/a11y/useSemanticElements: a flex row of bet buttons; fieldset would break the layout */}
-                <div className="flex flex-wrap justify-center gap-2" role="group" aria-label={t('label.betType')}>
-                  {BET_OPTIONS.map((opt) => (
-                    <button
-                      key={opt.type}
-                      type="button"
-                      aria-pressed={betType === opt.type}
-                      title={t(opt.descKey)}
-                      className={betType === opt.type ? btnPrimary : btnSecondary}
-                      onClick={() => setBetType(opt.type)}
-                      disabled={loading}
-                      data-testid={`teq-bet-${opt.type}`}
-                    >
-                      {t(opt.labelKey)}
-                    </button>
-                  ))}
+                <div
+                  className="flex flex-wrap justify-center items-start gap-2"
+                  role="group"
+                  aria-label={t('label.betType')}
+                >
+                  {BET_OPTIONS.map((opt) => {
+                    const selected = betType === opt.type;
+                    return (
+                      <div key={opt.type} className="flex flex-col items-center w-24">
+                        <button
+                          type="button"
+                          aria-pressed={selected}
+                          title={t(opt.descKey)}
+                          className={`w-full ${selected ? `${btnPrimary} ring-2 ring-white` : btnSecondary}`}
+                          onClick={() => setBetType(opt.type)}
+                          disabled={loading}
+                          data-testid={`teq-bet-${opt.type}`}
+                        >
+                          {/* Shape cue for the current choice, in addition to the colour. */}
+                          {selected && <span aria-hidden="true">✓ </span>}
+                          {t(opt.labelKey)}
+                        </button>
+                        {/* Couleur/Inverse are opaque on sight — keep the meaning always visible. */}
+                        <span className="mt-0.5 text-[10px] leading-tight text-ds-text-muted text-center">
+                          {t(opt.descKey)}
+                        </span>
+                      </div>
+                    );
+                  })}
                 </div>
                 <ChipBetInput
                   id="trenteetquarante-bet-amount"


### PR DESCRIPTION
## 概要

`TrenteEtQuarantePage.tsx` の BET_OPTIONS 4 種は `aria-pressed`／`title` は付くが、選択状態の視覚差が `btnPrimary`/`btnSecondary` の色替えのみで、Couleur/Inverse は初見では意味が分からず把握しづらかった。

選択中ボタンに ✓ アイコン＋白リングを追加し、各ベットの意味（`descKey`）をボタン下に常時テキスト表示する。

## 変更点

- `TrenteEtQuarantePage.tsx`: 各ベットボタンを flex-col でラップし、選択中は `✓`＋`ring-2 ring-white`、下に `descKey` の常時表示テキストを追加。`aria-pressed`／`role="group"` は維持
- 新規 i18n なし（既存 `betType.*Desc` を流用）

## 受け入れ条件

- [x] 選択中ベット種別にアイコン（✓）/枠強調（ring）が付く
- [x] Couleur/Inverse の意味が補助テキストで常時表示される
- [x] `aria-pressed` は維持し `role="group"` ラベルと整合
- [x] `TrenteEtQuarantePage.test.tsx` に選択強調テストを追加

## テスト

- `TrenteEtQuarantePage.test.tsx`: Couleur/Inverse 説明の常時表示、Rouge 選択で `aria-pressed`＋✓＋`ring-2`、Noir が非選択になることを検証（9 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3633