### PR TITLE
feat(rummy500): add a CUI hint listing meldable card combinations

### DIFF
--- a/internal/adapter/controller/Rummy500CuiController.go
+++ b/internal/adapter/controller/Rummy500CuiController.go
@@ -32,6 +32,7 @@ func (c *Rummy500CuiController) Exec(command string) string {
 			"ds", "drawstock", "dd", "drawdiscard",
 			"m", "meld", "lo", "layoff", "d", "discard",
 			"nr", "nextround",
+			"h", "hint",
 			"sd", "setdifficulty", "sl", "setlimit", "log", "l",
 		},
 		func(cmd string, args []string) (string, bool) {
@@ -68,7 +69,7 @@ func (c *Rummy500CuiController) Exec(command string) string {
 					return c.ci.ResetWithConfig(cfg)
 				})
 			default:
-				return handleCuiLog(cmd, c.ci.ActionLog)
+				return handleCuiHintAndLog(cmd, c.ci.Hint, c.ci.ActionLog)
 			}
 		},
 	)

--- a/internal/adapter/controller/Rummy500CuiController_test.go
+++ b/internal/adapter/controller/Rummy500CuiController_test.go
@@ -27,8 +27,17 @@ func TestRummy500CuiController_Exec(t *testing.T) {
 		m.On("Discard", mock.Anything).Return(mockOutput)
 		m.On("NextRound").Return(mockOutput)
 		m.On("ActionLog").Return(mockOutput)
+		m.On("Hint").Return(mockOutput)
 		return m
 	}
+
+	t.Run("hint h", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewRummy500CuiController(m)
+		assert.Equal(t, mockOutput, c.Exec("h"))
+		assert.Equal(t, mockOutput, c.Exec("hint"))
+		m.AssertCalled(t, "Hint")
+	})
 
 	t.Run("quit q", func(t *testing.T) {
 		c := controller.NewRummy500CuiController(newMock())

--- a/internal/adapter/controller/usecase/Rummy500Interactor_mock.go
+++ b/internal/adapter/controller/usecase/Rummy500Interactor_mock.go
@@ -53,6 +53,11 @@ func (_m *MockRummy500Interactor) ActionLog() string {
 	return _m.Called().String(0)
 }
 
+// Hint モック
+func (_m *MockRummy500Interactor) Hint() string {
+	return _m.Called().String(0)
+}
+
 func (_m *MockRummy500Interactor) Snapshot() ([]byte, error) {
 	ret := _m.Called()
 	return ret.Get(0).([]byte), ret.Error(1)

--- a/internal/adapter/presenter/Rummy500CuiPresenter.go
+++ b/internal/adapter/presenter/Rummy500CuiPresenter.go
@@ -103,3 +103,52 @@ func (p *Rummy500CuiPresenter) Output(g interfaces.Rummy500Game, lastErr error) 
 func (p *Rummy500CuiPresenter) ActionLogOutput(g interfaces.Rummy500Game) string {
 	return actionLogOutputText(g)
 }
+
+// rummy500MeldCandidates returns up to `limit` index triples of the player's
+// hand that form a valid meld. Reusing the domain validator, a 3-card subset is
+// enough: any longer set/run contains a valid 3-card meld, so at least one
+// representative surfaces for the player to build on.
+func rummy500MeldCandidates(player *domain.Rummy500Player, limit int) [][]int {
+	n := player.GetCardsSize()
+	cards := make([]*domain.Card, n)
+	for i := 0; i < n; i++ {
+		cards[i] = player.GetCard(i)
+	}
+	var out [][]int
+	for i := 0; i < n && len(out) < limit; i++ {
+		for j := i + 1; j < n && len(out) < limit; j++ {
+			for k := j + 1; k < n && len(out) < limit; k++ {
+				if domain.Rummy500IsValidMeld([]*domain.Card{cards[i], cards[j], cards[k]}) {
+					out = append(out, []int{i, j, k})
+				}
+			}
+		}
+	}
+	return out
+}
+
+// HintOutput lists meldable index groups from the human's hand during the play
+// phase; when none exist it advises discarding. Other phases and non-human turns
+// get no hint.
+func (p *Rummy500CuiPresenter) HintOutput(g interfaces.Rummy500Game) string {
+	if g.GetPhase() != domain.Rummy500PhasePlay || !g.IsHumanTurn() {
+		return i18n.T("rummy500.hintNone") + "\n"
+	}
+	player := g.GetPlayer(g.GetCurrentPlayerIdx())
+	if player == nil {
+		return i18n.T("rummy500.hintNone") + "\n"
+	}
+	cands := rummy500MeldCandidates(player, 3)
+	if len(cands) == 0 {
+		return color.Yellow(i18n.T("rummy500.hintNoMeld")) + "\n"
+	}
+	groups := make([]string, len(cands))
+	for gi, group := range cands {
+		idxs := make([]string, len(group))
+		for i, idx := range group {
+			idxs[i] = "[" + strconv.Itoa(idx) + "]" + cuiCardStr(player.GetCard(idx))
+		}
+		groups[gi] = "(" + strings.Join(idxs, " ") + ")"
+	}
+	return color.Yellow(i18n.Tf("rummy500.hintMeld", "cands", strings.Join(groups, " / "))) + "\n"
+}

--- a/internal/adapter/presenter/Rummy500CuiPresenter_test.go
+++ b/internal/adapter/presenter/Rummy500CuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupRummy500CuiMock() *interfaces.MockRummy500Game {
@@ -128,4 +130,50 @@ func TestRummy500CuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetGameEndFlag").Return(false)
 	out := p.ActionLogOutput(m)
 	assert.NotEmpty(t, out)
+}
+
+func TestRummy500CuiPresenter_HintOutput(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+	p := new(presenter.Rummy500CuiPresenter)
+
+	playPhase := func() (*interfaces.MockRummy500Game, []*domain.Rummy500Player) {
+		m, players := setupRummy500CuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.Rummy500PhasePlay)
+		m.On("IsHumanTurn").Return(true)
+		return m, players
+	}
+
+	t.Run("lists meld candidates", func(t *testing.T) {
+		m, players := playPhase()
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 8, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 8, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignClover, 8, false))
+		out := p.HintOutput(m)
+		prefix := strings.SplitN(i18n.T("rummy500.hintMeld"), "{{", 2)[0]
+		assert.Contains(t, out, prefix)
+	})
+
+	t.Run("advises discarding when no meld is possible", func(t *testing.T) {
+		m, players := playPhase()
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 2, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 7, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignClover, 11, false))
+		assert.Contains(t, p.HintOutput(m), i18n.T("rummy500.hintNoMeld"))
+	})
+
+	t.Run("no hint during the draw phase", func(t *testing.T) {
+		m, _ := setupRummy500CuiMockWithPlayers()
+		m.On("IsHumanTurn").Return(true)
+		assert.Contains(t, p.HintOutput(m), i18n.T("rummy500.hintNone"))
+	})
+
+	t.Run("no hint on a CPU turn", func(t *testing.T) {
+		m, _ := playPhase()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "IsHumanTurn")
+		m.On("IsHumanTurn").Return(false)
+		assert.Contains(t, p.HintOutput(m), i18n.T("rummy500.hintNone"))
+	})
 }

