### PR TITLE
feat(cego): surface declarer and contract in play-phase header

### DIFF
--- a/internal/adapter/presenter/CegoCuiPresenter.go
+++ b/internal/adapter/presenter/CegoCuiPresenter.go
@@ -125,6 +125,14 @@ func (p *CegoCuiPresenter) Output(g interfaces.CegoGame, lastErr error) string {
 			"trick", strconv.Itoa(g.GetTrickNumber()),
 			"contract", cegoContractLabel(g.GetContractType())) + "\n")
 
+		// Once the declarer is set, surface who it is and the contract at a glance
+		// (the declarer fights the whole field); before that, it isn't shown.
+		if declarer := g.GetDeclarerIdx(); declarer >= 0 {
+			b.WriteString(i18n.Tf("cego.declarerLine",
+				"name", cuiPlayerName(g.GetPlayer(declarer), declarer),
+				"contract", cegoContractLabel(g.GetContractType())) + "\n")
+		}
+
 		for i := 0; i < g.GetPlayerCnt(); i++ {
 			b.WriteString(cegoPlayerStr(g, i))
 		}

--- a/internal/adapter/presenter/CegoCuiPresenter_test.go
+++ b/internal/adapter/presenter/CegoCuiPresenter_test.go
@@ -3,6 +3,7 @@
 package presenter_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +11,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func cegoCuiGame() *domain.Cego {
@@ -64,6 +66,26 @@ func TestCegoCuiPresenter_Output(t *testing.T) {
 		result := p.Output(g, nil)
 		assert.Contains(t, result, "T7")
 		assert.Contains(t, result, "Sküs")
+	})
+
+	// declarerPrefix is the leading literal of the declarer line (before the
+	// {{name}} placeholder), stable enough to assert on under the default locale.
+	declarerPrefix := strings.SplitN(i18n.T("cego.declarerLine"), "{{", 2)[0]
+
+	t.Run("declarer line shown once declarer is set", func(t *testing.T) {
+		g := cegoCuiGame()
+		g.SetDeclarerIdx(0)
+		g.SetContract(domain.CegoBidPlay)
+		g.SetPhase(domain.CegoPhasePlay)
+		result := p.Output(g, nil)
+		assert.Contains(t, result, declarerPrefix)
+	})
+
+	t.Run("declarer line hidden before declarer is set", func(t *testing.T) {
+		g := cegoCuiGame() // default declarer idx is -1 during bidding
+		g.SetBidPlayerIdx(0)
+		result := p.Output(g, nil)
+		assert.NotContains(t, result, declarerPrefix)
 	})
 
 	t.Run("trick end", func(t *testing.T) {

--- a/internal/i18n/locales/en/cego.json
+++ b/internal/i18n/locales/en/cego.json
@@ -44,5 +44,6 @@
   "hintReasonLeadHigh": "You are the declarer — lead a strong card to take control",
   "hintReasonLeadLow": "You are an opponent — lead a low card to conserve",
   "hintReasonFollowWin": "You can win — take the trick",
-  "hintReasonFollowDuck": "Cannot/should not win — play low"
+  "hintReasonFollowDuck": "Cannot/should not win — play low",
+  "declarerLine": "Declarer: {{name}} (contract: {{contract}}) vs the field"
 }

--- a/internal/i18n/locales/ja/cego.json
+++ b/internal/i18n/locales/ja/cego.json
@@ -44,5 +44,6 @@
   "hintReasonLeadHigh": "あなたはデクレアラー — 強い札でリードして主導権を取る",
   "hintReasonLeadLow": "あなたは対戦側 — 安い札でリードして温存する",
   "hintReasonFollowWin": "勝てる — トリックを取る",
-  "hintReasonFollowDuck": "勝てない/取るべきでない — 低い札を出す"
+  "hintReasonFollowDuck": "勝てない/取るべきでない — 低い札を出す",
+  "declarerLine": "宣言者: {{name}}（契約: {{contract}}）が全員と対戦"
 }


### PR DESCRIPTION
## 概要
チェゴのプレイフェーズで、ラウンド行はコントラクトのみ表示していた。宣言者（デクレアラー）が確定した時点で、宣言者名とコントラクト種別を一行にまとめて表示する。宣言者が全員を相手に戦う構図が一目で分かるようにする。

## 変更点
- `CegoCuiPresenter.go`: `GetDeclarerIdx() >= 0` のときに `cego.declarerLine`（宣言者名＋コントラクト）を出力
- `internal/i18n/locales/{ja,en}/cego.json`: `declarerLine` キー追加
- テスト: 宣言者確定後に表示・入札中は非表示を検証

Closes #3536