### PR TITLE
feat(casinoholdem): add a CUI call/fold hint after the flop

### DIFF
--- a/internal/adapter/controller/CasinoHoldemCuiController.go
+++ b/internal/adapter/controller/CasinoHoldemCuiController.go
@@ -25,7 +25,7 @@ func (cc *CasinoHoldemCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return cc.ci.Reset() },
-		[]string{"b", "bet", "c", "call", "f", "fold", "log", "l"},
+		[]string{"b", "bet", "c", "call", "f", "fold", "h", "hint", "log", "l"},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "b", "bet":
@@ -46,7 +46,7 @@ func (cc *CasinoHoldemCuiController) Exec(command string) string {
 			case "f", "fold":
 				return cc.ci.Fold(), true
 			default:
-				return handleCuiLog(cmd, cc.ci.ActionLog)
+				return handleCuiHintAndLog(cmd, cc.ci.Hint, cc.ci.ActionLog)
 			}
 		},
 	)

--- a/internal/adapter/controller/CasinoHoldemCuiController_test.go
+++ b/internal/adapter/controller/CasinoHoldemCuiController_test.go
@@ -19,6 +19,7 @@ func newMockCasinoHoldemInteractor() *usecase.MockCasinoHoldemInteractor {
 	m.On("Call").Return("call result")
 	m.On("Fold").Return("fold result")
 	m.On("ActionLog").Return("action log result")
+	m.On("Hint").Return("hint result")
 	return m
 }
 
@@ -106,4 +107,12 @@ func TestCasinoHoldemCuiController_Empty(t *testing.T) {
 	c := controller.NewCasinoHoldemCuiController(m)
 	result := c.Exec("")
 	assert.Contains(t, result, "'help' でコマンド一覧を表示します。")
+}
+
+func TestCasinoHoldemCuiController_Hint(t *testing.T) {
+	m := newMockCasinoHoldemInteractor()
+	c := controller.NewCasinoHoldemCuiController(m)
+	assert.Equal(t, "hint result", c.Exec("h"))
+	assert.Equal(t, "hint result", c.Exec("hint"))
+	m.AssertCalled(t, "Hint")
 }

--- a/internal/adapter/controller/usecase/CasinoHoldemInteractor_mock.go
+++ b/internal/adapter/controller/usecase/CasinoHoldemInteractor_mock.go
@@ -34,6 +34,12 @@ func (m *MockCasinoHoldemInteractor) ActionLog() string {
 	return args.String(0)
 }
 
+// Hint モック
+func (m *MockCasinoHoldemInteractor) Hint() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 // Snapshot モック
 func (m *MockCasinoHoldemInteractor) Snapshot() ([]byte, error) {
 	ret := m.Called()

--- a/internal/adapter/presenter/CasinoHoldemCuiPresenter.go
+++ b/internal/adapter/presenter/CasinoHoldemCuiPresenter.go
@@ -133,3 +133,15 @@ func (cp *CasinoHoldemCuiPresenter) phaseStr(phase int) string {
 		return i18n.T("casinoholdem.phaseUnknown")
 	}
 }
+
+// HintOutput advises call/fold after the flop using basic strategy (call with a
+// pair or better, or an Ace/King; otherwise fold). Other phases get no hint.
+func (p *CasinoHoldemCuiPresenter) HintOutput(g interfaces.CasinoHoldemGame) string {
+	if g.GetPhase() != domain.CasinoHoldemPhaseFlop {
+		return i18n.T("casinoholdem.hintNone") + "\n"
+	}
+	if g.RecommendCall() {
+		return color.Yellow(i18n.T("casinoholdem.hintCall")) + "\n"
+	}
+	return color.Yellow(i18n.T("casinoholdem.hintFold")) + "\n"
+}

