### PR TITLE
feat(trash): add hint command to the CUI with placement guidance

### DIFF
--- a/internal/adapter/controller/TrashCuiController.go
+++ b/internal/adapter/controller/TrashCuiController.go
@@ -23,7 +23,7 @@ func (c *TrashCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return c.ti.Reset() },
-		[]string{"d", "draw", "p", "place", "cpu", "log", "l"},
+		[]string{"d", "draw", "p", "place", "cpu", "h", "hint", "log", "l"},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "d", "draw":
@@ -32,6 +32,8 @@ func (c *TrashCuiController) Exec(command string) string {
 				return c.handlePlace(args), true
 			case "cpu":
 				return c.ti.CpuStep(), true
+			case "h", "hint":
+				return c.ti.Hint(), true
 			default:
 				result, handled := handleCuiLog(cmd, c.ti.ActionLog)
 				return result, handled

--- a/internal/adapter/controller/TrashCuiController_test.go
+++ b/internal/adapter/controller/TrashCuiController_test.go
@@ -63,6 +63,14 @@ func TestTrashCuiControllerCpu(t *testing.T) {
 	assert.Equal(t, "cpu_output", c.Exec("cpu"))
 }
 
+func TestTrashCuiControllerHint(t *testing.T) {
+	ti := newMockTrashInteractor()
+	c := NewTrashCuiController(ti)
+	ti.On("Hint").Return("hint_output")
+	assert.Equal(t, "hint_output", c.Exec("h"))
+	assert.Equal(t, "hint_output", c.Exec("hint"))
+}
+
 func TestTrashCuiControllerActionLog(t *testing.T) {
 	ti := newMockTrashInteractor()
 	c := NewTrashCuiController(ti)

--- a/internal/adapter/controller/usecase/TrashInteractor_mock.go
+++ b/internal/adapter/controller/usecase/TrashInteractor_mock.go
@@ -31,6 +31,11 @@ func (_m *MockTrashInteractor) CpuStep() string {
 	return ret.Get(0).(string)
 }
 
+func (_m *MockTrashInteractor) Hint() string {
+	ret := _m.Called()
+	return ret.Get(0).(string)
+}
+
 func (_m *MockTrashInteractor) ActionLog() string {
 	ret := _m.Called()
 	return ret.Get(0).(string)

--- a/internal/adapter/presenter/TrashCuiPresenter.go
+++ b/internal/adapter/presenter/TrashCuiPresenter.go
@@ -73,6 +73,62 @@ func (p *TrashCuiPresenter) Output(t interfaces.TrashGame, lastErr error) string
 	})
 }
 
