### PR TITLE
feat(primero): show call amount and raise total in betting prompt

### DIFF
--- a/internal/adapter/presenter/PrimeroCuiPresenter.go
+++ b/internal/adapter/presenter/PrimeroCuiPresenter.go
@@ -91,8 +91,15 @@ func (p *PrimeroCuiPresenter) Output(g interfaces.PrimeroGame, lastErr error) st
 
 		switch g.GetPhase() {
 		case domain.PrimeroPhaseBetting:
+			// Spell out what the acting player must add to call and the total a
+			// raise reaches, so the human isn't left computing it by hand. The
+			// acting seat is always valid here and never bets past the current
+			// level, so need = currentBet - roundBet stays non-negative.
+			actor := g.GetPlayer(g.GetCurrentPlayerIdx())
 			b.WriteString(i18n.Tf("primero.promptBetting",
 				"bet", strconv.Itoa(g.GetCurrentBet()),
+				"need", strconv.Itoa(g.GetCurrentBet()-actor.GetRoundBet()),
+				"raiseTo", strconv.Itoa(g.GetCurrentBet()+g.GetAnte()),
 			) + "\n")
 		case domain.PrimeroPhaseResult:
 			b.WriteString(p.resultLine(g))

--- a/internal/adapter/presenter/PrimeroCuiPresenter_test.go
+++ b/internal/adapter/presenter/PrimeroCuiPresenter_test.go
@@ -2,6 +2,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,6 +20,19 @@ func TestPrimeroCuiPresenter_OutputBettingPhase(t *testing.T) {
 	// Title and round line should be present.
 	assert.Contains(t, out, "プリメロ")
 	assert.Contains(t, out, "ラウンド")
+}
+
+func TestPrimeroCuiPresenter_OutputBettingShowsCallNeed(t *testing.T) {
+	g := domain.NewDefaultPrimero()
+	require.Equal(t, domain.PrimeroPhaseBetting, g.GetPhase())
+	p := new(presenter.PrimeroCuiPresenter)
+	out := p.Output(g, nil)
+
+	actor := g.GetPlayer(g.GetCurrentPlayerIdx())
+	need := g.GetCurrentBet() - actor.GetRoundBet()
+	raiseTo := g.GetCurrentBet() + g.GetAnte()
+	assert.Contains(t, out, "必要 "+strconv.Itoa(need))
+	assert.Contains(t, out, strconv.Itoa(raiseTo))
 }
 
 func TestPrimeroCuiPresenter_OutputError(t *testing.T) {

--- a/internal/i18n/locales/en/primero.json
+++ b/internal/i18n/locales/en/primero.json
@@ -19,7 +19,7 @@
   "hand.primero": "Primero",
   "hand.numerus": "Numerus",
   "gameEnd": "Game over — player {{player}} wins!",
-  "promptBetting": "Act: c (call) / ra (raise, current {{bet}}) / f (fold)",
+  "promptBetting": "Act: c (call, need {{need}}) / ra (raise, current {{bet}}→{{raiseTo}}) / f (fold)",
   "promptResult": "Round over. Use n for the next round.",
   "promptHelp": "c / ra / f to act, n for the next round",
   "result.none": "The round is over.",

--- a/internal/i18n/locales/ja/primero.json
+++ b/internal/i18n/locales/ja/primero.json
@@ -19,7 +19,7 @@
   "hand.primero": "プリメロ",
   "hand.numerus": "ヌメルス",
   "gameEnd": "ゲーム終了 — プレイヤー {{player}} の勝ち！",
-  "promptBetting": "アクションしてください: c（コール）/ ra（レイズ・現在 {{bet}}）/ f（フォールド）",
+  "promptBetting": "アクションしてください: c（コール・必要 {{need}}）/ ra（レイズ・現在 {{bet}}→{{raiseTo}}）/ f（フォールド）",
   "promptResult": "ラウンド終了。n で次のラウンドへ。",
   "promptHelp": "c / ra / f でアクション、n で次のラウンド",
   "result.none": "ラウンド終了。",


### PR DESCRIPTION
## 概要
プリメロの betting プロンプトは現在ベット額のみを表示していた。手番プレイヤーがコールに追加で必要な額（`currentBet - roundBet`）と、レイズ後に到達する総額（`currentBet + ante`）を明示し、CUI プレイヤーの意思決定を補助する。

## 変更点
- `PrimeroCuiPresenter.go`: betting プロンプトに `need` / `raiseTo` を追加
- `internal/i18n/locales/{ja,en}/primero.json`: `promptBetting` を更新
- テスト: 必要額とレイズ後総額の表示を検証

Closes #3485