### PR TITLE
feat(highcardflush): add a CUI hint command with raise/fold basic strategy

### DIFF
--- a/internal/adapter/controller/HighCardFlushCuiController.go
+++ b/internal/adapter/controller/HighCardFlushCuiController.go
@@ -27,7 +27,7 @@ func (hcc *HighCardFlushCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return hcc.hi.Reset() },
-		[]string{"b", "bet", "ra", "raise", "f", "fold", "log", "l"},
+		[]string{"b", "bet", "ra", "raise", "f", "fold", "h", "hint", "log", "l"},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "b", "bet":
@@ -59,7 +59,7 @@ func (hcc *HighCardFlushCuiController) Exec(command string) string {
 			case "f", "fold":
 				return hcc.hi.Fold(), true
 			default:
-				return handleCuiLog(cmd, hcc.hi.ActionLog)
+				return handleCuiHintAndLog(cmd, hcc.hi.Hint, hcc.hi.ActionLog)
 			}
 		},
 	)

--- a/internal/adapter/controller/HighCardFlushCuiController_test.go
+++ b/internal/adapter/controller/HighCardFlushCuiController_test.go
@@ -22,6 +22,7 @@ func newMockHighCardFlushInteractor() *usecase.MockHighCardFlushInteractor {
 	m.On("Raise", 3).Return("raise 3x result")
 	m.On("Fold").Return("fold result")
 	m.On("ActionLog").Return("action log result")
+	m.On("Hint").Return("hint result")
 	return m
 }
 
