### PR TITLE
feat(spiteandmalice): display the hint reason via HintTooltip

### DIFF
--- a/frontend/src/pages/SpiteAndMalicePage.test.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.test.tsx
@@ -248,4 +248,16 @@ describe('SpiteAndMalicePage', () => {
     await waitFor(() => expect(screen.getAllByText(/ゲームオーバー|Game Over/).length).toBeGreaterThan(0));
     expect(screen.queryByTestId('sam-autocomplete-btn')).not.toBeInTheDocument();
   });
+
+  it('shows the HintTooltip reason when hints are enabled and a hint is available', async () => {
+    mockExec.mockResolvedValue({
+      ...baseState,
+      hint: { source: 'goal', index: 0, foundationIdx: 0, discard: false },
+    });
+    renderWithProviders(<SpiteAndMalicePage />);
+    const toggle = await screen.findByRole('checkbox', { name: 'ヒント表示' });
+    if (!(toggle as HTMLInputElement).checked) fireEvent.click(toggle);
+    const tooltip = await screen.findByTestId('hint-tooltip');
+    expect(tooltip).toHaveTextContent('ゴールパイルのトップをファウンデーションに出せます');
+  });
 });

--- a/frontend/src/pages/SpiteAndMalicePage.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.tsx
@@ -9,6 +9,7 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { HintTooltip } from '../components/hint/HintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
@@ -280,6 +281,9 @@ function SpiteAndMalicePageContent() {
               },
             ]}
           />
+          {hintEnabled && currentHint ? (
+            <HintTooltip reason={t(currentHint.reason)} confidence={currentHint.confidence} />
+          ) : null}
           <LandscapeBanner message={t('landscapeBanner', { defaultValue: '' })} />
 
           <div className="flex-1 overflow-y-auto pt-3 px-2 sm:px-4 lg:px-8 space-y-4">


### PR DESCRIPTION
## Summary
`SpiteAndMalicePage` already computes a frontend hint via `useGameHint('spiteandmalice', state)` and uses it for ring highlights, but it never imported/rendered `<HintTooltip>` — so players saw which card glows yet not *why* it's recommended (reason + confidence), unlike nearly every other game.

- `SpiteAndMalicePage.tsx` — imports `HintTooltip` and renders it (below the settings/hint toggle) when `hintEnabled && currentHint`, passing the translated reason and confidence. The existing highlight logic is untouched.
- `SpiteAndMalicePage.test.tsx` — asserts the tooltip appears with the translated reason once hints are enabled and a hint is available.

## Test plan
- [x] `bun run test -- --run SpiteAndMalice` (32 tests)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #3211