### PR TITLE
feat(tablanet): visualize tabla sweep condition on the play board

### DIFF
--- a/frontend/src/i18n/locales/en/tablanet.json
+++ b/frontend/src/i18n/locales/en/tablanet.json
@@ -26,6 +26,8 @@
   "playButton": "Play",
   "captureButton": "Capture",
   "trailButton": "Trail",
+  "tablaButton": "Tabla Capture!",
+  "tablaReady": "Tabla!",
   "newGame": "New Game",
   "result": {
     "title": "Final Scores",

--- a/frontend/src/i18n/locales/ja/tablanet.json
+++ b/frontend/src/i18n/locales/ja/tablanet.json
@@ -26,6 +26,8 @@
   "playButton": "出す",
   "captureButton": "捕獲",
   "trailButton": "トレイル",
+  "tablaButton": "タブラ捕獲！",
+  "tablaReady": "タブラ！",
   "newGame": "新しいゲーム",
   "result": {
     "title": "最終得点",

--- a/frontend/src/pages/TablanetPage.test.tsx
+++ b/frontend/src/pages/TablanetPage.test.tsx
@@ -36,7 +36,15 @@ const gameEndState = makeTablanetState({
   },
 });
 
+// A play-phase state where the human's non-Jack card 0 (value 5) can capture
+// EVERY table card (both indices), so selecting it makes a tabla possible. Card 1
+// is a Jack (value 11) whose sweep must NOT count as a tabla.
+const tablaReadyState = makeTablanetState({
+  captureOptions: { 0: [0, 1], 1: [0, 1] },
+});
+
 beforeEach(() => {
+  localStorage.clear();
   mockExec.mockReset();
   mockExec.mockResolvedValue(playPhaseState);
 });
@@ -173,5 +181,30 @@ describe('TablanetPage', () => {
     mockExec.mockResolvedValue(gameEndState);
     fireEvent.click(nextBtn);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('nextround'));
+  });
+
+  it('highlights the table and switches the button label when a tabla is possible', async () => {
+    mockExec.mockResolvedValue(tablaReadyState);
+    renderWithProviders(<TablanetPage />);
+    const handCard = await screen.findByTestId('hand-card-0');
+
+    // Before selecting a card, no tabla emphasis.
+    expect(screen.queryByTestId('tablanet-tabla-badge')).not.toBeInTheDocument();
+    expect(screen.getByTestId('tablanet-play-button')).toHaveTextContent('出す');
+
+    // Selecting the non-Jack sweep card reveals the tabla badge + button label.
+    fireEvent.click(handCard);
+    expect(screen.getByTestId('tablanet-tabla-badge')).toHaveTextContent('タブラ！');
+    expect(screen.getByTestId('tablanet-play-button')).toHaveTextContent('タブラ捕獲！');
+  });
+
+  it('does not treat a Jack sweep as a tabla', async () => {
+    mockExec.mockResolvedValue(tablaReadyState);
+    renderWithProviders(<TablanetPage />);
+    // Card 1 is a Jack: even though it can clear the table, it never scores a tabla.
+    const jackCard = await screen.findByTestId('hand-card-1');
+    fireEvent.click(jackCard);
+    expect(screen.queryByTestId('tablanet-tabla-badge')).not.toBeInTheDocument();
+    expect(screen.getByTestId('tablanet-play-button')).not.toHaveTextContent('タブラ捕獲！');
   });
 });

