### PR TITLE
feat(cribbage): show playable pegging indices and a go hint in the CUI

### DIFF
--- a/internal/adapter/presenter/CribbageCuiPresenter.go
+++ b/internal/adapter/presenter/CribbageCuiPresenter.go
@@ -12,6 +12,15 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
+// cribbagePegValue is a card's pegging value: face cards count as 10, aces as
+// 1, all others their pip value (mirrors the domain's cribbageCardValue).
+func cribbagePegValue(card *domain.Card) int {
+	if v := card.GetValue(); v <= 10 {
+		return v
+	}
+	return 10
+}
+
 // cribbagePlayerStr returns the display string for a single Cribbage player.
 func cribbagePlayerStr(player *domain.CribbagePlayer, i int, dealerIdx int) string {
 	var b strings.Builder
@@ -92,6 +101,22 @@ func (p *CribbageCuiPresenter) Output(g interfaces.CribbageGame, lastErr error) 
 			currentIdx := g.GetCurrentPlayerIdx()
 			b.WriteString(i18n.Tf("cribbage.promptPegging",
 				"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
+			// List the hand indices playable under the 31 limit so the human
+			// need not add pip values by hand; warn to declare go if none fit.
+			if cur := g.GetPlayer(currentIdx); cur != nil && cur.GetIsHuman() {
+				pegCount := g.GetPegCount()
+				var legal []string
+				for i := 0; i < cur.GetCardsSize(); i++ {
+					if pegCount+cribbagePegValue(cur.GetCard(i)) <= domain.CribbagePegLimit {
+						legal = append(legal, "["+strconv.Itoa(i)+"]")
+					}
+				}
+				if len(legal) > 0 {
+					b.WriteString(i18n.Tf("cribbage.legalPegLegend", "indices", strings.Join(legal, " ")) + "\n")
+				} else {
+					b.WriteString(color.Yellow(i18n.T("cribbage.mustGo")) + "\n")
+				}
+			}
 			b.WriteString(i18n.T("cribbage.promptPeggingHelp") + "\n")
 			b.WriteString(i18n.T("cribbage.promptPeggingGo") + "\n")
 		case domain.CribbagePhaseShow:

--- a/internal/adapter/presenter/CribbageCuiPresenter_test.go
+++ b/internal/adapter/presenter/CribbageCuiPresenter_test.go
@@ -119,6 +119,35 @@ func TestCribbageCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "invalid card index")
 	})
 
+	t.Run("pegging legend lists indices playable within 31 (boundary)", func(t *testing.T) {
+		m, players := setupCribbageCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPegCount")
+		m.On("GetPhase").Return(domain.CribbagePhasePegging)
+		m.On("GetPegCount").Return(25)
+		// [0]=6 → 25+6=31 (exactly the limit, legal); [1]=7 → 32 (illegal).
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 6, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 7, false))
+
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "出せる手札: [0]")
+		assert.NotContains(t, result, "出せる手札: [0] [1]")
+	})
+
+	t.Run("pegging warns to declare go when nothing fits", func(t *testing.T) {
+		m, players := setupCribbageCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPegCount")
+		m.On("GetPhase").Return(domain.CribbagePhasePegging)
+		m.On("GetPegCount").Return(30)
+		// Only a 2 in hand → 30+2=32 > 31, so nothing is playable.
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
+
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "go を宣言してください")
+		assert.NotContains(t, result, "出せる手札:")
+	})
+
 	t.Run("game ended shows winner human", func(t *testing.T) {
 		m, _ := setupCribbageCuiMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetGameEndFlag")

--- a/internal/i18n/locales/en/cribbage.json
+++ b/internal/i18n/locales/en/cribbage.json
@@ -19,6 +19,8 @@
   "promptDiscardHelp": "d <idx,idx>: discard 2 to the crib",
   "promptPegging": "{{name}} to act (pegging phase)",
   "promptPeggingHelp": "p <idx>: play a card",
+  "legalPegLegend": "Playable: {{indices}}",
+  "mustGo": "No playable card → declare go",
   "promptPeggingGo": "go: declare Go",
   "promptShow": "Show phase",
   "promptShowHelp": "sn / shownext: next score calculation",

--- a/internal/i18n/locales/ja/cribbage.json
+++ b/internal/i18n/locales/ja/cribbage.json
@@ -19,6 +19,8 @@
   "promptDiscardHelp": "d <idx,idx>・・・クリブに2枚捨てる",
   "promptPegging": "手番: {{name}} (ペギングフェーズ)",
   "promptPeggingHelp": "p <idx>・・・カードを出す",
+  "legalPegLegend": "出せる手札: {{indices}}",
+  "mustGo": "出せる札がありません → go を宣言してください",
   "promptPeggingGo": "go・・・Goを宣言する",
   "promptShow": "ショーフェーズ",
   "promptShowHelp": "sn / shownext・・・次のスコア計算",


### PR DESCRIPTION
## 概要
Web版 `CribbagePage` はペギング中に31を超えるカードを減光・aria-disabled にするが、`CribbageCuiPresenter` は現在の合計しか出さず、どのインデックスが合法（`pegCount + 値 <= 31`）かは自分で暗算する必要があった。人間のペギング手番で合法インデックスの凡例を表示し、出せる札がない場合は go 案内を強調する（`PinochleCuiPresenter` の `legalPlayLegend` と同目的）。

## 変更点
- `cribbagePegValue`（絵札=10 / それ以外=ピップ、domain `cribbageCardValue` と一致）を追加
- ペギングかつ人間の手番のとき、`pegCount + 値 <= CribbagePegLimit(31)` を満たすインデックスを `cribbage.legalPegLegend` で列挙、0件なら `cribbage.mustGo`（黄色）
- `legalPegLegend`/`mustGo` キーを ja/en に追加
- 合計31丁度（合法）の境界／出せる札なし（go案内）の分岐テストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3090