### PR TITLE
feat(daifugo): show who played the current table cards

### DIFF
--- a/frontend/src/i18n/locales/en/daifugo.json
+++ b/frontend/src/i18n/locales/en/daifugo.json
@@ -14,6 +14,7 @@
   "selectToPlay": "Click cards to select",
   "tableCards": "Table",
   "tableEmpty": "(empty)",
+  "lastPlayedBy": "(played by {{name}})",
   "playButton": "Play Selected",
   "passButton": "Pass",
   "clearSelectionButton": "Clear selection",

--- a/frontend/src/i18n/locales/ja/daifugo.json
+++ b/frontend/src/i18n/locales/ja/daifugo.json
@@ -14,6 +14,7 @@
   "selectToPlay": "カードをクリックして選択",
   "tableCards": "場札",
   "tableEmpty": "（なし）",
+  "lastPlayedBy": "（{{name}} が出した）",
   "playButton": "選択して出す",
   "passButton": "渡す",
   "clearSelectionButton": "選択解除",

--- a/frontend/src/pages/DaifugoPage.test.tsx
+++ b/frontend/src/pages/DaifugoPage.test.tsx
@@ -1355,4 +1355,20 @@ describe('DaifugoPage', () => {
       vi.useRealTimers();
     }
   });
+
+  it('shows who played the current table cards', async () => {
+    // cpuTurnState: table has cards, lastPlayPlayerIdx 0 (you).
+    mockExec.mockResolvedValue(cpuTurnState);
+    renderWithProviders(<DaifugoPage />);
+    await waitFor(() => expect(screen.getByTestId('daifugo-last-player')).toBeInTheDocument());
+    expect(screen.getByTestId('daifugo-last-player')).toHaveTextContent('あなた');
+  });
+
+  it('hides the played-by badge when the table has been flushed', async () => {
+    // humanTurnState: empty table, lastPlayPlayerIdx -1.
+    mockExec.mockResolvedValue(humanTurnState);
+    renderWithProviders(<DaifugoPage />);
+    await waitFor(() => expect(screen.getByText('（なし）')).toBeInTheDocument());
+    expect(screen.queryByTestId('daifugo-last-player')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -311,7 +311,14 @@ function DaifugoPageContent() {
               onDragOver={(e) => e.preventDefault()}
               onDrop={handleDrop}
             >
-              <div className="text-ds-text-primary font-bold mb-1.5">{t('tableCards')}</div>
+              <div className="text-ds-text-primary font-bold mb-1.5">
+                {t('tableCards')}
+                {tableCount > 0 && state.lastPlayPlayerIdx >= 0 && (
+                  <span className="ml-2 text-xs font-normal text-ds-text-muted" data-testid="daifugo-last-player">
+                    {t('lastPlayedBy', { name: findPlayerName(state.players, state.lastPlayPlayerIdx) })}
+                  </span>
+                )}
+              </div>
               <div className="flex flex-wrap gap-1">
                 {!state.tableCards || state.tableCards.length === 0 ? (
                   <span className="text-ds-text-muted">{t('tableEmpty')}</span>


### PR DESCRIPTION
## Summary
The Daifugo table area showed only the card images — unlike the CUI (`DaifugoCuiPresenter` prints the last player's name on `tableLine`), the Web player couldn't tell who played the current cards without scrolling the CPU action log.

- `DaifugoPage.tsx` — the「場札」header now appends a `(CPU2 が出した)` badge using the existing `state.lastPlayPlayerIdx`, shown only when the table has cards and a valid last player. When the pile is flushed (empty), the badge disappears.
- `daifugo.json` (ja/en) — new `lastPlayedBy` key.
- `DaifugoPage.test.tsx` — asserts the badge names the last player when cards are on the table and is absent once the table is flushed.

No backend change was needed — `lastPlayPlayerIdx` is already in `DaifugoResponse`.

## Test plan
- [x] `bun run test -- --run pages/DaifugoPage` (106 tests)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #2986