### PR TITLE
fix(accordion): highlight legal merge targets on selection for touch parity

### DIFF
--- a/frontend/src/pages/AccordionPage.test.tsx
+++ b/frontend/src/pages/AccordionPage.test.tsx
@@ -225,6 +225,28 @@ describe('AccordionPage', () => {
     expect(screen.getByRole('button', { name: /0:/ }).dataset.hoverTarget).toBe('false');
   });
 
+  it('selecting a pile persistently highlights its legal merge targets without hover (touch parity)', async () => {
+    // pile 3 (SPADE 9) can merge onto pile 0 (SPADE 7) at offset 3 (suit match).
+    mockExec.mockResolvedValue({
+      ...playingState,
+      piles: [
+        { cards: [card('SPADE', 7)], size: 1 },
+        { cards: [card('HEART', 2)], size: 1 },
+        { cards: [card('CLOVER', 3)], size: 1 },
+        { cards: [card('SPADE', 9)], size: 1 },
+      ],
+    });
+    renderWithProviders(<AccordionPage />);
+    const pile3 = await screen.findByRole('button', { name: /^3:/ });
+    // Select via click only — no mouseEnter, mimicking a touch device.
+    fireEvent.click(pile3);
+    const pile0 = screen.getByRole('button', { name: /^0:/ });
+    await waitFor(() => expect(pile0.dataset.legalTarget).toBe('true'));
+    expect(pile0.className).toContain('ring-ds-success');
+    // Adjacent pile (index 2, CLOVER 3) shares neither suit nor rank with SPADE 9.
+    expect(screen.getByRole('button', { name: /^2:/ }).dataset.legalTarget).toBe('false');
+  });
+
   it('shows error alert when API fails on mount', async () => {
     mockExec.mockRejectedValue(new Error('network error'));
     renderWithProviders(<AccordionPage />);

--- a/frontend/src/pages/AccordionPage.tsx
+++ b/frontend/src/pages/AccordionPage.tsx
@@ -341,12 +341,20 @@ function AccordionPageContent() {
               {(() => {
                 const hoverTargets =
                   isPlaying && hoveredIdx !== null ? new Set(accordionLegalTargets(state.piles, hoveredIdx)) : null;
+                // Touch devices never fire mouseenter, so also paint the selected
+                // pile's legal -1/-3 targets persistently once it is picked (#3190).
+                const selectedTargets =
+                  isPlaying && selectedIdx !== null ? new Set(accordionLegalTargets(state.piles, selectedIdx)) : null;
                 return state.piles.map((pile, idx) => {
                   const top = pile.cards[0];
                   const isSelected = selectedIdx === idx;
                   const hintFrom = state.hint?.fromIdx === idx;
                   const hintTo = state.hint?.toIdx === idx;
                   const isHoverTarget = hoverTargets?.has(idx) ?? false;
+                  const isSelectedTarget = selectedTargets?.has(idx) ?? false;
+                  // Highlight legal targets whether reached by hover (mouse) or by
+                  // selecting a source pile (touch/keyboard) so all inputs get parity.
+                  const isLegalTarget = isHoverTarget || isSelectedTarget;
                   // When a pile is selected, spell out its legal merge offsets (1/3)
                   // in the aria-label so screen-reader users learn where it can go (#2596).
                   const mergeSuffix =
@@ -371,7 +379,7 @@ function AccordionPageContent() {
                         isSelected ? 'ring-2 ring-ds-warning -translate-y-1' : ''
                       } ${hintFrom ? 'ring-2 ring-ds-info animate-pulse' : ''} ${
                         hintTo ? 'ring-2 ring-ds-success animate-pulse' : ''
-                      } ${isHoverTarget && !isSelected && !hintTo && !hintFrom ? 'ring-2 ring-ds-success' : ''}`}
+                      } ${isLegalTarget && !isSelected && !hintTo && !hintFrom ? 'ring-2 ring-ds-success' : ''}`}
                       onClick={() => handlePileClick(idx)}
                       onMouseEnter={isPlaying ? () => setHoveredIdx(idx) : undefined}
                       onMouseLeave={() => setHoveredIdx((cur) => (cur === idx ? null : cur))}
@@ -379,6 +387,7 @@ function AccordionPageContent() {
                       onBlur={() => setHoveredIdx((cur) => (cur === idx ? null : cur))}
                       disabled={!isPlaying}
                       data-hover-target={isHoverTarget ? 'true' : 'false'}
+                      data-legal-target={isLegalTarget ? 'true' : 'false'}
                       aria-label={`${baseLabel}${mergeSuffix}`}
                     >
                       {top && <AnimatedCard card={top} width={cardWidth} />}


### PR DESCRIPTION
## 概要

アコーディオンの合法な統合先ハイライト（`ring-2 ring-ds-success`）はこれまで `hoveredIdx`（`onMouseEnter`/`onFocus`）にのみ依存していたため、`mouseenter` が発火しないタッチ端末では合法な統合先を視覚的に確認できなかった。

選択済みの山（`selectedIdx`）からも `accordionLegalTargets` を導出し、`hoveredIdx` とは独立に合法統合先を常時ハイライトするようにした。これによりマウス・タッチ・キーボードの入力手段で挙動が揃う。

## 変更点

- `AccordionPage.tsx`: `selectedTargets`（`selectedIdx` 由来）を追加し、`isLegalTarget = isHoverTarget || isSelectedTarget` でリング表示を判定。デバッグ/テスト用に `data-legal-target` 属性を追加。
- `AccordionPage.test.tsx`: hover を発火させずに山を選択したとき合法統合先がリング表示されることを検証するテストを追加。

## 受け入れ条件

- [x] 山を選択した時点でタッチ端末でも合法な統合先が常時ハイライトされる
- [x] 既存のホバーによるハイライトの挙動は維持する（`data-hover-target` と hover テストは不変）
- [x] `AccordionPage.test.tsx` に選択時のハイライトを検証するテストを追加

## テスト

- `bun run test -- --run AccordionPage`: 41 passed
- `bun run build`: 成功
- `biome check`: クリーン

Closes #3190