### PR TITLE
feat(napoleon): show Napoleon-army face-collection progress in the CUI

### DIFF
--- a/internal/adapter/presenter/NapoleonCuiPresenter.go
+++ b/internal/adapter/presenter/NapoleonCuiPresenter.go
@@ -98,6 +98,29 @@ func (p *NapoleonCuiPresenter) Output(n interfaces.NapoleonGame, lastErr error) 
 			b.WriteString("\n")
 		}
 
+		// Napoleon-army face-card progress vs the bid target. The adjutant's
+		// captures are only added once revealed, to avoid leaking their identity
+		// (mirrors the web napoleonFaceProgress logic).
+		if n.GetPhase() == domain.NapoleonPhasePlay {
+			napIdx := n.GetNapoleonIdx()
+			if napIdx >= 0 {
+				collected := n.GetPlayer(napIdx).GetPictureCards()
+				if n.GetAdjutantRevealed() {
+					if adjIdx := n.GetAdjutantIdx(); adjIdx >= 0 && adjIdx != napIdx {
+						collected += n.GetPlayer(adjIdx).GetPictureCards()
+					}
+				}
+				bid := n.GetHighestBid()
+				line := i18n.Tf("napoleon.armyProgress",
+					"collected", strconv.Itoa(collected),
+					"bid", strconv.Itoa(bid))
+				if bid > 0 && collected >= bid {
+					line = color.Green(line)
+				}
+				b.WriteString(line + "\n")
+			}
+		}
+
 		// Player rows
 		for i := 0; i < n.GetPlayerCnt(); i++ {
 			b.WriteString(napoleonPlayerStr(n.GetPlayer(i), i, n.GetAdjutantRevealed()))

--- a/internal/adapter/presenter/NapoleonCuiPresenter_test.go
+++ b/internal/adapter/presenter/NapoleonCuiPresenter_test.go
@@ -24,6 +24,8 @@ func setupNapoleonCuiMock() *interfaces.MockNapoleonGame {
 	m.On("GetAdjutantCard").Return((*domain.Card)(nil))
 	m.On("GetAdjutantRevealed").Return(false)
 	m.On("GetHighestBid").Return(0)
+	m.On("GetNapoleonIdx").Return(-1)
+	m.On("GetAdjutantIdx").Return(-1)
 	m.On("GetCurrentTrick").Return([]*domain.NapoleonTrickCard(nil))
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetPhase").Return(domain.NapoleonPhasePlay)
@@ -120,6 +122,44 @@ func TestNapoleonCuiPresenter_Output(t *testing.T) {
 
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "最高ビッド: 14")
+	})
+
+	// napoleonArmyMock configures Napoleon(0) + adjutant(1) with the given face
+	// captures, bid, and reveal state for the army-progress tests.
+	napoleonArmyMock := func(napFaces, adjFaces, bid int, revealed bool) *interfaces.MockNapoleonGame {
+		m, players := setupNapoleonCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetNapoleonIdx")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetAdjutantIdx")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHighestBid")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetAdjutantRevealed")
+		m.On("GetNapoleonIdx").Return(0)
+		m.On("GetAdjutantIdx").Return(1)
+		m.On("GetHighestBid").Return(bid)
+		m.On("GetAdjutantRevealed").Return(revealed)
+		players[0].SetPictureCards(napFaces)
+		players[1].SetPictureCards(adjFaces)
+		return m
+	}
+
+	t.Run("army progress excludes adjutant faces while hidden", func(t *testing.T) {
+		m := napoleonArmyMock(5, 3, 14, false)
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "ナポレオン軍: 5/14枚")
+	})
+
+	t.Run("army progress adds adjutant faces once revealed", func(t *testing.T) {
+		m := napoleonArmyMock(5, 3, 14, true)
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "ナポレオン軍: 8/14枚")
+	})
+
+	t.Run("army progress turns green once the bid is met", func(t *testing.T) {
+		origNo := color.NoColor()
+		color.SetNoColor(false)
+		defer color.SetNoColor(origNo)
+		m := napoleonArmyMock(14, 0, 14, false)
+		result := p.Output(m, nil)
+		assert.Contains(t, result, color.Green("ナポレオン軍: 14/14枚"))
 	})
 
 	t.Run("player with scores and tricks and pictureCards", func(t *testing.T) {

--- a/internal/i18n/locales/en/napoleon.json
+++ b/internal/i18n/locales/en/napoleon.json
@@ -19,6 +19,7 @@
   "adjutantCard": "Adjutant card: {{card}}",
   "adjutantRevealed": " (revealed)",
   "adjutantHidden": " (hidden)",
+  "armyProgress": "Napoleon army: {{collected}}/{{bid}} faces",
   "highestBid": "Highest bid: {{bid}}",
   "gameEndNapoleonWin": "Game over! The Napoleon side wins!",
   "gameEndAlliedWin": "Game over! The Allied side wins!",

--- a/internal/i18n/locales/ja/napoleon.json
+++ b/internal/i18n/locales/ja/napoleon.json
@@ -19,6 +19,7 @@
   "adjutantCard": "副官カード: {{card}}",
   "adjutantRevealed": " (公開済み)",
   "adjutantHidden": " (非公開)",
+  "armyProgress": "ナポレオン軍: {{collected}}/{{bid}}枚",
   "highestBid": "最高ビッド: {{bid}}",
   "gameEndNapoleonWin": "ゲーム終了！ ナポレオン軍の勝利です！",
   "gameEndAlliedWin": "ゲーム終了！ 連合軍の勝利です！",


### PR DESCRIPTION
## 概要
Web版 `NapoleonPage` は「ナポレオン軍 {collected}/{bid} 枚」バッジを表示し、副官の獲得分は公開後のみ合算して正体漏洩を防ぐが、`NapoleonCuiPresenter` は各プレイヤーの個別絵札数を出すだけで、軍合計と目標ビッドの対比を毎回暗算する必要があった。PLAY フェーズに獲得/目標の進捗行を追加する（Web と同じ漏洩防止ロジック）。

## 変更点
- PLAY フェーズに `napoleon.armyProgress` 行を追加：ナポレオン本人＋（`GetAdjutantRevealed()` が true のときのみ）副官の `GetPictureCards()` を合算
- 目標達成（`collected >= bid`）時は `color.Green` で表示
- `armyProgress` キーを ja/en に追加
- 副官非公開（5/14）／公開（8/14）／達成緑（14/14）の分岐テストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3066