### PR TITLE
feat(omaha): show the 8-or-Better low qualifier rule in Hi-Lo games

### DIFF
--- a/internal/adapter/presenter/OmahaCuiPresenter.go
+++ b/internal/adapter/presenter/OmahaCuiPresenter.go
@@ -44,6 +44,12 @@ func (p *OmahaCuiPresenter) Output(o interfaces.OmahaGame, lastErr error) string
 		b.WriteString(i18n.Tf("omaha.mandatoryRuleLine",
 			"hole", strconv.Itoa(o.GetHoleCardCount())) + "\n")
 
+		// In Hi-Lo the split's low qualifier (eight-or-better) is easy to miss from
+		// the title alone, so spell it out during play — not just in the result.
+		if o.GetIsHiLo() {
+			b.WriteString(i18n.T("omaha.hiLoRuleLine") + "\n")
+		}
+
 		cfg := o.GetConfig()
 		if cfg.TournamentMode {
 			b.WriteString(i18n.Tf("omaha.tournamentLine",

--- a/internal/adapter/presenter/OmahaCuiPresenter_test.go
+++ b/internal/adapter/presenter/OmahaCuiPresenter_test.go
@@ -25,6 +25,15 @@ func makeOmahaForPresenter() (*domain.Omaha, []*domain.OmahaPlayer) {
 	return h, players
 }
 
+func makeOmahaHiLoForPresenter() *domain.Omaha {
+	tc := domain.NewTrumpCards(0)
+	players := []*domain.OmahaPlayer{
+		domain.NewOmahaPlayer(true, domain.HoldemStyleTAG),
+		domain.NewOmahaPlayer(false, domain.HoldemStyleLAP),
+	}
+	return domain.NewOmahaHiLo(tc, players, domain.DefaultOmahaConfig())
+}
+
 func TestOmahaCuiPresenter_Output(t *testing.T) {
 	origNoColor := color.NoColor()
 	color.SetNoColor(true)
@@ -47,6 +56,15 @@ func TestOmahaCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "♥11")
 		// The must-use-2 rule line is always shown; standard Omaha deals 4 holes.
 		assert.Contains(t, result, "手札4枚のうちちょうど2枚")
+		// Hi-only game → no low-qualifier rule line.
+		assert.NotContains(t, result, i18n.T("omaha.hiLoRuleLine"))
+	})
+
+	t.Run("hi-lo game shows the eight-or-better low rule", func(t *testing.T) {
+		h := makeOmahaHiLoForPresenter()
+		h.SetPhase(domain.OmahaPhasePreFlop)
+		result := p.Output(h, nil)
+		assert.Contains(t, result, i18n.T("omaha.hiLoRuleLine"))
 	})
 
 	t.Run("community cards displayed", func(t *testing.T) {

--- a/internal/i18n/locales/en/omaha.json
+++ b/internal/i18n/locales/en/omaha.json
@@ -43,5 +43,6 @@
   "muckPrompt": "Muck? (m=muck / sh=show)",
   "rebuyPrompt": "Rebuy? ({{chips}} chips, used {{used}}/{{max}}) (rb=rebuy / sr=skip)",
   "addonPrompt": "Add-on? ({{chips}} chips) (ad=addon / sa=skip)",
-  "gameEnd": "Game over"
+  "gameEnd": "Game over",
+  "hiLoRuleLine": "Low: five distinct cards 8-or-lower (8 or Better); if none qualifies, Hi takes the whole pot"
 }

--- a/internal/i18n/locales/ja/omaha.json
+++ b/internal/i18n/locales/ja/omaha.json
@@ -43,5 +43,6 @@
   "muckPrompt": "マックしますか? (m=マック / sh=ショー)",
   "rebuyPrompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済) (rb=リバイ / sr=スキップ)",
   "addonPrompt": "アドオンしますか? ({{chips}}チップ) (ad=アドオン / sa=スキップ)",
-  "gameEnd": "ゲーム終了"
+  "gameEnd": "ゲーム終了",
+  "hiLoRuleLine": "※ロー: 8以下5枚(8 or Better)。不成立時はHiが総取り"
 }


### PR DESCRIPTION
## Summary
Omaha's CUI showed the low hand only in the result for Hi-Lo games — during play the title alone didn't explain the eight-or-better low qualifier. This adds a rule line (below the must-use-2 line) when the game is Hi-Lo: five cards eight-or-lower qualify for the low; if none qualifies, Hi takes the whole pot. Hi-only games (Omaha, Big O) are unaffected.

Uses the existing `GetIsHiLo()` accessor — no domain change. The shared `OmahaCuiPresenter` serves all Omaha variants.

## Changes
- `OmahaCuiPresenter.go`: `omaha.hiLoRuleLine` shown when `GetIsHiLo()`
- `omaha.json` (ja/en): new `hiLoRuleLine` key
- Test: Hi-Lo game shows the rule; Hi-only game does not

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3012