### PR TITLE
feat(sevencardstud): add a CUI third-street basic-strategy hint

### DIFF
--- a/internal/adapter/controller/SevenCardStudCuiController.go
+++ b/internal/adapter/controller/SevenCardStudCuiController.go
@@ -34,6 +34,7 @@ var sevenCardStudNoArgCommands = cuiutil.NewCommandMap[usecase.SevenCardStudInte
 	Add(usecase.SevenCardStudInteractorIF.SkipAddon, "sa", "skipaddon").
 	Add(usecase.SevenCardStudInteractorIF.Muck, "m", "muck").
 	Add(usecase.SevenCardStudInteractorIF.ShowHand, "sh", "show").
+	Add(usecase.SevenCardStudInteractorIF.Hint, "h", "hint").
 	Add(usecase.SevenCardStudInteractorIF.ActionLog, "log", "l")
 
 // sevenCardStudArgfulCommands lists alias names for argful commands handled in

--- a/internal/adapter/controller/SevenCardStudCuiController_test.go
+++ b/internal/adapter/controller/SevenCardStudCuiController_test.go
@@ -499,3 +499,11 @@ func TestSevenCardStudCuiController_Log(t *testing.T) {
 	assert.Equal(t, "log output", c.Exec("log"))
 	assert.Equal(t, "log output", c.Exec("l"))
 }
+
+func TestSevenCardStudCuiController_Hint(t *testing.T) {
+	mi := new(usecase.MockSevenCardStudInteractor)
+	c := NewSevenCardStudCuiController(mi)
+	mi.On("Hint").Return("hint output")
+	assert.Equal(t, "hint output", c.Exec("h"))
+	assert.Equal(t, "hint output", c.Exec("hint"))
+}

--- a/internal/adapter/controller/usecase/SevenCardStudInteractor_mock.go
+++ b/internal/adapter/controller/usecase/SevenCardStudInteractor_mock.go
@@ -79,6 +79,12 @@ func (_m *MockSevenCardStudInteractor) ActionLog() string {
 	return ret.Get(0).(string)
 }
 
+// Hint モック
+func (_m *MockSevenCardStudInteractor) Hint() string {
+	ret := _m.Called()
+	return ret.Get(0).(string)
+}
+
 // Snapshot モック
 func (_m *MockSevenCardStudInteractor) Snapshot() ([]byte, error) {
 	ret := _m.Called()

--- a/internal/adapter/presenter/SevenCardStudCuiPresenter.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter.go
@@ -3,6 +3,7 @@
 package presenter
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 
@@ -206,4 +207,83 @@ func (p *SevenCardStudCuiPresenter) Output(s interfaces.SevenCardStudGame, lastE
 			b.WriteString(i18n.T("sevencardstud.gameEnd") + "\n")
 		}
 	})
+}
+
+// sevenCardStudThreeStraight reports whether the three distinct card values form
+// a run (including the Q-K-A wheel where the Ace is high).
+func sevenCardStudThreeStraight(cards []*domain.Card) bool {
+	vs := make([]int, 0, len(cards))
+	seen := map[int]bool{}
+	for _, c := range cards {
+		v := c.GetValue()
+		if seen[v] {
+			return false
+		}
+		seen[v] = true
+		vs = append(vs, v)
+	}
+	if len(vs) != 3 {
+		return false
+	}
+	sort.Ints(vs)
+	if vs[2]-vs[0] == 2 {
+		return true
+	}
+	return vs[0] == 1 && vs[1] == 12 && vs[2] == 13 // Q-K-A
+}
+
+// sevenCardStudThirdStreetAdvice returns whether to continue on third street and
+// the i18n reason key, using classic starting-hand rules (any pair, three to a
+// flush, three to a straight, or three high cards).
+func sevenCardStudThirdStreetAdvice(cards []*domain.Card) (cont bool, reasonKey string) {
+	if len(cards) < 3 {
+		return false, "sevencardstud.hintReasonFold"
+	}
+	vals := map[int]int{}
+	suits := map[int]int{}
+	high := 0
+	for _, c := range cards {
+		vals[c.GetValue()]++
+		suits[c.GetDesign()]++
+		if v := c.GetValue(); v == 1 || v >= 10 {
+			high++
+		}
+	}
+	for _, n := range vals {
+		if n >= 2 {
+			return true, "sevencardstud.hintReasonPair"
+		}
+	}
+	for _, n := range suits {
+		if n >= 3 {
+			return true, "sevencardstud.hintReasonFlush"
+		}
+	}
+	if sevenCardStudThreeStraight(cards) {
+		return true, "sevencardstud.hintReasonStraight"
+	}
+	if high >= 3 {
+		return true, "sevencardstud.hintReasonHigh"
+	}
+	return false, "sevencardstud.hintReasonFold"
+}
+
+// HintOutput advises continue/fold on third street using basic starting-hand
+// strategy. It applies to the high game only (Razz inverts hand strength, and
+// already surfaces the best low), and to the human's turn on third street.
+func (p *SevenCardStudCuiPresenter) HintOutput(s interfaces.SevenCardStudGame) string {
+	if s.GetIsLowball() || !s.IsHumanTurn() || s.GetPhase() != domain.SevenCardStudPhaseThirdStreet {
+		return i18n.T("sevencardstud.hintNone") + "\n"
+	}
+	player := s.GetPlayer(s.GetCurrentTurn())
+	if player == nil {
+		return i18n.T("sevencardstud.hintNone") + "\n"
+	}
+	cont, reasonKey := sevenCardStudThirdStreetAdvice(player.GetAllCards())
+	action := i18n.T("sevencardstud.hintFold")
+	if cont {
+		action = i18n.T("sevencardstud.hintContinue")
+	}
+	return color.Yellow(i18n.Tf("sevencardstud.hint",
+		"action", action, "reason", i18n.T(reasonKey))) + "\n"
 }

