### PR TITLE
refactor(pigtail): extract CLI parser/formatter modules and localize output

### DIFF
--- a/frontend/src/i18n/locales/en/pigtail.json
+++ b/frontend/src/i18n/locales/en/pigtail.json
@@ -29,5 +29,23 @@
   "hint": {
     "draw": "Your turn — draw a card from the circle.",
     "afterPenalty": "Previous draw caused a penalty. Draw again."
+  },
+  "cli": {
+    "help": ["d/draw  - Draw a card", "r/reset - Reset game"],
+    "phase": {
+      "play": "Play",
+      "end": "End"
+    },
+    "summary": "Phase: {{phase}} | Circle: {{circle}} | Center: {{center}}",
+    "you": "You",
+    "cpu": "CPU {{id}}",
+    "playerCards": "{{tag}}: {{count}} cards",
+    "penalty": "(PENALTY)",
+    "safe": "(safe)",
+    "last": "Last: {{card}} {{status}}",
+    "error": {
+      "unknown": "Unknown command: {{cmd}}",
+      "unknownSuggest": "Unknown command: {{cmd}}. Did you mean: {{suggestion}}?"
+    }
   }
 }

--- a/frontend/src/i18n/locales/ja/pigtail.json
+++ b/frontend/src/i18n/locales/ja/pigtail.json
@@ -29,5 +29,23 @@
   "hint": {
     "draw": "あなたの番です。山札から1枚引きましょう",
     "afterPenalty": "前のターンはペナルティでした。再度カードを引きます"
+  },
+  "cli": {
+    "help": ["d/draw  - カードを1枚引く", "r/reset - ゲームをリセット"],
+    "phase": {
+      "play": "プレイ中",
+      "end": "終了"
+    },
+    "summary": "フェーズ: {{phase}} | 輪: {{circle}} | 中央: {{center}}",
+    "you": "あなた",
+    "cpu": "CPU {{id}}",
+    "playerCards": "{{tag}}: {{count}}枚",
+    "penalty": "（ペナルティ）",
+    "safe": "（セーフ）",
+    "last": "最後: {{card}} {{status}}",
+    "error": {
+      "unknown": "不明なコマンド: {{cmd}}",
+      "unknownSuggest": "不明なコマンド: {{cmd}}。もしかして: {{suggestion}}？"
+    }
   }
 }

--- a/frontend/src/pages/PigsTailPage.tsx
+++ b/frontend/src/pages/PigsTailPage.tsx
@@ -18,12 +18,15 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { usePhaseNames } from '../hooks/usePhaseNames';
+import i18n from '../i18n';
 import { badgeErrorColors } from '../styles/badgeStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { Card, PigsTailResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import { valueName } from '../utils/cardUtils';
