### PR TITLE
feat(thirtyone): show per-suit score breakdown in the CUI

### DIFF
--- a/internal/adapter/presenter/ThirtyOneCuiPresenter.go
+++ b/internal/adapter/presenter/ThirtyOneCuiPresenter.go
@@ -12,6 +12,21 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
+// thirtyOneSuitSymbol maps a card design to its (locale-independent) suit symbol.
+func thirtyOneSuitSymbol(suit int) string {
+	switch suit {
+	case domain.CardDesignSpade:
+		return "♠"
+	case domain.CardDesignClover:
+		return "♣"
+	case domain.CardDesignHeart:
+		return "♥"
+	case domain.CardDesignDiamond:
+		return "♦"
+	}
+	return "?"
+}
+
 // thirtyOnePlayerStr returns the display string for a single ThirtyOne player.
 func thirtyOnePlayerStr(g interfaces.ThirtyOneGame, player *domain.ThirtyOnePlayer, i int) string {
 	var b strings.Builder
@@ -30,6 +45,15 @@ func thirtyOnePlayerStr(g interfaces.ThirtyOneGame, player *domain.ThirtyOnePlay
 		"cards", strconv.Itoa(player.GetCardsSize())) + "\n")
 	if player.GetIsHuman() && player.GetCardsSize() > 0 {
 		b.WriteString(cuiIndexedCardListStr(player) + "\n")
+		// Per-suit totals mirror the web suit-score badges so the human can see
+		// which suit to build toward 31 and which cards to discard.
+		scores := player.SuitScores()
+		b.WriteString(i18n.Tf("thirtyone.suitBreakdown",
+			"spade", strconv.Itoa(scores[domain.CardDesignSpade]),
+			"clover", strconv.Itoa(scores[domain.CardDesignClover]),
+			"heart", strconv.Itoa(scores[domain.CardDesignHeart]),
+			"diamond", strconv.Itoa(scores[domain.CardDesignDiamond]),
+			"best", thirtyOneSuitSymbol(player.BestSuit())) + "\n")
 	}
 	return b.String()
 }

--- a/internal/adapter/presenter/ThirtyOneCuiPresenter_test.go
+++ b/internal/adapter/presenter/ThirtyOneCuiPresenter_test.go
@@ -64,6 +64,15 @@ func TestThirtyOneCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, p.Output(m, nil), "あなたのベストスート合計:")
 	})
 
+	t.Run("human suit-score breakdown shown under the hand", func(t *testing.T) {
+		m, players := setupThirtyOneCuiMock()
+		// ♠A(11) + ♥5(5): best suit is spades.
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 1, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 5, false))
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "スート別: ♠11 ♣0 ♥5 ♦0（ベスト: ♠）")
+	})
+
 	t.Run("knock notice shown when someone has knocked", func(t *testing.T) {
 		m, _ := setupThirtyOneCuiMock()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetKnockerIdx")

--- a/internal/i18n/locales/en/thirtyone.json
+++ b/internal/i18n/locales/en/thirtyone.json
@@ -15,6 +15,7 @@
   "promptDrawHelpStock": "ds: draw from stock",
   "promptDrawHelpDiscard": "dd: draw from discard",
   "promptKnockHelp": "k: knock (stand on your hand)",
+  "suitBreakdown": "By suit: ♠{{spade}} ♣{{clover}} ♥{{heart}} ♦{{diamond}} (best: {{best}})",
   "yourBestSuit": "Your best-suit total: {{score}} (31 to win)",
   "knockNotice": "{{name}} knocked — this is the last turn",
   "promptDiscard": "{{name}} to act (discard phase)",

--- a/internal/i18n/locales/ja/thirtyone.json
+++ b/internal/i18n/locales/ja/thirtyone.json
@@ -15,6 +15,7 @@
   "promptDrawHelpStock": "ds: 山札から引く",
   "promptDrawHelpDiscard": "dd: 捨て札から引く",
   "promptKnockHelp": "k: ノック (引かずに勝負)",
+  "suitBreakdown": "スート別: ♠{{spade}} ♣{{clover}} ♥{{heart}} ♦{{diamond}}（ベスト: {{best}}）",
   "yourBestSuit": "あなたのベストスート合計: {{score}} (31で勝利)",
   "knockNotice": "{{name}} がノック — これが最終ターンです",
   "promptDiscard": "{{name}} の番です (ディスカードフェーズ)",


### PR DESCRIPTION
## 概要
Web版 `ThirtyOnePage.tsx` は4スートそれぞれの合計点をバッジ表示するが、`ThirtyOneCuiPresenter` は最良スートの合計点1つだけを表示しており、どのスートを伸ばすか・どれを捨てるかの判断材料が不足していた。人間手札の直下にスート別内訳行（ベストスート明示）を追加した。

## 変更点
- `thirtyOnePlayerStr`: 人間手札の下に `thirtyone.suitBreakdown`（スート別: ♠.. ♣.. ♥.. ♦..（ベスト: X））を追加
- ドメインの既存 `SuitScores()`/`BestSuit()` を利用（新規アクセサ不要、Webと同じ値）
- `thirtyOneSuitSymbol` ヘルパ、`thirtyone.suitBreakdown` キー（ja/en）を追加
- 内訳行のテストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3357