### PR TITLE
feat(macau): add a CUI hint command listing playable cards

### DIFF
--- a/internal/adapter/controller/MacauCuiController.go
+++ b/internal/adapter/controller/MacauCuiController.go
@@ -45,7 +45,7 @@ func (c *MacauCuiController) Exec(command string) string {
 			"p", "play", "d", "draw", "s", "suit",
 			"dc", "declare", "sk", "skipdeclare",
 			"nr", "nextround",
-			"sd", "setdifficulty", "sl", "setlimit", "log", "l",
+			"sd", "setdifficulty", "sl", "setlimit", "h", "hint", "log", "l",
 		},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
@@ -76,7 +76,7 @@ func (c *MacauCuiController) Exec(command string) string {
 					return c.ci.ResetWithConfig(cfg)
 				})
 			default:
-				return handleCuiLog(cmd, c.ci.ActionLog)
+				return handleCuiHintAndLog(cmd, c.ci.Hint, c.ci.ActionLog)
 			}
 		},
 	)

--- a/internal/adapter/controller/MacauCuiController_test.go
+++ b/internal/adapter/controller/MacauCuiController_test.go
@@ -28,6 +28,7 @@ func TestMacauCuiController_Exec(t *testing.T) {
 		m.On("SkipDeclare").Return(mockOutput)
 		m.On("NextRound").Return(mockOutput)
 		m.On("ActionLog").Return(mockOutput)
+		m.On("Hint").Return(mockOutput)
 		m.On("IsHumanChooseSuitTurn").Return(false)
 		m.On("IsHumanDeclareTurn").Return(false)
 		return m
@@ -49,6 +50,14 @@ func TestMacauCuiController_Exec(t *testing.T) {
 		c := controller.NewMacauCuiController(m)
 		assert.Equal(t, mockOutput, c.Exec("p 3"))
 		m.AssertCalled(t, "Play", 3)
+	})
+
+	t.Run("hint command", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewMacauCuiController(m)
+		assert.Equal(t, mockOutput, c.Exec("h"))
+		assert.Equal(t, mockOutput, c.Exec("hint"))
+		m.AssertCalled(t, "Hint")
 	})
 
 	t.Run("play no args", func(t *testing.T) {

--- a/internal/adapter/controller/usecase/MacauInteractor_mock.go
+++ b/internal/adapter/controller/usecase/MacauInteractor_mock.go
@@ -53,6 +53,11 @@ func (_m *MockMacauInteractor) ActionLog() string {
 	return _m.Called().String(0)
 }
 
+// Hint モック
+func (_m *MockMacauInteractor) Hint() string {
+	return _m.Called().String(0)
+}
+
 // Snapshot モック
 func (_m *MockMacauInteractor) Snapshot() ([]byte, error) {
 	ret := _m.Called()

--- a/internal/adapter/presenter/MacauCuiPresenter.go
+++ b/internal/adapter/presenter/MacauCuiPresenter.go
@@ -99,3 +99,30 @@ func (p *MacauCuiPresenter) Output(g interfaces.MacauGame, lastErr error) string
 func (p *MacauCuiPresenter) ActionLogOutput(g interfaces.MacauGame) string {
 	return actionLogOutputText(g)
 }
+
+// HintOutput lists the human's currently playable card indices. During a
+// penalty chain IsValidPlay already restricts to counter cards, so the same
+// scan works; when nothing is playable it advises drawing (or, mid-penalty,
+// accepting the accumulated penalty).
+func (p *MacauCuiPresenter) HintOutput(g interfaces.MacauGame) string {
+	if g.GetPhase() != domain.MacauPhasePlay || !g.IsHumanTurn() {
+		return i18n.T("macau.hintNone") + "\n"
+	}
+	player := g.GetPlayer(g.GetCurrentPlayerIdx())
+	if player == nil {
+		return i18n.T("macau.hintNone") + "\n"
+	}
+	var parts []string
+	for i := 0; i < player.GetCardsSize(); i++ {
+		if g.IsValidPlay(player.GetCard(i)) {
+			parts = append(parts, "["+strconv.Itoa(i)+"]"+cuiCardStr(player.GetCard(i)))
+		}
+	}
+	if len(parts) == 0 {
+		if g.GetPenaltyDrawCount() > 0 {
+			return color.Yellow(i18n.T("macau.hintReceivePenalty")) + "\n"
+		}
+		return color.Yellow(i18n.T("macau.hintDraw")) + "\n"
+	}
+	return color.Yellow(i18n.Tf("macau.hintPlayable", "cards", strings.Join(parts, " "))) + "\n"
+}

--- a/internal/adapter/presenter/MacauCuiPresenter_test.go
+++ b/internal/adapter/presenter/MacauCuiPresenter_test.go
@@ -220,4 +220,12 @@ func TestMacauCuiPresenter_HintOutput(t *testing.T) {
 		m.On("IsHumanTurn").Return(false)
 		assert.Contains(t, p.HintOutput(m), i18n.T("macau.hintNone"))
 	})
+
+	t.Run("no hint when the current player is nil", func(t *testing.T) {
+		m := setupMacauCuiMock()
+		m.On("GetPlayerCnt").Return(4)
+		m.On("GetPlayer", 0).Return((*domain.MacauPlayer)(nil))
+		m.On("IsHumanTurn").Return(true)
+		assert.Contains(t, p.HintOutput(m), i18n.T("macau.hintNone"))
+	})
 }

--- a/internal/adapter/presenter/MacauCuiPresenter_test.go
+++ b/internal/adapter/presenter/MacauCuiPresenter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupMacauCuiMock() *interfaces.MockMacauGame {
@@ -166,5 +167,57 @@ func TestMacauCuiPresenter_ActionLogOutput(t *testing.T) {
 		m.On("GetGameEndFlag").Return(false)
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜はありません")
+	})
+}
+
+func TestMacauCuiPresenter_HintOutput(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+	p := new(presenter.MacauCuiPresenter)
+
+	t.Run("lists only playable card indices", func(t *testing.T) {
+		m, players := setupMacauCuiMockWithPlayers()
+		m.On("IsHumanTurn").Return(true)
+		playable := domain.NewCard(domain.CardDesignHeart, 5, false)
+		unplayable := domain.NewCard(domain.CardDesignSpade, 9, false)
+		players[0].AddCard(playable)
+		players[0].AddCard(unplayable)
+		m.On("IsValidPlay", playable).Return(true)
+		m.On("IsValidPlay", unplayable).Return(false)
+
+		out := p.HintOutput(m)
+		assert.Contains(t, out, i18n.Tf("macau.hintPlayable", "cards", "[0]HEART 5"))
+		assert.NotContains(t, out, "[1]")
+	})
+
+	t.Run("advises drawing when nothing is playable", func(t *testing.T) {
+		m, players := setupMacauCuiMockWithPlayers()
+		m.On("IsHumanTurn").Return(true)
+		c := domain.NewCard(domain.CardDesignSpade, 9, false)
+		players[0].AddCard(c)
+		m.On("IsValidPlay", c).Return(false)
+
+		out := p.HintOutput(m)
+		assert.Contains(t, out, i18n.T("macau.hintDraw"))
+	})
+
+	t.Run("advises accepting the penalty mid-chain", func(t *testing.T) {
+		m, players := setupMacauCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPenaltyDrawCount")
+		m.On("GetPenaltyDrawCount").Return(2)
+		m.On("IsHumanTurn").Return(true)
+		c := domain.NewCard(domain.CardDesignSpade, 9, false)
+		players[0].AddCard(c)
+		m.On("IsValidPlay", c).Return(false)
+
+		out := p.HintOutput(m)
+		assert.Contains(t, out, i18n.T("macau.hintReceivePenalty"))
+	})
+
+	t.Run("no hint outside the human's play turn", func(t *testing.T) {
+		m, _ := setupMacauCuiMockWithPlayers()
+		m.On("IsHumanTurn").Return(false)
+		assert.Contains(t, p.HintOutput(m), i18n.T("macau.hintNone"))
 	})
 }

