### PR TITLE
refactor(easthaven): extract CLI parser/formatter modules and localize help/errors

### DIFF
--- a/frontend/src/i18n/locales/en/easthaven.json
+++ b/frontend/src/i18n/locales/en/easthaven.json
@@ -40,5 +40,24 @@
   "nav": {
     "easthaven": "Easthaven"
   },
-  "moveHereAriaLabel": "Empty tableau column {{col}} (move here)"
+  "moveHereAriaLabel": "Empty tableau column {{col}} (move here)",
+  "cli": {
+    "help": [
+      "m <from> <to>  Move top card between tableau columns",
+      "m t <col> f    Move tableau to foundation",
+      "m t <col> <idx> t <col>  Move a run by index",
+      "d              Deal one card to every column",
+      "g              Give up",
+      "h              Hint",
+      "ac             Auto-complete",
+      "u              Undo",
+      "r              Reset"
+    ],
+    "error": {
+      "invalidColumn": "Invalid column",
+      "invalidArg": "Invalid arg",
+      "usageMove": "Usage: m <fromCol> <toCol> | m t <col> f | m t <col> <idx> t <col>",
+      "unknownCommand": "Unknown command: {{cmd}}"
+    }
+  }
 }

--- a/frontend/src/i18n/locales/ja/easthaven.json
+++ b/frontend/src/i18n/locales/ja/easthaven.json
@@ -40,5 +40,24 @@
   "nav": {
     "easthaven": "イーストヘイブン"
   },
-  "moveHereAriaLabel": "空のタブロー列 {{col}}（ここに移動）"
+  "moveHereAriaLabel": "空のタブロー列 {{col}}（ここに移動）",
+  "cli": {
+    "help": [
+      "m <列> <列>  場札間で上のカードを移動",
+      "m t <列> f    場札から組札へ移動",
+      "m t <列> <番号> t <列>  番号指定で連続札を移動",
+      "d              各列に1枚ずつ配る",
+      "g              ギブアップ",
+      "h              ヒント",
+      "ac             自動完成",
+      "u              元に戻す",
+      "r              リセット"
+    ],
+    "error": {
+      "invalidColumn": "無効な列番号です",
+      "invalidArg": "無効な引数です",
+      "usageMove": "使い方: m <移動元列> <移動先列> | m t <列> f | m t <列> <番号> t <列>",
+      "unknownCommand": "不明なコマンド: {{cmd}}"
+    }
+  }
 }

--- a/frontend/src/pages/EasthavenPage.tsx
+++ b/frontend/src/pages/EasthavenPage.tsx
@@ -33,6 +33,8 @@ import type { EasthavenResponse } from '../types/card';
 import { EasthavenPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { easthavenHelp, parseEasthavenCommand } from '../utils/cli/commands/easthavenCommands';
+import { formatEasthavenState } from '../utils/cli/formatters/easthavenFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { isTableauAllFaceUp } from '../utils/solitaireUtils';
 
@@ -72,99 +74,6 @@ const EH_TUTORIAL_STEPS: TutorialStep[] = [
     advanceOn: 'next',
   },
 ];
