### PR TITLE
feat(tripeaks): add per-peak remaining-card indicator (#3085)

### DIFF
--- a/frontend/src/i18n/locales/en/tripeaks.json
+++ b/frontend/src/i18n/locales/en/tripeaks.json
@@ -8,6 +8,8 @@
   "stock": "Stock",
   "waste": "Waste",
   "moveCount": "Moves",
+  "peakRemaining": "Peaks left",
+  "peakCleared": "Peak cleared!",
   "combo": "Combo ×{{count}}",
   "draw": "Draw",
   "giveup": "Give Up",

--- a/frontend/src/i18n/locales/ja/tripeaks.json
+++ b/frontend/src/i18n/locales/ja/tripeaks.json
@@ -8,6 +8,8 @@
   "stock": "山札",
   "waste": "捨て札",
   "moveCount": "手数",
+  "peakRemaining": "ピーク残り",
+  "peakCleared": "ピーク制覇！",
   "combo": "コンボ ×{{count}}",
   "draw": "引く",
   "giveup": "ギブアップ",

--- a/frontend/src/pages/TriPeaksPage.test.tsx
+++ b/frontend/src/pages/TriPeaksPage.test.tsx
@@ -4,12 +4,18 @@ import { actionLogApi, tripeaksApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, TriPeaksCard, TriPeaksResponse } from '../types/card';
-import { TriPeaksPage } from './TriPeaksPage';
+import { computePeakRemaining, TriPeaksPage } from './TriPeaksPage';
 
 vi.mock('../api/gameApi', () => ({
   tripeaksApi: { exec: vi.fn() },
   actionLogApi: { tripeaks: vi.fn() },
 }));
+
+const mockPlaySound = vi.fn();
+vi.mock('../providers/SoundProvider', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../providers/SoundProvider')>();
+  return { ...actual, useSound: () => ({ playSound: mockPlaySound, muted: false, toggleMute: vi.fn() }) };
+});
 
 vi.mock('../hooks/useGameHint', () => ({
   useGameHint: vi.fn(() => ({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() })),
@@ -76,9 +82,11 @@ const gameOverState: TriPeaksResponse = {
 };
 
 beforeEach(() => {
+  localStorage.clear();
   mockExec.mockResolvedValue(playingState);
   vi.mocked(useGameHint).mockReturnValue({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() });
   mockCombo.mockReturnValue(0);
+  mockPlaySound.mockClear();
 });
 
 describe('TriPeaksPage', () => {
@@ -325,5 +333,63 @@ describe('TriPeaksPage', () => {
     renderWithProviders(<TriPeaksPage />);
     const badge = await screen.findByTestId('combo-badge');
     expect(badge.className).toContain('bg-ds-error');
+  });
+
+  // --- Per-peak remaining indicator (issue #3085) ---
+
+  it('renders the per-peak remaining-card indicator during play', async () => {
+    renderWithProviders(<TriPeaksPage />);
+    const indicator = await screen.findByTestId('peak-remaining');
+    // makeTestLayout: left peak 4 cards, middle 1, right 1.
+    expect(indicator.textContent).toMatch(/4\/1\/1/);
+  });
+
+  it('shows a check mark for a peak whose remaining count is zero', async () => {
+    const layout = makeTestLayout();
+    layout[0][6] = makeTriPeaksCard(null, true, false); // clear the right peak
+    mockExec.mockResolvedValue({ ...playingState, layout });
+    renderWithProviders(<TriPeaksPage />);
+    const indicator = await screen.findByTestId('peak-remaining');
+    expect(indicator).toHaveTextContent('✓');
+  });
+
+  it('hides the peak indicator after the game ends', async () => {
+    mockExec.mockResolvedValue(gameClearState);
+    renderWithProviders(<TriPeaksPage />);
+    await waitFor(() => expect(screen.getByText('ゲームクリア')).toBeInTheDocument());
+    expect(screen.queryByTestId('peak-remaining')).not.toBeInTheDocument();
+  });
+
+  it('plays a sound once when a peak is cleared', async () => {
+    renderWithProviders(<TriPeaksPage />);
+    await waitFor(() => expect(screen.getByTestId('peak-remaining')).toBeInTheDocument());
+    mockPlaySound.mockClear();
+
+    // Next server response clears the right peak (its only card is removed).
+    const cleared = makeTestLayout();
+    cleared[0][6] = makeTriPeaksCard(null, true, false);
+    mockExec.mockResolvedValue({ ...playingState, layout: cleared });
+    const drawButtons = screen.getAllByRole('button', { name: '引く' });
+    fireEvent.click(drawButtons[drawButtons.length - 1]);
+
+    await waitFor(() => expect(mockPlaySound).toHaveBeenCalledWith('cardPlace'));
+    expect(mockPlaySound.mock.calls.filter((c) => c[0] === 'cardPlace')).toHaveLength(1);
+  });
+});
+
+describe('computePeakRemaining', () => {
+  it('returns [0, 0, 0] for an undefined layout', () => {
+    expect(computePeakRemaining(undefined)).toEqual([0, 0, 0]);
+  });
+
+  it('counts present, non-removed cards per peak by column range', () => {
+    expect(computePeakRemaining(makeTestLayout())).toEqual([4, 1, 1]);
+  });
+
+  it('ignores removed cells and empty positions', () => {
+    const layout = makeTestLayout();
+    layout[3][0] = makeTriPeaksCard(card('SPADE', 5), true, true); // removed (left peak)
+    layout[0][3] = makeTriPeaksCard(null, false, false); // empty (middle peak)
+    expect(computePeakRemaining(layout)).toEqual([3, 0, 1]);
   });
 });

--- a/frontend/src/pages/TriPeaksPage.tsx
+++ b/frontend/src/pages/TriPeaksPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { tripeaksApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
@@ -43,6 +43,38 @@ const VALID_COLS: readonly number[][] = [
   [0, 1, 2, 3, 4, 5, 6, 7, 8],
   [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
 ];
+
+/** Number of peaks in a TriPeaks tableau. */
+const PEAK_COUNT = 3;
+
+/**
+ * Maps a tableau column index to its peak index (0-2). Columns are partitioned
+ * into three contiguous groups — 0-2 (left peak), 3-5 (middle peak), 6-9 (right
+ * peak) — so every card in the layout is attributed to exactly one peak.
+ */
+function peakOfColumn(col: number): number {
+  if (col < 3) return 0;
+  if (col < 6) return 1;
+  return 2;
+}
+
+/**
+ * Derives the number of remaining (present and not-yet-removed) cards in each of
+ * the three peaks from the TriPeaks layout. Returns a fixed-length `[left,
+ * middle, right]` tuple; a missing layout yields `[0, 0, 0]`.
+ */
+export function computePeakRemaining(layout: TriPeaksResponse['layout'] | undefined): number[] {
+  const remaining = [0, 0, 0];
+  if (!layout) return remaining;
+  for (const row of layout) {
+    row.forEach((cell, col) => {
+      if (cell?.card && !cell.removed) {
+        remaining[peakOfColumn(col)] += 1;
+      }
+    });
+  }
+  return remaining;
+}
 
 /** TriPeaks tutorial step definitions. */
 const TP_TUTORIAL_STEPS: TutorialStep[] = [
@@ -165,6 +197,25 @@ function TriPeaksPageContent() {
 
   const combo = useChainCombo(state?.moveCount, state?.stockCount);
 
+  // Remaining-card count per peak, derived from the board layout (issue #3085).
+  const peakRemaining = useMemo(() => computePeakRemaining(state?.layout), [state?.layout]);
+  const isPlayingForPeaks = state?.phase === TriPeaksPhase.PLAYING;
+  // Fire a subtle sound once when a peak's remaining count first reaches zero.
+  // The ref always tracks the latest counts, so reset/undo (which refill a peak)
+  // naturally re-arms the celebration without any explicit teardown.
+  const prevPeakRemaining = useRef<number[]>([0, 0, 0]);
+  useEffect(() => {
+    const prev = prevPeakRemaining.current;
+    if (isPlayingForPeaks) {
+      for (let i = 0; i < PEAK_COUNT; i++) {
+        if (prev[i] > 0 && peakRemaining[i] === 0) {
+          playSound('cardPlace');
+        }
+      }
+    }
+    prevPeakRemaining.current = peakRemaining;
+  }, [peakRemaining, isPlayingForPeaks, playSound]);
+
   if (!state)
     return <GameSkeleton gameKey="tripeaks" layout={{ kind: 'tiered-rows', rows: [3, 6, 9, 10], stockWaste: true }} />;
 
@@ -207,6 +258,23 @@ function TriPeaksPageContent() {
           <span>
             {t('moveCount')}: {state.moveCount}
           </span>
+          {isPlaying && (
+            <span data-testid="peak-remaining" className="flex items-center gap-1 text-xs">
+              <span className="sr-only">{t('peakRemaining')}</span>
+              <span aria-hidden="true">⛰</span>
+              {peakRemaining.map((n, i) => (
+                <span key={`peak-${i.toString()}`} className="flex items-center">
+                  {i > 0 && <span className="text-game-text-muted mx-0.5">/</span>}
+                  <span
+                    title={n === 0 ? t('peakCleared') : undefined}
+                    className={`font-bold ${n === 0 ? 'text-ds-success' : ''}`}
+                  >
+                    {n === 0 ? '✓' : n}
+                  </span>
+                </span>
+              ))}
+            </span>
+          )}
           {combo >= 2 && (
             <span
               data-testid="combo-badge"


### PR DESCRIPTION
## 概要

トリピークスに **ピーク単位の残枚数インジケーター**を追加します（issue #3085）。`state.layout` から 3 つのピーク（列 0-2 / 3-5 / 6-9）ごとの残枚数を導出し、プレイ中はヘッダーに「⛰ n / n / n」を常時表示します。あるピークの残枚数が 0 になると、そのピークにチェックマーク（成功色）を表示し、`cardPlace` サウンドを一度だけ鳴らします。

## 変更点

- `computePeakRemaining(layout)` — 純粋関数として列レンジで各ピークの残枚数（present かつ未除去のカード）を集計。exported でユニットテスト可能。
- ヘッダーにインジケーターを追加（`data-testid="peak-remaining"`、プレイ中のみ表示）。0 のピークは `✓`（`text-ds-success`）で表示。
- `useRef` で前回カウントを追跡し、>0 → 0 の遷移時に一度だけ `cardPlace` を再生。リセット/アンドゥでピークが再充填されると自動的に再アーム（明示的なリセット処理不要）。
- i18n キー `peakRemaining` / `peakCleared` を ja/en に追加（key-for-key で同期）。

## 受け入れ条件

- [x] 3 ピーク各々の残枚数が常時表示される
- [x] ピーク単位のクリア時に一度だけ演出（サウンド + チェックマーク）が発火する
- [x] リセットで演出状態も初期化される（残枚数と ref が再初期化）
- [x] ピーク残枚数導出ロジックのユニットテストを追加（`computePeakRemaining`）

## テスト

- `frontend/src/pages/TriPeaksPage.test.tsx` — インジケーター表示 / クリアのチェックマーク / 終局時の非表示 / クリア時サウンド 1 回、加えて `computePeakRemaining` の純粋関数テスト（undefined / 通常 / removed・空セル除外）。
- Gate: `biome check` / `bun run test -- --run TriPeaksPage`（37 passed）/ `bun run build`（tsc）すべてパス。

Closes #3085
