### PR TITLE
feat(oasispoker): add CUI exchange and play/fold hints

### DIFF
--- a/internal/adapter/controller/OasisPokerCuiController.go
+++ b/internal/adapter/controller/OasisPokerCuiController.go
@@ -27,7 +27,7 @@ func (oc *OasisPokerCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return oc.oi.Reset() },
-		[]string{"b", "bet", "e", "exchange", "s", "stand", "p", "play", "f", "fold", "log", "l"},
+		[]string{"b", "bet", "e", "exchange", "s", "stand", "p", "play", "f", "fold", "h", "hint", "log", "l"},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "b", "bet":
@@ -53,7 +53,7 @@ func (oc *OasisPokerCuiController) Exec(command string) string {
 			case "f", "fold":
 				return oc.oi.Fold(), true
 			default:
-				return handleCuiLog(cmd, oc.oi.ActionLog)
+				return handleCuiHintAndLog(cmd, oc.oi.Hint, oc.oi.ActionLog)
 			}
 		},
 	)

--- a/internal/adapter/controller/OasisPokerCuiController_test.go
+++ b/internal/adapter/controller/OasisPokerCuiController_test.go
@@ -23,6 +23,7 @@ func newMockOasisPokerInteractor() *usecase.MockOasisPokerInteractor {
 	m.On("Play").Return("play result")
 	m.On("Fold").Return("fold result")
 	m.On("ActionLog").Return("action log result")
+	m.On("Hint").Return("hint result")
 	return m
 }
 
@@ -153,4 +154,12 @@ func TestOasisPokerCuiController_Empty(t *testing.T) {
 
 	result := c.Exec("")
 	assert.Contains(t, result, "'help' でコマンド一覧を表示します。")
+}
+
+func TestOasisPokerCuiController_Hint(t *testing.T) {
+	m := newMockOasisPokerInteractor()
+	c := controller.NewOasisPokerCuiController(m)
+	assert.Equal(t, "hint result", c.Exec("h"))
+	assert.Equal(t, "hint result", c.Exec("hint"))
+	m.AssertCalled(t, "Hint")
 }

--- a/internal/adapter/controller/usecase/OasisPokerInteractor_mock.go
+++ b/internal/adapter/controller/usecase/OasisPokerInteractor_mock.go
@@ -44,6 +44,12 @@ func (m *MockOasisPokerInteractor) ActionLog() string {
 	return args.String(0)
 }
 
+// Hint モック
+func (m *MockOasisPokerInteractor) Hint() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 // Snapshot モック
 func (m *MockOasisPokerInteractor) Snapshot() ([]byte, error) {
 	ret := m.Called()

--- a/internal/adapter/presenter/OasisPokerCuiPresenter.go
+++ b/internal/adapter/presenter/OasisPokerCuiPresenter.go
@@ -130,3 +130,48 @@ func (op *OasisPokerCuiPresenter) phaseStr(phase int) string {
 		return i18n.T("oasispoker.phaseUnknown")
 	}
 }
+
+// oasisPokerExchangeIndices returns the hand indices worth exchanging: cards
+// that are neither part of a pair nor a high card (J/Q/K/A). Holding pairs and
+// high cards is the standard draw heuristic.
+func oasisPokerExchangeIndices(hand []*domain.Card) []int {
+	rankCount := map[int]int{}
+	for _, c := range hand {
+		rankCount[c.GetValue()]++
+	}
+	var ex []int
+	for i, c := range hand {
+		v := c.GetValue()
+		isPair := rankCount[v] >= 2
+		isHigh := v == 1 || v >= 11 // Ace or J/Q/K
+		if !isPair && !isHigh {
+			ex = append(ex, i)
+		}
+	}
+	return ex
+}
+
+// HintOutput advises the exchange (which cards to swap, or stand) and the action
+// (play/fold via basic strategy) decisions. Other phases get no hint.
+func (p *OasisPokerCuiPresenter) HintOutput(g interfaces.OasisPokerGame) string {
+	switch g.GetPhase() {
+	case domain.OasisPokerPhaseExchange:
+		ex := oasisPokerExchangeIndices(g.GetPlayerHand())
+		if len(ex) == 0 {
+			return color.Yellow(i18n.T("oasispoker.hintStand")) + "\n"
+		}
+		hand := g.GetPlayerHand()
+		parts := make([]string, len(ex))
+		for i, idx := range ex {
+			parts[i] = "[" + strconv.Itoa(idx) + "]" + cuiCardStr(hand[idx])
+		}
+		return color.Yellow(i18n.Tf("oasispoker.hintExchange", "cards", strings.Join(parts, " "))) + "\n"
+	case domain.OasisPokerPhaseAction:
+		if g.RecommendPlay() {
+			return color.Yellow(i18n.T("oasispoker.hintPlay")) + "\n"
+		}
+		return color.Yellow(i18n.T("oasispoker.hintFold")) + "\n"
+	default:
+		return i18n.T("oasispoker.hintNone") + "\n"
+	}
+}

