### PR TITLE
feat(sheepshead): visualize the blind as face-down cards in the pick phase

### DIFF
--- a/frontend/src/pages/SheepsheadPage.test.tsx
+++ b/frontend/src/pages/SheepsheadPage.test.tsx
@@ -118,6 +118,22 @@ describe('SheepsheadPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('pick', { pick: false }));
   });
 
+  it('visualizes the blind as face-down cards in the pick phase', async () => {
+    mockExec.mockResolvedValue(pickPhaseState);
+    renderWithProviders(<SheepsheadPage />);
+    const blind = await screen.findByTestId('sh-blind-display');
+    expect(blind).toBeInTheDocument();
+    // blindCount is 2, so two face-down card backs are rendered.
+    expect(screen.getAllByTestId('animated-card-back')).toHaveLength(2);
+  });
+
+  it('does not show the blind display outside the pick phase', async () => {
+    mockExec.mockResolvedValue(buryPhaseState);
+    renderWithProviders(<SheepsheadPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: /埋める/ })).toBeInTheDocument());
+    expect(screen.queryByTestId('sh-blind-display')).not.toBeInTheDocument();
+  });
+
   it('renders the bury button for the picker in the bury phase', async () => {
     mockExec.mockResolvedValue(buryPhaseState);
     renderWithProviders(<SheepsheadPage />);

--- a/frontend/src/pages/SheepsheadPage.tsx
+++ b/frontend/src/pages/SheepsheadPage.tsx
@@ -10,6 +10,7 @@ import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { HintTooltip } from '../components/hint/HintTooltip';
+import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
 import { PlayerHandSection } from '../components/PlayerHandSection';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { TrickDisplay } from '../components/TrickDisplay';
@@ -254,6 +255,19 @@ function SheepsheadPageContent() {
             <div className={lgTwoColGrid}>
               {/* Left: play area */}
               <div>
+                {/* Blind: face-down cards, shown only during the Pick phase before a picker takes them. */}
+                {isPickPhase && state.blindCount > 0 && (
+                  <div className="mb-3" data-testid="sh-blind-display">
+                    <div className="text-ds-text-muted text-sm mb-1 text-center">
+                      {t('blind')} ({state.blindCount})
+                    </div>
+                    <div className="flex justify-center gap-2">
+                      {Array.from({ length: state.blindCount }).map((_, i) => (
+                        <AnimatedCardBack key={i} width={cardWidth} dealDelay={i * 0.08} />
+                      ))}
+                    </div>
+                  </div>
+                )}
                 <TrickDisplay
                   currentTrick={state.currentTrick}
                   players={state.players}


### PR DESCRIPTION
## 概要
シープスヘッドの PICK フェーズで、ブラインド（伏せ札 2 枚）を枚数テキストだけでなく裏面カード（`AnimatedCardBack`）として可視化する。トリック表示の上部に表示され、ピッカー確定後は非表示になる。

Closes #3400

## 変更内容
- `SheepsheadPage.tsx`: PICK フェーズかつ `blindCount > 0` のとき、`state.blindCount` 枚の裏面カードを左プレイエリアに表示（`data-testid="sh-blind-display"`）。既存の `blind` i18n キーを再利用（新規キーなし）。
- `SheepsheadPage.test.tsx`: PICK フェーズでブラインドが 2 枚の裏面カードとして表示されること、および他フェーズでは非表示になることを検証するテストを追加。

## スコープ外（今回未実装）
- BURY フェーズでのブラインド由来 2 枚のハイライト（`blindIndices`）は、ドメイン層でピック済みブラインド札を並べ替え後の手札位置として追跡し、KV シリアライズ・interface/mock・controller・presenter・型まで横断的に変更する必要があり、本 PR の「表示のみ・軽量」スコープを超えるため見送り。レスポンスに識別情報が無いため現状フロントのみでは実装不可。

## 受け入れ条件
- [x] PICK フェーズでブラインドが裏面カードとして表示される
- [ ] BURY フェーズでブラインド由来の 2 枚がハイライトされる（スコープ外・要バックエンド対応）
- [ ] `SheepsheadResponse` に blindIndices が追加される（スコープ外・要バックエンド対応）
- [x] ページテスト更新

## 確認
- `bunx biome check`：警告・エラーなし
- `bun run test -- --run SheepsheadPage`：16 tests passed
- `bun run build`（tsc + vite）：成功