--- a/internal/adapter/presenter/SevenCardStudCuiPresenter_test.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func TestSevenCardStudCuiPresenter_Output(t *testing.T) {
@@ -501,5 +502,78 @@ func TestSevenCardStudCuiPresenter_ActionLogOutput(t *testing.T) {
 		result := p.ActionLogOutput(mockGame)
 		assert.Contains(t, result, "棋譜はありません")
 		mockGame.AssertExpectations(t)
+	})
+}
+
+func TestSevenCardStudCuiPresenter_HintOutput(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+	p := new(presenter.SevenCardStudCuiPresenter)
+
+	c := func(suit, val int) *domain.Card { return domain.NewCard(suit, val, false) }
+	set := func(s *domain.SevenCardStud, players []*domain.SevenCardStudPlayer, cards ...*domain.Card) {
+		s.SetPhase(domain.SevenCardStudPhaseThirdStreet)
+		s.SetCurrentTurn(0)
+		players[0].ClearCards()
+		players[0].AddHoleCard(cards[0])
+		players[0].AddHoleCard(cards[1])
+		players[0].AddDoorCard(cards[2])
+	}
+
+	cases := []struct {
+		name      string
+		cards     []*domain.Card
+		continue_ bool
+		reason    string
+	}{
+		{"pair", []*domain.Card{c(domain.CardDesignSpade, 8), c(domain.CardDesignHeart, 8), c(domain.CardDesignClover, 2)}, true, "sevencardstud.hintReasonPair"},
+		{"three flush", []*domain.Card{c(domain.CardDesignSpade, 4), c(domain.CardDesignSpade, 8), c(domain.CardDesignSpade, 12)}, true, "sevencardstud.hintReasonFlush"},
+		{"three straight", []*domain.Card{c(domain.CardDesignSpade, 6), c(domain.CardDesignHeart, 7), c(domain.CardDesignClover, 8)}, true, "sevencardstud.hintReasonStraight"},
+		{"Q-K-A wheel straight", []*domain.Card{c(domain.CardDesignSpade, 1), c(domain.CardDesignHeart, 12), c(domain.CardDesignClover, 13)}, true, "sevencardstud.hintReasonStraight"},
+		{"three high", []*domain.Card{c(domain.CardDesignSpade, 1), c(domain.CardDesignHeart, 13), c(domain.CardDesignClover, 11)}, true, "sevencardstud.hintReasonHigh"},
+		{"junk folds", []*domain.Card{c(domain.CardDesignSpade, 2), c(domain.CardDesignHeart, 5), c(domain.CardDesignClover, 9)}, false, "sevencardstud.hintReasonFold"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, players := makeSevenCardStudForPresenter()
+			set(s, players, tc.cards...)
+			out := p.HintOutput(s)
+			assert.Contains(t, out, i18n.T(tc.reason))
+			if tc.continue_ {
+				assert.Contains(t, out, i18n.T("sevencardstud.hintContinue"))
+			} else {
+				assert.Contains(t, out, i18n.T("sevencardstud.hintFold"))
+			}
+		})
+	}
+
+	t.Run("no hint on a CPU turn", func(t *testing.T) {
+		s, _ := makeSevenCardStudForPresenter()
+		s.SetPhase(domain.SevenCardStudPhaseThirdStreet)
+		s.SetCurrentTurn(1) // CPU
+		assert.Contains(t, p.HintOutput(s), i18n.T("sevencardstud.hintNone"))
+	})
+
+	t.Run("no hint outside third street", func(t *testing.T) {
+		s, _ := makeSevenCardStudForPresenter()
+		s.SetPhase(domain.SevenCardStudPhaseFifthStreet)
+		s.SetCurrentTurn(0)
+		assert.Contains(t, p.HintOutput(s), i18n.T("sevencardstud.hintNone"))
+	})
+
+	t.Run("no hint in Razz (lowball)", func(t *testing.T) {
+		tc := domain.NewTrumpCards(0)
+		players := []*domain.SevenCardStudPlayer{
+			domain.NewSevenCardStudPlayer(true, domain.HoldemStyleTAG),
+			domain.NewSevenCardStudPlayer(false, domain.HoldemStyleLAP),
+		}
+		s := domain.NewRazz(tc, players, domain.DefaultSevenCardStudConfig())
+		s.SetPhase(domain.SevenCardStudPhaseThirdStreet)
+		s.SetCurrentTurn(0)
+		players[0].AddHoleCard(domain.NewCard(domain.CardDesignSpade, 8, false))
+		players[0].AddHoleCard(domain.NewCard(domain.CardDesignHeart, 8, false))
+		players[0].AddDoorCard(domain.NewCard(domain.CardDesignClover, 2, false))
+		assert.Contains(t, p.HintOutput(s), i18n.T("sevencardstud.hintNone"))
 	})
 }

