### PR TITLE
fix(irishpoker): show the correct discard count in the shared CUI prompt

### DIFF
--- a/internal/adapter/presenter/PineappleCuiPresenter.go
+++ b/internal/adapter/presenter/PineappleCuiPresenter.go
@@ -107,7 +107,10 @@ func (pp *PineappleCuiPresenter) Output(p interfaces.PineappleGame, lastErr erro
 		if p.GetPhase() == domain.PineapplePhaseDiscard {
 			b.WriteString("----------\n")
 			b.WriteString(i18n.T("pineapple.discardHeader") + "\n")
-			b.WriteString(i18n.T("pineapple.discardPrompt") + "\n")
+			// The number of cards to discard is variant-dependent (Pineapple keeps
+			// 2 of 3, Irish Poker keeps 2 of 4), so derive it from the deal count.
+			discardCount := p.GetInitialDealCount() - 2
+			b.WriteString(i18n.Tf("pineapple.discardPrompt", "count", strconv.Itoa(discardCount)) + "\n")
 		}
 
 		results := p.GetRoundResults()

--- a/internal/adapter/presenter/PineappleCuiPresenter_test.go
+++ b/internal/adapter/presenter/PineappleCuiPresenter_test.go
@@ -34,6 +34,7 @@ func setupPineappleCuiMock() *interfaces.MockPineappleGame {
 	m.On("GetGameEndFlag").Return(false)
 	m.On("IsMuckAvailable").Return(false)
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	m.On("GetInitialDealCount").Return(3).Maybe()
 	return m
 }
 
@@ -125,6 +126,24 @@ func TestPineappleCuiPresenter_Output(t *testing.T) {
 		m.On("GetGameEndFlag").Return(true)
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "ゲーム終了")
+	})
+
+	t.Run("discard prompt says 1 card for a 3-card deal (Pineapple)", func(t *testing.T) {
+		m, _ := setupPineappleCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.PineapplePhaseDiscard)
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "手札から1枚選んで")
+	})
+
+	t.Run("discard prompt says 2 cards for a 4-card deal (Irish Poker)", func(t *testing.T) {
+		m, _ := setupPineappleCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetInitialDealCount")
+		m.On("GetPhase").Return(domain.PineapplePhaseDiscard)
+		m.On("GetInitialDealCount").Return(4)
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "手札から2枚選んで")
 	})
 }
 

--- a/internal/i18n/locales/en/pineapple.json
+++ b/internal/i18n/locales/en/pineapple.json
@@ -43,7 +43,7 @@
   "cpuActionLine": "  Player {{idx}}: {{action}}",
   "cpuActionAmount": " ({{amount}})",
   "discardHeader": "--- Discard phase ---",
-  "discardPrompt": "Pick one card from your hand to discard",
+  "discardPrompt": "Pick {{count}} card(s) from your hand to discard",
   "resultsHeader": "[Results]",
   "resultMucked": "  {{name}}: muck",
   "resultHand": "  {{name}}: {{hand}}{{kickers}}",

--- a/internal/i18n/locales/ja/pineapple.json
+++ b/internal/i18n/locales/ja/pineapple.json
@@ -43,7 +43,7 @@
   "cpuActionLine": "  Player {{idx}}: {{action}}",
   "cpuActionAmount": " ({{amount}})",
   "discardHeader": "--- ディスカードフェーズ ---",
-  "discardPrompt": "手札から1枚選んでディスカードしてください",
+  "discardPrompt": "手札から{{count}}枚選んでディスカードしてください",
   "resultsHeader": "[結果]",
   "resultMucked": "  {{name}}: マック",
   "resultHand": "  {{name}}: {{hand}}{{kickers}}",


### PR DESCRIPTION
## 概要
irishpoker はフロップ後に4枚のホールカードから2枚捨てるが、共有 `PineappleCuiPresenter` の捨て札プロンプトが「手札から1枚選んで…」と1枚固定になっており、irishpoker では案内と実際の必要枚数が食い違って CLI 操作を誤らせていた。捨て札枚数を `GetInitialDealCount() - 2` から算出し、プロンプトをパラメータ化した。

## 変更点
- 捨て札フェーズで `discardCount = GetInitialDealCount() - 2` を算出し `pineapple.discardPrompt` に枚数を渡す
- `discardPrompt` キーを `{{count}}` パラメータ付きに変更（ja/en）
- pineapple/crazypineapple（3枚配布→1枚）と irishpoker（4枚配布→2枚）の枚数別テストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3022