-
-/** CLI help text for Easthaven. */
-const EH_HELP = [
-  'm <from> <to>  Move top card between tableau columns',
-  'm t <col> f    Move tableau to foundation',
-  'm t <col> <idx> t <col>  Move a run by index',
-  'd              Deal one card to every column',
-  'g              Give up',
-  'h              Hint',
-  'ac             Auto-complete',
-  'u              Undo',
-  'r              Reset',
-];
-
-/** Parse an Easthaven CLI command into API call arguments. */
-function parseEasthavenCommand(input: string): { args: Parameters<typeof easthavenApi.exec> } | { error: string } {
-  const parts = input.trim().split(/\s+/);
-  const cmd = parts[0]?.toLowerCase();
-  switch (cmd) {
-    case 'r':
-    case 'reset':
-      return { args: ['reset'] };
-    case 'd':
-    case 'deal':
-      return { args: ['deal'] };
-    case 'g':
-    case 'giveup':
-      return { args: ['giveup'] };
-    case 'h':
-    case 'hint':
-      return { args: ['hint'] };
-    case 'ac':
-    case 'autocomplete':
-      return { args: ['autocomplete'] };
-    case 'u':
-    case 'undo':
-      return { args: ['undo'] };
-    case 'm':
-    case 'move': {
-      // m t <col> f  → tableau to foundation
-      if (parts.length === 4 && parts[1] === 't' && parts[3] === 'f') {
-        const col = Number.parseInt(parts[2], 10);
-        if (Number.isNaN(col)) return { error: 'Invalid column' };
-        return { args: ['move', { zone: 'tableau', col, cardIndex: -1 }, { zone: 'foundation' }] };
-      }
-      // m t <col> <idx> t <col>  → move a run by card index
-      if (parts.length === 6 && parts[1] === 't' && parts[4] === 't') {
-        const from = Number.parseInt(parts[2], 10);
-        const idx = Number.parseInt(parts[3], 10);
-        const to = Number.parseInt(parts[5], 10);
-        if (Number.isNaN(from) || Number.isNaN(idx) || Number.isNaN(to)) return { error: 'Invalid arg' };
-        return {
-          args: ['move', { zone: 'tableau', col: from, cardIndex: idx }, { zone: 'tableau', col: to }],
-        };
-      }
-      // m <from> <to>  → tableau top card
-      if (parts.length === 3) {
-        const from = Number.parseInt(parts[1], 10);
-        const to = Number.parseInt(parts[2], 10);
-        if (Number.isNaN(from) || Number.isNaN(to)) return { error: 'Invalid column' };
-        return {
-          args: ['move', { zone: 'tableau', col: from, cardIndex: -1 }, { zone: 'tableau', col: to }],
-        };
-      }
-      return { error: 'Usage: m <fromCol> <toCol> | m t <col> f | m t <col> <idx> t <col>' };
-    }
-    default:
-      return { error: `Unknown command: ${cmd}` };
-  }
-}
-
-/** Format Easthaven state for CLI display. */
-function formatEasthavenState(state: EasthavenResponse): string {
-  const lines: string[] = [];
-  lines.push(`Stock: ${state.stockCount}`);
-  lines.push('Foundation:');
-  for (let i = 0; i < state.foundation.length; i++) {
-    const pile = state.foundation[i];
-    const top = pile.length > 0 ? `${pile[pile.length - 1].design}-${pile[pile.length - 1].value}` : 'empty';
-    lines.push(`  ${FOUNDATION_SUITS[i]}: ${top} (${pile.length})`);
-  }
-  lines.push('');
-  lines.push('Tableau:');
-  for (let col = 0; col < state.tableau.length; col++) {
-    const cards = state.tableau[col]
-      .map((tc, i) => (tc.faceUp && tc.card ? `[${i}]${tc.card.design}-${tc.card.value}` : `[${i}]??`))
-      .join(' ');
-    lines.push(`  ${col}: ${cards || '(empty)'}`);
-  }
-  lines.push('');
-  lines.push(`Moves: ${state.moveCount}  Phase: ${state.phase}`);
-  return lines.join('\n');
-}
 
 /** Renders the Easthaven game page. */
 export const EasthavenPage = withTutorial(EasthavenPageContent, 'easthaven', EH_TUTORIAL_STEPS);
@@ -218,7 +127,7 @@ function EasthavenPageContent() {
       gameName: 'easthaven',
       parseCommand: parseEasthavenCommand,
       formatResponse: formatEasthavenState,
-      helpText: EH_HELP,
+      helpText: easthavenHelp(),
     }),
     [],
   );

