### PR TITLE
feat(scopone): replace the plain loading text with GameSkeleton

### DIFF
--- a/frontend/src/pages/ScoponePage.test.tsx
+++ b/frontend/src/pages/ScoponePage.test.tsx
@@ -23,6 +23,12 @@ afterEach(async () => {
 });
 
 describe('ScoponePage', () => {
+  it('renders the GameSkeleton while the initial state is loading', () => {
+    mockExec.mockReturnValue(new Promise(() => undefined));
+    renderWithProviders(<ScoponePage />);
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+  });
+
   it('calls reset on mount with the short "r" command', async () => {
     renderWithProviders(<ScoponePage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('r'));

--- a/frontend/src/pages/ScoponePage.tsx
+++ b/frontend/src/pages/ScoponePage.tsx
@@ -9,6 +9,7 @@ import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
+import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useCardDimensions } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
@@ -125,9 +126,10 @@ function ScoponePageContent() {
 
   if (!state || !human) {
     return (
-      <div className={`flex-1 flex items-center justify-center ${gameTheme.scopone.bg} text-ds-text-muted`} aria-busy>
-        {tc('skeleton.loading')}
-      </div>
+      <GameSkeleton
+        gameKey="scopone"
+        layout={{ kind: 'trick-taking', opponents: 3, trickArea: true, footerHandSize: 10 }}
+      />
     );
   }
 


### PR DESCRIPTION
## 概要
`ScoponePage.tsx` は `state` が null の間、素のテキスト1行を返しており、初回ロードや reset 時に画面が大きくレイアウトシフトしていた。共通の `GameSkeleton` に置換する。

## 変更点
- `ScoponePage.tsx`: null-state 分岐を `<GameSkeleton gameKey="scopone" layout={{ kind: 'trick-taking', opponents: 3, trickArea: true, footerHandSize: 10 }} />` に置換（背景/フッターは gameTheme から自動解決）
- 素の loading div とその文言依存を削除

## テスト
- `ScoponePage.test.tsx`: 初期ロード中に GameSkeleton（`data-testid="skeleton"`）が描画されることを検証。既存の「4人未満で手札非表示」分岐も skeleton 経路を通り green（17 tests green）
- build / biome / vitest all green

## 受け入れ条件
- [x] state null 時に GameSkeleton が描画される
- [x] ロード完了後のレイアウトシフトが軽減される（共通スケルトンでテーブル+手札プレースホルダ）
- [x] ページテストのローディング分岐アサーションを更新
- [x] bun run build / check / test が green

Closes #3463