### PR TITLE
feat(marias): show defenders' total points at round end

### DIFF
--- a/internal/adapter/presenter/MariasCuiPresenter.go
+++ b/internal/adapter/presenter/MariasCuiPresenter.go
@@ -96,9 +96,19 @@ func (p *MariasCuiPresenter) Output(g interfaces.MariasGame, lastErr error) stri
 		case domain.MariasPhaseRoundEnd:
 			pts := g.GetRoundCardPoints()
 			soloist := g.GetSoloistIdx()
+			// Sum the two defenders' card points so the outcome (soloist won or
+			// lost the round) is readable from this line alone.
+			defenderPts := 0
+			for i := 0; i < g.GetPlayerCnt(); i++ {
+				if i != soloist {
+					defenderPts += pts[i]
+				}
+			}
 			b.WriteString(i18n.Tf("marias.promptRoundEnd",
 				"soloist", cuiPlayerName(g.GetPlayer(soloist), soloist),
 				"pts", strconv.Itoa(pts[soloist])) + "\n")
+			b.WriteString(i18n.Tf("marias.promptRoundEndDefenders",
+				"pts", strconv.Itoa(defenderPts)) + "\n")
 			b.WriteString(i18n.T("marias.promptRoundEndHelp") + "\n")
 		}
 	})

--- a/internal/adapter/presenter/MariasCuiPresenter_test.go
+++ b/internal/adapter/presenter/MariasCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func makeMariasPlayers() []*domain.MariasPlayer {
@@ -72,12 +74,16 @@ func TestMariasCuiPresenter_Output(t *testing.T) {
 		assert.NotEmpty(t, result)
 	})
 
-	t.Run("round end prompt", func(t *testing.T) {
+	t.Run("round end shows defenders total", func(t *testing.T) {
 		m, _ := setupMariasCuiMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetRoundCardPoints")
 		m.On("GetPhase").Return(domain.MariasPhaseRoundEnd)
+		// Soloist (idx 0) took 40; the two defenders took 30 + 20 = 50.
+		m.On("GetRoundCardPoints").Return([domain.MariasPlayerCnt]int{40, 30, 20})
 		result := p.Output(m, nil)
-		assert.NotEmpty(t, result)
+		assert.Contains(t, result, strings.Split(i18n.T("marias.promptRoundEndDefenders"), "{{")[0])
+		assert.Contains(t, result, "50")
 	})
 
 	t.Run("game end banner", func(t *testing.T) {

--- a/internal/i18n/locales/en/marias.json
+++ b/internal/i18n/locales/en/marias.json
@@ -21,5 +21,6 @@
   "hintReasonLeadLow": "Lead a low card to conserve points",
   "hintReasonFollowWin": "Points on the table — win the trick",
   "hintReasonFollowDuck": "Cannot/should not win — duck",
-  "hintReasonDiscardLow": "Cannot follow suit — discard a low card"
+  "hintReasonDiscardLow": "Cannot follow suit — discard a low card",
+  "promptRoundEndDefenders": "Defenders total: {{pts}} pts"
 }

--- a/internal/i18n/locales/ja/marias.json
+++ b/internal/i18n/locales/ja/marias.json
@@ -21,5 +21,6 @@
   "hintReasonLeadLow": "低い札でリードして温存する",
   "hintReasonFollowWin": "得点があるので勝ちに行く",
   "hintReasonFollowDuck": "取れない／取る価値がないのでダック",
-  "hintReasonDiscardLow": "フォローできないので低い札を捨てる"
+  "hintReasonDiscardLow": "フォローできないので低い札を捨てる",
+  "promptRoundEndDefenders": "ディフェンダー合計: {{pts}}点"
 }


### PR DESCRIPTION
## Summary
Mariáš's CUI round-end line showed only the soloist's card points, so a CLI player couldn't tell from that line whether the soloist won or lost. This adds a defenders-total line (the two non-soloist players' combined card points) for an at-a-glance comparison.

Uses the existing `GetRoundCardPoints()` (per-player) and `GetSoloistIdx()` — no domain change.

## Changes
- `MariasCuiPresenter.go`: defenders-total line after the soloist line at round end
- `marias.json` (ja/en): new `promptRoundEndDefenders` key
- Test: round end shows the defenders' summed total (30+20 = 50)

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3428