### PR TITLE
feat(tablanet): annotate capturable table cards per hand card in the CUI

### DIFF
--- a/internal/adapter/presenter/TablanetCuiPresenter.go
+++ b/internal/adapter/presenter/TablanetCuiPresenter.go
@@ -40,6 +40,28 @@ func tablanetPlayerStr(g interfaces.TablanetGame, idx int) string {
 		"tabla", strconv.Itoa(player.GetTablaCount())) + "\n")
 	if player.GetIsHuman() && player.GetCardsSize() > 0 {
 		b.WriteString(cuiIndexedCardListStr(player) + "\n")
+		// Annotate which table cards each hand card can capture, reusing the
+		// domain's capture computation (GetCaptureOptions). Cards that capture
+		// nothing get no note; the map is empty outside the play phase.
+		if opts := g.GetCaptureOptions(idx); len(opts) > 0 {
+			var notes []string
+			for h := 0; h < player.GetCardsSize(); h++ {
+				tableIdxs := opts[h]
+				if len(tableIdxs) == 0 {
+					continue
+				}
+				marks := make([]string, len(tableIdxs))
+				for j, ti := range tableIdxs {
+					marks[j] = "[" + strconv.Itoa(ti) + "]"
+				}
+				notes = append(notes, i18n.Tf("tablanet.captureHint",
+					"hand", "["+strconv.Itoa(h)+"]"+cuiCardStr(player.GetCard(h)),
+					"table", strings.Join(marks, "")))
+			}
+			if len(notes) > 0 {
+				b.WriteString(strings.Join(notes, "  ") + "\n")
+			}
+		}
 	}
 	return b.String()
 }

--- a/internal/adapter/presenter/TablanetCuiPresenter_test.go
+++ b/internal/adapter/presenter/TablanetCuiPresenter_test.go
@@ -2,6 +2,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,6 +39,23 @@ func TestTablanetCuiPresenter_Output_AllPhases(t *testing.T) {
 	g.SetPhase(domain.TablanetPhasePlay)
 	g.SetTableCards(nil)
 	assert.NotEmpty(t, p.Output(g, nil))
+}
+
+func TestTablanetCuiPresenter_Output_CaptureHint(t *testing.T) {
+	g := domain.NewDefaultTablanet()
+	g.Reset()
+	g.SetPhase(domain.TablanetPhasePlay)
+	g.SetCurrentTurn(0)
+	g.SetTableCards([]*domain.Card{domain.NewCard(domain.CardDesignSpade, 5, false)})
+	g.GetPlayer(0).Reset()
+	g.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignHeart, 5, false))  // matches table[0] → capturable
+	g.GetPlayer(0).AddCard(domain.NewCard(domain.CardDesignClover, 9, false)) // captures nothing
+	p := new(presenter.TablanetCuiPresenter)
+	out := p.Output(g, nil)
+	// The ♥5 is annotated with the table index it can capture.
+	assert.Contains(t, out, "→ 場[0]")
+	// Only the capturing card gets a note; the ♣9 does not.
+	assert.Equal(t, 1, strings.Count(out, "→ 場"))
 }
 
 func TestTablanetCuiPresenter_HintOutput(t *testing.T) {

--- a/internal/i18n/locales/en/tablanet.json
+++ b/internal/i18n/locales/en/tablanet.json
@@ -15,5 +15,6 @@
   "hintReasonJack": "Play a Jack to sweep the table",
   "hintReasonCapture": "Capture the most valuable table cards",
   "hintReasonTrail": "No capture — trail a low card",
-  "result.scores": "Game over! Scores: {{scores}}"
+  "result.scores": "Game over! Scores: {{scores}}",
+  "captureHint": "{{hand}} → table {{table}}"
 }

--- a/internal/i18n/locales/ja/tablanet.json
+++ b/internal/i18n/locales/ja/tablanet.json
@@ -15,5 +15,6 @@
   "hintReasonJack": "ジャックで場を一掃する",
   "hintReasonCapture": "価値の高い場札を捕獲する",
   "hintReasonTrail": "捕獲できないので低い札を捨てる",
-  "result.scores": "ゲーム終了！ 得点: {{scores}}"
+  "result.scores": "ゲーム終了！ 得点: {{scores}}",
+  "captureHint": "{{hand}} → 場{{table}}"
 }


### PR DESCRIPTION
## Summary
Tablanet's CUI listed the human's hand and the table but showed which hand card captures which table cards only via `HintOutput` (on demand) — the web UI highlights this continuously. This annotates each capturing hand card with the table indices it can take (e.g. `[2]♣10 → table [0][3]`); cards that capture nothing get no note.

Reuses the existing `GetCaptureOptions()` interface accessor (which wraps the domain's capture computation) — no domain change.

## Changes
- `TablanetCuiPresenter.go`: capture annotations under the human hand in the play phase
- `tablanet.json` (ja/en): new `captureHint` key
- Test: a matching card is annotated with its table index; a non-capturing card is not

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3629