### PR TITLE
feat(handandfoot): add go-out readiness guidance to the play page

### DIFF
--- a/frontend/src/i18n/locales/en/handandfoot.json
+++ b/frontend/src/i18n/locales/en/handandfoot.json
@@ -45,6 +45,12 @@
     "selectOneMore": "Select one more card",
     "tooMany": "Select at most 2 cards"
   },
+  "goOutReason": {
+    "ready": "You can go out (foot cleared, red & black canastas complete)",
+    "needFoot": "Cannot go out until you enter your foot",
+    "needRedCanasta": "A red (natural) canasta is still required",
+    "needBlackCanasta": "A black (mixed) canasta is still required"
+  },
   "frozenIndicator": "❄️ Frozen",
   "selectMeld": "Select cards to meld",
   "result": {

--- a/frontend/src/i18n/locales/ja/handandfoot.json
+++ b/frontend/src/i18n/locales/ja/handandfoot.json
@@ -45,6 +45,12 @@
     "selectOneMore": "もう1枚選択してください",
     "tooMany": "選択は2枚までです"
   },
+  "goOutReason": {
+    "ready": "上がれます（フット消化・赤/黒カナスタ達成済み）",
+    "needFoot": "まだフットに入っていないため上がれません",
+    "needRedCanasta": "赤（ナチュラル）カナスタが不足しています",
+    "needBlackCanasta": "黒（ミックス）カナスタが不足しています"
+  },
   "frozenIndicator": "❄️ フリーズ",
   "selectMeld": "メルドするカードを選択してください",
   "result": {

--- a/frontend/src/pages/HandAndFootPage.test.tsx
+++ b/frontend/src/pages/HandAndFootPage.test.tsx
@@ -76,6 +76,40 @@ const discardPhaseState: HandAndFootResponse = {
   messageCode: 'handandfoot.discardPhase',
 };
 
+// A discard-phase state where the human has met every go-out requirement:
+// entered their foot and their team holds both a natural and a mixed canasta.
+const goOutReadyState: HandAndFootResponse = {
+  ...discardPhaseState,
+  players: [{ ...basePlayers[0], inFoot: true }, basePlayers[1]],
+  teams: [
+    {
+      team: 0,
+      melds: [
+        { cards: [], isNatural: true, isCanasta: true, rank: 7 },
+        { cards: [], isNatural: false, isCanasta: true, rank: 10 },
+      ],
+      red3Count: 0,
+      red3s: [],
+    },
+    { team: 1, melds: [], red3Count: 0, red3s: [] },
+  ],
+};
+
+// Human is in their foot and has a natural canasta but no mixed canasta yet.
+const goOutNeedBlackState: HandAndFootResponse = {
+  ...discardPhaseState,
+  players: [{ ...basePlayers[0], inFoot: true }, basePlayers[1]],
+  teams: [
+    {
+      team: 0,
+      melds: [{ cards: [], isNatural: true, isCanasta: true, rank: 7 }],
+      red3Count: 0,
+      red3s: [],
+    },
+    { team: 1, melds: [], red3Count: 0, red3s: [] },
+  ],
+};
+
 const roundEndState: HandAndFootResponse = {
   ...drawPhaseState,
   phase: 3,
@@ -170,6 +204,40 @@ describe('HandAndFootPage', () => {
     renderWithProviders(<HandAndFootPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '捨てる' })).toBeInTheDocument());
     expect(screen.getByRole('button', { name: '上がる' })).toBeInTheDocument();
+  });
+
+  it('disables go out and explains the unmet requirement when the player is not in their foot', async () => {
+    mockExec.mockResolvedValue(discardPhaseState);
+    renderWithProviders(<HandAndFootPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '上がる' })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: '上がる' })).toBeDisabled();
+    expect(screen.getByTestId('hf-go-out-guidance')).toHaveTextContent('まだフットに入っていないため上がれません');
+  });
+
+  it('shows the missing canasta reason when the player is in foot but lacks a mixed canasta', async () => {
+    mockExec.mockResolvedValue(goOutNeedBlackState);
+    renderWithProviders(<HandAndFootPage />);
+    await waitFor(() => expect(screen.getByTestId('hf-go-out-guidance')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: '上がる' })).toBeDisabled();
+    expect(screen.getByTestId('hf-go-out-guidance')).toHaveTextContent('黒（ミックス）カナスタが不足しています');
+  });
+
+  it('enables go out and confirms readiness once every requirement is met', async () => {
+    mockExec.mockResolvedValue(goOutReadyState);
+    renderWithProviders(<HandAndFootPage />);
+    await waitFor(() => expect(screen.getByTestId('hf-go-out-guidance')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: '上がる' })).not.toBeDisabled();
+    expect(screen.getByTestId('hf-go-out-guidance')).toHaveTextContent('上がれます');
+  });
+
+  it('calls goout command when go out is clicked while ready', async () => {
+    mockExec.mockResolvedValue(goOutReadyState);
+    renderWithProviders(<HandAndFootPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '上がる' })).not.toBeDisabled());
+    mockExec.mockClear();
+    mockExec.mockResolvedValue(roundEndState);
+    fireEvent.click(screen.getByRole('button', { name: '上がる' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('goout'));
   });
 
   it('shows next round button at round end', async () => {

--- a/frontend/src/pages/HandAndFootPage.tsx
+++ b/frontend/src/pages/HandAndFootPage.tsx
@@ -115,6 +115,22 @@ function HandAndFootPageContent() {
     return t('drawDiscardReason.selectTwo');
   }, [isDrawPhase, selectedCardIndices.length, state?.isFrozen, t]);
 
+  // Whether the human may currently "go out", plus the first unmet requirement.
+  // The web build always uses the default go-out rule (>=1 red/natural and >=1
+  // black/mixed team canasta, plus the player having entered their foot); see
+  // DefaultHandAndFootConfig — the web config never exposes the rc/bc thresholds.
+  const goOutGuidance = useMemo(() => {
+    if (!isDiscardPhase || !humanPlayer) return null;
+    const team = state?.teams.find((tm) => tm.team === humanPlayer.team);
+    const canastas = team?.melds.filter((m) => m.isCanasta) ?? [];
+    const redCanastas = canastas.filter((m) => m.isNatural).length;
+    const blackCanastas = canastas.filter((m) => !m.isNatural).length;
+    if (!humanPlayer.inFoot) return { canGoOut: false, reasonKey: 'goOutReason.needFoot' };
+    if (redCanastas < 1) return { canGoOut: false, reasonKey: 'goOutReason.needRedCanasta' };
+    if (blackCanastas < 1) return { canGoOut: false, reasonKey: 'goOutReason.needBlackCanasta' };
+    return { canGoOut: true, reasonKey: 'goOutReason.ready' };
+  }, [isDiscardPhase, humanPlayer, state?.teams]);
+
   const handleManualReset = useCallback(() => {
     hideActionLog();
     void gameExec('reset', undefined, {
@@ -416,19 +432,37 @@ function HandAndFootPageContent() {
                 </>
               )}
               {isDiscardPhase && isHumanTurn && (
-                <>
-                  <button
-                    type="button"
-                    className={btnPrimary}
-                    onClick={handleDiscard}
-                    disabled={loading || selectedCardIndices.length !== 1}
-                  >
-                    {t('discardButton')}
-                  </button>
-                  <button type="button" className={btnSuccess} onClick={handleGoOut} disabled={loading}>
-                    {t('goOutButton')}
-                  </button>
-                </>
+                <div className="flex gap-2 flex-col">
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      className={btnPrimary}
+                      onClick={handleDiscard}
+                      disabled={loading || selectedCardIndices.length !== 1}
+                    >
+                      {t('discardButton')}
+                    </button>
+                    <button
+                      type="button"
+                      className={btnSuccess}
+                      onClick={handleGoOut}
+                      disabled={loading || goOutGuidance?.canGoOut !== true}
+                      title={goOutGuidance && !goOutGuidance.canGoOut ? t(goOutGuidance.reasonKey) : undefined}
+                      aria-describedby={goOutGuidance ? 'hf-go-out-guidance' : undefined}
+                    >
+                      {t('goOutButton')}
+                    </button>
+                  </div>
+                  {goOutGuidance && (
+                    <div
+                      id="hf-go-out-guidance"
+                      data-testid="hf-go-out-guidance"
+                      className={`text-xs ${goOutGuidance.canGoOut ? 'text-ds-success' : 'text-ds-text-muted'}`}
+                    >
+                      {t(goOutGuidance.reasonKey)}
+                    </div>
+                  )}
+                </div>
               )}
               {isRoundEnd && (
                 <button type="button" className={btnSuccess} onClick={handleNextRound} disabled={loading}>


### PR DESCRIPTION
## 概要
ハンド・アンド・フットのディスカードフェーズで、人間プレイヤーが今「上がれる（ゴーアウト）」かどうかをガイダンス表示します。従来はゴーアウトボタンが常に有効で、条件未達時はサーバエラーの `ErrorAlert` が返るだけでした。既存の `drawDiscardReason`（捨て札取得の disabled 理由表示）の先例に倣い、ゴーアウトにも同様の可否ガイダンスを追加します。

## 変更内容
- `HandAndFootPage.tsx`: `goOutGuidance` を派生（display-only, 軽量）。
  - 条件: フット消化済み（`inFoot`）かつ 自チームに 赤（ナチュラル）カナスタ >=1 と 黒（ミックス）カナスタ >=1。
  - Web ビルドは常にデフォルト設定（rc=1 / bc=1、`DefaultHandAndFootConfig`）を用い、rc/bc 閾値はレスポンスに露出されないため、フロント側で既存フィールド（`players[].inFoot`, `teams[].melds[].isCanasta/isNatural`）から安全に導出できます。ドメインの `canGoOut` ルールと一致することを確認済み。
  - 条件未達時はゴーアウトボタンを `disabled` にし、最初の不足理由を `title` + 補助テキスト（`data-testid="hf-go-out-guidance"`）で表示。達成時は「上がれます」を表示し従来どおり実行可能。
  - 通常のプレイ（捨てる等）はハードブロックしません。
- i18n: `goOutReason.{ready,needFoot,needRedCanasta,needBlackCanasta}` を ja/en に key-for-key で追加。
- ページテストを追加（未達で disabled + 理由、達成で有効 + goout 実行）。

## 受け入れ条件
- [x] 条件未達時にゴーアウトボタンが disabled + 理由表示
- [x] 条件達成時は従来どおり実行できる
- [x] canGoOut の真偽分岐をテストで検証（presenter ではなくフロント派生で実装。理由は下記）
- [x] bun run test / build が green

## 実装メモ（presenter ではなくフロント派生を選択した理由）
issue は presenter への `canGoOut` 追加を提案していますが、可否は既存レスポンスのフィールド（`inFoot` と チームメルドの `isCanasta`/`isNatural`）から単純に導出でき、Web の go-out 閾値は常にデフォルト（rc=1/bc=1）で固定のため、追加のサーバ状態を持たずに display-only で完結する軽量実装としました。

## テスト
- `bunx biome check` OK
- `bun run test -- --run HandAndFootPage`: 21 passed
- `bun run build`（tsc）: OK

Closes #3470