--- a/internal/adapter/presenter/Rummy500WebPresenter.go
+++ b/internal/adapter/presenter/Rummy500WebPresenter.go
@@ -103,3 +103,9 @@ func (p *Rummy500WebPresenter) buildMessage(g interfaces.Rummy500Game, lastErr e
 func (p *Rummy500WebPresenter) ActionLogOutput(g interfaces.Rummy500Game) string {
 	return actionLogOutputJSON(g)
 }
+
+// HintOutput はヒントを返す。Web ではクライアント側でヒントを算出するため、
+// 状態出力にフォールバックする (CUI プレゼンターのみが専用ヒントを返す)。
+func (p *Rummy500WebPresenter) HintOutput(g interfaces.Rummy500Game) string {
+	return p.Output(g, nil)
+}

--- a/internal/adapter/presenter/Rummy500WebPresenter_test.go
+++ b/internal/adapter/presenter/Rummy500WebPresenter_test.go
@@ -127,3 +127,11 @@ func TestRummy500WebPresenter_ActionLogOutput(t *testing.T) {
 	out := p.ActionLogOutput(m)
 	assert.NotEmpty(t, out)
 }
+
+func TestRummy500WebPresenter_HintOutput(t *testing.T) {
+	m, players := setupRummy500WebMock()
+	players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 5, false))
+	p := new(presenter.Rummy500WebPresenter)
+	// The web presenter computes hints client-side, so HintOutput mirrors Output.
+	assert.Equal(t, p.Output(m, nil), p.HintOutput(m))
+}

--- a/internal/i18n/locales/en/rummy500.json
+++ b/internal/i18n/locales/en/rummy500.json
@@ -27,5 +27,8 @@
   "playPhase": "Play phase",
   "roundEnd": "Round end",
   "winnerHuman": "You win!",