--- a/internal/adapter/presenter/CasinoHoldemCuiPresenter_test.go
+++ b/internal/adapter/presenter/CasinoHoldemCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupCasinoHoldemCuiMockDefaults(m *interfaces.MockCasinoHoldemGame) {
@@ -306,4 +307,28 @@ func TestCasinoHoldemCuiPresenter_PhaseStr_Unknown(t *testing.T) {
 
 	result := p.Output(m, nil)
 	assert.Contains(t, result, "フェーズ: UNKNOWN")
+}
+
+func TestCasinoHoldemCuiPresenter_HintOutput(t *testing.T) {
+	p := new(CasinoHoldemCuiPresenter)
+
+	t.Run("recommends call when advised", func(t *testing.T) {
+		m := new(interfaces.MockCasinoHoldemGame)
+		m.On("GetPhase").Return(domain.CasinoHoldemPhaseFlop)
+		m.On("RecommendCall").Return(true)
+		assert.Contains(t, p.HintOutput(m), i18n.T("casinoholdem.hintCall"))
+	})
+
+	t.Run("recommends fold when not advised", func(t *testing.T) {
+		m := new(interfaces.MockCasinoHoldemGame)
+		m.On("GetPhase").Return(domain.CasinoHoldemPhaseFlop)
+		m.On("RecommendCall").Return(false)
+		assert.Contains(t, p.HintOutput(m), i18n.T("casinoholdem.hintFold"))
+	})
+
+	t.Run("no hint outside the flop phase", func(t *testing.T) {
+		m := new(interfaces.MockCasinoHoldemGame)
+		m.On("GetPhase").Return(domain.CasinoHoldemPhaseBet)
+		assert.Contains(t, p.HintOutput(m), i18n.T("casinoholdem.hintNone"))
+	})
 }

--- a/internal/adapter/presenter/CasinoHoldemWebPresenter.go
+++ b/internal/adapter/presenter/CasinoHoldemWebPresenter.go
@@ -67,6 +67,12 @@ func (cp *CasinoHoldemWebPresenter) ActionLogOutput(g interfaces.CasinoHoldemGam
 	return actionLogOutputJSON(g)
 }
 
+// HintOutput はヒントを返す。Web ではクライアント側でヒントを算出するため、
+// 状態出力にフォールバックする (CUI プレゼンターのみが専用ヒントを返す)。
+func (cp *CasinoHoldemWebPresenter) HintOutput(g interfaces.CasinoHoldemGame) string {
+	return cp.Output(g, nil)
+}
+
 // casinoHoldemMaskDealerHand returns the dealer hand with all cards masked
 // while the showdown has not yet happened.
 func casinoHoldemMaskDealerHand(cards []*domain.Card) []*controller.WebOutputCard {

--- a/internal/adapter/presenter/CasinoHoldemWebPresenter_test.go
+++ b/internal/adapter/presenter/CasinoHoldemWebPresenter_test.go
@@ -270,3 +270,11 @@ func TestCasinoHoldemWebPresenter_ActionLogOutput(t *testing.T) {
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "entries")
 }
+
+func TestCasinoHoldemWebPresenter_HintOutput(t *testing.T) {
+	m := new(interfaces.MockCasinoHoldemGame)
+	setupCasinoHoldemWebMockDefaults(m)
+	p := new(CasinoHoldemWebPresenter)
+	// The web presenter computes hints client-side, so HintOutput mirrors Output.
+	assert.Equal(t, p.Output(m, nil), p.HintOutput(m))
+}

--- a/internal/domain/CasinoHoldem.go
+++ b/internal/domain/CasinoHoldem.go
@@ -462,6 +462,27 @@ func (c *CasinoHoldem) GetBonusBet() int { return c.bonusBet }
 // GetCallBet コールベット額（2×アンテ）
 func (c *CasinoHoldem) GetCallBet() int { return c.callBet }
 
+// RecommendCall はフロップ後にコール (2×アンテ) を推奨するかを返す。基本戦略として
+// ワンペア以上、または A/K を含むときコール、それ以外はフォールドを推奨する。
+// (プレイヤーハンドランクはショーダウンまで設定されないため、その場で評価する。)
+func (c *CasinoHoldem) RecommendCall() bool {
+	cards := make([]*Card, 0, len(c.playerHand)+len(c.community))
+	cards = append(cards, c.playerHand...)
+	cards = append(cards, c.community...)
+	if len(cards) < 5 {
+		return true
+	}
+	if evalFiveCardHand(cards[:5]) >= PokerHandOnePair {
+		return true
+	}
+	for _, cc := range cards {
+		if v := cc.GetValue(); v == 1 || v == 13 { // Ace or King
+			return true
+		}
+	}
+	return false
+}
+
 // GetResult ゲーム結果
 func (c *CasinoHoldem) GetResult() GameResult { return c.result }
 

--- a/internal/domain/CasinoHoldem_test.go
+++ b/internal/domain/CasinoHoldem_test.go
@@ -626,3 +626,37 @@ func TestCasinoHoldem_ActionLog(t *testing.T) {
 	// bet → deal → flop → fold → result
 	assert.GreaterOrEqual(t, len(log), 5)
 }
+
+func TestCasinoHoldem_RecommendCall(t *testing.T) {
+	newFlop := func(hole, community []*domain.Card) *domain.CasinoHoldem {
+		g := domain.NewDefaultCasinoHoldem()
+		g.SetPlayerHand(hole)
+		g.SetCommunity(community)
+		g.SetPhase(domain.CasinoHoldemPhaseFlop)
+		return g
+	}
+
+	t.Run("call with a pair", func(t *testing.T) {
+		g := newFlop(
+			makeHandCH(cd{domain.CardDesignSpade, 8}, cd{domain.CardDesignHeart, 8}),
+			makeHandCH(cd{domain.CardDesignClover, 3}, cd{domain.CardDesignDiamond, 5}, cd{domain.CardDesignSpade, 9}),
+		)
+		assert.True(t, g.RecommendCall())
+	})
+
+	t.Run("call with an ace high", func(t *testing.T) {
+		g := newFlop(
+			makeHandCH(cd{domain.CardDesignSpade, 1}, cd{domain.CardDesignHeart, 7}),
+			makeHandCH(cd{domain.CardDesignClover, 3}, cd{domain.CardDesignDiamond, 5}, cd{domain.CardDesignSpade, 9}),
+		)
+		assert.True(t, g.RecommendCall())
+	})
+
+	t.Run("fold with junk", func(t *testing.T) {
+		g := newFlop(
+			makeHandCH(cd{domain.CardDesignSpade, 3}, cd{domain.CardDesignHeart, 7}),
+			makeHandCH(cd{domain.CardDesignClover, 9}, cd{domain.CardDesignDiamond, 11}, cd{domain.CardDesignSpade, 5}),
+		)
+		assert.False(t, g.RecommendCall())
+	})
+}

--- a/internal/domain/interfaces/casinoholdem.go
+++ b/internal/domain/interfaces/casinoholdem.go
@@ -54,4 +54,6 @@ type CasinoHoldemGame interface {
 	GetDealerBest() []*domain.Card
 	// GetChips チップを取得する
 	GetChips() int
+	// RecommendCall はフロップ後にコールを推奨するかを返す
+	RecommendCall() bool
 }

--- a/internal/domain/interfaces/casinoholdem_mock.go
+++ b/internal/domain/interfaces/casinoholdem_mock.go
@@ -32,6 +32,9 @@ func (m *MockCasinoHoldemGame) Fold() error {
 	return args.Error(0)
 }
 
+func (m *MockCasinoHoldemGame) RecommendCall() bool {
+	return m.Called().Bool(0)
+}
 func (m *MockCasinoHoldemGame) GetPlayerHand() []*domain.Card {
 	args := m.Called()
 	if args.Get(0) == nil {

--- a/internal/i18n/locales/en/casinoholdem.json
+++ b/internal/i18n/locales/en/casinoholdem.json
@@ -22,5 +22,8 @@
   "dealerWins": "Dealer wins!",
   "playerFolded": "Player folded.",
   "push": "Push!",
-  "totalPayoutLine": "total payout: {{payout}}"
+  "totalPayoutLine": "total payout: {{payout}}",
+  "hintNone": "No hint available.",
+  "hintCall": "Recommended: Call (2x ante) — a pair or better, or an Ace/King",
+  "hintFold": "Recommended: Fold — no qualifying hand"
 }

--- a/internal/i18n/locales/ja/casinoholdem.json
+++ b/internal/i18n/locales/ja/casinoholdem.json
@@ -22,5 +22,8 @@
   "dealerWins": "ディーラーの勝ち！",
   "playerFolded": "プレイヤーがフォールド。",
   "push": "プッシュ！",
-  "totalPayoutLine": "合計払戻し: {{payout}}"
+  "totalPayoutLine": "合計払戻し: {{payout}}",
+  "hintNone": "現在ヒントはありません。",
+  "hintCall": "推奨: コール（2×アンテ）— ワンペア以上または A/K を保持",
+  "hintFold": "推奨: フォールド — 続行条件を満たしません"
 }

--- a/internal/usecase/CasinoHoldemInteractor.go
+++ b/internal/usecase/CasinoHoldemInteractor.go
@@ -22,6 +22,8 @@ type CasinoHoldemInteractorIF interface {
 	Fold() string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
+	// Hint ヒントを出力する
+	Hint() string
 }
 
 // CasinoHoldemInteractor カジノホールデムインタラクタークラス
@@ -62,6 +64,11 @@ func (ci *CasinoHoldemInteractor) Fold() string {
 // ActionLog 棋譜を出力する
 func (ci *CasinoHoldemInteractor) ActionLog() string {
 	return ci.cp.ActionLogOutput(ci.Game)
+}
+
+// Hint ヒントを出力する
+func (ci *CasinoHoldemInteractor) Hint() string {
+	return ci.cp.HintOutput(ci.Game)
 }
 
 // RestoreCasinoHoldemInteractor deserialises JSON into a CasinoHoldemInteractor.

--- a/internal/usecase/CasinoHoldemInteractor_test.go
+++ b/internal/usecase/CasinoHoldemInteractor_test.go
@@ -127,3 +127,12 @@ func TestRestoreCasinoHoldemInteractor(t *testing.T) {
 		assert.Equal(t, ci.Game.GetBonusBet(), restored.Game.GetBonusBet())
 	})
 }
