### PR TITLE
feat(memory): highlight face-up cells and show pair progress in the CUI

### DIFF
--- a/internal/adapter/presenter/MemoryCuiPresenter.go
+++ b/internal/adapter/presenter/MemoryCuiPresenter.go
@@ -14,12 +14,21 @@ import (
 )
 
 // memoryCellStr returns the display string for a single Memory board cell.
-func memoryCellStr(bc *domain.MemoryBoardCard, pos int) string {
+// A face-up cell is highlighted so the two flipped cards stand out — green when
+// the current result is a match, yellow otherwise. Colour codes are added around
+// the already-padded label, so the visible column width is unchanged.
+func memoryCellStr(bc *domain.MemoryBoardCard, pos int, resultMatch bool) string {
 	if bc.Taken {
 		return fmt.Sprintf("[%2d]%-10s", pos, "")
 	}
 	if bc.FaceUp {
-		return fmt.Sprintf("[%2d]%-10s", pos, cuiCardStr(bc.Card))
+		label := fmt.Sprintf("%-10s", cuiCardStr(bc.Card))
+		if resultMatch {
+			label = color.Green(label)
+		} else {
+			label = color.Yellow(label)
+		}
+		return fmt.Sprintf("[%2d]%s", pos, label)
 	}
 	// Face-down: distinguish previously-seen cells (*?) from unseen ones (??).
 	if bc.Visited {
@@ -34,6 +43,19 @@ type MemoryCuiPresenter struct{}
 // Output renders the current game state for the active locale (#1699).
 func (p *MemoryCuiPresenter) Output(m interfaces.MemoryGame, lastErr error) string {
 	return buildCuiOutput(i18n.T("memory.helpTitle"), func(b *strings.Builder) {
+		board := m.GetBoard()
+
+		// Progress: how many of the 26 pairs remain unmatched (taken pairs are the
+		// sum of every player's captured pairs).
+		matched := 0
+		for i := 0; i < m.GetPlayerCnt(); i++ {
+			matched += m.GetPlayer(i).GetPairCount()
+		}
+		totalPairs := domain.MemoryBoardSize / 2
+		b.WriteString(i18n.Tf("memory.progressLine",
+			"remaining", strconv.Itoa(totalPairs-matched),
+			"total", strconv.Itoa(totalPairs)) + "\n")
+
 		// Players
 		for i := 0; i < m.GetPlayerCnt(); i++ {
 			player := m.GetPlayer(i)
@@ -44,19 +66,26 @@ func (p *MemoryCuiPresenter) Output(m interfaces.MemoryGame, lastErr error) stri
 
 		b.WriteString("----------\n")
 
-		// Render the 4×13 board
-		board := m.GetBoard()
+		// Render the 4×13 board; highlight the flipped (face-up) cells.
+		resultMatch := m.GetPhase() == domain.MemoryPhaseResult && m.GetLastMatchResult()
 		for row := 0; row < 4; row++ {
 			rowParts := make([]string, 13)
 			for col := 0; col < 13; col++ {
 				pos := row*13 + col
-				rowParts[col] = memoryCellStr(board[pos], pos)
+				rowParts[col] = memoryCellStr(board[pos], pos, resultMatch)
 			}
 			b.WriteString(strings.Join(rowParts, " "))
 			b.WriteString("\n")
 		}
 
+		visited := 0
+		for _, cell := range board {
+			if cell.Visited {
+				visited++
+			}
+		}
 		b.WriteString(i18n.T("memory.visitedLegend") + "\n")
+		b.WriteString(i18n.Tf("memory.visitedCountLegend", "count", strconv.Itoa(visited)) + "\n")
 		b.WriteString("----------\n")
 
 		cuiErrorBlock(b, lastErr)

--- a/internal/adapter/presenter/MemoryCuiPresenter_test.go
+++ b/internal/adapter/presenter/MemoryCuiPresenter_test.go
@@ -2,6 +2,7 @@ package presenter
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,6 +58,38 @@ func TestMemoryCuiPresenterOutput(t *testing.T) {
 		assert.Contains(t, result, "CPU 1: 0ペア")
 		assert.Contains(t, result, "1枚目を選んでください")
 		assert.Contains(t, result, "f <pos>")
+		// Progress shows all 26 pairs remaining; the seen-cell count starts at 0.
+		assert.Contains(t, result, "残り 26 ペア / 全 26 ペア")
+		assert.Contains(t, result, "既出セル数: 0")
+	})
+
+	t.Run("highlights a face-up cell", func(t *testing.T) {
+		mg := newMockMemoryGame()
+		setupMemoryMockDefaults(mg)
+		mg.ExpectedCalls = nil
+		mg.On("GetPlayerCnt").Return(4)
+		mg.On("GetGameEndFlag").Return(false)
+		mg.On("GetPhase").Return(domain.MemoryPhaseFlip2)
+		mg.On("GetCurrentPlayerIdx").Return(0)
+		mg.On("GetLastMatchResult").Return(false)
+		mg.On("GetWinnerIdx").Return(-1)
+		var board [domain.MemoryBoardSize]*domain.MemoryBoardCard
+		for i := 0; i < domain.MemoryBoardSize; i++ {
+			board[i] = &domain.MemoryBoardCard{Card: domain.NewCard(domain.CardDesignSpade, (i%13)+1, false)}
+		}
+		board[0].FaceUp = true // the flipped card
+		mg.On("GetBoard").Return(board)
+		for i := 0; i < 4; i++ {
+			mg.On("GetPlayer", i).Return(domain.NewMemoryPlayer(i == 0))
+		}
+
+		// Render with colour enabled so the highlight (yellow) is present.
+		color.SetNoColor(false)
+		defer color.SetNoColor(true)
+		p := new(MemoryCuiPresenter)
+		result := p.Output(mg, nil)
+		expected := color.Yellow(fmt.Sprintf("%-10s", cuiCardStr(domain.NewCard(domain.CardDesignSpade, 1, false))))
+		assert.Contains(t, result, expected)
 	})
 
 	t.Run("marks visited face-down cells distinctly with a legend", func(t *testing.T) {
@@ -189,6 +222,7 @@ func TestMemoryCuiPresenterOutput(t *testing.T) {
 		mg.ExpectedCalls = nil
 		mg.On("GetPlayerCnt").Return(4)
 		mg.On("GetGameEndFlag").Return(true)
+		mg.On("GetPhase").Return(domain.MemoryPhaseFlip1)
 		mg.On("GetWinnerIdx").Return(0)
 
 		var board [domain.MemoryBoardSize]*domain.MemoryBoardCard
@@ -215,6 +249,7 @@ func TestMemoryCuiPresenterOutput(t *testing.T) {
 		mg.ExpectedCalls = nil
 		mg.On("GetPlayerCnt").Return(4)
 		mg.On("GetGameEndFlag").Return(true)
+		mg.On("GetPhase").Return(domain.MemoryPhaseFlip1)
 		mg.On("GetWinnerIdx").Return(2)
 
 		var board [domain.MemoryBoardSize]*domain.MemoryBoardCard

--- a/internal/i18n/locales/en/memory.json
+++ b/internal/i18n/locales/en/memory.json
@@ -11,5 +11,7 @@
   "resultMatch": "match!",
   "resultMismatch": "no match.",
   "promptNextHelp": "n: next",
-  "gameEnd": "Game over! {{name}} wins!"
+  "gameEnd": "Game over! {{name}} wins!",
+  "progressLine": "Remaining: {{remaining}} / {{total}} pairs",
+  "visitedCountLegend": "Seen cells: {{count}}"
 }

--- a/internal/i18n/locales/ja/memory.json
+++ b/internal/i18n/locales/ja/memory.json
@@ -11,5 +11,7 @@
   "resultMatch": "ペアが揃いました！",
   "resultMismatch": "残念、不一致です。",
   "promptNextHelp": "n・・・次へ",
-  "gameEnd": "ゲーム終了！ {{name}}の勝利です！"
+  "gameEnd": "ゲーム終了！ {{name}}の勝利です！",
+  "progressLine": "残り {{remaining}} ペア / 全 {{total}} ペア",
+  "visitedCountLegend": "既出セル数: {{count}}"
 }


### PR DESCRIPTION
## Summary
Memory (Concentration)'s CUI rendered all 52 cells uniformly, making the two currently face-up cards hard to spot, and gave no pair-progress readout. This:
1. highlights face-up cells (yellow, green on a matching result) — colour codes wrap the already-padded label so column alignment is unchanged,
2. adds a header "remaining N / 26 pairs" progress line, and
3. adds a seen-cell count to the legend.

Computed in the presenter from the existing board/players — no domain change.

## Changes
- `MemoryCuiPresenter.go`: face-up highlight (`memoryCellStr` takes a match flag) + progress line + seen-cell legend
- `memory.json` (ja/en): new `progressLine` / `visitedCountLegend` keys
- Tests: progress + seen-count in the initial state; a face-up cell is yellow-highlighted (colour on)

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3030