### PR TITLE
feat(yaniv): show score limit in header and warn players near elimination

### DIFF
--- a/internal/adapter/presenter/YanivCuiPresenter.go
+++ b/internal/adapter/presenter/YanivCuiPresenter.go
@@ -29,6 +29,9 @@ func yanivPlayerStr(g interfaces.YanivGame, player *domain.YanivPlayer, i int) s
 	status := strconv.Itoa(player.GetScore())
 	if player.IsEliminated() {
 		status = "OUT"
+	} else if limit := g.GetConfig().ScoreLimit; limit > 0 && player.GetScore()*100 > limit*80 {
+		// Within 20% of the elimination threshold → flag the impending OUT.
+		status = color.Yellow(status + i18n.T("yaniv.nearOut"))
 	}
 	b.WriteString(i18n.Tf("yaniv.playerLine",
 		"name", cuiPlayerName(player, i),
@@ -50,6 +53,8 @@ func (p *YanivCuiPresenter) Output(g interfaces.YanivGame, lastErr error) string
 		b.WriteString(i18n.Tf("yaniv.header",
 			"round", strconv.Itoa(g.GetRoundNumber()),
 			"stock", strconv.Itoa(g.GetDrawPileCount())) + "\n")
+		b.WriteString(i18n.Tf("yaniv.limitLine",
+			"limit", strconv.Itoa(g.GetConfig().ScoreLimit)) + "\n")
 
 		if pickup := g.GetPickupCards(); len(pickup) > 0 {
 			cards := make([]string, 0, len(pickup))

--- a/internal/adapter/presenter/YanivCuiPresenter_test.go
+++ b/internal/adapter/presenter/YanivCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupYanivCuiMock() (*interfaces.MockYanivGame, []*domain.YanivPlayer) {
@@ -27,6 +29,7 @@ func setupYanivCuiMock() (*interfaces.MockYanivGame, []*domain.YanivPlayer) {
 	m.On("GetCallerIdx").Return(-1)
 	m.On("GetIsAsaf").Return(false)
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	m.On("GetConfig").Return(domain.DefaultYanivConfig())
 	m.On("GetPlayerCnt").Return(4)
 	for i := 0; i < 4; i++ {
 		m.On("GetPlayer", i).Return(players[i])
@@ -52,6 +55,17 @@ func TestYanivCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "山札: 39")
 		assert.Contains(t, result, "ディスカードフェーズ")
 		assert.Contains(t, result, "[0]SPADE 9")
+		// Header shows the configured score limit; no one is near out yet.
+		assert.Contains(t, result, strings.Split(i18n.T("yaniv.limitLine"), "{{")[0])
+		assert.NotContains(t, result, i18n.T("yaniv.nearOut"))
+	})
+
+	t.Run("player near the score limit is warned", func(t *testing.T) {
+		m, players := setupYanivCuiMock()
+		// Default limit is 200 → 80% = 160; a score above that flags near-out.
+		players[1].SetScore(180)
+		result := p.Output(m, nil)
+		assert.Contains(t, result, i18n.T("yaniv.nearOut"))
 	})
 
 	t.Run("yaniv help shown when hand low", func(t *testing.T) {

--- a/internal/i18n/locales/en/yaniv.json
+++ b/internal/i18n/locales/en/yaniv.json
@@ -20,5 +20,7 @@
   "promptYanivResult": "{{name}} declares Yaniv and wins the round!",
   "promptAsafResult": "{{name}}'s Yaniv is Asaf! +30 penalty",
   "promptRoundEnd": "Round complete",
-  "promptRoundEndHelp": "nr / nextround: advance to next round"
+  "promptRoundEndHelp": "nr / nextround: advance to next round",
+  "limitLine": "Score limit: {{limit}} (out if exceeded)",
+  "nearOut": " ⚠near out"
 }

--- a/internal/i18n/locales/ja/yaniv.json
+++ b/internal/i18n/locales/ja/yaniv.json
@@ -20,5 +20,7 @@
   "promptYanivResult": "{{name}} が Yaniv を宣言してラウンドに勝利!",
   "promptAsafResult": "{{name}} の Yaniv はアサフ! +30点のペナルティ",
   "promptRoundEnd": "ラウンド終了",
-  "promptRoundEndHelp": "nr / nextround: 次のラウンドへ"
+  "promptRoundEndHelp": "nr / nextround: 次のラウンドへ",
+  "limitLine": "スコア上限: {{limit}}（超過で脱落）",
+  "nearOut": " ⚠脱落間近"
 }


### PR DESCRIPTION
## Summary
Yaniv's CUI header showed only round and stock, never the configured score limit (web offers 100–250), and players had to mentally compute how close they were to elimination (OUT = score exceeds the limit). This adds the score limit to the header and colors a player's score yellow with a ⚠ warning once it passes 80% of the limit.

Uses the existing `GetConfig().ScoreLimit` (already on the interface) — no interface change.

## Changes
- `YanivCuiPresenter.go`: score-limit header line + near-out yellow warning per player
- `yaniv.json` (ja/en): new `limitLine` / `nearOut` keys
- Test: header shows the limit; a player above 80% (180 of 200) is warned

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3375