### PR TITLE
feat(koenigrufen): explain talon-bury constraints in the exchange prompt

### DIFF
--- a/internal/adapter/presenter/KoenigrufenCuiPresenter.go
+++ b/internal/adapter/presenter/KoenigrufenCuiPresenter.go
@@ -159,6 +159,10 @@ func (p *KoenigrufenCuiPresenter) writePrompt(b *strings.Builder, g interfaces.K
 		b.WriteString(i18n.Tf("koenigrufen.promptTalon",
 			"name", cuiPlayerName(g.GetPlayer(g.GetDeclarerIdx()), g.GetDeclarerIdx())) + "\n")
 		b.WriteString(i18n.T("koenigrufen.promptTalonHelp") + "\n")
+		// The web UI greys out cards that can't be buried; on the CLI, state the
+		// fill constraints (Kings and the trull honours are never buriable, plain
+		// trumps only when short of plain-suit cards) so the choice isn't guesswork.
+		b.WriteString(i18n.T("koenigrufen.promptTalonLegend") + "\n")
 	case domain.KoenigrufenPhasePlay:
 		currentIdx := g.GetCurrentPlayerIdx()
 		b.WriteString(i18n.Tf("koenigrufen.promptPlay",

--- a/internal/adapter/presenter/KoenigrufenCuiPresenter_test.go
+++ b/internal/adapter/presenter/KoenigrufenCuiPresenter_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func koenigrufenCuiGame() *domain.Koenigrufen {
@@ -49,6 +50,8 @@ func TestKoenigrufenCuiPresenter_Output(t *testing.T) {
 		g.SetPhase(domain.KoenigrufenPhaseTalon)
 		result := p.Output(g, nil)
 		assert.Contains(t, result, "場札交換")
+		// The bury-constraint legend guides the CLI player.
+		assert.Contains(t, result, i18n.T("koenigrufen.promptTalonLegend"))
 	})
 
 	t.Run("play phase renders trump and skus", func(t *testing.T) {

--- a/internal/i18n/locales/en/koenigrufen.json
+++ b/internal/i18n/locales/en/koenigrufen.json
@@ -41,5 +41,6 @@
   "hintReasonLeadHigh": "You are on the declarer's side — lead a strong card to take control",
   "hintReasonLeadLow": "You are an opponent — lead a low card to conserve",
   "hintReasonFollowWin": "You can win — take the trick",
-  "hintReasonFollowDuck": "Cannot/should not win — play low"
+  "hintReasonFollowDuck": "Cannot/should not win — play low",
+  "promptTalonLegend": "Cannot bury: Kings and the trull (Pagat/XXI/Sküs). Plain trumps only when fewer than 6 buriable plain cards remain."
 }

--- a/internal/i18n/locales/ja/koenigrufen.json
+++ b/internal/i18n/locales/ja/koenigrufen.json
@@ -41,5 +41,6 @@
   "hintReasonLeadHigh": "あなたはデクレアラー側 — 強い札でリードして主導権を取る",
   "hintReasonLeadLow": "あなたは対戦側 — 安い札でリードして温存する",
   "hintReasonFollowWin": "勝てる — トリックを取る",
-  "hintReasonFollowDuck": "勝てない/取るべきでない — 低い札を出す"
+  "hintReasonFollowDuck": "勝てない/取るべきでない — 低い札を出す",
+  "promptTalonLegend": "埋め不可: キング・トゥルル（パガト/XXI/スキュース）。平トランプは埋められる平札が6枚未満のときのみ可。"
 }


### PR DESCRIPTION
## 概要
ケーニッヒルーフェンのタロン交換段階は枚数案内のみで、Web 版 `makeUndiscardable` が実装する埋め制約が CLI から分からなかった。ドメインの `validateDiscards` と一致する凡例（王・トゥルル名誉札[パガト/XXI/スキュース]は埋め不可、平トランプは埋められる平札が6枚未満のときのみ可）を1行追加する。

## 変更点
- `KoenigrufenCuiPresenter.go`: タロン段階に `koenigrufen.promptTalonLegend` を追記
- `internal/i18n/locales/{ja,en}/koenigrufen.json`: `promptTalonLegend` 追加
- テスト: 凡例表示を検証

Closes #3530