### PR TITLE
feat(beleagueredcastle): label tableau columns with their index

### DIFF
--- a/frontend/src/pages/BeleagueredCastlePage.test.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.test.tsx
@@ -90,6 +90,16 @@ describe('BeleagueredCastlePage', () => {
     await waitFor(() => expect(screen.getAllByLabelText(/組札 1枚/).length).toBe(4));
   });
 
+  it('labels all eight tableau columns with their 0-based index (matching hint text)', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<BeleagueredCastlePage />);
+    await waitFor(() => expect(screen.getByText('#0')).toBeInTheDocument());
+    // Columns are numbered #0..#7 to match formatHintZone's raw fromCol/toCol.
+    for (let i = 0; i < 8; i++) {
+      expect(screen.getByText(`#${i}`)).toBeInTheDocument();
+    }
+  });
+
   it('gives each empty tableau column a distinct column-numbered aria-label', async () => {
     mockExec.mockResolvedValue(playingState);
     renderWithProviders(<BeleagueredCastlePage />);

--- a/frontend/src/pages/BeleagueredCastlePage.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.tsx
@@ -195,6 +195,9 @@ function BeleagueredCastlePageContent() {
     const tableauColZone: BeleagueredCastleMoveZone = { zone: 'tableau', col: colIdx };
     return (
       <div key={`col-${colIdx.toString()}`} className="flex-1 min-w-0">
+        <div className="text-center text-xs text-ds-text-muted mb-0.5" aria-hidden="true">
+          #{colIdx}
+        </div>
         <DropZone
           isDropTarget={dnd.isDropTarget(tableauColZone)}
           onDragOver={dnd.handleDragOver(tableauColZone)}


### PR DESCRIPTION
## 概要
`BeleagueredCastlePage.tsx` の8つのタブロー列には列番号ラベルが無く、ヒント表示（`formatHintZone(t, 'tableau', hint.fromCol)` →「タブロー列3 → タブロー列5」）の指示をプレイヤーが目視でカウントして特定する必要があった。Agnes ページの `#{i}` ラベルと同様に列番号を表示する。

## 変更点
- `BeleagueredCastlePage.tsx`: `renderTableauColumn` の各列上部に `#{colIdx}`（0始まり）ラベルを追加。`formatHintZone` が生の `fromCol`/`toCol`（0始まり）を表示するため番号が一致。ドラッグ&ドロップ構造は不変（ラベルは DropZone の外・上）

## テスト
- `BeleagueredCastlePage.test.tsx`: 8列すべてに `#0`〜`#7` ラベルが表示されることを検証（15 tests green）
- build / biome / vitest all green

## 受け入れ条件
- [x] 8列すべてに列番号ラベルが表示される
- [x] ヒント表示のcol番号とラベルが一致する（両方0始まり）
- [x] モバイルレイアウトでもラベルが視認できる（列ヘッダとして常時表示）
- [x] 既存のドラッグ&ドロップ操作に影響しない

Closes #3274