### PR TITLE
feat(ultimatetexasholdem): show current bets during play, not only at game end

### DIFF
--- a/internal/adapter/presenter/UltimateTexasHoldemCuiPresenter.go
+++ b/internal/adapter/presenter/UltimateTexasHoldemCuiPresenter.go
@@ -24,6 +24,19 @@ func (up *UltimateTexasHoldemCuiPresenter) Output(g interfaces.UltimateTexasHold
 	fmt.Fprintf(&sb, "%s\n", i18n.Tf("ultimatetexasholdem.chipsLine", "chips", strconv.Itoa(g.GetChips())))
 	fmt.Fprintf(&sb, "%s\n", i18n.Tf("ultimatetexasholdem.phaseLine", "phase", up.phaseStr(g.GetPhase())))
 
+	// During play (not the final result block), surface the current bets so the
+	// player can size the play-bet multiple; omitted before the ante is placed.
+	if !g.GetGameEndFlag() && g.GetAnteBet() > 0 {
+		fmt.Fprintf(&sb, "%s\n", i18n.Tf("ultimatetexasholdem.anteLine", "ante", strconv.Itoa(g.GetAnteBet())))
+		fmt.Fprintf(&sb, "%s\n", i18n.Tf("ultimatetexasholdem.blindLine", "blind", strconv.Itoa(g.GetBlindBet())))
+		if g.GetTripsBet() > 0 {
+			fmt.Fprintf(&sb, "%s\n", i18n.Tf("ultimatetexasholdem.tripsLine", "trips", strconv.Itoa(g.GetTripsBet())))
+		}
+		if play := g.GetPlayBet(); play > 0 {
+			fmt.Fprintf(&sb, "%s\n", i18n.Tf("ultimatetexasholdem.playBetLine", "play", strconv.Itoa(play)))
+		}
+	}
+
 	if community := g.GetCommunity(); len(community) > 0 {
 		sb.WriteString("--- " + color.Bold(i18n.T("ultimatetexasholdem.boardHeader")) + " ---\n")
 		parts := make([]string, len(community))

--- a/internal/adapter/presenter/UltimateTexasHoldemCuiPresenter_test.go
+++ b/internal/adapter/presenter/UltimateTexasHoldemCuiPresenter_test.go
@@ -2,6 +2,7 @@ package presenter
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,6 +46,8 @@ func TestUltimateTexasHoldemCuiPresenter_Output_BetPhase(t *testing.T) {
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "1000")
 	assert.NotEmpty(t, result)
+	// Before the ante is placed (bet phase), no live bet summary is shown.
+	assert.NotContains(t, result, strings.Split(i18n.T("ultimatetexasholdem.anteLine"), "{{")[0])
 }
 
 func TestUltimateTexasHoldemCuiPresenter_Output_PreFlopPhase_DealerHidden(t *testing.T) {
@@ -80,6 +83,30 @@ func TestUltimateTexasHoldemCuiPresenter_Output_PreFlopPhase_DealerHidden(t *tes
 
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "??", "dealer hand should be hidden in pre-flop")
+	// During play the live bet summary is shown (ante placed, game not ended).
+	assert.Contains(t, result, strings.Split(i18n.T("ultimatetexasholdem.anteLine"), "{{")[0])
+}
+
+func TestUltimateTexasHoldemCuiPresenter_Output_RiverPhase_TripsAndPlayBets(t *testing.T) {
+	p := new(UltimateTexasHoldemCuiPresenter)
+	m := new(interfaces.MockUltimateTexasHoldemGame)
+	setupUltimateTexasHoldemCuiMockDefaults(m)
+	m.ExpectedCalls = nil
+	m.On("GetChips").Return(500).Maybe()
+	m.On("GetPhase").Return(domain.UltimateTexasHoldemPhaseRiver).Maybe()
+	m.On("GetPlayerHand").Return(([]*domain.Card)(nil)).Maybe()
+	m.On("GetDealerHand").Return(([]*domain.Card)(nil)).Maybe()
+	m.On("GetCommunity").Return(([]*domain.Card)(nil)).Maybe()
+	m.On("GetGameEndFlag").Return(false).Maybe()
+	m.On("GetAnteBet").Return(100).Maybe()
+	m.On("GetBlindBet").Return(100).Maybe()
+	m.On("GetTripsBet").Return(20).Maybe() // exercises the trips branch
+	m.On("GetPlayBet").Return(100).Maybe() // exercises the play-bet branch
+	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
+
+	result := p.Output(m, nil)
+	assert.Contains(t, result, strings.Split(i18n.T("ultimatetexasholdem.tripsLine"), "{{")[0])
+	assert.Contains(t, result, strings.Split(i18n.T("ultimatetexasholdem.playBetLine"), "{{")[0])
 }
 
 func TestUltimateTexasHoldemCuiPresenter_Output_EndPhase_PlayerWins(t *testing.T) {


### PR DESCRIPTION
## Summary
Ultimate Texas Hold'em's CUI printed the ante/blind/trips/play bets only inside the game-end block, so during PRE_FLOP/FLOP/RIVER decisions the player couldn't see their ante — which directly drives the play-bet multiple. This adds a live bet summary after the phase line whenever the ante is placed and the game hasn't ended.

Reuses the existing `anteLine`/`blindLine`/`tripsLine`/`playBetLine` keys — no i18n or domain change. The game-end detail block is unchanged (mutually exclusive via the `!GameEnd` guard).

## Changes
- `UltimateTexasHoldemCuiPresenter.go`: live bet summary (ante/blind/trips/play) during play
- Test: pre-flop (ante placed) shows the summary; bet phase (no ante) omits it

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues

Closes #3254