### PR TITLE
feat(egyptianratscrew): show chance responder and trigger card in the CUI

### DIFF
--- a/internal/adapter/presenter/EgyptianRatscrewCuiPresenter.go
+++ b/internal/adapter/presenter/EgyptianRatscrewCuiPresenter.go
@@ -42,6 +42,16 @@ func (p *EgyptianRatscrewCuiPresenter) Output(g interfaces.EgyptianRatscrewGame,
 		if g.GetChanceRemaining() > 0 {
 			b.WriteString(color.Yellow(i18n.Tf("egyptianratscrew.promptChance",
 				"count", strconv.Itoa(g.GetChanceRemaining()))) + "\n")
+			// Name who must answer the chance (web shows chanceResponder) and, when
+			// a face card currently sits on top, which card is demanding it.
+			responder := i18n.T("egyptianratscrew.responderCpu")
+			if g.GetCurrentTurnIdx() == 0 {
+				responder = i18n.T("egyptianratscrew.responderHuman")
+			}
+			b.WriteString(i18n.Tf("egyptianratscrew.chanceResponder", "name", responder) + "\n")
+			if c := g.GetTopCard(); c != nil && g.IsTopFaceCard() {
+				b.WriteString(i18n.Tf("egyptianratscrew.chanceTrigger", "card", cuiCardStr(c)) + "\n")
+			}
 		}
 		if g.IsSlappable() {
 			b.WriteString(color.Yellow(i18n.T("egyptianratscrew.promptSlappable")) + "\n")

--- a/internal/adapter/presenter/EgyptianRatscrewCuiPresenter_test.go
+++ b/internal/adapter/presenter/EgyptianRatscrewCuiPresenter_test.go
@@ -5,6 +5,7 @@ package presenter_test
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func TestEgyptianRatscrewCuiPresenter_Output(t *testing.T) {
@@ -105,9 +107,17 @@ func TestEgyptianRatscrewCuiPresenter_Output(t *testing.T) {
 		_ = json.Unmarshal(data, &raw)
 		raw["cr"], _ = json.Marshal(2)
 		raw["ci"], _ = json.Marshal(0)
+		raw["ct"], _ = json.Marshal(0) // human must answer the chance
+		// A King sits on top, so the trigger line renders.
+		raw["cp"], _ = json.Marshal([]*domain.Card{domain.NewCard(domain.CardDesignSpade, 13, true)})
 		newData, _ := json.Marshal(raw)
 		_ = json.Unmarshal(newData, g)
-		assert.Contains(t, p.Output(g, nil), "チャンスバトル中")
+		out := p.Output(g, nil)
+		assert.Contains(t, out, "チャンスバトル中")
+		assert.Contains(t, out, i18n.Tf("egyptianratscrew.chanceResponder",
+			"name", i18n.T("egyptianratscrew.responderHuman")))
+		triggerPrefix := strings.SplitN(i18n.T("egyptianratscrew.chanceTrigger"), "{{", 2)[0]
+		assert.Contains(t, out, triggerPrefix)
 	})
 
 	t.Run("last event correct slap (pair) by human", func(t *testing.T) {

--- a/internal/i18n/locales/en/egyptianratscrew.json
+++ b/internal/i18n/locales/en/egyptianratscrew.json
@@ -26,5 +26,9 @@
   "chanceWinCpu": "CPU won the chance battle and took the pile...",
   "winHuman": "You win!",
   "winCpu": "CPU wins...",
-  "winDraw": "Draw"
+  "winDraw": "Draw",
+  "chanceResponder": "Responder: {{name}}",
+  "responderHuman": "You",
+  "responderCpu": "CPU",
+  "chanceTrigger": "Triggered by: {{card}}"
 }

--- a/internal/i18n/locales/ja/egyptianratscrew.json
+++ b/internal/i18n/locales/ja/egyptianratscrew.json
@@ -26,5 +26,9 @@
   "chanceWinCpu": "チャンスバトルで CPU に場札を奪われた...",
   "winHuman": "あなたの勝ちです！",
   "winCpu": "CPUの勝ちです...",
-  "winDraw": "引き分けです"
+  "winDraw": "引き分けです",
+  "chanceResponder": "応答者: {{name}}",
+  "responderHuman": "あなた",
+  "responderCpu": "CPU",
+  "chanceTrigger": "発動カード: {{card}}"
 }


### PR DESCRIPTION
## 概要
エジプシャン・ラットスクリューの CUI はチャンス残数のみ表示し、誰が応答すべきか・どのフェイスカードが要求元かを示していなかった。Web 版 `chanceResponder` と同等に、`GetCurrentTurnIdx()` から応答者名を、場のトップが絵札のとき `GetTopCard()` で発動カードを表示する。

## 変更点
- `EgyptianRatscrewCuiPresenter.go`: チャンス分岐に応答者行（`chanceResponder`）と発動カード行（`chanceTrigger`、`IsTopFaceCard()` ガード）を追加
- `internal/i18n/locales/{ja,en}/egyptianratscrew.json`: 4 キー追加
- テスト: 応答者・発動カード表示を検証

Closes #3228