### PR TITLE
feat(contractrummy): add web CLI mode

### DIFF
--- a/frontend/src/pages/ContractRummyPage.tsx
+++ b/frontend/src/pages/ContractRummyPage.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useMemo, useState } from 'react';
 import { contractrummyApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
+import { CliTerminal } from '../components/cli/CliTerminal';
+import { CliToggle } from '../components/cli/CliToggle';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
@@ -10,6 +12,8 @@ import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
+import { useCliGame } from '../hooks/useCliGame';
+import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
@@ -20,6 +24,9 @@ import { gameTheme } from '../styles/gameTheme';
 import type { Card, ContractRummyContractSlot, ContractRummyResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { CONTRACTRUMMY_HELP, parseContractRummyCommand } from '../utils/cli/commands/contractrummyCommands';
+import { formatContractRummyState } from '../utils/cli/formatters/contractrummyFormatter';
+import type { CliGameConfig } from '../utils/cli/types';
 import { evaluateContractSlot } from '../utils/contractRummyUtils';
 
 /** Phase identifiers for Contract Rummy. */
@@ -82,6 +89,18 @@ function ContractRummyPageContent() {
 
   useMountReset(execApi);
   const phaseNames = usePhaseNames('contractrummy', CR_PHASE_KEYS);
+
+  const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('contractrummy');
+  const cliConfig: CliGameConfig<ContractRummyResponse, Parameters<typeof execApi>> = useMemo(
+    () => ({
+      gameName: 'contractrummy',
+      parseCommand: parseContractRummyCommand,
+      formatResponse: formatContractRummyState,
+      helpText: CONTRACTRUMMY_HELP,
+    }),
+    [],
+  );
+  const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
   // Selected card indices in the human's hand (multi-select).
   const [selectedCards, setSelectedCards] = useState<number[]>([]);
@@ -218,227 +237,253 @@ function ContractRummyPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      headerExtra={<CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />}
     >
-      {error && <ErrorAlert message={error} onRetry={retry} />}
+      {cliEnabled ? (
+        <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
+      ) : (
+        <>
+          {error && <ErrorAlert message={error} onRetry={retry} />}
 
-      <section className="px-4 py-2 flex flex-wrap gap-3 items-center text-white" data-tutorial="cr-contract">
-        <span className="font-semibold">{t('roundLabel', { round: state.roundNumber, total: state.totalRounds })}</span>
-        <span>
-          {t('contractLabel')}: {state.contractSlots.map((s) => formatSlot(s, t)).join(' + ')}
-        </span>
-        <span>
-          {t('stockLabel')}: {state.drawPileCount}
-        </span>
-        {state.discardTop && (
-          <span className="flex items-center gap-2">
-            {t('discardLabel')}:
-            <AnimatedCard card={state.discardTop} width={cardWidth} />
-          </span>
-        )}
-      </section>
+          <section className="px-4 py-2 flex flex-wrap gap-3 items-center text-white" data-tutorial="cr-contract">
+            <span className="font-semibold">
+              {t('roundLabel', { round: state.roundNumber, total: state.totalRounds })}
+            </span>
+            <span>
+              {t('contractLabel')}: {state.contractSlots.map((s) => formatSlot(s, t)).join(' + ')}
+            </span>
+            <span>
+              {t('stockLabel')}: {state.drawPileCount}
+            </span>
+            {state.discardTop && (
+              <span className="flex items-center gap-2">
+                {t('discardLabel')}:
+                <AnimatedCard card={state.discardTop} width={cardWidth} />
+              </span>
+            )}
+          </section>
 
-      {isPlayPhase && humanPlayer && !humanPlayer.contractMet && state.contractSlots.length > 0 && (
-        <section className="px-4 py-2 flex flex-wrap gap-2 text-sm" data-testid="cr-slot-progress">
-          {state.contractSlots.map((slot, slotIdx) => {
-            const ev = slotEvaluations[slotIdx] ?? { placed: 0, required: slot.size, satisfied: false, invalid: false };
-            const color = ev.satisfied
-              ? badgeSuccessColors
-              : ev.invalid
-                ? badgeErrorColors
-                : ev.placed === 0
-                  ? 'bg-black/20 border border-white/30 text-ds-text-muted'
-                  : badgeWarningColors;
-            return (
-              <span
-                key={`slot-${slotIdx}`}
-                className={`px-2 py-1 rounded ${color}`}
-                data-testid={`cr-slot-progress-${slotIdx}`}
-                data-state={ev.satisfied ? 'satisfied' : ev.invalid ? 'invalid' : ev.placed === 0 ? 'empty' : 'partial'}
+          {isPlayPhase && humanPlayer && !humanPlayer.contractMet && state.contractSlots.length > 0 && (
+            <section className="px-4 py-2 flex flex-wrap gap-2 text-sm" data-testid="cr-slot-progress">
+              {state.contractSlots.map((slot, slotIdx) => {
+                const ev = slotEvaluations[slotIdx] ?? {
+                  placed: 0,
+                  required: slot.size,
+                  satisfied: false,
+                  invalid: false,
+                };
+                const color = ev.satisfied
+                  ? badgeSuccessColors
+                  : ev.invalid
+                    ? badgeErrorColors
+                    : ev.placed === 0
+                      ? 'bg-black/20 border border-white/30 text-ds-text-muted'
+                      : badgeWarningColors;
+                return (
+                  <span
+                    key={`slot-${slotIdx}`}
+                    className={`px-2 py-1 rounded ${color}`}
+                    data-testid={`cr-slot-progress-${slotIdx}`}
+                    data-state={
+                      ev.satisfied ? 'satisfied' : ev.invalid ? 'invalid' : ev.placed === 0 ? 'empty' : 'partial'
+                    }
+                  >
+                    {formatSlot(slot, t)} ({ev.placed}/{ev.required}){ev.satisfied ? ' ✓' : ''}
+                  </span>
+                );
+              })}
+            </section>
+          )}
+
+          <section className="px-4 py-2 grid gap-2 md:grid-cols-3">
+            {state.players.map((p) => (
+              <div
+                key={p.id}
+                className={`p-3 rounded border ${
+                  state.currentPlayerIdx === p.id ? 'border-ds-warning' : 'border-white/30'
+                } text-white text-sm bg-black/20`}
               >
-                {formatSlot(slot, t)} ({ev.placed}/{ev.required}){ev.satisfied ? ' ✓' : ''}
-              </span>
-            );
-          })}
-        </section>
-      )}
+                <div className="flex justify-between font-semibold">
+                  <span>
+                    {p.isHuman ? tc('player.you') : tc('player.cpu', { id: p.id })}
+                    {p.contractMet ? ` ✓` : ''}
+                  </span>
+                  <span>
+                    {t('cards')}: {p.cardCount}
+                  </span>
+                </div>
+                <div className="text-xs opacity-75">
+                  {t('scoreLabel')}: {p.cumulativeScore} (+{p.roundScore})
+                </div>
+                {p.melds.length > 0 && (
+                  <div className="mt-2">
+                    {p.melds.map((m, mi) => {
+                      const isLayoffTarget = layoffTarget?.playerIdx === p.id && layoffTarget?.meldIdx === mi;
+                      const playerLabel = p.isHuman ? tc('player.you') : tc('player.cpu', { id: p.id });
+                      // The meld is only a selectable layoff target once both contracts are met.
+                      const canLayoff = humanPlayer?.contractMet === true && p.contractMet;
+                      return (
+                        <button
+                          type="button"
+                          key={`${p.id}-${mi}`}
+                          onClick={() => {
+                            if (canLayoff) {
+                              setLayoffTarget({ playerIdx: p.id, meldIdx: mi });
+                            }
+                          }}
+                          aria-label={t('meldAria', { player: playerLabel, meld: mi + 1 })}
+                          // Only expose the toggle semantics when the meld is actually actionable.
+                          aria-pressed={canLayoff ? isLayoffTarget : undefined}
+                          className={`flex flex-wrap gap-1 mb-1 px-1 rounded ${focusRingWhite} ${
+                            isLayoffTarget ? 'ring-2 ring-ds-warning bg-ds-warning/20' : ''
+                          }`}
+                        >
+                          {m.cards.map((c, ci) => (
+                            <AnimatedCard key={`${p.id}-${mi}-${ci}`} card={c} width={cardWidth * 0.6} />
+                          ))}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            ))}
+          </section>
 
-      <section className="px-4 py-2 grid gap-2 md:grid-cols-3">
-        {state.players.map((p) => (
-          <div
-            key={p.id}
-            className={`p-3 rounded border ${
-              state.currentPlayerIdx === p.id ? 'border-ds-warning' : 'border-white/30'
-            } text-white text-sm bg-black/20`}
-          >
-            <div className="flex justify-between font-semibold">
-              <span>
-                {p.isHuman ? tc('player.you') : tc('player.cpu', { id: p.id })}
-                {p.contractMet ? ` ✓` : ''}
-              </span>
-              <span>
-                {t('cards')}: {p.cardCount}
-              </span>
-            </div>
-            <div className="text-xs opacity-75">
-              {t('scoreLabel')}: {p.cumulativeScore} (+{p.roundScore})
-            </div>
-            {p.melds.length > 0 && (
-              <div className="mt-2">
-                {p.melds.map((m, mi) => {
-                  const isLayoffTarget = layoffTarget?.playerIdx === p.id && layoffTarget?.meldIdx === mi;
-                  const playerLabel = p.isHuman ? tc('player.you') : tc('player.cpu', { id: p.id });
-                  // The meld is only a selectable layoff target once both contracts are met.
-                  const canLayoff = humanPlayer?.contractMet === true && p.contractMet;
+          {humanPlayer && (
+            <section className="px-4 py-2" data-tutorial="cr-hand">
+              <div className="text-white text-sm mb-1">
+                {t('yourHand')} ({humanPlayer.cardCount})
+                {contractSlots.length > 0 && (
+                  <span className="ml-2 opacity-75">
+                    {t('slotsBuilt')}: {contractSlots.length}
+                  </span>
+                )}
+              </div>
+              <div className="flex flex-wrap gap-1">
+                {humanPlayer.cards.map((c: Card, idx: number) => {
+                  const isSelected = selectedCards.includes(idx);
+                  const isInSlot = contractSlots.some((slot) => slot.includes(idx));
                   return (
                     <button
                       type="button"
-                      key={`${p.id}-${mi}`}
-                      onClick={() => {
-                        if (canLayoff) {
-                          setLayoffTarget({ playerIdx: p.id, meldIdx: mi });
-                        }
-                      }}
-                      aria-label={t('meldAria', { player: playerLabel, meld: mi + 1 })}
-                      // Only expose the toggle semantics when the meld is actually actionable.
-                      aria-pressed={canLayoff ? isLayoffTarget : undefined}
-                      className={`flex flex-wrap gap-1 mb-1 px-1 rounded ${focusRingWhite} ${
-                        isLayoffTarget ? 'ring-2 ring-ds-warning bg-ds-warning/20' : ''
+                      key={`${idx}-${c.design}-${c.value}`}
+                      onClick={() => toggleCard(idx)}
+                      disabled={isInSlot}
+                      aria-pressed={isSelected}
+                      aria-label={isInSlot ? `${cardAlt(c)} (${t('cardInSlotAria')})` : cardAlt(c)}
+                      className={`${focusRingWhite} ${isSelected ? 'ring-2 ring-ds-warning' : ''} ${
+                        isInSlot ? 'opacity-40' : ''
                       }`}
                     >
-                      {m.cards.map((c, ci) => (
-                        <AnimatedCard key={`${p.id}-${mi}-${ci}`} card={c} width={cardWidth * 0.6} />
-                      ))}
+                      <AnimatedCard card={c} width={cardWidth} />
                     </button>
                   );
                 })}
               </div>
-            )}
-          </div>
-        ))}
-      </section>
+            </section>
+          )}
 
-      {humanPlayer && (
-        <section className="px-4 py-2" data-tutorial="cr-hand">
-          <div className="text-white text-sm mb-1">
-            {t('yourHand')} ({humanPlayer.cardCount})
-            {contractSlots.length > 0 && (
-              <span className="ml-2 opacity-75">
-                {t('slotsBuilt')}: {contractSlots.length}
-              </span>
+          <section className="px-4 py-2 flex flex-wrap gap-2" data-tutorial="cr-actions">
+            {isDrawPhase && (
+              <>
+                <button type="button" onClick={handleDrawStock} className={btnPrimary}>
+                  {t('drawStock')}
+                </button>
+                {state.discardTop && (
+                  <button type="button" onClick={handleDrawDiscard} className={btnPrimary}>
+                    {t('drawDiscard')}
+                  </button>
+                )}
+              </>
             )}
-          </div>
-          <div className="flex flex-wrap gap-1">
-            {humanPlayer.cards.map((c: Card, idx: number) => {
-              const isSelected = selectedCards.includes(idx);
-              const isInSlot = contractSlots.some((slot) => slot.includes(idx));
-              return (
+            {isPlayPhase && humanPlayer && !humanPlayer.contractMet && (
+              <>
                 <button
                   type="button"
-                  key={`${idx}-${c.design}-${c.value}`}
-                  onClick={() => toggleCard(idx)}
-                  disabled={isInSlot}
-                  aria-pressed={isSelected}
-                  aria-label={isInSlot ? `${cardAlt(c)} (${t('cardInSlotAria')})` : cardAlt(c)}
-                  className={`${focusRingWhite} ${isSelected ? 'ring-2 ring-ds-warning' : ''} ${
-                    isInSlot ? 'opacity-40' : ''
-                  }`}
+                  onClick={handleAddSlot}
+                  disabled={selectedCards.length === 0}
+                  className={btnOutline}
                 >
-                  <AnimatedCard card={c} width={cardWidth} />
+                  {t('addSlot')}
                 </button>
-              );
-            })}
-          </div>
-        </section>
-      )}
-
-      <section className="px-4 py-2 flex flex-wrap gap-2" data-tutorial="cr-actions">
-        {isDrawPhase && (
-          <>
-            <button type="button" onClick={handleDrawStock} className={btnPrimary}>
-              {t('drawStock')}
-            </button>
-            {state.discardTop && (
-              <button type="button" onClick={handleDrawDiscard} className={btnPrimary}>
-                {t('drawDiscard')}
+                <button
+                  type="button"
+                  onClick={handleRemoveLastSlot}
+                  disabled={contractSlots.length === 0}
+                  className={btnOutline}
+                >
+                  {t('removeLastSlot')}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSubmitContract}
+                  disabled={!allSlotsSatisfied}
+                  className={`${btnPrimary} ${allSlotsSatisfied ? 'motion-safe:animate-pulse' : ''}`}
+                  data-testid="cr-submit-contract"
+                >
+                  {t('submitContract')}
+                </button>
+              </>
+            )}
+            {isPlayPhase && humanPlayer?.contractMet && (
+              <>
+                <button
+                  type="button"
+                  onClick={handleMeldExtra}
+                  disabled={selectedCards.length < 3}
+                  className={btnOutline}
+                >
+                  {t('meldExtra')}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleLayoff}
+                  disabled={selectedCards.length !== 1 || !layoffTarget}
+                  className={btnOutline}
+                >
+                  {t('layoff')}
+                </button>
+              </>
+            )}
+            {isPlayPhase && (
+              <button type="button" onClick={handleDiscard} disabled={selectedCards.length !== 1} className={btnDanger}>
+                {t('discard')}
               </button>
             )}
-          </>
-        )}
-        {isPlayPhase && humanPlayer && !humanPlayer.contractMet && (
-          <>
-            <button type="button" onClick={handleAddSlot} disabled={selectedCards.length === 0} className={btnOutline}>
-              {t('addSlot')}
-            </button>
-            <button
-              type="button"
-              onClick={handleRemoveLastSlot}
-              disabled={contractSlots.length === 0}
-              className={btnOutline}
-            >
-              {t('removeLastSlot')}
-            </button>
-            <button
-              type="button"
-              onClick={handleSubmitContract}
-              disabled={!allSlotsSatisfied}
-              className={`${btnPrimary} ${allSlotsSatisfied ? 'motion-safe:animate-pulse' : ''}`}
-              data-testid="cr-submit-contract"
-            >
-              {t('submitContract')}
-            </button>
-          </>
-        )}
-        {isPlayPhase && humanPlayer?.contractMet && (
-          <>
-            <button type="button" onClick={handleMeldExtra} disabled={selectedCards.length < 3} className={btnOutline}>
-              {t('meldExtra')}
-            </button>
-            <button
-              type="button"
-              onClick={handleLayoff}
-              disabled={selectedCards.length !== 1 || !layoffTarget}
-              className={btnOutline}
-            >
-              {t('layoff')}
-            </button>
-          </>
-        )}
-        {isPlayPhase && (
-          <button type="button" onClick={handleDiscard} disabled={selectedCards.length !== 1} className={btnDanger}>
-            {t('discard')}
-          </button>
-        )}
-        {isRoundEnd && (
-          <button type="button" onClick={handleNextRound} className={btnPrimary}>
-            {t('nextRound')}
-          </button>
-        )}
-      </section>
+            {isRoundEnd && (
+              <button type="button" onClick={handleNextRound} className={btnPrimary}>
+                {t('nextRound')}
+              </button>
+            )}
+          </section>
 
-      <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
+          <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
 
-      <ActionLogSection
-        isEndPhase={state.gameEndFlag || isRoundEnd}
-        actionLog={actionLog}
-        showActionLog={showActionLog}
-        hideActionLog={hideActionLog}
-      />
-
-      <GameFooter className={`${gameTheme.contractrummy.footer} px-4 py-2.5`}>
-        <div className="flex gap-2 items-center flex-wrap">
-          <GameResetButton
-            isGameEnd={state.gameEndFlag}
-            onReset={handleReset}
-            requestConfirm={requestConfirm}
-            loading={loading}
+          <ActionLogSection
+            isEndPhase={state.gameEndFlag || isRoundEnd}
+            actionLog={actionLog}
+            showActionLog={showActionLog}
+            hideActionLog={hideActionLog}
           />
-          {layoffTarget && layoffTargetLabel && (
-            <span data-testid="cr-layoff-target" className="text-xs text-ds-warning font-medium">
-              {t('layoffTargetSummary', { player: layoffTargetLabel, meld: layoffTarget.meldIdx + 1 })}
-            </span>
-          )}
-        </div>
-      </GameFooter>
+
+          <GameFooter className={`${gameTheme.contractrummy.footer} px-4 py-2.5`}>
+            <div className="flex gap-2 items-center flex-wrap">
+              <GameResetButton
+                isGameEnd={state.gameEndFlag}
+                onReset={handleReset}
+                requestConfirm={requestConfirm}
+                loading={loading}
+              />
+              {layoffTarget && layoffTargetLabel && (
+                <span data-testid="cr-layoff-target" className="text-xs text-ds-warning font-medium">
+                  {t('layoffTargetSummary', { player: layoffTargetLabel, meld: layoffTarget.meldIdx + 1 })}
+                </span>
+              )}
+            </div>
+          </GameFooter>
+        </>
+      )}
     </GamePageShell>
   );
 }

--- a/frontend/src/utils/cli/commands/contractrummyCommands.test.ts
+++ b/frontend/src/utils/cli/commands/contractrummyCommands.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { parseContractRummyCommand } from './contractrummyCommands';
+
+describe('parseContractRummyCommand', () => {
+  it('parses draw commands', () => {
+    expect(parseContractRummyCommand('ds')).toEqual({ args: ['drawstock'] });
+    expect(parseContractRummyCommand('drawstock')).toEqual({ args: ['drawstock'] });
+    expect(parseContractRummyCommand('dd')).toEqual({ args: ['drawdiscard'] });
+    expect(parseContractRummyCommand('drawdiscard')).toEqual({ args: ['drawdiscard'] });
+  });
+
+  it('parses discard with a single index', () => {
+    expect(parseContractRummyCommand('discard 3')).toEqual({ args: ['discard', { cardIndex: 3 }] });
+    expect(parseContractRummyCommand('x 0')).toEqual({ args: ['discard', { cardIndex: 0 }] });
+  });
+
+  it('errors on discard without exactly one index', () => {
+    expect('error' in parseContractRummyCommand('discard')).toBe(true);
+    expect('error' in parseContractRummyCommand('discard 1 2')).toBe(true);
+    expect('error' in parseContractRummyCommand('discard x')).toBe(true);
+  });
+
+  it('parses a multi-slot contract meld', () => {
+    expect(parseContractRummyCommand('meld 0,1,2 / 3,4,5')).toEqual({
+      args: [
+        'meldcontract',
+        {
+          indicesPerSlot: [
+            [0, 1, 2],
+            [3, 4, 5],
+          ],
+        },
+      ],
+    });
+  });
+
+  it('accepts space-separated indices within a meld slot', () => {
+    expect(parseContractRummyCommand('meld 0 1 2')).toEqual({
+      args: ['meldcontract', { indicesPerSlot: [[0, 1, 2]] }],
+    });
+  });
+
+  it('errors on an empty or invalid meld', () => {
+    expect('error' in parseContractRummyCommand('meld')).toBe(true);
+    expect('error' in parseContractRummyCommand('meld a,b')).toBe(true);
+  });
+
+  it('parses an extra meld with at least three cards', () => {
+    expect(parseContractRummyCommand('extra 1,2,3')).toEqual({
+      args: ['meldextra', { cardIndices: [1, 2, 3] }],
+    });
+  });
+
+  it('errors on an extra meld with fewer than three cards', () => {
+    expect('error' in parseContractRummyCommand('extra 1,2')).toBe(true);
+  });
+
+  it('parses layoff with card, player, and meld indices', () => {
+    expect(parseContractRummyCommand('layoff 2 1 0')).toEqual({
+      args: ['layoff', { cardIndex: 2, targetPlayerIdx: 1, meldIdx: 0 }],
+    });
+    expect(parseContractRummyCommand('lo 0 0 0')).toEqual({
+      args: ['layoff', { cardIndex: 0, targetPlayerIdx: 0, meldIdx: 0 }],
+    });
+  });
+
+  it('errors on layoff without three indices', () => {
+    expect('error' in parseContractRummyCommand('layoff 1 2')).toBe(true);
+  });
+
+  it('parses nextround, log, and reset', () => {
+    expect(parseContractRummyCommand('nr')).toEqual({ args: ['nextround'] });
+    expect(parseContractRummyCommand('nextround')).toEqual({ args: ['nextround'] });
+    expect(parseContractRummyCommand('log')).toEqual({ args: ['log'] });
+    expect(parseContractRummyCommand('l')).toEqual({ args: ['log'] });
+    expect(parseContractRummyCommand('reset')).toEqual({ args: ['reset'] });
+    expect(parseContractRummyCommand('r')).toEqual({ args: ['reset'] });
+  });
+
+  it('suggests a command for a close typo', () => {
+    const result = parseContractRummyCommand('discrd 1');
+    expect('error' in result).toBe(true);
+    if ('error' in result) expect(result.error).toContain('discard');
+  });
+
+  it('errors on an unknown command', () => {
+    expect('error' in parseContractRummyCommand('zzz')).toBe(true);
+  });
+});

--- a/frontend/src/utils/cli/commands/contractrummyCommands.ts
+++ b/frontend/src/utils/cli/commands/contractrummyCommands.ts
@@ -1,0 +1,118 @@
+import type { contractrummyApi } from '../../../api/gameApi';
+import { splitCommand, suggestCommand } from '../commandParserBase';
+import type { CliParseResult } from '../types';
+
+type ContractRummyArgs = Parameters<typeof contractrummyApi.exec>;
+
+const CR_COMMANDS = [
+  'ds',
+  'drawstock',
+  'dd',
+  'drawdiscard',
+  'x',
+  'discard',
+  'meld',
+  'extra',
+  'lo',
+  'layoff',
+  'nr',
+  'nextround',
+  'log',
+  'l',
+  'r',
+  'reset',
+  'help',
+  '?',
+];
+
+/**
+ * Parse a whitespace/comma-separated list of 0-based indices.
+ * Returns null if the list is empty or any token is not a non-negative integer.
+ */
+function parseIdxList(s: string): number[] | null {
+  const parts = s.split(/[\s,]+/).filter((p) => p.length > 0);
+  if (parts.length === 0) return null;
+  const out: number[] = [];
+  for (const p of parts) {
+    const n = Number(p);
+    if (!Number.isInteger(n) || n < 0) return null;
+    out.push(n);
+  }
+  return out;
+}
+
+/** Parse a Contract Rummy CLI command into API exec arguments (indices are 0-based). */
+export function parseContractRummyCommand(input: string): CliParseResult<ContractRummyArgs> {
+  const { cmd, args } = splitCommand(input);
+
+  switch (cmd) {
+    case 'ds':
+    case 'drawstock':
+      return { args: ['drawstock'] as ContractRummyArgs };
+    case 'dd':
+    case 'drawdiscard':
+      return { args: ['drawdiscard'] as ContractRummyArgs };
+    case 'x':
+    case 'discard': {
+      const list = parseIdxList(args.join(' '));
+      if (!list || list.length !== 1) return { error: 'Usage: discard <cardIdx>' };
+      return { args: ['discard', { cardIndex: list[0] }] as ContractRummyArgs };
+    }
+    case 'meld': {
+      // Slots are separated by '/', cards within a slot by spaces/commas.
+      const slotStrs = args
+        .join(' ')
+        .split('/')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+      if (slotStrs.length === 0) return { error: 'Usage: meld <i,j,k> / <i,j,k> ...' };
+      const indicesPerSlot: number[][] = [];
+      for (const s of slotStrs) {
+        const list = parseIdxList(s);
+        if (!list) return { error: 'Usage: meld <i,j,k> / <i,j,k> ...' };
+        indicesPerSlot.push(list);
+      }
+      return { args: ['meldcontract', { indicesPerSlot }] as ContractRummyArgs };
+    }
+    case 'extra': {
+      const list = parseIdxList(args.join(' '));
+      if (!list || list.length < 3) return { error: 'Usage: extra <i,j,k> (min 3 cards)' };
+      return { args: ['meldextra', { cardIndices: list }] as ContractRummyArgs };
+    }
+    case 'lo':
+    case 'layoff': {
+      const list = parseIdxList(args.join(' '));
+      if (!list || list.length !== 3) return { error: 'Usage: layoff <cardIdx> <playerIdx> <meldIdx>' };
+      return {
+        args: ['layoff', { cardIndex: list[0], targetPlayerIdx: list[1], meldIdx: list[2] }] as ContractRummyArgs,
+      };
+    }
+    case 'nr':
+    case 'nextround':
+      return { args: ['nextround'] as ContractRummyArgs };
+    case 'log':
+    case 'l':
+      return { args: ['log'] as ContractRummyArgs };
+    case 'r':
+    case 'reset':
+      return { args: ['reset'] as ContractRummyArgs };
+    default: {
+      const suggestion = suggestCommand(cmd, CR_COMMANDS);
+      if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
+      return { error: `Unknown command: ${cmd}` };
+    }
+  }
+}
+
+/** Help text for Contract Rummy CLI mode. */
+export const CONTRACTRUMMY_HELP: string[] = [
+  'ds/drawstock          - Draw from the stock pile',
+  'dd/drawdiscard        - Draw the discard top',
+  'meld <i,j> / <i,j,k>  - Lay down the round contract (slots split by /)',
+  'extra <i,j,k>         - Meld an extra set/run (min 3 cards)',
+  'lo/layoff <c> <p> <m> - Lay off card c onto player p meld m',
+  'x/discard <cardIdx>   - Discard a card',
+  'nr/nextround          - Advance to the next round',
+  'log                   - Show the action log',
+  'r/reset               - Reset game',
+];

--- a/frontend/src/utils/cli/formatters/contractrummyFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/contractrummyFormatter.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import type { ContractRummyPlayer, ContractRummyResponse } from '../../../types/card';
+import { formatContractRummyState } from './contractrummyFormatter';
+
+const player = (over: Partial<ContractRummyPlayer> = {}): ContractRummyPlayer => ({
+  id: 0,
+  isHuman: true,
+  cardCount: 2,
+  cards: [
+    { design: 'SPADE', value: 5 },
+    { design: 'HEART', value: 13 },
+  ],
+  melds: [],
+  contractMet: false,
+  roundScore: 0,
+  cumulativeScore: 0,
+  ...over,
+});
+
+const baseState: ContractRummyResponse = {
+  message: '',
+  players: [player(), player({ id: 1, isHuman: false, cardCount: 4, cards: [] })],
+  phase: 1,
+  roundNumber: 1,
+  totalRounds: 7,
+  currentPlayerIdx: 0,
+  discardTop: { design: 'CLOVER', value: 7 },
+  drawPileCount: 30,
+  gameEndFlag: false,
+  winnerIdx: -1,
+  roundWinnerIdx: -1,
+  contractSlots: [
+    { kind: 0, size: 3 },
+    { kind: 0, size: 3 },
+  ],
+  config: { cpuDifficulty: 1, failContractPenalty: 25 },
+};
+
+describe('formatContractRummyState', () => {
+  it('returns a loading placeholder for null state', () => {
+    expect(formatContractRummyState(null)).toBe('Loading...');
+  });
+
+  it('renders round, phase, contract, stock, and discard', () => {
+    const out = formatContractRummyState(baseState);
+    expect(out).toContain('Contract Rummy');
+    expect(out).toContain('round 1/7');
+    expect(out).toContain('phase: PLAY');
+    expect(out).toContain('contract: set(3) + set(3)');
+    expect(out).toContain('stock: 30');
+    expect(out).toContain('discard: ♣7');
+  });
+
+  it('shows an em dash when the discard pile is empty', () => {
+    const out = formatContractRummyState({ ...baseState, discardTop: null });
+    expect(out).toContain('discard: —');
+  });
+
+  it('marks the current player and renders melds', () => {
+    const out = formatContractRummyState({
+      ...baseState,
+      players: [
+        player({
+          contractMet: true,
+          melds: [
+            {
+              cards: [
+                { design: 'SPADE', value: 3 },
+                { design: 'HEART', value: 3 },
+                { design: 'DIAMOND', value: 3 },
+              ],
+            },
+          ],
+        }),
+        player({ id: 1, isHuman: false, cardCount: 4, cards: [] }),
+      ],
+    });
+    expect(out).toContain('>');
+    expect(out).toContain('[contract met]');
+    expect(out).toContain('M0: ♠3 ♥3 ♦3');
+  });
+
+  it('renders the indexed human hand', () => {
+    const out = formatContractRummyState(baseState);
+    expect(out).toContain('[0]♠5');
+    expect(out).toContain('[1]♥K');
+  });
+
+  it('announces the game winner', () => {
+    const out = formatContractRummyState({ ...baseState, gameEndFlag: true, winnerIdx: 0 });
+    expect(out).toContain('winner:');
+  });
+
+  it('announces the round winner at round end', () => {
+    const out = formatContractRummyState({ ...baseState, phase: 2, roundWinnerIdx: 1 });
+    expect(out).toContain('round winner:');
+  });
+
+  it('appends a server message when present', () => {
+    const out = formatContractRummyState({ ...baseState, message: 'Draw a card' });
+    expect(out).toContain('Draw a card');
+  });
+});

--- a/frontend/src/utils/cli/formatters/contractrummyFormatter.ts
+++ b/frontend/src/utils/cli/formatters/contractrummyFormatter.ts
@@ -1,0 +1,57 @@
+import type { ContractRummyContractSlot, ContractRummyResponse } from '../../../types/card';
+import { formatCard, formatHeader, formatPlayerName, formatSeparator } from '../formatterBase';
+
+const PHASE_NAMES: Record<number, string> = { 0: 'DRAW', 1: 'PLAY', 2: 'ROUND END', 3: 'GAME END' };
+
+/** Describe a contract slot as e.g. "set(3)" or "run(4)". */
+function formatSlot(slot: ContractRummyContractSlot): string {
+  return `${slot.kind === 0 ? 'set' : 'run'}(${slot.size})`;
+}
+
+/** Format a Contract Rummy game state as terminal text. */
+export function formatContractRummyState(state: ContractRummyResponse | null): string {
+  if (!state) return 'Loading...';
+  const lines: string[] = [];
+
+  lines.push(formatHeader('Contract Rummy'));
+  lines.push(`round ${state.roundNumber}/${state.totalRounds} | phase: ${PHASE_NAMES[state.phase] ?? state.phase}`);
+  lines.push(`contract: ${state.contractSlots.map(formatSlot).join(' + ')}`);
+  const discard = state.discardTop ? formatCard(state.discardTop) : '—';
+  lines.push(`stock: ${state.drawPileCount} | discard: ${discard}`);
+  lines.push('----------');
+
+  state.players.forEach((p) => {
+    const marker = p.id === state.currentPlayerIdx && !state.gameEndFlag ? '>' : ' ';
+    const met = p.contractMet ? ' [contract met]' : '';
+    lines.push(
+      `${marker}${formatPlayerName(p.id, p.isHuman)}: ${p.cardCount} cards | score ${p.cumulativeScore}${met}`,
+    );
+    p.melds.forEach((meld, mi) => {
+      lines.push(`    M${mi}: ${meld.cards.map(formatCard).join(' ')}`);
+    });
+  });
+  lines.push('----------');
+
+  const human = state.players.find((p) => p.isHuman);
+  if (human) {
+    const hand = human.cards.map((c, i) => `[${i}]${formatCard(c)}`).join('  ');
+    lines.push(`your hand: ${hand || '(empty)'}`);
+  }
+
+  if (state.gameEndFlag && state.winnerIdx >= 0) {
+    lines.push('----------');
+    lines.push(
+      `game over — winner: ${formatPlayerName(state.winnerIdx, state.players[state.winnerIdx]?.isHuman ?? false)}`,
+    );
+  } else if (state.phase === 2 && state.roundWinnerIdx >= 0) {
+    lines.push('----------');
+    lines.push(
+      `round winner: ${formatPlayerName(state.roundWinnerIdx, state.players[state.roundWinnerIdx]?.isHuman ?? false)}`,
+    );
+  }
+
+  if (state.message) lines.push(state.message);
+
+  lines.push(formatSeparator());
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
Adds a working web CLI mode to Contract Rummy (the page previously had no CLI toggle). Wires `CliToggle`/`CliTerminal` into the existing `GamePageShell` and adds a dedicated command parser + state formatter.

- `contractrummyCommands.ts` — parses `ds`/`dd` (draw), `x <idx>` (discard), `meld <i,j> / <i,j,k>` (contract, slots split by `/`, cards by space/comma), `extra <i,j,k>` (extra meld), `lo <card> <player> <meld>` (layoff), `nr` (next round), `log`, `r` (reset); typo suggestions via `suggestCommand`.
- `contractrummyFormatter.ts` — renders round/phase, the round contract (`set(3) + set(3)`), stock + discard top, per-player card counts / scores / melds with a current-player marker, the indexed human hand, and round/game winners.
- `ContractRummyPage.tsx` — `useCliMode`/`useCliGame` hooks, `headerExtra={<CliToggle/>}`, and the `cliEnabled ? <CliTerminal/> : <board/>` branch.

## Test plan
- [x] `bun run test -- --run contractrummy` (57 tests across 5 files)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #3252