### PR TITLE
feat(canasta): show the initial-meld minimum and frozen-pickup note in the CUI

### DIFF
--- a/internal/adapter/presenter/CanastaCuiPresenter.go
+++ b/internal/adapter/presenter/CanastaCuiPresenter.go
@@ -12,6 +12,21 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
+// canastaMinMeld returns the minimum points required for a player's initial
+// meld, tiered by their cumulative score (mirrors the web canastaMinMeld).
+func canastaMinMeld(cumulativeScore int) int {
+	switch {
+	case cumulativeScore < 0:
+		return 15
+	case cumulativeScore < 1500:
+		return 50
+	case cumulativeScore < 3000:
+		return 90
+	default:
+		return 120
+	}
+}
+
 // canastaPlayerStr returns the display string for a single Canasta player.
 func canastaPlayerStr(player *domain.CanastaPlayer, i int, showCards bool) string {
 	var b strings.Builder
@@ -98,12 +113,22 @@ func (p *CanastaCuiPresenter) Output(g interfaces.CanastaGame, lastErr error) st
 			currentIdx := g.GetCurrentPlayerIdx()
 			b.WriteString(i18n.Tf("canasta.promptDraw",
 				"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
+			if g.GetIsFrozen() {
+				b.WriteString(color.Yellow(i18n.T("canasta.frozenPickupNote")) + "\n")
+			}
 			b.WriteString(i18n.T("canasta.promptDrawHelpStock") + "\n")
 			b.WriteString(i18n.T("canasta.promptDrawHelpDiscard") + "\n")
 		case domain.CanastaPhaseMeld:
 			currentIdx := g.GetCurrentPlayerIdx()
 			b.WriteString(i18n.Tf("canasta.promptMeld",
 				"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
+			// Surface the score-tiered initial-meld minimum so the human need not
+			// memorize the 15/50/90/120 bands (mirrors the web ca-meld-points).
+			if cur := g.GetPlayer(currentIdx); cur != nil && cur.GetIsHuman() && !cur.GetHasInitMeld() {
+				b.WriteString(color.Yellow(i18n.Tf("canasta.initialMeldRequirement",
+					"min", strconv.Itoa(canastaMinMeld(cur.GetCumulativeScore())),
+					"score", strconv.Itoa(cur.GetCumulativeScore()))) + "\n")
+			}
 			b.WriteString(i18n.T("canasta.promptMeldHelp") + "\n")
 			b.WriteString(i18n.T("canasta.promptSkipMeld") + "\n")
 		case domain.CanastaPhaseDiscard:

--- a/internal/adapter/presenter/CanastaCuiPresenter_test.go
+++ b/internal/adapter/presenter/CanastaCuiPresenter_test.go
@@ -68,6 +68,41 @@ func TestCanastaCuiPresenter_Output(t *testing.T) {
 
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "[フリーズ]")
+		// Draw phase with a frozen pile also shows the pickup-restriction note.
+		assert.Contains(t, result, "捨て札は凍結中")
+	})
+
+	t.Run("meld phase shows the score-tiered initial-meld minimum", func(t *testing.T) {
+		m, players := setupCanastaCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.CanastaPhaseMeld)
+		// Human (player 0), no initial meld, cumulative 0 -> 50-point band.
+		players[0].SetCumulativeScore(0)
+		players[0].SetHasInitMeld(false)
+
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "初回メルド最低点: 50点")
+	})
+
+	t.Run("meld phase minimum rises with the score band", func(t *testing.T) {
+		m, players := setupCanastaCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.CanastaPhaseMeld)
+		players[0].SetCumulativeScore(1500) // 1500-2999 band -> 90
+		players[0].SetHasInitMeld(false)
+
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "初回メルド最低点: 90点")
+	})
+
+	t.Run("meld phase hides the minimum once the initial meld is done", func(t *testing.T) {
+		m, players := setupCanastaCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.CanastaPhaseMeld)
+		players[0].SetHasInitMeld(true)
+
+		result := p.Output(m, nil)
+		assert.NotContains(t, result, "初回メルド最低点")
 	})
 
 	t.Run("discard top shown", func(t *testing.T) {

--- a/internal/adapter/presenter/CanastaCuiPresenter_test.go
+++ b/internal/adapter/presenter/CanastaCuiPresenter_test.go
@@ -95,6 +95,28 @@ func TestCanastaCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "初回メルド最低点: 90点")
 	})
 
