### PR TITLE
feat(labellelucie): compact foundation display and redeal recommendation

### DIFF
--- a/internal/adapter/presenter/LaBelleLucieCuiPresenter.go
+++ b/internal/adapter/presenter/LaBelleLucieCuiPresenter.go
@@ -27,13 +27,23 @@ func llPileStr(pile []*domain.Card) string {
 	return strings.Join(parts, " ")
 }
 
+// llFoundationStr renders a foundation compactly as its top card plus a count,
+// since late-game foundations grow to 10+ cards and full listing is noisy.
+func llFoundationStr(pile []*domain.Card) string {
+	if len(pile) == 0 {
+		return i18n.T("cuiEmptyCol")
+	}
+	return "[" + cuiCardStr(pile[len(pile)-1]) + "] " +
+		i18n.Tf("labellelucie.foundationCount", "count", strconv.Itoa(len(pile)))
+}
+
 // Output renders the current game state.
 func (p *LaBelleLucieCuiPresenter) Output(g interfaces.LaBelleLucieGame, lastErr error) string {
 	return buildCuiOutput(i18n.T("labellelucie.helpTitle"), func(sb *strings.Builder) {
 		foundation := g.GetFoundation()
 		for i := 0; i < domain.LaBelleLucieFoundationCnt; i++ {
 			sb.WriteString(i18n.Tf("labellelucie.foundationLabel", "idx", strconv.Itoa(i)))
-			sb.WriteString(" " + llPileStr(foundation[i]) + "\n")
+			sb.WriteString(" " + llFoundationStr(foundation[i]) + "\n")
 		}
 		for i, fan := range g.GetFans() {
 			sb.WriteString(i18n.Tf("labellelucie.fanLabel", "idx", strconv.Itoa(i)))
@@ -46,6 +56,11 @@ func (p *LaBelleLucieCuiPresenter) Output(g interfaces.LaBelleLucieGame, lastErr
 		switch g.GetPhase() {
 		case domain.LaBelleLuciePhasePlaying:
 			sb.WriteString(i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(g.GetMoveCount())) + "\n")
+			// No legal move but redeals remain -> recommend a redeal, mirroring the
+			// web stuck banner.
+			if !g.HasAnyLegalMove() && g.GetRedealsLeft() > 0 {
+				sb.WriteString(color.Yellow(i18n.T("labellelucie.redealRecommended")) + "\n")
+			}
 		case domain.LaBelleLuciePhaseGameClear:
 			sb.WriteString(color.Green(i18n.T("cuiSolitaireGameClear")) + " " +
 				i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(g.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/LaBelleLucieCuiPresenter_test.go
+++ b/internal/adapter/presenter/LaBelleLucieCuiPresenter_test.go
@@ -4,12 +4,14 @@ package presenter_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 // llState builds a LaBelleLucie in an arbitrary state via JSON restore.
@@ -31,6 +33,30 @@ func TestLaBelleLucieCuiPresenter_Output(t *testing.T) {
 		out := p.Output(g, nil)
 		assert.Contains(t, out, "La Belle Lucie")
 		assert.Contains(t, out, "残りシャッフル")
+	})
+
+	t.Run("compact foundation and redeal recommendation when stuck", func(t *testing.T) {
+		// Foundation 0 holds an Ace; all fans are empty, so there is no legal
+		// move while redeals remain.
+		ace, _ := json.Marshal(domain.NewCard(domain.CardDesignSpade, 1, true))
+		js := fmt.Sprintf(`{"ph":0,"rd":2,"fd":[[%s],[],[],[]],"fn":[[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]]}`, ace)
+		g := llState(t, js)
+		out := p.Output(g, nil)
+		// Compact top-card + count for the non-empty foundation.
+		assert.Contains(t, out, i18n.Tf("labellelucie.foundationCount", "count", "1"))
+		// Empty foundations still show the shared empty marker.
+		assert.Contains(t, out, i18n.T("cuiEmptyCol"))
+		// No legal move + redeals remaining -> recommendation shown.
+		assert.Contains(t, out, i18n.T("labellelucie.redealRecommended"))
+	})
+
+	t.Run("no redeal recommendation when a legal move exists", func(t *testing.T) {
+		// An Ace on a fan top can always start a foundation -> legal move exists.
+		ace, _ := json.Marshal(domain.NewCard(domain.CardDesignSpade, 1, true))
+		js := fmt.Sprintf(`{"ph":0,"rd":2,"fd":[[],[],[],[]],"fn":[[%s],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]]}`, ace)
+		g := llState(t, js)
+		out := p.Output(g, nil)
+		assert.NotContains(t, out, i18n.T("labellelucie.redealRecommended"))
 	})
 
 	t.Run("game clear banner", func(t *testing.T) {

--- a/internal/domain/LaBelleLucie.go
+++ b/internal/domain/LaBelleLucie.go
@@ -393,6 +393,10 @@ func (g *LaBelleLucie) GetMoveCount() int { return g.moveCount }
 // GetRedealsLeft 残り再シャッフル回数。
 func (g *LaBelleLucie) GetRedealsLeft() int { return g.redealsLeft }
 
+// HasAnyLegalMove はファウンデーション手・扇間移動のいずれかが存在するかを返す
+// (合法手がなければリディールが必要)。
+func (g *LaBelleLucie) HasAnyLegalMove() bool { return g.hasAnyLegalMove() }
+
 // GetFans 扇の一覧を返す。
 func (g *LaBelleLucie) GetFans() [][]*Card { return g.fans }
 

--- a/internal/domain/interfaces/labellelucie.go
+++ b/internal/domain/interfaces/labellelucie.go
@@ -36,6 +36,8 @@ type LaBelleLucieGame interface {
 	GetMoveCount() int
 	// GetRedealsLeft 残り再シャッフル回数を取得する。
 	GetRedealsLeft() int
+	// HasAnyLegalMove 合法手が存在するかを返す (なければリディールが必要)。
+	HasAnyLegalMove() bool
 	// GetFans 扇の一覧を取得する。
 	GetFans() [][]*domain.Card
 	// GetFoundation ファウンデーションを取得する。

--- a/internal/i18n/locales/en/labellelucie.json
+++ b/internal/i18n/locales/en/labellelucie.json
@@ -10,5 +10,7 @@
   "redealsLine": "Redeals left: {{count}}",
   "hintToFan": "fan {{idx}}",
   "hintToFoundation": "a foundation",
-  "hintLine": "[HINT: move fan {{from}} to {{to}}]"
+  "hintLine": "[HINT: move fan {{from}} to {{to}}]",
+  "foundationCount": "({{count}} cards)",
+  "redealRecommended": "No legal moves. Redeal recommended (nr)."
 }

--- a/internal/i18n/locales/ja/labellelucie.json
+++ b/internal/i18n/locales/ja/labellelucie.json
@@ -10,5 +10,7 @@
   "redealsLine": "残りシャッフル: {{count}}",
   "hintToFan": "扇{{idx}}",
   "hintToFoundation": "ファウンデーション",
-  "hintLine": "[HINT: 扇{{from}} を {{to}} へ]"
+  "hintLine": "[HINT: 扇{{from}} を {{to}} へ]",
+  "foundationCount": "(計{{count}}枚)",
+  "redealRecommended": "合法手がありません。nr でリディールを推奨します。"
 }


### PR DESCRIPTION
## 概要
ラ・ベル・ルーシーの CUI はファウンデーションを全カード列挙しており終盤の出力が非常に長かった。また Web の stuck バナー相当の「合法手なし→リディール推奨」案内が CUI に無かった。ファウンデーションを「トップカード + 枚数」の簡潔表示にし、合法手なし・リディール残ありのとき黄色の推奨メッセージを出す。

## 変更点
- `LaBelleLucie.go` / `interfaces/labellelucie.go`: 既存 `hasAnyLegalMove` を公開する `HasAnyLegalMove()` を追加
- `LaBelleLucieCuiPresenter.go`: `llFoundationStr`（top+count、空は従来の空マーカー）＋ Playing 時のリディール推奨
- `internal/i18n/locales/{ja,en}/labellelucie.json`: `foundationCount` / `redealRecommended` 追加
- テスト: 簡潔表示・空マーカー・推奨の有無（合法手あり/なし）を検証

Closes #3579