### PR TITLE
feat(belote): show hints during the bid phase (order-up and call-trump)

### DIFF
--- a/frontend/src/i18n/locales/en/belote.json
+++ b/frontend/src/i18n/locales/en/belote.json
@@ -65,6 +65,9 @@
     "opponentTeamWin": "Opponent team wins!"
   },
   "hintPlay": "Recommended card",
+  "hintOrderUpTake": "Recommended: take",
+  "hintOrderUpPass": "Recommended: pass",
+  "hintCallSuit": "Recommended: call {{suit}}",
   "hintReason": {
     "strategic_pickup": "Take based on hand strength",
     "pass_recommended": "Pass with weak hand",

--- a/frontend/src/i18n/locales/ja/belote.json
+++ b/frontend/src/i18n/locales/ja/belote.json
@@ -65,6 +65,9 @@
     "opponentTeamWin": "相手チームの勝ち"
   },
   "hintPlay": "おすすめの一手",
+  "hintOrderUpTake": "おすすめ: 取る",
+  "hintOrderUpPass": "おすすめ: パス",
+  "hintCallSuit": "おすすめ: {{suit}}を宣言",
   "hintReason": {
     "strategic_pickup": "手札が強いので取る",
     "pass_recommended": "手札が弱いのでパス",

--- a/frontend/src/pages/BelotePage.test.tsx
+++ b/frontend/src/pages/BelotePage.test.tsx
@@ -283,4 +283,27 @@ describe('BelotePage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', undefined, undefined, expect.any(Object)));
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   });
+
+  it('shows the hint button during the bid phase and requests a hint', async () => {
+    renderWithProviders(<BelotePage />); // default state is BID_PICK_UP, human's bid turn
+    const btn = await screen.findByRole('button', { name: 'ヒント' });
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(initialState);
+    fireEvent.click(btn);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('hint'));
+  });
+
+  it('renders an order-up bid hint (take/pass) after requesting it', async () => {
+    mockExec.mockResolvedValue(makeState({ hint: { orderUp: true, reason: 'strong' } }));
+    renderWithProviders(<BelotePage />);
+    fireEvent.click(await screen.findByRole('button', { name: 'ヒント' }));
+    await waitFor(() => expect(screen.getByText(/おすすめ: 取る/)).toBeInTheDocument());
+  });
+
+  it('renders a call-trump suit bid hint after requesting it', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: BelotePhase.BID_CALL_TRUMP, hint: { suit: 1, reason: 'strong' } }));
+    renderWithProviders(<BelotePage />);
+    fireEvent.click(await screen.findByRole('button', { name: 'ヒント' }));
+    await waitFor(() => expect(screen.getByText(/を宣言/)).toBeInTheDocument());
+  });
 });

--- a/frontend/src/pages/BelotePage.tsx
+++ b/frontend/src/pages/BelotePage.tsx
@@ -404,10 +404,18 @@ function BelotePageContent() {
         {hint && (
           <div className="text-ds-warning text-sm mb-2">
             {/* hint.reason is a raw backend identifier; translate via hintReason.*,
-                falling back to a generic label for any unknown reason. */}
-            {`${t('hintPlay')}: [${hint.cardIndex ?? '-'}] (${t(`hintReason.${hint.reason}`, {
-              defaultValue: t('hintReason.fallback'),
-            })})`}
+                falling back to a generic label. The hint shape depends on the phase:
+                orderUp (take/pass) and suit (call trump) during bidding, cardIndex in play. */}
+            {(() => {
+              const reason = t(`hintReason.${hint.reason}`, { defaultValue: t('hintReason.fallback') });
+              if (hint.orderUp !== undefined) {
+                return `${hint.orderUp ? t('hintOrderUpTake') : t('hintOrderUpPass')} (${reason})`;
+              }
+              if (hint.suit !== undefined) {
+                return `${t('hintCallSuit', { suit: t(SUIT_LABEL_KEYS[hint.suit]) })} (${reason})`;
+              }
+              return `${t('hintPlay')}: [${hint.cardIndex ?? '-'}] (${reason})`;
+            })()}
           </div>
         )}
 
@@ -442,20 +450,20 @@ function BelotePageContent() {
             </span>
           )}
 
+          {(isHumanTurn || isHumanBidTurn) && (
+            <button type="button" className={btnSuccess} onClick={handleHint} disabled={loading || hintLoading}>
+              {tc('button.hint')}
+            </button>
+          )}
           {isHumanTurn && (
-            <>
-              <button type="button" className={btnSuccess} onClick={handleHint} disabled={loading || hintLoading}>
-                {tc('button.hint')}
-              </button>
-              <button
-                type="button"
-                className={btnPrimary}
-                onClick={handlePlay}
-                disabled={loading || selectedCardIndices.length !== 1}
-              >
-                {t('playButton')}
-              </button>
-            </>
+            <button
+              type="button"
+              className={btnPrimary}
+              onClick={handlePlay}
+              disabled={loading || selectedCardIndices.length !== 1}
+            >
+              {t('playButton')}
+            </button>
           )}
           {isTrickEnd && (
             <button type="button" className={btnSuccess} onClick={handleNextTrick} disabled={loading}>


### PR DESCRIPTION
## Summary
Belote's domain already computes bid-phase hints (`BeloteCuiPresenter.HintOutput` handles `orderUp` take/pass and `suit` call-trump), but `BelotePage`'s hint button only rendered during the PLAY phase, and the hint text assumed `hint.cardIndex` — so the moments beginners struggle most (BID_PICK_UP / BID_CALL_TRUMP) had no hint.

- `BelotePage.tsx` — the hint button now shows when `isHumanTurn || isHumanBidTurn`; the hint text branches on hint shape: order-up (take/pass) and call-trump (declare ♠/♥/…) during bidding, card index in play.
- `belote.json` (ja/en) — `hintOrderUpTake` / `hintOrderUpPass` / `hintCallSuit` keys.
- `BelotePage.test.tsx` — asserts the bid-phase hint button dispatches `hint` and that the order-up and call-trump hint texts render.

No hook change needed — `useBeloteGame` already exposes `handleHint`/`hint` via `useTrickGameBase`.

## Test plan
- [x] `bun run test -- --run Belote` (38 tests)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #3263