### PR TITLE
feat(sixcardgolf): add a CUI hint command for draw/swap/discard decisions

### DIFF
--- a/internal/adapter/controller/SixCardGolfCuiController.go
+++ b/internal/adapter/controller/SixCardGolfCuiController.go
@@ -29,7 +29,7 @@ func (c *SixCardGolfCuiController) Exec(command string) string {
 			"sw", "swap", "di", "discard", "fl", "flip", "sf", "skipflip",
 			"nr", "nextround",
 			"sd", "setdifficulty", "sp", "setplayers", "sr", "setrounds",
-			"log", "l",
+			"h", "hint", "log", "l",
 		},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
@@ -68,7 +68,7 @@ func (c *SixCardGolfCuiController) Exec(command string) string {
 					return c.ci.ResetWithConfig(cfg)
 				})
 			default:
-				return handleCuiLog(cmd, c.ci.ActionLog)
+				return handleCuiHintAndLog(cmd, c.ci.Hint, c.ci.ActionLog)
 			}
 		},
 	)

--- a/internal/adapter/controller/SixCardGolfCuiController_test.go
+++ b/internal/adapter/controller/SixCardGolfCuiController_test.go
@@ -1,0 +1,22 @@
+//go:build test
+
+package controller_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
+	mockUsecases "github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/usecase"
+)
+
+func TestSixCardGolfCuiController_Hint(t *testing.T) {
+	m := new(mockUsecases.MockSixCardGolfInteractor)
+	m.On("Hint").Return("hint result")
+	c := controller.NewSixCardGolfCuiController(m)
+
+	assert.Equal(t, "hint result", c.Exec("h"))
+	assert.Equal(t, "hint result", c.Exec("hint"))
+	m.AssertCalled(t, "Hint")
+}

--- a/internal/adapter/controller/usecase/SixCardGolfInteractor_mock.go
+++ b/internal/adapter/controller/usecase/SixCardGolfInteractor_mock.go
@@ -61,6 +61,11 @@ func (_m *MockSixCardGolfInteractor) ActionLog() string {
 	return _m.Called().String(0)
 }
 
