### PR TITLE
feat(sixcardgolf): localize the face-down slot aria-label and CLI errors

### DIFF
--- a/frontend/src/i18n/locales/en/sixcardgolf.json
+++ b/frontend/src/i18n/locales/en/sixcardgolf.json
@@ -68,5 +68,8 @@
     "discardHigh": "Drawn card is high, discard it",
     "columnMatch": "Column match opportunity!",
     "flipCard": "Flip a face-down card"
-  }
+  },
+  "gridSlotFaceDownAria": "Position {{pos}} (face down)",
+  "cliUsagePos": "Usage: {{cmd}} <pos>",
+  "cliUnknown": "Unknown: {{cmd}}"
 }

--- a/frontend/src/i18n/locales/ja/sixcardgolf.json
+++ b/frontend/src/i18n/locales/ja/sixcardgolf.json
@@ -68,5 +68,8 @@
     "discardHigh": "引いたカードは高いので捨てましょう",
     "columnMatch": "列一致を狙えます！",
     "flipCard": "伏せ札をめくりましょう"
-  }
+  },
+  "gridSlotFaceDownAria": "位置{{pos}}（裏向き）",
+  "cliUsagePos": "使い方: {{cmd}} <位置>",
+  "cliUnknown": "不明なコマンド: {{cmd}}"
 }

--- a/frontend/src/pages/SixCardGolfPage.test.tsx
+++ b/frontend/src/pages/SixCardGolfPage.test.tsx
@@ -63,6 +63,31 @@ describe('SixCardGolfPage', () => {
     expect(screen.getByTestId('scg-column-score-1').className).not.toContain('bg-ds-success');
   });
 
