### PR TITLE
feat(poker): show the current phase and per-phase action prompt in the CUI

### DIFF
--- a/internal/adapter/presenter/PokerCuiPresenter.go
+++ b/internal/adapter/presenter/PokerCuiPresenter.go
@@ -129,12 +129,39 @@ func (pcp *PokerCuiPresenter) Output(p interfaces.PokerGame, lastErr error) stri
 			}
 		}
 
+		b.WriteString(i18n.Tf("poker.phaseLine", "phase", pokerPhaseName(p.GetPhase())) + "\n")
+
 		cuiErrorBlock(b, lastErr)
 
 		if p.GetGameEndFlag() {
 			b.WriteString(i18n.T("poker.gameEnd") + "\n")
+		} else {
+			// Tell the human what to do this phase (draw poker: bet, then exchange,
+			// then bet again).
+			switch p.GetPhase() {
+			case domain.PokerPhaseDeal, domain.PokerPhaseSecondBet:
+				b.WriteString(i18n.T("poker.promptBet") + "\n")
+			case domain.PokerPhaseExchange:
+				b.WriteString(i18n.T("poker.promptExchange") + "\n")
+			}
 		}
 	})
+}
+
+// pokerPhaseName returns the localized name for a Poker phase constant.
+func pokerPhaseName(phase int) string {
+	switch phase {
+	case domain.PokerPhaseDeal:
+		return i18n.T("poker.phaseDeal")
+	case domain.PokerPhaseExchange:
+		return i18n.T("poker.phaseExchange")
+	case domain.PokerPhaseSecondBet:
+		return i18n.T("poker.phaseSecondBet")
+	case domain.PokerPhaseEnd:
+		return i18n.T("poker.phaseEnd")
+	default:
+		return i18n.T("poker.phaseInit")
+	}
 }
 
 // ActionLogOutput emits the action-log transcript as plain text.

--- a/internal/adapter/presenter/PokerCuiPresenter_test.go
+++ b/internal/adapter/presenter/PokerCuiPresenter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func makePokerCuiForPresenter() (*domain.Poker, []*domain.PokerPlayer) {
@@ -44,6 +45,17 @@ func TestPokerCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "あなた")
 		assert.Contains(t, result, "♠10")
 		assert.Contains(t, result, "♥11")
+		// The deal phase shows its name and the betting-command prompt.
+		assert.Contains(t, result, i18n.T("poker.phaseDeal"))
+		assert.Contains(t, result, i18n.T("poker.promptBet"))
+	})
+
+	t.Run("exchange phase shows exchange prompt", func(t *testing.T) {
+		p, _ := makePokerCuiForPresenter()
+		p.SetPhase(domain.PokerPhaseExchange)
+		result := pres.Output(p, nil)
+		assert.Contains(t, result, i18n.T("poker.phaseExchange"))
+		assert.Contains(t, result, i18n.T("poker.promptExchange"))
 	})
 
 	t.Run("CPU player info with play style name", func(t *testing.T) {

--- a/internal/i18n/locales/en/poker.json
+++ b/internal/i18n/locales/en/poker.json
@@ -35,5 +35,13 @@
   "wonAmount": " → won {{total}} chips",
   "gameEnd": "Game over",
   "drawOddsHeader": "[Draw odds]",
-  "drawOddsLine": "  {{name}}: {{prob}}% ({{count}}/{{total}})"
+  "drawOddsLine": "  {{name}}: {{prob}}% ({{count}}/{{total}})",
+  "phaseLine": "Phase: {{phase}}",
+  "phaseInit": "Init",
+  "phaseDeal": "First bet",
+  "phaseExchange": "Card exchange",
+  "phaseSecondBet": "Second bet",
+  "phaseEnd": "End",
+  "promptBet": "Commands: bet <amount> / call / raise <amount> / fold",
+  "promptExchange": "Commands: exchange <card indices> (exchange alone to keep all)"
 }

--- a/internal/i18n/locales/ja/poker.json
+++ b/internal/i18n/locales/ja/poker.json
@@ -35,5 +35,13 @@
   "wonAmount": " → {{total}}チップ獲得",
   "gameEnd": "ゲーム終了",
   "drawOddsHeader": "[ドローオッズ]",
-  "drawOddsLine": "  {{name}}: {{prob}}% ({{count}}/{{total}})"
+  "drawOddsLine": "  {{name}}: {{prob}}% ({{count}}/{{total}})",
+  "phaseLine": "フェーズ: {{phase}}",
+  "phaseInit": "初期化",
+  "phaseDeal": "第1ベット",
+  "phaseExchange": "カード交換",
+  "phaseSecondBet": "第2ベット",
+  "phaseEnd": "終了",
+  "promptBet": "操作: bet <額> / call / raise <額> / fold",
+  "promptExchange": "操作: exchange <カード番号...>（交換なしは exchange のみ）"
 }


### PR DESCRIPTION
## Summary
5-Card Draw Poker's CUI showed dealer/pot/players/results but no phase line or action prompt, so the player had to guess what to do on each redraw (unlike Blackjack's `phaseLine`). This adds a phase line (Init/First bet/Card exchange/Second bet/End) and a per-phase command prompt on the human's turn (bet in the betting rounds, exchange in the draw phase).

Uses the existing `GetPhase()` — no domain change.

## Changes
- `PokerCuiPresenter.go`: `poker.phaseLine` + `pokerPhaseName` helper + bet/exchange prompts
- `poker.json` (ja/en): new `phaseLine` / phase-name / `promptBet` / `promptExchange` keys
- Test: deal phase shows the bet prompt; exchange phase shows the exchange prompt

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #2982