### PR TITLE
feat(blackjackswitch): implement the web CLI mode (replace the stub)

### DIFF
--- a/frontend/src/pages/BlackJackSwitchPage.tsx
+++ b/frontend/src/pages/BlackJackSwitchPage.tsx
@@ -28,23 +28,14 @@ import type { BlackJackSwitchResponse, Card } from '../types/card';
 import { BlackJackSwitchPhase, BlackJackSwitchResult } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { blackjackSwitchPreviewScores } from '../utils/blackjackSwitchPreview';
+import { BLACKJACKSWITCH_HELP, parseBlackjackSwitchCommand } from '../utils/cli/commands/blackjackswitchCommands';
+import { formatBlackjackSwitchState } from '../utils/cli/formatters/blackjackswitchFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 
 const BJSWITCH_TUTORIAL_STEPS: TutorialStep[] = [];
 
-const BJSWITCH_CLI_HELP: string[] = [];
-
 // Mirrors the backend BJSwitchMaxBet (per-hand cap in internal/domain/BlackJackSwitch.go).
 const BJSWITCH_MAX_BET = 10000;
-
-/** Stub CLI parser — Blackjack Switch ships GUI-only for now (#1669 minimum). */
-function parseBlackjackSwitchCommand(): { error: string } {
-  return { error: 'CLI commands are not yet implemented for Blackjack Switch.' };
-}
-
-function formatBlackjackSwitchState(_state: BlackJackSwitchResponse | null): string {
-  return 'CLI mode is not implemented for Blackjack Switch.';
-}
 
 /** Renders the Blackjack Switch game page (#1669). */
 export const BlackJackSwitchPage = withTutorial(BlackJackSwitchPageContent, 'blackjackswitch', BJSWITCH_TUTORIAL_STEPS);
@@ -66,7 +57,7 @@ function BlackJackSwitchPageContent() {
       gameName: 'blackjackswitch',
       parseCommand: parseBlackjackSwitchCommand,
       formatResponse: formatBlackjackSwitchState,
-      helpText: BJSWITCH_CLI_HELP,
+      helpText: BLACKJACKSWITCH_HELP,
     }),
     [],
   );

--- a/frontend/src/utils/cli/commands/blackjackswitchCommands.test.ts
+++ b/frontend/src/utils/cli/commands/blackjackswitchCommands.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { parseBlackjackSwitchCommand } from './blackjackswitchCommands';
+
+describe('parseBlackjackSwitchCommand', () => {
+  it('parses bet with an amount', () => {
+    expect(parseBlackjackSwitchCommand('bet 100')).toEqual({ args: ['bet', 100] });
+    expect(parseBlackjackSwitchCommand('b 250')).toEqual({ args: ['bet', 250] });
+  });
+
+  it('errors on bet without a valid amount', () => {
+    expect('error' in parseBlackjackSwitchCommand('bet')).toBe(true);
+    expect('error' in parseBlackjackSwitchCommand('bet abc')).toBe(true);
+  });
+
+  it('parses switch and keep', () => {
+    expect(parseBlackjackSwitchCommand('sw')).toEqual({ args: ['switch'] });
+    expect(parseBlackjackSwitchCommand('switch')).toEqual({ args: ['switch'] });
+    expect(parseBlackjackSwitchCommand('k')).toEqual({ args: ['keep'] });
+    expect(parseBlackjackSwitchCommand('keep')).toEqual({ args: ['keep'] });
+  });
+
+  it('parses hit, stand, and double down', () => {
+    expect(parseBlackjackSwitchCommand('hit')).toEqual({ args: ['hit'] });
+    expect(parseBlackjackSwitchCommand('s')).toEqual({ args: ['stand'] });
+    expect(parseBlackjackSwitchCommand('stand')).toEqual({ args: ['stand'] });
+    expect(parseBlackjackSwitchCommand('dd')).toEqual({ args: ['doubledown'] });
+    expect(parseBlackjackSwitchCommand('doubledown')).toEqual({ args: ['doubledown'] });
+  });
+
+  it('parses log and reset', () => {
+    expect(parseBlackjackSwitchCommand('log')).toEqual({ args: ['log'] });
+    expect(parseBlackjackSwitchCommand('l')).toEqual({ args: ['log'] });
+    expect(parseBlackjackSwitchCommand('r')).toEqual({ args: ['reset'] });
+    expect(parseBlackjackSwitchCommand('reset')).toEqual({ args: ['reset'] });
+  });
+
+  it('suggests a command for a close typo', () => {
+    const result = parseBlackjackSwitchCommand('stan');
+    expect('error' in result).toBe(true);
+    if ('error' in result) expect(result.error).toContain('stand');
+  });
+
+  it('errors on an unknown command', () => {
+    expect('error' in parseBlackjackSwitchCommand('xyz')).toBe(true);
+  });
+});

