### PR TITLE
feat(tienlen): unify error display and name the table combo type in the CUI

### DIFF
--- a/internal/adapter/presenter/TienLenCuiPresenter.go
+++ b/internal/adapter/presenter/TienLenCuiPresenter.go
@@ -30,6 +30,26 @@ func tienLenPlayerStr(player *domain.TienLenPlayer, i int) string {
 	return b.String()
 }
 
+// tienLenPlayTypeLabel returns the i18n label for a table combo type.
+func tienLenPlayTypeLabel(pt domain.TienLenPlayType) string {
+	switch pt {
+	case domain.TienLenPlaySingle:
+		return i18n.T("tienlen.comboSingle")
+	case domain.TienLenPlayPair:
+		return i18n.T("tienlen.comboPair")
+	case domain.TienLenPlayTriple:
+		return i18n.T("tienlen.comboTriple")
+	case domain.TienLenPlayStraight:
+		return i18n.T("tienlen.comboStraight")
+	case domain.TienLenPlayThreePairRun:
+		return i18n.T("tienlen.comboThreePairRun")
+	case domain.TienLenPlayFourOfAKind:
+		return i18n.T("tienlen.comboFourOfAKind")
+	default:
+		return i18n.T("tienlen.comboInvalid")
+	}
+}
+
 // TienLenCuiPresenter renders the Tien Len CUI view.
 type TienLenCuiPresenter struct{}
 
@@ -43,10 +63,16 @@ func (p *TienLenCuiPresenter) Output(tg interfaces.TienLenGame, lastErr error) s
 		b.WriteString("----------\n")
 
 		if tg.GetTableCards() != nil {
-			b.WriteString(i18n.T("tienlen.tableCards") + ": " + cuiCardSliceStr(tg.GetTableCards()) + "\n")
+			// Name the combo on the table (pair/straight/…) so the player knows
+			// what shape they must beat, matching the web tableCombo display.
+			b.WriteString(i18n.T("tienlen.tableCards") + ": " + cuiCardSliceStr(tg.GetTableCards()) +
+				" " + i18n.Tf("tienlen.tableComboType", "type", tienLenPlayTypeLabel(tg.GetTablePlayType())) + "\n")
 		} else {
 			b.WriteString(i18n.T("tienlen.tableEmpty") + "\n")
 		}
+
+		// Unify error display with other presenters (red, right after the board).
+		cuiErrorBlock(b, lastErr)
 
 		if tg.GetGameEndFlag() {
 			b.WriteString(i18n.T("tienlen.gameEnd") + "\n")
@@ -78,10 +104,6 @@ func (p *TienLenCuiPresenter) Output(tg interfaces.TienLenGame, lastErr error) s
 				// (and self-diagnose an invalid combo shown in the error line).
 				b.WriteString(i18n.T("tienlen.comboRulesHint") + "\n")
 			}
-		}
-
-		if lastErr != nil {
-			b.WriteString(lastErr.Error() + "\n")
 		}
 	})
 }

--- a/internal/adapter/presenter/TienLenCuiPresenter_test.go
+++ b/internal/adapter/presenter/TienLenCuiPresenter_test.go
@@ -100,6 +100,35 @@ func TestTienLenCuiPresenter_Output(t *testing.T) {
 	})
 }
 
