### PR TITLE
feat(bakersdozen): flag single-card columns and note the empty-column rule in the CUI

### DIFF
--- a/internal/adapter/presenter/BakersDozenCuiPresenter.go
+++ b/internal/adapter/presenter/BakersDozenCuiPresenter.go
@@ -55,6 +55,11 @@ func (p *BakersDozenCuiPresenter) Output(bd interfaces.BakersDozenGame, lastErr 
 				b.WriteString(" " + i18n.T("cuiEmptyCol"))
 			} else {
 				b.WriteString(bakersDozenColumnStr(colCards))
+				// A column down to its last card is at risk of emptying, and empty
+				// columns can never be refilled — flag it so the risk is visible.
+				if len(colCards) == 1 {
+					b.WriteString(" " + color.Yellow(i18n.T("bakersdozen.oneCardWarning")))
+				}
 			}
 			b.WriteString("\n")
 		}
@@ -68,6 +73,7 @@ func (p *BakersDozenCuiPresenter) Output(bd interfaces.BakersDozenGame, lastErr 
 			if bd.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
 			}
+			b.WriteString(i18n.T("bakersdozen.emptyColNote") + "\n")
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(bd.GetMoveCount())) + "\n")
 		case domain.BakersDozenPhaseGameClear:

--- a/internal/adapter/presenter/BakersDozenCuiPresenter_test.go
+++ b/internal/adapter/presenter/BakersDozenCuiPresenter_test.go
@@ -49,6 +49,34 @@ func TestBakersDozenCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "Foundation")
 		assert.Contains(t, result, "列0:")
 		assert.Contains(t, result, "手数: 0")
+		// Playing phase surfaces the empty-column caveat; no column is at 1 card.
+		assert.Contains(t, result, "空列は再利用できません")
+		assert.NotContains(t, result, "残り1枚")
+	})
+
+	t.Run("single-card column is flagged with a warning marker", func(t *testing.T) {
+		bg := new(interfaces.MockBakersDozenGame)
+		setupBakersDozenCuiMockDefaults(bg)
+		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "GetTableau")
+		var tableau [domain.BakersDozenTableauCnt][]*domain.BakersDozenTableauCard
+		// Column 0 has a single card (at-risk); the rest keep four.
+		tableau[0] = []*domain.BakersDozenTableauCard{
+			{Card: domain.NewCard(domain.CardDesignSpade, 5, false), FaceUp: true},
+		}
+		for i := 1; i < domain.BakersDozenTableauCnt; i++ {
+			tableau[i] = make([]*domain.BakersDozenTableauCard, 4)
+			for j := range 4 {
+				tableau[i][j] = &domain.BakersDozenTableauCard{
+					Card:   domain.NewCard(domain.CardDesignHeart, j+1, false),
+					FaceUp: true,
+				}
+			}
+		}
+		bg.On("GetTableau").Return(tableau)
+		p := new(BakersDozenCuiPresenter)
+
+		result := p.Output(bg, nil)
+		assert.Contains(t, result, "残り1枚")
 	})
 
 	t.Run("with error", func(t *testing.T) {

--- a/internal/i18n/locales/en/bakersdozen.json
+++ b/internal/i18n/locales/en/bakersdozen.json
@@ -6,6 +6,8 @@
   "helpHint": "  h                    hint",
   "helpAutoComplete": "  ac                   auto-complete",
   "foundationHeader": "Foundation: ",
+  "oneCardWarning": "(!last card)",
+  "emptyColNote": "Note: empty columns cannot be refilled",
   "columnLabel": "Column {{col}}:",
   "hintFrom": "tableau column {{col}}[{{idx}}]",
   "hintToFoundation": "foundation",

--- a/internal/i18n/locales/ja/bakersdozen.json
+++ b/internal/i18n/locales/ja/bakersdozen.json
@@ -6,6 +6,8 @@
   "helpHint": "  h                    ヒント",
   "helpAutoComplete": "  ac                   オートコンプリート",
   "foundationHeader": "Foundation: ",
+  "oneCardWarning": "(!残り1枚)",
+  "emptyColNote": "注意: 空列は再利用できません",
   "columnLabel": "列{{col}}:",
   "hintFrom": "タブロー列{{col}}[{{idx}}]",
   "hintToFoundation": "ファンデーション",


### PR DESCRIPTION
## 概要
Baker's Dozen は空列を二度と埋められないため、`BakersDozenPage` は残り1枚の列に破線リング＋警告を出すが、`BakersDozenCuiPresenter` は各列を淡々と出力するのみで詰みリスクに気付きにくかった。残り1枚の列に警告マーカーを付け、プレイ中フェーズに空列再利用不可の注意書きを1行追加する。

## 変更点
- タブロー描画ループで `len(colCards) == 1` の列に `bakersdozen.oneCardWarning`（黄色）を付加
- プレイ中フェーズに `bakersdozen.emptyColNote`（空列は再利用不可）を表示
- 空列（`cuiEmptyCol`）表示は従来のまま
- `oneCardWarning`/`emptyColNote` キーを ja/en に追加
- 残り1枚列の警告表示／注意書き表示のテストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3229