### PR TITLE
feat(canasta): guard go-out button until a canasta is completed

### DIFF
--- a/frontend/src/i18n/locales/en/canasta.json
+++ b/frontend/src/i18n/locales/en/canasta.json
@@ -37,6 +37,7 @@
   "skipMeldButton": "Skip",
   "discardButton": "Discard",
   "goOutButton": "Go out",
+  "goOutReason": "Going out requires at least one completed canasta (7-card meld)",
   "nextRound": "Next round",
   "selectPair": "Select a pair (2 natural cards matching the top discard)",
   "drawDiscardReason": {

--- a/frontend/src/i18n/locales/ja/canasta.json
+++ b/frontend/src/i18n/locales/ja/canasta.json
@@ -37,6 +37,7 @@
   "skipMeldButton": "スキップ",
   "discardButton": "捨てる",
   "goOutButton": "上がる",
+  "goOutReason": "ゴーアウトするには完成したカナスタ（7枚メルド）が1組以上必要です",
   "nextRound": "次のラウンド",
   "selectPair": "ペアを選択してください（トップカードと同ランクの2枚）",
   "drawDiscardReason": {

--- a/frontend/src/pages/CanastaPage.test.tsx
+++ b/frontend/src/pages/CanastaPage.test.tsx
@@ -167,6 +167,28 @@ describe('CanastaPage', () => {
     expect(screen.getByRole('button', { name: '上がる' })).toBeInTheDocument();
   });
 
+  it('disables go out and shows the reason while the player has no canasta', async () => {
+    mockExec.mockResolvedValue(discardPhaseState); // hasCanasta: false
+    renderWithProviders(<CanastaPage />);
+    const goOut = await screen.findByTestId('ca-go-out-button');
+    expect(goOut).toBeDisabled();
+    const reason = screen.getByTestId('ca-go-out-reason');
+    expect(reason).toHaveTextContent('ゴーアウトするには完成したカナスタ（7枚メルド）が1組以上必要です');
+    expect(goOut).toHaveAttribute('aria-describedby', 'ca-go-out-reason');
+  });
+
+  it('enables go out and hides the reason once a canasta is completed', async () => {
+    mockExec.mockResolvedValue({
+      ...discardPhaseState,
+      players: [{ ...basePlayers[0], hasCanasta: true }, basePlayers[1]],
+    });
+    renderWithProviders(<CanastaPage />);
+    const goOut = await screen.findByTestId('ca-go-out-button');
+    expect(goOut).toBeEnabled();
+    expect(screen.queryByTestId('ca-go-out-reason')).not.toBeInTheDocument();
+    expect(goOut).not.toHaveAttribute('aria-describedby');
+  });
+
   it('shows next round button at round end', async () => {
     mockExec.mockResolvedValue(roundEndState);
     renderWithProviders(<CanastaPage />);

--- a/frontend/src/pages/CanastaPage.tsx
+++ b/frontend/src/pages/CanastaPage.tsx
@@ -94,6 +94,9 @@ function CanastaPageContent() {
 
   const humanPlayer = state?.players.find((p) => p.isHuman);
   const humanCardCount = humanPlayer?.cards?.length ?? 0;
+  // The server rejects a go-out unless the player holds at least one completed
+  // canasta (Canasta.PlayerGoOut -> HasCanasta()); mirror that guard client-side.
+  const canGoOut = humanPlayer?.hasCanasta === true;
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('canasta');
   const cliConfig: CliGameConfig<CanastaResponse, Parameters<typeof canastaApi.exec>> = useMemo(
@@ -464,9 +467,26 @@ function CanastaPageContent() {
                   >
                     {t('discardButton')}
                   </button>
-                  <button type="button" className={btnSuccess} onClick={handleGoOut} disabled={loading}>
+                  <button
+                    type="button"
+                    className={btnSuccess}
+                    onClick={handleGoOut}
+                    disabled={loading || !canGoOut}
+                    title={canGoOut ? undefined : t('goOutReason')}
+                    aria-describedby={canGoOut ? undefined : 'ca-go-out-reason'}
+                    data-testid="ca-go-out-button"
+                  >
                     {t('goOutButton')}
                   </button>
+                  {!canGoOut && (
+                    <div
+                      id="ca-go-out-reason"
+                      data-testid="ca-go-out-reason"
+                      className="w-full text-xs text-ds-text-muted"
+                    >
+                      {t('goOutReason')}
+                    </div>
+                  )}
                 </>
               )}
               {isRoundEnd && (


### PR DESCRIPTION
## 概要
カナスタのゴーアウトボタンは `disabled={loading}` のみで常時押下可能だったが、完成したカナスタ（7枚メルド）を1組も持たないプレイヤーのゴーアウトはルール上不可でサーバ側（`Canasta.PlayerGoOut` -> `HasCanasta()`）がエラーを返す。レスポンスに既に含まれる `hasCanasta` を使ってクライアント側で事前ガードする。

## 変更内容
- `CanastaPage.tsx`: `canGoOut = humanPlayer.hasCanasta` を導出し、破棄フェーズのゴーアウトボタンを `!canGoOut` のとき無効化。`title` と `aria-describedby` で理由テキストを提示（ドローフェーズの `drawDiscardReason` と同パターン）。
- `i18n` (ja/en): `goOutReason` キーを追加（key-for-key 同期）。
- `CanastaPage.test.tsx`: 非活性+理由表示、カナスタ成立後の活性化のテストを追加。

## 受け入れ条件
- [x] `hasCanasta` が false の間ゴーアウトボタンが無効化される
- [x] 無効時に理由テキストが表示され SR にも関連付く（`aria-describedby`）
- [x] `hasCanasta` 成立後は従来どおり押せる
- [x] `CanastaPage.test.tsx` に活性/非活性のテストを追加

## 検証
- `bunx biome check`: 変更4ファイル、問題なし
- `bun run test -- --run CanastaPage`: 22 passed
- `bun run build` (tsc): 成功

Closes #3059