+func TestTienLenCuiPresenter_Output_AllComboTypeLabels(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+	p := new(presenter.TienLenCuiPresenter)
+
+	// Every table combo type renders its own localized label.
+	for _, tc := range []struct {
+		playType domain.TienLenPlayType
+		labelKey string
+	}{
+		{domain.TienLenPlaySingle, "tienlen.comboSingle"},
+		{domain.TienLenPlayPair, "tienlen.comboPair"},
+		{domain.TienLenPlayTriple, "tienlen.comboTriple"},
+		{domain.TienLenPlayStraight, "tienlen.comboStraight"},
+		{domain.TienLenPlayThreePairRun, "tienlen.comboThreePairRun"},
+		{domain.TienLenPlayFourOfAKind, "tienlen.comboFourOfAKind"},
+		{domain.TienLenPlayInvalid, "tienlen.comboInvalid"},
+	} {
+		m, _ := setupTienLenCuiMock()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetTableCards")
+		m.On("GetTableCards").Return([]*domain.Card{domain.NewCard(domain.CardDesignSpade, 3, false)})
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetTablePlayType")
+		m.On("GetTablePlayType").Return(tc.playType)
+		result := p.Output(m, nil)
+		assert.Contains(t, result, i18n.Tf("tienlen.tableComboType", "type", i18n.T(tc.labelKey)))
+	}
+}
+
 func TestTienLenCuiPresenter_ActionLogOutput(t *testing.T) {
 	origNoColor := color.NoColor()
 	color.SetNoColor(true)

--- a/internal/adapter/presenter/TienLenCuiPresenter_test.go
+++ b/internal/adapter/presenter/TienLenCuiPresenter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupTienLenCuiMock() (*interfaces.MockTienLenGame, []*domain.TienLenPlayer) {
@@ -19,6 +20,7 @@ func setupTienLenCuiMock() (*interfaces.MockTienLenGame, []*domain.TienLenPlayer
 	players := makeTienLenPlayers()
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetTableCards").Return(([]*domain.Card)(nil))
+	m.On("GetTablePlayType").Return(domain.TienLenPlayInvalid)
 	m.On("GetCpuActions").Return(([]*domain.TienLenAction)(nil))
 	m.On("IsHumanTurn").Return(true)
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
@@ -60,6 +62,8 @@ func TestTienLenCuiPresenter_Output(t *testing.T) {
 		m, _ := setupTienLenCuiMock()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetTableCards")
 		m.On("GetTableCards").Return([]*domain.Card{domain.NewCard(domain.CardDesignSpade, 3, false)})
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetTablePlayType")
+		m.On("GetTablePlayType").Return(domain.TienLenPlaySingle)
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCpuActions")
 		m.On("GetCpuActions").Return([]*domain.TienLenAction{
 			{PlayerIdx: 1, PlayedCards: nil},
@@ -68,6 +72,8 @@ func TestTienLenCuiPresenter_Output(t *testing.T) {
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "場")
 		assert.Contains(t, result, "CPU 1")
+		// The table combo type is named alongside the cards.
+		assert.Contains(t, result, i18n.Tf("tienlen.tableComboType", "type", i18n.T("tienlen.comboSingle")))
 	})
 
 	t.Run("finished player shown", func(t *testing.T) {

--- a/internal/i18n/locales/en/tienlen.json
+++ b/internal/i18n/locales/en/tienlen.json
@@ -11,5 +11,13 @@
   "playerYou": "You",
   "yourTurn": "Your turn",
   "comboRulesHint": "Ranks: run > triple > pair > single. Match the table's count and type and beat its rank (runs compare by length then top rank).",
-  "actionPass": "pass"
+  "actionPass": "pass",
+  "tableComboType": "[combo: {{type}}]",
+  "comboSingle": "Single",
+  "comboPair": "Pair",
+  "comboTriple": "Triple",
+  "comboStraight": "Straight",
+  "comboThreePairRun": "Three-pair run",
+  "comboFourOfAKind": "Four of a kind",
+  "comboInvalid": "Unknown"
 }

--- a/internal/i18n/locales/ja/tienlen.json
+++ b/internal/i18n/locales/ja/tienlen.json
@@ -11,5 +11,13 @@
   "playerYou": "あなた",
   "yourTurn": "あなたのターンです",
   "comboRulesHint": "役: 連番>3カード>ペア>シングル。場と同じ枚数・同じ種類で、より強いランクのみ出せます（連番は同枚数で最高ランク比較）。",
-  "actionPass": "パス"
+  "actionPass": "パス",
+  "tableComboType": "[型: {{type}}]",
+  "comboSingle": "シングル",
+  "comboPair": "ペア",
+  "comboTriple": "トリプル",
+  "comboStraight": "ストレート",
+  "comboThreePairRun": "3連ペア",
+  "comboFourOfAKind": "フォーカード",
+  "comboInvalid": "不明"
 }


### PR DESCRIPTION
## 概要
ティエンレンの CUI はエラーを素のテキストで末尾に出力し、共通ヘルパー `cuiErrorBlock`（赤色・位置統一）を使っていなかった。またテーブル表示にコンボ型名が無く、何を上回れば出せるか分かりにくかった。(1) エラーを `cuiErrorBlock` に統一し区切り線直後に配置、(2) `GetTablePlayType()` を用いてテーブルカードにコンボ型名（シングル/ペア/ストレート等）を併記する。

## 変更点
- `TienLenCuiPresenter.go`: `cuiErrorBlock` 化＋ `tienLenPlayTypeLabel` でテーブル行に型名併記
- `internal/i18n/locales/{ja,en}/tienlen.json`: `tableComboType` + コンボ型名 7 キー追加
- テスト: 型名併記を検証、既存エラーテストは維持

Closes #3360