### PR TITLE
feat(pitch): highlight lead suit and trump cards in the current trick

### DIFF
--- a/frontend/src/i18n/locales/en/pitch.json
+++ b/frontend/src/i18n/locales/en/pitch.json
@@ -31,6 +31,11 @@
   "bidPass": "Pass",
   "bidNone": "Not bid",
   "currentTrick": "Current trick",
+  "leadBadge": "Lead",
+  "trickLegend": {
+    "lead": "Lead suit",
+    "trump": "Trump"
+  },
   "scores": "Scores",
   "scoresPlayer": "Player",
   "scoresBid": "Bid",

--- a/frontend/src/i18n/locales/ja/pitch.json
+++ b/frontend/src/i18n/locales/ja/pitch.json
@@ -31,6 +31,11 @@
   "bidPass": "パス",
   "bidNone": "未ビッド",
   "currentTrick": "現在のトリック",
+  "leadBadge": "リード",
+  "trickLegend": {
+    "lead": "リードスート",
+    "trump": "トランプ"
+  },
   "scores": "スコア",
   "scoresPlayer": "プレイヤー",
   "scoresBid": "ビッド",

--- a/frontend/src/pages/PitchPage.test.tsx
+++ b/frontend/src/pages/PitchPage.test.tsx
@@ -79,6 +79,18 @@ const playState: PitchResponse = {
   players: bidState.players.map((p, i) => (i === 0 ? { ...p, bid: 3 } : { ...p, bid: 0 })),
 };
 
