### PR TITLE
feat(acesup): mark removable/movable top cards in the CUI

### DIFF
--- a/internal/adapter/presenter/AcesUpCuiPresenter.go
+++ b/internal/adapter/presenter/AcesUpCuiPresenter.go
@@ -31,6 +31,15 @@ func (pr *AcesUpCuiPresenter) Output(g interfaces.AcesUpGame, lastErr error) str
 					}
 					if i == len(col)-1 {
 						b.WriteString(i18n.Tf("acesup.topCard", "card", cuiCardStr(card)))
+						// Mirror the web UI's enabled/draggable state: mark a top card
+						// removable (*) when a higher same-suit card sits elsewhere, and
+						// movable (>) only when an empty column exists to receive it.
+						if g.CanRemove(c) {
+							b.WriteString(color.Green("*"))
+						}
+						if g.CanMove(c) {
+							b.WriteString(color.Yellow(">"))
+						}
 					} else {
 						b.WriteString(cuiCardStr(card))
 					}
@@ -43,6 +52,7 @@ func (pr *AcesUpCuiPresenter) Output(g interfaces.AcesUpGame, lastErr error) str
 		b.WriteString(i18n.Tf("acesup.stockLine", "count", strconv.Itoa(g.GetStockCount())))
 		b.WriteString(i18n.Tf("acesup.discardLine", "count", strconv.Itoa(g.GetDiscardCount())))
 		b.WriteString("\n")
+		b.WriteString(i18n.T("acesup.markerLegend") + "\n")
 		b.WriteString("----------\n")
 
 		cuiErrorBlock(b, lastErr)

--- a/internal/adapter/presenter/AcesUpCuiPresenter_test.go
+++ b/internal/adapter/presenter/AcesUpCuiPresenter_test.go
@@ -7,9 +7,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupAcesUpCuiMockDefaults(g *interfaces.MockAcesUpGame) {
@@ -19,6 +23,8 @@ func setupAcesUpCuiMockDefaults(g *interfaces.MockAcesUpGame) {
 	g.On("GetDiscardCount").Return(4).Maybe()
 	g.On("IsStalemate").Return(false).Maybe()
 	g.On("GetColumns").Return(sampleAcesUpColumns()).Maybe()
+	g.On("CanRemove", mock.AnythingOfType("int")).Return(false).Maybe()
+	g.On("CanMove", mock.AnythingOfType("int")).Return(false).Maybe()
 }
 
 func TestAcesUpCuiPresenterOutput_Playing(t *testing.T) {
@@ -32,6 +38,35 @@ func TestAcesUpCuiPresenterOutput_Playing(t *testing.T) {
 	assert.Contains(t, result, "Discard: 4枚")
 	assert.Contains(t, result, "手数: 0")
 	assert.Contains(t, result, "[空]") // col2 is empty
+}
+
+func TestAcesUpCuiPresenterOutput_TopCardMarkers(t *testing.T) {
+	g := new(interfaces.MockAcesUpGame)
+	g.On("GetPhase").Return(domain.AcesUpPhasePlaying).Maybe()
+	g.On("GetMoveCount").Return(0).Maybe()
+	g.On("GetStockCount").Return(44).Maybe()
+	g.On("GetDiscardCount").Return(4).Maybe()
+	g.On("IsStalemate").Return(false).Maybe()
+	g.On("GetColumns").Return(sampleAcesUpColumns()).Maybe()
+	// Column 0 top card is removable; column 1 top card is movable.
+	g.On("CanRemove", 0).Return(true)
+	g.On("CanMove", 0).Return(false)
+	g.On("CanRemove", 1).Return(false)
+	g.On("CanMove", 1).Return(true)
+	g.On("CanRemove", mock.AnythingOfType("int")).Return(false).Maybe()
+	g.On("CanMove", mock.AnythingOfType("int")).Return(false).Maybe()
+
+	orig := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(orig)
+
+	p := &AcesUpCuiPresenter{}
+	result := p.Output(g, nil)
+	// The markers attach to the top-card bracket ("]*" / "]>"), distinguishing
+	// them from the "* =" / "> =" glyphs in the always-present legend line.
+	assert.Contains(t, result, "]*") // removable marker on col 0's top card
+	assert.Contains(t, result, "]>") // movable marker on col 1's top card
+	assert.Contains(t, result, i18n.T("acesup.markerLegend"))
 }
 
 func TestAcesUpCuiPresenterOutput_Error(t *testing.T) {

--- a/internal/i18n/locales/en/acesup.json
+++ b/internal/i18n/locales/en/acesup.json
@@ -13,5 +13,6 @@
   "hintRemove": "Hint: remove column {{col}}",
   "hintMove": "Hint: move column {{col}} to an empty column",
   "hintDraw": "Hint: deal a card to each column",
-  "hintUnknown": "Hint: unknown"
+  "hintUnknown": "Hint: unknown",
+  "markerLegend": "Markers: * = removable / > = movable to an empty column"
 }

--- a/internal/i18n/locales/ja/acesup.json
+++ b/internal/i18n/locales/ja/acesup.json
@@ -13,5 +13,6 @@
   "hintRemove": "ヒント: カード除去: 列{{col}}",
   "hintMove": "ヒント: 列{{col}}を空き列へ移動",
   "hintDraw": "ヒント: 各列にカードを配ってください",
-  "hintUnknown": "ヒント: 不明"
+  "hintUnknown": "ヒント: 不明",
+  "markerLegend": "マーカー: * = 捨て可能 / > = 空き列へ移動可能"
 }


### PR DESCRIPTION
## 概要
四つ葉のクローバー（Aces Up）の CUI は最上段カードが除去可能/移動可能かを示していなかった（Web 版 `AcesUpPage` は `removable`/`movable` フラグでボタン活性・draggable を制御）。ドメインの `CanRemove`/`CanMove` を介し、除去可能な最上段に `*`、空き列がある移動可能なカードに `>` のマーカーを付け、stock 行付近に凡例を追加する。

## 変更点
- `AcesUpCuiPresenter.go`: 最上段カードに `*`（除去可能）/`>`（移動可能）マーカー＋ `acesup.markerLegend` 凡例
- `internal/i18n/locales/{ja,en}/acesup.json`: `markerLegend` 追加
- テスト: マーカー表示（`]*`/`]>`）と凡例を検証

Closes #3348