### PR TITLE
feat(deuceswild): add a CUI hold recommendation to the video poker CUI

### DIFF
--- a/internal/adapter/controller/VideoPokerCuiController.go
+++ b/internal/adapter/controller/VideoPokerCuiController.go
@@ -28,7 +28,7 @@ func (vpc *VideoPokerCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return vpc.vi.Reset() },
-		[]string{"b", "bet", "h", "hold", "log", "l"},
+		[]string{"b", "bet", "h", "hold", "hint", "log", "l"},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "b", "bet":
@@ -44,7 +44,7 @@ func (vpc *VideoPokerCuiController) Exec(command string) string {
 				}
 				return vpc.vi.Hold(indices), true
 			default:
-				return handleCuiLog(cmd, vpc.vi.ActionLog)
+				return handleCuiHintAndLog(cmd, vpc.vi.Hint, vpc.vi.ActionLog)
 			}
 		},
 	)

--- a/internal/adapter/controller/VideoPokerCuiController_test.go
+++ b/internal/adapter/controller/VideoPokerCuiController_test.go
@@ -18,6 +18,7 @@ func newMockVideoPokerInteractor() *usecase.MockVideoPokerInteractor {
 	m.On("Hold", []int{0, 2, 4}).Return("hold result")
 	m.On("Hold", []int{}).Return("hold none result")
 	m.On("ActionLog").Return("action log result")
+	m.On("Hint").Return("hint result")
 	return m
 }
 
@@ -129,4 +130,11 @@ func TestVideoPokerCuiController_Empty(t *testing.T) {
 
 	result := c.Exec("")
 	assert.Contains(t, result, "'help' でコマンド一覧を表示します。")
+}
+
+func TestVideoPokerCuiController_Hint(t *testing.T) {
+	m := newMockVideoPokerInteractor()
+	c := controller.NewVideoPokerCuiController(m)
+	assert.Equal(t, "hint result", c.Exec("hint"))
+	m.AssertCalled(t, "Hint")
 }

--- a/internal/adapter/controller/usecase/VideoPokerInteractor_mock.go
+++ b/internal/adapter/controller/usecase/VideoPokerInteractor_mock.go
@@ -29,6 +29,12 @@ func (m *MockVideoPokerInteractor) ActionLog() string {
 	return args.String(0)
 }
 
+// Hint モック
+func (m *MockVideoPokerInteractor) Hint() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 // Snapshot モック
 func (m *MockVideoPokerInteractor) Snapshot() ([]byte, error) {
 	ret := m.Called()

--- a/internal/adapter/presenter/VideoPokerCuiPresenter.go
+++ b/internal/adapter/presenter/VideoPokerCuiPresenter.go
@@ -94,3 +94,46 @@ func (vpp *VideoPokerCuiPresenter) phaseStr(phase int) string {
 		return i18n.T("videopoker.phaseUnknown")
 	}
 }
+
+// videoPokerDeucesWildHold returns a hold mask for Deuces Wild: always hold the
+// wild deuces, plus any rank group of two or more (a made pair or better).
+func videoPokerDeucesWildHold(hand []*domain.Card) []bool {
+	hold := make([]bool, len(hand))
+	rankIdx := map[int][]int{}
+	for i, c := range hand {
+		if c.GetValue() == 2 { // deuces are wild
+			hold[i] = true
+			continue
+		}
+		rankIdx[c.GetValue()] = append(rankIdx[c.GetValue()], i)
+	}
+	for _, idxs := range rankIdx {
+		if len(idxs) >= 2 {
+			for _, i := range idxs {
+				hold[i] = true
+			}
+		}
+	}
+	return hold
+}
+
+// HintOutput recommends which cards to hold during the draw phase of Deuces
+// Wild (hold all deuces and any made pair-or-better). Other variants and phases
+// get no hint.
+func (p *VideoPokerCuiPresenter) HintOutput(g interfaces.VideoPokerGame) string {
+	if g.GetPhase() != domain.VideoPokerPhaseDraw || g.GetVariantName() != "deuceswild" {
+		return i18n.T("videopoker.hintNone") + "\n"
+	}
+	hand := g.GetHand()
+	hold := videoPokerDeucesWildHold(hand)
+	var parts []string
+	for i, h := range hold {
+		if h {
+			parts = append(parts, "["+strconv.Itoa(i)+"]"+cuiCardStr(hand[i]))
+		}
+	}
+	if len(parts) == 0 {
+		return color.Yellow(i18n.T("videopoker.hintHoldNone")) + "\n"
+	}
+	return color.Yellow(i18n.Tf("videopoker.hintHold", "cards", strings.Join(parts, " "))) + "\n"
+}

