### PR TITLE
feat(spades): color bag counts near the penalty and show point-limit progress in the CUI

### DIFF
--- a/internal/adapter/presenter/SpadesCuiPresenter.go
+++ b/internal/adapter/presenter/SpadesCuiPresenter.go
@@ -11,17 +11,28 @@ import (
 )
 
 // spadesPlayerStr returns the display string for a single Spades player.
-func spadesPlayerStr(player *domain.SpadesPlayer, i int) string {
+func spadesPlayerStr(player *domain.SpadesPlayer, i, bagThreshold int) string {
 	var b strings.Builder
 	bidStr := i18n.T("spades.bidPending")
 	if player.GetBid() >= 0 {
 		bidStr = strconv.Itoa(player.GetBid())
 	}
+	// Highlight the bag count as it nears the penalty threshold (each threshold
+	// of accumulated bags costs 100 points), red within 1 and yellow within 2.
+	bagsStr := strconv.Itoa(player.GetBags())
+	if bagThreshold > 0 {
+		switch remaining := bagThreshold - player.GetBags(); {
+		case remaining <= 1:
+			bagsStr = color.Red(bagsStr)
+		case remaining <= 2:
+			bagsStr = color.Yellow(bagsStr)
+		}
+	}
 	b.WriteString(i18n.Tf("spades.playerLine",
 		"name", cuiPlayerName(player, i),
 		"bid", bidStr,
 		"tricks", strconv.Itoa(player.GetTrickCount()),
-		"bags", strconv.Itoa(player.GetBags()),
+		"bags", bagsStr,
 		"cum", strconv.Itoa(player.GetCumulativeScore()),
 		"round", strconv.Itoa(player.GetRoundScore()),
 		"cards", strconv.Itoa(player.GetCardsSize()),
@@ -49,8 +60,22 @@ func (p *SpadesCuiPresenter) Output(s interfaces.SpadesGame, lastErr error) stri
 			b.WriteString(i18n.T("spades.spadesBrokenNo") + "\n")
 		}
 
+		// Point-limit progress: whoever reaches the limit first wins, so surface
+		// the limit and the current leader (highest cumulative score).
+		cfg := s.GetConfig()
+		leaderIdx, maxScore := 0, s.GetPlayer(0).GetCumulativeScore()
+		for i := 1; i < s.GetPlayerCnt(); i++ {
+			if score := s.GetPlayer(i).GetCumulativeScore(); score > maxScore {
+				maxScore, leaderIdx = score, i
+			}
+		}
+		b.WriteString(i18n.Tf("spades.limitProgress",
+			"limit", strconv.Itoa(cfg.PointLimit),
+			"name", cuiPlayerName(s.GetPlayer(leaderIdx), leaderIdx),
+			"score", strconv.Itoa(maxScore)) + "\n")
+
 		for i := 0; i < s.GetPlayerCnt(); i++ {
-			b.WriteString(spadesPlayerStr(s.GetPlayer(i), i))
+			b.WriteString(spadesPlayerStr(s.GetPlayer(i), i, cfg.BagPenaltyThreshold))
 		}
 
 		b.WriteString("----------\n")

--- a/internal/adapter/presenter/SpadesCuiPresenter_test.go
+++ b/internal/adapter/presenter/SpadesCuiPresenter_test.go
@@ -73,6 +73,25 @@ func TestSpadesCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "CPU 1: ビッド=未ビッド 獲得0トリック バッグ0 累積0点 ラウンド0点 1枚")
 		assert.Contains(t, result, "手番: あなた")
 		assert.Contains(t, result, "play <idx>")
+		// Point-limit progress line (default limit 500, all scores at 0).
+		assert.Contains(t, result, "上限: 500点")
+		assert.Contains(t, result, "首位:")
+	})
+
+	t.Run("bag count is colored as it nears the penalty threshold", func(t *testing.T) {
+		origNo := color.NoColor()
+		color.SetNoColor(false)
+		defer color.SetNoColor(origNo)
+		m, players := setupSpadesCuiMockWithPlayers()
+		players[0].SetBags(9) // threshold 10, remaining 1 -> red
+		players[1].SetBags(8) // remaining 2 -> yellow
+		players[2].SetBags(3) // remaining 7 -> plain
+
+		result := p.Output(m, nil)
+		assert.Contains(t, result, color.Red("9"))
+		assert.Contains(t, result, color.Yellow("8"))
+		assert.NotContains(t, result, color.Red("3"))
+		assert.NotContains(t, result, color.Yellow("3"))
 	})
 
 	t.Run("spades broken shows あり", func(t *testing.T) {

--- a/internal/i18n/locales/en/spades.json
+++ b/internal/i18n/locales/en/spades.json
@@ -10,6 +10,7 @@
   "spadesBrokenYes": "Spades broken: yes",
   "spadesBrokenNo": "Spades broken: no",
   "bidPending": "no bid",
+  "limitProgress": "Limit: {{limit}} pts / leader: {{name}} {{score}} pts",
   "playerLine": "{{name}}: bid={{bid}} won {{tricks}} tricks, bags {{bags}}, cum {{cum}}pt round {{round}}pt {{cards}} cards",
   "gameEnd": "Game over! {{name}} wins!",
   "promptBid": "Bid phase — {{name}} to act",

--- a/internal/i18n/locales/ja/spades.json
+++ b/internal/i18n/locales/ja/spades.json
@@ -10,6 +10,7 @@
   "spadesBrokenYes": "スペードブレイク: あり",
   "spadesBrokenNo": "スペードブレイク: なし",
   "bidPending": "未ビッド",
+  "limitProgress": "上限: {{limit}}点 / 首位: {{name}} {{score}}点",
   "playerLine": "{{name}}: ビッド={{bid}} 獲得{{tricks}}トリック バッグ{{bags}} 累積{{cum}}点 ラウンド{{round}}点 {{cards}}枚",
   "gameEnd": "ゲーム終了！ {{name}}の勝利です！",
   "promptBid": "ビッドフェーズ: {{name}}の番",


### PR DESCRIPTION
## 概要
`SpadesCuiPresenter` はバッグ数をペナルティ閾値と無関係に素の数値で出し、ゲーム終了条件のポイント上限に対する進捗行もなかった（Hearts と同様の課題だが Spades はバッグ減点があるぶん影響大）。バッグ表記を閾値接近で色付けし、ヘッダに上限＋首位スコアの進捗行を追加する。

## 変更点
- `spadesPlayerStr` に `bagThreshold` を渡し、`残り<=1` で赤／`残り<=2` で黄にバッグ数を色付け（`BagPenaltyThreshold`）
- ヘッダに `spades.limitProgress`（上限＋首位＝最高累計スコア）を追加（`GetConfig().PointLimit`）
- `limitProgress` キーを ja/en に追加
- 進捗行／バッグ色分岐（赤=9・黄=8・無色=3）のテストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3048