### PR TITLE
feat(gaps): mark locked cards kept on redeal in the CUI grid

### DIFF
--- a/internal/adapter/presenter/GapsCuiPresenter.go
+++ b/internal/adapter/presenter/GapsCuiPresenter.go
@@ -19,6 +19,7 @@ type GapsCuiPresenter struct{}
 func (pr *GapsCuiPresenter) Output(g interfaces.GapsGame, lastErr error) string {
 	return buildCuiOutput(i18n.T("gaps.helpTitle"), func(b *strings.Builder) {
 		grid := g.GetGrid()
+		locks := g.GetLockedPrefixLengths()
 		for r := 0; r < domain.GapsRowCnt; r++ {
 			for c := 0; c < domain.GapsColCnt; c++ {
 				if c > 0 {
@@ -32,6 +33,10 @@ func (pr *GapsCuiPresenter) Output(g interfaces.GapsGame, lastErr error) string 
 						"row", strconv.Itoa(r),
 						"col", strconv.Itoa(c),
 						"card", cuiCardStr(cell)))
+					// Mark cards in the row's locked prefix — those kept on a redeal.
+					if c < locks[r] {
+						b.WriteString(i18n.T("gaps.lockedMark"))
+					}
 				}
 			}
 			b.WriteString("\n")
@@ -41,6 +46,7 @@ func (pr *GapsCuiPresenter) Output(g interfaces.GapsGame, lastErr error) string 
 			"used", strconv.Itoa(g.GetRedealsUsed()),
 			"remaining", strconv.Itoa(g.GetRedealsRemaining())))
 		b.WriteString("\n")
+		b.WriteString(i18n.T("gaps.lockedLegend") + "\n")
 		b.WriteString("----------\n")
 		cuiErrorBlock(b, lastErr)
 		switch g.GetPhase() {

--- a/internal/adapter/presenter/GapsCuiPresenter_test.go
+++ b/internal/adapter/presenter/GapsCuiPresenter_test.go
@@ -4,12 +4,14 @@ package presenter
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupGapsCuiMock() *interfaces.MockGapsGame {
@@ -30,6 +32,7 @@ func setupGapsCuiMock() *interfaces.MockGapsGame {
 		}
 	}
 	g.On("GetGrid").Return(grid).Maybe()
+	g.On("GetLockedPrefixLengths").Return([domain.GapsRowCnt]int{3, 0, 0, 0}).Maybe()
 	g.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 	return g
 }
