### PR TITLE
feat(carioca): expand per-slot contract requirements and meld syntax in the CUI

### DIFF
--- a/internal/adapter/presenter/CariocaCuiPresenter.go
+++ b/internal/adapter/presenter/CariocaCuiPresenter.go
@@ -70,8 +70,24 @@ func (p *CariocaCuiPresenter) Output(g interfaces.CariocaGame, lastErr error) st
 			"total", strconv.Itoa(domain.CariocaTotalRounds),
 			"stock", strconv.Itoa(g.GetDrawPileCount())) + "\n")
 
+		contract := g.GetCurrentContract()
 		b.WriteString(i18n.Tf("carioca.contractLine",
-			"contract", cariocaContractDescription(g.GetCurrentContract())) + "\n")
+			"contract", cariocaContractDescription(contract)) + "\n")
+		// Expand each slot's detailed requirement (a set is same-rank, a run is a
+		// same-suit sequence) with its index, plus the meld slot-index syntax, so
+		// the human knows exactly what each slot needs and how to target it.
+		for i, slot := range contract.Slots {
+			detail := i18n.Tf("carioca.slotDetailRun", "n", strconv.Itoa(slot.Size))
+			if slot.Kind == domain.ContractSlotSet {
+				detail = i18n.Tf("carioca.slotDetailSet", "n", strconv.Itoa(slot.Size))
+			}
+			b.WriteString(i18n.Tf("carioca.slotLine",
+				"idx", strconv.Itoa(i),
+				"detail", detail) + "\n")
+		}
+		if len(contract.Slots) > 0 {
+			b.WriteString(i18n.T("carioca.meldSyntaxHint") + "\n")
+		}
 
 		if top := g.GetDiscardTop(); top != nil {
 			b.WriteString(i18n.Tf("carioca.discardLine", "card", cuiCardStr(top)) + "\n")

--- a/internal/adapter/presenter/CariocaCuiPresenter_test.go
+++ b/internal/adapter/presenter/CariocaCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupCariocaCuiMock(phase domain.CariocaPhase, gameEnd bool) (*interfaces.MockCariocaGame, []*domain.CariocaPlayer) {
@@ -53,6 +55,9 @@ func TestCariocaCuiPresenter_Output(t *testing.T) {
 		assert.NotEmpty(t, out)
 		assert.Contains(t, out, "カリオカ")
 		assert.Contains(t, out, "ラウンド")
+		// Each contract slot is expanded with its index and the meld syntax hint.
+		assert.Contains(t, out, strings.Split(i18n.T("carioca.slotLine"), "{{")[0])
+		assert.Contains(t, out, i18n.T("carioca.meldSyntaxHint"))
 	})
 
 	t.Run("play phase", func(t *testing.T) {

--- a/internal/i18n/locales/en/carioca.json
+++ b/internal/i18n/locales/en/carioca.json
@@ -31,5 +31,9 @@
   "promptPlayHelpLayoff": "lo <pIdx> <mIdx> <cIdx>: add a card to an existing meld",
   "promptPlayHelpDiscard": "d <idx>: discard a card",
   "promptRoundEnd": "Round complete",
-  "promptRoundEndHelp": "nr / nextround: advance to next round"
+  "promptRoundEndHelp": "nr / nextround: advance to next round",
+  "slotDetailSet": "{{n}} of the same rank",
+  "slotDetailRun": "{{n}} consecutive of the same suit",
+  "slotLine": "  Slot [{{idx}}]: {{detail}}",
+  "meldSyntaxHint": "  meld <slot> <card indices> (e.g. meld 0 1 2 3)"
 }

--- a/internal/i18n/locales/ja/carioca.json
+++ b/internal/i18n/locales/ja/carioca.json
@@ -31,5 +31,9 @@
   "promptPlayHelpLayoff": "lo <pIdx> <mIdx> <cIdx>・・・既存メルドにカード追加",
   "promptPlayHelpDiscard": "d <idx>・・・カードを捨てる",
   "promptRoundEnd": "ラウンド終了",
-  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ"
+  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
+  "slotDetailSet": "同ランク{{n}}枚",
+  "slotDetailRun": "同スート{{n}}枚の連番",
+  "slotLine": "  スロット[{{idx}}]: {{detail}}",
+  "meldSyntaxHint": "  meld <スロット番号> <カード番号...>（例: meld 0 1 2 3）"
 }


### PR DESCRIPTION
## Summary
Carioca's CUI summarized the round contract ("Set 3 + Run 4") but not each slot's detailed requirement or how to target a slot with the `meld` command — the web UI visualizes slot progress. This expands each contract slot with its index and requirement (a set is same-rank, a run is a same-suit sequence) and adds a `meld` slot-index syntax example.

Uses the existing `GetCurrentContract().Slots` — no domain change.

## Changes
- `CariocaCuiPresenter.go`: per-slot detail lines + meld syntax hint under the contract line
- `carioca.json` (ja/en): new `slotDetailSet` / `slotDetailRun` / `slotLine` / `meldSyntaxHint` keys
- Test: draw phase shows the slot lines and the meld syntax hint

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3494