### PR TITLE
feat(koikoi): show shobu stakes and both scores in the CUI decision prompt

### DIFF
--- a/internal/adapter/presenter/KoiKoiCuiPresenter.go
+++ b/internal/adapter/presenter/KoiKoiCuiPresenter.go
@@ -87,6 +87,34 @@ func koikoiPlayerStr(g interfaces.KoiKoiGame, idx int) string {
 	return b.String()
 }
 
+// koikoiDecisionInfoStr describes the stakes of a koi-koi / shobu decision:
+// the points locked in by calling shobu now (pending × the koi-koi multiplier)
+// and both players' current cumulative scores, so the CLI player can weigh the
+// reward against the risk of being overtaken by continuing.
+func koikoiDecisionInfoStr(g interfaces.KoiKoiGame) string {
+	// Calling shobu now scores pending × 2 once any koi-koi has been declared
+	// this round (mirrors KoiKoi.endRound).
+	mult := 1
+	if g.GetKoikoiCount() >= 1 {
+		mult = 2
+	}
+	confirmed := g.GetPendingPoints() * mult
+
+	humanIdx, oppIdx := 0, 1
+	for i := 0; i < g.GetPlayerCnt(); i++ {
+		if g.GetPlayer(i).GetIsHuman() {
+			humanIdx = i
+			oppIdx = (i + 1) % g.GetPlayerCnt()
+			break
+		}
+	}
+	return i18n.Tf("koikoi.promptDecisionInfo",
+		"confirmed", strconv.Itoa(confirmed),
+		"mult", strconv.Itoa(mult),
+		"you", strconv.Itoa(g.GetPlayer(humanIdx).GetScore()),
+		"opp", strconv.Itoa(g.GetPlayer(oppIdx).GetScore()))
+}
+
 // Output renders the current game state for the active locale.
 func (p *KoiKoiCuiPresenter) Output(g interfaces.KoiKoiGame, lastErr error) string {
 	return buildCuiOutput(i18n.T("koikoi.helpTitle"), func(b *strings.Builder) {
@@ -112,6 +140,7 @@ func (p *KoiKoiCuiPresenter) Output(g interfaces.KoiKoiGame, lastErr error) stri
 			b.WriteString(i18n.Tf("koikoi.promptDecision",
 				"yaku", koikoiYakuStr(g.GetPendingYaku()),
 				"points", strconv.Itoa(g.GetPendingPoints())) + "\n")
+			b.WriteString(koikoiDecisionInfoStr(g) + "\n")
 		case domain.KoiKoiPhaseRoundEnd:
 			b.WriteString(koikoiRoundResultStr(g) + "\n")
 		case domain.KoiKoiPhaseGameEnd:

--- a/internal/adapter/presenter/KoiKoiCuiPresenter_test.go
+++ b/internal/adapter/presenter/KoiKoiCuiPresenter_test.go
@@ -21,6 +21,26 @@ func TestKoiKoiCuiPresenter_Output_PlayPhase(t *testing.T) {
 	assert.Contains(t, out, "[0]") // human indexed hand + indexed field
 }
 
+func TestKoiKoiCuiPresenter_Output_DecisionInfo(t *testing.T) {
+	p := new(presenter.KoiKoiCuiPresenter)
+
+	g := domain.NewDefaultKoiKoi()
+	g.Reset()
+	g.SetPhase(domain.KoiKoiPhaseKoiKoiDecision)
+
+	// No koi-koi yet → the shobu multiplier is x1 (ja locale renders "倍率×1").
+	out := p.Output(g, nil)
+	assert.Contains(t, out, "×1")
+	// Both players' current cumulative scores are shown.
+	assert.Contains(t, out, "あなた")
+	assert.Contains(t, out, "相手")
+
+	// Once a koi-koi has been declared this round, the multiplier becomes x2.
+	g.SetKoikoiCount(1)
+	out = p.Output(g, nil)
+	assert.Contains(t, out, "×2")
+}
+
 func TestKoiKoiCuiPresenter_Output_AllPhases(t *testing.T) {
 	p := new(presenter.KoiKoiCuiPresenter)
 

--- a/internal/domain/KoiKoi.go
+++ b/internal/domain/KoiKoi.go
@@ -1017,6 +1017,9 @@ func (g *KoiKoi) GetCurrentTurn() int { return g.state.currentTurn }
 // SetCurrentTurn は現在の手番を設定する (テスト用)。
 func (g *KoiKoi) SetCurrentTurn(idx int) { g.state.currentTurn = idx }
 
+// SetKoikoiCount はこのラウンドのこいこい宣言回数を設定する (テスト用)。
+func (g *KoiKoi) SetKoikoiCount(n int) { g.state.koikoiCount = n }
+
 // GetFieldCards は場札を返す。
 func (g *KoiKoi) GetFieldCards() []*Card { return g.state.fieldCards }
 

--- a/internal/i18n/locales/en/koikoi.json
+++ b/internal/i18n/locales/en/koikoi.json
@@ -10,6 +10,7 @@
   "playerLine": "{{name}}: hand {{hand}}  captured: {{captured}}  score: {{score}}  yaku: {{yaku}} [{{points}}]",
   "promptPlay": "Turn: {{name}}",
   "promptDecision": "Yaku formed: {{yaku}} = {{points}} pts. Type kk (Koi-Koi) to continue, sb (Shobu) to score now.",
+  "promptDecisionInfo": "Shobu locks in {{confirmed}} pts (x{{mult}}) — current totals: you {{you}} vs opponent {{opp}}.",
   "promptGameEnd": "Game over. Type nr to start a new game.",
   "promptHelp": "p <h> [f] to play (f = field card on a 2-way match). kk=Koi-Koi, sb=Shobu, nr=next",
   "roundWin": "{{name}} wins the round! {{yaku}} -> {{total}} pts (x{{mult}})",

--- a/internal/i18n/locales/ja/koikoi.json
+++ b/internal/i18n/locales/ja/koikoi.json
@@ -10,6 +10,7 @@
   "playerLine": "{{name}}: 手札{{hand}}枚  取り札: {{captured}}  得点: {{score}}  役: {{yaku}} [{{points}}]",
   "promptPlay": "手番: {{name}}",
   "promptDecision": "役成立: {{yaku}} = {{points}}点。kk（こいこい）で続行、sb（勝負）で確定。",
+  "promptDecisionInfo": "勝負なら確定 {{confirmed}}点（倍率×{{mult}}） — 現在の累計 あなた{{you}} 対 相手{{opp}}",
   "promptGameEnd": "ゲーム終了。nr で新しいゲームを始めます。",
   "promptHelp": "p <h> [f] でプレイ（f は 2 枚一致時の場札）。kk=こいこい, sb=勝負, nr=次へ",
   "roundWin": "{{name}} がラウンド勝利！ {{yaku}} → {{total}}点（×{{mult}}）",


### PR DESCRIPTION
## Summary
Koi-Koi's koi-koi/shobu decision prompt only listed the formed yaku and its pending points. It never told the CLI player what calling shobu *now* would actually bank (pending × the koi-koi multiplier) nor how the two players' cumulative totals compare — the risk information the Web `koikoi-decision` panel conveys.

- `KoiKoiCuiPresenter.go` — adds `koikoiDecisionInfoStr`, printed under the decision prompt: the points locked in by calling shobu now (`pendingPoints × mult`, where `mult` is 2 once any koi-koi has been declared this round, mirroring `KoiKoi.endRound`) plus both players' current cumulative scores.
- `koikoi.json` (ja/en) — new `promptDecisionInfo` key.
- `KoiKoi.go` — adds a `SetKoikoiCount` test-only setter (matching the existing `SetPhase`/`SetCurrentTurn` helpers).
- `KoiKoiCuiPresenter_test.go` — covers both the ×1 and ×2 multiplier paths.

## Test plan
- [x] `go test -tags test ./...`
- [x] `golangci-lint run` on the changed packages (0 issues)
- [x] `GOOS=js GOARCH=wasm go build -tags extra` (koikoi is in the `extra` worker)

Closes #3518