### PR TITLE
fix(poker): preserve the typed raise amount across state updates

### DIFF
--- a/frontend/src/pages/PokerPage.test.tsx
+++ b/frontend/src/pages/PokerPage.test.tsx
@@ -794,6 +794,32 @@ describe('PokerPage', () => {
     await waitFor(() => expect((betInput as HTMLInputElement).value).toBe('10'));
   });
 
+  it('preserves a typed raise amount across a state update that keeps the same minRaise (#2980)', async () => {
+    mockExec.mockResolvedValue({ ...dealState, minRaise: 10 });
+    renderWithProviders(<PokerPage />);
+    const betInput = await screen.findByLabelText('ベット額:');
+    await waitFor(() => expect((betInput as HTMLInputElement).value).toBe('10'));
+    fireEvent.change(betInput, { target: { value: '80' } });
+    expect((betInput as HTMLInputElement).value).toBe('80');
+    // A CPU action arrives (state changes) but minRaise is unchanged.
+    mockExec.mockResolvedValue({ ...dealState, minRaise: 10, message: 'CPU acted' });
+    fireEvent.click(screen.getByRole('button', { name: 'チェック' }));
+    await waitFor(() => expect(screen.getByText('CPU acted')).toBeInTheDocument());
+    expect((betInput as HTMLInputElement).value).toBe('80');
+  });
+
+  it('bumps betAmount when minRaise rises (#2980)', async () => {
+    mockExec.mockResolvedValue({ ...dealState, minRaise: 10 });
+    renderWithProviders(<PokerPage />);
+    const betInput = await screen.findByLabelText('ベット額:');
+    await waitFor(() => expect((betInput as HTMLInputElement).value).toBe('10'));
+    fireEvent.change(betInput, { target: { value: '30' } });
+    // A raise lifts minRaise; the input follows the new minimum.
+    mockExec.mockResolvedValue({ ...dealState, minRaise: 60 });
+    fireEvent.click(screen.getByRole('button', { name: 'チェック' }));
+    await waitFor(() => expect((betInput as HTMLInputElement).value).toBe('60'));
+  });
+
   // ---- button click handlers ----
   it('calls bet command with betAmount', async () => {
     mockExec.mockResolvedValue(dealState);

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -129,13 +129,14 @@ function PokerPageContent() {
   const [cpuMetaAI, setCpuMetaAI] = useState(false);
   const turnStartRef = useRef(0);
 
+  // Sync the raise amount to the current minimum only when that minimum actually
+  // changes (a raise, or a new round). Keying on `state` would re-run on every CPU
+  // action and clobber the amount the player is typing (#2980).
+  const minRaiseValue = state?.minRaise;
   useEffect(() => {
-    if (state?.minRaise && state.minRaise > 0) {
-      setBetAmount(state.minRaise);
-    } else if (state) {
-      setBetAmount(10);
-    }
-  }, [state]);
+    if (minRaiseValue === undefined) return;
+    setBetAmount(minRaiseValue > 0 ? minRaiseValue : 10);
+  }, [minRaiseValue]);
 
   useEffect(() => {
     if (state && state.currentTurn === state.players?.find((p) => p.isHuman)?.id) {


### PR DESCRIPTION
## Summary
The `betAmount` sync effect depended on the whole `state`, so it re-ran on every state update (e.g. a CPU action) and snapped the raise amount the player was typing back to `minRaise`.

- `PokerPage.tsx` — the effect now depends only on `state.minRaise`, so it re-syncs the bet amount **only when the minimum actually changes** (a raise, or a new round). Mid-turn CPU updates that leave `minRaise` unchanged no longer clobber the typed value. The initial-value behaviour (snap to `minRaise`, or 10 when it's 0) is preserved.
- `PokerPage.test.tsx` — adds regressions: a typed amount survives a same-`minRaise` state update, and the amount follows `minRaise` upward when it rises.

## Test plan
- [x] `bun run test -- --run pages/PokerPage` (118 tests)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #2980