### PR TITLE
feat(wizard): show trick number and lead suit in the play prompt

### DIFF
--- a/internal/adapter/presenter/WizardCuiPresenter.go
+++ b/internal/adapter/presenter/WizardCuiPresenter.go
@@ -26,6 +26,24 @@ func wizardCuiCardStr(card *domain.Card) string {
 	return cuiCardStr(card)
 }
 
+// wizardLeadSuit returns the lead suit (design 1..4) of the in-progress trick,
+// or -1 when none is established yet — a Wizard led (suit is irrelevant) or only
+// Jesters have been played. Mirrors Wizard.leadSuitOfTrick so the CUI can name
+// the suit players must follow without a dedicated domain accessor.
+func wizardLeadSuit(trick []*domain.WizardTrickCard) int {
+	for _, tc := range trick {
+		switch tc.Card.GetDesign() {
+		case domain.WizardDesignWizard:
+			return -1
+		case domain.WizardDesignJester:
+			continue
+		default:
+			return tc.Card.GetDesign()
+		}
+	}
+	return -1
+}
+
 // wizardIndexedCardListStr は手札をインデックス付き (ウィザード/ジェスター対応) で描画する。
 func wizardIndexedCardListStr(hand cuiCardList) string {
 	return formatCardList(hand, wizardCuiCardStr, "  ", true)
@@ -115,6 +133,15 @@ func (p *WizardCuiPresenter) Output(o interfaces.WizardGame, lastErr error) stri
 			currentIdx := o.GetCurrentPlayerIdx()
 			b.WriteString(i18n.Tf("wizard.promptPlay",
 				"name", cuiPlayerName(o.GetPlayer(currentIdx), currentIdx)) + "\n")
+			// Spell out the trick number and the lead suit players must follow, so
+			// the human need not infer it from the raw trick block.
+			leadName := i18n.T("wizard.leadNone")
+			if leadSuit := wizardLeadSuit(o.GetCurrentTrick()); leadSuit >= 1 && leadSuit <= 4 {
+				leadName = cuiSuitName(leadSuit)
+			}
+			b.WriteString(i18n.Tf("wizard.promptLead",
+				"trick", strconv.Itoa(o.GetTrickNumber()),
+				"lead", leadName) + "\n")
 			b.WriteString(i18n.T("wizard.promptPlayHelp") + "\n")
 		case domain.WizardPhaseTrickEnd:
 			b.WriteString(i18n.T("wizard.promptTrickEnd") + "\n")

--- a/internal/adapter/presenter/WizardCuiPresenter_test.go
+++ b/internal/adapter/presenter/WizardCuiPresenter_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupWizardCuiMock() *interfaces.MockWizardGame {
@@ -61,6 +62,21 @@ func TestWizardCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "手札枚数: 1")
 		assert.Contains(t, result, "切り札:")
 		assert.Contains(t, result, "手番:")
+		// Empty trick → no established lead suit yet.
+		assert.Contains(t, result, i18n.T("wizard.leadNone"))
+	})
+
+	t.Run("play phase names the lead suit", func(t *testing.T) {
+		m, _ := setupWizardCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentTrick")
+		// A Jester (skipped) then a heart establishes hearts as the lead suit.
+		m.On("GetCurrentTrick").Return([]*domain.WizardTrickCard{
+			{PlayerIdx: 1, Card: domain.NewCard(domain.WizardDesignJester, 1, false)},
+			{PlayerIdx: 2, Card: domain.NewCard(domain.CardDesignHeart, 9, false)},
+		})
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "HEART")
+		assert.NotContains(t, result, i18n.T("wizard.leadNone"))
 	})
 
 	t.Run("renders wizard and jester cards in hand", func(t *testing.T) {

--- a/internal/i18n/locales/en/wizard.json
+++ b/internal/i18n/locales/en/wizard.json
@@ -23,5 +23,7 @@
   "promptRoundEndHelp": "nr / nextround — advance to the next round",
   "hintNone": "No hint available.",
   "hintBid": "[HINT: bid {{bid}} ({{reason}})]",
-  "hintCard": "[HINT: [{{idx}}]{{card}} ({{reason}})]"
+  "hintCard": "[HINT: [{{idx}}]{{card}} ({{reason}})]",
+  "promptLead": "Trick {{trick}} / Lead suit: {{lead}}",
+  "leadNone": "none (no follow constraint)"
 }

--- a/internal/i18n/locales/ja/wizard.json
+++ b/internal/i18n/locales/ja/wizard.json
@@ -23,5 +23,7 @@
   "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
   "hintNone": "ヒントはありません。",
   "hintBid": "[HINT: ビッド {{bid}} を推奨 ({{reason}})]",
-  "hintCard": "[HINT: [{{idx}}]{{card}} ({{reason}})]"
+  "hintCard": "[HINT: [{{idx}}]{{card}} ({{reason}})]",
+  "promptLead": "巡目 {{trick}} / リードスート: {{lead}}",
+  "leadNone": "なし（フォロー制約なし）"
 }


### PR DESCRIPTION
## Summary
Wizard's play prompt named only the current player, leaving the human to infer the lead suit — the suit they must follow — from the raw trick block. This adds a line showing the trick number and the established lead suit (or a "no follow constraint" note when a Wizard led or only Jesters have been played).

The lead suit is derived in the presenter from `GetCurrentTrick()` (Wizard → none, Jester → skipped, first suit card → lead), mirroring the domain's `leadSuitOfTrick` rule without needing a new accessor.

## Changes
- `WizardCuiPresenter.go`: `wizardLeadSuit` helper + `wizard.promptLead` line in the PLAY phase
- `wizard.json` (ja/en): new `promptLead` / `leadNone` keys
- Test: empty-trick (no lead) and Jester-then-heart (lead = HEART) cases

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3509