### PR TITLE
feat(doubt): highlight and pre-select the honest claim value

### DIFF
--- a/frontend/src/pages/DoubtPage.test.tsx
+++ b/frontend/src/pages/DoubtPage.test.tsx
@@ -1334,4 +1334,29 @@ describe('DoubtPage', () => {
     renderWithProviders(<DoubtPage />);
     await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument());
   });
+
+  it('highlights and pre-selects the honest next value (last claim + 1)', async () => {
+    mockExec.mockResolvedValue({
+      ...humanTurnState,
+      lastAction: { playerIdx: 1, claimedValue: 5, cardCount: 1, isBluff: false },
+    });
+    renderWithProviders(<DoubtPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+    fireEvent.click(screen.getByAltText('♠ A').closest('button') as HTMLButtonElement);
+    const honest = screen.getByTestId('doubt-honest-value');
+    expect(honest).toHaveTextContent('6');
+    // The honest value is pre-selected so an honest play needs no extra tap.
+    expect(honest).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('wraps the honest next value from 13 back to A', async () => {
+    mockExec.mockResolvedValue({
+      ...humanTurnState,
+      lastAction: { playerIdx: 1, claimedValue: 13, cardCount: 1, isBluff: false },
+    });
+    renderWithProviders(<DoubtPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+    fireEvent.click(screen.getByAltText('♠ A').closest('button') as HTMLButtonElement);
+    expect(screen.getByTestId('doubt-honest-value')).toHaveTextContent('A');
+  });
 });

--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -135,6 +135,13 @@ function DoubtPageContent() {
   const showClaimInput = selectedCardIndices.length > 0 && isHumanTurn && state?.phase === 0;
 
   const isHumanPlayTurn = isHumanTurn && state?.phase === 0;
+  // The "honest" next value is the last claim + 1, wrapping 13 → 1 (or 1 at the start).
+  const honestValue = state?.lastAction != null ? (state.lastAction.claimedValue % 13) + 1 : 1;
+  // Preset the claim selection to the honest value when the human's play turn begins,
+  // so honest plays don't require hunting for the right button each turn.
+  useEffect(() => {
+    if (isHumanPlayTurn) setClaimedValue(honestValue);
+  }, [isHumanPlayTurn, honestValue, setClaimedValue]);
   const humanPlayer = state?.players.find((p) => p.isHuman);
 
   useCardKeyboardNav({
@@ -526,9 +533,12 @@ function DoubtPageContent() {
                           className={
                             claimedValue === v
                               ? `${btnSecondary} min-w-[44px] ring-2 ring-ds-warning ${focusRingAccent}`
-                              : `${btnSecondary} min-w-[44px] ${focusRingAccent}`
+                              : v === honestValue
+                                ? `${btnSecondary} min-w-[44px] ring-2 ring-ds-success ${focusRingAccent}`
+                                : `${btnSecondary} min-w-[44px] ${focusRingAccent}`
                           }
                           aria-pressed={claimedValue === v}
+                          data-testid={v === honestValue ? 'doubt-honest-value' : undefined}
                           onClick={() => setClaimedValue(v)}
                           disabled={loading}
                         >


### PR DESCRIPTION
## Summary
Doubt's claim-value buttons (1–13) were always a flat, undifferentiated row, so an honest player had to hunt for "last claim + 1" each turn — a common source of accidental (unintended) bluffs.

- `DoubtPage.tsx` — computes the honest next value from `state.lastAction.claimedValue` (`+1`, wrapping 13 → 1; `1` at the start), gives that button a green `ring-ds-success` highlight (distinct from the amber selection ring), and pre-selects it via `setClaimedValue` when the human's play turn begins. Manual selection still overrides it.
- `DoubtPage.test.tsx` — asserts the honest value is highlighted + pre-selected, and that the 13 → A wrap is correct.

`useDoubtGame` already exposes `setClaimedValue`, so no hook change was needed.

## Test plan
- [x] `bun run test -- --run pages/DoubtPage` (102 tests)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #2995