### PR TITLE
feat(reddog): add hint command to the CUI with stay/raise recommendation

### DIFF
--- a/internal/adapter/controller/RedDogCuiController.go
+++ b/internal/adapter/controller/RedDogCuiController.go
@@ -25,7 +25,7 @@ func (rc *RedDogCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return rc.ci.Reset() },
-		[]string{"b", "bet", "raise", "s", "stay", "log"},
+		[]string{"b", "bet", "raise", "s", "stay", "h", "hint", "log"},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "b", "bet":
@@ -42,6 +42,8 @@ func (rc *RedDogCuiController) Exec(command string) string {
 				return rc.ci.Raise(amount), true
 			case "s", "stay":
 				return rc.ci.Stay(), true
+			case "h", "hint":
+				return rc.ci.Hint(), true
 			default:
 				return handleCuiLog(cmd, rc.ci.ActionLog)
 			}

--- a/internal/adapter/controller/RedDogCuiController_test.go
+++ b/internal/adapter/controller/RedDogCuiController_test.go
@@ -17,6 +17,7 @@ func newMockRedDogInteractor() *usecase.MockRedDogInteractor {
 	m.On("Bet", 100).Return("bet result")
 	m.On("Raise", 50).Return("raise result")
 	m.On("Stay").Return("stay result")
+	m.On("Hint").Return("hint result")
 	m.On("ActionLog").Return("action log result")
 	return m
 }
