### PR TITLE
feat(montecarlo): show removable-pair counter derived from the board

### DIFF
--- a/frontend/src/i18n/locales/en/montecarlo.json
+++ b/frontend/src/i18n/locales/en/montecarlo.json
@@ -12,6 +12,7 @@
     "dealCount": "Deals",
     "selectFirst": "Select the first card",
     "selectSecond": "Select an adjacent same-rank card",
+    "removablePairs": "Removable: {{n}} pairs",
     "stalemate": "No moves available",
     "win": "All 52 cards removed!",
     "loss": "Game Over"

--- a/frontend/src/i18n/locales/ja/montecarlo.json
+++ b/frontend/src/i18n/locales/ja/montecarlo.json
@@ -12,6 +12,7 @@
     "dealCount": "補充回数",
     "selectFirst": "1枚目のカードを選択してください",
     "selectSecond": "隣接する同ランクのカードを選択してください",
+    "removablePairs": "除去可能: {{n}} 組",
     "stalemate": "手詰まり",
     "win": "全52枚を取り除きました！",
     "loss": "ゲームオーバー"

--- a/frontend/src/pages/MonteCarloPage.test.tsx
+++ b/frontend/src/pages/MonteCarloPage.test.tsx
@@ -234,6 +234,37 @@ describe('MonteCarloPage', () => {
     expect(screen.getByTestId('mc-cell-0-1').className).toContain('ring-ds-warning');
   });
 
