### PR TITLE
feat(barbu): annotate current-trick cards with player names and lead marker

### DIFF
--- a/frontend/src/i18n/locales/en/barbu.json
+++ b/frontend/src/i18n/locales/en/barbu.json
@@ -48,7 +48,8 @@
     "yourTricks": "Tricks",
     "selectTrump": "Pick a trump suit",
     "you": "You",
-    "cpu": "CPU {{id}}"
+    "cpu": "CPU {{id}}",
+    "lead": "Lead"
   },
   "button": {
     "play": "Play",

--- a/frontend/src/i18n/locales/ja/barbu.json
+++ b/frontend/src/i18n/locales/ja/barbu.json
@@ -48,7 +48,8 @@
     "yourTricks": "トリック",
     "selectTrump": "切札スートを選んでください",
     "you": "あなた",
-    "cpu": "CPU {{id}}"
+    "cpu": "CPU {{id}}",
+    "lead": "リード"
   },
   "button": {
     "play": "出す",

--- a/frontend/src/pages/BarbuPage.test.tsx
+++ b/frontend/src/pages/BarbuPage.test.tsx
@@ -131,6 +131,29 @@ describe('BarbuPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('p', { handIndex: 0 }));
   });
 
+  it('labels each trick card with the player who played it and marks the lead', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: 'play',
+        currentContract: 0,
+        currentTurn: 2,
+        currentTrick: [
+          { playerIdx: 1, card: card('HEART', 10) },
+          { playerIdx: 0, card: card('HEART', 12) },
+        ],
+      }),
+    );
+    renderWithProviders(<BarbuPage />);
+    const trickCards = await screen.findAllByTestId('bb-trick-card');
+    expect(trickCards).toHaveLength(2);
+    // Lead card (index 0) was played by CPU 1 and carries the lead marker (▸).
+    expect(trickCards[0]).toHaveTextContent('CPU 1');
+    expect(trickCards[0]).toHaveTextContent('▸');
+    // Follow card was played by the human; no lead marker on it.
+    expect(trickCards[1]).toHaveTextContent('あなた');
+    expect(trickCards[1]).not.toHaveTextContent('▸');
+  });
+
   it('shows a pass button in Dominoes and passes when no card is playable', async () => {
     mockExec.mockResolvedValue(makeState({ phase: 'play', currentContract: 6, currentTurn: 0, dominoPlayable: [] }));
     renderWithProviders(<BarbuPage />);

--- a/frontend/src/pages/BarbuPage.tsx
+++ b/frontend/src/pages/BarbuPage.tsx
@@ -292,9 +292,28 @@ function BarbuPageContent() {
                       {state.currentTrick.length === 0 ? (
                         <span className="text-ds-text-muted text-sm self-center">—</span>
                       ) : (
-                        state.currentTrick.map((tcard, i) => (
-                          <AnimatedCard key={i} card={tcard.card} width={cardWidth * 0.9} />
-                        ))
+                        state.currentTrick.map((tcard, i) => {
+                          const tp = state.players[tcard.playerIdx];
+                          const tIsHuman = tp?.isHuman === true;
+                          const isLead = i === 0;
+                          return (
+                            <div key={i} className="text-center" data-testid="bb-trick-card">
+                              <div className={`inline-block rounded ${isLead ? 'ring-2 ring-ds-info' : ''}`}>
+                                <AnimatedCard card={tcard.card} width={cardWidth * 0.9} />
+                              </div>
+                              <div
+                                className={`text-xs mt-1 ${tIsHuman ? 'text-ds-accent font-semibold' : 'text-ds-text-muted'}`}
+                              >
+                                {isLead && (
+                                  <span aria-hidden="true" className="mr-0.5" title={t('label.lead')}>
+                                    ▸
+                                  </span>
+                                )}
+                                {tIsHuman ? tc('player.you') : tc('player.cpu', { id: tp?.id ?? tcard.playerIdx })}
+                              </div>
+                            </div>
+                          );
+                        })
                       )}
                     </div>
                   </>


### PR DESCRIPTION
## 概要
バルブのトリック表示（`bb-board`）はカード画像を並べるだけで「誰が何を出したか」が分からなかった。各カードに出したプレイヤー名を併記し、リードカードを視覚的に区別できるようにする。

## 変更点
- `BarbuPage.tsx`: 現在トリックの各カードに `tc('player.you')` / `tc('player.cpu',{id})` の小ラベルを併記（`tcard.playerIdx` は既存フィールド）。リードカード（1枚目）は ds-info リング＋▸ マーカーで区別
- ドミノーズコントラクトのレイアウト（別ブランチのスート別グリッド）は不変
- `barbu.json` (ja/en): `label.lead` を追加

## テスト
- `BarbuPage.test.tsx`: プレイフェーズで2枚のトリックに「CPU 1」（リード＋▸）と「あなた」（▸なし）が表示されることを検証（13 tests green）
- build / biome / vitest all green

## 受け入れ条件
- [x] トリックの各カードに出したプレイヤー名が表示される
- [x] リードカードが視覚的に区別できる（リング＋▸）
- [x] ドミノーズコントラクト時のレイアウトは影響を受けない
- [x] `BarbuPage.test.tsx` にプレイヤー名表示のテストを追加

Closes #3349