### PR TITLE
feat(spider): show difficulty, deals remaining, and empty-column deal warning

### DIFF
--- a/internal/adapter/presenter/SpiderCuiPresenter.go
+++ b/internal/adapter/presenter/SpiderCuiPresenter.go
@@ -37,20 +37,33 @@ func (p *SpiderCuiPresenter) Output(s interfaces.SpiderGame, lastErr error) stri
 			"total", strconv.Itoa(domain.SpiderFoundationCnt),
 			"stock", strconv.Itoa(s.GetStockCount()),
 			"score", strconv.Itoa(s.GetScore())) + "\n")
+		// The difficulty (suit count) and remaining deals (a deal lays one card per
+		// column, so stock/10) match the web header.
+		b.WriteString(i18n.Tf("spider.difficultyLine",
+			"suits", strconv.Itoa(int(s.GetDifficulty())),
+			"deals", strconv.Itoa(s.GetStockCount()/domain.SpiderTableauCnt)) + "\n")
 
 		b.WriteString("----------\n")
 
 		// Tableau
 		tableau := s.GetTableau()
+		emptyColumn := false
 		for col := range domain.SpiderTableauCnt {
 			colCards := tableau[col]
 			b.WriteString(i18n.Tf("spider.columnLabel", "col", strconv.Itoa(col)))
 			if len(colCards) == 0 {
+				emptyColumn = true
 				b.WriteString(" " + i18n.T("cuiEmptyCol"))
 			} else {
 				b.WriteString(spiderColumnStr(colCards))
 			}
 			b.WriteString("\n")
+		}
+
+		// A deal is blocked while any column is empty (and stock remains); warn up
+		// front instead of only surfacing the rejection as an error.
+		if emptyColumn && s.GetStockCount() > 0 {
+			b.WriteString(color.Yellow(i18n.T("spider.dealBlockedEmpty")) + "\n")
 		}
 
 		b.WriteString("----------\n")

--- a/internal/adapter/presenter/SpiderCuiPresenter_test.go
+++ b/internal/adapter/presenter/SpiderCuiPresenter_test.go
@@ -3,6 +3,7 @@
 package presenter
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +11,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupSpiderCuiMockDefaults(sg *interfaces.MockSpiderGame) {
@@ -18,6 +20,7 @@ func setupSpiderCuiMockDefaults(sg *interfaces.MockSpiderGame) {
 	sg.On("GetStockCount").Return(50).Maybe()
 	sg.On("GetCompletedSuits").Return(0).Maybe()
 	sg.On("GetScore").Return(500).Maybe()
+	sg.On("GetDifficulty").Return(domain.SpiderDifficulty1Suit).Maybe()
 	sg.On("IsStalemate").Return(false).Maybe()
 
 	var tableau [domain.SpiderTableauCnt][]*domain.SpiderTableauCard
@@ -50,6 +53,26 @@ func TestSpiderCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "スコア: 500")
 		assert.Contains(t, result, "列0:")
 		assert.Contains(t, result, "手数: 0")
+		// Difficulty/deals header is shown; no column is empty so no deal warning.
+		assert.Contains(t, result, strings.Split(i18n.T("spider.difficultyLine"), "{{")[0])
+		assert.NotContains(t, result, i18n.T("spider.dealBlockedEmpty"))
+	})
+
+	t.Run("deal-blocked warning when a column is empty", func(t *testing.T) {
+		sg := new(interfaces.MockSpiderGame)
+		setupSpiderCuiMockDefaults(sg)
+		sg.ExpectedCalls = filterCalls(sg.ExpectedCalls, "GetTableau")
+		var tableau [domain.SpiderTableauCnt][]*domain.SpiderTableauCard
+		for i := 1; i < domain.SpiderTableauCnt; i++ { // column 0 left empty
+			tableau[i] = []*domain.SpiderTableauCard{
+				{Card: domain.NewCard(domain.CardDesignSpade, 1, false), FaceUp: true},
+			}
+		}
+		sg.On("GetTableau").Return(tableau)
+		p := new(SpiderCuiPresenter)
+		result := p.Output(sg, nil)
+		// Stock remains (default 50) and column 0 is empty → deal is blocked.
+		assert.Contains(t, result, i18n.T("spider.dealBlockedEmpty"))
 	})
 
 	t.Run("with error", func(t *testing.T) {

--- a/internal/i18n/locales/en/spider.json
+++ b/internal/i18n/locales/en/spider.json
@@ -9,5 +9,7 @@
   "header": "Completed: {{completed}}/{{total}} | Stock: {{stock}} | Score: {{score}}",
   "columnLabel": "Column {{col}}:",
   "gameClearLine": "Game clear! Moves: {{moves}} Score: {{score}}",
-  "hintLine": "Hint: tableau column {{fromCol}}[{{idx}}] → tableau column {{toCol}}"
+  "hintLine": "Hint: tableau column {{fromCol}}[{{idx}}] → tableau column {{toCol}}",
+  "difficultyLine": "Difficulty: {{suits}}-suit / Deals left: {{deals}}",
+  "dealBlockedEmpty": "Cannot deal while a column is empty (fill every column first)"
 }

--- a/internal/i18n/locales/ja/spider.json
+++ b/internal/i18n/locales/ja/spider.json
@@ -9,5 +9,7 @@
   "header": "完成スーツ: {{completed}}/{{total}} | 山札: {{stock}}枚 | スコア: {{score}}",
   "columnLabel": "列{{col}}:",
   "gameClearLine": "ゲームクリア！ 手数: {{moves}} スコア: {{score}}",
-  "hintLine": "ヒント: タブロー列{{fromCol}}[{{idx}}] → タブロー列{{toCol}}"
+  "hintLine": "ヒント: タブロー列{{fromCol}}[{{idx}}] → タブロー列{{toCol}}",
+  "difficultyLine": "難易度: {{suits}}スート / 残りディール: {{deals}}回",
+  "dealBlockedEmpty": "空の列があるためディール不可（全列にカードを置いてください）"
 }


### PR DESCRIPTION
## Summary
Spider Solitaire's CUI header showed only completed suits, stock, and score — not the difficulty (1/2/4-suit) or remaining deals that the web header shows, and it gave no advance warning that a deal is blocked while a column is empty (the player learned only via a rejected deal). This adds:
1. a header line with difficulty (suit count) and deals remaining (`stock/10`, since a deal lays one card per column), and
2. a yellow warning when a column is empty and stock remains.

Uses the existing `GetDifficulty()`/`GetStockCount()`/`GetTableau()` accessors — no domain change (`SpiderDifficulty` is the suit count).

## Changes
- `SpiderCuiPresenter.go`: `spider.difficultyLine` header + `spider.dealBlockedEmpty` warning
- `spider.json` (ja/en): new `difficultyLine` / `dealBlockedEmpty` keys
- Test: header shown with no warning when full; warning shown when a column is empty

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3063