--- a/frontend/src/utils/cli/commands/blackjackswitchCommands.ts
+++ b/frontend/src/utils/cli/commands/blackjackswitchCommands.ts
@@ -1,0 +1,78 @@
+import type { blackjackswitchApi } from '../../../api/gameApi';
+import { parseIntArg, splitCommand, suggestCommand } from '../commandParserBase';
+import type { CliParseResult } from '../types';
+
+type BlackjackSwitchArgs = Parameters<typeof blackjackswitchApi.exec>;
+
+const VALID_COMMANDS = [
+  'b',
+  'bet',
+  'sw',
+  'switch',
+  'k',
+  'keep',
+  'hit',
+  's',
+  'stand',
+  'dd',
+  'double',
+  'doubledown',
+  'log',
+  'l',
+  'r',
+  'reset',
+  'help',
+  '?',
+];
+
+/** Parse a Blackjack Switch CLI command into API exec arguments. */
+export function parseBlackjackSwitchCommand(input: string): CliParseResult<BlackjackSwitchArgs> {
+  const { cmd, args } = splitCommand(input);
+
+  switch (cmd) {
+    case 'b':
+    case 'bet': {
+      const amount = parseIntArg(args, 0);
+      if ('error' in amount) return { error: 'Usage: bet <amount>' };
+      return { args: ['bet', amount.value] };
+    }
+    case 'sw':
+    case 'switch':
+      return { args: ['switch'] };
+    case 'k':
+    case 'keep':
+      return { args: ['keep'] };
+    case 'hit':
+      return { args: ['hit'] };
+    case 's':
+    case 'stand':
+      return { args: ['stand'] };
+    case 'dd':
+    case 'double':
+    case 'doubledown':
+      return { args: ['doubledown'] };
+    case 'log':
+    case 'l':
+      return { args: ['log'] };
+    case 'r':
+    case 'reset':
+      return { args: ['reset'] };
+    default: {
+      const suggestion = suggestCommand(cmd, VALID_COMMANDS);
+      if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
+      return { error: `Unknown command: ${cmd}` };
+    }
+  }
+}
+
+/** Help text for Blackjack Switch CLI mode. */
+export const BLACKJACKSWITCH_HELP: string[] = [
+  'bet <amt>   - Place the ante and deal',
+  'sw/switch   - Switch the two hands’ second cards',
+  'k/keep      - Keep the hands as dealt',
+  'hit         - Draw a card for the current hand',
+  's/stand     - Stand the current hand',
+  'dd          - Double down the current hand',
+  'log         - Show action log',
+  'r/reset     - Reset the game',
+];

--- a/frontend/src/utils/cli/formatters/blackjackswitchFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/blackjackswitchFormatter.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import type { BlackJackSwitchHand, BlackJackSwitchResponse } from '../../../types/card';
+import { formatBlackjackSwitchState } from './blackjackswitchFormatter';
+
+const hand = (over: Partial<BlackJackSwitchHand> = {}): BlackJackSwitchHand => ({
+  cards: [
+    { design: 'SPADE', value: 10 },
+    { design: 'HEART', value: 9 },
+  ],
+  score: 19,
+  bet: 100,
+  stood: false,
+  doubled: false,
+  busted: false,
+  isBJ: false,
+  result: 0,
+  payout: 0,
+  ...over,
+});
+
+const baseState: BlackJackSwitchResponse = {
+  hands: [hand(), hand({ score: 12, stood: true })],
+  dealerCards: [{ design: 'CLOVER', value: 13 }, null],
+  dealerScore: 10,
+  phase: 3,
+  currentHandIdx: 0,
+  chips: 800,
+  switched: false,
+  dealerPushed22: false,
+  overallResult: 0,
+  totalPayout: 0,
+  message: '',
+};
+
+describe('formatBlackjackSwitchState', () => {
+  it('returns a loading notice for a null state', () => {
+    expect(formatBlackjackSwitchState(null)).toContain('Loading');
+  });
+
+  it('renders chips, phase, and both hands with the active marker', () => {
+    const out = formatBlackjackSwitchState(baseState);
+    expect(out).toContain('Blackjack Switch');
+    expect(out).toContain('chips: 800 | phase: ACTION');
+    expect(out).toContain('>hand0'); // active hand marker
+    expect(out).toContain(' hand1');
+    expect(out).toContain('[stood]'); // hand1 flag
+  });
+
+  it('shows the dealer hole card as ??', () => {
+    const out = formatBlackjackSwitchState(baseState);
+    expect(out).toMatch(/dealer \(10\):.*\?\?/);
+  });
+
+  it('shows the total payout at end phase', () => {
+    const out = formatBlackjackSwitchState({ ...baseState, phase: 4, totalPayout: 300 });
+    expect(out).toContain('total payout: 300');
+  });
+});

