### PR TITLE
feat(razz): show the human's current best low in the shared CUI

### DIFF
--- a/internal/adapter/presenter/SevenCardStudCuiPresenter.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter.go
@@ -93,6 +93,17 @@ func (p *SevenCardStudCuiPresenter) Output(s interfaces.SevenCardStudGame, lastE
 				if holeCards := player.GetHoleCards(); len(holeCards) > 0 {
 					b.WriteString(i18n.Tf("sevencardstud.holeCards", "cards", cuiCardSliceStrEmoji(holeCards)) + "\n")
 				}
+				// In Razz (lowball) the goal is the lowest hand; surface the human's
+				// current best low, since the shared high-hand view never shows it.
+				if s.GetIsLowball() {
+					if low, complete := domain.SevenCardStudRazzBestLow(player.GetAllCards()); len(low) > 0 {
+						key := "sevencardstud.razzLowIncomplete"
+						if complete {
+							key = "sevencardstud.razzLowComplete"
+						}
+						b.WriteString(i18n.Tf(key, "cards", cuiCardSliceStrEmoji(low)) + "\n")
+					}
+				}
 			}
 		}
 

--- a/internal/adapter/presenter/SevenCardStudCuiPresenter_test.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter_test.go
@@ -37,6 +37,40 @@ func TestSevenCardStudCuiPresenter_Output(t *testing.T) {
 		assert.Contains(t, result, "♣5")
 	})
 
