### PR TITLE
feat(blackjack): show dealer hidden-card placeholder in the CUI

### DIFF
--- a/internal/adapter/presenter/BlackJackCuiPresenter.go
+++ b/internal/adapter/presenter/BlackJackCuiPresenter.go
@@ -114,7 +114,7 @@ func (bjp *BlackJackCuiPresenter) Output(bj interfaces.BlackJackGame, lastErr er
 	} else {
 		b.WriteString("\n")
 		if dealer.GetCardsSize() > 0 {
-			fmt.Fprintf(&b, "%s,\n", cuiCardStr(dealer.GetCard(0)))
+			fmt.Fprintf(&b, "%s, %s\n", cuiCardStr(dealer.GetCard(0)), i18n.T("blackjack.hiddenCard"))
 		}
 	}
 	b.WriteString("----------\n")

--- a/internal/adapter/presenter/BlackJackCuiPresenter_test.go
+++ b/internal/adapter/presenter/BlackJackCuiPresenter_test.go
@@ -62,6 +62,10 @@ func TestBlackJackCuiPresenters_Method(t *testing.T) {
 		assert.Contains(t, output, "フェーズ: ACTION")
 		assert.Contains(t, output, "ベット=100")
 		assert.Contains(t, output, "SPADE 5")
+		// In-progress dealer shows the up-card plus a hidden-card placeholder, with no trailing comma.
+		assert.Contains(t, output, "[??]")
+		assert.Contains(t, output, "CLOVER 10, [??]")
+		assert.NotContains(t, output, "CLOVER 10,\n")
 	})
 	t.Run("success Output end phase lose", func(t *testing.T) {
 		tc := domain.NewTrumpCards(0)

--- a/internal/i18n/locales/en/blackjack.json
+++ b/internal/i18n/locales/en/blackjack.json
@@ -17,6 +17,7 @@
   "multiHandLine": "multi-hand: {{count}} hands",
   "phaseLine": "phase: {{phase}}",
   "dealerLabel": "dealer",
+  "hiddenCard": "[??]",
   "playerLabel": "player",
   "scoreSuffix": " score ",
   "handLabel": "hand {{idx}}",

--- a/internal/i18n/locales/ja/blackjack.json
+++ b/internal/i18n/locales/ja/blackjack.json
@@ -17,6 +17,7 @@
   "multiHandLine": "マルチハンド: {{count}} ハンド",
   "phaseLine": "フェーズ: {{phase}}",
   "dealerLabel": "ディーラー",
+  "hiddenCard": "[??]",
   "playerLabel": "プレイヤー",
   "scoreSuffix": " スコア ",
   "handLabel": "ハンド {{idx}}",


### PR DESCRIPTION
## 概要
CUIのブラックジャックで、ゲーム進行中のディーラー表示がアップカード1枚＋末尾カンマのみで、伏せ札の存在が分からなかった。アップカードの後に i18n 化した `[??]` 伏せ札プレースホルダを出力し、余計な末尾カンマを除去して Web版の `AnimatedCardBack` と情報量を揃えた。

## 変更点
- `BlackJackCuiPresenter.Output`: 進行中ディーラー行を `{upcard}, [??]` 形式に変更（末尾カンマ除去）
- `blackjack.hiddenCard` キーを ja/en に追加
- 進行中ディーラー表示のテストを追加（プレースホルダ表示・末尾カンマ非出力）

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #2979