### PR TITLE
refactor(fivecardstud): extract CLI command/formatter to utils/cli convention

### DIFF
--- a/frontend/src/pages/FiveCardStudPage.tsx
+++ b/frontend/src/pages/FiveCardStudPage.tsx
@@ -35,7 +35,9 @@ import { gameTheme } from '../styles/gameTheme';
 import type { FiveCardStudResponse } from '../types/card';
 import { FiveCardStudPhase, FiveCardStudRebuyPhaseType } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
-import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
+import { FIVECARDSTUD_HELP, parseFiveCardStudCommand } from '../utils/cli/commands/fiveCardStudCommands';
+import { formatFiveCardStudState } from '../utils/cli/formatters/fiveCardStudFormatter';
+import type { CliGameConfig } from '../utils/cli/types';
 import { findPlayerName } from '../utils/playerUtils';
 
 /** Five Card Stud tutorial step definitions. */
@@ -100,60 +102,9 @@ function FiveCardStudPageContent() {
   const cliConfig: CliGameConfig<FiveCardStudResponse, FcsArgs> = useMemo(
     () => ({
       gameName: 'fivecardstud',
-      parseCommand: (input: string): CliParseResult<FcsArgs> => {
-        const parts = input.trim().split(/\s+/);
-        const cmd = parts[0]?.toLowerCase() ?? '';
-        const amount = parts[1] ? Number.parseInt(parts[1], 10) : undefined;
-        const validCmds = [
-          'reset',
-          'fold',
-          'check',
-          'call',
-          'bet',
-          'raise',
-          'allin',
-          'rebuy',
-          'skiprebuy',
-          'addon',
-          'skipaddon',
-          'muck',
-          'show',
-        ] as const;
-        type Cmd = (typeof validCmds)[number];
-        if (validCmds.includes(cmd as Cmd)) {
-          return { args: [cmd as Cmd, amount] };
-        }
-        return { error: `Unknown command: ${cmd}` };
-      },
-      formatResponse: (s: FiveCardStudResponse) => {
-        const lines: string[] = [];
-        lines.push(`Phase: ${phaseNames[s.phase] ?? 'Init'} | Pot: ${s.pot}`);
-        for (const p of s.players) {
-          const tag = p.isHuman ? 'You' : `CPU ${p.id}`;
-          const door = p.doorCards.map((c) => `${c.design[0]}${c.value}`).join(' ');
-          const hole = p.holeCards.map((c) => `${c.design[0]}${c.value}`).join(' ');
-          lines.push(
-            `${tag}: chips=${p.chips} door=[${door}] hole=[${hole}]${p.folded ? ' FOLDED' : ''}${p.allIn ? ' ALL-IN' : ''}`,
-          );
-        }
-        if (s.message) lines.push(s.message);
-        return lines.join('\n');
-      },
-      helpText: [
-        'f/fold      - Fold',
-        'ck/check    - Check',
-        'c/call      - Call',
-        'b/bet <amt> - Bet',
-        'ra/raise <amt> - Raise',
-        'a/allin     - All-in',
-        'rebuy       - Rebuy chips',
-        'skiprebuy   - Skip rebuy',
-        'addon       - Add-on chips',
-        'skipaddon   - Skip add-on',
-        'muck        - Muck hand',
-        'show        - Show hand',
-        'r/reset     - Reset game',
-      ],
+      parseCommand: parseFiveCardStudCommand,
+      formatResponse: (s: FiveCardStudResponse) => formatFiveCardStudState(s, phaseNames),
+      helpText: FIVECARDSTUD_HELP,
     }),
     [phaseNames],
   );

--- a/frontend/src/utils/cli/commands/fiveCardStudCommands.test.ts
+++ b/frontend/src/utils/cli/commands/fiveCardStudCommands.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { parseFiveCardStudCommand } from './fiveCardStudCommands';
+
+describe('parseFiveCardStudCommand', () => {
+  it('parses no-argument commands', () => {
+    expect(parseFiveCardStudCommand('fold')).toEqual({ args: ['fold', undefined] });
+    expect(parseFiveCardStudCommand('check')).toEqual({ args: ['check', undefined] });
+    expect(parseFiveCardStudCommand('call')).toEqual({ args: ['call', undefined] });
+    expect(parseFiveCardStudCommand('allin')).toEqual({ args: ['allin', undefined] });
+    expect(parseFiveCardStudCommand('reset')).toEqual({ args: ['reset', undefined] });
+  });
+
+  it('parses the rebuy/addon lifecycle commands', () => {
+    expect(parseFiveCardStudCommand('rebuy')).toEqual({ args: ['rebuy', undefined] });
+    expect(parseFiveCardStudCommand('skiprebuy')).toEqual({ args: ['skiprebuy', undefined] });
+    expect(parseFiveCardStudCommand('addon')).toEqual({ args: ['addon', undefined] });
+    expect(parseFiveCardStudCommand('skipaddon')).toEqual({ args: ['skipaddon', undefined] });
+    expect(parseFiveCardStudCommand('muck')).toEqual({ args: ['muck', undefined] });
+    expect(parseFiveCardStudCommand('show')).toEqual({ args: ['show', undefined] });
+  });
+
+  it('parses bet and raise with an amount', () => {
+    expect(parseFiveCardStudCommand('bet 50')).toEqual({ args: ['bet', 50] });
+    expect(parseFiveCardStudCommand('raise 100')).toEqual({ args: ['raise', 100] });
+  });
+
+  it('is case-insensitive for the command token', () => {
+    expect(parseFiveCardStudCommand('FOLD')).toEqual({ args: ['fold', undefined] });
+    expect(parseFiveCardStudCommand('Bet 20')).toEqual({ args: ['bet', 20] });
+  });
+
+  it('errors on an unknown command', () => {
+    expect(parseFiveCardStudCommand('zzz')).toEqual({ error: 'Unknown command: zzz' });
+    // Aliases are not parsed (behavior preserved from the original inline parser).
+    expect('error' in parseFiveCardStudCommand('f')).toBe(true);
+  });
+});

--- a/frontend/src/utils/cli/commands/fiveCardStudCommands.ts
+++ b/frontend/src/utils/cli/commands/fiveCardStudCommands.ts
@@ -1,0 +1,50 @@
+import type { fiveCardStudApi } from '../../../api/gameApi';
+import type { CliParseResult } from '../types';
+
+type FiveCardStudArgs = Parameters<typeof fiveCardStudApi.exec>;
+
+const VALID_COMMANDS = [
+  'reset',
+  'fold',
+  'check',
+  'call',
+  'bet',
+  'raise',
+  'allin',
+  'rebuy',
+  'skiprebuy',
+  'addon',
+  'skipaddon',
+  'muck',
+  'show',
+] as const;
+
+type FiveCardStudCommand = (typeof VALID_COMMANDS)[number];
+
+/** Parse a Five Card Stud CLI command into API exec arguments. */
+export function parseFiveCardStudCommand(input: string): CliParseResult<FiveCardStudArgs> {
+  const parts = input.trim().split(/\s+/);
+  const cmd = parts[0]?.toLowerCase() ?? '';
+  const amount = parts[1] ? Number.parseInt(parts[1], 10) : undefined;
+  if ((VALID_COMMANDS as readonly string[]).includes(cmd)) {
+    return { args: [cmd as FiveCardStudCommand, amount] as FiveCardStudArgs };
+  }
+  return { error: `Unknown command: ${cmd}` };
+}
+
+/** Help text for Five Card Stud CLI mode. */
+export const FIVECARDSTUD_HELP: string[] = [
+  'f/fold      - Fold',
+  'ck/check    - Check',
+  'c/call      - Call',
+  'b/bet <amt> - Bet',
+  'ra/raise <amt> - Raise',
+  'a/allin     - All-in',
+  'rebuy       - Rebuy chips',
+  'skiprebuy   - Skip rebuy',
+  'addon       - Add-on chips',
+  'skipaddon   - Skip add-on',
+  'muck        - Muck hand',
+  'show        - Show hand',
+  'r/reset     - Reset game',
+];

--- a/frontend/src/utils/cli/formatters/fiveCardStudFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/fiveCardStudFormatter.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, FiveCardStudPlayerData, FiveCardStudResponse } from '../../../types/card';
+import { formatFiveCardStudState } from './fiveCardStudFormatter';
+
+const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+const player = (over: Partial<FiveCardStudPlayerData> = {}): FiveCardStudPlayerData => ({
+  id: 0,
+  isHuman: true,
+  holeCards: [card('SPADE', 5)],
+  doorCards: [card('HEART', 10), card('DIAMOND', 12)],
+  chips: 1000,
+  currentBet: 0,
+  folded: false,
+  allIn: false,
+  handRank: 0,
+  handName: '',
+  bestHand: [],
+  playStyleName: '',
+  totalHands: 0,
+  vpip: 0,
+  pfr: 0,
+  threeBet: 0,
+  af: '',
+  ...over,
+});
+
+const baseState = (over: Partial<FiveCardStudResponse> = {}): FiveCardStudResponse =>
+  ({
+    message: '',
+    players: [player(), player({ id: 1, isHuman: false })],
+    pot: 40,
+    phase: 1,
+    ...over,
+  }) as FiveCardStudResponse;
+
+const phaseNames: Record<number, string> = { 1: 'Second Street' };
+
+describe('formatFiveCardStudState', () => {
+  it('renders the phase, pot, and each player line', () => {
+    const out = formatFiveCardStudState(baseState(), phaseNames);
+    expect(out).toContain('Phase: Second Street | Pot: 40');
+    expect(out).toContain('You: chips=1000 door=[H10 D12] hole=[S5]');
+    expect(out).toContain('CPU 1:');
+  });
+
+  it('falls back to "Init" for an unknown phase', () => {
+    const out = formatFiveCardStudState(baseState({ phase: 99 }), phaseNames);
+    expect(out).toContain('Phase: Init');
+  });
+
+  it('tags folded and all-in players', () => {
+    const out = formatFiveCardStudState(
+      baseState({
+        players: [player({ folded: true }), player({ id: 1, isHuman: false, allIn: true })],
+      }),
+      phaseNames,
+    );
+    expect(out).toContain('FOLDED');
+    expect(out).toContain('ALL-IN');
+  });
+
+  it('appends a server message when present', () => {
+    const out = formatFiveCardStudState(baseState({ message: 'Your turn' }), phaseNames);
+    expect(out).toContain('Your turn');
+  });
+});

