### PR TITLE
feat(fourcardpoker): itemize the end-of-hand payout breakdown in the CUI

### DIFF
--- a/internal/adapter/presenter/FourCardPokerCuiPresenter.go
+++ b/internal/adapter/presenter/FourCardPokerCuiPresenter.go
@@ -105,6 +105,21 @@ func (p *FourCardPokerCuiPresenter) Output(g interfaces.FourCardPokerGame, lastE
 			sb.WriteString(color.Yellow(i18n.T("fourcardpoker.push")) + "\n")
 		default:
 		}
+		// Break the total down by payout bucket (matching the web breakdown);
+		// list only the non-zero buckets, as the web UI does.
+		for _, item := range []struct {
+			key    string
+			amount int
+		}{
+			{"fourcardpoker.antePayoutLine", g.GetAntePayout()},
+			{"fourcardpoker.playPayoutLine", g.GetPlayPayout()},
+			{"fourcardpoker.anteBonusPayoutLine", g.GetAnteBonusPayout()},
+			{"fourcardpoker.acesUpPayoutLine", g.GetAcesUpPayout()},
+		} {
+			if item.amount != 0 {
+				sb.WriteString(i18n.Tf(item.key, "payout", strconv.Itoa(item.amount)) + "\n")
+			}
+		}
 		sb.WriteString(i18n.Tf("fourcardpoker.totalPayoutLine", "payout", strconv.Itoa(g.GetTotalPayout())) + "\n")
 		sb.WriteString("----------\n")
 	}

--- a/internal/adapter/presenter/FourCardPokerCuiPresenter_test.go
+++ b/internal/adapter/presenter/FourCardPokerCuiPresenter_test.go
@@ -1,12 +1,14 @@
 package presenter
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupFourCardPokerCuiMockDefaults(m *interfaces.MockFourCardPokerGame) {
@@ -132,6 +134,12 @@ func TestFourCardPokerCuiPresenter_Output_EndPhase_PlayerWins(t *testing.T) {
 	assert.Contains(t, result, "フェーズ: END")
 	assert.Contains(t, result, "プレイヤーの勝ち")
 	assert.Contains(t, result, "合計払戻し: 600")
+	// Non-zero buckets are itemized; the zero Aces Up bucket is omitted.
+	assert.Contains(t, result, i18n.Tf("fourcardpoker.antePayoutLine", "payout", "200"))
+	assert.Contains(t, result, i18n.Tf("fourcardpoker.playPayoutLine", "payout", "200"))
+	assert.Contains(t, result, i18n.Tf("fourcardpoker.anteBonusPayoutLine", "payout", "200"))
+	acesUpPrefix := strings.SplitN(i18n.T("fourcardpoker.acesUpPayoutLine"), "{{", 2)[0]
+	assert.NotContains(t, result, acesUpPrefix)
 }
 
 func TestFourCardPokerCuiPresenter_Output_EndPhase_Fold(t *testing.T) {

--- a/internal/i18n/locales/en/fourcardpoker.json
+++ b/internal/i18n/locales/en/fourcardpoker.json
@@ -20,5 +20,9 @@
   "dealerWins": "Dealer wins!",
   "playerFolded": "Player folded.",
   "push": "Push!",
-  "totalPayoutLine": "total payout: {{payout}}"
+  "totalPayoutLine": "total payout: {{payout}}",
+  "antePayoutLine": "Ante payout: {{payout}}",
+  "playPayoutLine": "Play payout: {{payout}}",
+  "anteBonusPayoutLine": "Ante bonus: {{payout}}",
+  "acesUpPayoutLine": "Aces Up: {{payout}}"
 }

--- a/internal/i18n/locales/ja/fourcardpoker.json
+++ b/internal/i18n/locales/ja/fourcardpoker.json
@@ -20,5 +20,9 @@
   "dealerWins": "ディーラーの勝ち！",
   "playerFolded": "プレイヤーがフォールド。",
   "push": "プッシュ！",
-  "totalPayoutLine": "合計払戻し: {{payout}}"
+  "totalPayoutLine": "合計払戻し: {{payout}}",
+  "antePayoutLine": "アンテ払戻し: {{payout}}",
+  "playPayoutLine": "プレイ払戻し: {{payout}}",
+  "anteBonusPayoutLine": "アンテボーナス: {{payout}}",
+  "acesUpPayoutLine": "エースアップ: {{payout}}"
 }


### PR DESCRIPTION
## 概要
フォーカードポーカーの終了ブロックは合計払戻しのみ表示していた。Web 版 `FourCardPokerPage` の `payout-breakdown` と同様に、Ante/Play/Ante ボーナス/Aces Up の各枠を項目別に表示する（0 の枠は非表示、Web と同挙動）。

## 変更点
- `FourCardPokerCuiPresenter.go`: 終了ブロックに 0 でないペイアウト項目行（`antePayoutLine`/`playPayoutLine`/`anteBonusPayoutLine`/`acesUpPayoutLine`）を追加
- `internal/i18n/locales/{ja,en}/fourcardpoker.json`: 4 キー追加
- テスト: 非0項目の列挙と 0 の Aces Up 非表示を検証

Closes #3318