### PR TITLE
feat(shortdeck): make the hand-name rule note tappable on touch

### DIFF
--- a/frontend/src/pages/ShortDeckPage.test.tsx
+++ b/frontend/src/pages/ShortDeckPage.test.tsx
@@ -341,6 +341,19 @@ describe('ShortDeckPage', () => {
     expect(marker).toHaveAttribute('aria-label', 'ショートデック特殊ルール：フラッシュ > フルハウス');
   });
 
+  it('toggles the rank-override note on tap so touch users can read it', async () => {
+    mockExec.mockResolvedValue(showdownState);
+    renderWithProviders(<ShortDeckPage />);
+    const marker = await screen.findByTestId('shortdeck-handname-rule');
+    // It is a real button (focusable, activatable), not a hover-only span.
+    expect(marker.tagName).toBe('BUTTON');
+    expect(screen.queryByTestId('shortdeck-rule-note')).not.toBeInTheDocument();
+    fireEvent.click(marker);
+    expect(screen.getByTestId('shortdeck-rule-note')).toHaveTextContent('ショートデック特殊ルール');
+    fireEvent.click(marker);
+    expect(screen.queryByTestId('shortdeck-rule-note')).not.toBeInTheDocument();
+  });
+
   it('shows CPU cards face-up during showdown when not folded', async () => {
     mockExec.mockResolvedValue(showdownState);
     renderWithProviders(<ShortDeckPage />);

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -115,6 +115,8 @@ function ShortDeckPageContent() {
   const { state, loading, error, exec: execApi, retry } = useGameApi(shortdeckApi.exec);
   const [betAmount, setBetAmount] = useState(20);
   const [learningMode, setLearningMode] = useState(false);
+  // Touch/keyboard-accessible toggle for the ★ rank-override note (title alone is hover-only).
+  const [showRuleNote, setShowRuleNote] = useState(false);
   const [cpuMetaAI, setCpuMetaAI] = useState(false);
   const { hint, hintEnabled, setHintEnabled } = useGameHint('shortdeck', state);
   const turnStartRef = useRef(0);
@@ -365,15 +367,24 @@ function ShortDeckPageContent() {
                       className={`inline-flex items-center gap-1 ml-2 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}
                     >
                       {humanPlayer.handName}
-                      <span
+                      {/* Button (not a hover-only title span) so touch + keyboard users can
+                          read the rank-override note; desktop hover title is preserved. */}
+                      <button
+                        type="button"
                         data-testid="shortdeck-handname-rule"
-                        role="img"
                         aria-label={t('rankOverrideReminder')}
+                        aria-expanded={showRuleNote}
                         title={t('rankOverrideReminder')}
+                        onClick={() => setShowRuleNote((v) => !v)}
                         className="cursor-help text-ds-warning"
                       >
                         ★
-                      </span>
+                      </button>
+                    </span>
+                  )}
+                  {isShowdown && !humanPlayer.folded && humanPlayer.handName && showRuleNote && (
+                    <span className="ml-2 text-xs text-ds-warning" data-testid="shortdeck-rule-note" role="status">
+                      {t('rankOverrideReminder')}
                     </span>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
At showdown, the ★ next to the Short Deck hand-name badge explained the rank-override rule only via a `title` tooltip — hover-only, so touch users could never read it.

- `ShortDeckPage.tsx` — the ★ is now a real `<button>` (focusable + Enter-activatable) that toggles an inline note showing the reminder text; it keeps its `title`/`aria-label` so desktop hover still works and screen readers still announce it (`aria-expanded` reflects the state).
- `ShortDeckPage.test.tsx` — asserts the marker is a button and that tapping it reveals/hides the note.

## Test plan
- [x] `bun run test -- --run pages/ShortDeckPage` (86 tests)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #3015