@@ -108,6 +109,13 @@ func TestHighCardFlushCuiController_ActionLog(t *testing.T) {
 	c := controller.NewHighCardFlushCuiController(m)
 	assert.Equal(t, "action log result", c.Exec("log"))
 	assert.Equal(t, "action log result", c.Exec("l"))
+}
+
+func TestHighCardFlushCuiController_Hint(t *testing.T) {
+	m := newMockHighCardFlushInteractor()
+	c := controller.NewHighCardFlushCuiController(m)
+	assert.Equal(t, "hint result", c.Exec("h"))
+	assert.Equal(t, "hint result", c.Exec("hint"))
 }
 
 func TestHighCardFlushCuiController_Unknown(t *testing.T) {

--- a/internal/adapter/controller/usecase/HighCardFlushInteractor_mock.go
+++ b/internal/adapter/controller/usecase/HighCardFlushInteractor_mock.go
@@ -34,6 +34,12 @@ func (m *MockHighCardFlushInteractor) ActionLog() string {
 	return args.String(0)
 }
 
+// Hint モック
+func (m *MockHighCardFlushInteractor) Hint() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 // Snapshot モック
 func (m *MockHighCardFlushInteractor) Snapshot() ([]byte, error) {
 	ret := m.Called()

--- a/internal/adapter/presenter/HighCardFlushCuiPresenter.go
+++ b/internal/adapter/presenter/HighCardFlushCuiPresenter.go
@@ -102,3 +102,16 @@ func (hp *HighCardFlushCuiPresenter) phaseStr(phase int) string {
 		return i18n.T("highcardflush.phaseUnknown")
 	}
 }
+
+// HintOutput emits a raise/fold recommendation during the action phase. Basic
+// strategy: raise once the player's longest flush reaches the dealer's
+// qualifying length (3); otherwise fold. Other phases have no decision to advise.
+func (hp *HighCardFlushCuiPresenter) HintOutput(hcf interfaces.HighCardFlushGame) string {
+	if hcf.GetPhase() != domain.HighCardFlushPhaseAction {
+		return i18n.T("highcardflush.hintNone") + "\n"
+	}
+	if hcf.GetPlayerFlushLen() >= domain.HighCardFlushDealerMinFlushLen {
+		return color.Yellow(i18n.T("highcardflush.hintRaise")) + "\n"
+	}
+	return color.Yellow(i18n.T("highcardflush.hintFold")) + "\n"
+}

--- a/internal/adapter/presenter/HighCardFlushCuiPresenter_test.go
+++ b/internal/adapter/presenter/HighCardFlushCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupHighCardFlushCuiMockDefaults(m *interfaces.MockHighCardFlushGame) {
@@ -254,4 +255,28 @@ func TestHighCardFlushCuiPresenter_ActionLogOutput(t *testing.T) {
 
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "棋譜はありません")
+}
+
+func TestHighCardFlushCuiPresenter_HintOutput(t *testing.T) {
+	p := new(HighCardFlushCuiPresenter)
+
+	t.Run("no hint outside the action phase", func(t *testing.T) {
+		m := new(interfaces.MockHighCardFlushGame)
+		m.On("GetPhase").Return(domain.HighCardFlushPhaseBet)
+		assert.Contains(t, p.HintOutput(m), i18n.T("highcardflush.hintNone"))
+	})
+
+	t.Run("raise when the flush qualifies", func(t *testing.T) {
+		m := new(interfaces.MockHighCardFlushGame)
+		m.On("GetPhase").Return(domain.HighCardFlushPhaseAction)
+		m.On("GetPlayerFlushLen").Return(domain.HighCardFlushDealerMinFlushLen)
+		assert.Contains(t, p.HintOutput(m), i18n.T("highcardflush.hintRaise"))
+	})
+
+	t.Run("fold when the flush is too short", func(t *testing.T) {
+		m := new(interfaces.MockHighCardFlushGame)
+		m.On("GetPhase").Return(domain.HighCardFlushPhaseAction)
+		m.On("GetPlayerFlushLen").Return(domain.HighCardFlushDealerMinFlushLen - 1)
+		assert.Contains(t, p.HintOutput(m), i18n.T("highcardflush.hintFold"))
+	})
 }

--- a/internal/adapter/presenter/HighCardFlushWebPresenter.go
+++ b/internal/adapter/presenter/HighCardFlushWebPresenter.go
@@ -77,3 +77,9 @@ func (hp *HighCardFlushWebPresenter) Output(hcf interfaces.HighCardFlushGame, la
 func (hp *HighCardFlushWebPresenter) ActionLogOutput(hcf interfaces.HighCardFlushGame) string {
 	return actionLogOutputJSON(hcf)
 }
+
+// HintOutput はヒントを返す。Web ではクライアント側でヒントを算出するため、
+// 状態出力にフォールバックする (CUI プレゼンターのみが専用ヒントを返す)。
+func (hp *HighCardFlushWebPresenter) HintOutput(hcf interfaces.HighCardFlushGame) string {
+	return hp.Output(hcf, nil)
+}

--- a/internal/i18n/locales/en/highcardflush.json
+++ b/internal/i18n/locales/en/highcardflush.json
@@ -20,5 +20,8 @@
   "dealerWins": "Dealer wins!",
   "playerFolded": "Player folded.",
   "push": "Push!",
-  "totalPayoutLine": "total payout: {{payout}}"
+  "totalPayoutLine": "total payout: {{payout}}",
+  "hintNone": "No hint available.",
+  "hintRaise": "Recommended: Raise (your flush meets the dealer qualifying length)",
+  "hintFold": "Recommended: Fold (your flush is below the dealer qualifying length)"
 }

--- a/internal/i18n/locales/ja/highcardflush.json
+++ b/internal/i18n/locales/ja/highcardflush.json
@@ -20,5 +20,8 @@
   "dealerWins": "ディーラーの勝ち！",
   "playerFolded": "プレイヤーがフォールド。",
   "push": "プッシュ！",
-  "totalPayoutLine": "合計払戻し: {{payout}}"
+  "totalPayoutLine": "合計払戻し: {{payout}}",
+  "hintNone": "現在ヒントはありません。",
+  "hintRaise": "推奨: レイズ（フラッシュ長がディーラーの条件を満たします）",
+  "hintFold": "推奨: フォールド（フラッシュ長がディーラーの条件に届きません）"
 }

