### PR TITLE
feat(sixcardgolf): show the human column scores during active play

### DIFF
--- a/frontend/src/i18n/locales/en/sixcardgolf.json
+++ b/frontend/src/i18n/locales/en/sixcardgolf.json
@@ -13,7 +13,8 @@
     "cpu": "CPU {{id}}",
     "faceDown": "Face Down",
     "finalTurn": "Final Turn",
-    "columnScore": "{{score}} pt"
+    "columnScore": "{{score}} pt",
+    "columnScoreUncertain": "{{score}}+? pt"
   },
   "button": {
     "flipInitial": "Flip",

--- a/frontend/src/i18n/locales/ja/sixcardgolf.json
+++ b/frontend/src/i18n/locales/ja/sixcardgolf.json
@@ -13,7 +13,8 @@
     "cpu": "CPU{{id}}",
     "faceDown": "伏せ札",
     "finalTurn": "最終ターン",
-    "columnScore": "{{score}}pt"
+    "columnScore": "{{score}}pt",
+    "columnScoreUncertain": "{{score}}+? pt"
   },
   "button": {
     "flipInitial": "めくる",

--- a/frontend/src/pages/SixCardGolfPage.test.tsx
+++ b/frontend/src/pages/SixCardGolfPage.test.tsx
@@ -88,10 +88,29 @@ describe('SixCardGolfPage', () => {
     expect(screen.getAllByRole('button', { name: '♠ 3' }).length).toBeGreaterThan(0);
   });
 
-  it('does not show the column breakdown during active play', async () => {
-    mockExec.mockResolvedValue(makeState({ phase: 1 /* player turn */ }));
+  it('shows the human column breakdown during active play, marking uncertain columns', async () => {
+    const faceDownGrid = [
+      slot(5),
+      slot(3),
+      slot(7),
+      { card: null, faceUp: false } as unknown as SixCardGolfSlot, // column 0 bottom still hidden
+      slot(9),
+      slot(2),
+    ];
+    mockExec.mockResolvedValue(
+      makeState({
+        phase: 1, // player turn
+        players: [
+          { id: 0, isHuman: true, grid: faceDownGrid, roundScore: 0, cumulativeScore: 0, allFaceUp: false },
+          { id: 1, isHuman: false, grid: [...faceDownGrid], roundScore: 0, cumulativeScore: 0, allFaceUp: false },
+        ],
+      }),
+    );
     renderWithProviders(<SixCardGolfPage />);
-    await waitFor(() => expect(mockExec).toHaveBeenCalled());
-    await waitFor(() => expect(screen.queryByTestId('scg-column-scores')).not.toBeInTheDocument());
+    // The breakdown is now visible mid-play.
+    await screen.findByTestId('scg-column-scores');
+    // Column 0 has a hidden bottom card → uncertain "+?" display; column 1 is fully revealed.
+    expect(screen.getByTestId('scg-column-score-0')).toHaveTextContent('+?');
+    expect(screen.getByTestId('scg-column-score-1')).not.toHaveTextContent('+?');
   });
 });

--- a/frontend/src/pages/SixCardGolfPage.tsx
+++ b/frontend/src/pages/SixCardGolfPage.tsx
@@ -221,7 +221,7 @@ function SixCardGolfPageContent() {
                   />
                 ))}
               </div>
