### PR TITLE
feat(pishti): show a provisional score during play

### DIFF
--- a/frontend/src/i18n/locales/en/pishti.json
+++ b/frontend/src/i18n/locales/en/pishti.json
@@ -8,6 +8,8 @@
   "pistiCelebration": "PİŞTİ +10!",
   "pistiCelebrationJack": "PİŞTİ +20! (J)",
   "finalScore": "{{score}} pts",
+  "provisional": "Provisional {{score}}",
+  "provisionalNote": "The provisional score includes only locked-in Pişti bonuses and the most-cards +3. Card points (A, J, 2♣, 10♦) are not yet counted, so final scores will be higher.",
   "pile": "Pile",
   "pileTop": "Pile top",
   "pileCount": "{{count}} cards",

--- a/frontend/src/i18n/locales/ja/pishti.json
+++ b/frontend/src/i18n/locales/ja/pishti.json
@@ -8,6 +8,8 @@
   "pistiCelebration": "PİŞTİ +10!",
   "pistiCelebrationJack": "PİŞTİ +20! (J)",
   "finalScore": "{{score}}点",
+  "provisional": "暫定 {{score}}点",
+  "provisionalNote": "暫定スコアは確定済みの Pişti ボーナスと最多獲得の +3 のみを含みます。A・J・♣2・♦10 のカード点は集計前のため、最終得点はこれより高くなります。",
   "pile": "場",
   "pileTop": "場の一番上",
   "pileCount": "{{count}}枚",

--- a/frontend/src/pages/PishtiPage.test.tsx
+++ b/frontend/src/pages/PishtiPage.test.tsx
@@ -273,4 +273,53 @@ describe('PishtiPage', () => {
     expect(screen.getByTestId('hand-card-1').className).not.toContain('ring-ds-');
     expect(screen.getByTestId('hand-card-0').className).not.toContain('ring-ds-');
   });
