### PR TITLE
feat(schnapsen): add web CLI mode

### DIFF
--- a/frontend/src/pages/SchnapsenPage.tsx
+++ b/frontend/src/pages/SchnapsenPage.tsx
@@ -1,7 +1,9 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { schnapsenApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CardImage } from '../components/CardImage';
+import { CliTerminal } from '../components/cli/CliTerminal';
+import { CliToggle } from '../components/cli/CliToggle';
 import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameMessageBox } from '../components/GameMessageBox';
@@ -12,6 +14,8 @@ import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { TrickDisplay } from '../components/TrickDisplay';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
+import { useCliGame } from '../hooks/useCliGame';
+import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
@@ -21,6 +25,9 @@ import type { SchnapsenResponse } from '../types/card';
 import { SchnapsenPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt, suitSymbol } from '../utils/cardAlt';
+import { parseSchnapsenCommand, SCHNAPSEN_HELP } from '../utils/cli/commands/schnapsenCommands';
+import { formatSchnapsenState } from '../utils/cli/formatters/schnapsenFormatter';
+import type { CliGameConfig } from '../utils/cli/types';
 
 /** Card design → Schnapsen trump-suit id (1=♠ 2=♣ 3=♥ 4=♦). */
 const DESIGN_TO_SUIT: Readonly<Record<string, number>> = { SPADE: 1, CLOVER: 2, HEART: 3, DIAMOND: 4 };
@@ -58,6 +65,18 @@ function SchnapsenPageContent() {
   } = useGameApi<SchnapsenResponse, Parameters<typeof schnapsenApi.exec>>(schnapsenApi.exec);
   const { cardWidth } = useCardDimensions();
   const { hint, hintEnabled, setHintEnabled } = useGameHint('schnapsen', state);
