### PR TITLE
feat(frenchtarot): add contract-multiplier legend to the bid prompt

### DIFF
--- a/internal/adapter/presenter/FrenchTarotCuiPresenter.go
+++ b/internal/adapter/presenter/FrenchTarotCuiPresenter.go
@@ -152,6 +152,10 @@ func (p *FrenchTarotCuiPresenter) writePrompt(b *strings.Builder, g interfaces.F
 			"name", cuiPlayerName(g.GetPlayer(g.GetBidPlayerIdx()), g.GetBidPlayerIdx()),
 			"high", frenchTarotBidLabel(g.GetHighestBid())) + "\n")
 		b.WriteString(i18n.T("frenchtarot.promptBidHelp") + "\n")
+		// The contract multipliers are fixed rules; spell them out and remind the
+		// player a new bid must outrank the current highest, since the CLI has no
+		// button greying to signal it.
+		b.WriteString(i18n.T("frenchtarot.promptBidLegend") + "\n")
 	case domain.FrenchTarotPhaseChien:
 		b.WriteString(i18n.Tf("frenchtarot.promptChien",
 			"name", cuiPlayerName(g.GetPlayer(g.GetDeclarerIdx()), g.GetDeclarerIdx())) + "\n")

--- a/internal/adapter/presenter/FrenchTarotCuiPresenter_test.go
+++ b/internal/adapter/presenter/FrenchTarotCuiPresenter_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func frenchTarotCuiGame() *domain.FrenchTarot {
@@ -31,6 +32,8 @@ func TestFrenchTarotCuiPresenter_Output(t *testing.T) {
 		result := p.Output(g, nil)
 		assert.Contains(t, result, "フレンチタロット") // helpTitle
 		assert.NotEmpty(t, result)
+		// The contract-multiplier legend guides the CLI bidder.
+		assert.Contains(t, result, i18n.T("frenchtarot.promptBidLegend"))
 	})
 
 	t.Run("chien phase", func(t *testing.T) {

--- a/internal/i18n/locales/en/frenchtarot.json
+++ b/internal/i18n/locales/en/frenchtarot.json
@@ -39,5 +39,6 @@
   "hintReasonLeadLow": "You are a defender — lead a low card to conserve",
   "hintReasonFollowWin": "You can win — take the trick",
   "hintReasonFollowDuck": "Cannot/should not win — play low",
-  "hintReasonPlayExcuse": "Play the Excuse — you keep it and it cannot be captured"
+  "hintReasonPlayExcuse": "Play the Excuse — you keep it and it cannot be captured",
+  "promptBidLegend": "Contract multipliers: Petite×1 / Garde×2 / Garde-Sans×4 / Garde-Contre×6 (only a contract above the current highest bid may be bid)"
 }

--- a/internal/i18n/locales/ja/frenchtarot.json
+++ b/internal/i18n/locales/ja/frenchtarot.json
@@ -39,5 +39,6 @@
   "hintReasonLeadLow": "あなたは防御側 — 安い札でリードして温存する",
   "hintReasonFollowWin": "勝てる — トリックを取る",
   "hintReasonFollowDuck": "勝てない/取るべきでない — 低い札を出す",
-  "hintReasonPlayExcuse": "エクスキューズを出す — 自分で保持し、取られない"
+  "hintReasonPlayExcuse": "エクスキューズを出す — 自分で保持し、取られない",
+  "promptBidLegend": "契約倍率: プティット×1 / ガルド×2 / ガルド・サン×4 / ガルド・コントル×6（現在の最高ビッドを上回る契約のみ入札可）"
 }


### PR DESCRIPTION
## 概要
フレンチタロットのビッドプロンプトは現在の最高ビッドは表示していたが、各契約の倍率や「新規ビッドは最高ビッドを上回る必要がある」旨を案内していなかった（Web 版はボタン活性で示す）。固定ルールである契約倍率の凡例（プティット×1 / ガルド×2 / ガルド・サン×4 / ガルド・コントル×6）と上回り必須の注記を1行追加する。

## 変更点
- `FrenchTarotCuiPresenter.go`: ビッド段階に `frenchtarot.promptBidLegend` を追記
- `internal/i18n/locales/{ja,en}/frenchtarot.json`: `promptBidLegend` 追加
- テスト: 凡例表示を検証

Closes #3527