### PR TITLE
feat(threethirteen): highlight this round's wild-rank cards

### DIFF
--- a/frontend/src/i18n/locales/en/threethirteen.json
+++ b/frontend/src/i18n/locales/en/threethirteen.json
@@ -15,6 +15,8 @@
   },
   "round": "Round {{n}}/11",
   "wildRank": "Wild: {{rank}}",
+  "wildBadge": "WILD",
+  "wildAria": "(wild)",
   "dealCount": "Hand size: {{count}}",
   "drawPile": "Draw pile: {{count}} cards",
   "discardTop": "Discard",

--- a/frontend/src/i18n/locales/ja/threethirteen.json
+++ b/frontend/src/i18n/locales/ja/threethirteen.json
@@ -15,6 +15,8 @@
   },
   "round": "ラウンド {{n}}/11",
   "wildRank": "ワイルド: {{rank}}",
+  "wildBadge": "WILD",
+  "wildAria": "（ワイルド）",
   "dealCount": "手札枚数: {{count}}",
   "drawPile": "山札: {{count}}枚",
   "discardTop": "捨て札",

--- a/frontend/src/pages/ThreeThirteenPage.test.tsx
+++ b/frontend/src/pages/ThreeThirteenPage.test.tsx
@@ -86,6 +86,26 @@ describe('ThreeThirteenPage', () => {
     await waitFor(() => expect(screen.getByTestId('threethirteen-deadwood-indicator')).toBeInTheDocument());
   });
 
+  it('badges wild-rank cards in the hand and on the discard top', async () => {
+    // Aces wild: the ♠A in hand and the ♣A discard top both match wildRank 1.
+    mockExec.mockResolvedValue({
+      ...drawPhaseState,
+      wildRank: 1,
+      discardTop: { design: 'CLOVER', value: 1 },
+    });
+    renderWithProviders(<ThreeThirteenPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+    // One hand card (♠A) + the discard top (♣A) → two wild badges. The ♥J is not wild.
+    expect(screen.getAllByTestId('tt-wild-badge')).toHaveLength(2);
+  });
+
+  it('shows no wild badges when no card matches the wild rank', async () => {
+    // Default wildRank 4: neither the ♠A/♥J hand nor the ♥7 discard top matches.
+    renderWithProviders(<ThreeThirteenPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+    expect(screen.queryByTestId('tt-wild-badge')).not.toBeInTheDocument();
+  });
+
   it('renders draw phase with human cards', async () => {
     renderWithProviders(<ThreeThirteenPage />);
     await waitFor(() => {

--- a/frontend/src/pages/ThreeThirteenPage.tsx
+++ b/frontend/src/pages/ThreeThirteenPage.tsx
@@ -24,7 +24,7 @@ import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { ThreeThirteenResponse } from '../types/card';
+import type { Card, ThreeThirteenResponse } from '../types/card';
 import { ThreeThirteenPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
@@ -155,6 +155,20 @@ function ThreeThirteenPageContent() {
   const isRoundEnd = state.phase === ThreeThirteenPhase.ROUND_END;
   const isGameEnd = state.phase === ThreeThirteenPhase.GAME_END || state.gameEndFlag;
   const isHumanTurn = (isDrawPhase || isDiscardPhase) && state.players[state.currentPlayerIdx]?.isHuman === true;
+
+  // The wild rank changes each round; flag matching cards so players don't have to cross-check the header.
+  const isWildCard = (card: Card): boolean => card.value === state.wildRank;
+  const wildBadge = (card: Card) =>
+    isWildCard(card) ? (
+      <span
+        aria-hidden="true"
+        className="absolute top-0.5 right-0.5 px-1 rounded bg-ds-accent text-ds-text-on-accent text-[8px] font-extrabold tracking-wider shadow-md pointer-events-none"
+        data-testid="tt-wild-badge"
+      >
+        {t('wildBadge')}
+      </span>
+    ) : null;
+
   // Lowest cumulative score wins, so highlight the leader (fewest points).
   const humanDeadwood = humanPlayer?.deadwood ?? null;
 
@@ -220,9 +234,17 @@ function ThreeThirteenPageContent() {
                 {/* Discard pile top */}
                 {state.discardTop && (
                   <div className="my-3 p-3 rounded bg-black/40 flex items-center gap-3" data-tutorial="tt-draw-area">
-                    <AnimatedCard card={state.discardTop} width={cardWidth} />
+                    <div
+                      className={`relative inline-block rounded ${isWildCard(state.discardTop) ? 'ring-2 ring-ds-accent' : ''}`}
+                    >
+                      <AnimatedCard card={state.discardTop} width={cardWidth} />
+                      {wildBadge(state.discardTop)}
+                    </div>
                     <div className="text-ds-text-muted text-sm">
                       <div>{t('discardTop')}</div>
+                      {isWildCard(state.discardTop) && (
+                        <div className="text-ds-accent font-semibold">{t('wildAria')}</div>
+                      )}
                     </div>
                   </div>
                 )}
@@ -309,9 +331,11 @@ function ThreeThirteenPageContent() {
                     type="button"
                     key={`${card.design}-${card.value}-${idx}`}
                     onClick={() => toggleCard(idx)}
-                    aria-label={cardAlt(card)}
+                    aria-label={`${cardAlt(card)}${isWildCard(card) ? ` ${t('wildAria')}` : ''}`}
                     aria-pressed={selectedCardIndices.includes(idx)}
-                    className={`transition-transform ${focusRingCard}`}
+                    className={`relative transition-transform ${focusRingCard} ${
+                      isWildCard(card) ? 'ring-2 ring-ds-accent' : ''
+                    }`}
                     style={{
                       background: 'none',
                       padding: 0,
@@ -321,6 +345,7 @@ function ThreeThirteenPageContent() {
                     }}
                   >
                     <AnimatedCard card={card} width={cardWidth} />
+                    {wildBadge(card)}
                   </button>
                 ))}
               </div>


### PR DESCRIPTION
## 概要
スリー・サーティーンはラウンドごとにワイルドランクが 3→K と変わるのが最大の特徴だが、`wildRank` はヘッダーテキストのみで、手札や捨て札のどれがワイルドかは自分で照合する必要があった。ラウンド遷移のたびに見落としが頻発する。

## 変更点
- `ThreeThirteenPage.tsx`: `card.value === state.wildRank` のカードに accent 色リング＋「WILD」バッジ（`data-testid="tt-wild-badge"`）を手札ボタンと `discardTop` の両方で付与。aria-label にもワイルド情報を追記。`wildRank` 基準なのでラウンド遷移で対象が自動追従
- `threethirteen.json` (ja/en): `wildBadge` / `wildAria` を追加

## テスト
- `ThreeThirteenPage.test.tsx`: wildRank=1（Aウ ワイルド）で手札♠A＋捨て札♣A の2バッジ表示／wildRank=4で該当なし時はバッジ非表示、を検証（21 tests green）
- build / biome / vitest all green

## 受け入れ条件
- [x] wildRank と一致する手札カードが強調される
- [x] discardTop がワイルドの場合も強調される
- [x] ラウンド遷移（wildRank 変化）で強調対象が更新される
- [x] ページテストでバッジ表示を検証

Closes #3545