### PR TITLE
feat(scopa): show next-round button on round end and mark the round boundary

### DIFF
--- a/frontend/src/i18n/locales/en/scopa.json
+++ b/frontend/src/i18n/locales/en/scopa.json
@@ -21,7 +21,8 @@
     "noTakeCandidate": "No capture candidates",
     "yourCaptures": "Captures",
     "cpuStats": "{{cards}} cards / {{score}} pt",
-    "humanStats": "Hand {{cards}} / Captured {{captured}} / Scopa {{scopa}} / Total {{score}} pt"
+    "humanStats": "Hand {{cards}} / Captured {{captured}} / Scopa {{scopa}} / Total {{score}} pt",
+    "roundEnd": "Round over — review the score, then continue to the next round"
   },
   "button": {
     "take": "Take",

--- a/frontend/src/i18n/locales/ja/scopa.json
+++ b/frontend/src/i18n/locales/ja/scopa.json
@@ -21,7 +21,8 @@
     "noTakeCandidate": "取り札候補はありません",
     "yourCaptures": "獲得カード",
     "cpuStats": "{{cards}}枚 / {{score}}pt",
-    "humanStats": "手札{{cards}}枚 / 捕獲{{captured}}枚 / スコパ{{scopa}} / 累計{{score}}pt"
+    "humanStats": "手札{{cards}}枚 / 捕獲{{captured}}枚 / スコパ{{scopa}} / 累計{{score}}pt",
+    "roundEnd": "ラウンド終了 — 得点を確認して「次のラウンド」へ進んでください"
   },
   "button": {
     "take": "取る",

--- a/frontend/src/pages/ScopaPage.test.tsx
+++ b/frontend/src/pages/ScopaPage.test.tsx
@@ -199,6 +199,26 @@ describe('ScopaPage', () => {
     );
   });
 
+  it('hides the next-round button and round-end banner during normal play', async () => {
+    renderWithProviders(<ScopaPage />);
+    await waitFor(() => expect(screen.getByTestId('hand-card-0')).toBeInTheDocument());
+    expect(screen.queryByTestId('next-round-button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sc-round-end-banner')).not.toBeInTheDocument();
+  });
+
+  it('shows the round-end banner and a working next-round button when the round ends', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: 'roundEnd', currentTurn: 1 }));
+    renderWithProviders(<ScopaPage />);
+    await waitFor(() => expect(screen.getByTestId('sc-round-end-banner')).toBeInTheDocument());
+    const nextRound = screen.getByTestId('next-round-button');
+    expect(nextRound).toBeInTheDocument();
+    expect(nextRound).not.toBeDisabled();
+
+    mockExec.mockClear();
+    fireEvent.click(nextRound);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('n'));
+  });
+
   it('shows loading state when state has fewer than 2 players', async () => {
     mockExec.mockResolvedValue(
       makeState({

--- a/frontend/src/pages/ScopaPage.tsx
+++ b/frontend/src/pages/ScopaPage.tsx
@@ -128,6 +128,9 @@ function ScopaPageContent() {
   }
 
   const isGameEnd = state.gameEndFlag;
+  // A round finished but the game continues — surface the round boundary and the
+  // "next round" control instead of letting the deal-again flow slip by silently.
+  const isRoundEnd = state.phase === 'roundEnd';
   const humanWon = isGameEnd && state.roundWinners.includes(0);
   const takeCandidateIndices =
     handIndex !== null && isHumanTurn
@@ -263,6 +266,16 @@ function ScopaPageContent() {
               </div>
             </div>
 
+            {isRoundEnd && (
+              <div
+                role="status"
+                className="text-center text-sm font-medium text-ds-info bg-ds-info/10 border border-ds-info/30 rounded-lg py-2 px-3"
+                data-testid="sc-round-end-banner"
+              >
+                {t('label.roundEnd')}
+              </div>
+            )}
+
             <GameMessageBox
               message={state.message}
               messageCode={state.messageCode}
@@ -326,15 +339,17 @@ function ScopaPageContent() {
               >
                 {t('button.lay')}
               </button>
-              <button
-                type="button"
-                onClick={handleNextRound}
-                disabled={loading || !isGameEnd === false}
-                className="px-4 py-2 rounded-lg bg-ds-info/70 text-white font-medium disabled:opacity-40 disabled:cursor-not-allowed text-sm hidden"
-                data-testid="next-round-button"
-              >
-                {t('button.nextRound')}
-              </button>
+              {isRoundEnd && (
+                <button
+                  type="button"
+                  onClick={handleNextRound}
+                  disabled={loading}
+                  className="px-4 py-2 rounded-lg bg-ds-info/70 text-white font-medium disabled:opacity-40 disabled:cursor-not-allowed text-sm"
+                  data-testid="next-round-button"
+                >
+                  {t('button.nextRound')}
+                </button>
+              )}
               <GameResetButton
                 isGameEnd={isGameEnd}
                 onReset={onReset}


### PR DESCRIPTION
## 概要
スコパのフッターにあった「次のラウンド」ボタンは、`className` に常時 `hidden` が付き、さらに `disabled={loading || !isGameEnd === false}`（`isGameEnd` が true のとき disabled=false になる紛らわしい反転条件）で実質的に描画されない死にボタンだった。`handleNextRound`（`"n"`）は実装済みなのに UI から到達できず、ラウンド遷移（デッキ配り直し）がプレイヤーに認識されないまま自動で流れていた。

`Rummy500Page.tsx` の `isRoundEnd` パターンに合わせ、レスポンスの `phase` からラウンド終了を判定して素直に条件レンダリングするよう整理し、ラウンド区切りを明示するバナーを追加した。

## 変更点
- `isRoundEnd = state.phase === 'roundEnd'` を導出
- 次ラウンドボタンを `{isRoundEnd && <button…>}` の素直な条件レンダリングに変更。`hidden` クラスと `!isGameEnd === false` を撤廃（表示タイミング・アクション `"n"` は不変）
- ラウンド終了時に `role="status"` のバナー（`sc-round-end-banner`）を表示し、区切りを視認可能に
- `label.roundEnd` を ja/en の scopa ロケールへ key-for-key で追加
- `ScopaPage.test.tsx` にラウンド終了バナー表示・次ラウンドボタン動作・通常プレイ時の非表示を追加

## 受け入れ条件
- [x] ラウンド終了時に次ラウンドボタンが表示・動作する
- [x] `!isGameEnd === false` の紛らわしい条件が解消される
- [x] ラウンド区切りがプレイヤーに視認できる（ラウンド終了バナー）
- [x] `ScopaPage.test.tsx` を更新

## テスト
- `bun run test -- --run ScopaPage` … 17 passed
- `bun run build`（tsc）… 成功
- `biome check` … clean

Closes #3344
