### PR TITLE
feat(cassino): add hint command to the CUI recommending take/build/trail

### DIFF
--- a/internal/adapter/controller/CassinoCuiController.go
+++ b/internal/adapter/controller/CassinoCuiController.go
@@ -88,7 +88,7 @@ func (c *CassinoCuiController) Exec(command string) string {
 		},
 		[]string{
 			"take", "t", "build", "b", "trail", "tr", "next", "n",
-			"sd", "setdifficulty", "sr", "setrule", "log", "l",
+			"h", "hint", "sd", "setdifficulty", "sr", "setrule", "log", "l",
 		},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
@@ -100,6 +100,8 @@ func (c *CassinoCuiController) Exec(command string) string {
 				return c.handleTrail(args)
 			case "n", "next":
 				return c.ci.NextRound(), true
+			case "h", "hint":
+				return c.ci.Hint(), true
 			case "sd", "setdifficulty":
 				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()

--- a/internal/adapter/controller/CassinoCuiController_test.go
+++ b/internal/adapter/controller/CassinoCuiController_test.go
@@ -22,6 +22,7 @@ func TestCassinoCuiController_Exec(t *testing.T) {
 		m.On("Take", mock.Anything, mock.Anything, mock.Anything).Return(mockOutput)
 		m.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(mockOutput)
 		m.On("Trail", mock.Anything).Return(mockOutput)
+		m.On("Hint").Return(mockOutput)
 		m.On("GetConfig").Return(domain.DefaultCassinoConfig())
 		m.On("ResetWithConfig", mock.Anything).Return(mockOutput)
 		m.On("ActionLog").Return("log")
@@ -45,6 +46,14 @@ func TestCassinoCuiController_Exec(t *testing.T) {
 		c := controller.NewCassinoCuiController(m)
 		assert.Equal(t, mockOutput, c.Exec("n"))
 		m.AssertCalled(t, "NextRound")
+	})
+
+	t.Run("hint command", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewCassinoCuiController(m)
+		assert.Equal(t, mockOutput, c.Exec("h"))
+		assert.Equal(t, mockOutput, c.Exec("hint"))
+		m.AssertCalled(t, "Hint")
 	})
 
 	t.Run("take command", func(t *testing.T) {

--- a/internal/adapter/controller/usecase/CassinoInteractor_mock.go
+++ b/internal/adapter/controller/usecase/CassinoInteractor_mock.go
@@ -38,6 +38,11 @@ func (_m *MockCassinoInteractor) Build(handIdx int, tableIdxs []int, declaredVal
 }
 
 // Trail モック
+func (_m *MockCassinoInteractor) Hint() string {
+	ret := _m.Called()
+	return ret.Get(0).(string)
+}
+
 func (_m *MockCassinoInteractor) Trail(handIdx int) string {
 	ret := _m.Called(handIdx)
 	return ret.Get(0).(string)

--- a/internal/adapter/presenter/CassinoCuiPresenter.go
+++ b/internal/adapter/presenter/CassinoCuiPresenter.go
@@ -132,6 +132,50 @@ func cassinoCardShort(c *domain.Card) string {
 	return cuiCardSliceStr([]*domain.Card{c})
 }
 
+// HintOutput recommends a take / build / trail for the human's turn, reusing
+// the shared domain suggestion logic.
+func (p *CassinoCuiPresenter) HintOutput(cg interfaces.CassinoGame) string {
+	if cg.GetPhase() != domain.CassinoPhasePlayerTurn || !cg.IsHumanTurn() {
+		return i18n.T("cassino.hintNotYourTurn") + "\n"
+	}
+	human := cg.GetPlayer(cg.GetCurrentTurn())
+	if human == nil {
+		return i18n.T("cassino.hintNotYourTurn") + "\n"
+	}
+	hand := make([]*domain.Card, human.GetCardsSize())
+	for i := range hand {
+		hand[i] = human.GetCard(i)
+	}
+	hint := domain.SuggestCassinoMove(hand, cg.GetTableCards(), cg.GetBuilds())
+	if hint == nil || hint.HandIdx < 0 || hint.HandIdx >= len(hand) {
+		return i18n.T("cassino.hintNoMove") + "\n"
+	}
+	card := cuiCardStr(hand[hint.HandIdx])
+	switch hint.Action {
+	case domain.CassinoHintTake:
+		return i18n.Tf("cassino.hintTake",
+			"card", card, "idxs", cassinoJoinIdxs(hint.TableIdxs)) + "\n"
+	case domain.CassinoHintBuild:
+		return i18n.Tf("cassino.hintBuild",
+			"card", card, "value", strconv.Itoa(hint.Value)) + "\n"
+	default:
+		return i18n.Tf("cassino.hintTrail", "card", card) + "\n"
+	}
+}
+
+// cassinoJoinIdxs renders 0-based table indices as a comma-separated string,
+// or a dash when the capture is builds-only.
+func cassinoJoinIdxs(idxs []int) string {
+	if len(idxs) == 0 {
+		return "-"
+	}
+	parts := make([]string, len(idxs))
+	for i, v := range idxs {
+		parts[i] = strconv.Itoa(v)
+	}
+	return strings.Join(parts, ", ")
+}
+
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CassinoCuiPresenter) ActionLogOutput(cg interfaces.CassinoGame) string {
 	return actionLogOutputText(cg)

--- a/internal/adapter/presenter/CassinoCuiPresenter_test.go
+++ b/internal/adapter/presenter/CassinoCuiPresenter_test.go
@@ -78,6 +78,58 @@ func TestCassinoCuiPresenter_Output(t *testing.T) {
 	})
 }
 
+func TestCassinoCuiPresenter_HintOutput(t *testing.T) {
+	p := new(presenter.CassinoCuiPresenter)
+
+	setup := func() *domain.Cassino {
+		players := makeCassinoPlayersForPresenter()
+		cg := domain.NewCassino(domain.NewTrumpCards(0), players, domain.DefaultCassinoConfig())
+		cg.SetPhase(domain.CassinoPhasePlayerTurn)
+		cg.SetCurrentTurn(0)
+		return cg
+	}
+
+	t.Run("recommends a take when the table can be captured", func(t *testing.T) {
+		cg := setup()
+		cg.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignHeart, 5, false))
+		cg.SetTableCards([]*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 2, false),
+			domain.NewCard(domain.CardDesignSpade, 3, false),
+		})
+		out := p.HintOutput(cg)
+		assert.Contains(t, out, "捕獲")
+	})
+
+	t.Run("recommends a build when a combined value is held", func(t *testing.T) {
+		cg := setup()
+		cg.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignHeart, 3, false))
+		cg.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignClover, 8, false))
+		cg.SetTableCards([]*domain.Card{domain.NewCard(domain.CardDesignSpade, 5, false)})
+		out := p.HintOutput(cg)
+		assert.Contains(t, out, "ビルド")
+	})
+
+	t.Run("recommends trailing when nothing can be captured or built", func(t *testing.T) {
+		cg := setup()
+		cg.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignHeart, 9, false))
+		cg.SetTableCards([]*domain.Card{domain.NewCard(domain.CardDesignSpade, 7, false)})
+		out := p.HintOutput(cg)
+		assert.Contains(t, out, "場に置く")
+	})
+
+	t.Run("declines when it is not the human's turn", func(t *testing.T) {
+		cg := setup()
+		cg.SetCurrentTurn(1)
+		assert.Contains(t, p.HintOutput(cg), "あなたの番ではありません")
+	})
+
+	t.Run("declines outside the play phase", func(t *testing.T) {
+		cg := setup()
+		cg.SetPhase(domain.CassinoPhaseRoundEnd)
+		assert.Contains(t, p.HintOutput(cg), "あなたの番ではありません")
+	})
+}
+
 func TestCassinoCuiPresenter_ActionLog(t *testing.T) {
 	p := new(presenter.CassinoCuiPresenter)
 	players := makeCassinoPlayersForPresenter()

--- a/internal/adapter/presenter/CassinoWebPresenter.go
+++ b/internal/adapter/presenter/CassinoWebPresenter.go
@@ -171,3 +171,10 @@ func (cwp *CassinoWebPresenter) buildResultMessage(cg interfaces.CassinoGame) st
 func (cwp *CassinoWebPresenter) ActionLogOutput(cg interfaces.CassinoGame) string {
 	return actionLogOutputJSON(cg)
 }
+
+// HintOutput ヒントを出力する。Web ではヒントはクライアント側 (useGameHint /
+// suggestCassinoAction) で算出するため、通常の状態出力を返す。CassinoPresenter
+// インタフェースを満たすための実装。
+func (cwp *CassinoWebPresenter) HintOutput(cg interfaces.CassinoGame) string {
+	return cwp.Output(cg, nil)
+}

--- a/internal/adapter/presenter/CassinoWebPresenter_test.go
+++ b/internal/adapter/presenter/CassinoWebPresenter_test.go
@@ -109,3 +109,11 @@ func TestCassinoWebPresenter_ActionLog(t *testing.T) {
 	out := p.ActionLogOutput(cg)
 	assert.NotEmpty(t, out)
 }
+
+func TestCassinoWebPresenter_HintOutput(t *testing.T) {
+	// Web hints are client-side, so HintOutput mirrors Output.
+	p := new(presenter.CassinoWebPresenter)
+	players := makeCassinoPlayersForPresenter()
+	cg := domain.NewCassino(domain.NewTrumpCards(0), players, domain.DefaultCassinoConfig())
+	assert.Equal(t, p.Output(cg, nil), p.HintOutput(cg))
+}

--- a/internal/domain/CassinoSuggest.go
+++ b/internal/domain/CassinoSuggest.go
@@ -1,0 +1,142 @@
+package domain
+
+// CassinoHintAction はヒントが推奨する行動種別。
+type CassinoHintAction int
+
+const (
+	// CassinoHintTrail 捕獲できないので場に置く。
+	CassinoHintTrail CassinoHintAction = iota
+	// CassinoHintTake 場札 / ビルドを捕獲する。
+	CassinoHintTake
+	// CassinoHintBuild ビルドを作る。
+	CassinoHintBuild
+)
+
+// CassinoHint は CUI 向けの推奨手。
+type CassinoHint struct {
+	Action    CassinoHintAction
+	HandIdx   int   // 出す手札のインデックス
+	TableIdxs []int // take: 捕獲する場札 (loose card) のインデックス
+	BuildIdxs []int // take: 捕獲するビルドのインデックス
+	Value     int   // take: 捕獲値 / build: 宣言値
+}
+
+// SuggestCassinoMove は手札・場札・ビルドから推奨手を返す。
+// 優先度は「捕獲枚数が最大の take > build > trail」。take で示す場札の部分集合は
+// 必ず手札の値ちょうどに合計するため、常に合法な捕獲となる (最適とは限らない)。
+// hand が空なら nil を返す。
+func SuggestCassinoMove(hand, table []*Card, builds []*CassinoBuild) *CassinoHint {
+	if len(hand) == 0 {
+		return nil
+	}
+
+	var best *CassinoHint
+	bestCaptured := 0
+	for hi, hc := range hand {
+		if hc == nil {
+			continue
+		}
+		tableIdxs, buildIdxs, captured := cassinoBestCaptureFor(hc, table, builds)
+		if captured > 0 && captured > bestCaptured {
+			bestCaptured = captured
+			best = &CassinoHint{
+				Action:    CassinoHintTake,
+				HandIdx:   hi,
+				TableIdxs: tableIdxs,
+				BuildIdxs: buildIdxs,
+				Value:     CassinoCardValue(hc),
+			}
+		}
+	}
+	if best != nil {
+		return best
+	}
+
+	if b := cassinoBestBuild(hand, table); b != nil {
+		return b
+	}
+
+	return &CassinoHint{Action: CassinoHintTrail, HandIdx: cassinoLowestHandIdx(hand)}
+}
+
+// cassinoBestCaptureFor は 1 枚の手札で捕獲できる場札 / ビルドと捕獲枚数を返す。
+func cassinoBestCaptureFor(hc *Card, table []*Card, builds []*CassinoBuild) (tableIdxs, buildIdxs []int, captured int) {
+	if CassinoIsFaceCard(hc) {
+		// 絵札は同ランクの場札のみ捕獲。ビルドは数値なので対象外。
+		idxs := findFaceRankMatches(table, hc.GetValue())
+		return idxs, nil, len(idxs)
+	}
+
+	v := CassinoCardValue(hc)
+	// 最も多く捕獲できる loose card の部分集合を選ぶ。
+	var bestSub []int
+	for _, s := range findSubsetsSummingTo(table, v) {
+		if len(s) > len(bestSub) {
+			bestSub = s
+		}
+	}
+	// 宣言値が一致するビルドも同時に捕獲できる。
+	var bidxs []int
+	buildCap := 0
+	for bi, b := range builds {
+		if b != nil && b.Value == v {
+			bidxs = append(bidxs, bi)
+			buildCap += len(b.AllCards())
+		}
+	}
+	return bestSub, bidxs, len(bestSub) + buildCap
+}
+
+// cassinoBestBuild は手札の数札を loose card と組み合わせてビルドを作れるかを探す。
+// 合成値 target を宣言するには target と同値の手札をもう 1 枚持っている必要がある。
+func cassinoBestBuild(hand, table []*Card) *CassinoHint {
+	for hi, hc := range hand {
+		if hc == nil || CassinoIsFaceCard(hc) {
+			continue
+		}
+		v := CassinoCardValue(hc)
+		for target := v + 1; target <= 10; target++ {
+			subs := findSubsetsSummingTo(table, target-v)
+			if len(subs) == 0 {
+				continue
+			}
+			if cassinoHandHasValueExcept(hand, target, hi) {
+				return &CassinoHint{Action: CassinoHintBuild, HandIdx: hi, TableIdxs: subs[0], Value: target}
+			}
+		}
+	}
+	return nil
+}
+
+// cassinoHandHasValueExcept は except 以外の手札に値 v の数札があるかを返す。
+func cassinoHandHasValueExcept(hand []*Card, v, except int) bool {
+	for i, c := range hand {
+		if i == except || c == nil || CassinoIsFaceCard(c) {
+			continue
+		}
+		if CassinoCardValue(c) == v {
+			return true
+		}
+	}
+	return false
+}
+
+// cassinoLowestHandIdx は最も値の小さい手札のインデックスを返す (trail 用)。
+func cassinoLowestHandIdx(hand []*Card) int {
+	best := -1
+	bestVal := 1 << 30
+	for i, c := range hand {
+		if c == nil {
+			continue
+		}
+		v := c.GetValue()
+		if v < bestVal {
+			bestVal = v
+			best = i
+		}
+	}
+	if best < 0 {
+		return 0
+	}
+	return best
+}

--- a/internal/domain/CassinoSuggest_test.go
+++ b/internal/domain/CassinoSuggest_test.go
@@ -1,0 +1,67 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func cassinoCard(v int) *Card { return NewCard(CardDesignSpade, v, false) }
+
+func TestSuggestCassinoMove(t *testing.T) {
+	t.Run("nil for an empty hand", func(t *testing.T) {
+		assert.Nil(t, SuggestCassinoMove(nil, []*Card{cassinoCard(3)}, nil))
+	})
+
+	t.Run("takes a loose-card sum capture", func(t *testing.T) {
+		hand := []*Card{cassinoCard(5)}
+		table := []*Card{cassinoCard(2), cassinoCard(3), cassinoCard(9)}
+		h := SuggestCassinoMove(hand, table, nil)
+		assert.Equal(t, CassinoHintTake, h.Action)
+		assert.Equal(t, 0, h.HandIdx)
+		assert.ElementsMatch(t, []int{0, 1}, h.TableIdxs) // 2 + 3 = 5
+	})
+
+	t.Run("prefers the capture that takes the most cards", func(t *testing.T) {
+		// 6 can take {6} (1 card) or {2,4} (2 cards) — prefer the latter.
+		hand := []*Card{cassinoCard(6)}
+		table := []*Card{cassinoCard(6), cassinoCard(2), cassinoCard(4)}
+		h := SuggestCassinoMove(hand, table, nil)
+		assert.Equal(t, CassinoHintTake, h.Action)
+		assert.Len(t, h.TableIdxs, 2)
+	})
+
+	t.Run("takes matching face cards by rank", func(t *testing.T) {
+		hand := []*Card{NewCard(CardDesignHeart, 13, false)} // King
+		table := []*Card{NewCard(CardDesignSpade, 13, false), cassinoCard(4)}
+		h := SuggestCassinoMove(hand, table, nil)
+		assert.Equal(t, CassinoHintTake, h.Action)
+		assert.Equal(t, []int{0}, h.TableIdxs)
+	})
+
+	t.Run("takes a build whose declared value matches the hand card", func(t *testing.T) {
+		hand := []*Card{cassinoCard(8)}
+		builds := []*CassinoBuild{NewCassinoBuild(1, 8, []*Card{cassinoCard(5), cassinoCard(3)})}
+		h := SuggestCassinoMove(hand, nil, builds)
+		assert.Equal(t, CassinoHintTake, h.Action)
+		assert.Equal(t, []int{0}, h.BuildIdxs)
+	})
+
+	t.Run("builds when a combined value is held in hand", func(t *testing.T) {
+		// Play 3 onto a table 5 to declare an 8, holding the other 8.
+		hand := []*Card{cassinoCard(3), cassinoCard(8)}
+		table := []*Card{cassinoCard(5)}
+		h := SuggestCassinoMove(hand, table, nil)
+		assert.Equal(t, CassinoHintBuild, h.Action)
+		assert.Equal(t, 0, h.HandIdx)
+		assert.Equal(t, 8, h.Value)
+	})
+
+	t.Run("trails the lowest card when nothing can be captured or built", func(t *testing.T) {
+		hand := []*Card{cassinoCard(9), cassinoCard(4)}
+		table := []*Card{cassinoCard(7)}
+		h := SuggestCassinoMove(hand, table, nil)
+		assert.Equal(t, CassinoHintTrail, h.Action)
+		assert.Equal(t, 1, h.HandIdx) // the 4 is lower than the 9
+	})
+}

--- a/internal/i18n/locales/en/cassino.json
+++ b/internal/i18n/locales/en/cassino.json
@@ -4,6 +4,7 @@
   "helpBuild": "  b <h> <value> <t...>     build declared value from hand h + table cards",
   "helpTrail": "  tr <h>                   trail hand card h (no capture)",
   "helpNext": "  n                        start next round",
+  "helpHint": "  h | hint                 show a recommended move (take/build/trail)",
   "helpLog": "  log | l                  show action log",
   "helpSetDifficulty": "  sd [0-2]                 CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
   "helpSetRule": "  sr <rule> <0|1>          toggle local rule (sr list to show all)",
@@ -22,5 +23,10 @@
   "actionTake": "take played={{played}} captured={{count}}{{suffix}}",
   "actionTakeSweepSuffix": " (sweep!)",
   "actionBuild": "build value {{value}} (played={{played}})",
-  "actionTrail": "trail {{played}}"
+  "actionTrail": "trail {{played}}",
+  "hintTake": "Suggestion: play {{card}} to capture table cards [{{idxs}}] (take)",
+  "hintBuild": "Suggestion: play {{card}} to make a build of {{value}} (build)",
+  "hintTrail": "Suggestion: trail {{card}} (trail)",
+  "hintNotYourTurn": "It is not your turn right now.",
+  "hintNoMove": "No move can be recommended."
 }

