### PR TITLE
feat(calabresella): show all players' thirds with roles at round end

### DIFF
--- a/internal/adapter/presenter/CalabresellaCuiPresenter.go
+++ b/internal/adapter/presenter/CalabresellaCuiPresenter.go
@@ -114,6 +114,19 @@ func (p *CalabresellaCuiPresenter) Output(g interfaces.CalabresellaGame, lastErr
 			b.WriteString(i18n.Tf("calabresella.promptRoundEnd",
 				"soloist", cuiPlayerName(g.GetPlayer(soloist), soloist),
 				"thirds", strconv.Itoa(soloistThirds)) + "\n")
+			// Break down every player's thirds with their role: the 11 thirds are
+			// split between the soloist and the two-player coalition, so the CUI
+			// should show each share, not just the soloist's.
+			for i := 0; i < g.GetPlayerCnt(); i++ {
+				role := i18n.T("calabresella.roleCoalition")
+				if i == soloist {
+					role = i18n.T("calabresella.roleSoloist")
+				}
+				b.WriteString(i18n.Tf("calabresella.thirdsLine",
+					"name", cuiPlayerName(g.GetPlayer(i), i),
+					"role", role,
+					"thirds", strconv.Itoa(thirds[i])) + "\n")
+			}
 			b.WriteString(i18n.T("calabresella.promptRoundEndHelp") + "\n")
 		}
 	})

--- a/internal/adapter/presenter/CalabresellaCuiPresenter_test.go
+++ b/internal/adapter/presenter/CalabresellaCuiPresenter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func makeCalabresellaPlayers() []*domain.CalabresellaPlayer {
@@ -91,12 +92,18 @@ func TestCalabresellaCuiPresenter_Output(t *testing.T) {
 		assert.NotEmpty(t, result)
 	})
 
-	t.Run("round end prompt", func(t *testing.T) {
+	t.Run("round end lists all players thirds with roles", func(t *testing.T) {
 		m, _ := setupCalabresellaCuiMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetRoundThirds")
 		m.On("GetPhase").Return(domain.CalabresellaPhaseRoundEnd)
+		// Soloist (index 0) takes 5, the two coalition players 3 each → 11 total.
+		m.On("GetRoundThirds").Return([domain.CalabresellaPlayerCnt]int{5, 3, 3})
 		result := p.Output(m, nil)
-		assert.NotEmpty(t, result)
+		assert.Contains(t, result, i18n.T("calabresella.roleCoalition"))
+		// Each player's thirds appear in the breakdown: soloist 5, coalition 3 each.
+		assert.Contains(t, result, "5/3")
+		assert.Contains(t, result, "3/3")
 	})
 
 	t.Run("game end banner", func(t *testing.T) {

--- a/internal/i18n/locales/en/calabresella.json
+++ b/internal/i18n/locales/en/calabresella.json
@@ -34,5 +34,6 @@
   "hintReasonDiscardLow": "Cannot follow suit — discard a low card",
   "hintReasonBidChiamo": "Solid hand — call chiamo",
   "hintReasonBidSolo": "Very strong hand — declare solo",
-  "hintReasonBidPass": "Weak hand — pass"
+  "hintReasonBidPass": "Weak hand — pass",
+  "thirdsLine": "  {{name}} ({{role}}): {{thirds}}/3"
 }

--- a/internal/i18n/locales/ja/calabresella.json
+++ b/internal/i18n/locales/ja/calabresella.json
@@ -34,5 +34,6 @@
   "hintReasonDiscardLow": "フォローできないので低い札を捨てる",
   "hintReasonBidChiamo": "手堅い手なのでキアーモを宣言",
   "hintReasonBidSolo": "非常に強い手なのでソロを宣言",
-  "hintReasonBidPass": "弱い手なのでパスする"
+  "hintReasonBidPass": "弱い手なのでパスする",
+  "thirdsLine": "  {{name}}（{{role}}）: {{thirds}}/3"
 }


### PR DESCRIPTION
## Summary
Calabresella's CUI round-end line reported only the soloist's thirds, but the 11 thirds are split between the soloist and the two-player coalition — the web UI lists every player's share. This adds a per-player breakdown line (name + role label + thirds) beneath the round-end summary.

Uses the existing `GetRoundThirds()` (already returns all players) and `GetSoloistIdx()` — no domain change. The `promptRoundEndHelp` line is preserved.

## Changes
- `CalabresellaCuiPresenter.go`: per-player thirds breakdown with soloist/coalition role labels
- `calabresella.json` (ja/en): new `thirdsLine` key
- Test: round end lists all three players' thirds (5/3/3) with role labels

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3609