### PR TITLE
feat(mao): show hidden-rule compliance progress before the hint unlocks

### DIFF
--- a/internal/adapter/presenter/MaoCuiPresenter.go
+++ b/internal/adapter/presenter/MaoCuiPresenter.go
@@ -65,9 +65,15 @@ func (p *MaoCuiPresenter) Output(g interfaces.MaoGame, lastErr error) string {
 			b.WriteString(maoPlayerStr(g.GetPlayer(i), i))
 		}
 
-		// 隠しルールのハーフヒント (3回正解で解放)
-		if g.GetHintUnlocked() && g.GetRuleHint() != "" {
-			b.WriteString(color.Yellow(i18n.Tf("mao.ruleHint", "hint", g.GetRuleHint())) + "\n")
+		// 隠しルールのハーフヒント (3回正解で解放)。解放前は正解の進捗を表示する。
+		if g.GetHintUnlocked() {
+			if g.GetRuleHint() != "" {
+				b.WriteString(color.Yellow(i18n.Tf("mao.ruleHint", "hint", g.GetRuleHint())) + "\n")
+			}
+		} else {
+			b.WriteString(i18n.Tf("mao.compliance",
+				"count", strconv.Itoa(g.GetPlayerCorrectCount()),
+				"total", strconv.Itoa(domain.MaoHintThreshold)) + "\n")
 		}
 		if g.GetRulePenaltyFlag() {
 			b.WriteString(color.Red(i18n.T("mao.rulePenalty")) + "\n")

--- a/internal/adapter/presenter/MaoCuiPresenter_test.go
+++ b/internal/adapter/presenter/MaoCuiPresenter_test.go
@@ -29,6 +29,7 @@ func setupMaoCuiMock() *interfaces.MockMaoGame {
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
 	m.On("GetAwaitingWord").Return(false)
 	m.On("GetHintUnlocked").Return(false)
+	m.On("GetPlayerCorrectCount").Return(1)
 	m.On("GetRuleHint").Return("")
 	m.On("GetRulePenaltyFlag").Return(false)
 	return m
@@ -58,6 +59,19 @@ func TestMaoCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "Mao")
 		assert.Contains(t, result, "ラウンド: 1")
 		assert.Contains(t, result, "手番: あなた")
+		// Before the hint unlocks, the compliance progress (1/3) is shown.
+		assert.Contains(t, result, "ルール適合: 1/3")
+	})
+
+	t.Run("unlocked hint replaces the compliance progress", func(t *testing.T) {
+		m, _ := setupMaoCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHintUnlocked")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetRuleHint")
+		m.On("GetHintUnlocked").Return(true)
+		m.On("GetRuleHint").Return("odd cards")
+		result := p.Output(m, nil)
+		assert.NotContains(t, result, "ルール適合:")
+		assert.Contains(t, result, "odd cards")
 	})
 
 	t.Run("awaiting word prompt and no hidden rule leak", func(t *testing.T) {

--- a/internal/i18n/locales/en/mao.json
+++ b/internal/i18n/locales/en/mao.json
@@ -31,5 +31,6 @@
   "promptAwaitingWord": "Declaration phase (secret rule)",
   "promptAwaitingWordHelp": "dw <word>: say a word",
   "promptRoundEnd": "Round complete",
-  "promptRoundEndHelp": "nr / nextround: advance to next round"
+  "promptRoundEndHelp": "nr / nextround: advance to next round",
+  "compliance": "Rule compliance: {{count}}/{{total}} (hint unlocks at {{total}})"
 }

--- a/internal/i18n/locales/ja/mao.json
+++ b/internal/i18n/locales/ja/mao.json
@@ -31,5 +31,6 @@
   "promptAwaitingWord": "宣言フェーズ (秘密のルール)",
   "promptAwaitingWordHelp": "dw <word>・・・言葉を宣言する",
   "promptRoundEnd": "ラウンド終了",
-  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ"
+  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
+  "compliance": "ルール適合: {{count}}/{{total}}（{{total}}回正解でヒント解放）"
 }


### PR DESCRIPTION
## Summary
Mao's CUI showed the half-hint only after it unlocked (3 correct rule-following plays), leaving the player with no sense of progress beforehand — unlike the web UI, which always shows "n / 3". This adds a compliance progress line (`rule compliance: n/3`) before the hint unlocks; after unlock, the existing rule-hint line is shown instead.

Uses the existing `GetPlayerCorrectCount()` accessor and the `MaoHintThreshold` constant — no domain change.

## Changes
- `MaoCuiPresenter.go`: `mao.compliance` progress line when the hint is locked
- `mao.json` (ja/en): new `compliance` key
- Test: locked state shows `1/3`; unlocked state shows the hint and no progress line

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3549