### PR TITLE
feat(gofish): show each CPU's completed book ranks

### DIFF
--- a/frontend/src/components/gofish/GoFishPlayerArea.test.tsx
+++ b/frontend/src/components/gofish/GoFishPlayerArea.test.tsx
@@ -135,4 +135,26 @@ describe('GoFishPlayerArea', () => {
     expect(queen).not.toHaveAttribute('data-matched');
     expect(queen?.className).not.toContain('bg-ds-warning');
   });
+
+  it('omits the book-ranks chip row when the player has no completed books', () => {
+    renderWithProviders(<GoFishPlayerArea player={cpuPlayer} isSelected={false} onSelect={vi.fn()} disabled={false} />);
+    expect(screen.queryByTestId('book-ranks-1')).not.toBeInTheDocument();
+  });
+
+  it("renders each of a CPU's completed book ranks with the localized rank label", () => {
+    const withBooks: GoFishPlayerData = {
+      ...cpuPlayer,
+      books: [
+        { rank: 1, cards: [] },
+        { rank: 13, cards: [] },
+      ],
+    };
+    renderWithProviders(<GoFishPlayerArea player={withBooks} isSelected={false} onSelect={vi.fn()} disabled={false} />);
+    const row = screen.getByTestId('book-ranks-1');
+    const chips = row.querySelectorAll('[data-rank]');
+    expect(chips).toHaveLength(2);
+    // valueName(1) → 'A', valueName(13) → 'K'
+    expect(row.textContent).toContain('A');
+    expect(row.textContent).toContain('K');
+  });
 });

--- a/frontend/src/components/gofish/GoFishPlayerArea.tsx
+++ b/frontend/src/components/gofish/GoFishPlayerArea.tsx
@@ -98,6 +98,24 @@ export function GoFishPlayerArea({
             })}
           </div>
         )}
+        {player.books.length > 0 && (
+          <div
+            data-testid={`book-ranks-${player.id}`}
+            className="mt-1 text-xs text-ds-text-muted flex flex-wrap gap-1 items-center"
+          >
+            <span aria-hidden="true">📚</span>
+            <span className="sr-only">{t('bookRanksLabel')}</span>
+            {player.books.map((book) => (
+              <span
+                key={book.rank}
+                data-rank={book.rank}
+                className="px-1.5 py-0.5 rounded font-medium bg-ds-success/50 text-white"
+              >
+                {valueName(book.rank)}
+              </span>
+            ))}
+          </div>
+        )}
       </button>
     </div>
   );

--- a/frontend/src/i18n/locales/en/gofish.json
+++ b/frontend/src/i18n/locales/en/gofish.json
@@ -33,6 +33,7 @@
   "deck": "Deck: {{count}} cards",
   "books": "Books: {{count}}",
   "knownRanksLabel": "Ranks they asked for",
+  "bookRanksLabel": "Completed book ranks",
   "tutorial": {
     "cpuArea": "Opponent's card count and books. Click to select them as your target.",
     "playerHand": "Your hand. Click a card to select the rank you want to ask for.",

--- a/frontend/src/i18n/locales/ja/gofish.json
+++ b/frontend/src/i18n/locales/ja/gofish.json
@@ -33,6 +33,7 @@
   "deck": "山札: {{count}}枚",
   "books": "ブック: {{count}}",
   "knownRanksLabel": "既知の要求済みランク",
+  "bookRanksLabel": "完成したブックのランク",
   "tutorial": {
     "cpuArea": "相手プレイヤーのカード枚数とブックです。クリックして要求先を選択します。",
     "playerHand": "あなたの手札です。カードをクリックして要求するランクを選択します。",


### PR DESCRIPTION
## 概要
ゴーフィッシュで各 CPU が完成させたブック（4枚組）のランクを、`GoFishPlayerArea` にバッジ表示します。これまで人間のブックのみ `GoFishBooksDisplay` で可視化され、CPU の完成ブックは `ActionLogSection` を遡らないと分かりませんでした。どのランクが場から消えたかは質問戦略の前提情報になるため、常時可視化します。

## 変更内容
- `GoFishPlayerArea` に `player.books` のランクを 📚 アイコン付きのチップ行として描画（`data-testid="book-ranks-{id}"`）
- ランク表記は既存の `valueName` を再利用（A/J/Q/K 表記）
- サーバは全プレイヤーの `books` を送出済みのため表示のみの追加変更（インタラクションを阻害しない純加算）
- i18n: `bookRanksLabel` を ja/en 両方に key-for-key で追加（sr-only ラベル用）
- `GoFishPlayerArea.test.tsx` にブック表示のテストを追加（空時に非表示 / 完成ランクを localized ラベルで描画）

## 受け入れ条件
- [x] 各 CPU の完成ブックのランクが常時表示される
- [x] ブック完成時に表示が即時更新される（`player.books` は毎レスポンスで更新）
- [x] ランク表示は `valueName` で A/J/Q/K 表記になる
- [x] `GoFishPlayerArea` のコンポーネントテストを更新

## テスト
- `bun run test -- --run GoFishPlayerArea` → 13 passed
- `bun run build` (tsc) → 成功
- `biome check` → クリーン

Closes #3106