@@ -61,6 +62,12 @@ func TestRedDogCuiController_Stay(t *testing.T) {
 	c := controller.NewRedDogCuiController(newMockRedDogInteractor())
 	assert.Equal(t, "stay result", c.Exec("s"))
 	assert.Equal(t, "stay result", c.Exec("stay"))
+}
+
+func TestRedDogCuiController_Hint(t *testing.T) {
+	c := controller.NewRedDogCuiController(newMockRedDogInteractor())
+	assert.Equal(t, "hint result", c.Exec("h"))
+	assert.Equal(t, "hint result", c.Exec("hint"))
 }
 
 func TestRedDogCuiController_ActionLog(t *testing.T) {

--- a/internal/adapter/controller/usecase/RedDogInteractor_mock.go
+++ b/internal/adapter/controller/usecase/RedDogInteractor_mock.go
@@ -29,6 +29,11 @@ func (m *MockRedDogInteractor) Stay() string {
 	return args.String(0)
 }
 
+func (m *MockRedDogInteractor) Hint() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 func (m *MockRedDogInteractor) ActionLog() string {
 	args := m.Called()
 	return args.String(0)

--- a/internal/adapter/presenter/RedDogCuiPresenter.go
+++ b/internal/adapter/presenter/RedDogCuiPresenter.go
@@ -117,6 +117,30 @@ func (rp *RedDogCuiPresenter) Output(rd interfaces.RedDogGame, lastErr error) st
 	return sb.String()
 }
 
+// redDogRaiseThreshold はレイズを推奨する最小スプレッド。スプレッド（勝てるランク数）が
+// これ以上なら3枚目が的中する確率が5割を超えるため、最大レイズが有利になる。
+const redDogRaiseThreshold = 7
+
+// HintOutput スプレッドの広さからステイ/レイズの推奨を出力する
+func (rp *RedDogCuiPresenter) HintOutput(rd interfaces.RedDogGame) string {
+	switch rd.GetPhase() {
+	case domain.RedDogPhaseSpreadDecision:
+		spread := rd.GetSpread()
+		rec := i18n.T("reddog.hintStayRec")
+		if spread >= redDogRaiseThreshold {
+			rec = i18n.T("reddog.hintRaiseRec")
+		}
+		return i18n.Tf("reddog.hintSpread",
+			"spread", strconv.Itoa(spread),
+			"ranks", redDogWinningRanksStr(rd.GetInitialCards()),
+			"rec", rec) + "\n"
+	case domain.RedDogPhaseBet, domain.RedDogPhaseInitialDealt:
+		return i18n.T("reddog.hintBetFirst") + "\n"
+	default:
+		return i18n.T("reddog.hintGameOver") + "\n"
+	}
+}
+
 // ActionLogOutput 棋譜をテキスト出力
 func (rp *RedDogCuiPresenter) ActionLogOutput(rd interfaces.RedDogGame) string {
 	return actionLogOutputText(rd)

--- a/internal/adapter/presenter/RedDogCuiPresenter_test.go
+++ b/internal/adapter/presenter/RedDogCuiPresenter_test.go
@@ -181,6 +181,55 @@ func TestRedDogWinningRanksStr(t *testing.T) {
 	assert.Equal(t, "", redDogWinningRanksStr([]*domain.Card{domain.NewCard(domain.CardDesignSpade, 5, false)}))
 }
 
+func TestRedDogCuiPresenter_HintOutput_RaiseRecommended(t *testing.T) {
+	p := new(RedDogCuiPresenter)
+	m := new(interfaces.MockRedDogGame)
+	cards := []*domain.Card{
+		domain.NewCard(domain.CardDesignSpade, 3, false),
+		domain.NewCard(domain.CardDesignHeart, 11, false), // spread 3..11 -> 7 winning ranks
+	}
+	m.On("GetPhase").Return(domain.RedDogPhaseSpreadDecision)
+	m.On("GetSpread").Return(7)
+	m.On("GetInitialCards").Return(cards)
+
+	result := p.HintOutput(m)
+	assert.Contains(t, result, "スプレッド 7")
+	assert.Contains(t, result, "レイズ推奨")
+	assert.Contains(t, result, "勝てるランク: 4, 5, 6, 7, 8, 9, 10")
+}
+
+func TestRedDogCuiPresenter_HintOutput_StayRecommended(t *testing.T) {
+	p := new(RedDogCuiPresenter)
+	m := new(interfaces.MockRedDogGame)
+	cards := []*domain.Card{
+		domain.NewCard(domain.CardDesignSpade, 5, false),
+		domain.NewCard(domain.CardDesignHeart, 10, false),
+	}
+	m.On("GetPhase").Return(domain.RedDogPhaseSpreadDecision)
+	m.On("GetSpread").Return(4)
+	m.On("GetInitialCards").Return(cards)
+
+	result := p.HintOutput(m)
+	assert.Contains(t, result, "スプレッド 4")
+	assert.Contains(t, result, "ステイ推奨")
+}
+
+func TestRedDogCuiPresenter_HintOutput_BetPhase(t *testing.T) {
+	p := new(RedDogCuiPresenter)
+	for _, phase := range []int{domain.RedDogPhaseBet, domain.RedDogPhaseInitialDealt} {
+		m := new(interfaces.MockRedDogGame)
+		m.On("GetPhase").Return(phase)
+		assert.Contains(t, p.HintOutput(m), "まずベットしてください")
+	}
+}
+
+func TestRedDogCuiPresenter_HintOutput_GameOver(t *testing.T) {
+	p := new(RedDogCuiPresenter)
+	m := new(interfaces.MockRedDogGame)
+	m.On("GetPhase").Return(domain.RedDogPhaseEnd)
+	assert.Contains(t, p.HintOutput(m), "ゲームは終了しています")
+}
+
 func TestRedDogCuiPresenter_ActionLogOutput(t *testing.T) {
 	p := new(RedDogCuiPresenter)
 	m := new(interfaces.MockRedDogGame)

--- a/internal/adapter/presenter/RedDogWebPresenter.go
+++ b/internal/adapter/presenter/RedDogWebPresenter.go
@@ -50,3 +50,9 @@ func (rp *RedDogWebPresenter) Output(rd interfaces.RedDogGame, lastErr error) st
 func (rp *RedDogWebPresenter) ActionLogOutput(rd interfaces.RedDogGame) string {
 	return actionLogOutputJSON(rd)
 }
+
+// HintOutput ヒントを出力する。Web ではヒントはクライアント側 (useGameHint) で
+// 算出するため、通常の状態出力を返す。RedDogPresenter インタフェースを満たすための実装。
+func (rp *RedDogWebPresenter) HintOutput(rd interfaces.RedDogGame) string {
+	return rp.Output(rd, nil)
+}

--- a/internal/i18n/locales/en/reddog.json
+++ b/internal/i18n/locales/en/reddog.json
@@ -19,5 +19,10 @@
   "playerWins": "Player wins!",
   "playerLoses": "Player loses.",
   "push": "Push.",
-  "totalPayoutLine": "total payout: {{payout}}"
+  "totalPayoutLine": "total payout: {{payout}}",
+  "hintRaiseRec": "Raise recommended",
+  "hintStayRec": "Stay recommended",
+  "hintSpread": "Spread {{spread}} (winning ranks: {{ranks}}) -> {{rec}}",
+  "hintBetFirst": "Place a bet first.",
+  "hintGameOver": "The game is over."
 }

--- a/internal/i18n/locales/en/reddog.json
+++ b/internal/i18n/locales/en/reddog.json
@@ -3,6 +3,7 @@
   "helpBet": "  b <amount>           bet (places ante and deals 2 cards)",
   "helpRaise": "  raise <amount>       raise (up to ante)",
   "helpStay": "  s                    stay (draw third card without raising)",
+  "helpHint": "  h                    hint (stay/raise recommendation)",
   "chipsLine": "chips: {{chips}}",
   "phaseLine": "phase: {{phase}}",
   "anteLine": "ante: {{ante}}",

--- a/internal/i18n/locales/ja/reddog.json
+++ b/internal/i18n/locales/ja/reddog.json
@@ -3,6 +3,7 @@
   "helpBet": "  b <金額>             ベット (アンテを賭けて2枚配る)",
   "helpRaise": "  raise <金額>         レイズ (最大アンテと同額)",
   "helpStay": "  s                    ステイ (レイズせず3枚目を引く)",
+  "helpHint": "  h                    ヒント (ステイ/レイズの推奨)",
   "chipsLine": "チップ: {{chips}}",
   "phaseLine": "フェーズ: {{phase}}",
   "anteLine": "アンテ: {{ante}}",

--- a/internal/i18n/locales/ja/reddog.json
+++ b/internal/i18n/locales/ja/reddog.json
@@ -19,5 +19,10 @@
   "playerWins": "プレイヤーの勝ち！",
   "playerLoses": "プレイヤーの負け。",
   "push": "プッシュ。",
-  "totalPayoutLine": "合計払戻し: {{payout}}"
+  "totalPayoutLine": "合計払戻し: {{payout}}",
+  "hintRaiseRec": "レイズ推奨",
+  "hintStayRec": "ステイ推奨",
+  "hintSpread": "スプレッド {{spread}}（勝てるランク: {{ranks}}）→ {{rec}}",
+  "hintBetFirst": "まずベットしてください。",
+  "hintGameOver": "ゲームは終了しています。"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -1054,7 +1054,7 @@ var gameRegistry = []GameRegistryEntry{
 				domain.NewDefaultRedDog(), new(presenter.RedDogCuiPresenter))),
 			CuiHelpSpec{
 				TitleKey:          "reddog.helpTitle",
-				CommandKeys:       []string{"reddog.helpBet", "reddog.helpRaise", "reddog.helpStay"},
+				CommandKeys:       []string{"reddog.helpBet", "reddog.helpRaise", "reddog.helpStay", "reddog.helpHint"},
 				ExtraCommandLines: []string{"  log                  action log"},
 			})
 	}},

