### PR TITLE
feat(nap): show current high bidder in the bid prompt

### DIFF
--- a/internal/adapter/presenter/NapCuiPresenter.go
+++ b/internal/adapter/presenter/NapCuiPresenter.go
@@ -116,6 +116,12 @@ func (p *NapCuiPresenter) writePrompt(b *strings.Builder, g interfaces.NapGame) 
 		b.WriteString(i18n.Tf("nap.promptBid",
 			"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx),
 			"contract", napBidName(int(g.GetContract()))) + "\n")
+		// Name who holds the current high bid (matching the web UI's bidHighest
+		// line); before anyone bids there is no holder, so the line is omitted.
+		if declIdx := g.GetDeclarerIdx(); declIdx >= 0 {
+			b.WriteString(i18n.Tf("nap.promptBidHolder",
+				"name", cuiPlayerName(g.GetPlayer(declIdx), declIdx)) + "\n")
+		}
 		b.WriteString(i18n.T("nap.promptBidHelp") + "\n")
 	case domain.NapPhasePlay:
 		currentIdx := g.GetCurrentPlayerIdx()

--- a/internal/adapter/presenter/NapCuiPresenter_test.go
+++ b/internal/adapter/presenter/NapCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,7 +13,14 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
+
+// napBidHolderPrefix returns the localized high-bidder line's text up to the
+// name placeholder, so assertions match regardless of the substituted name.
+func napBidHolderPrefix() string {
+	return strings.Split(i18n.T("nap.promptBidHolder"), "{{")[0]
+}
 
 func makeNapPlayers() []*domain.NapPlayer {
 	return []*domain.NapPlayer{
@@ -72,6 +80,17 @@ func TestNapCuiPresenter_Output(t *testing.T) {
 		m.On("GetDeclarerIdx").Return(-1)
 		result := p.Output(m, nil)
 		assert.NotEmpty(t, result)
+		// No one has bid yet → the high-bidder line is omitted.
+		assert.NotContains(t, result, napBidHolderPrefix())
+	})
+
+	t.Run("bid phase names the current high bidder", func(t *testing.T) {
+		m, _ := setupNapCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.NapPhaseBid)
+		// GetDeclarerIdx defaults to 0 (a bidder exists) → holder line is shown.
+		result := p.Output(m, nil)
+		assert.Contains(t, result, napBidHolderPrefix())
 	})
 
 	t.Run("no trump during bid", func(t *testing.T) {

--- a/internal/i18n/locales/en/nap.json
+++ b/internal/i18n/locales/en/nap.json
@@ -38,5 +38,6 @@
   "trickEnd": "Trick complete",
   "roundEnd": "Round complete",
   "result.humanWin": "Game over! You win!",
-  "result.cpuWin": "Game over! Player {{player}} wins!"
+  "result.cpuWin": "Game over! Player {{player}} wins!",
+  "promptBidHolder": "Current high bidder: {{name}}"
 }

--- a/internal/i18n/locales/ja/nap.json
+++ b/internal/i18n/locales/ja/nap.json
@@ -38,5 +38,6 @@
   "trickEnd": "トリック終了",
   "roundEnd": "ラウンド終了",
   "result.humanWin": "ゲーム終了！ あなたの勝ち！",
-  "result.cpuWin": "ゲーム終了！ プレイヤー{{player}}の勝ち！"
+  "result.cpuWin": "ゲーム終了！ プレイヤー{{player}}の勝ち！",
+  "promptBidHolder": "現在の最高入札者: {{name}}"
 }


### PR DESCRIPTION
## Summary
Nap's CUI bid prompt showed the current high contract but not **who** declared it, unlike the web `NapPage` which shows the high bid with the bidder's name. This adds a "Current high bidder" line during the bid phase, resolved from `GetDeclarerIdx()`. Before anyone bids (declarer < 0) the line is omitted, so the pass display is unchanged.

## Changes
- `NapCuiPresenter.go`: emit `nap.promptBidHolder` in the BID phase when a declarer exists
- `nap.json` (ja/en): new `promptBidHolder` key
- Test: with-bidder (line shown) and no-bid (line omitted) cases

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3440