### PR TITLE
fix(gofish): display ranks as A/J/Q/K instead of raw numbers in the CUI

### DIFF
--- a/internal/adapter/presenter/GoFishCuiPresenter.go
+++ b/internal/adapter/presenter/GoFishCuiPresenter.go
@@ -46,7 +46,7 @@ func writeGoFishKnownRanks(b *strings.Builder, gf interfaces.GoFishGame) {
 		}
 		parts := make([]string, len(ranks))
 		for k, r := range ranks {
-			s := strconv.Itoa(r)
+			s := cuiRankLabel(r)
 			if human != nil && human.HasRank(r) {
 				s += "*" // you hold this rank too — a strong ask target
 			}
@@ -80,7 +80,7 @@ func (p *GoFishCuiPresenter) Output(gf interfaces.GoFishGame, lastErr error) str
 		if gf.GetLastAskPlayerIdx() >= 0 {
 			askerName := cuiPlayerName(gf.GetPlayer(gf.GetLastAskPlayerIdx()), gf.GetLastAskPlayerIdx())
 			targetName := cuiPlayerName(gf.GetPlayer(gf.GetLastAskTargetIdx()), gf.GetLastAskTargetIdx())
-			rankStr := strconv.Itoa(gf.GetLastAskRank())
+			rankStr := cuiRankLabel(gf.GetLastAskRank())
 			if gf.GetLastAskSuccess() {
 				b.WriteString(i18n.Tf("gofish.askSuccess",
 					"asker", askerName,
@@ -95,7 +95,7 @@ func (p *GoFishCuiPresenter) Output(gf interfaces.GoFishGame, lastErr error) str
 			}
 			if gf.GetLastBookFormed() {
 				b.WriteString(i18n.Tf("gofish.bookFormed",
-					"rank", strconv.Itoa(gf.GetLastBookRank())) + "\n")
+					"rank", cuiRankLabel(gf.GetLastBookRank())) + "\n")
 			}
 		}
 
@@ -103,7 +103,7 @@ func (p *GoFishCuiPresenter) Output(gf interfaces.GoFishGame, lastErr error) str
 		for _, action := range gf.GetCpuActions() {
 			askerName := cuiPlayerName(gf.GetPlayer(action.AskPlayerIdx), action.AskPlayerIdx)
 			targetName := cuiPlayerName(gf.GetPlayer(action.AskTargetIdx), action.AskTargetIdx)
-			rankStr := strconv.Itoa(action.AskRank)
+			rankStr := cuiRankLabel(action.AskRank)
 			if action.Success {
 				b.WriteString(i18n.Tf("gofish.cpuAskSuccess",
 					"asker", askerName,
@@ -119,7 +119,7 @@ func (p *GoFishCuiPresenter) Output(gf interfaces.GoFishGame, lastErr error) str
 			if action.BookFormed {
 				b.WriteString(i18n.Tf("gofish.cpuBookFormed",
 					"asker", askerName,
-					"rank", strconv.Itoa(action.BookRank)) + "\n")
+					"rank", cuiRankLabel(action.BookRank)) + "\n")
 			}
 		}
 

--- a/internal/adapter/presenter/GoFishCuiPresenter_test.go
+++ b/internal/adapter/presenter/GoFishCuiPresenter_test.go
@@ -26,10 +26,10 @@ func TestGoFishCuiPresenter_Output_KnownRanks(t *testing.T) {
 	p := new(presenter.GoFishCuiPresenter)
 	m := setupGoFishMock()
 	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetKnownRanks")
-	m.On("GetKnownRanks").Return(map[int][]int{1: {7, 9}})
+	m.On("GetKnownRanks").Return(map[int][]int{1: {1, 13}})
 	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPlayer")
 	human := domain.NewGoFishPlayer(true)
-	human.AddCard(domain.NewCard(domain.CardDesignSpade, 7, false)) // human also holds rank 7
+	human.AddCard(domain.NewCard(domain.CardDesignSpade, 1, false)) // human also holds the Ace
 	m.On("GetPlayer", 0).Return(human)
 	for i := 1; i < 4; i++ {
 		m.On("GetPlayer", i).Return(domain.NewGoFishPlayer(false))
@@ -37,7 +37,9 @@ func TestGoFishCuiPresenter_Output_KnownRanks(t *testing.T) {
 
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "既知ランク")
-	assert.Contains(t, result, "7*") // human holds rank 7 -> strong ask target
+	// Ranks render as card-face labels: Ace starred (human holds it), King as K.
+	assert.Contains(t, result, "A* K")
+	assert.NotContains(t, result, "13")
 }
 
 func TestGoFishCuiPresenter_Output_GameEnd(t *testing.T) {
@@ -87,18 +89,20 @@ func TestGoFishCuiPresenter_Output_AskSuccess(t *testing.T) {
 	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetLastBookRank")
 	m.On("GetLastAskPlayerIdx").Return(0)
 	m.On("GetLastAskTargetIdx").Return(1)
-	m.On("GetLastAskRank").Return(7)
+	m.On("GetLastAskRank").Return(13)
 	m.On("GetLastAskSuccess").Return(true)
 	m.On("GetLastCardsReceived").Return([]*domain.Card{
-		domain.NewCard(domain.CardDesignSpade, 7, false),
+		domain.NewCard(domain.CardDesignSpade, 13, false),
 	})
 	m.On("GetLastBookFormed").Return(true)
-	m.On("GetLastBookRank").Return(7)
+	m.On("GetLastBookRank").Return(1)
 
 	result := p.Output(m, nil)
-	assert.Contains(t, result, "ランク 7")
+	// King asked, Ace booked → both render as card-face labels, not 13/1.
+	assert.Contains(t, result, "ランク K")
 	assert.Contains(t, result, "1枚もらった")
 	assert.Contains(t, result, "ブック完成")
+	assert.NotContains(t, result, "ランク 13")
 }
 
 // TestGoFishCuiPresenter_Output_AskFail exercises the Go-Fish failure branch


### PR DESCRIPTION
## 概要
`GoFishCuiPresenter` はランクを `strconv.Itoa` で出力しており、CUI では「1」「11」「12」「13」がエース・ジャック・クイーン・キングとして表示され、Web版の `valueName`（A/J/Q/K）と不一致だった。ランク描画5か所（既知ランク一覧＋ask成功/失敗＋ブック完成＋CPUアクション相当）を既存の `cuiRankLabel` ヘルパー経由に置き換えた。

## 変更点
- `writeGoFishKnownRanks` の既知ランク、`GetLastAskRank`/`GetLastBookRank`、CPUアクションの `AskRank`/`BookRank` を `cuiRankLabel(...)` で表示（A/2〜10/J/Q/K）
- 人間保持ランクの `*` マーカーと凡例は従来どおり
- 新規 i18n キーなし（既存 `cuiRankLabel` を再利用）
- 既知ランク一覧・ask結果の A/K 境界テストを更新

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues

Closes #3108