### PR TITLE
feat(freecell): gate the auto-complete button on readiness like Klondike

### DIFF
--- a/frontend/src/i18n/locales/en/freecell.json
+++ b/frontend/src/i18n/locales/en/freecell.json
@@ -10,6 +10,7 @@
   "giveup": "Give Up",
   "hint": "Hint",
   "autoComplete": "Auto Complete",
+  "autoCompleteNotReady": "Available once every card can go straight to the foundations",
   "undo": "Undo",
   "moveCount": "Moves",
   "empty": "Empty",

--- a/frontend/src/i18n/locales/ja/freecell.json
+++ b/frontend/src/i18n/locales/ja/freecell.json
@@ -10,6 +10,7 @@
   "giveup": "ギブアップ",
   "hint": "ヒント",
   "autoComplete": "オートコンプリート",
+  "autoCompleteNotReady": "すべてのカードをファウンデーションへ直接送れる状態になるとクリックできます",
   "undo": "元に戻す",
   "moveCount": "手数",
   "empty": "空",

--- a/frontend/src/pages/FreeCellPage.test.tsx
+++ b/frontend/src/pages/FreeCellPage.test.tsx
@@ -207,6 +207,24 @@ describe('FreeCellPage', () => {
     expect(screen.queryByTestId('freecell-autocomplete-ready-badge')).not.toBeInTheDocument();
   });
 
+  it('enables the auto-complete button (no tooltip) when the board is ready (#3035)', async () => {
+    renderWithProviders(<FreeCellPage />); // default playingState is ready
+    const btn = await screen.findByTestId('autocomplete-button');
+    expect(btn).toBeEnabled();
+    expect(btn).not.toHaveAttribute('title');
+  });
+
+  it('disables the auto-complete button with a reason tooltip when not ready (#3035)', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      tableau: [[card('SPADE', 2), card('HEART', 5)], [], [], [], [], [], [], []],
+    });
+    renderWithProviders(<FreeCellPage />);
+    const btn = await screen.findByTestId('autocomplete-button');
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute('title', 'すべてのカードをファウンデーションへ直接送れる状態になるとクリックできます');
+  });
+
   it('give up button opens a confirm dialog and only dispatches giveup after confirm', async () => {
     renderWithProviders(<FreeCellPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeInTheDocument());

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -530,7 +530,9 @@ function FreeCellPageContent() {
                       autoCompleteReady && !loading && !isAutoCompleting ? ' animate-pulse ring-2 ring-ds-success' : ''
                     }`}
                     onClick={handleAutoComplete}
-                    disabled={loading || isAutoCompleting}
+                    disabled={loading || isAutoCompleting || !autoCompleteReady}
+                    data-testid="autocomplete-button"
+                    title={autoCompleteReady ? undefined : t('autoCompleteNotReady')}
                   >
                     {t('autoComplete')}
                   </button>


### PR DESCRIPTION
## Summary
FreeCell's auto-complete button was only `disabled={loading || isAutoCompleting}`, so it could be pressed even when the board wasn't collectable (risking a partial run / error). Klondike already disables the same button on `!autoCompleteReady` with a reason tooltip.

- `FreeCellPage.tsx` — the button now also disables on `!autoCompleteReady`, gains `title={t('autoCompleteNotReady')}` when not ready, and a `data-testid="autocomplete-button"` (matching Klondike, E2E-friendly). The ready-state pulse + `AutoCompleteReadyBadge` are unchanged.
- `freecell.json` (ja/en) — adds the shared `autoCompleteNotReady` key (FreeCell-specific wording: available once every card can go straight to the foundations).
- `FreeCellPage.test.tsx` — adds both branches: enabled + no tooltip when ready, disabled + reason tooltip when a column blocks completion.

> `freeCellAutoComplete.ts` needed no change — the existing `freeCellAutoCompleteReady` already provides the gate.

## Test plan
- [x] `bun run test -- --run pages/FreeCellPage` (68 tests)
- [x] `bun run build` (clean tsc after removing `.tsbuildinfo`)
- [x] `bun run check`

Closes #3035