### PR TITLE
refactor(bigtwo): use the shared ErrorAlert component

### DIFF
--- a/frontend/src/pages/BigTwoPage.test.tsx
+++ b/frontend/src/pages/BigTwoPage.test.tsx
@@ -102,14 +102,17 @@ describe('BigTwoPage', () => {
     expect(screen.queryByTestId('play-button')).not.toBeInTheDocument();
   });
 
-  it('shows a retry button when an action fails', async () => {
+  it('shows the shared ErrorAlert with a retry button when an action fails', async () => {
     renderWithProviders(<BigTwoPage />);
     const passBtn = await screen.findByTestId('pass-button');
     mockExec.mockRejectedValueOnce(new Error('boom'));
     fireEvent.click(passBtn);
-    const retry = await screen.findByText(NETWORK_ERROR_MESSAGE());
+    // The error now surfaces via the shared ErrorAlert (role=alert), not a bare underline button.
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(NETWORK_ERROR_MESSAGE());
+    mockExec.mockClear();
     mockExec.mockResolvedValue(makeState());
-    fireEvent.click(retry);
+    fireEvent.click(screen.getByRole('button', { name: '再試行' }));
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('play', []));
   });
 

--- a/frontend/src/pages/BigTwoPage.tsx
+++ b/frontend/src/pages/BigTwoPage.tsx
@@ -4,6 +4,7 @@ import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
 import { ReplaySpeedSettingsPanel } from '../components/common/ReplaySpeedSettingsPanel';
 import { SettingsPanel } from '../components/common/SettingsPanel';
+import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
@@ -161,11 +162,7 @@ function BigTwoPageContent() {
       ) : (
         <>
           <div className="flex-1 overflow-y-auto px-4 py-2 space-y-3">
-            {error && (
-              <button type="button" onClick={retry} className="text-ds-error underline">
-                {error}
-              </button>
-            )}
+            <ErrorAlert message={error} onRetry={retry} />
 
             {/* CPU players */}
             <div className="flex justify-center gap-6 flex-wrap" data-tutorial="bt-cpu-area">


### PR DESCRIPTION
## Summary
`BigTwoPage` rendered errors as a bare underlined text button (`text-ds-error underline`), which — unlike the shared `ErrorAlert` used across other pages — doesn't announce itself as an alert to assistive tech and hides the retry affordance.

- `BigTwoPage.tsx` — replaces the custom error button with `<ErrorAlert message={error} onRetry={retry} />` (which is `role="alert"`, self-hides when there's no error, and renders a proper retry button).
- `BigTwoPage.test.tsx` — updates the failure test to assert the `role="alert"` element carries the error text and that clicking the ErrorAlert retry button re-dispatches the action.

## Test plan
- [x] `bun run test -- --run pages/BigTwoPage` (12 tests)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #2989