### PR TITLE
feat(penguin): スーパームーブ超過ツールチップに空きセル数・空き列数を含める

### DIFF
--- a/frontend/src/i18n/locales/en/penguin.json
+++ b/frontend/src/i18n/locales/en/penguin.json
@@ -20,7 +20,9 @@
   "emptyFoundationAriaLabel": "{{suit}} Foundation (empty)",
   "emptyFreecellAriaLabel": "Free Cell {{idx}} (empty)",
   "emptyColumnAriaLabel": "Empty column (only {{rank}} may be placed)",
-  "supermoveLimitTooltip": "Only {{limit}} card(s) can be moved at once",
+  "supermoveLimitTooltip": "Only {{limit}} card(s) can be moved at once ({{cells}} free cell(s), {{cols}} empty column(s))",
+  "supermoveBadge": "Max move: {{limit}}",
+  "supermoveBadgeTooltip": "Max cards movable at once ({{cells}} free cell(s), {{cols}} empty column(s)). More free space allows moving more",
   "tutorial": {
     "freeCells": "Seven free cells. Three start occupied after the deal. More empty cells allow moving more cards at once.",
     "foundation": "Foundation piles. Build each suit from the base rank upward, wrapping K to A.",

--- a/frontend/src/i18n/locales/ja/penguin.json
+++ b/frontend/src/i18n/locales/ja/penguin.json
@@ -20,7 +20,9 @@
   "emptyFoundationAriaLabel": "{{suit}} ファンデーション (空)",
   "emptyFreecellAriaLabel": "フリーセル {{idx}} (空)",
   "emptyColumnAriaLabel": "空き列（{{rank}} のみ置けます）",
-  "supermoveLimitTooltip": "一度に動かせるのは{{limit}}枚までです",
+  "supermoveLimitTooltip": "一度に動かせるのは{{limit}}枚まで（空きセル{{cells}}・空き列{{cols}}）",
+  "supermoveBadge": "最大移動: {{limit}}枚",
+  "supermoveBadgeTooltip": "一度に動かせる最大枚数（空きセル{{cells}}・空き列{{cols}}）。空きが増えるほど多く動かせます",
   "tutorial": {
     "freeCells": "7つのフリーセルです。初期配置で3セルが使用済みの状態からスタートします。空きセルが多いほど多くのカードを一度に移動できます。",
     "foundation": "ファンデーションです。各スートを基準ランクから順番に積み上げます（Kの次はAに回ります）。",

--- a/frontend/src/pages/PenguinPage.test.tsx
+++ b/frontend/src/pages/PenguinPage.test.tsx
@@ -32,6 +32,30 @@ const playingState: PenguinResponse = {
   messageCode: 'penguin.playing',
 };
 
+// All free cells occupied and every column non-empty → supermoveLimit = (1+0)*2^0 = 1,
+// so the 2-card stack in column 0 exceeds the limit and shows the tooltip.
+const supermoveExceedState: PenguinResponse = {
+  ...playingState,
+  freeCells: [
+    card('DIAMOND', 3),
+    card('CLOVER', 5),
+    card('HEART', 7),
+    card('SPADE', 9),
+    card('DIAMOND', 10),
+    card('CLOVER', 11),
+    card('HEART', 2),
+  ],
+  tableau: [
+    [card('SPADE', 13), card('SPADE', 12)],
+    [card('HEART', 6)],
+    [card('CLOVER', 8)],
+    [card('DIAMOND', 4)],
+    [card('SPADE', 6)],
+    [card('HEART', 9)],
+    [card('CLOVER', 2)],
+  ],
+};
+
 const gameClearState: PenguinResponse = {
   ...playingState,
   phase: 1,
@@ -103,6 +127,33 @@ describe('PenguinPage', () => {
     await waitFor(() =>
       expect(screen.getAllByRole('button', { name: '空き列（K のみ置けます）' }).length).toBeGreaterThanOrEqual(1),
     );
+  });
+
+  // --- Supermove limit ---
+
+  it('supermove-limit tooltip includes the limit, free-cell count, and empty-column count', async () => {
+    mockExec.mockResolvedValue(supermoveExceedState);
+    renderWithProviders(<PenguinPage />);
+    // Top card of column 0 exceeds the limit (stack of 2 > limit of 1).
+    const topCard = await screen.findByTestId('pg-tableau-0-0');
+    expect(topCard).toHaveAttribute('data-supermove-blocked', 'true');
+    // limit=1, cells=0, cols=0
+    expect(topCard).toHaveAttribute('title', '一度に動かせるのは1枚まで（空きセル0・空き列0）');
+  });
+
+  it('shows a supermove-limit badge reflecting the free-cell/column counts', async () => {
+    // playingState: 4 empty free cells, 5 empty columns → (1+4)*2^5 = 160.
+    renderWithProviders(<PenguinPage />);
+    const badge = await screen.findByTestId('pg-supermove-badge');
+    expect(badge).toHaveTextContent('最大移動: 160枚');
+  });
+
+  it('supermove-limit badge updates when free space shrinks', async () => {
+    mockExec.mockResolvedValue(supermoveExceedState);
+    renderWithProviders(<PenguinPage />);
+    const badge = await screen.findByTestId('pg-supermove-badge');
+    // 0 empty free cells, 0 empty columns → (1+0)*2^0 = 1.
+    expect(badge).toHaveTextContent('最大移動: 1枚');
   });
 
   // --- Foundation ---

--- a/frontend/src/pages/PenguinPage.tsx
+++ b/frontend/src/pages/PenguinPage.tsx
@@ -243,6 +243,13 @@ function PenguinPageContent() {
           <span>
             {t('baseRank')}: {baseRankLabel(state.baseRank)}
           </span>
+          <span data-testid="pg-supermove-badge" title={t('supermoveBadgeTooltip')}>
+            {t('supermoveBadge', {
+              limit: supermoveLimit,
+              cells: emptyFreeCells,
+              cols: emptyTableauCols,
+            })}
+          </span>
           <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
         </>
       }
@@ -449,7 +456,11 @@ function PenguinPageContent() {
                                       onBlur={() => setHoveredStack(null)}
                                       title={
                                         exceedsSupermove
-                                          ? t('supermoveLimitTooltip', { limit: supermoveLimit })
+                                          ? t('supermoveLimitTooltip', {
+                                              limit: supermoveLimit,
+                                              cells: emptyFreeCells,
+                                              cols: emptyTableauCols,
+                                            })
                                           : undefined
                                       }
                                       data-supermove-blocked={exceedsSupermove ? 'true' : undefined}


### PR DESCRIPTION
## 概要
Penguin ソリティアのスーパームーブ上限超過ツールチップに、空きフリーセル数と空き列数を追加し、「なぜその上限なのか」を説明できるようにしました（EightOff と同じ形式）。あわせてヘッダーに現在の最大移動枚数を常時表示するバッジを追加しました。

## 変更内容
- `PenguinPage.tsx`: `supermoveLimitTooltip` に `cells`/`cols` パラメータを追加。ヘッダーに `pg-supermove-badge` を追加し、空き状況に応じて上限を常時表示。
- `ja/en penguin.json`: `supermoveLimitTooltip` の文言を更新し、`supermoveBadge`/`supermoveBadgeTooltip` を追加（key-for-key で同期）。
- `PenguinPage.test.tsx`: ツールチップ内容（上限・空きセル・空き列）とバッジ表示・更新のテストを追加。

上限式 `(1 + 空きセル) << 空き列` は `internal/domain/Penguin.go` の `maxMovableCards` と一致することを確認済み。

## 受け入れ条件
- [x] ツールチップに上限・空きセル数・空き列数が表示される
- [x] ja/en の文言が更新されている
- [x] 上限バッジが空き状況に応じて更新される
- [x] `PenguinPage.test.tsx` にツールチップ内容のテストを追加

## テスト
- `bun run test -- --run PenguinPage`: 46 passed
- `bun run build`: 成功
- `biome check`: クリーン

Closes #3329