### PR TITLE
feat(sevens): render the board as a per-card grid instead of a min-max range

### DIFF
--- a/internal/adapter/presenter/SevensCuiPresenter.go
+++ b/internal/adapter/presenter/SevensCuiPresenter.go
@@ -139,17 +139,24 @@ func (p *SevensCuiPresenter) Output(s interfaces.SevensGame, lastErr error) stri
 
 		b.WriteString("----------\n")
 
-		// Board state
+		// Board state: render each suit's 1..13 positions individually (from the
+		// placed bitmask) so joker substitutions and skip placements show
+		// exactly which cards are down, unlike the old min~max range.
 		b.WriteString(i18n.T("sevens.boardLabel") + "\n")
 		suits := []int{domain.CardDesignSpade, domain.CardDesignClover, domain.CardDesignHeart, domain.CardDesignDiamond}
-		suitNames := []string{"SPADE", "CLOVER", "HEART", "DIAMOND"}
-		mins := s.GetTableMinVals()
-		maxs := s.GetTableMaxVals()
-		for i, suit := range suits {
-			b.WriteString(i18n.Tf("sevens.boardSuitRange",
-				"suit", suitNames[i],
-				"min", strconv.Itoa(mins[suit]),
-				"max", strconv.Itoa(maxs[suit])) + "\n")
+		placed := s.GetTablePlaced()
+		for _, suit := range suits {
+			cells := make([]string, 13)
+			for v := 1; v <= 13; v++ {
+				if placed[suit]&(1<<uint(v)) != 0 {
+					cells[v-1] = cuiRankLabel(v)
+				} else {
+					cells[v-1] = "_"
+				}
+			}
+			b.WriteString(i18n.Tf("sevens.boardSuitLine",
+				"suit", cuiSuitName(suit),
+				"cells", strings.Join(cells, " ")) + "\n")
 		}
 
 		// Human's previous action

--- a/internal/adapter/presenter/SevensCuiPresenter_test.go
+++ b/internal/adapter/presenter/SevensCuiPresenter_test.go
@@ -53,7 +53,8 @@ func TestSevensCuiPresenter_Method(t *testing.T) {
 		assert.Contains(t, result, "[0]SPADE 6")
 		assert.Contains(t, result, "CPU 1: 1枚")
 		assert.Contains(t, result, "ボード:")
-		assert.Contains(t, result, "SPADE: 7〜7")
+		// Only the seed 7 is on the board initially (positions 1..13 shown).
+		assert.Contains(t, result, "SPADE: _ _ _ _ _ _ 7 _ _ _ _ _ _")
 		assert.Contains(t, result, "手番: あなた")
 	})
 
@@ -82,10 +83,10 @@ func TestSevensCuiPresenter_Method(t *testing.T) {
 		players[1].AddCard(domain.NewCard(domain.CardDesignHeart, 2, false))
 		players[2].AddCard(domain.NewCard(domain.CardDesignHeart, 2, false))
 		players[3].AddCard(domain.NewCard(domain.CardDesignHeart, 2, false))
-		_ = s.PlayerPlay(0) // play 6♠ → minVal[Spade] = 6
+		_ = s.PlayerPlay(0) // play 6♠ → 6 and 7 now placed on spades
 
 		result := tsp.Output(s, nil)
-		assert.Contains(t, result, "SPADE: 6〜7")
+		assert.Contains(t, result, "SPADE: _ _ _ _ _ 6 7 _ _ _ _ _ _")
 	})
 
 	t.Run("success Output game ended", func(t *testing.T) {

--- a/internal/i18n/locales/en/sevens.json
+++ b/internal/i18n/locales/en/sevens.json
@@ -22,11 +22,11 @@
   "ruleEndStop": "[end-stop]",
   "ruleNoConsecutiveJokers": "[no consecutive jokers]",
   "boardLabel": "Board:",
-  "boardSuitRange": "  {{suit}}: {{min}}-{{max}}",
   "cpuActionsLabel": "[CPU actions]",
   "gameEnd": "Game over!",
   "rankLine": "  {{name}}: rank {{rank}}",
   "turnLine": "Turn: {{name}}",
   "playHint": "p [index] to play a card / p to pass",
-  "jokerHint": "j [card index] [suit] [value] to place a joker"
+  "jokerHint": "j [card index] [suit] [value] to place a joker",
+  "boardSuitLine": "  {{suit}}: {{cells}}"
 }

--- a/internal/i18n/locales/ja/sevens.json
+++ b/internal/i18n/locales/ja/sevens.json
@@ -22,11 +22,11 @@
   "ruleEndStop": "[片側ストップ]",
   "ruleNoConsecutiveJokers": "[ジョーカー連続禁止]",
   "boardLabel": "ボード:",
-  "boardSuitRange": "  {{suit}}: {{min}}〜{{max}}",
   "cpuActionsLabel": "[CPUの行動]",
   "gameEnd": "ゲーム終了！",
   "rankLine": "  {{name}}: {{rank}}位",
   "turnLine": "手番: {{name}}",
   "playHint": "p [インデックス] でカードを出す / p でパス",
-  "jokerHint": "j [カードインデックス] [スート] [値] でジョーカーを配置"
+  "jokerHint": "j [カードインデックス] [スート] [値] でジョーカーを配置",
+  "boardSuitLine": "  {{suit}}: {{cells}}"
 }


### PR DESCRIPTION
## 概要
`SevensCuiPresenter` はボードを各スートの min〜max レンジで表示し、スート名も英語ハードコードだった。min/max ではジョーカー代用やトンネル/飛ばし置きで生じる「レンジ内の空き」を表現できず実際の設置とズレる可能性があった。`GetTablePlaced()` のビットマスクから各スート 1〜13 の実際の設置状況を1枚単位で描画する。

## 変更点
- ボードを `GetTablePlaced()`（配置済みビットマスク）から各スート「♠: _ _ _ _ _ _ 7 _ …」形式で描画（設置済みは `cuiRankLabel` で A/J/Q/K 表記）
- 英語ハードコードの `suitNames` を除去し `cuiSuitName` を使用
- `sevens.boardSuitRange` を `boardSuitLine` に置換（ja/en）
- 初期状態／プレイ後の盤面グリッドのテストを更新

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #2994