--- a/internal/adapter/presenter/OasisPokerCuiPresenter_test.go
+++ b/internal/adapter/presenter/OasisPokerCuiPresenter_test.go
@@ -1,12 +1,14 @@
 package presenter
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupOasisPokerCuiMockDefaults(m *interfaces.MockOasisPokerGame) {
@@ -224,4 +226,54 @@ func TestOasisPokerCuiPresenter_ActionLogOutput(t *testing.T) {
 
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "棋譜はありません")
+}
+
+func TestOasisPokerCuiPresenter_HintOutput(t *testing.T) {
+	p := new(OasisPokerCuiPresenter)
+	c := func(suit, val int) *domain.Card { return domain.NewCard(suit, val, false) }
+
+	t.Run("exchange lists low cards to swap", func(t *testing.T) {
+		m := new(interfaces.MockOasisPokerGame)
+		m.On("GetPhase").Return(domain.OasisPokerPhaseExchange)
+		// Pair of Kings held; low singles 3,5,7 recommended for exchange.
+		m.On("GetPlayerHand").Return([]*domain.Card{
+			c(domain.CardDesignSpade, 13), c(domain.CardDesignHeart, 13),
+			c(domain.CardDesignClover, 3), c(domain.CardDesignDiamond, 5), c(domain.CardDesignSpade, 7),
+		})
+		out := p.HintOutput(m)
+		prefix := strings.SplitN(i18n.T("oasispoker.hintExchange"), "{{", 2)[0]
+		assert.Contains(t, out, prefix)
+		assert.Contains(t, out, "[2]")
+		assert.NotContains(t, out, "[0]") // king held
+	})
+
+	t.Run("exchange recommends stand when all held", func(t *testing.T) {
+		m := new(interfaces.MockOasisPokerGame)
+		m.On("GetPhase").Return(domain.OasisPokerPhaseExchange)
+		m.On("GetPlayerHand").Return([]*domain.Card{
+			c(domain.CardDesignSpade, 1), c(domain.CardDesignHeart, 13),
+			c(domain.CardDesignClover, 12), c(domain.CardDesignDiamond, 11), c(domain.CardDesignSpade, 1),
+		})
+		assert.Contains(t, p.HintOutput(m), i18n.T("oasispoker.hintStand"))
+	})
+
+	t.Run("action recommends play", func(t *testing.T) {
+		m := new(interfaces.MockOasisPokerGame)
+		m.On("GetPhase").Return(domain.OasisPokerPhaseAction)
+		m.On("RecommendPlay").Return(true)
+		assert.Contains(t, p.HintOutput(m), i18n.T("oasispoker.hintPlay"))
+	})
+
+	t.Run("action recommends fold", func(t *testing.T) {
+		m := new(interfaces.MockOasisPokerGame)
+		m.On("GetPhase").Return(domain.OasisPokerPhaseAction)
+		m.On("RecommendPlay").Return(false)
+		assert.Contains(t, p.HintOutput(m), i18n.T("oasispoker.hintFold"))
+	})
+
+	t.Run("no hint outside decision phases", func(t *testing.T) {
+		m := new(interfaces.MockOasisPokerGame)
+		m.On("GetPhase").Return(domain.OasisPokerPhaseBet)
+		assert.Contains(t, p.HintOutput(m), i18n.T("oasispoker.hintNone"))
+	})
 }

