### PR TITLE
feat(spoilfive): mark the lead player and round winner in player rows

### DIFF
--- a/internal/adapter/presenter/SpoilFiveCuiPresenter.go
+++ b/internal/adapter/presenter/SpoilFiveCuiPresenter.go
@@ -29,6 +29,14 @@ func spoilFivePlayerStr(g interfaces.SpoilFiveGame, idx int) string {
 		return ""
 	}
 	var b strings.Builder
+	// Mark the current lead and (at round end) the round winner so seat status is
+	// visible at a glance in the 5-player game, matching the web player panels.
+	if idx == g.GetLeadPlayerIdx() {
+		b.WriteString(i18n.T("spoilfive.leaderMark"))
+	}
+	if idx == g.GetRoundWinnerIdx() {
+		b.WriteString(i18n.T("spoilfive.winnerMark"))
+	}
 	b.WriteString(i18n.Tf("spoilfive.playerLine",
 		"name", cuiPlayerName(player, idx),
 		"cards", strconv.Itoa(player.GetCardsSize()),

--- a/internal/adapter/presenter/SpoilFiveCuiPresenter_test.go
+++ b/internal/adapter/presenter/SpoilFiveCuiPresenter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func makeSpoilFivePlayers() []*domain.SpoilFivePlayer {
@@ -30,6 +31,7 @@ func setupSpoilFiveCuiMock() *interfaces.MockSpoilFiveGame {
 	m.On("GetTrickNumber").Return(1)
 	m.On("GetTrumpSuit").Return(domain.CardDesignSpade)
 	m.On("GetPot").Return(5)
+	m.On("GetLeadPlayerIdx").Return(0)
 	m.On("GetRoundWinnerIdx").Return(-1)
 	m.On("GetCurrentTrick").Return(([]*domain.SpoilFiveTrickCard)(nil))
 	m.On("GetGameEndFlag").Return(false)
@@ -56,11 +58,14 @@ func TestSpoilFiveCuiPresenter_Output(t *testing.T) {
 	defer color.SetNoColor(orig)
 	p := new(presenter.SpoilFiveCuiPresenter)
 
-	t.Run("play phase shows current player", func(t *testing.T) {
+	t.Run("play phase shows current player and lead marker", func(t *testing.T) {
 		m, players := setupSpoilFiveCuiMockWithPlayers()
 		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 13, false))
 		result := p.Output(m, nil)
 		assert.NotEmpty(t, result)
+		// The lead player (seat 0) is flagged; no round winner during play.
+		assert.Contains(t, result, i18n.T("spoilfive.leaderMark"))
+		assert.NotContains(t, result, i18n.T("spoilfive.winnerMark"))
 	})
 
 	t.Run("trick end prompt", func(t *testing.T) {
@@ -79,6 +84,8 @@ func TestSpoilFiveCuiPresenter_Output(t *testing.T) {
 		m.On("GetRoundWinnerIdx").Return(0)
 		result := p.Output(m, nil)
 		assert.NotEmpty(t, result)
+		// Seat 0 is the round winner → the winner marker appears.
+		assert.Contains(t, result, i18n.T("spoilfive.winnerMark"))
 	})
 
 	t.Run("round end spoil prompt", func(t *testing.T) {

--- a/internal/i18n/locales/en/spoilfive.json
+++ b/internal/i18n/locales/en/spoilfive.json
@@ -18,5 +18,7 @@
   "hintCard": "[HINT: {{cards}} ({{reason}})]",
   "hintReasonLeadHigh": "Lead a high card to seize the trick",
   "hintReasonTakeTrick": "Play to win this trick (3 tricks takes the pot)",
-  "hintReasonDiscardLow": "Cannot win — discard a low card"
+  "hintReasonDiscardLow": "Cannot win — discard a low card",
+  "leaderMark": "▶(lead) ",
+  "winnerMark": "★(winner) "
 }

--- a/internal/i18n/locales/ja/spoilfive.json
+++ b/internal/i18n/locales/ja/spoilfive.json
@@ -18,5 +18,7 @@
   "hintCard": "[HINT: {{cards}} ({{reason}})]",
   "hintReasonLeadHigh": "高い札でリードしてトリックを取りにいく",
   "hintReasonTakeTrick": "このトリックを取りにいく（3トリックでポット獲得）",
-  "hintReasonDiscardLow": "取れないので低い札を捨てる"
+  "hintReasonDiscardLow": "取れないので低い札を捨てる",
+  "leaderMark": "▶(リード) ",
+  "winnerMark": "★(勝者) "
 }


### PR DESCRIPTION
## Summary
Spoil Five's CUI player rows showed name/cards/tricks/score but not who leads or (at round end) who won — in a 5-player game the seat situation was hard to track. This prepends a lead marker (▶) to the current lead's row and a winner marker (★) to the round winner's row, matching the web player panels.

Uses the existing `GetLeadPlayerIdx()` and `GetRoundWinnerIdx()` accessors — no domain change.

## Changes
- `SpoilFiveCuiPresenter.go`: lead/winner markers in `spoilFivePlayerStr`
- `spoilfive.json` (ja/en): new `leaderMark` / `winnerMark` keys
- Test: play phase shows the lead marker (no winner); round end shows the winner marker

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3446