### PR TITLE
feat(king): list remaining contracts in the contract-selection prompt

### DIFF
--- a/internal/adapter/presenter/KingCuiPresenter.go
+++ b/internal/adapter/presenter/KingCuiPresenter.go
@@ -65,6 +65,19 @@ func (p *KingCuiPresenter) Output(kg interfaces.KingGame, lastErr error) string 
 		if kg.GetPhase() == domain.KingPhaseSelectContract {
 			b.WriteString(i18n.Tf("king.selectPrompt",
 				"name", cuiPlayerName(kg.GetPlayer(kg.GetDealerIdx()), kg.GetDealerIdx())) + "\n")
+			// List the still-available contracts with their selection indices, so the
+			// dealer need not recall which of the seven deals are already spent.
+			used := kg.GetUsedContracts()
+			var remaining []string
+			for i := 0; i < domain.KingContractCnt; i++ {
+				if !used[i] {
+					remaining = append(remaining, "["+strconv.Itoa(i)+"]"+kingContractLabel(i))
+				}
+			}
+			if len(remaining) > 0 {
+				b.WriteString(i18n.Tf("king.remainingContracts",
+					"contracts", strings.Join(remaining, ", ")) + "\n")
+			}
 		} else if kg.GetPhase() == domain.KingPhaseDealEnd {
 			b.WriteString(i18n.T("king.dealEndPrompt") + "\n")
 		} else {

--- a/internal/adapter/presenter/KingCuiPresenter_test.go
+++ b/internal/adapter/presenter/KingCuiPresenter_test.go
@@ -2,12 +2,15 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func TestKingCuiPresenter_Output(t *testing.T) {
@@ -18,6 +21,38 @@ func TestKingCuiPresenter_Output(t *testing.T) {
 	assert.NotEmpty(t, out)
 	assert.Contains(t, out, "1/7") // deal line
 	assert.Contains(t, out, "[0]") // human indexed hand
+}
+
+// kingLineContaining returns the first line of out that contains marker.
+func kingLineContaining(out, marker string) string {
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, marker) {
+			return line
+		}
+	}
+	return ""
+}
+
+func TestKingCuiPresenter_RemainingContracts(t *testing.T) {
+	p := new(presenter.KingCuiPresenter)
+	prefix := strings.Split(i18n.T("king.remainingContracts"), "{{")[0]
+
+	// Right after reset every contract is available.
+	g := domain.NewDefaultKing()
+	g.Reset()
+	remaining := kingLineContaining(p.Output(g, nil), prefix)
+	assert.Contains(t, remaining, "[0]")
+	assert.Contains(t, remaining, "[6]")
+
+	// Once the dealer selects a contract it drops out of the remaining list.
+	g2 := domain.NewDefaultKing()
+	g2.Reset()
+	g2.SetDealerIdx(0) // human dealer
+	require.NoError(t, g2.SelectContract(domain.KingContractNoTricks, 0))
+	g2.SetPhase(domain.KingPhaseSelectContract) // force back to the selection view
+	remaining2 := kingLineContaining(p.Output(g2, nil), prefix)
+	assert.NotContains(t, remaining2, "[0]") // used contract 0 excluded
+	assert.Contains(t, remaining2, "[6]")
 }
 
 func TestKingCuiPresenter_ContractAndTrick(t *testing.T) {

--- a/internal/i18n/locales/en/king.json
+++ b/internal/i18n/locales/en/king.json
@@ -31,5 +31,6 @@
   "dealEnd": "deal finished",
   "result.scores": "Game over! Scores: {{scores}}",
   "result.humanWin": "Game over! You win!",
-  "result.cpuWin": "Game over! Player {{player}} wins!"
+  "result.cpuWin": "Game over! Player {{player}} wins!",
+  "remainingContracts": "Remaining contracts: {{contracts}}"
 }

--- a/internal/i18n/locales/ja/king.json
+++ b/internal/i18n/locales/ja/king.json
@@ -31,5 +31,6 @@
   "dealEnd": "ディール終了",
   "result.scores": "ゲーム終了！ 得点: {{scores}}",
   "result.humanWin": "ゲーム終了！ あなたの勝ち！",
-  "result.cpuWin": "ゲーム終了！ プレイヤー{{player}}の勝ち！"
+  "result.cpuWin": "ゲーム終了！ プレイヤー{{player}}の勝ち！",
+  "remainingContracts": "残りコントラクト: {{contracts}}"
 }


### PR DESCRIPTION
## Summary
King's CUI prompted the dealer to pick a contract but never showed which of the seven deals were already spent — the web UI disables used-contract buttons, but the CLI player had to remember. This adds a "remaining contracts" line listing the still-available contracts with their selection indices, reusing `kingContractLabel`.

Uses the existing `GetUsedContracts()` accessor — no domain change.

## Changes
- `KingCuiPresenter.go`: `king.remainingContracts` line in the contract-selection phase (used contracts excluded)
- `king.json` (ja/en): new `remainingContracts` key
- Test: all contracts listed after reset; a selected contract drops from the list

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3618