--- a/internal/adapter/presenter/SevenCardStudWebPresenter.go
+++ b/internal/adapter/presenter/SevenCardStudWebPresenter.go
@@ -227,6 +227,12 @@ func (p *SevenCardStudWebPresenter) ActionLogOutput(s interfaces.SevenCardStudGa
 	return actionLogOutputJSON(s)
 }
 
+// HintOutput はヒントを返す。Web ではクライアント側でヒントを算出するため、
+// 状態出力にフォールバックする (CUI プレゼンターのみが専用ヒントを返す)。
+func (p *SevenCardStudWebPresenter) HintOutput(s interfaces.SevenCardStudGame) string {
+	return p.Output(s, nil)
+}
+
 // getHandName ハンドランクから名前を返す
 func (p *SevenCardStudWebPresenter) getHandName(rank int) string {
 	if rank >= 0 && rank < len(domain.PokerHandNames) {

--- a/internal/adapter/presenter/SevenCardStudWebPresenter_test.go
+++ b/internal/adapter/presenter/SevenCardStudWebPresenter_test.go
@@ -472,3 +472,11 @@ func TestSevenCardStudWebPresenter_ActionLogOutput(t *testing.T) {
 		mockGame.AssertExpectations(t)
 	})
 }
+
+func TestSevenCardStudWebPresenter_HintOutput(t *testing.T) {
+	s, _ := makeSevenCardStudForPresenter()
+	s.SetPhase(domain.SevenCardStudPhaseThirdStreet)
+	p := new(presenter.SevenCardStudWebPresenter)
+	// The web presenter computes hints client-side, so HintOutput mirrors Output.
+	assert.Equal(t, p.Output(s, nil), p.HintOutput(s))
+}

--- a/internal/i18n/locales/en/sevencardstud.json
+++ b/internal/i18n/locales/en/sevencardstud.json
@@ -58,5 +58,14 @@
   "addonPrompt": "Add-on? ({{chips}} chips) (ad=addon / sa=skip)",
   "gameEnd": "Game over",
   "razzLowComplete": "Best low: {{cards}}",
-  "razzLowIncomplete": "Best low (incomplete): {{cards}}"
+  "razzLowIncomplete": "Best low (incomplete): {{cards}}",
+  "hintNone": "No hint available.",
+  "hint": "Recommended: {{action}} ({{reason}})",
+  "hintContinue": "Continue (call/bet)",
+  "hintFold": "Fold",
+  "hintReasonPair": "a pair or better",
+  "hintReasonFlush": "three to a flush",
+  "hintReasonStraight": "three to a straight",
+  "hintReasonHigh": "three high cards",
+  "hintReasonFold": "no qualifying starting hand"
 }

--- a/internal/i18n/locales/ja/sevencardstud.json
+++ b/internal/i18n/locales/ja/sevencardstud.json
@@ -58,5 +58,14 @@
   "addonPrompt": "アドオンしますか? ({{chips}}チップ) (ad=アドオン / sa=スキップ)",
   "gameEnd": "ゲーム終了",
   "razzLowComplete": "現在のベストロー: {{cards}}",
