### PR TITLE
feat(tysiac): show next bid amount on raise button and current bid by controls

### DIFF
--- a/frontend/src/i18n/locales/en/tysiac.json
+++ b/frontend/src/i18n/locales/en/tysiac.json
@@ -24,6 +24,7 @@
   "bidPhase": "Bidding phase — raise (+10) or pass.",
   "talonPhase": "Talon exchange — give a card to each opponent.",
   "bidRaise": "Raise +10",
+  "bidRaiseTo": "Raise ({{points}})",
   "bidPass": "Pass",
   "giveCard": "Give card",
   "marriageAvailable": "Marriage available: {{list}}",

--- a/frontend/src/i18n/locales/ja/tysiac.json
+++ b/frontend/src/i18n/locales/ja/tysiac.json
@@ -24,6 +24,7 @@
   "bidPhase": "入札フェーズ — レイズ（+10）またはパス。",
   "talonPhase": "タロン交換 — 各対戦相手に1枚ずつカードを渡します。",
   "bidRaise": "レイズ +10",
+  "bidRaiseTo": "レイズ（{{points}}）",
   "bidPass": "パス",
   "giveCard": "カードを渡す",
   "marriageAvailable": "マリッジ可能: {{list}}",

--- a/frontend/src/pages/TysiacPage.test.tsx
+++ b/frontend/src/pages/TysiacPage.test.tsx
@@ -42,6 +42,7 @@ const gameEndState = makeTysiacState({
 const cpuTurnState = makeTysiacState({ currentPlayerIdx: 1, isHumanTurn: false });
 
 beforeEach(() => {
+  localStorage.clear();
   mockExec.mockReset();
   mockExec.mockResolvedValue(playPhaseState);
 });
@@ -83,14 +84,38 @@ describe('TysiacPage', () => {
   it('renders the bid phase with raise and pass buttons', async () => {
     mockExec.mockResolvedValue(bidPhaseState);
     renderWithProviders(<TysiacPage />);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'レイズ +10' })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: 'レイズ（110）' })).toBeInTheDocument());
     expect(screen.getByRole('button', { name: 'パス' })).toBeInTheDocument();
