### PR TITLE
feat(sueca): show the trick winner and team at trick end in the CUI

### DIFF
--- a/internal/adapter/presenter/SuecaCuiPresenter.go
+++ b/internal/adapter/presenter/SuecaCuiPresenter.go
@@ -83,6 +83,16 @@ func (p *SuecaCuiPresenter) Output(g interfaces.SuecaGame, lastErr error) string
 				"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
 			b.WriteString(i18n.T("sueca.promptPlayHelp") + "\n")
 		case domain.SuecaPhaseTrickEnd:
+			// The trick winner leads the next trick, so name them and their team
+			// (parity with the web trick-winner banner).
+			winnerIdx := g.GetLeadPlayerIdx()
+			teamLabel := "A"
+			if domain.SuecaTeamOf(winnerIdx) == 1 {
+				teamLabel = "B"
+			}
+			b.WriteString(i18n.Tf("sueca.trickWinner",
+				"name", cuiPlayerName(g.GetPlayer(winnerIdx), winnerIdx),
+				"team", teamLabel) + "\n")
 			b.WriteString(i18n.T("sueca.promptTrickEnd") + "\n")
 			b.WriteString(i18n.T("sueca.promptTrickEndHelp") + "\n")
 		case domain.SuecaPhaseRoundEnd:

--- a/internal/adapter/presenter/SuecaCuiPresenter_test.go
+++ b/internal/adapter/presenter/SuecaCuiPresenter_test.go
@@ -35,6 +35,7 @@ func setupSuecaCuiMock() *interfaces.MockSuecaGame {
 	m.On("GetWinnerTeam").Return(-1)
 	m.On("GetRoundCardPoints").Return([domain.SuecaTeamCnt]int{0, 0})
 	m.On("GetTeamGamePoints").Return([domain.SuecaTeamCnt]int{0, 0})
+	m.On("GetLeadPlayerIdx").Return(0).Maybe()
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
 	return m
 }
@@ -64,12 +65,23 @@ func TestSuecaCuiPresenter_Output(t *testing.T) {
 		assert.NotEmpty(t, result)
 	})
 
-	t.Run("trick end prompt", func(t *testing.T) {
+	t.Run("trick end shows the winning player and team A", func(t *testing.T) {
 		m, _ := setupSuecaCuiMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
 		m.On("GetPhase").Return(domain.SuecaPhaseTrickEnd)
+		// Lead player 0 (you) -> team A won the trick.
 		result := p.Output(m, nil)
-		assert.NotEmpty(t, result)
+		assert.Contains(t, result, "（チームA）がトリックを獲得")
+	})
+
+	t.Run("trick end shows team B for an odd-index winner", func(t *testing.T) {
+		m, _ := setupSuecaCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetLeadPlayerIdx")
+		m.On("GetPhase").Return(domain.SuecaPhaseTrickEnd)
+		m.On("GetLeadPlayerIdx").Return(1) // CPU 1 -> team B
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "CPU 1（チームB）がトリックを獲得")
 	})
 
 	t.Run("round end prompt", func(t *testing.T) {

--- a/internal/i18n/locales/en/sueca.json
+++ b/internal/i18n/locales/en/sueca.json
@@ -18,5 +18,6 @@
   "hintReasonLeadLow": "Lead a low card to conserve points",
   "hintReasonFollowWin": "Points on the table — win the trick",
   "hintReasonFollowDuck": "Cannot/should not win — duck",
-  "hintReasonDiscardLow": "Cannot follow suit — discard a low card"
+  "hintReasonDiscardLow": "Cannot follow suit — discard a low card",
+  "trickWinner": "{{name}} (Team {{team}}) won the trick"
 }

--- a/internal/i18n/locales/ja/sueca.json
+++ b/internal/i18n/locales/ja/sueca.json
@@ -18,5 +18,6 @@
   "hintReasonLeadLow": "低い札でリードして温存する",
   "hintReasonFollowWin": "得点があるので勝ちに行く",
   "hintReasonFollowDuck": "取れない／取る価値がないのでダック",
-  "hintReasonDiscardLow": "フォローできないので低い札を捨てる"
+  "hintReasonDiscardLow": "フォローできないので低い札を捨てる",
+  "trickWinner": "{{name}}（チーム{{team}}）がトリックを獲得"
 }


### PR DESCRIPTION
## 概要
Web版 `SuecaPage` は TrickEnd でトリック勝者チームのバナーを表示するが、`SuecaCuiPresenter` は汎用プロンプトのみで、誰がトリックを取ったか分からなかった。`GetLeadPlayerIdx()`（勝者が次リード）から勝者名とチーム（A/B）を表示する。

## 変更点
- TrickEnd 分岐で `GetLeadPlayerIdx()` から勝者名＋チーム（`SuecaTeamOf` の偶奇で A/B）を `sueca.trickWinner` で表示
- 既存プロンプト行は維持
- `trickWinner` キーを ja/en に追加
- チームA（偶数idx）／チームB（奇数idx）勝者表示のテストを追加

## テスト
- `go test -tags test ./internal/adapter/presenter/` green
- `golangci-lint run` 0 issues
- ja/en キーパリティ確認済み

Closes #3413