### PR TITLE
feat(sheepshead): show the picker team's win/loss result at round end

### DIFF
--- a/internal/adapter/presenter/SheepsheadCuiPresenter.go
+++ b/internal/adapter/presenter/SheepsheadCuiPresenter.go
@@ -133,6 +133,13 @@ func (p *SheepsheadCuiPresenter) Output(g interfaces.SheepsheadGame, lastErr err
 			b.WriteString(i18n.Tf("sheepshead.promptRoundEnd",
 				"pts", strconv.Itoa(g.GetRoundPickerPoints()),
 				"mult", strconv.Itoa(g.GetRoundMultiplier())) + "\n")
+			// Points and multiplier alone don't say who won; spell out the picker
+			// team's result and the chip direction.
+			if g.GetRoundPickerWon() {
+				b.WriteString(color.Green(i18n.T("sheepshead.roundPickerWon")) + "\n")
+			} else {
+				b.WriteString(color.Red(i18n.T("sheepshead.roundPickerLost")) + "\n")
+			}
 			b.WriteString(i18n.T("sheepshead.promptRoundEndHelp") + "\n")
 		}
 	})

--- a/internal/adapter/presenter/SheepsheadCuiPresenter_test.go
+++ b/internal/adapter/presenter/SheepsheadCuiPresenter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func makeSheepsheadPlayers() []*domain.SheepsheadPlayer {
@@ -42,6 +43,7 @@ func setupSheepsheadCuiMock() *interfaces.MockSheepsheadGame {
 	m.On("IsPartnerRevealed").Return(false)
 	m.On("GetRoundPickerPoints").Return(0)
 	m.On("GetRoundMultiplier").Return(1)
+	m.On("GetRoundPickerWon").Return(false)
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
 	return m
 }
@@ -108,12 +110,22 @@ func TestSheepsheadCuiPresenter_Output(t *testing.T) {
 		assert.NotEmpty(t, result)
 	})
 
-	t.Run("round end prompt", func(t *testing.T) {
+	t.Run("round end shows picker won result", func(t *testing.T) {
+		m, _ := setupSheepsheadCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetRoundPickerWon")
+		m.On("GetPhase").Return(domain.SheepsheadPhaseRoundEnd)
+		m.On("GetRoundPickerWon").Return(true)
+		result := p.Output(m, nil)
+		assert.Contains(t, result, i18n.T("sheepshead.roundPickerWon"))
+	})
+
+	t.Run("round end shows picker lost result", func(t *testing.T) {
 		m, _ := setupSheepsheadCuiMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
 		m.On("GetPhase").Return(domain.SheepsheadPhaseRoundEnd)
-		result := p.Output(m, nil)
-		assert.NotEmpty(t, result)
+		result := p.Output(m, nil) // default GetRoundPickerWon = false
+		assert.Contains(t, result, i18n.T("sheepshead.roundPickerLost"))
 	})
 
 	t.Run("game end banner", func(t *testing.T) {

--- a/internal/i18n/locales/en/sheepshead.json
+++ b/internal/i18n/locales/en/sheepshead.json
@@ -38,5 +38,7 @@
   "hintReasonLeadLow": "Lead a low card to conserve points",
   "hintReasonFollowWin": "Points on the table — win the trick",
   "hintReasonFollowDuck": "Cannot/should not win — duck",
-  "hintReasonDiscardLow": "Cannot follow suit — discard a low card"
+  "hintReasonDiscardLow": "Cannot follow suit — discard a low card",
+  "roundPickerWon": "Picker team won (receives chips)",
+  "roundPickerLost": "Picker team lost (pays chips)"
 }

--- a/internal/i18n/locales/ja/sheepshead.json
+++ b/internal/i18n/locales/ja/sheepshead.json
@@ -38,5 +38,7 @@
   "hintReasonLeadLow": "低い札でリードして温存する",
   "hintReasonFollowWin": "得点があるので勝ちに行く",
   "hintReasonFollowDuck": "取れない／取る価値がないのでダック",
-  "hintReasonDiscardLow": "フォローできないので低い札を捨てる"
+  "hintReasonDiscardLow": "フォローできないので低い札を捨てる",
+  "roundPickerWon": "ピッカー組の勝ち（相手からチップを受け取る）",
+  "roundPickerLost": "ピッカー組の負け（相手へチップを支払う）"
 }


### PR DESCRIPTION
## Summary
Sheepshead's CUI round-end line showed the picker team's points and multiplier but not whether the picker team **won or lost** the round — the web UI shows `pickerWon`/`pickerLost`. This adds a coloured result line (green won / red lost) with the chip direction.

Uses the existing `GetRoundPickerWon()` accessor — no domain change. Points/multiplier line is unchanged.

## Changes
- `SheepsheadCuiPresenter.go`: picker won/lost line at round end
- `sheepshead.json` (ja/en): new `roundPickerWon` / `roundPickerLost` keys
- Test: round end shows the won result and the lost result

## Test plan
- [x] `go test -tags test ./internal/adapter/presenter/`
- [x] `golangci-lint run` — 0 issues
- [x] ja/en key parity

Closes #3402