### PR TITLE
feat(klaverjas): show Roem breakdown and total at round end in the CUI

### DIFF
--- a/internal/adapter/presenter/KlaverjasCuiPresenter.go
+++ b/internal/adapter/presenter/KlaverjasCuiPresenter.go
@@ -93,9 +93,17 @@ func (p *KlaverjasCuiPresenter) Output(g interfaces.KlaverjasGame, lastErr error
 			b.WriteString(i18n.T("klaverjas.promptTrickEndHelp") + "\n")
 		case domain.KlaverjasPhaseRoundEnd:
 			pts := g.GetRoundCardPoints()
+			roem := g.GetRoundRoem()
 			b.WriteString(i18n.Tf("klaverjas.promptRoundEnd",
 				"ptsA", strconv.Itoa(pts[0]),
 				"ptsB", strconv.Itoa(pts[1])) + "\n")
+			// Card points alone omit the Roem bonuses; show each team's Roem and the
+			// card-points+Roem total so the final round score is complete.
+			b.WriteString(i18n.Tf("klaverjas.promptRoundEndRoem",
+				"roemA", strconv.Itoa(roem[0]),
+				"roemB", strconv.Itoa(roem[1]),
+				"totalA", strconv.Itoa(pts[0]+roem[0]),
+				"totalB", strconv.Itoa(pts[1]+roem[1])) + "\n")
 			b.WriteString(i18n.T("klaverjas.promptRoundEndHelp") + "\n")
 		}
 	})

--- a/internal/adapter/presenter/KlaverjasCuiPresenter_test.go
+++ b/internal/adapter/presenter/KlaverjasCuiPresenter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func makeKlaverjasPlayers() []*domain.KlaverjasPlayer {
@@ -73,12 +74,18 @@ func TestKlaverjasCuiPresenter_Output(t *testing.T) {
 		assert.NotEmpty(t, result)
 	})
 
-	t.Run("round end prompt", func(t *testing.T) {
+	t.Run("round end shows roem breakdown and total", func(t *testing.T) {
 		m, _ := setupKlaverjasCuiMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetRoundCardPoints")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetRoundRoem")
 		m.On("GetPhase").Return(domain.KlaverjasPhaseRoundEnd)
+		m.On("GetRoundCardPoints").Return([domain.KlaverjasTeamCnt]int{62, 40})
+		m.On("GetRoundRoem").Return([domain.KlaverjasTeamCnt]int{20, 0})
 		result := p.Output(m, nil)
-		assert.NotEmpty(t, result)
+		// Team A: 62 card points + 20 Roem = 82 total.
+		assert.Contains(t, result, i18n.Tf("klaverjas.promptRoundEndRoem",
+			"roemA", "20", "roemB", "0", "totalA", "82", "totalB", "40"))
 	})
 
 	t.Run("game end banner", func(t *testing.T) {

--- a/internal/i18n/locales/en/klaverjas.json
+++ b/internal/i18n/locales/en/klaverjas.json
@@ -18,5 +18,6 @@
   "hintReasonLeadLow": "Lead a low card to conserve points",
   "hintReasonFollowWin": "Points on the table — win the trick",
   "hintReasonFollowDuck": "Cannot/should not win — duck",
-  "hintReasonDiscardLow": "Cannot follow suit — discard a low card"
+  "hintReasonDiscardLow": "Cannot follow suit — discard a low card",
+  "promptRoundEndRoem": "Roem: A +{{roemA}} / B +{{roemB}} (total A {{totalA}} / B {{totalB}})"
 }

--- a/internal/i18n/locales/ja/klaverjas.json
+++ b/internal/i18n/locales/ja/klaverjas.json
@@ -18,5 +18,6 @@
   "hintReasonLeadLow": "低い札でリードして温存する",
   "hintReasonFollowWin": "得点があるので勝ちに行く",
   "hintReasonFollowDuck": "取れない／取る価値がないのでダック",
-  "hintReasonDiscardLow": "フォローできないので低い札を捨てる"
+  "hintReasonDiscardLow": "フォローできないので低い札を捨てる",
+  "promptRoundEndRoem": "Roem: A +{{roemA}} / B +{{roemB}}（合計 A {{totalA}} / B {{totalB}}）"
 }


### PR DESCRIPTION
## Summary
Klaverjas' CUI round-end prompt showed only the card points, omitting each team's Roem bonus — so the final round score was incomplete (the web round-result block shows both card points and Roem). This adds a Roem line with each team's bonus and the card-points+Roem total.

Uses the existing `GetRoundCardPoints()` and `GetRoundRoem()` (already on the interface, already in the header) — no domain change.

## Changes
- `KlaverjasCuiPresenter.go`: `klaverjas.promptRoundEndRoem` line after the card-points line
- `klaverjas.json` (ja/en): new `promptRoundEndRoem` key
- Test: round end shows Roem (A +20) and totals (A 82 / B 40)

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3422