### PR TITLE
feat(sevenbridge): add hint command to the CUI suggesting a meld or discard

### DIFF
--- a/internal/adapter/controller/SevenBridgeCuiController.go
+++ b/internal/adapter/controller/SevenBridgeCuiController.go
@@ -35,6 +35,7 @@ func (c *SevenBridgeCuiController) Exec(command string) string {
 			"lo", "layoff",
 			"d", "discard",
 			"nr", "nextround",
+			"h", "hint",
 			"sd", "setdifficulty", "sl", "setlimit", "log", "l",
 		},
 		func(cmd string, args []string) (string, bool) {
@@ -57,6 +58,8 @@ func (c *SevenBridgeCuiController) Exec(command string) string {
 				return cuiutil.WithParsedInt(args, "Card index is required.", "Invalid card index: %s.", cuiutil.NoMin, cuiutil.NoMax, c.ci.Discard)
 			case "nr", "nextround":
 				return c.ci.NextRound(), true
+			case "h", "hint":
+				return c.ci.Hint(), true
 			case "sd", "setdifficulty":
 				return cuiutil.WithParsedInt(args, "CPU difficulty is required (0=Easy, 1=Normal, 2=Hard).", "Invalid CPU difficulty: %s. Please enter 0-2.", 0, 2, func(v int) string {
 					cfg := c.ci.GetConfig()

--- a/internal/adapter/controller/SevenBridgeCuiController_test.go
+++ b/internal/adapter/controller/SevenBridgeCuiController_test.go
@@ -27,6 +27,7 @@ func TestSevenBridgeCuiController_Exec(t *testing.T) {
 		m.On("Layoff", mock.Anything, mock.Anything, mock.Anything).Return(mockOutput)
 		m.On("Discard", mock.Anything).Return(mockOutput)
 		m.On("NextRound").Return(mockOutput)
+		m.On("Hint").Return(mockOutput)
 		m.On("ActionLog").Return(mockOutput)
 		return m
 	}
@@ -42,6 +43,14 @@ func TestSevenBridgeCuiController_Exec(t *testing.T) {
 		c := controller.NewSevenBridgeCuiController(m)
 		assert.Equal(t, mockOutput, c.Exec("r"))
 		m.AssertCalled(t, "ResetWithConfig", domain.DefaultSevenBridgeConfig())
+	})
+
+	t.Run("hint", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewSevenBridgeCuiController(m)
+		assert.Equal(t, mockOutput, c.Exec("h"))
+		assert.Equal(t, mockOutput, c.Exec("hint"))
+		m.AssertCalled(t, "Hint")
 	})
 
 	t.Run("reset word preserves config", func(t *testing.T) {

--- a/internal/adapter/controller/usecase/SevenBridgeInteractor_mock.go
+++ b/internal/adapter/controller/usecase/SevenBridgeInteractor_mock.go
@@ -49,6 +49,10 @@ func (_m *MockSevenBridgeInteractor) NextRound() string {
 	return _m.Called().String(0)
 }
 
+func (_m *MockSevenBridgeInteractor) Hint() string {
+	return _m.Called().String(0)
+}
+
 func (_m *MockSevenBridgeInteractor) GetConfig() domain.SevenBridgeConfig {
 	return _m.Called().Get(0).(domain.SevenBridgeConfig)
 }

--- a/internal/adapter/presenter/SevenBridgeCuiPresenter.go
+++ b/internal/adapter/presenter/SevenBridgeCuiPresenter.go
@@ -92,6 +92,34 @@ func (p *SevenBridgeCuiPresenter) Output(g interfaces.SevenBridgeGame, lastErr e
 	})
 }
 
+// HintOutput suggests a meld (or a discard when no meld is available) for the
+// human's play phase, reusing the shared domain suggestion logic.
+func (p *SevenBridgeCuiPresenter) HintOutput(g interfaces.SevenBridgeGame) string {
+	if g.GetPhase() != domain.SevenBridgePhasePlay || !g.IsHumanTurn() {
+		return i18n.T("sevenbridge.hintNotYourTurn") + "\n"
+	}
+	idx := g.GetCurrentPlayerIdx()
+	human := g.GetPlayer(idx)
+	if human == nil {
+		return i18n.T("sevenbridge.hintNotYourTurn") + "\n"
+	}
+	if meld := g.SuggestMeld(idx); len(meld) > 0 {
+		idxStrs := make([]string, len(meld))
+		cards := make([]string, len(meld))
+		for i, hi := range meld {
+			idxStrs[i] = strconv.Itoa(hi)
+			cards[i] = cuiCardStr(human.GetCard(hi))
+		}
+		return i18n.Tf("sevenbridge.hintMeld",
+			"idxs", strings.Join(idxStrs, ", "), "cards", strings.Join(cards, ",")) + "\n"
+	}
+	if d := g.SuggestDiscard(idx); d >= 0 && d < human.GetCardsSize() {
+		return i18n.Tf("sevenbridge.hintDiscard",
+			"idx", strconv.Itoa(d), "card", cuiCardStr(human.GetCard(d))) + "\n"
+	}
+	return i18n.T("sevenbridge.hintNoMove") + "\n"
+}
+
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SevenBridgeCuiPresenter) ActionLogOutput(g interfaces.SevenBridgeGame) string {
 	return actionLogOutputText(g)

--- a/internal/adapter/presenter/SevenBridgeCuiPresenter_test.go
+++ b/internal/adapter/presenter/SevenBridgeCuiPresenter_test.go
@@ -150,6 +150,42 @@ func TestSevenBridgeCuiPresenter_Output(t *testing.T) {
 	})
 }
 
