### PR TITLE
feat(russiansolitaire): make face-down rule note a one-time dismissible notice

### DIFF
--- a/frontend/src/i18n/locales/en/russiansolitaire.json
+++ b/frontend/src/i18n/locales/en/russiansolitaire.json
@@ -39,5 +39,6 @@
     "russiansolitaire": "Russian Solitaire"
   },
   "faceDownRule": "Face-down cards can't be moved — only face-up cards are playable",
+  "dismissRule": "Dismiss rule note",
   "faceDownCardLabel": "Column {{col}}, card {{pos}} from top, face down"
 }

--- a/frontend/src/i18n/locales/ja/russiansolitaire.json
+++ b/frontend/src/i18n/locales/ja/russiansolitaire.json
@@ -39,5 +39,6 @@
     "russiansolitaire": "ロシアンソリティア"
   },
   "faceDownRule": "裏向きのカードは移動できません（表向きのカードのみ操作可能）",
+  "dismissRule": "ルール説明を閉じる",
   "faceDownCardLabel": "列{{col}}、上から{{pos}}枚目、裏向き"
 }

--- a/frontend/src/pages/RussianSolitairePage.test.tsx
+++ b/frontend/src/pages/RussianSolitairePage.test.tsx
@@ -56,6 +56,9 @@ const gameOverState: RussianSolitaireResponse = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Clear the persisted rule-dismissed flag so it never leaks across tests
+  // (a dismissed flag left in localStorage would hide the banner in later tests).
+  localStorage.clear();
   mockExec.mockResolvedValue(playingState);
 });
 
@@ -86,6 +89,22 @@ describe('RussianSolitairePage', () => {
     expect(screen.getByLabelText('列1、上から1枚目、裏向き')).toBeInTheDocument();
     expect(screen.getByLabelText('列2、上から1枚目、裏向き')).toBeInTheDocument();
     expect(screen.getByLabelText('列2、上から2枚目、裏向き')).toBeInTheDocument();
+  });
+
+  it('dismisses the face-down rule note, persists it, and keeps it hidden on remount', async () => {
+    const { unmount } = renderWithProviders(<RussianSolitairePage />);
+    await waitFor(() => expect(screen.getByTestId('rs-facedown-rule')).toBeInTheDocument());
+
+    // Clicking the close control hides the note and persists the dismissal.
+    fireEvent.click(screen.getByRole('button', { name: 'ルール説明を閉じる' }));
+    expect(screen.queryByTestId('rs-facedown-rule')).not.toBeInTheDocument();
+    expect(localStorage.getItem('russiansolitaire-rules-dismissed')).toBe('true');
+
+    // On a fresh remount the persisted flag keeps the banner hidden.
+    unmount();
+    renderWithProviders(<RussianSolitairePage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(screen.queryByTestId('rs-facedown-rule')).not.toBeInTheDocument();
   });
 
   it('shows game clear phase', async () => {

--- a/frontend/src/pages/RussianSolitairePage.tsx
+++ b/frontend/src/pages/RussianSolitairePage.tsx
@@ -24,6 +24,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useLocalStorageToggle } from '../hooks/useLocalStorageToggle';
 import { useMountReset } from '../hooks/useMountReset';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { useSound } from '../providers/SoundProvider';
@@ -131,6 +132,11 @@ function RussianSolitairePageContent() {
    * tail to make the moving block visually unambiguous.
    */
   const [hoveredBlock, setHoveredBlock] = useState<{ col: number; cardIdx: number } | null>(null);
+
+  // The face-down rule is a one-time onboarding note: show it until the player
+  // dismisses it, then keep it hidden across resets and future visits so it no
+  // longer permanently occupies the space above the tableau (issue #3155).
+  const [rulesDismissed, setRulesDismissed] = useLocalStorageToggle('russiansolitaire-rules-dismissed', false);
 
   const {
     hint: frontendHint,
@@ -387,9 +393,19 @@ function RussianSolitairePageContent() {
             </div>
 
             {/* Tableau */}
-            <p className="text-game-text-muted text-xs text-center mb-1" data-testid="rs-facedown-rule">
-              {t('faceDownRule')}
-            </p>
+            {!rulesDismissed && (
+              <div className="flex items-center justify-center gap-1 mb-1" data-testid="rs-facedown-rule" role="note">
+                <p className="text-game-text-muted text-xs text-center">{t('faceDownRule')}</p>
+                <button
+                  type="button"
+                  onClick={() => setRulesDismissed(true)}
+                  aria-label={t('dismissRule')}
+                  className={`shrink-0 px-2 py-1 text-game-text-muted hover:text-game-text text-sm leading-none ${focusRingWhite} rounded`}
+                >
+                  ×
+                </button>
+              </div>
+            )}
             <div className="flex gap-1 sm:gap-2 justify-center" data-tutorial="rs-tableau">
               {state.tableau.map((col, colIdx) => (
                 <div key={colIdx} className="flex flex-col items-center" style={{ width: rs.cw }}>


### PR DESCRIPTION
## 概要
ロシアンソリティアの「裏向きのカードは移動できません」ルール説明バナーは、タブロー直上に常時表示され、リセットのたびに再表示されて画面領域を占有し続けていた。これを **一度きりの案内**（ユーザーが閉じるまで表示、閉じたら永続的に非表示）に変更する。

## 変更内容
- 常時表示の `<p>` バナーを、閉じるボタン（×）付きの一度きりノートに変更
- 既存の `useLocalStorageToggle` フックで dismissed 状態を `russiansolitaire-rules-dismissed` キーに永続化 — 新しいパターンは発明せず既存フックを再利用
- 閉じるボタンにアクセシブルなラベル（`dismissRule`）を ja/en 両方に追加
- `rs-facedown-rule` の `data-testid` はラッパー要素で維持（未 dismiss 時）
- テスト: 未 dismiss 時に表示 → クリックで非表示＆永続化 → 再マウントで非表示のまま を検証。`beforeEach` で `localStorage.clear()` を追加しテスト間のフラグ汚染を防止

## 受け入れ条件
- [x] 常時バナーの代わりに折りたたみ式（一度きり dismissible）方式に変更される
- [x] 初めてプレイするユーザーには依然としてルールが明示される（初回は表示）
- [x] `rs-facedown-rule` の `data-testid` は代替要素で維持
- [x] 画面の常時占有面積が削減される（dismiss 後は 0）

## テスト
- `bunx biome check` パス
- `bun run test -- --run RussianSolitairePage` 全 19 件パス（新規: dismiss 永続化テスト）
- `bun run build`（tsc）パス

Closes #3155