### PR TITLE
fix(yukon): support mid-column card index in the CLI move command

### DIFF
--- a/frontend/src/pages/YukonPage.tsx
+++ b/frontend/src/pages/YukonPage.tsx
@@ -33,6 +33,7 @@ import type { YukonResponse } from '../types/card';
 import { YukonPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { parseYukonCommand, YUKON_HELP } from '../utils/cli/commands/yukonCommands';
 import type { CliGameConfig } from '../utils/cli/types';
 import { isTableauAllFaceUp } from '../utils/solitaireUtils';
 
@@ -71,53 +72,6 @@ const YK_TUTORIAL_STEPS: TutorialStep[] = [
 ];
 
 /** CLI help text for Yukon. */
-const YUKON_HELP = [
-  'm <from> <to>  Move between tableau columns (top card)',
-  'm t <col> f    Move tableau to foundation',
-  'g              Give up',
-  'h              Hint',
-  'ac             Auto-complete',
-  'u              Undo',
-  'r              Reset',
-];
-
-/** Parse a Yukon CLI command into API call arguments. */
-function parseYukonCommand(input: string): { args: Parameters<typeof yukonApi.exec> } | { error: string } {
-  const parts = input.trim().split(/\s+/);
-  const cmd = parts[0]?.toLowerCase();
-  switch (cmd) {
-    case 'r':
-    case 'reset':
-      return { args: ['reset'] };
-    case 'g':
-    case 'giveup':
-      return { args: ['giveup'] };
-    case 'h':
-    case 'hint':
-      return { args: ['hint'] };
-    case 'ac':
-    case 'autocomplete':
-      return { args: ['autocomplete'] };
-    case 'u':
-    case 'undo':
-      return { args: ['undo'] };
-    case 'm':
-    case 'move': {
-      if (parts.length === 3) {
-        const from = Number.parseInt(parts[1], 10);
-        const to = Number.parseInt(parts[2], 10);
-        if (Number.isNaN(from) || Number.isNaN(to)) return { error: 'Invalid column' };
-        return {
-          args: ['move', { zone: 'tableau', col: from, cardIndex: -1 }, { zone: 'tableau', col: to }],
-        };
-      }
-      return { error: 'Usage: m <fromCol> <toCol>' };
-    }
-    default:
-      return { error: `Unknown command: ${cmd}` };
-  }
-}
-
 /** Format Yukon state for CLI display. */
 function formatYukonState(state: YukonResponse): string {
   const lines: string[] = [];

--- a/frontend/src/utils/cli/commands/yukonCommands.test.ts
+++ b/frontend/src/utils/cli/commands/yukonCommands.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { parseYukonCommand } from './yukonCommands';
+
+describe('parseYukonCommand', () => {
+  it('parses a two-column move as a top-of-column block (cardIndex -1)', () => {
+    expect(parseYukonCommand('m 0 3')).toEqual({
+      args: ['move', { zone: 'tableau', col: 0, cardIndex: -1 }, { zone: 'tableau', col: 3 }],
+    });
+    expect(parseYukonCommand('move 1 2')).toEqual({
+      args: ['move', { zone: 'tableau', col: 1, cardIndex: -1 }, { zone: 'tableau', col: 2 }],
+    });
+  });
+
+  it('parses a three-argument move with an explicit card index', () => {
+    expect(parseYukonCommand('m 0 2 5')).toEqual({
+      args: ['move', { zone: 'tableau', col: 0, cardIndex: 2 }, { zone: 'tableau', col: 5 }],
+    });
+  });
+
+  it('errors on a non-numeric column', () => {
+    expect(parseYukonCommand('m a 3')).toEqual({ error: 'Invalid column' });
+    expect(parseYukonCommand('m a 2 3')).toEqual({ error: 'Invalid column' });
+  });
+
+  it('errors on a negative or non-numeric card index', () => {
+    expect(parseYukonCommand('m 0 -1 3')).toEqual({ error: 'Invalid card index' });
+    expect(parseYukonCommand('m 0 z 3')).toEqual({ error: 'Invalid card index' });
+  });
+
+  it('errors on the wrong number of move arguments', () => {
+    expect(parseYukonCommand('m 0')).toEqual({ error: 'Usage: m <fromCol> [cardIdx] <toCol>' });
+    expect(parseYukonCommand('m 0 1 2 3')).toEqual({ error: 'Usage: m <fromCol> [cardIdx] <toCol>' });
+  });
+
+  it('parses the simple commands', () => {
+    expect(parseYukonCommand('r')).toEqual({ args: ['reset'] });
+    expect(parseYukonCommand('reset')).toEqual({ args: ['reset'] });
+    expect(parseYukonCommand('g')).toEqual({ args: ['giveup'] });
+    expect(parseYukonCommand('h')).toEqual({ args: ['hint'] });
+    expect(parseYukonCommand('ac')).toEqual({ args: ['autocomplete'] });
+    expect(parseYukonCommand('u')).toEqual({ args: ['undo'] });
+  });
+
+  it('suggests a command for a close typo', () => {
+    const result = parseYukonCommand('rese');
+    expect('error' in result).toBe(true);
+    if ('error' in result) expect(result.error).toContain('Did you mean');
+  });
+
+  it('errors on an unknown command', () => {
+    expect('error' in parseYukonCommand('zzz')).toBe(true);
+  });
+});

--- a/frontend/src/utils/cli/commands/yukonCommands.ts
+++ b/frontend/src/utils/cli/commands/yukonCommands.ts
@@ -1,0 +1,65 @@
+import type { yukonApi } from '../../../api/gameApi';
+import { splitCommand, suggestCommand } from '../commandParserBase';
+import type { CliParseResult } from '../types';
+
+type YukonArgs = Parameters<typeof yukonApi.exec>;
+
+const VALID_COMMANDS = ['m', 'move', 'g', 'giveup', 'h', 'hint', 'ac', 'autocomplete', 'u', 'undo', 'r', 'reset'];
+
+/** Parse a Yukon CLI command into API call arguments. */
+export function parseYukonCommand(input: string): CliParseResult<YukonArgs> {
+  const { cmd, args } = splitCommand(input);
+  switch (cmd) {
+    case 'r':
+    case 'reset':
+      return { args: ['reset'] };
+    case 'g':
+    case 'giveup':
+      return { args: ['giveup'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
+    case 'ac':
+    case 'autocomplete':
+      return { args: ['autocomplete'] };
+    case 'u':
+    case 'undo':
+      return { args: ['undo'] };
+    case 'm':
+    case 'move': {
+      // `m <fromCol> <toCol>`            → grab the whole face-up block (top card).
+      // `m <fromCol> <cardIdx> <toCol>`  → grab from a specific face-up card in the column.
+      if (args.length === 2) {
+        const from = Number.parseInt(args[0], 10);
+        const to = Number.parseInt(args[1], 10);
+        if (Number.isNaN(from) || Number.isNaN(to)) return { error: 'Invalid column' };
+        return { args: ['move', { zone: 'tableau', col: from, cardIndex: -1 }, { zone: 'tableau', col: to }] };
+      }
+      if (args.length === 3) {
+        const from = Number.parseInt(args[0], 10);
+        const cardIdx = Number.parseInt(args[1], 10);
+        const to = Number.parseInt(args[2], 10);
+        if (Number.isNaN(from) || Number.isNaN(to)) return { error: 'Invalid column' };
+        if (Number.isNaN(cardIdx) || cardIdx < 0) return { error: 'Invalid card index' };
+        return { args: ['move', { zone: 'tableau', col: from, cardIndex: cardIdx }, { zone: 'tableau', col: to }] };
+      }
+      return { error: 'Usage: m <fromCol> [cardIdx] <toCol>' };
+    }
+    default: {
+      const suggestion = suggestCommand(cmd, VALID_COMMANDS);
+      if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
+      return { error: `Unknown command: ${cmd}` };
+    }
+  }
+}
+
+/** Help text for Yukon CLI mode. */
+export const YUKON_HELP: string[] = [
+  'm <from> <to>          Move a tableau column block (top face-up card)',
+  'm <from> <cardIdx> <to>  Move starting from a specific face-up card',
+  'g              Give up',
+  'h              Hint',
+  'ac             Auto-complete',
+  'u              Undo',
+  'r              Reset',
+];


### PR DESCRIPTION
## Summary
Yukon lets you grab a face-up card from anywhere in a tableau column (along with everything stacked on it), but the CLI `m <from> <to>` command could only ever grab the top block (`cardIndex: -1`), so part of the GUI's moves were unreachable from the terminal.

- Adds a three-argument form `m <fromCol> <cardIdx> <toCol>` that passes the chosen `cardIndex` through to the move API. The two-argument form `m <from> <to>` still means "top of the column" (`cardIndex: -1`).
- Validates columns and the card index separately, returning distinct `Invalid column` / `Invalid card index` errors.
- Extracts the previously inline `parseYukonCommand` / `YUKON_HELP` from `YukonPage.tsx` into `utils/cli/commands/yukonCommands.ts` (matching the project's CLI convention) so the parser is unit-testable, and updates the help text.

## Test plan
- [x] `bun run test -- --run yukon` (31 tests across 3 files, incl. new `yukonCommands.test.ts`)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #3151