### PR TITLE
feat(tute): show declared marriage suits in the info sidebar

### DIFF
--- a/frontend/src/i18n/locales/en/tute.json
+++ b/frontend/src/i18n/locales/en/tute.json
@@ -47,6 +47,12 @@
     "teamA": "Team A points: {{points}}",
     "teamB": "Team B points: {{points}}"
   },
+  "declaredMarriages": {
+    "title": "Declared marriages",
+    "declared": "Declared",
+    "undeclared": "Not declared",
+    "trumpNote": "Trump suit scores +40"
+  },
   "hintAvailable": "Hint",
   "hint": {
     "lead_low": "Lead a low card to preserve strength",

--- a/frontend/src/i18n/locales/ja/tute.json
+++ b/frontend/src/i18n/locales/ja/tute.json
@@ -47,6 +47,12 @@
     "teamA": "チームAの獲得点: {{points}}",
     "teamB": "チームBの獲得点: {{points}}"
   },
+  "declaredMarriages": {
+    "title": "宣言済みマリッジ",
+    "declared": "宣言済",
+    "undeclared": "未宣言",
+    "trumpNote": "切り札スートは +40 点"
+  },
   "hintAvailable": "ヒント",
   "hint": {
     "lead_low": "低い札でリードして温存することを推奨",

--- a/frontend/src/pages/TutePage.test.tsx
+++ b/frontend/src/pages/TutePage.test.tsx
@@ -32,6 +32,7 @@ const gameEndState = makeTuteState({
 const cpuTurnState = makeTuteState({ currentPlayerIdx: 1 });
 
 beforeEach(() => {
+  localStorage.clear();
   mockExec.mockReset();
   mockExec.mockResolvedValue(playPhaseState);
 });
@@ -132,6 +133,18 @@ describe('TutePage', () => {
     mockExec.mockResolvedValue(gameEndState);
     renderWithProviders(<TutePage />);
     await waitFor(() => expect(screen.getByText('ゲーム終了！ あなたのチームの勝ち！')).toBeInTheDocument());
+  });
+
+  it('shows the declared-marriage readout reflecting declaredSuits', async () => {
+    // Club (suit 2) declared; the other three suits remain undeclared.
+    mockExec.mockResolvedValue(makeTuteState({ declaredSuits: [false, false, true, false, false] }));
+    renderWithProviders(<TutePage />);
+    const panel = await screen.findByTestId('tute-declared-marriages');
+    expect(panel).toHaveTextContent('宣言済みマリッジ');
+    // One suit declared, three not declared.
+    expect(screen.getAllByText('宣言済')).toHaveLength(1);
+    expect(screen.getAllByText('未宣言')).toHaveLength(3);
+    expect(panel).toHaveTextContent('切り札スートは +40 点');
   });
 
   it('does not show the play button on a CPU turn', async () => {

--- a/frontend/src/pages/TutePage.tsx
+++ b/frontend/src/pages/TutePage.tsx
@@ -231,6 +231,27 @@ function TutePageContent() {
                   </div>
                 </div>
 
+                {/* Declared marriage suits (persistent readout of state.declaredSuits) */}
+                <div
+                  className="mb-2 p-2 rounded bg-black/30 text-ds-text-muted text-sm"
+                  data-testid="tute-declared-marriages"
+                >
+                  <div className="mb-1 text-ds-text-primary">{t('declaredMarriages.title')}</div>
+                  {([1, 2, 3, 4] as const).map((suit) => {
+                    const declared = state.declaredSuits[suit] ?? false;
+                    return (
+                      <div key={suit} className="py-0.5">
+                        <span className="mr-1">{SUIT_SYMBOLS[suit]}</span>
+                        {suit === state.trumpSuit && <span className="mr-1 text-ds-warning">★</span>}
+                        <span className={declared ? 'text-ds-text-primary' : ''}>
+                          {declared ? t('declaredMarriages.declared') : t('declaredMarriages.undeclared')}
+                        </span>
+                      </div>
+                    );
+                  })}
+                  <div className="mt-1 text-xs">{t('declaredMarriages.trumpNote')}</div>
+                </div>
+
                 {/* Players: cards / tricks */}
                 {isMobile ? (
                   <details className="mb-2 p-2 rounded bg-black/30">


### PR DESCRIPTION
## 概要
トゥーテ (`tute`) の情報サイドバー（`data-tutorial="tute-info"`、チームスコアパネルの下）に「宣言済みマリッジ」欄を常時表示する。`state.declaredSuits` を走査し、各スートのシンボルと宣言状態（宣言済 / 未宣言）を一覧し、切り札スートには ★ を付けて「切り札スートは +40 点」と併記する。

これにより、宣言済みスートのマリッジボタンが非表示になる理由がプレイヤーに伝わり、CPU の宣言が `GameMessageBox` から流れた後も確認できる。表示専用で操作はブロックしない。

## 変更ファイル
- `frontend/src/pages/TutePage.tsx` — サイドバーに `tute-declared-marriages` 読み取り欄を追加
- `frontend/src/pages/TutePage.test.tsx` — 宣言状況表示のテスト追加（+ `localStorage.clear()`）
- `frontend/src/i18n/locales/ja/tute.json` / `en/tute.json` — `declaredMarriages.*` ラベル追加

## 受け入れ条件
- [x] サイドバーに declaredSuits に基づく宣言状況一覧が表示される
- [x] 宣言済みスートのマリッジボタン非表示と一覧表示が一致する（同じ `state.declaredSuits` を参照）
- [x] ja/en 両ロケールにラベル文言を追加
- [x] TutePage.test.tsx に宣言済み表示のテストを追加

## テスト
- `bun run test -- --run TutePage` — 14 passed
- `bun run build` (tsc) — 成功
- `biome check` — クリーン

Closes #3409