### PR TITLE
feat(ninetynine): ビッド選択中に宣言トリック数のライブプレビューを表示

### DIFF
--- a/frontend/src/i18n/locales/en/ninetynine.json
+++ b/frontend/src/i18n/locales/en/ninetynine.json
@@ -32,6 +32,8 @@
   "buryTooMany": "{{count}} too many selected; choose exactly 3",
   "buryButtonDisabledAria": "Bury 3 (select {{count}} more card(s) first)",
   "buryButtonTooManyAria": "Bury 3 (deselect {{count}} card(s) — exactly 3 required)",
+  "bidPreview": "Selected total = {{count}} declared tricks",
+  "bidLegend": "Suit values: ♦=0  ♠=1  ♥=2  ♣=3",
   "currentTrick": "Current Trick",
   "scores": "Scores",
   "scoresPlayer": "Player",

--- a/frontend/src/i18n/locales/ja/ninetynine.json
+++ b/frontend/src/i18n/locales/ja/ninetynine.json
@@ -32,6 +32,8 @@
   "buryTooMany": "{{count}} 枚多く選択されています。ちょうど3枚にしてください",
   "buryButtonDisabledAria": "3枚埋める（あと {{count}} 枚のカード選択が必要です）",
   "buryButtonTooManyAria": "3枚埋める（{{count}} 枚多いため選択を減らしてください）",
+  "bidPreview": "選択中の合計 = 宣言 {{count}} トリック",
+  "bidLegend": "スート対応: ♦=0  ♠=1  ♥=2  ♣=3",
   "currentTrick": "現在のトリック",
   "scores": "スコア",
   "scoresPlayer": "プレイヤー",

--- a/frontend/src/pages/NinetyNinePage.test.tsx
+++ b/frontend/src/pages/NinetyNinePage.test.tsx
@@ -207,6 +207,36 @@ describe('NinetyNinePage', () => {
     expect(screen.getByTestId('nn-bury-progress')).toHaveTextContent('3枚選択しました。埋めるボタンで確定できます');
   });
 