+	t.Run("meld phase minimum is 15 for a negative score", func(t *testing.T) {
+		m, players := setupCanastaCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.CanastaPhaseMeld)
+		players[0].SetCumulativeScore(-100) // negative band -> 15
+		players[0].SetHasInitMeld(false)
+
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "初回メルド最低点: 15点")
+	})
+
+	t.Run("meld phase minimum is 120 at 3000+", func(t *testing.T) {
+		m, players := setupCanastaCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.CanastaPhaseMeld)
+		players[0].SetCumulativeScore(3000) // 3000+ band -> 120
+		players[0].SetHasInitMeld(false)
+
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "初回メルド最低点: 120点")
+	})
+
 	t.Run("meld phase hides the minimum once the initial meld is done", func(t *testing.T) {
 		m, players := setupCanastaCuiMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")

--- a/internal/i18n/locales/en/canasta.json
+++ b/internal/i18n/locales/en/canasta.json
@@ -24,6 +24,8 @@
   "promptDrawHelpStock": "ds: draw from stock",
   "promptDrawHelpDiscard": "dd <idx,idx>: take the discard pile (natural pair indices)",
   "promptMeld": "{{name}} to act (meld phase)",
+  "initialMeldRequirement": "Initial meld minimum: {{min}} pts (cumulative {{score}})",
+  "frozenPickupNote": "Discard pile frozen: taking it needs a natural pair matching the top card",
   "promptMeldHelp": "m <idx,idx,idx;idx,idx,idx>: lay down meld(s) (; separates groups)",
   "promptSkipMeld": "sm: skip melding",
   "promptDiscard": "{{name}} to act (discard phase)",

--- a/internal/i18n/locales/ja/canasta.json
+++ b/internal/i18n/locales/ja/canasta.json
@@ -24,6 +24,8 @@
   "promptDrawHelpStock": "ds・・・山札から引く",
   "promptDrawHelpDiscard": "dd <idx,idx>・・・捨て札の山を取る (ナチュラルペアのインデックス)",
   "promptMeld": "手番: {{name}} (メルドフェーズ)",
+  "initialMeldRequirement": "初回メルド最低点: {{min}}点（現在の累計 {{score}}点）",
+  "frozenPickupNote": "捨て札は凍結中: 取るには手札の自然な2枚で捨て札トップと同ランクの組が必要",
   "promptMeldHelp": "m <idx,idx,idx;idx,idx,idx>・・・メルドを出す (;でグループ区切り)",
   "promptSkipMeld": "sm・・・メルドせずにスキップ",
   "promptDiscard": "手番: {{name}} (ディスカードフェーズ)",


### PR DESCRIPTION
## 概要
Web版は `canastaMinMeld` によりスコア帯に応じた初回メルド最低点を表示するが、`CanastaCuiPresenter` の MELD フェーズは定型文のみで、CUI プレイヤーは 15/50/90/120 の最低点を暗記していないと初回メルドに失敗し続けていた。人間の MELD 手番かつ初回メルド未達成のとき最低点（＋現在の累計）を表示し、DRAW フェーズに凍結時の取り札制限の注意書きを追加する。

## 変更点
- `canastaMinMeld(score)`（<0→15 / <1500→50 / <3000→90 / それ以外→120、Web と一致）を追加
- MELD かつ人間の手番かつ `!GetHasInitMeld()` のとき `canasta.initialMeldRequirement`（黄色）を表示
- DRAW かつ `GetIsFrozen()` のとき `canasta.frozenPickupNote`（黄色）を表示
- 両キーを ja/en に追加
- スコア帯（0→50 / 1500→90）別／初回メルド達成後の非表示／凍結注意書きのテストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3060