### PR TITLE
fix(chinesepoker): implement the CLI formatResponse

### DIFF
--- a/frontend/src/pages/ChinesePokerPage.tsx
+++ b/frontend/src/pages/ChinesePokerPage.tsx
@@ -31,6 +31,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { chinesePokerIsFoul } from '../utils/chinesePokerFoul';
 import { CHINESEPOKER_HELP, parseChinesepokerCommand } from '../utils/cli/commands/chinesepokerCommands';
+import { formatChinesePokerState } from '../utils/cli/formatters/chinesepokerFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 
 const FRONT_RANK_KEYS: Record<number, string> = {
@@ -100,7 +101,7 @@ function ChinesePokerPageContent() {
     () => ({
       gameName: 'chinesepoker',
       parseCommand: parseChinesepokerCommand,
-      formatResponse: () => '',
+      formatResponse: formatChinesePokerState,
       helpText: CHINESEPOKER_HELP,
     }),
     [],

--- a/frontend/src/utils/cli/formatters/chinesepokerFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/chinesepokerFormatter.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, ChinesePokerResponse } from '../../../types/card';
+import { formatChinesePokerState } from './chinesepokerFormatter';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+const baseState: ChinesePokerResponse = {
+  message: '',
+  playerCards: [card('SPADE', 2), card('HEART', 5), card('DIAMOND', 9)],
+  dealerCards: [],
+  playerFront: [],
+  playerMiddle: [],
+  playerBack: [],
+  dealerFront: [],
+  dealerMiddle: [],
+  dealerBack: [],
+  phase: 1,
+  chips: 1000,
+  bet: 0,
+  result: 0,
+  frontResult: 0,
+  middleResult: 0,
+  backResult: 0,
+  payout: 0,
+  playerFrontRank: 0,
+  playerMiddleRank: 0,
+  playerBackRank: 0,
+  dealerFrontRank: 0,
+  dealerMiddleRank: 0,
+  dealerBackRank: 0,
+  playerRoyalty: 0,
+  dealerRoyalty: 0,
+  scoop: false,
+};
+
+describe('formatChinesePokerState', () => {
+  it('returns a loading placeholder for null state', () => {
+    expect(formatChinesePokerState(null)).toBe('Loading...');
+  });
+
+  it('prompts for a bet in the BET phase', () => {
+    const out = formatChinesePokerState(baseState);
+    expect(out).toContain('Chinese Poker');
+    expect(out).toContain('chips: 1000');
+    expect(out).toContain('phase: BET');
+    expect(out).toContain('Place a bet');
+  });
+
+  it('shows the indexed hand in the SET HANDS phase', () => {
+    const out = formatChinesePokerState({ ...baseState, phase: 2, bet: 50 });
+    expect(out).toContain('phase: SET HANDS');
+    expect(out).toContain('[0]♠2');
+    expect(out).toContain('[2]♦9');
+    expect(out).toContain('Set with:');
+  });
+
+  it('renders both hands and per-row results at END', () => {
+    const out = formatChinesePokerState({
+      ...baseState,
+      phase: 3,
+      bet: 50,
+      playerFront: [card('SPADE', 2), card('SPADE', 3), card('SPADE', 4)],
+      playerMiddle: [card('HEART', 5)],
+      playerBack: [card('CLOVER', 10)],
+      dealerFront: [card('DIAMOND', 6)],
+      frontResult: 1,
+      middleResult: -1,
+      backResult: 0,
+      payout: 100,
+    });
+    expect(out).toContain('phase: END');
+    expect(out).toContain('front:  ♠2, ♠3, ♠4  [WIN]');
+    expect(out).toContain('[LOSE]');
+    expect(out).toContain('[PUSH]');
+    expect(out).toContain('dealer front:  ♦6');
+    expect(out).toContain('payout: 100');
+  });
+
+  it('announces a scoop and royalty bonus at END', () => {
+    const out = formatChinesePokerState({
+      ...baseState,
+      phase: 3,
+      scoop: true,
+      playerRoyalty: 6,
+    });
+    expect(out).toContain('SCOOP!');
+    expect(out).toContain('royalty bonus: +6');
+  });
+
+  it('appends a server message when present', () => {
+    const out = formatChinesePokerState({ ...baseState, message: 'Arrange your hand' });
+    expect(out).toContain('Arrange your hand');
+  });
+});

--- a/frontend/src/utils/cli/formatters/chinesepokerFormatter.ts
+++ b/frontend/src/utils/cli/formatters/chinesepokerFormatter.ts
@@ -1,0 +1,52 @@
+import type { ChinesePokerResponse } from '../../../types/card';
+import { ChinesePokerPhase } from '../../../types/phases';
+import { formatCardList, formatHeader, formatIndexedCards, formatSeparator } from '../formatterBase';
+
+const PHASE_NAMES: Record<number, string> = {
+  [ChinesePokerPhase.BET]: 'BET',
+  [ChinesePokerPhase.SET_HANDS]: 'SET HANDS',
+  [ChinesePokerPhase.END]: 'END',
+};
+
+/** Describe a single row's showdown result (from the player's perspective). */
+function rowResult(res: number): string {
+  if (res > 0) return 'WIN';
+  if (res < 0) return 'LOSE';
+  return 'PUSH';
+}
+
+/** Format a Chinese Poker game state as terminal text. */
+export function formatChinesePokerState(state: ChinesePokerResponse | null): string {
+  if (!state) return 'Loading...';
+  const lines: string[] = [];
+
+  lines.push(formatHeader('Chinese Poker'));
+  lines.push(`chips: ${state.chips} | bet: ${state.bet} | phase: ${PHASE_NAMES[state.phase] ?? state.phase}`);
+  lines.push('----------');
+
+  if (state.phase === ChinesePokerPhase.SET_HANDS) {
+    // Show the 13-card hand with indices so the player can build `set` arguments.
+    lines.push('your cards:');
+    lines.push(`  ${formatIndexedCards(state.playerCards)}`);
+    lines.push('Set with: s <f0 f1 f2 m0 m1 m2 m3 m4> (back = the remaining 5)');
+  } else if (state.phase === ChinesePokerPhase.END) {
+    lines.push(`you    front:  ${formatCardList(state.playerFront) || '-'}  [${rowResult(state.frontResult)}]`);
+    lines.push(`       middle: ${formatCardList(state.playerMiddle) || '-'}  [${rowResult(state.middleResult)}]`);
+    lines.push(`       back:   ${formatCardList(state.playerBack) || '-'}  [${rowResult(state.backResult)}]`);
+    lines.push('----------');
+    lines.push(`dealer front:  ${formatCardList(state.dealerFront) || '-'}`);
+    lines.push(`       middle: ${formatCardList(state.dealerMiddle) || '-'}`);
+    lines.push(`       back:   ${formatCardList(state.dealerBack) || '-'}`);
+    lines.push('----------');
+    if (state.scoop) lines.push('SCOOP! (won all three rows)');
+    if (state.playerRoyalty > 0) lines.push(`royalty bonus: +${state.playerRoyalty}`);
+    lines.push(`payout: ${state.payout}`);
+  } else {
+    lines.push('Place a bet: b <amount>');
+  }
+
+  if (state.message) lines.push(state.message);
+
+  lines.push(formatSeparator());
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
Chinese Poker's CLI mode had a working command parser but `formatResponse: () => ''`, so the terminal rendered nothing after every command. This adds a real `formatChinesePokerState` formatter (mirroring the sibling `openfacechineseFormatter`) and wires it into the page.

- `chinesepokerFormatter.ts` — renders chips/bet/phase; in **SET HANDS** shows the 13-card hand with indices plus the `s <f0..m4>` usage hint; at **END** shows the player's and dealer's front/middle/back rows with per-row WIN/LOSE/PUSH results, scoop, royalty bonus, and payout; otherwise prompts for a bet.
- `ChinesePokerPage.tsx` — replaces the empty `formatResponse` stub with `formatChinesePokerState`.

## Test plan
- [x] `bun run test -- --run chinesepoker` (51 tests across 4 files)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #3332