### PR TITLE
feat(mississippistud): show accumulated bet and fold-loss during the streets

### DIFF
--- a/internal/adapter/presenter/MississippiStudCuiPresenter.go
+++ b/internal/adapter/presenter/MississippiStudCuiPresenter.go
@@ -58,6 +58,13 @@ func (mp *MississippiStudCuiPresenter) Output(g interfaces.MississippiStudGame, 
 			))
 		}
 
+		// During the streets, show the accumulated bet and what a fold forfeits;
+		// the game-end block prints totalBet separately, so guard against dupes.
+		if !g.GetGameEndFlag() && g.GetTotalBet() > 0 {
+			fmt.Fprintf(b, "%s\n", i18n.Tf("mississippistud.totalBetLine", "bet", strconv.Itoa(g.GetTotalBet())))
+			fmt.Fprintf(b, "%s\n", i18n.Tf("mississippistud.foldLossLine", "loss", strconv.Itoa(g.GetTotalBet())))
+		}
+
 		cuiErrorBlock(b, lastErr)
 
 		if g.GetGameEndFlag() {

--- a/internal/adapter/presenter/MississippiStudCuiPresenter_test.go
+++ b/internal/adapter/presenter/MississippiStudCuiPresenter_test.go
@@ -2,6 +2,7 @@ package presenter
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,6 +40,8 @@ func TestMississippiStudCuiPresenter_Output_AntePhase(t *testing.T) {
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "1000")
 	assert.Contains(t, result, "ANTE")
+	// No bet placed yet → no fold-loss note.
+	assert.NotContains(t, result, strings.Split(i18n.T("mississippistud.foldLossLine"), "{{")[0])
 }
 
 func TestMississippiStudCuiPresenter_Output_Error(t *testing.T) {
@@ -83,6 +86,8 @@ func TestMississippiStudCuiPresenter_Output_ThirdSt(t *testing.T) {
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "3RD")
 	assert.Contains(t, result, "??") // community masked
+	// During the street, the accumulated bet and fold-loss note are shown.
+	assert.Contains(t, result, strings.Split(i18n.T("mississippistud.foldLossLine"), "{{")[0])
 }
 
 func TestMississippiStudCuiPresenter_Output_Win(t *testing.T) {

--- a/internal/i18n/locales/en/mississippistud.json
+++ b/internal/i18n/locales/en/mississippistud.json
@@ -21,5 +21,6 @@
   "phaseUnknown": "UNKNOWN",
   "playerWins": "Player wins!",
   "playerLoses": "Player loses.",
-  "push": "Push."
+  "push": "Push.",
+  "foldLossLine": "Loss on fold: {{loss}}"
 }

--- a/internal/i18n/locales/ja/mississippistud.json
+++ b/internal/i18n/locales/ja/mississippistud.json
@@ -21,5 +21,6 @@
   "phaseUnknown": "UNKNOWN",
   "playerWins": "プレイヤーの勝ち！",
   "playerLoses": "プレイヤーの負け。",
-  "push": "プッシュ。"
+  "push": "プッシュ。",
+  "foldLossLine": "フォールド時の損失: {{loss}}"
 }


### PR DESCRIPTION
## Summary
Mississippi Stud's CUI showed the street multipliers but printed the accumulated total bet only in the game-end block, so during the 3rd–5th streets the player couldn't see how much they'd committed or what a fold would forfeit. This adds a total-bet line plus a "loss on fold" note during play.

Reuses the existing `totalBetLine` key and adds `foldLossLine`. Guarded by `!GameEnd` so it doesn't duplicate the end-of-hand total.

## Changes
- `MississippiStudCuiPresenter.go`: total-bet + fold-loss lines during the streets
- `mississippistud.json` (ja/en): new `foldLossLine` key
- Test: 3rd street (bet placed) shows the fold-loss note; ante phase (no bet) omits it

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3261