+  it('shows the removable-pair counter with the current board pair count', async () => {
+    // boardWithPair has exactly one removable pair (♠7 at (0,0), ♥7 at (0,1)).
+    renderWithProviders(<MonteCarloPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    const counter = screen.getByTestId('mc-removable-count');
+    expect(counter.textContent).toContain('1');
+    // With a removable pair available the counter is not in the warning state.
+    expect(counter).not.toHaveAttribute('data-removable-zero');
+    expect(counter.className).toContain('text-ds-text-muted');
+    // Deal button is not urged when a pair is still removable.
+    expect(screen.getByTestId('mc-deal-button').className).not.toContain('ring-ds-warning');
+  });
+
+  it('warns and urges Deal when no removable pairs remain', async () => {
+    // Two adjacent cards of different ranks — no removable pair on the board.
+    const board = emptyBoard();
+    board[0][0] = { card: card('SPADE', 7) };
+    board[0][1] = { card: card('HEART', 9) };
+    mockExec.mockResolvedValue({ ...playingState, board });
+    renderWithProviders(<MonteCarloPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    const counter = screen.getByTestId('mc-removable-count');
+    expect(counter.textContent).toContain('0');
+    expect(counter).toHaveAttribute('data-removable-zero', 'true');
+    expect(counter.className).toContain('text-ds-warning');
+    // The Deal button gets the warning ring to prompt the player.
+    expect(screen.getByTestId('mc-deal-button').className).toContain('ring-ds-warning');
+  });
+
   it('lifts a matching adjacent pair candidate and shows a transient success toast on removal', async () => {
     vi.useFakeTimers();
     try {

--- a/frontend/src/pages/MonteCarloPage.tsx
+++ b/frontend/src/pages/MonteCarloPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { montecarloApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { SettingsPanel } from '../components/common/SettingsPanel';
@@ -24,6 +24,7 @@ import type { MonteCarloResponse } from '../types/card';
 import { MonteCarloPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { countRemovablePairs } from '../utils/montecarloRemovablePairs';
 
 const SIZE = 5;
 
@@ -166,6 +167,11 @@ function MonteCarloPageContent() {
 
   const dealHintActive = frontendHintEnabled && frontendHint?.targetAction === 'deal';
 
+  // How many removable (adjacent, same-rank) pairs currently sit on the board.
+  // Derived client-side from the board grid — 0 means it's time to Deal.
+  const removablePairs = useMemo(() => (state ? countRemovablePairs(state.board) : 0), [state]);
+  const noRemovablePairs = isPlaying && removablePairs === 0;
+
   return (
     <GamePageShell
       title={tc('nav.montecarlo')}
@@ -304,6 +310,18 @@ function MonteCarloPageContent() {
               {selected === null ? t('label.selectFirst') : t('label.selectSecond')}
             </div>
 
+            <div
+              className={`text-center text-sm font-mono mb-2 ${
+                noRemovablePairs ? 'text-ds-warning font-semibold' : 'text-ds-text-muted'
+              }`}
+              data-testid="mc-removable-count"
+              data-removable-zero={noRemovablePairs ? 'true' : undefined}
+              role="status"
+              aria-live="polite"
+            >
+              {t('label.removablePairs', { n: removablePairs })}
+            </div>
+
             {pairRemoved && (
               <div
                 role="status"
@@ -341,7 +359,7 @@ function MonteCarloPageContent() {
                     type="button"
                     data-testid="mc-deal-button"
                     data-tutorial="mc-deal"
-                    className={`${btnPrimary} ${dealHintActive ? 'ring-2 ring-ds-warning' : ''}`}
+                    className={`${btnPrimary} ${dealHintActive || noRemovablePairs ? 'ring-2 ring-ds-warning' : ''}`}
                     onClick={handleDeal}
                     disabled={loading}
                   >

--- a/frontend/src/utils/montecarloRemovablePairs.test.ts
+++ b/frontend/src/utils/montecarloRemovablePairs.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign, MonteCarloBoardCell } from '../types/card';
+import { countRemovablePairs } from './montecarloRemovablePairs';
+
+const card = (design: CardDesign, value: number): Card => ({ design, value });
+
+function emptyBoard(): MonteCarloBoardCell[][] {
+  return Array.from({ length: 5 }, () => Array.from({ length: 5 }, () => ({ card: null }) as MonteCarloBoardCell));
+}
+
+describe('countRemovablePairs', () => {
+  it('returns 0 for an empty board', () => {
+    expect(countRemovablePairs(emptyBoard())).toBe(0);
+  });
+
+  it('counts a horizontal adjacent same-rank pair once', () => {
+    const b = emptyBoard();
+    b[0][0] = { card: card('SPADE', 7) };
+    b[0][1] = { card: card('HEART', 7) };
+    expect(countRemovablePairs(b)).toBe(1);
+  });
+
+  it('counts a diagonal adjacent same-rank pair (8-way adjacency)', () => {
+    const b = emptyBoard();
+    b[1][1] = { card: card('SPADE', 9) };
+    b[2][2] = { card: card('DIAMOND', 9) };
+    expect(countRemovablePairs(b)).toBe(1);
+  });
+
+  it('does not count non-adjacent same-rank cards', () => {
+    const b = emptyBoard();
+    b[0][0] = { card: card('SPADE', 5) };
+    b[0][2] = { card: card('HEART', 5) };
+    expect(countRemovablePairs(b)).toBe(0);
+  });
+
+  it('does not count adjacent cards of different ranks', () => {
+    const b = emptyBoard();
+    b[0][0] = { card: card('SPADE', 5) };
+    b[0][1] = { card: card('HEART', 6) };
+    expect(countRemovablePairs(b)).toBe(0);
+  });
+
+  it('counts every distinct pair around a shared cell without double counting', () => {
+    // Three 7s in an L: (0,0), (0,1), (1,0). Pairs: (0,0)-(0,1), (0,0)-(1,0), (0,1)-(1,0) diagonal.
+    const b = emptyBoard();
+    b[0][0] = { card: card('SPADE', 7) };
+    b[0][1] = { card: card('HEART', 7) };
+    b[1][0] = { card: card('CLOVER', 7) };
+    expect(countRemovablePairs(b)).toBe(3);
+  });
+
+  it('counts a down-left diagonal pair', () => {
+    const b = emptyBoard();
+    b[0][2] = { card: card('SPADE', 3) };
+    b[1][1] = { card: card('HEART', 3) };
+    expect(countRemovablePairs(b)).toBe(1);
+  });
+});

--- a/frontend/src/utils/montecarloRemovablePairs.ts
+++ b/frontend/src/utils/montecarloRemovablePairs.ts
@@ -1,0 +1,42 @@
+import type { MonteCarloBoardCell } from '../types/card';
+
+/**
+ * Counts the removable pairs currently present on a Monte Carlo Solitaire board.
+ *
+ * A removable pair is two filled cells that are adjacent (8-way: horizontally,
+ * vertically, or diagonally — Chebyshev distance of 1) and hold cards of equal
+ * rank (`card.value`). This mirrors the backend rule in `internal/domain/MonteCarlo.go`
+ * (`Remove` rejects `absInt(r1-r2) > 1 || absInt(c1-c2) > 1` and unequal `GetValue`).
+ *
+ * Each pair is counted exactly once: for every filled cell only the four
+ * "forward" neighbours (right, down-left, down, down-right) are inspected,
+ * matching the domain's `findAdjacentPair` scan order.
+ *
+ * @param board - The 5x5 Monte Carlo board grid.
+ * @returns The number of distinct removable pairs on the board.
+ */
+export function countRemovablePairs(board: MonteCarloBoardCell[][]): number {
+  // Forward-only directions so each unordered pair is visited once.
+  const dirs: ReadonlyArray<readonly [number, number]> = [
+    [0, 1], // right
+    [1, -1], // down-left
+    [1, 0], // down
+    [1, 1], // down-right
+  ];
+  let count = 0;
+  for (let r = 0; r < board.length; r++) {
+    const row = board[r];
+    for (let c = 0; c < row.length; c++) {
+      const a = row[c]?.card;
+      if (!a) continue;
+      for (const [dr, dc] of dirs) {
+        const nr = r + dr;
+        const nc = c + dc;
+        const b = board[nr]?.[nc]?.card;
+        if (!b) continue;
+        if (a.value === b.value) count++;
+      }
+    }
+  }
+  return count;
+}


### PR DESCRIPTION
## 概要

モンテカルロ・ソリティアの盤面に「今あと何組の除去可能ペアが残っているか」を常時表示するカウンターを追加しました。`state.board` から `useMemo` で算出し、0 のときは警告色にして `deal` ボタンにも `ring-ds-warning` を付与してデッキ補充を促します。

除去可能ペアの判定（8方向の隣接 = チェビシェフ距離1 かつ 同ランク `card.value`）は、バックエンド `internal/domain/MonteCarlo.go` の `Remove`（`absInt(r1-r2) > 1 || absInt(c1-c2) > 1` を拒否、`GetValue()` 一致を要求）および `findAdjacentPair` の走査順（前方4方向で各ペアを1回ずつ数える）と厳密に一致させています。

## 変更内容

- `frontend/src/utils/montecarloRemovablePairs.ts` — `countRemovablePairs(board)` を新規追加（純関数、単体テスト付き）
- `frontend/src/pages/MonteCarloPage.tsx` — カウンター表示（`data-testid="mc-removable-count"`、0 のとき警告色 + `data-removable-zero`）、deal ボタンの警告リング条件に `noRemovablePairs` を追加
- `frontend/src/i18n/locales/{ja,en}/montecarlo.json` — `label.removablePairs` を両言語に追加
- 各テストファイルにケースを追加

## 受け入れ条件

- [x] 盤面の除去可能ペア数が常時表示される
- [x] ペア数 0 のとき deal ボタンが視覚的に促される
- [x] 除去・deal 後に数が正しく更新される（`useMemo([state])` により `state` 更新のたび再計算）
- [x] 算出ロジックの単体テストを追加する（`montecarloRemovablePairs.test.ts`）

## テスト

- `cd frontend && bun run test -- --run MonteCarlo montecarloRemovablePairs` → 3 files / 37 tests passed
- `bun run build`（tsc）→ pass
- `biome check` → pass

Closes #3247