+
+  it('shows a provisional score during play: Pişti bonus plus the sole most-cards +3', async () => {
+    // Human leads on captured cards (10 vs 4/0/0) → gets the provisional most-cards +3;
+    // combined with a locked-in Pişti bonus of 10 the provisional total is 13.
+    mockExec.mockResolvedValue(
+      makeState({
+        players: [
+          makePlayer({ id: 0, isHuman: true, capturedCount: 10, pistiBonus: 10 }),
+          makePlayer({ id: 1, capturedCount: 4 }),
+          makePlayer({ id: 2, capturedCount: 0 }),
+          makePlayer({ id: 3, capturedCount: 0 }),
+        ],
+      }),
+    );
+    renderWithProviders(<PishtiPage />);
+    const humanReadout = await screen.findByTestId('pishti-provisional-0');
+    expect(humanReadout).toHaveTextContent('暫定 13点');
+    // A non-leader with no bonus reads 0.
+    expect(screen.getByTestId('pishti-provisional-1')).toHaveTextContent('暫定 0点');
+    // The partial-score disclosure note is shown during play.
+    expect(screen.getByTestId('pishti-provisional-note')).toBeInTheDocument();
+  });
+
+  it('awards nobody the most-cards +3 when the captured-count leader is tied', async () => {
+    // Two players tie for the most captured cards → neither gets the +3 (mirrors the
+    // domain rule), so each provisional score reflects only its Pişti bonus.
+    mockExec.mockResolvedValue(
+      makeState({
+        players: [
+          makePlayer({ id: 0, isHuman: true, capturedCount: 8, pistiBonus: 10 }),
+          makePlayer({ id: 1, capturedCount: 8, pistiBonus: 0 }),
+          makePlayer({ id: 2, capturedCount: 2 }),
+          makePlayer({ id: 3, capturedCount: 0 }),
+        ],
+      }),
+    );
+    renderWithProviders(<PishtiPage />);
+    const humanReadout = await screen.findByTestId('pishti-provisional-0');
+    expect(humanReadout).toHaveTextContent('暫定 10点');
+    expect(screen.getByTestId('pishti-provisional-1')).toHaveTextContent('暫定 0点');
+  });
+
+  it('hides the provisional readout and shows the final score on game end', async () => {
+    mockExec.mockResolvedValue(gameEndState);
+    renderWithProviders(<PishtiPage />);
+    await waitFor(() => expect(screen.getByText(/11点/)).toBeInTheDocument());
+    expect(screen.queryByTestId('pishti-provisional-0')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('pishti-provisional-note')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/PishtiPage.tsx
+++ b/frontend/src/pages/PishtiPage.tsx
@@ -21,7 +21,7 @@ import { useSound } from '../providers/SoundProvider';
 import { btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { Card, PishtiResponse } from '../types/card';
+import type { Card, PishtiPlayer, PishtiResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { PISHTI_HELP, parsePishtiCommand } from '../utils/cli/commands/pishtiCommands';
@@ -179,6 +179,20 @@ function PishtiPageContent() {
 
   const playerLabel = (id: number, isHuman: boolean): string => (isHuman ? t('you') : t('cpu', { id }));
 
+  // Provisional score shown during play so players can gauge where they stand (#3560).
+  // The API exposes only capturedCount + pistiBonus (not the captured cards' values),
+  // so the true point-card score (A/J/2♣/10♦) is NOT derivable. What IS known:
+  //   - Pişti bonuses are already locked into the final score, and
+  //   - the most-cards +3 (PishtiScoreMostCards) goes to the sole captured-count leader
+  //     (ties award nobody, mirroring the domain's calcFinalScore).
+  // We surface only those; the note discloses that card points are still uncounted.
+  const MOST_CARDS_BONUS = 3;
+  const maxCaptured = Math.max(...state.players.map((p) => p.capturedCount));
+  const capturedLeaders = state.players.filter((p) => p.capturedCount === maxCaptured);
+  const provisionalLeaderSeat = maxCaptured > 0 && capturedLeaders.length === 1 ? capturedLeaders[0].id : -1;
+  const provisionalScore = (p: PishtiPlayer): number =>
+    p.pistiBonus + (p.id === provisionalLeaderSeat ? MOST_CARDS_BONUS : 0);
+
   const handleManualReset = () => {
     hideActionLog();
     exec('reset', { config: { cpuDifficulty, playerCnt } });
@@ -240,6 +254,11 @@ function PishtiPageContent() {
             {/* Players (hand / captured / Pişti bonus / current turn) */}
             <div className="mb-2 p-2 rounded bg-black/30" data-tutorial="pishti-players">
               <div className="mb-1 text-ds-text-primary text-sm">{t('playersTitle')}</div>
+              {!isGameEnd && (
+                <div className="mb-1 text-ds-text-muted text-xs" data-testid="pishti-provisional-note">
+                  {t('provisionalNote')}
+                </div>
+              )}
               {state.players.map((p) => (
                 <div
                   key={`player-${p.id}`}
@@ -250,6 +269,16 @@ function PishtiPageContent() {
                   <span>{playerLabel(p.id, p.isHuman)}</span>
                   <span>{t('captured', { count: p.capturedCount })}</span>
                   {p.pistiBonus > 0 && <span className="text-ds-accent">{t('pisti', { count: p.pistiBonus })}</span>}
+                  {!isGameEnd && (
+                    <span
+                      className="text-ds-text-primary"
+                      data-testid={`pishti-provisional-${p.id}`}
+                      title={t('provisionalNote')}
+                    >
+                      {t('provisional', { score: provisionalScore(p) })}
+                      {p.id === provisionalLeaderSeat && <span className="ml-1 text-ds-accent">★</span>}
+                    </span>
+                  )}
                   {isGameEnd && (
                     <span className="text-ds-text-primary">{t('finalScore', { score: p.finalScore })}</span>
                   )}


### PR DESCRIPTION
## 概要

プレイ中に各プレイヤーの暫定スコアを表示し、ゲーム終了前でも大まかな点差を把握できるようにします。Closes #3560。

## 実装方針（表示のみ・軽量）

`PishtiResponse` の各プレイヤーは `capturedCount` と `pistiBonus` のみを公開しており、獲得済みカードの実体（値）は返っていません。そのため **A/J/♣2/♦10 のカード点は算出不可能** です。API を変えずに、既知の情報だけで意味のある暫定スコアを表示します。

暫定スコア = 確定済みの **Pişti ボーナス** ＋ **最多獲得の +3**（`PishtiScoreMostCards`）。
- 最多獲得の +3 は `capturedCount` が単独最多のプレイヤーにのみ付与。同数タイは誰にも付与しない（ドメイン `calcFinalScore` の挙動を踏襲）。
- カード点が未集計であることは注記で明示（最終得点はこれより高くなる旨）。
- 暫定表示はプレイ中のみ。`gameEnd` では従来どおり `finalScore` を表示。

## 変更ファイル

- `frontend/src/pages/PishtiPage.tsx` — 暫定スコアの算出（単独リーダー判定）と表示、注記、★リーダー表示、`data-testid`
- `frontend/src/pages/PishtiPage.test.tsx` — 暫定スコア表示 / タイ時の +3 非付与 / gameEnd 非表示 のテスト
- `frontend/src/i18n/locales/{ja,en}/pishti.json` — `provisional` / `provisionalNote` キー（ja/en 同期）

## 受け入れ条件

- [x] プレイ中に各プレイヤーの暫定スコアが表示される
- [x] gameEnd の finalScore と整合する（gameEnd では暫定を隠し finalScore を表示。ただし暫定は Pişti ＋最多枚のみで**カード点を含まない部分値**であり、注記で明示。exact な finalScore の再現ではない）
- [x] テストで点数計算を検証（`PishtiPage.test.tsx`、暫定/タイ/gameEnd）
- [x] bun run test / build が green
- [ ] presenter テストで点数計算を検証 — 本 PR はフロント表示のみ（バックエンド未変更）。runningScore の presenter 追加はスコープ外

## 補足（正確 vs 部分値）

暫定スコアは **部分値**です。確定している Pişti ボーナスと、現状の最多獲得 +3 のみを合算しており、カード点（A/J/♣2/♦10）は API 未公開のため含みません。注記でその旨を明示しています。

## テスト

```
cd frontend
bun run test -- --run PishtiPage   # 25 passed
bun run build                      # tsc + vite OK
bunx biome check                   # clean
```
