### PR TITLE
feat(fortyandeight): label each foundation pile with its index in the CUI

### DIFF
--- a/internal/adapter/presenter/FortyAndEightCuiPresenter.go
+++ b/internal/adapter/presenter/FortyAndEightCuiPresenter.go
@@ -35,6 +35,9 @@ func (p *FortyAndEightCuiPresenter) Output(ft interfaces.FortyAndEightGame, last
 			if i != 0 {
 				b.WriteString(" | ")
 			}
+			// Label each pile with its move-command index (matching the tableau's
+			// column labels) so the eight piles are individually identifiable.
+			b.WriteString(i18n.Tf("fortyandeight.foundationLabel", "idx", strconv.Itoa(i)))
 			pile := foundation[i]
 			if len(pile) == 0 {
 				b.WriteString(i18n.T("cuiEmptyCol"))

--- a/internal/adapter/presenter/FortyAndEightCuiPresenter_test.go
+++ b/internal/adapter/presenter/FortyAndEightCuiPresenter_test.go
@@ -55,6 +55,9 @@ func TestFortyAndEightCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "列0:")
 		assert.Contains(t, result, "手数: 0")
 		assert.Contains(t, result, "操作: m で移動")
+		// Each foundation pile carries its move-command index label.
+		assert.Contains(t, result, "[f0]")
+		assert.Contains(t, result, "[f7]")
 	})
 
 	t.Run("with waste card", func(t *testing.T) {

--- a/internal/i18n/locales/en/fortyandeight.json
+++ b/internal/i18n/locales/en/fortyandeight.json
@@ -21,5 +21,6 @@
   "hintFromWaste": "waste",
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
-  "hintLine": "Hint: {{from}} → {{to}}"
+  "hintLine": "Hint: {{from}} → {{to}}",
+  "foundationLabel": "[f{{idx}}]"
 }

--- a/internal/i18n/locales/ja/fortyandeight.json
+++ b/internal/i18n/locales/ja/fortyandeight.json
@@ -21,5 +21,6 @@
   "hintFromWaste": "ウェイスト",
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "hintLine": "ヒント: {{from}} → {{to}}",
+  "foundationLabel": "[f{{idx}}]"
 }


### PR DESCRIPTION
## Summary
Forty and Eight's CUI listed the eight foundation piles' top cards separated by ` | ` with no labels, so a player couldn't tell which pile was which — unlike the tableau, which labels each column. This prefixes each pile with its move-command index (`[f0]`–`[f7]`), consistent with the tableau column labels.

No domain change.

## Changes
- `FortyAndEightCuiPresenter.go`: `fortyandeight.foundationLabel` prefix per pile
- `fortyandeight.json` (ja/en): new `foundationLabel` key
- Test: foundation row includes `[f0]`…`[f7]`

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3287