### PR TITLE
feat(tripeaks): add a playable-count summary line to the CUI

### DIFF
--- a/internal/adapter/presenter/TriPeaksCuiPresenter.go
+++ b/internal/adapter/presenter/TriPeaksCuiPresenter.go
@@ -38,6 +38,10 @@ func (pr *TriPeaksCuiPresenter) Output(t interfaces.TriPeaksGame, lastErr error)
 			wasteTop = waste[len(waste)-1]
 		}
 
+		// Count exposed tableau cards playable onto the current waste top so the
+		// summary line below can spare the player from scanning all four rows.
+		playableCount := 0
+
 		// Tableau (with row indent)
 		for row := range domain.TriPeaksRowCnt {
 			indent := strings.Repeat("  ", domain.TriPeaksRowCnt-1-row)
@@ -60,6 +64,7 @@ func (pr *TriPeaksCuiPresenter) Output(t interfaces.TriPeaksGame, lastErr error)
 					b.WriteString(i18n.Tf("tripeaks.blockedCard", "card", cuiCardStr(tc.Card)))
 				case wasteTop != nil && triPeaksAdjacentRank(tc.Card.GetValue(), wasteTop.GetValue()):
 					// Exposed and ±1 from the waste top: playable now (trailing *).
+					playableCount++
 					b.WriteString(i18n.Tf("tripeaks.playableCard",
 						"row", strconv.Itoa(row),
 						"col", strconv.Itoa(col),
@@ -87,6 +92,16 @@ func (pr *TriPeaksCuiPresenter) Output(t interfaces.TriPeaksGame, lastErr error)
 			b.WriteString(i18n.T("tripeaks.wasteEmpty"))
 		}
 		b.WriteString("\n")
+
+		// Playable-now summary: how many cards can be taken onto the waste top,
+		// plus a pre-emptive draw hint when none can (and the stock isn't empty).
+		if t.GetPhase() == domain.TriPeaksPhasePlaying {
+			b.WriteString(i18n.Tf("tripeaks.playableSummary",
+				"count", strconv.Itoa(playableCount)) + "\n")
+			if playableCount == 0 && t.GetStockCount() > 0 {
+				b.WriteString(color.Yellow(i18n.T("tripeaks.drawRecommended")) + "\n")
+			}
+		}
 
 		b.WriteString("----------\n")
 

--- a/internal/adapter/presenter/TriPeaksCuiPresenter_test.go
+++ b/internal/adapter/presenter/TriPeaksCuiPresenter_test.go
@@ -41,6 +41,9 @@ func TestTriPeaksCuiPresenterOutput_Playing(t *testing.T) {
 	assert.Contains(t, result, "TriPeaks")
 	assert.Contains(t, result, "Stock: 23枚")
 	assert.Contains(t, result, "手数: 0")
+	// No waste top -> nothing playable; stock remains, so draw is recommended.
+	assert.Contains(t, result, "今出せるカード: 0枚")
+	assert.Contains(t, result, "ドロー推奨")
 }
 
 func TestTriPeaksCuiPresenterOutput_PlayableAndBlocked(t *testing.T) {
@@ -71,6 +74,9 @@ func TestTriPeaksCuiPresenterOutput_PlayableAndBlocked(t *testing.T) {
 	assert.Contains(t, result, "[--]")
 	// (3,2) is exposed but not adjacent -> plain coordinate format, no marker.
 	assert.Contains(t, result, "(3,2)")
+	// Exactly one exposed card is playable, so no draw recommendation.
+	assert.Contains(t, result, "今出せるカード: 1枚")
+	assert.NotContains(t, result, "ドロー推奨")
 }
 
 func TestTriPeaksCuiPresenterOutput_Error(t *testing.T) {
@@ -97,6 +103,9 @@ func TestTriPeaksCuiPresenterOutput_Stalemate(t *testing.T) {
 	p := &TriPeaksCuiPresenter{}
 	result := p.Output(tg, nil)
 	assert.Contains(t, result, "手詰まり")
+	// Nothing playable but the stock is empty, so no draw recommendation.
+	assert.Contains(t, result, "今出せるカード: 0枚")
+	assert.NotContains(t, result, "ドロー推奨")
 }
 
 func TestTriPeaksCuiPresenterOutput_GameClear(t *testing.T) {

--- a/internal/i18n/locales/en/tripeaks.json
+++ b/internal/i18n/locales/en/tripeaks.json
@@ -7,6 +7,8 @@
   "tableauCard": "({{row}},{{col}}){{card}}",
   "playableCard": "({{row}},{{col}}){{card}}*",
   "blockedCard": "[--]{{card}}",
+  "playableSummary": "Playable now: {{count}}",
+  "drawRecommended": "Draw recommended (no playable cards)",
   "stockLine": "Stock: {{count}}",
   "wasteCard": " | Waste: {{card}}",
   "wasteEmpty": " | Waste: [empty]",

--- a/internal/i18n/locales/ja/tripeaks.json
+++ b/internal/i18n/locales/ja/tripeaks.json
@@ -7,6 +7,8 @@
   "tableauCard": "({{row}},{{col}}){{card}}",
   "playableCard": "({{row}},{{col}}){{card}}*",
   "blockedCard": "[--]{{card}}",
+  "playableSummary": "今出せるカード: {{count}}枚",
+  "drawRecommended": "ドロー推奨（出せる札がありません）",
   "stockLine": "Stock: {{count}}枚",
   "wasteCard": " | Waste: {{card}}",
   "wasteEmpty": " | Waste: [空]",


### PR DESCRIPTION
## 概要
`TriPeaksCuiPresenter` は盤面4行の各カードに `*` マーカーを付けるが、CUI では `*` を探して回る必要があり、ドロー判断に必要な「今すぐ出せる枚数」が一目で分からなかった。ストック/ウェイスト行の下に「今出せるカード: N枚」サマリー行を追加し、0枚かつ山札が残っているときは黄色でドロー推奨を併記した。

## 変更点
- タブロー走査中に playable（露出＋waste±1）を集計し、`tripeaks.playableSummary` を出力（プレイ中フェーズのみ）
- 0枚かつ `GetStockCount() > 0` のとき `tripeaks.drawRecommended`（黄色）を併記（山札0では出さない）
- `tripeaks.playableSummary`/`drawRecommended` キーを ja/en に追加
- 1枚時／0枚+山札あり／0枚+山札なし の3分岐テストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3086