### PR TITLE
refactor(caribbeanstud): move the hint toggle into the SettingsPanel

### DIFF
--- a/frontend/src/pages/CaribbeanStudPage.tsx
+++ b/frontend/src/pages/CaribbeanStudPage.tsx
@@ -186,15 +186,6 @@ function CaribbeanStudPageContent() {
               messageParams={state.messageParams}
             />
 
-            <label className="flex items-center gap-1 text-ds-text-primary text-xs justify-center mb-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={frontendHintEnabled}
-                onChange={(e) => setFrontendHintEnabled(e.target.checked)}
-              />
-              {tc('hint.toggle', { ns: 'tutorial' })}
-            </label>
-
             {frontendHintEnabled && frontendHint && (
               <HintTooltip reason={t(frontendHint.reason)} confidence={frontendHint.confidence} />
             )}
@@ -321,7 +312,22 @@ function CaribbeanStudPageContent() {
 
           <GameFooter className={`${gameTheme.caribbeanstud.footer} px-4 pt-3`}>
             <ErrorAlert message={error} onRetry={retry} />
-            <SettingsPanel title={t('settings.title')} groups={[]} />
+            <SettingsPanel
+              title={t('settings.title')}
+              groups={[
+                {
+                  items: [
+                    {
+                      type: 'checkbox',
+                      id: 'frontendHint',
+                      label: tc('hint.toggle', { ns: 'tutorial' }),
+                      checked: frontendHintEnabled,
+                      onToggle: setFrontendHintEnabled,
+                    },
+                  ],
+                },
+              ]}
+            />
             {isBetPhase && (
               <div className="flex flex-col items-center gap-2 pb-2" data-tutorial="csp-bet-controls">
                 <ChipBetInput


### PR DESCRIPTION
## 概要
`CaribbeanStudPage.tsx` は `SettingsPanel` を空の `groups` で呼び出す一方、ヒントのオン/オフをカードエリア上部の独立した生の `<label><input type="checkbox"></label>` として描画しており、カリビアンスタッドだけ設定項目がUI上で分断されていた。PaiGow/Canfield/Durak と同様に統合する。

## 変更点
- `CaribbeanStudPage.tsx`: ヒントチェックボックスを `SettingsPanel` の `groups[0].items` に移動（`type: 'checkbox', id: 'frontendHint', onToggle: setFrontendHintEnabled`）。カードエリア上部の独立 `<label>` を削除。挙動（`frontendHintEnabled`）は不変

## テスト
- 既存テストはそのまま green（`getByRole('checkbox')` は SettingsPanel 内のチェックボックスを検出、セレクタ更新不要）（21 tests green）
- build / biome / vitest all green

## 受け入れ条件
- [x] `SettingsPanel` の `groups` にヒントトグル項目が追加される
- [x] カードエリア上部の独立した `<label>` は削除される
- [x] 挙動（`frontendHintEnabled`/`setFrontendHintEnabled`）は変更しない
- [x] 既存テストが green（セレクタ更新は不要だった）

Closes #3136