### PR TITLE
feat(golf): pulse the stock on a draw hint and distinguish remove-hint rings

### DIFF
--- a/frontend/src/pages/GolfPage.test.tsx
+++ b/frontend/src/pages/GolfPage.test.tsx
@@ -306,4 +306,18 @@ describe('GolfPage', () => {
     const badge = await screen.findByTestId('combo-badge');
     expect(badge.className).toContain('bg-ds-error');
   });
+
+  it('pulses the stock pile when a draw hint is active', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<GolfPage />);
+    await waitFor(() => expect(screen.getByText('捨て札')).toBeInTheDocument());
+    // The hint is fetched via the hint command; a draw hint should pulse the stock.
+    mockExec.mockResolvedValue({ ...playingState, hint: { type: 'draw', col: -1 } });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+    await waitFor(() => {
+      const stock = screen.getByTestId('golf-stock');
+      expect(stock.className).toContain('ring-ds-warning');
+      expect(stock.className).toContain('animate-pulse');
+    });
+  });
 });

--- a/frontend/src/pages/GolfPage.tsx
+++ b/frontend/src/pages/GolfPage.tsx
@@ -266,7 +266,11 @@ function GolfPageContent() {
                           aria-label={cardAlt(gc.card)}
                           data-testid={isPlayable ? 'golf-playable' : undefined}
                           className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${
-                            isHinted && exposed ? 'ring-2 ring-ds-warning' : isPlayable ? 'ring-2 ring-ds-success' : ''
+                            isHinted && exposed
+                              ? 'ring-2 ring-ds-warning motion-safe:animate-pulse'
+                              : isPlayable
+                                ? 'ring-2 ring-ds-success'
+                                : ''
                           } ${!exposed ? 'opacity-60' : ''}`}
                         >
                           <AnimatedCard card={gc.card} width={effectiveCardWidth} />
@@ -285,11 +289,20 @@ function GolfPageContent() {
                   {t('stock')} ({state.stockCount})
                 </div>
                 {state.stockCount > 0 ? (
-                  <AnimatedCardBack
-                    width={effectiveCardWidth}
-                    onClick={isPlaying ? handleDraw : undefined}
-                    ariaLabel={t('draw')}
-                  />
+                  <div
+                    data-testid="golf-stock"
+                    className={
+                      hint?.type === 'draw'
+                        ? 'inline-block rounded ring-2 ring-ds-warning motion-safe:animate-pulse'
+                        : 'inline-block'
+                    }
+                  >
+                    <AnimatedCardBack
+                      width={effectiveCardWidth}
+                      onClick={isPlaying ? handleDraw : undefined}
+                      ariaLabel={t('draw')}
+                    />
+                  </div>
                 ) : (
                   <div
                     style={{ width: effectiveCardWidth, height: cardHeight }}


### PR DESCRIPTION
## Summary
Golf's hint highlighted a card only for `remove` hints; a `draw` hint ("no playable card — flip the stock") just showed text with nothing lit on the board, an asymmetry versus Pyramid's pulsing hint targets.

- `GolfPage.tsx` — when `hint?.type === 'draw'`, the stock pile now gets a `ring-2 ring-ds-warning motion-safe:animate-pulse` highlight (via a wrapper around `AnimatedCardBack`). The `remove`-hint card ring also gains `motion-safe:animate-pulse`, so a hint (pulsing amber) is visually distinct from the always-on playable ring (steady green). Highlights clear when the hint is absent (before request / after the move).
- `GolfPage.test.tsx` — asserts the stock wrapper pulses after a draw hint is fetched.

> The issue listed `AnimatedCardBack.tsx` / `golf.json` as possible targets; wrapping the stock in a highlight div avoids changing the shared card-back component, and the existing `hintType.draw` text needs no new i18n key.

## Test plan
- [x] `bun run test -- --run pages/GolfPage` (28 tests)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #3112