### PR TITLE
feat(knockoutwhist): add spectator-mode banner when human is knocked out

### DIFF
--- a/frontend/src/i18n/locales/en/knockoutwhist.json
+++ b/frontend/src/i18n/locales/en/knockoutwhist.json
@@ -28,6 +28,7 @@
   "you": "You",
   "cpu": "CPU {{id}}",
   "eliminated": "Knocked out",
+  "spectatorBanner": "You've been knocked out — spectating ({{n}} left)",
   "leader": "Leader",
   "roundWinner": "Round winner",
   "playButton": "Play",

--- a/frontend/src/i18n/locales/ja/knockoutwhist.json
+++ b/frontend/src/i18n/locales/ja/knockoutwhist.json
@@ -28,6 +28,7 @@
   "you": "あなた",
   "cpu": "CPU {{id}}",
   "eliminated": "脱落",
+  "spectatorBanner": "あなたは脱落しました — 観戦中（残り {{n}}人）",
   "leader": "リーダー",
   "roundWinner": "ラウンド勝者",
   "playButton": "出す",

--- a/frontend/src/pages/KnockoutWhistPage.test.tsx
+++ b/frontend/src/pages/KnockoutWhistPage.test.tsx
@@ -30,6 +30,7 @@ const gameEndState = makeKnockoutWhistState({
 const cpuTurnState = makeKnockoutWhistState({ currentPlayerIdx: 1, isHumanTurn: false });
 
 beforeEach(() => {
+  localStorage.clear();
   mockExec.mockReset();
   mockExec.mockResolvedValue(playPhaseState);
 });
@@ -120,6 +121,38 @@ describe('KnockoutWhistPage', () => {
       expect(row.className).toContain('opacity-70');
       expect(row.className).not.toContain('opacity-40');
     }
+  });
+
+  // Build a state whose human (seat 0) is knocked out, using a fresh players array so the
+  // shared base fixture (referenced by makeKnockoutWhistState's shallow spread) is not mutated.
+  const eliminatedHumanState = (overrides?: Parameters<typeof makeKnockoutWhistState>[0]) => {
+    const base = makeKnockoutWhistState(overrides);
+    return {
+      ...base,
+      players: base.players.map((p) => (p.isHuman ? { ...p, eliminated: true, dogbones: 0 } : p)),
+    };
+  };
+
+  it('shows the spectator banner while the human is eliminated and the match continues', async () => {
+    mockExec.mockResolvedValue(eliminatedHumanState({ isHumanTurn: false, currentPlayerIdx: 1, activeCount: 2 }));
+    renderWithProviders(<KnockoutWhistPage />);
+    const banner = await screen.findByTestId('kw-spectator-banner');
+    expect(banner).toHaveAttribute('role', 'status');
+    expect(banner).toHaveTextContent('観戦中');
+    expect(banner).toHaveTextContent('残り 2人');
+  });
+
+  it('does not show the spectator banner while the human is still active', async () => {
+    renderWithProviders(<KnockoutWhistPage />);
+    await waitFor(() => expect(screen.getByAltText('♥ Q')).toBeInTheDocument());
+    expect(screen.queryByTestId('kw-spectator-banner')).not.toBeInTheDocument();
+  });
+
+  it('does not show the spectator banner once the game has ended', async () => {
+    mockExec.mockResolvedValue(eliminatedHumanState({ phase: 3, gameEndFlag: true, winnerPlayer: 1, activeCount: 1 }));
+    renderWithProviders(<KnockoutWhistPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('kw-spectator-banner')).not.toBeInTheDocument();
   });
 
   it('renders the leader badge with an opaque, high-contrast surface', async () => {

--- a/frontend/src/pages/KnockoutWhistPage.tsx
+++ b/frontend/src/pages/KnockoutWhistPage.tsx
@@ -147,7 +147,10 @@ function KnockoutWhistPageContent() {
   const isTrumpSelect = state.phase === KnockoutWhistPhase.TRUMP_SELECT;
   const isGameEnd = state.phase === KnockoutWhistPhase.GAME_END || state.gameEndFlag;
 
-  const canPlay = isPlayPhase && isHumanTurn && !(state.players[humanIdx]?.eliminated ?? false);
+  const isHumanEliminated = state.players[humanIdx]?.eliminated ?? false;
+  const canPlay = isPlayPhase && isHumanTurn && !isHumanEliminated;
+  // Show a spectator banner while the human is knocked out but the match continues among the CPUs.
+  const showSpectatorBanner = isHumanEliminated && !isGameEnd;
   const trumpSymbol = SUIT_SYMBOLS[state.trumpSuit] ?? '?';
 
   const handleManualReset = () => {
@@ -227,6 +230,16 @@ function KnockoutWhistPageContent() {
           />
 
           <div className={`flex-1 overflow-y-auto pt-3 px-4 lg:px-8 ${lgCardAreaConstraint}`}>
+            {showSpectatorBanner && (
+              <div
+                role="status"
+                data-testid="kw-spectator-banner"
+                className="mb-3 p-2 rounded border border-ds-warning/50 bg-black/30 text-ds-warning text-center text-sm font-medium"
+              >
+                {t('spectatorBanner', { n: state.activeCount })}
+              </div>
+            )}
+
             <div className="text-ds-text-primary text-center mb-2">
               <span className="mr-4">{t('round', { n: state.roundNumber })}</span>
               <span className="mr-4">{t('handSize', { n: state.handSize })}</span>


### PR DESCRIPTION
## 概要
ノックアウト・ホイストで人間プレイヤーが脱落した後もゲームは CPU 同士で継続するが、画面中央には操作不能の理由が示されていなかった。人間が脱落している間、TrickDisplay の上に「あなたは脱落しました — 観戦中（残りn人）」の常設バナー（`role="status"`）を表示する。

- `state.players[humanIdx].eliminated` が真かつ `gameEndFlag`/GAME_END でない間だけ表示
- `state.activeCount` を併記
- ja/en 両ロケールに `spectatorBanner` キーを追加（キー同期済み）

## 受け入れ条件
- [x] 人間脱落中に観戦バナーが常時表示される
- [x] activeCount が併記される
- [x] role=status が付与される
- [x] KnockoutWhistPage.test.tsx に脱落状態のテストを追加（脱落中は表示 / アクティブ時は非表示 / ゲーム終了後は非表示）

## テスト
- `bun run test -- --run KnockoutWhistPage` : 14 passed
- `bunx biome check` : clean
- `bun run build` (tsc) : pass

Closes #3436