--- a/frontend/src/pages/TablanetPage.tsx
+++ b/frontend/src/pages/TablanetPage.tsx
@@ -158,6 +158,19 @@ function TablanetPageContent() {
     handIndex !== null && isHumanTurn ? new Set(state.captureOptions[handIndex] ?? []) : new Set<number>();
   const canPlay = isHumanTurn && handIndex !== null;
 
+  // Tabla (sweep) is possible when the selected non-Jack card can capture EVERY
+  // table card, clearing the board. Jack sweeps are excluded (they never score a
+  // tabla). This mirrors the backend award rule (Tablanet.go applyPlay) and is
+  // derived purely from captureOptions + tableCards.length as the issue requires.
+  const selectedHandCard = handIndex !== null ? (human?.cards[handIndex] ?? null) : null;
+  const selectedIsJack = selectedHandCard?.value === 11;
+  const tablaPossible =
+    isHumanTurn &&
+    handIndex !== null &&
+    !selectedIsJack &&
+    state.tableCards.length > 0 &&
+    captureCandidates.size === state.tableCards.length;
+
   const winnerNames = state.winners.map((i) => (state.players[i]?.isHuman ? t('you') : t('cpu', { id: i }))).join(', ');
 
   const humanStats = human
@@ -209,8 +222,24 @@ function TablanetPageContent() {
             </div>
 
             {/* Table cards */}
-            <div className="py-3 bg-black/20 rounded-lg" data-tutorial="tablanet-table-cards">
-              <div className="text-center text-xs text-ds-text-muted mb-2">{t('table')}</div>
+            <div
+              className={`py-3 rounded-lg transition-all ${
+                tablaPossible ? 'bg-ds-success/20 ring-2 ring-ds-success motion-safe:animate-pulse' : 'bg-black/20'
+              }`}
+              data-tutorial="tablanet-table-cards"
+              data-tabla-ready={tablaPossible || undefined}
+            >
+              <div className="text-center text-xs text-ds-text-muted mb-2">
+                {t('table')}
+                {tablaPossible && (
+                  <span
+                    className="ml-2 px-2 py-0.5 rounded-full bg-ds-success text-ds-text-primary text-xs font-bold"
+                    data-testid="tablanet-tabla-badge"
+                  >
+                    {t('tablaReady')}
+                  </span>
+                )}
+              </div>
               <div className="flex justify-center gap-2 min-h-[60px] flex-wrap">
                 {state.tableCards.length === 0 ? (
                   <span className="text-ds-text-muted text-sm self-center">{t('tableEmpty')}</span>
@@ -352,8 +381,14 @@ function TablanetPageContent() {
           <GameFooter className={`${gameTheme.tablanet.footer} px-4 py-2.5`}>
             <div className="flex gap-2 justify-center flex-wrap items-center" data-tutorial="tablanet-actions">
               {!isGameEnd && isHumanTurn && (
-                <button type="button" className={btnPrimary} onClick={playCard} disabled={loading || !canPlay}>
-                  {tableIndices.length > 0 ? t('captureButton') : t('playButton')}
+                <button
+                  type="button"
+                  className={btnPrimary}
+                  onClick={playCard}
+                  disabled={loading || !canPlay}
+                  data-testid="tablanet-play-button"
+                >
+                  {tablaPossible ? t('tablaButton') : tableIndices.length > 0 ? t('captureButton') : t('playButton')}
                 </button>
               )}
               {isGameEnd && (


### PR DESCRIPTION
## 概要

タブラネット（Tablanet）で「タブラ（場一掃）」が成立可能なタイミングを可視化する。選択した非ジャックの手札で場札を全て捕獲できる場合、場エリアを特別強調し「タブラ！」バッジを表示、キャプチャボタンのラベルを専用ラベルに切り替える。

判定はフロントで `captureOptions` と `tableCards.length` のみから算出する（`captureCandidates.size === tableCards.length` かつ場札が空でない、かつ選択札がジャックでない）。ジャックのスイープはタブラ得点に含まれないためバックエンドの得点ルール（`Tablanet.go` の `applyPlay`）に合わせて除外している。

## 変更点

- `frontend/src/pages/TablanetPage.tsx`: `tablaPossible` の算出、場エリアの強調＋`タブラ！`バッジ（`data-testid="tablanet-tabla-badge"`）、ボタンラベル切替（`data-testid="tablanet-play-button"`）
- `frontend/src/i18n/locales/{ja,en}/tablanet.json`: `tablaButton` / `tablaReady` キーを追加（ja/en 同期）
- `frontend/src/pages/TablanetPage.test.tsx`: タブラ強調テストとジャック除外テストを追加

## 受け入れ条件

- [x] タブラ成立可能時に場エリアが特別強調される
- [x] キャプチャボタンがタブラ用ラベルに変わる
- [x] 判定はフロントで `captureOptions` と `tableCards.length` から算出
- [x] `TablanetPage.test.tsx` にタブラ強調テストを追加
- [x] ジャックのスイープはタブラ扱いしない（バックエンド得点ルールと整合）

## テスト

- `bun run test -- --run TablanetPage`: 14 passed
- `bun run build`（tsc + vite）: 成功
- `biome check`: クリーン

Closes #3628