### PR TITLE
feat(deucetoseven): add draw-phase hint command to the CUI

### DIFF
--- a/internal/adapter/controller/DeuceToSevenCuiController.go
+++ b/internal/adapter/controller/DeuceToSevenCuiController.go
@@ -44,6 +44,7 @@ func (dcc *DeuceToSevenCuiController) Exec(command string) string {
 		[]string{
 			"e", "exchange", "s", "stand", "b", "bet", "c", "call", "ra", "raise",
 			"f", "fold", "ck", "check", "a", "allin",
+			"h", "hint",
 			"bl", "bettinglimit", "scc", "setcpucount", "mai", "metaai",
 			"log", "l",
 		},
@@ -54,6 +55,8 @@ func (dcc *DeuceToSevenCuiController) Exec(command string) string {
 				return cuiutil.PrependSkippedWarning(dcc.di.Exchange(indices), skipped), true
 			case "s", "stand":
 				return dcc.di.Stand(), true
+			case "h", "hint":
+				return dcc.di.Hint(), true
 			case "b", "bet":
 				amount := parseCuiAmount(args)
 				return dcc.di.Action(domain.DeuceToSevenActionBet, amount, 0), true

--- a/internal/adapter/controller/DeuceToSevenCuiController_test.go
+++ b/internal/adapter/controller/DeuceToSevenCuiController_test.go
@@ -15,6 +15,15 @@ func newDeuceToSevenMockInteractor() *mockUsecase.MockDeuceToSevenInteractor {
 	return new(mockUsecase.MockDeuceToSevenInteractor)
 }
 
+func TestDeuceToSevenCuiController_Hint(t *testing.T) {
+	mi := newDeuceToSevenMockInteractor()
+	mi.On("Hint").Return("hint ok")
+	c := NewDeuceToSevenCuiController(mi)
+	assert.Equal(t, "hint ok", c.Exec("h"))
+	assert.Equal(t, "hint ok", c.Exec("hint"))
+	mi.AssertCalled(t, "Hint")
+}
+
 func TestDeuceToSevenCuiController_Quit(t *testing.T) {
 	c := NewDeuceToSevenCuiController(newDeuceToSevenMockInteractor())
 	assert.Equal(t, "bye.", c.Exec("q"))

--- a/internal/adapter/controller/usecase/DeuceToSevenInteractor_mock.go
+++ b/internal/adapter/controller/usecase/DeuceToSevenInteractor_mock.go
@@ -50,6 +50,11 @@ func (m *MockDeuceToSevenInteractor) Stand() string {
 	return ret.Get(0).(string)
 }
 
+func (m *MockDeuceToSevenInteractor) Hint() string {
+	ret := m.Called()
+	return ret.Get(0).(string)
+}
+
 // ActionLog mock.
 func (m *MockDeuceToSevenInteractor) ActionLog() string {
 	ret := m.Called()

--- a/internal/adapter/presenter/DeuceToSevenCuiPresenter.go
+++ b/internal/adapter/presenter/DeuceToSevenCuiPresenter.go
@@ -127,6 +127,38 @@ func (dcp *DeuceToSevenCuiPresenter) Output(g interfaces.DeuceToSevenGame, lastE
 	})
 }
 
+// HintOutput recommends which cards to exchange (or to stand pat) during the
+// human's draw phase, reusing the shared domain suggestion logic.
+func (dcp *DeuceToSevenCuiPresenter) HintOutput(g interfaces.DeuceToSevenGame) string {
+	if g.GetGameEndFlag() || g.GetPhase() != domain.DeuceToSevenPhaseDraw {
+		return i18n.T("deucetoseven.hintNotYourTurn") + "\n"
+	}
+	players := g.GetPlayers()
+	humanSeat := -1
+	for i, pl := range players {
+		if pl != nil && pl.GetIsHuman() {
+			humanSeat = i
+			break
+		}
+	}
+	if humanSeat < 0 || g.GetCurrentTurn() != humanSeat {
+		return i18n.T("deucetoseven.hintNotYourTurn") + "\n"
+	}
+	ex := g.SuggestExchange(humanSeat)
+	if len(ex) == 0 {
+		return i18n.T("deucetoseven.hintStandPat") + "\n"
+	}
+	human := players[humanSeat]
+	idxParts := make([]string, len(ex))
+	cardParts := make([]string, len(ex))
+	for i, hi := range ex {
+		idxParts[i] = strconv.Itoa(hi)
+		cardParts[i] = cuiCardStr(human.GetCard(hi))
+	}
+	return i18n.Tf("deucetoseven.hintExchange",
+		"idxs", strings.Join(idxParts, ", "), "cards", strings.Join(cardParts, ",")) + "\n"
+}
+
 // ActionLogOutput renders the action log as plain text.
 func (dcp *DeuceToSevenCuiPresenter) ActionLogOutput(g interfaces.DeuceToSevenGame) string {
 	return actionLogOutputText(g)

--- a/internal/adapter/presenter/DeuceToSevenCuiPresenter.go
+++ b/internal/adapter/presenter/DeuceToSevenCuiPresenter.go
@@ -156,7 +156,9 @@ func (dcp *DeuceToSevenCuiPresenter) HintOutput(g interfaces.DeuceToSevenGame) s
 		cardParts[i] = cuiCardStr(human.GetCard(hi))
 	}
 	return i18n.Tf("deucetoseven.hintExchange",
-		"idxs", strings.Join(idxParts, ", "), "cards", strings.Join(cardParts, ",")) + "\n"
+		"idxs", strings.Join(idxParts, ", "),
+		"cards", strings.Join(cardParts, ","),
+		"cmd", strings.Join(idxParts, " ")) + "\n"
 }
 
 // ActionLogOutput renders the action log as plain text.

