### PR TITLE
fix(callbreak): keep spades-break status visible in hand footer

### DIFF
--- a/frontend/src/pages/CallBreakPage.test.tsx
+++ b/frontend/src/pages/CallBreakPage.test.tsx
@@ -233,7 +233,15 @@ describe('CallBreakPage', () => {
   it('renders spades-broken status text', async () => {
     mockExec.mockResolvedValue(spadesBrokenState);
     renderWithProviders(<CallBreakPage />);
-    await waitFor(() => expect(screen.getByText('スペードブレイク済')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getAllByText('スペードブレイク済').length).toBeGreaterThan(0));
+  });
+
+  it('shows a persistent spades-break indicator in the footer hand area', async () => {
+    mockExec.mockResolvedValue(spadesBrokenState);
+    renderWithProviders(<CallBreakPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId('cb-spades-break-footer')).toHaveTextContent('スペードブレイク済');
+    });
   });
 
   it('shows decimal score in the score table (cumulativeScore 41 → 4.1)', async () => {

--- a/frontend/src/pages/CallBreakPage.tsx
+++ b/frontend/src/pages/CallBreakPage.tsx
@@ -437,6 +437,9 @@ function CallBreakPageContent() {
           <GameFooter className={`${gameTheme.callbreak.footer} px-4 py-2.5`}>
             {humanPlayer && (
               <>
+                <div className="mb-1 text-ds-text-muted text-xs" role="status" data-testid="cb-spades-break-footer">
+                  {state.spadesBroken ? t('spadesBroken') : t('spadesNotBroken')}
+                </div>
                 {humanPlayer.bid >= 0 && (
                   <div className="mb-1 text-ds-text-muted text-xs">
                     <div>


### PR DESCRIPTION
## 概要
コールブレイクで、モバイル端末でプレイヤーが手札を選ぶためにスクロールダウンすると、上部情報バーにしかない「スペードブレイク状態」が画面外に消えてしまう問題を修正する。

`GameFooter`（常時表示される手札エリア）の手札セクション付近に、スペードブレイク状態（`spadesBroken` / `spadesNotBroken`）を小さく常時表示する。既存の上部情報バーの表示はそのまま維持する。ゲームロジックは一切変更していない、純粋なレイアウト追加。

## 変更点
- `frontend/src/pages/CallBreakPage.tsx`: `GameFooter` 内の手札セクション直前に `role="status"` / `data-testid="cb-spades-break-footer"` の常時表示インジケータを追加。
- `frontend/src/pages/CallBreakPage.test.tsx`: 既存テストを `getAllByText`（テキストが上部/フッター2箇所に出るため）に更新し、フッターインジケータの表示位置を検証するテストを追加。

## 受け入れ条件
- [x] 手札選択エリア付近にスペードブレイク状態が常時表示される
- [x] 既存の上部情報バーの表示は維持する
- [x] モバイル/デスクトップ双方でレイアウトが崩れない（フッター内テキスト行のみ、既存 bid 進捗行と同じスタイル）
- [x] コンポーネントテストで表示位置を検証する（`cb-spades-break-footer`）

## テスト
- `bun run test -- --run CallBreakPage`: 24 passed
- `bun run build`: 成功

Closes #3301