### PR TITLE
feat(poker): add a 2-7 lowball hand-rank quick reference

### DIFF
--- a/frontend/src/i18n/locales/en/poker.json
+++ b/frontend/src/i18n/locales/en/poker.json
@@ -20,6 +20,13 @@
   "cpuExchangeEntry": "Player {{idx}}: exchanged {{count}} card(s)",
   "exchangeCount": "Exchanged: {{count}}",
   "lowball": "2-7 Lowball",
+  "lowballRank": {
+    "title": "2-7 Lowball hand guide",
+    "best": "Best: 7-5-4-3-2 (unsuited)",
+    "aceHigh": "Aces are always high (the worst card for a low)",
+    "straightFlushCount": "Straights and flushes count against you",
+    "goal": "Aim for the lowest 5 cards with no pair, straight, or flush"
+  },
   "lowballMode": "2-7 Lowball Mode",
   "cardSelected": "(selected for exchange)",
   "settings": {

--- a/frontend/src/i18n/locales/ja/poker.json
+++ b/frontend/src/i18n/locales/ja/poker.json
@@ -20,6 +20,13 @@
   "cpuExchangeEntry": "Player {{idx}}: {{count}}枚交換",
   "exchangeCount": "交換: {{count}}枚",
   "lowball": "2-7 ローボール",
+  "lowballRank": {
+    "title": "2-7 ローボール 役早見表",
+    "best": "最強: 7-5-4-3-2（スート違い）",
+    "aceHigh": "A は常に最高位（＝ロー狙いでは最も弱い）",
+    "straightFlushCount": "ストレート・フラッシュは成立扱い（ローでは不利）",
+    "goal": "ペア・ストレート・フラッシュを避けた最も低い5枚を目指す"
+  },
   "lowballMode": "2-7 ローボール モード",
   "cardSelected": "(交換選択中)",
   "settings": {

--- a/frontend/src/pages/PokerPage.test.tsx
+++ b/frontend/src/pages/PokerPage.test.tsx
@@ -1481,4 +1481,18 @@ describe('PokerPage', () => {
 
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('bet', undefined, 10, undefined, expect.any(Number)));
   });
+
+  it('shows the lowball hand-rank reference only in lowball mode', async () => {
+    mockExec.mockResolvedValue({ ...dealState, isLowball: true });
+    renderWithProviders(<PokerPage />);
+    expect(await screen.findByTestId('pk-lowball-reference')).toBeInTheDocument();
+  });
+
+  it('hides the lowball reference in normal (non-lowball) mode', async () => {
+    mockExec.mockResolvedValue(dealState); // isLowball: false
+    renderWithProviders(<PokerPage />);
+    // Wait for the deal phase to render before asserting the reference is absent.
+    await screen.findByRole('button', { name: 'ベット' });
+    expect(screen.queryByTestId('pk-lowball-reference')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -231,6 +231,21 @@ function PokerPageContent() {
         <>
           {/* Scrollable: CPU players + logs */}
           <div className={`flex-1 overflow-y-auto pt-4 px-5 lg:px-8 ${lgCardAreaConstraint}`}>
+            {/* Lowball hand-rank quick reference (only meaningful in 2-7 lowball). */}
+            {state?.isLowball && (
+              <details className="mb-2" data-testid="pk-lowball-reference">
+                <summary className="cursor-pointer select-none text-ds-text-primary text-sm font-bold py-1">
+                  {t('lowballRank.title')}
+                </summary>
+                <ul className="list-disc list-inside text-ds-text-muted text-xs py-1 space-y-0.5">
+                  <li className="text-ds-text-primary font-semibold">{t('lowballRank.best')}</li>
+                  <li>{t('lowballRank.aceHigh')}</li>
+                  <li>{t('lowballRank.straightFlushCount')}</li>
+                  <li>{t('lowballRank.goal')}</li>
+                </ul>
+              </details>
+            )}
+
             {/* CPU players */}
             {(() => {
               const cpuCards = cpuPlayers.map((p) => (


### PR DESCRIPTION
## Summary
Poker has a lowball mode (and a `[lowballMode]` header badge), but no UI explained how 2-7 lowball hand strength differs (aces high, straights/flushes count against you). Short Deck's `sd-handrank-reference` `<details>` was the precedent.

- `PokerPage.tsx` — renders a collapsible `<details data-testid="pk-lowball-reference">` quick reference in the card area **only when `state.isLowball`**: best hand (7-5-4-3-2 unsuited), aces-high, straights/flushes count, and the overall goal.
- `poker.json` (ja/en) — new `lowballRank` block.
- `PokerPage.test.tsx` — asserts the reference shows in lowball mode and is absent in normal mode.

## Test plan
- [x] `bun run test -- --run pages/PokerPage` (116 tests)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #2981