### PR TITLE
feat(ohhell): highlight the winning card at trick end

### DIFF
--- a/frontend/src/components/TrickDisplay.test.tsx
+++ b/frontend/src/components/TrickDisplay.test.tsx
@@ -87,4 +87,32 @@ describe('TrickDisplay', () => {
     );
     expect(container.querySelector('[data-team-role]')).not.toBeInTheDocument();
   });
+
+  it('highlights the winning card with a badge when winnerIdx is set', () => {
+    const { container } = render(
+      <TrickDisplay
+        currentTrick={trick}
+        players={players}
+        cardWidth={40}
+        label="label"
+        winnerIdx={1}
+        winnerLabel="勝ち"
+      />,
+    );
+    const badge = screen.getByTestId('trick-winner-badge');
+    expect(badge).toHaveTextContent('勝ち');
+    // Exactly one card is flagged the winner.
+    expect(container.querySelectorAll('[data-trick-winner="true"]')).toHaveLength(1);
+  });
+
+  it('shows no winner highlight when winnerIdx is omitted', () => {
+    const { container } = render(<TrickDisplay currentTrick={trick} players={players} cardWidth={40} label="label" />);
+    expect(screen.queryByTestId('trick-winner-badge')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-trick-winner]')).not.toBeInTheDocument();
+  });
+
+  it('defaults the winner badge text to WIN', () => {
+    render(<TrickDisplay currentTrick={trick} players={players} cardWidth={40} label="label" winnerIdx={0} />);
+    expect(screen.getByTestId('trick-winner-badge')).toHaveTextContent('WIN');
+  });
 });

--- a/frontend/src/components/TrickDisplay.tsx
+++ b/frontend/src/components/TrickDisplay.tsx
@@ -28,6 +28,10 @@ export interface TrickDisplayProps {
   label: string;
   /** Value for the `data-tutorial` attribute (e.g. `"ht-trick-display"`). */
   dataTutorial?: string;
+  /** When set (e.g. the trick winner at TRICK_END), that player's card gets a gold ring + WIN badge. */
+  winnerIdx?: number;
+  /** Localised badge/announcement text for the winning card (defaults to "WIN"). */
+  winnerLabel?: string;
 }
 
 /**
@@ -41,7 +45,15 @@ export interface TrickDisplayProps {
  * team's color (blue) or the opposing team's color (red) to make ally/opponent
  * relationships scannable at a glance.
  */
