### PR TITLE
feat(razz): add bring-in player indicator on 3rd street

### DIFF
--- a/frontend/src/i18n/locales/en/razz.json
+++ b/frontend/src/i18n/locales/en/razz.json
@@ -16,6 +16,7 @@
   "currentLow": "Current low: {{low}}",
   "currentLowIncomplete": "Low incomplete (fewer than 5 ranks)",
   "anteBringIn": "Ante/Bring-in",
+  "bringIn": "Bring-in",
   "handNumber": "Hand {{count}} / Lv.{{level}}",
   "rebuy": {
     "prompt": "Rebuy? ({{chips}} chips, {{used}}/{{max}} times)",

--- a/frontend/src/i18n/locales/ja/razz.json
+++ b/frontend/src/i18n/locales/ja/razz.json
@@ -16,6 +16,7 @@
   "currentLow": "現在のロー: {{low}}",
   "currentLowIncomplete": "ロー未完成（5枚揃わず）",
   "anteBringIn": "アンティ/ブリングイン",
+  "bringIn": "ブリングイン",
   "handNumber": "ハンド#{{count}} (レベルアップ:{{level}}ハンド毎)",
   "rebuy": {
     "prompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済)",

--- a/frontend/src/pages/RazzPage.test.tsx
+++ b/frontend/src/pages/RazzPage.test.tsx
@@ -915,6 +915,31 @@ describe('RazzPage', () => {
   });
 
   // ---- Seventh street: 3 hole card placeholders ----
+  // ---- bring-in indicator ----
+  it('shows the bring-in badge on the human when they post the bring-in during 3rd street', async () => {
+    // thirdStreetState has bringInPlayerIdx 0 → the human (id 0).
+    mockExec.mockResolvedValue(thirdStreetState);
+    renderWithProviders(<RazzPage />);
+    const badge = await screen.findByTestId('razz-bringin-badge-0');
+    expect(badge).toHaveTextContent('ブリングイン');
+  });
+
+  it('shows the bring-in badge on the CPU indicated by bringInPlayerIdx during 3rd street', async () => {
+    mockExec.mockResolvedValue({ ...thirdStreetState, bringInPlayerIdx: 1 });
+    renderWithProviders(<RazzPage />);
+    // bringInPlayerIdx 1 → CPU with id 1; the human (id 0) must not carry the badge.
+    expect(await screen.findByTestId('razz-bringin-badge-1')).toHaveTextContent('ブリングイン');
+    expect(screen.queryByTestId('razz-bringin-badge-0')).not.toBeInTheDocument();
+  });
+
+  it('hides the bring-in badge outside of 3rd street', async () => {
+    mockExec.mockResolvedValue(showdownState);
+    renderWithProviders(<RazzPage />);
+    await waitFor(() => expect(screen.getByText('ショーダウン')).toBeInTheDocument());
+    expect(screen.queryByTestId('razz-bringin-badge-0')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('razz-bringin-badge-1')).not.toBeInTheDocument();
+  });
+
   it('shows 3 face-down placeholders for human hole cards on seventh street', async () => {
     mockExec.mockResolvedValue({
       ...thirdStreetState,

--- a/frontend/src/pages/RazzPage.tsx
+++ b/frontend/src/pages/RazzPage.tsx
@@ -218,6 +218,14 @@ function RazzPageContent() {
   const humanIdx = state?.players?.findIndex((p) => p.isHuman) ?? 0;
   const humanRebuyCount = state?.rebuyCounts?.[humanIdx] ?? 0;
   const cpuPlayers = useMemo(() => state?.players?.filter((p) => !p.isHuman) ?? [], [state?.players]);
+  // Bring-in player (highest door card, posts the forced bet). Shown only during 3rd street,
+  // the single round where the bring-in is relevant. `bringInPlayerIdx` indexes into state.players.
+  const bringInIdx = state?.bringInPlayerIdx ?? -1;
+  const bringInPlayerId =
+    phase === SevenCardStudPhase.THIRD_STREET && bringInIdx >= 0 ? state?.players?.[bringInIdx]?.id : undefined;
+  const bringInCardClass = 'ring-2 ring-game-status-active rounded p-0.5';
+  const bringInBadgeClass =
+    'inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 bg-game-status-active text-game-text-strong';
 
   const actionBindings = useMemo(
     () => [
@@ -306,6 +314,11 @@ function RazzPageContent() {
                     )}
                     {p.folded && <span className="ml-2 text-ds-error text-xs">[{tc('status.folded')}]</span>}
                     {p.allIn && <span className="ml-2 text-ds-warning text-xs">[{tc('status.allIn')}]</span>}
+                    {p.id === bringInPlayerId && (
+                      <span data-testid={`razz-bringin-badge-${p.id}`} className={bringInBadgeClass}>
+                        {t('bringIn')}
+                      </span>
+                    )}
                     {isShowdown && !p.folded && p.handName && (
                       <span className={`inline-block ml-2 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}>
                         {p.handName}
@@ -314,7 +327,7 @@ function RazzPageContent() {
                   </div>
                   {/* Door cards (always visible) */}
                   <div className="text-ds-text-muted text-xs mb-0.5">{t('doorCards')}</div>
-                  <div className="flex flex-wrap gap-1 mb-1">
+                  <div className={`flex flex-wrap gap-1 mb-1 ${p.id === bringInPlayerId ? bringInCardClass : ''}`}>
                     {p.doorCards?.length
                       ? p.doorCards.map((card) => (
                           <AnimatedCard
@@ -405,6 +418,11 @@ function RazzPageContent() {
                   )}
                   {humanPlayer.folded && <span className="ml-2 text-ds-error text-xs">[{tc('status.folded')}]</span>}
                   {humanPlayer.allIn && <span className="ml-2 text-ds-warning text-xs">[{tc('status.allIn')}]</span>}
+                  {humanPlayer.id === bringInPlayerId && (
+                    <span data-testid={`razz-bringin-badge-${humanPlayer.id}`} className={bringInBadgeClass}>
+                      {t('bringIn')}
+                    </span>
+                  )}
                   {razzLow && (
                     <span
                       data-testid="razz-best-low"
@@ -421,7 +439,9 @@ function RazzPageContent() {
                 </div>
                 {/* Door cards */}
                 <div className="text-ds-text-muted text-xs mb-0.5">{t('doorCards')}</div>
-                <div className="flex flex-wrap gap-1.5 mb-1">
+                <div
+                  className={`flex flex-wrap gap-1.5 mb-1 ${humanPlayer.id === bringInPlayerId ? bringInCardClass : ''}`}
+                >
                   {humanPlayer.doorCards?.length
                     ? humanPlayer.doorCards.map((card) => (
                         <AnimatedCard


### PR DESCRIPTION
## 概要
ラズ（Razz）で、3rd street の強制ベット担当者（ブリングイン）を視覚的に示す手がかりがなかった問題に対応する。CPU・人間いずれのプレイヤーにも「ブリングイン」バッジと、ドアカード表示の強調枠を追加する。

レスポンスに既存の `bringInPlayerIdx`（`state.players` へのインデックス）を利用するだけの、純粋に加算的な表示変更。ゲームルールの再計算は一切していない。ブリングインが意味を持つ 3rd street のみ表示し、以降のストリートでは非表示にする。

## 変更点
- `RazzPage.tsx`: `bringInPlayerIdx` から対象プレイヤーを特定し、人間・CPU の見出しに `data-testid="razz-bringin-badge-<id>"` のバッジを追加。ドアカードコンテナに強調枠（ring）を付与。`phase === THIRD_STREET` のときのみ表示。
- `razz.json`（ja/en）: `bringIn` バッジ文言を追加（key-for-key 同期）。
- `RazzPage.test.tsx`: 3ケース追加。

## 受け入れ条件
- [x] ブリングイン担当プレイヤーに視覚的なバッジが表示される
- [x] 3rd street の初回のみ表示され、以降のストリートでは表示されない
- [x] `RazzPage.test.tsx` にバッジ表示を検証するテストを追加

## テスト
- `bun run test -- --run RazzPage`: 64 passed
- `bun run build`（tsc）: 成功
- `biome check`: クリーン

Closes #3183