+
+  const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('schnapsen');
+  const cliConfig: CliGameConfig<SchnapsenResponse, Parameters<typeof schnapsenApi.exec>> = useMemo(
+    () => ({
+      gameName: 'schnapsen',
+      parseCommand: parseSchnapsenCommand,
+      formatResponse: formatSchnapsenState,
+      helpText: SCHNAPSEN_HELP,
+    }),
+    [],
+  );
+  const { handleCommand } = useCliGame(dispatch, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
   // Initial reset on mount.
   useEffect(() => {
@@ -128,171 +147,191 @@ function SchnapsenPageContent() {
       confirmOpen={confirmOpen}
       confirmReset={confirmReset}
       cancelReset={cancelReset}
+      headerExtra={<CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />}
     >
-      <div className="flex-1 overflow-y-auto pt-3 px-4 lg:px-8">
-        <div className="text-ds-text-primary text-center mb-3">
-          <span className="mr-4">
-            {t('header.trick')}: {state.trickNumber}
-          </span>
-          <span className="mr-4">
-            {t('header.stock')}: {state.stockRemaining}
-          </span>
-          <span className="mr-4">
-            {t('header.points')} — {t('header.you')}: {human?.points ?? 0} / {t('header.cpu')}: {cpu?.points ?? 0}
-          </span>
-          <span className="text-ds-accent" data-testid="schnapsen-phase">
-            {state.isEndgame ? t('header.phase2') : t('header.phase1')}
-          </span>
-        </div>
-
-        {/* CPU info + trump upcard */}
-        <div className="flex flex-wrap items-start gap-4 mb-4">
-          <div className="p-2 rounded bg-black/30 text-ds-text-muted text-sm">
-            {t('header.cpu')}: {cpu?.cardCount ?? 0} / {t('header.tricks')}: {cpu?.trickCount ?? 0}
-          </div>
-          <div
-            className="flex items-center gap-2 rounded bg-black/30 p-2"
-            data-testid="schnapsen-stock"
-            data-tutorial="schnapsen-trump"
-          >
-            <span className="text-ds-text-muted text-sm">
-              {state.trumpCard ? t('header.trump') : t('header.trumpNone')}
-            </span>
-            {state.trumpCard ? (
-              <div
-                className="relative"
-                style={{ width: Math.round(cardWidth * 1.1), height: Math.round(cardWidth * 0.95) }}
-              >
-                <div
-                  className="absolute left-0 top-1/2"
-                  style={{ transform: 'translateY(-50%) rotate(90deg)', transformOrigin: 'left center' }}
-                >
-                  <CardImage card={state.trumpCard} width={Math.round(cardWidth * 0.7)} />
-                </div>
-                {state.stockRemaining > 0 && (
-                  <div
-                    className="absolute left-1/2 top-1/2 -translate-y-1/2"
-                    style={{ transform: 'translate(0,-50%)' }}
-                  >
-                    <div className="relative">
-                      {Array.from({ length: Math.min(state.stockRemaining, 4) }, (_, i) => (
-                        <div key={`back-${i.toString()}`} className="absolute" style={{ top: i * -1.5, left: i * 1.5 }}>
-                          <AnimatedCardBack width={Math.round(cardWidth * 0.7)} />
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
-            ) : null}
-          </div>
-        </div>
-
-        {/* Current trick */}
-        <div data-tutorial="schnapsen-trick">
-          <TrickDisplay
-            currentTrick={state.currentTrick}
-            players={state.players}
-            cardWidth={cardWidth}
-            label={t('currentTrick')}
-          />
-        </div>
-
-        {/* Result banner */}
-        {resultBanner && (
-          <div className="text-center text-xl my-4 text-ds-accent font-semibold" role="status">
-            {resultBanner}
-          </div>
-        )}
-
-        <GameMessageBox message={state.message} messageCode={state.messageCode} messageParams={state.messageParams} />
-        <ErrorAlert message={error} onRetry={retry} />
-
-        {/* Human hand */}
-        {human && human.cards.length > 0 && (
-          <div className="mt-4" data-tutorial="schnapsen-hand">
-            <div className="text-ds-text-muted text-sm mb-1">
-              {t('header.you')}: {human.cardCount} / {t('header.tricks')}: {human.trickCount}
+      {cliEnabled ? (
+        <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
+      ) : (
+        <>
+          <div className="flex-1 overflow-y-auto pt-3 px-4 lg:px-8">
+            <div className="text-ds-text-primary text-center mb-3">
+              <span className="mr-4">
+                {t('header.trick')}: {state.trickNumber}
+              </span>
+              <span className="mr-4">
+                {t('header.stock')}: {state.stockRemaining}
+              </span>
+              <span className="mr-4">
+                {t('header.points')} — {t('header.you')}: {human?.points ?? 0} / {t('header.cpu')}: {cpu?.points ?? 0}
+              </span>
+              <span className="text-ds-accent" data-testid="schnapsen-phase">
+                {state.isEndgame ? t('header.phase2') : t('header.phase1')}
+              </span>
             </div>
-            <div className="flex flex-wrap gap-2">
-              {human.cards.map((card, idx) => {
-                const playable = isHumanTurn && (!restrictPlays || validPlaySet.has(idx));
-                return (
-                  <div key={`${card.design}-${card.value}-${idx}`} className="flex flex-col items-center gap-1">
-                    <button
-                      type="button"
-                      onClick={() => handlePlay(idx)}
-                      disabled={loading || !playable}
-                      aria-label={t('actions.playAria', { card: cardAlt(card) })}
-                      className="disabled:opacity-50"
+
+            {/* CPU info + trump upcard */}
+            <div className="flex flex-wrap items-start gap-4 mb-4">
+              <div className="p-2 rounded bg-black/30 text-ds-text-muted text-sm">
+                {t('header.cpu')}: {cpu?.cardCount ?? 0} / {t('header.tricks')}: {cpu?.trickCount ?? 0}
+              </div>
+              <div
+                className="flex items-center gap-2 rounded bg-black/30 p-2"
+                data-testid="schnapsen-stock"
+                data-tutorial="schnapsen-trump"
+              >
+                <span className="text-ds-text-muted text-sm">
+                  {state.trumpCard ? t('header.trump') : t('header.trumpNone')}
+                </span>
+                {state.trumpCard ? (
+                  <div
+                    className="relative"
+                    style={{ width: Math.round(cardWidth * 1.1), height: Math.round(cardWidth * 0.95) }}
+                  >
+                    <div
+                      className="absolute left-0 top-1/2"
+                      style={{ transform: 'translateY(-50%) rotate(90deg)', transformOrigin: 'left center' }}
                     >
-                      <CardImage card={card} width={cardWidth} />
-                    </button>
-                    {isHumanTurn && marriageSet.has(idx) && (
-                      <button
-                        type="button"
-                        onClick={() => handleMarriage(idx)}
-                        disabled={loading}
-                        className={`${btnWarning} text-xs px-2 py-1`}
-                        data-testid={`schnapsen-marriage-${idx.toString()}`}
-                        aria-label={t('actions.marriageAria', {
-                          suit: suitSymbol(card.design),
-                          points: DESIGN_TO_SUIT[card.design] === state.trumpSuit ? 40 : 20,
-                        })}
+                      <CardImage card={state.trumpCard} width={Math.round(cardWidth * 0.7)} />
+                    </div>
+                    {state.stockRemaining > 0 && (
+                      <div
+                        className="absolute left-1/2 top-1/2 -translate-y-1/2"
+                        style={{ transform: 'translate(0,-50%)' }}
                       >
-                        👑 {t('actions.marriage')}
-                      </button>
+                        <div className="relative">
+                          {Array.from({ length: Math.min(state.stockRemaining, 4) }, (_, i) => (
+                            <div
+                              key={`back-${i.toString()}`}
+                              className="absolute"
+                              style={{ top: i * -1.5, left: i * 1.5 }}
+                            >
+                              <AnimatedCardBack width={Math.round(cardWidth * 0.7)} />
+                            </div>
+                          ))}
+                        </div>
+                      </div>
                     )}
                   </div>
-                );
-              })}
+                ) : null}
+              </div>
             </div>
-          </div>
-        )}
 
-        {/* Frontend hint */}
-        {hintEnabled && hint && (
-          <div className="mt-3 flex justify-center">
-            <HintTooltip reason={t(hint.reason)} confidence={hint.confidence} />
-          </div>
-        )}
+            {/* Current trick */}
+            <div data-tutorial="schnapsen-trick">
+              <TrickDisplay
+                currentTrick={state.currentTrick}
+                players={state.players}
+                cardWidth={cardWidth}
+                label={t('currentTrick')}
+              />
+            </div>
 
-        {/* Phase-specific controls */}
-        <div className="mt-4 flex flex-wrap gap-2" data-tutorial="schnapsen-actions">
-          {isTrickEnd && (
-            <button type="button" className={btnSuccess} onClick={handleNext} disabled={loading}>
-              {t('actions.next')}
-            </button>
-          )}
-          <button type="button" className={btnPrimary} onClick={() => requestConfirm(handleReset)} disabled={loading}>
-            {t('actions.reset')}
-          </button>
-        </div>
+            {/* Result banner */}
+            {resultBanner && (
+              <div className="text-center text-xl my-4 text-ds-accent font-semibold" role="status">
+                {resultBanner}
+              </div>
+            )}
 
-        <SettingsPanel
-          title={tc('settings.title')}
-          groups={[
-            {
-              items: [
+            <GameMessageBox
+              message={state.message}
+              messageCode={state.messageCode}
+              messageParams={state.messageParams}
+            />
+            <ErrorAlert message={error} onRetry={retry} />
+
+            {/* Human hand */}
+            {human && human.cards.length > 0 && (
+              <div className="mt-4" data-tutorial="schnapsen-hand">
+                <div className="text-ds-text-muted text-sm mb-1">
+                  {t('header.you')}: {human.cardCount} / {t('header.tricks')}: {human.trickCount}
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {human.cards.map((card, idx) => {
+                    const playable = isHumanTurn && (!restrictPlays || validPlaySet.has(idx));
+                    return (
+                      <div key={`${card.design}-${card.value}-${idx}`} className="flex flex-col items-center gap-1">
+                        <button
+                          type="button"
+                          onClick={() => handlePlay(idx)}
+                          disabled={loading || !playable}
+                          aria-label={t('actions.playAria', { card: cardAlt(card) })}
+                          className="disabled:opacity-50"
+                        >
+                          <CardImage card={card} width={cardWidth} />
+                        </button>
+                        {isHumanTurn && marriageSet.has(idx) && (
+                          <button
+                            type="button"
+                            onClick={() => handleMarriage(idx)}
+                            disabled={loading}
+                            className={`${btnWarning} text-xs px-2 py-1`}
+                            data-testid={`schnapsen-marriage-${idx.toString()}`}
+                            aria-label={t('actions.marriageAria', {
+                              suit: suitSymbol(card.design),
+                              points: DESIGN_TO_SUIT[card.design] === state.trumpSuit ? 40 : 20,
+                            })}
+                          >
+                            👑 {t('actions.marriage')}
+                          </button>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* Frontend hint */}
+            {hintEnabled && hint && (
+              <div className="mt-3 flex justify-center">
+                <HintTooltip reason={t(hint.reason)} confidence={hint.confidence} />
+              </div>
+            )}
+
+            {/* Phase-specific controls */}
+            <div className="mt-4 flex flex-wrap gap-2" data-tutorial="schnapsen-actions">
+              {isTrickEnd && (
+                <button type="button" className={btnSuccess} onClick={handleNext} disabled={loading}>
+                  {t('actions.next')}
+                </button>
+              )}
+              <button
+                type="button"
+                className={btnPrimary}
+                onClick={() => requestConfirm(handleReset)}
+                disabled={loading}
+              >
+                {t('actions.reset')}
+              </button>
+            </div>
+
+            <SettingsPanel
+              title={tc('settings.title')}
+              groups={[
                 {
-                  type: 'checkbox' as const,
-                  id: 'frontendHint',
-                  label: tc('hint.toggle', { ns: 'tutorial' }),
-                  checked: hintEnabled,
-                  onToggle: setHintEnabled,
+                  items: [
+                    {
+                      type: 'checkbox' as const,
+                      id: 'frontendHint',
+                      label: tc('hint.toggle', { ns: 'tutorial' }),
+                      checked: hintEnabled,
+                      onToggle: setHintEnabled,
+                    },
+                  ],
                 },
-              ],
-            },
-          ]}
-        />
-      </div>
+              ]}
+            />
+          </div>
 
-      <ActionLogSection
-        isEndPhase={isGameEnd}
-        actionLog={actionLog}
-        showActionLog={showActionLog}
-        hideActionLog={hideActionLog}
-      />
+          <ActionLogSection
+            isEndPhase={isGameEnd}
+            actionLog={actionLog}
+            showActionLog={showActionLog}
+            hideActionLog={hideActionLog}
+          />
+        </>
+      )}
     </GamePageShell>
   );
 }

--- a/frontend/src/utils/cli/commands/schnapsenCommands.test.ts
+++ b/frontend/src/utils/cli/commands/schnapsenCommands.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { parseSchnapsenCommand } from './schnapsenCommands';
+
+describe('parseSchnapsenCommand', () => {
+  it('parses play with a card index', () => {
+    expect(parseSchnapsenCommand('play 2')).toEqual({ args: ['play', 2] });
+    expect(parseSchnapsenCommand('p 0')).toEqual({ args: ['play', 0] });
+  });
+
+  it('errors on play without a valid index', () => {
+    expect('error' in parseSchnapsenCommand('play')).toBe(true);
+    expect('error' in parseSchnapsenCommand('p abc')).toBe(true);
+  });
+
+  it('parses marriage with a card index', () => {
+    expect(parseSchnapsenCommand('marriage 3')).toEqual({ args: ['marriage', 3] });
+    expect(parseSchnapsenCommand('m 1')).toEqual({ args: ['marriage', 1] });
+  });
+
+  it('errors on marriage without a valid index', () => {
+    expect('error' in parseSchnapsenCommand('marriage')).toBe(true);
+  });
+
+  it('parses next, hint, log, and reset', () => {
+    expect(parseSchnapsenCommand('next')).toEqual({ args: ['next'] });
+    expect(parseSchnapsenCommand('n')).toEqual({ args: ['next'] });
+    expect(parseSchnapsenCommand('hint')).toEqual({ args: ['hint'] });
+    expect(parseSchnapsenCommand('h')).toEqual({ args: ['hint'] });
+    expect(parseSchnapsenCommand('log')).toEqual({ args: ['log'] });
+    expect(parseSchnapsenCommand('l')).toEqual({ args: ['log'] });
+    expect(parseSchnapsenCommand('reset')).toEqual({ args: ['reset'] });
+    expect(parseSchnapsenCommand('r')).toEqual({ args: ['reset'] });
+  });
+
+  it('suggests a command for a close typo', () => {
+    const result = parseSchnapsenCommand('marraige 1');
+    expect('error' in result).toBe(true);
+    if ('error' in result) expect(result.error).toContain('marriage');
+  });
+
+  it('errors on an unknown command', () => {
+    expect('error' in parseSchnapsenCommand('zzz')).toBe(true);
+  });
+});

--- a/frontend/src/utils/cli/commands/schnapsenCommands.ts
+++ b/frontend/src/utils/cli/commands/schnapsenCommands.ts
@@ -1,0 +1,54 @@
+import type { schnapsenApi } from '../../../api/gameApi';
+import { parseIntArg, splitCommand, suggestCommand } from '../commandParserBase';
+import type { CliParseResult } from '../types';
+
+type SchnapsenArgs = Parameters<typeof schnapsenApi.exec>;
+
+const VALID_COMMANDS = ['p', 'play', 'm', 'marriage', 'n', 'next', 'h', 'hint', 'r', 'reset', 'log', 'l'];
+
+/** Parse a Schnapsen CLI command into API exec arguments (indices are 0-based). */
+export function parseSchnapsenCommand(input: string): CliParseResult<SchnapsenArgs> {
+  const { cmd, args } = splitCommand(input);
+
+  switch (cmd) {
+    case 'p':
+    case 'play': {
+      const idx = parseIntArg(args, 0);
+      if ('error' in idx) return { error: 'Usage: p <cardIdx>' };
+      return { args: ['play', idx.value] as SchnapsenArgs };
+    }
+    case 'm':
+    case 'marriage': {
+      const idx = parseIntArg(args, 0);
+      if ('error' in idx) return { error: 'Usage: m <cardIdx>' };
+      return { args: ['marriage', idx.value] as SchnapsenArgs };
+    }
+    case 'n':
+    case 'next':
+      return { args: ['next'] as SchnapsenArgs };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] as SchnapsenArgs };
+    case 'log':
+    case 'l':
+      return { args: ['log'] as SchnapsenArgs };
+    case 'r':
+    case 'reset':
+      return { args: ['reset'] as SchnapsenArgs };
+    default: {
+      const suggestion = suggestCommand(cmd, VALID_COMMANDS);
+      if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
+      return { error: `Unknown command: ${cmd}` };
+    }
+  }
+}
+
+/** Help text for Schnapsen CLI mode. */
+export const SCHNAPSEN_HELP: string[] = [
+  'p <cardIdx>  - Play a card (marked * in your hand)',
+  'm <cardIdx>  - Declare a marriage with a card (marked M)',
+  'n/next       - Advance to the next trick',
+  'h/hint       - Show a hint',
+  'log          - Show the action log',
+  'r/reset      - Reset game',
+];

--- a/frontend/src/utils/cli/formatters/schnapsenFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/schnapsenFormatter.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, SchnapsenPlayerData, SchnapsenResponse } from '../../../types/card';
+import { formatSchnapsenState } from './schnapsenFormatter';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+const player = (over: Partial<SchnapsenPlayerData> = {}): SchnapsenPlayerData => ({
+  id: 0,
+  isHuman: true,
+  cardCount: 5,
+  cards: [card('SPADE', 13), card('SPADE', 12), card('HEART', 10)],
+  points: 0,
+  trickCount: 0,
+  ...over,
+});
+
+const baseState: SchnapsenResponse = {
+  message: '',
+  players: [player(), player({ id: 1, isHuman: false, cards: [] })],
+  phase: 0,
+  trickNumber: 1,
+  currentPlayerIdx: 0,
+  currentTrick: [],
+  trumpSuit: 3,
+  trumpCard: card('HEART', 11),
+  dealerIdx: 1,
+  leadPlayerIdx: 0,
+  stockRemaining: 9,
+  isEndgame: false,
+  validPlays: [0, 2],
+  marriagePlays: [0],
+  gameEndFlag: false,
+  winnerIdx: -1,
+  config: { cpuDifficulty: 1 },
+};
+
+describe('formatSchnapsenState', () => {
+  it('returns a loading placeholder for null state', () => {
+    expect(formatSchnapsenState(null)).toBe('Loading...');
+  });
+
+  it('renders trick, phase, trump, and stock', () => {
+    const out = formatSchnapsenState(baseState);
+    expect(out).toContain('Schnapsen');
+    expect(out).toContain('trick 1');
+    expect(out).toContain('phase: PLAY');
+    expect(out).toContain('trump: ♥J');
+    expect(out).toContain('stock: 9');
+  });
+
+  it('falls back to the trump suit symbol once the upcard is gone', () => {
+    const out = formatSchnapsenState({ ...baseState, trumpCard: undefined, isEndgame: true });
+    expect(out).toContain('trump: ♥');
+    expect(out).toContain('(endgame)');
+  });
+
+  it('marks valid plays with * and marriage cards with M', () => {
+    const out = formatSchnapsenState(baseState);
+    expect(out).toContain('[0]♠K*M');
+    expect(out).toContain('[2]♥10*');
+  });
+
+  it('renders the current trick when cards have been played', () => {
+    const out = formatSchnapsenState({
+      ...baseState,
+      currentTrick: [{ playerIdx: 1, card: card('DIAMOND', 1) }],
+    });
+    expect(out).toContain('trick:');
+    expect(out).toContain('♦A');
+  });
+
+  it('announces the winner at game end', () => {
+    const out = formatSchnapsenState({ ...baseState, gameEndFlag: true, winnerIdx: 0 });
+    expect(out).toContain('winner:');
+  });
+
+  it('announces a tie at game end with no winner', () => {
+    const out = formatSchnapsenState({ ...baseState, gameEndFlag: true, winnerIdx: -1 });
+    expect(out).toContain('tie');
+  });
+
+  it('appends a server message when present', () => {
+    const out = formatSchnapsenState({ ...baseState, message: 'Your turn' });
+    expect(out).toContain('Your turn');
+  });
+});

--- a/frontend/src/utils/cli/formatters/schnapsenFormatter.ts
+++ b/frontend/src/utils/cli/formatters/schnapsenFormatter.ts
@@ -1,0 +1,69 @@
+import type { SchnapsenResponse } from '../../../types/card';
+import { SchnapsenPhase } from '../../../types/phases';
+import { formatCard, formatHeader, formatPlayerName, formatSeparator } from '../formatterBase';
+
+const PHASE_NAMES: Record<number, string> = {
+  [SchnapsenPhase.PLAY]: 'PLAY',
+  [SchnapsenPhase.TRICK_END]: 'TRICK END',
+  [SchnapsenPhase.GAME_END]: 'GAME END',
+};
+
+// Schnapsen trumpSuit is a 1-based suit code (see DESIGN_TO_SUIT on the page).
+const SUIT_SYMBOLS: Record<number, string> = { 1: '♠', 2: '♣', 3: '♥', 4: '♦' };
+
+/** Format a Schnapsen game state as terminal text. */
+export function formatSchnapsenState(state: SchnapsenResponse | null): string {
+  if (!state) return 'Loading...';
+  const lines: string[] = [];
+
+  lines.push(formatHeader('Schnapsen'));
+  lines.push(
+    `trick ${state.trickNumber} | phase: ${PHASE_NAMES[state.phase] ?? state.phase}${state.isEndgame ? ' (endgame)' : ''}`,
+  );
+  const trump = state.trumpCard ? formatCard(state.trumpCard) : (SUIT_SYMBOLS[state.trumpSuit] ?? '?');
+  lines.push(`trump: ${trump} | stock: ${state.stockRemaining}`);
+  lines.push('----------');
+
+  // Current trick (cards played so far this trick).
+  if (state.currentTrick.length > 0) {
+    const trick = state.currentTrick
+      .map((tc) => `${formatPlayerName(tc.playerIdx, false)}:${formatCard(tc.card)}`)
+      .join('  ');
+    lines.push(`trick: ${trick}`);
+    lines.push('----------');
+  }
+
+  state.players.forEach((p) => {
+    const marker = p.id === state.currentPlayerIdx && !state.gameEndFlag ? '>' : ' ';
+    lines.push(
+      `${marker}${formatPlayerName(p.id, p.isHuman)}: ${p.points} pts | ${p.trickCount} tricks | ${p.cardCount} cards`,
+    );
+  });
+
+  // Human hand, indexed; '*' = legal to play, 'M' = can declare a marriage.
+  const human = state.players.find((p) => p.isHuman);
+  if (human) {
+    lines.push('----------');
+    const hand = human.cards
+      .map((c, i) => {
+        const tags = `${state.validPlays.includes(i) ? '*' : ''}${state.marriagePlays.includes(i) ? 'M' : ''}`;
+        return `[${i}]${formatCard(c)}${tags}`;
+      })
+      .join('  ');
+    lines.push(`your hand: ${hand || '(empty)'}`);
+  }
+
+  if (state.gameEndFlag) {
+    lines.push('----------');
+    lines.push(
+      state.winnerIdx >= 0
+        ? `game over — winner: ${formatPlayerName(state.winnerIdx, state.players[state.winnerIdx]?.isHuman ?? false)}`
+        : 'game over — tie',
+    );
+  }
+
+  if (state.message) lines.push(state.message);
+
+  lines.push(formatSeparator());
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
Adds a web CLI mode to Schnapsen (the page had no CLI toggle). Wires `CliToggle`/`CliTerminal` into the existing `GamePageShell` and adds a command parser + state formatter.

- `schnapsenCommands.ts` — parses `p <idx>` (play), `m <idx>` (declare marriage), `n`/`next`, `h`/`hint`, `log`, `r`/`reset`; typo suggestions via `suggestCommand`.
- `schnapsenFormatter.ts` — renders trick number, phase (with an endgame flag), the trump upcard/suit, stock count, the current trick, per-player points/tricks/cards with a current-player marker, and the indexed human hand where `*` marks legal plays and `M` marks marriage-capable cards; announces the winner/tie at game end.
- `SchnapsenPage.tsx` — `useCliMode`/`useCliGame` hooks, `headerExtra={<CliToggle/>}`, and the `cliEnabled ? <CliTerminal/> : <board/>` branch.

## Test plan
- [x] `bun run test -- --run schnapsen` (32 tests across 4 files)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #3367