### PR TITLE
feat(crazyeights): mark legal cards in the human's hand in the CUI

### DIFF
--- a/internal/adapter/presenter/CrazyEightsCuiPresenter.go
+++ b/internal/adapter/presenter/CrazyEightsCuiPresenter.go
@@ -10,8 +10,41 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
-// crazyEightsPlayerStr returns the display string for a single CrazyEights player.
-func crazyEightsPlayerStr(player *domain.CrazyEightsPlayer, i int) string {
+// crazyEightsIsLegal reports whether a card may be played onto the current
+// discard top (mirrors the domain's unexported isValidPlay): eights are always
+// legal; once a suit is chosen only that suit matches; otherwise suit or rank.
+func crazyEightsIsLegal(card, top *domain.Card, chosenSuit int) bool {
+	if card.GetValue() == domain.CrazyEightsWildValue {
+		return true
+	}
+	if top == nil {
+		return true
+	}
+	if chosenSuit > 0 {
+		return card.GetDesign() == chosenSuit
+	}
+	return card.GetDesign() == top.GetDesign() || card.GetValue() == top.GetValue()
+}
+
+// crazyEightsHandStr renders the human hand as an indexed list, appending "*"
+// to each card that is legal to play right now.
+func crazyEightsHandStr(player *domain.CrazyEightsPlayer, top *domain.Card, chosenSuit int) string {
+	parts := make([]string, player.GetCardsSize())
+	for i := 0; i < player.GetCardsSize(); i++ {
+		c := player.GetCard(i)
+		s := "[" + strconv.Itoa(i) + "]" + cuiCardStr(c)
+		if crazyEightsIsLegal(c, top, chosenSuit) {
+			s += "*"
+		}
+		parts[i] = s
+	}
+	return strings.Join(parts, "  ")
+}
+
+// crazyEightsPlayerStr returns the display string for a single CrazyEights
+// player. When markLegal is set (the human's play turn), legal cards are
+// starred to spare the player from matching suit/rank by hand.
+func crazyEightsPlayerStr(player *domain.CrazyEightsPlayer, i int, markLegal bool, top *domain.Card, chosenSuit int) string {
 	var b strings.Builder
 	b.WriteString(i18n.Tf("crazyeights.playerLine",
 		"name", cuiPlayerName(player, i),
@@ -19,7 +52,11 @@ func crazyEightsPlayerStr(player *domain.CrazyEightsPlayer, i int) string {
 		"round", strconv.Itoa(player.GetRoundScore()),
 		"cards", strconv.Itoa(player.GetCardsSize())) + "\n")
 	if player.GetIsHuman() && player.GetCardsSize() > 0 {
-		b.WriteString(cuiIndexedCardListStr(player) + "\n")
+		if markLegal {
+			b.WriteString(crazyEightsHandStr(player, top, chosenSuit) + "\n")
+		} else {
+			b.WriteString(cuiIndexedCardListStr(player) + "\n")
+		}
 	}
 	return b.String()
 }
@@ -44,8 +81,13 @@ func (p *CrazyEightsCuiPresenter) Output(g interfaces.CrazyEightsGame, lastErr e
 			b.WriteString("\n")
 		}
 
+		phase := g.GetPhase()
+		currentIdx := g.GetCurrentPlayerIdx()
+		top := g.GetDiscardTop()
+		chosenSuit := g.GetChosenSuit()
 		for i := 0; i < g.GetPlayerCnt(); i++ {
-			b.WriteString(crazyEightsPlayerStr(g.GetPlayer(i), i))
+			markLegal := phase == domain.CrazyEightsPhasePlay && i == currentIdx
+			b.WriteString(crazyEightsPlayerStr(g.GetPlayer(i), i, markLegal, top, chosenSuit))
 		}
 
 		b.WriteString("----------\n")
@@ -59,9 +101,8 @@ func (p *CrazyEightsCuiPresenter) Output(g interfaces.CrazyEightsGame, lastErr e
 			b.WriteString(color.Green(banner) + "\n")
 			return
 		}
-		switch g.GetPhase() {
+		switch phase {
 		case domain.CrazyEightsPhasePlay:
-			currentIdx := g.GetCurrentPlayerIdx()
 			b.WriteString(i18n.Tf("crazyeights.promptCurrentPlayer",
 				"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
 			b.WriteString(i18n.T("crazyeights.promptPlayHelp") + "\n")

--- a/internal/adapter/presenter/CrazyEightsCuiPresenter_test.go
+++ b/internal/adapter/presenter/CrazyEightsCuiPresenter_test.go
@@ -82,6 +82,53 @@ func TestCrazyEightsCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "捨て札: HEART 7")
 	})
 
+	t.Run("legal cards are starred on the human's play turn", func(t *testing.T) {
+		m, players := setupCrazyEightsCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetDiscardTop")
+		m.On("GetDiscardTop").Return(domain.NewCard(domain.CardDesignHeart, 7, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 5, false))  // suit match -> legal
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 3, false))  // no match -> not legal
+		players[0].AddCard(domain.NewCard(domain.CardDesignClover, 7, false)) // rank match -> legal
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 8, false))  // eight -> always legal
+
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "[0]HEART 5*")
+		assert.Contains(t, result, "[1]SPADE 3")
+		assert.NotContains(t, result, "[1]SPADE 3*")
+		assert.Contains(t, result, "[2]CLOVER 7*")
+		assert.Contains(t, result, "[3]SPADE 8*")
+	})
+
+	t.Run("chosen suit governs legality after an eight is played", func(t *testing.T) {
+		m, players := setupCrazyEightsCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetDiscardTop")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetChosenSuit")
+		m.On("GetDiscardTop").Return(domain.NewCard(domain.CardDesignSpade, 8, false))
+		m.On("GetChosenSuit").Return(domain.CardDesignHeart)
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 2, false))  // matches chosen suit -> legal
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 3, false))  // spade, not 8 -> not legal
+		players[0].AddCard(domain.NewCard(domain.CardDesignClover, 8, false)) // eight -> always legal
+
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "[0]HEART 2*")
+		assert.Contains(t, result, "[1]SPADE 3")
+		assert.NotContains(t, result, "[1]SPADE 3*")
+		assert.Contains(t, result, "[2]CLOVER 8*")
+	})
+
+	t.Run("no legal markers when it is not the human's turn", func(t *testing.T) {
+		m, players := setupCrazyEightsCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetDiscardTop")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentPlayerIdx")
+		m.On("GetDiscardTop").Return(domain.NewCard(domain.CardDesignHeart, 7, false))
+		m.On("GetCurrentPlayerIdx").Return(1)                                // a CPU is to act
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 5, false)) // would be legal if marked
+
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "[0]HEART 5")
+		assert.NotContains(t, result, "[0]HEART 5*")
+	})
+
 	t.Run("discard top nil hides section", func(t *testing.T) {
 		m, _ := setupCrazyEightsCuiMockWithPlayers()
 


### PR DESCRIPTION
## 概要
Web版は `isCrazyEightsLegalPlay` で合法カードを緑リング表示するが、`CrazyEightsCuiPresenter` は手札を無差別に列挙するだけで、捨て札トップ（`GetDiscardTop`）と選択スート（`GetChosenSuit`）に対して出せるカードが分からず、毎ターン自分でスート/ランク照合する必要があった。人間の手番（PhasePlay かつ current が human）のとき、合法カードに `*` を付ける。

## 変更点
- `crazyEightsIsLegal`（8=常に可 / chosenSuit>0 はそのスートのみ / それ以外はスートorランク一致、domain `isValidPlay` と一致）を追加
- `crazyEightsHandStr` で合法カードに `*` を付けたインデックス表示、`markLegal`（PhasePlay かつ current が human）時のみ使用
- 新規 i18n キーなし
- 合法判定（スート/ランク/8）／chosenSuit 指定後（8プレイ直後）／手番外非表示 の分岐テストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues

Closes #3051