### PR TITLE
feat(kingalbert): add r0-r6 number labels to reserve slots

### DIFF
--- a/frontend/src/pages/KingAlbertPage.test.tsx
+++ b/frontend/src/pages/KingAlbertPage.test.tsx
@@ -102,6 +102,16 @@ describe('KingAlbertPage', () => {
     expect(screen.queryByRole('img', { name: '空のリザーブ枠 1' })).not.toBeInTheDocument();
   });
 
+  it('labels all 7 reserve slots with 0-based numbers matching the hint text', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<KingAlbertPage />);
+    await waitFor(() => expect(screen.getByTestId('ka-reserve-label-0')).toBeInTheDocument());
+    for (let i = 0; i < 7; i++) {
+      const label = screen.getByTestId(`ka-reserve-label-${i.toString()}`);
+      expect(label).toHaveTextContent(`r${i.toString()}`);
+    }
+  });
+
   it('selecting a reserve card marks it as selected', async () => {
     mockExec.mockResolvedValue(playingState);
     renderWithProviders(<KingAlbertPage />);

--- a/frontend/src/pages/KingAlbertPage.tsx
+++ b/frontend/src/pages/KingAlbertPage.tsx
@@ -274,32 +274,46 @@ function KingAlbertPageContent() {
   const renderReserveCell = (cellIdx: number) => {
     const reserveCard = state.reserve[cellIdx];
     const reserveZone: KingAlbertMoveZone = { zone: 'reserve', col: cellIdx };
+    // Label matches the CUI (`[r0]`..`[r6]`) and the 0-based reserve number in the hint
+    // text (`t('frontendHint.reserve', { col })`), so players can map a hint to its slot.
+    const slotLabel = (
+      <span
+        data-testid={`ka-reserve-label-${cellIdx.toString()}`}
+        className="text-game-text-muted text-[10px] leading-none mt-0.5"
+      >
+        r{cellIdx}
+      </span>
+    );
     if (!reserveCard) {
       return (
-        <div
-          key={`r-${cellIdx.toString()}`}
-          role="img"
-          aria-label={t('emptyReserveSlot', { idx: cellIdx + 1 })}
-          className="rounded border border-dashed border-white/10"
-          style={{ width: dims.cw, height: dims.ch }}
-        />
+        <div key={`r-${cellIdx.toString()}`} className="flex flex-col items-center">
+          <div
+            role="img"
+            aria-label={t('emptyReserveSlot', { idx: cellIdx + 1 })}
+            className="rounded border border-dashed border-white/10"
+            style={{ width: dims.cw, height: dims.ch }}
+          />
+          {slotLabel}
+        </div>
       );
     }
     return (
-      <button
-        key={`r-${cellIdx.toString()}`}
-        type="button"
-        onClick={() => game.handleSelectSource(reserveZone)}
-        disabled={!isPlaying || loading}
-        aria-label={cardAlt(reserveCard)}
-        aria-pressed={isSourceSelected('reserve', cellIdx)}
-        draggable={isPlaying && !loading}
-        onDragStart={dnd.handleDragStart(reserveZone)}
-        onDragEnd={dnd.handleDragEnd}
-        className={`p-0 border-0 bg-transparent rounded cursor-pointer ${focusRingWhite} ${isSourceSelected('reserve', cellIdx) ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(reserveZone) ? 'opacity-50' : ''}`}
-      >
-        <AnimatedCard card={reserveCard} width={dims.cw} draggable={false} />
-      </button>
+      <div key={`r-${cellIdx.toString()}`} className="flex flex-col items-center">
+        <button
+          type="button"
+          onClick={() => game.handleSelectSource(reserveZone)}
+          disabled={!isPlaying || loading}
+          aria-label={cardAlt(reserveCard)}
+          aria-pressed={isSourceSelected('reserve', cellIdx)}
+          draggable={isPlaying && !loading}
+          onDragStart={dnd.handleDragStart(reserveZone)}
+          onDragEnd={dnd.handleDragEnd}
+          className={`p-0 border-0 bg-transparent rounded cursor-pointer ${focusRingWhite} ${isSourceSelected('reserve', cellIdx) ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(reserveZone) ? 'opacity-50' : ''}`}
+        >
+          <AnimatedCard card={reserveCard} width={dims.cw} draggable={false} />
+        </button>
+        {slotLabel}
+      </div>
     );
   };
 


### PR DESCRIPTION
## 概要
キング・アルバートのリザーブ7枠それぞれの下に、0始まりの小さな番号ラベル `r0`〜`r6` を表示する。これにより、ヒント文言（`リザーブ0`）や CUI 出力（`[r0]`）が指す枠を目視でマッピングできる。

番号は既存の `KingAlbertCuiPresenter.go`（`[r%d]`, 0始まり）および `formatHintZone` の `t('frontendHint.reserve', { col })`（`hint.fromCol`, 0始まり）と一致させている。

## 変更ファイル
- `frontend/src/pages/KingAlbertPage.tsx` — `renderReserveCell` を flex-col ラッパーに変更し、カード/空枠の下に `r{idx}` ラベル（`data-testid="ka-reserve-label-{idx}"`）を追加。ドラッグ&ドロップは非変更。
- `frontend/src/pages/KingAlbertPage.test.tsx` — 7枠すべてのラベル表示を検証するテストを追加。

## 受け入れ条件
- [x] 7枠すべてに番号ラベルが表示される
- [x] ヒント文言のcol番号（0始まり）とラベルが一致する
- [x] モバイルレイアウトでも視認できる（各セルを `flex flex-col items-center` でラップ）
- [x] コンポーネントテストでラベル表示を検証する

## テスト
- `bunx biome check` パス
- `bun run test -- --run KingAlbertPage` パス（13件）
- `bun run build`（tsc）パス

Closes #3281