### PR TITLE
feat(machiavelli): show layoff command format and table-meld availability

### DIFF
--- a/internal/adapter/presenter/MachiavelliCuiPresenter.go
+++ b/internal/adapter/presenter/MachiavelliCuiPresenter.go
@@ -83,7 +83,14 @@ func (p *MachiavelliCuiPresenter) Output(g interfaces.MachiavelliGame, lastErr e
 				"name", cuiPlayerName(g.GetPlayer(currentIdx), currentIdx)) + "\n")
 			b.WriteString(i18n.T("machiavelli.promptDrawHelp") + "\n")
 			b.WriteString(i18n.T("machiavelli.promptNewMeldHelp") + "\n")
-			b.WriteString(i18n.T("machiavelli.promptLayoffHelp") + "\n")
+			// Spell out the layoff argument format and how many table melds it can
+			// target; when the table is empty, layoff is impossible.
+			if meldCount := len(g.GetTable()); meldCount > 0 {
+				b.WriteString(i18n.Tf("machiavelli.promptLayoffHelp",
+					"count", strconv.Itoa(meldCount)) + "\n")
+			} else {
+				b.WriteString(i18n.T("machiavelli.promptLayoffNone") + "\n")
+			}
 		case domain.MachiavelliPhaseRoundEnd:
 			b.WriteString(i18n.T("machiavelli.promptRoundEnd") + "\n")
 			b.WriteString(i18n.T("machiavelli.promptRoundEndHelp") + "\n")

--- a/internal/adapter/presenter/MachiavelliCuiPresenter_test.go
+++ b/internal/adapter/presenter/MachiavelliCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupMachiavelliCuiMock(phase domain.MachiavelliPhase, gameEnd bool, table [][]*domain.Card) (*interfaces.MockMachiavelliGame, []*domain.MachiavelliPlayer) {
@@ -54,12 +56,17 @@ func TestMachiavelliCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, out, "マキャヴェッリ")
 		assert.Contains(t, out, "ラウンド")
 		assert.Contains(t, out, "場のメルド")
+		// With melds on the table, the layoff-help format line is shown.
+		assert.Contains(t, out, strings.Split(i18n.T("machiavelli.promptLayoffHelp"), "{{")[0])
+		assert.NotContains(t, out, i18n.T("machiavelli.promptLayoffNone"))
 	})
 
 	t.Run("turn phase empty table", func(t *testing.T) {
 		m, _ := setupMachiavelliCuiMock(domain.MachiavelliPhaseTurn, false, nil)
 		out := p.Output(m, nil)
 		assert.NotEmpty(t, out)
+		// With no melds, layoff is announced as unavailable.
+		assert.Contains(t, out, i18n.T("machiavelli.promptLayoffNone"))
 	})
 
 	t.Run("round end", func(t *testing.T) {

--- a/internal/i18n/locales/en/machiavelli.json
+++ b/internal/i18n/locales/en/machiavelli.json
@@ -16,9 +16,10 @@
   "promptTurn": "{{name}} to act",
   "promptDrawHelp": "dr: draw one card from stock (ends turn)",
   "promptNewMeldHelp": "nm <i j k...>: form a new meld from your hand",
-  "promptLayoffHelp": "lo <meldIdx handIdx>: add a hand card to an existing meld",
+  "promptLayoffHelp": "layoff <meld idx> <hand idx> ... add a card to a table meld ({{count}} available; e.g. layoff 0 2)",
   "promptRoundEnd": "Round complete",
   "promptRoundEndHelp": "nr / nextround: advance to next round",
   "turnPhase": "Your turn. Draw or play.",
-  "roundEnd": "Round complete. Advance to the next round."
+  "roundEnd": "Round complete. Advance to the next round.",
+  "promptLayoffNone": "Layoff unavailable: no melds on the table"
 }

--- a/internal/i18n/locales/ja/machiavelli.json
+++ b/internal/i18n/locales/ja/machiavelli.json
@@ -16,9 +16,10 @@
   "promptTurn": "手番: {{name}}",
   "promptDrawHelp": "dr・・・山札から1枚引く (ターン終了)",
   "promptNewMeldHelp": "nm <i j k...>・・・手札から新しいメルドを作る",
-  "promptLayoffHelp": "lo <meldIdx handIdx>・・・既存メルドに手札を足す",
+  "promptLayoffHelp": "layoff <メルドidx> <手札idx>・・・場のメルド({{count}}件)に手札を付ける（例: layoff 0 2）",
   "promptRoundEnd": "ラウンド終了",
   "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
   "turnPhase": "あなたの手番です。引くかプレイしてください。",
-  "roundEnd": "ラウンド終了。次のラウンドへ進んでください。"
+  "roundEnd": "ラウンド終了。次のラウンドへ進んでください。",
+  "promptLayoffNone": "レイオフ不可: 場にメルドがありません"
 }


### PR DESCRIPTION
## Summary
Machiavelli's CUI listed three turn-phase help lines (newMeld/draw/layoff) but the layoff line didn't spell out its argument format — layoff is the central table operation. This makes the layoff help concrete: `layoff <meld idx> <hand idx>` with the count of table melds it can target, and when the table is empty it announces that layoff is unavailable.

Uses the existing `GetTable()` (its length is the meld count) — no domain change.

## Changes
- `MachiavelliCuiPresenter.go`: dynamic layoff help (format + meld count) or an "unavailable" line when the table is empty
- `machiavelli.json` (ja/en): updated `promptLayoffHelp` (adds `{{count}}`) + new `promptLayoffNone`
- Test: table with melds shows the format line; empty table shows the unavailable line

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3503