### PR TITLE
fix(threethirteen): hide CPU deadwood during play to stop an info leak

### DIFF
--- a/internal/adapter/presenter/ThreeThirteenCuiPresenter.go
+++ b/internal/adapter/presenter/ThreeThirteenCuiPresenter.go
@@ -14,13 +14,20 @@ import (
 
 // threeThirteenPlayerStr returns the display string for a single Three Thirteen player.
 func threeThirteenPlayerStr(g interfaces.ThreeThirteenGame, player *domain.ThreeThirteenPlayer, i int) string {
+	// A CPU's deadwood is hidden information (its hand isn't public); reveal it
+	// only for the human, or once all hands are shown at round/game end.
+	revealed := g.GetPhase() == domain.ThreeThirteenPhaseRoundEnd || g.GetGameEndFlag()
+	deadwoodStr := "?"
+	if player.GetIsHuman() || revealed {
+		deadwoodStr = strconv.Itoa(g.GetPlayerDeadwoodValue(i))
+	}
 	var b strings.Builder
 	b.WriteString(i18n.Tf("threethirteen.playerLine",
 		"name", cuiPlayerName(player, i),
 		"cum", strconv.Itoa(player.GetCumulativeScore()),
 		"round", strconv.Itoa(player.GetRoundScore()),
 		"cards", strconv.Itoa(player.GetCardsSize()),
-		"deadwood", strconv.Itoa(g.GetPlayerDeadwoodValue(i))) + "\n")
+		"deadwood", deadwoodStr) + "\n")
 	if player.GetIsHuman() && player.GetCardsSize() > 0 {
 		b.WriteString(cuiIndexedCardListStr(player) + "\n")
 	}

--- a/internal/adapter/presenter/ThreeThirteenCuiPresenter_test.go
+++ b/internal/adapter/presenter/ThreeThirteenCuiPresenter_test.go
@@ -64,6 +64,17 @@ func TestThreeThirteenCuiPresenter_Output(t *testing.T) {
 		})
 	}
 
+	t.Run("cpu deadwood masked during play, revealed at round end", func(t *testing.T) {
+		m, _ := setupThreeThirteenCuiMock(domain.ThreeThirteenPhaseDraw, false)
+		out := p.Output(m, nil)
+		assert.Contains(t, out, "デッドウッド?") // CPU hands are hidden
+		assert.Contains(t, out, "デッドウッド5") // the human's own deadwood
+
+		m2, _ := setupThreeThirteenCuiMock(domain.ThreeThirteenPhaseRoundEnd, false)
+		out2 := p.Output(m2, nil)
+		assert.NotContains(t, out2, "デッドウッド?") // all hands revealed at round end
+	})
+
 	t.Run("error block", func(t *testing.T) {
 		m, _ := setupThreeThirteenCuiMock(domain.ThreeThirteenPhaseDraw, false)
 		assert.NotEmpty(t, p.Output(m, errors.New("err")))


### PR DESCRIPTION
## Summary
Three Thirteen's CUI printed `GetPlayerDeadwoodValue(i)` for **every** player's row, leaking how well each CPU's concealed hand is formed — the web UI shows only the human's deadwood and reveals the rest at round end. This masks a CPU's deadwood as `?` during play and reveals it only at ROUND_END / GAME_END, matching the web disclosure.

No domain change — just gates the existing accessor on human/reveal.

## Changes
- `ThreeThirteenCuiPresenter.go`: deadwood shown for the human always, for CPUs only when revealed (else `?`)
- Test: draw phase masks CPU deadwood (`?`) but shows the human's; round end reveals all

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues

Closes #3546