+// trashHumanFaceDownSlots returns the 1-based positions of the human's slots
+// that are still unfilled (face down) — the valid targets for a wild card.
+func trashHumanFaceDownSlots(t interfaces.TrashGame) []string {
+	var out []string
+	for i, s := range t.GetPlayerSlots(domain.TrashHumanIdx) {
+		if !s.FaceUp {
+			out = append(out, strconv.Itoa(i+1))
+		}
+	}
+	return out
+}
+
+// trashIsWild reports whether a card is a Trash wild (King or Joker).
+func trashIsWild(c *domain.Card) bool {
+	return c != nil && (c.GetDesign() == domain.CardDesignJoker || c.GetValue() == 13)
+}
+
+// trashSlotFor returns the 1-based slot a rank-value card fills, or 0 for
+// end-turn/wild cards that have no fixed slot.
+func trashSlotFor(c *domain.Card) int {
+	if c == nil || c.GetDesign() == domain.CardDesignJoker {
+		return 0
+	}
+	if v := c.GetValue(); v >= 1 && v <= domain.TrashSlotCnt {
+		return v
+	}
+	return 0
+}
+
+// HintOutput suggests where the drawn/wild card should go, or whether the
+// face-up discard is worth taking on the player's turn.
+func (p *TrashCuiPresenter) HintOutput(t interfaces.TrashGame) string {
+	switch t.GetPhase() {
+	case domain.TrashPhaseAwaitWild:
+		slots := trashHumanFaceDownSlots(t)
+		if len(slots) == 0 {
+			return i18n.T("trash.hintGameOver") + "\n"
+		}
+		// Filling the highest open position first keeps the low ranks — which
+		// you are equally likely to draw — available to place themselves.
+		rec := slots[len(slots)-1]
+		return i18n.Tf("trash.hintWild", "slots", strings.Join(slots, ", "), "rec", rec) + "\n"
+	case domain.TrashPhasePlayerTurn:
+		top := t.GetDiscardTop()
+		if trashIsWild(top) && len(trashHumanFaceDownSlots(t)) > 0 {
+			return i18n.T("trash.hintTakeDiscardWild") + "\n"
+		}
+		if slot := trashSlotFor(top); slot > 0 && !t.GetPlayerSlots(domain.TrashHumanIdx)[slot-1].FaceUp {
+			return i18n.Tf("trash.hintTakeDiscard", "slot", strconv.Itoa(slot)) + "\n"
+		}
+		return i18n.T("trash.hintDrawStock") + "\n"
+	default:
+		return i18n.T("trash.hintGameOver") + "\n"
+	}
+}
+
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TrashCuiPresenter) ActionLogOutput(t interfaces.TrashGame) string {
 	if t.GetPhase() != domain.TrashPhaseGameOver {

--- a/internal/adapter/presenter/TrashCuiPresenter.go
+++ b/internal/adapter/presenter/TrashCuiPresenter.go
@@ -105,6 +105,11 @@ func trashSlotFor(c *domain.Card) int {
 // HintOutput suggests where the drawn/wild card should go, or whether the
 // face-up discard is worth taking on the player's turn.
 func (p *TrashCuiPresenter) HintOutput(t interfaces.TrashGame) string {
+	// Advice is always for the human's board, so it only makes sense on the
+	// human's turn — the same phases apply to the CPU mid-resolution.
+	if t.GetPhase() != domain.TrashPhaseGameOver && t.GetCurrent() != domain.TrashHumanIdx {
+		return i18n.T("trash.hintNotYourTurn") + "\n"
+	}
 	switch t.GetPhase() {
 	case domain.TrashPhaseAwaitWild:
 		slots := trashHumanFaceDownSlots(t)

--- a/internal/adapter/presenter/TrashCuiPresenter_test.go
+++ b/internal/adapter/presenter/TrashCuiPresenter_test.go
@@ -86,3 +86,56 @@ func TestTrashCuiPresenter_ActionLogOutput(t *testing.T) {
 		assert.NotEmpty(t, out)
 	})
 }
+
+func TestTrashCuiPresenter_HintOutput(t *testing.T) {
+	p := new(TrashCuiPresenter)
+
+	t.Run("await wild lists candidate slots and recommends the highest open one", func(t *testing.T) {
+		slots := make([]domain.TrashSlot, domain.TrashSlotCnt)
+		for i := range slots {
+			// Slots 1-3 already filled (face up); 4-10 are open.
+			slots[i] = domain.TrashSlot{Card: domain.NewCard(domain.CardDesignSpade, i+1, false), FaceUp: i < 3}
+		}
+		tg := buildTrashMock(trashMockOpts{
+			phase:   domain.TrashPhaseAwaitWild,
+			pending: domain.NewCard(domain.CardDesignSpade, 13, false),
+			p0Slots: slots,
+		})
+		out := p.HintOutput(tg)
+		assert.Contains(t, out, "配置候補: 4, 5, 6, 7, 8, 9, 10")
+		assert.Contains(t, out, "推奨: 10")
+	})
+
+	t.Run("player turn recommends taking a placeable discard", func(t *testing.T) {
+		tg := buildTrashMock(trashMockOpts{
+			phase:      domain.TrashPhasePlayerTurn,
+			discardTop: domain.NewCard(domain.CardDesignHeart, 5, false),
+		})
+		out := p.HintOutput(tg)
+		assert.Contains(t, out, "スロット5")
+	})
+
+	t.Run("player turn flags a wild discard", func(t *testing.T) {
+		tg := buildTrashMock(trashMockOpts{
+			phase:      domain.TrashPhasePlayerTurn,
+			discardTop: domain.NewCard(domain.CardDesignSpade, 13, false),
+		})
+		out := p.HintOutput(tg)
+		assert.Contains(t, out, "ワイルド")
+	})
+
+	t.Run("player turn advises drawing when the discard is useless", func(t *testing.T) {
+		tg := buildTrashMock(trashMockOpts{
+			phase:      domain.TrashPhasePlayerTurn,
+			discardTop: domain.NewCard(domain.CardDesignSpade, 11, false), // Jack = end-turn card
+		})
+		out := p.HintOutput(tg)
+		assert.Contains(t, out, "山札から引き")
+	})
+
+	t.Run("game over reports the game is finished", func(t *testing.T) {
+		tg := buildTrashMock(trashMockOpts{phase: domain.TrashPhaseGameOver, winner: 1, winnerSet: true})
+		out := p.HintOutput(tg)
+		assert.Contains(t, out, "ゲームは終了")
+	})
+}

--- a/internal/adapter/presenter/TrashCuiPresenter_test.go
+++ b/internal/adapter/presenter/TrashCuiPresenter_test.go
@@ -158,6 +158,16 @@ func TestTrashCuiPresenter_HintOutput(t *testing.T) {
 		assert.Contains(t, out, "山札から引き")
 	})
 
+	t.Run("declines advice when it is not the human's turn", func(t *testing.T) {
+		tg := buildTrashMock(trashMockOpts{
+			phase:      domain.TrashPhasePlayerTurn,
+			current:    domain.TrashCpuIdx,
+			discardTop: domain.NewCard(domain.CardDesignHeart, 5, false),
+		})
+		out := p.HintOutput(tg)
+		assert.Contains(t, out, "あなたの番ではありません")
+	})
+
 	t.Run("game over reports the game is finished", func(t *testing.T) {
 		tg := buildTrashMock(trashMockOpts{phase: domain.TrashPhaseGameOver, winner: 1, winnerSet: true})
 		out := p.HintOutput(tg)

--- a/internal/adapter/presenter/TrashCuiPresenter_test.go
+++ b/internal/adapter/presenter/TrashCuiPresenter_test.go
@@ -133,6 +133,31 @@ func TestTrashCuiPresenter_HintOutput(t *testing.T) {
 		assert.Contains(t, out, "山札から引き")
 	})
 
+	t.Run("await wild with no open slots falls back to game over", func(t *testing.T) {
+		slots := make([]domain.TrashSlot, domain.TrashSlotCnt)
+		for i := range slots {
+			slots[i] = domain.TrashSlot{Card: domain.NewCard(domain.CardDesignSpade, i+1, false), FaceUp: true}
+		}
+		tg := buildTrashMock(trashMockOpts{phase: domain.TrashPhaseAwaitWild, p0Slots: slots})
+		out := p.HintOutput(tg)
+		assert.Contains(t, out, "ゲームは終了")
+	})
+
+	t.Run("player turn draws when the discard's slot is already filled", func(t *testing.T) {
+		slots := make([]domain.TrashSlot, domain.TrashSlotCnt)
+		for i := range slots {
+			// Slot 5 (index 4) is already filled, so a drawn 5 has nowhere to go.
+			slots[i] = domain.TrashSlot{Card: domain.NewCard(domain.CardDesignSpade, i+1, false), FaceUp: i == 4}
+		}
+		tg := buildTrashMock(trashMockOpts{
+			phase:      domain.TrashPhasePlayerTurn,
+			discardTop: domain.NewCard(domain.CardDesignHeart, 5, false),
+			p0Slots:    slots,
+		})
+		out := p.HintOutput(tg)
+		assert.Contains(t, out, "山札から引き")
+	})
+
 	t.Run("game over reports the game is finished", func(t *testing.T) {
 		tg := buildTrashMock(trashMockOpts{phase: domain.TrashPhaseGameOver, winner: 1, winnerSet: true})
 		out := p.HintOutput(tg)

--- a/internal/adapter/presenter/TrashWebPresenter.go
+++ b/internal/adapter/presenter/TrashWebPresenter.go
@@ -52,6 +52,12 @@ func (p *TrashWebPresenter) ActionLogOutput(t interfaces.TrashGame) string {
 	return actionLogToJSON(t.GetActionLog())
 }
 
+// HintOutput ヒントを出力する。Web ではヒントはクライアント側 (useGameHint) で
+// 算出するため、通常の状態出力を返す。TrashPresenter インタフェースを満たすための実装。
+func (p *TrashWebPresenter) HintOutput(t interfaces.TrashGame) string {
+	return p.Output(t, nil)
+}
+
 // buildBase は共通フィールドを詰めたレスポンスオブジェクトを返す
 func (p *TrashWebPresenter) buildBase(t interfaces.TrashGame) *controller.TrashWebOutput {
 	resObj := new(controller.TrashWebOutput)

--- a/internal/adapter/presenter/TrashWebPresenter_test.go
+++ b/internal/adapter/presenter/TrashWebPresenter_test.go
@@ -184,3 +184,10 @@ func TestTrashWebPresenter_ActionLogOutput(t *testing.T) {
 		assert.Contains(t, result, "entries")
 	})
 }
+
+func TestTrashWebPresenter_HintOutput(t *testing.T) {
+	// Web hints are computed client-side, so HintOutput mirrors Output.
+	tg := buildTrashMock(trashMockOpts{})
+	p := new(TrashWebPresenter)
+	assert.Equal(t, p.Output(tg, nil), p.HintOutput(tg))
+}

--- a/internal/i18n/locales/en/trash.json
+++ b/internal/i18n/locales/en/trash.json
@@ -31,5 +31,6 @@
   "hintTakeDiscard": "The top discard fills slot {{slot}} -- worth taking.",
   "hintTakeDiscardWild": "The top discard is a wild -- take it and place it in any slot.",
   "hintDrawStock": "The discard is not useful. Draw from the stock.",
-  "hintGameOver": "The game is over."
+  "hintGameOver": "The game is over.",
+  "hintNotYourTurn": "It is not your turn right now."
 }

--- a/internal/i18n/locales/en/trash.json
+++ b/internal/i18n/locales/en/trash.json
@@ -25,5 +25,10 @@
   "pending": "Pending: {{card}}",
   "promptAwaitWild": "Place the wild (p <pos>)",
   "winHuman": "You win!",
-  "winCpu": "CPU wins"
+  "winCpu": "CPU wins",
+  "hintWild": "Wild placement options: {{slots}} (recommended: {{rec}})",
+  "hintTakeDiscard": "The top discard fills slot {{slot}} -- worth taking.",
+  "hintTakeDiscardWild": "The top discard is a wild -- take it and place it in any slot.",
+  "hintDrawStock": "The discard is not useful. Draw from the stock.",
+  "hintGameOver": "The game is over."
 }

--- a/internal/i18n/locales/en/trash.json
+++ b/internal/i18n/locales/en/trash.json
@@ -3,6 +3,7 @@
   "helpDraw": "  d, draw             Draw the top stock card",
   "helpPlace": "  p, place <pos>      Place the wild at position <pos> (e.g. p 7)",
   "helpCpu": "  cpu                 Advance the CPU's turn by one step",
+  "helpHint": "  h, hint             Show a placement hint",
   "helpLog": "  log, l              Show action log",
   "promptPosition": "Enter target position (1-10):",
   "playerTurn": "Your turn. Draw from the stock",

--- a/internal/i18n/locales/ja/trash.json
+++ b/internal/i18n/locales/ja/trash.json
@@ -31,5 +31,6 @@
   "hintTakeDiscard": "捨て札の一番上はスロット{{slot}}に入ります。取ると良いでしょう。",
   "hintTakeDiscardWild": "捨て札の一番上はワイルドです。取って好きなスロットに置けます。",
   "hintDrawStock": "捨て札は使えません。山札から引きましょう。",
-  "hintGameOver": "ゲームは終了しています。"
+  "hintGameOver": "ゲームは終了しています。",
+  "hintNotYourTurn": "今はあなたの番ではありません。"
 }

--- a/internal/i18n/locales/ja/trash.json
+++ b/internal/i18n/locales/ja/trash.json
@@ -25,5 +25,10 @@
   "pending": "ペンディング: {{card}}",
   "promptAwaitWild": "ワイルドを配置してください (p <位置>)",
   "winHuman": "あなたの勝ち！",
-  "winCpu": "CPUの勝ち"
+  "winCpu": "CPUの勝ち",
+  "hintWild": "ワイルドの配置候補: {{slots}}（推奨: {{rec}}）",
+  "hintTakeDiscard": "捨て札の一番上はスロット{{slot}}に入ります。取ると良いでしょう。",
+  "hintTakeDiscardWild": "捨て札の一番上はワイルドです。取って好きなスロットに置けます。",
+  "hintDrawStock": "捨て札は使えません。山札から引きましょう。",
+  "hintGameOver": "ゲームは終了しています。"
 }

