### PR TITLE
feat(flowergarden): label bouquet slots with their index

### DIFF
--- a/frontend/src/pages/FlowerGardenPage.test.tsx
+++ b/frontend/src/pages/FlowerGardenPage.test.tsx
@@ -91,6 +91,17 @@ describe('FlowerGardenPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: '♦ 7' })).toBeInTheDocument());
   });
 
+  it('labels all 16 bouquet slots with their 0-based index (matching hint text)', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<FlowerGardenPage />);
+    // Slots are numbered #0..#15 to match formatHintZone's raw reserve col and
+    // the CUI's [r0]..[r15], so hint text maps to a visible card.
+    await waitFor(() => expect(screen.getByText('#0')).toBeInTheDocument());
+    for (let i = 0; i < 16; i++) {
+      expect(screen.getByText(`#${i}`)).toBeInTheDocument();
+    }
+  });
+
   it('selecting a reserve card marks it as selected', async () => {
     mockExec.mockResolvedValue(playingState);
     renderWithProviders(<FlowerGardenPage />);

--- a/frontend/src/pages/FlowerGardenPage.tsx
+++ b/frontend/src/pages/FlowerGardenPage.tsx
@@ -274,30 +274,31 @@ function FlowerGardenPageContent() {
   const renderReserveCell = (cellIdx: number) => {
     const reserveCard = state.reserve[cellIdx];
     const reserveZone: FlowerGardenMoveZone = { zone: 'reserve', col: cellIdx };
-    if (!reserveCard) {
-      return (
-        <div
-          key={`r-${cellIdx.toString()}`}
-          className="rounded border border-dashed border-white/10"
-          style={{ width: dims.cw, height: dims.ch }}
-        />
-      );
-    }
+    // Number each bouquet slot 0..15 to match formatHintZone's raw reserve col
+    // (and the CUI's [r0]..[r15]), so players can map hint text to a card.
     return (
-      <button
-        key={`r-${cellIdx.toString()}`}
-        type="button"
-        onClick={() => game.handleSelectSource(reserveZone)}
-        disabled={!isPlaying || loading}
-        aria-label={cardAlt(reserveCard)}
-        aria-pressed={isSourceSelected('reserve', cellIdx)}
-        draggable={isPlaying && !loading}
-        onDragStart={dnd.handleDragStart(reserveZone)}
-        onDragEnd={dnd.handleDragEnd}
-        className={`p-0 border-0 bg-transparent rounded cursor-pointer ${focusRingWhite} ${isSourceSelected('reserve', cellIdx) ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(reserveZone) ? 'opacity-50' : ''}`}
-      >
-        <AnimatedCard card={reserveCard} width={dims.cw} draggable={false} />
-      </button>
+      <div key={`r-${cellIdx.toString()}`} className="flex flex-col items-center">
+        {reserveCard ? (
+          <button
+            type="button"
+            onClick={() => game.handleSelectSource(reserveZone)}
+            disabled={!isPlaying || loading}
+            aria-label={cardAlt(reserveCard)}
+            aria-pressed={isSourceSelected('reserve', cellIdx)}
+            draggable={isPlaying && !loading}
+            onDragStart={dnd.handleDragStart(reserveZone)}
+            onDragEnd={dnd.handleDragEnd}
+            className={`p-0 border-0 bg-transparent rounded cursor-pointer ${focusRingWhite} ${isSourceSelected('reserve', cellIdx) ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(reserveZone) ? 'opacity-50' : ''}`}
+          >
+            <AnimatedCard card={reserveCard} width={dims.cw} draggable={false} />
+          </button>
+        ) : (
+          <div className="rounded border border-dashed border-white/10" style={{ width: dims.cw, height: dims.ch }} />
+        )}
+        <span className="text-xs text-ds-text-muted mt-0.5" aria-hidden="true">
+          #{cellIdx}
+        </span>
+      </div>
     );
   };
 


### PR DESCRIPTION
## 概要
フラワーガーデンのブーケ（リザーブ行）16枚に小さな番号ラベル `#0`〜`#15` を追加。ヒント文言（`formatHintZone` は 0 始まりの生の reserve col を表示）と CUI の `[r0]`〜`[r15]` に一致させ、プレイヤーがヒントの指す位置を目視で特定できるようにする。

ラベルはインタラクティブなカードボタンの外側（`aria-hidden` の `<span>`）に配置し、既存のクリック選択・ドラッグ&ドロップ操作には影響しない。空スロットにも番号を付けるためインデックスの対応が崩れない。

## 受け入れ条件
- [x] 16枚すべてに番号ラベルが表示される
- [x] ヒント表示の番号（0始まり）とUI表示が一致する
- [x] 既存のクリック選択操作に影響しない
- [x] コンポーネントテストでラベル表示を検証する（`labels all 16 bouquet slots with their 0-based index (matching hint text)`）

## 確認
- `bunx biome check` OK
- `bun run test -- --run FlowerGardenPage` 12 passed
- `bun run build`（tsc）OK

Closes #3284