### PR TITLE
feat(streetsandalleys): show per-foundation n/13 progress counter

### DIFF
--- a/frontend/src/i18n/locales/en/streetsandalleys.json
+++ b/frontend/src/i18n/locales/en/streetsandalleys.json
@@ -11,6 +11,7 @@
   "empty": "Empty",
   "foundationAriaLabel": "{{suit}} foundation {{count}} cards",
   "emptyFoundationAriaLabel": "Empty foundation ({{suit}})",
+  "foundationProgress": "{{count}}/13",
   "landscapeBanner": "Landscape mode recommended",
   "hint": "Hint",
   "autoComplete": "Auto Complete",

--- a/frontend/src/i18n/locales/ja/streetsandalleys.json
+++ b/frontend/src/i18n/locales/ja/streetsandalleys.json
@@ -11,6 +11,7 @@
   "empty": "空",
   "foundationAriaLabel": "{{suit}} 組札 {{count}}枚",
   "emptyFoundationAriaLabel": "空の組札 ({{suit}})",
+  "foundationProgress": "{{count}}/13",
   "landscapeBanner": "横画面での表示を推奨します",
   "hint": "ヒント",
   "autoComplete": "自動完成",

--- a/frontend/src/pages/StreetsAndAlleysPage.test.tsx
+++ b/frontend/src/pages/StreetsAndAlleysPage.test.tsx
@@ -116,6 +116,38 @@ describe('StreetsAndAlleysPage', () => {
     await waitFor(() => expect(screen.getAllByLabelText(/組札 1枚/).length).toBe(4));
   });
 
+  it('renders per-foundation progress counters (n/13) for partially-built piles', async () => {
+    const progressState: StreetsAndAlleysResponse = {
+      ...playingState,
+      foundation: [
+        [card('SPADE', 1), card('SPADE', 2), card('SPADE', 3), card('SPADE', 4), card('SPADE', 5)],
+        [card('CLOVER', 1)],
+        [card('HEART', 1), card('HEART', 2)],
+        [card('DIAMOND', 1)],
+      ],
+    };
+    mockExec.mockResolvedValue(progressState);
+    renderWithProviders(<StreetsAndAlleysPage />);
+    expect(await screen.findByTestId('sa-foundation-progress-0')).toHaveTextContent('5/13');
+    expect(screen.getByTestId('sa-foundation-progress-1')).toHaveTextContent('1/13');
+    expect(screen.getByTestId('sa-foundation-progress-2')).toHaveTextContent('2/13');
+    expect(screen.getByTestId('sa-foundation-progress-3')).toHaveTextContent('1/13');
+  });
+
+  it('marks a completed foundation (13/13) with a success color and checkmark', async () => {
+    const fullSpades = Array.from({ length: 13 }, (_, i) => card('SPADE', i + 1));
+    const completeState: StreetsAndAlleysResponse = {
+      ...playingState,
+      foundation: [fullSpades, [card('CLOVER', 1)], [card('HEART', 1)], [card('DIAMOND', 1)]],
+    };
+    mockExec.mockResolvedValue(completeState);
+    renderWithProviders(<StreetsAndAlleysPage />);
+    const done = await screen.findByTestId('sa-foundation-progress-0');
+    expect(done).toHaveTextContent('13/13');
+    expect(done.textContent).toContain('✓');
+    expect(done.className).toContain('text-ds-success');
+  });
+
   it('renders giveup button when playing', async () => {
     mockExec.mockResolvedValue(playingState);
     renderWithProviders(<StreetsAndAlleysPage />);

--- a/frontend/src/pages/StreetsAndAlleysPage.tsx
+++ b/frontend/src/pages/StreetsAndAlleysPage.tsx
@@ -351,6 +351,13 @@ function StreetsAndAlleysPageContent() {
                           </button>
                         )}
                       </DropZone>
+                      <div
+                        data-testid={`sa-foundation-progress-${idx.toString()}`}
+                        className={`text-xs mt-1 tabular-nums ${pile.length === 13 ? 'text-ds-success' : 'text-game-text-muted'}`}
+                      >
+                        {pile.length === 13 && <span aria-hidden="true">✓ </span>}
+                        {t('foundationProgress', { count: pile.length })}
+                      </div>
                     </div>
                   );
                 })}


### PR DESCRIPTION
## 概要
ストリート・アンド・アレイズの4つのfoundationパイルは最上段カードとスート記号しか表示しておらず、各スートがA〜Kのどこまで積み上がっているか（残り枚数）が分からなかった。`state.foundation[idx].length` を用いて各foundationの下に `n/13` の進捗カウンタを追加した。13枚到達時は成功色＋チェックマーク（✓）で完了を表現する。

サーバー応答に既にある `foundation: Card[][]` の各パイル長から算出する、フロントエンドのみの派生表示。

## 変更点
- `frontend/src/pages/StreetsAndAlleysPage.tsx`: 各foundationパイル下に `data-testid="sa-foundation-progress-{idx}"` の進捗表示を追加（完成時は `text-ds-success` ＋ ✓）
- `frontend/src/i18n/locales/{ja,en}/streetsandalleys.json`: `foundationProgress` キー（`{{count}}/13`）を追加
- `frontend/src/pages/StreetsAndAlleysPage.test.tsx`: 部分構築時のカウンタ値と完成時表現を検証するテストを2件追加

## 受け入れ条件
- [x] 各foundationパイルに現在の積み上げ枚数が表示される
- [x] 13枚到達時に視覚的な完了表現（チェックマーク＋成功色）が出る
- [x] モバイル/デスクトップ両レイアウトで表示崩れが無い（既存 flex レイアウト内に小さなテキスト行を追加）
- [x] コンポーネントテストでカウンタ値を検証する

## テスト
- `bunx biome check`: パス
- `bun run test -- --run StreetsAndAlleysPage`: 17件パス
- `bun run build`（tsc含む）: パス

Closes #3277