### PR TITLE
feat(prsi): list legal cards and draw guidance in the CUI

### DIFF
--- a/internal/adapter/presenter/PrsiCuiPresenter.go
+++ b/internal/adapter/presenter/PrsiCuiPresenter.go
@@ -22,6 +22,39 @@ func prsiPlayerStr(player *domain.PrsiPlayer, i int) string {
 	return b.String()
 }
 
+// prsiIsLegalPlay reports whether card may be played on top given the discard
+// top and pending 7-penalty. Mirrors Prsi.isValidPlay so the CUI can flag
+// playable cards without a domain accessor: during a 7-penalty only a 7 stacks;
+// otherwise the card must match the top's suit or rank (any card on an empty pile).
+func prsiIsLegalPlay(card, top *domain.Card, penalty int) bool {
+	if card == nil {
+		return false
+	}
+	if penalty > 0 {
+		return card.GetValue() == domain.PrsiSevenValue
+	}
+	if top == nil {
+		return true
+	}
+	return card.GetDesign() == top.GetDesign() || card.GetValue() == top.GetValue()
+}
+
+// prsiLegalCardsLine returns the localized "playable cards" line for the human's
+// hand, or the draw guidance when no card is legal (the human must draw).
+func prsiLegalCardsLine(player *domain.PrsiPlayer, top *domain.Card, penalty int) string {
+	var legal []string
+	for i := 0; i < player.GetCardsSize(); i++ {
+		card := player.GetCard(i)
+		if prsiIsLegalPlay(card, top, penalty) {
+			legal = append(legal, "["+strconv.Itoa(i)+"]"+cuiCardStr(card))
+		}
+	}
+	if len(legal) == 0 {
+		return color.Yellow(i18n.T("prsi.noLegalPlay")) + "\n"
+	}
+	return color.Yellow(i18n.Tf("prsi.legalPlays", "cards", strings.Join(legal, ", "))) + "\n"
+}
+
 // PrsiCuiPresenter renders the Prší CUI view.
 type PrsiCuiPresenter struct{}
 
