### PR TITLE
feat(anaconda): show the pass recipient/direction in the pass prompt

### DIFF
--- a/internal/adapter/presenter/AnacondaCuiPresenter.go
+++ b/internal/adapter/presenter/AnacondaCuiPresenter.go
@@ -12,6 +12,28 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
+// anacondaPassRecipient returns the seat the human passes to — the next still-in
+// (not eliminated) participant to the left — or -1 when it can't be determined.
+// Mirrors the domain executePass rotation (participants[(k+1)%n]).
+func anacondaPassRecipient(g interfaces.AnacondaGame) int {
+	humanPos := -1
+	var participants []int
+	for i := 0; i < g.GetPlayerCnt(); i++ {
+		p := g.GetPlayer(i)
+		if p == nil || p.GetOut() {
+			continue
+		}
+		if p.GetIsHuman() {
+			humanPos = len(participants)
+		}
+		participants = append(participants, i)
+	}
+	if humanPos < 0 || len(participants) < 2 {
+		return -1
+	}
+	return participants[(humanPos+1)%len(participants)]
+}
+
 // AnacondaCuiPresenter renders the Anaconda CUI view.
 type AnacondaCuiPresenter struct{}
 
@@ -89,6 +111,13 @@ func (p *AnacondaCuiPresenter) Output(g interfaces.AnacondaGame, lastErr error) 
 		switch g.GetPhase() {
 		case domain.AnacondaPhasePass:
 			b.WriteString(i18n.Tf("anaconda.promptPass", "count", strconv.Itoa(g.GetPassCount())) + "\n")
+			// Name who receives the pass (the next still-in player to the left) so
+			// the human knows where their discarded cards go.
+			if recipient := anacondaPassRecipient(g); recipient >= 0 {
+				b.WriteString(i18n.Tf("anaconda.promptPassTo",
+					"name", cuiPlayerName(g.GetPlayer(recipient), recipient),
+					"count", strconv.Itoa(g.GetPassCount())) + "\n")
+			}
 		case domain.AnacondaPhaseSet:
 			b.WriteString(i18n.T("anaconda.promptKeep") + "\n")
 		case domain.AnacondaPhaseRoll:

--- a/internal/adapter/presenter/AnacondaCuiPresenter_test.go
+++ b/internal/adapter/presenter/AnacondaCuiPresenter_test.go
@@ -2,12 +2,14 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func TestAnacondaCuiPresenter_OutputPassPhase(t *testing.T) {
@@ -18,6 +20,20 @@ func TestAnacondaCuiPresenter_OutputPassPhase(t *testing.T) {
 	assert.Contains(t, out, "アナコンダ")
 	assert.Contains(t, out, "ラウンド")
 	assert.Contains(t, out, "パスフェーズ")
+	// The pass prompt names the recipient (the next player to the left).
+	assert.Contains(t, out, strings.Split(i18n.T("anaconda.promptPassTo"), "{{")[0])
+}
+
+func TestAnacondaCuiPresenter_PassNoRecipientWhenAlone(t *testing.T) {
+	g := domain.NewDefaultAnaconda()
+	// Eliminate every non-human seat → the human is the only participant, so
+	// there is no one to pass to and the direction line is omitted.
+	for i := 1; i < g.GetPlayerCnt(); i++ {
+		g.GetPlayer(i).SetOut(true)
+	}
+	p := new(presenter.AnacondaCuiPresenter)
+	out := p.Output(g, nil)
+	assert.NotContains(t, out, strings.Split(i18n.T("anaconda.promptPassTo"), "{{")[0])
 }
 
 func TestAnacondaCuiPresenter_OutputError(t *testing.T) {

--- a/internal/i18n/locales/en/anaconda.json
+++ b/internal/i18n/locales/en/anaconda.json
@@ -45,5 +45,6 @@
   "hintReasonKeepBest": "keep your strongest 5 cards",
   "hintReasonStrongHand": "strong hand — worth raising",
   "hintReasonMediumHand": "decent hand — call to see more",
-  "hintReasonWeakHand": "weak hand — better to fold"
+  "hintReasonWeakHand": "weak hand — better to fold",
+  "promptPassTo": "→ pass {{count}} card(s) left to {{name}}"
 }

--- a/internal/i18n/locales/ja/anaconda.json
+++ b/internal/i18n/locales/ja/anaconda.json
@@ -45,5 +45,6 @@
   "hintReasonKeepBest": "最強の5枚を残す",
   "hintReasonStrongHand": "強い手 — レイズの価値あり",
   "hintReasonMediumHand": "そこそこの手 — コールで様子見",
-  "hintReasonWeakHand": "弱い手 — 降りるのが無難"
+  "hintReasonWeakHand": "弱い手 — 降りるのが無難",
+  "promptPassTo": "→ 左隣の {{name}} へ {{count}} 枚渡す"
 }


### PR DESCRIPTION
## Summary
Anaconda (Pass the Trash) asked the human to pass N cards but never said **to whom** — the direction is the strategic core (dump weak cards to the left). This adds a line naming the recipient (the next still-in player to the left).

The recipient is derived in the presenter to match the domain `executePass` rotation (participants[(k+1)%n], skipping eliminated seats) from existing `GetPlayer`/`GetOut`/`GetIsHuman` accessors — no domain change.

## Changes
- `AnacondaCuiPresenter.go`: `anacondaPassRecipient` helper + `anaconda.promptPassTo` line in the pass phase
- `anaconda.json` (ja/en): new `promptPassTo` key
- Test: pass phase names the recipient direction

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3500