### PR TITLE
feat(manille): add rank-order reminder to play prompt

### DIFF
--- a/internal/adapter/presenter/ManilleCuiPresenter.go
+++ b/internal/adapter/presenter/ManilleCuiPresenter.go
@@ -85,6 +85,10 @@ func (p *ManilleCuiPresenter) Output(g interfaces.ManilleGame, lastErr error) st
 			b.WriteString(i18n.Tf("manille.promptPlay",
 				"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
 			b.WriteString(i18n.T("manille.promptPlayHelp") + "\n")
+			// Manille's rank order is inverted from a normal deck (10 is highest),
+			// which is easy to misread since the hand lists cards by strength, not
+			// face value — spell out the order and each card's point worth.
+			b.WriteString(i18n.T("manille.rankHelp") + "\n")
 		case domain.ManillePhaseTrickEnd:
 			b.WriteString(i18n.T("manille.promptTrickEnd") + "\n")
 			b.WriteString(i18n.T("manille.promptTrickEndHelp") + "\n")

--- a/internal/adapter/presenter/ManilleCuiPresenter_test.go
+++ b/internal/adapter/presenter/ManilleCuiPresenter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func makeManillePlayers() []*domain.ManillePlayer {
@@ -61,7 +62,8 @@ func TestManilleCuiPresenter_Output(t *testing.T) {
 		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 13, false))
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "Manille")
-		assert.NotEmpty(t, result)
+		// The play prompt includes the inverted rank-order reminder.
+		assert.Contains(t, result, i18n.T("manille.rankHelp"))
 	})
 
 	t.Run("trick end prompt", func(t *testing.T) {

--- a/internal/i18n/locales/en/manille.json
+++ b/internal/i18n/locales/en/manille.json
@@ -18,5 +18,6 @@
   "hintReasonLeadLow": "Lead a low card to conserve points",
   "hintReasonFollowWin": "Points on the table — win the trick",
   "hintReasonFollowDuck": "Cannot/should not win — duck",
-  "hintReasonDiscardLow": "Cannot follow suit — discard a low card"
+  "hintReasonDiscardLow": "Cannot follow suit — discard a low card",
+  "rankHelp": "Rank order: 10 > A > K > Q > J > 9 > 8 > 7 (points: 10=5, A=4, K=3, Q=2, J=1)"
 }

--- a/internal/i18n/locales/ja/manille.json
+++ b/internal/i18n/locales/ja/manille.json
@@ -18,5 +18,6 @@
   "hintReasonLeadLow": "低い札でリードして温存する",
   "hintReasonFollowWin": "得点があるので勝ちに行く",
   "hintReasonFollowDuck": "取れない／取る価値がないのでダック",
-  "hintReasonDiscardLow": "フォローできないので低い札を捨てる"
+  "hintReasonDiscardLow": "フォローできないので低い札を捨てる",
+  "rankHelp": "ランク順: 10 > A > K > Q > J > 9 > 8 > 7（得点: 10=5, A=4, K=3, Q=2, J=1）"
 }


### PR DESCRIPTION
## Summary
Manille's rank order is inverted from a standard deck — 10 is the strongest card and Ace is second — and the CUI lists a hand by strength rather than face value, so it is easy to misread 10 as a weak card. This adds a one-line rank-order + point-value reminder below the play-phase help.

## Changes
- `ManilleCuiPresenter.go`: emit `manille.rankHelp` after the play help in the PLAY phase
- `manille.json` (ja/en): new `rankHelp` key (rank 10 > A > K > Q > J > 9 > 8 > 7; points 10=5, A=4, K=3, Q=2, J=1)
- Test: play-phase case asserts the reminder is present

Existing prompt lines are unchanged.

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3425