@@ -60,6 +93,11 @@ func (p *PrsiCuiPresenter) Output(g interfaces.PrsiGame, lastErr error) string {
 			currentIdx := g.GetCurrentPlayerIdx()
 			b.WriteString(i18n.Tf("prsi.promptCurrentPlayer",
 				"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
+			// On the human's turn, spell out which hand indices are legal (or that
+			// they must draw) so they need not re-derive the match rule each turn.
+			if human := g.GetPlayer(currentIdx); human != nil && human.GetIsHuman() {
+				b.WriteString(prsiLegalCardsLine(human, g.GetDiscardTop(), g.GetPenaltyDrawCount()))
+			}
 			b.WriteString(i18n.T("prsi.promptPlayHelp") + "\n")
 			b.WriteString(i18n.T("prsi.promptDrawHelp") + "\n")
 		}

--- a/internal/adapter/presenter/PrsiCuiPresenter_test.go
+++ b/internal/adapter/presenter/PrsiCuiPresenter_test.go
@@ -2,6 +2,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,14 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
+
+// prsiLegalPrefix returns the "playable cards" line text up to the placeholder,
+// so assertions match regardless of the substituted card list.
+func prsiLegalPrefix() string {
+	return strings.Split(i18n.T("prsi.legalPlays"), "{{")[0]
+}
 
 func setupPrsiCuiMock() *interfaces.MockPrsiGame {
 	m := new(interfaces.MockPrsiGame)
@@ -63,6 +71,52 @@ func TestPrsiCuiPresenter_Output(t *testing.T) {
 
 		out := p.Output(m, nil)
 		assert.Contains(t, out, "4") // penalty count appears
+	})
+
+	t.Run("legal cards listed for the human", func(t *testing.T) {
+		m, players := setupPrsiCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetDiscardTop")
+		m.On("GetDiscardTop").Return(domain.NewCard(domain.CardDesignHeart, 5, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 13, false)) // suit match → legal
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 5, false))  // rank match → legal
+		players[0].AddCard(domain.NewCard(domain.CardDesignClover, 8, false)) // neither → illegal
+
+		out := p.Output(m, nil)
+		assert.Contains(t, out, prsiLegalPrefix())
+		assert.Contains(t, out, "[0]")
+		assert.Contains(t, out, "[1]")
+	})
+
+	t.Run("penalty allows only sevens", func(t *testing.T) {
+		m, players := setupPrsiCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetDiscardTop")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPenaltyDrawCount")
+		m.On("GetDiscardTop").Return(domain.NewCard(domain.CardDesignHeart, 7, false))
+		m.On("GetPenaltyDrawCount").Return(2)
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 7, false))  // seven → legal under penalty
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 13, false)) // non-seven → illegal
+
+		out := p.Output(m, nil)
+		lines := strings.Split(out, "\n")
+		var legalLine string
+		for _, l := range lines {
+			if strings.Contains(l, prsiLegalPrefix()) {
+				legalLine = l
+			}
+		}
+		// Only the seven ([0]) is legal; the king ([1]) is excluded from the line.
+		assert.Contains(t, legalLine, "[0]")
+		assert.NotContains(t, legalLine, "[1]")
+	})
+
+	t.Run("no legal card shows draw guidance", func(t *testing.T) {
+		m, players := setupPrsiCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetDiscardTop")
+		m.On("GetDiscardTop").Return(domain.NewCard(domain.CardDesignHeart, 5, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignClover, 8, false)) // neither suit nor rank
+
+		out := p.Output(m, nil)
+		assert.Contains(t, out, i18n.T("prsi.noLegalPlay"))
 	})
 
 	t.Run("error block rendered", func(t *testing.T) {

--- a/internal/i18n/locales/en/prsi.json
+++ b/internal/i18n/locales/en/prsi.json
@@ -10,5 +10,7 @@
   "gameEnd": "Game over! {{name}} wins!",
   "promptCurrentPlayer": "{{name}} to play",
   "promptPlayHelp": "play <idx>: play a card matching suit or rank",
-  "promptDrawHelp": "draw: draw when stuck (takes the whole 7-penalty stack)"
+  "promptDrawHelp": "draw: draw when stuck (takes the whole 7-penalty stack)",
+  "legalPlays": "Playable: {{cards}}",
+  "noLegalPlay": "No playable card → use draw to take a card"
 }

--- a/internal/i18n/locales/ja/prsi.json
+++ b/internal/i18n/locales/ja/prsi.json
@@ -10,5 +10,7 @@
   "gameEnd": "ゲーム終了！ {{name}}の勝利です！",
   "promptCurrentPlayer": "手番: {{name}}",
   "promptPlayHelp": "play <idx>・・・スートかランクが一致するカードを出す",
-  "promptDrawHelp": "draw・・・出せなければ山札から引く (7ペナルティ中はまとめて引く)"
+  "promptDrawHelp": "draw・・・出せなければ山札から引く (7ペナルティ中はまとめて引く)",
+  "legalPlays": "出せる札: {{cards}}",
+  "noLegalPlay": "出せる札がありません → draw で引いてください"
 }


### PR DESCRIPTION
## Summary
Prší's CUI listed the human's hand indiscriminately, giving no hint which cards are legal — unlike the web `PrsiPage` which rings playable cards. This adds a yellow "playable cards" line on the human's turn, showing each legal card's hand index and face, or draw guidance when nothing is playable.

The legality rule (during a 7-penalty only a 7 stacks; otherwise match the discard top's suit or rank) is replicated in the presenter from `Prsi.isValidPlay` using existing exported getters (`GetDiscardTop`, `GetPenaltyDrawCount`) — no domain change.

## Changes
- `PrsiCuiPresenter.go`: `prsiIsLegalPlay` / `prsiLegalCardsLine` helpers + line in the PLAY phase on the human's turn
- `prsi.json` (ja/en): new `legalPlays` / `noLegalPlay` keys
- Test: legal list, penalty-only-sevens, and no-legal-card (draw guidance) branches

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3597