### PR TITLE
feat(sedma): show trick winner and captured points at trick end

### DIFF
--- a/internal/adapter/presenter/SedmaCuiPresenter.go
+++ b/internal/adapter/presenter/SedmaCuiPresenter.go
@@ -74,6 +74,19 @@ func (p *SedmaCuiPresenter) Output(g interfaces.SedmaGame, lastErr error) string
 				"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
 			b.WriteString(i18n.T("sedma.promptPlayHelp") + "\n")
 		case domain.SedmaPhaseTrickEnd:
+			// The last effective card wins the whole trick, so name the winner
+			// (the next lead) and the card points (each A or 10 is worth 10) they
+			// just collected — the key information Sedma's CUI previously omitted.
+			winnerIdx := g.GetLeadPlayerIdx()
+			trickPts := 0
+			for _, tc := range g.GetCurrentTrick() {
+				if v := tc.Card.GetValue(); v == 1 || v == 10 {
+					trickPts += 10
+				}
+			}
+			b.WriteString(i18n.Tf("sedma.trickWinner",
+				"name", cuiPlayerName(g.GetPlayer(winnerIdx), winnerIdx),
+				"points", strconv.Itoa(trickPts)) + "\n")
 			b.WriteString(i18n.T("sedma.promptTrickEnd") + "\n")
 			b.WriteString(i18n.T("sedma.promptTrickEndHelp") + "\n")
 		case domain.SedmaPhaseRoundEnd:

--- a/internal/adapter/presenter/SedmaCuiPresenter_test.go
+++ b/internal/adapter/presenter/SedmaCuiPresenter_test.go
@@ -62,12 +62,22 @@ func TestSedmaCuiPresenter_Output(t *testing.T) {
 		assert.NotEmpty(t, result)
 	})
 
-	t.Run("trick end prompt", func(t *testing.T) {
+	t.Run("trick end shows winner and captured points", func(t *testing.T) {
 		m, _ := setupSedmaCuiMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentTrick")
 		m.On("GetPhase").Return(domain.SedmaPhaseTrickEnd)
+		m.On("GetLeadPlayerIdx").Return(2)
+		// One ace and one ten (10 pts each) plus a plain card (0 pts) → 20 pts,
+		// exercising all three branches of the point-counting loop.
+		m.On("GetCurrentTrick").Return([]*domain.SedmaTrickCard{
+			{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignSpade, 1, false)},
+			{PlayerIdx: 3, Card: domain.NewCard(domain.CardDesignHeart, 10, false)},
+			{PlayerIdx: 0, Card: domain.NewCard(domain.CardDesignClover, 7, false)},
+			{PlayerIdx: 1, Card: domain.NewCard(domain.CardDesignDiamond, 8, false)},
+		})
 		result := p.Output(m, nil)
-		assert.NotEmpty(t, result)
+		assert.Contains(t, result, "20")
 	})
 
 	t.Run("round end prompt", func(t *testing.T) {

--- a/internal/i18n/locales/en/sedma.json
+++ b/internal/i18n/locales/en/sedma.json
@@ -17,5 +17,6 @@
   "hintCard": "[HINT: {{cards}} ({{reason}})]",
   "hintReasonLeadLow": "Lead a low card to conserve points",
   "hintReasonCapture": "Capture the trick (same rank or a 7)",
-  "hintReasonDiscardLow": "Cannot/should not capture — discard a low card"
+  "hintReasonDiscardLow": "Cannot/should not capture — discard a low card",
+  "trickWinner": "{{name}} won the trick (+{{points}} pts)"
 }

--- a/internal/i18n/locales/ja/sedma.json
+++ b/internal/i18n/locales/ja/sedma.json
@@ -17,5 +17,6 @@
   "hintCard": "[HINT: {{cards}} ({{reason}})]",
   "hintReasonLeadLow": "低い札でリードして温存する",
   "hintReasonCapture": "奪取する（同ランクまたは7）",
-  "hintReasonDiscardLow": "取れない／取る価値がないので低い札を捨てる"
+  "hintReasonDiscardLow": "取れない／取る価値がないので低い札を捨てる",
+  "trickWinner": "{{name}} がトリックを獲得 (+{{points}}点)"
 }


### PR DESCRIPTION
## Summary
Sedma's CUI previously showed only a generic "trick ended" prompt, omitting who won the trick and how many card points they collected. This adds a winner line at trick end naming the next lead (the trick winner) and the points captured (each Ace or Ten is worth 10).

Points are computed in the presenter from `GetCurrentTrick()`, which still holds the completed trick during the TrickEnd phase — no domain or interface change needed.

## Changes
- `SedmaCuiPresenter.go`: emit `sedma.trickWinner` line in the TrickEnd branch
- `sedma.json` (ja/en): new `trickWinner` key
- Test: trick-end case asserts winner + captured points, covering all point-value branches

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3431