### PR TITLE
feat(gostop): show captured-card category counts per player in the CUI

### DIFF
--- a/internal/adapter/presenter/GoStopCuiPresenter.go
+++ b/internal/adapter/presenter/GoStopCuiPresenter.go
@@ -74,6 +74,30 @@ func gostopScoreStr(bd *domain.GoStopBreakdown) string {
 	return strings.Join(parts, " ") + " (" + strconv.Itoa(bd.Base) + ")"
 }
 
+// gostopCategoryCountStr counts captured cards by card category (光/열끗/띠/피),
+// letting CLI players gauge role progress before a category actually scores.
+// Captured piles are public in Go-Stop, so this is shown for every player.
+func gostopCategoryCountStr(captured []*domain.Card) string {
+	var gwang, yeol, tti, pi int
+	for _, c := range captured {
+		switch domain.GoStopCardCategory(c) {
+		case domain.GoStopGwang:
+			gwang++
+		case domain.GoStopYeol:
+			yeol++
+		case domain.GoStopTti:
+			tti++
+		case domain.GoStopPi:
+			pi++
+		}
+	}
+	return i18n.Tf("gostop.categoryCounts",
+		"gwang", strconv.Itoa(gwang),
+		"yeol", strconv.Itoa(yeol),
+		"tti", strconv.Itoa(tti),
+		"pi", strconv.Itoa(pi))
+}
+
 func gostopPlayerStr(g interfaces.GoStopGame, idx int) string {
 	player := g.GetPlayer(idx)
 	if player == nil {
@@ -88,6 +112,9 @@ func gostopPlayerStr(g interfaces.GoStopGame, idx int) string {
 		"score", strconv.Itoa(player.GetScore()),
 		"go", strconv.Itoa(player.GetGoCount()),
 		"breakdown", gostopScoreStr(bd)) + "\n")
+	if player.CapturedCount() > 0 {
+		b.WriteString(gostopCategoryCountStr(player.GetCapturedCards()) + "\n")
+	}
 	if player.GetIsHuman() && player.GetCardsSize() > 0 {
 		b.WriteString(gostopCuiHandStr(player) + "\n")
 	}

--- a/internal/adapter/presenter/GoStopCuiPresenter_test.go
+++ b/internal/adapter/presenter/GoStopCuiPresenter_test.go
@@ -2,6 +2,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func TestGoStopCuiPresenter_Output_PlayPhase(t *testing.T) {
@@ -43,6 +45,18 @@ func TestGoStopCuiPresenter_Output_AllPhases(t *testing.T) {
 	g.SetPhase(domain.GoStopPhasePlay)
 	g.SetFieldCards(nil)
 	assert.NotEmpty(t, p.Output(g, nil))
+}
+
+func TestGoStopCuiPresenter_CategoryCounts(t *testing.T) {
+	g := domain.NewDefaultGoStop()
+	g.Reset()
+	g.SetCurrentTurn(0)
+	g.GetPlayer(0).AddCaptured(gostopGwang3Cards()) // 3 光 (Gwang)
+	p := new(presenter.GoStopCuiPresenter)
+	out := p.Output(g, nil)
+	assert.Contains(t, out, strings.Split(i18n.T("gostop.categoryCounts"), "{{")[0])
+	// The three captured Gwang are counted in the category line.
+	assert.Contains(t, out, "光3")
 }
 
 func TestGoStopCuiPresenter_HintOutput(t *testing.T) {

--- a/internal/i18n/locales/en/gostop.json
+++ b/internal/i18n/locales/en/gostop.json
@@ -31,5 +31,6 @@
   "cat.pi": "Pi",
   "bak.gwang": "Gwang-bak",
   "bak.pi": "Pi-bak",
-  "bak.go": "Go-bak"
+  "bak.go": "Go-bak",
+  "categoryCounts": "  Captured: Gwang {{gwang}} / Yeol {{yeol}} / Tti {{tti}} / Pi {{pi}}"
 }

--- a/internal/i18n/locales/ja/gostop.json
+++ b/internal/i18n/locales/ja/gostop.json
@@ -31,5 +31,6 @@
   "cat.pi": "피",
   "bak.gwang": "光박",
   "bak.pi": "피박",
-  "bak.go": "고박"
+  "bak.go": "고박",
+  "categoryCounts": "  獲得内訳: 光{{gwang}} 열끗{{yeol}} 띠{{tti}} 피{{pi}}"
 }


### PR DESCRIPTION
## Summary
Go-Stop's CUI showed a player's captured **count** and scored breakdown, but not the per-category card counts (光/열끗/띠/피) the web UI exposes via `breakdownChips`. Korean scoring hinges on card-type combinations, so CLI players couldn't gauge role progress before a category actually scored. This adds a category-count line under each player, reusing the domain classifier `GoStopCardCategory`.

Captured piles are public in Go-Stop, so counts are shown for every player. Current score is already on the player line.

## Changes
- `GoStopCuiPresenter.go`: `gostopCategoryCountStr` helper + line under each player with captured cards
- `gostop.json` (ja/en): new `categoryCounts` key
- Test: three captured Gwang are counted (光3)

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3521