--- a/internal/i18n/locales/ja/cassino.json
+++ b/internal/i18n/locales/ja/cassino.json
@@ -4,6 +4,7 @@
   "helpBuild": "  b <h> <value> <t...>     手札hと場札でビルドを作成",
   "helpTrail": "  tr <h>                   手札hを場に置く (捕獲しない)",
   "helpNext": "  n                        次のラウンドを開始する",
+  "helpHint": "  h | hint                 推奨手 (テイク/ビルド/トレイル) を表示",
   "helpLog": "  log | l                  棋譜を表示",
   "helpSetDifficulty": "  sd [0-2]                 CPU難易度 (0=Easy, 1=Normal, 2=Hard)",
   "helpSetRule": "  sr <rule> <0|1>          ルール切替 (sr list で一覧表示)",
@@ -22,5 +23,10 @@
   "actionTake": "捕獲 played={{played}} captured={{count}}枚{{suffix}}",
   "actionTakeSweepSuffix": " (スイープ!)",
   "actionBuild": "ビルド値{{value}} (played={{played}})",
-  "actionTrail": "場に置く {{played}}"
+  "actionTrail": "場に置く {{played}}",
+  "hintTake": "推奨: 手札 {{card}} で場札 [{{idxs}}] を捕獲 (take)",
+  "hintBuild": "推奨: 手札 {{card}} でビルド値 {{value}} を作成 (build)",
+  "hintTrail": "推奨: 手札 {{card}} を場に置く (trail)",
+  "hintNotYourTurn": "今はあなたの番ではありません。",
+  "hintNoMove": "推奨できる手がありません。"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -1225,6 +1225,7 @@ var gameRegistry = []GameRegistryEntry{
 					"cassino.helpBuild",
 					"cassino.helpTrail",
 					"cassino.helpNext",
+					"cassino.helpHint",
 					"cassino.helpLog",
 				},
 				SettingKeys: []string{

--- a/internal/usecase/CassinoInteractor.go
+++ b/internal/usecase/CassinoInteractor.go
@@ -20,6 +20,8 @@ type CassinoInteractorIF interface {
 	Build(handIdx int, tableIdxs []int, declaredValue int) string
 	// Trail 場に置くだけ (捕獲しない)
 	Trail(handIdx int) string
+	// Hint ヒント取得
+	Hint() string
 	// ResetWithConfig 設定を変更してゲームを初期化
 	ResetWithConfig(config domain.CassinoConfig) string
 	// GetConfig 現在の設定を返す
@@ -94,6 +96,11 @@ func (ci *CassinoInteractor) Trail(handIdx int) string {
 		ci.runCpuTurns()
 	}
 	return ci.cp.Output(ci.Game, err)
+}
+
+// Hint ヒント取得。
+func (ci *CassinoInteractor) Hint() string {
+	return ci.cp.HintOutput(ci.Game)
 }
 
 // GetConfig 現在の設定を返す。

--- a/internal/usecase/CassinoInteractor_test.go
+++ b/internal/usecase/CassinoInteractor_test.go
@@ -40,6 +40,11 @@ func TestCassinoInteractor_Methods(t *testing.T) {
 		assert.Equal(t, mockOutput, ci.Reset())
 	})
 
