### PR TITLE
feat(conquian): add 11-card meld progress indicator

### DIFF
--- a/frontend/src/i18n/locales/en/conquian.json
+++ b/frontend/src/i18n/locales/en/conquian.json
@@ -23,6 +23,8 @@
   "scoresWins": "Wins",
   "melds": "Melds",
   "tableMelds": "Table Melds",
+  "meldProgress": "Melds {{count}}/{{total}}",
+  "meldRemaining": "{{count}} to go",
   "drawStockButton": "Draw Stock",
   "drawDiscardButton": "Draw Discard",
   "meldButton": "Meld",

--- a/frontend/src/i18n/locales/ja/conquian.json
+++ b/frontend/src/i18n/locales/ja/conquian.json
@@ -23,6 +23,8 @@
   "scoresWins": "勝利",
   "melds": "メルド",
   "tableMelds": "テーブルメルド",
+  "meldProgress": "メルド {{count}}/{{total}}",
+  "meldRemaining": "あと {{count}} 枚",
   "drawStockButton": "山札から引く",
   "drawDiscardButton": "捨て札から引く",
   "meldButton": "メルドする",

--- a/frontend/src/pages/ConquianPage.test.tsx
+++ b/frontend/src/pages/ConquianPage.test.tsx
@@ -101,7 +101,39 @@ const meldsDisplayState: ConquianResponse = {
   ],
 };
 
+// Human has laid a 3-card set and a 6-card run (9 of 11 melded, 2 remaining ->
+// the "close to winning" highlight should appear).
+const meldProgressState: ConquianResponse = {
+  ...meldPhaseState,
+  players: [
+    {
+      ...drawPhaseState.players[0],
+      melds: [
+        {
+          cards: [
+            { design: 'SPADE', value: 5 },
+            { design: 'HEART', value: 5 },
+            { design: 'CLOVER', value: 5 },
+          ],
+        },
+        {
+          cards: [
+            { design: 'DIAMOND', value: 3 },
+            { design: 'DIAMOND', value: 4 },
+            { design: 'DIAMOND', value: 5 },
+            { design: 'DIAMOND', value: 6 },
+            { design: 'DIAMOND', value: 7 },
+            { design: 'DIAMOND', value: 8 },
+          ],
+        },
+      ],
+    },
+    { id: 1, isHuman: false, cardCount: 10, cards: [], melds: [], wins: 1 },
+  ],
+};
+
 beforeEach(() => {
+  localStorage.clear();
   mockExec.mockResolvedValue(drawPhaseState);
 });
 