--- a/frontend/src/pages/EasthavenPage.tsx
+++ b/frontend/src/pages/EasthavenPage.tsx
@@ -26,6 +26,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
+import i18n from '../i18n';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnOutline, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -122,6 +123,9 @@ function EasthavenPageContent() {
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('easthaven');
+  // easthavenHelp() reads i18n internally, so depend on i18n.language to
+  // re-localize the CLI help after a runtime language switch.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: i18n.language drives help re-localization
   const easthavenCliConfig: CliGameConfig<EasthavenResponse, Parameters<typeof easthavenApi.exec>> = useMemo(
     () => ({
       gameName: 'easthaven',
@@ -129,7 +133,7 @@ function EasthavenPageContent() {
       formatResponse: formatEasthavenState,
       helpText: easthavenHelp(),
     }),
-    [],
+    [i18n.language],
   );
   const { handleCommand } = useCliGame(apiExec, easthavenCliConfig, state, {
     addInput,

--- a/frontend/src/utils/cli/commands/easthavenCommands.test.ts
+++ b/frontend/src/utils/cli/commands/easthavenCommands.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { easthavenHelp, parseEasthavenCommand } from './easthavenCommands';
+
+describe('parseEasthavenCommand', () => {
+  it('parses simple commands and their aliases', () => {
+    expect(parseEasthavenCommand('r')).toEqual({ args: ['reset'] });
+    expect(parseEasthavenCommand('reset')).toEqual({ args: ['reset'] });
+    expect(parseEasthavenCommand('d')).toEqual({ args: ['deal'] });
+    expect(parseEasthavenCommand('deal')).toEqual({ args: ['deal'] });
+    expect(parseEasthavenCommand('g')).toEqual({ args: ['giveup'] });
+    expect(parseEasthavenCommand('giveup')).toEqual({ args: ['giveup'] });
+    expect(parseEasthavenCommand('h')).toEqual({ args: ['hint'] });
+    expect(parseEasthavenCommand('hint')).toEqual({ args: ['hint'] });
+    expect(parseEasthavenCommand('ac')).toEqual({ args: ['autocomplete'] });
+    expect(parseEasthavenCommand('autocomplete')).toEqual({ args: ['autocomplete'] });
+    expect(parseEasthavenCommand('u')).toEqual({ args: ['undo'] });
+    expect(parseEasthavenCommand('undo')).toEqual({ args: ['undo'] });
+  });
+
+  it('parses m <from> <to> as a tableau top-card move', () => {
+    expect(parseEasthavenCommand('m 1 4')).toEqual({
+      args: ['move', { zone: 'tableau', col: 1, cardIndex: -1 }, { zone: 'tableau', col: 4 }],
+    });
+  });
+
+  it('parses m t <col> f as a tableau-to-foundation move', () => {
+    expect(parseEasthavenCommand('m t 2 f')).toEqual({
+      args: ['move', { zone: 'tableau', col: 2, cardIndex: -1 }, { zone: 'foundation' }],
+    });
+  });
+
+  it('parses m t <col> <idx> t <col> as a run move by index', () => {
+    expect(parseEasthavenCommand('m t 0 3 t 5')).toEqual({
+      args: ['move', { zone: 'tableau', col: 0, cardIndex: 3 }, { zone: 'tableau', col: 5 }],
+    });
+  });
+
+  it('is case-insensitive on the command word', () => {
+    expect(parseEasthavenCommand('MOVE 1 4')).toEqual({
+      args: ['move', { zone: 'tableau', col: 1, cardIndex: -1 }, { zone: 'tableau', col: 4 }],
+    });
+  });
+
+  it('returns a localized error for a non-numeric column in a top-card move', () => {
+    const result = parseEasthavenCommand('m x 4');
+    expect('error' in result && result.error).toBe('無効な列番号です');
+  });
+
+  it('returns a localized error for a non-numeric column in a foundation move', () => {
+    const result = parseEasthavenCommand('m t x f');
+    expect('error' in result && result.error).toBe('無効な列番号です');
+  });
+
+  it('returns a localized error for a non-numeric arg in a run move', () => {
+    const result = parseEasthavenCommand('m t 0 x t 5');
+    expect('error' in result && result.error).toBe('無効な引数です');
+  });
+
+  it('returns the usage error for a malformed move', () => {
+    const result = parseEasthavenCommand('m');
+    expect('error' in result && typeof result.error === 'string' && result.error.startsWith('使い方')).toBe(true);
+  });
+
+  it('returns an unknown-command error including the command', () => {
+    const result = parseEasthavenCommand('zzz');
+    expect('error' in result && result.error).toBe('不明なコマンド: zzz');
+  });
+});
+
+describe('easthavenHelp', () => {
+  it('returns a non-empty list of localized help lines', () => {
+    const help = easthavenHelp();
+    expect(Array.isArray(help)).toBe(true);
+    expect(help.length).toBeGreaterThan(0);
+    expect(help.some((line) => line.includes('m t'))).toBe(true);
+  });
+});

--- a/frontend/src/utils/cli/commands/easthavenCommands.ts
+++ b/frontend/src/utils/cli/commands/easthavenCommands.ts
@@ -1,0 +1,69 @@
+import type { easthavenApi } from '../../../api/gameApi';
+import i18n from '../../../i18n';
+import type { CliParseResult } from '../types';
+
+type EasthavenArgs = Parameters<typeof easthavenApi.exec>;
+
+/** Localized CLI help lines for Easthaven (resolved via the i18n instance). */
+export function easthavenHelp(): string[] {
+  return i18n.t('easthaven:cli.help', { returnObjects: true }) as string[];
+}
+
+/** Parse an Easthaven CLI command into API exec arguments. Error strings are localized. */
+export function parseEasthavenCommand(input: string): CliParseResult<EasthavenArgs> {
+  const parts = input.trim().split(/\s+/);
+  const cmd = parts[0]?.toLowerCase();
+  switch (cmd) {
+    case 'r':
+    case 'reset':
+      return { args: ['reset'] };
+    case 'd':
+    case 'deal':
+      return { args: ['deal'] };
+    case 'g':
+    case 'giveup':
+      return { args: ['giveup'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
+    case 'ac':
+    case 'autocomplete':
+      return { args: ['autocomplete'] };
+    case 'u':
+    case 'undo':
+      return { args: ['undo'] };
+    case 'm':
+    case 'move': {
+      // m t <col> f  → tableau to foundation
+      if (parts.length === 4 && parts[1] === 't' && parts[3] === 'f') {
+        const col = Number.parseInt(parts[2], 10);
+        if (Number.isNaN(col)) return { error: i18n.t('easthaven:cli.error.invalidColumn') };
+        return { args: ['move', { zone: 'tableau', col, cardIndex: -1 }, { zone: 'foundation' }] };
+      }
+      // m t <col> <idx> t <col>  → move a run by card index
+      if (parts.length === 6 && parts[1] === 't' && parts[4] === 't') {
+        const from = Number.parseInt(parts[2], 10);
+        const idx = Number.parseInt(parts[3], 10);
+        const to = Number.parseInt(parts[5], 10);
+        if (Number.isNaN(from) || Number.isNaN(idx) || Number.isNaN(to)) {
+          return { error: i18n.t('easthaven:cli.error.invalidArg') };
+        }
+        return {
+          args: ['move', { zone: 'tableau', col: from, cardIndex: idx }, { zone: 'tableau', col: to }],
+        };
+      }
+      // m <from> <to>  → tableau top card
+      if (parts.length === 3) {
+        const from = Number.parseInt(parts[1], 10);
+        const to = Number.parseInt(parts[2], 10);
+        if (Number.isNaN(from) || Number.isNaN(to)) return { error: i18n.t('easthaven:cli.error.invalidColumn') };
+        return {
+          args: ['move', { zone: 'tableau', col: from, cardIndex: -1 }, { zone: 'tableau', col: to }],
+        };
+      }
+      return { error: i18n.t('easthaven:cli.error.usageMove') };
+    }
+    default:
+      return { error: i18n.t('easthaven:cli.error.unknownCommand', { cmd: cmd ?? '' }) };
+  }
+}

--- a/frontend/src/utils/cli/commands/easthavenCommands.ts
+++ b/frontend/src/utils/cli/commands/easthavenCommands.ts
@@ -64,6 +64,6 @@ export function parseEasthavenCommand(input: string): CliParseResult<EasthavenAr
       return { error: i18n.t('easthaven:cli.error.usageMove') };
     }
     default:
-      return { error: i18n.t('easthaven:cli.error.unknownCommand', { cmd: cmd ?? '' }) };
+      return { error: i18n.t('easthaven:cli.error.unknownCommand', { cmd }) };
   }
 }

--- a/frontend/src/utils/cli/formatters/easthavenFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/easthavenFormatter.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { EasthavenResponse } from '../../../types/card';
+import { formatEasthavenState } from './easthavenFormatter';
+
+const card = (design: string, value: number) => ({ design, value }) as EasthavenResponse['foundation'][number][number];
+
+function makeState(overrides: Partial<EasthavenResponse> = {}): EasthavenResponse {
+  return {
+    stockCount: 3,
+    foundation: [[card('SPADE', 1)], [], [], []],
+    tableau: [
+      [
+        { faceUp: false, card: null },
+        { faceUp: true, card: card('HEART', 13) },
+      ],
+      [],
+    ],
+    moveCount: 7,
+    phase: 1,
+    ...overrides,
+  } as EasthavenResponse;
+}
+
+describe('formatEasthavenState', () => {
+  it('renders stock, foundations, tableau, and footer', () => {
+    const out = formatEasthavenState(makeState());
+    expect(out).toContain('Stock: 3');
+    expect(out).toContain('♠: SPADE-1 (1)');
+    expect(out).toContain('♣: empty (0)');
+    expect(out).toContain('Moves: 7  Phase: 1');
+  });
+
+  it('hides face-down cards and marks empty columns', () => {
+    const out = formatEasthavenState(makeState());
+    expect(out).toContain('[0]??');
+    expect(out).toContain('[1]HEART-13');
+    expect(out).toContain('(empty)');
+  });
+});

--- a/frontend/src/utils/cli/formatters/easthavenFormatter.ts
+++ b/frontend/src/utils/cli/formatters/easthavenFormatter.ts
@@ -1,0 +1,26 @@
+import type { EasthavenResponse } from '../../../types/card';
+
+const FOUNDATION_SUITS = ['♠', '♣', '♥', '♦'] as const;
+
+/** Format Easthaven state for CLI display. */
+export function formatEasthavenState(state: EasthavenResponse): string {
+  const lines: string[] = [];
+  lines.push(`Stock: ${state.stockCount}`);
+  lines.push('Foundation:');
+  for (let i = 0; i < state.foundation.length; i++) {
+    const pile = state.foundation[i];
+    const top = pile.length > 0 ? `${pile[pile.length - 1].design}-${pile[pile.length - 1].value}` : 'empty';
+    lines.push(`  ${FOUNDATION_SUITS[i]}: ${top} (${pile.length})`);
+  }
+  lines.push('');
+  lines.push('Tableau:');
+  for (let col = 0; col < state.tableau.length; col++) {
+    const cards = state.tableau[col]
+      .map((tc, i) => (tc.faceUp && tc.card ? `[${i}]${tc.card.design}-${tc.card.value}` : `[${i}]??`))
+      .join(' ');
+    lines.push(`  ${col}: ${cards || '(empty)'}`);
+  }
+  lines.push('');
+  lines.push(`Moves: ${state.moveCount}  Phase: ${state.phase}`);
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
- Extract `parseEasthavenCommand` + help text from `EasthavenPage.tsx` into `utils/cli/commands/easthavenCommands.ts`, and `formatEasthavenState` into `utils/cli/formatters/easthavenFormatter.ts`, matching the per-game CLI module convention documented in `frontend/CLAUDE.md`.
- Localize CLI help and error strings through the i18n instance (`easthaven:cli.help`, `easthaven:cli.error.*`); add ja/en translations.
- No behavior change to commands (m/d/g/h/ac/u/r and the three `m` forms).

## Test plan
- `easthavenCommands.test.ts` — parsing, aliases, all three move forms, localized errors, unknown-command suggestion.
- `easthavenFormatter.test.ts` — stock/foundation/tableau/footer rendering, face-down and empty-column branches.
- Existing `EasthavenPage.test.tsx` still passes; `tsc -b`, biome, and build are green.

Closes #3390