### PR TITLE
refactor(slapjack): extract CLI parser/formatter modules and localize output

### DIFF
--- a/frontend/src/i18n/locales/en/slapjack.json
+++ b/frontend/src/i18n/locales/en/slapjack.json
@@ -46,5 +46,26 @@
     "playerPile": "Your stock. You lose if it empties.",
     "stepButton": "Flip the top card of your stock.",
     "slapButton": "Slap when the top is a Jack. Wrong slaps cost you a card."
+  },
+  "cli": {
+    "help": [
+      "s/step  - Flip top of stock onto pile",
+      "j/slap  - Slap the pile (when J is on top)",
+      "tick    - Advance CPU by one tick",
+      "r/reset - Reset game",
+      "l/log   - Show action log"
+    ],
+    "phase": {
+      "play": "Play",
+      "end": "End"
+    },
+    "summary": "Phase: {{phase}} | Pile: {{pile}} | Top: {{top}} | Turn: P{{turn}}",
+    "you": "You",
+    "cpu": "CPU",
+    "playerStock": "{{tag}}: stock={{stock}}",
+    "error": {
+      "unknown": "Unknown command: {{cmd}}",
+      "unknownSuggest": "Unknown command: {{cmd}}. Did you mean: {{suggestion}}?"
+    }
   }
 }

--- a/frontend/src/i18n/locales/ja/slapjack.json
+++ b/frontend/src/i18n/locales/ja/slapjack.json
@@ -46,5 +46,26 @@
     "playerPile": "あなたのストックです。なくなると負けです。",
     "stepButton": "このボタンでカードをめくります。",
     "slapButton": "場のトップがJのとき素早く叩きます。J以外で叩くとペナルティです。"
+  },
+  "cli": {
+    "help": [
+      "s/step  - ストックのトップを場に出す",
+      "j/slap  - 場札を叩く（Jが出たとき）",
+      "tick    - CPUを1ステップ進める",
+      "r/reset - ゲームをリセット",
+      "l/log   - アクションログを表示"
+    ],
+    "phase": {
+      "play": "プレイ中",
+      "end": "終了"
+    },
+    "summary": "フェーズ: {{phase}} | 場札: {{pile}} | トップ: {{top}} | 手番: P{{turn}}",
+    "you": "あなた",
+    "cpu": "CPU",
+    "playerStock": "{{tag}}: ストック={{stock}}",
+    "error": {
+      "unknown": "不明なコマンド: {{cmd}}",
+      "unknownSuggest": "不明なコマンド: {{cmd}}。もしかして: {{suggestion}}？"
+    }
   }
 }

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -22,11 +22,14 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
 import { useReflexShortcuts } from '../hooks/useReflexShortcuts';
