### PR TITLE
feat(solowhist): show every player's bid in the CUI bid phase

### DIFF
--- a/internal/adapter/presenter/SoloWhistCuiPresenter.go
+++ b/internal/adapter/presenter/SoloWhistCuiPresenter.go
@@ -114,6 +114,20 @@ func (p *SoloWhistCuiPresenter) writePrompt(b *strings.Builder, g interfaces.Sol
 		b.WriteString(i18n.Tf("solowhist.promptBid",
 			"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx),
 			"contract", soloWhistBidName(int(g.GetContract()))) + "\n")
+		// List every player's declared bid (pass included) so later bidders can see
+		// the auction; players who have not yet bid show "-".
+		bids := g.GetBids()
+		bidDone := g.GetBidDone()
+		entries := make([]string, g.GetPlayerCnt())
+		for i := 0; i < g.GetPlayerCnt(); i++ {
+			state := "-"
+			if bidDone[i] {
+				state = soloWhistBidName(int(bids[i]))
+			}
+			entries[i] = cuiPlayerName(g.GetPlayer(i), i) + "=" + state
+		}
+		b.WriteString(i18n.Tf("solowhist.bidHistory",
+			"bids", strings.Join(entries, ", ")) + "\n")
 		b.WriteString(i18n.T("solowhist.promptBidHelp") + "\n")
 	case domain.SoloWhistPhasePlay:
 		currentIdx := g.GetCurrentPlayerIdx()

--- a/internal/adapter/presenter/SoloWhistCuiPresenter_test.go
+++ b/internal/adapter/presenter/SoloWhistCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func makeSoloWhistPlayers() []*domain.SoloWhistPlayer {
@@ -34,6 +36,8 @@ func setupSoloWhistCuiMock() *interfaces.MockSoloWhistGame {
 	m.On("GetCurrentPlayerIdx").Return(0)
 	m.On("GetDeclarerIdx").Return(0)
 	m.On("GetContract").Return(domain.SoloWhistBidSolo)
+	m.On("GetBids").Return([domain.SoloWhistPlayerCnt]domain.SoloWhistBid{domain.SoloWhistBidSolo, domain.SoloWhistBidPass, domain.SoloWhistBidPass, domain.SoloWhistBidPass})
+	m.On("GetBidDone").Return([domain.SoloWhistPlayerCnt]bool{true, true, false, false})
 	m.On("GetWinnerPlayer").Return(-1)
 	m.On("GetPlayerScores").Return([domain.SoloWhistPlayerCnt]int{0, 0, 0, 0})
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
@@ -72,6 +76,9 @@ func TestSoloWhistCuiPresenter_Output(t *testing.T) {
 		m.On("GetDeclarerIdx").Return(-1)
 		result := p.Output(m, nil)
 		assert.NotEmpty(t, result)
+		// The bid-status line lists every player; an un-bid player renders "-".
+		assert.Contains(t, result, strings.Split(i18n.T("solowhist.bidHistory"), "{{")[0])
+		assert.Contains(t, result, "=-")
 	})
 
 	t.Run("misere shows no trump", func(t *testing.T) {

--- a/internal/domain/SoloWhist.go
+++ b/internal/domain/SoloWhist.go
@@ -798,6 +798,10 @@ func (g *SoloWhist) SetContract(b SoloWhistBid) { g.contract = b }
 // GetBids 各プレイヤーの入札を取得
 func (g *SoloWhist) GetBids() [SoloWhistPlayerCnt]SoloWhistBid { return g.bids }
 
+// GetBidDone は各プレイヤーが入札済みか（true=済み）を返す。未入札とパスを
+// 区別できるよう、プレゼンター向けに公開する。
+func (g *SoloWhist) GetBidDone() [SoloWhistPlayerCnt]bool { return g.bidDone }
+
 // GetTrumpSuit 切り札スート取得 (0=なし)
 func (g *SoloWhist) GetTrumpSuit() int { return g.trumpSuit }
 

--- a/internal/domain/interfaces/solowhist.go
+++ b/internal/domain/interfaces/solowhist.go
@@ -57,6 +57,8 @@ type SoloWhistGame interface {
 	GetContract() domain.SoloWhistBid
 	// GetBids 各プレイヤーの入札を取得する
 	GetBids() [domain.SoloWhistPlayerCnt]domain.SoloWhistBid
+	// GetBidDone 各プレイヤーが入札済みかを取得する (未入札とパスの区別用)
+	GetBidDone() [domain.SoloWhistPlayerCnt]bool
 	// GetTrumpSuit 切り札スートを取得する (0=なし)
 	GetTrumpSuit() int
 	// GetPlayerScores プレイヤー別累積点を取得する

--- a/internal/domain/interfaces/solowhist_mock.go
+++ b/internal/domain/interfaces/solowhist_mock.go
@@ -152,6 +152,12 @@ func (_m *MockSoloWhistGame) GetBids() [domain.SoloWhistPlayerCnt]domain.SoloWhi
 	return ret.Get(0).([domain.SoloWhistPlayerCnt]domain.SoloWhistBid)
 }
 
+// GetBidDone モック
+func (_m *MockSoloWhistGame) GetBidDone() [domain.SoloWhistPlayerCnt]bool {
+	ret := _m.Called()
+	return ret.Get(0).([domain.SoloWhistPlayerCnt]bool)
+}
+
 // GetTrumpSuit モック
 func (_m *MockSoloWhistGame) GetTrumpSuit() int {
 	ret := _m.Called()

--- a/internal/i18n/locales/en/solowhist.json
+++ b/internal/i18n/locales/en/solowhist.json
@@ -37,5 +37,6 @@
   "trickEnd": "Trick complete",
   "roundEnd": "Round complete",
   "result.humanWin": "Game over! You win!",
-  "result.cpuWin": "Game over! Player {{player}} wins!"
+  "result.cpuWin": "Game over! Player {{player}} wins!",
+  "bidHistory": "Bids: {{bids}}"
 }

--- a/internal/i18n/locales/ja/solowhist.json
+++ b/internal/i18n/locales/ja/solowhist.json
@@ -37,5 +37,6 @@
   "trickEnd": "トリック終了",
   "roundEnd": "ラウンド終了",
   "result.humanWin": "ゲーム終了！ あなたの勝ち！",
-  "result.cpuWin": "ゲーム終了！ プレイヤー{{player}}の勝ち！"
+  "result.cpuWin": "ゲーム終了！ プレイヤー{{player}}の勝ち！",
+  "bidHistory": "ビッド状況: {{bids}}"
 }


### PR DESCRIPTION
## Summary
Solo Whist's CUI bid phase showed only the current high contract, not who bid what (or passed), leaving later bidders in the dark. This adds a bid-status line listing each player's declared bid, with players who have not yet bid shown as `-`.

Distinguishing "not yet bid" from "passed" (both map to bid 0) required exposing the domain's per-player `bidDone` flag via a new `GetBidDone()` accessor. The existing high-contract line is unchanged.

## Changes
- `SoloWhist.go`: `GetBidDone()` accessor
- `interfaces/solowhist.go` + `solowhist_mock.go`: expose it
- `SoloWhistCuiPresenter.go`: `solowhist.bidHistory` line in the bid phase
- `solowhist.json` (ja/en): new `bidHistory` key
- Test: bid phase lists all players; an un-bid player renders `-`

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3434