### PR TITLE
feat(blackhole): show acceptable ranks next to the hole

### DIFF
--- a/frontend/src/i18n/locales/en/blackhole.json
+++ b/frontend/src/i18n/locales/en/blackhole.json
@@ -29,5 +29,8 @@
   "holeEmptyAria": "Black hole: empty",
   "hintPlayable": "playable",
   "hintLegalFans": "Playable: {{list}}",
-  "hintNoLegal": "No playable card"
+  "hintNoLegal": "No playable card",
+  "acceptableRanks": "Playable ranks: {{ranks}}",
+  "acceptableRanksNone": "Playable ranks: none",
+  "legalMoveCount": "Legal moves: {{count}}"
 }

--- a/frontend/src/i18n/locales/ja/blackhole.json
+++ b/frontend/src/i18n/locales/ja/blackhole.json
@@ -29,5 +29,8 @@
   "holeEmptyAria": "ブラックホール: 空",
   "hintPlayable": "置けます",
   "hintLegalFans": "置けるカード: {{list}}",
-  "hintNoLegal": "置けるカードがありません"
+  "hintNoLegal": "置けるカードがありません",
+  "acceptableRanks": "受け入れ可能: {{ranks}}",
+  "acceptableRanksNone": "受け入れ可能: なし",
+  "legalMoveCount": "合法手: {{count}}"
 }

--- a/frontend/src/pages/BlackHolePage.test.tsx
+++ b/frontend/src/pages/BlackHolePage.test.tsx
@@ -132,6 +132,41 @@ describe('BlackHolePage', () => {
     await waitFor(() => expect(screen.getByTestId('card-0-1')).not.toHaveAttribute('data-hinted-legal'));
   });
 
