### PR TITLE
feat(samba): explain the frozen-pile take condition in the draw help

### DIFF
--- a/internal/adapter/presenter/SambaCuiPresenter.go
+++ b/internal/adapter/presenter/SambaCuiPresenter.go
@@ -117,6 +117,11 @@ func (p *SambaCuiPresenter) Output(g interfaces.SambaGame, lastErr error) string
 				"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
 			b.WriteString(i18n.T("samba.promptDrawHelpStock") + "\n")
 			b.WriteString(i18n.T("samba.promptDrawHelpDiscard") + "\n")
+			// While the pile is frozen, taking the discard requires showing two
+			// natural matching cards from hand — spell out that extra condition.
+			if g.GetIsFrozen() {
+				b.WriteString(i18n.T("samba.promptDrawHelpFrozen") + "\n")
+			}
 		case domain.SambaPhaseMeld:
 			currentIdx := g.GetCurrentPlayerIdx()
 			b.WriteString(i18n.Tf("samba.promptMeld",

--- a/internal/adapter/presenter/SambaCuiPresenter_test.go
+++ b/internal/adapter/presenter/SambaCuiPresenter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupSambaCuiMock() *interfaces.MockSambaGame {
@@ -59,14 +60,18 @@ func TestSambaCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "あなた (チーム0)")
 		assert.Contains(t, result, "[0]SPADE 5")
 		assert.Contains(t, result, "手番: あなた")
+		// Not frozen → no frozen draw-help note.
+		assert.NotContains(t, result, i18n.T("samba.promptDrawHelpFrozen"))
 	})
 
-	t.Run("frozen tag", func(t *testing.T) {
+	t.Run("frozen tag and frozen draw help", func(t *testing.T) {
 		m, _ := setupSambaCuiMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetIsFrozen")
 		m.On("GetIsFrozen").Return(true)
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "[フリーズ]")
+		// Frozen draw phase spells out the take-condition.
+		assert.Contains(t, result, i18n.T("samba.promptDrawHelpFrozen"))
 	})
 
 	t.Run("discard top shown", func(t *testing.T) {

--- a/internal/i18n/locales/en/samba.json
+++ b/internal/i18n/locales/en/samba.json
@@ -34,5 +34,6 @@
   "promptDiscardHelp": "d <idx>: discard a card",
   "promptGoOutHelp": "go: go out (team needs 2+ completed melds)",
   "promptRoundEnd": "Round complete",
-  "promptRoundEndHelp": "nr / nextround: advance to next round"
+  "promptRoundEndHelp": "nr / nextround: advance to next round",
+  "promptDrawHelpFrozen": "  Note (frozen): taking the discard requires showing two natural matching cards from hand"
 }

--- a/internal/i18n/locales/ja/samba.json
+++ b/internal/i18n/locales/ja/samba.json
@@ -34,5 +34,6 @@
   "promptDiscardHelp": "d <idx>・・・カードを捨てる",
   "promptGoOutHelp": "go・・・上がる (チームで2個以上の完成メルドが必要)",
   "promptRoundEnd": "ラウンド終了",
-  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ"
+  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
+  "promptDrawHelpFrozen": "  ※凍結中: 捨札の取得には手札から同ランクの札2枚の提示が必要"
 }


### PR DESCRIPTION
## Summary
Samba's CUI tagged the header `[frozen]` but its draw-phase help used a fixed string that never mentioned the extra rule: while frozen, taking the discard pile requires showing two natural matching cards from hand (the web UI's `drawDiscardReason.frozen`). This branches the draw help on `GetIsFrozen()` to add that note when frozen.

## Changes
- `SambaCuiPresenter.go`: frozen note after the draw help when `GetIsFrozen()`
- `samba.json` (ja/en): new `promptDrawHelpFrozen` key
- Test: frozen draw phase shows the note; non-frozen omits it

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3497