### PR TITLE
feat(tonk): reveal knocker melds and CPU hands at round end in the CUI

### DIFF
--- a/internal/adapter/presenter/TonkCuiPresenter.go
+++ b/internal/adapter/presenter/TonkCuiPresenter.go
@@ -51,6 +51,47 @@ func tonkPlayerStr(player *domain.TonkPlayer, i int) string {
 	return b.String()
 }
 
+// tonkMeldIsSet reports whether a meld is a set (same rank) rather than a run.
+func tonkMeldIsSet(meld []*domain.Card) bool {
+	if len(meld) == 0 {
+		return false
+	}
+	rank := meld[0].GetValue()
+	for _, c := range meld {
+		if c.GetValue() != rank {
+			return false
+		}
+	}
+	return true
+}
+
+// writeTonkKnockerMelds lists the knocker's melds with a set/run label.
+func writeTonkKnockerMelds(b *strings.Builder, melds [][]*domain.Card) {
+	if len(melds) == 0 {
+		return
+	}
+	b.WriteString(color.Bold(i18n.T("tonk.knockerMeldsHeader")) + "\n")
+	for i, meld := range melds {
+		typeLabel := i18n.T("tonk.meldRun")
+		if tonkMeldIsSet(meld) {
+			typeLabel = i18n.T("tonk.meldSet")
+		}
+		b.WriteString(i18n.Tf("tonk.knockerMeldLine",
+			"idx", strconv.Itoa(i+1),
+			"type", typeLabel,
+			"cards", cuiCardSliceStr(meld)) + "\n")
+	}
+}
+
+// tonkHandCards returns a player's remaining cards as a slice.
+func tonkHandCards(player *domain.TonkPlayer) []*domain.Card {
+	cards := make([]*domain.Card, player.GetCardsSize())
+	for i := range cards {
+		cards[i] = player.GetCard(i)
+	}
+	return cards
+}
+
 // TonkCuiPresenter renders the Tonk CUI view.
 type TonkCuiPresenter struct{}
 
@@ -106,6 +147,17 @@ func (p *TonkCuiPresenter) Output(g interfaces.TonkGame, lastErr error) string {
 		case domain.TonkPhaseRoundEnd:
 			if g.GetIsTonk() {
 				b.WriteString(i18n.T("tonk.promptDealtTonk") + "\n")
+			}
+			// Reveal the knocker's melds and each CPU's remaining hand so the
+			// round score has visible justification (parity with the web panel).
+			writeTonkKnockerMelds(b, g.GetKnockerMelds())
+			for i := 0; i < g.GetPlayerCnt(); i++ {
+				cp := g.GetPlayer(i)
+				if !cp.GetIsHuman() && cp.GetCardsSize() > 0 {
+					b.WriteString(i18n.Tf("tonk.revealedHand",
+						"name", cuiPlayerName(cp, i),
+						"cards", cuiCardSliceStr(tonkHandCards(cp))) + "\n")
+				}
 			}
 			b.WriteString(i18n.T("tonk.promptRoundEnd") + "\n")
 			b.WriteString(i18n.T("tonk.promptRoundEndHelp") + "\n")

--- a/internal/adapter/presenter/TonkCuiPresenter_test.go
+++ b/internal/adapter/presenter/TonkCuiPresenter_test.go
@@ -24,6 +24,7 @@ func setupTonkCuiMock() *interfaces.MockTonkGame {
 	m.On("GetCurrentPlayerIdx").Return(0)
 	m.On("GetWinnerIdx").Return(-1)
 	m.On("GetIsTonk").Return(false)
+	m.On("GetKnockerMelds").Return(([][]*domain.Card)(nil)).Maybe()
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
 	return m
 }
@@ -179,6 +180,41 @@ func TestTonkCuiPresenter_Output(t *testing.T) {
 
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "配牌Tonk成立")
+	})
+
+	t.Run("round end reveals knocker melds and CPU hands", func(t *testing.T) {
+		m, players := setupTonkCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetKnockerMelds")
+		m.On("GetPhase").Return(domain.TonkPhaseRoundEnd)
+		m.On("GetKnockerMelds").Return([][]*domain.Card{
+			{ // set of 7s
+				domain.NewCard(domain.CardDesignSpade, 7, false),
+				domain.NewCard(domain.CardDesignHeart, 7, false),
+				domain.NewCard(domain.CardDesignClover, 7, false),
+			},
+			{ // run of clubs 4-5-6
+				domain.NewCard(domain.CardDesignClover, 4, false),
+				domain.NewCard(domain.CardDesignClover, 5, false),
+				domain.NewCard(domain.CardDesignClover, 6, false),
+			},
+		})
+		// The CPU's remaining hand is revealed at round end.
+		players[1].AddCard(domain.NewCard(domain.CardDesignDiamond, 12, false))
+
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "[ノッカーのメルド]")
+		assert.Contains(t, result, "メルド1(セット):")
+		assert.Contains(t, result, "メルド2(ラン):")
+		assert.Contains(t, result, "CPU 1の手札: DIAMOND 12")
+	})
+
+	t.Run("CPU hands are not revealed during play", func(t *testing.T) {
+		m, players := setupTonkCuiMockWithPlayers()
+		players[1].AddCard(domain.NewCard(domain.CardDesignDiamond, 12, false))
+
+		result := p.Output(m, nil) // default phase is Draw
+		assert.NotContains(t, result, "CPU 1の手札:")
 	})
 }
 

