### PR TITLE
feat(pyramid): ring exposed kings as removable-alone

### DIFF
--- a/frontend/src/i18n/locales/en/pyramid.json
+++ b/frontend/src/i18n/locales/en/pyramid.json
@@ -43,6 +43,7 @@
   "a11y": {
     "blocked": "(blocked)",
     "selected": "(selected)",
-    "pairCandidate": "(pairs to 13)"
+    "pairCandidate": "(pairs to 13)",
+    "kingRemovable": "(K, removable alone)"
   }
 }

--- a/frontend/src/i18n/locales/ja/pyramid.json
+++ b/frontend/src/i18n/locales/ja/pyramid.json
@@ -43,6 +43,7 @@
   "a11y": {
     "blocked": "（ブロック中）",
     "selected": "（選択中）",
-    "pairCandidate": "（合計13の相手）"
+    "pairCandidate": "（合計13の相手）",
+    "kingRemovable": "（単独除去可能なK）"
   }
 }

--- a/frontend/src/pages/PyramidPage.test.tsx
+++ b/frontend/src/pages/PyramidPage.test.tsx
@@ -102,7 +102,7 @@ describe('PyramidPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
     await waitFor(() => expect(screen.getByLabelText('♦ 3')).toHaveClass('ring-ds-warning'));
     expect(screen.getByLabelText('♠ 10')).toHaveClass('ring-ds-warning');
-    expect(screen.getByLabelText('♥ K')).not.toHaveClass('ring-ds-warning');
+    expect(screen.getByLabelText(/♥ K/)).not.toHaveClass('ring-ds-warning');
   });
 
   it('shows only the hint ring when a card is both hinted and a pair candidate', async () => {
@@ -123,15 +123,15 @@ describe('PyramidPage', () => {
 
   it('rings the king cell for a king hint and clears it on the next card click', async () => {
     renderWithProviders(<PyramidPage />);
-    await waitFor(() => expect(screen.getByLabelText('♥ K')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByLabelText(/♥ K/)).toBeInTheDocument());
 
     mockExec.mockResolvedValueOnce({ ...playingState, hint: { type: 'king', row1: 2, col1: 2, row2: -1, col2: -1 } });
     fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
-    await waitFor(() => expect(screen.getByLabelText('♥ K')).toHaveClass('ring-ds-warning'));
+    await waitFor(() => expect(screen.getByLabelText(/♥ K/)).toHaveClass('ring-ds-warning'));
 
     // Any card interaction clears the hint highlight.
     fireEvent.click(screen.getByLabelText('♦ 3'));
-    await waitFor(() => expect(screen.getByLabelText('♥ K')).not.toHaveClass('ring-ds-warning'));
+    await waitFor(() => expect(screen.getByLabelText(/♥ K/)).not.toHaveClass('ring-ds-warning'));
   });
 
   it('renders skeleton when no state', () => {
@@ -321,6 +321,38 @@ describe('PyramidPage', () => {
     );
     // No pair-candidate attribute should appear anywhere because partnerValue stays null for Kings.
     expect(document.querySelectorAll('[data-pair-candidate="true"]')).toHaveLength(0);
+  });
+
+  it('marks an exposed King as removable-alone with a success ring and aria hint', async () => {
+    renderWithProviders(<PyramidPage />);
+    await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
+    // ♥ K is exposed in row 2 → flagged as removable alone.
+    const kingButton = screen.getByAltText('♥ K').closest('button') as HTMLButtonElement;
+    expect(kingButton).toHaveAttribute('data-king-removable', 'true');
+    expect(kingButton.className).toContain('ring-ds-success');
+    // The always-on King ring must not reuse the pulsing pair-candidate style.
+    expect(kingButton.className).not.toContain('animate-pulse');
+    expect(kingButton).toHaveAttribute('aria-label', '♥ K （単独除去可能なK）');
+  });
+
+  it('does not mark a covered King or a non-King exposed card as removable-alone', async () => {
+    renderWithProviders(<PyramidPage />);
+    await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
+    // ♠ K in row 0 is covered (exposed:false) → no marker.
+    const coveredKing = screen.getByAltText('♠ K').closest('button') as HTMLButtonElement;
+    expect(coveredKing).not.toHaveAttribute('data-king-removable');
+    // ♦ 3 is exposed but not a King → no marker.
+    const nonKing = screen.getByAltText('♦ 3').closest('button') as HTMLButtonElement;
+    expect(nonKing).not.toHaveAttribute('data-king-removable');
+  });
+
+  it('marks a King on top of the waste as removable-alone', async () => {
+    mockExec.mockResolvedValue({ ...playingState, waste: [card('SPADE', 13)] });
+    renderWithProviders(<PyramidPage />);
+    await waitFor(() => expect(screen.getByText('ウェイスト')).toBeInTheDocument());
+    const wasteButton = screen.getByRole('button', { name: '♠ K （単独除去可能なK）' });
+    expect(wasteButton).toHaveAttribute('data-king-removable', 'true');
+    expect(wasteButton.className).toContain('ring-ds-success');
   });
 
   it('clicking same card twice deselects it', async () => {

--- a/frontend/src/pages/PyramidPage.tsx
+++ b/frontend/src/pages/PyramidPage.tsx
@@ -180,6 +180,8 @@ function PyramidPageContent() {
   const wasteTopCard = state.waste.length > 0 ? state.waste[state.waste.length - 1] : null;
   const isWastePairCandidate =
     partnerValue !== null && !isSelected('waste') && wasteTopCard !== null && wasteTopCard.value === partnerValue;
+  // The waste top is always exposed; a King there is removable alone (issue #3082).
+  const isWasteExposedKing = wasteTopCard !== null && wasteTopCard.value === 13 && !isSelected('waste');
 
   // Calculate pyramid layout dimensions
   const maxCols = 7; // bottom row has 7 cards
@@ -260,6 +262,10 @@ function PyramidPageContent() {
                         exposed &&
                         pc.card.value === partnerValue &&
                         !isSelected('pyramid', rowIdx, colIdx);
+                      // A King (13) is removable alone once exposed — surface that
+                      // affordance so players don't hunt for a nonexistent partner
+                      // (issue #3082). Selected/hint states take visual precedence.
+                      const isExposedKing = exposed && pc.card.value === 13 && !isSelected('pyramid', rowIdx, colIdx);
                       // Server hint targets (-1 sentinels for king/waste never match a cell).
                       const isHintTarget =
                         !!hint &&
@@ -274,7 +280,9 @@ function PyramidPageContent() {
                           ? ` ${t('a11y.selected')}`
                           : isPairCandidate
                             ? ` ${t('a11y.pairCandidate')}`
-                            : '';
+                            : isExposedKing
+                              ? ` ${t('a11y.kingRemovable')}`
+                              : '';
                       return (
                         <div key={`pc-${rowIdx.toString()}-${colIdx.toString()}`} className="absolute" style={{ left }}>
                           <button
@@ -287,6 +295,7 @@ function PyramidPageContent() {
                             aria-label={`${cardAlt(pc.card)}${statusSuffix}`}
                             aria-pressed={cellSelected}
                             data-pair-candidate={isPairCandidate ? 'true' : undefined}
+                            data-king-removable={isExposedKing ? 'true' : undefined}
                             className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${
                               isSelected('pyramid', rowIdx, colIdx)
                                 ? 'ring-2 ring-ds-warning'
@@ -294,7 +303,9 @@ function PyramidPageContent() {
                                   ? 'ring-2 ring-ds-warning animate-pulse'
                                   : isPairCandidate
                                     ? 'ring-2 ring-ds-success animate-pulse'
-                                    : ''
+                                    : isExposedKing
+                                      ? 'ring-2 ring-ds-success'
+                                      : ''
                             } ${!exposed ? 'opacity-60' : ''}`}
                           >
                             <AnimatedCard card={pc.card} width={effectiveCardWidth} />
@@ -338,12 +349,13 @@ function PyramidPageContent() {
                     type="button"
                     onClick={() => handleSelectCard({ zone: 'waste' }, wasteTopCard.value)}
                     disabled={!isPlaying || loading}
-                    aria-label={cardAlt(wasteTopCard)}
+                    aria-label={`${cardAlt(wasteTopCard)}${isWasteExposedKing ? ` ${t('a11y.kingRemovable')}` : ''}`}
                     aria-pressed={isSelected('waste')}
                     data-pair-candidate={isWastePairCandidate ? 'true' : undefined}
+                    data-king-removable={isWasteExposedKing ? 'true' : undefined}
                     className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${
                       isSelected('waste') ? 'ring-2 ring-ds-warning' : ''
-                    } ${isWastePairCandidate ? 'ring-2 ring-ds-success animate-pulse' : ''}`}
+                    } ${isWastePairCandidate ? 'ring-2 ring-ds-success animate-pulse' : isWasteExposedKing ? 'ring-2 ring-ds-success' : ''}`}
                   >
                     <AnimatedCard card={wasteTopCard} width={effectiveCardWidth} />
                   </button>


### PR DESCRIPTION
## 概要
ピラミッド・ソリティアで、露出した K（値13）は単独で除去できるが、UI 上は何のアフォーダンスもなかった（ペア候補リングは `selectedValue < 13` でガードされ K を対象外）。露出中の K（ピラミッド・waste 双方）に常時サクセスリング（`ring-2 ring-ds-success`）と aria ヒントを付与し、初心者が存在しないペア相手を探して迷わないようにする。クリックはブロックしない（表示のみ）。

ドメイン `RemoveKing` / `RemoveWasteKing`（`internal/domain/Pyramid.go`）が「露出中かつ値13の K を単独除去」を明確にサポートしていることを確認済み。

## 変更点
- `PyramidPage.tsx`: 露出 K に `isExposedKing` / `isWasteExposedKing` を算出し、`ring-2 ring-ds-success`（pulse なし、pair 候補と視覚区別）と `data-king-removable` 属性、`a11y.kingRemovable` aria サフィックスを付与。選択中・ヒント対象は従来どおり優先。
- `pyramid.json`（ja/en）: `a11y.kingRemovable` キーを追加。
- `PyramidPage.test.tsx`: K マーカーの出現条件テストを追加。

## 受け入れ条件
- [x] 露出中の K（ピラミッド・waste 双方）に視覚マーカーが付く
- [x] 覆われている K には付かない
- [x] 既存のペア候補リング・ヒントリングと視覚衝突しない（K リングは pulse なし・優先度は selected > hint > pair > king）
- [x] ページテストで K マーカーの出現条件を検証

## テスト
- `bun run test -- --run PyramidPage` … 55 passed（新規3件含む）
- `bun run build`（tsc）… 成功
- `bunx biome check` … クリーン

Closes #3082