### PR TITLE
feat(omaha): show the must-use-2 rule line in the CUI

### DIFF
--- a/internal/adapter/presenter/OmahaCuiPresenter.go
+++ b/internal/adapter/presenter/OmahaCuiPresenter.go
@@ -39,6 +39,11 @@ func omahaTitleKey(holeCards int, hiLo bool) string {
 func (p *OmahaCuiPresenter) Output(o interfaces.OmahaGame, lastErr error) string {
 	titleKey := omahaTitleKey(o.GetHoleCardCount(), o.GetIsHiLo())
 	return buildCuiOutput(i18n.T(titleKey), func(b *strings.Builder) {
+		// Omaha's defining pitfall: exactly two hole cards must be used. Surface
+		// it every render (the count adapts for Big O's five hole cards).
+		b.WriteString(i18n.Tf("omaha.mandatoryRuleLine",
+			"hole", strconv.Itoa(o.GetHoleCardCount())) + "\n")
+
 		cfg := o.GetConfig()
 		if cfg.TournamentMode {
 			b.WriteString(i18n.Tf("omaha.tournamentLine",

--- a/internal/adapter/presenter/OmahaCuiPresenter_test.go
+++ b/internal/adapter/presenter/OmahaCuiPresenter_test.go
@@ -45,6 +45,8 @@ func TestOmahaCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "あなた")
 		assert.Contains(t, result, "♠10")
 		assert.Contains(t, result, "♥11")
+		// The must-use-2 rule line is always shown; standard Omaha deals 4 holes.
+		assert.Contains(t, result, "手札4枚のうちちょうど2枚")
 	})
 
 	t.Run("community cards displayed", func(t *testing.T) {

--- a/internal/i18n/locales/en/omaha.json
+++ b/internal/i18n/locales/en/omaha.json
@@ -11,6 +11,7 @@
   "helpAllIn": "  a                    all-in",
   "helpBettingLimit": "  bl [0-2]             betting limit (0=Fixed, 1=PotLimit, 2=NoLimit)",
   "helpTournament": "  tm [0-1]             tournament mode",
+  "mandatoryRuleLine": "* Use exactly 2 of your {{hole}} hole cards + 3 board cards",
   "tournamentLine": "Tournament hand #{{hand}} SB:{{sb}} BB:{{bb}} (level-up every {{levelup}} hands)",
   "rebuyLine": "Rebuy: {{chips}} chips (max {{max}}, through hand {{period}})",
   "addonLine": "Add-on: {{chips}} chips (offered after hand {{after}})",

--- a/internal/i18n/locales/ja/omaha.json
+++ b/internal/i18n/locales/ja/omaha.json
@@ -11,6 +11,7 @@
   "helpAllIn": "  a                    オールイン",
   "helpBettingLimit": "  bl [0-2]             ベッティングリミット (0=Fixed, 1=PotLimit, 2=NoLimit)",
   "helpTournament": "  tm [0-1]             トーナメントモード",
+  "mandatoryRuleLine": "※手札{{hole}}枚のうちちょうど2枚＋ボード3枚を使用",
   "tournamentLine": "トーナメント ハンド#{{hand}} SB:{{sb}} BB:{{bb}} (レベルアップ:{{levelup}}ハンド毎)",
   "rebuyLine": "リバイ: {{chips}}チップ (最大{{max}}回, {{period}}ハンド目まで)",
   "addonLine": "アドオン: {{chips}}チップ ({{after}}ハンド目に提供)",


### PR DESCRIPTION
## 概要
Web版 `OmahaPage` は「手札からちょうど2枚＋ボード3枚」ルールバッジを常時表示するが、`OmahaCuiPresenter` はタイトル以降このルールへの言及がなく、CUI の初心者はオマハ最大の落とし穴を画面から知る術がなかった。タイトル直後にルール行を常時出力する。

## 変更点
- `Output` 冒頭に `omaha.mandatoryRuleLine` を出力（`GetHoleCardCount()` を `{{hole}}` に渡すため Big O の5枚でも文言が適応）
- `mandatoryRuleLine` キーを ja/en に追加
- 初期状態テストにルール行（手札4枚のうちちょうど2枚）のアサーションを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3003