### PR TITLE
feat(klaverjas): show the winning team in a status banner at trick end

### DIFF
--- a/frontend/src/i18n/locales/en/klaverjas.json
+++ b/frontend/src/i18n/locales/en/klaverjas.json
@@ -23,7 +23,9 @@
   "you": "You",
   "cpu": "CPU {{id}}",
   "yourTeam": "Your Team",
-  "roem": { "title": "Roem (bonus)" },
+  "roem": {
+    "title": "Roem (bonus)"
+  },
   "team": {
     "a": "Team A",
     "b": "Team B"
@@ -31,6 +33,7 @@
   "teamScore": "{{team}}: {{score}} pts",
   "playButton": "Play",
   "nextTrick": "Next Trick",
+  "trickWinner": "{{team}} won the trick",
   "nextRound": "Next Round",
   "roundResult": {
     "title": "Round Result",

--- a/frontend/src/i18n/locales/ja/klaverjas.json
+++ b/frontend/src/i18n/locales/ja/klaverjas.json
@@ -23,7 +23,9 @@
   "you": "あなた",
   "cpu": "CPU {{id}}",
   "yourTeam": "あなたのチーム",
-  "roem": { "title": "Roem(ボーナス)" },
+  "roem": {
+    "title": "Roem(ボーナス)"
+  },
   "team": {
     "a": "チームA",
     "b": "チームB"
@@ -31,6 +33,7 @@
   "teamScore": "{{team}}: {{score}}点",
   "playButton": "出す",
   "nextTrick": "次のトリック",
+  "trickWinner": "{{team}} がトリック獲得",
   "nextRound": "次のラウンド",
   "roundResult": {
     "title": "ラウンド結果",

--- a/frontend/src/pages/KlaverjasPage.test.tsx
+++ b/frontend/src/pages/KlaverjasPage.test.tsx
@@ -75,6 +75,31 @@ describe('KlaverjasPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: '次のトリック' })).toBeInTheDocument());
   });
 
+  it('shows the winning team in a status banner at trick end', async () => {
+    // leadPlayerIdx 0 -> Team A won the trick.
+    mockExec.mockResolvedValue(trickEndState);
+    renderWithProviders(<KlaverjasPage />);
+    const banner = await screen.findByTestId('klaverjas-trick-winner');
+    expect(banner).toHaveTextContent('チームA がトリック獲得');
+    expect(banner).toHaveAttribute('role', 'status');
+    expect(banner).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('attributes the trick to Team B when an odd-seat player leads next', async () => {
+    mockExec.mockResolvedValue({ ...trickEndState, leadPlayerIdx: 1 });
+    renderWithProviders(<KlaverjasPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId('klaverjas-trick-winner')).toHaveTextContent('チームB がトリック獲得'),
+    );
+  });
+
+  it('does not show the trick-winner banner during play', async () => {
+    mockExec.mockResolvedValue(playPhaseState);
+    renderWithProviders(<KlaverjasPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('klaverjas-trick-winner')).not.toBeInTheDocument();
+  });
+
   it('renders round end with the next round button and the round result', async () => {
     mockExec.mockResolvedValue(roundEndState);
     renderWithProviders(<KlaverjasPage />);

--- a/frontend/src/pages/KlaverjasPage.tsx
+++ b/frontend/src/pages/KlaverjasPage.tsx
@@ -230,6 +230,17 @@ function KlaverjasPageContent() {
                   label={t('currentTrick')}
                   dataTutorial="klaverjas-trick-display"
                 />
+                {/* At TrickEnd leadPlayerIdx is the trick winner, so their team is shown before Next Trick. */}
+                {isTrickEnd && (
+                  <div
+                    className="my-2 p-2 rounded bg-ds-accent/15 text-center text-sm font-semibold text-ds-accent"
+                    role="status"
+                    aria-live="polite"
+                    data-testid="klaverjas-trick-winner"
+                  >
+                    {t('trickWinner', { team: state.leadPlayerIdx % 2 === 0 ? t('team.a') : t('team.b') })}
+                  </div>
+                )}
               </div>
 
               {/* Right: info sidebar */}


### PR DESCRIPTION
## 概要
クラヴァヤスの TRICK_END フェーズは「次のトリック」ボタンを出すだけで、どちらのチームがトリックを取ったか分からなかった。SuecaPage の勝者バナーパターンを移植する。

## 変更点
- `KlaverjasPage.tsx`: `isTrickEnd` のとき `leadPlayerIdx % 2`（トリック勝者が次リード）からチームA/Bを判定し、TrickDisplay の下にバナー表示。`data-testid="klaverjas-trick-winner"`、`role="status"` / `aria-live="polite"`
- `klaverjas.json` (ja/en): `trickWinner` を追加（Sueca と同一文言）

## テスト
- `KlaverjasPage.test.tsx`: TrickEnd でチームA表示・leadPlayerIdx:1→チームB・role/aria-live 付与・プレイ中は非表示、を検証（16 tests green）
- build / biome / vitest all green

## 受け入れ条件
- [x] TrickEnd で勝者チームのバナーが表示される
- [x] role=status と aria-live=polite が付与される
- [x] ja/en 両ロケールに trickWinner キーを追加
- [x] KlaverjasPage.test.tsx にテストを追加

Closes #3421