+func TestSevenBridgeCuiPresenter_HintOutput(t *testing.T) {
+	p := new(presenter.SevenBridgeCuiPresenter)
+
+	newHintMock := func() *interfaces.MockSevenBridgeGame {
+		m := new(interfaces.MockSevenBridgeGame)
+		human := domain.NewSevenBridgePlayer(true)
+		for _, v := range []int{3, 3, 3, 8} {
+			human.AddCard(domain.NewCard(domain.CardDesignSpade, v, false))
+		}
+		m.On("GetPhase").Return(domain.SevenBridgePhasePlay)
+		m.On("IsHumanTurn").Return(true)
+		m.On("GetCurrentPlayerIdx").Return(0)
+		m.On("GetPlayer", 0).Return(human)
+		return m
+	}
+
+	t.Run("recommends a meld when one is available", func(t *testing.T) {
+		m := newHintMock()
+		m.On("SuggestMeld", 0).Return([]int{0, 1, 2})
+		assert.Contains(t, p.HintOutput(m), "メルド")
+	})
+
+	t.Run("recommends a discard when no meld is available", func(t *testing.T) {
+		m := newHintMock()
+		m.On("SuggestMeld", 0).Return(([]int)(nil))
+		m.On("SuggestDiscard", 0).Return(3)
+		assert.Contains(t, p.HintOutput(m), "捨てる")
+	})
+
+	t.Run("declines outside the human's play phase", func(t *testing.T) {
+		m := new(interfaces.MockSevenBridgeGame)
+		m.On("GetPhase").Return(domain.SevenBridgePhaseDraw)
+		assert.Contains(t, p.HintOutput(m), "プレイフェーズではありません")
+	})
+}
+
 func TestSevenBridgeCuiPresenter_ActionLogOutput(t *testing.T) {
 	orig := color.NoColor()
 	color.SetNoColor(true)

--- a/internal/adapter/presenter/SevenBridgeWebPresenter.go
+++ b/internal/adapter/presenter/SevenBridgeWebPresenter.go
@@ -100,3 +100,9 @@ func (p *SevenBridgeWebPresenter) buildMessage(g interfaces.SevenBridgeGame, las
 func (p *SevenBridgeWebPresenter) ActionLogOutput(g interfaces.SevenBridgeGame) string {
 	return actionLogOutputJSON(g)
 }
+
+// HintOutput ヒントを出力する。Web ではヒントはクライアント側 (useGameHint) で
+// 算出するため、通常の状態出力を返す。SevenBridgePresenter インタフェースを満たすための実装。
+func (p *SevenBridgeWebPresenter) HintOutput(g interfaces.SevenBridgeGame) string {
+	return p.Output(g, nil)
+}

--- a/internal/adapter/presenter/SevenBridgeWebPresenter_test.go
+++ b/internal/adapter/presenter/SevenBridgeWebPresenter_test.go
@@ -165,3 +165,10 @@ func TestSevenBridgeWebPresenter_ActionLogOutput(t *testing.T) {
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "draw_stock")
 }
+
+func TestSevenBridgeWebPresenter_HintOutput(t *testing.T) {
+	// Web hints are client-side, so HintOutput mirrors Output.
+	p := new(presenter.SevenBridgeWebPresenter)
+	m, _ := setupSevenBridgeWebMockWithPlayers()
+	assert.Equal(t, p.Output(m, nil), p.HintOutput(m))
+}

--- a/internal/domain/SevenBridge.go
+++ b/internal/domain/SevenBridge.go
@@ -693,6 +693,29 @@ func (g *SevenBridge) findChiIndices(playerIdx int, top *Card) ([]int, bool) {
 }
 
 // findBestMeldIndices プレイヤーの手札から最大のメルド（3 枚以上）を探す
+// SuggestMeld は playerIdx の最善メルド (手札インデックス) を返す。メルドできる組が
+// 無ければ nil。CUI ヒント用に findBestMeldIndices を公開する薄いラッパー。
+func (g *SevenBridge) SuggestMeld(playerIdx int) []int {
+	p := g.GetPlayer(playerIdx)
+	if p == nil {
+		return nil
+	}
+	if idxs, ok := g.findBestMeldIndices(p); ok {
+		return idxs
+	}
+	return nil
+}
+
+// SuggestDiscard は playerIdx の推奨ディスカード手札インデックスを返す。手札が無ければ -1。
+// CUI ヒント用に chooseCpuDiscard を公開する薄いラッパー。
+func (g *SevenBridge) SuggestDiscard(playerIdx int) int {
+	p := g.GetPlayer(playerIdx)
+	if p == nil || p.GetCardsSize() == 0 {
+		return -1
+	}
+	return g.chooseCpuDiscard(p)
+}
+
 func (g *SevenBridge) findBestMeldIndices(p *SevenBridgePlayer) ([]int, bool) {
 	n := p.GetCardsSize()
 	// セット候補

--- a/internal/domain/SevenBridgeSuggest_test.go
+++ b/internal/domain/SevenBridgeSuggest_test.go
@@ -1,0 +1,34 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSevenBridge_SuggestMeldAndDiscard(t *testing.T) {
+	g := NewDefaultSevenBridge()
+	g.Reset()
+
+	t.Run("out-of-range indices are guarded", func(t *testing.T) {
+		assert.Nil(t, g.SuggestMeld(-1))
+		assert.Nil(t, g.SuggestMeld(999))
+		assert.Equal(t, -1, g.SuggestDiscard(-1))
+		assert.Equal(t, -1, g.SuggestDiscard(999))
+	})
+
+	t.Run("SuggestDiscard returns an in-range index for a non-empty hand", func(t *testing.T) {
+		d := g.SuggestDiscard(0)
+		assert.GreaterOrEqual(t, d, 0)
+		assert.Less(t, d, g.GetPlayer(0).GetCardsSize())
+	})
+
+	t.Run("SuggestMeld finds a guaranteed set of three", func(t *testing.T) {
+		human := g.GetPlayer(0)
+		human.AddCard(NewCard(CardDesignSpade, 3, false))
+		human.AddCard(NewCard(CardDesignClover, 3, false))
+		human.AddCard(NewCard(CardDesignHeart, 3, false))
+		meld := g.SuggestMeld(0)
+		assert.GreaterOrEqual(t, len(meld), SevenBridgeMeldMinSize)
+	})
+}

--- a/internal/domain/interfaces/sevenbridge.go
+++ b/internal/domain/interfaces/sevenbridge.go
@@ -23,6 +23,10 @@ type SevenBridgeGame interface {
 	PlayerLayoff(targetPlayerIdx, meldIdx, cardIndex int) error
 	// PlayerDiscard プレイヤーがカードを捨てる
 	PlayerDiscard(cardIndex int) error
+	// SuggestMeld playerIdx の最善メルド (手札インデックス) を返す。無ければ nil
+	SuggestMeld(playerIdx int) []int
+	// SuggestDiscard playerIdx の推奨ディスカード手札インデックスを返す。無ければ -1
+	SuggestDiscard(playerIdx int) int
 	// CpuPlay CPU プレイヤーが 1 ターン実行する
 	CpuPlay()
 

--- a/internal/domain/interfaces/sevenbridge_mock.go
+++ b/internal/domain/interfaces/sevenbridge_mock.go
@@ -23,7 +23,17 @@ func (m *MockSevenBridgeGame) PlayerLayoff(t, mi, ci int) error {
 	return m.Called(t, mi, ci).Error(0)
 }
 func (m *MockSevenBridgeGame) PlayerDiscard(i int) error { return m.Called(i).Error(0) }
-func (m *MockSevenBridgeGame) CpuPlay()                  { m.Called() }
+func (m *MockSevenBridgeGame) SuggestMeld(playerIdx int) []int {
+	ret := m.Called(playerIdx)
+	if v := ret.Get(0); v != nil {
+		return v.([]int)
+	}
+	return nil
+}
+func (m *MockSevenBridgeGame) SuggestDiscard(playerIdx int) int {
+	return m.Called(playerIdx).Int(0)
+}
+func (m *MockSevenBridgeGame) CpuPlay() { m.Called() }
 func (m *MockSevenBridgeGame) GetConfig() domain.SevenBridgeConfig {
 	return m.Called().Get(0).(domain.SevenBridgeConfig)
 }

--- a/internal/i18n/locales/en/sevenbridge.json
+++ b/internal/i18n/locales/en/sevenbridge.json
@@ -7,6 +7,7 @@
   "helpLayoff": "  lo <pIdx> <mIdx> <cIdx>  add a card to an existing meld",
   "helpDiscard": "  d <idx>              discard a card",
   "helpNextRound": "  nr                   next round",
+  "helpHint": "  h | hint             suggest a meld or discard",
   "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
   "helpSetLimit": "  sl <n>               point limit",
   "header": "Round: {{round}}  Stock: {{stock}}",
@@ -23,5 +24,9 @@
   "promptPlayHelpLayoff": "lo <pIdx> <mIdx> <cIdx>: add a card to an existing meld",
   "promptPlayHelpDiscard": "d <idx>: discard a card",
   "promptRoundEnd": "Round complete",
-  "promptRoundEndHelp": "nr / nextround: advance to next round"
+  "promptRoundEndHelp": "nr / nextround: advance to next round",
+  "hintMeld": "Suggestion: meld hand [{{idxs}}] ({{cards}}) with m {{idxs}}",
+  "hintDiscard": "Suggestion: discard hand {{idx}} ({{card}}) with d {{idx}}",
+  "hintNoMove": "No move can be recommended.",
+  "hintNotYourTurn": "It is not your play phase right now."
 }

--- a/internal/i18n/locales/ja/sevenbridge.json
+++ b/internal/i18n/locales/ja/sevenbridge.json
@@ -7,6 +7,7 @@
   "helpLayoff": "  lo <pIdx> <mIdx> <cIdx>  既存メルドにカード追加",
   "helpDiscard": "  d <idx>              カードを捨てる",
   "helpNextRound": "  nr                   次のラウンドへ",
+  "helpHint": "  h | hint             メルド/ディスカードの推奨を表示",
   "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)",
   "helpSetLimit": "  sl <n>               ポイント上限",
   "header": "ラウンド: {{round}}  山札: {{stock}}枚",
@@ -23,5 +24,9 @@
   "promptPlayHelpLayoff": "lo <pIdx> <mIdx> <cIdx>・・・既存メルドにカード追加",
   "promptPlayHelpDiscard": "d <idx>・・・カードを捨てる",
   "promptRoundEnd": "ラウンド終了",
-  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ"
+  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
+  "hintMeld": "推奨: 手札 [{{idxs}}] ({{cards}}) でメルド (m {{idxs}})",
+  "hintDiscard": "推奨: 手札 {{idx}} ({{card}}) を捨てる (d {{idx}})",
+  "hintNoMove": "推奨できる手がありません。",
+  "hintNotYourTurn": "今はあなたのプレイフェーズではありません。"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -1193,6 +1193,7 @@ var gameRegistry = []GameRegistryEntry{
 					"sevenbridge.helpLayoff",
 					"sevenbridge.helpDiscard",
 					"sevenbridge.helpNextRound",
+					"sevenbridge.helpHint",
 				},
 				SettingKeys: []string{"sevenbridge.helpSetDifficulty", "sevenbridge.helpSetLimit"},
 			})