+  });
+
+  it('shows the next bid amount on the raise button and the current bid near the controls', async () => {
+    mockExec.mockResolvedValue(bidPhaseState);
+    renderWithProviders(<TysiacPage />);
+    // Raise button label reflects currentBid (100) + step (10).
+    await waitFor(() => expect(screen.getByTestId('tysiac-bid-raise')).toHaveTextContent('レイズ（110）'));
+    // Current highest bid is shown right by the bid controls.
+    expect(screen.getByTestId('tysiac-current-bid')).toHaveTextContent('入札: 100');
+  });
+
+  it('reflects a higher current bid in the raise-button next amount', async () => {
+    mockExec.mockResolvedValue(makeTysiacState({ phase: 0, currentPlayerIdx: 0, isHumanTurn: true, currentBid: 130 }));
+    renderWithProviders(<TysiacPage />);
+    await waitFor(() => expect(screen.getByTestId('tysiac-bid-raise')).toHaveTextContent('レイズ（140）'));
+    expect(screen.getByTestId('tysiac-current-bid')).toHaveTextContent('入札: 130');
+  });
+
+  it('hides the bid display once bidding is over (talon phase)', async () => {
+    mockExec.mockResolvedValue(talonPhaseState);
+    renderWithProviders(<TysiacPage />);
+    await waitFor(() => expect(screen.getByTestId('tysiac-talon-prompt')).toBeInTheDocument());
+    expect(screen.queryByTestId('tysiac-current-bid')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('tysiac-bid-raise')).not.toBeInTheDocument();
   });
 
   it('raising the bid dispatches bid with raise=true', async () => {
     mockExec.mockResolvedValue(bidPhaseState);
     renderWithProviders(<TysiacPage />);
-    const raiseBtn = await screen.findByRole('button', { name: 'レイズ +10' });
+    const raiseBtn = await screen.findByRole('button', { name: 'レイズ（110）' });
     mockExec.mockClear();
     mockExec.mockResolvedValue(bidPhaseState);
     fireEvent.click(raiseBtn);

--- a/frontend/src/pages/TysiacPage.tsx
+++ b/frontend/src/pages/TysiacPage.tsx
@@ -35,6 +35,9 @@ import { playerName } from '../utils/playerUtils';
 /** Suit symbols indexed by suit number (0=unset, 1=♠ 2=♣ 3=♥ 4=♦). */
 const SUIT_SYMBOLS = ['-', '♠', '♣', '♥', '♦'] as const;
 
+/** Bid increment applied by a raise (mirrors backend `TysiacBidStep`). */
+const TYSIAC_BID_STEP = 10;
+
 /** Card design string → suit number (1=♠ 2=♣ 3=♥ 4=♦), to align with SUIT_SYMBOLS / trumpSuit. */
 const DESIGN_TO_SUIT: Readonly<Record<string, number>> = { SPADE: 1, CLOVER: 2, HEART: 3, DIAMOND: 4 };
 
@@ -333,8 +336,11 @@ function TysiacPageContent() {
           {/* Footer */}
           <GameFooter className={`${gameTheme.tysiac.footer} px-4 py-2.5`}>
             {isBidPhase && (
-              <div className="mb-1 text-center text-sm text-ds-accent font-semibold" data-testid="tysiac-bid-prompt">
-                {t('bidPhase')}
+              <div className="mb-1 text-center" data-testid="tysiac-bid-prompt">
+                <div className="text-sm text-ds-accent font-semibold">{t('bidPhase')}</div>
+                <div className="text-sm text-ds-text-primary font-semibold" data-testid="tysiac-current-bid">
+                  {t('currentBid', { points: state.currentBid })}
+                </div>
               </div>
             )}
             {canDiscard && (
@@ -379,8 +385,14 @@ function TysiacPageContent() {
             <div className="flex flex-wrap gap-2 items-center" data-tutorial="tysiac-action-buttons">
               {canBid && (
                 <>
-                  <button type="button" className={btnPrimary} onClick={() => handleBid(true)} disabled={loading}>
-                    {t('bidRaise')}
+                  <button
+                    type="button"
+                    className={btnPrimary}
+                    onClick={() => handleBid(true)}
+                    disabled={loading}
+                    data-testid="tysiac-bid-raise"
+                  >
+                    {t('bidRaiseTo', { points: state.currentBid + TYSIAC_BID_STEP })}
                   </button>
                   <button type="button" className={btnSecondary} onClick={() => handleBid(false)} disabled={loading}>
                     {t('bidPass')}


### PR DESCRIPTION
## 概要
サウザンド（`tysiac`）の入札フェーズで、レイズするといくらになるのかがボタンに表示されず、現在ビッドも情報バーの遠い位置にあった。ボタン近くに現在ビッド額を明示し、レイズボタンのラベルを動的な次ビッド額表示に変更した。

## 変更内容
- レイズボタンのラベルを静的な「レイズ +10」から動的な「レイズ（{{currentBid + 10}}）」へ変更（`bidRaiseTo` i18n キーを ja/en に追加）
- フッターの入札プロンプト直下に現在の最高ビッド額（`入札: {{points}}`）を `data-testid="tysiac-current-bid"` 付きで表示
- 入札フェーズ以外では両表示とも自動的に非表示

## 対象外（バックエンド未対応のため）
- 各プレイヤーのビッド/パス状態チップ列: レスポンス（`TysiacResponse`）に per-player のビッド履歴／パス状態の配列が存在しないため、本 PR のスコープ外。実装にはバックエンド変更が必要。

## 受け入れ条件
- [x] レイズボタンに次のビッド額が表示される
- [x] 入札フェーズ中に現在ビッド額がボタン近くで確認できる
- [x] ビッド確定後（タロン以降）は表示が消える
- [ ] 各プレイヤーのビッド/パス状態チップ（バックエンドにデータが無いため未対応）
- [x] `TysiacPage.test.tsx` にラベル・表示・非表示のテストを追加

## テスト
- `bunx biome check` パス
- `bun run test -- --run TysiacPage`: 16 passed
- `bun run build`（tsc ゲート）パス

Closes #3604