### PR TITLE
feat(shithead): list indexed blind slots on a face-down human turn

### DIFF
--- a/internal/adapter/presenter/ShitheadCuiPresenter.go
+++ b/internal/adapter/presenter/ShitheadCuiPresenter.go
@@ -112,6 +112,18 @@ func (p *ShitheadCuiPresenter) Output(sg interfaces.ShitheadGame, lastErr error)
 		b.WriteString(i18n.Tf("shithead.promptCurrentTurn",
 			"name", currentName,
 			"source", source) + "\n")
+		// On a blind (face-down) human turn, list the selectable slot indices so
+		// the player knows which number to play; the card faces stay hidden.
+		if source == domain.ShitheadSourceFaceDown {
+			if human := sg.GetPlayer(currentTurn); human != nil && human.GetIsHuman() && human.GetFaceDownSize() > 0 {
+				slots := make([]string, human.GetFaceDownSize())
+				for i := range slots {
+					slots[i] = "[" + strconv.Itoa(i) + "]??"
+				}
+				b.WriteString(i18n.Tf("shithead.facedownSlots",
+					"slots", strings.Join(slots, " ")) + "\n")
+			}
+		}
 		b.WriteString(i18n.T("shithead.promptPlayHelp") + "\n")
 	})
 }

--- a/internal/adapter/presenter/ShitheadCuiPresenter_test.go
+++ b/internal/adapter/presenter/ShitheadCuiPresenter_test.go
@@ -31,6 +31,24 @@ func TestShitheadCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "手番:")
 	})
 
+	t.Run("facedown blind turn lists indexed slots", func(t *testing.T) {
+		s := newShitheadForPresenter()
+		s.Reset() // currentTurn = 0 (the human)
+		// Empty the human's hand and face-up piles so the current source is the
+		// face-down (blind) pile, leaving three concealed slots.
+		human := s.GetPlayer(0)
+		human.Reset()
+		human.AddFaceDown(domain.NewCard(domain.CardDesignSpade, 1, false))
+		human.AddFaceDown(domain.NewCard(domain.CardDesignHeart, 2, false))
+		human.AddFaceDown(domain.NewCard(domain.CardDesignClover, 3, false))
+
+		result := p.Output(s, nil)
+		// All three blind slots are listed with concealed (??) faces.
+		assert.Contains(t, result, "[0]??")
+		assert.Contains(t, result, "[1]??")
+		assert.Contains(t, result, "[2]??")
+	})
+
 	t.Run("error message rendered", func(t *testing.T) {
 		s := newShitheadForPresenter()
 		s.Reset()

--- a/internal/i18n/locales/en/shithead.json
+++ b/internal/i18n/locales/en/shithead.json
@@ -25,5 +25,6 @@
   "rankLine": "  {{name}}: rank={{rank}}{{suffix}}",
   "rankShithead": " (Shithead!)",
   "promptCurrentTurn": "{{name}} to act (source: {{source}})",
-  "promptPlayHelp": "p [indices...] to play / p to pick up the pile"
+  "promptPlayHelp": "p [indices...] to play / p to pick up the pile",
+  "facedownSlots": "Blind slots: {{slots}}"
 }

--- a/internal/i18n/locales/ja/shithead.json
+++ b/internal/i18n/locales/ja/shithead.json
@@ -25,5 +25,6 @@
   "rankLine": "  {{name}}: rank={{rank}}{{suffix}}",
   "rankShithead": " (Shithead!)",
   "promptCurrentTurn": "手番: {{name}} (出すソース: {{source}})",
-  "promptPlayHelp": "p [インデックス...] でカードを出す / p で場札を引き取る"
+  "promptPlayHelp": "p [インデックス...] でカードを出す / p で場札を引き取る",
+  "facedownSlots": "ブラインド選択: {{slots}}"
 }


### PR DESCRIPTION
## Summary
Shithead's CUI showed the human's hand and face-up cards but represented the face-down (blind) pile only as a count. When `CurrentSource()` is `facedown`, the player must pick a slot by index to play blind, yet no index list was shown. This lists the selectable slots as `[0]?? [1]?? [2]??` on a blind human turn — the card faces stay concealed.

Uses the existing `CurrentSource()` and the player's `GetFaceDownSize()` — no domain change.

## Changes
- `ShitheadCuiPresenter.go`: `shithead.facedownSlots` line when the source is face-down and it's the human's turn
- `shithead.json` (ja/en): new `facedownSlots` key
- Test: a blind human turn lists all three `[n]??` slots

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3219