### PR TITLE
feat(cuarenta): チーム別獲得枚数カウンタの表示

### DIFF
--- a/frontend/src/i18n/locales/en/cuarenta.json
+++ b/frontend/src/i18n/locales/en/cuarenta.json
@@ -5,6 +5,7 @@
   "playersTitle": "Players",
   "team": "Team {{name}}",
   "teamScore": "{{name}}: {{score}} / {{target}}",
+  "teamCaptured": "Captured {{count}}",
   "captured": "captured {{count}}",
   "table": "Table",
   "tableCount": "{{count}} cards",

--- a/frontend/src/i18n/locales/ja/cuarenta.json
+++ b/frontend/src/i18n/locales/ja/cuarenta.json
@@ -5,6 +5,7 @@
   "playersTitle": "プレイヤー",
   "team": "チーム{{name}}",
   "teamScore": "{{name}}: {{score}} / {{target}}点",
+  "teamCaptured": "獲得 {{count}}枚",
   "captured": "捕獲 {{count}}枚",
   "table": "場",
   "tableCount": "{{count}}枚",

--- a/frontend/src/pages/CuarentaPage.test.tsx
+++ b/frontend/src/pages/CuarentaPage.test.tsx
@@ -117,6 +117,50 @@ describe('CuarentaPage', () => {
     expect(screen.getAllByText(/捕獲 0枚/).length).toBe(4);
   });
 