--- a/internal/adapter/presenter/VideoPokerCuiPresenter_test.go
+++ b/internal/adapter/presenter/VideoPokerCuiPresenter_test.go
@@ -1,6 +1,7 @@
 package presenter
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,6 +9,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupVideoPokerCuiMockDefaults(m *interfaces.MockVideoPokerGame) {
@@ -212,4 +214,60 @@ func TestVideoPokerCuiPresenter_cardStr_NilCard(t *testing.T) {
 	p := new(VideoPokerCuiPresenter)
 	m := new(interfaces.MockVideoPokerGame)
 	assert.Equal(t, "??", p.cardStr(m, nil))
+}
+
+func TestVideoPokerCuiPresenter_HintOutput(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(orig)
+	p := new(VideoPokerCuiPresenter)
+
+	deucesDraw := func(hand []*domain.Card) *interfaces.MockVideoPokerGame {
+		m := new(interfaces.MockVideoPokerGame)
+		m.On("GetPhase").Return(domain.VideoPokerPhaseDraw)
+		m.On("GetVariantName").Return("deuceswild")
+		m.On("GetHand").Return(hand)
+		return m
+	}
+
+	t.Run("holds deuces and a made pair", func(t *testing.T) {
+		hand := []*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 2, false),  // deuce (wild)
+			domain.NewCard(domain.CardDesignHeart, 8, false),  // pair of 8s
+			domain.NewCard(domain.CardDesignClover, 8, false), // pair of 8s
+			domain.NewCard(domain.CardDesignDiamond, 5, false),
+			domain.NewCard(domain.CardDesignSpade, 11, false),
+		}
+		out := p.HintOutput(deucesDraw(hand))
+		prefix := strings.SplitN(i18n.T("videopoker.hintHold"), "{{", 2)[0]
+		assert.Contains(t, out, prefix)
+		assert.Contains(t, out, "[0]") // deuce
+		assert.Contains(t, out, "[1]") // pair
+		assert.Contains(t, out, "[2]") // pair
+		assert.NotContains(t, out, "[3]")
+	})
+
+	t.Run("recommends redraw with no deuces or pair", func(t *testing.T) {
+		hand := []*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 3, false),
+			domain.NewCard(domain.CardDesignHeart, 7, false),
+			domain.NewCard(domain.CardDesignClover, 9, false),
+			domain.NewCard(domain.CardDesignDiamond, 11, false),
+			domain.NewCard(domain.CardDesignSpade, 13, false),
+		}
+		assert.Contains(t, p.HintOutput(deucesDraw(hand)), i18n.T("videopoker.hintHoldNone"))
+	})
+
+	t.Run("no hint for a non-deuceswild variant", func(t *testing.T) {
+		m := new(interfaces.MockVideoPokerGame)
+		m.On("GetPhase").Return(domain.VideoPokerPhaseDraw)
+		m.On("GetVariantName").Return("jacksorbetter")
+		assert.Contains(t, p.HintOutput(m), i18n.T("videopoker.hintNone"))
+	})
+
+	t.Run("no hint outside the draw phase", func(t *testing.T) {
+		m := new(interfaces.MockVideoPokerGame)
+		m.On("GetPhase").Return(domain.VideoPokerPhaseBet)
+		assert.Contains(t, p.HintOutput(m), i18n.T("videopoker.hintNone"))
+	})
 }

--- a/internal/adapter/presenter/VideoPokerWebPresenter.go
+++ b/internal/adapter/presenter/VideoPokerWebPresenter.go
@@ -53,3 +53,9 @@ func (vpp *VideoPokerWebPresenter) Output(vp interfaces.VideoPokerGame, lastErr 
 func (vpp *VideoPokerWebPresenter) ActionLogOutput(vp interfaces.VideoPokerGame) string {
 	return actionLogOutputJSON(vp)
 }
+
+// HintOutput はヒントを返す。Web ではクライアント側でヒントを算出するため、
+// 状態出力にフォールバックする (CUI プレゼンターのみが専用ヒントを返す)。
+func (vpp *VideoPokerWebPresenter) HintOutput(vp interfaces.VideoPokerGame) string {
+	return vpp.Output(vp, nil)
+}

--- a/internal/adapter/presenter/VideoPokerWebPresenter_test.go
+++ b/internal/adapter/presenter/VideoPokerWebPresenter_test.go
@@ -139,3 +139,11 @@ func TestVideoPokerWebPresenter_ActionLogOutput(t *testing.T) {
 		assert.Len(t, out.Entries, 1)
 	})
 }
+
+func TestVideoPokerWebPresenter_HintOutput(t *testing.T) {
+	m := new(interfaces.MockVideoPokerGame)
+	setupVideoPokerWebMockDefaults(m)
+	p := new(VideoPokerWebPresenter)
+	// The web presenter computes hints client-side, so HintOutput mirrors Output.
+	assert.Equal(t, p.Output(m, nil), p.HintOutput(m))
+}

--- a/internal/i18n/locales/en/videopoker.json
+++ b/internal/i18n/locales/en/videopoker.json
@@ -13,5 +13,8 @@
   "betLine": "bet: {{bet}} coin(s)",
   "winLine": "{{handName}}! You win!",
   "noWin": "No winning hand.",
-  "payoutLine": "payout: {{payout}}"
+  "payoutLine": "payout: {{payout}}",
+  "hintNone": "No hint available.",
+  "hintHold": "Hold recommendation: {{cards}} (h <idx...> to hold)",
+  "hintHoldNone": "Nothing to hold; consider redrawing all five."
 }

