### PR TITLE
feat(sevens): show remaining pass count on the pass button

### DIFF
--- a/frontend/src/i18n/locales/en/sevens.json
+++ b/frontend/src/i18n/locales/en/sevens.json
@@ -8,6 +8,7 @@
   "passUnlimited": "∞",
   "clickPlayable": "Click a playable card",
   "mustPass": "No playable cards — please pass",
+  "passRemaining": "Pass ({{count}} left)",
   "playTitle": "Play: {{design}} {{value}}",
   "rankLabel": "#{{rank}}",
   "placeAriaLabel": "Place at {{suit}} {{value}}",

--- a/frontend/src/i18n/locales/ja/sevens.json
+++ b/frontend/src/i18n/locales/ja/sevens.json
@@ -8,6 +8,7 @@
   "passUnlimited": "∞",
   "clickPlayable": "出せるカードをクリック",
   "mustPass": "出せるカードがありません — パスしてください",
+  "passRemaining": "パス (残り{{count}}回)",
   "playTitle": "出す: {{design}} {{value}}",
   "rankLabel": "{{rank}}位",
   "placeAriaLabel": "{{suit}} {{value}} に配置",

--- a/frontend/src/pages/SevensPage.test.tsx
+++ b/frontend/src/pages/SevensPage.test.tsx
@@ -223,33 +223,33 @@ describe('SevensPage', () => {
 
   it('pass button is enabled on human turn with passes remaining', async () => {
     renderWithProviders(<SevensPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'パス' })).not.toBeDisabled());
+    await waitFor(() => expect(screen.getByRole('button', { name: /パス/ })).not.toBeDisabled());
   });
 
   it('pass button is disabled on CPU turn', async () => {
     mockExec.mockResolvedValue(cpuTurnState);
     renderWithProviders(<SevensPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'パス' })).toBeDisabled());
+    await waitFor(() => expect(screen.getByRole('button', { name: /パス/ })).toBeDisabled());
   });
 
   it('pass button is disabled when game has ended', async () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<SevensPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'パス' })).toBeDisabled());
+    await waitFor(() => expect(screen.getByRole('button', { name: /パス/ })).toBeDisabled());
   });
 
   it('pass button is disabled when passes are exhausted', async () => {
     mockExec.mockResolvedValue(passesExhaustedState);
     renderWithProviders(<SevensPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'パス' })).toBeDisabled());
+    await waitFor(() => expect(screen.getByRole('button', { name: /パス/ })).toBeDisabled());
   });
 
   it('calls play with -1 when pass button is clicked', async () => {
     renderWithProviders(<SevensPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'パス' })).not.toBeDisabled());
+    await waitFor(() => expect(screen.getByRole('button', { name: /パス/ })).not.toBeDisabled());
     mockExec.mockClear();
     mockExec.mockResolvedValue(cpuTurnState);
-    fireEvent.click(screen.getByRole('button', { name: 'パス' }));
+    fireEvent.click(screen.getByRole('button', { name: /パス/ }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', -1));
   });
 
@@ -365,16 +365,16 @@ describe('SevensPage', () => {
     // reset → humanTurnState, play → stateWithCpuActions
     mockExec.mockResolvedValueOnce(humanTurnState).mockResolvedValueOnce(stateWithCpuActions);
     renderWithProviders(<SevensPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'パス' })).not.toBeDisabled());
+    await waitFor(() => expect(screen.getByRole('button', { name: /パス/ })).not.toBeDisabled());
 
-    fireEvent.click(screen.getByRole('button', { name: 'パス' }));
+    fireEvent.click(screen.getByRole('button', { name: /パス/ }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', -1));
 
     // Buttons stay disabled during animation
-    expect(screen.getByRole('button', { name: 'パス' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /パス/ })).toBeDisabled();
 
     // After replay delay, human turn is restored and buttons re-enable
-    await waitFor(() => expect(screen.getByRole('button', { name: 'パス' })).not.toBeDisabled(), { timeout: 4000 });
+    await waitFor(() => expect(screen.getByRole('button', { name: /パス/ })).not.toBeDisabled(), { timeout: 4000 });
   }, 10000);
 
   it('shows game result message when game ends', async () => {
@@ -586,20 +586,20 @@ describe('SevensPage', () => {
 
   it('disables action buttons while loading', async () => {
     renderWithProviders(<SevensPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'パス' })).not.toBeDisabled());
+    await waitFor(() => expect(screen.getByRole('button', { name: /パス/ })).not.toBeDisabled());
 
     let resolve!: (value: SevensResponse) => void;
     const slowPromise = new Promise<SevensResponse>((res) => {
       resolve = res;
     });
     mockExec.mockReturnValueOnce(slowPromise);
-    fireEvent.click(screen.getByRole('button', { name: 'パス' }));
+    fireEvent.click(screen.getByRole('button', { name: /パス/ }));
 
-    expect(screen.getByRole('button', { name: 'パス' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /パス/ })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'リセット' })).toBeDisabled();
 
     resolve(humanTurnState);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'パス' })).not.toBeDisabled());
+    await waitFor(() => expect(screen.getByRole('button', { name: /パス/ })).not.toBeDisabled());
   });
 
   it('shows error message when API call fails', async () => {
@@ -896,7 +896,7 @@ describe('SevensPage', () => {
     };
     mockExec.mockResolvedValue(unlimitedPassState);
     renderWithProviders(<SevensPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'パス' })).not.toBeDisabled());
