### PR TITLE
feat(calabresella): show remaining discard count during the monte swap

### DIFF
--- a/frontend/src/i18n/locales/en/calabresella.json
+++ b/frontend/src/i18n/locales/en/calabresella.json
@@ -22,6 +22,7 @@
   "bidNone": "-",
   "bidPhase": "Bidding phase — pass / chiamo (stake 1) / solo (stake 2).",
   "discardPhase": "Monte exchange — discard four cards down to twelve.",
+  "discardPhaseRemaining": "Select cards to discard ({{count}} left)",
   "bidChiamo": "Chiamo",
   "bidSolo": "Solo",
   "bidPass": "Pass",

--- a/frontend/src/i18n/locales/ja/calabresella.json
+++ b/frontend/src/i18n/locales/ja/calabresella.json
@@ -22,6 +22,7 @@
   "bidNone": "-",
   "bidPhase": "入札フェーズ — パス／キアーモ（賭け1）／ソロ（賭け2）。",
   "discardPhase": "モンテ交換 — 16枚から12枚になるよう4枚を捨てます。",
+  "discardPhaseRemaining": "捨て札を選択（残り {{count}} 枚）",
   "bidChiamo": "キアーモ",
   "bidSolo": "ソロ",
   "bidPass": "パス",

--- a/frontend/src/pages/CalabresellaPage.test.tsx
+++ b/frontend/src/pages/CalabresellaPage.test.tsx
@@ -19,7 +19,44 @@ const bidPhaseState = makeCalabresellaState({
   isHumanTurn: true,
   winningBid: 0,
 });