--- a/internal/i18n/locales/ja/trash.json
+++ b/internal/i18n/locales/ja/trash.json
@@ -3,6 +3,7 @@
   "helpDraw": "  d, draw             山札から1枚引く",
   "helpPlace": "  p, place <pos>      ワイルドを位置 <pos> に配置 (例: p 7)",
   "helpCpu": "  cpu                 CPUのターンを1ステップ進める",
+  "helpHint": "  h, hint             配置候補などのヒントを表示",
   "helpLog": "  log, l              棋譜を表示",
   "promptPosition": "配置する位置 (1〜10) を入力してください:",
   "playerTurn": "あなたのターンです。山札から引いてください",

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -1174,6 +1174,7 @@ var gameRegistry = []GameRegistryEntry{
 					"trash.helpDraw",
 					"trash.helpPlace",
 					"trash.helpCpu",
+					"trash.helpHint",
 					"trash.helpLog",
 				},
 			})

--- a/internal/usecase/TrashInteractor.go
+++ b/internal/usecase/TrashInteractor.go
@@ -18,6 +18,8 @@ type TrashInteractorIF interface {
 	PlaceWild(pos int) string
 	// CpuStep CPUのターンを1ステップ進める
 	CpuStep() string
+	// Hint ヒント取得
+	Hint() string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
 }
