### PR TITLE
feat(hearts): show point-limit progress and warn near-limit scores in the CUI

### DIFF
--- a/internal/adapter/presenter/HeartsCuiPresenter.go
+++ b/internal/adapter/presenter/HeartsCuiPresenter.go
@@ -10,12 +10,18 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
-// heartsPlayerStr returns the display string for a single Hearts player.
-func heartsPlayerStr(player *domain.HeartsPlayer, i int) string {
+// heartsPlayerStr returns the display string for a single Hearts player. The
+// cumulative score is highlighted once a player passes 80% of the point limit,
+// since reaching it ends the game (and loses).
+func heartsPlayerStr(player *domain.HeartsPlayer, i, pointLimit int) string {
 	var b strings.Builder
+	cum := strconv.Itoa(player.GetCumulativeScore())
+	if pointLimit > 0 && player.GetCumulativeScore()*100 >= pointLimit*80 {
+		cum = color.Yellow(cum)
+	}
 	b.WriteString(i18n.Tf("hearts.playerLine",
 		"name", cuiPlayerName(player, i),
-		"cum", strconv.Itoa(player.GetCumulativeScore()),
+		"cum", cum,
 		"round", strconv.Itoa(player.GetRoundScore()),
 		"cards", strconv.Itoa(player.GetCardsSize()),
 		"tricks", strconv.Itoa(player.GetTrickCount()),
@@ -43,8 +49,22 @@ func (p *HeartsCuiPresenter) Output(h interfaces.HeartsGame, lastErr error) stri
 			b.WriteString(i18n.T("hearts.heartsBrokenNo") + "\n")
 		}
 
+		// Point-limit progress: the highest cumulative score is closest to ending
+		// the game (whoever reaches the limit loses), so surface it and the limit.
+		pointLimit := h.GetConfig().PointLimit
+		leaderIdx, maxScore := 0, -1
 		for i := 0; i < h.GetPlayerCnt(); i++ {
-			b.WriteString(heartsPlayerStr(h.GetPlayer(i), i))
+			if s := h.GetPlayer(i).GetCumulativeScore(); s > maxScore {
+				maxScore, leaderIdx = s, i
+			}
+		}
+		b.WriteString(i18n.Tf("hearts.limitProgress",
+			"limit", strconv.Itoa(pointLimit),
+			"name", cuiPlayerName(h.GetPlayer(leaderIdx), leaderIdx),
+			"score", strconv.Itoa(maxScore)) + "\n")
+
+		for i := 0; i < h.GetPlayerCnt(); i++ {
+			b.WriteString(heartsPlayerStr(h.GetPlayer(i), i, pointLimit))
 		}
 
 		b.WriteString("----------\n")

--- a/internal/adapter/presenter/HeartsCuiPresenter_test.go
+++ b/internal/adapter/presenter/HeartsCuiPresenter_test.go
@@ -88,6 +88,30 @@ func TestHeartsCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "CPU 1: 累積0点 ラウンド0点 1枚 0トリック")
 		assert.Contains(t, result, "手番: あなた")
 		assert.Contains(t, result, "play <idx>")
+		// Point-limit progress line (default limit 100, all at 0 → leader score 0).
+		assert.Contains(t, result, "上限: 100点")
+		assert.Contains(t, result, "最多失点:")
+	})
+
+	t.Run("progress line names the highest-scoring player", func(t *testing.T) {
+		m, players := setupHeartsCuiMockWithPlayers()
+		players[2].SetCumulativeScore(42)
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "最多失点: CPU 2 42点")
+	})
+
+	t.Run("cumulative score over 80% of the limit is highlighted", func(t *testing.T) {
+		// Colors are enabled here so the ANSI yellow wrapper is observable.
+		origNo := color.NoColor()
+		color.SetNoColor(false)
+		defer color.SetNoColor(origNo)
+		m, players := setupHeartsCuiMockWithPlayers()
+		players[1].SetCumulativeScore(85) // >= 80% of 100
+		players[0].SetCumulativeScore(10) // below threshold
+		result := p.Output(m, nil)
+		yellow := color.Yellow("85")
+		assert.Contains(t, result, yellow)
+		assert.NotContains(t, result, color.Yellow("10"))
 	})
 
 	t.Run("hearts broken shows あり", func(t *testing.T) {

--- a/internal/i18n/locales/en/hearts.json
+++ b/internal/i18n/locales/en/hearts.json
@@ -9,6 +9,7 @@
   "round": "Round: {{round}}  Trick: {{trick}}",
   "heartsBrokenYes": "Hearts broken: yes",
   "heartsBrokenNo": "Hearts broken: no",
+  "limitProgress": "Limit: {{limit}} pts / most: {{name}} {{score}} pts",
   "playerLine": "{{name}}: cum {{cum}}pt round {{round}}pt {{cards}} cards, {{tricks}} tricks",
   "gameEnd": "Game over! {{name}} wins!",
   "promptPass": "Pass phase: {{direction}}",

--- a/internal/i18n/locales/ja/hearts.json
+++ b/internal/i18n/locales/ja/hearts.json
@@ -9,6 +9,7 @@
   "round": "ラウンド: {{round}}  トリック: {{trick}}",
   "heartsBrokenYes": "ハートブレイク: あり",
   "heartsBrokenNo": "ハートブレイク: なし",
+  "limitProgress": "上限: {{limit}}点 / 最多失点: {{name}} {{score}}点",
   "playerLine": "{{name}}: 累積{{cum}}点 ラウンド{{round}}点 {{cards}}枚 {{tricks}}トリック",
   "gameEnd": "ゲーム終了！ {{name}}の勝利です！",
   "promptPass": "パスフェーズ: {{direction}}",


### PR DESCRIPTION
## 概要
`HeartsCuiPresenter` はゲーム終了条件であるポイント上限（`PointLimit`）に対する進捗を一切表示せず、手札一覧でも各累計点が同じ書式のため、CUI プレイヤーはゲーム終了の近さを把握できなかった。ヘッダに上限＋最多失点プレイヤーの進捗行を追加し、上限の80%を超えた累計点を黄色で警告表示する。

## 変更点
- ヘッダに `hearts.limitProgress`（上限 / 最多失点プレイヤーとそのスコア）を追加（`GetConfig().PointLimit` を利用、新規インターフェース不要）
- `heartsPlayerStr` に `pointLimit` を渡し、累計点が `>= 80%` のとき `color.Yellow` で強調
- `hearts.limitProgress` キーを ja/en に追加
- 進捗行・最多失点プレイヤー名・80%超警告色の分岐テストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3027