### PR TITLE
feat(openfacechinese): add a web hint button and suggested-row display

### DIFF
--- a/frontend/src/i18n/locales/en/openfacechinese.json
+++ b/frontend/src/i18n/locales/en/openfacechinese.json
@@ -23,6 +23,13 @@
   "fantasyland": "Fantasyland reached!",
   "roundEndTitle": "Round over",
   "next": "Next round",
+  "hint": {
+    "button": "Hint",
+    "text": "Suggested: {{row}} — {{reason}}",
+    "strong_back": "Weight your strongest cards to the bottom",
+    "weak_front": "Keep the top row weak to stay safe",
+    "balance": "Balance the rows"
+  },
   "gameEnd": "Game over",
   "phase": {
     "placing": "Placing",

--- a/frontend/src/i18n/locales/ja/openfacechinese.json
+++ b/frontend/src/i18n/locales/ja/openfacechinese.json
@@ -23,6 +23,13 @@
   "fantasyland": "ファンタジーランド達成！",
   "roundEndTitle": "ラウンド終了",
   "next": "次のラウンドへ",
+  "hint": {
+    "button": "ヒント",
+    "text": "推奨: {{row}} — {{reason}}",
+    "strong_back": "強い組み合わせはボトムに寄せましょう",
+    "weak_front": "トップは弱めにまとめて安全に",
+    "balance": "バランス良く配置しましょう"
+  },
   "gameEnd": "ゲーム終了",
   "phase": {
     "placing": "配置",

--- a/frontend/src/pages/OpenFaceChinesePage.test.tsx
+++ b/frontend/src/pages/OpenFaceChinesePage.test.tsx
@@ -192,4 +192,19 @@ describe('OpenFaceChinesePage', () => {
     await waitFor(() => expect(screen.getByRole('log')).toBeInTheDocument());
     expect(screen.queryByTestId('place-front')).not.toBeInTheDocument();
   });
+
+  it('dispatches hint when the hint button is clicked', async () => {
+    renderWithProviders(<OpenFaceChinesePage />);
+    const btn = await screen.findByRole('button', { name: 'ヒント' });
+    mockExec.mockClear();
+    fireEvent.click(btn);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
+  });
+
+  it('renders the suggested row and reason when a hint is present', async () => {
+    mockExec.mockResolvedValue(makeState({ hint: { row: 2, reason: 'strong_back' } }));
+    renderWithProviders(<OpenFaceChinesePage />);
+    const hint = await screen.findByTestId('ofc-hint');
+    expect(hint).toHaveTextContent('強い組み合わせはボトムに寄せましょう');
+  });
 });

--- a/frontend/src/pages/OpenFaceChinesePage.tsx
+++ b/frontend/src/pages/OpenFaceChinesePage.tsx
@@ -117,6 +117,8 @@ function OpenFaceChinesePageContent() {
 
   const handlePlace = (row: number) => exec('place', { row });
   const handleNext = () => exec('nextround');
+  const handleHint = () => exec('hint');
+  const rowNames = ['front', 'middle', 'back'] as const;
 
   const playerName = (player: OpenFaceChinesePlayer) => (player.isHuman ? t('you') : t('cpu', { n: player.id }));
 
@@ -221,7 +223,18 @@ function OpenFaceChinesePageContent() {
                   >
                     {t('place.back')}
                   </button>
+                  <button type="button" className={btnSuccess} onClick={handleHint} disabled={loading}>
+                    {t('hint.button')}
+                  </button>
                 </div>
+                {state.hint && (
+                  <p className="text-center text-sm text-ds-accent mt-1" data-testid="ofc-hint">
+                    {t('hint.text', {
+                      row: t(`rows.${rowNames[state.hint.row] ?? 'back'}`),
+                      reason: t(`hint.${state.hint.reason}`),
+                    })}
+                  </p>
+                )}
               </div>
             )}
 


### PR DESCRIPTION
## Summary
Open Face Chinese Poker already has server hints (`hint` command, `OpenFaceChineseResponse.hint`, `OpenFaceChineseWebPresenter.HintOutput`), but `OpenFaceChinesePage` never exposed them — Web players couldn't ask which row to place the pending card.

- `OpenFaceChinesePage.tsx` — adds `handleHint` (`exec('hint')`), a hint button beside the place buttons (shown while the human can place), and a hint line that renders `state.hint`: the suggested row (top/middle/bottom) plus its translated reason.
- `openfacechinese.json` (ja/en) — a `hint` block with `button` / `text` and one entry per CUI reason (`strong_back` / `weak_front` / `balance`).
- `OpenFaceChinesePage.test.tsx` — asserts the button dispatches `hint` and the suggested-row text renders.

Backend already has hint output + tests, so no backend change is needed.

## Test plan
- [x] `bun run test -- --run OpenFaceChinese` (29 tests)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #3572