### PR TITLE
feat(canfield): add desktop-collapsible column action buttons

### DIFF
--- a/frontend/src/i18n/locales/en/canfield.json
+++ b/frontend/src/i18n/locales/en/canfield.json
@@ -44,5 +44,6 @@
     "actionButtons": "Action buttons: hint, auto-complete, undo, give up.",
     "resetButton": "Start a new game."
   },
-  "columnActionsFor": "Column {{n}} actions"
+  "columnActionsFor": "Column {{n}} actions",
+  "collapseColumnActions": "Collapse column action buttons"
 }

--- a/frontend/src/i18n/locales/ja/canfield.json
+++ b/frontend/src/i18n/locales/ja/canfield.json
@@ -44,5 +44,6 @@
     "actionButtons": "ヒント・自動完成・元に戻すなどの操作ボタンです。",
     "resetButton": "新しいゲームを始めるボタンです。"
   },
-  "columnActionsFor": "列 {{n}} の操作"
+  "columnActionsFor": "列 {{n}} の操作",
+  "collapseColumnActions": "列の操作ボタンを折りたたむ"
 }

--- a/frontend/src/pages/CanfieldPage.test.tsx
+++ b/frontend/src/pages/CanfieldPage.test.tsx
@@ -49,6 +49,7 @@ const gameOverState: CanfieldResponse = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  localStorage.clear();
   mockExec.mockResolvedValue(playingState);
 });
 
@@ -180,6 +181,32 @@ describe('CanfieldPage', () => {
     renderWithProviders(<CanfieldPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
     expect(screen.queryByTestId('cf-col-actions-0')).not.toBeInTheDocument();
+  });
+
+  it('collapses per-column actions on desktop when the setting is toggled on', async () => {
+    renderWithProviders(<CanfieldPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    // Initially expanded (no disclosure) on desktop.
+    expect(screen.queryByTestId('cf-col-actions-0')).not.toBeInTheDocument();
+    // Toggle the "collapse column actions" setting.
+    const toggle = screen.getByRole('checkbox', { name: '列の操作ボタンを折りたたむ' });
+    fireEvent.click(toggle);
+    // Now each column's actions live behind a <details> disclosure, collapsed by default.
+    const details = await screen.findByTestId('cf-col-actions-0');
+    expect(details.tagName.toLowerCase()).toBe('details');
+    expect(details).not.toHaveAttribute('open');
+    expect(details.querySelector('summary')).toHaveTextContent('列 0 の操作');
+    // The move buttons remain reachable inside the disclosure (functionality preserved).
+    expect(screen.getAllByRole('button', { name: '→組' }).length).toBeGreaterThan(0);
+  });
+
+  it('persists the collapse setting across remounts via localStorage', async () => {
+    localStorage.setItem('canfield-collapse-col-actions', 'true');
+    renderWithProviders(<CanfieldPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    // Restored as collapsed on desktop without re-toggling.
+    expect(await screen.findByTestId('cf-col-actions-0')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: '列の操作ボタンを折りたたむ' })).toBeChecked();
   });
 
   it('per-column action buttons dispatch the matching move', async () => {

--- a/frontend/src/pages/CanfieldPage.tsx
+++ b/frontend/src/pages/CanfieldPage.tsx
@@ -21,6 +21,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
+import { useLocalStorageToggle } from '../hooks/useLocalStorageToggle';
 import { useMountReset } from '../hooks/useMountReset';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { btnDanger, btnOutline, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
@@ -89,6 +90,10 @@ function CanfieldPageContent() {
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('canfield', state);
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('canfield');
+  // Desktop declutter: let players collapse the dense per-column action buttons
+  // behind a <details> disclosure, matching the mobile treatment. Persisted so
+  // the preference survives reloads. Drag-and-drop is unaffected either way.
+  const [collapseColActions, setCollapseColActions] = useLocalStorageToggle('canfield-collapse-col-actions', false);
   const cliConfig: CliGameConfig<CanfieldResponse, Parameters<typeof canfieldApi.exec>> = useMemo(
     () => ({
       gameName: 'canfield',
@@ -221,6 +226,13 @@ function CanfieldPageContent() {
                     label: tc('hint.toggle', { ns: 'tutorial' }),
                     checked: frontendHintEnabled,
                     onToggle: setFrontendHintEnabled,
+                  },
+                  {
+                    type: 'checkbox' as const,
+                    id: 'collapseColActions',
+                    label: t('collapseColumnActions'),
+                    checked: collapseColActions,
+                    onToggle: setCollapseColActions,
                   },
                 ],
               },
@@ -403,9 +415,11 @@ function CanfieldPageContent() {
                             )}
                           </div>
                         );
-                        // On mobile, collapse the dense per-column action buttons behind a
-                        // details disclosure so they don't crowd below the 44px tap-target min.
-                        return isMobile ? (
+                        // Collapse the dense per-column action buttons behind a details
+                        // disclosure when space is tight (mobile) or when the player opts in
+                        // via the settings toggle on desktop — so they don't crowd below the
+                        // 44px tap-target min. Drag-and-drop stays available regardless.
+                        return isMobile || collapseColActions ? (
                           <details className="mt-1 w-full" data-testid={`cf-col-actions-${i}`}>
                             {/* Include the column number so a screen reader can tell the
                                 per-column action panels apart. 0-based to match the rest


### PR DESCRIPTION
## 概要

キャンフィールドの各タブロー列に並ぶ最大9個・9列合計80個以上の操作ボタンがデスクトップで常時全表示されクラッターとなっていた問題を、モバイルと同じ `<details>` 折りたたみをデスクトップでも選べるようにして整理する。ボタン自体は削除せず、ドラッグ＆ドロップにも影響しない純粋なUX整理。

## 変更内容

- `SettingsPanel` に「列の操作ボタンを折りたたむ」チェックボックスを追加
- 設定は `useLocalStorageToggle('canfield-collapse-col-actions')` で永続化（リロード後も保持）
- 有効時は各列の操作ボタンを既存の `<details>`（モバイルと同一実装）に格納。デフォルトは従来通り展開表示
- ドラッグ＆ドロップ経路は不変
- i18n キー `collapseColumnActions` を ja/en に追加
- テスト2件追加（デスクトップでのトグル折りたたみ、localStorage永続化）

## 受け入れ条件

- [x] デスクトップでも列アクションボタンを折りたたみ表示できる
- [x] 折りたたみ状態を localStorage で保持する
- [x] ドラッグ＆ドロップ操作には影響しない
- [x] モバイルの既存 `<details>` 実装との一貫性を保つ

## テスト

- `bun run test -- --run CanfieldPage` — 29 passed
- `bun run build`（tsc + vite）— 成功
- `biome check` — クリーン

Closes #3146
