### PR TITLE
feat(penguin): render base rank as A/J/Q/K instead of a raw number

### DIFF
--- a/internal/adapter/presenter/PenguinCuiPresenter.go
+++ b/internal/adapter/presenter/PenguinCuiPresenter.go
@@ -50,8 +50,9 @@ func (p *PenguinCuiPresenter) Output(pg interfaces.PenguinGame, lastErr error) s
 		}
 		b.WriteString("\n")
 
-		// Base rank
-		b.WriteString(i18n.Tf("penguin.baseRankLabel", "rank", strconv.Itoa(pg.GetBaseRank())))
+		// Base rank — render 1/11/12/13 as A/J/Q/K (matching the web baseRankLabel
+		// and cuiCardStr) rather than a raw number.
+		b.WriteString(i18n.Tf("penguin.baseRankLabel", "rank", cuiRankLabel(pg.GetBaseRank())))
 		b.WriteString("\n")
 
 		b.WriteString("----------\n")

--- a/internal/adapter/presenter/PenguinCuiPresenter_test.go
+++ b/internal/adapter/presenter/PenguinCuiPresenter_test.go
@@ -24,6 +24,20 @@ func TestPenguinCuiPresenterOutputPlaying(t *testing.T) {
 	assert.Contains(t, result, "手数:")
 }
 
+func TestPenguinCuiPresenterOutputBaseRankLabels(t *testing.T) {
+	p := new(PenguinCuiPresenter)
+	// Face-rank base values render as A/J/Q/K, matching the web baseRankLabel.
+	cases := map[int]string{1: "A", 11: "J", 12: "Q", 13: "K", 7: "7"}
+	for rank, label := range cases {
+		g := domain.NewPenguin(domain.NewTrumpCards(0))
+		g.Reset()
+		g.SetPhase(domain.PenguinPhasePlaying)
+		g.SetBaseRank(rank)
+		result := p.Output(g, nil)
+		assert.Contains(t, result, "BaseRank: "+label)
+	}
+}
+
 func TestPenguinCuiPresenterOutputGameClear(t *testing.T) {
 	p := new(PenguinCuiPresenter)
 	g := domain.NewPenguin(domain.NewTrumpCards(0))


### PR DESCRIPTION
## Summary
Penguin's base rank changes each deal and the CUI printed it as a raw number, so `BaseRank: 13` instead of `BaseRank: K` — mismatching the web `baseRankLabel()` (1→A, 11→J, 12→Q, 13→K). This applies the shared `cuiRankLabel` before rendering; 2–10 stay numeric.

No domain or i18n change (the template just interpolates the value).

## Changes
- `PenguinCuiPresenter.go`: format base rank via `cuiRankLabel`
- Test: boundary values 1/11/12/13 render A/J/Q/K; 7 stays `7`

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues

Closes #3328