### PR TITLE
feat(daifugo): add a clear-selection button

### DIFF
--- a/frontend/src/i18n/locales/en/daifugo.json
+++ b/frontend/src/i18n/locales/en/daifugo.json
@@ -16,6 +16,7 @@
   "tableEmpty": "(empty)",
   "playButton": "Play Selected",
   "passButton": "Pass",
+  "clearSelectionButton": "Clear selection",
   "discardButton": "Discard",
   "sevenPassBanner": "[7-Pass] Give 1 card to {{target}}",
   "tenDiscardBanner": "[10-Discard] Select 1 card to discard",

--- a/frontend/src/i18n/locales/ja/daifugo.json
+++ b/frontend/src/i18n/locales/ja/daifugo.json
@@ -16,6 +16,7 @@
   "tableEmpty": "（なし）",
   "playButton": "選択して出す",
   "passButton": "渡す",
+  "clearSelectionButton": "選択解除",
   "discardButton": "捨てる",
   "sevenPassBanner": "【7渡し】{{target}}にカードを1枚渡してください",
   "tenDiscardBanner": "【10捨て】捨てるカードを1枚選択してください",

--- a/frontend/src/pages/DaifugoPage.test.tsx
+++ b/frontend/src/pages/DaifugoPage.test.tsx
@@ -697,6 +697,20 @@ describe('DaifugoPage', () => {
     expect(screen.getByRole('button', { name: '選択して出す' })).toBeInTheDocument();
   });
 
+  it('clears the whole selection with the deselect button', async () => {
+    renderWithProviders(<DaifugoPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ 3')).toBeInTheDocument());
+    const clearBtn = screen.getByTestId('daifugo-clear-selection');
+    // Disabled with nothing selected.
+    expect(clearBtn).toBeDisabled();
+    // Select a card → the deselect button activates.
+    fireEvent.click(screen.getByAltText('♠ 3'));
+    expect(clearBtn).not.toBeDisabled();
+    // Clicking it empties the selection (the play button goes back to disabled).
+    fireEvent.click(clearBtn);
+    expect(screen.getByRole('button', { name: '選択して出す' })).toBeDisabled();
+  });
+
   it('settings panel renders checkbox labels', async () => {
     renderWithProviders(<DaifugoPage />);
     await waitFor(() => expect(screen.getByText('ルール設定')).toBeInTheDocument());

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -471,6 +471,15 @@ function DaifugoPageContent() {
               >
                 {playButtonLabel}
               </button>
+              <button
+                type="button"
+                className={`${btnSecondary} min-w-[90px]`}
+                disabled={loading || selectedIndices.length === 0}
+                onClick={clearSelection}
+                data-testid="daifugo-clear-selection"
+              >
+                {t('clearSelectionButton')}
+              </button>
             </div>
           </GameFooter>
         </>


### PR DESCRIPTION
## Summary
Daifugo's `clearSelection` was only wired to the Escape key (`useCardKeyboardNav.onClear`), so mouse/touch players re-picking a staircase or multi-card play had to tap each selected card off one by one.

- `DaifugoPage.tsx` — adds a `clearSelectionButton` (「選択解除」) to the play/pass button row, enabled only while `selectedIndices.length > 0`, calling the existing `clearSelection`. The Escape-key behaviour is unchanged.
- `daifugo.json` (ja/en) — new `clearSelectionButton` key.
- `DaifugoPage.test.tsx` — asserts the button is disabled with no selection, activates once a card is selected, and empties the selection on click.

## Test plan
- [x] `bun run test -- --run pages/DaifugoPage` (104 tests)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #2987