### PR TITLE
feat(handandfoot): add meld-candidate hint command to the CUI

### DIFF
--- a/internal/adapter/controller/HandAndFootCuiController.go
+++ b/internal/adapter/controller/HandAndFootCuiController.go
@@ -16,6 +16,7 @@ var handAndFootNoArgCommands = cuiutil.NewCommandMap[usecase.HandAndFootInteract
 	Add(usecase.HandAndFootInteractorIF.SkipMeld, "sm", "skipmeld").
 	Add(usecase.HandAndFootInteractorIF.GoOut, "go", "goout").
 	Add(usecase.HandAndFootInteractorIF.NextRound, "nr", "nextround").
+	Add(usecase.HandAndFootInteractorIF.Hint, "h", "hint").
 	Add(usecase.HandAndFootInteractorIF.ActionLog, "log", "l")
 
 // handAndFootArgfulCommands lists alias names for argful commands handled in the

--- a/internal/adapter/controller/HandAndFootCuiController_test.go
+++ b/internal/adapter/controller/HandAndFootCuiController_test.go
@@ -28,6 +28,7 @@ func TestHandAndFootCuiController_Exec(t *testing.T) {
 		m.On("GoOut").Return(mockOutput)
 		m.On("NextRound").Return(mockOutput)
 		m.On("ActionLog").Return(mockOutput)
+		m.On("Hint").Return(mockOutput)
 		return m
 	}
 
@@ -49,6 +50,14 @@ func TestHandAndFootCuiController_Exec(t *testing.T) {
 		c := controller.NewHandAndFootCuiController(m)
 		assert.Equal(t, mockOutput, c.Exec("ds"))
 		m.AssertCalled(t, "DrawFromStock")
+	})
+
+	t.Run("hint h", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewHandAndFootCuiController(m)
+		assert.Equal(t, mockOutput, c.Exec("h"))
+		assert.Equal(t, mockOutput, c.Exec("hint"))
+		m.AssertCalled(t, "Hint")
 	})
 
 	t.Run("drawdiscard dd with indices", func(t *testing.T) {

--- a/internal/adapter/controller/usecase/HandAndFootInteractor_mock.go
+++ b/internal/adapter/controller/usecase/HandAndFootInteractor_mock.go
@@ -53,6 +53,10 @@ func (_m *MockHandAndFootInteractor) GetConfig() domain.HandAndFootConfig {
 	return _m.Called().Get(0).(domain.HandAndFootConfig)
 }
 
+func (_m *MockHandAndFootInteractor) Hint() string {
+	return _m.Called().String(0)
+}
+
 func (_m *MockHandAndFootInteractor) ActionLog() string {
 	return _m.Called().String(0)
 }

--- a/internal/adapter/presenter/HandAndFootCuiPresenter.go
+++ b/internal/adapter/presenter/HandAndFootCuiPresenter.go
@@ -133,6 +133,27 @@ func (p *HandAndFootCuiPresenter) Output(g interfaces.HandAndFootGame, lastErr e
 	})
 }
 
+// HintOutput lists the meld groups the human can currently form, reusing the
+// shared domain suggestion logic. Returns a "no meld" message when none exist.
+func (p *HandAndFootCuiPresenter) HintOutput(g interfaces.HandAndFootGame) string {
+	if !g.IsHumanTurn() {
+		return i18n.T("handandfoot.hintNotYourTurn") + "\n"
+	}
+	melds := g.SuggestMelds(g.GetCurrentPlayerIdx())
+	if len(melds) == 0 {
+		return i18n.T("handandfoot.hintNone") + "\n"
+	}
+	parts := make([]string, len(melds))
+	for i, group := range melds {
+		cards := make([]string, len(group))
+		for j, c := range group {
+			cards[j] = cuiCardStr(c)
+		}
+		parts[i] = "[" + strings.Join(cards, " ") + "]"
+	}
+	return color.Yellow(i18n.Tf("handandfoot.hintMeld", "melds", strings.Join(parts, ", "))) + "\n"
+}
+
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *HandAndFootCuiPresenter) ActionLogOutput(g interfaces.HandAndFootGame) string {
 	return actionLogOutputText(g)

--- a/internal/adapter/presenter/HandAndFootCuiPresenter_test.go
+++ b/internal/adapter/presenter/HandAndFootCuiPresenter_test.go
@@ -156,6 +156,43 @@ func TestHandAndFootCuiPresenter_Output(t *testing.T) {
 	})
 }
 