+// A play-phase trick with trump = SPADE (1); lead card is a HEART, so HEART is
+// the lead suit, and the SPADE card is a trump cut.
+const trickState: PitchResponse = {
+  ...playState,
+  trumpSuit: 1,
+  currentTrick: [
+    { playerIdx: 3, card: makeCard('HEART', 9) },
+    { playerIdx: 0, card: makeCard('HEART', 4) },
+    { playerIdx: 1, card: makeCard('SPADE', 12) },
+  ],
+};
+
 const gameEndState: PitchResponse = {
   ...bidState,
   phase: PitchPhase.GAME_END,
@@ -230,6 +242,27 @@ describe('PitchPage', () => {
     const badge = await screen.findByTestId('pitch-game-pips-badge');
     expect(badge.className).toContain('min-h-[44px]');
     expect(badge.className).toContain('min-w-[44px]');
+  });
+
+  it('emphasizes the lead card and trump cards in the current trick', async () => {
+    mockApi.mockResolvedValue(trickState);
+    renderWithProviders(<PitchPage />);
+
+    // Lead badge is on the first card of the trick, whose wrapper is ringed as
+    // the lead suit (HEART here, distinct from the trump ring color).
+    const leadBadge = await screen.findByTestId('pt-trick-lead-badge');
+    expect(leadBadge).toHaveTextContent('リード');
+    expect(leadBadge.parentElement?.className).toContain('ring-ds-info');
+
+    // Trump card carries a suit-symbol badge (non-color cue) and an orange ring.
+    const trumpBadge = screen.getByTestId('pt-trick-trump-badge');
+    expect(trumpBadge).toHaveTextContent('♠');
+    expect(trumpBadge.parentElement?.className).toContain('ring-ds-warning');
+
+    // The header trump indicator is emphasized once trump is set.
+    expect(screen.getByTestId('pt-trump-indicator').className).toContain('ring-ds-warning');
+    // Legend explains both rings.
+    expect(screen.getByTestId('pt-trick-legend')).toBeInTheDocument();
   });
 
   it('closes the pips popover on Escape and on an outside click', async () => {

--- a/frontend/src/pages/PitchPage.tsx
+++ b/frontend/src/pages/PitchPage.tsx
@@ -97,6 +97,14 @@ const SUIT_DESIGNS: Readonly<Record<string, string>> = {
   DIAMOND: '♦',
 };
 
+/** Maps the numeric `trumpSuit` (1–4) to the matching card `design` string. */
+const SUIT_NUM_TO_DESIGN: Readonly<Record<number, string>> = {
+  1: 'SPADE',
+  2: 'CLOVER',
+  3: 'HEART',
+  4: 'DIAMOND',
+};
+
 const VALUE_LABELS: Readonly<Record<number, string>> = {
   1: 'A',
   11: 'J',
@@ -279,7 +287,14 @@ function PitchPageContent() {
               <span>{t('round', { n: state.roundNumber })}</span>
               <span>{t('trick', { n: state.trickNumber })}</span>
               <span>{t('dealer', { name: findPlayerName(state.players, state.dealerIdx) })}</span>
-              <span>
+              <span
+                data-testid="pt-trump-indicator"
+                className={
+                  state.trumpSuit === 0
+                    ? 'opacity-60'
+                    : 'rounded px-1.5 py-0.5 font-semibold ring-1 ring-ds-warning text-ds-warning'
+                }
+              >
                 {t('trumpSuit', {
                   suit: state.trumpSuit === 0 ? t('trumpUnset') : (SUIT_LABELS[state.trumpSuit] ?? '?'),
                 })}
@@ -334,17 +349,56 @@ function PitchPageContent() {
               {state.currentTrick.length === 0 ? (
                 <div className="opacity-50">—</div>
               ) : (
-                <div className="flex flex-wrap gap-2">
-                  {state.currentTrick.map((tc) => (
-                    <div
-                      key={`${tc.playerIdx}-${tc.card.design}-${tc.card.value}`}
-                      className="flex flex-col items-center"
-                    >
-                      <span className="text-[10px] opacity-60">{findPlayerName(state.players, tc.playerIdx)}</span>
-                      <CardImage card={tc.card} width={cardWidth} />
-                    </div>
-                  ))}
-                </div>
+                <>
+                  <div className="flex flex-wrap gap-2">
+                    {state.currentTrick.map((tc, idx) => {
+                      const leadDesign = state.currentTrick[0]?.card.design;
+                      const trumpDesign = SUIT_NUM_TO_DESIGN[state.trumpSuit];
+                      const isLead = idx === 0;
+                      const isTrump = trumpDesign !== undefined && tc.card.design === trumpDesign;
+                      const isLeadSuit = !isTrump && tc.card.design === leadDesign;
+                      const ringClass = isTrump ? 'ring-2 ring-ds-warning' : isLeadSuit ? 'ring-2 ring-ds-info' : '';
+                      return (
+                        <div
+                          key={`${tc.playerIdx}-${tc.card.design}-${tc.card.value}`}
+                          className="flex flex-col items-center gap-0.5"
+                        >
+                          <span className="text-[10px] opacity-60">{findPlayerName(state.players, tc.playerIdx)}</span>
+                          <div className={`relative inline-block rounded ${ringClass}`}>
+                            <CardImage card={tc.card} width={cardWidth} />
+                            {isLead && (
+                              <span
+                                data-testid="pt-trick-lead-badge"
+                                className="absolute -top-1 -left-1 rounded bg-ds-info px-1 py-0.5 text-[9px] font-bold leading-none text-white shadow"
+                              >
+                                {t('leadBadge')}
+                              </span>
+                            )}
+                            {isTrump && (
+                              <span
+                                data-testid="pt-trick-trump-badge"
+                                title={t('trickLegend.trump')}
+                                className="absolute -top-1 -right-1 rounded-full bg-ds-warning px-1 py-0.5 text-[10px] font-bold leading-none text-white shadow"
+                              >
+                                {SUIT_LABELS[state.trumpSuit] ?? '?'}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                  <div data-testid="pt-trick-legend" className="mt-2 flex flex-wrap gap-3 text-[10px] opacity-70">
+                    <span className="inline-flex items-center gap-1">
+                      <span className="inline-block h-3 w-3 rounded-sm ring-2 ring-ds-info" />
+                      {t('trickLegend.lead')}
+                    </span>
+                    <span className="inline-flex items-center gap-1">
+                      <span className="inline-block h-3 w-3 rounded-sm ring-2 ring-ds-warning" />
+                      {t('trickLegend.trump')}
+                    </span>
+                  </div>
+                </>
               )}
             </div>
 


### PR DESCRIPTION
## 概要
Pitch の現在トリック表示で、リードカード・リードスート・トランプスートのカードを視覚的に区別できるようにした。Pitch は「リードスートに従う or トランプで切る」判断が核心のゲームだが、従来はカードが平坦に並ぶだけで盤面の意味が読み取れなかった。

## 変更点 (フロントのみ / バックエンド変更なし)
- `state.currentTrick[0]` のスートをリードスートとして導出し、`state.trumpSuit` (`SUIT_NUM_TO_DESIGN` で design 文字列へ変換) と比較。
- トランプ札: `ring-2 ring-ds-warning` + スート記号バッジ (♠等) を重ねる。
- リードスート札 (非トランプ): `ring-2 ring-ds-info` の別色リング。
- トリック先頭カードに「リード」バッジを付与。
- ヘッダーの切り札表示を、未確定時 (`opacity-60`) と確定時 (`ring-ds-warning` 強調) で色分け。
- リング色の意味を示す凡例を追加。
- i18n キー `leadBadge` / `trickLegend.lead` / `trickLegend.trump` を ja/en 双方に追加。

強調は色だけでなくバッジ (テキスト/記号) と凡例でも区別できるため、色覚に依存しない。

## テスト
`PitchPage.test.tsx` に `emphasizes the lead card and trump cards in the current trick` を追加。リードバッジ・トランプバッジ (♠)・トランプリング・リードスートリング・ヘッダー強調・凡例の存在を検証。

- `bunx biome check` : pass
- `bun run test -- --run PitchPage` : 15 passed
- `bun run build` (tsc) : pass

## 受け入れ条件
- [x] トリック先頭カードにリードバッジが表示される
- [x] トランプスートのカードが強調表示される
- [x] 強調は色以外の手掛かり (バッジ/形状) も持つ
- [x] `PitchPage.test.tsx` にテストを追加する

Closes #3238