-  "razzLowIncomplete": "ベストロー(未完成): {{cards}}"
+  "razzLowIncomplete": "ベストロー(未完成): {{cards}}",
+  "hintNone": "現在ヒントはありません。",
+  "hint": "推奨: {{action}}（{{reason}}）",
+  "hintContinue": "続行（コール／ベット）",
+  "hintFold": "フォールド",
+  "hintReasonPair": "ワンペア以上",
+  "hintReasonFlush": "3枚同スート（フラッシュの目）",
+  "hintReasonStraight": "3枚連続（ストレートの目）",
+  "hintReasonHigh": "3枚とも高札",
+  "hintReasonFold": "続行条件を満たしません"
 }

--- a/internal/usecase/SevenCardStudInteractor.go
+++ b/internal/usecase/SevenCardStudInteractor.go
@@ -23,6 +23,8 @@ type SevenCardStudInteractorIF interface {
 	GetConfig() domain.SevenCardStudConfig
 	// ActionLog 棋譜を出力する
 	ActionLog() string
+	// Hint ヒントを出力する
+	Hint() string
 }
 
 // SevenCardStudInteractor セブンカードスタッドインタラクタークラス
@@ -76,6 +78,11 @@ func (si *SevenCardStudInteractor) GetConfig() domain.SevenCardStudConfig {
 // ActionLog 棋譜を出力する
 func (si *SevenCardStudInteractor) ActionLog() string {
 	return si.sp.ActionLogOutput(si.Game)
+}
+
+// Hint ヒントを出力する
+func (si *SevenCardStudInteractor) Hint() string {
+	return si.sp.HintOutput(si.Game)
 }
 
 // RestoreSevenCardStudInteractor deserialises JSON into a SevenCardStudInteractor.

--- a/internal/usecase/SevenCardStudInteractor_test.go
+++ b/internal/usecase/SevenCardStudInteractor_test.go
@@ -208,3 +208,13 @@ func TestSevenCardStudInteractor_ResetWithConfig_WithProfile(t *testing.T) {
 	assert.Equal(t, "profile output", result)
 	mg.AssertCalled(t, "ImportProfile", mock.Anything)
 }
+
+func TestSevenCardStudInteractor_Hint(t *testing.T) {
+	mg := new(interfaces.MockSevenCardStudGame)
+	mp := new(presenter.MockSevenCardStudPresenter)
+	si := NewSevenCardStudInteractor(mg, mp)
+
+	mp.On("HintOutput", mg).Return("hint output")
+
+	assert.Equal(t, "hint output", si.Hint())
+}

--- a/internal/usecase/presenter/SevenCardStudPresenter.go
+++ b/internal/usecase/presenter/SevenCardStudPresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // SevenCardStudPresenter セブンカードスタッドプレゼンターインタフェース
-type SevenCardStudPresenter = GamePresenter[interfaces.SevenCardStudGame]
+type SevenCardStudPresenter interface {
+	GamePresenter[interfaces.SevenCardStudGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.SevenCardStudGame) string
+}

--- a/internal/usecase/presenter/SevenCardStudPresenter_mock.go
+++ b/internal/usecase/presenter/SevenCardStudPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockSevenCardStudPresenter セブンカードスタッドプレゼンターモック
-type MockSevenCardStudPresenter = MockGamePresenter[interfaces.SevenCardStudGame]
+type MockSevenCardStudPresenter struct {
+	MockGamePresenter[interfaces.SevenCardStudGame]
+}
+
+// HintOutput モック
+func (_m *MockSevenCardStudPresenter) HintOutput(g interfaces.SevenCardStudGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 概要
`SevenCardStudCuiPresenter` に `HintOutput` が無く、CUI プレイヤーはベット判断の支援を得られなかった。3rd ストリートの続行/フォールド推奨（ワンペア以上・3枚同スート・3枚連続・3枚とも高札）を理由付きで表示する。ハイゲーム限定（ラズはロー志向で強さが反転し、既にベストロー表示があるため対象外）かつ人間の手番のときのみ出す。

## 変更点
- `SevenCardStudCuiPresenter.go`: `HintOutput` + `sevenCardStudThirdStreetAdvice`/`sevenCardStudThreeStraight`
- `usecase/presenter/SevenCardStudPresenter.go`(+mock): インタフェースに `HintOutput` 追加
- `SevenCardStudWebPresenter.go`: `HintOutput` は `Output` に委譲
- `SevenCardStudInteractor.go`(+mock): `Hint()` 追加、`SevenCardStudCuiController.go`: h/hint 配線
- i18n: hintNone/hint/hintContinue/hintFold/理由キー5種 ja/en
- テスト: テーブル駆動 presenter（pair/flush/straight/wheel/high/junk/非手番/他ストリート/ラズ）＋ interactor Hint ＋ controller h/hint ＋ web HintOutput

Closes #3119