+  it('shows a live declared-trick preview that matches the domain suit mapping, plus a legend', async () => {
+    mockExec.mockResolvedValue(bidPhaseState);
+    renderWithProviders(<NinetyNinePage />);
+    await waitFor(() => expect(screen.getByAltText('♠ A')).toBeInTheDocument());
+
+    // Legend is visible throughout the bid phase.
+    expect(screen.getByTestId('nn-bid-legend')).toHaveTextContent('スート対応: ♦=0 ♠=1 ♥=2 ♣=3');
+
+    // No cards selected yet: total is 0.
+    const preview = screen.getByTestId('nn-bid-preview');
+    expect(preview).toHaveAttribute('aria-live', 'polite');
+    expect(preview).toHaveTextContent('選択中の合計 = 宣言 0 トリック');
+
+    // ♠ A → +1 (SPADE=1).
+    fireEvent.click(screen.getByAltText('♠ A').closest('button') as HTMLButtonElement);
+    expect(screen.getByTestId('nn-bid-preview')).toHaveTextContent('選択中の合計 = 宣言 1 トリック');
+
+    // ♥ J → +2 (HEART=2) ⇒ 3.
+    fireEvent.click(screen.getByAltText('♥ J').closest('button') as HTMLButtonElement);
+    expect(screen.getByTestId('nn-bid-preview')).toHaveTextContent('選択中の合計 = 宣言 3 トリック');
+
+    // ♣ 5 → +3 (CLOVER=3) ⇒ 6, the declared bid for these exact 3 cards.
+    fireEvent.click(screen.getByAltText('♣ 5').closest('button') as HTMLButtonElement);
+    expect(screen.getByTestId('nn-bid-preview')).toHaveTextContent('選択中の合計 = 宣言 6 トリック');
+
+    // ♦ 8 → +0 (DIAMOND=0): total stays 6.
+    fireEvent.click(screen.getByAltText('♦ 8').closest('button') as HTMLButtonElement);
+    expect(screen.getByTestId('nn-bid-preview')).toHaveTextContent('選択中の合計 = 宣言 6 トリック');
+  });
+
   it('announces an over-selection message instead of a negative count when more than 3 are picked', async () => {
     mockExec.mockResolvedValue(bidPhaseState);
     renderWithProviders(<NinetyNinePage />);

--- a/frontend/src/pages/NinetyNinePage.tsx
+++ b/frontend/src/pages/NinetyNinePage.tsx
@@ -36,6 +36,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { NINETYNINE_HELP, parseNinetynineCommand } from '../utils/cli/commands/ninetynineCommands';
 import { formatNinetynineState } from '../utils/cli/formatters/ninetynineFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { ninetynineDeclaredTricks } from '../utils/hints/ninetynineHint';
 import { playerName } from '../utils/playerUtils';
 
 /** Number of cards the human must bury during the bid phase. */
@@ -185,6 +186,13 @@ function NinetyNinePageContent() {
   const buryRemaining = Math.max(0, BURY_COUNT - burySelectedCount);
   const buryOverBy = Math.max(0, burySelectedCount - BURY_COUNT);
   const buryReady = burySelectedCount === BURY_COUNT;
+  // Live declared-trick preview: sum of the currently-selected cards' suit
+  // bid values (♦=0 ♠=1 ♥=2 ♣=3). Equals the bid the backend registers once
+  // exactly 3 cards are selected, and updates immediately on every change.
+  const burySelectedCards = selectedCardIndices
+    .map((i) => humanPlayer?.cards[i])
+    .filter((c): c is NonNullable<typeof c> => c != null);
+  const buryPreviewTricks = ninetynineDeclaredTricks(burySelectedCards);
 
   const dealerName = playerName(
     state.players[state.dealerIdx]?.id ?? state.dealerIdx,
@@ -269,6 +277,20 @@ function NinetyNinePageContent() {
                         : buryOverBy > 0
                           ? t('buryTooMany', { count: buryOverBy })
                           : t('buryRemaining', { count: buryRemaining })}
+                    </div>
+                    {/* Live declared-trick preview + suit→value legend so the player can
+                        see what bid their current 3-card selection will produce without
+                        memorising the suit mapping. Announced politely as it updates. */}
+                    <div
+                      className="text-sm text-ds-text-primary mt-1"
+                      role="status"
+                      aria-live="polite"
+                      data-testid="nn-bid-preview"
+                    >
+                      {t('bidPreview', { count: buryPreviewTricks })}
+                    </div>
+                    <div className="text-xs text-ds-text-muted" data-testid="nn-bid-legend">
+                      {t('bidLegend')}
                     </div>
                   </div>
                 )}

--- a/frontend/src/utils/hints/ninetynineHint.test.ts
+++ b/frontend/src/utils/hints/ninetynineHint.test.ts
@@ -1,9 +1,35 @@
 import { describe, expect, it } from 'vitest';
 import type { Card, NinetyNineResponse } from '../../types/card';
 import { NinetyNinePhase } from '../../types/phases';
-import { getNinetyNineHint } from './ninetynineHint';
+import { getNinetyNineHint, ninetynineBidValue, ninetynineDeclaredTricks } from './ninetynineHint';
 
 const card = (design: Card['design'], value: number): Card => ({ design, value });
+
+describe('ninetynineBidValue', () => {
+  // Must match ninetyNineSuitBidValue in internal/domain/NinetyNine.go exactly.
+  it('maps each suit to its domain bid value', () => {
+    expect(ninetynineBidValue('DIAMOND')).toBe(0);
+    expect(ninetynineBidValue('SPADE')).toBe(1);
+    expect(ninetynineBidValue('HEART')).toBe(2);
+    expect(ninetynineBidValue('CLOVER')).toBe(3);
+  });
+
+  it('treats any other design (e.g. JOKER) as 0', () => {
+    expect(ninetynineBidValue('JOKER')).toBe(0);
+  });
+});
+
+describe('ninetynineDeclaredTricks', () => {
+  it('returns 0 for no cards', () => {
+    expect(ninetynineDeclaredTricks([])).toBe(0);
+  });
+
+  it('sums the buried cards suit values (max bid = 3 clubs = 9)', () => {
+    expect(ninetynineDeclaredTricks([card('SPADE', 1), card('HEART', 2), card('CLOVER', 3)])).toBe(6);
+    expect(ninetynineDeclaredTricks([card('CLOVER', 3), card('CLOVER', 4), card('CLOVER', 5)])).toBe(9);
+    expect(ninetynineDeclaredTricks([card('DIAMOND', 3), card('DIAMOND', 4), card('DIAMOND', 5)])).toBe(0);
+  });
+});
 
 function makeState(overrides: Partial<NinetyNineResponse> = {}): NinetyNineResponse {
   return {

--- a/frontend/src/utils/hints/ninetynineHint.ts
+++ b/frontend/src/utils/hints/ninetynineHint.ts
@@ -10,6 +10,37 @@ const SUIT_NUM_TO_DESIGN: Readonly<Record<number, Card['design']>> = {
   4: 'DIAMOND',
 };
 
+/**
+ * Maps a buried card's suit to its Ninety-Nine bid value.
+ *
+ * Mirrors `ninetyNineSuitBidValue` in `internal/domain/NinetyNine.go` exactly:
+ * ♦=0, ♠=1, ♥=2, ♣=3. Any other design (e.g. JOKER) contributes 0.
+ */
+export function ninetynineBidValue(design: Card['design']): number {
+  switch (design) {
+    case 'DIAMOND':
+      return 0;
+    case 'SPADE':
+      return 1;
+    case 'HEART':
+      return 2;
+    case 'CLOVER':
+      return 3;
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Sums the bid values of the given cards to compute the declared trick count.
+ *
+ * When exactly the 3 buried cards are passed, the result (0-9) equals the bid
+ * the backend will register. Used for the live bid preview during selection.
+ */
+export function ninetynineDeclaredTricks(cards: readonly Card[]): number {
+  return cards.reduce((sum, c) => sum + ninetynineBidValue(c.design), 0);
+}
+
 /** Returns a frontend HintResult for Ninety-Nine, or null if no suggestion. */
 export function getNinetyNineHint(state: NinetyNineResponse): HintResult | null {
   const human = state.players.find((p) => p.isHuman);


### PR DESCRIPTION
## 概要

ナインティナインのビッド（埋め3枚）選択中に、選択したカードのスート合計から算出される宣言トリック数をライブでプレビュー表示します。スート対応の凡例も常設しました。初心者がスート→数の対応を暗記しなくてもプレイできるようになります。

## 実装

- `frontend/src/utils/hints/ninetynineHint.ts` に純関数 `ninetynineBidValue` / `ninetynineDeclaredTricks` を追加。ドメイン実装 `ninetyNineSuitBidValue`（`internal/domain/NinetyNine.go`）と完全一致: **♦=0, ♠=1, ♥=2, ♣=3**。
- `NinetyNinePage.tsx`: 人間のビッドターン中、選択中カードの合計宣言トリック数を `data-testid="nn-bid-preview"`（`aria-live="polite"`）で表示。凡例を `data-testid="nn-bid-legend"` で常設。選択変更時に即時更新。
- i18n キー `bidPreview` / `bidLegend` を ja/en 両方にキー対応で追加。

## テスト

- `ninetynineHint.test.ts`: 純関数がドメインのスート→値マッピングと一致することを検証（全スート + JOKER=0 + 合計 0/6/9）。
- `NinetyNinePage.test.tsx`: `shows a live declared-trick preview that matches the domain suit mapping, plus a legend` — カード選択に応じてプレビューが 0→1→3→6→6 と更新され、凡例が表示されることを検証。

## 受け入れ条件

- [x] 3 枚選択時に宣言トリック数のプレビューが表示される
- [x] 選択が 3 枚未満/変更時に表示が即時更新される
- [x] スート対応の凡例がビッドフェーズ中に確認できる
- [x] 計算関数のユニットテストがドメイン実装と一致することを検証

## ゲート

- `biome check --write`: パス
- `bun run test -- --run NinetyNine`: 54 tests パス
- `bun run build` (tsc): パス

Closes #3097