### PR TITLE
feat(twotenjack): add a CPU-declaring progress indicator

### DIFF
--- a/frontend/src/i18n/locales/en/twotenjack.json
+++ b/frontend/src/i18n/locales/en/twotenjack.json
@@ -31,6 +31,7 @@
   "team1": "Opponents (1,3)",
   "declarePhase": "Declare the trump suit (♠/♣/♥/♦)",
   "declarePrompt": "Choose trump →",
+  "cpuDeclaring": "CPU is declaring trump...",
   "playButton": "Play",
   "nextTrick": "Next Trick",
   "nextRound": "Next Round",

--- a/frontend/src/i18n/locales/ja/twotenjack.json
+++ b/frontend/src/i18n/locales/ja/twotenjack.json
@@ -31,6 +31,7 @@
   "team1": "相手チーム (1,3)",
   "declarePhase": "切り札スートを宣言してください (♠/♣/♥/♦)",
   "declarePrompt": "切り札を選択 →",
+  "cpuDeclaring": "CPUが切り札を宣言中...",
   "playButton": "出す",
   "nextTrick": "次のトリック",
   "nextRound": "次のラウンド",

--- a/frontend/src/pages/TwoTenJackPage.test.tsx
+++ b/frontend/src/pages/TwoTenJackPage.test.tsx
@@ -135,6 +135,20 @@ describe('TwoTenJackPage', () => {
     expect(screen.queryByTestId('tt-declare-prompt')).not.toBeInTheDocument();
   });
 
+  it('shows a CPU-declaring indicator while a CPU declares trump', async () => {
+    mockExec.mockResolvedValue(declarePhaseCpuState);
+    renderWithProviders(<TwoTenJackPage />);
+    await waitFor(() => expect(screen.getByTestId('tt-cpu-declaring')).toBeInTheDocument());
+    expect(screen.getByTestId('tt-cpu-declaring')).toHaveTextContent('CPUが切り札を宣言中');
+  });
+
+  it('does not show the CPU-declaring indicator when the human declares', async () => {
+    mockExec.mockResolvedValue(declarePhaseState);
+    renderWithProviders(<TwoTenJackPage />);
+    await waitFor(() => expect(screen.getByTestId('tt-declare-prompt')).toBeInTheDocument());
+    expect(screen.queryByTestId('tt-cpu-declaring')).not.toBeInTheDocument();
+  });
+
   it('dispatches declare command when a suit button is clicked', async () => {
     mockExec.mockResolvedValue(declarePhaseState);
     renderWithProviders(<TwoTenJackPage />);

--- a/frontend/src/pages/TwoTenJackPage.tsx
+++ b/frontend/src/pages/TwoTenJackPage.tsx
@@ -417,6 +417,19 @@ function TwoTenJackPageContent() {
                   {t('declarePrompt')}
                 </span>
               )}
+              {isDeclarePhase && !isHumanDeclarer && (
+                <span
+                  data-testid="tt-cpu-declaring"
+                  role="status"
+                  className="flex items-center gap-2 text-ds-info text-sm font-medium w-full sm:w-auto"
+                >
+                  <span
+                    aria-hidden="true"
+                    className="inline-block w-3 h-3 rounded-full border-2 border-ds-info border-t-transparent motion-safe:animate-spin"
+                  />
+                  {t('cpuDeclaring')}
+                </span>
+              )}
               {isHumanDeclarer &&
                 SUIT_OPTIONS.map((suit) => (
                   <button


### PR DESCRIPTION
## 概要
ツーテンジャックでは人間が宣言者のときだけ案内テキストが出て、CPUが切り札を宣言している間は進行状況が何も表示されず「待っている」ことしか分からなかった。CPU宣言中のインジケーターを追加する。

## 変更点
- `TwoTenJackPage.tsx`: `isDeclarePhase && !isHumanDeclarer` のとき、スピナー＋「CPUが切り札を宣言中...」を `data-testid="tt-cpu-declaring"`（`role="status"`）で表示。`motion-safe:animate-spin` の円形スピナー
- `twotenjack.json` (ja/en): `cpuDeclaring` を追加
- `tt-declare-controls` 周辺のレイアウトは不変（人間宣言プロンプトと排他表示）

## テスト
- `TwoTenJackPage.test.tsx`: CPU宣言時にインジケーターが出ること／人間宣言時には出ないことを検証（29 tests green）
- build / biome / vitest all green

## 受け入れ条件
- [x] `isDeclarePhase && !isHumanDeclarer` の場合に専用のCPU宣言中表示が出る
- [x] 表示にはスピナー（アニメーション）を含める
- [x] `tt-declare-controls` 周辺レイアウトを崩さない
- [x] `t()` ベースの新規i18nキーがja/en両方に追加される

Closes #3134