### PR TITLE
feat(fortyfives): show every player's bid in the CUI bid phase

### DIFF
--- a/internal/adapter/presenter/FortyFivesCuiPresenter.go
+++ b/internal/adapter/presenter/FortyFivesCuiPresenter.go
@@ -136,6 +136,19 @@ func (p *FortyFivesCuiPresenter) writePrompt(b *strings.Builder, g interfaces.Fo
 		b.WriteString(i18n.Tf("fortyfives.promptBid",
 			"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx),
 			"high", fortyFivesBidName(int(highBid))) + "\n")
+		// List every player's declared bid (pass included) so the opposing team's
+		// bidding is visible; players who have not yet bid show "-".
+		bidDone := g.GetBidDone()
+		entries := make([]string, g.GetPlayerCnt())
+		for i := 0; i < g.GetPlayerCnt(); i++ {
+			state := "-"
+			if bidDone[i] {
+				state = fortyFivesBidName(int(bids[i]))
+			}
+			entries[i] = cuiPlayerName(g.GetPlayer(i), i) + "=" + state
+		}
+		b.WriteString(i18n.Tf("fortyfives.bidHistory",
+			"bids", strings.Join(entries, ", ")) + "\n")
 		b.WriteString(i18n.T("fortyfives.promptBidHelp") + "\n")
 	case domain.FortyFivesPhasePlay:
 		currentIdx := g.GetCurrentPlayerIdx()

--- a/internal/adapter/presenter/FortyFivesCuiPresenter_test.go
+++ b/internal/adapter/presenter/FortyFivesCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func makeFortyFivesPlayers() []*domain.FortyFivesPlayer {
@@ -35,6 +37,7 @@ func setupFortyFivesCuiMock() *interfaces.MockFortyFivesGame {
 	m.On("GetDeclarerIdx").Return(0)
 	m.On("GetContract").Return(domain.FortyFivesBidTwenty)
 	m.On("GetBids").Return([domain.FortyFivesPlayerCnt]domain.FortyFivesBid{domain.FortyFivesBidTwenty, domain.FortyFivesBidPass, domain.FortyFivesBidPass, domain.FortyFivesBidPass})
+	m.On("GetBidDone").Return([domain.FortyFivesPlayerCnt]bool{true, true, false, false})
 	m.On("GetWinnerTeam").Return(-1)
 	m.On("GetTeamScores").Return([domain.FortyFivesTeamCnt]int{0, 0})
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
@@ -75,6 +78,9 @@ func TestFortyFivesCuiPresenter_Output(t *testing.T) {
 		m.On("GetTrumpSuit").Return(0)
 		result := p.Output(m, nil)
 		assert.NotEmpty(t, result)
+		// The bid-history line lists every player: seat 0 bid, seat 2 has not (shown "-").
+		assert.Contains(t, result, strings.Split(i18n.T("fortyfives.bidHistory"), "{{")[0])
+		assert.Contains(t, result, "=-") // an un-bid player renders as "-"
 	})
 
 	t.Run("trick end prompt", func(t *testing.T) {

--- a/internal/domain/FortyFives.go
+++ b/internal/domain/FortyFives.go
@@ -827,6 +827,10 @@ func (g *FortyFives) SetContract(b FortyFivesBid) { g.contract = b }
 // GetBids 各プレイヤーの入札を取得
 func (g *FortyFives) GetBids() [FortyFivesPlayerCnt]FortyFivesBid { return g.bids }
 
+// GetBidDone は各プレイヤーが入札を済ませたか（true=済み）を返す。未入札と
+// 「パス（bid=0）」を区別できるよう、プレゼンター向けに公開する。
+func (g *FortyFives) GetBidDone() [FortyFivesPlayerCnt]bool { return g.bidDone }
+
 // GetTrumpSuit 切り札スート取得 (0=なし)
 func (g *FortyFives) GetTrumpSuit() int { return g.trumpSuit }
 

--- a/internal/domain/interfaces/fortyfives.go
+++ b/internal/domain/interfaces/fortyfives.go
@@ -57,6 +57,8 @@ type FortyFivesGame interface {
 	GetContract() domain.FortyFivesBid
 	// GetBids 各プレイヤーの入札を取得する
 	GetBids() [domain.FortyFivesPlayerCnt]domain.FortyFivesBid
+	// GetBidDone 各プレイヤーが入札を済ませたかを取得する (未入札とパスの区別用)
+	GetBidDone() [domain.FortyFivesPlayerCnt]bool
 	// GetTrumpSuit 切り札スートを取得する (0=なし)
 	GetTrumpSuit() int
 	// GetTeamScores チーム別累積点を取得する

--- a/internal/domain/interfaces/fortyfives_mock.go
+++ b/internal/domain/interfaces/fortyfives_mock.go
@@ -152,6 +152,12 @@ func (_m *MockFortyFivesGame) GetBids() [domain.FortyFivesPlayerCnt]domain.Forty
 	return ret.Get(0).([domain.FortyFivesPlayerCnt]domain.FortyFivesBid)
 }
 
+// GetBidDone モック
+func (_m *MockFortyFivesGame) GetBidDone() [domain.FortyFivesPlayerCnt]bool {
+	ret := _m.Called()
+	return ret.Get(0).([domain.FortyFivesPlayerCnt]bool)
+}
+
 // GetTrumpSuit モック
 func (_m *MockFortyFivesGame) GetTrumpSuit() int {
 	ret := _m.Called()

--- a/internal/i18n/locales/en/fortyfives.json
+++ b/internal/i18n/locales/en/fortyfives.json
@@ -37,5 +37,6 @@
   "trickEnd": "Trick complete",
   "roundEnd": "Round complete",
   "result.humanWin": "Game over! Your team wins!",
-  "result.cpuWin": "Game over! Team {{team}} wins!"
+  "result.cpuWin": "Game over! Team {{team}} wins!",
+  "bidHistory": "Bids: {{bids}}"
 }

--- a/internal/i18n/locales/ja/fortyfives.json
+++ b/internal/i18n/locales/ja/fortyfives.json
@@ -37,5 +37,6 @@
   "trickEnd": "トリック終了",
   "roundEnd": "ラウンド終了",
   "result.humanWin": "ゲーム終了！ あなたのチームの勝ち！",
-  "result.cpuWin": "ゲーム終了！ チーム{{team}}の勝ち！"
+  "result.cpuWin": "ゲーム終了！ チーム{{team}}の勝ち！",
+  "bidHistory": "ビッド状況: {{bids}}"
 }


### PR DESCRIPTION
## Summary
Forty-Fives' CUI bid phase showed only the current high bid, so a player couldn't see who bid what (or passed). This adds a bid-status line listing each player's declared bid (`You=Pass, CPU1=15, CPU2=-, CPU3=20`), with players who have not yet bid shown as `-`.

Distinguishing "not yet bid" from "passed" (both map to bid 0) required exposing the domain's per-player `bidDone` flag via a new `GetBidDone()` accessor. The existing high-bid line is unchanged.

## Changes
- `FortyFives.go`: `GetBidDone()` accessor
- `interfaces/fortyfives.go` + `fortyfives_mock.go`: expose it
- `FortyFivesCuiPresenter.go`: `fortyfives.bidHistory` line in the bid phase
- `fortyfives.json` (ja/en): new `bidHistory` key
- Test: bid phase lists all players; an un-bid player renders `-`

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3417