--- a/internal/usecase/HighCardFlushInteractor.go
+++ b/internal/usecase/HighCardFlushInteractor.go
@@ -22,6 +22,8 @@ type HighCardFlushInteractorIF interface {
 	Fold() string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
+	// Hint ヒントを出力する
+	Hint() string
 }
 
 // HighCardFlushInteractor ハイカードフラッシュインタラクタークラス
@@ -62,6 +64,11 @@ func (hi *HighCardFlushInteractor) Fold() string {
 // ActionLog 棋譜を出力する
 func (hi *HighCardFlushInteractor) ActionLog() string {
 	return hi.hp.ActionLogOutput(hi.Game)
+}
+
+// Hint ヒントを出力する
+func (hi *HighCardFlushInteractor) Hint() string {
+	return hi.hp.HintOutput(hi.Game)
 }
 
 // RestoreHighCardFlushInteractor deserialises JSON into a HighCardFlushInteractor.

--- a/internal/usecase/HighCardFlushInteractor_test.go
+++ b/internal/usecase/HighCardFlushInteractor_test.go
@@ -106,6 +106,15 @@ func TestHighCardFlushInteractor_ActionLog(t *testing.T) {
 	assert.Equal(t, "log", hi.ActionLog())
 }
 
+func TestHighCardFlushInteractor_Hint(t *testing.T) {
+	mockGame := new(interfaces.MockHighCardFlushGame)
+	mockPresenter := new(presenter.MockHighCardFlushPresenter)
+	hi := NewHighCardFlushInteractor(mockGame, mockPresenter)
+
+	mockPresenter.On("HintOutput", mockGame).Return("hint")
+	assert.Equal(t, "hint", hi.Hint())
+}
+
 func TestRestoreHighCardFlushInteractor(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mockPresenter := new(presenter.MockHighCardFlushPresenter)

--- a/internal/usecase/presenter/HighCardFlushPresenter.go
+++ b/internal/usecase/presenter/HighCardFlushPresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // HighCardFlushPresenter ハイカードフラッシュプレゼンターインタフェース
-type HighCardFlushPresenter = GamePresenter[interfaces.HighCardFlushGame]
+type HighCardFlushPresenter interface {
+	GamePresenter[interfaces.HighCardFlushGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.HighCardFlushGame) string
+}

--- a/internal/usecase/presenter/HighCardFlushPresenter_mock.go
+++ b/internal/usecase/presenter/HighCardFlushPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockHighCardFlushPresenter ハイカードフラッシュプレゼンターモック
-type MockHighCardFlushPresenter = MockGamePresenter[interfaces.HighCardFlushGame]
+type MockHighCardFlushPresenter struct {
+	MockGamePresenter[interfaces.HighCardFlushGame]
+}
+
+// HintOutput モック
+func (_m *MockHighCardFlushPresenter) HintOutput(g interfaces.HighCardFlushGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 概要
`HighCardFlushCuiPresenter` に `HintOutput` が無く、CUI で `hint` コマンドが使えなかった（Web 版はクライアント側でヒントを算出）。基本戦略（プレイヤーの最長フラッシュ長がディーラー条件=3 に達すればレイズ、届かなければフォールド）に基づくヒントを実装し、共通の hint コマンドを配線する。

## 変更点
- `HighCardFlushCuiPresenter.go`: `HintOutput`（Action フェーズでレイズ/フォールド、他フェーズは hintNone）
- `usecase/presenter/HighCardFlushPresenter.go` / `_mock.go`: インタフェースに `HintOutput` を追加（型エイリアス→独自インタフェース）＋モック
- `HighCardFlushInteractor.go`: `Hint()` を IF とメソッドに追加
- `HighCardFlushCuiController.go`: `handleCuiHintAndLog` で h/hint を配線
- `HighCardFlushWebPresenter.go`: `HintOutput` は `Output` に委譲（Web はクライアント側算出）
- i18n: `hintNone`/`hintRaise`/`hintFold` を ja/en に追加
- テスト: presenter 3分岐・interactor Hint・controller h/hint コマンド

Closes #3308