--- a/internal/adapter/presenter/OasisPokerWebPresenter.go
+++ b/internal/adapter/presenter/OasisPokerWebPresenter.go
@@ -74,6 +74,12 @@ func (op *OasisPokerWebPresenter) ActionLogOutput(g interfaces.OasisPokerGame) s
 	return actionLogOutputJSON(g)
 }
 
+// HintOutput はヒントを返す。Web ではクライアント側でヒントを算出するため、
+// 状態出力にフォールバックする (CUI プレゼンターのみが専用ヒントを返す)。
+func (op *OasisPokerWebPresenter) HintOutput(g interfaces.OasisPokerGame) string {
+	return op.Output(g, nil)
+}
+
 // oasisPokerMaskDealerHand returns the dealer hand with all cards except the first masked.
 // 1枚目だけは表示し、それ以降は Design 空文字・Value 0 でマスクする。
 func oasisPokerMaskDealerHand(cards []*domain.Card) []*controller.WebOutputCard {

--- a/internal/adapter/presenter/OasisPokerWebPresenter_test.go
+++ b/internal/adapter/presenter/OasisPokerWebPresenter_test.go
@@ -259,3 +259,11 @@ func TestOasisPokerWebPresenter_ActionLogOutput(t *testing.T) {
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "entries")
 }
+
+func TestOasisPokerWebPresenter_HintOutput(t *testing.T) {
+	m := new(interfaces.MockOasisPokerGame)
+	setupOasisPokerWebMockDefaults(m)
+	p := new(OasisPokerWebPresenter)
+	// The web presenter computes hints client-side, so HintOutput mirrors Output.
+	assert.Equal(t, p.Output(m, nil), p.HintOutput(m))
+}