+import i18n from '../i18n';
 import { gameTheme } from '../styles/gameTheme';
 import type { SlapjackResponse } from '../types/card';
 import { SlapjackEventKind, SlapjackPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
-import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
+import { parseSlapjackCommand, slapjackHelp } from '../utils/cli/commands/slapjackCommands';
+import { formatSlapjackState } from '../utils/cli/formatters/slapjackFormatter';
+import type { CliGameConfig } from '../utils/cli/types';
 
 type SlapjackArgs = Parameters<typeof slapjackApi.exec>;
 
@@ -124,39 +127,17 @@ function SlapjackPageContent() {
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('slapjack');
+  // slapjackHelp() reads i18n internally, so depend on i18n.language to
+  // re-localize the CLI help after a runtime language switch.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: i18n.language drives help re-localization
   const cliConfig: CliGameConfig<SlapjackResponse, SlapjackArgs> = useMemo(
     () => ({
       gameName: 'slapjack',
-      parseCommand: (input: string): CliParseResult<SlapjackArgs> => {
-        const cmd = input.trim().toLowerCase();
-        if (cmd === 'reset' || cmd === 'r') return { args: ['reset'] };
-        if (cmd === 'step' || cmd === 's') return { args: ['step'] };
-        if (cmd === 'slap' || cmd === 'j') return { args: ['slap'] };
-        if (cmd === 'tick') return { args: ['tick'] };
-        if (cmd === 'log' || cmd === 'l') return { args: ['log'] };
-        return { error: `Unknown command: ${cmd}` };
-      },
-      formatResponse: (s: SlapjackResponse) => {
-        const lines: string[] = [];
-        const phase = s.phase === SlapjackPhase.GAME_END ? 'End' : 'Play';
-        const top = s.topCard ? `${s.topCard.value}` : '--';
-        lines.push(`Phase: ${phase} | Pile: ${s.centerPileSize} | Top: ${top} | Turn: P${s.currentTurnIdx}`);
-        for (const p of s.players) {
-          const tag = p.isHuman ? 'You' : 'CPU';
-          lines.push(`${tag}: stock=${p.stockSize}`);
-        }
-        if (s.message) lines.push(s.message);
-        return lines.join('\n');
-      },
-      helpText: [
-        's/step  - Flip top of stock onto pile',
-        'j/slap  - Slap the pile (when J is on top)',
-        'tick    - Advance CPU by one tick',
-        'r/reset - Reset game',
-        'l/log   - Show action log',
-      ],
+      parseCommand: parseSlapjackCommand,
+      formatResponse: formatSlapjackState,
+      helpText: slapjackHelp(),
     }),
-    [],
+    [i18n.language],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/utils/cli/commands/slapjackCommands.test.ts
+++ b/frontend/src/utils/cli/commands/slapjackCommands.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { parseSlapjackCommand, slapjackHelp } from './slapjackCommands';
+
+describe('parseSlapjackCommand', () => {
+  it('parses commands and their aliases', () => {
+    expect(parseSlapjackCommand('r')).toEqual({ args: ['reset'] });
+    expect(parseSlapjackCommand('reset')).toEqual({ args: ['reset'] });
+    expect(parseSlapjackCommand('s')).toEqual({ args: ['step'] });
+    expect(parseSlapjackCommand('step')).toEqual({ args: ['step'] });
+    expect(parseSlapjackCommand('j')).toEqual({ args: ['slap'] });
+    expect(parseSlapjackCommand('slap')).toEqual({ args: ['slap'] });
+    expect(parseSlapjackCommand('tick')).toEqual({ args: ['tick'] });
+    expect(parseSlapjackCommand('l')).toEqual({ args: ['log'] });
+    expect(parseSlapjackCommand('log')).toEqual({ args: ['log'] });
+  });
+
+  it('is case-insensitive on the command word', () => {
+    expect(parseSlapjackCommand('STEP')).toEqual({ args: ['step'] });
+  });
+
+  it('suggests the closest command for a near-miss typo', () => {
+    expect(parseSlapjackCommand('slp')).toEqual({ error: '不明なコマンド: slp。もしかして: slap？' });
+    expect(parseSlapjackCommand('rest')).toEqual({ error: '不明なコマンド: rest。もしかして: reset？' });
+  });
+
+  it('returns a plain unknown-command error when nothing is close', () => {
+    expect(parseSlapjackCommand('zzzzzz')).toEqual({ error: '不明なコマンド: zzzzzz' });
+  });
+});
+
+describe('slapjackHelp', () => {
+  it('returns a non-empty list of localized help lines', () => {
+    const help = slapjackHelp();
+    expect(Array.isArray(help)).toBe(true);
+    expect(help.length).toBe(5);
+    expect(help.some((line) => line.includes('slap'))).toBe(true);
+  });
+});

--- a/frontend/src/utils/cli/commands/slapjackCommands.ts
+++ b/frontend/src/utils/cli/commands/slapjackCommands.ts
@@ -1,0 +1,39 @@
+import type { slapjackApi } from '../../../api/gameApi';
+import i18n from '../../../i18n';
+import { splitCommand, suggestCommand } from '../commandParserBase';
+import type { CliParseResult } from '../types';
+
+type SlapjackArgs = Parameters<typeof slapjackApi.exec>;
+
+const VALID_COMMANDS = ['step', 'slap', 'tick', 'reset', 'log'];
+
+/** Localized CLI help lines for Slap Jack (resolved via the i18n instance). */
+export function slapjackHelp(): string[] {
+  return i18n.t('slapjack:cli.help', { returnObjects: true }) as string[];
+}
+
+/** Parse a Slap Jack CLI command into API exec arguments. Error strings are localized. */
+export function parseSlapjackCommand(input: string): CliParseResult<SlapjackArgs> {
+  const { cmd } = splitCommand(input);
+  switch (cmd) {
+    case 'r':
+    case 'reset':
+      return { args: ['reset'] };
+    case 's':
+    case 'step':
+      return { args: ['step'] };
+    case 'j':
+    case 'slap':
+      return { args: ['slap'] };
+    case 'tick':
+      return { args: ['tick'] };
+    case 'l':
+    case 'log':
+      return { args: ['log'] };
+    default: {
+      const suggestion = suggestCommand(cmd, VALID_COMMANDS);
+      if (suggestion) return { error: i18n.t('slapjack:cli.error.unknownSuggest', { cmd, suggestion }) };
+      return { error: i18n.t('slapjack:cli.error.unknown', { cmd }) };
+    }
+  }
+}

--- a/frontend/src/utils/cli/formatters/slapjackFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/slapjackFormatter.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { SlapjackResponse } from '../../../types/card';
+import { SlapjackPhase } from '../../../types/phases';
+import { formatSlapjackState } from './slapjackFormatter';
+
+function makeState(overrides: Partial<SlapjackResponse> = {}): SlapjackResponse {
+  return {
+    phase: SlapjackPhase.PLAY,
+    centerPileSize: 3,
+    topCard: { value: 11 } as SlapjackResponse['topCard'],
+    currentTurnIdx: 0,
+    players: [
+      { isHuman: true, stockSize: 20 },
+      { isHuman: false, stockSize: 32 },
+    ],
+    message: '',
+    ...overrides,
+  } as SlapjackResponse;
+}
+
+describe('formatSlapjackState', () => {
+  it('renders localized phase, pile summary, and player stock rows', () => {
+    const out = formatSlapjackState(makeState());
+    expect(out).toContain('フェーズ: プレイ中 | 場札: 3 | トップ: 11 | 手番: P0');
+    expect(out).toContain('あなた: ストック=20');
+    expect(out).toContain('CPU: ストック=32');
+  });
+
+  it('shows End phase and a placeholder top when the pile is empty', () => {
+    const out = formatSlapjackState(makeState({ phase: SlapjackPhase.GAME_END, topCard: null }));
+    expect(out).toContain('フェーズ: 終了');
+    expect(out).toContain('トップ: --');
+  });
+
+  it('appends any message', () => {
+    const out = formatSlapjackState(makeState({ message: 'テストメッセージ' }));
+    expect(out).toContain('テストメッセージ');
+  });
+});

--- a/frontend/src/utils/cli/formatters/slapjackFormatter.ts
+++ b/frontend/src/utils/cli/formatters/slapjackFormatter.ts
@@ -1,0 +1,18 @@
+import i18n from '../../../i18n';
+import type { SlapjackResponse } from '../../../types/card';
+import { SlapjackPhase } from '../../../types/phases';
+
+/** Format Slap Jack state for CLI display. Labels are localized via the i18n instance. */
+export function formatSlapjackState(s: SlapjackResponse): string {
+  const lines: string[] = [];
+  const phase =
+    s.phase === SlapjackPhase.GAME_END ? i18n.t('slapjack:cli.phase.end') : i18n.t('slapjack:cli.phase.play');
+  const top = s.topCard ? `${s.topCard.value}` : '--';
+  lines.push(i18n.t('slapjack:cli.summary', { phase, pile: s.centerPileSize, top, turn: s.currentTurnIdx }));
+  for (const p of s.players) {
+    const tag = p.isHuman ? i18n.t('slapjack:cli.you') : i18n.t('slapjack:cli.cpu');
+    lines.push(i18n.t('slapjack:cli.playerStock', { tag, stock: p.stockSize }));
+  }
+  if (s.message) lines.push(s.message);
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
- Extract the inline CLI `parseCommand`/`formatResponse`/`helpText` from `SlapjackPage.tsx` into `utils/cli/commands/slapjackCommands.ts` and `utils/cli/formatters/slapjackFormatter.ts`, matching the per-game CLI module convention.
- Localize CLI output (phase, pile/top/turn summary, player stock rows) and help through the i18n instance (`slapjack:cli.*`); add ja/en translations that stay key-for-key in sync.
- The CLI config `useMemo` depends on `i18n.language` so help re-localizes after a runtime language switch.
- Unknown commands offer a Levenshtein-based suggestion via `suggestCommand`.
- Command behavior (s/j/tick/r/l and aliases) is unchanged.

## Test plan
- `slapjackCommands.test.ts` — all commands/aliases, case-insensitivity, near-miss suggestion, plain unknown fallback, localized help.
- `slapjackFormatter.test.ts` — localized phase/summary/stock rows, End phase + empty-pile placeholder, message pass-through.
- Existing `SlapjackPage.test.tsx` still passes; `tsc -b`, biome, and build are green.

Closes #3225