### PR TITLE
feat(ombre): format bid-phase hints as an action recommendation

### DIFF
--- a/internal/adapter/presenter/OmbreCuiPresenter.go
+++ b/internal/adapter/presenter/OmbreCuiPresenter.go
@@ -161,9 +161,24 @@ func (p *OmbreCuiPresenter) HintOutput(g interfaces.OmbreGame) string {
 			"cards", strings.Join(cards, ", "),
 			"reason", reason)) + "\n"
 	}
+	// Bid-phase decisions carry no cards; render them as an action recommendation
+	// instead of the meaningless "recommended cards: -" line.
+	if actionKey, ok := ombreBidActionKeys[hint.Reason]; ok {
+		return color.Yellow(i18n.Tf("ombre.hintDecision",
+			"action", i18n.T(actionKey),
+			"reason", reason)) + "\n"
+	}
 	return color.Yellow(i18n.Tf("ombre.hintCard",
 		"cards", "-",
 		"reason", reason)) + "\n"
+}
+
+// ombreBidActionKeys maps bid-phase hint-reason identifiers to the i18n key for
+// the recommended action name (Entrar / Solo / Pass).
+var ombreBidActionKeys = map[string]string{
+	"bid_entrar": "ombre.hintActionEntrar",
+	"bid_solo":   "ombre.hintActionSolo",
+	"bid_pass":   "ombre.hintActionPass",
 }
 
 // ombreHintReasonKeys maps Ombre-specific hint-reason identifiers to i18n keys.

--- a/internal/adapter/presenter/OmbreCuiPresenter_test.go
+++ b/internal/adapter/presenter/OmbreCuiPresenter_test.go
@@ -130,11 +130,21 @@ func TestOmbreCuiPresenter_HintOutput(t *testing.T) {
 		assert.NotEmpty(t, result)
 	})
 
-	t.Run("hint no card indices", func(t *testing.T) {
+	t.Run("bid decision hint shows the action, not an empty card list", func(t *testing.T) {
 		m, _ := setupOmbreCuiMockWithPlayers()
 		m.On("GetHint").Return(&domain.OmbreHint{CardIndices: nil, Reason: "bid_solo"})
 		result := p.HintOutput(m)
-		assert.NotEmpty(t, result)
+		assert.Contains(t, result, "ソロ")  // recommended action name
+		assert.Contains(t, result, "を推奨") // hintDecision format
+		assert.NotContains(t, result, "HINT: -")
+	})
+
+	t.Run("non-bid empty-card hint falls back to the card line", func(t *testing.T) {
+		m, _ := setupOmbreCuiMockWithPlayers()
+		m.On("GetHint").Return(&domain.OmbreHint{CardIndices: nil, Reason: "discard_low"})
+		result := p.HintOutput(m)
+		assert.Contains(t, result, "-") // hintCard fallback keeps the placeholder
+		assert.NotContains(t, result, "を推奨")
 	})
 }
 

--- a/internal/i18n/locales/en/ombre.json
+++ b/internal/i18n/locales/en/ombre.json
@@ -40,5 +40,9 @@
   "hintReasonDiscardLow": "Cannot follow suit — discard a low card",
   "hintReasonBidEntrar": "Solid hand — declare entrar",
   "hintReasonBidSolo": "Very strong hand — declare solo",
-  "hintReasonBidPass": "Weak hand — pass"
+  "hintReasonBidPass": "Weak hand — pass",
+  "hintDecision": "[HINT: recommend {{action}} ({{reason}})]",
+  "hintActionEntrar": "Entrar",
+  "hintActionSolo": "Solo",
+  "hintActionPass": "Pass"
 }

--- a/internal/i18n/locales/ja/ombre.json
+++ b/internal/i18n/locales/ja/ombre.json
@@ -40,5 +40,9 @@
   "hintReasonDiscardLow": "フォローできないので低い札を捨てる",
   "hintReasonBidEntrar": "手堅い手なのでエントラールを宣言",
   "hintReasonBidSolo": "非常に強い手なのでソロを宣言",
-  "hintReasonBidPass": "弱い手なのでパスする"
+  "hintReasonBidPass": "弱い手なのでパスする",
+  "hintDecision": "[HINT: {{action}} を推奨 ({{reason}})]",
+  "hintActionEntrar": "エントラール",
+  "hintActionSolo": "ソロ",
+  "hintActionPass": "パス"
 }


### PR DESCRIPTION
## Summary
- Bid-decision hints (`bid_entrar` / `bid_solo` / `bid_pass`) carry no cards, so `HintOutput` rendered a meaningless `[HINT: - (...)]` line.
- Map each bid reason to its action name (Entrar / Solo / Pass) and render it via a new `ombre.hintDecision` format (`[HINT: recommend Solo (…)]`), matching the established AllFours `hintDecision` pattern. Play-phase card hints are unchanged (non-bid empty-card reasons still fall back to the card line).
- Add ja/en `hintDecision` + `hintAction*` keys.

## Test plan
- `OmbreCuiPresenter_test.go` — a `bid_solo` hint shows the action name and the decision format (no empty `HINT: -`); a non-bid empty-card hint (`discard_low`) still uses the card line.
- `go test -tags test ./internal/...`, `golangci-lint`, and the extra WASM worker build all pass.

Closes #3612