### PR TITLE
feat(manille): show the trick winner and team in a status banner at trick end

### DIFF
--- a/frontend/src/i18n/locales/en/manille.json
+++ b/frontend/src/i18n/locales/en/manille.json
@@ -23,6 +23,7 @@
   "you": "You",
   "cpu": "CPU {{id}}",
   "yourTeam": "Your Team",
+  "trickWinner": "{{name}} ({{team}}) won the trick",
   "team": {
     "a": "Team A",
     "b": "Team B"

--- a/frontend/src/i18n/locales/ja/manille.json
+++ b/frontend/src/i18n/locales/ja/manille.json
@@ -23,6 +23,7 @@
   "you": "あなた",
   "cpu": "CPU {{id}}",
   "yourTeam": "あなたのチーム",
+  "trickWinner": "{{name}}（{{team}}）がトリック獲得",
   "team": {
     "a": "チームA",
     "b": "チームB"

--- a/frontend/src/pages/ManillePage.test.tsx
+++ b/frontend/src/pages/ManillePage.test.tsx
@@ -85,6 +85,32 @@ describe('ManillePage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: '次のトリック' })).toBeInTheDocument());
   });
 
+  it('shows the trick winner and team in a status banner at trick end', async () => {
+    // leadPlayerIdx 0 = the human (Team A), so their own-team banner appears.
+    mockExec.mockResolvedValue(trickEndState);
+    renderWithProviders(<ManillePage />);
+    const banner = await screen.findByTestId('manille-trick-winner');
+    expect(banner).toHaveTextContent('あなた（チームA）がトリック獲得');
+    expect(banner).toHaveClass('text-ds-accent');
+    expect(banner).toHaveAttribute('role', 'status');
+    expect(banner).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('shows an opponent-team win without own-team emphasis', async () => {
+    mockExec.mockResolvedValue({ ...trickEndState, leadPlayerIdx: 1 });
+    renderWithProviders(<ManillePage />);
+    const banner = await screen.findByTestId('manille-trick-winner');
+    expect(banner).toHaveTextContent('チームB');
+    expect(banner).not.toHaveClass('text-ds-accent');
+  });
+
+  it('does not show the trick-winner banner during play', async () => {
+    mockExec.mockResolvedValue(playPhaseState);
+    renderWithProviders(<ManillePage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('manille-trick-winner')).not.toBeInTheDocument();
+  });
+
   it('renders round end with the next round button and the round result', async () => {
     mockExec.mockResolvedValue(roundEndState);
     renderWithProviders(<ManillePage />);

--- a/frontend/src/pages/ManillePage.tsx
+++ b/frontend/src/pages/ManillePage.tsx
@@ -232,6 +232,27 @@ function ManillePageContent() {
                   label={t('currentTrick')}
                   dataTutorial="manille-trick-display"
                 />
+                {/* At TrickEnd leadPlayerIdx is the trick winner (they lead next), so show who took it. */}
+                {isTrickEnd &&
+                  (() => {
+                    const winnerIdx = state.leadPlayerIdx;
+                    const isMyTeam = winnerIdx % 2 === humanTeam;
+                    return (
+                      <div
+                        className={`my-2 p-2 rounded text-center text-sm font-semibold ${
+                          isMyTeam ? 'bg-ds-accent/15 text-ds-accent' : 'bg-black/30 text-ds-text-muted'
+                        }`}
+                        role="status"
+                        aria-live="polite"
+                        data-testid="manille-trick-winner"
+                      >
+                        {t('trickWinner', {
+                          name: playerName(winnerIdx, state.players[winnerIdx]?.isHuman ?? false),
+                          team: winnerIdx % 2 === 0 ? t('team.a') : t('team.b'),
+                        })}
+                      </div>
+                    );
+                  })()}
               </div>
 
               {/* Right: info sidebar */}


### PR DESCRIPTION
## 概要
マニーユの TRICK_END フェーズは「次のトリック」ボタンを出すだけで、どのプレイヤー・チームがトリックを取ったか表示しなかった。1トリックに最大15点が乗る得点差の大きいゲームなので、勝者バナーを追加する。

## 変更点
- `ManillePage.tsx`: `isTrickEnd` のとき `leadPlayerIdx`（勝者が次リード）から勝者名とチームA/Bを表示するバナーを TrickDisplay の下に追加。自チーム獲得時は accent 色で強調、`role="status"` / `aria-live="polite"`、`data-testid="manille-trick-winner"`
- `manille.json` (ja/en): `trickWinner` を追加

## テスト
- `ManillePage.test.tsx`: 自チーム勝利（accent強調）／相手チーム勝利（非強調）／role・aria-live付与／プレイ中は非表示、を検証（13 tests green）
- build / biome / vitest all green

## 受け入れ条件
- [x] TrickEnd で勝者プレイヤー名とチームが表示される
- [x] 自チーム獲得時に視覚的な強調がされる（accent色）
- [x] role=status / aria-live=polite が付与される
- [x] ManillePage.test.tsx にテストを追加

Closes #3426