### PR TITLE
fix(doubleklondike): localize hint zone names in the CUI

### DIFF
--- a/internal/adapter/presenter/DoubleKlondikeCuiPresenter.go
+++ b/internal/adapter/presenter/DoubleKlondikeCuiPresenter.go
@@ -74,6 +74,22 @@ func (p *DoubleKlondikeCuiPresenter) Output(g interfaces.DoubleKlondikeGame, las
 	})
 }
 
+// doubleKlondikeZoneName localises a hint zone identifier (waste / tableau /
+// foundation). Unknown identifiers fall back to the raw string so the hint never
+// panics or renders empty.
+func doubleKlondikeZoneName(zone string) string {
+	switch zone {
+	case "waste":
+		return i18n.T("doubleklondike.zoneWaste")
+	case "tableau":
+		return i18n.T("doubleklondike.zoneTableau")
+	case "foundation":
+		return i18n.T("doubleklondike.zoneFoundation")
+	default:
+		return zone
+	}
+}
+
 // HintOutput emits the current hint.
 func (p *DoubleKlondikeCuiPresenter) HintOutput(g interfaces.DoubleKlondikeGame) string {
 	hint := g.GetHint()
@@ -81,9 +97,9 @@ func (p *DoubleKlondikeCuiPresenter) HintOutput(g interfaces.DoubleKlondikeGame)
 		return i18n.T("cuiHintNone") + "\n"
 	}
 	return color.Yellow(i18n.Tf("doubleklondike.hintLine",
-		"from", hint.FromZone,
+		"from", doubleKlondikeZoneName(hint.FromZone),
 		"fromCol", strconv.Itoa(hint.FromCol),
-		"to", hint.ToZone,
+		"to", doubleKlondikeZoneName(hint.ToZone),
 		"toCol", strconv.Itoa(hint.ToCol))) + "\n"
 }
 

--- a/internal/adapter/presenter/DoubleKlondikeCuiPresenter_test.go
+++ b/internal/adapter/presenter/DoubleKlondikeCuiPresenter_test.go
@@ -47,7 +47,13 @@ func TestDoubleKlondikeCuiPresenter_Output(t *testing.T) {
 	t.Run("hint output", func(t *testing.T) {
 		// Waste holds an Ace -> foundation hint.
 		js := `{"wa":[{"d":1,"v":1,"w":true}],"ph":0}`
-		assert.Contains(t, p.HintOutput(dkState(t, js)), "HINT")
+		out := p.HintOutput(dkState(t, js))
+		assert.Contains(t, out, "HINT")
+		// Zone identifiers are localised (ja), not raw "waste"/"foundation".
+		assert.Contains(t, out, "ウェイスト")
+		assert.Contains(t, out, "ファウンデーション")
+		assert.NotContains(t, out, "waste")
+		assert.NotContains(t, out, "foundation")
 		assert.NotEmpty(t, p.HintOutput(dkState(t, `{"ph":2}`)))
 	})
 

--- a/internal/adapter/presenter/DoubleKlondikeZone_internal_test.go
+++ b/internal/adapter/presenter/DoubleKlondikeZone_internal_test.go
@@ -1,0 +1,23 @@
+//go:build test
+
+package presenter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
+)
+
+func TestDoubleKlondikeZoneName(t *testing.T) {
+	i18n.SetLang("en")
+	defer i18n.SetLang("ja")
+
+	assert.Equal(t, "Waste", doubleKlondikeZoneName("waste"))
+	assert.Equal(t, "Tableau", doubleKlondikeZoneName("tableau"))
+	assert.Equal(t, "Foundation", doubleKlondikeZoneName("foundation"))
+	// Unknown identifiers fall back to the raw string without panicking.
+	assert.Equal(t, "stock", doubleKlondikeZoneName("stock"))
+	assert.Equal(t, "", doubleKlondikeZoneName(""))
+}

--- a/internal/i18n/locales/en/doubleklondike.json
+++ b/internal/i18n/locales/en/doubleklondike.json
@@ -9,5 +9,8 @@
   "stockLine": "Stock: {{stock}}  Waste: {{waste}}",
   "foundationLabel": "Foundation {{idx}}:",
   "tableauLabel": "Col {{idx}}:",
-  "hintLine": "[HINT: {{from}}{{fromCol}} -> {{to}}{{toCol}}]"
+  "hintLine": "[HINT: {{from}}{{fromCol}} -> {{to}}{{toCol}}]",
+  "zoneWaste": "Waste",
+  "zoneTableau": "Tableau",
+  "zoneFoundation": "Foundation"
 }

--- a/internal/i18n/locales/ja/doubleklondike.json
+++ b/internal/i18n/locales/ja/doubleklondike.json
@@ -9,5 +9,8 @@
   "stockLine": "ストック: {{stock}}  ウェイスト: {{waste}}",
   "foundationLabel": "組札{{idx}}:",
   "tableauLabel": "列{{idx}}:",
-  "hintLine": "[HINT: {{from}}{{fromCol}} → {{to}}{{toCol}}]"
+  "hintLine": "[HINT: {{from}}{{fromCol}} → {{to}}{{toCol}}]",
+  "zoneWaste": "ウェイスト",
+  "zoneTableau": "タブロー",
+  "zoneFoundation": "ファウンデーション"
 }


### PR DESCRIPTION
## Summary
- `DoubleKlondikeCuiPresenter.HintOutput` embedded the raw domain zone identifiers (`waste` / `tableau` / `foundation`) directly into the hint line, so `--lang ja` rendered English tokens mixed into an otherwise-localized line.
- Add a `doubleKlondikeZoneName` helper that maps each identifier to a localized label via i18n, using it for both the `from` and `to` zones. Unknown identifiers fall back to the raw string (no panic).
- Add ja/en `zoneWaste` / `zoneTableau` / `zoneFoundation` translations (ja uses the game's established ウェイスト / タブロー / ファウンデーション terms).

## Test plan
- `DoubleKlondikeZone_internal_test.go` — every zone maps correctly and unknown/empty identifiers fall back without panic.
- `DoubleKlondikeCuiPresenter_test.go` — the waste→foundation hint now renders localized zone names and no longer contains raw `waste`/`foundation`.
- `go test -tags test ./internal/...`, `golangci-lint`, and the classic WASM worker build all pass.

Closes #3585