### PR TITLE
feat(russianpoker): add a SELECT-phase guide and Ante/Play payout breakdown to the CUI

### DIFF
--- a/internal/adapter/presenter/RussianPokerCuiPresenter.go
+++ b/internal/adapter/presenter/RussianPokerCuiPresenter.go
@@ -91,6 +91,10 @@ func (rp *RussianPokerCuiPresenter) Output(g interfaces.RussianPokerGame, lastEr
 		sb.WriteString(color.Yellow(i18n.T("russianpoker.forceQualifyGuide")) + "\n")
 	}
 
+	if g.GetPhase() == domain.RussianPokerPhaseSelect {
+		sb.WriteString(color.Yellow(i18n.T("russianpoker.selectGuide")) + "\n")
+	}
+
 	if g.GetGameEndFlag() {
 		sb.WriteString(i18n.Tf("russianpoker.anteLine", "ante", strconv.Itoa(g.GetAnteBet())) + "\n")
 		if g.GetPlayBet() > 0 {
@@ -112,6 +116,14 @@ func (rp *RussianPokerCuiPresenter) Output(g interfaces.RussianPokerGame, lastEr
 		case domain.GameResultDraw:
 			sb.WriteString(color.Yellow(i18n.T("russianpoker.push")) + "\n")
 		default:
+		}
+		// Per-bet payout breakdown (omitted when zero) so the player sees which
+		// bet paid, matching the web payout-breakdown.
+		if ante := g.GetAntePayout(); ante != 0 {
+			sb.WriteString(i18n.Tf("russianpoker.antePayoutLine", "payout", strconv.Itoa(ante)) + "\n")
+		}
+		if play := g.GetPlayPayout(); play != 0 {
+			sb.WriteString(i18n.Tf("russianpoker.playPayoutLine", "payout", strconv.Itoa(play)) + "\n")
 		}
 		sb.WriteString(i18n.Tf("russianpoker.totalPayoutLine", "payout", strconv.Itoa(g.GetTotalPayout())) + "\n")
 		sb.WriteString("----------\n")

--- a/internal/adapter/presenter/RussianPokerCuiPresenter_test.go
+++ b/internal/adapter/presenter/RussianPokerCuiPresenter_test.go
@@ -203,7 +203,52 @@ func TestRussianPokerCuiPresenter_Output_EndPhase_PlayerWins(t *testing.T) {
 	assert.Contains(t, result, "フェーズ: END")
 	assert.Contains(t, result, "プレイヤーの勝ち")
 	assert.Contains(t, result, "(Qualified)")
+	assert.Contains(t, result, "アンテ払戻し: 200")
+	assert.Contains(t, result, "プレイ払戻し: 800")
 	assert.Contains(t, result, "合計払戻し: 1000")
+}
+
+func TestRussianPokerCuiPresenter_Output_SelectPhase_ShowsGuide(t *testing.T) {
+	p := new(RussianPokerCuiPresenter)
+	m := new(interfaces.MockRussianPokerGame)
+	setupRussianPokerCuiMockDefaults(m)
+	m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPhase")
+	m.On("GetPhase").Return(domain.RussianPokerPhaseSelect).Maybe()
+
+	result := p.Output(m, nil)
+	assert.Contains(t, result, "捨てるカードの番号を選んでください")
+}
+
+func TestRussianPokerCuiPresenter_Output_EndPhase_ZeroBreakdownOmitted(t *testing.T) {
+	p := new(RussianPokerCuiPresenter)
+	m := new(interfaces.MockRussianPokerGame)
+	m.On("GetChips").Return(900).Maybe()
+	m.On("GetPhase").Return(domain.RussianPokerPhaseEnd).Maybe()
+	m.On("GetPlayerHand").Return(([]*domain.Card)(nil)).Maybe()
+	m.On("GetDealerHand").Return(([]*domain.Card)(nil)).Maybe()
+	m.On("GetGameEndFlag").Return(true).Maybe()
+	m.On("GetAnteBet").Return(100).Maybe()
+	m.On("GetExchangeCount").Return(0).Maybe()
+	m.On("GetExchangeFee").Return(0).Maybe()
+	m.On("GetBought6th").Return(false).Maybe()
+	m.On("GetBuy6thFee").Return(0).Maybe()
+	m.On("GetForceExchanged").Return(false).Maybe()
+	m.On("GetForceExchangeFee").Return(0).Maybe()
+	m.On("GetPlayBet").Return(0).Maybe()
+	m.On("GetResult").Return(domain.GameResultLose).Maybe()
+	m.On("GetAntePayout").Return(0).Maybe()
+	m.On("GetPlayPayout").Return(0).Maybe()
+	m.On("GetTotalPayout").Return(0).Maybe()
+	m.On("GetDealerQualified").Return(false).Maybe()
+	m.On("GetPlayerHandRank").Return(domain.PokerHandHighCard).Maybe()
+	m.On("GetDealerHandRank").Return(domain.PokerHandHighCard).Maybe()
+	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
+
+	result := p.Output(m, nil)
+	// Zero ante/play payouts omit their breakdown lines.
+	assert.NotContains(t, result, "アンテ払戻し")
+	assert.NotContains(t, result, "プレイ払戻し")
+	assert.Contains(t, result, "合計払戻し: 0")
 }
 
 func TestRussianPokerCuiPresenter_Output_EndPhase_Fold(t *testing.T) {

--- a/internal/i18n/locales/en/russianpoker.json
+++ b/internal/i18n/locales/en/russianpoker.json
@@ -32,5 +32,8 @@
   "dealerWins": "Dealer wins!",
   "playerFolded": "Player folded.",
   "push": "Push!",
+  "selectGuide": "Choose the number of the card to discard",
+  "antePayoutLine": "Ante payout: {{payout}}",
+  "playPayoutLine": "Play payout: {{payout}}",
   "totalPayoutLine": "total payout: {{payout}}"
 }

--- a/internal/i18n/locales/ja/russianpoker.json
+++ b/internal/i18n/locales/ja/russianpoker.json
@@ -32,5 +32,8 @@
   "dealerWins": "ディーラーの勝ち！",
   "playerFolded": "プレイヤーがフォールド。",
   "push": "プッシュ！",
+  "selectGuide": "捨てるカードの番号を選んでください",
+  "antePayoutLine": "アンテ払戻し: {{payout}}",
+  "playPayoutLine": "プレイ払戻し: {{payout}}",
   "totalPayoutLine": "合計払戻し: {{payout}}"
 }


### PR DESCRIPTION
## 概要
`RussianPokerCuiPresenter` は SELECT（6枚目購入後の捨て札選択）フェーズに操作ガイドがなく、CUIプレイヤーはどう操作すべきか分からなかった。また終了時は手数料は出るが Web の `payout-breakdown`（Ante/Play 別の払い戻し）に相当する行がなく合計のみだった。SELECT ガイドと Ante/Play 払戻し内訳を追加する。

## 変更点
- `GetPhase() == RussianPokerPhaseSelect` のとき `russianpoker.selectGuide`（黄色）を表示
- 終了ブロックで `GetAntePayout()`/`GetPlayPayout()` が 0 以外のとき `antePayoutLine`/`playPayoutLine` を合計の前に表示
- `selectGuide`/`antePayoutLine`/`playPayoutLine` キーを ja/en に追加
- SELECT ガイド表示／Ante/Play 内訳表示／0時の省略 のテストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3327