### PR TITLE
feat(scarto): list discardable indices and exclusion legend in scarto phase

### DIFF
--- a/internal/adapter/presenter/ScartoCuiPresenter.go
+++ b/internal/adapter/presenter/ScartoCuiPresenter.go
@@ -43,6 +43,15 @@ func scartoCuiCardStr(c *domain.Card) string {
 	}
 }
 
+// scartoCuiDiscardable は通常スカルトに出せる札か (非切り札・非エクスキューズ・非コートの
+// ピップ) を返す。ドメインの scartoDiscardable と同じ規則を提示側で再現する。
+func scartoCuiDiscardable(c *domain.Card) bool {
+	if c == nil || c.GetDesign() == domain.ScartoTrumpDesign || c.GetDesign() == domain.ScartoExcuseDesign {
+		return false
+	}
+	return c.GetValue() < domain.ScartoCourtMin
+}
+
 // scartoIndexedHand 人間手札をインデックス付きで表示する。
 func scartoIndexedHand(p *domain.ScartoPlayer) string {
 	parts := make([]string, p.GetCardsSize())
@@ -131,9 +140,27 @@ func (p *ScartoCuiPresenter) Output(g interfaces.ScartoGame, lastErr error) stri
 func (p *ScartoCuiPresenter) writePrompt(b *strings.Builder, g interfaces.ScartoGame) {
 	switch g.GetPhase() {
 	case domain.ScartoPhaseScarto:
+		dealerIdx := g.GetDealerIdx()
 		b.WriteString(i18n.Tf("scarto.promptScarto",
-			"name", cuiPlayerName(g.GetPlayer(g.GetDealerIdx()), g.GetDealerIdx())) + "\n")
+			"name", cuiPlayerName(g.GetPlayer(dealerIdx), dealerIdx)) + "\n")
 		b.WriteString(i18n.T("scarto.promptScartoHelp") + "\n")
+		// The web UI disables trumps/Excuse/courts; on the CLI, spell out which
+		// of the human dealer's cards may actually be discarded, plus the legend
+		// of excluded kinds so the choice isn't trial-and-error.
+		if dealer := g.GetPlayer(dealerIdx); dealer != nil && dealer.GetIsHuman() {
+			var idxs []string
+			for i := 0; i < dealer.GetCardsSize(); i++ {
+				if scartoCuiDiscardable(dealer.GetCard(i)) {
+					idxs = append(idxs, "["+strconv.Itoa(i)+"]"+scartoCuiCardStr(dealer.GetCard(i)))
+				}
+			}
+			list := strings.Join(idxs, "  ")
+			if list == "" {
+				list = i18n.T("scarto.discardableNone")
+			}
+			b.WriteString(i18n.Tf("scarto.discardableList", "cards", list) + "\n")
+			b.WriteString(i18n.T("scarto.discardableLegend") + "\n")
+		}
 	case domain.ScartoPhasePlay:
 		currentIdx := g.GetCurrentPlayerIdx()
 		b.WriteString(i18n.Tf("scarto.promptPlay",

--- a/internal/adapter/presenter/ScartoCuiPresenter_test.go
+++ b/internal/adapter/presenter/ScartoCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func scartoCuiGame() *domain.Scarto {
@@ -30,6 +32,21 @@ func TestScartoCuiPresenter_Output(t *testing.T) {
 		result := p.Output(g, nil)
 		assert.Contains(t, result, "スカルト") // helpTitle
 		assert.NotEmpty(t, result)
+		// The discardable list and the excluded-kinds legend both appear.
+		assert.Contains(t, result, i18n.T("scarto.discardableLegend"))
+		discardablePrefix := strings.SplitN(i18n.T("scarto.discardableList"), "{{", 2)[0]
+		assert.Contains(t, result, discardablePrefix)
+	})
+
+	t.Run("scarto phase with no discardable cards shows none", func(t *testing.T) {
+		g := scartoCuiGame()
+		dealer := g.GetPlayer(g.GetDealerIdx())
+		dealer.Reset()
+		// A hand of only trumps has nothing legally discardable.
+		dealer.AddCard(domain.NewCard(domain.ScartoTrumpDesign, 3, false))
+		dealer.AddCard(domain.NewCard(domain.ScartoTrumpDesign, 8, false))
+		result := p.Output(g, nil)
+		assert.Contains(t, result, i18n.Tf("scarto.discardableList", "cards", i18n.T("scarto.discardableNone")))
 	})
 
 	t.Run("play phase renders trump and excuse", func(t *testing.T) {

--- a/internal/i18n/locales/en/scarto.json
+++ b/internal/i18n/locales/en/scarto.json
@@ -27,5 +27,8 @@
   "hintReasonLeadLow": "Lead a low card to conserve your point cards",
   "hintReasonFollowWin": "You can win — take the trick to gather points",
   "hintReasonFollowDuck": "Cannot win — throw a low card",
-  "hintReasonPlayExcuse": "Play the Excuse — you keep it and it cannot be captured"
+  "hintReasonPlayExcuse": "Play the Excuse — you keep it and it cannot be captured",
+  "discardableList": "Discardable: {{cards}}",
+  "discardableNone": "none",
+  "discardableLegend": "Note: trumps, the Excuse, and court cards cannot be discarded"
 }

--- a/internal/i18n/locales/ja/scarto.json
+++ b/internal/i18n/locales/ja/scarto.json
@@ -27,5 +27,8 @@
   "hintReasonLeadLow": "安い札でリードして点札を温存する",
   "hintReasonFollowWin": "勝てる — トリックを取って点を集める",
   "hintReasonFollowDuck": "勝てない — 低い札を捨てる",
-  "hintReasonPlayExcuse": "エクスキューズを出す — 自分で保持し、取られない"
+  "hintReasonPlayExcuse": "エクスキューズを出す — 自分で保持し、取られない",
+  "discardableList": "捨て可能: {{cards}}",
+  "discardableNone": "なし",
+  "discardableLegend": "※ 切り札・エクスキューズ・絵札は捨てられません"
 }


### PR DESCRIPTION
## 概要
スカルトの捨て札段階は汎用ヘルプのみで、「捨てられるのは 0.5 点ピップ札のみ、切り札・エクスキューズ・絵札は不可」という制約が CLI から分からなかった。人間ディーラーの手札から捨て可能なインデックス（ドメインの `scartoDiscardable` と同一規則）を列挙し、捨て不可種別の凡例を添える。

## 変更点
- `ScartoCuiPresenter.go`: `scartoCuiDiscardable` を追加し、スカルト段階で捨て可能一覧＋凡例を出力（該当なしは「なし」表示）
- `internal/i18n/locales/{ja,en}/scarto.json`: `discardableList` / `discardableNone` / `discardableLegend` 追加
- テスト: 一覧・凡例の表示と「なし」分岐を検証

Closes #3533