### PR TITLE
feat(pageone): add a CUI hint command listing playable cards

### DIFF
--- a/internal/adapter/controller/PageOneCuiController.go
+++ b/internal/adapter/controller/PageOneCuiController.go
@@ -14,6 +14,7 @@ var pageOneNoArgCommands = cuiutil.NewCommandMap[usecase.PageOneInteractorIF]().
 	Add(usecase.PageOneInteractorIF.Declare, "dc", "declare").
 	Add(usecase.PageOneInteractorIF.SkipDeclare, "sk", "skip").
 	Add(usecase.PageOneInteractorIF.NextRound, "nr", "nextround").
+	Add(usecase.PageOneInteractorIF.Hint, "h", "hint").
 	Add(usecase.PageOneInteractorIF.ActionLog, "log", "l")
 
 // pageOneArgfulCommands lists alias names for argful commands handled in the

--- a/internal/adapter/controller/PageOneCuiController_test.go
+++ b/internal/adapter/controller/PageOneCuiController_test.go
@@ -26,8 +26,17 @@ func TestPageOneCuiController_Exec(t *testing.T) {
 		m.On("SkipDeclare").Return(mockOutput)
 		m.On("NextRound").Return(mockOutput)
 		m.On("ActionLog").Return(mockOutput)
+		m.On("Hint").Return(mockOutput)
 		return m
 	}