--- a/internal/adapter/presenter/MacauWebPresenter.go
+++ b/internal/adapter/presenter/MacauWebPresenter.go
@@ -91,3 +91,9 @@ func (p *MacauWebPresenter) buildMessage(g interfaces.MacauGame, lastErr error) 
 func (p *MacauWebPresenter) ActionLogOutput(g interfaces.MacauGame) string {
 	return actionLogOutputJSON(g)
 }
+
+// HintOutput はヒントを返す。Web ではクライアント側でヒントを算出するため、
+// 状態出力にフォールバックする (CUI プレゼンターのみが専用ヒントを返す)。
+func (p *MacauWebPresenter) HintOutput(g interfaces.MacauGame) string {
+	return p.Output(g, nil)
+}

--- a/internal/adapter/presenter/MacauWebPresenter_test.go
+++ b/internal/adapter/presenter/MacauWebPresenter_test.go
@@ -71,6 +71,13 @@ func TestMacauWebPresenter_Output(t *testing.T) {
 		assert.Len(t, resObj.Players[1].Cards, 0)
 	})
 
+	t.Run("HintOutput falls back to the state output", func(t *testing.T) {
+		m, players := setupMacauWebMockWithPlayers()
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 5, false))
+		// The web presenter computes hints client-side, so HintOutput mirrors Output.
+		assert.Equal(t, p.Output(m, nil), p.HintOutput(m))
+	})
+
 	t.Run("penalty and direction populated", func(t *testing.T) {
 		m, _ := setupMacauWebMockWithPlayers()
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPenaltyDrawCount")

--- a/internal/domain/Macau.go
+++ b/internal/domain/Macau.go
@@ -477,6 +477,10 @@ func (g *Macau) GetActionLog() []*ActionLogEntry { return g.actionLog }
 
 // --- Private methods ---
 
+// IsValidPlay は現在の場状態 (捨て札トップ・宣言スート・ペナルティ連鎖) を踏まえ
+// カードがプレイ可能かを返す (公開版; CUI ヒントが利用する)。
+func (g *Macau) IsValidPlay(card *Card) bool { return g.isValidPlay(card) }
+
 // isValidPlay カードがプレイ可能か判定
 func (g *Macau) isValidPlay(card *Card) bool {
 	// ペナルティ中は2のみ重ねられる

--- a/internal/domain/Macau_test.go
+++ b/internal/domain/Macau_test.go
@@ -130,6 +130,18 @@ func TestMacau_GetDiscardTop(t *testing.T) {
 	assert.Equal(t, card, g.GetDiscardTop())
 }
 
+func TestMacau_IsValidPlay(t *testing.T) {
+	g := newTestMacau()
+	g.Reset()
+	g.SetDiscardPile([]*domain.Card{domain.NewCard(domain.CardDesignSpade, 5, false)})
+	g.SetChosenSuit(-1)
+	g.SetPenaltyDrawCount(0)
+
+	assert.True(t, g.IsValidPlay(domain.NewCard(domain.CardDesignSpade, 3, false)), "same suit is playable")
+	assert.True(t, g.IsValidPlay(domain.NewCard(domain.CardDesignHeart, 5, false)), "same rank is playable")
+	assert.False(t, g.IsValidPlay(domain.NewCard(domain.CardDesignHeart, 7, false)), "different suit and rank is not playable")
+}
+
 func TestMacau_GetValidPlayIndices(t *testing.T) {
 	g := newTestMacau()
 	g.Reset()

--- a/internal/domain/interfaces/macau.go
+++ b/internal/domain/interfaces/macau.go
@@ -61,4 +61,6 @@ type MacauGame interface {
 	GetPlayerCnt() int
 	// GetPlayer 指定インデックスのプレイヤーを取得する
 	GetPlayer(i int) *domain.MacauPlayer
+	// IsValidPlay カードが現在の場状態でプレイ可能かを返す
+	IsValidPlay(card *domain.Card) bool
 }

--- a/internal/domain/interfaces/macau_mock.go
+++ b/internal/domain/interfaces/macau_mock.go
@@ -45,6 +45,9 @@ func (m *MockMacauGame) GetPlayerCnt() int           { return m.Called().Int(0) 
 func (m *MockMacauGame) GetPlayer(i int) *domain.MacauPlayer {
 	return m.Called(i).Get(0).(*domain.MacauPlayer)
 }
+func (m *MockMacauGame) IsValidPlay(card *domain.Card) bool {
+	return m.Called(card).Bool(0)
+}
 func (m *MockMacauGame) GetActionLog() []*domain.ActionLogEntry {
 	return m.Called().Get(0).([]*domain.ActionLogEntry)
 }

--- a/internal/i18n/locales/en/macau.json
+++ b/internal/i18n/locales/en/macau.json
@@ -24,5 +24,9 @@
   "promptMustDeclare": "Declaration phase (one card left)",
   "promptMustDeclareHelp": "dc / declare: declare \"Macau!\" / sk / skipdeclare: skip and take penalty",
   "promptRoundEnd": "Round complete",
-  "promptRoundEndHelp": "nr / nextround: advance to next round"
+  "promptRoundEndHelp": "nr / nextround: advance to next round",
+  "hintNone": "No hint available.",
+  "hintPlayable": "Playable cards: {{cards}}",
+  "hintDraw": "No playable card. Draw with d.",
+  "hintReceivePenalty": "No counter card. Accept the penalty with d."
 }

--- a/internal/i18n/locales/ja/macau.json
+++ b/internal/i18n/locales/ja/macau.json
@@ -24,5 +24,9 @@
   "promptMustDeclare": "宣言フェーズ (手札が残り1枚)",
   "promptMustDeclareHelp": "dc / declare・・・「マカオ！」と宣言 / sk / skipdeclare・・・宣言せずペナルティ",
   "promptRoundEnd": "ラウンド終了",
-  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ"
+  "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
+  "hintNone": "現在ヒントはありません。",
+  "hintPlayable": "出せるカード: {{cards}}",
+  "hintDraw": "出せるカードがありません。d でドローしてください。",
+  "hintReceivePenalty": "カウンターできるカードがありません。d でペナルティを受けてください。"
 }

--- a/internal/usecase/MacauInteractor.go
+++ b/internal/usecase/MacauInteractor.go
@@ -32,6 +32,8 @@ type MacauInteractorIF interface {
 	GetConfig() domain.MacauConfig
 	// ActionLog 棋譜を出力する
 	ActionLog() string
+	// Hint ヒントを出力する
+	Hint() string
 	// IsHumanChooseSuitTurn reports whether the human just played an 8 and the
 	// game is now waiting for them to pick a suit.
 	IsHumanChooseSuitTurn() bool
@@ -148,6 +150,11 @@ func (ci *MacauInteractor) GetConfig() domain.MacauConfig {
 // ActionLog 棋譜を出力する
 func (ci *MacauInteractor) ActionLog() string {
 	return ci.gp.ActionLogOutput(ci.Game)
+}
+
+// Hint ヒントを出力する
+func (ci *MacauInteractor) Hint() string {
+	return ci.gp.HintOutput(ci.Game)
 }
 
 // IsHumanChooseSuitTurn reports whether the game is currently waiting for the

--- a/internal/usecase/MacauInteractor_test.go
+++ b/internal/usecase/MacauInteractor_test.go
@@ -350,6 +350,16 @@ func TestMacauInteractor_ActionLog(t *testing.T) {
 	pMock.AssertExpectations(t)
 }
 
+func TestMacauInteractor_Hint(t *testing.T) {
+	pMock := new(presenter.MockMacauPresenter)
+	gameMock := new(interfaces.MockMacauGame)
+	pMock.On("HintOutput", gameMock).Return("hint")
+
+	ci := usecase.NewMacauInteractor(gameMock, pMock)
+	assert.Equal(t, "hint", ci.Hint())
+	pMock.AssertExpectations(t)
+}
+
 func TestMacauInteractor_IsHumanTurnHelpers(t *testing.T) {
 	t.Run("IsHumanChooseSuitTurn", func(t *testing.T) {
 		pMock := new(presenter.MockMacauPresenter)

--- a/internal/usecase/presenter/MacauPresenter.go
+++ b/internal/usecase/presenter/MacauPresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MacauPresenter マカオプレゼンターインタフェース
-type MacauPresenter = GamePresenter[interfaces.MacauGame]
+type MacauPresenter interface {
+	GamePresenter[interfaces.MacauGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.MacauGame) string
+}

--- a/internal/usecase/presenter/MacauPresenter_mock.go
+++ b/internal/usecase/presenter/MacauPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockMacauPresenter マカオプレゼンターモック
-type MockMacauPresenter = MockGamePresenter[interfaces.MacauGame]
+type MockMacauPresenter struct {
+	MockGamePresenter[interfaces.MacauGame]
+}
+
+// HintOutput モック
+func (_m *MockMacauPresenter) HintOutput(g interfaces.MacauGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 概要
`MacauCuiPresenter` に `HintOutput` が無く、CUI で `hint` コマンドが使えなかった（合法手判定は同ランク/同スート・マジックカード・ペナルティ連鎖中はカウンターのみ、と複雑）。ドメインの合法手判定 `isValidPlay` を公開し、人間の番のとき出せるカードのインデックスを列挙する。ペナルティ連鎖中は `IsValidPlay` が自動的にカウンター可能札のみに制限する。出せる手が無いときはドロー（連鎖中はペナルティ受領）を案内する。

## 変更点
- `Macau.go` / `interfaces/macau.go`(+mock): `IsValidPlay(card)` を公開
- `usecase/presenter/MacauPresenter.go`(+mock): インタフェースに `HintOutput` 追加
- `MacauCuiPresenter.go`: `HintOutput`（出せるカード一覧／ドロー・ペナルティ案内／非手番は hintNone）
- `MacauWebPresenter.go`: `HintOutput` は `Output` に委譲
- `MacauInteractor.go`(+mock): `Hint()` 追加、`MacauCuiController.go`: h/hint 配線
- i18n: hintNone/hintPlayable/hintDraw/hintReceivePenalty を ja/en
- テスト: presenter 4分岐・interactor Hint・controller h/hint

Closes #3354