### PR TITLE
feat(cinch): emphasize set-back bidder in the round result

### DIFF
--- a/frontend/src/i18n/locales/en/cinch.json
+++ b/frontend/src/i18n/locales/en/cinch.json
@@ -38,6 +38,8 @@
   "dealResult": {
     "title": "Deal Result",
     "setBack": "The bidding side was set back (bid not made).",
+    "bidderMade": "Bidder {{name}}: bid {{bid}} → captured {{captured}} ({{delta}} pts)",
+    "bidderSet": "Bidder {{name}}: bid {{bid}} → captured {{captured}} → set back {{delta}} pts",
     "gained": "{{name}} gained: {{points}} pts"
   },
   "hintAvailable": "Hint",

--- a/frontend/src/i18n/locales/ja/cinch.json
+++ b/frontend/src/i18n/locales/ja/cinch.json
@@ -38,6 +38,8 @@
   "dealResult": {
     "title": "ディール結果",
     "setBack": "ビッダー側がセットバック（ビッド未達）。",
+    "bidderMade": "ビッダー {{name}}: {{bid}} 約束 → {{captured}}点 獲得（{{delta}}点）",
+    "bidderSet": "ビッダー {{name}}: {{bid}} 約束 → {{captured}}点 獲得 → セットバック {{delta}}点",
     "gained": "{{name}} 獲得: {{points}}点"
   },
   "hintAvailable": "ヒント",

--- a/frontend/src/pages/CinchPage.test.tsx
+++ b/frontend/src/pages/CinchPage.test.tsx
@@ -37,6 +37,17 @@ const roundEndState = makeCinchState({
     gained: { 0: 6, 1: -1, 2: -1, 3: -1 },
   },
 });
