### PR TITLE
feat(oichokabu): add max-bet and draw/stand hints to the CUI

### DIFF
--- a/internal/adapter/presenter/OichoKabuCuiPresenter.go
+++ b/internal/adapter/presenter/OichoKabuCuiPresenter.go
@@ -43,6 +43,17 @@ func (p *OichoKabuCuiPresenter) Output(o interfaces.OichoKabuGame, lastErr error
 		sb.WriteString(i18n.Tf("oichokabu.betLine", "bet", strconv.Itoa(o.GetBet())) + "\n")
 	}
 
+	// Give CLI players the same guidance the web UI shows: the bet ceiling
+	// (current chips) while betting, and the draw/stand choice while drawing.
+	if !o.GetGameEndFlag() {
+		switch o.GetPhase() {
+		case domain.OichoKabuPhaseBet:
+			sb.WriteString(i18n.Tf("oichokabu.maxBetHint", "max", strconv.Itoa(o.GetChips())) + "\n")
+		case domain.OichoKabuPhaseDraw:
+			sb.WriteString(i18n.T("oichokabu.drawHint") + "\n")
+		}
+	}
+
 	if hand := o.GetPlayerHand(); len(hand) > 0 {
 		sb.WriteString("--- " + color.Bold(i18n.T("oichokabu.playerHeader")) + " ---\n")
 		sb.WriteString(i18n.Tf("oichokabu.handLine", "cards", oichoKabuHandStr(hand)) + "\n")

--- a/internal/adapter/presenter/OichoKabuCuiPresenter_test.go
+++ b/internal/adapter/presenter/OichoKabuCuiPresenter_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupOichoKabuCuiMockDefaults(m *interfaces.MockOichoKabuGame) {
@@ -35,6 +36,8 @@ func TestOichoKabuCuiPresenter_Output_BetPhase(t *testing.T) {
 	assert.Contains(t, result, "チップ: 1000")
 	assert.Contains(t, result, "BET")
 	assert.Contains(t, result, "伏せ札")
+	// Betting hint spells out the ceiling (current chips).
+	assert.Contains(t, result, i18n.Tf("oichokabu.maxBetHint", "max", "1000"))
 }
 
 func TestOichoKabuCuiPresenter_Output_Error(t *testing.T) {
@@ -63,6 +66,8 @@ func TestOichoKabuCuiPresenter_Output_DrawPhase(t *testing.T) {
 	assert.Contains(t, result, "掛け金: 100")
 	assert.Contains(t, result, "手札: 7,2")
 	assert.Contains(t, result, "伏せ札", "banker hand hidden during draw")
+	// Draw hint spells out the draw/stand choice.
+	assert.Contains(t, result, i18n.T("oichokabu.drawHint"))
 }
 
 func TestOichoKabuCuiPresenter_Output_EndWin(t *testing.T) {

--- a/internal/i18n/locales/en/oichokabu.json
+++ b/internal/i18n/locales/en/oichokabu.json
@@ -18,5 +18,7 @@
   "playerWins": "Player wins!",
   "bankerWins": "Banker wins.",
   "push": "Push.",
-  "totalPayoutLine": "total payout: {{payout}}"
+  "totalPayoutLine": "total payout: {{payout}}",
+  "maxBetHint": "Max bet: {{max}} (bet <amount> to wager)",
+  "drawHint": "draw to take a card / stand to hold"
 }

--- a/internal/i18n/locales/ja/oichokabu.json
+++ b/internal/i18n/locales/ja/oichokabu.json
@@ -18,5 +18,7 @@
   "playerWins": "子の勝ち！",
   "bankerWins": "親の勝ち。",
   "push": "引き分け (プッシュ)。",
-  "totalPayoutLine": "合計払戻し: {{payout}}"
+  "totalPayoutLine": "合計払戻し: {{payout}}",
+  "maxBetHint": "最大ベット: {{max}}（bet <額> で賭ける）",
+  "drawHint": "draw で1枚引く / stand で確定"
 }


### PR DESCRIPTION
## 概要
おいちょかぶの CUI はベット上限やドローフェーズの操作案内を出しておらず、Web 版に比べ情報が乏しかった。ベットフェーズに「最大ベット={チップ}」、ドローフェーズに「draw で引く / stand で確定」の案内行を追加する。

## 変更点
- `OichoKabuCuiPresenter.go`: フェーズ分岐で `oichokabu.maxBetHint` / `oichokabu.drawHint` を出力（ゲーム終了時は非表示）
- `internal/i18n/locales/{ja,en}/oichokabu.json`: `maxBetHint` / `drawHint` 追加
- テスト: ベット上限とドロー案内の表示を検証

Closes #3512