### PR TITLE
feat(indianpoker): show call/min-raise/max amounts on the human's turn in the CUI

### DIFF
--- a/internal/adapter/presenter/IndianPokerCuiPresenter.go
+++ b/internal/adapter/presenter/IndianPokerCuiPresenter.go
@@ -70,6 +70,23 @@ func (p *IndianPokerCuiPresenter) Output(ip interfaces.IndianPokerGame, lastErr 
 			if ip.GetPhase() == domain.IndianPokerPhaseBetting && player.GetIsHuman() && !player.GetFolded() {
 				b.WriteString(i18n.Tf("indianpoker.equityLine",
 					"pct", strconv.Itoa(ip.GetEstimatedStrength(i))) + "\n")
+
+				// On the human's turn, spell out the amount to call, the minimum
+				// raise, and the max bet so the decision needs no mental math
+				// (mirrors the web BettingControls inputs).
+				if ip.GetCurrentTurn() == i {
+					_, maxBet := domain.CalculateBettingLimits(cfg.BettingLimit, ip.GetPot(), ip.GetLastBet())
+					toCall := ip.GetLastBet() - player.GetCurrentBet()
+					if toCall <= 0 {
+						b.WriteString(i18n.Tf("indianpoker.checkAvailableLine",
+							"max", strconv.Itoa(maxBet)) + "\n")
+					} else {
+						b.WriteString(i18n.Tf("indianpoker.betInfoLine",
+							"call", strconv.Itoa(toCall),
+							"minraise", strconv.Itoa(ip.GetMinRaise()),
+							"max", strconv.Itoa(maxBet)) + "\n")
+					}
+				}
 			}
 		}
 

--- a/internal/adapter/presenter/IndianPokerCuiPresenter_test.go
+++ b/internal/adapter/presenter/IndianPokerCuiPresenter_test.go
@@ -57,6 +57,46 @@ func TestIndianPokerCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "推定勝率:")
 	})
 
+	t.Run("betting shows check-available on human turn with no outstanding bet", func(t *testing.T) {
+		ip, players := makeIndianPokerForPresenter()
+		ip.SetPhase(domain.IndianPokerPhaseBetting)
+		ip.SetCurrentTurn(0)
+		ip.SetLastBet(0)
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 10, false))
+
+		result := p.Output(ip, nil)
+		assert.Contains(t, result, "チェック可能")
+		assert.NotContains(t, result, "コール:")
+	})
+
+	t.Run("betting shows call amount and min raise on human turn", func(t *testing.T) {
+		ip, players := makeIndianPokerForPresenter()
+		ip.SetPhase(domain.IndianPokerPhaseBetting)
+		ip.SetCurrentTurn(0)
+		ip.SetLastBet(50)
+		ip.SetMinRaise(20)
+		players[0].SetCurrentBet(10)
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 10, false))
+
+		result := p.Output(ip, nil)
+		assert.Contains(t, result, "コール: 40") // 50 - 10 already committed
+		assert.Contains(t, result, "ミニマムレイズ: 20")
+		assert.NotContains(t, result, "チェック可能")
+	})
+
+	t.Run("betting hides call info when it is not the human's turn", func(t *testing.T) {
+		ip, players := makeIndianPokerForPresenter()
+		ip.SetPhase(domain.IndianPokerPhaseBetting)
+		ip.SetCurrentTurn(1) // a CPU is to act
+		ip.SetLastBet(50)
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 10, false))
+
+		result := p.Output(ip, nil)
+		assert.Contains(t, result, "推定勝率:")
+		assert.NotContains(t, result, "コール:")
+		assert.NotContains(t, result, "チェック可能")
+	})
+
 	t.Run("showdown phase hides equity", func(t *testing.T) {
 		ip, players := makeIndianPokerForPresenter()
 		ip.SetPhase(domain.IndianPokerPhaseShowdown)

--- a/internal/i18n/locales/en/indianpoker.json
+++ b/internal/i18n/locales/en/indianpoker.json
@@ -27,6 +27,8 @@
   "cardLine": "  card: {{card}}",
   "cardHidden": "  card: ??",
   "equityLine": "  est. win: {{pct}}%",
+  "betInfoLine": "  To call: {{call}} / min raise: {{minraise}} / max: {{max}}",
+  "checkAvailableLine": "  Check available / max: {{max}}",
   "cpuActionsHeader": "[CPU actions]",
   "cpuActionLine": "  Player {{idx}}: {{action}}",
   "cpuActionAmount": " ({{amount}})",

--- a/internal/i18n/locales/ja/indianpoker.json
+++ b/internal/i18n/locales/ja/indianpoker.json
@@ -27,6 +27,8 @@
   "cardLine": "  カード: {{card}}",
   "cardHidden": "  カード: ??",
   "equityLine": "  推定勝率: {{pct}}%",
+  "betInfoLine": "  コール: {{call}} / ミニマムレイズ: {{minraise}} / 上限: {{max}}",
+  "checkAvailableLine": "  チェック可能 / 上限: {{max}}",
   "cpuActionsHeader": "[CPU行動]",
   "cpuActionLine": "  Player {{idx}}: {{action}}",
   "cpuActionAmount": " ({{amount}})",


### PR DESCRIPTION
## 概要
`IndianPokerCuiPresenter` はポット・アンティ・推定勝率まで表示するが、意思決定に直結する「コール必要額」「ミニマムレイズ」「上限額」を出力しておらず、CUI プレイヤーは毎回自分で計算する必要があった。人間の手番のとき、推定勝率行の直後にコール/ミニマムレイズ/上限の行を追加し、アウトスタンディングベットがない場合は「チェック可能」表記に切り替えた（Web版 `BettingControls` とパリティ）。

## 変更点
- BETTING かつ人間の手番（`GetCurrentTurn()==i`）のとき、`toCall = GetLastBet() - GetCurrentBet()` を算出
  - `toCall <= 0`: `indianpoker.checkAvailableLine`（チェック可能 / 上限）
  - `toCall > 0`: `indianpoker.betInfoLine`（コール / ミニマムレイズ / 上限）
- 上限は既存 `domain.CalculateBettingLimits(limit, pot, lastBet)` を利用（ポットリミット/ノーリミット対応）
- `betInfoLine`/`checkAvailableLine` キーを ja/en に追加
- チェック可能／コール必要額／手番外非表示 の3テストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3069