### PR TITLE
feat(spades): warn when bags near the penalty threshold

### DIFF
--- a/frontend/src/i18n/locales/en/spades.json
+++ b/frontend/src/i18n/locales/en/spades.json
@@ -28,6 +28,7 @@
   "bidProgress.made": "Bid made (+{{bags}} bags)",
   "bidProgress.nilOk": "Nil on track",
   "bidProgress.nilFail": "Nil failed",
+  "bagWarning": "Bags {{bags}}/{{threshold}} — watch out",
   "currentTrick": "Current Trick",
   "scores": "Scores",
   "scoresPlayer": "Player",

--- a/frontend/src/i18n/locales/ja/spades.json
+++ b/frontend/src/i18n/locales/ja/spades.json
@@ -28,6 +28,7 @@
   "bidProgress.made": "ビッド達成 (+{{bags}} バッグ)",
   "bidProgress.nilOk": "ニル継続中",
   "bidProgress.nilFail": "ニル失敗",
+  "bagWarning": "バッグ {{bags}}/{{threshold}} 注意",
   "currentTrick": "現在のトリック",
   "scores": "スコア",
   "scoresPlayer": "プレイヤー",

--- a/frontend/src/pages/SpadesPage.test.tsx
+++ b/frontend/src/pages/SpadesPage.test.tsx
@@ -93,6 +93,51 @@ describe('SpadesPage', () => {
     expect(badge).toHaveTextContent('\u9054\u6210\u307e\u3067\u6b8b\u308a 3 \u30c8\u30ea\u30c3\u30af');
   });
 