+
+	t.Run("hint h", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewPageOneCuiController(m)
+		assert.Equal(t, mockOutput, c.Exec("h"))
+		assert.Equal(t, mockOutput, c.Exec("hint"))
+		m.AssertCalled(t, "Hint")
+	})
 
 	t.Run("quit q", func(t *testing.T) {
 		c := controller.NewPageOneCuiController(newMock())

--- a/internal/adapter/controller/usecase/PageOneInteractor_mock.go
+++ b/internal/adapter/controller/usecase/PageOneInteractor_mock.go
@@ -49,6 +49,11 @@ func (_m *MockPageOneInteractor) ActionLog() string {
 	return _m.Called().String(0)
 }
 
+// Hint モック
+func (_m *MockPageOneInteractor) Hint() string {
+	return _m.Called().String(0)
+}
+
 // Snapshot モック
 func (_m *MockPageOneInteractor) Snapshot() ([]byte, error) {
 	ret := _m.Called()

--- a/internal/adapter/presenter/PageOneCuiPresenter.go
+++ b/internal/adapter/presenter/PageOneCuiPresenter.go
@@ -2,6 +2,7 @@ package presenter
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -99,4 +100,27 @@ func (p *PageOneCuiPresenter) Output(g interfaces.PageOneGame, lastErr error) st
 // ActionLogOutput 棋譜をテキスト出力
 func (p *PageOneCuiPresenter) ActionLogOutput(g interfaces.PageOneGame) string {
 	return actionLogOutputText(g)
+}
+
+// HintOutput lists the human's playable card indices during the play phase, or
+// advises drawing when nothing is playable. Other phases and non-human turns
+// get no hint.
+func (p *PageOneCuiPresenter) HintOutput(g interfaces.PageOneGame) string {
+	if g.GetPhase() != domain.PageOnePhasePlay || !g.IsHumanTurn() {
+		return i18n.T("pageone.hintNone") + "\n"
+	}
+	player := g.GetPlayer(g.GetCurrentPlayerIdx())
+	if player == nil {
+		return i18n.T("pageone.hintNone") + "\n"
+	}
+	var parts []string
+	for i := 0; i < player.GetCardsSize(); i++ {
+		if g.IsValidPlay(player.GetCard(i)) {
+			parts = append(parts, "["+strconv.Itoa(i)+"]"+cuiCardStr(player.GetCard(i)))
+		}
+	}
+	if len(parts) == 0 {
+		return color.Yellow(i18n.T("pageone.hintDraw")) + "\n"
+	}
+	return color.Yellow(i18n.Tf("pageone.hintPlayable", "cards", strings.Join(parts, " "))) + "\n"
 }

--- a/internal/adapter/presenter/PageOneCuiPresenter_test.go
+++ b/internal/adapter/presenter/PageOneCuiPresenter_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupPageOneCuiMock() *interfaces.MockPageOneGame {
@@ -168,5 +169,50 @@ func TestPageOneCuiPresenter_ActionLogOutput(t *testing.T) {
 		m.On("GetGameEndFlag").Return(false)
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜はありません")
+	})
+}
+
+func TestPageOneCuiPresenter_HintOutput(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+	p := new(presenter.PageOneCuiPresenter)
+
+	t.Run("lists only playable card indices", func(t *testing.T) {
+		m, players := setupPageOneCuiMockWithPlayers()
+		m.On("IsHumanTurn").Return(true)
+		playable := domain.NewCard(domain.CardDesignHeart, 5, false)
+		unplayable := domain.NewCard(domain.CardDesignSpade, 9, false)
+		players[0].AddCard(playable)
+		players[0].AddCard(unplayable)
+		m.On("IsValidPlay", playable).Return(true)
+		m.On("IsValidPlay", unplayable).Return(false)
+
+		out := p.HintOutput(m)
+		assert.Contains(t, out, i18n.Tf("pageone.hintPlayable", "cards", "[0]HEART 5"))
+		assert.NotContains(t, out, "[1]")
+	})
+
+	t.Run("advises drawing when nothing is playable", func(t *testing.T) {
+		m, players := setupPageOneCuiMockWithPlayers()
+		m.On("IsHumanTurn").Return(true)
+		c := domain.NewCard(domain.CardDesignSpade, 9, false)
+		players[0].AddCard(c)
+		m.On("IsValidPlay", c).Return(false)
+		assert.Contains(t, p.HintOutput(m), i18n.T("pageone.hintDraw"))
+	})
+
+	t.Run("no hint on a CPU turn", func(t *testing.T) {
+		m, _ := setupPageOneCuiMockWithPlayers()
+		m.On("IsHumanTurn").Return(false)
+		assert.Contains(t, p.HintOutput(m), i18n.T("pageone.hintNone"))
+	})
+
+	t.Run("no hint outside the play phase", func(t *testing.T) {
+		m, _ := setupPageOneCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.PageOnePhaseRoundEnd)
+		m.On("IsHumanTurn").Return(true)
+		assert.Contains(t, p.HintOutput(m), i18n.T("pageone.hintNone"))
 	})
 }

--- a/internal/adapter/presenter/PageOneWebPresenter.go
+++ b/internal/adapter/presenter/PageOneWebPresenter.go
@@ -81,3 +81,9 @@ func (p *PageOneWebPresenter) buildMessage(g interfaces.PageOneGame, lastErr err
 func (p *PageOneWebPresenter) ActionLogOutput(g interfaces.PageOneGame) string {
 	return actionLogOutputJSON(g)
 }
+
+// HintOutput はヒントを返す。Web ではクライアント側でヒントを算出するため、
+// 状態出力にフォールバックする (CUI プレゼンターのみが専用ヒントを返す)。
+func (p *PageOneWebPresenter) HintOutput(g interfaces.PageOneGame) string {
+	return p.Output(g, nil)
+}

--- a/internal/adapter/presenter/PageOneWebPresenter_test.go
+++ b/internal/adapter/presenter/PageOneWebPresenter_test.go
@@ -98,3 +98,10 @@ func TestPageOneWebPresenter_ActionLogOutput(t *testing.T) {
 	result := p.ActionLogOutput(m)
 	assert.NotEmpty(t, result)
 }
+
+func TestPageOneWebPresenter_HintOutput(t *testing.T) {
+	m := setupPageOneWebMock()
+	p := new(presenter.PageOneWebPresenter)
+	// The web presenter computes hints client-side, so HintOutput mirrors Output.
+	assert.Equal(t, p.Output(m, nil), p.HintOutput(m))
+}

--- a/internal/domain/PageOne.go
+++ b/internal/domain/PageOne.go
@@ -401,6 +401,9 @@ func (g *PageOne) GetValidPlayIndices(playerIdx int) []int {
 // --- Private methods ---
 
 // isValidPlay カードがプレイ可能か判定 (スートまたはランクが一致)
+// IsValidPlay は現在の場状態を踏まえカードがプレイ可能かを返す (公開版; CUI ヒントが利用)。
+func (g *PageOne) IsValidPlay(card *Card) bool { return g.isValidPlay(card) }
+
 func (g *PageOne) isValidPlay(card *Card) bool {
 	top := g.GetDiscardTop()
 	if top == nil {

--- a/internal/domain/PageOne_test.go
+++ b/internal/domain/PageOne_test.go
@@ -538,3 +538,13 @@ func TestPageOne_UnmarshalJSON_Invalid(t *testing.T) {
 	var jsonErr *json.SyntaxError
 	assert.True(t, errors.As(err, &jsonErr) || err != nil)
 }
+
+func TestPageOne_IsValidPlay(t *testing.T) {
+	g := newTestPageOne()
+	g.Reset()
+	setupPageOnePlayPhase(g, 0, domain.NewCard(domain.CardDesignSpade, 5, false))
+
+	assert.True(t, g.IsValidPlay(domain.NewCard(domain.CardDesignSpade, 3, false)), "same suit is playable")
+	assert.True(t, g.IsValidPlay(domain.NewCard(domain.CardDesignHeart, 5, false)), "same rank is playable")
+	assert.False(t, g.IsValidPlay(domain.NewCard(domain.CardDesignHeart, 7, false)), "different suit and rank is not playable")
+}

--- a/internal/domain/interfaces/pageone.go
+++ b/internal/domain/interfaces/pageone.go
@@ -49,4 +49,6 @@ type PageOneGame interface {
 	GetPlayerCnt() int
 	// GetPlayer 指定インデックスのプレイヤーを取得する
 	GetPlayer(i int) *domain.PageOnePlayer
+	// IsValidPlay カードが現在の場状態でプレイ可能かを返す
+	IsValidPlay(card *domain.Card) bool
 }

--- a/internal/domain/interfaces/pageone_mock.go
+++ b/internal/domain/interfaces/pageone_mock.go
@@ -40,6 +40,9 @@ func (m *MockPageOneGame) GetPlayerCnt() int           { return m.Called().Int(0
 func (m *MockPageOneGame) GetPlayer(i int) *domain.PageOnePlayer {
 	return m.Called(i).Get(0).(*domain.PageOnePlayer)
 }
+func (m *MockPageOneGame) IsValidPlay(card *domain.Card) bool {
+	return m.Called(card).Bool(0)
+}
 func (m *MockPageOneGame) GetActionLog() []*domain.ActionLogEntry {
 	return m.Called().Get(0).([]*domain.ActionLogEntry)
 }

--- a/internal/i18n/locales/en/pageone.json
+++ b/internal/i18n/locales/en/pageone.json
@@ -22,5 +22,8 @@
   "cmdSkip": "skip        ... skip declaration (penalty: draw 2)",
   "roundEnd": "Round over",
   "cmdNextRound": "nr / nextround ... advance to next round",
-  "gameEnd": "Game over! {{name}} wins!"
+  "gameEnd": "Game over! {{name}} wins!",
+  "hintNone": "No hint available.",
+  "hintPlayable": "Playable cards: {{cards}} (p <idx> to play)",
+  "hintDraw": "No playable card. Draw with d."
 }

--- a/internal/i18n/locales/ja/pageone.json
+++ b/internal/i18n/locales/ja/pageone.json
@@ -22,5 +22,8 @@
   "cmdSkip": "skip・・・宣言をスキップ（ペナルティ: 2枚引く）",
   "roundEnd": "ラウンド終了",
   "cmdNextRound": "nr / nextround・・・次のラウンドへ",
-  "gameEnd": "ゲーム終了！ {{name}}の勝利です！"
+  "gameEnd": "ゲーム終了！ {{name}}の勝利です！",
+  "hintNone": "現在ヒントはありません。",
+  "hintPlayable": "出せるカード: {{cards}}（p <idx> で出す）",
+  "hintDraw": "出せるカードがありません。d でドローしてください。"
 }

--- a/internal/usecase/PageOneInteractor.go
+++ b/internal/usecase/PageOneInteractor.go
@@ -28,6 +28,8 @@ type PageOneInteractorIF interface {
 	GetConfig() domain.PageOneConfig
 	// ActionLog 棋譜を出力する
 	ActionLog() string
+	// Hint ヒントを出力する
+	Hint() string
 }
 
 // PageOneInteractor ページワンインタラクタークラス
@@ -125,6 +127,11 @@ func (ci *PageOneInteractor) GetConfig() domain.PageOneConfig {
 // ActionLog 棋譜を出力する
 func (ci *PageOneInteractor) ActionLog() string {
 	return ci.gp.ActionLogOutput(ci.Game)
+}
+
+// Hint ヒントを出力する
+func (ci *PageOneInteractor) Hint() string {
+	return ci.gp.HintOutput(ci.Game)
 }
 
 // runCpuTurns ゲームが終わるか人間の手番またはラウンド/ゲーム終了になるまでCPUターンを実行

--- a/internal/usecase/PageOneInteractor_test.go
+++ b/internal/usecase/PageOneInteractor_test.go
@@ -241,3 +241,10 @@ func TestRestorePageOneInteractor(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, ci)
 }
+
+func TestPageOneInteractor_Hint(t *testing.T) {
+	gm, pm := newPageOneMocks()
+	pm.On("HintOutput", mock.Anything).Return("hint")
+	ci := usecase.NewPageOneInteractor(gm, pm)
+	assert.Equal(t, "hint", ci.Hint())
+}

--- a/internal/usecase/presenter/PageOnePresenter.go
+++ b/internal/usecase/presenter/PageOnePresenter.go
@@ -3,4 +3,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // PageOnePresenter ページワンプレゼンターインタフェース
-type PageOnePresenter = GamePresenter[interfaces.PageOneGame]
+type PageOnePresenter interface {
+	GamePresenter[interfaces.PageOneGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.PageOneGame) string
+}

--- a/internal/usecase/presenter/PageOnePresenter_mock.go
+++ b/internal/usecase/presenter/PageOnePresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockPageOnePresenter ページワンプレゼンターモック
-type MockPageOnePresenter = MockGamePresenter[interfaces.PageOneGame]
+type MockPageOnePresenter struct {
+	MockGamePresenter[interfaces.PageOneGame]
+}
+
+// HintOutput モック
+func (_m *MockPageOnePresenter) HintOutput(g interfaces.PageOneGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 概要
`PageOneCuiPresenter` に `HintOutput` が無く、CUI プレイヤーだけがヒント機能を使えなかった。ドメインの合法手判定 `isValidPlay` を公開し、プレイフェーズで人間の出せるカードのインデックスを列挙する（無ければドロー推奨）。

## 変更点
- `PageOne.go` / `interfaces/pageone.go`(+mock): `IsValidPlay(card)` を公開
- `usecase/presenter/PageOnePresenter.go`(+mock): インタフェースに `HintOutput` 追加
- `PageOneCuiPresenter.go`: `HintOutput`（出せるカード一覧／ドロー案内／非手番・他フェーズは hintNone）
- `PageOneWebPresenter.go`: `HintOutput` は `Output` に委譲
- `PageOneInteractor.go`(+mock): `Hint()` 追加、`PageOneCuiController.go`: h/hint 配線（CommandMap）
- i18n: hintNone/hintPlayable/hintDraw ja/en
- テスト: presenter 4分岐・domain IsValidPlay・interactor Hint・controller h/hint・web HintOutput

Closes #3170