### PR TITLE
feat(chinchon): show the human's deadwood and knock threshold in the CUI

### DIFF
--- a/internal/adapter/presenter/ChinchonCuiPresenter.go
+++ b/internal/adapter/presenter/ChinchonCuiPresenter.go
@@ -46,6 +46,20 @@ func (p *ChinchonCuiPresenter) Output(g interfaces.ChinchonGame, lastErr error) 
 
 		for i := 0; i < g.GetPlayerCnt(); i++ {
 			b.WriteString(chinchonPlayerStr(g.GetPlayer(i), i))
+			// Show the human's current deadwood (the core knock-timing signal),
+			// green with a "knock ready" note once at or below the threshold. CPU
+			// deadwood stays hidden so hands are not exposed mid-round.
+			if player := g.GetPlayer(i); player != nil && player.GetIsHuman() && player.GetCardsSize() > 0 {
+				deadwood := g.GetPlayerDeadwoodValue(i)
+				threshold := g.GetKnockThreshold()
+				line := i18n.Tf("chinchon.deadwoodLine",
+					"value", strconv.Itoa(deadwood),
+					"threshold", strconv.Itoa(threshold))
+				if deadwood <= threshold {
+					line = color.Green(line + " " + i18n.T("chinchon.knockReady"))
+				}
+				b.WriteString(line + "\n")
+			}
 		}
 
 		// レイオフフェーズではノッカーのメルドを表示する。