+  it('always shows the acceptable ranks (hole top ±1) and the legal-move count', async () => {
+    // Hole top 7 → accepts 6 and 8. fan0 top ♣6 is legal, fan1 top ♦10 is not.
+    mockExec.mockResolvedValue(makeState({ blackHole: [card('SPADE', 7)] }));
+    renderWithProviders(<BlackHolePage />);
+    const readout = await screen.findByTestId('bh-acceptable');
+    expect(readout).toHaveTextContent('受け入れ可能: 6 / 8');
+    const count = screen.getByTestId('bh-legal-count');
+    expect(count).toHaveTextContent('合法手: 1');
+    expect(count.className).toContain('text-ds-text-muted');
+  });
+
+  it('shows only one side of the acceptable ranks at the A and K ends', async () => {
+    // Hole top A(1): no wrap, so only rank 2 is acceptable.
+    mockExec.mockResolvedValue(makeState({ blackHole: [card('SPADE', 1)] }));
+    const { unmount } = renderWithProviders(<BlackHolePage />);
+    expect(await screen.findByTestId('bh-acceptable')).toHaveTextContent('受け入れ可能: 2');
+    unmount();
+
+    // Hole top K(13): only rank Q(12) is acceptable.
+    mockExec.mockResolvedValue(makeState({ blackHole: [card('SPADE', 13)] }));
+    renderWithProviders(<BlackHolePage />);
+    expect(await screen.findByTestId('bh-acceptable')).toHaveTextContent('受け入れ可能: Q');
+  });
+
+  it('marks the legal-move count with a warning colour when no move remains', async () => {
+    // Hole top 7, but neither fan top is ±1 (fan0 ♣6 replaced by ♦Q, fan1 ♦10).
+    const stuck = makeState({ blackHole: [card('SPADE', 7)] });
+    stuck.fans[0] = [card('DIAMOND', 12)];
+    mockExec.mockResolvedValue(stuck);
+    renderWithProviders(<BlackHolePage />);
+    const count = await screen.findByTestId('bh-legal-count');
+    expect(count).toHaveTextContent('合法手: 0');
+    expect(count.className).toContain('text-ds-warning');
+  });
+
   it('does not ring an A-K wrap (no wrap in Black Hole)', async () => {
     // Hole top A(1): only rank 2 is adjacent — K(13) must NOT highlight.
     const wrap = makeState({ blackHole: [card('SPADE', 1)] });

--- a/frontend/src/pages/BlackHolePage.tsx
+++ b/frontend/src/pages/BlackHolePage.tsx
@@ -18,6 +18,7 @@ import { gameTheme } from '../styles/gameTheme';
 import { BlackHolePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { valueName } from '../utils/cardUtils';
 
 /** Black Hole tutorial step definitions. */
 const BH_TUTORIAL_STEPS: TutorialStep[] = [
@@ -116,6 +117,11 @@ function BlackHolePageContent() {
       : [],
   );
 
+  // Ranks currently accepted by the hole: the hole top's rank ±1, clamped to
+  // [1, 13] with no A↔K wrap (matching the Go domain's blackHoleAdjacent). At the
+  // A/K ends only one neighbour survives the clamp, so a single rank is shown.
+  const acceptableRanks = holeTop ? [holeTop.value - 1, holeTop.value + 1].filter((v) => v >= 1 && v <= 13) : [];
+
   // Spoken hint result: list the playable fan-top cards (or "none"), shown only
   // while the visual highlight is active.
   const hintAnnounce = !showLegalHint
@@ -206,6 +212,21 @@ function BlackHolePageContent() {
             {holeTop ? <CardImage card={holeTop} width={w} /> : null}
           </div>
           <div className="text-ds-text-muted text-xs">{t('moveCount', { count: state.moveCount })}</div>
+          {/* Always-on readout of which rank(s) the hole accepts next, plus the
+              current legal-move count (warning colour when no move remains). */}
+          <div className="flex flex-col gap-0.5 text-xs" data-testid="bh-acceptable">
+            <span className="text-ds-text-primary">
+              {acceptableRanks.length > 0
+                ? t('acceptableRanks', { ranks: acceptableRanks.map(valueName).join(' / ') })
+                : t('acceptableRanksNone')}
+            </span>
+            <span
+              className={legalFans.size === 0 ? 'text-ds-warning' : 'text-ds-text-muted'}
+              data-testid="bh-legal-count"
+            >
+              {t('legalMoveCount', { count: legalFans.size })}
+            </span>
+          </div>
         </div>
 
         {/* Hint result also spoken (colour/animation is not enough). */}


### PR DESCRIPTION
## 概要

ブラックホールの隣に、次に受け入れ可能なランクを常時表示します。従来はヒントボタン押下時の4秒間ハイライトでしか合法手が分からず、毎手番プレイヤーが holeTop±1 を暗算して17扇を目視走査する必要がありました。

- ホール横に「受け入れ可能: 6 / 8」のように holeTop±1 のランクラベルを常時表示
- A/K の端では clamp により片側のみ表示（A→2、K→Q）。**A↔K ラップなし**で Go ドメイン `blackHoleAdjacent`（`diff == 1`）と一致
- 合法手数（`legalFans.size`）を併記し、0件で `text-ds-warning` の警告色に切り替え
- ヒントボタンの挙動は不変（純粋に追加のみ・操作をブロックしない）

## 隣接ルールの確認

`internal/domain/BlackHole.go` の `blackHoleAdjacent` は `|a.value - b.value| == 1`（スート不問・K-A ラップなし）。フロントの `acceptableRanks = [top-1, top+1].filter(1..13)` はこれと厳密に一致します。

## テスト

`frontend/src/pages/BlackHolePage.test.tsx` に3ケース追加:
- 受け入れ可能ランク（6 / 8）と合法手数（1・muted色）の常時表示
- A端（→2）/ K端（→Q）で片側のみ表示
- 合法手0件で警告色 `text-ds-warning`

## ゲート

- `bunx biome check --write` ✅
- `bun run test -- --run BlackHolePage` ✅ (14 passed)
- `bun run build` (tsc) ✅

## 受け入れ条件

- [x] 受け入れ可能ランクがホール横に常時表示される
- [x] A/K の端ランクで片側のみ正しく表示される
- [x] 合法手数が表示され0件で警告色になる
- [x] `BlackHolePage.test.tsx` に表示ロジックのテストを追加

Closes #3586

🤖 Generated with [Claude Code](https://claude.com/claude-code)