### PR TITLE
fix(omaha): localize player names in CPU action lines

### DIFF
--- a/internal/adapter/presenter/OmahaCuiPresenter.go
+++ b/internal/adapter/presenter/OmahaCuiPresenter.go
@@ -110,7 +110,7 @@ func (p *OmahaCuiPresenter) Output(o interfaces.OmahaGame, lastErr error) string
 			b.WriteString("----------\n")
 			b.WriteString(color.Bold(i18n.T("omaha.cpuActionsHeader")) + "\n")
 			for _, action := range cpuActions {
-				b.WriteString(i18n.Tf("omaha.cpuActionLine", "idx", strconv.Itoa(action.PlayerIdx), "action", cuiBettingActionName(action.Action)))
+				b.WriteString(i18n.Tf("omaha.cpuActionLine", "name", cuiPlayerName(o.GetPlayer(action.PlayerIdx), action.PlayerIdx), "action", cuiBettingActionName(action.Action)))
 				if action.Amount > 0 {
 					b.WriteString(i18n.Tf("omaha.cpuActionAmount", "amount", strconv.Itoa(action.Amount)))
 				}

--- a/internal/adapter/presenter/OmahaCuiPresenter_test.go
+++ b/internal/adapter/presenter/OmahaCuiPresenter_test.go
@@ -163,8 +163,10 @@ func TestOmahaCuiPresenter_Output(t *testing.T) {
 
 		result := p.Output(h, nil)
 		assert.Contains(t, result, "[CPU行動]")
-		assert.Contains(t, result, "Player 1: コール")
-		assert.Contains(t, result, "Player 2: レイズ")
+		// CPU action lines use the localized player name, matching the result section.
+		assert.Contains(t, result, "CPU 1: コール")
+		assert.Contains(t, result, "CPU 2: レイズ")
+		assert.NotContains(t, result, "Player 1:")
 		assert.Contains(t, result, "(30)")
 	})
 

--- a/internal/i18n/locales/en/omaha.json
+++ b/internal/i18n/locales/en/omaha.json
@@ -27,7 +27,7 @@
   "playerBet": " bet:{{bet}}",
   "humanHand": "  hand: {{cards}}",
   "cpuActionsHeader": "[CPU actions]",
-  "cpuActionLine": "  Player {{idx}}: {{action}}",
+  "cpuActionLine": "  {{name}}: {{action}}",
   "cpuActionAmount": " ({{amount}})",
   "resultsHeader": "[Results]",
   "resultMucked": "  {{name}}: muck",

--- a/internal/i18n/locales/ja/omaha.json
+++ b/internal/i18n/locales/ja/omaha.json
@@ -27,7 +27,7 @@
   "playerBet": " ベット:{{bet}}",
   "humanHand": "  手札: {{cards}}",
   "cpuActionsHeader": "[CPU行動]",
-  "cpuActionLine": "  Player {{idx}}: {{action}}",
+  "cpuActionLine": "  {{name}}: {{action}}",
   "cpuActionAmount": " ({{amount}})",
   "resultsHeader": "[結果]",
   "resultMucked": "  {{name}}: マック",


### PR DESCRIPTION
## Summary
- The CPU action lines embedded the raw player index (`Player 2: ...`) while the result section used `cuiPlayerName`, so a single screen mixed `CPU 2` with index notation.
- Render the CPU action line through `cuiPlayerName(o.GetPlayer(action.PlayerIdx), action.PlayerIdx)` so it matches the result section. Big O shares this presenter and benefits too. The `omaha.cpuActionLine` key drops the `Player {{idx}}` prefix in favour of `{{name}}`.
- Out of scope (noted in the issue): holdem/shortdeck/pineapple have the same pattern.

## Test plan
- `OmahaCuiPresenter_test.go` — CPU action lines now read `CPU 1: …` / `CPU 2: …` and no longer contain `Player 1:`.
- `go test -tags test ./internal/...`, `golangci-lint`, and the casino WASM worker build all pass.

Closes #3009