### PR TITLE
feat(canasta): compact meld display with rank stack and count badge

### DIFF
--- a/frontend/src/i18n/locales/en/canasta.json
+++ b/frontend/src/i18n/locales/en/canasta.json
@@ -27,6 +27,7 @@
   "red3s": "Red 3s",
   "naturalCanasta": "Natural Canasta",
   "mixedCanasta": "Mixed Canasta",
+  "meldExpand": "Tap to expand all cards",
   "drawStockButton": "Draw from stock",
   "drawDiscardButton": "Pick up discard",
   "meldButton": "Meld",

--- a/frontend/src/i18n/locales/ja/canasta.json
+++ b/frontend/src/i18n/locales/ja/canasta.json
@@ -27,6 +27,7 @@
   "red3s": "赤3",
   "naturalCanasta": "ナチュラルカナスタ",
   "mixedCanasta": "ミックスカナスタ",
+  "meldExpand": "タップで全カードを展開",
   "drawStockButton": "山札から引く",
   "drawDiscardButton": "捨て札を取る",
   "meldButton": "メルドする",

--- a/frontend/src/pages/CanastaPage.test.tsx
+++ b/frontend/src/pages/CanastaPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { canastaApi } from '../api/gameApi';
 import { renderWithProviders } from '../test/renderWithProviders';
