### PR TITLE
feat(gaigel): list marriage candidate cards in the play prompt

### DIFF
--- a/internal/adapter/presenter/GaigelCuiPresenter.go
+++ b/internal/adapter/presenter/GaigelCuiPresenter.go
@@ -78,8 +78,18 @@ func (p *GaigelCuiPresenter) Output(g interfaces.GaigelGame, lastErr error) stri
 			currentIdx := g.GetCurrentPlayerIdx()
 			out.WriteString(i18n.Tf("gaigel.promptCurrentPlayer",
 				"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
-			if len(g.GetMarriageIndices(currentIdx)) > 0 {
+			if idxs := g.GetMarriageIndices(currentIdx); len(idxs) > 0 {
 				out.WriteString(i18n.T("gaigel.promptMarriageHint") + "\n")
+				// On the human's turn, name the K/Q cards (and their hand indices)
+				// that can be declared; never for a CPU, to avoid leaking its hand.
+				if human := g.GetPlayer(currentIdx); human != nil && human.GetIsHuman() {
+					cards := make([]string, len(idxs))
+					for i, idx := range idxs {
+						cards[i] = "[" + strconv.Itoa(idx) + "]" + cuiCardStr(human.GetCard(idx))
+					}
+					out.WriteString(i18n.Tf("gaigel.promptMarriageCards",
+						"cards", strings.Join(cards, ", ")) + "\n")
+				}
 			}
 			out.WriteString(i18n.T("gaigel.promptPlayHelp") + "\n")
 		case domain.GaigelPhaseTrickEnd:

--- a/internal/adapter/presenter/GaigelCuiPresenter_test.go
+++ b/internal/adapter/presenter/GaigelCuiPresenter_test.go
@@ -1,6 +1,7 @@
 package presenter_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,6 +10,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupGaigelCuiMock() *interfaces.MockGaigelGame {
@@ -77,7 +79,7 @@ func TestGaigelCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "切り札: 未確定")
 	})
 
-	t.Run("marriage available prompt", func(t *testing.T) {
+	t.Run("marriage available prompt lists candidate cards", func(t *testing.T) {
 		m, players := setupGaigelCuiMockWithPlayers()
 		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 13, false))
 		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 12, false))
@@ -86,6 +88,24 @@ func TestGaigelCuiPresenter_Output(t *testing.T) {
 
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "マリアージュ")
+		// The human's K/Q candidate indices are enumerated.
+		assert.Contains(t, result, strings.Split(i18n.T("gaigel.promptMarriageCards"), "{{")[0])
+		assert.Contains(t, result, "[0]")
+		assert.Contains(t, result, "[1]")
+	})
+
+	t.Run("cpu turn does not leak marriage cards", func(t *testing.T) {
+		m, players := setupGaigelCuiMockWithPlayers()
+		players[1].AddCard(domain.NewCard(domain.CardDesignSpade, 13, false))
+		players[1].AddCard(domain.NewCard(domain.CardDesignSpade, 12, false))
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentPlayerIdx")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetMarriageIndices")
+		m.On("GetCurrentPlayerIdx").Return(1) // a CPU
+		m.On("GetMarriageIndices", 1).Return([]int{0, 1})
+
+		result := p.Output(m, nil)
+		// Generic hint may show, but the CPU's specific candidate cards must not.
+		assert.NotContains(t, result, strings.Split(i18n.T("gaigel.promptMarriageCards"), "{{")[0])
 	})
 
 	t.Run("phase: trick end", func(t *testing.T) {

--- a/internal/i18n/locales/en/gaigel.json
+++ b/internal/i18n/locales/en/gaigel.json
@@ -29,5 +29,6 @@
   "hintReasonFollowCut": "Trump the trick",
   "hintReasonFollowWin": "Win the trick",
   "hintReasonFollowDump": "Discard a low card",
-  "hintReasonMarriage": "Declare a marriage for bonus points"
+  "hintReasonMarriage": "Declare a marriage for bonus points",
+  "promptMarriageCards": "Declarable: {{cards}}"
 }

--- a/internal/i18n/locales/ja/gaigel.json
+++ b/internal/i18n/locales/ja/gaigel.json
@@ -29,5 +29,6 @@
   "hintReasonFollowCut": "切り札でトリックを取る",
   "hintReasonFollowWin": "トリックを取る",
   "hintReasonFollowDump": "低いカードを捨てる",
-  "hintReasonMarriage": "マリアージュを宣言してボーナス点を得る"
+  "hintReasonMarriage": "マリアージュを宣言してボーナス点を得る",
+  "promptMarriageCards": "宣言可能: {{cards}}"
 }


### PR DESCRIPTION
## Summary
Gaigel's CUI showed a generic "you can declare a marriage" hint but not **which** K/Q cards qualify, forcing the human to hunt for the pair in their hand and guess the index. This enumerates each candidate as `[idx]card` (using existing `GetMarriageIndices`), shown only on the human's turn so a CPU's hand is never leaked.

## Changes
- `GaigelCuiPresenter.go`: `gaigel.promptMarriageCards` line after the marriage hint, gated on the human turn
- `gaigel.json` (ja/en): new `promptMarriageCards` key
- Tests: human turn lists candidate indices; CPU turn does not leak the cards

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3603