### PR TITLE
feat(tichu): show live cumulative team scores during play

### DIFF
--- a/frontend/src/pages/TichuPage.test.tsx
+++ b/frontend/src/pages/TichuPage.test.tsx
@@ -225,6 +225,24 @@ describe('TichuPage', () => {
     await waitFor(() => expect(screen.getByTestId('tichu-bomb-badge-0')).toBeInTheDocument());
   });
 
+  it('play phase: shows the live team-score bar with the human team highlighted', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: 'play', scores: [30, 70] }));
+    renderWithProviders(<TichuPage />);
+    const bar = await screen.findByTestId('tichu-score-bar');
+    expect(bar).toHaveTextContent(/チームA.*30/);
+    expect(bar).toHaveTextContent(/チームB.*70/);
+    // Human (P0) is on team A, so Team A is emphasised.
+    const teamA = screen.getByText(/チームA.*30/);
+    expect(teamA).toHaveClass('text-ds-accent');
+  });
+
+  it('end phase: hides the live score bar (only the result block shows scores)', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: 'end', gameEndFlag: true, scores: [100, 0] }));
+    renderWithProviders(<TichuPage />);
+    await waitFor(() => expect(screen.getByText(/あなたのチームの勝利/)).toBeInTheDocument());
+    expect(screen.queryByTestId('tichu-score-bar')).not.toBeInTheDocument();
+  });
+
   it('end phase: shows team scores, the win banner, and the one-two note', async () => {
     mockExec.mockResolvedValue(makeState({ phase: 'end', gameEndFlag: true, isOneTwo: true, scores: [200, -100] }));
     renderWithProviders(<TichuPage />);

--- a/frontend/src/pages/TichuPage.tsx
+++ b/frontend/src/pages/TichuPage.tsx
@@ -243,6 +243,19 @@ function TichuPageContent() {
           <GameMessageBox messageCode={state.messageCode} messageParams={state.messageParams} message={state.message} />
           {hint && hintEnabled && <HintTooltip reason={t(hint.reason)} confidence={hint.confidence} />}
 
+          {/* Live cumulative team scores (visible during declare/play) */}
+          {!isGameEnd && (
+            <div className="flex justify-center gap-4 text-sm text-ds-text-primary" data-testid="tichu-score-bar">
+              <span className={humanTeam === 0 ? 'font-bold text-ds-accent' : ''}>
+                {t('label.teamA')}: {state.scores[0]}
+              </span>
+              <span className={humanTeam === 1 ? 'font-bold text-ds-accent' : ''}>
+                {t('label.teamB')}: {state.scores[1]}
+              </span>
+              {state.isOneTwo && <span className="text-xs opacity-75">{t('label.oneTwo')}</span>}
+            </div>
+          )}
+
           {/* CPU areas */}
           <div className="flex justify-around gap-2" data-tutorial="tichu-cpus">
             {state.players


### PR DESCRIPTION
## 概要

ティチューのプレイ画面で、両チームの累計スコアを declare / play フェーズ中も常時表示するスコアバーを追加しました。従来は `isGameEnd` の結果ブロックでしか `state.scores` を表示しておらず、ティチュー宣言（±100 / ±200 のリスク判断）に必要な現在の点差・目標が見えませんでした。

- CPU エリアの上に `Team A: {scores[0]} / Team B: {scores[1]}` を常時表示
- 人間の所属チームを `text-ds-accent font-bold` で視覚的に強調
- 1-2 フィニッシュ（`isOneTwo`）時は同バーに +200 表示を反映
- ゲーム終了時はバーを非表示にし、既存の結果表示と重複させない
- 既存の `scores` / `isOneTwo` レスポンスフィールドと `teamA`/`teamB`/`oneTwo` i18n キーを再利用（新規キーなし）。純粋な追加でインタラクションはブロックしない

## 受け入れ条件

- [x] declare / play フェーズ中も両チームの累計スコアが表示される
- [x] 人間の所属チームが視覚的に区別できる（`text-ds-accent`）
- [x] ゲーム終了時の既存結果表示と重複せず整合する（終了時はバー非表示）
- [x] `TichuPage.test.tsx` にスコアバー表示テスト追加

## テスト

- `bun run test -- --run TichuPage` — 14 passed（新規2件: play フェーズのスコアバー表示＋人間チーム強調、end フェーズでのバー非表示）
- `bun run build`（tsc）通過
- `biome check` 通過

Closes #3391