--- a/internal/i18n/locales/ja/videopoker.json
+++ b/internal/i18n/locales/ja/videopoker.json
@@ -13,5 +13,8 @@
   "betLine": "ベット: {{bet}} コイン",
   "winLine": "{{handName}}! あなたの勝利です！",
   "noWin": "役なし。",
-  "payoutLine": "払戻し: {{payout}}"
+  "payoutLine": "払戻し: {{payout}}",
+  "hintNone": "現在ヒントはありません。",
+  "hintHold": "ホールド推奨: {{cards}}（h <idx...> でホールド）",
+  "hintHoldNone": "ホールド推奨なし。5枚すべて引き直しを検討してください。"
 }

--- a/internal/usecase/VideoPokerInteractor.go
+++ b/internal/usecase/VideoPokerInteractor.go
@@ -20,6 +20,8 @@ type VideoPokerInteractorIF interface {
 	Hold(indices []int) string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
+	// Hint ヒントを出力する
+	Hint() string
 }
 
 // VideoPokerInteractor ビデオポーカーインタラクタークラス
@@ -55,6 +57,11 @@ func (vi *VideoPokerInteractor) Hold(indices []int) string {
 // ActionLog 棋譜を出力する
 func (vi *VideoPokerInteractor) ActionLog() string {
 	return vi.vpp.ActionLogOutput(vi.Game)
+}
+
+// Hint ヒントを出力する
+func (vi *VideoPokerInteractor) Hint() string {
+	return vi.vpp.HintOutput(vi.Game)
 }
 
 // RestoreVideoPokerInteractor deserialises JSON into a VideoPokerInteractor.

--- a/internal/usecase/VideoPokerInteractor_test.go
+++ b/internal/usecase/VideoPokerInteractor_test.go
@@ -110,3 +110,12 @@ func TestVideoPokerInteractor_ActionLog(t *testing.T) {
 	result := vi.ActionLog()
 	assert.Equal(t, "log output", result)
 }
+
+func TestVideoPokerInteractor_Hint(t *testing.T) {
+	mockGame := new(interfaces.MockVideoPokerGame)
+	mockPresenter := new(presenter.MockVideoPokerPresenter)
+	vi := NewVideoPokerInteractor(mockGame, mockPresenter)
+
+	mockPresenter.On("HintOutput", mockGame).Return("hint output")
+	assert.Equal(t, "hint output", vi.Hint())
+}

--- a/internal/usecase/interactor_snapshot_test.go
+++ b/internal/usecase/interactor_snapshot_test.go
@@ -61,6 +61,7 @@ type stubVideoPokerPresenter struct{}
 
 func (s *stubVideoPokerPresenter) Output(_ interfaces.VideoPokerGame, _ error) string { return `{}` }
 func (s *stubVideoPokerPresenter) ActionLogOutput(_ interfaces.VideoPokerGame) string { return `{}` }
+func (s *stubVideoPokerPresenter) HintOutput(_ interfaces.VideoPokerGame) string      { return `{}` }
 
 // stubHeartsPresenter implements presenter.HeartsPresenter (GamePresenter + HintOutput)
 type stubHeartsPresenter struct{}

--- a/internal/usecase/presenter/VideoPokerPresenter.go
+++ b/internal/usecase/presenter/VideoPokerPresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // VideoPokerPresenter ビデオポーカープレゼンターインタフェース
-type VideoPokerPresenter = GamePresenter[interfaces.VideoPokerGame]
+type VideoPokerPresenter interface {
+	GamePresenter[interfaces.VideoPokerGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.VideoPokerGame) string
+}

--- a/internal/usecase/presenter/VideoPokerPresenter_mock.go
+++ b/internal/usecase/presenter/VideoPokerPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockVideoPokerPresenter ビデオポーカープレゼンターモック
-type MockVideoPokerPresenter = MockGamePresenter[interfaces.VideoPokerGame]
+type MockVideoPokerPresenter struct {
+	MockGamePresenter[interfaces.VideoPokerGame]
+}
+
+// HintOutput モック
+func (_m *MockVideoPokerPresenter) HintOutput(g interfaces.VideoPokerGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 概要
共有の `VideoPokerCuiPresenter` に `HintOutput` が無く、CUI プレイヤーはホールド判断の支援を得られなかった。デューシーズワイルドのドローフェーズで、ワイルドの 2 とペア以上の役札のホールドを推奨する（`GetVariantName()` で判定、他バリアント/他フェーズは hintNone）。

## 変更点
- `VideoPokerCuiPresenter.go`: `HintOutput` + `videoPokerDeucesWildHold`
- `usecase/presenter/VideoPokerPresenter.go`(+mock): インタフェースに `HintOutput` 追加
- `VideoPokerWebPresenter.go`: `HintOutput` は `Output` に委譲
- `VideoPokerInteractor.go`(+mock, snapshot stub): `Hint()` 追加、`VideoPokerCuiController.go`: hint 配線（h は hold のため hint のみ）
- i18n: hintNone/hintHold/hintHoldNone ja/en
- テスト: presenter 4分岐・interactor Hint・controller hint・web HintOutput

Closes #3075