### PR TITLE
feat(doubt): surface CPU tells in the CUI action history

### DIFF
--- a/internal/adapter/presenter/DoubtCuiPresenter.go
+++ b/internal/adapter/presenter/DoubtCuiPresenter.go
@@ -90,10 +90,16 @@ func (p *DoubtCuiPresenter) Output(d interfaces.DoubtGame, lastErr error) string
 		if cpuActions := d.GetCpuActions(); len(cpuActions) > 0 {
 			b.WriteString(color.Bold(i18n.T("doubt.cpuActionsHeader")) + "\n")
 			for _, action := range cpuActions {
-				b.WriteString(i18n.Tf("doubt.cpuActionLine",
+				// Surface the CPU's tell (nervous behaviour) so the CLI player has
+				// the same read-the-opponent cue the web UI shows.
+				line := i18n.Tf("doubt.cpuActionLine",
 					"name", cuiPlayerName(d.GetPlayer(action.PlayerIdx), action.PlayerIdx),
 					"value", strconv.Itoa(action.ClaimedValue),
-					"count", strconv.Itoa(action.CardCount)) + "\n")
+					"count", strconv.Itoa(action.CardCount))
+				if action.HasTell {
+					line += " " + color.Yellow(i18n.T("doubt.tell"))
+				}
+				b.WriteString(line + "\n")
 			}
 		}
 

--- a/internal/adapter/presenter/DoubtCuiPresenter_test.go
+++ b/internal/adapter/presenter/DoubtCuiPresenter_test.go
@@ -1,6 +1,7 @@
 package presenter_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,6 +10,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func makeDoubtGameForPresenter() (*domain.Doubt, []*domain.DoubtPlayer) {
@@ -197,6 +199,19 @@ func TestDoubtCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "「3」を2枚")
 		assert.Contains(t, result, "CPU 2")
 		assert.Contains(t, result, "「5」を1枚")
+	})
+
+	t.Run("CPU tell shown only when HasTell is true", func(t *testing.T) {
+		game, _ := makeDoubtGameForPresenter()
+		game.SetCpuActions([]*domain.DoubtCpuAction{
+			{PlayerIdx: 1, ClaimedValue: 3, CardCount: 2, HasTell: true},
+			{PlayerIdx: 2, ClaimedValue: 5, CardCount: 1, HasTell: false},
+		})
+
+		result := p.Output(game, nil)
+		tell := i18n.T("doubt.tell")
+		// The tell appears exactly once — for the HasTell CPU only.
+		assert.Equal(t, 1, strings.Count(result, tell))
 	})
 
 	t.Run("error message shown", func(t *testing.T) {

--- a/internal/i18n/locales/en/doubt.json
+++ b/internal/i18n/locales/en/doubt.json
@@ -29,5 +29,6 @@
   "promptDoubtPhaseGeneric": "Doubt phase",
   "promptDoubtHelp": "d <idx...>: doubt / s: skip",
   "promptCurrentPlayer": "{{name}} to play",
-  "promptPlayHelp": "p <value> <idx...>: play cards"
+  "promptPlayHelp": "p <value> <idx...>: play cards",
+  "tell": "(looks nervous…)"
 }

--- a/internal/i18n/locales/ja/doubt.json
+++ b/internal/i18n/locales/ja/doubt.json
@@ -29,5 +29,6 @@
   "promptDoubtPhaseGeneric": "ダウトフェーズ",
   "promptDoubtHelp": "d <idx...>・・・ダウト / s・・・スキップ",
   "promptCurrentPlayer": "手番: {{name}}",
-  "promptPlayHelp": "p <値> <idx...>・・・カードを出す"
+  "promptPlayHelp": "p <値> <idx...>・・・カードを出す",
+  "tell": "（そわそわしている…）"
 }


### PR DESCRIPTION
## 概要
ダウトの CUI は CPU アクション行に name/value/count のみ表示し、Web 版 `DoubtPage` の `cpuTells`（`HasTell` 可視化）に相当する読み合い情報を出していなかった。`HasTell` が true の CPU アクション行に「そわそわしている…」のテル表示を付ける。

## 変更点
- `DoubtCuiPresenter.go`: CPU アクション行に `HasTell` のときテル表示（`doubt.tell`）を付加。lastAction は `DoubtAction` 型で `HasTell` を持たないため対象外。
- `internal/i18n/locales/{ja,en}/doubt.json`: `tell` 追加
- テスト: HasTell true/false 混在で表示が1回のみ出ることを検証

Closes #2997