### PR TITLE
fix(russiansolitaire): support mid-column card index in the CLI move command

### DIFF
--- a/frontend/src/pages/RussianSolitairePage.tsx
+++ b/frontend/src/pages/RussianSolitairePage.tsx
@@ -33,6 +33,7 @@ import type { RussianSolitaireResponse } from '../types/card';
 import { RussianSolitairePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { parseRussianSolitaireCommand, RS_HELP } from '../utils/cli/commands/russiansolitaireCommands';
 import type { CliGameConfig } from '../utils/cli/types';
 import { isTableauAllFaceUp } from '../utils/solitaireUtils';
 
@@ -66,56 +67,6 @@ const RS_TUTORIAL_STEPS: TutorialStep[] = [
     advanceOn: 'next',
   },
 ];
-
-/** CLI help text for Russian Solitaire. */
-const RS_HELP = [
-  'm <from> <to>  Move between tableau columns (top card)',
-  'm t <col> f    Move tableau to foundation',
-  'g              Give up',
-  'h              Hint',
-  'ac             Auto-complete',
-  'u              Undo',
-  'r              Reset',
-];
-
-/** Parse a Russian Solitaire CLI command into API call arguments. */
-function parseRussianSolitaireCommand(
-  input: string,
-): { args: Parameters<typeof russianSolitaireApi.exec> } | { error: string } {
-  const parts = input.trim().split(/\s+/);
-  const cmd = parts[0]?.toLowerCase();
-  switch (cmd) {
-    case 'r':
-    case 'reset':
-      return { args: ['reset'] };
-    case 'g':
-    case 'giveup':
-      return { args: ['giveup'] };
-    case 'h':
-    case 'hint':
-      return { args: ['hint'] };
-    case 'ac':
-    case 'autocomplete':
-      return { args: ['autocomplete'] };
-    case 'u':
-    case 'undo':
-      return { args: ['undo'] };
-    case 'm':
-    case 'move': {
-      if (parts.length === 3) {
-        const from = Number.parseInt(parts[1], 10);
-        const to = Number.parseInt(parts[2], 10);
-        if (Number.isNaN(from) || Number.isNaN(to)) return { error: 'Invalid column' };
-        return {
-          args: ['move', { zone: 'tableau', col: from, cardIndex: -1 }, { zone: 'tableau', col: to }],
-        };
-      }
-      return { error: 'Usage: m <fromCol> <toCol>' };
-    }
-    default:
-      return { error: `Unknown command: ${cmd}` };
-  }
-}
 
 /** Format Russian Solitaire state for CLI display. */
 function formatRussianSolitaireState(state: RussianSolitaireResponse): string {

--- a/frontend/src/utils/cli/commands/russiansolitaireCommands.test.ts
+++ b/frontend/src/utils/cli/commands/russiansolitaireCommands.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { parseRussianSolitaireCommand } from './russiansolitaireCommands';
+
+describe('parseRussianSolitaireCommand', () => {
+  it('parses a two-column move as a top-of-column block (cardIndex -1)', () => {
+    expect(parseRussianSolitaireCommand('m 0 3')).toEqual({
+      args: ['move', { zone: 'tableau', col: 0, cardIndex: -1 }, { zone: 'tableau', col: 3 }],
+    });
+    expect(parseRussianSolitaireCommand('move 1 2')).toEqual({
+      args: ['move', { zone: 'tableau', col: 1, cardIndex: -1 }, { zone: 'tableau', col: 2 }],
+    });
+  });
+
+  it('parses a three-argument move with an explicit card index', () => {
+    expect(parseRussianSolitaireCommand('m 0 2 5')).toEqual({
+      args: ['move', { zone: 'tableau', col: 0, cardIndex: 2 }, { zone: 'tableau', col: 5 }],
+    });
+  });
+
+  it('errors on a non-numeric column', () => {
+    expect(parseRussianSolitaireCommand('m a 3')).toEqual({ error: 'Invalid column' });
+    expect(parseRussianSolitaireCommand('m a 2 3')).toEqual({ error: 'Invalid column' });
+  });
+
+  it('errors on a negative or non-numeric card index', () => {
+    expect(parseRussianSolitaireCommand('m 0 -1 3')).toEqual({ error: 'Invalid card index' });
+    expect(parseRussianSolitaireCommand('m 0 z 3')).toEqual({ error: 'Invalid card index' });
+  });
+
+  it('errors on the wrong number of move arguments', () => {
+    expect(parseRussianSolitaireCommand('m 0')).toEqual({ error: 'Usage: m <fromCol> [cardIdx] <toCol>' });
+    expect(parseRussianSolitaireCommand('m 0 1 2 3')).toEqual({ error: 'Usage: m <fromCol> [cardIdx] <toCol>' });
+  });
+
+  it('parses the simple commands', () => {
+    expect(parseRussianSolitaireCommand('r')).toEqual({ args: ['reset'] });
+    expect(parseRussianSolitaireCommand('reset')).toEqual({ args: ['reset'] });
+    expect(parseRussianSolitaireCommand('g')).toEqual({ args: ['giveup'] });
+    expect(parseRussianSolitaireCommand('h')).toEqual({ args: ['hint'] });
+    expect(parseRussianSolitaireCommand('ac')).toEqual({ args: ['autocomplete'] });
+    expect(parseRussianSolitaireCommand('u')).toEqual({ args: ['undo'] });
+  });
+
+  it('suggests a command for a close typo', () => {
+    const result = parseRussianSolitaireCommand('rese');
+    expect('error' in result).toBe(true);
+    if ('error' in result) expect(result.error).toContain('Did you mean');
+  });
+
+  it('errors on an unknown command', () => {
+    expect('error' in parseRussianSolitaireCommand('zzz')).toBe(true);
+  });
+});

--- a/frontend/src/utils/cli/commands/russiansolitaireCommands.ts
+++ b/frontend/src/utils/cli/commands/russiansolitaireCommands.ts
@@ -1,0 +1,65 @@
+import type { russianSolitaireApi } from '../../../api/gameApi';
+import { splitCommand, suggestCommand } from '../commandParserBase';
+import type { CliParseResult } from '../types';
+
+type RussianSolitaireArgs = Parameters<typeof russianSolitaireApi.exec>;
+
+const VALID_COMMANDS = ['m', 'move', 'g', 'giveup', 'h', 'hint', 'ac', 'autocomplete', 'u', 'undo', 'r', 'reset'];
+
+/** Parse a Russian Solitaire CLI command into API call arguments. */
+export function parseRussianSolitaireCommand(input: string): CliParseResult<RussianSolitaireArgs> {
+  const { cmd, args } = splitCommand(input);
+  switch (cmd) {
+    case 'r':
+    case 'reset':
+      return { args: ['reset'] };
+    case 'g':
+    case 'giveup':
+      return { args: ['giveup'] };
+    case 'h':
+    case 'hint':
+      return { args: ['hint'] };
+    case 'ac':
+    case 'autocomplete':
+      return { args: ['autocomplete'] };
+    case 'u':
+    case 'undo':
+      return { args: ['undo'] };
+    case 'm':
+    case 'move': {
+      // `m <fromCol> <toCol>`            → grab the whole face-up block (top card).
+      // `m <fromCol> <cardIdx> <toCol>`  → grab from a specific face-up card in the column.
+      if (args.length === 2) {
+        const from = Number.parseInt(args[0], 10);
+        const to = Number.parseInt(args[1], 10);
+        if (Number.isNaN(from) || Number.isNaN(to)) return { error: 'Invalid column' };
+        return { args: ['move', { zone: 'tableau', col: from, cardIndex: -1 }, { zone: 'tableau', col: to }] };
+      }
+      if (args.length === 3) {
+        const from = Number.parseInt(args[0], 10);
+        const cardIdx = Number.parseInt(args[1], 10);
+        const to = Number.parseInt(args[2], 10);
+        if (Number.isNaN(from) || Number.isNaN(to)) return { error: 'Invalid column' };
+        if (Number.isNaN(cardIdx) || cardIdx < 0) return { error: 'Invalid card index' };
+        return { args: ['move', { zone: 'tableau', col: from, cardIndex: cardIdx }, { zone: 'tableau', col: to }] };
+      }
+      return { error: 'Usage: m <fromCol> [cardIdx] <toCol>' };
+    }
+    default: {
+      const suggestion = suggestCommand(cmd, VALID_COMMANDS);
+      if (suggestion) return { error: `Unknown command: ${cmd}. Did you mean: ${suggestion}?` };
+      return { error: `Unknown command: ${cmd}` };
+    }
+  }
+}
+
+/** Help text for Russian Solitaire CLI mode. */
+export const RS_HELP: string[] = [
+  'm <from> <to>          Move a tableau column block (top face-up card)',
+  'm <from> <cardIdx> <to>  Move starting from a specific face-up card',
+  'g              Give up',
+  'h              Hint',
+  'ac             Auto-complete',
+  'u              Undo',
+  'r              Reset',
+];


### PR DESCRIPTION
## Summary
Mirrors the Yukon fix (#3151/#3921) for Russian Solitaire, which shares the same "grab a face-up card from anywhere in a column" rule. The CLI `m <from> <to>` could only grab the top block (`cardIndex: -1`), leaving part of the GUI's moves unreachable from the terminal.

- Adds the three-argument form `m <fromCol> <cardIdx> <toCol>`; the two-argument form still means "top of the column" (`cardIndex: -1`).
- Validates columns and the card index separately (`Invalid column` / `Invalid card index`).
- Extracts the inline `parseRussianSolitaireCommand` / `RS_HELP` from `RussianSolitairePage.tsx` into `utils/cli/commands/russiansolitaireCommands.ts` (matching the Yukon implementation and the project's CLI convention), so the parser is unit-testable, and updates the help text.

## Test plan
- [x] `bun run test -- --run russiansolitaire` (31 tests across 3 files, incl. new `russiansolitaireCommands.test.ts`)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #3156