-import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
+import { parsePigtailCommand, pigtailHelp } from '../utils/cli/commands/pigtailCommands';
+import { formatPigtailState } from '../utils/cli/formatters/pigtailFormatter';
+import type { CliGameConfig } from '../utils/cli/types';
 
 const SUIT_SYMBOLS: Record<string, string> = {
   SPADE: '♠',
@@ -93,33 +96,17 @@ function PigsTailPageContent() {
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('pigtail');
   type PtArgs = Parameters<typeof pigtailApi.exec>;
+  // pigtailHelp() reads i18n internally, so depend on i18n.language to
+  // re-localize the CLI help after a runtime language switch.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: i18n.language drives help re-localization
   const cliConfig: CliGameConfig<PigsTailResponse, PtArgs> = useMemo(
     () => ({
       gameName: 'pigtail',
-      parseCommand: (input: string): CliParseResult<PtArgs> => {
-        const cmd = input.trim().toLowerCase();
-        if (cmd === 'reset' || cmd === 'r') return { args: ['reset'] };
-        if (cmd === 'draw' || cmd === 'd') return { args: ['draw'] };
-        return { error: `Unknown command: ${cmd}` };
-      },
-      formatResponse: (s: PigsTailResponse) => {
-        const lines: string[] = [];
-        const phase = s.gameEndFlag ? 'End' : 'Play';
-        lines.push(`Phase: ${phase} | Circle: ${s.circleCount} | Center: ${s.centerCount}`);
-        for (const p of s.players) {
-          const tag = p.isHuman ? 'You' : `CPU ${p.id}`;
-          lines.push(`${tag}: ${p.cardCount} cards`);
-        }
-        if (s.lastDrawCard) {
-          const card = `${s.lastDrawCard.design[0]}${s.lastDrawCard.value}`;
-          lines.push(`Last: ${card} ${s.lastPenalty ? '(PENALTY)' : '(safe)'}`);
-        }
-        if (s.message) lines.push(s.message);
-        return lines.join('\n');
-      },
-      helpText: ['d/draw  - Draw a card', 'r/reset - Reset game'],
+      parseCommand: parsePigtailCommand,
+      formatResponse: formatPigtailState,
+      helpText: pigtailHelp(),
     }),
-    [],
+    [i18n.language],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/utils/cli/commands/pigtailCommands.test.ts
+++ b/frontend/src/utils/cli/commands/pigtailCommands.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { parsePigtailCommand, pigtailHelp } from './pigtailCommands';
+
+describe('parsePigtailCommand', () => {
+  it('parses draw and reset with their aliases', () => {
+    expect(parsePigtailCommand('r')).toEqual({ args: ['reset'] });
+    expect(parsePigtailCommand('reset')).toEqual({ args: ['reset'] });
+    expect(parsePigtailCommand('d')).toEqual({ args: ['draw'] });
+    expect(parsePigtailCommand('draw')).toEqual({ args: ['draw'] });
+  });
+
+  it('is case-insensitive on the command word', () => {
+    expect(parsePigtailCommand('DRAW')).toEqual({ args: ['draw'] });
+  });
+
+  it('suggests the closest command for a near-miss typo', () => {
+    expect(parsePigtailCommand('drw')).toEqual({ error: '不明なコマンド: drw。もしかして: draw？' });
+    expect(parsePigtailCommand('rest')).toEqual({ error: '不明なコマンド: rest。もしかして: reset？' });
+  });
+
+  it('returns a plain unknown-command error when nothing is close', () => {
+    expect(parsePigtailCommand('zzzzzz')).toEqual({ error: '不明なコマンド: zzzzzz' });
+  });
+});
+
+describe('pigtailHelp', () => {
+  it('returns a non-empty list of localized help lines', () => {
+    const help = pigtailHelp();
+    expect(Array.isArray(help)).toBe(true);
+    expect(help.length).toBe(2);
+    expect(help.some((line) => line.includes('draw'))).toBe(true);
+  });
+});

--- a/frontend/src/utils/cli/commands/pigtailCommands.ts
+++ b/frontend/src/utils/cli/commands/pigtailCommands.ts
@@ -1,0 +1,31 @@
+import type { pigtailApi } from '../../../api/gameApi';
+import i18n from '../../../i18n';
+import { splitCommand, suggestCommand } from '../commandParserBase';
+import type { CliParseResult } from '../types';
+
+type PigtailArgs = Parameters<typeof pigtailApi.exec>;
+
+const VALID_COMMANDS = ['draw', 'reset'];
+
+/** Localized CLI help lines for Pig's Tail (resolved via the i18n instance). */
+export function pigtailHelp(): string[] {
+  return i18n.t('pigtail:cli.help', { returnObjects: true }) as string[];
+}
+
+/** Parse a Pig's Tail CLI command into API exec arguments. Error strings are localized. */
+export function parsePigtailCommand(input: string): CliParseResult<PigtailArgs> {
+  const { cmd } = splitCommand(input);
+  switch (cmd) {
+    case 'r':
+    case 'reset':
+      return { args: ['reset'] };
+    case 'd':
+    case 'draw':
+      return { args: ['draw'] };
+    default: {
+      const suggestion = suggestCommand(cmd, VALID_COMMANDS);
+      if (suggestion) return { error: i18n.t('pigtail:cli.error.unknownSuggest', { cmd, suggestion }) };
+      return { error: i18n.t('pigtail:cli.error.unknown', { cmd }) };
+    }
+  }
+}

--- a/frontend/src/utils/cli/formatters/pigtailFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/pigtailFormatter.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import type { PigsTailResponse } from '../../../types/card';
+import { formatPigtailState } from './pigtailFormatter';
+
+function makeState(overrides: Partial<PigsTailResponse> = {}): PigsTailResponse {
+  return {
+    players: [
+      { id: 0, isHuman: true, cardCount: 3 },
+      { id: 1, isHuman: false, cardCount: 5 },
+    ],
+    circleCount: 40,
+    centerCount: 4,
+    gameEndFlag: false,
+    lastDrawCard: null,
+    lastPenalty: false,
+    message: '',
+    ...overrides,
+  } as PigsTailResponse;
+}
+
+describe('formatPigtailState', () => {
+  it('renders localized phase, circle/center summary, and player rows', () => {
+    const out = formatPigtailState(makeState());
+    expect(out).toContain('フェーズ: プレイ中 | 輪: 40 | 中央: 4');
+    expect(out).toContain('あなた: 3枚');
+    expect(out).toContain('CPU 1: 5枚');
+  });
+
+  it('shows End phase when the game has ended', () => {
+    const out = formatPigtailState(makeState({ gameEndFlag: true }));
+    expect(out).toContain('フェーズ: 終了');
+  });
+
+  it('renders a penalty draw line and any message', () => {
+    const out = formatPigtailState(
+      makeState({
+        lastDrawCard: { design: 'HEART', value: 7 } as PigsTailResponse['lastDrawCard'],
+        lastPenalty: true,
+        message: 'テストメッセージ',
+      }),
+    );
+    expect(out).toContain('最後: H7 （ペナルティ）');
+    expect(out).toContain('テストメッセージ');
+  });
+
+  it('marks a safe draw', () => {
+    const out = formatPigtailState(
+      makeState({ lastDrawCard: { design: 'SPADE', value: 2 } as PigsTailResponse['lastDrawCard'] }),
+    );
+    expect(out).toContain('（セーフ）');
+  });
+});

--- a/frontend/src/utils/cli/formatters/pigtailFormatter.ts
+++ b/frontend/src/utils/cli/formatters/pigtailFormatter.ts
@@ -1,0 +1,20 @@
+import i18n from '../../../i18n';
+import type { PigsTailResponse } from '../../../types/card';
+
+/** Format Pig's Tail state for CLI display. Labels are localized via the i18n instance. */
+export function formatPigtailState(s: PigsTailResponse): string {
+  const lines: string[] = [];
+  const phase = s.gameEndFlag ? i18n.t('pigtail:cli.phase.end') : i18n.t('pigtail:cli.phase.play');
+  lines.push(i18n.t('pigtail:cli.summary', { phase, circle: s.circleCount, center: s.centerCount }));
+  for (const p of s.players) {
+    const tag = p.isHuman ? i18n.t('pigtail:cli.you') : i18n.t('pigtail:cli.cpu', { id: p.id });
+    lines.push(i18n.t('pigtail:cli.playerCards', { tag, count: p.cardCount }));
+  }
+  if (s.lastDrawCard) {
+    const card = `${s.lastDrawCard.design[0]}${s.lastDrawCard.value}`;
+    const status = s.lastPenalty ? i18n.t('pigtail:cli.penalty') : i18n.t('pigtail:cli.safe');
+    lines.push(i18n.t('pigtail:cli.last', { card, status }));
+  }
+  if (s.message) lines.push(s.message);
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
- Extract the inline CLI `parseCommand`/`formatResponse`/`helpText` from `PigsTailPage.tsx` into `utils/cli/commands/pigtailCommands.ts` and `utils/cli/formatters/pigtailFormatter.ts`, matching the per-game CLI module convention.
- Localize CLI output — phase, player rows, penalty/safe status — and help through the i18n instance (`pigtail:cli.*`); add ja/en translations.
- Unknown commands now offer a Levenshtein-based suggestion via `suggestCommand` (shared `commandParserBase`).
- The CLI config `useMemo` depends on `i18n.language` so help re-localizes after a runtime language switch.

## Test plan
- `pigtailCommands.test.ts` — draw/reset aliases, case-insensitivity, near-miss suggestion, plain unknown fallback, localized help.
- `pigtailFormatter.test.ts` — localized phase/summary/player rows, End phase, penalty + message, safe draw.
- Existing `PigsTailPage.test.tsx` still passes; `tsc -b`, biome, and build are green.

Closes #3117