-const discardPhaseState = makeCalabresellaState({ phase: 1, soloistIdx: 0 });
+// A realistic discard phase: the soloist holds 16 cards (took the 4-card monte) and must
+// discard down to the regulation 12, so 4 discards remain. Keeps ♥Q for selection tests.
+const soloist16CardHand = [
+  { design: 'HEART' as const, value: 12 },
+  { design: 'HEART' as const, value: 13 },
+  { design: 'SPADE' as const, value: 1 },
+  { design: 'SPADE' as const, value: 2 },
+  { design: 'SPADE' as const, value: 3 },
+  { design: 'SPADE' as const, value: 4 },
+  { design: 'SPADE' as const, value: 5 },
+  { design: 'SPADE' as const, value: 6 },
+  { design: 'SPADE' as const, value: 7 },
+  { design: 'CLOVER' as const, value: 1 },
+  { design: 'CLOVER' as const, value: 2 },
+  { design: 'CLOVER' as const, value: 3 },
+  { design: 'CLOVER' as const, value: 4 },
+  { design: 'CLOVER' as const, value: 5 },
+  { design: 'CLOVER' as const, value: 6 },
+  { design: 'CLOVER' as const, value: 7 },
+];
+const discardPhaseState = makeCalabresellaState({
+  phase: 1,
+  soloistIdx: 0,
+  players: [
+    {
+      id: 0,
+      isHuman: true,
+      cardCount: 16,
+      cards: soloist16CardHand,
+      trickCount: 0,
+      score: 0,
+      isSoloist: true,
+      roundThirds: 0,
+    },
+    { id: 1, isHuman: false, cardCount: 12, cards: [], trickCount: 0, score: 0, isSoloist: false, roundThirds: 0 },
+    { id: 2, isHuman: false, cardCount: 12, cards: [], trickCount: 0, score: 0, isSoloist: false, roundThirds: 0 },
+  ],
+});
 const trickEndState = makeCalabresellaState({
   phase: 3,
   currentTrick: [
@@ -92,7 +129,41 @@ describe('CalabresellaPage', () => {
     mockExec.mockResolvedValue(discardPhaseState);
     renderWithProviders(<CalabresellaPage />);
     await waitFor(() => expect(screen.getByTestId('calabresella-discard-prompt')).toBeInTheDocument());
-    expect(screen.getByRole('button', { name: 'カードを捨てる' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /カードを捨てる/ })).toBeInTheDocument();
+  });
+
+  it('shows the remaining discard count in the prompt and on the button', async () => {
+    // 16-card soloist hand → 4 discards remain before reaching the regulation 12.
+    mockExec.mockResolvedValue(discardPhaseState);
+    renderWithProviders(<CalabresellaPage />);
+    const prompt = await screen.findByTestId('calabresella-discard-prompt');
+    expect(prompt).toHaveTextContent('残り 4 枚');
+    expect(screen.getByTestId('calabresella-discard-button')).toHaveTextContent('(4)');
+  });
+
+  it('hides the discard prompt once the hand is down to the regulation 12', async () => {
+    mockExec.mockResolvedValue({
+      ...discardPhaseState,
+      players: [
+        {
+          id: 0,
+          isHuman: true,
+          cardCount: 12,
+          cards: soloist16CardHand.slice(0, 12),
+          trickCount: 0,
+          score: 0,
+          isSoloist: true,
+          roundThirds: 0,
+        },
+        ...discardPhaseState.players.slice(1),
+      ],
+    });
+    renderWithProviders(<CalabresellaPage />);
+    await waitFor(() => expect(screen.getByTestId('calabresella-discard-button')).toBeInTheDocument());
+    expect(screen.queryByTestId('calabresella-discard-prompt')).not.toBeInTheDocument();
+    // With nothing left to discard the button no longer carries a count suffix.
+    expect(screen.getByTestId('calabresella-discard-button')).toHaveTextContent('カードを捨てる');
+    expect(screen.getByTestId('calabresella-discard-button').textContent).not.toContain('(');
   });
 
   it('selecting a card then discarding dispatches discard', async () => {
@@ -100,7 +171,7 @@ describe('CalabresellaPage', () => {
     renderWithProviders(<CalabresellaPage />);
     const card = await screen.findByAltText('♥ Q');
     fireEvent.click(card);
-    const discardBtn = await screen.findByRole('button', { name: 'カードを捨てる' });
+    const discardBtn = await screen.findByRole('button', { name: /カードを捨てる/ });
     mockExec.mockClear();
     mockExec.mockResolvedValue(discardPhaseState);
     fireEvent.click(discardBtn);

--- a/frontend/src/pages/CalabresellaPage.tsx
+++ b/frontend/src/pages/CalabresellaPage.tsx
@@ -144,6 +144,10 @@ function CalabresellaPageContent() {
   const canBid = isBidPhase && state.currentBidderIdx === humanIdx;
   const canDiscard = isDiscardPhase && state.soloistIdx === humanIdx;
   const canPlay = isPlayPhase && isHumanTurn;
+  // The soloist takes the 4-card monte (16 cards) and discards down to the regulation
+  // 12-card hand (CalabresellaHandSize in the backend).
+  const REGULATION_HAND_SIZE = 12;
+  const discardRemaining = humanPlayer ? Math.max(0, humanPlayer.cards.length - REGULATION_HAND_SIZE) : 0;
 
   const handleManualReset = () => {
     hideActionLog();
@@ -309,12 +313,12 @@ function CalabresellaPageContent() {
                 {t('bidPhase')}
               </div>
             )}
-            {canDiscard && (
+            {canDiscard && discardRemaining > 0 && (
               <div
                 className="mb-1 text-center text-sm text-ds-accent font-semibold"
                 data-testid="calabresella-discard-prompt"
               >
-                {t('discardPhase')}
+                {t('discardPhaseRemaining', { count: discardRemaining })}
               </div>
             )}
             {humanPlayer && (
@@ -364,8 +368,9 @@ function CalabresellaPageContent() {
                   className={btnPrimary}
                   onClick={handleDiscard}
                   disabled={loading || selectedCardIndices.length !== 1}
+                  data-testid="calabresella-discard-button"
                 >
-                  {t('discardCard')}
+                  {discardRemaining > 0 ? `${t('discardCard')} (${discardRemaining})` : t('discardCard')}
                 </button>
               )}
               {canPlay && (


### PR DESCRIPTION
## 概要
カラブレセッラの DISCARD フェーズは、ソリストがモンテ交換後に規定枚数まで手札を捨てる工程だが、**あと何枚捨てる必要があるか**が画面に出ず、残数不明のまま discardCard ボタンを押し直す操作を繰り返していた。

## 変更点
- `CalabresellaPage.tsx`: `humanPlayer.cards.length` と規定手札枚数（`CalabresellaHandSize = 12`）から残ディスカード数を算出。プロンプトを「捨て札を選択（残り n 枚）」の動的表示にし、残0でプロンプトを非表示。ボタンにも `(n)` を併記（`data-testid="calabresella-discard-button"`）
- `calabresella.json` (ja/en): `discardPhaseRemaining` を追加

> 注: issue 本文は規定枚数を「8枚」としていましたが、バックエンド `CalabresellaHandSize = 12`（16枚から4枚捨てる）に合わせて 12 を採用しました。

## テスト
- `CalabresellaPage.test.tsx`: 16枚手札で「残り 4 枚」＋ボタン `(4)`／規定12枚到達でプロンプト非表示・カウント無し、を検証。既存の discard フィクスチャを現実的な16枚手札に更新（14 tests green）
- build / biome / vitest all green（tsc も green）

## 受け入れ条件
- [x] ディスカード残数がプロンプトに表示される
- [x] 1枚捨てるごとにカウントが減る
- [x] 規定枚数到達でプロンプトが消える
- [x] `CalabresellaPage.test.tsx` にカウント表示のテストを追加

Closes #3607