### PR TITLE
feat(pan): enrich the play-phase help with command examples and a meld note

### DIFF
--- a/internal/adapter/presenter/PanCuiPresenter.go
+++ b/internal/adapter/presenter/PanCuiPresenter.go
@@ -86,6 +86,7 @@ func (p *PanCuiPresenter) Output(g interfaces.PanGame, lastErr error) string {
 			b.WriteString(i18n.T("pan.promptPlayHelpMeld") + "\n")
 			b.WriteString(i18n.T("pan.promptPlayHelpLayoff") + "\n")
 			b.WriteString(i18n.T("pan.promptPlayHelpDiscard") + "\n")
+			b.WriteString(i18n.T("pan.promptPlayHelpNote") + "\n")
 		case domain.PanPhaseRoundEnd:
 			b.WriteString(i18n.T("pan.promptRoundEnd") + "\n")
 			b.WriteString(i18n.T("pan.promptRoundEndHelp") + "\n")

--- a/internal/adapter/presenter/PanCuiPresenter_test.go
+++ b/internal/adapter/presenter/PanCuiPresenter_test.go
@@ -62,12 +62,16 @@ func TestPanCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "捨て札")
 	})
 
-	t.Run("play phase prompts", func(t *testing.T) {
+	t.Run("play phase prompts include command examples and a meld note", func(t *testing.T) {
 		m, _ := setupPanCuiMock()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
 		m.On("GetPhase").Return(domain.PanPhasePlay)
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "プレイフェーズ")
+		assert.Contains(t, result, "例: m 0 1 2")  // meld command format example
+		assert.Contains(t, result, "例: lo 1 0 3") // layoff command format example
+		assert.Contains(t, result, "valle")       // legal-meld / chip note
+		assert.Contains(t, result, "最低3枚")        // min meld size note
 	})
 
 	t.Run("round end shows prompt", func(t *testing.T) {

--- a/internal/i18n/locales/en/pan.json
+++ b/internal/i18n/locales/en/pan.json
@@ -18,9 +18,10 @@
   "promptDrawHelpStock": "ds: draw from stock",
   "promptDrawHelpDiscard": "dd: draw the discard top",
   "promptPlay": "{{name}} to act (play phase)",
-  "promptPlayHelpMeld": "m <idx...>: lay down a meld",
-  "promptPlayHelpLayoff": "lo <owner> <meld> <idx>: lay off a card",
-  "promptPlayHelpDiscard": "d <idx>: discard a card",
+  "promptPlayHelpMeld": "m <idx...>: lay down a meld (e.g. m 0 1 2)",
+  "promptPlayHelpLayoff": "lo <owner> <meld> <idx>: lay off a card (e.g. lo 1 0 3)",
+  "promptPlayHelpDiscard": "d <idx>: discard a card (e.g. d 4)",
+  "promptPlayHelpNote": "A meld is 3+ cards of the same rank or a same-suit run. Melds containing valle (special) cards collect chips.",
   "promptRoundEnd": "Round complete",
   "promptRoundEndHelp": "nr / nextround: advance to next round"
 }

--- a/internal/i18n/locales/ja/pan.json
+++ b/internal/i18n/locales/ja/pan.json
@@ -18,9 +18,10 @@
   "promptDrawHelpStock": "ds・・・山札から引く",
   "promptDrawHelpDiscard": "dd・・・捨て札から引く",
   "promptPlay": "手番: {{name}} (プレイフェーズ)",
-  "promptPlayHelpMeld": "m <idx...>・・・メルドを場に出す",
-  "promptPlayHelpLayoff": "lo <owner> <meld> <idx>・・・レイオフ",
-  "promptPlayHelpDiscard": "d <idx>・・・カードを捨てる",
+  "promptPlayHelpMeld": "m <idx...>・・・メルドを場に出す (例: m 0 1 2)",
+  "promptPlayHelpLayoff": "lo <owner> <meld> <idx>・・・レイオフ (例: lo 1 0 3)",
+  "promptPlayHelpDiscard": "d <idx>・・・カードを捨てる (例: d 4)",
+  "promptPlayHelpNote": "メルドは同ランクの組か同スートの連番で最低3枚。valle(特別札)を含むメルドはチップを獲得します。",
   "promptRoundEnd": "ラウンド終了",
   "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ"
 }


### PR DESCRIPTION
## Summary
- The Panguingue play-phase prompt listed the `meld` / `layoff` / `discard` commands without argument-format examples or the legal-meld requirements, so players had to infer valid melds from their hand unaided.
- Add copy-paste command examples (`m 0 1 2` / `lo 1 0 3` / `d 4`) to the three help lines and a new note line explaining a meld is 3+ cards of the same rank or a same-suit run, and that melds with valle (special) cards collect chips.

## Test plan
- `PanCuiPresenter_test.go` — the play-phase prompt now contains the command examples and the meld note (min size + valle chips).
- `go test -tags test ./internal/...`, `golangci-lint`, and the extra WASM worker build all pass.

Closes #3506