@@ -41,6 +44,9 @@ func TestGapsCuiPresenter_Output_Playing(t *testing.T) {
 	assert.Contains(t, out, "Gaps")
 	assert.Contains(t, out, "再配り 0/3")
 	assert.Contains(t, out, "[ . ]")
+	// Locked legend plus 3 markers on row 0 (one per locked card) → 4 asterisks.
+	assert.Contains(t, out, i18n.T("gaps.lockedLegend"))
+	assert.Equal(t, 4, strings.Count(out, "*"))
 }
 
 func TestGapsCuiPresenter_Output_GameClear(t *testing.T) {
@@ -55,6 +61,7 @@ func TestGapsCuiPresenter_Output_GameClear(t *testing.T) {
 	g.On("UndoToEscape").Return(0).Maybe()
 	var grid [domain.GapsRowCnt][domain.GapsColCnt]domain.GapsCell
 	g.On("GetGrid").Return(grid).Maybe()
+	g.On("GetLockedPrefixLengths").Return([domain.GapsRowCnt]int{}).Maybe()
 	g.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 
 	p := &GapsCuiPresenter{}
@@ -74,6 +81,7 @@ func TestGapsCuiPresenter_Output_GameOver(t *testing.T) {
 	g.On("UndoToEscape").Return(-1).Maybe()
 	var grid [domain.GapsRowCnt][domain.GapsColCnt]domain.GapsCell
 	g.On("GetGrid").Return(grid).Maybe()
+	g.On("GetLockedPrefixLengths").Return([domain.GapsRowCnt]int{}).Maybe()
 	g.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 	p := &GapsCuiPresenter{}
 	out := p.Output(g, nil)

--- a/internal/domain/Gaps.go
+++ b/internal/domain/Gaps.go
@@ -443,6 +443,10 @@ func (g *Gaps) GetMoveCount() int { return g.moveCount }
 // GetGrid は盤面を返す。
 func (g *Gaps) GetGrid() [GapsRowCnt][GapsColCnt]GapsCell { return g.grid }
 
+// GetLockedPrefixLengths は各行のロック済み接頭辞の長さ（再配布で保持される
+// 先頭カード数）を返す。プレゼンターがロック済みカードを可視化するために使う。
+func (g *Gaps) GetLockedPrefixLengths() [GapsRowCnt]int { return g.lockedPrefixLengths() }
+
 // SetGrid は盤面を設定する（テスト用）。
 func (g *Gaps) SetGrid(grid [GapsRowCnt][GapsColCnt]GapsCell) { g.grid = grid }
 

--- a/internal/domain/interfaces/gaps.go
+++ b/internal/domain/interfaces/gaps.go
@@ -33,6 +33,8 @@ type GapsGame interface {
 	GetMoveCount() int
 	// GetGrid は盤面を返す。
 	GetGrid() [domain.GapsRowCnt][domain.GapsColCnt]domain.GapsCell
+	// GetLockedPrefixLengths は各行のロック済み接頭辞の長さ（再配布で保持される先頭カード数）を返す。
+	GetLockedPrefixLengths() [domain.GapsRowCnt]int
 	// GetRedealsUsed は使用済み再配り回数を返す。
 	GetRedealsUsed() int
 	// GetRedealsRemaining は残りの再配り回数を返す。

--- a/internal/domain/interfaces/gaps_mock.go
+++ b/internal/domain/interfaces/gaps_mock.go
@@ -75,6 +75,12 @@ func (_m *MockGapsGame) GetGrid() [domain.GapsRowCnt][domain.GapsColCnt]domain.G
 	return ret.Get(0).([domain.GapsRowCnt][domain.GapsColCnt]domain.GapsCell)
 }
 
+// GetLockedPrefixLengths モック
+func (_m *MockGapsGame) GetLockedPrefixLengths() [domain.GapsRowCnt]int {
+	ret := _m.Called()
+	return ret.Get(0).([domain.GapsRowCnt]int)
+}
+
 func (_m *MockGapsGame) GetRedealsUsed() int {
 	ret := _m.Called()
 	return ret.Int(0)

--- a/internal/i18n/locales/en/gaps.json
+++ b/internal/i18n/locales/en/gaps.json
@@ -13,5 +13,7 @@
   "gameClear": "Game Clear!",
   "gameOver": "Game Over",
   "hintAvailable": "Hint available",
-  "noHint": "No hint"
+  "noHint": "No hint",
+  "lockedMark": "*",
+  "lockedLegend": "* = kept on redeal"
 }

--- a/internal/i18n/locales/ja/gaps.json
+++ b/internal/i18n/locales/ja/gaps.json
@@ -13,5 +13,7 @@
   "gameClear": "ゲームクリア！",
   "gameOver": "ゲームオーバー",
   "hintAvailable": "ヒントあり",
-  "noHint": "ヒントなし"
+  "noHint": "ヒントなし",
+  "lockedMark": "*",
+  "lockedLegend": "* = 再配布で保持されるカード"
 }


### PR DESCRIPTION
## Summary
Gaps' CUI drew the grid and the redeal count but never showed which cards are locked — those kept on a redeal — so the CLI player lacked the key input for deciding when to redeal (the web UI shows a 🔒 badge and green ring). This marks each row's locked prefix with `*` and adds a legend line.

The locked-prefix computation is the domain's own redeal rule, exposed via a new `GetLockedPrefixLengths()` accessor (it was previously unexported) — so the CUI matches the engine exactly.

## Changes
- `Gaps.go`: `GetLockedPrefixLengths()` accessor (wraps the existing `lockedPrefixLengths`)
- `interfaces/gaps.go` + `gaps_mock.go`: expose it
- `GapsCuiPresenter.go`: `*` marker on locked cards + `gaps.lockedLegend` line
- `gaps.json` (ja/en): new `lockedMark` / `lockedLegend` keys
- Test: a 3-card locked prefix renders 3 markers plus the legend

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3313