--- a/internal/adapter/presenter/DeuceToSevenCuiPresenter_test.go
+++ b/internal/adapter/presenter/DeuceToSevenCuiPresenter_test.go
@@ -118,15 +118,19 @@ func TestDeuceToSevenCuiPresenter_HintOutput(t *testing.T) {
 		dt.SetPhase(domain.DeuceToSevenPhaseDraw)
 		dt.SetCurrentTurn(0)
 		for _, c := range []*domain.Card{
-			domain.NewCard(domain.CardDesignSpade, 2, false),
-			domain.NewCard(domain.CardDesignHeart, 2, false), // paired rank → discard the dup
-			domain.NewCard(domain.CardDesignDiamond, 13, false),
-			domain.NewCard(domain.CardDesignClover, 12, false),
-			domain.NewCard(domain.CardDesignSpade, 11, false),
+			domain.NewCard(domain.CardDesignSpade, 2, false),   // idx 0 — kept
+			domain.NewCard(domain.CardDesignHeart, 3, false),   // idx 1 — kept
+			domain.NewCard(domain.CardDesignDiamond, 4, false), // idx 2 — kept
+			domain.NewCard(domain.CardDesignClover, 13, false), // idx 3 — discard (K)
+			domain.NewCard(domain.CardDesignSpade, 12, false),  // idx 4 — discard (Q)
 		} {
 			players[0].AddCard(c)
 		}
-		assert.Contains(t, pres.HintOutput(dt), "交換")
+		out := pres.HintOutput(dt)
+		assert.Contains(t, out, "交換")
+		// The copy-paste command must be space-separated so `e` parses every index
+		// (discards are ordered highest-value first: K=idx3, Q=idx4).
+		assert.Contains(t, out, "e 3 4")
 	})
 
 	t.Run("recommends standing pat on a made low", func(t *testing.T) {

--- a/internal/adapter/presenter/DeuceToSevenCuiPresenter_test.go
+++ b/internal/adapter/presenter/DeuceToSevenCuiPresenter_test.go
@@ -110,6 +110,53 @@ func TestDeuceToSevenCuiPresenter_Output_ErrorSurfaces(t *testing.T) {
 	assert.Contains(t, out, "oops")
 }
 
+func TestDeuceToSevenCuiPresenter_HintOutput(t *testing.T) {
+	pres := new(presenter.DeuceToSevenCuiPresenter)
+
+	t.Run("recommends exchanging weak cards", func(t *testing.T) {
+		dt, players := makeDeuceToSevenForPresenter()
+		dt.SetPhase(domain.DeuceToSevenPhaseDraw)
+		dt.SetCurrentTurn(0)
+		for _, c := range []*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 2, false),
+			domain.NewCard(domain.CardDesignHeart, 2, false), // paired rank → discard the dup
+			domain.NewCard(domain.CardDesignDiamond, 13, false),
+			domain.NewCard(domain.CardDesignClover, 12, false),
+			domain.NewCard(domain.CardDesignSpade, 11, false),
+		} {
+			players[0].AddCard(c)
+		}
+		assert.Contains(t, pres.HintOutput(dt), "交換")
+	})
+
+	t.Run("recommends standing pat on a made low", func(t *testing.T) {
+		dt, players := makeDeuceToSevenForPresenter()
+		dt.SetPhase(domain.DeuceToSevenPhaseDraw)
+		dt.SetCurrentTurn(0)
+		designs := []int{domain.CardDesignSpade, domain.CardDesignHeart, domain.CardDesignDiamond, domain.CardDesignClover, domain.CardDesignSpade}
+		for i, v := range []int{7, 5, 4, 3, 2} {
+			players[0].AddCard(domain.NewCard(designs[i], v, false))
+		}
+		assert.Contains(t, pres.HintOutput(dt), "スタンドパット")
+	})
+
+	t.Run("declines outside the draw phase", func(t *testing.T) {
+		dt, _ := makeDeuceToSevenForPresenter()
+		dt.SetPhase(domain.DeuceToSevenPhaseBet)
+		assert.Contains(t, pres.HintOutput(dt), "ドローフェーズではありません")
+	})
+
+	t.Run("declines when it is not the human's turn", func(t *testing.T) {
+		dt, players := makeDeuceToSevenForPresenter()
+		dt.SetPhase(domain.DeuceToSevenPhaseDraw)
+		dt.SetCurrentTurn(1)
+		for _, v := range []int{7, 5, 4, 3, 2} {
+			players[0].AddCard(domain.NewCard(domain.CardDesignSpade, v, false))
+		}
+		assert.Contains(t, pres.HintOutput(dt), "ドローフェーズではありません")
+	})
+}
+
 func TestDeuceToSevenCuiPresenter_ActionLogOutput(t *testing.T) {
 	pres := new(presenter.DeuceToSevenCuiPresenter)
 	dt, _ := makeDeuceToSevenForPresenter()

--- a/internal/adapter/presenter/DeuceToSevenWebPresenter.go
+++ b/internal/adapter/presenter/DeuceToSevenWebPresenter.go
@@ -21,6 +21,12 @@ func (dwp *DeuceToSevenWebPresenter) ActionLogOutput(g interfaces.DeuceToSevenGa
 	return actionLogOutputJSON(g)
 }
 
+// HintOutput ヒントを出力する。Web ではヒントはクライアント側 (useGameHint) で
+// 算出するため、通常の状態出力を返す。DeuceToSevenPresenter インタフェースを満たすための実装。
+func (dwp *DeuceToSevenWebPresenter) HintOutput(g interfaces.DeuceToSevenGame) string {
+	return dwp.Output(g, nil)
+}
+
 func (dwp *DeuceToSevenWebPresenter) buildOutput(g interfaces.DeuceToSevenGame, lastErr error) *controller.DeuceToSevenWebOutput {
 	out := new(controller.DeuceToSevenWebOutput)
 	out.Phase = g.GetPhase()

--- a/internal/adapter/presenter/DeuceToSevenWebPresenter_test.go
+++ b/internal/adapter/presenter/DeuceToSevenWebPresenter_test.go
@@ -153,3 +153,10 @@ func TestDeuceToSevenWebPresenter_ActionLogOutput(t *testing.T) {
 	got := pres.ActionLogOutput(dt)
 	assert.NotEmpty(t, got)
 }
+
+func TestDeuceToSevenWebPresenter_HintOutput(t *testing.T) {
+	// Web hints are client-side, so HintOutput mirrors Output.
+	pres := new(presenter.DeuceToSevenWebPresenter)
+	dt, _ := makeDeuceToSevenForPresenter()
+	assert.Equal(t, pres.Output(dt, nil), pres.HintOutput(dt))
+}

--- a/internal/domain/DeuceToSeven.go
+++ b/internal/domain/DeuceToSeven.go
@@ -778,6 +778,57 @@ func (d *DeuceToSeven) cpuDecideExchange(idx int) []int {
 // discard: pair duplicates and high cards (value 9+ or Ace), keeping the lowest
 // distinct cards (2..8). If keeping every card would leave a made straight or
 // flush (no natural discard), the single highest card is dropped to break it.
+// SuggestExchange は playerIdx の推奨交換カードインデックスを返す。空 (nil) の場合は
+// 完成ロー (スタンドパット) 推奨。既に 8 以下で完成したローならスタンドパットを推奨し、
+// それ以外は deuceToSevenDiscardIndices の交換候補を返す。
+func (d *DeuceToSeven) SuggestExchange(playerIdx int) []int {
+	players := d.GetPlayers()
+	if playerIdx < 0 || playerIdx >= len(players) {
+		return nil
+	}
+	pl := players[playerIdx]
+	if deuceToSevenIsPatLow(pl) {
+		return nil
+	}
+	return deuceToSevenDiscardIndices(pl)
+}
+
+// deuceToSevenIsPatLow は手札が完成ロー (8 以下で立てられるパット) かを判定する。
+// 条件: 5 枚がすべて異なるランクで 8 以下 (エースは高札扱いで不可)、かつストレートでも
+// フラッシュでもないこと。
+func deuceToSevenIsPatLow(pl *DeuceToSevenPlayer) bool {
+	if pl.GetCardsSize() != 5 {
+		return false
+	}
+	ranks := make([]int, 0, 5)
+	firstSuit := pl.GetCard(0).GetDesign()
+	flush := true
+	seen := make(map[int]bool, 5)
+	for i := 0; i < 5; i++ {
+		c := pl.GetCard(i)
+		v := c.GetValue()
+		if v == 1 {
+			v = 14 // Ace is always high (bad for low)
+		}
+		if v > 8 || seen[v] {
+			return false // too high or paired
+		}
+		seen[v] = true
+		ranks = append(ranks, v)
+		if c.GetDesign() != firstSuit {
+			flush = false
+		}
+	}
+	if flush {
+		return false
+	}
+	sort.Ints(ranks)
+	if ranks[len(ranks)-1]-ranks[0] == 4 {
+		return false // 5 distinct consecutive ranks = straight
+	}
+	return true
+}
+
 func deuceToSevenDiscardIndices(pl *DeuceToSevenPlayer) []int {
 	type cardInfo struct{ idx, low int } // low = 2-7 value with Ace = 14
 	n := pl.GetCardsSize()

--- a/internal/domain/DeuceToSevenSuggest_test.go
+++ b/internal/domain/DeuceToSevenSuggest_test.go
@@ -1,0 +1,49 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeuceToSeven_SuggestExchange(t *testing.T) {
+	newGame := func() (*DeuceToSeven, *DeuceToSevenPlayer) {
+		players := []*DeuceToSevenPlayer{
+			NewDeuceToSevenPlayer(true, DeuceToSevenStyleBalanced),
+			NewDeuceToSevenPlayer(false, DeuceToSevenStyleBalanced),
+		}
+		g := NewDeuceToSeven(NewTrumpCards(0), players, DefaultDeuceToSevenConfig())
+		return g, players[0]
+	}
+
+	t.Run("out-of-range index returns nil", func(t *testing.T) {
+		g, _ := newGame()
+		assert.Nil(t, g.SuggestExchange(-1))
+		assert.Nil(t, g.SuggestExchange(99))
+	})
+
+	t.Run("made pat low returns nil (stand pat)", func(t *testing.T) {
+		g, pl := newGame()
+		ds := []int{CardDesignSpade, CardDesignHeart, CardDesignDiamond, CardDesignClover, CardDesignSpade}
+		for i, v := range []int{7, 5, 4, 3, 2} {
+			pl.AddCard(NewCard(ds[i], v, false))
+		}
+		assert.Nil(t, g.SuggestExchange(0))
+	})
+
+	t.Run("a flush is not treated as a pat low", func(t *testing.T) {
+		g, pl := newGame()
+		for _, v := range []int{7, 5, 4, 3, 2} { // all spades → flush (bad low)
+			pl.AddCard(NewCard(CardDesignSpade, v, false))
+		}
+		assert.NotEmpty(t, g.SuggestExchange(0))
+	})
+
+	t.Run("weak hand returns a non-empty discard list", func(t *testing.T) {
+		g, pl := newGame()
+		for _, v := range []int{2, 2, 13, 12, 11} { // pair + high cards
+			pl.AddCard(NewCard(CardDesignSpade, v, false))
+		}
+		assert.NotEmpty(t, g.SuggestExchange(0))
+	})
+}

--- a/internal/domain/interfaces/deuce_to_seven.go
+++ b/internal/domain/interfaces/deuce_to_seven.go
@@ -25,6 +25,9 @@ type DeuceToSevenGame interface {
 
 	// GetPlayers returns the seated players.
 	GetPlayers() []*domain.DeuceToSevenPlayer
+	// SuggestExchange returns the recommended exchange card indices for the
+	// given seat (nil means a made low — stand pat).
+	SuggestExchange(playerIdx int) []int
 	// GetPhase returns the current phase constant (DeuceToSevenPhase*).
 	GetPhase() int
 	// GetDrawIndex returns the current draw round counter (0..3).

--- a/internal/domain/interfaces/deuce_to_seven_mock.go
+++ b/internal/domain/interfaces/deuce_to_seven_mock.go
@@ -43,6 +43,15 @@ func (m *MockDeuceToSevenGame) GetPlayers() []*domain.DeuceToSevenPlayer {
 	return ret.Get(0).([]*domain.DeuceToSevenPlayer)
 }
 
+// SuggestExchange mock.
+func (m *MockDeuceToSevenGame) SuggestExchange(playerIdx int) []int {
+	ret := m.Called(playerIdx)
+	if v := ret.Get(0); v != nil {
+		return v.([]int)
+	}
+	return nil
+}
+
 // GetPhase mock.
 func (m *MockDeuceToSevenGame) GetPhase() int {
 	ret := m.Called()

--- a/internal/i18n/locales/en/deucetoseven.json
+++ b/internal/i18n/locales/en/deucetoseven.json
@@ -8,6 +8,7 @@
   "helpAllIn": "  a                    all-in",
   "helpExchange": "  e [0-4]              exchange cards (e.g. e 0 2)",
   "helpStand": "  s                    stand pat (no exchange)",
+  "helpHint": "  h | hint             suggest which cards to exchange",
   "helpBettingLimit": "  bl [0-2]             betting limit (0=Fixed, 1=PotLimit, 2=NoLimit)",
   "helpCpuCount": "  scc [1-3]            CPU player count",
   "outputTitle": "2-7 Triple Draw (Deuce to Seven Lowball)",
@@ -32,5 +33,8 @@
   "resultHand": "  {{name}}: {{hand}}",
   "resultName": "  {{name}}",
   "wonAmount": " → won {{total}} chips",
-  "gameEnd": "Game over"
+  "gameEnd": "Game over",
+  "hintExchange": "Suggestion: exchange hand [{{idxs}}] ({{cards}}) with e {{idxs}}",
+  "hintStandPat": "Suggestion: made low — stand pat (s).",
+  "hintNotYourTurn": "It is not your draw phase right now."
 }

--- a/internal/i18n/locales/en/deucetoseven.json
+++ b/internal/i18n/locales/en/deucetoseven.json
@@ -34,7 +34,7 @@
   "resultName": "  {{name}}",
   "wonAmount": " → won {{total}} chips",
   "gameEnd": "Game over",
-  "hintExchange": "Suggestion: exchange hand [{{idxs}}] ({{cards}}) with e {{idxs}}",
+  "hintExchange": "Suggestion: exchange hand [{{idxs}}] ({{cards}}) with e {{cmd}}",
   "hintStandPat": "Suggestion: made low — stand pat (s).",
   "hintNotYourTurn": "It is not your draw phase right now."
 }

--- a/internal/i18n/locales/ja/deucetoseven.json
+++ b/internal/i18n/locales/ja/deucetoseven.json
@@ -34,7 +34,7 @@
   "resultName": "  {{name}}",
   "wonAmount": " → {{total}}チップ獲得",
   "gameEnd": "ゲーム終了",
-  "hintExchange": "推奨: 手札 [{{idxs}}] ({{cards}}) を交換 (e {{idxs}})",
+  "hintExchange": "推奨: 手札 [{{idxs}}] ({{cards}}) を交換 (e {{cmd}})",
   "hintStandPat": "推奨: 完成ロー。スタンドパット (s) しましょう。",
   "hintNotYourTurn": "今はあなたのドローフェーズではありません。"
 }

--- a/internal/i18n/locales/ja/deucetoseven.json
+++ b/internal/i18n/locales/ja/deucetoseven.json
@@ -8,6 +8,7 @@
   "helpAllIn": "  a                    オールイン",
   "helpExchange": "  e [0-4]              カード交換 (例: e 0 2)",
   "helpStand": "  s                    スタンドパット (交換なし)",
+  "helpHint": "  h | hint             交換すべきカードの推奨を表示",
   "helpBettingLimit": "  bl [0-2]             ベッティングリミット (0=Fixed, 1=PotLimit, 2=NoLimit)",
   "helpCpuCount": "  scc [1-3]            CPU人数",
   "outputTitle": "2-7 Triple Draw (Deuce to Seven Lowball)",
@@ -32,5 +33,8 @@
   "resultHand": "  {{name}}: {{hand}}",
   "resultName": "  {{name}}",
   "wonAmount": " → {{total}}チップ獲得",
-  "gameEnd": "ゲーム終了"
+  "gameEnd": "ゲーム終了",
+  "hintExchange": "推奨: 手札 [{{idxs}}] ({{cards}}) を交換 (e {{idxs}})",
+  "hintStandPat": "推奨: 完成ロー。スタンドパット (s) しましょう。",
+  "hintNotYourTurn": "今はあなたのドローフェーズではありません。"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -1092,6 +1092,7 @@ var gameRegistry = []GameRegistryEntry{
 					"deucetoseven.helpAllIn",
 					"deucetoseven.helpExchange",
 					"deucetoseven.helpStand",
+					"deucetoseven.helpHint",
 				},
 				SettingKeys: []string{"deucetoseven.helpBettingLimit", "deucetoseven.helpCpuCount"},
 			})

--- a/internal/usecase/DeuceToSevenInteractor.go
+++ b/internal/usecase/DeuceToSevenInteractor.go
@@ -27,6 +27,8 @@ type DeuceToSevenInteractorIF interface {
 	Exchange(indices []int) string
 	// Stand passes on the current draw.
 	Stand() string
+	// Hint returns the draw-phase hint output.
+	Hint() string
 	// ActionLog returns the log output for the current hand.
 	ActionLog() string
 }
@@ -94,6 +96,11 @@ func (di *DeuceToSevenInteractor) Stand() string {
 // ActionLog returns the log output for the current hand.
 func (di *DeuceToSevenInteractor) ActionLog() string {
 	return di.pp.ActionLogOutput(di.Game)
+}
+
+// Hint returns the draw-phase hint output.
+func (di *DeuceToSevenInteractor) Hint() string {
+	return di.pp.HintOutput(di.Game)
 }
 
 // RestoreDeuceToSevenInteractor deserialises JSON into a DeuceToSevenInteractor.

--- a/internal/usecase/DeuceToSevenInteractor_test.go
+++ b/internal/usecase/DeuceToSevenInteractor_test.go
@@ -48,6 +48,16 @@ func TestDeuceToSevenInteractor_Reset(t *testing.T) {
 	mg.AssertCalled(t, "Reset")
 }
 
+func TestDeuceToSevenInteractor_Hint(t *testing.T) {
+	mg, mp := newDeuceToSevenMocks()
+	di := usecase.NewDeuceToSevenInteractor(mg, mp)
+
+	mp.On("HintOutput", mg).Return("hint output")
+
+	assert.Equal(t, "hint output", di.Hint())
+	mp.AssertCalled(t, "HintOutput", mg)
+}
+
 func TestDeuceToSevenInteractor_Reset_Error(t *testing.T) {
 	mg, mp := newDeuceToSevenMocks()
 	di := usecase.NewDeuceToSevenInteractor(mg, mp)

--- a/internal/usecase/presenter/DeuceToSevenPresenter.go
+++ b/internal/usecase/presenter/DeuceToSevenPresenter.go
@@ -9,4 +9,8 @@ import (
 // DeuceToSevenPresenter is the 2-7 Triple Draw presenter alias over the generic
 // GamePresenter. Adapter-side implementations satisfy this via Output +
 // ActionLogOutput.
-type DeuceToSevenPresenter = GamePresenter[interfaces.DeuceToSevenGame]
+type DeuceToSevenPresenter interface {
+	GamePresenter[interfaces.DeuceToSevenGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.DeuceToSevenGame) string
+}

--- a/internal/usecase/presenter/DeuceToSevenPresenter_mock.go
+++ b/internal/usecase/presenter/DeuceToSevenPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockDeuceToSevenPresenter is the testify/mock presenter for 2-7 Triple Draw.
-type MockDeuceToSevenPresenter = MockGamePresenter[interfaces.DeuceToSevenGame]
+type MockDeuceToSevenPresenter struct {
+	MockGamePresenter[interfaces.DeuceToSevenGame]
+}
+
+// HintOutput mock.
+func (_m *MockDeuceToSevenPresenter) HintOutput(g interfaces.DeuceToSevenGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## Summary
- Add a domain `SuggestExchange(playerIdx)` that returns the recommended exchange indices, or `nil` for a made pat low. Pat detection is a new `deuceToSevenIsPatLow` check (5 distinct ranks ≤ 8, no straight, no flush); otherwise it reuses the existing `deuceToSevenDiscardIndices` heuristic.
- `DeuceToSevenCuiPresenter.HintOutput` recommends the exchange (showing indices + cards) or standing pat, during the human's draw phase only.
- Wire `h`/`hint` end-to-end: promote `DeuceToSevenPresenter` from a `GamePresenter` alias to an interface with `HintOutput` (both CUI and Web presenters implement it — Web delegates to `Output` since web hints are computed client-side), add `DeuceToSevenInteractor.Hint()` + IF method, register the command in `DeuceToSevenCuiController` and the CUI help spec, and extend the game/presenter/interactor mocks.
- Add ja/en `hint*` + `helpHint` translations.

## Test plan
- `DeuceToSevenSuggest_test.go` — out-of-range guard, pat low → nil, flush not pat, weak hand → non-empty discards.
- `DeuceToSevenCuiPresenter_test.go` — exchange recommendation, stand-pat, wrong-phase and not-your-turn guards.
- `DeuceToSevenCuiController_test.go` — `h`/`hint` routes to `Hint()`; `DeuceToSevenInteractor_test.go` — `Hint()` delegates; `DeuceToSevenWebPresenter_test.go` — `HintOutput` mirrors `Output`.
- `go test -tags test ./internal/...`, `golangci-lint`, server build, and the casino WASM worker build all pass.

Closes #3178