--- a/internal/usecase/RedDogInteractor.go
+++ b/internal/usecase/RedDogInteractor.go
@@ -20,6 +20,8 @@ type RedDogInteractorIF interface {
 	Raise(amount int) string
 	// Stay レイズせず3枚目を引く
 	Stay() string
+	// Hint ヒント取得
+	Hint() string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
 }
@@ -63,6 +65,11 @@ func (ri *RedDogInteractor) Raise(amount int) string {
 // Stay レイズせず3枚目を引く
 func (ri *RedDogInteractor) Stay() string {
 	return execAndPresent(ri.Game, ri.cp, ri.Game.Stay)
+}
+
+// Hint ヒント取得
+func (ri *RedDogInteractor) Hint() string {
+	return ri.cp.HintOutput(ri.Game)
 }
 
 // ActionLog 棋譜を出力する

--- a/internal/usecase/presenter/RedDogPresenter.go
+++ b/internal/usecase/presenter/RedDogPresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // RedDogPresenter レッドドッグプレゼンターインタフェース
-type RedDogPresenter = GamePresenter[interfaces.RedDogGame]
+type RedDogPresenter interface {
+	GamePresenter[interfaces.RedDogGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(rd interfaces.RedDogGame) string
+}

--- a/internal/usecase/presenter/RedDogPresenter_mock.go
+++ b/internal/usecase/presenter/RedDogPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockRedDogPresenter レッドドッグプレゼンターモック
-type MockRedDogPresenter = MockGamePresenter[interfaces.RedDogGame]
+type MockRedDogPresenter struct {
+	MockGamePresenter[interfaces.RedDogGame]
+}
+
+// HintOutput モック
+func (_m *MockRedDogPresenter) HintOutput(rd interfaces.RedDogGame) string {
+	ret := _m.Called(rd)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## Summary
- Add `HintOutput` to `RedDogCuiPresenter`: in the spread-decision phase it recommends **raise** when the spread (number of winning ranks) is ≥ 7 (third card hits >50% of the time) and **stay** otherwise, reusing the existing `redDogWinningRanksStr`. Bet/initial-dealt phases prompt to bet first; the end phase reports the game is over.
- Wire the `hint`/`h` command end-to-end: promote `RedDogPresenter` from a `GamePresenter` alias to an interface with `HintOutput` (implemented by both CUI and Web presenters — the Web side delegates to `Output`, since web hints are computed client-side), add `RedDogInteractor.Hint()` + IF method, register the command in `RedDogCuiController`, and extend the presenter/interactor mocks.
- Add ja/en `hint*` translations to `internal/i18n/locales/{ja,en}/reddog.json`.

## Test plan
- `RedDogCuiPresenter_test.go` — HintOutput for spread≥7 (raise), spread<7 (stay), bet/initial-dealt (bet first), end (game over).
- `RedDogCuiController_test.go` — `h`/`hint` routes to `Hint()`.
- `go test -tags test ./internal/...`, `golangci-lint`, server build, and the casino WASM worker build all pass.

Closes #3173