@@ -85,6 +85,37 @@ const gameEndState: CanastaResponse = {
   phase: 4,
   gameEndFlag: true,
   winnerIdx: 0,
+};
+
+// Human holds one completed natural canasta (7 cards) and one incomplete meld (3 cards)
+// so the compact stack + count badge rendering can be exercised.
+const meldDisplayState: CanastaResponse = {
+  ...meldPhaseState,
+  players: [
+    {
+      ...basePlayers[0],
+      hasCanasta: true,
+      melds: [
+        {
+          rank: 7,
+          isNatural: true,
+          isCanasta: true,
+          cards: Array.from({ length: 7 }, (_, i) => ({ design: i % 2 ? 'HEART' : 'SPADE', value: 7 })),
+        },
+        {
+          rank: 10,
+          isNatural: false,
+          isCanasta: false,
+          cards: [
+            { design: 'SPADE', value: 10 },
+            { design: 'CLOVER', value: 10 },
+            { design: 'HEART', value: 10 },
+          ],
+        },
+      ],
+    },
+    basePlayers[1],
+  ],
 };
 
 describe('CanastaPage', () => {
@@ -285,6 +316,32 @@ describe('CanastaPage', () => {
     expect(screen.getByTestId('ca-draw-discard-reason')).toHaveTextContent(
       'フリーズ中はワイルドカードでの代用ができません',
     );
+  });
+
+  it('renders melds compactly with a count badge and canasta label, collapsed by default', async () => {
+    mockExec.mockResolvedValue(meldDisplayState);
+    renderWithProviders(<CanastaPage />);
+
+    const canastaMeld = await screen.findByTestId('ca-meld-0-0');
+    // Collapsed by default so a meld occupies ~one card of height.
+    expect(canastaMeld).not.toHaveAttribute('open');
+    // Count badge shows the number of cards in the meld.
+    expect(screen.getByTestId('ca-meld-badge-0-0')).toHaveTextContent('7');
+    expect(screen.getByTestId('ca-meld-badge-0-1')).toHaveTextContent('3');
+    // Canasta type (with the ★) is visible at a glance for the completed canasta.
+    expect(within(canastaMeld).getByText(/ナチュラルカナスタ/)).toBeInTheDocument();
+  });
+
+  it('expands a meld to reveal every constituent card when the summary is clicked', async () => {
+    mockExec.mockResolvedValue(meldDisplayState);
+    renderWithProviders(<CanastaPage />);
+
+    const canastaMeld = (await screen.findByTestId('ca-meld-0-0')) as HTMLDetailsElement;
+    expect(canastaMeld.open).toBe(false);
+    const summary = canastaMeld.querySelector('summary');
+    if (!summary) throw new Error('meld summary not found');
+    fireEvent.click(summary);
+    expect(canastaMeld.open).toBe(true);
   });
 
   afterEach(() => {

--- a/frontend/src/pages/CanastaPage.tsx
+++ b/frontend/src/pages/CanastaPage.tsx
@@ -275,20 +275,49 @@ function CanastaPageContent() {
                         {playerName(p.id, p.isHuman)} - {t('melds')}
                         {p.hasCanasta && <span className="ml-2 text-ds-warning">★</span>}
                       </div>
-                      {p.melds.map((m, mi) => (
-                        <div key={mi} className="flex flex-wrap gap-1 mb-1">
-                          <span className="text-xs text-ds-text-muted self-center mr-1">
-                            {m.isCanasta
-                              ? m.isNatural
-                                ? t('naturalCanasta')
-                                : t('mixedCanasta')
-                              : `(${m.cards.length})`}
-                          </span>
-                          {m.cards.map((card, ci) => (
-                            <AnimatedCard key={`meld-${pi}-${mi}-${ci}`} card={card} width={cardWidth * 0.6} />
-                          ))}
-                        </div>
-                      ))}
+                      {p.melds.map((m, mi) => {
+                        // Same-rank cards are collapsed into an overlapping stack so a meld
+                        // occupies ~one card of height; the <details> expands to the full spread.
+                        const meldW = cardWidth * 0.6;
+                        const canastaLabel = m.isCanasta
+                          ? m.isNatural
+                            ? t('naturalCanasta')
+                            : t('mixedCanasta')
+                          : null;
+                        return (
+                          <details key={mi} className="mb-1" data-testid={`ca-meld-${pi}-${mi}`}>
+                            <summary
+                              className="flex items-center gap-2 cursor-pointer list-none marker:hidden"
+                              title={t('meldExpand')}
+                            >
+                              <div className="relative flex items-center shrink-0">
+                                {m.cards.map((card, ci) => (
+                                  <div
+                                    key={`meld-stack-${pi}-${mi}-${ci}`}
+                                    style={{ marginLeft: ci === 0 ? 0 : -meldW * 0.72, zIndex: ci }}
+                                  >
+                                    <AnimatedCard card={card} width={meldW} silent />
+                                  </div>
+                                ))}
+                              </div>
+                              <span
+                                className="text-xs font-bold px-1.5 py-0.5 rounded-full bg-black/50 text-ds-text-primary"
+                                data-testid={`ca-meld-badge-${pi}-${mi}`}
+                              >
+                                {m.cards.length}
+                              </span>
+                              {canastaLabel && (
+                                <span className="text-xs font-bold text-ds-warning">★ {canastaLabel}</span>
+                              )}
+                            </summary>
+                            <div className="flex flex-wrap gap-1 mt-1 pl-2">
+                              {m.cards.map((card, ci) => (
+                                <AnimatedCard key={`meld-${pi}-${mi}-${ci}`} card={card} width={meldW} silent />
+                              ))}
+                            </div>
+                          </details>
+                        );
+                      })}
                       {p.red3s.length > 0 && (
                         <div className="flex flex-wrap gap-1 mt-1">
                           <span className="text-xs text-ds-error self-center mr-1">{t('red3s')}</span>


### PR DESCRIPTION
## 概要
カナスタのメルド表示を、全カード横並びから **ランク別の重ねスタック＋枚数バッジ** に変更し、`<details>` でコンパクト化しました。中盤以降にカナスタが複数できても左カラムが縦に伸びず、捨て札や操作ボタンが画面外へ押し出されにくくなります。

Closes #3058

## 変更内容
- 各メルドを `<details>` にまとめ、`<summary>` に **同ランクカードの重ねスタック（先頭カード＋残りを数 px ずらし）** ＋ **枚数バッジ** ＋ 既存の naturalCanasta/mixedCanasta ラベル（★付き）を表示
- タップ/クリックで `<details>` を展開し、構成カードを従来どおり全部確認可能
- 赤3（red3s）の並びは現状維持
- メルド要素・枚数バッジに `data-testid`（`ca-meld-{pi}-{mi}` / `ca-meld-badge-{pi}-{mi}`）を付与
- i18n キー `meldExpand` を ja/en 双方に追加（展開操作のヒント）
- 純粋な表示変更で、メルドのデータ・アクションは不変（バックエンド変更なし）

## 受け入れ条件
- [x] メルド 1 組の表示高さがカード約 1 枚分に収まる（重ねスタック＋`<details>` 折りたたみ）
- [x] 枚数バッジとカナスタ種別（★含む）が一目で分かる
- [x] 展開操作で構成カード全部を確認できる
- [x] `CanastaPage.test.tsx` にスタック表示と展開のテストを追加

## テスト
- `cd frontend && bun run test -- --run CanastaPage` → 24 passed（新規 2 件含む）
  - `renders melds compactly with a count badge and canasta label, collapsed by default`
  - `expands a meld to reveal every constituent card when the summary is clicked`
- `bun run build`（tsc）: pass
- `biome check`: pass