+
+func TestCasinoHoldemInteractor_Hint(t *testing.T) {
+	mockGame := new(interfaces.MockCasinoHoldemGame)
+	mockPresenter := new(presenter.MockCasinoHoldemPresenter)
+	ci := NewCasinoHoldemInteractor(mockGame, mockPresenter)
+
+	mockPresenter.On("HintOutput", mockGame).Return("hint output")
+	assert.Equal(t, "hint output", ci.Hint())
+}

--- a/internal/usecase/presenter/CasinoHoldemPresenter.go
+++ b/internal/usecase/presenter/CasinoHoldemPresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // CasinoHoldemPresenter カジノホールデムプレゼンターインタフェース
-type CasinoHoldemPresenter = GamePresenter[interfaces.CasinoHoldemGame]
+type CasinoHoldemPresenter interface {
+	GamePresenter[interfaces.CasinoHoldemGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.CasinoHoldemGame) string
+}

--- a/internal/usecase/presenter/CasinoHoldemPresenter_mock.go
+++ b/internal/usecase/presenter/CasinoHoldemPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockCasinoHoldemPresenter カジノホールデムプレゼンターモック
-type MockCasinoHoldemPresenter = MockGamePresenter[interfaces.CasinoHoldemGame]
+type MockCasinoHoldemPresenter struct {
+	MockGamePresenter[interfaces.CasinoHoldemGame]
+}
+
+// HintOutput モック
+func (_m *MockCasinoHoldemPresenter) HintOutput(g interfaces.CasinoHoldemGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 概要
`CasinoHoldemCuiPresenter` に `HintOutput` が無く、CUI プレイヤーはコール/フォールド判断の支援を得られなかった。ドメインに `RecommendCall`（フロップ後のホール+コミュニティ5枚を評価し、ワンペア以上または A/K でコール推奨。プレイヤーハンドランクはショーダウンまで未設定のためその場で評価）を追加し、`HintOutput` で整形する。

## 変更点
- `CasinoHoldem.go` / `interfaces/casinoholdem.go`(+mock): `RecommendCall()` を公開
- `usecase/presenter/CasinoHoldemPresenter.go`(+mock): インタフェースに `HintOutput` 追加
- `CasinoHoldemCuiPresenter.go`: `HintOutput`（Flop で call/fold、他フェーズは hintNone）
- `CasinoHoldemWebPresenter.go`: `HintOutput` は `Output` に委譲
- `CasinoHoldemInteractor.go`(+mock): `Hint()` 追加、`CasinoHoldemCuiController.go`: h/hint 配線
- i18n: hintNone/hintCall/hintFold ja/en
- テスト: domain RecommendCall（pair/ace/junk）＋ presenter 3分岐 ＋ interactor Hint ＋ controller h/hint ＋ web HintOutput

Closes #3300