-              {player.isHuman && (phase === SCG_PHASE_ROUND_OVER || isGameEnd) && (
+              {player.isHuman && (
                 <div className="mt-1 grid grid-cols-3 gap-1" data-testid="scg-column-scores">
                   {sixCardGolfColumnScores(player.grid).map((col, cIdx) => (
                     <span
@@ -231,7 +231,9 @@ function SixCardGolfPageContent() {
                         col.isPair ? 'bg-ds-success text-white' : 'bg-ds-surface-elevated text-ds-text-muted'
                       }`}
                     >
-                      {t('label.columnScore', { score: col.score })}
+                      {col.hasHidden
+                        ? t('label.columnScoreUncertain', { score: col.score })
+                        : t('label.columnScore', { score: col.score })}
                     </span>
                   ))}
                 </div>

--- a/frontend/src/utils/sixCardGolfColumnScores.test.ts
+++ b/frontend/src/utils/sixCardGolfColumnScores.test.ts
@@ -26,23 +26,33 @@ describe('sixCardGolfColumnScores', () => {
     expect(cols).toHaveLength(3);
     expect(cols.map((c) => c.score)).toEqual([7, 11, 15]);
     expect(cols.every((c) => !c.isPair)).toBe(true);
+    // All cards face up → no column is uncertain.
+    expect(cols.every((c) => !c.hasHidden)).toBe(true);
   });
 
   it('cancels a matched column to zero', () => {
     // Column 0 is a pair (5 over 5) → 0; column 1 is K over K → pair 0.
     const grid = [slot(5), slot(13), slot(2), slot(5), slot(13), slot(9)];
     const cols = sixCardGolfColumnScores(grid);
-    expect(cols[0]).toEqual({ score: 0, isPair: true });
-    expect(cols[1]).toEqual({ score: 0, isPair: true });
-    expect(cols[2]).toEqual({ score: 11, isPair: false });
+    expect(cols[0]).toEqual({ score: 0, isPair: true, hasHidden: false });
+    expect(cols[1]).toEqual({ score: 0, isPair: true, hasHidden: false });
+    expect(cols[2]).toEqual({ score: 11, isPair: false, hasHidden: false });
   });
 
-  it('ignores face-down cards in the total', () => {
+  it('ignores face-down cards in the total and flags the column uncertain', () => {
     const grid = [slot(8), slot(4), slot(2), slot(6, false), slot(4, false), slot(2)];
     const cols = sixCardGolfColumnScores(grid);
-    // col0: 8 + (face-down) = 8; col1: 4 + (face-down) = 4 (no pair, bottom hidden); col2: 2+2 pair → 0
-    expect(cols[0]).toEqual({ score: 8, isPair: false });
-    expect(cols[1]).toEqual({ score: 4, isPair: false });
-    expect(cols[2]).toEqual({ score: 0, isPair: true });
+    // col0: 8 + (face-down) = 8, uncertain; col1: 4 + (face-down) = 4, uncertain; col2: 2+2 pair → 0, certain.
+    expect(cols[0]).toEqual({ score: 8, isPair: false, hasHidden: true });
+    expect(cols[1]).toEqual({ score: 4, isPair: false, hasHidden: true });
+    expect(cols[2]).toEqual({ score: 0, isPair: true, hasHidden: false });
+  });
+
+  it('marks a column uncertain when a slot has no card yet', () => {
+    const grid = [slot(8), slot(4), slot(2), slot(null), slot(6), slot(9)];
+    const cols = sixCardGolfColumnScores(grid);
+    expect(cols[0].hasHidden).toBe(true); // bottom slot has no card
+    expect(cols[1].hasHidden).toBe(false);
+    expect(cols[2].hasHidden).toBe(false);
   });
 });

--- a/frontend/src/utils/sixCardGolfColumnScores.ts
+++ b/frontend/src/utils/sixCardGolfColumnScores.ts
@@ -25,6 +25,8 @@ export interface SixCardGolfColumnScore {
   score: number;
   /** True when both cards are face up and share the same value (cancels to 0). */
   isPair: boolean;
+  /** True when at least one card in the column is still face down (score not yet certain). */
+  hasHidden: boolean;
 }
 
 /**
@@ -39,15 +41,17 @@ export function sixCardGolfColumnScores(grid: SixCardGolfSlot[]): SixCardGolfCol
   for (let col = 0; col < SIX_CARD_GOLF_COLUMNS; col++) {
     const top = grid[col];
     const bot = grid[col + SIX_CARD_GOLF_COLUMNS];
+    // A slot with no face-up card (face down, or no card yet) keeps the column uncertain.
+    const hasHidden = !(top?.faceUp && top.card != null) || !(bot?.faceUp && bot.card != null);
     const isPair =
       !!top?.faceUp && !!bot?.faceUp && top.card != null && bot.card != null && top.card.value === bot.card.value;
     if (isPair) {
-      result.push({ score: 0, isPair: true });
+      result.push({ score: 0, isPair: true, hasHidden: false });
       continue;
     }
     const topScore = top?.faceUp ? sixCardGolfCardScore(top.card) : 0;
     const botScore = bot?.faceUp ? sixCardGolfCardScore(bot.card) : 0;
-    result.push({ score: topScore + botScore, isPair: false });
+    result.push({ score: topScore + botScore, isPair: false, hasHidden });
   }
   return result;
 }


### PR DESCRIPTION
## 概要
シックスカードゴルフの核心は「縦2枚ペアで0点」を狙う判断だが、列スコア表示（`scg-column-scores`）は ROUND_OVER / ゲーム終了時のみ描画され、スワップ先を選ぶプレイ中は表向きカードから暗算するしかなかった。プレイ中も常時表示に変更する。

## 変更点
- `sixCardGolfColumnScores.ts`: 返り値に `hasHidden`（裏向き/未配置カードを含む列 = スコア未確定）を追加
- `SixCardGolfPage.tsx`: 人間グリッドの列スコアをフェーズ非依存で常時表示。`hasHidden` 列は `{{score}}+? pt` の不確定表示、ペア成立列の緑ハイライトはそのまま
- `sixcardgolf.json` (ja/en): `label.columnScoreUncertain` を追加

## テスト
- `sixCardGolfColumnScores.test.ts`: 既存の `toEqual` を `hasHidden` 込みに更新＋裏向き列/未配置スロットの不確定判定テストを追加
- `SixCardGolfPage.test.tsx`: 「プレイ中は非表示」テストを「プレイ中も表示＋不確定列は +? 表示」に反転更新（25 tests green）
- build / biome / vitest all green

## 受け入れ条件
- [x] プレイ中も人間の列スコアが表示される
- [x] 裏向きカードを含む列は不確定表示（+?）になる
- [x] ペア成立列の緑ハイライトがプレイ中も機能する
- [x] `sixCardGolfColumnScores.test.ts` と `SixCardGolfPage.test.tsx` を更新

Closes #3334