### PR TITLE
feat(badugi): show minimum raise and max bet in the CUI betting phase

### DIFF
--- a/internal/adapter/presenter/BadugiCuiPresenter.go
+++ b/internal/adapter/presenter/BadugiCuiPresenter.go
@@ -36,6 +36,22 @@ func (bcp *BadugiCuiPresenter) Output(g interfaces.BadugiGame, lastErr error) st
 			b.WriteString(i18n.Tf("badugi.limitLine", "name", domain.BettingLimitNames[cfg.BettingLimit]) + "\n")
 		}
 
+		// During betting, show the minimum raise and (where applicable) the max bet
+		// so the human can size a bet without trial-and-error error messages.
+		if g.GetPhase() != domain.BadugiPhaseEnd {
+			minRaise := strconv.Itoa(g.GetMinRaise())
+			switch cfg.BettingLimit {
+			case domain.BettingLimitPotLimit:
+				_, maxBet := domain.CalculateBettingLimits(cfg.BettingLimit, g.GetPot(), g.GetLastBet())
+				b.WriteString(i18n.Tf("badugi.betLimitsMax",
+					"min", minRaise, "max", strconv.Itoa(maxBet)) + "\n")
+			case domain.BettingLimitNoLimit:
+				b.WriteString(i18n.Tf("badugi.betLimitsNoCap", "min", minRaise) + "\n")
+			default:
+				b.WriteString(i18n.Tf("badugi.betLimitsMin", "min", minRaise) + "\n")
+			}
+		}
+
 		b.WriteString("----------\n")
 		isEnd := g.GetPhase() == domain.BadugiPhaseEnd
 		for i, pl := range players {

--- a/internal/adapter/presenter/BadugiCuiPresenter_test.go
+++ b/internal/adapter/presenter/BadugiCuiPresenter_test.go
@@ -52,6 +52,33 @@ func TestBadugiCuiPresenter_Output_ShowsHumanHand(t *testing.T) {
 	}
 }
 
+func TestBadugiCuiPresenter_Output_ShowsBetLimits(t *testing.T) {
+	pres := new(presenter.BadugiCuiPresenter)
+
+	// Fixed limit (default) → min raise only, no cap line.
+	bd, _ := makeBadugiForPresenter()
+	out := pres.Output(bd, nil)
+	assert.Contains(t, out, "最小レイズ:")
+	assert.NotContains(t, out, "上限")
+
+	// Pot-limit → a max bet is shown.
+	bdPot, _ := makeBadugiForPresenter()
+	cfg := bdPot.GetConfig()
+	cfg.BettingLimit = domain.BettingLimitPotLimit
+	bdPot.SetConfig(cfg)
+	outPot := pres.Output(bdPot, nil)
+	assert.Contains(t, outPot, "上限:")
+	assert.NotContains(t, outPot, "上限: なし")
+
+	// No-limit → unlimited note.
+	bdNo, _ := makeBadugiForPresenter()
+	cfg2 := bdNo.GetConfig()
+	cfg2.BettingLimit = domain.BettingLimitNoLimit
+	bdNo.SetConfig(cfg2)
+	outNo := pres.Output(bdNo, nil)
+	assert.Contains(t, outNo, "上限: なし")
+}
+
 func TestBadugiCuiPresenter_HintOutput_StandPat(t *testing.T) {
 	pres := new(presenter.BadugiCuiPresenter)
 	bd, players := makeBadugiForPresenter()

--- a/internal/i18n/locales/en/badugi.json
+++ b/internal/i18n/locales/en/badugi.json
@@ -35,5 +35,8 @@
   "resultHand": "  {{name}}: {{hand}}",
   "resultName": "  {{name}}",
   "wonAmount": " → won {{total}} chips",
-  "gameEnd": "Game over"
+  "gameEnd": "Game over",
+  "betLimitsMax": "Min raise: {{min}} / Max bet: {{max}}",
+  "betLimitsNoCap": "Min raise: {{min}} / Max bet: unlimited",
+  "betLimitsMin": "Min raise: {{min}}"
 }

--- a/internal/i18n/locales/ja/badugi.json
+++ b/internal/i18n/locales/ja/badugi.json
@@ -35,5 +35,8 @@
   "resultHand": "  {{name}}: {{hand}}",
   "resultName": "  {{name}}",
   "wonAmount": " → {{total}}チップ獲得",
-  "gameEnd": "ゲーム終了"
+  "gameEnd": "ゲーム終了",
+  "betLimitsMax": "最小レイズ: {{min}} / 上限: {{max}}",
+  "betLimitsNoCap": "最小レイズ: {{min}} / 上限: なし",
+  "betLimitsMin": "最小レイズ: {{min}}"
 }


### PR DESCRIPTION
## Summary
Badugi's CUI printed the pot, draw round, and betting-limit **name** but never the current minimum raise or the maximum you may bet, so CLI players had to probe with trial-and-error bet commands. This adds a betting-phase line showing the minimum raise and, for pot-limit/no-limit games, the max bet (or an "unlimited" note).

Reuses `GetMinRaise()` and `CalculateBettingLimits` (the same computation the web presenter feeds to `maxBetAmount`) — no domain change.

## Changes
- `BadugiCuiPresenter.go`: min-raise / max-bet line during betting (per limit type)
- `badugi.json` (ja/en): new `betLimitsMax` / `betLimitsNoCap` / `betLimitsMin` keys
- Test: fixed (min only, no cap), pot-limit (max shown), no-limit (unlimited)

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3177