### PR TITLE
feat(euchre): mark the sitting-out partner during a go-alone hand

### DIFF
--- a/internal/adapter/presenter/EuchreCuiPresenter.go
+++ b/internal/adapter/presenter/EuchreCuiPresenter.go
@@ -13,7 +13,8 @@ import (
 )
 
 // euchrePlayerStr returns the display string for a single Euchre player.
-func euchrePlayerStr(player *domain.EuchrePlayer, i int) string {
+// sittingOut appends a marker when this seat sits out a go-alone hand.
+func euchrePlayerStr(player *domain.EuchrePlayer, i int, sittingOut bool) string {
 	var b strings.Builder
 	b.WriteString(i18n.Tf("euchre.playerLine",
 		"name", cuiPlayerName(player, i),
@@ -21,11 +22,37 @@ func euchrePlayerStr(player *domain.EuchrePlayer, i int) string {
 		"tricks", strconv.Itoa(player.GetTrickCount()),
 		"cards", strconv.Itoa(player.GetCardsSize()),
 	))
+	if sittingOut {
+		b.WriteString(i18n.T("euchre.sittingOut"))
+	}
 	b.WriteString("\n")
 	if player.GetIsHuman() && player.GetCardsSize() > 0 {
 		b.WriteString(cuiIndexedCardListStr(player) + "\n")
 	}
 	return b.String()
+}
+
+// euchreSittingOutIdx returns the seat that sits out during a go-alone hand —
+// the lone player's same-team partner — or -1 when nobody sits out. Mirrors the
+// web euchreSittingOutIdx helper so the CUI matches the graphical UI.
+func euchreSittingOutIdx(e interfaces.EuchreGame) int {
+	if !e.GetGoingAlone() {
+		return -1
+	}
+	goer := e.GetGoingAlonePlayerIdx()
+	gp := e.GetPlayer(goer)
+	if gp == nil {
+		return -1
+	}
+	for i := 0; i < e.GetPlayerCnt(); i++ {
+		if i == goer {
+			continue
+		}
+		if p := e.GetPlayer(i); p != nil && p.GetTeam() == gp.GetTeam() {
+			return i
+		}
+	}
+	return -1
 }
 
 // EuchreCuiPresenter renders the Euchre CUI view.
@@ -63,8 +90,9 @@ func (p *EuchreCuiPresenter) Output(e interfaces.EuchreGame, lastErr error) stri
 			"t0", strconv.Itoa(e.GetTeamScore(0)),
 			"t1", strconv.Itoa(e.GetTeamScore(1))) + "\n")
 
+		sittingOutIdx := euchreSittingOutIdx(e)
 		for i := 0; i < e.GetPlayerCnt(); i++ {
-			b.WriteString(euchrePlayerStr(e.GetPlayer(i), i))
+			b.WriteString(euchrePlayerStr(e.GetPlayer(i), i, i == sittingOutIdx))
 		}
 
 		b.WriteString("----------\n")

--- a/internal/adapter/presenter/EuchreCuiPresenter_test.go
+++ b/internal/adapter/presenter/EuchreCuiPresenter_test.go
@@ -2,6 +2,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +11,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 // setupEuchreCuiMock creates a MockEuchreGame with sensible defaults for CUI tests.
@@ -115,6 +117,15 @@ func TestEuchreCuiPresenter_Output(t *testing.T) {
 
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "ゴーアローン: あなた")
+		// Player 0's same-team partner (seat 2) sits out → marker shown exactly once.
+		assert.Contains(t, result, i18n.T("euchre.sittingOut"))
+		assert.Equal(t, 1, strings.Count(result, i18n.T("euchre.sittingOut")))
+	})
+
+	t.Run("no sitting-out marker in a normal hand", func(t *testing.T) {
+		m, _ := setupEuchreCuiMockWithPlayers()
+		result := p.Output(m, nil)
+		assert.NotContains(t, result, i18n.T("euchre.sittingOut"))
 	})
 
 	t.Run("team scores shown", func(t *testing.T) {

--- a/internal/i18n/locales/en/euchre.json
+++ b/internal/i18n/locales/en/euchre.json
@@ -39,5 +39,6 @@
   "hintCallSuit": "[HINT: call {{suit}} ({{reason}})]",
   "hintCallSuitAlone": "[HINT: call {{suit}} (go alone) ({{reason}})]",
   "hintCard": "[HINT: [{{idx}}]{{card}} ({{reason}})]",
-  "hintReasonDiscardWeakest": "discard the weakest card"
+  "hintReasonDiscardWeakest": "discard the weakest card",
+  "sittingOut": " 💤(sitting out)"
 }

--- a/internal/i18n/locales/ja/euchre.json
+++ b/internal/i18n/locales/ja/euchre.json
@@ -39,5 +39,6 @@
   "hintCallSuit": "[HINT: {{suit}}をコール ({{reason}})]",
   "hintCallSuitAlone": "[HINT: {{suit}}をコール (ゴーアローン) ({{reason}})]",
   "hintCard": "[HINT: [{{idx}}]{{card}} ({{reason}})]",
-  "hintReasonDiscardWeakest": "最弱カードを捨てる"
+  "hintReasonDiscardWeakest": "最弱カードを捨てる",
+  "sittingOut": " 💤（休み）"
 }


### PR DESCRIPTION
## Summary
Euchre's CUI announced the go-alone declarer but never showed which seat sits out that hand, so it wasn't obvious why only three players follow to a trick (the web UI greys the seat with a 💤 badge). This appends a sitting-out marker to the partner's player row.

The sitting-out seat is derived in the presenter (the lone player's same-team partner), mirroring the web `euchreSittingOutIdx` helper, from the existing `GetGoingAlone`/`GetGoingAlonePlayerIdx`/`GetTeam` accessors — no domain change.

## Changes
- `EuchreCuiPresenter.go`: `euchreSittingOutIdx` helper + sitting-out marker on the partner's row
- `euchre.json` (ja/en): new `sittingOut` key
- Test: go-alone marks exactly one seat; a normal hand marks none

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3081