### PR TITLE
feat(beleagueredcastle): show undo-to-escape guidance on stalemate

### DIFF
--- a/internal/adapter/presenter/BeleagueredCastleCuiPresenter.go
+++ b/internal/adapter/presenter/BeleagueredCastleCuiPresenter.go
@@ -67,6 +67,12 @@ func (p *BeleagueredCastleCuiPresenter) Output(bc interfaces.BeleagueredCastleGa
 		case domain.BeleagueredCastlePhasePlaying:
 			if bc.IsStalemate() {
 				b.WriteString(color.Red(i18n.T("cuiSolitaireStalemate")) + "\n")
+				// Tell the player how many undos escape the dead end, and the command
+				// to use, matching the web StalemateEscapeButton.
+				if n := bc.UndoToEscape(); n > 0 {
+					b.WriteString(color.Yellow(i18n.Tf("beleagueredcastle.undoToEscape",
+						"count", strconv.Itoa(n))) + "\n")
+				}
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(bc.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/BeleagueredCastleCuiPresenter_test.go
+++ b/internal/adapter/presenter/BeleagueredCastleCuiPresenter_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupBeleagueredCastleCuiMockDefaults(bg *interfaces.MockBeleagueredCastleGame) {
@@ -54,6 +55,18 @@ func TestBeleagueredCastleCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "手数: 0")
 	})
 
+	t.Run("stalemate shows undo-to-escape guidance", func(t *testing.T) {
+		bg := new(interfaces.MockBeleagueredCastleGame)
+		setupBeleagueredCastleCuiMockDefaults(bg)
+		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "IsStalemate")
+		bg.On("IsStalemate").Return(true)
+		bg.On("UndoToEscape").Return(3)
+		p := new(BeleagueredCastleCuiPresenter)
+
+		result := p.Output(bg, nil)
+		assert.Contains(t, result, i18n.Tf("beleagueredcastle.undoToEscape", "count", "3"))
+	})
+
 	t.Run("with error", func(t *testing.T) {
 		bg := new(interfaces.MockBeleagueredCastleGame)
 		setupBeleagueredCastleCuiMockDefaults(bg)
@@ -90,6 +103,7 @@ func TestBeleagueredCastleCuiPresenter_Output(t *testing.T) {
 		setupBeleagueredCastleCuiMockDefaults(bg)
 		bg.ExpectedCalls = filterCalls(bg.ExpectedCalls, "IsStalemate")
 		bg.On("IsStalemate").Return(true)
+		bg.On("UndoToEscape").Return(0)
 
 		p := new(BeleagueredCastleCuiPresenter)
 		result := p.Output(bg, nil)

--- a/internal/domain/interfaces/beleagueredcastle.go
+++ b/internal/domain/interfaces/beleagueredcastle.go
@@ -29,4 +29,6 @@ type BeleagueredCastleGame interface {
 	AllFaceUp() bool
 	// IsStalemate 手詰まり状態を取得する
 	IsStalemate() bool
+	// UndoToEscape 手詰まりから抜けるために必要なアンドゥ回数を取得する
+	UndoToEscape() int
 }

--- a/internal/i18n/locales/en/beleagueredcastle.json
+++ b/internal/i18n/locales/en/beleagueredcastle.json
@@ -10,5 +10,6 @@
   "hintFrom": "tableau column {{col}}[{{idx}}]",
   "hintToFoundation": "foundation",
   "hintToTableau": "tableau column {{col}}",
-  "hintLine": "Hint: {{from}} → {{to}}"
+  "hintLine": "Hint: {{from}} → {{to}}",
+  "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)"
 }

--- a/internal/i18n/locales/ja/beleagueredcastle.json
+++ b/internal/i18n/locales/ja/beleagueredcastle.json
@@ -10,5 +10,6 @@
   "hintFrom": "タブロー列{{col}}[{{idx}}]",
   "hintToFoundation": "ファンデーション",
   "hintToTableau": "タブロー列{{col}}",
-  "hintLine": "ヒント: {{from}} → {{to}}"
+  "hintLine": "ヒント: {{from}} → {{to}}",
+  "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）"
 }


### PR DESCRIPTION
## Summary
Beleaguered Castle's CUI printed only a generic "stalemate" warning, while the web UI shows a `StalemateEscapeButton` telling the player how many undos escape the dead end. This adds that count and the undo command to the stalemate branch.

Exposes the domain's existing `UndoToEscape()` via the interface (the mock already had the method) — no new domain logic.

## Changes
- `interfaces/beleagueredcastle.go`: add `UndoToEscape()` to the interface
- `BeleagueredCastleCuiPresenter.go`: `beleagueredcastle.undoToEscape` line when stalemate and undo count > 0
- `beleagueredcastle.json` (ja/en): new `undoToEscape` key
- Test: stalemate with an undo count shows the guidance line

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3275