### PR TITLE
feat(indianrummy): mark wild-rank cards in hands with a WILD badge

### DIFF
--- a/frontend/src/i18n/locales/en/indianrummy.json
+++ b/frontend/src/i18n/locales/en/indianrummy.json
@@ -17,6 +17,8 @@
   "round": "Round {{n}}/{{total}}",
   "drawPile": "Draw pile: {{count}} cards",
   "wildJoker": "Wild Joker",
+  "wildBadge": "WILD",
+  "wildAria": "(wild)",
   "discardTop": "Discard",
   "cards": "{{count}} cards",
   "cumulativeScore": "Total: {{score}}",

--- a/frontend/src/i18n/locales/ja/indianrummy.json
+++ b/frontend/src/i18n/locales/ja/indianrummy.json
@@ -17,6 +17,8 @@
   "round": "ラウンド {{n}}/{{total}}",
   "drawPile": "山札: {{count}}枚",
   "wildJoker": "ワイルドジョーカー",
+  "wildBadge": "WILD",
+  "wildAria": "（ワイルド）",
   "discardTop": "捨て札",
   "cards": "{{count}}枚",
   "cumulativeScore": "累計: {{score}}",

--- a/frontend/src/pages/IndianRummyPage.test.tsx
+++ b/frontend/src/pages/IndianRummyPage.test.tsx
@@ -124,6 +124,37 @@ describe('IndianRummyPage', () => {
     });
   });
 
+  it('marks wild-rank cards in the human hand with a WILD badge', async () => {
+    const wildInHandState: IndianRummyResponse = {
+      ...drawPhaseState,
+      players: [
+        player({
+          cards: [
+            { design: 'SPADE', value: 1 },
+            { design: 'DIAMOND', value: 5 }, // matches wildJoker rank 5 -> wild
+            { design: 'JOKER', value: 0 }, // printed joker -> wild
+          ],
+        }),
+        drawPhaseState.players[1],
+      ],
+    };
+    mockExec.mockResolvedValue(wildInHandState);
+    renderWithProviders(<IndianRummyPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+    // Two of the three hand cards are wild (the rank-5 card and the printed joker).
+    expect(screen.getAllByTestId('ir-wild-badge')).toHaveLength(2);
+    // The non-wild ace carries no wild annotation in its label.
+    expect(screen.getByRole('button', { name: '♠ A' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /♦ 5 .*ワイルド/ })).toBeInTheDocument();
+  });
+
+  it('marks wild-rank cards in revealed CPU hands with a WILD badge', async () => {
+    mockExec.mockResolvedValue(roundEndCpuCardsState);
+    renderWithProviders(<IndianRummyPage />);
+    // CPU hand has a rank-5 card (DIAMOND 5) matching the wild joker.
+    await waitFor(() => expect(screen.getAllByTestId('ir-wild-badge').length).toBeGreaterThanOrEqual(1));
+  });
+
   it('renders draw stock and draw discard buttons on human draw turn', async () => {
     renderWithProviders(<IndianRummyPage />);
     await waitFor(() => {

--- a/frontend/src/pages/IndianRummyPage.tsx
+++ b/frontend/src/pages/IndianRummyPage.tsx
@@ -31,7 +31,7 @@ import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { IndianRummyResponse } from '../types/card';
+import type { Card, IndianRummyResponse } from '../types/card';
 import { IndianRummyPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
@@ -180,6 +180,21 @@ function IndianRummyPageContent() {
   const revealCpu = isRoundEnd || isGameEnd;
   const isHumanTurn = (isDrawPhase || isDiscardPhase) && state.players[state.currentPlayerIdx]?.isHuman === true;
 
+  // A card counts as wild when it is a printed joker or shares the rank of the round's wild joker.
+  const wildValue = state.wildJoker?.value;
+  const isWildCard = (card: Card): boolean =>
+    card.design === 'JOKER' || (wildValue !== undefined && card.value === wildValue);
+  const wildBadge = (card: Card) =>
+    isWildCard(card) ? (
+      <span
+        aria-hidden="true"
+        className="absolute top-0.5 right-0.5 px-1 rounded bg-ds-info text-ds-text-on-accent text-[8px] font-extrabold tracking-wider shadow-md pointer-events-none"
+        data-testid="ir-wild-badge"
+      >
+        {t('wildBadge')}
+      </span>
+    ) : null;
+
   return (
     <GamePageShell
       title={tc('nav.indianrummy')}
@@ -300,11 +315,16 @@ function IndianRummyPageContent() {
                       {revealCpu && p.cards.length > 0 && (
                         <div className="flex flex-wrap gap-1 mt-1">
                           {p.cards.map((card, idx) => (
-                            <AnimatedCard
+                            <div
                               key={`cpu-${p.id}-${card.design}-${card.value}-${idx}`}
-                              card={card}
-                              width={cardWidth * 0.8}
-                            />
+                              className={`relative inline-block rounded ${
+                                isWildCard(card) ? 'ring-2 ring-ds-info' : ''
+                              }`}
+                            >
+                              <AnimatedCard card={card} width={cardWidth * 0.8} />
+                              {isWildCard(card) && <span className="sr-only">{t('wildAria')}</span>}
+                              {wildBadge(card)}
+                            </div>
                           ))}
                         </div>
                       )}
@@ -360,9 +380,11 @@ function IndianRummyPageContent() {
                     type="button"
                     key={`${card.design}-${card.value}-${idx}`}
                     onClick={() => toggleCard(idx)}
-                    aria-label={cardAlt(card)}
+                    aria-label={`${cardAlt(card)}${isWildCard(card) ? ` ${t('wildAria')}` : ''}`}
                     aria-pressed={selectedCardIndices.includes(idx)}
-                    className={`transition-transform ${focusRingCard}`}
+                    className={`relative transition-transform ${focusRingCard} ${
+                      isWildCard(card) ? 'ring-2 ring-ds-info' : ''
+                    }`}
                     style={{
                       background: 'none',
                       padding: 0,
@@ -372,6 +394,7 @@ function IndianRummyPageContent() {
                     }}
                   >
                     <AnimatedCard card={card} width={cardWidth} />
+                    {wildBadge(card)}
                   </button>
                 ))}
               </div>


### PR DESCRIPTION
## 概要
インドラミーの手札で、その局のワイルドジョーカーと同ランクのカード（および印刷ジョーカー）に **WILD バッジ** と ds-info リングを付与し、パネルと手札を見比べる負担を解消する。

## 変更点
- `IndianRummyPage.tsx`: 人間の手札・公開された CPU 手札の両方でワイルド該当カードにバッジ＋リングを表示
- スクリーンリーダー向けに aria-label / sr-only テキストでワイルドである旨を通知
- ラウンドが変わり wildJoker が変わるとバッジ対象が追従（`state.wildJoker.value` 基準）
- `indianrummy.json` (ja/en): `wildBadge` / `wildAria` を追加

## テスト
- `IndianRummyPage.test.tsx`: 人間手札のワイルド該当カード（ランク一致＋印刷ジョーカー）にバッジが付くこと、非該当カードには付かないこと、公開 CPU 手札のワイルドカードにバッジが付くことを検証（47 tests green）
- build / biome / vitest all green

## 受け入れ条件
- [x] ワイルドランクのカードとジョーカーにバッジが表示される
- [x] aria-label にワイルド情報が含まれる
- [x] ラウンドが変わり wildJoker が変わるとバッジ対象が追従する
- [x] `IndianRummyPage.test.tsx` にバッジ表示テストを追加

Closes #3055