### PR TITLE
feat(doudizhu): show current bidder and human bid prompt in bid phase

### DIFF
--- a/internal/adapter/presenter/DoudizhuCuiPresenter.go
+++ b/internal/adapter/presenter/DoudizhuCuiPresenter.go
@@ -24,6 +24,14 @@ func (p *DoudizhuCuiPresenter) Output(dg interfaces.DoudizhuGame, lastErr error)
 		if phase == domain.DoudizhuPhaseBid {
 			b.WriteString(color.BoldYellow(i18n.T("doudizhu.phaseBid")) + "\n")
 			fmt.Fprintf(b, "%s: %d\n", i18n.T("doudizhu.highestBid"), dg.GetHighestBid())
+			// Name whose bid it is and, on the human's turn, how to respond —
+			// play/end phases already carry this much context.
+			curIdx := dg.GetCurrentTurn()
+			b.WriteString(i18n.Tf("doudizhu.currentBidder",
+				"name", cuiPlayerName(dg.GetPlayer(curIdx), curIdx)) + "\n")
+			if dg.IsHumanTurn() {
+				b.WriteString(i18n.T("doudizhu.promptBid") + "\n")
+			}
 		}
 
 		for idx := 0; idx < dg.GetPlayerCnt(); idx++ {
@@ -53,13 +61,9 @@ func (p *DoudizhuCuiPresenter) Output(dg interfaces.DoudizhuGame, lastErr error)
 			scores := dg.GetScores()
 			b.WriteString(color.BoldYellow(i18n.T("doudizhu.gameEnd")) + "\n")
 			for idx := 0; idx < dg.GetPlayerCnt(); idx++ {
-				player := dg.GetPlayer(idx)
-				var name string
-				if player.GetIsHuman() {
-					name = i18n.T("doudizhu.you")
-				} else {
-					name = fmt.Sprintf("CPU %d", idx)
-				}
+				// Use the shared name helper so the end-score names match every
+				// other phase instead of a locally hardcoded "CPU %d".
+				name := cuiPlayerName(dg.GetPlayer(idx), idx)
 				fmt.Fprintf(b, "%s: %d\n", name, scores[idx])
 			}
 		}

--- a/internal/adapter/presenter/DoudizhuCuiPresenter_test.go
+++ b/internal/adapter/presenter/DoudizhuCuiPresenter_test.go
@@ -2,21 +2,36 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func TestDoudizhuCuiPresenter_Output_BidPhase(t *testing.T) {
 	dg := newDoudizhuForPresenter()
 	dg.Reset()
+	// Put the human on turn so the bid prompt renders.
+	humanIdx := 0
+	for i := 0; i < dg.GetPlayerCnt(); i++ {
+		if dg.GetPlayer(i).GetIsHuman() {
+			humanIdx = i
+			break
+		}
+	}
+	dg.SetCurrentTurn(humanIdx)
 
 	p := new(presenter.DoudizhuCuiPresenter)
 	out := p.Output(dg, nil)
 	assert.NotEmpty(t, out)
+	// The current bidder line and the human bid prompt should both appear.
+	bidderPrefix := strings.SplitN(i18n.T("doudizhu.currentBidder"), "{{", 2)[0]
+	assert.Contains(t, out, bidderPrefix)
+	assert.Contains(t, out, i18n.T("doudizhu.promptBid"))
 }
 
 func TestDoudizhuCuiPresenter_Output_PlayPhase(t *testing.T) {

--- a/internal/i18n/locales/en/doudizhu.json
+++ b/internal/i18n/locales/en/doudizhu.json
@@ -13,5 +13,7 @@
   "kittyCards": "Kitty Cards",
   "tableCards": "Table",
   "playerFinished": " (finished)",
-  "playerCardCount": " ({{count}} cards)"
+  "playerCardCount": " ({{count}} cards)",
+  "currentBidder": "Current bidder: {{name}}",
+  "promptBid": "Place your bid (b 0-3, 0 = pass)"
 }

--- a/internal/i18n/locales/ja/doudizhu.json
+++ b/internal/i18n/locales/ja/doudizhu.json
@@ -13,5 +13,7 @@
   "kittyCards": "底牌",
   "tableCards": "場",
   "playerFinished": " (上がり)",
-  "playerCardCount": " ({{count}}枚)"
+  "playerCardCount": " ({{count}}枚)",
+  "currentBidder": "現在の入札者: {{name}}",
+  "promptBid": "入札してください（b 0-3、0=パス）"
 }


### PR DESCRIPTION
## 概要
斗地主のビッドフェーズは最高ビッドしか表示しておらず、誰の入札番か・人間が何を入力すべきかが分からなかった。現在の入札者名を表示し、人間の番には入札コマンド案内（`b 0-3`）を出す。あわせて終了スコアのプレイヤー名を、他フェーズと同じ `cuiPlayerName` に統一する（ハードコードの `CPU %d` を廃止）。

## 変更点
- `DoudizhuCuiPresenter.go`: ビッド中に `doudizhu.currentBidder`、人間番に `doudizhu.promptBid` を出力／終了スコア名を `cuiPlayerName` に統一
- `internal/i18n/locales/{ja,en}/doudizhu.json`: `currentBidder` / `promptBid` 追加
- テスト: ビッド者表示と人間プロンプトを検証

Closes #3339