### PR TITLE
feat(threecard): show ante/pair-plus wagers during action phase

### DIFF
--- a/frontend/src/i18n/locales/en/threecard.json
+++ b/frontend/src/i18n/locales/en/threecard.json
@@ -34,6 +34,11 @@
     "pairPlus": "Pair Plus",
     "total": "Total"
   },
+  "betSlip": {
+    "ante": "Ante",
+    "pairPlus": "Pair Plus",
+    "playRequired": "To Play"
+  },
   "handRank": {
     "1": "High Card",
     "2": "Pair",

--- a/frontend/src/i18n/locales/ja/threecard.json
+++ b/frontend/src/i18n/locales/ja/threecard.json
@@ -34,6 +34,11 @@
     "pairPlus": "ペアプラス",
     "total": "合計"
   },
+  "betSlip": {
+    "ante": "アンテ",
+    "pairPlus": "ペアプラス",
+    "playRequired": "プレイに必要"
+  },
   "handRank": {
     "1": "ハイカード",
     "2": "ペア",

--- a/frontend/src/pages/ThreeCardPage.test.tsx
+++ b/frontend/src/pages/ThreeCardPage.test.tsx
@@ -162,6 +162,31 @@ describe('ThreeCardPage', () => {
     expect(screen.getByRole('button', { name: 'フォールド' })).toBeInTheDocument();
   });
 
+  it('shows the ante and play-required amounts during action phase', async () => {
+    mockExec.mockResolvedValue(actionPhaseState);
+    renderWithProviders(<ThreeCardPage />);
+    await waitFor(() => expect(screen.getByTestId('action-bet-slip')).toBeInTheDocument());
+    const slip = screen.getByTestId('action-bet-slip');
+    expect(slip).toHaveTextContent('アンテ: 100');
+    expect(slip).toHaveTextContent('プレイに必要: 100');
+    // pairPlusBet is 0 in this fixture → the pair-plus row is omitted
+    expect(slip).not.toHaveTextContent('ペアプラス');
+  });
+
+  it('shows the pair-plus row in the action bet slip when pair plus is wagered', async () => {
+    mockExec.mockResolvedValue({ ...actionPhaseState, pairPlusBet: 50 });
+    renderWithProviders(<ThreeCardPage />);
+    await waitFor(() => expect(screen.getByTestId('action-bet-slip')).toBeInTheDocument());
+    expect(screen.getByTestId('action-bet-slip')).toHaveTextContent('ペアプラス: 50');
+  });
+
+  it('does not show the action bet slip during bet phase', async () => {
+    mockExec.mockResolvedValue(betPhaseState);
+    renderWithProviders(<ThreeCardPage />);
+    await waitFor(() => expect(screen.getByText('チップ: 1000')).toBeInTheDocument());
+    expect(screen.queryByTestId('action-bet-slip')).not.toBeInTheDocument();
+  });
+
   it('shows end phase with player wins', async () => {
     mockExec.mockResolvedValueOnce(actionPhaseState).mockResolvedValueOnce(endPhasePlayerWins);
     renderWithProviders(<ThreeCardPage />);

--- a/frontend/src/pages/ThreeCardPage.tsx
+++ b/frontend/src/pages/ThreeCardPage.tsx
@@ -215,6 +215,23 @@ function ThreeCardPageContent() {
               </div>
             )}
 
+            {/* Bet slip during action phase — mirrors the end-phase payout breakdown */}
+            {isActionPhase && (
+              <div className="text-ds-text-primary text-center text-sm mb-2" data-testid="action-bet-slip">
+                <div>
+                  {t('betSlip.ante')}: {state.anteBet}
+                </div>
+                {state.pairPlusBet > 0 && (
+                  <div>
+                    {t('betSlip.pairPlus')}: {state.pairPlusBet}
+                  </div>
+                )}
+                <div className="font-bold mt-1">
+                  {t('betSlip.playRequired')}: {state.anteBet}
+                </div>
+              </div>
+            )}
+
             {/* Player Hand */}
             {state.playerHand.length > 0 && (
               <div className="mb-4" data-tutorial="tc-results">


### PR DESCRIPTION
Closes #3092

## 概要
スリーカードポーカーの ACTION フェーズで、直前に置いたアンティ額・ペアプラス額・プレイに必要な額が見えず、「フォールドで失う額」「プレイに必要な追加額」がわからないまま意思決定していました。ACTION フェーズの手札上部にベット票を常時表示します。

## 変更内容
- `ThreeCardPage.tsx`: ACTION フェーズに `data-testid="action-bet-slip"` のベット票を追加（アンテ / ペアプラス / プレイに必要）。END フェーズの `payout-breakdown` と同じ中央寄せ小テキストのスタイルで視覚的に整合。プレイに必要な額 = アンテ額。
- i18n: ja/en `threecard.json` に `betSlip.{ante,pairPlus,playRequired}` を key-for-key で追加。
- テスト: ページテスト 3 件を追加。

バックエンドは既に `anteBet`/`pairPlusBet`/`playBet` を返しており（`ThreeCardWebPresenter.Output`）、レスポンス型 `ThreeCardResponse` にも存在するため、変更は純粋にフロントの表示追加のみ。

## 受け入れ条件
- [x] ACTION フェーズでアンティ・ペアプラス・プレイ必要額が表示される
- [x] ペアプラス 0 のときはその行を省略
- [x] END フェーズの配当内訳（`payout-breakdown`）と視覚的に整合する
- [x] ページテストを追加（プレゼンターは既存出力で対応済みのため変更なし）

## テスト
- `bunx biome check` パス
- `bun run test -- --run ThreeCardPage`: 40 passed（新規 3 件）
- `bun run build` (tsc) パス