### PR TITLE
feat(pinochle): show localized player names on trick cards

### DIFF
--- a/frontend/src/pages/PinochlePage.test.tsx
+++ b/frontend/src/pages/PinochlePage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { pinochleApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -422,12 +422,15 @@ describe('PinochlePage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('nextround'));
   });
 
-  it('renders trick cards on table', async () => {
+  it('renders trick cards with localized player names (not P0/P1)', async () => {
     mockExec.mockResolvedValue(trickEndState);
-    renderWithProviders(<PinochlePage />);
-    await waitFor(() => {
-      expect(screen.getByText('P0')).toBeInTheDocument();
-    });
+    const { container } = renderWithProviders(<PinochlePage />);
+    await waitFor(() => expect(container.querySelector('[data-tutorial="pn-trick-display"]')).toBeInTheDocument());
+    const trick = container.querySelector('[data-tutorial="pn-trick-display"]') as HTMLElement;
+    // playerIdx 0 is the human ("あなた"), playerIdx 1 a CPU ("CPU 1").
+    expect(within(trick).getByText('あなた')).toBeInTheDocument();
+    expect(within(trick).getByText('CPU 1')).toBeInTheDocument();
+    expect(within(trick).queryByText('P0')).not.toBeInTheDocument();
   });
 
   it('renders game end state', async () => {

--- a/frontend/src/pages/PinochlePage.tsx
+++ b/frontend/src/pages/PinochlePage.tsx
@@ -318,12 +318,19 @@ function PinochlePageContent() {
               <div className="mb-3 p-2 rounded bg-black/40" data-tutorial="pn-trick-display">
                 <div className="text-ds-text-muted text-sm mb-1">{t('table')}:</div>
                 <div className="flex gap-2 justify-center">
-                  {state.currentTrick.map((tc, i) => (
-                    <div key={i} className="text-center">
-                      <AnimatedCard card={tc.card} width={cardWidth * 0.8} />
-                      <div className="text-xs text-ds-text-muted mt-1">P{tc.playerIdx}</div>
-                    </div>
-                  ))}
+                  {state.currentTrick.map((tc, i) => {
+                    const isHuman = state.players[tc.playerIdx]?.isHuman === true;
+                    return (
+                      <div key={i} className="text-center">
+                        <AnimatedCard card={tc.card} width={cardWidth * 0.8} />
+                        <div
+                          className={`text-xs mt-1 ${isHuman ? 'text-ds-accent font-semibold' : 'text-ds-text-muted'}`}
+                        >
+                          {playerName(tc.playerIdx, isHuman)}
+                        </div>
+                      </div>
+                    );
+                  })}
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Summary
Pinochle's current-trick display labelled each card with a raw `P{playerIdx}`, while the rest of the page (and other trick games) use `playerName(id, isHuman)` → 「あなた」「CPU n」. Players couldn't tell at a glance which card was theirs.

- `PinochlePage.tsx` — the trick-card label now uses `playerName(tc.playerIdx, isHuman)` and colours the human's own card with the accent style (`text-ds-accent`) so it stands out. The `data-tutorial="pn-trick-display"` hook is unchanged.
- `PinochlePage.test.tsx` — updates the trick test to assert the localized 「あなた」/「CPU 1」 names (scoped to the trick container) instead of `P0`.

> This takes the proposal's "at minimum apply `playerName`" path — a low-risk in-place fix — rather than swapping in the shared `TrickDisplay` (whose different layout would be a larger change), so `TrickDisplay.tsx`/`playerUtils.ts` are untouched.

## Test plan
- [x] `bun run test -- --run pages/PinochlePage` (29 tests)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #3109