### PR TITLE
fix(casinowar): show burn cards face-up in the web to match the CUI

### DIFF
--- a/frontend/src/pages/CasinoWarPage.test.tsx
+++ b/frontend/src/pages/CasinoWarPage.test.tsx
@@ -190,6 +190,10 @@ describe('CasinoWarPage', () => {
     mockApi.mockResolvedValue(warDealtState);
     renderWithProviders(<CasinoWarPage />);
     await waitFor(() => expect(screen.getByText(/burn|焼き札|焼/i)).toBeInTheDocument());
+    // Burn cards are shown face-up (as AnimatedCard), matching the CUI — no backs.
+    expect(screen.queryAllByTestId('animated-card-back')).toHaveLength(0);
+    // 2 main + 3 burn + 2 war cards are all rendered face-up.
+    expect(screen.getAllByTestId('animated-card')).toHaveLength(7);
   });
 
   it('renders the CLI terminal when useCliMode reports cliEnabled', async () => {

--- a/frontend/src/pages/CasinoWarPage.tsx
+++ b/frontend/src/pages/CasinoWarPage.tsx
@@ -13,7 +13,6 @@ import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { KbdBadge } from '../components/KbdBadge';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
-import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
@@ -202,8 +201,8 @@ function CasinoWarPageContent() {
               <div className="mb-4">
                 <div className="text-ds-info font-bold text-center mb-1">{t('label.burnCards')}</div>
                 <div className="flex justify-center gap-2 flex-wrap">
-                  {state.burnCards.map((_, i) => (
-                    <AnimatedCardBack key={`burn-${i}`} width={cardWidth} />
+                  {state.burnCards.map((c, i) => (
+                    <AnimatedCard key={`burn-${i}`} card={c} width={cardWidth} />
                   ))}
                 </div>
               </div>


### PR DESCRIPTION
## 概要
戦争時のバーンカードについて、`CasinoWarCuiPresenter` は表面表示するのに `CasinoWarPage.tsx` は裏面（`AnimatedCardBack`）で表示しており、同じゲーム状態で Web と CUI の情報公開レベルが食い違っていた。WebPresenter は既にカード面を送っている（フロントで捨てているだけ）ため、`AnimatedCard` で表面表示に統一する（「何が焼かれたか」を見せる方が演出上も望ましい、という issue の方針）。

## 変更点
- `CasinoWarPage.tsx`: バーンカードを `AnimatedCardBack` → `AnimatedCard`（表面）で描画、未使用になった import を削除
- `CasinoWarPage.test.tsx`: WAR_DEALT で裏面が無く 7 枚すべて表面描画されることを検証

Closes #3236