### PR TITLE
feat(doppelkopf): add a web hint-request button

### DIFF
--- a/frontend/src/hooks/useDoppelkopfGame.test.ts
+++ b/frontend/src/hooks/useDoppelkopfGame.test.ts
@@ -56,6 +56,15 @@ describe('useDoppelkopfGame', () => {
     expect(mockExec).toHaveBeenCalledWith('announce');
   });
 
+  it('handleHint dispatches the hint command and toggles hintLoading', async () => {
+    const { result } = renderHook(() => useDoppelkopfGame(), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.handleHint();
+    });
+    expect(mockExec).toHaveBeenCalledWith('hint');
+    expect(result.current.hintLoading).toBe(false);
+  });
+
   it('handleNextTrick / handleNextRound dispatch their commands', async () => {
     const { result } = renderHook(() => useDoppelkopfGame(), { wrapper: createWrapper() });
     await act(async () => {

--- a/frontend/src/hooks/useDoppelkopfGame.ts
+++ b/frontend/src/hooks/useDoppelkopfGame.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { type DoppelkopfConfigInput, doppelkopfApi } from '../api/gameApi';
 import { useCardSelection } from './useCardSelection';
 import { useGameApi } from './useGameApi';
@@ -39,6 +39,18 @@ export function useDoppelkopfGame() {
   }, [clearSelection]);
 
   const { state, loading, error, exec, retry } = useGameApi(doppelkopfApi.exec, { onSuccess });
+
+  const [hintLoading, setHintLoading] = useState(false);
+
+  /** Requests a play hint from the server; guards against double-clicks. */
+  const handleHint = useCallback(async () => {
+    setHintLoading(true);
+    try {
+      await exec('hint');
+    } finally {
+      setHintLoading(false);
+    }
+  }, [exec]);
 
   /** Resets the game, applying the current config. */
   const reset = useCallback(() => {
@@ -82,5 +94,7 @@ export function useDoppelkopfGame() {
     handleAnnounce,
     handleNextTrick,
     handleNextRound,
+    handleHint,
+    hintLoading,
   };
 }

--- a/frontend/src/pages/DoppelkopfPage.test.tsx
+++ b/frontend/src/pages/DoppelkopfPage.test.tsx
@@ -81,6 +81,15 @@ describe('DoppelkopfPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', { cardIndex: 0 }));
   });
 
+  it('shows the hint button on the human turn and requests a hint', async () => {
+    renderWithProviders(<DoppelkopfPage />);
+    const hintBtn = await screen.findByRole('button', { name: 'ヒント' });
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(playPhaseState);
+    fireEvent.click(hintBtn);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
+  });
+
   it('shows the Re announce button when the human is Re and can announce', async () => {
     mockExec.mockResolvedValue(announceState);
     renderWithProviders(<DoppelkopfPage />);

--- a/frontend/src/pages/DoppelkopfPage.tsx
+++ b/frontend/src/pages/DoppelkopfPage.tsx
@@ -90,6 +90,8 @@ function DoppelkopfPageContent() {
     handleAnnounce,
     handleNextTrick,
     handleNextRound,
+    handleHint,
+    hintLoading,
   } = useDoppelkopfGame();
 
   // Fetch a fresh game on mount.
@@ -321,6 +323,11 @@ function DoppelkopfPageContent() {
                   disabled={loading || selectedCardIndices.length !== 1}
                 >
                   {t('playButton')}
+                </button>
+              )}
+              {canPlay && (
+                <button type="button" className={btnSuccess} onClick={handleHint} disabled={loading || hintLoading}>
+                  {tc('button.hint')}
                 </button>
               )}
               {state.canAnnounce && (


### PR DESCRIPTION
## Summary
Doppelkopf's hint logic already exists server-side (the CUI `HintOutput` shows a recommended card + reason), and `DoppelkopfPage` already renders `state.hint` passively — but there was no button to *request* a hint, so Web players couldn't reach it (gongzhu / tressette have a hint button).

- `useDoppelkopfGame.ts` — adds `handleHint` (`exec('hint')`) with a `hintLoading` flag to suppress double-clicks.
- `DoppelkopfPage.tsx` — renders a `tc('button.hint')` button in the action row during the human's play turn (`canPlay`), disabled while loading; the recommended card + reason then appear via the existing `state.hint` block.
- Tests — hook test for `handleHint`/`hintLoading`; page test asserting the button appears on the human turn and dispatches `hint`.

## Test plan
- [x] `bun run test -- --run doppelkopf` (22 tests across 3 files)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #3404