### PR TITLE
feat(tysiac): show contract value, target, and current bid in the header

### DIFF
--- a/internal/adapter/presenter/TysiacCuiPresenter.go
+++ b/internal/adapter/presenter/TysiacCuiPresenter.go
@@ -59,6 +59,20 @@ func (p *TysiacCuiPresenter) Output(g interfaces.TysiacGame, lastErr error) stri
 			"trick", strconv.Itoa(g.GetTrickNumber()),
 			"trump", tysiacSuitSymbol(g.GetTrumpSuit())) + "\n")
 
+		// Surface the declarer's contract obligation and the match target during
+		// play (not only at round end), plus the live bid while bidding.
+		contractStr := "-"
+		if c := g.GetContract(); c > 0 {
+			contractStr = strconv.Itoa(c)
+		}
+		b.WriteString(i18n.Tf("tysiac.headerInfo",
+			"contract", contractStr,
+			"target", strconv.Itoa(g.GetConfig().TargetPoints)) + "\n")
+		if g.GetPhase() == domain.TysiacPhaseBid {
+			b.WriteString(i18n.Tf("tysiac.headerBid",
+				"bid", strconv.Itoa(g.GetCurrentBid())) + "\n")
+		}
+
 		for i := 0; i < g.GetPlayerCnt(); i++ {
 			b.WriteString(tysiacPlayerStr(g, i))
 		}

--- a/internal/adapter/presenter/TysiacCuiPresenter_test.go
+++ b/internal/adapter/presenter/TysiacCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func makeTysiacPlayers() []*domain.TysiacPlayer {
@@ -34,6 +36,7 @@ func setupTysiacCuiMock() *interfaces.MockTysiacGame {
 	m.On("GetDeclarerIdx").Return(0)
 	m.On("GetContract").Return(100)
 	m.On("GetCurrentBid").Return(100)
+	m.On("GetConfig").Return(domain.DefaultTysiacConfig())
 	m.On("GetWinnerPlayer").Return(-1)
 	m.On("GetRoundCardPoints").Return([domain.TysiacPlayerCnt]int{0, 0, 0})
 	m.On("GetPlayerScores").Return([domain.TysiacPlayerCnt]int{0, 0, 0})
@@ -64,6 +67,10 @@ func TestTysiacCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "トゥシオンツ") // translated helpTitle
 		assert.Contains(t, result, "マリッジ")   // play-phase help explains the marriage bonus
 		assert.NotEmpty(t, result)
+		// The header shows the contract and target during play.
+		assert.Contains(t, result, strings.Split(i18n.T("tysiac.headerInfo"), "{{")[0])
+		// The live-bid line is only shown while bidding.
+		assert.NotContains(t, result, strings.Split(i18n.T("tysiac.headerBid"), "{{")[0])
 	})
 
 	t.Run("bid phase prompt", func(t *testing.T) {
@@ -73,6 +80,16 @@ func TestTysiacCuiPresenter_Output(t *testing.T) {
 		result := p.Output(m, nil)
 		assert.NotEmpty(t, result)
 		assert.Contains(t, result, "ビッド") // translated bid prompt/help
+		// The bid phase adds the current-bid line to the header.
+		assert.Contains(t, result, strings.Split(i18n.T("tysiac.headerBid"), "{{")[0])
+	})
+
+	t.Run("unconfirmed contract shows placeholder", func(t *testing.T) {
+		m, _ := setupTysiacCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetContract")
+		m.On("GetContract").Return(0)
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "契約: -")
 	})
 
 	t.Run("talon phase prompt", func(t *testing.T) {

--- a/internal/i18n/locales/en/tysiac.json
+++ b/internal/i18n/locales/en/tysiac.json
@@ -31,5 +31,7 @@
   "hintReasonDiscardLow": "Cannot follow suit — discard a low card",
   "hintReasonBidRaise": "Strong hand — raise the bid",
   "hintReasonBidPass": "Weak hand — pass",
-  "hintReasonTalonDiscard": "Give away your weakest card"
+  "hintReasonTalonDiscard": "Give away your weakest card",
+  "headerInfo": "Contract: {{contract}} / Target: {{target}}",
+  "headerBid": "Current bid: {{bid}}"
 }

--- a/internal/i18n/locales/ja/tysiac.json
+++ b/internal/i18n/locales/ja/tysiac.json
@@ -31,5 +31,7 @@
   "hintReasonDiscardLow": "フォローできないので低い札を捨てる",
   "hintReasonBidRaise": "強い手なのでビッドを上げる",
   "hintReasonBidPass": "弱い手なのでパスする",
-  "hintReasonTalonDiscard": "最も弱い札を渡す"
+  "hintReasonTalonDiscard": "最も弱い札を渡す",
+  "headerInfo": "契約: {{contract}} / 目標: {{target}}",
+  "headerBid": "現在ビッド: {{bid}}"
 }


### PR DESCRIPTION
## Summary
Thousand (Tysiąc)'s CUI header showed only round/trick/trump — the contract value appeared only at round end, and the match target and live bid were never shown, unlike the web info bar. This adds a header line with the contract (placeholder `-` until confirmed) and target points, plus a current-bid line during the bid phase.

Uses the existing `GetContract()`, `GetCurrentBid()`, and `GetConfig().TargetPoints` accessors — no domain change.

## Changes
- `TysiacCuiPresenter.go`: contract/target header line + bid line in the bid phase
- `tysiac.json` (ja/en): new `headerInfo` / `headerBid` keys
- Test: play phase shows contract/target (no bid line); bid phase adds the bid line; unconfirmed contract renders `-`

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3606