### PR TITLE
feat(tressette): add card-point legend panel

### DIFF
--- a/frontend/src/i18n/locales/en/tressette.json
+++ b/frontend/src/i18n/locales/en/tressette.json
@@ -53,5 +53,19 @@
     "followDuck": "Cannot/should not win, so duck",
     "givePartner": "Partner is winning, so give them point cards",
     "discardLow": "Cannot follow, so discard a low card"
+  },
+  "pointLegend": {
+    "title": "Card Points",
+    "cardCol": "Card",
+    "pointCol": "Points",
+    "ace": "A (Ace)",
+    "aceValue": "1 pt",
+    "figures": "K / Q / J / 2 / 3",
+    "figuresValue": "1/3 pt",
+    "others": "Others (4-7, 10)",
+    "othersValue": "0 pt",
+    "lastTrick": "Last trick (ultima)",
+    "lastTrickValue": "+1/3 pt",
+    "note": "Each round totals 11 points. First team to reach the target (default 21) wins."
   }
 }

--- a/frontend/src/i18n/locales/ja/tressette.json
+++ b/frontend/src/i18n/locales/ja/tressette.json
@@ -53,5 +53,19 @@
     "followDuck": "取れない／取る価値がないのでダック推奨",
     "givePartner": "味方が勝っているので得点札を渡す",
     "discardLow": "フォローできないので低い札を捨てる"
+  },
+  "pointLegend": {
+    "title": "点数の凡例",
+    "cardCol": "カード",
+    "pointCol": "点数",
+    "ace": "A（エース）",
+    "aceValue": "1点",
+    "figures": "K・Q・J・2・3",
+    "figuresValue": "1/3点",
+    "others": "その他（4〜7・10）",
+    "othersValue": "0点",
+    "lastTrick": "最終トリック（ラスト取り）",
+    "lastTrickValue": "+1/3点",
+    "note": "1ラウンドの合計は11点。先に目標点（既定21点）へ達したチームの勝ち。"
   }
 }

--- a/frontend/src/pages/TressettePage.test.tsx
+++ b/frontend/src/pages/TressettePage.test.tsx
@@ -111,4 +111,17 @@ describe('TressettePage', () => {
     const team1 = screen.getByTestId('tr-thirds-1');
     expect(team1.querySelectorAll('.bg-ds-accent')).toHaveLength(0);
   });
+
+  it('renders a collapsible card-point legend with the scoring values', async () => {
+    mockExec.mockResolvedValue(makeTressetteState());
+    renderWithProviders(<TressettePage />);
+
+    const legend = await screen.findByTestId('tr-point-legend');
+    // Summary is always present; the point values render inside the details.
+    expect(legend).toHaveTextContent('点数の凡例');
+    expect(legend).toHaveTextContent('1点');
+    expect(legend).toHaveTextContent('1/3点');
+    expect(legend).toHaveTextContent('+1/3点');
+    expect(legend).toHaveTextContent('0点');
+  });
 });

--- a/frontend/src/pages/TressettePage.tsx
+++ b/frontend/src/pages/TressettePage.tsx
@@ -319,6 +319,46 @@ function TressettePageContent() {
                     </tbody>
                   </table>
                 </div>
+
+                {/* Card-point legend (static reference) */}
+                <details className="my-3 p-2 rounded bg-black/30" data-testid="tr-point-legend">
+                  <summary className="cursor-pointer select-none text-ds-text-muted text-sm">
+                    {t('pointLegend.title')}
+                  </summary>
+                  <div className="mt-1 text-ds-text-muted text-xs">
+                    <table className="w-full">
+                      <thead>
+                        <tr>
+                          <th scope="col" className="text-left font-normal">
+                            {t('pointLegend.cardCol')}
+                          </th>
+                          <th scope="col" className="text-right font-normal">
+                            {t('pointLegend.pointCol')}
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr>
+                          <td>{t('pointLegend.ace')}</td>
+                          <td className="text-right">{t('pointLegend.aceValue')}</td>
+                        </tr>
+                        <tr>
+                          <td>{t('pointLegend.figures')}</td>
+                          <td className="text-right">{t('pointLegend.figuresValue')}</td>
+                        </tr>
+                        <tr>
+                          <td>{t('pointLegend.others')}</td>
+                          <td className="text-right">{t('pointLegend.othersValue')}</td>
+                        </tr>
+                        <tr>
+                          <td>{t('pointLegend.lastTrick')}</td>
+                          <td className="text-right">{t('pointLegend.lastTrickValue')}</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <div className="mt-1">{t('pointLegend.note')}</div>
+                  </div>
+                </details>
               </div>
             </div>
 


### PR DESCRIPTION
## 概要
トレセッテのスコアテーブル (`tr-score-table`) 付近に、カード点数を説明する折りたたみ式 (`<details>`) の点数凡例パネルを追加しました。Web には従来 CUI の `tressette.thirdsRule` に相当する説明がなかったため、初見でも得点体系が分かるようにします。

点数は Go ドメイン (`internal/domain/Tressette.go` の `tressetteThirds`) と一致することを確認済み:

| カード | 点数 |
|--------|------|
| A（エース） | 1点 |
| K・Q・J・2・3 | 1/3点 |
| その他（4〜7・10） | 0点 |
| 最終トリック（ラスト取り） | +1/3点 |

1ラウンド合計 11点、目標点（既定21点）先取で勝利。

静的な凡例のみでルールは再実装していません。バックエンド変更なし・純粋な追加。

## 受け入れ条件
- [x] スコアテーブル近くに点数凡例が折りたたみで表示される (`data-testid="tr-point-legend"`)
- [x] 凡例は ja / en で翻訳される (`pointLegend.*` を両ロケールにキー同期で追加)
- [x] モバイル（isMobile）でも閲覧できる（スコアテーブルと同じコンテナ内に配置）
- [x] `TressettePage.test.tsx` に凡例表示テスト追加

## テスト
- `bunx biome check --write`：パス
- `bun run test -- --run TressettePage`：10 passed（新規: `renders a collapsible card-point legend with the scoring values`）
- `bun run build`（tsc）：パス

Closes #3385