+	t.Run("Hint delegates to the presenter", func(t *testing.T) {
+		ppMock.On("HintOutput", mock.Anything).Return("hint_output")
+		assert.Equal(t, "hint_output", ci.Hint())
+	})
+
 	t.Run("Take with nothing returns error output", func(t *testing.T) {
 		// After Reset the player has 4 cards. A legal take depends on the deal.
 		// Without knowing specific cards, just assert output string type.

--- a/internal/usecase/presenter/CassinoPresenter.go
+++ b/internal/usecase/presenter/CassinoPresenter.go
@@ -3,4 +3,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // CassinoPresenter カシノプレゼンターインタフェース。
-type CassinoPresenter = GamePresenter[interfaces.CassinoGame]
+type CassinoPresenter interface {
+	GamePresenter[interfaces.CassinoGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(cg interfaces.CassinoGame) string
+}

--- a/internal/usecase/presenter/CassinoPresenter_mock.go
+++ b/internal/usecase/presenter/CassinoPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockCassinoPresenter カシノプレゼンターモック。
-type MockCassinoPresenter = MockGamePresenter[interfaces.CassinoGame]
+type MockCassinoPresenter struct {
+	MockGamePresenter[interfaces.CassinoGame]
+}
+
+// HintOutput モック
+func (_m *MockCassinoPresenter) HintOutput(cg interfaces.CassinoGame) string {
+	ret := _m.Called(cg)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## Summary
- Add a shared domain helper `SuggestCassinoMove` (in `internal/domain/CassinoSuggest.go`) that reuses the existing subset-sum / face-match primitives in `CassinoEval` to recommend, in priority order:
  1. the **take** that captures the most cards (loose-card subset summing to the hand card + any matching builds),
  2. else a valid **build** (combine a hand card with loose cards to a value held elsewhere in hand),
  3. else **trail** the lowest card.
  Every recommended take genuinely sums to the played card's value, so the advice is always a legal move.
- `CassinoCuiPresenter.HintOutput` formats the suggestion (showing target table indices on a take) and is gated to the human's play turn.
- Wire `h`/`hint` end-to-end: promote `CassinoPresenter` from a `GamePresenter` alias to an interface with `HintOutput` (both CUI and Web presenters implement it — Web delegates to `Output` since web hints are computed client-side by `suggestCassinoAction`/`useGameHint`), add `CassinoInteractor.Hint()` + IF method, register the command in `CassinoCuiController` and the CUI help spec, and extend the mocks.
- Add ja/en `hint*` + `helpHint` translations.

The web-side `frontend/src/utils/cassinoUtils.ts` selection-validator is unchanged; per the proposal the reusable logic now lives in the Go domain layer.

## Test plan
- `CassinoSuggest_test.go` — take (sum + most-cards preference), face take, build-match take, build, trail.
- `CassinoCuiPresenter_test.go` — take/build/trail formatting, not-your-turn and wrong-phase guards.
- `CassinoCuiController_test.go` — `h`/`hint` routes to `Hint()`; `CassinoInteractor_test.go` — `Hint()` delegates; `CassinoWebPresenter_test.go` — `HintOutput` mirrors `Output`.
- `go test -tags test ./internal/...`, `golangci-lint`, server build, and the classic WASM worker build all pass.

Closes #3203