### PR TITLE
feat(gongzhu): list each player's captured point cards in the CUI

### DIFF
--- a/internal/adapter/presenter/GongZhuCuiPresenter.go
+++ b/internal/adapter/presenter/GongZhuCuiPresenter.go
@@ -10,6 +10,37 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
+// gongZhuIsPointCard reports whether a card scores in Gong Zhu: any heart, the
+// pig (♠Q), the sheep (♦J), or the doubler (♣10).
+func gongZhuIsPointCard(c *domain.Card) bool {
+	switch {
+	case c.GetDesign() == domain.CardDesignHeart:
+		return true
+	case c.GetDesign() == domain.CardDesignSpade && c.GetValue() == 12: // pig
+		return true
+	case c.GetDesign() == domain.CardDesignDiamond && c.GetValue() == 11: // sheep
+		return true
+	case c.GetDesign() == domain.CardDesignClover && c.GetValue() == 10: // doubler
+		return true
+	default:
+		return false
+	}
+}
+
+// gongZhuCapturedPoints returns the scoring cards a player has captured in
+// their tricks, in capture order.
+func gongZhuCapturedPoints(player *domain.GongZhuPlayer) []*domain.Card {
+	var pts []*domain.Card
+	for _, trick := range player.GetTricksTaken() {
+		for _, c := range trick {
+			if gongZhuIsPointCard(c) {
+				pts = append(pts, c)
+			}
+		}
+	}
+	return pts
+}
+
 // gongZhuPlayerStr returns the display string for a single Gong Zhu player.
 func gongZhuPlayerStr(player *domain.GongZhuPlayer, i int) string {
 	var b strings.Builder
@@ -21,6 +52,12 @@ func gongZhuPlayerStr(player *domain.GongZhuPlayer, i int) string {
 		"tricks", strconv.Itoa(player.GetTrickCount()),
 	))
 	b.WriteString("\n")
+	// Show which scoring cards this player has taken (who holds the pig etc.);
+	// players with none get no line, keeping the output compact.
+	if pts := gongZhuCapturedPoints(player); len(pts) > 0 {
+		b.WriteString(i18n.Tf("gongzhu.capturedLine",
+			"cards", formatCardSlice(pts, cuiCardStr, " ")) + "\n")
+	}
 	if player.GetIsHuman() && player.GetCardsSize() > 0 {
 		b.WriteString(cuiIndexedCardListStr(player) + "\n")
 	}

--- a/internal/adapter/presenter/GongZhuCuiPresenter_test.go
+++ b/internal/adapter/presenter/GongZhuCuiPresenter_test.go
@@ -1,6 +1,7 @@
 package presenter_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,6 +51,21 @@ func TestGongZhuCuiPresenter_Output(t *testing.T) {
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "Gong Zhu")
 		assert.NotEmpty(t, result)
+	})
+
+	t.Run("captured point cards are listed per player", func(t *testing.T) {
+		m, players := setupGongZhuCuiMockWithPlayers()
+		// CPU 1 took a trick containing the pig (♠Q), a heart, and a plain card.
+		players[1].AddTrick([]*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 12, false),  // pig -> shown
+			domain.NewCard(domain.CardDesignHeart, 5, false),   // heart -> shown
+			domain.NewCard(domain.CardDesignClover, 3, false),  // plain -> not shown
+			domain.NewCard(domain.CardDesignDiamond, 8, false), // plain -> not shown
+		})
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "獲得: SPADE 12 HEART 5")
+		// Only the one capturing player gets a line; the others took nothing.
+		assert.Equal(t, 1, strings.Count(result, "獲得:"))
 	})
 
 	t.Run("expose phase prompt", func(t *testing.T) {

--- a/internal/i18n/locales/en/gongzhu.json
+++ b/internal/i18n/locales/en/gongzhu.json
@@ -28,5 +28,6 @@
   "hintReasonExposeSheep": "Expose the ♦J (sheep) to double its value",
   "hintReasonExposeNone": "Hold back and don't expose",
   "hintReasonDiscardPig": "A chance to dump the ♠Q (pig)",
-  "hintReasonDiscardHearts": "Discard hearts"
+  "hintReasonDiscardHearts": "Discard hearts",
+  "capturedLine": "  Taken: {{cards}}"
 }

--- a/internal/i18n/locales/ja/gongzhu.json
+++ b/internal/i18n/locales/ja/gongzhu.json
@@ -28,5 +28,6 @@
   "hintReasonExposeSheep": "♦J（羊）を公開して得点を倍に",
   "hintReasonExposeNone": "公開せず様子を見る",
   "hintReasonDiscardPig": "♠Q（豚）を捨てるチャンス",
-  "hintReasonDiscardHearts": "ハートを捨てる"
+  "hintReasonDiscardHearts": "ハートを捨てる",
+  "capturedLine": "  獲得: {{cards}}"
 }


### PR DESCRIPTION
## 概要
`GongZhuCuiPresenter` の `gongZhuPlayerStr` は累計/ラウンド点・手札枚数・トリック数のみで、各プレイヤーが取ったポイントカードの内訳が分からず「豚を誰が持っているか」が見えなかった。プレイヤー行の下に獲得ポイントカードの内訳行を追加する。

## 変更点
- `gongZhuIsPointCard`（ハート全部 / ♠Q豚 / ♦J羊 / ♣10変圧器）を追加
- `GetTricksTaken()` からポイントカードを抽出し `gongzhu.capturedLine`（獲得: …）で表示
- 未獲得プレイヤーは行を省略
- `capturedLine` キーを ja/en に追加
- ポイントカード内訳表示（プレーンカード除外・1件のみ）のテストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3377