+  it('shows a bag-penalty warning badge when human bags are within two of the threshold', async () => {
+    mockExec.mockResolvedValue(
+      makeSpadesState({
+        players: [{ ...playPhaseState.players[0], bags: 8 }, ...playPhaseState.players.slice(1)],
+      }),
+    );
+    renderWithProviders(<SpadesPage />);
+    const badge = await screen.findByTestId('sp-bag-warning');
+    // ja: "バッグ 8/10 注意"
+    expect(badge).toHaveTextContent('バッグ 8/10 注意');
+    expect(badge).toHaveClass('text-ds-warning');
+    expect(badge).not.toHaveClass('motion-safe:animate-pulse');
+  });
+
+  it('escalates the bag warning to danger (pulse) within one bag of the threshold', async () => {
+    mockExec.mockResolvedValue(
+      makeSpadesState({
+        players: [{ ...playPhaseState.players[0], bags: 9 }, ...playPhaseState.players.slice(1)],
+      }),
+    );
+    renderWithProviders(<SpadesPage />);
+    const badge = await screen.findByTestId('sp-bag-warning');
+    expect(badge).toHaveTextContent('バッグ 9/10 注意');
+    expect(badge).toHaveClass('motion-safe:animate-pulse');
+    expect(badge).toHaveClass('border-ds-error');
+  });
+
+  it('hides the bag warning when human bags are far from the threshold', async () => {
+    // Default human player has 0 bags (threshold 10) → no warning.
+    renderWithProviders(<SpadesPage />);
+    await screen.findByTestId('sp-bid-progress');
+    expect(screen.queryByTestId('sp-bag-warning')).not.toBeInTheDocument();
+  });
+
+  it('colors the human score-table bags cell when near the threshold', async () => {
+    mockExec.mockResolvedValue(
+      makeSpadesState({
+        players: [{ ...playPhaseState.players[0], bags: 8 }, ...playPhaseState.players.slice(1)],
+      }),
+    );
+    renderWithProviders(<SpadesPage />);
+    const cell = await screen.findByTestId('sp-bags-cell-0');
+    expect(cell).toHaveClass('text-ds-warning');
+  });
+
   it('warns when a Nil bid has been broken', async () => {
     mockExec.mockResolvedValue(
       makeSpadesState({

--- a/frontend/src/pages/SpadesPage.tsx
+++ b/frontend/src/pages/SpadesPage.tsx
@@ -24,7 +24,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { CPU_DIFFICULTY_OPTIONS, POINT_LIMIT_OPTIONS, useSpadesGame } from '../hooks/useSpadesGame';
-import { badgeInfo, badgeSuccess, badgeWarning } from '../styles/badgeStyles';
+import { badgeError, badgeInfo, badgeSuccess, badgeWarning } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary, btnSuccess } from '../styles/buttonStyles';
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
@@ -35,7 +35,7 @@ import { parseSpadesCommand, SPADES_HELP } from '../utils/cli/commands/spadesCom
 import { formatSpadesState } from '../utils/cli/formatters/spadesFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
-import { spadesBidProgress } from '../utils/spadesBid';
+import { spadesBagWarning, spadesBidProgress } from '../utils/spadesBid';
 
 /** Spades tutorial step definitions. */
 const SP_TUTORIAL_STEPS: TutorialStep[] = [
@@ -189,6 +189,15 @@ function SpadesPageContent() {
     (isPlayPhase || isTrickEnd) && humanPlayer && humanPlayer.bid >= 0
       ? spadesBidProgress(humanPlayer.bid, humanPlayer.trickCount)
       : null;
+  // Bag-penalty proximity warning for the human player.
+  const bagThreshold = state.config.bagPenaltyThreshold;
+  const humanBagWarning = humanPlayer ? spadesBagWarning(humanPlayer.bags, bagThreshold) : null;
+  // Warning color for a score-table bags cell based on that player's own bags.
+  const bagCellClass = (bags: number): string => {
+    const w = spadesBagWarning(bags, bagThreshold);
+    if (!w) return '';
+    return w.level === 'danger' ? 'text-ds-warning font-bold' : 'text-ds-warning';
+  };
 
   return (
     <GamePageShell
@@ -254,26 +263,38 @@ function SpadesPageContent() {
               <span>{state.spadesBroken ? t('spadesBroken') : t('spadesNotBroken')}</span>
             </div>
 
-            {bidProgress && (
-              <div className="text-center mb-2">
-                <span
-                  data-testid="sp-bid-progress"
-                  className={
-                    bidProgress.kind === 'nilFail'
-                      ? badgeWarning
+            {(bidProgress || humanBagWarning) && (
+              <div className="text-center mb-2 flex flex-wrap gap-2 justify-center items-center">
+                {bidProgress && (
+                  <span
+                    data-testid="sp-bid-progress"
+                    className={
+                      bidProgress.kind === 'nilFail'
+                        ? badgeWarning
+                        : bidProgress.kind === 'made'
+                          ? badgeSuccess
+                          : badgeInfo
+                    }
+                  >
+                    {bidProgress.kind === 'remaining'
+                      ? t('bidProgress.remaining', { n: bidProgress.remaining })
                       : bidProgress.kind === 'made'
-                        ? badgeSuccess
-                        : badgeInfo
-                  }
-                >
-                  {bidProgress.kind === 'remaining'
-                    ? t('bidProgress.remaining', { n: bidProgress.remaining })
-                    : bidProgress.kind === 'made'
-                      ? t('bidProgress.made', { bags: bidProgress.bags })
-                      : bidProgress.kind === 'nilFail'
-                        ? t('bidProgress.nilFail')
-                        : t('bidProgress.nilOk')}
-                </span>
+                        ? t('bidProgress.made', { bags: bidProgress.bags })
+                        : bidProgress.kind === 'nilFail'
+                          ? t('bidProgress.nilFail')
+                          : t('bidProgress.nilOk')}
+                  </span>
+                )}
+                {humanBagWarning && (
+                  <span
+                    data-testid="sp-bag-warning"
+                    className={
+                      humanBagWarning.level === 'danger' ? `${badgeError} motion-safe:animate-pulse` : badgeWarning
+                    }
+                  >
+                    {t('bagWarning', { bags: humanBagWarning.bags, threshold: humanBagWarning.threshold })}
+                  </span>
+                )}
               </div>
             )}
 
@@ -361,7 +382,12 @@ function SpadesPageContent() {
                               <td>{playerName(p.id, p.isHuman)}</td>
                               <td className="text-center">{p.bid >= 0 ? p.bid : '-'}</td>
                               <td className="text-center">{p.trickCount}</td>
-                              <td className="text-center">{p.bags}</td>
+                              <td
+                                className={`text-center ${bagCellClass(p.bags)}`}
+                                data-testid={`sp-bags-cell-${p.id}`}
+                              >
+                                {p.bags}
+                              </td>
                               <td className="text-center">{p.roundScore}</td>
                               <td className="text-center">{p.cumulativeScore}</td>
                             </tr>
@@ -394,7 +420,12 @@ function SpadesPageContent() {
                               <td>{playerName(p.id, p.isHuman)}</td>
                               <td className="text-center">{p.bid >= 0 ? p.bid : '-'}</td>
                               <td className="text-center">{p.trickCount}</td>
-                              <td className="text-center">{p.bags}</td>
+                              <td
+                                className={`text-center ${bagCellClass(p.bags)}`}
+                                data-testid={`sp-bags-cell-${p.id}`}
+                              >
+                                {p.bags}
+                              </td>
                               <td className="text-center">{p.roundScore}</td>
                               <td className="text-center">{p.cumulativeScore}</td>
                             </tr>

--- a/frontend/src/utils/spadesBid.test.ts
+++ b/frontend/src/utils/spadesBid.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { spadesBidProgress } from './spadesBid';
+import { spadesBagWarning, spadesBidProgress } from './spadesBid';
 
 describe('spadesBidProgress', () => {
   it('reports tricks remaining when the bid is not yet met', () => {
@@ -17,5 +17,25 @@ describe('spadesBidProgress', () => {
 
   it('treats a Nil bid as failed once a trick is taken', () => {
     expect(spadesBidProgress(0, 1)).toEqual({ kind: 'nilFail' });
+  });
+});
+
+describe('spadesBagWarning', () => {
+  it('returns null when the player is more than two bags away', () => {
+    expect(spadesBagWarning(7, 10)).toBeNull();
+    expect(spadesBagWarning(0, 10)).toBeNull();
+  });
+
+  it('warns at exactly two bags away from the threshold', () => {
+    expect(spadesBagWarning(8, 10)).toEqual({ level: 'warn', bags: 8, threshold: 10 });
+  });
+
+  it('escalates to danger at one bag away or once the threshold is reached', () => {
+    expect(spadesBagWarning(9, 10)).toEqual({ level: 'danger', bags: 9, threshold: 10 });
+    expect(spadesBagWarning(10, 10)).toEqual({ level: 'danger', bags: 10, threshold: 10 });
+  });
+
+  it('returns null when the threshold is disabled', () => {
+    expect(spadesBagWarning(5, 0)).toBeNull();
   });
 });

--- a/frontend/src/utils/spadesBid.ts
+++ b/frontend/src/utils/spadesBid.ts
@@ -23,3 +23,32 @@ export function spadesBidProgress(bid: number, trickCount: number): SpadesBidPro
   }
   return { kind: 'made', bags: trickCount - bid };
 }
+
+/** Number of bags within the penalty threshold that triggers a warning. */
+export const SPADES_BAG_WARNING_MARGIN = 2;
+
+/**
+ * Severity of a Spades player's bag count as it nears the penalty threshold.
+ * `warn` when the player is exactly `SPADES_BAG_WARNING_MARGIN` bags away;
+ * `danger` once within one bag of (or having reached) the threshold.
+ */
+export type SpadesBagWarning = { level: 'warn' | 'danger'; bags: number; threshold: number };
+
+/**
+ * Determines whether a player's bag count is close enough to the penalty
+ * threshold to warrant a warning. Returns `null` when the threshold is disabled
+ * (`<= 0`) or the player is more than {@link SPADES_BAG_WARNING_MARGIN} bags
+ * away. Within the margin the level escalates: `warn` at the margin edge,
+ * `danger` at one bag away or once the threshold is reached.
+ *
+ * @param bags - The player's accumulated bags (overtricks).
+ * @param threshold - The bag penalty threshold (`config.bagPenaltyThreshold`).
+ * @returns A warning descriptor, or `null` when no warning applies.
+ */
+export function spadesBagWarning(bags: number, threshold: number): SpadesBagWarning | null {
+  if (threshold <= 0 || bags < threshold - SPADES_BAG_WARNING_MARGIN) {
+    return null;
+  }
+  const level = bags >= threshold - 1 ? 'danger' : 'warn';
+  return { level, bags, threshold };
+}


### PR DESCRIPTION
## 概要

スペードで、バッグ（オーバートリック）がペナルティ閾値（`config.bagPenaltyThreshold`、既定 10）に近づいた際に人間プレイヤーへ警告を出す、純粋に追加のみの UI 改善です。

- ビッド進捗バッジの隣に警告バッジを表示。バッグが閾値の 2 個以内で `badgeWarning`、閾値の 1 個以内（到達含む）で `badgeError` + `motion-safe:animate-pulse` に段階的にエスカレーション。
- スコアテーブルの各プレイヤーの bags セルを、そのプレイヤー自身のバッグが閾値に近い場合に `text-ds-warning`（danger で `font-bold`）で着色。
- 閾値到達でペナルティが発生しバッグがリセットされると、バッジは自動的に消えます（`bags` 追従）。
- 判定ロジックは `spadesBagWarning(bags, threshold)` として `utils/spadesBid.ts` に切り出し、単体テストを追加。

閾値は Go ドメイン（`internal/domain/SpadesConfig.go` の既定 10、最小 1）と一致し、レスポンスの `config.bagPenaltyThreshold` を参照しています。バッグは `SpadesPlayerData.bags`（プレイヤー単位）を使用。

## 受け入れ条件

- [x] bags >= threshold-2 で警告バッジが表示される
- [x] 閾値到達によるペナルティ発生後はバッジが消える（bags リセット追従）
- [x] スコアテーブルの該当セルが警告色になる
- [x] バッジ表示条件の単体テストを追加

## テスト

- `cd frontend && bun run test -- --run SpadesPage spadesBid` → 81 passed
- `cd frontend && bun run build`（tsc）→ 成功
- `bunx biome check` → 通過
- i18n ja/en キー整合を確認

Closes #3047
