### PR TITLE
feat(osmosis): annotate foundation rows with placeable ranks in the CUI

### DIFF
--- a/internal/adapter/presenter/OsmosisCuiPresenter.go
+++ b/internal/adapter/presenter/OsmosisCuiPresenter.go
@@ -21,8 +21,10 @@ func (p *OsmosisCuiPresenter) Output(o interfaces.OsmosisGame, lastErr error) st
 		// Base rank
 		b.WriteString(i18n.Tf("osmosis.baseRank", "rank", strconv.Itoa(o.GetBaseRank())) + "\n")
 
-		// Foundation rows (top card of each)
+		// Foundation rows (top card of each), each annotated with the ranks that
+		// may be placed on it so the player need not run the hint command.
 		foundation := o.GetFoundation()
+		baseRank := o.GetBaseRank()
 		for i := range domain.OsmosisFoundationCnt {
 			b.WriteString(i18n.Tf("osmosis.foundationLabel", "idx", strconv.Itoa(i)))
 			pile := foundation[i]
@@ -31,6 +33,15 @@ func (p *OsmosisCuiPresenter) Output(o interfaces.OsmosisGame, lastErr error) st
 			} else {
 				b.WriteString(" " + cuiCardStr(pile[len(pile)-1]) +
 					i18n.Tf("osmosis.foundationCount", "count", strconv.Itoa(len(pile))))
+			}
+			var allowed string
+			if i == 0 && len(pile) > 0 {
+				allowed = i18n.T("osmosis.anyRank")
+			} else {
+				allowed = osmosisRankLabels(osmosisAllowedRanks(foundation, baseRank, i))
+			}
+			if allowed != "" {
+				b.WriteString(" " + i18n.Tf("osmosis.allowedRanks", "ranks", allowed))
 			}
 			b.WriteString("\n")
 		}

--- a/internal/adapter/presenter/OsmosisCuiPresenter_test.go
+++ b/internal/adapter/presenter/OsmosisCuiPresenter_test.go
@@ -47,6 +47,27 @@ func TestOsmosisCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "ストック: 34枚")
 		assert.Contains(t, result, "ウェイスト: [空]")
 		assert.Contains(t, result, "手数: 0")
+		// Row 0 has cards -> any rank; row 1 (empty, row 0 seeded) -> base rank 7.
+		assert.Contains(t, result, "任意ランク")
+		assert.Contains(t, result, "[置ける: 7]")
+	})
+
+	t.Run("lower row lists ranks present in the row above", func(t *testing.T) {
+		og := new(interfaces.MockOsmosisGame)
+		setupOsmosisCuiMockDefaults(og)
+		og.ExpectedCalls = filterCalls(og.ExpectedCalls, "GetFoundation")
+		var f [domain.OsmosisFoundationCnt][]*domain.Card
+		// Row 0 holds 7,8,9; row 1 holds only 7 -> row 1 may still take 8 and 9.
+		f[0] = []*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 7, false),
+			domain.NewCard(domain.CardDesignSpade, 8, false),
+			domain.NewCard(domain.CardDesignSpade, 9, false),
+		}
+		f[1] = []*domain.Card{domain.NewCard(domain.CardDesignHeart, 7, false)}
+		og.On("GetFoundation").Return(f)
+		p := new(OsmosisCuiPresenter)
+		result := p.Output(og, nil)
+		assert.Contains(t, result, "[置ける: 8 9]")
 	})
 
 	t.Run("waste card", func(t *testing.T) {

--- a/internal/i18n/locales/en/osmosis.json
+++ b/internal/i18n/locales/en/osmosis.json
@@ -27,6 +27,7 @@
   "hintFromReserve": "reserve col {{col}}",
   "hintFromWaste": "waste",
   "hintToFoundation": "foundation {{idx}}",
+  "allowedRanks": "[playable: {{ranks}}]",
   "anyRank": "any rank",
   "hintLine": "Hint: {{from}} → {{to}} (allowed: {{allowed}})"
 }

--- a/internal/i18n/locales/ja/osmosis.json
+++ b/internal/i18n/locales/ja/osmosis.json
@@ -27,6 +27,7 @@
   "hintFromReserve": "リザーブ{{col}}列",
   "hintFromWaste": "ウェイスト",
   "hintToFoundation": "組札{{idx}}段",
+  "allowedRanks": "[置ける: {{ranks}}]",
   "anyRank": "任意ランク",
   "hintLine": "ヒント: {{from}} → {{to}} (配置可能: {{allowed}})"
 }


### PR DESCRIPTION
## 概要
`OsmosisCuiPresenter` には Web と同じ配置可否ロジック `osmosisAllowedRanks` があるが `HintOutput` からしか使われておらず、`Output` はファウンデーション各行のトップカードと枚数しか出さないため、CUI プレイヤーはヒントコマンドなしで配置可能ランクを判断できなかった。各ファウンデーション行の末尾に配置可能ランクを追記する（Web版 `os-allowed-i` と同等）。

## 変更点
- `Output` のファウンデーション行ループで `osmosisAllowedRanks`＋`osmosisRankLabels` を呼び、行末に `osmosis.allowedRanks` を追記
- 行0にカードがある場合は既存 `osmosis.anyRank`（任意ランク）を表示（HintOutput と同じ分岐）
- `osmosis.allowedRanks` キーを ja/en に追加
- 任意ランク／ベースランク／上段に存在するランクの分岐テストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3363