### PR TITLE
feat(fourcardpoker): add web CLI mode

### DIFF
--- a/frontend/src/pages/FourCardPokerPage.tsx
+++ b/frontend/src/pages/FourCardPokerPage.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react';
 import { fourcardpokerApi } from '../api/gameApi';
 import { ActionLogPanel } from '../components/ActionLogPanel';
+import { CliTerminal } from '../components/cli/CliTerminal';
+import { CliToggle } from '../components/cli/CliToggle';
 import { ChipBetInput } from '../components/common/ChipBetInput';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
@@ -13,6 +15,8 @@ import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
 import { useCardDimensions } from '../hooks/useCardDimensions';
+import { useCliGame } from '../hooks/useCliGame';
+import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useMountReset } from '../hooks/useMountReset';
@@ -20,8 +24,12 @@ import { useSound } from '../providers/SoundProvider';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
+import type { FourCardPokerResponse } from '../types/card';
 import { FourCardPokerPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { FOURCARDPOKER_HELP, parseFourCardPokerCommand } from '../utils/cli/commands/fourcardpokerCommands';
+import { formatFourCardPokerState } from '../utils/cli/formatters/fourcardpokerFormatter';
+import type { CliGameConfig } from '../utils/cli/types';
 
 /** Four Card Poker tutorial step definitions. */
 const FCP_TUTORIAL_STEPS: TutorialStep[] = [
@@ -71,6 +79,18 @@ function FourCardPokerPageContent() {
   const { cardWidth } = useCardDimensions();
   const { playSound } = useSound();
   const { state, loading, error, exec: execApi, retry } = useGameApi(fourcardpokerApi.exec);
+
+  const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('fourcardpoker');
+  const cliConfig: CliGameConfig<FourCardPokerResponse, Parameters<typeof execApi>> = useMemo(
+    () => ({
+      gameName: 'fourcardpoker',
+      parseCommand: parseFourCardPokerCommand,
+      formatResponse: formatFourCardPokerState,
+      helpText: FOURCARDPOKER_HELP,
+    }),
+    [],
+  );
+  const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
   useMountReset(execApi);
 
@@ -139,204 +159,217 @@ function FourCardPokerPageContent() {
       confirmReset={confirmReset}
       cancelReset={cancelReset}
       headerExtra={
-        <span>
-          {t('label.chips')}: {state.chips}
-        </span>
+        <div className="flex items-center gap-3">
+          <span>
+            {t('label.chips')}: {state.chips}
+          </span>
+          <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
+        </div>
       }
     >
-      <div
-        data-testid="card-area"
-        className={[`overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`, !isBetPhase && 'flex-1']
-          .filter(Boolean)
-          .join(' ')}
-      >
-        <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
-
-        {/* Payout table during bet phase */}
-        {isBetPhase && (
-          <div className="flex flex-col items-center justify-center py-4 gap-4">
-            <p className="text-ds-text-muted text-lg">{t('betGuide')}</p>
-            <details className="bg-black/30 rounded-lg w-full max-w-sm">
-              <summary className="cursor-pointer select-none px-4 py-2 text-ds-text-primary font-bold text-sm">
-                {t('payoutRef.title')}
-              </summary>
-              <div className="px-4 pb-3 text-ds-text-muted text-sm space-y-2">
-                <div>
-                  <div className="font-bold text-ds-text-primary mb-1">{t('payoutRef.anteBonusHeader')}</div>
-                  <ul className="space-y-0.5">
-                    {(['anteBonusThreeOfAKind', 'anteBonusStraightFlush', 'anteBonusFourOfAKind'] as const).map(
-                      (key) => (
-                        <li key={key}>{t(`payoutRef.${key}`)}</li>
-                      ),
-                    )}
-                  </ul>
-                </div>
-                <div>
-                  <div className="font-bold text-ds-text-primary mb-1">{t('payoutRef.acesUpHeader')}</div>
-                  <ul className="space-y-0.5">
-                    {(
-                      [
-                        'acesUpPairOfAces',
-                        'acesUpTwoPair',
-                        'acesUpStraight',
-                        'acesUpFlush',
-                        'acesUpThreeOfAKind',
-                        'acesUpStraightFlush',
-                        'acesUpFourOfAKind',
-                      ] as const
-                    ).map((key) => (
-                      <li key={key}>{t(`payoutRef.${key}`)}</li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-            </details>
-          </div>
-        )}
-
-        {/* Player Hand */}
-        {state.playerHand.length > 0 && (
-          <div className="mb-4" data-tutorial="fcp-results">
-            <div className="text-ds-warning font-bold text-center mb-1">
-              <span aria-hidden="true">🟡</span> {t('player')}
-              {isEndPhase && state.playerHandRank > 0 && (
-                <span className="ml-2 text-sm">({t(HAND_RANK_KEYS[state.playerHandRank])})</span>
-              )}
-            </div>
-            <div className="flex justify-center gap-2">
-              {state.playerHand.map((card, i) => (
-                <AnimatedCard key={`p-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* Dealer Hand */}
-        {state.dealerHand.length > 0 && (
-          <div className="mb-4">
-            <div className="text-ds-error font-bold text-center mb-1">
-              <span aria-hidden="true">🔴</span> {t('dealer')}
-              {isActionPhase && <span className="ml-2 text-xs">({t('dealerUpcard')})</span>}
-              {isEndPhase && state.dealerHandRank > 0 && (
-                <span className="ml-2 text-sm">({t(HAND_RANK_KEYS[state.dealerHandRank])})</span>
-              )}
-            </div>
-            <div className="flex justify-center gap-2">
-              {state.dealerHand.map((card, i) => (
-                <AnimatedCard key={`d-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* Payout breakdown */}
-        {isEndPhase && (
-          <div className="text-ds-text-primary text-center text-sm mb-2" data-testid="payout-breakdown">
-            {state.antePayout !== 0 && (
-              <div>
-                {t('payout.ante')}: {state.antePayout}
-              </div>
-            )}
-            {state.playPayout !== 0 && (
-              <div>
-                {t('payout.play')}: {state.playPayout}
-              </div>
-            )}
-            {state.anteBonusPayout !== 0 && (
-              <div>
-                {t('payout.anteBonus')}: {state.anteBonusPayout}
-              </div>
-            )}
-            {state.acesUpPayout !== 0 && (
-              <div>
-                {t('payout.acesUp')}: {state.acesUpPayout}
-              </div>
-            )}
-            <div className="font-bold mt-1">
-              {t('payout.total')}: {state.totalPayout}
-            </div>
-          </div>
-        )}
-
-        {actionLog && <ActionLogPanel entries={actionLog} onClose={hideActionLog} />}
-      </div>
-
-      <GameFooter className={`${gameTheme.fourcardpoker.footer} px-4 pt-3`}>
-        <ErrorAlert message={error} onRetry={retry} />
-        <SettingsPanel title={t('settings.title')} groups={[]} />
-        {isBetPhase && (
-          <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="fcp-bet-controls">
-            <ChipBetInput
-              id="fcp-ante-amount"
-              label={t('label.ante')}
-              value={anteAmount}
-              onChange={setAnteAmount}
-              min={10}
-              max={state.chips}
-              step={10}
-              disabled={loading}
-              showSteppers
-              invalid={anteInvalid || betInvalid}
-              describedBy={betInvalid ? 'fcp-bet-error' : undefined}
+      {cliEnabled ? (
+        <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
+      ) : (
+        <>
+          <div
+            data-testid="card-area"
+            className={[`overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`, !isBetPhase && 'flex-1']
+              .filter(Boolean)
+              .join(' ')}
+          >
+            <GameMessageBox
+              message={state.message}
+              messageCode={state.messageCode}
+              messageParams={state.messageParams}
             />
-            <ChipBetInput
-              id="fcp-acesup-amount"
-              label={t('label.acesUp')}
-              value={acesUpAmount}
-              onChange={setAcesUpAmount}
-              min={0}
-              max={state.chips}
-              step={10}
-              disabled={loading}
-              showSteppers
-              invalid={acesUpInvalid || betInvalid}
-              describedBy={betInvalid ? 'fcp-bet-error' : undefined}
-            />
-            {betInvalid && (
-              <p id="fcp-bet-error" role="alert" className="text-ds-error text-xs">
-                {t('betError')}
-              </p>
+
+            {/* Payout table during bet phase */}
+            {isBetPhase && (
+              <div className="flex flex-col items-center justify-center py-4 gap-4">
+                <p className="text-ds-text-muted text-lg">{t('betGuide')}</p>
+                <details className="bg-black/30 rounded-lg w-full max-w-sm">
+                  <summary className="cursor-pointer select-none px-4 py-2 text-ds-text-primary font-bold text-sm">
+                    {t('payoutRef.title')}
+                  </summary>
+                  <div className="px-4 pb-3 text-ds-text-muted text-sm space-y-2">
+                    <div>
+                      <div className="font-bold text-ds-text-primary mb-1">{t('payoutRef.anteBonusHeader')}</div>
+                      <ul className="space-y-0.5">
+                        {(['anteBonusThreeOfAKind', 'anteBonusStraightFlush', 'anteBonusFourOfAKind'] as const).map(
+                          (key) => (
+                            <li key={key}>{t(`payoutRef.${key}`)}</li>
+                          ),
+                        )}
+                      </ul>
+                    </div>
+                    <div>
+                      <div className="font-bold text-ds-text-primary mb-1">{t('payoutRef.acesUpHeader')}</div>
+                      <ul className="space-y-0.5">
+                        {(
+                          [
+                            'acesUpPairOfAces',
+                            'acesUpTwoPair',
+                            'acesUpStraight',
+                            'acesUpFlush',
+                            'acesUpThreeOfAKind',
+                            'acesUpStraightFlush',
+                            'acesUpFourOfAKind',
+                          ] as const
+                        ).map((key) => (
+                          <li key={key}>{t(`payoutRef.${key}`)}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                </details>
+              </div>
             )}
-            <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading || betInvalid}>
-              {t('button.bet')}
-            </button>
+
+            {/* Player Hand */}
+            {state.playerHand.length > 0 && (
+              <div className="mb-4" data-tutorial="fcp-results">
+                <div className="text-ds-warning font-bold text-center mb-1">
+                  <span aria-hidden="true">🟡</span> {t('player')}
+                  {isEndPhase && state.playerHandRank > 0 && (
+                    <span className="ml-2 text-sm">({t(HAND_RANK_KEYS[state.playerHandRank])})</span>
+                  )}
+                </div>
+                <div className="flex justify-center gap-2">
+                  {state.playerHand.map((card, i) => (
+                    <AnimatedCard key={`p-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Dealer Hand */}
+            {state.dealerHand.length > 0 && (
+              <div className="mb-4">
+                <div className="text-ds-error font-bold text-center mb-1">
+                  <span aria-hidden="true">🔴</span> {t('dealer')}
+                  {isActionPhase && <span className="ml-2 text-xs">({t('dealerUpcard')})</span>}
+                  {isEndPhase && state.dealerHandRank > 0 && (
+                    <span className="ml-2 text-sm">({t(HAND_RANK_KEYS[state.dealerHandRank])})</span>
+                  )}
+                </div>
+                <div className="flex justify-center gap-2">
+                  {state.dealerHand.map((card, i) => (
+                    <AnimatedCard key={`d-${card.design}-${card.value}-${i}`} card={card} width={cardWidth} />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Payout breakdown */}
+            {isEndPhase && (
+              <div className="text-ds-text-primary text-center text-sm mb-2" data-testid="payout-breakdown">
+                {state.antePayout !== 0 && (
+                  <div>
+                    {t('payout.ante')}: {state.antePayout}
+                  </div>
+                )}
+                {state.playPayout !== 0 && (
+                  <div>
+                    {t('payout.play')}: {state.playPayout}
+                  </div>
+                )}
+                {state.anteBonusPayout !== 0 && (
+                  <div>
+                    {t('payout.anteBonus')}: {state.anteBonusPayout}
+                  </div>
+                )}
+                {state.acesUpPayout !== 0 && (
+                  <div>
+                    {t('payout.acesUp')}: {state.acesUpPayout}
+                  </div>
+                )}
+                <div className="font-bold mt-1">
+                  {t('payout.total')}: {state.totalPayout}
+                </div>
+              </div>
+            )}
+
+            {actionLog && <ActionLogPanel entries={actionLog} onClose={hideActionLog} />}
           </div>
-        )}
-        {isActionPhase && (
-          <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="fcp-action-buttons">
-            <div className="flex flex-wrap justify-center gap-2">
-              {[1, 2, 3].map((mult) => (
-                <button
-                  key={mult}
-                  type="button"
-                  className={btnSuccess}
-                  onClick={() => handlePlay(mult)}
+
+          <GameFooter className={`${gameTheme.fourcardpoker.footer} px-4 pt-3`}>
+            <ErrorAlert message={error} onRetry={retry} />
+            <SettingsPanel title={t('settings.title')} groups={[]} />
+            {isBetPhase && (
+              <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="fcp-bet-controls">
+                <ChipBetInput
+                  id="fcp-ante-amount"
+                  label={t('label.ante')}
+                  value={anteAmount}
+                  onChange={setAnteAmount}
+                  min={10}
+                  max={state.chips}
+                  step={10}
                   disabled={loading}
-                  data-testid={`play-${mult}x`}
-                >
-                  {t('button.playMult', { mult })}
+                  showSteppers
+                  invalid={anteInvalid || betInvalid}
+                  describedBy={betInvalid ? 'fcp-bet-error' : undefined}
+                />
+                <ChipBetInput
+                  id="fcp-acesup-amount"
+                  label={t('label.acesUp')}
+                  value={acesUpAmount}
+                  onChange={setAcesUpAmount}
+                  min={0}
+                  max={state.chips}
+                  step={10}
+                  disabled={loading}
+                  showSteppers
+                  invalid={acesUpInvalid || betInvalid}
+                  describedBy={betInvalid ? 'fcp-bet-error' : undefined}
+                />
+                {betInvalid && (
+                  <p id="fcp-bet-error" role="alert" className="text-ds-error text-xs">
+                    {t('betError')}
+                  </p>
+                )}
+                <button type="button" className={btnPrimary} onClick={handleBet} disabled={loading || betInvalid}>
+                  {t('button.bet')}
                 </button>
-              ))}
-              <button type="button" className={btnDanger} onClick={handleFold} disabled={loading}>
-                {t('button.fold')}
-              </button>
-            </div>
-          </div>
-        )}
-        {isEndPhase && (
-          <div className="flex justify-center gap-2 pb-2">
-            <GameResetButton
-              isGameEnd={isEndPhase}
-              onReset={handleReset}
-              requestConfirm={requestConfirm}
-              loading={loading}
-            />
-            <button type="button" className={btnSecondary} onClick={showActionLog} disabled={loading}>
-              {tc('actionLog.view')}
-            </button>
-          </div>
-        )}
-      </GameFooter>
+              </div>
+            )}
+            {isActionPhase && (
+              <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="fcp-action-buttons">
+                <div className="flex flex-wrap justify-center gap-2">
+                  {[1, 2, 3].map((mult) => (
+                    <button
+                      key={mult}
+                      type="button"
+                      className={btnSuccess}
+                      onClick={() => handlePlay(mult)}
+                      disabled={loading}
+                      data-testid={`play-${mult}x`}
+                    >
+                      {t('button.playMult', { mult })}
+                    </button>
+                  ))}
+                  <button type="button" className={btnDanger} onClick={handleFold} disabled={loading}>
+                    {t('button.fold')}
+                  </button>
+                </div>
+              </div>
+            )}
+            {isEndPhase && (
+              <div className="flex justify-center gap-2 pb-2">
+                <GameResetButton
+                  isGameEnd={isEndPhase}
+                  onReset={handleReset}
+                  requestConfirm={requestConfirm}
+                  loading={loading}
+                />
+                <button type="button" className={btnSecondary} onClick={showActionLog} disabled={loading}>
+                  {tc('actionLog.view')}
+                </button>
+              </div>
+            )}
+          </GameFooter>
+        </>
+      )}
     </GamePageShell>
   );
 }

--- a/frontend/src/utils/cli/commands/fourcardpokerCommands.test.ts
+++ b/frontend/src/utils/cli/commands/fourcardpokerCommands.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { parseFourCardPokerCommand } from './fourcardpokerCommands';
+
+describe('parseFourCardPokerCommand', () => {
+  it('parses bet with an ante only (acesUp defaults to 0)', () => {
+    expect(parseFourCardPokerCommand('bet 100')).toEqual({ args: ['bet', 100, 0] });
+    expect(parseFourCardPokerCommand('b 50')).toEqual({ args: ['bet', 50, 0] });
+  });
+
+  it('parses bet with an ante and an aces-up side bet', () => {
+    expect(parseFourCardPokerCommand('bet 100 25')).toEqual({ args: ['bet', 100, 25] });
+  });
+
+  it('errors on bet without a valid ante', () => {
+    expect('error' in parseFourCardPokerCommand('bet')).toBe(true);
+    expect('error' in parseFourCardPokerCommand('bet abc')).toBe(true);
+    expect('error' in parseFourCardPokerCommand('bet 100 xyz')).toBe(true);
+  });
+
+  it('parses play with a multiplier of 1-3', () => {
+    expect(parseFourCardPokerCommand('play 1')).toEqual({ args: ['play', undefined, undefined, 1] });
+    expect(parseFourCardPokerCommand('p 3')).toEqual({ args: ['play', undefined, undefined, 3] });
+  });
+
+  it('errors on an out-of-range or missing play multiplier', () => {
+    expect('error' in parseFourCardPokerCommand('play')).toBe(true);
+    expect('error' in parseFourCardPokerCommand('play 0')).toBe(true);
+    expect('error' in parseFourCardPokerCommand('play 4')).toBe(true);
+  });
+
+  it('parses fold, log, and reset', () => {
+    expect(parseFourCardPokerCommand('fold')).toEqual({ args: ['fold'] });
+    expect(parseFourCardPokerCommand('f')).toEqual({ args: ['fold'] });
+    expect(parseFourCardPokerCommand('log')).toEqual({ args: ['log'] });
+    expect(parseFourCardPokerCommand('l')).toEqual({ args: ['log'] });
+    expect(parseFourCardPokerCommand('reset')).toEqual({ args: ['reset'] });
+    expect(parseFourCardPokerCommand('r')).toEqual({ args: ['reset'] });
+  });
+
+  it('suggests a command for a close typo', () => {
+    const result = parseFourCardPokerCommand('fol');
+    expect('error' in result).toBe(true);
+    if ('error' in result) expect(result.error).toContain('fold');
+  });
+
+  it('errors on an unknown command', () => {
+    expect('error' in parseFourCardPokerCommand('zzz')).toBe(true);
+  });
+});

--- a/frontend/src/utils/cli/commands/fourcardpokerCommands.ts
+++ b/frontend/src/utils/cli/commands/fourcardpokerCommands.ts
@@ -1,0 +1,58 @@
+import type { fourcardpokerApi } from '../../../api/gameApi';
+import { parseIntArg, splitCommand, suggestCommand } from '../commandParserBase';
+import type { CliParseResult } from '../types';
+
+type FourCardPokerArgs = Parameters<typeof fourcardpokerApi.exec>;
+
+const VALID_COMMANDS = ['b', 'bet', 'p', 'play', 'f', 'fold', 'r', 'reset', 'log', 'l'];
+
+/** Parse a Four Card Poker CLI command into API exec arguments. */
+export function parseFourCardPokerCommand(input: string): CliParseResult<FourCardPokerArgs> {
+  const { cmd, args } = splitCommand(input);
+
+  switch (cmd) {
+    case 'b':
+    case 'bet': {
+      const ante = parseIntArg(args, 0);
+      if ('error' in ante) return { error: 'Usage: b <ante> [acesUp]' };
+      let acesUp = 0;
+      if (args.length > 1) {
+        const parsed = parseIntArg(args, 1);
+        if ('error' in parsed) return { error: 'Usage: b <ante> [acesUp]' };
+        acesUp = parsed.value;
+      }
+      return { args: ['bet', ante.value, acesUp] as FourCardPokerArgs };
+    }
+    case 'p':
+    case 'play': {
+      const mult = parseIntArg(args, 0);
+      if ('error' in mult || mult.value < 1 || mult.value > 3) {
+        return { error: 'Usage: p <1|2|3> (play bet multiplier)' };
+      }
+      return { args: ['play', undefined, undefined, mult.value] as FourCardPokerArgs };
+    }
+    case 'f':
+    case 'fold':
+      return { args: ['fold'] as FourCardPokerArgs };
+    case 'log':
+    case 'l':
+      return { args: ['log'] as FourCardPokerArgs };
+    case 'r':
+    case 'reset':
+      return { args: ['reset'] as FourCardPokerArgs };
+    default: {
+      const suggestion = suggestCommand(cmd, VALID_COMMANDS);
+      if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
+      return { error: `Unknown command: ${cmd}` };
+    }
+  }
+}
+
+/** Help text for Four Card Poker CLI mode. */
+export const FOURCARDPOKER_HELP: string[] = [
+  'b <ante> [acesUp]  - Place the ante (and optional Aces Up side bet)',
+  'p <1|2|3>          - Make the play bet at the given ante multiplier',
+  'f/fold             - Fold and forfeit the ante',
+  'log                - Show the action log',
+  'r/reset            - Reset game',
+];

--- a/frontend/src/utils/cli/formatters/fourcardpokerFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/fourcardpokerFormatter.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, FourCardPokerResponse } from '../../../types/card';
+import { formatFourCardPokerState } from './fourcardpokerFormatter';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+const baseState: FourCardPokerResponse = {
+  message: '',
+  playerHand: [card('SPADE', 5), card('HEART', 5), card('DIAMOND', 9), card('CLOVER', 11), card('SPADE', 2)],
+  dealerHand: [card('HEART', 13)],
+  playerBest: [],
+  dealerBest: [],
+  phase: 1,
+  chips: 1000,
+  anteBet: 0,
+  acesUpBet: 0,
+  playBet: 0,
+  playMultiplier: 0,
+  result: 0,
+  antePayout: 0,
+  playPayout: 0,
+  anteBonusPayout: 0,
+  acesUpPayout: 0,
+  totalPayout: 0,
+  playerHandRank: 0,
+  dealerHandRank: 0,
+};
+
+describe('formatFourCardPokerState', () => {
+  it('returns a loading placeholder for null state', () => {
+    expect(formatFourCardPokerState(null)).toBe('Loading...');
+  });
+
+  it('prompts for a bet in the BET phase', () => {
+    const out = formatFourCardPokerState(baseState);
+    expect(out).toContain('Four Card Poker');
+    expect(out).toContain('chips: 1000');
+    expect(out).toContain('phase: BET');
+    expect(out).toContain('Place a bet');
+  });
+
+  it('shows the hand and dealer upcard in the ACTION phase', () => {
+    const out = formatFourCardPokerState({ ...baseState, phase: 2, anteBet: 100 });
+    expect(out).toContain('phase: ACTION');
+    expect(out).toContain('your hand: ♠5, ♥5');
+    expect(out).toContain('dealer up: ♥K');
+    expect(out).toContain('Make your play bet');
+  });
+
+  it('reveals best hands and payouts in the END phase', () => {
+    const out = formatFourCardPokerState({
+      ...baseState,
+      phase: 3,
+      anteBet: 100,
+      playBet: 100,
+      dealerHand: [card('HEART', 13), card('SPADE', 7), card('CLOVER', 3), card('DIAMOND', 4)],
+      playerBest: [card('SPADE', 5), card('HEART', 5), card('CLOVER', 11), card('DIAMOND', 9)],
+      dealerBest: [card('HEART', 13), card('SPADE', 7), card('CLOVER', 3), card('DIAMOND', 4)],
+      antePayout: 100,
+      anteBonusPayout: 0,
+      playPayout: 100,
+      acesUpPayout: 0,
+      totalPayout: 200,
+    });
+    expect(out).toContain('phase: END');
+    expect(out).toContain('dealer hand:');
+    expect(out).toContain('your best:');
+    expect(out).toContain('dealer best:');
+    expect(out).toContain('total payout: 200');
+  });
+
+  it('appends a server message when present', () => {
+    const out = formatFourCardPokerState({ ...baseState, message: 'Place your ante' });
+    expect(out).toContain('Place your ante');
+  });
+});

--- a/frontend/src/utils/cli/formatters/fourcardpokerFormatter.ts
+++ b/frontend/src/utils/cli/formatters/fourcardpokerFormatter.ts
@@ -1,0 +1,48 @@
+import type { FourCardPokerResponse } from '../../../types/card';
+import { FourCardPokerPhase } from '../../../types/phases';
+import { formatCardList, formatHeader, formatSeparator } from '../formatterBase';
+
+const PHASE_NAMES: Record<number, string> = {
+  [FourCardPokerPhase.BET]: 'BET',
+  [FourCardPokerPhase.ACTION]: 'ACTION',
+  [FourCardPokerPhase.END]: 'END',
+};
+
+/** Format a Four Card Poker game state as terminal text. */
+export function formatFourCardPokerState(state: FourCardPokerResponse | null): string {
+  if (!state) return 'Loading...';
+  const lines: string[] = [];
+
+  lines.push(formatHeader('Four Card Poker'));
+  lines.push(`chips: ${state.chips} | phase: ${PHASE_NAMES[state.phase] ?? state.phase}`);
+  lines.push(`ante: ${state.anteBet} | acesUp: ${state.acesUpBet} | play: ${state.playBet}`);
+  lines.push('----------');
+
+  if (state.phase === FourCardPokerPhase.BET) {
+    lines.push('Place a bet: b <ante> [acesUp]');
+  } else {
+    lines.push(`your hand: ${formatCardList(state.playerHand) || '-'}`);
+    // During the action phase only the dealer upcard is revealed.
+    const dealerLabel = state.phase === FourCardPokerPhase.END ? 'dealer hand' : 'dealer up';
+    lines.push(`${dealerLabel}: ${formatCardList(state.dealerHand) || '-'}`);
+
+    if (state.phase === FourCardPokerPhase.ACTION) {
+      lines.push('Make your play bet: p <1|2|3>, or fold (f)');
+    }
+
+    if (state.phase === FourCardPokerPhase.END) {
+      lines.push('----------');
+      lines.push(`your best:   ${formatCardList(state.playerBest) || '-'}`);
+      lines.push(`dealer best: ${formatCardList(state.dealerBest) || '-'}`);
+      lines.push('----------');
+      lines.push(`ante payout: ${state.antePayout} | ante bonus: ${state.anteBonusPayout}`);
+      lines.push(`play payout: ${state.playPayout} | acesUp: ${state.acesUpPayout}`);
+      lines.push(`total payout: ${state.totalPayout}`);
+    }
+  }
+
+  if (state.message) lines.push(state.message);
+
+  lines.push(formatSeparator());
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
Adds a web CLI mode to Four Card Poker (the page had no CLI toggle). Wires `CliToggle`/`CliTerminal` into the existing `GamePageShell` and adds a command parser + state formatter.

- `fourcardpokerCommands.ts` — parses `b <ante> [acesUp]` (ante + optional Aces Up side bet), `p <1|2|3>` (play bet at the given ante multiplier), `f`/`fold`, `log`, `r`/`reset`; typo suggestions via `suggestCommand`.
- `fourcardpokerFormatter.ts` — renders chips/phase and the ante/acesUp/play bets; in **ACTION** shows the player's 5-card hand plus the dealer upcard; at **END** reveals both best 4-card hands and the ante/ante-bonus/play/aces-up/total payouts; otherwise prompts for a bet.
- `FourCardPokerPage.tsx` — `useCliMode`/`useCliGame` hooks, `CliToggle` added to `headerExtra`, and the `cliEnabled ? <CliTerminal/> : <board/>` branch.

## Test plan
- [x] `bun run test -- --run fourcardpoker` (32 tests across 4 files)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #3317