### PR TITLE
feat(kingalbert): show undo-to-escape guidance on stalemate in the CUI

### DIFF
--- a/internal/adapter/presenter/KingAlbertCuiPresenter.go
+++ b/internal/adapter/presenter/KingAlbertCuiPresenter.go
@@ -83,6 +83,10 @@ func (p *KingAlbertCuiPresenter) Output(bc interfaces.KingAlbertGame, lastErr er
 		case domain.KingAlbertPhasePlaying:
 			if bc.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Point the player at the concrete escape (how many undos are
+				// needed), matching the web StalemateEscapeButton.
+				b.WriteString(color.Yellow(i18n.Tf("kingalbert.stalemateEscape",
+					"count", strconv.Itoa(bc.UndoToEscape()))) + "\n")
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(bc.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/KingAlbertCuiPresenter_test.go
+++ b/internal/adapter/presenter/KingAlbertCuiPresenter_test.go
@@ -91,15 +91,17 @@ func TestKingAlbertCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "ゲームオーバー")
 	})
 
-	t.Run("stalemate", func(t *testing.T) {
+	t.Run("stalemate shows the undo-to-escape guidance", func(t *testing.T) {
 		bg := new(interfaces.MockKingAlbertGame)
 		setupKingAlbertCuiMockDefaults(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "IsStalemate")
 		bg.On("IsStalemate").Return(true)
+		bg.On("UndoToEscape").Return(3)
 
 		p := new(KingAlbertCuiPresenter)
 		result := p.Output(bg, nil)
 		assert.Contains(t, result, "手詰まり")
+		assert.Contains(t, result, "脱出には undo を 3 回")
 	})
 
 	t.Run("empty column and depleted reserve", func(t *testing.T) {

--- a/internal/i18n/locales/en/kingalbert.json
+++ b/internal/i18n/locales/en/kingalbert.json
@@ -9,6 +9,7 @@
   "helpAutoComplete": "  ac                   auto-complete",
   "foundationHeader": "Foundation: ",
   "reserveHeader": "Reserve: ",
+  "stalemateEscape": "Undo {{count}} time(s) (undo command) to escape",
   "columnLabel": "Column {{col}}:",
   "promptToZone": "destination column or 'f' for foundation",
   "hintFrom": "tableau column {{col}}[{{idx}}]",

--- a/internal/i18n/locales/ja/kingalbert.json
+++ b/internal/i18n/locales/ja/kingalbert.json
@@ -9,6 +9,7 @@
   "helpAutoComplete": "  ac                   オートコンプリート",
   "foundationHeader": "Foundation: ",
   "reserveHeader": "リザーブ: ",
+  "stalemateEscape": "脱出には undo を {{count}} 回（undo コマンド）実行してください",
   "columnLabel": "列{{col}}:",
   "promptToZone": "移動先の列、または組札なら 'f'",
   "hintFrom": "タブロー列{{col}}[{{idx}}]",


### PR DESCRIPTION
## 概要
`KingAlbertCuiPresenter` の stalemate 分岐は `cuiSolitaireStalemate` の警告文のみで、Web版 `KingAlbertPage` の `undoToEscape` 件数／`StalemateEscapeButton` に相当する脱出手順の案内がなかった。King Albert はリザーブ＋9列タブローで手詰まり局面の把握が複雑なため、脱出に必要な undo 回数と undo コマンドの案内を追記する。

## 変更点
- stalemate 分岐に `bc.UndoToEscape()`（`SolitaireGame` 経由、既存）の件数を `kingalbert.stalemateEscape`（黄色）で表示
- `stalemateEscape` キーを ja/en に追加
- stalemate テストに脱出案内（undo 回数）のアサーションを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3282