### PR TITLE
feat(dragontiger): show the big-road history in the CUI

### DIFF
--- a/internal/adapter/presenter/DragonTigerCuiPresenter.go
+++ b/internal/adapter/presenter/DragonTigerCuiPresenter.go
@@ -12,6 +12,10 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
+// dragonTigerHistoryMaxShown caps the trailing run of results shown so a long
+// shoe does not overflow the terminal line.
+const dragonTigerHistoryMaxShown = 20
+
 // DragonTigerCuiPresenter ドラゴンタイガーCUIプレゼンタークラス
 type DragonTigerCuiPresenter struct{}
 
@@ -82,6 +86,43 @@ func (dp *DragonTigerCuiPresenter) Output(dt interfaces.DragonTigerGame, lastErr
 			}
 			b.WriteString(i18n.Tf("dragontiger.oddsLine", "type", i18n.T(betTypeKey), "odds", strconv.Itoa(odds)) + "\n")
 			b.WriteString(i18n.Tf("dragontiger.payoutLine", "payout", strconv.Itoa(dt.GetPayout())) + "\n")
+		}
+
+		// Big-road history: recent results as a colored D/T/= row plus totals.
+		if history := dt.GetHistory(); len(history) > 0 {
+			dCount, tCount, tieCount := 0, 0, 0
+			for _, r := range history {
+				switch r {
+				case domain.DragonTigerResultDragon:
+					dCount++
+				case domain.DragonTigerResultTiger:
+					tCount++
+				case domain.DragonTigerResultTie:
+					tieCount++
+				}
+			}
+			shown := history
+			if len(shown) > dragonTigerHistoryMaxShown {
+				shown = shown[len(shown)-dragonTigerHistoryMaxShown:]
+			}
+			syms := make([]string, len(shown))
+			for i, r := range shown {
+				switch r {
+				case domain.DragonTigerResultDragon:
+					syms[i] = color.Red("D")
+				case domain.DragonTigerResultTiger:
+					syms[i] = color.Yellow("T")
+				case domain.DragonTigerResultTie:
+					syms[i] = "="
+				default:
+					syms[i] = "?"
+				}
+			}
+			b.WriteString(i18n.Tf("dragontiger.historyLine", "symbols", strings.Join(syms, " ")) + "\n")
+			b.WriteString(i18n.Tf("dragontiger.historyCounts",
+				"d", strconv.Itoa(dCount),
+				"t", strconv.Itoa(tCount),
+				"tie", strconv.Itoa(tieCount)) + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/DragonTigerCuiPresenter_test.go
+++ b/internal/adapter/presenter/DragonTigerCuiPresenter_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 )
@@ -32,6 +33,28 @@ func TestDragonTigerCuiPresenter_Output_BetPhase(t *testing.T) {
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "チップ: 1000")
 	assert.Contains(t, result, "フェーズ: BET")
+	// No history yet, so the history line is omitted.
+	assert.NotContains(t, result, "履歴:")
+}
+
+func TestDragonTigerCuiPresenter_Output_History(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+	p := new(DragonTigerCuiPresenter)
+	m := new(interfaces.MockDragonTigerGame)
+	setupDragonTigerCuiMockDefaults(m)
+	m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetHistory")
+	m.On("GetHistory").Return([]int{
+		domain.DragonTigerResultDragon,
+		domain.DragonTigerResultTiger,
+		domain.DragonTigerResultTie,
+		domain.DragonTigerResultDragon,
+	}).Maybe()
+
+	result := p.Output(m, nil)
+	assert.Contains(t, result, "履歴: D T = D")
+	assert.Contains(t, result, "集計: D:2 T:1 =:1")
 }
 
 func TestDragonTigerCuiPresenter_Output_DragonWins(t *testing.T) {

--- a/internal/i18n/locales/en/dragontiger.json
+++ b/internal/i18n/locales/en/dragontiger.json
@@ -20,5 +20,7 @@
   "tieWin": "Tie! You win the tie bet.",
   "tieRefund": "Tie. Half of your bet is refunded.",
   "oddsLine": "Bet: {{type}} ×{{odds}}",
-  "payoutLine": "payout: {{payout}}"
+  "payoutLine": "payout: {{payout}}",
+  "historyLine": "History: {{symbols}}",
+  "historyCounts": "Totals: D:{{d}} T:{{t}} =:{{tie}}"
 }

--- a/internal/i18n/locales/ja/dragontiger.json
+++ b/internal/i18n/locales/ja/dragontiger.json
@@ -20,5 +20,7 @@
   "tieWin": "タイ！タイベット的中！",
   "tieRefund": "タイ。ベット額の半分を返還します。",
   "oddsLine": "ベット: {{type}} ×{{odds}}",
-  "payoutLine": "払戻し: {{payout}}"
+  "payoutLine": "払戻し: {{payout}}",
+  "historyLine": "履歴: {{symbols}}",
+  "historyCounts": "集計: D:{{d}} T:{{t}} =:{{tie}}"
 }


### PR DESCRIPTION
## 概要
Web版 `DragonTigerPage` は `state.history` を D/T/= バッジ列（罫線）で表示するが、`DragonTigerCuiPresenter` にはこの履歴表示が一切なかった。ドメインには履歴データが既にあるため、CUI 表示追加のみで機能差を埋める。

## 変更点
- `GetHistory()` から直近最大20件を色分き1行（D=赤 / T=黄 / =無色）で表示
- 全履歴を走査して D/T/tie 件数サマリー（`集計: D:.. T:.. =:..`）を併記
- 履歴が空のときは行自体を出さない
- `historyLine`/`historyCounts` キーを ja/en に追加
- 履歴表示（多件）／履歴なし非表示 のテストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3243