+// Hint モック
+func (_m *MockSixCardGolfInteractor) Hint() string {
+	return _m.Called().String(0)
+}
+
 // Snapshot モック
 func (_m *MockSixCardGolfInteractor) Snapshot() ([]byte, error) {
 	ret := _m.Called()

--- a/internal/adapter/presenter/SixCardGolfCuiPresenter.go
+++ b/internal/adapter/presenter/SixCardGolfCuiPresenter.go
@@ -124,3 +124,31 @@ func scgPlayerName(player *domain.SixCardGolfPlayer, idx int) string {
 func (p *SixCardGolfCuiPresenter) ActionLogOutput(g interfaces.SixCardGolfGame) string {
 	return actionLogOutputText(g)
 }
+
+// HintOutput recommends a draw source (PlayerTurn) or a swap/discard for the
+// drawn card (DrawPending), mirroring the CPU's own evaluation so the advice
+// matches how the game scores. Other phases and non-human turns get no hint.
+func (p *SixCardGolfCuiPresenter) HintOutput(g interfaces.SixCardGolfGame) string {
+	if !g.IsHumanTurn() {
+		return i18n.T("sixcardgolf.hintNone") + "\n"
+	}
+	switch g.GetPhase() {
+	case domain.SixCardGolfPhasePlayerTurn:
+		if g.ShouldDrawFromDiscard() {
+			return color.Yellow(i18n.Tf("sixcardgolf.hintDrawDiscard",
+				"card", cuiCardStr(g.GetDiscardTop()))) + "\n"
+		}
+		return color.Yellow(i18n.T("sixcardgolf.hintDrawStock")) + "\n"
+	case domain.SixCardGolfPhaseDrawPending:
+		pos, formsPair := g.RecommendedSwap()
+		if pos < 0 {
+			return color.Yellow(i18n.T("sixcardgolf.hintDiscard")) + "\n"
+		}
+		if formsPair {
+			return color.Yellow(i18n.Tf("sixcardgolf.hintSwapPair", "pos", strconv.Itoa(pos))) + "\n"
+		}
+		return color.Yellow(i18n.Tf("sixcardgolf.hintSwap", "pos", strconv.Itoa(pos))) + "\n"
+	default:
+		return i18n.T("sixcardgolf.hintNone") + "\n"
+	}
+}

--- a/internal/adapter/presenter/SixCardGolfCuiPresenter_test.go
+++ b/internal/adapter/presenter/SixCardGolfCuiPresenter_test.go
@@ -1,0 +1,84 @@
+//go:build test
+
+package presenter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
+)
+
+// sixCardGolfDrawPending returns a human-turn DrawPending game whose grid is
+// filled with the given face-up value and with drawnCard set.
+func sixCardGolfDrawPending(gridValue, drawnValue int) *domain.SixCardGolf {
+	g := domain.NewDefaultSixCardGolf()
+	g.Reset()
+	g.SetCurrentPlayerIdx(0)
+	g.SetPhase(domain.SixCardGolfPhaseDrawPending)
+	p := g.GetPlayer(0)
+	for i := range p.Grid {
+		p.Grid[i] = domain.SixCardGolfSlot{Card: domain.NewCard(domain.CardDesignSpade, gridValue, false), FaceUp: true}
+	}
+	g.SetDrawnCard(domain.NewCard(domain.CardDesignSpade, drawnValue, false))
+	return g
+}
+
+func TestSixCardGolfCuiPresenter_HintOutput(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(orig)
+	p := new(presenter.SixCardGolfCuiPresenter)
+
+	t.Run("swap recommended for a low drawn card", func(t *testing.T) {
+		g := sixCardGolfDrawPending(11, 1) // Jacks in grid, drew an Ace
+		assert.Contains(t, p.HintOutput(g), "sw")
+	})
+
+	t.Run("discard recommended for a high drawn card", func(t *testing.T) {
+		g := sixCardGolfDrawPending(1, 11) // Aces in grid, drew a Jack
+		assert.Contains(t, p.HintOutput(g), i18n.T("sixcardgolf.hintDiscard"))
+	})
+
+	t.Run("column pair is called out", func(t *testing.T) {
+		g := sixCardGolfDrawPending(9, 5)
+		g.GetPlayer(0).Grid[3] = domain.SixCardGolfSlot{Card: domain.NewCard(domain.CardDesignSpade, 5, false), FaceUp: true}
+		assert.Contains(t, p.HintOutput(g), i18n.Tf("sixcardgolf.hintSwapPair", "pos", "0"))
+	})
+
+	t.Run("draw from discard for a low top card", func(t *testing.T) {
+		g := domain.NewDefaultSixCardGolf()
+		g.Reset()
+		g.SetCurrentPlayerIdx(0)
+		g.SetPhase(domain.SixCardGolfPhasePlayerTurn)
+		g.SetDiscardPile([]*domain.Card{domain.NewCard(domain.CardDesignSpade, 13, false)}) // King = 0
+		assert.Contains(t, p.HintOutput(g), "dd")
+	})
+
+	t.Run("draw from stock for a high top card", func(t *testing.T) {
+		g := domain.NewDefaultSixCardGolf()
+		g.Reset()
+		g.SetCurrentPlayerIdx(0)
+		g.SetPhase(domain.SixCardGolfPhasePlayerTurn)
+		g.SetDiscardPile([]*domain.Card{domain.NewCard(domain.CardDesignSpade, 9, false)}) // 9 > 3
+		assert.Contains(t, p.HintOutput(g), i18n.T("sixcardgolf.hintDrawStock"))
+	})
+
+	t.Run("no hint on a CPU turn", func(t *testing.T) {
+		g := sixCardGolfDrawPending(11, 1)
+		g.SetCurrentPlayerIdx(1) // CPU
+		assert.Contains(t, p.HintOutput(g), i18n.T("sixcardgolf.hintNone"))
+	})
+
+	t.Run("no hint outside a decision phase", func(t *testing.T) {
+		g := domain.NewDefaultSixCardGolf()
+		g.Reset()
+		g.SetCurrentPlayerIdx(0)
+		g.SetPhase(domain.SixCardGolfPhaseSetup)
+		assert.Contains(t, p.HintOutput(g), i18n.T("sixcardgolf.hintNone"))
+	})
+}

--- a/internal/adapter/presenter/SixCardGolfWebPresenter.go
+++ b/internal/adapter/presenter/SixCardGolfWebPresenter.go
@@ -112,3 +112,9 @@ func (p *SixCardGolfWebPresenter) buildMessage(g interfaces.SixCardGolfGame, las
 func (p *SixCardGolfWebPresenter) ActionLogOutput(g interfaces.SixCardGolfGame) string {
 	return actionLogOutputJSON(g)
 }
+
+// HintOutput はヒントを返す。Web ではクライアント側でヒントを算出するため、
+// 状態出力にフォールバックする (CUI プレゼンターのみが専用ヒントを返す)。
+func (p *SixCardGolfWebPresenter) HintOutput(g interfaces.SixCardGolfGame) string {
+	return p.Output(g, nil)
+}

--- a/internal/adapter/presenter/SixCardGolfWebPresenter_test.go
+++ b/internal/adapter/presenter/SixCardGolfWebPresenter_test.go
@@ -1,0 +1,20 @@
+//go:build test
+
+package presenter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+)
+
+func TestSixCardGolfWebPresenter_HintOutput(t *testing.T) {
+	g := domain.NewDefaultSixCardGolf()
+	g.Reset()
+	p := new(presenter.SixCardGolfWebPresenter)
+	// The web presenter computes hints client-side, so HintOutput mirrors Output.
+	assert.Equal(t, p.Output(g, nil), p.HintOutput(g))
+}

--- a/internal/domain/SixCardGolf.go
+++ b/internal/domain/SixCardGolf.go
@@ -672,6 +672,50 @@ func (g *SixCardGolf) ScorePlayer(playerIdx int) int {
 	return total
 }
 
+// ShouldDrawFromDiscard は捨て札トップを引くべきか (スコア <= 3 の低いカード) を返す。
+// CPU の cpuDraw と同じ基準で、PlayerTurn の CUI ヒントが利用する。
+func (g *SixCardGolf) ShouldDrawFromDiscard() bool {
+	top := g.GetDiscardTop()
+	return top != nil && g.sixCardGolfCardScore(top) <= 3
+}
+
+// RecommendedSwap は引いたカードを交換すべき最良のグリッド位置と、それが列ペアを
+// 完成させるかを返す。交換より捨てが良ければ pos = -1。DrawPending 以外・引いた
+// カードなしでも pos = -1。CPU の cpuSwapOrDiscard と同じ評価ロジックを用いる。
+func (g *SixCardGolf) RecommendedSwap() (pos int, formsPair bool) {
+	if g.phase != SixCardGolfPhaseDrawPending || g.drawnCard == nil {
+		return -1, false
+	}
+	p := g.players[g.currentPlayerIdx]
+	if p == nil {
+		return -1, false
+	}
+	drawnScore := g.sixCardGolfCardScore(g.drawnCard)
+	bestPos, bestGain, bestPair := -1, 0, false
+	for i := 0; i < SixCardGolfGridSize; i++ {
+		s := p.Grid[i]
+		pair := g.wouldColumnMatch(g.currentPlayerIdx, i, g.drawnCard)
+		var gain int
+		if s.FaceUp {
+			gain = g.sixCardGolfCardScore(s.Card) - drawnScore
+			if pair {
+				gain = g.sixCardGolfCardScore(s.Card) + drawnScore
+			}
+		} else if drawnScore <= 3 {
+			gain = 5 - drawnScore
+			if pair {
+				gain = 10
+			}
+		} else {
+			continue
+		}
+		if gain > bestGain {
+			bestGain, bestPos, bestPair = gain, i, pair
+		}
+	}
+	return bestPos, bestPair
+}
+
 // sixCardGolfCardScore カード1枚のスコア
 func (g *SixCardGolf) sixCardGolfCardScore(c *Card) int {
 	if c == nil {

--- a/internal/domain/SixCardGolf_test.go
+++ b/internal/domain/SixCardGolf_test.go
@@ -857,3 +857,68 @@ func skipSetup(g *SixCardGolf) {
 	g.SetPhase(SixCardGolfPhasePlayerTurn)
 	g.SetCurrentPlayerIdx(0)
 }
+
+func TestSixCardGolf_ShouldDrawFromDiscard(t *testing.T) {
+	g := newTestSixCardGolf()
+	g.Reset()
+	g.SetDiscardPile([]*Card{NewCard(CardDesignSpade, 13, false)}) // King = score 0
+	assert.True(t, g.ShouldDrawFromDiscard())
+	g.SetDiscardPile([]*Card{NewCard(CardDesignSpade, 9, false)}) // 9 > 3
+	assert.False(t, g.ShouldDrawFromDiscard())
+	g.SetDiscardPile(nil)
+	assert.False(t, g.ShouldDrawFromDiscard())
+}
+
+func TestSixCardGolf_RecommendedSwap(t *testing.T) {
+	fill := func(g *SixCardGolf, value int) {
+		p := g.GetPlayer(0)
+		for i := range p.Grid {
+			p.Grid[i] = makeSlot(value, CardDesignSpade, true)
+		}
+	}
+
+	t.Run("swaps a low drawn card into a high grid", func(t *testing.T) {
+		g := newTestSixCardGolf()
+		g.Reset()
+		g.SetCurrentPlayerIdx(0)
+		g.SetPhase(SixCardGolfPhaseDrawPending)
+		fill(g, 11)                                        // Jacks = 10 each
+		g.SetDrawnCard(NewCard(CardDesignSpade, 1, false)) // Ace = 1
+		pos, pair := g.RecommendedSwap()
+		assert.GreaterOrEqual(t, pos, 0)
+		assert.False(t, pair)
+	})
+
+	t.Run("recommends discard for a high drawn card over a low grid", func(t *testing.T) {
+		g := newTestSixCardGolf()
+		g.Reset()
+		g.SetCurrentPlayerIdx(0)
+		g.SetPhase(SixCardGolfPhaseDrawPending)
+		fill(g, 1)                                          // Aces = 1 each
+		g.SetDrawnCard(NewCard(CardDesignSpade, 11, false)) // Jack = 10
+		pos, _ := g.RecommendedSwap()
+		assert.Equal(t, -1, pos)
+	})
+
+	t.Run("flags a column pair", func(t *testing.T) {
+		g := newTestSixCardGolf()
+		g.Reset()
+		g.SetCurrentPlayerIdx(0)
+		g.SetPhase(SixCardGolfPhaseDrawPending)
+		fill(g, 9) // 9s so no accidental pairs
+		p := g.GetPlayer(0)
+		p.Grid[3] = makeSlot(5, CardDesignSpade, true) // column 0 partner is a 5
+		g.SetDrawnCard(NewCard(CardDesignHeart, 5, false))
+		pos, pair := g.RecommendedSwap()
+		assert.Equal(t, 0, pos)
+		assert.True(t, pair)
+	})
+
+	t.Run("no recommendation outside DrawPending", func(t *testing.T) {
+		g := newTestSixCardGolf()
+		g.Reset()
+		g.SetPhase(SixCardGolfPhasePlayerTurn)
+		pos, _ := g.RecommendedSwap()
+		assert.Equal(t, -1, pos)
+	})
+}

--- a/internal/domain/interfaces/sixcardgolf.go
+++ b/internal/domain/interfaces/sixcardgolf.go
@@ -60,4 +60,8 @@ type SixCardGolfGame interface {
 	GetCanFlip() bool
 	// GetFinalTurnTrigger 最終ターントリガーのプレイヤーインデックス
 	GetFinalTurnTrigger() int
+	// ShouldDrawFromDiscard 捨て札トップを引くべきか
+	ShouldDrawFromDiscard() bool
+	// RecommendedSwap 引いたカードの推奨交換位置 (-1=捨て) と列ペア成立可否
+	RecommendedSwap() (pos int, formsPair bool)
 }

--- a/internal/i18n/locales/en/sixcardgolf.json
+++ b/internal/i18n/locales/en/sixcardgolf.json
@@ -21,5 +21,11 @@
   "promptFlip": "Flip a face-down card (fl <pos>) or skip (sf)",
   "promptNextRound": "Round over (nr for next round)",
   "playerLine": "{{name}} (Total={{cum}}, R={{round}}){{marker}}",
-  "scoreLine": "  Score: {{score}}"
+  "scoreLine": "  Score: {{score}}",
+  "hintNone": "No hint available.",
+  "hintDrawDiscard": "Recommended: draw the discard {{card}} (dd) — it is a low card",
+  "hintDrawStock": "Recommended: draw from the stock (ds)",
+  "hintSwap": "Recommended: swap the drawn card into position {{pos}} (sw {{pos}})",
+  "hintSwapPair": "Recommended: swap into position {{pos}} (sw {{pos}}) — completes a column pair",
+  "hintDiscard": "Recommended: discard the drawn card (di)"
 }

--- a/internal/i18n/locales/ja/sixcardgolf.json
+++ b/internal/i18n/locales/ja/sixcardgolf.json
@@ -21,5 +21,11 @@
   "promptFlip": "伏せ札をめくれます (fl <pos>) またはスキップ (sf)",
   "promptNextRound": "ラウンド終了 (nr で次のラウンドへ)",
   "playerLine": "{{name}} (累計={{cum}}, R={{round}}){{marker}}",
-  "scoreLine": "  Score: {{score}}"
+  "scoreLine": "  Score: {{score}}",
+  "hintNone": "現在ヒントはありません。",
+  "hintDrawDiscard": "推奨: 捨て札 {{card}} を引く（dd）— 低いカードです",
+  "hintDrawStock": "推奨: 山札から引く（ds）",
+  "hintSwap": "推奨: 引いたカードを位置 {{pos}} と交換（sw {{pos}}）",
+  "hintSwapPair": "推奨: 位置 {{pos}} と交換（sw {{pos}}）— 列ペアが成立します",
+  "hintDiscard": "推奨: 引いたカードを捨てる（di）"
 }

--- a/internal/usecase/SixCardGolfInteractor.go
+++ b/internal/usecase/SixCardGolfInteractor.go
@@ -34,6 +34,8 @@ type SixCardGolfInteractorIF interface {
 	GetConfig() domain.SixCardGolfConfig
 	// ActionLog 棋譜
 	ActionLog() string
+	// Hint ヒントを出力する
+	Hint() string
 }
 
 // SixCardGolfInteractor シックスカードゴルフインタラクター
@@ -170,6 +172,11 @@ func (ci *SixCardGolfInteractor) GetConfig() domain.SixCardGolfConfig {
 // ActionLog 棋譜
 func (ci *SixCardGolfInteractor) ActionLog() string {
 	return ci.gp.ActionLogOutput(ci.Game)
+}
+
+// Hint ヒントを出力する
+func (ci *SixCardGolfInteractor) Hint() string {
+	return ci.gp.HintOutput(ci.Game)
 }
 
 // runCpuTurns CPUターンループ

--- a/internal/usecase/SixCardGolfInteractor_test.go
+++ b/internal/usecase/SixCardGolfInteractor_test.go
@@ -1,0 +1,23 @@
+//go:build test
+
+package usecase_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase/presenter"
+)
+
+func TestSixCardGolfInteractor_Hint(t *testing.T) {
+	game := domain.NewDefaultSixCardGolf()
+	pMock := new(presenter.MockSixCardGolfPresenter)
+	pMock.On("HintOutput", game).Return("hint")
+
+	ci := usecase.NewSixCardGolfInteractor(game, pMock)
+	assert.Equal(t, "hint", ci.Hint())
+	pMock.AssertExpectations(t)
+}

--- a/internal/usecase/presenter/SixCardGolfPresenter.go
+++ b/internal/usecase/presenter/SixCardGolfPresenter.go
@@ -3,4 +3,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // SixCardGolfPresenter シックスカードゴルフプレゼンターインタフェース
-type SixCardGolfPresenter = GamePresenter[interfaces.SixCardGolfGame]
+type SixCardGolfPresenter interface {
+	GamePresenter[interfaces.SixCardGolfGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.SixCardGolfGame) string
+}

--- a/internal/usecase/presenter/SixCardGolfPresenter_mock.go
+++ b/internal/usecase/presenter/SixCardGolfPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockSixCardGolfPresenter シックスカードゴルフプレゼンターモック
-type MockSixCardGolfPresenter = MockGamePresenter[interfaces.SixCardGolfGame]
+type MockSixCardGolfPresenter struct {
+	MockGamePresenter[interfaces.SixCardGolfGame]
+}
+
+// HintOutput モック
+func (_m *MockSixCardGolfPresenter) HintOutput(g interfaces.SixCardGolfGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 概要
`SixCardGolfCuiPresenter` に `HintOutput` が無く、CUI で `hint` コマンドが使えなかった。ドメインの CPU 評価ロジックを公開し（`RecommendedSwap`＝最良の交換位置 or 捨て＋列ペア成立可否、`ShouldDrawFromDiscard`＝捨て札トップが低スコアか）、CPU と同じ判断でヒントを出す。PlayerTurn ではドロー元、DrawPending では引いたカードの交換位置 or 捨てを推奨する。

## 変更点
- `SixCardGolf.go` / `interfaces/sixcardgolf.go`: `RecommendedSwap()` / `ShouldDrawFromDiscard()` を公開
- `usecase/presenter/SixCardGolfPresenter.go`(+mock): インタフェースに `HintOutput` 追加
- `SixCardGolfCuiPresenter.go`: `HintOutput`（hintSwap/hintSwapPair/hintDiscard/hintDrawDiscard/hintDrawStock/hintNone）
- `SixCardGolfWebPresenter.go`: `HintOutput` は `Output` に委譲
- `SixCardGolfInteractor.go`(+mock): `Hint()` 追加、`SixCardGolfCuiController.go`: h/hint 配線
- i18n: 6 キー ja/en
- テスト: 新規 presenter/interactor/controller/web テスト + ドメイン `RecommendedSwap`/`ShouldDrawFromDiscard`

Closes #3336