### PR TITLE
fix(mus): show localized result-kind names instead of raw integers

### DIFF
--- a/internal/adapter/presenter/MusCuiPresenter.go
+++ b/internal/adapter/presenter/MusCuiPresenter.go
@@ -46,6 +46,23 @@ func musActionLabel(action int) string {
 	}
 }
 
+// musResultKindLabel returns the i18n display label for a mus result kind int,
+// so the round-result line shows a name rather than a raw MusResult* constant.
+func musResultKindLabel(kind int) string {
+	switch kind {
+	case domain.MusResultDeferred:
+		return i18n.T("mus.resultDeferred")
+	case domain.MusResultAccepted:
+		return i18n.T("mus.resultAccepted")
+	case domain.MusResultAwarded:
+		return i18n.T("mus.resultAwarded")
+	case domain.MusResultOrdago:
+		return i18n.T("mus.resultOrdago")
+	default:
+		return "?"
+	}
+}
+
 // musPlayerStr returns the display string for a single Mus player.
 func musPlayerStr(g interfaces.MusGame, i int) string {
 	player := g.GetPlayer(i)
@@ -95,7 +112,7 @@ func (p *MusCuiPresenter) Output(g interfaces.MusGame, lastErr error) string {
 				if r.Kind != domain.MusResultPending {
 					b.WriteString(i18n.Tf("mus.resultLine",
 						"round", musPhaseLabel(ri),
-						"kind", strconv.Itoa(r.Kind),
+						"kind", musResultKindLabel(r.Kind),
 						"stake", strconv.Itoa(r.Stake),
 					) + "\n")
 				}

--- a/internal/adapter/presenter/MusCuiPresenter_test.go
+++ b/internal/adapter/presenter/MusCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func makeMusPlayers() []*domain.MusPlayer {
@@ -124,15 +126,29 @@ func TestMusCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "boom")
 	})
 
-	t.Run("betting results shown when in betting phase", func(t *testing.T) {
-		m, _ := setupMusCuiMockWithPlayers()
-		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
-		m.On("GetPhase").Return(domain.MusPhaseChica)
-		for ri := 0; ri < domain.MusRoundCnt; ri++ {
-			m.On("GetResult", ri).Return(domain.MusRoundResult{Kind: domain.MusResultDeferred, Stake: 1, Team: -1})
+	t.Run("betting results show localized kind names, not raw ints", func(t *testing.T) {
+		// Each result kind renders by its localized name, covering every branch.
+		for _, tc := range []struct {
+			kind  int
+			label string
+		}{
+			{domain.MusResultDeferred, i18n.T("mus.resultDeferred")},
+			{domain.MusResultAccepted, i18n.T("mus.resultAccepted")},
+			{domain.MusResultAwarded, i18n.T("mus.resultAwarded")},
+			{domain.MusResultOrdago, i18n.T("mus.resultOrdago")},
+		} {
+			m, _ := setupMusCuiMockWithPlayers()
+			m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+			m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetResult")
+			m.On("GetPhase").Return(domain.MusPhaseChica)
+			for ri := 0; ri < domain.MusRoundCnt; ri++ {
+				m.On("GetResult", ri).Return(domain.MusRoundResult{Kind: tc.kind, Stake: 1, Team: -1})
+			}
+			result := p.Output(m, nil)
+			assert.Contains(t, result, tc.label)
+			// A raw kind int must not leak into the result line.
+			assert.NotContains(t, result, "種別="+strconv.Itoa(tc.kind))
 		}
-		result := p.Output(m, nil)
-		assert.NotEmpty(t, result)
 	})
 }
 

--- a/internal/i18n/locales/en/mus.json
+++ b/internal/i18n/locales/en/mus.json
@@ -44,5 +44,9 @@
   "hintReasonBetEnvido": "Hand is strong — bet",
   "hintReasonBetOrdago": "Hand is very strong — go all in",
   "hintReasonBetQuiero": "Hand beats opponent — accept",
-  "hintReasonBetNoQuiero": "Hand is beaten — decline"
+  "hintReasonBetNoQuiero": "Hand is beaten — decline",
+  "resultDeferred": "Paso (deferred to showdown)",
+  "resultAccepted": "Quiero (showdown)",
+  "resultAwarded": "No quiero (awarded)",
+  "resultOrdago": "Ordago accepted"
 }

--- a/internal/i18n/locales/ja/mus.json
+++ b/internal/i18n/locales/ja/mus.json
@@ -44,5 +44,9 @@
   "hintReasonBetEnvido": "手が強い ― 賭ける",
   "hintReasonBetOrdago": "手が非常に強い ― 全賭けする",
   "hintReasonBetQuiero": "相手に勝っている ― 受ける",
-  "hintReasonBetNoQuiero": "相手に負けている ― 降りる"
+  "hintReasonBetNoQuiero": "相手に負けている ― 降りる",
+  "resultDeferred": "パソ（ショーダウン持ち越し）",
+  "resultAccepted": "キエロ（ショーダウン）",
+  "resultAwarded": "ノキエロ（即時獲得）",
+  "resultOrdago": "オルダゴ受諾"
 }


### PR DESCRIPTION
## Summary
Mus's CUI rendered each betting round's result kind with `strconv.Itoa(r.Kind)`, leaking the raw `MusResult*` constant (e.g. "種別=2") — meaningless to the player, while the sibling `musActionLabel` already localizes action ints. This adds a `musResultKindLabel` helper mapping every `MusResult*` kind to a localized name.

Pure presenter — reuses the existing constants; no domain change.

## Changes
- `MusCuiPresenter.go`: `musResultKindLabel` helper; result line uses it instead of the raw int
- `mus.json` (ja/en): new `resultDeferred` / `resultAccepted` / `resultAwarded` / `resultOrdago` keys
- Test: every result kind renders its localized name and no raw int leaks

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3407