-  "winnerCpu": "CPU {{idx}} wins"
+  "winnerCpu": "CPU {{idx}} wins",
+  "hintNone": "No hint available.",
+  "hintMeld": "Meld candidates: {{cands}} (m <idx...> to lay down)",
+  "hintNoMeld": "No meldable combination. Consider discarding with d <idx>."
 }

--- a/internal/i18n/locales/ja/rummy500.json
+++ b/internal/i18n/locales/ja/rummy500.json
@@ -27,5 +27,8 @@
   "playPhase": "プレイフェーズ",
   "roundEnd": "ラウンド終了",
   "winnerHuman": "あなたの勝利！",
-  "winnerCpu": "CPU {{idx}}の勝利"
+  "winnerCpu": "CPU {{idx}}の勝利",
+  "hintNone": "現在ヒントはありません。",
+  "hintMeld": "メルド候補: {{cands}}（m <idx...> で場に出す）",
+  "hintNoMeld": "メルドできる組み合わせがありません。d <idx> で捨て札を検討してください。"
 }

--- a/internal/usecase/Rummy500Interactor.go
+++ b/internal/usecase/Rummy500Interactor.go
@@ -32,6 +32,8 @@ type Rummy500InteractorIF interface {
 	GetConfig() domain.Rummy500Config
 	// ActionLog 棋譜を出力する
 	ActionLog() string
+	// Hint ヒントを出力する
+	Hint() string
 }
 
 // Rummy500Interactor Rummy 500インタラクタークラス
@@ -134,6 +136,11 @@ func (ci *Rummy500Interactor) GetConfig() domain.Rummy500Config {
 // ActionLog 棋譜を出力する
 func (ci *Rummy500Interactor) ActionLog() string {
 	return ci.gp.ActionLogOutput(ci.Game)
+}
+
+// Hint ヒントを出力する
+func (ci *Rummy500Interactor) Hint() string {
+	return ci.gp.HintOutput(ci.Game)
 }
 
 // runCpuTurns CPUターンを連続実行

--- a/internal/usecase/Rummy500Interactor_test.go
+++ b/internal/usecase/Rummy500Interactor_test.go
@@ -353,3 +353,11 @@ func TestRestoreRummy500Interactor(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, ci)
 }
+
+func TestRummy500Interactor_Hint(t *testing.T) {
+	pMock := new(presenter.MockRummy500Presenter)
+	pMock.On("HintOutput", mock.Anything).Return("hint output")
+	gameMock := new(interfaces.MockRummy500Game)
+	ci := usecase.NewRummy500Interactor(gameMock, pMock)
+	assert.Equal(t, "hint output", ci.Hint())
+}

--- a/internal/usecase/presenter/Rummy500Presenter.go
+++ b/internal/usecase/presenter/Rummy500Presenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // Rummy500Presenter Rummy 500プレゼンターインタフェース
-type Rummy500Presenter = GamePresenter[interfaces.Rummy500Game]
+type Rummy500Presenter interface {
+	GamePresenter[interfaces.Rummy500Game]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.Rummy500Game) string
+}

--- a/internal/usecase/presenter/Rummy500Presenter_mock.go
+++ b/internal/usecase/presenter/Rummy500Presenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockRummy500Presenter Rummy 500プレゼンターモック
-type MockRummy500Presenter = MockGamePresenter[interfaces.Rummy500Game]
+type MockRummy500Presenter struct {
+	MockGamePresenter[interfaces.Rummy500Game]
+}
+
+// HintOutput モック
+func (_m *MockRummy500Presenter) HintOutput(g interfaces.Rummy500Game) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 概要
`Rummy500CuiPresenter` に `HintOutput` が無く、CUI プレイヤーはメルド構築の支援を得られなかった。プレイフェーズで人間の手札から成立するメルド（セット/ラン）のインデックス組を列挙して表示する（ドメインの既存 `Rummy500IsValidMeld` を再利用、3枚代表で任意のセット/ランを検出）。候補が無ければ捨て札を勧める。

## 変更点
- `Rummy500CuiPresenter.go`: `HintOutput` + `rummy500MeldCandidates`
- `usecase/presenter/Rummy500Presenter.go`(+mock): インタフェースに `HintOutput` 追加
- `Rummy500WebPresenter.go`: `HintOutput` は `Output` に委譲
- `Rummy500Interactor.go`(+mock): `Hint()` 追加、`Rummy500CuiController.go`: h/hint 配線
- i18n: hintNone/hintMeld/hintNoMeld ja/en
- テスト: presenter（候補あり/なし/ドロー中/CPU番）＋ interactor Hint ＋ controller h/hint ＋ web HintOutput

Closes #3321