### PR TITLE
feat(mighty): show kitty cards in the CUI exchange phase

### DIFF
--- a/internal/adapter/presenter/MightyCuiPresenter.go
+++ b/internal/adapter/presenter/MightyCuiPresenter.go
@@ -71,6 +71,36 @@ func mightyPlayerStr(player *domain.MightyPlayer, i int, partnerRevealed bool) s
 // MightyCuiPresenter renders the Mighty CUI view.
 type MightyCuiPresenter struct{}
 
+// mightyKittyLine returns an indexed list of the kitty cards as they now sit in
+// the declarer's hand (the kitty is merged in when this phase begins), so the CUI
+// player can see exactly which hand indices to discard. Returns "" when there is
+// no human-visible kitty to show. The indices shown match those the `e` (exchange)
+// command consumes.
+func mightyKittyLine(m interfaces.MightyGame) string {
+	declarer := m.GetPlayer(m.GetDeclarerIdx())
+	if declarer == nil {
+		return ""
+	}
+	kitty := m.GetKitty()
+	parts := make([]string, 0, len(kitty))
+	for _, kc := range kitty {
+		if kc == nil {
+			continue
+		}
+		for i := 0; i < declarer.GetCardsSize(); i++ {
+			hc := declarer.GetCard(i)
+			if hc != nil && hc.GetDesign() == kc.GetDesign() && hc.GetValue() == kc.GetValue() {
+				parts = append(parts, "["+strconv.Itoa(i)+"]"+mightyCuiCardStr(hc))
+				break
+			}
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return i18n.T("mighty.promptKittyCards") + " " + strings.Join(parts, "  ")
+}
+
 // Output renders the current game state for the active locale.
 func (p *MightyCuiPresenter) Output(m interfaces.MightyGame, lastErr error) string {
 	return buildCuiOutput(i18n.T("mighty.helpTitle"), func(b *strings.Builder) {
@@ -139,6 +169,9 @@ func (p *MightyCuiPresenter) Output(m interfaces.MightyGame, lastErr error) stri
 			b.WriteString(i18n.T("mighty.promptTrumpSuitLegend") + "\n")
 		case domain.MightyPhaseKittyExchange:
 			b.WriteString(i18n.T("mighty.promptKittyHeader") + "\n")
+			if line := mightyKittyLine(m); line != "" {
+				b.WriteString(line + "\n")
+			}
 			b.WriteString(i18n.T("mighty.promptKittyHelp") + "\n")
 		case domain.MightyPhasePlay:
 			currentIdx := m.GetCurrentPlayerIdx()

--- a/internal/adapter/presenter/MightyCuiPresenter_test.go
+++ b/internal/adapter/presenter/MightyCuiPresenter_test.go
@@ -34,6 +34,8 @@ func setupMightyCuiMock() *interfaces.MockMightyGame {
 	m.On("GetLeadPlayerIdx").Return(0)
 	m.On("GetConfig").Return(domain.DefaultMightyConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+	m.On("GetDeclarerIdx").Return(0)
+	m.On("GetKitty").Return([]*domain.Card{})
 	return m
 }
 
@@ -196,6 +198,29 @@ func TestMightyCuiPresenter_Output(t *testing.T) {
 		m.On("GetWinnerTeam").Return(domain.MightyWinnerOpposition)
 		result := p.Output(m, nil)
 		assert.Contains(t, result, "野党")
+	})
+
+	t.Run("kitty phase lists kitty cards with hand indices", func(t *testing.T) {
+		m, players := setupMightyCuiMockWithPlayers()
+		// Declarer (player 0, human) hand — the kitty is merged in and sorted.
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 1, false))  // idx 0
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 5, false))  // idx 1
+		players[0].AddCard(domain.NewCard(domain.CardDesignClover, 9, false)) // idx 2
+		kitty := []*domain.Card{
+			domain.NewCard(domain.CardDesignHeart, 5, false),
+			domain.NewCard(domain.CardDesignClover, 9, false),
+		}
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.MightyPhaseKittyExchange)
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetKitty")
+		m.On("GetKitty").Return(kitty)
+
+		result := p.Output(m, nil)
+		assert.Contains(t, result, "キティのカード")
+		// The kitty cards are shown at their positions in the declarer's hand,
+		// matching the indices the `e` (exchange) command consumes.
+		assert.Contains(t, result, "[1]HEART 5")
+		assert.Contains(t, result, "[2]CLOVER 9")
 	})
 
 	t.Run("phase prompts", func(t *testing.T) {

--- a/internal/adapter/presenter/MightyCuiPresenter_test.go
+++ b/internal/adapter/presenter/MightyCuiPresenter_test.go
@@ -208,6 +208,7 @@ func TestMightyCuiPresenter_Output(t *testing.T) {
 		players[0].AddCard(domain.NewCard(domain.CardDesignClover, 9, false)) // idx 2
 		kitty := []*domain.Card{
 			domain.NewCard(domain.CardDesignHeart, 5, false),
+			nil, // defensive: a nil kitty entry is skipped
 			domain.NewCard(domain.CardDesignClover, 9, false),
 		}
 		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
@@ -221,6 +222,23 @@ func TestMightyCuiPresenter_Output(t *testing.T) {
 		// matching the indices the `e` (exchange) command consumes.
 		assert.Contains(t, result, "[1]HEART 5")
 		assert.Contains(t, result, "[2]CLOVER 9")
+	})
+
+	t.Run("kitty line omitted when declarer is missing", func(t *testing.T) {
+		m, _ := setupMightyCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.MightyPhaseKittyExchange)
+		// Declarer index points at an absent player → GetPlayer returns nil.
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetDeclarerIdx")
+		m.On("GetDeclarerIdx").Return(9)
+		m.On("GetPlayer", 9).Return((*domain.MightyPlayer)(nil))
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetKitty")
+		m.On("GetKitty").Return([]*domain.Card{domain.NewCard(domain.CardDesignSpade, 1, false)})
+
+		result := p.Output(m, nil)
+		// No kitty line, but the phase prompt still renders.
+		assert.NotContains(t, result, "キティのカード")
+		assert.Contains(t, result, "場札")
 	})
 
 	t.Run("phase prompts", func(t *testing.T) {

--- a/internal/i18n/locales/en/mighty.json
+++ b/internal/i18n/locales/en/mighty.json
@@ -32,6 +32,7 @@
   "promptTrumpDeclareHelp": "Command: t <suit> <partnerSuit> <partnerVal>",
   "promptTrumpSuitLegend": "  suit: -1=No-Trump 1=♠ 2=♣ 3=♥ 4=♦   partnerSuit: 0=Joker 1=♠ 2=♣ 3=♥ 4=♦",
   "promptKittyHeader": "Kitty merged into your hand. Discard 3 cards.",
+  "promptKittyCards": "Kitty cards (positions in your hand):",
   "promptKittyHelp": "Command: e <i> <j> <k>",
   "promptPlayTurn": "Play phase: {{name}}'s turn",
   "promptPlayHelp": "Command: p <idx>   To lead the Joker: jl <idx> <suit>",

--- a/internal/i18n/locales/ja/mighty.json
+++ b/internal/i18n/locales/ja/mighty.json
@@ -32,6 +32,7 @@
   "promptTrumpDeclareHelp": "コマンド: t <suit> <partnerSuit> <partnerVal>",
   "promptTrumpSuitLegend": "  suit: -1=No-Trump 1=♠ 2=♣ 3=♥ 4=♦   partnerSuit: 0=Joker 1=♠ 2=♣ 3=♥ 4=♦",
   "promptKittyHeader": "場札(キティ)が手札に加わりました。3枚を捨ててください",
+  "promptKittyCards": "キティのカード(手札内の位置):",
   "promptKittyHelp": "コマンド: e <i> <j> <k>",
   "promptPlayTurn": "プレイフェーズ: {{name}}の番",
   "promptPlayHelp": "コマンド: p <idx>   ジョーカーをリードする時は jl <idx> <suit>",


### PR DESCRIPTION
## Summary
In Mighty's kitty-exchange phase, the CUI only printed the `promptKittyHeader`/`promptKittyHelp` prompts — it never showed the kitty. The Web version highlights the kitty cards, so CUI players had to discard 3 cards blind. The kitty is merged (and sorted) into the declarer's hand on entering this phase, so the newly-added cards are invisible among the other 13.

- `MightyCuiPresenter.go` — adds `mightyKittyLine`, which locates each kitty card in the declarer's now-merged hand and renders it as `[i]CARD`. The indices shown are the declarer's hand indices — exactly what the `e <i> <j> <k>` exchange command consumes (acceptance criterion #3).
- `mighty.json` (ja/en) — new `promptKittyCards` label.
- `MightyCuiPresenter_test.go` — asserts the kitty cards appear at their hand indices; the base mock now stubs `GetDeclarerIdx`/`GetKitty`.

## Test plan
- [x] `go test -tags test ./...`
- [x] `golangci-lint run` on the presenter package (0 issues)
- [x] `GOOS=js GOARCH=wasm go build -tags casino` (mighty is in the `casino` worker)

Closes #3269