--- a/internal/i18n/locales/en/tonk.json
+++ b/internal/i18n/locales/en/tonk.json
@@ -21,6 +21,11 @@
   "promptDiscardHelp": "d <idx>: discard a card",
   "promptKnockHelp": "k <idx>: knock (deadwood <= 5)",
   "promptDealtTonk": "Dealt-hand Tonk!",
+  "knockerMeldsHeader": "[Knocker melds]",
+  "knockerMeldLine": "Meld {{idx}} ({{type}}): {{cards}}",
+  "meldSet": "set",
+  "meldRun": "run",
+  "revealedHand": "{{name}} hand: {{cards}}",
   "promptRoundEnd": "Round complete",
   "promptRoundEndHelp": "nr / nextround: advance to next round"
 }

--- a/internal/i18n/locales/ja/tonk.json
+++ b/internal/i18n/locales/ja/tonk.json
@@ -21,6 +21,11 @@
   "promptDiscardHelp": "d <idx>・・・カードを捨てる",
   "promptKnockHelp": "k <idx>・・・ノック (デッドウッド5点以下で宣言)",
   "promptDealtTonk": "配牌Tonk成立！",
+  "knockerMeldsHeader": "[ノッカーのメルド]",
+  "knockerMeldLine": "メルド{{idx}}({{type}}): {{cards}}",
+  "meldSet": "セット",
+  "meldRun": "ラン",
+  "revealedHand": "{{name}}の手札: {{cards}}",
   "promptRoundEnd": "ラウンド終了",
   "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ"
 }


### PR DESCRIPTION
## 概要
Web版 `TonkPage` はラウンド終了時にノッカーのメルドと CPU の手札を公開するが、`TonkCuiPresenter` は定型プロンプトのみで、ノッカーが揃えたメルドや各プレイヤーの残り手札が分からず点数の根拠が不明だった。ラウンド終了時にノッカーのメルド（セット/ラン別）と各 CPU の残り手札を公開する（プレイ中は非表示）。

## 変更点
- RoundEnd 分岐で `GetKnockerMelds()` を「メルド{n}(セット/ラン): カード列」で表示
- 各 CPU（非人間）の残り手札を `tonk.revealedHand` で公開
- `tonkMeldIsSet`/`writeTonkKnockerMelds`/`tonkHandCards` ヘルパを追加
- `knockerMeldsHeader`/`knockerMeldLine`/`meldSet`/`meldRun`/`revealedHand` キーを ja/en に追加
- ラウンド終了時の公開／プレイ中の非公開（情報リークなし）のテストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3233