### PR TITLE
feat(president): add hint command to the CUI recommending the weakest play

### DIFF
--- a/internal/adapter/controller/PresidentCuiController.go
+++ b/internal/adapter/controller/PresidentCuiController.go
@@ -84,13 +84,15 @@ func (c *PresidentCuiController) Exec(command string) string {
 			return c.pi.ResetWithConfig(cfg)
 		},
 		[]string{
-			"p", "play", "sd", "setdifficulty", "sr", "setrule", "log", "l",
+			"p", "play", "h", "hint", "sd", "setdifficulty", "sr", "setrule", "log", "l",
 		},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
 				indices, skipped := cuiutil.ParseIntSlice(args)
 				return cuiutil.PrependSkippedWarning(c.pi.Play(indices), skipped), true
+			case "h", "hint":
+				return c.pi.Hint(), true
 			case "sd", "setdifficulty":
 				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
 					cfg := c.pi.GetConfig()

--- a/internal/adapter/controller/PresidentCuiController_test.go
+++ b/internal/adapter/controller/PresidentCuiController_test.go
@@ -18,6 +18,7 @@ func TestPresidentCuiController_Exec(t *testing.T) {
 		m := new(mockUsecases.MockPresidentInteractor)
 		m.On("Reset").Return(mockOutput)
 		m.On("Play", mock.Anything).Return(mockOutput)
+		m.On("Hint").Return(mockOutput)
 		m.On("GetConfig").Return(domain.DefaultPresidentConfig())
 		m.On("ResetWithConfig", mock.Anything).Return(mockOutput)
 		return m
@@ -35,6 +36,14 @@ func TestPresidentCuiController_Exec(t *testing.T) {
 		assert.Equal(t, mockOutput, c.Exec("r"))
 		m.AssertCalled(t, "GetConfig")
 		m.AssertCalled(t, "ResetWithConfig", mock.Anything)
+	})
+
+	t.Run("hint command", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewPresidentCuiController(m)
+		assert.Equal(t, mockOutput, c.Exec("h"))
+		assert.Equal(t, mockOutput, c.Exec("hint"))
+		m.AssertCalled(t, "Hint")
 	})
 
 	t.Run("play command variants", func(t *testing.T) {

--- a/internal/adapter/controller/usecase/PresidentInteractor_mock.go
+++ b/internal/adapter/controller/usecase/PresidentInteractor_mock.go
@@ -25,6 +25,11 @@ func (_m *MockPresidentInteractor) Play(indices []int) string {
 	return ret.Get(0).(string)
 }
 
+func (_m *MockPresidentInteractor) Hint() string {
+	ret := _m.Called()
+	return ret.Get(0).(string)
+}
+
 // GetConfig モック
 func (_m *MockPresidentInteractor) GetConfig() domain.PresidentConfig {
 	ret := _m.Called()

--- a/internal/adapter/presenter/PresidentCuiPresenter.go
+++ b/internal/adapter/presenter/PresidentCuiPresenter.go
@@ -111,6 +111,32 @@ func (p *PresidentCuiPresenter) Output(pg interfaces.PresidentGame, lastErr erro
 	})
 }
 
+// HintOutput recommends the weakest legal play for the human's turn, or a pass
+// when no legal play exists, reusing the shared domain suggestion logic.
+func (p *PresidentCuiPresenter) HintOutput(pg interfaces.PresidentGame) string {
+	if pg.GetGameEndFlag() || !pg.IsHumanTurn() {
+		return i18n.T("president.hintNotYourTurn") + "\n"
+	}
+	idx := pg.GetCurrentTurn()
+	human := pg.GetPlayer(idx)
+	if human == nil {
+		return i18n.T("president.hintNotYourTurn") + "\n"
+	}
+	play := pg.SuggestWeakestPlay(idx)
+	if len(play) == 0 {
+		return i18n.T("president.hintPass") + "\n"
+	}
+	idxParts := make([]string, len(play))
+	cardParts := make([]string, len(play))
+	for i, hi := range play {
+		idxParts[i] = strconv.Itoa(hi)
+		cardParts[i] = cuiCardStr(human.GetCard(hi))
+	}
+	return i18n.Tf("president.hintPlay",
+		"idxs", strings.Join(idxParts, ", "),
+		"cards", strings.Join(cardParts, ",")) + "\n"
+}
+
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *PresidentCuiPresenter) ActionLogOutput(pg interfaces.PresidentGame) string {
 	return actionLogOutputText(pg)

--- a/internal/adapter/presenter/PresidentCuiPresenter_test.go
+++ b/internal/adapter/presenter/PresidentCuiPresenter_test.go
@@ -170,6 +170,47 @@ func TestPresidentCuiPresenter_Output(t *testing.T) {
 	})
 }
 
