### PR TITLE
feat(threecard): show ante-bonus and pair-plus payout breakdown in the CUI

### DIFF
--- a/internal/adapter/presenter/ThreeCardCuiPresenter.go
+++ b/internal/adapter/presenter/ThreeCardCuiPresenter.go
@@ -84,6 +84,13 @@ func (tp *ThreeCardCuiPresenter) Output(tc interfaces.ThreeCardGame, lastErr err
 			sb.WriteString(color.Yellow(i18n.T("threecard.push")) + "\n")
 		default:
 		}
+		// Side-bet / bonus payout breakdown (omitted when zero to stay concise).
+		if bonus := tc.GetAnteBonusPayout(); bonus != 0 {
+			sb.WriteString(i18n.Tf("threecard.anteBonusPayoutLine", "payout", strconv.Itoa(bonus)) + "\n")
+		}
+		if pairPlus := tc.GetPairPlusPayout(); pairPlus != 0 {
+			sb.WriteString(i18n.Tf("threecard.pairPlusPayoutLine", "payout", strconv.Itoa(pairPlus)) + "\n")
+		}
 		sb.WriteString(i18n.Tf("threecard.totalPayoutLine", "payout", strconv.Itoa(tc.GetTotalPayout())) + "\n")
 		sb.WriteString("----------\n")
 	}

--- a/internal/adapter/presenter/ThreeCardCuiPresenter_test.go
+++ b/internal/adapter/presenter/ThreeCardCuiPresenter_test.go
@@ -159,6 +159,45 @@ func TestThreeCardCuiPresenter_Output_EndPhase_PlayerWins(t *testing.T) {
 	assert.Contains(t, result, "DEALER")
 	assert.Contains(t, result, "(Qualified)")
 	assert.Contains(t, result, "合計払戻し: 400")
+	// Zero side-bet/bonus payouts omit their breakdown lines (backward compatible).
+	assert.NotContains(t, result, "ペアプラス配当")
+	assert.NotContains(t, result, "アンテボーナス配当")
+}
+
+func TestThreeCardCuiPresenter_Output_EndPhase_PayoutBreakdown(t *testing.T) {
+	p := new(ThreeCardCuiPresenter)
+	m := new(interfaces.MockThreeCardGame)
+	m.On("GetChips").Return(1500).Maybe()
+	m.On("GetPhase").Return(domain.ThreeCardPhaseEnd).Maybe()
+	m.On("GetPlayerHand").Return([]*domain.Card{
+		domain.NewCard(domain.CardDesignSpade, 10, false),
+		domain.NewCard(domain.CardDesignSpade, 11, false),
+		domain.NewCard(domain.CardDesignSpade, 12, false),
+	}).Maybe()
+	m.On("GetDealerHand").Return([]*domain.Card{
+		domain.NewCard(domain.CardDesignDiamond, 5, false),
+		domain.NewCard(domain.CardDesignHeart, 3, false),
+		domain.NewCard(domain.CardDesignClover, 2, false),
+	}).Maybe()
+	m.On("GetGameEndFlag").Return(true).Maybe()
+	m.On("GetAnteBet").Return(100).Maybe()
+	m.On("GetPairPlusBet").Return(100).Maybe()
+	m.On("GetPlayBet").Return(100).Maybe()
+	m.On("GetResult").Return(domain.GameResultWin).Maybe()
+	m.On("GetAntePayout").Return(200).Maybe()
+	m.On("GetPlayPayout").Return(200).Maybe()
+	m.On("GetAnteBonusPayout").Return(500).Maybe()
+	m.On("GetPairPlusPayout").Return(4000).Maybe()
+	m.On("GetTotalPayout").Return(4900).Maybe()
+	m.On("GetDealerQualified").Return(false).Maybe()
+	m.On("GetPlayerHandRank").Return(domain.ThreeCardHandStraightFlush).Maybe()
+	m.On("GetDealerHandRank").Return(domain.ThreeCardHandHighCard).Maybe()
+	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
+
+	result := p.Output(m, nil)
+	assert.Contains(t, result, "アンテボーナス配当: 500")
+	assert.Contains(t, result, "ペアプラス配当: 4000")
+	assert.Contains(t, result, "合計払戻し: 4900")
 }
 
 func TestThreeCardCuiPresenter_Output_EndPhase_Fold(t *testing.T) {

--- a/internal/i18n/locales/en/threecard.json
+++ b/internal/i18n/locales/en/threecard.json
@@ -23,5 +23,7 @@
   "dealerWins": "Dealer wins!",
   "playerFolded": "Player folded.",
   "push": "Push!",
+  "anteBonusPayoutLine": "Ante bonus payout: {{payout}}",
+  "pairPlusPayoutLine": "Pair Plus payout: {{payout}}",
   "totalPayoutLine": "total payout: {{payout}}"
 }

--- a/internal/i18n/locales/ja/threecard.json
+++ b/internal/i18n/locales/ja/threecard.json
@@ -23,5 +23,7 @@
   "dealerWins": "ディーラーの勝ち！",
   "playerFolded": "プレイヤーがフォールド。",
   "push": "プッシュ！",
+  "anteBonusPayoutLine": "アンテボーナス配当: {{payout}}",
+  "pairPlusPayoutLine": "ペアプラス配当: {{payout}}",
   "totalPayoutLine": "合計払戻し: {{payout}}"
 }


### PR DESCRIPTION
## 概要
Web版 `ThreeCardPage.tsx` の END フェーズは ante/play/ante-bonus/pair-plus/total を項目別に表示するが、CUI はアンテ・プレイ・合計のみで、ペアプラスに賭けた CUI プレイヤーはサイドベットやアンテボーナスの払い戻しを確認できなかった。ゲーム終了ブロックにアンテボーナス配当・ペアプラス配当の行を追加した（0 のときは省略し従来の簡潔さを維持）。

## 変更点
- 終了ブロックで `GetAnteBonusPayout()`/`GetPairPlusPayout()` が 0 以外のとき内訳行を出力（既存 getter を利用）
- `threecard.anteBonusPayoutLine`/`pairPlusPayoutLine` キーを ja/en に追加
- 非ゼロ配当の内訳表示テストと、ゼロ時の非表示（後方互換）テストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3093