### PR TITLE
feat(durak): implement the web CLI mode

### DIFF
--- a/frontend/src/pages/DurakPage.tsx
+++ b/frontend/src/pages/DurakPage.tsx
@@ -25,6 +25,8 @@ import { gameTheme } from '../styles/gameTheme';
 import type { DurakResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { DURAK_HELP, parseDurakCommand } from '../utils/cli/commands/durakCommands';
+import { formatDurakState } from '../utils/cli/formatters/durakFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 
@@ -96,9 +98,9 @@ function DurakPageContent() {
   const durakCliConfig: CliGameConfig<DurakResponse, Parameters<typeof gameExec>> = useMemo(
     () => ({
       gameName: 'durak',
-      parseCommand: (_cmd: string) => ({ error: 'CLI not supported' }) as const,
-      formatResponse: (_res: DurakResponse): string => '',
-      helpText: [] as string[],
+      parseCommand: parseDurakCommand,
+      formatResponse: formatDurakState,
+      helpText: DURAK_HELP,
     }),
     [],
   );

--- a/frontend/src/utils/cli/commands/durakCommands.test.ts
+++ b/frontend/src/utils/cli/commands/durakCommands.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { parseDurakCommand } from './durakCommands';
+
+describe('parseDurakCommand', () => {
+  it('parses attack with a card index', () => {
+    expect(parseDurakCommand('attack 2')).toEqual({ args: ['attack', 2] });
+    expect(parseDurakCommand('a 0')).toEqual({ args: ['attack', 0] });
+  });
+
+  it('errors on attack without a valid index', () => {
+    expect('error' in parseDurakCommand('attack')).toBe(true);
+    expect('error' in parseDurakCommand('a abc')).toBe(true);
+  });
+
+  it('parses defend with card and pair indices', () => {
+    expect(parseDurakCommand('defend 1 0')).toEqual({ args: ['defend', 1, 0] });
+    expect(parseDurakCommand('d 3 2')).toEqual({ args: ['defend', 3, 2] });
+  });
+
+  it('errors on defend missing an index', () => {
+    expect('error' in parseDurakCommand('defend 1')).toBe(true);
+    expect('error' in parseDurakCommand('d')).toBe(true);
+  });
+
+  it('parses pass and take', () => {
+    expect(parseDurakCommand('pass')).toEqual({ args: ['pass'] });
+    expect(parseDurakCommand('p')).toEqual({ args: ['pass'] });
+    expect(parseDurakCommand('take')).toEqual({ args: ['take'] });
+    expect(parseDurakCommand('t')).toEqual({ args: ['take'] });
+  });
+
+  it('parses sort by suit and value', () => {
+    expect(parseDurakCommand('sort suit')).toEqual({ args: ['sort', undefined, undefined, undefined, 0] });
+    expect(parseDurakCommand('sort s')).toEqual({ args: ['sort', undefined, undefined, undefined, 0] });
+    expect(parseDurakCommand('sort value')).toEqual({ args: ['sort', undefined, undefined, undefined, 1] });
+    expect(parseDurakCommand('sort v')).toEqual({ args: ['sort', undefined, undefined, undefined, 1] });
+    expect(parseDurakCommand('sort 1')).toEqual({ args: ['sort', undefined, undefined, undefined, 1] });
+  });
+
+  it('errors on an invalid sort mode', () => {
+    expect('error' in parseDurakCommand('sort')).toBe(true);
+    expect('error' in parseDurakCommand('sort rank')).toBe(true);
+  });
+
+  it('parses reset', () => {
+    expect(parseDurakCommand('reset')).toEqual({ args: ['reset'] });
+    expect(parseDurakCommand('r')).toEqual({ args: ['reset'] });
+  });
+
+  it('suggests a command for a close typo', () => {
+    const result = parseDurakCommand('atack 1');
+    expect('error' in result).toBe(true);
+    if ('error' in result) expect(result.error).toContain('attack');
+  });
+
+  it('errors on an unknown command', () => {
+    expect('error' in parseDurakCommand('zzz')).toBe(true);
+  });
+});

--- a/frontend/src/utils/cli/commands/durakCommands.ts
+++ b/frontend/src/utils/cli/commands/durakCommands.ts
@@ -1,0 +1,73 @@
+import type { durakApi } from '../../../api/gameApi';
+import { parseIntArg, splitCommand, suggestCommand } from '../commandParserBase';
+import type { CliParseResult } from '../types';
+
+type DurakArgs = Parameters<typeof durakApi.exec>;
+
+const DURAK_COMMANDS = ['a', 'attack', 'd', 'defend', 'p', 'pass', 't', 'take', 'sort', 'r', 'reset', 'help', '?'];
+
+/** Map a sort argument (suit/value/s/v/0/1) to the numeric sort mode, or null if invalid. */
+function parseSortMode(arg: string | undefined): number | null {
+  switch (arg) {
+    case 'suit':
+    case 's':
+    case '0':
+      return 0;
+    case 'value':
+    case 'v':
+    case '1':
+      return 1;
+    default:
+      return null;
+  }
+}
+
+/** Parse a Durak CLI command into API exec arguments (indices are 0-based). */
+export function parseDurakCommand(input: string): CliParseResult<DurakArgs> {
+  const { cmd, args } = splitCommand(input);
+
+  switch (cmd) {
+    case 'a':
+    case 'attack': {
+      const parsed = parseIntArg(args, 0);
+      if ('error' in parsed) return { error: 'Usage: a <cardIdx>' };
+      return { args: ['attack', parsed.value] as DurakArgs };
+    }
+    case 'd':
+    case 'defend': {
+      const card = parseIntArg(args, 0);
+      const pair = parseIntArg(args, 1);
+      if ('error' in card || 'error' in pair) return { error: 'Usage: d <cardIdx> <pairIdx>' };
+      return { args: ['defend', card.value, pair.value] as DurakArgs };
+    }
+    case 'p':
+    case 'pass':
+      return { args: ['pass'] as DurakArgs };
+    case 't':
+    case 'take':
+      return { args: ['take'] as DurakArgs };
+    case 'sort': {
+      const mode = parseSortMode(args[0]);
+      if (mode === null) return { error: 'Usage: sort <suit|value>' };
+      return { args: ['sort', undefined, undefined, undefined, mode] as DurakArgs };
+    }
+    case 'r':
+    case 'reset':
+      return { args: ['reset'] as DurakArgs };
+    default: {
+      const suggestion = suggestCommand(cmd, DURAK_COMMANDS);
+      if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
+      return { error: `Unknown command: ${cmd}` };
+    }
+  }
+}
+
+/** Help text for Durak CLI mode. */
+export const DURAK_HELP: string[] = [
+  'a <cardIdx>          - Attack with a hand card',
+  'd <cardIdx> <pairIdx>- Defend a table pair with a hand card',
+  'p/pass               - Pass (stop attacking)',
+  't/take               - Take the table cards (give up defending)',
+  'sort <suit|value>    - Sort your hand',
+  'r/reset              - Reset game',
+];

--- a/frontend/src/utils/cli/formatters/durakFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/durakFormatter.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import type { DurakPlayerData, DurakResponse } from '../../../types/card';
+import { formatDurakState } from './durakFormatter';
+
+const player = (over: Partial<DurakPlayerData> = {}): DurakPlayerData => ({
+  id: 0,
+  isHuman: true,
+  isFinished: false,
+  cardCount: 2,
+  cards: [
+    { design: 'SPADE', value: 5 },
+    { design: 'HEART', value: 13 },
+  ],
+  ...over,
+});
+
+const baseState: DurakResponse = {
+  message: '',
+  players: [player(), player({ id: 1, isHuman: false, cardCount: 3, cards: [] })],
+  currentTurn: 0,
+  phase: 1,
+  attackerIdx: 1,
+  defenderIdx: 0,
+  tablePairs: [],
+  trumpSuit: 'SPADE',
+  trumpCard: { design: 'SPADE', value: 6 },
+  stockCount: 12,
+  loserIdx: -1,
+  gameEndFlag: false,
+  config: { playerCount: 2, cpuDifficulty: 1, transferEnabled: false },
+  cpuActions: [],
+  humanAction: null,
+  boutNumber: 1,
+  sortMode: 0,
+};
+
+describe('formatDurakState', () => {
+  it('returns a loading placeholder for null state', () => {
+    expect(formatDurakState(null)).toBe('Loading...');
+  });
+
+  it('renders trump, stock, and roles', () => {
+    const out = formatDurakState(baseState);
+    expect(out).toContain('Durak');
+    expect(out).toContain('trump: ♠6');
+    expect(out).toContain('stock: 12');
+    expect(out).toContain('attacker:');
+    expect(out).toContain('defender:');
+  });
+
+  it('shows an empty table and the indexed human hand', () => {
+    const out = formatDurakState(baseState);
+    expect(out).toContain('table: (empty)');
+    expect(out).toContain('[0]♠5');
+    expect(out).toContain('[1]♥K');
+  });
+
+  it('renders table pairs with undefended and defended entries', () => {
+    const out = formatDurakState({
+      ...baseState,
+      tablePairs: [
+        { attack: { design: 'CLOVER', value: 7 }, defense: null },
+        { attack: { design: 'DIAMOND', value: 8 }, defense: { design: 'DIAMOND', value: 10 } },
+      ],
+    });
+    expect(out).toContain('[0] ♣7 -> (undefended)');
+    expect(out).toContain('[1] ♦8 -> ♦10');
+  });
+
+  it('shows opponent card counts and finished status', () => {
+    const out = formatDurakState({
+      ...baseState,
+      players: [player(), player({ id: 1, isHuman: false, cardCount: 0, isFinished: true, cards: [] })],
+    });
+    expect(out).toContain('0 cards (out)');
+  });
+
+  it('reports the loser when the game ends', () => {
+    const out = formatDurakState({ ...baseState, gameEndFlag: true, loserIdx: 0 });
+    expect(out).toContain('loser (durak):');
+  });
+
+  it('reports a draw when the game ends with no loser', () => {
+    const out = formatDurakState({ ...baseState, gameEndFlag: true, loserIdx: -1 });
+    expect(out).toContain('draw');
+  });
+
+  it('appends a server message when present', () => {
+    const out = formatDurakState({ ...baseState, message: 'Your turn to attack' });
+    expect(out).toContain('Your turn to attack');
+  });
+});

--- a/frontend/src/utils/cli/formatters/durakFormatter.ts
+++ b/frontend/src/utils/cli/formatters/durakFormatter.ts
@@ -1,0 +1,59 @@
+import type { DurakResponse } from '../../../types/card';
+import { formatCard, formatHeader, formatPlayerName, formatSeparator } from '../formatterBase';
+
+/** Format a Durak game state as terminal text. */
+export function formatDurakState(state: DurakResponse | null): string {
+  if (!state) return 'Loading...';
+  const lines: string[] = [];
+
+  lines.push(formatHeader('Durak'));
+
+  const trump = state.trumpCard ? formatCard(state.trumpCard) : state.trumpSuit || '?';
+  lines.push(`trump: ${trump} | stock: ${state.stockCount}`);
+
+  const nameOf = (idx: number): string => {
+    const p = state.players[idx];
+    return p ? formatPlayerName(p.id, p.isHuman) : `P${idx}`;
+  };
+  lines.push(`attacker: ${nameOf(state.attackerIdx)} | defender: ${nameOf(state.defenderIdx)}`);
+  lines.push('----------');
+
+  // Table pairs (attack -> defense), indexed for the `defend` command.
+  if (state.tablePairs.length === 0) {
+    lines.push('table: (empty)');
+  } else {
+    lines.push('table:');
+    state.tablePairs.forEach((pair, i) => {
+      const def = pair.defense ? formatCard(pair.defense) : '(undefended)';
+      lines.push(`  [${i}] ${formatCard(pair.attack)} -> ${def}`);
+    });
+  }
+  lines.push('----------');
+
+  // Opponents' card counts.
+  state.players
+    .filter((p) => !p.isHuman)
+    .forEach((p) => {
+      const done = p.isFinished ? ' (out)' : '';
+      lines.push(`${formatPlayerName(p.id, false)}: ${p.cardCount} cards${done}`);
+    });
+
+  // Human hand, indexed for the `attack`/`defend` commands.
+  const human = state.players.find((p) => p.isHuman);
+  if (human) {
+    lines.push('----------');
+    const hand = human.cards.map((c, i) => `[${i}]${formatCard(c)}`).join('  ');
+    lines.push(`your hand: ${hand || '(empty)'}`);
+  }
+
+  if (state.gameEndFlag) {
+    const loser = state.loserIdx >= 0 ? nameOf(state.loserIdx) : null;
+    lines.push('----------');
+    lines.push(loser ? `game over — loser (durak): ${loser}` : 'game over — draw');
+  }
+
+  if (state.message) lines.push(state.message);
+
+  lines.push(formatSeparator());
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
Replaces the placeholder ("CLI not supported") CLI-mode config on `DurakPage` with a working parser + formatter, so Durak can be played from the web terminal like the other games.

- `durakCommands.ts` — parses `a <cardIdx>` (attack), `d <cardIdx> <pairIdx>` (defend), `p`/`pass`, `t`/`take`, `sort <suit|value>`, `r`/`reset`; typo suggestions via `suggestCommand`.
- `durakFormatter.ts` — renders trump + stock, attacker/defender roles, indexed table pairs (`[i] ♣7 -> (undefended)`), opponent card counts, the indexed human hand, and end-of-game loser/draw.
- `DurakPage.tsx` — wires the real `parseDurakCommand`/`formatDurakState`/`DURAK_HELP` into the existing `CliToggle`/`CliTerminal`.

## Test plan
- [x] `bun run test -- --run durak` (55 tests across 4 files)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #3124