### PR TITLE
feat(crazypineapple): use variant-specific titles in the shared CUI

### DIFF
--- a/internal/adapter/presenter/PineappleCuiPresenter.go
+++ b/internal/adapter/presenter/PineappleCuiPresenter.go
@@ -12,6 +12,20 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
+// pineappleTitleKey selects the CUI title for the shared presenter's variant:
+// Irish Poker deals 4 hole cards, Crazy Pineapple discards after flop betting,
+// and plain Pineapple discards before the flop.
+func pineappleTitleKey(dealCount int, discardAfterFlop bool) string {
+	switch {
+	case dealCount >= 4:
+		return "irishpoker.helpTitle"
+	case discardAfterFlop:
+		return "crazypineapple.helpTitle"
+	default:
+		return "pineapple.helpTitle"
+	}
+}
+
 // PineappleCuiPresenter renders the Pineapple Poker CUI view.
 type PineappleCuiPresenter struct{}
 
@@ -22,7 +36,8 @@ func (pp *PineappleCuiPresenter) ActionLogOutput(p interfaces.PineappleGame) str
 
 // Output renders the current game state for the active locale (#1699).
 func (pp *PineappleCuiPresenter) Output(p interfaces.PineappleGame, lastErr error) string {
-	return buildCuiOutput(i18n.T("pineapple.helpTitle"), func(b *strings.Builder) {
+	titleKey := pineappleTitleKey(p.GetInitialDealCount(), p.IsDiscardAfterFlopBetting())
+	return buildCuiOutput(i18n.T(titleKey), func(b *strings.Builder) {
 		cfg := p.GetConfig()
 		if cfg.TournamentMode {
 			b.WriteString(i18n.Tf("pineapple.tournamentLine",

--- a/internal/adapter/presenter/PineappleCuiPresenter_test.go
+++ b/internal/adapter/presenter/PineappleCuiPresenter_test.go
@@ -35,6 +35,7 @@ func setupPineappleCuiMock() *interfaces.MockPineappleGame {
 	m.On("IsMuckAvailable").Return(false)
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
 	m.On("GetInitialDealCount").Return(3).Maybe()
+	m.On("IsDiscardAfterFlopBetting").Return(false).Maybe()
 	return m
 }
 
@@ -144,6 +145,30 @@ func TestPineappleCuiPresenter_Output(t *testing.T) {
 		m.On("GetInitialDealCount").Return(4)
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "手札から2枚選んで")
+	})
+
+	t.Run("title is plain Pineapple for a 3-card pre-flop-discard deal", func(t *testing.T) {
+		m, _ := setupPineappleCuiMockWithPlayers()
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "パイナップルポーカー")
+		assert.NotContains(t, result, "クレイジー")
+		assert.NotContains(t, result, "アイリッシュ")
+	})
+
+	t.Run("title is Crazy Pineapple when discarding after flop betting", func(t *testing.T) {
+		m, _ := setupPineappleCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "IsDiscardAfterFlopBetting")
+		m.On("IsDiscardAfterFlopBetting").Return(true)
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "クレイジーパイナップル")
+	})
+
+	t.Run("title is Irish Poker for a 4-card deal", func(t *testing.T) {
+		m, _ := setupPineappleCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetInitialDealCount")
+		m.On("GetInitialDealCount").Return(4)
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "アイリッシュポーカー")
 	})
 }
 

--- a/internal/domain/interfaces/pineapple.go
+++ b/internal/domain/interfaces/pineapple.go
@@ -64,6 +64,8 @@ type PineappleGame interface {
 	GetDiscardDone() []bool
 	// GetInitialDealCount 初期配布枚数を取得する
 	GetInitialDealCount() int
+	// IsDiscardAfterFlopBetting Crazy Pineapple / Irish Poker モード（フロップベッティング後にディスカード）かを返す
+	IsDiscardAfterFlopBetting() bool
 	TournamentActionGame
 	// GetHumanProfile メタAIプロファイルを取得する
 	GetHumanProfile() *domain.BettingHumanProfile

--- a/internal/domain/interfaces/pineapple_mock.go
+++ b/internal/domain/interfaces/pineapple_mock.go
@@ -203,6 +203,12 @@ func (_m *MockPineappleGame) GetInitialDealCount() int {
 	return ret.Int(0)
 }
 
+// IsDiscardAfterFlopBetting モック
+func (_m *MockPineappleGame) IsDiscardAfterFlopBetting() bool {
+	ret := _m.Called()
+	return ret.Bool(0)
+}
+
 // Rebuy モック
 func (_m *MockPineappleGame) Rebuy() error {
 	ret := _m.Called()


### PR DESCRIPTION
## 概要
crazypineapple / irishpoker は CUI で `PineappleCuiPresenter` を共用しており、タイトルが `pineapple.helpTitle` 固定のため、プレイ中でも常に「Pineapple Poker (パイナップルポーカー)」と表示されていた（`crazypineapple.helpTitle`/`irishpoker.helpTitle` キーは存在するが未使用）。`omahaTitleKey` 方式のヘルパーでバリアント別タイトルに切り替える。

## 変更点
- `pineappleTitleKey(dealCount, discardAfterFlop)` を追加（4枚配布=irishpoker、フロップ後ディスカード=crazypineapple、それ以外=pineapple）
- バリアント判定用に `IsDiscardAfterFlopBetting()` を `PineappleGame` インターフェース＋モックに追加（ドメインは既に実装済み）
- 既存キー `crazypineapple.helpTitle`/`irishpoker.helpTitle` を利用（新規キーなし）
- pineapple / crazypineapple / irishpoker の3バリアントのタイトル分岐テストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/ ./internal/usecase/` green
- `golangci-lint run` 0 issues

Closes #3021