### PR TITLE
feat(tute): list declarable marriage suits in the play prompt

### DIFF
--- a/internal/adapter/presenter/TuteCuiPresenter.go
+++ b/internal/adapter/presenter/TuteCuiPresenter.go
@@ -85,6 +85,21 @@ func (p *TuteCuiPresenter) Output(g interfaces.TuteGame, lastErr error) string {
 			b.WriteString(i18n.T("tute.promptPlayHelp") + "\n")
 			if g.CanHumanDeclareMarriage() {
 				b.WriteString(i18n.T("tute.promptMarriage") + "\n")
+				// List which suits' K+Q can be declared (trump marked), so the
+				// human need not scan the hand and recall what is already claimed.
+				if suits := g.GetHumanDeclarableMarriageSuits(); len(suits) > 0 {
+					trump := g.GetTrumpSuit()
+					labels := make([]string, len(suits))
+					for i, suit := range suits {
+						label := tuteSuitSymbol(suit)
+						if suit == trump {
+							label += i18n.T("tute.marriageTrumpMark")
+						}
+						labels[i] = label
+					}
+					b.WriteString(i18n.Tf("tute.promptMarriageSuits",
+						"suits", strings.Join(labels, ", ")) + "\n")
+				}
 			}
 			if g.CanHumanDeclareTute() {
 				b.WriteString(i18n.T("tute.promptTute") + "\n")

--- a/internal/adapter/presenter/TuteCuiPresenter_test.go
+++ b/internal/adapter/presenter/TuteCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func makeTutePlayers() []*domain.TutePlayer {
@@ -34,6 +36,7 @@ func setupTuteCuiMock() *interfaces.MockTuteGame {
 	m.On("GetCurrentPlayerIdx").Return(0)
 	m.On("GetWinnerTeam").Return(-1)
 	m.On("CanHumanDeclareMarriage").Return(false)
+	m.On("GetHumanDeclarableMarriageSuits").Return(([]int)(nil))
 	m.On("CanHumanDeclareTute").Return(false)
 	m.On("GetRoundTeamPoints").Return([domain.TuteTeamCnt]int{0, 0})
 	m.On("GetTeamScores").Return([domain.TuteTeamCnt]int{0, 0})
@@ -72,6 +75,19 @@ func TestTuteCuiPresenter_Output(t *testing.T) {
 		m.On("CanHumanDeclareMarriage").Return(true)
 		result := p.Output(m, nil)
 		assert.NotEmpty(t, result)
+	})
+
+	t.Run("marriage prompt lists declarable suits with trump mark", func(t *testing.T) {
+		m, _ := setupTuteCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "CanHumanDeclareMarriage")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHumanDeclarableMarriageSuits")
+		m.On("CanHumanDeclareMarriage").Return(true)
+		// Trump is spades (default mock); heart is a plain marriage.
+		m.On("GetHumanDeclarableMarriageSuits").Return([]int{domain.CardDesignSpade, domain.CardDesignHeart})
+		result := p.Output(m, nil)
+		assert.Contains(t, result, strings.Split(i18n.T("tute.promptMarriageSuits"), "{{")[0])
+		// The trump suit (spades) carries the +40 marker.
+		assert.Contains(t, result, i18n.T("tute.marriageTrumpMark"))
 	})
 
 	t.Run("play phase with tute prompt", func(t *testing.T) {

--- a/internal/domain/Tute.go
+++ b/internal/domain/Tute.go
@@ -848,6 +848,23 @@ func (g *Tute) CanHumanDeclareMarriage() bool {
 	return g.cpuMarriageSuit(human) > 0
 }
 
+// GetHumanDeclarableMarriageSuits returns the suits (1..CardDesignMax) for which
+// the human may currently declare a K+Q marriage — the human leads and holds an
+// unclaimed suit's King and Queen. Empty when no declaration is possible now.
+func (g *Tute) GetHumanDeclarableMarriageSuits() []int {
+	human := g.findHumanIdx()
+	if human < 0 {
+		return nil
+	}
+	var suits []int
+	for suit := 1; suit <= CardDesignMax; suit++ {
+		if g.canDeclareMarriage(human, suit) {
+			suits = append(suits, suit)
+		}
+	}
+	return suits
+}
+
 // CanHumanDeclareTute 人間が今 Tute を宣言できるか。
 func (g *Tute) CanHumanDeclareTute() bool {
 	human := g.findHumanIdx()

--- a/internal/domain/Tute_test.go
+++ b/internal/domain/Tute_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func tuteCard(design, value int) *Card { return NewCard(design, value, false) }
@@ -168,6 +170,32 @@ func TestTute_MarriageDeclaration(t *testing.T) {
 	if g.canDeclareMarriage(0, CardDesignHeart) {
 		t.Error("cannot declare mid-trick")
 	}
+}
+
+func TestTute_GetHumanDeclarableMarriageSuits(t *testing.T) {
+	g := newTuteGame(true)
+	g.SetPhase(TutePhasePlay)
+	g.SetTrumpSuit(CardDesignDiamond)
+	g.SetCurrentPlayerIdx(0)
+	g.SetLeadPlayerIdx(0)
+	g.SetCurrentTrick(nil)
+	// Human holds K+Q of clubs and diamonds (both declarable); hearts is only a K.
+	tuteSetHand(g.GetPlayer(0),
+		tuteCard(CardDesignClover, 13), tuteCard(CardDesignClover, 12),
+		tuteCard(CardDesignDiamond, 13), tuteCard(CardDesignDiamond, 12),
+		tuteCard(CardDesignHeart, 13))
+	got := g.GetHumanDeclarableMarriageSuits()
+	assert.ElementsMatch(t, []int{CardDesignClover, CardDesignDiamond}, got)
+
+	// After declaring clubs, only diamonds remains.
+	if err := g.PlayerDeclareMarriage(CardDesignClover); err != nil {
+		t.Fatalf("marriage err: %v", err)
+	}
+	assert.Equal(t, []int{CardDesignDiamond}, g.GetHumanDeclarableMarriageSuits())
+
+	// Mid-trick (not leading) → nothing is declarable.
+	g.SetCurrentTrick([]*TuteTrickCard{{PlayerIdx: 3, Card: tuteCard(CardDesignSpade, 1)}})
+	assert.Empty(t, g.GetHumanDeclarableMarriageSuits())
 }
 
 func TestTute_TuteInstantWin(t *testing.T) {

--- a/internal/domain/interfaces/tute.go
+++ b/internal/domain/interfaces/tute.go
@@ -65,6 +65,8 @@ type TuteGame interface {
 	GetPlayer(i int) *domain.TutePlayer
 	// CanHumanDeclareMarriage 人間が結婚宣言できるかを返す
 	CanHumanDeclareMarriage() bool
+	// GetHumanDeclarableMarriageSuits 人間が結婚宣言できる未宣言スート一覧を返す
+	GetHumanDeclarableMarriageSuits() []int
 	// CanHumanDeclareTute 人間が Tute を宣言できるかを返す
 	CanHumanDeclareTute() bool
 	// GetPlayableIndices プレイ可能なカードのインデックスを取得する

--- a/internal/domain/interfaces/tute_mock.go
+++ b/internal/domain/interfaces/tute_mock.go
@@ -180,6 +180,15 @@ func (_m *MockTuteGame) CanHumanDeclareMarriage() bool {
 	return ret.Get(0).(bool)
 }
 
+// GetHumanDeclarableMarriageSuits モック
+func (_m *MockTuteGame) GetHumanDeclarableMarriageSuits() []int {
+	ret := _m.Called()
+	if v := ret.Get(0); v != nil {
+		return v.([]int)
+	}
+	return nil
+}
+
 // CanHumanDeclareTute モック
 func (_m *MockTuteGame) CanHumanDeclareTute() bool {
 	ret := _m.Called()

--- a/internal/i18n/locales/en/tute.json
+++ b/internal/i18n/locales/en/tute.json
@@ -25,5 +25,7 @@
   "hintReasonFollowDuck": "Cannot/should not win — duck",
   "hintReasonDiscardLow": "Cannot follow suit — discard a low card",
   "hintReasonDeclareMarriage": "Declare a marriage for bonus points",
-  "hintReasonDeclareTute": "Declare Tute for an instant win!"
+  "hintReasonDeclareTute": "Declare Tute for an instant win!",
+  "promptMarriageSuits": "Declarable: {{suits}}",
+  "marriageTrumpMark": "(trump +40)"
 }

--- a/internal/i18n/locales/ja/tute.json
+++ b/internal/i18n/locales/ja/tute.json
@@ -25,5 +25,7 @@
   "hintReasonFollowDuck": "取れない／取る価値がないのでダック",
   "hintReasonDiscardLow": "フォローできないので低い札を捨てる",
   "hintReasonDeclareMarriage": "結婚宣言でボーナス点を獲得する",
-  "hintReasonDeclareTute": "Tute 宣言で即勝利！"
+  "hintReasonDeclareTute": "Tute 宣言で即勝利！",
+  "promptMarriageSuits": "宣言可能: {{suits}}",
+  "marriageTrumpMark": "(切り札+40)"
 }


### PR DESCRIPTION
## Summary
Tute's CUI showed a generic "you may declare a marriage" prompt but not **which** suits' K+Q the human holds and can still declare, forcing them to scan the hand and remember what was already claimed. This enumerates the declarable suits (trump marked `+40`) below the marriage prompt.

A new domain accessor `GetHumanDeclarableMarriageSuits()` reuses the existing `canDeclareMarriage` rule (human leads, unclaimed suit, holds K+Q); `declaredSuits` is domain-internal so a presenter-side computation was not possible.

## Changes
- `Tute.go`: `GetHumanDeclarableMarriageSuits()` (+ domain test)
- `interfaces/tute.go` + `tute_mock.go`: expose the accessor
- `TuteCuiPresenter.go`: `tute.promptMarriageSuits` line listing suits with trump mark
- `tute.json` (ja/en): new `promptMarriageSuits` / `marriageTrumpMark` keys
- Tests: domain (declarable set shrinks after a declaration, empty mid-trick) + presenter (suit list with trump mark)

## Test plan
- [x] `go test -tags test ./internal/domain/ ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3410