+const setBackState = makeCinchState({
+  phase: 4,
+  lastDealDetail: {
+    trumpSuit: 1,
+    bidderIdx: 1,
+    bid: 8,
+    setBack: true,
+    points: { 0: 4, 1: 5, 2: 3, 3: 2 },
+    gained: { 0: 1, 1: -8, 2: 1, 3: 1 },
+  },
+});
 const gameEndState = makeCinchState({
   phase: 5,
   gameEndFlag: true,
@@ -155,6 +166,25 @@ describe('CinchPage', () => {
     renderWithProviders(<CinchPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '次のディール' })).toBeInTheDocument());
     expect(screen.getByText('ディール結果')).toBeInTheDocument();
+  });
+
+  it('shows the bidder detail without a set-back row when the bid is made', async () => {
+    mockExec.mockResolvedValue(roundEndState);
+    renderWithProviders(<CinchPage />);
+    const detail = await screen.findByTestId('cinch-bidder-detail');
+    // Made-bid detail is not styled with the danger color and no set-back row is present.
+    expect(detail).not.toHaveClass('text-ds-error');
+    expect(screen.queryByTestId('cinch-setback-row')).not.toBeInTheDocument();
+  });
+
+  it('emphasizes the bidder detail and set-back row when the bidder is set back', async () => {
+    mockExec.mockResolvedValue(setBackState);
+    renderWithProviders(<CinchPage />);
+    const detail = await screen.findByTestId('cinch-bidder-detail');
+    // Set-back bidder detail is emphasized with the danger color.
+    expect(detail).toHaveClass('text-ds-error');
+    // The bidder's gained row is highlighted as a set-back row.
+    expect(screen.getByTestId('cinch-setback-row')).toBeInTheDocument();
   });
 
   it('renders the game end message', async () => {

--- a/frontend/src/pages/CinchPage.tsx
+++ b/frontend/src/pages/CinchPage.tsx
@@ -41,6 +41,9 @@ const SUIT_KEYS: Readonly<Record<number, string>> = { 1: 'spade', 2: 'club', 3: 
 /** Hearts and diamonds render red; spades and clubs stay the default text color. */
 const isRedSuit = (suit: number): boolean => suit === 3 || suit === 4;
 
+/** Format a signed match-point delta for display (e.g. 6 -> "+6", -8 -> "-8", 0 -> "0"). */
+const signedDelta = (n: number): string => (n > 0 ? `+${n}` : String(n));
+
 /** Selectable trump suits named by the bid winner. */
 const TRUMP_SUITS = [1, 2, 3, 4] as const;
 
@@ -304,17 +307,34 @@ function CinchPageContent() {
                     data-testid="cinch-deal-result"
                   >
                     <div className="mb-1 text-ds-text-primary">{t('dealResult.title')}</div>
-                    {state.lastDealDetail.setBack && (
-                      <div className="text-ds-error mb-1">{t('dealResult.setBack')}</div>
-                    )}
-                    {state.players.map((p) => (
-                      <div key={p.id}>
-                        {t('dealResult.gained', {
-                          name: playerName(p.id, p.isHuman),
-                          points: state.lastDealDetail?.gained[p.id] ?? 0,
+                    {state.lastDealDetail.bidderIdx >= 0 && (
+                      <div
+                        className={`mb-1 ${state.lastDealDetail.setBack ? 'text-ds-error font-semibold' : 'text-ds-text-primary'}`}
+                        data-testid="cinch-bidder-detail"
+                      >
+                        {t(state.lastDealDetail.setBack ? 'dealResult.bidderSet' : 'dealResult.bidderMade', {
+                          name: playerName(state.lastDealDetail.bidderIdx, state.lastDealDetail.bidderIdx === humanIdx),
+                          bid: state.lastDealDetail.bid,
+                          captured: state.lastDealDetail.points[state.lastDealDetail.bidderIdx] ?? 0,
+                          delta: signedDelta(state.lastDealDetail.gained[state.lastDealDetail.bidderIdx] ?? 0),
                         })}
                       </div>
-                    ))}
+                    )}
+                    {state.players.map((p) => {
+                      const isSetBackRow = p.id === state.lastDealDetail?.bidderIdx && state.lastDealDetail?.setBack;
+                      return (
+                        <div
+                          key={p.id}
+                          className={isSetBackRow ? 'text-ds-error font-semibold' : undefined}
+                          data-testid={isSetBackRow ? 'cinch-setback-row' : undefined}
+                        >
+                          {t('dealResult.gained', {
+                            name: playerName(p.id, p.isHuman),
+                            points: state.lastDealDetail?.gained[p.id] ?? 0,
+                          })}
+                        </div>
+                      );
+                    })}
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## 概要

シンチのラウンド結果ボックスに、ビッダーが約束したビッド・実獲得ポイント・マッチポイントの増減を表示し、セットバック（ビッド未達）時に該当行をエラーカラーで強調します。

これまでは `setBack` が真のとき汎用的な赤字一行を出すだけで、誰がいくらビッドして何点足りなかったかが分かりませんでした。

## 変更点

- ビッダー明細行を追加: 「ビッダー {name}: {bid} 約束 → {captured}点 獲得 → セットバック {delta}点」。成立時と未達時で文言を出し分け。
- セットバック時はビッダー明細行と該当プレイヤーの獲得行を `text-ds-error font-semibold` で強調（`data-testid="cinch-bidder-detail"` / `cinch-setback-row`）。
- 全データは既存の `lastDealDetail`（`bidderIdx` / `bid` / `points` / `gained` / `setBack`）から導出。**バックエンド変更なし**（`CinchWebPresenter` は既に全フィールドを出力済み）。
- i18n キー `dealResult.bidderMade` / `dealResult.bidderSet` を ja / en 両方に追加。

## 受け入れ条件

- [x] セットバック時に約束値・実獲得値・減点が表示される
- [x] ビッド者行が結果ボックスでハイライトされる
- [x] ラウンド集計の約束/実獲得は既存 `lastDealDetail` で提供済み（追加のバックエンド変更不要）
- [x] `CinchPage.test.tsx` で強調表示（成立時は非強調・未達時は強調）を検証
- [x] biome / `bun run build`(tsc) / vitest すべてパス

Closes #3620