--- a/internal/adapter/presenter/ChinchonCuiPresenter_test.go
+++ b/internal/adapter/presenter/ChinchonCuiPresenter_test.go
@@ -4,14 +4,17 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func makeChinchonPlayers() []*domain.ChinchonPlayer {
@@ -37,6 +40,8 @@ func setupChinchonCuiMock(phase domain.ChinchonPhase, ended bool, winner int) (*
 	m.On("GetPlayerCnt").Return(2)
 	m.On("GetPlayer", 0).Return(players[0])
 	m.On("GetPlayer", 1).Return(players[1])
+	m.On("GetPlayerDeadwoodValue", mock.Anything).Return(15)
+	m.On("GetKnockThreshold").Return(5)
 	return m, players
 }
 
@@ -53,6 +58,22 @@ func TestChinchonCuiPresenter_Output(t *testing.T) {
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "Chinchón (チンチョン)")
 		assert.Contains(t, result, "ラウンド: 1")
+		// Human deadwood (default 15) is shown but above the threshold → no knock note.
+		assert.Contains(t, result, strings.Split(i18n.T("chinchon.deadwoodLine"), "{{")[0])
+		assert.NotContains(t, result, i18n.T("chinchon.knockReady"))
+	})
+
+	t.Run("human deadwood at threshold shows knock-ready, cpu hidden", func(t *testing.T) {
+		m, players := setupChinchonCuiMock(domain.ChinchonPhaseDiscard, false, -1)
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPlayerDeadwoodValue")
+		m.On("GetPlayerDeadwoodValue", 0).Return(3) // human, at/under threshold 5
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 1, false))
+		players[1].AddCard(domain.NewCard(domain.CardDesignHeart, 5, false)) // CPU also holds cards
+		result := p.Output(m, nil)
+		assert.Contains(t, result, i18n.T("chinchon.knockReady"))
+		// Only the human's deadwood line appears; the CPU's stays hidden.
+		prefix := strings.Split(i18n.T("chinchon.deadwoodLine"), "{{")[0]
+		assert.Equal(t, 1, strings.Count(result, prefix))
 	})
 
 	t.Run("discard phase prompt", func(t *testing.T) {

--- a/internal/domain/Chinchon.go
+++ b/internal/domain/Chinchon.go
@@ -743,6 +743,19 @@ func (g *Chinchon) IsHumanTurn() bool {
 	return g.players[g.currentPlayerIdx].GetIsHuman()
 }
 
+// GetPlayerDeadwoodValue はプレイヤーの手札を最善メルド分割したときのデッドウッド点を返す（プレゼンター向け）。
+func (g *Chinchon) GetPlayerDeadwoodValue(i int) int {
+	p := g.GetPlayer(i)
+	if p == nil {
+		return 0
+	}
+	_, dead := chinchonFindBestMelds(handCards(p))
+	return CalcDeadwoodValue(dead)
+}
+
+// GetKnockThreshold はノック可能なデッドウッド点の上限（この値以下でノック可）を返す。
+func (g *Chinchon) GetKnockThreshold() int { return g.config.KnockThreshold }
+
 // GetConfig 設定取得
 func (g *Chinchon) GetConfig() ChinchonConfig { return g.config }
 

--- a/internal/domain/Chinchon_test.go
+++ b/internal/domain/Chinchon_test.go
@@ -234,6 +234,26 @@ func TestChinchon_KnockZeroDeadwood(t *testing.T) {
 	assert.Equal(t, 0, domain.CalcDeadwoodValue(g.GetKnockerDeadwood()))
 }
 
+func TestChinchon_GetPlayerDeadwoodValue(t *testing.T) {
+	g := newTestChinchon(2)
+	g.Reset()
+	chClearState(g)
+	// A full 7-card heart run melds completely → deadwood 0.
+	chSetHand(g.GetPlayer(0),
+		chCard(domain.CardDesignHeart, 1),
+		chCard(domain.CardDesignHeart, 2),
+		chCard(domain.CardDesignHeart, 3),
+		chCard(domain.CardDesignHeart, 4),
+		chCard(domain.CardDesignHeart, 5),
+		chCard(domain.CardDesignHeart, 6),
+		chCard(domain.CardDesignHeart, 7),
+	)
+	assert.Equal(t, 0, g.GetPlayerDeadwoodValue(0))
+	assert.Equal(t, g.GetConfig().KnockThreshold, g.GetKnockThreshold())
+	// Out-of-range index returns 0 rather than panicking.
+	assert.Equal(t, 0, g.GetPlayerDeadwoodValue(99))
+}
+
 func TestChinchon_DrawFromStock(t *testing.T) {
 	g := newTestChinchon(2)
 	g.Reset()

--- a/internal/domain/interfaces/chinchon.go
+++ b/internal/domain/interfaces/chinchon.go
@@ -49,6 +49,10 @@ type ChinchonGame interface {
 	GetPlayerCnt() int
 	// GetPlayer 指定インデックスのプレイヤーを取得する
 	GetPlayer(i int) *domain.ChinchonPlayer
+	// GetPlayerDeadwoodValue プレイヤーの最善メルド分割でのデッドウッド点を取得する
+	GetPlayerDeadwoodValue(i int) int
+	// GetKnockThreshold ノック可能なデッドウッド点の上限を取得する
+	GetKnockThreshold() int
 	// GetKnockerIdx ノッカーのインデックスを取得する (-1 = ノックなし)
 	GetKnockerIdx() int
 	// GetKnockerMelds ノッカーのメルドを取得する

--- a/internal/domain/interfaces/chinchon_mock.go
+++ b/internal/domain/interfaces/chinchon_mock.go
@@ -45,7 +45,9 @@ func (m *MockChinchonGame) GetPlayerCnt() int     { return m.Called().Int(0) }
 func (m *MockChinchonGame) GetPlayer(i int) *domain.ChinchonPlayer {
 	return m.Called(i).Get(0).(*domain.ChinchonPlayer)
 }
-func (m *MockChinchonGame) GetKnockerIdx() int { return m.Called().Int(0) }
+func (m *MockChinchonGame) GetPlayerDeadwoodValue(i int) int { return m.Called(i).Int(0) }
+func (m *MockChinchonGame) GetKnockThreshold() int           { return m.Called().Int(0) }
+func (m *MockChinchonGame) GetKnockerIdx() int               { return m.Called().Int(0) }
 func (m *MockChinchonGame) GetKnockerMelds() [][]*domain.Card {
 	return m.Called().Get(0).([][]*domain.Card)
 }

--- a/internal/i18n/locales/en/chinchon.json
+++ b/internal/i18n/locales/en/chinchon.json
@@ -32,5 +32,7 @@
   "promptRoundEnd": "Round complete",
   "promptRoundEndHelp": "nr / nextround: advance to next round",
   "result.humanWin": "Game over! You win!",
-  "result.cpuWin": "Game over! CPU {{cpuId}} wins!"
+  "result.cpuWin": "Game over! CPU {{cpuId}} wins!",
+  "deadwoodLine": "Deadwood: {{value}} (knock at {{threshold}} or less)",
+  "knockReady": "→ ready to knock"
 }

--- a/internal/i18n/locales/ja/chinchon.json
+++ b/internal/i18n/locales/ja/chinchon.json
@@ -32,5 +32,7 @@
   "promptRoundEnd": "ラウンド終了",
   "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
   "result.humanWin": "ゲーム終了！ あなたの勝ち！",
-  "result.cpuWin": "ゲーム終了！ CPU {{cpuId}}の勝ち！"
+  "result.cpuWin": "ゲーム終了！ CPU {{cpuId}}の勝ち！",
+  "deadwoodLine": "デッドウッド: {{value}}点 (ノック閾値 {{threshold}}点以下)",
+  "knockReady": "→ ノック可能"
 }


### PR DESCRIPTION
## Summary
Chinchón's CUI showed only cumulative/round scores and card counts, omitting the current deadwood — the core signal for deciding when to knock — which the web UI shows live via `chinchon-deadwood-indicator`. This adds the human's deadwood value and knock threshold to their row, colored green with a "ready to knock" note once at or below the threshold. CPU deadwood stays hidden so hands aren't exposed mid-round.

Two domain accessors were added (`declaredSuits`/meld computation are domain-internal): `GetPlayerDeadwoodValue(i)` (reuses `chinchonFindBestMelds`+`CalcDeadwoodValue`) and `GetKnockThreshold()`.

## Changes
- `Chinchon.go`: `GetPlayerDeadwoodValue` / `GetKnockThreshold` (+ domain test)
- `interfaces/chinchon.go` + `chinchon_mock.go`: expose the accessors
- `ChinchonCuiPresenter.go`: human deadwood line (green + knock note at/under threshold)
- `chinchon.json` (ja/en): new `deadwoodLine` / `knockReady` keys
- Tests: domain (deadwood value, threshold, out-of-range) + presenter (above threshold no note; at threshold green + CPU hidden)

## Test plan
- [x] `go test -tags test ./internal/domain/ ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3540