### PR TITLE
feat(spanish21): show variant bonus names at game end in the CUI

### DIFF
--- a/internal/adapter/presenter/BlackJackCuiPresenter.go
+++ b/internal/adapter/presenter/BlackJackCuiPresenter.go
@@ -206,6 +206,14 @@ func (bjp *BlackJackCuiPresenter) Output(bj interfaces.BlackJackGame, lastErr er
 				b.WriteString(color.Red(i18n.T("blackjack.resultLose")) + "\n")
 			}
 		}
+		// Variant bonuses (e.g. Spanish 21's 5/6/7-card 21, 6-7-8, 7-7-7). Empty
+		// for standard Blackjack, so this leaves the normal output unchanged.
+		if bonusKeys := bj.GetBonusKeys(); len(bonusKeys) > 0 {
+			b.WriteString(color.BoldYellow(i18n.T("blackjack.bonusHeader")) + "\n")
+			for _, key := range bonusKeys {
+				b.WriteString(color.Yellow(i18n.Tf("blackjack.bonusLine", "name", i18n.T(key))) + "\n")
+			}
+		}
 		b.WriteString("\n----------\n")
 	}
 	return b.String()

--- a/internal/adapter/presenter/BlackJackCuiPresenter_test.go
+++ b/internal/adapter/presenter/BlackJackCuiPresenter_test.go
@@ -127,6 +127,31 @@ func TestBlackJackCuiPresenters_Method(t *testing.T) {
 		_ = bj.PlayerStand()
 		output := tbp.Output(bj, nil)
 		assert.Contains(t, output, "あなたの勝ちです")
+		// Standard Blackjack has no variant bonuses, so no bonus section.
+		assert.NotContains(t, output, "[ボーナス]")
+	})
+	t.Run("success Output shows Spanish 21 variant bonuses", func(t *testing.T) {
+		tc := domain.NewTrumpCards(0)
+		player := domain.NewBlackJackPlayer()
+		dealer := domain.NewBlackJackPlayer()
+		player.SetChips(900)
+		dealer.SetChips(1000)
+		bj := domain.NewBlackJack(tc, player, dealer)
+		bj.Reset()
+		hand := bj.GetPlayerHands()[0]
+		hand.SetBet(100)
+		hand.AddCard(domain.NewCard(domain.CardDesignSpade, 1, false))
+		hand.AddCard(domain.NewCard(domain.CardDesignSpade, 10, false))
+		dealer.AddCard(domain.NewCard(domain.CardDesignClover, 9, false))
+		dealer.AddCard(domain.NewCard(domain.CardDesignClover, 10, false))
+		bj.SetPhase(domain.BJPhaseAction)
+		_ = bj.PlayerStand()
+		bj.SetBonusKeys([]string{"spanish21.bonus.fivecard21", "spanish21.bonus.678.spade"})
+
+		output := tbp.Output(bj, nil)
+		assert.Contains(t, output, "[ボーナス]")
+		assert.Contains(t, output, "5枚で21 ボーナス")
+		assert.Contains(t, output, "6-7-8 (全スペード)")
 	})
 	t.Run("success Output insurance phase", func(t *testing.T) {
 		tc := domain.NewTrumpCards(0)

--- a/internal/domain/BlackJack.go
+++ b/internal/domain/BlackJack.go
@@ -671,6 +671,11 @@ func (b *BlackJack) SetMultiHandCount(count int) {
 	b.multiHandCount = count
 }
 
+// SetBonusKeys 成立したバリアントボーナスのi18nキー一覧を設定（テスト用）
+func (b *BlackJack) SetBonusKeys(keys []string) {
+	b.bonusKeys = keys
+}
+
 // GetPerfectPairsBet Perfect Pairsベット額取得
 func (b *BlackJack) GetPerfectPairsBet() int {
 	return b.perfectPairsBet

--- a/internal/domain/BlackJackSpanish21_test.go
+++ b/internal/domain/BlackJackSpanish21_test.go
@@ -264,3 +264,14 @@ func TestSpanish21BonusKeysCapturedOnResolve(t *testing.T) {
 	bj.resolvePayouts()
 	assert.Empty(t, bj.GetBonusKeys())
 }
+
+// TestBlackJack_SetBonusKeys は SetBonusKeys が成立ボーナスキーを設定し
+// GetBonusKeys で取得できることを検証する（テスト用セッター）。
+func TestBlackJack_SetBonusKeys(t *testing.T) {
+	bj := NewSpanish21BlackJack()
+	assert.Empty(t, bj.GetBonusKeys())
+
+	keys := []string{"spanish21.bonus.fivecard21", "spanish21.bonus.678.spade"}
+	bj.SetBonusKeys(keys)
+	assert.Equal(t, keys, bj.GetBonusKeys())
+}

--- a/internal/i18n/locales/en/blackjack.json
+++ b/internal/i18n/locales/en/blackjack.json
@@ -17,6 +17,8 @@
   "multiHandLine": "multi-hand: {{count}} hands",
   "phaseLine": "phase: {{phase}}",
   "dealerLabel": "dealer",
+  "bonusHeader": "[Bonuses]",
+  "bonusLine": "★ {{name}}",
   "hiddenCard": "[??]",
   "playerLabel": "player",
   "scoreSuffix": " score ",

--- a/internal/i18n/locales/en/spanish21.json
+++ b/internal/i18n/locales/en/spanish21.json
@@ -1,3 +1,12 @@
 {
-  "helpTitle": "Spanish 21"
+  "helpTitle": "Spanish 21",
+  "bonus.fivecard21": "5-card 21 bonus",
+  "bonus.sixcard21": "6-card 21 bonus",
+  "bonus.sevencard21": "7+card 21 bonus",
+  "bonus.678.mixed": "6-7-8 (mixed suits)",
+  "bonus.678.samesuit": "6-7-8 (same suit)",
+  "bonus.678.spade": "6-7-8 (all spades)",
+  "bonus.777.mixed": "7-7-7 (mixed suits)",
+  "bonus.777.samesuit": "7-7-7 (same suit)",
+  "bonus.777.spade": "7-7-7 (all spades)"
 }

--- a/internal/i18n/locales/ja/blackjack.json
+++ b/internal/i18n/locales/ja/blackjack.json
@@ -17,6 +17,8 @@
   "multiHandLine": "マルチハンド: {{count}} ハンド",
   "phaseLine": "フェーズ: {{phase}}",
   "dealerLabel": "ディーラー",
+  "bonusHeader": "[ボーナス]",
+  "bonusLine": "★ {{name}}",
   "hiddenCard": "[??]",
   "playerLabel": "プレイヤー",
   "scoreSuffix": " スコア ",

--- a/internal/i18n/locales/ja/spanish21.json
+++ b/internal/i18n/locales/ja/spanish21.json
@@ -1,3 +1,12 @@
 {
-  "helpTitle": "Spanish 21 (スパニッシュ21)"
+  "helpTitle": "Spanish 21 (スパニッシュ21)",
+  "bonus.fivecard21": "5枚で21 ボーナス",
+  "bonus.sixcard21": "6枚で21 ボーナス",
+  "bonus.sevencard21": "7枚以上で21 ボーナス",
+  "bonus.678.mixed": "6-7-8 (異なるスート)",
+  "bonus.678.samesuit": "6-7-8 (同一スート)",
+  "bonus.678.spade": "6-7-8 (全スペード)",
+  "bonus.777.mixed": "7-7-7 (異なるスート)",
+  "bonus.777.samesuit": "7-7-7 (同一スート)",
+  "bonus.777.spade": "7-7-7 (全スペード)"
 }


### PR DESCRIPTION
## 概要
Web版 `BlackJackPage`（variant=spanish21）は Spanish 21 固有ボーナス（5/6/7枚21、6-7-8、7-7-7）をバッジ表示するが、共有 `BlackJackCuiPresenter` はボーナス出力が皆無で、CUI プレイヤーは達成に気づけなかった。ゲーム終了時に成立ボーナス名を表示する。

## 変更点
- 終了ブロックで `GetBonusKeys()` が非空のとき `blackjack.bonusHeader` + 各ボーナス名を出力（標準 Blackjack は空なので影響なし）
- ボーナス名は `GetBonusKeys()` の返す i18n キー（`spanish21.bonus.*`）を `i18n.T` で解決
- **ボーナスキーはフロントエンドのみ定義だった**ため、バックエンド `internal/i18n/locales/{ja,en}/spanish21.json` にフラットキー（`bonus.fivecard21` 等、backend i18n は `map[string]string` でネスト非対応）を追加
- `blackjack.bonusHeader`/`bonusLine` キーを ja/en に追加
- ドメインに `SetBonusKeys`（テスト用）を追加
- ボーナス表示／標準Blackjack非表示のテストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/ ./internal/domain/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み（blackjack・spanish21）

Closes #3205