### PR TITLE
feat(wasp): show persistent empty-column highlight on touch devices

### DIFF
--- a/frontend/src/pages/WaspPage.test.tsx
+++ b/frontend/src/pages/WaspPage.test.tsx
@@ -187,6 +187,32 @@ describe('WaspPage', () => {
     expect(emptyCol).toHaveAttribute('aria-label', expect.stringContaining('任意カード可'));
   });
 
+  it('shows a persistent success ring on empty columns while a source is selected (touch-friendly)', async () => {
+    const state = {
+      ...playingState,
+      tableau: [
+        [{ card: card('SPADE', 13), faceUp: true }],
+        [], // empty column
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+    };
+    mockExec.mockResolvedValue(state);
+    renderWithProviders(<WaspPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    const emptyCol = screen.getByTestId('sc-empty-col-1');
+    // No source selected yet → no persistent ring.
+    expect(emptyCol.className).not.toContain('ring-ds-success');
+    // Select ♠K as the move source (no hover event fired).
+    fireEvent.click(screen.getByRole('button', { name: '♠ K' }));
+    await waitFor(() => expect(screen.getByTestId('sc-empty-col-1').className).toContain('ring-ds-success'));
+    // The highlight is persistent, not hover-gated.
+    expect(screen.getByTestId('sc-empty-col-1').className).not.toContain('hover:ring');
+  });
+
   it('deal button exposes empty-column reason via title when blocked', async () => {
     const stateWithEmptyCol: WaspResponse = {
       ...playingState,

--- a/frontend/src/pages/WaspPage.tsx
+++ b/frontend/src/pages/WaspPage.tsx
@@ -407,7 +407,7 @@ function WaspPageContent() {
                         key={`empty-${colIdx.toString()}-${emptyDealAttemptKey.toString()}`}
                         type="button"
                         className={`border-2 border-dashed border-game-border rounded-lg flex items-center justify-center text-game-text-muted ${focusRingWhite} ${
-                          selectedSource ? 'hover:ring-2 hover:ring-ds-warning cursor-pointer' : ''
+                          selectedSource ? 'ring-2 ring-ds-success cursor-pointer' : ''
                         }${emptyDealAttemptKey > 0 ? ' animate-shake border-ds-warning text-ds-warning' : ''}`}
                         style={{ width: sc.cw, height: sc.ch }}
                         onClick={() => selectedSource && handleSelectTarget('tableau', colIdx)}


### PR DESCRIPTION
## 概要
Wasp ソリティアで、空列への合法手ハイライトが `hover:` 時のみ表示されていたため、マウスホバーのないタッチ端末では発見できず、フィルド列の常時ハイライト（`ring-2 ring-ds-success`）との一貫性も崩れていました。

カード選択中は空列にもフィルド列と同じ `ring-2 ring-ds-success` を常時付与し、ホバーなしで合法な移動先を視認できるようにしました。

## 変更点
- `frontend/src/pages/WaspPage.tsx`: 空列プレースホルダのクラスを `hover:ring-2 hover:ring-ds-warning` から、ソース選択中に常時表示される `ring-2 ring-ds-success` に変更（`cursor-pointer` は維持）。
- `frontend/src/pages/WaspPage.test.tsx`: ソース選択時に空列へ `ring-ds-success` が付与され、`hover:ring` を含まないことを検証するテストを追加。

## 受け入れ条件
- [x] カード選択中は空列にも常時ハイライトが表示される
- [x] タッチ端末での操作でホバーなしにハイライトが視認できる（`hover:` 依存を除去）
- [x] `WaspPage.test.tsx` に空列のハイライトクラスを検証するテストを追加

## テスト
- `bun run test -- --run WaspPage`: 43 passed
- `bunx biome check`: 通過
- `bun run build`（tsc）: 通過

Closes #3189