### PR TITLE
feat(tressette): show per-team round breakdown and last-trick team at round end

### DIFF
--- a/internal/adapter/presenter/TressetteCuiPresenter.go
+++ b/internal/adapter/presenter/TressetteCuiPresenter.go
@@ -86,6 +86,16 @@ func (p *TressetteCuiPresenter) Output(g interfaces.TressetteGame, lastErr error
 			b.WriteString(i18n.T("tressette.promptTrickEnd") + "\n")
 			b.WriteString(i18n.T("tressette.promptTrickEndHelp") + "\n")
 		case domain.TressettePhaseRoundEnd:
+			// Break down each team's thirds this round and name the team that took
+			// the last trick (the ultima-presa +1/3 bonus goes to that trick's
+			// winner, who becomes the next lead).
+			lastTeam := domain.TressetteTeamOf(g.GetLeadPlayerIdx())
+			b.WriteString(i18n.Tf("tressette.roundBreakdown",
+				"a", tressetteTeamLabel(0),
+				"athird", strconv.Itoa(thirds[0]),
+				"b", tressetteTeamLabel(1),
+				"bthird", strconv.Itoa(thirds[1]),
+				"lastteam", tressetteTeamLabel(lastTeam)) + "\n")
 			b.WriteString(i18n.T("tressette.promptRoundEnd") + "\n")
 			b.WriteString(i18n.T("tressette.promptRoundEndHelp") + "\n")
 		}

--- a/internal/adapter/presenter/TressetteCuiPresenter_test.go
+++ b/internal/adapter/presenter/TressetteCuiPresenter_test.go
@@ -2,6 +2,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +11,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupTressetteCuiMock() *interfaces.MockTressetteGame {
@@ -18,6 +20,7 @@ func setupTressetteCuiMock() *interfaces.MockTressetteGame {
 	m.On("GetTrickNumber").Return(1)
 	m.On("GetTeamScores").Return([domain.TressetteTeamCnt]int{0, 0})
 	m.On("GetTeamRoundThirds").Return([domain.TressetteTeamCnt]int{0, 0})
+	m.On("GetLeadPlayerIdx").Return(0)
 	m.On("GetCurrentTrick").Return([]*domain.TressetteTrickCard(nil))
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetPhase").Return(domain.TressettePhasePlay)
@@ -63,12 +66,19 @@ func TestTressetteCuiPresenter_Output(t *testing.T) {
 		assert.NotEmpty(t, result)
 	})
 
-	t.Run("round end prompt", func(t *testing.T) {
+	t.Run("round end shows team breakdown and last-trick team", func(t *testing.T) {
 		m, _ := setupTressetteCuiMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetTeamRoundThirds")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetLeadPlayerIdx")
 		m.On("GetPhase").Return(domain.TressettePhaseRoundEnd)
+		m.On("GetTeamRoundThirds").Return([domain.TressetteTeamCnt]int{7, 4})
+		m.On("GetLeadPlayerIdx").Return(1) // team B took the last trick
 		result := p.Output(m, nil)
-		assert.NotEmpty(t, result)
+		assert.Contains(t, result, strings.Split(i18n.T("tressette.roundBreakdown"), "{{")[0])
+		// Each team's thirds appear (7 and 4).
+		assert.Contains(t, result, "thirds7")
+		assert.Contains(t, result, "thirds4")
 	})
 
 	t.Run("game end banner", func(t *testing.T) {

--- a/internal/i18n/locales/en/tressette.json
+++ b/internal/i18n/locales/en/tressette.json
@@ -22,5 +22,6 @@
   "hintReasonFollowWin": "Points are on the table, so win the trick",
   "hintReasonFollowDuck": "Cannot/should not win, so duck the trick",
   "hintReasonGivePartner": "Partner is winning, so give them point cards",
-  "hintReasonDiscardLow": "Cannot follow, so discard a low card"
+  "hintReasonDiscardLow": "Cannot follow, so discard a low card",
+  "roundBreakdown": "Round breakdown: Team {{a}} thirds {{athird}} / Team {{b}} thirds {{bthird}} (last trick: Team {{lastteam}})"
 }

--- a/internal/i18n/locales/ja/tressette.json
+++ b/internal/i18n/locales/ja/tressette.json
@@ -22,5 +22,6 @@
   "hintReasonFollowWin": "得点があるので勝てる札で取りに行く",
   "hintReasonFollowDuck": "取れない／取る価値がないのでダックする",
   "hintReasonGivePartner": "味方が勝っているので得点札を渡す",
-  "hintReasonDiscardLow": "フォローできないので低い札を捨てる"
+  "hintReasonDiscardLow": "フォローできないので低い札を捨てる",
+  "roundBreakdown": "ラウンド内訳: チーム{{a}} thirds{{athird}} / チーム{{b}} thirds{{bthird}}（ラストトリック: チーム{{lastteam}}）"
 }


### PR DESCRIPTION
## Summary
Tressette's CUI round-end branch printed only a fixed prompt — the header showed cumulative scores and current thirds, but not each team's round thirds or which team took the last-trick (ultima-presa) bonus. This adds a round-breakdown line naming each team's thirds and the team that won the final trick.

Uses the existing `GetTeamRoundThirds()` and `GetLeadPlayerIdx()` (the last trick's winner becomes the next lead) plus `TressetteTeamOf` — no domain change.

## Changes
- `TressetteCuiPresenter.go`: `tressette.roundBreakdown` line in the round-end phase
- `tressette.json` (ja/en): new `roundBreakdown` key
- Test: round end shows both teams' thirds (7/4) and the breakdown line

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3387