@@ -52,6 +54,11 @@ func (ti *TrashInteractor) PlaceWild(pos int) string {
 // CpuStep CPUターンを1ステップ進める
 func (ti *TrashInteractor) CpuStep() string {
 	return execAndPresent(ti.Game, ti.tp, ti.Game.CpuStep)
+}
+
+// Hint ヒント取得
+func (ti *TrashInteractor) Hint() string {
+	return ti.tp.HintOutput(ti.Game)
 }
 
 // ActionLog 棋譜を出力する

--- a/internal/usecase/TrashInteractor_test.go
+++ b/internal/usecase/TrashInteractor_test.go
@@ -44,6 +44,17 @@ func TestTrashInteractorReset(t *testing.T) {
 	tg.AssertCalled(t, "Reset")
 }
 
+func TestTrashInteractorHint(t *testing.T) {
+	tg := newMockTrashGame()
+	tp := newMockTrashPresenter()
+	ti := NewTrashInteractor(tg, tp)
+
+	tp.On("HintOutput", tg).Return("hint_output")
+
+	assert.Equal(t, "hint_output", ti.Hint())
+	tp.AssertCalled(t, "HintOutput", tg)
+}
+
 func TestTrashInteractorDraw(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		tg := newMockTrashGame()

--- a/internal/usecase/presenter/TrashPresenter.go
+++ b/internal/usecase/presenter/TrashPresenter.go
@@ -5,4 +5,6 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 // TrashPresenter トラッシュプレゼンターインタフェース
 type TrashPresenter interface {
 	GamePresenter[interfaces.TrashGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(t interfaces.TrashGame) string
 }

--- a/internal/usecase/presenter/TrashPresenter_mock.go
+++ b/internal/usecase/presenter/TrashPresenter_mock.go
@@ -22,3 +22,8 @@ func (_m *MockTrashPresenter) ActionLogOutput(t interfaces.TrashGame) string {
 	ret := _m.Called(t)
 	return ret.String(0)
 }
+
+func (_m *MockTrashPresenter) HintOutput(t interfaces.TrashGame) string {
+	ret := _m.Called(t)
+	return ret.String(0)
+}


### PR DESCRIPTION
## Summary
- Add `HintOutput` to `TrashCuiPresenter`:
  - **AWAIT_WILD** phase: lists the open (face-down) slots as wild-placement candidates and recommends the highest one (keeps low ranks, which you're equally likely to draw, free to place themselves).
  - **Player turn**: advises taking the face-up discard when it fills a slot (or is a wild), otherwise drawing from the stock.
  - Game over: reports the game is finished.
- Wire the `hint`/`h` command end-to-end: add `HintOutput` to the `TrashPresenter` interface (both CUI and Web presenters implement it — the Web side delegates to `Output`, since web hints are computed client-side), add `TrashInteractor.Hint()` + IF method, register the command in `TrashCuiController`, and extend the presenter/interactor mocks.
- Add ja/en `hint*` translations to `internal/i18n/locales/{ja,en}/trash.json`.

## Test plan
- `TrashCuiPresenter_test.go` — HintOutput for await-wild (candidate list + recommendation), placeable discard, wild discard, useless discard (draw stock), and game over.
- `TrashCuiController_test.go` — `h`/`hint` routes to `Hint()`.
- `go test -tags test ./internal/...`, `golangci-lint`, server build, and the classic WASM worker build all pass.

Closes #3193