### PR TITLE
feat(twentynine): flash a banner when the hidden trump is revealed

### DIFF
--- a/frontend/src/i18n/locales/en/twentynine.json
+++ b/frontend/src/i18n/locales/en/twentynine.json
@@ -17,6 +17,7 @@
   "round": "Round {{n}}",
   "trick": "Trick {{n}}",
   "trump": "Trump: {{suit}}",
+  "trumpRevealBanner": "Trump revealed: {{suit}}",
   "noTrump": "none",
   "hiddenTrump": "Hidden",
   "cards": "{{count}} cards",

--- a/frontend/src/i18n/locales/ja/twentynine.json
+++ b/frontend/src/i18n/locales/ja/twentynine.json
@@ -17,6 +17,7 @@
   "round": "ラウンド {{n}}",
   "trick": "トリック {{n}}",
   "trump": "切り札: {{suit}}",
+  "trumpRevealBanner": "切り札公開: {{suit}}",
   "noTrump": "なし",
   "hiddenTrump": "非公開",
   "cards": "{{count}}枚",

--- a/frontend/src/pages/TwentyNinePage.test.tsx
+++ b/frontend/src/pages/TwentyNinePage.test.tsx
@@ -141,6 +141,24 @@ describe('TwentyNinePage', () => {
     expect(screen.getByText('落札者')).toBeInTheDocument();
   });
 
+  it('flashes a trump-reveal banner when the hidden trump becomes revealed', async () => {
+    // Start on a human play turn with the trump still hidden.
+    mockExec.mockResolvedValue({ ...playPhaseState, trumpRevealed: false });
+    renderWithProviders(<TwentyNinePage />);
+    const card = await screen.findByAltText('♥ Q');
+    expect(screen.queryByTestId('tn-trump-reveal-banner')).not.toBeInTheDocument();
+
+    // Play a card; the resolved state now has the trump revealed (♥ = suit 3).
+    fireEvent.click(card);
+    const playBtn = await screen.findByRole('button', { name: '出す' });
+    mockExec.mockResolvedValue(playPhaseState);
+    fireEvent.click(playBtn);
+
+    const banner = await screen.findByTestId('tn-trump-reveal-banner');
+    expect(banner).toHaveTextContent('♥');
+    expect(banner).toHaveAttribute('role', 'status');
+  });
+
   it('shows live round card points during play', async () => {
     mockExec.mockResolvedValue(makeTwentyNineState({ phase: 1, isHumanBidTurn: false, roundTeamPoints: [12, 7] }));
     renderWithProviders(<TwentyNinePage />);

--- a/frontend/src/pages/TwentyNinePage.tsx
+++ b/frontend/src/pages/TwentyNinePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { twentyNineApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -126,6 +126,22 @@ function TwentyNinePageContent() {
   const { cardWidth, isMobile } = useCardDimensions();
   const phaseNames = usePhaseNames('twentynine', TWENTY_NINE_PHASE_KEYS);
 
+  // Flash a transient banner the moment the hidden trump is revealed mid-play,
+  // so the reveal is not missed while a CPU is playing (mirrors SpoilFive's potDelta).
+  const [showTrumpBanner, setShowTrumpBanner] = useState(false);
+  const prevTrumpRevealedRef = useRef<boolean | null>(null);
+  useEffect(() => {
+    const revealed = state?.trumpRevealed;
+    if (revealed == null) return;
+    const prev = prevTrumpRevealedRef.current;
+    prevTrumpRevealedRef.current = revealed;
+    if (prev === false && revealed === true) {
+      setShowTrumpBanner(true);
+      const id = setTimeout(() => setShowTrumpBanner(false), 3000);
+      return () => clearTimeout(id);
+    }
+  }, [state?.trumpRevealed]);
+
   if (!state)
     return <GameSkeleton gameKey="twentynine" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 8 }} />;
 
@@ -143,11 +159,8 @@ function TwentyNinePageContent() {
 
   const canPlay = isPlayPhase && isHumanTurn;
   // The trump suit is hidden until trumpRevealed flips true mid-play.
-  const trumpSymbol = !state.trumpRevealed
-    ? t('hiddenTrump')
-    : state.trumpSuit === 0
-      ? t('noTrump')
-      : (SUIT_SYMBOLS[state.trumpSuit] ?? '?');
+  const revealedTrumpSymbol = state.trumpSuit === 0 ? t('noTrump') : (SUIT_SYMBOLS[state.trumpSuit] ?? '?');
+  const trumpSymbol = !state.trumpRevealed ? t('hiddenTrump') : revealedTrumpSymbol;
 
   // The current highest (non-pass) bid; a new non-pass bid must beat it.
   const highestBid = Math.max(0, ...state.bids);
@@ -221,6 +234,16 @@ function TwentyNinePageContent() {
               <span className="mr-4">{t('trump', { suit: trumpSymbol })}</span>
               <span>{t('target', { points: state.config.targetPoints })}</span>
             </div>
+
+            {showTrumpBanner && (
+              <div
+                role="status"
+                data-testid="tn-trump-reveal-banner"
+                className="mx-auto mb-2 w-fit rounded-lg bg-ds-warning/20 px-4 py-1.5 text-center font-semibold text-ds-warning motion-safe:animate-pulse"
+              >
+                {t('trumpRevealBanner', { suit: revealedTrumpSymbol })}
+              </div>
+            )}
 
             <div className="text-ds-text-muted text-center mb-2 text-sm">
               {state.declarerIdx >= 0


### PR DESCRIPTION
## 概要
29（トゥエンティナイン）では隠し切り札の公開が最重要イベントだが、公開後はヘッダーの trumpSymbol が静かに差し替わるだけで、CPUのプレイ中に公開されると見逃しやすい。公開時に一時ハイライトバナーを表示する。

## 変更点
- `TwentyNinePage.tsx`: SpoilFive の `potDelta` と同じ `useRef`+`useEffect` パターンで `trumpRevealed` の false→true 遷移を検知し、「切り札公開: ♥」バナーを約3秒間 `motion-safe:animate-pulse` 付きで表示。`role="status"` でスクリーンリーダーにも通知
- `twentynine.json` (ja/en): `trumpRevealBanner` を追加

## テスト
- `TwentyNinePage.test.tsx`: 隠し切り札の状態でバナー非表示 → プレイ後に公開状態へ遷移するとバナー（♥・role=status）が表示されることを検証（15 tests green）
- build / biome / vitest all green

## 受け入れ条件
- [x] trumpRevealed が真に変わった直後にバナーが表示される
- [x] 一定時間後に自動で消える（setTimeout 3s + クリーンアップ）
- [x] role=status が付与される
- [x] TwentyNinePage.test.tsx に遷移テストを追加

Closes #3418