--- a/internal/usecase/SevenBridgeInteractor.go
+++ b/internal/usecase/SevenBridgeInteractor.go
@@ -32,6 +32,8 @@ type SevenBridgeInteractorIF interface {
 	NextRound() string
 	// GetConfig 現在の設定を取得
 	GetConfig() domain.SevenBridgeConfig
+	// Hint ヒント取得
+	Hint() string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
 }
@@ -150,6 +152,11 @@ func (ci *SevenBridgeInteractor) GetConfig() domain.SevenBridgeConfig {
 // ActionLog 棋譜を出力する
 func (ci *SevenBridgeInteractor) ActionLog() string {
 	return ci.gp.ActionLogOutput(ci.Game)
+}
+
+// Hint ヒント取得
+func (ci *SevenBridgeInteractor) Hint() string {
+	return ci.gp.HintOutput(ci.Game)
 }
 
 // runCpuTurns CPU ターンを連続で処理する

--- a/internal/usecase/SevenBridgeInteractor_test.go
+++ b/internal/usecase/SevenBridgeInteractor_test.go
@@ -53,6 +53,15 @@ func TestSevenBridgeInteractor_Reset(t *testing.T) {
 	gameMock.AssertCalled(t, "Reset")
 }
 
+func TestSevenBridgeInteractor_Hint(t *testing.T) {
+	pMock, gameMock := setupSevenBridgeMocks()
+	pMock.On("HintOutput", gameMock).Return("hint_output")
+
+	ci := usecase.NewSevenBridgeInteractor(gameMock, pMock)
+	assert.Equal(t, "hint_output", ci.Hint())
+	pMock.AssertCalled(t, "HintOutput", gameMock)
+}
+
 func TestSevenBridgeInteractor_ResetWithConfig_Valid(t *testing.T) {
 	pMock, gameMock := setupSevenBridgeMocks()
 	cfg := domain.SevenBridgeConfig{CpuDifficulty: domain.SevenBridgeCpuDifficultyHard, PointLimit: 200}

--- a/internal/usecase/presenter/SevenBridgePresenter.go
+++ b/internal/usecase/presenter/SevenBridgePresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // SevenBridgePresenter セブンブリッジプレゼンターインタフェース
-type SevenBridgePresenter = GamePresenter[interfaces.SevenBridgeGame]
+type SevenBridgePresenter interface {
+	GamePresenter[interfaces.SevenBridgeGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.SevenBridgeGame) string
+}

--- a/internal/usecase/presenter/SevenBridgePresenter_mock.go
+++ b/internal/usecase/presenter/SevenBridgePresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockSevenBridgePresenter セブンブリッジプレゼンターモック
-type MockSevenBridgePresenter = MockGamePresenter[interfaces.SevenBridgeGame]
+type MockSevenBridgePresenter struct {
+	MockGamePresenter[interfaces.SevenBridgeGame]
+}
+
+// HintOutput モック
+func (_m *MockSevenBridgePresenter) HintOutput(g interfaces.SevenBridgeGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## Summary
- Expose the game's existing `findBestMeldIndices` / `chooseCpuDiscard` as public domain methods `SuggestMeld(playerIdx)` / `SuggestDiscard(playerIdx)` on the `SevenBridgeGame` interface.
- `SevenBridgeCuiPresenter.HintOutput` recommends a meld (showing hand indices + cards) in the play phase, or a discard when no meld is available, for the human's turn.
- Wire `h`/`hint` end-to-end: promote `SevenBridgePresenter` from a `GamePresenter` alias to an interface with `HintOutput` (both CUI and Web presenters implement it — Web delegates to `Output` since web hints are computed client-side), add `SevenBridgeInteractor.Hint()` + IF method, register the command in `SevenBridgeCuiController` and the CUI help spec, and extend the game/presenter/interactor mocks.
- Add ja/en `hint*` + `helpHint` translations.

## Test plan
- `SevenBridgeSuggest_test.go` — out-of-range guards, in-range discard, guaranteed set-of-three meld.
- `SevenBridgeCuiPresenter_test.go` — meld recommendation, discard fallback, not-play-phase guard.
- `SevenBridgeCuiController_test.go` — `h`/`hint` routes to `Hint()`; `SevenBridgeInteractor_test.go` — `Hint()` delegates; `SevenBridgeWebPresenter_test.go` — `HintOutput` mirrors `Output`.
- `go test -tags test ./internal/...`, `golangci-lint`, server build, and the solo WASM worker build all pass.

Closes #3196