### PR TITLE
feat(loo): list looed players and per-player chip deltas at round end

### DIFF
--- a/internal/adapter/presenter/LooCuiPresenter.go
+++ b/internal/adapter/presenter/LooCuiPresenter.go
@@ -23,6 +23,14 @@ func looTrumpLabel(suit int) string {
 	return suitNames[suit]
 }
 
+// looSignedInt は符号付きでチップ増減を表示する (正なら "+" を前置)。
+func looSignedInt(n int) string {
+	if n > 0 {
+		return "+" + strconv.Itoa(n)
+	}
+	return strconv.Itoa(n)
+}
+
 // looPlayingLabel は参加状態の表示を返す。
 func looPlayingLabel(playing bool) string {
 	if playing {
@@ -84,6 +92,24 @@ func (p *LooCuiPresenter) Output(g interfaces.LooGame, lastErr error) string {
 			b.WriteString(i18n.T("loo.promptTrickEnd") + "\n")
 		case domain.LooPhaseRoundEnd:
 			b.WriteString(i18n.T("loo.promptRoundEnd") + "\n")
+			if det := g.GetLastDealDetail(); det != nil {
+				// Name who was looed (penalised) and show each player's chip change
+				// this deal, matching the web round-result breakdown.
+				if len(det.Looed) > 0 {
+					names := make([]string, len(det.Looed))
+					for i, idx := range det.Looed {
+						names[i] = cuiPlayerName(g.GetPlayer(idx), idx)
+					}
+					b.WriteString(color.Red(i18n.Tf("loo.looedList",
+						"names", strings.Join(names, ", "))) + "\n")
+				}
+				for i := 0; i < g.GetPlayerCnt(); i++ {
+					delta := det.Gained[i] // 0 when the player didn't participate
+					b.WriteString(i18n.Tf("loo.chipDeltaLine",
+						"name", cuiPlayerName(g.GetPlayer(i), i),
+						"delta", looSignedInt(delta)) + "\n")
+				}
+			}
 		}
 		b.WriteString(i18n.T("loo.promptHelp") + "\n")
 	})

--- a/internal/adapter/presenter/LooCuiPresenter_test.go
+++ b/internal/adapter/presenter/LooCuiPresenter_test.go
@@ -2,12 +2,15 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func TestLooCuiPresenter_Output_DecidePhase(t *testing.T) {
@@ -41,6 +44,28 @@ func TestLooCuiPresenter_Output_AllPhases(t *testing.T) {
 
 	// エラー出力。
 	assert.NotEmpty(t, p.Output(g, errors.New("boom")))
+}
+
+func TestLooCuiPresenter_Output_RoundEndShowsLooed(t *testing.T) {
+	g := domain.NewDefaultLoo()
+	g.Reset()
+	// Two players in; player 1 takes zero tricks and is looed.
+	g.GetPlayer(0).SetPlaying(true)
+	g.GetPlayer(1).SetPlaying(true)
+	g.GetPlayer(2).SetPlaying(false)
+	g.GetPlayer(3).SetPlaying(false)
+	g.SetRoundTricks([domain.LooPlayerCnt]int{domain.LooTrickCount, 0, 0, 0})
+	g.SetPhase(domain.LooPhaseRoundEnd)
+	g.ScoreRound()
+	require.NotNil(t, g.GetLastDealDetail())
+	require.Contains(t, g.GetLastDealDetail().Looed, 1)
+
+	p := new(presenter.LooCuiPresenter)
+	out := p.Output(g, nil)
+	looedPrefix := strings.SplitN(i18n.T("loo.looedList"), "{{", 2)[0]
+	assert.Contains(t, out, looedPrefix)
+	// Player 0 swept the pot, so their chip delta is shown with a + sign.
+	assert.Contains(t, out, "+")
 }
 
 func TestLooCuiPresenter_HintOutput(t *testing.T) {

--- a/internal/i18n/locales/en/loo.json
+++ b/internal/i18n/locales/en/loo.json
@@ -21,5 +21,7 @@
   "hintReasonLeadHigh": "Lead with a strong card to take control",
   "hintReasonFollowWin": "Play a winning card to take the trick",
   "hintReasonDiscardLow": "Can't win — discard a low card",
-  "result.chips": "Deal over! Chips: {{chips}}"
+  "result.chips": "Deal over! Chips: {{chips}}",
+  "looedList": "Looed (penalised): {{names}}",
+  "chipDeltaLine": "  {{name}}: {{delta}}"
 }

--- a/internal/i18n/locales/ja/loo.json
+++ b/internal/i18n/locales/ja/loo.json
@@ -21,5 +21,7 @@
   "hintReasonLeadHigh": "強い札でリードして主導権を握る",
   "hintReasonFollowWin": "勝てる札を出してトリックを取る",
   "hintReasonDiscardLow": "取れないので低い札を捨てる",
-  "result.chips": "ディール終了！ チップ: {{chips}}"
+  "result.chips": "ディール終了！ チップ: {{chips}}",
+  "looedList": "ルー（罰）: {{names}}",
+  "chipDeltaLine": "  {{name}}: {{delta}}"
 }


### PR DESCRIPTION
## 概要
ルーのラウンド終了は固定文言のみで、参加したのにトリック0で罰（looed）になったプレイヤーや各自のチップ増減が CUI に出ていなかった。Web 版 `LooPage` の round-result 内訳と同様に、looed プレイヤー一覧（赤字）と各プレイヤーのチップ増減を `GetLastDealDetail()`（`.Looed`/`.Gained`）から表示する。

## 変更点
- `LooCuiPresenter.go`: RoundEnd に looed 一覧＋符号付きチップ増減行（`looSignedInt`）を追加
- `internal/i18n/locales/{ja,en}/loo.json`: `looedList` / `chipDeltaLine` 追加
- テスト: 実精算（ScoreRound）を駆動し looed 表示と増減を検証

Closes #3624