### PR TITLE
feat(montecarlo): include card faces in the CUI remove hint

### DIFF
--- a/internal/adapter/presenter/MonteCarloCuiPresenter.go
+++ b/internal/adapter/presenter/MonteCarloCuiPresenter.go
@@ -68,11 +68,29 @@ func (pr *MonteCarloCuiPresenter) HintOutput(g interfaces.MonteCarloGame) string
 	if hint.Action == domain.MonteCarloHintActionDeal {
 		return i18n.T("montecarlo.hintLineDeal") + "\n"
 	}
+	board := g.GetBoard()
+	c1 := monteCarloBoardCard(board, hint.FromR, hint.FromC)
+	c2 := monteCarloBoardCard(board, hint.ToR, hint.ToC)
+	if c1 != nil && c2 != nil {
+		return i18n.Tf("montecarlo.hintLineRemoveCard",
+			"r1", strconv.Itoa(hint.FromR), "c1", strconv.Itoa(hint.FromC), "card1", cuiCardStr(c1),
+			"r2", strconv.Itoa(hint.ToR), "c2", strconv.Itoa(hint.ToC), "card2", cuiCardStr(c2)) + "\n"
+	}
+	// Fallback: coordinates only if a board cell is unreadable (nil-guard).
 	return i18n.Tf("montecarlo.hintLineRemove",
 		"r1", strconv.Itoa(hint.FromR),
 		"c1", strconv.Itoa(hint.FromC),
 		"r2", strconv.Itoa(hint.ToR),
 		"c2", strconv.Itoa(hint.ToC)) + "\n"
+}
+
+// monteCarloBoardCard safely reads a board cell, returning nil for out-of-range
+// coordinates so the hint never panics.
+func monteCarloBoardCard(board [domain.MonteCarloGridSize][domain.MonteCarloGridSize]*domain.Card, r, c int) *domain.Card {
+	if r < 0 || r >= domain.MonteCarloGridSize || c < 0 || c >= domain.MonteCarloGridSize {
+		return nil
+	}
+	return board[r][c]
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/MonteCarloCuiPresenter_test.go
+++ b/internal/adapter/presenter/MonteCarloCuiPresenter_test.go
@@ -87,16 +87,36 @@ func TestMonteCarloCuiPresenter_Output(t *testing.T) {
 }
 
 func TestMonteCarloCuiPresenter_HintOutput(t *testing.T) {
-	t.Run("with remove hint", func(t *testing.T) {
+	t.Run("with remove hint includes both card faces", func(t *testing.T) {
 		g := new(interfaces.MockMonteCarloGame)
 		g.On("Hint").Return(&domain.MonteCarloHint{
 			Action: domain.MonteCarloHintActionRemove,
 			FromR:  0, FromC: 1, ToR: 1, ToC: 2,
 		})
+		var board [domain.MonteCarloGridSize][domain.MonteCarloGridSize]*domain.Card
+		board[0][1] = domain.NewCard(domain.CardDesignSpade, 7, false)
+		board[1][2] = domain.NewCard(domain.CardDesignHeart, 7, false)
+		g.On("GetBoard").Return(board)
 
 		p := new(MonteCarloCuiPresenter)
 		result := p.HintOutput(g)
-		assert.Contains(t, result, "ヒント")
+		assert.Contains(t, result, "(0,1)")
+		assert.Contains(t, result, "(1,2)")
+		assert.Contains(t, result, cuiCardStr(board[0][1]))
+		assert.Contains(t, result, cuiCardStr(board[1][2]))
+	})
+
+	t.Run("with remove hint falls back to coordinates when a cell is empty", func(t *testing.T) {
+		g := new(interfaces.MockMonteCarloGame)
+		g.On("Hint").Return(&domain.MonteCarloHint{
+			Action: domain.MonteCarloHintActionRemove,
+			FromR:  0, FromC: 1, ToR: 1, ToC: 2,
+		})
+		var board [domain.MonteCarloGridSize][domain.MonteCarloGridSize]*domain.Card // all nil
+		g.On("GetBoard").Return(board)
+
+		p := new(MonteCarloCuiPresenter)
+		result := p.HintOutput(g)
 		assert.Contains(t, result, "(0,1)")
 		assert.Contains(t, result, "(1,2)")
 	})

--- a/internal/i18n/locales/en/montecarlo.json
+++ b/internal/i18n/locales/en/montecarlo.json
@@ -16,5 +16,6 @@
   "cellCard": "({{r}},{{c}}) {{card}}",
   "header": "Stock: {{stock}}  Removed: {{removed}}/52  Deals: {{deals}}",
   "hintLineRemove": "Hint: remove ({{r1}},{{c1}}) and ({{r2}},{{c2}})",
+  "hintLineRemoveCard": "Hint: remove ({{r1}},{{c1}}){{card1}} and ({{r2}},{{c2}}){{card2}}",
   "hintLineDeal": "Hint: deal from stock"
 }

--- a/internal/i18n/locales/ja/montecarlo.json
+++ b/internal/i18n/locales/ja/montecarlo.json
@@ -16,5 +16,6 @@
   "cellCard": "({{r}},{{c}}) {{card}}",
   "header": "残り山札: {{stock}}  取り除いた枚数: {{removed}}/52  補充回数: {{deals}}",
   "hintLineRemove": "ヒント: ({{r1}},{{c1}}) と ({{r2}},{{c2}}) を取り除く",
+  "hintLineRemoveCard": "ヒント: ({{r1}},{{c1}}){{card1}} と ({{r2}},{{c2}}){{card2}} を取り除く",
   "hintLineDeal": "ヒント: 山札から補充 (deal)"
 }


### PR DESCRIPTION
## Summary
- The Monte Carlo remove hint printed only board coordinates (`remove (0,1) and (1,2)`), forcing the player to cross-reference the 5×5 grid.
- Look up both cards via `GetBoard()` and render them with `cuiCardStr` through a new `hintLineRemoveCard` i18n key, e.g. `remove (0,1)♠7 and (1,2)♥7`.
- A nil-guarded board accessor (`monteCarloBoardCard`) falls back to the original coordinate-only line when a cell is unreadable, so the hint never panics.

## Test plan
- `MonteCarloCuiPresenter_test.go` — the remove hint now includes both card faces; a nil-board case falls back to coordinates without panic.
- `go test -tags test ./internal/...`, `golangci-lint`, and the solo WASM worker build all pass.

Closes #3249