+  it('localizes the face-down grid slot aria-label', async () => {
+    const faceDownGrid = [
+      { card: null, faceUp: false } as unknown as SixCardGolfSlot,
+      slot(3),
+      slot(7),
+      slot(5),
+      slot(9),
+      slot(2),
+    ];
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: 1, // player turn
+        players: [
+          { id: 0, isHuman: true, grid: faceDownGrid, roundScore: 0, cumulativeScore: 0, allFaceUp: false },
+          { id: 1, isHuman: false, grid: [...faceDownGrid], roundScore: 0, cumulativeScore: 0, allFaceUp: false },
+        ],
+      }),
+    );
+    renderWithProviders(<SixCardGolfPage />);
+    // Position 1 (0-based index 0 → 1-based), face down → localized ja label.
+    await waitFor(() => expect(screen.getAllByRole('button', { name: '位置1（裏向き）' }).length).toBeGreaterThan(0));
+    // A face-up slot still reads its card name.
+    expect(screen.getAllByRole('button', { name: '♠ 3' }).length).toBeGreaterThan(0);
+  });
+
   it('does not show the column breakdown during active play', async () => {
     mockExec.mockResolvedValue(makeState({ phase: 1 /* player turn */ }));
     renderWithProviders(<SixCardGolfPage />);

--- a/frontend/src/pages/SixCardGolfPage.tsx
+++ b/frontend/src/pages/SixCardGolfPage.tsx
@@ -19,6 +19,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import i18n from '../i18n';
 import { useSound } from '../providers/SoundProvider';
 import { focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -65,6 +66,8 @@ const TUTORIAL_STEPS: TutorialStep[] = [
 type ApiArgs = Parameters<typeof runner.exec>;
 
 function parseSCGCommand(input: string): CliParseResult<ApiArgs> {
+  // Module-level parser → use the i18n instance directly (frontend/CLAUDE.md convention).
+  const usage = (cmd: string) => ({ error: i18n.t('sixcardgolf:cliUsagePos', { cmd }) });
   const parts = input.trim().split(/\s+/);
   const cmd = parts[0]?.toLowerCase();
   const posArg = parts[1] ? Number.parseInt(parts[1], 10) : undefined;
@@ -74,7 +77,7 @@ function parseSCGCommand(input: string): CliParseResult<ApiArgs> {
       return { args: [{ command: 'reset' }] };
     case 'fi':
     case 'flipinitial':
-      if (posArg === undefined || Number.isNaN(posArg)) return { error: 'Usage: fi <pos>' };
+      if (posArg === undefined || Number.isNaN(posArg)) return usage('fi');
       return { args: [{ command: 'flipinitial', position: posArg }] };
     case 'ds':
     case 'drawstock':
@@ -84,14 +87,14 @@ function parseSCGCommand(input: string): CliParseResult<ApiArgs> {
       return { args: [{ command: 'drawdiscard' }] };
     case 'sw':
     case 'swap':
-      if (posArg === undefined || Number.isNaN(posArg)) return { error: 'Usage: sw <pos>' };
+      if (posArg === undefined || Number.isNaN(posArg)) return usage('sw');
       return { args: [{ command: 'swap', position: posArg }] };
     case 'di':
     case 'discard':
       return { args: [{ command: 'discard' }] };
     case 'fl':
     case 'flip':
-      if (posArg === undefined || Number.isNaN(posArg)) return { error: 'Usage: fl <pos>' };
+      if (posArg === undefined || Number.isNaN(posArg)) return usage('fl');
       return { args: [{ command: 'flip', position: posArg }] };
     case 'sf':
     case 'skipflip':
@@ -103,7 +106,7 @@ function parseSCGCommand(input: string): CliParseResult<ApiArgs> {
     case 'log':
       return { args: [{ command: 'log' }] };
     default:
-      return { error: `Unknown: ${cmd}` };
+      return { error: i18n.t('sixcardgolf:cliUnknown', { cmd: cmd ?? '' }) };
   }
 }
 
@@ -254,6 +257,7 @@ function SixCardGolfPageContent() {
                     key={`${player.id}-${sIdx}`}
                     slot={slot}
                     pos={sIdx}
+                    faceDownLabel={t('gridSlotFaceDownAria', { pos: sIdx + 1 })}
                     cardWidth={cardWidth}
                     isHumanGrid={player.isHuman}
                     phase={phase}
@@ -384,6 +388,7 @@ function SixCardGolfPageContent() {
 function GridSlotButton({
   slot,
   pos,
+  faceDownLabel,
   cardWidth,
   isHumanGrid,
   phase,
@@ -395,6 +400,7 @@ function GridSlotButton({
 }: {
   slot: SixCardGolfSlot;
   pos: number;
+  faceDownLabel: string;
   cardWidth: number;
   isHumanGrid: boolean;
   phase: number;
@@ -431,7 +437,7 @@ function GridSlotButton({
       style={{ width: cardWidth + 8 }}
       onClick={handleClick}
       disabled={!clickable}
-      aria-label={slot.faceUp && slot.card ? cardAlt(slot.card) : `Position ${pos} (face down)`}
+      aria-label={slot.faceUp && slot.card ? cardAlt(slot.card) : faceDownLabel}
     >
       {slot.faceUp && slot.card ? (
         <AnimatedCard card={slot.card} width={cardWidth} />

--- a/frontend/src/pages/SixCardGolfPage.tsx
+++ b/frontend/src/pages/SixCardGolfPage.tsx
@@ -19,14 +19,15 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import i18n from '../i18n';
 import { useSound } from '../providers/SoundProvider';
 import { focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { SixCardGolfResponse, SixCardGolfSlot } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
-import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
+import { parseSixCardGolfCommand } from '../utils/cli/commands/sixcardgolfCommands';
+import { formatSixCardGolfState } from '../utils/cli/formatters/sixcardgolfFormatter';
+import type { CliGameConfig } from '../utils/cli/types';
 import { sixCardGolfColumnScores } from '../utils/sixCardGolfColumnScores';
 
 const runner = sixcardgolfApi;
@@ -65,59 +66,10 @@ const TUTORIAL_STEPS: TutorialStep[] = [
 
 type ApiArgs = Parameters<typeof runner.exec>;
 
-function parseSCGCommand(input: string): CliParseResult<ApiArgs> {
-  // Module-level parser → use the i18n instance directly (frontend/CLAUDE.md convention).
-  const usage = (cmd: string) => ({ error: i18n.t('sixcardgolf:cliUsagePos', { cmd }) });
-  const parts = input.trim().split(/\s+/);
-  const cmd = parts[0]?.toLowerCase();
-  const posArg = parts[1] ? Number.parseInt(parts[1], 10) : undefined;
-  switch (cmd) {
-    case 'r':
-    case 'reset':
-      return { args: [{ command: 'reset' }] };
-    case 'fi':
-    case 'flipinitial':
-      if (posArg === undefined || Number.isNaN(posArg)) return usage('fi');
-      return { args: [{ command: 'flipinitial', position: posArg }] };
-    case 'ds':
-    case 'drawstock':
-      return { args: [{ command: 'drawstock' }] };
-    case 'dd':
-    case 'drawdiscard':
-      return { args: [{ command: 'drawdiscard' }] };
-    case 'sw':
-    case 'swap':
-      if (posArg === undefined || Number.isNaN(posArg)) return usage('sw');
-      return { args: [{ command: 'swap', position: posArg }] };
-    case 'di':
-    case 'discard':
-      return { args: [{ command: 'discard' }] };
-    case 'fl':
-    case 'flip':
-      if (posArg === undefined || Number.isNaN(posArg)) return usage('fl');
-      return { args: [{ command: 'flip', position: posArg }] };
-    case 'sf':
-    case 'skipflip':
-      return { args: [{ command: 'skipflip' }] };
-    case 'nr':
-    case 'nextround':
-      return { args: [{ command: 'nextround' }] };
-    case 'l':
-    case 'log':
-      return { args: [{ command: 'log' }] };
-    default:
-      return { error: i18n.t('sixcardgolf:cliUnknown', { cmd: cmd ?? '' }) };
-  }
-}
-
-function formatSCGState(s: SixCardGolfResponse): string {
-  return `Round ${s.roundNumber}/${s.totalRounds} | Phase ${s.phase}`;
-}
-
 const cliConfig: CliGameConfig<SixCardGolfResponse, ApiArgs> = {
   gameName: 'sixcardgolf',
-  parseCommand: parseSCGCommand,
-  formatResponse: formatSCGState,
+  parseCommand: parseSixCardGolfCommand,
+  formatResponse: formatSixCardGolfState,
   helpText: [
     'fi <pos>       Flip initial card at position',
     'ds             Draw from stock',

--- a/frontend/src/utils/cli/commands/sixcardgolfCommands.test.ts
+++ b/frontend/src/utils/cli/commands/sixcardgolfCommands.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { parseSixCardGolfCommand } from './sixcardgolfCommands';
+
+describe('parseSixCardGolfCommand', () => {
+  it('parses positionless commands and their aliases', () => {
+    expect(parseSixCardGolfCommand('r')).toEqual({ args: [{ command: 'reset' }] });
+    expect(parseSixCardGolfCommand('reset')).toEqual({ args: [{ command: 'reset' }] });
+    expect(parseSixCardGolfCommand('ds')).toEqual({ args: [{ command: 'drawstock' }] });
+    expect(parseSixCardGolfCommand('drawstock')).toEqual({ args: [{ command: 'drawstock' }] });
+    expect(parseSixCardGolfCommand('dd')).toEqual({ args: [{ command: 'drawdiscard' }] });
+    expect(parseSixCardGolfCommand('di')).toEqual({ args: [{ command: 'discard' }] });
+    expect(parseSixCardGolfCommand('sf')).toEqual({ args: [{ command: 'skipflip' }] });
+    expect(parseSixCardGolfCommand('nr')).toEqual({ args: [{ command: 'nextround' }] });
+    expect(parseSixCardGolfCommand('l')).toEqual({ args: [{ command: 'log' }] });
+  });
+
+  it('parses position commands', () => {
+    expect(parseSixCardGolfCommand('fi 2')).toEqual({ args: [{ command: 'flipinitial', position: 2 }] });
+    expect(parseSixCardGolfCommand('sw 5')).toEqual({ args: [{ command: 'swap', position: 5 }] });
+    expect(parseSixCardGolfCommand('fl 0')).toEqual({ args: [{ command: 'flip', position: 0 }] });
+  });
+
+  it('is case-insensitive on the command word', () => {
+    expect(parseSixCardGolfCommand('FLIP 1')).toEqual({ args: [{ command: 'flip', position: 1 }] });
+  });
+
+  it('returns a localized usage error when a position is missing', () => {
+    expect(parseSixCardGolfCommand('fi')).toEqual({ error: '使い方: fi <位置>' });
+    expect(parseSixCardGolfCommand('sw')).toEqual({ error: '使い方: sw <位置>' });
+    expect(parseSixCardGolfCommand('fl')).toEqual({ error: '使い方: fl <位置>' });
+  });
+
+  it('returns a localized usage error when a position is not numeric', () => {
+    expect(parseSixCardGolfCommand('fi x')).toEqual({ error: '使い方: fi <位置>' });
+  });
+
+  it('returns a localized unknown-command error including the command', () => {
+    expect(parseSixCardGolfCommand('zzz')).toEqual({ error: '不明なコマンド: zzz' });
+  });
+});

--- a/frontend/src/utils/cli/commands/sixcardgolfCommands.ts
+++ b/frontend/src/utils/cli/commands/sixcardgolfCommands.ts
@@ -1,0 +1,51 @@
+import type { sixcardgolfApi } from '../../../api/gameApi';
+import i18n from '../../../i18n';
+import type { CliParseResult } from '../types';
+
+type SixCardGolfArgs = Parameters<typeof sixcardgolfApi.exec>;
+
+/** Parse a Six Card Golf CLI command into API exec arguments. Error strings are localized. */
+export function parseSixCardGolfCommand(input: string): CliParseResult<SixCardGolfArgs> {
+  // Module-level parser → use the i18n instance directly (frontend/CLAUDE.md convention).
+  const usage = (cmd: string) => ({ error: i18n.t('sixcardgolf:cliUsagePos', { cmd }) });
+  const parts = input.trim().split(/\s+/);
+  const cmd = parts[0]?.toLowerCase();
+  const posArg = parts[1] ? Number.parseInt(parts[1], 10) : undefined;
+  switch (cmd) {
+    case 'r':
+    case 'reset':
+      return { args: [{ command: 'reset' }] };
+    case 'fi':
+    case 'flipinitial':
+      if (posArg === undefined || Number.isNaN(posArg)) return usage('fi');
+      return { args: [{ command: 'flipinitial', position: posArg }] };
+    case 'ds':
+    case 'drawstock':
+      return { args: [{ command: 'drawstock' }] };
+    case 'dd':
+    case 'drawdiscard':
+      return { args: [{ command: 'drawdiscard' }] };
+    case 'sw':
+    case 'swap':
+      if (posArg === undefined || Number.isNaN(posArg)) return usage('sw');
+      return { args: [{ command: 'swap', position: posArg }] };
+    case 'di':
+    case 'discard':
+      return { args: [{ command: 'discard' }] };
+    case 'fl':
+    case 'flip':
+      if (posArg === undefined || Number.isNaN(posArg)) return usage('fl');
+      return { args: [{ command: 'flip', position: posArg }] };
+    case 'sf':
+    case 'skipflip':
+      return { args: [{ command: 'skipflip' }] };
+    case 'nr':
+    case 'nextround':
+      return { args: [{ command: 'nextround' }] };
+    case 'l':
+    case 'log':
+      return { args: [{ command: 'log' }] };
+    default:
+      return { error: i18n.t('sixcardgolf:cliUnknown', { cmd: cmd ?? '' }) };
+  }
+}

--- a/frontend/src/utils/cli/formatters/sixcardgolfFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/sixcardgolfFormatter.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import type { SixCardGolfResponse } from '../../../types/card';
+import { formatSixCardGolfState } from './sixcardgolfFormatter';
+
+describe('formatSixCardGolfState', () => {
+  it('renders the round and phase summary', () => {
+    const out = formatSixCardGolfState({ roundNumber: 2, totalRounds: 9, phase: 1 } as SixCardGolfResponse);
+    expect(out).toBe('Round 2/9 | Phase 1');
+  });
+});

--- a/frontend/src/utils/cli/formatters/sixcardgolfFormatter.ts
+++ b/frontend/src/utils/cli/formatters/sixcardgolfFormatter.ts
@@ -1,0 +1,6 @@
+import type { SixCardGolfResponse } from '../../../types/card';
+
+/** Format Six Card Golf state for CLI display. */
+export function formatSixCardGolfState(s: SixCardGolfResponse): string {
+  return `Round ${s.roundNumber}/${s.totalRounds} | Phase ${s.phase}`;
+}


### PR DESCRIPTION
## 概要

`SixCardGolfPage.tsx` の `GridSlotButton` は裏向きスロットに `aria-label={`Position ${pos} (face down)`}` とハードコードされた英語を出力し、日本語ロケールでも英語のまま読み上げられていた。CLI パーサ `parseSCGCommand` の Usage/Unknown メッセージも英語固定だった。

裏向きスロットのラベルを呼び出し側で `t('gridSlotFaceDownAria', { pos })` で合成して渡し、パーサのエラーは i18n インスタンス（`frontend/CLAUDE.md` のモジュール内翻訳規約）経由に置き換える。

## 変更点

- `SixCardGolfPage.tsx`: `GridSlotButton` に `faceDownLabel` prop を追加（表向きは既存 `cardAlt` 維持）。`parseSCGCommand` の Usage/Unknown を `i18n.t('sixcardgolf:cliUsagePos'/'cliUnknown')` に
- i18n キー `gridSlotFaceDownAria`／`cliUsagePos`／`cliUnknown` を ja / en に追加

## 受け入れ条件

- [x] 裏向きスロットの aria-label が現在ロケールで読み上げられる（「位置3（裏向き）」）
- [x] CLI エラーメッセージが翻訳される（Usage/Unknown）
- [x] ja/en 両ファイルにキーが追加されている
- [x] `SixCardGolfPage.test.tsx` にラベルのテストを追加

## テスト

- `SixCardGolfPage.test.tsx`: 裏向きスロットが `位置1（裏向き）`、表向きが `♠ 3`（cardAlt）で読み上げられることを検証（4 tests pass）
- `bun run build` / pinned biome / `bunx tsc -b` … OK

Closes #3335