### PR TITLE
feat(spiderette): add web-embedded CLI terminal mode

### DIFF
--- a/frontend/src/pages/SpiderettePage.tsx
+++ b/frontend/src/pages/SpiderettePage.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useMemo, useState } from 'react';
-import type { SpideretteMoveZone } from '../api/gameApi';
+import type { SpideretteMoveZone, spideretteApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
+import { CliTerminal } from '../components/cli/CliTerminal';
+import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { DropZone } from '../components/DropZone';
 import { ErrorAlert } from '../components/ErrorAlert';
@@ -15,6 +17,8 @@ import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
+import { useCliGame } from '../hooks/useCliGame';
+import { useCliMode } from '../hooks/useCliMode';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useResponsiveTableau } from '../hooks/useResponsiveTableau';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
@@ -22,9 +26,13 @@ import { useSpideretteGame } from '../hooks/useSpideretteGame';
 import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
+import type { SpideretteResponse } from '../types/card';
 import { SpiderettePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { parseSpideretteCommand, SPIDERETTE_HELP } from '../utils/cli/commands/spideretteCommands';
+import { formatSpideretteState } from '../utils/cli/formatters/spideretteFormatter';
+import type { CliGameConfig } from '../utils/cli/types';
 import { isTableauAllFaceUp } from '../utils/solitaireUtils';
 
 const SPDT_TUTORIAL_STEPS: TutorialStep[] = [
@@ -94,6 +102,18 @@ function SpiderettePageContent() {
     isAutoCompleting,
   } = game;
   const runCmd = game.exec;
+
+  const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('spiderette');
+  const cliConfig: CliGameConfig<SpideretteResponse, Parameters<typeof spideretteApi.exec>> = useMemo(
+    () => ({
+      gameName: 'spiderette',
+      parseCommand: parseSpideretteCommand,
+      formatResponse: formatSpideretteState,
+      helpText: SPIDERETTE_HELP,
+    }),
+    [],
+  );
+  const { handleCommand } = useCliGame(runCmd, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
   const tableau = useResponsiveTableau(TABLEAU_COLS, { padX: 32, gapPx: 2 });
   const isPlayingForKbd = state?.phase === SpiderettePhase.PLAYING;
@@ -195,6 +215,7 @@ function SpiderettePageContent() {
           <span className="ml-3">
             {t('score')}: {state.score}
           </span>
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
         </>
       }
       headerEnd={
@@ -203,216 +224,233 @@ function SpiderettePageContent() {
         </span>
       }
     >
-      <LandscapeBanner message={t('landscapeBanner')} />
+      {cliEnabled ? (
+        <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
+      ) : (
+        <>
+          <LandscapeBanner message={t('landscapeBanner')} />
 
-      <div className="flex-1 overflow-y-auto pt-3 px-4 lg:px-8">
-        <div className="flex gap-2 mb-3 items-start">
-          <div className="text-center" data-tutorial="spdt-stock-pile">
-            <div className="text-game-text-muted text-xs mb-1">
-              {t('stock')} ({state.stockCount})
+          <div className="flex-1 overflow-y-auto pt-3 px-4 lg:px-8">
+            <div className="flex gap-2 mb-3 items-start">
+              <div className="text-center" data-tutorial="spdt-stock-pile">
+                <div className="text-game-text-muted text-xs mb-1">
+                  {t('stock')} ({state.stockCount})
+                </div>
+                {state.stockCount > 0 ? (
+                  <AnimatedCardBack
+                    width={tableau.cw}
+                    onClick={isPlaying ? handleDealGuarded : undefined}
+                    ariaLabel={t('deal')}
+                  />
+                ) : (
+                  <div
+                    style={{ width: tableau.cw, height: tableau.ch }}
+                    className="rounded border border-white/20 flex items-center justify-center text-game-text-muted text-xs"
+                  >
+                    {t('empty')}
+                  </div>
+                )}
+                {state.stockCount > 0 && (
+                  <div className="text-game-text-muted text-xs mt-1">
+                    {t('dealsRemaining', { count: dealsRemaining })}
+                  </div>
+                )}
+              </div>
             </div>
-            {state.stockCount > 0 ? (
-              <AnimatedCardBack
-                width={tableau.cw}
-                onClick={isPlaying ? handleDealGuarded : undefined}
-                ariaLabel={t('deal')}
-              />
-            ) : (
-              <div
-                style={{ width: tableau.cw, height: tableau.ch }}
-                className="rounded border border-white/20 flex items-center justify-center text-game-text-muted text-xs"
-              >
-                {t('empty')}
+
+            <div className="relative">
+              <div className="flex gap-0.5 sm:gap-1 mb-3" data-tutorial="spdt-tableau">
+                {state.tableau.map((col, colIdx) => {
+                  const tableauColZone: SpideretteMoveZone = { zone: 'tableau', col: colIdx };
+                  return (
+                    <div
+                      key={`col-${colIdx.toString()}`}
+                      data-testid={`spdt-col-${colIdx.toString()}`}
+                      className={
+                        isHintTargetCol(colIdx)
+                          ? 'flex-1 min-w-0 rounded ring-1 ring-ds-success animate-pulse'
+                          : 'flex-1 min-w-0'
+                      }
+                    >
+                      <DropZone
+                        isDropTarget={dnd.isDropTarget(tableauColZone)}
+                        onDragOver={dnd.handleDragOver(tableauColZone)}
+                        onDrop={dnd.handleDrop(tableauColZone)}
+                        onDragLeave={dnd.handleDragLeave}
+                        className="relative block"
+                      >
+                        <div className="relative" style={{ minHeight: tableau.ch }}>
+                          {col.length === 0 ? (
+                            <button
+                              key={`empty-${colIdx.toString()}-${emptyDealAttemptKey.toString()}`}
+                              type="button"
+                              onClick={() => handleSelectTarget(tableauColZone)}
+                              disabled={!isPlaying || loading || !selectedSource}
+                              style={{ height: tableau.ch }}
+                              data-testid={`spdt-empty-col-${colIdx.toString()}`}
+                              className={`w-full rounded border-2 border-dashed border-white/20 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}${emptyDealAttemptKey > 0 ? ' animate-shake border-ds-warning text-ds-warning' : ''}`}
+                            >
+                              {t('empty')}
+                            </button>
+                          ) : (
+                            col.map((tc, cardIdx) => {
+                              const cardZone: SpideretteMoveZone = { zone: 'tableau', col: colIdx, cardIndex: cardIdx };
+                              return (
+                                <div
+                                  key={`tc-${colIdx.toString()}-${cardIdx.toString()}`}
+                                  className="absolute left-0 right-0"
+                                  style={{ top: cardIdx * tableau.co }}
+                                >
+                                  {tc.faceUp && tc.card ? (
+                                    <button
+                                      type="button"
+                                      onClick={() => {
+                                        if (selectedSource) {
+                                          if (selectedSource.col !== colIdx) {
+                                            handleSelectTarget(tableauColZone);
+                                          } else {
+                                            handleSelectSource(cardZone);
+                                          }
+                                        } else {
+                                          handleSelectSource(cardZone);
+                                        }
+                                      }}
+                                      disabled={!isPlaying || loading}
+                                      aria-label={cardAlt(tc.card)}
+                                      aria-pressed={isSourceSelected(colIdx, cardIdx)}
+                                      draggable={isPlaying && !loading}
+                                      onDragStart={dnd.handleDragStart(cardZone)}
+                                      onDragEnd={dnd.handleDragEnd}
+                                      data-testid={`spdt-card-${colIdx.toString()}-${cardIdx.toString()}`}
+                                      className={`p-0 border-0 bg-transparent cursor-pointer w-full rounded ${focusRingWhite} ${isSourceSelected(colIdx, cardIdx) ? 'ring-2 ring-ds-warning' : isHintSource(colIdx, cardIdx) ? 'ring-2 ring-ds-info animate-pulse' : ''} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
+                                    >
+                                      <AnimatedCard
+                                        card={tc.card}
+                                        width={tableau.cw}
+                                        draggable={false}
+                                        style={{ width: '100%' }}
+                                      />
+                                    </button>
+                                  ) : (
+                                    <AnimatedCardBack width={tableau.cw} style={{ width: '100%' }} />
+                                  )}
+                                </div>
+                              );
+                            })
+                          )}
+                          {col.length > 0 && <div style={{ height: (col.length - 1) * tableau.co + tableau.ch }} />}
+                        </div>
+                      </DropZone>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            {hint && (
+              <div className="text-ds-warning text-sm mb-2" role="status" aria-live="polite">
+                {t('hintAvailable')}: {t('tableau')} {hint.fromCol} [{hint.cardIndex}] → {t('tableau')} {hint.toCol}
               </div>
             )}
-            {state.stockCount > 0 && (
-              <div className="text-game-text-muted text-xs mt-1">{t('dealsRemaining', { count: dealsRemaining })}</div>
-            )}
-          </div>
-        </div>
 
-        <div className="relative">
-          <div className="flex gap-0.5 sm:gap-1 mb-3" data-tutorial="spdt-tableau">
-            {state.tableau.map((col, colIdx) => {
-              const tableauColZone: SpideretteMoveZone = { zone: 'tableau', col: colIdx };
-              return (
-                <div
-                  key={`col-${colIdx.toString()}`}
-                  data-testid={`spdt-col-${colIdx.toString()}`}
-                  className={
-                    isHintTargetCol(colIdx)
-                      ? 'flex-1 min-w-0 rounded ring-1 ring-ds-success animate-pulse'
-                      : 'flex-1 min-w-0'
-                  }
-                >
-                  <DropZone
-                    isDropTarget={dnd.isDropTarget(tableauColZone)}
-                    onDragOver={dnd.handleDragOver(tableauColZone)}
-                    onDrop={dnd.handleDrop(tableauColZone)}
-                    onDragLeave={dnd.handleDragLeave}
-                    className="relative block"
-                  >
-                    <div className="relative" style={{ minHeight: tableau.ch }}>
-                      {col.length === 0 ? (
-                        <button
-                          key={`empty-${colIdx.toString()}-${emptyDealAttemptKey.toString()}`}
-                          type="button"
-                          onClick={() => handleSelectTarget(tableauColZone)}
-                          disabled={!isPlaying || loading || !selectedSource}
-                          style={{ height: tableau.ch }}
-                          data-testid={`spdt-empty-col-${colIdx.toString()}`}
-                          className={`w-full rounded border-2 border-dashed border-white/20 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}${emptyDealAttemptKey > 0 ? ' animate-shake border-ds-warning text-ds-warning' : ''}`}
-                        >
-                          {t('empty')}
-                        </button>
-                      ) : (
-                        col.map((tc, cardIdx) => {
-                          const cardZone: SpideretteMoveZone = { zone: 'tableau', col: colIdx, cardIndex: cardIdx };
-                          return (
-                            <div
-                              key={`tc-${colIdx.toString()}-${cardIdx.toString()}`}
-                              className="absolute left-0 right-0"
-                              style={{ top: cardIdx * tableau.co }}
-                            >
-                              {tc.faceUp && tc.card ? (
-                                <button
-                                  type="button"
-                                  onClick={() => {
-                                    if (selectedSource) {
-                                      if (selectedSource.col !== colIdx) {
-                                        handleSelectTarget(tableauColZone);
-                                      } else {
-                                        handleSelectSource(cardZone);
-                                      }
-                                    } else {
-                                      handleSelectSource(cardZone);
-                                    }
-                                  }}
-                                  disabled={!isPlaying || loading}
-                                  aria-label={cardAlt(tc.card)}
-                                  aria-pressed={isSourceSelected(colIdx, cardIdx)}
-                                  draggable={isPlaying && !loading}
-                                  onDragStart={dnd.handleDragStart(cardZone)}
-                                  onDragEnd={dnd.handleDragEnd}
-                                  data-testid={`spdt-card-${colIdx.toString()}-${cardIdx.toString()}`}
-                                  className={`p-0 border-0 bg-transparent cursor-pointer w-full rounded ${focusRingWhite} ${isSourceSelected(colIdx, cardIdx) ? 'ring-2 ring-ds-warning' : isHintSource(colIdx, cardIdx) ? 'ring-2 ring-ds-info animate-pulse' : ''} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
-                                >
-                                  <AnimatedCard
-                                    card={tc.card}
-                                    width={tableau.cw}
-                                    draggable={false}
-                                    style={{ width: '100%' }}
-                                  />
-                                </button>
-                              ) : (
-                                <AnimatedCardBack width={tableau.cw} style={{ width: '100%' }} />
-                              )}
-                            </div>
-                          );
-                        })
-                      )}
-                      {col.length > 0 && <div style={{ height: (col.length - 1) * tableau.co + tableau.ch }} />}
-                    </div>
-                  </DropZone>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-
-        {hint && (
-          <div className="text-ds-warning text-sm mb-2" role="status" aria-live="polite">
-            {t('hintAvailable')}: {t('tableau')} {hint.fromCol} [{hint.cardIndex}] → {t('tableau')} {hint.toCol}
-          </div>
-        )}
-
-        {/* Announce the empty-column deal guard for screen readers; the key
+            {/* Announce the empty-column deal guard for screen readers; the key
             forces a remount on each blocked attempt so it re-announces, mirroring
             the visual shake animation. */}
-        {emptyDealAttemptKey > 0 && (
-          <div
-            key={`deal-warn-${emptyDealAttemptKey.toString()}`}
-            className="sr-only"
-            role="status"
-            aria-live="assertive"
-          >
-            {t('cannotDealEmptyColExists')}
+            {emptyDealAttemptKey > 0 && (
+              <div
+                key={`deal-warn-${emptyDealAttemptKey.toString()}`}
+                className="sr-only"
+                role="status"
+                aria-live="assertive"
+              >
+                {t('cannotDealEmptyColExists')}
+              </div>
+            )}
+
+            <GameMessageBox
+              message={state.message}
+              messageCode={state.messageCode}
+              messageParams={state.messageParams}
+            />
+
+            <ActionLogSection
+              isEndPhase={isEnded}
+              actionLog={actionLog}
+              showActionLog={showActionLog}
+              hideActionLog={hideActionLog}
+            />
           </div>
-        )}
 
-        <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
+          <SettingsPanel title={tc('settings.title')} groups={[]} />
 
-        <ActionLogSection
-          isEndPhase={isEnded}
-          actionLog={actionLog}
-          showActionLog={showActionLog}
-          hideActionLog={hideActionLog}
-        />
-      </div>
-
-      <SettingsPanel title={tc('settings.title')} groups={[]} />
-
-      <GameFooter className={`${gameTheme.spiderette.footer} px-4 py-2.5`}>
-        <ErrorAlert message={error ?? hintError} onRetry={retry} />
-        <div className="flex gap-2 items-center flex-wrap">
-          {isPlaying && (
-            <div data-tutorial="spdt-controls">
-              <button
-                type="button"
-                className={btnPrimary}
-                onClick={handleDealGuarded}
-                disabled={loading || isAutoCompleting}
-                title={dealBlockedByEmpty ? t('cannotDealEmptyColExists') : undefined}
-              >
-                {t('deal')}
-              </button>
-              <button
-                type="button"
-                className={btnPrimary}
-                onClick={handleUndo}
-                disabled={loading || isAutoCompleting || !state.canUndo}
-              >
-                {t('undo')}
-              </button>
-              {state.isStalemate && (
-                <StalemateEscapeButton
-                  undoToEscape={state.undoToEscape ?? 0}
-                  onEscape={handleUndoEscape}
-                  disabled={loading || isAutoCompleting}
-                />
+          <GameFooter className={`${gameTheme.spiderette.footer} px-4 py-2.5`}>
+            <ErrorAlert message={error ?? hintError} onRetry={retry} />
+            <div className="flex gap-2 items-center flex-wrap">
+              {isPlaying && (
+                <div data-tutorial="spdt-controls">
+                  <button
+                    type="button"
+                    className={btnPrimary}
+                    onClick={handleDealGuarded}
+                    disabled={loading || isAutoCompleting}
+                    title={dealBlockedByEmpty ? t('cannotDealEmptyColExists') : undefined}
+                  >
+                    {t('deal')}
+                  </button>
+                  <button
+                    type="button"
+                    className={btnPrimary}
+                    onClick={handleUndo}
+                    disabled={loading || isAutoCompleting || !state.canUndo}
+                  >
+                    {t('undo')}
+                  </button>
+                  {state.isStalemate && (
+                    <StalemateEscapeButton
+                      undoToEscape={state.undoToEscape ?? 0}
+                      onEscape={handleUndoEscape}
+                      disabled={loading || isAutoCompleting}
+                    />
+                  )}
+                  <button
+                    type="button"
+                    className={btnSuccess}
+                    onClick={handleHint}
+                    disabled={loading || isAutoCompleting}
+                  >
+                    {t('hint')}
+                  </button>
+                  <button
+                    type="button"
+                    className={`${btnSuccess}${autoCompleteReady && !loading && !isAutoCompleting ? ' animate-pulse ring-2 ring-ds-success' : ''}`}
+                    onClick={handleAutoComplete}
+                    disabled={loading || isAutoCompleting || !autoCompleteReady}
+                    data-testid="autocomplete-button"
+                    title={autoCompleteReady ? undefined : t('autoCompleteNotReady')}
+                  >
+                    {t('autoComplete')}
+                  </button>
+                  <button
+                    type="button"
+                    className={btnDanger}
+                    onClick={confirmGiveUpAction}
+                    disabled={loading || isAutoCompleting}
+                  >
+                    {t('giveup')}
+                  </button>
+                </div>
               )}
-              <button type="button" className={btnSuccess} onClick={handleHint} disabled={loading || isAutoCompleting}>
-                {t('hint')}
-              </button>
-              <button
-                type="button"
-                className={`${btnSuccess}${autoCompleteReady && !loading && !isAutoCompleting ? ' animate-pulse ring-2 ring-ds-success' : ''}`}
-                onClick={handleAutoComplete}
-                disabled={loading || isAutoCompleting || !autoCompleteReady}
-                data-testid="autocomplete-button"
-                title={autoCompleteReady ? undefined : t('autoCompleteNotReady')}
-              >
-                {t('autoComplete')}
-              </button>
-              <button
-                type="button"
-                className={btnDanger}
-                onClick={confirmGiveUpAction}
-                disabled={loading || isAutoCompleting}
-              >
-                {t('giveup')}
-              </button>
+              <GameResetButton
+                isGameEnd={isEnded}
+                onReset={handleManualReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+                dataTutorial="spdt-reset-button"
+              />
             </div>
-          )}
-          <GameResetButton
-            isGameEnd={isEnded}
-            onReset={handleManualReset}
-            requestConfirm={requestConfirm}
-            loading={loading}
-            dataTutorial="spdt-reset-button"
-          />
-        </div>
-      </GameFooter>
+          </GameFooter>
+        </>
+      )}
     </GamePageShell>
   );
 }

--- a/frontend/src/utils/cli/commands/spideretteCommands.test.ts
+++ b/frontend/src/utils/cli/commands/spideretteCommands.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { parseSpideretteCommand } from './spideretteCommands';
+
+describe('parseSpideretteCommand', () => {
+  it('parses deal', () => {
+    expect(parseSpideretteCommand('d')).toEqual({ args: ['deal'] });
+    expect(parseSpideretteCommand('deal')).toEqual({ args: ['deal'] });
+  });
+
+  it('parses move from col to col', () => {
+    expect(parseSpideretteCommand('m 0 3')).toEqual({
+      args: ['move', { zone: 'tableau', col: 0 }, { zone: 'tableau', col: 3 }],
+    });
+  });
+
+  it('parses move with card index', () => {
+    expect(parseSpideretteCommand('m 0 2 3')).toEqual({
+      args: ['move', { zone: 'tableau', col: 0, cardIndex: 2 }, { zone: 'tableau', col: 3 }],
+    });
+  });
+
+  it('returns error for move without enough args', () => {
+    expect('error' in parseSpideretteCommand('m')).toBe(true);
+    expect('error' in parseSpideretteCommand('m 0')).toBe(true);
+  });
+
+  it('returns error for move with non-numeric args', () => {
+    expect('error' in parseSpideretteCommand('m a b')).toBe(true);
+    expect('error' in parseSpideretteCommand('m 0 b 3')).toBe(true);
+    expect('error' in parseSpideretteCommand('m 0 2 c')).toBe(true);
+  });
+
+  it('parses giveup', () => {
+    expect(parseSpideretteCommand('g')).toEqual({ args: ['giveup'] });
+    expect(parseSpideretteCommand('giveup')).toEqual({ args: ['giveup'] });
+  });
+
+  it('parses autocomplete', () => {
+    expect(parseSpideretteCommand('ac')).toEqual({ args: ['autocomplete'] });
+    expect(parseSpideretteCommand('autocomplete')).toEqual({ args: ['autocomplete'] });
+  });
+
+  it('parses undo', () => {
+    expect(parseSpideretteCommand('u')).toEqual({ args: ['undo'] });
+    expect(parseSpideretteCommand('undo')).toEqual({ args: ['undo'] });
+  });
+
+  it('parses hint', () => {
+    expect(parseSpideretteCommand('h')).toEqual({ args: ['hint'] });
+    expect(parseSpideretteCommand('hint')).toEqual({ args: ['hint'] });
+  });
+
+  it('parses log', () => {
+    expect(parseSpideretteCommand('log')).toEqual({ args: ['log'] });
+  });
+
+  it('parses reset', () => {
+    expect(parseSpideretteCommand('r')).toEqual({ args: ['reset'] });
+    expect(parseSpideretteCommand('reset')).toEqual({ args: ['reset'] });
+  });
+
+  it('suggests a command for a close typo', () => {
+    const result = parseSpideretteCommand('deak');
+    expect('error' in result).toBe(true);
+    if ('error' in result) expect(result.error).toContain('deal');
+  });
+
+  it('returns error for unknown command', () => {
+    expect('error' in parseSpideretteCommand('xyz')).toBe(true);
+  });
+});

--- a/frontend/src/utils/cli/commands/spideretteCommands.ts
+++ b/frontend/src/utils/cli/commands/spideretteCommands.ts
@@ -1,0 +1,95 @@
+import type { spideretteApi } from '../../../api/gameApi';
+import { parseIntArg, splitCommand, suggestCommand } from '../commandParserBase';
+import type { CliParseResult } from '../types';
+
+type SpideretteArgs = Parameters<typeof spideretteApi.exec>;
+
+const VALID_COMMANDS = [
+  'd',
+  'deal',
+  'm',
+  'move',
+  'g',
+  'giveup',
+  'ac',
+  'autocomplete',
+  'u',
+  'undo',
+  'h',
+  'hint',
+  'log',
+  'r',
+  'reset',
+  'help',
+  '?',
+];
+
+/** Parse a Spiderette CLI command into API exec arguments. */
+export function parseSpideretteCommand(input: string): CliParseResult<SpideretteArgs> {
+  const { cmd, args } = splitCommand(input);
+
+  switch (cmd) {
+    case 'd':
+    case 'deal':
+      return { args: ['deal'] };
+    case 'm':
+    case 'move': {
+      if (args.length < 2) return { error: 'Usage: m <fromCol> <toCol> or m <fromCol> <cardIdx> <toCol>' };
+      const fromCol = parseIntArg(args, 0);
+      if ('error' in fromCol) return { error: 'Usage: m <fromCol> <toCol>' };
+      if (args.length >= 3) {
+        const cardIdx = parseIntArg(args, 1);
+        if ('error' in cardIdx) return { error: 'Usage: m <fromCol> <cardIdx> <toCol>' };
+        const toCol = parseIntArg(args, 2);
+        if ('error' in toCol) return { error: 'Usage: m <fromCol> <cardIdx> <toCol>' };
+        return {
+          args: [
+            'move',
+            { zone: 'tableau', col: fromCol.value, cardIndex: cardIdx.value },
+            { zone: 'tableau', col: toCol.value },
+          ],
+        };
+      }
+      const toCol = parseIntArg(args, 1);
+      if ('error' in toCol) return { error: 'Usage: m <fromCol> <toCol>' };
+      return {
+        args: ['move', { zone: 'tableau', col: fromCol.value }, { zone: 'tableau', col: toCol.value }],
+      };
+    }
+    case 'g':
+    case 'giveup':
+      return { args: ['giveup'] };
+    case 'ac':
+    case 'autocomplete':
+      return { args: ['autocomplete'] };
+    case 'u':
+    case 'undo':
+      return { args: ['undo'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
+    case 'log':
+      return { args: ['log'] };
+    case 'r':
+    case 'reset':
+      return { args: ['reset'] };
+    default: {
+      const suggestion = suggestCommand(cmd, VALID_COMMANDS);
+      if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
+      return { error: `Unknown command: ${cmd}` };
+    }
+  }
+}
+
+/** Help text for Spiderette CLI mode. */
+export const SPIDERETTE_HELP: string[] = [
+  'd/deal      - Deal new row',
+  'm <c1> <c2> - Move top card from col to col',
+  'm <c1> <i> <c2> - Move card at index to col',
+  'ac          - Auto-complete',
+  'u/undo      - Undo last move',
+  'h/hint      - Get a hint',
+  'g/giveup    - Give up',
+  'log         - Show action log',
+  'r/reset     - Reset the game',
+];

--- a/frontend/src/utils/cli/formatters/spideretteFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/spideretteFormatter.test.ts
@@ -22,6 +22,7 @@ const baseState: SpideretteResponse = {
   moveCount: 3,
   canUndo: true,
   isStalemate: false,
+  message: '',
 };
 
 describe('formatSpideretteState', () => {

--- a/frontend/src/utils/cli/formatters/spideretteFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/spideretteFormatter.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import type { SpideretteResponse } from '../../../types/card';
+import { formatSpideretteState } from './spideretteFormatter';
+
+const baseState: SpideretteResponse = {
+  tableau: [
+    [{ card: { design: 'SPADE', value: 13 }, faceUp: true }],
+    [],
+    [
+      { card: null, faceUp: false },
+      { card: { design: 'HEART', value: 5 }, faceUp: true },
+    ],
+    [],
+    [],
+    [],
+    [],
+  ],
+  stockCount: 20,
+  completedSuits: 1,
+  score: 40,
+  phase: 0,
+  moveCount: 3,
+  canUndo: true,
+  isStalemate: false,
+};
+
+describe('formatSpideretteState', () => {
+  it('renders the header, stock, and completed count', () => {
+    const out = formatSpideretteState(baseState);
+    expect(out).toContain('Spiderette');
+    expect(out).toContain('stock: 20 | completed: 1/4');
+    expect(out).toContain('moves: 3 | score: 40');
+  });
+
+  it('renders columns with face-up indices, hidden cards, and empties', () => {
+    const out = formatSpideretteState(baseState);
+    expect(out).toContain('col0: [0]'); // face-up king
+    expect(out).toContain('col1: [empty]');
+    expect(out).toContain('[?]'); // face-down card hidden
+  });
+
+  it('renders a hint line when present', () => {
+    const out = formatSpideretteState({ ...baseState, hint: { fromCol: 0, cardIndex: 0, toCol: 2 } });
+    expect(out).toContain('HINT: col0[0] → col2');
+  });
+
+  it('renders a stalemate notice and a win banner', () => {
+    expect(formatSpideretteState({ ...baseState, isStalemate: true })).toContain('Stalemate');
+    expect(formatSpideretteState({ ...baseState, phase: 1 })).toContain('Congratulations');
+  });
+});

--- a/frontend/src/utils/cli/formatters/spideretteFormatter.ts
+++ b/frontend/src/utils/cli/formatters/spideretteFormatter.ts
@@ -1,0 +1,34 @@
+import type { SpideretteResponse } from '../../../types/card';
+import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+
+/** Format a Spiderette game state as terminal text. */
+export function formatSpideretteState(state: SpideretteResponse): string {
+  const lines: string[] = [];
+
+  lines.push(formatHeader('Spiderette'));
+  lines.push(`stock: ${state.stockCount} | completed: ${state.completedSuits}/4`);
+  lines.push('----------');
+
+  for (let col = 0; col < state.tableau.length; col++) {
+    const column = state.tableau[col];
+    if (column.length === 0) {
+      lines.push(`col${col}: [empty]`);
+    } else {
+      const cardStrs = column.map((tc, i) => (tc.faceUp && tc.card ? `[${i}]${formatCard(tc.card)}` : '[?]'));
+      lines.push(`col${col}: ${cardStrs.join(' ')}`);
+    }
+  }
+  lines.push('----------');
+
+  lines.push(`moves: ${state.moveCount} | score: ${state.score}`);
+
+  if (state.isStalemate) lines.push('Stalemate - no more moves possible');
+  if (state.hint) {
+    lines.push(`HINT: col${state.hint.fromCol}[${state.hint.cardIndex}] → col${state.hint.toCol}`);
+  }
+  if (state.message) lines.push(state.message);
+  if (state.phase === 1) lines.push('Congratulations! You win!');
+
+  lines.push(formatSeparator());
+  return lines.join('\n');
+}


### PR DESCRIPTION
## 概要
`SpideretteCuiPresenter` は CUI 出力を完全実装済みだが、`SpiderettePage.tsx` には他ソリティアページが持つ Web 内蔵 CLI モードが無かった。`spider` のパターンを踏襲し、`spideretteCommands.ts`（パーサ）と `spideretteFormatter.ts`（状態フォーマッタ）を新設して `CliToggle`/`CliTerminal` を配線する。

## 変更点
- `spideretteCommands.ts`(+test): deal/move/autocomplete/undo/hint/giveup/log/reset のパーサ
- `spideretteFormatter.ts`(+test): 盤面テキスト整形（tableau/stock/completed/hint/勝敗）
- `SpiderettePage.tsx`: `useCliMode`/`useCliGame` フック、ヘッダーに `CliToggle`、`cliEnabled` 時に `CliTerminal` を描画（GUI は不変）

## 受け入れ条件
- [x] ヘッダーに CliToggle が表示され CLI モードに切替可能
- [x] deal/move/hint/undo 等のコマンドが CLI から実行可能
- [x] パーサ・フォーマッタに単体テスト
- [x] 既存 GUI 操作に影響なし（SpiderettePage.test.tsx 全通過）

Closes #3266