@@ -368,6 +400,26 @@ describe('ConquianPage', () => {
     expect(cardBtn).toHaveAttribute('aria-pressed', 'false');
     fireEvent.click(cardBtn);
     expect(cardBtn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('shows meld progress toward 11 for the human and CPU', async () => {
+    renderWithProviders(<ConquianPage />);
+    const humanProgress = await screen.findByTestId('conquian-meld-progress');
+    // Fresh game: nobody has melded yet.
+    expect(humanProgress).toHaveTextContent('メルド 0/11');
+    expect(screen.getByTestId('conquian-meld-progress-cpu-1')).toHaveTextContent('メルド 0/11');
+  });
+
+  it('counts melded cards and highlights the final stretch', async () => {
+    mockExec.mockResolvedValue(meldProgressState);
+    renderWithProviders(<ConquianPage />);
+    const humanProgress = await screen.findByTestId('conquian-meld-progress');
+    // 3 + 6 = 9 melded of 11.
+    expect(humanProgress).toHaveTextContent('メルド 9/11');
+    expect(humanProgress).toHaveTextContent('あと 2 枚');
+    const bar = humanProgress.querySelector('[role="progressbar"]');
+    expect(bar).toHaveAttribute('aria-valuenow', '9');
+    expect(bar).toHaveAttribute('aria-valuemax', '11');
   });
 
   it('renders tutorial button', async () => {

--- a/frontend/src/pages/ConquianPage.tsx
+++ b/frontend/src/pages/ConquianPage.tsx
@@ -26,7 +26,7 @@ import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { ConquianResponse } from '../types/card';
+import type { ConquianPlayerData, ConquianResponse } from '../types/card';
 import { ConquianPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
@@ -34,6 +34,9 @@ import { CONQUIAN_HELP, parseConquianCommand } from '../utils/cli/commands/conqu
 import { formatConquianState } from '../utils/cli/formatters/conquianFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
+
+/** Total cards a player must lay in table melds to win a Conquian round. */
+const CONQUIAN_MELD_TARGET = 11;
 
 const CONQUIAN_PHASE_KEYS: Readonly<Record<number, string>> = {
   [ConquianPhase.DRAW]: 'draw',
@@ -107,6 +110,37 @@ function ConquianPageContent() {
 
   const humanPlayer = state?.players.find((p) => p.isHuman);
   const humanCardCount = humanPlayer?.cards?.length ?? 0;
+
+  // Meld-progress indicator: count the cards laid across a player's table melds
+  // toward the 11-card win condition, highlighting the final stretch (<=2 left).
+  const renderMeldProgress = (p: ConquianPlayerData, testId: string) => {
+    const melded = p.melds.reduce((sum, m) => sum + m.cards.length, 0);
+    const remaining = CONQUIAN_MELD_TARGET - melded;
+    const isClose = remaining > 0 && remaining <= 2;
+    const pct = Math.min(100, (melded / CONQUIAN_MELD_TARGET) * 100);
+    const label = t('meldProgress', { count: melded, total: CONQUIAN_MELD_TARGET });
+    return (
+      <div data-testid={testId} className="mt-1">
+        <div className="flex items-center justify-between text-xs mb-0.5">
+          <span className="text-ds-text-muted">{label}</span>
+          {isClose && <span className="text-ds-warning font-bold">{t('meldRemaining', { count: remaining })}</span>}
+        </div>
+        <div
+          role="progressbar"
+          aria-label={label}
+          aria-valuemin={0}
+          aria-valuemax={CONQUIAN_MELD_TARGET}
+          aria-valuenow={melded}
+          className="h-1.5 w-full rounded-sm bg-white/15 overflow-hidden"
+        >
+          <div
+            className={`h-full rounded-sm ${isClose ? 'bg-ds-warning' : 'bg-ds-accent'}`}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      </div>
+    );
+  };
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('conquian');
   const cliConfig: CliGameConfig<ConquianResponse, Parameters<typeof conquianApi.exec>> = useMemo(
@@ -267,6 +301,7 @@ function ConquianPageContent() {
                         {playerName(p.id, p.isHuman)}: {t('cards', { count: p.cardCount })} |{' '}
                         {t('wins', { count: p.wins })}
                       </div>
+                      {renderMeldProgress(p, `conquian-meld-progress-cpu-${p.id}`)}
                       {/* Reveal CPU cards at round/game end */}
                       {(isRoundEnd || isGameEnd) && p.cards.length > 0 && (
                         <div className="flex flex-wrap gap-1 mt-1">
@@ -326,6 +361,9 @@ function ConquianPageContent() {
               <div className="text-xs font-bold mb-1 text-ds-info" data-testid="conquian-forced-use">
                 {t('forcedUse')}
               </div>
+            )}
+            {humanPlayer && (
+              <div className="mb-2 max-w-xs">{renderMeldProgress(humanPlayer, 'conquian-meld-progress')}</div>
             )}
             {humanPlayer && (
               <div className="flex flex-wrap gap-1 mb-2" data-tutorial="cq-player-hand">


### PR DESCRIPTION
## 概要

コンキャンの勝利条件（場に計 11 枚メルド）に対する進捗を、各プレイヤー情報枠に `x / 11` のプログレスバーで表示する。集計はレスポンスの `players[].melds[].cards` から行い、バックエンド変更は不要。

- 人間: 手札の上（フッター）に `data-testid="conquian-meld-progress"`
- CPU: プレイヤー情報枠に `data-testid="conquian-meld-progress-cpu-{id}"`
- 残り 2 枚以下になると `ds-warning` 色で「あと n 枚」を強調表示、バーも警告色に

## 受け入れ条件

- [x] 人間と CPU 双方に x/11 の進捗が表示される
- [x] 残り 2 枚以下で強調表示される
- [x] メルド追加後に進捗が即時更新される（レスポンス由来のため再レンダーで反映）
- [x] ページテストで進捗表示を検証

## テスト

- `bunx biome check --write` 通過
- `bun run test -- --run ConquianPage` 30 tests 通過（新規 2 件: 進捗表示 / 最終盤ハイライト）
- `bun run build`（tsc + vite）通過
- i18n キー `meldProgress` / `meldRemaining` を ja/en に追加

Closes #3473