### PR TITLE
feat(shortdeck): show the reshuffled hand-ranking rule reminder in the CUI

### DIFF
--- a/internal/adapter/presenter/ShortDeckCuiPresenter.go
+++ b/internal/adapter/presenter/ShortDeckCuiPresenter.go
@@ -23,6 +23,11 @@ func (p *ShortDeckCuiPresenter) ActionLogOutput(o interfaces.ShortDeckGame) stri
 // Output renders the current game state for the active locale (#1699).
 func (p *ShortDeckCuiPresenter) Output(o interfaces.ShortDeckGame, lastErr error) string {
 	return buildCuiOutput(i18n.T("shortdeck.outputTitle"), func(b *strings.Builder) {
+		// Short Deck reshuffles the hand ranking (flush beats full house) and
+		// counts A-6-7-8-9 as a straight; surface it every render so the CUI
+		// player is not caught out by the 36-card deck's rules.
+		b.WriteString(i18n.T("shortdeck.ruleReminderLine") + "\n")
+
 		cfg := o.GetConfig()
 		if cfg.TournamentMode {
 			b.WriteString(i18n.Tf("shortdeck.tournamentLine",

--- a/internal/adapter/presenter/ShortDeckCuiPresenter_test.go
+++ b/internal/adapter/presenter/ShortDeckCuiPresenter_test.go
@@ -44,6 +44,9 @@ func TestShortDeckCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "あなた")
 		assert.Contains(t, result, "♠10")
 		assert.Contains(t, result, "♥11")
+		// The Short Deck rule reminder is always shown.
+		assert.Contains(t, result, "フラッシュ＞フルハウス")
+		assert.Contains(t, result, "A-6-7-8-9")
 	})
 
 	t.Run("community cards displayed", func(t *testing.T) {

--- a/internal/i18n/locales/en/shortdeck.json
+++ b/internal/i18n/locales/en/shortdeck.json
@@ -9,6 +9,7 @@
   "helpBettingLimit": "  bl [0-2]             betting limit (0=Fixed, 1=PotLimit, 2=NoLimit)",
   "helpTournament": "  tm [0-1]             tournament mode",
   "outputTitle": "Short Deck Hold'em",
+  "ruleReminderLine": "* 36-card deck: flush beats full house / A-6-7-8-9 is a straight",
   "tournamentLine": "Tournament hand #{{hand}} SB:{{sb}} BB:{{bb}} (level-up every {{levelup}} hands)",
   "rebuyLine": "Rebuy: {{chips}} chips (max {{max}}, through hand {{period}})",
   "addonLine": "Add-on: {{chips}} chips (offered after hand {{after}})",

--- a/internal/i18n/locales/ja/shortdeck.json
+++ b/internal/i18n/locales/ja/shortdeck.json
@@ -9,6 +9,7 @@
   "helpBettingLimit": "  bl [0-2]             ベッティングリミット (0=Fixed, 1=PotLimit, 2=NoLimit)",
   "helpTournament": "  tm [0-1]             トーナメントモード",
   "outputTitle": "Short Deck Hold'em",
+  "ruleReminderLine": "※36枚デッキ: フラッシュ＞フルハウス / A-6-7-8-9もストレート",
   "tournamentLine": "トーナメント ハンド#{{hand}} SB:{{sb}} BB:{{bb}} (レベルアップ:{{levelup}}ハンド毎)",
   "rebuyLine": "リバイ: {{chips}}チップ (最大{{max}}回, {{period}}ハンド目まで)",
   "addonLine": "アドオン: {{chips}}チップ ({{after}}ハンド目に提供)",


### PR DESCRIPTION
## 概要
Web版 `ShortDeckPage` はショートデック特有のルール（フラッシュ＞フルハウス、A-6-7-8-9ストレート）を3箇所で案内するが、`ShortDeckCuiPresenter` にはこれらへの言及が皆無で、CUIプレイヤーは36枚デッキの役順位変更を知る術がなかった。タイトル直後にルール注意行を常時出力する。

## 変更点
- `Output` 冒頭に `shortdeck.ruleReminderLine`（※36枚デッキ: フラッシュ＞フルハウス / A-6-7-8-9もストレート）を常時出力
- `ruleReminderLine` キーを ja/en に追加
- 初期状態テストにルール行のアサーションを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3014