+  it('sums each team captured-card total from its two players', async () => {
+    // Team A = seats {0,2}: 8 + 5 = 13; Team B = seats {1,3}: 6 + 1 = 7.
+    mockExec.mockResolvedValue(
+      makeState({
+        players: [
+          makePlayer({ id: 0, team: 0, isHuman: true, capturedCount: 8 }),
+          makePlayer({ id: 1, team: 1, capturedCount: 6 }),
+          makePlayer({ id: 2, team: 0, capturedCount: 5 }),
+          makePlayer({ id: 3, team: 1, capturedCount: 1 }),
+        ],
+      }),
+    );
+    renderWithProviders(<CuarentaPage />);
+    await waitFor(() => expect(screen.getByTestId('cuarenta-team-captured-0')).toHaveTextContent('獲得 13枚'));
+    expect(screen.getByTestId('cuarenta-team-captured-1')).toHaveTextContent('獲得 7枚');
+  });
+
+  it('highlights a team counter as it approaches the 20-card bonus', async () => {
+    // Team A at 19 (approaching) is emphasized; Team B at 7 is not.
+    mockExec.mockResolvedValue(
+      makeState({
+        players: [
+          makePlayer({ id: 0, team: 0, isHuman: true, capturedCount: 10 }),
+          makePlayer({ id: 1, team: 1, capturedCount: 4 }),
+          makePlayer({ id: 2, team: 0, capturedCount: 9 }),
+          makePlayer({ id: 3, team: 1, capturedCount: 3 }),
+        ],
+      }),
+    );
+    renderWithProviders(<CuarentaPage />);
+    const teamA = await screen.findByTestId('cuarenta-team-captured-0');
+    expect(teamA).toHaveTextContent('獲得 19枚');
+    expect(teamA.className).toContain('text-ds-accent');
+    const teamB = screen.getByTestId('cuarenta-team-captured-1');
+    expect(teamB.className).not.toContain('text-ds-accent');
+  });
+
+  it('resets team captured totals to zero on a fresh round', async () => {
+    // Default fixture has all capturedCount 0 — both team counters read 0.
+    renderWithProviders(<CuarentaPage />);
+    await waitFor(() => expect(screen.getByTestId('cuarenta-team-captured-0')).toHaveTextContent('獲得 0枚'));
+    expect(screen.getByTestId('cuarenta-team-captured-1')).toHaveTextContent('獲得 0枚');
+  });
+
   it('renders the human hand cards', async () => {
     renderWithProviders(<CuarentaPage />);
     await waitFor(() => expect(screen.getByTestId('hand-card-0')).toBeInTheDocument());

--- a/frontend/src/pages/CuarentaPage.tsx
+++ b/frontend/src/pages/CuarentaPage.tsx
@@ -30,6 +30,11 @@ import { CUARENTA_HELP, parseCuarentaCommand } from '../utils/cli/commands/cuare
 import { formatCuarentaState } from '../utils/cli/formatters/cuarentaFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 
+/** Cards a team must capture in a round to earn the extra "más de veinte" points. */
+const CUARENTA_CAPTURE_BONUS = 20;
+/** Captured-card count from which a team's counter is highlighted as approaching the bonus. */
+const CUARENTA_CAPTURE_NEAR = CUARENTA_CAPTURE_BONUS - 1;
+
 /** CPU difficulty options for the Cuarenta settings panel. */
 const CPU_DIFFICULTY_OPTIONS = [
   { value: 0, label: 'easy' },
@@ -152,6 +157,12 @@ function CuarentaPageContent() {
   const humanPlayer = state.players.find((p) => p.isHuman);
   // Team A = seats {0,2}; the human (seat 0) is on Team A.
   const humanTeam = humanPlayer?.team ?? 0;
+
+  // Per-team captured-card totals this round: capturing 20+ cards earns the
+  // "más de veinte" bonus, so the running tally matters mid-round (#3563).
+  const teamCaptured = state.teamScores.map((_, team) =>
+    state.players.reduce((sum, p) => (p.team === team ? sum + p.capturedCount : sum), 0),
+  );
   const winningTeam = state.roundWinners.length === 1 ? state.roundWinners[0] : -1;
   const humanWon = isGameEnd && state.roundWinners.includes(humanTeam);
 
@@ -242,16 +253,27 @@ function CuarentaPageContent() {
               <span>{t('deck', { count: state.remainingDeck })}</span>
             </div>
 
-            {/* Team scores */}
+            {/* Team scores + running captured-card totals (20+ earns a bonus) */}
             <div className="mb-2 p-2 rounded bg-black/30 flex justify-center gap-6" data-tutorial="cuarenta-teams">
-              {state.teamScores.map((score, team) => (
-                <span
-                  key={`team-${team}`}
-                  className={`text-sm font-semibold ${team === humanTeam ? 'text-ds-warning' : 'text-ds-text-primary'}`}
-                >
-                  {t('teamScore', { name: teamLabel(team), score, target: state.config.targetScore })}
-                </span>
-              ))}
+              {state.teamScores.map((score, team) => {
+                const captured = teamCaptured[team] ?? 0;
+                const nearBonus = captured >= CUARENTA_CAPTURE_NEAR;
+                return (
+                  <div key={`team-${team}`} className="flex flex-col items-center gap-0.5">
+                    <span
+                      className={`text-sm font-semibold ${team === humanTeam ? 'text-ds-warning' : 'text-ds-text-primary'}`}
+                    >
+                      {t('teamScore', { name: teamLabel(team), score, target: state.config.targetScore })}
+                    </span>
+                    <span
+                      className={`text-xs font-semibold ${nearBonus ? 'text-ds-accent' : 'text-ds-text-muted'}`}
+                      data-testid={`cuarenta-team-captured-${team}`}
+                    >
+                      {t('teamCaptured', { count: captured })}
+                    </span>
+                  </div>
+                );
+              })}
             </div>
 
             {/* Players (team / hand / captured / current turn) */}


### PR DESCRIPTION
## 概要

クアレンタ (`cuarenta`) は 2v2 のチーム戦で、ラウンド終了時にチームの獲得カードが 20 枚以上だと「más de veinte」の追加点になる。従来 `CuarentaPage.tsx` は `p.capturedCount` を個人単位でしか表示せず、チーム合算の途中経過がどこにも出ていなかった。

本 PR はチームスコア表示枠に、チームごとの獲得枚数合計「獲得 n 枚」を追加する。フロント側で `state.players` を `p.team` でグループ化して集計するのみ（サーバ変更なし）。

## 変更点

- チームスコアの下に各チームの獲得枚数合計を表示（席 {0,2}=A / {1,3}=B）
- 20 枚のボーナスラインに接近（19 枚以上）したチームのカウンタを強調色 (`text-ds-accent`) に切替
- `capturedCount` はサーバ側でラウンドごとに 0 リセットされるため、次ラウンドで自動的に 0 に戻る
- i18n キー `teamCaptured` を ja/en 両方に追加（キー同期）
- ページテスト 3 件追加（合算 / 閾値強調 / リセット時 0）

## 受け入れ条件

- [x] 両チームの獲得枚数合計が表示される
- [x] 閾値接近時に強調表示される
- [x] ラウンドリセットで枚数が 0 に戻る
- [x] 集計ロジックのテストを追加

## テスト

- `frontend`: `bun run test -- --run CuarentaPage` → 20 passed（新規 3 件含む）
- `frontend`: `bun run build`（tsc）通過
- `frontend`: `biome check` 通過

Closes #3563
