### PR TITLE
feat(whist): name the hinted card and ring-highlight it in hand

### DIFF
--- a/frontend/src/pages/CatchTenPage.test.tsx
+++ b/frontend/src/pages/CatchTenPage.test.tsx
@@ -144,4 +144,13 @@ describe('CatchTenPage', () => {
     expect(team0Chips.length).toBeGreaterThan(0);
     expect(team1Chips.length).toBeGreaterThan(0);
   });
+
+  it('names the recommended card (suit + rank) in the hint text', async () => {
+    renderWithProviders(<CatchTenPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+    // cardIndex 0 in the human hand is ♠ A.
+    mockExec.mockResolvedValueOnce(makeState({ hint: { cardIndex: 0, reason: 'lead_strong' } }));
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+    await waitFor(() => expect(screen.getByText(/♠ A/)).toBeInTheDocument());
+  });
 });

--- a/frontend/src/pages/CatchTenPage.tsx
+++ b/frontend/src/pages/CatchTenPage.tsx
@@ -31,6 +31,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { CatchTenPlayerData, CatchTenResponse } from '../types/card';
 import { CatchTenPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import { CATCHTEN_HELP, parseCatchTenCommand } from '../utils/cli/commands/catchtenCommands';
 import { formatCatchTenState } from '../utils/cli/formatters/catchtenFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -476,6 +477,7 @@ function CatchTenPageContent() {
                 cardWidth={cardWidth}
                 isMobile={isMobile}
                 dataTutorialPrefix="ct"
+                highlightIndices={isHumanTurn && hint?.cardIndex !== undefined ? [hint.cardIndex] : undefined}
               />
             )}
 
@@ -483,7 +485,11 @@ function CatchTenPageContent() {
 
             {hint && (
               <div className="text-ds-warning text-sm mb-2">
-                {`${t('hintPlay')}: [${hint.cardIndex}] (${t(`hintReason.${hint.reason}`)})`}
+                {(() => {
+                  const card = hint.cardIndex !== undefined ? humanPlayer?.cards[hint.cardIndex] : undefined;
+                  const name = card ? cardAlt(card) : '-';
+                  return `${t('hintPlay')}: ${name} [${hint.cardIndex ?? '-'}] (${t(`hintReason.${hint.reason}`)})`;
+                })()}
               </div>
             )}
 

--- a/frontend/src/pages/WhistPage.test.tsx
+++ b/frontend/src/pages/WhistPage.test.tsx
@@ -83,6 +83,15 @@ describe('WhistPage', () => {
     await waitFor(() => expect(screen.getByText(/トランプでカット/)).toBeInTheDocument());
   });
 
+  it('names the recommended card (suit + rank) in the hint text, not just its index', async () => {
+    renderWithProviders(<WhistPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+    // cardIndex 0 in the human hand is ♠ A.
+    mockExec.mockResolvedValueOnce(makeState({ hint: { cardIndex: 0, reason: 'trump_cut' } }));
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+    await waitFor(() => expect(screen.getByText(/♠ A/)).toBeInTheDocument());
+  });
+
   it('falls back to generic text for an unknown hint reason', async () => {
     renderWithProviders(<WhistPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());

--- a/frontend/src/pages/WhistPage.tsx
+++ b/frontend/src/pages/WhistPage.tsx
@@ -32,6 +32,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { WhistResponse } from '../types/card';
 import { WhistPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { cardAlt } from '../utils/cardAlt';
 import { parseWhistCommand, WHIST_HELP } from '../utils/cli/commands/whistCommands';
 import { formatWhistState } from '../utils/cli/formatters/whistFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -438,6 +439,7 @@ function WhistPageContent() {
                 cardWidth={cardWidth}
                 isMobile={isMobile}
                 dataTutorialPrefix="wh"
+                highlightIndices={isHumanTurn && hint?.cardIndex !== undefined ? [hint.cardIndex] : undefined}
               />
             )}
 
@@ -449,9 +451,12 @@ function WhistPageContent() {
                     added, add its key under hintReason in whist.json (ja/en).
                     Unknown reasons fall back to hintReason.fallback instead of
                     showing the raw key. */}
-                {`${t('hintPlay')}: [${hint.cardIndex}] (${t(`hintReason.${hint.reason}`, {
-                  defaultValue: t('hintReason.fallback'),
-                })})`}
+                {(() => {
+                  const reason = t(`hintReason.${hint.reason}`, { defaultValue: t('hintReason.fallback') });
+                  const card = hint.cardIndex !== undefined ? humanPlayer?.cards[hint.cardIndex] : undefined;
+                  const name = card ? cardAlt(card) : '-';
+                  return `${t('hintPlay')}: ${name} [${hint.cardIndex ?? '-'}] (${reason})`;
+                })()}
               </div>
             )}
 


### PR DESCRIPTION
## Summary
Whist's (and Catch the Ten's) web hint only told the player the recommended card's hand *index* (`[2]`), while the CUI (`WhistCuiPresenter.HintOutput`) shows the actual card name — the Web version was the less helpful of the two. Both pages share the identical hint rendering, so #3157's cross-apply note applies.

- `WhistPage.tsx` / `CatchTenPage.tsx` — the hint text now names the recommended card (suit + rank via `cardAlt`) alongside its index, and the card is ring-highlighted in hand via `highlightIndices={[hint.cardIndex]}` on `PlayerHandSection` while it's the human's turn.
- `WhistPage.test.tsx` / `CatchTenPage.test.tsx` — assert the hint text includes the card name (♠ A).

## Test plan
- [x] `bun run test -- --run pages/WhistPage` (12) and `pages/CatchTenPage` (10)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #3157

Also closes #3161 — Scotch Whist is another name for Catch the Ten and its issue targets the same `CatchTenPage.tsx`, resolved by the Catch the Ten change here.