### PR TITLE
feat(golf): mark waste-adjacent playable cards in the CUI

### DIFF
--- a/internal/adapter/presenter/GolfCuiPresenter.go
+++ b/internal/adapter/presenter/GolfCuiPresenter.go
@@ -12,6 +12,17 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
+// golfAdjacentRank reports whether two ranks differ by one, treating King(13)
+// and Ace(1) as adjacent — matching the domain's isAdjacentRank and the
+// frontend's isGolfAdjacent (K-A wrap included).
+func golfAdjacentRank(v1, v2 int) bool {
+	diff := v1 - v2
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff == 1 || diff == 12
+}
+
 // GolfCuiPresenter renders the Golf Solitaire CUI view.
 type GolfCuiPresenter struct{}
 
@@ -20,6 +31,13 @@ func (pr *GolfCuiPresenter) Output(g interfaces.GolfGame, lastErr error) string 
 	return buildCuiOutput(i18n.T("golf.helpTitle"), func(b *strings.Builder) {
 		layout := g.GetLayout()
 
+		// Waste top drives the ±1 playable check for exposed tableau cards.
+		waste := g.GetWaste()
+		var wasteTop *domain.Card
+		if len(waste) > 0 {
+			wasteTop = waste[len(waste)-1]
+		}
+
 		// Tableau (each row prints 7 columns)
 		for row := range domain.GolfRowCnt {
 			for col := range domain.GolfColCnt {
@@ -27,13 +45,19 @@ func (pr *GolfCuiPresenter) Output(g interfaces.GolfGame, lastErr error) string 
 					b.WriteString("  ")
 				}
 				gc := layout[col][row]
-				if gc == nil || gc.Removed {
+				switch {
+				case gc == nil || gc.Removed:
 					b.WriteString("    ")
-				} else if g.IsExposed(col, row) {
+				case g.IsExposed(col, row) && wasteTop != nil && golfAdjacentRank(gc.Card.GetValue(), wasteTop.GetValue()):
+					// Exposed and ±1 from the waste top: playable now (trailing *).
+					b.WriteString(i18n.Tf("golf.playableCard",
+						"col", strconv.Itoa(col),
+						"card", cuiCardStr(gc.Card)))
+				case g.IsExposed(col, row):
 					b.WriteString(i18n.Tf("golf.exposedCard",
 						"col", strconv.Itoa(col),
 						"card", cuiCardStr(gc.Card)))
-				} else {
+				default:
 					b.WriteString("   " + cuiCardStr(gc.Card))
 				}
 			}
@@ -45,7 +69,6 @@ func (pr *GolfCuiPresenter) Output(g interfaces.GolfGame, lastErr error) string 
 		// Stock + waste
 		b.WriteString(i18n.Tf("golf.stockLine",
 			"count", strconv.Itoa(g.GetStockCount())))
-		waste := g.GetWaste()
 		if len(waste) > 0 {
 			b.WriteString(i18n.Tf("golf.wasteCard",
 				"card", cuiCardStr(waste[len(waste)-1])))

--- a/internal/adapter/presenter/GolfCuiPresenter_test.go
+++ b/internal/adapter/presenter/GolfCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
@@ -50,6 +51,34 @@ func TestGolfCuiPresenterOutput_Playing(t *testing.T) {
 	assert.Contains(t, result, "Golf")
 	assert.Contains(t, result, "Stock: 16枚")
 	assert.Contains(t, result, "手数: 0")
+}
+
+func TestGolfCuiPresenterOutput_PlayableMarker(t *testing.T) {
+	gg := new(interfaces.MockGolfGame)
+	gg.On("GetPhase").Return(domain.GolfPhasePlaying).Maybe()
+	gg.On("GetMoveCount").Return(0).Maybe()
+	gg.On("GetStockCount").Return(10).Maybe()
+	gg.On("IsStalemate").Return(false).Maybe()
+	// Waste top is K(13): adjacent to Q(12) normally and to A(1) via K-A wrap.
+	gg.On("GetWaste").Return([]*domain.Card{domain.NewCard(domain.CardDesignHeart, 13, false)}).Maybe()
+
+	bottom := domain.GolfRowCnt - 1
+	var layout [domain.GolfColCnt][domain.GolfRowCnt]*domain.GolfCard
+	layout[0][bottom] = &domain.GolfCard{Card: domain.NewCard(domain.CardDesignSpade, 12, false)} // adjacent -> playable
+	layout[1][bottom] = &domain.GolfCard{Card: domain.NewCard(domain.CardDesignSpade, 1, false)}  // K-A wrap -> playable
+	layout[2][bottom] = &domain.GolfCard{Card: domain.NewCard(domain.CardDesignSpade, 8, false)}  // not adjacent
+	gg.On("GetLayout").Return(layout).Maybe()
+	gg.On("IsExposed", 0, bottom).Return(true).Maybe()
+	gg.On("IsExposed", 1, bottom).Return(true).Maybe()
+	gg.On("IsExposed", 2, bottom).Return(true).Maybe()
+	gg.On("IsExposed", mock.Anything, mock.Anything).Return(false).Maybe()
+
+	p := &GolfCuiPresenter{}
+	result := p.Output(gg, nil)
+	assert.Contains(t, result, "(0)SPADE 12*")   // adjacent
+	assert.Contains(t, result, "(1)SPADE 1*")    // K-A wrap
+	assert.Contains(t, result, "(2)SPADE 8")     // exposed, not adjacent
+	assert.NotContains(t, result, "(2)SPADE 8*") // no marker on non-adjacent
 }
 
 func TestGolfCuiPresenterOutput_Error(t *testing.T) {

--- a/internal/i18n/locales/en/golf.json
+++ b/internal/i18n/locales/en/golf.json
@@ -5,6 +5,7 @@
   "helpGiveUp": "  g                        give up",
   "helpHint": "  h                        hint",
   "exposedCard": "({{col}}){{card}}",
+  "playableCard": "({{col}}){{card}}*",
   "stockLine": "Stock: {{count}}",
   "wasteCard": " | Waste: {{card}}",
   "wasteEmpty": " | Waste: [empty]",

--- a/internal/i18n/locales/ja/golf.json
+++ b/internal/i18n/locales/ja/golf.json
@@ -5,6 +5,7 @@
   "helpGiveUp": "  g                        ギブアップ",
   "helpHint": "  h                        ヒント",
   "exposedCard": "({{col}}){{card}}",
+  "playableCard": "({{col}}){{card}}*",
   "stockLine": "Stock: {{count}}枚",
   "wasteCard": " | Waste: {{card}}",
   "wasteEmpty": " | Waste: [空]",


### PR DESCRIPTION
## 概要
同型ゲームの `TriPeaksCuiPresenter` は waste トップと隣接する露出カードに `*` を付けるが、`GolfCuiPresenter` は露出/伏せ札の2区分のみで「今出せる札」のマーカーがなく、Web版 `GolfPage`（緑リング）とのパリティ欠如がゴルフだけに残っていた。同じ隣接判定（±1・K-Aラップ）を追加し、露出かつ waste トップと隣接するカードを `golf.playableCard`（`*`付き）で描画する。

## 変更点
- `golfAdjacentRank`（±1・K-Aラップ、domain `isAdjacentRank` / frontend `isGolfAdjacent` と一致）を追加
- タブロー描画で露出＋waste±1 のカードを `golf.playableCard` で出力（waste が空なら従来出力）
- `golf.playableCard` キーを ja/en に追加
- 隣接・K-Aラップ・非隣接の境界テストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3113