+func TestPresidentCuiPresenter_HintOutput(t *testing.T) {
+	p := new(presenter.PresidentCuiPresenter)
+
+	t.Run("recommends the weakest legal play", func(t *testing.T) {
+		players := makePresidentPlayersForPresenter()
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 3, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 7, false))
+		m := new(interfaces.MockPresidentGame)
+		m.On("GetGameEndFlag").Return(false)
+		m.On("IsHumanTurn").Return(true)
+		m.On("GetCurrentTurn").Return(0)
+		m.On("GetPlayer", 0).Return(players[0])
+		m.On("SuggestWeakestPlay", 0).Return([]int{0})
+		assert.Contains(t, p.HintOutput(m), "を出す")
+	})
+
+	t.Run("recommends passing when no legal play exists", func(t *testing.T) {
+		m := new(interfaces.MockPresidentGame)
+		m.On("GetGameEndFlag").Return(false)
+		m.On("IsHumanTurn").Return(true)
+		m.On("GetCurrentTurn").Return(0)
+		m.On("GetPlayer", 0).Return(makePresidentPlayersForPresenter()[0])
+		m.On("SuggestWeakestPlay", 0).Return(([]int)(nil))
+		assert.Contains(t, p.HintOutput(m), "パス")
+	})
+
+	t.Run("declines when it is not the human's turn", func(t *testing.T) {
+		m := new(interfaces.MockPresidentGame)
+		m.On("GetGameEndFlag").Return(false)
+		m.On("IsHumanTurn").Return(false)
+		assert.Contains(t, p.HintOutput(m), "あなたの番ではありません")
+	})
+
+	t.Run("declines when the game is over", func(t *testing.T) {
+		m := new(interfaces.MockPresidentGame)
+		m.On("GetGameEndFlag").Return(true)
+		m.On("IsHumanTurn").Return(true)
+		assert.Contains(t, p.HintOutput(m), "あなたの番ではありません")
+	})
+}
+
 func TestPresidentCuiPresenter_ActionLogOutput(t *testing.T) {
 	p := new(presenter.PresidentCuiPresenter)
 	players := makePresidentPlayersForPresenter()

--- a/internal/adapter/presenter/PresidentWebPresenter.go
+++ b/internal/adapter/presenter/PresidentWebPresenter.go
@@ -113,3 +113,9 @@ func (pwp *PresidentWebPresenter) buildResultMessage(pg interfaces.PresidentGame
 func (pwp *PresidentWebPresenter) ActionLogOutput(pg interfaces.PresidentGame) string {
 	return actionLogOutputJSON(pg)
 }
+
+// HintOutput ヒントを出力する。Web ではヒントはクライアント側 (useGameHint) で
+// 算出するため、通常の状態出力を返す。PresidentPresenter インタフェースを満たすための実装。
+func (pwp *PresidentWebPresenter) HintOutput(pg interfaces.PresidentGame) string {
+	return pwp.Output(pg, nil)
+}

--- a/internal/adapter/presenter/PresidentWebPresenter_test.go
+++ b/internal/adapter/presenter/PresidentWebPresenter_test.go
@@ -48,3 +48,11 @@ func TestPresidentWebPresenter_ActionLog(t *testing.T) {
 	out := p.ActionLogOutput(pg)
 	assert.NotEmpty(t, out)
 }
+
+func TestPresidentWebPresenter_HintOutput(t *testing.T) {
+	// Web hints are client-side, so HintOutput mirrors Output.
+	p := new(presenter.PresidentWebPresenter)
+	players := makePresidentPlayersForPresenter()
+	pg := domain.NewPresident(domain.NewTrumpCards(0), players, domain.DefaultPresidentConfig())
+	assert.Equal(t, p.Output(pg, nil), p.HintOutput(pg))
+}

--- a/internal/domain/PresidentCPU.go
+++ b/internal/domain/PresidentCPU.go
@@ -21,6 +21,16 @@ func (p *President) findBestPlay(player *PresidentPlayer) []int {
 	}
 }
 
+// SuggestWeakestPlay は playerIdx の最弱の合法手 (手札インデックス) を返す。
+// 合法手が無い (=パスすべき) 場合は nil を返す。CUI ヒント用に findWeakestLegalPlay
+// を公開する薄いラッパー。
+func (p *President) SuggestWeakestPlay(playerIdx int) []int {
+	if playerIdx < 0 || playerIdx >= len(p.players) {
+		return nil
+	}
+	return p.findWeakestLegalPlay(p.players[playerIdx])
+}
+
 // findWeakestLegalPlay 最弱の合法手を返す (Easy)
 func (p *President) findWeakestLegalPlay(player *PresidentPlayer) []int {
 	candidates := p.enumeratePlays(player)

--- a/internal/domain/PresidentSuggest_test.go
+++ b/internal/domain/PresidentSuggest_test.go
@@ -1,0 +1,27 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPresident_SuggestWeakestPlay(t *testing.T) {
+	p := NewDefaultPresident()
+	p.Reset()
+
+	t.Run("returns nil for an out-of-range player index", func(t *testing.T) {
+		assert.Nil(t, p.SuggestWeakestPlay(-1))
+		assert.Nil(t, p.SuggestWeakestPlay(999))
+	})
+
+	t.Run("delegates to findWeakestLegalPlay for a valid index", func(t *testing.T) {
+		// A freshly dealt player on an open field always has at least one legal
+		// single-card play, so the suggestion is non-empty and in range.
+		play := p.SuggestWeakestPlay(0)
+		for _, idx := range play {
+			assert.GreaterOrEqual(t, idx, 0)
+			assert.Less(t, idx, p.GetPlayer(0).GetCardsSize())
+		}
+	})
+}

--- a/internal/domain/interfaces/president.go
+++ b/internal/domain/interfaces/president.go
@@ -13,6 +13,8 @@ type PresidentGame interface {
 	IsHumanTurn() bool
 	// PlayerPlay プレイヤーがカードを出す
 	PlayerPlay(indices []int) error
+	// SuggestWeakestPlay playerIdx の最弱の合法手 (手札インデックス) を返す。合法手が無ければ nil
+	SuggestWeakestPlay(playerIdx int) []int
 	// CpuPlay CPUプレイヤーが1ターン実行する
 	CpuPlay()
 	// SetConfig ゲーム設定をセットする

--- a/internal/domain/interfaces/president_mock.go
+++ b/internal/domain/interfaces/president_mock.go
@@ -36,6 +36,15 @@ func (_m *MockPresidentGame) PlayerPlay(indices []int) error {
 	return ret.Error(0)
 }
 
+// SuggestWeakestPlay モック
+func (_m *MockPresidentGame) SuggestWeakestPlay(playerIdx int) []int {
+	ret := _m.Called(playerIdx)
+	if v := ret.Get(0); v != nil {
+		return v.([]int)
+	}
+	return nil
+}
+
 // CpuPlay モック
 func (_m *MockPresidentGame) CpuPlay() {
 	_m.Called()

--- a/internal/i18n/locales/en/president.json
+++ b/internal/i18n/locales/en/president.json
@@ -2,6 +2,7 @@
   "helpTitle": "President / Scum",
   "helpPlay": "  p [idx ...]          play cards (no index = pass)",
   "helpPass": "  p                    pass",
+  "helpHint": "  h | hint             suggest the weakest legal play",
   "helpLog": "  log | l              show action log",
   "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
   "helpSetRule": "  sr <rule> <0|1>      toggle local rule (sr list to show all)",
@@ -24,5 +25,8 @@
   "rankVicePresident": "Vice-President",
   "rankViceScum": "Vice-Scum",
   "rankScum": "Scum",
-  "rankUnknown": "unknown"
+  "rankUnknown": "unknown",
+  "hintPlay": "Suggestion: play hand [{{idxs}}] ({{cards}})",
+  "hintPass": "Suggestion: no legal play — pass (p).",
+  "hintNotYourTurn": "It is not your turn right now."
 }

--- a/internal/i18n/locales/ja/president.json
+++ b/internal/i18n/locales/ja/president.json
@@ -2,6 +2,7 @@
   "helpTitle": "President (プレジデント)",
   "helpPlay": "  p [idx ...]          カードを出す (インデックスなし=パス)",
   "helpPass": "  p                    パス",
+  "helpHint": "  h | hint             最弱の合法手を推奨",
   "helpLog": "  log | l              棋譜を表示",
   "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)",
   "helpSetRule": "  sr <rule> <0|1>      ルール切替 (sr list で一覧表示)",
@@ -24,5 +25,8 @@
   "rankVicePresident": "副大統領",
   "rankViceScum": "副スカム",
   "rankScum": "スカム",
-  "rankUnknown": "不明"
+  "rankUnknown": "不明",
+  "hintPlay": "推奨: 手札 [{{idxs}}] ({{cards}}) を出す",
+  "hintPass": "推奨: 出せる手がないのでパス (p) しましょう。",
+  "hintNotYourTurn": "今はあなたの番ではありません。"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -1206,6 +1206,7 @@ var gameRegistry = []GameRegistryEntry{
 				CommandKeys: []string{
 					"president.helpPlay",
 					"president.helpPass",
+					"president.helpHint",
 					"president.helpLog",
 				},
 				SettingKeys: []string{

--- a/internal/usecase/PresidentInteractor.go
+++ b/internal/usecase/PresidentInteractor.go
@@ -14,6 +14,8 @@ type PresidentInteractorIF interface {
 	Reset() string
 	// Play 人間プレイヤーがカードを出す (または パスする)
 	Play(indices []int) string
+	// Hint ヒント取得
+	Hint() string
 	// ResetWithConfig 設定を変更してゲームを初期化
 	ResetWithConfig(config domain.PresidentConfig) string
 	// GetConfig 現在の設定を返す
@@ -54,6 +56,11 @@ func (pi *PresidentInteractor) Play(indices []int) string {
 		pi.runCpuTurns()
 	}
 	return pi.pp.Output(pi.Game, err)
+}
+
+// Hint ヒント取得
+func (pi *PresidentInteractor) Hint() string {
+	return pi.pp.HintOutput(pi.Game)
 }
 
 // GetConfig 現在の設定を返す

--- a/internal/usecase/PresidentInteractor_test.go
+++ b/internal/usecase/PresidentInteractor_test.go
@@ -40,6 +40,11 @@ func TestPresidentInteractor_Method(t *testing.T) {
 		assert.Equal(t, mockOutput, pi.Reset())
 	})
 
+	t.Run("Hint delegates to the presenter", func(t *testing.T) {
+		ppMock.On("HintOutput", mock.Anything).Return("hint_output")
+		assert.Equal(t, "hint_output", pi.Hint())
+	})
+
 	t.Run("Play pass", func(t *testing.T) {
 		assert.Equal(t, mockOutput, pi.Play([]int{}))
 	})

--- a/internal/usecase/presenter/PresidentPresenter.go
+++ b/internal/usecase/presenter/PresidentPresenter.go
@@ -3,4 +3,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // PresidentPresenter プレジデントプレゼンターインタフェース
-type PresidentPresenter = GamePresenter[interfaces.PresidentGame]
+type PresidentPresenter interface {
+	GamePresenter[interfaces.PresidentGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(pg interfaces.PresidentGame) string
+}

--- a/internal/usecase/presenter/PresidentPresenter_mock.go
+++ b/internal/usecase/presenter/PresidentPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockPresidentPresenter プレジデントプレゼンターモック
-type MockPresidentPresenter = MockGamePresenter[interfaces.PresidentGame]
+type MockPresidentPresenter struct {
+	MockGamePresenter[interfaces.PresidentGame]
+}
+
+// HintOutput モック
+func (_m *MockPresidentPresenter) HintOutput(pg interfaces.PresidentGame) string {
+	ret := _m.Called(pg)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## Summary
- Expose the game's existing `findWeakestLegalPlay` as a public domain method `SuggestWeakestPlay(playerIdx)` on the `PresidentGame` interface.
- `PresidentCuiPresenter.HintOutput` recommends the weakest legal play (showing the hand indices + cards) for the human's turn, or a **pass** when no legal play exists.
- Wire `h`/`hint` end-to-end: promote `PresidentPresenter` from a `GamePresenter` alias to an interface with `HintOutput` (both CUI and Web presenters implement it — Web delegates to `Output` since web hints are computed client-side), add `PresidentInteractor.Hint()` + IF method, register the command in `PresidentCuiController` and the CUI help spec, and extend the game/presenter/interactor mocks.
- Add ja/en `hint*` + `helpHint` translations.

## Test plan
- `PresidentSuggest_test.go` — out-of-range index → nil, valid delegation stays in range.
- `PresidentCuiPresenter_test.go` — weakest-play recommendation, pass recommendation, not-your-turn and game-over guards.
- `PresidentCuiController_test.go` — `h`/`hint` routes to `Hint()`; `PresidentInteractor_test.go` — `Hint()` delegates; `PresidentWebPresenter_test.go` — `HintOutput` mirrors `Output`.
- `go test -tags test ./internal/...`, `golangci-lint`, server build, and the classic WASM worker build all pass.

Closes #3199