### PR TITLE
feat(eightoff): show the max cards movable at once in the CUI

### DIFF
--- a/internal/adapter/presenter/EightOffCuiPresenter.go
+++ b/internal/adapter/presenter/EightOffCuiPresenter.go
@@ -76,6 +76,25 @@ func (p *EightOffCuiPresenter) Output(e interfaces.EightOffGame, lastErr error) 
 			if e.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
 			}
+			// Show how many cards can be moved as one stack — (1 + empty free
+			// cells) * 2^(empty columns), the same formula the web UI uses — so the
+			// human isn't surprised by a rejected multi-card move.
+			emptyCells := 0
+			for i := 0; i < domain.EightOffCellCnt; i++ {
+				if freeCells[i] == nil {
+					emptyCells++
+				}
+			}
+			emptyCols := 0
+			for col := 0; col < domain.EightOffTableauCnt; col++ {
+				if len(tableau[col]) == 0 {
+					emptyCols++
+				}
+			}
+			b.WriteString(i18n.Tf("eightoff.supermoveLine",
+				"limit", strconv.Itoa((1+emptyCells)<<emptyCols),
+				"cells", strconv.Itoa(emptyCells),
+				"cols", strconv.Itoa(emptyCols)) + "\n")
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(e.GetMoveCount())) + "\n")
 		case domain.EightOffPhaseGameClear:

--- a/internal/adapter/presenter/EightOffCuiPresenter_test.go
+++ b/internal/adapter/presenter/EightOffCuiPresenter_test.go
@@ -25,6 +25,29 @@ func TestEightOffCuiPresenterOutputPlaying(t *testing.T) {
 	assert.Contains(t, result, "手数:")
 }
 
+func TestEightOffCuiPresenterSupermoveLine(t *testing.T) {
+	p := new(EightOffCuiPresenter)
+	e := domain.NewEightOff(domain.NewTrumpCards(0))
+	e.Reset()
+	e.SetPhase(domain.EightOffPhasePlaying)
+
+	// 6 free cells filled (2 empty) and 7 columns occupied (1 empty) →
+	// (1 + 2) * 2^1 = 6 cards movable at once.
+	var cells [domain.EightOffCellCnt]*domain.Card
+	for i := 0; i < 6; i++ {
+		cells[i] = domain.NewCard(domain.CardDesignSpade, i+1, false)
+	}
+	e.SetFreeCells(cells)
+	var tableau [domain.EightOffTableauCnt][]*domain.Card
+	for col := 0; col < 7; col++ {
+		tableau[col] = []*domain.Card{domain.NewCard(domain.CardDesignHeart, col+1, false)}
+	}
+	e.SetTableau(tableau)
+
+	result := p.Output(e, nil)
+	assert.Contains(t, result, "一度に移動可能: 6枚")
+}
+
 func TestEightOffCuiPresenterOutputGameClear(t *testing.T) {
 	p := new(EightOffCuiPresenter)
 	e := domain.NewEightOff(domain.NewTrumpCards(0))

--- a/internal/i18n/locales/en/eightoff.json
+++ b/internal/i18n/locales/en/eightoff.json
@@ -19,5 +19,6 @@
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
   "hintToFreeCell": "free cell {{col}}",
-  "hintLine": "Hint: {{from}} → {{to}}"
+  "hintLine": "Hint: {{from}} → {{to}}",
+  "supermoveLine": "Max cards per move: {{limit}} (free cells {{cells}}, empty columns {{cols}})"
 }

--- a/internal/i18n/locales/ja/eightoff.json
+++ b/internal/i18n/locales/ja/eightoff.json
@@ -19,5 +19,6 @@
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
   "hintToFreeCell": "フリーセル{{col}}",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "hintLine": "ヒント: {{from}} → {{to}}",
+  "supermoveLine": "一度に移動可能: {{limit}}枚（空きセル{{cells}}・空き列{{cols}}）"
 }


### PR DESCRIPTION
## Summary
Eight Off's CUI didn't show how many cards can be moved as one stack, so a player only learned the limit when the engine rejected a multi-card move. This adds a line computing the supermove cap with the same formula as the web UI — `(1 + empty free cells) × 2^(empty columns)` — plus the empty-cell and empty-column counts.

Computed in the presenter from the existing free-cell/tableau state — no domain change.

## Changes
- `EightOffCuiPresenter.go`: `eightoff.supermoveLine` in the PLAYING phase, before the move count
- `eightoff.json` (ja/en): new `supermoveLine` key
- Test: 2 empty cells + 1 empty column → limit 6

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3324