--- a/frontend/src/utils/cli/formatters/blackjackswitchFormatter.ts
+++ b/frontend/src/utils/cli/formatters/blackjackswitchFormatter.ts
@@ -1,0 +1,41 @@
+import type { BlackJackSwitchResponse, Card } from '../../../types/card';
+import { formatCard, formatHeader, formatSeparator } from '../formatterBase';
+
+const PHASE_NAMES: Record<number, string> = { 1: 'BET', 2: 'SWITCH', 3: 'ACTION', 4: 'END' };
+
+// Render a row of cards; face-down entries (null) show as "??".
+function cardsRow(cards: (Card | null)[]): string {
+  return cards.map((c) => (c ? formatCard(c) : '??')).join(' ');
+}
+
+/** Format a Blackjack Switch game state as terminal text. */
+export function formatBlackjackSwitchState(state: BlackJackSwitchResponse | null): string {
+  if (!state) return 'Loading...';
+  const lines: string[] = [];
+
+  lines.push(formatHeader('Blackjack Switch'));
+  lines.push(`chips: ${state.chips} | phase: ${PHASE_NAMES[state.phase] ?? state.phase}`);
+  lines.push('----------');
+
+  lines.push(`dealer (${state.dealerScore}): ${cardsRow(state.dealerCards)}`);
+  lines.push('----------');
+
+  state.hands.forEach((hand, i) => {
+    const marker = state.phase === 3 && i === state.currentHandIdx ? '>' : ' ';
+    const flags = [hand.isBJ && 'BJ', hand.busted && 'BUST', hand.stood && 'stood', hand.doubled && 'x2']
+      .filter(Boolean)
+      .join(',');
+    lines.push(
+      `${marker}hand${i} (${hand.score}) bet:${hand.bet} ${cardsRow(hand.cards)}${flags ? ` [${flags}]` : ''}`,
+    );
+  });
+  lines.push('----------');
+
+  if (state.phase === 4) {
+    lines.push(`total payout: ${state.totalPayout}`);
+  }
+  if (state.message) lines.push(state.message);
+
+  lines.push(formatSeparator());
+  return lines.join('\n');
+}


### PR DESCRIPTION
## 概要
`BlackJackSwitchPage.tsx` の `parseBlackjackSwitchCommand`/`formatBlackjackSwitchState` は「CLI not yet implemented」のインラインスタブだった（#1669 最小実装）。CasinoWar のパターンを踏襲して `blackjackswitchCommands.ts`/`blackjackswitchFormatter.ts` を新設し、スタブを実装に差し替える。

## 変更点
- `blackjackswitchCommands.ts`(+test): `bet <額>`/`sw`(switch)/`k`(keep)/`hit`/`s`(stand)/`dd`(doubledown)/`log`/`r`(reset)
- `blackjackswitchFormatter.ts`(+test): チップ・フェーズ・2ハンド（スコア/ベット/アクティブマーカー/BJ・BUST 等フラグ）・ディーラー（伏せ札 ??）・終了時の合計払戻し
- `BlackJackSwitchPage.tsx`: インラインスタブを削除し実装関数を import（CliToggle/CliTerminal は既存）

## 受け入れ条件
- [x] CLI で bet/switch/keep/hit/stand/dd が動作
- [x] フォーマッタが 2 ハンド＋ディーラー（伏せ札 ??）を表示
- [x] ヘルプ表示
- [x] commands/formatter 単体テスト（46 tests 全通過、既存 GUI テスト不変）

Closes #3244