--- a/internal/domain/OasisPoker.go
+++ b/internal/domain/OasisPoker.go
@@ -382,6 +382,23 @@ func (op *OasisPoker) appendLog(playerIdx int, actionType, detail string, cards 
 // GetPlayerHand プレイヤーハンド取得
 func (op *OasisPoker) GetPlayerHand() []*Card { return op.playerHand }
 
+// RecommendPlay はアクションフェーズでプレイ (続行) を推奨するかを返す。基本戦略として
+// ワンペア以上、または A/K を含むときプレイ、それ以外はフォールドを推奨する。
+func (op *OasisPoker) RecommendPlay() bool {
+	if len(op.playerHand) < 5 {
+		return true
+	}
+	if evalFiveCardHand(op.playerHand) >= PokerHandOnePair {
+		return true
+	}
+	for _, c := range op.playerHand {
+		if v := c.GetValue(); v == 1 || v == 13 { // Ace or King
+			return true
+		}
+	}
+	return false
+}
+
 // GetDealerHand ディーラーハンド取得
 func (op *OasisPoker) GetDealerHand() []*Card { return op.dealerHand }
 

--- a/internal/domain/OasisPoker_test.go
+++ b/internal/domain/OasisPoker_test.go
@@ -617,3 +617,30 @@ func TestOasisPoker_SetSettersExposeFields(t *testing.T) {
 	assert.Equal(t, 20, op.GetJackpotBet())
 	assert.Equal(t, 200, op.GetPlayBet())
 }
+
+func TestOasisPoker_RecommendPlay(t *testing.T) {
+	t.Run("play with a pair", func(t *testing.T) {
+		op := domain.NewDefaultOasisPoker()
+		op.SetPlayerHand(makeHand(
+			cd{domain.CardDesignSpade, 8}, cd{domain.CardDesignHeart, 8},
+			cd{domain.CardDesignClover, 3}, cd{domain.CardDesignDiamond, 5}, cd{domain.CardDesignSpade, 9},
+		))
+		assert.True(t, op.RecommendPlay())
+	})
+	t.Run("play with an ace high", func(t *testing.T) {
+		op := domain.NewDefaultOasisPoker()
+		op.SetPlayerHand(makeHand(
+			cd{domain.CardDesignSpade, 1}, cd{domain.CardDesignHeart, 7},
+			cd{domain.CardDesignClover, 3}, cd{domain.CardDesignDiamond, 5}, cd{domain.CardDesignSpade, 9},
+		))
+		assert.True(t, op.RecommendPlay())
+	})
+	t.Run("fold with junk", func(t *testing.T) {
+		op := domain.NewDefaultOasisPoker()
+		op.SetPlayerHand(makeHand(
+			cd{domain.CardDesignSpade, 3}, cd{domain.CardDesignHeart, 7},
+			cd{domain.CardDesignClover, 9}, cd{domain.CardDesignDiamond, 11}, cd{domain.CardDesignSpade, 5},
+		))
+		assert.False(t, op.RecommendPlay())
+	})
+}

--- a/internal/domain/interfaces/oasis_poker.go
+++ b/internal/domain/interfaces/oasis_poker.go
@@ -56,4 +56,6 @@ type OasisPokerGame interface {
 	GetDealerHandRank() int
 	// GetChips チップを取得する
 	GetChips() int
+	// RecommendPlay はアクションフェーズでプレイを推奨するかを返す
+	RecommendPlay() bool
 }

--- a/internal/domain/interfaces/oasis_poker_mock.go
+++ b/internal/domain/interfaces/oasis_poker_mock.go
@@ -42,6 +42,9 @@ func (m *MockOasisPokerGame) Fold() error {
 	return args.Error(0)
 }
 
+func (m *MockOasisPokerGame) RecommendPlay() bool {
+	return m.Called().Bool(0)
+}
 func (m *MockOasisPokerGame) GetPlayerHand() []*domain.Card {
 	args := m.Called()
 	if args.Get(0) == nil {

--- a/internal/i18n/locales/en/oasispoker.json
+++ b/internal/i18n/locales/en/oasispoker.json
@@ -24,5 +24,10 @@
   "dealerWins": "Dealer wins!",
   "playerFolded": "Player folded.",
   "push": "Push!",
-  "totalPayoutLine": "total payout: {{payout}}"
+  "totalPayoutLine": "total payout: {{payout}}",
+  "hintNone": "No hint available.",
+  "hintExchange": "Exchange suggestion: {{cards}} (e <idx...> to swap)",
+  "hintStand": "No exchange needed; stand with s.",
+  "hintPlay": "Recommended: Play (p) — a pair or better, or an Ace/King",
+  "hintFold": "Recommended: Fold (f) — no qualifying hand"
 }

--- a/internal/i18n/locales/ja/oasispoker.json
+++ b/internal/i18n/locales/ja/oasispoker.json
@@ -24,5 +24,10 @@
   "dealerWins": "ディーラーの勝ち！",
   "playerFolded": "プレイヤーがフォールド。",
   "push": "プッシュ！",
-  "totalPayoutLine": "合計払戻し: {{payout}}"
+  "totalPayoutLine": "合計払戻し: {{payout}}",
+  "hintNone": "現在ヒントはありません。",
+  "hintExchange": "交換推奨: {{cards}}（e <idx...> で交換）",
+  "hintStand": "交換不要です。s でスタンドしてください。",
+  "hintPlay": "推奨: プレイ（p）— ワンペア以上または A/K を保持",
+  "hintFold": "推奨: フォールド（f）— 続行条件を満たしません"
 }

--- a/internal/usecase/OasisPokerInteractor.go
+++ b/internal/usecase/OasisPokerInteractor.go
@@ -26,6 +26,8 @@ type OasisPokerInteractorIF interface {
 	Fold() string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
+	// Hint ヒントを出力する
+	Hint() string
 }
 
 // OasisPokerInteractor オアシスポーカーインタラクタークラス
@@ -76,6 +78,11 @@ func (oi *OasisPokerInteractor) Fold() string {
 // ActionLog 棋譜を出力する
 func (oi *OasisPokerInteractor) ActionLog() string {
 	return oi.op.ActionLogOutput(oi.Game)
+}
+
+// Hint ヒントを出力する
+func (oi *OasisPokerInteractor) Hint() string {
+	return oi.op.HintOutput(oi.Game)
 }
 
 // RestoreOasisPokerInteractor deserialises JSON into an OasisPokerInteractor.

--- a/internal/usecase/OasisPokerInteractor_snapshot_test.go
+++ b/internal/usecase/OasisPokerInteractor_snapshot_test.go
@@ -23,6 +23,10 @@ func (s *stubOasisPokerPresenter) ActionLogOutput(_ interfaces.OasisPokerGame) s
 	return `{"log":[]}`
 }
 
+func (s *stubOasisPokerPresenter) HintOutput(_ interfaces.OasisPokerGame) string {
+	return `{"ok":true}`
+}
+
 func TestOasisPokerInteractor_SnapshotRestore(t *testing.T) {
 	op := domain.NewDefaultOasisPoker()
 	oi := NewOasisPokerInteractor(op, new(stubOasisPokerPresenter))

--- a/internal/usecase/OasisPokerInteractor_test.go
+++ b/internal/usecase/OasisPokerInteractor_test.go
@@ -150,3 +150,12 @@ func TestOasisPokerInteractor_ActionLog(t *testing.T) {
 
 	assert.Equal(t, "log output", oi.ActionLog())
 }
+
+func TestOasisPokerInteractor_Hint(t *testing.T) {
+	mockGame := new(interfaces.MockOasisPokerGame)
+	mockPresenter := new(presenter.MockOasisPokerPresenter)
+	oi := NewOasisPokerInteractor(mockGame, mockPresenter)
+
+	mockPresenter.On("HintOutput", mockGame).Return("hint output")
+	assert.Equal(t, "hint output", oi.Hint())
+}

--- a/internal/usecase/presenter/OasisPokerPresenter.go
+++ b/internal/usecase/presenter/OasisPokerPresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // OasisPokerPresenter オアシスポーカープレゼンターインタフェース
-type OasisPokerPresenter = GamePresenter[interfaces.OasisPokerGame]
+type OasisPokerPresenter interface {
+	GamePresenter[interfaces.OasisPokerGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(g interfaces.OasisPokerGame) string
+}

--- a/internal/usecase/presenter/OasisPokerPresenter_mock.go
+++ b/internal/usecase/presenter/OasisPokerPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockOasisPokerPresenter オアシスポーカープレゼンターモック
-type MockOasisPokerPresenter = MockGamePresenter[interfaces.OasisPokerGame]
+type MockOasisPokerPresenter struct {
+	MockGamePresenter[interfaces.OasisPokerGame]
+}
+
+// HintOutput モック
+func (_m *MockOasisPokerPresenter) HintOutput(g interfaces.OasisPokerGame) string {
+	ret := _m.Called(g)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 概要
`OasisPokerCuiPresenter` に `HintOutput` が無く、CUI プレイヤーは戦略提示を得られなかった。交換フェーズでは低い単札の交換（ペア・高札は保持）を、アクションフェーズではプレイ/フォールドを推奨する（ドメインに `RecommendPlay`＝ワンペア以上または A/K でプレイ推奨、を追加）。

## 変更点
- `OasisPoker.go` / `interfaces/oasis_poker.go`(+mock): `RecommendPlay()` を公開
- `usecase/presenter/OasisPokerPresenter.go`(+mock): インタフェースに `HintOutput` 追加
- `OasisPokerCuiPresenter.go`: `HintOutput`（Exchange=交換推奨/スタンド、Action=play/fold、他は hintNone）
- `OasisPokerWebPresenter.go`: `HintOutput` は `Output` に委譲
- `OasisPokerInteractor.go`(+mock, snapshot stub): `Hint()` 追加、`OasisPokerCuiController.go`: h/hint 配線
- i18n: hintNone/hintExchange/hintStand/hintPlay/hintFold ja/en
- テスト: domain RecommendPlay＋presenter 5分岐＋interactor Hint＋controller h/hint＋web HintOutput

Closes #3273