+	t.Run("razz mode shows the human's current best low", func(t *testing.T) {
+		tc := domain.NewTrumpCards(0)
+		players := []*domain.SevenCardStudPlayer{
+			domain.NewSevenCardStudPlayer(true, domain.HoldemStyleTAG),
+			domain.NewSevenCardStudPlayer(false, domain.HoldemStyleLAP),
+		}
+		s := domain.NewRazz(tc, players, domain.DefaultSevenCardStudConfig())
+		s.SetPhase(domain.SevenCardStudPhaseThirdStreet)
+		// A completed low: 2-3-4-5-7.
+		players[0].AddHoleCard(domain.NewCard(domain.CardDesignSpade, 2, false))
+		players[0].AddHoleCard(domain.NewCard(domain.CardDesignHeart, 3, false))
+		players[0].AddDoorCard(domain.NewCard(domain.CardDesignClover, 4, false))
+		players[0].AddDoorCard(domain.NewCard(domain.CardDesignDiamond, 5, false))
+		players[0].AddDoorCard(domain.NewCard(domain.CardDesignSpade, 7, false))
+
+		result := p.Output(s, nil)
+		assert.Contains(t, result, "現在のベストロー")
+	})
+
+	t.Run("razz mode shows incomplete low with fewer than five cards", func(t *testing.T) {
+		tc := domain.NewTrumpCards(0)
+		players := []*domain.SevenCardStudPlayer{
+			domain.NewSevenCardStudPlayer(true, domain.HoldemStyleTAG),
+			domain.NewSevenCardStudPlayer(false, domain.HoldemStyleLAP),
+		}
+		s := domain.NewRazz(tc, players, domain.DefaultSevenCardStudConfig())
+		s.SetPhase(domain.SevenCardStudPhaseThirdStreet)
+		players[0].AddHoleCard(domain.NewCard(domain.CardDesignSpade, 2, false))
+		players[0].AddDoorCard(domain.NewCard(domain.CardDesignClover, 4, false))
+
+		result := p.Output(s, nil)
+		assert.Contains(t, result, "未完成")
+	})
+
 	t.Run("action prompt shows call amount on human betting turn", func(t *testing.T) {
 		s, players := makeSevenCardStudForPresenter()
 		s.SetPhase(domain.SevenCardStudPhaseThirdStreet)

--- a/internal/domain/SevenCardStudPlayer.go
+++ b/internal/domain/SevenCardStudPlayer.go
@@ -224,6 +224,32 @@ func (p *SevenCardStudPlayer) EvalBestHandRazz() int {
 	return p.handRank
 }
 
+// SevenCardStudRazzBestLow returns the strongest 5-card Razz low from cards and
+// whether it is complete. With fewer than 5 cards the low cannot be made yet, so
+// the cards are returned sorted ascending (Ace low) for a progress display and
+// complete is false. This is a pure, non-mutating read used by the CUI. It lives
+// here (not hand_eval.go) because it depends on combinations, which only ships in
+// the casino worker build.
+func SevenCardStudRazzBestLow(cards []*Card) (best []*Card, complete bool) {
+	if len(cards) < 5 {
+		sorted := make([]*Card, len(cards))
+		copy(sorted, cards)
+		sort.Slice(sorted, func(i, j int) bool {
+			return sorted[i].GetValue() < sorted[j].GetValue()
+		})
+		return sorted, false
+	}
+	bestRank := -1
+	for _, combo := range combinations(cards, 5) {
+		rank := evalRazzHand(combo)
+		if bestRank == -1 || rank < bestRank || (rank == bestRank && compareRazzCards(combo, best) < 0) {
+			bestRank = rank
+			best = append([]*Card(nil), combo...)
+		}
+	}
+	return best, true
+}
+
 // EvalVisibleHand 表向き札のみからハンドを評価 (ベッティング順序決定用)
 // 5枚未満の場合はハイカード比較用にソートした値を返す
 func (p *SevenCardStudPlayer) EvalVisibleHand() int {

--- a/internal/domain/SevenCardStudPlayer_test.go
+++ b/internal/domain/SevenCardStudPlayer_test.go
@@ -393,6 +393,45 @@ func TestEvalBestHandRazz_LessThan5Cards(t *testing.T) {
 	assert.Nil(t, p.GetBestHand())
 }
 
+func TestSevenCardStudRazzBestLow_CompleteFive(t *testing.T) {
+	// 7 cards; best low is the five lowest distinct ranks: 2-3-4-5-7.
+	cards := []*Card{
+		NewCard(CardDesignSpade, 2, false),
+		NewCard(CardDesignHeart, 3, false),
+		NewCard(CardDesignClover, 4, false),
+		NewCard(CardDesignDiamond, 5, false),
+		NewCard(CardDesignSpade, 7, false),
+		NewCard(CardDesignHeart, 11, false),
+		NewCard(CardDesignClover, 13, false),
+	}
+	best, complete := SevenCardStudRazzBestLow(cards)
+	assert.True(t, complete)
+	assert.Len(t, best, 5)
+	vals := map[int]bool{}
+	for _, c := range best {
+		vals[c.GetValue()] = true
+	}
+	for _, v := range []int{2, 3, 4, 5, 7} {
+		assert.True(t, vals[v], "expected %d in best low", v)
+	}
+	assert.False(t, vals[11] || vals[13], "high cards must be excluded")
+}
+
+func TestSevenCardStudRazzBestLow_IncompleteSortedAsc(t *testing.T) {
+	cards := []*Card{
+		NewCard(CardDesignSpade, 7, false),
+		NewCard(CardDesignHeart, 1, false), // Ace low
+		NewCard(CardDesignClover, 4, false),
+	}
+	best, complete := SevenCardStudRazzBestLow(cards)
+	assert.False(t, complete)
+	assert.Len(t, best, 3)
+	// Sorted ascending with Ace (1) first.
+	assert.Equal(t, 1, best[0].GetValue())
+	assert.Equal(t, 4, best[1].GetValue())
+	assert.Equal(t, 7, best[2].GetValue())
+}
+
 func TestCompareVisibleHandsLow_LowerRankWins(t *testing.T) {
 	a := NewSevenCardStudPlayer(true, 0)
 	a.AddDoorCard(NewCard(CardDesignSpade, 2, false)) // HighCard

--- a/internal/domain/hand_eval.go
+++ b/internal/domain/hand_eval.go
@@ -372,27 +372,3 @@ func razzCardValues(cards []*Card) []int {
 	}
 	return vals
 }
-
-// SevenCardStudRazzBestLow returns the strongest 5-card Razz low from cards and
-// whether it is complete. With fewer than 5 cards the low cannot be made yet, so
-// the cards are returned sorted ascending (Ace low) for a progress display and
-// complete is false. This is a pure, non-mutating read used by the CUI.
-func SevenCardStudRazzBestLow(cards []*Card) (best []*Card, complete bool) {
-	if len(cards) < 5 {
-		sorted := make([]*Card, len(cards))
-		copy(sorted, cards)
-		sort.Slice(sorted, func(i, j int) bool {
-			return sorted[i].GetValue() < sorted[j].GetValue()
-		})
-		return sorted, false
-	}
-	bestRank := -1
-	for _, combo := range combinations(cards, 5) {
-		rank := evalRazzHand(combo)
-		if bestRank == -1 || rank < bestRank || (rank == bestRank && compareRazzCards(combo, best) < 0) {
-			bestRank = rank
-			best = append([]*Card(nil), combo...)
-		}
-	}
-	return best, true
-}

--- a/internal/domain/hand_eval.go
+++ b/internal/domain/hand_eval.go
@@ -372,3 +372,27 @@ func razzCardValues(cards []*Card) []int {
 	}
 	return vals
 }
+
+// SevenCardStudRazzBestLow returns the strongest 5-card Razz low from cards and
+// whether it is complete. With fewer than 5 cards the low cannot be made yet, so
+// the cards are returned sorted ascending (Ace low) for a progress display and
+// complete is false. This is a pure, non-mutating read used by the CUI.
+func SevenCardStudRazzBestLow(cards []*Card) (best []*Card, complete bool) {
+	if len(cards) < 5 {
+		sorted := make([]*Card, len(cards))
+		copy(sorted, cards)
+		sort.Slice(sorted, func(i, j int) bool {
+			return sorted[i].GetValue() < sorted[j].GetValue()
+		})
+		return sorted, false
+	}
+	bestRank := -1
+	for _, combo := range combinations(cards, 5) {
+		rank := evalRazzHand(combo)
+		if bestRank == -1 || rank < bestRank || (rank == bestRank && compareRazzCards(combo, best) < 0) {
+			bestRank = rank
+			best = append([]*Card(nil), combo...)
+		}
+	}
+	return best, true
+}

--- a/internal/i18n/locales/en/sevencardstud.json
+++ b/internal/i18n/locales/en/sevencardstud.json
@@ -56,5 +56,7 @@
   "actionPromptCheck": "Your turn: check / min bet {{raise}} / fold",
   "rebuyPrompt": "Rebuy? ({{chips}} chips, used {{used}}/{{max}}) (rb=rebuy / sr=skip)",
   "addonPrompt": "Add-on? ({{chips}} chips) (ad=addon / sa=skip)",
-  "gameEnd": "Game over"
+  "gameEnd": "Game over",
+  "razzLowComplete": "Best low: {{cards}}",
+  "razzLowIncomplete": "Best low (incomplete): {{cards}}"
 }

--- a/internal/i18n/locales/ja/sevencardstud.json
+++ b/internal/i18n/locales/ja/sevencardstud.json
@@ -56,5 +56,7 @@
   "actionPromptCheck": "あなたの手番: チェック可 / 最低ベット {{raise}} / フォールド可",
   "rebuyPrompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済) (rb=リバイ / sr=スキップ)",
   "addonPrompt": "アドオンしますか? ({{chips}}チップ) (ad=アドオン / sa=スキップ)",
-  "gameEnd": "ゲーム終了"
+  "gameEnd": "ゲーム終了",
+  "razzLowComplete": "現在のベストロー: {{cards}}",
+  "razzLowIncomplete": "ベストロー(未完成): {{cards}}"
 }


### PR DESCRIPTION
## 概要
Razz は Seven Card Stud とプレゼンターを共有しており、ハイハンド前提の表示のため Razz 固有の「現在のベストロー」が CUI にまったく出なかった（Web 版 `RazzPage` は `razzLow.ts` で表示）。ドメインに純粋関数 `SevenCardStudRazzBestLow` を追加し、ローボールモードのとき人間の現在のベストロー（5枚未満は未完成表示）を出力する。

## 変更点
- `hand_eval.go`: 非破壊の `SevenCardStudRazzBestLow(cards) ([]*Card, bool)` を追加（既存 `evalRazzHand`/`compareRazzCards` を再利用）
- `SevenCardStudCuiPresenter.go`: `GetIsLowball()` かつ人間のとき `razzLowComplete`/`razzLowIncomplete` を出力（ハイモードは不変）
- `internal/i18n/locales/{ja,en}/sevencardstud.json`: 2 キー追加
- テスト: ドメイン関数の完成/未完成分岐、プレゼンターのローボール表示を検証

Closes #3181