### PR TITLE
feat(flowergarden): wrap the 16 reserve cards across rows in the CUI

### DIFF
--- a/internal/adapter/presenter/FlowerGardenCuiPresenter.go
+++ b/internal/adapter/presenter/FlowerGardenCuiPresenter.go
@@ -44,11 +44,18 @@ func (p *FlowerGardenCuiPresenter) Output(bc interfaces.FlowerGardenGame, lastEr
 		}
 		b.WriteString("\n")
 
-		// Reserve (the bouquet)
+		// Reserve (the bouquet). Wrap the 16 cards across rows so the labelled
+		// list doesn't overflow an 80-column terminal (the tableau wraps too).
 		b.WriteString(i18n.T("flowergarden.reserveHeader"))
 		reserve := bc.GetReserve()
+		const reservePerRow = 8
 		for i := range reserve {
-			if i != 0 {
+			switch {
+			case i == 0:
+				// first card follows the header directly
+			case i%reservePerRow == 0:
+				b.WriteString("\n")
+			default:
 				b.WriteString(" ")
 			}
 			fmt.Fprintf(b, "[r%d]", i)

--- a/internal/adapter/presenter/FlowerGardenCuiPresenter_test.go
+++ b/internal/adapter/presenter/FlowerGardenCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -58,6 +59,21 @@ func TestFlowerGardenCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "Foundation")
 		assert.Contains(t, result, "列0:")
 		assert.Contains(t, result, "手数: 0")
+		// The 16 reserve cards wrap across rows: r0 and r8 land on different lines.
+		assert.Contains(t, result, "[r0]")
+		assert.Contains(t, result, "[r15]")
+		var r0Line, r8Line string
+		for _, l := range strings.Split(result, "\n") {
+			if strings.Contains(l, "[r0]") {
+				r0Line = l
+			}
+			if strings.Contains(l, "[r8]") {
+				r8Line = l
+			}
+		}
+		assert.NotEmpty(t, r0Line)
+		assert.NotEmpty(t, r8Line)
+		assert.NotContains(t, r0Line, "[r8]") // wrapped onto a separate row
 	})
 
 	t.Run("with error", func(t *testing.T) {


### PR DESCRIPTION
## Summary
Flower Garden's CUI printed all 16 reserve ("bouquet") cards as labelled entries on a single line, which overflows a standard 80-column terminal and hurts readability — unlike the tableau, which breaks per column. This wraps the reserve into rows of 8 while keeping each card's `r0`–`r15` index label intact.

No domain or i18n change (command parsing is unaffected — labels are unchanged).

## Changes
- `FlowerGardenCuiPresenter.go`: wrap the reserve output every 8 cards
- Test: reserve r0 and r8 land on different lines; r0–r15 labels remain present

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues

Closes #3285