### PR TITLE
feat(bridge): show the auction history in the CUI bid phase

### DIFF
--- a/internal/adapter/presenter/BridgeCuiPresenter.go
+++ b/internal/adapter/presenter/BridgeCuiPresenter.go
@@ -141,6 +141,18 @@ func (p *BridgeCuiPresenter) Output(b interfaces.BridgeGame, lastErr error) stri
 		}
 		switch b.GetPhase() {
 		case domain.BridgePhaseBid:
+			// Show the auction so far (partner signals, doubles) so the human need
+			// not track it from memory; omitted before the first bid.
+			if history := b.GetBidHistory(); len(history) > 0 {
+				entries := make([]string, len(history))
+				for i, e := range history {
+					entries[i] = i18n.Tf("bridge.bidHistoryEntry",
+						"name", cuiPlayerName(b.GetPlayer(e.PlayerIdx), e.PlayerIdx),
+						"bid", bridgeBidEntryStr(e))
+				}
+				sb.WriteString(i18n.Tf("bridge.bidHistory",
+					"bids", strings.Join(entries, " → ")) + "\n")
+			}
 			bidIdx := b.GetBidPlayerIdx()
 			sb.WriteString(i18n.Tf("bridge.promptBid",
 				"name", cuiPlayerName(b.GetPlayer(bidIdx), bidIdx)) + "\n")
@@ -205,6 +217,15 @@ func bridgeBidTypeStr(bidType int) string {
 		return i18n.T(key)
 	}
 	return i18n.Tf("bridge.bidUnknown", "n", strconv.Itoa(bidType))
+}
+
+// bridgeBidEntryStr formats one auction entry: "1♣" for a normal bid, or the
+// localized pass/double/redouble label.
+func bridgeBidEntryStr(e *domain.BridgeBidEntry) string {
+	if e.BidType == domain.BridgeBidNormal {
+		return strconv.Itoa(e.Level) + bridgeBidSuitName(e.Suit)
+	}
+	return bridgeBidTypeStr(int(e.BidType))
 }
 
 // bridgeHintReasonKeys maps Bridge-specific hint-reason identifiers to

--- a/internal/adapter/presenter/BridgeCuiPresenter_test.go
+++ b/internal/adapter/presenter/BridgeCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -273,6 +274,26 @@ func TestBridgeCuiPresenter_Output(t *testing.T) {
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "ビッドフェーズ: あなたの番")
 		assert.Contains(t, result, "b <type>")
+		// No auction history before the first bid.
+		assert.NotContains(t, result, strings.Split(i18n.T("bridge.bidHistory"), "{{")[0])
+	})
+
+	t.Run("bid phase shows the auction history", func(t *testing.T) {
+		m, _ := setupBridgeCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetBidHistory")
+		m.On("GetPhase").Return(domain.BridgePhaseBid)
+		m.On("GetBidHistory").Return([]*domain.BridgeBidEntry{
+			{PlayerIdx: 0, BidType: domain.BridgeBidNormal, Level: 1, Suit: domain.BridgeBidSuitClub},
+			{PlayerIdx: 1, BidType: domain.BridgeBidPass},
+			{PlayerIdx: 2, BidType: domain.BridgeBidDouble},
+		})
+		result := p.Output(m, nil)
+		// Auction header, the 1♣ normal bid (level + clover suit), and the labels.
+		assert.Contains(t, result, strings.Split(i18n.T("bridge.bidHistory"), "{{")[0])
+		assert.Contains(t, result, "1CLOVER")
+		assert.Contains(t, result, i18n.T("bridge.bidPass"))
+		assert.Contains(t, result, i18n.T("bridge.bidDouble"))
 	})
 
 	t.Run("trick end phase shows next command", func(t *testing.T) {

--- a/internal/i18n/locales/en/bridge.json
+++ b/internal/i18n/locales/en/bridge.json
@@ -34,5 +34,7 @@
   "bidRedouble": "redouble",
   "bidUnknown": "unknown({{n}})",
   "hintReasonSupportPartner": "support partner",
-  "hintReasonCompetitiveBid": "competitive bid"
+  "hintReasonCompetitiveBid": "competitive bid",
+  "bidHistory": "Auction: {{bids}}",
+  "bidHistoryEntry": "{{name}}: {{bid}}"
 }

--- a/internal/i18n/locales/ja/bridge.json
+++ b/internal/i18n/locales/ja/bridge.json
@@ -34,5 +34,7 @@
   "bidRedouble": "リダブル",
   "bidUnknown": "不明({{n}})",
   "hintReasonSupportPartner": "パートナーをサポート",
-  "hintReasonCompetitiveBid": "競り合い"
+  "hintReasonCompetitiveBid": "競り合い",
+  "bidHistory": "オークション: {{bids}}",
+  "bidHistoryEntry": "{{name}}:{{bid}}"
 }


### PR DESCRIPTION
## Summary
Bridge's CUI bid phase showed only whose turn it was, never the auction so far — but bidding is partnership communication, so CLI players had to track prior bids and doubles from memory (the web UI shows the full `bidHistory`). This adds an auction line listing every bid in order (e.g. `You:1♣ → CPU1:Pass → CPU2:Double`).

Uses the existing `GetBidHistory()` accessor (already on the interface, already fed to the web presenter) and the existing `bridgeBidSuitName`/`bridgeBidTypeStr` helpers — no domain change. The section is omitted before the first bid.

## Changes
- `BridgeCuiPresenter.go`: `bridgeBidEntryStr` helper + auction-history line in the bid phase
- `bridge.json` (ja/en): new `bidHistory` / `bidHistoryEntry` keys
- Test: no history before first bid; normal/pass/double bids rendered after

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3102