+func TestHandAndFootCuiPresenter_HintOutput(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(orig)
+	p := new(presenter.HandAndFootCuiPresenter)
+
+	t.Run("lists meld candidates", func(t *testing.T) {
+		m := new(interfaces.MockHandAndFootGame)
+		m.On("IsHumanTurn").Return(true)
+		m.On("GetCurrentPlayerIdx").Return(0)
+		m.On("SuggestMelds", 0).Return([][]*domain.Card{
+			{
+				domain.NewCard(domain.CardDesignSpade, 7, false),
+				domain.NewCard(domain.CardDesignHeart, 7, false),
+				domain.NewCard(domain.CardDesignClover, 7, false),
+			},
+		})
+		result := p.HintOutput(m)
+		assert.Contains(t, result, "メルド候補")
+		assert.Contains(t, result, "7")
+	})
+
+	t.Run("no meld available", func(t *testing.T) {
+		m := new(interfaces.MockHandAndFootGame)
+		m.On("IsHumanTurn").Return(true)
+		m.On("GetCurrentPlayerIdx").Return(0)
+		m.On("SuggestMelds", 0).Return(([][]*domain.Card)(nil))
+		assert.Contains(t, p.HintOutput(m), "出せるメルドはありません")
+	})
+
+	t.Run("not the human's turn", func(t *testing.T) {
+		m := new(interfaces.MockHandAndFootGame)
+		m.On("IsHumanTurn").Return(false)
+		assert.Contains(t, p.HintOutput(m), "あなたの番ではありません")
+	})
+}
+
 func TestHandAndFootCuiPresenter_ActionLogOutput(t *testing.T) {
 	p := new(presenter.HandAndFootCuiPresenter)
 

--- a/internal/adapter/presenter/HandAndFootWebPresenter.go
+++ b/internal/adapter/presenter/HandAndFootWebPresenter.go
@@ -126,3 +126,9 @@ func (p *HandAndFootWebPresenter) buildMessage(g interfaces.HandAndFootGame, las
 func (p *HandAndFootWebPresenter) ActionLogOutput(g interfaces.HandAndFootGame) string {
 	return actionLogOutputJSON(g)
 }
+
+// HintOutput ヒントを出力する。Web ではヒントはクライアント側 (useGameHint) で
+// 算出するため、通常の状態出力を返す。HandAndFootPresenter インタフェースを満たすための実装。
+func (p *HandAndFootWebPresenter) HintOutput(g interfaces.HandAndFootGame) string {
+	return p.Output(g, nil)
+}

--- a/internal/adapter/presenter/HandAndFootWebPresenter_test.go
+++ b/internal/adapter/presenter/HandAndFootWebPresenter_test.go
@@ -230,3 +230,10 @@ func TestHandAndFootWebPresenter_ActionLogOutput(t *testing.T) {
 		m.AssertExpectations(t)
 	})
 }
+
+func TestHandAndFootWebPresenter_HintOutput(t *testing.T) {
+	// Web hints are client-side, so HintOutput mirrors Output.
+	p := new(presenter.HandAndFootWebPresenter)
+	m, _ := setupHandAndFootWebMockWithPlayers()
+	assert.Equal(t, p.Output(m, nil), p.HintOutput(m))
+}

--- a/internal/domain/HandAndFoot.go
+++ b/internal/domain/HandAndFoot.go
@@ -848,6 +848,17 @@ func (g *HandAndFoot) cpuFindNaturalPair(player *HandAndFootPlayer, topCard *Car
 }
 
 // cpuFindMelds CPUのメルド候補を見つける