-export function TrickDisplay({ currentTrick, players, cardWidth, label, dataTutorial }: TrickDisplayProps) {
+export function TrickDisplay({
+  currentTrick,
+  players,
+  cardWidth,
+  label,
+  dataTutorial,
+  winnerIdx,
+  winnerLabel,
+}: TrickDisplayProps) {
   if (currentTrick.length === 0) {
     return null;
   }
@@ -59,7 +71,15 @@ export function TrickDisplay({ currentTrick, players, cardWidth, label, dataTuto
           const team = player?.team;
           const isAlly = hasTeams && team !== undefined && team === humanTeam;
           const isFoe = hasTeams && team !== undefined && team !== humanTeam;
-          const wrapperClass = isAlly ? 'ring-2 ring-ds-info rounded' : isFoe ? 'ring-2 ring-ds-error rounded' : '';
+          const isWinner = winnerIdx !== undefined && winnerIdx === trickCard.playerIdx;
+          // The winning card's gold ring takes visual priority over the ally/foe team rings.
+          const wrapperClass = isWinner
+            ? 'ring-2 ring-ds-warning rounded motion-safe:animate-pulse'
+            : isAlly
+              ? 'ring-2 ring-ds-info rounded'
+              : isFoe
+                ? 'ring-2 ring-ds-error rounded'
+                : '';
           const labelClass = isAlly
             ? 'text-ds-info font-semibold'
             : isFoe
@@ -68,11 +88,20 @@ export function TrickDisplay({ currentTrick, players, cardWidth, label, dataTuto
           return (
             <div
               key={`trick-${trickCard.playerIdx}`}
-              className="text-center"
+              className="relative text-center"
               data-team={team ?? undefined}
               data-team-role={isAlly ? 'ally' : isFoe ? 'foe' : undefined}
+              data-trick-winner={isWinner || undefined}
             >
               <AnimatedCard card={trickCard.card} width={cardWidth} wrapperClassName={wrapperClass || undefined} />
+              {isWinner && (
+                <span
+                  data-testid="trick-winner-badge"
+                  className="absolute top-0 right-0 px-1 rounded bg-ds-warning text-ds-text-on-accent text-[8px] font-extrabold tracking-wider shadow-md pointer-events-none"
+                >
+                  {winnerLabel ?? 'WIN'}
+                </span>
+              )}
               <div className={`text-xs mt-1 ${labelClass}`}>
                 {playerName(player?.id ?? trickCard.playerIdx, player?.isHuman ?? false)}
               </div>

--- a/frontend/src/i18n/locales/en/ohhell.json
+++ b/frontend/src/i18n/locales/en/ohhell.json
@@ -40,6 +40,7 @@
     "exact": "(exact)"
   },
   "currentTrick": "Current Trick",
+  "trickWinnerBadge": "WIN",
   "scores": "Scores",
   "scoresPlayer": "Player",
   "scoresBid": "Bid",

--- a/frontend/src/i18n/locales/ja/ohhell.json
+++ b/frontend/src/i18n/locales/ja/ohhell.json
@@ -40,6 +40,7 @@
     "exact": "(ぴったり)"
   },
   "currentTrick": "現在のトリック",
+  "trickWinnerBadge": "勝ち",
   "scores": "スコア",
   "scoresPlayer": "プレイヤー",
   "scoresBid": "ビッド",

--- a/frontend/src/pages/OhHellPage.test.tsx
+++ b/frontend/src/pages/OhHellPage.test.tsx
@@ -369,6 +369,23 @@ describe('OhHellPage', () => {
     );
   });
 
+  it('highlights the trick winner card at trick end', async () => {
+    // trickEndState.leadPlayerIdx is 0, so the trick winner badge appears.
+    mockExec.mockResolvedValue(trickEndState);
+    renderWithProviders(<OhHellPage />);
+    await waitFor(() => expect(screen.getByTestId('trick-winner-badge')).toBeInTheDocument());
+  });
+
+  it('does not highlight a trick winner during active play', async () => {
+    mockExec.mockResolvedValue({
+      ...trickEndState,
+      phase: 1, // PLAY
+    });
+    renderWithProviders(<OhHellPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('trick-winner-badge')).not.toBeInTheDocument();
+  });
+
   it('shows next round button on round end', async () => {
     mockExec.mockResolvedValue(roundEndState);
     renderWithProviders(<OhHellPage />);

--- a/frontend/src/pages/OhHellPage.tsx
+++ b/frontend/src/pages/OhHellPage.tsx
@@ -365,6 +365,8 @@ function OhHellPageContent() {
                   cardWidth={cardWidth}
                   label={t('currentTrick')}
                   dataTutorial="oh-trick-display"
+                  winnerIdx={isTrickEnd ? state.leadPlayerIdx : undefined}
+                  winnerLabel={t('trickWinnerBadge')}
                 />
               </div>
 


### PR DESCRIPTION
## 概要
オー・ヘルの `TRICK_END` フェーズでは 4 枚が同列に並ぶだけで、どのカードがトリックを取ったかは `GameMessageBox` の文章と `trickCount` 増分から推測するしかなかった。ビッド達成管理が核のゲームなので勝敗の因果を盤面上で示す。

## 変更点
- `TrickDisplay.tsx`（共有コンポーネント）: オプショナルな `winnerIdx` / `winnerLabel` プロップを追加。勝者カードに金色リング（`ring-ds-warning`）＋「WIN」バッジ（`data-testid="trick-winner-badge"`）。**プロップ未指定の既存利用箇所は無変更で動作**（デフォルトでハイライトなし）
- `OhHellPage.tsx`: `winnerIdx={isTrickEnd ? state.leadPlayerIdx : undefined}`（TRICK_END では leadPlayerIdx = 次リーダー = 勝者）＋ `winnerLabel={t('trickWinnerBadge')}` を渡す（バックエンド変更不要）
- `ohhell.json` (ja/en): `trickWinnerBadge` を追加

## テスト
- `TrickDisplay.test.tsx`: winnerIdx 指定時のバッジ＋`data-trick-winner`／未指定時ハイライトなし／デフォルト "WIN" 文言、を検証（11 tests）
- `OhHellPage.test.tsx`: TRICK_END で勝者バッジ表示／PLAY 中は非表示、を検証（51 tests）
- build / biome / vitest all green

## 受け入れ条件
- [x] TRICK_END フェーズで勝者のカードが視覚的に強調される
- [x] PLAY フェーズ中は強調が出ない
- [x] `TrickDisplay` の既存利用箇所（プロップ未指定）が無変更で動く
- [x] コンポーネント・ページ双方のテスト追加

Closes #3094

_注: issue はプレゼンター `trickWinnerIdx` の追加を提案していましたが、`leadPlayerIdx`（TRICK_END 時は次リーダー = 勝者）が既にレスポンスにあるため、バックエンド変更なしでフロントのみで実現しました。_