--- a/frontend/src/utils/cli/formatters/fiveCardStudFormatter.ts
+++ b/frontend/src/utils/cli/formatters/fiveCardStudFormatter.ts
@@ -1,0 +1,22 @@
+import type { FiveCardStudResponse } from '../../../types/card';
+
+/**
+ * Format a Five Card Stud game state as terminal text.
+ *
+ * @param s - The current game state.
+ * @param phaseNames - Phase-index → localized phase label lookup (from `usePhaseNames`).
+ */
+export function formatFiveCardStudState(s: FiveCardStudResponse, phaseNames: Record<number, string>): string {
+  const lines: string[] = [];
+  lines.push(`Phase: ${phaseNames[s.phase] ?? 'Init'} | Pot: ${s.pot}`);
+  for (const p of s.players) {
+    const tag = p.isHuman ? 'You' : `CPU ${p.id}`;
+    const door = p.doorCards.map((c) => `${c.design[0]}${c.value}`).join(' ');
+    const hole = p.holeCards.map((c) => `${c.design[0]}${c.value}`).join(' ');
+    lines.push(
+      `${tag}: chips=${p.chips} door=[${door}] hole=[${hole}]${p.folded ? ' FOLDED' : ''}${p.allIn ? ' ALL-IN' : ''}`,
+    );
+  }
+  if (s.message) lines.push(s.message);
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
`FiveCardStudPage.tsx` defined its CLI `parseCommand` / `formatResponse` / `helpText` inline as a ~60-line `useMemo`, which couldn't be unit-tested and bloated the component. This moves them into the standard `utils/cli` layout, matching every other CLI-mode game — with **no behavior change**.

- `utils/cli/commands/fiveCardStudCommands.ts` — `parseFiveCardStudCommand` (+ `FIVECARDSTUD_HELP`), extracted verbatim (still accepts only the full command names, still returns `Unknown command: <cmd>`).
- `utils/cli/formatters/fiveCardStudFormatter.ts` — `formatFiveCardStudState(state, phaseNames)`; `phaseNames` is threaded in from the page's `usePhaseNames` so the output (including the `Init` fallback and `FOLDED`/`ALL-IN` tags) is identical.
- `FiveCardStudPage.tsx` — now imports the two functions; the `cliConfig` `useMemo` is a thin wrapper. Removed the now-unused `CliParseResult` import.

## Test plan
- [x] `bun run test -- --run fiveCardStud` (new command + formatter unit tests)
- [x] `bun run test -- --run pages/FiveCardStudPage` (existing page test still green — behavior unchanged)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #3566