+    await waitFor(() => expect(screen.getByRole('button', { name: /パス/ })).not.toBeDisabled());
   });
 
   it('forced pass human action has forced-pass testid', async () => {
@@ -943,9 +943,9 @@ describe('SevensPage', () => {
 
   it('sets aria-busy while loading', async () => {
     renderWithProviders(<SevensPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'パス' })).not.toBeDisabled());
+    await waitFor(() => expect(screen.getByRole('button', { name: /パス/ })).not.toBeDisabled());
 
-    const container = screen.getByRole('button', { name: 'パス' }).closest('[aria-busy]') as HTMLElement;
+    const container = screen.getByRole('button', { name: /パス/ }).closest('[aria-busy]') as HTMLElement;
     expect(container).toHaveAttribute('aria-busy', 'false');
 
     let resolve!: (value: SevensResponse) => void;
@@ -953,7 +953,7 @@ describe('SevensPage', () => {
       resolve = res;
     });
     mockExec.mockReturnValueOnce(slowPromise);
-    fireEvent.click(screen.getByRole('button', { name: 'パス' }));
+    fireEvent.click(screen.getByRole('button', { name: /パス/ }));
 
     expect(container).toHaveAttribute('aria-busy', 'true');
 
@@ -1713,5 +1713,34 @@ describe('SevensPage', () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<SevensPage />);
     await waitFor(() => expect(screen.getByTestId('phase-indicator')).toHaveTextContent('終了'));
+  });
+
+  it('shows the remaining pass count on the pass button', async () => {
+    // humanTurnState: passesUsed 0 / maxPasses 5 → 5 remaining.
+    mockExec.mockResolvedValue(humanTurnState);
+    renderWithProviders(<SevensPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: /残り5回/ })).toBeInTheDocument());
+  });
+
+  it('warns when only one pass remains', async () => {
+    const oneLeft: SevensResponse = {
+      ...humanTurnState,
+      players: [{ ...humanTurnState.players[0], passesUsed: 4, maxPasses: 5 }, ...humanTurnState.players.slice(1)],
+    };
+    mockExec.mockResolvedValue(oneLeft);
+    renderWithProviders(<SevensPage />);
+    const btn = await screen.findByRole('button', { name: /残り1回/ });
+    expect(btn.className).toContain('text-ds-warning');
+  });
+
+  it('omits the count on the pass button when passes are unlimited', async () => {
+    const unlimited: SevensResponse = {
+      ...humanTurnState,
+      players: [{ ...humanTurnState.players[0], maxPasses: 0 }, ...humanTurnState.players.slice(1)],
+    };
+    mockExec.mockResolvedValue(unlimited);
+    renderWithProviders(<SevensPage />);
+    const btn = await screen.findByRole('button', { name: 'パス' });
+    expect(btn.textContent).toBe('パス');
   });
 });

--- a/frontend/src/pages/SevensPage.tsx
+++ b/frontend/src/pages/SevensPage.tsx
@@ -188,6 +188,10 @@ function SevensPageContent() {
     humanPlayer != null &&
     (humanPlayer.maxPasses === 0 || humanPlayer.passesUsed < humanPlayer.maxPasses);
 
+  // Passes remaining before a forced dobon; null when passes are unlimited (maxPasses=0).
+  const passesRemaining =
+    humanPlayer != null && humanPlayer.maxPasses > 0 ? humanPlayer.maxPasses - humanPlayer.passesUsed : null;
+
   const settingsGroups: SettingsGroup[] = [
     {
       title: t('config.groupRules'),
@@ -456,12 +460,12 @@ function SevensPageContent() {
               />
               <button
                 type="button"
-                className={`${btnSecondary} min-w-[90px]`}
+                className={`${btnSecondary} min-w-[90px] ${passesRemaining === 1 ? 'text-ds-warning' : ''}`}
                 disabled={loading || !canPass}
                 onClick={() => exec('play', -1)}
                 data-tutorial="sv-play-pass"
               >
-                {tc('button.pass')}
+                {passesRemaining === null ? tc('button.pass') : t('passRemaining', { count: passesRemaining })}
               </button>
               {jokerCardIdx !== null && (
                 <button type="button" className={`${btnSecondary} min-w-[90px]`} onClick={() => setJokerCardIdx(null)}>


### PR DESCRIPTION
## Summary
In Sevens, the pass button only went `disabled` once passes ran out — the number of passes left (and the looming forced-dobon risk) was only visible by reading the CPU-area stats.

- `SevensPage.tsx` — the pass button now reads「パス (残りN回)」, computed from `humanPlayer.maxPasses - passesUsed`. With unlimited passes (`maxPasses === 0`) it stays the plain「パス」with no count, and at 1 pass remaining it turns `text-ds-warning`.
- `sevens.json` (ja/en) — new `passRemaining` key.
- `SevensPage.test.tsx` — asserts the count is shown, the warning colour appears at 1 remaining, and no count is shown when unlimited. Existing pass-button queries updated from `'パス'` to `/パス/` to tolerate the appended count.

## Test plan
- [x] `bun run test -- --run pages/SevensPage` (112 tests)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #2992