### PR TITLE
feat(pineapple): show an indexed hand during the discard phase in the CUI

### DIFF
--- a/internal/adapter/presenter/PineappleCuiPresenter.go
+++ b/internal/adapter/presenter/PineappleCuiPresenter.go
@@ -100,7 +100,16 @@ func (pp *PineappleCuiPresenter) Output(p interfaces.PineappleGame, lastErr erro
 			b.WriteString("\n")
 
 			if player.GetIsHuman() && !player.GetFolded() {
-				b.WriteString(i18n.Tf("pineapple.humanHand", "cards", cuiCardListStrEmoji(player)) + "\n")
+				cards := cuiCardListStrEmoji(player)
+				// The discard prompt asks for a card number, so show an indexed
+				// hand until the human has discarded.
+				if p.GetPhase() == domain.PineapplePhaseDiscard {
+					discardDone := p.GetDiscardDone()
+					if i >= len(discardDone) || !discardDone[i] {
+						cards = cuiIndexedCardListStrEmoji(player)
+					}
+				}
+				b.WriteString(i18n.Tf("pineapple.humanHand", "cards", cards) + "\n")
 			}
 		}
 

--- a/internal/adapter/presenter/PineappleCuiPresenter_test.go
+++ b/internal/adapter/presenter/PineappleCuiPresenter_test.go
@@ -36,6 +36,7 @@ func setupPineappleCuiMock() *interfaces.MockPineappleGame {
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
 	m.On("GetInitialDealCount").Return(3).Maybe()
 	m.On("IsDiscardAfterFlopBetting").Return(false).Maybe()
+	m.On("GetDiscardDone").Return(([]bool)(nil)).Maybe()
 	return m
 }
 
@@ -145,6 +146,28 @@ func TestPineappleCuiPresenter_Output(t *testing.T) {
 		m.On("GetInitialDealCount").Return(4)
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "手札から2枚選んで")
+	})
+
+	t.Run("hand is indexed during the discard phase before discarding", func(t *testing.T) {
+		m, players := setupPineappleCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.PineapplePhaseDiscard)
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 5, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 9, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignClover, 2, false))
+
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "[0]")
+		assert.Contains(t, result, "[2]")
+	})
+
+	t.Run("hand is not indexed outside the discard phase", func(t *testing.T) {
+		m, players := setupPineappleCuiMockWithPlayers()
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 5, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 9, false))
+
+		result := p.Output(m, nil) // default phase is pre-flop
+		assert.NotContains(t, result, "[0]")
 	})
 
 	t.Run("title is plain Pineapple for a 3-card pre-flop-discard deal", func(t *testing.T) {


### PR DESCRIPTION
## 概要
`PineappleCuiPresenter` は人間の手札を常にインデックスなし（`cuiCardListStrEmoji`）で表示するが、`PineapplePhaseDiscard` では番号入力を促すため、どの番号がどのカードか判別できなかった。捨て札フェーズかつ人間が未ディスカードのときのみ番号付き（`cuiIndexedCardListStrEmoji`）に切り替える（`PokerCuiPresenter` の交換フェーズと同様）。

## 変更点
- `GetPhase() == PineapplePhaseDiscard` かつ `GetDiscardDone()[i]` が未達成のとき、人間手札を番号付き表示に切り替え
- その他フェーズは従来のインデックスなし表示を維持
- 新規 i18n キーなし（共有の `cuiIndexedCardListStrEmoji` を利用）
- 捨て札フェーズの番号付き表示／その他フェーズの非番号表示のテストを追加（crazypineapple/irishpoker も同じ共有プレゼンターで機能）

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues

Closes #3017