+// SuggestMelds は playerIdx がいま作れるメルド候補 (同ランク 3 枚以上、ワイルド補完込み・
+// 既存チームメルドへの追加を含む) をカード群のリストで返す。無ければ nil。CUI ヒント用に
+// cpuFindMelds を公開する薄いラッパー。
+func (g *HandAndFoot) SuggestMelds(playerIdx int) [][]*Card {
+	player := g.GetPlayer(playerIdx)
+	if player == nil {
+		return nil
+	}
+	return g.cpuFindMelds(player, HandAndFootTeamOf(playerIdx))
+}
+
 func (g *HandAndFoot) cpuFindMelds(player *HandAndFootPlayer, team int) [][]*Card {
 	var melds [][]*Card
 

--- a/internal/domain/HandAndFootSuggest_test.go
+++ b/internal/domain/HandAndFootSuggest_test.go
@@ -1,0 +1,26 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandAndFoot_SuggestMelds(t *testing.T) {
+	g := NewDefaultHandAndFoot()
+	g.Reset()
+
+	t.Run("out-of-range index returns nil", func(t *testing.T) {
+		assert.Nil(t, g.SuggestMelds(-1))
+		assert.Nil(t, g.SuggestMelds(999))
+	})
+
+	t.Run("finds a meld from a guaranteed triple", func(t *testing.T) {
+		p := g.GetPlayer(0)
+		p.AddCard(NewCard(CardDesignSpade, 7, false))
+		p.AddCard(NewCard(CardDesignHeart, 7, false))
+		p.AddCard(NewCard(CardDesignClover, 7, false))
+		melds := g.SuggestMelds(0)
+		assert.NotEmpty(t, melds)
+	})
+}

--- a/internal/domain/interfaces/handandfoot.go
+++ b/internal/domain/interfaces/handandfoot.go
@@ -17,6 +17,8 @@ type HandAndFootGame interface {
 	PlayerDrawFromDiscard(naturalPairIndices []int) error
 	// PlayerMeld プレイヤーがメルドを出す
 	PlayerMeld(meldGroups [][]int) error
+	// SuggestMelds playerIdx が作れるメルド候補 (カード群) を返す。無ければ nil
+	SuggestMelds(playerIdx int) [][]*domain.Card
 	// PlayerSkipMeld メルドフェーズをスキップする
 	PlayerSkipMeld() error
 	// PlayerDiscard プレイヤーがカードを捨てる

--- a/internal/domain/interfaces/handandfoot_mock.go
+++ b/internal/domain/interfaces/handandfoot_mock.go
@@ -24,6 +24,13 @@ func (m *MockHandAndFootGame) PlayerDrawFromDiscard(naturalPairIndices []int) er
 func (m *MockHandAndFootGame) PlayerMeld(meldGroups [][]int) error {
 	return m.Called(meldGroups).Error(0)
 }
+func (m *MockHandAndFootGame) SuggestMelds(playerIdx int) [][]*domain.Card {
+	ret := m.Called(playerIdx)
+	if v := ret.Get(0); v != nil {
+		return v.([][]*domain.Card)
+	}
+	return nil
+}
 func (m *MockHandAndFootGame) PlayerSkipMeld() error { return m.Called().Error(0) }
 func (m *MockHandAndFootGame) PlayerDiscard(cardIndex int) error {
 	return m.Called(cardIndex).Error(0)

--- a/internal/i18n/locales/en/handandfoot.json
+++ b/internal/i18n/locales/en/handandfoot.json
@@ -7,6 +7,7 @@
   "helpDiscard": "  d <idx>              discard a card",
   "helpGoOut": "  go                   go out (in foot + required canastas)",
   "helpNextRound": "  nr                   next round",
+  "helpHint": "  h | hint             show meld candidates you can play",
   "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
   "helpSetLimit": "  sl <n>               point limit",
   "header": "Round: {{round}}  Stock: {{stock}}  Discard: {{discard}}",
@@ -37,5 +38,8 @@
   "discardPhase": "Discard phase.",
   "roundEnd": "The round has ended.",
   "result.humanWin": "Game over! Your team wins!",
-  "result.cpuWin": "Game over! The CPU team wins!"
+  "result.cpuWin": "Game over! The CPU team wins!",
+  "hintMeld": "[HINT: meld candidates {{melds}}]",
+  "hintNone": "No melds can be played right now.",
+  "hintNotYourTurn": "It is not your turn right now."
 }

--- a/internal/i18n/locales/ja/handandfoot.json
+++ b/internal/i18n/locales/ja/handandfoot.json
@@ -7,6 +7,7 @@
   "helpDiscard": "  d <idx>              カードを捨てる",
   "helpGoOut": "  go                   上がる (フット取り込み＋必要カナスタ)",
   "helpNextRound": "  nr                   次のラウンドへ",
+  "helpHint": "  h | hint             出せるメルド候補を表示",
   "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)",
   "helpSetLimit": "  sl <n>               ポイント上限",
   "header": "ラウンド: {{round}}  山札: {{stock}}枚  廃棄山: {{discard}}枚",
@@ -37,5 +38,8 @@
   "discardPhase": "ディスカードフェーズです。",
   "roundEnd": "ラウンドが終了しました。",
   "result.humanWin": "ゲーム終了！ あなたのチームの勝ち！",
-  "result.cpuWin": "ゲーム終了！ CPUチームの勝ち！"
+  "result.cpuWin": "ゲーム終了！ CPUチームの勝ち！",
+  "hintMeld": "[HINT: メルド候補 {{melds}}]",
+  "hintNone": "いま出せるメルドはありません。",
+  "hintNotYourTurn": "今はあなたの番ではありません。"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -2651,6 +2651,7 @@ var gameRegistry = []GameRegistryEntry{
 					"handandfoot.helpDiscard",
 					"handandfoot.helpGoOut",
 					"handandfoot.helpNextRound",
+					"handandfoot.helpHint",
 				},
 				ExtraCommandLines: []string{"  l                    action log"},
 				SettingKeys: []string{

--- a/internal/usecase/HandAndFootInteractor.go
+++ b/internal/usecase/HandAndFootInteractor.go
@@ -32,6 +32,8 @@ type HandAndFootInteractorIF interface {
 	NextRound() string
 	// GetConfig 現在の設定を取得
 	GetConfig() domain.HandAndFootConfig
+	// Hint ヒント取得
+	Hint() string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
 }
@@ -151,6 +153,11 @@ func (ci *HandAndFootInteractor) NextRound() string {
 // GetConfig 現在の設定を取得
 func (ci *HandAndFootInteractor) GetConfig() domain.HandAndFootConfig {
 	return ci.Game.GetConfig()
+}
+
+// Hint ヒント取得
+func (ci *HandAndFootInteractor) Hint() string {
+	return ci.gp.HintOutput(ci.Game)
 }
 
 // ActionLog 棋譜を出力する

--- a/internal/usecase/HandAndFootInteractor_test.go
+++ b/internal/usecase/HandAndFootInteractor_test.go
@@ -32,6 +32,16 @@ func TestNewHandAndFootInteractor_NilGuards(t *testing.T) {
 	})
 }
 
+func TestHandAndFootInteractor_Hint(t *testing.T) {
+	pMock := new(presenter.MockHandAndFootPresenter)
+	gameMock := new(interfaces.MockHandAndFootGame)
+	pMock.On("HintOutput", gameMock).Return("hint output")
+
+	ci := usecase.NewHandAndFootInteractor(gameMock, pMock)
+	assert.Equal(t, "hint output", ci.Hint())
+	pMock.AssertCalled(t, "HintOutput", gameMock)
+}
+
 func TestHandAndFootInteractor_Reset(t *testing.T) {
 	mockOutput := `{"phase":0}`
 	pMock := new(presenter.MockHandAndFootPresenter)

--- a/internal/usecase/presenter/HandAndFootPresenter.go
+++ b/internal/usecase/presenter/HandAndFootPresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // HandAndFootPresenter ハンドアンドフットプレゼンタインタフェース
-type HandAndFootPresenter = GamePresenter[interfaces.HandAndFootGame]
+type HandAndFootPresenter interface {
+	GamePresenter[interfaces.HandAndFootGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.HandAndFootGame) string
+}

--- a/internal/usecase/presenter/HandAndFootPresenter_mock.go
+++ b/internal/usecase/presenter/HandAndFootPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockHandAndFootPresenter ハンドアンドフットプレゼンターモック
-type MockHandAndFootPresenter = MockGamePresenter[interfaces.HandAndFootGame]
+type MockHandAndFootPresenter struct {
+	MockGamePresenter[interfaces.HandAndFootGame]
+}
+
+// HintOutput モック
+func (_m *MockHandAndFootPresenter) HintOutput(g interfaces.HandAndFootGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## Summary
- Expose the game's existing `cpuFindMelds` as a public domain method `SuggestMelds(playerIdx)` on the `HandAndFootGame` interface.
- `HandAndFootCuiPresenter.HintOutput` lists the meld groups (same-rank 3+ with wild completion, including additions to existing team melds) the human can currently form, or a "no meld" message, on their turn.
- Wire `h`/`hint` end-to-end: promote `HandAndFootPresenter` from a `GamePresenter` alias to an interface with `HintOutput` (both CUI and Web presenters implement it — Web delegates to `Output` since web hints are computed client-side), add `HandAndFootInteractor.Hint()` + IF method, register the command in `HandAndFootCuiController` and the CUI help spec, and extend the game/presenter/interactor mocks.
- Add ja/en `hint*` + `helpHint` translations.

## Test plan
- `HandAndFootSuggest_test.go` — out-of-range guard, guaranteed-triple meld.
- `HandAndFootCuiPresenter_test.go` — meld-candidate list, no-meld message, not-your-turn guard.
- `HandAndFootCuiController_test.go` — `h`/`hint` routes to `Hint()`; `HandAndFootInteractor_test.go` — `Hint()` delegates; `HandAndFootWebPresenter_test.go` — `HintOutput` mirrors `Output`.
- `go test -tags test ./internal/...`, `golangci-lint`, and the extra WASM worker build all pass.

Closes #3471