### PR TITLE
feat(oldmaid): cap the CUI draw history to the latest 10 entries

### DIFF
--- a/internal/adapter/presenter/OldMaidCuiPresenter.go
+++ b/internal/adapter/presenter/OldMaidCuiPresenter.go
@@ -11,6 +11,10 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
+// oldMaidMaxDrawHistory is the maximum number of most-recent draw-history
+// entries shown in the CUI; older entries are summarized as an omitted count.
+const oldMaidMaxDrawHistory = 10
+
 // oldMaidPlayerStr returns the display string for a single OldMaid player.
 func oldMaidPlayerStr(player *domain.OldMaidPlayer, i int) string {
 	var b strings.Builder
@@ -84,11 +88,18 @@ func (p *OldMaidCuiPresenter) Output(om interfaces.OldMaidGame, lastErr error) s
 			}
 		}
 
-		// Draw history
+		// Draw history (cap to the most recent entries so a long game doesn't
+		// flood the terminal; the full log stays available via ActionLogOutput).
 		drawHistory := om.GetDrawHistory()
 		if len(drawHistory) > 0 {
 			b.WriteString(color.Bold(i18n.T("oldmaid.drawHistoryHeader")) + "\n")
-			for i, entry := range drawHistory {
+			start := 0
+			if len(drawHistory) > oldMaidMaxDrawHistory {
+				start = len(drawHistory) - oldMaidMaxDrawHistory
+				b.WriteString(i18n.Tf("oldmaid.drawHistoryOmitted", "count", strconv.Itoa(start)) + "\n")
+			}
+			for i := start; i < len(drawHistory); i++ {
+				entry := drawHistory[i]
 				drawer := cuiPlayerName(om.GetPlayer(entry.DrawPlayerIdx), entry.DrawPlayerIdx)
 				from := cuiPlayerName(om.GetPlayer(entry.DrawFromIdx), entry.DrawFromIdx)
 				b.WriteString(i18n.Tf("oldmaid.drawHistoryEntry",

--- a/internal/adapter/presenter/OldMaidCuiPresenter_test.go
+++ b/internal/adapter/presenter/OldMaidCuiPresenter_test.go
@@ -1,6 +1,7 @@
 package presenter_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
@@ -342,6 +343,36 @@ func TestOldMaidCuiPresenter_DrawHistory(t *testing.T) {
 		assert.Contains(t, result, "1. あなたがCPU 1から引いた (2組捨て) [あなた上がり]")
 		assert.Contains(t, result, "2. CPU 2がCPU 3から引いた")
 		assert.NotContains(t, result, "2. CPU 2がCPU 3から引いた (")
+	})
+
+	t.Run("exactly 10 entries shown in full without omission summary", func(t *testing.T) {
+		om, _ := setupOldMaidCuiTest()
+		om.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignSpade, 1, false))
+		entries := make([]*domain.OldMaidDrawHistoryEntry, 0, 10)
+		for range 10 {
+			entries = append(entries, &domain.OldMaidDrawHistoryEntry{DrawPlayerIdx: 0, DrawFromIdx: 1})
+		}
+		om.SetDrawHistory(entries)
+		result := top.Output(om, nil)
+		assert.Contains(t, result, "1. あなたがCPU 1から引いた")
+		assert.Contains(t, result, "10. あなたがCPU 1から引いた")
+		assert.NotContains(t, result, "…他")
+	})
+
+	t.Run("over 10 entries shows only latest 10 plus omission summary", func(t *testing.T) {
+		om, _ := setupOldMaidCuiTest()
+		om.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignSpade, 1, false))
+		entries := make([]*domain.OldMaidDrawHistoryEntry, 0, 13)
+		for range 13 {
+			entries = append(entries, &domain.OldMaidDrawHistoryEntry{DrawPlayerIdx: 0, DrawFromIdx: 1})
+		}
+		om.SetDrawHistory(entries)
+		result := top.Output(om, nil)
+		// 3 oldest entries omitted; entries 4..13 (real 1-based indices) remain.
+		assert.Contains(t, result, "…他3件（棋譜は log コマンドで参照可）")
+		assert.Equal(t, 10, strings.Count(result, "から引いた"))
+		assert.Contains(t, result, "4. あなたがCPU 1から引いた")  // first shown = real index 4
+		assert.Contains(t, result, "13. あなたがCPU 1から引いた") // last shown = real index 13
 	})
 }
 

--- a/internal/i18n/locales/en/oldmaid.json
+++ b/internal/i18n/locales/en/oldmaid.json
@@ -15,6 +15,7 @@
   "drawActionDiscard": ". Discarded {{count}} pair(s)",
   "cpuActionsHeader": "[CPU actions]",
   "drawHistoryHeader": "[Draw history]",
+  "drawHistoryOmitted": "…and {{count}} more (use the log command for the full record)",
   "drawHistoryEntry": "{{idx}}. {{drawer}} drew from {{from}}",
   "drawHistoryDiscard": " ({{count}} pair(s) discarded)",
   "drawHistoryFinished": " [{{name}} finished]",

--- a/internal/i18n/locales/ja/oldmaid.json
+++ b/internal/i18n/locales/ja/oldmaid.json
@@ -15,6 +15,7 @@
   "drawActionDiscard": "。{{count}}組捨てました",
   "cpuActionsHeader": "[CPUの行動]",
   "drawHistoryHeader": "[引き履歴]",
+  "drawHistoryOmitted": "…他{{count}}件（棋譜は log コマンドで参照可）",
   "drawHistoryEntry": "{{idx}}. {{drawer}}が{{from}}から引いた",
   "drawHistoryDiscard": " ({{count}}組捨て)",
   "drawHistoryFinished": " [{{name}}上がり]",


### PR DESCRIPTION
## 概要
ババ抜きの `OldMaidCuiPresenter.Output` は `GetDrawHistory()` を毎回全件出力しており、ジョーカーが行き来する長いゲームでは履歴が数十行になって手札とプロンプトが流れてしまっていた。直近10件のみ表示し、省略件数をサマリ行で示すようにした（全履歴は既存の `ActionLogOutput`／log コマンドで参照可能）。

## 変更点
- `oldMaidMaxDrawHistory = 10` を導入し、10件超のとき最新10件のみ描画（実インデックスは保持）
- 省略時に `oldmaid.drawHistoryOmitted`（…他N件）のサマリ行を追加（ja/en）
- 10件ちょうど＝全件表示（省略なし）／10件超＝最新10件＋サマリ の境界テストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #2985