### PR TITLE
feat(seahaventowers): show the max cards movable at once in the CUI

### DIFF
--- a/internal/adapter/presenter/SeahavenTowersCuiPresenter.go
+++ b/internal/adapter/presenter/SeahavenTowersCuiPresenter.go
@@ -76,6 +76,17 @@ func (p *SeahavenTowersCuiPresenter) Output(s interfaces.SeahavenTowersGame, las
 			if s.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
 			}
+			// Show the one-move stack limit (1 + empty reserved cells, the web
+			// formula) so the human isn't surprised by a rejected multi-card move.
+			emptyReserved := 0
+			for i := 0; i < domain.SeahavenTowersCellCnt; i++ {
+				if cells[i] == nil {
+					emptyReserved++
+				}
+			}
+			b.WriteString(i18n.Tf("seahaventowers.supermoveLine",
+				"limit", strconv.Itoa(1+emptyReserved),
+				"reserved", strconv.Itoa(emptyReserved)) + "\n")
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(s.GetMoveCount())) + "\n")
 		case domain.SeahavenTowersPhaseGameClear:

--- a/internal/adapter/presenter/SeahavenTowersCuiPresenter_test.go
+++ b/internal/adapter/presenter/SeahavenTowersCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,6 +24,23 @@ func TestSeahavenTowersCuiPresenterOutputPlaying(t *testing.T) {
 	assert.Contains(t, result, "Reserved:")
 	assert.Contains(t, result, "Foundation:")
 	assert.Contains(t, result, "手数:")
+}
+
+func TestSeahavenTowersCuiPresenterSupermoveLine(t *testing.T) {
+	p := new(SeahavenTowersCuiPresenter)
+	// empty reserved cells → one-move limit (1 + empties).
+	for empties, limit := range map[int]int{0: 1, 1: 2, 2: 3} {
+		s := domain.NewSeahavenTowers(domain.NewTrumpCards(0))
+		s.Reset()
+		s.SetPhase(domain.SeahavenTowersPhasePlaying)
+		var cells [domain.SeahavenTowersCellCnt]*domain.Card
+		for i := 0; i < domain.SeahavenTowersCellCnt-empties; i++ {
+			cells[i] = domain.NewCard(domain.CardDesignSpade, i+1, false)
+		}
+		s.SetFreeCells(cells)
+		result := p.Output(s, nil)
+		assert.Contains(t, result, "一括移動可能: 最大"+strconv.Itoa(limit)+"枚")
+	}
 }
 
 func TestSeahavenTowersCuiPresenterOutputGameClear(t *testing.T) {

--- a/internal/i18n/locales/en/seahaventowers.json
+++ b/internal/i18n/locales/en/seahaventowers.json
@@ -25,5 +25,6 @@
   "promptToZoneFromCell": "Enter destination (t = tableau, f = foundation):",
   "invalidFromZone": "invalid source zone: {{val}}",
   "invalidToZone": "invalid destination zone: {{val}}",
-  "moveUsage": "usage: m t <col> [<idx>] t|f|c <toCol|cell>"
+  "moveUsage": "usage: m t <col> [<idx>] t|f|c <toCol|cell>",
+  "supermoveLine": "Max cards per move: {{limit}} (empty reserved cells {{reserved}})"
 }

--- a/internal/i18n/locales/ja/seahaventowers.json
+++ b/internal/i18n/locales/ja/seahaventowers.json
@@ -25,5 +25,6 @@
   "promptToZoneFromCell": "移動先を指定してください (t = タブロー、f = 組札):",
   "invalidFromZone": "無効な移動元です: {{val}}",
   "invalidToZone": "無効な移動先です: {{val}}",
-  "moveUsage": "使い方: m t <col> [<idx>] t|f|c <toCol|cell>"
+  "moveUsage": "使い方: m t <col> [<idx>] t|f|c <toCol|cell>",
+  "supermoveLine": "一括移動可能: 最大{{limit}}枚（空きリザーブ{{reserved}}）"
 }


### PR DESCRIPTION
## Summary
Seahaven Towers' CUI listed reserved cells, foundation, and tableau but never the one-move stack limit, so a player only learned it by triggering a rejected multi-card move. This adds a line computing the limit with the same formula as the web UI — `1 + empty reserved cells` — with the empty-reserved count.

Computed in the presenter from the existing reserved-cell state — no domain change.

## Changes
- `SeahavenTowersCuiPresenter.go`: `seahaventowers.supermoveLine` in the PLAYING phase, before the move count
- `seahaventowers.json` (ja/en): new `supermoveLine` key
- Test: 0/1/2 empty reserved cells → limits 1/2/3

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3039